### PR TITLE
fix(guard,#10097): detect CODE_SPAN_PIPE -- bare | in inline code span breaks notebook-renderer tables

### DIFF
--- a/.github/workflows/markdown-table-guard.yml
+++ b/.github/workflows/markdown-table-guard.yml
@@ -2,10 +2,11 @@ name: Markdown table syntax advisory
 
 # Source-level lint for GFM markdown table syntax defects (#10097, sub-issue of
 # #3966). The scanner (scripts/notebook_tools/scan_md_table_syntax.py) detects
-# four pathologies that break table rendering: COL_MISMATCH (bare unescaped |
-# in a cell), NO_SEP (missing |---| separator), NO_BLANK_BEFORE/AFTER (paragraph
-# glued to the table). This workflow makes defects in *.ipynb markdown cells and
-# *.md / README* files VISIBLE on the PR.
+# five pathologies that break table rendering: COL_MISMATCH (bare unescaped |
+# in a cell), CODE_SPAN_PIPE (bare | inside an inline code span -- the notebook
+# renderer does not protect code spans), NO_SEP (missing |---| separator),
+# NO_BLANK_BEFORE/AFTER (paragraph glued to the table). This workflow makes
+# defects in *.ipynb markdown cells and *.md / README* files VISIBLE on the PR.
 #
 # ADVISORY, never blocking (mirrors exercises-advisory.yml, #8814 acceptance 5):
 # the job ALWAYS exits 0. The actionable payload is the `markdown-table-syntax`
@@ -96,7 +97,7 @@ jobs:
           set_label()   { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
           unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
 
-          ensure_label "$LABEL_DEFECT" "PR introduces a markdown table syntax defect (COL_MISMATCH / NO_SEP / NO_BLANK_BEFORE/AFTER). Advisory, non-blocking. See #10097." "d93f0b"
+          ensure_label "$LABEL_DEFECT" "PR introduces a markdown table syntax defect (COL_MISMATCH / CODE_SPAN_PIPE / NO_SEP / NO_BLANK_BEFORE/AFTER). Advisory, non-blocking. See #10097." "d93f0b"
 
           if [ "$COUNT" -eq 0 ]; then
             echo "No in-scope files to scan."

--- a/scripts/notebook_tools/scan_md_table_syntax.py
+++ b/scripts/notebook_tools/scan_md_table_syntax.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Source-level lint for GFM markdown table syntax defects.
 
-Detects four pathologies that break table rendering in the GitHub preview
+Detects five pathologies that break table rendering in the GitHub preview
 (source-level, render-agnostic -- it flags the *convention violation* that
 breaks rendering on at least one common renderer, not a post-render check):
 
@@ -13,6 +13,17 @@ breaks rendering on at least one common renderer, not a post-render check):
     A source-level lint counts raw pipes (it does not try to honor inline-code
     spans, because not every renderer does either -- the portable convention is
     to escape the pipe as ``\\|``). See #10097 acceptance sample.
+
+  - **CODE_SPAN_PIPE**: a BARE ``|`` inside an inline code span (`` `` `...` `` ``)
+    within a recognized table row. The logical column counter (``_column_count``)
+    deliberately excludes code-span pipes, so this does NOT show as COL_MISMATCH
+    -- but the notebook renderer (notebooks.githubusercontent.com) splits cells on
+    raw ``|`` WITHOUT protecting code spans, so a row like
+    `` | ceci | `P[|emp-true|>eps]` | ... | `` acquires excess columns, drifts
+    from the header, and the WHOLE table is demoted to a paragraph (renders as
+    literal pipes + ``\n``). Confirmed on 2.8c-Borne-Temoin-Concentration cell[12]
+    (#12220). Escaping the pipe as ``\\|`` inside the code span is safe on every
+    renderer -- this is the actionable fix.
 
   - **NO_SEP**: a run of 3+ consecutive ``|``-shaped lines with NO
     ``:?-+:?`` separator row among them. GFM does not recognize the block as a
@@ -89,11 +100,13 @@ HEADING_RE = re.compile(r'^\s{0,3}#{1,6}\s')
 # Spans whose interior `|` must NOT count as a column delimiter (GFM-correct
 # column counting). Three classes, all NON-ACTIONABLE (flagging them would tell
 # the author to "fix" something that is already correct, or impossible to fix):
-#   1. Inline code spans `` `...` `` -- GFM table parsing protects them (the
-#      spec parses code spans BEFORE splitting cells). A `|` inside `` `a|b` ``
-#      is a literal, not a delimiter. Counting it (as the #10097 preliminary
-#      ``gh api`` sample did for `` `Crossover | Mutation` ``) is a FALSE
-#      POSITIVE: GitHub renders the cell correctly.
+#   1. Inline code spans `` `...` `` -- for the LOGICAL column count (COL_MISMATCH)
+#      a `|` inside `` `a|b` `` is a literal, not a delimiter; counting it (as
+#      the #10097 preliminary ``gh api`` sample did for `` `Crossover | Mutation` ``
+#      is a FALSE positive on the count (cmark-gfm / the standard GFM renderer
+#      protects code spans). NOTE: this protection does NOT hold on the notebook
+#      renderer, which splits cells on raw ``|`` -- so the same bare pipe is also
+#      surfaced by the separate CODE_SPAN_PIPE pathology.
 #   2. Escaped pipes ``\|`` -- the GFM-correct way to put a literal `|` in a
 #      cell. The author did it RIGHT; flagging it is a false positive
 #      (e.g. ``P(S=T\|C=T)`` in Infer-4 cell[7]).
@@ -240,6 +253,22 @@ def _column_count(line):
     return len(parts)
 
 
+def _has_bare_pipe_in_code_span(line):
+    """True if an inline code span in ``line`` holds a bare ``|`` (not ``\\|``).
+
+    The notebook renderer splits GFM table cells on raw ``|`` without protecting
+    inline code spans, so a bare pipe inside `` `` `...` `` `` in a table cell
+    breaks the column layout (the row drifts from the header and the whole table
+    is demoted to a paragraph). Escaped ``\\|`` inside the code span is safe on
+    every renderer, so only the bare form is flagged.
+    """
+    for m in CODE_SPAN_RE.finditer(line):
+        span = m.group(0)
+        if '|' in ESCAPED_PIPE_RE.sub('', span):
+            return True
+    return False
+
+
 def _is_blank(line):
     # A bare blockquote marker ``>`` (optionally followed by whitespace) renders
     # as a blank separator within a blockquote -- it provides the same visual
@@ -316,6 +345,25 @@ def detect_md_table_syntax(lines, source_label="line"):
                             ),
                             "snippet": d_line.strip()[:80],
                         })
