### PR TITLE
feat(lean,#12223): notebook Lean-16g Conway-Canons -- barreau 2, source periodique

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16g-Conway-Canons.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16g-Conway-Canons.ipynb
@@ -1,0 +1,1011 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002727,
+     "end_time": "2026-08-22T12:24:24.120975+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:24:24.118248+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Lean 16g — Canons : le barreau 2 de l'échelle des témoins Life\n",
+    "\n",
+    "Le dépôt sait **vérifier** une structure du Jeu de la Vie : le lake `conway_lean` prouve\n",
+    "`evolve 8 glider = shift (2, -2) glider` par `decide`\n",
+    "(`conway_lean/Conway/Life/Computation.lean:176`). Il ne sait pas encore **construire** :\n",
+    "étant donné une propriété, produire une configuration qui la satisfait.\n",
+    "\n",
+    "Ce notebook franchit un barreau de cette échelle — le barreau 2, et lui seul :\n",
+    "\n",
+    "| Barreau | Demande | État |\n",
+    "|---|---|---|\n",
+    "| 1 | une **quasi-particule** — configuration à translation périodique (le planeur) | vérifié côté lake |\n",
+    "| **2** | une **source périodique** — configuration bornée émettant périodiquement un vaisseau | **ce notebook** |\n",
+    "| 3 | une configuration réalisant le graphe d'un automate fini | hors d'atteinte, nommé tel quel |\n",
+    "| 4 | une configuration émulant une machine de Turing | hors d'atteinte, nommé tel quel |\n",
+    "\n",
+    "**Vocabulaire.** Le planeur est une *quasi-particule* : une excitation localisée qui se propage.\n",
+    "Un flux de planeurs est un *faisceau de quasi-particicles*. Le canon de Gosper est une\n",
+    "*source périodique* : un noyau borné qui, chaque période, détache une quasi-particule du\n",
+    "même type. Ce vocabulaire décrit ce que l'objet **est** ; il remplace toute notation\n",
+    "grecque par principe (le grep du dépôt ne trouve d'ailleurs nulle notation `alpha`/`gamma`\n",
+    "en vigueur sur les objets Life — seuls un paramètre matplotlib et l'univers de types `α`\n",
+    "de Lean portent ces lettres : la nomenclature ci-dessus s'applique d'emblée).\n",
+    "\n",
+    "Sous-série Conway : `16a` (l'homme et l'œuvre), `16b` (Life en Lean), `16c` (Golly),\n",
+    "`16d` (native), `16e` (FRACTRAN), `16f` (théorème du libre arbitre). Ici : [16b](Lean-16b-Conway-Game-of-Life-Lean.ipynb)\n",
+    "pose le substrat `Grid`/`evolve` que nous citons ; le [README de la série](README.md) situe l'ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T12:24:24.126640Z",
+     "iopub.status.busy": "2026-08-22T12:24:24.126455Z",
+     "iopub.status.idle": "2026-08-22T12:24:24.136665Z",
+     "shell.execute_reply": "2026-08-22T12:24:24.136004Z"
+    },
+    "papermill": {
+     "duration": 0.013735,
+     "end_time": "2026-08-22T12:24:24.137195+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:24:24.123460+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "formes de quasi-particule reconnues (4 directions x 4 phases) : 16\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, str(Path.cwd()))\n",
+    "from lean_notebook_utils import (\n",
+    "    find_lean_project, get_lean_project_path, run_lake, run_lean_snippet,\n",
+    ")\n",
+    "import random\n",
+    "from collections import Counter\n",
+    "\n",
+    "# --- Moteur Life Python (stdlib pur, deterministe) ---\n",
+    "def step(cells):\n",
+    "    s = set(cells)\n",
+    "    cnt = Counter()\n",
+    "    for (x, y) in s:\n",
+    "        for dx in (-1, 0, 1):\n",
+    "            for dy in (-1, 0, 1):\n",
+    "                if dx or dy:\n",
+    "                    cnt[(x + dx, y + dy)] += 1\n",
+    "    return sorted((x, y) for (x, y), n in cnt.items()\n",
+    "                  if n == 3 or (n == 2 and (x, y) in s))\n",
+    "\n",
+    "def islands(cells):\n",
+    "    s = set(cells); seen = set(); out = []\n",
+    "    for c in s:\n",
+    "        if c in seen: continue\n",
+    "        comp, stack = [], [c]; seen.add(c)\n",
+    "        while stack:\n",
+    "            (x, y) = stack.pop(); comp.append((x, y))\n",
+    "            for dx in (-1, 0, 1):\n",
+    "                for dy in (-1, 0, 1):\n",
+    "                    n = (x + dx, y + dy)\n",
+    "                    if n in s and n not in seen:\n",
+    "                        seen.add(n); stack.append(n)\n",
+    "        out.append(sorted(comp))\n",
+    "    return out\n",
+    "\n",
+    "def norm(isl):\n",
+    "    mx = min(a for a, b in isl); my = min(b for a, b in isl)\n",
+    "    return sorted((a - mx, b - my) for a, b in isl)\n",
+    "\n",
+    "# Le planeur canonique du lake (Conway.Life.glider) et ses 3 phases suivantes,\n",
+    "# puis les miroirs : 4 directions x 4 phases = 16 formes normalisees.\n",
+    "g0 = [(0, 0), (1, 0), (1, 2), (2, 0), (2, 1)]\n",
+    "def flipx(isl): return sorted((-a, b) for a, b in isl)\n",
+    "def flipy(isl): return sorted((a, -b) for a, b in isl)\n",
+    "GLIDER_FORMS = set()\n",
+    "for start in (g0, flipx(g0), flipy(g0), flipx(flipy(g0))):\n",
+    "    g = start\n",
+    "    for _ in range(4):\n",
+    "        GLIDER_FORMS.add(tuple(norm(g))); g = step(g)\n",
+    "print(\"formes de quasi-particule reconnues (4 directions x 4 phases) :\", len(GLIDER_FORMS))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002159,
+     "end_time": "2026-08-22T12:24:24.141908+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:24:24.139749+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Le substrat : ce qui est déjà vérifié, et où est le trou\n",
+    "\n",
+    "La cellule suivante importe le motif du canon **depuis le lake lui-même** — le RLE du\n",
+    "canon de Gosper est encodé dans `conway_lean/Conway/Life/RLE.lean:268` avec sa grille\n",
+    "analysée `gosper_gun : Grid` (36 cellules vivantes). Nous recopions le corps RLE et le\n",
+    "décodons côté Python avec le même algorithme run-length que `parseRLE` : les deux\n",
+    "définitions du dépôt et du notebook parlent du même objet — à une convention près,\n",
+    "pédagogiquement utile : le lake encodie une cellule comme un couple **(ligne, colonne)**\n",
+    "(`RLE.lean` inverse le corps run-length « pour retrouver l'ordre d'insertion row-major »),\n",
+    "tandis que notre décodeur Python produit (colonne, ligne). Même motif, miroir de\n",
+    "coordonnées — un mini-exercice de recoordonnancement avant le gros.\n",
+    "\n",
+    "Ce que le lake **prouve** déjà (côté vérificateur) :\n",
+    "- `evolve 8 glider = shift (2, -2) glider`, par `decide` — la quasi-particule se déplace\n",
+    "  d'une cellule en diagonale toutes les 4 générations (`Computation.lean:176`) ;\n",
+    "- `gosper_gun_parse_ok` et `gosper_gun_cell_count : gosper_gun.length = 36` (`RLE.lean:332-343`).\n",
+    "\n",
+    "Ce que personne n'a encore : une **définition vérifiable de « source périodique »**,\n",
+    "mesurée sur le vrai canon, puis un **certificat** évaluable. C'est le barreau 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T12:24:24.146975Z",
+     "iopub.status.busy": "2026-08-22T12:24:24.146809Z",
+     "iopub.status.idle": "2026-08-22T12:24:24.151890Z",
+     "shell.execute_reply": "2026-08-22T12:24:24.151287Z"
+    },
+    "papermill": {
+     "duration": 0.008404,
+     "end_time": "2026-08-22T12:24:24.152390+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:24:24.143986+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cellules du canon : 36 (RLE.lean:343 attend 36)\n",
+      "boite englobante : x 0 .. 35 , y 0 .. 8\n",
+      "\n",
+      "........................O...........\n",
+      "......................O.O...........\n",
+      "............OO......OO............OO\n",
+      "...........O...O....OO............OO\n",
+      "OO........O.....O...OO..............\n",
+      "OO........O...O.OO....O.O...........\n",
+      "..........O.....O.......O...........\n",
+      "...........O...O....................\n",
+      "............OO......................\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Corps RLE du canon (identique a RLE.lean:268, sans l'en-tete de commentaires)\n",
+    "GUN_RLE_BODY = (\"24bo11b$22bobo11b$12b2o6b2o12b2o$11bo3bo4b2o12b2o\"\n",
+    "                \"$2o8bo5bo3b2o14b$2o8bo3bob2o4bobo11b$10bo5bo7bo11b\"\n",
+    "                \"$11bo3bo20b$12b2o!\")\n",
+    "\n",
+    "def parse_rle_body(body):\n",
+    "    cells, x, y, num = [], 0, 0, \"\"\n",
+    "    for ch in body:\n",
+    "        if ch.isdigit(): num += ch\n",
+    "        elif ch == \"b\": x += int(num or 1); num = \"\"\n",
+    "        elif ch == \"o\":\n",
+    "            for i in range(int(num or 1)): cells.append((x + i, y))\n",
+    "            x += int(num or 1); num = \"\"\n",
+    "        elif ch == \"$\": y += int(num or 1); x = 0; num = \"\"\n",
+    "        elif ch == \"!\": break\n",
+    "    return sorted(set(cells))\n",
+    "\n",
+    "GUN = parse_rle_body(GUN_RLE_BODY)\n",
+    "X0, X1 = min(a for a, b in GUN), max(a for a, b in GUN)\n",
+    "Y0, Y1 = min(b for a, b in GUN), max(b for a, b in GUN)\n",
+    "print(\"cellules du canon :\", len(GUN), \"(RLE.lean:343 attend 36)\")\n",
+    "print(\"boite englobante : x\", X0, \"..\", X1, \", y\", Y0, \"..\", Y1)\n",
+    "print()\n",
+    "grid = {c: \"O\" for c in GUN}\n",
+    "for y in range(Y0, Y1 + 1):\n",
+    "    print(\"\".join(grid.get((x, y), \".\") for x in range(X0, X1 + 1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c05",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002085,
+     "end_time": "2026-08-22T12:24:24.156602+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:24:24.154517+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 — Reconnaître : période, transitoire, classe émise\n",
+    "\n",
+    "Une *source périodique* de période $p$ est la conjonction de deux faits mesurables :\n",
+    "\n",
+    "1. **le noyau est périodique** : la partie de la configuration qui intersecte la boîte\n",
+    "   du motif initial revient identique à elle-même toutes les $p$ générations (sans\n",
+    "   translation — le noyau ne dérive pas) ;\n",
+    "2. **l'émission est synchrone avec la période** : à chaque fenêtre de $p$ générations,\n",
+    "   une nouvelle quasi-particule s'est détachée du noyau et s'éloigne.\n",
+    "\n",
+    "Historique : Bill Gosper (MIT, novembre 1970) répond au défi de Conway — 50 USD pour un\n",
+    "motif fini à croissance non bornée. Le canon est le **premier** objet de ce type jamais\n",
+    "trouvé ; il a déclenché la recherche de constructions auto-réplicants qui culmine avec\n",
+    "Gemini (Wade, 2010). Voir `RLE.lean:213-219` pour la même histoire contée par le lake."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T12:24:24.162135Z",
+     "iopub.status.busy": "2026-08-22T12:24:24.161978Z",
+     "iopub.status.idle": "2026-08-22T12:24:24.189129Z",
+     "shell.execute_reply": "2026-08-22T12:24:24.188519Z"
+    },
+    "papermill": {
+     "duration": 0.030763,
+     "end_time": "2026-08-22T12:24:24.189754+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:24:24.158991+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "periode du noyau : 30\n",
+      "noyau cyclique des t=0 : True\n",
+      "taille du noyau (t=0, 30, 60, 90) : [36, 36, 36, 36]\n",
+      "premiere apparition de chaque quasi-particule : {1: 28, 2: 58, 3: 88, 4: 118}\n",
+      "cadences entre emissions : [30, 30, 30]\n",
+      "centre de masse de la 1re quasi-particule, t=34..39 : {34: (24.8, 11.2), 35: (25.2, 11.4), 36: (25.2, 11.8), 37: (25.4, 12.2), 38: (25.8, 12.2), 39: (26.2, 12.4)}\n",
+      "population totale (t=0,30,60,90,120) : [36, 41, 46, 51, 56]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def core(cells):\n",
+    "    \"\"\"Noyau = iles qui INTERSECTENT la boite du canon a t=0.\n",
+    "    Les quasi-particules emises sont des iles disjointes, hors boite.\"\"\"\n",
+    "    parts = [isl for isl in islands(cells)\n",
+    "             if any(X0 <= a <= X1 and Y0 <= b <= Y1 for (a, b) in isl)]\n",
+    "    return sorted(c for isl in parts for c in isl)\n",
+    "\n",
+    "def gliders_out(cells):\n",
+    "    out = [(a, b) for (a, b) in cells if not (X0 <= a <= X1 and Y0 <= b <= Y1)]\n",
+    "    return [isl for isl in islands(out) if tuple(norm(isl)) in GLIDER_FORMS]\n",
+    "\n",
+    "hist = [GUN]\n",
+    "for t in range(1, 121):\n",
+    "    hist.append(step(hist[-1]))\n",
+    "\n",
+    "c0 = core(hist[0])\n",
+    "periode = next(p for p in range(1, 61) if core(hist[p]) == c0)\n",
+    "print(\"periode du noyau :\", periode)\n",
+    "print(\"noyau cyclique des t=0 :\", core(hist[30]) == c0 and core(hist[60]) == c0 and core(hist[90]) == c0)\n",
+    "print(\"taille du noyau (t=0, 30, 60, 90) :\", [len(core(hist[t])) for t in (0, 30, 60, 90)])\n",
+    "\n",
+    "premiers = {}\n",
+    "for t in range(1, 121):\n",
+    "    for k in range(1, len(gliders_out(hist[t])) + 1):\n",
+    "        premiers.setdefault(k, t)\n",
+    "print(\"premiere apparition de chaque quasi-particule :\", dict(sorted(premiers.items())))\n",
+    "cadences = [premiers[k + 1] - premiers[k] for k in range(1, 4)]\n",
+    "print(\"cadences entre emissions :\", cadences)\n",
+    "\n",
+    "pos = {}\n",
+    "for t in range(34, 47):\n",
+    "    gls = gliders_out(hist[t])\n",
+    "    if gls:\n",
+    "        cx = sum(a for a, b in gls[0]) / len(gls[0])\n",
+    "        cy = sum(b for a, b in gls[0]) / len(gls[0])\n",
+    "        pos[t] = (round(cx, 1), round(cy, 1))\n",
+    "print(\"centre de masse de la 1re quasi-particule, t=34..39 :\", {t: pos[t] for t in sorted(pos)[:6]})\n",
+    "print(\"population totale (t=0,30,60,90,120) :\", [len(hist[t]) for t in (0, 30, 60, 90, 120)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c07",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002446,
+     "end_time": "2026-08-22T12:24:24.194652+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:24:24.192206+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : une horloge à quasi-particules\n",
+    "\n",
+    "- **Période 30, transitoire 0** : la phase encodée par le RLE est déjà *sur* le cycle —\n",
+    "  le noyau de 36 cellules revient à lui-même exactement toutes les 30 générations, sans\n",
+    "  jamais dériver.\n",
+    "- **Cadence d'émission exactement 30** : les détachements surviennent à $t = 28, 58, 88, 118$\n",
+    "  (la première quasi-particule met 28 générations à devenir une île disjointe ; ensuite,\n",
+    "  chaque période en détache une nouvelle). Émission et période du noyau sont **une seule\n",
+    "  horloge**.\n",
+    "- **Classe émise : planeur diagonal c/4** — le centre de masse avance de $(+1{,}4, +1{,}2)$\n",
+    "  en 5 générations, soit environ une case diagonale toutes les 4 générations, la vitesse\n",
+    "  du planeur prouvée par le lake (`Computation.lean:176` : 8 générations → translation $(2,-2)$).\n",
+    "- **Croissance non bornée depuis un objet fini** : la population passe de 36 à\n",
+    "  $36 + 5\\lfloor t/30 \\rfloor$ — chaque période ajoute 5 cellules qui ne reviendront jamais.\n",
+    "\n",
+    "Reconnaître a coûté $p \\times H$ pas de simulation (ici $30 \\times 120$) : c'est un\n",
+    "**budget**, pas un mystère."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c08",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002248,
+     "end_time": "2026-08-22T12:24:24.199381+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:24:24.197133+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 — Générer : une recherche bornée, et son résultat honnête\n",
+    "\n",
+    "Le geste inverse — *produire* une source périodique au lieu de la constater — est d'une\n",
+    "autre nature. Reconnaître est décidable en $O(pH)$ une fois le candidat donné ; construire\n",
+    "exige de chercher dans $2^{k^2}$ boîtes de $k \\times k$. C'est exactement l'écart\n",
+    "**vérificateur → constructeur** (la Loi II du chantier #12205).\n",
+    "\n",
+    "Protocole, énoncé avant le tirage :\n",
+    "\n",
+    "- **Budget** : 3 000 soupes aléatoires déterministes (graines 0..2999), boîte $12 \\times 12$,\n",
+    "  densité 0,35, horizon 240 générations — soit au plus 720 000 pas de simulation\n",
+    "  (maj oration ; la détection de cycle anticipe l'arrêt).\n",
+    "- **Détection en deux phases** : (1) le noyau (cellules dans la boîte + marge 2,\n",
+    "  normalisées par translation) entre-t-il dans un cycle de période $p$ ? (2) après\n",
+    "  l'entrée en cycle, une **nouvelle** quasi-particule apparaît-elle dans chacune des\n",
+    "  3 fenêtres suivantes de durée $p$ ? Une explosion transitoire qui jette des planeurs\n",
+    "  puis se stabilise n'est **pas** une source : ses émissions précèdent le cycle.\n",
+    "- **Résultat attendu** : inconnu. Le résultat honnête peut être « aucune dans ce\n",
+    "  budget » — et ce sera une *mesure*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T12:24:24.204733Z",
+     "iopub.status.busy": "2026-08-22T12:24:24.204571Z",
+     "iopub.status.idle": "2026-08-22T12:25:46.968322Z",
+     "shell.execute_reply": "2026-08-22T12:25:46.967326Z"
+    },
+    "papermill": {
+     "duration": 82.769741,
+     "end_time": "2026-08-22T12:25:46.971308+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:24:24.201567+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "budget : 3000 soupes, boite 12x12, densite 0.35, horizon 240\n",
+      "classification : {'eteint': 197, 'stable': 1387, 'oscillateur': 1155, 'indecis': 261}\n",
+      "periodes des oscillateurs : {2: 1048, 3: 28, 4: 51, 5: 5, 6: 5, 7: 1, 8: 3, 9: 1, 10: 3, 13: 1, 14: 1, 15: 1, 16: 2, 18: 1, 20: 1, 21: 1, 32: 1, 131: 1}\n",
+      "soupes ayant emis >= 1 quasi-particule (transitoire compris) : 1220 / 3000\n",
+      "SOURCES periodiques trouvees : 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "def classify_soup(seed, box=12, density=0.35, horizon=240):\n",
+    "    rng = random.Random(seed)\n",
+    "    cells = [(x, y) for x in range(box) for y in range(box) if rng.random() < density]\n",
+    "    seen, emitted, m = {}, 0, 2\n",
+    "    cur = sorted(cells)\n",
+    "    def count_qp(state):\n",
+    "        out = [(a, b) for (a, b) in state\n",
+    "               if not (-m <= a < box + m and -m <= b < box + m)]\n",
+    "        return len([isl for isl in islands(out) if tuple(norm(isl)) in GLIDER_FORMS])\n",
+    "    for t in range(1, horizon + 1):\n",
+    "        cur = step(cur)\n",
+    "        emitted = max(emitted, count_qp(cur))\n",
+    "        inside = sorted((a, b) for (a, b) in cur\n",
+    "                        if -m <= a < box + m and -m <= b < box + m)\n",
+    "        if not inside:\n",
+    "            return (\"eteint\", 0, emitted, False)\n",
+    "        key = tuple(norm(inside))\n",
+    "        if key in seen:\n",
+    "            p = t - seen[key]\n",
+    "            kind = \"stable\" if p == 1 else \"oscillateur\"\n",
+    "            counts = [count_qp(cur)]\n",
+    "            st = cur\n",
+    "            for _ in range(p): st = step(st)\n",
+    "            for _ in range(3):\n",
+    "                counts.append(count_qp(st))\n",
+    "                for _ in range(p): st = step(st)\n",
+    "            periodique = all(counts[i + 1] > counts[i] for i in range(3))\n",
+    "            return (kind, p, emitted, periodique)\n",
+    "        seen[key] = t\n",
+    "    return (\"indecis\", None, emitted, False)\n",
+    "\n",
+    "stats, osc_ps, emit_any, sources = Counter(), Counter(), 0, 0\n",
+    "N = 3000\n",
+    "for seed in range(N):\n",
+    "    kind, p, emitted, periodique = classify_soup(seed)\n",
+    "    stats[kind] += 1\n",
+    "    if kind == \"oscillateur\": osc_ps[p] += 1\n",
+    "    if emitted >= 1: emit_any += 1\n",
+    "    if periodique: sources += 1\n",
+    "\n",
+    "print(\"budget :\", N, \"soupes, boite 12x12, densite 0.35, horizon 240\")\n",
+    "print(\"classification :\", dict(stats))\n",
+    "print(\"periodes des oscillateurs :\", dict(sorted(osc_ps.items())))\n",
+    "print(\"soupes ayant emis >= 1 quasi-particule (transitoire compris) :\", emit_any, \"/\", N)\n",
+    "print(\"SOURCES periodiques trouvees :\", sources)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c10",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002912,
+     "end_time": "2026-08-22T12:25:46.977477+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:25:46.974565+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : un zéro calibré\n",
+    "\n",
+    "- **0 source périodique en 3 000 soupes.** Et ce zéro est *calibré* : le même détecteur,\n",
+    "  sur le même budget, trouve 1 155 oscillateurs (dont 1 048 clignotants de période 2),\n",
+    "  1 387 formes stables, et **1 220 soupes qui ont réellement émis au moins une\n",
+    "  quasi-particule** — mais par explosion transitoire, suivie d'une stabilisation. Le\n",
+    "  détecteur voit abondamment tout ce qui est *presque* une source ; il ne voit aucune\n",
+    "  source. Le zéro mesure le budget, pas un aveuglement de l'instrument.\n",
+    "- La rareté a une cause structurelle : une source exige que l'émission coïncide avec la\n",
+    "  période du noyau — deux conditions conjointes, chacune rare, et leur conjonction\n",
+    "  l'est quadratiquement. Le canon de Gosper (36 cellules choisies parmi $2^{36 \\cdot 9}$)\n",
+    "  n'a pas été tiré au hasard : l'équipe du MIT l'a **construit** par recherche dirigée,\n",
+    "  en assemblant des composants connus. Construire n'est pas échantillonner — c'est le\n",
+    "  geste que le barreau 2 isole."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T12:25:46.984259Z",
+     "iopub.status.busy": "2026-08-22T12:25:46.983991Z",
+     "iopub.status.idle": "2026-08-22T12:25:47.015041Z",
+     "shell.execute_reply": "2026-08-22T12:25:47.014273Z"
+    },
+    "papermill": {
+     "duration": 0.035557,
+     "end_time": "2026-08-22T12:25:47.015716+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:25:46.980159+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "controle positif — periode : 30 | source detectee : True\n",
+      "comptages par fenetre (doivent croitre strictement) : [1, 2, 3, 4]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# CONTROLE POSITIF : le detecteur, applique au canon lui-meme, doit dire SOURCE.\n",
+    "def gun_control():\n",
+    "    m = 2\n",
+    "    def inside_of(state):\n",
+    "        return sorted((a, b) for (a, b) in state\n",
+    "                      if X0 - m <= a <= X1 + m and Y0 - m <= b <= Y1 + m)\n",
+    "    def count_qp(state):\n",
+    "        out = [(a, b) for (a, b) in state if not (X0 <= a <= X1 and Y0 <= b <= Y1)]\n",
+    "        return len([isl for isl in islands(out) if tuple(norm(isl)) in GLIDER_FORMS])\n",
+    "    seen, cur = {}, GUN\n",
+    "    for t in range(1, 241):\n",
+    "        cur = step(cur)\n",
+    "        key = tuple(norm(inside_of(cur)))\n",
+    "        if key in seen:\n",
+    "            p = t - seen[key]\n",
+    "            counts = [count_qp(cur)]\n",
+    "            st = cur\n",
+    "            for _ in range(p): st = step(st)\n",
+    "            for _ in range(3):\n",
+    "                counts.append(count_qp(st))\n",
+    "                for _ in range(p): st = step(st)\n",
+    "            return p, all(counts[i + 1] > counts[i] for i in range(3)), counts\n",
+    "        seen[key] = t\n",
+    "    return None, False, []\n",
+    "\n",
+    "p_ctrl, est_source, fenetres = gun_control()\n",
+    "print(\"controle positif — periode :\", p_ctrl, \"| source detectee :\", est_source)\n",
+    "print(\"comptages par fenetre (doivent croitre strictement) :\", fenetres)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c12",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003023,
+     "end_time": "2026-08-22T12:25:47.021647+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:25:47.018624+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Pourquoi le contrôle positif n'est pas un luxe\n",
+    "\n",
+    "Un zéro de détecteur et un zéro de corpus sont **indiscernables** sans témoin positif :\n",
+    "si le détecteur était cassé (formes de planeur incomplètes, marge mal calibrée), il\n",
+    "rendrait le même « 0 sources » que la vérité. La cellule précédente applique\n",
+    "l'instrument, sans aucune modification, au seul objet du dépôt dont on sait\n",
+    "(quand même — par la mesure de l'exercice 1) qu'il est une source : il répond\n",
+    "`periode 30, source detectee True, fenetres [1, 2, 3, 4]`. L'instrument est sain ;\n",
+    "le zéro de la recherche est un fait du monde.\n",
+    "\n",
+    "Notez aussi pourquoi les 1 220 émetteurs transitoires ne comptent pas : leurs\n",
+    "quasi-particules partent *pendant* l'explosion initiale, avant que le noyau n'entre\n",
+    "dans son cycle. Une source exige l'émission **pendant** le régime périodique —\n",
+    "l'horloge, pas le bang."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003584,
+     "end_time": "2026-08-22T12:25:47.029857+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:25:47.026273+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 — Le certificat : énoncer la propriété de façon vérifiable\n",
+    "\n",
+    "Reconnaître (exercice 1) mesurait en Python. Un **certificat** doit être énoncé dans le\n",
+    "langage du dépôt — un prédicat `Bool` sur `Grid` — et évalué par le moteur de Lean,\n",
+    "sur un horizon fini explicite. Le lake fournit les briques : `Grid = List (Int × Int)` (`Life.lean:66`),\n",
+    "`evolve : Nat → Grid → Grid` (`Life.lean:155`), `gosper_gun : Grid` (`RLE.lean:277`) —\n",
+    "toutes sous le namespace `Conway.Life` / `Conway.Life.RLE`, avec la convention\n",
+    "(ligne, colonne) pour les cellules.\n",
+    "\n",
+    "Le prédicat du barreau 2, restreint à un horizon fini $H$ :\n",
+    "\n",
+    "> `core (evolve p g) = core g` pour chaque multiple de $p$ jusqu'à $H$, où `core`\n",
+    "> restreint une grille à la boîte du motif initial.\n",
+    "\n",
+    "Deux précisions d'honnêteté :\n",
+    "- le filtre `core` **doit** exister dans le certificat — sans lui l'égalité est fausse,\n",
+    "  puisque le canon croît (les quasi-particules s'accumulent hors boîte) ;\n",
+    "- `#eval` **évalue** (interpréteur Lean) ; ce n'est pas une preuve au sens du noyau.\n",
+    "  Le passage de `#eval` à `decide` — ce que `Computation.lean:176` a fait pour le\n",
+    "  planeur (barreau 1) — est un travail lake-side, nommé ici comme tel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T12:25:47.036398Z",
+     "iopub.status.busy": "2026-08-22T12:25:47.036093Z",
+     "iopub.status.idle": "2026-08-22T12:26:17.133471Z",
+     "shell.execute_reply": "2026-08-22T12:26:17.132765Z"
+    },
+    "papermill": {
+     "duration": 30.103451,
+     "end_time": "2026-08-22T12:26:17.136054+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:25:47.032603+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "true\n",
+      "true\n",
+      "true\n",
+      "36\n",
+      "true\n",
+      "5\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "LEAN_PROJECT = get_lean_project_path('conway_lean')  # forme /mnt/c/... pour run_lean_snippet\n",
+    "snippet = '''\n",
+    "import Conway.Life\n",
+    "import Conway.Life.RLE\n",
+    "open Conway.Life\n",
+    "open Conway.Life.RLE\n",
+    "\n",
+    "/-- Boite stricte du canon a t=0, en convention (ligne, colonne) du lake :\n",
+    "    lignes 0..8, colonnes 0..35 (RLE.lean annonce x=36, y=9). -/\n",
+    "def inBox (c : Int × Int) : Bool := 0 ≤ c.1 ∧ c.1 < 9 ∧ 0 ≤ c.2 ∧ c.2 < 36\n",
+    "\n",
+    "/-- Noyau = cellules dans la boite stricte. -/\n",
+    "def core (g : Grid) : Grid := g.filter inBox\n",
+    "\n",
+    "-- Certificat horizon fini : le noyau revient a lui-meme a chaque periode\n",
+    "#eval core (evolve 30 gosper_gun) == core gosper_gun\n",
+    "#eval core (evolve 60 gosper_gun) == core gosper_gun\n",
+    "#eval core (evolve 90 gosper_gun) == core gosper_gun\n",
+    "\n",
+    "-- Le noyau est exactement le canon : 36 cellules, rien de moins\n",
+    "#eval (core gosper_gun).length\n",
+    "#eval core gosper_gun == gosper_gun\n",
+    "\n",
+    "-- Le complementaire apres une periode : la quasi-particule emise (5 cellules)\n",
+    "#eval ((evolve 30 gosper_gun).filter (fun c => !inBox c)).length\n",
+    "'''\n",
+    "out = run_lean_snippet(LEAN_PROJECT, snippet, timeout=120, snippet_id=\"canon_certificat\")\n",
+    "print(out)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002508,
+     "end_time": "2026-08-22T12:26:17.141297+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:26:17.138789+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du certificat\n",
+    "\n",
+    "Six lignes `#eval`, six réponses attendues : `true`, `true`, `true`, `36`, `true`, `5`.\n",
+    "\n",
+    "- les trois `true` disent : **à chaque multiple de 30 générations (horizon 30, 60, 90),\n",
+    "  le noyau est exactement le canon initial** — la partie bornée du système est une\n",
+    "  horloge, vérifiée par le moteur de Lean sur un horizon fini et explicite ;\n",
+    "- `36` et `true` : le noyau n'est ni tronqué ni étendu — le filtre `inBox` ne cache rien ;\n",
+    "- `5` : après une période, le complémentaire hors boîte compte 5 cellules — une\n",
+    "  quasi-particule complète, cohérente avec la mesure Python de l'exercice 1 (une\n",
+    "  émission par période).\n",
+    "\n",
+    "Ce que le certificat **ne prétend pas** :\n",
+    "- il ne dit rien des instants *entre* les multiples de 30 (le noyau excursione hors\n",
+    "  boîte pendant le cycle — mesuré : y jusqu'à 11 pendant t = 0..29) ;\n",
+    "- il ne prouve pas la périodicité **pour tout** $t$ : cela exigerait une induction sur\n",
+    "  les horizons et l'argument que la quasi-particule émise ne réinteragit jamais avec le\n",
+    "  noyau — un théorème lake-side, pas une évaluation ;\n",
+    "- `#eval` reste une évaluation. La version `decide` (preuve noyau) du barreau 1 existe\n",
+    "  pour le planeur (`Computation.lean:176`) ; son analogue au canon est le prochain\n",
+    "  geste du lake."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c16",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002487,
+     "end_time": "2026-08-22T12:26:17.146297+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:26:17.143810+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Ce qui reste hors d'atteinte — nommé, pas maquillé\n",
+    "\n",
+    "| Barreau | Ce qu'il faudrait | Pourquoi ce n'est pas « une perspective » |\n",
+    "|---|---|---|\n",
+    "| 3 — automate fini | une configuration dont le faisceau de quasi-particules réalise le graphe de transitions d'un automate donné | les canons connus n'émettent pas *l'information* ; il faut des collisionneurs, des réflecteurs, une **synthèse dirigée** de composants — pas un tirage de soupes |\n",
+    "| 4 — machine de Turing | l'encodage explicite d'une machine et sa construction | c'est le programme Gemini (Wade, 2010) : des années-homme de design dirigé |\n",
+    "\n",
+    "La leçon des deux exercices est la même des deux côtés de l'échelle : **l'écart entre\n",
+    "vérifier et construire n'est pas un manque d'ingéniosité, il est structurel**. Le\n",
+    "vérificateur est un algorithme polynomial en l'horizon ; le constructeur navigue un\n",
+    "espace exponentiel dont la structure n'est connue que par fragments (gliders, canons,\n",
+    "collisionneurs). C'est précisément pourquoi le chantier #12205 parle de *témoin* : le\n",
+    "canon de Gosper est le témoin que « croissance non bornée depuis un objet fini » est\n",
+    "**réalisable** — et le barreau 2 s'arrête là où sa réalisation vérifiée s'arrête."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c17",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002522,
+     "end_time": "2026-08-22T12:26:17.151422+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:26:17.148900+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "***\n",
+    "\n",
+    "## Exercices\n",
+    "\n",
+    "### Exercice 1 — Reconnaître un autre objet : le pulsar\n",
+    "\n",
+    "Le lake encode aussi le pulsar (`pulsar_RLE`, `RLE.lean:247`) : oscillateur de période 3,\n",
+    "48 cellules, le grand oscillateur le plus courant dans les soupes (votre recherche en a\n",
+    "d'ailleurs trouvé, période 3 : 28 instances). Appliquez le protocole de l'exercice 1 :\n",
+    "mesurez sa période, puis montrez qu'il échoue **au critère 2** — aucune émission. Un\n",
+    "oscillateur n'est pas une source : il n'y a d'horloge que pour lui-même."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T12:26:17.157487Z",
+     "iopub.status.busy": "2026-08-22T12:26:17.157283Z",
+     "iopub.status.idle": "2026-08-22T12:26:17.160197Z",
+     "shell.execute_reply": "2026-08-22T12:26:17.159538Z"
+    },
+    "papermill": {
+     "duration": 0.006879,
+     "end_time": "2026-08-22T12:26:17.160778+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:26:17.153899+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# TODO etudiant\n",
+    "# 1. Parser le RLE du pulsar (corps ci-dessous, meme decodeur que c04)\n",
+    "PULSAR_RLE_BODY = (\"2b3o3b3o2b$13b$o4bobo4bo$o4bobo4bo$o4bobo4bo$2b3o3b3o2b\"\n",
+    "                   \"$13b$2b3o3b3o2b$o4bobo4bo$o4bobo4bo$o4bobo4bo$13b$2b3o3b3o2b!\")\n",
+    "# 2. Mesurer la periode du noyau (methode c06)\n",
+    "# 3. Compter les quasi-particules emises sur 90 generations (methode gliders_out)\n",
+    "# 4. Conclure : periode = ?, emissions = 0, donc oscillateur / non source\n",
+    "resultat_ex1 = None  # TODO etudiant"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c19",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002501,
+     "end_time": "2026-08-22T12:26:17.165867+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:26:17.163366+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Étendre le budget : le zéro résiste-t-il ?\n",
+    "\n",
+    "Le résultat « 0 sources en 3 000 soupes » est une mesure **à budget donné**. Étendez :\n",
+    "boîte $16 \\times 16$, densité 0,35, 30 000 soupes (dix fois le budget). Deux issues\n",
+    "honnêtes : le zéro tient (renforcez la borne), ou une source apparaît — alors mesurez\n",
+    "sa période, son transitoire, sa classe émise, et passez-la au contrôle de la cellule c11.\n",
+    "Attention au coût : 30 000 soupes × horizon 240 ≈ quelques minutes ; mesurez et\n",
+    "affichez votre budget réel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T12:26:17.172263Z",
+     "iopub.status.busy": "2026-08-22T12:26:17.171979Z",
+     "iopub.status.idle": "2026-08-22T12:26:17.174990Z",
+     "shell.execute_reply": "2026-08-22T12:26:17.174242Z"
+    },
+    "papermill": {
+     "duration": 0.006992,
+     "end_time": "2026-08-22T12:26:17.175562+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:26:17.168570+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# TODO etudiant\n",
+    "# 1. Reexecuter classify_soup avec box=16 et le triple horizon si besoin\n",
+    "# 2. Boucle sur 30000 graines (mesurez le temps reel et affichez-le)\n",
+    "# 3. Rapporter : classification, periodes, sources (0 attendu ? a mesurer)\n",
+    "resultat_ex2 = None  # TODO etudiant"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c21",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002772,
+     "end_time": "2026-08-22T12:26:17.180821+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:26:17.178049+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Le certificat pour le pulsar, côté Lean\n",
+    "\n",
+    "Reprenez le snippet de c14 : remplacez `gosper_gun` par une définition du pulsar\n",
+    "(décodez le RLE en `Grid` — ou encodez les 48 cellules à la main), et évaluez\n",
+    "`core (evolve 3 pulsar) == core pulsar` sur les horizons 3, 6, 9. La périodicité du\n",
+    "noyau doit se vérifier ; le complémentaire hors boîte doit rester **vide** — c'est la\n",
+    "signature Lean d'un oscillateur : périodicité **sans** émission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T12:26:17.186832Z",
+     "iopub.status.busy": "2026-08-22T12:26:17.186666Z",
+     "iopub.status.idle": "2026-08-22T12:26:17.189430Z",
+     "shell.execute_reply": "2026-08-22T12:26:17.188927Z"
+    },
+    "papermill": {
+     "duration": 0.006506,
+     "end_time": "2026-08-22T12:26:17.189904+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:26:17.183398+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# TODO etudiant\n",
+    "# Ecrire le snippet Lean (methode c14) : inBoxPulsar, corePulsar, #eval sur horizons 3/6/9\n",
+    "# puis run_lean_snippet(LEAN_PROJECT, snippet, timeout=280, snippet_id=\"pulsar_certificat\")\n",
+    "resultat_ex3 = None  # TODO etudiant"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c23",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002383,
+     "end_time": "2026-08-22T12:26:17.194840+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T12:26:17.192457+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion — où en est l'échelle\n",
+    "\n",
+    "| Barreau | Vérifié ? | Construit ? | Témoignage |\n",
+    "|---|---|---|---|\n",
+    "| 1 — quasi-particule | **oui, par le lake** (`decide`, `Computation.lean:176`) | le planeur est une donnée, pas une construction | la translation périodique existe |\n",
+    "| 2 — source périodique | **oui, ici** : période 30 + cadence 30 mesurées, certificat `#eval` sur horizon 90 | **non, et mesuré** : 0/3 000 soupes, zéro calibré par contrôle positif | le canon de Gosper : croissance non bornée depuis 36 cellules |\n",
+    "| 3 — automate fini | non | non | nécessite une synthèse dirigée — hors d'atteinte, dit comme tel |\n",
+    "| 4 — machine de Turing | non | non | programme Gemini : des années de design |\n",
+    "\n",
+    "Le barreau 2 referme un cycle complet : **reconnaître** (mesures), **générer** (le zéro\n",
+    "honnête, qui est une information positive sur la rareté), **certifier** (prédicat\n",
+    "vérifiable, évalué sur horizon fini). Le barreau suivant ne se franchira pas en\n",
+    "échantillonnant plus fort — le protocole de l'exercice 2 le dira à quiconque essaie —\n",
+    "mais en assemblant des composants : c'est un changement de nature, pas de budget.\n",
+    "\n",
+    "*Lean-16g — Canons, barreau 2 de l'échelle des témoins (issue #12223, chantier #12205).\n",
+    "Substrat et citations : lake `conway_lean` (`Life.lean`, `RLE.lean`, `Computation.lean`),\n",
+    "consommé en lecture — aucun `.lean` modifié. Vocabulaire : quasi-particule, faisceau,\n",
+    "source périodique.*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 114.698143,
+   "end_time": "2026-08-22T12:26:17.433409+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lean-16g-Conway-Canons.ipynb",
+   "output_path": "Lean-16g-Conway-Canons.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-22T12:24:22.735266+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -64,7 +64,7 @@ Tous les notebooks incluent une **barre de navigation** en haut et en bas permet
 | **Intégration IA** | 1-7, 7b | ~5h | Ajoute LLMs, exemples et benchmarks |
 | **Complet** | 1-12 | ~11h | Toutes les fonctionnalités incluant LeanDojo et théorème de sensibilité |
 | **Avec Pilier 1.B** | 1-12, 13 | ~12h | Inclut le port Kochen-Specker (Cabello 18-vecteurs) - contextuality quantique |
-| **Avec hommages** | 1-12, 13, 15, 16a, 16b, 16c, 16d, 16e, 16f | ~17h20 | Ajoute Lean-15 (Grothendieck), Lean-16a (Conway, l'homme et l'oeuvre), Lean-16b (Conway, Game of Life), Lean-16d (Conway, Game of Life sur kernel Lean natif), Lean-16e (Conway, FRACTRAN sur kernel Lean natif) et Lean-16f (Conway, théorème du libre arbitre - adossé à Lean-13) |
+| **Avec hommages** | 1-12, 13, 15, 16a, 16b, 16c, 16d, 16e, 16f, 16g | ~18h05 | Ajoute Lean-15 (Grothendieck), Lean-16a (Conway, l'homme et l'oeuvre), Lean-16b (Conway, Game of Life), Lean-16d (Conway, Game of Life sur kernel Lean natif), Lean-16e (Conway, FRACTRAN sur kernel Lean natif), Lean-16f (Conway, théorème du libre arbitre - adossé à Lean-13) et Lean-16g (Conway, canons - le barreau 2 de l'échelle des témoins Life) |
 | **Avec théorie des nœuds** | 1-12, 13, 15, 16a-c, 16f, 17a, 17b | ~17h30 | Ajoute Lean-17a (Conway, les nœuds et la preuve de Piccirillo) et Lean-17b (invariants : PD-codes, tricolorabilité de Fox, mouvements de Reidemeister) - companion `knot_lean`, Epic #2874 |
 
 ## Structure
@@ -115,6 +115,7 @@ Tous les notebooks incluent une **barre de navigation** en haut et en bas permet
 | 16d | [Lean-16d-Conway-Game-of-Life-Lean-Native](Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb) | Game of Life sur **kernel Lean natif** (`lean4-wsl`) : grille, règle B3/S23, moteur `step`/`evolve`, motifs (bloc, clignoteur, planeur) et faits certifiés par `decide`/`native_decide`, sans axiome `sorry` - Epic #1647 / #3294 | 40 min |
 | 16e | [Lean-16e-Conway-FRACTRAN-Lean-Native](Lean-16e-Conway-FRACTRAN-Lean-Native.ipynb) | FRACTRAN sur **kernel Lean natif** (`lean4-wsl`) : type `Frac` (preuve `den > 0`), moteur `fracMulNat`/`fractranStep`/`fractranRun`, programmes (doubler, diviser) et le générateur de nombres premiers de Conway (14 fractions), faits certifiés par `decide` sans axiome `sorry` - Epic #1647 / #3294 | 40 min |
 | 16f | [Lean-16f-Conway-Free-Will-Theorem](Lean-16f-Conway-Free-Will-Theorem.ipynb) | théorème du libre arbitre (Conway-Kochen) : les trois axiomes SPIN/TWIN/MIN en profondeur, argument en deux temps (1 particule via Kochen-Specker, puis 2 particules via TWIN), ce que le théorème dit et NE dit PAS, port formel adossé à `FreeWillTheorem.lean` (chaîne de réduction `free_will_theorem -> fwt_single_particle -> kochen_specker`, 0 sorry), registre d'extensibilité - Epic #2162 / #2156 | 40 min |
+| 16g | [Lean-16g-Conway-Canons](Lean-16g-Conway-Canons.ipynb) | Barreau 2 de l'échelle des témoins Life (#12223, chantier #12205) : la source périodique (canon de Gosper) — reconnaître (période 30, transitoire 0, cadence d'émission 30 mesurées), générer (recherche bornée 3 000 soupes, zéro calibré par contrôle positif), certifier (prédicat `core (evolve 30 gosper_gun) = core gosper_gun` évalué `#eval` sur horizons 30/60/90 depuis le lake), barreaux 3-4 nommés hors d'atteinte | 45 min |
 
 ### Partie 5 : Théorie des noeuds
 
@@ -158,6 +159,7 @@ A l'issue de la série, vous saurez :
 - **Situer l'oeuvre de Conway** dans sa largeur : des nombres surréels au Monstrous Moonshine, du réseau de Leech au théorème du libre arbitre, en exécutant les premières noix formalisées (Doomsday, Look-and-Say, Nim, Angel, Life) directement depuis le projet conway_lean (0 sorry). Notebook 16a.
 - **Explorer les noix de Conway** en Lean 4 : Game of Life as Computation, Doomsday, FRACTRAN, Look-and-Say, Nim, Angel — port formel de résultats combinatoires iconiques. Notebooks 16a-16e.
 - **Comprendre le théorème du libre arbitre** (Conway-Kochen) : les axiomes SPIN/TWIN/MIN, l'argument en deux temps qui réduit le cas à deux particules au théorème de Kochen-Specker (Notebook 13), et la lecture honnête de sa portée (ce qu'il dit et ne dit pas) — adossé à `FreeWillTheorem.lean` (0 sorry). Notebook 16f.
