### PR TITLE
feat(probas,#12226): Infer-20-Quotients-et-Fibres 4-temps protocole

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-20-Quotients-et-Fibres.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-20-Quotients-et-Fibres.ipynb
@@ -1,0 +1,707 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ab5c5884",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002509,
+     "end_time": "2026-08-22T02:45:42.167914",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.165405",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Infer-20 — Quotients, fibres et recollement : ce qui survit à la projection, ce qui ne vit que dans les fibres\n",
+    "\n",
+    "> **Corpus bayésien / information théorique.** Ce notebook (20ᵉ du corpus\n",
+    "> [Infer.NET](../Infer-Glossary.md), 5ᵉ de la saison « protocoles\n",
+    "> d'analyse ») sort de la famille inférentielle stricte pour attaquer un\n",
+    "> problème de **représentation** : deux observations du même phénomène\n",
+    "> peuvent-elles être comparées autrement que par « laquelle est plus\n",
+    "> proche de la vérité » ?\n",
+    "\n",
+    "Le protocole proposé a quatre temps — et le temps 4 ne s'atteint que si\n",
+    "le temps 3 a produit un quotient opérationnel.\n",
+    "\n",
+    "**Pourquoi ce notebook existe.** Le premier protocole Čech du dépôt\n",
+    "demandait, sur un recouvrement, `X_j ≈ a·X_i + b`, et mesurait un résidu.\n",
+    "Le remède n'est pas de remplacer l'affine par du non-linéaire plus\n",
+    "sophistiqué — ce serait **repeindre le même jouet**. C'est de changer\n",
+    "le **protocole**.\n",
+    "\n",
+    "La direction vient de la *proper forcing*, ou plus largement de la\n",
+    "théorie de l'information conditionnelle : une projection vers un\n",
+    "**quotient** `π` s'analyse **conjointement avec l'information\n",
+    "conditionnelle qui reste dans les fibres** `X | π(X)`.\n",
+    "\n",
+    "```\n",
+    "X   ⟶   π(X)   +   X | π(X)\n",
+    "```\n",
+    "\n",
+    "La question devient : **qu'est-ce qui SURVIT dans la représentation\n",
+    "grossière, et qu'est-ce qui NE VIT QUE dans les fibres locales ?**\n",
+    "\n",
+    "Et la comparaison entre deux représentations se retourne : la bonne\n",
+    "mesure n'est peut-être pas la **proximité de leurs valeurs**, mais la\n",
+    "**quantité de structure informationnelle supplémentaire** produite\n",
+    "quand on les met en relation — via information mutuelle, divergences\n",
+    "distributionnelles, transports composés.\n",
+    "\n",
+    "## Plan\n",
+    "\n",
+    "1. **Temps 1 — Construire deux représentations** `X₁` et `X₂` d'un même\n",
+    "   phénomène (gaussiennes bivariées corrélées).\n",
+    "2. **Temps 2 — Sur l'intersection, mesurer le commun / le conditionnel /\n",
+    "   le perdu par projection / le créé par combinaison** (≠ affinité).\n",
+    "3. **Temps 3 — Chercher un quotient commun `Q`** tel que les descriptions\n",
+    "   locales deviennent simples conditionnellement à `Q`. Mesurer\n",
+    "   `H(X_i|Q)`, `H(X_j|Q)`, `I(X_i;X_j|Q)`.\n",
+    "4. **Temps 4 — Composer deux transports et mesurer l'écart à la\n",
+    "   composition** (condition : Q produit au temps 3).\n",
+    "\n",
+    "## Garde-fou\n",
+    "\n",
+    "La **distance entropique de Ruzsa** n'est PAS applicable par défaut —\n",
+    "elle suppose une structure de groupe additif. Sur des proxys qui\n",
+    "n'en ont pas, ce serait **le nouveau mapping affine**. Si la structure\n",
+    "de groupe manque : information mutuelle conditionnelle, divergences\n",
+    "distributionnelles. **Le notebook écrit laquelle des deux voies est\n",
+    "prise, et pourquoi.**\n",
+    "\n",
+    "## Critère d'acceptation de fond (hérité de de Finetti)\n",
+    "\n",
+    "Un défaut de recollement doit produire un **témoin opérationnel**, pas\n",
+    "un résidu. Ce notebook ne le livre pas nécessairement — il dit\n",
+    "honnêtement s'il ne l'a pas livré.\n",
+    "\n",
+    "See #12226 · See #12206\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd65dca6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001032,
+     "end_time": "2026-08-22T02:45:42.170561",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.169529",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Outils\n",
+    "\n",
+    "| Bibliothèque | Version | Rôle |\n",
+    "|---|---|---|\n",
+    "| `numpy` | 2.2.6 | Tirages gaussiens, manipulations vectorielles |\n",
+    "| `scipy.special` | 1.16.3 | `rel_entr` (KL discrète) |\n",
+    "| `scipy.stats` | 1.16.3 | `entropy` (entropie de Shannon, base `e`) |\n",
+    "\n",
+    "**Pas d'Infer.NET, pas de .NET Interactive ici.** Le protocole\n",
+    "quoti­ent/fibres est un calcul d'**information conditionnelle**\n",
+    "(classique, fréquentiste), pas une inférence bayésienne. La machinerie\n",
+    "est volontairement minimale et **interprétable au niveau de la ligne**.\n",
+    "\n",
+    "**Graine fixée.** Toutes les mesures utilisent `numpy.random.default_rng(20260822)`\n",
+    "pour reproductibilité byte-stable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bb8e132c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T02:45:42.175303Z",
+     "iopub.status.busy": "2026-08-22T02:45:42.175303Z",
+     "iopub.status.idle": "2026-08-22T02:45:42.612117Z",
+     "shell.execute_reply": "2026-08-22T02:45:42.611586Z"
+    },
+    "papermill": {
+     "duration": 0.439397,
+     "end_time": "2026-08-22T02:45:42.612699",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.173302",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "numpy 2.2.6 · scipy 1.16.3\n",
+      "Graine fixée : RNG.bit_generator.state['state']['state'] = 165599870888322723834153514999483032662\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import scipy\n",
+    "from scipy.special import rel_entr\n",
+    "from scipy.stats import entropy\n",
+    "\n",
+    "print(f\"numpy {np.__version__} · scipy {scipy.__version__}\")\n",
+    "RNG = np.random.default_rng(20260822)\n",
+    "print(f\"Graine fixée : RNG.bit_generator.state['state']['state'] = {RNG.bit_generator.state['state']['state']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a3ac9e0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002124,
+     "end_time": "2026-08-22T02:45:42.616143",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.614019",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Temps 1 — Deux représentations d'un même phénomène\n",
+    "\n",
+    "On construit **deux observations** `X₁` et `X₂` d'un même phénomène\n",
+    "sous-jacent (un scalaire latent `Z`). Les deux représentations sont :\n",
+    "\n",
+    "- **`X₁`** : observation directe (bruit additif gaussien).\n",
+    "- **`X₂`** : observation transformée (bruit additif gaussien + non-linéarité).\n",
+    "\n",
+    "**Corrélation visée** : `ρ = 0.6` entre `X₁` et `X₂` (information mutuelle\n",
+    "non triviale, mais pas dégénérée). Le paramètre `ρ` est un *proxy* de la\n",
+    "« quantité de phénomène partagé » — il ne présume rien sur la forme de\n",
+    "la représentation.\n",
+    "\n",
+    "Forme de la corrélation :\n",
+    "\n",
+    "```\n",
+    "(X₁, X₂) ~ N(0, Σ), Σ = [[1, ρ], [ρ, 1]]\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ed4868db",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T02:45:42.621862Z",
+     "iopub.status.busy": "2026-08-22T02:45:42.621197Z",
+     "iopub.status.idle": "2026-08-22T02:45:42.626203Z",
+     "shell.execute_reply": "2026-08-22T02:45:42.626203Z"
+    },
+    "papermill": {
+     "duration": 0.009629,
+     "end_time": "2026-08-22T02:45:42.627546",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.617917",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N = 5000 observations, rho = 0.6\n",
+      "X1 : mean = 0.0130, std = 1.0063\n",
+      "X2 : mean = -0.0097, std = 1.0146\n",
+      "Empirical corr(X1, X2) = 0.6081  (cible: 0.6)\n"
+     ]
+    }
+   ],
+   "source": [
+    "N = 5000\n",
+    "RHO = 0.6\n",
+    "mean = np.array([0.0, 0.0])\n",
+    "cov = np.array([[1.0, RHO], [RHO, 1.0]])\n",
+    "X = RNG.multivariate_normal(mean, cov, size=N)\n",
+    "X1, X2 = X[:, 0], X[:, 1]\n",
+    "\n",
+    "print(f\"N = {N} observations, rho = {RHO}\")\n",
+    "print(f\"X1 : mean = {X1.mean():.4f}, std = {X1.std():.4f}\")\n",
+    "print(f\"X2 : mean = {X2.mean():.4f}, std = {X2.std():.4f}\")\n",
+    "print(f\"Empirical corr(X1, X2) = {np.corrcoef(X1, X2)[0, 1]:.4f}  (cible: {RHO})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "689a98a0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002026,
+     "end_time": "2026-08-22T02:45:42.632753",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.630727",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Temps 2 — Quatre mesures sur l'intersection `X₁ ∩ X₂`\n",
+    "\n",
+    "**Hypothèse de travail** : `X₁` et `X₂` sont définis sur le même\n",
+    "support (ici `ℝ`), donc l'intersection est l'ensemble des paires\n",
+    "`(x₁, x₂)` effectivement observées.\n",
+    "\n",
+    "Quatre mesures, **chacune un scalaire reproductible** :\n",
+    "\n",
+    "| Mesure | Notation | Signification |\n",
+    "|---|---|---|\n",
+    "| **Commun** | `I(X₁; X₂)` | Information mutuelle — bits partagés |\n",
+    "| **Conditionnel** | `H(X₁|X₂)` | Reste dans `X₁` une fois `X₂` connue |\n",
+    "| **Perdu par projection** | `H(X₁) − I(X₁;X₂)` | Ce qui devient invisible si on garde seulement `X₂` |\n",
+    "| **Créé par combinaison** | `H(X₁, X₂) − H(X₁) − H(X₂)` | *Négatif* en discret (ce n'est pas de l'information « créée ») |\n",
+    "\n",
+    "**Discrétisation.** On estimera entropies et MI par histogramme 2D\n",
+    "`bins × bins` (méthode plug-in, biais de discrétisation documenté)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eb1aab3d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T02:45:42.639363Z",
+     "iopub.status.busy": "2026-08-22T02:45:42.639363Z",
+     "iopub.status.idle": "2026-08-22T02:45:42.644830Z",
+     "shell.execute_reply": "2026-08-22T02:45:42.644830Z"
+    },
+    "papermill": {
+     "duration": 0.010553,
+     "end_time": "2026-08-22T02:45:42.645834",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.635281",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Discretisation : bins = 24 x 24\n",
+      "H(X1)          = 2.5980 nats\n",
+      "H(X2)          = 2.6966 nats\n",
+      "H(X1,X2)       = 5.0301 nats\n",
+      "I(X1;X2)       = 0.2645 nats   (commun)\n",
+      "H(X1)-I        = 2.3335 nats  (perdu par projection sur X2)\n",
+      "H(X1,X2)-H1-H2 = -0.2645 nats  (toujours <= 0 en discret)\n",
+      "I theorique (gauss. bivariee, rho=0.6) = 0.2231 nats\n",
+      "Biais plug-in = +0.0414 nats (sous-estimation classique de Miller-Madow)\n"
+     ]
+    }
+   ],
+   "source": [
+    "BINS = 24  # compromis biais/variance ; documente plus bas\n",
+    "\n",
+    "def joint_2d(x, y, bins):\n",
+    "    H, _, _ = np.histogram2d(x, y, bins=bins)\n",
+    "    P = H / H.sum()\n",
+    "    return P\n",
+    "\n",
+    "def entropies_from_joint(P):\n",
+    "    # H(X1), H(X2), H(X1,X2), I(X1;X2) depuis P(X1,X2) plug-in.\n",
+    "    p1 = P.sum(axis=1)\n",
+    "    p2 = P.sum(axis=0)\n",
+    "    H1 = -np.sum(p1 * np.log(p1 + 1e-12))\n",
+    "    H2 = -np.sum(p2 * np.log(p2 + 1e-12))\n",
+    "    H12 = -np.sum(P * np.log(P + 1e-12))\n",
+    "    I = H1 + H2 - H12\n",
+    "    return H1, H2, H12, I\n",
+    "\n",
+    "P = joint_2d(X1, X2, bins=BINS)\n",
+    "H1, H2, H12, MI = entropies_from_joint(P)\n",
+    "\n",
+    "perdu = H1 - MI\n",
+    "combine = H12 - H1 - H2  # negatif en discret : ce n'est pas de l'info creee\n",
+    "\n",
+    "print(f\"Discretisation : bins = {BINS} x {BINS}\")\n",
+    "print(f\"H(X1)          = {H1:.4f} nats\")\n",
+    "print(f\"H(X2)          = {H2:.4f} nats\")\n",
+    "print(f\"H(X1,X2)       = {H12:.4f} nats\")\n",
+    "print(f\"I(X1;X2)       = {MI:.4f} nats   (commun)\")\n",
+    "print(f\"H(X1)-I        = {perdu:.4f} nats  (perdu par projection sur X2)\")\n",
+    "print(f\"H(X1,X2)-H1-H2 = {combine:.4f} nats  (toujours <= 0 en discret)\")\n",
+    "\n",
+    "# Biais de discretisation plug-in : I est sous-estimee\n",
+    "# (la theorie pour bivariee gaussienne : I_theorique = -0.5 * log(1 - rho^2))\n",
+    "I_theorique = -0.5 * np.log(1 - RHO**2)\n",
+    "print(f\"I theorique (gauss. bivariee, rho={RHO}) = {I_theorique:.4f} nats\")\n",
+    "print(f\"Biais plug-in = {MI - I_theorique:+.4f} nats (sous-estimation classique de Miller-Madow)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45d21ca1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001021,
+     "end_time": "2026-08-22T02:45:42.648919",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.647898",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Temps 3 — Le quotient `Q`\n",
+    "\n",
+    "**Question :** existe-t-il une variable `Q` (à valeur dans un alphabet\n",
+    "*petit*) telle que, conditionnellement à `Q`, les deux représentations\n",
+    "deviennent **faiblement dépendantes** ?\n",
+    "\n",
+    "Construction : on prend `Q` comme une **quantification** de la somme\n",
+    "`X₁ + X₂`. Choix pédagogiques :\n",
+    "\n",
+    "- 4 bins équipopulants → `Q` à 4 valeurs.\n",
+    "- On espère que `I(X₁; X₂ | Q) ≪ I(X₁; X₂)` — la majeure partie de\n",
+    "  la dépendance passe par `Q`.\n",
+    "\n",
+    "**Critère d'acceptation** : si `I(X₁; X₂ | Q) < 0.5 · I(X₁; X₂)`,\n",
+    "alors `Q` est un quotient opérationnel (le protocole peut passer au\n",
+    "temps 4). Sinon, il faut raffiner `Q` ou accepter que la dépendance\n",
+    "n'est pas factorisable par une variable 1D simple."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8d8af1ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T02:45:42.652948Z",
+     "iopub.status.busy": "2026-08-22T02:45:42.652948Z",
+     "iopub.status.idle": "2026-08-22T02:45:42.662340Z",
+     "shell.execute_reply": "2026-08-22T02:45:42.662340Z"
+    },
+    "papermill": {
+     "duration": 0.011913,
+     "end_time": "2026-08-22T02:45:42.662340",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.650427",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Q : 4 bins equipopulants de S = X1 + X2\n",
+      "  Q = 0 : 1250 obs  (25.0%)\n",
+      "  Q = 1 : 1250 obs  (25.0%)\n",
+      "  Q = 2 : 1250 obs  (25.0%)\n",
+      "  Q = 3 : 1250 obs  (25.0%)\n",
+      "\n",
+      "I(X1;X2 | Q) = 0.4453 nats\n",
+      "I(X1;X2)     = 0.2645 nats\n",
+      "Ratio I(X1;X2|Q) / I(X1;X2) = 1.684\n",
+      "\n",
+      "=> Q N'EST PAS operationnel : la dependance ne se factorise pas par une variable 1D simple.\n",
+      "   Le temps 4 ne sera pas tente (cf critere d'acceptation).\n"
+     ]
+    }
+   ],
+   "source": [
+    "Q_BINS = 4\n",
+    "\n",
+    "# Quotient : Q = quantification equipopulante de X1 + X2\n",
+    "S = X1 + X2\n",
+    "quantiles = np.quantile(S, np.linspace(0, 1, Q_BINS + 1))\n",
+    "quantiles[0] -= 1e-9\n",
+    "quantiles[-1] += 1e-9\n",
+    "Q = np.digitize(S, quantiles[1:-1])\n",
+    "\n",
+    "# Verification : Q est bien repartie\n",
+    "print(f\"Q : {Q_BINS} bins equipopulants de S = X1 + X2\")\n",
+    "for k in range(Q_BINS):\n",
+    "    mask = Q == k\n",
+    "    print(f\"  Q = {k} : {mask.sum()} obs  ({mask.mean()*100:.1f}%)\")\n",
+    "\n",
+    "# I(X1; X2 | Q) = H(X1|Q) + H(X2|Q) - H(X1, X2 | Q)\n",
+    "H1_cond = 0.0\n",
+    "H2_cond = 0.0\n",
+    "H12_cond = 0.0\n",
+    "weights = []\n",
+    "for k in range(Q_BINS):\n",
+    "    mask = Q == k\n",
+    "    p_k = mask.mean()\n",
+    "    if p_k < 0.01:\n",
+    "        continue\n",
+    "    weights.append(p_k)\n",
+    "    Pk = joint_2d(X1[mask], X2[mask], bins=BINS)\n",
+    "    h1, h2, h12, _ = entropies_from_joint(Pk)\n",
+    "    H1_cond += p_k * h1\n",
+    "    H2_cond += p_k * h2\n",
+    "    H12_cond += p_k * h12\n",
+    "\n",
+    "MI_cond = H1_cond + H2_cond - H12_cond\n",
+    "\n",
+    "print(f\"\\nI(X1;X2 | Q) = {MI_cond:.4f} nats\")\n",
+    "print(f\"I(X1;X2)     = {MI:.4f} nats\")\n",
+    "ratio = MI_cond / MI if MI > 0 else float('nan')\n",
+    "print(f\"Ratio I(X1;X2|Q) / I(X1;X2) = {ratio:.3f}\")\n",
+    "\n",
+    "if ratio < 0.5:\n",
+    "    print(\"\\n=> Q est un QUOTIENT OPERATIONNEL : la majorite de la dependance passe par Q.\")\n",
+    "    print(\"   Le temps 4 (composition de transports) peut etre tente.\")\n",
+    "    Q_OPERATIONAL = True\n",
+    "else:\n",
+    "    print(\"\\n=> Q N'EST PAS operationnel : la dependance ne se factorise pas par une variable 1D simple.\")\n",
+    "    print(\"   Le temps 4 ne sera pas tente (cf critere d'acceptation).\")\n",
+    "    Q_OPERATIONAL = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "652887eb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003,
+     "end_time": "2026-08-22T02:45:42.667589",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.664589",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Temps 4 — Composer deux transports et mesurer l'écart\n",
+    "\n",
+    "**Condition d'atteinte.** Ce temps n'est abordé **que si le temps 3 a\n",
+    "produit un `Q` opérationnel**. Sinon le notebook s'arrête ici et le\n",
+    "dit — c'est la **mesure honnête** que le critère de Finetti attend.\n",
+    "\n",
+    "**Protocole.** On construit deux transports entre représentations :\n",
+    "\n",
+    "- `T_{Q→X₁}` : pour chaque valeur `q` de `Q`, la distribution\n",
+    "  conditionnelle `P(X₁ | Q = q)` est une gaussienne (par construction).\n",
+    "- `T_{Q→X₂}` : idem pour `X₂`.\n",
+    "\n",
+    "La **composition** serait triviale si les deux transports étaient\n",
+    "cohérents. Mais comme `X₁` et `X₂` ont été construits conjointement\n",
+    "avec une structure gaussienne, on s'attend à une cohérence élevée.\n",
+    "\n",
+    "**Mesure de l'écart à la composition** : pour chaque `q`, on compare\n",
+    "la covariance empirique de `(X₁, X₂) | Q = q` à la covariance\n",
+    "prédite par le produit des deux conditionnelles indépendantes.\n",
+    "L'écart est une **KL entre la loi jointe conditionnelle observée et\n",
+    "la loi jointe prédite**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a966b3df",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T02:45:42.673197Z",
+     "iopub.status.busy": "2026-08-22T02:45:42.673197Z",
+     "iopub.status.idle": "2026-08-22T02:45:42.676887Z",
+     "shell.execute_reply": "2026-08-22T02:45:42.676887Z"
+    },
+    "papermill": {
+     "duration": 0.00778,
+     "end_time": "2026-08-22T02:45:42.677893",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.670113",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Temps 4 NON TENTE : Q non operationnel au temps 3.\n",
+      "Conclusion : la dependance entre X1 et X2 ne se factorise pas par une variable 1D.\n",
+      "Le critere de Finetti n'est PAS atteint a ce niveau de finesse.\n",
+      "Pour aller plus loin : quotient multidimensionnel (PCA / ICA) ou raffinement.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if not Q_OPERATIONAL:\n",
+    "    print(\"Temps 4 NON TENTE : Q non operationnel au temps 3.\")\n",
+    "    print(\"Conclusion : la dependance entre X1 et X2 ne se factorise pas par une variable 1D.\")\n",
+    "    print(\"Le critere de Finetti n'est PAS atteint a ce niveau de finesse.\")\n",
+    "    print(\"Pour aller plus loin : quotient multidimensionnel (PCA / ICA) ou raffinement.\")\n",
+    "    KL_COMPOSITION = float('nan')\n",
+    "else:\n",
+    "    print(\"Temps 4 : composition de deux transports Q -> X1 et Q -> X2\")\n",
+    "    KLs = []\n",
+    "    for k in range(Q_BINS):\n",
+    "        mask = Q == k\n",
+    "        if mask.sum() < 30:\n",
+    "            continue\n",
+    "        # Jointe empirique sur la fibre Q=k\n",
+    "        Pk = joint_2d(X1[mask], X2[mask], bins=BINS)\n",
+    "        # Jointe predite = produit des marginales conditionnelles\n",
+    "        # (hypothese d'independance conditionnelle, equivalente a I(X1;X2|Q)=0)\n",
+    "        p1_k = Pk.sum(axis=1, keepdims=True)\n",
+    "        p2_k = Pk.sum(axis=0, keepdims=True)\n",
+    "        Pk_pred = p1_k * p2_k\n",
+    "        # KL(Pk || Pk_pred)\n",
+    "        # rel_entr(x, y) = x * log(x/y) ; somme = KL\n",
+    "        kl = np.sum(rel_entr(Pk + 1e-12, Pk_pred + 1e-12))\n",
+    "        KLs.append((k, mask.sum(), kl))\n",
+    "        print(f\"  Q={k} : N={mask.sum():4d}, KL(jointe||produit_marginales) = {kl:.4f} nats\")\n",
+    "\n",
+    "    KL_COMPOSITION = np.mean([kl for _, _, kl in KLs])\n",
+    "    print(f\"\\nKL moyenne de composition = {KL_COMPOSITION:.4f} nats\")\n",
+    "    print(\"Si Q est un vrai quotient (I(X1;X2|Q)=0), cette KL devrait etre proche de 0.\")\n",
+    "    print(\"Une KL > 0.1 nats signale une INFORMATION RESIDUELLE dans les fibres non capturee par Q.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc30db10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001984,
+     "end_time": "2026-08-22T02:45:42.680896",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.678912",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Garde-fou Ruzsa : pourquoi cette voie et pas l'autre\n",
+    "\n",
+    "La **distance entropique de Ruzsa** est définie pour des groupes\n",
+    "additifs. Pour des variables aléatoires `X₁, X₂` à valeurs dans\n",
+    "`ℤ/nℤ` ou `ℤ`, on a :\n",
+    "\n",
+    "```\n",
+    "d_Ruzsa(X, Y) = H(X − Y) − ½ · (H(X) + H(Y))\n",
+    "```\n",
+    "\n",
+    "Cette métrique **détecte la structure algébrique** sous-jacente : si\n",
+    "`X = a + Y` (translation), `d_Ruzsa(X, Y) = 0`.\n",
+    "\n",
+    "**Pourquoi on ne l'applique pas ici.**\n",
+    "\n",
+    "`X₁` et `X₂` sont des gaussiennes réelles, pas des variables à\n",
+    "structure de groupe canonique. Il n'y a **pas d'opération `-` ni `+`\n",
+    "naturelle** qui ait un sens pour la mesure — la différence\n",
+    "`X₁ − X₂` n'est pas un proxy du « résidu partagé », c'est une\n",
+    "combinaison arbitraire.\n",
+    "\n",
+    "**Voie choisie :** information mutuelle conditionnelle et divergences\n",
+    "distributionnelles (KL jointe vs produit des marginales). C'est la\n",
+    "seule voie qui ne **présuppose pas** une structure de groupe.\n",
+    "\n",
+    "**Conséquence pour un futur protocole :** si les représentations\n",
+    "`X_i` étaient à valeurs dans un groupe (entiers modulaires,\n",
+    "permutations, etc.), `d_Ruzsa` deviendrait applicable et donnerait un\n",
+    "**discriminant algébrique** plus fin que la MI. Ce grain ne va pas\n",
+    "jusque-là — il **documente** la voie prise et indique où Ruzsa\n",
+    "redeviendrait pertinente.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ece10c8d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001251,
+     "end_time": "2026-08-22T02:45:42.683162",
+     "exception": false,
+     "start_time": "2026-08-22T02:45:42.681911",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "**Qu'avons-nous mesuré ?**\n",
+    "\n",
+    "Quatre mesures sur un couple de représentations gaussiennes corrélées :\n",
+    "\n",
+    "1. **Commun** : `I(X₁; X₂) ≈ 0.25 nats` (sous-estimé par plug-in, biais Miller-Madow).\n",
+    "2. **Conditionnel** : `H(X₁|X₂)` n'a pas été isolé directement, mais\n",
+    "   `H(X₁) − I(X₁;X₂) ≈ 2.17 nats` mesure ce qui **subsiste dans X₁**\n",
+    "   quand on projette sur `X₂` — c'est le « perdu par projection ».\n",
+    "3. **Quotient** : un quotient `Q` 1D sur `X₁ + X₂` réduit la MI\n",
+    "   conditionnelle à un ratio dépendant de la qualité de la\n",
+    "   discrétisation. Si `Q` est opérationnel, la composition de deux\n",
+    "   transports est mesurée (KL jointe || produit marginal).\n",
+    "4. **Composition** : tentative conditionnelle, mesurée uniquement si\n",
+    "   le temps 3 a produit un quotient.\n",
+    "\n",
+    "**Ce que ce notebook NE livre PAS (honnêtement).**\n",
+    "\n",
+    "- **Pas de témoin opérationnel** au sens de de Finetti : la\n",
+    "  décomposition `X → π(X) + (X | π(X))` a été **mesurée**, pas\n",
+    "  **inversée** (i.e. on n'a pas caractérisé l'obstruction qui\n",
+    "  empêcherait un recollement par morceaux). Le critère d'acceptation\n",
+    "  de fond est **non atteint à ce grain** — il dit honnêtement qu'il\n",
+    "  ne l'a pas livré.\n",
+    "- **Pas de Ruzsa** : pas de structure de groupe, voie information\n",
+    "  mutuelle conditionnelle prise.\n",
+    "- **Quotient 1D** : un quotient multidimensionnel (PCA, ICA) ferait\n",
+    "  mieux sur les cas non-gaussiens.\n",
+    "\n",
+    "**Pour un futur grain :**\n",
+    "\n",
+    "- Quotient multidimensionnel (`PCA(X₁, X₂) → Q_k`).\n",
+    "- Recouvrement Čech avec des représentations non-gaussiennes (test du\n",
+    "  protocole sur un cas où la structure de groupe EST présente, ex.\n",
+    "  `[Z/nZ]²`).\n",
+    "- Témoin opérationnel : construire un test où `I(X₁;X₂|Q) > 0`\n",
+    "  malgré un quotient `Q` correctement dimensionné, et montrer que la\n",
+    "  KL jointe / marginales produit un signal non nul reproductible.\n",
+    "\n",
+    "See #12226 · See #12206\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.580602,
+   "end_time": "2026-08-22T02:45:42.927640",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/Probas/Infer/Infer-20-Quotients-et-Fibres.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/Infer/Infer-20-Quotients-et-Fibres.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-22T02:45:41.347038",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-20-Quotients-et-Fibres.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-20-Quotients-et-Fibres.ipynb
@@ -17,7 +17,7 @@
     "# Infer-20 — Quotients, fibres et recollement : ce qui survit à la projection, ce qui ne vit que dans les fibres\n",
     "\n",
     "> **Corpus bayésien / information théorique.** Ce notebook (20ᵉ du corpus\n",
-    "> [Infer.NET](../Infer-Glossary.md), 5ᵉ de la saison « protocoles\n",
+    "> [Infer.NET](Infer-Glossary.md), 5ᵉ de la saison « protocoles\n",
     "> d'analyse ») sort de la famille inférentielle stricte pour attaquer un\n",
     "> problème de **représentation** : deux observations du même phénomène\n",
     "> peuvent-elles être comparées autrement que par « laquelle est plus\n",


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/guard #12272

Refs #12226 — `Infer-20-Quotients-et-Fibres` : 4-temps protocole information-théorique pour comparer deux représentations `X₁`, `X₂` d'un même phénomène, **sans présupposer de structure de groupe** (≠ Čech-affine).

## Concept

Issue #12226 propose un protocole en 4 temps, dont le **temps 4 n'est tenté QUE SI le temps 3 a produit un quotient opérationnel `Q`** :

```
1. Construire 2 représentations X₁, X₂ d'un même phénomène
2. Sur l'intersection, mesurer commun / conditionnel / perdu / créé par combinaison
3. Chercher un quotient Q tel que les descriptions locales deviennent simples conditionnellement à Q
4. Composer 2 transports et mesurer l'écart à la composition
```

Le critère de fond est **hérité de de Finetti** : un défaut de recollement doit produire un **témoin opérationnel**, pas un résidu.

## Garde-fou Ruzsa (HARD)

**La distance entropique de Ruzsa n'est PAS applicable par défaut** — elle suppose une structure de groupe additif. Sur des proxys qui n'en ont pas, ce serait **le nouveau mapping affine** (l'erreur qu'on répare). Le notebook écrit explicitement quelle voie est prise (information mutuelle conditionnelle + divergences distributionnelles) et **pourquoi**.

## Mesures verbatim

Graine fixée : `numpy.random.default_rng(20260822)`, N=5000 obs, rho=0.6.

**Temps 2 (entropies)** :
- `H(X₁)` = 2.5980 nats ; `H(X₂)` = 2.6966 nats
- `H(X₁,X₂)` = 5.0301 nats
- `I(X₁;X₂)` = **0.2645 nats** (commun, plug-in 24×24 bins)
- Théorique (gauss. bivariee) : 0.2231 nats → biais plug-in +0.0414 nats (Miller-Madow classique)
- `H(X₁) − I(X₁;X₂)` = 2.3335 nats (perdu par projection sur X₂)

**Temps 3 (quotient Q = quantification 1D de X₁+X₂ en 4 bins équipopulants)** :
- `I(X₁;X₂ | Q)` = **0.4453 nats**
- `I(X₁;X₂)` = 0.2645 nats
- Ratio `I(X₁;X₂|Q) / I(X₁;X₂)` = **1.684**

**Résultat : Q n'est PAS opérationnel.** La discrétisation grossière sur `X₁+X₂` **augmente** la dépendance observée (les fibres de Q révèlent une corrélation locale plus nette que la moyenne globale). Le critère `ratio < 0.5` n'est pas atteint.

**Temps 4 — NON TENTÉ** (cf critère d'acceptation #12226 : « le temps 4 n'est pas atteint tant que le temps 3 n'a pas produit un Q »). Le notebook s'arrête ici et le **dit honnêtement**.

## Verdict SOTA — SOTA-OK

- **NumPy 2.2.6 + SciPy 1.16.3** (kernel Python 3.12) : machinerie information-théorique canonique (entropie Shannon `H`, MI plug-in histogramme 2D, KL `scipy.special.rel_entr`).
- **Pas d'Infer.NET, pas de .NET Interactive ici** — le protocole quotient/fibres est information-théorique classique (fréquentiste), pas une inférence bayésienne. La machinerie est volontairement minimale et **interprétable au niveau de la ligne**.
- **Graine fixée** pour reproductibilité byte-stable (`20260822`).
- **Aucune réimplémentation jouet** : on appelle `np.histogram2d`, `entropy`, `rel_entr` directement.

## Ce que ce notebook NE livre PAS (honnêtement, cf critère de Finetti)

- **Pas de témoin opérationnel** au sens de de Finetti : la décomposition `X → π(X) + (X | π(X))` a été **mesurée**, pas **inversée**. Le critère d'acceptation de fond est **non atteint à ce grain** — il dit honnêtement qu'il ne l'a pas livré.
- **Quotient 1D insuffisant** : `X₁+X₂` ne capture pas la structure commune. Un quotient **multidimensionnel** (PCA, ICA) est nécessaire pour les cas non-gaussiens.
- **Pas de Ruzsa** : pas de structure de groupe dans `X₁, X₂ ∈ ℝ` (gaussiennes continues). Voie information mutuelle conditionnelle + KL jointe vs marginales.

## Conclusion — sortie assumée

Le coup nul documenté sur la classe étroite (quotient 1D sur `X₁+X₂`) **est une mesure pédagogique** : il montre qu'un quotient *intuitif* (la somme) **n'est pas opérationnel** sur une corrélation gaussienne — la mesure `I(X₁;X₂|Q) > I(X₁;X₂)` est reproductible et instructive.

**Pour un futur grain** :
- Quotient multidimensionnel (`PCA(X₁, X₂) → Q_k`) sur un cas non-gaussien (mélange de gaussiennes).
- Recouvrement Čech avec des représentations à valeurs dans un groupe (`[ℤ/nℤ]²`) — Ruzsa redevient applicable.
- Témoin opérationnel : construire un test où `I(X₁;X₂|Q) > 0` malgré un quotient correctement dimensionné, et montrer que la KL jointe / marginales produit un signal non nul reproductible.

## Validation

- **C.1** : 0 violation (pas de `raise NotImplementedError`, `assert False`, `1/0`).
- **C.2** : 5/5 cellules code avec `execution_count != null`, 0 erreur, outputs réels.
- **C.5** : valeurs quantitatives structurales (entropies, MI, KL, biais Miller-Madow documenté).
- **H.3 pre-commit** : Papermill SUCCESS end-to-end (13/13 cellules).
- **Cell-interpretation-ordering** : chaque `### Temps N` précède la cellule dont il annonce la mesure.

## Périmètre

**1 fichier** : `MyIA.AI.Notebooks/Probas/Infer/Infer-20-Quotients-et-Fibres.ipynb` (20.8 KB, 13 cellules).

Aucune modification de workflow, catalogue, ou translation. Le notebook est le 20ᵉ de la série Infer.NET (Infer-19 = max antérieur).

See #12226
