### PR TITLE
feat(lean,#6724): borne de nouveaute niveau noeuds de macrocells dans Novelty (FR+EN)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Novelty.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Novelty.lean
@@ -19,21 +19,20 @@ cardinal au plus `p` contenant toute la trajectoire
 par `p`, independamment de l'horizon : c'est le pendant quantitatif du
 constat empirique « Golly est rapide sur les oscillateurs ».
 
-**Portee et limite, documentees.** La borne est au niveau GRILLE (etats
-distincts). La nouveaute operationnelle de hashlife se mesure au niveau des
-NOEUDS de macrocells (taux de hit du cache de memoisation, avec partage de
-sous-arbres) : pour un oscillateur borde, chaque etat periodique engendre un
-arbre dont les sous-arbres se repetent, mais le passage grille -> arbre de
-macrocells a une taille qui croit avec la fenetre, et la borne au niveau
-noeud demande une induction sur la structure de `MacroCell` qui reste
-hors de portee de ce module (diagnostic ecrit, cf #11162 acceptation :
-l'alternative « borne deriverie ou diagnostic » est ici le diagnostic de la
-borne noeud, la borne grille etant livree).
-
-La caracterisation « quels motifs ont une nouveaute persistante » est
-indecidable a la limite (Life est Turing-complet : une machine de Turing
-programmee encode la production infinie de motifs neufs) — les patterns
-pathologiques (MT, #6724) sont les temoins de ce plafond.
+**Portee et limite, documentees.** Deux niveaux de borne sont livres :
+GRILLE (`trajectory_states_le_of_period` : au plus `p` etats distincts) et
+NOEUDS (`nodes_novelty_bound_of_period` : au plus `p * nodesBound k`
+sous-arbres distincts de la trajectoire cadree au niveau `k`). La seconde
+est la quantite operationnelle de hashlife — le taux de hit du cache de
+memoisation, avec partage de sous-arbres : l'induction sur la structure de
+`MacroCell` que ce module declarait hors de portee lors de la livraison
+initiale (#11162, ou l'alternative « borne ou diagnostic » avait retenu le
+diagnostic) est desormais le contenu de la section dediee ci-dessous. Reste
+ouvert, et pour de bon : la caracterisation « quels motifs ont une
+nouveaute persistante » est indecidable a la limite (Life est
+Turing-complet : une machine de Turing programmee encode la production
+infinie de motifs neufs) — les patterns pathologiques (MT, #6724) sont les
+temoins de ce plafond.
 
 Ce module est entierement prouve (aucun `sorry`, aucun axiome natif).
 -/
@@ -48,6 +47,7 @@ Ce module est entierement prouve (aucun `sorry`, aucun axiome natif).
 -/
 
 import Conway.Life
+import Conway.Life.MacroCell
 import Conway.Life.HashlifeCorrectness.Foundation
 
 namespace Conway
@@ -125,6 +125,145 @@ l'horizon de simulation. -/
 theorem blinker_h_trajectory_states_le :
     ∃ s : Finset Grid, s.card ≤ 2 ∧ ∀ t : Nat, evolve t blinker_h ∈ s :=
   trajectory_states_le_of_period _ 2 (by norm_num) (by decide)
+
+open Conway.Life.MacroCell
+
+/-! ## Borne de nouveaute au niveau noeuds (macrocells)
+
+Le diagnostic du preambule est ici leve : l'induction sur la structure de
+`MacroCell` y etait declaree hors de portee, elle est le contenu de cette
+section. La nouveaute operationnelle de hashlife se mesure au niveau des
+NOEUDS du quadtree — les cles du cache de memoisation, avec partage de
+sous-arbres. La trajectoire d'un oscillateur, cadree au niveau `k`, ne
+visite qu'un nombre borne de sous-arbres distincts, de majorant
+`p * nodesBound k` independant de l'horizon : le pendant quantitatif, au
+niveau du cache, de la borne grille ci-dessus. -/
+
+/-- Compte les noeuds d'un quadtree parfait de profondeur `k` : la somme
+geometrique `1 + 4 + 16 + ... + 4^k = (4^(k+1) - 1) / 3`, definie par sa
+recurrence — la forme manipulable en preuve. -/
+def nodesBound : Nat → Nat
+  | 0 => 1
+  | k + 1 => 1 + 4 * nodesBound k
+
+/-- Profondeur structurelle d'une macrocell : la hauteur de l'arbre,
+mesuree sur la plus profonde des quatre sous-cellules. Contrairement a
+`level` (qui ne regarde que le quadrant nord-ouest), elle ne suppose pas la
+bonne formation : c'est le parametre naturel de la borne de cardinal
+ci-dessous, valide pour toute macrocell, equilibree ou non. -/
+def depth : MacroCell → Nat
+  | leaf _ => 0
+  | node nw ne sw se =>
+      1 + max (depth nw) (max (depth ne) (max (depth sw) (depth se)))
+
+/-- Tous les sous-arbres d'une macrocell, elle-meme incluse. Chaque element
+est un noeud du quadtree — une cle potentielle du cache de memoisation de
+hashlife. La nouveaute niveau noeuds d'un etat, c'est le cardinal de cet
+ensemble. -/
+def allSubtrees (c : MacroCell) : Finset MacroCell :=
+  match c with
+  | leaf _ => {c}
+  | node nw ne sw se =>
+      insert c (allSubtrees nw ∪ allSubtrees ne ∪ allSubtrees sw ∪ allSubtrees se)
+
+/-- `nodesBound` croit avec la profondeur. -/
+theorem nodesBound_mono {k m : Nat} (h : k ≤ m) : nodesBound k ≤ nodesBound m := by
+  obtain ⟨n, rfl⟩ : ∃ n, m = k + n := ⟨m - k, by omega⟩
+  clear h
+  induction n with
+  | zero => exact Nat.le_refl _
+  | succ n ih =>
+    calc nodesBound k ≤ nodesBound (k + n) := ih
+      _ ≤ 1 + 4 * nodesBound (k + n) := by omega
+      _ = nodesBound ((k + n) + 1) := rfl.symm
+      _ = nodesBound (k + (n + 1)) := by rw [Nat.add_assoc]
+
+/-- Une macrocell de profondeur `d` porte au plus `nodesBound d` sous-arbres
+distincts : l'induction sur la structure de `MacroCell` annoncee en
+preambule. L'union peut dedoubler (sous-arbres partages entre quadrants),
+jamais grossir — la borne vaut meme pour les arbres non equilibrés. -/
+theorem allSubtrees_card (c : MacroCell) : (allSubtrees c).card ≤ nodesBound (depth c) := by
+  induction c with
+  | leaf b =>
+    simp only [allSubtrees, depth, nodesBound]
+    simp
+  | node nw ne sw se ihnw ihne ihsw ihse =>
+    simp only [allSubtrees, depth]
+    set M := max (depth nw) (max (depth ne) (max (depth sw) (depth se))) with hM
+    have h1 := Finset.card_insert_le (a := node nw ne sw se)
+      (s := allSubtrees nw ∪ allSubtrees ne ∪ allSubtrees sw ∪ allSubtrees se)
+    have e1 := Finset.card_union_le (allSubtrees nw ∪ allSubtrees ne ∪ allSubtrees sw)
+      (allSubtrees se)
+    have e2 := Finset.card_union_le (allSubtrees nw ∪ allSubtrees ne) (allSubtrees sw)
+    have e3 := Finset.card_union_le (allSubtrees nw) (allSubtrees ne)
+    have hn : (allSubtrees nw).card ≤ nodesBound M := ihnw.trans (nodesBound_mono (by omega))
+    have he : (allSubtrees ne).card ≤ nodesBound M := ihne.trans (nodesBound_mono (by omega))
+    have hs : (allSubtrees sw).card ≤ nodesBound M := ihsw.trans (nodesBound_mono (by omega))
+    have hd : (allSubtrees se).card ≤ nodesBound M := ihse.trans (nodesBound_mono (by omega))
+    have hstep : nodesBound (1 + M) = 1 + 4 * nodesBound M := by
+      rw [Nat.add_comm]; rfl
+    omega
+
+/-- Le cadrage de niveau `k` d'une grille est un quadtree exactement de
+profondeur `k` : `buildFromGrid` construit l'arbre parfait couvrant le
+carre, tous les quadrants presents jusqu'aux feuilles. -/
+theorem depth_buildFromGrid (g : Grid) (lvl : Nat) (r0 c0 : Int) :
+    depth (buildFromGrid g r0 c0 lvl) = lvl := by
+  induction lvl generalizing r0 c0 with
+  | zero => rfl
+  | succ n ih =>
+    simp only [buildFromGrid, depth]
+    simp only [ih]
+    omega
+
+/-- **Borne de nouveaute au niveau noeuds pour un oscillateur** : si
+`evolve p g = g` avec `p > 0`, alors la trajectoire complete, cadree au
+niveau `k` en `(r0, c0)`, ne visite qu'un nombre borne de noeuds distincts —
+au plus `p * nodesBound k` sous-arbres, un majorant independant de
+l'horizon. Chaque instant de la trajectoire reduit a l'un des `p` premiers
+instants (`novelty_bound_of_period`), et chacun de ces instants contribue
+au plus `nodesBound k` noeuds (`allSubtrees_card`, sur un cadrage de
+profondeur exactement `k` par `depth_buildFromGrid`). C'est le pendant
+quantitatif, au niveau du cache de hashlife, de la borne grille : le taux
+de hit de la memoisation ne peut pas se degrader avec l'horizon, sur la
+classe des oscillateurs. -/
+theorem nodes_novelty_bound_of_period (g : Grid) (p : Nat) (hp0 : 0 < p)
+    (hp : evolve p g = g) (k : Nat) (r0 c0 : Int) :
+    ∃ s : Finset MacroCell, s.card ≤ p * nodesBound k ∧
+      ∀ t : Nat, ∀ x ∈ allSubtrees (buildFromGrid (evolve t g) r0 c0 k), x ∈ s := by
+  refine ⟨(Finset.range p).biUnion
+    fun r => allSubtrees (buildFromGrid (evolve r g) r0 c0 k), ?_, ?_⟩
+  · calc ((Finset.range p).biUnion
+          fun r => allSubtrees (buildFromGrid (evolve r g) r0 c0 k)).card
+        ≤ ∑ r ∈ Finset.range p,
+            (allSubtrees (buildFromGrid (evolve r g) r0 c0 k)).card := Finset.card_biUnion_le
+      _ ≤ ∑ _r ∈ Finset.range p, nodesBound k := Finset.sum_le_sum fun r _ => by
+          have h := allSubtrees_card (buildFromGrid (evolve r g) r0 c0 k)
+          rw [depth_buildFromGrid] at h
+          exact h
+      _ = p * nodesBound k := by rw [Finset.sum_const, Finset.card_range, Nat.nsmul_eq_mul]
+  · intro t x hx
+    obtain ⟨r, hr, heq⟩ := novelty_bound_of_period g p hp0 hp t
+    rw [heq] at hx
+    exact Finset.mem_biUnion.2 ⟨r, Finset.mem_range.2 hr, hx⟩
+
+/-! ### Application : le blinker, niveau noeuds -/
+
+/-- Le blinker (periode 2), cadre au niveau `k` : au plus
+`2 * nodesBound k` noeuds distincts visites sur toute la trajectoire, quel
+que soit l'horizon. -/
+theorem blinker_h_nodes_novelty_bound (k : Nat) (r0 c0 : Int) :
+    ∃ s : Finset MacroCell, s.card ≤ 2 * nodesBound k ∧
+      ∀ t : Nat, ∀ x ∈ allSubtrees (buildFromGrid (evolve t blinker_h) r0 c0 k), x ∈ s :=
+  nodes_novelty_bound_of_period _ 2 (by norm_num) (by decide) k r0 c0
+
+/-- Temoin numerique exact : le cadre de niveau 2 du blinker porte
+exactement 6 noeuds distincts — la racine, trois quadrants distincts (les
+deux quadrants Est, vides, s'identifient) et les deux feuilles — pour une
+borne generale de `nodesBound 2 = 21` sur un seul etat. -/
+theorem blinker_h_level2_nodes_card :
+    (allSubtrees (buildFromGrid blinker_h (-1) (-1) 2)).card = 6 := by
+  decide
 
 end Life
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Novelty_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Novelty_en.lean
@@ -19,21 +19,19 @@ of cardinal at most `p` containing the entire trajectory
 `p`, independently of the horizon: this is the quantitative counterpart of
 the empirical fact "Golly is fast on oscillators".
 
-**Scope and limit, documented.** The bound is at the GRID level (distinct
-states). The operational novelty of hashlife is measured at the level of
-MACROCELL NODES (memoization cache hit rate, with subtree sharing): for a
-bounded oscillator each periodic state grows a tree whose subtrees repeat,
-but the grid -> macrocell tree passage has a size growing with the window,
-and the node-level bound requires an induction over the `MacroCell`
-structure which remains out of reach of this module (written diagnosis,
-cf #11162 acceptance: the "derived bound or diagnosis" alternative is here
-the diagnosis of the node-level bound, the grid-level bound being
-delivered).
-
-The characterization "which patterns have persistent novelty" is
-undecidable in the limit (Life is Turing-complete: a programmed Turing
-machine encodes the infinite production of new patterns) — pathological
-patterns (TM, #6724) are the witnesses of this ceiling.
+**Scope and limit, documented.** Two levels of bound are delivered: GRID
+(`trajectory_states_le_of_period`: at most `p` distinct states) and NODES
+(`nodes_novelty_bound_of_period`: at most `p * nodesBound k` distinct
+subtrees of the trajectory framed at level `k`). The second is the
+operational quantity of hashlife — the memoization cache hit rate, with
+subtree sharing: the induction over the `MacroCell` structure that this
+module declared out of reach at the initial delivery (#11162, where the
+"bound or diagnosis" alternative had retained the diagnosis) is now the
+content of the dedicated section below. Still open, for good: the
+characterization "which patterns have persistent novelty" is undecidable in
+the limit (Life is Turing-complete: a programmed Turing machine encodes
+the infinite production of new patterns) — pathological patterns (TM,
+#6724) are the witnesses of this ceiling.
 
 This module is fully proved (no `sorry`, no native axioms).
 -/
@@ -48,6 +46,7 @@ This module is fully proved (no `sorry`, no native axioms).
 -/
 
 import Conway.Life
+import Conway.Life.MacroCell
 import Conway.Life.HashlifeCorrectness.Foundation
 
 namespace Conway_en
@@ -128,6 +127,142 @@ simulation horizon. -/
 theorem blinker_h_trajectory_states_le :
     ∃ s : Finset Grid, s.card ≤ 2 ∧ ∀ t : Nat, evolve t blinker_h ∈ s :=
   trajectory_states_le_of_period _ 2 (by norm_num) (by decide)
+
+open Conway.Life.MacroCell
+
+/-! ## Novelty bound at the node level (macrocells)
+
+The diagnosis of the preamble is lifted here: the induction over the
+`MacroCell` structure declared out of reach there is the content of this
+section. The operational novelty of hashlife is measured at the level of
+the quadtree NODES — the memoization cache keys, with subtree sharing. The
+trajectory of an oscillator, framed at level `k`, visits only a bounded
+number of distinct subtrees, with upper bound `p * nodesBound k`
+independent of the horizon: the quantitative counterpart, at the cache
+level, of the grid bound above. -/
+
+/-- Counts the nodes of a perfect quadtree of depth `k`: the geometric sum
+`1 + 4 + 16 + ... + 4^k = (4^(k+1) - 1) / 3`, defined by its recurrence —
+the proof-friendly form. -/
+def nodesBound : Nat → Nat
+  | 0 => 1
+  | k + 1 => 1 + 4 * nodesBound k
+
+/-- Structural depth of a macrocell: the height of the tree, measured on
+the deepest of the four sub-cells. Unlike `level` (which only looks at the
+north-west quadrant), it assumes no well-formedness: it is the natural
+parameter of the cardinal bound below, valid for any macrocell, balanced
+or not. -/
+def depth : MacroCell → Nat
+  | leaf _ => 0
+  | node nw ne sw se =>
+      1 + max (depth nw) (max (depth ne) (max (depth sw) (depth se)))
+
+/-- All the subtrees of a macrocell, itself included. Every element is a
+node of the quadtree — a potential memoization cache key of hashlife. The
+node-level novelty of a state is the cardinal of this set. -/
+def allSubtrees (c : MacroCell) : Finset MacroCell :=
+  match c with
+  | leaf _ => {c}
+  | node nw ne sw se =>
+      insert c (allSubtrees nw ∪ allSubtrees ne ∪ allSubtrees sw ∪ allSubtrees se)
+
+/-- `nodesBound` grows with the depth. -/
+theorem nodesBound_mono {k m : Nat} (h : k ≤ m) : nodesBound k ≤ nodesBound m := by
+  obtain ⟨n, rfl⟩ : ∃ n, m = k + n := ⟨m - k, by omega⟩
+  clear h
+  induction n with
+  | zero => exact Nat.le_refl _
+  | succ n ih =>
+    calc nodesBound k ≤ nodesBound (k + n) := ih
+      _ ≤ 1 + 4 * nodesBound (k + n) := by omega
+      _ = nodesBound ((k + n) + 1) := rfl.symm
+      _ = nodesBound (k + (n + 1)) := by rw [Nat.add_assoc]
+
+/-- A macrocell of depth `d` carries at most `nodesBound d` distinct
+subtrees: the induction over the `MacroCell` structure announced in the
+preamble. The union may deduplicate (subtrees shared across quadrants),
+never grow — the bound holds even for unbalanced trees. -/
+theorem allSubtrees_card (c : MacroCell) : (allSubtrees c).card ≤ nodesBound (depth c) := by
+  induction c with
+  | leaf b =>
+    simp only [allSubtrees, depth, nodesBound]
+    simp
+  | node nw ne sw se ihnw ihne ihsw ihse =>
+    simp only [allSubtrees, depth]
+    set M := max (depth nw) (max (depth ne) (max (depth sw) (depth se))) with hM
+    have h1 := Finset.card_insert_le (a := node nw ne sw se)
+      (s := allSubtrees nw ∪ allSubtrees ne ∪ allSubtrees sw ∪ allSubtrees se)
+    have e1 := Finset.card_union_le (allSubtrees nw ∪ allSubtrees ne ∪ allSubtrees sw)
+      (allSubtrees se)
+    have e2 := Finset.card_union_le (allSubtrees nw ∪ allSubtrees ne) (allSubtrees sw)
+    have e3 := Finset.card_union_le (allSubtrees nw) (allSubtrees ne)
+    have hn : (allSubtrees nw).card ≤ nodesBound M := ihnw.trans (nodesBound_mono (by omega))
+    have he : (allSubtrees ne).card ≤ nodesBound M := ihne.trans (nodesBound_mono (by omega))
+    have hs : (allSubtrees sw).card ≤ nodesBound M := ihsw.trans (nodesBound_mono (by omega))
+    have hd : (allSubtrees se).card ≤ nodesBound M := ihse.trans (nodesBound_mono (by omega))
+    have hstep : nodesBound (1 + M) = 1 + 4 * nodesBound M := by
+      rw [Nat.add_comm]; rfl
+    omega
+
+/-- The level-`k` framing of a grid is a quadtree of depth exactly `k`:
+`buildFromGrid` builds the perfect tree covering the square, all quadrants
+present down to the leaves. -/
+theorem depth_buildFromGrid (g : Grid) (lvl : Nat) (r0 c0 : Int) :
+    depth (buildFromGrid g r0 c0 lvl) = lvl := by
+  induction lvl generalizing r0 c0 with
+  | zero => rfl
+  | succ n ih =>
+    simp only [buildFromGrid, depth]
+    simp only [ih]
+    omega
+
+/-- **Node-level novelty bound for an oscillator**: if `evolve p g = g` with
+`p > 0`, then the whole trajectory, framed at level `k` at `(r0, c0)`,
+visits only a bounded number of distinct nodes — at most `p * nodesBound k`
+subtrees, an upper bound independent of the horizon. Every instant of the
+trajectory reduces to one of the first `p` steps
+(`novelty_bound_of_period`), and each of those steps contributes at most
+`nodesBound k` nodes (`allSubtrees_card`, on a framing of depth exactly `k`
+by `depth_buildFromGrid`). This is the quantitative counterpart, at the
+hashlife cache level, of the grid bound: the memoization hit rate cannot
+degrade with the horizon, on the class of oscillators. -/
+theorem nodes_novelty_bound_of_period (g : Grid) (p : Nat) (hp0 : 0 < p)
+    (hp : evolve p g = g) (k : Nat) (r0 c0 : Int) :
+    ∃ s : Finset MacroCell, s.card ≤ p * nodesBound k ∧
+      ∀ t : Nat, ∀ x ∈ allSubtrees (buildFromGrid (evolve t g) r0 c0 k), x ∈ s := by
+  refine ⟨(Finset.range p).biUnion
+    fun r => allSubtrees (buildFromGrid (evolve r g) r0 c0 k), ?_, ?_⟩
+  · calc ((Finset.range p).biUnion
+          fun r => allSubtrees (buildFromGrid (evolve r g) r0 c0 k)).card
+        ≤ ∑ r ∈ Finset.range p,
+            (allSubtrees (buildFromGrid (evolve r g) r0 c0 k)).card := Finset.card_biUnion_le
+      _ ≤ ∑ _r ∈ Finset.range p, nodesBound k := Finset.sum_le_sum fun r _ => by
+          have h := allSubtrees_card (buildFromGrid (evolve r g) r0 c0 k)
+          rw [depth_buildFromGrid] at h
+          exact h
+      _ = p * nodesBound k := by rw [Finset.sum_const, Finset.card_range, Nat.nsmul_eq_mul]
+  · intro t x hx
+    obtain ⟨r, hr, heq⟩ := novelty_bound_of_period g p hp0 hp t
+    rw [heq] at hx
+    exact Finset.mem_biUnion.2 ⟨r, Finset.mem_range.2 hr, hx⟩
+
+/-! ### Application: the blinker, node level -/
+
+/-- The blinker (period 2), framed at level `k`: at most `2 * nodesBound k`
+distinct nodes visited over the whole trajectory, whatever the horizon. -/
+theorem blinker_h_nodes_novelty_bound (k : Nat) (r0 c0 : Int) :
+    ∃ s : Finset MacroCell, s.card ≤ 2 * nodesBound k ∧
+      ∀ t : Nat, ∀ x ∈ allSubtrees (buildFromGrid (evolve t blinker_h) r0 c0 k), x ∈ s :=
+  nodes_novelty_bound_of_period _ 2 (by norm_num) (by decide) k r0 c0
+
+/-- Exact numerical witness: the level-2 framing of the blinker carries
+exactly 6 distinct nodes — the root, three distinct quadrants (the two
+empty East quadrants are identified) and the two leaves — against a general
+bound of `nodesBound 2 = 21` on a single state. -/
+theorem blinker_h_level2_nodes_card :
+    (allSubtrees (buildFromGrid blinker_h (-1) (-1) 2)).card = 6 := by
+  decide
 
 end Life_en
 end Conway_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA — prev: DEEP/notebook-python #12265

## Summary

Grain **#6724** (axe efficacité hashlife) — la **borne de nouveauté au niveau NOEUDS de macrocells** livrée dans `Novelty.lean` + sibling `Novelty_en.lean` : le morceau que le préambule du module diagnostiquait lui-même comme restant (« la borne au niveau noeud demande une induction sur la structure de `MacroCell` qui reste hors de portee de ce module », écrit à la livraison initiale #11162). Le diagnostic est levé — l'induction est le contenu de cette PR.

**Livrable (nouveau, entièrement prouvé — 0 sorry ajouté) :**

- `nodesBound k` — compte des noeuds d'un quadtree parfait de profondeur `k` (somme géométrique `1 + 4 + ... + 4^k` par récurrence, la forme manipulable en preuve).
- `depth : MacroCell → Nat` — profondeur **structurelle** (plus profonde des 4 sous-cellules). Contrairement à `level` (qui ne regarde que le quadrant NW), elle ne suppose pas la bonne formation : la borne de cardinal vaut pour toute macrocell, équilibrée ou non.
- `allSubtrees : MacroCell → Finset MacroCell` — tous les sous-arbres d'une macrocell, elle-même incluse. Chaque élément = une clé potentielle du cache de mémoisation hashlife : la nouveauté niveau noeuds d'un état EST le cardinal de cet ensemble.
- `allSubtrees_card` : `(allSubtrees c).card ≤ nodesBound (depth c)` — **l'induction sur la structure de MacroCell** (l'union dédoublonne les sous-arbres partagés, jamais ne grossit).
- `depth_buildFromGrid` : le cadrage de niveau `k` est exactement de profondeur `k` (quadtree parfait).
- **`nodes_novelty_bound_of_period`** (théorème principal) : si `evolve p g = g` avec `p > 0`, la trajectoire complète cadrée au niveau `k` en `(r0, c0)` visite au plus `p * nodesBound k` noeuds distincts — majorant **indépendant de l'horizon**. Preuve : `Finset.card_biUnion_le` sur `(Finset.range p).biUnion` + chaque instant réduit à l'un des `p` premiers (`novelty_bound_of_period`) + au plus `nodesBound k` noeuds par état (`allSubtrees_card` via `depth_buildFromGrid`).
- Applications blinker : `blinker_h_nodes_novelty_bound` (≤ `2 * nodesBound k` pour tout `k`, tout cadrage) et **témoin numérique exact** `blinker_h_level2_nodes_card = 6` **par `decide`** (racine + 3 quadrants distincts — les deux quadrants Est vides s'identifient — + 2 feuilles ; borne générale `nodesBound 2 = 21` sur un état).

**Portée pédagogique** : c'est le pendant quantitatif, au niveau du cache de hashlife, de la borne grille `trajectory_states_le_of_period` — le taux de hit de la mémoisation ne peut pas se dégrader avec l'horizon sur la classe des oscillateurs, désormais aux DEUX niveaux (grille ET noeuds). Le préambule du module est réécrit en conséquence (les deux niveaux livrés ; reste ouvert : la caractérisation des motifs à nouveauté persistante, indécidable à la limite — Turing-complet).

## Validation (§B Lean)

- **`sorry` count** (`python scripts/lean/count_code_sorry.py --json`, champ `distinct_code_sorry` sur `conway_lean`) : **1 avant → 1 après** (aucun sorry ajouté ni retiré ; le résidu est le sorry documenté de la carte #6724, hors des fichiers touchés).
- **`lake build`** : `lake build Conway.Life.Novelty Conway.Life.Novelty_en` — **SUCCESS** (`Build completed successfully (8662 jobs)`, Novelty 271 s / Novelty_en 276 s, WSL lake incrémental, zéro erreur — les warnings restants sont des linters pre-existing de `HashlifeCorrectness/Foundation.lean`, hors scope).
- **§B.3 proof-integrity** : **applicable** — le job bloquant `proof-integrity-audit` de `lean-conway.yml` porte `target-modules: "*"` (aucun `continue-on-error`), donc il énumère les axiomes de `Conway.Life.Novelty` et tournera sur cette PR en CI (le job `proof-integrity` plus étroit, `KochenSpecker/FreeWillTheorem`, ne l'atteint pas, mais l'audit `*` si). Trois classes forbidden (`native_decide.*`, `sorryAx`, `Classical.choice` par wildcard) : aucune introduite — le module n'utilise que les lemmes Finset/Mathlib standards et `decide` kernel. Le job `ci` cold-build les globs `Conway`/`Conway_en` du lakefile, qui couvrent `Conway.Life.Novelty(_en)` par clôture.
- **i18n (#4980)** : `python scripts/lean/check_i18n_siblings.py .../Novelty_en.lean` → **OK, 1/1 pairs byte-identical** (le code est byte-identique entre FR et EN ; seules les docstrings et le bloc d'en-tête diffèrent).
- **Scope du diff** : 2 fichiers (`Novelty.lean`, `Novelty_en.lean`), +304/−30 (les −30 = préambules réécrits). Aucun autre fichier touché, catalogue byte-identique à main (non régénéré).
- **L898** : aucune PR ouverte touchant `conway_lean` (vérifié pre-claim) ; claim partitionné c.5377066672 (`paths: .../Novelty.lean, .../Novelty_en.lean`), `check_lane_claim.py` → `my_active_claim: true`, `blocking_lanes: []`.

See #6724 (contribution à l'axe efficacité : la borne noeuds diagnostiquée dans le préambule de Novelty.lean depuis #11162 est livrée ; ne clôt pas l'EPIC — le cœur résiduel P4 et les sorries restent).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
