### PR TITLE
fix(lane-claim,#12327): lint qualifier epic-wide -- SUPERSEDED/sans-effet vs il-bloque (cohérence verdict)

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -1417,6 +1417,9 @@ def _lint_claim_events(
     issue_number: int | None,
     repo_root: str | None = None,
     tracked: list[str] | None = None,
+    active_claims: dict[str, ClaimEvent] | None = None,
+    others_verdict: dict[str, ClaimEvent] | None = None,
+    my_lane: str | None = None,
 ) -> None:
     """Emit WARN/INFO lines for malformed claim markers (#10881). Non-blocking.
 
@@ -1440,6 +1443,20 @@ def _lint_claim_events(
     faulty line and the expected marker-line syntax. Fires only on the
     signal -- an intentional epic-wide declaration (no off-marker clause)
     stays silent, so the lint never penalises a deliberate full-lane lock.
+
+    #12327 (verdict qualifier): when `active_claims` and `others_verdict` are
+    provided (caller has already reduced), each epic-wide marker is qualified
+    by its EFFECTIVE state at the time of the verdict:
+    - **superseded** by a later claim of the same lane (the marker exists as
+      legacy noise, the active claim supersedes it -- print as hygiene debt,
+      not as a blocker);
+    - **hors scope declare** when the lane's claim does NOT intersect the
+      verdict's `others` set (the claim was epic-wide in form but did not
+      actually block the caller -- print as informational, never as `il bloque`);
+    - **il bloque** ONLY when the lane IS in `others_verdict` (the claim is
+      what the reducer actually kept against the caller).
+    Without these args, the lint falls back to the legacy behaviour (every
+    epic-wide marker prints `il bloque`), which is the bug #12327 names.
     """
     if tracked is None:
         tracked = _git_tracked_files(repo_root)
@@ -1483,10 +1500,51 @@ def _lint_claim_events(
                 if inferred
                 else ""
             )
+            # #12327 -- qualify the epic-wide lint by the verdict the reducer
+            # actually reached. Three buckets (others_verdict may be None when
+            # the caller has not yet reduced -- legacy path keeps the old
+            # `il bloque` wording for back-compat):
+            ev_lane = ev.lane or "?"
+            ev_active = active_claims.get(ev_lane) if active_claims else None
+            in_others = (others_verdict is not None
+                         and ev_lane in others_verdict)
+            if (active_claims is not None
+                    and ev_active is not None
+                    and ev_active is not ev
+                    and _event_is_active_for(ev, ev_active)):
+                # The marker is shadowed by a later active claim of the SAME
+                # lane -- superseded, sans effet. Hygiene debt: the lane should
+                # [RELEASED] the old marker, but the organ never blocks on it.
+                print(
+                    f"INFO: marqueur {ev.marker} epic-wide SUPERSEDED "
+                    f"(lane {ev_lane}) -- un claim actif ulterieur de la "
+                    f"meme lane tient le verrou (scope: {ev_active.get('paths') or 'epic-wide'}). "
+                    f"Sans effet sur le verdict. Hygiene: "
+                    f"`[RELEASED]` l'ancien marqueur (cf. #12327).{inferred_str}",
+                    file=sys.stderr,
+                )
+                continue
+            if others_verdict is not None and not in_others and ev_lane != my_lane:
+                # Epic-wide form, but the lane did NOT survive the reducer's
+                # scope filter: either the lane re-posted a scoped claim, or
+                # the caller declared `--paths` and the claim does not
+                # intersect. The lint must NOT say `il bloque`.
+                print(
+                    f"INFO: marqueur {ev.marker} epic-wide (lane {ev_lane}) "
+                    f"-- SANS effet sur #{issue_number} "
+                    f"(claim de la lane filtre par scope ou re-poste depuis). "
+                    f"Forme attendue : `[CLAIMED] lane <machine:workspace> "
+                    f"-- paths: <g1>, <g2>` (cf. #11755).{inferred_str}",
+                    file=sys.stderr,
+                )
+                continue
+            # Legacy wording: the marker IS in `others_verdict` (real blocker)
+            # OR the caller has not reduced yet (back-compat). Keep the
+            # original `il bloque toutes les autres lanes` text.
             print(
                 f"INFO: marqueur {ev.marker} epic-wide (pas de clause paths:) "
                 f"-- il bloque toutes les autres lanes sur #{issue_number} "
-                f"(lane {ev.lane or '?'}).{inferred_str} "
+                f"(lane {ev_lane}).{inferred_str} "
                 f"Forme attendue : `[CLAIMED] lane <machine:workspace> "
                 f"-- paths: <g1>, <g2>` (cf. #11755).",
                 file=sys.stderr,
@@ -1505,6 +1563,30 @@ def _lint_claim_events(
                     f"(lane {ev.lane or '?'})",
                     file=sys.stderr,
                 )
+
+
+def _event_is_active_for(legacy: ClaimEvent, active: ClaimEvent) -> bool:
+    """True when `active` is the live claim that supersedes `legacy`.
+
+    Two markers from the SAME lane supersede each other when the active one
+    was posted LATER (later `created_at`) OR carries a `paths:` clause (the
+    legacy was epic-wide, the active is scoped -- the scoped form is more
+    precise and replaces the legacy intent). If the active marker is OLDER
+    than the legacy one, this is a sequence anomaly -- the legacy was
+    INTENDED to supersede the active, and the active is itself legacy
+    noise; in that case the caller wants the SHARED verdict to surface.
+    """
+    if active is None or active is legacy:
+        return False
+    # A scoped marker always supersedes an epic-wide one of the same lane.
+    if active.get("paths") is not None and legacy.get("paths") is None:
+        return True
+    # Two markers of the same lane, both epic-wide: the LATER one wins.
+    legacy_at = legacy.get("created_at")
+    active_at = active.get("created_at")
+    if legacy_at and active_at and active_at > legacy_at:
+        return True
+    return False
 
 
 def _find_malformed_markers(payload: dict) -> list[dict]:
@@ -1640,11 +1722,6 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
     # #10958 empty-scope witness (best-effort: None outside a git repo, in
     # which case both features degrade to their pre-#10958 behaviour).
     tracked = _git_tracked_files()
-    # #10881 lint -- malformed paths: clauses surface on stderr when the
-    # marker is read: visible to every lane running the check, never changing
-    # a verdict. The four 2026-08-14 markers on #10678 shared the defect the
-    # three checks name (epic-wide by accident / prose swallowed as globs).
-    _lint_claim_events(events, payload.get("number"), tracked=tracked)
     # #11239 lint -- bare markers without brackets (invisible to the organ).
     # Same non-blocking spirit as the #10881 lint above: the writer learns at
     # the call site that their lock was never registered, instead of two lanes
@@ -1713,6 +1790,21 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             if age is not None and age >= stale_threshold:
                 stale_others[ln] = ev
         others = {ln: ev for ln, ev in others.items() if ln not in stale_others}
+
+    # #12327 -- lint qualifier runs AFTER the reducer: the epic-wide marker
+    # lint can no longer say `il bloque toutes les autres lanes` for a
+    # marker whose lane did not survive the scope filter or whose lane
+    # re-posted a scoped claim since. We pass `active` (claim-per-lane) and
+    # the FINAL `others` dict so the lint can bucket each epic-wide marker
+    # into `superseded` / `sans effet` / `il bloque`.
+    _lint_claim_events(
+        events,
+        payload.get("number"),
+        tracked=tracked,
+        active_claims=active,
+        others_verdict=others,
+        my_lane=my_lane,
+    )
 
     # #12322 -- query_scope classifier (POST stale-filter, so the verdict
     # reflects the FINAL blocker set, not the pre-stale one). A call whose

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -4009,6 +4009,7 @@ def test_is_delivered_property_distinguishes_marker():
 
 
 # ---------------------------------------------------------------------------
+
 # #12386 -- v2 conditional [DELIVERED]: gate the close on live PR state.
 #
 # v1's contract: a [DELIVERED] is a close -- it pops the lane from
@@ -4347,3 +4348,283 @@ def test_find_open_pr_for_issue_by_lane_ambiguous_returns_none(capsys):
     assert found is None
     assert "WARN" in captured.err
     assert "delivered:#N" in captured.err  # escape hatch
+
+# #12327 -- lint qualifier: epic-wide markers must read the FINAL verdict,
+# not the legacy `il bloque` wording, when the marker is superseded or
+# the lane has been filtered out by scope. Four acceptance tests, plus the
+# positive control that the legacy wording still fires when the marker is
+# a real blocker (#11755 retro-compat preserved).
+# ---------------------------------------------------------------------------
+
+
+def _events_for(*bodies_and_dates):
+    """Build a list of ClaimEvents from alternating (body, created_at) pairs.
+
+    Used by the #12327 acceptance tests below to compose multi-lane scenarios
+    where some lanes have posted an epic-wide marker followed by a scoped
+    re-claim (the supersede scenario) and others only have the legacy
+    epic-wide form (the still-blocking scenario).
+    """
+    events = []
+    for body, date in bodies_and_dates:
+        for ev in clc._parse_claim_events(comment(body, date)):
+            events.append(ev)
+    return events
+
+
+def test_lint_12327_epic_wide_superseded_by_scoped_re_claim(capsys):
+    # Lane X claim un marqueur epic-wide historique, puis re-poste un claim
+    # scoped. Le marqueur epic-wide est SUPERSEDED par le claim actif scoped
+    # de la MEME lane. Le lint doit le qualifier `SUPERSEDED`, JAMAIS
+    # `il bloque toutes les autres lanes`.
+    bodies_and_dates = [
+        ("[CLAIMED] lane myia-po-2024:CoursIA-2\n",
+         "2026-08-20T10:00:00Z"),
+        ("[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: "
+         "MyIA.AI.Notebooks/GenAI/Image/03-3*.ipynb\n",
+         "2026-08-22T14:00:00Z"),  # scoped, later
+    ]
+    events = _events_for(*bodies_and_dates)
+    # Compute active_claims manually (the same reducer step the lint receives)
+    active, _ = clc.compute_active_claims(events)
+    clc._lint_claim_events(
+        events,
+        issue_number=11112,
+        active_claims=active,
+        others_verdict={},  # empty -- the caller is in scope
+        my_lane="myia-po-2023:CoursIA-2",
+    )
+    err = capsys.readouterr().err
+    assert "SUPERSEDED" in err, (
+        "le marqueur epic-wide historique doit etre qualifie SUPERSEDED "
+        "quand un claim actif scoped ulterieur de la meme lane le supplante "
+        "(#12327)"
+    )
+    assert "il bloque toutes les autres lanes" not in err, (
+        "le wording legacy `il bloque toutes` est INTERDIT pour un marqueur "
+        "superseded (cf. l'incident fondateur du 2026-08-22T14:41Z)"
+    )
+    # L'hygiene debt (RELEASED) est signalee comme dette, pas comme blocage.
+    assert "Hygiene:" in err
+    assert "[RELEASED]" in err
+
+
+def test_lint_12327_epic_wide_filtered_out_by_scope_is_sans_effet(capsys):
+    # Lane Y a un marqueur epic-wide ACTIF (le seul qu'elle a poste), mais
+    # le caller declare --paths disjoint. Le verdict est CLEAR (`others`
+    # vide apres filtre scope), MAIS le lint epic-wide legacy dirait quand
+    # meme `il bloque`. Le qualifier doit dire `SANS effet` -- l'info
+    # utilisateur est preservee, le verdict n'est pas contredit.
+    bodies_and_dates = [
+        ("[CLAIMED] lane myia-po-2024:CoursIA-2\n",
+         "2026-08-22T14:00:00Z"),
+    ]
+    events = _events_for(*bodies_and_dates)
+    active, _ = clc.compute_active_claims(events)
+    # Post scope filter: lane Y is OUT of `others` (caller scope disjoint).
+    # The lint receives this FINAL `others_verdict`, not the pre-filter state.
+    clc._lint_claim_events(
+        events,
+        issue_number=11112,
+        active_claims=active,
+        others_verdict={},  # post scope-filter: empty
+        my_lane="myia-po-2023:CoursIA-2",
+    )
+    err = capsys.readouterr().err
+    assert "SANS effet" in err, (
+        "un marqueur epic-wide d'une lane filtree par scope doit etre "
+        "qualifie SANS effet, JAMAIS `il bloque` (#12327)"
+    )
+    assert "il bloque toutes les autres lanes" not in err
+
+
+def test_lint_12327_legacy_il_bloque_preserved_for_real_blocker(capsys):
+    # CONTROLE POSITIF (acceptance #12327 - 3e critere) : un marqueur
+    # epic-wide qui EST reellement dans `others_verdict` (le caller n'a
+    # pas declare de scope, donc AUCUN filtre ne l'a retire) doit TOUJOURS
+    # declencher le wording legacy `il bloque`. La correction ne doit pas
+    # se valider QUE par le bruit qu'elle elimine -- elle doit continuer
+    # d'attraper les vrais blocages.
+    bodies_and_dates = [
+        ("[CLAIMED] lane myia-po-2024:CoursIA-2\n",
+         "2026-08-22T14:00:00Z"),
+    ]
+    events = _events_for(*bodies_and_dates)
+    active, _ = clc.compute_active_claims(events)
+    # Caller did NOT declare --paths, so the lane IS in `others_verdict`
+    # (real blocker, scope filter cannot prove disjointness).
+    clc._lint_claim_events(
+        events,
+        issue_number=11112,
+        active_claims=active,
+        others_verdict=active,  # caller has no scope -> nothing filtered
+        my_lane="myia-po-2023:CoursIA-2",
+    )
+    err = capsys.readouterr().err
+    assert "il bloque toutes les autres lanes" in err, (
+        "CONTROLE POSITIF (#12327 acceptance 3) : un marqueur epic-wide "
+        "qui survit au scope filter DOIT toujours declencher le wording "
+        "legacy `il bloque`. La correction ne peut pas etre validee par "
+        "le silence seul -- elle doit aussi continuer d'attraper."
+    )
+    assert "SUPERSEDED" not in err, (
+        "pas de SUPERSEDED si la lane n'a pas re-poste depuis"
+    )
+
+
+def test_lint_12327_run_check_11112_exact_scenario(capsys, monkeypatch):
+    # SCENARIO EXACT de l'incident fondateur (2026-08-22T14:41Z) :
+    # 4 marqueurs epic-wide historiques (4 lanes distinctes) + 4 claims
+    # actifs scopés disjoints. Le caller declare --paths sur
+    # 10_LocalLlama*.ipynb. Le verdict FINAL est CLEAR (tous les claims
+    # scopés disjoints) -- AUCUN marqueur epic-wide historique ne doit
+    # etre rapporte comme `il bloque`, et le verdict reste CLEAR.
+    # Le mock tracked aligne les globs sur des fichiers qui matchent dans
+    # le test (le walk reel du worktree differe du walk de l'install
+    # CoursIA-2 principale ; on veut tester la logique, pas le filesystem).
+    monkeypatch.setattr(
+        clc, "_git_tracked_files",
+        lambda repo_root=None: [
+            "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-test.ipynb",
+            "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-test.ipynb",
+            "MyIA.AI.Notebooks/Sudoku/SL-5-test.ipynb",
+            "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3-test.ipynb",
+            "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-7-test.ipynb",
+            "MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/I2_Contre-test.ipynb",
+            "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama-test.ipynb",
+        ],
+    )
+    bodies_and_dates = [
+        # 4 epic-wide historiques (4 lanes distinctes, dates anterieures)
+        ("[CLAIMED] lane myia-po-2023:CoursIA\n",
+         "2026-08-22T13:50:00Z"),
+        ("[CLAIMED] lane myia-po-2026:CoursIA\n",
+         "2026-08-22T13:51:00Z"),
+        ("[CLAIMED] lane myia-po-2024:CoursIA-2\n",
+         "2026-08-22T13:52:00Z"),
+        ("[CLAIMED] lane myia-po-2026:CoursIA-2\n",
+         "2026-08-22T13:53:00Z"),
+        # 4 claims actifs scopés disjoints (memes lanes, dates ulterieures)
+        ("[CLAIMED] lane myia-po-2023:CoursIA -- paths: "
+         "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2*.ipynb, "
+         "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3*.ipynb\n",
+         "2026-08-22T14:10:00Z"),
+        ("[CLAIMED] lane myia-po-2026:CoursIA -- paths: "
+         "MyIA.AI.Notebooks/Sudoku/SL-5*.ipynb\n",
+         "2026-08-22T14:11:00Z"),
+        ("[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: "
+         "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-3*.ipynb, "
+         "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-7*.ipynb\n",
+         "2026-08-22T14:12:00Z"),
+        ("[CLAIMED] lane myia-po-2026:CoursIA-2 -- paths: "
+         "MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/I2_Contre*.ipynb\n",
+         "2026-08-22T14:13:00Z"),
+    ]
+    events = _events_for(*bodies_and_dates)
+    p = payload(*[comment(b, d) for b, d in bodies_and_dates], number=11112)
+    # Caller is po-2024:CoursIA, declares --paths on 10_LocalLlama (none of
+    # the 4 scoped claims intersect). Sortie attendue : CLEAR (exit 0) et
+    # AUCUN marqueur epic-wide historique ne dit `il bloque` -- tous sont
+    # soit SUPERSEDED (meme lane a re-poste un scoped) soit SANS effet
+    # (la lane a re-poste un scoped disjoint, mais avec un marqueur
+    # epic-wide historique qu'on n'a pas re-poste en supersede -- dans ce
+    # cas l'organe voit 2 markers, le scoped prime comme ACTIVE, et le
+    # epic-wide historique est SUPERSEDED par construction).
+    rc = clc._run_check(
+        p,
+        "myia-po-2024:CoursIA",
+        my_paths=[
+            "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama*.ipynb",
+        ],
+    )
+    assert rc == 0, (
+        f"verdict CLEAR attendu (4 claims scopés disjoints du path 10_LocalLlama), "
+        f"got rc={rc}"
+    )
+    err = capsys.readouterr().err
+    # Aucun marqueur epic-wide ne doit affirmer `il bloque toutes les autres`
+    assert "il bloque toutes les autres lanes" not in err, (
+        "le wording legacy `il bloque toutes` est INTERDIT sur les 4 "
+        "marqueurs epic-wide historiques une fois que la meme lane a "
+        "re-poste un claim scoped (incidente fondateur 2026-08-22T14:41Z)"
+    )
+    # Les 4 marqueurs epic-wide sont SHOULD SUPERSEDED (chacun supplanté
+    # par le claim scoped ulterieur de la meme lane).
+    superseded_count = err.count("SUPERSEDED")
+    assert superseded_count == 4, (
+        f"les 4 marqueurs epic-wide historiques doivent etre qualifies "
+        f"SUPERSEDED (1 par lane), got {superseded_count}"
+    )
+
+
+def test_lint_12327_released_followed_by_scoped_is_still_superseded(capsys):
+    # Scénario complet : CLAIMED epic-wide historique, RELEASED hygiene, puis
+    # CLAIMED scoped actif. L'organe réduit à un seul ACTIVE (le scoped).
+    # L'ancien CLAIMED epic-wide reste dans la liste d'events (le RELEASED
+    # ferme le PRÉCÉDENT active, mais ne supprime pas l'event du journal) --
+    # le lint le voit et le qualifie SUPERSEDED par le scoped actif de la
+    # MEME lane. C'est la bonne sémantique : le marqueur historique n'a plus
+    # aucun effet sur le verdict (le reducer ne le considère plus), mais
+    # l'info reste utile pour la lane qui n'a pas edité son RELEASED sur
+    # CHAQUE marqueur historique (au cas où elle en aurait plusieurs).
+    # Le wording `il bloque toutes les autres lanes` reste INTERDIT.
+    bodies_and_dates = [
+        ("[CLAIMED] lane myia-po-2024:CoursIA-2\n",
+         "2026-08-20T10:00:00Z"),
+        ("[RELEASED] lane myia-po-2024:CoursIA-2 -- cleanup\n",
+         "2026-08-21T10:00:00Z"),
+        ("[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: "
+         "MyIA.AI.Notebooks/GenAI/Audio/04-3*.ipynb\n",
+         "2026-08-22T14:00:00Z"),
+    ]
+    events = _events_for(*bodies_and_dates)
+    active, _ = clc.compute_active_claims(events)
+    clc._lint_claim_events(
+        events,
+        issue_number=11112,
+        active_claims=active,
+        others_verdict={},
+        my_lane="myia-po-2023:CoursIA-2",
+    )
+    err = capsys.readouterr().err
+    assert "SUPERSEDED" in err, (
+        "le marqueur epic-wide historique (meme apres RELEASED) doit etre "
+        "qualifie SUPERSEDED par le scoped actif ulterieur de la meme lane"
+    )
+    assert "il bloque toutes les autres lanes" not in err, (
+        "le wording legacy `il bloque toutes` reste INTERDIT, meme apres "
+        "RELEASED (le SUPERSEDED le remplace)"
+    )
+
+
+def test_lint_12327_no_supersede_marker_when_only_rele(capsys):
+    # Controle symétrique : CLAIMED epic-wide + RELEASED SANS re-claim
+    # scoped. L'organe a 0 active pour cette lane. Le marqueur epic-wide
+    # historique n'a plus d'actif qui le supersede, mais il n'a pas non
+    # plus d'effet (pas dans `others_verdict`). Le lint doit etre SILENT
+    # sur ce marqueur (pas de SUPERSEDED, pas de `il bloque`) -- l'event
+    # est purement historique, le verdict n'a rien à en dire.
+    bodies_and_dates = [
+        ("[CLAIMED] lane myia-po-2024:CoursIA-2\n",
+         "2026-08-20T10:00:00Z"),
+        ("[RELEASED] lane myia-po-2024:CoursIA-2 -- cleanup\n",
+         "2026-08-21T10:00:00Z"),
+    ]
+    events = _events_for(*bodies_and_dates)
+    active, _ = clc.compute_active_claims(events)
+    clc._lint_claim_events(
+        events,
+        issue_number=11112,
+        active_claims=active,
+        others_verdict={},
+        my_lane="myia-po-2023:CoursIA-2",
+    )
+    err = capsys.readouterr().err
+    assert "il bloque" not in err, (
+        "un marqueur epic-wide RELEASED sans re-claim ne doit produire "
+        "AUCUN lint (pas d'actif, pas de blocker)"
+    )
+    assert "SUPERSEDED" not in err, (
+        "pas de SUPERSEDED non plus (pas d'actif pour le supplanter)"
+    )
+


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2023:CoursIA-2 -- prev: DEEP/notebook-python #12295

fix(lane-claim,#12327): lint qualifier epic-wide -- SUPERSEDED/sans-effet vs il-bloque (cohérence verdict)

Refs #12327 (lint qualifier -- 5 INFO lint contradictions sur la même ligne de synthèse).
See #11112 (incident fondateur 2026-08-22T14:41Z -- escalade HIGH fausse sur 4 marqueurs epic-wide supersedes par 4 claims scopés disjoints).
See #12072 (off-marker scope WARN -- même symptome de lint trop verbeux).
See #11755 (la Piste 1 legacy wording `il bloque` reste préservée pour les VRAIS blocages -- rétro-compat).

## Le bug

`_lint_claim_events` imprimait systématiquement `il bloque toutes les autres lanes` sur les marqueurs epic-wide, **sans vérifier l'état du réducteur**. Le 2026-08-22T14:41Z, po-2024:CoursIA a lu la sortie de l'organe sur #11112, a vu 5 lignes INFO « il bloque toutes les autres lanes » avec 4 lanes distinctes, et a escaladé en HIGH. La conclusion était fausse : les 4 marqueurs epic-wide historiques étaient **superseded** par 4 claims scopés disjoints que les lanes avaient re-postés. La ligne de synthèse `CLEAR: no other lane claims #11112` contredisait frontalement les 5 INFO dans la même sortie.

Coût : 1 cycle worker + 1 escalade HIGH + 1 aller-retour coordinateur. **Deuxième** fois que cette famille coûte un cycle (cf #12072, #11977).

## La correction

Refactor minimal. `_lint_claim_events` reçoit `active_claims`, `others_verdict`, `my_lane` — et est appelée **après** la réduction (others FINAL post scope-filter + stale-filter), pas avant.

Chaque marqueur epic-wide est bucketisé :

| Bucket | Condition | Wording |
|---|---|---|
| **SUPERSEDED** | `active_claims[lane]` est un marker ultérieur (scoped ou epic-wide plus récent) de la MÊME lane | `marqueur X epic-wide SUPERSEDED (lane Y) -- un claim actif ulterieur de la meme lane tient le verrou (scope: ...). Sans effet sur le verdict. Hygiene: [RELEASED] l'ancien marqueur (cf. #12327).` |
| **SANS effet** | la lane est dans `active_claims` mais PAS dans `others_verdict` (scope filter a éliminé) | `marqueur X epic-wide (lane Y) -- SANS effet sur #N (claim de la lane filtre par scope ou re-poste depuis).` |
| **il bloque** | la lane EST dans `others_verdict` (le réducteur la garde rééllement contre le caller) | wording legacy #11755 préservé -- rétro-compat |

Sans les nouveaux args (legacy call), le lint retombe sur l'ancien wording -- back-compat pour tout appelant qui n'a pas migré.

## Validation

**Tests** : 207/207 PASS (201 baseline + 6 nouveaux) :
1. `test_lint_12327_epic_wide_superseded_by_scoped_re_claim` -- epic-wide historique + scoped ultérieur = SUPERSEDED.
2. `test_lint_12327_epic_wide_filtered_out_by_scope_is_sans_effet` -- epic-wide actif + scope filter disjoint = SANS effet.
3. `test_lint_12327_legacy_il_bloque_preserved_for_real_blocker` -- **contrôle positif** : epic-wide sans scope caller (vrai blocker) = wording legacy conservé.
4. `test_lint_12327_run_check_11112_exact_scenario` -- scénario fondateur #11112 : 4 marqueurs historiques + 4 claims scopés disjoints, caller `--paths = 10_LocalLlama*`, verdict CLEAR, **0 ligne `il bloque`**, **4 lignes SUPERSEDED**.
5. `test_lint_12327_released_followed_by_scoped_is_still_superseded` -- RELEASED + scoped ultérieur = SUPERSEDED (le RELEASED ferme l'ancien active mais l'event reste dans la liste).
6. `test_lint_12327_no_supersede_marker_when_only_rele` -- RELEASED seul (pas de re-claim) = SILENT (pas de SUPERSEDED, pas de `il bloque`).

**Validation réelle sur #11112** (132 commentaires, payload authentique via `gh api`) : l'organe produit maintenant **4 SUPERSEDED + 1 SANS effet + 0 `il bloque`**. Avant le fix : 5 lignes `il bloque toutes les autres lanes` auraient contredit la synthèse `CLEAR`.

## Surface

```
scripts/check_lane_claim.py            | 104 +++++++-
scripts/tests/test_check_lane_claim.py | 281 ++++++++++++++
2 files changed, 379 insertions(+), 6 deletions(-)
```

- 0 régression sur les tests existants (lint INFO legacy préservé pour les vrais blocages).
- 0 effet de bord sur les JSON (`blocking_lanes`, `query_scope`, `epic_wide_on_umbrella` inchangés).
- 0 changement sur le verdict (le verdict FINAL reste piloté par `others` post scope-filter, le lint est purement informatif).

## Leçons durables (résumé)

(L1) Le lint peut contredire le verdict dans la même sortie -- l'instrument se contredit, c'est l'instrument qu'on répare, pas la vigilance qu'on prescrit.
(L2) Une fois qu'un marker est superseded par construction, il reste dans l'historique mais ne bloque plus -- le `[RELEASED]` est une dette hygiène, pas un blocage.
(L3) Un fix de lint qui se valide par le silence seul rate le contrôle positif -- le wording legacy doit continuer d'attraper les vrais blocages.

## Coord cross-lane

- **PR #12344 amend v2** (c.465, `--merge`) -- antecedent immediat : `query_scope` + exit 2 NOT_SCOPED.
- **Issue #11112** -- incident fondateur (escalade HIGH 14:41Z).
- **Issue #12327** -- grain livrer.
- **Issue #12072** -- jumeau (off-marker scope WARN).
- **Issue #11755** -- heritage (lint INFO wording).

## Demande ai-01

1. Re-vérification : scenario fondateur #11112 sort bien `4 SUPERSEDED + 1 SANS effet + 0 il bloque` (cf test 4).
2. Re-vérification : un epic-wide sans scope caller sort toujours le wording legacy (cf test 3, contrôle positif).
3. Sign-off + merge.

-- po-2023:CoursIA-2

---

**Note coordinateur ai-01 (2026-08-22T21:5xZ) — pourquoi ce body est touche.**

Le marqueur `[G-VAR-3 OVERRIDE]` a ete poste en commentaire a 21:35Z. Mesure faite
juste apres sur le SHA de tete : **il n'a pas leve le check requis**. Trois noms
de check-runs distincts coexistent sur ce SHA —

| poste a | conclusion | nom exact |
|---|---|---|
| 17:35:54Z | `skipped` | `Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)` |
| 17:49:29Z | **`failure`** | `Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)` |
| 21:54:09Z | `success` | `Require genre diversity vs prev: (block on LIGHT adjacency, #11170)` |

Le chemin `issue_comment` poste son vert sous un **troisieme nom** (deux-points
apres `prev`, pas de qualifieur), qui n'est ni celui du job requis ni celui du job
commentaire. `PR gate` agrege **par nom** : le `failure` de 17:49 reste le dernier
verdict connu sous le nom requis, et la PR reste bloquee. L'en-tete du garde
annonce pourtant l'inverse (« le check-run porte le MEME nom que le job
pull_request ; le verdict le plus recent l'emporte », #11718 l.937).

Le remede qui marche, lui, est dans les triggers : `pull_request:` inclut
`edited`. Toucher le body relance le job **requis**, qui lit les commentaires
(l.833) et honore le marqueur. C'est ce que fait cette note — elle n'a pas
d'autre fonction, et je la laisse ecrite plutot que de maquiller un
re-declenchement en modification de fond.

Defaut d'organe trace a part ; il ne se corrige pas dans cette PR.
