### PR TITLE
feat(check_lane_claim,#12386): v2 conditional [DELIVERED] -- PR state-bound active claim

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -776,7 +776,10 @@ def _claim_scope_effectively_epic_wide(ev: ClaimEvent) -> bool:
     return len(empty) >= len(paths)
 
 
-def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEvent]]:
+def compute_active_claims(
+    events: list[ClaimEvent],
+    pr_states: dict[int, str] | None = None,
+) -> tuple[dict, list[ClaimEvent]]:
     """Reduce a chronologically-ordered event list to active claims per lane.
 
     Returns `(active_by_lane, unattributed)`:
@@ -836,6 +839,22 @@ def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEve
                 state[ev.lane] = ev
         elif ev.is_open:
             state[ev.lane] = ev
+        elif ev.is_delivered:
+            # #12386 -- v2 conditional gate. `is_delivered` already separated
+            # `[DELIVERED]` from `[RELEASED]` (close markers in v1); v2 keeps
+            # the close behaviour for two of the three branches (CLOSED /
+            # lookup-failed) and re-marks the event as `open` for OPEN / MERGED.
+            # `locked: True` on the MERGED branch is the cross-check the
+            # #10223 `[OVERRIDE]` machinery can read to refuse a plain
+            # re-claim (the override branch in `_run_check` honours it).
+            v2_action = _resolve_delivered_v2(ev, pr_states)
+            if v2_action == "open":
+                state[ev.lane] = ev
+            elif v2_action == "open_locked":
+                ev["locked"] = True
+                state[ev.lane] = ev
+            else:  # "close" -- legacy v1 behaviour preserved on this branch
+                state.pop(ev.lane, None)
         else:
             state.pop(ev.lane, None)
     return state, unattributed
@@ -883,6 +902,150 @@ def _sort_events(payload: dict) -> list[ClaimEvent]:
     # Server createdAt, ISO 8601 UTC -> lexicographic order == chronological.
     events.sort(key=lambda e: e.created_at or "")
     return events
+
+
+# #12386 -- PR-state lookup for the `[DELIVERED]` v2 conditional reducer.
+#
+# A `[DELIVERED] lane X -- PR #N` carries a PR reference, and the v2 conditional
+# gate binds the marker's effective action to the LIVE PR state:
+#
+#   - PR OPEN       -> DELIVERED is re-marked as `action: open` (the substance
+#                      is in flight; the lane stays blocked). A second lane
+#                      arriving at this issue MUST NOT re-claim -- this closes
+#                      the 10 h 24 window measured on #12213 where the deliverer
+#                      released the lock and another lane re-shipped the same work.
+#   - PR MERGED      -> DELIVERED is re-marked as `action: open` AND the event
+#                      carries `locked: True`. Re-claiming demands a written
+#                      `[OVERRIDE]` from a coordinator; the substance has been
+#                      accepted by main and the issue is considered resolved.
+#   - PR CLOSED (not merged) -> legacy v1 behaviour: DELIVERED pops the lane.
+#                      The attempt failed, the lane is free.
+#
+# The reducer was deliberately built without side effects (#12320 in the v1
+# docstring: "the fetch itself (state of PR N) is left to consumers: the
+# reducer stays pure"). v2 walks that line by passing an injected `pr_states`
+# map (testability + opt-out) -- the default path reads from `gh` lazily, only
+# for `[DELIVERED]` events that carry a `pr_ref`. Callers that already know the
+# state (replay of an audit log, an offline test) can pass the map directly.
+#
+# Failures are surfaced as `pr_state: None` (the reducer falls back to legacy
+# v1 close-on-DELIVERED). The previous v1 semantics are PRESERVED on a fetch
+# failure -- an unreachable `gh` MUST NOT cause a `[DELIVERED]` to suddenly
+# start blocking. The failure is visible in `delivered_claims_failed` so an
+# operator can see which lookups were silently degraded.
+_PR_STATE_CACHE: dict[int, tuple[str | None, str | None]] = {}
+# value shape: (pr_state, error_message) where pr_state in
+# {"OPEN","MERGED","CLOSED",None} and error_message is None on success.
+
+
+def _fetch_pr_state(pr_ref: int) -> tuple[str | None, str | None]:
+    """Return (pr_state, error) for a PR number, with a per-process cache.
+
+    `pr_state` is one of:
+      - "OPEN"    : the PR is still mergeable / not yet closed or merged
+      - "CLOSED"  : closed WITHOUT being merged
+      - "MERGED"  : closed AND merged (the substance reached main)
+      - None      : the lookup failed (no network, gh error, PR not found)
+
+    `error` is a short string on failure, None on success. The cache prevents
+    repeated `gh pr view` calls when a single check visit processes several
+    DELIVERED events on the same PR (rare but seen on audit issues with
+    multiple deliveries from different lanes).
+
+    The function is NOT called from the parser: parse_claim_event stays pure,
+    per the #12320 contract. The reducer (`compute_active_claims`) is the only
+    caller, and only for events that already have `pr_ref != None`.
+    """
+    if pr_ref in _PR_STATE_CACHE:
+        return _PR_STATE_CACHE[pr_ref]
+    try:
+        proc = subprocess.run(
+            [
+                "gh", "pr", "view", str(pr_ref),
+                "--json", "state,merged",
+            ],
+            capture_output=True, text=True, shell=False,
+        )
+    except Exception as exc:  # pragma: no cover -- defensive
+        result = (None, f"gh exec failed: {exc}")
+        _PR_STATE_CACHE[pr_ref] = result
+        return result
+    if proc.returncode != 0:
+        result = (None, f"gh pr view {pr_ref} exit {proc.returncode}: {proc.stderr.strip()[:200]}")
+        _PR_STATE_CACHE[pr_ref] = result
+        return result
+    try:
+        d = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        result = (None, f"gh pr view {pr_ref} non-JSON: {exc}")
+        _PR_STATE_CACHE[pr_ref] = result
+        return result
+    # GH field model: `state` in {OPEN, CLOSED, MERGED}, `merged` is a bool.
+    # When `state == "MERGED"`, the reducer should still treat the substance as
+    # locked -- the PR reached main. `merged=True` on its own is enough to lock
+    # even if `state` was raced (defence in depth: the bool was the canonical
+    # source until 2026).
+    if d.get("merged") is True:
+        result = ("MERGED", None)
+    elif d.get("state") == "MERGED":
+        result = ("MERGED", None)
+    elif d.get("state") == "CLOSED":
+        result = ("CLOSED", None)
+    elif d.get("state") == "OPEN":
+        result = ("OPEN", None)
+    else:
+        result = (None, f"unexpected gh state payload: {d!r}")
+    _PR_STATE_CACHE[pr_ref] = result
+    return result
+
+
+def _resolve_delivered_v2(
+    ev: ClaimEvent,
+    pr_states: dict[int, str] | None,
+) -> str:
+    """Compute the effective action for a `[DELIVERED]` event under the v2 semantics.
+
+    Returns one of:
+      - "open"          : the PR is OPEN; the substance is in flight; the lane
+                          MUST stay blocked. Equivalent to re-marking the event
+                          as a `[CLAIMED]`.
+      - "open_locked"   : the PR is MERGED; the substance has been accepted;
+                          the lane MUST stay blocked AND cannot be re-claimed
+                          without a coordinator `[OVERRIDE]`.
+      - "close"         : the PR is CLOSED without merge, OR the PR state could
+                          not be resolved, OR the event carries no `pr_ref`.
+                          Equivalent to legacy v1 behaviour (lane pops from state).
+
+    Side effect (#12386, JSON summary): when a `pr_ref` is present, the resolved
+    state is attached to the event as `ev["pr_state"]` so the JSON summary can
+    surface it to consumers (the `delivered_claims_pr_states` map and the
+    per-active-claim `pr_state` field both read this attribute). On a
+    `pr_ref is None` event, no `pr_state` is attached -- the legacy v1 path
+    is unchanged for unreferenced deliveries.
+
+    `pr_states` is an optional injection map (testable): if supplied, the
+    reducer does NOT call `gh`. If absent or the pr_ref is unknown to the map,
+    the reducer calls `gh pr view` via `_fetch_pr_state`. The map and the live
+    fetch are mutually exclusive -- a test that provides the map can run
+    offline, an end-to-end test can omit it.
+    """
+    pr_ref = ev.get("pr_ref")
+    if pr_ref is None:
+        return "close"  # legacy: a DELIVERED without a PR ref is a close
+    if pr_states is not None:
+        st = pr_states.get(pr_ref)
+    else:
+        st, _err = _fetch_pr_state(pr_ref)
+    # Attach the resolved state to the event for the JSON summary. On a None
+    # state (lookup failed) we still attach None so the consumer sees that we
+    # TRIED -- the absence of the key would otherwise be indistinguishable from
+    # a non-DELIVERED event.
+    ev["pr_state"] = st
+    if st == "OPEN":
+        return "open"
+    if st == "MERGED":
+        return "open_locked"
+    return "close"
 
 
 def _post_comment(issue: str, body: str) -> None:
@@ -942,6 +1105,84 @@ def _gh_open_prs_with_files() -> list[dict]:
         )
 
 
+# #12386 v2 -- `_find_open_pr_for_issue_by_lane` returns the unique OPEN PR
+# in `lane` whose body references `issue_number` (case insensitive
+# `Closes #N` / `Fixes #N` / `Refs #N` / `See #N` / plain `#N`), OR `None`
+# when no match (caller falls back to plain `[RELEASED]`).
+#
+# Why the helper is here and not in `main`: callers (`--release` smart
+# branch) want ONE function that returns "the PR to bind", and we want
+# the predicate (open + same-lane + references-the-issue) to live in
+# exactly one place. The legacy `_gh_open_prs_with_files()` is reused
+# because we already paginate 200 OPEN PRs (enough for typical work) and
+# we already consume its body field elsewhere.
+#
+# Test injection: callers may pre-fetch the PRs once and pass `prs` to
+# avoid double `gh pr list` round-trips in tests; otherwise we fetch
+# here. The lane-tag reading uses the SHARED `extract_lane` helper --
+# never a private regex -- so the rule stays single-sourced (#9485).
+def _find_open_pr_for_issue_by_lane(
+    issue_number: int,
+    lane: str,
+    prs: list[dict] | None = None,
+) -> int | None:
+    """Return the unique OPEN PR number in `lane` referencing `issue_number`.
+
+    The matcher accepts any of: `Closes #N` / `Fixes #N` / `Refs #N` / `See
+    #N` / `Resolves #N` / a bare `#N` token in the PR body. The
+    `Refs #N` / `See #N` forms are the dispatch style (#10555) where a PR
+    only partially closes an epic. The bare `#N` form covers PRs that
+    mention the issue informally -- we keep it lenient because the
+    `[DELIVERED]` marker is itself the binding attestation; the PR-body
+    match just surfaces WHICH PR to record.
+    """
+    if prs is None:
+        prs = _gh_open_prs_with_files()
+    pat = re.compile(
+        r"(?i)\b(?:closes|fixes|refs|see|resolves|part\s+of|part-of)\s*"
+        + r"#(\d+)\b|\B#(\d+)\b"
+    )
+    matches: list[int] = []
+    for pr in prs:
+        body = (pr.get("body") or "")
+        # Per #9485 single-reader: use the SAME `extract_lane` the rest
+        # of the file uses. `extract_lane(body)` returns the first lane
+        # token it finds, accepting both `lane myia-po-2023:CoursIA-2`
+        # and `<!-- lane: ... -->` forms.
+        pr_lane = extract_lane(body)
+        if pr_lane != lane:
+            continue
+        for m in pat.finditer(body):
+            captured = m.group(1) or m.group(2)
+            if captured is None:
+                continue
+            try:
+                if int(captured) == issue_number:
+                    matches.append(int(pr["number"]))
+                    break
+            except (KeyError, ValueError, TypeError):
+                continue
+    if len(matches) == 0:
+        return None
+    if len(matches) > 1:
+        # Multiple OPEN PRs in the same lane reference the issue -- the
+        # caller has been racing themselves. We pick the lowest number
+        # (deterministic, oldest PR wins) and emit a stderr warning so
+        # the dashboard [DONE] can flag the ambiguity. We do NOT post
+        # DELIVERED silently here: a misleading PR reference would
+        # LOCK the wrong PR. Callers should fall back to plain
+        # `[RELEASED]` in this case.
+        print(
+            f"WARN: {len(matches)} OPEN PRs in lane {lane} reference "
+            f"#{issue_number}; refusing to pick one to bind to "
+            f"[DELIVERED]. Use --release with --note 'delivered:#N' to "
+            f"force a specific PR, or close/merge the others first.",
+            file=sys.stderr,
+        )
+        return None
+    return matches[0]
+
+
 def _path_matches(path: str, patterns: list[str]) -> bool:
     """Return True if `path` matches any of the caller-provided patterns.
 
@@ -979,6 +1220,23 @@ _CLAIM_BODY_TMPL = (
 )
 _RELEASE_BODY_TMPL = (
     "[RELEASED] lane {lane} -- {note}{paths_clause}\n"
+)
+# #12386 v2 -- `[DELIVERED]` carries an explicit PR reference. The `locked:
+# True` reducer branch on `_fetch_pr_state(pr_ref) == "MERGED"` is the
+# v2 gate; a plain `[RELEASED]` would only free the active_claims slot,
+# losing the merged-link that powers the LOCKED verdict above. The
+# `--release` flow in `main` chooses DELIVERED when (a) the caller has
+# exactly one OPEN PR in their lane referencing the issue (body or
+# refs/closes), and (b) the PR number parses; otherwise it falls back to
+# RELEASED for backwards compat (caller can be releasing without an OPEN
+# PR -- the "released" plain form still applies).
+_DELIVERED_BODY_TMPL = (
+    "[DELIVERED] lane {lane} -- PR #{pr_ref}{paths_clause}\n\n"
+    "(#12386 v2: PR state-bound. While the PR is OPEN the lane keeps an "
+    "active claim that blocks cross-lane claims; once the PR is MERGED on "
+    "main the claim is `locked: True` and a `[OVERRIDE]` is required to "
+    "re-open. A `Closes #N` in the next PR body or `gh issue close --reason "
+    "COMPLETED` will retire the claim.)\n"
 )
 
 
@@ -1357,7 +1615,8 @@ def _parse_iso_utc(iso: str) -> datetime | None:
 
 def _run_check(payload: dict, my_lane: str, stale_threshold=None,
                now: datetime | None = None,
-               my_paths: list[str] | None = None) -> int:
+               my_paths: list[str] | None = None,
+               pr_states: dict[int, str] | None = None) -> int:
     """Issue-claim check: exit 1 if another lane blocks, 0 if clear.
 
     Args:
@@ -1408,7 +1667,7 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
         for ev in events:
             if ev.get("paths"):
                 ev["empty_scope"] = _empty_scope_in(ev["paths"], tracked)
-    active, unattributed = compute_active_claims(events)
+    active, unattributed = compute_active_claims(events, pr_states=pr_states)
     others = {ln: ev for ln, ev in active.items() if ln != my_lane}
     mine = active.get(my_lane)
 
@@ -1532,6 +1791,21 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
                 # its gate on the live PR state. None on every non-DELIVERED
                 # marker, and on a DELIVERED marker that did not name a PR.
                 "pr_ref": ev.get("pr_ref"),
+                # #12386 -- v2 conditional gate witness. Surfaces the live PR
+                # state that the reducer used to bind the event's effective
+                # action. None on a non-DELIVERED event, on a DELIVERED event
+                # whose `pr_ref` is None, OR on a DELIVERED event whose PR
+                # state could not be fetched (degraded to legacy v1 close).
+                # Strings: "OPEN" (substance in flight), "MERGED" (locked),
+                # "CLOSED" (attempt failed, lane free), or None (lookup-failed).
+                "pr_state": ev.get("pr_state"),
+                # #12386 -- locked witness for v2 MERGED branch. True ONLY on
+                # an event the reducer re-marked as `open` because the PR is
+                # MERGED: the substance reached main, the issue is resolved,
+                # and re-claiming requires a coordinator `[OVERRIDE]`. None
+                # on every other branch (legacy v1 close, OPEN, RELEASED,
+                # etc.).
+                "locked": ev.get("locked", False),
                 # #10597 hardener -- surface the witness list of residual
                 # `{`/`}` so a human reviewer can see WHY an unparseable claim
                 # is being treated as epic-wide. The list may be empty (the
@@ -1571,6 +1845,20 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             for ev in events
             if ev.marker == "DELIVERED" and ev.get("pr_ref")
         }),
+        # #12386 -- v2 PR-state map for every historical `[DELIVERED]` close on
+        # this issue. Keys = PR number, value = the LIVE state the reducer read
+        # (`OPEN` / `MERGED` / `CLOSED`) or `None` when the lookup failed. A
+        # consumer that needs to decide "should I re-claim?" looks up its
+        # `delivered_claims` list here: any non-CLOSED value is information,
+        # any CLOSED value is "free to re-claim" only if the original attempt
+        # failed (no MERGED on the same number). The map is keyed by PR number
+        # to match `delivered_claims`. An issue with NO deliveries has an
+        # empty map.
+        "delivered_claims_pr_states": {
+            ev.get("pr_ref"): ev.get("pr_state")
+            for ev in events
+            if ev.marker == "DELIVERED" and ev.get("pr_ref") is not None
+        },
         "unattributed_markers": len(unattributed),
         # #11239 -- bare-marker lines (no brackets) carrying a claim motif.
         # The organ does not read them (`_MARKER_RE` requires the brackets),
@@ -1708,6 +1996,38 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             f"`[CLAIMED] paths: ...`, or wait for release.",
             file=sys.stderr,
         )
+        # #12386 -- v2 LOCKED verdict. When the blocker is a `[DELIVERED]`
+        # whose PR reached main (`locked: True`), a plain re-claim is NOT a
+        # path forward -- the issue is resolved. We surface a tailored message
+        # naming the merged PR and pointing at the `[OVERRIDE]` lane-comment
+        # machinery as the only escape (cf #10223, marker semantics: a
+        # coordinator `[OVERRIDE]` is the documented way to re-open a locked
+        # claim). Without this branch, a lane arriving on a CLEAR-summary
+        # would still see `blocking_lanes` empty AND the merged PR in
+        # `delivered_claims_pr_states` -- the message naming the lock is what
+        # closes the loop. We do NOT raise the exit code: 1 stays the
+        # `BLOCKED` verdict for both branches; the message discriminates.
+        locked_blockers = [
+            ev for ev in others.values() if ev.get("locked")
+        ]
+        if locked_blockers:
+            lines = []
+            for ev in locked_blockers:
+                pr = ev.get("pr_ref")
+                ln = ev.get("lane") or "?"
+                lines.append(f"  - lane {ln} -- PR #{pr} MERGED on main")
+            print(
+                f"\nLOCKED (v2): the issue is resolved on main by a MERGED "
+                f"PR. A plain re-claim is not a path forward -- the substance "
+                f"has reached `main` and the issue is considered done. The "
+                f"only mechanical escape is a coordinator `[OVERRIDE] lane "
+                f"<m:w>` comment on #{payload.get('number')} (cf #10223); "
+                f"the writer lane that delivered the merge (or any other "
+                f"lane) can also close the issue R5 (`Closes #N` in the next "
+                f"PR body, or `gh issue close --reason COMPLETED`).\n"
+                + "\n".join(lines),
+                file=sys.stderr,
+            )
         return 1
     # #12345 -- fail-CLOSED on an entirely-dead scope, EVEN with no
     # blockers. Without this branch, a caller who typo'd every glob in
@@ -2119,17 +2439,77 @@ def main(argv: list[str] | None = None) -> int:
         print(f"posted [CLAIMED] lane {args.lane} on #{args.issue}{scope}")
         return 0
     if args.release is not None:
+        # #12386 v2 -- smart DELIVERED-vs-RELEASED selection. A `[RELEASED]`
+        # would only free the active_claims slot and lose the merged-link
+        # that powers the LOCKED verdict above. When the caller has a single
+        # OPEN PR in their lane referencing the issue, we post
+        # `[DELIVERED] … -- PR #N` instead; the PR-state gate then stays
+        # live until the PR reaches MERGED (`locked: True`).
+        #
+        # Smart-selection rules (the `--note` arg can override):
+        #   1. `--note` literal starting with `delivered:#N` forces
+        #      `[DELIVERED]` with that exact PR (escape hatch for the
+        #      multi-PR ambiguity case).
+        #   2. Else, `_find_open_pr_for_issue_by_lane` returns a single
+        #      PR or None.
+        #   3. Single match -> `[DELIVERED]` with that PR.
+        #   4. None match -> `[RELEASED]` (back-compat: caller may be
+        #      releasing without an OPEN PR referencing this issue).
+        #   5. Multi-match -> `[RELEASED]` (the WARN has been emitted by
+        #      the helper; the caller should disambiguate next cycle).
         note = args.release or "released"
-        body = _RELEASE_BODY_TMPL.format(
-            lane=args.lane, note=note, paths_clause=_paths_clause(args.paths),
-        )
+        chosen_kind = "RELEASED"
+        chosen_pr: int | None = None
+        forced = note.lower().startswith("delivered:#")
+        if forced:
+            forced_str = note.split(":", 1)[1].strip()
+            try:
+                chosen_pr = int(forced_str.lstrip("#"))
+                chosen_kind = "DELIVERED"
+            except ValueError:
+                print(
+                    f"WARN: --note {note!r} starts with 'delivered:#' but "
+                    f"cannot be parsed as an integer; falling back to "
+                    f"[RELEASED].",
+                    file=sys.stderr,
+                )
+                chosen_kind = "RELEASED"
+                chosen_pr = None
+        else:
+            try:
+                chosen_pr = _find_open_pr_for_issue_by_lane(
+                    int(args.issue), args.lane,
+                )
+            except (RuntimeError, ValueError) as exc:
+                # gh failure or non-integer issue -- degrade to RELEASED
+                # rather than refusing the post (the comment is the
+                # primary contract; the PR-binding is a nicety).
+                print(
+                    f"WARN: could not scan OPEN PRs to bind "
+                    f"[DELIVERED]: {exc}. Falling back to [RELEASED].",
+                    file=sys.stderr,
+                )
+                chosen_pr = None
+            if chosen_pr is not None:
+                chosen_kind = "DELIVERED"
+        if chosen_kind == "DELIVERED":
+            body = _DELIVERED_BODY_TMPL.format(
+                lane=args.lane, pr_ref=chosen_pr,
+                paths_clause=_paths_clause(args.paths),
+            )
+        else:
+            body = _RELEASE_BODY_TMPL.format(
+                lane=args.lane, note=note,
+                paths_clause=_paths_clause(args.paths),
+            )
         try:
             _post_comment(args.issue, body)
         except RuntimeError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2
         scope = f" (paths: {', '.join(args.paths)})" if args.paths else ""
-        print(f"posted [RELEASED] lane {args.lane} on #{args.issue}{scope}")
+        marker = "[DELIVERED]" if chosen_kind == "DELIVERED" else "[RELEASED]"
+        print(f"posted {marker} lane {args.lane} on #{args.issue}{scope}")
         return 0
 
     # Check mode (default). `--paths` (when supplied with an issue) threads

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -4006,3 +4006,344 @@ def test_is_delivered_property_distinguishes_marker():
         "[CLAIMED] lane X -- working", "2026-08-22T01:00:00Z"))
     assert ev.is_delivered is False
     assert ev.is_open is True
+
+
+# ---------------------------------------------------------------------------
+# #12386 -- v2 conditional [DELIVERED]: gate the close on live PR state.
+#
+# v1's contract: a [DELIVERED] is a close -- it pops the lane from
+# `state` (see test_delivered_close_drops_lane_from_active_claims above).
+# v2's contract: a [DELIVERED] is a CONDITIONAL close keyed on the PR
+# state:
+#
+#   - PR OPEN   -> the deliverer keeps an active claim (still WRITING);
+#                 subsequent claims from other lanes are BLOCKED.
+#   - PR MERGED -> the deliverer keeps an active claim but `locked: True`;
+#                 a plain re-claim is BLOCKED with a tailored LOCKED
+#                 message; the only escape is a coordinator [OVERRIDE].
+#   - PR CLOSED (not merged) -> legacy close: lane popped from state.
+#   - PR not found / lookup failure -> legacy close (fail-CLOSED means
+#                 refuse to BLOCK on unknown).
+#   - DELIVERED without PR #N reference -> legacy close (the v1 surface).
+#
+# Tests below use `pr_states` injection to avoid any `gh pr view` round
+# trip; the live-PR-state code path is exercised in the integration
+# smoke at the bottom of `test_run_check_delivered_uses_gh_pr_view` (NOT
+# auto-run in CI; covered manually on the worker with a real PR ref).
+# ---------------------------------------------------------------------------
+
+def _pr_states(pr: int, st: str) -> dict[int, str]:
+    """Build a single-entry pr_states injection dict for v2 tests."""
+    return {pr: st}
+
+
+def test_delivered_open_blocks_subsequent_claim_via_pr_state(capsys):
+    """v2: a [DELIVERED] whose PR is still OPEN keeps the lane active (#12386).
+
+    The motivating incident is #12253/#12298: a 10-hour window of
+    free state let another lane claim an issue whose [DELIVERED] lane
+    was still WRITING the PR. v2 closes the conditional gap by gating
+    the [DELIVERED] on the live PR state -- an OPEN PR keeps the claim
+    active, BLOCKING subsequent claimers from any other lane until either
+    the PR is merged (locked) or closed (legacy lift).
+    """
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA-2 -- substance A",
+                "2026-08-22T01:00:00Z"),
+        comment("[DELIVERED] lane myia-po-2026:CoursIA-2 -- PR #12253",
+                "2026-08-22T02:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2023:CoursIA-2",
+                       pr_states=_pr_states(12253, "OPEN"),
+                       my_paths=["scripts/check_lane_claim.py"])
+    assert rc == 1  # BLOCKED
+    out = _json_out(capsys.readouterr())
+    assert "myia-po-2026:CoursIA-2" in out["blocking_lanes"]
+    # PR state surfaces in the JSON summary for forensics. JSON serialises
+    # int keys as strings -- this is the same shape consumers see on stdout.
+    assert out["delivered_claims_pr_states"] == {"12253": "OPEN"}
+    # Active-claim entry for the deliverer exposes the live pr_state (raw,
+    # not JSON-serialised).
+    active = out["active_claims"]["myia-po-2026:CoursIA-2"]
+    assert active["pr_ref"] == 12253
+    assert active["pr_state"] == "OPEN"
+    assert active["locked"] is False
+
+
+def test_delivered_merged_locks_with_overrides_required(capsys):
+    """v2: a [DELIVERED] whose PR is MERGED on main locks the lane (#12386).
+
+    `locked: True` is the flag the reducer attaches so the BLOCKED
+    branch above can render a tailored message naming the merged PR and
+    pointing the caller at [OVERRIDE] / R5 close as the only escapes.
+    Without this flag, a lane arriving on a CLEAR summary would still
+    see `blocking_lanes` empty AND the merged PR in
+    `delivered_claims_pr_states` -- the message naming the lock is
+    what closes the loop.
+    """
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA-2 -- substance A",
+                "2026-08-22T01:00:00Z"),
+        comment("[DELIVERED] lane myia-po-2026:CoursIA-2 -- PR #12298",
+                "2026-08-22T02:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2023:CoursIA-2",
+                       pr_states=_pr_states(12298, "MERGED"),
+                       my_paths=["scripts/check_lane_claim.py"])
+    assert rc == 1  # BLOCKED (LOCKED branch fires inside)
+    captured = capsys.readouterr()
+    out = _json_out(captured)
+    assert "myia-po-2026:CoursIA-2" in out["blocking_lanes"]
+    assert out["delivered_claims_pr_states"] == {"12298": "MERGED"}
+    active = out["active_claims"]["myia-po-2026:CoursIA-2"]
+    assert active["locked"] is True
+    assert active["pr_state"] == "MERGED"
+    # The LOCKED message naming the merged PR must appear on stderr.
+    assert "LOCKED (v2)" in captured.err
+    assert "PR #12298 MERGED" in captured.err
+
+
+def test_delivered_closed_lifts_active_claim(capsys):
+    """v2: a [DELIVERED] whose PR was CLOSED (not merged) lifts the claim (#12386).
+
+    CLOSED-without-MERGED is the legacy lift path: the PR did not reach
+    main, the deliverer's claim should NOT block forever. The reducer
+    pops the lane from `state`, identical to v1 behaviour for this
+    state. The forensic record (delivered_claims) survives.
+    """
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA-2 -- substance A",
+                "2026-08-22T01:00:00Z"),
+        comment("[DELIVERED] lane myia-po-2026:CoursIA-2 -- PR #12253",
+                "2026-08-22T02:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2023:CoursIA-2",
+                       pr_states=_pr_states(12253, "CLOSED"),
+                       my_paths=["scripts/check_lane_claim.py"])
+    assert rc == 0
+    out = _json_out(capsys.readouterr())
+    assert out["my_active_claim"] is False
+    assert out["blocking_lanes"] == []
+    assert out["delivered_claims"] == [12253]
+    assert out["delivered_claims_pr_states"] == {"12253": "CLOSED"}
+
+
+def test_delivered_lookup_failure_legacy_close(capsys):
+    """v2: when gh pr view cannot resolve the PR, fall back to legacy close (#12386).
+
+    Fail-CLOSED semantics: a [DELIVERED] that we cannot bind to a PR
+    must NOT keep the lane active forever (that would itself be a bug:
+    it would lock every issue where a PR was deleted or moved). The
+    reducer treats `None` from `_fetch_pr_state` as the legacy v1
+    "close" action. The forensic record still carries the PR ref.
+    """
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA-2 -- substance A",
+                "2026-08-22T01:00:00Z"),
+        comment("[DELIVERED] lane myia-po-2026:CoursIA-2 -- PR #99999",
+                "2026-08-22T02:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2023:CoursIA-2",
+                       pr_states={},  # 99999 not present -> legacy close
+                       my_paths=["scripts/check_lane_claim.py"])
+    assert rc == 0
+    out = _json_out(capsys.readouterr())
+    assert out["my_active_claim"] is False
+    assert out["blocking_lanes"] == []
+    assert out["delivered_claims"] == [99999]
+
+
+def test_delivered_without_pr_ref_still_lifts_active_claim(capsys):
+    """v2: [DELIVERED] without a PR #N keeps the v1 close path (#12320/v2 compat).
+
+    The marker is legal but unreferenced. v1 treated it as a close;
+    v2 preserves that behaviour because there is no PR to bind the
+    state to. The forensic record surface (`delivered_claims`,
+    `delivered_claims_pr_states`) only carries entries with a PR
+    reference -- an unreferenced [DELIVERED] is recorded by the parser
+    but invisible in the forensic lists (consistent with v1).
+    """
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA-2 -- substance A",
+                "2026-08-22T01:00:00Z"),
+        comment("[DELIVERED] lane myia-po-2026:CoursIA-2 -- substance shipped",
+                "2026-08-22T02:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2023:CoursIA-2",
+                       pr_states=None,
+                       my_paths=["scripts/check_lane_claim.py"])
+    assert rc == 0
+    out = _json_out(capsys.readouterr())
+    assert out["my_active_claim"] is False
+    # Unreferenced [DELIVERED] is filtered from the forensic lists (the
+    # parser records it but consumers want only PR-bound entries).
+    assert out["delivered_claims"] == []
+    assert out["delivered_claims_pr_states"] == {}
+
+
+def test_delivered_replay_locks_again_after_open_then_merged(capsys):
+    """v2: chronological replay of one DELIVERED should track the live PR.
+
+    The motivating chronologie is #12213 (a 07:40 replay of an OPEN
+    [DELIVERED] was BLOCKED, then a later cycle with MERGED returned
+    BLOCKED+locked). We replay that exact sequence here with `pr_states`
+    toggled across two calls; the second call MUST show `locked: True`
+    while the first MUST show the active-claim. Without the v2 gate,
+    the first call would CLEAR (v1 behaviour) and the second would
+    still be CLEAR -- exactly the failure mode #12213 named.
+    """
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA-2",
+                "2026-08-22T01:00:00Z"),
+        comment("[DELIVERED] lane myia-po-2026:CoursIA-2 -- PR #12213",
+                "2026-08-22T02:00:00Z"),
+    )
+    my_paths = ["scripts/check_lane_claim.py"]
+    # Step 1: PR is still OPEN -> BLOCKED
+    rc = clc._run_check(p, "myia-po-2023:CoursIA-2",
+                       pr_states=_pr_states(12213, "OPEN"),
+                       my_paths=my_paths)
+    assert rc == 1
+    out = _json_out(capsys.readouterr())
+    assert "myia-po-2026:CoursIA-2" in out["blocking_lanes"]
+    assert out["active_claims"]["myia-po-2026:CoursIA-2"]["locked"] is False
+    # Step 2: PR now MERGED -> BLOCKED + locked
+    rc = clc._run_check(p, "myia-po-2023:CoursIA-2",
+                       pr_states=_pr_states(12213, "MERGED"),
+                       my_paths=my_paths)
+    assert rc == 1
+    captured = capsys.readouterr()
+    out = _json_out(captured)
+    assert "myia-po-2026:CoursIA-2" in out["blocking_lanes"]
+    assert out["active_claims"]["myia-po-2026:CoursIA-2"]["locked"] is True
+    assert "LOCKED (v2)" in captured.err
+
+
+def test_pr_states_signature_is_optional_no_behavioural_change(capsys):
+    """v2: callers that don't pass `pr_states` keep the v1 surface.
+
+    Without an injected state, `_resolve_delivered_v2` calls
+    `_fetch_pr_state` (which round-trips through `gh`). In CI without
+    `gh` available, this surfaces as the legacy close -- the test
+    asserts the function signature accepts `None` and returns v1 shape.
+    """
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2026:CoursIA-2",
+                "2026-08-22T01:00:00Z"),
+        comment("[DELIVERED] lane myia-po-2026:CoursIA-2 -- PR #99999",
+                "2026-08-22T02:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2023:CoursIA-2",
+                       pr_states=None,
+                       my_paths=["scripts/check_lane_claim.py"])
+    # Either CLEAR (legacy close when gh auth works) or NOT_SCOPED
+    # (when gh auth fails and we cannot introspect). Both are valid v1
+    # surfaces -- the test pins that v2 did not crash with a TypeError
+    # on the new kwarg.
+    assert rc in (0, 2)
+    captured = capsys.readouterr()
+    if rc == 0:
+        out = _json_out(captured)
+        # The forensic PR ref still surfaces.
+        assert 99999 in out["delivered_claims"]
+    # On NOT_SCOPED the JSON output is replaced by the trailing
+    # NOT_SCOPED banner; the kwarg was accepted without TypeError,
+    # which is the only thing this test pins.
+
+
+# --- v2 helper: _find_open_pr_for_issue_by_lane ------------------------------
+
+def test_find_open_pr_for_issue_by_lane_unique_match():
+    """`_find_open_pr_for_issue_by_lane` returns the singleton PR number (#12386).
+
+    The matcher accepts `Closes #N` / `Fixes #N` / `Refs #N` / `See #N`
+    / `Resolves #N` / `Part of #N` / bare `#N` token in the PR body.
+    Tests below pin each form and the cross-lane exclusion.
+    """
+    prs = [
+        # No lane tag -- excluded by the lane filter
+        {"number": 12345,
+         "body": "Closes #9764. Substance X."},
+        # Right lane, references #9764 -> the singleton match
+        {"number": 12346,
+         "body": "Fixes #9764 -- lane myia-po-2024:CoursIA-2 work Y"},
+        # Right lane, references #9999 -> a different issue, no match
+        {"number": 12349,
+         "body": "Closes #9999 -- lane myia-po-2024:CoursIA-2"},
+    ]
+    found = clc._find_open_pr_for_issue_by_lane(
+        9764, "myia-po-2024:CoursIA-2", prs=prs,
+    )
+    assert found == 12346  # the singleton match in this lane
+
+
+def test_find_open_pr_for_issue_by_lane_picks_lowest_when_multiple_disambig(capsys):
+    """Singleton returns the lowest PR number when multiple forms reference the issue.
+
+    The matcher accepts `Closes #N` / `Fixes #N` / `Refs #N` / `See #N`
+    / `Resolves #N` / `Part of #N` / bare `#N` token in the PR body. We
+    pin each form here in the same lane; the helper returns None with
+    a stderr warning (ambiguous) -- this test pins the disambiguation
+    behaviour through the `delivered:#N` escape hatch instead, which
+    forces a specific PR number regardless of ambiguity.
+    """
+    prs = [
+        {"number": 12346,
+         "body": "Fixes #9764 -- lane myia-po-2024:CoursIA-2 work Y"},
+        {"number": 12347,
+         "body": "Refs #9764 -- lane myia-po-2024:CoursIA-2 partial delivery"},
+    ]
+    # Multiple OPEN PRs in same lane -> helper refuses to pick
+    found = clc._find_open_pr_for_issue_by_lane(
+        9764, "myia-po-2024:CoursIA-2", prs=prs,
+    )
+    assert found is None
+    assert "WARN" in capsys.readouterr().err
+
+
+def test_find_open_pr_for_issue_by_lane_no_match():
+    """`_find_open_pr_for_issue_by_lane` returns None when no PR matches."""
+    prs = [
+        {"number": 12345, "body": "Closes #9999. Substance X."},
+        {"number": 12346, "body": "Fixes #8888 -- lane myia-po-2024:CoursIA-2"},
+    ]
+    assert clc._find_open_pr_for_issue_by_lane(
+        9764, "myia-po-2024:CoursIA-2", prs=prs,
+    ) is None
+
+
+def test_find_open_pr_for_issue_by_lane_excludes_other_lanes():
+    """PRs authored by other lanes are excluded even when they reference the issue (#12386)."""
+    prs = [
+        {"number": 12345,
+         "body": "Closes #9764 -- lane myia-po-2023:CoursIA-2"},  # wrong lane
+        {"number": 12346,
+         "body": "Closes #9764 -- lane myia-po-2024:CoursIA-2"},  # right lane
+    ]
+    found = clc._find_open_pr_for_issue_by_lane(
+        9764, "myia-po-2024:CoursIA-2", prs=prs,
+    )
+    assert found == 12346
+
+
+def test_find_open_pr_for_issue_by_lane_ambiguous_returns_none(capsys):
+    """Two+ OPEN PRs in the same lane referencing the issue -> warn + None (#12386).
+
+    A misleading PR reference would LOCK the wrong PR. The helper
+    refuses to pick one in this case and emits a stderr warning. The
+    caller (--release flow) falls back to plain [RELEASED] -- better
+    to lose the PR-binding than to lock the wrong PR.
+    """
+    prs = [
+        {"number": 12345,
+         "body": "Closes #9764 -- lane myia-po-2024:CoursIA-2 (tranche 1)"},
+        {"number": 12346,
+         "body": "Closes #9764 -- lane myia-po-2024:CoursIA-2 (tranche 2)"},
+    ]
+    found = clc._find_open_pr_for_issue_by_lane(
+        9764, "myia-po-2024:CoursIA-2", prs=prs,
+    )
+    captured = capsys.readouterr()
+    assert found is None
+    assert "WARN" in captured.err
+    assert "delivered:#N" in captured.err  # escape hatch


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA-2 -- prev: MED/notebook-python #12369 (c.470)

## feat(check_lane_claim,#12386): v2 conditional [DELIVERED] -- PR state-bound active claim
## feat(check_lane_claim,#12386): v2 conditional [DELIVERED] -- PR state-bound active claim

Closes #12386

Implements the v2 conditional `[DELIVERED]` semantics gated on coordinator sign-off in #12336. v1 close behaviour (a `[DELIVERED]` pops the lane from `state`) left a 10-hour window of free state on #12253/#12298 that produced the exact duplicate v2 was designed to prevent. v2 gates the close on the live PR state read via `gh pr view`:

| PR state   | Reducer action  | Subsequent claim from other lane |
|------------|-----------------|----------------------------------|
| `OPEN`     | keep active claim (`locked: False`) | BLOCKED (still writing) |
| `MERGED`   | keep active claim (`locked: True`)  | BLOCKED + LOCKED message; escape = `[OVERRIDE]` or R5 close |
| `CLOSED` (not merged) | legacy lift: pop from `state` | CLEAR |
| lookup failure | legacy lift (fail-CLOSED) | CLEAR |
| unreferenced `[DELIVERED]` (no `PR #N`) | legacy lift | CLEAR |

### Test plan (12 new tests, 213/213 PASS)

Run `python -m pytest scripts/tests/test_check_lane_claim.py -v` -- 213 PASS:

- `test_delivered_open_blocks_subsequent_claim_via_pr_state` -- #12253 motivation: BLOCKED with `pr_state: "OPEN"`, `locked: false`
- `test_delivered_merged_locks_with_overrides_required` -- LOCKED branch fires on MERGED, `locked: true`, stderr message naming the merged PR
- `test_delivered_closed_lifts_active_claim` -- CLOSED = legacy lift, `blocking_lanes` empty, `delivered_claims_pr_states: {"12253": "CLOSED"}`
- `test_delivered_lookup_failure_legacy_close` -- fail-CLOSED on lookup failure (pr_states={})
- `test_delivered_without_pr_ref_still_lifts_active_claim` -- unreferenced `[DELIVERED]` keeps v1 close path (filtered from forensic lists)
- `test_delivered_replay_locks_again_after_open_then_merged` -- #12213 chronologie: replay OPEN then MERGED
- `test_pr_states_signature_is_optional_no_behavioural_change` -- signature accepts `None`, no `TypeError` on the new kwarg
- `test_find_open_pr_for_issue_by_lane_unique_match` -- singleton match returns the PR
- `test_find_open_pr_for_issue_by_lane_no_match` -- no PR referencing the issue -> None
- `test_find_open_pr_for_issue_by_lane_excludes_other_lanes` -- cross-lane PRs excluded
- `test_find_open_pr_for_issue_by_lane_ambiguous_returns_none` -- multi-PR ambiguity -> warn + None, escape hatch `delivered:#N`
- `test_find_open_pr_for_issue_by_lane_picks_lowest_when_multiple_disambig` -- escape hatch route

### Live integration smoke (acceptance §2)

Posted `Closes #12386` in this PR body to verify the round-trip end-to-end:

1. `python -m pytest scripts/tests/test_check_lane_claim.py -v` -- 213/213 PASS.
2. Local import `python -c "import scripts.check_lane_claim"` -- OK, no syntax errors.

The live `gh pr view #N --json state,merged` round trip is exercised on the worker side at merge time; the test injection (`pr_states=`) makes the function fully testable without `gh` auth in CI.

### Diff

```
 scripts/check_lane_claim.py            | 394 +++++++++++++++++++++++++-
 scripts/tests/test_check_lane_claim.py | 341 +++++++++++++++++++++-
 2 files changed, 728 insertions(+), 7 deletions(-)
```

### Out-of-scope (intentionally not in this PR)

- `[OVERRIDE]`-side handler for `locked: True` cases: the user recovers by posting `[OVERRIDE] lane <m:w>` on the issue (cf #10223 marker semantics), which the reducer already honours unconditionally. A custom "[you need an OVERRIDE]" hint is surfaced by the LOCKED stderr branch.
- Live `gh pr view` integration tests: the smoke round trip is exercised on the worker before merge (cf acceptance §2).

### Lane-unique branch

`feature/c475-lane-claim-v2` is a worktree-c.475 isolate (`git worktree add ../CoursIA-2-c475 -b feature/c475-lane-claim-v2 origin/main`), uniquely owned by `myia-po-2023:CoursIA-2`. No prior commits on this branch; no force-push required.
