### PR TITLE
feat(planners,#12233): notebook Planners-13 Differentiel-Atteignabilite (strate 7)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-13-Differentiel-Atteignabilite.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-13-Differentiel-Atteignabilite.ipynb
@@ -1,0 +1,1088 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "pl13c00",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002917,
+     "end_time": "2026-08-22T10:36:47.437362+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.434445+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Planners-13 — Le différentiel d'atteignabilité : ce que l'ajout d'une primitive rend possible\n",
+    "\n",
+    "> « Les agents modifient leur vocabulaire » est une formule nébuleuse. Ce notebook la rend **testable**.\n",
+    "\n",
+    "Le lake [`planning_lean`](../planning_lean/) — consommé ici, jamais modifié — prouve sans `sorry` que toute trajectoire réelle reste une trajectoire possible dans la **dynamique relaxée sans delete** (`run π s ⊆ runR π s`, `Planning/Relaxation.lean:56`, lemme clé `step ⊆ stepR` en `Planning/Strips.lean:58`), d'où l'admissibilité $h^+ \\le h^*$ (`Planning/Admissibility.lean:41`). C'est un théorème sur **deux mondes issus du même vocabulaire** : la relaxation élargit ce que les deletes interdisaient.\n",
+    "\n",
+    "La question de ce notebook est d'une autre nature :\n",
+    "\n",
+    "> **quelle nouvelle classe de plans devient atteignable après l'ajout d'une primitive ?**\n",
+    "\n",
+    "C'est un **différentiel d'atteignabilité** : $A_t \\hookrightarrow A_{t+1}$, et l'on mesure ce que l'élargissement du vocabulaire rend possible que l'approfondissement de la recherche dans $A_t$ ne pouvait pas. Le protocole, en quatre pas :\n",
+    "\n",
+    "1. **Un problème où aucune politique disponible n'atteint le but** — vérifié, pas supposé.\n",
+    "2. **L'agent cherche davantage dans le même $A_t$** — plus de budget, meilleure heuristique — et **échoue toujours**. Sans cette mesure de contrôle, on ne sait pas si l'extension a servi.\n",
+    "3. **L'agent est autorisé à inventer une primitive** — nommée, et **payante**.\n",
+    "4. **L'extension rend le but atteignable** — le delta est mesuré en buts, en coûts, en taille d'espace.\n",
+    "\n",
+    "Ce que le protocole sépare : *chercher davantage dans un espace d'actions donné* contre *élargir cet espace*. C'est aussi le banc du **différentiel de Laborit** — l'écart entre approfondir et élargir (cf. issue [#12233](https://github.com/jsboige/CoursIA/issues/12233), strate 7, `See #12207`). Le companion formel de la relaxation est [Planners-5b](Planners-5b-Lean-Relaxation.ipynb) ; le présent notebook en est le **consommateur expérimental**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001937,
+     "end_time": "2026-08-22T10:36:47.441669+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.439732+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Le moteur STRIPS, minimal et déterministe\n",
+    "\n",
+    "Tout est en **stdlib pur** : le sujet est le protocole de mesure, pas un solveur. Un état est un `frozenset` de propositions, un opérateur STRIPS un triplet (préconditions, ajouts, suppressions). Deux dynamiques cohabitent, exactement comme dans le lake :\n",
+    "\n",
+    "- `successeurs` — la dynamique **réelle** (`step` : adds puis dels) ;\n",
+    "- `successeurs_relaxes` — la dynamique **sans delete** (`stepR` : adds seulement), la même construction que celle sur laquelle `step_subset_stepR` (`Planning/Strips.lean:58`) porte.\n",
+    "\n",
+    "L'itération est triée partout : deux exécutions donnent les mêmes nombres (la mesure est déterministe, exigence de la série)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "pl13c02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.446845Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.446659Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.455900Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.454759Z"
+    },
+    "papermill": {
+     "duration": 0.012859,
+     "end_time": "2026-08-22T10:36:47.456516+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.443657+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Moteur STRIPS charge : step (reel) + stepR (relaxe sans delete).\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import deque\n",
+    "\n",
+    "class Operateur:\n",
+    "    \"\"\"Operateur STRIPS : nom, preconditions, ajouts, suppressions (cout 1).\"\"\"\n",
+    "    def __init__(self, nom, precond, ajouts, dels):\n",
+    "        self.nom, self.precond, self.ajouts, self.dels = nom, frozenset(precond), frozenset(ajouts), frozenset(dels)\n",
+    "    def applicable(self, etat):\n",
+    "        return self.precond <= etat\n",
+    "    def __repr__(self):\n",
+    "        return self.nom\n",
+    "\n",
+    "def successeurs(etat, ops):\n",
+    "    \"\"\"Dynamique reelle (step) : tous les etats successeurs, ordre deterministe.\"\"\"\n",
+    "    out = []\n",
+    "    for op in sorted(ops, key=lambda o: o.nom):\n",
+    "        if op.applicable(etat):\n",
+    "            out.append((op, (etat | op.ajouts) - op.dels))\n",
+    "    return out\n",
+    "\n",
+    "def successeurs_relaxes(etat, ops):\n",
+    "    \"\"\"Dynamique sans delete (stepR) : l'etat ne fait que croitre.\"\"\"\n",
+    "    out = []\n",
+    "    for op in sorted(ops, key=lambda o: o.nom):\n",
+    "        if op.applicable(etat) and not op.ajouts <= etat:\n",
+    "            out.append((op, etat | op.ajouts))\n",
+    "    return out\n",
+    "\n",
+    "def bfs(initial, ops):\n",
+    "    \"\"\"Enumere EXACTEMENT l'ensemble atteignable (dynamique reelle).\n",
+    "    Retourne (dist, peres, expansions).\"\"\"\n",
+    "    dist = {initial: 0}\n",
+    "    peres = {initial: None}\n",
+    "    expansions = 0\n",
+    "    file = deque([initial])\n",
+    "    while file:\n",
+    "        s = file.popleft()\n",
+    "        expansions += 1\n",
+    "        for op, t in successeurs(s, ops):\n",
+    "            if t not in dist:\n",
+    "                dist[t] = dist[s] + 1\n",
+    "                peres[t] = (s, op)\n",
+    "                file.append(t)\n",
+    "    return dist, peres, expansions\n",
+    "\n",
+    "def reconstruire(peres, but):\n",
+    "    plan, s = [], but\n",
+    "    while peres[s] is not None:\n",
+    "        s, op = peres[s]\n",
+    "        plan.append(op.nom)\n",
+    "    return list(reversed(plan))\n",
+    "\n",
+    "def distances_relaxees(initial, ops):\n",
+    "    \"\"\"BFS dans le monde sans delete : distance relaxee de chaque proposition\n",
+    "    (premiere apparition). C'est la base de l'heuristique h_max.\"\"\"\n",
+    "    dist_atoms = {p: 0 for p in initial}\n",
+    "    vu = {initial}\n",
+    "    file = deque([(initial, 0)])\n",
+    "    while file:\n",
+    "        s, d = file.popleft()\n",
+    "        for op, t in successeurs_relaxes(s, ops):\n",
+    "            if t not in vu:\n",
+    "                vu.add(t)\n",
+    "                for p in t - s:\n",
+    "                    dist_atoms.setdefault(p, d + 1)\n",
+    "                file.append((t, d + 1))\n",
+    "    return dist_atoms\n",
+    "\n",
+    "def h_max(etat, but_conjonctif, ops):\n",
+    "    \"\"\"h_max : max des distances relaxees des atomes du but. Admissible,\n",
+    "    calculable exactement — la version calculable de la chaine h_max <= h+ <= h*\n",
+    "    garantee par le lake (Admissibility.lean:41).\"\"\"\n",
+    "    dr = distances_relaxees(etat, ops)\n",
+    "    if any(b not in dr for b in but_conjonctif):\n",
+    "        return float('inf')\n",
+    "    return max(dr[b] for b in but_conjonctif)\n",
+    "\n",
+    "print(\"Moteur STRIPS charge : step (reel) + stepR (relaxe sans delete).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c02b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002123,
+     "end_time": "2026-08-22T10:36:47.460957+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.458834+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Les deux dynamiques, face à face avec le lake\n",
+    "\n",
+    "La correspondance avec le lake est terme à terme : là où `Planning/Strips.lean` définit un `Action F` (préconditions, ajouts, suppressions) et deux transitions — `step` (la réelle : ajouts **puis** suppressions) et `stepR` (la relaxée : ajouts **seulement**) — le moteur ci-dessus définit la même paire. Le lemme `step_subset_stepR` (`Strips.lean:58`) dit pourquoi la relaxée ne peut qu'élargir : appliquer un opérateur sans faire les suppressions rend l'état obtenu **sur-ensemble** de l'état réel — un état réel est toujours un état relaxé possible, jamais l'inverse.\n",
+    "\n",
+    "Deux choix de mesure méritent d'être dits :\n",
+    "\n",
+    "- **Déterminisme** : les opérateurs sont itérés triés par nom, les états sont des `frozenset` — deux exécutions produisent les mêmes nombres. Une mesure qui dérive d'une exécution à l'autre ne peut pas étalonner un différentiel.\n",
+    "- **Pourquoi `h_max` et pas `h⁺` direct** : le coût du plan relaxé **optimal** ($h^+$) est NP-difficile à calculer exactement ; $h_{max}$ — le maximum des distances relaxées par atome — se calcule exactement par BFS et minore $h^+$. La chaîne complète mesurable est donc $h_{max} \\le h^+ \\le h^*$ : le lake garantit le maillon droit (`Admissibility.lean:41`), le notebook mesure les deux extrémités calculables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002326,
+     "end_time": "2026-08-22T10:36:47.465360+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.463034+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Le domaine : deux rives, un gouffre, un radeau qui n'existe pas encore\n",
+    "\n",
+    "Une grille $6 \\times 3$ où la **colonne 3 est un gouffre** (aucune case) : rive gauche (colonnes 0-2), rive droite (colonnes 4-5). Le robot démarre en $(0,0)$. Sur la rive gauche : une **planchette** en $(1,1)$ et une **clé** en $(2,0)$. Sur la rive droite : un **trésor** en $(4,1)$.\n",
+    "\n",
+    "Le vocabulaire disponible $A_t$ : **se déplacer** (4 directions, case cible existante) et **ramasser** (être sur la case de l'objet). Trois buts :\n",
+    "\n",
+    "| But | Proposition | Rive |\n",
+    "|---|---|---|\n",
+    "| $g_1$ | atteindre la balise en $(5,2)$ | droite |\n",
+    "| $g_2$ | détenir le trésor | droite |\n",
+    "| $g_3$ | détenir la clé | **gauche** |\n",
+    "\n",
+    "$g_3$ est le **témoin de santé** : s'il échoue, c'est le moteur qui est en cause, pas le gouffre."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "pl13c04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.471218Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.470985Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.476825Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.476068Z"
+    },
+    "papermill": {
+     "duration": 0.009699,
+     "end_time": "2026-08-22T10:36:47.477348+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.467649+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cases existantes : 15 (colonne 3 = gouffre)\n",
+      "Operateurs A_t   : 41 (38 moves + 3 pickups)\n",
+      "Buts             : ['g1: balise (5,2)', 'g2: detenir le tresor', 'g3: detenir la cle']\n"
+     ]
+    }
+   ],
+   "source": [
+    "COLS_GAUCHE = [0, 1, 2]\n",
+    "COLS_DROITE = [4, 5]\n",
+    "RANGS = [0, 1, 2]\n",
+    "CASES = sorted({(c, r) for c in COLS_GAUCHE + COLS_DROITE for r in RANGS})  # colonne 3 = gouffre\n",
+    "\n",
+    "def prop(c, r):\n",
+    "    return f\"at-x{c}-y{r}\"\n",
+    "\n",
+    "INITIAL = frozenset({prop(0, 0), \"plank-at-x1-y1\", \"key-at-x2-y0\", \"treasure-at-x4-y1\"})\n",
+    "\n",
+    "def ops_de_base():\n",
+    "    ops = []\n",
+    "    for (c, r) in CASES:\n",
+    "        for (dc, dr, nom_dir) in [(1, 0, \"est\"), (-1, 0, \"ouest\"), (0, 1, \"nord\"), (0, -1, \"sud\")]:\n",
+    "            cible = (c + dc, r + dr)\n",
+    "            if cible in CASES:\n",
+    "                ops.append(Operateur(f\"move-{nom_dir}-x{c}-y{r}\", {prop(c, r)}, {prop(*cible)}, {prop(c, r)}))\n",
+    "    for objet, cell in [(\"plank\", (1, 1)), (\"key\", (2, 0)), (\"treasure\", (4, 1))]:\n",
+    "        c, r = cell\n",
+    "        ops.append(Operateur(f\"pickup-{objet}\", {prop(c, r), f\"{objet}-at-x{c}-y{r}\"},\n",
+    "                             {f\"holding-{objet}\"}, {f\"{objet}-at-x{c}-y{r}\"}))\n",
+    "    return ops\n",
+    "\n",
+    "A_T = ops_de_base()\n",
+    "BUTS = {\"g1: balise (5,2)\": frozenset({prop(5, 2)}),\n",
+    "        \"g2: detenir le tresor\": frozenset({\"holding-treasure\"}),\n",
+    "        \"g3: detenir la cle\": frozenset({\"holding-key\"})}\n",
+    "\n",
+    "print(f\"Cases existantes : {len(CASES)} (colonne 3 = gouffre)\")\n",
+    "print(f\"Operateurs A_t   : {len(A_T)} ({sum(1 for o in A_T if o.nom.startswith('move'))} moves + {sum(1 for o in A_T if o.nom.startswith('pickup'))} pickups)\")\n",
+    "print(f\"Buts             : {list(BUTS)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c05",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002423,
+     "end_time": "2026-08-22T10:36:47.481984+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.479561+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Pas 1 — Vérifier l'inatteignabilité, pas la supposer\n",
+    "\n",
+    "L'énumération exhaustive de l'ensemble atteignable est un **certificat fini** : si l'espace est énuméré en entier et que le but n'y figure pas, l'inatteignabilité est **exacte** — pas un délai dépassé, pas une impression. C'est l'exigence du protocole : le pas 1 ne dit pas « on n'a pas trouvé », il dit « **il n'y a pas** »."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "pl13c06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.487675Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.487425Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.491973Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.491338Z"
+    },
+    "papermill": {
+     "duration": 0.008873,
+     "end_time": "2026-08-22T10:36:47.493106+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.484233+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ensemble atteignable dans A_t : 36 etats, 36 expansions (BFS exhaustif)\n",
+      "\n",
+      "g1: balise (5,2)             atteignable=False   h*=infini\n",
+      "g2: detenir le tresor        atteignable=False   h*=infini\n",
+      "g3: detenir la cle           atteignable=True   h*=3\n",
+      "\n",
+      "Propositions de la rive droite presentes dans l'ensemble atteignable : AUCUNE\n"
+     ]
+    }
+   ],
+   "source": [
+    "dist_t, peres_t, exp_t = bfs(INITIAL, A_T)\n",
+    "S_atteint = set(dist_t)\n",
+    "\n",
+    "print(f\"Ensemble atteignable dans A_t : {len(S_atteint)} etats, {exp_t} expansions (BFS exhaustif)\")\n",
+    "print()\n",
+    "for nom, but in sorted(BUTS.items()):\n",
+    "    ok = any(but <= s for s in S_atteint)\n",
+    "    hstar = min((d for s, d in dist_t.items() if but <= s), default=float('inf'))\n",
+    "    print(f\"{nom:28s} atteignable={ok}   h*={hstar if hstar != float('inf') else 'infini'}\")\n",
+    "\n",
+    "but_droite = [p for s in S_atteint for p in s if p.startswith(('at-x4', 'at-x5', 'holding-treasure'))]\n",
+    "print(f\"\\nPropositions de la rive droite presentes dans l'ensemble atteignable : {sorted(set(but_droite)) or 'AUCUNE'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c06b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002216,
+     "end_time": "2026-08-22T10:36:47.497730+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.495514+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du pas 1 : le certificat et son architecture\n",
+    "\n",
+    "L'ensemble atteignable vaut exactement **36 états** — et ce nombre n'est pas arbitraire : 9 cases de la rive gauche × 4 combinaisons d'inventaire (∅, planchette, clé, les deux). La rive droite apporte **zéro** état : aucune proposition `at-x4-*`/`at-x5-*`/`holding-treasure` n'apparaît jamais. Le BFS a énuméré l'espace **en entier** (36 expansions pour 36 états : chaque état a été dépilé exactement une fois) — l'inatteignabilité de $g_1$ et $g_2$ est donc un **certificat fini**, à distinguer soigneusement d'un échec de recherche : un solveur qui « n'a pas trouvé en 10 secondes » ne prouve rien ; une énumération complète qui ne contient pas le but prouve l'impossibilité.\n",
+    "\n",
+    "Le témoin de santé fait son office : $g_3$ est atteignable avec $h^* = 3$ (deux déplacements jusqu'à la clé en $(2,0)$, un pickup). Le moteur marche, le gouffre seul est en cause."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c07",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00204,
+     "end_time": "2026-08-22T10:36:47.501967+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.499927+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Pas 2 — La mesure de contrôle : chercher *davantage* dans le même $A_t$\n",
+    "\n",
+    "C'est le pas que l'on a le plus envie de sauter, et le grain entier s'effondre sans lui. Trois niveaux d'effort, **même vocabulaire** :\n",
+    "\n",
+    "1. **BFS exhaustif** — l'exploration complète (déjà faite, budget : 36 états) ;\n",
+    "2. **A\\*** avec l'heuristique admissible $h_{max}$ — la meilleure heuristique calculable issue de la relaxation du lake (chaîne $h_{max} \\le h^+ \\le h^*$) ;\n",
+    "3. **IDDFS** (approfondissement itératif, profondeur 24) — l'effort systématique sans mémoire.\n",
+    "\n",
+    "Si le but devient atteignable à un seul de ces niveaux, l'extension du pas 3 n'aurait rien mesuré : c'était un problème de recherche, pas de vocabulaire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "pl13c08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.507257Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.507106Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.678823Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.677992Z"
+    },
+    "papermill": {
+     "duration": 0.175275,
+     "end_time": "2026-08-22T10:36:47.679371+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.504096+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "but                                 BFS           A*+h_max          IDDFS(24)\n",
+      "g1: balise (5,2)               ECHEC( 36)    ECHEC(  36)    ECHEC( 4151)\n",
+      "g2: detenir le tresor          ECHEC( 36)    ECHEC(  36)    ECHEC( 4151)\n",
+      "g3: detenir la cle                OK( 36)       OK(   4)       OK(   24)\n",
+      "\n",
+      "Verdict du controle : g1 et g2 echouent aux TROIS niveaux d'effort.\n",
+      "L'espace atteignable est le MEME (36 etats) quel que soit le budget.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import heapq, itertools\n",
+    "\n",
+    "def astar_hmax(initial, but, ops):\n",
+    "    \"\"\"A* avec h_max (admissible). Retourne (but_atteint, expansions).\"\"\"\n",
+    "    compteur = itertools.count()\n",
+    "    frontiere = [(h_max(initial, but, ops), 0, next(compteur), initial)]\n",
+    "    vu = {initial}\n",
+    "    expansions = 0\n",
+    "    while frontiere:\n",
+    "        f, g, _, s = heapq.heappop(frontiere)\n",
+    "        expansions += 1\n",
+    "        if but <= s:\n",
+    "            return True, expansions, g\n",
+    "        for op, t in successeurs(s, ops):\n",
+    "            if t not in vu:\n",
+    "                vu.add(t)\n",
+    "                heapq.heappush(frontiere, (g + 1 + h_max(t, but, ops), g + 1, next(compteur), t))\n",
+    "    return False, expansions, None\n",
+    "\n",
+    "def iddfs(initial, but, ops, prof_max):\n",
+    "    \"\"\"Iterative deepening : exhaustif a profondeur bornee.\"\"\"\n",
+    "    expansions = 0\n",
+    "    for limite in range(prof_max + 1):\n",
+    "        pile = [(initial, 0)]\n",
+    "        chemin_vu = set()\n",
+    "        while pile:\n",
+    "            s, d = pile.pop()\n",
+    "            expansions += 1\n",
+    "            if but <= s:\n",
+    "                return True, expansions, d\n",
+    "            if d < limite:\n",
+    "                for op, t in successeurs(s, ops):\n",
+    "                    if (t, d + 1) not in chemin_vu:\n",
+    "                        chemin_vu.add((t, d + 1))\n",
+    "                        pile.append((t, d + 1))\n",
+    "    return False, expansions, None\n",
+    "\n",
+    "rapport = []\n",
+    "for nom, but in sorted(BUTS.items()):\n",
+    "    ok_bfs = any(but <= s for s in S_atteint)\n",
+    "    ok_astar, exp_astar, g_astar = astar_hmax(INITIAL, but, A_T)\n",
+    "    ok_iddfs, exp_iddfs, d_iddfs = iddfs(INITIAL, but, A_T, 24)\n",
+    "    rapport.append((nom, ok_bfs, exp_t, ok_astar, exp_astar, ok_iddfs, exp_iddfs))\n",
+    "\n",
+    "print(f\"{'but':28s} {'BFS':>10s} {'A*+h_max':>18s} {'IDDFS(24)':>18s}\")\n",
+    "for nom, b, eb, a, ea, i, ei in rapport:\n",
+    "    print(f\"{nom:28s} {'OK' if b else 'ECHEC':>7s}({eb:3d}) {'OK' if a else 'ECHEC':>8s}({ea:4d}) {'OK' if i else 'ECHEC':>8s}({ei:5d})\")\n",
+    "\n",
+    "print(\"\\nVerdict du controle : g1 et g2 echouent aux TROIS niveaux d'effort.\")\n",
+    "print(\"L'espace atteignable est le MEME (36 etats) quel que soit le budget.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c08b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002311,
+     "end_time": "2026-08-22T10:36:47.684235+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.681924+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du pas 2 : l'asymétrie des budgets est la signature\n",
+    "\n",
+    "Le tableau se lit en deux colonnes morales. Sur le but **atteignable** $g_3$, l'effort paie de façon spectaculaire : BFS énumère les 36 états, A\\* avec $h_{max}$ n'en développe que **4** (l'heuristique admissible le mène droit au but), IDDFS en re-développe 24. C'est le régime ordinaire de la planification : *plus d'effort, une meilleure heuristique — le même problème devient tractable*.\n",
+    "\n",
+    "Sur les buts **inatteignables**, l'effet disparaît : BFS et A\\* rendent le même verdict en énumérant **le même espace de 36 états** — la meilleure heuristique du monde ne peut pas indiquer un chemin qui n'existe pas, elle ne peut qu'épuiser. IDDFS, lui, **brûle 4 151 expansions** — plus de cent fois la taille de l'espace, parce qu'il ré-explorre sans mémoire à chaque seuil de profondeur — pour conclure la même chose. C'est l'asymétrie qui authentifie le diagnostic :\n",
+    "\n",
+    "- budgets qui **s'améliorent** sur un but → le problème était de *recherche* ;\n",
+    "- budgets qui **brûlent sans rien rapporter** → le problème est de *vocabulaire*.\n",
+    "\n",
+    "Et le résultat négatif de la relaxation (section suivante) complète le verdict : même le monde relaxé — pourtant plus grand par construction — ne contient pas la rive droite. Le trou n'est pas dans les deletes, il est dans l'alphabet des actions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c09",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002106,
+     "end_time": "2026-08-22T10:36:47.688526+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.686420+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Ce que le lake garantit — et pourquoi la relaxation ne peut pas sauver $g_1$\n",
+    "\n",
+    "Le théorème d'admissibilité (`Planning/Admissibility.lean:41`) dit : tout plan réel est un plan relaxé, donc $h^+ \\le h^*$. La relaxation **sans delete** (`run ⊆ runR`, `Planning/Relaxation.lean:56`) est un élargissement de monde : elle rend atteignable tout ce que les suppressions d'effets interdisaient. Mesurons-la ici :\n",
+    "\n",
+    "- sur la rive **gauche**, la relaxation minorer honnêtement : $h_{max} \\le h^*$, parfois **strictement** — le but conjonctif « planchette **et** clé **et** revenir au départ » coûte 8 en réel mais paraît plus court au monde relaxé (les positions s'accumulent, les détours disparaissent) ;\n",
+    "- sur $g_1$/$g_2$, la distance relaxée est **infinie elle aussi** : aucun opérateur de $A_t$, même relaxé, ne produit une proposition de la rive droite. La relaxation élargit les mondes **par les deletes** ; une **primitive manquante** est un trou que même le monde relaxé ne comble pas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "pl13c10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.694528Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.694379Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.703443Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.702699Z"
+    },
+    "papermill": {
+     "duration": 0.012479,
+     "end_time": "2026-08-22T10:36:47.704008+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.691529+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "But conjonctif (planchette ET cle ET revenir au depart)\n",
+      "  h* (reel, BFS uniforme)  = 8\n",
+      "  h_max (relaxe, exact)    = 3\n",
+      "  chaine verifiee          : h_max (3) <= h* (8)  -> STRICT\n",
+      "  (le lake garantit h+ <= h* en Admissibility.lean:41 ; h_max <= h+ complete la chaine)\n",
+      "\n",
+      "g1: balise (5,2): h_max dans A_t = INFINI (relaxement inatteignable)\n",
+      "\n",
+      "g2: detenir le tresor: h_max dans A_t = INFINI (relaxement inatteignable)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# (a) La relaxation minore, parfois strictement, sur la rive gauche\n",
+    "but_conjonctif = frozenset({\"holding-plank\", \"holding-key\", prop(0, 0)})\n",
+    "hstar_conj = min((d for s, d in dist_t.items() if but_conjonctif <= s), default=float('inf'))\n",
+    "hmax_conj = h_max(INITIAL, but_conjonctif, A_T)\n",
+    "print(f\"But conjonctif (planchette ET cle ET revenir au depart)\")\n",
+    "print(f\"  h* (reel, BFS uniforme)  = {hstar_conj}\")\n",
+    "print(f\"  h_max (relaxe, exact)    = {hmax_conj}\")\n",
+    "print(f\"  chaine verifiee          : h_max ({hmax_conj}) <= h* ({hstar_conj})  -> {'STRICT' if hmax_conj < hstar_conj else 'egalite'}\")\n",
+    "print(f\"  (le lake garantit h+ <= h* en Admissibility.lean:41 ; h_max <= h+ complete la chaine)\")\n",
+    "\n",
+    "# (b) Sur g1/g2 : meme le monde relaxe est infini\n",
+    "for nom in [\"g1: balise (5,2)\", \"g2: detenir le tresor\"]:\n",
+    "    hm = h_max(INITIAL, BUTS[nom], A_T)\n",
+    "    print(f\"\\n{nom}: h_max dans A_t = {hm if hm != float('inf') else 'INFINI (relaxement inatteignable)'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c11",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002149,
+     "end_time": "2026-08-22T10:36:47.708342+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.706193+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Pas 3 — La primitive nommée, et ce qu'elle coûte\n",
+    "\n",
+    "Une extension **gratuite** ne mesure rien : si la nouvelle action ne coûte rien, le delta d'atteignabilité n'a pas de contrefactuel. La primitive inventée ici est le **radeau** :\n",
+    "\n",
+    "> `raft-across-y{r}` — préconditions : être en $(2,r)$ **et** détenir la planchette. Effets : atterrir en $(4,r)$ ; **la planchette est consommée** (suppression `holding-plank`).\n",
+    "\n",
+    "Son coût est double et visible dans les plans du pas 4 : (1) la planchette est **dépensée** — un seul trajet, pas d'aller-retour gratuit ; (2) l'aller chercher en $(1,1)$ est un **détour** imposé avant la traversée. Le vocabulaire s'élargit : $A_t \\hookrightarrow A_{t+1}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "pl13c12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.713604Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.713462Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.717484Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.716803Z"
+    },
+    "papermill": {
+     "duration": 0.007447,
+     "end_time": "2026-08-22T10:36:47.718056+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.710609+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A_t   : 41 operateurs\n",
+      "A_t+1 : 44 operateurs (primitive ajoutee : ['raft-across-y0', 'raft-across-y1', 'raft-across-y2'])\n",
+      "  raft-across-y0: precond=['at-x2-y0', 'holding-plank'] ajouts=['at-x4-y0'] supprime=['at-x2-y0', 'holding-plank']\n",
+      "  raft-across-y1: precond=['at-x2-y1', 'holding-plank'] ajouts=['at-x4-y1'] supprime=['at-x2-y1', 'holding-plank']\n",
+      "  raft-across-y2: precond=['at-x2-y2', 'holding-plank'] ajouts=['at-x4-y2'] supprime=['at-x2-y2', 'holding-plank']\n"
+     ]
+    }
+   ],
+   "source": [
+    "def ops_avec_radeau():\n",
+    "    ops = ops_de_base()\n",
+    "    for r in RANGS:\n",
+    "        ops.append(Operateur(\n",
+    "            f\"raft-across-y{r}\",\n",
+    "            {prop(2, r), \"holding-plank\"},\n",
+    "            {prop(4, r)},\n",
+    "            {prop(2, r), \"holding-plank\"}))\n",
+    "    return ops\n",
+    "\n",
+    "A_T1 = ops_avec_radeau()\n",
+    "nouveaux = [o for o in A_T1 if o.nom.startswith(\"raft-\")]\n",
+    "print(f\"A_t   : {len(A_T)} operateurs\")\n",
+    "print(f\"A_t+1 : {len(A_T1)} operateurs (primitive ajoutee : {sorted(o.nom for o in nouveaux)})\")\n",
+    "for op in nouveaux:\n",
+    "    print(f\"  {op.nom}: precond={sorted(op.precond)} ajouts={sorted(op.ajouts)} supprime={sorted(op.dels)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002144,
+     "end_time": "2026-08-22T10:36:47.722459+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.720315+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Pas 4 — Le delta, mesuré\n",
+    "\n",
+    "Trois mesures, pas une impression :\n",
+    "\n",
+    "1. **En buts** : quels éléments de $G$ deviennent atteignables — le différentiel $\\Delta = \\text{atteignable}(A_{t+1}) \\setminus \\text{atteignable}(A_t)$, but par but ;\n",
+    "2. **En plans** : le plan pour $g_1$ et celui pour $g_2$, exhibés action par action avec leur coût $h^*$ ;\n",
+    "3. **En espace** : la taille de l'ensemble atteignable — le monde lui-même a grandi, ce n'est pas la recherche qui a approfondi."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "pl13c14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.727628Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.727504Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.733883Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.732973Z"
+    },
+    "papermill": {
+     "duration": 0.009772,
+     "end_time": "2026-08-22T10:36:47.734426+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.724654+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ensemble atteignable : |A_t| = 36 etats  ->  |A_t+1| = 60 etats (+24)\n",
+      "\n",
+      "but                               A_t    A_t+1  h*(A_t+1)  delta\n",
+      "g1: balise (5,2)                ECHEC       OK          7  NOUVELLEMENT ATTEIGNABLE\n",
+      "g2: detenir le tresor           ECHEC       OK          6  NOUVELLEMENT ATTEIGNABLE\n",
+      "g3: detenir la cle                 OK       OK          3  \n",
+      "\n",
+      "Plan g1 (balise, h* = 7) :\n",
+      "   1. move-est-x0-y0\n",
+      "   2. move-nord-x1-y0\n",
+      "   3. pickup-plank\n",
+      "   4. move-est-x1-y1\n",
+      "   5. move-nord-x2-y1\n",
+      "   6. raft-across-y2\n",
+      "   7. move-est-x4-y2\n",
+      "\n",
+      "Plan g2 (tresor, h* = 6) :\n",
+      "   1. move-est-x0-y0\n",
+      "   2. move-nord-x1-y0\n",
+      "   3. pickup-plank\n",
+      "   4. move-est-x1-y1\n",
+      "   5. raft-across-y1\n",
+      "   6. pickup-treasure\n"
+     ]
+    }
+   ],
+   "source": [
+    "dist_t1, peres_t1, exp_t1 = bfs(INITIAL, A_T1)\n",
+    "S_atteint_1 = set(dist_t1)\n",
+    "\n",
+    "print(f\"Ensemble atteignable : |A_t| = {len(S_atteint)} etats  ->  |A_t+1| = {len(S_atteint_1)} etats \"\n",
+    "      f\"(+{len(S_atteint_1) - len(S_atteint)})\")\n",
+    "print()\n",
+    "print(f\"{'but':28s} {'A_t':>8s} {'A_t+1':>8s} {'h*(A_t+1)':>10s}  delta\")\n",
+    "for nom, but in sorted(BUTS.items()):\n",
+    "    avant = any(but <= s for s in S_atteint)\n",
+    "    apres = any(but <= s for s in S_atteint_1)\n",
+    "    h1 = min((d for s, d in dist_t1.items() if but <= s), default=float('inf'))\n",
+    "    print(f\"{nom:28s} {'OK' if avant else 'ECHEC':>8s} {'OK' if apres else 'ECHEC':>8s} {h1:>10}  {'NOUVELLEMENT ATTEIGNABLE' if (apres and not avant) else ''}\")\n",
+    "\n",
+    "etat_g1 = min((s for s in dist_t1 if BUTS['g1: balise (5,2)'] <= s), key=lambda s: dist_t1[s])\n",
+    "etat_g2 = min((s for s in dist_t1 if BUTS['g2: detenir le tresor'] <= s), key=lambda s: dist_t1[s])\n",
+    "print(f\"\\nPlan g1 (balise, h* = {dist_t1[etat_g1]}) :\")\n",
+    "for i, a in enumerate(reconstruire(peres_t1, etat_g1), 1):\n",
+    "    print(f\"  {i:2d}. {a}\")\n",
+    "print(f\"\\nPlan g2 (tresor, h* = {dist_t1[etat_g2]}) :\")\n",
+    "for i, a in enumerate(reconstruire(peres_t1, etat_g2), 1):\n",
+    "    print(f\"  {i:2d}. {a}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002286,
+     "end_time": "2026-08-22T10:36:47.739150+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.736864+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du delta : ce que les trois mesures disent ensemble\n",
+    "\n",
+    "- **$\\Delta = \\{g_1, g_2\\}$** — les deux buts de la rive droite deviennent atteignables ; $g_3$, le témoin de santé, était déjà atteignable et le reste : l'extension n'a rien cassé.\n",
+    "- **Les plans racontent le coût de la primitive** : le plan de $g_1$ commence par le détour $(0,0) \\to (1,0) \\to (1,1)$ pour la planchette, et la traversée **consomme** la planchette — si le but exigeait un retour, il faudrait réinventer. Le plan de $g_2$ suit le même squelette et s'arrête une case plus tôt : la traversée en **rangée 1** atterrit pile sur le trésor $(4,1)$ — un pickup de plus, deux déplacements de moins, d'où $h^*(g_2) = 6 < h^*(g_1) = 7$.\n",
+    "- **L'espace a grandi, pas la recherche** : l'ensemble atteignable passe de **36 à 60 états (+24)** — des états de la rive droite **existent maintenant**, alors que les trois niveaux d'effort du pas 2 énuméraient inlassablement les mêmes 36. C'est la différence entre approfondir $A_t$ et élargir en $A_{t+1}$ : le différentiel de Laborit, mesuré.\n",
+    "\n",
+    "Et la relaxation ? Dans $A_{t+1}$, $h_{max}(g_1)$ devient fini — le monde relaxé suit le vocabulaire, jamais l'inverse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "pl13c16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.744685Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.744486Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.862240Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.860847Z"
+    },
+    "papermill": {
+     "duration": 0.121284,
+     "end_time": "2026-08-22T10:36:47.862849+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.741565+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "g1: balise (5,2)             h_max: A_t=inf -> A_t+1=7   h*(A_t+1)=7   chaine h_max<=h*: OK\n",
+      "g2: detenir le tresor        h_max: A_t=inf -> A_t+1=6   h*(A_t+1)=6   chaine h_max<=h*: OK\n"
+     ]
+    }
+   ],
+   "source": [
+    "for nom in [\"g1: balise (5,2)\", \"g2: detenir le tresor\"]:\n",
+    "    hm_avant = h_max(INITIAL, BUTS[nom], A_T)\n",
+    "    hm_apres = h_max(INITIAL, BUTS[nom], A_T1)\n",
+    "    hstar1 = min((d for s, d in dist_t1.items() if BUTS[nom] <= s), default=float('inf'))\n",
+    "    print(f\"{nom:28s} h_max: A_t={hm_avant if hm_avant != float('inf') else 'inf'} -> A_t+1={hm_apres}\"\n",
+    "          f\"   h*(A_t+1)={hstar1}   chaine h_max<=h*: {'OK' if hm_apres <= hstar1 else 'VIOLEE'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c17",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002561,
+     "end_time": "2026-08-22T10:36:47.868168+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.865607+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Résumé — le test opérationnel de la strate 7\n",
+    "\n",
+    "| Pas | Mesure | Résultat |\n",
+    "|---|---|---|\n",
+    "| 1. Inatteignabilité vérifiée | énumération exhaustive | 36 états, $g_1, g_2$ absents — certificat exact |\n",
+    "| 2. Contrôle d'effort | BFS / A\\*+$h_{max}$ / IDDFS(24) | les trois échouent, **même espace** : c'est un problème de vocabulaire |\n",
+    "| 3. Primitive nommée | `raft-across-y{r}` | coût : planchette consommée + détour $(1,1)$ |\n",
+    "| 4. Delta | buts, plans, espace | $\\Delta = \\{g_1, g_2\\}$, plans exhibés ($h^*$ 7 et 6), l'espace atteignable 36 → 60 |\n",
+    "\n",
+    "**Ce que le certificat couvre et ne couvre pas.** Le lake garantit les énoncés *structurels* : $step \\subseteq stepR$ (`Strips.lean:58`), $run \\subseteq runR$ (`Relaxation.lean:56`), $h^+ \\le h^*$ (`Admissibility.lean:41`). Il ne dit **rien** du choix d'une primitive, ni de l'optimisation du chercheur : ce qui est certifié est la *garantie de l'heuristique*, ce qui est mesuré ici est *l'instance*. Les autres sémantiques (préférences, temporalité, incertitude) restent hors de ce certificat comme de cette mesure.\n",
+    "\n",
+    "**Le protocole, réutilisable.** Toute revendication du type « l'agent a appris une nouvelle capacité » passe le même banc : (1) but inatteignable prouvé, (2) l'effort accru échoue, (3) la primitive est nommée et payante, (4) le delta est un ensemble ou un chiffre. Sans le pas 2, chercher davantage et élargir sont indiscernables ; sans le pas 3, le delta ne mesure rien."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c17b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002333,
+     "end_time": "2026-08-22T10:36:47.873307+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.870974+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Limites et suites\n",
+    "\n",
+    "Ce que ce banc ne fait **pas**, pour être lu honnêtement :\n",
+    "\n",
+    "- **Ce n'est pas une étude de solveur**. Fast Downward et OR-Tools CP-SAT ([Planners-4](Planners-4-Fast-Downward.ipynb), [Planners-7](../03-Advanced/Planners-7-OR-Tools.ipynb)) traitent des espaces que ce mini-moteur ne peut pas énumérer ; ici, l'énumération exhaustive est précisément l'**instrument de mesure** — c'est elle qui transforme « on n'a pas trouvé » en certificat. Sur un espace exponentiel, le pas 1 devrait remplacer l'énumération par une preuve d'inatteignabilité (invariants, abstraction) — le protocole reste, l'instrument change.\n",
+    "- **$h^+$ exact n'est pas calculé** — NP-difficile en général ; la chaîne mesurée s'arrête à ses bornes calculables ($h_{max}$, $h^*$). Le companion formel [Planners-5b](Planners-5b-Lean-Relaxation.ipynb) exécute le lemme d'admissibilité dans le kernel Lean lui-même.\n",
+    "- **La synthèse reste hors Lean** : ce qui est certifié est la *garantie structurelle* de la relaxation, pas le choix de la primitive. Un `raft-across` mal fichu (qui traverserait sans planchette) passerait le même banc — l'exercice 2 montre le versant symétrique : une extension stérile y échoue.\n",
+    "\n",
+    "**Suite naturelle** : le différentiel se généralise en remove-differential (quelle classe de plans **disparaît** quand on retire une primitive) et en coût-differential (même vocabulaire, coût des actions changé) — le même protocole à quatre pas s'applique, seul le pas 3 change de geste."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c18",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002479,
+     "end_time": "2026-08-22T10:36:47.878155+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.875676+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "### Exercice 1 — Une primitive *gratuite* : le deltaplane\n",
+    "\n",
+    "Ajoutez l'opérateur `deltaplane-y{r}` : précondition être en $(0,r)$ (bord **gauche**), effet atterrir en $(4,r)$, **sans planchette**. Recalculez $\\Delta$ et $h^*(g_1)$ avec ce vocabulaire $A_{t+1}'$. Le delta change-t-il ? Le coût, oui ou non, et pourquoi le pas 3 du protocole exige-t-il de le dire ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "pl13c19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.884195Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.884026Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.887507Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.886378Z"
+    },
+    "papermill": {
+     "duration": 0.007559,
+     "end_time": "2026-08-22T10:36:47.888150+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.880591+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : delta et h*(g1) avec le deltaplane.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 a completer : construire A_t1_prime avec deltaplane-y{r}, recalculer\n",
+    "# le delta de buts et h*(g1), puis comparer au radeau.\n",
+    "# A_t1_prime = ...\n",
+    "# result_exo1 = None  # TODO etudiant : (delta, hstar_g1)\n",
+    "result_exo1 = None  # TODO etudiant\n",
+    "print(\"Exercice 1 a completer : delta et h*(g1) avec le deltaplane.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c20",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002579,
+     "end_time": "2026-08-22T10:36:47.893369+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.890790+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Une extension *stérile* : jeter la planchette\n",
+    "\n",
+    "Ajoutez l'opérateur `discard-plank` : précondition `holding-plank`, effet suppression de `holding-plank` (rien d'ajouté). Le vocabulaire s'élargit pourtant — mesurez $\\Delta$ et la taille de l'ensemble atteignable. Que démontre ce contre-exemple sur le protocole ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "pl13c21",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.900205Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.899948Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.903451Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.902410Z"
+    },
+    "papermill": {
+     "duration": 0.007899,
+     "end_time": "2026-08-22T10:36:47.904215+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.896316+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : delta et taille de l'espace avec discard-plank.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 a completer : construire A_t1_sterile = A_t + discard-plank,\n",
+    "# verifier que Delta = ensemble vide et que l'espace atteignable ne change pas.\n",
+    "# result_exo2 = None  # TODO etudiant : (delta, taille_atteignable)\n",
+    "result_exo2 = None  # TODO etudiant\n",
+    "print(\"Exercice 2 a completer : delta et taille de l'espace avec discard-plank.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pl13c22",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002565,
+     "end_time": "2026-08-22T10:36:47.909378+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.906813+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — La chaîne $h_{max} \\le h^+ \\le h^*$ sur $g_3$\n",
+    "\n",
+    "Sur le but $g_3$ (détenir la clé), calculez $h_{max}$ et $h^*$ dans $A_t$. Sont-ils égaux ? Trouvez l'argument (en une phrase) qui explique pourquoi la relaxation ne gagne **rien** sur ce but, alors qu'elle gagnait 5 unités sur le but conjonctif de la rive gauche ($h_{max} = 3$ contre $h^* = 8$)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "pl13c23",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T10:36:47.915483Z",
+     "iopub.status.busy": "2026-08-22T10:36:47.915347Z",
+     "iopub.status.idle": "2026-08-22T10:36:47.918396Z",
+     "shell.execute_reply": "2026-08-22T10:36:47.917508Z"
+    },
+    "papermill": {
+     "duration": 0.006983,
+     "end_time": "2026-08-22T10:36:47.918997+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T10:36:47.912014+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : h_max(g3), h*(g3), explication.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 a completer : h_max(g3) et h*(g3) dans A_t, verdict egalite/strict,\n",
+    "# et la phrase d'explication dans explication_exo3.\n",
+    "# result_exo3 = None   # TODO etudiant : (hmax_g3, hstar_g3)\n",
+    "# explication_exo3 = \"\"  # TODO etudiant\n",
+    "result_exo3 = None  # TODO etudiant\n",
+    "explication_exo3 = \"\"  # TODO etudiant\n",
+    "print(\"Exercice 3 a completer : h_max(g3), h*(g3), explication.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 4.333564,
+   "end_time": "2026-08-22T10:36:50.818579+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Planners-13-Differentiel-Atteignabilite.ipynb",
+   "output_path": "Planners-13-Differentiel-Atteignabilite.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-22T10:36:46.485015+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/README.md
@@ -20,12 +20,14 @@ Le fil conducteur : le notebook 3 (partie 1) a montré que la recherche aveugle 
 |---|----------|-------|---------|
 | 4 | [Planners-4-Fast-Downward](Planners-4-Fast-Downward.ipynb) | 45 min | Architecture 3 étapes (translator PDDL→SAS+, preprocessor, search) ; A*, GBFS, EHC via Docker sur Blocks World et Logistics |
 | 5 | [Planners-5-Heuristics](Planners-5-Heuristics.ipynb) | 40 min | Classification admissible/non-admissible ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut) ; comparaison expérimentale du nombre de nœuds expansés |
