### PR TITLE
fix(lane-claim,#12322): un appel sans --paths rend exit 2 + NOT_SCOPED -- le caller peut re-run avec --paths pour lever le sur-block

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -1337,28 +1337,34 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
     others = {ln: ev for ln, ev in active.items() if ln != my_lane}
     mine = active.get(my_lane)
 
+    # #12345 / #12322 v2 -- the caller's CARRYING scope is computed EARLY
+    # (before `query_scope` classification) so the classifier can read it.
+    # `my_scope` = `--paths` merged with the caller's OWN active-claim
+    # `paths:` clause (#10419). When `my_paths is None` AND the caller has
+    # no own active claim with a `paths:` clause, `my_scope` is None -- the
+    # caller declared no intent at all (legacy case, unchanged).
+    mine_paths = mine.get("paths") if mine else None
+    my_scope = list(dict.fromkeys((my_paths or []) + (mine_paths or []))) or None
+    # Dead-glob witness on the CALLER side (mirror of `empty_scope` on the
+    # claim side, #10958). `caller_empty_scope` lists the globs in `my_scope`
+    # that match ZERO tracked files in the repo. Empty list when:
+    # (a) `my_scope` is None (no declared scope -- legacy case),
+    # (b) every glob in `my_scope` matches at least one tracked file,
+    # (c) `tracked is None` (no git walk possible -- degrade silently).
+    # The list is JSON-serialised in `caller_empty_scope` (#12345) so the
+    # caller can see WHY a scope they thought is alive is being treated
+    # as empty.
+    caller_empty_scope = _empty_scope_in(my_scope, tracked) if tracked is not None else []
+
     # Override-scope filter (#10342): an `[OVERRIDE]` with a `paths:` clause
     # only locks lanes whose intended files intersect the scope. Without
     # `my_paths`, we conservatively treat every scoped override as blocking
     # (the caller's intent is unknown -- better to over-block than silently
-    # merge a write that should have pinged a held lane).
+    # merge a write that should have pinged a held lane). Note: `_filter_by_
+    # claim_scope` already short-circuits when `my_scope` is entirely dead
+    # (#10958 caller-side lift, line ~1614) so an entirely-dead MY scope
+    # does not get to false-clear other lanes.
     others = _filter_by_claim_scope(others, my_paths, mine, tracked=tracked)
-
-    # #12322 -- query_scope classifier. A call whose CARRYING scope is empty
-    # (`my_paths` is None AND the caller's own active claim carries no `paths:`
-    # clause) cannot prove disjointness from any blocker, so it lands in
-    # `EPIC_WIDE_NO_PATHS_DECLARED`. This is NOT the same as a real blocker --
-    # the caller has the option to re-run the check WITH `--paths` to scope-bind
-    # the query and lift the over-block. Distinguishing the two is what gives
-    # the caller an actionable next step (vs the old `exit 1` + `blocking_lanes:
-    # [...4 lanes...]` which reads as a hard block and prompts one of the costly
-    # fumbles measured on #11112: a same-author ISSUE comment on the blockers'
-    # lanes, or a DM `URGENT` to ai-01, both wrong).
-    mine_paths = mine.get("paths") if mine else None
-    if others and my_paths is None and mine_paths is None:
-        query_scope = "EPIC_WIDE_NO_PATHS_DECLARED"
-    else:
-        query_scope = "PATH_SCOPED"
 
     # Stale-claim handling (#9812): a claim older than `stale_threshold` hours
     # (age from the server createdAt, NEVER the body) is treated as STALE -- it
@@ -1373,6 +1379,30 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             if age is not None and age >= stale_threshold:
                 stale_others[ln] = ev
         others = {ln: ev for ln, ev in others.items() if ln not in stale_others}
+
+    # #12322 -- query_scope classifier (POST stale-filter, so the verdict
+    # reflects the FINAL blocker set, not the pre-stale one). A call whose
+    # CARRYING scope is empty (no `--paths` AND no `paths:` on the caller's
+    # own claim) cannot prove disjointness from any FINAL blocker, so it
+    # lands in `EPIC_WIDE_NO_PATHS_DECLARED`. #12345 v2: a call whose
+    # declared scope is ENTIRELY dead (every glob matches zero tracked
+    # files) is structurally indistinguishable from the no-scope case -- the
+    # caller cannot prove disjointness because the claim they think they
+    # made locks nothing. Same verdict (`EPIC_WIDE_NO_PATHS_DECLARED`),
+    # same `exit 2`, plus a WARN stderr naming each dead glob so the caller
+    # fixes the typo before re-running. The fail-CLOSED (the third property
+    # of #12345's acceptance) lives at the verdict-emission point below --
+    # a scope that is entirely dead does NOT clear to `exit 0`, it changes
+    # verdict and acquires an explanation.
+    if others and my_scope is None:
+        query_scope = "EPIC_WIDE_NO_PATHS_DECLARED"
+    elif caller_empty_scope and my_scope and len(caller_empty_scope) >= len(my_scope):
+        # #12345 -- every glob in `my_scope` is dead: the caller declared a
+        # scope they believe is alive, but it matches zero tracked files.
+        # Cannot prove disjointness -> same verdict as the no-scope case.
+        query_scope = "EPIC_WIDE_NO_PATHS_DECLARED"
+    else:
+        query_scope = "PATH_SCOPED"
 
     # #12156 -- umbrella signal. Two booleans surface the diagnostic that
     # the body of #12156 asks to expose in `check_lane_claim.py`'s JSON:
@@ -1462,8 +1492,38 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
         # actionable next step for the caller (re-run with `--paths` to lift
         # the over-block).
         "query_scope": query_scope,
+        # #12345 -- dead-glob witness on the CALLER side (mirror of
+        # `empty_scope` on the claim side, #10958). Lists the globs in
+        # `my_scope` that match zero tracked files in the repo. Empty
+        # when (a) caller declared no scope, (b) every glob is live, or
+        # (c) `tracked` was None (no git walk possible). Non-empty means
+        # the caller reissued with a typo'd path or a deleted file -- the
+        # verdict below has already routed the call to `NOT_SCOPED` when
+        # the dead globs cover the whole scope, otherwise the live globs
+        # continue to carry the disjointness test.
+        "caller_empty_scope": caller_empty_scope,
     }
     print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+    # #12345 -- SCOPE_DEAD_GLOB warning. When the caller declared a scope
+    # whose globs include at least one dead glob, surface the witness list
+    # on stderr so the caller fixes the typo at the call site instead of
+    # re-running with the same broken path. Best-effort: when the file walk
+    # failed (`tracked is None`), `caller_empty_scope` is empty by
+    # construction -- we never false-WARN outside a git repo. The warning
+    # is non-blocking on purpose: a PARTIALLY-dead scope still carries
+    # disjointness on its live part (`_filter_by_claim_scope` uses `my_scope`
+    # as-is); only an ENTIRELY-dead scope fails-CLOSED to `NOT_SCOPED` at
+    # `exit 2` via the verdict block below.
+    if caller_empty_scope:
+        dead = ", ".join(repr(g) for g in caller_empty_scope)
+        print(
+            f"SCOPE_DEAD_GLOB: your declared scope contains globs that "
+            f"match zero tracked files in this repo: {dead}. The live "
+            f"globs (if any) continue to carry disjointness; reissue with "
+            f"valid paths to lift this hint.",
+            file=sys.stderr,
+        )
 
     # #10597 bonus -- SCOPE_ZERO_COVERAGE warning. When a lane declares a
     # SCOPED claim whose expanded globs do not match any tracked file in
@@ -1552,6 +1612,32 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             file=sys.stderr,
         )
         return 1
+    # #12345 -- fail-CLOSED on an entirely-dead scope, EVEN with no
+    # blockers. Without this branch, a caller who typo'd every glob in
+    # `--paths` would see CLEAR + `exit 0` on an issue no one else has
+    # claimed, and the broken lock would authorise them to write anywhere.
+    # The acceptance on #12345 names this explicitly: a scope that is
+    # entirely dead "changes verdict and acquires an explanation; it
+    # does not gain the authorisation to write." We route to the same
+    # `NOT_SCOPED` + `exit 2` verdict the BLOCKED branch above emits,
+    # minus the blocker names (there are none) -- the actionable next
+    # step is the same: re-issue with valid globs.
+    if query_scope == "EPIC_WIDE_NO_PATHS_DECLARED":
+        dead = ", ".join(repr(g) for g in caller_empty_scope)
+        print(
+            f"\nNOT_SCOPED: this call's declared scope is entirely dead "
+            f"on #{payload.get('number')}: every glob in `--paths` matches "
+            f"zero tracked files ({dead}). The lock is empty -- the call "
+            f"does NOT clear to `exit 0` because a broken scope is not a "
+            f"permissive scope (#12345 fail-CLOSED). Re-run with valid "
+            f"`--paths <glob>` matching the files you intend to edit; if "
+            f"they intersect any blocker the call returns BLOCKED at "
+            f"`exit 1`, otherwise CLEAR at `exit 0`. Exiting with `exit 2` "
+            f"so callers can branch on the verdict without false-alarming "
+            f"on a scope-typo.",
+            file=sys.stderr,
+        )
+        return 2
     parts = []
     if mine:
         parts.append("resuming your own active claim")

--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -1344,6 +1344,22 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
     # merge a write that should have pinged a held lane).
     others = _filter_by_claim_scope(others, my_paths, mine, tracked=tracked)
 
+    # #12322 -- query_scope classifier. A call whose CARRYING scope is empty
+    # (`my_paths` is None AND the caller's own active claim carries no `paths:`
+    # clause) cannot prove disjointness from any blocker, so it lands in
+    # `EPIC_WIDE_NO_PATHS_DECLARED`. This is NOT the same as a real blocker --
+    # the caller has the option to re-run the check WITH `--paths` to scope-bind
+    # the query and lift the over-block. Distinguishing the two is what gives
+    # the caller an actionable next step (vs the old `exit 1` + `blocking_lanes:
+    # [...4 lanes...]` which reads as a hard block and prompts one of the costly
+    # fumbles measured on #11112: a same-author ISSUE comment on the blockers'
+    # lanes, or a DM `URGENT` to ai-01, both wrong).
+    mine_paths = mine.get("paths") if mine else None
+    if others and my_paths is None and mine_paths is None:
+        query_scope = "EPIC_WIDE_NO_PATHS_DECLARED"
+    else:
+        query_scope = "PATH_SCOPED"
+
     # Stale-claim handling (#9812): a claim older than `stale_threshold` hours
     # (age from the server createdAt, NEVER the body) is treated as STALE -- it
     # no longer blocks, but a warning is printed and the new claimant MUST post
@@ -1437,6 +1453,15 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
         "malformed_markers": len(malformed),
         "malformed_marker_lines": [m["line"] for m in malformed],
         "blocked": bool(others),
+        # #12322 -- query_scope is the read-mode classifier for THIS call.
+        # `EPIC_WIDE_NO_PATHS_DECLARED` means the caller did not pass `--paths`
+        # AND did not post an active scoped claim, so we cannot prove
+        # disjointness from any blocker. `PATH_SCOPED` covers everything else
+        # (the caller is scoped one way or another). Co-rolled with the
+        # `exit 2` verdict (vs `exit 1`) below -- the difference is the
+        # actionable next step for the caller (re-run with `--paths` to lift
+        # the over-block).
+        "query_scope": query_scope,
     }
     print(json.dumps(summary, ensure_ascii=False, indent=2))
 
@@ -1487,6 +1512,36 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             excerpt = (ev.get("intent") if hasattr(ev, "get") else None) or "(no intent)"
             intent_lines.append(f"{tag}{excerpt}")
         intent_block = "\n".join(intent_lines)
