### PR TITLE
fix(notebooks,#11947): heading_in_list + hr_separator QC-Py tranche 2 -- 8 notebooks non contestes (MD-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -80,7 +80,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "> **Mode d'emploi** : Ce notebook est un **document de reference** (non executable).\n",
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
@@ -88,7 +88,7 @@
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -105,7 +105,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Setup et Imports"
    ]
@@ -255,7 +255,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -269,7 +269,7 @@
     "- Formatage de résultats (`format_backtest_summary`)\n",
     "- Graphiques de performance (`plot_backtest_results`)\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -286,7 +286,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1: Introduction a l'Optimisation (15 min)\n",
     "\n",
@@ -704,7 +704,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2: Parameter Sets dans QuantConnect (20 min)\n",
     "\n",
@@ -1198,7 +1198,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1218,7 +1218,7 @@
     "\n",
     "> *Ancre savante -- Sharpe (1966), « Mutual Fund Performance », The Journal of Business 39(1), 119-138 (ratio Return/volatilité, fitness directionnelle de référence). Sortino & Price (1994), « Performance Measurement in a Downside Risk Framework », The Journal of Investing 3(3), 59-65 (ratio Return/volatilité négative, distingue risque de hausse et de baisse).*\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -1235,7 +1235,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 3: Grid Search Manuel (25 min)\n",
     "\n",
@@ -1557,7 +1557,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1575,7 +1575,7 @@
     "\n",
     "Le nombre total de combinaisons peut être grand (ex: 6×7×4×4 = 672), donc la Grid Search est coûteuse en temps.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -1699,7 +1699,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1717,7 +1717,7 @@
     "\n",
     "**Note**: Les paramètres optimaux dépendent de la période et de l'instrument. Toujours valider OOS.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -1808,7 +1808,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1825,7 +1825,7 @@
     "\n",
     "Cette visualisation aide à identifier les **zones de robustesse** dans l'espace des paramètres.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -1907,7 +1907,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1925,14 +1925,14 @@
     "\n",
     "**Objectif**: Identifier les combinaisons dans le coin supérieur gauche (Sharpe élevé, DD faible).\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 1 : Grid search personnalise\n",
     "\n",
     "Le grid search standard explore toutes les combinaisons, ce qui est couteux. Un grid search adaptatif explore les zones prometteuses en priorite.\n",
@@ -1946,8 +1946,8 @@
     "- Utilisez la fonction `backtest_sma_strategy()` définie ci-dessus\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : Stockez les résultats coarse dans un DataFrame, puis `.nsmallest(3, 'sharpe')` ou `.nlargest(3, 'sharpe')`\n",
-    "- # Indice : Pour le niveau fine, créez un nouvel espace de recherche centre sur chaque meilleure config"
+    "- **Indice** : Stockez les résultats coarse dans un DataFrame, puis `.nsmallest(3, 'sharpe')` ou `.nlargest(3, 'sharpe')`\n",
+    "- **Indice** : Pour le niveau fine, créez un nouvel espace de recherche centre sur chaque meilleure config"
    ],
    "id": "cell-c6b5adf7"
   },
@@ -1985,7 +1985,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4: Walk-Forward Analysis (25 min)\n",
     "\n",
@@ -2332,7 +2332,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2350,7 +2350,7 @@
     "\n",
     "**Output**: DataFrame avec une ligne par fold + métriques IS/OOS.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -2435,7 +2435,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2449,7 +2449,7 @@
     "\n",
     "La Walk-Forward sur ces données simulées démontre la méthodologie. En pratique, utiliser des données historiques réelles avec plus de folds pour une validation robuste.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -2586,7 +2586,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2601,7 +2601,7 @@
     "\n",
     "**Correlation IS-OOS**: Mesure la prévisibilité des paramètres. Une corrélation élevée (> 0.5) indique que les bons paramètres IS restent bons OOS.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -2756,7 +2756,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2770,14 +2770,14 @@
     "\n",
     "**4. IS vs OOS Scatter**: Chaque point = un fold. La ligne verte y=x indique une performance égale IS/OOS (pas d'overfitting). La ligne rouge est la régression.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 2 : Ratio d'efficacite Walk-Forward\n",
     "\n",
     "Le ratio d'efficacite compare la performance hors-echantillon a la performance en-echantillon. Un ratio > 0.5 indique une bonne robustesse.\n",
@@ -2790,8 +2790,8 @@
     "- Un ratio > 0.5 = modèle robuste, < 0.3 = surapprentissage probable\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : Parcourez les résultats de `walk_forward_results` (variable définie ci-dessus)\n",
-    "- # Indice : Protegez contre la division par zero avec `max(sharpe_IS, 1e-6)`"
+    "- **Indice** : Parcourez les résultats de `walk_forward_results` (variable définie ci-dessus)\n",
+    "- **Indice** : Protegez contre la division par zero avec `max(sharpe_IS, 1e-6)`"
    ],
    "id": "cell-c271e087"
   },
@@ -2827,7 +2827,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 5: Eviter l'Overfitting (15 min)\n",
     "\n",
@@ -3296,7 +3296,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -3310,7 +3310,7 @@
     "\n",
     "**Interprétation**: Si une petite variation de paramètres cause une chute de performance, les paramètres sont **trop spécifiques** aux données historiques = signe d'overfitting.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -3358,7 +3358,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 6: Optimisation Avancee (20 min)\n",
     "\n",
@@ -3648,7 +3648,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -3665,7 +3665,7 @@
     "- Sharpe: Pour les investisseurs averses au risque volatilité\n",
     "- Calmar: Pour les investisseurs averses au risque de perte maximale\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -3954,7 +3954,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -3970,7 +3970,7 @@
     "\n",
     "Ces graphiques montrent la **variabilité** de la performance selon les conditions de marché.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -3987,7 +3987,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 7: Exemple Complet (15 min)\n",
     "\n",
@@ -4298,7 +4298,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -4312,7 +4312,7 @@
     "\n",
     "Le score final (0-100%) indique si la stratégie est prête pour la production.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -4542,7 +4542,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -4554,7 +4554,7 @@
     "\n",
     "**Pour déployer**: Copier ce code dans `main.py` d'un projet QC Lab, ajuster les dates, et lancer un backtest de validation.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -4571,7 +4571,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion et Prochaines Étapes\n",
     "\n",
