### PR TITLE
feat(lean,#2874): AreMutants au niveau PD — groupe de Klein, refl/symm + controles trefoil (knot_lean 13→12)

### DIFF
--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -112,7 +112,7 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean
       display-name: knot_lean
-      sorry-baseline: "13"
+      sorry-baseline: "12"
       sorry-filter-mode: real
 
   # Level 3 proof-integrity gate (criterion B.3 of pr-review-discipline).
@@ -133,7 +133,7 @@ jobs:
       display-name: knot_lean
       target-modules: "*"
       allow-axioms: ""
-      # 13 acknowledged tactic `sorry`s = the `sorry-baseline` declared by the
+      # 12 acknowledged tactic `sorry`s = the `sorry-baseline` declared by the
       # build job above; the gate tolerates them (`fail-on-sorry: false`) but
       # still reports `has_sorry` per module and hard-fails forbidden axioms.
       # The per-module enumeration now lives in the gate's runtime derivation

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean
@@ -47,11 +47,177 @@ structure ConwaySphere where
   points : Fin 4 → Nat
   -- TODO: proper geometric definition
 
-/-- Deux nœuds sont mutants s'ils sont reliés par une mutation de Conway. -/
-def AreMutants (k₁ k₂ : Knot) : Prop := sorry
-  -- Definition: ∃ Conway sphere in k₁, rotate 180°, obtain k₂
-  -- Reference: Conway (1970), An enumeration of knots and links
-  -- Mathlib prerequisites: PL topology, cutting and gluing manifolds
+/-! ### Traduction combinatoire de la mutation au niveau des codes PD
+
+La mutation est géométrique (découper le long d'une sphère de Conway, tourner
+de 180°, recoller), mais la topologie PL — recollement de variétés à bord —
+est hors de portée de Mathlib. La traduction combinatoire retenue : la rotation
+de 180° d'un tangle à 2 brins agit sur ses 4 points de bord comme un élément
+du groupe de Klein {id, (12)(34), (13)(24), (14)(23)} — les trois demi-tours
+et l'identité. Au niveau des codes PD, muter une fenêtre de croisements =
+permuter les positions des étiquettes dans chaque croisement de la fenêtre.
+
+La mutation préserve le nombre de croisements (lemme `mutateWindow_length`) —
+c'est ce qui rend le contrôle négatif ci-dessous décidable.
+-/
+
+/-- Rotations de 180° d'un tangle à 2 brins : le groupe de Klein sur les
+quatre points de bord {id, (12)(34), (13)(24), (14)(23)}. Chaque élément est
+son propre inverse. -/
+inductive KleinRot where
+  | id : KleinRot
+  | r12 : KleinRot
+  | r13 : KleinRot
+  | r14 : KleinRot
+
+/-- Action d'une rotation de Klein sur un croisement PD : les étiquettes
+(valeurs) sont préservées, leurs positions sont permutées. -/
+def KleinRot.apply (ρ : KleinRot) (c : PDCrossing) : PDCrossing :=
+  match ρ with
+  | .id => c
+  | .r12 => ⟨c.e2, c.e1, c.e4, c.e3⟩
+  | .r13 => ⟨c.e3, c.e4, c.e1, c.e2⟩
+  | .r14 => ⟨c.e4, c.e3, c.e2, c.e1⟩
+
+theorem KleinRot.apply_involutive (ρ : KleinRot) (c : PDCrossing) :
+    ρ.apply (ρ.apply c) = c := by
+  cases ρ <;> cases c <;> rfl
+
+/-- Mutation d'une fenêtre [i, j) de la liste de croisements : les croisements
+hors de la fenêtre sont inchangés, ceux de la fenêtre sont rotés par ρ.
+Fenêtre vide (j ≤ i) : identité. Fenêtre pleine : tout le diagramme. -/
+def mutateWindow : List PDCrossing → Nat → Nat → KleinRot → List PDCrossing
+  | [], _, _, _ => []
+  | c :: cs', 0, 0, _ => c :: cs'
+  | c :: cs', 0, j+1, ρ => ρ.apply c :: mutateWindow cs' 0 j ρ
+  | c :: cs', _+1, 0, _ => c :: cs'
+  | c :: cs', i+1, j+1, ρ => c :: mutateWindow cs' i j ρ
+
+/-- La mutation préserve le nombre de croisements. -/
+theorem mutateWindow_length (cs : List PDCrossing) (i j : Nat) (ρ : KleinRot) :
+    (mutateWindow cs i j ρ).length = cs.length := by
+  induction cs generalizing i j with
+  | nil => rfl
+  | cons c cs' ih =>
+    match i, j with
+    | 0, 0 => rfl
+    | 0, _+1 => simp [mutateWindow, ih]
+    | _+1, 0 => rfl
+    | _+1, _+1 => simp [mutateWindow, ih]
+
+/-- La mutation est involutive : muter deux fois la même fenêtre avec la même
+rotation redonne la liste initiale (chaque élément de Klein est son propre
+inverse). -/
+theorem mutateWindow_involutive (cs : List PDCrossing) (i j : Nat) (ρ : KleinRot) :
+    mutateWindow (mutateWindow cs i j ρ) i j ρ = cs := by
+  induction cs generalizing i j with
+  | nil => rfl
+  | cons c cs' ih =>
+    match i, j with
+    | 0, 0 => rfl
+    | 0, j+1 =>
+      simp only [mutateWindow]
+      rw [ih 0 j, KleinRot.apply_involutive]
+    | _+1, 0 => rfl
+    | _+1, _+1 => simp only [mutateWindow, ih _ _]
+
+/-- Deux diagrammes sont mutants s'il existe une fenêtre et une rotation de
+Klein envoyant la liste de croisements de l'un sur celle de l'autre. -/
+def AreMutantDiagrams (d₁ d₂ : KnotDiagram) : Prop :=
+  ∃ (i j : Nat) (ρ : KleinRot), mutateWindow d₁.crossings i j ρ = d₂.crossings
+
+/-- Deux nœuds sont mutants s'ils possèdent des diagrammes représentants (au
+sens de Reidemeister) mutants. Le quantificateur existentiel sur les
+représentants est essentiel : la mutation ne s'applique pas nécessairement
+aux diagrammes désignés, mais à des diagrammes des mêmes classes d'isotopie. -/
+def AreMutants (k₁ k₂ : Knot) : Prop :=
+  ∃ (d₁ d₂ : KnotDiagram),
+    ReidemeisterEquiv k₁.diagram d₁ ∧
+    ReidemeisterEquiv k₂.diagram d₂ ∧
+    AreMutantDiagrams d₁ d₂
+
+/-! ### Théorie élémentaire : réflexivité et symétrie
+
+Réflexivité : fenêtre vide. Symétrie : involutivité de `mutateWindow`
+(chaque rotation de Klein est son propre inverse). La transitivité est
+fausse en général pour la mutation (composer deux mutations sur des fenêtres
+différentes n'est pas une mutation one-shot) — ce n'est PAS une relation
+d'équivalence, et c'est correct : c'est le phénomène biologique des enzymes
+de restriction, pas une identité. -/
+/- NOTE : pas de transitivité affirmée — la mutation compose des rotations sur
+des fenêtres potentiellement différentes, qui n'est pas une rotation one-shot. -/
+
+/-- Fenêtre vide : la mutation y est l'identité, pour toute liste. -/
+theorem mutateWindow_zero_window (cs : List PDCrossing) (ρ : KleinRot) :
+    mutateWindow cs 0 0 ρ = cs := by
+  cases cs with
+  | nil => rfl
+  | cons _ _ => rfl
+
+theorem AreMutantDiagrams.refl (d : KnotDiagram) : AreMutantDiagrams d d :=
+  ⟨0, 0, .id, mutateWindow_zero_window d.crossings .id⟩
+
+theorem AreMutantDiagrams.symm {d₁ d₂ : KnotDiagram} (h : AreMutantDiagrams d₁ d₂) :
+    AreMutantDiagrams d₂ d₁ := by
+  obtain ⟨i, j, ρ, hmut⟩ := h
+  refine ⟨i, j, ρ, ?_⟩
+  rw [← hmut]
+  exact mutateWindow_involutive d₁.crossings i j ρ
+
+theorem AreMutants.refl (k : Knot) : AreMutants k k :=
+  ⟨k.diagram, k.diagram, ReidemeisterEquiv.refl k.diagram,
+    ReidemeisterEquiv.refl k.diagram, AreMutantDiagrams.refl k.diagram⟩
+
+theorem AreMutants.symm {k₁ k₂ : Knot} (h : AreMutants k₁ k₂) : AreMutants k₂ k₁ := by
+  obtain ⟨d₁, d₂, hd₁, hd₂, hmut⟩ := h
+  exact ⟨d₂, d₁, hd₂, hd₁, AreMutantDiagrams.symm hmut⟩
+
+/-! ### Contrôles : la définition discrimine
+
+Une définition qui n'attraperait ni paire mutante ni contre-exemple serait un
+`True` déguisé et le retrait du `sorry` serait cosmétique. Deux contrôles :
+
+- NÉGATIF (`not_areMutantDiagrams_trefoil_unknot`) : la mutation préserve le
+  nombre de croisements, donc le trèfle (3 croisements) et le nœud trivial
+  (0) ne sont pas mutants — au niveau des diagrammes désignés.
+- POSITIF (`areMutants_trefoil_mutant`) : une mutation non triviale (fenêtre
+  pleine, rotation r12) est capturée par la définition.
+
+NOTE (limite du témoin canonique) : les diagrammes désignés
+`conwayKnotDiagram` et `kinoshitaTerasakaDiagram` (codes PD KnotInfo) diffèrent
+aux croisements 2, 9 et 11 par un recâblage cyclique des arêtes {10, 12, 22}
+qu'aucune rotation de Klein one-shot n'envoie de l'un sur l'autre.
+`AreMutants conwayKnot kinoshitaTerasakaKnot` exigera un diagramme
+intermédiaire (isotopie de Reidemeister) — sous-grain ultérieur.
+-/
+
+/-- Contrôle négatif : trèfle et nœud trivial ne sont pas mutants (la
+mutation préserve le nombre de croisements). -/
+theorem not_areMutantDiagrams_trefoil_unknot :
+    ¬ AreMutantDiagrams trefoilDiagram unknotDiagram := by
+  intro ⟨i, j, ρ, hmut⟩
+  have hlen := mutateWindow_length trefoilDiagram.crossings i j ρ
+  simp only [unknotDiagram] at hmut
+  rw [hmut] at hlen
+  simp [trefoilDiagram] at hlen
+
+/-- Le mutant du trèfle par r12 sur la fenêtre pleine. -/
+def trefoilMutantDiagram : KnotDiagram where
+  crossings := mutateWindow trefoilDiagram.crossings 0 3 KleinRot.r12
+  numEdges := 6
+
+def trefoilMutant : Knot where
+  diagram := trefoilMutantDiagram
+
+/-- Contrôle positif : la définition attrape une mutation non triviale
+(fenêtre pleine, rotation non identique). -/
+theorem areMutantDiagrams_trefoil_mutant :
+    AreMutantDiagrams trefoilDiagram trefoilMutantDiagram :=
+  ⟨0, 3, .r12, rfl⟩
+
+theorem areMutants_trefoil_mutant : AreMutants trefoil trefoilMutant :=
+  ⟨trefoilDiagram, trefoilMutantDiagram, ReidemeisterEquiv.refl _,
+    ReidemeisterEquiv.refl _, areMutantDiagrams_trefoil_mutant⟩
 
 /-! ## 2. Le nœud de Conway (11n34)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
@@ -57,11 +57,175 @@ structure ConwaySphere where
   points : Fin 4 → Nat
   -- TODO: proper geometric definition
 
-/-- Two knots are mutants if related by a Conway mutation. -/
-def AreMutants (k₁ k₂ : Knot) : Prop := sorry
-  -- Definition: ∃ Conway sphere in k₁, rotate 180°, obtain k₂
-  -- Reference: Conway (1970), An enumeration of knots and links
-  -- Mathlib prerequisites: PL topology, cutting and gluing manifolds
+/-! ### Combinatorial translation of mutation at the PD level
+
+Mutation is geometric (cut along a Conway sphere, rotate 180°, reglue), but
+PL topology — gluing manifolds with boundary — is out of reach of Mathlib.
+The retained combinatorial translation: a 180° rotation of a 2-strand tangle
+acts on its 4 boundary points as an element of the Klein group
+{id, (12)(34), (13)(24), (14)(23)} — the three half-turns and the identity.
+At the PD-code level, mutating a window of crossings = permuting the label
+positions within each crossing of the window.
+
+Mutation preserves the crossing count (lemma `mutateWindow_length`) — this
+is what makes the negative control below decidable.
+-/
+
+/-- 180° rotations of a 2-strand tangle: the Klein group on the four
+boundary points {id, (12)(34), (13)(24), (14)(23)}. Every element is its
+own inverse. -/
+inductive KleinRot where
+  | id : KleinRot
+  | r12 : KleinRot
+  | r13 : KleinRot
+  | r14 : KleinRot
+
+/-- Action of a Klein rotation on a PD crossing: the labels (values) are
+preserved, their positions are permuted. -/
+def KleinRot.apply (ρ : KleinRot) (c : PDCrossing) : PDCrossing :=
+  match ρ with
+  | .id => c
+  | .r12 => ⟨c.e2, c.e1, c.e4, c.e3⟩
+  | .r13 => ⟨c.e3, c.e4, c.e1, c.e2⟩
+  | .r14 => ⟨c.e4, c.e3, c.e2, c.e1⟩
+
+theorem KleinRot.apply_involutive (ρ : KleinRot) (c : PDCrossing) :
+    ρ.apply (ρ.apply c) = c := by
+  cases ρ <;> cases c <;> rfl
+
+/-- Mutation of a window [i, j) of the crossing list: crossings outside the
+window are unchanged, those inside are rotated by ρ. Empty window (j ≤ i):
+identity. Full window: the whole diagram. -/
+def mutateWindow : List PDCrossing → Nat → Nat → KleinRot → List PDCrossing
+  | [], _, _, _ => []
+  | c :: cs', 0, 0, _ => c :: cs'
+  | c :: cs', 0, j+1, ρ => ρ.apply c :: mutateWindow cs' 0 j ρ
+  | c :: cs', _+1, 0, _ => c :: cs'
+  | c :: cs', i+1, j+1, ρ => c :: mutateWindow cs' i j ρ
+
+/-- Mutation preserves the crossing count. -/
+theorem mutateWindow_length (cs : List PDCrossing) (i j : Nat) (ρ : KleinRot) :
+    (mutateWindow cs i j ρ).length = cs.length := by
+  induction cs generalizing i j with
+  | nil => rfl
+  | cons c cs' ih =>
+    match i, j with
+    | 0, 0 => rfl
+    | 0, _+1 => simp [mutateWindow, ih]
+    | _+1, 0 => rfl
+    | _+1, _+1 => simp [mutateWindow, ih]
+
+/-- Mutation is involutive: mutating the same window twice with the same
+rotation returns the initial list (every Klein element is its own inverse). -/
+theorem mutateWindow_involutive (cs : List PDCrossing) (i j : Nat) (ρ : KleinRot) :
+    mutateWindow (mutateWindow cs i j ρ) i j ρ = cs := by
+  induction cs generalizing i j with
+  | nil => rfl
+  | cons c cs' ih =>
+    match i, j with
+    | 0, 0 => rfl
+    | 0, j+1 =>
+      simp only [mutateWindow]
+      rw [ih 0 j, KleinRot.apply_involutive]
+    | _+1, 0 => rfl
+    | _+1, _+1 => simp only [mutateWindow, ih _ _]
+
+/-- Two diagrams are mutants if there exist a window and a Klein rotation
+mapping the crossing list of one onto the other. -/
+def AreMutantDiagrams (d₁ d₂ : KnotDiagram) : Prop :=
+  ∃ (i j : Nat) (ρ : KleinRot), mutateWindow d₁.crossings i j ρ = d₂.crossings
+
+/-- Two knots are mutants if they admit representative diagrams (in the
+Reidemeister sense) that are mutants. The existential quantifier over
+representatives is essential: mutation does not necessarily apply to the
+designated diagrams, but to diagrams of the same isotopy classes. -/
+def AreMutants (k₁ k₂ : Knot) : Prop :=
+  ∃ (d₁ d₂ : KnotDiagram),
+    ReidemeisterEquiv k₁.diagram d₁ ∧
+    ReidemeisterEquiv k₂.diagram d₂ ∧
+    AreMutantDiagrams d₁ d₂
+
+/-! ### Elementary theory: reflexivity and symmetry
+
+Reflexivity: empty window. Symmetry: involutivity of `mutateWindow` (every
+Klein rotation is its own inverse). Transitivity is false in general for
+mutation (composing two mutations on different windows is not a one-shot
+mutation) — this is NOT an equivalence relation, and that is correct.
+-/
+/- NOTE: no transitivity claimed — mutation composes rotations over
+potentially different windows, which is not a one-shot rotation. -/
+
+/-- Empty window: mutation is the identity there, for any list. -/
+theorem mutateWindow_zero_window (cs : List PDCrossing) (ρ : KleinRot) :
+    mutateWindow cs 0 0 ρ = cs := by
+  cases cs with
+  | nil => rfl
+  | cons _ _ => rfl
+
+theorem AreMutantDiagrams.refl (d : KnotDiagram) : AreMutantDiagrams d d :=
+  ⟨0, 0, .id, mutateWindow_zero_window d.crossings .id⟩
+
+theorem AreMutantDiagrams.symm {d₁ d₂ : KnotDiagram} (h : AreMutantDiagrams d₁ d₂) :
+    AreMutantDiagrams d₂ d₁ := by
+  obtain ⟨i, j, ρ, hmut⟩ := h
+  refine ⟨i, j, ρ, ?_⟩
+  rw [← hmut]
+  exact mutateWindow_involutive d₁.crossings i j ρ
+
+theorem AreMutants.refl (k : Knot) : AreMutants k k :=
+  ⟨k.diagram, k.diagram, ReidemeisterEquiv.refl k.diagram,
+    ReidemeisterEquiv.refl k.diagram, AreMutantDiagrams.refl k.diagram⟩
+
+theorem AreMutants.symm {k₁ k₂ : Knot} (h : AreMutants k₁ k₂) : AreMutants k₂ k₁ := by
+  obtain ⟨d₁, d₂, hd₁, hd₂, hmut⟩ := h
+  exact ⟨d₂, d₁, hd₂, hd₁, AreMutantDiagrams.symm hmut⟩
+
+/-! ### Controls: the definition discriminates
+
+A definition catching neither a mutant pair nor a counterexample would be a
+disguised `True` and removing the `sorry` would be cosmetic. Two controls:
+
+- NEGATIVE (`not_areMutantDiagrams_trefoil_unknot`): mutation preserves the
+  crossing count, so the trefoil (3 crossings) and the unknot (0) are not
+  mutants — at the designated-diagram level.
+- POSITIVE (`areMutants_trefoil_mutant`): a non-trivial mutation (full
+  window, r12 rotation) is captured by the definition.
+
+NOTE (limit of the canonical witness): the designated diagrams
+`conwayKnotDiagram` and `kinoshitaTerasakaDiagram` (KnotInfo PD codes) differ
+at crossings 2, 9 and 11 by a cyclic rewiring of edges {10, 12, 22} that no
+one-shot Klein rotation maps from one onto the other.
+`AreMutants conwayKnot kinoshitaTerasakaKnot` will require an intermediate
+diagram (Reidemeister isotopy) — later sub-grain.
+-/
+
+/-- Negative control: trefoil and unknot are not mutants (mutation preserves
+the crossing count). -/
+theorem not_areMutantDiagrams_trefoil_unknot :
+    ¬ AreMutantDiagrams trefoilDiagram unknotDiagram := by
+  intro ⟨i, j, ρ, hmut⟩
+  have hlen := mutateWindow_length trefoilDiagram.crossings i j ρ
+  simp only [unknotDiagram] at hmut
+  rw [hmut] at hlen
+  simp [trefoilDiagram] at hlen
+
+/-- The trefoil mutant by r12 over the full window. -/
+def trefoilMutantDiagram : KnotDiagram where
+  crossings := mutateWindow trefoilDiagram.crossings 0 3 KleinRot.r12
+  numEdges := 6
+
+def trefoilMutant : Knot where
+  diagram := trefoilMutantDiagram
+
+/-- Positive control: the definition catches a non-trivial mutation (full
+window, non-identity rotation). -/
+theorem areMutantDiagrams_trefoil_mutant :
+    AreMutantDiagrams trefoilDiagram trefoilMutantDiagram :=
+  ⟨0, 3, .r12, rfl⟩
+
+theorem areMutants_trefoil_mutant : AreMutants trefoil trefoilMutant :=
+  ⟨trefoilDiagram, trefoilMutantDiagram, ReidemeisterEquiv.refl _,
+    ReidemeisterEquiv.refl _, areMutantDiagrams_trefoil_mutant⟩
 
 /-! ## 2. The Conway knot (11n34)
 


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: LIGHT/readme #12397

See #2874 (grain `AreMutants` provisionné par ai-01, DM msg-20260822T230334 — contribution partielle à l'umbrella, il reste 12 sorry sur knot_lean). Claim scopé posé (c.5383103500, `paths: **/knot_lean/Knots/Conway*.lean`).

## Résumé

Remplace le `sorry` de `AreMutants` (FR `Conway.lean:51` + EN `Conway_en.lean:61`) par une **définition combinatoire de la mutation de Conway au niveau des codes PD** — la décision de design tranchée par ai-01 (géométrique = topologie PL hors Mathlib, intractable).

**knot_lean porte 13 des 17 `sorry` réels du dépôt (76 % de la dette formelle)** — ce grain retire l'un des deux (`distinct_code_sorry` : **13 → 12**, mesuré ci-dessous).

1. **`KleinRot`** : groupe de Klein sur les 4 points de bord d'un tangle à 2 brins — `{id, (12)(34), (13)(24), (14)(23)}`, les trois rotations de 180° + identité. Chaque élément est involutif (`apply_involutive`, prouvé).
2. **`mutateWindow`** : mutation d'une fenêtre [i, j) de la liste de croisements — permutation des positions d'étiquettes dans chaque croisement de la fenêtre. Deux lemmes prouvés : `mutateWindow_length` (préserve le nombre de croisements) et `mutateWindow_involutive` (involutive).
3. **`AreMutants k₁ k₂`** : existentiel sur des diagrammes représentants Reidemeister-équivalents, reliés par `AreMutantDiagrams` (fenêtre + rotation Klein). Signature inchangée : `(k₁ k₂ : Knot) : Prop`.
4. **Théorie élémentaire prouvée** : `AreMutantDiagrams.refl`, `.symm`, `AreMutants.refl`, `AreMutants.symm` (la symétrie knot-level est un swap de paire — l'existentiel sur représentants est directionnel, `ReidemeisterEquiv k.diagram d` ne se retourne pas ; la symétrie combinatoire vit dans `mutateWindow_involutive`). **Transitivité délibérément NON affirmée** (composer deux mutations sur des fenêtres différentes n'est pas une mutation one-shot) — documenté in-file.
5. **Deux contrôles exigés par le greenlight, en lemmes prouvés (pas en prose)** :
   - **Négatif** — `not_areMutantDiagrams_trefoil_unknot` : ¬ mutant au niveau diagrammes, car la mutation préserve le nombre de croisements (trèfle 3, unknot 0). Une définition qui ne discrimine rien serait un `True` déguisé.
   - **Positif** — `areMutants_trefoil_mutant` : une mutation non triviale (fenêtre pleine, rotation r12) est capturée — témoin concret `trefoilMutantDiagram` avec liste de croisements calculée par `rfl`.

### Finding honnête — le positif canonique Conway/KT exige une isotopie

Les diagrammes désignés `conwayKnotDiagram`/`kinoshitaTerasakaDiagram` (codes PD KnotInfo, 11 croisements chacun) diffèrent aux croisements 2, 9, 11 par un **recâblage cyclique des arêtes {10, 12, 22}** qu'**aucune rotation de Klein one-shot n'envoie de l'un sur l'autre** (vérifié : énumération des 3 rotations × fenêtres). `AreMutants conwayKnot kinoshitaTerasakaKnot` passera par l'existentiel sur représentants dès qu'un diagramme intermédiaire (isotopie de Reidemeister) sera exhibé — documenté in-file, laissé en sous-grain. Le témoin positif livré est la mutation r12 du trèfle, genuinement non triviale.

## Validation (B.1-B.3)

- **Sorry réel avant/après** (`python scripts/lean/count_code_sorry.py --json`, champ `distinct_code_sorry`) : knot_lean **13 → 12** ; autres lacs inchangés (decision_theory 2, game_theory 1, conway 1) ; total dépôt 17 → 16. Jamais `grep -c sorry` (sur-compte la prose ~4,5×).
- **`lake build Knots.Conway Knots.Conway_en`** (WSL elan, Lean 4.32.1) : **SUCCESS — 0 erreur** (build ciblé sur répertoire natif avec oleans Mathlib v4.32.1 en cache ; log `/tmp/knot_build.log`). Les 18 warnings `sorry` restants du build sont les déclarations pré-existantes Phase 4+ (alexanderPolynomial & co, lignes 294+), 9 par sibling — aucune dans le bloc ajouté.
- **Proof integrity** : câblé — `lean-knot.yml` invoque `lean-axiom.yml` (vérifié `grep -ln lean-axiom .github/workflows/*.yml`) ; le job CI tournera sur la PR.
- **Dé-risking** : l'intégralité des preuves (les 3 lemmes auxiliaires, les deux contrôles, le témoin concret) a été validée standalone avec `lean` nu AVANT le build complet (proto sans Mathlib, exit 0).
- **Anti-régression** : aucun `sorry` ajouté, aucune preuve existante modifiée — le diff est purement additif autour de la définition remplacée (deletions = les 5 lignes du `def ... := sorry` + commentaires TODO, insertions = définition + 10 théorèmes).

## i18n FR/EN (#4980)

Les deux siblings modifiés dans la même PR : `Conway.lean` (docstrings FR) et `Conway_en.lean` (docstrings EN, namespace `Knots_en`). Signatures, preuves et tactiques **byte-identiques** entre les deux fichiers — seules les docstrings/commentaires diffèrent. `scripts/lean/check_i18n_siblings.py --all` à l'appréciation du reviewer.

## Périmètre — 3 fichiers

1. `MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway.lean` — définition `AreMutants` + groupe de Klein + 10 théorèmes (refl/symm/contrôles).
2. `MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean` — sibling EN byte-identique hors docstrings.
3. `.github/workflows/lean-knot.yml` — `sorry-baseline` **13 → 12** : le gate bidirectionnel (anti-régression §D, #8853/#8856) exige que la baseline suive le compte réel dans la même PR — mesure CI de ce grain : Conway 7 + Reidemeister 2 + Invariant 1 + Lidman 2 = 12 tactic sorries réels (les siblings `_en` exclus du scan par design). Une baseline stale à 13 masquerait la prochaine régression.

Catalogue byte-identique à `origin/main` (aucun diff catalogue). Aucun secret, aucun `.env`.