+        # #12322 -- distinct verdict for EPIC_WIDE_NO_PATHS_DECLARED. The
+        # caller is asking without scoping themselves -- this is a
+        # `non-scope question` showing up as a `block`, which is the trap
+        # measured on #11112 (1 ESCALATION HIGH + 1 ASK HIGH in one day,
+        # both from the user, both rooted in the same `exit 1 + blocker names
+        # without the "re-scope to lift" hint). We keep `exit 1` semantics
+        # for the genuine-scope case (PATH_SCOPED with blockers, including
+        # the case where the caller narrowed their own scope and it still
+        # intersects a blocker), and split out `exit 2` for the call whose
+        # answer changes when the caller re-runs with `--paths`.
+        if query_scope == "EPIC_WIDE_NO_PATHS_DECLARED":
+            print(
+                f"\nNOT_SCOPED: this call did not pass `--paths` so we cannot "
+                f"prove disjointness on #{payload.get('number')}. The blockers "
+                f"below may not actually conflict with the files you intend to "
+                f"edit.\n"
+                f"  Blocked-by (legacy `blocking_lanes` field, taken at face value): "
+                f"{who}\n"
+                f"  Claimed scopes (marker-line excerpts -- #10395 Variante 2):\n"
+                f"{intent_block}\n"
+                f"  ACTION: re-run with `--paths <glob1> --paths <glob2> ...` "
+                f"matching the files you intend to edit. If your files intersect "
+                f"the blockers' scopes the call returns BLOCKED at `exit 1` "
+                f"(real conflict); if they are disjoint the call returns CLEAR "
+                f"at `exit 0`. Exiting with `exit 2` (distinct from real "
+                f"`exit 1` conflicts) so callers can branch on the verdict "
+                f"without false-alarming on a scope-typo.",
+                file=sys.stderr,
+            )
+            return 2
         print(
             f"\nBLOCKED: another lane holds an active claim on "
             f"#{payload.get('number')}: {who}.\n"

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -462,7 +462,13 @@ def test_check_query_scope_path_scoped_when_caller_already_owns_scoped_claim(cap
     active scoped claim (`paths:`) on the same issue. Their scope merges
     with the call site via the #10419 rule. The verdict is `PATH_SCOPED`
     at exit 1 -- the caller is, in effect, scoped through their own active
-    claim, so the unscoped-caller hint does not apply."""
+    claim, so the unscoped-caller hint does not apply.
+
+    # #12345 -- the caller's own claim scopes to `Sudoku-9.ipynb`, which does
+    # NOT exist as a tracked file. Post-#12345, the scope-vivacity classifier
+    # sees `caller_empty_scope == my_scope` and routes to
+    # `EPIC_WIDE_NO_PATHS_DECLARED` at exit 2 (a broken scope is a non-scope).
+    """
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2024:CoursIA -- "
@@ -476,8 +482,14 @@ def test_check_query_scope_path_scoped_when_caller_already_owns_scoped_claim(cap
     )
     rc = clc._run_check(p, "myia-po-2024:CoursIA")
     out = capsys.readouterr().out
-    assert rc == 1  # BLOCKED -- other lane is epic-wide, still blocks caller
-    assert '"query_scope": "PATH_SCOPED"' in out
+    # #12345 -- the caller's own scope (`Sudoku-9.ipynb`) is dead, so the
+    # classifier sees an entirely-dead scope and routes to
+    # `EPIC_WIDE_NO_PATHS_DECLARED` at exit 2. The other lane's epic-wide
+    # claim still blocks the caller; the verdict is `NOT_SCOPED` (exit 2),
+    # not `BLOCKED` (exit 1), because the broken scope proves nothing about
+    # disjointness.
+    assert rc == 2  # NOT_SCOPED -- caller's own scope is dead (#12345)
+    assert '"query_scope": "EPIC_WIDE_NO_PATHS_DECLARED"' in out
     # Verify the caller's own scoped claim is in the active_claims dict.
     assert '"myia-po-2024:CoursIA"' in out
 
@@ -1384,6 +1396,12 @@ def test_check_override_no_paths_preserves_legacy_epic_wide_behaviour(capsys):
 
 
 def test_check_override_paths_blocks_other_lane_on_matching_path(capsys):
+    # #12345 -- the caller's `--paths` `Foo.lean` and the override claim's
+    # `SymbolicAI/Lean/**` are both ENTIRELY dead in this test repo (the
+    # tests live outside any actual SymbolicAI tree). Pre-#12345 the
+    # presence-of-flag predicate returned exit 1 + BLOCKED, hiding the
+    # broken scope. Post-#12345 the caller's scope is entirely dead ->
+    # `EPIC_WIDE_NO_PATHS_DECLARED` at exit 2 (fail-CLOSED).
     # Override with `paths: A/**` to lane X; I (lane Z) want to edit a file
     # UNDER A/ -> my path intersects the scope -> Z is BLOCKED.
     p = payload(
@@ -1400,9 +1418,14 @@ def test_check_override_paths_blocks_other_lane_on_matching_path(capsys):
         "myia-po-2025:CoursIA-2",
         my_paths=["MyIA.AI.Notebooks/SymbolicAI/Lean/Foo.lean"],
     )
-    assert rc == 1
+    # #12345 -- the caller's scope `Foo.lean` does NOT exist in this test
+    # repo (and the override claim's `SymbolicAI/Lean/**` glob is also
+    # dead). Post-#12345, an entirely-dead caller scope routes to
+    # `EPIC_WIDE_NO_PATHS_DECLARED` at exit 2 (fail-CLOSED -- a broken
+    # scope is a non-scope, NOT a permissive one).
+    assert rc == 2  # NOT_SCOPED -- caller's scope is dead (#12345)
     captured = capsys.readouterr()
-    assert "BLOCKED" in captured.err
+    assert "NOT_SCOPED" in captured.err
     assert "myia-po-2024:CoursIA" in captured.out
 
 
@@ -1661,6 +1684,11 @@ def test_check_claimed_one_scoped_one_plain_blocks(capsys):
     # One scoped claim + one plain (epic-wide) claim -> BLOCKED. Disjointness is
     # only honoured when BOTH sides declare a scope (acceptance #2 of #10419);
     # a plain claim's intent is unknown, so it conservatively blocks.
+    # #12345 -- the caller's OWN claim scope `Search/Search-3.ipynb` is dead
+    # in this test repo (no Search tree exists here). Post-#12345 the scope
+    # is entirely dead -> `EPIC_WIDE_NO_PATHS_DECLARED` at exit 2 (the broken
+    # scope proves nothing about disjointness against `B`'s plain claim,
+    # so the verdict is `NOT_SCOPED`, not `BLOCKED`).
     p = payload(
         comment("[CLAIMED] lane A:CoursIA -- paths: Search/Search-3.ipynb",
                 "2026-08-11T04:02:00Z"),
@@ -1668,7 +1696,7 @@ def test_check_claimed_one_scoped_one_plain_blocks(capsys):
                 "2026-08-11T04:05:00Z"),
     )
     rc = clc._run_check(p, "A:CoursIA")
-    assert rc == 1
+    assert rc == 2  # NOT_SCOPED -- caller's scope is dead (#12345)
     assert "B:CoursIA-2" in capsys.readouterr().err
 
 
@@ -2422,7 +2450,15 @@ def test_run_check_summary_exposes_empty_scope_field(capsys):
 def test_run_check_my_dead_scope_keeps_others(capsys):
     """Caller-side guard: when MY OWN scope is entirely dead, I cannot use
     disjointness to clear another lane -- globs that lock nothing prove
-    nothing. Every other lane stays -> BLOCKED until my claim is reissued."""
+    nothing. Every other lane stays -> NOT_SCOPED until my claim is reissued.
+
+    # #12345 -- pre-#12345 the verdict was `BLOCKED` at exit 1 (a real-
+    # conflict surface), masking the fact that the caller's own broken scope
+    # is what disabled disjointness. Post-#12345 the verdict is
+    # `NOT_SCOPED` at exit 2 -- the caller learns at the call site that the
+    # issue is THEIR scope, not the other lane's, and the actionable next
+    # step is the same as the no-scope case (re-run with valid `--paths`).
+    """
     p = payload(
         comment("[CLAIMED] lane A:CoursIA -- paths: scripts/nowhere/typo.py",
                 "2026-08-11T04:02:00Z"),
@@ -2430,8 +2466,11 @@ def test_run_check_my_dead_scope_keeps_others(capsys):
                 "2026-08-11T04:05:00Z"),
     )
     rc = clc._run_check(p, "A:CoursIA")
-    assert rc == 1
-    assert "BLOCKED" in capsys.readouterr().err
+    # #12345 -- caller's own scope is entirely dead (`nowhere/typo.py` is not
+    # tracked). The verdict is NOT_SCOPED (exit 2), not BLOCKED (exit 1):
+    # a broken scope is a non-scope, NOT a real conflict against B.
+    assert rc == 2  # NOT_SCOPED -- caller's scope is dead (#12345)
+    assert "NOT_SCOPED" in capsys.readouterr().err
 
 
 def test_run_check_partially_dead_scope_stays_scoped(capsys):
@@ -2493,7 +2532,16 @@ def test_run_check_emits_scope_zero_coverage_warning(capsys):
     """End-to-end: the lane declares a scoped claim whose globs match
     no real file, then calls `_run_check` for its OWN claim -- the
     `SCOPE_ZERO_COVERAGE` line lands on stderr. This pins the user-visible
-    UX of the bonus hardener."""
+    UX of the bonus hardener.
+
+    # #12345 -- pre-#12345 the verdict was CLEAR at exit 0 (the lane owns
+    # the only claim on the issue, and no other lane blocks). Post-#12345
+    # the verdict is NOT_SCOPED at exit 2 (fail-CLOSED -- a broken scope is
+    # NOT a permissive scope, even when no one else is blocking). The lane
+    # keeps the `SCOPE_ZERO_COVERAGE` guidance and additionally sees a
+    # caller-side `SCOPE_DEAD_GLOB` WARN and the `caller_empty_scope` JSON
+    # field populated with the dead globs.
+    """
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2024:CoursIA-2 -- "
@@ -2501,12 +2549,19 @@ def test_run_check_emits_scope_zero_coverage_warning(capsys):
             "2026-08-12T11:00:00Z",
         ),
     )
-    rc = clc._run_check(p, "myia-po-2024:CoursIA-2")  # own lane, CLEAR
-    assert rc == 0
+    rc = clc._run_check(p, "myia-po-2024:CoursIA-2")  # own lane, scope dead
+    # #12345 -- fail-CLOSED: broken scope is not a permissive scope.
+    assert rc == 2  # NOT_SCOPED -- caller's own scope is dead (#12345)
     captured = capsys.readouterr()
+    # Both warnings fire: the legacy SCOPE_ZERO_COVERAGE (declaring-side
+    # hint) and the new SCOPE_DEAD_GLOB (caller-side witness list).
     assert "SCOPE_ZERO_COVERAGE" in captured.err
+    assert "SCOPE_DEAD_GLOB" in captured.err
     # The scope itself is named verbatim so the lane can reissue.
     assert "definitely-not-a-real-glob-*.zxyq" in captured.err
+    # And the JSON summary carries the dead-glob witness on the caller side.
+    assert '"caller_empty_scope": [' in captured.out
+    assert "definitely-not-a-real-glob-*.zxyq" in captured.out
 
 
 def test_run_check_no_warning_when_scope_matches_files(capsys):
@@ -2886,6 +2941,194 @@ def test_claim_body_without_paths_stays_epic_wide():
         "[CLAIMED] lane myia-po-2024:CoursIA -- fix ML-4"
 
 
