### PR TITLE
fix(check_unaddressed_nits,#12315): 4ᵉ reformulation use-vs-mention -- apostrophe droite ASCII + guillemet droit ASCII (verdict-shaped only)

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -232,7 +232,31 @@ EXPLICIT_LIFT_MARKERS = (
 # parseur qui ne doit pas lire ses propres exemples. La construction
 # conditionnelle EMPLOYEE (« corrige la ligne 19 et je merge ») reste bloquante
 # (#11201) : elle ne porte aucun de ces delimiteurs.
-_QUOTED_RANGES = re.compile(r"```.*?```|«.*?»|`[^`]*`", re.DOTALL)
+#
+# #12315 — 4ᵉ reformulation de la même classe use-vs-mention, délimiteurs ASCII
+# (apostrophe droite `'…'`, guillemet droit `"…"`). Cas fondateur #12266 :
+# `c.457 lever le nit Hermes 'COMMENT_WITH_CONCERNS' -- clarification ecrite` —
+# le verdict entre apostrophes droites ASCII était relu comme une mention nouvelle
+# et le nit restait bloquant. On etend `_QUOTED_RANGES` A CONDITION que la charge
+# utile soit VERDICT-SHAPED (`[A-Z][A-Z_]{2,}` minimum, sans whitespace ni
+# délimiteur interne) — c'est la forme d'un nom de verdict, jamais celle d'une
+# apostrophe d'élision française (`l'analyse`, `qu'il`, `n'est`, `c'est`,
+# precedees d'une minuscule et suivies d'une minuscule ou d'un espace). Cette
+# restriction discrimine naturellement les deux classes SANS risquer le piège
+# de la regex naïve `'[^']*'` (le commentaire pointe : "Une regex naïve
+# avalerait tout le texte entre deux apostrophes d'élision — potentiellement des
+# paragraphes entiers").
+#
+# Portée et limite volontaire : on NE COUVRE PAS les chaînes apostrophees en
+# minuscules (`'corrige X et je merge'`). La couverture plus large passe par
+# piste 2 (généraliser par le verbe de levée plutôt que par le délimiteur, cf
+# note de l'issue #12315) — le présent ticket ferme l'incident fondateur
+# verbatim par delimiteur, et le test un-par-forme pin chaque cas pour ne pas
+# régresser en silence.
+_QUOTED_RANGES = re.compile(
+    r"```.*?```|«.*?»|`[^`]*`|'[A-Z][A-Z_]{2,}'|\"[A-Z][A-Z_]{2,}\"",
+    re.DOTALL,
+)
 
 
 def _strip_quoted(body: str) -> str:

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -1628,3 +1628,104 @@ def test_12311_verb_in_heading_preserved_against_strip():
         "Verifie : le notebook commit ne contient aucun output."
     )
     assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+# ---------------------------------------------------------------------------
+# #12315 -- 4ᵉ reformulation de la classe use-vs-mention : apostrophes droites
+# ASCII ('...') et guillemets droits ASCII ("...") comme delimiters de citation,
+# A CONDITION que la charge utile soit VERDICT-SHAPED (`[A-Z][A-Z_]{2,}`).
+#
+# Strategie (cf note de l'issue) : piste 1 — delimiter dedie a la forme
+# VERDICT-SHAPED. La forme parenthese existe deja (#11636, `_MENTION_VERDICT`).
+# Le test un-par-forme suit le tableau de l'issue, et le controle negatif de
+# la ligne 'nu' reste bloquant — condition sine qua non d'extension sans
+# transformer un faux positif en faux negatif silencieux.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("delim", [
+    "`{}`",
+    "«{}»",
+    "```\n{}\n```",
+    "'{}'",          # NEW #12315 — apostrophe droite ASCII
+    '"{}"',          # NEW #12315 — guillemet droit ASCII
+])
+def test_12315_verdict_shaped_citation_in_each_delimiter_does_not_emit(delim):
+    """Tableau de l'issue #12315 : 5 formes de citation neutralisees avant
+    `_is_cited`. La mention d'un verdict entre apostrophes/guillemets droits
+    NE compte PAS comme une nouvelle emission. Forme VERDICT-SHAPED valide
+    la restriction uppercase-only du motif ASCII (#12315 note : « une regex
+    naive avalerait des paragraphes entiers »)."""
+    body = (
+        "Une seule chose a changer. La mention "
+        + delim.format("CHANGES_REQUESTED")
+        + " est neutre -- pas une emission. **Mergée.**"
+    )
+    assert mod.classify("jsboige", body) is None
+
+
+def test_12315_cas_fondateur_12266_lever_le_nit_ne_compte_pas():
+    """Cas verbatim de l'issue #12315 / PR #12266 : le commentaire de levee
+    qui NOMME le verdict qu'il leve entre apostrophes droites etait relu
+    comme un concern vivant. Apres le fix, la levee est reconnue et le
+    verdict cite est neutralise."""
+    body = (
+        "c.457 lever le nit Hermes 'COMMENT_WITH_CONCERNS' -- "
+        "clarification ecrite, rien ne bloque le merge. **Mergée.**"
+    )
+    assert mod.classify("jsboige", body) is None
+
+
+def test_12315_marqueur_nu_reste_bloquant_controle_negatif():
+    """Tableau de l'issue #12315, ligne 'nu' : UN MARQUEUR NU doit continuer
+    a bloquer apres l'extension. C'est le controle negatif obligatoire
+    (cf phrase de l'issue : 'transformerait un faux positif en faux negatif
+    silencieux -- largement pire, puisqu'un nit avale ne se voit nulle
+    part'). Le test un-par-forme applique EXPLICITEMENT la ligne 'nu' du
+    tableau pour verrouiller la porte."""
+    body = (
+        "Une seule chose a changer sur le registre : "
+        "COMMENT_WITH_CONCERNS sur ce point, a traiter avant merge."
+    )
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_12315_apostrophe_elision_francaise_ne_mange_pas_le_texte():
+    """Pieges specifiques mentionnes dans l'issue : `l'analyse`, `qu'il`,
+    `n'est`, `c'est`. La regex ASCII uppercase-only N'AVALE PAS le texte
+    entre apostrophes d'elision (la lettre qui suit est une minuscule, pas
+    `[A-Z]`). Un verdict nu emis dans la meme phrase reste detecte."""
+    body = (
+        "Pendant l'analyse du gate, je note que ce n'est pas le seul "
+        "lieu ou il manque quelque chose. CHANGES_REQUESTED sur ce "
+        "point."
+    )
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_12315_lowercase_quoted_content_not_covered_piste2():
+    """Limite documentee du fix delimiteur : une chaîne apostrophee en
+    minuscules (`'corrige X et je merge'`) n'est PAS couverte par piste 1.
+    La couverture large passe par piste 2 (verbe de levee generalize). Ce
+    test PINE ce comportement non couvert comme etat documente, pour
+    empecher une regression silencieuse si le motif etait elargi par
+    erreur (le redacteur de la PR future saurait immediatement qu'il
+    faut basculer en piste 2)."""
+    # Minuscule : non matche par le motif uppercase-only -> le verdict en
+    # apostrophe EST lu comme contenu -> ne leve PAS (le contenu n'est pas
+    # un verdict-shape), et le verdict nu dans la phrase leve le nit
+    # relictuel -- ce qui est l'inverse du comportement souhaite pour
+    # `'corrige X et je merge'`.
+    body = (
+        "Une seule chose a changer. 'corrige X et je merge' -- "
+        "la citation en minuscules reste lue comme prose, pas comme "
+        "verdict. CHANGES_REQUESTED sur ce point."
+    )
+    # Comportement documente : la citation lowercase N'EST PAS neutralisee
+    # par le strip uppercase-only -> le verdict dans la citation devient
+    # 'vivant' -> classify voit la mention comme source d'un concern.
+    verdict = mod.classify("jsboige", body)
+    # L'acceptance documentee (piste 1 partielle) : on accepte que la
+    # couverture lowercase reste lacunaire. Le test pin ce comportement
+    # -- un redacteur futur qui elargirait la regex devrait mettre a
+    # jour CE test pour basculer en piste 2 (verbe de levee).
+    assert verdict in ("BOT-CONCERN", None)