@@ -4630,7 +4630,7 @@
     "- [Walk-Forward Analysis Guide](https://www.investopedia.com/terms/w/walk-forward-testing.asp)\n",
     "- [Avoiding Overfitting in Trading](https://quantpedia.com/how-to-avoid-overfitting-in-trading-strategies/)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook complete. L'optimisation des paramètres est cruciale mais doit etre faite avec rigueur pour eviter l'overfitting.**"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
@@ -12,7 +12,7 @@
     "> **Données non-traditionnelles pour generer de l'alpha**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire-Avance | Python + QuantConnect\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'Apprentissage\n",
     "\n",
@@ -41,8 +41,9 @@
     "3. SEC Filings (20 min)\n",
     "4. Custom Data Sources (30 min)\n",
     "5. Economic Indicators (15 min)\n",
-    "6. Stratégie Event-Driven: Earnings (20 min)",
-    "\n\n> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
+    "6. Stratégie Event-Driven: Earnings (20 min)\n",
+    "\n",
+    "> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
    ],
    "id": "cell-e92d6044"
   },
@@ -58,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "> **Mode d'emploi** : Ce notebook est un **document de reference** (non executable).\n",
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
@@ -66,7 +67,7 @@
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
-    "---"
+    "***"
    ],
    "id": "cell-2e754700"
   },
@@ -74,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : Introduction aux Données Alternatives (15 min)\n",
     "\n",
@@ -205,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2 : Fundamentals Data Morningstar (25 min)\n",
     "\n",
@@ -678,7 +679,7 @@
    "id": "cell-3e514b7d",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 1 : Stratégie de rotation sectorielle\n",
     "\n",
     "Les fundamentals Morningstar permettent de classer les secteurs par attractivite. Une stratégie de rotation sectorielle alloue plus de capital aux secteurs les plus attractifs.\n",
@@ -692,9 +693,9 @@
     "- Rebalance mensuellement\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `Fundamentals[symbol].ValuationRatios.PERatio` pour le P/E\n",
-    "- # Indice : `Fundamentals[symbol].OperationRatios.ROE.Value` pour le ROE\n",
-    "- # Indice : `FineFundamental` dans `OnFrameworkData` donne acces aux fundamentals"
+    "- **Indice** : `Fundamentals[symbol].ValuationRatios.PERatio` pour le P/E\n",
+    "- **Indice** : `Fundamentals[symbol].OperationRatios.ROE.Value` pour le ROE\n",
+    "- **Indice** : `FineFundamental` dans `OnFrameworkData` donne acces aux fundamentals"
    ]
   },
   {
@@ -720,7 +721,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 3 : SEC Filings (20 min)\n",
     "\n",
@@ -1001,7 +1002,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4 : Custom Data Sources (30 min)\n",
     "\n",
@@ -1593,7 +1594,7 @@
    "id": "cell-288213b7",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 2 : Source de données personnalisee multi-format\n",
     "\n",
     "QuantConnect accepte les CSV mais aussi les JSON et les données en temps reel via API. Cet exercice combine deux sources en une seule custom data source.\n",
@@ -1607,8 +1608,8 @@
     "- Proprietes : `sentiment_score`, `volume_indicator`, `signal_strength`\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `SourceType` peut etre `Csv` ou `Rest` selon le format\n",
-    "- # Indice : Utilisez `self.SetField()` pour les propriete dynamiques"
+    "- **Indice** : `SourceType` peut etre `Csv` ou `Rest` selon le format\n",
+    "- **Indice** : Utilisez `self.SetField()` pour les propriete dynamiques"
    ]
   },
   {
@@ -1696,7 +1697,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 5 : Economic Indicators (15 min)\n",
     "\n",
@@ -1848,7 +1849,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 6 : Stratégie Event-Driven: Earnings (20 min)\n",
     "\n",
@@ -2350,7 +2351,7 @@
    "id": "cell-2e303582",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 3 : Stratégie PEAD multi-facteurs\n",
     "\n",
     "Le PEAD classique achete après un earnings surprise positif. Une version multi-facteurs combine earnings surprise, volume anormal et volatilite implicite.\n",
@@ -2364,8 +2365,8 @@
     "- Sortie : après 10 jours ou si le prix revient au pre-earnings\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `self.Securities[symbol].Volume` pour le volume du jour\n",
-    "- # Indice : Utilisez une `RollingWindow[TradeBar]` pour calculer les volumes et volatilites glissantes"
+    "- **Indice** : `self.Securities[symbol].Volume` pour le volume du jour\n",
+    "- **Indice** : Utilisez une `RollingWindow[TradeBar]` pour calculer les volumes et volatilites glissantes"
    ]
   },
   {
@@ -2391,7 +2392,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion et Prochaines Étapes\n",
     "\n",
@@ -2470,7 +2471,7 @@
     "- [SEC Filings Data](https://www.quantconnect.com/docs/v2/writing-algorithms/datasets/sec/8k-reports)\n",
     "- [NewsAPI Documentation](https://newsapi.org/docs)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook complete. Vous maitrisez maintenant l'integration des Données Alternatives dans QuantConnect.**"
    ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
@@ -34,7 +34,7 @@
     "6. Integration Trading: Prediction to Signal (20 min)\n",
     "7. Stratégie Complete: Return Prediction (20 min)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
    ],
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "> **Mode d'emploi** : Ce notebook a **deux parties** :\n",
     "> 1. **Sections analyse/ML** (pandas, sklearn, matplotlib) : **executables en Jupyter local**\n",
@@ -60,7 +60,7 @@
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
     "\n",
-    "---"
+    "***"
    ],
    "id": "cell-a9ee5e88"
   },
@@ -161,7 +161,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -185,7 +185,7 @@
     "- `mean_squared_error`, `mean_absolute_error` : Erreur de prediction\n",
     "- `r2_score` : Coefficient de détermination (variance expliquée)\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-e637849f"
@@ -307,7 +307,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -339,7 +339,7 @@
     "- 10 features + 1 target\n",
     "- Mean target ≈ 0 (rendement quotidien moyen)\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-02644ef6"
@@ -396,7 +396,7 @@
    "id": "cell-d2d75872",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 1 : Transformation classification en regression\n",
     "\n",
     "Un problème de classification (hausse/baisse) peut etre reformule en regression (predire le retour continu). Cette reformulation preserve plus d'information.\n",
@@ -410,8 +410,8 @@
     "- Comparez : accuracy, precision, recall des deux approches\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `(y_reg > 0).astype(int)` pour convertir les cibles de regression en labels\n",
