### PR TITLE
feat(semanticweb,#11601): SW-12-Python-GraphRAG densite round 2 markdown-only (1994 -> 2570)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
@@ -64,7 +64,9 @@
     "tags": []
    },
    "source": [
-    "## Installation des dependances"
+    "## Installation des dependances\n",
+    "\n",
+    "Chaque dépendance a un rôle précis dans le pipeline : `rdflib` porte les triplets RDF (sections 4 et 5), `networkx` l'analyse structurelle et la détection de communautés (sections 4 et 6), `matplotlib` les visualisations, `openai` / `anthropic` l'extraction LLM réelle (optionnelle — le notebook fonctionne sans), `python-dotenv` le chargement des clés, `pandas` l'intégration tabulaire de l'exercice 5. Rien n'est installé à l'exécution : un notebook de cours doit rester déterministe et hors-ligne sur ce plan.\n"
    ]
   },
   {
@@ -362,7 +364,11 @@
     "| **API Anthropic** | `ANTHROPIC_API_KEY` configure | Extraction reelle avec Claude |\n",
     "| **Demonstration** | Aucune cle | Données pre-calculees, même flux pedagogique |\n",
     "\n",
-    "> **Point cle** : L'ensemble du notebook fonctionne sans cle API. Les résultats de demonstration sont representatifs de ce que produit un vrai LLM."
+    "> **Point cle** : L'ensemble du notebook fonctionne sans cle API. Les résultats de demonstration sont representatifs de ce que produit un vrai LLM.\n",
+    "\n",
+    "**Pourquoi le test `startswith(\"sk-...\")` ?** Le dépôt embarque un `.env.example` dont les clés sont des valeurs fictives (`sk-...`, `sk-ant-...`). Sans ce garde, copier le fichier d'exemple suffirait à faire croire au notebook qu'une clé valide est configurée — et le premier appel API échouerait en pleine démonstration. Le test écarte donc les *placeholders* avant de déclarer un provider disponible.\n",
+    "\n",
+    "**La précédence OpenAI > Anthropic** est arbitraire mais explicite : si les deux clés sont présentes, `HAS_OPENAI` est testé en premier dans chaque site d'appel. En pratique on configure un seul provider, et la sortie ci-dessus (`OpenAI : Non configure`, `Anthropic : Non configure`) reflète exactement l'état de l'environnement d'exécution de ce notebook committé — le mode Démonstration, que toutes les sections suivantes empruntent.\n"
    ]
   },
   {
@@ -955,7 +961,9 @@
     "- **Les types sont-ils coherents ?** Le coloriage par type d'entite (les films en turquoise, les personnes dans une autre teinte) revele d'un coup d'oeil les erreurs de classification de l'extraction — par exemple un studio par erreur tagge `Person`.\n",
     "- **Les chemins multi-hop existent-ils ?** Suivre des aretes a l'oeil (Ledger -> The Dark Knight -> Oscar) montre physiquement ce que la requete `graphrag_query` refera programmatiquement.\n",
     "\n",
-    "Le layout `spring` positionne les noeuds lies proches les uns des autres : la topologie que vous voyez est donc une approximation fidele de la structure du graphe, pas un arrangement decoratif."
+    "Le layout `spring` positionne les noeuds lies proches les uns des autres : la topologie que vous voyez est donc une approximation fidele de la structure du graphe, pas un arrangement decoratif.\n",
+    "\n",
+    "Un phénomène visible mérite d'être anticipé avant l'exécution : le graphe porte 15 nœuds mais seulement 12 arêtes — trois nœuds (Dom Cobb, Joker, Batman) sont **isolés**. Dans un layout `spring`, un nœud sans arête ne subit aucune force d'attraction : il dérive vers la périphérie, poussé par les seules forces de répulsion. Leur position dans la figure n'est donc pas un artefact de calcul mais l'écho graphique d'une décision d'annotation prise en amont (section 3) — et la section 6 les retrouvera comme communautés-singletons.\n"
    ]
   },
   {
@@ -1102,7 +1110,11 @@
     "| Deux chemins vers Oscar | DiCaprio via Inception, Ledger via The Dark Knight |\n",
     "| Warner Bros connecte a Inception | Information de production recuperable |\n",
     "\n",
-    "> **Avantage GraphRAG** : En RAG classique, ces connexions seraient perdues. Le graphe les preserve et les rend interrogeables."
+    "> **Avantage GraphRAG** : En RAG classique, ces connexions seraient perdues. Le graphe les preserve et les rend interrogeables.\n",
+    "\n",
+    "**Lecture en degrés, sur les 12 arêtes vérifiées** : le classement des hubs ne va pas où l'intuition l'envoie. Les nœuds de degré maximal sont les **films** — Inception (réalisateur, acteur, studio, prix) et Interstellar (réalisateur, deux acteurs, compositeur), chacun à 4 arêtes — devant The Dark Knight (3) et Nolan (3). Le réalisateur n'est donc pas le hub du graphe : ce sont les films, **par construction** — chaque événement cinématographique (production, prix, casting) se rattache à l'œuvre, pas à la personne. Conséquence directe pour le GraphRAG : une question ancrée sur un *film* récupère un contexte plus large qu'une question ancrée sur une *personne*, à égalité de `max_hops`.\n",
+    "\n",
+    "La distribution complète se lit en dix secondes : degrés 4-4-3-3 pour les deux films vedettes, The Dark Knight et Nolan, puis 2 pour Ledger (`acted_in` + `won` — la double connexion du tableau ci-dessus) et pour Oscar (prix de Inception et de Ledger), puis 1 pour les six autres personnes et le studio, et 0 pour les trois personnages fictifs. Somme : 24 = 2 × 12 arêtes — la vérification arithmétique que le graphe converti en NetworkX n'a perdu ni doublon ni arête.\n"
    ]
   },
   {
@@ -1306,7 +1318,9 @@
     "| 3. Serialisation du contexte | Transformer les triplets en texte pour le LLM | Le contexte est un **fait structure**, pas un passage de document |\n",
     "| 4. Generation | Le LLM repond ancre sur le contexte fourni | Etape commune aux deux approches |\n",
     "\n",
-    "Le parametre `max_hops=1` de la demonstration limite le voisinage aux aretes directes ; `max_hops=2` capture les chemins transitifs (acteur -> film -> realisateur). Observez dans les sorties comment la taille du contexte evolue avec ce parametre — c'est le levier precision/exhaustivite du GraphRAG."
+    "Le parametre `max_hops=1` de la demonstration limite le voisinage aux aretes directes ; `max_hops=2` capture les chemins transitifs (acteur -> film -> realisateur). Observez dans les sorties comment la taille du contexte evolue avec ce parametre — c'est le levier precision/exhaustivite du GraphRAG.\n",
+    "\n",
+    "**Le budget de contexte, chiffré** : la cellule suivante récupère 9 faits pour une question ancrée sur Nolan. À l'échelle de ce corpus de 61 triplets, tout tiendrait dans n'importe quel contexte — mais rapportez ce chiffre à la vraie échelle annoncée en section 4 (~40 000 triplets pour 10 000 entités) : la question du *quoi passer au LLM* devient le cœur du métier. La sérialisation ligne-par-triplet retenue ici (`sujet -- prédicat --> objet`) est délibérément verbeuse mais trivialement filtrable ; les implémentations industrielles la remplacent par des résumés de communautés (section 6) ou des sous-graphes contraints par type.\n"
    ]
   },
   {
@@ -1487,7 +1501,11 @@
     "| Justification | Aucune | Chaque fait tracable dans le graphe |\n",
     "| Questions multi-hop | Approximatif | Précis (traversee du graphe) |\n",
     "\n",
-    "> **Point cle** : GraphRAG ne remplace pas le LLM, il le **renforce** avec des faits verifies. Le LLM conserve sa capacite de synthese et de formulation naturelle."
+    "> **Point cle** : GraphRAG ne remplace pas le LLM, il le **renforce** avec des faits verifies. Le LLM conserve sa capacite de synthese et de formulation naturelle.\n",
+    "\n",
+    "**Une honnêteté nécessaire sur la réponse simulée** : comparez le contenu de la réponse affichée aux 9 faits récupérés. La réponse énumère les acteurs des trois films — information qui ne figure **pas** dans le sous-graphe de Nolan à un saut (elle vivrait à deux sauts : Nolan -> film -> acteur). En mode Démonstration, cette réponse est pré-calculée pour illustrer ce qu'une génération complète produirait ; en mode API, la réponse du LLM serait contrainte par les faits effectivement passés dans le prompt — et avec `max_hops=1`, elle ne pourrait nommer que les films, pas leurs acteurs. Ce décalage n'est pas un défaut du pipeline : c'est le levier précision/exhaustivité signalé plus haut, et l'exercice 6 le fait manipuler.\n",
+    "\n",
+    "Notez enfin l'économie du liaison d'entités : la question ne mentionne que Nolan, et c'est la seule entité détectée — le complément « et quels acteurs y jouent » n'est compris par **aucune** des étapes mécaniques (ni le match de noms, ni le parcours). En mode API, c'est le LLM de génération qui interprète cette seconde clause face au contexte fourni ; si le fait manque, il répond honnêtement qu'il ne sait pas. La compréhension de la question reste un rôle du modèle, pas du graphe.\n"
    ]
   },
   {
@@ -1512,7 +1530,9 @@
     "- **Multi-saut** (*Qui a compose la musique du film ou joue l'acteur ayant gagne un Oscar pour le Joker ?*) : deux ou trois traversées consecutives. C'est le territoire ou le graphe domine — la similarite vectorielle n'a aucune raison de rapprocher *Zimmer* de *Ledger*.\n",
     "- **Aggregation** (*Combien d'acteurs communs entre Inception et The Dark Knight ?*) : compter des chemins partageant une extremite, ce qu'une requete SPARQL exprime nativement.\n",
     "\n",
-    "En lisant les reponses generees, demandez-vous pour chaque question : quel sous-graphe a ete extrait ? Le contexte fourni au LLM contenait-il le fait attendu ?"
+    "En lisant les reponses generees, demandez-vous pour chaque question : quel sous-graphe a ete extrait ? Le contexte fourni au LLM contenait-il le fait attendu ?\n",
+    "\n",
+    "Un point de méthode pour la lecture des sorties : le pipeline affiche pour chaque question les **entités détectées** et la **taille du contexte**. Ces deux chiffres racontent toute l'histoire de la requête — quelle porte d'entrée dans le graphe, et combien de faits ont traversé cette porte. Une taille de contexte de 0 avec des entités détectées signale une entité connue du texte mais absente du graphe (normalisation ratée) ; des entités non détectées sur une question qui en contient signale l'échec du match exact — les deux modes de défaillance silencieuse du liaison d'entités.\n"
    ]
   },
   {
@@ -1893,7 +1913,9 @@
     "| Questions multi-hop | Faible | Excellent | Bon |\n",
     "| Questions de synthese | Faible | Moyen | Excellent |\n",
     "| Explicabilite | Faible (chunks) | Elevee (triplets) | Elevee (communautes) |\n",
-    "| Mise a jour | Re-embedding | Ajout de triplets | Reconstruction partielle |"
+    "| Mise a jour | Re-embedding | Ajout de triplets | Reconstruction partielle |\n",
+    "\n",
+    "**Comment lire ce tableau** : la colonne à retenir n'est pas une colonne, c'est la *diagonale* — chaque approche domine sur sa question de prédilection (factuelle et multi-hop pour le GraphRAG local, synthèse pour le global). Le vrai choix d'architecture se joue sur deux lignes invisibles du tableau : **la fréquence d'interrogation** (le coût initial élevé du global s'amortit sur des milliers de questions) et **la taille du corpus** (sur dix documents, le RAG vectoriel suffit ; la structure ne paie qu'à l'échelle où les connexions inter-documents deviennent la question). En dessous de ce seuil, construire un KG est un coût sans contrepartie — la ligne « Cout initial : Eleve » est la seule qui doive vous arrêter.\n"
    ]
   },
   {
@@ -2058,7 +2080,9 @@
     "3. Toujours fournir un `demo_response` representatif du vrai résultat\n",
     "4. Tester la connexion au demarrage pour un feedback rapide\n",
     "\n",
-    "> **Note** : Le fichier `.env.example` documente les variables attendues sans exposer de secrets. Il est commit dans git, contrairement a `.env` qui est dans `.gitignore`."
+    "> **Note** : Le fichier `.env.example` documente les variables attendues sans exposer de secrets. Il est commit dans git, contrairement a `.env` qui est dans `.gitignore`.\n",
+    "\n",
+    "**Les trois patterns comme machine à états** : la détection (pattern 1) fixe l'état une fois au démarrage, le fallback (pattern 2) fait vivre chaque appel selon cet état, la vérification (pattern 3) expose l'état à l'utilisateur. La sortie ci-dessus (`Aucune API configuree`) est donc le même fait technique vu par le pattern 3 que celui qui orientera le pattern 2 dans toutes les cellules suivantes. C'est cette séparation qui rend le notebook exécutable dans trois environnements différents — salle de cours sans clé, poste avec clé OpenAI, poste avec clé Anthropic — sans aucune édition de cellule.\n"
    ]
   },
   {
@@ -2159,7 +2183,9 @@
     "| Evaluation de l'extraction | Comparaison prediction / reference | Extraction d'entites |\n",
     "| Pipeline libre (football) | Transposition du pipeline complet a un autre domaine | Tout le notebook |\n",
     "\n",
-    "Les exercices 1 a 3 ont leur version guidee juste au-dessus (Exemples guides 1 a 3) : si vous bloquez, etudiez la cellule guidee correspondante, puis revenez a la version bare."
+    "Les exercices 1 a 3 ont leur version guidee juste au-dessus (Exemples guides 1 a 3) : si vous bloquez, etudiez la cellule guidee correspondante, puis revenez a la version bare.\n",
+    "\n",
+    "La correspondance est strictement 1-1 : l'exemple guide 1 déroule l'exercice 1, le guide 2 l'exercice 2, le guide 3 l'exercice 3, et le guide 4 (football) l'exercice final. Les commentaires internes des cellules guidées portent une numérotation héritée d'une version antérieure — fiez-vous aux titres `###` ci-dessus, pas aux en-têtes de code.\n"
    ]
   },
   {
@@ -2449,7 +2475,9 @@
     "\n",
     "Le rapport mesure x170 entre le premier appel (1,510 s, extraction simulee + ecriture Turtle) et le second (8,86 ms, lecture seule). Rapportez ce facteur aux vraies echelles : une extraction LLM reelle coute plusieurs secondes **par chunk** ; sur un corpus de 1 000 chunks, le cache economise des heures et surtout des credits API a chaque re-execution du pipeline.\n",
     "\n",
-    "La ligne d'honnetete de la sortie merite d'etre soulignee : la latence du premier appel est SIMULEE par `time.sleep` — le facteur x170 mesure la mecanique du cache (ecriture vs lecture d'un fichier Turtle), pas la latence reelle d'un appel LLM. Avec une vraie cle API, le rapport serait plus grand encore."
+    "La ligne d'honnetete de la sortie merite d'etre soulignee : la latence du premier appel est SIMULEE par `time.sleep` — le facteur x170 mesure la mecanique du cache (ecriture vs lecture d'un fichier Turtle), pas la latence reelle d'un appel LLM. Avec une vraie cle API, le rapport serait plus grand encore.\n",
+    "\n",
+    "Le choix du format **Turtle** pour le cache n'est pas anodin : lisible par un humain (préfixes, indentation par sujet), il permet d'ouvrir `graph_extracted.ttl` dans un éditeur pour vérifier son contenu — un avantage pédagogique que N-Triples (une ligne par triplet, verbeux mais trivial à parser en flux) ou JSON-LD (natif pour les outillages web) n'offrent pas au même degré. Les trois formats décrivent exactement le même graphe ; la ligne `61 triplets preserves` le prouve par l'invariant le plus simple qui soit : parser ce qu'on vient de sérialiser doit rendre l'identique.\n"
    ]
   },
   {
@@ -2582,7 +2610,9 @@
     "\n",
     "Les quatre \"hallucinations\" listees meritent un examen plus fin que leur nom. Batman, Joker et Dom Cobb sont **reellement mentionnes dans le texte source** (comme roles joues) — l'extraction a capture des entites vraies que le gold standard, plus strict, avait choisies d'ignorer. Et l'Oscar est explicitement evoque dans le texte (\"quatre Oscars\"). Autrement dit : le rappel parfait (1,00) et la precision de 0,73 ne mesurent pas une extraction fautive, mais un **desaccord d'annotation** sur la frontiere du vocabulaire — les personnages fictifs font-ils partie du domaine ?\n",
     "\n",
-    "C'est exactement pourquoi les protocoles serieux d'evaluation NER font annoter le gold standard par plusieurs personnes et mesurent l'accord inter-annotateurs (kappa de Cohen) avant d'evaluer le modele : une partie de l'\"erreur\" mesuree vit dans le gold, pas dans l'extraction."
+    "C'est exactement pourquoi les protocoles serieux d'evaluation NER font annoter le gold standard par plusieurs personnes et mesurent l'accord inter-annotateurs (kappa de Cohen) avant d'evaluer le modele : une partie de l'\"erreur\" mesuree vit dans le gold, pas dans l'extraction.\n",
+    "\n",
+    "L'arithmétique mérite d'être refaite à la main une fois : 15 entités extraites, 11 dans le gold, intersection 11 — soit une précision de 11/15 = 0,73, un rappel de 11/11 = 1,00, et un F1 de 2 × (0,73 × 1,00) / (0,73 + 1,00) = 0,85. Le rappel parfait dit que le gold est **inclus** dans l'extraction ; la précision dit que l'extraction ajoute 4 entités que le gold n'a pas retenues. Les deux corrections coexistent : contraindre l'extraction (le prompt) ou corriger le gold (élargir le vocabulaire aux personnages fictifs) — et le choix dépend de la question à laquelle le KG doit répondre, pas d'un défaut de l'une des parties.\n"
    ]
   },
   {
@@ -3088,7 +3118,9 @@
     "3. **Requête** : Posez une question necessitant un parcours multi-hop dans le graphe\n",
     "4. **Reponse** : Generez une reponse contextuelle en utilisant les chemins trouves\n",
     "\n",
-    "Indice : Inspirez-vous des patterns d'extraction et de fallback presentes dans la section 7."
+    "Indice : Inspirez-vous des patterns d'extraction et de fallback presentes dans la section 7.\n",
+    "\n",
+    "**Critères d'un bon domaine** : trois conditions rendent l'exercice instructif plutôt que mécanique. (1) Au moins trois types d'entités qui **interagissent** — sinon le graphe est une collection d'étoiles disjointes. (2) Une question multi-hop dont la réponse n'existe dans aucune phrase du texte source (le test de l'exemple guide 4 : si la réponse est copiable mot à mot depuis le texte, ce n'est pas du GraphRAG, c'est de la recherche). (3) Un lexique sans ambiguïté de normalisation — deux homonymes dans six phrases produisent des fusions de nœuds fausses, comme l'exercice 4 le fait observer. Le domaine de l'exemple guide (le football) coche les trois ; le vôtre aussi, ou changez de domaine.\n"
    ]
   },
   {
@@ -3150,7 +3182,9 @@
     "- **Exercice 4** (extraction sur texte personnalise) : fournissez votre propre paragraphe et observez le comportement de l'extraction. Le piege classique est la **normalisation des entites** — si votre texte mentionne *Timothée Chalamet* et *Chalamet*, le LLM produira-t-il un seul noeud ou deux ? Comparez avec ce que le vocabulaire contraint de la demo evitait silencieusement.\n",
     "- **Exercice 5** (mini-KG thematique sur `movies.csv`) : ici le texte source est remplace par des **donnees tabulaires**. Chaque ligne devient des triplets — la mapping colonne -> predicat remplace le prompt d'extraction. C'est le mode d'integration le plus courant en entreprise.\n",
     "\n",
-    "Un fois votre mini-KG construit, testez-le avec une question multi-hop : c'est le critere qui distingue un vrai Knowledge Graph d'une simple table exportee."
+    "Un fois votre mini-KG construit, testez-le avec une question multi-hop : c'est le critere qui distingue un vrai Knowledge Graph d'une simple table exportee.\n",
+    "\n",
+    "Ces deux exercices complètent la couverture des trois sources de données d'un KG réel : texte libre (sections 3 à 7), données tabulaires (exercice 5), et votre propre texte (exercice 4). Le questionnaire de relecture est le même pour les trois : le graphe obtenu répond-il à une question qu'aucune ligne ou phrase du source ne contenait mot à mot ?\n"
    ]
   },
   {
@@ -3233,7 +3267,9 @@
     "**Indices** :\n",
     "- Reutilisez le code de construction de KG de SW-11\n",
     "- Ecrivez une requête SPARQL pour trouver les chemins realisateur -> film -> acteur -> film -> realisateur\n",
-    "- Formatez le résultat comme contexte pour un prompt LLM"
+    "- Formatez le résultat comme contexte pour un prompt LLM\n",
+    "\n",
+    "La différence conceptuelle avec l'extraction LLM mérite d'être formulée avant de coder : dans un CSV, le **schéma est fixé par la table** — chaque colonne devient un prédicat, chaque ligne un sujet, sans hallucination possible ni décision de vocabulaire. Ce que l'on gagne en fiabilité, on le perd en découverte : les relations implicites qu'un LLM infère d'un texte (le genre d'un film depuis sa description) n'existent pas dans des colonnes. Les deux modes ne s'opposent pas : la plupart des KG d'entreprise naissent du tabulaire, puis s'enrichissent par extraction — et SW-11 a déjà montré la moitié tabulaire du chemin.\n"
    ]
   },
   {
@@ -3297,7 +3333,9 @@
     "**Indices** :\n",
     "- Augmentez le paramètre `max_hops` dans `extract_subgraph()`\n",
     "- La question necessite le chemin : Nolan -> films -> acteurs -> (autres films de ces acteurs) -> genres\n",
-    "- Comparez la reponse avec max_hops=1 et max_hops=2"
+    "- Comparez la reponse avec max_hops=1 et max_hops=2\n",
+    "\n",
+    "**Ce qui change concrètement entre les profondeurs** : à un saut depuis Nolan, la BFS visite ses trois films et rapporte leurs attributs — dont le genre, quand l'extraction l'a retenu (Interstellar et The Dark Knight en portent un ; Inception non). À deux sauts elle atteint les acteurs ; à trois, les éventuels autres films de ces acteurs. La subtilité de CETTE question sur CE graphe : aucun acteur ne joue dans un film hors de ceux de Nolan, donc « les films où jouent les acteurs dirigés par Nolan » se réduit exactement aux trois films déjà visités à un saut — la question multi-hop se referme sur elle-même par fermeture du corpus. C'est une leçon en soi : la profondeur nécessaire dépend de ce que le graphe contient, pas de la forme grammaticale de la question. Sur un vrai corpus (centaines de films, acteurs partagés), la même question exige trois sauts — et c'est là que le RAG vectoriel décroche.\n"
    ]
   },
   {
@@ -3364,7 +3402,11 @@
     "\n",
     "Dans le notebook suivant (**SW-13-Python-Reasoners**), nous comparerons les raisonneurs OWL (owlrl, HermiT, reasonable, Growl) pour comprendre les compromis entre expressivite, performance et facilite d'integration.\n",
     "\n",
-    "Pour aller plus loin que ce notebook : brancher une vraie cle API (section 3) et comparer l'extraction reelle aux donnees de demonstration sur le meme texte est l'experience la plus instructive — les ecarts portent precisement sur les cas limites identifies ici (personnages fictifs, cardinalite des prix, normalisation des noms)."
+    "Pour aller plus loin que ce notebook : brancher une vraie cle API (section 3) et comparer l'extraction reelle aux donnees de demonstration sur le meme texte est l'experience la plus instructive — les ecarts portent precisement sur les cas limites identifies ici (personnages fictifs, cardinalite des prix, normalisation des noms).\n",
+    "\n",
+    "**Le pipeline en huit chiffres mesurés** : 15 entités et 12 relations extraites d'un texte de 145 mots ; 61 triplets RDF une fois structuré (ratio ~4:1 — chaque entité emporte son type, son label et ses attributs) ; 9 faits récupérés pour une question ancrée sur Nolan à un saut ; 6 communautés détectées dont 3 singletons, reflet direct des personnages fictifs extraits sans relations ; un facteur x170 entre extraction et lecture de cache (1,510 s contre 8,86 ms) ; et sur l'évaluation, un rappel de 1,00 pour une précision de 0,73 — l'écart entier venant d'un désaccord d'annotation, pas d'erreurs d'extraction. Ces chiffres sont petits, mais chacun transporte une décision d'architecture : le ratio 4:1 justifie les magasins de triplets dédiés, les singletons motivent le filtrage avant summarization, le x170 justifie la persistance, le désaccord d'annotation justifie les protocoles d'accord inter-annotateurs.\n",
+    "\n",
+    "**Perspectives au-delà du notebook** : le pipeline démontré ici est *local* (sous-graphe autour des entités de la question). Le mode *global* de Microsoft GraphRAG — résumer chaque communauté puis interroger la hiérarchie de résumés — devient rentable quand les questions portent sur le corpus entier (« quels sont les thèmes dominants ? »), précisément ce qu'aucun sous-graphe local ne peut assembler. Entre les deux, l'ingénierie réelle joue sur trois leviers que ce notebook n'a fait qu'effleurer : la qualité du liaison d'entités (un NER ou un LLM plutôt que le match exact de noms), la stratégie de `max_hops` selon la question, et l'hybridation avec le vectoriel — retrouver d'abord les entités candidates par similarité, puis les étendre par parcours de graphe.\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet #12251

## Summary

Tranche densité round 2 (#11601) sur `SW-12-Python-GraphRAG.ipynb` : épaississement **markdown-only** de 16 cellules existantes, chaque ajout ancré à une valeur mesurée dans les outputs du notebook.

**Density (outil officiel `pedagogy_density.py`) : 1994 → 2570** prose-chars/cellule-code (+29%, seuil umbrella ≥1500 ✓). `md_pct` 50.7 → 57.0.

## Cellules épaissies (append, aucune cellule ajoutée)

| Cellule | Rôle | Ajout ancré |
|---|---|---|
| 1, 8 | setup / config | rôles des dépendances ; pourquoi `startswith("sk-...")` + précédence providers (sortie réelle : `Non configure` ×2) |
| 17, 19 | viz interp | 3 nœuds isolés = écho d'annotation (section 3) ; **lecture en degrés des 12 arêtes** : 4-4-3-3 (films + Nolan), 2-2 (Ledger, Oscar), somme 24 = 2×12 |
| 23, 25 | génération | budget de contexte (9 faits vs ~40k triplets section 4) ; **honnêteté sur la réponse simulée** — les acteurs sont à 2 sauts, pas dans les 9 faits à `max_hops=1` |
| 32, 35 | comparaison RAG / patterns | lecture en diagonale du tableau + seuils de rentabilité ; les 3 patterns comme machine à états |
| 43, 46 | cache Turtle / éval | invariants de round-trip (61 triplets) ; **arithmétique P/R/F1 refaite** : 11/15=0,73, 11/11=1,00, F1=0,85 |
| 26, 38, 57, 59, 61, 63 | énoncés/transitions | modes de défaillance du liaison d'entités ; correspondance guides↔exercices 1-1 ; critères d'un bon domaine ; tabulaire vs extraction LLM ; **fermeture du corpus** (aucun acteur hors films de Nolan → la question multi-hop se referme) |
| 65 | conclusion | **8 chiffres mesurés du pipeline** + perspectives local/global |

## Validation

- `pedagogy_density.py` : 2570 ≥ 1500 ✓ (mesuré pre-tranche sur stash : 1994)
- `detect_markdown_rendering.py` : **0 violations** ✓
- `check_interp_positioning.py` : **0 findings** ✓
- C.1 : 0 erreur volontaire (l'unique grep "1/0" = base64 PNG, préexistant) ✓
- **Forensic C.2/C.3 markdown-only** : `git diff` = 0 ligne `"source"` de cellule code touchée, 0 output touché → re-exec non requise (exception markdown-only)
- H.3 pre-commit : passé

## Anchor check (c.1331p10488 ★★★) — triage du détecteur advisory

`check_markdown_claims_output.py` : **3 findings préexistants sur main** (md[13] "GPT-3.5" = nom de modèle, md[55] seuils pédagogiques d'énoncé) + **4 nouveaux en md[65]**, tous vérifiés firsthand contre les outputs sources :

- `1,510 s` / `8,86 ms` → output cellule 42 (exemple guidé 2 : `x170`)
- `1,00` / `0,73` → output cellule 45 (exemple guidé 3 : P=0.73 R=1.00 F1=0.85)

Valeurs réelles, sources citées ; le détecteur (fenêtre 3 cellules) ne peut pas voir une conclusion qui synthétise des mesures lointaines. Notez que md[46] cite les mêmes P/R/F1 **sans** flag — les valeurs sont dans la fenêtre de leur cellule source.

See #11601 (umbrella — tranche, pas clôture)