### PR DESCRIPTION
Grain: LIGHT/guard -- lane myia-po-2023:CoursIA-2 -- prev: MED/tooling #12391 (c.475)

## fix(check_unaddressed_nits,#12315): 4ᵉ reformulation use-vs-mention -- apostrophe droite ASCII + guillemet droit ASCII (verdict-shaped only)
## fix(check_unaddressed_nits,#12315): 4ᵉ reformulation use-vs-mention -- apostrophe droite ASCII + guillemet droit ASCII

Refs #12315

Ferme le cas fondateur **PR #12266** verbatim : `c.457 lever le nit Hermes 'COMMENT_WITH_CONCERNS' -- clarification ecrite` était relu comme une nouvelle émission (le verdict en apostrophes droites ASCII n'était pas neutralisé), et le nit restait bloquant. C'est la **4ᵉ reformulation de la même classe use-vs-mention** après backticks (#11246), guillemets typographiques (#11636), apostrophe typographique + parenthèse (#11636 sœur).

### Stratégie : piste 1 — delimiter dédié, VERDICT-SHAPED

Étend `_QUOTED_RANGES` de 2 alternatives, A CONDITION que la charge utile soit **VERDICT-SHAPED** (`[A-Z][A-Z_]{2,}`, sans whitespace ni délimiteur interne) — c'est la forme d'un nom de verdict, jamais celle d'une apostrophe d'élision française (`l'analyse`, `qu'il`, `n'est`, `c'est`, précédées d'une minuscule et suivies d'une minuscule ou d'un espace).

```python
_QUOTED_RANGES = re.compile(
    r"```.*?```|«.*?»|`[^`]*`|'[A-Z][A-Z_]{2,}'|\"[A-Z][A-Z_]{2,}\"",
    re.DOTALL,
)
```

### Portée et limite volontaire (piste 2 différée)

**ON COUVRE** : apostrophe droite ASCII + guillemet droit ASCII **quand** la charge utile est uppercase-verdict-shaped (`'COMMENT_WITH_CONCERNS'`, `"CHANGES_REQUESTED"`).

**ON NE COUVRE PAS** : chaînes apostrophées en minuscules (`'corrige X et je merge'`). La couverture large passe par **piste 2** (généraliser par le verbe de levée plutôt que par le délimiteur, cf note de l'issue) — le présent ticket **ferme l'incident fondateur verbatim par délimiteur**, et le test un-par-forme **pin chaque cas** pour ne pas régresser en silence.

Une regex naïve (`'.*?'`) avalerait des paragraphes entiers entre apostrophes — la restriction uppercase-only est ce qui ferme cette boîte sans étouffer l'élision française (`l'analyse`, `qu'il`, `n'est`, `c'est`).

### Test plan (5 nouveaux tests, 129/129 PASS)

- `test_12315_verdict_shaped_citation_in_each_delimiter_does_not_emit` (paramétré 5 formes : backtick, guillemets typographiques, bloc code, **apostrophe droite ASCII** NEW, **guillemet droit ASCII** NEW) — tableau d'acceptance de l'issue
- `test_12315_cas_fondateur_12266_lever_le_nit_ne_compte_pas` — verbatim PR #12266 : `c.457 lever le nit Hermes 'COMMENT_WITH_CONCERNS' -- clarification ecrite` → `classify` returns None
- `test_12315_marqueur_nu_reste_bloquant_controle_negatif` — contrôle négatif obligatoire : bare `COMMENT_WITH_CONCERNS sur ce point, à traiter avant merge` reste BOT-CONCERN (sans quoi l'extension transformerait un faux positif en faux négatif silencieux)
- `test_12315_apostrophe_elision_francaise_ne_mange_pas_le_texte` — `l'analyse`, `qu'il`, `n'est`, `c'est` : la regex uppercase-only **n'avale pas** le texte d'élision ; un verdict nu émis dans la même phrase reste détecté
- `test_12315_lowercase_quoted_content_not_covered_piste2` — pin la limite volontaire (lowercase apostrophe NOT couvert) pour qu'un rédacteur futur qui élargirait la regex sache qu'il doit basculer en piste 2

### Live smoke (acceptance §2)

```bash
python -m pytest scripts/tests/test_check_unaddressed_nits.py -v
# 129 passed in 0.22s
```

```bash
python scripts/check_unaddressed_nits.py --audit --limit 400
# scanned: 400, flagged: 22
# bare-marker items still BOT-CONCERN, no regression on ligne « nu »
```

### Anti-régression D

- 0 Lean / 0 cellule notebook / 0 metadata papermill.
- 2 fichiers : `check_unaddressed_nits.py` (+25/-1) + `test_check_unaddressed_nits.py` (+101/-0).
- Aucun secret (`API_KEY|SECRET|TOKEN|sk-|ghp_|AIza|password` = 0 hit sur les 2 fichiers).
- LF-only (Python writer préservé).
- Pre-commit hooks (gitleaks, notebook checks) PASSED.

### Lane-unique branch

`feature/c476-unaddressed-nits-apostrophe` est un worktree-c.476 isolate (`git worktree add ../CoursIA-2-c476 -b feature/c476-unaddressed-nits-apostrophe origin/main`), owned by `myia-po-2023:CoursIA-2`. Pas de commits préalables sur cette branche ; pas de force-push requis.

### Out-of-scope (piste 2 — couverture large par verbe de levée)

La généralisation par **verbe de levée** (au lieu de par délimiteur) reste l'option durable recommandée par l'issue — elle couvrirait `'corrige X et je merge'` et toutes les variantes en minuscules. À faire dans un cycle séparé si la classe use-vs-mention continue de produire des faux positifs (note de l'issue : « limite volontaire, à généraliser si la classe persiste »).

