### PR TITLE
fix(notebooks,#11947): heading_in_list GenAI/Texte 7/8/9 -- 36 lignes Étape en markdown list -> `# Étape N` : via fix_hint_headings.py (MD-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
@@ -612,10 +612,10 @@
     "L'objectif est de créer une fonction `generate_and_validate` qui demande au modèle de generer une fonction Python repondant a un cahier des charges, puis valide que le code genere est correct en l'executant avec des tests predefinis.\n",
     "\n",
     "**Indices :**\n",
-    "- # Étape 1 : Définir un prompt qui demande une fonction Python spécifique (ex: tri a bulles)\n",
-    "- # Étape 2 : Appeler l'API Chat Completions pour generer le code\n",
-    "- # Étape 3 : Extraire le bloc de code de la reponse (chercher les blocs ```python ... ```)\n",
-    "- # Étape 4 : Executer le code extrait avec exec() et le tester avec des cas connus"
+    "- `# Étape 1` : Définir un prompt qui demande une fonction Python spécifique (ex: tri a bulles)\n",
+    "- `# Étape 2` : Appeler l'API Chat Completions pour generer le code\n",
+    "- `# Étape 3` : Extraire le bloc de code de la reponse (chercher les blocs ```python ... ```)\n",
+    "- `# Étape 4` : Executer le code extrait avec exec() et le tester avec des cas connus"
    ]
   },
   {
@@ -1241,10 +1241,10 @@
     "L'objectif est de créer une fonction qui genere un graphique en deux sous-figures : un histogramme avec la distribution des ventes et un boxplot par region, avec mise en evidence des outliers.\n",
     "\n",
     "**Indices :**\n",
-    "- # Étape 1 : Créer la fonction plot_sales_analysis(df, value_col, group_col)\n",
-    "- # Étape 2 : Utiliser plt.subplots(1, 2) pour les deux graphiques\n",
-    "- # Étape 3 : Gauche : histogramme avec ax.hist() + lignes verticales pour moyenne et mediane\n",
-    "- # Étape 4 : Droite : boxplot avec ax.boxplot() par groupe pour identifier les outliers"
+    "- `# Étape 1` : Créer la fonction plot_sales_analysis(df, value_col, group_col)\n",
+    "- `# Étape 2` : Utiliser plt.subplots(1, 2) pour les deux graphiques\n",
+    "- `# Étape 3` : Gauche : histogramme avec ax.hist() + lignes verticales pour moyenne et mediane\n",
+    "- `# Étape 4` : Droite : boxplot avec ax.boxplot() par groupe pour identifier les outliers"
    ]
   },
   {
@@ -1675,10 +1675,10 @@
     "L'objectif est d'implementer une fonction `analyze_dataframe` qui prend un DataFrame et retourne un rapport statistique complet avec interpretation automatique.\n",
     "\n",
     "**Indices :**\n",
-    "- # Étape 1 : Créer la fonction qui accepte un DataFrame et une liste de colonnes numériques\n",
-    "- # Étape 2 : Pour chaque colonne, calculer : moyenne, mediane, ecart-type, min, max, nb outliers (> 2 sigma)\n",
-    "- # Étape 3 : Retourner un DataFrame recapitulatif avec une ligne par colonne analysee\n",
-    "- # Étape 4 : Ajouter une colonne \"interpretation\" qui indique si la distribution est symetrique (moyenne proche de mediane)"
+    "- `# Étape 1` : Créer la fonction qui accepte un DataFrame et une liste de colonnes numériques\n",
+    "- `# Étape 2` : Pour chaque colonne, calculer : moyenne, mediane, ecart-type, min, max, nb outliers (> 2 sigma)\n",
+    "- `# Étape 3` : Retourner un DataFrame recapitulatif avec une ligne par colonne analysee\n",
+    "- `# Étape 4` : Ajouter une colonne \"interpretation\" qui indique si la distribution est symetrique (moyenne proche de mediane)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -794,10 +794,10 @@
     "L'objectif est de comparer une resolution \"directe\" (sans reflexion) avec une resolution \"pas a pas\" (chain-of-thought) sur un problème de calcul multi-étapes, en utilisant le mode chat standard.\n",
     "\n",
     "**Indices :**\n",
-    "- # Étape 1 : Définir un problème de calcul avec 3-4 étapes (ex: prix avec taxe, remise et frais de port)\n",
-    "- # Étape 2 : Appeler le modèle avec un prompt direct (\"Donne uniquement la reponse finale\")\n",
-    "- # Étape 3 : Appeler le modèle avec un prompt chain-of-thought (\"Resous étape par étape, montre chaque calcul\")\n",
-    "- # Étape 4 : Comparer les deux reponses avec la reponse correcte et afficher les résultats"
+    "- `# Étape 1` : Définir un problème de calcul avec 3-4 étapes (ex: prix avec taxe, remise et frais de port)\n",
+    "- `# Étape 2` : Appeler le modèle avec un prompt direct (\"Donne uniquement la reponse finale\")\n",
+    "- `# Étape 3` : Appeler le modèle avec un prompt chain-of-thought (\"Resous étape par étape, montre chaque calcul\")\n",
+    "- `# Étape 4` : Comparer les deux reponses avec la reponse correcte et afficher les résultats"
    ]
   },
   {
@@ -1397,10 +1397,10 @@
     "L'objectif est de comparer les 3 niveaux de `reasoning_effort` sur un problème de logique multi-étapes, et de mesurer le compromis temps/qualite.\n",
     "\n",
     "**Indices :**\n",
-    "- # Étape 1 : Définir un problème de logique a plusieurs étapes (ex: enigme des 3 portes, problème de transvasement)\n",
-    "- # Étape 2 : Boucler sur les 3 niveaux (\"low\", \"medium\", \"high\")\n",
-    "- # Étape 3 : Pour chaque niveau, mesurer le temps de reponse et stocker le résultat\n",
-    "- # Étape 4 : Afficher un tableau comparatif avec les temps, les reponses et la reponse correcte"
+    "- `# Étape 1` : Définir un problème de logique a plusieurs étapes (ex: enigme des 3 portes, problème de transvasement)\n",
+    "- `# Étape 2` : Boucler sur les 3 niveaux (\"low\", \"medium\", \"high\")\n",
+    "- `# Étape 3` : Pour chaque niveau, mesurer le temps de reponse et stocker le résultat\n",
+    "- `# Étape 4` : Afficher un tableau comparatif avec les temps, les reponses et la reponse correcte"
    ]
   },
   {
@@ -2090,10 +2090,10 @@
     "L'objectif est de créer une fonction qui demande au modèle de **verifier** si une reponse donnee a un problème mathematique est correcte, en utilisant le mode reasoning pour valider pas a pas.\n",
     "\n",
     "**Indices :**\n",
-    "- # Étape 1 : Construire un prompt qui presente le problème ET la reponse a verifier\n",
-    "- # Étape 2 : Utiliser reasoning_effort='medium' pour permettre une verification approfondie\n",
-    "- # Étape 3 : Demander au modèle de repondre uniquement par \"CORRECT\" ou \"INCORRECT\" suivi de la justification\n",
-    "- # Étape 4 : Parser la reponse pour extraire le verdict et l'explication"
+    "- `# Étape 1` : Construire un prompt qui presente le problème ET la reponse a verifier\n",
+    "- `# Étape 2` : Utiliser reasoning_effort='medium' pour permettre une verification approfondie\n",
+    "- `# Étape 3` : Demander au modèle de repondre uniquement par \"CORRECT\" ou \"INCORRECT\" suivi de la justification\n",
+    "- `# Étape 4` : Parser la reponse pour extraire le verdict et l'explication"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
@@ -1442,10 +1442,10 @@
     "L'objectif est de créer un decorateur `@retry_with_log` qui wrappe n'importe quel appel API avec retry automatique ET logging structure de chaque tentative.\n",
     "\n",
     "**Indices :**\n",
-    "- # Étape 1 : Définir le decorateur avec paramètres (max_retries, backoff_base)\n",
-    "- # Étape 2 : Dans le wrapper, boucler sur les tentatives avec try/except\n",
-    "- # Étape 3 : Logger chaque tentative (numéro, duree, succes/echec)\n",
-    "- # Étape 4 : Utiliser time.sleep avec un delai exponentiel entre les tentatives"
+    "- `# Étape 1` : Définir le decorateur avec paramètres (max_retries, backoff_base)\n",
+    "- `# Étape 2` : Dans le wrapper, boucler sur les tentatives avec try/except\n",
+    "- `# Étape 3` : Logger chaque tentative (numéro, duree, succes/echec)\n",
+    "- `# Étape 4` : Utiliser time.sleep avec un delai exponentiel entre les tentatives"
    ]
   },
   {
@@ -1715,10 +1715,10 @@
     "L'objectif est d'implementer un cache memoire qui stocke les résultats des appels API pour eviter de re-appeler le modèle sur des prompts identiques.\n",
     "\n",
     "**Indices :**\n",
-    "- # Étape 1 : Créer une classe SimpleCache avec un dictionnaire interne\n",
-    "- # Étape 2 : Implementer get(key) qui retourne la valeur ou None si absente\n",
-    "- # Étape 3 : Implementer set(key, value, ttl_seconds) avec un timestamp d'expiration\n",
-    "- # Étape 4 : Implementer cached_completion(prompt) qui utilise le cache avant d'appeler l'API"
+    "- `# Étape 1` : Créer une classe SimpleCache avec un dictionnaire interne\n",
+    "- `# Étape 2` : Implementer get(key) qui retourne la valeur ou None si absente\n",
+    "- `# Étape 3` : Implementer set(key, value, ttl_seconds) avec un timestamp d'expiration\n",
+    "- `# Étape 4` : Implementer cached_completion(prompt) qui utilise le cache avant d'appeler l'API"
    ]
   },
   {
@@ -2011,10 +2011,10 @@
     "L'objectif est de créer une classe `CostTracker` qui accumule les couts de chaque appel API et declenche une alerte quand un seuil est atteint.\n",
     "\n",
     "**Indices :**\n",
-    "- # Étape 1 : Créer la classe avec un attribut total_cost et un budget_max\n",
-    "- # Étape 2 : Implementer track(input_tokens, output_tokens, model) qui calcule le cout et l'ajoute au total\n",
-    "- # Étape 3 : Verifier si total_cost depasse budget_max et afficher un warning si oui\n",
-    "- # Étape 4 : Implementer summary() qui retourne un dict avec total_cost, nb_requetes, cout_moyen"
+    "- `# Étape 1` : Créer la classe avec un attribut total_cost et un budget_max\n",
+    "- `# Étape 2` : Implementer track(input_tokens, output_tokens, model) qui calcule le cout et l'ajoute au total\n",
+    "- `# Étape 3` : Verifier si total_cost depasse budget_max et afficher un warning si oui\n",
+    "- `# Étape 4` : Implementer summary() qui retourne un dict avec total_cost, nb_requetes, cout_moyen"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-lean #12342

## Summary

Rework **complet** suite au CHANGES_REQUESTED d'ai-01 (DM msg-20260822T153838) : la branche est **resettée à la base `ad4f46762`** et la réparation est refaite par l'outil canonique `fix_hint_headings.py` — les 36 remplacements manuels en gras sont retirés, remplacés par la forme tranchée.

```
- # Étape 1 : Définir un prompt…      →      - `# Étape 1` : Définir un prompt…
```

**36 lignes / 3 notebooks** (12 chacun : 7_Code_Interpreter, 8_Reasoning_Models, 9_Production_Patterns), 9 cellules markdown touchées, **0 cellule code modifiée** (byte-identiques `source` + `outputs` + `execution_count` → C.3, pas de ré-exécution due).

## Corrections des deux affirmations fausses du body précédent (demandées par ai-01)

1. **« l'outil backtick-wrap vit encore en PR (#12131), non mergée »** — FAUX, corrigé : l'outil `fix_hint_headings.py` est **sur `main` depuis `6711caf42`** (PR #12154). #12131 n'est pas l'outil, c'est une **tranche** qui l'emploie.
2. **« la forme gras est canonique (#12247) »** — FAUX, corrigé : #12247 relève de la campagne **#11947**, pas de la même remédiation ; la forme canonique du **transform de réparation** `heading_in_list` est `` - `# Étape N` : … `` (marqueur backtiqué) — prescrite nominativement par l'ombrelle, mesurée sur `main` à 762 lignes backtick contre 10 où le code-span avale l'instruction. Le gras reste légitime pour de la prose écrite d'origine, pas pour réparer.

## Pourquoi la forme backtick (les 3 raisons d'ai-01, vérifiées firsthand)

1. **Invariant de round-trip** : le fixer *n'insère que des backticks* — rien n'est supprimé ni réordonné (vérifié par l'outil sur chaque cellule touchée, et re-vérifié par cellule post-application : `strip('`')` byte-identique avant/après). Le gras **supprime** le `#` — le texte d'origine n'est plus reconstructible.
2. **Le `#` porte du sens** : les stubs Python portent littéralement `# Étape 1 : …` en commentaire — garder le `#` visible maintient la correspondance plan ↔ stub.
3. **Un outil livré et testé** produit cette forme ; le gras se pose à la main, tranche par tranche.

## Référence d'ombrelle

#12128 (fermée, consolidation ai-01) → l'ombrelle unique est **#11947** — les prochains `[CLAIMED] … -- paths:` de cette campagne iront là.

## Validation (post-commit dddf87482)

- `fix_hint_headings.py --scan` : **36 occurrences** détectées, `--apply` : **36 corrigées**, invariant round-trip de l'outil : PASS (l'outil refuse d'écrire s'il casse)
- Cellules code **byte-identiques** vs base : 40/40 sur les 3 notebooks ✓ · invariant backtick-only par cellule : ✓
- Sérialisation : forme d'origine préservée (fichier 7 sans newline final restauré byte-exact, CRLF de l'écriture Windows réparé)
- `detect_markdown_rendering.py` par fichier : **0 violation** ×3 ✓
- `nbformat.validate` : 3/3 OK · LF endings : ✓
- `validate_pr_notebooks.py ad4f46762 <3 fichiers>` : **PASS** ✓
- Hooks pre-commit (H.3, oversized-markdown, source-newlines) : Passed ✓

Compte exact : **36 lignes** (le body précédent disait « 37/37 » à tort — le titre avait raison).

See #11947

🤖 Generated with [Claude Code](https://github.com/anthropics/claude-code)