+# --- #12345 -- caller-side scope-vivacity classifier -------------------------
+#
+# #12345 v2 acceptance points (one test each, with the per-point assertion
+# the comment on #12322's PR review named explicitly):
+#   (1) every glob in `--paths` is dead  -> exit 2 + `SCOPE_DEAD_GLOB` WARN
+#       naming each dead glob + `caller_empty_scope: [...]` JSON field;
+#   (2) SOME globs are dead               -> `SCOPE_DEAD_GLOB` WARN on those,
+#       the remaining live glob continues to carry disjointness;
+#   (3) outside a git repo (`tracked=None`) -> silent degradation, NO false
+#       WARN -- a caller without a tracked-files walk must not see a
+#       `SCOPE_DEAD_GLOB` for globs that may be live elsewhere;
+#   (4) positive control: a LIVE glob produces NO `SCOPE_DEAD_GLOB` WARN --
+#       a silenced detector and a disabled detector render the same output,
+#       and this test pins the distinction (without it, a future refactor
+#       could break the WARN path without any test catching it);
+#   (5) fail-CLOSED: an entirely-dead scope with ZERO blockers does NOT
+#       clear to `exit 0` -- the verdict is `NOT_SCOPED` at `exit 2` with
+#       a dedicated stderr message naming the dead globs, so the caller
+#       learns that the missing write-authorisation is THEIR scope.
+
+
+def test_check_caller_scope_all_globsmdead_routes_to_not_scoped(capsys, monkeypatch):
+    """#12345 acceptance (1) -- every glob in `--paths` is dead -> exit 2 +
+    `SCOPE_DEAD_GLOB` WARN + `caller_empty_scope: [...]` JSON field.
+    Caller has TWO dead globs; both must surface in the WARN and the JSON."""
+    monkeypatch.setattr(clc, "_git_tracked_files",
+                        lambda: ["x/a.ipynb", "y/01.ipynb"])
+    blocker = comment(
+        "[CLAIMED] lane A:CoursIA -- tranche x -- paths: x/**",
+        "2026-08-15T00:00:00Z",
+    )
+    p = payload(blocker, number=11064, title="t")
+    rc = clc._run_check(
+        p, "B:CoursIA",
+        my_paths=["dead1/glob.ipynb", "dead2/other.ipynb"],
+    )
+    captured = capsys.readouterr()
+    # #12345 -- entirely-dead scope -> NOT_SCOPED (exit 2), not BLOCKED (exit 1).
+    # The blocker `x/**` would have been a true conflict if the caller's
+    # scope had been live; the broken scope prevents the disjointness test.
+    assert rc == 2
+    assert "SCOPE_DEAD_GLOB" in captured.err
+    # Both dead globs named verbatim so the caller can reissue.
+    assert "dead1/glob.ipynb" in captured.err
+    assert "dead2/other.ipynb" in captured.err
+    # And the JSON summary carries the dead-glob witness on the caller side.
+    assert '"caller_empty_scope": [' in captured.out
+    assert "dead1/glob.ipynb" in captured.out
+    assert "dead2/other.ipynb" in captured.out
+
+
+def test_check_caller_scope_partially_dead_warns_but_keeps_live(capsys, monkeypatch):
+    """#12345 acceptance (2) -- SOME globs are dead -> `SCOPE_DEAD_GLOB` WARN
+    on those, the live glob continues to carry disjointness. The verdict is
+    `PATH_SCOPED` (not `EPIC_WIDE_NO_PATHS_DECLARED`) because at least one
+    glob is alive -- the partial lift only kicks in when the WHOLE scope
+    is dead."""
+    monkeypatch.setattr(clc, "_git_tracked_files",
+                        lambda: ["x/a.ipynb", "y/01.ipynb"])
+    blocker = comment(
+        "[CLAIMED] lane A:CoursIA -- tranche x -- paths: x/**",
+        "2026-08-15T00:00:00Z",
+    )
+    p = payload(blocker, number=11064, title="t")
+    # Caller's scope: one live glob (`x/a.ipynb` -- intersect with `x/**`),
+    # one dead glob (`dead/nowhere.ipynb`). The live glob forces the verdict
+    # to PATH_SCOPED + BLOCKED; the dead glob is surfaced as a hint.
+    rc = clc._run_check(
+        p, "B:CoursIA",
+        my_paths=["x/a.ipynb", "dead/nowhere.ipynb"],
+    )
+    captured = capsys.readouterr()
+    # The LIVE glob intersects the blocker -> real BLOCKED at exit 1.
+    assert rc == 1
+    assert "BLOCKED" in captured.err
+    # The DEAD glob is named in the WARN (partial coverage).
+    assert "SCOPE_DEAD_GLOB" in captured.err
+    assert "dead/nowhere.ipynb" in captured.err
+    # The live glob does NOT appear in the WARN (selectivity pin).
+    assert "x/a.ipynb" not in captured.err.split("SCOPE_DEAD_GLOB")[1] if "SCOPE_DEAD_GLOB" in captured.err else True
+    # JSON exposes the dead globs list (only the dead ones, not the live ones).
+    assert 'dead/nowhere.ipynb' in captured.out
+    # The live glob DOES NOT appear in the caller_empty_scope field.
+    out_json = captured.out
+    assert "\"caller_empty_scope\": [\n    \"dead/nowhere.ipynb\"\n  ]" in out_json or \
+           '"caller_empty_scope": ["dead/nowhere.ipynb"]' in out_json
+
+
+def test_check_caller_scope_silent_outside_git_repo(capsys, monkeypatch):
+    """#12345 acceptance (3) -- outside a git repo (`tracked=None`) we
+    degrade silently: NO `SCOPE_DEAD_GLOB` WARN, `caller_empty_scope: []`
+    in the JSON. Without this pin, a caller running the check outside a
+    git repo (e.g. just `--from-json` for triage) would see false-positive
+    WARNs on every scope.
+
+    The verdict semantics under `tracked=None`: `_empty_scope_in` short-
+    circuits to `[]` when the walk failed, so the dead-glob classifier
+    cannot fire. The verdict falls to PATH_SCOPED; `_filter_by_claim_scope`
+    cannot lift the blocker `x/**` (the lift requires `tracked is not None`)
+    and cannot prove disjointness (fnmatch on `does/not/exist/in/repo.ipynb`
+    against `x/**` returns no match), so the blocker is DROPPED and the
+    call returns CLEAR at exit 0. The verdict is the legacy behaviour, the
+    PIN this test cares about is exclusively the silent-degradation aspect
+    (no WARN, empty JSON witness list).
+    """
+    # Mock `_git_tracked_files` to return the None sentinel (the real walk
+    # returns None when not in a git repo or when git is missing). The
+    # organ calls the helper with one positional arg (`repo_root`), so the
+    # mock accepts and ignores it.
+    monkeypatch.setattr(clc, "_git_tracked_files", lambda repo_root=None: None)
+    p = payload(
+        comment("[CLAIMED] lane A:CoursIA -- tranche x -- paths: x/**",
+                "2026-08-15T00:00:00Z"),
+        number=11064, title="t",
+    )
+    # Caller's `--paths` would normally be dead in this repo, but the
+    # tracked-files walk failed -- the WARN must NOT fire (best-effort),
+    # and the verdict falls to the legacy PATH_SCOPED branch (CLEAR or
+    # BLOCKED depending on fnmatch disjointness).
+    rc = clc._run_check(
+        p, "B:CoursIA",
+        my_paths=["does/not/exist/in/repo.ipynb"],
+    )
+    captured = capsys.readouterr()
+    # Under `tracked=None`, fnmatch says `does/not/exist/in/repo.ipynb` is
+    # disjoint from `x/**` (the path does not match the pattern), so the
+    # blocker is dropped -> CLEAR at exit 0. The verdict semantics here
+    # are the legacy behaviour -- the PIN is silent degradation.
+    assert rc == 0
+    # PIN: silent degradation. NO WARN, empty JSON witness list.
+    assert "SCOPE_DEAD_GLOB" not in captured.err
+    assert '"caller_empty_scope": []' in captured.out
+
+
+def test_check_caller_scope_live_glob_produces_no_warn(capsys, monkeypatch):
+    """#12345 acceptance (4) -- POSITIVE CONTROL: a live glob produces NO
+    `SCOPE_DEAD_GLOB` WARN. Without this test, a silent detector and a
+    disabled detector would render the same output, and a future refactor
+    that breaks the WARN path would not be caught by any other test (the
+    failure modes `WARN-always` and `WARN-never` are equally broken from
+    a caller's standpoint -- both mask the actual dead-glob state)."""
+    monkeypatch.setattr(clc, "_git_tracked_files",
+                        lambda: ["x/a.ipynb", "y/01.ipynb", "z/deep/f.ipynb"])
+    p = payload(
+        comment("[CLAIMED] lane A:CoursIA -- tranche x -- paths: x/**",
+                "2026-08-15T00:00:00Z"),
+        number=11064, title="t",
+    )
+    # `z/deep/f.ipynb` is in the mock AND disjoint from `x/**` -> CLEAR at
+    # exit 0. Crucially: NO `SCOPE_DEAD_GLOB` WARN (the live glob is live).
+    rc = clc._run_check(p, "B:CoursIA", my_paths=["z/deep/f.ipynb"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "SCOPE_DEAD_GLOB" not in captured.err
+    # The dead-glob witness list is empty in the JSON too.
+    assert '"caller_empty_scope": []' in captured.out
+
+
+def test_check_caller_scope_fail_closed_when_no_blockers(capsys, monkeypatch):
+    """#12345 acceptance (5) -- fail-CLOSED: an entirely-dead scope with
+    ZERO blockers does NOT clear to `exit 0`. The verdict is `NOT_SCOPED`
+    at `exit 2` with a dedicated stderr message naming the dead globs, so
+    the caller learns that the missing write-authorisation is THEIR scope
+    (not "nothing blocks me, I'm free to write"). This is the third property
+    of #12345's acceptance list -- the most important because it converts
+    a silent `exit 0` into an explicit refusal."""
+    monkeypatch.setattr(clc, "_git_tracked_files",
+                        lambda: ["x/a.ipynb", "y/01.ipynb"])
+    # ONLY the caller has a claim (their own, scoped, dead). No other lane.
+    body = clc._CLAIM_BODY_TMPL.format(
+        lane="B:CoursIA", intention="tranche",
+        paths_clause=clc._paths_clause(["dead/nowhere.ipynb"]),
+    )
+    p = payload(comment(body, "2026-08-15T00:00:00Z"), number=11064, title="t")
+    rc = clc._run_check(p, "B:CoursIA")  # own lane, no other claims
+    captured = capsys.readouterr()
+    # #12345 -- fail-CLOSED. Broken scope is not a permissive scope.
+    assert rc == 2  # NOT_SCOPED, NOT CLEAR
+    assert "NOT_SCOPED" in captured.err
+    # The dedicated message names the dead glob.
+    assert "dead/nowhere.ipynb" in captured.err
+    # And it explicitly explains that this is NOT a permissive CLEAR.
+    assert "broken scope" in captured.err or "fail-CLOSED" in captured.err
+    # The JSON shows the dead-glob witness list.
+    assert '"caller_empty_scope": [' in captured.out
+    assert "dead/nowhere.ipynb" in captured.out
+
+
 def test_claim_paths_roundtrip_reads_back_scoped(monkeypatch):
     # #11064 acceptance (4): a claim posted with --paths is read back by the
     # check as SCOPED -- a disjoint lane stays free (exit 0), an intersecting
@@ -2904,17 +3147,57 @@ def test_claim_paths_roundtrip_reads_back_scoped(monkeypatch):
     )
     pl = payload(comment(body, "2026-08-15T00:00:00Z"), number=11064, title="t")
     assert clc._run_check(pl, "B:CoursIA", my_paths=["z/**"]) == 0       # disjoint -> CLEAR
-    assert clc._run_check(pl, "B:CoursIA", my_paths=["x/sub/f.ipynb"]) == 1  # intersect -> BLOCKED
+    # #12345 -- the leg below USED to be `== 1` (intersect -> BLOCKED) on
+    # the path `x/sub/f.ipynb` matching `x/**`. Post-#12345, `x/sub/f.ipynb`
+    # is NOT in the mock tracked-files list -- the caller's scope is entirely
+    # dead -> `EPIC_WIDE_NO_PATHS_DECLARED` at exit 2 (fail-CLOSED). The
+    # genuine-intersection case is now pinned separately in
+    # `test_claim_paths_roundtrip_reads_back_scoped_intersect_live_glob`
+    # below with a glob that IS in the mock (`z/deep/f.ipynb`).
+    assert clc._run_check(pl, "B:CoursIA", my_paths=["x/sub/f.ipynb"]) == 2  # dead scope -> NOT_SCOPED
     # The unscoped-caller leg: previously `== 1` (false-positive real conflict).
     # #12322 lifts this to `== 2` (NOT_SCOPED) -- the verdict is honest about
     # the missing scope binding instead of pretending to be a hard block.
     assert clc._run_check(pl, "B:CoursIA") == 2
 
 
+def test_claim_paths_roundtrip_reads_back_scoped_intersect_live_glob(monkeypatch):
+    """Companion to `test_claim_paths_roundtrip_reads_back_scoped` (above) --
+    pins the LEGITIMATE intersection case (caller's glob DOES match a tracked
+    file AND falls under the claimant's `paths:` clause). Pre-#12345 this
+    leg was on the same test as the dead-glob case (it was forced to use a
+    dead glob because the assertion was `== 1`). Post-#12345 the dead-glob
+    leg is #12345-routed to exit 2; the live-intersection leg is here."""
+    monkeypatch.setattr(clc, "_git_tracked_files",
+                        lambda: ["x/a.ipynb", "y/01.ipynb", "z/deep/f.ipynb"])
+    body = clc._CLAIM_BODY_TMPL.format(
+        lane="A:CoursIA", intention="tranche x",
+        paths_clause=clc._paths_clause(["x/**", "y/01.ipynb"]),
+    )
+    pl = payload(comment(body, "2026-08-15T00:00:00Z"), number=11064, title="t")
+    # The claimant's claim scope is `x/**, y/01.ipynb`. A caller scope
+    # `z/deep/f.ipynb` is LIVE (in the mock) but does NOT match `x/**` or
+    # `y/01.ipynb` -> disjoint -> CLEAR exit 0. We need a glob that is BOTH
+    # in the mock AND under the claim's `paths:` clause -> `x/a.ipynb`.
+    assert clc._run_check(pl, "B:CoursIA", my_paths=["x/a.ipynb"]) == 1  # live intersect -> BLOCKED
+
+
 def test_claim_refuses_when_blocked(monkeypatch, tmp_path):
     # #11064 acceptance (1): `--claim` runs the check before posting and
-    # REFUSES (exit 1, nothing posted) when another lane holds an overlapping
-    # claim -- instead of posting first and printing a reassuring success.
+    # REFUSES (nothing posted) when another lane holds an overlapping claim
+    # -- instead of posting first and printing a reassuring success. The
+    # refusal channel is `exit != 0` (the caller's `--claim` must NOT post
+    # a comment); the EXACT exit code distinguishes two distinct refusal
+    # modes that pre-#12345 were collapsed:
+    #   - `exit 1` (BLOCKED): a true overlap, the caller's `--paths` matches
+    #     a live tracked file under the claimant's scope. The lane MUST wait
+    #     for release or post a `[RELEASED]` on its own claim.
+    #   - `exit 2` (NOT_SCOPED, #12345): the caller's `--paths` is entirely
+    #     dead in this repo (the glob matches zero tracked files). The
+    #     refusal is the same (do not post), but the actionable next step
+    #     is re-run with a valid `--paths` glob, not wait-for-release.
+    # #12345 -- the test's caller `--paths x/sub/f.ipynb` is dead in the real
+    # repo (no `x/` tree). Post-#12345 the refusal is `exit 2` (NOT_SCOPED).
     blocker = comment(
         "[CLAIMED] lane A:CoursIA -- tranche x -- paths: x/**",
         "2026-08-15T00:00:00Z",
@@ -2926,7 +3209,10 @@ def test_claim_refuses_when_blocked(monkeypatch, tmp_path):
                         lambda issue, body: posted.append((issue, body)))
     rc = clc.main(["--lane", "B:CoursIA", "--paths", "x/sub/f.ipynb",
                    "--claim", "tranche x", "11064", "--from-json", json_path])
-    assert rc == 1
+    # #12345 -- the caller's glob is dead -> NOT_SCOPED (exit 2), NOT
+    # BLOCKED (exit 1). The refusal channel (no post) is what the test
+    # actually pins; the exit code is the diagnostic.
+    assert rc == 2  # NOT_SCOPED -- caller's --paths is dead (#12345)
     assert posted == []
 
 

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -288,19 +288,22 @@ def test_decorated_paths_clause_scopes_claim():
     assert fnmatch.fnmatch("notebooks/b.ipynb", "notebooks/b.ipynb**")  # invariant
 
 
-def test_check_blocked_when_claim_comment_mentions_marker_in_prose(capsys):
+def test_check_no_paths_claim_in_prose_returns_exit_2_not_scoped(capsys):
     # Full-flow regression for the #10228 FN: a claim comment that ALSO mentions
     # a close marker in instructional prose must still BLOCK another lane. This
     # is the exact shape of ai-01's dispatch comments (claim + release instructions).
+    # #12322 -- caller has no scope so the verdict is `NOT_SCOPED` (exit 2),
+    # not `BLOCKED` (exit 1). The nuance is that the caller can lift the
+    # block by re-running with `--paths` matching their actual files.
     body = (
         "[CLAIMED] lane myia-po-2025:CoursIA-2 -- Taches 1-2 (CPU).\r\n\r\n"
         "(Release with `[RELEASED]` when your PR lands.)"
     )
     p = payload(comment(body, "2026-08-09T21:19:00Z", author="myia-ai-01"))
     rc = clc._run_check(p, "myia-po-2024:CoursIA")
-    assert rc == 1                          # BLOCKED, not CLEAR (the FN returned 0)
+    assert rc == 2                          # NOT_SCOPED, not BLOCKED (legacy returned 1)
     captured = capsys.readouterr()
-    assert "BLOCKED" in captured.err
+    assert "NOT_SCOPED" in captured.err
     assert "myia-po-2025:CoursIA-2" in captured.out
 
 
@@ -402,16 +405,128 @@ def test_check_clear_when_only_my_lane(capsys):
     assert "CLEAR" in out
 
 
-def test_check_blocked_when_other_lane_active(capsys):
+def test_check_no_paths_returns_exit_2_and_not_scoped(capsys):
+    # #12322 -- when the caller does NOT pass `--paths` AND has no scoped
+    # active claim of their own, the call cannot prove disjointness from any
+    # blocker. The legacy verdict (exit 1, BLOCKED) was a hard read that
+    # prompted the fumble on #11112 (user-mistaking the question for a
+    # real block, then escalating to ai-01 and posting an URGENT DM).
+    # The fix splits this into `exit 2` + the `NOT_SCOPED` verdict label
+    # so the next step is unambiguously "re-run with `--paths`" instead
+    # of "find another grain".
     p = payload(comment(
         "[CLAIMED] lane myia-po-2025:CoursIA -- working here",
         "2026-08-06T22:43:31Z",
     ))
     rc = clc._run_check(p, "myia-po-2024:CoursIA")
-    assert rc == 1
+    assert rc == 2
     captured = capsys.readouterr()
-    assert "BLOCKED" in captured.err
+    assert "NOT_SCOPED" in captured.err
+    assert "ACTION" in captured.err
     assert "myia-po-2025:CoursIA" in captured.out
+
+
+# --- #12322 -- query_scope + exit code semantics -----------------------------
+#
+# Three exit codes:
+#   0 -> CLEAR (no blocker at all).
+#   1 -> BLOCKED (caller's scope proves disjointness impossible -- real conflict).
+#   2 -> NOT_SCOPED (caller did not bind scope, blocker cannot be confirmed
+#        as a real conflict -- the next step is to re-run with `--paths`).
+#
+# The test above (test_check_no_paths_returns_exit_2_and_not_scoped) covers
+# the unscoped-caller-against-unscoped-blocker leg. The four tests below
+# pin the OTHER three legs of the matrix so the verdict behaviour does not
+# silently drift on either the PATH_SCOPED or the CLEAR branch.
+
+def test_check_query_scope_path_scoped_when_caller_passes_paths(capsys):
+    """When the caller passes `--paths`, the verdict field is `PATH_SCOPED`
+    EVEN WHEN a blocker exists. This pins the matrix: the caller IS scoping,
+    so the verdict layer is no longer the right place for the actionable
+    hint -- the verdict is the real exit 1 / real BLOCKED label."""
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2025:CoursIA -- working here",
+                "2026-08-06T22:43:31Z"),
+    )
+    rc = clc._run_check(
+        p, "myia-po-2024:CoursIA",
+        my_paths=["scripts/check_lane_claim.py"],
+    )
+    out = capsys.readouterr().out
+    assert rc == 1  # BLOCKED at exit 1 -- caller IS scoping, real conflict
+    assert '"query_scope": "PATH_SCOPED"' in out
+
+
+def test_check_query_scope_path_scoped_when_caller_already_owns_scoped_claim(capsys):
+    """Symmetric leg: the caller does NOT pass `--paths` BUT already owns an
+    active scoped claim (`paths:`) on the same issue. Their scope merges
+    with the call site via the #10419 rule. The verdict is `PATH_SCOPED`
+    at exit 1 -- the caller is, in effect, scoped through their own active
+    claim, so the unscoped-caller hint does not apply."""
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2024:CoursIA -- "
+            "paths: MyIA.AI.Notebooks/Sudoku/Sudoku-9.ipynb",
+            "2026-08-11T04:02:00Z",
+        ),
+        comment(
+            "[CLAIMED] lane myia-po-2025:CoursIA -- working here",
+            "2026-08-06T22:43:31Z",
+        ),
+    )
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    out = capsys.readouterr().out
+    assert rc == 1  # BLOCKED -- other lane is epic-wide, still blocks caller
+    assert '"query_scope": "PATH_SCOPED"' in out
+    # Verify the caller's own scoped claim is in the active_claims dict.
+    assert '"myia-po-2024:CoursIA"' in out
+
+
+def test_check_query_scope_clears_when_no_blockers_and_caller_is_unscoped(capsys):
+    """The CLEAR case at exit 0 -- caller is unscoped, no other lane holds
+    a claim. The verdict is still CLEAR and `query_scope` is `PATH_SCOPED`
+    (the caller's not-scoping does not influence the verdict when nothing
+    is blocking). Pinning this prevents a future change from falsely
+    classifying `CLEAR + unscoped` as a sentinel of any kind."""
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2024:CoursIA -- build the guard",
+        "2026-08-06T22:43:31Z",
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    out = capsys.readouterr().out
+    assert rc == 0
+    # query_scope is PATH_SCOPED on a CLEAR even when the caller did not
+    # bind `--paths` -- the field reports the FORCED CLASSIFIER, not the
+    # caller's own choice. The rule `EPIC_WIDE_NO_PATHS_DECLARED` only
+    # triggers when there is at least one blocker to label.
+    assert '"query_scope": "PATH_SCOPED"' in out
+    assert '"blocked": false' in out
+
+
+def test_check_path_scoped_blocks_against_real_intersecting_scope(capsys):
+    """The decisive positive control -- a SCOPED caller whose scope
+    intersects the blocker's scope reads as `BLOCKED` at `exit 1` (NOT
+    `NOT_SCOPED` at `exit 2`). The exit-code distinction is the only thing
+    that lets the caller automate against this verdict."""
+    # Blocker's scope: scripts/**
+    # Caller's scope: scripts/check_lane_claim.py (intersects)
+    p = payload(
+        comment(
+            "[OVERRIDE] lane myia-po-2024:CoursIA -- paths: scripts/**",
+            "2026-08-11T18:00:00Z",
+        ),
+    )
+    rc = clc._run_check(
+        p,
+        "myia-po-2025:CoursIA-2",
+        my_paths=["scripts/check_lane_claim.py"],
+    )
+    err = capsys.readouterr().err
+    assert rc == 1
+    # The non-path-scoped BLOCKED message fires -- distinct from the
+    # NOT_SCOPED message which would have fired if the caller had no scope.
+    assert "BLOCKED: another lane holds an active claim" in err
+    assert "NOT_SCOPED" not in err
 
 
 def test_check_clear_after_other_lane_releases(capsys):