+- **Franchir un barreau de l'échelle vérifier→construire** : reconnaître une source périodique Life (période, transitoire, cadence d'émission mesurées sur le canon de Gosper), chercher à en générer une dans un budget borné (zéro calibré par contrôle positif), et certifier la périodicité du noyau par un prédicat `Grid` évalué sur horizon fini — l'écart structurel entre vérificateur et constructeur. Notebook 16g.
 - **Formaliser les invariants de nœuds** : PD-codes, mouvements de Reidemeister et tricolorabilité de Fox, en s'appuyant sur le companion `knot_lean` (transfert de tricolorabilité le long d'un twist R1 connecté, preuve forward sorry-free + backward partielle). Notebooks 17a, 17b.
 - **Lire le paysage galoisien moderne** : la preuve formelle que **M₂₃ (groupe sporadique de Mathieu d'ordre 10 200 960) est simple** est *vendored* dans le companion `galois_lean/` (PR #10486, août 2026, Apache-2.0) ; la réalisation galoisienne — *M₂₃ groupe de Galois sur ℚ* — est **prouvée** dans le préprint (Huang–Jackson–Lee–Poonen–Pries–Zhang, arXiv:2608.08538, 9 août 2026 : polynôme explicite f₁ de degré 23, identification `23T5`) mais **non formalisée** — le notebook [Lean-23](Lean-23-Galois-Probleme-Inverse-M23.ipynb) exécute la preuve formelle côté groupe et vérifie f₁ computationnellement, les deux énoncés soigneusement distingués (Epic #10478).
 
@@ -188,7 +190,10 @@ Pour l'état formel détaillé des modules support (preuves résolues vs `sorry`
 | 16a | Conway-Man-and-Work | ~39 | 3 | 0 | **NOUVEAU** (hommage) |
 | 16b | Conway-Game-of-Life-Lean | ~26 | 0 | - | **NOUVEAU** (hommage) |
 | 16c | Conway-Game-of-Life-Golly | ~47 | 5 | - | **NOUVEAU** (hommage) |
+| 16d | Conway-Game-of-Life-Lean-Native | ~32 | 0 | 0 | **NOUVEAU** (hommage, kernel `lean4-wsl`) |
+| 16e | Conway-FRACTRAN-Lean-Native | ~22 | 0 | 0 | **NOUVEAU** (hommage, kernel `lean4-wsl`) |
 | 16f | Conway-Free-Will-Theorem | ~28 | 3 | 0 | **NOUVEAU** (hommage) |
+| 16g | Conway-Canons | ~23 | 3 | - | **NOUVEAU** (barreau 2 #12223) |
 | 17a | Knots-a-Conway-and-Proofs | ~13 | 0 | - | **NOUVEAU** (hommage) |
 | 17b | Knots-b-Invariants-Companion | ~19 | 3 | - | **NOUVEAU** |
 | 23 | Galois-Probleme-Inverse-M23 | ~25 | 3 | 0 | **NOUVEAU** (exécution Lean + sympy) |
@@ -370,6 +375,7 @@ Lean/
 ├── Lean-16c-Conway-Game-of-Life-Golly.ipynb  # Python kernel - hommage Conway (Game of Life en images, compagnon Golly)
 ├── Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb  # Lean4 (WSL) kernel - Game of Life natif (grille, B3/S23, decide/native_decide, 0 sorry)
 ├── Lean-16e-Conway-FRACTRAN-Lean-Native.ipynb      # Lean4 (WSL) kernel - FRACTRAN natif (machine universelle de Conway, générateur de premiers)
+├── Lean-16g-Conway-Canons.ipynb                    # Python kernel - barreau 2 de l'échelle des témoins : source périodique (canon de Gosper) mesurée, cherchée, certifiée #eval (#12223)
 ├── Lean-13-Kochen-Specker.ipynb    # Lean4 kernel - théorème de Kochen-Specker (Pilier 1.B)
 ├── Lean-14-Finiteness-Derivatives.ipynb # Python kernel - dérivées symboliques de Brzozowski (finitude, matching linéaire)
 ├── Lean-14b-Finiteness-Lean-Companion.ipynb # Lean kernel - companion natif du lake finiteness_lean (7 déclarations citées)


### PR DESCRIPTION
Grain: DEEP/notebook-lean — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #12308

Closes #12223 (barreau 2 du chantier, livré en entier) · See #12205 (chantier parent)

## Summary

Nouveau notebook `Lean-16g-Conway-Canons.ipynb` (23 cellules, 9 code, kernel python3, stdlib + `lean_notebook_utils`, déterministe) : le canon de Gosper comme **source périodique** de quasi-particules — le troisième type d'objet Conway après l'oscillateur (16b) et le vaisseau (16e/16f). Vocabulaire de l'issue adopté : quasi-particule / faisceau / source périodique (grep vérifié : aucune notation alpha/gamma en usage dans le dépôt — la nomenclature est adoptée d'entrée, pas retouchée).

| Exigence du barreau 2 | Livré / mesuré |
|---|---|
| **Mesurer la période et le transitoire** | Période **30**, transitoire **0** (le cœur est cyclique dès t=0 : `core (evolve 30 gosper_gun) == core gosper_gun` vrai dès le premier cycle) ; émissions à t = 28, 58, 88, 118 — cadence exactement 30 ; population 36 + 5⌊t/30⌋ ; vitesse c/4 diagonale |
| **Recherche bornée honnête** | 3000 soupes 12×12, densité 0.35, horizon 240 : **0 sources** — zéro calibré par **contrôle positif** (le détecteur, appliqué au canon lui-même, détecte SOURCE, fenêtres [1,2,3,4]) ; classification complète : 1220 émetteurs transitoires, 1155 oscillateurs (dont 1048 blinkers p2), 1387 stables, 197 éteints, 261 indécis |
| **Certificat vérifiable** | `core (evolve p g) = core g` évalué par `#eval` **depuis le lake lui-même** (Conway.Life.RLE) aux horizons 30/60/90 : `true / true / true` ; `core` = 36 cellules ; 5 cellules hors boîte à t=30 (le glider fraîchement émis) ; détection en deux phases (régime périodique ≠ explosion transitoire) — le comptage en une phase donnait 200 faux positifs, diagnostiqué et corrigé |

Barreaux 3-4 nommés **hors d'atteinte** dans le notebook (génération de canons inédits, preuve kernel de l'émission infinie), sans maquillage — conforme au garde-fou de #12223.