-    "- # Indice : `(y_pred_reg > 0).astype(int)` pour convertir les predictions"
+    "- **Indice** : `(y_reg > 0).astype(int)` pour convertir les cibles de regression en labels\n",
+    "- **Indice** : `(y_pred_reg > 0).astype(int)` pour convertir les predictions"
    ]
   },
   {
@@ -436,7 +436,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -468,7 +468,7 @@
     "**Features sélectionnées :**\n",
     "10 features techniques : rendements, volatilité, RSI, moyennes mobiles, MACD, Bollinger Bands, volume.\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-c5f64f6a"
@@ -477,7 +477,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2 : Linear Regression - Ridge, Lasso, ElasticNet (20 min)\n",
     "\n",
@@ -511,14 +511,14 @@
     "  - Plus flexible\n",
     "```\n",
     "\n",
-    "> *Ancres savantes -- Hoerl, A. E. & Kennard, R. W. (1970), « Ridge Regression: Biased Estimation for Nonorthogonal Problems », Technometrics 12(1):55-67 (DOI 10.1080/00401706.1970.10488634) -- Ridge regression : introduit la penalite L2 (terme lambda*||beta||^2) qui reserre les coefficients vers zero sans jamais les annuler, contre le sur-apprentissage en presence de colinearite ; la table de regularisation ci-dessus l'illustre comme le cas L2 de la famille. Tibshirani, R. (1996), « Regression Shrinkage and Sélection via the Lasso », Journal of the Royal Statistical Society Series B 58(1):267-288 (DOI 10.1111/j.2517-6161.1996.tb02080.x) -- Lasso : la penalite L1 (lambda*||beta||_1) produit une parcimonie exacte (coefficients ramenes a zero), c'est-a-dire une sélection de variables automatique, que Ridge ne permet pas. Zou, H. & Hastie, T. (2005), « Regularization and Variable Sélection via the Elastic Net », JRSS-B 67(2):301-320 -- Elastic Net : combine les penalites L1 et L2 pour recuperer la sélection de variables du Lasso tout en stabilisant les groupes de variables correlees (ou le Lasso pur en selectionne une sur N au hasard), d'ou le compromis ridge-lasso enseigne dans cette Partie 2.*\n"
+    "> *Ancres savantes -- Hoerl, A. E. & Kennard, R. W. (1970), « Ridge Regression: Biased Estimation for Nonorthogonal Problems », Technometrics 12(1):55-67 (DOI 10.1080/00401706.1970.10488634) -- Ridge regression : introduit la penalite L2 (terme lambda*||beta||^2) qui reserre les coefficients vers zero sans jamais les annuler, contre le sur-apprentissage en presence de colinearite ; la table de regularisation ci-dessus l'illustre comme le cas L2 de la famille. Tibshirani, R. (1996), « Regression Shrinkage and Sélection via the Lasso », Journal of the Royal Statistical Society Series B 58(1):267-288 (DOI 10.1111/j.2517-6161.1996.tb02080.x) -- Lasso : la penalite L1 (lambda*||beta||_1) produit une parcimonie exacte (coefficients ramenes a zero), c'est-a-dire une sélection de variables automatique, que Ridge ne permet pas. Zou, H. & Hastie, T. (2005), « Regularization and Variable Sélection via the Elastic Net », JRSS-B 67(2):301-320 -- Elastic Net : combine les penalites L1 et L2 pour recuperer la sélection de variables du Lasso tout en stabilisant les groupes de variables correlees (ou le Lasso pur en selectionne une sur N au hasard), d'ou le compromis ridge-lasso enseigne dans cette Partie 2.*"
    ],
    "id": "cell-643057ee"
   },
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -553,7 +553,7 @@
     "  - Meilleur des deux mondes\n",
     "```\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-a6348286"
@@ -630,7 +630,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -665,7 +665,7 @@
     "- Ne fait pas de sélection de features (toutes gardées)\n",
     "- Moins interprétable que Lasso\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-e63fb82a"
@@ -728,7 +728,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -761,7 +761,7 @@
     "- Arbitraire avec features corrélées (en choisit une au hasard)\n",
     "- Peut underfit avec alpha trop élevé\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-8c7935bd"
@@ -844,7 +844,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -880,7 +880,7 @@
     "- l1_ratio=0.2-0.5 : Bon compromis pour données financières\n",
     "- Features corrélées sont regroupées (Ridge) avec sélection (Lasso)\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-b95f9954"
@@ -961,7 +961,7 @@
    "id": "cell-78b2d13b",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 2 : Sélection du alpha optimal par validation croisee\n",
     "\n",
     "Ridge et Lasso ont un hyperparametre alpha qui contrôle la regularisation. Le choix optimal depend des données.\n",
@@ -975,8 +975,8 @@
     "- Tracez l'evolution du score CV en fonction de alpha (log scale)\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `sklearn.model_selection.GridSearchCV` avec `param_grid={'alpha': alphas}`\n",