@@ -573,21 +688,26 @@ def test_stale_threshold_unblocks_old_claim(capsys):
     assert '"blocked": false' in captured.out
 
 
-def test_stale_threshold_fresh_claim_still_blocks(capsys):
-    # Other lane claimed 2h ago; threshold 24h -> still BLOCKED.
+def test_stale_threshold_fresh_claim_returns_exit_2_not_scoped(capsys):
+    # Other lane claimed 2h ago; threshold 24h -> NOT_SCOPED at exit 2 (#12322).
+    # Pre-#12322 this returned `exit 1` + `BLOCKED`, conflating a non-scoped
+    # caller with a real conflict. The new verdict reflects the action the
+    # caller can take (re-run with `--paths`).
     p = payload(comment(
         "[CLAIMED] lane myia-po-2025:CoursIA -- working here",
         "2026-08-07T10:00:00Z",
     ))
     rc = clc._run_check(p, "myia-po-2024:CoursIA",
                         stale_threshold=24.0, now=NOW)
-    assert rc == 1
+    assert rc == 2
     captured = capsys.readouterr()
-    assert "BLOCKED" in captured.err
+    assert "NOT_SCOPED" in captured.err
 
 
 def test_stale_threshold_stale_plus_fresh_blocks_on_fresh(capsys):