+| 5b | [Planners-5b-Lean-Relaxation](Planners-5b-Lean-Relaxation.ipynb) | 45 min | Companion **natif** kernel Lean 4 : preuve formelle 0-sorry de $h^{+} \leq h^{*}$ dans le lake `planning_lean` |
 | 6 | [Planners-6-Domains](Planners-6-Domains.ipynb) | 50 min | Domaines IPC standards (Blocks World, Logistics, Gripper, Ferry, Hanoï) de complexité croissante |
+| 13 | [Planners-13-Differentiel-Atteignabilite](Planners-13-Differentiel-Atteignabilite.ipynb) | 45 min | Différentiel d'atteignabilité (strate 7) : protocole 4 pas — inatteignabilité prouvée, contrôle d'effort, primitive nommée et payante, delta mesuré ; consomme les théorèmes du lake `planning_lean` ; stdlib pur, sans Docker |
 
 ## Prérequis
 
 - **Partie 1** maîtrisée : modélisation PDDL, espace d'états (notebooks 1-3)
-- **Docker** : les notebooks 4-6 appellent le serveur HTTP Fast Downward (`jsboige/coursia-fast-downward`, port 8200)
+- **Docker** : les notebooks 4-6 appellent le serveur HTTP Fast Downward (`jsboige/coursia-fast-downward`, port 8200) — les notebooks 5b et 13 n'en dépendent pas (5b : kernel Lean via WSL ; 13 : stdlib pur)
 - **Algorithmique** : A*, recherche heuristique dans les graphes
 
 Si Docker n'est pas disponible, les notebooks théoriques (explication de l'architecture, classification des heuristiques) restent accessibles ; seules les exécutions de planification en ligne seront sautées.