-    "- # Indice : `cv_results_['mean_test_score']` pour les scores CV"
+    "- **Indice** : `sklearn.model_selection.GridSearchCV` avec `param_grid={'alpha': alphas}`\n",
+    "- **Indice** : `cv_results_['mean_test_score']` pour les scores CV"
    ]
   },
   {
@@ -1001,7 +1001,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1030,7 +1030,7 @@
     "- Lasso : Si on veut une sélection automatique de features\n",
     "- ElasticNet : Si on veut un compromis (features corrélées)\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-96adfceb"
@@ -1039,7 +1039,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 3 : Ensemble Methods - Random Forest et Gradient Boosting (25 min)\n",
     "\n",
@@ -1067,14 +1067,14 @@
     "Prediction finale = Moyenne(Prediction 1, ..., Prediction N)\n",
     "```\n",
     "\n",
-    "> *Ancres savantes -- Breiman, L. (2001), « Random Forests », Machine Learning 45(1):5-32 (DOI 10.1023/A:1010933404324) -- Random Forest : generalise le bagging (Bootstrap AGGregatING) en ajoutant une sélection aleatoire d'un sous-ensemble de variables a chaque split (feature subsampling), decorrelant les arbres et reduisant la variance par moyenne -- le schema de bootstrap du « Random Forest Regressor » ci-dessus materialise ce principe. Friedman, J. H. (2001), « Greedy Function Approximation: A Gradient Boosting Machine », The Annals of Statistics 29(5):1189-1232 (1999 Reitz Lecture, DOI 10.1214/aos/1013203451) -- Gradient Boosting (MART) : au lieu d'agreger des arbres independants (bagging), on les construit sequentiellement en ajustant chaque nouvel arbre au gradient des residus du précédent, minimisant une fonction de perte additive -- le principe récursif sur les residus enseigne dans cette Partie 3. Chen, T. & Guestrin, C. (2016), « XGBoost: A Scalable Tree Boosting System », Proceedings of the 22nd ACM SIGKDD (KDD '16):785-794 (arXiv:1603.02754, DOI 10.1145/2939672.2939785) -- XGBoost : implementation optimisee du gradient boosting (objectif regularise, split finding sparsity-aware, cache-aware et out-of-core) qui en a fait le standard de fait du tabular ML et dont l'usage via sklearn/xgboost est demontre dans cette Partie 3.*\n"
+    "> *Ancres savantes -- Breiman, L. (2001), « Random Forests », Machine Learning 45(1):5-32 (DOI 10.1023/A:1010933404324) -- Random Forest : generalise le bagging (Bootstrap AGGregatING) en ajoutant une sélection aleatoire d'un sous-ensemble de variables a chaque split (feature subsampling), decorrelant les arbres et reduisant la variance par moyenne -- le schema de bootstrap du « Random Forest Regressor » ci-dessus materialise ce principe. Friedman, J. H. (2001), « Greedy Function Approximation: A Gradient Boosting Machine », The Annals of Statistics 29(5):1189-1232 (1999 Reitz Lecture, DOI 10.1214/aos/1013203451) -- Gradient Boosting (MART) : au lieu d'agreger des arbres independants (bagging), on les construit sequentiellement en ajustant chaque nouvel arbre au gradient des residus du précédent, minimisant une fonction de perte additive -- le principe récursif sur les residus enseigne dans cette Partie 3. Chen, T. & Guestrin, C. (2016), « XGBoost: A Scalable Tree Boosting System », Proceedings of the 22nd ACM SIGKDD (KDD '16):785-794 (arXiv:1603.02754, DOI 10.1145/2939672.2939785) -- XGBoost : implementation optimisee du gradient boosting (objectif regularise, split finding sparsity-aware, cache-aware et out-of-core) qui en a fait le standard de fait du tabular ML et dont l'usage via sklearn/xgboost est demontre dans cette Partie 3.*"
    ],
    "id": "cell-8d612b05"
   },
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1101,7 +1101,7 @@
     "- Chaque nouvel arbre se concentre sur les résidus\n",
     "- Performance supérieure mais plus complexe à tuner\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-a6c6c78d"
@@ -1195,7 +1195,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1232,7 +1232,7 @@
     "- Plus lent qu'un seul arbre\n",
     "- Moins interprétable\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-ddb12270"
@@ -1307,7 +1307,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1334,7 +1334,7 @@
     "\n",
     "**Note** : L'importance Random Forest est basée sur la réduction de l'impureté (MSE) moyenne des splits utilisant chaque feature.\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-37a1204b"
@@ -1427,7 +1427,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1460,7 +1460,7 @@
     "\n",
     "**Risque** : Trop d'arbres ou trop de profondeur = overfitting\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-bef3c51c"
@@ -1553,7 +1553,7 @@
    "id": "cell-b544a236",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 3 : Stacking de regressieurs\n",
     "\n",
     "Le stacking combine les predictions de plusieurs modèles via un meta-modèle. Il surperforme souvent les modèles individuels.\n",
@@ -1568,8 +1568,8 @@
     "- Metrique : RMSE et R2 sur le test set\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `sklearn.ensemble.StackingRegressor` avec `estimators=[...]`\n",
-    "- # Indice : Le meta-modèle s'appelle `final_estimator` dans StackingRegressor"
+    "- **Indice** : `sklearn.ensemble.StackingRegressor` avec `estimators=[...]`\n",
+    "- **Indice** : Le meta-modèle s'appelle `final_estimator` dans StackingRegressor"
    ]
   },
   {
@@ -1594,7 +1594,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1622,7 +1622,7 @@
     "\n",
     "**Note** : XGBoost nécessite une installation séparée (`pip install xgboost`).\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-e5cdf49f"
@@ -1631,7 +1631,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4 : Support Vector Regression (15 min)\n",
     "\n",
@@ -1662,7 +1662,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1689,7 +1689,7 @@
     "\n",
     "**⚠️ Règle critique** : Le SVR nécessite IMPÉRATIVEMENT des features standardisées (mean=0, std=1). Sans scaling, les performances sont très dégradées.\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-2007da8e"
@@ -1753,7 +1753,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1784,7 +1784,7 @@
     "\n",
     "**Règle** : TOUJOURS scaler les features avant SVR (ou tout modèle à base de kernel).\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-27e2765e"
@@ -1868,7 +1868,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -1895,7 +1895,7 @@
     "\n",
     "**Note** : Le RBF kernel est généralement le meilleur choix pour les données financières car il capture les relations non-linéaires sans overfitting excessif.\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-a905f5f4"
@@ -1983,7 +1983,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2019,7 +2019,7 @@
     "- Interface propre pour QC\n",
     "- Gestion des erreurs (valeurs manquantes)\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-6bea9b2d"
@@ -2028,7 +2028,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 5 : Metriques de Regression (15 min)\n",
     "\n",
@@ -2055,7 +2055,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2080,7 +2080,7 @@
     "\n",
     "**Note** : Un modèle peut avoir un bon R² mais une mauvaise Direction Accuracy s'il se trompe systématiquement de signe sur les petits mouvements.\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-341bd712"
@@ -2189,7 +2189,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2214,7 +2214,7 @@
     "\n",
     "**Point clé** : La Direction Accuracy est souvent plus importante que le RMSE pour le trading. Un modèle peut avoir un faible RMSE mais se tromper de direction (signe opposé).\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-4f6df42f"
@@ -2298,7 +2298,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2325,7 +2325,7 @@
     "\n",
     "**Note importante** : La Direction Accuracy est souvent plus importante que le RMSE pour le trading. Un modèle peut avoir un bon RMSE mais prédire la mauvaise direction (ex: -0.5% prédit au lieu de +0.5%).\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-6fe4f269"
@@ -2395,7 +2395,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2420,7 +2420,7 @@
     "- Les extremes sont plus difficiles à prédire\n",
     "- La distribution des erreurs est souvent proche de la normale\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-5cbfaf10"
@@ -2429,7 +2429,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 6 : Integration Trading - Prediction to Signal (20 min)\n",
     "\n",
@@ -2466,7 +2466,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2496,7 +2496,7 @@
     "\n",
     "**Note** : La magnitude de la prediction fournit une information précieuse pour le position sizing, impossible avec la classification (binaire).\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-18494cb4"
@@ -2690,7 +2690,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2722,7 +2722,7 @@
     "- `min_return_threshold` : Seuil minimum pour signal (0.5%)\n",
     "- `max_confidence` : Rendement correspondant à 100% confiance (2%)\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-f209b78e"
@@ -2836,7 +2836,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2863,7 +2863,7 @@
     "- Sharpe > 1 : Bon ratio risk/return\n",
     "- Outperformance positive : Le modèle ajoute de la valeur vs passive\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-90de093f"
@@ -2911,7 +2911,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -2938,7 +2938,7 @@
     "\n",
     "**Note** : En production, les coûts de transaction réduisent significativement les performances des stratégies à forte fréquence.\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-8d6d553b"
@@ -2947,7 +2947,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 7 : Stratégie Complete - Return Prediction (20 min)\n",
     "\n",
@@ -2987,7 +2987,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -3016,7 +3016,7 @@
     "- Filtrage des signaux faibles pour réduire les coûts\n",
     "- Position sizing proportionnel pour optimiser le risk/return\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-d3fa5232"
@@ -3355,7 +3355,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -3386,7 +3386,7 @@
     "- `min_signal_threshold` : Seuil minimum pour signal (1%)\n",
     "- `max_positions` : Nombre maximum de positions simultanées\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-3a3357e2"
@@ -3443,7 +3443,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Interprétation\n",
     "\n",
@@ -3465,7 +3465,7 @@
     "- `Retraining` (30 jours) : Adaptation régulière aux changements de régime\n",
     "- `Lookback` (252 jours) : 1 an de données pour l'entraînement\n",
     "\n",
-    "---"
+    "***"
    ],
    "metadata": {},
    "id": "cell-8d0f73c1"
