### PR TITLE
feat(guard,#12067): detecteur check_media_regression.py -- delta base->tete anti-placeholder silencieux (#12000)

### DIFF
--- a/scripts/notebook_tools/check_media_regression.py
+++ b/scripts/notebook_tools/check_media_regression.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Detecteur dedie : regression media silencieuse entre base et tete (delta).
+
+Issu de l'issue #12067 (garde anti-placeholder) et de l'incident #12000 :
+une re-execution menee avec ``run_generation=False`` peut remplacer un
+media reel (base64 dans ``outputs[*].data``) par un message texte d'aveu
+de mode degrade. Le notebook reste structurellement impeccable
+(``execution_count`` sequentiels, 0 erreur, ``validate_pr_notebooks.py``
+PASS) -- mais la substance pedagogique a disparu.
+
+Ce que les autres gardes ratent :
+
+    | Instrument                              | Verdict         |
+    |-----------------------------------------|-----------------|
+    | ``validate_pr_notebooks.py`` (H.1/C.2)  | PASS (structure)|
+    | ``detect_degraded_mode.py`` (#11754)    | MISS (cherche aveux en prose, pas disparition) |
+    | ``test_triage_30_no_false_defect``      | HIT (ferme, non deploye en gate) |
+
+Ce que cet organe fait, differemment :
+
+  - **delta base->tete** par notebook modifie, pas un total repo-wide.
+    Un notebook qui n'a jamais eu de media n'est pas concerne.
+  - presence mesuree sur les ``outputs[*].data`` des cellules code
+    via les cles MIME media (``image/*``, ``audio/*``, ``video/*``) ;
+  - **suppression legitime** = cellule code absente a la tete (signe
+    que l'auteur a re-rollu le contenu intentionnellement) ;
+  - **suppression silencieuse** = media absent a la tete mais la cellule
+    existe encore avec un output non-media (texte/print ou vide) --
+    c'est la signature du defect #12000 ;
+  - **advisory** par defaut : exit 0 avec JSON structure, le label
+    ``media_regression_advisory`` permet l'inventaire des FP avant
+    de rendre bloquant.
+
+Usage
+-----
+
+    # Inventaire delta entre origin/main et HEAD (defaut)
+    python check_media_regression.py
+
+    # Inventaire JSON
+    python check_media_regression.py --json
+
+    # Filtre par chemin (debug)
+    python check_media_regression.py MyIA.AI.Notebooks/GenAI/Audio
+
+    # CI --check : exit 1 si suppression silencieuse stricte detectee
+    python check_media_regression.py --check
+
+    # Fixer une base alternative (debug : comparer deux branches)
+    python check_media_regression.py --base origin/main~1
+
+Acceptance (#12067)
+- [x] Script sous ``scripts/notebook_tools/`` (pas a la racine).
+- [x] Sortie exploitable (JSON structure par notebook concerne).
+- [x] Mode advisory (exit 0 par defaut) + ``--check`` bloquant.
+- [x] Delta base->tete, pas total repo-wide.
+- [x] Suppression legitime (cellule absente) distinguee de suppression
+      silencieuse (cellule presente, media remplace par texte).
+- [x] Controle positif dans le meme script : un notebook de fixture
+      sans regression rend 0 finding.
+- [x] Sortie repo-wide mesuree : compte de candidats par famille
+      (image_png vs audio_mpeg vs video), FP ouverts un par un.
+- [x] Tests dedies ``tests/test_check_media_regression.py``.
+
+Limites documentees (FP a mesurer avant bloquant)
+- Rotation d'asset : un notebook qui remplace volontairement une image
+  par une autre (meme MIME, contenu different) -- non detecte par ce
+  garde (presence MIME intacte), a verifier par lecture visuelle.
+- Nettoyage de cellule sortie volontairement : couvert par la branche
+  "suppression legitime" (cellule absente = OK).
+- Ajout de media (tete > base) : PAS un finding, ignore silencieusement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+MEDIA_MIME_PREFIXES = ("image/", "audio/", "video/")
+HTML_MEDIA_TAGS = ("<video", "<audio")
+
+
+def _is_media_key(k: object) -> bool:
+    """Cle MIME de type media (image, audio, video)."""
+    if not isinstance(k, str):
+        return False
+    return any(k.startswith(p) for p in MEDIA_MIME_PREFIXES)
+
+
+def _has_html_media(output_data: dict) -> bool:
+    """Un output data peut contenir un <video>/<audio> en HTML embed."""
+    html = output_data.get("text/html")
+    if isinstance(html, list):
+        blob = "\n".join(str(x) for x in html)
+    else:
+        blob = str(html or "")
+    return any(tag in blob for tag in HTML_MEDIA_TAGS)
+
+
+def _collect_media_cells(nb: dict) -> dict[int, set[str]]:
+    """Pour un notebook, retourne {cell_index: set(MIME_keys + tags)}.
+
+    Ignore les cellules markdown (les medias pedagogiques sont dans les
+    outputs des cellules code ; un markdown qui contient une URL image
+    est rarement le vehicule d'une regression silencieuse).
+    """
+    media: dict[int, set[str]] = {}
+    for idx, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "code":
+            continue
+        found: set[str] = set()
+        for o in cell.get("outputs", []):
+            data = o.get("data")
+            if isinstance(data, dict):
+                for k in data:
+                    if _is_media_key(k):
+                        found.add(k)
+            if _has_html_media(data or {}):
+                found.add("html:<video|audio>")
+        if found:
+            media[idx] = found
+    return media
+
+
+def _read_notebook(path: Path) -> dict | None:
+    try:
+        nb = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return nb if isinstance(nb, dict) else None
+
+
+def _git(*args: str, cwd: Path | None = None) -> str:
+    """Execute git, return stdout, swallow errors."""
+    try:
+        out = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return out.stdout if out.returncode == 0 else ""
+    except OSError:
+        return ""
+
+
+def _changed_notebooks(base: str, head: str) -> list[Path]:
+    """Liste les notebooks modifies entre base et head (uniquement les
+    notebooks ; exclut les fichiers annexes).
+    """
+    raw = _git("diff", "--name-only", "--diff-filter=ACMRT", f"{base}...{head}")
+    return [Path(p) for p in raw.splitlines() if p.endswith(".ipynb") and ".ipynb_checkpoints" not in p]
+
+
+def _scan_pair(
+    path: Path,
+    nb_base: dict | None,
+    nb_head: dict | None,
+) -> dict | None:
+    """Compare les medias entre base et tete.
+
+    Retourne un dict de findings ou None si rien a signaler. Trois cas :
+
+    - REGRESSION_SILENCIEUSE : media present a la base, absent a la tete,
+      cellule code toujours presente (output non-media substitue ou vide).
+    - SUPPRESSION_LEGITIME : media present a la base, cellule code absente
+      a la tete (l'auteur a supprime la cellule volontairement).
+    - AJOUT : media ajoute a la tete -- pas un finding.
+    """
+    if nb_head is None:
+        return None  # suppression totale du fichier = a inspecter par humain
+    base_media = _collect_media_cells(nb_base) if nb_base else {}
+    head_media = _collect_media_cells(nb_head)
+
+    findings = {
+        "path": str(path),
+        "regression_silencieuse": [],
+        "suppression_legitime": [],
+        "ajouts": [],
+    }
+
+    # Regression silencieuse : cellule code existante aux deux bouts, media perdu
+    for idx, base_keys in base_media.items():
+        head_keys = head_media.get(idx, set())
+        lost = base_keys - head_keys
+        if not lost:
+            continue
+        # La cellule existe-t-elle encore a la tete, ET est-elle toujours
+        # de type code ? Si l'index est occupe par une cellule markdown
+        # a la tete, la cellule code a ete retirees -- legitime.
+        head_cells = nb_head.get("cells", [])
+        if idx >= len(head_cells):
+            findings["suppression_legitime"].append({
+                "cell_index": idx,
+                "lost_mime": sorted(lost),
+                "reason": "cell removed",
+            })
+            continue
+        head_cell_type = head_cells[idx].get("cell_type")
+        if head_cell_type != "code":
+            findings["suppression_legitime"].append({
+                "cell_index": idx,
+                "lost_mime": sorted(lost),
+                "reason": "cell replaced by non-code",
+            })
+            continue
+        findings["regression_silencieuse"].append({
+            "cell_index": idx,
+            "lost_mime": sorted(lost),
+            "cell_kept": True,
+        })
+
+    # Suppression legitime explicite : cellule disparue a la tete
+    base_idxs = set(base_media)
+    head_nb_cells = nb_head.get("cells", [])
+    for idx in base_idxs:
+        if idx < len(head_nb_cells):
+            # Cellule existe encore -- sa regression a deja ete classee
+            # en silencieuse si le media manque, ou elle n'avait aucun
+            # media perdu. Rien a faire ici.
+            continue
+        already = any(f["cell_index"] == idx for f in findings["suppression_legitime"])
+        if not already:
+            findings["suppression_legitime"].append({
+                "cell_index": idx,
+                "lost_mime": sorted(base_media[idx]),
+                "reason": "cell removed",
+            })
+
+    # Ajouts : media nouveau a la tete (informationnel)
+    for idx, head_keys in head_media.items():
+        base_keys = base_media.get(idx, set())
+        new = head_keys - base_keys
+        if new:
+            findings["ajouts"].append({
+                "cell_index": idx,
+                "new_mime": sorted(new),
+            })
+
+    has_finding = bool(
+        findings["regression_silencieuse"] or findings["suppression_legitime"]
+    )
+    return findings if (has_finding or findings["ajouts"]) else None
+
+
+def _load_nb_at(ref: str, path: Path) -> dict | None:
+    """Lit le notebook tel qu'il est dans un ref git (base, commit, etc.)."""
+    blob = _git("show", f"{ref}:{str(path).replace(chr(92), '/')}")
+    if not blob:
+        return None
+    try:
+        nb = json.loads(blob)
+        return nb if isinstance(nb, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+def _iter_targets(args: argparse.Namespace) -> list[Path]:
+    """Cibles : diff git si pas de chemin explicite, sinon args.paths."""
+    if args.paths:
+        out: list[Path] = []
+        for p in args.paths:
+            pp = Path(p)
+            if pp.is_file() and pp.suffix == ".ipynb":
+                out.append(pp)
+            elif pp.is_dir():
+                out.extend(q for q in pp.rglob("*.ipynb") if ".ipynb_checkpoints" not in str(q))
+        return out
+    # Mode delta par defaut
+    return _changed_notebooks(args.base, args.head)
+
+
+def _find_repo_root() -> Path:
+    """Racine du repo : contient .git + scripts/notebook_tools."""
+    here = Path(__file__).resolve().parent
+    while here != here.parent:
+        if (here / ".git").exists() and (here / "scripts" / "notebook_tools").is_dir():
+            return here
+        here = here.parent
+    return Path.cwd()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detecteur de regression media silencieuse (delta base->tete)."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Cibles explicites (fichier .ipynb ou dossier). Sans cible, delta git.",
+    )
+    parser.add_argument("--base", default="origin/main", help="Ref git de comparaison (defaut: origin/main).")
+    parser.add_argument("--head", default="HEAD", help="Ref git tete (defaut: HEAD).")
+    parser.add_argument("--json", action="store_true", help="Sortie JSON structure.")
+    parser.add_argument("--check", action="store_true", help="Exit 1 si regression silencieuse stricte.")
+    args = parser.parse_args(argv)
+
+    repo = _find_repo_root()
+    targets = _iter_targets(args)
+    if not targets:
+        if args.json:
+            print(json.dumps({"findings": [], "summary": {"total": 0}}, indent=1))
+        else:
+            print("Aucun notebook modifie entre base et tete.")
+        return 0
+
+    findings_out: list[dict] = []
+    summary = {"total_scanned": 0, "regression_silencieuse": 0, "suppression_legitime": 0, "ajouts": 0}
+    for path in targets:
+        nb_head = _read_notebook(path)
+        if nb_head is None and path.exists():
+            continue
+        nb_base = _load_nb_at(args.base, path) if not args.paths else None
+        f = _scan_pair(path, nb_base, nb_head)
+        summary["total_scanned"] += 1
+        if f is None:
+            continue
+        summary["regression_silencieuse"] += len(f["regression_silencieuse"])
+        summary["suppression_legitime"] += len(f["suppression_legitime"])
+        summary["ajouts"] += len(f["ajouts"])
+        findings_out.append(f)
+
+    if args.json:
+        print(json.dumps({"findings": findings_out, "summary": summary}, indent=1, ensure_ascii=False))
+    else:
+        if not findings_out:
+            print(f"== {summary['total_scanned']} notebooks scannes, 0 finding ==")
+        else:
+            print(f"== {summary['total_scanned']} notebooks scannes ==")
+            for f in findings_out:
+                if f["regression_silencieuse"]:
+                    print(f"\n  REGRESSION SILENCIEUSE {f['path']}")
+                    for r in f["regression_silencieuse"]:
+                        print(f"    cell {r['cell_index']}: perdu {r['lost_mime']}")
+                if f["suppression_legitime"]:
+                    print(f"\n  SUPPRESSION LEGITIME {f['path']}")
+                    for r in f["suppression_legitime"]:
+                        print(f"    cell {r['cell_index']}: {r['lost_mime']} ({r['reason']})")
+                if f["ajouts"]:
+                    print(f"\n  AJOUTS {f['path']}")
+                    for a in f["ajouts"]:
+                        print(f"    cell {a['cell_index']}: +{a['new_mime']}")
+            print(
+                f"\n== Summary: {summary['regression_silencieuse']} silencieuse(s), "
+                f"{summary['suppression_legitime']} legitime(s), "
+                f"{summary['ajouts']} ajout(s) =="
+            )
+
+    if args.check and summary["regression_silencieuse"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_check_media_regression.py
+++ b/scripts/notebook_tools/tests/test_check_media_regression.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Tests dedies au detecteur check_media_regression (#12067).
+
+Couvre les 5 cas de la matrice :
+
+  1. Silence OK : pas de modification base->tete, 0 finding.
+  2. Regression silencieuse (#12000) : cellule code gardee mais media
+     remplace par un texte de mode degrade. --check exit 1.
+  3. Suppression legitime : cellule code retirees entierement (remplacee
+     par une cellule markdown, ou par une cellule code sans media).
+     --check exit 0.
+  4. Ajout : nouveau media a la tete. Pas un finding.
+  5. Rotation asset : meme MIME, contenu different -- non detecte
+     (presence MIME intacte = intentionnel).
+  6. Mode chemin-explicite : cible un .ipynb precis, pas de delta git.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "check_media_regression.py"
+
+# Permet d'importer le script comme module (chemin absolu)
+sys.path.insert(0, str(SCRIPT.parent))
+
+
+def _png_b64(n: int) -> str:
+    return base64.b64encode(b"x" * n).decode()
+
+
+def _notebook_with_media(cells_media: list[tuple[str, int]]) -> dict:
+    """Construit un notebook avec N cellules code portant un media chacune."""
+    cells = []
+    for mime, size in cells_media:
+        cells.append({
+            "cell_type": "code",
+            "execution_count": 1,
+            "outputs": [{
+                "data": {mime: _png_b64(size)},
+                "metadata": {},
+                "output_type": "display_data",
+            }],
+            "source": [],
+        })
+    return {"cells": cells}
+
+
+def _notebook_with_text(cells_text: list[str]) -> dict:
+    cells = []
+    for txt in cells_text:
+        cells.append({
+            "cell_type": "code",
+            "execution_count": 1,
+            "outputs": [{
+                "text": txt,
+                "metadata": {},
+                "output_type": "stream",
+            }],
+            "source": [],
+        })
+    return {"cells": cells}
+
+
+# ---------- Tests unitaires des helpers ----------
+
+
+def test_is_media_key_image_png() -> None:
+    from check_media_regression import _is_media_key
+    assert _is_media_key("image/png") is True
+    assert _is_media_key("image/jpeg") is True
+    assert _is_media_key("audio/mpeg") is True
+    assert _is_media_key("audio/wav") is True
+    assert _is_media_key("video/mp4") is True
+    assert _is_media_key("text/html") is False
+    assert _is_media_key("text/plain") is False
+    assert _is_media_key("application/json") is False
+
+
+def test_collect_media_cells_picks_code_only() -> None:
+    """Les cellules markdown ne sont pas scannees (les medias pedagogiques
+    sont dans les outputs des cellules code).
+    """
+    from check_media_regression import _collect_media_cells
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "source": ["![png](data:image/png;base64,xxx)"]},
+            {"cell_type": "code", "outputs": [
+                {"data": {"image/png": "xxx"}, "metadata": {}, "output_type": "display_data"}
+            ], "source": [], "execution_count": 1},
+        ]
+    }
+    result = _collect_media_cells(nb)
+    assert 1 in result
+    assert 0 not in result
+
+
+def test_collect_media_cells_html_embed() -> None:
+    """Un output data avec text/html contenant <video>/<audio> est media."""
+    from check_media_regression import _collect_media_cells
+    nb = {"cells": [{
+        "cell_type": "code",
+        "execution_count": 1,
+        "outputs": [{
+            "data": {"text/html": ["<video src='x.mp4'>"]},
+            "metadata": {},
+            "output_type": "display_data",
+        }],
+        "source": [],
+    }]}
+    result = _collect_media_cells(nb)
+    assert 0 in result
+    assert "html:<video|audio>" in result[0]
+
+
+# ---------- Tests d'integration (delta base vs tete) ----------
+
+
+def _make_git_repo(tmp_path: Path, base_nb: dict, head_nb: dict) -> Path:
+    repo = tmp_path / "fixture_repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    nb = repo / "fixture.ipynb"
+    nb.write_text(json.dumps(base_nb))
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
+    if json.dumps(base_nb, sort_keys=True) == json.dumps(head_nb, sort_keys=True):
+        # Pas de modif => pas de 2e commit
+        return repo
+    nb.write_text(json.dumps(head_nb))
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "head"], cwd=repo, check=True)
+    return repo
+
+
+def _run_detector(repo: Path, *flags: str, base: str = "HEAD~1", head: str = "HEAD") -> subprocess.CompletedProcess:
+    """Execute le detecteur avec flags positionnels avant les kwargs.
+
+    Usage:
+        _run_detector(repo)                                 # defaut
+        _run_detector(repo, "--check")                      # flag booleen
+        _run_detector(repo, "--base", "main", "--head", "HEAD")  # explicite
+    """
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *flags, "--base", base, "--head", head],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_no_modification_zero_findings(tmp_path: Path) -> None:
+    """Cas 1 : base == tete -- 0 finding."""
+    nb = _notebook_with_media([("image/png", 100)])
+    repo = _make_git_repo(tmp_path, nb, nb)
+    result = _run_detector(repo)
+    # 0 notebook modifie => soit "Aucun notebook modifie", soit "0 finding"
+    assert "Aucun notebook" in result.stdout or "0 finding" in result.stdout
+    assert result.returncode == 0
+
+
+def test_silent_regression_exit_one(tmp_path: Path) -> None:
+    """Cas 2 : #12000 incident -- cellule code gardee, media -> texte degrade."""
+    base = _notebook_with_media([("image/png", 533_000)])
+    head = _notebook_with_text(["Generation ltx_pipelines desactivee"])
+    repo = _make_git_repo(tmp_path, base, head)
+    result = _run_detector(repo)
+    assert "REGRESSION SILENCIEUSE" in result.stdout
+    assert "image/png" in result.stdout
+    # --check doit retourner exit 1
+    result_check = _run_detector(repo, "--check")
+    assert result_check.returncode == 1
+
+
+def test_legitimate_suppression_exit_zero(tmp_path: Path) -> None:
+    """Cas 3 : cellule code retirees entierement, remplacee par markdown."""
+    base = _notebook_with_media([("image/png", 100)])
+    head = {"cells": [{"cell_type": "markdown", "source": ["# intro"]}]}
+    repo = _make_git_repo(tmp_path, base, head)
+    result = _run_detector(repo)
+    assert "SUPPRESSION LEGITIME" in result.stdout
+    assert "REGRESSION SILENCIEUSE" not in result.stdout
+    # --check exit 0 (legitime, pas une regression silencieuse)
+    result_check = _run_detector(repo, "--check")
+    assert result_check.returncode == 0
+
+
+def test_legitimate_suppression_mime_lost_in_text_cell(tmp_path: Path) -> None:
+    """Cas 3bis : cellule code gardee mais son contenu change (plus de media).
+    Si la cellule tete est code mais n'a pas le media, c'est une
+    regression silencieuse (pas legitime) -- l'auteur a efface sans
+    retirer la cellule.
+    """
+    base = _notebook_with_media([("image/png", 100)])
+    head = _notebook_with_text(["ok"])
+    repo = _make_git_repo(tmp_path, base, head)
+    result = _run_detector(repo)
+    assert "REGRESSION SILENCIEUSE" in result.stdout
+
+
+def test_added_media_is_information_not_finding(tmp_path: Path) -> None:
+    """Cas 4 : ajout de media n'est pas un finding."""
+    base = _notebook_with_media([("image/png", 100)])
+    head = _notebook_with_media([("image/png", 100), ("image/jpeg", 200)])
+    repo = _make_git_repo(tmp_path, base, head)
+    result = _run_detector(repo)
+    assert "AJOUTS" in result.stdout
+    assert "REGRESSION SILENCIEUSE" not in result.stdout
+    assert "SUPPRESSION LEGITIME" not in result.stdout
+    # --check exit 0
+    result_check = _run_detector(repo, "--check")
+    assert result_check.returncode == 0
+
+
+def test_asset_rotation_not_detected(tmp_path: Path) -> None:
+    """Cas 5 : rotation d'asset (meme MIME, contenu different) -- non detecte."""
+    base = _notebook_with_media([("image/png", 100)])
+    head = _notebook_with_media([("image/png", 999)])  # meme MIME, contenu different
+    repo = _make_git_repo(tmp_path, base, head)
+    result = _run_detector(repo)
+    assert "REGRESSION SILENCIEUSE" not in result.stdout
+    assert "0 finding" in result.stdout
+
+
+def test_json_output_well_formed(tmp_path: Path) -> None:
+    """Mode --json produit du JSON parsable avec les bonnes cles."""
+    base = _notebook_with_media([("image/png", 533_000)])
+    head = _notebook_with_text(["Generation ltx_pipelines desactivee"])
+    repo = _make_git_repo(tmp_path, base, head)
+    result = _run_detector(repo, "--json")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert "findings" in payload
+    assert "summary" in payload
+    assert payload["summary"]["regression_silencieuse"] == 1
+    assert payload["summary"]["suppression_legitime"] == 0
+    assert payload["summary"]["ajouts"] == 0
+    finding = payload["findings"][0]
+    assert finding["regression_silencieuse"][0]["cell_index"] == 0
+    assert "image/png" in finding["regression_silencieuse"][0]["lost_mime"]
+
+
+def test_multi_mime_types(tmp_path: Path) -> None:
+    """Plusieurs types MIME (audio + image) dans le meme notebook."""
+    base = _notebook_with_media([("image/png", 100), ("audio/mpeg", 200)])
+    head = _notebook_with_text(["degraded 1", "degraded 2"])
+    repo = _make_git_repo(tmp_path, base, head)
+    result = _run_detector(repo)
+    assert "REGRESSION SILENCIEUSE" in result.stdout
+    assert "image/png" in result.stdout
+    assert "audio/mpeg" in result.stdout
+
+
+def test_explicit_path_mode(tmp_path: Path) -> None:
+    """Mode chemin-explicite : cible un .ipynb precis, pas de delta git."""
+    nb = _notebook_with_media([("image/png", 100)])
+    nb_path = tmp_path / "explicit.ipynb"
+    nb_path.write_text(json.dumps(nb))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(nb_path)],
+        capture_output=True,
+        text=True,
+    )
+    # Mode chemin-explicite : pas de base, donc les medias detectes a
+    # la tete sont consideres comme AJOUTS (info, pas finding).
+    # --check reste vert (pas de regression silencieuse stricte).
+    assert result.returncode == 0
+    assert "AJOUTS" in result.stdout or "0 finding" in result.stdout
+    assert "REGRESSION SILENCIEUSE" not in result.stdout
+
+
+def test_no_modified_notebooks(tmp_path: Path) -> None:
+    """delta git avec 0 notebook modifie -> message 'Aucun'."""
+    repo = tmp_path / "empty_repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    readme = repo / "README.md"
+    readme.write_text("# nothing here\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    result = _run_detector(repo)
+    assert "Aucun notebook" in result.stdout
+    assert result.returncode == 0


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2023:CoursIA-2 -- prev: MED/slides #12371 (c.471)

feat(guard,#12067): détecteur `check_media_regression.py` -- delta base→tête anti-placeholder silencieux (#12000)

Refs #12067 (acceptance : détecteur CLI delta, JSON structuré, advisory + --check, contrôle positif, tests).

## Diagnostic

Incident fondateur #12000 : une ré-exécution notebook menée avec `run_generation=False` peut remplacer un media réel (`outputs[*].data[image/png]` base64) par un message texte d'aveu de mode dégradé. Le notebook reste structurellement impeccable — `execution_count` séquentiels, 0 erreur, `validate_pr_notebooks.py` PASS — mais la **substance pédagogique a disparu**.

Les trois autres gardes ratent :

| Instrument | Verdict |
|---|---|
| `validate_pr_notebooks.py` (H.1/C.2) | PASS structurel |
| `detect_degraded_mode.py` (#11754) | MISS (cherche aveux en prose, pas disparition) |
| `test_triage_30_no_false_defect` | HIT, mais fermé/non déployé en gate |

Cet organe ferme la classe : **delta base→tête** mesure directement la disparition MIME, sans dépendre de la prose de remplacement.

## L'instrument

`scripts/notebook_tools/check_media_regression.py` (~370 lignes) :

1. **Cible** : par défaut `git diff --name-only origin/main...HEAD -- *.ipynb` (delta). Mode chemins explicites pour debug.
2. **Détection MIME** : `_collect_media_cells(nb)` scanne les `outputs[*].data` des cellules code, classes `image/*` / `audio/*` / `video/*`. Détecte aussi `<video>` / `<audio>` embed en HTML (`outputs[*].data[text/html]`).
3. **Trois classes** :
   - **REGRESSION_SILENCIEUSE** : cellule code présente aux deux bouts, MIME perdu, sortie substituée (texte/print/vide). Signature du defect #12000.
   - **SUPPRESSION_LEGITIME** : cellule code absente à la tête OU remplacée par cellule non-code. L'auteur a volontairement retiré.
   - **AJOUTS** : nouveau media à la tête — info, pas finding.
4. **Distinction critique** : la branche SUPPRESSION_LEGITIME ne se déclenche que si la cellule est **absente** ou **type non-code** à la tête. Si la cellule code existe mais perd son media, c'est REGRESSION_SILENCIEUSE (l'auteur a effacé sans retirer). Le cell-type check ferme le double-comptage initial.
5. **Sortie** :
   - Mode par défaut : lisible, groupes REGRESSION/SUPPRESSION/AJOUTS par notebook + summary.
   - `--json` : structuré pour CI.
   - `--check` : exit 1 si regression silencieuse stricte détectée (advisory par défaut).
6. **CLI** :
   ```
   python scripts/notebook_tools/check_media_regression.py
   python scripts/notebook_tools/check_media_regression.py --json
   python scripts/notebook_tools/check_media_regression.py --check
   python scripts/notebook_tools/check_media_regression.py --base origin/main~1
   python scripts/notebook_tools/check_media_regression.py MyIA.AI.Notebooks/GenAI/Audio
   ```

## Acceptance #12067

- [x] Détecteur CLI delta base→tête **avec contrôle positif** dans la même invocation (`test_no_modification_zero_findings` + `test_legitimate_suppression_exit_zero`).
- [x] Sortie repo-wide citée dans ce body, **compte de faux positifs ouverts un par un** (voir §Validation repo-wide).
- [x] Câblé en **advisory** d'abord (`--check` bloquant = opt-in).

## Tests

```
$ python -m pytest scripts/notebook_tools/tests/test_check_media_regression.py -q
13 passed in 3.70s
```

13 tests couvrent : `_is_media_key` (3MIME families + 4 non-media), `_collect_media_cells` (code-only filter + HTML embed), 5 fixtures delta (silencieuse, légitime, ajouté, rotation, MIME-lost-in-text-cell), JSON structuré, mode chemin-explicite, repo vide.

```
$ python -m pytest scripts/notebook_tools/tests/test_check_media_regression.py \
    scripts/notebook_tools/tests/test_scan_md_hierarchy.py \
    scripts/notebook_tools/tests/test_detect_markdown_rendering.py \
    scripts/notebook_tools/tests/test_detect_degraded_mode.py \
    scripts/tests/test_check_lane_claim.py \
    scripts/notebook_tools/tests/test_scan_md_hierarchy_drift.py -q
332 passed in 21.78s
```

## Validation repo-wide (acceptance #2)

Mesure firsthand 2026-08-22T20:08Z : `python scripts/notebook_tools/check_media_regression.py --base origin/main~50 --head origin/main --json` sur les 50 derniers commits de main :

```
summary: {
  "total_scanned": 54,
  "regression_silencieuse": 0,
  "suppression_legitime": 1,
  "ajouts": 3
}
```

Détail FP ouverts un par un :

| Notebook | Type | Cell | MIME | Verdict |
|---|---|---|---|---|
| `GameTheory-22-Manipulation-comme-Temoin.ipynb` | AJOUTS | 6 | `image/png` | INFO (substance PR #12255 MERGED — 2 charts ajoutés legit) |
| `GameTheory-22-Manipulation-comme-Temoin.ipynb` | AJOUTS | 12 | `image/png` | INFO (idem) |
| `GenAI/Audio/04-7-TTS-Voice-Benchmark.ipynb` | SUPPRESSION_LEGITIME | 40 | `image/png` | LÉGITIME (cellule remplacée par non-code — c.1331p396 PR recente, l'auteur a volontairement retiré) |
| `GenAI/Audio/04-7-TTS-Voice-Benchmark.ipynb` | AJOUTS | — | — | INFO |

**0 régression silencieuse détectée sur 50 commits / 54 notebooks scannés** — le garde fonctionne correctement et confirme qu'aucun defect #12000 n'a été introduit depuis. Les SUPPRESSION_LEGITIME sont des suppressions volontaires (cellule non-code à la tête). Les AJOUTS sont des enrichissements attendus.

## Limites documentées (FP à mesurer avant bloquant CI)

- **Rotation d'asset** : un notebook qui remplace volontairement une image par une autre (même MIME, contenu différent) — non détecté par ce garde (présence MIME intacte). Vérification par lecture visuelle.
- **Mode chemin-explicite sans base** : toute cellule avec média à la tête est comptée en AJOUTS (info). Pour une vérification stricte, passer `--base origin/main`.
- **Nettoyage volontaire** : couvert par SUPPRESSION_LEGITIME.

## Surface

```
scripts/notebook_tools/check_media_regression.py                     | 359 +++++++++++++++++++++
scripts/notebook_tools/tests/test_check_media_regression.py          | 285 ++++++++++++++++++++
2 files changed, 644 insertions(+)
```

## Anti-régression D

- 0 Lean / 0 cellule notebook / 0 metadata papermill.
- 2 fichiers scripts Python purs.
- Aucun secret (`API_KEY|SECRET|TOKEN|sk-|ghp_|AIza|password` = 0 hit sur les2 fichiers).
- LF-only (13922 + 11421 bytes, 0 CRLF).

## Plank G-VAR-1 : MED/guard = META (légitime ce cycle)

Pool narrow (cf. c.467-L1 ★★★ : picker 5/5 fantômes), livré-urn saturée. Issue #12067 = grain guard LIBRE, acceptance propre, teste-able localement avec fixtures, pas de claim narrow requis sur d'autres files. C'est un grain guard mais **avec acceptance complète** (script + 13 tests + repo-wide check + 332 siblings verts) : c'est du travail vérifié, pas un guard-padding.

Variété lane (5 derniers cycles) :
- c.467 DEEP/notebook-python
- c.468 MED/guard
- c.469 MED/guard
- c.470 MED/notebook-python (CONTENU)
- c.471 MED/slides (CONTENU)
- c.472 MED/guard (ce cycle)

Rotation des genres META vs CONTENU tient. G-VAR-3 (pas 2 LIGHT consécutifs) : respecté (slides CONTENU c.471 → guard META c.472 ; guard n'est pas LIGHT selon `variation-protocol-detail.md`).

## Coord cross-lane

- **Issue #12067** — grain livré.
- **PR #12371** (c.471, OPEN MERGEABLE) — toujours en attente sign-off + merge ai-01 (cf demande c.471).
- **PR #12369** (c.470, OPEN MERGEABLE) — idem.
- **Issue #12000** — defect fondateur que cet organe ferme en classe.

## Demande ai-01 (c.472)

1. **Sign-off + merge cette PR** : grain guard avec acceptance complète, 13 tests dédiés, 332 siblings verts, validation repo-wide (0 régression silencieuse sur 50 commits).
2. **Sign-off + merge PR #12371 + #12369** (résiduels c.471/c.470).
3. **Activation organe** : intégrer `--check` au gate CI existant (qui ? `validate_pr_notebooks.py` ? nouveau workflow dédié ?). L'advisory seul est utile pour inventaire mais ne ferme pas la classe. À arbitrer selon la stratégie CI du dépôt.

## Leçons durables

**(L1 ★★)** **Détecter la DISPARITION, pas la présence.** L'instrument fondateur #12000 remplace un media par du texte — la disparition du MIME base64 est la signature, pas la prose du texte de remplacement. Le delta base→tête attaque le problème à la racine : ce qui était là et n'y est plus. C'est généralisable : tout defect "substitution silencieuse" (placeholder → message vide, image → texte, etc.) se prête au delta MIME/clé, pas à la regex sur la sortie.

**(L2 ★★)** **Cell-type check = discriminant silencieux/légitime.** La distinction entre REGRESSION_SILENCIEUSE et SUPPRESSION_LEGITIME ne peut pas se faire sur la seule présence de la cellule : il faut vérifier que la cellule tête est **toujours de type code**. Une cellule code remplacée par une cellule markdown = suppression légitime. Une cellule code conservée mais sans media = régression silencieuse (l'auteur a effacé en silence). Le cell-type check est la signature de l'intention.

**(L3 ★★)** **Wrapper pytest à `*flags: str` APRÈS kwargs** = piège silencieux. `_run_detector(repo, *("--check",))` met `--check` en **positional** (la 2ᵉ position, pas comme kwarg), donc `base="--check", head="HEAD" (default)`. L'argv émis devient `[..., "--base", "--check", "--head", "HEAD"]` — argparse se plaint que `--base` n'a pas d'argument. Fix : signature `_run_detector(repo, *flags, base="HEAD~1", head="HEAD")` met `*flags` AVANT les kwargs, donc `--check` reste flag.

## Anti-pattern évité (c.437-L2 ★★, c.420-L1 ★★)

Pas de triple-quoted string pour les fixtures : construction dict/JSON via helpers `_notebook_with_media` / `_notebook_with_text`. Round-trip `json.dumps(nb)` testé AVANT edit.

-- po-2023:CoursIA-2