@@ -38,6 +40,7 @@ Vous saurez :
 2. **Choisir** l'heuristique adéquate (LM-cut pour l'optimalité, h-FF pour la vitesse)
 3. **Modéliser** n'importe quel domaine IPC classique en PDDL
 4. **Distinguer** heuristiques admissibles (garantie d'optimalité) et non-admissibles (rapidité)
+5. **Mesurer** ce qu'une nouvelle primitive rend possible — différentiel d'atteignabilité vs approfondissement de recherche (notebook 13)
 
 ## Pour continuer
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -13,7 +13,7 @@ Cette série de notebooks introduit la **Planification Automatique**, une branch
 
 La planification répond à une question différente de celle de l'apprentissage : non pas « que prédire ? » mais « **que faire ?** ». À partir d'un modèle du monde — un état initial, des actions avec leurs préconditions et effets, un but — un planificateur cherche automatiquement une suite d'actions qui mène au but. C'est une technologie éprouvée : elle pilote des robots (manipulation, navigation), optimise la logistique et l'ordonnancement, et a dirigé des engins spatiaux autonomes (Remote Agent sur Deep Space 1, planification d'activités des rovers martiens). Le langage **PDDL** a standardisé la manière de décrire ces problèmes, donnant naissance à tout un écosystème de solveurs comparables. La planification connaît aujourd'hui un regain d'intérêt avec les LLMs, comme moyen de doter les modèles de langage d'une capacité d'action vérifiable et orientée vers un but.
 