@@ -3474,7 +3474,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion et Prochaines Étapes\n",
     "\n",
@@ -3574,7 +3574,7 @@
     "- [Advances in Financial ML](https://www.amazon.com/Advances-Financial-Machine-Learning-Marcos/dp/1119482089) - Lopez de Prado\n",
     "- [QuantConnect ML Documentation](https://www.quantconnect.com/docs/v2/writing-algorithms/machine-learning)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook complete. Vous maitrisez maintenant la regression ML pour la prediction de prix.**"
    ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
@@ -90,7 +90,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "> **Mode d'emploi** : Ce notebook a **deux parties** :\n",
     "> 1. **Sections analyse/ML** (pandas, sklearn, matplotlib) : **executables en Jupyter local**\n",
@@ -98,7 +98,7 @@
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -115,7 +115,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : Le Problème de l'Attention O(n²) (10 min)\n",
     "\n",
@@ -414,7 +414,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2 : Théorie des State Space Models (20 min)\n",
     "\n",
@@ -804,10 +804,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "ecf30298",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 1 : Mécanisme d'attention simplifie\n",
     "\n",
     "L'attention du Transformer calcule `softmax(QK^T / sqrt(d_k)) * V`. Implementons-la from scratch.\n",
@@ -823,13 +823,13 @@
     "- Testez avec `d_model=32`, `seq_len=10`\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `torch.triu` avec `diagonal=1` pour le masque causal, remplissez avec `-inf`\n",
