### PR TITLE
fix(secrets,#12100): retirer le commentaire codeql inerte + consigner l'intention

### DIFF
--- a/scripts/secrets/render_settings_json.py
+++ b/scripts/secrets/render_settings_json.py
@@ -118,7 +118,11 @@ def fingerprint(value: str) -> str:
     """
     if not value:
         return "<empty>"
-    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]  # noqa: S324 -- discriminant only, not auth # codeql[py/weak-sensitive-data-hashing] -- cf #10275: cle API haute entropie, aucune decision d'auth
+    # NOTE: ce sha256[:8] est un discriminant (tag de coherence), pas une
+    # fonction d'auth (cf #10275). Aucun mecanisme de securite ne depend
+    # de sa resistance aux collisions. Le commentaire `# codeql[py/weak-sensitive-data-hashing]`
+    # retire ici etait inerte (default setup, pas de AlertSuppression.ql) -- cf #12100.
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]  # noqa: S324 -- discriminant only, not auth
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2024:CoursIA-2 — prev: LIGHT/coordination #12153

## fix(secrets,#12100): retirer le commentaire codeql inerte + consigner l'intention

### Concept

Le commentaire `# codeql[py/weak-sensitive-data-hashing]` sur la ligne
`fingerprint()` de `scripts/secrets/render_settings_json.py:121` etait
**inerte** sur ce depot : CodeQL y tourne en **default setup** (= gere
par GitHub, hors du repo), donc il n'existe aucun point d'insertion pour
`AlertSuppression.ql` ni pour `dismiss-alerts`. Le commentaire ne produit
rien dans le SARIF, ne leve rien, et ajoute juste du bruit a la lecture.

Deux commits de #11905 (`95b03899f`, `380922b45`) ont ete depenses a
deplacer le commentaire pour lever deux alertes. Les alertes sont toujours
ouvertes sur la tete analysee (`ee8823b55`, check-run 96714903857) -- preuve
que ce n'etait pas un probleme de placement, mais un probleme de mecanique :
les commentaires sont inertes par construction sur ce depot.

### Modification

Avant (1 ligne, 2 commentaires en queue) :

```python
return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]  # noqa: S324 -- discriminant only, not auth # codeql[py/weak-sensitive-data-hashing] -- cf #10275: cle API haute entropie, aucune decision d'auth
```

Apres (5 lignes : 4 de NOTE + 1 de retour preserve) :

```python
# NOTE: ce sha256[:8] est un discriminant (tag de coherence), pas une
# fonction d'auth (cf #10275). Aucun mecanisme de securite ne depend
# de sa resistance aux collisions. Le commentaire `# codeql[py/weak-sensitive-data-hashing]`
# retire ici etait inerte (default setup, pas de AlertSuppression.ql) -- cf #12100.
return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]  # noqa: S324 -- discriminant only, not auth
```

Le `# noqa: S324` reste (utile pour ruff/bandit/flake8, **eux ne dependent
pas de CodeQL**). Le discriminant `sha256[:8]` lui-meme est preserve byte-pour-byte.

### Validation

| Verification | Resultat |
|---|---|
| Import `from render_settings_json import fingerprint` | OK |
| `fingerprint('hello')` -> `'sha256:2cf24dba'` | OK (meme valeur qu'avant) |
| `fingerprint('')` -> `'<empty>'` | OK (meme valeur qu'avant) |
| `git diff --stat` | `1 file changed, 5 insertions(+), 1 deletion(-)` |
| LF preserve | OK (0 CRLF, ASCII-only) |
| Encoding | UTF-8 no-BOM (coherent avec original) |
| Pas de secret / path absolu / literal fallback | OK |

### Conformite

- **C.1** : N/A (pas un notebook, juste un script Python).
- **C.2** : N/A (pas de cellule a executer).
- **C.5** : N/A (prose quantitative absente -- fix mecanique de commentaire).
- **H.1** : validation end-to-end par import + 2 appels de la fonction preserve.
- **H.3** : pre-commit attendu PASS (script Python modifie sans violation).
- **S.1 / Secrets hygiene** : aucune cle, aucun path, aucun literal-default.
- **D / Anti-regression** : la fonction `fingerprint()` est preservee byte-pour-byte (meme calcul, meme retour). Aucune regression de substance.
- **Prong A SOTA** : pas un workaround degrade, c'est l'oppose -- c'est un retrait de workaround (le commentaire inerte etait lui-meme un workaround deformaté).
- **Prong B** : N/A (probleme non-trivial de moteur : non, c'est un commentaire, pas un solveur).

### Portee

**Perimetre : 1 fichier** (cf [pr-review-discipline.md](.claude/rules/pr-review-discipline.md) E : top-line unique).

- `scripts/secrets/render_settings_json.py` (+5/-1)

Le scope strict respecte le `paths:` du claim partitionne
`myia-po-2024:CoursIA-2 -- paths: scripts/secrets/render_settings_json.py`
pose sur #12100.

### Ce que cette PR ne fait PAS (volontairement)

- **Pas de regle `.claude/rules/`** ajoutee : l'acceptance de #12100 mentionne
  que cette consignation dans `.claude/rules/` necessite PR + sign-off user.
  Ce cycle-ci livre le retrait (mecanique verifiable firsthand) ; la consignation
  en regle est un autre grain qui meriterait son propre cycle avec ai-01.
- **Pas de cleanup des commits `95b03899f` / `380922b45`** : ils appartiennent
  a #11905 (TTS) qui n'est pas mon scope.
- **Pas de modification de la fonction** : seul le commentaire change. Le
  discriminant reste `sha256[:8]` pour ne pas casser les hashs deja emis.

### Suite logique (hors scope ce cycle)

- AI-01 / sign-off user : si la consignation `codeql-suppressions-inertes` doit
  devenir une regle `.claude/rules/`, ouvrir un grain dedie (cf acceptance #12100).
- Lane po-2025 / po-2026 : alerter sur les futurs commentaires `# codeql[...]`
  qui pourraient etre ajoutes -- le warning est local a ce fichier mais le
  phenomene pourrait se reproduire ailleurs.

### Conformite cycle

- Pas de merge, pas de `gh auth switch`, scope strict `scripts/secrets/render_settings_json.py`.
- Pas de touch au catalogue (script seul).
- `git status` clean avant commit (1 fichier, +5/-1).
- Worker discipline : scope strict, pas de regen catalogue, branche `fix/12100-codeql-inert-comment`, base = origin/main frais (c7bc85f2d).
- L898 PRE-WORK search : `gh pr list --search "codeql"` + `--search "12100"` clean avant claim.
- L677-L4 PR body genere HORS worktree (`<scratchpad-dir>/c1331p364_pr_body.md`).

Refs #12100
