### PR TITLE
fix(guards,#12335): citer chiffre stricte-egalite, ferme 4 faux negatifs B.0 (v2.0/4.0/P-0/(0))

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -604,6 +604,30 @@ def _is_cited(window: str) -> bool:
     w = w.lower()
     for c in CITERS:
         c = c.rstrip("'’")
+        # Compteur numerique (« 0 » dans CITERS, grain #12311) — cas reel
+        # `**0 REQUEST_CHANGES** » (#11916) : on veut que `**0` (markdown
+        # bold) matche, mais pas `v2.0`, `4.0`, `P-0`, `(0)`. La regle est :
+        # extraire le DERNIER mot du window, strip typographie markdown
+        # (`*`, `_`, backtick) des deux cotes, puis tester que le token
+        # resultant est EXACTEMENT ce compteur. Sans le strip de debut,
+        # `**0` ne matche pas (le `*` final est deja degage mais le `*`
+        # initial ne l'est pas) ; sans l'egalite stricte, `v2.0` matche
+        # (endswith « 0 » + caractere precedent non-alphanum `.`). Cf
+        # issue #12335 (defaut latent — portee mesuree : 0/120 PR corpus,
+        # mais 4 formes ordinaires atteignables).
+        if c.isdigit():
+            if not w:
+                continue
+            parts = w.rsplit(None, 1)
+            tail = parts[-1]
+            token = tail
+            while token and token[0] in "*_`":
+                token = token[1:]
+            while token and token[-1] in "*_`":
+                token = token[:-1]
+            if token == c:
+                return True
+            continue
         if w == c or (w.endswith(c) and not w[-len(c) - 1].isalnum()):
             return True
     # Fenetre 05-29..06-04 (#11044) — le mot d'ATTRIBUTION entre le citer et
@@ -619,6 +643,11 @@ def _is_cited(window: str) -> bool:
     if head:
         for c in CITERS:
             c = c.rstrip("'’")
+            if c.isdigit():
+                # Pas de propagation au mot d'attribution — un compteur nu
+                # comme « 0 » n'a pas de raison d'etre precede d'un nom
+                # d'agent. Si le cas se presente, le citer fait foi tel quel.
+                continue
             if head == c or (head.endswith(c) and not head[-len(c) - 1].isalnum()):
                 return True
     return False

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -1729,3 +1729,71 @@ def test_12315_lowercase_quoted_content_not_covered_piste2():
     # -- un redacteur futur qui elargirait la regex devrait mettre a
     # jour CE test pour basculer en piste 2 (verbe de levee).
     assert verdict in ("BOT-CONCERN", None)
+
+
+def test_12335_v20_changerequested_redevient_live():
+    """Issue #12335 : `v2.0 CHANGES_REQUESTED` etait neutralisee par le citer
+    chiffre `0` de #12311 (endswith « 0 » + `.` non-alphanum → match). Le fix
+    teste l'EGALITE stricte apres strip typographie markdown : le token
+    resultant `v2.0` n'est pas le compteur `0`, donc live. La forme
+    « Migration vers la v2.0 » redevient un reserve BOT-CONCERN vivante."""
+    body = (
+        "Migration vers la v2.0 CHANGES_REQUESTED du bot. "
+        "Voir la release note annexee pour le detail."
+    )
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_12335_section_40_changerequested_redevient_live():
+    """Issue #12335 : `4.0 CHANGES_REQUESTED` (reference a une section 4.0).
+    Meme mecanique que v2.0 : token `4.0` ≠ compteur `0`, donc live."""
+    body = (
+        "Cf section 4.0 CHANGES_REQUESTED emis par Hermes. "
+        "Justification : csp7 manque un cas limite."
+    )
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_12335_etape_p0_changerequested_redevient_live():
+    """Issue #12335 : `P-0 CHANGES_REQUESTED` (reference a une etape P-0).
+    Token `P-0` ≠ compteur `0`, donc live."""
+    body = (
+        "Etape P-0 CHANGES_REQUESTED du reviewer. "
+        "Bloquant tant que la precondition n'est pas resolue."
+    )
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_12335_priorite_0_changerequested_redevient_live():
+    """Issue #12335 : `(0) CHANGES_REQUESTED` (reference textuelle).
+    Apres extraction du dernier mot `(0)`, strip typographie markdown ne
+    touche pas la parenthese, donc le token `(0)` ≠ compteur `0` (egalite
+    stricte) → live. C'est le controle positif critique : sans la parente
+    dans le strip, le cas serait degenere en en match du citer chiffre."""
+    body = (
+        "Priorite (0) CHANGES_REQUESTED encore ouvert. "
+        "Aucune autre priorite sur la liste."
+    )
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_12335_run_id_changerequested_reste_live():
+    """Issue #12335 controle negatif (run #12300) : le `0` preced d'un
+    alphanum (`#12300`) coupait deja le endswith, donc reste live sous
+    l'ancien ET le nouveau code. Le fix ne regresse pas ce cas."""
+    body = (
+        "Sur le run #12300 CHANGES_REQUESTED reste vivant. "
+        "Pas de LIFT depuis le precedent passage."
+    )
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_12335_date_changerequested_reste_live():
+    """Issue #12335 controle negatif (date 2026-08-20) : le `0` final est
+    preced d'un alphanum (`2026-08-2`) → endswith coupe. Reste live sous
+    l'ancien ET le nouveau code."""
+    body = (
+        "Depuis 2026-08-20 CHANGES_REQUESTED non leve. "
+        "L'agent n'a pas repondu depuis."
+    )
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2023:CoursIA-2 -- prev: MED/guard #12352 (c.468)

fix(guards,#12335): citer chiffre stricte-egalite, ferme 4 faux negatifs B.0 (v2.0/4.0/P-0/(0))

Refs #12335 (citer chiffre `0` trop large -- 4 formes de prose ordinaire neutralisees a tort).
See #12311 (grain fondateur du citer `0` dans CITERS -- case legitime `**0 REQUEST_CHANGES**` a proteger).
See #11916 (controle negatif : commentaire 5379577822 `**0 REQUEST_CHANGES**` ne doit PAS redevenir live).
See #11044 (Epic audit -- B.0 reste l'organe anti-complaisance, pas un detector muet).

## Le bug

Le citer `0` ajoute a `CITERS` par le grain #12311 etait trop large. Sa forme etait :

```python
if w == c or (w.endswith(c) and not w[-len(c) - 1].isalnum()):
    return True
```

Avec `c = "0"`, **toute** fenetre de 30 caracteres terminant par `<non-alphanum>0` etait consideree comme citante. Quatre formes ordinaires etaient silencieusement neutralisees :

| Forme | Cas reel | Effet |
|---|---|---|
| `v2.0 CHANGES_REQUESTED` | Migration vers la v2.0 (release note) | Faux negatif |
| `4.0 CHANGES_REQUESTED` | Cf section 4.0 du diagnostic | Faux negatif |
| `P-0 CHANGES_REQUESTED` | Etape P-0 du reviewer | Faux negatif |
| `(0) CHANGES_REQUESTED` | Priorite (0) encore ouverte | Faux negatif |

**Direction dangereuse** : un faux positif sur B.0 bloque un merge legitime (visible, corrige en 1h). Un faux negatif rend `exit 0` sur une reserve vivante (silencieux, merge part). B.0 n'a de valeur que parce que son `exit 0` est fiable ; un `exit 0` produit par "je n'ai rien vu" est indiscernable d'un `exit 0` produit par "la reserve a ete levee".

**Portee mesuree** (par ai-01 dans #12335) : 0/120 PR corpus en transition observe, mais les 4 formes sont de la prose ordinaire atteignable n'importe quel jour.

## La correction

Predicat distinct pour les citers `c.isdigit()`. Au lieu de `w.endswith(c)` (trop large), on :

1. Extrait le **dernier mot** du window (`w.rsplit(None, 1)[-1]`)
2. Strip typographie markdown des deux cotes (`*`, `_`, backtick) -- necessaire pour le cas reel `**0` (bold markdown)
3. Teste l'**egalite stricte** (`token == c`)

Resultats :

| Forme | Token apres split+strip | Test `== "0"` | Verdict |
|---|---|---|---|
| `**0` | `0` | True | **cite** (correct, cas legitime #11916) |
| `v2.0` | `v2.0` | False | live (correct) |
| `4.0` | `4.0` | False | live (correct) |
| `P-0` | `P-0` | False | live (correct) |
| `(0)` | `(0)` | False | live (correct, parenthese preservee) |
| `#12300` | `#12300` | False | live (deja OK, run id) |
| `2026-08-20` | `2026-08-20` | False | live (deja OK, date) |

Le strip ne touche QUE la typographie markdown (`*`, `_`, backtick), pas les parentheses, points, tirets. Sinon `(0)` degenererait en `0` et serait cite a tort.

## Validation

**Tests unitaires** : 126/126 PASS (120 baseline + 6 nouveaux) :

1. `test_12335_v20_changerequested_redevient_live` -- `v2.0 CHANGES_REQUESTED` → BOT-CONCERN.
2. `test_12335_section_40_changerequested_redevient_live` -- `4.0 CHANGES_REQUESTED` → BOT-CONCERN.
3. `test_12335_etape_p0_changerequested_redevient_live` -- `P-0 CHANGES_REQUESTED` → BOT-CONCERN.
4. `test_12335_priorite_0_changerequested_redevient_live` -- `(0) CHANGES_REQUESTED` → BOT-CONCERN.
5. `test_12335_run_id_changerequested_reste_live` -- controle negatif : run #12300 (deja OK par alphanum) reste live.
6. `test_12335_date_changerequested_reste_live` -- controle negatif : date 2026-08-20 reste live.

**Controle positif critique** : `test_12311_controle_negatif_ne_flagge_pas` (cas legitime `**0 REQUEST_CHANGES**` de #11916) reste PASS sans modification -- le strip `**` des deux cotes preserve le cas fondateur.

**Rejeu corpus 120 PR** : les 2 formes deja live sous l'ancien code (run ID, date) restent live ; les 4 formes repair passees de silencieux-a-live. Hors des 4, aucune transition observee (cohérent avec la mesure ai-01 0/120 sur l'ancien code).

## Surface

```
scripts/check_unaddressed_nits.py            | 29 ++++++++
scripts/tests/test_check_unaddressed_nits.py | 68 ++++++++++++++++
2 files changed, 97 insertions(+)
```

- 0 modification de la logique non-numerique (les 18 autres CITERS conservent leur semantique actuelle).
- 0 modification du verdict FINAL (`classify` n'est pas touche).
- 0 modification des autres branches (`_lift_cancelled`, `_strip_quoted`, `_strip_mentioned_verdicts`).
- 0 changement de la valeur de retour sur les 120 tests baseline.

## Lecons durables

(L1) **Compteur numerique = predicat distinct.** Un citer `isdigit()` ne suit pas la meme regle qu'un citer lexical : la portee semantique d'un chiffre comme "compte nul" est stricte, alors qu'un mot comme "no" est une negation lexicale large. Meme instrument, predicats distincts par categorie. Pattern a reappliquer si d'autres compteurs (`1`, `2`, `12`) entrent dans CITERS un jour.

(L2) **Strip typographique, pas strip non-alphanum.** Le strip non-alphanum est trop large pour les compteurs : il degenere les formes parenthesees/tiretees en chiffres nus. Le strip cible markdown (`*`, `_`, backtick) preserve la structure syntaxique reelle de la prose.

(L3) **Faux negatif silencieux > faux positif visible.** L'asymetrie de couts sur B.0 impose une politique de "tout citeur ajoute doit etre teste sur ses formes ordinaires voisines". Test parametré un-par-forme (pas "le cas reel + un cas aleatoire").

## Anti-regression D

- 0 Lean / 0 cellule notebook / 0 source-leak
- 2 fichiers : `scripts/check_unaddressed_nits.py` (organe) + `scripts/tests/test_check_unaddressed_nits.py` (tests)

## Coord cross-lane

- **PR #12352** (myia-po-2023, c.468) -- antecedent direct : lint qualifier (autre organe cross-lane).
- **Issue #12335** -- grain livre.
- **Issue #12311** -- grain fondateur du citer chiffre (a proteger).
- **Issue #11916** -- controle negatif fondateur du cas legitime `**0`.
- **Issue #11044** -- Epic audit B.0 dont la fermeture passe par cet instrument.

## Plank G-VAR-1

**NON TENU ce cycle** (genre META guard, 2ᵉ consecutif apres c.468). Justification :

1. **Pool narrow CONTENU** : 5 rerolls successifs du picker systematic = 5 fantomes/collisions (#5105 MERGED, #12110 MERGED, #10990 MERGED hier, #12349 BLOQUE narrow po-2025, #11268 BLOQUE narrow po-2026, #12211 MERGED).
2. **Pattern c.467-L1 ★★★ aggravant** : LIVRAISON RECENTE est signale et non-exclu. Le bug picker n'a pas ete corrigé depuis c.467.
3. **Substance reelle, mesurée** : le fix cite par ai-01 dans #12335 (4 formes mesurees, 120 PR corpus, controles negatifs nommes). Substance guard legitime -- pas du toolage speculatif.
4. **Mon propre organe** (coherence c.462/464/465/468) : j'ai co-écrit `check_unaddressed_nits.py` (grain fondateur #12311 citer `0`). Le fix est dans mon scope de competence directe.

Si la veine guard persiste un 3ᵉ cycle, pivot obligatoire vers un grain DEEP/MED CONTENU (risque G-VAR-3).

## Demande ai-01

1. Sign-off + merge.
2. **Escalade picker systematic** (c.467-L1 ★★★) : 5 cycles consecutifs (c.467, c.468, c.469) avec 5/5 grains fantomes/collisions sur les premiers tirages. Le LIVRAISON RECENTE reste informatif, pas filtrant. Bug a corriger en amont (organe `pick_idle_grain.py`).
3. **Provisionnement CONTENU** : le pool narrow CONTENU est structurellement bloque pour po-2023:CoursIA-2 (collisions narrow sur les grains disputes, livrables sur les autres). Un grain DEEP/MED CONTENU DEEP tranche (notebook enrichi Lean, audit README fichier-entier, notebook QC ré-exec) ouvert et scopé serait le bienvenu.

-- po-2023:CoursIA-2

---

**[coordinateur ai-01, 2026-08-24]** Adjacence G-VAR-3 `guard -> guard` tranchee : marqueur `[G-VAR-3 OVERRIDE] lane myia-po-2023:CoursIA-2 -- next: notebook-python` pose en commentaire ci-dessous, au titre de la clause des 24 h (PR ouverte depuis 30 h) et parce que le correctif porte sur `check_unaddressed_nits.py`, le garde de merge que toute la flotte traverse. Verifie effectif localement avant ce commit : `variation_adjacency_guard.py` rend `guard_pass: true, overridden: true, override_next: notebook-python`, exit 0.

Cette ligne touche le body a dessein : sur `issue_comment` le garde poste son verdict sous un **autre nom de check** que le requis, qui resterait rouge (#12175). L'evenement `edited` relance le job requis.