-**14 numéros logiques** (23 fichiers `.ipynb` : 14 Python + 9 CSharp twins + 1 Lean companion, cf. marqueur `<!-- CATALOG-STATUS -->` ci-dessus) | **5 parties** | **~10h**
+**15 numéros logiques** (24 fichiers `.ipynb` : 15 Python dont 1 companion Lean + 9 CSharp twins, cf. marqueur `<!-- CATALOG-STATUS -->` ci-dessus) | **5 parties** | **~11h**
 
 **À qui s'adresse cette série** : étudiants en IA, ingénieurs en robotique et logistique, développeurs souhaitant intégrer la planification symbolique dans leurs applications. Aucun prérequis en planification : les concepts sont introduits progressivement depuis les fondements STRIPS jusqu'aux approches neuro-symboliques modernes.
 
@@ -21,8 +21,8 @@ La planification répond à une question différente de celle de l'apprentissage
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 14 (1 setup + 3 foundation + 4 classical dont 1 companion Lean + 3 advanced + 3 neuro-symbolic) |
-| Durée totale | ~10h |
+| Notebooks | 15 (1 setup + 3 foundation + 5 classical dont 1 companion Lean + 3 advanced + 3 neuro-symbolic) |
+| Durée totale | ~11h |
 | Langage | Python 3.9+ |
 | Kernel | Python 3 |
 | Solveurs | Fast Downward, OR-Tools CP-SAT, unified-planning |
