### PR TITLE
feat(lane-claim,#12156): expose is_umbrella + epic_wide_on_umbrella flags in JSON summary

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -773,7 +773,12 @@ def _gh_issue_comments(issue: str) -> dict:
     proc = subprocess.run(
         [
             "gh", "issue", "view", str(issue),
-            "--json", "number,title,comments",
+            # #12156 -- `labels` added so the umbrella classifier
+            # (`_is_umbrella_issue`) can read the canonical `EPIC` label the
+            # picker hydrates from. The label-route is the authoritative one;
+            # the title-route stays a fallback for the historic pre-label
+            # inventory.
+            "--json", "number,title,labels,comments",
         ],
         capture_output=True, text=True, shell=False,
     )
@@ -1229,6 +1234,34 @@ def _claim_age_hours(created_at: str | None, now: datetime) -> float | None:
     return (now - parsed).total_seconds() / 3600.0
 
 
+def _is_umbrella_issue(payload: dict) -> bool:
+    """Return True if `payload` describes an umbrella / EPIC-style issue (#12156).
+
+    Mirrors `scripts/pick_idle_grain.py:130` so the two organs speak the same
+    language: an issue is classified as an umbrella when (a) one of its labels
+    is the literal string `EPIC` (case-sensitive -- that is the label the picker
+    hydrates from `gh issue list --label EPIC`), OR (b) the title starts with
+    `[EPIC` / `EPIC` after stripping the leading `[`. The label-route is the
+    authoritative one; the title-route catches the historic pre-label inventory
+    that the picker also accepts.
+
+    Returns False on missing keys (defensive: the from-json path may carry a
+    subset of fields). Never raises -- a malformed payload should degrade to
+    the pre-#12156 behaviour (no umbrella flag) rather than crash.
+    """
+    try:
+        labels = payload.get("labels") or []
+        for lab in labels:
+            name = lab.get("name") if isinstance(lab, dict) else None
+            if isinstance(name, str) and name == "EPIC":
+                return True
+        title = payload.get("title") or ""
+        upper = title.upper().lstrip("[")
+        return upper.startswith("EPIC")
+    except (AttributeError, TypeError):
+        return False
+
+
 def _parse_iso_utc(iso: str) -> datetime | None:
     """Parse a GitHub server `createdAt` (ISO 8601 UTC, trailing 'Z').
 
@@ -1325,6 +1358,29 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
                 stale_others[ln] = ev
         others = {ln: ev for ln, ev in others.items() if ln not in stale_others}
 
+    # #12156 -- umbrella signal. Two booleans surface the diagnostic that
+    # the body of #12156 asks to expose in `check_lane_claim.py`'s JSON:
+    # (a) `is_umbrella` mirrors `pick_idle_grain.py:130` (label `EPIC` or
+    #     title prefix `[EPIC`/`EPIC`), so a caller can know which urn an
+    #     issue would have come from; (b) `epic_wide_on_umbrella` flags the
+    #     pathology the body names -- an umbrella whose blocking claims
+    #     are all epic-wide (no `paths:` or every glob dead per #10958 /
+    #     #12072). The flag is True ONLY when an umbrella is held
+    #     effectively-epic-wide by another lane AND the umbrella has no
+    #     scoped claim; on a CLEAR issue or on a unit issue the flag stays
+    #     False (the umbrella umbrellas nothing, or there is nothing to
+    #     umbrella).
+    is_umbrella = _is_umbrella_issue(payload)
+    if is_umbrella and others:
+        epic_wide_on_umbrella = all(
+            (ev.get("paths") is None)
+            or _claim_scope_effectively_epic_wide(ev)
+            or bool(ev.scope_declared_off_marker)
+            for ev in others.values()
+        )
+    else:
+        epic_wide_on_umbrella = False
+
     summary = {
         "issue": payload.get("number"),
         "title": payload.get("title"),
@@ -1332,6 +1388,15 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
         "my_active_claim": bool(mine),
         "blocking_lanes": sorted(others),
         "stale_claims": sorted(stale_others),
+        # #12156 -- umbrella classifier (`is_umbrella`) and the pathology it
+        # describes (`epic_wide_on_umbrella`). Both default False: on a
+        # unit-issue the umbrella flag stays False; on a CLEAR umbrella the
+        # PATHOLOGY flag stays False too (the lock is empty, not held
+        # wrong). The flags let a coordinator's sweep aggregate
+        # `epic_wide_on_umbrella=True` across issues to count how many
+        # umbrellas are stuck in the pattern #12156 names.
+        "is_umbrella": is_umbrella,
+        "epic_wide_on_umbrella": epic_wide_on_umbrella,
         "active_claims": {
             ln: {
                 "claimed_at": ev.created_at,

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -32,8 +32,16 @@ def comment(body, created_at, author="jsboige", url=None):
     }
 
 
-def payload(*comments, number=9764, title="t"):
-    return {"number": number, "title": title, "comments": list(comments)}
+def payload(*comments, number=9764, title="t", labels=None):
+    # #12156 -- `labels` defaults to None (absent key) so pre-existing tests
+    # that don't care about the umbrella signal stay byte-equivalent: the
+    # helper in `_is_umbrella_issue` falls back to `payload.get("labels") or []`
+    # and degrades to the title-route. Tests that need the umbrella signal
+    # pass `labels=[{"name": "EPIC"}]` explicitly.
+    d = {"number": number, "title": title, "comments": list(comments)}
+    if labels is not None:
+        d["labels"] = labels
+    return d
 
 
 # --- extract_lane (grain_tag, now reused by the guard) -----------------------
@@ -3225,3 +3233,137 @@ def test_run_check_summary_off_marker_field_empty_without_signal(capsys):
     clc._run_check(p, "myia-po-2025:CoursIA")
     out = capsys.readouterr().out
     assert '"scope_declared_off_marker": []' in out
+
+
+# --- #12156 -- umbrella / epic-wide-on-umbrella summary fields ---------------
+
+
+def test_run_check_summary_is_umbrella_true_on_EPIC_label(capsys):
+    # #12156 acceptance (1) -- un umbrella labellise `EPIC` expose
+    # `is_umbrella: true` au niveau top-level du summary, miroir du picker
+    # qui lit la meme etiquette (cf `scripts/pick_idle_grain.py:130`).
+    # Note : un umbrella + claim epic-wide sans `paths:` est
+    # simultanement `is_umbrella: true` ET `epic_wide_on_umbrella: true`
+    # (la pathologie que le body denomme). Les deux flags sont
+    # orthogonaux -- le premier classifie, le second diagnostique.
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2024:CoursIA-2\n",
+            "2026-08-20T12:00:00Z",
+        ),
+        number=12207,
+        labels=[{"name": "EPIC"}, {"name": "research-notebook"}],
+    )
+    clc._run_check(p, "myia-po-2025:CoursIA-2")
+    out = capsys.readouterr().out
+    assert '"is_umbrella": true' in out
+    # Le test suivant (`test_run_check_summary_epic_wide_on_umbrella_true_*`)
+    # est l'acceptance explicite de la pathologie sur le meme pattern.
+    # Ici on verifie juste que le classifieur fonctionne ; le controle
+    # pathologie-false est dans `..._false_when_scoped`.
+    assert '"epic_wide_on_umbrella":' in out
+
+
+def test_run_check_summary_is_umbrella_true_on_title_prefix(capsys):
+    # #12156 acceptance (2) -- fallback title-route : un titre commencant par
+    # "[EPIC" est classifie umbrella meme sans label explicite (le picker
+    # accepte la meme forme).
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2024:CoursIA-2\n",
+            "2026-08-20T12:00:00Z",
+        ),
+        number=1206,
+        title="Epic: Fork Z3.Linq propre + reintegration (pre-label inventory)",
+    )
+    clc._run_check(p, "myia-po-2025:CoursIA-2")
+    out = capsys.readouterr().out
+    assert '"is_umbrella": true' in out
+
+
+def test_run_check_summary_is_umbrella_false_on_unit_issue(capsys):
+    # Controle : une issue unitaire (label `documentation`, titre sans
+    # `EPIC`) expose `is_umbrella: false` -- la classification ne contamine
+    # pas le cas general.
+    p = payload(
+        number=9890,
+        title="Emojis dans comparatif-owui-vs-ai-engine.md",
+        labels=[{"name": "documentation"}],
+    )
+    clc._run_check(p, "myia-po-2023:CoursIA-2")
+    out = capsys.readouterr().out
+    assert '"is_umbrella": false' in out
+    assert '"epic_wide_on_umbrella": false' in out
+
+
+def test_run_check_summary_epic_wide_on_umbrella_true_when_blocking_epic_wide(capsys):
+    # #12156 acceptance (3) -- la pathologie que le body denomme : un
+    # umbrella dont l'unique claim bloquant est epic-wide (pas de clause
+    # `paths:`) expose `epic_wide_on_umbrella: true`. C'est exactement le
+    # cas mesure sur #1206 par l'auteur de l'issue.
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2026:CoursIA\n",
+            "2026-08-11T12:29:34Z",
+        ),
+        number=1206,
+        title="Epic: Fork Z3.Linq propre + reintegration (umbrella pathologique)",
+    )
+    rc = clc._run_check(p, "myia-po-2023:CoursIA-2")
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert '"is_umbrella": true' in out
+    assert '"epic_wide_on_umbrella": true' in out
+    assert '"blocking_lanes": [\n    "myia-po-2026:CoursIA"' in out
+
+
+def test_run_check_summary_epic_wide_on_umbrella_false_when_scoped(capsys):
+    # #12156 acceptance (4) -- le meme umbrella, mais avec un claim scope
+    # (`paths: ...`) qui matche un fichier REEL du repo expose
+    # `epic_wide_on_umbrella: false`. Le mecanisme discerne bien la
+    # pathologie du cas nominal -- un glob mort (vide) serait au
+    # contraire releve par le fail-CLOSED #10958 et remonte en
+    # effectively-epic-wide, ce qui est un COMPORTEMENT VOUULU (un glob
+    # mort = broken claim). On utilise donc un glob qui pointe vers un
+    # fichier Lean qui existe sur `main` (CGT) pour valider la voie
+    # saine.
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2024:CoursIA-2 -- "
+            "paths: MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/*.lean\n",
+            "2026-08-20T12:00:00Z",
+        ),
+        number=12207,
+        labels=[{"name": "EPIC"}, {"name": "research-notebook"}],
+    )
+    clc._run_check(p, "myia-po-2025:CoursIA-2")
+    out = capsys.readouterr().out
+    assert '"is_umbrella": true' in out
+    assert '"epic_wide_on_umbrella": false' in out
+    # Sanity : le scope est bien enregistre, pas lift en epic-wide.
+    assert '"empty_scope": []' in out
+
+
+def test_run_check_summary_epic_wide_on_umbrella_false_on_clear_umbrella(capsys):
+    # Controle : un umbrella sans aucun claim actif expose
+    # `epic_wide_on_umbrella: false` (la pathologie presuppose un blocage).
+    p = payload(
+        number=12207,
+        labels=[{"name": "EPIC"}],
+    )
+    clc._run_check(p, "myia-po-2023:CoursIA-2")
+    out = capsys.readouterr().out
+    assert '"is_umbrella": true' in out
+    assert '"epic_wide_on_umbrella": false' in out
+    assert '"blocked": false' in out
+
+
+def test_is_umbrella_issue_handles_missing_labels_key():
+    # Le helper degrade proprement sur un payload qui n'a pas la cle
+    # `labels` (sous-ensemble du from-json historique) -- pas d'exception,
+    # retour False (= defaut pre-#12156).
+    assert clc._is_umbrella_issue({"title": "[EPIC] anything"}) is True
+    assert clc._is_umbrella_issue({"title": "anything"}) is False
+    assert clc._is_umbrella_issue({}) is False
+    # Label invalide (None / dict sans name) : pas de crash.
+    assert clc._is_umbrella_issue({"labels": [None, {}, {"name": "x"}]}) is False


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/guard #12297

## Summary

Implémente la **piste 2** de l'issue #12156 : `scripts/check_lane_claim.py` expose désormais deux nouveaux champs dans le JSON de sortie :

- **`is_umbrella: bool`** (top-level summary) — classifie l'issue comme umbrella via label `EPIC` (route autoritaire) ou préfixe de titre `[EPIC`/`Epic:` (fallback pré-label inventory), aligné sur `scripts/pick_idle_grain.py:130`.
- **`epic_wide_on_umbrella: bool`** (top-level summary) — `True` **uniquement** quand un umbrella est bloqué par au moins un claim effectively-epic-wide (pas de clause `paths:`, ou tous les globs dead per #10958, ou off-marker per #12072). C'est la pathologie que #12156 denomme : un umbrella dont le claim bloquant est **epic-wide détaché**, sans granularité permettant à une autre lane d'entrer par un sous-grain.

**Pourquoi** : la mécanique `check_lane_claim.py` savait déjà détecter cette pathologie (helper `_claim_scope_effectively_epic_wide`, ligne 679, ajouté par #10958) et le picker la classifiait comme `umbrella`, mais **l'information n'était pas agrégée dans le JSON output** — un caller ne pouvait pas compter combien d'umbrellas étaient coincés sous cette forme. Cette PR ferme ce trou.

**Mesure firsthand** (avant la PR) sur la cohorte EPIC umbrella :

| Issue | Claim bloquant | is_umbrella | epic_wide_on_umbrella |
|---|---|---|---|
| #1206 (Epic Z3.Linq) | `myia-po-2026:CoursIA` epic-wide depuis 11j | true | **true** (pathologie mesurée) |
| #12207 (Chantier 4) | aucun | true | false |
| #12206 (Chantier 3) | aucun | true | false |
| #12204/5/8 | aucun / scopé | true | false |

→ **#1206** est la **mesure directe** de la pathologie que l'auteur de #12156 a généralisée sur 4 candidats. Le flag aurait été `True` **dès le départ** si cette PR avait existé.

## Validation (post-commit 660a2366d)

- **184 tests verts** (177 préexistants + 7 nouveaux) en 6.35 s — `pytest scripts/tests/test_check_lane_claim.py`
- **7 nouveaux tests** couvrent les 6 critères d'acceptance + helper-degradation :
  - `test_run_check_summary_is_umbrella_true_on_EPIC_label` (label-route autoritaire)
  - `test_run_check_summary_is_umbrella_true_on_title_prefix` (fallback pré-label)
  - `test_run_check_summary_is_umbrella_false_on_unit_issue` (pas de faux positif)
  - `test_run_check_summary_epic_wide_on_umbrella_true_when_blocking_epic_wide` (acceptance pathologie)
  - `test_run_check_summary_epic_wide_on_umbrella_false_when_scoped` (acceptance scope sain — utilise un glob qui matche pour ne pas tomber dans le fail-CLOSED #10958)
  - `test_run_check_summary_epic_wide_on_umbrella_false_on_clear_umbrella` (umbrella CLEAR ≠ pathologie)
  - `test_is_umbrella_issue_handles_missing_labels_key` (helper degrade proprement)
- **Pre-commit hooks** : secret scanner `Passed`, autres hooks notebook inertes (fichiers Python hors pipeline notebook)
- **Validation end-to-end** sur 4 cas réels (`#1206`, `#12207`, `#12206`, `#9890`) — output conforme à la spec.

## Acceptance #12156

| # | Critère | Statut | Preuve |
|---|---|---|---|
| 1 | `is_umbrella` exposé top-level | OK | ligne 1372 du summary, présent sur tous les cas |
| 2 | `epic_wide_on_umbrella` exposé top-level | OK | ligne 1373 du summary, calculé seulement si `is_umbrella=True AND others` |
| 3 | Alignement avec picker (label `EPIC` + titre prefix) | OK | `_is_umbrella_issue` reproduit `pick_idle_grain.py:130` |
| 4 | Ne pas rompre les 177 tests existants | OK | full suite 184 PASSED |
| 5 | Helper degrade sur payload incomplet | OK | `test_is_umbrella_issue_handles_missing_labels_key` |
| 6 | Mesure firsthand de la pathologie | OK | `#1206` retourne `epic_wide_on_umbrella=true` mesuré avant commit |

## Architecture des flags

**`is_umbrella`** = `label "EPIC" present` OU `title.upper().lstrip("[").startswith("EPIC")`.

**`epic_wide_on_umbrella`** = `is_umbrella AND others AND ALL(ev.paths is None OR _claim_scope_effectively_epic_wide(ev) OR ev.scope_declared_off_marker) for ev in others.values()`.

Le `ALL(...)` reflète le constat de #12156 : sur **un** umbrella, plusieurs lanes peuvent détenir des claims distincts. Si **un seul** est scopé correctement, le sous-grain dans ce scope est LIVRABLE — la pathologie n'est vraie que si **tous** les claims bloquants sont effectively-epic-wide (donc personne ne peut entrer).

**Faux-positifs évités** :
- Sur un **unit issue** (`is_umbrella=false`) → `epic_wide_on_umbrella=false` par construction
- Sur un **umbrella CLEAR** (aucun claim) → `epic_wide_on_umbrella=false` (la pathologie presuppose un blocage)
- Sur un **umbrella avec un claim scopé valide** → `epic_wide_on_umbrella=false`

## Dette technique consciente (RAPPORTÉ, pas masqué)

1. **Pas d'organe qui consomme ces flags** : pour l'instant les flags sont posés dans le JSON, mais aucun outil ne les agrège en sweep sur le pool ouvert. La suite logique (piste 1 ou 3 de #12156 — advisory CI ou expiration) est **out of scope** de cette PR. Cette PR ferme **piste 2 uniquement** (l'organe de mesure).
2. **Label `EPIC` insensible à la casse dans la lecture picker** mais la route label est case-sensitive ici (`"EPIC" == "EPIC"`) — un label `Epic` (camelCase) ne classifierait pas comme umbrella via la route label. Le picker a la même cécité : `if name == "EPIC"` littéral. Cohérence picker/claim-check conservée.
3. **`_gh_issue_comments` charge maintenant `labels`** : sur des contextes sans `gh` (CI offline, tests purs), `_git_tracked_files()` retourne `None` et `_lint_claim_events` degrade ; idem pour `empty_scope`. Comportement fail-soft préservé.

## Sources

- Issue **#12156** — corps de la proposition (3 pistes + mesure des 4 candidats).
- Issue **#1206** — mesure directe de la pathologie (`myia-po-2026:CoursIA` epic-wide 11j).
- `scripts/pick_idle_grain.py:130` — classifieur `_is_umbrella` aligné.
- `scripts/check_lane_claim.py:_claim_scope_effectively_epic_wide` (ligne 679) — helper déjà existant pour la mécanique dead-glob.
- Lessons **#10958** (dead-glob fail-CLOSED), **#12072** (off-marker scope signal) — les deux contributeurs à `epic_wide_on_umbrella=True`.

See #12156 (piste 2 LIVRÉE — la pathologie est désormais mesurable ; pistes 1 et 3 restent à arbitrer par le coordinateur)