+
+            # --- CODE_SPAN_PIPE: bare | inside an inline code span in a row ---
+            # The logical column count (COL_MISMATCH) excludes code-span pipes, so
+            # this does not surface there -- but the notebook renderer splits
+            # cells on raw | WITHOUT protecting code spans, so a bare pipe inside
+            # ``...`` makes the row drift from the header and demotes the whole
+            # table to a paragraph. Escape as \| (safe on every renderer).
+            for c_lnum, c_line in rows:
+                if _has_bare_pipe_in_code_span(c_line):
+                    findings.append({
+                        "pathology": "CODE_SPAN_PIPE",
+                        "line": c_lnum,
+                        "detail": (
+                            "pipe brute dans un code span (``...``) d'une cellule "
+                            "de table -> le renderer notebook decoupe la cellule "
+                            "et casse la table ; echapper en '\\|'"
+                        ),
+                        "snippet": c_line.strip()[:80],
+                    })
 
         # --- NO_BLANK_BEFORE: line immediately before the block is prose ---
         # block occupies lines [blk['start'] .. blk['end']] (1-indexed) in the

--- a/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
+++ b/scripts/notebook_tools/tests/test_scan_md_table_syntax.py
@@ -257,6 +257,63 @@ class TestDetectColMismatch:
         assert [x for x in f if x["pathology"] == "COL_MISMATCH"] == []
 
 
