### PR TITLE
feat(gameTheory,#12207): notebook GT-3e Meta-Actions-Tarifees (versant D4)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3c-Meta-Actions-Tarifees.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3c-Meta-Actions-Tarifees.ipynb
@@ -1,0 +1,1085 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003595,
+     "end_time": "2026-08-22T11:33:54.021721+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.018126+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory 3c : Meta-Actions Tarifees -- l'agent qui joue, puis qui change les regles\n",
+    "\n",
+    "[← GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb) | [GameTheory-3b-Chambres-et-Murs →](GameTheory-3b-Chambres-et-Murs.ipynb) | [↑ README GameTheory](README.md)\n",
+    "\n",
+    "**Versant D4 du chantier #12207.** Les notebooks [GT-3](GameTheory-3-Topology2x2.ipynb), [GT-3b](GameTheory-3b-Chambres-et-Murs.ipynb) et [GT-21](GameTheory-21-Deux-Especes-de-Fleches.ipynb) ont fait de l'espace des jeux 2x2 ordinaux un **univers fini manipulable** : 576 chambres strictes, six swaps generateurs, des murs ou vivent les egalites. Ce notebook monte l'echelle d'un cran : les swaps y deviennent des **actions que l'agent paie**.\n",
+    "\n",
+    "## Plan\n",
+    "\n",
+    "1. **Marche 1 -- l'agent joue** : equilibres de Nash purs et dynamique de meilleure reponse sur les 576 jeux\n",
+    "2. **Marche 2 -- l'agent deplace le jeu** : meta-actions tarifees, un cout mesure en echelons de rang, seuil de migration\n",
+    "3. **Marche 3 -- deux agents en desaccord** : le meta-jeu 4x4, ses equilibres, et la question de l'accord\n",
+    "\n",
+    "## La question\n",
+    "\n",
+    "La strate 6 de la theorie des jeux dit ce qu'un agent fait *dans* des regles donnees. La strate 7 demande ce qui se passe quand **modifier les regles est lui-meme une action** -- avec un cout, donc un arbitrage, donc un equilibre au niveau superieur. Rendu operationnel sur un univers fini, le franchissement devient mesurable : *a quel prix un agent accepte-t-il de deplacer son propre jeu, et que devient cet arbitrage quand les deux joueurs le jouent simultanement ?*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c02",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002316,
+     "end_time": "2026-08-22T11:33:54.026645+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.024329+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 0. Le substrat, herite de GT-3b\n",
+    "\n",
+    "Un jeu = **deux tables de rangs**, une par joueur, chacune un 4-uplet ordonnant strictement les quatre cases (haut-gauche, haut-droite, bas-gauche, bas-droite) -- rang 4 = meilleur. Les **swaps** `R1, R2, R3` (cote Ligne) et `C1, C2, C3` (cote Colonne) echangent les cases portant deux rangs adjacents `k` et `k+1` : ce sont les six generateurs de l'espace, chacun traverse un mur du monde de Bruns-Kimmich. Toute la mecanique est reprise tel quel de [GT-3b](GameTheory-3b-Chambres-et-Murs.ipynb), sans modification -- ce notebook est un consommateur du substrat, pas une refonte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.032925Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.032696Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.040171Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.038889Z"
+    },
+    "papermill": {
+     "duration": 0.012088,
+     "end_time": "2026-08-22T11:33:54.040986+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.028898+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chambres strictes par joueur : 24 | jeux 2x2 stricts : 576\n",
+      "Generateurs : R1 R2 R3 (Ligne) x C1 C2 C3 (Colonne)\n",
+      "PD : Ligne (3, 1, 4, 2) Colonne (3, 4, 1, 2) (rang 4 = meilleur, cases TG TD BG BD)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Substrat GT-3b, repris tel quel -- pur stdlib\n",
+    "from itertools import product\n",
+    "from collections import Counter, deque\n",
+    "\n",
+    "def swap_val(t, k):\n",
+    "    \"\"\"Echange les cases portant les rangs k et k+1 (traversee de la facette k<->k+1).\"\"\"\n",
+    "    pk, pk1 = t.index(k), t.index(k + 1)\n",
+    "    l = list(t); l[pk], l[pk1] = l[pk1], l[pk]; return tuple(l)\n",
+    "\n",
+    "chambres = sorted({tuple(p) for p in product(range(1, 5), repeat=4) if len(set(p)) == 4})\n",
+    "jeux = [(r, c) for r in chambres for c in chambres]\n",
+    "print(\"Chambres strictes par joueur :\", len(chambres), \"| jeux 2x2 stricts :\", len(jeux))\n",
+    "print(\"Generateurs : R1 R2 R3 (Ligne) x C1 C2 C3 (Colonne)\")\n",
+    "\n",
+    "# Le Dilemme du Prisonnier, encodage GT-21 / GT-3b\n",
+    "PD = ((3, 1, 4, 2), (3, 4, 1, 2))\n",
+    "print(\"PD : Ligne\", PD[0], \"Colonne\", PD[1], \"(rang 4 = meilleur, cases TG TD BG BD)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002558,
+     "end_time": "2026-08-22T11:33:54.046313+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.043755+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Marche 1 -- l'agent joue\n",
+    "\n",
+    "Avant de changer les regles, il faut les subir. Pour chaque jeu, deux instruments :\n",
+    "\n",
+    "- les **equilibres de Nash purs** : cases ou personne ne prefere devier unilateralement ;\n",
+    "- la **dynamique de meilleure reponse** depuis la case haut-gauche : Ligne ajuste, puis Colonne, et on repete -- c'est la facon la plus simple dont des agents \"jouent\" quand personne ne calcule d'equilibre.\n",
+    "\n",
+    "Sur des rangs *ordinaux*, l'equilibre mixte n'a pas de sens (on ne peut pas moyenner des rangs) : un jeu sans equilibre pur est ici **injouable** -- la dynamique cycle sans fin. C'est un fait, pas une anomalie a corriger."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.052139Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.051954Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.060165Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.059206Z"
+    },
+    "papermill": {
+     "duration": 0.011998,
+     "end_time": "2026-08-22T11:33:54.060743+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.048745+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NE purs par jeu : {0: 72, 1: 432, 2: 72} sur 576\n",
+      "Dynamique BR depuis TG : converge 504 | cycle 72\n",
+      "Croisement (#NE, BR) : {(0, 'cycle'): 72, (1, 'ok'): 432, (2, 'ok'): 72}\n",
+      "\n",
+      "PD : NE purs = [(1, 1)] -> (bas,droite) = defection mutuelle, rang 2 chacun\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Marche 1 : NE purs + dynamique BR depuis la case haut-gauche\n",
+    "def ne_purs(row, col):\n",
+    "    nes = []\n",
+    "    for r in (0, 1):\n",
+    "        for c in (0, 1):\n",
+    "            if row[2*r+c] > row[2*(1-r)+c] and col[2*r+c] > col[2*r+(1-c)]:\n",
+    "                nes.append((r, c))\n",
+    "    return nes\n",
+    "\n",
+    "def br_dyn(row, col, start=(0, 0), max_steps=16):\n",
+    "    \"\"\"BR alterne (Ligne d'abord). ('cycle'|'ok', case finale).\"\"\"\n",
+    "    r, c = start\n",
+    "    for _ in range(max_steps):\n",
+    "        moved = False\n",
+    "        nr = r if row[2*r+c] > row[2*(1-r)+c] else (1 - r)\n",
+    "        if nr != r: r, moved = nr, True\n",
+    "        nc = c if col[2*r+c] > col[2*r+(1-c)] else (1 - c)\n",
+    "        if nc != c: c, moved = nc, True\n",
+    "        if not moved: return ('ok', (r, c))\n",
+    "    return ('cycle', (r, c))\n",
+    "\n",
+    "dist_ne = Counter(len(ne_purs(r, c)) for r, c in jeux)\n",
+    "stats = Counter(br_dyn(r, c)[0] for r, c in jeux)\n",
+    "print(\"NE purs par jeu :\", dict(sorted(dist_ne.items())), \"sur\", len(jeux))\n",
+    "print(\"Dynamique BR depuis TG : converge\", stats['ok'], \"| cycle\", stats['cycle'])\n",
+    "croisement = Counter((len(ne_purs(r, c)), br_dyn(r, c)[0]) for r, c in jeux)\n",
+    "print(\"Croisement (#NE, BR) :\", dict(sorted(croisement.items())))\n",
+    "print()\n",
+    "print(\"PD : NE purs =\", ne_purs(*PD), \"-> (bas,droite) = defection mutuelle, rang\", PD[0][3], \"chacun\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c07",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002474,
+     "end_time": "2026-08-22T11:33:54.065842+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.063368+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture de la marche 1\n",
+    "\n",
+    "La distribution est remarquablement symetrique : **72 jeux sans equilibre pur, 432 avec un seul, 72 avec deux** (les coordinations). Et le croisement est exact : la dynamique converge **si et seulement si** un equilibre pur existe -- les 72 cycles sont precisement les 72 jeux sans equilibre. Aucun jeu a deux equilibres ne pose ici de probleme de selection *dynamique* : parti de haut-gauche, le jeu se stabilise toujours quelque part.\n",
+    "\n",
+    "Le Dilemme du Prisonnier fait ce qu'on attend de lui : equilibre unique a la defection mutuelle, rang 2 chacun -- le rang 4 de la cooperation existe mais n'est pas stable. Retenons ce chiffre, **2** : c'est ce que vaut le Dilemme pour celui qui y est piege."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.071504Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.071333Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.076541Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.075597Z"
+    },
+    "papermill": {
+     "duration": 0.00903,
+     "end_time": "2026-08-22T11:33:54.077137+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.068107+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeu sans NE pur : Ligne (2, 3, 1, 4) Colonne (1, 2, 4, 3)\n",
+      "Trajectoire BR depuis TG : TG -> TD -> BD -> BG -> TG -> TD -> ... (cycle)\n",
+      "Boucle : TD -> BD -> BG -> TG -> ... repetee indefiniment\n",
+      "\n",
+      "Convention : gain au sorti de BR ; jeu injouable -> 0 pour chacun (pire que tout rang >= 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le fait brut : exhiber un jeu injouable (cycle BR complet)\n",
+    "ex_injouable = ((2, 3, 1, 4), (1, 2, 4, 3))\n",
+    "row, col = ex_injouable\n",
+    "print(\"Jeu sans NE pur : Ligne\", row, \"Colonne\", col)\n",
+    "NOMS_CASES = (\"TG\", \"TD\", \"BG\", \"BD\")\n",
+    "r, c = 0, 0\n",
+    "trace = [(r, c)]\n",
+    "for _ in range(6):\n",
+    "    nr = r if row[2*r+c] > row[2*(1-r)+c] else (1 - r)\n",
+    "    if nr != r: r = nr; trace.append((r, c))\n",
+    "    nc = c if col[2*r+c] > col[2*r+(1-c)] else (1 - c)\n",
+    "    if nc != c: c = nc; trace.append((r, c))\n",
+    "print(\"Trajectoire BR depuis TG :\", \" -> \".join(NOMS_CASES[2*tr+tc] for tr, tc in trace[:6]) + \" -> ... (cycle)\")\n",
+    "print(\"Boucle :\", \" -> \".join(NOMS_CASES[2*tr+tc] for tr, tc in trace[1:5]) + \" -> ... repetee indefiniment\")\n",
+    "\n",
+    "# Convention de la suite : un jeu injouable vaut 0 pour chacun (pire que tout rang jouable)\n",
+    "def payoff(row, col, cote):\n",
+    "    st, (r, c) = br_dyn(row, col)\n",
+    "    if st == 'cycle': return 0\n",
+    "    return row[2*r+c] if cote == 0 else col[2*r+c]\n",
+    "print()\n",
+    "print(\"Convention : gain au sorti de BR ; jeu injouable -> 0 pour chacun (pire que tout rang >= 1)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c09",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002326,
+     "end_time": "2026-08-22T11:33:54.081837+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.079511+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Marche 2 -- l'agent deplace le jeu, et paie\n",
+    "\n",
+    "L'agent Ligne recoit desormais des **meta-actions** : appliquer l'un de ses trois swaps `R1, R2, R3` -- reecrire ses propres preference declarees -- puis jouer le jeu deplace. Chaque swap coute **c echelons de rang**. Cette unite n'est pas un artifice : payer 1 signifie *renoncer a un echelon de preference pour l'atteindre*, ce qui rend la soustraction `rang final - cout` honnetement interpretable dans un monde purement ordinal.\n",
+    "\n",
+    "Ligne arbitre : rester et toucher son rang courant, ou migrer vers une table distante de d swaps et toucher `rang(final) - c*d`. Comme l'espace est fini, l'optimum se calcule par parcours exhaustif -- BFS depuis **sa propre table** (le graphe de Cayley des 24 tables, diametre 6, deja mesure par GT-3b)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.087515Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.087370Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.124363Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.123225Z"
+    },
+    "papermill": {
+     "duration": 0.040851,
+     "end_time": "2026-08-22T11:33:54.124960+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.084109+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c   | %migrer | dist.opt moy | gain net moy (migrants) | fuient un cycle\n",
+      "------------------------------------------------------------------------\n",
+      "0   |   56%   |     1.33     |          +1.93          |     72\n",
+      "1   |   16%   |     1.25     |          +2.00          |     72\n",
+      "2   |    8%   |     1.00     |          +1.50          |     48\n",
+      "3   |    4%   |     1.00     |          +1.00          |     24\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Marche 2 : optimum de migration par jeu, puis sweep du cout\n",
+    "def bfs_from(t0):\n",
+    "    d = {t0: 0}; q = deque([t0])\n",
+    "    while q:\n",
+    "        u = q.popleft()\n",
+    "        for k in (1, 2, 3):\n",
+    "            v = swap_val(u, k)\n",
+    "            if v not in d: d[v] = d[u] + 1; q.append(v)\n",
+    "    return d\n",
+    "\n",
+    "best_by_dist = {}\n",
+    "for row_t, col_t in jeux:\n",
+    "    m = {}\n",
+    "    for t2, d in bfs_from(row_t).items():\n",
+    "        p = payoff(t2, col_t, 0)\n",
+    "        m[d] = max(m.get(d, -1), p)\n",
+    "    best_by_dist[(row_t, col_t)] = m   # m[0] = rang courant, m[d] = meilleur rang atteignable a distance d\n",
+    "\n",
+    "print(\"c   | %migrer | dist.opt moy | gain net moy (migrants) | fuient un cycle\")\n",
+    "print(\"-\" * 72)\n",
+    "for c in (0, 1, 2, 3):\n",
+    "    n_mig = tot_d = tot_gain = fuit = 0\n",
+    "    for (r_t, c_t), m in best_by_dist.items():\n",
+    "        best = max(m[d] - c * d for d in m)\n",
+    "        bd = min(d for d in m if m[d] - c * d == best)\n",
+    "        if bd > 0 and best > m[0]:            # migrer ssi strictement meilleur que rester\n",
+    "            n_mig += 1; tot_d += bd; tot_gain += best - m[0]\n",
+    "            if payoff(r_t, c_t, 0) == 0: fuit += 1\n",
+    "    n = len(jeux)\n",
+    "    print(f\"{c}   |  {100*n_mig//n:3d}%   |     {tot_d/max(n_mig,1):.2f}     |          {tot_gain/max(n_mig,1):+.2f}          |     {fuit}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c12",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002528,
+     "end_time": "2026-08-22T11:33:54.130491+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.127963+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du sweep : un seuil monotone, une distance qui se contracte\n",
+    "\n",
+    "Quatre faits mesures :\n",
+    "\n",
+    "1. **La migration s'effondre avec le cout** : 56 % des jeux voient Ligne migrer a cout nul, 16 % a cout 1, 8 % a cout 2, 4 % a cout 3. A un echelon par swap, six jeux sur sept restent -- le privilege de reecrire ses preferences est cher.\n",
+    "2. **La distance optimale se contracte** de 1,33 vers 1,00 : plus le km de swap est cher, plus on ne paie que le deplacement minimal -- a cout eleve, seuls les gains de proximite immediate survivent.\n",
+    "3. **Le gain net moyen des migrants monte puis redescend** (+1,93 a c=0, +2,00 a c=1, +1,50 a c=2, +1,00 a c=3) : a c=0 partent aussi les migrations gadgets ; a c=1 ne restent que les migrations de fond ; au-dela, le cout ronge le gain.\n",
+    "4. **Les 72 jeux injouables se vident a leur rythme** : meme a cout 1, les 72 fuient tous (quitter un gain nul vaut n'importe quel prix raisonnable) ; a cout 2 il en reste 48, a cout 3 seulement 24 -- les autres preferent le cycle gratuit au deplacement trop cher. *Meme l'injouable a un prix au-dessus duquel on le tolere.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.137980Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.137737Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.143145Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.142074Z"
+    },
+    "papermill": {
+     "duration": 0.010772,
+     "end_time": "2026-08-22T11:33:54.144117+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.133345+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PD : rang courant de Ligne (defection mutuelle) = 2\n",
+      "Meilleur rang atteignable par distance :\n",
+      "  a distance 0 : rang 2   (rester)\n",
+      "  a distance 1 : rang 3  -> net a c=1 : 2\n",
+      "  a distance 2 : rang 4  -> net a c=1 : 2\n",
+      "  a distance 3 : rang 4  -> net a c=1 : 1\n",
+      "  a distance 4 : rang 4  -> net a c=1 : 0\n",
+      "  a distance 5 : rang 4  -> net a c=1 : -1\n",
+      "  a distance 6 : rang 4  -> net a c=1 : -2\n",
+      "\n",
+      "c = 0 : net optimal 4 (courant 2) -> Ligne MIGRE a distance 2\n",
+      "c = 1 : net optimal 2 (courant 2) -> Ligne RESTE\n",
+      "c = 2 : net optimal 2 (courant 2) -> Ligne RESTE\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le Dilemme sous les meta-actions : que peut acheter Ligne ?\n",
+    "m_pd = best_by_dist[PD]\n",
+    "print(\"PD : rang courant de Ligne (defection mutuelle) =\", m_pd[0])\n",
+    "print(\"Meilleur rang atteignable par distance :\")\n",
+    "for d in sorted(m_pd):\n",
+    "    print(f\"  a distance {d} : rang {m_pd[d]}\" + (f\"  -> net a c=1 : {m_pd[d]-d}\" if d > 0 else \"   (rester)\"))\n",
+    "print()\n",
+    "for c in (0, 1, 2):\n",
+    "    best = max(m_pd[d] - c * d for d in m_pd)\n",
+    "    bd = min(d for d in m_pd if m_pd[d] - c * d == best)\n",
+    "    verdict = \"RESTE\" if bd == 0 else f\"MIGRE a distance {bd}\"\n",
+    "    print(f\"c = {c} : net optimal {best} (courant {m_pd[0]}) -> Ligne {verdict}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c14",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002888,
+     "end_time": "2026-08-22T11:33:54.150190+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.147302+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le Dilemme exactement indifferent\n",
+    "\n",
+    "A cout nul, Ligne quitte le Dilemme : deux swaps l'amennent a un jeu ou sa table lui donne le rang 4, net +2. Mais **a cout 1, l'indifference est exacte** : le rang 3 a distance 1 et le rang 4 a distance 2 donnent tous deux un net de 2 -- strictement egal a rester. Le gain de fuite du Dilemme est **entierement mange par le cout du deplacement**. Ce n'est pas un accident d'arrondi : sur l'echelle des rangs, la fuite solitaire du Dilemme coute precisement ce qu'elle rapporte. Le piege de la strate 6 a une propriete economique de plus : il est *juste assez solide* pour retenir un agent solitaire qui doit payer son deplacement -- ce qui rend d'autant plus interessante la question des deux agents, en marche 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.156692Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.156477Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.164987Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.163885Z"
+    },
+    "papermill": {
+     "duration": 0.01276,
+     "end_time": "2026-08-22T11:33:54.165613+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.152853+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Migrants a c=1 : 96 jeux sur 576 dont 72 refugies (partent d'un rang nul)\n",
+      "Opportuniste : jeu ((1, 4, 2, 3), (1, 2, 4, 3)) | rang 2 -> rang 4 en 1 swap (table cible (2, 4, 1, 3) )\n",
+      "\n",
+      "Jeux injouables : 72 | reparables en 1 swap : 48 | autres : 24\n",
+      "Exemple ((1, 3, 4, 2), (2, 1, 3, 4)) -> tables jouables a distance 1 : [(1, 2, 4, 3)] | meilleur rang 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Les migrants a cout 1 : qui part, et la fuite des injouables\n",
+    "mig = []\n",
+    "for (r_t, c_t), m in best_by_dist.items():\n",
+    "    best = max(m[d] - d for d in m)\n",
+    "    bd = min(d for d in m if m[d] - d == best)\n",
+    "    if bd > 0 and best > m[0]:\n",
+    "        mig.append((r_t, c_t, bd, m[0], m[bd]))\n",
+    "print(\"Migrants a c=1 :\", len(mig), \"jeux sur\", len(jeux), \"dont\", sum(1 for x in mig if x[3] == 0), \"refugies (partent d'un rang nul)\")\n",
+    "opp = [x for x in mig if x[3] > 0]\n",
+    "r_t, c_t, bd, p0, p1 = opp[0]\n",
+    "t_cible = [t for t, d in bfs_from(r_t).items() if d == bd and payoff(t, c_t, 0) == p1][0]\n",
+    "print(\"Opportuniste : jeu\", (r_t, c_t), \"| rang\", p0, \"-> rang\", p1, \"en\", bd, \"swap (table cible\", t_cible, \")\")\n",
+    "\n",
+    "inj = [g for g in jeux if not ne_purs(*g)]\n",
+    "rep1 = sum(1 for g in inj if min(d for d in best_by_dist[g] if best_by_dist[g][d] > 0) == 1)\n",
+    "print()\n",
+    "print(\"Jeux injouables :\", len(inj), \"| reparables en 1 swap :\", rep1, \"| autres :\", len(inj) - rep1)\n",
+    "row_i, col_i = inj[0]\n",
+    "jouables_d1 = [t for t, d in bfs_from(row_i).items() if d == 1 and payoff(t, col_i, 0) > 0]\n",
+    "meilleur = max(payoff(t, col_i, 0) for t in jouables_d1) if jouables_d1 else None\n",
+    "print(\"Exemple\", (row_i, col_i), \"-> tables jouables a distance 1 :\", jouables_d1,\n",
+    "      \"| meilleur rang\", meilleur)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c16",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002674,
+     "end_time": "2026-08-22T11:33:54.171064+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.168390+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : deux raisons de partir\n",
+    "\n",
+    "Les migrants a cout 1 ne sont pas une population homogene. Il y a les **opportunistes** -- des jeux jouables ou un seul swap proche decalle l'equilibre vers une case de meilleur rang (l'exemple affiche saute de deux echelons en un swap) -- et les **refugies** : les 72 jeux sans equilibre, dont 48 se reparent a distance 1. Pour un refugie, la meta-action n'est pas du luxe strategique, c'est la condition meme de jouabilite : sans elle, le jeu ne produit aucun resultat -- c'est le refugie affiche plus bas, parti du rang nul. La strate 7 commence deja ici -- *changer les regles pour que le jeu existe* -- avant meme toute consideration d'amelioration."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c17",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00254,
+     "end_time": "2026-08-22T11:33:54.176261+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.173721+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Marche 3 -- deux agents, un meta-jeu\n",
+    "\n",
+    "Derniere marche : **Ligne et Colonne disposent simultanement de leurs meta-actions**. Chacun choisit une action dans {rester, R1, R2, R3} x {rester, C1, C2, C3} -- chacun ne reecrit que **sa** table, payer ses propres echelons -- puis le jeu deplace est joue (dynamique BR depuis haut-gauche, convention de marche 1), et chacun touche son rang final moins son cout. Seize profils par jeu de base : un **meta-jeu 4x4** dont on peut chercher les equilibres de Nash purs, exactement comme a la marche 1.\n",
+    "\n",
+    "La question du desaccord devient calculable : *existe-t-il un equilibre du meta-jeu, bouge-t-on a l'equilibre, et cet equilibre est-il bon pour les deux ?*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.184909Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.184556Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.218170Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.216951Z"
+    },
+    "papermill": {
+     "duration": 0.040173,
+     "end_time": "2026-08-22T11:33:54.219042+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.178869+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeux avec au moins un meta-NE pur : 572 / 576\n",
+      "Distribution du nombre de meta-NE : {0: 4, 1: 166, 2: 266, 3: 16, 4: 116, 5: 6, 6: 2}\n",
+      "\n",
+      "Statut du mouvement a l'equilibre :\n",
+      "  tous les meta-NE restent sur place : 134\n",
+      "  (rester) coexiste avec des NE mobiles : 332 (selection d'equilibre)\n",
+      "  aucun meta-NE ne reste sur place : 106 (bouger est necessaire)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Marche 3 : le meta-jeu 4x4 et ses equilibres (cout = 1)\n",
+    "def meta_profil(row_t, col_t, a1, a2, cout=1):\n",
+    "    r2 = swap_val(row_t, a1) if a1 > 0 else row_t\n",
+    "    c2 = swap_val(col_t, a2) if a2 > 0 else col_t\n",
+    "    p1 = payoff(r2, c2, 0); p2 = payoff(r2, c2, 1)\n",
+    "    return p1 - (cout if a1 > 0 else 0), p2 - (cout if a2 > 0 else 0)\n",
+    "\n",
+    "def meta_ne(row_t, col_t, cout=1):\n",
+    "    profils = {(a1, a2): meta_profil(row_t, col_t, a1, a2, cout)\n",
+    "               for a1 in range(4) for a2 in range(4)}\n",
+    "    nes = []\n",
+    "    for (a1, a2), (u1, u2) in profils.items():\n",
+    "        if all(profils[(a1b, a2)][0] <= u1 for a1b in range(4)) and \\\n",
+    "           all(profils[(a1, a2b)][1] <= u2 for a2b in range(4)):\n",
+    "            nes.append((a1, a2))\n",
+    "    return nes, profils\n",
+    "\n",
+    "st_ne = Counter()\n",
+    "tous_restant = ambigu = aucun_restant = 0\n",
+    "for row_t, col_t in jeux:\n",
+    "    nes, _ = meta_ne(row_t, col_t)\n",
+    "    st_ne[len(nes)] += 1\n",
+    "    if not nes: continue\n",
+    "    if all(n == (0, 0) for n in nes): tous_restant += 1\n",
+    "    elif (0, 0) in nes: ambigu += 1\n",
+    "    else: aucun_restant += 1\n",
+    "print(\"Jeux avec au moins un meta-NE pur :\", sum(v for k, v in st_ne.items() if k > 0), \"/\", len(jeux))\n",
+    "print(\"Distribution du nombre de meta-NE :\", dict(sorted(st_ne.items())))\n",
+    "print()\n",
+    "print(\"Statut du mouvement a l'equilibre :\")\n",
+    "print(\"  tous les meta-NE restent sur place :\", tous_restant)\n",
+    "print(\"  (rester) coexiste avec des NE mobiles :\", ambigu, \"(selection d'equilibre)\")\n",
+    "print(\"  aucun meta-NE ne reste sur place :\", aucun_restant, \"(bouger est necessaire)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c19",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002602,
+     "end_time": "2026-08-22T11:33:54.224520+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.221918+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le meta-jeu a presque toujours des equilibres\n",
+    "\n",
+    "Premiere surprise : **572 jeux sur 576** ont au moins un equilibre pur au niveau meta -- ajouter des meta-actions *stabilise* plutot qu'elle ne destabilise. Le detail du statut est plus riche :\n",
+    "\n",
+    "- **134 jeux** : tous les equilibres restent sur place -- la meta-action existe mais personne n'a interet a s'en servir a l'equilibre (l'immobilisme est stable) ;\n",
+    "- **332 jeux** : rester et bouger coexistent comme equilibres -- c'est le domaine de la *selection d'equilibre* : plusieurs futurs possibles, aucun critere ordinal n'en designe un ;\n",
+    "- **106 jeux** : aucun equilibre sur place -- **bouger est une necessite d'equilibre**. Dans pres d'un jeu sur cinq, l'equilibre de strate 6 n'est plus tenable des que reecrire les regles est possible : l'agent qui refuse de payer reste piege pendant que l'autre reconfigure.\n",
+    "\n",
+    "La marche 2 disait *quand un agent solitaire part* ; la marche 3 dit que **des qu'on ouvre la porte aux deux, dans un cinquieme des jeux, partir est force**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.230917Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.230722Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.235366Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.234365Z"
+    },
+    "papermill": {
+     "duration": 0.008813,
+     "end_time": "2026-08-22T11:33:54.235955+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.227142+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Meta-jeu du PD (Ligne en lignes, Colonne en colonnes) :\n",
+      "               reste        C1        C2        C3\n",
+      "   reste  (2,2) * (4,1)   (2,2) * (2,1)   \n",
+      "      R1  (1,4)   (3,1)   (1,3)   (-1,-1)   \n",
+      "      R2  (2,2) * (3,1)   (2,2) * (2,1)   \n",
+      "      R3  (1,2)   (-1,-1)   (1,2)   (3,3) * \n",
+      "\n",
+      "* = equilibre de Nash pur du meta-jeu : [(0, 0), (0, 2), (2, 0), (2, 2), (3, 3)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le meta-jeu du Dilemme, en entier\n",
+    "nes_pd, prof_pd = meta_ne(*PD)\n",
+    "noms = [\"reste\", \"R1\", \"R2\", \"R3\"]\n",
+    "noms_c = [\"reste\", \"C1\", \"C2\", \"C3\"]\n",
+    "print(\"Meta-jeu du PD (Ligne en lignes, Colonne en colonnes) :\")\n",
+    "print(\"          \" + \"\".join(f\"{n:>10s}\" for n in noms_c))\n",
+    "for a1 in range(4):\n",
+    "    ligne = f\"{noms[a1]:>8s}  \"\n",
+    "    for a2 in range(4):\n",
+    "        u1, u2 = prof_pd[(a1, a2)]\n",
+    "        marque = \" *\" if (a1, a2) in nes_pd else \"  \"\n",
+    "        ligne += f\"({u1},{u2}){marque} \"\n",
+    "    print(ligne)\n",
+    "print()\n",
+    "print(\"* = equilibre de Nash pur du meta-jeu :\", nes_pd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c21",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002587,
+     "end_time": "2026-08-22T11:33:54.241575+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.238988+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le Dilemme se resout -- a deux, et par equilibre\n",
+    "\n",
+    "Le meta-jeu du Dilemme porte **cinq equilibres**. Quatre laissent les deux prisonniers a (2,2) -- le statu quo auquel on pense toujours. Mais le cinquieme, **(R3, C3), paie (3,3)** : chacun reecrit sa propre preference au niveau 3-4, le jeu deplace devient une coordination dont l'equilibre selectionne par la dynamique est la case mutuellement meilleure (rang 4 chacun), et meme apres avoir paye un echelon chacun, il reste **(3,3) > (2,2)**. Trois proprietes remarquables :\n",
+    "\n",
+    "1. **L'evasion est unilateralement stable** : si un seul migre, la dynamique retombe sur la defection mutuelle et le migrant a paye pour rien -- les profils (R3, reste) et (reste, C3) du tableau paient (1, 2) et (2, 1) : moins que (3, 3) pour chacun -- personne ne peut profiter du départ de l'autre ;\n",
+    "2. **Elle est symetrique** : chacun ne touche qu'a sa table ; personne ne reecrit les preferences de l'autre ;\n",
+    "3. **Elle n'est pas unique** : quatre autres equilibres restent au (2,2). L'evasion *existe et est stable*, mais rien ne la *selectionne* -- c'est un probleme de focalisation, plus de stabilite.\n",
+    "\n",
+    "C'est la reponse mesuree a la question de la marche : *modifier les regles est une action, et dans le Dilemme cette action est un equilibre qui domine le piege -- a condition que les deux la jouent ensemble.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.247876Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.247699Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.276674Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.275594Z"
+    },
+    "papermill": {
+     "duration": 0.032962,
+     "end_time": "2026-08-22T11:33:54.277183+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.244221+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeux (avec meta-NE) dont AU MOINS UN equilibre est Pareto-optimal : 568\n",
+      "Jeux ou AUCUN equilibre n'est Pareto-optimal : 4 -- l'echec de coordination dur\n",
+      "\n",
+      "Exemple ((1, 3, 2, 4), (3, 4, 2, 1)) : les meta-NE paient [(2, 2), (2, 2), (2, 2), (2, 2)]\n",
+      "Frontiere de Pareto du meta-jeu : [(4, 1), (3, 1), (1, 3), (3, 1), (3, 3)] ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# L'echec de coordination : quand AUCUN equilibre n'est Pareto-optimal\n",
+    "def pareto_dominated(profils, p):\n",
+    "    return any(v[0] > p[0] and v[1] > p[1] for v in profils.values())\n",
+    "\n",
+    "au_moins_un_bon = aucun_bon = 0\n",
+    "ex_dur = None\n",
+    "for row_t, col_t in jeux:\n",
+    "    nes, profils = meta_ne(row_t, col_t)\n",
+    "    if not nes: continue\n",
+    "    if any(not pareto_dominated(profils, profils[n]) for n in nes):\n",
+    "        au_moins_un_bon += 1\n",
+    "    else:\n",
+    "        aucun_bon += 1\n",
+    "        if ex_dur is None: ex_dur = (row_t, col_t, nes, profils)\n",
+    "print(\"Jeux (avec meta-NE) dont AU MOINS UN equilibre est Pareto-optimal :\", au_moins_un_bon)\n",
+    "print(\"Jeux ou AUCUN equilibre n'est Pareto-optimal :\", aucun_bon, \"-- l'echec de coordination dur\")\n",
+    "row_t, col_t, nes, profils = ex_dur\n",
+    "print()\n",
+    "print(\"Exemple\", (row_t, col_t), \": les meta-NE paient\", [profils[n] for n in nes])\n",
+    "frontiere = {k: v for k, v in profils.items() if not pareto_dominated(profils, v)}\n",
+    "print(\"Frontiere de Pareto du meta-jeu :\", list(frontiere.values())[:5], \"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c23",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002762,
+     "end_time": "2026-08-22T11:33:54.282759+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.279997+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : la limite du decentralise\n",
+    "\n",
+    "Dans **568 jeux sur 572**, au moins un equilibre du meta-jeu est Pareto-optimal : en general, le meilleur a deux est stable, le probleme est seulement de *le choisir* parmi les equilibres. Mais **4 jeux realisent l'echec de coordination pur** : tous leurs equilibres paient (2,2) tandis que la frontiere de Pareto contient des profils mutuellement meilleurs -- des regles reecrites dont les deux joueurs profiteraient, et qui ne sont **pas stables** : chacun serait tente d'en devier. L'exhibe le montre chiffres en main : l'accord existe dans la matrice, il n'existe pas dans les incitations.\n",
+    "\n",
+    "C'est exactement la jonction annoncee par le chantier : la ou la strate 7 rencontre la theorie des mecanismes. Quand changer les regles est une action decentralisee, l'accord mutuel sur le changement reste un equilibre a produire -- le probleme ne fait que remonter d'un etage. Un protocole d'engagement (le versant commitment de [GT-20](GameTheory-20-Commitment-Stackelberg.ipynb)) est le candidat naturel, et l'exercice 3 le fait toucher du doigt."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c24",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002717,
+     "end_time": "2026-08-22T11:33:54.288247+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.285530+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Limites et conventions (lues avant d'etendre)\n",
+    "\n",
+    "- **Le cout en echelons de rang** est une convention locale, documentee : elle rend `rang - cout` interpretable sans cardinaliser les preferences. Un cout en energie, en temps ou en argent exigerait une echelle cardinale et changerait les seuils -- pas la forme du protocole.\n",
+    "- **La regle de jeu** est la dynamique BR depuis la case haut-gauche. Une autre regle de selection (depuis une autre case, tirage aleatoire, dynamique simultanee) deplace certains equilibres selectionnes ; les comptages d'equilibres *purs* (marche 1) et de meta-NE (marche 3) n'en dependent pas.\n",
+    "- **Le meta-jeu est one-shot et simultane** : pas de repetition, pas d'engagement, pas d'ordre de passage. L'exercice 3 ouvre le sequentiel.\n",
+    "- **Chacun ne reecrit que sa table** : le redesign institutionnel croise (reecrire la table de l'autre, ou une table commune) est hors perimetre -- c'est une strate encore au-dessus.\n",
+    "- Les dettes de verification du chantier (passage 576 vers 144, tore a 37 trous, references arXiv non ouvertes firsthand) restent **RAPPORTEES** et ne sont pas utilisees ici : ce notebook ne derive que du substrat exact de GT-3b, lui-meme exhaustivement verifie."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c25",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002619,
+     "end_time": "2026-08-22T11:33:54.293559+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.290940+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 -- le sweep vu par Colonne\n",
+    "\n",
+    "La marche 2 a fait migrer Ligne. Refaites le meme sweep du cout **cote Colonne** (ses swaps C1-C3, son gain au sorti de la dynamique). Le compte de migrants a c=1 est-il le meme que cote Ligne (16 %) ? Si oui, dites pourquoi la symetrie l'impose ; sinon, exhibez un jeu qui les distingue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c26",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.299822Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.299625Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.303349Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.302162Z"
+    },
+    "papermill": {
+     "duration": 0.007702,
+     "end_time": "2026-08-22T11:33:54.303880+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.296178+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 : a completer (sweep cote Colonne)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : sweep du cout cote Colonne\n",
+    "# TODO etudiant : reconstruire best_by_dist_col (BFS sur la table Colonne, payoff cote 1)\n",
+    "# puis le tableau c=0..3 : %migrer, distance optimale moyenne, fuient-un-cycle\n",
+    "resultat_ex1 = None  # TODO etudiant : {c: (pct_migrer, dist_moyenne, fuites)}\n",
+    "print(\"Exercice 1 : a completer (sweep cote Colonne)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c27",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002761,
+     "end_time": "2026-08-22T11:33:54.309581+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.306820+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 -- deplacer la selection d'equilibre\n",
+    "\n",
+    "Les 72 jeux a deux equilibres purs sont les coordinations. En partant de l'un d'eux, montrez un cas ou **un seul swap de Ligne change l'equilibre selectionne** par la dynamique (la case d'arrivee change), et un cas ou aucun swap ne la change. Combien des 72 jeux sont du premier type ? (Le comptage exhaustif est possible : 72 jeux x 24 tables.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.316012Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.315835Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.319457Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.318455Z"
+    },
+    "papermill": {
+     "duration": 0.007768,
+     "end_time": "2026-08-22T11:33:54.320019+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.312251+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 : a completer (selection deplacable)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : la selection d'equilibre sous meta-actions\n",
+    "# TODO etudiant : pour chaque jeu a 2 NE purs, comparer l'arrivee de br_dyn pour la table\n",
+    "# courante et pour les 23 autres tables ; compter ceux ou l'arrivee peut changer\n",
+    "resultat_ex2 = None  # TODO etudiant : (nb_jeux_selection_deplacable, exemple)\n",
+    "print(\"Exercice 2 : a completer (selection deplacable)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c29",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002837,
+     "end_time": "2026-08-22T11:33:54.325823+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.322986+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 -- le meta-jeu sequentiel\n",
+    "\n",
+    "La marche 3 est simultanee : les 4 echecs de coordination dur proviennent de l'instabilite de l'accord. Rendez le meta-jeu **sequentiel** : Ligne annonce et joue sa meta-action, Colonne voit le jeu deplace puis choisit la sienne. Proposez le protocole (qui observe quoi, ordre des couts), recalculez les equilibres (backward induction sur les 4x4 sous-jeux), et dites combien des 4 echecs durs se referment. Verdict attendu en une phrase : *le sequentiel suffit-il a stabiliser l'accord ?*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c30",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T11:33:54.332608Z",
+     "iopub.status.busy": "2026-08-22T11:33:54.332421Z",
+     "iopub.status.idle": "2026-08-22T11:33:54.336185Z",
+     "shell.execute_reply": "2026-08-22T11:33:54.335144Z"
+    },
+    "papermill": {
+     "duration": 0.008182,
+     "end_time": "2026-08-22T11:33:54.336992+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.328810+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 : a completer (meta-jeu sequentiel)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : equilibres parfaits du meta-jeu sequentiel\n",
+    "# TODO etudiant : pour chacun des 4 jeux en echec dur, construire l'arbre\n",
+    "# (Ligne : 4 actions ; Colonne observe ; 4 actions) et resoudre par induction\n",
+    "resultat_ex3 = None  # TODO etudiant : {jeu: equilibre_sequentiel, referme: bool}\n",
+    "print(\"Exercice 3 : a completer (meta-jeu sequentiel)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c31",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002853,
+     "end_time": "2026-08-22T11:33:54.343161+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.340308+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion : trois marches, un franchissement\n",
+    "\n",
+    "Les trois marches mesurent le passage de la strate 6 a la strate 7 sur un univers fini ou tout se verifie :\n",
+    "\n",
+    "| Marche | Ce que fait l'agent | Chiffre cle |\n",
+    "|---|---|---|\n",
+    "| 1 -- jouer | subit les regles, converge ou cycle | 72 jeux injouables sur 576 ; convergence si et seulement si equilibre pur |\n",
+    "| 2 -- deplacer | paie des echelons pour reecrire sa table | 56 % -> 16 % -> 8 % -> 4 % de migrants quand le cout monte ; le Dilemme exactement indifferent a c=1 |\n",
+    "| 3 -- se coordonner sur les regles | joue le meta-jeu 4x4 | 106 jeux ou bouger est necessaire ; le Dilemme s'evade a (3,3) par equilibre symetrique ; 4 echecs de coordination dur |\n",
+    "\n",
+    "Le resultat qui donne son sens au chantier : **changer les regles est une action ordinaire** -- elle a un prix, un seuil, des equilibres, et meme ses propres echecs de coordination. Le vocabulaire strategique de la strate 6 s'applique sans modification un etage plus haut ; c'est la definition meme d'un franchissement reussi.\n",
+    "\n",
+    "*Suite du chantier (#12207)* : D1 (la grammaire des generateurs manipulables) et D3 (le chemin minimal certifie, cible Lean a terme via #12205) restent a ecrire sur le meme substrat."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c32",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003015,
+     "end_time": "2026-08-22T11:33:54.349087+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T11:33:54.346072+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "***\n",
+    "\n",
+    "[← GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb) | [GameTheory-3b-Chambres-et-Murs →](GameTheory-3b-Chambres-et-Murs.ipynb) | [↑ README GameTheory](README.md)\n",
+    "\n",
+    "*GameTheory 3c -- Meta-Actions Tarifees, versant D4 du chantier « Les jeux comme objets » (#12207). Substrat, encodages et swaps herites de GT-3b ; jumeaux conceptuels GT-21 (les deux especes de fleches) et GT-20 (l'engagement comme protocole de coordination sur les regles).*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.492723,
+   "end_time": "2026-08-22T11:33:54.469587+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-3c-Meta-Actions-Tarifees.ipynb",
+   "output_path": "GameTheory-3c-Meta-Actions-Tarifees.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-22T11:33:52.976864+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3e-Meta-Actions-Tarifees.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3e-Meta-Actions-Tarifees.ipynb
@@ -5,16 +5,16 @@
    "id": "c01",
    "metadata": {
     "papermill": {
-     "duration": 0.003595,
-     "end_time": "2026-08-22T11:33:54.021721+00:00",
+     "duration": 0.002974,
+     "end_time": "2026-08-22T11:41:58.805538+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.018126+00:00",
+     "start_time": "2026-08-22T11:41:58.802564+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "# GameTheory 3c : Meta-Actions Tarifees -- l'agent qui joue, puis qui change les regles\n",
+    "# GameTheory 3e : Meta-Actions Tarifees -- l'agent qui joue, puis qui change les regles\n",
     "\n",
     "[← GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb) | [GameTheory-3b-Chambres-et-Murs →](GameTheory-3b-Chambres-et-Murs.ipynb) | [↑ README GameTheory](README.md)\n",
     "\n",
@@ -36,10 +36,10 @@
    "id": "c02",
    "metadata": {
     "papermill": {
-     "duration": 0.002316,
-     "end_time": "2026-08-22T11:33:54.026645+00:00",
+     "duration": 0.002076,
+     "end_time": "2026-08-22T11:41:58.810292+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.024329+00:00",
+     "start_time": "2026-08-22T11:41:58.808216+00:00",
      "status": "completed"
     },
     "tags": []
@@ -56,16 +56,16 @@
    "id": "c03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.032925Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.032696Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.040171Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.038889Z"
+     "iopub.execute_input": "2026-08-22T11:41:58.815565Z",
+     "iopub.status.busy": "2026-08-22T11:41:58.815382Z",
+     "iopub.status.idle": "2026-08-22T11:41:58.821210Z",
+     "shell.execute_reply": "2026-08-22T11:41:58.820289Z"
     },
     "papermill": {
-     "duration": 0.012088,
-     "end_time": "2026-08-22T11:33:54.040986+00:00",
+     "duration": 0.009416,
+     "end_time": "2026-08-22T11:41:58.821762+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.028898+00:00",
+     "start_time": "2026-08-22T11:41:58.812346+00:00",
      "status": "completed"
     },
     "tags": []
@@ -106,10 +106,10 @@
    "id": "c04",
    "metadata": {
     "papermill": {
-     "duration": 0.002558,
-     "end_time": "2026-08-22T11:33:54.046313+00:00",
+     "duration": 0.002229,
+     "end_time": "2026-08-22T11:41:58.826573+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.043755+00:00",
+     "start_time": "2026-08-22T11:41:58.824344+00:00",
      "status": "completed"
     },
     "tags": []
@@ -131,16 +131,16 @@
    "id": "c06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.052139Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.051954Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.060165Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.059206Z"
+     "iopub.execute_input": "2026-08-22T11:41:58.831971Z",
+     "iopub.status.busy": "2026-08-22T11:41:58.831821Z",
+     "iopub.status.idle": "2026-08-22T11:41:58.839212Z",
+     "shell.execute_reply": "2026-08-22T11:41:58.838422Z"
     },
     "papermill": {
-     "duration": 0.011998,
-     "end_time": "2026-08-22T11:33:54.060743+00:00",
+     "duration": 0.010951,
+     "end_time": "2026-08-22T11:41:58.839702+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.048745+00:00",
+     "start_time": "2026-08-22T11:41:58.828751+00:00",
      "status": "completed"
     },
     "tags": []
@@ -195,10 +195,10 @@
    "id": "c07",
    "metadata": {
     "papermill": {
-     "duration": 0.002474,
-     "end_time": "2026-08-22T11:33:54.065842+00:00",
+     "duration": 0.00216,
+     "end_time": "2026-08-22T11:41:58.844024+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.063368+00:00",
+     "start_time": "2026-08-22T11:41:58.841864+00:00",
      "status": "completed"
     },
     "tags": []
@@ -217,16 +217,16 @@
    "id": "c08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.071504Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.071333Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.076541Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.075597Z"
+     "iopub.execute_input": "2026-08-22T11:41:58.849179Z",
+     "iopub.status.busy": "2026-08-22T11:41:58.849043Z",
+     "iopub.status.idle": "2026-08-22T11:41:58.853713Z",
+     "shell.execute_reply": "2026-08-22T11:41:58.852963Z"
     },
     "papermill": {
-     "duration": 0.00903,
-     "end_time": "2026-08-22T11:33:54.077137+00:00",
+     "duration": 0.008082,
+     "end_time": "2026-08-22T11:41:58.854239+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.068107+00:00",
+     "start_time": "2026-08-22T11:41:58.846157+00:00",
      "status": "completed"
     },
     "tags": []
@@ -274,10 +274,10 @@
    "id": "c09",
    "metadata": {
     "papermill": {
-     "duration": 0.002326,
-     "end_time": "2026-08-22T11:33:54.081837+00:00",
+     "duration": 0.002883,
+     "end_time": "2026-08-22T11:41:58.859781+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.079511+00:00",
+     "start_time": "2026-08-22T11:41:58.856898+00:00",
      "status": "completed"
     },
     "tags": []
@@ -296,16 +296,16 @@
    "id": "c11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.087515Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.087370Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.124363Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.123225Z"
+     "iopub.execute_input": "2026-08-22T11:41:58.865743Z",
+     "iopub.status.busy": "2026-08-22T11:41:58.865509Z",
+     "iopub.status.idle": "2026-08-22T11:41:58.903940Z",
+     "shell.execute_reply": "2026-08-22T11:41:58.902634Z"
     },
     "papermill": {
-     "duration": 0.040851,
-     "end_time": "2026-08-22T11:33:54.124960+00:00",
+     "duration": 0.042588,
+     "end_time": "2026-08-22T11:41:58.904790+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.084109+00:00",
+     "start_time": "2026-08-22T11:41:58.862202+00:00",
      "status": "completed"
     },
     "tags": []
@@ -362,10 +362,10 @@
    "id": "c12",
    "metadata": {
     "papermill": {
-     "duration": 0.002528,
-     "end_time": "2026-08-22T11:33:54.130491+00:00",
+     "duration": 0.002487,
+     "end_time": "2026-08-22T11:41:58.910205+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.127963+00:00",
+     "start_time": "2026-08-22T11:41:58.907718+00:00",
      "status": "completed"
     },
     "tags": []
@@ -387,16 +387,16 @@
    "id": "c13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.137980Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.137737Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.143145Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.142074Z"
+     "iopub.execute_input": "2026-08-22T11:41:58.916874Z",
+     "iopub.status.busy": "2026-08-22T11:41:58.916637Z",
+     "iopub.status.idle": "2026-08-22T11:41:58.921568Z",
+     "shell.execute_reply": "2026-08-22T11:41:58.920334Z"
     },
     "papermill": {
-     "duration": 0.010772,
-     "end_time": "2026-08-22T11:33:54.144117+00:00",
+     "duration": 0.009457,
+     "end_time": "2026-08-22T11:41:58.922451+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.133345+00:00",
+     "start_time": "2026-08-22T11:41:58.912994+00:00",
      "status": "completed"
     },
     "tags": []
@@ -442,10 +442,10 @@
    "id": "c14",
    "metadata": {
     "papermill": {
-     "duration": 0.002888,
-     "end_time": "2026-08-22T11:33:54.150190+00:00",
+     "duration": 0.002672,
+     "end_time": "2026-08-22T11:41:58.928185+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.147302+00:00",
+     "start_time": "2026-08-22T11:41:58.925513+00:00",
      "status": "completed"
     },
     "tags": []
@@ -462,16 +462,16 @@
    "id": "c15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.156692Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.156477Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.164987Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.163885Z"
+     "iopub.execute_input": "2026-08-22T11:41:58.934914Z",
+     "iopub.status.busy": "2026-08-22T11:41:58.934696Z",
+     "iopub.status.idle": "2026-08-22T11:41:58.942700Z",
+     "shell.execute_reply": "2026-08-22T11:41:58.941747Z"
     },
     "papermill": {
-     "duration": 0.01276,
-     "end_time": "2026-08-22T11:33:54.165613+00:00",
+     "duration": 0.012724,
+     "end_time": "2026-08-22T11:41:58.943672+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.152853+00:00",
+     "start_time": "2026-08-22T11:41:58.930948+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,10 +519,10 @@
    "id": "c16",
    "metadata": {
     "papermill": {
-     "duration": 0.002674,
-     "end_time": "2026-08-22T11:33:54.171064+00:00",
+     "duration": 0.002612,
+     "end_time": "2026-08-22T11:41:58.949115+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.168390+00:00",
+     "start_time": "2026-08-22T11:41:58.946503+00:00",
      "status": "completed"
     },
     "tags": []
@@ -538,10 +538,10 @@
    "id": "c17",
    "metadata": {
     "papermill": {
-     "duration": 0.00254,
-     "end_time": "2026-08-22T11:33:54.176261+00:00",
+     "duration": 0.002726,
+     "end_time": "2026-08-22T11:41:58.954799+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.173721+00:00",
+     "start_time": "2026-08-22T11:41:58.952073+00:00",
      "status": "completed"
     },
     "tags": []
@@ -560,16 +560,16 @@
    "id": "c18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.184909Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.184556Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.218170Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.216951Z"
+     "iopub.execute_input": "2026-08-22T11:41:58.961465Z",
+     "iopub.status.busy": "2026-08-22T11:41:58.961241Z",
+     "iopub.status.idle": "2026-08-22T11:41:58.990820Z",
+     "shell.execute_reply": "2026-08-22T11:41:58.989534Z"
     },
     "papermill": {
-     "duration": 0.040173,
-     "end_time": "2026-08-22T11:33:54.219042+00:00",
+     "duration": 0.034014,
+     "end_time": "2026-08-22T11:41:58.991507+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.178869+00:00",
+     "start_time": "2026-08-22T11:41:58.957493+00:00",
      "status": "completed"
     },
     "tags": []
@@ -630,10 +630,10 @@
    "id": "c19",
    "metadata": {
     "papermill": {
-     "duration": 0.002602,
-     "end_time": "2026-08-22T11:33:54.224520+00:00",
+     "duration": 0.002612,
+     "end_time": "2026-08-22T11:41:58.997390+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.221918+00:00",
+     "start_time": "2026-08-22T11:41:58.994778+00:00",
      "status": "completed"
     },
     "tags": []
@@ -656,16 +656,16 @@
    "id": "c20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.230917Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.230722Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.235366Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.234365Z"
+     "iopub.execute_input": "2026-08-22T11:41:59.003781Z",
+     "iopub.status.busy": "2026-08-22T11:41:59.003554Z",
+     "iopub.status.idle": "2026-08-22T11:41:59.008281Z",
+     "shell.execute_reply": "2026-08-22T11:41:59.007178Z"
     },
     "papermill": {
-     "duration": 0.008813,
-     "end_time": "2026-08-22T11:33:54.235955+00:00",
+     "duration": 0.008906,
+     "end_time": "2026-08-22T11:41:59.008922+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.227142+00:00",
+     "start_time": "2026-08-22T11:41:59.000016+00:00",
      "status": "completed"
     },
     "tags": []
@@ -709,10 +709,10 @@
    "id": "c21",
    "metadata": {
     "papermill": {
-     "duration": 0.002587,
-     "end_time": "2026-08-22T11:33:54.241575+00:00",
+     "duration": 0.00248,
+     "end_time": "2026-08-22T11:41:59.014303+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.238988+00:00",
+     "start_time": "2026-08-22T11:41:59.011823+00:00",
      "status": "completed"
     },
     "tags": []
@@ -735,16 +735,16 @@
    "id": "c22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.247876Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.247699Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.276674Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.275594Z"
+     "iopub.execute_input": "2026-08-22T11:41:59.021429Z",
+     "iopub.status.busy": "2026-08-22T11:41:59.021214Z",
+     "iopub.status.idle": "2026-08-22T11:41:59.051785Z",
+     "shell.execute_reply": "2026-08-22T11:41:59.050665Z"
     },
     "papermill": {
-     "duration": 0.032962,
-     "end_time": "2026-08-22T11:33:54.277183+00:00",
+     "duration": 0.034929,
+     "end_time": "2026-08-22T11:41:59.052379+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.244221+00:00",
+     "start_time": "2026-08-22T11:41:59.017450+00:00",
      "status": "completed"
     },
     "tags": []
@@ -791,10 +791,10 @@
    "id": "c23",
    "metadata": {
     "papermill": {
-     "duration": 0.002762,
-     "end_time": "2026-08-22T11:33:54.282759+00:00",
+     "duration": 0.003206,
+     "end_time": "2026-08-22T11:41:59.058489+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.279997+00:00",
+     "start_time": "2026-08-22T11:41:59.055283+00:00",
      "status": "completed"
     },
     "tags": []
@@ -812,10 +812,10 @@
    "id": "c24",
    "metadata": {
     "papermill": {
-     "duration": 0.002717,
-     "end_time": "2026-08-22T11:33:54.288247+00:00",
+     "duration": 0.002858,
+     "end_time": "2026-08-22T11:41:59.064641+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.285530+00:00",
+     "start_time": "2026-08-22T11:41:59.061783+00:00",
      "status": "completed"
     },
     "tags": []
@@ -835,10 +835,10 @@
    "id": "c25",
    "metadata": {
     "papermill": {
-     "duration": 0.002619,
-     "end_time": "2026-08-22T11:33:54.293559+00:00",
+     "duration": 0.002816,
+     "end_time": "2026-08-22T11:41:59.070361+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.290940+00:00",
+     "start_time": "2026-08-22T11:41:59.067545+00:00",
      "status": "completed"
     },
     "tags": []
@@ -855,16 +855,16 @@
    "id": "c26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.299822Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.299625Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.303349Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.302162Z"
+     "iopub.execute_input": "2026-08-22T11:41:59.077474Z",
+     "iopub.status.busy": "2026-08-22T11:41:59.077174Z",
+     "iopub.status.idle": "2026-08-22T11:41:59.081936Z",
+     "shell.execute_reply": "2026-08-22T11:41:59.080535Z"
     },
     "papermill": {
-     "duration": 0.007702,
-     "end_time": "2026-08-22T11:33:54.303880+00:00",
+     "duration": 0.009908,
+     "end_time": "2026-08-22T11:41:59.083126+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.296178+00:00",
+     "start_time": "2026-08-22T11:41:59.073218+00:00",
      "status": "completed"
     },
     "tags": []
@@ -891,10 +891,10 @@
    "id": "c27",
    "metadata": {
     "papermill": {
-     "duration": 0.002761,
-     "end_time": "2026-08-22T11:33:54.309581+00:00",
+     "duration": 0.003041,
+     "end_time": "2026-08-22T11:41:59.089390+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.306820+00:00",
+     "start_time": "2026-08-22T11:41:59.086349+00:00",
      "status": "completed"
     },
     "tags": []
@@ -911,16 +911,16 @@
    "id": "c28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.316012Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.315835Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.319457Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.318455Z"
+     "iopub.execute_input": "2026-08-22T11:41:59.096691Z",
+     "iopub.status.busy": "2026-08-22T11:41:59.096505Z",
+     "iopub.status.idle": "2026-08-22T11:41:59.099612Z",
+     "shell.execute_reply": "2026-08-22T11:41:59.098831Z"
     },
     "papermill": {
-     "duration": 0.007768,
-     "end_time": "2026-08-22T11:33:54.320019+00:00",
+     "duration": 0.007683,
+     "end_time": "2026-08-22T11:41:59.100433+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.312251+00:00",
+     "start_time": "2026-08-22T11:41:59.092750+00:00",
      "status": "completed"
     },
     "tags": []
@@ -947,10 +947,10 @@
    "id": "c29",
    "metadata": {
     "papermill": {
-     "duration": 0.002837,
-     "end_time": "2026-08-22T11:33:54.325823+00:00",
+     "duration": 0.002519,
+     "end_time": "2026-08-22T11:41:59.105551+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.322986+00:00",
+     "start_time": "2026-08-22T11:41:59.103032+00:00",
      "status": "completed"
     },
     "tags": []
@@ -967,16 +967,16 @@
    "id": "c30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T11:33:54.332608Z",
-     "iopub.status.busy": "2026-08-22T11:33:54.332421Z",
-     "iopub.status.idle": "2026-08-22T11:33:54.336185Z",
-     "shell.execute_reply": "2026-08-22T11:33:54.335144Z"
+     "iopub.execute_input": "2026-08-22T11:41:59.112198Z",
+     "iopub.status.busy": "2026-08-22T11:41:59.112044Z",
+     "iopub.status.idle": "2026-08-22T11:41:59.115526Z",
+     "shell.execute_reply": "2026-08-22T11:41:59.114618Z"
     },
     "papermill": {
-     "duration": 0.008182,
-     "end_time": "2026-08-22T11:33:54.336992+00:00",
+     "duration": 0.007739,
+     "end_time": "2026-08-22T11:41:59.116069+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.328810+00:00",
+     "start_time": "2026-08-22T11:41:59.108330+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1003,10 +1003,10 @@
    "id": "c31",
    "metadata": {
     "papermill": {
-     "duration": 0.002853,
-     "end_time": "2026-08-22T11:33:54.343161+00:00",
+     "duration": 0.002719,
+     "end_time": "2026-08-22T11:41:59.121689+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.340308+00:00",
+     "start_time": "2026-08-22T11:41:59.118970+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1032,10 +1032,10 @@
    "id": "c32",
    "metadata": {
     "papermill": {
-     "duration": 0.003015,
-     "end_time": "2026-08-22T11:33:54.349087+00:00",
+     "duration": 0.002636,
+     "end_time": "2026-08-22T11:41:59.127222+00:00",
      "exception": false,
-     "start_time": "2026-08-22T11:33:54.346072+00:00",
+     "start_time": "2026-08-22T11:41:59.124586+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1045,7 +1045,7 @@
     "\n",
     "[← GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb) | [GameTheory-3b-Chambres-et-Murs →](GameTheory-3b-Chambres-et-Murs.ipynb) | [↑ README GameTheory](README.md)\n",
     "\n",
-    "*GameTheory 3c -- Meta-Actions Tarifees, versant D4 du chantier « Les jeux comme objets » (#12207). Substrat, encodages et swaps herites de GT-3b ; jumeaux conceptuels GT-21 (les deux especes de fleches) et GT-20 (l'engagement comme protocole de coordination sur les regles).*"
+    "*GameTheory 3e -- Meta-Actions Tarifees, versant D4 du chantier « Les jeux comme objets » (#12207). Substrat, encodages et swaps herites de GT-3b ; jumeaux conceptuels GT-21 (les deux especes de fleches) et GT-20 (l'engagement comme protocole de coordination sur les regles).*"
    ]
   }
  ],
@@ -1069,14 +1069,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.492723,
-   "end_time": "2026-08-22T11:33:54.469587+00:00",
+   "duration": 1.450664,
+   "end_time": "2026-08-22T11:41:59.245325+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "GameTheory-3c-Meta-Actions-Tarifees.ipynb",
-   "output_path": "GameTheory-3c-Meta-Actions-Tarifees.ipynb",
+   "input_path": "GameTheory-3e-Meta-Actions-Tarifees.ipynb",
+   "output_path": "GameTheory-3e-Meta-Actions-Tarifees.ipynb",
    "parameters": {},
-   "start_time": "2026-08-22T11:33:52.976864+00:00",
+   "start_time": "2026-08-22T11:41:57.794661+00:00",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -200,7 +200,9 @@ flowchart TD
 | 2 | [GameTheory-2-NormalForm](GameTheory-2-NormalForm.ipynb) | Python | Matrices de gains, dominance, best response | 45 min |
 | 2b | [GameTheory-2b-Lean-Definitions](GameTheory-2b-Lean-Definitions.ipynb) | Lean 4 | Formalisation Game2x2, stratégies, Nash | 45 min |
 | 3 | [GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb) | Python | Classification Robinson-Goforth, table périodique | 55 min |
-| 3b | [GameTheory-3-Topology2x2-Csharp](GameTheory-3-Topology2x2-Csharp.ipynb) | C# (.NET) | **Jumeau C#** — topologie ordinale from-scratch : permutations, swaps de rangs, BFS swap-path, Nash, classification des 576 jeux (parité #4956) | 50 min |
+| 3 (C#) | [GameTheory-3-Topology2x2-Csharp](GameTheory-3-Topology2x2-Csharp.ipynb) | C# (.NET) | **Jumeau C#** — topologie ordinale from-scratch : permutations, swaps de rangs, BFS swap-path, Nash, classification des 576 jeux (parité #4956) | 50 min |
+| 3b | [GameTheory-3b-Chambres-et-Murs](GameTheory-3b-Chambres-et-Murs.ipynb) | Python | Chambres et murs (Bruns-Kimmich) : les 576 jeux stricts comme chambres d'un arrangement, les égalités comme murs de codimension — 75 ordres faibles, incidence double-face mur/chambre, BFS connexe diamètre 6, swaps en longueurs de Coxeter, make_tie/break_tie duales (chantier 4 #12207, versant D2) | 45 min |
+| 3c | [GameTheory-3c-Meta-Actions-Tarifees](GameTheory-3c-Meta-Actions-Tarifees.ipynb) | Python | Méta-actions tarifées : changer les règles comme action payante — NE/BR sur les 576 jeux (72 injouables), coût en échelons de rang avec seuil de migration 56→16→8→4 %, le Dilemme exactement indifférent à c=1, méta-jeu 4x4 où l'évasion conjointe du Dilemme EST un équilibre (3,3), 4 échecs de coordination dur (chantier 4 #12207, versant D4) | 45 min |
 | 4 | [GameTheory-4-NashEquilibrium](GameTheory-4-NashEquilibrium.ipynb) | Python | Nash pur/mixte, Lemke-Howson, analyse paramétrique | 60 min |
 | 4 (C#) | [GameTheory-4-NashEquilibrium-Csharp](GameTheory-4-NashEquilibrium-Csharp.ipynb) | .NET (C#) | Twin C# du 4 : **NE pur (best-response mutuelle) + mixte 2x2 (indifférence) + support enumeration from-scratch (élimination de Gauss)**, Matching Pennies/BoS/Stag Hunt/PD/RPS (See #4956) | 50 min |
 | 4b | [GameTheory-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) | Lean 4 | Brouwer, Kakutani, preuve existence Nash | 55 min |
@@ -269,10 +271,12 @@ La vague « strate 7 » étend la série au-delà du fil historique : chaque not
 |---|----------|--------|---------|-------|
 | 20 | [GameTheory-20-Commitment-Stackelberg](GameTheory-20-Commitment-Stackelberg.ipynb) | Python | Stackelberg : la performativité sans mystère — l'engagement contraignant qui **transforme la meilleure réponse d'autrui** (action sous-optimale à l'équilibre simultané, delta +2 mesuré), l'annonce révocable dissoute par induction à rebours (cheap talk), et le seuil de crédibilité **s\* = écart de tentation** (caution minimale calculée) | 40 min |
 | 21 | [GameTheory-21-Deux-Especes-de-Fleches](GameTheory-21-Deux-Especes-de-Fleches.ipynb) | Python | Deux espèces de flèches : le théorème fini du chemin minimal de swaps (un swap R(a,b) traverse un mur ssi colonne {a,b} ET mur habité — conjecture naïve réfutée sur 288 désaccords, condition vérifiée 3456/3456, comptage 432/576 dérivé) | 60 min |
+| 3b | [GameTheory-3b-Chambres-et-Murs](GameTheory-3b-Chambres-et-Murs.ipynb) | Python | Chambres et murs (Bruns-Kimmich, chantier 4 #12207 versant D2) : l'espace des jeux comme arrangement — 24 chambres × 24 = 576 jeux, les égalités comme murs de codimension (75 ordres faibles), incidence double-face mur/chambre, graphe des chambres connexe de diamètre 6, make_tie/break_tie duales | 45 min |
+| 3c | [GameTheory-3c-Meta-Actions-Tarifees](GameTheory-3c-Meta-Actions-Tarifees.ipynb) | Python | Méta-actions tarifées (chantier 4 #12207 versant D4) : changer les règles comme action payante — coût en échelons de rang, seuil de migration 56→16→8→4 % au sweep c=0..3, le Dilemme exactement indifférent à c=1, méta-jeu 4x4 où l'évasion conjointe EST un équilibre (3,3), 4 échecs de coordination dur (tous NE Pareto-dominés) | 45 min |
 
-> En livraison parallèle sur la même vague : 18 (open games et lentilles, #12212), 22 (manipulation Gibbard-Satterthwaite comme témoin, #12239), 23 (échange de reins, #12240) — issues ouvertes, fichiers pas encore sur `main`.
+> En livraison parallèle sur la même vague : 18 (open games et lentilles, #12212), 22 (manipulation Gibbard-Satterthwaite comme témoin, #12239), 23 (échange de reins, #12240) — issues ouvertes, fichiers pas encore sur `main`. Le chantier 4 (#12207) poursuit la vague : 3b livré, 3c livré ici, versants D1/D3 ouverts.
 
-**Durée totale** : ~28h25 (avec side tracks b/c, sous-série SocialChoice et Partie 4 livrée)
+**Durée totale** : ~29h55 (avec side tracks b/c, sous-série SocialChoice et Partie 4 livrée)
 
 ## Concepts clés
 
@@ -289,6 +293,7 @@ La vague « strate 7 » étend la série au-delà du fil historique : chaque not
 | **Théorème d'Arrow** | Impossibilité d'agrégation parfaite des préférences |
 | **Processus de Moran** | Dynamique stochastique d'évolution en population FINIE (Axelrod) — fixation d'une stratégie par dérive génétique, distincte du replicator déterministe mean-field |
 | **Stochastic finite-population fixation** | À population finie, le bruit d'échantillonnage peut fixer des stratégies sous-optimales (Defector 28 % sur 25 graines Moran, alors qu'il est dominé en round-robin) |
+| **Méta-action tarifée (strate 7)** | Réécrire ses propres préférences déclarées au prix d'échelons de rang — l'action de changer les règles a un coût, un seuil de migration et ses propres équilibres (GT-3c) |
 
 ## Ce que chaque notebook apporte
 
@@ -301,6 +306,8 @@ Chaque notebook introduit un concept ou un modèle spécifique. Le tableau ci-de
 | 1 | Setup | Installation Nashpy/OpenSpiel, premier dilemme du prisonnier |
 | 2 | NormalForm | Matrices de gains, dominance, meilleure réponse, équilibre pur |
 | 3 | Topology2x2 | Classification géométrique des 144 jeux 2x2 (Robinson-Goforth) |
+| 3b | Chambres-et-Murs | Les égalités comme objets géométriques : murs de codimension, incidence double-face, BFS du graphe des chambres |
+| 3c | Meta-Actions-Tarifees | Changer les règles comme action payante : seuil de migration, méta-jeu et évasion du Dilemme par équilibre |
 | 4 | NashEquilibrium | Nash mixte, Lemke-Howson, analyse paramétrique, support enumeration |
 | 5 | ZeroSum-Minimax | Théorème minimax, dualité LP, programmation linéaire pour jeux |
 | 6 | EvolutionTrust | Tournoi Axelrod, tit-for-tat, **processus de Moran (stochastic fixation finie vs replicator mean-field)** [#7594], émergence coopération |
@@ -317,6 +324,8 @@ Chaque notebook introduit un concept ou un modèle spécifique. Le tableau ci-de
 | 15 | CooperativeGames | Valeur de Shapley, Core, Bondareva-Shapley |
 | 16 | MechanismDesign | Principe de révélation, VCG (incl. non-monotonie du revenu), matching, enchères |
 | 17 | MultiAgent-RL | NFSP, PSRO, AlphaZero intro, lien vers RL |
+| 20 | Commitment-Stackelberg | La performativité sans mystère : l'engagement contraignant transforme la meilleure réponse d'autrui (seuil de crédibilité s\* mesuré) |
+| 21 | Deux-Especes-de-Fleches | Théorème fini du chemin minimal de swaps : préserver le monde vs le transformer (conjecture naïve réfutée, condition exacte) |
 
 ### Side tracks Lean 4 (formalisation)
 
@@ -622,6 +631,8 @@ Chaque notebook adopte la même trame pédagogique — introduction motivée, pl
 | 2 | NormalForm | ~25 | 3 | **COMPLET** |
 | 2b | Lean-Definitions | ~25 | 3 | **COMPLET** |
 | 3 | Topology2x2 | ~30 | 3 | **COMPLET** |
+| 3b | Chambres-et-Murs | ~38 | 3 | **NOUVEAU** (chantier 4 #12207) |
+| 3c | Meta-Actions-Tarifees | ~30 | 3 | **NOUVEAU** (chantier 4 #12207) |
 | 4 | NashEquilibrium | ~35 | 3 | **COMPLET** |
 | 4b | Lean-NashExistence | ~20 | 3 | **COMPLET** |
 | 4c | NashExistence-Python | ~20 | 2 | **COMPLET** |
@@ -649,6 +660,8 @@ Chaque notebook adopte la même trame pédagogique — introduction motivée, pl
 | SC-03 | Voting-Methods | ~43 | 3 | **COMPLET** |
 | SC-04 | Computational-Aggregation-SAT-Z3 | ~66 | 2 | **COMPLET** |
 | 17 | MultiAgent-RL | ~35 | 3 | **COMPLET** |
+| 20 | Commitment-Stackelberg | ~18 | 3 | **NOUVEAU** (strate 7) |
+| 21 | Deux-Especes-de-Fleches | ~30 | 3 | **NOUVEAU** (strate 7) |
 
 **Jumeaux C#** : le tableau ci-dessus liste les notebooks Python/Lean de référence. Chaque notebook du fil principal (GT-2 à GT-17, plus 4c/6c/8c/15c et SC-01/SC-03/SC-04) dispose en outre d'un **jumeau C#** (`*-Csharp.ipynb`, 23 jumeaux distincts — 24 fichiers `.ipynb` en comptant la tranche `Part2` du GT-2) livré par le marathon parité #4956 — algorithmes from-scratch en BCL .NET 9, voir la section « Parité .NET » en tête de fichier.
 

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -202,7 +202,7 @@ flowchart TD
 | 3 | [GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb) | Python | Classification Robinson-Goforth, table périodique | 55 min |
 | 3 (C#) | [GameTheory-3-Topology2x2-Csharp](GameTheory-3-Topology2x2-Csharp.ipynb) | C# (.NET) | **Jumeau C#** — topologie ordinale from-scratch : permutations, swaps de rangs, BFS swap-path, Nash, classification des 576 jeux (parité #4956) | 50 min |
 | 3b | [GameTheory-3b-Chambres-et-Murs](GameTheory-3b-Chambres-et-Murs.ipynb) | Python | Chambres et murs (Bruns-Kimmich) : les 576 jeux stricts comme chambres d'un arrangement, les égalités comme murs de codimension — 75 ordres faibles, incidence double-face mur/chambre, BFS connexe diamètre 6, swaps en longueurs de Coxeter, make_tie/break_tie duales (chantier 4 #12207, versant D2) | 45 min |
-| 3c | [GameTheory-3c-Meta-Actions-Tarifees](GameTheory-3c-Meta-Actions-Tarifees.ipynb) | Python | Méta-actions tarifées : changer les règles comme action payante — NE/BR sur les 576 jeux (72 injouables), coût en échelons de rang avec seuil de migration 56→16→8→4 %, le Dilemme exactement indifférent à c=1, méta-jeu 4x4 où l'évasion conjointe du Dilemme EST un équilibre (3,3), 4 échecs de coordination dur (chantier 4 #12207, versant D4) | 45 min |
+| 3e | [GameTheory-3e-Meta-Actions-Tarifees](GameTheory-3e-Meta-Actions-Tarifees.ipynb) | Python | Méta-actions tarifées : changer les règles comme action payante — NE/BR sur les 576 jeux (72 injouables), coût en échelons de rang avec seuil de migration 56→16→8→4 %, le Dilemme exactement indifférent à c=1, méta-jeu 4x4 où l'évasion conjointe du Dilemme EST un équilibre (3,3), 4 échecs de coordination dur (chantier 4 #12207, versant D4) | 45 min |
 | 4 | [GameTheory-4-NashEquilibrium](GameTheory-4-NashEquilibrium.ipynb) | Python | Nash pur/mixte, Lemke-Howson, analyse paramétrique | 60 min |
 | 4 (C#) | [GameTheory-4-NashEquilibrium-Csharp](GameTheory-4-NashEquilibrium-Csharp.ipynb) | .NET (C#) | Twin C# du 4 : **NE pur (best-response mutuelle) + mixte 2x2 (indifférence) + support enumeration from-scratch (élimination de Gauss)**, Matching Pennies/BoS/Stag Hunt/PD/RPS (See #4956) | 50 min |
 | 4b | [GameTheory-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) | Lean 4 | Brouwer, Kakutani, preuve existence Nash | 55 min |
@@ -272,9 +272,9 @@ La vague « strate 7 » étend la série au-delà du fil historique : chaque not
 | 20 | [GameTheory-20-Commitment-Stackelberg](GameTheory-20-Commitment-Stackelberg.ipynb) | Python | Stackelberg : la performativité sans mystère — l'engagement contraignant qui **transforme la meilleure réponse d'autrui** (action sous-optimale à l'équilibre simultané, delta +2 mesuré), l'annonce révocable dissoute par induction à rebours (cheap talk), et le seuil de crédibilité **s\* = écart de tentation** (caution minimale calculée) | 40 min |
 | 21 | [GameTheory-21-Deux-Especes-de-Fleches](GameTheory-21-Deux-Especes-de-Fleches.ipynb) | Python | Deux espèces de flèches : le théorème fini du chemin minimal de swaps (un swap R(a,b) traverse un mur ssi colonne {a,b} ET mur habité — conjecture naïve réfutée sur 288 désaccords, condition vérifiée 3456/3456, comptage 432/576 dérivé) | 60 min |
 | 3b | [GameTheory-3b-Chambres-et-Murs](GameTheory-3b-Chambres-et-Murs.ipynb) | Python | Chambres et murs (Bruns-Kimmich, chantier 4 #12207 versant D2) : l'espace des jeux comme arrangement — 24 chambres × 24 = 576 jeux, les égalités comme murs de codimension (75 ordres faibles), incidence double-face mur/chambre, graphe des chambres connexe de diamètre 6, make_tie/break_tie duales | 45 min |
-| 3c | [GameTheory-3c-Meta-Actions-Tarifees](GameTheory-3c-Meta-Actions-Tarifees.ipynb) | Python | Méta-actions tarifées (chantier 4 #12207 versant D4) : changer les règles comme action payante — coût en échelons de rang, seuil de migration 56→16→8→4 % au sweep c=0..3, le Dilemme exactement indifférent à c=1, méta-jeu 4x4 où l'évasion conjointe EST un équilibre (3,3), 4 échecs de coordination dur (tous NE Pareto-dominés) | 45 min |
+| 3e | [GameTheory-3e-Meta-Actions-Tarifees](GameTheory-3e-Meta-Actions-Tarifees.ipynb) | Python | Méta-actions tarifées (chantier 4 #12207 versant D4) : changer les règles comme action payante — coût en échelons de rang, seuil de migration 56→16→8→4 % au sweep c=0..3, le Dilemme exactement indifférent à c=1, méta-jeu 4x4 où l'évasion conjointe EST un équilibre (3,3), 4 échecs de coordination dur (tous NE Pareto-dominés) | 45 min |
 
-> En livraison parallèle sur la même vague : 18 (open games et lentilles, #12212), 22 (manipulation Gibbard-Satterthwaite comme témoin, #12239), 23 (échange de reins, #12240) — issues ouvertes, fichiers pas encore sur `main`. Le chantier 4 (#12207) poursuit la vague : 3b livré, 3c livré ici, versants D1/D3 ouverts.
+> En livraison parallèle sur la même vague : 18 (open games et lentilles, #12212), 22 (manipulation Gibbard-Satterthwaite comme témoin, #12239), 23 (échange de reins, #12240) — issues ouvertes, fichiers pas encore sur `main`. Le chantier 4 (#12207) poursuit la vague : 3b livré, 3e livré ici (le 3c « Le Joueur LLM » et le 3d « Plan de déformation » sont en livraison parallèle sur d'autres lanes), versants D1/D3 ouverts.
 
 **Durée totale** : ~29h55 (avec side tracks b/c, sous-série SocialChoice et Partie 4 livrée)
 
@@ -307,7 +307,7 @@ Chaque notebook introduit un concept ou un modèle spécifique. Le tableau ci-de
 | 2 | NormalForm | Matrices de gains, dominance, meilleure réponse, équilibre pur |
 | 3 | Topology2x2 | Classification géométrique des 144 jeux 2x2 (Robinson-Goforth) |
 | 3b | Chambres-et-Murs | Les égalités comme objets géométriques : murs de codimension, incidence double-face, BFS du graphe des chambres |
-| 3c | Meta-Actions-Tarifees | Changer les règles comme action payante : seuil de migration, méta-jeu et évasion du Dilemme par équilibre |
+| 3e | Meta-Actions-Tarifees | Changer les règles comme action payante : seuil de migration, méta-jeu et évasion du Dilemme par équilibre |
 | 4 | NashEquilibrium | Nash mixte, Lemke-Howson, analyse paramétrique, support enumeration |
 | 5 | ZeroSum-Minimax | Théorème minimax, dualité LP, programmation linéaire pour jeux |
 | 6 | EvolutionTrust | Tournoi Axelrod, tit-for-tat, **processus de Moran (stochastic fixation finie vs replicator mean-field)** [#7594], émergence coopération |
@@ -632,7 +632,7 @@ Chaque notebook adopte la même trame pédagogique — introduction motivée, pl
 | 2b | Lean-Definitions | ~25 | 3 | **COMPLET** |
 | 3 | Topology2x2 | ~30 | 3 | **COMPLET** |
 | 3b | Chambres-et-Murs | ~38 | 3 | **NOUVEAU** (chantier 4 #12207) |
-| 3c | Meta-Actions-Tarifees | ~30 | 3 | **NOUVEAU** (chantier 4 #12207) |
+| 3e | Meta-Actions-Tarifees | ~30 | 3 | **NOUVEAU** (chantier 4 #12207) |
 | 4 | NashEquilibrium | ~35 | 3 | **COMPLET** |
 | 4b | Lean-NashExistence | ~20 | 3 | **COMPLET** |
 | 4c | NashExistence-Python | ~20 | 2 | **COMPLET** |


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/notebook-lean #12306

See #12207 (chantier 4 — versant D4 ; D1/D3 restent ouverts)

## Summary

Nouveau notebook `GameTheory-3e-Meta-Actions-Tarifees.ipynb` (30 cellules, 12 code, kernel python3, **stdlib pur, déterministe**) : le versant D4 du chantier 4 — l'agent qui joue (NE/BR), puis l'agent qui **change les règles** (méta-actions tarifées en échelons de rang), puis deux agents en désaccord sur les règles (méta-jeu 4x4). Le substrat est repris tel quel de GT-3b (`swap_val`, 24 chambres, 576 jeux, PD = ((3,1,4,2),(3,4,1,2))).

| Marche de l'issue (D4) | Mesure dans le notebook |
|---|---|
| **M1 — l'agent qui joue** | NE purs + BR alternée sur les 576 jeux : distribution {0:72, 1:432, 2:72} (72 jeux injouables sans NE pur, cycle BR exhibé sur ((2,3,1,4),(1,2,4,3))), croisement exact NE statique vs dynamique (504 ok / 72 cycle) |
| **M2 — l'agent qui déplace le jeu** | BFS du graphe de Cayley des 24 tables **depuis la table propre de chaque jeu** (générateurs R1-R3), gain net = rang final − c·distance, sweep c=0..3 : migration 56 % → 16 % → 8 % → 4 %, seuil monotone ; le Dilemme est **exactement indifférent à c=1** (fuite rang 2→3 à d=1, net 2 ; rang 2→4 à d=2, net 2 — le gain de fuite est entièrement mangé par le coût) ; à c=1 : 96 migrants dont 72 réfugiés fuyant un cycle, opportuniste rang 2→4 en 1 swap, 48/72 injouables réparables en 1 swap |
| **M3 — deux agents en désaccord** | Méta-jeu 4x4 (chacun : rester/R1/R2/R3, ne réécrit que SA table, paie ses échelons) : 572/576 jeux avec méta-NE ; sur le Dilemme lui-même, **5 NE dont (R3,C3) qui paie (3,3)** vs (2,2) statu quo — l'évasion conjointe EST un équilibre, l'évasion unilatérale paie (1,2)/(2,1) ; Pareto honnête : 568 jeux avec ≥1 NE Pareto-optimal, **4 échecs de coordination dur** (tous NE Pareto-dominés, exemple ((1,3,2,4),(3,4,2,1)) : tous NE à (2,2), frontière à (4,1)/(3,3) — jonction directe avec GT-20 : c'est là que l'engagement entre) |

3 exercices C.1 stubbés (`resultat_exN = None  # TODO etudiant`) : sweep côté Colonne, sélection d'équilibre déplaçable, méta-jeu séquentiel (les 4 échecs durs se referment-ils ?).

## Validation

- **Execution** : `scripts/notebook_tools/wsl_papermill.py execute` — **12/12 cellules code, 0 erreur**, séquence [1..12], outputs committés (C.2).
- **C.1** : 0 violation (`raise NotImplementedError` / `assert False` / `1/0`).
- **Densité** : 1263 caractères prose / cellule code (seuil 1200).
- **Ancrage prose↔outputs** : audit des outputs AVANT commit — 3 corrections appliquées (l'exemple migrant de M2 était un réfugié 0→3, pas l'opportuniste 2→4 annoncé → sortie scindée réfugié/opportuniste ; la note d'évasion unilatérale citait une ligne "(−1)" inexistante → remplacée par les gains réels (1,2)/(2,1) ; coquille "moinde"). Leçon MGS-5/MGS-6 appliquée.
- **Navlinks** : 5/5 résolus (GT-3, GT-3b, GT-20, GT-21, README série).
- **Exactitude** : tous les chiffres calculés offline AVANT la prose (script de vérification scratchpad), énumération exhaustive exacte des 576 jeux, aucun sampling.

## SOTA (§H)

L'instrument de mesure EST l'énumération exhaustive exacte (576 jeux × 24 tables × BFS borné — stdlib pur, déterministe, aucune approximation). Verdict **SOTA-OK**. Limites documentées dans le notebook : coûts linéaires en échelons (d'autres tarifs changent les seuils), méta-jeu restreint aux swaps adjacents simples (pas des réécritures arbitraires), convention injouable = 0.

## README série GameTheory (audit fichier entier, règle §E)

- **Table de structure** : correction d'une **collision de label préexistante** — le jumeau C# étiqueté « 3b » est renuméroté « 3 (C#) » (convention déjà utilisée par « 4 (C#) », « 5 (C#) »), et le **vrai 3b (Chambres-et-Murs, livré #12253 mais jamais inscrit)** est ajouté ; ligne 3e ajoutée.
- **Partie 4 (strate 7)** : lignes 3b + 3e ajoutées au tableau de la vague, note de livraison parallèle mise à jour (D1/D3 ouverts).
- **« Ce que chaque notebook apporte »** : +4 lignes (3b, 3e, 20, 21 — résidu déclaré au cycle 13, réconcilié ici).
- **Table maturité** : +4 lignes (3b ~38 cellules/3 exos, 3e ~30/3, 20 ~18/3, 21 ~30/3), comptages mesurés mécaniquement.
- **Concepts clés** : + méta-action tarifée.
- **Durée totale** : ~28h25 → **~29h55** (+3b, +3e).
- **CATALOG-STATUS byte-identique** (vérifié par diff) — inscription du nouveau notebook laissée au bot `catalog-drift` / cron.

## Scope

2 fichiers : le notebook + le README de série. Aucun autre fichier touché.

## Renumerotation 3c -> 3e (commit f1911b68ed)

Le slot **3c etait deja pris** : `GameTheory-3c-Le-Joueur-LLM.ipynb` (PR #12295, lane myia-po-2023:CoursIA-2, versant D6 du meme chantier, ouverte avant notre claim) et le **3d** par le plan de deformation (PR #12284). Le notebook livre ici est donc **renumerote 3e** : fichier regenere, re-execute (12/12, 0 erreur, batterie re-passee : densite 1263, C.1 clean, navlinks 4/4), README aligne (les deux lignes 3c + note de livraison parallele citent desormais le 3c joueur-LLM et le 3d comme lanes paralleles).