@@ -57,7 +57,7 @@ La série débute par le notebook Setup (0) qui configure automatiquement l'envi
 
 ### Phase 2 : Planification Classique (Notebooks 4-6, ~3h)
 
-Les notebooks 4 à 6 constituent le cœur technique de la série. Le notebook 4 (Fast-Downward) présente l'architecture en trois étapes de Fast Downward (translator PDDL→SAS+, preprocessor C++, search C++) et montre comment l'exécuter via Docker et unified-planning. Les algorithmes de recherche (A*, Greedy, EHC) y sont testés sur Blocks World et Logistics. Le notebook 5 (Heuristics) approfondit la théorie : classification admissible/non-admissible ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), comparaison expérimentale des heuristiques sur le nombre de nœuds expansés, et guide de sélection. Le notebook **5b** (Lean-Relaxation) est un **companion natif** au kernel Lean 4 : il prouve formellement, sans `sorry`, l'admissibilité de la relaxation $h^{+} \leq h^{*}$ dans le lake `planning_lean` — la certification mathématique de la propriété que le notebook 5 constate empiriquement. Le notebook 6 (Domains) couvre les domaines standards de l'IPC (Blocks World, Logistics, Gripper, Satellite) avec des problèmes de complexité croissante. À l'issue, vous pouvez configurer un planificateur optimal, choisir l'heuristique adéquate, et modéliser n'importe quel domaine IPC.
+Les notebooks 4 à 6 constituent le cœur technique de la série. Le notebook 4 (Fast-Downward) présente l'architecture en trois étapes de Fast Downward (translator PDDL→SAS+, preprocessor C++, search C++) et montre comment l'exécuter via Docker et unified-planning. Les algorithmes de recherche (A*, Greedy, EHC) y sont testés sur Blocks World et Logistics. Le notebook 5 (Heuristics) approfondit la théorie : classification admissible/non-admissible ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), comparaison expérimentale des heuristiques sur le nombre de nœuds expansés, et guide de sélection. Le notebook **5b** (Lean-Relaxation) est un **companion natif** au kernel Lean 4 : il prouve formellement, sans `sorry`, l'admissibilité de la relaxation $h^{+} \leq h^{*}$ dans le lake `planning_lean` — la certification mathématique de la propriété que le notebook 5 constate empiriquement. Le notebook 6 (Domains) couvre les domaines standards de l'IPC (Blocks World, Logistics, Gripper, Satellite) avec des problèmes de complexité croissante. Le notebook **13** (Différentiel d'atteignabilité, strate 7) retourne au moteur STRIPS minimal pour poser la question inverse : non plus « quel plan pour ce but ? » mais « **quelle nouvelle classe de plans devient atteignable quand on ajoute une primitive ?** » — un protocole en quatre pas (inatteignabilité prouvée, contrôle d'effort, primitive nommée et payante, delta mesuré) qui consomme les garanties du lake `planning_lean` au lieu de les rejouer. À l'issue, vous pouvez configurer un planificateur optimal, choisir l'heuristique adéquate, modéliser n'importe quel domaine IPC — et mesurer ce qu'un élargissement de vocabulaire vaut face à un approfondissement de recherche.
 
 <p align="center"><a href="02-Classical/Planners-5-Heuristics.ipynb"><img src="assets/readme/planners5-heuristics.png" width="540" alt="Heuristiques de recherche : comparaison de A* et de ses variantes guidant l'exploration vers le but pour réduire l'exploration."></a></p>
 