-    # Two other lanes: one stale (48h), one fresh (1h). The fresh one blocks.
+    # Two other lanes: one stale (48h), one fresh (1h). The fresh one
+    # triggers the NOT_SCOPED verdict (#12322 exit 2) since the caller
+    # has no scope of their own.
     p = payload(
         comment("[CLAIMED] lane myia-po-2025:CoursIA -- old",
                 "2026-08-05T12:00:00Z"),
@@ -596,11 +716,11 @@ def test_stale_threshold_stale_plus_fresh_blocks_on_fresh(capsys):
     )
     rc = clc._run_check(p, "myia-po-2024:CoursIA",
                         stale_threshold=24.0, now=NOW)
-    assert rc == 1
+    assert rc == 2
     captured = capsys.readouterr()
-    # The stale one is warned about, the fresh one blocks.
+    # The stale one is warned about, the fresh one drives the NOT_SCOPED.
     assert "STALE_CLAIM myia-po-2025:CoursIA" in captured.err
-    assert "BLOCKED" in captured.err
+    assert "NOT_SCOPED" in captured.err
     assert "myia-po-2023:CoursIA" in captured.out
 
 
@@ -618,27 +738,31 @@ def test_stale_threshold_boundary_is_stale(capsys):
 
 def test_no_stale_flag_blocks_old_claim_unchanged(capsys):
     # Criterion 1: without the flag, an old claim still blocks (current behaviour).
+    # #12322 -- the verdict label is `NOT_SCOPED` (exit 2) since the caller
+    # does not declare `--paths`. The exit code change is the corrective.
     p = payload(comment(
         "[CLAIMED] lane myia-po-2025:CoursIA -- very old orphan",
         "2026-08-01T00:00:00Z",
     ))
     rc = clc._run_check(p, "myia-po-2024:CoursIA", now=NOW)
-    assert rc == 1
+    assert rc == 2
     captured = capsys.readouterr()
     assert "STALE_CLAIM" not in captured.err
-    assert "BLOCKED" in captured.err
+    assert "NOT_SCOPED" in captured.err
 
 
 def test_stale_threshold_unparseable_not_treated_stale(capsys):
     # A claim whose createdAt is unparseable cannot be dated -> NOT stale
     # (conservative: we cannot prove an age, so we do not lift the block).
+    # #12322 -- caller has no scope, so the verdict is exit 2 NOT_SCOPED
+    # instead of the legacy exit 1 BLOCKED.
     p = payload(comment(
         "[CLAIMED] lane myia-po-2025:CoursIA -- undated",
         "not-an-iso-date",
     ))
     rc = clc._run_check(p, "myia-po-2024:CoursIA",
                         stale_threshold=24.0, now=NOW)
-    assert rc == 1
+    assert rc == 2
 
 
 # --- --paths mode (#9959) ----------------------------------------------------
@@ -965,7 +1089,11 @@ def test_check_override_for_my_lane_is_clear(capsys):
 
 
 def test_check_override_to_other_lane_blocks(capsys):
-    # I claimed, then the coordinator overrode to ANOTHER lane -> BLOCKED for me.
+    # I claimed, then the coordinator overrode to ANOTHER lane -> NOT_SCOPED
+    # for me. #12322 -- the caller (myia-po-2025:CoursIA-2) did not pass
+    # `--paths`, so the verdict is NOT_SCOPED at exit 2 even though an
+    # [OVERRIDE] reassigned the lock. The override retains the BLOCKED
+    # semantics; only the verdict label on the unscoped caller leg moves.
     p = payload(
         comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- working here",
                 "2026-08-09T11:41:43Z"),
@@ -973,9 +1101,9 @@ def test_check_override_to_other_lane_blocks(capsys):
                 "2026-08-09T22:00:00Z"),
     )
     rc = clc._run_check(p, "myia-po-2025:CoursIA-2")
-    assert rc == 1
+    assert rc == 2  # #12322 NOT_SCOPED (the override reassigned to a different lane)
     captured = capsys.readouterr()
-    assert "BLOCKED" in captured.err
+    assert "NOT_SCOPED" in captured.err
     assert "myia-po-2026:CoursIA" in captured.out
 
 
@@ -1239,8 +1367,9 @@ def test_reducer_scoped_override_closes_empty_scope_full_claim_overlapping_live(
 
 def test_check_override_no_paths_preserves_legacy_epic_wide_behaviour(capsys):
     # Override WITHOUT `paths:` clause, check WITHOUT `--paths` -> legacy
-    # epic-wide block. This pins backward compatibility: a caller that did
-    # not opt into the new scope mechanism keeps the old behaviour.
+    # epic-wide block. #12322 -- the verdict text is `NOT_SCOPED` (exit 2)
+    # so the caller can branch on the verdict: exit 1 means a real conflict,
+    # exit 2 means "scope your call to lift the over-block".
     p = payload(
         comment("[CLAIMED] lane myia-po-2026:CoursIA -- original",
                 "2026-08-09T11:00:00Z"),
@@ -1248,9 +1377,9 @@ def test_check_override_no_paths_preserves_legacy_epic_wide_behaviour(capsys):
                 "2026-08-09T22:00:00Z"),
     )
     rc = clc._run_check(p, "myia-po-2026:CoursIA")
-    assert rc == 1
+    assert rc == 2
     captured = capsys.readouterr()
-    assert "BLOCKED" in captured.err
+    assert "NOT_SCOPED" in captured.err
     assert "myia-po-2024:CoursIA" in captured.out
 
 
@@ -1356,8 +1485,9 @@ def test_active_claims_summary_exposes_paths(capsys):
     # The audit JSON surfaces the `paths` field on override events, so a
     # human reviewer can verify the scope without re-reading the source.
     # The reducer grants A the claim -> A is in `others` (because I am B),
-    # so the verdict is BLOCKED; that is not what this test is pinning. We
-    # only check that the scope payload leaks into the JSON, NOT the verdict.
+    # so the verdict is NOT_SCOPED at exit 2 (#12322); that is not what this
+    # test is pinning. We only check that the scope payload leaks into the
+    # JSON, NOT the verdict.
     p = payload(
         comment(
             "[OVERRIDE] lane myia-po-2024:CoursIA -- paths: Lean/**, scripts/**",
@@ -1366,9 +1496,10 @@ def test_active_claims_summary_exposes_paths(capsys):
     )
     rc = clc._run_check(p, "myia-po-2025:CoursIA-2")
     out = capsys.readouterr().out
-    assert rc == 1  # override granted A, so B is blocked (epic-wide read)
+    assert rc == 2  # exit 2 NOT_SCOPED -- caller did not bind `--paths`
     assert "Lean/**" in out
     assert "scripts/**" in out
+    assert '"query_scope": "EPIC_WIDE_NO_PATHS_DECLARED"' in out
 
 
 # --- [CLAIMED] paths: scope (#10419) -----------------------------------------
@@ -1652,7 +1783,12 @@ def test_intent_caps_at_120_chars():
 
 
 def test_blocked_verdict_surfaces_intent_side_by_side(capsys):
-    """Two lanes with disjoint marker-line excerpts both render in BLOCKED."""
+    """Two lanes with disjoint marker-line excerpts both render in NOT_SCOPED.
+
+    #12322 -- the verdict label is `NOT_SCOPED` (exit 2) when the caller
+    does not bind scope. The intent side-by-side block is preserved verbatim
+    (it was Variante 2's headline) so a reader still gets the disambiguating
+    signal that prevents #10382-style over-blocks."""
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2023:CoursIA — Part1-Foundations BFS notebook",
@@ -1664,14 +1800,12 @@ def test_blocked_verdict_surfaces_intent_side_by_side(capsys):
         ),
     )
     rc = clc._run_check(p, "myia-po-2025:CoursIA-2")
-    assert rc == 1
+    assert rc == 2  # #12322 -- NOT_SCOPED, caller has no scope binding
     err = capsys.readouterr().err
-    # The bare BLOCKED message used to say "Do not start -- pick another grain,
-    # or wait for release." Variante 2 adds the side-by-side intent block.
-    assert "BLOCKED" in err
+    assert "NOT_SCOPED" in err
     assert "Part1-Foundations BFS notebook" in err
     assert "Part3-Advanced A* notebook" in err
-    assert "Claimed scopes" in err  # the new header line
+    assert "Claimed scopes" in err  # the Variante 2 header preserved
 
 
 def test_trio_ortools_scenario_disjoint_intents_visible(capsys):
@@ -1680,10 +1814,11 @@ def test_trio_ortools_scenario_disjoint_intents_visible(capsys):
     Three lanes, each with a valid [CLAIMED] on the same EPIC #10382 but
     on DISJOINT notebooks. The block is the tool's job (the reducer keeps
     them all in `others` -- epic-wide semantics are preserved). The FIX is
-    that the BLOCKED verdict now surfaces all three intents side-by-side,
+    that the NOT_SCOPED verdict now surfaces all three intents side-by-side,
     so a coordinator reads "three disjoint notebooks" at a glance instead
     of "three blocking claims" and can decide whether the scope overlap
-    actually warrants arbitration, or whether each lane can proceed.
+    actually warrants arbitration, or whether each lane can proceed by
+    re-running the check with `--paths`. (#12322)
     """
     p = payload(
         comment(
@@ -1700,10 +1835,9 @@ def test_trio_ortools_scenario_disjoint_intents_visible(capsys):
         ),
     )
     rc = clc._run_check(p, "myia-po-2025:CoursIA-2")
-    # Reducer keeps all three in `others` (no scope mechanism for [CLAIMED]
-    # yet -- that's the next iteration; the immediate fix is the verdict
-    # SURFACES them legibly).
-    assert rc == 1
+    # Reducer keeps all three in `others` (caller did not bind scope, so the
+    # call lands in `EPIC_WIDE_NO_PATHS_DECLARED` per #12322).
+    assert rc == 2
     err = capsys.readouterr().err
     assert "myia-po-2023:CoursIA" in err
     assert "myia-po-2024:CoursIA" in err
@@ -1739,8 +1873,9 @@ def test_blocked_verdict_uses_no_intent_sentinel(capsys):
 
 def test_blocked_verdict_prints_intent_for_named_lane(capsys):
     """A claim with a lane token AND a marker-line excerpt has its intent
-    printed in the BLOCKED verdict. This is the common case (the lane token
-    IS the intent excerpt when the author writes nothing else)."""
+    printed in the NOT_SCOPED verdict. This is the common case (the lane
+    token IS the intent excerpt when the author writes nothing else).
+    #12322 -- caller has no scope binding -> NOT_SCOPED at exit 2."""
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2025:CoursIA",
@@ -1748,18 +1883,19 @@ def test_blocked_verdict_prints_intent_for_named_lane(capsys):
         ),
     )
     rc = clc._run_check(p, "myia-po-2024:CoursIA")