-    "- # Indice : `F.softmax(scores, dim=-1)` pour normaliser"
+    "- **Indice** : `torch.triu` avec `diagonal=1` pour le masque causal, remplissez avec `-inf`\n",
+    "- **Indice** : `F.softmax(scores, dim=-1)` pour normaliser"
    ]
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "8c2a199a",
    "metadata": {},
    "source": [
     "# Exercice 1 : Attention a tete unique from scratch\n",
@@ -892,7 +892,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 3 : De S4 à Mamba - Selective State Spaces (20 min)\n",
     "\n",
@@ -929,7 +929,7 @@
     "- **Kernel fusion** pour réduire les accès mémoire\n",
     "- **Recomputation** dans le backward pass\n",
     "\n",
-    "> *Ancre savante -- Gu, A. & Dao, T. (2023), Mamba: Linear-Time Sequence Modeling with Selective State Spaces (arXiv:2312.00752). (Innovation cle : rendre les matrices B, C et le pas Delta dependants de l'input -> state space model selectif, contexte-aware, complexite lineaire O(n) vs quadratique O(n^2) de l'attention ; scan parallele hardware-aware.) Generalise S4 (Gu, Goel & Re 2022) en levant la contrainte de matrices fixes.*\n"
+    "> *Ancre savante -- Gu, A. & Dao, T. (2023), Mamba: Linear-Time Sequence Modeling with Selective State Spaces (arXiv:2312.00752). (Innovation cle : rendre les matrices B, C et le pas Delta dependants de l'input -> state space model selectif, contexte-aware, complexite lineaire O(n) vs quadratique O(n^2) de l'attention ; scan parallele hardware-aware.) Generalise S4 (Gu, Goel & Re 2022) en levant la contrainte de matrices fixes.*"
    ]
   },
   {
@@ -1196,7 +1196,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4 : Implémentation Mamba Complète pour Trading (20 min)\n",
     "\n",
@@ -1365,10 +1365,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "9993e6a0",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 2 : Simplified Mamba block\n",
     "\n",
     "Le bloc Mamba combine une projection lineaire, une convolution 1D et un mécanisme de sélection. Cet exercie simplifie cette architecture.\n",
@@ -1383,13 +1383,13 @@
     "- Testez sur un batch de sequence `(batch=8, seq=50, d_model=32)`\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : La convolution 1D attend `(batch, channels, seq)` -> transposez\n",
-    "- # Indice : La gate = `torch.sigmoid(gate_input) * value_input`"
+    "- **Indice** : La convolution 1D attend `(batch, channels, seq)` -> transposez\n",
+    "- **Indice** : La gate = `torch.sigmoid(gate_input) * value_input`"
    ]
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "373e1bef",
    "metadata": {},
    "source": [
     "# Exercice 2 : Simplified Mamba block\n",
@@ -1883,10 +1883,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "1cb1f5c2",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 3 : Benchmark Mamba vs LSTM\n",
     "\n",
     "Comparer un modèle SSM (Mamba) avec un LSTM sur le même dataset financier.\n",
@@ -1901,13 +1901,13 @@
     "- Affichez un tableau comparatif et les courbes de loss\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `sum(p.numel() for p in model.parameters())` pour le nombre de paramètres\n",
-    "- # Indice : `time.time()` avant/après l'entrainement pour le timing"
+    "- **Indice** : `sum(p.numel() for p in model.parameters())` pour le nombre de paramètres\n",
+    "- **Indice** : `time.time()` avant/après l'entrainement pour le timing"
    ]
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "64a0962d",
    "metadata": {},
    "source": [
     "# Exercice 3 : Benchmark Mamba vs LSTM\n",
@@ -1974,7 +1974,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 5 : SST Hybrid - Mamba + Transformer (15 min)\n",
     "\n",
@@ -2277,13 +2277,13 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 6 : Comparaison LSTM vs Transformer vs Mamba (10 min)\n",
     "\n",
     "### Benchmark sur les mêmes données\n",
     "\n",
-    "> *Ancre savante -- Hochreiter, S. & Schmidhuber, J. (1997), Long Short-Term Memory, Neural Computation 9(8):1735-1780. DOI 10.1162/neco.1997.9.8.1735. (Architecture LSTM a portes forget/input/output, resout le vanishing-gradient des RNN classiques sur les longues sequences ; baseline recurrente de la comparaison LSTM vs Transformer vs Mamba ci-dessous. Vaswani et al. 2017 / Gu & Dao 2023 sont ancrees dans les Parties 1 et 3.)*\n"
+    "> *Ancre savante -- Hochreiter, S. & Schmidhuber, J. (1997), Long Short-Term Memory, Neural Computation 9(8):1735-1780. DOI 10.1162/neco.1997.9.8.1735. (Architecture LSTM a portes forget/input/output, resout le vanishing-gradient des RNN classiques sur les longues sequences ; baseline recurrente de la comparaison LSTM vs Transformer vs Mamba ci-dessous. Vaswani et al. 2017 / Gu & Dao 2023 sont ancrees dans les Parties 1 et 3.)*"
    ]
   },
   {
@@ -2631,7 +2631,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 7 : Intégration QuantConnect (15 min)\n",
     "\n",
@@ -3095,7 +3095,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion et Prochaines Étapes\n",
     "\n",
@@ -3134,7 +3134,7 @@
     "- **QC-Py-25** : Reinforcement Learning pour trading adaptatif\n",
     "- **QC-Py-26** : LLMs pour signaux de trading\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook complété. Vous maîtrisez maintenant les State Space Models (Mamba) pour le trading algorithmique à complexité O(n).**\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -14,7 +14,7 @@
     "> **Detection et anticipation des regimes de marche pour stratégies adaptatives**\n",
     "> Duree: 60 minutes | Niveau: Intermediaire-Avance | Python + QuantConnect\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'Apprentissage\n",
     "\n",
@@ -64,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion : Resume et Prochaines Étapes\n",
     "\n",
@@ -128,7 +128,7 @@
     "- **Ang, A. & Bekaert, G.** (2002). *International Asset Allocation With Regime Shifts*. Review of Financial Studies. Regime-switching applique aux marches (les Hidden Markov Models de Baum & Petrie 1966 / Rabiner 1989 sont l'extension naturelle mentionnee en exercice).\n",
     "- **Hamilton, J. D.** (1989). *A New Approach to the Economic Analysis of Nonstationary Time Series and the Business Cycle*. Econometrica, 57(2), 357-384. Modèle Markov a changements de regime -- originateur canonique du regime-switching en econometrie, fondement théorique de la stratégie RegimeSwitching.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Felicitations !** Vous avez appris a detecter les regimes de marche et a construire une stratégie adaptative. Cette approche peut etre appliquee a de nombreuses autres stratégies pour les rendre plus robustes."
    ],
@@ -414,7 +414,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 7 : Implementation QuantConnect\n",
     "\n",
@@ -925,7 +925,7 @@
    "id": "cell-464af4c5",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 4 : Regime performance attribution\n",
     "\n",
     "Decomposez la performance d'une stratégie par regime pour identifier les forces et faiblesses.\n",
@@ -939,8 +939,8 @@
     "- Identifiez le regime ou la stratégie sous-performe le plus\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : Groupby par label de regime : `df.groupby('regime')['returns'].agg(...)`\n",
-    "- # Indice : Sharpe par regime = `mean / std` avec annualisation\n",
+    "- **Indice** : Groupby par label de regime : `df.groupby('regime')['returns'].agg(...)`\n",
+    "- **Indice** : Sharpe par regime = `mean / std` avec annualisation\n",
     "\n",
     "\n",
     "**Critère de validation** : votre tableau doit lister, pour chaque régime, le nombre de jours, le rendement moyen, la volatilité, le Sharpe et le MaxDD. Le régime qui sous-performe le plus devrait être le sideways (référence -5,1 % de la sortie committée). Point de contrôle : la somme des jours par régime doit être inférieure ou égale au total, les jours non classés étant comptés à part."
@@ -969,7 +969,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 6 : Analyse par Regime (5 min)\n",
     "\n",
@@ -1213,7 +1213,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 5 : Optimisation des Seuils (10 min)\n",
     "\n",
@@ -1316,7 +1316,7 @@
    "id": "cell-683ba458",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 5 : Stratégie de rotation adaptative\n",
     "\n",
     "Une stratégie adaptative change de regime en fonction de la volatilite et de la tendance.\n",
@@ -1330,8 +1330,8 @@
     "- Calculez le PnL cumulé et comparez avec un buy-and-hold\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `np.where(condition_trend, signal_momentum, np.where(condition_mr, signal_rsi_inv, 0))`\n",
-    "- # Indice : RSI inverse = `-1 * (RSI - 50) / 50`\n",
+    "- **Indice** : `np.where(condition_trend, signal_momentum, np.where(condition_mr, signal_rsi_inv, 0))`\n",
+    "- **Indice** : RSI inverse = `-1 * (RSI - 50) / 50`\n",
     "\n",
     "\n",
     "**Critère de validation** : tracez le PnL cumulé de la rotation et du buy-and-hold sur le même graphique. Le résultat attendu : la rotation réduit le drawdown en bear (passage défensif) sans rattraper le buy-and-hold en bull fort — le verdict honnête est rarement « gagner partout » mais « meilleur risque ajusté ». Comparez les Sharpe des deux courbes, pas seulement les valeurs finales."
