### PR TITLE
fix(lean,#12221): porter la section correction-diagnostic dans le Lean-27 de main (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-27-Coherence-et-Temoin.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-27-Coherence-et-Temoin.ipynb
@@ -572,6 +572,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "l27c14b",
+   "metadata": {},
+   "source": [
+    "### La correction d'un diagnostic antérieur\n",
+    "\n",
+    "Les deux démonstrations referment la correction annoncée en ouverture. L'erreur du premier Čech affine ([ICT-15d](../../IIT/ICT-Series/ICT-15d-NerveDiscriminant.ipynb)) ne se corrige pas en condamnant la carte — elle se corrige en produisant, chaque fois, la structure qui légitime la forme employée. Écrite comme le lit un carnet de bord :\n",
+    "\n",
+    "```\n",
+    "ERREUR INITIALE   :  on transporte une mesure avec une carte affine, sans axiome.\n",
+    "DIAGNOSTIC       :  « l'affine produit des artefacts numériques ».\n",
+    "CORRECTION       :  axiome vNM d'abord, puis l'affine est légitime.\n",
+    "                    OU axiome manquant : l'affine N'EST PAS canonique.\n",
+    "                    Le témoin de Finetti est la sanction constructive du cas incohérent.\n",
+    "```\n",
+    "\n",
+    "Le diagnostic initial était **mal posé** : il blâmait la carte au lieu de blâmer l'absence de justification. Et la sanction, quand la structure manque, n'est pas un verdict abstrait — le témoin de Finetti est un **livre qui paie** : l'obstruction devenue objet opérationnel.\n",
+    "\n",
+    "C'est la leçon de méthode, une dernière fois : **une carte entre représentations doit d'abord justifier sa forme.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "l27c15",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2025:CoursIA-2 — prev: MED/guard #12339

## Summary

Porte la section « ### La correction d'un diagnostic antérieur » depuis ma branche fermée `feature/c315-12221-finetti` (PR #12269, fermée après la collision Lean-27) dans le `Lean-27-Coherence-et-Temoin.ipynb` de `main` (version issue de #12306). Livraison du grain dispatché par ai-01 (DM msg-20260822T152514).

**Markdown-only** : 1 cellule ajoutée (`l27c14b`) entre le Résumé (cellule 14) et les Exercices (cellule 16). Les 21 cellules d'origine sont **byte-identiques** (vérifié par alignement d'id contre `origin/main`) — code + outputs intacts, C.3 (exemption markdown).

## Valeur ajoutée vs la cellule 0 de main

L'intro de main (cellule `l27c00`) porte déjà le récit en prose. La section portée apporte ce qui n'y est pas :

1. **Le bloc structuré** `ERREUR INITIALE / DIAGNOSTIC / CORRECTION` — le carnet de bord de la correction, absent de main ;
2. **« le témoin de Finetti est la sanction constructive du cas incohérent »** — le lien Finetti↔diagnostic que la cellule 0 ne fait pas ;
3. La clôture synthétique du notebook : le récit annoncé en ouverture est *refermé* après les démonstrations.

## Adaptations au portage (vs le texte source de #12269)

- **Ré-accentué intégralement** (`anterieur`→`antérieur`, `temoin`→`témoin`, `legitime`→`légitime`, `incoherent`→`incohérent`, etc.) — le texte source était ASCII désaccentué ;
- **Références machine-local remplacées** : `L-ICT-15d` et `c.425-L3` n'existent pas sur `main` (vérifié `git grep`, 0 match) → lien relatif réel vers [`ICT-15d-NerveDiscriminant.ipynb`](../../blob/main/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15d-NerveDiscriminant.ipynb) (cible vérifiée sur disque) ;
- **Orthographe « Čech »** alignée sur la cellule 0 de main (le corpus dit Čech dans ICT-15d/e/g et Lean-15/15b) ;
- L'ouverture est reformulée (« referment la correction annoncée en ouverture ») pour ne pas dupliquer verbatim la phrase de la cellule 0.

## Validation (post-commit 9b6779a40)

- Cellules d'origine **byte-identiques** : 21/21 par comparaison d'id, 1 seule cellule ajoutée ✓
- `detect_markdown_rendering.py` sur le fichier : **0 violation** ✓
- `nbformat.validate` : OK (4.5) · LF endings : ✓
- `validate_pr_notebooks.py origin/main <file>` : **PASS** (8 code cells) ✓
- Hooks pre-commit (H.3, oversized-markdown, source-newlines) : Passed ✓

See #12221

🤖 Generated with [Claude Code](https://github.com/anthropics/claude-code)
