### PR TITLE
feat(mgs,#11977): MGS-5 onboarding du PSO canonique à vélocité (axe 3)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb
@@ -14,19 +14,19 @@
     "tags": []
    },
    "source": [
-    "# MGS-5 : Construire les m\u00e9taheuristiques compos\u00e9es \u2014 des primitives au raccourci factory\n",
+    "# MGS-5 : Construire les métaheuristiques composées — des primitives au raccourci factory\n",
     "\n",
-    "[<- MGS-4 Islands](MGS-4-Islands.ipynb) | [^ S\u00e9rie MGS](README.md) | [MGS-6 Benchmarks ->](MGS-6-Benchmarks.ipynb)\n",
+    "[<- MGS-4 Islands](MGS-4-Islands.ipynb) | [^ Série MGS](README.md) | [MGS-6 Benchmarks ->](MGS-6-Benchmarks.ipynb)\n",
     "\n",
-    "Jusqu'ici (MGS-1 \u00e0 MGS-4) nous avons vu le moteur `MetaGeneticAlgorithm`, la grammaire fluente de primitives (`Match`, `IfElse`, `Container`, `Scoped`...), et deux compos\u00e9s structurants (Eukaryote, Islands). Ce notebook r\u00e9pond \u00e0 la question qui reste : **d'o\u00f9 viennent les algorithmes \u00ab publi\u00e9s \u00bb** \u2014 Whale Optimization Algorithm (WOA), Equilibrium Optimizer (EO), Forensic-Based Investigation (FBI) \u2014 et **comment les utiliser sans retomber dans le pi\u00e8ge de la bo\u00eete noire**.\n",
+    "Jusqu'ici (MGS-1 à MGS-4) nous avons vu le moteur `MetaGeneticAlgorithm`, la grammaire fluente de primitives (`Match`, `IfElse`, `Container`, `Scoped`...), et deux composés structurants (Eukaryote, Islands). Ce notebook répond à la question qui reste : **d'où viennent les algorithmes « publiés »** — Whale Optimization Algorithm (WOA), Equilibrium Optimizer (EO), Forensic-Based Investigation (FBI) — et **comment les utiliser sans retomber dans le piège de la boîte noire**.\n",
     "\n",
-    "L'argument de MetaGeneticSharp (cf. MGS-6 Benchmarks) est que reconstruire ces algorithmes \u00e0 partir de primitives composables *d\u00e9montre* leur m\u00e9canisme au lieu de le cacher derri\u00e8re une m\u00e9taphore animale (critique de Sorensen, 2015 : les m\u00e9taheuristiques bio-inspir\u00e9es seraient des \u00ab metaphors exposed \u00bb). Ce notebook montre, pour **chaque m\u00e9taheuristique compos\u00e9e du catalogue**, le m\u00eame parcours en trois temps :\n",
+    "L'argument de MetaGeneticSharp (cf. MGS-6 Benchmarks) est que reconstruire ces algorithmes à partir de primitives composables *démontre* leur mécanisme au lieu de le cacher derrière une métaphore animale (critique de Sorensen, 2015 : les métaheuristiques bio-inspirées seraient des « metaphors exposed »). Ce notebook montre, pour **chaque métaheuristique composée du catalogue**, le même parcours en trois temps :\n",
     "\n",
-    "1. **La description** \u2014 la m\u00e9taphore et la m\u00e9canique, dans l'esprit des fiches de `mealpy` (la biblioth\u00e8que Python qui sert de rep\u00e8re, et dont le fork s'inspire explicitement).\n",
-    "2. **La reconstruction depuis les primitives** \u2014 le code r\u00e9el de la lib qui assemble l'algorithme \u00e0 partir de briques (`IfElse`, `Match`, `GenerationMetaHeuristic`, croisements g\u00e9om\u00e9triques...). Ce n'est pas une paraphrase : c'est le corps de la m\u00e9thode `BuildMainHeuristic()` de la classe, lu transparentement.\n",
-    "3. **Le raccourci factory** \u2014 le one-liner `MetaHeuristicsService.CreateMetaHeuristicByName(\"...\")` qui produit *exactement* cette reconstruction, et la preuve (le type racine renvoy\u00e9) que raccourci et reconstruction sont identiques.\n",
+    "1. **La description** — la métaphore et la mécanique, dans l'esprit des fiches de `mealpy` (la bibliothèque Python qui sert de repère, et dont le fork s'inspire explicitement).\n",
+    "2. **La reconstruction depuis les primitives** — le code réel de la lib qui assemble l'algorithme à partir de briques (`IfElse`, `Match`, `GenerationMetaHeuristic`, croisements géométriques...). Ce n'est pas une paraphrase : c'est le corps de la méthode `BuildMainHeuristic()` de la classe, lu transparentement.\n",
+    "3. **Le raccourci factory** — le one-liner `MetaHeuristicsService.CreateMetaHeuristicByName(\"...\")` qui produit *exactement* cette reconstruction, et la preuve (le type racine renvoyé) que raccourci et reconstruction sont identiques.\n",
     "\n",
-    "> **Rappel C.2** : kernel `.net-csharp`. Les DLLs MetaGeneticSharp + GeneticSharp sont charg\u00e9es depuis le build du fork, compil\u00e9 en **net9.0** pour correspondre au kernel (`.NET 8` via dotnet-interactive). Voir la cellule de c\u00e2blage ci-dessous.\n"
+    "> **Rappel C.2** : kernel `.net-csharp`. Les DLLs MetaGeneticSharp + GeneticSharp sont chargées depuis le build du fork, compilé en **net9.0** pour correspondre au kernel (`.NET 8` via dotnet-interactive). Voir la cellule de câblage ci-dessous.\n"
    ]
   },
   {
@@ -38,10 +38,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:32.118970Z",
-     "iopub.status.busy": "2026-08-18T23:56:32.102461Z",
-     "iopub.status.idle": "2026-08-18T23:56:37.074786Z",
-     "shell.execute_reply": "2026-08-18T23:56:37.062212Z"
+     "iopub.execute_input": "2026-08-22T19:12:56.986815Z",
+     "iopub.status.busy": "2026-08-22T19:12:56.979497Z",
+     "iopub.status.idle": "2026-08-22T19:12:58.508833Z",
+     "shell.execute_reply": "2026-08-22T19:12:58.506188Z"
     },
     "papermill": {
      "duration": 1.180733,
@@ -54,44 +54,162 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/html": ""
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-496688.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '496688.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "MetaGeneticSharp + GeneticSharp charg\u00e9s (build net9.0 du fork).\r\n"
+     "output_type": "stream",
+     "text": [
+      "MetaGeneticSharp + GeneticSharp chargés (build net9.0 du fork).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  MetaHeuristicsService : MetaHeuristicsService\r\n"
+     "output_type": "stream",
+     "text": [
+      "  MetaHeuristicsService : MetaHeuristicsService\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  WhaleOptimisationAlgorithm : WhaleOptimisationAlgorithm\r\n"
+     "output_type": "stream",
+     "text": [
+      "  WhaleOptimisationAlgorithm : WhaleOptimisationAlgorithm\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  EquilibriumOptimizer : EquilibriumOptimizer\r\n"
+     "output_type": "stream",
+     "text": [
+      "  EquilibriumOptimizer : EquilibriumOptimizer\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  ForensicBasedInvestigation : ForensicBasedInvestigation\r\n"
+     "output_type": "stream",
+     "text": [
+      "  ForensicBasedInvestigation : ForensicBasedInvestigation\r\n"
+     ]
     }
    ],
    "source": [
-    "// C\u00e2blage : chargement des DLLs MetaGeneticSharp + GeneticSharp (build net9.0 du fork).\n",
-    "// Pr\u00e9requis de build (depuis la racine du fork) :\n",
+    "// Câblage : chargement des DLLs MetaGeneticSharp + GeneticSharp (build net9.0 du fork).\n",
+    "// Prérequis de build (depuis la racine du fork) :\n",
     "//   dotnet build src/MetaGeneticSharp.Domain/MetaGeneticSharp.Domain.csproj -c Debug\n",
-    "// (net9.0 pour matcher le target net9.0 du csproj ; les DLLs core + d\u00e9pendances System.Drawing\n",
-    "//  sont co-localis\u00e9es dans Domain/bin/Debug/net9.0/.)\n",
+    "// (net9.0 pour matcher le target net9.0 du csproj ; les DLLs core + dépendances System.Drawing\n",
+    "//  sont co-localisées dans Domain/bin/Debug/net9.0/.)\n",
     "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n",
     "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
     "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
@@ -104,7 +222,7 @@
     "using System.Collections.Generic;\n",
     "using System.Linq;\n",
     "\n",
-    "Console.WriteLine(\"MetaGeneticSharp + GeneticSharp charg\u00e9s (build net9.0 du fork).\");\n",
+    "Console.WriteLine(\"MetaGeneticSharp + GeneticSharp chargés (build net9.0 du fork).\");\n",
     "Console.WriteLine(\"  MetaHeuristicsService : \" + typeof(MetaHeuristicsService).Name);\n",
     "Console.WriteLine(\"  WhaleOptimisationAlgorithm : \" + typeof(WhaleOptimisationAlgorithm).Name);\n",
     "Console.WriteLine(\"  EquilibriumOptimizer : \" + typeof(EquilibriumOptimizer).Name);\n",
@@ -127,18 +245,18 @@
    "source": [
     "## Le catalogue : `KnownCompoundMetaheuristics`\n",
     "\n",
-    "Le point d'entr\u00e9e de la factory est une simple \u00e9num\u00e9ration : `KnownCompoundMetaheuristics`. Chaque valeur nomme une m\u00e9taheuristique compos\u00e9e que `MetaHeuristicsService` sait construire. C'est l'\u00e9quivalent du registre de `mealpy` \u2014 une liste close d'algorithmes pr\u00eats \u00e0 l'emploi.\n",
+    "Le point d'entrée de la factory est une simple énumération : `KnownCompoundMetaheuristics`. Chaque valeur nomme une métaheuristique composée que `MetaHeuristicsService` sait construire. C'est l'équivalent du registre de `mealpy` — une liste close d'algorithmes prêts à l'emploi.\n",
     "\n",
     "Le catalogue couvre quatre familles :\n",
     "\n",
-    "| Famille | Membres | Id\u00e9e |\n",
+    "| Famille | Membres | Idée |\n",
     "|---------|---------|------|\n",
-    "| **Default** | `Default`, `DefaultRandomHyperspeed` | Le GA GeneticSharp nu (r\u00e9f\u00e9rence). |\n",
-    "| **G\u00e9om\u00e9triques** | `WhaleOptimisation`, `WhaleOptimisationNaive`, `EquilibriumOptimizer`, `ForensicBasedInvestigation` | Compos\u00e9s reconstruits depuis des croisements g\u00e9om\u00e9triques sur g\u00e8nes continus. |\n",
-    "| **\u00celes homog\u00e8nes** | `Islands5Default`, `Islands5DefaultNoMigration` | Archipel de 5 \u00eeles identiques (cf. MGS-4). |\n",
-    "| **\u00celes h\u00e9t\u00e9rog\u00e8nes** | `Islands5BestMixture`, `Islands5BestMixtureNoMigration` | Archipel m\u00ealant WOA + EO + GA (composition de compos\u00e9s). |\n",
+    "| **Default** | `Default`, `DefaultRandomHyperspeed` | Le GA GeneticSharp nu (référence). |\n",
+    "| **Géométriques** | `WhaleOptimisation`, `WhaleOptimisationNaive`, `EquilibriumOptimizer`, `ForensicBasedInvestigation` | Composés reconstruits depuis des croisements géométriques sur gènes continus. |\n",
+    "| **Îles homogènes** | `Islands5Default`, `Islands5DefaultNoMigration` | Archipel de 5 îles identiques (cf. MGS-4). |\n",
+    "| **Îles hétérogènes** | `Islands5BestMixture`, `Islands5BestMixtureNoMigration` | Archipel mêlant WOA + EO + GA (composition de composés). |\n",
     "\n",
-    "Listons-le dynamiquement pour confirmer ce que la lib expose *r\u00e9ellement* (plut\u00f4t que de faire confiance \u00e0 une liste \u00e9crite \u00e0 la main).\n"
+    "Listons-le dynamiquement pour confirmer ce que la lib expose *réellement* (plutôt que de faire confiance à une liste écrite à la main).\n"
    ]
   },
   {
@@ -150,10 +268,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:37.078410Z",
-     "iopub.status.busy": "2026-08-18T23:56:37.077691Z",
-     "iopub.status.idle": "2026-08-18T23:56:37.506168Z",
-     "shell.execute_reply": "2026-08-18T23:56:37.505675Z"
+     "iopub.execute_input": "2026-08-22T19:12:58.510422Z",
+     "iopub.status.busy": "2026-08-22T19:12:58.510229Z",
+     "iopub.status.idle": "2026-08-22T19:12:58.652189Z",
+     "shell.execute_reply": "2026-08-22T19:12:58.651727Z"
     },
     "papermill": {
      "duration": 0.221607,
@@ -166,108 +284,146 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Catalogue KnownCompoundMetaheuristics (16 entr\u00e9es) :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Catalogue KnownCompoundMetaheuristics (16 entrées) :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - None\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - None\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - Default\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - Default\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - DefaultRandomHyperspeed\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - DefaultRandomHyperspeed\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - WhaleOptimisation\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - WhaleOptimisation\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - WhaleOptimisationNaive\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - WhaleOptimisationNaive\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - EquilibriumOptimizer\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - EquilibriumOptimizer\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - ForensicBasedInvestigation\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - ForensicBasedInvestigation\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - DifferentialEvolution\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - DifferentialEvolution\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - BareBonesParticleSwarm\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - BareBonesParticleSwarm\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - ParticleSwarmOptimization\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - ParticleSwarmOptimization\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - SimulatedAnnealing\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - SimulatedAnnealing\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - ScatterSearch\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - ScatterSearch\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - Islands5Default\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - Islands5Default\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - Islands5DefaultNoMigration\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - Islands5DefaultNoMigration\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - Islands5BestMixture\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - Islands5BestMixture\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - Islands5BestMixtureNoMigration\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - Islands5BestMixtureNoMigration\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "CreateMetaHeuristicByName(Default) -> DefaultMetaHeuristic\r\n"
+     "output_type": "stream",
+     "text": [
+      "CreateMetaHeuristicByName(Default) -> DefaultMetaHeuristic\r\n"
+     ]
     }
    ],
    "source": [
     "// Le catalogue vu par la lib (Reflection sur l'enum KnownCompoundMetaheuristics).\n",
     "var names = MetaHeuristicsService.GetMetaHeuristicNames();\n",
-    "Console.WriteLine(\"Catalogue KnownCompoundMetaheuristics (\" + names.Count + \" entr\u00e9es) :\");\n",
+    "Console.WriteLine(\"Catalogue KnownCompoundMetaheuristics (\" + names.Count + \" entrées) :\");\n",
     "foreach (var n in names) Console.WriteLine(\"  - \" + n);\n",
     "\n",
-    "// La factory : un seul appel construit n'importe quel compos\u00e9 par son nom.\n",
+    "// La factory : un seul appel construit n'importe quel composé par son nom.\n",
     "// Signature : CreateMetaHeuristicByName(name, maxGenerations=1000, populationSize=100,\n",
     "//                                       geometricConverter=null, noMutation=true)\n",
     "IMetaHeuristic demo = MetaHeuristicsService.CreateMetaHeuristicByName(\"Default\");\n",
@@ -291,9 +447,9 @@
    "source": [
     "## Le terrain commun : chromosome continu et banc d'essai\n",
     "\n",
-    "Les compos\u00e9s g\u00e9om\u00e9triques (WOA, EO, FBI) op\u00e8rent sur des g\u00e8nes **continus** lus comme des `double` via un `GeometricConverter`. Le chromosome `DoubleArrayChromosome` ci-dessous (r\u00e9plique minimale de l'assistant de test du fork) stocke des `double` nus : la conversion gene <-> double est donc l'identit\u00e9. C'est la repr\u00e9sentation commune sur laquelle nous lancerons chaque compos\u00e9.\n",
+    "Les composés géométriques (WOA, EO, FBI) opèrent sur des gènes **continus** lus comme des `double` via un `GeometricConverter`. Le chromosome `DoubleArrayChromosome` ci-dessous (réplique minimale de l'assistant de test du fork) stocke des `double` nus : la conversion gene <-> double est donc l'identité. C'est la représentation commune sur laquelle nous lancerons chaque composé.\n",
     "\n",
-    "Les fonctions test (`Sphere`, `Rastrigin`, `Rosenbrock`) sont d\u00e9finies **inline** plus bas pour garder ce notebook autonome (trois surfaces canoniques d'optimisation continue). Rappel : GeneticSharp *maximise*, les fonctions test *minimisent* -> la fitness est l'objectif **n\u00e9gativ\u00e9** (plus proche de 0 = meilleur). Le banc d'essai `RunBenchmark` c\u00e2ble un compos\u00e9 dans le moteur `MetaGeneticAlgorithm` (s\u00e9lection \u00e9litiste, croisement uniforme, mutation uniforme) et renvoie la meilleure fitness. `BuildViaFactory(name)` est le raccourci param\u00e9tr\u00e9 par nom que nous r\u00e9utiliserons pour chaque compos\u00e9.\n"
+    "Les fonctions test (`Sphere`, `Rastrigin`, `Rosenbrock`) sont définies **inline** plus bas pour garder ce notebook autonome (trois surfaces canoniques d'optimisation continue). Rappel : GeneticSharp *maximise*, les fonctions test *minimisent* -> la fitness est l'objectif **négativé** (plus proche de 0 = meilleur). Le banc d'essai `RunBenchmark` câble un composé dans le moteur `MetaGeneticAlgorithm` (sélection élitiste, croisement uniforme, mutation uniforme) et renvoie la meilleure fitness. `BuildViaFactory(name)` est le raccourci paramétré par nom que nous réutiliserons pour chaque composé.\n"
    ]
   },
   {
@@ -305,10 +461,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:37.509677Z",
-     "iopub.status.busy": "2026-08-18T23:56:37.508864Z",
-     "iopub.status.idle": "2026-08-18T23:56:38.267405Z",
-     "shell.execute_reply": "2026-08-18T23:56:38.266165Z"
+     "iopub.execute_input": "2026-08-22T19:12:58.653830Z",
+     "iopub.status.busy": "2026-08-22T19:12:58.653624Z",
+     "iopub.status.idle": "2026-08-22T19:12:58.935284Z",
+     "shell.execute_reply": "2026-08-22T19:12:58.935080Z"
     },
     "papermill": {
      "duration": 0.49574,
@@ -321,15 +477,17 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Harness + fonctions test inline + factory BuildViaFactory(name) pr\u00eats.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Harness + fonctions test inline + factory BuildViaFactory(name) prêts.\r\n"
+     ]
     }
    ],
    "source": [
-    "// DoubleArrayChromosome : chromosome minimal stockant des g\u00e8nes double nus.\n",
-    "// (Inspir\u00e9 de l'assistant de test MetaGeneticSharp.Domain.Tests.Geometric.DoubleArrayChromosome,\n",
-    "//  \u00e9tendu avec des bornes par g\u00e8ne pour que CreateNew() randomise la population initiale.)\n",
+    "// DoubleArrayChromosome : chromosome minimal stockant des gènes double nus.\n",
+    "// (Inspiré de l'assistant de test MetaGeneticSharp.Domain.Tests.Geometric.DoubleArrayChromosome,\n",
+    "//  étendu avec des bornes par gène pour que CreateNew() randomise la population initiale.)\n",
     "public class DoubleArrayChromosome : ChromosomeBase\n",
     "{\n",
     "    private readonly double _min;\n",
@@ -352,10 +510,10 @@
     "    public double[] GetDoubleValues() => GetGenes().Select(g => (double)g.Value).ToArray();\n",
     "}\n",
     "\n",
-    "// --- Fonctions test inline (objectif \u00e0 minimiser -> fitness = -objectif). ---\n",
-    "// Sphere :    f(x) = \u03a3 x_i\u00b2               minimum global 0 en 0.\n",
-    "// Rastrigin : f(x) = \u03a3 (x_i\u00b2 - 10 cos(2\u03c0 x_i)) + 10\u00b7n   minimum global 0 en 0.\n",
-    "// Rosenbrock: f(x) = \u03a3 [100(x_{i+1}-x_i\u00b2)\u00b2 + (1-x_i)\u00b2]  minimum global 0 en (1,...,1).\n",
+    "// --- Fonctions test inline (objectif à minimiser -> fitness = -objectif). ---\n",
+    "// Sphere :    f(x) = Σ x_i²               minimum global 0 en 0.\n",
+    "// Rastrigin : f(x) = Σ (x_i² - 10 cos(2π x_i)) + 10·n   minimum global 0 en 0.\n",
+    "// Rosenbrock: f(x) = Σ [100(x_{i+1}-x_i²)² + (1-x_i)²]  minimum global 0 en (1,...,1).\n",
     "\n",
     "public class SphereFitness : IFitness\n",
     "{\n",
@@ -402,7 +560,7 @@
     "const int PopSize = 60;\n",
     "const int Generations = 80;\n",
     "\n",
-    "// Banc d'essai : lance une m\u00e9taheuristique sur une fonction test, renvoie la meilleure fitness.\n",
+    "// Banc d'essai : lance une métaheuristique sur une fonction test, renvoie la meilleure fitness.\n",
     "double RunBenchmark(IFitness fitness, Type fitnessType, IMetaHeuristic mh, int dim = Dim)\n",
     "{\n",
     "    var (min, max) = Bounds(fitnessType);\n",
@@ -420,7 +578,7 @@
     "    return ga.BestChromosome.Fitness.HasValue ? ga.BestChromosome.Fitness.Value : double.NaN;\n",
     "}\n",
     "\n",
-    "// Raccourci factory param\u00e9tr\u00e9 par nom (c\u00e2ble automatiquement un convertisseur identit\u00e9 pour les g\u00e9om\u00e9triques).\n",
+    "// Raccourci factory paramétré par nom (câble automatiquement un convertisseur identité pour les géométriques).\n",
     "IMetaHeuristic BuildViaFactory(string name) =>\n",
     "    MetaHeuristicsService.CreateMetaHeuristicByName(name, maxGenerations: Generations, populationSize: PopSize);\n",
     "\n",
@@ -430,7 +588,7 @@
     "    (\"Rastrigin\",  typeof(RastriginFitness)),\n",
     "    (\"Rosenbrock\", typeof(RosenbrockFitness)),\n",
     "};\n",
-    "Console.WriteLine(\"Harness + fonctions test inline + factory BuildViaFactory(name) pr\u00eats.\");\n"
+    "Console.WriteLine(\"Harness + fonctions test inline + factory BuildViaFactory(name) prêts.\");\n"
    ]
   },
   {
@@ -449,15 +607,15 @@
    "source": [
     "## Le parcours en trois temps\n",
     "\n",
-    "Pour chaque compos\u00e9 g\u00e9om\u00e9trique (WOA, EO, FBI), la lib d\u00e9finit une classe qui h\u00e9rite de `GeometricMetaHeuristicBase`. Cette classe impl\u00e9mente `BuildMainHeuristic()` : c'est la **reconstruction depuis les primitives** \u2014 la m\u00e9thode qui assemble l'algorithme avec la grammaire fluente vue en MGS-2. Appeler `.Build()` (ou la factory) ex\u00e9cute cette reconstruction et renvoie l'arbre de primitives pr\u00eat \u00e0 l'emploi.\n",
+    "Pour chaque composé géométrique (WOA, EO, FBI), la lib définit une classe qui hérite de `GeometricMetaHeuristicBase`. Cette classe implémente `BuildMainHeuristic()` : c'est la **reconstruction depuis les primitives** — la méthode qui assemble l'algorithme avec la grammaire fluente vue en MGS-2. Appeler `.Build()` (ou la factory) exécute cette reconstruction et renvoie l'arbre de primitives prêt à l'emploi.\n",
     "\n",
-    "Nous allons donc, pour chaque compos\u00e9 :\n",
+    "Nous allons donc, pour chaque composé :\n",
     "\n",
-    "- lire sa fiche (m\u00e9taphore + \u00e9quations),\n",
-    "- **lire sa reconstruction** `BuildMainHeuristic()` \u2014 c'est l'impl\u00e9mentation, montr\u00e9e transparentement,\n",
-    "- appeler la factory et **prouver** qu'elle renvoie le m\u00eame type racine que la reconstruction (donc : m\u00eame arbre).\n",
+    "- lire sa fiche (métaphore + équations),\n",
+    "- **lire sa reconstruction** `BuildMainHeuristic()` — c'est l'implémentation, montrée transparentement,\n",
+    "- appeler la factory et **prouver** qu'elle renvoie le même type racine que la reconstruction (donc : même arbre).\n",
     "\n",
-    "Commen\u00e7ons par le plus c\u00e9l\u00e8bre : WOA.\n"
+    "Commençons par le plus célèbre : WOA.\n"
    ]
   },
   {
@@ -478,22 +636,22 @@
     "\n",
     "### Description\n",
     "\n",
-    "WOA (Mirjalili & Lewis, 2016) mime la **chasse en *bubble-net*** des baleines \u00e0 bosse. La m\u00e9canique se d\u00e9compose en trois comportements s\u00e9lectionn\u00e9s stochastiquement \u00e0 chaque g\u00e9n\u00e9ration :\n",
+    "WOA (Mirjalili & Lewis, 2016) mime la **chasse en *bubble-net*** des baleines à bosse. La mécanique se décompose en trois comportements sélectionnés stochastiquement à chaque génération :\n",
     "\n",
-    "- **Encerclement de la proie** : chaque baleine se rapproche de la meilleure solution connue (ou d'une solution al\u00e9atoire en phase d'exploration) par un d\u00e9placement lin\u00e9aire `D = |C\u00b7x_best - x|` puis `x <- x_best - A\u00b7D`.\n",
-    "- **Spirale *bubble-net*** (exploitation) : la baleine d\u00e9crit une h\u00e9lice autour de la meilleure proie : `x <- D'\u00b7exp(b\u00b7l)\u00b7cos(2\u03c0\u00b7l) + x_best`, avec `b` l'amplitude h\u00e9lico\u00efdale et `l` un angle al\u00e9atoire.\n",
-    "- **Recherche al\u00e9atoire** : quand `|A| > 1`, on se d\u00e9place vers un individu al\u00e9atoire (exploration globale).\n",
+    "- **Encerclement de la proie** : chaque baleine se rapproche de la meilleure solution connue (ou d'une solution aléatoire en phase d'exploration) par un déplacement linéaire `D = |C·x_best - x|` puis `x <- x_best - A·D`.\n",
+    "- **Spirale *bubble-net*** (exploitation) : la baleine décrit une hélice autour de la meilleure proie : `x <- D'·exp(b·l)·cos(2π·l) + x_best`, avec `b` l'amplitude hélicoïdale et `l` un angle aléatoire.\n",
+    "- **Recherche aléatoire** : quand `|A| > 1`, on se déplace vers un individu aléatoire (exploration globale).\n",
     "\n",
-    "Deux param\u00e8tres clef : **`a`** d\u00e9croit lin\u00e9airement de 2 \u00e0 0 (il pilote la bascule exploration -> exploitation via `A = 2a\u00b7r - a`), et **`b`** fixe la spirale. C'est exactement la fiche `mealpy` (`mealpy.evolutionary_based.WOA`), dont le fork reproduit les \u00e9quations.\n",
+    "Deux paramètres clef : **`a`** décroit linéairement de 2 à 0 (il pilote la bascule exploration -> exploitation via `A = 2a·r - a`), et **`b`** fixe la spirale. C'est exactement la fiche `mealpy` (`mealpy.evolutionary_based.WOA`), dont le fork reproduit les équations.\n",
     "\n",
     "### Reconstruction depuis les primitives\n",
     "\n",
-    "La classe `WhaleOptimisationAlgorithm.BuildMainHeuristic()` construit l'algorithme ainsi (code r\u00e9el de la lib, annot\u00e9) :\n",
+    "La classe `WhaleOptimisationAlgorithm.BuildMainHeuristic()` construit l'algorithme ainsi (code réel de la lib, annoté) :\n",
     "\n",
     "```csharp\n",
     "var woa = new IfElseMetaHeuristic()                 // tirage < 0.5 -> branche \"poursuite\", sinon -> bubble-net\n",
     "    .WithScope(EvolutionStage.Crossover)            // on intercepte le STAGE croisement\n",
-    "    .WithParam(\"a\",  ..., (h,ctx) => 2.0 - generation*(2.0/MaxGen))  // a d\u00e9cro\u00eet 2 -> 0\n",
+    "    .WithParam(\"a\",  ..., (h,ctx) => 2.0 - generation*(2.0/MaxGen))  // a décroît 2 -> 0\n",
     "    .WithParam(\"A\",  ..., (h,ctx,a) => 2*a*rnd - a)                  // Eq. (2.3)\n",
     "    .WithParam(\"C\",  ..., (h,ctx) => 2*rnd)                          // Eq. (2.4)\n",
     "    .WithParam(\"l\",  ..., (h,ctx,a2) => (a2-1)*rnd + 1.0)            // angle spirale\n",
@@ -501,18 +659,18 @@
     "    .WithTrue(                                        // POURSUITE (encerclement)\n",
     "        new IfElseMetaHeuristic()\n",
     "          .WithCaseGenerator(\"a\", (h,ctx,a) => Math.Abs(a) > 1)\n",
-    "          .WithTrue(new MatchMetaHeuristic()          // |a|>1 : cible AL\u00c9ATOIRE (exploration)\n",
+    "          .WithTrue(new MatchMetaHeuristic()          // |a|>1 : cible ALÉATOIRE (exploration)\n",
     "              .WithMatches(Current, Random)\n",
-    "              .WithCrossoverMetaHeuristic(encircling))// croisement lin\u00e9aire D=|C\u00b7x-A|\n",
+    "              .WithCrossoverMetaHeuristic(encircling))// croisement linéaire D=|C·x-A|\n",
     "          .WithFalse(new MatchMetaHeuristic()         // |a|<=1 : cible MEILLEURE (exploitation)\n",
     "              .WithMatches(Current, Best)\n",
     "              .WithCrossoverMetaHeuristic(encircling)))\n",
-    "    .WithFalse(new MatchMetaHeuristic()               // BUBBLE-NET : spirale h\u00e9lico\u00efdale\n",
+    "    .WithFalse(new MatchMetaHeuristic()               // BUBBLE-NET : spirale hélicoïdale\n",
     "        .WithMatches(Current, Best)\n",
-    "        .WithCrossoverMetaHeuristic(bubbleNet));       // D'\u00b7exp(b\u00b7l)\u00b7cos(2\u03c0\u00b7l)+best\n",
+    "        .WithCrossoverMetaHeuristic(bubbleNet));       // D'·exp(b·l)·cos(2π·l)+best\n",
     "```\n",
     "\n",
-    "Chaque ligne est une **primitive** : `IfElseMetaHeuristic` (dispatch bool\u00e9en), `MatchMetaHeuristic` (choix des parents par `MatchingKind.Current/Random/Best`), `CrossoverMetaHeuristic` + `GeometricCrossover` (l'op\u00e9rateur de d\u00e9placement continu), `WithParam` (param\u00e8tres d\u00e9pendants du contexte : g\u00e9n\u00e9ration, individu). Aucune bo\u00eete noire \u2014 tout est lisible et modifiable. C'est la r\u00e9ponse de MetaGeneticSharp \u00e0 Sorensen : on ne nie pas que WOA est une composition d'op\u00e9rateurs standards, on l'**expose** comme telle.\n"
+    "Chaque ligne est une **primitive** : `IfElseMetaHeuristic` (dispatch booléen), `MatchMetaHeuristic` (choix des parents par `MatchingKind.Current/Random/Best`), `CrossoverMetaHeuristic` + `GeometricCrossover` (l'opérateur de déplacement continu), `WithParam` (paramètres dépendants du contexte : génération, individu). Aucune boîte noire — tout est lisible et modifiable. C'est la réponse de MetaGeneticSharp à Sorensen : on ne nie pas que WOA est une composition d'opérateurs standards, on l'**expose** comme telle.\n"
    ]
   },
   {
@@ -524,10 +682,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:38.271523Z",
-     "iopub.status.busy": "2026-08-18T23:56:38.270625Z",
-     "iopub.status.idle": "2026-08-18T23:56:38.841526Z",
-     "shell.execute_reply": "2026-08-18T23:56:38.840699Z"
+     "iopub.execute_input": "2026-08-22T19:12:58.936675Z",
+     "iopub.status.busy": "2026-08-22T19:12:58.936477Z",
+     "iopub.status.idle": "2026-08-22T19:12:59.130008Z",
+     "shell.execute_reply": "2026-08-22T19:12:59.129822Z"
     },
     "papermill": {
      "duration": 0.555135,
@@ -540,38 +698,50 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "WOA via factory            : IfElseMetaHeuristic\r\n"
+     "output_type": "stream",
+     "text": [
+      "WOA via factory            : IfElseMetaHeuristic\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Type racine (GetMetaHeuristicTypeByName) : IfElseMetaHeuristic\r\n"
+     "output_type": "stream",
+     "text": [
+      "Type racine (GetMetaHeuristicTypeByName) : IfElseMetaHeuristic\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  == typeof(IfElseMetaHeuristic) ? True\r\n"
+     "output_type": "stream",
+     "text": [
+      "  == typeof(IfElseMetaHeuristic) ? True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  -> la factory renvoie bien l'arbre IfElse de la reconstruction ci-dessus.\r\n"
+     "output_type": "stream",
+     "text": [
+      "  -> la factory renvoie bien l'arbre IfElse de la reconstruction ci-dessus.\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "WOA sur Sphere (5D, 80 gen) -> fitness = -1,096E-12  (proche de 0 = bon)\r\n"
+     "output_type": "stream",
+     "text": [
+      "WOA sur Sphere (5D, 80 gen) -> fitness = -8,6682E-10  (proche de 0 = bon)\r\n"
+     ]
     }
    ],
    "source": [
-    "// --- WOA : raccourci factory + preuve d'\u00e9quivalence avec la reconstruction ---\n",
+    "// --- WOA : raccourci factory + preuve d'équivalence avec la reconstruction ---\n",
     "IMetaHeuristic woaViaFactory = BuildViaFactory(\"WhaleOptimisation\");\n",
     "Type woaRootViaFactory = MetaHeuristicsService.GetMetaHeuristicTypeByName(\"WhaleOptimisation\");\n",
     "\n",
@@ -582,7 +752,7 @@
     "Console.WriteLine(\"  -> la factory renvoie bien l'arbre IfElse de la reconstruction ci-dessus.\");\n",
     "Console.WriteLine();\n",
     "\n",
-    "// Ex\u00e9cution : WOA sur Sphere (unimodale lisse, terrain favorable au bubble-net).\n",
+    "// Exécution : WOA sur Sphere (unimodale lisse, terrain favorable au bubble-net).\n",
     "double woaSphere = RunBenchmark(new SphereFitness(), typeof(SphereFitness), woaViaFactory);\n",
     "Console.WriteLine(\"WOA sur Sphere (5D, \" + Generations + \" gen) -> fitness = \" + woaSphere.ToString(\"G5\") + \"  (proche de 0 = bon)\");\n"
    ]
@@ -605,27 +775,27 @@
     "\n",
     "### Description\n",
     "\n",
-    "EO (Faramarzi et al., 2019) est inspir\u00e9 du **bilan de masse en volume de contr\u00f4le** : on estime l'\u00e9tat d'\u00e9quilibre d'un syst\u00e8me dynamique. Le fork le porte directement depuis `mealpy.physics_based.EO`.\n",
+    "EO (Faramarzi et al., 2019) est inspiré du **bilan de masse en volume de contrôle** : on estime l'état d'équilibre d'un système dynamique. Le fork le porte directement depuis `mealpy.physics_based.EO`.\n",
     "\n",
-    "La m\u00e9canique : on garde un **pool d'\u00e9quilibre** des 4 meilleures solutions + leur **centro\u00efde**. Chaque particule se d\u00e9place vers ce point d'\u00e9quilibre pond\u00e9r\u00e9, avec un terme de **d\u00e9croissance exponentielle** du premier ordre qui ralentit le d\u00e9placement au fil des g\u00e9n\u00e9rations (taux `f = a1\u00b7sign(r-0.5)\u00b7(exp(-lambda\u00b7t) - 1)`). Un **generation control probability** `gcp` active ou non la mise \u00e0 jour, ce qui m\u00e9lange exploitation (vers l'\u00e9quilibre) et diversit\u00e9.\n",
+    "La mécanique : on garde un **pool d'équilibre** des 4 meilleures solutions + leur **centroïde**. Chaque particule se déplace vers ce point d'équilibre pondéré, avec un terme de **décroissance exponentielle** du premier ordre qui ralentit le déplacement au fil des générations (taux `f = a1·sign(r-0.5)·(exp(-lambda·t) - 1)`). Un **generation control probability** `gcp` active ou non la mise à jour, ce qui mélange exploitation (vers l'équilibre) et diversité.\n",
     "\n",
     "### Reconstruction depuis les primitives\n",
     "\n",
     "`EquilibriumOptimizer.BuildMainHeuristic()` :\n",
     "\n",
     "```csharp\n",
-    "var eo = new MatchMetaHeuristic()                  // compos\u00e9 = un Match principal\n",
-    "    .WithMatches(Current, Custom)                  // parent + cible \"custom\" (le centro\u00efde)\n",
+    "var eo = new MatchMetaHeuristic()                  // composé = un Match principal\n",
+    "    .WithMatches(Current, Custom)                  // parent + cible \"custom\" (le centroïde)\n",
     "    .WithCustomMatchStep(Best, AdditionalPicks=3)  // les 4 meilleures solutions (1+3)\n",
-    "    .WithChildMetaHeuristic(centroidHeuristic)     // GeometricCrossover 4-parents = moyenne (centro\u00efde)\n",
-    "    .WithCrossoverMetaHeuristic(generationHeuristic) // op\u00e9rateur EO : \u00e9q. bilan de masse + decay exp\n",
+    "    .WithChildMetaHeuristic(centroidHeuristic)     // GeometricCrossover 4-parents = moyenne (centroïde)\n",
+    "    .WithCrossoverMetaHeuristic(generationHeuristic) // opérateur EO : éq. bilan de masse + decay exp\n",
     "    .WithParam(\"t\",      (h,ctx) => GetTime(...))   // temps sans dimension Eq. 9\n",
-    "    .WithParam(\"lambda\", (h,ctx,n) => rnd x n genes)// par g\u00e8ne\n",
-    "    .WithParam(\"f\",      (h,ctx,t,l,r) => ExponentialRate) // d\u00e9croissance Eq. 11\n",
+    "    .WithParam(\"lambda\", (h,ctx,n) => rnd x n genes)// par gène\n",
+    "    .WithParam(\"f\",      (h,ctx,t,l,r) => ExponentialRate) // décroissance Eq. 11\n",
     "    .WithParam(\"gcp\",    (h,ctx,n,r1,r2) => GetGCP); // generation control Eq. 15\n",
     "```\n",
     "\n",
-    "L'id\u00e9e g\u00e9om\u00e9trique est limpide : `MatchMetaHeuristic` choisit les parents (les 4 meilleures + le centro\u00efde calcul\u00e9 par un croisement 4-parents), puis le `GeometricCrossover` applique l'\u00e9quation du bilan de masse. Encore une fois, l'algorithme \u00ab physique \u00bb se r\u00e9v\u00e8le \u00eatre une composition d'op\u00e9rateurs standards sur un croisement g\u00e9om\u00e9trique.\n"
+    "L'idée géométrique est limpide : `MatchMetaHeuristic` choisit les parents (les 4 meilleures + le centroïde calculé par un croisement 4-parents), puis le `GeometricCrossover` applique l'équation du bilan de masse. Encore une fois, l'algorithme « physique » se révèle être une composition d'opérateurs standards sur un croisement géométrique.\n"
    ]
   },
   {
@@ -637,10 +807,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:38.844169Z",
-     "iopub.status.busy": "2026-08-18T23:56:38.843597Z",
-     "iopub.status.idle": "2026-08-18T23:56:40.149001Z",
-     "shell.execute_reply": "2026-08-18T23:56:40.148576Z"
+     "iopub.execute_input": "2026-08-22T19:12:59.131331Z",
+     "iopub.status.busy": "2026-08-22T19:12:59.131164Z",
+     "iopub.status.idle": "2026-08-22T19:12:59.317268Z",
+     "shell.execute_reply": "2026-08-22T19:12:59.316905Z"
     },
     "papermill": {
      "duration": 0.561648,
@@ -653,28 +823,36 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "EO via factory  : MatchMetaHeuristic\r\n"
+     "output_type": "stream",
+     "text": [
+      "EO via factory  : MatchMetaHeuristic\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Type racine EO  : MatchMetaHeuristic  (== MatchMetaHeuristic ? True)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Type racine EO  : MatchMetaHeuristic  (== MatchMetaHeuristic ? True)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "EO sur Sphere -> fitness = -1,3627E-25\r\n"
+     "output_type": "stream",
+     "text": [
+      "EO sur Sphere -> fitness = -7,7364E-24\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     }
    ],
    "source": [
-    "// --- EO : raccourci factory + ex\u00e9cution ---\n",
+    "// --- EO : raccourci factory + exécution ---\n",
     "IMetaHeuristic eoViaFactory = BuildViaFactory(\"EquilibriumOptimizer\");\n",
     "Type eoRoot = MetaHeuristicsService.GetMetaHeuristicTypeByName(\"EquilibriumOptimizer\");\n",
     "Console.WriteLine(\"EO via factory  : \" + eoViaFactory.GetType().Name);\n",
@@ -703,32 +881,32 @@
     "\n",
     "### Description\n",
     "\n",
-    "FBI (Chou & Nguyen, 2020) mime le **processus d'enqu\u00eate polici\u00e8re** : localisation du suspect, enqu\u00eate, localisation de la poursuite. Le fork le porte depuis `mealpy.human_based.FBIO`. C'est un compos\u00e9 **multi-phase** : 4 \u00e9tapes (A1, A2, B1, B2) cycl\u00e9es \u00e0 chaque g\u00e9n\u00e9ration.\n",
+    "FBI (Chou & Nguyen, 2020) mime le **processus d'enquête policière** : localisation du suspect, enquête, localisation de la poursuite. Le fork le porte depuis `mealpy.human_based.FBIO`. C'est un composé **multi-phase** : 4 étapes (A1, A2, B1, B2) cyclées à chaque génération.\n",
     "\n",
-    "- **A1** (localisation) : on perturbe un g\u00e8ne al\u00e9atoire d'un individu avec un bruit gaussien combin\u00e9 \u00e0 deux t\u00e9moins al\u00e9atoires.\n",
-    "- **A2** (enqu\u00eate) : selon une probabilit\u00e9 li\u00e9e au rang de fitness de l'individu, on croise avec le meilleur + 3 t\u00e9moins (5-parent), sinon on ne fait rien (`NoOp`).\n",
-    "- **B1** : combinaison lin\u00e9aire entre courant et meilleur.\n",
-    "- **B2** : combinaison courant + al\u00e9atoire + meilleur, avec une branche d\u00e9pendant d'un drapeau `randomBetter`.\n",
+    "- **A1** (localisation) : on perturbe un gène aléatoire d'un individu avec un bruit gaussien combiné à deux témoins aléatoires.\n",
+    "- **A2** (enquête) : selon une probabilité liée au rang de fitness de l'individu, on croise avec le meilleur + 3 témoins (5-parent), sinon on ne fait rien (`NoOp`).\n",
+    "- **B1** : combinaison linéaire entre courant et meilleur.\n",
+    "- **B2** : combinaison courant + aléatoire + meilleur, avec une branche dépendant d'un drapeau `randomBetter`.\n",
     "\n",
     "### Reconstruction depuis les primitives\n",
     "\n",
-    "`ForensicBasedInvestigation.BuildMainHeuristic()` \u2014 c'est l'exemple le plus parlant de \u00ab composition de phases \u00bb :\n",
+    "`ForensicBasedInvestigation.BuildMainHeuristic()` — c'est l'exemple le plus parlant de « composition de phases » :\n",
     "\n",
     "```csharp\n",
     "var a1 = new MatchMetaHeuristic().WithMatches(Current, Random, Random)   // 3-parent + bruit gaussien\n",
     "                                  .WithCrossoverMetaHeuristic(A1Crossover);\n",
-    "var a2 = new IfElseMetaHeuristic()                                        // enqu\u00eate conditionnelle\n",
+    "var a2 = new IfElseMetaHeuristic()                                        // enquête conditionnelle\n",
     "            .WithCaseGenerator((h,ctx,prob) => rnd > prob)\n",
     "            .WithTrue(Match(Current,Best,Random,Random,Random))           // 5-parent\n",
     "            .WithFalse(new NoOpMetaHeuristic());                          // rien sinon\n",
     "var b1 = new MatchMetaHeuristic().WithMatches(Current, Best).WithCrossoverMetaHeuristic(B1Crossover);\n",
     "var b2 = new MatchMetaHeuristic().WithMatches(Current, Random, Best).WithCrossoverMetaHeuristic(B2Crossover);\n",
     "\n",
-    "var fbi = new GenerationMetaHeuristic(1, a1, a2, b1, b2)   // <-- 4 phases cycl\u00e9es\n",
+    "var fbi = new GenerationMetaHeuristic(1, a1, a2, b1, b2)   // <-- 4 phases cyclées\n",
     "              .WithScope(EvolutionStage.Crossover);\n",
     "```\n",
     "\n",
-    "La primitive clef ici est **`GenerationMetaHeuristic`** : elle cycle ses sous-heuristiques par num\u00e9ro de g\u00e9n\u00e9ration (cf. MGS-2). Un algorithme \u00ab humain \u00bb \u00e0 4 phases devient l'encha\u00eenement de 4 `MatchMetaHeuristic`/`IfElseMetaHeuristic` standards. Changer une phase (par ex. remplacer le bruit gaussien de A1) est une \u00e9dition locale \u2014 impossible dans une `mealpy.FBIO()` monolithique.\n"
+    "La primitive clef ici est **`GenerationMetaHeuristic`** : elle cycle ses sous-heuristiques par numéro de génération (cf. MGS-2). Un algorithme « humain » à 4 phases devient l'enchaînement de 4 `MatchMetaHeuristic`/`IfElseMetaHeuristic` standards. Changer une phase (par ex. remplacer le bruit gaussien de A1) est une édition locale — impossible dans une `mealpy.FBIO()` monolithique.\n"
    ]
   },
   {
@@ -740,10 +918,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:40.152467Z",
-     "iopub.status.busy": "2026-08-18T23:56:40.151825Z",
-     "iopub.status.idle": "2026-08-18T23:56:40.595529Z",
-     "shell.execute_reply": "2026-08-18T23:56:40.595196Z"
+     "iopub.execute_input": "2026-08-22T19:12:59.318710Z",
+     "iopub.status.busy": "2026-08-22T19:12:59.318481Z",
+     "iopub.status.idle": "2026-08-22T19:12:59.421750Z",
+     "shell.execute_reply": "2026-08-22T19:12:59.421396Z"
     },
     "papermill": {
      "duration": 0.198386,
@@ -756,28 +934,36 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "FBI via factory : GenerationMetaHeuristic\r\n"
+     "output_type": "stream",
+     "text": [
+      "FBI via factory : GenerationMetaHeuristic\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Type racine FBI : GenerationMetaHeuristic  (== GenerationMetaHeuristic ? True)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Type racine FBI : GenerationMetaHeuristic  (== GenerationMetaHeuristic ? True)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "FBI sur Sphere -> fitness = -7,5057E-26\r\n"
+     "output_type": "stream",
+     "text": [
+      "FBI sur Sphere -> fitness = -1,0514E-24\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     }
    ],
    "source": [
-    "// --- FBI : raccourci factory + ex\u00e9cution ---\n",
+    "// --- FBI : raccourci factory + exécution ---\n",
     "IMetaHeuristic fbiViaFactory = BuildViaFactory(\"ForensicBasedInvestigation\");\n",
     "Type fbiRoot = MetaHeuristicsService.GetMetaHeuristicTypeByName(\"ForensicBasedInvestigation\");\n",
     "Console.WriteLine(\"FBI via factory : \" + fbiViaFactory.GetType().Name);\n",
@@ -802,33 +988,33 @@
     "tags": []
    },
    "source": [
-    "## 4. Islands : la composition de compos\u00e9s\n",
+    "## 4. Islands : la composition de composés\n",
     "\n",
     "### Description\n",
     "\n",
-    "Le mod\u00e8le insulaire (d\u00e9j\u00e0 d\u00e9taill\u00e9 en MGS-4) partitionne la population en sous-populations (\u00ab \u00eeles \u00bb) \u00e9volu\u00e9es ind\u00e9pendamment, avec une **migration** p\u00e9riodique qui \u00e9change des individus. Le catalogue en expose deux variantes riches :\n",
+    "Le modèle insulaire (déjà détaillé en MGS-4) partitionne la population en sous-populations (« îles ») évoluées indépendamment, avec une **migration** périodique qui échange des individus. Le catalogue en expose deux variantes riches :\n",
     "\n",
-    "- **`Islands5Default`** : 5 \u00eeles homog\u00e8nes, toutes en `DefaultMetaHeuristic`, migration \u00ab ring \u00bb \u00e0 2 % (`MediumMigrationRate`). Une variante `NoMigration` d\u00e9sactive les \u00e9changes (\u00eeles isol\u00e9es).\n",
-    "- **`Islands5BestMixture`** : 5 \u00eeles **h\u00e9t\u00e9rog\u00e8nes** \u2014 2 \u00eeles WOA, 2 \u00eeles EO, 1 \u00eele GA \u2014 migration plus fine (0.5 %). C'est le cas d'\u00e9cole de la **composition de compos\u00e9s** : on m\u00e9lange des algorithmes complets dans un m\u00eame archipel.\n",
+    "- **`Islands5Default`** : 5 îles homogènes, toutes en `DefaultMetaHeuristic`, migration « ring » à 2 % (`MediumMigrationRate`). Une variante `NoMigration` désactive les échanges (îles isolées).\n",
+    "- **`Islands5BestMixture`** : 5 îles **hétérogènes** — 2 îles WOA, 2 îles EO, 1 île GA — migration plus fine (0.5 %). C'est le cas d'école de la **composition de composés** : on mélange des algorithmes complets dans un même archipel.\n",
     "\n",
     "### Reconstruction\n",
     "\n",
-    "Aucune magie : la factory instancie un `IslandCompoundMetaheuristic` (lui-m\u00eame un `IslandMetaHeuristic`) avec les compos\u00e9s voulus :\n",
+    "Aucune magie : la factory instancie un `IslandCompoundMetaheuristic` (lui-même un `IslandMetaHeuristic`) avec les composés voulus :\n",
     "\n",
     "```csharp\n",
-    "// Islands5Default : 5 \u00eeles identiques (GA), migration ring 2%.\n",
+    "// Islands5Default : 5 îles identiques (GA), migration ring 2%.\n",
     "var islandCompound = new IslandCompoundMetaheuristic(\n",
     "    populationSize / 5, 5, new SimpleCompoundMetaheuristic(new DefaultMetaHeuristic()));\n",
     "islandCompound.GlobalMigrationRate = IslandMetaHeuristic.MediumMigrationRate;\n",
     "\n",
-    "// Islands5BestMixture : archipel h\u00e9t\u00e9rog\u00e8ne 2 WOA + 2 EO + 1 GA.\n",
+    "// Islands5BestMixture : archipel hétérogène 2 WOA + 2 EO + 1 GA.\n",
     "var mix = new IslandCompoundMetaheuristic(populationSize,\n",
     "    (2, woaIsland),\n",
     "    (2, eoIsland),\n",
     "    (1, woaIsland));\n",
     "```\n",
     "\n",
-    "On voit ici tout l'int\u00e9r\u00eat de l'approche primitives-based : un hybride \u00ab \u00eeles WOA+EO \u00bb qui n'existe dans **aucune** biblioth\u00e8que monolithique s'\u00e9nonce en quelques lignes, parce que WOA et EO sont eux-m\u00eames des compos\u00e9s r\u00e9utilisables. C'est exactement le prolongement annonc\u00e9 en conclusion de MGS-6.\n"
+    "On voit ici tout l'intérêt de l'approche primitives-based : un hybride « îles WOA+EO » qui n'existe dans **aucune** bibliothèque monolithique s'énonce en quelques lignes, parce que WOA et EO sont eux-mêmes des composés réutilisables. C'est exactement le prolongement annoncé en conclusion de MGS-6.\n"
    ]
   },
   {
@@ -840,10 +1026,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:40.598722Z",
-     "iopub.status.busy": "2026-08-18T23:56:40.598141Z",
-     "iopub.status.idle": "2026-08-18T23:56:41.339973Z",
-     "shell.execute_reply": "2026-08-18T23:56:41.339713Z"
+     "iopub.execute_input": "2026-08-22T19:12:59.422984Z",
+     "iopub.status.busy": "2026-08-22T19:12:59.422799Z",
+     "iopub.status.idle": "2026-08-22T19:12:59.623431Z",
+     "shell.execute_reply": "2026-08-22T19:12:59.623170Z"
     },
     "papermill": {
      "duration": 0.541577,
@@ -856,33 +1042,43 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Islands5Default via factory : IslandMetaHeuristic\r\n"
+     "output_type": "stream",
+     "text": [
+      "Islands5Default via factory : IslandMetaHeuristic\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Type racine Islands         : IslandMetaHeuristic  (== IslandMetaHeuristic ? True)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Type racine Islands         : IslandMetaHeuristic  (== IslandMetaHeuristic ? True)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Islands5Default sur Sphere -> fitness = -0,026699\r\n"
+     "output_type": "stream",
+     "text": [
+      "Islands5Default sur Sphere -> fitness = -0,016137\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Islands5BestMixture sur Sphere -> fitness = -1,4432E-17\r\n"
+     "output_type": "stream",
+     "text": [
+      "Islands5BestMixture sur Sphere -> fitness = -1,3681E-20\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     }
    ],
    "source": [
-    "// --- Islands : raccourci factory (homog\u00e8ne + h\u00e9t\u00e9rog\u00e8ne) + ex\u00e9cution ---\n",
+    "// --- Islands : raccourci factory (homogène + hétérogène) + exécution ---\n",
     "IMetaHeuristic islandsHomog = BuildViaFactory(\"Islands5Default\");\n",
     "Type islandsRoot = MetaHeuristicsService.GetMetaHeuristicTypeByName(\"Islands5Default\");\n",
     "Console.WriteLine(\"Islands5Default via factory : \" + islandsHomog.GetType().Name);\n",
@@ -891,7 +1087,7 @@
     "double islSphere = RunBenchmark(new SphereFitness(), typeof(SphereFitness), islandsHomog);\n",
     "Console.WriteLine(\"Islands5Default sur Sphere -> fitness = \" + islSphere.ToString(\"G5\"));\n",
     "\n",
-    "// Variante h\u00e9t\u00e9rog\u00e8ne : 2 WOA + 2 EO + 1 GA (composition de compos\u00e9s).\n",
+    "// Variante hétérogène : 2 WOA + 2 EO + 1 GA (composition de composés).\n",
     "IMetaHeuristic islandsMix = BuildViaFactory(\"Islands5BestMixture\");\n",
     "double mixSphere = RunBenchmark(new SphereFitness(), typeof(SphereFitness), islandsMix);\n",
     "Console.WriteLine(\"Islands5BestMixture sur Sphere -> fitness = \" + mixSphere.ToString(\"G5\"));\n",
@@ -914,7 +1110,7 @@
    "source": [
     "## Vue d'ensemble : les quatre familles sur le banc\n",
     "\n",
-    "Pour comparer les compos\u00e9s g\u00e9om\u00e9triques entre eux (et avec les \u00eeles), nous lan\u00e7ons chacun sur les m\u00eames fonctions test. Rappel : fitness = objectif n\u00e9gativ\u00e9, donc la valeur la **moins n\u00e9gative** (la plus proche de 0) est la meilleure. L'objectif n'est pas de d\u00e9signer un \u00ab gagnant \u00bb (No Free Lunch : il n'y en a pas), mais de v\u00e9rifier que **chaque compos\u00e9 reconstruit depuis des primitives est un solveur fonctionnel et comp\u00e9titif** \u2014 la preuve que la reconstruction pr\u00e9serve le pouvoir d'optimisation.\n"
+    "Pour comparer les composés géométriques entre eux (et avec les îles), nous lançons chacun sur les mêmes fonctions test. Rappel : fitness = objectif négativé, donc la valeur la **moins négative** (la plus proche de 0) est la meilleure. L'objectif n'est pas de désigner un « gagnant » (No Free Lunch : il n'y en a pas), mais de vérifier que **chaque composé reconstruit depuis des primitives est un solveur fonctionnel et compétitif** — la preuve que la reconstruction préserve le pouvoir d'optimisation.\n"
    ]
   },
   {
@@ -926,10 +1122,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:41.341999Z",
-     "iopub.status.busy": "2026-08-18T23:56:41.341753Z",
-     "iopub.status.idle": "2026-08-18T23:56:45.043763Z",
-     "shell.execute_reply": "2026-08-18T23:56:45.043434Z"
+     "iopub.execute_input": "2026-08-22T19:12:59.624900Z",
+     "iopub.status.busy": "2026-08-22T19:12:59.624693Z",
+     "iopub.status.idle": "2026-08-22T19:13:00.726761Z",
+     "shell.execute_reply": "2026-08-22T19:13:00.726357Z"
     },
     "papermill": {
      "duration": 2.813811,
@@ -942,43 +1138,57 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Fonction         Default (GA)             WOA              EO             FBI Islands5BestMix\r\n"
+     "output_type": "stream",
+     "text": [
+      "Fonction         Default (GA)             WOA              EO             FBI Islands5BestMix\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "--------------------------------------------------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Sphere              -0,01373     -3,0539E-09     -1,3328E-24     -9,1548E-26     -3,3395E-15\r\n"
+     "output_type": "stream",
+     "text": [
+      "Sphere            -0,0066593     -1,6788E-09     -8,8624E-26     -3,0532E-25     -1,0447E-17\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Rastrigin           -0,89627         -6,1131         -3,9798     -1,2499E-08     -4,9738E-14\r\n"
+     "output_type": "stream",
+     "text": [
+      "Rastrigin            -2,2338         -13,686              -0              -0     -7,6869E-05\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Rosenbrock           -11,274         -1,0622         -3,3436         -3,7616         -3,5892\r\n"
+     "output_type": "stream",
+     "text": [
+      "Rosenbrock           -39,302         -2,5069         -3,2651          -3,715         -3,7076\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Chaque colonne est le m\u00eame type d'objet (IMetaHeuristic) construit en un appel de factory.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Chaque colonne est le même type d'objet (IMetaHeuristic) construit en un appel de factory.\r\n"
+     ]
     }
    ],
    "source": [
-    "// Grille de comparaison : Default + 4 familles de compos\u00e9s x 3 fonctions test.\n",
+    "// Grille de comparaison : Default + 4 familles de composés x 3 fonctions test.\n",
     "var configs = new (string Name, Func<IMetaHeuristic> Build)[]\n",
     "{\n",
     "    (\"Default (GA)\",    () => BuildViaFactory(\"Default\")),\n",
@@ -1003,7 +1213,7 @@
     "    Console.WriteLine(row);\n",
     "}\n",
     "Console.WriteLine();\n",
-    "Console.WriteLine(\"Chaque colonne est le m\u00eame type d'objet (IMetaHeuristic) construit en un appel de factory.\");\n"
+    "Console.WriteLine(\"Chaque colonne est le même type d'objet (IMetaHeuristic) construit en un appel de factory.\");\n"
    ]
   },
   {
@@ -1011,19 +1221,19 @@
    "id": "mgs5-debias-intro-md",
    "metadata": {},
    "source": [
-    "## Les nouveaux arrivants, sur le banc d\u00e9-biais\u00e9\n",
+    "## Les nouveaux arrivants, sur le banc dé-biaisé\n",
     "\n",
-    "La grille ci-dessus compare les quatre familles historiques du catalogue. Mais le catalogue (`KnownCompoundMetaheuristics`) contient aussi **trois compos\u00e9s plus r\u00e9cents** que cette grille ne montre pas : **`DifferentialEvolution`** (Storn & Price, 1997), **`BareBonesParticleSwarm`** (Kennedy, 2003) et **`SimulatedAnnealing`** (Kirkpatrick et al., 1983). La factory les construit exactement comme les autres -- un appel par nom.\n",
+    "La grille ci-dessus compare les quatre familles historiques du catalogue. Mais le catalogue (`KnownCompoundMetaheuristics`) contient aussi **trois composés plus récents** que cette grille ne montre pas : **`DifferentialEvolution`** (Storn & Price, 1997), **`BareBonesParticleSwarm`** (Kennedy, 2003) et **`SimulatedAnnealing`** (Kirkpatrick et al., 1983). La factory les construit exactement comme les autres -- un appel par nom.\n",
     "\n",
-    "Pour les d\u00e9montrer, on ne se contente pas du banc centr\u00e9 : on les confronte au **banc d\u00e9-biais\u00e9** (cf. [MGS-6](MGS-6-Benchmarks.ipynb) pour l'analyse compl\u00e8te du protocole). Rappel du probl\u00e8me : le harnais seede le chromosome *adam* au **milieu des bornes** -- sur l'optimum de Sphere et Rastrigin (fonctions \u00e0 optimum en z\u00e9ro, bornes sym\u00e9triques). Le protocole CEC d\u00e9place l'optimum hors du centre (`f_debias(x) = f(Q\u00b7x \u2212 offset)`, `Q` orthogonale seed\u00e9e, `offset` par dimension seed\u00e9) via les d\u00e9corateurs du fork :\n",
+    "Pour les démontrer, on ne se contente pas du banc centré : on les confronte au **banc dé-biaisé** (cf. [MGS-6](MGS-6-Benchmarks.ipynb) pour l'analyse complète du protocole). Rappel du problème : le harnais seede le chromosome *adam* au **milieu des bornes** -- sur l'optimum de Sphere et Rastrigin (fonctions à optimum en zéro, bornes symétriques). Le protocole CEC déplace l'optimum hors du centre (`f_debias(x) = f(Q·x − offset)`, `Q` orthogonale seedée, `offset` par dimension seedé) via les décorateurs du fork :\n",
     "\n",
     "```csharp\n",
-    "var offset = ShiftVectors.Seeded(Dim, 1.5, seed);   // ~30 % de la demi-\u00e9tendue [-5.12, 5.12]\n",
+    "var offset = ShiftVectors.Seeded(Dim, 1.5, seed);   // ~30 % de la demi-étendue [-5.12, 5.12]\n",
     "var Q      = RotationMatrices.Seeded(Dim, seed);\n",
     "var cec    = new RotatedFitness(new ShiftedFitness(inner, offset), Q);\n",
     "```\n",
     "\n",
-    "L'exp\u00e9rience est **appari\u00e9e** : chaque configuration (Default en r\u00e9f\u00e9rence + les trois nouveaux) tourne sur la version centr\u00e9e ET la version d\u00e9-biais\u00e9e de Sphere et Rastrigin, **3 runs ind\u00e9pendants par cellule** (moyenne -- le GA est stochastique). Question : **les nouveaux arrivants r\u00e9sistent-ils au retrait du cadeau du centre ?**"
+    "L'expérience est **appariée** : chaque configuration (Default en référence + les trois nouveaux) tourne sur la version centrée ET la version dé-biaisée de Sphere et Rastrigin, **3 runs indépendants par cellule** (moyenne -- le GA est stochastique). Question : **les nouveaux arrivants résistent-ils au retrait du cadeau du centre ?**"
    ]
   },
   {
@@ -1035,61 +1245,81 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:45.046221Z",
-     "iopub.status.busy": "2026-08-18T23:56:45.045685Z",
-     "iopub.status.idle": "2026-08-18T23:56:49.466955Z",
-     "shell.execute_reply": "2026-08-18T23:56:49.466501Z"
+     "iopub.execute_input": "2026-08-22T19:13:00.728247Z",
+     "iopub.status.busy": "2026-08-22T19:13:00.728022Z",
+     "iopub.status.idle": "2026-08-22T19:13:03.356917Z",
+     "shell.execute_reply": "2026-08-22T19:13:03.356615Z"
     }
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "seed=42  Q orthogonal: True  runs per cell=3\r\n"
+     "output_type": "stream",
+     "text": [
+      "seed=42  Q orthogonal: True  runs per cell=3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "(fitness = objectif negativ\u00e9, plus proche de 0 = meilleur; moyenne sur les runs)\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "(fitness = objectif negativé, plus proche de 0 = meilleur; moyenne sur les runs)\n",
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Sphere     |offset|_inf=  1,123  (optimum a Q^T*offset, hors centre)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Sphere     |offset|_inf=  1,123  (optimum a Q^T*offset, hors centre)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  centered :  Default (GA)         -0,0076366  DifferentialEvol    -2,5189E-11  BareBonesPSO        -6,4181E-21  SimulatedAnneal     -0,00090249\r\n"
+     "output_type": "stream",
+     "text": [
+      "  centered :  Default (GA)         -0,0068747  DifferentialEvol    -3,8737E-11  BareBonesPSO        -1,4291E-21  CanonicalPSO        -1,3712E-20  SimulatedAnneal     -0,00058158\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  shifted  :  Default (GA)         -0,0069615  DifferentialEvol    -2,1394E-11  BareBonesPSO        -1,3582E-21  SimulatedAnneal     -0,00068621\r\n"
+     "output_type": "stream",
+     "text": [
+      "  shifted  :  Default (GA)          -0,010811  DifferentialEvol     -9,088E-11  BareBonesPSO         -2,786E-21  CanonicalPSO        -3,6019E-22  SimulatedAnneal     -0,00064945\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Rastrigin  |offset|_inf=  1,123  (optimum a Q^T*offset, hors centre)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Rastrigin  |offset|_inf=  1,123  (optimum a Q^T*offset, hors centre)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  centered :  Default (GA)            -1,0743  DifferentialEvol        -1,3381  BareBonesPSO             -6,633  SimulatedAnneal         -1,9329\r\n"
+     "output_type": "stream",
+     "text": [
+      "  centered :  Default (GA)            -1,2941  DifferentialEvol       -0,39332  BareBonesPSO            -10,945  CanonicalPSO            -15,293  SimulatedAnneal         -1,9103\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  shifted  :  Default (GA)            -10,156  DifferentialEvol        -4,5969  BareBonesPSO            -18,121  SimulatedAnneal         -7,0557\r\n"
+     "output_type": "stream",
+     "text": [
+      "  shifted  :  Default (GA)            -6,5856  DifferentialEvol        -3,8168  BareBonesPSO            -7,9597  CanonicalPSO            -20,637  SimulatedAnneal         -6,1777\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\n--- Done: 4 configs x 2 fonctions a optimum-centre, centered vs shifted+rotated, 3 runs/cellule ---\r\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Done: 5 configs x 2 fonctions a optimum-centre, centered vs shifted+rotated, 3 runs/cellule ---\r\n"
+     ]
     }
    ],
    "source": [
-    "// Nouveaux compos\u00e9s (DE, BareBonesParticleSwarm, SimulatedAnnealing) via la factory,\n",
+    "// Nouveaux composés (DE, BareBonesPSO, PSO canonique à vélocité, SimulatedAnnealing) via la factory,\n",
     "// confrontes au banc de-biase (shifted+rotated CEC). Comparaison appariee centered-vs-debiased,\n",
     "// 3 runs par cellule (moyenne), Default en reference.\n",
     "int ndSeed  = 42;\n",
@@ -1100,6 +1330,12 @@
     "    (\"Default (GA)\",     () => BuildViaFactory(\"Default\")),\n",
     "    (\"DifferentialEvol\", () => BuildViaFactory(\"DifferentialEvolution\")),\n",
     "    (\"BareBonesPSO\",     () => BuildViaFactory(\"BareBonesParticleSwarm\")),\n",
+    "    // PSO canonique a velocite (#11977 axe 3) : recurrence Shi & Eberhart\n",
+    "    // w*v + c1*r1*(pbest-x) + c2*r2*(gbest-x), constantes Clerc. Ce n'est PAS\n",
+    "    // le bare-bones de Kennedy ci-dessus : les deux coexistent au catalogue\n",
+    "    // parce qu'elles incarnent deux lectures de \"essaim\" -- memorie par\n",
+    "    // particule (velocite + pbest) vs tirage gaussien sans etat.\n",
+    "    (\"CanonicalPSO\",     () => BuildViaFactory(\"ParticleSwarmOptimization\")),\n",
     "    (\"SimulatedAnneal\",  () => BuildViaFactory(\"SimulatedAnnealing\")),\n",
     "};\n",
     "\n",
@@ -1111,7 +1347,7 @@
     "\n",
     "var Qnd = RotationMatrices.Seeded(Dim, ndSeed);\n",
     "Console.WriteLine($\"seed={ndSeed}  Q orthogonal: {RotationMatrices.IsOrthogonal(Qnd)}  runs per cell={ndRuns}\");\n",
-    "Console.WriteLine(\"(fitness = objectif negativ\u00e9, plus proche de 0 = meilleur; moyenne sur les runs)\\n\");\n",
+    "Console.WriteLine(\"(fitness = objectif negativé, plus proche de 0 = meilleur; moyenne sur les runs)\\n\");\n",
     "\n",
     "double MeanRuns(IFitness f, Type t, Func<IMetaHeuristic> build) =>\n",
     "    Enumerable.Range(0, ndRuns).Select(_ => RunBenchmark(f, t, build())).Average();\n",
@@ -1135,7 +1371,7 @@
     "    Console.WriteLine(rowD);\n",
     "}\n",
     "\n",
-    "Console.WriteLine(\"\\n--- Done: 4 configs x 2 fonctions a optimum-centre, centered vs shifted+rotated, 3 runs/cellule ---\");"
+    "Console.WriteLine(\"\\n--- Done: 5 configs x 2 fonctions a optimum-centre, centered vs shifted+rotated, 3 runs/cellule ---\");"
    ]
   },
   {
@@ -1145,17 +1381,28 @@
    "source": [
     "### Lecture : les nouveaux arrivants passent le test -- mais le peloton se tasse\n",
     "\n",
-    "Rappel : fitness = objectif n\u00e9gativ\u00e9, plus proche de 0 = meilleur ; chaque cellule = moyenne sur 3 runs ; les deux lignes par fonction sont **appari\u00e9es** (m\u00eame harnais, seul l'optimum bouge : centre vs `Q^T\u00b7offset`, `Q orthogonal: True` en sortie).\n",
+    "Rappel : fitness = objectif négativé, plus proche de 0 = meilleur ; chaque cellule = moyenne sur 3 runs ; les deux lignes par fonction sont **appariées** (même harnais, seul l'optimum bouge : centre vs `Q^T·offset`, `Q orthogonal: True` en sortie).\n",
     "\n",
-    "1. **Sphere : aucun des nouveaux n'avait besoin du cadeau du centre.** DE et BBPSO convergent \u00e0 la pr\u00e9cision machine **des deux c\u00f4t\u00e9s** -- DE \u00e0 `-2,2824E-11` (centr\u00e9) et `-2,0894E-10` (d\u00e9-biais\u00e9), BBPSO \u00e0 `-4,0262E-20` et `-1,7391E-20`. \u00c0 ce niveau de pr\u00e9cision, l'\u00e9cart centered/shifted n'est pas mesurable : ces deux compos\u00e9s ne doivent rien \u00e0 la position de l'optimum sur une unimodale. C'est le comportement qu'on attend d'un vrai optimiseur -- et le contraste avec WOA dans [MGS-6](MGS-6-Benchmarks.ipynb), dont la marge s'\u00e9vaporait de neuf ordres de grandeur sur la m\u00eame fonction.\n",
+    "1. **Sphere : aucun des nouveaux n'avait besoin du cadeau du centre.** DE et BBPSO convergent à la précision machine **des deux côtés** -- DE à `-2,2824E-11` (centré) et `-2,0894E-10` (dé-biaisé), BBPSO à `-4,0262E-20` et `-1,7391E-20`. À ce niveau de précision, l'écart centered/shifted n'est pas mesurable : ces deux composés ne doivent rien à la position de l'optimum sur une unimodale. C'est le comportement qu'on attend d'un vrai optimiseur -- et le contraste avec WOA dans [MGS-6](MGS-6-Benchmarks.ipynb), dont la marge s'évaporait de neuf ordres de grandeur sur la même fonction.\n",
     "\n",
-    "2. **Rastrigin : DE r\u00e9siste au d\u00e9-biais.** Premier des deux c\u00f4t\u00e9s -- `-0,88694` centr\u00e9, `-6,2631` d\u00e9-biais\u00e9 -- devant Default (`-1,2454` / `-7,1297`). Mais la marge **fond** : l'\u00e9cart relatif Default/DE passe de **\u00d71,40** (centr\u00e9) \u00e0 **\u00d71,14** (d\u00e9-biais\u00e9). Le leadership tient, il est moins \u00e9crasant.\n",
+    "2. **Rastrigin : DE résiste au dé-biais.** Premier des deux côtés -- `-0,88694` centré, `-6,2631` dé-biaisé -- devant Default (`-1,2454` / `-7,1297`). Mais la marge **fond** : l'écart relatif Default/DE passe de **×1,40** (centré) à **×1,14** (dé-biaisé). Le leadership tient, il est moins écrasant.\n",
     "\n",
-    "3. **La queue se redistribue.** Au centre, SA (`-2,5855`) devance BBPSO (`-9,6179`). D\u00e9-biais\u00e9, c'est invers\u00e9 : BBPSO `-7,9597` devant SA `-8,0833`. Le recuit simul\u00e9, qui accepte des pas d\u00e9gradants calibr\u00e9s sur la g\u00e9om\u00e9trie du paysage, perd son avantage quand la rotation d\u00e9saxe les vall\u00e9es ; BBPSO, qui resample autour des meilleures solutions, y gagne relativement.\n",
+    "3. **La queue se redistribue.** Au centre, SA (`-2,5855`) devance BBPSO (`-9,6179`). Dé-biaisé, c'est inversé : BBPSO `-7,9597` devant SA `-8,0833`. Le recuit simulé, qui accepte des pas dégradants calibrés sur la géométrie du paysage, perd son avantage quand la rotation désaxe les vallées ; BBPSO, qui resample autour des meilleures solutions, y gagne relativement.\n",
     "\n",
-    "Verdict honn\u00eate : **les trois nouveaux compos\u00e9s sortent du banc d\u00e9-biais\u00e9 sans faux champion** -- DE confirme un leadership r\u00e9el (il tient sans le centre), BBPSO montre une robustesse de pr\u00e9cision machine, et aucun classement ne reposait sur le seeding au centre. La signature de biais de Kudela, qui renversait 3 des 4 fonctions dans MGS-6 pour les familles historiques, ne renverse ici ni le vainqueur de Sphere ni celui de Rastrigin ; elle resserre les marges et redistribue la queue. R\u00e9serve de m\u00e9thode identique \u00e0 MGS-6 : 3 runs d\u00e9partagent les \u00e9carts nets, pas les \u00e9carts serr\u00e9s (SA vs BBPSO d\u00e9-biais\u00e9 : 0,12 d'\u00e9cart sur une moyenne de 3).\n",
+    "Verdict honnête : **les trois nouveaux composés sortent du banc dé-biaisé sans faux champion** -- DE confirme un leadership réel (il tient sans le centre), BBPSO montre une robustesse de précision machine, et aucun classement ne reposait sur le seeding au centre. La signature de biais de Kudela, qui renversait 3 des 4 fonctions dans MGS-6 pour les familles historiques, ne renverse ici ni le vainqueur de Sphere ni celui de Rastrigin ; elle resserre les marges et redistribue la queue. Réserve de méthode identique à MGS-6 : 3 runs départagent les écarts nets, pas les écarts serrés (SA vs BBPSO dé-biaisé : 0,12 d'écart sur une moyenne de 3).\n",
     "\n",
-    "Et toujours le m\u00eame argument d'architecture : cette section n'a **aucun nouvel algorithme** \u00e0 \u00e9crire -- trois noms de factory en plus, deux d\u00e9corateurs compos\u00e9s, z\u00e9ro modification du moteur."
+    "Et toujours le même argument d'architecture : cette section n'a **aucun nouvel algorithme** à écrire -- trois noms de factory en plus, deux décorateurs composés, zéro modification du moteur.\n",
+    "\n",
+    "**Le PSO canonique à vélocité entre au banc (#11977 axe 3).** La ligne\n",
+    "`CanonicalPSO` est la récurrence de Shi & Eberhart — inertie `w`, termes\n",
+    "cognitif `c1` et social `c2`, mémoire de vitesse et de `pbest` par particule —\n",
+    "livrée dans la lib par #12030. La comparer au `BareBonesPSO` de la même table\n",
+    "n'est pas une coquetterie de catalogue : le bare-bones de Kennedy **supprime**\n",
+    "précisément la récurrence vitesse/position au profit d'un tirage gaussien centré\n",
+    "sur `(pbest+gbest)/2`. Les deux lignes mesurent donc ce que cette mémoire\n",
+    "apporte (ou coûte) sur le même banc dé-biaisé — la lecture se fait sur les\n",
+    "chiffres ci-dessus, pas sur la métaphore. Pour la confrontation lib-vs-lib à\n",
+    "moteur égal (MGS vs `mealpy`, même grille de sudoku), voir MGS-22."
    ]
   },
   {
@@ -1163,66 +1410,86 @@
    "id": "c29",
    "metadata": {},
    "source": [
-    "## Deuxi\u00e8me vague : les quatre briques de la derni\u00e8re fusion\n",
+    "## Deuxième vague : les quatre briques de la dernière fusion\n",
     "\n",
-    "Le fork [MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) vient d'absorber quatre nouvelles briques (PRs fork #45 \u00e0 #48). La r\u00e9partition est le point p\u00e9dagogique : **une seule** entre au catalogue `KnownCompoundMetaheuristics` et se construit par la factory ; les trois autres se construisent **directement** -- et c'est la th\u00e8se compositionnelle du cours en acte.\n",
+    "Le fork [MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) vient d'absorber quatre nouvelles briques (PRs fork #45 à #48). La répartition est le point pédagogique : **une seule** entre au catalogue `KnownCompoundMetaheuristics` et se construit par la factory ; les trois autres se construisent **directement** -- et c'est la thèse compositionnelle du cours en acte.\n",
     "\n",
-    "| Brique | Nature | R\u00e9f\u00e9rence |\n",
+    "| Brique | Nature | Référence |\n",
     "|---|---|---|\n",
-    "| **ScatterSearch** | compos\u00e9 du catalogue (nouvelle entr\u00e9e `enum` + factory) | Glover, *A Template for Scatter Search and Path Relinking*, 1998 ; Laguna & Marti, 2003 |\n",
-    "| **MemeticAlgorithm** | *wrapper* : emballe n'importe quel `ICompoundMetaheuristic` et y greffe une couche d'am\u00e9lioration locale | Moscato, *On Evolution, Search, Optimization, Genetic Algorithms and Martial Arts*, 1989 |\n",
-    "| **Primitives Tabu** | pi\u00e8ces d\u00e9tach\u00e9es : projections, m\u00e9moires (recency / frequency / reactive / hybrid), filtres (strict / aspiration), `TabuHillClimb` | recherche tabou : Glover, 1986 ; d\u00e9couplage du monolithe `DiscreteTS` de ygmh (Hernandez & Gonzalez, *Metaheuristics in C#*) |\n",
-    "| **DiscreteSwapPSO** | PSO o\u00f9 la v\u00e9locit\u00e9 est une *distribution sur des transpositions* (alg\u00e8bre `Minus` / `Move` / `Times`) | port du `DiscretePSO` de ygmh (Hernandez & Gonzalez) |\n",
+    "| **ScatterSearch** | composé du catalogue (nouvelle entrée `enum` + factory) | Glover, *A Template for Scatter Search and Path Relinking*, 1998 ; Laguna & Marti, 2003 |\n",
+    "| **MemeticAlgorithm** | *wrapper* : emballe n'importe quel `ICompoundMetaheuristic` et y greffe une couche d'amélioration locale | Moscato, *On Evolution, Search, Optimization, Genetic Algorithms and Martial Arts*, 1989 |\n",
+    "| **Primitives Tabu** | pièces détachées : projections, mémoires (recency / frequency / reactive / hybrid), filtres (strict / aspiration), `TabuHillClimb` | recherche tabou : Glover, 1986 ; découplage du monolithe `DiscreteTS` de ygmh (Hernandez & Gonzalez, *Metaheuristics in C#*) |\n",
+    "| **DiscreteSwapPSO** | PSO où la vélocité est une *distribution sur des transpositions* (algèbre `Minus` / `Move` / `Times`) | port du `DiscretePSO` de ygmh (Hernandez & Gonzalez) |\n",
     "\n",
-    "`MemeticAlgorithm` n'est pas un \u00ab nouvel algorithme \u00bb : c'est un **emballage**. Sa documentation le dit explicitement -- `ImproveOperator == null` d\u00e9sactive la couche (pass-through pur), le wrapper se contente alors d'encha\u00eener le compos\u00e9 interne. Arm\u00e9 d'un op\u00e9rateur, il applique une am\u00e9lioration locale au meilleur chromosome \u00e0 chaque g\u00e9n\u00e9ration (`ImprovementCount` chromosome(s) am\u00e9lior\u00e9s par g\u00e9n\u00e9ration).\n",
+    "`MemeticAlgorithm` n'est pas un « nouvel algorithme » : c'est un **emballage**. Sa documentation le dit explicitement -- `ImproveOperator == null` désactive la couche (pass-through pur), le wrapper se contente alors d'enchaîner le composé interne. Armé d'un opérateur, il applique une amélioration locale au meilleur chromosome à chaque génération (`ImprovementCount` chromosome(s) améliorés par génération).\n",
     "\n",
-    "L'exp\u00e9rience monte l'\u00e9chelle compl\u00e8te. D'abord ScatterSearch et DiscreteSwapPSO sur le banc appari\u00e9 Rastrigin (centr\u00e9 vs d\u00e9-biais\u00e9, m\u00eame protocole que la premi\u00e8re vague). Puis `Memetic(ScatterSearch)` **arm\u00e9 d'un hill-climb tabou** construit sur les primitives -- trois briques sur quatre dans une seule construction."
+    "L'expérience monte l'échelle complète. D'abord ScatterSearch et DiscreteSwapPSO sur le banc apparié Rastrigin (centré vs dé-biaisé, même protocole que la première vague). Puis `Memetic(ScatterSearch)` **armé d'un hill-climb tabou** construit sur les primitives -- trois briques sur quatre dans une seule construction."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "c30",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-08-22T19:13:03.358772Z",
+     "iopub.status.busy": "2026-08-22T19:13:03.358450Z",
+     "iopub.status.idle": "2026-08-22T19:13:08.593949Z",
+     "shell.execute_reply": "2026-08-22T19:13:08.593762Z"
     }
    },
-   "execution_count": 10,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "ScatterSearch au catalogue : True (sur 16 entrees)\r\n"
+     "output_type": "stream",
+     "text": [
+      "ScatterSearch au catalogue : True (sur 16 entrees)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "fitness = objectif negativ\u00e9, plus proche de 0 = meilleur ; moyenne sur les runs\r\n"
+     "output_type": "stream",
+     "text": [
+      "fitness = objectif negativé, plus proche de 0 = meilleur ; moyenne sur les runs\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "config                      centr\u00e9        d\u00e9-biais\u00e9\r\n"
+     "output_type": "stream",
+     "text": [
+      "config                      centré        dé-biaisé\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Default (GA)             -0,472001         -6,77962\r\n"
+     "output_type": "stream",
+     "text": [
+      "Default (GA)              -1,09737         -11,5217\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "ScatterSearch             -3,43736         -2,61791\r\n"
+     "output_type": "stream",
+     "text": [
+      "ScatterSearch             -4,74636         -4,01343\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "DiscreteSwapPSO           -38,0009          -51,471\r\n"
+     "output_type": "stream",
+     "text": [
+      "DiscreteSwapPSO           -50,4389         -49,4892\r\n"
+     ]
     }
    ],
    "source": [
@@ -1233,7 +1500,7 @@
     "var namesWave2 = MetaHeuristicsService.GetMetaHeuristicNames();\n",
     "bool scatterInCatalog = namesWave2.Contains(\"ScatterSearch\");\n",
     "Console.WriteLine($\"ScatterSearch au catalogue : {scatterInCatalog} (sur {namesWave2.Count} entrees)\");\n",
-    "Console.WriteLine(\"fitness = objectif negativ\u00e9, plus proche de 0 = meilleur ; moyenne sur les runs\");\n",
+    "Console.WriteLine(\"fitness = objectif negativé, plus proche de 0 = meilleur ; moyenne sur les runs\");\n",
     "Console.WriteLine();\n",
     "\n",
     "var wave2Configs = new (string Name, Func<IMetaHeuristic> Build)[]\n",
@@ -1248,7 +1515,7 @@
     "var offsetWave2 = ShiftVectors.Seeded(Dim, 1.5, ndSeed);\n",
     "var cecWave2 = new RotatedFitness(new ShiftedFitness(rastriginInner, offsetWave2), Qnd);\n",
     "\n",
-    "Console.WriteLine(\"{0,-17} {1,16} {2,16}\", \"config\", \"centr\u00e9\", \"d\u00e9-biais\u00e9\");\n",
+    "Console.WriteLine(\"{0,-17} {1,16} {2,16}\", \"config\", \"centré\", \"dé-biaisé\");\n",
     "foreach (var (cfgName, build) in wave2Configs)\n",
     "{\n",
     "    double centered = Enumerable.Range(0, ndRuns).Select(_ => RunBenchmark(rastriginInner, rastriginType, build())).Average();\n",
@@ -1262,44 +1529,58 @@
    "id": "c31",
    "metadata": {},
    "source": [
-    "### Lecture : ScatterSearch r\u00e9siste au d\u00e9-biais, DiscreteSwapPSO paye l'inad\u00e9quation du domaine\n",
+    "### Lecture : ScatterSearch résiste au dé-biais, DiscreteSwapPSO paye l'inadéquation du domaine\n",
     "\n",
-    "Rappel : fitness = objectif n\u00e9gativ\u00e9, plus proche de 0 = meilleur ; moyenne sur 3 runs ; le d\u00e9corateur d\u00e9-biais\u00e9 est **le m\u00eame que celui de la premi\u00e8re vague** (m\u00eame seed -- m\u00eame `offset`, m\u00eame rotation `Qnd`), donc la colonne \u00ab d\u00e9-biais\u00e9 \u00bb est comparable d'une vague \u00e0 l'autre.\n",
+    "Rappel : fitness = objectif négativé, plus proche de 0 = meilleur ; moyenne sur 3 runs ; le décorateur dé-biaisé est **le même que celui de la première vague** (même seed -- même `offset`, même rotation `Qnd`), donc la colonne « dé-biaisé » est comparable d'une vague à l'autre.\n",
     "\n",
-    "1. **ScatterSearch entre au catalogue et passe le test difficile.** D\u00e9-biais\u00e9 : `-2,61791` contre `-6,77962` pour Default sur la m\u00eame ex\u00e9cution -- l'\u00e9cart (\u00d72,6) d\u00e9passe la d\u00e9rive inter-ex\u00e9cutions du m\u00eame Default d'une vague \u00e0 l'autre (`-10,156` en premi\u00e8re vague, `-6,7796` ici, soit \u00d71,5) : l'avantage reste au-del\u00e0 du bruit de re-tirage, quoique moins dramatiquement que le centr\u00e9 (\u00d77,3). La raison tient au m\u00e9canisme : le reference-set conserve une fraction de membres choisis par **diversit\u00e9 max-min**, pas seulement par qualit\u00e9 -- la recherche ne s'engouffre pas dans le bassin d'attraction du point de d\u00e9part, pr\u00e9cis\u00e9ment l\u00e0 o\u00f9 le d\u00e9centrage de l'optimum pi\u00e8ge les m\u00e9thodes gourmandes en exploitation. Sur cette ex\u00e9cution, ScatterSearch est le meilleur d\u00e9-biais\u00e9 des deux vagues confondues (premi\u00e8re vague : DE `-4,5969`, SA `-7,0557`, BBPSO `-18,121`, Default `-10,156`).\n",
+    "1. **ScatterSearch entre au catalogue et passe le test difficile.** Dé-biaisé : `-2,61791` contre `-6,77962` pour Default sur la même exécution -- l'écart (×2,6) dépasse la dérive inter-exécutions du même Default d'une vague à l'autre (`-10,156` en première vague, `-6,7796` ici, soit ×1,5) : l'avantage reste au-delà du bruit de re-tirage, quoique moins dramatiquement que le centré (×7,3). La raison tient au mécanisme : le reference-set conserve une fraction de membres choisis par **diversité max-min**, pas seulement par qualité -- la recherche ne s'engouffre pas dans le bassin d'attraction du point de départ, précisément là où le décentrage de l'optimum piège les méthodes gourmandes en exploitation. Sur cette exécution, ScatterSearch est le meilleur dé-biaisé des deux vagues confondues (première vague : DE `-4,5969`, SA `-7,0557`, BBPSO `-18,121`, Default `-10,156`).\n",
     "\n",
-    "2. **DiscreteSwapPSO : le contre-exemple instructif.** `-38,0009` / `-51,471`, loin derri\u00e8re tout le plateau. Ce n'est pas un d\u00e9faut d'impl\u00e9mentation mais une **inad\u00e9quation de domaine** : la v\u00e9locit\u00e9 de ce PSO est une distribution sur des *transpositions* -- elle r\u00e9arrange des valeurs existantes, elle n'en fabrique pas. Sur des g\u00e8nes continus, aucun r\u00e9arrangement ne peut raffiner vers l'optimum. L'op\u00e9rateur est fait pour les espaces de permutations, o\u00f9 \u00ab d\u00e9placer un occupant vers sa position cible \u00bb est pr\u00e9cis\u00e9ment le bon geste -- ce sera l'arme naturelle sur le TSP de [MGS-7](MGS-7-TSP.ipynb). Le catalogue ne promet pas l'universalit\u00e9 : chaque brique a son domaine."
+    "2. **DiscreteSwapPSO : le contre-exemple instructif.** `-38,0009` / `-51,471`, loin derrière tout le plateau. Ce n'est pas un défaut d'implémentation mais une **inadéquation de domaine** : la vélocité de ce PSO est une distribution sur des *transpositions* -- elle réarrange des valeurs existantes, elle n'en fabrique pas. Sur des gènes continus, aucun réarrangement ne peut raffiner vers l'optimum. L'opérateur est fait pour les espaces de permutations, où « déplacer un occupant vers sa position cible » est précisément le bon geste -- ce sera l'arme naturelle sur le TSP de [MGS-7](MGS-7-TSP.ipynb). Le catalogue ne promet pas l'universalité : chaque brique a son domaine."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "c32",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-08-22T19:13:08.595326Z",
+     "iopub.status.busy": "2026-08-22T19:13:08.595136Z",
+     "iopub.status.idle": "2026-08-22T19:13:20.018189Z",
+     "shell.execute_reply": "2026-08-22T19:13:20.017844Z"
     }
    },
-   "execution_count": 11,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "config                         centr\u00e9        d\u00e9-biais\u00e9\r\n"
+     "output_type": "stream",
+     "text": [
+      "config                         centré        dé-biaisé\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "SS nu                        -2,30094          -6,2467\r\n"
+     "output_type": "stream",
+     "text": [
+      "SS nu                        -4,24116         -6,25822\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Memetic(SS) inerte           -6,31368         -5,63601\r\n"
+     "output_type": "stream",
+     "text": [
+      "Memetic(SS) inerte           -4,26159         -4,94617\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Memetic(SS)+tabou            -4,86159         -6,17512\r\n"
+     "output_type": "stream",
+     "text": [
+      "Memetic(SS)+tabou             -8,2761         -5,05199\r\n"
+     ]
     }
    ],
    "source": [
@@ -1347,7 +1628,7 @@
     "\n",
     "var ladderInner = (IFitness)Activator.CreateInstance(rastriginType);\n",
     "\n",
-    "Console.WriteLine(\"{0,-20} {1,16} {2,16}\", \"config\", \"centr\u00e9\", \"d\u00e9-biais\u00e9\");\n",
+    "Console.WriteLine(\"{0,-20} {1,16} {2,16}\", \"config\", \"centré\", \"dé-biaisé\");\n",
     "foreach (var (name, build) in ladderConfigs)\n",
     "{\n",
     "    double c = Enumerable.Range(0, ndRuns).Select(_ => RunBenchmark(ladderInner, rastriginType, build(ladderInner))).Average();\n",
@@ -1371,13 +1652,13 @@
    "id": "c33",
    "metadata": {},
    "source": [
-    "### Lecture : l'\u00e9chelle prouve la composition, pas un classement\n",
+    "### Lecture : l'échelle prouve la composition, pas un classement\n",
     "\n",
-    "1. **Trois barreaux, une seule bande.** De `-2,3` \u00e0 `-6,3` selon la colonne : \u00e0 ce budget (80 g\u00e9n\u00e9rations, 60 individus, 3 runs), la variance inter-trajectoires domine les diff\u00e9rences entre barreaux. D\u00e9tail r\u00e9v\u00e9lateur : le barreau **inerte** (`-6,31368` centr\u00e9) fait mieux que SS nu (`-2,30094`) alors que sa couche d'am\u00e9lioration est d\u00e9sactiv\u00e9e. La neutralit\u00e9 du wrapper est **structurelle** -- `ImproveOperator == null`, aucune \u00e9valuation ajout\u00e9e, aucun individu modifi\u00e9 -- mais pas **trajectorielle** : l'arbre d'op\u00e9rateurs compte un conteneur de plus, le flux RNG est consomm\u00e9 diff\u00e9remment, et sur un paysage multimodal comme Rastrigin deux trajectoires distinctes \u00e0 budget \u00e9gal peuvent atterrir dans des bassins diff\u00e9rents. Un benchmark \u00e0 3 runs s\u00e9pare le m\u00e9canisme du bruit -- le protocole complet (multi-runs, fonctions multiples) est l'objet de [MGS-6](MGS-6-Benchmarks.ipynb).\n",
+    "1. **Trois barreaux, une seule bande.** De `-2,3` à `-6,3` selon la colonne : à ce budget (80 générations, 60 individus, 3 runs), la variance inter-trajectoires domine les différences entre barreaux. Détail révélateur : le barreau **inerte** (`-6,31368` centré) fait mieux que SS nu (`-2,30094`) alors que sa couche d'amélioration est désactivée. La neutralité du wrapper est **structurelle** -- `ImproveOperator == null`, aucune évaluation ajoutée, aucun individu modifié -- mais pas **trajectorielle** : l'arbre d'opérateurs compte un conteneur de plus, le flux RNG est consommé différemment, et sur un paysage multimodal comme Rastrigin deux trajectoires distinctes à budget égal peuvent atterrir dans des bassins différents. Un benchmark à 3 runs sépare le mécanisme du bruit -- le protocole complet (multi-runs, fonctions multiples) est l'objet de [MGS-6](MGS-6-Benchmarks.ipynb).\n",
     "\n",
-    "2. **Ce que l'\u00e9chelle prouve est m\u00e9canique.** Les briques s'embo\u00eetent sans toucher au compos\u00e9 interne : `ScatterSearch` -- reconstruit ici \u00e0 la main avec le convertisseur identit\u00e9 que la factory mat\u00e9rialise d'ordinaire pour nous -- entre dans `MemeticAlgorithm` (wrapper), qui re\u00e7oit un op\u00e9rateur `TabuHillClimb.Improvement` c\u00e2bl\u00e9 sur trois pi\u00e8ces d\u00e9tach\u00e9es : projection (`SolutionHashProjection` : l'attribut interdit est la solution enti\u00e8re), m\u00e9moire (`RecencyTabuMemory(32)` : file FIFO des 32 derniers attributs), filtre (`AspirationOnBestFilter` : l'interdit se l\u00e8ve si le candidat bat le meilleur jamais vu). Aucune de ces classes n'en conna\u00eet une autre ; toutes trois sont inject\u00e9es.\n",
+    "2. **Ce que l'échelle prouve est mécanique.** Les briques s'emboîtent sans toucher au composé interne : `ScatterSearch` -- reconstruit ici à la main avec le convertisseur identité que la factory matérialise d'ordinaire pour nous -- entre dans `MemeticAlgorithm` (wrapper), qui reçoit un opérateur `TabuHillClimb.Improvement` câblé sur trois pièces détachées : projection (`SolutionHashProjection` : l'attribut interdit est la solution entière), mémoire (`RecencyTabuMemory(32)` : file FIFO des 32 derniers attributs), filtre (`AspirationOnBestFilter` : l'interdit se lève si le candidat bat le meilleur jamais vu). Aucune de ces classes n'en connaît une autre ; toutes trois sont injectées.\n",
     "\n",
-    "3. **L'armement tabou : un signal, pas un verdict.** D\u00e9-biais\u00e9 `-6,17512` contre `-5,63601` pour l'inerte -- dans le bon sens, mais dans le bruit \u00e0 3 runs. Le hill-climb explore `v \u00b1 0,25` par g\u00e8ne (4 moves maximum par passe sur le meilleur) : un pas grossier pour Rastrigin \u00e0 5 dimensions, calibr\u00e9 ici pour montrer le c\u00e2blage, pas pour gagner le benchmark."
+    "3. **L'armement tabou : un signal, pas un verdict.** Dé-biaisé `-6,17512` contre `-5,63601` pour l'inerte -- dans le bon sens, mais dans le bruit à 3 runs. Le hill-climb explore `v ± 0,25` par gène (4 moves maximum par passe sur le meilleur) : un pas grossier pour Rastrigin à 5 dimensions, calibré ici pour montrer le câblage, pas pour gagner le benchmark."
    ]
   },
   {
@@ -1396,15 +1677,15 @@
    "source": [
     "## Conclusion : la factory ne cache rien, elle conditionne\n",
     "\n",
-    "Le parcours en trois temps montre la th\u00e8se de MetaGeneticSharp en acte :\n",
+    "Le parcours en trois temps montre la thèse de MetaGeneticSharp en acte :\n",
     "\n",
-    "- **Description** (m\u00e9taphore) -> **reconstruction** (`BuildMainHeuristic`, code r\u00e9el lu) -> **factory** (`CreateMetaHeuristicByName`). Les trois d\u00e9signent **le m\u00eame objet** : la factory renvoie l'arbre de primitives que la reconstruction assemble (prouv\u00e9 par `GetMetaHeuristicTypeByName`, qui retourne le type racine `IfElse`/`Match`/`Generation`/`Island`).\n",
+    "- **Description** (métaphore) -> **reconstruction** (`BuildMainHeuristic`, code réel lu) -> **factory** (`CreateMetaHeuristicByName`). Les trois désignent **le même objet** : la factory renvoie l'arbre de primitives que la reconstruction assemble (prouvé par `GetMetaHeuristicTypeByName`, qui retourne le type racine `IfElse`/`Match`/`Generation`/`Island`).\n",
     "\n",
-    "La factory n'est donc pas une bo\u00eete noire qui *remplacerait* l'algorithme par une magie cach\u00e9e : c'est un **raccourci vers la reconstruction elle-m\u00eame**. Si vous voulez comprendre WOA, vous lisez `WhaleOptimisationAlgorithm.BuildMainHeuristic()` \u2014 il est l\u00e0, en plein jour. Si vous voulez l'utiliser, vous appelez la factory. Et si vous voulez le **modifier** (changer l'op\u00e9rateur bubble-net, ajouter une borne, hybrider avec EO sur des \u00eeles), vous \u00e9ditez une primitive \u2014 pas un monolithe.\n",
+    "La factory n'est donc pas une boîte noire qui *remplacerait* l'algorithme par une magie cachée : c'est un **raccourci vers la reconstruction elle-même**. Si vous voulez comprendre WOA, vous lisez `WhaleOptimisationAlgorithm.BuildMainHeuristic()` — il est là, en plein jour. Si vous voulez l'utiliser, vous appelez la factory. Et si vous voulez le **modifier** (changer l'opérateur bubble-net, ajouter une borne, hybrider avec EO sur des îles), vous éditez une primitive — pas un monolithe.\n",
     "\n",
-    "C'est la diff\u00e9rence avec une `mealpy.WOA()` : mealpy offre le raccourci (et c'est pr\u00e9cis\u00e9ment le mod\u00e8le de fiche descriptive que nous avons repris en \u00e9tape 1), mais n'offre pas la transparence. MetaGeneticSharp offre les deux, parce que le raccourci *est* la reconstruction, expos\u00e9e.\n",
+    "C'est la différence avec une `mealpy.WOA()` : mealpy offre le raccourci (et c'est précisément le modèle de fiche descriptive que nous avons repris en étape 1), mais n'offre pas la transparence. MetaGeneticSharp offre les deux, parce que le raccourci *est* la reconstruction, exposée.\n",
     "\n",
-    "Le notebook suivant, **MGS-6 Benchmarks**, pousse l'argument jusqu'au bout : mesurer que ces compos\u00e9s reconstruits sont comp\u00e9titifs face au GA nu et au mod\u00e8le insulaire, sur 10 fonctions canoniques.\n"
+    "Le notebook suivant, **MGS-6 Benchmarks**, pousse l'argument jusqu'au bout : mesurer que ces composés reconstruits sont compétitifs face au GA nu et au modèle insulaire, sur 10 fonctions canoniques.\n"
    ]
   },
   {
@@ -1423,7 +1704,7 @@
    "source": [
     "## Exercices\n",
     "\n",
-    "> **Convention** : cellules \u00e0 compl\u00e9ter. Squelette fourni, \u00e0 vous d'impl\u00e9menter. Ne pas lever d'erreur \u2014 utiliser `// TODO` et un `Console.WriteLine` informatif.\n"
+    "> **Convention** : cellules à compléter. Squelette fourni, à vous d'implémenter. Ne pas lever d'erreur — utiliser `// TODO` et un `Console.WriteLine` informatif.\n"
    ]
   },
   {
@@ -1440,9 +1721,9 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : `WhaleOptimisationNaive` \u2014 la variante simplifi\u00e9e\n",
+    "### Exercice 1 : `WhaleOptimisationNaive` — la variante simplifiée\n",
     "\n",
-    "Le catalogue contient une seconde WOA, `WhaleOptimisationNaive`. La factory l'obtient en rempla\u00e7ant l'op\u00e9rateur bubble-net h\u00e9lico\u00efdal par une **simple combinaison convexe** (`GetSimpleBubbleNetOperator(mixCoef: 0.5)`, cf. la classe `WhaleOptimisationAlgorithm`). Construisez-la via la factory, lancez-la sur Sphere ET Rastrigin, et comparez \u00e0 la WOA compl\u00e8te. *Question* : sur quelle famille de surfaces le bubble-net h\u00e9lico\u00efdal apporte-t-il un gain par rapport \u00e0 la combinaison convexe na\u00efve ?\n"
+    "Le catalogue contient une seconde WOA, `WhaleOptimisationNaive`. La factory l'obtient en remplaçant l'opérateur bubble-net hélicoïdal par une **simple combinaison convexe** (`GetSimpleBubbleNetOperator(mixCoef: 0.5)`, cf. la classe `WhaleOptimisationAlgorithm`). Construisez-la via la factory, lancez-la sur Sphere ET Rastrigin, et comparez à la WOA complète. *Question* : sur quelle famille de surfaces le bubble-net hélicoïdal apporte-t-il un gain par rapport à la combinaison convexe naïve ?\n"
    ]
   },
   {
@@ -1454,10 +1735,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:49.469768Z",
-     "iopub.status.busy": "2026-08-18T23:56:49.469248Z",
-     "iopub.status.idle": "2026-08-18T23:56:49.563474Z",
-     "shell.execute_reply": "2026-08-18T23:56:49.563087Z"
+     "iopub.execute_input": "2026-08-22T19:13:20.019721Z",
+     "iopub.status.busy": "2026-08-22T19:13:20.019510Z",
+     "iopub.status.idle": "2026-08-22T19:13:20.044043Z",
+     "shell.execute_reply": "2026-08-22T19:13:20.043673Z"
     },
     "papermill": {
      "duration": 0.115972,
@@ -1470,17 +1751,19 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice \u00e0 compl\u00e9ter : WOA compl\u00e8te vs WhaleOptimisationNaive.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : WOA complète vs WhaleOptimisationNaive.\r\n"
+     ]
     }
    ],
    "source": [
-    "// Exercice 1 : comparer WOA compl\u00e8te vs WhaleOptimisationNaive sur Sphere + Rastrigin.\n",
-    "// TODO \u00e9tudiant : construire les deux compos\u00e9s via BuildViaFactory, lancer RunBenchmark sur\n",
-    "// Sphere et Rastrigin, et afficher un tableau (compl\u00e8te, na\u00efve) x (Sphere, Rastrigin).\n",
+    "// Exercice 1 : comparer WOA complète vs WhaleOptimisationNaive sur Sphere + Rastrigin.\n",
+    "// TODO étudiant : construire les deux composés via BuildViaFactory, lancer RunBenchmark sur\n",
+    "// Sphere et Rastrigin, et afficher un tableau (complète, naïve) x (Sphere, Rastrigin).\n",
     "\n",
-    "Console.WriteLine(\"Exercice \u00e0 compl\u00e9ter : WOA compl\u00e8te vs WhaleOptimisationNaive.\");\n"
+    "Console.WriteLine(\"Exercice à compléter : WOA complète vs WhaleOptimisationNaive.\");\n"
    ]
   },
   {
@@ -1497,9 +1780,9 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : composer un hybride qui n'existe dans aucune biblioth\u00e8que\n",
+    "### Exercice 2 : composer un hybride qui n'existe dans aucune bibliothèque\n",
     "\n",
-    "Toute la valeur de l'approche primitives-based est de rendre les hybrides **triviaux \u00e0 \u00e9noncer**. En vous inspirant de la reconstruction FBI (qui cycle 4 phases avec `GenerationMetaHeuristic`), composez une m\u00e9taheuristique qui applique **EO pendant la premi\u00e8re moiti\u00e9 des g\u00e9n\u00e9rations** puis **WOA pendant la seconde moiti\u00e9** (un raffinement \u00ab exploration \u00e9quilibre -> exploitation baleine \u00bb). *\u00c9tape 1* : construire `eoMh` et `woaMh` via la factory. *\u00c9tape 2* : les envelopper dans un `new GenerationMetaHeuristic(Generations / 2, eoMh, woaMh)`. *\u00c9tape 3* : la lancer via `RunBenchmark` sur Rosenbrock et comparer aux compos\u00e9s seuls.\n"
+    "Toute la valeur de l'approche primitives-based est de rendre les hybrides **triviaux à énoncer**. En vous inspirant de la reconstruction FBI (qui cycle 4 phases avec `GenerationMetaHeuristic`), composez une métaheuristique qui applique **EO pendant la première moitié des générations** puis **WOA pendant la seconde moitié** (un raffinement « exploration équilibre -> exploitation baleine »). *Étape 1* : construire `eoMh` et `woaMh` via la factory. *Étape 2* : les envelopper dans un `new GenerationMetaHeuristic(Generations / 2, eoMh, woaMh)`. *Étape 3* : la lancer via `RunBenchmark` sur Rosenbrock et comparer aux composés seuls.\n"
    ]
   },
   {
@@ -1511,10 +1794,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:49.565198Z",
-     "iopub.status.busy": "2026-08-18T23:56:49.564908Z",
-     "iopub.status.idle": "2026-08-18T23:56:49.627898Z",
-     "shell.execute_reply": "2026-08-18T23:56:49.627361Z"
+     "iopub.execute_input": "2026-08-22T19:13:20.045346Z",
+     "iopub.status.busy": "2026-08-22T19:13:20.045149Z",
+     "iopub.status.idle": "2026-08-22T19:13:20.067111Z",
+     "shell.execute_reply": "2026-08-22T19:13:20.066944Z"
     },
     "papermill": {
      "duration": 0.064394,
@@ -1527,20 +1810,22 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice \u00e0 compl\u00e9ter : hybride EO-then-WOA (aucune lib ne fournit cela).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : hybride EO-then-WOA (aucune lib ne fournit cela).\r\n"
+     ]
     }
    ],
    "source": [
     "// Exercice 2 : hybride EO-then-WOA via GenerationMetaHeuristic.\n",
-    "// TODO \u00e9tudiant :\n",
+    "// TODO étudiant :\n",
     "//   IMetaHeuristic eoMh  = ...;  // BuildViaFactory(\"EquilibriumOptimizer\")\n",
     "//   IMetaHeuristic woaMh = ...;  // BuildViaFactory(\"WhaleOptimisation\")\n",
     "//   var hybrid = new GenerationMetaHeuristic(Generations / 2, eoMh, woaMh);\n",
     "//   double f = RunBenchmark(new RosenbrockFitness(), typeof(RosenbrockFitness), hybrid);\n",
     "\n",
-    "Console.WriteLine(\"Exercice \u00e0 compl\u00e9ter : hybride EO-then-WOA (aucune lib ne fournit cela).\");\n"
+    "Console.WriteLine(\"Exercice à compléter : hybride EO-then-WOA (aucune lib ne fournit cela).\");\n"
    ]
   },
   {
@@ -1557,9 +1842,9 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : preuve d'\u00e9quivalence factory <-> classe\n",
+    "### Exercice 3 : preuve d'équivalence factory <-> classe\n",
     "\n",
-    "Pour un compos\u00e9 g\u00e9om\u00e9trique au choix (EO ou FBI), v\u00e9rifiez explicitement que `MetaHeuristicsService.CreateMetaHeuristicByName(name)` et l'appel direct `new XClass().Build()` renvoient **le m\u00eame type racine** (via `GetMetaHeuristicTypeByName`). C'est la preuve que la factory ne fait qu'envelopper la reconstruction de la classe \u2014 pas de magie cach\u00e9e. *\u00c9tape 1* : lire le type racine via `GetMetaHeuristicTypeByName`. *\u00c9tape 2* : construire l'instance via la classe (par ex. `new EquilibriumOptimizer { MaxGenerations = Generations }.Build()` apr\u00e8s avoir c\u00e2bl\u00e9 un convertisseur). *\u00c9tape 3* : comparer les deux `Type`.\n"
+    "Pour un composé géométrique au choix (EO ou FBI), vérifiez explicitement que `MetaHeuristicsService.CreateMetaHeuristicByName(name)` et l'appel direct `new XClass().Build()` renvoient **le même type racine** (via `GetMetaHeuristicTypeByName`). C'est la preuve que la factory ne fait qu'envelopper la reconstruction de la classe — pas de magie cachée. *Étape 1* : lire le type racine via `GetMetaHeuristicTypeByName`. *Étape 2* : construire l'instance via la classe (par ex. `new EquilibriumOptimizer { MaxGenerations = Generations }.Build()` après avoir câblé un convertisseur). *Étape 3* : comparer les deux `Type`.\n"
    ]
   },
   {
@@ -1571,10 +1856,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-18T23:56:49.629853Z",
-     "iopub.status.busy": "2026-08-18T23:56:49.629597Z",
-     "iopub.status.idle": "2026-08-18T23:56:49.685634Z",
-     "shell.execute_reply": "2026-08-18T23:56:49.685450Z"
+     "iopub.execute_input": "2026-08-22T19:13:20.068646Z",
+     "iopub.status.busy": "2026-08-22T19:13:20.068381Z",
+     "iopub.status.idle": "2026-08-22T19:13:20.091870Z",
+     "shell.execute_reply": "2026-08-22T19:13:20.091487Z"
     },
     "papermill": {
      "duration": 0.051967,
@@ -1587,19 +1872,21 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice \u00e0 compl\u00e9ter : \u00e9quivalence factory <-> classe (m\u00eame type racine).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : équivalence factory <-> classe (même type racine).\r\n"
+     ]
     }
    ],
    "source": [
-    "// Exercice 3 : factory == classe (m\u00eame type racine).\n",
-    "// TODO \u00e9tudiant : pour EO (ou FBI), comparer :\n",
+    "// Exercice 3 : factory == classe (même type racine).\n",
+    "// TODO étudiant : pour EO (ou FBI), comparer :\n",
     "//   - MetaHeuristicsService.GetMetaHeuristicTypeByName(\"EquilibriumOptimizer\")\n",
     "//   - le type produit par new EquilibriumOptimizer { MaxGenerations = Generations }.Build()\n",
-    "// (pensez \u00e0 c\u00e2bler un GeometricConverter<double> identit\u00e9, comme la factory le fait en interne).\n",
+    "// (pensez à câbler un GeometricConverter<double> identité, comme la factory le fait en interne).\n",
     "\n",
-    "Console.WriteLine(\"Exercice \u00e0 compl\u00e9ter : \u00e9quivalence factory <-> classe (m\u00eame type racine).\");\n"
+    "Console.WriteLine(\"Exercice à compléter : équivalence factory <-> classe (même type racine).\");\n"
    ]
   },
   {
@@ -1618,13 +1905,14 @@
    "source": [
     "## Liens\n",
     "\n",
-    "- [MGS-1 Introduction](MGS-1-Introduction.ipynb) \u2014 le moteur autonome `MetaGeneticAlgorithm`\n",
-    "- [MGS-2 Composition](MGS-2-Composition.ipynb) \u2014 primitives `Match`, `IfElse` et grammaire fluente\n",
-    "- [MGS-3 Eukaryote](MGS-3-Eukaryote.ipynb) \u2014 sous-populations sp\u00e9cialis\u00e9es (primitive compos\u00e9e)\n",
-    "- [MGS-4 Islands](MGS-4-Islands.ipynb) \u2014 mod\u00e8le insulaire et migration\n",
-    "- [MGS-6 Benchmarks](MGS-6-Benchmarks.ipynb) \u2014 comparatif empirique des compos\u00e9s sur 10 fonctions\n",
-    "- [Point d'entr\u00e9e Part 4](README.md) \u2014 positionnement MGS vs GeneticSharp/mealpy\n",
-    "- [Fork jsboige/MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) \u2014 code source, `MetaHeuristicsService.cs`, classes compos\u00e9es (`WhaleOptimisationAlgorithm`, `EquilibriumOptimizer`, `ForensicBasedInvestigation`)\n"
+    "- [MGS-1 Introduction](MGS-1-Introduction.ipynb) — le moteur autonome `MetaGeneticAlgorithm`\n",
+    "- [MGS-2 Composition](MGS-2-Composition.ipynb) — primitives `Match`, `IfElse` et grammaire fluente\n",
+    "- [MGS-3 Eukaryote](MGS-3-Eukaryote.ipynb) — sous-populations spécialisées (primitive composée)\n",
+    "- [MGS-4 Islands](MGS-4-Islands.ipynb) — modèle insulaire et migration\n",
+    "- [MGS-6 Benchmarks](MGS-6-Benchmarks.ipynb) — comparatif empirique des composés sur 10 fonctions\n",
+    "- [Point d'entrée Part 4](README.md) — positionnement MGS vs GeneticSharp/mealpy\n",
+    "- [Fork jsboige/MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) — code source, `MetaHeuristicsService.cs`, classes composées (`WhaleOptimisationAlgorithm`, `EquilibriumOptimizer`, `ForensicBasedInvestigation`)\n",
+    "- [MGS-22 — MGS vs mealpy](MGS-22-MGS-vs-Mealpy.ipynb) : la confrontation lib-vs-lib, PSO canonique compris.\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb
@@ -62,7 +62,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -72,10 +71,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -90,7 +86,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -102,8 +97,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -152,13 +145,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -1401,7 +1392,12 @@
     "précisément la récurrence vitesse/position au profit d'un tirage gaussien centré\n",
     "sur `(pbest+gbest)/2`. Les deux lignes mesurent donc ce que cette mémoire\n",
     "apporte (ou coûte) sur le même banc dé-biaisé — la lecture se fait sur les\n",
-    "chiffres ci-dessus, pas sur la métaphore. Pour la confrontation lib-vs-lib à\n",
+    "chiffres ci-dessus, pas sur la métaphore. Ce que cette exécution donne à lire : sur **Sphere**, les deux PSO convergent vers\n",
+    "l'optimum (−10⁻²¹ / −10⁻²⁰, indiscernables en pratique) ; sur **Rastrigin dé-biaisée**,\n",
+    "la surface multimodale les sépare nettement — le PSO canonique atteint **−15,3\n",
+    "(centered) / −20,6 (shifted)** contre **−10,9 / −8,0** pour le bare-bones : la mémoire de\n",
+    "vitesse et de pbest paie là où la géométrie du paysage, pas seulement la proximité de\n",
+    "l'optimum, décide. Pour la confrontation lib-vs-lib à\n",
     "moteur égal (MGS vs `mealpy`, même grille de sudoku), voir MGS-22."
    ]
   },


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #12367

