### PR TITLE
docs(semanticweb,#11601): SW-12 GraphRAG densite 1509 -> 1994 (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
@@ -136,7 +136,15 @@
     "Question -> Extraction entites -> Recherche dans le KG -> Contexte structure -> LLM -> Reponse fondee\n",
     "```\n",
     "\n",
-    "L'idee centrale : au lieu de recuperer des chunks de texte brut, on recupere des **sous-graphes** autour des entites mentionnees dans la question. Cela fournit au LLM un contexte riche et structure."
+    "L'idee centrale : au lieu de recuperer des chunks de texte brut, on recupere des **sous-graphes** autour des entites mentionnees dans la question. Cela fournit au LLM un contexte riche et structure.\n",
+    "\n",
+    "### Position dans la serie, et un peu d'histoire\n",
+    "\n",
+    "Ce notebook est le point de convergence de la serie Python : SW-2 a pose les triplets RDF, SW-7 les ontologies OWL, SW-10 la provenance RDF-star, SW-11 les Knowledge Graphs construits et interroges en SPARQL. Ici le KG devient un **organe de retrieval** pour un LLM — la rencontre du Web semantique (specifications W3C des annees 2000) et de la generation augmente (2023-2024).\n",
+    "\n",
+    "Le terme GraphRAG a ete popularise par l'equipe Microsoft Research (Edge et al., 2024, *From Local to Global: A Graph RAG Approach to Query-Focused Summarization*) : leur apport decisif n'est pas l'idee de graphe, mais l'**indexation hierarchique par communautes** (section 6 de ce notebook), qui rend possibles les questions de synthese sur un corpus entier. Les pipelines industriels (LlamaIndex property graph, Neo4j GraphRAG, Azure AI Search) ont suivi en quelques mois.\n",
+    "\n",
+    "Ce que ce notebook fait et ne fait pas : il execute le pipeline complet (extraction, graphe RDF, sous-graphe, generation) sur un corpus de trois films, en mode demonstration sans cle API. Il ne mesure pas la qualite retrieval a l'echelle d'un benchmark — l'exemple guide 3 montre seulement comment evaluer l'etape d'extraction face a un gold standard."
    ]
   },
   {
@@ -223,7 +231,13 @@
     "    graphe -->|\"Interrogation\"| LLM[\"LLM\"]\n",
     "    SOUS[\"Sous-graphe comme contexte\"] -.-> LLM\n",
     "    LLM --> REP[\"Reponse fondee\"]\n",
-    "```"
+    "```\n",
+    "\n",
+    "### Une asymetrie de cout a retenir\n",
+    "\n",
+    "Les quatre etapes ne coutent pas le meme prix au meme moment. L'extraction et la construction sont payees **une fois, hors ligne** — c'est la que se concentrent les appels LLM, un par document voire par chunk. L'indexation par communautes est aussi hors ligne, nettement moins couteuse. L'interrogation, elle, est payee **a chaque question**, mais elle ne coute qu'un parcours de graphe (microsecondes) plus un appel LLM.\n",
+    "\n",
+    "Cette repartition explique le choix d'engineering de l'exemple guide 2 : persister le KG en Turtle pour ne jamais repayer l'extraction. C'est aussi ce qui distingue GraphRAG du RAG vectoriel, ou la construction initiale est bon marche (des embeddings) mais ou chaque requete depend de la similarite approximative — le GraphRAG deplace le cout vers l'aval : construction riche une fois, interrogation exacte et quasi gratuite ensuite."
    ]
   },
   {
@@ -699,7 +713,9 @@
     "- Les relations refletent bien le contenu du texte\n",
     "- Certaines relations implicites (comme le genre des films) sont inferees\n",
     "\n",
-    "> **Point cle** : La qualite de l'extraction depend fortement du prompt et du modèle utilise. GPT-4 et Claude produisent généralement des résultats superieurs a GPT-3.5 pour cette tâche."
+    "> **Point cle** : La qualite de l'extraction depend fortement du prompt et du modèle utilise. GPT-4 et Claude produisent généralement des résultats superieurs a GPT-3.5 pour cette tâche.\n",
+    "\n",
+    "**Lecture fine des 15 entites** : la sortie detaillee montre trois categories que le tableau resume cache. D'abord les 7 personnes reelles (Nolan, DiCaprio, McConaughey, Hathaway, Ledger, Bale, Zimmer). Ensuite les 3 **personnages fictifs** — Dom Cobb, Joker, Batman — tagges `Person` avec un role distinct : le texte les mentionne comme roles joues, et l'extraction les a captures comme entites a part entiere. C'est une decision d'annotation discutable (une ontologie OWL rigoureuse separerait la classe `FictionalCharacter` de `Person`), et elle aura une consequence visible a la section 6 : ces trois noeuds, sans relation extraite, deviendront des singletons. Enfin l'entite `Oscar` est **generique** — le texte dit \"quatre Oscars\" pour Inception, mais le graphe ne porte qu'un seul noeud Prix auquel tous les `won` aboutissent ; la cardinalite est perdue dans l'extraction (elle vivrait dans un attribut, pas dans la structure)."
    ]
   },
   {
@@ -910,7 +926,11 @@
     "\n",
     "> **Note** : `Genre` et `Concept` figurent dans le vocabulaire interne (`TYPE_MAP`) mais aucune entite de ces types n'est extraite du texte de demonstration. De même, la relation `genre_of` est définie dans `REL_MAP` mais n'apparait pas dans les relations extraites. Les compteurs ci-dessus refletent ce qui est reellement present dans le graphe RDF construit (15 entites, 12 relations, 61 triplets).\n",
     "\n",
-    "> **Point cle** : Le passage du texte brut au graphe RDF structure l'information de maniere interrogeable. Chaque fait est maintenant un triplet verifiable et navigable."
+    "> **Point cle** : Le passage du texte brut au graphe RDF structure l'information de maniere interrogeable. Chaque fait est maintenant un triplet verifiable et navigable.\n",
+    "\n",
+    "**D'ou viennent les 61 triplets ?** Le decompte arithmetique rend l'explosion RDF concrete. Chaque entite contribue au minimum deux triplets — son `rdf:type` et son `rdfs:label` — soit 15 x 2 = 30. Les attributs (nationalite, annee de naissance, role...) en ajoutent 19 : ce sont les feuilles litterales que SPARQL saura filtrer mais pas parcourir. Les 12 relations entite-entite en ajoutent 12. Total : 30 + 19 + 12 = 61, exactement la valeur affichee.\n",
+    "\n",
+    "Retenez ce ratio : **15 entites et 12 relations produisent 61 triplets**, environ 4 par entite. Sur un corpus reel de 10 000 entites, le meme ratio donne ~40 000 triplets — c'est pourquoi les magasins de triplets dedies (GraphDB, Blazegraph, Virtuoso) existent, et pourquoi la section 6 cherche a compresser cette richesse en communautes resumees."
    ]
   },
   {
@@ -1256,7 +1276,9 @@
     "\n",
     "Ce sous-graphe sera fourni comme contexte au LLM dans l'étape suivante.\n",
     "\n",
-    "> **Avantage** : Le LLM recoit des faits structures et verifiables, pas des fragments de texte decontextualises. Cela reduit les hallucinations."
+    "> **Avantage** : Le LLM recoit des faits structures et verifiables, pas des fragments de texte decontextualises. Cela reduit les hallucinations.\n",
+    "\n",
+    "**Deux details de la sortie meritent l'oeil**. D'abord l'affichage `22-rdf-syntax-ns#type` : le serialiseur tronque le debut de l'URI et laisse ce fragment — c'est un artefact d'affichage du helper, pas une corruption du graphe ; l'URI complete est bien `http://www.w3.org/1999/02/22-rdf-syntax-ns#type`, plus connue sous son prefixe `rdf:type`. Ensuite, comparez les volumes : la section precedente a construit 61 triplets, le sous-graphe de la question Nolan/DiCaprio n'en expose qu'une dizaine a `max_hops=1`. C'est tout l'enjeu du parametre — a 1 saut le contexte reste compact mais peut manquer le chemin transitif (acteur -> film -> compositeur) ; a 2 sauts il capture la chaine complete mais gonfle le prompt. L'exercice 6 vous fait mesurer cet echange precision/contexte sur une vraie question."
    ]
   },
   {
@@ -1614,7 +1636,11 @@
     "**Limites observees** :\n",
     "- La detection d'entites est basee sur une heuristique simple (correspondance de noms)\n",
     "- Les questions indirectes (\"le realisateur du film avec DiCaprio\") necessitent un raisonnement multi-hop\n",
-    "- En production, on utiliserait un NER avance ou un LLM pour l'étape d'extraction des entites de la question"
+    "- En production, on utiliserait un NER avance ou un LLM pour l'étape d'extraction des entites de la question\n",
+    "\n",
+    "**Ce que disent les tailles de contexte** : 8 faits pour Interstellar, 7 pour The Dark Knight, 7 pour Inception, 5 pour Heath Ledger. Ces differences ne sont pas du bruit — elles refletent le **degre** de chaque entite dans le graphe : Interstellar porte ses acteurs, son realisateur, son compositeur et son annee (contexte large), tandis que Ledger n'a que son type, son label, sa relation `acted_in` et son Oscar (contexte etroit). La taille du contexte recupere est donc un proxy du degre d'interconnexion — exactement l'information que la visualisation de la section 4 montrait en couleurs.\n",
+    "\n",
+    "Notez aussi l'honnetete du tableau ci-dessus : les quatre questions de demonstration sont toutes **mono-saut**. Le cas multi-hop — le territoire ou le graphe domine vraiment le vectoriel — est renvoye a l'exercice 6, avec la question \"quel est le genre des films ou jouent les acteurs diriges par Nolan\", trois sauts qu'aucun `max_hops=1` ne peut resoudre."
    ]
   },
   {
@@ -1679,7 +1705,9 @@
     "| Principe | Optimisation de la modularite (densification intra-communaute) |\n",
     "| Avantage vs Louvain | Garantit la connexite des communautes |\n",
     "| Complexite | O(n log n) en pratique |\n",
-    "| Usage dans GraphRAG | Regrouper les entites en thèmes pour la summarization |"
+    "| Usage dans GraphRAG | Regrouper les entites en thèmes pour la summarization |\n",
+    "\n",
+    "Un mot sur l'outil reellement utilise dans la cellule suivante : ce notebook demontre la detection de communautes avec `greedy_modularity_communities` de NetworkX — un **proxy pedagogique** de Leiden. Les deux optimisent la modularite (la mesure qui quantifie a quel point les aretes intra-communaute sont plus denses que le hasard ne le predirait), mais Leiden ajoute une phase de raffinement qui garantit des communautes **connexes** (accessibles interieurement), la ou la version gloutonne de NetworkX et l'algorithme Louvain historique peuvent produire des communautes deconnectees en pratique. Le vrai Leiden vit dans `leidenalg` / `igraph` ; pour un graphe de 15 noeuds, les deux algorithmes convergent vers des partitions comparables — l'ecart ne devient visible qu'a grande echelle."
    ]
   },
   {
@@ -1833,7 +1861,11 @@
     "| Communaute intermediaire | Thèmes (filmographie Nolan, acteurs) | Questions thematiques |\n",
     "| Communaute globale | Resume de l'ensemble du corpus | Questions de synthese |\n",
     "\n",
-    "> **Point cle** : La detection de communautes permet de generer des resumes a différents niveaux de granularite. Cela rend possible les questions du type \"Quels sont les grands thèmes de ce corpus ?\" sans parcourir tous les documents."
+    "> **Point cle** : La detection de communautes permet de generer des resumes a différents niveaux de granularite. Cela rend possible les questions du type \"Quels sont les grands thèmes de ce corpus ?\" sans parcourir tous les documents.\n",
+    "\n",
+    "**Lecture des 6 communautes mesurees** : la sortie est plus informative que le resume ci-dessus. Les trois communautes structurees (5, 4 et 3 membres) se recrutent par **densite d'aretes, pas par film**. La communaute 1 melange le Heath Ledger de The Dark Knight avec le Leonardo DiCaprio d'Inception — parce qu'Oscar et Warner Bros, noeuds ponts, sont plus denses avec ce groupe qu'avec leur film d'origine. La communaute 2 est le cluster Interstellar complet (Hathaway, Zimmer, McConaughey) : Zimmer, connecte uniquement a Interstellar, y est correctement absorbe. La communaute 3 rend enfin Nolan a The Dark Knight, avec Christian Bale.\n",
+    "\n",
+    "Les trois dernieres communautes sont des **singletons** : Dom Cobb, Joker, Batman. C'est la consequence directe de la lecture de la section 3 — ces personnages fictifs ont ete extraits comme entites, mais aucune relation ne les relie aux films dans les 12 relations retenues (15 noeuds, 12 aretes porteuses : les 3 restants sont isoles, et l'exemple guide 1 le confirme mecaniquement — converti en NetworkX sur les seules relations, le graphe n'a plus que 12 noeuds). Pour une indexation Microsoft GraphRAG reelle, ces singletons seraient rattaches manuellement ou filtres avant summarization : sinon ils produisent des communautes-de-bruit qui polluent les resumes."
    ]
   },
   {
@@ -2408,6 +2440,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-cache-lecture",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "Le rapport mesure x170 entre le premier appel (1,510 s, extraction simulee + ecriture Turtle) et le second (8,86 ms, lecture seule). Rapportez ce facteur aux vraies echelles : une extraction LLM reelle coute plusieurs secondes **par chunk** ; sur un corpus de 1 000 chunks, le cache economise des heures et surtout des credits API a chaque re-execution du pipeline.\n",
+    "\n",
+    "La ligne d'honnetete de la sortie merite d'etre soulignee : la latence du premier appel est SIMULEE par `time.sleep` — le facteur x170 mesure la mecanique du cache (ecriture vs lecture d'un fichier Turtle), pas la latence reelle d'un appel LLM. Avec une vraie cle API, le rapport serait plus grand encore."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "exemple-fb1db4c2",
    "metadata": {
     "papermill": {
@@ -2523,6 +2569,20 @@
     "else:\n",
     "    print(\"\\n  -> F1 <= 0.7 : extraction a ameliorer.\")\n",
     ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-eval-lecture",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "Les quatre \"hallucinations\" listees meritent un examen plus fin que leur nom. Batman, Joker et Dom Cobb sont **reellement mentionnes dans le texte source** (comme roles joues) — l'extraction a capture des entites vraies que le gold standard, plus strict, avait choisies d'ignorer. Et l'Oscar est explicitement evoque dans le texte (\"quatre Oscars\"). Autrement dit : le rappel parfait (1,00) et la precision de 0,73 ne mesurent pas une extraction fautive, mais un **desaccord d'annotation** sur la frontiere du vocabulaire — les personnages fictifs font-ils partie du domaine ?\n",
+    "\n",
+    "C'est exactement pourquoi les protocoles serieux d'evaluation NER font annoter le gold standard par plusieurs personnes et mesurent l'accord inter-annotateurs (kappa de Cohen) avant d'evaluer le modele : une partie de l'\"erreur\" mesuree vit dans le gold, pas dans l'extraction."
    ]
   },
   {
@@ -2698,6 +2758,20 @@
     "\n",
     "print(f\"\\nQuestion : {question}\")\n",
     "print(f\"Reponse  : {answer}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-football-lecture",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "La sortie confirme les trois proprietes que le pipeline devait transporter d'un domaine a l'autre. Le KG football compte 32 triplets pour 11 entites (ratio ~3, proche du cinema) : la structure RDF produit la meme densite quelle que soit la matiere premiere. Les trois chemins multi-hop affiches sont chacun une chaine coach -> club -> joueur -> pays, soit **quatre sauts d'arete** relies par un seul parcours — la ou un RAG vectoriel devrait esperer que les chunks \"Guardiola\", \"Manchester City\" et \"Haaland\" aient des embeddings proches, ce qu'aucune similarite semantique ne garantit.\n",
+    "\n",
+    "Enfin, la question de synthese (\"De quels pays viennent les joueurs du club entraine par Guardiola ?\") repond \"Belgique, Norvege\" — une reponse qui n'existe **dans aucune phrase du texte source**. Elle est produite par la traversee du graphe : Guardiola -> Manchester City -> Haaland / De Bruyne -> Norvege / Belgique. C'est la signature du raisonnement multi-hop reussi : la reponse est **construite**, pas retrouvee."
    ]
   },
   {
@@ -3288,7 +3362,9 @@
     "\n",
     "La gestion robuste des cles API (detection automatique, fallback vers les données de demonstration, verification au demarrage) garantit que le notebook fonctionne dans tous les environnements, avec ou sans acces a un LLM. Ce pattern est transposable a tout notebook utilisant des services externes.\n",
     "\n",
-    "Dans le notebook suivant (**SW-13-Python-Reasoners**), nous comparerons les raisonneurs OWL (owlrl, HermiT, reasonable, Growl) pour comprendre les compromis entre expressivite, performance et facilite d'integration."
+    "Dans le notebook suivant (**SW-13-Python-Reasoners**), nous comparerons les raisonneurs OWL (owlrl, HermiT, reasonable, Growl) pour comprendre les compromis entre expressivite, performance et facilite d'integration.\n",
+    "\n",
+    "Pour aller plus loin que ce notebook : brancher une vraie cle API (section 3) et comparer l'extraction reelle aux donnees de demonstration sur le meme texte est l'experience la plus instructive — les ecarts portent precisement sur les cas limites identifies ici (personnages fictifs, cardinalite des prix, normalisation des noms)."
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/notebook-lean #12317

See #11601 (tranche densité round 2, pool prioritaire SW-10/12/13 — SW-13 déjà traité #12129, SW-10 jumeau twin-registered)

## Summary

Enrichissement markdown-only de `SW-12-Python-GraphRAG.ipynb` : **densité 1509 → 1994** c/cell (+485, +10 683 chars de prose ; la valeur 1271 du baseline JSON datait — mesure avant/après refaite sur la même paire de commits). 63 → 66 cellules (3 nouvelles `### Lecture du resultat`), 22 cellules code **inchangées** (C.2 exception markdown-only : aucun output, aucun `execution_count` touché).

| Zone enrichie | Ancrage output réel |
|---|---|
| Intro (position série + Edge et al. 2024, périmètre honnête du notebook) | — (prose) |
| Architecture : asymétrie de coût construction/interrogation | renvoi exemple guide 2 |
| Lecture des 15 entités (3 personnages fictifs, Oscar générique) | sortie détaillée ec=4 |
| Décomposition arithmétique des 61 triplets (30 type+label + 19 attributs + 12 relations) | sortie ec=5 |
| Sous-graphe : artefact d'affichage `22-rdf-syntax-ns#type` + effet max_hops | sortie ec=7 |
| Questions : tailles de contexte 8/7/7/5 = degré des entités ; honnêteté « toutes mono-saut » | sortie ec=9 |
| Leiden : greedy_modularity = proxy pédagogique, connexité vs Louvain, `leidenalg` | sortie ec=10 |
| Lecture des 6 communautés (ponts Oscar/WB ; 3 singletons = personnages fictifs, cohérent 15-12=3 avec exemple guide 1) | sorties ec=10 + ec=12 |
| **3 nouvelles** Lectures : cache ×170 (latence simulée soulignée), évaluation P=0.73/R=1.00 relue comme désaccord d'annotation (les 4 « hallucinations » sont dans le texte), pipeline football (réponse construite par traversee, absente du texte source) | sorties ec=13/14/15 |

## Validation

- **Densité** : `pedagogy_density.py` — 1509 → **1994** (mesuré avant/après sur main vs branche, même métrique).
- **Ancrage prose↔outputs** : chaque chiffre cité vérifié contre les outputs committés (61=30+19+12, communautés C1 5 membres/C2 4/C3 3 + 3 singletons, 8/7/7/5 faits, 0.73/1.00/0.85, ×170, 1.510 s/8.86 ms, 32 triplets/11 entités, Belgique+Norvège).
- **Interp positioning** : `check_interp_positioning.py` — 0 finding (les 3 nouvelles Lectures suivent immédiatement leur cellule code).
- **validate_pr_notebooks** : 1/1 PASS.
- **C.1/C.2/H.3** : aucune cellule code modifiée, outputs et `execution_count` inchangés, hooks verts.
- **Interp-duplicate** : aucun doublon consécutif créé (appends dans cellules existantes + 3 Lectures séparées par des cellules code).

## Scope

1 fichier, markdown-only. Pas de twin (SW-12 n'a pas de jumeau C# enregistré — vérifié `twin_pairs.d/`). Aucun README touché (la tranche ne modifie pas les compteurs de série).

## Note

Le label `candidate-delivered` de #11601 a été retiré ce cycle (commentaire 5380522791) : l'umbrella reste vivante (189 notebooks dans le pool round 2).