+class TestDetectCodeSpanPipe:
+    """CODE_SPAN_PIPE (raffinement #10097, cas 2.8c) : un ``|`` brut dans un code
+    span au sein d'une ligne de table reconnue. Le compte logique de colonnes
+    (COL_MISMATCH) l'exclut -- mais le renderer notebook (notebooks.github.com)
+    decoupe les cellules sur le ``|`` SANS proteger les code spans, donc une ligne
+    comme ``P[|emp-true|>eps]`` derive de l'en-tete et fait tomber toute la table
+    en paragraphe. Echapper en ``\\|`` est sur sur tous les renderers."""
+
+    def test_bare_pipe_in_code_span_flagged(self):
+        # Cas 2.8c-Borne-Temoin-Concentration cell[12] (#12220) : P[|emp-true|>eps]
+        # dans des backticks casse la mise en page de la table cote notebook.
+        lines = [
+            "| Triptyque | Borne | Concentration |",
+            "|-----------|-------|---------------|",
+            "| Hoeffding | `P[|emp-true|>eps] <= 2e` | `O(1/sqrt(n))` |",
+        ]
+        f = detect_md_table_syntax(lines)
+        p = [x for x in f if x["pathology"] == "CODE_SPAN_PIPE"]
+        assert len(p) == 1, f"got {f}"
+        assert p[0]["line"] == 3
+        # Ce n'est PAS un COL_MISMATCH : le compte logique reste a 3 colonnes.
+        assert [x for x in f if x["pathology"] == "COL_MISMATCH"] == []
+
+    def test_escaped_pipe_in_code_span_not_flagged(self):
+        # \\| dans un code span est deja sur sur tous les renderers -> pas flagge.
+        lines = [
+            "| a | b |",
+            "|---|---|",
+            "| x | `a\\|b` |",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "CODE_SPAN_PIPE"] == []
+
+    def test_clean_table_no_code_span_pipe(self):
+        lines = [
+            "| a | b |",
+            "|---|---|",
+            "| 1 | 2 |",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "CODE_SPAN_PIPE"] == []
+
+    def test_mgs3_crossover_mutation_now_advisory_flagged(self):
+        # Echantillon canonique #10097 (MGS-3, `Crossover | Mutation` protege par
+        # backticks) : toujours AUCUN COL_MISMATCH sur le compte logique, mais il
+        # est desormais signale en CODE_SPAN_PIPE advisoire -- le renderer notebook
+        # ne protege pas les code spans, echapper en \\| est le fix portable.
+        lines = [
+            "| Strat | Valeur | Note |",
+            "|------|--------|------|",
+            "| Scope | `Crossover | Mutation` | ok |",
+        ]
+        f = detect_md_table_syntax(lines)
+        assert [x for x in f if x["pathology"] == "COL_MISMATCH"] == []
+        assert [x for x in f if x["pathology"] == "CODE_SPAN_PIPE"] != []
+
+
 class TestDetectNoSep:
     def test_three_pipe_lines_no_sep_flagged(self):
         # 3+ pipe-lines, no |---| separator -> GFM renders as <pre>, not a table.


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA — prev: MED/notebook-python #12372

**Demande user directe** : la commit `f4cd590` (notebook 2.8c, PR #12220) a été mergé avec une **table mal rendue** — il faut patcher le CI pour attraper cette classe de défaut.

## Diagnostic

Le renderer notebook (notebooks.githubusercontent.com) découpe les cellules de table GFM sur chaque `|` **sans protéger les code spans**. Une ligne `| ... | `P[|emp-true|>eps]` | ... |` gagne des colonnes fantômes, dérive de l'en-tête (4 colonnes), et **toute la table est démotée en paragraphe** — rendu en pipes + `\n` littéraux. Vérifié sur la vue blob : la cellule 12 est émise en `<p>| Triptyque | ...` et non en `<table>`.

Le scanner `scan_md_table_syntax.py` **ratte** ce défaut : `_column_count` strippe les code-span pipes avant de compter → chaque ligne de données compte 4 = l'en-tête → aucun `COL_MISMATCH`. D'où le merge du défaut.

## Fix

Nouvelle **5e pathologie `CODE_SPAN_PIPE`** : un `|` nu dans un code span au sein d'une ligne de table reconnue. Le compte logique (`COL_MISMATCH`) conserve l'exclusion des code-span pipes → le cas canonique #10097 (`Crossover | Mutation`) reste vert ; la nouvelle pathologie signale séparément le hazard, et l'échappement `\|` est sûr sur **tous** les renderers.

- `scan_md_table_syntax.py` : helper `_has_bare_pipe_in_code_span` + détection dans `detect_md_table_syntax` (bloc `has_sep`)
- `test_scan_md_table_syntax.py` : 4 nouveaux tests (cas 2.8c positif, pipe échappée clean, table clean, MGS-3 advisoire)
- `markdown-table-guard.yml` : description du label + en-tête mis à jour (5 pathologies), advisory non-bloquant préservé

## Validation

- **62 tests passent** (58 existants + 4 nouveaux), `pytest scripts/notebook_tools/tests/test_scan_md_table_syntax.py`
- Scanner sur le notebook 2.8c **réel** (cell 12) : **2 findings `CODE_SPAN_PIPE`** (lignes 8-9 : `P[|emp-true|>eps]`, `log|H|`) — le défaut mergé est maintenant attrapé
- Advisory (label `markdown-table-syntax`, exit 0) inchangé ; promotion en gate bloquant = décision séparée

See #10097 (contribution : 5e pathologie du scanner table), #3966.