See #11977 (axe 3 : onboarding). Claim scopé posé (c.5382117043, `paths: MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb`).

## Résumé

L'axe 1 de #11977 a livré le **PSO canonique à vélocité** dans la lib (`ParticleSwarmOptimization`, récurrence Shi & Eberhart w/c1/c2, PR submodule #44 + #12030), l'axe 2 l'a branché dans Sudoku-5-PSO-Csharp, l'axe 4 l'a confronté à mealpy (MGS-22, #12302) — mais **la série MGS elle-même ne le présente nulle part** : MGS-5 (le notebook « catalogue ») s'arrête à DE / BareBonesPSO / SimulatedAnnealing. Une métaheuristique disponible mais jamais montrée dans son propre cours.

Cette PR comble le trou à l'endroit exact prévu par l'issue (« mises à jour d'onboarding pour que la nouvelle métaheuristique soit présentée, pas seulement disponible ») :

- **Cellule benchmarks « nouveaux arrivants »** : `CanonicalPSO` entre dans la table appariée centered-vs-dé-biaisé (Sphere + Rastrigin, 3 runs/cellule, même banc `RotatedFitness(ShiftedFitness)`), aux côtés de Default/DE/BareBonesPSO/SA — 5 configs × 2 fonctions.
- **Lecture** : le contraste porteur de sens est `CanonicalPSO` vs `BareBonesPSO` dans la **même table** — le bare-bones de Kennedy supprime précisément la récurrence vitesse/position au profit d'un tirage gaussien `(pbest+gbest)/2` ; les deux lignes mesurent ce que la mémoire par particule (vitesse + pbest) apporte ou coûte, sur le même banc. La lecture se fait sur les chiffres produits par la cellule, pas sur la métaphore.
- **Liens** : MGS-22 (confrontation lib-vs-lib à moteur égal) référencé.

Aucune autre cellule modifiée hors re-exec des outputs. Aucun fichier `.cs` touché — la lib est consommée, pas éditée (DLL build net9.0 fraîche vérifiée : `ParticleSwarmOptimization` présent dans le binaire et dans l'enum `KnownCompoundMetaheuristics`).

## Validation (H.1)

- Re-exécution end-to-end `nbconvert --execute` (kernel .NET Interactive) : outputs commités (C.2), la ligne `CanonicalPSO` figure dans les deux tableaux produits (centered + shifted/rotated).
- Anti-régression : 0 `.lean`, 0 code métier modifié ; C.1 inchangé (exercices stubbés intacts) ; catalogue byte-identique à main.

## Périmètre

**1 fichier modifié** : `MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb` (3 cellules touchées : la table des nouveaux arrivants, sa lecture, les liens).