-    assert rc == 1
+    assert rc == 2
     err = capsys.readouterr().err
-    assert "BLOCKED" in err
+    assert "NOT_SCOPED" in err
     # The intent is the lane token (the only thing on the marker line).
     assert "myia-po-2025:CoursIA" in err
 
 
 def test_blocked_message_includes_paths_narrowing_hint(capsys):
-    """The new BLOCKED hint mentions `[CLAIMED] paths: ...` as a narrowing
-    path. The path-scope clause is already supported for [OVERRIDE] (#10342);
-    [CLAIMED] with paths: is a natural follow-up, but the immediate value of
-    Variante 2 is to teach the reader that this is the next move.
+    """The NOT_SCOPED hint names `--paths ...` as the next move. The
+    path-scope clause is already supported for [OVERRIDE] (#10342);
+    [CLAIMED] with paths: is a natural follow-up (#10419). #12322 -- the
+    narrowing hint is now in the NOT_SCOPED verdict, where the actionable
+    next step belongs (the post-fix message is action-shaped).
     """
     p = payload(
         comment(
@@ -1768,10 +1904,10 @@ def test_blocked_message_includes_paths_narrowing_hint(capsys):
         ),
     )
     rc = clc._run_check(p, "myia-po-2024:CoursIA")
-    assert rc == 1
+    assert rc == 2
     err = capsys.readouterr().err
-    assert "paths:" in err
-    assert "scope-narrowing" in err
+    assert "paths" in err
+    assert "ACTION" in err
 
 
 # --- brace-group path scopes (#10597) ----------------------------------------
@@ -1995,8 +2131,9 @@ def test_filter_by_claim_scope_lifts_unparseable_to_epic_wide():
 
 def test_run_check_unparseable_scope_blocks_other_lane(capsys):
     """End-to-end: a scoped CLAIMED with an unclosed brace BLOCKS another
-    lane checking the same issue. This pins the user-visible verdict.
-    """
+    lane checking the same issue. #12322 -- the caller has no scope binding
+    so the verdict is NOT_SCOPED at exit 2 (the unparseable scope was lifted
+    to epic-wide so the call cannot prove disjointness)."""
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: scripts/{a,b-*.yaml",
@@ -2004,19 +2141,21 @@ def test_run_check_unparseable_scope_blocks_other_lane(capsys):
         ),
     )
     rc = clc._run_check(p, "myia-po-2025:CoursIA")
-    # BLOCKED -- the unparseable scope lifted the lane to epic-wide.
-    assert rc == 1
+    # NOT_SCOPED -- the unparseable scope lifted the lane to epic-wide (#12322).
+    assert rc == 2
     captured = capsys.readouterr()
     # The audit JSON names the residual brace so the lane learns to reissue.
     assert "scripts/{a,b-*.yaml" in captured.out
     # And the verdict itself is in stderr.
-    assert "BLOCKED" in captured.err
+    assert "NOT_SCOPED" in captured.err
 
 
 def test_run_check_summary_exposes_unparseable_scope_field(capsys):
     """The audit JSON surfaces the witness list under
     `active_claims.<lane>.unparseable_scope` so a human reviewer (and the
-    lane that owns the malformed claim) can read the defect at a glance."""
+    lane that owns the malformed claim) can read the defect at a glance.
+    #12322 -- also surfaces `query_scope: EPIC_WIDE_NO_PATHS_DECLARED` so
+    a reader can branch on the verdict without re-running the check."""
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2024:CoursIA-2 -- "
@@ -2025,11 +2164,12 @@ def test_run_check_summary_exposes_unparseable_scope_field(capsys):
         ),
     )
     rc = clc._run_check(p, "myia-po-2025:CoursIA")
-    assert rc == 1
+    assert rc == 2
     out = capsys.readouterr().out
     # The JSON includes the structured witness list under the lane entry.
     assert '"unparseable_scope"' in out
     assert "scripts/{a,b-*.yaml" in out
+    assert '"query_scope": "EPIC_WIDE_NO_PATHS_DECLARED"' in out
 
 
 def test_run_check_clean_brace_scope_does_not_show_unparseable(capsys):
@@ -2241,7 +2381,8 @@ def test_run_check_dead_scope_blocks_other_lane(capsys):
     """CORE #10958 fail-safe, end-to-end: a scoped claim whose every glob is
     dead (here a typo'd path, WITH the ` -- ts` suffix the truncation now
     handles) is lifted to epic-wide and BLOCKS another lane checking the
-    same issue. Pre-fix this was the #9764-style false CLEAR."""
+    same issue. Pre-fix this was the #9764-style false CLEAR. #12322 --
+    the caller has no scope binding so the verdict is NOT_SCOPED at exit 2."""
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2024:CoursIA-2 -- "
@@ -2250,9 +2391,9 @@ def test_run_check_dead_scope_blocks_other_lane(capsys):
         ),
     )
     rc = clc._run_check(p, "myia-po-2025:CoursIA")
-    assert rc == 1  # lifted to epic-wide -> blocks
+    assert rc == 2  # #12322 NOT_SCOPED (lifted to epic-wide -> cannot prove disjointness)
     captured = capsys.readouterr()
-    assert "BLOCKED" in captured.err
+    assert "NOT_SCOPED" in captured.err
     # The audit JSON names the dead glob so the lane learns to reissue.
     assert '"empty_scope"' in captured.out
     assert "scripts/nowhere/typo.py" in captured.out
@@ -2261,7 +2402,8 @@ def test_run_check_dead_scope_blocks_other_lane(capsys):
 def test_run_check_summary_exposes_empty_scope_field(capsys):
     """Acceptance: dead globs surface in the audit JSON under
     `active_claims.<lane>.empty_scope`, not only as a stderr WARN. A
-    PARTIALLY dead scope still surfaces its dead glob without lifting."""
+    PARTIALLY dead scope still surfaces its dead glob without lifting.
+    #12322 -- also surfaces `query_scope: EPIC_WIDE_NO_PATHS_DECLARED`."""
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: "
@@ -2270,10 +2412,11 @@ def test_run_check_summary_exposes_empty_scope_field(capsys):
         ),
     )
     rc = clc._run_check(p, "myia-po-2025:CoursIA")
-    assert rc == 1  # no my_scope -> the scoped claim still blocks
+    assert rc == 2  # #12322 NOT_SCOPED
     out = capsys.readouterr().out
     assert '"empty_scope"' in out
     assert "scripts/nowhere/typo.py" in out
+    assert '"query_scope": "EPIC_WIDE_NO_PATHS_DECLARED"' in out
 
 
 def test_run_check_my_dead_scope_keeps_others(capsys):
@@ -2450,12 +2593,12 @@ WELL_FORMED_MARKER = (
 
 def test_lint_override_without_paths_emits_info(capsys):
     # F1 -- the 05:53:20Z [OVERRIDE]: no `paths:` clause -> epic-wide. The
-    # INFO line names the blocking effect; the verdict itself is unchanged
-    # (the override still blocks a third lane).
+    # INFO line names the blocking effect; the verdict itself is now
+    # `NOT_SCOPED` at exit 2 (#12322) since the caller does not bind scope.
     p = payload(comment(F1_OVERRIDE_NO_PATHS, "2026-08-14T05:53:20Z"),
                 number=10678)
     rc = clc._run_check(p, "myia-po-2026:CoursIA")
-    assert rc == 1  # verdict unchanged: the override blocks
+    assert rc == 2  # #12322 -- NOT_SCOPED (caller did not bind scope)
     err = capsys.readouterr().err
     assert "INFO: marqueur OVERRIDE epic-wide (pas de clause paths:)" in err
     assert "il bloque toutes les autres lanes sur #10678" in err
@@ -2471,10 +2614,12 @@ def test_lint_f2_prose_suffix_now_truncated_silent(capsys):
     # F4 below still pins the lint's own value: prose WITHOUT a
     # whitespace-delimited ` -- `/` — ` separator is still swallowed and
     # still WARNs.
+    # #12322 -- caller did not pass `--paths`, so the verdict label flips
+    # to NOT_SCOPED (exit 2) while the lint contract (no WARN) holds.
     p = payload(comment(F2_PROSE_AFTER_CLAUSE, "2026-08-14T06:41:00Z"),
                 number=10678)
     rc = clc._run_check(p, "myia-po-2025:CoursIA")
-    assert rc == 1  # verdict unchanged: po-2024's scoped claim blocks
+    assert rc == 2  # #12322 NOT_SCOPED, exit distinct from exit 1 real conflict
     err = capsys.readouterr().err
     assert "WARN:" not in err
     # The parse-layer proof: the truncated clause keeps exactly the 9 family
@@ -2492,9 +2637,10 @@ def test_lint_family_globs_are_silent(capsys):
     # defect here is over-breadth (the globs catch unrelated OPEN PRs), which
     # is a SEMANTIC judgement the lint deliberately does not make -- this is
     # exactly the selectivity the acceptance's "la moitié qui compte" pins.
+    # #12322 -- caller has no scope, so the verdict is NOT_SCOPED at exit 2.
     p = payload(comment(F3_FAMILY_GLOBS, "2026-08-14T06:55:07Z"), number=10678)
     rc = clc._run_check(p, "myia-po-2025:CoursIA")
-    assert rc == 1  # verdict unchanged: po-2023's claim blocks
+    assert rc == 2  # #12322
     err = capsys.readouterr().err
     assert "WARN:" not in err
     assert "INFO:" not in err
@@ -2505,11 +2651,11 @@ def test_lint_prose_mentioning_paths_warns_suspect(capsys):
     # and `_PATHS_CLAUSE_RE` grabs everything after it as ONE bogus glob. The
     # lint surfaces it as a swallowed-prose WARN (the machine reads a clause
     # where the author wrote prose -- not the INFO path, but the defect is
-    # caught and named).
+    # caught and named). #12322 -- caller has no scope -> NOT_SCOPED exit 2.
     p = payload(comment(F4_PROSE_GRABBED_AS_CLAUSE, "2026-08-14T07:06:23Z"),
                 number=10678)
     rc = clc._run_check(p, "myia-po-2025:CoursIA")
-    assert rc == 1  # verdict unchanged
+    assert rc == 2  # #12322
     err = capsys.readouterr().err
     assert "WARN: glob suspect (prose avalée ?)" in err
     assert "et bloquait donc les deux lanes epic-wide" in err
@@ -2519,11 +2665,11 @@ def test_lint_prose_mentioning_paths_warns_suspect(capsys):
 def test_lint_well_formed_marker_produces_nothing(capsys):
     # The acceptance's decisive negative: a well-formed marker with two
     # EXISTING files produces NO warning at all -- the lint must not cry wolf
-    # on correct markers.
+    # on correct markers. #12322 -- caller has no scope -> NOT_SCOPED exit 2.
     p = payload(comment(WELL_FORMED_MARKER, "2026-08-14T08:00:00Z"),
                 number=10678)
     rc = clc._run_check(p, "myia-po-2025:CoursIA")
-    assert rc == 1  # verdict unchanged: the claim blocks
+    assert rc == 2  # #12322
     err = capsys.readouterr().err
     assert "WARN:" not in err
     assert "INFO:" not in err
@@ -2743,7 +2889,10 @@ def test_claim_body_without_paths_stays_epic_wide():
 def test_claim_paths_roundtrip_reads_back_scoped(monkeypatch):
     # #11064 acceptance (4): a claim posted with --paths is read back by the
     # check as SCOPED -- a disjoint lane stays free (exit 0), an intersecting
-    # lane is blocked (exit 1), an unscoped caller is conservatively blocked.
+    # lane is blocked (exit 1), and an unscoped caller is #12322-graded as
+    # `EPIC_WIDE_NO_PATHS_DECLARED` (exit 2) so the verdict is actionable
+    # (re-run with `--paths`) instead of indistinguishable from a real
+    # conflict (the old exit 1 + BLOCKED on a non-scoped caller).
     # The fake globs must match "tracked files" or the #10958 fail-safe lifts
     # the scope to epic-wide (an entirely-dead scope is a broken claim, not a
     # permissive one) -- mock the repo walk so the scopes stay live.
@@ -2754,9 +2903,12 @@ def test_claim_paths_roundtrip_reads_back_scoped(monkeypatch):
         paths_clause=clc._paths_clause(["x/**", "y/01.ipynb"]),
     )
     pl = payload(comment(body, "2026-08-15T00:00:00Z"), number=11064, title="t")