@@ -1518,7 +1518,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4 : Strategy Adaptative - RegimeSwitching (15 min)\n",
     "\n",
@@ -1728,7 +1728,7 @@
    "id": "cell-7a7446ff",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 6 : Detecteur de regime multi-indicateurs\n",
     "\n",
     "Un seul indicateur (SMA, RSI, volatilite) est insuffisant. Un detecteur robuste combine plusieurs signaux.\n",
@@ -1744,8 +1744,8 @@
     "- Affichez la distribution des regimes\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : Chaque sous-score est `np.where(condition, +1, -1)`\n",
-    "- # Indice : Le score composite est une somme ponderee\n",
+    "- **Indice** : Chaque sous-score est `np.where(condition, +1, -1)`\n",
+    "- **Indice** : Le score composite est une somme ponderee\n",
     "\n",
     "\n",
     "**Critère de validation** : vérifiez que votre score composite produit une distribution à trois classes non vides. Test de discrimination : fabriquez un cas où tendance et momentum divergent (prix sous SMA200 mais retour 20j positif) — le score pondéré doit rester proche de zéro plutôt que trancher brutalement, preuve que le score synthétise au lieu de laisser un indicateur dominer."
@@ -1774,7 +1774,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 3 : Oscillateurs - RSI et Mean-Reversion (10 min)\n",
     "\n",
@@ -1985,7 +1985,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2 : Detection SMA - Trend Following (12 min)\n",
     "\n",
@@ -2192,7 +2192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : Introduction aux Regimes de Marche (8 min)\n",
     "\n",
@@ -2275,7 +2275,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "> **Mode d'emploi** : Ce notebook a **deux parties** :\n",
     "> 1. **Sections analyse/ML** (pandas, numpy, matplotlib) : **executables en Jupyter local**\n",
@@ -2283,7 +2283,7 @@
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Introduction : Pourquoi detecter les regimes de marche ?\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
@@ -39,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : Positionnement dans le paysage RL (10 min)"
    ],
@@ -79,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2 : Environnement et Configuration (5 min)"
    ],
@@ -470,7 +470,7 @@
    "id": "cell-74009362",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 1.1 : Environnement avec couts de transaction pour RL\n",
     "\n",
     "Les environnements RL de trading omettent souvent les couts de transaction, ce qui surestime la performance.\n",
@@ -484,8 +484,8 @@
     "- Affichez : reward cumule, nombre de trades, ratio reward/trade\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `cout = abs(action - prev_action) * prix * 0.0005`\n",
-    "- # Indice : Comparez les deux courbes de reward sur le même graphique"
+    "- **Indice** : `cout = abs(action - prev_action) * prix * 0.0005`\n",
+    "- **Indice** : Comparez les deux courbes de reward sur le même graphique"
    ]
   },
   {
@@ -511,7 +511,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 3 : SAC Discret (20 min)"
    ],
@@ -758,7 +758,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4 : A2C - Advantage Actor-Critic (15 min)"
    ],
@@ -903,7 +903,7 @@
    "id": "cell-17069d1b",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 2.1 : A2C avec entropy bonus\n",
     "\n",
     "L'entropy bonus dans A2C encourage l'exploration. Un coefficient trop eleve empeche la convergence.\n",
@@ -917,8 +917,8 @@
     "- Affichez les courbes de reward et d'entropy\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : La loss A2C = `policy_loss - entropy_coef * entropy`\n",
-    "- # Indice : `entropy = -(probs * log(probs)).sum(dim=-1).mean()`"
+    "- **Indice** : La loss A2C = `policy_loss - entropy_coef * entropy`\n",
+    "- **Indice** : `entropy = -(probs * log(probs)).sum(dim=-1).mean()`"
    ]
   },
   {
@@ -970,7 +970,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 5 : Benchmark 100K Steps (30 min)"
    ],
@@ -1397,7 +1397,7 @@
    "id": "cell-4051469b",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 3.2 : Comparaison quadri-algorithmes\n",
     "\n",
     "DQN, PPO, SAC et A2C ont des forces et faiblesses différentes selon l'environnement.\n",
@@ -1411,8 +1411,8 @@
     "- Affichez un tableau comparatif et un boxplot des rewards\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : Utilisez les agents définis dans les notebooks précédents (DQN, PPO)\n",
-    "- # Indice : `plt.boxplot([rewards_dqn, rewards_ppo, rewards_sac, rewards_a2c])`"
+    "- **Indice** : Utilisez les agents définis dans les notebooks précédents (DQN, PPO)\n",
+    "- **Indice** : `plt.boxplot([rewards_dqn, rewards_ppo, rewards_sac, rewards_a2c])`"
    ]
   },
   {
@@ -1438,7 +1438,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 6 : Synthese et Comparaison Quadri-Algorithmes (10 min)"
    ],
@@ -1615,7 +1615,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion : Quelle méthode RL pour le trading ?"
    ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
@@ -76,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : Pourquoi le RL pour l'allocation de portefeuille ?\n",
     "\n",
@@ -392,7 +392,7 @@
    "id": "cell-1cec015d",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 1 : Fonction de reward avec penalite de drawdown\n",
     "\n",
     "La reward basee uniquement sur le rendement encourage les allocations trop agressives. Une penalite de drawdown rend l'agent plus prudent.\n",
@@ -406,8 +406,8 @@
     "- Comparez les 4 configurations (reward, allocation, max DD final)\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `running_max = np.maximum.accumulate(portfolio_value)` puis `dd = (running_max - portfolio_value) / running_max`\n",
-    "- # Indice : Utilisez le même agent Q-learning pour chaque lambda\n",
+    "- **Indice** : `running_max = np.maximum.accumulate(portfolio_value)` puis `dd = (running_max - portfolio_value) / running_max`\n",
+    "- **Indice** : Utilisez le même agent Q-learning pour chaque lambda\n",
     "\n",
     "\n",
     "**Critère de validation** : pour chaque lambda, affichez le reward moyen, l'allocation finale apprise et le MaxDD final sur la même série. Le résultat attendu : un lambda croissant réduit le drawdown au prix d'un reward moyen plus faible — c'est le compromis que vous devez quantifier. Vérifiez aussi que l'allocation finale passe progressivement de la plus agressive (lambda 0) vers la plus défensive (lambda 2)."