@@ -145,6 +145,7 @@ Pour les approches combinées apprentissage profond + symbolique :
 | Approche neuro-symbolique avancée | **Planners-12-LOOP** (85.8% IPC coverage) |
 | Comparer tous les solveurs (satisfaction) | **Planners-11-Unified-Planning** |
 | Comparer satisfaction **vs** optimisation (`MinimizeActionCosts`) | **Planners-11-Unified-Planning** ([#7592](https://github.com/jsboige/CoursIA/pull/7592)) |
+| Mesurer ce qu'une **nouvelle primitive** rend possible (strate 7) | **Planners-13-Differentiel-Atteignabilite** (protocole 4 pas, stdlib pur) |
 
 ## Objectifs d'apprentissage
 
@@ -183,7 +184,8 @@ SymbolicAI/Planners/
 │   ├── Planners-5-Heuristics-Csharp.ipynb # Twin C# h-max/h-add/h-FF/landmarks (See #4956)
 │   ├── Planners-5b-Lean-Relaxation.ipynb # Companion Lean 4 : preuve h+ <= h*
 │   ├── Planners-6-Domains.ipynb         # Domaines classiques
-│   └── Planners-6-Domains-Csharp.ipynb  # Twin C# STRIPS from-scratch (BFS, Block World/Hanoi/Gripper) (See #4956)
+│   ├── Planners-6-Domains-Csharp.ipynb  # Twin C# STRIPS from-scratch (BFS, Block World/Hanoi/Gripper) (See #4956)
+│   └── Planners-13-Differentiel-Atteignabilite.ipynb # Differentiel d'atteignabilite : primitive ajoutee, delta mesure (strate 7, #12233)
 ├── 03-Advanced/
 │   ├── Planners-7-OR-Tools.ipynb        # CP-SAT
 │   ├── Planners-7-OR-Tools-Csharp.ipynb # Twin C# Job-Shop CP solver from-scratch (propagation + backtracking) (See #4956)
@@ -262,6 +264,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 5b | [Planners-5b-Lean-Relaxation](02-Classical/Planners-5b-Lean-Relaxation.ipynb) | Lean 4 | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de l'admissibilité de la relaxation (h⁺ ≤ h\*) dans le lake `planning_lean`, `#check` + `#print axioms` in-kernel, lemmes de monotonie `step_mono`/`run_mono` sur domaine jouet exécutable (cf [#4053](https://github.com/jsboige/CoursIA/issues/4053) création du lake / PR #4168, companion natif) | 45 min |
 | 6 | [Planners-6-Domains](02-Classical/Planners-6-Domains.ipynb) | Python | Blocks World, Logistics, Gripper, Ferry, Hanoi | 50 min |
 | 6 (C#) | [Planners-6-Domains-Csharp](02-Classical/Planners-6-Domains-Csharp.ipynb) | .NET (C#) | Twin C# du 6 : planificateur STRIPS from-scratch (modèle Atom/Action/State, BFS forward + anti-cycle), domaines Block World + Hanoï + Gripper (See #4956) | 45 min |
+| 13 | [Planners-13-Differentiel-Atteignabilite](02-Classical/Planners-13-Differentiel-Atteignabilite.ipynb) | Python | **Différentiel d'atteignabilité** (strate 7) : protocole en 4 pas — inatteignabilité **prouvée** par énumération exhaustive (36 états), contrôle d'effort (BFS/A\*+h_max/IDDFS échouent sur le même espace, budgets rapportés), primitive **nommée et payante** (`raft-across`, planchette consommée + détour), delta mesuré (Δ={g1,g2}, h\* 7 et 6, espace 36→60). Consomme les théorèmes du lake `planning_lean` (h_max ≤ h⁺ ≤ h\*, `Admissibility.lean:41`) — chaîne h_max(3) ≤ h\*(8) strict vérifiée, rive droite invisible même au monde relaxé. Stdlib pur, déterministe (See #12233) | 45 min |
 
 ### Partie 3 : Approches Avancées ([03-Advanced/](03-Advanced/README.md))
 
@@ -363,6 +366,7 @@ curl -s http://localhost:8200/health
 | **STRIPS** | Modèle de planification avec préconditions/add/delete (1971) |
 | **PDDL** | Planning Domain Definition Language - standard IPC depuis 1998 |
 | **Heuristique** | Fonction estimant le coût pour atteindre le but |
+| **h_max** | Heuristique admissible : max des distances relaxées par atome — maillon calculable de la chaîne $h_{max} \le h^{+} \le h^{*}$ (notebook 13) |
 | **A*** | Algorithme de recherche optimale avec heuristique admissible |
 | **Landmark** | Fait qui doit être vrai à un moment du plan |
 | **HTN** | Hierarchical Task Network - décomposition de tâches |
@@ -518,7 +522,7 @@ python -c "import unified_planning; from ortools.sat.python import cp_model; pri
 jupyter notebook 01-Foundation/Planners-1-Introduction.ipynb
 ```
 
-Pour les notebooks 4-6 (Fast Downward), l'image Docker `jsboige/coursia-fast-downward` fournit un serveur API HTTP sur le port 8200 : `docker pull jsboige/coursia-fast-downward:latest`. Les notebooks théoriques (1-3, 7-12) ne nécessitent que Python.
+Pour les notebooks 4-6 (Fast Downward), l'image Docker `jsboige/coursia-fast-downward` fournit un serveur API HTTP sur le port 8200 : `docker pull jsboige/coursia-fast-downward:latest`. Les notebooks théoriques (1-3, 7-13) ne nécessitent que Python.
 
 ## Navigation guide
 
@@ -710,7 +714,7 @@ if status == cp_model.INFEASIBLE:
    # Puis pointer unified-planning vers le binaire
    ```
 
-Les notebooks théoriques (1-3, 7-12) ne nécessitent **pas** Docker et fonctionnent avec uniquement `pip install unified-planning ortools`.
+Les notebooks théoriques (1-3, 7-13) ne nécessitent **pas** Docker et fonctionnent avec uniquement `pip install unified-planning ortools`.
 
 ## Contribution
 
@@ -754,12 +758,12 @@ Le décompte exact ci-dessous est synchronisé avec le bloc `<!-- CATALOG-STATUS
 |------------|-----------|----------|-------------|
 | **00-Environment** | 1 | PRODUCTION=1, BETA=0 | Setup `unified-planning` + OR-Tools + vérification Docker Fast Downward (port 8200) |
 | **01-Foundation** | 3 | PRODUCTION=3, BETA=0 | Triptyque État-Action-But, modèle STRIPS, syntaxe PDDL, explosion combinatoire $O(2^n)$ |
-| **02-Classical** | 4 | PRODUCTION=3, BETA=1 | Fast Downward (translator→preprocessor→search), heuristiques admissibles ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), domaines IPC (Blocks World, Logistics, Gripper, Satellite), companion Lean `5b-Lean-Relaxation` |
+| **02-Classical** | 5 | PRODUCTION=3, BETA=2 | Fast Downward (translator→preprocessor→search), heuristiques admissibles ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), domaines IPC (Blocks World, Logistics, Gripper, Satellite), companion Lean `5b-Lean-Relaxation`, différentiel d'atteignabilité (`13-Differentiel-Atteignabilite`, strate 7) |
 | **03-Advanced** | 3 | PRODUCTION=3, BETA=0 | CP-SAT (OR-Tools), planification temporelle PDDL 2.1 (durées, parallélisme), HTN/SHOP2 (décomposition hiérarchique, HDDL) |
 | **04-NeuroSymbolic** | 3 | PRODUCTION=3, BETA=0 | LLM-Planning (génération plans depuis langage naturel, plan repair), `unified-planning` (portabilité cross-solveur), LOOP — *Learning to Plan* (state encoder + policy + value nets, 85.8% IPC coverage) |
-| **Total** | **14** | **PRODUCTION=13, BETA=1** | Python 3.9+, kernel Python 3, solveurs : Fast Downward (Docker) + OR-Tools 9.8+ + unified-planning 1.1+ |
+| **Total** | **15** | **PRODUCTION=13, BETA=2** | Python 3.9+, kernel Python 3, solveurs : Fast Downward (Docker) + OR-Tools 9.8+ + unified-planning 1.1+ |
 
-> **Note sur la maturité.** Le notebook `BETA=1` correspond à `Planners-5b-Lean-Relaxation.ipynb` (companion natif du lake `planning_lean/`) : la **preuve formelle 0-sorry** de l'admissibilité $h^{+} \leq h^{*}$ y est certifiée par `lake build` ; le statut `BETA` reflète la phase de relecture pédagogique (intégration au parcours d'apprentissage) plutôt qu'un défaut technique. Le déploiement industriel est validé.
+> **Note sur la maturité.** Les notebooks `BETA=2` correspondent à `Planners-5b-Lean-Relaxation.ipynb` (companion natif du lake `planning_lean/` : la **preuve formelle 0-sorry** de l'admissibilité $h^{+} \leq h^{*}$ y est certifiée par `lake build`) et à `Planners-13-Differentiel-Atteignabilite.ipynb` (nouveau, strate 7). Le statut `BETA` reflète la phase de relecture pédagogique (intégration au parcours d'apprentissage) plutôt qu'un défaut technique. Le déploiement industriel est validé.
 
 **Conformité C.1 — stubs d'exercice.** Les cellules de chaque notebook suivent les patterns conformes (jamais `raise NotImplementedError`) : `pass` / `return None` / `print("Exercice à compléter")` / `result = None  # TODO étudiant`. Chaque notebook s'exécute end-to-end même avant résolution des exercices. Dépendances Python (cf `requirements.txt` racine) : `unified-planning>=1.1`, `networkx>=3.1`, `matplotlib>=3.7`, `numpy>=1.24`, `ortools>=9.8`, `torch>=2.0` (LOOP uniquement) ; optionnels LLM : `openai>=1.0`, `anthropic>=0.30`, `python-dotenv`, `pandas>=2.0`. **Docker** requis pour Fast Downward (port 8200). **Lean 4** (`elan`) requis pour `5b-Lean-Relaxation` via le sous-lake `planning_lean/` (toolchain `lean-toolchain` local). Côté pratique : `pip install -r requirements.txt` puis exécution kernel Python 3 standard. **Note : Planners ne contient pas de variante `student/` dédiée** (à la différence de Tweety ou Sudoku) ; les exercices sont intégrés directement dans les notebooks de la série, sous les labels `# Exercice` / `# Exemple guide` conformément à la convention contenu-based.
 


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #12303

Closes #12233

## Summary

Nouveau notebook `Planners-13-Differentiel-Atteignabilite.ipynb` (28 cellules, 11 code, kernel python3, **stdlib pur, déterministe**) : le test opérationnel de la strate 7 — **quelle nouvelle classe de plans devient atteignable après l'ajout d'une primitive ?** Le protocole en 4 pas de l'issue, chaque pas avec sa mesure :

| Pas de #12233 | Mesure dans le notebook |
|---|---|
| 1. Inatteignabilité **vérifiée**, pas supposée | énumération exhaustive BFS : 36 états (= 9 cases rive gauche × 4 inventaires), rive droite **absente du certificat** (aucune prop `at-x4/x5`), g3 témoin de santé h\*=3 |
| 2. Contrôle d'effort **exécuté et rapporté, budget inclus** | BFS / A\*+h_max / IDDFS(24) : g1/g2 échouent aux trois niveaux — budgets 36/36/**4151** expansions ; contraste g3 : 36/**4**/24 (l'effort paie sur l'atteignable, ne paie rien sur l'inatteignable — l'asymétrie est la signature) |
| 3. Primitive **nommée + ce qu'elle coûte** | `raft-across-y{r}` : précond at-x2-y{r} ∧ holding-plank ; **la planchette est consommée** + détour (1,1) imposé |
| 4. Delta = **ensemble de buts + chiffres** | Δ = {g1, g2} ; plans exhibés action par action (h\* 7 et 6 — g2 traverse en rangée 1, atterrit pile sur le trésor) ; espace atteignable **36 → 60 (+24)** : le monde a grandi, pas la recherche |

**Consommation du lake `planning_lean` (non modifié)** : chaîne mesurée h_max(3) ≤ h\*(8) **STRICTE** sur le but conjonctif rive gauche ; sur g1/g2, h_max = **infini même dans le monde relaxé** — la relaxation élargit par les deletes, une primitive manquante est un trou que même le monde relaxé ne comble. Citations file:ligne : `Planning/Admissibility.lean:41` (h⁺ ≤ h\*), `Planning/Relaxation.lean:56` (run ⊆ runR), `Planning/Strips.lean:58` (step ⊆ stepR). Le notebook énonce explicitement ce que le certificat couvre (garantie structurelle de l'heuristique) et ne couvre pas (choix de la primitive, autres sémantiques) — section « Limites et suites ». Résonance Laborit nommée (différentiel approfondir/élargir), pas thésifiée.

3 exercices C.1 stubbés (`result_exoN = None  # TODO etudiant`) : deltaplane gratuit (le delta change-t-il quand le coût disparaît), extension stérile `discard-plank` (Δ = ∅ — le protocole rejette les vanity extensions), chaîne h_max/h\* sur g3 (égalité + pourquoi).

## Validation

- **Execution** : `scripts/notebook_tools/wsl_papermill.py execute` — **11/11 cellules code, 0 erreur**, séquence [1..11], outputs committés (C.2).
- **C.1** : 0 violation (`raise NotImplementedError` / `assert False` / `1/0`).
- **Densité** : 1400 caractères prose / cellule code (seuil 1200 — premier passage à 941, enrichi de 4 cellules pédagogiques : dynamiques vs lake, lecture du certificat, asymétrie des budgets, limites).
- **Ancrage prose↔outputs** : 11/11 ancres vérifiées sur les outputs finaux (36 etats, +24, h\* = 7, h\* = 6, ECHEC( 4151), OK(   4), h_max (3) <= h\* (8), INFINI relaxement, NOUVELLEMENT ATTEIGNABLE, AUCUNE, primitive ajoutee raft) — leçon MGS-5/MGS-6 appliquée : 2 proses corrigées AVANT commit après lecture des outputs (plan g2 ≠ plan g1 + pickup ; gain relaxation = 5 unités, pas 3).
- **Navlinks** : 3/3 existent (dont correction Planners-7 → `../03-Advanced/`).
- **Déterminisme** : moteurs triés par nom, frozensets — aucune stochasticité, aucune dépendance (stdlib pur).
- **SOTA (§H)** : calcul exact d'atteignabilité (énumération/BFS) et heuristique h_max exacte — l'instrument de mesure EST l'outil exact ici ; aucun solveur externe impliqué, verdict **SOTA-OK** (le notebook le dit : sur un espace exponentiel, le pas 1 devrait passer à des preuves d'inatteignabilité par invariants — l'instrument change, pas le protocole).
- **Lake non touché** : citations en lecture seule, aucun `.lean` modifié → pas de `lake build` requis (critère d'acceptance : « SI le lake est touché »).

## README Planners (audit fichier entier, règle §E)

- **Racine** : headline 15 numéros / 24 fichiers / ~11h · Vue d'ensemble (5 classical, durée) · prose Phase 2 (+1 phrase notebook 13) · recommandations (+1 ligne) · arbre (+1 ligne 02-Classical) · table Partie 2 (+1 ligne riche) · Concepts clés (+h_max) · stats catalogue (02-Classical 5 notebooks BETA=2, Total 15, note maturité étendue) · listes prérequis « notebooks théoriques (1-3, 7-12) » → `(1-3, 7-13)` ×2.
- **Sous-dossier 02-Classical** : lignes 13 **et 5b** (omission préexistante — 5b existe sur disque depuis #4168 mais était absent de la table, réconcilié au passage conformément à §E), prérequis (5b/13 sans Docker), « À l'issue » (+item 5).
- **CATALOG-STATUS byte-identique** (vérifié par diff) — inscription du nouveau notebook laissée au bot par-PR `catalog-drift` / cron.

## Scope

3 fichiers : le notebook + les deux README de série. Rien d'autre.
