### PR TITLE
fix(guard,#12366): un strip pre-commit n'est pas une re-execution — le ratchet papermill contredisait ses propres hooks

### DIFF
--- a/scripts/notebook_tools/check_papermill_ratchet.py
+++ b/scripts/notebook_tools/check_papermill_ratchet.py
@@ -32,9 +32,13 @@ changed-outputs + identical-block regression exists.
 
 import argparse
 import json
+import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 # Same exclusions as check_exec_ratchet.py / notebook-execution-required.yml:
 # archived, papermill-output and research copies are not deliverable notebooks.
@@ -109,6 +113,58 @@ def papermill_block(nb):
     return json.dumps(block, sort_keys=True, ensure_ascii=False)
 
 
+# --- sanctioned output strips -------------------------------------------
+# Three pre-commit hooks in .pre-commit-config.yaml rewrite committed cell
+# outputs without any re-execution. Two of them touch the code-cell outputs
+# this gate hashes:
+#
+#   strip-probeaddresses-banner -> strip_probe_banner.py --apply
+#   strip-dotnet-nuget-ext      -> strip_machine_paths.py --apply
+#
+# (The third, scrub-papermill-paths, rewrites metadata.papermill and is
+# therefore already visible to the block comparison, not to exec_evidence.)
+#
+# Both hooks exist precisely BECAUSE re-execution does not fix what they
+# remove: the strip-dotnet-nuget-ext description says the message "is
+# re-injected at every kernel re-execution ... so the durable fix is this
+# output-only pre-commit strip - no source change, execution_count
+# preserved". A branch that merely touches a markdown cell of a notebook
+# still carrying such a leak therefore gets its OUTPUTS rewritten at commit
+# time, by an organ of this very repository - and would be judged as riding
+# a stale block, which it is not.
+#
+# The test is exact, not heuristic: the base blob is passed through the same
+# tools, and the result must equal the head evidence BYTE FOR BYTE. A
+# hand-edited output does not survive it, because no strip tool produces a
+# hand-edit.
+STRIP_TOOLS = ("strip_machine_paths", "strip_probe_banner")
+
+
+def stripped_evidence(content):
+    """exec_evidence of `content` after the output-touching strip hooks.
+
+    Returns None when the tools cannot run, so a failure here can only leave
+    the caller on its previous (stricter) verdict - never turn a FAIL into a
+    PASS by accident.
+    """
+    handle, tmp = tempfile.mkstemp(suffix=".ipynb")
+    os.close(handle)
+    try:
+        Path(tmp).write_text(content, encoding="utf-8")
+        import strip_machine_paths
+        import strip_probe_banner
+        strip_machine_paths.strip_in_place(tmp)
+        strip_probe_banner.strip_banner_in_place(tmp)
+        return exec_evidence(json.loads(Path(tmp).read_text(encoding="utf-8")))
+    except Exception:
+        return None
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
 def state_at_base(base, path, cwd=None):
     """(evidence, block) of the notebook blob at base ref.
 
@@ -117,12 +173,16 @@ def state_at_base(base, path, cwd=None):
     """
     content = git("show", f"{base}:{path}", cwd=cwd)
     if content is None:
-        return "ABSENT", None, None
+        return "ABSENT", None, None, None
     try:
         nb = json.loads(content)
     except Exception:
-        return "PARSE_ERROR", None, None
-    return "OK", exec_evidence(nb), papermill_block(nb)
+        return "PARSE_ERROR", None, None, None
+    # Lazy: the strip tools cost ~150 ms per notebook and are only ever
+    # consulted on the STALE_BLOCK branch, which is the rare one. A thunk
+    # keeps a 200-notebook PR at the cost it had before this exemption.
+    return ("OK", exec_evidence(nb), papermill_block(nb),
+            lambda: stripped_evidence(content))
 
 
 def state_at_head(path, cwd=None):
@@ -130,14 +190,14 @@ def state_at_head(path, cwd=None):
     try:
         nb = json.loads((Path(cwd or ".") / path).read_text(encoding="utf-8"))
     except Exception:
-        return "PARSE_ERROR", None, None
-    return "OK", exec_evidence(nb), papermill_block(nb)
+        return "PARSE_ERROR", None, None, None
+    return "OK", exec_evidence(nb), papermill_block(nb), None
 
 
 def classify(base_state, head_state):
     """Verdict of one changed notebook. Regression iff stale block ridden."""
-    b_status, b_ev, b_block = base_state
-    h_status, h_ev, h_block = head_state
+    b_status, b_ev, b_block, b_ev_stripped = base_state  # 4th is a thunk
+    h_status, h_ev, h_block, _ = head_state
     if b_status == "ABSENT":
         return "ADDED", False
     if b_status == "PARSE_ERROR" or h_status == "PARSE_ERROR":
@@ -148,6 +208,12 @@ def classify(base_state, head_state):
     if h_ev == b_ev:
         # Outputs untouched: a markdown-only edit rides the block legally.
         return "OUTPUTS_UNCHANGED", False
+    if b_ev_stripped is not None and h_ev == b_ev_stripped():
+        # The whole delta is what the sanctioned output-strip hooks produce.
+        # No run happened, so the block is not stale - it still describes the
+        # execution that produced these outputs, minus a machine-path leak
+        # that no re-execution could have removed.
+        return "OUTPUTS_STRIPPED", False
     if h_block == b_block:
         # Outputs changed but the block is byte-identical: it describes the
         # previous run, not the one that produced the committed outputs.

--- a/scripts/notebook_tools/tests/test_check_papermill_ratchet.py
+++ b/scripts/notebook_tools/tests/test_check_papermill_ratchet.py
@@ -241,3 +241,61 @@ class TestMain:
         with pytest.raises(SystemExit) as exc:
             gate.main()
         assert exc.value.code == 0
+
+
+class TestSanctionedOutputStrips:
+    """A pre-commit strip is not a re-execution (#12366).
+
+    Three hooks of .pre-commit-config.yaml rewrite committed outputs with no
+    kernel involved; two of them touch the code-cell outputs this gate
+    hashes. They exist BECAUSE re-execution does not fix what they remove --
+    the strip-dotnet-nuget-ext description says the leak "is re-injected at
+    every kernel re-execution". So a branch that merely edits a markdown cell
+    of a notebook still carrying such a leak gets its outputs rewritten at
+    commit time by an organ of this repo, and was judged as riding a stale
+    block. Measured on PR #12366: 1 REGRESSION on a one-line stderr warning,
+    and 6 notebooks repo-wide carry the same landmine.
+
+    The exemption is exact, not heuristic: it holds only when the base blob,
+    passed through the SAME tools, reproduces the head evidence byte for
+    byte. The second test is the positive control -- a hand-edited output is
+    still caught, because no strip tool produces a hand-edit.
+    """
+
+    LEAK = "C:\\Users\\someuser\\AppData\\Roaming\\Python\\Python313\\site-packages\\diffusers\\models\\lora.py:391: FutureWarning: deprecated\\n"
+
+    def _leaky(self, text):
+        return [{"output_type": "stream", "name": "stderr", "text": [text]}]
+
+    def _branch_from(self, repo, head_outputs):
+        write_nb(repo, "a.ipynb",
+                 make_nb([self._leaky(self.LEAK)], papermill=PM))
+        base = commit(repo, "base: notebook carrying a machine-path leak")
+        git_ok(repo, "checkout", "-q", "-b", "feature")
+        nb = make_nb([head_outputs], papermill=PM)
+        nb["cells"].insert(0, {"cell_type": "markdown",
+                               "source": "# prose", "metadata": {}})
+        write_nb(repo, "a.ipynb", nb)
+        commit(repo, "feature: markdown edit")
+        return base
+
+    def test_strip_hook_rewrite_is_not_a_stale_block(self, repo):
+        stripped = gate.stripped_evidence(
+            json.dumps(make_nb([self._leaky(self.LEAK)], papermill=PM)))
+        assert "<USER_PATH>" in stripped, (
+            "positive control: the strip tool must actually redact this leak, "
+            "otherwise the test below would pass for the wrong reason")
+        base = self._branch_from(
+            repo, self._leaky(self.LEAK.replace(
+                "C:" + chr(92) + "Users" + chr(92) + "someuser",
+                "<USER_PATH>")))
+        recs = gate.ratchet(base, cwd=repo)
+        assert [r["verdict"] for r in recs] == ["OUTPUTS_STRIPPED"]
+        assert recs[0]["regression"] is False
+
+    def test_a_hand_edited_output_is_still_caught(self, repo):
+        base = self._branch_from(
+            repo, self._leaky("HAND-EDITED-BY-A-HUMAN"))
+        recs = gate.ratchet(base, cwd=repo)
+        assert [r["verdict"] for r in recs] == ["STALE_BLOCK"]
+        assert recs[0]["regression"] is True


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/notebook-python #12366

## Le defaut

Le garde **`Papermill ratchet (base vs PR)`** rend `REGRESSION` / `STALE_BLOCK` des que les outputs d'un notebook changent alors que `metadata.papermill` reste identique. Il hache les outputs bruts (`exec_evidence`) et **ne connait aucun des hooks de `.pre-commit-config.yaml` qui reecrivent ces memes outputs sans kernel** :

| hook | entry | ce qu'il touche |
|---|---|---|
| `strip-probeaddresses-banner` | `strip_probe_banner.py --apply` | outputs de cellule |
| `strip-dotnet-nuget-ext` | `strip_machine_paths.py --apply` | outputs de cellule |
| `scrub-papermill-paths` | `scrub_papermill_paths.py --apply` | `metadata.papermill` (deja visible du garde) |

Ces hooks existent **precisement parce que la re-execution ne repare pas ce qu'ils retirent**. Verbatim de la description de `strip-dotnet-nuget-ext` dans `.pre-commit-config.yaml` :

> The message is re-injected at every kernel re-execution (category-A kernel-injected leak of rule-6 secrets-hygiene), so the durable fix is this output-only pre-commit strip — no source change, execution_count preserved.

Deux organes de ce depot se contredisent donc : le hook **doit** reecrire l'output, le ratchet **interdit** que l'output ait bouge.

## Comment il s'est manifeste

Sur **#12366** (resorption de `heading_in_list`, edition de cellules **markdown** uniquement), une unique ligne de `stderr` — un `FutureWarning` de `diffusers` imprimant le chemin `site-packages` de la machine — a suffi a rendre 1 `REGRESSION`. Le hook reappliquant le strip **a chaque commit**, la PR etait irreparable sans toucher au garde : un revert manuel etait annule par le hook au commit suivant (constate firsthand).

Le nom du hook dit « NuGet cache » mais son `entry` est `strip_machine_paths.py`, un stripper **generique** couvrant 8 categories de runtime — d'ou le declenchement sur un warning Python.

## Ampleur

```
$ python scripts/notebook_tools/strip_machine_paths.py --scan-all
scan summary (all categories): 6 notebook(s) carrying 11 leak line(s)
```

Six notebooks sont des **pieges armes** pour la prochaine lane qui y touchera, quel que soit son grain.

## Le correctif — exact, pas heuristique

Le blob de base est repasse par les **memes outils**, et le resultat doit egaler l'evidence de tete **octet pour octet** → verdict `OUTPUTS_STRIPPED`, non-regression. Une hand-edition n'y survit pas, puisqu'aucun outil de strip ne produit de hand-edition.

**Fail-closed** : si les outils ne peuvent pas tourner, `stripped_evidence` rend `None` et l'appelant reste sur son verdict anterieur (plus strict). Ce chemin **ne peut jamais** transformer un FAIL en PASS.

**Paresseux** (thunk) : ~150 ms par notebook, payes seulement sur la branche `STALE_BLOCK`, qui est la rare.

| ratchet sur les 16 notebooks de #12366 | temps |
|---|---|
| avant ce correctif | 2,12 s |
| calcul systematique | 4,39 s |
| paresseux (retenu) | 2,57 s |

## Preuve de discrimination (les deux sens)

Verification firsthand sur le cas reel, worktree de #12366 :

```
avant : regressions 1  --  STALE_BLOCK        03-1-Multi-Model-Audio-Comparison.ipynb  REGRESSION
apres : regressions 0  --  OUTPUTS_STRIPPED   03-1-Multi-Model-Audio-Comparison.ipynb
```

Puis **controle positif injecte** : une sortie de `03-2-Audio-Pipeline-Orchestration.ipynb` remplacee par `HAND-EDITED-BY-A-HUMAN` →

```
regressions       : 1
  OUTPUTS_STRIPPED   .../03-1-Multi-Model-Audio-Comparison.ipynb
  STALE_BLOCK        .../03-2-Audio-Pipeline-Orchestration.ipynb REGRESSION
exit=1
```

Le garde discrimine : strip sanctionne → passe ; hand-edition → toujours attrape.

## Tests

2 nouveaux dans `scripts/notebook_tools/tests/test_check_papermill_ratchet.py`, **chacun portant son controle** :

- `test_strip_hook_rewrite_is_not_a_stale_block` — asserte d'ABORD que l'outil redacte reellement la fuite (`"<USER_PATH>" in stripped`), sinon l'assertion suivante passerait pour la mauvaise raison ;
- `test_a_hand_edited_output_is_still_caught` — une sortie hand-editee rend toujours `STALE_BLOCK` + `regression=True`.

```
$ python -m pytest scripts/notebook_tools/tests/test_check_papermill_ratchet.py -q
15 passed in 5.77s
```

(13 tests existants inchanges + 2 nouveaux.)

## Perimetre

Un seul fichier de code (`scripts/notebook_tools/check_papermill_ratchet.py`) et son fichier de tests. **Aucun** fichier sous `.github/workflows/**`, aucun notebook, aucun fichier genere.

See #12366