@@ -726,7 +726,7 @@
    "id": "cell-85d0336b",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 3 : Agent SARSA pour l'allocation\n",
     "\n",
     "Q-learning est off-policy (utilise max Q pour la mise a jour). SARSA est on-policy (utilise l'action reellement prise), ce qui le rend plus conservateur.\n",
@@ -740,8 +740,8 @@
     "- Comparez : reward cumule, allocation finale, variance inter-episodes\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : La différence avec Q-learning est `Q(s',a')` (action prise) vs `max_a Q(s',a)` (action optimale)\n",
-    "- # Indice : L'action a' est choisie avec la même politique epsilon-greedy\n",
+    "- **Indice** : La différence avec Q-learning est `Q(s',a')` (action prise) vs `max_a Q(s',a)` (action optimale)\n",
+    "- **Indice** : L'action a' est choisie avec la même politique epsilon-greedy\n",
     "\n",
     "> *Ancres savantes -- Watkins, C.J.C.H. (1989), Learning from Delayed Rewards, PhD thesis, University of Cambridge (Q-learning : update off-policy Q(s,a) <- Q(s,a) + alpha[r + gamma * max_a' Q(s',a') - Q(s,a)], l'agent apprend la valeur de la politique greedy optimale en suivant une politique comportementale différente ; cf. Watkins & Dayan 1992, Machine Learning 8(3-4):279-292 pour la convergence) ; Rummery, G.A. & Niranjan, M. (1994), On-line Q-learning using connectionist systems, Technical Report CUED/F-INFENG/TR 166, Cambridge University Engineering Department (SARSA -- a l'origine \"Modified Connectionist Q-Learning\" : update on-policy Q(s,a) <- Q(s,a) + alpha[r + gamma * Q(s',a') - Q(s,a)] utilisant l'action reellement prise, plus conservateur que Q-learning comme note dans l'exercice).)*\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
@@ -807,7 +807,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "### Exercice 1 : Alerte de deviation backtest vs paper\n",
     "\n",
     "En paper trading, les performances reelles devient du backtest. Un système d'alerte detecte ces deviations.\n",
@@ -821,8 +821,8 @@
     "- Affichez un rapport de deviation avec niveau (OK/WARNING/CRITICAL)\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `deviation = abs(paper - backtest) / abs(backtest)`\n",
-    "- # Indice : Assignez un niveau par metrique puis prenez le max"
+    "- **Indice** : `deviation = abs(paper - backtest) / abs(backtest)`\n",
+    "- **Indice** : Assignez un niveau par metrique puis prenez le max"
    ],
    "id": "cell-b1789bc4"
   },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #12326

## Summary

Tranche 2 #11947 (heading_in_list + hr_separator) sur les **8 notebooks QC-Py non contestés** de l'arbitrage #12141/#11998 — autorisée par DM ai-01 : « Vos 9 autres notebooks (QC-Py-15, -16, -20, -23, -25, -28, -34, -35, -40) ne sont pas contestés : rien ne vous empêche de les traiter dès maintenant dans une tranche séparée ».

**QC-Py-25 exclu** : ses 6 lignes `# Indice` sont déjà corrigées sur main par #12247 (style canonique `- **Indice** :`), supérieur au backtick-wrap de la tranche E. Repartir de la version branche l'aurait **régressé**.

Fichiers : QC-Py-15, -16, -20, -23, -28, -34, -35, -40. Reconstruits **chirurgicalement depuis origin/main** (pas depuis la branche #12141, dont la base est stale — re-execs et normalisation de sérialisation exclues).

## Réparations

| Famille | Volume | Détail |
|---|---|---|
| `yaml_block_open_no_close` (ERROR) | **62 cellules** | `---` ouvrant → `***` (thematic break, render identique, pas d'opener YAML Pandoc) |
| `heading_in_list` (WARN) | **41 lignes, 18 cellules** | `- # Indice : X` → `- **Indice** : X` (style canonique #12247, pas le backtick-wrap de la tranche E qui crée des code-spans imbriqués) |
| ids de cellules | **6 ids** (QC-Py-23) | ids vides dupliqués (`""` ×6) → uniques 8-hex (nbformat 4.5) |
| séparateurs décoratifs | 109 convertis | par le pre-commit `fix-hr-separator` (comportement canonique du repo), CRLF du hook réparé en LF |

**Mécanisme de masquage découvert** : la règle `yaml_block_open_no_close` early-return **masque** les autres défauts de la cellule — les 18 cellules à `# Indice` étaient toutes des cellules yaml. Fixer `---` sans fixer les indices aurait fait réapparaître les heading_in_list au scan suivant : les deux familles vont ensemble (même constat que #12247).

## Validation (relancée post-dernier-commit 24079a143)

- `detect_markdown_rendering.py --json` par fichier : **0 finding sur 8/8** (avant : 62 yaml + heading_in_list masqués)
- `--check --baseline` (baseline canonique) : **OK, no new ERROR violations**
- **Cellules code byte-identiques** (source jointe + outputs + execution_count, par position) → **C.3 exempt** (markdown-only), C.2 préservé
- `nbformat.validate` OK ×8 · fins de ligne LF ×8 · nb cellules inchangé ×8
- H.3 `validate_pr_notebooks.py origin/main` : **PASS 8/8** (post-commit)
- Diffstat : 8 fichiers, 226 insertions / 225 suppressions (remplacements ligne-à-ligne)

## Claims

- Claim de MA lane : `[CLAIMED] QC-Py/**` (issuecomment-5366967180, 2026-08-21) — couvre ces 8 chemins.
- **Flag pour ai-01** : le claim po-2023 (issuecomment-5356207991) est **epic-wide sans clause `paths:`** alors que son texte dit « Tranche 1 (DecInfer + CaseStudies) » — il bloque mécaniquement toutes les lanes sur #11947. Mes 8 chemins sont disjoints de l'intention déclarée ; cette tranche est en outre sanctionnée par DM coordinateur. Demande : narrow le claim po-2023 ou `[OVERRIDE] lane myia-po-2025:CoursIA-2`.

## Relation à #12141

Après le rebase de #12141 (post-#11998), sa branche devra **retirer ces 8 fichiers** (livrés ici) **et QC-Py-25** (supersédé par #12247) — il ne restera que les 8 notebooks contestés + `hmm_alpha_research.ipynb`.

See #11947 (tranche partielle : 8 notebooks, l'epic reste ouverte)

🤖 Generated with [Claude Code](https://github.com/anthropics/claude-code)
