### PR TITLE
feat(probas,#11601): densite PyMC-5 1200→1603 — 5 Lectures ancrees (sprinkler/backdoor/front-door/Simpson/contrefactuel)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb
@@ -11,7 +11,7 @@
     "**Duree estimee** : 65 minutes\n",
     "**Prerequis** : [PyMC-4-Bayesian-Networks](PyMC-4-Bayesian-Networks.ipynb) (reseaux bayesiens, CPT, D-separation)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs\n",
     "\n",
@@ -445,6 +445,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2c2259ea",
+   "source": "### Lecture du résultat — la requête inverse rend le contraste flagrant\n\nSur le baromètre, l'observation et l'intervention différaient (`0.656` vs `0.310`) mais restaient toutes deux des probabilités de tempête « plausibles ». Ici le contraste est plus net : **observer** la pluie fait monter `P(Cloudy)` à `0.800` — la pluie est un excellent indice de nuages — tandis que **provoquer** la pluie (arroseur géant) laisse `P(Cloudy)` à sa marginale `0.500`. L'information remonte l'arc `Cloudy → Rain` quand on observe, mais aucun mécanisme physique ne la fait redescendre quand on intervient : `do(Rain)` coupe l'arc entrant, et `Cloudy` redevient une pièce non biaisée.\n\nC'est la signature directionnelle de la causalité que les probabilités classiques ne peuvent pas exprimer : `P(Cloudy|Rain)` et `P(Rain|Cloudy)` vivent dans la même table jointe, mais `P(Cloudy|do(Rain))` **n'est pas** une lecture de cette table — c'est une propriété du graphe orienté. L'échantillonnage `pm.do` (~`0.503` sur 40 000 tirages) confirme la valeur exacte `0.500` à la fluctuation d'échantillonnage près : le `do` natif de PyMC exécute bien la mutilation, pas un simple conditionnement.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "fe765a62",
    "metadata": {},
    "source": [
@@ -496,6 +502,12 @@
     "print(f\"do(barometre) direct (pm.do / enumeration) = {p_storm_do:.3f}\")\n",
     "print(f\"=> Les deux methodes coincident ({backdoor:.3f} ~ {p_storm_do:.3f}) : verification de coherence.\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90cb61d3",
+   "source": "### Lecture du résultat — deux routes, un même nombre\n\nL'ajustement backdoor `0.80*0.3 + 0.10*0.7 = 0.310` coïncide **exactement** avec le `do(barometro)` direct par mutilation (`0.310`). Ce n'est pas une coïncidence numérique : les deux expriment la même quantité `P(tempete | do(barometre))`, l'une en **transformant le graphe** (mutilation : on coupe l'arc `BassePression → Barometre`), l'autre en **corrigeant l'observation** (on conditionne sur le confondeur puis on moyenne selon sa distribution `P(pression)`).\n\nLa condition de validité est graphique : `BassePression` bloque **tous** les chemins backdoor de `Barometre` (ici il n'y en a qu'un, `Barometre ← BassePression → Tempete`), et l'indépendance conditionnelle `tempete ⊥ barometre | pression` justifie la simplification `P(tempete|barometre, pression) = P(tempete|pression)` utilisée dans le calcul. Retenez l'économie de la méthode : **pas besoin de manipuler le modèle** — avec des données observationnelles et la bonne liste de variables d'ajustement, l'effet causal se calcule par une somme pondérée. C'est le fondement de l'inférence causale en épidémiologie et en économétrie (variables de contrôle).",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -573,6 +585,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "422398fa",
+   "source": "### Lecture du résultat — identifier l'effet causal sans voir le confondeur\n\nLe résultat clé est l'égalité parfaite `0.689 = 0.689` : la formule front-door, construite **uniquement** à partir de quantités observationnelles (`P(X=1) = 0.400`, `P(M=1|X=1) = 0.900`, et les conditionnelles `P(Y|M,X)`), restitue exactement l'effet de la mutilation `do(Smoke=True)` — alors même que cette mutilation « triche » en utilisant le SCM complet, `U` compris.\n\nDécomposons pourquoi ça marche : le goudron `M` capture **tout** l'effet de `X` sur `Y` (il n'y a pas d'arc direct `Smoke → Cancer`), et `X` n'a pas de parent observé qui corrompe `P(M|X)`. Le premier facteur `P(M=m|X)` mesure donc l'effet causal `X → M` non biaisé ; la somme interne `Somme_x' P(Y|M=m, x') P(x')` « re-randomise » `X` pour neutraliser le biais du confondeur sur `M → Y`. C'est une **décomposition** de l'effet total en deux morceaux identifiés séparément — l'astuce de Pearl qui rend l'inference causale possible même quand `U` (génétique, statut socio-économique...) n'est **pas mesurable**.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "aeba42bb",
    "metadata": {},
    "source": [
@@ -644,6 +662,12 @@
     "print(f\"P(Rec | do(Drug))   = {do_drug:.3f}\")\n",
     "print(f\"P(Rec | do(NoDrug)) = {do_nodrug:.3f}   => le medicament AIDE causalement.\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37b96f91",
+   "source": "### Lecture du résultat — l'agrégé ment, le `do` rétablit\n\nTrois lectures du **même** SCM, trois verdicts :\n\n- **Agrégé** : `P(Rec|Drug) = 0.580` < `P(Rec|NoDrug) = 0.620` — le médicament semble **nuire**. C'est le chiffre qu'une analyse naïve du tableau croisé rapporterait.\n- **Conditionnel** : dans **chaque** sous-groupe le médicament aide (`0.50 > 0.30` chez les graves, `0.90 > 0.70` chez les légers). Le renversement est le mécanisme exact du paradoxe de Simpson : les graves, qui guérissent moins bien quel que soit le traitement, reçoivent le médicament dans 80 % des cas — l'agrégé est dominé par ce mélange de populations.\n- **Interventionnel** : `P(Rec|do(Drug)) = 0.700` contre `0.500` — l'effet causal vrai, obtenu en coupant l'arc `Severité → Drug` (mutilation) ou, de façon équivalente, par l'ajustement backdoor sur la sévérité de la section 5.\n\nLa leçon pratique : **aucun intervalle de confiance sur l'agrégé ne corrige ce biais** — c'est un défaut de structure du graphe, pas un problème de taille d'échantillon. Seule la question causale bien posée (`do`, ou ajustement sur un ensemble Z validé par le critère backdoor) restaure le bon signe.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -726,6 +750,12 @@
     "print(f\"=> Meme si le patient a gueri AVEC le medicament, sans medicament il n'aurait eu\")\n",
     "print(f\"   qu'environ {p_rec_cf*100:.0f}% de chances de guerison (contrefactuel).\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "415c6890",
+   "source": "### Lecture du résultat — le contrefactuel est un nombre, pas une vague\n\nL'abduction renverse la flèche informationnelle : sachant que le patient a pris le médicament **et** a guéri, la probabilité qu'il soit un cas grave passe de `0.5` (prior) à `0.690` — les guérisons sous médicament sont plus fréquentes chez les légers, donc une guérison observée penche vers « léger », mais le médicament est plus prescrit aux graves... le posterieur `0.690` est le compromis exact de ces deux forces.\n\nLa prédiction contrefactuelle donne `0.424` : ce patient précis, re-placé dans le monde contrefactuel `do(NoDrug)` avec **son** profil abduit, n'aurait eu qu'environ 42 % de chances de guérison — contre 100 % dans le monde factual (il a guéri). C'est la lecture niveau 3 de Pearl : **la même personne**, deux mondes, deux nombres. Ni l'observation (`P(rec|nodrug)` agrégé) ni l'intervention (`do(nodrug)` sur la population) ne répondent à cette question — seuls les **deux temps** abduction → prediction y répondent, et c'est pourquoi le niveau 3 est strictement plus expressif que le niveau 2.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -908,7 +938,7 @@
     "\n",
     "- **References** : Pearl (2000) *Causality* ; Pearl, Glymour & Jewell (2016) *Causal Inference in Statistics : A Primer* ; Shpitser & Pearl (2006) *Identification of Conditional Interventional Effects*.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "[← PyMC-7-Sequential](../DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb) | [Retour a la serie](README.md)"
    ]
@@ -933,7 +963,7 @@
    "version": "3.12.13"
   },
   "cost": {
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "api_provider": "none",
    "cpu_min": 2,
    "gpu_min": 0,

--- a/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
@@ -15,6 +15,12 @@
       by: myia-po-2023:CoursIA-2
       python_sha: 9c569a28a0d7395d0211dfc26a9d0a00cd03f4d2
       csharp_sha: 85bc41d76098400b0727d7ea7b6184d021704f4c
+    - date: "2026-08-23"
+      by: myia-po-2024:CoursIA
+      python_sha: 6e57837153c85d2e220f068750d55c29d550d2bb
+      csharp_sha: 85bc41d76098400b0727d7ea7b6184d021704f4c
+      content_python_sha: 7982b837250567bfcb6ea251dcc50c02a9c86977ed91b0774f1bc9ba1ecea800
+      content_csharp_sha: a0f227fe94560563b68715671c05d1add944a7620260f56b850caa97b58464b6
   known_differences:
   - 'Socle pedagogique commun : inference causale (do-calculus, ajustement) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/lean #12406

See #11601 (umbrella densité round 2, lane assignée po-2024 — contribution partielle, le pool reste large). Claim scopé posé (c.5383213471, `paths: MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb`).

## Résumé

Tranche densité markdown-only sur le notebook le plus bas de la bande : **1200 → 1603 c/cell** (mesuré à l'outil officiel `pedagogy_density.py`, `prose_chars/code_cells`).

**5 Lectures du résultat insérées**, chacune ancrée à la cellule de code dont l'output porte les valeurs citées (vérifié cellule par cellule, cf règle ancrage sémantique Epic #10678) :

1. **Sprinkler** (`0.800` obs vs `0.500` do, pm.do ~`0.503`) — la requête inverse rend le contraste flagrant ; `P(Cloudy|do(Rain))` n'est pas une lecture de la table jointe.
2. **Backdoor** (`0.310 = 0.310`) — deux routes (mutilation vs ajustement), un même nombre ; la condition de validité est graphique.
3. **Front-door** (`0.689 = 0.689`, `P(X)=0.400`, `P(M=1|X=1)=0.900`) — identifier l'effet causal sans voir le confondeur ; décomposition en deux morceaux identifiés séparément.
4. **Simpson** (reversal `0.580`/`0.620` agrégé vs `0.50>0.30` / `0.90>0.70` conditionnel, `do` `0.700`/`0.500`) — l'agrégé ment, le `do` rétablit ; aucun intervalle de confiance ne corrige un défaut de structure.
5. **Contrefactuel** (abduction `0.690`, CF `0.424`) — le contrefactuel est un nombre ; pourquoi le niveau 3 est strictement plus expressif que le niveau 2.

### Finding : les priorités du body de l'umbrella sont périmées

Le body liste « QC-Py-26 (LSTM), QC-Py-21 (Portfolio) » comme tranches prioritaires — mesurées ce cycle à l'outil : **3065** et **2916** c/cell, déjà au-dessus du seuil 2000. La liste datait de c.1331p258. J'ai re-scanné le pool réel depuis `pedagogy_density_baseline.json` : **291 notebooks vivants en bande 1200-2000**, dont PyMC-5 (1200) était le plus bas. Signalé dans le claim de l'issue.

## Validation

- Densité : **1200 → 1603** (`pedagogy_density.py`, seuil umbrella ≥1500 atteint).
- Ancrage : chaque `### Lecture du résultat` suit immédiatement la cellule code dont l'output contient chaque valeur citée (script de vérification + lecture des outputs — la règle #10678 exige le regard, fait).
- Markdown rendering : **0 nouvelle violation** (baseline 1539, `detect_markdown_rendering.py`).
- C.1 : aucun `raise NotImplementedError`/`assert False`/`1/0`.
- C.3 : markdown-only — 0 ligne `execution_count` touchée (diff +33/−3), outputs inchangés, pas de re-exec requise.
- Ordre cellules : 0 finding interp (le seul finding `CONSECUTIVE_CODE` LOW sur les 4 cellules exercices est préexistant, hors scope markdown-only).
- 2 séparateurs décoratifs `---` convertis en `***` par le hook pre-commit `fix-hr-separator` (voie sanctionnée, pas un hand-edit d'output).

## Périmètre — 2 fichiers

1. `MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb` (markdown-only, +33/−3).
2. `scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml` — attestation twin post-enrichissement (commit 6cae2e78aa) : un edit markdown-only du côté Python déclenche quand même le drift du registre (#8057) ; séquence canonique commit notebook → `--update --pair` (sélecteur explicite, #8508). Vérifié : `check_twin_parity.py --check` → 157/157 OK DRIFT=0.

Catalogue byte-identique à main. Aucun secret.
