### PR TITLE
fix(guard,#12014): l'advisory composition rougit MUET sur tout constat — set -uo pipefail ne désarme pas le -e de GitHub

### DIFF
--- a/.github/workflows/slides-composition-advisory.yml
+++ b/.github/workflows/slides-composition-advisory.yml
@@ -20,7 +20,9 @@ name: Slides Composition Advisory
 # « un gate qui énumère zéro cible est vert et muet ») :
 #   (a) zéro deck découvert alors que slides/ a changé ;
 #   (b) binaire slidev introuvable — aucun deck n'est mesurable ;
-#   (c) deck découvert mais serveur jamais prêt — ce deck n'est PAS mesuré.
+#   (c) deck découvert mais serveur jamais prêt — ce deck n'est PAS mesuré ;
+#   (d) scanner sorti en 2 — contrôle positif tombé ou `__slidev__.nav.total`
+#       absent : le deck a été visité mais aucune slide n'a été mesurée.
 # (b) et (c) sont ajoutées après coup (#12147) : le gate a rendu trois verts
 # les 20-21/08 sans mesurer une seule slide — chemin node_modules faux d'un
 # niveau, puis warning + continue + exit 0. Un vert qui n'a rien mesuré est
@@ -162,12 +164,18 @@ jobs:
               META_FAIL=1
               rm -f "$DIR/dev.md"; kill %1 2>/dev/null || true; continue
             fi
+            # `set -uo pipefail` en tete de step NE desarme PAS le `-e` que GitHub
+            # met dans `shell: bash -e {0}`. Sans `|| SCAN_EXIT=$?`, le premier
+            # constat de composition (scanner -> 1) tuait le step ICI, avant le
+            # rejeu d'annotations et avant le resume : la doctrine « les CONSTATS
+            # restent advisory » n'etait pas implementee, et le rouge sortait MUET
+            # (0 octet de stdout -- mesure sur #12189/#12192/#12196 le 21/08).
+            SCAN_EXIT=0
             python scripts/notebook_tools/scan_slidev_composition.py \
               --url "http://localhost:$PORT/" \
               --slides-md "$MD" \
               --github-annotations \
-              --out "/tmp/report_$PORT.json" > /tmp/scan_$PORT.log 2>&1
-            SCAN_EXIT=$?
+              --out "/tmp/report_$PORT.json" > /tmp/scan_$PORT.log 2>&1 || SCAN_EXIT=$?
             # --github-annotations ecrit sur STDOUT ; la redirection ci-dessus les
             # enterre dans /tmp, ou GitHub ne les lit jamais -- le gate mesurait
             # sans jamais annoter. On les rejoue ici, ce que l'acceptance de #11923
@@ -175,6 +183,17 @@ jobs:
             # grep APRES l'affectation de SCAN_EXIT : un pipe rendrait le statut du
             # dernier maillon, pas celui du scanner.
             grep -E '^::(warning|error) ' "/tmp/scan_$PORT.log" || true
+            # Le scanner separe lui-meme constat (1) et defaillance d'instrument
+            # (2 : controle positif tombe, ou `__slidev__.nav.total` absent donc
+            # AUCUNE slide mesuree). Seul 2 est une meta-defaillance -- 1 reste
+            # advisory. Les confondre est precisement ce que ce gate existe pour
+            # eviter, dans le sens rouge cette fois.
+            if [ "$SCAN_EXIT" -ge 2 ]; then
+              echo "::error title=Composition gate meta-failure::$MD : scanner sorti en $SCAN_EXIT (defaillance d instrument, pas un constat) -- deck NON MESURE de facon fiable"
+              echo "--- tail /tmp/scan_$PORT.log ---"
+              tail -40 "/tmp/scan_$PORT.log" 2>/dev/null || echo "(aucun log scanner)"
+              META_FAIL=1
+            fi
             python - "$MD" "/tmp/report_$PORT.json" "$SCAN_EXIT" >> "$GITHUB_STEP_SUMMARY" <<'PYEOF'
           import json, sys
           md, rp, exit_code = sys.argv[1], sys.argv[2], int(sys.argv[3])


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #12378

## Le défaut

`slides-composition-advisory.yml` déclare `set -uo pipefail` en tête de step. Mais GitHub lance tout `run:` en `shell: /usr/bin/bash -e {0}`, et `set -uo pipefail` **ne désarme pas** `-e`. Le scanner `scan_slidev_composition.py` rend **1** dès qu'il trouve un constat de composition — donc `-e` tuait le step **sur la ligne du scanner** :

```
python scripts/notebook_tools/scan_slidev_composition.py ... > /tmp/scan_$PORT.log 2>&1
SCAN_EXIT=$?     # <-- jamais atteint
```

Tout ce qui est écrit sous cette ligne — le rejeu des annotations, le résumé, la logique advisory — était du **code mort**. L'auteur avait pourtant écrit le commentaire soigneux sur `grep` APRÈS l'affectation de `SCAN_EXIT` : l'intention était juste, `-e` la préemptait.

## Ce que ça coûtait, mesuré

Sur **#12189 / #12192 / #12196** (21/08), le job sort **0 octet de stdout** puis `exit 1`, 2 min 16 s après le début du step. Deux conséquences :

1. **La doctrine écrite en tête du fichier n'était pas implémentée.** Le commentaire dit « Les CONSTATS restent advisory (exit 0) : c'est la doctrine de ce gate ». En pratique tout constat devenait un rouge.
2. **Les annotations `::warning file=,line=` n'ont jamais été émises.** C'est le critère d'acceptance explicite de #11923 (« file=,line= exploitable en annotation CI »). Elles restaient dans `/tmp/scan_$PORT.log`, et le `grep` qui les rejoue est sous la ligne fatale.

Et le gate perdait, **dans le sens rouge**, la distinction qu'il existe pour porter : `scanner=1` (constat normal) et `scanner=2` (défaillance d'instrument — contrôle positif tombé, ou `__slidev__.nav.total` absent donc **aucune** slide mesurée) rendaient le même rouge muet. L'en-tête sépare trois causes de méta-défaillance précisément parce qu'« un vert qui n'a rien mesuré est indiscernable d'un vert qui n'a rien trouvé » ; le symétrique rouge était cassé.

