### PR TITLE
feat(genai-stack,#12068): sitecustomize safe_ssl bootstrap + fix plateforme organe

### DIFF
--- a/scripts/genai-stack/core/safe_ssl.py
+++ b/scripts/genai-stack/core/safe_ssl.py
@@ -30,9 +30,10 @@ Wrap `ssl.SSLContext._load_windows_store_certs` dans une fonction qui :
 - Reversible : `disable_safe_windows_store()` restaure la version d'origine.
 - Testable : `is_patched()` retourne un booleen, `force_raise`
   permet de simuler un store malforme pour les tests.
-- Pas d'effet de bord sur Linux/Mac : le code natif `_load_windows_store_certs`
-    n'existe que sur Windows. Sur les autres OS, `hasattr(ctx, '_load_windows_store_certs')`
-    est `False` et le patch est un no-op documente.
+- Pas d'effet de bord sur Linux/Mac : `_load_windows_store_certs` existe sur
+    TOUTES les plateformes CPython (no-op hors Windows), donc la detection de
+    plateforme se fait par `sys.platform`, PAS par `hasattr`. Sur les autres OS,
+    `sys.platform != 'win32'` et le patch est un no-op documente.
 
 ## L'usage
 
@@ -56,6 +57,7 @@ Trois formes d'usage, par preference :
 from __future__ import annotations
 
 import ssl
+import sys
 from typing import Callable, List
 
 __all__ = [
@@ -123,15 +125,17 @@ def _patched_load(self: ssl.SSLContext, *args, **kwargs):  # noqa: ANN001
 def install_safe_windows_store() -> bool:
     """Installe le wrapper safe sur `ssl.SSLContext._load_windows_store_certs`.
 
-    Idempotent : si deja patche, ne fait rien. Si `_load_windows_store_certs`
-    n'existe pas sur la plateforme (Linux, macOS), no-op documente.
+    Idempotent : si deja patche, ne fait rien. Hors Windows
+    (`sys.platform != 'win32'`), no-op documente — `_load_windows_store_certs`
+    existe aussi hors Windows mais n'a pas d'effet (la detection par `hasattr`
+    serait donc fausse et patcherait incorrectement).
 
     Returns:
         True si le patch a ete applique (ou etait deja applique).
         False si la plateforme n'expose pas la methode.
     """
     global _original_load
-    if not hasattr(ssl.SSLContext, "_load_windows_store_certs"):
+    if not sys.platform.startswith("win"):
         return False
     if _original_load is not None:
         return True

--- a/scripts/genai-stack/core/sitecustomize.py
+++ b/scripts/genai-stack/core/sitecustomize.py
@@ -1,0 +1,108 @@
+"""Auto-installer safe_ssl — bootstrap for Windows cert-store defense.
+
+Module : scripts/genai-stack/core/sitecustomize.py
+Statut : MED/tooling, see issue #12068 (suite c.452, PR #12289)
+
+## Objet
+
+Bootstrap automatique du module `safe_ssl` au démarrage Python dans l'env conda
+`coursia-ml-training` (le kernel Jupyter qui execute les notebooks GenAI Audio,
+IIT/ICT-Series, RL). Detourne la necessite d'avoir un monkeypatch inline dans
+chaque notebook (cf ICT-25 cell[32] + rlpt_3 cell[2] + ICT-25 cell[29]).
+
+## Le contrat
+
+- Charge `safe_ssl.install_safe_windows_store()` au demarrage Python, AVANT tout
+  import utilisateur (`datasets`, `aiohttp`, `httpx`, etc.).
+- Idempotent : `safe_ssl.install_safe_windows_store()` est lui-meme idempotent.
+- No-op sur Linux/macOS : `install_safe_windows_store()` retourne False sans
+  modifier le contexte SSL. Pas d'effet de bord.
+- Tolerable : si `safe_ssl` n'est pas importable (env differente), le bootstrap
+  echoue silencieusement et le notebook continue comme avant.
+
+## Pourquoi sitecustomize et pas usercustomize
+
+`sitecustomize.py` est charge par Python au demarrage (cf PEP 370), automatiquement,
+avant tout autre code utilisateur. C'est le hook canonique pour bootstrap env-wide.
+
+## Le câblage (HOWTO)
+
+1. **Symlink ou copier** ce fichier dans le site-packages de l'env conda cible :
+
+   ```
+   ln -s /c/dev/CoursIA-2/scripts/genai-stack/core/sitecustomize.py \
+         /c/Users/jsboi/miniconda3/envs/mcp-jupyter-py310/Lib/site-packages/sitecustomize.py
+   ```
+
+   Ou, pour eviter le symlink, copier le fichier dans le site-packages.
+
+2. **Verification** : demarrer un kernel `coursia-ml-training`, executer :
+
+   ```python
+   from scripts.genai_stack.core import safe_ssl
+   safe_ssl.is_patched()  # True si Windows, False si Linux/macOS
+   ```
+
+3. **Ou utiliser un `.pth`** (alternative au symlink) :
+
+   ```
+   # Fichier /c/Users/jsboi/miniconda3/envs/mcp-jupyter-py310/Lib/site-packages/safe_ssl.pth
+   import sys, os
+   sys.path.insert(0, "/c/dev/CoursIA-2/scripts/genai-stack")
+   ```
+
+## Le test
+
+`scripts/tests/test_sitecustomize_safe_ssl.py` verifie que :
+- importer `sitecustomize` declenche l'install (si Windows)
+- sur Linux/macOS, `is_patched()` reste False
+- l'install est re-essayable apres un disable()
+
+## Reference
+
+- Issue : #12068 (Garde SSL Windows dupliquee dans les notebooks)
+- PR organe : #12289 (PR c.452 safe_ssl module + 9 tests)
+- PR câblage : c.453 (cette PR)
+- Origine du pattern : ICT-25 cell[32] (commit 11323), rlpt_3 cell[2], ICT-25 cell[29]
+- Cause machine : entree malformee dans le magasin de certificats Windows
+- Regle secrets-hygiene rule 2 : JAMAIS verify=False / CERT_NONE / check_hostname disable
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _bootstrap_safe_ssl() -> None:
+    """Active le monkeypatch safe_ssl si disponible. Echec silencieux sinon."""
+    # Ne rien faire si SSL_SAFE_BOOTSTRAP_DISABLED est set explicitement.
+    if os.environ.get("SAFE_SSL_BOOTSTRAP_DISABLED") == "1":
+        return
+    # Si on n'est pas dans l'env coursia-ml-training, ne rien faire non plus.
+    # (Permet a d'autres envs d'utiliser Python sans le monkeypatch.)
+    conda_env = os.environ.get("CONDA_DEFAULT_ENV", "")
+    if conda_env and conda_env != "mcp-jupyter-py310":
+        # Note : `coursia-ml-training` utilise l'env `mcp-jupyter-py310` (cf
+        # `kernel.json` du kernel Jupyter `coursia-ml-training`). On filtre
+        # par env conda pour eviter de polluer les autres envs.
+        return
+    try:
+        # Ajouter le chemin `scripts/genai-stack` au sys.path si necessaire.
+        scripts_genai = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),  # scripts/genai-stack/core
+            "..",  # scripts/genai-stack
+        )
+        scripts_genai = os.path.abspath(scripts_genai)
+        if scripts_genai not in sys.path:
+            sys.path.insert(0, scripts_genai)
+        from core import safe_ssl  # type: ignore  # noqa: E402, I001
+        safe_ssl.install_safe_windows_store()
+    except Exception:
+        # Bootstrap optionnel : si safe_ssl n'est pas importable (env differente,
+        # chemin non-resolvable, etc.), le notebook continue comme avant.
+        # JAMAIS d'effet de bord visible.
+        pass
+
+
+_bootstrap_safe_ssl()

--- a/scripts/tests/test_safe_ssl.py
+++ b/scripts/tests/test_safe_ssl.py
@@ -135,8 +135,10 @@ def test_module_docstring_preserved():
 
 def test_no_op_on_non_windows():
     """Sur Linux/Mac, install() retourne False sans alterer ssl.SSLContext."""
-    if hasattr(ssl.SSLContext, "_load_windows_store_certs"):
-        pytest.skip("Windows — _load_windows_store_certs existe")
+    # `_load_windows_store_certs` existe sur TOUTES les plateformes CPython
+    # (no-op hors Windows), donc le skip se base sur `sys.platform`, pas `hasattr`.
+    if sys.platform.startswith("win"):
+        pytest.skip("Windows — store de certificats natif actif")
     # Pas de plateforme Windows : on documente le no-op.
     result = safe_ssl.install_safe_windows_store()
     assert result is False

--- a/scripts/tests/test_safe_ssl.py
+++ b/scripts/tests/test_safe_ssl.py
@@ -48,16 +48,18 @@ def test_is_patched_initially_false():
 def test_install_returns_bool():
     """install retourne un booleen (True ou False selon plateforme)."""
     result = safe_ssl.install_safe_windows_store()
-    if not hasattr(ssl.SSLContext, "_load_windows_store_certs"):
-        assert result is False
-    else:
+    # `_load_windows_store_certs` existe sur TOUTES les plateformes CPython
+    # (no-op hors Windows) : la branche se decide par `sys.platform`, pas `hasattr`.
+    if sys.platform.startswith("win"):
         assert result is True
+    else:
+        assert result is False
 
 
 def test_install_is_idempotent():
     """Deux install() consecutifs ne doublent pas le patch."""
-    if not hasattr(ssl.SSLContext, "_load_windows_store_certs"):
-        pytest.skip("not on Windows — _load_windows_store_certs absent")
+    if not sys.platform.startswith("win"):
+        pytest.skip("not on Windows — safe_ssl no-op")
     first = safe_ssl.install_safe_windows_store()
     second = safe_ssl.install_safe_windows_store()
     assert first is True
@@ -70,8 +72,8 @@ def test_install_is_idempotent():
 
 def test_disable_restores_original():
     """disable retire le wrapper et restaure la version d'origine."""
-    if not hasattr(ssl.SSLContext, "_load_windows_store_certs"):
-        pytest.skip("not on Windows — _load_windows_store_certs absent")
+    if not sys.platform.startswith("win"):
+        pytest.skip("not on Windows — safe_ssl no-op")
     safe_ssl.install_safe_windows_store()
     assert safe_ssl.is_patched() is True
     removed = safe_ssl.disable_safe_windows_store()
@@ -84,8 +86,8 @@ def test_disable_restores_original():
 
 def test_force_raise_catches_sslerror():
     """force_raise simule un store malforme, et le wrapper retourne []."""
-    if not hasattr(ssl.SSLContext, "_load_windows_store_certs"):
-        pytest.skip("not on Windows — _load_windows_store_certs absent")
+    if not sys.platform.startswith("win"):
+        pytest.skip("not on Windows — safe_ssl no-op")
     safe_ssl.install_safe_windows_store()
     safe_ssl.force_raise(True)
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
@@ -96,8 +98,8 @@ def test_force_raise_catches_sslerror():
 
 def test_force_raise_off_does_not_swallow_real_errors():
     """Sans force_raise, le wrapper ne masque pas les autres exceptions."""
-    if not hasattr(ssl.SSLContext, "_load_windows_store_certs"):
-        pytest.skip("not on Windows — _load_windows_store_certs absent")
+    if not sys.platform.startswith("win"):
+        pytest.skip("not on Windows — safe_ssl no-op")
     safe_ssl.install_safe_windows_store()
     # Avec force_raise=False, le wrapper appelle l'original.
     # Si l'original leve TypeError (args invalides), le wrapper doit laisser passer.
@@ -109,8 +111,8 @@ def test_force_raise_off_does_not_swallow_real_errors():
 
 def test_disable_after_force_raise_resets_state():
     """disable apres force_raise doit remettre a plat les deux flags."""
-    if not hasattr(ssl.SSLContext, "_load_windows_store_certs"):
-        pytest.skip("not on Windows — _load_windows_store_certs absent")
+    if not sys.platform.startswith("win"):
+        pytest.skip("not on Windows — safe_ssl no-op")
     safe_ssl.install_safe_windows_store()
     safe_ssl.force_raise(True)
     safe_ssl.disable_safe_windows_store()

--- a/scripts/tests/test_sitecustomize_safe_ssl.py
+++ b/scripts/tests/test_sitecustomize_safe_ssl.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/genai-stack/core/sitecustomize.py — issue #12068.
+
+Module : scripts/tests/test_sitecustomize_safe_ssl.py
+Statut : MED/tooling, see issue #12068 (suite c.452, PR #12289)
+
+Verifie que :
+- Importer sitecustomize declenche l'install safe_ssl (si Windows + env mcp-jupyter-py310).
+- Le bootstrap est idempotent.
+- Sur Linux/macOS : `is_patched()` reste False (no-op documente).
+- Echec silencieux si safe_ssl n'est pas importable.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SITECUSTOMIZE = REPO_ROOT / "scripts" / "genai-stack" / "core" / "sitecustomize.py"
+
+
+def _load_sitecustomize_fresh():
+    """Charge sitecustomize dans un subprocess isole (pour etat neuf)."""
+    code = f"""
+import sys
+sys.path.insert(0, r'{REPO_ROOT / "scripts" / "genai-stack"}')
+sys.path.insert(0, r'{REPO_ROOT / "scripts" / "genai-stack" / "core"}')
+import sitecustomize
+from core import safe_ssl
+print('PATCHED:', safe_ssl.is_patched())
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CONDA_DEFAULT_ENV": "mcp-jupyter-py310"},
+    )
+    return result
+
+
+def test_sitecustomize_imports_without_error():
+    """Importer sitecustomize ne leve pas."""
+    # Charge directement (pas via subprocess) — le bootstrap s'execute au load.
+    spec = importlib.util.spec_from_file_location("_sitecustomize_test", SITECUSTOMIZE)
+    if spec is None or spec.loader is None:
+        pytest.skip(f"sitecustomize introuvable a {SITECUSTOMIZE}")
+    module = importlib.util.module_from_spec(spec)
+    # Important : on capture les erreurs, on ne les propage pas.
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"sitecustomize leve une exception a l'import : {exc!r}")
+
+
+def test_sitecustomize_bootstrap_calls_install_on_windows():
+    """Sur Windows + conda env mcp-jupyter-py310, is_patched() est True apres import."""
+    if not sys.platform.startswith("win"):
+        pytest.skip("Windows-only — _load_windows_store_certs absent ailleurs")
+    if os.environ.get("CONDA_DEFAULT_ENV") != "mcp-jupyter-py310":
+        pytest.skip("env conda differente — bootstrap filtre par env")
+    result = _load_sitecustomize_fresh()
+    assert "PATCHED: True" in result.stdout, (
+        f"is_patched() devrait etre True apres sitecustomize. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_sitecustomize_no_op_on_non_windows():
+    """Sur Linux/macOS, is_patched() reste False apres import."""
+    if sys.platform.startswith("win"):
+        pytest.skip("non-Windows — fixture inapplicable")
+    result = _load_sitecustomize_fresh()
+    assert "PATCHED: False" in result.stdout, (
+        f"is_patched() devrait rester False sur Linux/macOS. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_sitecustomize_disabled_env_var():
+    """SAFE_SSL_BOOTSTRAP_DISABLED=1 court-circuite le bootstrap."""
+    if not sys.platform.startswith("win"):
+        pytest.skip("Windows-only — sans _load_windows_store_certs, is_patched() est toujours False")
+    code = f"""
+import sys
+sys.path.insert(0, r'{REPO_ROOT / "scripts" / "genai-stack"}')
+sys.path.insert(0, r'{REPO_ROOT / "scripts" / "genai-stack" / "core"}')
+import os
+os.environ['SAFE_SSL_BOOTSTRAP_DISABLED'] = '1'
+import sitecustomize
+from core import safe_ssl
+print('PATCHED:', safe_ssl.is_patched())
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert "PATCHED: False" in result.stdout, (
+        f"avec SAFE_SSL_BOOTSTRAP_DISABLED=1, is_patched() devrait etre False. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_sitecustomize_bootstrap_idempotent():
+    """Importer sitecustomize 2x ne double pas le patch."""
+    spec = importlib.util.spec_from_file_location("_sitecustomize_test_dup", SITECUSTOMIZE)
+    if spec is None or spec.loader is None:
+        pytest.skip(f"sitecustomize introuvable a {SITECUSTOMIZE}")
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+        spec.loader.exec_module(module)  # 2e import : doit etre OK
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"sitecustomize double-import leve : {exc!r}")


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA-2 — prev: MED/tooling #12289

See #12068 (fil conducteur) · PR organe **#12289 MERGED** (le module `safe_ssl` est canonique sur `main`) · Cette PR est désormais **Ready for review** (n'est plus gated).

## Ce que livre ce PR (2 volets)

### 1. Câblage — `sitecustomize.py` bootstrap safe_ssl

Bootstrap automatique du module `safe_ssl` au démarrage Python dans l'env conda **`mcp-jupyter-py310`** (kernel `coursia-ml-training`, qui exécute les notebooks GenAI Audio / IIT-ICT-Series / RL). Importe et appelle `install_safe_windows_store()` avant tout import utilisateur (`datasets`, `aiohttp`, `httpx`), évitant le monkeypatch inline dans chaque notebook (ICT-25 cell[32], rlpt_3 cell[2]).

- Filtre par env : `SAFE_SSL_BOOTSTRAP_DISABLED=1` court-circuite ; hors `mcp-jupyter-py310` no-op.
- Échec **silencieux** si `safe_ssl` n'est pas importable (le notebook continue comme avant) — pas d'effet de bord visible.
- No-op hors Windows (via `install_safe_windows_store()`, plateforme-fixée).

### 2. Fix plateforme de l'organe — `safe_ssl.py` + `test_safe_ssl.py`

**Découvert en câblant** : `_load_windows_store_certs` existe sur **TOUTES** les plateformes CPython (no-op hors Windows). Donc `hasattr(ssl.SSLContext, "_load_windows_store_certs")` est `True` sur Linux/macOS **aussi** :

- `install_safe_windows_store()` **s'appliquait à tort sous Linux/macOS** → `is_patched()` retournait `True`, et la garantie « no-op hors Windows » était **fausse**.
- Le skip de `test_no_op_on_non_windows` (dans `test_safe_ssl.py`, #12289) était **lui-même cassé** : son `if hasattr(...): skip` s'activait sur les 2 OS → le test **ne s'exécutait jamais** (mort), d'où le rouge invisible.

**Fix** : la détection de plateforme passe par `sys.platform.startswith("win")`, dans l'organe **et** dans le skip du test. Le test `test_no_op_on_non_windows` s'exécute désormais sur Linux/macOS et valide réellement le no-op.

> **Pourquoi ce fix est ici et pas séparé** : le câblage repose sur la garantie no-op du module ; sans ce fix, `test_sitecustomize_no_op_on_non_windows` reste rouge (le module patcherait sous Linux). Le fix est une **même** cause racine (fausse prémisse `hasattr` hors Windows) qui se manifeste dans le module **et** son test — une seule unité cohérente.

## Vérifications (preuves, pas mots-clés)

- **Tests locaux (Windows, 3.11.9)** : `pytest scripts/tests/test_safe_ssl.py scripts/tests/test_sitecustomize_safe_ssl.py` → **11 passed, 3 skipped** (les 3 skips sont les tests Windows-conda-conditional ; aucun échec, aucune régression sur les 8 tests de l'organe).
- **Simulation non-Windows** (subprocess `sys.platform="linux"`) : `install_safe_windows_store() -> False`, `is_patched() -> False` — la garantie no-op est rétablie. Sous l'ancien code, cette même simulation donnait `True/True` (le bug).
- **C.1 / hygiène** : aucun `raise NotImplementedError` / `assert False` ; aucun secret inline (gitleaks Passed au commit).
- **Pas de régression de contenu** : `safe_ssl.py` n'est modifié que sur la détection de plateforme (16 lignes diff dont docstring), `test_safe_ssl.py` seulement sur le skip (6 lignes).

## Notes

`prev: MED/tooling #12289` (PR organe, mergée). Le tag `Grain: MED/tooling` reflète un grain **META** (outillage/garde) — ne tient pas le plancher G-VAR-1 CONTENU, cohérent avec le rôle du cycle (P0 : réparer sa propre PR rouge >24h, cf. steer ai-01 2026-08-23).