-    assert clc._run_check(pl, "B:CoursIA", my_paths=["z/**"]) == 0
-    assert clc._run_check(pl, "B:CoursIA", my_paths=["x/sub/f.ipynb"]) == 1
-    assert clc._run_check(pl, "B:CoursIA") == 1
+    assert clc._run_check(pl, "B:CoursIA", my_paths=["z/**"]) == 0       # disjoint -> CLEAR
+    assert clc._run_check(pl, "B:CoursIA", my_paths=["x/sub/f.ipynb"]) == 1  # intersect -> BLOCKED
+    # The unscoped-caller leg: previously `== 1` (false-positive real conflict).
+    # #12322 lifts this to `== 2` (NOT_SCOPED) -- the verdict is honest about
+    # the missing scope binding instead of pretending to be a hard block.
+    assert clc._run_check(pl, "B:CoursIA") == 2
 
 
 def test_claim_refuses_when_blocked(monkeypatch, tmp_path):
@@ -3203,6 +3355,9 @@ def test_run_check_summary_exposes_scope_declared_off_marker(capsys):
     # #12072 acceptance (1) -- le champ structure monte dans le JSON de sortie
     # sous `active_claims.<lane>.scope_declared_off_marker`, a cote des autres
     # temoins (unparseable_scope, empty_scope). Vide sur un claim sans signal.
+    # #12322 -- caller did not bind scope, so the verdict flips to NOT_SCOPED
+    # at exit 2 (the off-marker path the writer meant was epic-wide anyway,
+    # so the call lands in EPIC_WIDE_NO_PATHS_DECLARED).
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2024:CoursIA-2 -- tranche 04-7\n"
@@ -3212,12 +3367,13 @@ def test_run_check_summary_exposes_scope_declared_off_marker(capsys):
         ),
     )
     rc = clc._run_check(p, "myia-po-2025:CoursIA")
-    assert rc == 1  # epic-wide (paths None) -> bloque
+    assert rc == 2  # #12322 NOT_SCOPED (epic-wide + caller has no scope)
     out = capsys.readouterr().out
     assert '"scope_declared_off_marker"' in out
     assert "04-7-TTS-Voice-Benchmark.ipynb" in out
     # Le claim n'est PAS re-scope : `paths` reste null dans le JSON.
     assert '"paths": null' in out
+    assert '"query_scope": "EPIC_WIDE_NO_PATHS_DECLARED"' in out
 
 
 def test_run_check_summary_off_marker_field_empty_without_signal(capsys):
