### PR TITLE
feat(gametheory,#12236): notebook GT-20 Commitment-Stackelberg

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-20-Commitment-Stackelberg.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-20-Commitment-Stackelberg.ipynb
@@ -1,0 +1,762 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "gt20c00",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003042,
+     "end_time": "2026-08-22T10:05:48.473491+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.470449+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Stackelberg : la performativité sans mystère\n",
+    "\n",
+    "Une action **mauvaise, voire dominée** dans le jeu simultané peut devenir la meilleure si l'agent peut **s'y engager** avant que l'autre ne choisisse — parce que l'engagement **transforme la meilleure réponse de l'autre**. C'est le cœur de la solution de Stackelberg [von Stackelberg, 1934], et c'est aussi, déguisé en théorie des jeux, un noyau mathématique propre pour ce qu'Austin [1962] appelle le **performatif** : un énoncé (ou un acte) qui ne décrit pas le monde mais le *fait*.\n",
+    "\n",
+    "```text\n",
+    "sigma_L  ->  BR_F(sigma_L)  ->  u_L(sigma_L, BR_F(sigma_L))\n",
+    "```\n",
+    "\n",
+    "> **L'acte n'a plus seulement une valeur par son RÉSULTAT DIRECT. Il a une valeur parce qu'il MODIFIE L'ESPACE DE RÉPONSE D'AUTRUI.**\n",
+    "\n",
+    "La condition de félicité d'Austin — ce qui distingue une annonce qui *fait* d'une annonce qui ne *dit* rien — se traduit ici en termes brutaux : **l'engagement doit être crédible**. S'il ne l'est pas, rien ne change. S'il l'est, l'annonce devient **causalement constitutive** du jeu qui suit :\n",
+    "\n",
+    "```text\n",
+    "representation publique  ->  anticipation collective  ->  changement des actions  ->  nouvelle realite strategique\n",
+    "```\n",
+    "\n",
+    "Ce notebook démonte la mécanique sur un jeu d'entrée sur marché, en quatre régimes calculés exactement : le jeu simultané, la mise séquentielle sans engagement, l'engagement contraignant, et l'engagement révocable — puis il **mesure** ce que coûte la crédibilité, et montre que le seuil à payer est exactement l'écart de tentation du déviateur. Une performativité sans mystère : chaque affirmation de ce notebook est un nombre calculé dans une cellule.\n",
+    "\n",
+    "Le fil suivra la série [GameTheory](GameTheory-2-NormalForm.ipynb) (jeux sous forme normale, [équilibres de Nash](GameTheory-4-NashEquilibrium.ipynb), [induction à rebours](GameTheory-9-BackwardInduction.ipynb)) et rejoint le chantier « strate 7 » (vocabulaires et extensions) : l'engagement est l'archétype de l'acte qui change l'espace des actions disponibles plutôt que d'en choisir une."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "gt20c01",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:05:48.478733Z",
+     "iopub.status.busy": "2026-08-22T10:05:48.478514Z",
+     "iopub.status.idle": "2026-08-22T10:05:48.485252Z",
+     "shell.execute_reply": "2026-08-22T10:05:48.484325Z"
+    },
+    "papermill": {
+     "duration": 0.010319,
+     "end_time": "2026-08-22T10:05:48.485807+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.475488+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Matrice de gains (u_entrant, u_incumbent) :\n",
+      "                    Acc        Fight\n",
+      "In               (2, 1)     (-1, -2)\n",
+      "Out              (0, 0)       (0, 3)\n",
+      "\n",
+      "Meilleures reponses :\n",
+      "  BR_entrant(Acc  ) = In     (gains E : In= 2, Out= 0)\n",
+      "  BR_entrant(Fight) = Out    (gains E : In=-1, Out= 0)\n",
+      "  BR_incumbent(In  ) = Acc     (gains I : Acc= 1, Fight=-2)\n",
+      "  BR_incumbent(Out ) = Fight   (gains I : Acc= 0, Fight= 3)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Le jeu d'entree sur marche : l'entrant (E) face a l'incumbent (I) ===\n",
+    "# Convention : chaque case = (u_entrant, u_incumbent).\n",
+    "#   Entrant : 'In' (entrer) / 'Out' (rester dehors).\n",
+    "#   Incumbent : 'Acc' (accommoder, se partager le marche) / 'Fight' (guerre de prix).\n",
+    "ACTIONS_E = ['In', 'Out']\n",
+    "ACTIONS_I = ['Acc', 'Fight']\n",
+    "U = {('In',  'Acc'):   (2,  1),   # duopole accommodant\n",
+    "     ('In',  'Fight'): (-1, -2),  # guerre de prix : les deux perdent\n",
+    "     ('Out', 'Acc'):   (0,  0),   # marche vide, rien a accommoder\n",
+    "     ('Out', 'Fight'): (0,  3)}   # dissuasion reussie : monopole intact\n",
+    "\n",
+    "def u_E(ae, ai): return U[(ae, ai)][0]\n",
+    "def u_I(ae, ai): return U[(ae, ai)][1]\n",
+    "\n",
+    "def br_E(ai):  # meilleure reponse de l'entrant a l'action de l'incumbent\n",
+    "    return max(ACTIONS_E, key=lambda ae: u_E(ae, ai))\n",
+    "\n",
+    "def br_I(ae):  # meilleure reponse de l'incumbent a l'action de l'entrant\n",
+    "    return max(ACTIONS_I, key=lambda ai: u_I(ae, ai))\n",
+    "\n",
+    "print('Matrice de gains (u_entrant, u_incumbent) :')\n",
+    "print(f'{\"\":10} {\"Acc\":>12} {\"Fight\":>12}')\n",
+    "for ae in ACTIONS_E:\n",
+    "    row = ' '.join(f'{str(U[(ae, ai)]):>12}' for ai in ACTIONS_I)\n",
+    "    print(f'{ae:10} {row}')\n",
+    "print()\n",
+    "print(\"Meilleures reponses :\")\n",
+    "for ai in ACTIONS_I:\n",
+    "    print(f'  BR_entrant({ai:5}) = {br_E(ai):4}   (gains E : In={u_E(\"In\", ai):>2}, Out={u_E(\"Out\", ai):>2})')\n",
+    "for ae in ACTIONS_E:\n",
+    "    print(f'  BR_incumbent({ae:4}) = {br_I(ae):5}   (gains I : Acc={u_I(ae, \"Acc\"):>2}, Fight={u_I(ae, \"Fight\"):>2})')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt20c02",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001773,
+     "end_time": "2026-08-22T10:05:48.489349+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.487576+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : la valeur de Fight vit dans la colonne Out\n",
+    "\n",
+    "Regardez les deux meilleures réponses de l'incumbent : contre une **entrée**, il accommodne (1 > −2) ; contre l'**abstention**, il « combat » (3 > 0) — combattre un marché vide ne coûte rien et laisse le monopole intact. L'action `Fight` n'est donc pas dominée dans l'absolu, mais elle est **strictement dominée conditionnellement à l'entrée** : sur la colonne `In`, elle vaut −2 contre 1 pour `Acc`. Toute sa valeur (3) vit dans la colonne `Out` — une colonie de gains qui n'existe que si l'entrant reste dehors.\n",
+    "\n",
+    "C'est la tension de tout le notebook : `Fight` est l'action qu'il *faudrait* pouvoir choisir, précisément dans le monde où elle ne coûte rien — et l'entrant le sait. La question de Stackelberg est de savoir si l'incumbent peut **faire exister** la colonne `Out`. La question d'Austin est de savoir à quel prix l'annonce « je combattrai » devient un fait plutôt qu'un souffle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "gt20c03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:05:48.493522Z",
+     "iopub.status.busy": "2026-08-22T10:05:48.493379Z",
+     "iopub.status.idle": "2026-08-22T10:05:48.497486Z",
+     "shell.execute_reply": "2026-08-22T10:05:48.496905Z"
+    },
+    "papermill": {
+     "duration": 0.007327,
+     "end_time": "2026-08-22T10:05:48.498320+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.490993+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Equilibres de Nash (actions pures) du jeu simultane :\n",
+      "  (In, Acc)  ->  u_E =  2, u_I =  1\n",
+      "  (Out, Fight)  ->  u_E =  0, u_I =  3\n",
+      "\n",
+      "Mise sequentielle (entrant puis incumbent), induction a rebours :\n",
+      "  si E joue In   : I repond Acc   -> u_E =  2\n",
+      "  si E joue Out  : I repond Fight -> u_E =  0\n",
+      "  -> issue sequentielle : (In, Acc), u_E = 2, u_I = 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Regime 1 : le jeu simultane -- equilibres de Nash en actions pures ===\n",
+    "nes = [(ae, ai) for ae in ACTIONS_E for ai in ACTIONS_I\n",
+    "       if ae == br_E(ai) and ai == br_I(ae)]\n",
+    "print('Equilibres de Nash (actions pures) du jeu simultane :')\n",
+    "for ae, ai in nes:\n",
+    "    print(f'  ({ae}, {ai})  ->  u_E = {u_E(ae, ai):>2}, u_I = {u_I(ae, ai):>2}')\n",
+    "\n",
+    "# === Regime 2 : mise sequentielle SANS engagement (l'entrant joue le premier) ===\n",
+    "# Induction a rebours : l'incumbent repond, l'entrant anticipe la reponse.\n",
+    "print()\n",
+    "print('Mise sequentielle (entrant puis incumbent), induction a rebours :')\n",
+    "for ae in ACTIONS_E:\n",
+    "    print(f'  si E joue {ae:4} : I repond {br_I(ae):5} -> u_E = {u_E(ae, br_I(ae)):>2}')\n",
+    "seq_ae = max(ACTIONS_E, key=lambda ae: u_E(ae, br_I(ae)))\n",
+    "print(f'  -> issue sequentielle : ({seq_ae}, {br_I(seq_ae)}), u_E = {u_E(seq_ae, br_I(seq_ae))}, u_I = {u_I(seq_ae, br_I(seq_ae))}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt20c04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001712,
+     "end_time": "2026-08-22T10:05:48.501712+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.500000+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : deux équilibres simultanés, un seul survit à la séquentialisation\n",
+    "\n",
+    "Le jeu simultané porte **deux** équilibres de Nash : `(In, Acc)` où l'entrant vient et se fait accueillir (l'incumbent touche 1), et `(Out, Fight)` où l'entrant reste dehors face à la menace (l'incumbent touche 3). Le second vaut trois fois le premier pour l'incumbent — mais regardez ce que la mise séquentielle en fait : dès que l'entrant peut *tester* la menace en jouant le premier, l'induction à rebours la dissout. L'incumbent qui fait face à une entrée réelle accommode (1 > −2), l'entrant le sait, entre, et l'issue retombe sur `(In, Acc)` : **u_I = 1**.\n",
+    "\n",
+    "L'équilibre `(Out, Fight)` n'était pas faux — c'est un équilibre de Nash parfaitement valide de la forme normale — il était **incroyable** : sa valeur repose sur une action (`Fight` face à `In`) que l'incumbent ne choisirait jamais au moment de la choisir. La différence 3 − 1 = **2** n'est pas perdue : elle est *en attente*. C'est exactement le montant qu'un engagement contraignant peut débloquer — et que rien d'autre ne peut."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "gt20c05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:05:48.505744Z",
+     "iopub.status.busy": "2026-08-22T10:05:48.505608Z",
+     "iopub.status.idle": "2026-08-22T10:05:48.510354Z",
+     "shell.execute_reply": "2026-08-22T10:05:48.509468Z"
+    },
+    "papermill": {
+     "duration": 0.008099,
+     "end_time": "2026-08-22T10:05:48.511414+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.503315+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Engagement contraignant : tableau (engagement -> reponse de E -> gain de I)\n",
+      "  s engager a Acc   -> E repond In   -> u_I =  1\n",
+      "  s engager a Fight -> E repond Out  -> u_I =  3\n",
+      "  -> engagement optimal : Fight (u_I = 3), contre 1 sans engagement : delta = +2\n",
+      "\n",
+      "Engagement mixte (p = P(Fight)) : meilleure reponse de E et gain de I\n",
+      "    p   BR_E      u_I\n",
+      " 0.00         In     1.00\n",
+      " 0.05         In     0.85\n",
+      " 0.10         In     0.70\n",
+      " 0.15         In     0.55\n",
+      " 0.20         In     0.40\n",
+      " 0.25         In     0.25\n",
+      " 0.30         In     0.10\n",
+      " 0.35         In    -0.05\n",
+      " 0.40         In    -0.20\n",
+      " 0.45         In    -0.35\n",
+      " 0.50         In    -0.50\n",
+      " 0.55         In    -0.65\n",
+      " 0.60         In    -0.80\n",
+      " 0.65         In    -0.95\n",
+      " 0.70        Out     2.10\n",
+      " 0.75        Out     2.25\n",
+      " 0.80        Out     2.40\n",
+      " 0.85        Out     2.55\n",
+      " 0.90        Out     2.70\n",
+      " 0.95        Out     2.85\n",
+      " 1.00        Out     3.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Regime 3 : l'engagement CONTRAIGNANT (l'incumbent joue le premier, de facon liante) ===\n",
+    "# Pour chaque action a laquelle l'incumbent peut s'engager, l'entrant best-repond, l'incumbent encaisse.\n",
+    "print('Engagement contraignant : tableau (engagement -> reponse de E -> gain de I)')\n",
+    "commit = {}\n",
+    "for ai in ACTIONS_I:\n",
+    "    r = br_E(ai)\n",
+    "    commit[ai] = u_I(r, ai)\n",
+    "    print(f'  s engager a {ai:5} -> E repond {r:4} -> u_I = {u_I(r, ai):>2}')\n",
+    "best_ai = max(ACTIONS_I, key=lambda ai: commit[ai])\n",
+    "gain_seq = u_I(seq_ae, br_I(seq_ae))\n",
+    "print(f'  -> engagement optimal : {best_ai} (u_I = {commit[best_ai]}), contre {gain_seq} sans engagement : delta = {commit[best_ai] - gain_seq:+d}')\n",
+    "\n",
+    "# === Engagement MIXTE : l'incumbent s'engage a une probabilite p de Fight ===\n",
+    "print()\n",
+    "print('Engagement mixte (p = P(Fight)) : meilleure reponse de E et gain de I')\n",
+    "print(f'{\"p\":>5} {\"BR_E\":>6} {\"u_I\":>8}')\n",
+    "for k in range(21):\n",
+    "    p = k / 20\n",
+    "    in_pay = 2 - 3 * p        # u_E(In) si I mixe (p Fight, 1-p Acc)\n",
+    "    r = 'In' if in_pay > 0 else ('Out' if in_pay < 0 else 'indifferent')\n",
+    "    if r == 'In':\n",
+    "        val = 1 - 3 * p       # u_I si E entre\n",
+    "    else:\n",
+    "        val = 3 * p           # u_I si E reste dehors (pire cas a l indifferenciation)\n",
+    "    print(f'{p:>5.2f} {r:>10} {val:>8.2f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt20c06",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001832,
+     "end_time": "2026-08-22T10:05:48.515276+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.513444+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : l'action sous-optimale devient l'engagement unique optimal\n",
+    "\n",
+    "Le tableau de l'engagement est la cellule centrale du notebook :\n",
+    "\n",
+    "| engagement de I | réponse de E | gain de I |\n",
+    "|---|---|---|\n",
+    "| `Acc` | `In` | 1 |\n",
+    "| **`Fight`** | **`Out`** | **3** |\n",
+    "\n",
+    "S'engager à `Acc` ne change rien (l'entrant vient, gain 1). S'engager à `Fight` **transforme la meilleure réponse de l'entrant** — face à un adversaire lié à la guerre de prix, `Out` (0) domine `In` (−1) — et rapporte 3. Le delta est **+2**, exactement l'écart entre les deux équilibres du jeu simultané : l'engagement n'invente pas de valeur, il **sélectionne** l'équilibre que la menace incroyable ne pouvait pas tenir.\n",
+    "\n",
+    "Et le point décisif, celui qui donne son titre à l'issue : `Fight` était **strictement dominée conditionnellement à l'entrée** (−2 < 1 sur la colonne `In`). Elle devient l'engagement *unique* optimal — non parce que sa valeur directe aurait changé (combattre une entrée vaut toujours −2), mais parce que **commettre la transforme en device de sélection** : l'acte ne vaut pas par son résultat direct, il vaut par la modification de l'espace de réponse d'autrui. C'est le sens exact de la chaîne `sigma_L -> BR_F(sigma_L) -> u_L` ouverte en tête de notebook.\n",
+    "\n",
+    "L'engagement **mixte** referme la porte d'une évasion : aucun mixage ne bat le sommet pur. Tant que p < 2/3, l'entrant entre et le gain de l'incumbent décroît (1 − 3p) ; dès que p ≥ 2/3, l'entrant sort et le gain plafonne à 3p, maximal à p = 1. La valeur d'engagement de ce jeu est un **sommet du simplexe**, pas un intérieur — la nuance honnête étant qu'il existe d'autres jeux (les jeux d'inspection, où le contrôleur doit rester imprévisible) où c'est l'intérieur qui gagne : le phénomène « mixer bat commettre » existe, ce n'est simplement pas celui d'ici."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt20c07",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001751,
+     "end_time": "2026-08-22T10:05:48.518829+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.517078+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : le duel publicitaire — équilibres et action candidate\n",
+    "\n",
+    "Le jeu de ce notebook n'est pas le seul où vit un engagement. Soit le duel publicitaire suivant : deux firmes A (leader potentiel) et B ; A choisit `PasCampagne` / `Campagne`, B choisit `Reste` / `Attaque`. Gains `(u_A, u_B)` : `('PasCampagne','Reste'): (3, 3)`, `('PasCampagne','Attaque'): (1, 4)`, `('Campagne','Reste'): (2, 0)`, `('Campagne','Attaque'): (0, -1)`.\n",
+    "\n",
+    "Calculez les meilleures réponses, listez **tous** les équilibres de Nash en actions pures du jeu simultané, puis l'issue de la mise séquentielle où B joue le premier. Identifiez enfin l'action de A qui est sous-optimale conditionnellement à `Attaque` — la candidate au rôle que `Fight` joue ci-dessus.\n",
+    "\n",
+    "```python\n",
+    "# TODO etudiant\n",
+    "# Etape 1 : coder la matrice U_EXO1 et les fonctions br_A / br_B (modeles de la cellule 2).\n",
+    "# Etape 2 : enumerer les equilibres de Nash (modele de la cellule 3).\n",
+    "# Etape 3 : induction a rebours (B premier) et identification de l'action candidate.\n",
+    "result_exo1 = None\n",
+    "print('Exercice a completer : equilibres du duel publicitaire et action candidate.')\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "gt20c08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:05:48.523426Z",
+     "iopub.status.busy": "2026-08-22T10:05:48.523243Z",
+     "iopub.status.idle": "2026-08-22T10:05:48.526467Z",
+     "shell.execute_reply": "2026-08-22T10:05:48.525446Z"
+    },
+    "papermill": {
+     "duration": 0.006464,
+     "end_time": "2026-08-22T10:05:48.527108+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.520644+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : equilibres du duel publicitaire et action candidate.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 1 : equilibres du duel publicitaire, mise sequentielle B-premier,\n",
+    "# action sous-optimale conditionnellement (la candidate a l'engagement).\n",
+    "# Indice : repris cellule 2 pour la matrice, cellule 3 pour les equilibres.\n",
+    "# Etape 1 : U_EXO1 = {('PasCampagne','Reste'): (3,3), ...} + br_A / br_B.\n",
+    "# Etape 2 : enumeration des NE par double best-response.\n",
+    "# Etape 3 : induction a rebours (B joue, A repond) -> issue, puis comparer a chaque NE.\n",
+    "result_exo1 = None  # TODO etudiant\n",
+    "print('Exercice a completer : equilibres du duel publicitaire et action candidate.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "gt20c09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:05:48.531847Z",
+     "iopub.status.busy": "2026-08-22T10:05:48.531693Z",
+     "iopub.status.idle": "2026-08-22T10:05:48.536501Z",
+     "shell.execute_reply": "2026-08-22T10:05:48.535587Z"
+    },
+    "papermill": {
+     "duration": 0.008053,
+     "end_time": "2026-08-22T10:05:48.537124+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.529071+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Annonce revocable (aucun lien), induction a rebours sur tout l arbre :\n",
+      "  si E joue In   : I choisit en dernier Acc   -> (2, 1)\n",
+      "  si E joue Out  : I choisit en dernier Fight -> (0, 3)\n",
+      "  -> issue : (In, Acc)  ->  u_E = 2, u_I = 1\n",
+      "  -> le gain d engagement (3) retombe a 1 : dissous, quelle que soit l annonce.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Regime 4 : l'annonce REVOCABLE -- l'engagement sans le lien ===\n",
+    "# Arbre a trois etages : I annonce (sans effet lie), puis E choisit, puis I choisit LIBREMENT.\n",
+    "# Toutes les annonces menent au meme sous-arbre : seule compte la decision finale de I.\n",
+    "def sous_arbre_final(ae):\n",
+    "    # Au dernier etage, I choisit librement entre Acc et Fight.\n",
+    "    return {ai: U[(ae, ai)] for ai in ACTIONS_I}\n",
+    "\n",
+    "def induction_rebours(arbre_bas):\n",
+    "    # Etage du bas : I (indice 1) choisit dans {Acc: ..., Fight: ...}\n",
+    "    bas = {ae: max(sous.items(), key=lambda kv: kv[1][1]) for ae, sous in arbre_bas.items()}\n",
+    "    # Etage du haut : E (indice 0) choisit In / Out en anticipant bas\n",
+    "    issue = max(bas.items(), key=lambda kv: kv[1][1][0])\n",
+    "    return issue  # (action_E, (action_I, (u_E, u_I)))\n",
+    "\n",
+    "arbre = {ae: sous_arbre_final(ae) for ae in ACTIONS_E}\n",
+    "action_E, (action_I, payoffs) = induction_rebours(arbre)\n",
+    "print('Annonce revocable (aucun lien), induction a rebours sur tout l arbre :')\n",
+    "for ae in ACTIONS_E:\n",
+    "    rep_I = max(ACTIONS_I, key=lambda ai: u_I(ae, ai))\n",
+    "    print(f'  si E joue {ae:4} : I choisit en dernier {rep_I:5} -> {U[(ae, rep_I)]}')\n",
+    "print(f'  -> issue : ({action_E}, {action_I})  ->  u_E = {payoffs[0]}, u_I = {payoffs[1]}')\n",
+    "print(f'  -> le gain d engagement (3) retombe a {payoffs[1]} : dissous, quelle que soit l annonce.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt20c10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002021,
+     "end_time": "2026-08-22T10:05:48.541107+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.539086+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : la condition de félicité — l'annonce n'est pas l'engagement\n",
+    "\n",
+    "Retirez le lien (l'irrévocabilité) et tout s'effondre dans l'ordre exact prédit par la théorie : au dernier étage, l'incumbent face à une entrée **réelle** accommodne (1 > −2) — au moment de choisir, la menace n'a plus de valeur ; l'entrant, qui fait cette induction à rebours autant que nous, entre (2 > 0) ; et le gain de l'engagement **3 → 1**. Aucune annonce, si forte soit-elle, n'y change rien : l'issue est **indépendante de l'annonce**. C'est le théorème du *cheap talk* dans sa version la plus plate — quand parler ne coûte rien et n'engage à rien, parler ne fait rien.\n",
+    "\n",
+    "C'est ici que la condition de félicité d'Austin cesse d'être une métaphore littéraire. « Je combattrai » n'est pas un énoncé performatif en soi ; il ne le devient que si l'énonciation **modifie les gains ou les contraintes du locuteur** — si se dédire coûte. L'annonce révocable est un énoncé *constatif* déguisé : elle décrit une intention que tout le monde sait révisable, et l'anticipation collective la traite comme telle. La performativité n'est pas dans les mots : elle est dans **l'architecture du jeu que les mots modifient**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "gt20c11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:05:48.545867Z",
+     "iopub.status.busy": "2026-08-22T10:05:48.545690Z",
+     "iopub.status.idle": "2026-08-22T10:05:48.550475Z",
+     "shell.execute_reply": "2026-08-22T10:05:48.549544Z"
+    },
+    "papermill": {
+     "duration": 0.00802,
+     "end_time": "2026-08-22T10:05:48.551018+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.542998+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " s (caution)            issue      u_I  regime\n",
+      "         0.0    ('In', 'Acc')     1.00  annonce dissoute (non credible)\n",
+      "         0.5    ('In', 'Acc')     0.50  annonce dissoute (non credible)\n",
+      "         1.0    ('In', 'Acc')     0.00  annonce dissoute (non credible)\n",
+      "         1.5    ('In', 'Acc')    -0.50  annonce dissoute (non credible)\n",
+      "         2.0    ('In', 'Acc')    -1.00  annonce dissoute (non credible)\n",
+      "         2.5    ('In', 'Acc')    -1.50  annonce dissoute (non credible)\n",
+      "         3.0 ('Out', 'Fight')     3.00  dissuasion tenue (credible)\n",
+      "         3.5 ('Out', 'Fight')     3.00  dissuasion tenue (credible)\n",
+      "         4.0 ('Out', 'Fight')     3.00  dissuasion tenue (credible)\n",
+      "\n",
+      "Seuil de credibilite : s* = 3 (ecart de tentation 1 - (-2)).\n",
+      "Au seuil s = 3 : u_I = 3 -- la pleine valeur d engagement est restauree.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === La credibilite au prix exact : le seuil de la caution (bond) ===\n",
+    "# L'incumbent signe un contrat : accommoder APRES avoir promis de combattre coute s (penalite).\n",
+    "# Payoff modifie : u_I(In, Acc) = 1 - s. Le reste est inchange.\n",
+    "def equilibre_avec_bond(s):\n",
+    "    # Dernier etage : I face a In compare Acc (1-s) a Fight (-2) ; face a Out : Fight (3 > 0).\n",
+    "    rep_in = 'Acc' if 1 - s > -2 else 'Fight'\n",
+    "    rep_out = 'Fight'\n",
+    "    # L'entrant anticipe :\n",
+    "    if rep_in == 'Fight':\n",
+    "        ae = 'Out'  # entrer ne rapporte que -1\n",
+    "        return (ae, 'Fight'), U[('Out', 'Fight')]\n",
+    "    ae = 'In'\n",
+    "    return (ae, rep_in), (2, 1 - s)\n",
+    "\n",
+    "print(f'{\"s (caution)\":>12} {\"issue\":>16} {\"u_I\":>8}  regime')\n",
+    "for k in range(9):\n",
+    "    s = k * 0.5\n",
+    "    issue, pay = equilibre_avec_bond(s)\n",
+    "    regime = 'annonce dissoute (non credible)' if issue[1] == 'Acc' else 'dissuasion tenue (credible)'\n",
+    "    print(f'{s:>12.1f} {str(issue):>16} {pay[1]:>8.2f}  {regime}')\n",
+    "print()\n",
+    "_, pay_3 = equilibre_avec_bond(3.0)\n",
+    "ecart_tentation = u_I('In', 'Acc') - u_I('In', 'Fight')\n",
+    "print(f'Seuil de credibilite : s* = {ecart_tentation} (ecart de tentation 1 - (-2)).')\n",
+    "print(f'Au seuil s = 3 : u_I = {pay_3[1]} -- la pleine valeur d engagement est restauree.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt20c12",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001881,
+     "end_time": "2026-08-22T10:05:48.554899+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.553018+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le prix exact de la félicité — la caution doit couvrir la tentation\n",
+    "\n",
+    "La caution transforme l'architecture : accommoder après avoir promis coûte désormais `1 − s`. Le balayage le montre sans zone grise : en dessous de `s* = 3`, l'entrant entre, l'incumbent accommodne en payant la peine, et le gain reste celui du jeu de base ; à partir de `s* = 3` (égalité exacte au seuil, stricte au-dessus), combattre devient la meilleure réponse **même face à une entrée réelle**, l'entrant le sait, reste dehors, et la valeur d'engagement **3** est intégralement restaurée. La condition de félicité d'Austin est devenue un nombre.\n",
+    "\n",
+    "Et ce nombre a une forme remarquable : `s*` est exactement **l'écart de tentation** — la différence entre céder (1) et tenir (−2) au moment de la tester. La caution n'a pas besoin d'être aussi grande que le gain de l'engagement ni que le dommage de la guerre ; elle doit couvrir précisément ce que coûte le fait de dévier *au moment où dévier tenterait*. C'est la définition opérationnelle de la crédibilité : **crédible = dévier ne rapporte plus**, et le prix à payer pour y arriver se calcule sur la matrice. La « réputation », la « détermination », les métaphores volontaristes de la dissuasion se réduisent ici à cette inégalité."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt20c13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00189,
+     "end_time": "2026-08-22T10:05:48.558734+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.556844+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 : le couple (engagement, gain) sur VOTRE matrice\n",
+    "\n",
+    "Reprenez le duel publicitaire de l'Exercice 1. Construisez le tableau de l'engagement contraignant : pour **chacune** des deux actions pures de A, calculez la meilleure réponse de B et le gain de A qui en résulte. Produisez le **couple** `(stratégie d'engagement, gain)` optimal, et comparez-le au gain de A à l'issue séquentielle sans engagement — le delta d'engagement en un chiffre. Vérifiez enfin le mixte sur une grille `p ∈ [0, 1]` (pas de 0,05) : le sommet est-il pur, comme dans le jeu d'entrée, ou intérieur ?\n",
+    "\n",
+    "```python\n",
+    "# TODO etudiant\n",
+    "# Etape 1 : pour chaque action de A, BR de B puis gain de A (modele : cellule 5).\n",
+    "# Etape 2 : argmax -> le couple (engagement, gain).\n",
+    "# Etape 3 : balayage mixte p par pas de 0.05 -> sommet pur ou interieur ?\n",
+    "result_exo2 = None\n",
+    "print('Exercice a completer : couple (engagement, gain) et delta sur le duel publicitaire.')\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "gt20c14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:05:48.563460Z",
+     "iopub.status.busy": "2026-08-22T10:05:48.563295Z",
+     "iopub.status.idle": "2026-08-22T10:05:48.566610Z",
+     "shell.execute_reply": "2026-08-22T10:05:48.565641Z"
+    },
+    "papermill": {
+     "duration": 0.006892,
+     "end_time": "2026-08-22T10:05:48.567492+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.560600+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : couple (engagement, gain) et delta sur le duel publicitaire.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 2 : couple (engagement, gain) + delta + test du mixte sur U_EXO1.\n",
+    "# Indice : deux lignes de table {action: gain}, un argmax, une boucle 21 points.\n",
+    "# Etape 1 : tableau engagement (BR de B -> gain de A).\n",
+    "# Etape 2 : argmax = le couple a produire ; delta contre l issue sequentielle B-premier.\n",
+    "# Etape 3 : balayage p = P(seconde action de A) -> valeur d engagement en fonction de p.\n",
+    "result_exo2 = None  # TODO etudiant\n",
+    "print('Exercice a completer : couple (engagement, gain) et delta sur le duel publicitaire.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt20c15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002081,
+     "end_time": "2026-08-22T10:05:48.571646+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.569565+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 : l'évanouissement mesuré — annonce révocable et caution minimale\n",
+    "\n",
+    "Toujours sur le duel publicitaire : (a) codez l'arbre à trois étages « A annonce, B choisit, A choisit librement » et montrez par induction à rebours que l'issue est **indépendante de l'annonce** — le gain d'engagement s'évanouit ; (b) introduisez la caution `s` qui pénalise l'écart de promesse de A, balayez `s` et trouvez le seuil `s*` où l'engagement redevient crédible ; (c) vérifiez que `s*` égale l'écart de tentation de A sur la colonne critique. Sans (c), la félicité n'a pas été mesurée.\n",
+    "\n",
+    "```python\n",
+    "# TODO etudiant\n",
+    "# Etape 1 : arbre a 3 etages + induction a rebours (modele : cellule 9).\n",
+    "# Etape 2 : caution s sur l ecart de promesse, balayage (modele : cellule 11).\n",
+    "# Etape 3 : s* contre l ecart de tentation -- l identite qui ferme l exercice.\n",
+    "result_exo3 = None\n",
+    "print('Exercice a completer : evanouissement + caution minimale sur le duel publicitaire.')\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "gt20c16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:05:48.576670Z",
+     "iopub.status.busy": "2026-08-22T10:05:48.576521Z",
+     "iopub.status.idle": "2026-08-22T10:05:48.579705Z",
+     "shell.execute_reply": "2026-08-22T10:05:48.578825Z"
+    },
+    "papermill": {
+     "duration": 0.00637,
+     "end_time": "2026-08-22T10:05:48.580179+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.573809+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : evanouissement + caution minimale sur le duel publicitaire.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 3 : annonce revocable (issue independante de l annonce) puis caution minimale s*.\n",
+    "# Indice : l arbre de la cellule 9 se transpose ; la caution modifie UN seul payoff (l ecart de promesse).\n",
+    "# Etape 1 : induction a rebours sur l arbre a 3 etages -> issue identique pour toute annonce.\n",
+    "# Etape 2 : balayage de s -> tableau issue/u_A (modele cellule 11).\n",
+    "# Etape 3 : s* = ecart de tentation sur la colonne critique -> l egaler par le calcul.\n",
+    "result_exo3 = None  # TODO etudiant\n",
+    "print('Exercice a completer : evanouissement + caution minimale sur le duel publicitaire.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt20c17",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001966,
+     "end_time": "2026-08-22T10:05:48.584522+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:05:48.582556+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Résumé : quatre régimes, un seul nombre qui change, et ce qu'il prouve\n",
+    "\n",
+    "| régime | mécanisme | issue | u_I |\n",
+    "|---|---|---|---|\n",
+    "| simultané, équilibre crédible | Nash `(In, Acc)` | entrée accueillie | 1 |\n",
+    "| simultané, équilibre de menace | Nash `(Out, Fight)` — incroyable | dissuasion *non tenable* | (3, fantôme) |\n",
+    "| séquentiel sans engagement | induction à rebours | `(In, Acc)` — la menace dissoute | 1 |\n",
+    "| **engagement contraignant** | `sigma_L -> BR_F(sigma_L)` | **`(Out, Fight)` — sélectionné** | **3** |\n",
+    "| annonce révocable | cheap talk — arbre à 3 étages | `(In, Acc)` — indépendant de l'annonce | 1 |\n",
+    "| engagement + caution s ≥ 3 | dévier ne rapporte plus | `(Out, Fight)` tenu sans jamais combattre | 3 |\n",
+    "\n",
+    "Le noyau tient en trois phrases. **Un engagement n'invente pas de valeur : il sélectionne un équilibre existant** que la menace seule ne pouvait pas tenir — le delta +2 était déjà dans la matrice, endormi dans la colonne `Out`. **L'acte engagé vaut par la modification de l'espace de réponse d'autrui**, non par son résultat direct : `Fight` vaut −2 *exécutée* contre une entrée, et 3 *commise* contre l'entrée qui n'aura pas lieu. **La félicité se mesure** : une annonce sans lien ne fait rien (l'issue est indépendante de l'annonce), et restaurer le lien coûte exactement l'écart de tentation `s* = 3` — la caution minimale telle que dévier ne rapporte plus.\n",
+    "\n",
+    "C'est une performativité sans mystère au sens strict : la chaîne `représentation publique -> anticipation collective -> changement des actions -> nouvelle réalité stratégique` est ici un calcul réversible, chaque flèche étant une cellule de ce notebook. Ce que le cadre ne couvre **pas** — et il faut l'écrire — : les contextes où l'engagement est multi-décisionnel et répété (réputation dynamique), où la caution est endogène (capacités détruites plutôt que caution versée), et les jeux d'inspection où c'est l'engagement *mixte* qui bat le sommet pur. Chacun de ces reliefs est un notebook à part entière — pas une extrapolation sociologique de celui-ci.\n",
+    "\n",
+    "**Ouvertures de la série** : la sélection d'équilibre par contrainte rejoint les [jeux répétés et le folk theorem](GameTheory-6b-Lean-RepeatedGames.ipynb) (l'engagement comme cas limite de la punition crédible), et la modification de l'espace des actions plutôt que du choix en leur sein est exactement le geste de la strate 7 sur les vocabulaires — voir aussi GT-18, les open games (issue #12212, en cours de livraison), où la représentation locale modifie le global dont elle est issue."
+   ]
+  }
+ ],
+ "metadata": {
+  "cost_notes": "Calcul exact stdlib pur (aucune dependance, aucun aleatoire) : execution quasi instantanee.",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  },
+  "metadata_written": "2026-08-22",
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.231492,
+   "end_time": "2026-08-22T10:05:48.701968+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-20-Commitment-Stackelberg.ipynb",
+   "output_path": "GameTheory-20-Commitment-Stackelberg.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-22T10:05:47.470476+00:00",
+   "version": "2.7.0"
+  },
+  "reproducibility": "EXACT - aucun tirage aleatoire, tout est arithmetique entiere/deterministe sur matrices finies."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -261,7 +261,18 @@ flowchart TD
 | 17 | [GameTheory-17-MultiAgent-RL](GameTheory-17-MultiAgent-RL.ipynb) | Python | NFSP, PSRO, AlphaZero intro | 55 min |
 | 17 (C#) | [GameTheory-17-MultiAgent-RL-Csharp](GameTheory-17-MultiAgent-RL-Csharp.ipynb) | .NET (C#) | Twin C# du 17 : **Self-Play naif (cycle R-P-S)**, **Fictitious Play** (BR vs frequence empirique, convergence Robinson 1951), **exploitabilite**, **NFSP table-based** (Q-values + memoire, caveat convergence G.1), **PSRO** (population + meta-Nash) from-scratch, BCL .NET 9, **courbes d'exploitabilite SVG inline** (Self-Play naif oscille, FP -> 0 Robinson 1951, NFSP chute puis plafonne) via `SvgChartHelper.Overlay` zero-CDN [#6855] (See #4956) | 50 min |
 
-**Durée totale** : ~26h45 (avec side tracks b/c et sous-série SocialChoice complète)
+### Partie 4 : Strate 7 — extensions du vocabulaire stratégique (notebooks 18+)
+
+La vague « strate 7 » étend la série au-delà du fil historique : chaque notebook y isole un geste qui **modifie l'espace des jeux** (engagement, témoin, extension de vocabulaire) plutôt qu'une solution dans un jeu donné. La numérotation est non séquentielle — les numéros se remplissent au fil des livraisons parallèles.
+
+| # | Notebook | Kernel | Contenu | Durée |
+|---|----------|--------|---------|-------|
+| 20 | [GameTheory-20-Commitment-Stackelberg](GameTheory-20-Commitment-Stackelberg.ipynb) | Python | Stackelberg : la performativité sans mystère — l'engagement contraignant qui **transforme la meilleure réponse d'autrui** (action sous-optimale à l'équilibre simultané, delta +2 mesuré), l'annonce révocable dissoute par induction à rebours (cheap talk), et le seuil de crédibilité **s\* = écart de tentation** (caution minimale calculée) | 40 min |
+| 21 | [GameTheory-21-Deux-Especes-de-Fleches](GameTheory-21-Deux-Especes-de-Fleches.ipynb) | Python | Deux espèces de flèches : le théorème fini du chemin minimal de swaps (un swap R(a,b) traverse un mur ssi colonne {a,b} ET mur habité — conjecture naïve réfutée sur 288 désaccords, condition vérifiée 3456/3456, comptage 432/576 dérivé) | 60 min |
+
+> En livraison parallèle sur la même vague : 18 (open games et lentilles, #12212), 22 (manipulation Gibbard-Satterthwaite comme témoin, #12239), 23 (échange de reins, #12240) — issues ouvertes, fichiers pas encore sur `main`.
+
+**Durée totale** : ~28h25 (avec side tracks b/c, sous-série SocialChoice et Partie 4 livrée)
 
 ## Concepts clés
 


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/notebook-dotnet #12302

Closes #12236

## Summary

Nouveau notebook `GameTheory-20-Commitment-Stackelberg.ipynb` (18 cellules, 8 code, kernel python3, **stdlib pur**) : la performativité de l'engagement expliquée sans mystère sur le jeu d'entrée numéroté. Chaque affirmation de l'issue est **calculée**, pas assertée :

| Affirmation de #12236 | Mesure dans le notebook |
|---|---|
| Equilibres simultanés | enumeration par double meilleure reponse : NE (In, Acc) u_I=1 et (Out, Fight) u_I=3, le second non-credible (le tueur d'entrée ne croit pas a la menace) |
| Induction sequentielle | arbre a rebours sur 3 niveaux : seul (In, Acc) survit, u_I=1 |
| Engagement transforme la MR d'autrui | table `commit[ai] = u_I(br_E(ai), ai)` :Fight captif → u_I=3, **delta = +2** |
| Annonce revoquable = cheap talk | equilibre du jeu a 3 niveaux **independant de l'annonce** (retombe a 1) — l'issue sans verrou est dissoute par induction |
| Seuil de credibilite | sweep de caution s : u_I(In, Acc)=1-s, bascule a s*=3, plateau 3.00 — **s* = ecart de tentation** (1-(-2)), calculé puis verifié |

Structure pedagogique : matrice → Nash → sequentiel → engagement pur → engagement mixte (sweep p 0..1, bascule a p=2/3, sommet pur optimal ici) → annonce revoquable → caution. **3 exercices** stubbes C.1 (`result_exoN = None  # TODO etudiant` + print) sur le duel publicitaire — le notebook s'execute de bout en bout.

## Validation

- **Execution** : `scripts/notebook_tools/wsl_papermill.py execute` (organe canonique GameTheory Python) — **8/8 cellules code, 0 erreur**, sequence [1..8]. Outputs committes (C.2).
- **C.1** : 0 violation (`raise NotImplementedError` / `assert False` / `1/0` — regex sur cellules code).
- **Densite pedagogique** : 1728 caracteres prose / cellule code (seuil 1200).
- **Ancrage prose↔outputs** : 6/6 ancres verifiees dans les outputs frais (`(In, Acc)`, `(Out, Fight)`, `delta = +2`, `s* = 3`, `retombe a 1`, `3.00`).
- **Determinisme** : calcul exact enumeratif (aucune stochasticite) — re-executions consecutives byte-identiques sur les valeurs.
- **SOTA (§H)** : calcul exact de theorie des jeux en stdlib pur — aucun moteur externe implique, verdict **SOTA-OK trivially** (l'enumeration exhaustive EST l'outil exact ici).

## README GameTheory (audit fichier entier, regle §E)

- **Nouvelle section Partie 4 (strate 7)** : table avec GT-20 (cette PR) et **GT-21** (`GameTheory-21-Deux-Especes-de-Fleches.ipynb`, sur `main` depuis #12245 — absent du README jusqu'ici, staleness corrigee au passage), note de livraison parallele pour 18/22/23 (issues ouvertes, pas de fichier — pas de navlink casse).
- `**Duree totale**` : ~26h45 → ~28h25 (+50 min GT-20, +60 min GT-21).
- **CATALOG-STATUS byte-identique** (non touche) ; catalogue non regenere sur la branche (cron <24h cree l'entree, regle catalog-pr-hygiene).
- Residuels declares (pas dans cette PR pour rester atomique) : tables « Concepts cles » et « Ce que chaque notebook apporte » non etendues a la Partie 4 ; bloc mermaid non mis a jour. Signales sur le dashboard pour reprise.

## Scope

2 fichiers : le notebook + le README de serie. Rien d'autre.