## Le fix

1. `SCAN_EXIT=0` puis `|| SCAN_EXIT=$?` — la forme assignation-sur-échec est la seule qui survive à `-e` tout en préservant le code.
2. `SCAN_EXIT >= 2` devient la cause **(d)** de méta-défaillance, nommée dans un `::error` avec le tail du log, et documentée dans l'en-tête du workflow aux côtés de (a)/(b)/(c).

`1` reste advisory. `2` rougit **en disant pourquoi**.

## Contrôle positif — les deux directions, harnais identique sous `bash -e`

| | annotations | résumé | exit |
|---|---|---|---|
| **avant** fix, scanner **=1** | ✗ aucune | ✗ | **1** (rouge muet) |
| après fix, scanner **=0** | ✓ | ✓ | 0 |
| après fix, scanner **=1** | ✓ | ✓ | **0** — constat = advisory |
| après fix, scanner **=2** | ✓ + `::error` nommant la cause | ✓ | **1** — méta-défaillance |

Sémantique bash vérifiée isolément :

```
$ bash -e -c 'set -uo pipefail; false; echo REACHED'      ; echo "exit=$?"
exit=1                                    # <- rien d'imprimé : -e reste actif
$ bash -e -c 'set -uo pipefail; RC=0; false || RC=$?; echo "REACHED rc=$RC"'
REACHED rc=1                              # exit=0
```

`yaml.safe_load` sur le workflow : OK. `bash -n` sur le step extrait du YAML : OK.

## Portée — ce que ce fix ne fait pas

Il rétablit le **plancher mécanisable** et ses annotations. Il ne dit rien de la composition des trois PRs slides : leur QA visuel reste dû, et par la doctrine du gate lui-même il **précède** le verdict, il ne le suit pas. Ce fix rend simplement ce QA possible sur une mesure au lieu d'un rouge aveugle.

See #12014
