### PR TITLE
feat(search,#11977): MGS-22 MGS-vs-mealpy — bench croisé apparié lib-vs-lib sur sudoku

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-22-MGS-vs-Mealpy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-22-MGS-vs-Mealpy.ipynb
@@ -1,0 +1,870 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "m22c00",
+   "metadata": {},
+   "source": [
+    "# MGS-22 : MGS contre mealpy \u2014 le bench crois\u00e9 lib-vs-lib sur le Sudoku\n",
+    "\n",
+    "[Jusqu'ici](MGS-6-Benchmarks.ipynb), les bancs de la s\u00e9rie comparaient des **compos\u00e9s entre eux** \u2014 WOA contre EO contre Islands, tous construits dans le m\u00eame moteur. Et quand [Sudoku-5](../../Sudoku/Sudoku-5-PSO-Csharp.ipynb) confrontait le solveur maison \u00e0 GeneticSharp puis \u00e0 MetaGeneticSharp (Tranches 2-3), chaque moteur tournait *dans son langage*, avec sa propre fonction de co\u00fbt et son propre budget \u2014 la comparaison \u00e9tait honn\u00eate en qualit\u00e9, approximative en m\u00e9thode.\n",
+    "\n",
+    "Ce notebook fait le banc que l'axe 4 de l'issue #11977 demande : **la m\u00eame exp\u00e9rience, deux biblioth\u00e8ques, deux langages, dans une seule ex\u00e9cution** \u2014 [MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) (C#/.NET 9, DLLs du sous-module) contre [mealpy](https://github.com/thieu1995/mealpy) 3.0.2 (Python/NumPy, la r\u00e9f\u00e9rence du catalogue open-source des m\u00e9taheuristiques) \u2014 reli\u00e9s par le pont PythonNet dans le kernel .NET. L'hypoth\u00e8se de d\u00e9part est celle du user, cit\u00e9e telle quelle : *\u00ab possible que les perfs ne suivent pas mealpy sous NumPy optimis\u00e9, mais la comparaison sera int\u00e9ressante \u00bb*. Un r\u00e9sultat \u00ab MGS plus lent \u00bb est donc un livrable valide \u2014 \u00e0 condition qu'il soit **mesur\u00e9 avec la m\u00e9thode** : m\u00eames grilles, m\u00eames budgets d'\u00e9valuations, graines nomm\u00e9es."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c01",
+   "metadata": {},
+   "source": [
+    "## 1. Le protocole appari\u00e9, pr\u00e9-enregistr\u00e9\n",
+    "\n",
+    "Avant d'ex\u00e9cuter quoi que ce soit, le protocole \u2014 parce qu'un bench dont les r\u00e8gles sont \u00e9crites apr\u00e8s les r\u00e9sultats n'est pas un bench.\n",
+    "\n",
+    "| \u00c9l\u00e9ment | Valeur (fix\u00e9e d'avance) |\n",
+    "|---|---|\n",
+    "| **Grille** | `Easy[0]` de Sudoku_Easy51 \u2014 la m\u00eame que MGS-21 et les Tranches 1-4 de Sudoku-5 : 36 cellules vides, 45 indices |\n",
+    "| **Repr\u00e9sentation** | R1 : vecteur continu $[1,10)^{36}$, d\u00e9codage par arrondi + clamp \u2014 le substrat continu, identique des deux c\u00f4t\u00e9s |\n",
+    "| **Fonction de co\u00fbt** | conflits totaux (lignes + colonnes + blocs) \u2014 **la m\u00eame impl\u00e9ment\u00e9e deux fois** (C# et Python), \u00e9galit\u00e9 v\u00e9rifi\u00e9e par sanity check |\n",
+    "| **Moteurs** | PSO canonique \u00e0 v\u00e9locit\u00e9 : compos\u00e9 `ParticleSwarmOptimization` de MetaGeneticSharp contre `OriginalPSO` de mealpy |\n",
+    "| **Budget** | ~8 000 \u00e9valuations par course : population 50 \u00d7 160 g\u00e9n\u00e9rations/epochs, **\u00e9vals r\u00e9ellement consomm\u00e9es instrument\u00e9es** des deux c\u00f4t\u00e9s |\n",
+    "| **Graines** | {0, 1, 7, 42} \u2014 nomm\u00e9es, une par course, 4 courses par moteur |\n",
+    "| **Mesures** | (a) qualit\u00e9 : conflits finaux, m\u00e9diane + min-max sur 4 graines \u00b7 (b) vitesse : ms par course, **m\u00e9diane de 3 r\u00e9p\u00e9titions par graine** (amendement post-run-pilote, motiv\u00e9 en \u00a72) \u00b7 (c) co\u00fbt par \u00e9valuation : ms/\u00e9val sur 500 \u00e9valuations de fitness isol\u00e9es, m\u00e9diane de 5 r\u00e9p\u00e9titions |\n",
+    "\n",
+    "**Crit\u00e8res de lecture, pr\u00e9-enregistr\u00e9s.** (1) *Qualit\u00e9* : un moteur domine si sa m\u00e9diane de conflits est strictement inf\u00e9rieure ET que ses maxima restent sous les minima de l'autre ; sinon \u00ab comparable \u00bb. (2) *Vitesse* : rapport des ms/\u00e9val moyens. (3) Le verdict global reprend l'hypoth\u00e8se user \u2014 chaque axe est rapport\u00e9 s\u00e9par\u00e9ment, **aucune compensation entre axes** (un moteur plus lent ET de m\u00eame qualit\u00e9 se d\u00e9clare comme tel).\n",
+    "\n",
+    "Pourquoi ce design est le seul honn\u00eate : comparer \u00ab MGS 37 s contre mealpy 3 s \u00bb pris sur deux notebooks, deux fonctions de co\u00fbt voisines et deux budgets diff\u00e9rents ne prouve rien \u2014 c'est la comparaison que la Tranche 3 de Sudoku-5 *subissait* (37 033 ms pour 200 000 \u00e9valuations, budget et impl\u00e9mentation non appari\u00e9s). Ici chaque facteur autre que la biblioth\u00e8que (grille, co\u00fbt, budget, graine) est **clou\u00e9**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m22c02",
+   "execution_count": 1,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": ""
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Grille de r\u00e9f\u00e9rence : 36 cellules vides, 45 indices fixes, 36 g\u00e8nes R1.\r\n"
+    }
+   ],
+   "source": [
+    "// === MGS-22 : socle commun \u2014 DLLs MGS, grille de r\u00e9f\u00e9rence, fonction de co\u00fbt ===\n",
+    "// M\u00eame socle que MGS-21 : la repr\u00e9sentation R1 (continu + arrondi) est le substrat du bench.\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "using MetaGeneticSharp;\n",
+    "using GeneticSharp;\n",
+    "using System.Diagnostics;\n",
+    "\n",
+    "// Grille facile Easy[0] de Sudoku_Easy51.txt \u2014 la M\u00caME que MGS-21 et Sudoku-5 Tranches 1-4.\n",
+    "public static string PuzzleLine22 = \"902005403100063025508407060026309001057010290090670530240530600705200304080041950\";\n",
+    "\n",
+    "public static int[,] ParsePuzzle22()\n",
+    "{\n",
+    "    var g = new int[9, 9];\n",
+    "    for (int i = 0; i < 81; i++) g[i / 9, i % 9] = PuzzleLine22[i] - '0';\n",
+    "    return g;\n",
+    "}\n",
+    "\n",
+    "// Fonction de co\u00fbt du bench : conflits totaux (lignes + colonnes + blocs) sur grille PLEINE.\n",
+    "// Renvoie 0 ssi r\u00e9solu. Le c\u00f4t\u00e9 Python r\u00e9impl\u00e9mente exactement ce comptage.\n",
+    "public static int CountConflicts22(int[,] g)\n",
+    "{\n",
+    "    int conflicts = 0;\n",
+    "    for (int i = 0; i < 9; i++)\n",
+    "    {\n",
+    "        var row = new HashSet<int>(); var col = new HashSet<int>(); var blk = new HashSet<int>();\n",
+    "        for (int j = 0; j < 9; j++)\n",
+    "        {\n",
+    "            if (!row.Add(g[i, j])) conflicts++;\n",
+    "            if (!col.Add(g[j, i])) conflicts++;\n",
+    "            int br = 3 * (i / 3) + j / 3, bc = 3 * (i % 3) + j % 3;\n",
+    "            if (!blk.Add(g[br, bc])) conflicts++;\n",
+    "        }\n",
+    "    }\n",
+    "    return conflicts;\n",
+    "}\n",
+    "\n",
+    "public static int CountEmpty22(int[,] p) { int n = 0; foreach (var v in p) if (v == 0) n++; return n; }\n",
+    "\n",
+    "public static List<(int r, int c)> EmptyCells22(int[,] p)\n",
+    "{\n",
+    "    var l = new List<(int, int)>();\n",
+    "    for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++) if (p[r, c] == 0) l.Add((r, c));\n",
+    "    return l;\n",
+    "}\n",
+    "\n",
+    "// D\u00e9codage R1 : arrondi + clamp vers 1..9 sur les cellules vides, ordre de lecture.\n",
+    "public static int[,] DecodeR1_22(double[] genes)\n",
+    "{\n",
+    "    var Puzzle = ParsePuzzle22();\n",
+    "    var empties = EmptyCells22(Puzzle);\n",
+    "    var g = (int[,])Puzzle.Clone();\n",
+    "    for (int k = 0; k < empties.Count; k++)\n",
+    "        g[empties[k].r, empties[k].c] = Math.Max(1, Math.Min(9, (int)Math.Round(genes[k])));\n",
+    "    return g;\n",
+    "}\n",
+    "\n",
+    "var Puzzle22 = ParsePuzzle22();\n",
+    "Console.WriteLine($\"Grille de r\u00e9f\u00e9rence : {CountEmpty22(Puzzle22)} cellules vides, \" +\n",
+    "                  $\"{81 - CountEmpty22(Puzzle22)} indices fixes, {EmptyCells22(Puzzle22).Count} g\u00e8nes R1.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c03",
+   "metadata": {},
+   "source": [
+    "### Interpr\u00e9tation : le socle est pos\u00e9\n",
+    "\n",
+    "Rien de neuf c\u00f4t\u00e9 C# \u2014 c'est voulu. Le chromosome R1 \u00e0 36 g\u00e8nes continus et le compte de conflits totaux sont exactement ceux de MGS-21 : le pr\u00e9sent bench **h\u00e9rite du substrat valid\u00e9** plut\u00f4t que d'en r\u00e9introduire un. La seule pi\u00e8ce nouvelle est `DecodeR1_22` d\u00e9coupl\u00e9 du chromosome : le d\u00e9codage vit comme une fonction pure sur un vecteur, parce que le c\u00f4t\u00e9 Python devra appliquer **exactement la m\u00eame transformation** aux solutions mealpy.\n",
+    "\n",
+    "Un d\u00e9tail d'impl\u00e9mentation \u00e0 ne pas laisser passer : `(int)Math.Round` en C# applique l'arrondi bancaire (les demi-entiers vont au pair), et `int(round(...))` en Python aussi \u2014 mais ce n'est pas une raison pour *croire* les deux paysages identiques : sur des g\u00e8nes tir\u00e9s uniform\u00e9ment dans $[1,10)$, la probabilit\u00e9 de tomber exactement sur un demi-entier est nulle en th\u00e9orie et n\u00e9gligeable en pratique. L'argument, pourtant, ne sera **pas invoqu\u00e9** : la sanity check de la section suivante tranche sur des donn\u00e9es r\u00e9elles \u2014 trois vecteurs t\u00e9moins co\u00fbt\u00e9s ind\u00e9pendamment des deux c\u00f4t\u00e9s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m22c04",
+   "execution_count": 2,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "MGS PSO (graine 7, t\u00e9moin) : 46 conflits, 8000 \u00e9valuations, 1134 ms.\r\n"
+    }
+   ],
+   "source": [
+    "// === Moteur MGS : chromosome R1, fitness instrument\u00e9e, PSO canonique compos\u00e9 ===\n",
+    "// Le PSO canonique \u00e0 v\u00e9locit\u00e9 (axe 1 de #11977) : r\u00e9currence w/c1/c2 de Shi & Eberhart.\n",
+    "public class SudokuR1Chromosome22 : ChromosomeBase\n",
+    "{\n",
+    "    private const double LO = 1.0, HI = 10.0;\n",
+    "    public SudokuR1Chromosome22() : base(EmptyCells22(ParsePuzzle22()).Count) { CreateGenes(); }\n",
+    "    public override Gene GenerateGene(int index)\n",
+    "        => new Gene(RandomizationProvider.Current.GetDouble(LO, HI));\n",
+    "    public override IChromosome CreateNew() => new SudokuR1Chromosome22();\n",
+    "    public double[] ToGenes() { var v = new double[Length]; for (int i = 0; i < Length; i++) v[i] = (double)GetGene(i).Value; return v; }\n",
+    "    public int[,] ToGrid() => DecodeR1_22(ToGenes());\n",
+    "}\n",
+    "\n",
+    "// Fitness instrument\u00e9e : chaque \u00e9valuation est compt\u00e9e \u2014 le budget se mesure, il ne se suppose pas.\n",
+    "public class SudokuR1Fitness22 : IFitness\n",
+    "{\n",
+    "    public static int Evals;\n",
+    "    public double Evaluate(IChromosome chromosome)\n",
+    "    {\n",
+    "        Evals++;\n",
+    "        return -CountConflicts22(((SudokuR1Chromosome22)chromosome).ToGrid());\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "public static class Mgs22Host\n",
+    "{\n",
+    "    public static (int conflicts, int evals, double ms, double[] genes) RunPso(int seed, int popSize, int maxGens)\n",
+    "    {\n",
+    "        // Seeding AVANT cr\u00e9ation de population : le RNG est consomm\u00e9 par CreateNew()\n",
+    "        // de chaque individu initial (le\u00e7on #12071 / MGS-21).\n",
+    "        FastRandomRandomization.ResetSeed(seed);\n",
+    "        var compound = MetaHeuristicsService.CreateMetaHeuristicByName(\n",
+    "            \"ParticleSwarmOptimization\", maxGens, popSize);\n",
+    "        var adam = new SudokuR1Chromosome22();\n",
+    "        var pop = new MetaPopulation(popSize, popSize, adam);\n",
+    "        var ga = new MetaGeneticAlgorithm(\n",
+    "            pop, new SudokuR1Fitness22(),\n",
+    "            new EliteSelection(), new UniformCrossover(0.5f), new UniformMutation(true),\n",
+    "            compound);\n",
+    "        ga.Termination = new GenerationNumberTermination(maxGens);\n",
+    "        SudokuR1Fitness22.Evals = 0;\n",
+    "        var sw = Stopwatch.StartNew();\n",
+    "        ga.Start();\n",
+    "        sw.Stop();\n",
+    "        var best = (SudokuR1Chromosome22)ga.BestChromosome;\n",
+    "        return (CountConflicts22(best.ToGrid()), SudokuR1Fitness22.Evals,\n",
+    "                sw.Elapsed.TotalMilliseconds, best.ToGenes());\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// \u00c9chauffement JIT (course jet\u00e9e), puis course t\u00e9moin graine 7.\n",
+    "var warmupMgs = Mgs22Host.RunPso(123, 50, 10);\n",
+    "var demoMgs = Mgs22Host.RunPso(7, 50, 160);\n",
+    "Console.WriteLine($\"MGS PSO (graine 7, t\u00e9moin) : {demoMgs.Item1} conflits, \" +\n",
+    "                  $\"{demoMgs.Item2} \u00e9valuations, {demoMgs.Item3:F0} ms.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c05",
+   "metadata": {},
+   "source": [
+    "### Interpr\u00e9tation : ce que le moteur MGS expose\n",
+    "\n",
+    "Trois choix de wiring portent la validit\u00e9 du bench :\n",
+    "\n",
+    "1. **Le compteur d'\u00e9valuations vit dans la fitness, pas dans un estimateur.** `SudokuR1Fitness22.Evals` s'incr\u00e9mente \u00e0 chaque `Evaluate` \u2014 le \u00ab budget ~8 000 \u00bb du protocole se **v\u00e9rifie** course par course au lieu d'\u00eatre suppos\u00e9 depuis `population \u00d7 g\u00e9n\u00e9rations`. C'est la m\u00eame instrumentation que MGS-21, et elle rend la comparaison des budgets lisible dans le tableau final plut\u00f4t qu'argu\u00e9e dans la prose.\n",
+    "2. **Le seeding pr\u00e9c\u00e8de la cr\u00e9ation de population.** `FastRandomRandomization.ResetSeed(seed)` avant `new SudokuR1Chromosome22()` \u2014 le RNG est consomm\u00e9 par `CreateNew()` de chaque individu initial ; re-seeder apr\u00e8s ne fixe rien (le\u00e7on #12071). Les graines {0, 1, 7, 42} produisent des courses **reproductibles** : r\u00e9-ex\u00e9cuter ce notebook redonne les m\u00eames conflits.\n",
+    "3. **L'\u00e9chauffement est jet\u00e9, pas compt\u00e9.** La premi\u00e8re course (graine 123, 10 g\u00e9n\u00e9rations) paie la compilation JIT et l'amor\u00e7age des DLLs ; la course t\u00e9moin et le bench mesurent du code chaud. Le c\u00f4t\u00e9 mealpy aura son \u00e9chauffement sym\u00e9trique \u2014 sinon la comparaison des temps mesurerait l'amor\u00e7age d'un c\u00f4t\u00e9 et le r\u00e9gime permanent de l'autre.\n",
+    "\n",
+    "La course t\u00e9moin (graine 7) donne le premier point de donn\u00e9es. Regardez ses conflits : de l'ordre de la colonne R1/PSO de MGS-21 (m\u00e9diane 45,0 \u00e0 budget \u00e9gal), pas de la r\u00e9solution. C'est attendu \u2014 le PSO continu plafonne sur le Sudoku discret, et il plafonnera **des deux c\u00f4t\u00e9s** de la comparaison \u00e0 venir : c'est pr\u00e9cis\u00e9ment pourquoi le protocole compare \u00e0 budget \u00e9gal plut\u00f4t qu'\u00e0 r\u00e9solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m22c06",
+   "execution_count": 3,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>pythonnet</span></li></ul></div><div></div></div>"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Pont PythonNet actif : mealpy 3.0.2 sur Python 3.13.7\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  vecteur t\u00e9moin 1 : co\u00fbt C# = 67, co\u00fbt Python = 67 -> IDENTIQUE\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  vecteur t\u00e9moin 2 : co\u00fbt C# = 71, co\u00fbt Python = 71 -> IDENTIQUE\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  vecteur t\u00e9moin 3 : co\u00fbt C# = 60, co\u00fbt Python = 60 -> IDENTIQUE\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Sanity check PASSE : la fonction de co\u00fbt est identique des deux c\u00f4t\u00e9s -- le bench est valide.\r\n"
+    }
+   ],
+   "source": [
+    "// === Le pont PythonNet : mealpy dans le m\u00eame kernel, la m\u00eame ex\u00e9cution ===\n",
+    "// Recette valid\u00e9e (probe SC-4) : pythonnet 3.1.0 + DLL autonome du Python python.org.\n",
+    "// Le Python 3.13 du syst\u00e8me porte mealpy 3.0.2 (version affich\u00e9e ci-dessous = preuve).\n",
+    "#r \"nuget: pythonnet,3.1.0\"\n",
+    "using Python.Runtime;\n",
+    "Runtime.PythonDLL = @\"C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\python313.dll\";\n",
+    "PythonEngine.Initialize();\n",
+    "\n",
+    "// Le probl\u00e8me Python : decode + co\u00fbt r\u00e9impl\u00e9ment\u00e9s \u00e0 l'identique, compteur d'\u00e9vals,\n",
+    "// solveur mealpy avec seed EXPLICITE en solve() (API 3.x \u2014 le seed du constructeur est\n",
+    "// ignor\u00e9, v\u00e9rifi\u00e9 en amont) et journal muet (log_to='nothing').\n",
+    "public static PyModule S22;\n",
+    "using (Py.GIL())\n",
+    "{\n",
+    "    S22 = Py.CreateScope();\n",
+    "    S22.Set(\"puzzle_line22\", PuzzleLine22);\n",
+    "    S22.Exec(@\"import sys\n",
+    "import mealpy\n",
+    "from mealpy.swarm_based.PSO import OriginalPSO\n",
+    "from mealpy import Problem, FloatVar\n",
+    "import json as _json\n",
+    "\n",
+    "puzzle = [int(ch) for ch in puzzle_line22]\n",
+    "empties = [(i // 9, i % 9) for i in range(81) if puzzle[i] == 0]\n",
+    "\n",
+    "def decode(vec):\n",
+    "    g = [puzzle[r * 9:(r + 1) * 9] for r in range(9)]\n",
+    "    for k in range(len(empties)):\n",
+    "        r, c = empties[k]\n",
+    "        v = int(round(float(vec[k])))\n",
+    "        g[r][c] = max(1, min(9, v))\n",
+    "    return g\n",
+    "\n",
+    "def cost(g):\n",
+    "    conflicts = 0\n",
+    "    for i in range(9):\n",
+    "        units = ([g[i][j] for j in range(9)],\n",
+    "                 [g[j][i] for j in range(9)],\n",
+    "                 [g[3 * (i // 3) + j // 3][3 * (i % 3) + j % 3] for j in range(9)])\n",
+    "        for unit in units:\n",
+    "            seen = set()\n",
+    "            for v in unit:\n",
+    "                if v in seen:\n",
+    "                    conflicts += 1\n",
+    "                seen.add(v)\n",
+    "    return conflicts\n",
+    "\n",
+    "def cost_of_vector(vec):\n",
+    "    return cost(decode(vec))\n",
+    "\n",
+    "PY_EVALS = [0]\n",
+    "\n",
+    "class SudokuProblem(Problem):\n",
+    "    def __init__(self, bounds=None, minmax='min', **kwargs):\n",
+    "        super().__init__(bounds, minmax, log_to='nothing', **kwargs)\n",
+    "    def obj_func(self, x):\n",
+    "        PY_EVALS[0] += 1\n",
+    "        return float(cost(decode(x)))\n",
+    "\n",
+    "def run_mealpy_pso(seed, pop_size, epoch):\n",
+    "    import time\n",
+    "    PY_EVALS[0] = 0\n",
+    "    prob = SudokuProblem(bounds=FloatVar(lb=(1.0,) * len(empties), ub=(10.0,) * len(empties), name='genes'), minmax='min')\n",
+    "    model = OriginalPSO(epoch=epoch, pop_size=pop_size)\n",
+    "    t0 = time.perf_counter()\n",
+    "    g_best = model.solve(prob, seed=seed)\n",
+    "    dt = (time.perf_counter() - t0) * 1000.0\n",
+    "    sol = _json.dumps([float(v) for v in g_best.solution])\n",
+    "    return cost(decode(g_best.solution)), PY_EVALS[0], dt, sol\n",
+    "\n",
+    "def bench_mealpy(seeds_json, pop_size, epoch, reps=3):\n",
+    "    out = []\n",
+    "    for sd in _json.loads(seeds_json):\n",
+    "        runs = [run_mealpy_pso(sd, pop_size, epoch) for _ in range(reps)]\n",
+    "        cs = [r[0] for r in runs]\n",
+    "        es = [r[1] for r in runs]\n",
+    "        ts = sorted(r[2] for r in runs)\n",
+    "        med = ts[len(ts) // 2] if len(ts) % 2 == 1 else (ts[len(ts) // 2 - 1] + ts[len(ts) // 2]) / 2.0\n",
+    "        out.append({'seed': sd, 'conflicts': cs[0], 'all_same': len(set(cs)) == 1,\n",
+    "                    'evals': es[0], 'ms': med, 'sol': runs[0][3]})\n",
+    "    return _json.dumps(out)\n",
+    "\n",
+    "def time_python_evals(vecs_json, reps=5):\n",
+    "    import time\n",
+    "    vecs = _json.loads(vecs_json)\n",
+    "    ts = []\n",
+    "    for _ in range(reps):\n",
+    "        t0 = time.perf_counter()\n",
+    "        for v in vecs:\n",
+    "            cost_of_vector(v)\n",
+    "        ts.append((time.perf_counter() - t0) * 1000.0)\n",
+    "    ts.sort()\n",
+    "    return ts[len(ts) // 2]\n",
+    "\n",
+    "__mealpy_ver__ = 'mealpy ' + mealpy.__version__ + ' sur Python ' + sys.version.split()[0]\");\n",
+    "    Console.WriteLine($\"Pont PythonNet actif : {S22.Get<string>(\"__mealpy_ver__\")}\");\n",
+    "}\n",
+    "\n",
+    "// --- Sanity check : la fonction de co\u00fbt est-elle la M\u00caME des deux c\u00f4t\u00e9s ? ---\n",
+    "// 3 vecteurs t\u00e9moins D\u00c9TERMINISTES (LCG \u00e9crit \u00e0 la main), d\u00e9cod\u00e9s et cost\u00e9s des deux c\u00f4t\u00e9s.\n",
+    "public static double[] LcgVector22(int seed, int n)\n",
+    "{\n",
+    "    uint state = (uint)seed;\n",
+    "    var v = new double[n];\n",
+    "    for (int i = 0; i < n; i++)\n",
+    "    {\n",
+    "        state = state * 1664525u + 1013904223u;\n",
+    "        v[i] = 1.0 + (state / 4294967296.0) * 9.0; // uniforme dans [1, 10)\n",
+    "    }\n",
+    "    return v;\n",
+    "}\n",
+    "\n",
+    "var witnessVectors = new[] { LcgVector22(1, 36), LcgVector22(2, 36), LcgVector22(3, 36) };\n",
+    "using (Py.GIL())\n",
+    "{\n",
+    "    S22.Set(\"__witness_json__\",\n",
+    "        System.Text.Json.JsonSerializer.Serialize(witnessVectors.Select(v => v.ToList()).ToList()));\n",
+    "    S22.Exec(@\"__py_costs_json__ = _json.dumps([cost_of_vector(v) for v in _json.loads(__witness_json__)])\");\n",
+    "    var pyCosts = System.Text.Json.JsonSerializer.Deserialize<List<int>>(S22.Get<string>(\"__py_costs_json__\"));\n",
+    "    bool allEqual = true;\n",
+    "    for (int i = 0; i < witnessVectors.Length; i++)\n",
+    "    {\n",
+    "        int csCost = CountConflicts22(DecodeR1_22(witnessVectors[i]));\n",
+    "        bool eq = csCost == pyCosts[i];\n",
+    "        allEqual &= eq;\n",
+    "        Console.WriteLine($\"  vecteur t\u00e9moin {i + 1} : co\u00fbt C# = {csCost}, co\u00fbt Python = {pyCosts[i]} -> {(eq ? \"IDENTIQUE\" : \"DIFFERENT\")}\");\n",
+    "    }\n",
+    "    Console.WriteLine(allEqual\n",
+    "        ? \"Sanity check PASSE : la fonction de co\u00fbt est identique des deux c\u00f4t\u00e9s -- le bench est valide.\"\n",
+    "        : \"Sanity check ECHOUE : les fonctions de co\u00fbt diff\u00e8rent -- le bench serait invalide.\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c07",
+   "metadata": {},
+   "source": [
+    "### Interpr\u00e9tation : pourquoi la sanity check porte tout le bench\n",
+    "\n",
+    "Le point fragile d'une comparaison cross-langage n'est pas le solveur \u2014 c'est la **fonction de co\u00fbt**. Si le C# comptait les doublons avec une convention diff\u00e9rente du Python, les deux moteurs n'optimiseraient pas le m\u00eame paysage, et chaque milliseconde compar\u00e9e serait du bruit raffin\u00e9. D'o\u00f9 le protocole en deux temps :\n",
+    "\n",
+    "- **des vecteurs t\u00e9moins d\u00e9terministes** \u2014 g\u00e9n\u00e9r\u00e9s par un LCG \u00e9crit \u00e0 la main ($state \\leftarrow state \\times 1664525 + 1013904223$, la paire classique de Numerical Recipes), parce que `System.Random` et le RNG de NumPy ne produisent pas les m\u00eames suites : le LCG garantit que les deux c\u00f4t\u00e9s co\u00fbtent **exactement les m\u00eames points** de l'espace ;\n",
+    "- **le co\u00fbt calcul\u00e9 ind\u00e9pendamment de chaque c\u00f4t\u00e9**, puis confront\u00e9 \u2014 trois vecteurs, trois paires.\n",
+    "\n",
+    "Si les trois paires co\u00efncident, l'\u00e9galit\u00e9 des fonctions de co\u00fbt est \u00e9tablie *sur donn\u00e9es* \u2014 et l'argument th\u00e9orique sur les arrondis de demi-entiers devient superflu.\n",
+    "\n",
+    "Le pont lui-m\u00eame suit la recette du probe : `Runtime.PythonDLL` point\u00e9 sur la DLL autonome du Python python.org 3.13, code Python inject\u00e9 par `scope.Exec` en cha\u00eene verbatim, donn\u00e9es \u00e9chang\u00e9es en JSON (`Set` pour descendre, `Get` pour remonter) \u2014 jamais par lecture directe de variables Python complexes, qui ne traversent pas proprement la fronti\u00e8re. Le scope `S22` est gard\u00e9 en champ statique : les cellules suivantes (course t\u00e9moin mealpy, bench complet, profil de co\u00fbt) r\u00e9utilisent le m\u00eame espace de noms Python et les m\u00eames d\u00e9finitions. Notez aussi les **graines des deux moteurs pass\u00e9es explicitement** : `solve(prob, seed=N)` c\u00f4t\u00e9 mealpy (le param\u00e8tre du constructeur est silencieusement ignor\u00e9 par l'API 3.x \u2014 un pi\u00e8ge document\u00e9 dans le code), `ResetSeed(N)` c\u00f4t\u00e9 MGS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m22c08",
+   "execution_count": 4,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "mealpy OriginalPSO (graine 7, t\u00e9moin) : 26 conflits, 8050 \u00e9valuations, 751 ms.\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Contre-v\u00e9rif crois\u00e9e : co\u00fbt C# du meilleur mealpy = 26 (Python rapporte 26) -> IDENTIQUE\r\n"
+    }
+   ],
+   "source": [
+    "// === Moteur mealpy : course t\u00e9moin + contre-v\u00e9rification crois\u00e9e du vainqueur ===\n",
+    "using (Py.GIL())\n",
+    "{\n",
+    "    // \u00c9chauffement sym\u00e9trique (course jet\u00e9e), puis course t\u00e9moin graine 7.\n",
+    "    S22.Exec(@\"_wu_c, _wu_e, _wu_t, _wu_sol = run_mealpy_pso(123, 50, 10)\n",
+    "__d_c__, __d_e__, __d_t__, __d_sol__ = run_mealpy_pso(7, 50, 160)\");\n",
+    "    int dConflicts = S22.Get<int>(\"__d_c__\");\n",
+    "    int dEvals = S22.Get<int>(\"__d_e__\");\n",
+    "    double dMs = S22.Get<double>(\"__d_t__\");\n",
+    "    Console.WriteLine($\"mealpy OriginalPSO (graine 7, t\u00e9moin) : {dConflicts} conflits, \" +\n",
+    "                      $\"{dEvals} \u00e9valuations, {dMs:F0} ms.\");\n",
+    "\n",
+    "    // Contre-v\u00e9rification crois\u00e9e : le vainqueur mealpy, d\u00e9cod\u00e9 et cost\u00e9 c\u00f4t\u00e9 C#.\n",
+    "    var solJson = S22.Get<string>(\"__d_sol__\");\n",
+    "    var genes = System.Text.Json.JsonSerializer.Deserialize<double[]>(solJson);\n",
+    "    int csRecheck = CountConflicts22(DecodeR1_22(genes));\n",
+    "    Console.WriteLine($\"Contre-v\u00e9rif crois\u00e9e : co\u00fbt C# du meilleur mealpy = {csRecheck} \" +\n",
+    "                      $\"(Python rapporte {dConflicts}) -> {(csRecheck == dConflicts ? \"IDENTIQUE\" : \"DIFFERENT\")}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c09",
+   "metadata": {},
+   "source": [
+    "## 2. Le croisement \u2014 2 moteurs \u00d7 4 graines \u00e0 budget \u00e9gal\n",
+    "\n",
+    "Le plan est maintenant enti\u00e8rement c\u00e2bl\u00e9 : m\u00eame grille, m\u00eame co\u00fbt (prouv\u00e9 sur donn\u00e9es), m\u00eame repr\u00e9sentation. Reste \u00e0 ex\u00e9cuter le plan de la section 1 \u2014 population 50, 160 g\u00e9n\u00e9rations/epochs, graines {0, 1, 7, 42} \u2014 et \u00e0 rapporter **les quatre colonnes** : conflits finaux, \u00e9valuations r\u00e9ellement consomm\u00e9es, temps, et le ratio ms/\u00e9val. Les courses mealpy tournent en une seule entr\u00e9e dans le scope Python (la boucle vit c\u00f4t\u00e9 Python, les r\u00e9sultats reviennent en JSON) ; les courses MGS tournent c\u00f4t\u00e9 C#. M\u00e9dianes et min-max se calculent sur les 4 graines de chaque moteur.\n",
+    "\n",
+    "**Amendement de protocole, motiv\u00e9 par le run pilote.** La premi\u00e8re ex\u00e9cution compl\u00e8te a montr\u00e9 le d\u00e9faut du timing single-run : les temps MGS varient de \u00b130 % d'une ex\u00e9cution \u00e0 l'autre (paliers de garbage collection .NET \u2014 un run a mesur\u00e9 1 132 ms l\u00e0 o\u00f9 un autre donne 660 ms pour la m\u00eame course seed\u00e9e), soit *plus que l'\u00e9cart entre moteurs*. Un protocole vitesse qui bouge plus que la grandeur mesur\u00e9e ne mesure rien. Amendement, appliqu\u00e9 sym\u00e9triquement : **3 r\u00e9p\u00e9titions par graine et par moteur, la colonne ms rapporte la m\u00e9diane** des 3 ; les conflits seed\u00e9s doivent \u00eatre identiques sur les 3 r\u00e9p\u00e9titions (et le notebook l'affiche \u2014 preuve de d\u00e9terminisme en direct, 12 courses par moteur). La fitness isol\u00e9e (section 3) suit la m\u00eame r\u00e8gle \u00e0 5 r\u00e9p\u00e9titions. La qualit\u00e9, elle, ne bouge pas : elle est seed\u00e9e, le pilote l'a montr\u00e9 chiffre par chiffre.\n",
+    "\n",
+    "Rappel des crit\u00e8res pr\u00e9-enregistr\u00e9s : *qualit\u00e9* \u2014 m\u00e9diane strictement inf\u00e9rieure ET max sous min de l'autre, sinon \u00ab comparable \u00bb ; *vitesse* \u2014 rapport des ms/\u00e9val moyens ; *aucune compensation* entre les axes. Le verdict sur l'hypoth\u00e8se user (\u00ab possible que les perfs ne suivent pas mealpy \u00bb) se lira sur l'axe vitesse ; l'axe qualit\u00e9 dira si les deux impl\u00e9mentations du PSO canonique convergent pareil \u00e0 budget \u00e9gal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m22c10",
+   "execution_count": 5,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "moteur    graine  conflits   evals       ms  ms/eval\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "MGS            0        39    8000      857    0,107\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "MGS            1        41    8000      689    0,086\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "MGS            7        46    8000      680    0,085\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "MGS           42        48    8000      692    0,087\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "mealpy         0        30    8050      735    0,091\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "mealpy         1        27    8050      728    0,090\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "mealpy         7        26    8050      725    0,090\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "mealpy        42        31    8050      710    0,088\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "MGS    : m\u00e9diane conflits 43,5 (min 39, max 48), ms/\u00e9val moyen 0,091\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "mealpy : m\u00e9diane conflits 28,5 (min 26, max 31), ms/\u00e9val moyen 0,090\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Rapport ms/\u00e9val mealpy/MGS : 0,99x\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "D\u00e9terminisme : conflits identiques sur les 3 r\u00e9p\u00e9titions pour 8/8 paires graine-moteur.\r\n"
+    }
+   ],
+   "source": [
+    "// === LE BENCH : 2 moteurs x 4 graines {0,1,7,42}, population 50, 160 g\u00e9n\u00e9rations ===\n",
+    "public class BenchRow22\n",
+    "{\n",
+    "    public int seed { get; set; }\n",
+    "    public int conflicts { get; set; }\n",
+    "    public bool all_same { get; set; }\n",
+    "    public int evals { get; set; }\n",
+    "    public double ms { get; set; }\n",
+    "    public string sol { get; set; }\n",
+    "}\n",
+    "\n",
+    "int[] Seeds22 = { 0, 1, 7, 42 };\n",
+    "\n",
+    "// --- C\u00f4t\u00e9 MGS (C#) : 3 r\u00e9p\u00e9titions par graine, ms = m\u00e9diane (amendement \u00a72) ---\n",
+    "var mgsRows = new List<(int seed, int conflicts, int evals, double ms, bool allSame)>();\n",
+    "foreach (var sd in Seeds22)\n",
+    "{\n",
+    "    var runs3 = new List<(int c, int e, double t)>();\n",
+    "    for (int rep = 0; rep < 3; rep++)\n",
+    "    {\n",
+    "        var r = Mgs22Host.RunPso(sd, 50, 160);\n",
+    "        runs3.Add((r.Item1, r.Item2, r.Item3));\n",
+    "    }\n",
+    "    var times = runs3.Select(x => x.t).OrderBy(t => t).ToList();\n",
+    "    double med = times[1];\n",
+    "    mgsRows.Add((sd, runs3[0].c, runs3[0].e, med, runs3.All(x => x.c == runs3[0].c)));\n",
+    "}\n",
+    "\n",
+    "// --- C\u00f4t\u00e9 mealpy (Python, boucle unique dans le scope) ---\n",
+    "string mealpyJson;\n",
+    "using (Py.GIL())\n",
+    "{\n",
+    "    S22.Set(\"__seeds_json__\", System.Text.Json.JsonSerializer.Serialize(Seeds22.ToList()));\n",
+    "    S22.Exec(@\"__bench_json__ = bench_mealpy(__seeds_json__, 50, 160)\");\n",
+    "    mealpyJson = S22.Get<string>(\"__bench_json__\");\n",
+    "}\n",
+    "var mealpyRows = System.Text.Json.JsonSerializer.Deserialize<List<BenchRow22>>(mealpyJson);\n",
+    "\n",
+    "// --- Table ---\n",
+    "static double Median22(List<int> xs)\n",
+    "{\n",
+    "    var s = xs.OrderBy(x => x).ToList();\n",
+    "    return (s.Count % 2 == 1) ? s[s.Count / 2] : (s[s.Count / 2 - 1] + s[s.Count / 2]) / 2.0;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine($\"{\"moteur\",-9} {\"graine\",6} {\"conflits\",9} {\"evals\",7} {\"ms\",8} {\"ms/eval\",8}\");\n",
+    "foreach (var r in mgsRows)\n",
+    "    Console.WriteLine($\"{\"MGS\",-9} {r.seed,6} {r.conflicts,9} {r.evals,7} {r.ms,8:F0} {r.ms / r.evals,8:F3}\");\n",
+    "foreach (var r in mealpyRows)\n",
+    "    Console.WriteLine($\"{\"mealpy\",-9} {r.seed,6} {r.conflicts,9} {r.evals,7} {r.ms,8:F0} {r.ms / r.evals,8:F3}\");\n",
+    "\n",
+    "var mgsC = mgsRows.Select(r => r.conflicts).ToList();\n",
+    "var mpC = mealpyRows.Select(r => r.conflicts).ToList();\n",
+    "double mgsMsEval = mgsRows.Average(r => r.ms / r.evals);\n",
+    "double mpMsEval = mealpyRows.Average(r => r.ms / r.evals);\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"MGS    : m\u00e9diane conflits {Median22(mgsC):F1} (min {mgsC.Min()}, max {mgsC.Max()}), ms/\u00e9val moyen {mgsMsEval:F3}\");\n",
+    "Console.WriteLine($\"mealpy : m\u00e9diane conflits {Median22(mpC):F1} (min {mpC.Min()}, max {mpC.Max()}), ms/\u00e9val moyen {mpMsEval:F3}\");\n",
+    "Console.WriteLine($\"Rapport ms/\u00e9val mealpy/MGS : {mpMsEval / mgsMsEval:F2}x\");\n",
+    "int detMgs = mgsRows.Count(r => r.allSame) + mealpyRows.Count(r => r.all_same);\n",
+    "Console.WriteLine($\"D\u00e9terminisme : conflits identiques sur les 3 r\u00e9p\u00e9titions pour {detMgs}/8 paires graine-moteur.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c11",
+   "metadata": {},
+   "source": [
+    "### Lecture du croisement : ex \u00e6quo en vitesse, mealpy domine en qualit\u00e9\n",
+    "\n",
+    "Les crit\u00e8res pr\u00e9-enregistr\u00e9s, appliqu\u00e9s aux m\u00e9dianes de 3 r\u00e9p\u00e9titions :\n",
+    "\n",
+    "- **Qualit\u00e9** : mealpy m\u00e9diane 28,5 contre 43,5 pour MGS \u2014 et **s\u00e9paration totale des gammes** : le pire mealpy (31 conflits, graine 42) fait mieux que le meilleur MGS (39 conflits, graine 0). Le crit\u00e8re \u00ab m\u00e9diane strictement inf\u00e9rieure ET max sous min \u00bb est satisfait dans les deux clauses : domination compl\u00e8te, sans chevauchement de distributions.\n",
+    "- **Vitesse** : rapport ms/\u00e9val de **0,99\u00d7** \u2014 ex \u00e6quo statistique. Les m\u00e9dianes par graine se tiennent dans une fourchette serr\u00e9e c\u00f4t\u00e9 mealpy (710-735 ms pour ~8 000 \u00e9valuations) ; c\u00f4t\u00e9 MGS (680-692 ms, sauf la graine 0 \u00e0 857) la sensibilit\u00e9 GC survit partiellement \u00e0 la m\u00e9diane de 3 \u2014 deux des trois r\u00e9p\u00e9titions de la graine 0 ont pris le palier, preuve que trois r\u00e9p\u00e9titions bornent le bruit sans l'\u00e9liminer. Et l'amendement de protocole a \u00e9t\u00e9 d\u00e9cisif ici : le run pilote en timing single-run concluant \u00ab 0,8\u00d7, mealpy 20 % plus vite \u00bb \u00e9tait un **artefact** \u2014 un pic de garbage collection .NET (1 132 ms mesur\u00e9s pour une course qui en prend ~700 \u00e0 chaud) avait gonfl\u00e9 la moyenne MGS. \u00c0 m\u00e9diane de r\u00e9p\u00e9titions, l'\u00e9cart s'\u00e9vanouit.\n",
+    "- **D\u00e9terminisme** : 8/8 paires graine-moteur avec conflits identiques sur les 3 r\u00e9p\u00e9titions \u2014 le seeding est prouv\u00e9 *en direct*, et corollaire important : la diff\u00e9rence de qualit\u00e9 entre moteurs (39-48 contre 26-31) **n'est pas du bruit**, chaque course seed\u00e9e reproduit exactement son r\u00e9sultat.\n",
+    "\n",
+    "L'hypoth\u00e8se de d\u00e9part \u2014 *\u00ab possible que les perfs ne suivent pas mealpy sous NumPy optimis\u00e9 \u00bb* \u2014 se lit donc en deux moiti\u00e9s : **r\u00e9fut\u00e9e sur l'axe vitesse** (MGS tient le rythme de mealpy \u00e0 budget \u00e9gal), et **v\u00e9rifi\u00e9e en sens inverse sur l'axe qualit\u00e9** (mealpy devant, nettement). La nuance honn\u00eate sur l'axe qualit\u00e9 : les deux \u00ab PSO canoniques \u00bb ne partagent pas leurs param\u00e8tres par d\u00e9faut (coefficients d'inertie et d'attraction r\u00e9gl\u00e9s diff\u00e9remment par chaque biblioth\u00e8que) \u2014 l'axe mesure *la biblioth\u00e8que telle qu'on la lance*, ce que mesure un utilisateur r\u00e9el, pas une course de formules identiques. La section suivante explique pourquoi l'ex \u00e6quo vitesse est, malgr\u00e9 tout, le r\u00e9sultat le plus instructif du notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m22c12",
+   "execution_count": 6,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Fitness seule, 500 vecteurs identiques (m\u00e9diane de 5 r\u00e9p\u00e9titions par c\u00f4t\u00e9) :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  C#     : 3,7 ms total -> 0,007 ms/\u00e9val\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Python : 21,3 ms total -> 0,043 ms/\u00e9val\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  rapport Python/C# : 5,72x\r\n"
+    }
+   ],
+   "source": [
+    "// === Co\u00fbt par \u00e9valuation : la fitness seule, hors moteur, 500 vecteurs identiques ===\n",
+    "// Les vecteurs sont g\u00e9n\u00e9r\u00e9s c\u00f4t\u00e9 C# (LCG, graines 42..541) et pass\u00e9s en JSON au Python :\n",
+    "// les DEUX c\u00f4t\u00e9s chronom\u00e8trent decode+co\u00fbt sur exactement les m\u00eames 500 points.\n",
+    "int K22 = 500;\n",
+    "var benchVecs = new List<double[]>();\n",
+    "for (int i = 0; i < K22; i++) benchVecs.Add(LcgVector22(42 + i, 36));\n",
+    "\n",
+    "var csTimes = new List<double>();\n",
+    "for (int rep = 0; rep < 5; rep++)\n",
+    "{\n",
+    "    var swRep = Stopwatch.StartNew();\n",
+    "    foreach (var v in benchVecs) CountConflicts22(DecodeR1_22(v));\n",
+    "    swRep.Stop();\n",
+    "    csTimes.Add(swRep.Elapsed.TotalMilliseconds);\n",
+    "}\n",
+    "csTimes.Sort();\n",
+    "double csMs = csTimes[2]; // m\u00e9diane de 5 (amendement \u00a72)\n",
+    "\n",
+    "double pyMs;\n",
+    "using (Py.GIL())\n",
+    "{\n",
+    "    S22.Set(\"__vecs_json__\", System.Text.Json.JsonSerializer.Serialize(benchVecs.Select(v => v.ToList()).ToList()));\n",
+    "    S22.Exec(@\"__py_ms__ = time_python_evals(__vecs_json__)\");\n",
+    "    pyMs = S22.Get<double>(\"__py_ms__\");\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine($\"Fitness seule, {K22} vecteurs identiques (m\u00e9diane de 5 r\u00e9p\u00e9titions par c\u00f4t\u00e9) :\");\n",
+    "Console.WriteLine($\"  C#     : {csMs:F1} ms total -> {csMs / K22:F3} ms/\u00e9val\");\n",
+    "Console.WriteLine($\"  Python : {pyMs:F1} ms total -> {pyMs / K22:F3} ms/\u00e9val\");\n",
+    "Console.WriteLine($\"  rapport Python/C# : {pyMs / csMs:F2}x\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c13",
+   "metadata": {},
+   "source": [
+    "### Lecture du co\u00fbt par \u00e9valuation : fitness C# 5,5\u00d7 plus rapide \u2014 et un bench ex \u00e6quo quand m\u00eame\n",
+    "\n",
+    "C'est la cellule qui explique le paradoxe apparent du croisement. Mesur\u00e9e seule, hors moteur, sur les 500 m\u00eames vecteurs (m\u00e9diane de 5 r\u00e9p\u00e9titions) :\n",
+    "\n",
+    "- **fitness C# : 0,007 ms/\u00e9val** (3,7 ms pour 500) \u2014 **fitness Python : 0,043 ms/\u00e9val** (21,3 ms) : rapport **5,72\u00d7** en faveur du C#. L'\u00e9cart attendu entre code JIT .NET et code objet Python interpr\u00e9t\u00e9 est bien l\u00e0, massif et stable (5,5-5,7\u00d7 d'une ex\u00e9cution \u00e0 l'autre).\n",
+    "\n",
+    "Pourtant le bench complet donne 0,091 ms/\u00e9val pour MGS contre 0,090 pour mealpy \u2014 l'ex \u00e6quo presque parfait. La d\u00e9composition arithm\u00e9tique est la le\u00e7on du notebook :\n",
+    "\n",
+    "| | fitness (mesur\u00e9e) | moteur (bench \u2212 fitness) | total |\n",
+    "|---|---|---|---|\n",
+    "| **MGS** | 0,007 ms/\u00e9val | **0,084 ms/\u00e9val** | 0,091 |\n",
+    "| **mealpy** | 0,043 ms/\u00e9val | **0,047 ms/\u00e9val** | 0,090 |\n",
+    "\n",
+    "Deux effets oppos\u00e9s s'annulent : la fitness C# est 5,5\u00d7 plus rapide, mais la **m\u00e9canique de g\u00e9n\u00e9ration** de MetaGeneticSharp (s\u00e9lection, croisement, mutation, structures de population) d\u00e9pense ~0,084 ms par \u00e9valuation, soit **~1,8\u00d7** celle de mealpy (~0,047 ms) \u2014 et la fitness ne p\u00e8se que 8 % du co\u00fbt total c\u00f4t\u00e9 MGS. Trois moralit\u00e9s mesur\u00e9es : *le co\u00fbt par \u00e9valuation d'un moteur n'est pas le co\u00fbt de sa fitness* ; *un avantage fitness spectaculaire (5,5\u00d7) peut \u00eatre invisible dans le temps total* ; et *un timing single-run aurait conclu n'importe quoi* \u2014 0,8\u00d7 sur un run, 1,0\u00d7 sur l'autre, pour le m\u00eame code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c14",
+   "metadata": {},
+   "source": [
+    "## Exercice 1 : la revanche du GA \u2014 `BaseGA` mealpy contre le compos\u00e9 `Default` MGS\n",
+    "\n",
+    "Le croisement ci-dessus compare deux impl\u00e9mentations du **m\u00eame** algorithme (PSO canonique). L'exercice sym\u00e9trique naturel est le **GA** : `mealpy.evolutionary_based.GA.BaseGA` contre le compos\u00e9 `\"Default\"` de MetaGeneticSharp (celui de la colonne R1/GA de MGS-21, m\u00e9diane 10,5 \u00e0 8 000 \u00e9valuations). Consignez pour chaque moteur et chaque graine de {0, 1, 7, 42} : conflits finaux, \u00e9valuations consomm\u00e9es, temps \u2014 puis r\u00e9pondez : *est-ce que l'ordre observ\u00e9 PSO-contre-PSO se retrouve GA-contre-GA, ou est-ce une propri\u00e9t\u00e9 du couple algorithme \u00d7 biblioth\u00e8que ?*\n",
+    "\n",
+    "Plan sugg\u00e9r\u00e9 : r\u00e9utiliser `run_mealpy_pso` comme gabarit pour \u00e9crire `run_mealpy_ga` (seule la classe du mod\u00e8le change), et `Mgs22Host.RunPso` pour un `RunGa` (le compos\u00e9 `\"Default\"` se cr\u00e9e par le m\u00eame `CreateMetaHeuristicByName`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m22c15",
+   "execution_count": 7,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer : bench croise GA mealpy vs GA MGS (4 graines, budget egal).\r\n"
+    }
+   ],
+   "source": [
+    "// EXERCICE 1 : bench crois\u00e9 GA mealpy (BaseGA) contre GA MGS (compos\u00e9 \"Default\")\n",
+    "// Graine par graine, budget ~8000 \u00e9vals, m\u00eames colonnes que le croisement PSO.\n",
+    "// Indice : c\u00f4t\u00e9 Python -> from mealpy.evolutionary_based.GA import BaseGA puis\n",
+    "//          un run_mealpy_ga sur le m\u00eame SudokuProblem ; c\u00f4t\u00e9 C# -> compos\u00e9 \"Default\".\n",
+    "// Etape 1 : impl\u00e9menter run_mealpy_ga dans le scope S22.\n",
+    "// Etape 2 : impl\u00e9menter Mgs22Host.RunGa (copie de RunPso, compos\u00e9 \"Default\").\n",
+    "// Etape 3 : boucler sur les 4 graines des deux c\u00f4t\u00e9s, imprimer la table, m\u00e9dianes.\n",
+    "var resultExo1 = null as List<string>;\n",
+    "Console.WriteLine(\"Exercice a completer : bench croise GA mealpy vs GA MGS (4 graines, budget egal).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c16",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 : budget \u00d74 \u2014 l'\u00e9cart de qualit\u00e9 se referme-t-il ?\n",
+    "\n",
+    "Le croisement se conclut (voir la Lecture) \u00e0 ~8 000 \u00e9valuations, budget o\u00f9 la repr\u00e9sentation R1 plafonne loin de la r\u00e9solution. Multipliez le budget par 4 (population 50 \u00d7 640 g\u00e9n\u00e9rations) **des deux c\u00f4t\u00e9s**, graines {0, 1, 7, 42}, et mesurez : les m\u00e9dianes de conflits descendent-elles de concert ? Le rapport ms/\u00e9val bouge-t-il, ou est-il une propri\u00e9t\u00e9 de la fitness, ind\u00e9pendante du budget ? Un moteur profite-t-il du budget long plus vite que l'autre \u2014 et si oui, laquelle des deux impl\u00e9mentations (param\u00e8tres par d\u00e9faut diff\u00e9rents : coefficients de Clerc contre Shi & Eberhart, gestion du voisinage) est la cause plausible ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m22c17",
+   "execution_count": 8,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer : budget x4 des deux cotes, comparaison des medianes et du rapport ms/eval.\r\n"
+    }
+   ],
+   "source": [
+    "// EXERCICE 2 : budget x4 (pop 50, 640 g\u00e9n\u00e9rations/epochs), 4 graines, deux moteurs.\n",
+    "// Indice : un seul changement de param\u00e8tre par c\u00f4t\u00e9 -- 160 -> 640.\n",
+    "// Etape 1 : relancer le plan du croisement avec gens/epoch = 640.\n",
+    "// Etape 2 : comparer m\u00e9dianes/min-max \u00e0 8000 vs 32000 \u00e9vals par moteur.\n",
+    "// Etape 3 : rapporter si le rapport ms/\u00e9val reste stable (fitness-d\u00e9termin\u00e9) ou d\u00e9rive.\n",
+    "var resultExo2 = null as List<string>;\n",
+    "Console.WriteLine(\"Exercice a completer : budget x4 des deux cotes, comparaison des medianes et du rapport ms/eval.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c18",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 : profiler la fitness \u2014 o\u00f9 va la milliseconde ?\n",
+    "\n",
+    "La cellule du co\u00fbt par \u00e9valuation mesure `decode + cost` en bloc. D\u00e9composez : chronom\u00e9trez s\u00e9par\u00e9ment (a) le **d\u00e9codage** (construction de la grille depuis le vecteur), (b) le **compte de conflits** (parcours des 27 unit\u00e9s), sur les 500 m\u00eames vecteurs, des deux c\u00f4t\u00e9s. Le rapport Python/C# est-il homog\u00e8ne entre (a) et (b), ou une des deux \u00e9tapes porte-t-elle l'\u00e9cart ? Puis la question qui ferme la boucle : *combien de la ms/\u00e9val du bench complet est de la fitness, combien du moteur ?* (diff\u00e9rence bench-complet moins fitness-isol\u00e9e, par c\u00f4t\u00e9)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "m22c19",
+   "execution_count": 9,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer : profil decode/cost par cote, repartition fitness vs moteur.\r\n"
+    }
+   ],
+   "source": [
+    "// EXERCICE 3 : profil decode vs cost, 500 vecteurs, deux c\u00f4t\u00e9s, puis s\u00e9paration\n",
+    "// fitness/moteur dans la ms/\u00e9val du bench complet.\n",
+    "// Indice : c\u00f4t\u00e9 C# deux Stopwatches (DecodeR1_22 seul, CountConflicts22 seul) ;\n",
+    "//          c\u00f4t\u00e9 Python deux time.perf_counter autour de decode(v) et cost(g).\n",
+    "// Etape 1 : mesurer (a) decode seul, (b) cost seul, chaque c\u00f4t\u00e9.\n",
+    "// Etape 2 : r\u00e9partir la ms/\u00e9val du bench entre fitness et moteur.\n",
+    "var resultExo3 = null as List<string>;\n",
+    "Console.WriteLine(\"Exercice a completer : profil decode/cost par cote, repartition fitness vs moteur.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m22c20",
+   "metadata": {},
+   "source": [
+    "## R\u00e9sum\u00e9 et perspectives\n",
+    "\n",
+    "**R\u00e9ponse \u00e0 l'hypoth\u00e8se de d\u00e9part.** Sur ce plan (PSO canonique contre OriginalPSO, grille Easy[0], co\u00fbt prouv\u00e9 identique, ~8 000 \u00e9valuations, graines {0, 1, 7, 42}, m\u00e9dianes de r\u00e9p\u00e9titions) : **ex \u00e6quo en vitesse** (0,99\u00d7 le co\u00fbt par \u00e9valuation), **mealpy domine en qualit\u00e9** (m\u00e9diane 28,5 contre 43,5 conflits, s\u00e9paration totale des gammes 26-31 contre 39-48). L'hypoth\u00e8se \u00ab les perfs ne suivront pas mealpy \u00bb est r\u00e9fut\u00e9e sur l'axe vitesse \u2014 MetaGeneticSharp tient le rythme \u2014 et l'\u00e9cart r\u00e9el entre biblioth\u00e8ques se joue sur les **d\u00e9fauts du solveur** (qualit\u00e9 \u00e0 budget \u00e9gal), pas sur la vitesse d'ex\u00e9cution.\n",
+    "\n",
+    "**Le m\u00e9canisme, mesur\u00e9.** La fitness C# est 5,72\u00d7 plus rapide (0,007 contre 0,043 ms/\u00e9val), mais la m\u00e9canique MGS co\u00fbte ~1,8\u00d7 plus par \u00e9valuation (0,084 contre 0,047 ms) \u2014 les deux effets se compensent presque exactement (0,091 contre 0,090 ms/\u00e9val au total). C'est la d\u00e9monstration la plus utile du notebook pour la suite de la s\u00e9rie : optimiser la fitness C# (d\u00e9j\u00e0 marginale \u00e0 8 % du total) ne rapprochera MGS de personne ; la cible est la m\u00e9canique de g\u00e9n\u00e9ration.\n",
+    "\n",
+    "**La m\u00e9thode, r\u00e9utilisable.** Sanity check sur vecteurs t\u00e9moins LCG avant tout bench cross-langage ; seed explicite en `solve()` c\u00f4t\u00e9 mealpy (le constructeur l'ignore silencieusement \u2014 pi\u00e8ge document\u00e9 ici pour la s\u00e9rie) ; `ResetSeed` avant cr\u00e9ation de population c\u00f4t\u00e9 MGS ; **tout timing en m\u00e9diane de r\u00e9p\u00e9titions** \u2014 l'amendement de ce notebook (un pic GC .NET peut fausser un single-run de \u00b160 %) vaut pour tous les bancs \u00e0 venir.\n",
+    "\n",
+    "**Perspectives.** (1) Les exercices testent la robustesse du verdict : GA contre GA (Exercice 1 \u2014 mealpy a aussi `BaseGA`, MGS son compos\u00e9 `Default`), budget \u00d74 (Exercice 2). (2) Le point d'entr\u00e9e pour d\u00e9passer mealpy en qualit\u00e9 n'est pas la vitesse brute mais les **compos\u00e9s sp\u00e9cialis\u00e9s** de la s\u00e9rie (seeding MGS-4/MGS-7, \u00eeles) : le compos\u00e9 PSO canonique, pris isol\u00e9ment, perd contre les d\u00e9fauts bien r\u00e9gl\u00e9s de mealpy sur ce cas. (3) Le profiling de l'Exercice 3 dira o\u00f9 va la milliseconde moteur \u2014 les 0,084 ms/\u00e9val de m\u00e9canique MGS \u00e9tant la cible \u00e9vidente."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "name": "C#"
+  },
+  "cost_notes": "Bench crois\u00e9 lib-vs-lib : MGS (C#/.NET 9, DLLs sous-module) contre mealpy 3.0.2 (Python 3.13 via pont PythonNet pythonnet 3.1.0). Co\u00fbt : ~1 s/course MGS + ~2-5 s/course mealpy (pont) ; bench total ~30 s.",
+  "reproducibility": "HIGH - graines nomm\u00e9es {0,1,7,42}, ResetSeed MGS avant cr\u00e9ation de population, seed mealpy explicite en solve(), fonctions de co\u00fbt \u00e9gales v\u00e9rifi\u00e9es par sanity check sur vecteurs t\u00e9moins LCG.",
+  "metadata_written": "2026-08-22"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/research-code #12301

See #11977 (axe 4 : benchmark croisé MGS vs mealpy — tranche, l'EPIC reste ouverte)

Nouveau notebook `MGS-22-MGS-vs-Mealpy.ipynb` (Partie 4) : le bench que l'axe 4 demande — **la même expérience, deux bibliothèques, deux langages, une seule exécution**. MetaGeneticSharp (C#/.NET 9, DLLs du sous-module) contre mealpy 3.0.2 (Python/NumPy) reliés par le pont PythonNet (pythonnet 3.1.0, recette SC-4) dans le kernel .NET.

## Design (protocole apparié, pré-enregistré dans le notebook)

- Même grille Easy[0] (36 vides, même que MGS-21 / Sudoku-5 Tranches 1-4), même représentation R1 continue.
- **Fonction de coût implémentée deux fois, égalité PROUVÉE** : sanity check sur 3 vecteurs témoins LCG (coût C# = coût Python, 3/3) + contre-vérification croisée du vainqueur mealpy décodé côté C#.
- PSO canonique vs OriginalPSO, budget ~8 000 évals **instrumenté des deux côtés** (8 000 MGS / 8 050 mealpy, écart 0,6 % documenté), graines {0,1,7,42}.
- **Amendement de protocole documenté** : le run pilote single-run donnait « 0,8× mealpy 20 % plus vite », artefact d'un pic GC .NET (1 132 ms pour une course qui en prend ~700). Amendé en médiane de 3 répétitions par graine, symétriquement — le rapport devient 0,99× (stable sur 2 exécutions complètes amendées).

## Résultats (seedés, déterminisme 8/8 prouvé in-notebook sur 3 répétitions × 8 paires graine-moteur)

| axe | MGS | mealpy | verdict |
|---|---|---|---|
| qualité (conflits, médiane [min-max]) | 43,5 [39-48] | **28,5 [26-31]** | **mealpy domine** — séparation totale des gammes |
| vitesse (ms/éval, médiane 3 reps) | 0,091 | 0,090 | **ex æquo** (0,99×) |
| fitness isolée (500 vecteurs identiques) | **0,007 ms/éval** | 0,043 ms/éval | **C# 5,72× plus rapide** |

**L'hypothèse user citée dans l'issue** (« possible que les perfs ne suivent pas mealpy sous NumPy optimisé, mais la comparaison sera intéressante ») **est réfutée sur l'axe vitesse** — MGS tient le rythme — et **vérifiée en sens inverse sur l'axe qualité** (mealpy devant à paramètres par défaut, nuance écrite : défauts ≠ même formule). Mécanisme mesuré : la fitness C# 5,72× plus rapide est engloutie par la mécanique moteur MGS ~1,8× plus coûteuse par éval (0,084 vs 0,047 ms) — décomposition arithmétique dans le notebook.

## Pièges API mealpy 3.x documentés dans le notebook (nouveaux pour la série)

- `seed` passe en `model.solve(prob, seed=N)` — le seed du **constructeur** est silencieusement ignoré (vérifié firsthand : non-reproductible → reproductible).
- `Problem` s'importe depuis `mealpy` racine (`mealpy.problem` n'existe plus en 3.x — l'import du vieux Sudoku-5-PSO-Python est périmé) ; bornes via `FloatVar(lb=..., ub=...)` ; journal muet via `log_to='nothing'`.
- `Py.CreateScope()` renvoie un `PyModule` (pas de `PyScope` en pythonnet 3.1.0).

## Validation

- **Exécution réelle** : kernel dotnet-interactive via `dotnet_executor.py`, 9/9 cellules code `execution_count` 1..9, 0 erreur, 4 exécutions complètes au total (2 pilots + amendé + final) ; banner probe strippée.
- **Déterminisme** : prouvé DANS le notebook (8/8 paires graine-moteur, conflits identiques sur 3 répétitions) — ligne committée dans les outputs.
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0` (regex sur cellules code) ; 3 exercices stubbés conformes.
- **C.2 / H.3** : outputs réels committés, pre-commitPassed.
- **Densité pédagogique** : 17 885 chars de prose / 9 cellules code = **1 987 ch/cellule** (seuil 1 200).
- **Ancrage prose↔outputs** : toutes les valeurs citées dans les Lectures vérifiées contre les outputs du run committé (re-calage post-run final sur les décimales ms).
- **Verdict SOTA** : SOTA-OK — les deux vraies bibliothèques (DLLs fork + mealpy 3.0.2 via pont), aucune réimplémentation jouet ; mealpy n'était jamais réellement utilisée dans Sudoku-5-PSO-Python (import optionnel jamais exécuté) — c'est sa première exécution réelle dans le dépôt.

## Notes review

- Les références prose à MGS-21 (résultats 45,0/10,5, plan croisé) pointent #12301 (OPEN MERGEABLE au moment du push) — références textuelles uniquement, aucun lien relatif cassé.
- La ligne README Part4 (table 22 + compte 24) est **différée** à une PR suivante : le README est en cours de modification par #12301 (même lane) — l'éditer ici créerait un conflit certain. Pas de marqueur CATALOG-STATUS dans ce README ; l'entrée catalogue sera créée par le cron <24 h.

See #12204
