### PR TITLE
feat(notebooks,#11601): PyMC-8 TrueSkill densite 1219->1612 — 5 Lectures ancrees + 4 alignements C.4

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb
@@ -425,9 +425,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Le modèle 1v1 confirme le mécanisme central de TrueSkill : un `pm.Potential` impose la contrainte \"gagnant a une meilleure performance\", et l'echantillonnage NUTS propage cette information vers les posterieurs de skill. Le gagnant voit son $\\mu$ augmenter (+4.09) et le perdant le sien diminuer (-4.22), tandis que les deux incertitudes diminuent. Visualisons ces distributions posterieures."
-   ]
+   "source": "Le modèle 1v1 confirme le mécanisme central de TrueSkill : un `pm.Potential` impose la contrainte \"gagnant a une meilleure performance\", et l'echantillonnage NUTS propage cette information vers les posterieurs de skill. Le gagnant voit son $\\mu$ augmenter (+4.20) et le perdant le sien diminuer (-4.17), tandis que les deux incertitudes diminuent (8.33 → 7.20 et 7.25). Visualisons ces distributions posterieures."
   },
   {
    "cell_type": "code",
@@ -490,6 +488,12 @@
     "print(\"Le gagnant voit son mu augmenter et le perdant voit le sien diminuer.\")\n",
     "print(\"Les deux incertitudes (sigma) diminuent car on a de l'information.\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5f3de1b",
+   "source": "### Lecture du résultat — la figure résume la mécanique bayesienne d'un match\n\nLa courbe noire en pointillés est le **prior commun** $\\mathcal{N}(25,\\,8.33)$ : avant tout match, les deux joueurs sont indiscernables. Après l'observation « Joueur 1 gagne », la courbe bleue (gagnant, $\\mu = 29.2$) s'est décalée vers la droite et la rouge (perdant, $\\mu = 20.8$) vers la gauche, quasi symétriquement autour du prior — le modèle ne savait pas qui était le plus fort, il révise dans les deux sens à partir de la même information.\n\nLe point que la figure rend visible et qu'Elo ne peut pas exprimer : les deux courbes posterieures sont **plus étroites** que le prior. La zone de recouvrement des deux distributions reste large — un rematch n'est pas joué d'avance — mais elle a rétréci : le système a *appris quelque chose*, et ce quelque chose est quantifié par la largeur des courbes ($\\sigma$ : 8.33 → 7.20 et 7.25), pas seulement par leurs moyennes. Elo n'aurait déplacé que deux points ; TrueSkill déplace deux points **et** resserre deux distributions.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -672,6 +676,12 @@
     "print(f\"Les deux joueurs gardent le meme mu mais l'incertitude diminue.\")\n",
     "print(f\"Sigma: {sigma_init:.2f} -> J1={sA_post.std():.2f}, J2={sB_post.std():.2f}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cec0cc6b",
+   "source": "### Lecture du résultat — un match nul informe sans orienter, et NUTS en souffre\n\nLe résultat clé est dans la dernière ligne : $\\sigma$ passe de 8.33 à 5.40 et 3.80 alors que les $\\mu$ bougent à peine (25 → 26.20 et 26.41). C'est la signature logique d'un **nul** : l'observation `|perfA − perfB| < 1` ne dit pas qui est le plus fort, elle dit seulement que les deux skills sont **proches** — l'information réduit l'incertitude sans déplacer les moyennes. Comparez au match décisif de la section 2 : là, le même genre de mise à jour contractait $\\sigma$ **et** déplaçait les $\\mu$ de ±4.2.\n\n**Lisez aussi les avertissements — ils font partie du résultat.** Les quatre chaînes atteignent la profondeur d'arbre maximale, `rhat > 1.01` et `ess < 100` : ce modèle est **dix fois plus lent** (195 s contre 18 s pour le 1v1) et moins fiable à échantillonner. La cause est le `pt.switch` du `pm.Potential` : la vraisemblance passe brutalement de 1.0 à 0.01 à la frontière `|diff| = ε`, créant une géométrie postérieure à paroi raide que NUTS explore mal. L'écart 5.40 vs 3.80 entre deux joueurs **symétriques par construction** (priors identiques, contrainte symétrique) en est le symptôme : la contraction devrait être identique, la différence est du bruit d'échantillonnage. C'est exactement le cas où le moteur EP du jumeau C# (Infer-8) traite la même contrainte analytiquement — le contraste est développé en section 7 bis.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -1160,9 +1170,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Le tournoi de 6 matchs revele une hiérarchie claire : Alice domine avec $\\mu = 33.3$, suivie de Charlie ($\\mu = 28.5$), Bob ($\\mu = 21.8$) et Dave ($\\mu = 16.5$). Le *conservative rating* ($\\mu - 3\\sigma$) penalise les joueurs avec plus d'incertitude — Dave a le rating le plus bas ($-1.8$) non seulement a cause de son $\\mu$ faible, mais aussi de son $\\sigma$ eleve. Observons les distributions posterieures completes."
-   ]
+   "source": "Le tournoi de 6 matchs revele une hiérarchie claire : Alice domine avec $\\mu = 33.4$, suivie de Charlie ($\\mu = 28.4$), Bob ($\\mu = 21.5$) et Dave ($\\mu = 16.8$). Le *conservative rating* ($\\mu - 3\\sigma$) penalise les joueurs avec plus d'incertitude — Dave a le rating le plus bas ($-1.8$) non seulement a cause de son $\\mu$ faible, mais aussi de son $\\sigma$ eleve. Observons les distributions posterieures completes."
   },
   {
    "cell_type": "code",
@@ -1217,6 +1225,12 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8b45f1d",
+   "source": "### Lecture du résultat — le classement est une famille de distributions, pas un ordre net\n\nLa figure montre les quatre posterieurs après les 6 matchs du tournoi : Alice ($\\mu = 33.4$, $\\sigma = 6.23$), Charlie ($28.4$, $5.81$), Bob ($21.5$, $5.73$) et Dave ($16.8$, $6.21$). L'ordre des moyennes est net, mais **les courbes se chevauchent deux à deux** : la zone où Bob pourrait dépasser Charlie n'est pas vide. TrueSkill ne dit pas « Charlie > Bob », il dit « Charlie est devant Bob avec telle probabilité » — c'est précisément cette incertitude résiduelle que le matchmaking d'Xbox Live exploitait pour apparier des joueurs de niveau comparable.\n\nNotez aussi l'asymétrie des largeurs : Alice et Dave (6.23, 6.21) restent plus incertains que Charlie et Bob (5.81, 5.73). Avec seulement 6 matchs, le volume d'information par joueur diffère selon le calendrier des rencontres — un effet que le tableau `show_ranking` cache (une ligne par joueur) et que la figure rend évident. Le *conservative rating* $\\mu - 3\\sigma$ de Dave ($-1.8$) cumule donc deux pénalités : un $\\mu$ bas **et** un $\\sigma$ qui ne s'est pas encore resserré.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -1372,6 +1386,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "745ad7f7",
+   "source": "### Lecture du résultat — la dilution d'information d'un match par équipes\n\nLes quatre skills sortent en deux paires : A et B à 27.75 et 27.79, C et D à 21.92 et 21.87. Deux lectures :\n\n- **Le gain individuel est dilué** : +2.99 par membre contre +4.21 en 1v1. Une seule observation (l'équipe 1 gagne) est maintenant partagée par **quatre** variables latentes — chaque joueur ne reçoit qu'une part du crédit, car la vraisemblance ne contraint que la *somme* `perfA + perfB > perfC + perfD`. C'est le comportement attendu : dans un match 2v2, un seul joueur peut avoir porté toute la victoire, et le modèle ne peut pas savoir lequel.\n\n- **A et B sont indiscernables par construction** : mêmes priors, contribution symétrique à la somme — le posterior est théoriquement **identique** pour les deux. L'écart 27.75 vs 27.79 (4 centièmes) est donc du pur bruit d'échantillonnage MCMC, et il en va de même côté perdants (21.92 vs 21.87). C'est un point d'**identifiabilité** important : pour séparer A de B, il faut des matchs où ils s'affrontent **entre eux** — aucune quantité de victoires en commun ne le fera.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "8fcf0537",
    "metadata": {
     "papermill": {
@@ -1522,9 +1542,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Le modèle free-for-all estime les skills de 4 joueurs simultanement. Les résultats montrent une separation nette entre les positions : le Joueur 1 ($\\mu \\approx 32.7$) et le Joueur 4 ($\\mu \\approx 17.4$) sont les plus affectes, tandis que les positions intermediaires presentent des changements plus moderes. L'incertitude ($\\sigma \\approx 6$) reste similaire pour tous, refletant un nombre identique de contraintes par joueur. Comparons visuellement ces distributions posterieures."
-   ]
+   "source": "Le modèle free-for-all estime les skills de 4 joueurs simultanement. Les résultats montrent une separation nette entre les positions : le Joueur 1 ($\\mu \\approx 32.5$) et le Joueur 4 ($\\mu \\approx 17.5$) sont les plus affectes, tandis que les positions intermediaires presentent des changements plus moderes. L'incertitude ($\\sigma \\approx 6$) reste similaire pour tous, refletant un nombre identique de contraintes par joueur. Comparons visuellement ces distributions posterieures."
   },
   {
    "cell_type": "code",
@@ -1592,6 +1610,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3c4ff267",
+   "source": "### Lecture du résultat — le free-for-all concentre l'information sur chaque individu\n\nLes quatre courbes sont rangées dans l'ordre du classement : Joueur 1 ($\\mu = 32.5$, or), Joueur 2 ($27.2$), Joueur 3 ($22.9$), Joueur 4 ($17.5$, gris). Le contraste avec le 2v2 de la section précédente est instructif : ici **une seule course** (trois contraintes d'ordre) déplace les extrêmes de ±7.5 environ (32.54 et 17.50 contre un prior à 25) — davantage qu'un match 1v1 décisif (+4.20) — tandis que les positions intermédiaires, tirées vers le haut par le joueur derrière elles et vers le bas par celui devant, bougent à peine (27.19 et 22.93).\n\nC'est la différence structurelle avec la dilution par équipes : dans le free-for-all, chaque contrainte `perf[i] > perf[i+1]` porte sur **un joueur nommé**, l'information n'est pas partagée. Les $\\sigma$ finaux (6.60, 5.97, 5.99, 6.51) le montrent : resserrés par rapport au prior 8.37, et comparables à ce que les 6 matchs 1v1 du tournoi produisaient en section 4 (5.73 à 6.23) — une course à 4 joueurs apporte à peu près autant d'information par joueur que plusieurs matchs individuels, au prix d'un seul échantillonnage.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "3aa251cf",
    "metadata": {
     "papermill": {
@@ -1618,7 +1642,7 @@
     "**Note** : TrueSkill beneficie grandement d'Infer.NET car EP traite les comparaisons\n",
     "de Gaussiennes de maniere analytique. PyMC est plus general mais plus lent pour ce cas précis.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Retour au sommaire** : [Index Probas](../README.md)"
    ]
@@ -1649,7 +1673,8 @@
     "$$\\mu_w' = \\mu_w + \\sigma_w^2 \\cdot \\frac{V(t)}{c}, \\qquad \\mu_l' = \\mu_l - \\sigma_l^2 \\cdot \\frac{V(t)}{c}$$\n",
     "\n",
     "$$(\\sigma_w^2)' = \\sigma_w^2 \\Big(1 - \\tfrac{\\sigma_w^2}{c^2}\\, W(t)\\Big), \\qquad (\\sigma_l^2)' = \\sigma_l^2 \\Big(1 - \\tfrac{\\sigma_l^2}{c^2}\\, W(t)\\Big)$$\n",
-    "\n> **Détail subtil** : la variance se contracte du facteur $\\tfrac{\\sigma^2}{c^2}\\, W(t)$, et **non** de $W(t)$ seul — le ratio $\\sigma^2/c^2 < 1$ borne la contraction (un prior très confiant $\\sigma^2 \\ll c^2$ ne peut guère se resserrer). La cellule numérique suivante le vérifie : $\\sigma$ passe de 8,33 à **7,19**, cohérent avec le moteur EP du jumeau C# (Infer-8 cellule 16 : $N(29{,}21,\\,7{,}19)$).\n",
+    "\n",
+    "> **Détail subtil** : la variance se contracte du facteur $\\tfrac{\\sigma^2}{c^2}\\, W(t)$, et **non** de $W(t)$ seul — le ratio $\\sigma^2/c^2 < 1$ borne la contraction (un prior très confiant $\\sigma^2 \\ll c^2$ ne peut guère se resserrer). La cellule numérique suivante le vérifie : $\\sigma$ passe de 8,33 à **7,19**, cohérent avec le moteur EP du jumeau C# (Infer-8 cellule 16 : $N(29{,}21,\\,7{,}19)$).\n",
     "\n",
     "**Interpretation** : $V(t)$ mesure a quel point la comparaison etait informative — un match equilibre ($t\\approx 0$) instruit beaucoup (grand $V$), une victoire evidente ($t\\gg 0$) instruit peu. La variance $\\sigma^2$ se contracte d'autant. C'est l'equivalent analytique exact de ce que NUTS approxime par echantillonnage dans les sections précédentes.\n",
     "\n",
@@ -1667,7 +1692,7 @@
     "\n",
     "> **Lien pedagogique** : notre PyMC rederivation (sections 3-6) reste pertinente — elle isole la **sémantique bayesienne** du modèle. La forme fermee EP (cette section) est ce qui le rend **operationnel**. Les deux sont complementaires : PyMC pour comprendre, EP pour deployer.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Retour au sommaire** : [Index Probas](../README.md)"
    ]
@@ -1730,18 +1755,7 @@
    "cell_type": "markdown",
    "id": "ep-closedform-interp",
    "metadata": {},
-   "source": [
-    "### Interpretation : la mise a jour analytique EP\n",
-    "\n",
-    "La cellule precedente calcule en forme fermee (O(1), aucun echantillonnage) ce que NUTS\n",
-    "approxime par tirages Monte Carlo dans les sections 2-3. Sur un match a priors egaux,\n",
-    "l'ecart standardise est nul ($t = 0$) : le match est maximalement informatif ($V(0) \\approx 0{,}80$),\n",
-    "d'ou un deplacement important du skill ($\\pm 4{,}2$ points) et une contraction de\n",
-    "l'incertitude ($\\sigma$ : $8{,}33 \\to 7{,}19$, soit $-13{,}7\\,\\%$). C'est le meme raisonnement qui produit,\n",
-    "apres plusieurs matchs successifs, la hierarchie Alice $\\mu = 33{,}3$ observee en section 4 --\n",
-    "mais ici chaque mise a jour coute une multiplication plutot qu'une serie de tirages.\n",
-    "C'est ce cout O(1) qui rend TrueSkill deployable a l'echelle de millions de joueurs.\n"
-   ]
+   "source": "### Interpretation : la mise a jour analytique EP\n\nLa cellule precedente calcule en forme fermee (O(1), aucun echantillonnage) ce que NUTS\napproxime par tirages Monte Carlo dans les sections 2-3. Sur un match a priors egaux,\nl'ecart standardise est nul ($t = 0$) : le match est maximalement informatif ($V(0) \\approx 0{,}80$),\nd'ou un deplacement important du skill ($\\pm 4{,}2$ points) et une contraction de\nl'incertitude ($\\sigma$ : $8{,}33 \\to 7{,}19$, soit $-13{,}7\\,\\%$). C'est le meme raisonnement qui produit,\napres plusieurs matchs successifs, la hierarchie Alice $\\mu = 33{,}4$ observee en section 4 --\nmais ici chaque mise a jour coute une multiplication plutot qu'une serie de tirages.\nC'est ce cout O(1) qui rend TrueSkill deployable a l'echelle de millions de joueurs.\n"
   },
   {
    "cell_type": "markdown",
@@ -1900,7 +1914,7 @@
     "- **Dans ce notebook**, l'incertitude (sigma) ne fait que **diminuer** : chaque match contracte la variance, le posterieur MCMC devenant le prior du match suivant (sections 3 a 7).\n",
     "- Le **vrai** TrueSkill (section 7 bis) ajoute deux mécanismes analytiques **non implementes ici** : la contraction exacte en forme fermee via $W(t)$, **et** un terme de dynamique $\\tau^2$ injecte entre les matchs ($\\sigma^2 \\leftarrow \\sigma^2 + \\tau^2$). C'est ce terme — absent de notre implementation pedagogique — qui, en production, empeche sigma de converger vers 0 et fait remonter l'incertitude d'un joueur inactif.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Retour au sommaire** : [Index Probas](../README.md)"
    ]
@@ -2273,7 +2287,7 @@
    }
   },
   "cost": {
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "api_provider": "none",
    "cpu_min": 2,
    "gpu_min": 0,

--- a/scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml
@@ -34,6 +34,12 @@
       csharp_sha: ec972d10edc2a47588ddfedefc4ec529a0ec2532
       content_python_sha: 6a2f4d9afc8fded99521d64673bc7e136b3097d494eac1a99f5190b3e2445590
       content_csharp_sha: 844487a722a729158e13f01b7fae0a9ba2c96772d9148775f7b57b5e22606a63
+    - date: "2026-08-23"
+      by: myia-po-2024:CoursIA
+      python_sha: d7f29c8e9e934b02e5bf286039733385cd8ffc88
+      csharp_sha: ec972d10edc2a47588ddfedefc4ec529a0ec2532
+      content_python_sha: b36ffb5866839beaa0ef9f7d8ff26f7b588d3e119691d7f3d3ac6b375a5bcd70
+      content_csharp_sha: 844487a722a729158e13f01b7fae0a9ba2c96772d9148775f7b57b5e22606a63
   known_differences:
   - '2026-08-19 (myia-ai-01) #11685 : REBASELINE cote C# apres reparation. Le merge 9881553 (#11622) avait re-execute Infer-8 sur une machine sans Graphviz -- le helper .NET imprime l''echec au lieu de lever, donc 12 bannieres "Problem with converting DOT to SVG" + chemins machine se sont retrouves dans les sorties, et l''audit precedent a enregistre un csharp_sha (532e6b70ee07) qui n''a JAMAIS ete le blob du fichier (test_twin_registry_integrity rouge sur main depuis ce merge). Repare par re-execution reelle avec dot sur le PATH (Graphviz 14.1.3 present sur ai-01, seulement absent du PATH) puis strip_probe_banner.py, --update en DERNIER (#8957). Volume de rendu verifie contre la base de fusion : blocs SVG 18093 -> 18099, 22104 -> 22110, 35287 -> 35293 et 44897 -> 44903 B, svg 4 -> 4 -- aucun livrable rendu perdu. content_python_sha inchange : le jumeau Python n''est pas touche.'
   - "2026-07-28 (myia-po-2026) #8704/#8715 : backfill section 14 \"Pour aller plus loin\" -- formules fermees EP V(t)/W(t)/tau^2 (Herbrich-Minka-Graepel 2007) ajoutees en markdown + NOUVELLE cellule code .NET executee (#r MathNet.Numerics, computation closed-form). Add-only (65 -> 69 cellules), 0 cellule existante alteree, 0 output drift sur les sections 1-13. Variance utilise la forme canonique sigma^2*(1-(sigma^2/c^2)*W(t)) (facteur de gain de Kalman sigma^2/c^2 present) -> posterior sigma=7,19 match exact Infer.NET cellule 16 N(29,21,7,19). python_sha inchange a ce stade (note: PyMC-8 cell29 portait la variante sans facteur sigma^2/c^2 -> bug source trace/corrige en #8718). csharp_sha rebaseline suite au changement de blob."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #12416

See #11601 (tranche densité PyMC-8, 2e et dernière PR du jour sur cette veine — cap 2/2 respecté). Claim scopé posé (c.5383329270, `paths: MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb`). Contribution partielle à l'umbrella (291 notebooks dans la bande, le bas de la file avance notebook par notebook).

## Résumé

Enrichissement markdown-only de PyMC-8 (TrueSkill) : **densité pédagogique 1219 → 1612** (cible umbrella ≥ 1500), via **5 `### Lecture du résultat` insérées**, chacune immédiatement après la cellule de code dont l'output porte les valeurs citées (Epic #10678, vérifié cellule par cellule) :

1. **d5f3de1b** après `5760e439` (viz 1v1) — prior N(25, 8.33) vs posterieurs mu=29.2/20.8, σ 8.33→7.20/7.25 : TrueSkill déplace deux points ET resserre deux distributions (ce qu'Elo ne peut pas exprimer).
2. **cec0cc6b** après `ab84b100` (match nul) — σ 8.33→5.40/3.80 avec μ quasi immobiles (26.20/26.41) : le nul informe sans orienter. Lecture honnête des diagnostics NUTS : max tree depth ×4 chaînes, rhat>1.01, ess<100, 195 s vs 18 s — cause = paroi raide du `pt.switch` ; l'écart 5.40 vs 3.80 entre joueurs symétriques par construction = bruit d'échantillonnage, symptôme affiché comme tel.
3. **e8b45f1d** après `b73bd9ad` (viz tournoi) — courbes qui se chevauchent deux à deux (33.4/6.23, 28.4/5.81, 21.5/5.73, 16.8/6.21) : le classement est une famille de distributions, pas un ordre net ; rating conservateur de Dave (−1.8) cumule μ bas + σ non resserré.
4. **745ad7f7** après `3b2c7481` (2v2) — dilution : +2.99/membre vs +4.21 en 1v1 (une observation partagée par 4 latents) ; point d'identifiabilité : A et B (27.75/27.79) indiscernables par construction, l'écart de 4 centièmes = pur bruit MCMC.
5. **3c4ff267** après `3e9588ea` (viz free-for-all) — une course déplace les extrêmes de ±7.5 (32.54/17.50 vs prior 25), davantage qu'un 1v1 (+4.20) ; σ finaux 6.60/5.97/5.99/6.51 comparables au tournoi de 6 matchs (5.73–6.23) : l'information par joueur n'est PAS diluée contrairement au 2v2.

## Alignements C.4 (4 cellules existantes, prose ≠ outputs committés)

Diagnostic dérive : **(b) claim antérieure fabriquée** — la prose citait des valeurs d'une exécution antérieure à la dernière re-exécution committée (seed=42, outputs stables). Verdict : **CAUSE_FIXED** — la prose est alignée sur les outputs committés (la direction sanctionnée ; jamais l'inverse, aucun output touché) :

- `16031c41` : +4.09/−4.22 → **+4.20/−4.17** (+ σ 8.33→7.20/7.25 ajouté, tous dans l'output de `40e53b79`).
- `9cd5cccd` : 33.3/28.5/21.8/16.5 → **33.4/28.4/21.5/16.8** (output `c0f1b776`).
- `3088ba7e` : ≈32.7/≈17.4 → **≈32.5/≈17.5** (output `050f6d0d`).
- `ep-closedform-interp` : Alice 33,3 → **33,4** (renvoi section 4).

## Validation

- **Densité** : `pedagogy_density.py` `_measure` → prose 18287→24180, n_code 15 inchangé, **1612** (floor 1200, cible umbrella 1500 ✓).
- **Ordre des cellules** : `scan_cell_ordering.py` → 1 scanned, **0 finding**.
- **Rendu markdown** : `detect_markdown_rendering.py` → **0 violation**.
- **C.1** : grep `raise NotImplementedError|assert False|1/0` → **0 match**.
- **C.3** : diff markdown-only vérifié (`git diff | grep -c '"execution_count"'` = 0, `'"outputs"'` = 0) — aucune cellule code source modifiée, pas de re-exécution due.
- **Pre-commit** : hook `fix-hr-separator` a converti 3 `---` décoratifs en `***` (cellules résumé/conclusion existantes) — chemin sanctionné, re-stagé.

## Twin parity (#8057)

`probas-8-trueskill.yaml` : attestation post-enrichissement commitée dans la même PR (commit fbf712d896) — séquence canonique notebook → `check_twin_parity.py --update --pair "Probas-8 TrueSkill"` → yaml. Évite le DRIFT vu sur #12416.

## Périmètre — 2 fichiers

1. `MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb` (+40/−26, markdown-only).
2. `scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml` (+6, attestation).

Catalogue byte-identique à `origin/main`. Aucun secret, aucun `.env`.