@@ -3300,7 +3456,11 @@ def test_run_check_summary_epic_wide_on_umbrella_true_when_blocking_epic_wide(ca
     # #12156 acceptance (3) -- la pathologie que le body denomme : un
     # umbrella dont l'unique claim bloquant est epic-wide (pas de clause
     # `paths:`) expose `epic_wide_on_umbrella: true`. C'est exactement le
-    # cas mesure sur #1206 par l'auteur de l'issue.
+    # cas mesure sur #1206 par l'auteur de l'issue. #12322 -- caller has
+    # no scope binding, so the verdict is NOT_SCOPED at exit 2; the JSON
+    # additions (`query_scope`, `NOT_SCOPED`) ride along with the umbrella
+    # diagnosis so a coordinator's sweep can correlate `epic_wide_on_umbrella:
+    # true` AND `query_scope: EPIC_WIDE_NO_PATHS_DECLARED` in one pass.
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2026:CoursIA\n",
@@ -3310,10 +3470,11 @@ def test_run_check_summary_epic_wide_on_umbrella_true_when_blocking_epic_wide(ca
         title="Epic: Fork Z3.Linq propre + reintegration (umbrella pathologique)",
     )
     rc = clc._run_check(p, "myia-po-2023:CoursIA-2")
-    assert rc == 1
+    assert rc == 2  # #12322 NOT_SCOPED
     out = capsys.readouterr().out
     assert '"is_umbrella": true' in out
     assert '"epic_wide_on_umbrella": true' in out
+    assert '"query_scope": "EPIC_WIDE_NO_PATHS_DECLARED"' in out
     assert '"blocking_lanes": [\n    "myia-po-2026:CoursIA"' in out
 
 


### PR DESCRIPTION
[Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python c.463 (PR #12341 [RELEASED])]

# fix(lane-claim,#12322): un appel sans `--paths` rend `exit 2` + `NOT_SCOPED`

Sub-grain canonique du chantier c.462 (PR #12336 — livraison v1 `[DELIVERED]` marqueur). Ferme une **classe de défaut user-mesurée** : 1 ESCALATION HIGH + 1 ASK HIGH en une journée sur #11112, **toutes deux** déclenchées par cette lecture-légitime-joue-comme-block.

**c.465 (cette PR, v2) replie #12345 dans la même livraison.** Issue #12345 a été ouverte par ai-01 pour la deuxième moitié de la même classe de défaut (un caller qui passe `--paths` avec un glob mort — faute de frappe, fichier supprimé — tombait en `PATH_SCOPED` → `exit 1` + `BLOCKED`, indistinguable d'un vrai conflit scope-intersectant). Ai-01 a fermé #12345 avec son contenu transplante sur #12322 commentaire #5381290620 et a explicitement demandé de replier dans cette PR, **pas** en second temps. La review CHANGES_REQUESTED est exactement cette demande.

## Diagnostic

`check_lane_claim.py <issue> --lane <lane>` :

- **v1 (c.464)** : un appel SANS `--paths` rendait `exit 1` + `BLOCKED` là où il aurait dû dire « question non scopée, re-run avec `--paths` ». Correctif v1 : 3 exit codes (0=CLEAR, 1=BLOCKED vrai conflit, 2=NOT_SCOPED) + champ JSON `query_scope`.
- **v2 (c.465, cette livraison)** : un appel AVEC `--paths` mais dont TOUS les globs matchent zéro fichier tracké tombait en `PATH_SCOPED` → `exit 1` + `BLOCKED` (la même sortie qu'un vrai conflit scope-intersectant). Le prédicat testait la **présence du flag** (`my_paths is None`), pas la **vivacité du scope** (chaque glob match-il un fichier tracké ?).

Mesure firsthand d'ai-01 sur la branche v1 (msg-20260822T124158) :

```
--paths .../GenAI/Image/01-Images-Foundation/01-4-Forge-SD-XL-Turbo.ipynb   (répertoire inexistant)
    -> exit=1   BLOCKED        <-- le piège survit intact

aucun --paths
    -> exit=2   NOT_SCOPED     <-- corrigé par v1

--paths .../GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb          (chemin réel)
    -> exit=0
```

Coût mesuré sur #11112 du cas non corrigé : ai-01 a tapé `01-Images-Foundation` au lieu de `01-Foundation` en instruisant l'escalade, a obtenu `BLOCKED` par 4 lanes, et était à une phrase d'écrire que l'organe sur-bloque des scopes disjoints (accusation fausse — les 4 claims étaient étroits et bien formés ; le glob du caller était le fautif).

## Correctif v2

### `query_scope` porte la vivacité du scope, pas la présence du flag

```python
# v1 -- testait la PRÉSENCE du flag (faux négatif sur glob mort)
if others and my_paths is None and mine_paths is None:
    query_scope = "EPIC_WIDE_NO_PATHS_DECLARED"
else:
    query_scope = "PATH_SCOPED"

# v2 -- teste la VIVACITÉ du scope (true negative sur glob mort)
if others and my_scope is None:
    query_scope = "EPIC_WIDE_NO_PATHS_DECLARED"   # no-scope branch
elif caller_empty_scope and my_scope and len(caller_empty_scope) >= len(my_scope):
    query_scope = "EPIC_WIDE_NO_PATHS_DECLARED"   # dead-scope branch (NEW)
else:
    query_scope = "PATH_SCOPED"
```

`my_scope` = `--paths` fusionné avec le `paths:` du claim actif propre du caller (#10419). `caller_empty_scope = _empty_scope_in(my_scope, tracked)` — miroir côté caller du `empty_scope` claim-side (#10958). Listé dans le JSON pour audit.

### WARN stderr `SCOPE_DEAD_GLOB`

Quand `caller_empty_scope` est non-vide (un caller a passé des globs dont certains ou tous sont morts), un WARN stderr nomme chaque glob mort :

```
SCOPE_DEAD_GLOB: your declared scope contains globs that match zero tracked files in this repo: 'dead1/glob.ipynb', 'dead2/other.ipynb'. The live globs (if any) continue to carry disjointness; reissue with valid paths to lift this hint.
```

Le WARN est non-bloquant (un scope partiellement mort continue de porter la disjointness sur sa partie vivante, le verdict reste `PATH_SCOPED`). Il est aussi silencieusement absent hors dépôt git (`_git_tracked_files()` → `None`, `caller_empty_scope = []` par construction dans `_empty_scope_in`).

### Champ JSON `caller_empty_scope`

```json
"caller_empty_scope": [
  "MyIA.AI.Notebooks/GenAI/Image/01-Images-Foundation/01-4-Forge-SD-XL-Turbo.ipynb"
]
```

Vide quand tous les globs sont vivants (ou que le walk a échoué). Mirror direct du champ `empty_scope` existant sur les claims.

### Fail-CLOSED — un scope entièrement mort ne devient PAS `exit 0`

Branche verdict **avant** le `CLEAR` : si `query_scope == "EPIC_WIDE_NO_PATHS_DECLARED"` même avec `others = {}` (typiquement : caller est le seul lane owner sur l'issue, mais son scope est mort), le verdict est `NOT_SCOPED` + `exit 2` avec un message dédié qui explique qu'un scope cassé n'est pas un scope permissif. Sans ce fail-CLOSED, un caller qui typo'd tous ses globs et qui n'a pas de blocker verrait `CLEAR` + `exit 0` — autorisation d'écrire avec un lock vide. Trois issues distinctes interdit cela :

1. **Premier re-run du caller** : il re-lance avec le même chemin faux, retombant en boucle. Le WARN stderr sur le glob mort + le verdict `NOT_SCOPED` cassent la boucle.
2. **Sécurité lane-claim** : un `exit 0` trompeur invite à écrire en territoire non-couvert par le claim. Le `NOT_SCOPED` explicite force la re-scopé.
3. **Auditabilité** : la sortie JSON du verdict est la seule trace vérifiable de ce que le check a décidé. Si elle dit CLEAR pour un scope mort, l'audit post-mortem ne peut pas reconstituer la situation.

```python
# fail-CLOSED -- broken scope is NOT a permissive scope
if query_scope == "EPIC_WIDE_NO_PATHS_DECLARED":
    print("\nNOT_SCOPED: this call's declared scope is entirely dead "
          f"on #{payload.get('number')}: every glob in `--paths` matches "
          f"zero tracked files ({dead}). The lock is empty -- the call "
          f"does NOT clear to `exit 0` because a broken scope is not a "
          f"permissive scope (#12345 fail-CLOSED). Re-run with valid "
          f"`--paths <glob>` matching the files you intend to edit; if "
          f"they intersect any blocker the call returns BLOCKED at "
          f"`exit 1`, otherwise CLEAR at `exit 0`. Exiting with `exit 2` "
          f"so callers can branch on the verdict without false-alarming "
          f"on a scope-typo.", file=sys.stderr)
    return 2
```

### Migration du `query_scope` post-stale-filter

Le `query_scope` est calculé **après** le stale-filter (ligne ~1383) pour que le verdict reflète l'état FINAL des blockers, pas l'état pré-stale. Sans ce réordonnancement, un caller sans scope avec un blocker stale voyait `EPIC_WIDE_NO_PATHS_DECLARED` (parce que `others` était non-vide avant stale-filter), et se faisait sermonner sur un blocker qui n'existait plus.

## Acceptance #12345 — 6 points nommés par ai-01

| # | Point | Test qui le couvre |
|---|---|---|
| 1 | tous les globs dead → exit 2 + `SCOPE_DEAD_GLOB` WARN + `caller_empty_scope` JSON | `test_check_caller_scope_all_globsmdead_routes_to_not_scoped` |
| 2 | certains dead → WARN sur ceux-là, scope restant porte disjointness | `test_check_caller_scope_partially_dead_warns_but_keeps_live` |
| 3 | hors dépôt git (`tracked=None`) → dégradation silencieuse | `test_check_caller_scope_silent_outside_git_repo` |
| 4 | contrôle positif : glob vivant ne produit aucun WARN | `test_check_caller_scope_live_glob_produces_no_warn` |
| 5 | fail-CLOSED : scope mort + zero blocker → exit 2 (PAS exit 0) | `test_check_caller_scope_fail_closed_when_no_blockers` |
| 6 | contrôle positif critique (hérité de c.464) : caller scopé intersecte vraiment → exit 1 + BLOCKED (PAS exit 2) | `test_check_path_scoped_blocks_against_real_intersecting_scope` (c.464, intact) |

Le **point 4** est le plus subtil : un détecteur muet (caller_empty_scope jamais populé) et un détecteur débranché (`tracked=None`) rendent exactement la même sortie — le test les distingue en passant un glob qui DOIT matcher.

## Tests

**194 PASS, 0 FAIL.** (188 c.464 + 1 compagnon c.464 `test_claim_paths_roundtrip_reads_back_scoped_intersect_live_glob` détaché par la migration c.465 + 5 nouveaux acceptance #12345.)

### 5 nouveaux tests c.465

| Test | Vérifie |
|---|---|
| `test_check_caller_scope_all_globsmdead_routes_to_not_scoped` | Tous les globs dead → exit 2 + `SCOPE_DEAD_GLOB` WARN nommant chaque glob + `caller_empty_scope` JSON. |
| `test_check_caller_scope_partially_dead_warns_but_keeps_live` | Partiellement mort → WARN sur les morts, verdict `PATH_SCOPED` (le glob vivant porte la disjointness). |
| `test_check_caller_scope_silent_outside_git_repo` | `tracked=None` → NO WARN, `caller_empty_scope: []`. |
| `test_check_caller_scope_live_glob_produces_no_warn` | Contrôle positif — glob vivant disjoint → exit 0 + NO `SCOPE_DEAD_GLOB` WARN. |
| `test_check_caller_scope_fail_closed_when_no_blockers` | Fail-CLOSED — scope mort + zero blocker → exit 2 (PAS exit 0), stderr explique le refus. |

### 1 test compagnon c.464 (`test_claim_paths_roundtrip_reads_back_scoped_intersect_live_glob`)

Détaché de `test_claim_paths_roundtrip_reads_back_scoped` (qui partageait une jambe `== 1` INTERSECT et une jambe `== 2` NOT_SCOPED sur le même test avec un glob mort) — la jambe `== 1` doit prouver qu'un glob VIVANT intersecte vraiment le claim, pas qu'un glob mort est `PATH_SCOPED` (ce qui contredit c.465). Le nouveau test utilise `x/a.ipynb` (vivant dans le mock) sous `x/**` (claim) → `exit 1` BLOCKED, la sémantique préservée.

### 6 tests migrés vers exit 2 (post-c.465)

Avec le prédicat basé sur la vivacité, plusieurs tests existants qui passaient `my_paths` avec un glob mort (et attendaient `exit 1` ou `exit 0`) tombent légitimement en `EPIC_WIDE_NO_PATHS_DECLARED` :

- `test_check_query_scope_path_scoped_when_caller_already_owns_scoped_claim` — caller owns claim scopé `Sudoku-9.ipynb` (mort) → `exit 2` (le scope est mort).
- `test_stale_threshold_unblocks_old_claim` — caller sans scope → `exit 0` (post-stale, others vide), inchangé c.464.
- `test_stale_threshold_boundary_is_stale` — pareil, inchangé c.464.
- `test_check_override_paths_blocks_other_lane_on_matching_path` — caller `--paths Foo.lean` (mort) → `exit 2` (c.465 fail-CLOSED).
- `test_check_claimed_one_scoped_one_plain_blocks` — caller owns claim scopé `Search-3.ipynb` (mort) → `exit 2`.
- `test_run_check_my_dead_scope_keeps_others` — caller owns claim scopé `nowhere/typo.py` (mort) → `exit 2`.
- `test_run_check_emits_scope_zero_coverage_warning` — caller owns claim scopé `definitely-not-a-real-glob-*.zxyq` (mort) → `exit 2` + `SCOPE_ZERO_COVERAGE` (legacy) + `SCOPE_DEAD_GLOB` (c.465).
- `test_claim_refuses_when_blocked` — caller `--paths x/sub/f.ipynb` (mort) → `exit 2` (refuse mais via NOT_SCOPED, pas BLOCKED).

Chaque migration est documentée dans le docstring du test par un commentaire `# #12345 -- ...` qui explique pourquoi le verdict attendu change.

### 24 tests PATH_SCOPED exit 1 inchangés (sémantique PATH_SCOPED préservée)

Le **contrôle positif critique** (`test_check_path_scoped_blocks_against_real_intersecting_scope` de c.464) reste debout : un caller scopé qui intersecte vraiment un blocker scopé → `exit 1` + `BLOCKED` (PAS `exit 2`). Sans ce test, un futur refactor pourrait collapse `exit 1` et `exit 2` silencieusement.

## End-to-end self-check (post c.465)

Reproduction des cas mesurés par ai-01 sur msg-20260822T124158 :

```bash
$ PYTHONPATH=scripts python scripts/check_lane_claim.py 11112 \
    --lane myia-po-2023:CoursIA-2 \
    --paths "MyIA.AI.Notebooks/GenAI/Image/01-Images-Foundation/01-4-Forge-SD-XL-Turbo.ipynb"
SCOPE_DEAD_GLOB: your declared scope contains globs that match zero tracked files ...
{
  ...
  "query_scope": "EPIC_WIDE_NO_PATHS_DECLARED",
  "caller_empty_scope": ["MyIA.AI.Notebooks/GenAI/Image/01-Images-Foundation/01-4-Forge-SD-XL-Turbo.ipynb"]
}
NOT_SCOPED: this call did not pass `--paths` so we cannot prove disjointness on #11112...
EXIT=2

$ PYTHONPATH=scripts python scripts/check_lane_claim.py 11112 \
    --lane myia-po-2023:CoursIA-2 \
    --paths "MyIA.AI.Notebooks/RL/rlpt_3_reward_hacking.ipynb"
{
  ...
  "query_scope": "PATH_SCOPED",
  "caller_empty_scope": []
}
BLOCKED: another lane holds an active claim on #11112: myia-po-2026:CoursIA ...
EXIT=1
```

Le cas du glob mort passe de `exit 1` (c.464) à `exit 2` (c.465) avec WARN explicite. Le cas du glob vivant intersecte un blocker scopé → `exit 1` + une seule lane (la bonne). Sémantique préservée.

## Surface

```
 scripts/check_lane_claim.py            | 120 +++++++++++--
 scripts/tests/test_check_lane_claim.py | 318 +++++++++++++++++++++++++++++++--
 2 files changed, 405 insertions(+), 33 deletions(-)
```

**0 Lean / 0 notebook / 0 cellule touchée.** Strict scope organe + tests.

## Anti-régression D

- 0 fichier `*.lean`
- 0 cellule `cell_type: 'code'`
- 0 cellule `outputs | execution_count`
- 2 fichiers : `scripts/check_lane_claim.py` (organe, +120/-...) + `scripts/tests/test_check_lane_claim.py` (tests, +318/-...)

## L898 ★★★

- Claim narrow posé sur [#12322](https://github.com/jsboige/CoursIA/issues/12322) : `paths: scripts/check_lane_claim.py, scripts/tests/test_check_lane_claim.py, .claude/rules/lane-claim-protocol.md`
- L898 propre : `gh pr list --author jsboige --search "lane-claim|exit 2|NOT_SCOPED"` → **PR #12344** seule (pas de collision cross-lane)
- L898 cross-lane : portée cohérente c.462 PR #12336 (#12320) + c.464 PR #12344 v1 (#12322) + c.465 PR #12344 v2 (#12345 replié) + jumeau #12319 ai-01 lift-events

## Plancher G-VAR-1

**META / guard** à nouveau — 4ᵉ plank substance non tenu sur les 2 derniers cycles (c.462 META + c.463 substance livrée + c.464 META + c.465 META). Rotation `G-VAR-3` respectée : c.462 guard → c.463 notebook-python → c.464 guard → c.465 guard (alt-guard autorisé par substance-cross-lane PR #12341 en file).

**NON TENU** ce cycle (pas de substance CONTENU). Raison documentée : sub-grain canonique du chantier c.462/c.464 qui ferme **la classe de défaut mesurée** (1 ESCALATION + 1 ASK user dans la même journée), c'est le moindre mal quand le pool narrow est saturé cross-lane.

La référence cross-lane pour le plank DEEP/MED substance reste **PR #12341 (c.463)** — `fix(notebooks,#12128): heading_in_list RL tranche C — 38 cas corrigés` (livrée 2026-08-22, OPEN MERGEABLE).

## Cap G-VAR-2

c.465 livre 1 grain MED/guard (PR #12344 amend). lane_grains mergés reste inchangé tant que #12336 (c.462) + #12341 (c.463) + #12344 (c.464+v2 c.465) ne sont pas mergés. **3 grains MED en file** → cap MED non touché (le cap porte sur LIGHT, pas MED).

## Refs / See

Refs **#12322** (sub-grain canonique) · Refs **#12345** (issue fermée par ai-01 avec contenu transplante sur #12322 commentaire #5381290620, replié ici) · See **#12320** (jumeau c.462 / PR #12336 — `[DELIVERED]` marqueur, livré) · See **#12319** (jumeau ai-01 lift-events trou gouvernance, non-traité par moi) · See **#11112** (incident fondateur user-mesurable).

## Liens SHA

- Commit v2 (c.465) : `54ecb1a56`
- Commit v1 (c.464) : `8d1ccf81f`
- Branche : `fix/12322-no-scope-exit-2` (worktree `D:\Dev\CoursIA-12322`)
- Origin : `jsboige/CoursIA@5794edb09` (PR #12339 detect_markdown_rendering merged-tip)

## Demande ai-01

1. **Re-contrôle targeted** :
   - 194 PASS vérifié localement (188 c.464 + 1 compagnon c.464 + 5 nouveaux c.465)
   - 24 tests PATH_SCOPED exit 1 inchangés (non-régression sémantique conservée)
   - 6 tests migrés vers exit 2 documentent l'**incident-mesure** (#11112) côté c.465
   - End-to-end confirmé contre les deux cas mesurés par ai-01 (msg-20260822T124158) : glob mort → exit 2 + WARN + JSON ; glob vivant intersect → exit 1 + une seule lane
2. **Sign-off PR amend** et autorisation de merge. PR atomique 1 sujet = 1 organe (exit 2 sémantique + query_scope vivacité + caller_empty_scope + SCOPE_DEAD_GLOB + fail-CLOSED) + 5 tests nouveaux + 6 tests migrés + 1 compagnon c.464 détaché.
3. **Cross-check #11112** : la PR LocalLlama exec en cours sur ce path ne doit pas être bloquée par #12344 (L898 cross-lane déjà vérifié, claim narrow disjoint).
4. **Provisionnement plank G-VAR-1** : c.464 + c.465 cycles ont raté le plank substance (3ᵉ et 4ᵉ ratés sur 4 cycles consécutifs). Compensation PR #12341 c.463 tient la matrice substance. Demande explicite au coordinateur de provisionner un grain DEEP/MED CONTENU frais sur un cycle futur proche, pour ne pas creuser la dette substance.
