### PR TITLE
fix(guards,#12338): detect_markdown_rendering -- le early-return yaml masquait les autres regles de la cellule (58 cellules corpus)

### DIFF
--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -753,7 +753,12 @@ def scan_cell(cell) -> list[dict]:
             "evidence": lines[0].strip(),
             "hash": _cell_hash("yaml_block_open_no_close", text),
         })
-        return findings  # the YAML-opener shape fully describes this cell
+        # #12338: no early return here. The YAML-opener finding describes the
+        # cell's head, not its body: a `- # Indice` line further down is a
+        # separate rendering defect (heading_in_list) that this return was
+        # silencing -- on the 8 QC-Py notebooks of #12332, all 18 cells with
+        # heading_in_list were yaml cells, and the detector reported 0. The
+        # finding hashes are per-rule, so both can coexist in the baseline.
 
     # ---- frontmatter-in-markdown ------------------------------------------------
     if _is_frontmatter_block(lines):

--- a/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
+++ b/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
@@ -661,6 +661,31 @@ class TestYamlBlockOpenNoClose:
         """
         assert _selfcheck() == 0
 
+    def test_yaml_opener_does_not_mask_other_rules(self):
+        """#12338: the yaml finding must not stop the scan of the cell body.
+
+        Pre-#12338 the yaml branch ended with ``return findings``, so no rule
+        after it ever ran on a yaml cell. Measured on the 8 QC-Py notebooks of
+        #12332: all 18 cells carrying ``- # Indice :`` heading_in_list lines
+        were yaml cells, and the detector reported ``heading_in_list = 0`` on
+        the whole family -- a zero of denominator, not of numerator. This cell
+        reproduces the shape: YAML opener + an in-list heading further down.
+        Both findings must appear.
+        """
+        src = (
+            "---\n"
+            "### Exercice 3 : Sortino Ratio par regime\n"
+            "\n"
+            "- # Indice : Groupby par label de regime : `df.groupby('regime')`\n"
+        )
+        rules = _rules(scan_cell(_cell(src)))
+        assert "yaml_block_open_no_close" in rules, (
+            f"yaml opener lost: {rules}"
+        )
+        assert "heading_in_list" in rules, (
+            f"heading_in_list still masked by the yaml branch: {rules}"
+        )
+
 
 class TestQuartoClosure:
     """Pin the ``--closure`` mode of detect_markdown_rendering.


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #12334

## Summary

Fix #12338 : le early-return du finding `yaml_block_open_no_close` dans `detect_markdown_rendering.py` (`scan_cell`) **masquait toutes les règles suivantes** de la cellule (`heading_in_list`, `code_stmt_in_markdown`, `cjk_in_prose`). Le return est retiré ; le scan collecte désormais tous les findings de la cellule. Le early-return du `_is_frontmatter_block` (double-rapport setext documenté) est **inchangé** — c'est un cas différent, protégé par ses propres tests.

Le grain CONTENU du cycle suivant est nommé en fin de body (G-VAR-1, META ce cycle).

## Le changement

- `detect_markdown_rendering.py` : 1 ligne retirée (le `return findings`), remplacée par un commentaire renvoyant à #12338. Les hashes de findings étant per-règle (`_cell_hash(rule, text)`), les deux règles coexistent dans le ratchet baseline sans collision.
- `tests/test_detect_markdown_rendering.py` : nouveau test `test_yaml_opener_does_not_mask_other_rules` — cellule YAML-opener + ligne `- # Indice :` → **les deux** findings attendus.

## Validation (post-dernier-commit 43b3d0151)

- `pytest test_detect_markdown_rendering.py` : **58/58 PASS** (57 préexistants + le nouveau — dont le selfcheck embarqué `_selfcheck() == 0` aux deux formes #11630)
- Suites voisines : `test_detect_markdown_rendering_stmt.py` + `test_check_render_volume_delta.py` : **33/33 PASS**
- Gate `--check --baseline` sur QC-Py : **OK, no new ERROR violations** (les findings démasqués sont `heading_in_list` = WARN, non bloquants — l'ERROR yaml était déjà compté)

## Re-mesure corpus (acceptance #12338, critère 3)

Scan pure-Python corpus des cellules yaml porteuses de lignes `_CONTAINER_HEADING_RE` non-fencées :

| Famille | Cellules yaml masquées |
|---|---|
| `QuantConnect/Python` | **35** |
| `GenAI/Audio` | **21** |
| `Probas/DecisionTheory` | **2** |
| **Total** | **58** |

Conséquences lisibles : le compte « 32 heading_in_list GenAI/Audio » de #12131 (PR ouverte) était **incomplet** — 21 cellules de plus y sont masquées (total réel ~53). Les 18 cellules QC-Py de #12332 (PR ouverte) sont incluses dans les 35 — il reste ~17 cellules QC-Py **hors** du périmètre de cette tranche, à couvrir.

## Grain CONTENU nommé pour le cycle suivant (G-VAR-1)

La re-mesure ci-dessus fournit la prochaine tranche : **solde QC-Py yaml+heading_in_list** (~17 cellules hors périmètre #12332) via `_CONTAINER_HEADING_RE` direct — livrable indépendamment du merge de ce fix.

Closes #12338

🤖 Generated with [Claude Code](https://github.com/anthropics/claude-code)
