### PR TITLE
fix(lean-ci,#12330): SocialChoice sorry-gate fail-open grep -> CERTIFIED.txt contract + lean-axiom.yml wiring

### DIFF
--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -87,7 +87,7 @@ jobs:
       # A gate whose whole lot passes is also what a de-wired gate produces:
       # the difference is made at the positive controls, not at the green.
       run: |
-        python -m pip install --quiet pyyaml
+        python -m pip install --quiet pytest pyyaml
         python -m pytest scripts/tests/test_check_certified_sorry.py -q
 
   # The real proof-integrity gate (#12330 criterion 4, first branch): the

--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -112,6 +112,7 @@ jobs:
 
   build:
     name: "Lake build"
+    runs-on: ubuntu-latest
     # Serialized only behind the CHEAP text-level gate (fail fast before
     # spending a Mathlib build); proof-integrity (lean-axiom.yml) runs its own
     # full build in parallel rather than doubling this one in series.

--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -11,16 +11,31 @@ on:
     branches: [ main ]
     paths:
       - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/**.lean'
+      - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/CERTIFIED.txt'
       - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice.lean'
       - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/lakefile.lean'
       - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/lean-toolchain'
+      # The gates' own implementation: a change to them must re-run them
+      # (conway lesson, #8951 -- a gate whose own edits don't trigger it
+      # can be rewritten red-free and never prove anything again).
+      - '.github/workflows/lean-social-choice.yml'
+      - '.github/workflows/lean-axiom.yml'
+      - 'scripts/lean/check_certified_sorry.py'
+      - 'scripts/lean/count_code_sorry.py'
+      - 'scripts/tests/test_check_certified_sorry.py'
   pull_request:
     branches: [ main ]
     paths:
       - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/**.lean'
+      - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/CERTIFIED.txt'
       - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice.lean'
       - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/lakefile.lean'
       - 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/lean-toolchain'
+      - '.github/workflows/lean-social-choice.yml'
+      - '.github/workflows/lean-axiom.yml'
+      - 'scripts/lean/check_certified_sorry.py'
+      - 'scripts/lean/count_code_sorry.py'
+      - 'scripts/tests/test_check_certified_sorry.py'
   workflow_dispatch:
 
 permissions:
@@ -31,57 +46,76 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  fail-on-sorry:
-    name: "Proof integrity (no sorry)"
+  # #12330: this job was named "Proof integrity (no sorry)" while being a
+  # fail-open `grep -c sorry` over a hardcoded 4-file list -- a name that
+  # promised the three forbidden-axiom classes (sorryAx / native_decide /
+  # Classical whitelist) while testing none of them. It is now two jobs:
+  #   - `certified-no-sorry` (below): the source-level contract, named for
+  #     what it does -- canonical instrument, fail-CLOSED on a missing
+  #     certified file, exhaustiveness against SocialChoice/CERTIFIED.txt.
+  #   - `proof-integrity` (lean-axiom.yml, below): the REAL axiom gate --
+  #     transitive sorryAx, native_decide, Classical whitelist -- so the
+  #     name "Proof integrity" finally means what B.3 says it means.
+  certified-no-sorry:
+    name: "Certified modules: no code sorry (SocialChoice)"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: MyIA.AI.Notebooks/GameTheory/game_theory_lean
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install elan
-      run: |
-        curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain none
-        echo "$HOME/.elan/bin" >> $GITHUB_PATH
-
-    - name: Cache Mathlib oleans
-      uses: actions/cache@v4
+    - uses: actions/setup-python@v5
       with:
-        path: MyIA.AI.Notebooks/GameTheory/game_theory_lean/.lake
-        key: lake-sc-${{ runner.os }}-${{ hashFiles('MyIA.AI.Notebooks/GameTheory/game_theory_lean/lakefile.lean', 'MyIA.AI.Notebooks/GameTheory/game_theory_lean/lean-toolchain') }}
-        restore-keys: lake-sc-${{ runner.os }}-
+        python-version: '3.x'
 
-    - name: Check for sorry in certified modules
+    - name: Lake-wide honest report (canonical instrument, advisory)
+      # Reports the WHOLE lake -- including the acknowledged stretch sorry in
+      # RepeatedGames/Folk.lean -- so a reader of the log sees the lake's real
+      # total, not only the certified subtree's zero. --repo autodetects from
+      # the script location, so cwd is irrelevant here.
       run: |
-        echo "Checking sorry count in certified modules (Arrow, Sen, Framework, Basic)..."
-        SORRY_COUNT=0
-        for f in SocialChoice/Arrow.lean SocialChoice/Sen.lean SocialChoice/Framework.lean SocialChoice/Basic.lean; do
-          if [ -f "$f" ]; then
-            COUNT=$(grep -c "sorry" "$f" || true)
-            if [ "$COUNT" -gt 0 ]; then
-              echo "FAIL: $f has $COUNT sorry"
-              grep -n "sorry" "$f"
-              SORRY_COUNT=$((SORRY_COUNT + COUNT))
-            else
-              echo "OK: $f (0 sorry)"
-            fi
-          fi
-        done
-        if [ "$SORRY_COUNT" -gt 0 ]; then
-          echo ""
-          echo "FAILED: $SORRY_COUNT sorry found in certified modules"
-          echo "These modules are formally verified and must not contain sorry."
-          exit 1
-        fi
-        echo "All certified modules are sorry-free."
+        python "scripts/lean/count_code_sorry.py" \
+          --lake MyIA.AI.Notebooks/GameTheory/game_theory_lean --no-vacuous || true
+
+    - name: Certified contract gate (fail-closed, #12330)
+      run: |
+        python "$GITHUB_WORKSPACE/scripts/lean/check_certified_sorry.py" \
+          --repo "$GITHUB_WORKSPACE" \
+          --lake MyIA.AI.Notebooks/GameTheory/game_theory_lean \
+          --subdir SocialChoice
+
+    - name: Positive-control tests of the gate itself
+      # A gate whose whole lot passes is also what a de-wired gate produces:
+      # the difference is made at the positive controls, not at the green.
+      run: |
+        python -m pip install --quiet pyyaml
+        python -m pytest scripts/tests/test_check_certified_sorry.py -q
+
+  # The real proof-integrity gate (#12330 criterion 4, first branch): the
+  # reusable axiom checker already serving conway/knot/galois/grothendieck/
+  # mimo/sensitivity. Blocking (fail-on-sorry: true) on the certified
+  # modules -- the SocialChoice subtree carries 0 sorry on main, so this
+  # gate is green-by-truth, not green-by-construction. The Folk.lean
+  # stretch sorry (RepeatedGames, outside SocialChoice) is deliberately NOT
+  # in target-modules: it is acknowledged debt with its own scope (#4880
+  # STRETCH doctrine), not a certified module. target-modules is pinned to
+  # SocialChoice/CERTIFIED.txt by
+  # scripts/tests/test_check_certified_sorry.py::test_workflow_targets_match_manifest.
+  proof-integrity:
+    uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/GameTheory/game_theory_lean
+      display-name: game_theory_lean
+      target-modules: "SocialChoice.Arrow,SocialChoice.Arrow_en,SocialChoice.Basic,SocialChoice.Basic_en,SocialChoice.Framework,SocialChoice.Framework_en,SocialChoice.MechanismDesign,SocialChoice.MechanismDesign_en,SocialChoice.Sen,SocialChoice.Sen_en,SocialChoice.SortedListCounting,SocialChoice.SortedListCounting_en,SocialChoice.Voting,SocialChoice.Voting_en"
+      # allow-axioms inherits the workflow default (named standard set:
+      # propext, funext, Classical.choice, Quot.*) -- same contract as conway.
+      fail-on-sorry: true
 
   build:
     name: "Lake build"
-    runs-on: ubuntu-latest
-    needs: fail-on-sorry
+    # Serialized only behind the CHEAP text-level gate (fail fast before
+    # spending a Mathlib build); proof-integrity (lean-axiom.yml) runs its own
+    # full build in parallel rather than doubling this one in series.
+    needs: certified-no-sorry
     defaults:
       run:
         working-directory: MyIA.AI.Notebooks/GameTheory/game_theory_lean

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/CERTIFIED.txt
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/CERTIFIED.txt
@@ -1,0 +1,35 @@
+# Certified modules contract — gate by scripts/lean/check_certified_sorry.py (#12330).
+#
+# One filename per line. Every module listed here is part of the no-sorry
+# certification carried over from the absorption of `social_choice_lean`
+# (PR #6058, c.357) and extended since. A module MUST be added here in the
+# same PR that adds it to this subtree — the gate flags any *.lean that is
+# neither certified nor explicitly excluded (STALE-LIST).
+#
+# `!name.lean` = deliberate exclusion, kept visible: an exclusion is a
+# decision, not a silence.
+#
+# Instrument: count_code_sorry.scan_file (comment-stripped — a `sorry` inside
+# a docstring does not count; a real tactic `sorry` fails the gate).
+
+# FR modules (7)
+Arrow.lean
+Basic.lean
+Framework.lean
+MechanismDesign.lean
+Sen.lean
+SortedListCounting.lean
+Voting.lean
+
+# EN i18n siblings (#4980) — compiled modules, proofs byte-identical, gated too
+Arrow_en.lean
+Basic_en.lean
+Framework_en.lean
+MechanismDesign_en.lean
+Sen_en.lean
+SortedListCounting_en.lean
+Voting_en.lean
+
+# Explicit exclusion
+# lake-local smoke test, not part of the certification
+!_SmokeTest.lean

--- a/scripts/lean/check_certified_sorry.py
+++ b/scripts/lean/check_certified_sorry.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Gate the certified-modules contract of a lake subtree (#12330).
+
+Why this organ exists
+---------------------
+The ``fail-on-sorry`` job of ``lean-social-choice.yml`` carried three defects
+(issue #12330):
+
+1. **Fail-open**: a certified module that disappears (rename, move, absorb)
+   passed in silence -- ``if [ -f "$f" ]`` with no ``else`` -- and the job
+   still concluded "All certified modules are sorry-free". A zero denominator
+   read exactly like a zero numerator. ``SocialChoice`` itself already lived
+   this motion: the subtree was absorbed from the retired lake
+   ``social_choice_lean`` (workflow header), and #12329 added a module the
+   hardcoded list never learned about.
+2. **Wrong instrument**: ``grep -c "sorry"`` counts the prose (docstrings,
+   ``--`` comments) -- the very instrument ``anti-regression.md`` forbids
+   (measured 2026-08-14: 484 naive for 21 real across the 21 lakes).
+3. **Unverifiable exhaustiveness**: the certified list was hardcoded in the
+   workflow, so a module added to the subtree was invisible to the gate.
+
+This script replaces the hand-rolled loop. The certified contract lives in a
+manifest **next to the modules** (``<subdir>/CERTIFIED.txt``): one filename
+per line, ``#`` comments allowed, ``!name.lean`` = explicitly excluded (the
+exclusion is a decision, not a silence). The gate verifies three things, each
+naming its target on failure (a gate that blushes must say at what):
+
+1. every listed file EXISTS                        -> ``MISSING: <file>``
+2. every ``*.lean`` in the subtree is listed or
+   explicitly excluded                             -> ``STALE-LIST: <file>``
+3. every listed file carries 0 real code ``sorry``
+   (canonical instrument: ``count_code_sorry.scan_file``,
+   comment-stripped, docstrings don't count)       -> ``SORRY: <decl> <file>:<line>``
+
+Exit 0 = contract holds. Exit 1 = the named failure(s). Pure text analysis,
+no Lean toolchain needed, CI-cheap.
+
+Usage
+-----
+    python scripts/lean/check_certified_sorry.py \
+        --lake MyIA.AI.Notebooks/GameTheory/game_theory_lean \
+        --subdir SocialChoice
+
+Module usage:
+    from check_certified_sorry import check_subtree, parse_manifest
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from count_code_sorry import scan_file  # noqa: E402  -- canonical instrument
+
+MANIFEST_NAME = "CERTIFIED.txt"
+
+
+def parse_manifest(text: str) -> tuple[list[str], list[str]]:
+    """Split manifest text into (certified files, explicitly-excluded files).
+
+    One filename per line. ``!name.lean`` marks a deliberate exclusion (kept
+    visible so the exclusion is a decision, not an oversight). ``#`` comments
+    and blank lines are ignored.
+    """
+    certified: list[str] = []
+    excluded: list[str] = []
+    for raw in text.splitlines():
+        # Inline comments too: a `#` never appears in a .lean filename, so
+        # `Arrow.lean  # reason` is Arrow.lean. (Caught live on first run:
+        # entries with inline comments matched no file.)
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("!"):
+            excluded.append(line[1:].strip())
+        else:
+            certified.append(line)
+    return certified, excluded
+
+
+def check_subtree(lake_root: Path, subdir: str) -> tuple[list[str], dict]:
+    """Run the three checks. Returns (failures, report). failures == [] = pass."""
+    tree = lake_root / subdir
+    manifest_path = tree / MANIFEST_NAME
+    if not manifest_path.is_file():
+        return ([f"MISSING-MANIFEST: {subdir}/{MANIFEST_NAME} — the certified "
+                 f"contract file does not exist (create it: one filename per "
+                 f"line, !name.lean = explicit exclusion)"], {})
+
+    certified, excluded = parse_manifest(manifest_path.read_text(encoding="utf-8"))
+    failures: list[str] = []
+    report: dict = {"subdir": subdir, "certified": certified,
+                    "excluded": excluded, "per_file": {}}
+
+    # Check 1 -- every certified file exists (fail-CLOSED: the anchor is the
+    # contract; a renamed module must break the gate, not slip out of view).
+    for name in certified:
+        if not (tree / name).is_file():
+            failures.append(f"MISSING: {subdir}/{name}")
+
+    # Check 2 -- exhaustiveness: nothing in the subtree is unaccounted for.
+    on_disk = sorted(p.name for p in tree.glob("*.lean"))
+    accounted = set(certified) | set(excluded)
+    for name in on_disk:
+        if name not in accounted:
+            failures.append(
+                f"STALE-LIST: {subdir}/{name} is in the subtree but neither "
+                f"certified nor explicitly excluded in {MANIFEST_NAME} — a new "
+                f"module must enter the contract in the same PR that adds it")
+    for name in certified:
+        if name in excluded:
+            failures.append(f"CONTRADICTION: {subdir}/{name} both certified and excluded")
+
+    # Check 3 -- 0 real code sorry in every certified file (canonical
+    # instrument: comment-stripped scan, docstrings don't count).
+    for name in certified:
+        path = tree / name
+        if not path.is_file():
+            continue  # already reported by check 1
+        decls, naive, code = scan_file(path, lake_root)
+        report["per_file"][name] = {"naive_sorry": naive, "code_sorry": code}
+        if code:
+            where = [f"{d.kind} {d.name or '<anon>'} ({subdir}/{name}:{d.line})"
+                     for d in decls if d.sorry_count]
+            for w in where:
+                failures.append(f"SORRY: {w}")
+    return failures, report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Gate the certified-modules contract of a lake subtree (#12330).")
+    parser.add_argument("--repo", default=".", help="repo root (default: cwd)")
+    parser.add_argument("--lake", required=True, help="lake root, repo-relative")
+    parser.add_argument("--subdir", required=True,
+                        help="certified subtree inside the lake (e.g. SocialChoice)")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args(argv)
+
+    lake_root = (Path(args.repo) / args.lake).resolve()
+    failures, report = check_subtree(lake_root, args.subdir)
+
+    if args.json:
+        print(json.dumps({"ok": not failures, "failures": failures, **report},
+                         indent=2, ensure_ascii=False))
+    else:
+        for name, stats in report.get("per_file", {}).items():
+            print(f"  {args.subdir}/{name}: code sorry = {stats['code_sorry']} "
+                  f"(naive grep would say {stats['naive_sorry']})")
+        if failures:
+            print()
+            for f in failures:
+                print(f"FAIL {f}")
+            return 1
+        print(f"OK: {len(report.get('certified', []))} certified modules, "
+              f"{len(report.get('excluded', []))} explicit exclusion(s), "
+              f"0 code sorry (canonical instrument).")
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_certified_sorry.py
+++ b/scripts/tests/test_check_certified_sorry.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Unit tests for check_certified_sorry.py — the certified-modules gate of #12330.
+
+The issue's acceptance criteria demand POSITIVE CONTROLS on both polarities
+(criterion 3): a module whose docstring says `sorry` but whose code has none
+must stay GREEN (the old grep blushed on it), and a module with a real
+`:= by sorry` must blush (the old loop, fail-open on missing files, did not
+need to be fooled — it just went quiet). These tests replay both, plus the
+fail-open fix (criterion 1: a missing certified file FAILS, named) and the
+exhaustiveness contract (criterion 5: an unaccounted module is STALE-LIST).
+
+Run: python -m pytest scripts/tests/test_check_certified_sorry.py
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lean"))
+
+import check_certified_sorry as ccs  # noqa: E402
+
+
+# --- fixtures ----------------------------------------------------------------
+
+def make_lake(tmp_path: Path, files: dict[str, str], manifest: str,
+              subdir: str = "Sub") -> Path:
+    """Lay out a fake lake: lakefile + subdir with files + CERTIFIED.txt."""
+    lake = tmp_path / "lake"
+    tree = lake / subdir
+    tree.mkdir(parents=True)
+    (lake / "lakefile.lean").write_text("-- fake lake\n", encoding="utf-8")
+    for name, body in files.items():
+        (tree / name).write_text(body, encoding="utf-8")
+    (tree / ccs.MANIFEST_NAME).write_text(manifest, encoding="utf-8")
+    return lake
+
+
+CLEAN_MODULE = """import Mathlib.Tactic
+theorem clean_thm (p : Prop) : p → p := by intro h; exact h
+"""
+
+DOCSTRING_SORRY_MODULE = """/-
+  Docstring mentioning sorry on purpose: the module documents that it carries
+  zero sorry, which the old grep counted as one.
+-/
+import Mathlib.Tactic
+theorem doc_ok (p : Prop) : p → p := by intro h; exact h
+"""
+
+REAL_SORRY_MODULE = """import Mathlib.Tactic
+theorem broken_thm (p : Prop) : p := by sorry
+"""
+
+
+# --- criterion 1: fail-open fixed (missing file blushes, named) ---------------
+
+def test_missing_certified_file_fails_with_name(tmp_path):
+    # Sen.lean is certified but absent (renamed/moved): the gate must blush
+    # AND name it. The old loop passed in silence (if [ -f ] without else).
+    lake = make_lake(tmp_path, {"Arrow.lean": CLEAN_MODULE},
+                     "Arrow.lean\nSen.lean\n")
+    failures, _ = ccs.check_subtree(lake, "Sub")
+    assert any("MISSING: Sub/Sen.lean" in f for f in failures), failures
+
+
+def test_missing_manifest_is_a_failure_not_a_pass(tmp_path):
+    # No CERTIFIED.txt at all: a gate with no contract must not read as green.
+    lake = tmp_path / "lake"
+    (lake / "Sub").mkdir(parents=True)
+    failures, _ = ccs.check_subtree(lake, "Sub")
+    assert any("MISSING-MANIFEST" in f for f in failures), failures
+
+
+# --- criterion 3: positive controls on both polarities ------------------------
+
+def test_docstring_sorry_stays_green(tmp_path):
+    # `sorry` inside a docstring is prose, not proof debt: canonical
+    # instrument (comment-stripped) must keep this GREEN. The old
+    # `grep -c sorry` blushed on it (the over-counting polarity).
+    lake = make_lake(tmp_path, {"Arrow.lean": DOCSTRING_SORRY_MODULE},
+                     "Arrow.lean\n")
+    failures, report = ccs.check_subtree(lake, "Sub")
+    assert failures == [], failures
+    # the docstring says "sorry" twice -- grep sees 2, the real debt is 0
+    assert report["per_file"]["Arrow.lean"]["naive_sorry"] == 2
+    assert report["per_file"]["Arrow.lean"]["code_sorry"] == 0
+
+
+def test_real_sorry_blushes_with_declaration_and_line(tmp_path):
+    # A real tactic sorry must blush, naming the declaration and its line.
+    lake = make_lake(tmp_path, {"Arrow.lean": REAL_SORRY_MODULE},
+                     "Arrow.lean\n")
+    failures, _ = ccs.check_subtree(lake, "Sub")
+    assert any("SORRY: theorem broken_thm (Sub/Arrow.lean:2)" in f
+               for f in failures), failures
+
+
+def test_sorry_in_en_mirror_also_blushes(tmp_path):
+    # _en siblings are compiled modules: proof debt there is debt too.
+    lake = make_lake(tmp_path, {"Arrow.lean": CLEAN_MODULE,
+                                "Arrow_en.lean": REAL_SORRY_MODULE},
+                     "Arrow.lean\nArrow_en.lean\n")
+    failures, _ = ccs.check_subtree(lake, "Sub")
+    assert any("Arrow_en.lean" in f and "SORRY" in f for f in failures), failures
+
+
+# --- criterion 5: exhaustiveness is verifiable --------------------------------
+
+def test_unaccounted_module_is_stale_list(tmp_path):
+    # A module in the subtree that is neither certified nor excluded is a
+    # stale contract: the PR that adds a module must add it here (this is
+    # the #12329 lesson — MechanismDesign entered the tree silently).
+    lake = make_lake(tmp_path, {"Arrow.lean": CLEAN_MODULE,
+                                "NewModule.lean": CLEAN_MODULE},
+                     "Arrow.lean\n")
+    failures, _ = ccs.check_subtree(lake, "Sub")
+    assert any("STALE-LIST: Sub/NewModule.lean" in f for f in failures), failures
+
+
+def test_explicit_exclusion_is_visible_and_ok(tmp_path):
+    # `!name.lean` excludes on purpose and passes — an exclusion is a
+    # decision, not a silence. The excluded file is NOT sorry-scanned.
+    lake = make_lake(tmp_path, {"Arrow.lean": CLEAN_MODULE,
+                                "_SmokeTest.lean": REAL_SORRY_MODULE},
+                     "Arrow.lean\n!_SmokeTest.lean\n")
+    failures, report = ccs.check_subtree(lake, "Sub")
+    assert failures == [], failures
+    assert report["excluded"] == ["_SmokeTest.lean"]
+    assert "_SmokeTest.lean" not in report["per_file"]
+
+
+def test_certified_and_excluded_is_contradiction(tmp_path):
+    lake = make_lake(tmp_path, {"Arrow.lean": CLEAN_MODULE},
+                     "Arrow.lean\n!Arrow.lean\n")
+    failures, _ = ccs.check_subtree(lake, "Sub")
+    assert any("CONTRADICTION" in f for f in failures), failures
+
+
+def test_inline_comments_in_manifest_do_not_break_names(tmp_path):
+    # Regression of the first live run: `Arrow.lean  # reason` parsed as a
+    # filename-with-comment matched no file and read as MISSING.
+    lake = make_lake(tmp_path, {"Arrow.lean": CLEAN_MODULE},
+                     "Arrow.lean  # the impossibility module\n")
+    failures, _ = ccs.check_subtree(lake, "Sub")
+    assert failures == [], failures
+
+
+# --- the real contract, pinned -------------------------------------------------
+
+REAL_LAKE = Path(__file__).resolve().parents[2] / (
+    "MyIA.AI.Notebooks/GameTheory/game_theory_lean")
+
+
+def test_real_socialchoice_contract_holds():
+    # The committed manifest must hold against the committed tree: this is
+    # what CI runs on every PR touching the lake.
+    if not REAL_LAKE.is_dir():  # pragma: no cover - repo layout guarantee
+        pytest.skip("game_theory_lean not found")
+    failures, report = ccs.check_subtree(REAL_LAKE, "SocialChoice")
+    assert failures == [], failures
+    assert len(report["certified"]) >= 14  # 7 FR + 7 EN on main
+
+
+def test_workflow_targets_match_manifest():
+    # Criterion 5, second surface: the lean-axiom.yml blocking job's
+    # target-modules is ALSO a list — pin it to the manifest so the two
+    # cannot drift apart silently (same class as the STALE-LIST check).
+    import yaml
+    repo = Path(__file__).resolve().parents[2]
+    manifest = (REAL_LAKE / "SocialChoice" / ccs.MANIFEST_NAME).read_text(
+        encoding="utf-8")
+    certified, _ = ccs.parse_manifest(manifest)
+    expected = sorted("SocialChoice." + f[:-len(".lean")] for f in certified)
+    wf = yaml.safe_load(
+        (repo / ".github/workflows/lean-social-choice.yml").read_text(
+            encoding="utf-8"))
+    raw = wf["jobs"]["proof-integrity"]["with"]["target-modules"]
+    actual = sorted(m.strip() for m in raw.split(","))
+    assert actual == expected, (
+        f"lean-social-choice.yml target-modules drifted from "
+        f"SocialChoice/CERTIFIED.txt: workflow={actual} manifest={expected}")


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA — prev: DEEP/notebook-dotnet #12346

## Summary

Remplace le job `fail-on-sorry` de `lean-social-choice.yml` — nommé « Proof integrity (no sorry) » alors qu'il était (1) **fail-open** (`if [ -f "$f" ]` sans `else` : un module certifié renommé/disparu passait en silence), (2) **au mauvais instrument** (`grep -c "sorry"` compte la prose — l'instrument qu'`anti-regression.md` interdit, mesuré 484 naïfs pour 21 réels sur les 21 lakes), (3) **non exhaustif** (liste en dur de 4 fichiers ; #12329 a ajouté MechanismDesign sans que la liste l'apprenne) — par :

- **`SocialChoice/CERTIFIED.txt`** — le contrat vit à côté des modules : un filename/ligne, `#` commentaires, `!name.lean` = exclusion explicite visible. 14 modules certifiés (7 FR + 7 siblings `_en`), 1 exclusion (`!_SmokeTest.lean`).
- **`scripts/lean/check_certified_sorry.py`** — gate fail-closed à 3 axes : `MISSING: <fichier>` (le fichier certifié absent rompt le gate, nommé), `STALE-LIST: <fichier>` (tout `*.lean` du subtree ni certifié ni exclu = contrat périmé — le module ajouté doit entrer au manifeste dans la même PR), `SORRY: <decl> (fichier:ligne)` via l'instrument canonique `count_code_sorry.scan_file` (comment-stripped : un « sorry » de docstring reste vert, un vrai `:= by sorry` rougit avec déclaration + ligne).
- **Deux jobs honnêtes dans le workflow** : `certified-no-sorry` (analyse texte pure, nommée pour ce qu'elle fait) + `proof-integrity` (`lean-axiom.yml@main`, bloquant, `fail-on-sorry: true`, 14 target-modules) — le nom « Proof integrity » signifie enfin le gate d'axiomes B.3 (sorryAx transitif, `native_decide`, whitelist Classical par nom). Wiring identique à conway/knot/galois/grothendieck/mimo/sensitivity.
- **`test_workflow_targets_match_manifest`** épingle la liste `target-modules` du workflow au manifeste : les deux listes ne peuvent plus dériver séparément (même classe de défaut que le STALE-LIST).

Ferme aussi le gap adjacent documenté (lean-merge-discipline §1) : « lean-social-choice.yml ne build PAS Voting.lean » — les 14 modules sont désormais build + axiom-checkés par `lean-axiom.yml`.

## Validation

```
$ python scripts/lean/check_certified_sorry.py --lake MyIA.AI.Notebooks/GameTheory/game_theory_lean --subdir SocialChoice
  SocialChoice/Arrow.lean: code sorry = 0 (naive grep would say 0)
  [... 14 modules ...]
OK: 14 certified modules, 1 explicit exclusion(s), 0 code sorry (canonical instrument).   # exit 0

$ python -m pytest scripts/tests/test_check_certified_sorry.py -q
11 passed in 0.19s
```

Contrôles positifs (critère 3 de l'issue, en tests unitaires rejouables) :

| Contrôle | Résultat attendu | Test |
|---|---|---|
| Docstring contenant « sorry » ×2, code propre | **vert** (naive=2, code=0) | `test_docstring_sorry_stays_green` |
| Vrai `theorem broken_thm (p : Prop) : p := by sorry` | **rouge** `SORRY: theorem broken_thm (Sub/Arrow.lean:2)` | `test_real_sorry_blushes_with_declaration_and_line` |
| Fichier certifié absent du disque | **rouge** `MISSING: Sub/Sen.lean` (nommé) | `test_missing_certified_file_fails_with_name` |
| Module du subtree non couvert | **rouge** `STALE-LIST: Sub/NewModule.lean` | `test_unaccounted_module_is_stale_list` |
| Manifeste absent | **rouge** `MISSING-MANIFEST` (pas un vert par défaut) | `test_missing_manifest_is_a_failure_not_a_pass` |
| Manifeste ↔ workflow target-modules | **épingle** (drift = rouge) | `test_workflow_targets_match_manifest` |

Le MISSING-path a de plus **rougi en live** sur l'arbre réel pendant le développement (la première run du gate a attrapé mes propres entrées de manifeste avec commentaires inline mal parsées — contrôle positif involontaire du fail-closed, corrigé + test de régression `test_inline_comments_in_manifest_do_not_break_names`).

## Résiduels

- **Première run CI du job `proof-integrity`** = la validation live du wiring (aucun run `lean-axiom.yml` n'a jamais touché game_theory_lean). Si elle rougit sur un axiome non couvert par la allow-list standard (propext/funext/Classical.choice/Quot.*), le suivi est une entrée `allow-axioms` **nominative** (doctrine B.3 : jamais de wildcard).
- Le sorry réel distinct du lake (1 : `RepeatedGames/Folk.lean`, scope STRETCH assumé #4880) reste hors périmètre SocialChoice — délibérément pas dans target-modules.

Closes #12330
