### PR TITLE
fix(rules,#11815): codifier REPAIR herite du genre de la PR reparee (G-VAR-1)

### DIFF
--- a/.claude/rules/variation-protocol.md
+++ b/.claude/rules/variation-protocol.md
@@ -53,6 +53,24 @@ Un genre hors liste est un **alias** que le merge-gate normalise : pas une viola
 
 **Entrer dans la liste LIGHT de G-VAR-3 se mesure, jamais s'intuitionne** : un genre y entre dès **≥ 2 grains LIGHT mergés**.
 
+### Grain REPAIR — hérite du genre de la PR qu'il répare
+
+Un grain dont le livrable principal est **réparer une PR pré-existante** (la débloquer après un PR-gate rouge, lever une review REQUEST_CHANGES, fixer un ratchet Papermill, etc.) **hérite du genre de la PR qu'il répare** :
+
+- Réparer une PR `notebook-python` (ex : #12141 tranche E #12128) → tag `MED/notebook-python` → genre **CONTENU** → tient le plancher G-VAR-1.
+- Réparer une PR `lean` (ex : #12252 Lean-21b companion) → tag `MED/notebook-lean` → genre **CONTENU** → tient le plancher.
+- Réparer une PR `guard` (ex : #11997 fix #11732 abort --update) → tag `MED/guard` → genre **META** → ne tient **pas** le plancher, comme toute PR META.
+
+Le raisonnement : G-VAR-1 demande « qu'est-ce qui atteint `main` quand ce travail aboutit ? » — la réponse regarde ce qui **arrive sur `main`**, pas ce que le REPAIR a fait. Quand une PR de notebook passe au vert et merge, ce qui arrive sur `main` est un notebook. Le REPAIR est de la fabrication qui sortait de l'entrepôt, pas de l'outillage.
+
+**Cas négatif explicite** : un REPAIR d'une PR **META** reste **META**. Une lane qui ne réparerait que ses propres PR de tooling/docs ne tiendrait toujours pas G-VAR-1. L'échappatoire se ferme d'elle-même.
+
+**Forme du tag** : le REPAIR déclare directement le genre hérité, sans annotation spéciale. Le fait que ce soit un REPAIR se lit dans le titre (préfixe `fix(`) et le diff (`<fichiers de la PR originale> + ajustements`). Une annotation `MED/notebook-python (repair de #11722)` ajoute du bruit sans information : le tag existe pour répondre « quel genre de substance ce grain met-il sur `main` », et la réponse est la même dans les deux cas.
+
+**Tier du REPAIR** : trancher par le litmus habituel. Un REPAIR qui demande une **ré-exécution complète + diagnostic de ratchet** est `MED` (ré-exécution + change quelque chose). Un REPAIR d'**une ligne de body** reste `LIGHT` et consomme le budget G-VAR-2 — `variation-protocol.md` ne crée pas d'exception.
+
+**Sources de l'arbitrage** : ticket #11815 (escalade formelle po-2023 après 3 cycles G-VAR-1 non-tenu sur REPAIR de notebooks, voir DM `msg-20260819T163135-h66acw` et arbitrage `msg-20260819T171752-4jd3od`). La présente clause en codifie la lecture **au cas** en forme **durable**, sous sign-off user (CLAUDE.md §A).
+
 ## 2. Les trois gates durs
 
 - **G-VAR-1 — Plat principal DEEP ou MED, dans un genre de CONTENU.** La PR-plancher du cycle (R1 de proactive-coordination) **DOIT** être DEEP ou MED **et** porter un genre de la classe CONTENU. **Une LIGHT ne satisfait JAMAIS le plancher ; un genre META non plus, quel que soit son tier.** Le pool global porte toujours du DEEP/MED de contenu : la monoculture vient du choix du plus facile *disponible*, pas d'une absence de substance.


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA-2 — prev: LIGHT/guard (LIVRE-URN authentique #11997 c.1301+327)

## Résumé

Codifie durablement dans `variation-protocol.md` la lecture au cas de l'arbitrage rendu par le coordinateur `ai-01` dans le DM `msg-20260819T171752-4jd3od` : un grain **REPAIR** (PR dont le livrable principal est de débloquer une autre PR) **hérite du genre de la PR qu'il répare**. Sans cette clause, G-VAR-1 ne sait pas trancher une PR `fix(notebooks,#X)` qui répare un notebook : il la voit `docs`/`guard`/`tooling` META et refuse le plancher, alors que ce qui sortira sur `main` quand la PR passe est le notebook, pas l'outillage.

## Source de l'arbitrage

Issue **#11815** — escalade formelle `myia-po-2023:CoursIA-2` après 3 cycles G-VAR-1 non-tenu sur REPAIR de notebooks (#11710, #11720, #11722, #11739). Le DM `msg-20260819T163135-h66acw` documente le précédent (po-2023 a livré 4 PR REPAIR, dont trois portent des notebooks, comptées à zéro par G-VAR-1). L'arbitrage rendu `msg-20260819T171752-4jd3od` retient l'option (a) : **le REPAIR déclare directement le genre hérité**, sans annotation spéciale.

## Périmètre (déclaré en début de body — leçon L978)

**1 fichier modifié** : `.claude/rules/variation-protocol.md`. **+18 lignes, 0 suppression** — clause ajoutée entre §1 (GENRE — énumération CLOSE) et §2 (Les trois gates durs). Pas de churn cosmétique sur l'existant.

## Le contenu de la clause

La section ajoutée `### Grain REPAIR — hérite du genre de la PR qu'il répare` tranche **trois questions** :

1. **Quel genre ?** Le REPAIR hérite du genre de la PR qu'il répare (`MED/notebook-python` pour une PR `notebooks/`, `MED/lean` pour une PR `lean`, `MED/guard` pour une PR `tooling`).
2. **Quel cas négatif ?** REPAIR d'une PR META reste META — l'échappatoire se ferme d'elle-même.
3. **Quel tier ?** Le litmus habituel tranche : ré-exécution + diagnostic = MED, ligne de body = LIGHT (G-VAR-2 inchangé).

L'argumentaire est explicite : G-VAR-1 demande « qu'est-ce qui atteint `main` quand ce travail aboutit ? » — la réponse regarde ce qui arrive sur `main`, pas ce que le REPAIR a fait.

## Acceptance LIVRÉE firsthand

- [x] `variation-protocol.md` dit explicitement comment un grain REPAIR se tague.
- [x] un cas négatif est écrit noir sur blanc : REPAIR d'une PR META reste META.
- [x] `scripts/variation_light_cap.py` et `variation-tag-guard.yml` restent cohérents avec la forme retenue (pas de nouveau genre hors énumération).
- [ ] **sign-off user sur la PR qui porte le texte** (CLAUDE.md §A — coordinateur arbitre le merge-gate, il ne promeut pas seul une règle).

## Pourquoi une PR plutôt qu'un commit direct

CLAUDE.md §A : *« un coordinateur arbitre le merge-gate, c'est à lui ; il ne promeut pas seul une règle : tout ajout à `.claude/rules/` passe par une **PR + sign-off user** »* (cf. aussi `audit-cross-source-distillation.md` : « aucun agent ne s'auto-autorise à promouvoir une règle »).

L'arbitrage rendu est écrit **au cas** dans les DM, et ce ticket porte la demande de forme durable. La présente PR la porte.

## Cohérence avec l'arbitrage user (option 1 de #11154)

Cette clause **ne crée pas d'exception** au budget G-VAR-2 : un REPAIR `LIGHT` (ligne de body) reste `LIGHT` et consomme le budget. La dette `DEFECT-ALIVE` de #11044/#11154 reste traitée par l'option 1 (consomme le budget + exception écrite + mesure résiduelle citée).

## Anti-régression

- **Pas de modification de scripts/** : `scripts/variation_light_cap.py`, `scripts/grain_tag.py`, `scripts/ci/variation_prev_guard.py` restent intacts. La clause est une **lecture** de G-VAR-1, pas une modification de l'outillage.
- **Pas de nouveau genre** : la clause utilise l'énumération close existante (l'option 1 de l'arbitrage).
- **Pas d'auto-promotion de règle** : la PR demande le sign-off user explicite, comme requis par CLAUDE.md §A.

## Voir aussi

- #11815 (issue umbrella — source de l'arbitrage)
- msg-20260819T163135-h66acw (escalade po-2023)
- msg-20260819T171752-4jd3od (arbitrage ai-01 — option a)
- #11154 (DEFECT-ALIVE option 1 — cohérence)
- #11170 (référencé dans la source)

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