3 exercices C.1 stubbés (`resultat_exN = None  # TODO etudiant`) : reconnaître un pulsar (oscillateur ≠ source), budget étendu 30k soupes, certificat Lean du pulsar.

## Validation

- **Exécution** : `wsl_papermill.py execute --mode native` — **9/9 cellules code, 0 erreur**, séquence [1..9], 117.8 s, outputs committés (C.2).
- **Audit output de CHAQUE cellule** (leçon MGS-5) : la première exécution de c14 échouait **silencieusement** (`bash: cd: ... No such file or directory`, exit 0) — cause : chemin Windows passé à `run_lean_snippet`. Corrigé via `get_lean_project_path()` (forme `/mnt/c/...`), re-exécuté, certificat vert.
- **C.1** : 0 violation (`raise NotImplementedError` / `assert False` / `1/0`).
- **Densité** : 1628 caractères prose / cellule code (seuil 1200).
- **Navlinks** : 2/2 résolus (Lean-16b, README série).
- **Ancrage prose↔outputs** : tous les chiffres cités (28/58/88/118, [30,30,30], 1220/3000, [1,2,3,4], 36+5⌊t/30⌋) vérifiés contre les outputs réels avant commit ; tous calculés offline AVANT la prose.

## §B Lean — non applicable, écrit tel quel

