### PR TITLE
feat(lean,#11703): Lean-16h compagnon natif Conway PatternTour — le module pédagogique ouvre sa salle de classe

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16h-Conway-PatternTour-Native.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16h-Conway-PatternTour-Native.ipynb
@@ -1,0 +1,1601 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f2638f76",
+   "metadata": {
+    "papermill": {
+     "duration": 0.043729,
+     "end_time": "2026-08-23T00:19:00.168697+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:19:00.124968+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Lean-16h : la tournée des motifs du Jeu de la Vie — compagnon formel natif de `Conway.Life.PatternTour`\n",
+    "\n",
+    "Compagnon **natif** du module [`Conway/Life/PatternTour.lean`](conway_lean/Conway/Life/PatternTour.lean) du lake\n",
+    "[`conway_lean`](conway_lean/) : le module est **importé et exécuté** ici dans un kernel Lean 4 réel\n",
+    "(`lean4-wsl`), et chaque théorème de la tournée est interrogé par `#check`, `#eval` ou\n",
+    "`#print axioms`. Les sorties de ce notebook sont des sorties du compilateur Lean, pas de la prose\n",
+    "à propos de Lean.\n",
+    "\n",
+    "Ce module a une histoire : il a été conçu **comme** un chemin pédagogique (PR #9796 — « PatternTour\n",
+    "pedagogical module ») qui relie quatre modules jusque-là indépendants (`Oscillators`, `Spaceships`,\n",
+    "`RLE`, `Computation`) en un seul récit. Mais à sa livraison, **aucun notebook ne le citait** : la\n",
+    "mesure de l'EPIC #11703 (visibilité des lakes) le comptait parmi les 16 modules noirs de\n",
+    "`conway_lean`. Ce compagnon est la réponse — il existait un cours sans salle de classe.\n",
+    "\n",
+    "**Position dans la série 16.** `Lean-16d` reconstruit le moteur du Jeu de la Vie *à la main* dans\n",
+    "le notebook (la pédagogie de la construction) ; `Lean-16b` montre la simulation côté Python/Golly ;\n",
+    "`Lean-16e` et `Lean-16g` visitent FRACTRAN et les canons. Ici, le geste est inverse : on **monte\n",
+    "dans le lake** et on fait tourner la théorie telle qu'elle compile — la tournée des cinq régimes\n",
+    "dynamiques du Jeu de la Vie, chaque étape à la fois *regardée* (`#eval`) et *prouvée*\n",
+    "(`theorem ... := by decide`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5673530c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02195,
+     "end_time": "2026-08-23T00:19:00.273192+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:19:00.251242+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le lake, le module, et les trois prédicats\n",
+    "\n",
+    "`conway_lean` porte le cœur du Jeu de la Vie formalisé dans `Conway/Life.lean` : une `Grid` est la\n",
+    "liste des cellules vivantes, `step` applique la règle B3/S23, `evolve n` itère, `shift v` translate.\n",
+    "Sur ce moteur vivent trois **prédicats de régime** — chacun une ligne :\n",
+    "\n",
+    "```lean\n",
+    "def isStillLife  (g : Grid)            : Bool := step g == g\n",
+    "def isOscillator (g : Grid) (n : Nat)  : Bool := evolve n g == g\n",
+    "def isSpaceship  (g : Grid) (n : Nat) (v : Int × Int) : Bool := -- evolve n g == shift v g\n",
+    "```\n",
+    "\n",
+    "`PatternTour` importe ces définitions et ajoute le fil narratif : **équilibre** (still lifes) →\n",
+    "**cycle** (oscillateurs) → **translation** (vaisseaux) → **sérialisation** (RLE) → **accélération**\n",
+    "(Hashlife). La cellule suivante importe la session entière — toutes les importations de ce notebook\n",
+    "viennent de là — et liste les huit théorèmes qui jalonnent la tournée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "68b7d140",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:19:00.328911Z",
+     "iopub.status.busy": "2026-08-23T00:19:00.328765Z",
+     "iopub.status.idle": "2026-08-23T00:21:52.198204Z",
+     "shell.execute_reply": "2026-08-23T00:21:52.197488Z"
+    },
+    "papermill": {
+     "duration": 171.903034,
+     "end_time": "2026-08-23T00:21:52.201793+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:19:00.298759+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Toutes les importations de la session (tete de session, pattern Lean-26) :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Conway<span class=\"bp\">.</span>Life</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>Oscillators</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>Spaceships</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>RLE</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>Computation</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>PatternTour</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">open</span><span class=\"w\"> </span>Conway<span class=\"bp\">.</span>Life</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">open</span><span class=\"w\"> </span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>RLE</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Les huit points d&#39;ancrage de la tournee (tous dans Conway.Life.PatternTour) :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>loaf_is_still_life<span class=\"w\">                  </span><span class=\"c1\">-- section 2  : equilibre</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> loaf_is_still_life<span class=\"w\"> </span>:<span class=\"w\"> </span>isStillLife<span class=\"w\"> </span>loaf<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>tub_is_still_life<span class=\"w\">                   </span><span class=\"c1\">-- section 2  : equilibre</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> tub_is_still_life<span class=\"w\"> </span>:<span class=\"w\"> </span>isStillLife<span class=\"w\"> </span>tub<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>beacon_is_oscillator<span class=\"w\">                </span><span class=\"c1\">-- section 3  : cycle</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> beacon_is_oscillator<span class=\"w\"> </span>:<span class=\"w\"> </span>isOscillator<span class=\"w\"> </span>beacon<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>pulsar_is_oscillator<span class=\"w\">                </span><span class=\"c1\">-- section 3  : cycle (native_decide)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> pulsar_is_oscillator<span class=\"w\"> </span>:<span class=\"w\"> </span>isOscillator<span class=\"w\"> </span>pulsar<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>glider_is_spaceship<span class=\"w\">                 </span><span class=\"c1\">-- section 4  : translation</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> glider_is_spaceship<span class=\"w\"> </span>:<span class=\"w\"> </span>isSpaceship<span class=\"w\"> </span>glider<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>(<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>lwss_is_spaceship<span class=\"w\">                   </span><span class=\"c1\">-- section 4  : translation</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> lwss_is_spaceship<span class=\"w\"> </span>:<span class=\"w\"> </span>isSpaceship<span class=\"w\"> </span>lwss<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>(<span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">2</span>)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>glider_two_periods_translation<span class=\"w\">      </span><span class=\"c1\">-- section 4  : invariance d&#39;echelle</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> glider_two_periods_translation<span class=\"w\"> </span>:<span class=\"w\"> </span>evolve<span class=\"w\"> </span><span class=\"mi\">8</span><span class=\"w\"> </span>glider<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>shift<span class=\"w\"> </span>(<span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"mi\">2</span>)<span class=\"w\"> </span>glider</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>hashlife_fast_glider_translation_4<span class=\"w\">  </span><span class=\"c1\">-- section 6  : acceleration</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> hashlife_fast_glider_translation_4<span class=\"w\"> </span>:<span class=\"w\"> </span>evolveHashlifeFast<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>glider<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>shift<span class=\"w\"> </span>(<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"mi\">1</span>)<span class=\"w\"> </span>glider</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Toutes les importations de la session (tete de session, pattern Lean-26) :\\nimport Conway.Life\\nimport Conway.Life.Oscillators\\nimport Conway.Life.Spaceships\\nimport Conway.Life.RLE\\nimport Conway.Life.Computation\\nimport Conway.Life.PatternTour\\n\\nopen Conway.Life\\nopen Conway.Life.RLE\\n\\n-- Les huit points d'ancrage de la tournee (tous dans Conway.Life.PatternTour) :\\n#check @loaf_is_still_life                  -- section 2  : equilibre\\n#check @tub_is_still_life                   -- section 2  : equilibre\\n#check @beacon_is_oscillator                -- section 3  : cycle\\n#check @pulsar_is_oscillator                -- section 3  : cycle (native_decide)\\n#check @glider_is_spaceship                 -- section 4  : translation\\n#check @lwss_is_spaceship                   -- section 4  : translation\\n#check @glider_two_periods_translation      -- section 4  : invariance d'echelle\\n#check @hashlife_fast_glider_translation_4  -- section 6  : acceleration\"}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 13, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 13, \"column\": 6},\r\n",
+       "   \"data\": \"loaf_is_still_life : isStillLife loaf = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 14, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 14, \"column\": 6},\r\n",
+       "   \"data\": \"tub_is_still_life : isStillLife tub = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 15, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 15, \"column\": 6},\r\n",
+       "   \"data\": \"beacon_is_oscillator : isOscillator beacon 2 = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 16, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 16, \"column\": 6},\r\n",
+       "   \"data\": \"pulsar_is_oscillator : isOscillator pulsar 3 = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 17, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 17, \"column\": 6},\r\n",
+       "   \"data\": \"glider_is_spaceship : isSpaceship glider 4 (1, -1) = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 18, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 18, \"column\": 6},\r\n",
+       "   \"data\": \"lwss_is_spaceship : isSpaceship lwss 4 (0, 2) = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 19, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 19, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"glider_two_periods_translation : evolve 8 glider = shift (2, -2) glider\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 20, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 20, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"hashlife_fast_glider_translation_4 : evolveHashlifeFast 4 glider = shift (1, -1) glider\"}],\r\n",
+       " \"env\": 0}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Toutes les importations de la session (tete de session, pattern Lean-26) :\n",
+       "import Conway.Life\n",
+       "import Conway.Life.Oscillators\n",
+       "import Conway.Life.Spaceships\n",
+       "import Conway.Life.RLE\n",
+       "import Conway.Life.Computation\n",
+       "import Conway.Life.PatternTour\n",
+       "\n",
+       "open Conway.Life\n",
+       "open Conway.Life.RLE\n",
+       "\n",
+       "-- Les huit points d'ancrage de la tournee (tous dans Conway.Life.PatternTour) :\n",
+       "#check @loaf_is_still_life                  -- section 2  : equilibre\n",
+       "──────▶  loaf_is_still_life : isStillLife loaf = true\n",
+       "#check @tub_is_still_life                   -- section 2  : equilibre\n",
+       "──────▶  tub_is_still_life : isStillLife tub = true\n",
+       "#check @beacon_is_oscillator                -- section 3  : cycle\n",
+       "──────▶  beacon_is_oscillator : isOscillator beacon 2 = true\n",
+       "#check @pulsar_is_oscillator                -- section 3  : cycle (native_decide)\n",
+       "──────▶  pulsar_is_oscillator : isOscillator pulsar 3 = true\n",
+       "#check @glider_is_spaceship                 -- section 4  : translation\n",
+       "──────▶  glider_is_spaceship : isSpaceship glider 4 (1, -1) = true\n",
+       "#check @lwss_is_spaceship                   -- section 4  : translation\n",
+       "──────▶  lwss_is_spaceship : isSpaceship lwss 4 (0, 2) = true\n",
+       "#check @glider_two_periods_translation      -- section 4  : invariance d'echelle\n",
+       "──────▶  glider_two_periods_translation : evolve 8 glider = shift (2, -2) glider\n",
+       "#check @hashlife_fast_glider_translation_4  -- section 6  : acceleration\n",
+       "──────▶  hashlife_fast_glider_translation_4 : evolveHashlifeFast 4 glider = shift (1, -1) glider\n",
+       "--% env 0\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Toutes les importations de la session (tete de session, pattern Lean-26) :\\nimport Conway.Life\\nimport Conway.Life.Oscillators\\nimport Conway.Life.Spaceships\\nimport Conway.Life.RLE\\nimport Conway.Life.Computation\\nimport Conway.Life.PatternTour\\n\\nopen Conway.Life\\nopen Conway.Life.RLE\\n\\n-- Les huit points d'ancrage de la tournee (tous dans Conway.Life.PatternTour) :\\n#check @loaf_is_still_life                  -- section 2  : equilibre\\n#check @tub_is_still_life                   -- section 2  : equilibre\\n#check @beacon_is_oscillator                -- section 3  : cycle\\n#check @pulsar_is_oscillator                -- section 3  : cycle (native_decide)\\n#check @glider_is_spaceship                 -- section 4  : translation\\n#check @lwss_is_spaceship                   -- section 4  : translation\\n#check @glider_two_periods_translation      -- section 4  : invariance d'echelle\\n#check @hashlife_fast_glider_translation_4  -- section 6  : acceleration\"}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 13, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 13, \"column\": 6},\r\n",
+       "   \"data\": \"loaf_is_still_life : isStillLife loaf = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 14, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 14, \"column\": 6},\r\n",
+       "   \"data\": \"tub_is_still_life : isStillLife tub = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 15, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 15, \"column\": 6},\r\n",
+       "   \"data\": \"beacon_is_oscillator : isOscillator beacon 2 = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 16, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 16, \"column\": 6},\r\n",
+       "   \"data\": \"pulsar_is_oscillator : isOscillator pulsar 3 = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 17, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 17, \"column\": 6},\r\n",
+       "   \"data\": \"glider_is_spaceship : isSpaceship glider 4 (1, -1) = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 18, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 18, \"column\": 6},\r\n",
+       "   \"data\": \"lwss_is_spaceship : isSpaceship lwss 4 (0, 2) = true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 19, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 19, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"glider_two_periods_translation : evolve 8 glider = shift (2, -2) glider\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 20, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 20, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"hashlife_fast_glider_translation_4 : evolveHashlifeFast 4 glider = shift (1, -1) glider\"}],\r\n",
+       " \"env\": 0}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Toutes les importations de la session (tete de session, pattern Lean-26) :\n",
+    "import Conway.Life\n",
+    "import Conway.Life.Oscillators\n",
+    "import Conway.Life.Spaceships\n",
+    "import Conway.Life.RLE\n",
+    "import Conway.Life.Computation\n",
+    "import Conway.Life.PatternTour\n",
+    "\n",
+    "open Conway.Life\n",
+    "open Conway.Life.RLE\n",
+    "\n",
+    "-- Les huit points d'ancrage de la tournee (tous dans Conway.Life.PatternTour) :\n",
+    "#check @loaf_is_still_life                  -- section 2  : equilibre\n",
+    "#check @tub_is_still_life                   -- section 2  : equilibre\n",
+    "#check @beacon_is_oscillator                -- section 3  : cycle\n",
+    "#check @pulsar_is_oscillator                -- section 3  : cycle (native_decide)\n",
+    "#check @glider_is_spaceship                 -- section 4  : translation\n",
+    "#check @lwss_is_spaceship                   -- section 4  : translation\n",
+    "#check @glider_two_periods_translation      -- section 4  : invariance d'echelle\n",
+    "#check @hashlife_fast_glider_translation_4  -- section 6  : acceleration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fe1e15d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.024027,
+     "end_time": "2026-08-23T00:21:52.272665+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:52.248638+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** Huit théorèmes, cinq régimes. Notez les *types* : `loaf_is_still_life :\n",
+    "isStillLife loaf = true` est une égalité de `Bool` — la preuve oblige Lean à **réduire le calcul**\n",
+    "dans le noyau. C'est la signature de toute la tournée : chaque `theorem` est un calcul que le noyau\n",
+    "refait lui-même, pas un argument que l'on raconte. Deux théorèmes échappent à la règle du « zéro\n",
+    "axiome » (`pulsar_is_oscillator` bascule sur `native_decide`) — la section 3 montre pourquoi, et ce\n",
+    "que cela coûte exactement."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10526813",
+   "metadata": {
+    "papermill": {
+     "duration": 0.026061,
+     "end_time": "2026-08-23T00:21:52.334550+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:52.308489+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Équilibre — les still lifes, regardés puis prouvés\n",
+    "\n",
+    "Un *still life* n'est pas de l'inertie : chaque cellule vivante doit avoir exactement deux ou trois\n",
+    "voisins, chaque cellule morte tout sauf trois, pour que **rien ne bouge**. Le `loaf` (pain, 7\n",
+    "cellules) et le `tub` (bac, 4 cellules) sont deux équilibres locaux de formes différentes. Le\n",
+    "module pose le geste deux fois : le `#eval` *regarde* l'équilibre, le `theorem` le *prouve*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "85be0e3e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:21:52.449389Z",
+     "iopub.status.busy": "2026-08-23T00:21:52.449008Z",
+     "iopub.status.idle": "2026-08-23T00:21:52.683551Z",
+     "shell.execute_reply": "2026-08-23T00:21:52.682424Z"
+    },
+    "papermill": {
+     "duration": 0.271552,
+     "end_time": "2026-08-23T00:21:52.684473+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:52.412921+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- On regarde : le calcul confirme la stabilite.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>isStillLife<span class=\"w\"> </span>loaf<span class=\"w\">        </span><span class=\"c1\">-- attendu : true</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>step<span class=\"w\"> </span>loaf<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>loaf<span class=\"w\">       </span><span class=\"c1\">-- attendu : true (reduction explicite d&#39;une etape)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>loaf<span class=\"w\">                    </span><span class=\"c1\">-- la grille elle-meme : 7 cellules</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> [(<span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>),<span class=\"w\"> </span>(<span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">2</span>),<span class=\"w\"> </span>(<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>),<span class=\"w\"> </span>(<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">3</span>),<span class=\"w\"> </span>(<span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>),<span class=\"w\"> </span>(<span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"mi\">3</span>),<span class=\"w\"> </span>(<span class=\"mi\">3</span>,<span class=\"w\"> </span><span class=\"mi\">2</span>)]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- On prouve : dans le noyau, sans axiome.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>loaf_is_still_life</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>loaf_is_still_life&#39;<span class=\"w\"> </span>does<span class=\"w\"> </span>not<span class=\"w\"> </span>depend<span class=\"w\"> </span>on<span class=\"w\"> </span>any<span class=\"w\"> </span>axioms</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>tub_is_still_life</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>tub_is_still_life&#39;<span class=\"w\"> </span>does<span class=\"w\"> </span>not<span class=\"w\"> </span>depend<span class=\"w\"> </span>on<span class=\"w\"> </span>any<span class=\"w\"> </span>axioms</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- On regarde : le calcul confirme la stabilite.\\n#eval isStillLife loaf        -- attendu : true\\n#eval step loaf == loaf       -- attendu : true (reduction explicite d'une etape)\\n#eval loaf                    -- la grille elle-meme : 7 cellules\\n\\n-- On prouve : dans le noyau, sans axiome.\\n#print axioms loaf_is_still_life\\n#print axioms tub_is_still_life\", \"env\": 0}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"[(0, 1), (0, 2), (1, 0), (1, 3), (2, 1), (2, 3), (3, 2)]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\": \"'Conway.Life.loaf_is_still_life' does not depend on any axioms\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"data\": \"'Conway.Life.tub_is_still_life' does not depend on any axioms\"}],\r\n",
+       " \"env\": 1}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- On regarde : le calcul confirme la stabilite.\n",
+       "#eval isStillLife loaf        -- attendu : true\n",
+       "─────▶  true\n",
+       "#eval step loaf == loaf       -- attendu : true (reduction explicite d'une etape)\n",
+       "─────▶  true\n",
+       "#eval loaf                    -- la grille elle-meme : 7 cellules\n",
+       "─────▶  [(0, 1), (0, 2), (1, 0), (1, 3), (2, 1), (2, 3), (3, 2)]\n",
+       "\n",
+       "-- On prouve : dans le noyau, sans axiome.\n",
+       "#print axioms loaf_is_still_life\n",
+       "──────▶  'Conway.Life.loaf_is_still_life' does not depend on any axioms\n",
+       "#print axioms tub_is_still_life\n",
+       "──────▶  'Conway.Life.tub_is_still_life' does not depend on any axioms\n",
+       "--% env 1\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- On regarde : le calcul confirme la stabilite.\\n#eval isStillLife loaf        -- attendu : true\\n#eval step loaf == loaf       -- attendu : true (reduction explicite d'une etape)\\n#eval loaf                    -- la grille elle-meme : 7 cellules\\n\\n-- On prouve : dans le noyau, sans axiome.\\n#print axioms loaf_is_still_life\\n#print axioms tub_is_still_life\", \"env\": 0}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"[(0, 1), (0, 2), (1, 0), (1, 3), (2, 1), (2, 3), (3, 2)]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\": \"'Conway.Life.loaf_is_still_life' does not depend on any axioms\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"data\": \"'Conway.Life.tub_is_still_life' does not depend on any axioms\"}],\r\n",
+       " \"env\": 1}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- On regarde : le calcul confirme la stabilite.\n",
+    "#eval isStillLife loaf        -- attendu : true\n",
+    "#eval step loaf == loaf       -- attendu : true (reduction explicite d'une etape)\n",
+    "#eval loaf                    -- la grille elle-meme : 7 cellules\n",
+    "\n",
+    "-- On prouve : dans le noyau, sans axiome.\n",
+    "#print axioms loaf_is_still_life\n",
+    "#print axioms tub_is_still_life"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21af1bc2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.070822,
+     "end_time": "2026-08-23T00:21:52.771799+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:52.700977+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture du certificat.** `#print axioms` répond `'loaf_is_still_life' does not depend on any\n",
+    "axioms` : la preuve est close, réduite jusqu'au fond par le noyau Lean — aucun `sorry` transitif,\n",
+    "aucun `native_decide`, aucun `Classical.choice`. C'est le grade le plus élevé qu'une preuve\n",
+    "calculatoire peut porter ici, et la tournée l'obtient sur `loaf` **et** `tub`. Le contraste arrive\n",
+    "à la section suivante : le `pulsar`, trop gros pour ce grade exact, paiera d'un axiome."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91f13f39",
+   "metadata": {
+    "papermill": {
+     "duration": 0.072168,
+     "end_time": "2026-08-23T00:21:52.933259+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:52.861091+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": "## 3. Cycle — la bascule `decide` → `native_decide`\n\nUn oscillateur de période *n* revient à lui-même après *n* étapes. Le `beacon` (phare, période 2)\npasse le noyau sans encombre. Le `pulsar` (48 cellules, période 3) dépasse la limite de récursion\n`maxRecDepth` du noyau : `decide` échoue, et le module bascule sur `native_decide` — qui **compile**\nle calcul au lieu de le réduire. Le coût est précis et mesurable : un axiome — ici\n`pulsar_is_oscillator._native.native_decide.ax_1_1`, l'auxiliaire que le compilateur génère pour ce\n`native_decide` précis (le rôle que les toolchains antérieurs confiaient au générique\n`Lean.ofReduceBool`) : « le compilateur et le noyau calculent la même chose ». C'est l'équivalent formel d'un\n`#eval` témoin : on croit le résultat, mais sur parole du compilateur."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "828f6f1d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:21:53.003849Z",
+     "iopub.status.busy": "2026-08-23T00:21:53.003694Z",
+     "iopub.status.idle": "2026-08-23T00:21:53.376178Z",
+     "shell.execute_reply": "2026-08-23T00:21:53.374810Z"
+    },
+    "papermill": {
+     "duration": 0.396586,
+     "end_time": "2026-08-23T00:21:53.377116+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:52.980530+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le beacon : le noyau y suffit.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>isOscillator<span class=\"w\"> </span>beacon<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\">        </span><span class=\"c1\">-- attendu : true</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>evolve<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span>beacon<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>beacon<span class=\"w\">    </span><span class=\"c1\">-- attendu : false (la demi-periode change la forme)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> false</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le pulsar : le noyau ne suffit plus.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>isOscillator<span class=\"w\"> </span>pulsar<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\">        </span><span class=\"c1\">-- attendu : true (par evaluation, pas par noyau)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>evolve<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>pulsar<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>pulsar<span class=\"w\">    </span><span class=\"c1\">-- attendu : true (une periode complete)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le certificat des deux preuves : le contraste est la lecon.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>beacon_is_oscillator</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>beacon_is_oscillator&#39;<span class=\"w\"> </span>does<span class=\"w\"> </span>not<span class=\"w\"> </span>depend<span class=\"w\"> </span>on<span class=\"w\"> </span>any<span class=\"w\"> </span>axioms</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>pulsar_is_oscillator</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>pulsar_is_oscillator&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[pulsar_is_oscillator<span class=\"bp\">._</span>native<span class=\"bp\">.</span>native_decide<span class=\"bp\">.</span>ax_1_1]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Le beacon : le noyau y suffit.\\n#eval isOscillator beacon 2        -- attendu : true\\n#eval evolve 1 beacon == beacon    -- attendu : false (la demi-periode change la forme)\\n\\n-- Le pulsar : le noyau ne suffit plus.\\n#eval isOscillator pulsar 3        -- attendu : true (par evaluation, pas par noyau)\\n#eval evolve 3 pulsar == pulsar    -- attendu : true (une periode complete)\\n\\n-- Le certificat des deux preuves : le contraste est la lecon.\\n#print axioms beacon_is_oscillator\\n#print axioms pulsar_is_oscillator\", \"env\": 1}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"false\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\": \"'Conway.Life.beacon_is_oscillator' does not depend on any axioms\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 11, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 11, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Conway.Life.pulsar_is_oscillator' depends on axioms: [pulsar_is_oscillator._native.native_decide.ax_1_1]\"}],\r\n",
+       " \"env\": 2}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Le beacon : le noyau y suffit.\n",
+       "#eval isOscillator beacon 2        -- attendu : true\n",
+       "─────▶  true\n",
+       "#eval evolve 1 beacon == beacon    -- attendu : false (la demi-periode change la forme)\n",
+       "─────▶  false\n",
+       "\n",
+       "-- Le pulsar : le noyau ne suffit plus.\n",
+       "#eval isOscillator pulsar 3        -- attendu : true (par evaluation, pas par noyau)\n",
+       "─────▶  true\n",
+       "#eval evolve 3 pulsar == pulsar    -- attendu : true (une periode complete)\n",
+       "─────▶  true\n",
+       "\n",
+       "-- Le certificat des deux preuves : le contraste est la lecon.\n",
+       "#print axioms beacon_is_oscillator\n",
+       "──────▶  'Conway.Life.beacon_is_oscillator' does not depend on any axioms\n",
+       "#print axioms pulsar_is_oscillator\n",
+       "──────▶  'Conway.Life.pulsar_is_oscillator' depends on axioms: [pulsar_is_oscillator._native.native_decide.ax_1_1]\n",
+       "--% env 2\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Le beacon : le noyau y suffit.\\n#eval isOscillator beacon 2        -- attendu : true\\n#eval evolve 1 beacon == beacon    -- attendu : false (la demi-periode change la forme)\\n\\n-- Le pulsar : le noyau ne suffit plus.\\n#eval isOscillator pulsar 3        -- attendu : true (par evaluation, pas par noyau)\\n#eval evolve 3 pulsar == pulsar    -- attendu : true (une periode complete)\\n\\n-- Le certificat des deux preuves : le contraste est la lecon.\\n#print axioms beacon_is_oscillator\\n#print axioms pulsar_is_oscillator\", \"env\": 1}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"false\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\": \"'Conway.Life.beacon_is_oscillator' does not depend on any axioms\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 11, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 11, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Conway.Life.pulsar_is_oscillator' depends on axioms: [pulsar_is_oscillator._native.native_decide.ax_1_1]\"}],\r\n",
+       " \"env\": 2}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Le beacon : le noyau y suffit.\n",
+    "#eval isOscillator beacon 2        -- attendu : true\n",
+    "#eval evolve 1 beacon == beacon    -- attendu : false (la demi-periode change la forme)\n",
+    "\n",
+    "-- Le pulsar : le noyau ne suffit plus.\n",
+    "#eval isOscillator pulsar 3        -- attendu : true (par evaluation, pas par noyau)\n",
+    "#eval evolve 3 pulsar == pulsar    -- attendu : true (une periode complete)\n",
+    "\n",
+    "-- Le certificat des deux preuves : le contraste est la lecon.\n",
+    "#print axioms beacon_is_oscillator\n",
+    "#print axioms pulsar_is_oscillator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcdda560",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022704,
+     "end_time": "2026-08-23T00:21:53.442551+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:53.419847+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": "**Lecture du contraste.** `beacon_is_oscillator` : *does not depend on any axioms*. Une ligne\nplus bas, `pulsar_is_oscillator` : `depends on axioms:\n[pulsar_is_oscillator._native.native_decide.ax_1_1]` — l'auxiliaire nommé par théorème que la\nv4.32.1 génère pour chaque `native_decide`.\nLa bascule `decide` → `native_decide` est exactement le diagnostic documenté dans le module (cycle\nc.736, `decidable_instance_propagation.md`) : sur les prédicats d'état du Jeu de la Vie, `decide`\ntient jusqu'à une profondeur de récursion modérée, puis cède. La tournée ne cache pas la bascule —\nelle la **signale** et en paie le prix au grand jour. C'est une leçon d'honnêteté formelle : un\nthéorème par `native_decide` reste un théorème, mais son certificat porte la trace de ce qu'on a\ndû croire au noyau."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "547c4e0b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015766,
+     "end_time": "2026-08-23T00:21:53.472683+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:53.456917+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Translation — les vaisseaux et l'invariance d'échelle\n",
+    "\n",
+    "Un *vaisseau* est un oscillateur dans le référentiel qui voyage avec lui : après *n* étapes, le\n",
+    "motif réapparaît translaté de *v*. Le `glider` (5 cellules) est le plus petit vaisseau et le seul\n",
+    "diagonal à c/4 — une cellule en diagonale toutes les 4 étapes. Le `lwss` (vaisseau léger) file à\n",
+    "c/2, orthogonal. Le théorème d'invariance d'échelle (`glider_two_periods_translation`) ajoute la\n",
+    "conclusion qui intéresse : le mouvement est **linéaire** — deux périodes = exactement le double du\n",
+    "déplacement, le glider ne dérive pas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0e27ce70",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:21:53.499572Z",
+     "iopub.status.busy": "2026-08-23T00:21:53.499421Z",
+     "iopub.status.idle": "2026-08-23T00:21:53.708298Z",
+     "shell.execute_reply": "2026-08-23T00:21:53.707505Z"
+    },
+    "papermill": {
+     "duration": 0.221557,
+     "end_time": "2026-08-23T00:21:53.708791+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:53.487234+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le glider : translation diagonale (1, -1) toutes les 4 etapes.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>isSpaceship<span class=\"w\"> </span>glider<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>(<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"mi\">1</span>)<span class=\"w\">              </span><span class=\"c1\">-- attendu : true</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>evolve<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>glider<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>shift<span class=\"w\"> </span>(<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"mi\">1</span>)<span class=\"w\"> </span>glider<span class=\"w\">   </span><span class=\"c1\">-- attendu : true (translation calculee)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>evolve<span class=\"w\"> </span><span class=\"mi\">8</span><span class=\"w\"> </span>glider<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>shift<span class=\"w\"> </span>(<span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"mi\">2</span>)<span class=\"w\"> </span>glider<span class=\"w\">   </span><span class=\"c1\">-- attendu : true (deux periodes -&gt; double)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le lwss : translation orthogonale (0, 2), vitesse c/2.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk16\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk16\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>isSpaceship<span class=\"w\"> </span>lwss<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>(<span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">2</span>)<span class=\"w\">                 </span><span class=\"c1\">-- attendu : true</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Certificats : noyau pur sur les trois.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk17\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk17\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>glider_is_spaceship</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>glider_is_spaceship&#39;<span class=\"w\"> </span>does<span class=\"w\"> </span>not<span class=\"w\"> </span>depend<span class=\"w\"> </span>on<span class=\"w\"> </span>any<span class=\"w\"> </span>axioms</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk18\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk18\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>lwss_is_spaceship</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>lwss_is_spaceship&#39;<span class=\"w\"> </span>does<span class=\"w\"> </span>not<span class=\"w\"> </span>depend<span class=\"w\"> </span>on<span class=\"w\"> </span>any<span class=\"w\"> </span>axioms</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk19\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk19\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>glider_two_periods_translation</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>glider_two_periods_translation&#39;<span class=\"w\"> </span>does<span class=\"w\"> </span>not<span class=\"w\"> </span>depend<span class=\"w\"> </span>on<span class=\"w\"> </span>any<span class=\"w\"> </span>axioms</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Le glider : translation diagonale (1, -1) toutes les 4 etapes.\\n#eval isSpaceship glider 4 (1, -1)              -- attendu : true\\n#eval evolve 4 glider == shift (1, -1) glider   -- attendu : true (translation calculee)\\n#eval evolve 8 glider == shift (2, -2) glider   -- attendu : true (deux periodes -> double)\\n\\n-- Le lwss : translation orthogonale (0, 2), vitesse c/2.\\n#eval isSpaceship lwss 4 (0, 2)                 -- attendu : true\\n\\n-- Certificats : noyau pur sur les trois.\\n#print axioms glider_is_spaceship\\n#print axioms lwss_is_spaceship\\n#print axioms glider_two_periods_translation\", \"env\": 2}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\": \"'Conway.Life.glider_is_spaceship' does not depend on any axioms\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 11, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 11, \"column\": 6},\r\n",
+       "   \"data\": \"'Conway.Life.lwss_is_spaceship' does not depend on any axioms\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Conway.Life.glider_two_periods_translation' does not depend on any axioms\"}],\r\n",
+       " \"env\": 3}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Le glider : translation diagonale (1, -1) toutes les 4 etapes.\n",
+       "#eval isSpaceship glider 4 (1, -1)              -- attendu : true\n",
+       "─────▶  true\n",
+       "#eval evolve 4 glider == shift (1, -1) glider   -- attendu : true (translation calculee)\n",
+       "─────▶  true\n",
+       "#eval evolve 8 glider == shift (2, -2) glider   -- attendu : true (deux periodes -> double)\n",
+       "─────▶  true\n",
+       "\n",
+       "-- Le lwss : translation orthogonale (0, 2), vitesse c/2.\n",
+       "#eval isSpaceship lwss 4 (0, 2)                 -- attendu : true\n",
+       "─────▶  true\n",
+       "\n",
+       "-- Certificats : noyau pur sur les trois.\n",
+       "#print axioms glider_is_spaceship\n",
+       "──────▶  'Conway.Life.glider_is_spaceship' does not depend on any axioms\n",
+       "#print axioms lwss_is_spaceship\n",
+       "──────▶  'Conway.Life.lwss_is_spaceship' does not depend on any axioms\n",
+       "#print axioms glider_two_periods_translation\n",
+       "──────▶  'Conway.Life.glider_two_periods_translation' does not depend on any axioms\n",
+       "--% env 3\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Le glider : translation diagonale (1, -1) toutes les 4 etapes.\\n#eval isSpaceship glider 4 (1, -1)              -- attendu : true\\n#eval evolve 4 glider == shift (1, -1) glider   -- attendu : true (translation calculee)\\n#eval evolve 8 glider == shift (2, -2) glider   -- attendu : true (deux periodes -> double)\\n\\n-- Le lwss : translation orthogonale (0, 2), vitesse c/2.\\n#eval isSpaceship lwss 4 (0, 2)                 -- attendu : true\\n\\n-- Certificats : noyau pur sur les trois.\\n#print axioms glider_is_spaceship\\n#print axioms lwss_is_spaceship\\n#print axioms glider_two_periods_translation\", \"env\": 2}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\": \"'Conway.Life.glider_is_spaceship' does not depend on any axioms\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 11, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 11, \"column\": 6},\r\n",
+       "   \"data\": \"'Conway.Life.lwss_is_spaceship' does not depend on any axioms\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Conway.Life.glider_two_periods_translation' does not depend on any axioms\"}],\r\n",
+       " \"env\": 3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Le glider : translation diagonale (1, -1) toutes les 4 etapes.\n",
+    "#eval isSpaceship glider 4 (1, -1)              -- attendu : true\n",
+    "#eval evolve 4 glider == shift (1, -1) glider   -- attendu : true (translation calculee)\n",
+    "#eval evolve 8 glider == shift (2, -2) glider   -- attendu : true (deux periodes -> double)\n",
+    "\n",
+    "-- Le lwss : translation orthogonale (0, 2), vitesse c/2.\n",
+    "#eval isSpaceship lwss 4 (0, 2)                 -- attendu : true\n",
+    "\n",
+    "-- Certificats : noyau pur sur les trois.\n",
+    "#print axioms glider_is_spaceship\n",
+    "#print axioms lwss_is_spaceship\n",
+    "#print axioms glider_two_periods_translation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "922db481",
+   "metadata": {
+    "papermill": {
+     "duration": 0.028527,
+     "end_time": "2026-08-23T00:21:53.746746+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:53.718219+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** Trois `#print axioms`, trois *does not depend on any axioms* : même le théorème\n",
+    "d'invariance d'échelle — qui compare `evolve 8 glider` (huit pas de simulation naïve) à\n",
+    "`shift (2, -2) glider` (une translation formelle) — est réduit intégralement dans le noyau. La\n",
+    "linéarité du mouvement du glider n'est pas observée sur un écran : elle est *prouvée*, et le\n",
+    "certificat n'emprunte rien."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ee0708d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015504,
+     "end_time": "2026-08-23T00:21:53.785242+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:53.769738+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Sérialisation — le format RLE et l'opacité du parseur\n",
+    "\n",
+    "Le format *Run-Length Encoded* est la lingua franca des motifs : une chaîne compacte (`bo$2b3o!`)\n",
+    "encode une grille lisible par tous les simulateurs. Le lake définit chaque motif **deux fois** —\n",
+    "une constante écrite à la main (`glider : Grid`) et la même grille parsée depuis sa chaîne\n",
+    "(`glider_parsed := parseRLE! glider_RLE`) — et la tournée vérifie qu'elles coïncident. Le **canon\n",
+    "de Gosper** (36 cellules, 1970), premier motif fini connu à croissance non bornée, n'existe dans le\n",
+    "lake **que** sous forme RLE : `gosper_gun := parseRLE! gosper_gun_RLE`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2209d59e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:21:53.816506Z",
+     "iopub.status.busy": "2026-08-23T00:21:53.816374Z",
+     "iopub.status.idle": "2026-08-23T00:21:54.006808Z",
+     "shell.execute_reply": "2026-08-23T00:21:54.005885Z"
+    },
+    "papermill": {
+     "duration": 0.208734,
+     "end_time": "2026-08-23T00:21:54.007393+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:53.798659+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le canon de Gosper, analyse depuis sa chaine RLE :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1a\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1a\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>gosper_gun<span class=\"bp\">.</span>length<span class=\"w\">                          </span><span class=\"c1\">-- attendu : 36</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">36</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1b\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>(parseRLE<span class=\"w\"> </span>gosper_gun_RLE)<span class=\"bp\">.</span>toOption<span class=\"bp\">.</span>isSome<span class=\"w\">  </span><span class=\"c1\">-- attendu : true (RLE bien forme)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Recoupements serialisation &lt;-&gt; constante manuelle :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1c\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>glider_parsed<span class=\"bp\">.</span>length<span class=\"w\">    </span><span class=\"c1\">-- attendu : 5 (meme cardinal que glider)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">5</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1d\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>lwss_parsed<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>lwss<span class=\"w\">     </span><span class=\"c1\">-- attendu : true (coincidence exacte)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Le canon de Gosper, analyse depuis sa chaine RLE :\\n#eval gosper_gun.length                          -- attendu : 36\\n#eval (parseRLE gosper_gun_RLE).toOption.isSome  -- attendu : true (RLE bien forme)\\n\\n-- Recoupements serialisation <-> constante manuelle :\\n#eval glider_parsed.length    -- attendu : 5 (meme cardinal que glider)\\n#eval lwss_parsed == lwss     -- attendu : true (coincidence exacte)\", \"env\": 3}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 5},\r\n",
+       "   \"data\": \"36\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
+       "   \"data\": \"5\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 5},\r\n",
+       "   \"data\": \"true\"}],\r\n",
+       " \"env\": 4}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Le canon de Gosper, analyse depuis sa chaine RLE :\n",
+       "#eval gosper_gun.length                          -- attendu : 36\n",
+       "─────▶  36\n",
+       "#eval (parseRLE gosper_gun_RLE).toOption.isSome  -- attendu : true (RLE bien forme)\n",
+       "─────▶  true\n",
+       "\n",
+       "-- Recoupements serialisation <-> constante manuelle :\n",
+       "#eval glider_parsed.length    -- attendu : 5 (meme cardinal que glider)\n",
+       "─────▶  5\n",
+       "#eval lwss_parsed == lwss     -- attendu : true (coincidence exacte)\n",
+       "─────▶  true\n",
+       "--% env 4\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Le canon de Gosper, analyse depuis sa chaine RLE :\\n#eval gosper_gun.length                          -- attendu : 36\\n#eval (parseRLE gosper_gun_RLE).toOption.isSome  -- attendu : true (RLE bien forme)\\n\\n-- Recoupements serialisation <-> constante manuelle :\\n#eval glider_parsed.length    -- attendu : 5 (meme cardinal que glider)\\n#eval lwss_parsed == lwss     -- attendu : true (coincidence exacte)\", \"env\": 3}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 5},\r\n",
+       "   \"data\": \"36\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
+       "   \"data\": \"5\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 5},\r\n",
+       "   \"data\": \"true\"}],\r\n",
+       " \"env\": 4}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Le canon de Gosper, analyse depuis sa chaine RLE :\n",
+    "#eval gosper_gun.length                          -- attendu : 36\n",
+    "#eval (parseRLE gosper_gun_RLE).toOption.isSome  -- attendu : true (RLE bien forme)\n",
+    "\n",
+    "-- Recoupements serialisation <-> constante manuelle :\n",
+    "#eval glider_parsed.length    -- attendu : 5 (meme cardinal que glider)\n",
+    "#eval lwss_parsed == lwss     -- attendu : true (coincidence exacte)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "607e65b0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014503,
+     "end_time": "2026-08-23T00:21:54.031686+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:54.017183+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture — pourquoi un `#eval` et pas un `theorem` ici.** On pourrait vouloir énoncer\n",
+    "`theorem gosper_gun_has_36_cells : gosper_gun.length = 36 := by decide`. Le module explique\n",
+    "pourquoi il s'en abstient : `gosper_gun` est une `def` non-`@[reducible]` qui enveloppe le parseur,\n",
+    "et le noyau ne déplie pas cette opacité lors de la synthèse de l'instance `Decidable` (cf.\n",
+    "`decidable_instance_propagation.md`, cycle c.939). Le `#eval`, qui réduit **par évaluation**,\n",
+    "est la preuve computationnelle honnête du compte de cellules — sans ajouter l'axiome\n",
+    "`Lean.ofReduceBool` qu'exigerait `native_decide`. Devant un calcul que le noyau ne peut pas\n",
+    "certifier proprement, la tournée choisit le témoin non-axiomatisé plutôt que le théorème\n",
+    "axiomatisé : le degré de la preuve affiché correspond au degré réellement atteint."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9eebb0c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.016418,
+     "end_time": "2026-08-23T00:21:54.060902+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:54.044484+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Accélération — Hashlife contre la référence naïve, prouvés égaux\n",
+    "\n",
+    "`evolveHashlifeFast` avance une grille de `2^k` générations en une seule étape de l'algorithme\n",
+    "récursif Hashlife, qui exploite la redondance du quadtree du plan. Pour les motifs périodiques,\n",
+    "l'accélération est exponentielle : avancer de `2^k` coûte essentiellement comme avancer de\n",
+    "`2^(k-1)`. La correction de ce « chemin rapide » se prouve contre la référence naïve `evolve` —\n",
+    "deux algorithmes aux complexités radicalement différentes, et l'égalité de leurs résultats **dans\n",
+    "le noyau**, rendue possible par le fix `ceilLog2` (#9536) qui a désopacisé la couche `MacroCell`\n",
+    "pour le réducteur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "44f17c48",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:21:54.161052Z",
+     "iopub.status.busy": "2026-08-23T00:21:54.160859Z",
+     "iopub.status.idle": "2026-08-23T00:21:54.417287Z",
+     "shell.execute_reply": "2026-08-23T00:21:54.416727Z"
+    },
+    "papermill": {
+     "duration": 0.320745,
+     "end_time": "2026-08-23T00:21:54.417741+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:54.096996+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Hashlife vs reference : meme resultat sur le glider.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1e\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1e\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>evolveHashlifeFast<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>glider<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>evolve<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>glider<span class=\"w\">    </span><span class=\"c1\">-- attendu : true</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1f\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1f\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>evolveHashlifeFast<span class=\"w\"> </span><span class=\"mi\">8</span><span class=\"w\"> </span>glider<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>evolve<span class=\"w\"> </span><span class=\"mi\">8</span><span class=\"w\"> </span>glider<span class=\"w\">    </span><span class=\"c1\">-- attendu : true</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le chemin rapide retrouve la translation prouvee en section 4 :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk20\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk20\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>evolveHashlifeFast<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>glider<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>shift<span class=\"w\"> </span>(<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"mi\">1</span>)<span class=\"w\"> </span>glider<span class=\"w\">  </span><span class=\"c1\">-- attendu : true</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk21\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk21\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>evolveHashlifeFast<span class=\"w\"> </span><span class=\"mi\">8</span><span class=\"w\"> </span>glider<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>shift<span class=\"w\"> </span>(<span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"mi\">2</span>)<span class=\"w\"> </span>glider<span class=\"w\">  </span><span class=\"c1\">-- attendu : true</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Certificat de la coincidence : noyau pur.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk22\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk22\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>hashlife_fast_glider_translation_4</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Conway<span class=\"bp\">.</span>Life<span class=\"bp\">.</span>hashlife_fast_glider_translation_4&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Hashlife vs reference : meme resultat sur le glider.\\n#eval evolveHashlifeFast 4 glider == evolve 4 glider    -- attendu : true\\n#eval evolveHashlifeFast 8 glider == evolve 8 glider    -- attendu : true\\n\\n-- Le chemin rapide retrouve la translation prouvee en section 4 :\\n#eval evolveHashlifeFast 4 glider == shift (1, -1) glider  -- attendu : true\\n#eval evolveHashlifeFast 8 glider == shift (2, -2) glider  -- attendu : true\\n\\n-- Certificat de la coincidence : noyau pur.\\n#print axioms hashlife_fast_glider_translation_4\", \"env\": 4}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Conway.Life.hashlife_fast_glider_translation_4' depends on axioms: [propext]\"}],\r\n",
+       " \"env\": 5}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Hashlife vs reference : meme resultat sur le glider.\n",
+       "#eval evolveHashlifeFast 4 glider == evolve 4 glider    -- attendu : true\n",
+       "─────▶  true\n",
+       "#eval evolveHashlifeFast 8 glider == evolve 8 glider    -- attendu : true\n",
+       "─────▶  true\n",
+       "\n",
+       "-- Le chemin rapide retrouve la translation prouvee en section 4 :\n",
+       "#eval evolveHashlifeFast 4 glider == shift (1, -1) glider  -- attendu : true\n",
+       "─────▶  true\n",
+       "#eval evolveHashlifeFast 8 glider == shift (2, -2) glider  -- attendu : true\n",
+       "─────▶  true\n",
+       "\n",
+       "-- Certificat de la coincidence : noyau pur.\n",
+       "#print axioms hashlife_fast_glider_translation_4\n",
+       "──────▶  'Conway.Life.hashlife_fast_glider_translation_4' depends on axioms: [propext]\n",
+       "--% env 5\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Hashlife vs reference : meme resultat sur le glider.\\n#eval evolveHashlifeFast 4 glider == evolve 4 glider    -- attendu : true\\n#eval evolveHashlifeFast 8 glider == evolve 8 glider    -- attendu : true\\n\\n-- Le chemin rapide retrouve la translation prouvee en section 4 :\\n#eval evolveHashlifeFast 4 glider == shift (1, -1) glider  -- attendu : true\\n#eval evolveHashlifeFast 8 glider == shift (2, -2) glider  -- attendu : true\\n\\n-- Certificat de la coincidence : noyau pur.\\n#print axioms hashlife_fast_glider_translation_4\", \"env\": 4}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 5},\r\n",
+       "   \"data\": \"true\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'Conway.Life.hashlife_fast_glider_translation_4' depends on axioms: [propext]\"}],\r\n",
+       " \"env\": 5}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Hashlife vs reference : meme resultat sur le glider.\n",
+    "#eval evolveHashlifeFast 4 glider == evolve 4 glider    -- attendu : true\n",
+    "#eval evolveHashlifeFast 8 glider == evolve 8 glider    -- attendu : true\n",
+    "\n",
+    "-- Le chemin rapide retrouve la translation prouvee en section 4 :\n",
+    "#eval evolveHashlifeFast 4 glider == shift (1, -1) glider  -- attendu : true\n",
+    "#eval evolveHashlifeFast 8 glider == shift (2, -2) glider  -- attendu : true\n",
+    "\n",
+    "-- Certificat de la coincidence : noyau pur.\n",
+    "#print axioms hashlife_fast_glider_translation_4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fefd8dff",
+   "metadata": {
+    "papermill": {
+     "duration": 0.029889,
+     "end_time": "2026-08-23T00:21:54.457465+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:54.427576+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** La boucle est bouclée : le `shift (1, -1)` prouvé pas à pas par la référence\n",
+    "naïve en section 4 est retrouvé **en une étape MacroCell** par Hashlife, et l'égalité des deux\n",
+    "chemins est réduite dans le noyau sans axiome. C'est le point d'aboutissement que le module\n",
+    "annonce : la même évolution, calculée par deux algorithmes aux coûts opposés, **prouvée égale**.\n",
+    "La tournée relie ainsi ses cinq régimes — l'accélération vient certifier la translation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5801d783",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021348,
+     "end_time": "2026-08-23T00:21:54.505605+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:54.484257+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "Trois exercices, dans l'esprit de la tournée : utiliser le lake, construire soi-même, relier au\n",
+    "théorème. Chaque cellule s'exécute telle quelle (sortie de stub) — à vous de remplacer le contenu\n",
+    "par la vraie vérification."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18e9b420",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023414,
+     "end_time": "2026-08-23T00:21:54.550780+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:54.527366+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Le bateau, encore à quai\n",
+    "\n",
+    "Le lake définit `boat` (Oscillators.lean, 5 cellules) mais la tournée ne le prouve pas : seuls\n",
+    "`loaf` et `tub` ont leur théorème. Complétez la vérification computationnelle — le `#eval` jumeau\n",
+    "de ce que serait `boat_is_still_life`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2ec0997c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:21:54.577710Z",
+     "iopub.status.busy": "2026-08-23T00:21:54.577540Z",
+     "iopub.status.idle": "2026-08-23T00:21:54.735094Z",
+     "shell.execute_reply": "2026-08-23T00:21:54.733941Z"
+    },
+    "papermill": {
+     "duration": 0.170419,
+     "end_time": "2026-08-23T00:21:54.735539+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:54.565120+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 1 : le bateau est-il un still life ?</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : remplacez le #eval place par la verification (attendu : true),</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- puis ajoutez le temoin de reduction explicite (une etape laisse la grille inchangee).</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk23\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk23\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"c1\">-- remplacez : isStillLife boat</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 1 : le bateau est-il un still life ?\\n-- TODO etudiant : remplacez le #eval place par la verification (attendu : true),\\n-- puis ajoutez le temoin de reduction explicite (une etape laisse la grille inchangee).\\n#eval 0 -- remplacez : isStillLife boat\", \"env\": 5}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"0\"}],\r\n",
+       " \"env\": 6}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 1 : le bateau est-il un still life ?\n",
+       "-- TODO etudiant : remplacez le #eval place par la verification (attendu : true),\n",
+       "-- puis ajoutez le temoin de reduction explicite (une etape laisse la grille inchangee).\n",
+       "#eval 0 -- remplacez : isStillLife boat\n",
+       "─────▶  0\n",
+       "--% env 6\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 1 : le bateau est-il un still life ?\\n-- TODO etudiant : remplacez le #eval place par la verification (attendu : true),\\n-- puis ajoutez le temoin de reduction explicite (une etape laisse la grille inchangee).\\n#eval 0 -- remplacez : isStillLife boat\", \"env\": 5}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"0\"}],\r\n",
+       " \"env\": 6}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 1 : le bateau est-il un still life ?\n",
+    "-- TODO etudiant : remplacez le #eval place par la verification (attendu : true),\n",
+    "-- puis ajoutez le temoin de reduction explicite (une etape laisse la grille inchangee).\n",
+    "#eval 0 -- remplacez : isStillLife boat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc0d2851",
+   "metadata": {
+    "papermill": {
+     "duration": 0.029004,
+     "end_time": "2026-08-23T00:21:54.804964+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:54.775960+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Construire le blinker\n",
+    "\n",
+    "Le `blinker` — trois cellules alignées, le plus petit oscillateur (période 2) — n'est pas défini\n",
+    "dans le lake : construisez-le. Une `Grid` est une liste de paires d'entiers ; le `glider` du lake\n",
+    "est écrit `[(0, 0), (1, 0), (1, 2), (2, 0), (2, 1)]` — suivez le même style. La définition\n",
+    "incomplète ci-dessous s'exécute (le stub rend `false`) : c'est en complétant les trois cellules\n",
+    "qu'elle doit rendre `true`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7dda3aaa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:21:54.860281Z",
+     "iopub.status.busy": "2026-08-23T00:21:54.860142Z",
+     "iopub.status.idle": "2026-08-23T00:21:55.067539Z",
+     "shell.execute_reply": "2026-08-23T00:21:55.066772Z"
+    },
+    "papermill": {
+     "duration": 0.235575,
+     "end_time": "2026-08-23T00:21:55.068019+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:54.832444+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 2 : definir le blinker (3 cellules alignees) et le verifier.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : les 3 cellules du blinker (ligne verticale ou horizontale, au choix).</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>blinker_ex<span class=\"w\"> </span>:<span class=\"w\"> </span>Grid<span class=\"w\"> </span>:=<span class=\"w\"> </span>[(<span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>)]<span class=\"w\">  </span><span class=\"c1\">-- incomplet : une seule cellule meurt</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk24\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk24\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>isOscillator<span class=\"w\"> </span>blinker_ex<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\">   </span><span class=\"c1\">-- attendu : false tant que la definition est incomplete</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> false</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 7</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 2 : definir le blinker (3 cellules alignees) et le verifier.\\n-- TODO etudiant : les 3 cellules du blinker (ligne verticale ou horizontale, au choix).\\ndef blinker_ex : Grid := [(0, 0)]  -- incomplet : une seule cellule meurt\\n\\n#eval isOscillator blinker_ex 2   -- attendu : false tant que la definition est incomplete\", \"env\": 6}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 5},\r\n",
+       "   \"data\": \"false\"}],\r\n",
+       " \"env\": 7}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 2 : definir le blinker (3 cellules alignees) et le verifier.\n",
+       "-- TODO etudiant : les 3 cellules du blinker (ligne verticale ou horizontale, au choix).\n",
+       "def blinker_ex : Grid := [(0, 0)]  -- incomplet : une seule cellule meurt\n",
+       "\n",
+       "#eval isOscillator blinker_ex 2   -- attendu : false tant que la definition est incomplete\n",
+       "─────▶  false\n",
+       "--% env 7\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 2 : definir le blinker (3 cellules alignees) et le verifier.\\n-- TODO etudiant : les 3 cellules du blinker (ligne verticale ou horizontale, au choix).\\ndef blinker_ex : Grid := [(0, 0)]  -- incomplet : une seule cellule meurt\\n\\n#eval isOscillator blinker_ex 2   -- attendu : false tant que la definition est incomplete\", \"env\": 6}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 5},\r\n",
+       "   \"data\": \"false\"}],\r\n",
+       " \"env\": 7}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 2 : definir le blinker (3 cellules alignees) et le verifier.\n",
+    "-- TODO etudiant : les 3 cellules du blinker (ligne verticale ou horizontale, au choix).\n",
+    "def blinker_ex : Grid := [(0, 0)]  -- incomplet : une seule cellule meurt\n",
+    "\n",
+    "#eval isOscillator blinker_ex 2   -- attendu : false tant que la definition est incomplete"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6db0b6e1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.024372,
+     "end_time": "2026-08-23T00:21:55.106739+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:55.082367+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Trois périodes : prédire puis vérifier\n",
+    "\n",
+    "Le théorème `glider_two_periods_translation` (section 4) dit : 8 étapes = 2 périodes = translation\n",
+    "`(2, -2)`. Le lake cache aussi `Computation.glider_3periods` : 12 étapes = 3 périodes = `shift (3, -3) glider`.\n",
+    "**Prédisez d'abord** (sans exécuter) : si la linéarité prouvée tient, où sera le glider après\n",
+    "trois périodes ? Puis vérifiez votre prédiction par le calcul."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e9e32d88",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:21:55.142050Z",
+     "iopub.status.busy": "2026-08-23T00:21:55.141913Z",
+     "iopub.status.idle": "2026-08-23T00:21:55.332457Z",
+     "shell.execute_reply": "2026-08-23T00:21:55.331825Z"
+    },
+    "papermill": {
+     "duration": 0.213675,
+     "end_time": "2026-08-23T00:21:55.333131+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:55.119456+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : la linearite du glider sur trois periodes.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : ecrivez le #eval qui verifie evolve 12 glider == shift (3, -3) glider</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- (attendu : true). Indice : le squelette est en commentaire ci-dessous.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval evolve 12 glider == shift (3, -3) glider</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk25\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk25\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"c1\">-- remplacez par votre verification</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">2</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 8</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 3 : la linearite du glider sur trois periodes.\\n-- TODO etudiant : ecrivez le #eval qui verifie evolve 12 glider == shift (3, -3) glider\\n-- (attendu : true). Indice : le squelette est en commentaire ci-dessous.\\n-- #eval evolve 12 glider == shift (3, -3) glider\\n#eval 1 + 1 -- remplacez par votre verification\", \"env\": 7}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 5},\r\n",
+       "   \"data\": \"2\"}],\r\n",
+       " \"env\": 8}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 3 : la linearite du glider sur trois periodes.\n",
+       "-- TODO etudiant : ecrivez le #eval qui verifie evolve 12 glider == shift (3, -3) glider\n",
+       "-- (attendu : true). Indice : le squelette est en commentaire ci-dessous.\n",
+       "-- #eval evolve 12 glider == shift (3, -3) glider\n",
+       "#eval 1 + 1 -- remplacez par votre verification\n",
+       "─────▶  2\n",
+       "--% env 8\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 3 : la linearite du glider sur trois periodes.\\n-- TODO etudiant : ecrivez le #eval qui verifie evolve 12 glider == shift (3, -3) glider\\n-- (attendu : true). Indice : le squelette est en commentaire ci-dessous.\\n-- #eval evolve 12 glider == shift (3, -3) glider\\n#eval 1 + 1 -- remplacez par votre verification\", \"env\": 7}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 5},\r\n",
+       "   \"data\": \"2\"}],\r\n",
+       " \"env\": 8}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 3 : la linearite du glider sur trois periodes.\n",
+    "-- TODO etudiant : ecrivez le #eval qui verifie evolve 12 glider == shift (3, -3) glider\n",
+    "-- (attendu : true). Indice : le squelette est en commentaire ci-dessous.\n",
+    "-- #eval evolve 12 glider == shift (3, -3) glider\n",
+    "#eval 1 + 1 -- remplacez par votre verification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16d67f86",
+   "metadata": {
+    "papermill": {
+     "duration": 0.024769,
+     "end_time": "2026-08-23T00:21:55.391139+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:21:55.366370+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": "## Conclusion — ce que la visibilité change\n\nDu `loaf` immobile au canon de Gosper qui émet des vaisseaux, les cinq régimes du Jeu de la Vie\nsont ici **à la fois regardés et prouvés** — chaque `theorem` un point d'ancrage, chaque `#eval`\nun témoin vivant, chaque `#print axioms` un certificat au degré réel (noyau pur, ou axiome\n`native_decide` assumé et nommé). Le fil — équilibre, cycle, translation, sérialisation, accélération —\nrelie des modules qui vivaient séparément : c'était la raison d'être de `PatternTour`, et ce\nnotebook en est la salle de classe.\n\nC'est aussi la réponse au constat de l'EPIC #11703 : un module pédagogique que personne ne lit\nn'existe pas. Après ce compagnon, `PatternTour` n'est plus un module noir — la mesure\n`scan_lake_notebook_visibility.py` le comptera parmi les modules cités. Pour prolonger :\n`Lean-16b` (la simulation côté Python et Golly), `Lean-16e` (FRACTRAN natif), `Lean-16g` (les\ncanons à gliders) et le corpus Hashlife du lake (`HashlifeCorrectness`), dont les murs `NE`/`SW`\nattendent encore leur visiteur."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Lean 4 (WSL)",
+   "language": "lean4",
+   "name": "lean4-wsl"
+  },
+  "language_info": {
+   "codemirror_mode": "lean4",
+   "file_extension": ".lean",
+   "mimetype": "text/x-lean4",
+   "name": "lean4"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 197.502674,
+   "end_time": "2026-08-23T00:21:58.118373+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "/mnt/d/dev/CoursIA-16h-patterntour/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16h-Conway-PatternTour-Native.ipynb",
+   "output_path": "/mnt/d/dev/CoursIA-16h-patterntour/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16h-Conway-PatternTour-Native.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-23T00:18:40.615699+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-lean — lane myia-po-2025:CoursIA — prev: MED/ledger #12401

## Summary

Compagnon **natif** kernel `lean4-wsl` du module `Conway/Life/PatternTour.lean` (vague V3 de l'EPIC) : `Lean-16h-Conway-PatternTour-Native.ipynb`, 27 cellules (9 code / 18 md), import réel du lake + les 8 théorèmes de la tournée interrogés par `#check` / `#eval` / `#print axioms`, pattern Lean-26. Le module — conçu COMME chemin pédagogique (#9796) mais jamais cité par aucun notebook — a sa salle de classe.

## Mesure de visibilité (preuve du grain, scanner de l'EPIC)

```text
$ python scripts/lean/scan_lake_notebook_visibility.py --lake conway_lean   (worktree)
conway_lean   738 decl   strict 131 -> 141   modules noirs 16 -> 15
```

`PatternTour.lean` quitte la liste des modules invisibles ; +10 noms distinctifs cités (loaf_is_still_life, glider_two_periods_translation, hashlife_fast_glider_translation_4, …).

## Exécution réelle (H.1/C.2)

- Papermill **kernel `lean4-wsl`**, cwd = dossier du lake (`conway_lean/`) — condition nécessaire : le lake n'est PAS un ancêtre du notebook, le kernel doit démarrer dedans (pattern DecInfer-2 / GT-8d) ; 27/27 cellules, **exec 1..9, 0 erreur**.
- Vérification scriptée des sorties rendues (piège connu du kernel lean4-wsl : les erreurs vivent dans les outputs HTML) : **0 marqueur ❌**, valeurs attendues présentes (`true` ×8, `does not depend on any axioms` ×7, `gosper_gun.length = 36`, `glider_parsed.length = 5`).
- `lake build Conway.Life.PatternTour` local préalable : **Build completed successfully (3004 jobs)**, warnings préexistants seulement (simp args MacroCell, vendored).

## Découverte en passant — axiome native_decide nommé par théorème

La docstring du module dit que le `pulsar_is_oscillator` (native_decide) « ajoute l'axiome `Lean.ofReduceBool` ». La sortie **réelle** en v4.32.1 :

```text
'Conway.Life.pulsar_is_oscillator' depends on axioms: [pulsar_is_oscillator._native.native_decide.ax_1_1]
```

La v4.32.1 génère un **auxiliaire nommé par théorème** (traçable dans `#print axioms`), pas le générique. La prose du notebook (3 cellules) cite la sortie mesurée, avec la note historique pour `Lean.ofReduceBool`. Le contraste pédagogique beacon (zéro axiome) vs pulsar (axiome nommé) est conservé — renforcé même.

## Validation

- C.1 : 0 erreur volontaire (les 3 exercices sont des stubs `#eval 0`/squelette exécutables).
- Densité (outil officiel) : **1267** prose-chars/cellule-code ≥ seuil lean 1200 ; md_pct 73.
- 3 exercices : boat (vérification still-life à écrire), blinker (construction par l'étudiant), linéarité 3 périodes (prédire puis vérifier).
- Faux-noir du scanner constaté au passage : `finiteness_lean` listé noir alors que Lean-14b cite ses 6 déclarations 34-163× chacune (noms <10 chars non « distinctifs ») — signalé pour l'EPIC, pas corrigé ici (hors scope).

See #11703 (EPIC — tranche V3, pas de clôture)