La PR ne touche **aucun fichier `*.lean`** (notebook .ipynb + README.md uniquement) : comptage `sorry` avant/après, `lake build` de module et `proof-integrity` sont **N/A sur le scope**. À noter quand même : le lake `conway_lean` a été **built localement** (SUCCESS, 3003 jobs, révisions Mathlib du manifeste vérifiées avant réutilisation des oleans) pour exécuter les snippets `#eval` du certificat — le certificat affiché dans le notebook est la sortie réelle du lake, pas une valeur copiée.

## SOTA (§H)

Verdict **SOTA-OK** : le substrat d'énumération/simulation est exhaustif et exact (stdlib déterministe, aucun sampling), et le certificat est évalué par le vrai lake via `#eval`. Limite documentée honnêtement : `#eval` est une **évaluation**, pas une preuve kernel — le barreau 4 (preuve formelle de l'émission infinie) reste hors d'atteinte et est nommé comme tel.

## README série Lean (audit fichier entier, règle §E)

- **Table de structure** : ligne 16g ajoutée (barreau 2 #12223, 45 min).
- **Table maturité** : ligne 16g (`~23` cellules, 3 exos, **NOUVEAU**) **+ réconciliation de deux omissions préexistantes** : 16d et 16e n'y figuraient pas — ajoutées avec comptages mesurés (~32/0 kernel lean4-wsl, ~22/0).
- **Arbre** : ligne 16g insérée dans le cluster Conway (après 16e ; l'arbre préexistant n'est pas linéairement ordonné — 16f vit après 14b).
- **Parcours** : ligne « Avec hommages » étendue 16a→16g, durée ~17h20 → ~18h05.
- **Acquis d'apprentissage** : +1 puce (franchir un barreau vérifier→construire).
- **Durée totale : NON touchée** (~23h30 sur main ; la reconstruction ~29h vit dans la PR #12306 ouverte — évite le conflit).
- **CATALOG-STATUS byte-identique** (vérifié : 0 ligne CATALOG dans le diff) — inscription laissée au bot catalog-drift / cron.

## Scope

2 fichiers : le notebook + le README de série. Aucun autre fichier touché.
