### PR TITLE
feat(notebooks,#12413): Notebook ML 2.5b Calibration des probabilites (reliability + ECE + Brier + Platt + Isotonic, contraste LR vs RF)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5b-Calibration-Probabilites.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5b-Calibration-Probabilites.ipynb
@@ -458,9 +458,9 @@
     "À vous de jouer : rééchantillonnez le test **avec remise** (*bootstrap*) et recalculez l'ECE à chaque tirage pour obtenir un intervalle à 95 %.\n",
     "\n",
     "Indices :\n",
-    "- # Étape 1 : tirer `n_test` indices avec remise : `tirage = rng.integers(0, n_test, n_test)`.\n",
-    "- # Étape 2 : sélectionner `y_test[tirage]` et `proba_rf[tirage]`, calculer `ece_score` dessus, et répéter 100 fois.\n",
-    "- # Étape 3 : l'intervalle à 95 % est `np.percentile(ece_echantillons, [2.5, 97.5])`.\n",
+    "- `# Étape 1` : tirer `n_test` indices avec remise : `tirage = rng.integers(0, n_test, n_test)`.\n",
+    "- `# Étape 2` : sélectionner `y_test[tirage]` et `proba_rf[tirage]`, calculer `ece_score` dessus, et répéter 100 fois.\n",
+    "- `# Étape 3` : l'intervalle à 95 % est `np.percentile(ece_echantillons, [2.5, 97.5])`.\n",
     "- Lecture : si l'intervalle du RF ne recouvre pas l'ECE de la régression logistique, l'écart est robuste malgré le petit test.\n"
    ]
   },
@@ -783,9 +783,9 @@
     "Le code ci-dessous simule un réseau **surconfiant** : les labels de validation ont été générés avec une vraie température de 2 (les logits sont deux fois trop grands pour la réalité). À vous de retrouver $T$.\n",
     "\n",
     "Indices :\n",
-    "- # Étape 1 : probabilité = `1 / (1 + np.exp(-logits / T))` (le softmax binaire est une sigmoïde).\n",
-    "- # Étape 2 : NLL = `-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p))`, en protégeant les logs (`np.clip(p, 1e-12, 1 - 1e-12)`).\n",
-    "- # Étape 3 : balayer `T` sur `np.linspace(0.5, 5.0, 91)` et garder le minimisateur.\n"
+    "- `# Étape 1` : probabilité = `1 / (1 + np.exp(-logits / T))` (le softmax binaire est une sigmoïde).\n",
+    "- `# Étape 2` : NLL = `-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p))`, en protégeant les logs (`np.clip(p, 1e-12, 1 - 1e-12)`).\n",
+    "- `# Étape 3` : balayer `T` sur `np.linspace(0.5, 5.0, 91)` et garder le minimisateur.\n"
    ]
   },
   {
@@ -942,9 +942,9 @@
     "La cellule précédente calcule l'espérance *si l'on traite tous* les patients borderline. L'exercice est de choisir **qui traiter** : balayer le seuil de décision $s$ (traiter si $p \\geq s$) et trouver celui qui maximise le gain **total** sur l'ensemble de test, avec les probabilités **calibrées** (Platt). C'est la généralisation calculée de la section 7 du notebook 2.5, où le seuil était posé à la main selon le coût des erreurs.\n",
     "\n",
     "Indices :\n",
-    "- # Étape 1 : pour un seuil `s`, les décisions sont `probas >= s`.\n",
-    "- # Étape 2 : gain = `+(benefice - cout)` si traité et `y == 1`, `-cout` si traité et `y == 0`, `0` sinon (vectoriser avec `np.where`).\n",
-    "- # Étape 3 : balayer `seuils` avec `proba_rf_platt` et `y_test`, garder le `s` du gain total maximal.\n",
+    "- `# Étape 1` : pour un seuil `s`, les décisions sont `probas >= s`.\n",
+    "- `# Étape 2` : gain = `+(benefice - cout)` si traité et `y == 1`, `-cout` si traité et `y == 0`, `0` sinon (vectoriser avec `np.where`).\n",
+    "- `# Étape 3` : balayer `seuils` avec `proba_rf_platt` et `y_test`, garder le `s` du gain total maximal.\n",
     "- Question bonus : le seuil optimal diffère-t-il de celui obtenu avec les probabilités brutes ? (Repensez à la section 6 : l'ordre est préservé… mais le seuil 0.5 calibré correspond à un autre seuil sur le score brut.)\n"
    ]
   },

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5b-Calibration-Probabilites.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5b-Calibration-Probabilites.ipynb
@@ -1,0 +1,1074 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a256b9ed",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00296,
+     "end_time": "2026-08-23T00:52:51.776773+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:51.773813+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 2.5b — Calibration des probabilités : reliability diagrams, ECE, et pourquoi 0.87 n'est pas 87 % de chances\n",
+    "\n",
+    "**Navigation** : [<< 2.5-Biais-Variance-CV-ROC](2.5-Biais-Variance-CV-ROC.ipynb) | [Index](README.md) | [2.6-Clustering-KMeans-PCA >>](2.6-Clustering-KMeans-PCA.ipynb)\n",
+    "\n",
+    "**Kernel** : Python 3\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "Le notebook 2.5 a montré comment évaluer un classifieur au-delà de l'accuracy : la **courbe ROC** et l'**AUC** mesurent la capacité du modèle à **ordonner** les exemples — lequel patient est plus à risque que lequel. Mais l'AUC ne dit rien d'une question très concrète : quand le modèle affiche **0.87** pour un patient, a-t-il **87 % de chances** d'être positif ? Rien n'est moins sûr. Beaucoup de modèles produisent des **scores** qui ordonnent bien les exemples mais ne se comportent pas comme des **probabilités**. La calibration est la propriété qui fait coïncider les deux — et elle se diagnostique, se mesure et se répare.\n",
+    "\n",
+    "Ce notebook s'intercale entre 2.5 et 2.6 : nous restons dans le supervisé probabiliste (même jeu de données `breast_cancer` et même découpage 70/30 que 2.5) en ajoutant l'outil qui manquait — lire un score comme une probabilité digne de ce nom.\n",
+    "\n",
+    "### Objectifs d'apprentissage\n",
+    "\n",
+    "À la fin de ce notebook, vous saurez :\n",
+    "1. Distinguer **score discriminant** (ordonner) et **probabilité calibrée** (quantifier), et diagnostiquer un modèle mal calibré.\n",
+    "2. Construire un **reliability diagram** from scratch : binning, confiance moyenne vs fréquence observée.\n",
+    "3. Chiffrer la calibration par l'**ECE** (Expected Calibration Error) et le **Brier score**.\n",
+    "4. Recalibrer un modèle avec le **Platt scaling** et la **régression isotonique** — et comprendre ce que la calibration **ne change pas** (ordre, AUC).\n",
+    "5. Consommer des probabilités calibrées dans une **décision coût/bénéfice** (espérance de gain).\n",
+    "\n",
+    "### Prérequis\n",
+    "\n",
+    "- Notebook 2.1 (standardisation, train/test split, métriques).\n",
+    "- Notebook 2.3 (régression logistique, sigmoïde).\n",
+    "- Notebook 2.4 (forêts aléatoires).\n",
+    "- Notebook 2.5 (courbe ROC, AUC, seuil de décision).\n",
+    "\n",
+    "> **Référence.** Niculescu-Mizil, A. & Caruana, R. (2005), *Predicting Good Probabilities With Supervised Learning*, ICML 2005. La régression logistique sort généralement bien calibrée, tandis que les modèles à base d'arbres écrasent leurs scores vers 0 et 1 — exactement le contraste que nous allons mesurer.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8787d89e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:51.781934Z",
+     "iopub.status.busy": "2026-08-23T00:52:51.781934Z",
+     "iopub.status.idle": "2026-08-23T00:52:53.927766Z",
+     "shell.execute_reply": "2026-08-23T00:52:53.927766Z"
+    },
+    "papermill": {
+     "duration": 2.150193,
+     "end_time": "2026-08-23T00:52:53.929557+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:51.779364+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Configuration OK : 2.5b - Calibration des probabilites\n",
+      "Mesures retenues : ['mean perimeter', 'mean fractal dimension']\n",
+      "Entrainement : 398 lignes | Test : 171 lignes\n",
+      "Taux de base (part de classe 1, benin) dans le test : 0.626\n"
+     ]
+    }
+   ],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "def _warn_no_path(message, category, filename, lineno, file=None, line=None):\n",
+    "    return f\"{category.__name__}: {message}\\n\"\n",
+    "\n",
+    "warnings.formatwarning = _warn_no_path\n",
+    "# Configuration et imports pour le notebook 2.5b\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from sklearn.datasets import load_breast_cancer\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.metrics import roc_auc_score\n",
+    "\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "# Meme jeu de donnees et meme decoupage 70/30 stratifie que le notebook 2.5,\n",
+    "# mais protocole reduit a DEUX mesures morphometriques (voir section 1)\n",
+    "cancer = load_breast_cancer()\n",
+    "X = cancer.data[:, [2, 9]]   # mean perimeter, mean fractal dimension\n",
+    "y = cancer.target\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X, y, test_size=0.3, random_state=42, stratify=y\n",
+    ")\n",
+    "\n",
+    "print(\"Configuration OK : 2.5b - Calibration des probabilites\")\n",
+    "print(f\"Mesures retenues : {[str(cancer.feature_names[i]) for i in [2, 9]]}\")\n",
+    "print(f\"Entrainement : {X_train.shape[0]} lignes | Test : {X_test.shape[0]} lignes\")\n",
+    "print(f\"Taux de base (part de classe 1, benin) dans le test : {y_test.mean():.3f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b40deeee",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002869,
+     "end_time": "2026-08-23T00:52:53.935870+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:53.933001+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Pourquoi calibrer ? Le modèle qui dit 0.87 a-t-il raison 87 % du temps ?\n",
+    "\n",
+    "Un classifieur binaire produit pour chaque exemple un score dans [0, 1]. Deux questions distinctes s'y cachent :\n",
+    "\n",
+    "- **Ordonner** (*discrimination*) : le patient A (score 0.91) est-il plus à risque que le patient B (score 0.12) ? C'est ce que mesurent l'accuracy et l'AUC.\n",
+    "- **Quantifier** (*calibration*) : parmi tous les patients qui reçoivent le score 0.87, quelle proportion est réellement positive ? Si la réponse est « 87 % », le modèle est **calibré** : son score s'interprète littéralement comme une probabilité.\n",
+    "\n",
+    "Un modèle peut ordonner correctement et quantifier très mal. Le cas classique : les modèles à base d'arbres (forêt aléatoire, gradient boosting) agrègent des votes binaires 0/1 et écrasent leurs scores vers les extrêmes — la **moyenne** des scores reste proche du taux de base, mais presque aucun score ne vit au milieu : l'histogramme est **bi-modal**, écrasé contre 0 et 1. À l'inverse, la régression logistique optimise une log-vraisemblance et produit naturellement des scores proches de probabilités (Niculescu-Mizil & Caruana, 2005).\n",
+    "\n",
+    "**Un choix de protocole, et pourquoi.** Sur les 30 variables du jeu (notebook 2.5), le problème est si bien séparé que même la forêt reste quasi calibrée : ses scores extrêmes sont *mérités*. Le défaut de calibration naît quand les classes se **chevauchent** et qu'un modèle flexible **mémorise** le bruit. Nous travaillons donc avec **deux mesures seulement** — le périmètre moyen et la dimension fractale moyenne, deux des variables les moins informatives du jeu — comme dans un dépistage grossier à deux mesures. La confrontation :\n",
+    "\n",
+    "| Modèle | Discrimination attendue | Calibration attendue |\n",
+    "|---|---|---|\n",
+    "| `LogisticRegression(max_iter=1000)` (sur mesures standardisées) | bonne | **bonne** (bien calibrée) |\n",
+    "| `RandomForestClassifier(n_estimators=100)` | bonne, du même ordre | **mauvaise** (écrasée vers 0/1) |\n",
+    "\n",
+    "L'objectif n'est pas de les départager en accuracy : c'est de rendre visible le **second axe**, celui que l'AUC ne voit pas.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5c9ceada",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:53.942983Z",
+     "iopub.status.busy": "2026-08-23T00:52:53.941983Z",
+     "iopub.status.idle": "2026-08-23T00:52:54.326749Z",
+     "shell.execute_reply": "2026-08-23T00:52:54.326749Z"
+    },
+    "papermill": {
+     "duration": 0.389905,
+     "end_time": "2026-08-23T00:52:54.328655+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:53.938750+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                    mean_proba_class_1  count_pred_class_1  part_scores_dans_[0.1, 0.9]\n",
+      "LogisticRegression               0.605                 106                        0.374\n",
+      "RandomForest                     0.595                 105                        0.240\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEEAAAFyCAYAAAAat8RwAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAcyFJREFUeJzt3QeYE1X79/F7l16kLFWKWLAiIIJiQbFhxYLYEBVRQLEiYkFF8RFEsQN2Hhs2sCu2R5qKSlMRCzYsFJW2NOmy816/43/yZrPJbjY72ewm3891BTbJ5OTkZDLnzD2nZHme5xkAAAAAAECay051BgAAAAAAAEoDQRAAAAAAAJARCIIAAAAAAICMQBAEAAAAAABkBIIgAAAAAAAgIxAEAQAAAAAAGYEgCAAAAAAAyAgEQQAAAAAAQEYgCAIAAAAAADICQRAgwurVqy0rK8vuvvvuMp1mpvnmm29cGb744oupzgpS4Prrr7eKFStS9gAKuP/++1398Ndff1E6AIAiEQRBmda1a1erWrWqlQdqfKkRpsZYkJRm+G277bazjh072hNPPBHo+wDJMmDAgHLzOwYQ3W+//ZavLsrOzrY6depY586d7Y033sjoYhs2bFiButq/nXPOOVZWA8vKH5CpZsyYYUcccYTVrFnTateubSeffLL98MMPgb5Hs2bNinUMWLNmjT3zzDPu/KdKlSruN/r3338Hmif8iyAIEEGNOs/zbNCgQWUmze7du7vX5+Xl2fz5823vvfe2Cy+80B544AHLFPrMKoOzzjor1VkBgIx19dVXu2PxP//8Y3PmzHGB+VNOOcVef/11y3RffvmlK5vw27PPPpvqbAGIoGPX4Ycfbi1btrSFCxe6trUccsghtmjRopSV14gRI2zSpEl28cUXu7Y/kocgCFCOKCKsqPIjjzxi9erVs1GjRqU6SwCADKSeIDqBePrpp13dNHr06FRnCQDicu2111qjRo3soYcespycHGvSpIk7lm3YsMH+85//pKwU77jjjlBPkMqVK6csH5mAIAjKvbVr17ru9jvssIM7YChIcOmll1pubm6+7ZYuXWo9e/Z0vTJ009+aq0Pd4C677LIi5+8YM2aMtWnTxm2//fbbu25zn3/+eahLnR6Tq666KtQNVpHcwtLUlbS77rrLpVutWjVr2rSp9e7d2xYvXlzoZ65UqZK1aNEi6navvfaaderUyeWzevXqLqo9derUAu970003ubLSNurO/PXXX7uDrnpchNtxxx1d74u5c+e6qLm2V3mLKosbb7zRdt11V9dtr2HDhnbBBRfYsmXLQq/ftm2b6yq8xx57uNc2b97cevToka/LYTzbxJoTRMOQ+vTp48pf3/9OO+3kuvlu3LgxtM306dPdaydOnGj//e9/bZdddnHDM/bff3/77LPPLB4HHHBAXEM64vksftkNGTLEbad0Vc5XXHGFrVy5MuHP9vDDD7uTkgoVKrirHPLtt9/a6aefbg0aNHDf0Z577lkgePbLL7/Y2Wef7fY/5Vn7gD6D8liUotLXFWL1WNq8eXO+LuLqWh8+lt+/1apVy+2P7777bpHvXRqfD0DhFJCvW7dugfpI9V34b1vdzQ877DB7//33822nY1z9+vVt3bp1dv7557vtVEf36tUrajfwl156yVq3bu2Om/q9634sH3zwgXtPvz488MADC/RY8d9/1apVrq7T++uEyO9puWLFCncMV570WQcPHux6eCRi+fLlrl2gY5GO6Truq4fo+vXrQ9vo2K3yevnll23s2LG22267ufmQdKyX77//3uVT9a3S2H333e2ee+7Jl6fff//dzj33XFfHq23RqlUrGzp0aKg89fo777zT/R3+HSntWPT9xju8p6j39+n91BZTHaft9tlnH/eZ1evV99FHH9lRRx3l6gZ9h/vtt5+NHz8+6pBL7UP6PvU9qb70qd2g775GjRrupiEQn3zySb403nrrLTv44IPdvqzboYceam+++WaRnzXe9EX5VvtMvad04q021xdffBF6Xvuh8j9z5ky3ncpEbTXRff97Uh2vMlPZqRdDIp8jWWWiNNWuieboo492+3z4vhpPPgorl0TyqHbWtGnT7MQTT8w315h+43r/V155Ja7feGF5Vztb39WSJUvsueeeC313HTp0KDJdlBIPKMNOOOEEr0qVKjGf37x5s9ehQwevcePG3rvvvuutWbPGmzJlite8eXNv77339tavX++227hxo7u/0047eR999JG3du1a7+233/Z69Ojh1ahRw7v00ktDaa5atUpHPu+uu+4KPTZ27FivYsWK3nPPPedeu2LFCm/ixIneWWedFdrmzz//dK+77777CuQzWprbtm3zjj/+eK927dref//7X2/p0qUujaeeesq76aabQtvpdd27dy/wuXNycryWLVvme/zuu+/2srOzvf/85z/e4sWLvWXLlnlDhgzxKlSo4H3wwQeh7S688EKvWrVq3jPPPOOtXr3amzt3rsvLgQce6LVq1Spfmi1atPA6d+7sHXfccd5XX33l8vjyyy97mzZt8g444ABX1ioLlcs333zj0th99929devWudcPHTrU22677bx33nnH+/vvv93rJ0yY4F188cWh94hnm6+//tqVxQsvvJCvXHfeeWdXDtOnT3ff/+uvv+7K5rDDDvP++ecft93HH3/sXqvv65ZbbvH++usv77fffvMOOeQQr0GDBqH9pDAdO3YsdF8szmfZsGGDt99++7n99qWXXvJWrlzp/f77797o0aND+09xP1u3bt28G2+80fvjjz/cPq7vYubMmV716tW9k08+2fvuu+/cd6T3q1WrlnfdddeF8rPrrru6NL///nv3W5k/f7538803e88//3yhnzXe9K+88sq4yk6/CX0v2r5SpUre559/HnpO6Wk/TuT9E/18AP6/X3/91R1rrr766nzFonomKyvLO+qoo4r8bV922WVe5cqVXZ0TXh/puHbeeee5ely/Yx0/a9asma9ulvHjx7s8DBgwwB3rdNw8//zzvZNOOsk9ruOt77XXXnP14QUXXOC20/bKu7ZTnR75/j179vQmT57sjrWPPfaY2051nY4vqj/1+BNPPOEeVz0d7rbbbnOPf/nllzHLQJ9LdeOOO+7offjhhy491Z2qgw466CBv69atbrvZs2eHjunXXHONt2TJEu+zzz5zaeum+kX1sepE1bP6nHXr1nXHTZ/aOwcffLA7Lqqu1rFPeQzPt46RxTkNWLRokdte5VSUeN5/zpw5rv11+OGHu7/1WdTG6NOnjzdv3jy3zfvvv+/aXmqr/fLLL67uVvtI+XjggQcK1DHKm8ojNzfXtav8Ollp3HnnnW4fUBraD7QffvLJJ24b1TWqX1QvaH9WXvScvnu1kQoTT/qifOs91AbRb0l1vPZz7fe+evXqud9R165dvW+//da14/R5IqkemzVrlmuXtG7d2rUJi/M5klkm+m3p+1G7JZx+g/o93nrrrcUuu1jlkmgep02b5vKoNleka6+91j23cOHCmK8vTt6bNm0a128mml69erm8+O1pBIsgCMp1EMRvkLz66qv5HleDJTwg8fjjj7v7auCEU4Wsx4sKgpxzzjnuRKowxQ2CvPjii+4xBSIKExkEUUPEPzCqoebTQVgH34suuqhAGqo82rdv7/7+8ccfXYNVwZFwCxYscJVJtCCITkj1vuHUAFEedBIeThWHtvfLQSefauQUJp5togVBFOzRYzoZDvfkk0+6x3VCHB4oUEM5nF6nxxXcCko8n0XBqmj7Y7jifrYuXboUSEOBFu23fgMp/P1VeWufUWNCr/cbjMURT/rFCYKE04mCTpgKC4Ik+/MBiB0EUWDjp59+cifk+m0qgBGPZs2auSBGeBAiWj3ev39/r2rVqu59fLqQoRO/cAoI77LLLgWCIAoiqz7Ly8vLt72C+jqp0sl5+PsryBxu3333dSfpCoREHncUQI8WBIl28+vOkSNHuvsKgIRTnabHx40bly8IEvkeosd0bFQgPdyYMWPcCaYCTbpIo9c/+OCDXmGKGwSJV7zvr4soOkGM/Czh2rRp475HP0AU3jZUMEiBJb+O0Xs++uijUds1kYE70QUb7Qty//33u9crMFUc8aavdpe+nyuuuKLQ9LRf6gLV8uXL43p/BY+Ub53Ux/s5kl0mOmFXALN3794FggYqAwVDipOPwsol0Ty+8sor+X5z4W6//Xb33BdffBHz9cXJO0GQsovhMCjXJk+e7LqynXTSSfkeV9dJdWvT86LhIOpGqa5q4SJfF0vbtm3tp59+csMVNARGQx5K6p133nFdGs8888wit1XXPL8rnYZXaLyg5gXp27dvaJv//e9/tmXLFjc0IJLKQ10u1RVVXQAVW1E3wHA777yz67Iazb777uu6tYZTF8TGjRu7ronhlD91z/3www9DZafurBr6oSEt0boYxrNNNPp+lS8Nawl32mmnhZ4Pd8IJJ+S7ry7V/nCJoMTzWfTdq+wi98eSfLbIfVnDv2bPnu2GbUWOK9X+oK6an376qRsTq7wMHz7cxo0bl28oU2HiTb8o6gauIVX+sKDw4TI///xzid8/0c8HIDoNvfC75Gso5JQpU9wQk2OPPTbfdqpvNHQk8retYRWRv209ftxxx+V7TMPWNm3aZH/88Ye7/+uvv7pb5LFO+Yisz3T80HG9W7duBVZA0TFU3eE1xDP8/SPzr3zr+BSZLw3BiVVnRJsY1a87dcxWt3511w936qmnuvlVijqma7iOhsRoCIWGA0Qe8zSERM9rmIXqYQ13eeqpp9yxsjTF8/4arqxhxPp+Ij+LT8OQ5s2b58ohcnl0fYca+jJr1qxCy0zDKtVei9YuOvLII93QBdUVqrdFQ320P2u/i0e86b/33nvu+9GwzKIcdNBBbj+JpIk7NYxJQ7VUHuFDK/zfUzyfI9lloqFnatdqmJo//Em/A+0LXbp0cUPXi5OPwsol0Tz6ClsdqbDnipt3lE0EQVCuqSGjg6IaQZF08qNK1N9O42cjafxgZOUazZVXXmm33Xabm3dBlY4qeTVc/DlBEqGTMeU9nomP/NVhdFDVibUqA504/vjjj/nmj5BjjjnGfSaViRpWumkeCb1eDQ9/zolo5RHtMdH45Uh6P930XuHvp4pDefTfRyefmidFc3Eo6KC5GzRWOHyOjHi2iUbvoRPcaJWwxmf637/Pn7fFp8aX8q05W4ISz2fRdx+tTEvy2SLT8/eHe++9N/T9+N+Rxl3776HnFEDba6+9rF+/fu53o2CY5swIn3skUrzpF0VjmjWXiRrMOtlRw0L7qk6Atm7dWuL3T/TzASh8dRgF3XUSqjH+qiM130U4nbA99thjNnLkyHy/bQUXIn/bqosj51zSHBDiH5/944l+w5EiH/O3jXYM9R8LP4bq/TWnUDjN2+DPQxH5eCJ1RqxjutoAev+ijumqN1R+msgx8pjnz8Gg91AdrHlXdBy85JJL3HsqcKM5OcLnHkmWeN7f31cKqweL+x2qLCL3A7+e0JwRke0i1QFqU2leOc0bo4tLml9DJ7GaF0YXKYpa+jne9P3ge1H1fqxt9Hq9x59//ukuQGkZVe0L/hwu/u8pns+R7DIRzd+hAIg/d4sCfApMalXD4uajsHJJNI+aM8YPLEbyf9tq58dS3LyjbCIIgnJNBylVgtF6Zujqgx811gEvsoHmHwDjidZqIlJNwqSrPzqQa8I0ReV1RSdyUqp46eRYeVdDMl460OoE7tVXX3WfWRPH+T0N/M/qR6D1vK486OZfkVIE3j/4R7siHusquT5/JL2fJuHUe4W/n/9e6g0hOmHX5K9qBCtoo2CSeqNowlZdyYl3m1jff7SrTKp81diKvGpQWGQ/KPF8Fn33miyrMMX9bJHfkf/8zTffHPp+Ir8jBQVEwRo1rFT560qirojqdZdffnnM/BUn/VjUkNMEZpqYWD069JnViNBrNbFeYZL9+QAUTsccTVKp+khLSoZPMK4T2LffftsFR3R13v9t6/cZ7bcdz7HZr7uiHRcjH/NPYArbNvwYGuv9g6wzYh3T1QZQW6SoY7r/+bWqRaxjnnqrioIOOhFUuuoRp+9AddFFF11kpaGo91cdKIXVg8X9Dv3eEeH857/66quY7SL/fXSxQr2D1FbUhJdKSxN7qxdHLPGmH8/nLay9pQtwKkutwNS+fXvXzhD1jIpU1OdIdpn4E8mrrfrEE0+4+/pf+6/q+eKWXWHlkmgedZFF20W70Ka2vXqSqzdTLMXNO8omgiAo1xT51QFIFUQ4dYvTCY+eF61qohNHnYyGi3xdPLQqi2awv++++9zqEv4qHH6lpFUw4qEurTpwRs5yHg/12Ljhhhtcd1J/Znz1AFElUVR6ipzr4K8GajhVplppI17qfqwumOEzmxdFXaf79+9vt9xyi6uw/HXZi7uNT9+vGt+RPXLUKPefT6VYn0Xfva4kRK7aE+Rn01WTdu3aue3j7ZapK6G6sqHu7grw+YGskqav34auVEUODdJ+qMcir8BqhaPCgl+l8fkAxEe9rDQ0c8KECW71BvFPRiN/21rxJNEeWFrtQ71OFNAMpxOPyLpc2+qmYTqRxx0NL9UJit9jrLTomK16IHLlC+VRn6GoY7pOvLQShYIL8V48UfnrNeppp6EI4ce84rZZEhHr/VX+elzH+lj7gwIHfgA78kKXvkP1iowcLhrp+OOPd8G34rSzVM4apuO/prB6It70NaRK2z3//PNWEpG/J/WCKO7nSHaZ+NTrQwEw3fQ9K1gR3vM5kXwElUcFZNQG0L4V3n7QeYPOH9T7urAAaHHyrt9ZMn9jKIFUT0oClGRiVE1spsnLtt9+e+9///ufmyRLE0RpMs8999zTrc7hz6StCdI0eZpmrPZnnz/77LPjWh1Gs89rAiatKqG0NLHTGWec4V4bPoP0Djvs4B1zzDEujeKsDqMJXv3VYZ5++ukiV4cRTSamz73bbruFJg3zV4fR6zWTurbRrOyaoCx8dmpNBKdVNZ599lk3oZRmZNes27FWhznzzDMLvL/KQdvrM2viOE1Ypdm4Z8yY4Sa01GcSzdKt2cI1gZ6+L00QdsQRR3gNGzYMzXgdzzbRJkbVDPCaJE5l8Omnn7rv9c0333STaGkCucgVVN56660CnyPW5FaJrg4Tz2cJXx1GZafPof1Ik9v5E8oG8dk0qar20RNPPNHNoq5VcPQ+mgBQedL3pRnmtX9pMmHtg8rbe++951ZY6devX6GfNZ70Rauw+Hn08+3TBGKaOExpqXz0GTt16uRWFzjyyCOLXB0mmZ8PQNGrw4gmIdbEhfrd+bQ6iFYP029Qxy/9LnXsUt2sejK8PtJxLZImLdT76dgfOYmo8qD6Ur93rf4SbXUYHVs1CXjfvn3ddnpOq61ETioe6/01ybjq50hqL+i4U9zVYVTXarUvTfSp47bfDlHdoPply5Yt+SZG9Se/DqfJGnXsOvbYY912OuZp8mcdNzU5tlao0Moqqod0nNN9HfMmTZoUWoHHp4lo/feJnHi0JKvDxPv+kavDqL2m1+r78leH0WS7Ou5rcnrtfzqGayUQ5ePee+8NpVXY5NtajUSTtes7UhrKj1atUZtO370MHz7cGzx4sCtf5UPtGf99tEJNYeJJX7R6mz6LJgjVBLaxVocJf41P2/sroem3pn1Zq8ycfvrpLo8PP/xwsT5HsstEtL0m69cxIPJ3XNyyi1UuJcmj2g/aZ7S/aYU+rcKk44jey5+8tTDx5v3UU091bbnIxQXiweowyUUQBGU+CBJrxnU/hqeK5PLLL3czzmtFiCZNmrjlSDVDeThVxgp6qAGhm/7WiaYO0gMHDiw0YKEDnLZR402z1Sv4cNpppxWYPVonWlquTGkqDX+llmhpiho9I0aMcOnqYKyTQc2oHX6wjBUEEZ0063mtfuNTparGUJ06dVxelbZmJNds1j41eG644QZXVtrm0EMPdY0OrSKjoFI8QRA/EDJs2DB3wqp01MjRUn8PPfRQaNlZVQoqBzX+9Bn1PenAruCAL55togVBRA0ClVmjRo3c96/8qqHrB8BKOwgSz2cR5U+VtwJz2l9USep7Ct9vS/rZ5IcffnCNLH3XqrCVhvanqVOnhoJxagzrpERLNapRqkCYZkiPXHUlkfRFgQ8te1i/fn13UqL86jclangooKh9R79LLQupRr1WMyoqCFIanw9A0UEQGTRokHveX45dv2P9FrV8q37bOhnQMa1t27YJB0H8ldX0G9ZxU0Fi1QkKHkcGQUQn4gq86ARSQRodxyNXeymtIIjoJF7HQrUhdLzSCeJVV10VWuWkqCCI/Pzzz+7CjOoWpaELEaecckqo3HXMe+ONN9xFFtUdyqvaAVpxTHW2T6vmaAUeHRf947Iu9JQ0CBLv+4uWO9XxX3WDvp927dq59kz4ikBTpkxxgRKlo3aG6obIFd2KWoFMy6kqDX2feh/tP9qP/ZNdtQW11Km/IpDyo4BerHq1uOn7dOFJ+6D2R+1zuvgU3o6MdbIvWk1OF0+Uvr57rfCnfSE8CFKcz5HsMhE/SLP//vuXqOxilUtJ86ilbHUhRt+HVhvS96E2XLziybvafv4xSGXhr9QYi3/ci3aLXBkLJZOlf0rSkwQozzSuVBNsaeK2a665xjKdxvFqlZjIoTIAAAAAkA6YEwQZTeNKpXPnzpbpNB+IJomiLAAAAACkK3qCIGNo6VL1ctAkqZpFXDNHazb7Tp06JTRBanmmidgU8DjttNPcknKafFMTeGoyynnz5rnl+gAAAAAg3dATBBnjnHPOsXfffdc6duzoVpbQEpkXX3xxaHWVTKJZ2rWGuVYp0YzaZ5xxhltpQ8uHEgABAAAAkK7oCQIAAAAAADICPUEAAAAAAEBGIAgCAAAAAAAyQsVUZ6A05OXl2R9//GHbbbedZWVlpTo7AAAgQZ7nuUmcmzRpYtnZJb+WQxsBAIDMaiNkRBBEAZDmzZunOhsAACAgixYtsmbNmpU4HdoIAABkVhshpUGQQw891DZs2FDg8e7du9vgwYND96dOnWpjxoyxpUuXWuvWre2mm25yq3vESz1A/MKoVatWQLn/9+rR8uXLrUGDBoFcjQLlXVawb1PW6Yj9Oj3KWitb6cKGX7eXVLLaCMI+V3ooa8o6HbFfU9bpKK8MtBFSGgR54IEHbNu2baH733zzjfXu3dtuuOGG0GOTJ0+2Y4891m688Ubr16+fjRo1yg4++GCbN29e3I0VfwiMtg86CLJp0yaXJkGQ5KO8Sw9lTVmnI/br9CrroIa3JquNIOxzpYeypqzTEfs1ZZ2O8spAGyGlQZB27drluz9u3Dhr1KiRnXjiiaHHhgwZYqeffroNHTo01Htk++23t0cffdSuueaaUs8zAAAAAAAon8rMGI7Nmzfbc889Z+eff75VqlTJPbZ+/XqbMWOGnXDCCaHtqlWrZkceeaTrIQIAAAAAABCvMjMx6uuvv265ubnWp0+f0GOLFy92M7xqdtdwul9YEEQBFd3Cxwb5XW90C4rSUv6CTBOUd1nAvk1ZpyP26/Qo65KmWVptBD9N2gmlg7IuPZQ1ZZ2O2K8zq41QZoIg//3vf+2www6zli1bhh7bunWr+79KlSr5tlVvEP+5aEaMGGG33nprgcc1AYvGHwVZyGvWrHFfInOCJB/lXXooa8o6HbFfp0dZa+m7kiitNoKwz5UeypqyTkfs15R1OsorA22EMhEE+f33313PjmeffTbf4/Xq1XP/r1y5Mt/jK1asCD0XjVaWGThwYIFZYjUDbdATo2rSFVaHKR2Ud+mhrCnrdMR+nR5lXbVq1RK9vrTaCMI+V3ooa8o6HbFfU9bpKK8MtBHKRBDkySeftDp16tipp56a73FNgKrb7Nmz802WOnPmTOvcuXPM9NRzJLL3iKiQgy5ofYHJSBeUd6qxb1PW6Yj9uvyXdUnTK802grDPlR7KmrJOR+zXlHU6ykpxGyG7LESCFAQ577zzojZKLrzwQhs7dqwtWrTI3R8/frzNnz/fPQ4AAAAAABCvlPcEmTRpki1cuDDfhKjhtETuggULbNddd3UToi5btsweeeQRa9++fannFQAAAAAAlF8pD4Lsvffe9uWXX1qrVq2iPl+5cmV7/vnnbenSpS4Asssuu1j16tVLPZ8AAAAAAKB8S3kQRL07IpfAjaZRo0buBgAAAAAAkIiUzwkCAAAAAABQGgiCAAAAAACAEC8vz8pj2uViOAwAAAAAACg7srKz7cd777cNixYHmm615s2s9tlnWSoRBAEAAAAAAPkoALL+l18tSF6WWW1LLYbDAAAAAACAjEAQBAAAAAAAZASCIAAAAAAAICMQBAEAAAAAABmBIAgAAAAAAMgIBEEAAAAAAEBGIAgCAAAAAAAyAkEQAAAAAACQEQiCAAAAAACAjEAQBAAAAAAAZASCIAAAAAAAICMQBAEAAAAAABmBIAgAAAAAAMgIBEEAAAAAAEBGIAgCAAAAAAAyAkEQAAAAAACQEQiCAAAAAACAjEAQBAAAAAAAZASCIAAAAAAAICMQBAEAAAAAABmBIAgAAAAAAMgIBEEAAAAAAEBGIAgCAAAAAAAyAkEQAAAAAACQEVIeBFm5cqVde+211qFDBzv00EPt2WefLbDNG2+8YUceeaTtvffe1qNHD/v5559TklcAAAAAAFB+Zac6ANKxY0ebO3eu3Xfffe42efJkmz59emibiRMn2mmnnWYnnnii/fe//zXP8+yQQw6x3NzcVGYdAAAAAACUMxVT+eZDhgyxbdu22ZtvvmlVq1Z1jz355JPuMd/QoUPtnHPOsQEDBrj7zzzzjG2//fb28MMP24033piyvAMAAAAAgPIlZT1B1KNj/PjxLsDhB0B8FSpUcP+vW7fOvvjiCzvmmGNCz1WuXNmOOuoomzZtWqnnGQAAAAAAlF8p6wmyYsUKN6SlefPmdv7559vnn39uTZo0sV69etnZZ5/ttlm8eLELljRu3Djfa3V/3rx5MdPevHmzu/nWrl3r/s/Ly3O3oCgt5S/INEF5lwXs25R1OmK/To+yLmmapdVG8NOknVA6KOvSQ1lT1umI/To6L0u3LAuS938dIlLZRqiYaACjfv36xX4u3JYtW9z/11xzjY0YMcIGDhxoM2fOtAsuuMDWrFlj/fv3D32ISpUq5XuteoOED5mJpPRuvfXWAo8vX77cNm3aZEFR/pRXfYnZ2SmfYzbtUd6UdTpiv6as01Ey92v1Ei2J0mojCL/v0kNZU9bpiP2ask61jTk5tmXL1kDTzKqXY6tXr05pGyGhIEiDBg1cpov7XLh69eq5D92tWze75JJL3GNt2rRxPUIef/xxFwTxgymaQLU4gZbBgwe7oEr4VR71OFHeatWqZUEemLKysly6BEGSj/IuPZQ1ZZ2O2K/To6wjh9AWV2m1EYR9rvRQ1pR1OmK/pqxT7c/cXMtbvCTQNKtVrmR16tRJaRsh0OEwGzdujPuNtZ2CHiqAcLq/fv1693ejRo1cw+Szzz6zk046KbTNJ598Yscee2zMtKtUqeJukVTIQRe0GnnJSBeUd6qxb1PW6Yj9uvyXdUnTK802grDPlR7KmrJOR+zXlHVK9z9PNy/YNMtAG6FYQZBhw4ZF/duPVM6ZM8cFNuJ12WWXuRVe9H/Lli3t119/tWeffdbOPPPM0DYXX3yxWzpXc4Xsscce9thjj9kvv/xiffv2LU7WAQAAAABAhitWEGTixIlR//bn7dhxxx3dWNt4XXjhhbZw4ULbd999rWbNmrZq1So799xzbfjw4aFtrrvuOjdBatu2ba1GjRpu5RgFSlq3bl2crAMAAAAAgAxXrCDIjBkz3P9du3YtEARJlCYnu+GGG9yEZFr1pWLF/FlS0OOhhx6yu+66y60ms/322xfYBgAAAAAAoCgJDcJ56623XA8On/6+44477KWXXkokOTc2t1mzZoUGN9QLRPODEAABAAAAAACJSKhLxcMPP2zz58+30aNHu6VuDzvsMDcJiXpzaOjKVVddlVBmAAAAAAAAylRPkFGjRtmVV17p/p46darryfHDDz/Y22+/7QIkAAAAAAAAaREE+f33361p06ahIIiWr9XcHR06dHA9QQAAAAAAANIiCLLzzjvba6+9ZuvWrbPx48dbly5d3OMLFixwzwEAAAAAAKRFEOTmm2+2Xr16WZ06ddyEpocffrh7fOzYsdanT5+g8wgAAAAAAJCaiVHPPPNM69Spky1ZssTatWvnhsLI0UcfbUceeWTJcwUAAAAAAFAWgiCiOUH8eUF8xx13XBB5AgAAAAAAKBvDYeSDDz6wHj16WMeOHfOtGrN69eqg8gYAAAAAAJDaIIgmQ+3evbs1aNDAZs2aFXp8y5YtNnLkyOByBwAAAAAAkMogyPDhw23ChAmu50e4bt262bhx44LKGwAAAAAAQGqDID/99JN17tzZ/Z2VlRV6vGHDhrZs2bLgcgcAAAAAAJDKIIiGwfz8888FgiBTpkyxFi1aBJU3AAAAAACA1AZBevfubf369bO5c+e6IMjSpUvt6aeftr59+1qfPn2Cyx0AAAAAAEAql8gdMmSIrVixwjp06GDbtm2zxo0bW3Z2tvXv398GDRoUVN4AAAAAAABSGwTRMrgPPvigDR061PUGycvLs7Zt27pgiIIj9evXDy6HAAAAAAAAqQqCaE4Qz/Pc/126dIn6HAAAAAAAQLmfEySWjRs3WtWqVYNMEgAAAAAAoPR7ggwbNizq36IhMXPmzLE2bdoEkzMAAAAAAIBUBUEmTpwY9W+pVKmS7bjjjjZixIjgcgcAAAAAAJCKIMiMGTPc/127di0QBAEAAAAAAEi7OUEIgAAAAAAAgIyeGBUAAAAAAKCsIggCAAAAAAAyAkEQAAAAAACQEQiCAAAAAACAjFCs1WF8119/faHP33HHHYnmBwAAAAAAoOwEQebMmZPvfl5eni1YsMAWLlxohxxySFB5AwAAAAAASG0QZNKkSQUeUyDkmmuuscqVKweRLwAAAAAAgLI5J0h2drbdcMMN9uKLL8b9mkGDBln9+vXz3aL1JHnmmWesffv21qxZMzvuuONs3rx5QWUbAAAAAABkiEAnRl23bp3l5ubGvf3ff/9tBx10kH3//feh21tvvZVvmwkTJlifPn3s8ssvt8mTJ7tAyOGHH25Lly4NMusAAAAAACDNJTQc5qmnnirw2KpVq+yJJ56wo446qlhpafiMeoDEMnz4cOvdu7edf/757v4jjzxib775pj300EN26623JpB7AAAAAACQiRIKgtx0000FHqtbt64bynLbbbcVK62pU6faDjvsYLVr13avV2CjQYMG7rk1a9a4oS/h71ehQgU74ogj7OOPP04k6wAAAAAAIEMlFARZvHhxIG++/fbb2913322dO3e2JUuW2LXXXmsHH3ywzZ0716pXr25//PGH265Ro0b5Xqf72iaWzZs3u5tv7dq1oclbdQuK0vI8L9A0QXmXBezblHU6Yr9Oj7IuaZql1Ubw06SdUDoo69JDWVPW6Yj9OjovS7csC5KnW4rbCAkFQYJyyy23hP7eeeed7Y033rDmzZu7yVUvuOACVzh+749wFStWLPQDjhgxIupQmeXLl9umTZsCy7/yoN4qyqcmhkVyUd6lh7KmrNMR+3W0MlH9lZWUsl69enVS6kfNP1YSpdVGEPa50kNZU9bpiP2ask61jTk5tmXL1kDTzKqXk/I2QtxBkOuvvz7uN7/jjjssEQ0bNnRDYzRBqvjDYtQwCaf7/nPRDB482AYOHJjvKo+CK3pNrVq1LMgDU1ZWlkuXIEjyUd6lh7KmrNMR+3V0977whS1ZWrLAQqSmjWpazyOaJaV+rFq1aoleX1ptBGGfKz2UNWWdjtivKetU+zM31/IWLwk0zWqVK1mdOnVS2kaIOwgSPvxE3UinTZvm5vHYc8893WPfffeda0gcdthhlqgNGza4ITB+gEP/77TTTjZ9+nQ75ZRTQtt99NFHduqpp8ZMp0qVKu4WSYUcdEErCJKMdEF5pxr7NmWdjtivC1q89G9bsGRtuSnrkqZXmm0EYZ8rPZQ1ZZ2O2K8p65Tuf55uXrBploE2Qtzv+t5774Vubdu2tV69erl5PD777DN3U/BCj+2zzz5xpadASt++fe2XX34J9e7QCjAa6tKjR4/QdldccYWNHTvWZs6caf/884+NHDnSvddFF10Ub9YBAAAAAAASmxPklVdesS+++MJq1KgRekx/K0DRoUMHu++++4pMQ1dhOnXqZF27drXff//dPab7WvWlWbNmoe2uvPJKW7ZsmVt6V4GTpk2b2quvvmq77bYbXx8AAAAAAEhuECQ3N9dWrFhRYF4OPbZy5cq401HPEd00EVms8TvqKnP77bfbsGHDbP369bbddtslkmUAAAAAAJDhEhqEc+KJJ9pZZ51lU6ZMcfOA6Ka/NYzl5JNPTsoEJhrfQwAEAAAAAACUahDk0UcftdatW1uXLl3c5Ki66e82bdrYI488knBmAAAAAAAAytRwGAU9nn32Wbv77rvthx9+cI/tscce1qhRo6DzBwAAAAAAkLogiK9x48buBgAAAAAAUNYFuzAvAAAAAABAGUUQBAAAAAAAZASCIAAAAAAAICMkFATxPM8WLlwYuq+/77jjDnvppZeCzBsAAAAAAEBqJ0Z9+OGHbf78+TZ69GjbsmWLHXbYYZadnW3Lly+3xYsX21VXXRVcDgEAAAAAAFLVE2TUqFF25ZVXur+nTp1qVapUcUvlvv322y5AAgAAAAAAkBZBkN9//92aNm0aCoKcdNJJVqFCBevQoYPrCQIAAAAAAJAWQZCdd97ZXnvtNVu3bp2NHz/eunTp4h5fsGCBew4AAAAAACAtgiA333yz9erVy+rUqWPNmjWzww8/3D0+duxY69OnT9B5BAAAAAAASM3EqEceeaT99ttvtmTJEmvXrp0bCiNHH320tW3btuS5AgAAAAAAKAtBkAYNGrhlcv15QXzHHXecZWVluecAAAAAAADK/XCYWDZu3GhVq1YNMkkAAAAAAIDS7wkybNiwqH9LXl6ezZkzx9q0aRNMzgAAAAAAAFIVBJk4cWLUv6VSpUq244472ogRI4LLHQAAAAAAQCqCIDNmzHD/d+3atUAQBAAAAPl5eXlJSzcrO9BRzQAAZISEJkYlAAIAAFA0BSp+un+UbVy0OLDiqt68me02cADFDwBAaQVB5I033rBPPvnEcnNzCzw3duzYRJMFAABIKxsWL7YNv/ya6mwAAIBEgyCDBw+2++67zzp37mx169alIAEAAAAAQHoGQZ544gl7//33XRAEAAAAAACgPEhoRq1t27ZZhw4dgs8NAAAAAABAWQqCqAeIeoIAAAAAAACk9XCYHXbYwXr27GnnnXeetWzZ0rKysvI9P2jQoKDyBwAAAAAAkLogyNSpU2333Xe3mTNnulskgiAAAAAAACAtgiBz584NPicAAAAAAABlbU4QAAAAAACAjAmCfPDBB9ajRw/r2LFj6LFRo0bZ6tWrE0rvhhtusIoVK9rVV19d4LnRo0fbLrvsYjVr1rQDDzzQPvvss0SzDQAAAAAAMlRCQZDx48db9+7drUGDBjZr1qzQ41u2bLGRI0cWO71JkybZq6++ajvvvLNbfjfck08+adddd53dc889tmDBAjvooIPs6KOPtkWLFiWSdQAAAAAAkKESCoIMHz7cJkyY4Hp+hOvWrZuNGzeuWGktW7bMLrjgAve66tWrF3j+rrvucs+fcsop1qhRI7v77rutVq1a9vDDDyeSdQAAAAAAkKESCoL89NNP1rlzZ/d3+PK4DRs2dEGNeHme55bZveiii2y//fYr8PyqVats/vz5dvjhh4ce0/vp/qeffppI1gEAAAAAQIZKaHUYDYP5+eefrXXr1vmCIFOmTLEWLVrEnY56eaxfv96uv/76qM//+eefoeBK5PvPmTMnZrqbN292N9/atWvd/3l5ee4WFKWlQE6QaYLyLgvYtynrdMR+HV2Wefb/a/Lg0kxW/VjSNEurjeCnqXLwdOEnrL1UUl5Wycsh3fD7pqzTEfs1ZZ1qXlaw9ZdL8/86Q6SyjZBQEKR3797Wr18/NyRFQZClS5fae++9Z9dcc40NGjQorjQ+//xzFwSZPXu2VahQoVjvn52d7QoulhEjRtitt95a4PHly5fbpk2bLMhCXrNmjcuL8oTkorxLD2VNWacj9uvocqr/Y1tygk9TE6Uno35ct25diV5fWm2E8H1uY70c27Jla2DpZufkFKvnbSbg901ZpyP2a8o61TbmBFt/SVa9nJS3ERIKggwZMsRWrFhhHTp0cBOZNm7c2H2A/v37xx0E0QovK1eutJYtW4YeU1rz5s2zMWPGuKs0StdvmIRTxa/5QWIZPHiwDRw4MN9VnubNm7seJJpPJMgDk4JASpcgSPJR3qWHsqas0xH7dXS5Gyraotxgy7pKtYpWp06dpNSPVatWLdHrS6uNEL7PbVyZa97iJYGlW61ypQK9ZDMdv2/KOh2xX1PWqfZnbq7lBVh/+XVYqtsICQVBtJTtgw8+aEOHDrW5c+e6H2jbtm1DQYt4XHrppXbxxRfne0xBFc01opVg1DskJyfHdtttN/vwww/t1FNPddsoYjRt2jTr2bNnzLSrVKnibpFUyEEXtBo3yUgXlHeqsW9T1umI/bogDYaJ3bcy8TSTVdYlTa802wiiclBH4qxCerAWO02v5OWQjvh9U9bpiP2ask7p/ucFW3+5NJO4X8ebXkJBEJ+iN126dEnotfrgCqYU9fjVV1/trtgcf/zxdsABB7gleHNzcwsEUAAAAAAAAAIJgqjXh/+//3dR2wZBc49ozJDmIdEwmL333tveeecd23HHHQN7DwAAAAAAkP7iDoJMmjQpFODw/w46CKLJUsNXm/Fde+217gYAAAAAAJD0IMj06dNDf7/++utWv379qNtpwtREFXeVGAAAAAAAgHhlJzoXSCLPAQAAAAAApEqg07Fu3LixxEvXAQAAAAAAJEOxVocZNmxY1L9Fy+TOmTPH2rRpE1zuAAAAAAAAUhEEmThxYtS/pVKlSm7FlhEjRgSVNwAAAAAAgNQEQWbMmOH+79q1a4EgCAAAAAAAQNrNCUIABAAAAAAApHVPkEh//PGHLVy40P755598j3fq1Kmk+QIAAAAAAEh9EGTRokV21lln2aeffhr1ec/zSpovAAAAAACA1A+HGTBggJsE9c8//3T3V61aZe+//77tuuuu9tBDDwWbQwAAAAAAgFQFQT766CO76667rHHjxu5+zZo17eijj7Znn33W7r///iDyBQAAAAAAkPogyIoVK6xJkybu75ycHFu2bJn7u1WrVvbbb78Fm0MAAAAAAIBUBUHCtWvXzh588EFbvXq1Pfzww9aiRYsg8gUAAAAAAJD6iVG7d+8e+nv48OF2/PHH2+23327VqlWz5557Lsj8AQAAAAAApC4I8vLLL4f+7tixo1st5scff3S9QOrWrRtMzgAAAAAAAFIdBIlcDrdq1aq2zz77BJMjAAAAAACAsjQnyFNPPWVt27Z1Q2CqV6/ugiDPPPNMsLkDAAAAAABIZU+Q//znP3b33XfbJZdcYjfffLN7bPbs2XbZZZe5oTE33nhjUPkDAAAAAABIXRBk9OjR9uKLL7oJUcMnSz300EOtd+/eGRUEycvzkpp2dnZW0tIHAAAAACCTJBQE2bZtm3Xq1KnA43rsn3/+sUyiIMW9L3xhi5f+HWi6zRptZ4N6tg80TQAAAAAAMllCQZCDDz7YXnjhBbvooovyPa7H9FymWbJ0nS1YsjbV2QAAAAAAAEEHQXbeeWfr37+/vfHGG7bffvu5FWLmzJlj7733nl1xxRVuvhDfoEGDEnkLAAAAAACA1AdBPvzwQ2vTpo398ccfLhDi02PTpk3Lty1BEAAAAAAAUG6DIHPnzg0+JwAAAAAAAEmUnczEAQAAAAAAygqCIAAAAAAAICMQBAEAAAAAABmBIAgAAAAAAMgIZSIIoiV28/Lyitxu69atpZIfAAAAAACQfhIOgnzwwQfWo0cP69ixY+ixUaNG2erVq+NO49tvv7UzzjjD6tWrZ9WqVXNL7L788ssFtrvtttvcNlWrVrU999zTJk2alGi2AQAAAABAhkooCDJ+/Hjr3r27NWjQwGbNmhV6fMuWLTZy5Mi403n66aftvPPOs4ULF9ratWvtggsusDPPPNM+//zz0DYPPvig3XXXXfbKK6/Y33//bWeffbadeOKJtmDBgkSyDgAAAAAAMlRCQZDhw4fbhAkTXM+PcN26dbNx48bFnY4CJl27drWaNWtalSpV7IorrrDs7GybO3duaJv777/fLrzwQjvssMNcb5EhQ4ZYw4YN7ZFHHkkk6wAAAAAAIENVTORFP/30k3Xu3Nn9nZWVFXpcwYlly5YVK61t27bZxo0bXU+Qxx57zHJycuzYY491z61cudJ+/vlnO/TQQ/O9Ru89Y8aMRLIOAAAAAAAyVEJBEA2DUXCidevW+YIgU6ZMsRYtWhQrralTp9opp5xiGzZssNq1a9vzzz9vTZs2dc8tXbo09H6R7z9z5syYaW7evNndfAqwiCZfjWcC1ngpLU3qmmW6BUtpBpnXdOCXN+VCWacT9mvKOtWSVYcl63hd0jRLq43gp6ly8DQJfFh7qaS8rJKXQ7rhWEpZpyP2a8o61bysYOsvl2YxFkYprnjTTCgI0rt3b+vXr589/PDDLgiiYMV7771n11xzjQ0aNKhYaR111FFurg/1BlFPkJNPPtkmT55shxxySMwPo/vhwZdII0aMsFtvvbXA48uXL7dNmzZZUJSPNWvWWE71f6x5jgVKaRa3V02688tbPxoNmwJlnQ7YrynrVFN9syUJdZgmSk/G8XrdunUlen1ptRHCf98b6+XYli3BrXCXnZNDGyFGWdNGSD7KuvRQ1pR1qm3MCbb+kqx6OSlvIyQUBNG8HCtWrLAOHTq44SyNGzd2H6B///7FDoL4NN/HlVde6XqCaMJUBUGaNGninosMBuj+9ttvHzOtwYMH28CBA/Nd5WnevLnrQVKrVi0Lih+Myd3wpy3KtUBVrlbRDS9CwfLW90gQJLko69JDWVPWqZa7oWLgdViVahWtTp06STlea6W4kiitNkL473vjylzzFi8JLN1qlSvRRohR1rQRko+yLj2UNWWdan/m5lpegPWXX4eluo2QUBCkYsWKbtWWoUOHuklM9QNt27atC4aU1Pr1661y5crubxVOq1atXM+Q0047zT2m99Kwmz59+sRMQ5Os6hZJhRx0QavC/XdATLCUJif60cs7Gd8jKOtUYr+mrFMpWXVYsvbrkqZXmm0EUTmo72qWF1wpZ3klL4d0xLGUsk5H7NeUdUr3Py/Y+sulmcT9Ot70EgqC+BS96dKlS8LBDgU2rrvuOttrr71cl5gxY8bYjz/+aE888URou+uvv94FPLQ6zIEHHuhWlNHQGfU6AQAAAAAAiFfcQRAFI+J1xx13FLlNjRo1XJp33nmnffnll+5+u3bt7NNPP3XDbHznnHOOmzRV43c194gmY500aVJoqAwAAAAAAECgQRANe/FpVvVp06a51Vz23HNP99h3333nxtWqx0a8tNStv9RuYTQJq24AAAAAAABJD4Jo9RffgAED3FK4mhdEPTj84S2XXnqp1a1bN+HMAAAAAAAAJEtCM5G88sordtddd4UCIKK/NV+HngMAAAAAAEiLIEhubq5bIjeSHlu5cmUQ+QIAAAAAAEh9EOTEE0+0s846yy1Vq3lAdNPfPXr0sJNPPjnYHAIAAAAAAKQqCPLoo4+6VVq0PK4mR9VNf7dp08YeeeSRIPIFAAAAAACQmolRwyno8eyzz9rdd99tP/zwg3tsjz32sEaNGgWbOwAAAAAAgFQGQXyNGzd2NwAAAAAAgLQcDgMAAAAAAFDeEAQBAAAAAAAZgSAIAAAAAADICARBAAAAAABARkg4CPLBBx9Yjx49rGPHjqHHRo0aZatXrw4qbwAAAAAAAKkNgowfP966d+9uDRo0sFmzZoUe37Jli40cOTK43AEAAAAAAKQyCDJ8+HCbMGGC6/kRrlu3bjZu3Lig8gYAAAAAAJDaIMhPP/1knTt3dn9nZWWFHm/YsKEtW7YsuNwBAAAAAACkMgiiYTA///xzgSDIlClTrEWLFkHlDQAAAAAAILVBkN69e1u/fv1s7ty5LgiydOlSe/rpp61v377Wp0+f4HIHAAAAAAAQkIqJvGjIkCG2YsUK69Chg23bts0aN25s2dnZ1r9/fxs0aFBQeQMAAAAAAEhtEKRixYr24IMP2tChQ11vkLy8PGvbtq0LhgAAAAAAAKRNEKRy5cpuOVzNDdKlS5fgcwUAAAAAAFAW5gSpW7euLV++POi8AAAAAAAAlK0gyIUXXmi33HKL6w0CAAAAAACQtsNhJk+ebLNmzbIXX3zRWrZs6YbHhJs+fXpQ+QMAAAAAAEhdEOS4445zNwAAAAAAgLQOgmhVGAAAAAAAgLQPgvh++eUX+/77793fe+65p+20005B5QsAAAAAACD1QZCVK1e6yVHfeOMNy87+d27VvLw869atm40dO9ZycnKCzSUAAAAAAEAqVofp27evLV682D777DPbtGmTu+nvhQsXWr9+/UqaJwAAAAAAgLLRE+S9996zr776ynbdddfQYwcccIC98MIL1rZt22Knt379eqtYsaJVqVIl5jZajnft2rVWr149y8rKSiTbAAAAAAAggyXUE6RBgwZWq1atAo/rsYYNG8adznPPPWft2rWz7bff3urUqWMdO3a02bNn59tGw2yuvvpq9/yOO+5ozZo1s9deey2RbAMAAAAAgAyWUBDkrLPOsgEDBtiaNWtCj61evdquvPJK91w8tm3bZu+++6499dRTLh29Xr1ItPRubm5uaLt77rnHnnzySfv0009dT5DrrrvOzjzzTJs/f34iWQcAAAAAABkq7iBIp06dQrdp06bZiy++6HpwKHDRpk0ba9KkiY0fP96mTp0aV3oVKlSwZ5991r1ew1s0FEZL72rS1fDeIA8++KD16dPH9tlnHzcJ6xVXXGE77LCDPfbYY4l9YgAAAAAAkJHinhPkqKOOyndfPTaC9vPPP7v/Gzdu7P5ftmyZ/f7773bwwQfn206BmFmzZgX+/gAAAAAAIH3FHQRRL41k2rBhg+vlcfjhh4cmV12+fLn7v379+vm21X0Nj4ll8+bN7ubTMBp/fhHdgqK0PM+zLNMtWEozyLymA7+8KRfKOp2wX1PWqZasOixZx+uSpllabQQ/TZWDZ2ZegJO6e1klL4d0w7GUsk5H7NeUdap5WcHWXy5N3VLcRkhodZigaeWX0047zQVCtPKMT8Nf5J9//sm3/datW91wmlhGjBhht956a4HHFVTRcr5BFrLmM8mp/o81z7FAKU31hEHB8taPxt83kByUdemhrCnrVFN9syUJdZjm+krG8XrdunUlen1ptRHCf98b6+XYli1bA0s3OyeHNkKMsqaNkHyUdemhrCnrVNuYE2z9JVn1clLeRkgoCKIgxDPPPGPTp0+3VatWFXj+9ddfL3YA5Mcff3RzjfhDYaRp06bu/7/++ivfa5YuXRp6LprBgwfbwIED813lad68ecxVbUpyYNJ8Jrkb/rRF/38u10BUrlaxWCvtZAK/vPU9EgShrNMF+zVlnWq5GyoGXodVqVbRreqWjON11apVS/T60mojhP++N67MNW/xksDSrVa5Em2EGGVNGyH5KOvSQ1lT1qn2Z26u5QVYf/l1WKrbCAkFQS677DJ7+eWX3bwgWrI2UQqmnH766fbdd9+5AEhkWmqMaELUDz74wK0I4/cKmTx5sl1++eUx09Ukq7pFUiEHXdCqcP8dEBMspcmJfvTyTsb3CMo6ldivKetUSlYdlqz9uqTplWYbQVQO6kic5QVXylleycshHXEspazTEfs1ZZ3S/c8Ltv5yaSZxv443vYSCIFoF5uOPP7bWrVtbSSKbWk53xowZ9sYbb7jHFi9e7P7Pycmx6tWru7+HDBniAiD77befHXjggXb33Xe7x/v375/wewMAAAAAgMyTUOilYsWKrutoSWjc5syZM61SpUpuOMwBBxwQuvlBETn11FPdUrpPP/20devWzXVb/fDDD133GQAAAAAAgHgl1BPk7LPPtnvuucf+85//uK4siahbt26o50dR1BPEHw4DAAAAAABQakEQTSrWqlUr10Nj5513LhAImTRpUkKZAQAAAAAAKFNBkH79+rmZV4855hg3sysAAAAAAEBaBkHU0+PLL7+0PfbYI/gcAQAAAAAAlJWJUTUpaaNGjYLPDQAAAAAAQFkKgpx88sk2fPhwt8wtAAAAAABA2g6H0dK2s2fPtueff9522mmnAhOjTp8+Paj8AQAAAAAApC4Icvzxx7sbAABIvrw8z7KzE1uSHgAAACUMggwdOjSRlwEAgAQoAHL3c5/b4qXrAiu/ffdoaOcdvxffBwAAyCgJBUEAAEDpUgBkwZI1gaXXrGHNwNICAABI64lR5aWXXrIOHTpYjRo13E1/6zEAAAAAAIC06Qny0EMP2dVXX20XXnihDRgwwE2M+tlnn9l5551ny5cvt0suuST4nAIAAAAAAJR2EOSee+6xcePG2WmnnRZ6rGfPnta5c2e7/vrrCYIAAAAAAID0GA6zaNEiO+aYYwo8rsf0HAAAAAAAQFoEQVq0aGHvvvtugcffeecd9xwAAAAAAEBaDIe59tprrVevXjZlyhTbf//93WMzZ860p59+2saMGRN0HgEAAAAAAFITBOnbt681atTIRo4caRMmTHCP7bXXXu7vk046qeS5AgAAAAAAKAtBEFGwg4AHAAAAAABIyyDIyy+/HNd24avGAAAAAAAAlLsgyOmnnx7Xdp7nJZofAAAAAACA1K8Oo+BGtNuqVavsuuuus6pVq1r79u2Tk1MAAAAAAIDSXiLXt3nzZrv33nttl112cUNlnnzySZs9e3ZJkgQAAAAAACg7E6Pm5eXZc889Z0OGDLGNGzfarbfeahdddJFVqlQp+BwCAAAAAACkIgjy/vvvu6EvCxYssIEDB9o111xjNWvWDCIvAAAAAAAAZSMIcuSRR9rHH39sffr0ccGQRo0aJS9nAAAAAAAAqZoTZMqUKW4ozDPPPOPmAVEPkGg3AAAAAACAct0T5PHHH09eTgAAAAAAAMpKEETDYAAAAAAAQOp5eXmWlV2iRV8zTkKrwwAAAAAAgNRSAOTHe++3DYsWB5Zm3fbtrMU5PS1dlYkgyJo1a2zRokW20047WY0aNaJus3r1aluxYoXtsMMOVrly5VLPIwAAAAAAZY0CIOt/+TWw9Ko1a2rpLKX9Zr777js3xEaTrLZu3dpmz55dYJt//vnHLrzwQrcSzaGHHmoNGzZ0E7MCAAAAAACUmyDIhx9+aB07drRPPvkk5ja33367TZw40QVM/vjjDxs1apT17t3b5s6dW6p5BQCUf3l5XrlMGwAAAGkwHKZ///7u/8WLY49feuyxx6xv376ut4icd955NmLECBs7dqyNGTOm1PIKACj/srOz7N4XvrDFS/8ONN1mjbazQT3bB5omAAAA0nROkFj++usvW7JkiestEu7AAw+0zz//PGX5AgCUX0uWrrMFS9amOhsAAABIgTIdBFm5cqX7v169evke131NkhrL5s2b3c23du2/jd28vDx3C4rS8jzPsky3YCnNIPOaDvzyplwo63TCfl36ZV1ej9nB5/vfPCerPJJ1vC5pmqXVRvDTVDlooJSXFVwpe1klL4d0w7GUsk5H7NeUdXHqhUDrGfu//S/gdP20U91GKNNBkIoV/83eli1b8j2uxkulSpVivk7DZW699dYCjy9fvtw2bdoUaCFrZZuc6v9Y8xwLlNJctmxZsImWc35560eTzVrYlHWaYL8u/bIur8dsvceWAPNdo8Iml+eg0xWlqVXdknG8XrduXYleX1pthPB9bmO9HNuyZWtg6Wbn5NBGiFHWtBGSj7IuPZQ1ZR2vjTnB1jN/V6/u6pmg05WsejkpbyOU6SBI06ZNLSsry/788898j+t+8+bNY75u8ODBNnDgwHxXebR9gwYNrFatWoHlz11By8qy3A1/2qJcC1TlahXdSjgoWN76HgmCJBdlXXoo69Iv6/J6zM7dUDHQfO/UoqrLc9DpSpVqFa1OnTpJOV5XrVq1RK8vrTZC+D63cWWueYuXBJZutcqVaCPEKGvaCMlHWZceypqyjtefubmWF2A9U3OnHV09E3S6fh2W6jZCmQ6C1KxZ0/bbbz975513rEePHqFeIJMmTbLrrrsu5uuqVKnibpFUyEEXtCrcfztXB0tpcqIfvbyT8T2Csk4l9uvSLevyeswOPt//5jlZ5ZGs/bqk6ZVmG0FUDupInOUFV8pZXsnLIR1xLKWs0xH7NWUd137iBVzP2L/1TNDp+mmnuo2Q0iCIusFoZZilS5e6+7/++qvVr1/fRZ38K2rqstq1a1fbe++93YSo9913n9WoUcMuvvjiVGYdAAAAAACUMym9jPDhhx/aWWedZVdeeaW1atXK7rnnHnf/5ZdfDm1z7LHH2sSJE922V111ldWuXdumT5/uutAAAAAAAADEK6U9QU4++WR3K4oCIboBAAAAAAAkigGlAAAAAAAgIxAEAQAAAAAAGYEgCAAAJVRnuyqWlxf0GitAdJXq1DEvLy9pxZPMtAEASLUyvUQuAADlQc1qlSw7O8vufu5zW7x0XaBp77tHQzvv+L0CTRPlW8WaNSwrO9t+vPd+27BocaBpV2/ezHYbOCDQNAEAKEsIggAAEBAFQBYsWRNoeTZrWDPQ9JA+FABZ/8uvqc4GAADlCsNhAAAAAABARiAIAgAAAAAAMgJBEAAAAAAAkBEIggAAAAAAgIxAEAQAAAAAAGQEgiBlVJ3tqlhenpe09JOZNpCqfY/9uvTwPQIAAKA8YoncMqpmtUqWnZ1ldz/3uVtyMUjNGm1ng3q2DzRNIF7s1+mB7xEAAADlEUGQMk4BkAVL1qQ6G0Cg2K/TA98jAAAAyhuGwwAAAAAAgIxAEARgfgMgY+ZDAgAAQGZjOAzA/AZARsyHtO/uDezo9vUCTRMAAADlC0EQ4P8wvwGQ3r/HZg1rmBlBEAAAgEzGcBgAAAAAAJARCIKgXClvcwUke36D8lYeiI59BAAAlDYvL6/cpV0e85zstFF8DIdBuaK5Au594QtbvPTvwNLcd4+Gdt7xe1l5m9+gWaPtbFDP9oGmifTZr4V9BAAAxJKVnW0/3nu/bVi0ONBCqtu+nbU4p2fgaVdv3sx2GzjAklkeP90/yjaWk/IITxvFQxAE5c4SN1fA2sDSa9awpiUb842gtPdrAACAouikfP0vvwZaUNWaNU1a2sm2YfFi21COysNPG8XDcBgAAAAAAJARCIIAQByYfwUAMhPzBIB9pGyoVKcOc2sgEAyHAYA4JGtul313b2BHt2fZVgDItHkTkj2/Acr/PlKteTOrffZZgaZZnlWsWSNpZV2nfTuretSRgaaJsosgCACkcG6XZg1rmBlBEAAoy8rj3AYo//uIl2VWO9AU00Myyrpqs6ZWNdAUUZYxHAYAAAAAAGQEgiAZqM52VZI6v8G2JKaN0sMcGOVfsn/rAFBczK9RevMbkHbplUeyVKrNHBhAMjAcJgPVrFYpefMb7NHQzjt+L+ZOSAPaR+594QtbvPTvwPcPlO/fOt8jgEQxd0LpzG+Q7PlGlO+f7h9lGwPOd9327azFOT0DL5PyOv+Kv48ks6yBTFRugiCLFi2ypUuX2m677Wa1atVKdXbSQnLmN6iZxLSZO6G0LXHf49rA9w+UrqB/j3yPAEqCuROSXx6lYcPixbYh4HxXa9a0XJdJeSxrIBOV+eEwmzZtsu7du9vuu+9u5557rjVu3NhGjx6d6mwBAAAAAIBypswHQW699VabNWuWLViwwObPn2/PP/+8XXHFFTZz5sxUZw0AACCtJHueimRh7oT0+B6ThfIAUK6Gwzz55JPWv39/23777d39U045xfbee2/3eMeOHVOdPQAAgLSRzHkqkjkHQbLmTiiv8yYk83us076dVT3qSCtPyut+DSADgyB//PGHmwekffv2+R7ff//97csvv4z5us2bN7ubb82af8fCr1692vICjIorrbVr11q97cw216tgQdquyjaX3/rbmW0h7X/LpPK2pJR3eS1rpam0kyFZ+3Z5LY/w9ygv+3Uyy7u8/mbKY1knM+1k5lllrLKuXLmyZWcH2+lU6YrnJbbyUWm1EcKPpdvq17e8sPcsqS21arr8bmtQ3/K2BJdueNrrNm2yDQGnXWHjhqTmW2WtfG8MMO1k57k8fo/ZGzfYliTs18ksk/K+X5ensk5m2snOM2VdOmWt/TnlbQSvDPv666+Ve+/TTz/N9/g111zjtWzZMubrbrnlFvc6bpQB+wD7APsA+wD7QHruA4sWLUqobUEbIfXfHTfKgH2AfYB9gH3AUthGyNI/Vkb98MMPtscee9iUKVPs8MMPDz1++eWXu8e+/fbbuK7y6EpMbm6u1atXz7KysgKNNDVv3tytXMOKNclHeZceypqyTkfs1+lR1mq2rFu3zpo0aZLQFaTSaiMI+1zpoawp63TEfk1Zp6O1ZaCNUKaHw6hwlPklS5bke1z3d9hhh5ivq1KliruFq1OnTtLyqS+PIEjpobwp63TEfk1Zp6Nk7de1a9dO+LWl3UYQft+lh7KmrNMR+zVlnY5qpbCNUKZXh6levboddNBB9uabb4YeW79+vU2aNMm6dOmS0rwBAAAAAIDypUz3BJFhw4a5gMfgwYPtwAMPtNGjR1vDhg2tX79+qc4aAAAAAAAoR8p0TxDp3LmzTZ061X7//Xd74IEHrFWrVjZ9+nSrWbNmqrPmutPecsstBbrVgvIu79i3Ket0xH5NWbPPpS9+35R1OmK/pqzTUZUycA5dpidGBQAAAAAAyJieIAAAAAAAAEEgCAIAAAAAADICQRAAAAAAAJARCIIUYcuWLfbFF1/YDz/8kNTXwGzbtm02b948+/rrry0vLy+uIlm3bp19+eWX9tdff1GExfT999+7stP+WhyLFy92kxOvWLGCMo/Tr7/+ap9//rlb4jteW7dudb+HhQsXUs7F8Mcff9js2bNt1apVcb/mt99+szlz5nAcKSYdfz/55BNbsmRJ3K9ZuXKl+37S5Ziteuurr76yb775Ju56K5HX4F/z58939ZaOj/HYuHGjK+tFixZRhMX0yy+/FLvekuXLl7s2gtoKiI+OoaqDilNv6djx3Xff2c8//0wxF4ParqqDli5dWqzvR78FjiPFs3nzZvv000/dsSRea9eudb+FUmn7amJURPf+++979evX93baaScvJyfHa9eunbd48eLAXwPP++KLL7wWLVp4TZs29Ro3buztsssu3tdffx2zaH777TfvzDPP9OrUqePts88+Xq1atbwjjzzS+/PPPynOIixcuNBr27atV69ePbefNmjQwJs0aVJc5bZ69Wr33ejQ8cILL1DWRVizZo131FFHeTVr1vR222039/8zzzxTZLk9+eST7vih1+yxxx7eKaec4q1bt47yLsTWrVu9c88916tataq31157eVWqVPGGDx9eaJn9+OOP7regY3b79u3d93Pssce67w2FH0Muvvhid6yuVKmSd9ddd8VVXDfccIP7Xvzvp1+/ft62bdvKbVHPnj3b22GHHbxmzZp5jRo18lq2bOl9++23gb8G/9b5bdq0cb/VHXfc0ZXd1KlTYxbNypUr3f6lNkL4b3z+/PkUZxz1/OGHH+5tt912rg7S/88991xc5bZlyxavY8eOXnZ2tjdixAjKOo7yOvvss129teeee7r/77jjjiLL7e2333bHELWb9bs45JBDvD/++IPyLsJ1112Xrw665JJLvLy8vJjbL1++3OvcubM7x9Dxo27dut7+++/vLVq0iLIuhI6/11xzjdekSROvevXq3qWXXurF48EHH/SqVavm2r163cknn+xt2LDBSxaCIIV8gbVr1/Zuvvlmd3/Tpk3ewQcf7HXp0iXQ1+DfSmDnnXf2evXq5YpDB6TTTz/d/QhiNZDV+Bk/fnzo+VWrVrkD1IknnkiRFuGwww5zt82bN4cqBR3YVYZFOeOMM9z2BEHi06dPH2/33Xf3cnNz3f3HH3/cq1ixovfDDz/EfM1rr73mVahQwXv11VdDj7311lvuJACxqeGoE51ffvnF3Z88ebJriCswHcvxxx/vHXTQQe5YLX/99Zc7ubrxxhsp6kKobNVYWbt2rSuveIIgL7/8sle5cmXvs88+c/e/++47d3KldMojHT91AnLhhRe6+6qLunXr5rVq1SpmozqR1+BfnTp1chc61F6Qq6++2gXyYwUs582b5z366KOhem7jxo3eCSec4LVu3ZoiLcL555/vThIVDJGHH37YBTt//vnnIstOJz5qy+m4QBCkaMOGDfMaNmwYqt//97//eVlZWe4YW1ggVe2IBx54IPSYjquff/45+3YhXnzxRRf4mDVrlruvC601atRwx4lYFCTR+Yn/W/j777+9vffe2+vZsydlXQgdf9UmW7ZsmQuKxhME0X6tfd9v++qitgJ9OqYkC0GQGB577DEXkQ2/+vr666+7kz9dBQvqNfj3oK8yCq9g586d6x77+OOP4y6iu+++253MIzadIKpc33vvvdBjCn6ogaPeB4VRRXHAAQe4/ZsgSNF0Yq1I9pgxY0KP6URHkfHCTrLVSNeVIRSPrlgOGDCgwImTeozFst9++3mXXXZZvscUuNYVZMQn3iCIAk5du3YtcLKl4HV59M4777jj4K+//hp6bM6cOe4xP9ATxGvwb48tlVF4j8UVK1a4E8Fx48bFXUQKxCkdenrFpquuasc+8sgjoccUrNPv/JZbbim0fNWuUE9RPzhKEKRoOsEeNGhQvsfUzirsJFsX+xS8R/EcffTRrldtuHPOOcedpMeiC7KR9Za+G6WF+MQbBFHASQGmcEOHDnUXt5J1kYA5QWLQmNPdd9/datasGXps//33d//PnTs3sNfg33KrXbu27bLLLqHiaNu2rVWuXNk9Fy+N8WvZsiVFWgi/PNu3bx96rE6dOrbrrrsWWtYadzpkyBB79tlnrWLFipRxHDQn0IYNG/KVdVZWlnXo0CFmWWsstebEOfHEE93YYI1BXbZsGeVdBI1Z//HHH/OVtX/8LWy/vvnmm+3ll1+2Rx55xCZPnmxDhw6133//3a666irKPGD6HqJ9P5r3pjzOi6HPU69ePdtxxx1Dj+27775WoUKFmPtcIq9B9HpL5bjzzjsXu43QoEEDq1WrFsVayJwrmzZtylfW2dnZ7n5hZa35FS644AJ75plnbLvttqN845z7QHMlFKfe0sXrKVOmuDaC6j21EYozJ1Mmi1UH6fxM5RrNNddc4+anGDlypGsj3H///TZp0iS76aabSinXmePLGN+P5nBJ1vxCnM3EkJub6yrZcP59PRfUaxC93Pyyi7fcXnvtNZswYYK98cYbFGkh/PLMycmJu6w1sdyZZ55pd955pwtUqYGEovnlGe2YoIZmrEk95eOPP7YBAwZYkyZNXDDlmGOOsXHjxlmNGjUo+ij8yeSilXVhx5BOnTrZkUceaTfeeKO1aNHCNUivuOIKgqlJEKt+1ASXmmBVgfDy/nkU5NSxtThthKJeg3/LTYGiyH2kOG2EmTNnuhOYu+66iyJNsN7SBN/R6ATy3HPPtb59+9pBBx1E+QZQ1rH2awVOFPz46aefbLfddrNGjRq5emufffaxF1980Ro3bkz5F1Le0cpak3fqglW09lWbNm2sR48edvvtt7ugq34Dag8reI1gFXUO3bx584DfkdVhYqpUqVKBkz2dDIp6KAT1GkQvN7/s4im3qVOnWs+ePd1BStFxFF7WooN+vGV92223uQaoetloxnfN9Cw6Odes+yi8rKMdEwo7hojKWav3aJUp9XCYMWOG66WA4MpaunXr5q5g6iqDv6KXejtdf/31FHXA0q1+TKTeKmldl6lUblpRJ3JFmHjL7dtvv7WuXbva+eefb5dffnkSc5qZx9LHH3/c9RY97LDDXN2lm74r9apT8AnBlbX/mnfffddmzZrl6i2tbqYLAezbwddBF198sX3wwQcu+KGy1oolavf26tWL3ToN2ggMh4lBVwUju5j593fYYYfAXoN/y03dncKXalWke82aNUWW24cffugCHzfccAMnLnGWdfh+Gd4DIVZZV6tWzQ3x0omhbhoWIy+88IKNHj2aXbiYZa37scpaj+vK8FlnneWGKUnTpk3dPq7eIYhOXdyrV69erLLWMWbatGmuC7f2cdFVtdNPP93efPNNijpgserH+vXrh8q/vH0eDVULPzHXVdq///670DZCcV+D/38s9XvKxVNv+XRyfsQRR7iA58MPP0xxxrFfS3GOpaqzNMRLQwT8doJ6d+lEXRdREJ16bVSpUqVYZa16TvWd2gRqG4jaCmoz0EYoet+OVtb6HvzgUqSJEyfa2WefbXXr1nX3NdTrvPPOs7feeivmEBoE+/3o+JKMXiBCECSGLl26uCi2xiv7NNRCB5v99tvP3VdDRhFvncDH+xoUpO7oKsv33nsv9JhOQjQOVY0Xn3oghI8L0wH/hBNOsOuuu47xeXHq2LGjO4iHn+RpnLQak9p/w8fm+WvPK+jhX93RTeMiRT0Txo4dyy4dQ7NmzWyPPfbIV9Y6Afrss8/ylbWGxmgeEFGw6eCDDy5QEWi/V8MH0fnHivCyVlBVjfDwstYVM+3vfmNS3V8jx5ouWrSIsg7AX3/95Y4XfkNR38Pbb7/truiH14/h3095ctRRR7kedbpKGP55NGfS4YcfHnrsk08+Cf2e430N8jvwwAPdbzX8963jqI6n4fuPrtQuWLAg37FVx4WTTjrJHn30UdeYRuEUzFCvz/Cy/vPPP12vg/CyVnDpm2++cX9rGEx4G0E3DfHSVXSdRCI69bDV7z68rHV8UFs4vKzVC0HzUvg0PJY2QvH5dVD4HFQq+/Cy1r6u/dendle0NoKC9xxPSmb16tWurP3eHvoeNN+NLlCF148HHHBAvrk2A5WU6VbTxHHHHeeWaZ0wYYI3evRoN2P2qFGjQs9r+Z7IVTKKeg2i69+/v9e4cWPvmWeecauUaOm7gQMH5ttGS1v5s41rRv2aNWu6WbK1gkz4jaUGC3fPPfe4VUu0NKWWGd511129k046Kd82WrLRX8YxkpYaZHWY+PjL3d52223u7wMPPNBr27ZtaJlH0TroWofep31Y+7b2dS3vqiWJlca0adPifNfMpOUBdby94oorvDfffNPt01qJZ/ny5aFttKxm06ZNQ/dVtrVq1XJLDWqVqptuusktqxt+TEdB69evDx1vc3Jy3Mzv+vvbb78NbaNlNXWc0PFCFi9e7GZ51zLb+n60fLT28/DXlDd9+/Z1+5hWKHniiSdcWVx77bX5ttFvN3z1nHheg4LuvPNOt5yl9istdalVSLS8cDgtR37RRRe5v7XkqNoU+++/v/fRRx/layNoBRQUvoqOVt4ZPny4W65SZbjvvvt6W7duDW2j5Ya1ZHEsrA4THy3XqratVjbTcVHlqmVBV65cGdrmyiuvdEtrh6+WVKdOHVd/qY2gtoKWHy/OSkmZSKt06tyiR48erqwvuOACt0z7999/H9pG522qt/x93V8eWksZq40wcuRIr1q1aqx8VAStKOUfb7Xc9qmnnur+/uKLL0LbvPvuu66s58+fH1p+WOcjOq5oZdXBgwe749CUKVO8ZGFi1EK88sordu+997rxjrpq+NRTT7kJcXwao6SrtuFXaIt6DaLTsIq99trLnn/+eRddHTZsmPXr1y/fNiprv0uUJoLSCjKaLCdy/L4iiYyvjm3gwIG2/fbbu0m0FIHt3bt3gdUwNOmTVoyJddU9cr9HdKeccorrjaDjgYZeHHrooa7nUnjXS+336jocPlmnetuMGTPG/b/TTju53gvt2rWjmAuhfVZXFR544AE3AaJ64ei4ois2PpWlv2KXjBgxwh1H1LVVN/XeUZlrbDti0zwq/nF3zz33dLPr66bjgiZQFh1jdF/HC1HXbc0PoFn29f2ou7d692n/L68eeughN8Tiueeec59T+1OfPn3ybaPfs/ar4rwGBV177bVuHxo/fry7Wq7eB5o8OpxWFvBXiNPYfX/FucGDB+fbTu0Mhh/F1r17d9eDQz091Z5SbxrVW+Erw7Vq1SrfEOZovU6T1YU9naiXuHo1jxo1yh0XdTzVamXhk9drQs7w3uRqm2mesHvuuccdT/W7UO8RepMVTvujys2vgzT8Qj3KtKqnT5PRq97ye3moN5O2U3tZbTgNmdWxW8PrEJuO0X4bQUOJ/DaD9mWtIOU/rrLWubKot5/acHfccYf7PTRs2NAdfw455BBLlixFQpKWOgAAAAAAQBnBnCAAAAAAACAjEAQBAAAAAAAZgSAIAAAAAADICARBAAAAAABARiAIAgAAAAAAMgJBEAAAAAAAkBEIggAAAAAAgIxAEARA0n388cc2d+7c0P0pU6bY119/Xe5LvjQ+R7qUFQAA0XzxxRf2ySefhO7PnDnTZsyYUe4LqzQ+R7qUFVDaKpb6OwJp6I8//rBvv/3WsrKyrG3bttagQYNUZ6lMufPOO22PPfawffbZx93/z3/+Y506dbLWrVu7+5MnT7ZGjRrZ3nvvbeVJ5Ocor+8RBAVq9Bs49NBDrUmTJqnODgCUGStXrrR58+bZ5s2b3bG8adOmqc5SmfLEE0/YX3/9ZQcffLC7//DDD9s///xjBxxwgLuvk3y1rzp27GjlSeTnKK/vEYRff/3VZs2aZfvuu6/tuuuuqc4OQBAEKKmrr77aVUKqgKpWrepOBrt06WKPPvqoVapUiQKO4ogjjnBBEd8tt9xiRx11VLkLguDfXj433HCDLV261H766Sd76623CIIAwP+55557XB2nCyQ5OTn2zTffuBPBxx9/3N1HQQp25OXlhe6PGTPGKlasWO6CIDC3v1977bX2/fff2+LFi+3ee+8lCIIygZ4gQAlMnDjR7rvvPvv888+tXbt27rFt27bZs88+a1u3bs0XBFmzZo3rtpidnW0HHnig1ahRI19aqhyUTvXq1d3VEP0f/tp3333XTjnlFPvhhx/s559/dkEX/2rSggULXEXTsGFDlw8FY2L57rvvXM+VQw45xA1R0cmr3q9evXpRt/nss89s2bJldsYZZ7jn1DBRNF+va9mypbVq1arAeyi/OjmuW7duqFzCqWeD31tm+vTptmLFCpf/F1980T2mzxn5Gf73v/9Z8+bN3euUb5Wj8hcZaNq0aZPrVrtu3TrX82THHXfM97xO0pXnnXfeOfTYhx9+aLVr1w71VPHfq379+u47q1OnjstzUVRWv//+u7tipdcqvfByjUVlqu9eZa7XtGjRosTvoe9Q+4nSatOmjds+nufi+X7DqZxvv/12d3VT3zcA4F+6KDJo0CB7/fXX7eSTTw4VyxtvvGHr16/PFwTZuHGj6/GgOkz1e+TxVPWknlfdd9BBB7l6yaeeAC+//LK7AKNeJ+qVp2P3brvt5p5fsmSJq2NUzykAs91228X8ilS/qI7t2rWrffXVV7Zo0SJr3769NWvWLOo2qiOV/vHHHx9q13z55ZduG9UxCv4oz+H0WVXvqp6P1kZQHj3Py5eW0vDbCPqckfWe6v0qVaq4z6zX6D3UMzG8LeWXlcpx+fLl7mLMnnvuWWAIqtoZ4b0v58yZ43rx+D1V/PdSjwbVyapDjznmGCuKegOp/hV9v6p/t99++yJf57/2l19+cfndfffdS/weSkvb+e3G8LZUYc/F8/1Gtgcvu+wyO/bYYwn6oUwhCAKUgE7c1YgJr8QrVKhgvXr1yrfdM888Y5deeqmruFQpqVExfvx4V3n4w0VuvfVWFxxRxawTUDWS/O6N2r5Hjx52wgkn2G+//WZ77bWXq3waN25s/fr1szfffNNdIdFJ9Nq1a91rY528vvrqq/bf//7XNVZ0Ev3333/bjz/+6Bpp6qERvk2tWrVcQ0MVoYIgqvROOukk27Jli6v8NY5XjaOXXnrJKleuHGosqLLTkAg1JJR3XcEJ7/kRPsRDDSg12nSVQHmQ4447rkAQRL0NlGcFfPQ6v+zVYPEbQ6r81RBTvhUg+vTTT+2qq66yYcOGhdK5/PLL7aabbsoXBBkxYoTrheIHQfReNWvWdGWtBkTnzp3jCoLMnj3bvaeoUaj8qJtv9+7dY75G76Ggj753vb/KQd/pddddl9B7qOF47rnn2vvvv+8aytpGDV7tI/pMsZ7T//F8v5FU3rJ69eoiywcAMomCEXLkkUfmezw8IOIH3nv27Onq2h122MGdNKo3qXpIii6sXHTRRS44oJN4pTtu3LhQOgqcqI2g47EulKguufDCC11AQPXdgw8+6NoTClorAK72h+q1aHQBQ+0V1Yl6L53sKzCuNoHyGL6N2jDaRnk+7LDDXN1x6qmnuqEPek751FBX1TF+Pa3nDj/8cHdirXpYdZ62URrRhngokKR2hAINfhuhQ4cOBYIguiClOkwXbdTe0PsocKE2wi677BK62HT00Ue7AIm2UTCjW7du9tRTT4UuBkQbgjp27FgXhPKDIHqvhQsXuraLylifNZ4giMpD7TNRegqg3HHHHa5dEktubq6ddtpprq7ff//93efS/qTeMYm+x+DBg+2hhx5yF5JWrVrlyum1115zF38Ke073i/p+I/llBpQ5HoCETZkyRZcqvAEDBnjffvutl5eXV2Cbr776yqtQoYI3duzY0GOLFy/2Zs+e7f6eN2+el52d7U2cODH0fO/evb0999zT27p1q7v/9ddfu/c5//zz873HyJEjvdatW3tr1qwJPTZo0CCvY8eOMfN82223ubQef/zx0GNXXnmlt8suu4Tez9/mtddey/fagw46yH1WPw/r16/32rRp440YMSK0Tfv27fPl86WXXnJpXX311aFtOnfu7N14442h+wcffLB3yy23FFLS/6Zbs2ZN75dffnH3165d6+29997eFVdc4e7r/fbbbz/vjDPO8LZt2+Yemzp1qpeVleVNnz49lE6LFi3yfXY55phj8uVP79WoUSPvr7/+KjRPkZ8j0nPPPefVr1/f27RpU8xt9t9/f+/oo4/2NmzY4O4r72+99VbC7/HNN9+4z6x9zKfPv2zZskKfi/f7jWXVqlXuew7POwBksh9//NGrVKmSd/bZZ3tffPGF988//xTYZunSpa5uu+mmm/IdT6dNm+b+Vj2k58eMGRN6fujQoe64v3r1and/3bp17vjbpUsXb8uWLaHtJkyY4DVp0sRbsmRJ6DGl06xZs3zbhRs3bpxLK7zeue+++7zatWt7ubm5+bbR4+H0OU877bRQW0L/H3vssd5FF10U2qZbt27eUUcdFXr/mTNnujZQ9+7dQ9v06tXL69mzZ+i+/tZjhdHrlc6MGTPcfaWv9znppJNC2yhvnTp18jZu3Ojuz58/36tWrZqrRwurc5X/8Pzp7ypVqrjXFybyc0RS/at0wr+fSKeffrrXtm1bb+XKlaHHXn/99YTfQ/uK2gGffvppaBu1DX744YdCn4v3+y2M9qHRo0fHtS2QbKwOA5SArmboCsLbb7/tel6ol4euKnz00UehbZ577jl3VV1XZXzqpaArGTJhwgR3xUW9PHw33nijzZ8/30X+wymSHz504cknn3TReF1F0tV6paXeEbpqo662sShif8EFF4Tuq9eBeliou6xPUX/1UPCpt4h6IOjKzSuvvOLeT8OBdIVl6tSpbhtdYVIa6v7r51NXMMJ7XZSE0tppp53c3+q5cMkll7jP7HffVC+J66+/PtQ1U1emdBVCV72KSz1fdIWjuNSLRxO96j11VUxXYpS3aPQd67vSladq1aq5x5R3dTFO9D38HjThK8qoDNQrp7Dn4vl+AQDxU92vq+gaWqBeHOqlqJ6Sfo8G0fFWx/0hQ4aEHtNQF7+nho7D6jVx8cUXh57XHAvq9al6IJy2CR+6oDaC2hc6tvttBPXsUI8I1deFUT3uU68PDfVVWyO816vqYJ/aHEpfPSz0+fR+6lWqHh5+HaL6Sr0UBgwYEMqnejeorg6Chr/484Yo/YEDB7ohsOr5oSHK+i70mF8XKq/qRekPsykO9SgJ7+EaL/WanDZtmisr9XBRPjXsKBr11FUZqndG+NCpyJ5ExXkPfW/q2al2gD/kyB86Vdhz8Xy/QHnCcBighDT0RTd1jdQ4U012pgpdjRMFSfS4Py43GnXfjAwS6ERfjSI9p4aTL3Jcp4ZSaIyvxgJHnsCr0o+cdyQ8wBE+hlPpqmGk9/MbENHeSxTgUUXpU4Xpfz59Vomch8MPXJRUtHQ1o7y6ayrvElmWOon3nyuOeMfphtOwJgU0NDxKARQNAxJ1z40cdxxeXoXtH8V9D31eddXVPqmGnoY4nX/++a5BXdhz8Xy/AIDi0QUO3RS81vBPXRjRxRIFKHT8VT2gui3WkEN/7oXw47KC5qqjIuu2aPW26ojINsKZZ55ZaJ4VhAmfc0Qn0bp4E/5+upgSnmcNr9QQFl0I0STZ4fzhpAq+aN6paHV5EEMqo6Wrk3l/WK4COdHaCAqOlEYbQcOaFDhSIEFzrKj8lCfV39GoTPV8cergot5D+87TTz/tAmk333yzq/81zElDYQt7Lp7vFyhPCIIAAVE0XDddVdCEki+88IILgqghoQo4Fs3LEdmQUWNADQU9Fy68F4joqtKJJ57o5rAoDo3rDKeAiQIJ4e8X7b1Ec5doTpJo/DGhSj88ABP5fomKTEf31SNEARw/7xo/q8CQT/fDlyxW8Cd81nl/PHWkyM9fFI0N1tUaP/glCtDoyol/RSWS38jUa+OZVDTe97jyyitdryH1JFLjTuOH1VtJY5ZjPeeXWWHfLwAgMQpa62RSN83f9fzzz7sgiOoBHdtjUd2meiyS6r942gia1+qxxx4rVl41d4hOeP0ge7T3i9VG0Hwm/lxRhbURIj9LcevcaKKlK8q3/1kiy1L3wz9XstoIqqPVo+aBBx6w3r17hx5TWymeNkKQ76EgmG6aj0X1/9lnn+1WbdF8ZLGe035b1PcLlCcMhwFKQFc11FAIp4i7ul36lZe6TOrqjyYrC6chDH4EXT1I1CjyqZuh33gpjLrV6mqSAhjhFLEvjIIumt3bpy6NqiT9iUGjUY8UTdr2yCOPFHjOz7smflVjIryrr4bZxOrq6dOEndEaGZHULTi8vJVvf9ItXSlR/vSYTw0HddMMv0qhq1nh3YDVSCoqf/HQVT41MsJnbY+8+hZJvTkUoNHEueE0SWqi76HPrP1BDTl9nwpqaMiUPwFtrOfi+X4BAPHTMVsXGSJpWIjfRtBKJ6qzNYFntHpA9ZcupGjScZ8mt9bwBH/y9MLaCKoj/PZGvG0EtWNU3/o0gajyo8nbY9FE7apPotUh/vsp2K7hOeFtBK0eEjmsJ9E2gup7pedTe0A9IjSURG0qTXYa3kbQ96BJPQtrI6g9p89fUtoPNIQpvP5WkCHa/hEeOFM7MN42QjzvoSE22kZUNldffbW7QKJ2aGHPxfP9AuUJPUGAEtASb7fccovr2qpKR5W0eoDoRNMfv6t5NTR+U2NVdRVeDR+NAb7iiivc45ppWxWwhiYowq7KbeTIke4W3qMhGq1qohm8NaZWUX91WVVlrUosvAETSY0Bva/yo4aUZg7XXBrhY04jqUulZkg//fTTXcNOs9arYaUGxHnnnWf9+/d3Qyxuu+02N95XXS91Uj1q1KjQFaJYND+KxuSqDNUdM9oSuaLGjSpkXaXQGGeN9dUSu6Lt77rrLuvbt6/Ll4b8qLJWrwblz6e/tWKMel6ofBVECuIKlIIwGo6iGfo13ETzfUQ2XKKVqfKo16gR4c+Er31A+1Ei76HGm57T96Ruvgrw6IqOhmkV9lw832+sQKC+gw0bNoRWDVBDSg2owoJqAJDudIzWMVd1vb9im+bE0HFedaMoAK15KrSN6mTVXQpyqLefeu3pefUY0ZV4zdOhCwGqs7Wt5hwpjLZ/9913bb/99nPHcNV5CqZo/iwtcRuLeleqPaL6QXWD2iOaRyzasM5w6nGiOlo3tYtUF2geEa0ypvaKKO+q4/U5VE+o3gnvcRKrjaBekFoxR58h2hK5ojaQ2lJ9+vRx81xpBRW1t3waDqpeDAry6IReQ5N0UUAn+z6toKbhS+phq+E1qouDGKqjpXqVb30PKltdXNCqPdHaOuG0Uo7KU72M9b9WZlFQIto8HPG8h3q+qIz0/ah9pCFT2kd08a2w5+L9fiPpQpP2Zz+gpFXn1N7Tfs7KMUglgiBACWispOb/0ASVupquxsJZZ51l55xzTmh4g06wNVxBV2MmTZrkKiN/rKXvnXfecSfjSkOVmE48VZH5FDjRib8/eWb4mFQ1ZHQirIaNrpaocaEJRAujhowaB8qTghU6CVa+fWqsRfYuEQ290dK0WppPJ76qxEaPHh2a5FUU/NHyuGro6cRYy7cqYKGrKz5VsuETiqmxoQCM5qPQFYtoS+SKGioaG6331jAYNQTCT7R1sq5GiypsTTiqhpBu4WOpFSTRd/PBBx+4ctVScLoKpc/iUwUfz5CQ8M+hRpyCYipXTUimoVFamk6fTcGgWBSM0hhblam2V1nefffdCb+H5nRRo0TpaVuVu9L30yjsuXi+30gK3vhX9bSPqpeRbkqLIAiATKb2gXpd6qRPdbV68im4oRN/1ZO+e+65x9X5Cuyrx54fOPFpe52M68RXJ+06GQ1fel0n/zr+Rg6PUZtAgWm9VhdIVBeqN4dOjAujulE9U1QXKBCiXoOqS32qZ8MnTvfpgowmgdWE8aqb1JNBF1hUj/kUYFDamrtCQSKlrXZIeA8O1WPhQ1IUBNJ91es68Y62RK6o7aNgkeo5tSXU5gpva2n4p9JQm0nlobaGlh4Ov1Cj3rvvvfee6zGi/GmietVpGiLk04UrtUGKEvk5lKbKXvWr6myVg4Ichc2bpuXsFTRTG1FtKbXP1EZM9D3UblBbU9+R9g3tM2oPKFAmhT0Xz/cbLQjitxHULlC7UPd10YcgCFIpS0vEpDQHAErVsGHDXC8RBRDKEzV61MBRhQsAAIKn4IR6kGi+qfJE7QOdtEcbrgEAkZgTBAAAAAAAZASGwwAZJtZQl7Iu3iEqAAAgMbGGupR18Q5RAQBhOAwAAAAAAMgIDIcBAAAAAAAZgSAIAAAAAADICARBAAAAAABARiAIAgAAAAAAMgJBEAAAAAAAkBEIggAAAAAAgIxAEAQAAAAAAGQEgiAAAAAAACAjEAQBAAAAAACWCf4fTfKed6T9adEAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1100x380 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Deux modeles contrastes : regression logistique (bien calibree) vs foret aleatoire (ecrasee vers 0/1)\n",
+    "# Les deux mesures vivent sur des echelles tres differentes (dizaines vs centiemes) : on standardise,\n",
+    "# comme au notebook 2.1 -- sinon la regularisation L2 penalise injustement la dimension fractale.\n",
+    "lr = Pipeline(\n",
+    "    [(\"sc\", StandardScaler()), (\"lr\", LogisticRegression(max_iter=1000))]\n",
+    ").fit(X_train, y_train)\n",
+    "rf = RandomForestClassifier(n_estimators=100, random_state=42).fit(X_train, y_train)\n",
+    "\n",
+    "proba_lr = lr.predict_proba(X_test)[:, 1]\n",
+    "proba_rf = rf.predict_proba(X_test)[:, 1]\n",
+    "\n",
+    "# Contraste chiffre : moyenne des scores vs part des scores vivant au centre (hors extremes)\n",
+    "contrast = pd.DataFrame(\n",
+    "    {\n",
+    "        \"mean_proba_class_1\": [proba_lr.mean(), proba_rf.mean()],\n",
+    "        \"count_pred_class_1\": [int((proba_lr >= 0.5).sum()), int((proba_rf >= 0.5).sum())],\n",
+    "        \"part_scores_dans_[0.1, 0.9]\": [\n",
+    "            float(((proba_lr >= 0.1) & (proba_lr <= 0.9)).mean()),\n",
+    "            float(((proba_rf >= 0.1) & (proba_rf <= 0.9)).mean()),\n",
+    "        ],\n",
+    "    },\n",
+    "    index=[\"LogisticRegression\", \"RandomForest\"],\n",
+    ").round(3)\n",
+    "print(contrast.to_string())\n",
+    "\n",
+    "# Histogrammes : LR etalee sur [0, 1], RF bi-modale ecrasee contre 0 et 1\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(11, 3.8), sharey=True)\n",
+    "bins = np.linspace(0, 1, 21)\n",
+    "axes[0].hist(proba_lr, bins=bins, color=\"#4c72b0\", edgecolor=\"white\")\n",
+    "axes[0].set_title(\"LogisticRegression : scores etales\")\n",
+    "axes[1].hist(proba_rf, bins=bins, color=\"#c44e52\", edgecolor=\"white\")\n",
+    "axes[1].set_title(\"RandomForest : scores ecrases vers 0 et 1\")\n",
+    "for ax in axes:\n",
+    "    ax.set_xlabel(\"Score predit pour la classe 1\")\n",
+    "    ax.grid(alpha=0.3)\n",
+    "axes[0].set_ylabel(\"Nombre de patients du test\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "019c892b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002962,
+     "end_time": "2026-08-23T00:52:54.335142+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:54.332180+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Le reliability diagram : le construire from scratch\n",
+    "\n",
+    "L'histogramme ci-dessus montre le symptôme — des moyennes proches, des distributions radicalement différentes : les trois quarts des scores de la forêt vivent sous 0.1 ou au-dessus de 0.9, alors que la régression logistique occupe tout l'intervalle. Mais l'histogramme ne dit pas lequel a **raison**. Le **reliability diagram** (diagramme de fiabilité) tranche. L'idée tient en une phrase : **regrouper les prédictions par niveaux de confiance et confronter chaque groupe à la réalité observée**.\n",
+    "\n",
+    "Construction, bin par bin :\n",
+    "\n",
+    "1. On découpe [0, 1] en **10 bins** de largeur 0.1 : [0.0, 0.1), [0.1, 0.2), ..., [0.9, 1.0].\n",
+    "2. Pour chaque bin, on calcule la **confiance moyenne** (moyenne des scores prédits des exemples du bin) et la **fréquence observée** (proportion réelle de classe 1 dans ce bin).\n",
+    "3. On trace un point par bin — *(confiance moyenne, fréquence observée)* — plus la diagonale **y = x** de calibration parfaite.\n",
+    "\n",
+    "Lecture : un modèle bien calibré aligne ses points sur la diagonale — les patients à qui il promet ~0.7 sont positifs dans ~70 % des cas. Un modèle écrasé vers 0/1 produit des points **au-dessus** de la diagonale à gauche (il dit ~0.02, la réalité est plus élevée) et **en dessous** à droite (il dit ~0.98, la réalité est plus basse) : l'écart visuel **est** le défaut de calibration.\n",
+    "\n",
+    "Nous l'implémentons **from scratch avec numpy** (`np.digitize` pour assigner chaque score à son bin, puis un masque et deux moyennes) plutôt qu'avec `sklearn.calibration` : c'est le seul moyen de constater qu'il n'y a aucune magie dans cet outil.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c40f6c22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:54.341346Z",
+     "iopub.status.busy": "2026-08-23T00:52:54.341346Z",
+     "iopub.status.idle": "2026-08-23T00:52:54.571278Z",
+     "shell.execute_reply": "2026-08-23T00:52:54.571278Z"
+    },
+    "papermill": {
+     "duration": 0.23455,
+     "end_time": "2026-08-23T00:52:54.572690+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:54.338140+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " bin_center  LR_freq  RF_freq\n",
+      "       0.05    0.025    0.135\n",
+      "       0.15    0.000    0.333\n",
+      "       0.25    0.444    0.250\n",
+      "       0.35    0.250    0.333\n",
+      "       0.45    0.375    0.250\n",
+      "       0.55    0.667    0.750\n",
+      "       0.65    0.833    1.000\n",
+      "       0.75    0.727    0.857\n",
+      "       0.85    0.947    0.875\n",
+      "       0.95    0.970    0.925\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjoAAAHWCAYAAAB+JiOkAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAw7JJREFUeJzsnQd4E/Ubx1+6dwstFMqmZbfsvbfsIVNFQARlo8ifpQxFZSoyZCMbRUBBZA/Ze5c9y2oLbeneI//n+0svpKVpkzRpRt/P8wTuLpe7yy/Xu++9s4BMJpMRwzAMwzCMGWJh6ANgGIZhGIbRFyx0GIZhGIYxW1joMAzDMAxjtrDQYRiGYRjGbGGhwzAMwzCM2cJCh2EYhmEYs4WFDsMwDMMwZgsLHYZhGIZhzBYWOgzDMAzDmC0sdBgFTk5O9MUXX+S4TB1SUlKoQIEC9M033+h039oejy6pVKkSde/e3eiOyxhISEigMmXK0IIFCwyyf12cd7okLi6OihYtSsuXL9fbPswZY/s9s7sGMMYLCx0T5OHDh+KPX3pZWFiQm5sbtWjRgnbv3k35DSsrKxo/fryhD4Mhop9//pmSk5Np+PDhGcYjNDSUVq5cSW3atBG/F25I2XHw4EFq1KgROTg4kLu7O33wwQf0/PlzkxtjHP/kyZNp2rRpFBkZaejDYfL5Ncwqn14rWeiYMBMnTiS0KsNTz8WLF8ne3p66deumU7ETExNDv/zyi862l9v95NXxaIqxHldekpiYKITOkCFDyM7OLsN7uNlfunSJJk2aRC1btsx2OwcOHKCOHTtS8+bNKTg4WHzu5cuX1KxZM4qIiDC5323w4MFiP6tXr9brfhiGyRoWOmYALDrly5en9evXC+GzZMkSQx8Skw/Ztm0bhYWF0ccff/zOe6tWrVJYdCwtLbPdzpdffkk1atSgWbNmkYuLC5UtW5Y2btwoLDo//fQTmRrOzs7UtWtXdl8xjIFgoWNGFClSRNwYXrx4kWE5xM+KFSuoVq1awuqDdTp16kQ3btzQyuft4+OjcJvBFFqiRAkaOnQohYSEZLmNffv2UfXq1cVTPnzb69atU2s/OR0PvieOITU1VdwApWPq3Lmz+M4VK1akJk2aZLkdX19fqlevXrb7wlP4yJEjqXDhwoqbFSwLOR2XpuMUHR0tXD2Z95M5DkA5XuHQoUNUp04dsrW1VQhbdfanvA1YTvC7wL0CN9HNmzcVv1fNmjXFueLn50cnT54kdYAlsWTJkuI4tOXOnTvi1aNHjwzLS5cuLc5fiCl10ea8Ux6f48ePizHG5/GdILYys3nzZqpbty65urqK369t27b033//vbNeq1athMsZ302XqPO3rY/vpOl+dXGuqfN7ajtGurgGaLOf7K5hmm43u9/thRr7MWtkjMnx4MEDGX66iRMnZlgeFBQklrdv3z7D8mHDhskcHBxky5cvl4WEhMieP38uGzRokMzJyUl2+/ZtxXqOjo6ysWPHZvhsVsuUiY2NlR0/flxWpUoVWYsWLWRpaWlieXJysjiWTp06yfr06SN79OiR7PXr17Jp06aJ5StXrsxxP+ous7S0lH311VfvHNuCBQvEvq5fv55h+bFjx8RyjIcq8D3atGkj8/DwkO3evVsWGRkp+++//8T3KVeunKxbt246GSf837JlS1nhwoVle/bskUVFRclOnDgh69q16zv7kca0c+fOst69e4vzAOO6f/9+tfcnbaNLly6ygQMHyp4+fSoLDAyUtW7dWlaqVCnZ0aNHZR999JHsyZMn4nxq166dGIOYmBhZTnh5ecl69OiR43rvvfeeGK+s+OOPP8Txbdu27Z33BgwYILOwsJDFx8er3HZuzzvp8xj3/v37yx4+fCgLDQ0Vf0MFChTIcC5h3LHuokWLZG/evJFFRESI8evYseM7x3X16tUczzltUOdvWx/fSZP95uZc08V1RN3rX26vAdruJ7trmLrbVfd3s8xmP+YMCx0zEDqpqamy+/fviwuFlZWV7ODBg4p1z58/L9adN29ehm3gAlK+fHlZ3759cyV0JP7991+xn7t37yq2j3lPT893bkwQYrh4JCUl6VXohIeHiwsELhTK4DtjOS5cqjhw4IA4/rVr12ZYLl1QNBU6qsZp3759Yn79+vUZ1jt8+PA7+5HGFKIou5t9dvuTtoEbjfL4X7hwQSyvWLGiLCEhQbH88uXLYvnmzZuz3Q+2i5vmiBEjciV0fv31V7G/Q4cOvfPemDFjxHu4WWZ3HLk576TPlyhRQpaYmJhBOOLGMnr0aMWySZMmifNIHYKDg8V2J0+eLNMV6v5t6/o7abrf3Jxruf09Nbn+5eYakJv9ZHcNU3e76p6LlvlU6LDryoSZM2eOMD8i5qFChQp04sQJ+ueff4TJUkIKTO7du3eGz8K1gWBPmLI1BcGhCHqGqwz7VjaBwjyvTLt27d4JTIU7Blk46piOcwMy0T788EPatGmTcA+BV69e0V9//UW9evUSJmBVHDlyRPwPU7Uy7733njAf62qcJNNyly5dMny2devWwsyfFVmNqbr7U96+tbW1Yh6uAAB3HtxhEpUrVxb/P378ONvviowiPDjBvK8LcOzavKer8w5/QzY2Nop5/BaIFVIeB7hRkD7ev39/On36tMg2U4V0ruUUTI0YJuWMSsyrQtO/bV19J033q4tzTdvfMzfXP02uAfq4zmqyXU3OxfwICx0zyLpKSkqi8+fPi/iIMWPGiIBQCWStAG9vb/HHgRsggpfxQhaI8rrq8ODBA5H9Ao4ePSp82DiGY8eOiWWZ/8A8PT3f2Ya0DBcpfQP/Oo5RikXAd8Yxfvrpp9l+DuOC8SpUqNA770FI6GqcpP0ULFhQ7f0UL15c6/1JFCtWLMO8JFAyL8cFHedMTjdoxAXgxhwVFUW5AankIDw8/J33cAxSKYWcyO15l3kcJLGiPA79+vWjRYsW0eXLl0UsGI4L2WIY/8xI45LV76wtmv5t6+o75Xa/2pxr2v6eubn+aXIN0PV1VtPtanIu5kdY6JgBeFrC09GOHTsoICBAiB0JDw8PxR8MggMRjJaWliZekkjSBASDxsfHiwwaBPRKTzZPnjzJcn1YUFQtk25q+gTZOw0bNqRly5aJ747jRoaaJApUgWPDeL158+ad916/fq2zcZL2k9WNXdV+lJ+ONd1fTlYRdawlWYGLsJeXl+LCrC0ISAX37t175z0E8uK3y8qapevzTt1xGD16tDiuwMBA+u2338SNB9YH3HCUCQoKUgRVZ8fhw4fF36X0wrwqNP3b1tV30tV+NTnXtP09c3P90+QaoOvrrDbbVfdczI+w0DEjcJNAzY7ff/9dcXJLLpE///xTp/tSNjmDDRs2ZLkesoNQX0WZXbt2iT9gmFt1gaOj4zv7UGbEiBEiy2PChAn07NkzMUY5gSwZkLkmEQrZQVDoapykmjJ79uzJsBwuLZii9fW76AM8ScJ9lhuqVKkiXBs7d+7MsPzp06d05coV4XJUh7w475SBdaJv3760Zs0acTOC+0CZCxcuiP+bNm2qs33q6287p++k7/3q8vfMzbFqcg3I7ZiouoZps93szkXHHK6V5goLHTNj6tSpwg8/ZcoUMY9UTqQu4yYP0ybSDHEDxY3/xx9/1LhKJsyhMJ+OGzdOmIxR2wQWJFVPVUiJHDRokLAsIM3522+/FWmiM2fOzNIyoQ2wYOCPWZUFBP5tpFuimB2OfeDAgTluE09CECH/+9//aO/evSLGBzFQixcvFmZkXY0T/P3YD36H/fv3i/2cOnWKFi5cqNZ+NN2fPsFFGfvNHA+kKfidIGpQZBAuH5w7qM0Dl91XX32l1jby4rzDufHDDz+IvyXc+PDUjVYP+B0yCxq4EJDOLcWh6AJd/22r+530sV99/Z65OVZNrgG5HRNV1zB1t6vuueibw7XSXGGhY2agdgr+MPDUIcVnLF26VLhutm7dKi608C8jaA19ifAHoqkrCG4SWIwQE4SAOJjjVd2AUCMD+0JAH45ty5Ytwrc8bNgw0hW4AMB1guPIqjYErByo1isJgqxiFTKD7eCJsWfPnjRgwADxGQR/YxyxL12Nk7QfBFZinKT9/Prrr+JpLLOFJrf70yewtuAJO6vaLPPnz1cE2KKmSmxsrGI+c8+gDh06CAsXrFqIw8BNDuOCGivqxrjkxXmHmwxcBwh4h6CEZQGBtAhixf4lcINEkoAu9y2hy79tTb6Trverz99T22PV9BqQmzHJ7hqmznbV/d0W5XCtNFcKIPXK0AfBMPpm9uzZwkIAlwgyk4wd/FkiFgUXclh3TGmc8cT76NEjtWJp8gP4/fC0jYBxBG0zDJO3sEWHyRfgaQjBsqgoagogLgBPaLDMmBKoMgxXAp5CGXn3crSy+O6771jkMIyByNkGzzAmDLITIHKuXbsmmjeq43bKayAKcFxw2SD1FrUx4H6sXbv2OzU8jB1YcZD5x7ytVZPbTDSGYXIHu64Ys+XcuXMitRzuAvi04ULIqaGkIUBw5fTp00XsCoIN4YOHwPn+++91WneFYRgmP8JCh2EYhmEYs4VjdBiGYRiGMVtY6DAMwzAMY7YYX2RmHgWookw2Aj+1LXnPMAzDMIzhSnCgRhWyadH7KzvypdCByEFRNYZhGIZhTBdUY0cRyezIl0JH6p6LAUL3Xl1aipBBg3YDOSlMhsfaFOBzmsfaHOHz2vTHGe1hYLCQ7ufZkS+FjuSugsjRtdBBWW5sk4WOfuGxzht4nPMOHmsea3MjLQ/uieqEn7DZgWEYhmEYs4WFDsMwDMMwZgsLHYZhGIZhzJZ8GaOjrm8RTRU1/UxycrLwSXKMjn7hsc4bTGGc0UTUGFt7MAxjHLDQyQIInCdPnoiLvKZ5/fgMcvu5Po9+4bHOG0xlnN3c3Kho0aJGfYwMwxgGFjpZXNiDgoLEEyJS1zR5isVnU1JSRCdqvuDqFx7rvMHYxxnHFxcXR69fvxbzxYoVM/QhMQxjZLDQyQQu6rhwotqig4ODWd0UzAkeax5nCXt7e/E/xA46v7Mbi2EYZYzT6W5AUlNTxf82NjaGPhSGYdREeihBPBHDMIwyLHRUwBYZhjEd+O+VYRhVsNBh3uHZs2ciTknVfEBAAL169SpPRy7zMZhDv7WbN2+KbCZj+P6PHj0SAcfGyMOHDyk2NtbQh8EwjIliUKEDM/P27dupTZs2oinX2bNn1frcn3/+SY0bNyYfHx/q0aMH3blzR+/HakrgpoCbQ0REhFafHzNmDP3www8q54cMGUILFiwgfYGbenBwcLbHZKog/qtBgwZUs2ZN6tevnxAY6pD5+2c1Rtpy+/ZtatKkicZZhnnFb7/9RmPHjjX0YZgciSEhFPPoscoX3meY/IBBg5GnTJlCjx8/pgEDBtDAgQMpMTExx8/8/fff9NFHH9HixYupYcOG9NNPP1Hz5s3p1q1bonFYfubGjRs0fvx4OnnyJBUvXlwIHTQ8++qrr2jUqFFab7d06dLk6elJecWIESOEiP3ll18Mdgz6AucvRMqLFy9E/Rd1yfz9sxojbZk4caI4P1xdXckY+d///icehL788kuqWrWqoQ/HJICIuTx8NMmyiVkqYG1NtZctJtt8ft1kzB+DCp3Zs2eLDAlc9NVl5syZQhQNGzZM8bSHlNJly5bRtGnTKL9y7do18VQOEbh161YqWLCgWI6xnTdvngiyxljDZfLmzRvxnru7u1rpuBBKqm7KyHRBphmy1JSBewvZMLg548YOa0GZMmVy3P/Lly+FCyUsLEy4dkCFChVUHkNoaKgQdBACmQPIlY8B62EMchJLyp9R9d3UGcOsvj/G//Lly+K3uXfvHtna2lL58uXV2p7y91c1RtL3x3twLZYqVSrHoHpY/vbv30/Lly8X8/gcLILlypXLsB7GAt2Ccby6JCYmRowVRJudnZ1i+YMHD0SAMQQ7xqtr1660ZMkS8XfO5ExyVHS2IgfgfazHQocxdwwqdDRNA8WF9urVq+IJVAKp3K1bt6YTJ05QfgauDdyEcCNQrv2DJ+GFCxcq5tesWSOEkHTzws14/fr11KJFi2y3je3gRiMBdyGeriMjI8V22rZtK7br5OSkcG85OjoKix1uvC1btqS1a9fmuH8cP35jWOjwP9i9e7d4mlc+Btzk+/fvT8eOHRPiADfMOXPmKASwdAw4HggNrA+xA7fRP//8I44tK6TjhgBQ9d3UGcOsvj9u2Fu2bBHbhdsKQmTv3r1qbU/5N1A1RiiYN3LkSOHaRZo1RMvQoUOF1VPV3xosTFWqVBGCApw5c4Y+/vhj4RaTvi/AMtSVwrFmBscs1bFRRdmyZbMcc/z99u3bl+rXry8eWgCEV5cuXcTftHRc7dq1o8mTJ7PQYRjGvOvo4EkW4IKuDJ6ar1+/rvJzcIkpu8UgmACesjPHJWAeNVqkl6ZIn9Hms9qCm/ipU6dE3AyyT7Lb9zfffCNeEvjMhx9+KG7sUj0SkPn7Z57HjRWCoVOnTiJIFu7Db7/9lubOnatYBzesw4cPC0uTtI2c9g+LHaxT3t7e77hllI8Bwgc3cpwThQoVErFeuGHWqVOHateurfjMoUOH6OjRo1SvXj0KCQmhWrVqiZslLCSqyOm7qTuGmb8/gHt1x44ddPHiRbXHJPP3VzVGEDXPnz+np0+fijGBpahVq1ZCoIwbNy7L73r+/HmqXr26Ylw7d+4sBM4ff/xBn376qViG7R05coSOHz+e5bmFdVeuXEnZARFTt27dd5bDqgXxB6HTvn17Ie4GDRpEX3/9tRCl0v4Q04TfG2OC750ZaWyy+ps2FaRrjy6OX91tmPJ4GctYM6rBNQgPWfoYZ022aVJCR/pieApUBiZ9qf5NVsyaNUvcqDKDG1/mrBcESGM/cFngJYEbXubgT5Sdx5MqtgELB/5wJBcRBAcuzgBuCgShKgNXC25GOIbMrjvcaDRxEcBqgH1jm8rHrAqsi/3CwtGsWTOaMGEC+fv7CxGgfBGQtpV5HtO4gb733ntiGW7eEA544v7xxx8V60Ao4GaV+Zhy2r9001L+nPIxwEKyefNmYQVBDBKWde/enZo2bSpcMJJ7A+sjWB3bxTqwqMD6ByuIqnFS57up+x2y+v6Zx1Lb3yTzGMFKBCvQ6tWrxcUFAhDvd+jQgXbu3CksQlmB8xoCRPl4YL2BMIGLGNvAduFaghjJatyGDx8uXjmhasxhUUKgNaxxEF1wm02aNCnD+pIrFt8L53lW28YYQfRrEvtkTOD48TtizHPbVywxXO4KzYnw8DcU9/qt5S6/oMuxZt4lPj5ePKzgQfPff//VyzhrkiVqUkJHCjbGzUAZzGcXiIyblPITLSw6eMrFZ1xcXDKsC9GCAYSYUhZUMNl/9913GdZFPMzGjRuFAMJNQJUww5P2uXPnMry3YcMG4Xr566+/aPTo0Rneg5ke1gBNi6XBapVZBGbmwIEDwr2BGwIsYbgp4CTEd5A+ixMSQk3VPKZxc1Lel5+fn4iVwcUDriSsgxtW5uNRZ//4rPL+Mh8DXFH4DPapfFPDPDKIlLcD14fydiAicbNUNU7qfDd1v0NW3z/zWGr7m2QeI/Rmw80eoj7zPuHyUvV9YVGBuFd+/7PPPhPuLmSEIfZn06ZN9Pnnn6vcRm5cVxKw0OFvCe6qu3fviuNSRnqQwbme1XFgGcYIv49yrI8pgesFflNcl3J7U4iJjiF1Ih8LFixETkWKUH5Dl2PNZATXjT59+oi/419//VW46PUxzpr8nZuU0EHcAZ7mTp8+Td26dVMsh9sGPn1V4KKZ+cIJMPCZB1+6oUgvCTxtKu9TesrEOhBNCDLNbNGRPr9u3bp36oAgMBfvw93SqFGjDO/BSqFJATRYf+DigAUA21MFjg2xIXCTQPjhu+Imh8/i2JX3mfn7Z56HIFSeh4LHPG5m0vLMrTBys3/lZVLsiGSNk9bDMSjvX9X3UP4/K7L7brhAqvsdsmoFknn/uvpNpPMbbiDJCqQOECAQfsrbxfkEdx1iqiC64Q5DZqSqMUNM0IoVK7LdD7aVletKApmCiDnCuQ/XHiw6ysBKJR1vVschjUVWf9OmhK6+g7qfN/Xxyg3mcL4YGwcOHBD3IA8PD/Fwj4dEPATpY5w12Z7RCx2Y8K9cuSJiHQCefJGtBWsKBhHBmXjCx1OoPkEmjKoMJShL3FxU9V+qWLGiyu1C6eY2LR43OdyIoJ5RbyTz9tCNHdk3cFPAKgE3j3SSIJg3O7efKqR4Del7Ig4G31M5piQz6u4f45ldKX+IRIjM//77T7g6ALaBbeG8yC3ZfTe4GXU1hkDb3yTzGFWuXFlYMyA6Mgsd6ffPCgga5eB+5WBqlCpAfA5iZ7LLzoNFMrNVUhNgLYO7DC5CuPrwNIgAcOVYK+miiQsoozuS0+MVGUYX4O8Tbn88+CC0w1hioAwqZbdt2ybM6tKTXu/evcX8zz//rFgHabfKsTG4GCJ2ABdEuJ0gehAMiQt9fgYp5LgZo7YQ3GywMEEczp8/X2RH4caJNGmIBNQvQhDq77//ToMHD9aqfD7igj755BNhXYPAQgDt1KlTs/2MuvvHbwmxgZsb0qdxo1YGQnLGjBnihVgSWPRwo4RL8osvvtD4u2jy3XQ5hrnZXuYxgjCDuwl/O/CNI3tqz5494sFg+vTpKreDGCbEj+G7KtOzZ0/hCkUcFIKD9QnieyDS4BqG4MP+IFiV49pg5YGYZ9QjMSSje18VT9aso5RM8YMMowmw2MD1jOs0Hk5wzYDIMSYMatFBsCZuzJlRjpvBDVz5RoenXlzMIXDwJAwFyX1u5O4uxDcg9gcZQ0uXLhVjg4BoWAik9OJ9+/aJGx8KzuEpHcGruIkrj3nm4nSZ5+E+gEsDLh58FlYsBAEjU0h5nczZcfjt1Nk//mgQmAvrFFx+yILKfAywIMCVBGEQHh5O1apVE5W1EeCd3TFAWORU1gCBuyiel9V3U/c7ZLVvAGsbAns1HZPM3z+rMcIDANZDMDbGB98VWVRS9pSq8wZiCOcLqo0rW4x69epFu3btoo4dO5K+gFhDXBUujpLVCZlkOG48FeJ7IqMSdXVgZWLUI3jf2xi/Er3eJ/dGb6+zSZER9HDhr5QcEUHxz5/T3R/nUJXp35CFiQZxM7kjNU1Gtx+H0ZuoBCrkYkdVyrmTpYV6D254oIKBAtdJeFWM1eBQQJaXedBGAp78cSODUMoqGBmBnbhRaRrUqMp1xegefY012pEgRR1COr+AGkRwT8EyCouqBMYB9X+QbWbIcxqVkREgDiubKnLzd2sswMyPp2PEIuYmniHy5i26+bW8eKqtZxGq9euid0RM3IsX5D/pa0qJjhHz7o0bUsWvvqQCGtY2M1V0NdamzpkbgbRypz+FRb7NPnZ3taPPuvtRo2oZC6Vmvv6iOwE8LEjEgcs8c2FVfY9zdvfxzOTfX5hhGAGCu+H+k0QOyiEsWrRIuMRyE3ujK2DVzU7kMBlvQM82/66YL9Wvb5aWGocSJajK1K/JIj2IPez0WXq8+rc8rf/FGF7kzFp/MYPIAZjHcryvCsRHwpoM6zemsxI5xgQLHYZRQpXLKT8BVxZcSbDwIKOQMR0irl6jqNvyJsf2JYpT4eZNVa7rXLECVZo4Hv5TMR+8dz+92LYjz46VMay7auVO/2zXWbXrplhPGSleFrXGUPQUcYGmULeKhQ7DKLFq1SqdBDSbMghiR3AyAoMZ0wHWmKeblKw5H/bL0RVVsHYtKj96pGIe1qDgg/IMV8b8SEhKofvPwmnDnlvvWHIyExoRL2J3JPDwg/hC1H6TXNumgtGnlzMMwzA58+bcBYp99EhMO5YtQ+4NG6g1bEVataDkyEgKWLdBzD9atoKsXV3IvX49HnYTBZaYoNAYehoUTQFBUfQ0OEr8HxwWS5p4JxGgjGQgxMnBnY2kDKSPmxosdBiGYUwcWWoqPduiZM356AMqoEHwZ/Ee3SgpIoICd/6DCFK6P38BVZkxlVyrVtHTETO6suJFRCdmEDNPg6LoWXA0JaXkvoaNRVqC6D936dIlUWoDpSBMMdGGhQ7DMIyJE3rqDMU9ey6mnSqUp4J13hZbVJcyAz8WKechx05QWlIS3flhNvn9OJMcy7zbW4zJe+ITU+iZEDPRQtRA0EDYRMVmrDOmChsrCypVzIXKFHWhkkWdacfRB9l+1sPNnmpXLSFKXqByeVZtjkwFFjoMwzCmbs35/Q/FfOn+H2r11A0LkM/okZQcGSWCmlNjY+n2t9+T35wfyC4f9sPKy3o0GbaTmkaBobFyC01gupUmGG4n9Qo74qcv5u5IpSFqirko/i/q7pjheIoWchDZVVkjozbVncjB3k4U6zR1WOgwDMOYMK+P/kcJQfJsGBffquRazU/rbVlYWYlMrJtTZ1DMg4eU9OYN3Z4xk/xm/0DWOdQqyc9oU48GbieIosxxNM9fRVOymm4nN2dbYaGRixln8X9JT2eys8n51t6omhdNHlj3neOm5Bi6tG8JtSuDIqkZ+zCaKix0GIZhTJS05GR6vnVbrq05ylja21OVqVPoxqRvKCEwkOJfBtLt734k3+9nkKWJFmPMi3o0mZHq0UBM1KhQWMTNSDE0Aemup+g41T39lLG1saRSns7CMqNspXF1erdZtSY0quZF9X2LCUvUlRt3ad7sbynw0RXatHGjXiui5zUsdBiNQN8sFHDT9o8gt583N9ACBUW3PvjgA0MfCmOCvDp4SNHXqmDtmuRSuZJOtmvt6kpVZ0ylGxOnUHJ4OMU8eED35s6nSlMmCasPo349mjkbLlGamqlO8CwV83BSEjNyK03RQo5koYUbTB0sLQpQxVIu1KnVh6KC8ZXLl0X/PXMiV2esVEXTFKOwTcVfqy7jxo2j58+fi0ap+uTly5cZmi1mB5qMIiVROR1Rk89LQgDfCzg4OFC5cuVE5H/Xrl3JHED3cvSqYhhNSU1MpOdKBf5KfahbsWznWYSqzviG/KdMpdTYOAq/fJUeLl5K5ceO0iijy5zBNT6nejSqRE4hF1sqrXA7uSjcTrbWedeGIz4+XjTvRRNONAEuX768ybZQ0ZnQgbBBA0JUTEUDSdy0AErHN2vWTDyV4qaW34XPGf9AWrXzpsb9Q3IDuryjyaO+QQPGggULqrUuzg/8IWn7eUkI9OnTRwg5CCQ08UQhO5yHrVu3JlMH3cdz6tPCMFkRtGcfJYdHiGn3hvXJycdb5wPlWKYMVf56Et2aPpNkyckUcuw42RR0ozKDuJM8wIOsOiA42M/Hg0oXk7ufIHBy63bKLY8fP6aePXuSt7c3bd++nfz8tI/tMnbUluUHDhwQbocBAwaIZoroc7F+/XrxgukdRYU++ugjsc7Bgwcpv3LuZjDNXn9Jq/4h+gQN0NAJGs0RK1WqJDplh4W9rXoJ0Hzt448/FqoeJb5RCbNu3br0999/K9Zp27at6G0igXUgcmG9gQC5fPmywhIDYYKO0xDCtWrVyvLzycnJNGvWLKpXr57ofDtq1CjRpE0ZCAFso0KFCqLLN9ZDEzlljhw5IhpTonIn6j5s3LjxnTFAV+zq1auLju4YixkzZmRwGU2YMIE+//xz0cQS3dAbNWqkaEz3888/i2PE93z//ffpxo0bGbaNjvEYMxxjp06dRO8odd7r0aOH6BAugTGbOHGiuOhgfXQeh9hTBseGCs4YW6yHsda3JY8xLlLi4ujlXzvlMwUKiCrI+sK1alWqOP5LRauIl3/vopeot8MIa706jO5TQ7y6NvWmaj6FDS5ydu/eTbVr16bo6Gj65ptvyNxR26KDJ2rcZHBhtrGxyXIdiB3cFFFCH0/u+dFdtWb37Rz7hyD4S59urKyAVeTVq1fiBolO1PiNOnfuTGfOnFFY4KDuIWI3b94sBAh6HuGGruxaUXY9wRoxaNAg+u2334QgQjPISZMm0aFDh8R5gCeFOXPmCCufZXop+syuq759+9L169eFkIDAgghC/5TvvvtO5XdxdHQUf6AS//77Lw0cOFBsAzf9u3fv0rBhw4Q16bPPPhPrrF69mqZOnUrLli0TQmfNmjU0c+ZM0Z1b2Sq2du1aGjx4sBiDwoULi+XY1tWrV8V3KV68uBAuEEH+/v6iNxbO9d69e4ttQ/Q9evRI7AutFDAmqt7DmGR2XWHfGA+sj2abGE+IQyyTxjAwMFB0DYZwQ8XSvXv3CsHm6+srRCBj/gT+8y+lpP8NFG7WlBxKldLr/twb1CfvYUPp0dIVYj5g7XqydnOlIi2aU34GIQmw1mfnvkI9GqxnLEyfPl1cX+H+h6ECbitzR22hg4t6Tm3WIYBw4+rVqxeZE18uOEbh0Yk5rpeckkpRsck59g8ZMGMfWVvl7Ict6GxLC75sQbkFggQWOdyQpRsh3I8QIrC+QYigtxFeDx8+FHEwADd9yRKTFehuXbp0aYVVBNaUDh06iGk0xoSAcnd3V3TFzsz58+eFIELVTTxdAFicYEFRBb4HRAfidCQmT54s/nghdgAsIWg+ByEgCR2IFIiD/v37i3mIoqNHj76z/VKlStHy5csVogLjAZH05MkT8V0BxAUEGUQjrD8Y10KFCokO2/jOGId27dqJ6ezeywwEGixkZ8+epQYN5OX74arDfmFaxt+WBEQoRBGAlWnp0qXi+7DQMX+So6MpcNdu+YyFBZX8oE+e7Lfoe+0oOSKSnm2R1+x5uOhXkXJesFZNyq/ggbVnSx9aufOmynWGdvPN8wfb7HBycqLZs2fTmEGDKDXsDcWEvclyPWsXZ7JNf9jLN0InJ5GjjHSTMBcgcnIKONMEuRhSL61QF8AaAOuE8k0QN09YI/AehA6ELCpgSiIHwPKBAGBVtGnTRtz04Y6BuEXMDISCuuCGDiEkiRxV5xpECcQGLEHh4eFC1EA4wPoElxwEFwQH1kMcGV6w5kgusISEBGFJady4cYbtwipz//79DMvg2lI+f3GMoHlz+ZOrtH1Yf3DBALDUYBnGo1+/fmIcpHHM7r3M4LewtbXNUIEUvxvcwXhPWejAeqOMp6cnhYbKs28Y8wauo9R0q6hn61ZkX6xYnu27RJ9elBQeQcH79otChXdnzyPfmTNEJ/T8CP62L915rdKSA5Gjr7hMTTh79qzoNo4wE1yzE0NC6PLw0SLuShUFrK2p9rLFZiF2dJ4nuG7dOuHOMCdgWVEHdSw6wMXRWm2Lji5AVD1uoJnBMrwnuR2zckmqclMCpCBKVgjEmYwePVrEycBaBPdYTkCoZHVcmUEsClynERERwjIDtxNiaTw8PBTHP3/+fBGbkxX4brggZf4uWe07c8YBRBLWQwn0zFYYe3t78T9SMmG5wTjA4jR+/HghomCtyu69zPvCd7G2tn5nP8q/U3YPE1IWJGO+oB9V0L97xXQBKysq2Tdvrec4N8sNHSxaRYSdPUdpiYl0e+aPoqCgQ4nilN+4cCuYrtyTCx24sBCHExOXnCeZtuqAa8LixYuFNRtufcRm4tqcHBWdrcgRn01OFuux0MkCPGmbm9BR132UkppGQ344lKO/dvXXbfP0DwCuDcSCICtLijuBJQRR93DzALhUED8Di4mUFfXixQshLrIDlgQ8JeCF9SF+EKMDFxZuxtndfOGmwnHhc6rcW8rByHhJ7jQInw0bNgixI4kJyS2V1efxvWH5kSwzAFasnIA1BWIHx4lgZFXAPQV3Gl4YZ1jLIGbg1svuvcy/U0xMjPhdJKsPBM6dO3dEkDjDvNj+lxAXkivJEDehApaWVGHcWLr1bTRF3bwlYoVuf4vqyT+SrXuhfPMjJSWn0up/3rqshnTzpdqVPMlYwLUED4lbt24VyRd4SFTnAdQc0agYQkBAQI6v/AzEy6ddsu/2awh/LdwmEDQQI3DpwMIBoYCbf7du3cQ6iBuBkIDFAe9jPayTHchs2rJliyKFHIIF8TWSmELgLoJxVYF9Quwg1gQZX+DKlSu0cuVKlZ/BHyoKDuKPF7E9eMKEKXbhwoXCqgRhBUvR8ePHRbCxBCxAsPrAhQUQ85JVjE5mYH1p0qSJiPWR3Fy4gCA+B0HJAL1gYGWSgooRH4RgboxDdu9lBkIKL2Q0Yh/4Hog/gmDkgoIMCgMG7zsgBsLCxoZK9H7fYIOC/VeeMpEcy8oLyyW+DhFiJyUm/9SE+vv4Q0X/qWo+HtTYCFxUykybNk3Uxvnzzz+FWx/W4vyKRkIHT6I5vfI7DXyL0qSBdYQZM7MlB6XA9emvhR9WsnxIL1gCcKPEDRcBtYiwh4UDaeA7d+5UuE8gIPAHARcN3odI8fLyEtYdVe4ruIpQzwZWHVhWunTpIjKm6tSpI97/+uuvRewMApOzCmrGPuHOwR8g9odjgyCBiTU7EFOEbCmIAACzLEQNsqMQN4NjRlaBcqHCKVOmiNgXWE2wH4gepMNn55qTgKBBSjfid7BtjCsEmXSciP1BwDfGCwIGViOkbEJgZvdeZiDa4PaDtQ1WIPwOGB9Yf7jWDvN823aSpaSIgSjWuSPZaFCPSh9YOTpSlWnfkK2nvOFn3NNndOeHWaKQobkTEh5P2448ENOoWDy0u5/R1I9Ddi1ALCMeBnv37q14LzU+nl4dOkwPFi6h/EQBmQaO/ZIlSwrzV3YBp02bNjX6WAHcSFxdXUWwauYbCNwUEAQQbZpWiJSsCbiBp8koTysjw+WUVYVdfAeIEAl8ZxxndimFCGpFkDC2if+RjSXVlEFqM272UnwKSE1NFWOaVSFAWHiwPayDYOesPg9gFYKlI/PvAQsIAqIzL0d6ObaLoGopeBnfC7WB8NuqenrB5/D7YP+wZkGkSRYkfF9sAyIjK3B8cOVlZY2Rvivez+rzqt7D98N3yxz0jePE/rLaFtxo+P2UxxAuMcTy6FoQKZ/TxnIhz4rc/N0aCzhHYNmEKzZzQH58UDBdHTlGBACjF1XtlctEVowxEB8YSP6TvhZdz0Gh+vVEY1C4uExxrNVh7sZLdPKavGBu5yZl6fMe1cjQwBIP6zYs7XDl4wFT+huOvnuPXh0+QqGnzlBagvqJNdV/nkdO3lknT+TFOGt7H8+MRg67oUOHiniBDz9EV1MmOyBqUAkzr4B4UKfiME4MVeAPRLJc4EaLwDXE3CjHpsAykRlYjFTtGyc3TvLsPg9w084sfoD0x5oZWG5wQ1O++WJaWdQpgzRxWKtQ1BIiCNYr1N9RLm6Z0/jhc6pEjvRdVYkkVe+p+n7OzqpvYhCMmcnuuBjT5/kffwqRA7y6dTEakQPsvbyEZcf/62niJvrm/AV6tGIVeQ//3KjFsbb4PwpViBwXRxv66D3d9BfLDQgbQK00WHAWLFggHuCSIiIp5L9jQuDEv5Afb35FI4mFwCbJLKYKmMsY0wQCB5V4ccOHYEBwMorRmUMAG6yRcO3hAgCRhIKJiLMxhzYSjHkT9+w5hRw/IaatnJ3Iq2tnMjbQfqLy5AkiEwy8OnCInv++lcyN1NQ0Wvn32ySGAR0rk5NDzu5vfYJK6wgNQE/A48eO0Qf1G4i0/0uDh1LAug0ZRA6sgZ7vtSWfsaMpP6HRHQxP49kFigKU1WdME1hz8ESAQFjErqgTv2IqwK2DcxcVh+Hi45gXxlR4BsGQHg5QvEd3ERtjjLjVqE7lx46m+z8tEPPPt24jazc3KtaxPZkL+88GUECQ3EXnU8KV2tSTFxE1JLAUd2zYiCZ27EQxq9bSnTfvFgB0qVKZPNu2JvdGDcnSzk7U0UGdnJzq6BiT5TA3mP6jOqNzpEJ45gjcbCxyGFMh5vFjCjsjL1opREMneeVxY6VwsyaUHBlJT1b/JuYfr1xN1q6u5NE4+wQDUyAyJpE27b+rmEdcjqHq5CCe8Mdvv6WxHTpR6omTNJQs6c3e/RnWsS7oRkVatiDPNq3JvnjGkAGUJUAxQNTJUUW+rIzMMAzD5C3PNsvbLYASvd4XT+PGjleXTpQUHk4vd/wtLFH3f/5FuNzcqpl2d2yInJh4uQWkVZ2SVKlM3tcMQmDx5T17ae/sOdTWtSA9fbI84wqIBaxbm4q0bk2F6tTKNiDctnBhsxEyOcFCh2EYxgiJunuPwi9dFtM2Hh5UtH07MhVKf/yR6Iv1+shRkRJ/98c55PvjTHIqZ5olSB6+iKAD5+R14uxtrWhgp+zrpekaWF4Qp3Xnz21kFxVNrd0zChQ7Ly/hmirSsrnByw4YIyx0GIZhjJBnm39XTKPVg4UJFXwTDWxHDqPkqEgKv3hZ1G+5/d33VG32D2SnItPQWIEVBQHIUtWUfm0ripIhet8vSlJcv0GvDh0RmWwQjMp7tbC1JY/GjYTAca5cySwz3HQFCx2GYRgjI+KGP0XekGf3QBgUadWSTA24TSr+7yu6NfVbir53j5LDI+jWDHmrCBs31WUujI1jV17QnQB5gG/xwk7Upan2dWXUIeH1a3p95D9hDUM17Mw4VSgvxI1Hk8ZklU3TZUYHQufBgwei/D/68qxfv14sQwl+NHVUp1EjwzAMk7UF4dkmJWvOB33IwkRLPFja2lLlqZPJf9I3FP/iBSUEBdPt734g3++/JSuHd+tmGRtxCcm07t9bivmh3X3J2kq3he9AWnIyhZ27QK8PHxFWHIX5KJ1UGxsq2b6dEDgO2RTsZbJGq18MfYRq1KghKuaisaLEmTNnaOnSpdpskjEDRo0aRTdu3DD0YTCMSRNx5aqwgAD7kiWocNMmZMpYOztT1RlTycbdXczHPnpEd2fPFTd3Y+fPw/fpTZS8pUX9qkV13rQzNiCAHq9aQxc/GUL35/9MEdeuK0QO/j33Kph2Uir5LltMZT/9hEWOlmj1mDBp0iTR+h3NGJX9ggMHDhT9g9Aplclb0NUbwlOq4It+TGhx4Ovrm2fHsG7dOmHRQz0efYMGpaiHg/NPOgdRTRhVQQ0JCmaiDUpWvawYRp24jOdb3mZalfqwn1G3UlAX28IeQuz4T/6GUmJiKPL6DXqwcDFVGPcFFdBxawBd8TIkhnadkDcBhhUH3cl1ARqfhpw8Jaw3MQ/l21fGurAH7X/5gpadOE5fTJtKc/73P523T8hvaCV0/P39qW/fvmJaWeig71B+72AOn2pCXJzKwDB91SaAlQ2Vf9HrBL2J0EgSVje4F1Ea3NxAuwp0P2/btq1irI2hxxGap6KyNAsdRhtir12n2MdPxLRjubLk3rCB2QykQ6mSVHnqFLo1dQalJSVR6MnTosZO2SEZH5iNxX24aqc/paTKrSs9WvhQUfesCzWi+F5O9WiQNRd185ZoxxB25pz4/pmL8+G3hmvKsVJFmt+/P235d7doXswYSOg4OjqKRl1ooKd8gqKjs6rePfkBnPA3xnyZY7VJFGrSh9hBDyS06QDo5I1+Vegerix00OkbTdDwhIC2CLD6KFtgEhMTaeTIkTRhwgThioQrCr2qPvvsswy9mtCsDWIDlZQhcFX1P0Pn76NHj4r9oZu4ckdxaV9jx46lCxcu0M2bN8W+0MEcouW3336je/fuiY7j2H/mSs3oRo7vm9VFEs1DYWFCDxj06/rkk08y9IPatm2baHGBCwk6hsfFxdHChQvFe9gnlqFBKPYNS6VyEUU0E4XLFqK+XLlyokM8mp/OmzdP7Hfr1q3iu4Dly5ebRQsNRv+gl9Wbf/5VzJf66AOjEwC5xaVSRao44Su68+McXEQo6N+9Ih0aNYKMiYt3XtHlu6/FtIerHfVuVV7lNf/y8NHZXvNR28bW3V2smxmIWRT082jWhJavW0d1YmOooY2N6MXH6A6t7GE9e/ak8ePHixupxPnz58VNxxytB+oCVZ/tCY+LWXJytupfl+Am/ezZswzLateuTQ0aNBD/o+N148aNRXNLCXTMXrNmjbCUwBUGEYP30b0c7yk3eJ04caIQttgOtgnhkjlmBwIDFg6I4169etHUqVPf2RcsMxcvXqRSpUrRpk2bhPho0aIF3b17VwgJCBC4SdXl/v37wmUHoebj40MHDhwQYg7CRvl8/eGHH+iDDz4QjU7r1Kkjlv/999/UsGFD0Wkcn92/f7/oAYZ5qWMuxu7YsWNUvnx5IWxwrGibUaVKFdGYFGOG8cDL3G5UjP6AhSM5KFhMO1eqSAVr1zLL4S5Utw75jByumH+6cTO9OnyUjIWk5FRavVP+oAIGd/ElO1srra/5EHTKIsfS0ZGKdmxP1RfMoxoL5pNz86b08dChwh2Ph0JG92j1qDlnzhzq0aOHeIrFkz2e9FGSGg0Sv/vuO90fJaMx+F3gzvLzy1iNNLPlBeICv1nnzhkbBfbv318IAQCLBSwtaB4HEQIrD2KCIE5w0wfe3t7CEiOBdRCYfuLECWrSRB5MiXUhhCFaYA2UQCPR77//XmGlgfjC/Ndffy2WVa1alTp06ECrV6/O4J6CVeb27dsKMYFzslOnTjRlyhSxL0nAwWKE7SJ+BtuQgDi5fv26oqM6rDoQ6xBf2BbAxadZs2b0008/0cyZM8V3hkUHGYbSfuEuRFwU9g1RB4EjWdYYRq2/15QU0aHcnK05yni2aUXJERFC5ICHvy4ja1cXIYIMDeJygsJixbSvtzs1qZGxfYKyBS4p7N2+UqpwreYnrDeFGtQT2Wjgzp07wnCAhpywBOdnQ4HRCR0EfR4+fFjEhMB1gZsquqciCNMcuTZuAiVHhKt1sVKHW9/OVCtd1NqtINX4eS6pC1wuuMEiRgc3ZJDZBAqLBOJ2YPXANKwc+GPLjHKMCYQs3D5wAwEIKLiDJJEDELOlLHQgcIoXL64QOQBuMpQegKVFWegodxCHFQW0atUqwzKcY0FBQRk+B5GmbDXB/gCsLRDjyv2t+vXrRytWrMjwHWGpkUQOwPn85s0bIZBgBYKfHi+I+GvXrimOBeP77bffCpcWjkfZJcYw2vD66H+U+OqV4oZo6u0S1KF4zx6UFBFBQbv3CKvHvbk/UdXvppNL5UoGO6bQiHjaevi+mEYbq6GdKlH8y5ciLT4hOJgSgl5RQnAQxQe9osTXr0URP3Wo/PUkKlSvboZlqamp4oEKbn247itXrqyX78TksmAgTPx4Ifvl0KFD4ik+LzJu8hqIHE2Ue06kRMq73+oaNKuUXEhwqcBtBbeMBCwREKS4WSM7qlKlSkLkwD2TGbhglIFYwB8mQHwWrHnKYD/KsShYx8PDI8M6ECT43Kv0C3pW+5KyC7JaJu0/uxgdiBCIlcz7xnzm/bq5uWWYx/hgW9iucpZDvXr1RPwTgFsKIv+XX34RQg/fG/FDyEQ05ydwRn8gMPX5H9sU8yU/7Jcvhht/L2UHDxJNQENPnBLjcOf7WeQ363sRuJxXpMTFKUTMwX2XqOWLF1QwOYaKWcRR0NiNFJSppo02SKn1ICkpSViT8QCJ5AVcU8y5kbLJCh2Y7WFmg2UAT9p4Ir969aq4yWCZlJFlLsCyog6w6KgjYqxcXdS26GgbjDx8+HAROwKrw5EjR8QyWCpwA8eNWrqRK7ty1AVBzLDuwNoh3dwhrPD7K68DcyzOD2lfEGDBwcHCEqMvILYwDk+fPs2wHPM57RcWIXwnxCNll5YPyyVe+G4YW1iqEK+DGCQWO4ymBB84RElhYWLawc+XnCtWyDeDiNTy8mNGUXJklEg5R+q5/zfTxTKbghkfRLTNWsXfNLYvFzNBlBD8iuKDgij62Qt6GhZGKVFvr9ml0185YWFjQ3bFipKVs7PIplIXWNDhnoKwgdUYbnnGSIUOzPZSNWS4IXDTQ0AqrDqIYzA3oaOu+yj64SO68dWEHNerOn0qOXnrt4w4xMWiRYuEBWf37t3UpUsX8QcPsYEnCsS64KliyZIlGm+7Y8eOInYFbjHpt85cvwbrIDYG2UmDBg0Sy7AvWGqU3VL6AIJj1apVIhYIFxRYeJDBJR2HKmANg7ULMT7bt29XZHlBsEHIwdIDqyXcbwj0xhhDTCIuBxlaAE9p2B/DqENqQgK92LZDMV+oW8ZYufwAenhVmjSBbkycQvHPnlFKZCTdmSmPD1Q3axXxMolhYULEyAVN+itd1KQlJGh8XOi4jvYbEDTi/6KeZF+smJi2LugmHmpiHj2m6+P+p9b2EGgMFzquK4gvZIxc6CAbBk+w0o8HPyPcJri5DRgwQNfHyGgJ6ugg+Hjy5Mnit0HQ2+zZs6lmzZriPYhUbcoBoBgh0tbxWyNLCrE+EE/KrT9gHUG2FCxLEESw9iCYGUHMymnq+gBBxydPnhSB2HA7IXsMsTRImc/JGvTXX3+Jopdw6+GzsEDhhQBlAHEDIQWXFbZ5+fJl8vT0VAQR4rMI7n7y5IkYD04vZ7IjaM8+4boB7o0akm3JvHPZGBNoB4HKv7enf5vteshwCj13gWBHVgga/P9K/XgZZWzcCwnhEmLhSOdeplC4tRM5FS9Gk77sSLYuzqQrNm7cQKNmzhQPefB6cFyfCQgd3ByRngvzPXyMsPBIZjkpliE/ArMqnjhyqqOD9XQNrBfK6f4Sc+fOpb179wqLAzKnEFQLdwvSpWG5QMwM3peApQfWEGRRKYMaMVIKNhg3bpyI80HtJCmdGn/ACPBVTkFHthQEDgQCrDvKwiqrfSHQHcuU3UyIr8EyHL8ErFWq4sEgpBCMjaBpWBtRqwfnqrJbCcIEKfSZgTiCkMcxSzV4YMmRrDtwaWEMUZAR7jAEYMPVJbnnUBUcWVqIfUpISGBXFqOSlNhYevnXTvmMhQWV6NeHYvLxeFk7qxenErD6N/U3amFBdkWKvLXKFPMku6LFyNazCEVZFKCiJUpQTHwK/TjrMMUUkl+35w5oqrbIUfeab+nkLK63M2bMEPGOTN5SQAZ/hoYg1XbatGlCleIpGMXRcNOaNWuWcIdIacnGCiwQeCJH4TxYopTBzQlP43ha17TSLoYyNiiYZAaojJzfwFjDSoTzj+NieJxz83drKJ79vlWRUl64ZQvyGTNSBPFD0OfHkv+auIGyipeBa8lOuJYgZoqSfbGi4lqbVQsNxNdJY738L3/ad1Ze0b9l7RI07sO32aTqoKoyMrJgL1w4T4NHjsy31/w0pXHW9Tmd3X1cJxYdVNfF0z2eaOESkS4siFUYMWIE5WfQ04VvvgzDZAdujIG7dotp3IhL9evNA6YmRdq0IpcqldPjZoqSTaGCWj/sPH4ZSfvPyUWOva0lDeqseXAwRExmIQMXPe6FKCI6aOJErY6NMYL08ubNmyumpfRymPCV05kZhmGYd3n5905KjY8X00XatBY3bDz9MjlTrGMHnSRziH5Wu25KzcKpX9uKVMgld9bA+Ph4Gj16tIjpQwYsml+bioXRnLHQNr1cqrArpZcj+wZBrkg7ZxiGYbIm6U246PEkxW+U7NOLh8oAXLgTRrefyDMkixd2pC5NM8YlagMKlW7evFlkeSKukEWOCQsdBB8jkydzejmyaxCnwzAMw2TNi+1/KbpXF23/Htl6ZCy+qWtS02Tk/zCUjl95If7HfH4nPjGFth9/2wdwaHc/srbSPoYEcSgAmZ2ocowef4zxwOnlDMMweQQCV4MPHBTTFra2VKKXvKeavjhzI5BW7vSnsMi3dWTcXe3os+5+1Kha1j2c8kPW6rYjDygiRr6felWKUu1KnlptB9XaUc4CWaD+/v4iAzVzf0HG8HB6uQq0SEZjGMZAmEp8y/Ot2xX1Xry6dCKbTG1IdC1yZq2X97xTBqIHyycPrGtUYgcBvSgGmFUGky6zVgNDYkTjTmBlaUFDuqmugp4d8GJ88MEH9N9//4m6YqgGz5iR0EFdEmRbSenlqKcCUO3R1Ksiows1IvhxEuP7aRLNzynPeQePNY+zdB6gWCX+XpG+KtU7MkbiAwPp1ZGjYtrSwYG8unfV277gnoIlJzsQiFvftxhZonulkZBVBpOuwfdOSZU/yHZvXo6KeThqvA0UCkXrl+TkZNFSp2XLlno4UkZXcHp5JlDMCZV/EXcUECBPO9Tkoiv1duLaLvqFxzpvMJVxdnBwEEUmjbn+jGjcmW55Kt69K1k7675wqMTtx2EZ3FWqOnVjPT+fjA1wzZmLt4Pp0h15c183J2vq3Vpe4V9T0BAYxVFXrlwpqsAz+SC9XGLYsGFkDqA/ElpcQK1rAm4IqECMasPGfME1B3iseZyVH06MvXZV7NNnFHLipJhGI8hiXTrpdX9vohJ0up45kJySKqw5Er1blCY7G/VvgSiGi0QcFMtFNfc9e/bo6UgZoxE6EmgloNy1WirZb+rg4qlpqW7cfOH6QkohCx39wmOdN/A464bnv/8B85iYLtGzB1k5OJA+UbceTG7rxpgSO48/oqDQWDFdtVwhqltJ/Z57aAvz/vvviwa/cFk1adJEj0fK6BqtzA4oufzpp5+KssuohoxYFuUXwzAMIyfm4SMKO3teTKPrddGO8phGfVKhdEGysszewoV06jLFsi+dby6ERcbTn4fvi2mEJA3t5qu2BRBlU+rWrSvWRw89Fjn5ROj873//o4cPH9I///wj5s+ePSs6VcNlg+7YDMMwjJynm39XDEXJ3r3I0tZW70Ozce8dRcCtKpJT0uh/i0/SyxDzbyW6dvdtSkhKFdMdGpWlsl7qVfBHc95+/fpRly5dRCPrSpUq6flIGaMROvBNrl69mlq0aCHm69WrR2PGjKFNmzYJ9cswDMMQRd2+QxFXrir64Hm2a6P3YTl57aUifRqhgq5OGTPRMC/FpkDkfLXwBF25Jy94Z47cehxGx6++ENPODjb0UfucxQqy+BCIX7lyZVEUF9WOEbvJ5KMYncDAQPLx8RHTcF+9efNGxOU0bdqUbt26petjZBiGMTlwo8xgzenXhyysrfW6z+evomnRVrmwAp/3qEbvNSgjsqsQeIyYnCrl3CkkPI6+/+08PQ2Optj4ZPp21Vn6pIsvdWtWzqiDurVKs//7bZr9xx0rC7GTXd2lo0ePivo4U6dOpVGjRlGDBg3y6GgZfaF1apD0xwBT3l9//SWmDxw4YBaByAzDMLkl8voNiropf/Cz8ypGRVrKLeD6Ii4hmX5cd0HhomlZuwR1aFhG1MlBCnnzWiXE/5gv6u5Ic0c3pfpVi4p10RVizT83aeHWqyI7yVw4eC6AHgdGiulyxV2pXf3SKteF+EHoRdu2balatWomXxOOyaXQqVr1bSv7r7/+WnRrLVq0KPXu3ZsmatiSHg1C0RTU19dXqGjE/mRHQkKCOBmbNWsmSm136tRJESvEMAxjNNacTW+tOaU+6EsFNMzi1HR/i/+8Ri9ey+NtEGQ8olf1bK0zDnbWNGVQPerbpoJi2ZGLz2nK0tMUbgZp51GxSbRx3x3F/Oc9/FQWR4yNjaUePXqIHo5Tpkyh/fv3c2JNfhc6N2++rUXQtWtX4a765ZdfRLVIiB51+ffff6lXr14i0Att7fHHCvcXXGGqQCzQkiVLRED0li1bRJwQTtC9e+XdgBmGYQxN+MVLFPPggZh2KF2KPJo01uv+/jn5mE5dD5Tvz85KtHdQp0aMhUUB6t+hMk34uA7ZWMuF2N2n4TTul+P08HkEmTKb99+h6Dh5LbQWtUpQlbKqm6fa29uTo6OjuCfNnDlT49IijHGjk6p2iNdBZHqNGjU0+tyMGTOof//+9MUXX1D9+vVpw4YNopz7smXLVH7m0KFDIrUd4ggWHQgeWINQhpthGMbQyNLSMsTmlPqwHxXQYwFRBNuu3f02NvLLD2qRV2HNAmeb1ihOc0c1IQ83ezEfGplAE5ecpBPpQbymxpPASNp/Vl7Z3s7GkgZ1rpLleuvWrRMxOah7hgdneAiYfByM/Mcff6i9UYienIiOjqYrV67Q+PHjFcvQp6ZNmzZ07Ngx4RLLClhw0EQNAgdR8LAuPX78mL7//nu1j49hGEZfhJ05S3EBT8W0k483FapfT2/7gotp7saLIugW9GpVnhr4FtNqW94l3OjnL5rRrHUX6U7AG0pKSaN5my5TQFAU9W9fWVh/TAF4Blb87S/ijkDfthXJ3VUu4JRDIL766ishbiZMmECtWrUyzMEyxiV0EH2uS6GDXlI4IRHbowzmb9y4ofJz6C0yYMAAKlKkCBUqVEi4uX799Vdh4VFFYmKieElERUUpgs902fUY25J6AzH6hcc6b+Bx1gxZaio93fL2obDkh/3ENQEvXY91amoazd14id5Eya9tft7u9GG7Crm6/rg62tDMzxvQ8r9v0uELz8SybUceCLEz7oOaIq7H2Dlx9aWwcgEvD0fq0qRMhjF58uSJiCdFjZxVq1bR4MGD+ZptgtcPTbapttAJDQ0lfRwkWiYoA6tOaqrqqH+k/J0+fVrUNUC/kYMHD4q4HUwjQDkrZs2aJXqUZFUrAcpel98JVaPxw3ILCP3CY5038DhrRtTZc5TwUh4rY+fjTYlexej169d6Gettx57RzfQbOhpUDnqvNIWF6eY63adZUfJwLkB/Hn0qLCMXb78ScTujelSgIgWNt20EMs7W/PM2nbxX8xIU/kY+RgBji1YOGGfcQ5A6ru7vwxjX9QNeoTzrdaUtUho6mmBmFlSqUtQxYPPmzRN+VQQgA6QBojIzAsgQv5MViKQfN25cBotOyZIlRVQ96gDp8kdFlgO2y0JHv/BY5w08zhqMVXIyvdi7XzHvPWgAuXh66mWsz9wIpIMXg8Q0Wj1MHliPfMqo37tJHT5o70mVyxUT7quY+GQKCounWZtv04SPa1P18sbZ6gdZVhEx8gDkupU9qXUDeUYZHp7RlxHV+3///XfhEUDTZr5Wm+71Az0l9Sp0nj59Kk6WSZMmZViOtO8PP/yQSpUqleM2PD09hdiASEHmlgSsNe3bZ90LBu4nDBz6aymD+aAg+R99Vtja2opXZjDwuh58/Kj62C7DY20o+JxWj1dHj1Hi6xAx7VajOrn5+eplrF+8jqZFf15XzH/a1ZeqlNNP/bJalTzppy+aieKCz1/FCMEzY/V5GtLVlzo3KWtUxQUDQ2No5/HHYtrK0oKGdPcV4wjLPUqXxMfH06lTp6hKlSriPgJLDl+rTff6ocn2tNozUsiR6ZRVfR24kdRl2LBhopUEOsNK8TcILB46dKhiHdQ06Nixo5iGCocFZ8GCBcK6AxDPs2PHDlHkiWEYxhCkJibSiz+3K+ZLffSBXvaTkJhCs9ZfpPjEFDHfvGYJ6tS4LOkTLw8nmj+mGdWpLLdOpaHa8E5/WrLtuuiXZSys3nWTUlLlx9Ojhbc47nPnzlGtWrXEfQJWf2MSZkzeoZXQQTpe8+bN31mOZciIUhcUF0RQWPXq1UVgMTKt0C8LaeMSUN3PnsmD4gB6aaWkpAiLkJeXl0hLR/CzqiwthmEYfRO8/yAlpdf/KlS/LjlXKK+fooDbrtGzYHlsQqmizjSqd/ZFAXUFgpC/GVxfZHVJHDz/lL5Zfpoiot8mehiKS3deiTgi4O5qR71bV6AVK1aIuE14GK5evcqZVfkYrVxXzs7OdP/+fapdu3aG5ViGwkvqgqJMS5cuFXE3yJ4qVqwYWVlZvRNIrBwwXLFiRTp+/LgwQ+IzyNLi4k4MwxiK1Ph4erlD3gaHChQQdXP0wb+nnoiMImBvayWqGtvZ5l2YJaoKD+xUhUoXc6HFW6+K9PPbT97QuIXH6ZtP6osWC4YALStW7XwbgPxJ56pifBCuMHLkSJo7d+47SS9M/kIriw6i1uFeun37tmIZqiMPGTJEvKcpqEiJeJ3MIgcgiAnvZQaCqnjx4ixyGIYxKIH/7qXkSHnJCo8mjcixTBmd7+NuwBvRi0rii341qbiGRQF1BaoMzxrZRDQIBSHh8TRhyUk6dV0uwvKaf048psDQWDFdtqg9nd6/UUwPGjRIhDmwyGG0EjoIOka2EmJykCGFSHbE7Li5udGcOXN4VBmGyRekxMTSy793yWcsLKhkP903goRraPaGt0UB32/hQ42qeZEhqVCqIC34sjlVLCVPDElMSqU5Gy7R5v13RQxPXhEWGU9bD98T0wVIRtt+/ZI2bdqoqJXGMLlyXaF68cmTJ0V1Y/iIa9asKfpUMQzD5Bde7vqHUmPl1gR0J3coUVyn20dRwHmbLlFYpNx97+vtTgM6ViZjABadH0c0pl+3X6ejl56LZX8cukdPg6NEGwq4j/TNuj23KT5RXnftybX91KJhNVEEEFXzGUYiV2cihA2LG4Zh8iPJkZEU+M+/YrqAlRWV7NtbL3VhbjyUFwEs5GJLE/rXIUtL4yldgUagcKOV9XIR/bZgzDnrH0RBoSfp60/qUVF3R73t+/aTMDp2Wd6LKyk+mgZ18aNxY0dwZhXzDsbzF8MwDGNCvPhrJ6WlJ0p4tm1Ddp5FdLp9CIYd/z1UBAJPHFCXCqbHxRgTsOh3b+5D04Y0IEc7+bOzaBnxywnyTxdpugZuvF+3XVXM92hWir76YiSLHCZLWOgwDMNoSGLYGwpOr4JsYWNDJXr31OkYBobE0C9/XFHMD+5SlaqUdTfq36l2JU+aP7YZFS8st+JExyXR1BVnaO+ZJzrdD4r9ffXtCnr2Kj0A2cuFhvbhsAlGNSx0GIZhsiExJIRiHj3O8Hqy+jdKS0oS73u0aEa27rprv5CQJC8KGJcgLwrYtEZx6tK0nEn8RiWKONP8sc2pVqUiCsvLsh03aOn264pifrkBbRy69+xLd0LeusQ+71FNWLwYxuh6XTEMw5iCyLk8fDTJkuX9k7Ii5L/jVKpPL7ItXFgnRQEhDOD6ASU9nWh0nxom5ZJxsremaZ82oPV7btPfx+Sut31nA+j562iaNKAuuTq9245HHVDCpFu3buRavgN52bsoKkNXLWfcli7GhC06Dx48EB3BBw4cqFi2a9cu0Y+KYRjGHEiOis5W5AC8j/V0wfFrr+nYFakooKVo1pkX2Uu6BhYWuNu+/KCm6DsFbj4Ko3ELT9CTQHn7Hk1xdXUlnyr1qHjVNmLezsaSPulSRafHzZgnWgkdVCauUaOGaMC5YcMGxfIzZ86ISscMwzCMZtx7Fk5/HH2qmB/TtyaV9HQ26WFsVacUzRrZmAo6y604r9/E0YTFJ+msf6Ban0dV/MmTJ1NYWJgoEFvjvREkSy/T06dNBXJ3Vb8SP5N/0UrooGv54sWL6eDBgxmWw7qzbNkyXR0bwzBMviAyJlEU3JOKAnZr5k1Nquu2Jo+hqFS6kCgu6FPSTcwnJKXSj+suipo7cNWp4smTJ9S4cWP65Zdf6PLly3TqWiDdehwm3ivm4Ujdm3vn2Xdg8qHQ8ff3p7595RVAlX3HpUuXpoCAAN0dHcMwjJkDcTN/02VFUcAqZQvRoM7m5ZKB5WX2yCYipkYCVZQh7tCRPTN79+4VvRQRfHz27Flq1rwV/bb7bQuMod18ydrKMs+On8mHQge9qdBVPLPQQZVkNNlkGIZh1GPLgbt07UGImHZ1tKb/9a+tiGsxJ2ytLemrj2qJxqDSbeP0jUDRJwsuLYlnz56JoOMmTZoISw7CJLYdfUCh6UKwTmVPqluF7zOM+mj119SzZ08aP348RUe/DcA7f/68aOrZp08fbTbJMAyT77hwK5j+PHxfTFtYFKDPuvoommWaI3gw7tWqPH0zuL4iyPpJYJTogH7u+hNKTU2lUqVKifZCO3fuFP0Tg0Jj6a/0wokQgLDmMIzehQ4ad0ZGRopmnijeVKhQIWrQoIHoMv7dd99ps0mGYZh8BW7gP2+5rJgf1LEyVSghT5s2d+pVKUo/jW0mYm1AZEwSzVx7hb76bqWYr1uvPt16/IaOX3lBC36/rKjBg7gcLwN1bWfyYVPPw4cPC9/ppUuXhNipVasW971iGMassHZxpgLW1tmmmON9rKd5UcALFJteFLBxNS/q2qwchYTIXVj5AWSUzR/TlMbM2klh8XZkYWlFj2K8aMaqs6KOkBSzpFyfB5lWDKMpuSrQ0LBhQ/FiGIYxR1AEsPayxRR65hwF/LZOLPNo2piK9+iuWAciR5NigVJRQLhsQPHCTjSmr2kVBdQFqLk2/LPB9Pvvf9CHYxdSpEVJsfzyXXn8Z2Zi4pPp6r3X1KiaVx4fKZNvhM66dfI/cnUYNGiQtsfDMAxjVEDEJIa8bU7p0bQJOXlr35LhwLmndPTSc0XRuymD6pKDnbWwjOcnbGxsxOv337eILN4DZwNoyfbr2X5m1a6bVN+3GLd8YPQjdGbMmJHhiQSR8QDBYgBpgACBZCx0GIYxJyL9/eUTFhbkWrWq1tu5/yycVvydvi0i0d6hVNH8EZcjsW3bNnJwcKBOnTrR2rVrFcvVib0JjYin24/DyM/HQ89HyeTLYGTUx5FeI0aMoBYtWog2EOHh4eKFaSwbOXKkfo+YYRgmD0mKiKS4AHnFYqdyZcnK6W1DSU2LAs7ecFERWItGnc2U6sqYO8nJyfTll1+KzNzdu3e/8/6bqIwxOapQdz2GyVXW1apVq2j9+vXk4+OjWIZpLMN7DMMw5kLUzbeF6lyr+WldFPCnzZcpJDxezFcuU4g+6ay9ZcjUePnyJbVs2ZKWLFlCixYtyrKCvrpp9eacfs8YUTAyTloLi3c1Epa9ePFCF8fFMAxjFETcyL3Q+ePgPbp6X55R5eZkSxMH1CFrK/MrCqiK/v37C28A+iQ2atQoy3WqlHMnd1e7d7KtlPFwsxfrMYwmaPWXhv4jQ4cOzSBqMI1lTZs21WaTDMMwRh2fU8DKilwqV9L485fuvBJ9nYBFAaIJH9fJF80oEVyNZpxg5cqVonK+KpEjdTz/rHv2QhLFArEew+hd6KxevZpCQ0NFbyt0lPXy8hLTOKnxHsMwjDmAbKuEwCAx7VyhPFnaaeY2CQ6LFS4riQEdq+SLQFokp/To0YNat24tqh2XL1+eihQpkuPnkDo+eWBdYdnJbMnBck4tZ/LMdVWmTBm6ePGiKNN9+/ZtsaxKlSpszWEYxjyzreC2ql5No88mJafSrPUXRf0X0NCvGL3f8m1co7ly7do16tWrl3jw3bhxI1laatZ8E2IGKeTIrkLgMWJy4K5iSw5jkIKBcFOxq4phmHwRn+OnWY+l5X/doMcvI8W0l4cjje1b0+yLAm7atEmEMFSuXJkOHjxI5cppV28IoiY/WL6YvCH/RMMxDMNoAOqFRd6QW3QsbGyE60pdDp5/SocuyGuN2YqigPXI0d7a7Mffzs6OPvroIzp9+rTWIodhdA0LHYZhmCxAbE5SejCtS5XKZGGtnlB5+DxCWHMkRvWqTqWLmW9RwCdPntC3334rhCFcVojTtLc3/2BrxnRgocMwDJMFEenWHE3ic6LjkmjWhouUnCIvCtipcVlqUVvew8kc2bNnj2jojBpqSFBhGGOEhQ7DMExOgchqxOekpcno5y1X6PWbODFfsXRB+rSrZnE9pgIyqaZOnUqdO3cWcZqXL1+mwho0NmUYkxA6aPkAc+XAgQMVy3bt2iU60jIMw5gysrQ0ivS/JaYtHR1E64ec2Hr4vqiZA1ydbGjSgLpmWxRwzZo19OOPP4rXzp07qWDBgoY+JIZRiVZ/hahuWaNGDRFwtmHDBsXyM2fO0NKlS7XZJMMwjNEQ9/QZpURFiWlX36pUIIcU6ct3X9HvB++KadSz+99HdUTtF3NDck8NHjxYXO8nT56cZZV8hjEmtDpDJ02aRIsXLxbpg8rAupNVDxOGYRiTjc+pln18DlxVKAook8nn+3eoTNUrmJcbB4HGv/76q6ihhgrHVlZWVL9+fUMfFsPoT+j4+/tT3759xbRyXQhUR0Y/E4ZhGHOJz3Gr5pt9UcANFyk6Tl4UsH7VotSzpfpp6KZATEyMSBkfNWoUffrpp+Tra55xR4z5olXBQEdHR3r9+jWVLVs2g9CB0i9atKguj49hGCZPkaWmUtRNecV3a1dXsi+pOmtq5U5/kU4Oirk70hcf1CILM+rF9OjRI+ratSs9ffqUfv/9d+rXr5+hD4lh8sai07NnTxo/fjxFR0crlp0/f56GDBlCffr00WaTDMMwRkHMw0eUGh8vpl2r+aqsZnz4wjM6cO6pmLaxtqTJg+qSk5kVBXR2dha9DNHyh0UOk6+Ezpw5cygyMpLc3d1Fh9pChQpRgwYNqGTJkvTdd9/p/igZhmEMHJ+TmiYj/4ehdPzKCzpwLoCWbr+meG9kr2pU1svVLH6j5ORkmj59OgUHB4tGnIcOHRItHRgmX7muoPIPHz5MZ8+epUuXLgmxg6JR3PeKYRhTR2r7oByfc+ZGoHBThUUmvLN+h4ZlqFWdUmQOBAYGCqs8LPTVq1en999/39CHxDCGberZsGFD8WIYhjEH0pKSKPruPTFtW6Qw2Xp6CpGDLuSq8PNxJ3Pg2LFjIsnE2tpalBBp1KiRoQ+JYfJW6Pzxxx9qb5R9uQzDmCJRd+8JsQNc/fwoTSYPOM6O33bfpkbViouO26YKkks6duwoHlwRdAyXFcPkO6GD1EJ1YaHDMIwpEul/UzHtWs2Pbj8Oy9JdpUxoRLxYz8/Hg0wNxFo6ODgIYXP06FGqW7cuWeZQHJFhzFbocMM2hmHyU3wO+lvdeSrvW5UTb6KyF0PGyLVr10S3ccTkoJUDEkoYxhzh2t0MwzBElBIXTzEPHoqxsC9RnGzdC1EhFzu1xkbd9YyFdevWCTcVEktQBJBhzBmO0WEYhkF8zu3boligFJ8DqpRzJ3dXu2zdV+hphfVMgZSUFBoxYgStWrVK9KtasmQJ2dubX08uhlGGY3QYhmEyxee4VZcLHQQYD+3uS7PXX1I5RkO7+ZpMIDLib9CEc/Xq1WzJYfINHKPDMAyjHJ9ToAC5VK2qGBNnBxuVlhyInEbVvIx+/Pbu3Uvx8fGiqv3y5csNfTgMYzp1dBiGYcyB5Khoin0ib0jsWLYMWbs4K97befyRYrpfmwpUwtNZxOTAXWXslpzU1FT69ttvaebMmSIbFkKHYfIbWgudBw8e0JYtW+jx48e0fv16sWzXrl3Uvn17srW11eUxMgzD6JXImzeJZDJFWrnEy5AYunj7lcKC069dRbK0NI0cDmTKfvjhh3TkyBH64YcfaNKkSYY+JIYxCFr9xaJqZo0aNej06dO0YcMGxfIzZ87Q0qVLdXl8DMMweifyhlJ8jpLQ2XXirTWnS5NyJiNyAIKNr169SgcOHKApU6aI2ByGyY9odebjyWDx4sV08ODBDMsHDhxIy5Yt09WxMQzD5AmR/vL4nAKWluSc3sAyKjaJjlx8LqbtbS2pXYPSRv9ryGQyCgsLE9OLFi0SQqdNmzaGPiyGMT2h4+/vL3qigAIF3vqoS5cuTQEBcj83wzCMKZAYFkbxL16KaafyPmTlIE+3RofypGR5unmbeqXJyd6ajJnY2Fj6+OOPRY+qxMREKlOmDJUoUcLQh8Uwphmj4+joKHqjlC1bNoPQuXLlChUtWlSXx8cwDJOnbR9Ackoa/XvqsZjGJa5r03JG/Svcu3dPBBrjQXPNmjUcJ8kwubXo4A9q/PjxFB0drVh2/vx5GjJkiCgnzjAMY8rxOaeuv6Q3UYliuoFvMSrq7kjGys6dO6lOnToiw+rixYsKazvDMLkQOnPmzBHN4Nzd3SktLY0KFSok+qSULFmSvvvuO202yTAMY5CYlsgbN8S0hY0NOVesIJYpp5R3a+Zt1L8Mslw7d+5MFy5coMrp8UUMw+TSdYX+KIcPH6azZ8/SpUuXhNipVasWNW3aVJvNMQzDGISE4FeUGBIqpp0rVRRix/9RKD1+GSmW+ZR0oyplCxndrxMYGEgrVqygGTNmUIcOHcSLYRg9FAxEUzi8GIZhTDnbSjk+Z5eSNad7M+8McYjGwLFjx4R7ysrKSoQLwJLOMIxqLHJTMBAVN5FSLoGCgYj2ZxiGMam2D+nxOYEhMXThdrCY93C1o8bVjae9A1xqc+fOpdatW5Ovr69IHWeRwzA5wwUDGYbJx/E58kBkS3t7cvLxpn9OPpYKJFPnJuXIyogKBG7dupUmTpwo6pihhlmRIkUMfUgMYxJwwUCGYfIlcc+eU3KkPBbHxbcKxSSm0uGLz8S8nY0lvWckBQKlAoDIaD116pRo54Au5AzDmEjBwP3791OnTp1EeuQnn3yi1ueR8TVt2jRq0qQJtWvXjrZv367Ft2AYJj+j7LZy9fOjA+eeUmJSeoHAuqXISUXX8rwEfQRR+A8CBy0cGjdubOhDYpj8IXSkgoEgNwUDIXK6dOkisrV++uknioiIEOIF/6siPDxcpLKfOHGCpk+fLl47duwQfbYYhmG0CUR29vXNUCCwSzPDFghMSEigzz//nAYNGiQsObVr1zbo8TBMvsu6kgoGrlu3LlcFAyFS+vXrp+iqCwEDobR8+XKVnXbxGZQ637t3Lzk4OIhleMpJTk7W5qswDJMPkaWmUuTNW2LaysWFrkRYUlhkgpivV6UoeXk4GezYXrx4Qe+//z7dvHmTVq9eTZ9++qnBjoVhzAGDFQyMiYkRVTw7duyYofAVGtD9999/Kj/3+++/i34uksiRsLY27j40DMMYDzGPn1BqbJyYdvWtSjtPyK05oHtzwxYIhMXczc1NWKlZ5DCMCRcMfPnypch6KFasWIblmL91S/6klZmQkBAKDQ0VPbaGDRtGly9fJi8vL5HijicgVSDlXTntPSoqSvyP48ZLV2Bb+E663CbDY21IzPWcjrgur4YMYouVpUfX5UHJ3iVcqXKZgnn+fdG+Yfbs2dS+fXuqWbOmyKoC5jbuxoK5ntf5aZzTNNimVkLHz89PBCTnpmBgSkqK+N/GJmPAH6w6qtxQSUlJ4n+4zRCMPHjwYOEy++CDD+jXX38VrrOsmDVrlqj5k5Vwgi9clwMPSxd+WAQOMvqDxzpvMNdxDrl8RTF98PXby2CL6h7iupDXWVUjRowQAcewTBcvXtysxtoYMdfzOj+Nc7RSr029CJ3nz5+Lg3d1dSVtgdtLOXVSAvMeHh5ZfgYuMgQ/d+3alcaNGyeW1atXj27cuEHLli1TKXQmT56sWF+y6MDNVrhwYXJxcSFd/qg4PmyX/3j0C4913mCO45yWnExPHsqrH1sWLERng1A4pwC5u9pRhyaVyNoq774nHtSQwRofHy/iDqtVq2ZWY22smON5nd/G2c7OTr9CB26ilStX0v/+9z/SFgQdw+2EP3RkXknAHYbKn1lhb28vKoJKIkkCwig7dQcrEV6ZwcDrevDxo+pjuwyPtaEwt3M6+uFDSku3DocWKkkykmeOdmpclmxtctUVRyPwsIgeVWjEuW3bNnE9RDarOY21MWNu53V+G2cLDban1V81AoknTJggKnVWqVLlHfcTMgXUAemTS5cuFS6ocuXK0YYNG+j+/fsi4Fg5ywoWm7///lvMw8Q7c+ZM+uKLL0TdHmQobNmyhbp3767NV2EYJp8hVUMGF+KdiRyIbG0sqX3DMnmyf2SNouAfLOIosYH4RlxDOV6EYfSDlbZKSioYiLgZKXZGU6ZMmSIKBFaqVElYZeLi4ui3336jGjVqZAhaRl8tZXH05MkTYdmBOSwoKIh69+4t4nAYhmE0KRT40NpT/N+6TklyzoMCgffu3RPlOVq1akWLFi0S2aoMwxih0Pnjjz90s3MrKyFsUCwQ2VSlSpV6x8WEdHUIIGUzGNLbp06dSsHBwVSiRAmNfHUMw+RfUhMSKPq+/MEp0taVoq0dRYHArs30n1KOwqao/o5gY2SNMgyTN+SdQzobChYsKF5ZAb91Vjg5OZGPj4+ej4xhGHMi6vYdkqVnfD629VQUCCxeWH8FApFxgnhGPNChoCpc+yjRwTBM3sBRWAzD5Bsi/d/G5zy1l7er6aZnaw6s0KiTs3DhQmENZ5HDMPnQosMwDJPX8TlPHYpSueKu5OudMYtTVxw/flzEGH744Ye0YMECveyDYRg9WXRQ2Eqb9xiGYQxFSkyMaP0AXtsUpHhLO2HNUW5MrCtX1bx580SZjM2bN4t5hmFMTOhk1+pBkzYQDMMweYVo4pleNh5uq0IuttS0RnHd7iMyUtQZQ/kNvHbt2qVzIcUwjAFdVxEREex/ZhjG6OvnwG3VqXE5nVdBHjlypGhKDIGDCu4Mw5iY0Onfv3+W0wDFrm7evMl1IRiGMUrC0xt5plEBCnb20mmBwDdv3ogWNWjMib563t6G7YDOMMxbLDSte4OX8rT0cnR0FEUEN23apMkmGYZh9E5SRAQlvHghpoNs3alpA29yccx9gUA0BUZNHFQ3RsV41PVikcMwJmzRWbdunfgfVYznz5+vr2NiGIbRKeHX5NYcyW31QdNyud4mqrqjKru/vz/9+uuvorYXwzDGh1YO6gMHDuj+SBiGYfTEg+MXFNN2lSpTiSK5K9h36NAhql27NoWFhdGZM2fo008/1cFRMgxjNELn+fPnIruAYRjG2EF6d+ztW2I6hSyoadfcZ4aiCScyTC9fvizcVgzDmJnQQfrkypUrdX80DMMwOubW5QfklBAlpsNci1H1ylm3lckJ9ONDjz1UOW7evDnt3LlTZesahmFMPL0cQXeoEbF161aqUqWKeLpRBr1cGIZhjIELe05QxfTpQjWqaVXX5sKFC9SrVy+Kj4+njz/+mCpUqKDz42QYxogsOhYWFiLDCk01k5KShPBRfjEMwxgDwWGxlPLgrmK+WruGGru9li1bRk2aNBFdx69cucIih2Hyg0UHjekYhmGMnd0nH1GpuGAxnWZtQ26VJNuOeuzbt49GjBhBo0ePFpmmma3XDMMYP9zUk2EYsyQ2PpkunfSnKqnxYt6lSmWySK8Dpm4BwA4dOojmnM2aNdPz0TIMY3RCJy4ujs6dO0fPnj2jlJSUDO8NGTJEF8fGMAyjNYcuPKWiEfIigcCjZnW1Prdjxw4aPHiwiEFs3749ixyGyY9C5/r169S5c2cRj4P+Vp6envTq1SvxXqlSpVjoMAxjUFJT02j3ycfUOF7utgKu1fyy/UxycjJNnjyZfvrpJ1EIsHHjxnlwpAzDGGUw8rhx40TmQXh4uJgPDg4WVUIRsMfWHIZhDM3Zm0H0+k0clUoXOlZOTuRYVnVvq9evX1Pr1q1p4cKFtGDBAmHNcXbOXVFBhmFMWOigSNb48ePFNFI1kXlVunRpWrNmDa1atUrXx8gwDKMRO48/Is+kN2SfliTmXf2qUgEL1Zc7BwcHsrW1FZ3Hv/jiC61S0BmGMSOhg6rICNQDhQsXppcvX4rpYsWKiScjhmEYQ3E34A3dexpOpdOzrYCrn1+WqeM///wzPXjwQPSpQlsHWKUZhjEvcp11hQsDqoWOGjWK1q9fT1WrVtXNkTEMw2jBzhOPxP+ls4nPwcPaoEGDRHVjWHLKly/PY80wZopWQufrr79WTM+ZM0cE7jVs2FC4r7jGDsMwhuLVmzg6eyOQLGRpVCpBniBhXbAg2Zcorljnxo0b1LNnTwoJCaFdu3ZR165d+QdjGDNGK6Hz/fffK6ZRHfnq1auUkJBAdnZ2ujw2hmEYjfj31GNKkxEVTwgl6zR52Qu3an6KmBu0cHjvvfdEpuj+/fvJ29ubR5hhzJxcua5QPwd1dKS0coZhGEMRl5BMB88/FdPlEuXWHOBazVc8iKEZp6Ojo7Di+Pn5kb29Pf9YDJMP0CoYOTExkSZNmkRubm7iiQgvTE+ZMkVkYDEMw+Q1hy48o7gEuRWnmuUbxfLoggVFLCHiCEG9evVY5DBMPkIri87YsWNp7969tGTJEqpbt65YdvHiRZo2bZooILh06VJdHyfDMIxKUtNk9M/Jx2LaKi2FnMPkmaBpLs5Ur20bcnV1VQgdhmHyF1oJnS1bttCRI0cUIgcg26pKlSrUtm1bFjoMw+Qp59ILBIIWRZKJHsstO3v8/UWixMaNGxUlMRiGyV9o5bpCcS0EIWcGKZp4j2EYJi/ZdVyeUg4a2Ecppr1btaDdu3ezyGGYfIxWQgeN7ubOnSsKbklgGsvwHsMwTF5x7+kbuhMgj8kp7GJF0dfOK94bOPUbssimIjLDMOaPlbady2fPnk3btm2j2rVrC5Fz5coVevTokaipo9zvavXq1bo8XoZhmAzsOiGPzQHn/l5En5RyRG8acihVkmwKFuTRYph8jlZCB09Iffv2VcyjRkWdOnXEC6CrOcMwjL55HR5Hp28EiunE2AjqX6cMWYSEqmz7wDBM/kMrocPVjxmGMQb+PfWE0lAhkIjqlHegfq4NKGj3v4r6OQzDMGo7r2/fvk36WJdhGEYbAoND6MC5ADFtZVmAJnzWlSL9/eVvWliQqy/33WMYRoNgZKSNf/zxx3T69OkMQcgSaWlpdOzYMfroo4+oTZs2PLYMw+iF5ORkGj9+PHXo94WiQGDL2iXJMS2B4gLklZGdypUlKycn/gUYhlHfdXXnzh364YcfqGPHjmRlZUW1atUS/WIgeoKDg+ny5ctivc8//5zu3r3LQ8swjM4JCgoS8YFnz52n7l9spoRU+fJuzbwp8uZNld3KGYbJv6ht0XFxcRGdyl++fEnLli0TxQGRfYUeMr6+vrRq1SrxHtbBugzDMLrk1KlTVLNmTXr48CGt2LSXElKtxfKaFQpT6WIuFHE93W0lApE5PodhGC2DkZ2cnKhPnz7ixTAMk1fY2NhQjRo1aP369fTztvuK5d2by4uXSvE5BaysyKVKZf5hGIYRcCUthmGMlsjISNFDD3E5aMa5f/9+iky0odtP5AUCS3o6U82KhSkxJJQSAoPEMucK5cnSzs7AR84wjLHAQodhGKPkxo0bojbXwoULM2Ry7jrxtt0DYnNQxyvSn+NzGIbJGhY6DMMYHWjC2aBBA9E7D4kO1atXF8tDwuPp1HV5gUAXRxtqUbuEmI64oRSfw/VzGIZRgoUOwzBGxcmTJ2nAgAEiDvDs2bMZGgjvOf1YUSCwY6OyZGttKTI/I9OFjoWNDTlXqGCwY2cYxkwqIzMMw+iaiIgIcnNzoyZNmtB///1HzZs3F24pifjEFNp/VioQaEEdG5cR0wlBQZQUFiamEYRsYS3PxmIYhtHaooPigEuWLBGpnq6urorlEydOpBcvXvDIMiZLapqM/B+G0vErL8T/mGf0D4KMvb29aceOHULctGjRIoPIAUcuPqPY9AKBLWqVoILO8oDjyBscn8MwjI4tOr/88gstWrSIJkyYQCNHjlQsr1SpEs2cOZNWrFihzWYZxqCcuRFIK3f6U1hkgmKZu6sdfdbdjxpV8zLosZkrqamp4prx3XffUYcOHahly5ZZr5cmo3+UupR3a+6tmI64cUMxzYUCGYbRiUVn+fLl9Oeff9KIESPeaRPx999/a7NJhjG4yJm1/mIGkQMwj+V4n9Et4eHh1KlTJyFy8Nq9ezcVKlQoy3Uv3AqmoLBYMV2jfGEqU0xelFSWlkaR/rfEtKWjg2j9wDAMk2uLztOnT8nPT15iXdm8jAyJqKgobTbJMAYD1gJYcrJj1a6bVN+3GFlaZHSnMNpjl17r5sCBA+IhKTsypJQrWXPinj2jlPRrDpp4FrC05J+EYZjcW3TKlCmj6G2lLHTgX4f7imFMiduPw96x5GQmNCJerMfkDmRIwSLs7+9P9vb2IjYnJ5Hz8HkE3Uof+xJFnKhWxSKK9zLE56Q/fDEMw+Ra6IwbN06kf/7xxx9i/vjx4zR58mQaM2aMeI9hTIk3UQk6XY/JmtjYWHHdGD58OP37779qD1PmAoEWSlY1js9hGEYvrit0KE9KSqIvvvhCZGAhQ8LDw4PmzZsnLmQMY0oUcrHT6XrMu9y/f5969uxJjx8/ps2bN9OHH36o1jCFRcbTyWsvxbSzgw21rFNS8Z4sNZWibsorJlu7upJDqbfvMQzD5LqOzujRo2nUqFEinRxip2TJkmRhwfUHGdOjSjl3kV2VnfvKw81erMdoDvpUvffee6Ip54ULF6hq1apqf/bfU08UKf4dG5URBQIlYh4+otT4eEU15Mzp6AzDMCBXygQXFgic0qVLs8hhTBYEGCOFPDuGdvPlQGQtBE5MTAxZW1vTtm3b6OLFixqJHBQI3KdUILBT44wZVRnbPnB8DsMwWcMFAxmGiHxKuqkcByd7a6rm48HjpAFBQUHUunVrGjRokJhHc04XF3lKuLocRYHA+GQx3axmcSqYyXUotX0AHIjMMIxOhQ4KBs6fP5+GDh2aIZ1cKhjIMKbG5TuvFNNt6pakrz6qReXTxU9MfDKt/udtdg+TPSdOnBBV0x8+fCji+LQB/ax2nXxbILC7Ukq5eD8piaLv3hPTtkUKk11RT/5ZGIbJEi4YyDBEdFFJ6HRqUo5a1CpJkwfWI3tbeRjbkYvP6ZLSOkzW/Pzzz9SqVSuqXLkyXb16VfSt0oaLt4MpKFReIBDWtLJeb1vNgOh794XYkaw5HJ/DMIxOhQ4XDGTMiaTkVLr+IFRMF3S2pXLpN9XCBe3p066+ivUW/3lNWHcY1cTHx9P48ePp0KFD5OmpvZVl1wnV1px343Pe/kYMwzCZ4YKBTL7H/1GoEDugTmXPDHVa2tUvRTUrFFbU0Vmzi11YmUHxv5UrV4rpr7/+mmbPnk1WVlondNLDFxHiNwHFCztR7UrvCiaOz2EYRl24YCCT71F2SdWunPGmCpfIqD41FC6swxefsQtLiY0bN1L9+vVFtWPU1tIFGQsElssgPEFKXDzFPHgopu1LFCdb96z7YzEMw2gtdFAw8Msvv8xQMHD16tVcMJAxyZYEktBBmrlkvVGmSEGHDC6sJdvYhZWYmCgqHKNAaN++fenUqVOiTk5uEQUCr0oFAq0zFAiUiL5zRxQLBJxtxTCM3urooGAgUkifPXtGAQEB9OrVK1FAUFP+++8/UTEVQYu4cL58Kb/IqcOGDRtE2ioCIBlGG16GxFBwWJyYrlrOnRzsrLNcDy6sGukiCIUFf8vnWVjTpk2jtWvX0qpVq+i3334TDX11wZ7TbwsEtm9Yhuxs3nWBcXwOwzB6FzqNGzemZcuW0Zs3b3JVMPDIkSPUrl070Ql96tSpQjRh2+p0QL9z5w598803QmDhcwyTW7cV4nNUARfWaCUX1qEL+dOFFRERIf5Hb7szZ87QkCFDdJbxlJCYQvsVBQILvFMg8J34nAIFyNWXA5EZhtGD0KlduzbNmDGDihUrRt26dRNVTxMSNG94CHHTu3dvsS2UiN++fbu4kK5YsSLbz2FfMJcvWLCA3N25LD+jf6Hz1oVVNYMLSypoZ+7ARf3tt99ShQoVhCXXzc2NatWqpdN9HL38nKLj5OPZtEZxcne1f2ed5Khoin0iF0OOZcuQtYuzTo+BYRjzQyuhs2jRIgoMDKR//vlHVDsdPHgwFS1alD799FPhilK3k/G5c+eoU6dOimX29vaimiosPdmB+KC6desKlxfDaEtcQjLdehwmpj0LOVCJIk45fqZd/dJUo/xbF9aafODCCgsLE3+nEDpjxozJVdp4dgUC/8nUpTwrom7dQmCVmOa2DwzDqIPWOaCWlpbUvn178YqLi6Ndu3aJtFL46xHgmRNoBor1vLy8MizHfHZC56+//hI1Oq5du6ZR4CReEpJrDE+peOkKbAvfSZfbZPQ31lfvvaaUVPm5WrtSEbE9dc7dkb2r0ZifjoteTHBhNfIrRrUqFTHLnwr9qfBAASvqvn37qG3btmK5rs/xi7df0csQeYFAX293KuvlkuU+wq/dUEy7+FY1q781vn7wWJsbaXq8J2qyTe2LXaTz+vVr2rp1K23evJlu3Lgh4m3UbfgHbG1tMyyHVUd6L6tChcOGDaPdu3eTk1POT98Ss2bNEk+jmQkJCdHK5ZbdwEdGRooflju56xddjPWpq08V0z7FbMW5rC69mpekjQefiOlFf16lGZ/4kUN6/I45gaacJUqUoMWLF4t4PE3GSBO2HbmrmG5RzV3lft5IDzgWFpRY2ENvx2MI+PrBY21upOnxnhgdHa32ulbaXvx27twpxA2sK7DCfPDBByIDQ12hI8XWwCyuTGhoqMq4GwgcWI9GjhypWHb//n0RM4D01vPnzwtLU2YQODlu3LgMFh1ctAsXLqxxo8GcflQEZmK7LHT0S27HGn94t57Kb5o21hbUpLY32Vq/e+6oomebwnTjSbSoqBwenUT/nguhUb2rkzmAv7G5c+fSpEmTqHnz5vT333/r9Zx+/DKS7j2TW1m9PBypdYMK79TOAUlv3tCjYHlMlXOF8lS0VCkyJ/j6wWNtbqTp8Z5oZ5exya/OhQ589KiZAZP24cOHxcVQ08wLBDLjBdN4ly5dFMshVrC9rEAAcoMGDTIs++ijj0RwNIRMViJHshplthwBDLyuBx/joI/tMrod60cvIig8Su7OrOZTmOxts04rz44xfWrSqPlHKT4xVbiwmlQvbvIurAcPHoi/60ePHlGHDh1EMUB9n9O7T8ktY6BrM2+yssr67zjq5m3FNOJzzPFvjK8fPNbmRgE9XT802Z6FttVQg4ODRZFAFAvUNr0UwcvYxvPnz8U8XGBIG8dyie+//5769esnpqEKUTdH+QVXV5EiRcQ0w+gj20oVRQo50CddlHthXTXpLCxYbvB3hHi2CxcuUMOGDfW+T7TVOHH1hZh2srem1lkUCMy67QOnlTMMo0ehM3369CwtJNqkl0MolS9fnsqVKycEDkrJw0IjgWKEN2+af2YLY3pCB7RvUFp01wahkQm09t9bZIoguP/9998Xda1gZa1a9W0avT5AUUD/h6G0bMd1RUC4KBCoIs4JrsbIG/JAZAsbG3KpVFGvx8cwjPmglesKFhgEGLm6yrs8awvcX1u2bBFF/xBU6O3t/U6FVYghxASpAp93duZaGoz6RMYk0r1n4WK6pKezSC3XFlgzx/StSaPTXVgHzj2lRtW8qFZF03BhoW4V/o5r1Kghsh1btmypswKAqjhzI5BW7vQX6fnKFHVX/TskvnpFiSHyRp/OlSoKscMwDKM3iw6e/KRuxboAMT8IYs6qjDyqLmf3dFmlShURWMwwmqSVS1nkdXNhzZGAUPqk89tzdPGf10SNHmPn5MmTVLlyZdFKBbRq1SpPRM6s9RffETlgybbr4v2siLjx1qrL9XMYhtEErbOuJkyYIGJqIDQyN/ND3A3DGCsXld1WVXRT/O69BmXo1PVAuvEwlEIj4um33bdoVO8aZIzADYT+cBMnTqSmTZuKquR5AdxVsORkx6pdN6m+bzHRYFUZyW0F3Kqpl9nJMAyjtUUH0c7IgPLx8aGkpCQhfJRfDGOs4GZ75a689oqjnRVVLlNIJ9tFOjRcWHY28owhuLBgOTI28PfZq1cvGj9+vHihPASqmucFtx+HZWnJUQYiEeu9G58jt+hY2tuTk0/WVZMZhmF0ZtH5448/tPkYwxice0/fUEx6ZlSNikXIylJ3KY/ChdWlKi3bIbc+LN52jZaMb6myI7ohQBIBimQiw6p79+55um9kWGmzXvzz55QcGSmmXXyrUAEVZSQYhmGywvwKUTCMutlWlXTfs6l9gzKKLKyQ8Hha++/b2i+GZNOmTSKbytramvbs2ZPnIgc4O6gn+Aq52KmOz1GzICnDMEyuhA6qHS5ZsoRq1qyZIfMKPn/0sGIYUxA6tSvrPjMKLqzRfWooXFj7zwbQtfuGc2GhJs6IESPo448/Fn3iDEVCYgr99d/DHNfzcLOnKuUyVkbn+ByGYfJc6Pzyyy80f/58Gjp0qKJBJqhUqRLNnDkzVwfEMPoiLDKengTKz1efkm5U0Fn9EuKaUNTdkQYpZWEtMlAWFnrDIdh4zZo1Ikvyxx9/JEOA7z5j9Tm6/lCeHp4dQ7v5ZghElqWmUuRNeW0iKxcXcihtXm0fGIYxUqGDon5//vmneFJUBp2N4ftnGGO35ugirTw7OjQsQ37eb11Y6/LYhQWra+fOnUV9qtOnT4uHEn2njmcF4qGmrTxLt9IDjB3srOjjDpXJ3dXuHUvO5IF1RQ2iDJ9//IRSY+PEtKtfVSpghm0fGIYxwmBkPClKzTuVL56og6Ns4WEYc6yGrH4WVg0aPf8/SkhKpX1nA6hxNS+qXqGw3gUOMqvQrBb1cVCHqlAh3WSWaUpUbBJNW3mGHr2IVLR4+O7zhlS+ZEHq2aq8yK5C4DFicuCuypxSDiL9OT6HYZjcodXjUZkyZejy5cvvCJ0dO3YI9xXDGBvJKal07X6ImHZ1siGfEm5636dwYXWqophf9OdVvbqwwsLCqFOnTtS7d2+Rko0YOkOJnPDoBJqy9JRC5GDMfxzRWIgcAFHj5+NBzWuVEP9nJXJA5HWun8MwjAGEDjqFDxgwQJFmfvz4cZo8eTKNGTNGvMcwxgZcJ7CsgNqVPIXFJS/o0KiswoX1Gi6sPfpxYSGjqlatWuL/r776yiBuKuVYqMm/nqanwdFivpCLLc0a0YTKemnWMiYtOZmibt8R0zbuhcjOq5hejpdhGPNGK6Hz+eef05dffklffPGFMJWjMSeqIc+bN08IIIYx6mrIenZbZeXCsk3Pwtp3JoCuP5BblnTFqlWrqEmTJqLw35UrV0RjTkPx+k2cEDkvQ2IUsTezRjYRPcU0Jfr+A0pLShLTrtWqGVS8MQyTz2J0wOjRo2nUqFEinRxiB/2mUDGZyd8khoRQcpT8ST4rrF2cybawfuNUsuLS7VcK4VEzjxtuSi6sFX/L2x8s2nqVFuugkKA01rLgVzRh4CDx8GGTnEIxjx4bZKyDQmPp6+WnRfC11KTz+2GNtW6aqhyf41bNV2fHyTBM/kIroYO2D8jkQKdjCJxz587R9OnTRffxSZMmiaJkTP4DN97Lw0eTLFl1HEoBa2uqvWxxnt6AA0NiKDA0Vkyj5QOCYvOajo3K0ukbgXTzUZjChTWiZ3Wtt3f3wkUKmTWXLNLSCInseN2Z9LXBxvr5q2j6ZvkZRVXj4oUd6Yfhjcnd1V7rbSrH57j6sdBhGEY7tDLBfP/993T27FkxjQwPpLG+evWK1q1bR998842Wh8KYOsK6kI3IAXg/O4uPqWdbZevC6lNTJy6snTt30oc9egiRYwxjHRAURVOWnlaInFJFnUVMTm5ETmpCgnBdAbtiRQ1iBWQYJh8LnY0bN9LAgQPF9MGDB4UlZ9++fbR79276/fffdX2MDGMy9XOyo5iHIw3sqJyFdY3iE1PU/nxKSgpNmDCBevToQQ0aNCBj4OGLCJFdFRGTKObLFXelH4c3poKZ2jhoStSduyRLSVHE5zAMw+Sp0EERMqn1w3///UcdO3ZUpJ0jxZVhjAUICf9H8nOycEF7YW0wJJ0al6Wq6S0OELi77l951V91mDNnDv3888/ihWlDc/fpG/pm2WmKjpNb8SqWKkg/DGtErk62ud525A15PBPg+ByGYfJc6Pj6+tKCBQtEhgdSzNu3by+W3759m6pWfVv6nmEMzY0HIZSSmqZo4mnozB24sMb2rUk21nIX1t4zAXTjYfYurMj0zt1jx46lU6dOiaBjQ3+Pm49CadqKMxSbILe6VClbSBQDdHKw0cn2lYWOiy/H5zAMk8dCB2nkCxcupNq1a4sCZfXr1xfLIX6Qcs4w2ZESKw8MzvO08iqGc1u948LqVFkxv2hr1i4sFP376aefqFy5cvTkyRNycnISLquUuDh6sV29Bp3Yhq5Bk9Lpq85RfKK8LlH18h707dCGuc4ik0iJiRGtHwB6W9m4aVZ/h2EYJtdCp1mzZsJ9hSdNBCBLIPPqgw8+0GaTTD7i3px5FHLilF5uwspg+5fThY61lQVVSy/cZwx0blxO4cJ69SaO1mcqJIhWKr169aLx48eLPlXIbgRvLl6iq6O+oLAz8mSAnHi8bCUlBAfr7Lgv3g6m79acp6TkVEVw99RPG5CdrdaVKt4h8tZt9LIQ0xyfwzBMbtG68A1q5qC31ePHj8ULgZIVKlQwuEmdMX5SYmLp/k8L6M4PsygxNEyv2UChkfJMILQZ0OXNWFeFBCUX1p7TT8g/vbs3XMB16tShw4cPiya5s2fPprSYWLo3/2e68/0sStIgDi7m4UO6OvpLernzH9EJPDec9Q+kH9ddoOQUuQhp4FuUpgyqS7bp30FXcHwOwzAGFzqJiYmiXo6bm5vIuMIL01OmTBE1dpj8SdKbNzmvpCSEwy9epqujxlLQvv0kyyFVOtdp5ZWMw22ljJeHEw3s+NaFtXDrVUpITCErKyvy9PSkS5cuUbdu3ej1f8fo6qgxFHrytGJdlyqVqYCVesIN1YUD1q6nGxMmU+yTAK2O9cTVlzR7wyVKSZVb4ZrVKE4TB9QlayvdipwMQsfCglyqvs1SYxiG0QatHnERFLl3715asmQJ1a1bVyxDj51p06ZRREQELV26VKuDYUyXtJQUerppi2K+aIf3yLNtm3fWQ7XemIeP6NGKVZQcHkGp8fH0ePkqCj1xirxHDieHEsX1k1ZuJPE5mencpByd8Q8Svbjgwlq18zqN7lubTpw4IQow3v72e4q4ek2xvpWzE5Ud/AkVbtmckkJDs62Tg4KBr/YfpKC9++DHE+N+/asJVLxHNyrZtzdZ2KgXOHz6Zgit3/8YmxC0qlOSxvStqbIRZ25IioiguGfPxbSTtzdZOTrqfB8Mw+QvtBI6W7ZsoSNHjihEDkC2VZUqVaht27YsdPIhL//aSXEBT8W0Y9kyVHbIYLJQYXFA8TdXPz8KWLeBXh06LJaheeO1L74SN2DciFV9Vl1i4pLoboDcwlS8sJNow2CMwIXVq0kRuvkgmApYWtPBCy+oea2S5HH3Aj3d9DulJchdb8CjSWMqO/RTRXAuxjGnQnrlPvuUPJo1oYeLl1L8ixfCfYVA5rCz54SwdM3BYrLvbACt2ydvKQHaNyxDw9+vpremqJE3lNo+VPfTyz4YhslfaOW6QmyOj4/PO8vLly8v3mPyF3gCf751m3zGwoJ8Ro/MUahYOTmSz6jhVHXmDLIrWlRRyffZpi3C6hD94GGujunKvdeUJjNuaw44cOAAtW/diIJu7hbzHokR9GjGDHqyeq1C5KBzd+WvJ1HF/43TKgPJpVJFqvHLfCrZr4/C3RX/MpBuTplKj5avFFlcWbHrxCNa/tfbNO+uTcvRiJ76Ezkg0v/t/rjtA8MwBhM6qJszd+7cDFkzmMYyqaYOkz+AheDhkqWKKrbFu3clJ+9yan/erZof1Vj0s7DiQCQBWIYQT/Jk7XpKTZRX3DW3+Bzw8OFDUWwTltG9G2dTj7R79Mnzf6lIzKsMLsCaSxZSoXpvrafaYGFtTaU+6EvVf55HThXKK5YH7zsgsriQzaXMtiP3afWut9aVni19aEg3X70nG0jxORBkzpUr6XVfDMPkD9T2DwwZMkQxHRcXJzJBtm3bJmrpQOSgeOCjR4+od+/e+jpWxggJ2rOPou/dF9N2Xl7CaqAplra2VGbQAOGagWgSAbNpaRS48x96c+48eY8YRm7V1W8DkJomo8t3X4tpe1tLqpKexm0sIHXc2dlZWEXRQqVOMS969MNsqvj8hWKdMGsXKvn5Z+TdtqFO9+1YuhRVm/2DiNt5unELpSUmiiwuZHN5NG1MZT4dTNvPB9Mfh+4pPtO1cXH6uEMlvYuchFevKSFYLvKcK1UU5wXDMEyeWXTQvFN6IbW8b9++IgUWFz/MYxrLMM3kD1CfRTkAufzoEbm6OTn5eFO1+XOo9McfiUBa+T5e0a1p39KDxb+KQnLq8PB5OEXFyrP/alQoImroGAsI2vfz8xNxbAjELvs4QLiQ4tNFjszCgs4U9KPfSnahZRdjRRaWrilgaUleXTpTzcW/kFuNtx3UkdV1/vNRdHPHXhG8DJAV1qVRiTwpGxHprxSfU43jcxiGyWOLDlo9MIwErHgPf10uLAKgaMf2IuU5tyC2p0Sv98m9YQN6+OsyikLxOPSFOnyUwi9doXKfDyGPRg3Vr4ZswCaemcdr5cqVNGbMGKpRowa18fahq6O/oMQQee0c4OjtTeVGDqd/9r6g1IA3FBQWSxv23aHPuuvnpm/nWYSqzJhKIceOi5ggCEnLxHjq/Po0VYl5QgU/GkAdW/qI4qB5QYb4HBY6DMPoCON51GVMileHjijiKWwLe1Dpj/vrdPv2xb3I9/tvyXv452SZHuCeHBFB9+bMpzuz5mZbs0c5Pqd2pSJkaBISEmjQoEE0bNgwGvnJYFrXux+FLlupEDlI8y7zyUCqPm8WuXiXpbH9apJNuhVq98nHoq+UvoClxqN5c7ra/jO67VRGsbxcXCC5b/yFgnbv0UuNo6yEYMR1+flkYWcnrHsMwzAGFTrXrl2j/v37ixidWrVqiWksY8yfxLAwUYBOAmnKVg72Ot9PAQsLKtq+HdVc8kuGYFzE7Vwb/SVFnTz9ThuJN1EJ9OiFvAlmueKu5O6q++PSFGtra4qMiKS/f5xF/eIS6M3JUxksFzUWLRBB3HApSenwH3eskqEXVkKS7l1YIDU1jX754wrtuRZK/xRtRjuKtSKZszyzC1lfAb+to5dzf1LUttEX8S9fUnJ4uJiGZRDB0wzDMAYTOrt27RICJzg4mDp06CAae2Iay/755x+dHBhjnEBYPFq2klLTU5KLtGpJBWvW0Os+bd3dqdKUiSK92tpVfhPG/kM2baHb076l+KAgxbpSbytjcFuhfQMK/6W8Cacf69SlwucuUnJklHjP0tGRfEaPoKrfTSf7YvL0emW6NC1HlcsUEtNwYW3ce0fnx4eu7vM2X6b/Lsvjg5A23uPz7tRg5RKR7SWR+CSAbnz1P3q25Q9KS04mvdfPYbcVwzA6RKuqbFOnTqWff/5ZVEhWBh3Nv/nmG+ratauujo8xMhCwGp6eimzt5kZlBg/Mk/0KF0uTxqLJY8DadfT66DGxPOrmLbo2ZhyV/KAvFe/WhS7dVaqGbCChg75vaIcyf948+unjAWSTlCoCjyUQf1TusyFkU6igym2g6jBcWGPm/0dJKWm0+9RjalTNS9EINLckp6TSnA2X6PwtecNPK8sCNOHjutTQr5iY9x72GXk0bSKy4BICg0iWkipqJYWeOUs+o0aI2jz66m/F8TkMwxjconP37l0Rc5AZLLt3721aKmNeJEdG0uNVaxTz3sOGkrWzc54eA1pIlB87mipP/4as3N0VvZyert9I176aSC+u3RXLnB1sqHwp1UJCXwQFBVHr1q1p+4qVtLf/QKoXGaMQOdYFC1KlSROo0qT/ZStyJOQuLHmANzx0oheWDlxYicmp9P3aCwqRg3igrz+prxA5EqiaXH3BfHLr0F7hVkN2mP+kr+nxyjUZxFtuQAxQ5E25RcfKyYkcy5TWyXYZhmG0FjpFihShq1evvrP88uXLVDiHkvSM6fJ49W+UEiV3vbg3aigsE4YCadElp39Nxbp0UjQKjXvyhPo9/oeah16mOj4F9dKLKSe3Xu/33ye/mDja0LodOSv1ofJs14ZqLVlI7g3ra7TNLk29qVJpuSgKCo2ljfty58KKT0yh71afoyvpdYZsbSxp2pAGKt18CJR2796F/ObNfhsgLJNR0J69Imss/Mq71wFNiQ0IoJRoeekAF9+qClHFMAxjMKEzdOhQUTPnl19+oTNnzojXggULqF+/fuI9xvx4c+GiaLwpPXWjh5KhsUChwcGDqNqcH8mhdCn5MpJRw4hbVO/YOoq8eSvPBA6KAKJp5jy/GvRBiVJUIDVVvGdXrKhoc+GDgG0nzfttSS4s5SwsNADVhtj4ZJq+8izdeCjP4rK3taJvhzak6uVzfjhB/7Jqc2eJ7DCpGSiyxtB09P6ChZScLoC1geNzGIYxyhgde3t7+v777yksTH7RdXd3pwkTJtD48eN1fYyMgUmJjRU9kSTKfvoJ2RTMe7eQKpwrVqDqP82l5eN+pqrPLpEVpVGBNyF08+tp5PleWyoz4GOtRIY6QOAMHfQJ1YiJpWaOTqRosGVhITKpUCk6txV+SxRxpv4dKtNvu28pXFiLvmpBdjbq//lGxyUJkfPgeYSYd7S3pu8+a0gVNHDvwdKC71Sofj16tHS5Iq4m5NgJCr9yjcoNHSziejQtLsjxOQzDGJ1FB9WPIWpCQ0NFttWrV6/ENJZxZWTzA13Gk8LkdWvcatWkwi2bk7HxOiqJ9tlUorWlOlOY69tYk1cHDtGVUWMp7Nx5ne/z5s2bNKBZc+odE0fN7B0VIsexbFmqPn8OlRn4sc7aGHRt5k0VlVxYm/bJY5HUITImkb5edlohchC/9MOwRhqJHGWQJYZsMWSNIXsMwKV5/6dfRCsJ5SKIOZGWkkKR6UUhrQu6kX2J4lodE8MwjN4KBnp6eoqYHcY8ibjhT68OHlYUcvMZ8XmetAPQFCmtPMzGjRI+HiVcazhegPosd2fNpbtz5lNSeq2W3LJ13Xra+smn9L/S5aiYvbygIVw6pQf0p2rzZ2vU2FRtF1bfmop2Fv+cfES3n+TswkJdoclLT9OTQLlryc3ZlmaNbEzeJdxydTw4BzzbtKZavy4U8VoS4ZcuC2GJHmjqFBqMefBQ0aXd1c/PKM8thmFMG66MzKgkNSGBHv26TDEPC4WtkQabK7d9qFu1GBXr1JFqLfmFCtauqVgeduas6NT96vDRdwoNqgs+F3r6DBXdu5/ae5VQLEcQbY2FP1GJnj1EGwt9UNLTmfq3V8rC+iP7LKyQ8Hia/Ospev5KHhTt7mpHs0c2odJFXXR2THBhVpo4XmSTIasMQLg8Xrma/KdMpbgXbxuV5tjfqjr3t2IYRvew0GFU8mzz74pu0qhWiyrFxghu9v7pAba4mZcpJr+RQ5RVnvo1lf9yLFmlp8Gjn9PDxb/SrenfiaakmvD4xg3aM+Rzujf3J7JKlDcNRXsK7xGfk+/MGWTv5UX6plvzty6swNBY2rw/axdWcFgsTVp6SqwDihRyECIHKev6ANlkyCpDdplE9J27dG3sV/T8z+0qCw1miM/xY6HDMIzu0c+jJ2PyRN+7T4G79yhcMigSh5YMxghEDorqAaRJK7s/MF2kRTMqWLM6PVmzjkKOnxDLI6/foKujv6RS/T8gr86dRO+sZKV0cGXggrm4fTulnDpLBZWsNYXq16Vynw8VlZvzCsmFNfbnY5Sckka7TjyiBlWLUZpMJtxUhVzshHtq2oozFBopdwkV83CkH4Y1psIF9dsOAwHfyC5DQDKClROCgkmWkiIEc+ip0+QzeiTZuLkqxhn1jyLvyIWadaGCQoQmWhQwWqshwzCmSQGZtjZ8EwaZMq6urhQZGUkuLroz46elpYlOz4hZMuWgbDx9X/tyvCgOB0oP/JhKvN+djAnlsV7xtz/tPRMglk8ZVO+dwnfKvLl0WbSwSAp9GzDrUKY0xb94KW7K6oA2FOiijtgUQ8WU/PXfA1r7721F64Y0KdtLiDu5awuU9HSi74c1FgIoL8/p1MREev7Hn/Ry5z/YyNsDwyub2J0C1tZUe9nifCl2zOX6YQrwWJv+OGtyH7fQ9uCXLFlCNWvWFDuSmDhxIr3IwSfPGD9wNUgix9HbW7RWMFag06Vu5WhjUKNC9jfIQnVqU83Fv1CxTh3eFhoMeKq2yEFvr5q/LiSPxo0MGjjbrbkPeXnIM56URQ6QRE5hN3v6cXgTrUVObkC2GWK6kH3mWK7s2wPLIUBZlpys0rLGMAyjDVoJHRQKnD9/vigOCFUlUalSJZo5c6ZWB8IYB7FPAujljr8VdVPKjxlh1JVqn7+Kodfh8lYEvuU8RBG8nECndfSa8pv1PdmXeBtQnBNwU5UfOyrP216oIi4xe3EGd5azo7y4n6FA9lm1ebNFNloBPQVpMwzD6FzoLF++nP78808aMWJEhuVt27YVHZsZ00SWmkoPFi8V/4PiPXuQY5kyZMwoN/GsU0WzJp4ulStRjV/mU5G2rdUuTGgs3H4cRhHRidmuExaZINYzNMhCQzYaus8zDMOYhNB5+vQp+aVnSCib7x0cHDJYeBjT4uWu3RT76JGYti9Zgkr26UXGzuU78p5NQFW/puywsLamYh3ak6mBwGNdrpcX5Me4G4ZhTFTolClTRjTwzCx0duzYIdxXjOkR/zKQnv++VT5ToACVHz1SiABjBq6b2wFvFJlF+kqdNkbUjbsxRHwOwzCMMaGV03zcuHE0YMAA+vHHH8X88ePHaf/+/SJ2Z8WKFbo+RkbPIH364ZKlIt0XeHXpZFRuGlXcDohUBOLW1cKaY8pUKecuagbBPaUKDzd7sR7DMEx+Riuh8/nnn1NSUhJ98cUXIgOrRYsW5OHhQfPmzRMCiDEtgvcfpKjbd8S0XVFPKtX/QzIF/B/LezeB2loInZSUFHHODurQkUwN1NP5rLsfzVp/UeU6Q7v5ivUYhmHyM1qnQYwePZpGjRol0skhdkqWLMm1H0yQhNevKWD9RsW898jhOmtEqU9gyZGEjq2NJfl5a2a5QDPafv360alTp8i3VClyt7YWqc3Z1XexdjGObCuJRtW8aPLAurRyp38Gyw4sORA5eN+YwPgVMMFxZhjGtMlVvificyBwGNMENWgeLV2haKqI8v1u1UyjDP+jl5EUHSdPr65RvjBZW6mfAg9x06dPH/H9jx49Ss2aNaPEdu2yrd+Cm68xBtNCzNT3LSayq6TKyHBXGaMlB+OHYoCmOM4Mw+QzobNv3z7atm0b/fbbbxmWf/LJJ9S3b19q3970sljyIyH/HaeIq9fEtI17ISozyHTcjlK3ck2zrV6+fEmtW7emBg0a0NatW6lo0aJiOW6upnqDhajx8/EgU8CUx5lhmHyUdTVp0iT68ssv31mOZVOmTNHFcTF6Jik8nJ6sWauY9x72GVk5yivtmgKX7r5NK69dKWehExMTI1ysxYsXp71799KRI0cUIodhGIYxX7QSOvfu3aPSpUu/sxzL7tyRB7Uyxs3jFatFE0Xg0awJFapXl0wFFMp7+EIen4NO5Tk1q7x58ybVrl2b5s6dK+Zh0bHiKr0MwzD5Aq2ETrly5YT7KjN4Us5KADHGReiZsxR29pyYtnJxoXJDBpMpceXeK0U/p9qVimS77ubNm6l+/fpka2tLPXv2zJsDZBiGYUw7Rmfs2LH02Wef0aNHj0QgJ4I6T5w4QXPmzBHpuozxkhwdLaw5EuWGfiq6cZsSF28rx+dkLXSSk5OFK/XXX38VJQ+WLVsmKnczDMMw+Qut6+jExcWJgoFff/21WIY6Ot9++614jzFeAn5bR8kRcrcP3FUeTRuTKZGamkZX78njcxzsLKliqYJZrgfXVEhIiChgieazhuw0zjAMw5hgejmelmHZef78ubiJlChRguvoGDnhV67S66PHxLSlgwOVG2Z6AuBOwBuKTZCnlVct40aWlhm9r4cOHRIWxnbt2tEff/xhct+PYRiGMYIYHcWHLSxETE6pUqW0Fjlnzpyhjz76iNq0aSPE06tXb90SWREeHi5cZN26dRMxFwsWLKCE9DowjGpS4uLp0dLlivkynwwkW3fTaw9wSSmt3K/cW5cbMqpmzpxJ7733Hq1fv14sY5HDMAzDaKVO4uPjhdjo2rUrNWnS5J2XuiCuB+0jUHQQlZaRHdO4cWORCpwVqampVLNmTYqIiKBPP/2UevfuTStXrhQ3N5TzZ1TzdOMmSgwJFdOu1fzIs21rkxwuSejAUONb1k1Mh4WFUefOnWn69Ok0Y8YM2rjxbaVnhmEYJn+jletq+PDhwkXQq1cvqlWrltY7R3xP9+7dafbs2WIeVp1ixYoJ8YLGoZmxtLQkf39/cnZ+WyIe3dIhfi5evEgNGzbU+ljMmchbtyl4734xbWFrSz4jh5mkteN1eBw9DZZX1S1f0o2cHeTd1T/88EO6dOmSyASE6GUYhmGYXAmdXbt2iTL6VatWJW1BMDPcVpKbATg6OgqxAxGVldAByiIHuKZnDLH7KmtSExNFZ3KJ0v0/JDsTLZSnXA0ZaeXR0dFUpEgR+uWXX0RGFZc2YBiGYXQidHBTyW2PKwQxS5VqlcE8+g+py6xZs8jT01PUSlFFYmKieElERUWJ/7F/vHQFtoVAWF1uM7c8+30rJQQGiWmnCuXJs8N7RnV82qaV/7t1Gc26+B9duHCBKlasKJaZ6vcyZozxnDZXeKx5rM2NND1ePzTZplZCB/EQsMQgrkZbUOcE2NnZZVhub29PSUlJam1j6dKltG7dOtqzZ0+2NVIghpD6nhmkH+vSEoSBj4yMFD+stsHZuiTx6TMK3LVbPmNlRQU/6EshYWFkiiSnpNH1ByFiOiUhiv7+fTXNmDFdBKcbw1ibK8Z2TpszPNY81uZGmh6vH7Do61Xo4OYyZswY2r59O/n4+LwT77F69duCdKooVKiQIpBUGcxL72XHmjVrRJbW77//Tm3bts123cmTJ2dwhcGiA4tU4cKFycXFhXT5o2IssF1D3xTSUlLIf9ZcHJSYL9mnF5WoUZ1MlSt3X1NSivy7xLy+S2fOnBa9qoxhrM0ZYzqnzR0eax5rcyNNj9ePzEYSnQsdHDC6lIPY2FhtNkFeXl7C5XT58mVhIZKAKwKZV9mxdu1aGjFiBG3atEmtsv4o/49XVt9D14OPH1Uf29WUlzv/obiAp2LaoUxpKtGzh8GPKTdcTi8SCKZ/9QlVr16OXr9+bRRjbe4YyzmdH+Cx5rE2Nwro6fqhyfa0EjooxKYLPvnkE2H9QTsJZFvt3LlTpJgrW4SQxn7r1i3asGGDmMf/w4YNEyIH6eXMu8Q9e07Pt26Tz1hYUPnRI8nCRJtYoq7Sxo2b6F5SNTFvaVGAGtXgfmoMwzCMehj07oe6J+iEDvcXMmYCAgJo4cKFGQKLHzx4QFeuXBHTqJ8DceTm5ibWw0ti0qRJGSxD+RVZaqrIspKl1xUq3r0rOfl4kymCzL4+ffqQjVMR8usij7GqWs6dHOysOTiWYRiG0Z/Qgd8NgcCIk3n8+LEINgITJ04UAcpoB6Guj+2vv/6iZ8+eiSf3ChUqKNLFlQWMFHTk5OREx48fz3Jb5cuX1+armB1Be/ZR9L37YtrOy4tK9utDpgYC15Ay/r///U+4MT8dv4C2HXsu3qtT2dPQh8cwDMOYu9DBTWjRokU0YcIEGjlyZIbifSjDj0aKmoAWEnhlBaw9ioO1stKo8nJ+IyE4mJ5u2qKY9xk1nCyziE0yduCeRPA4hA4ax85YfV7xHgsdhmEYRhO0ig5avnw5/fnnnyIgWBlkP/3999/abJLRgRXk4a/LKS29XlDRju3JtWoVkxpXyXKHSseHDx+muXPnUlKKjG49lmfmeRZyoBJFnAx8lAzDMIzZC52nT5+Sn5+fmFZOLUctG6kYH5O3vDp0hCJv+Itp28IeVPrj/ib1E2zZskXEaSEey9ramlq3lvfiQu2clFSZwppjiq0rGIZhGBMTOmXKlBFp4UD5xrNjxw7hvmLylsSwMApY+7aVhveIYWTlYG8SPwMqVo8aNUp0sEcweebzR7kaMrutGIZhmDyJ0UH8xIABA0T8BECA8P79+0XsjqbxOUzuXVaPlq2k1Lg4MV+kVQsqWKumSQzrixcvRGPYq1evCncoygwoC2d8t8t35ULHxtqS/Hw8DHi0DMMwTL4ROp9//rlo0/DFF1+IDKwWLVqQh4cHzZs3TwggJu8IPXmawi9eEtPWbm5UZvAgkxl+BJdLaeR169Z95/3HLyPpTZQ85qiajwfZWlvm+TEyDMMw+bSODtLI4XLAUznEDloqcOXUvCU5MpIer1qjmPceNpSsM3V3NzZwrsDy179/f9HC4ezZsyrjbi6lW3MAu60YhmGYPC8YiBtUbruYM9rzePVvlJIe/O3esIF4GTNv3ryhjz/+mPbt20dFihQRYie74OJLHJ/DMAzDGELodO/ePdv30cqB0S9vLlyk0BOnxLSVkxOV+3yIUQ85gtcRj4OsvL1791L79u2zXT8yJpHuPQsX0yU9nUVqOcMwDMPkidDJXPkY7gi0akDtE2TPMPolJTaWHi1fqZgv++knZFOwoNEOOzrSI46rcuXKdOzYMZFGnhNX770mmTyrnOpyNWSGYRgmL4XOkiVLVC5HBg2jXwLWbaCksDdi2q1WTSrcsrlRDnl8fLyoiePu7k67du0S7Ryy6iKfFRfvKMXnVOG2DwzDMIx26LRvOjKuEH/B6I+IG/706uBhMW1hZ0c+Iz43yiJ6Dx8+pIYNG4rGraBVq1Zqi5zUNBlduftaTDvaWVHlMoX0eqwMwzCM+aLT7uVo8Im0c0Y3JIaEUHKUvC0CQHuHB78sUsyXeL8H2RYubHTDDevNwIEDRcBxv379NP78vadvKCY+WUzXqFiErCx1qscZhmGYfIRWQgcdxTMTHh4u+lwh4JTRjci5PHw0yZLlN/yseL5tOxVp1dxoxA5itaZMmUJz5syhHj160Nq1a9/pRq8Ol5TdVpXYbcUwDMPksdC5dEleoE6ZggUL0jfffEPDhg3LxeEwErDkZCdyAN7HesYidOBCCwoKovnz54vq2dq61JSFTu3KRXR4hAzDMEx+Qyuhg+wqhpE4ffq0qJHTpUsXWrduXa5ihsIi4+lJoLw2kE9JNyrobMcDzTAMw2gNBz8wWoNeVAsWLBCp4ytXrhTzuQ2MVrbmcFo5wzAMY5QFA5Xh4oHmSXR0NA0ePJi2b99O48ePFw1edZH9lSE+h+vnMAzDMIYQOi4uLrRx40by9fWlOnXqiGUXL16kW7duiRL/hQpxOrC5A5Fz4MAB2rFjB73//vs62WZySipdux8ipl2dbMinhJtOtsswDMPkX7QSOikpKTRjxgxFjRSJb7/9lu7fvy+aNjLma8lxdnamWbNm0Q8//EAVKlTQ2bZvPQ6jhKRUMV27kidZWBhffSCGYRgmnwQjL1269J3lY8eOpYoVK+riuBgjA/WRkEl19OhR0bfKx8dH5/vIUA2Z3VYMwzCMoYKRcdO7ffv2O8vhuuKCgbrB2sWZClhbZ7sO3sd6+ub58+fUrFkzWrVqFY0ePZrs7PSTCXU5XejAklOzIqeVMwzDMAay6KDqLQoDom5O3bp1RbYNaut8//33NGjQIB0cFoPaOLWXLc5QGTkzEDn6rqFz5MgRUd3YwcGBTp48SfXq1dPLfgJDY+hlSKyYRssHJ/vsRR7DMAzD6E3o/PTTT1S4cGGaOnWqqJ8C0Ljxyy+/pIkTJ2qzSSYLIGIMXQwwNjZWBJwj+NzDw0Nv+7l0m91WDMMwjJG4rqysrIQ1JywsjIKDg8UrNDSUvv76a/EeY9pAvM6bN09Y6rp27Up79+7Vq8gBXD+HYRiG0Qe5ViWentyLyJxAoDHcklFRUeL/smXL6r07enxiCvk/ChPThQvaU6mi+o87YhiGYfIHFto2b1yyZAnVrFkzQ9NGuK1evHihy+Nj8ghYbxBs3KhRI2G9uXLlihA5ecGNByGUkpqmaOKpb2HFMAzD5B+0Ejqok4PGjUOHDhVP/hKVKlWimTNn6vL4mDwCnec/++wzUQjw1KlTVLp06Twb+wxp5VXYQsgwDMMYWOgsX76c/vzzTxoxYkSG5W3bthU3TMZ0iImJEf9369aN9u3bR8uWLSNbW9s8tSRJaeXWVhZUzVu/sUAMwzBM/kIrofP06VPy8/MT08puBqQgK1t4GONm165dVKZMGWHBsbS0pPbt2+f5MQQERVFoZIKY9vPxIDtbDmZnGIZhDCx0cHNE0GpmoYO+R3BfMcYNWnhMmjRJNGdFIUBJtBqCDE08K7HbimEYhtEtWj0+oxXAgAEDRMdqcPz4cdq/f7+I3VmxYoWOD5HRJa9fv6a+ffuK4n9IIf/qq68MGvybIa2c43MYhmEYYxA6n3/+uWj18MUXX4gMrBYtWohMHdw4IYAY4wUuqvj4eFHxuHnz5gY9lpi4JLobIC84WbywExV1dzTo8TAMwzDmh1ZC5+HDh6Ln0ahRo0Q6OcROyZIlycJCK08YkwcBv2jCCldV8eLF6ezZs0aRwn3l3mtKk8mn2ZrDMAzDGI3QQYfy1NRUcbOEwGGMl+joaJEyvn37diFEhw8fbhQiB3B8DsMwDGOUQgdWgWfPnlGpUqV0f0SMzkA3+Z49e1JgYCBt27ZNVDo2FlLTZHT57msxbW9rSVXKuRv6kBiGYRgzRCtfEyogo4YOV0E27vo4iMGxtrYWneWNSeSAh8/DKSo2SUzXqFBE1NBhGIZhGKOw6EyfPl009ITbytnZmWxsbDK8jwafjGFAkDhwcnISVpx69eqRo6PxBflmqIZcmdPKGYZhGCMSOuhzxRgfz58/pz59+lDdunVp0aJF1LJlSzJWpGrIoHalIgY9FoZhGMZ80Ujo9O/fnzZt2kT9+vUT83CJ1KlTR1/HxmjA4cOH6YMPPiB7e3tauHChUY/dm6gEevgiUkyXK+5K7q72hj4khmEYxkzRKDBi8+bNGeZhOWAMnzr+ww8/ULt27ahWrVqi6zjcVcaMsjWH3VYMwzCMPuEIUBMHqeIICp82bRrt3btXFG40di7dVaqGzPE5DMMwjB7hDoomCnqNBQQEiPRxFAM0lto4OZGckkZX74WIaWcHGypfqqChD4lhGIYxYzQWOnfv3s12HnBjT/26qtasWSOqUsNF9f7775uMyAF3AsIoPjFFEYRsaWE6x84wDMPkA6FTuXLlbOelmzGje+Li4mjkyJG0bt060W8MTVRNSeSAi7c5PodhGIYxUqGDHkmM4YAV548//hBCZ+DAgSb5U1xOj8+BIacWp5UzDMMwxiR0GjRooL8jYbKtcowCgDNmzKCxY8dS9erVTXK0gsNi6fmrGDFdsXQhEaPDMAzDMPqEs66MmJSUFJo8ebIQNlFRUaK3mKmKHMBp5QzDMExew1lXRsqrV69EAcATJ07Q7NmzRasNU0e57UPdKtz2gWEYhtE/LHSMkDNnzlDv3r0pNTWVjhw5IppzmjoJSSnk/1DeA83d1Y7KFHMx9CExDMMw+QAWOkZIfHw8VahQgbZs2ULFihWj1DQZ3X4cJlonFHKxoyrl3E0uLRsiJyklTVEN2dSyxRiGYRjThIWOkRAdHU3Lli2j8ePHU+vWralVq1ZCDJy5EUgrd/pTWGSCYl1YRD7r7keNqnmRqXApQxNPdlsxDMMweQMHIxsBt27dEn3Dvv/+e0UBRknkzFp/MYPIAZjHcrxvCqCukiR0rCwLUI0KhQ19SAzDMEw+gYWOgfn9999FhWNra2vRDb5KlSpiOdxVsORkx6pdN8V6xs7zV9H0OjxeTPuW8yB7WzYkMgzDMHkDCx0DcvjwYfrwww+pR48edO7cORGXI4GYnMyWnMyERsTTWf9Ao69Erey2qsPZVgzDMEwewo/WBiA2NpYcHR1FLM6///5LHTt2fCc4F4HH6jBnwyVyc7KlciVcybs4Xm5UrrgrFXV3MJqA30t3XiumEYjMMAzDMHkFCx0DWHE++ugj2rBhA7333nvUqVOnLNdDdpW6RMQk0pW7r8VLwsHOSgiecuniByKoRBEnsrTMWyNebHwy3X4SJqaLeThS8cJOebp/hmEYJn/DQiePSEtLo1mzZtHUqVOpbdu2VLt27WzXRwo5squyc18h1qVCKTd6/DKKouOSMrwXl5BCNx+FiZeEjZUFlfFyUVh9vEu4UumiLmRjbUn64ur914o4orpszWEYhmHyGBY6eUBERAT179+f9u7dK4TOtGnTyNIye3GBOjlIIUd2lSq+6FdTpJgjRic0IoEev4ygRy8j6fHLSHr0IoJCM4kk1LG5/yxCvJT3U9LTOd3yA/HjRmW9XMjBzlr3aeUsdBiGYZj8JnSQaYT6MWh54OfnJ+rIuLu76/wzhsTCwoLevHlDe/bsoQ4dOqj9OYiYyQPrvlNHx8PNnoZ281XU0UEsTuGC9uJV37eYYr3ImMQMwgf/B4bGZtgHrC0BQVHidfTSc8VyLw/HdKtPuvWnuCu5OtmqfezY7s1HoXT2RpCYt7G2ID9v4/2NGIZhGPPEytCtDlq2bEnDhw+ndu3a0dKlS6lx48Z0+fJlEayrq88YirVr11KzZs3I29ubTp8+rVVwMMQMxIs2lZEhTGpVLCJeEnEJyfQkMIoewfrzQi6Cnr2KprRMaeoQRHiduv62Vo+Hq10G4VOuuBt5uNm9872yKnJIMqKLt1+ZVJFDhmEYxvQpIDNgbnKLFi2oUKFC9NdffymqA3t5eYnCeWPHjtXZZzKDTuCurq4UGRlJLi4uOo3Def36tWjAOXr0aCF05syZQxMmTCBjJik5lZ4GRymED0RQQGCUomVDdjg72IhYHynjKzI2kVb8rbr+DyxUuhA70lgXKVJEWMwY/cDjnHfwWPNYmxtperxOa3IftzJkP6eTJ08KMSABgYCU64MHD2YpWrT5TF4TEBAgrE337t2j9evX04ABA8jYQTBy+ZIFxUsiNTWNXryOEa4vCB8IILwQ5KwMgqCv3Q8RL3VAkUNYqEytVxfDMAxjmhhM6Dx//lyovRIlSmRYjvn//vtPZ58BiYmJ4qWsBAG2hZeugBB7//33hQsNLrZq1arpdPt5CbxRJT2dxKtFreJiGdxbr97E0eNAueiRW38iKTImY8ZXTkUObz4KIT9vj1wdH8YVxkhTHV9TgceZx9oc4fPa9MdZk20aTOgkJclvjvb29hmWOzg4KN7TxWcA0rq//fbbd5aHhIRQQoJ6hfnUHXi4qtC3ys3NTZjszA3kipUvakXli7oT1XYXJ3FkbDI9fRVLZ2+G0uX7b3LcRsCL1+TpnJbrsYbJEvtn15X+4HHOO3iseazNjTQ9XqcRtmL0QqdgQbmbBNlIyoSFhSne08VnwOTJk2ncuHEZLDolS5akwoUL6zxGp02bNmK7+enmi1rHFcoRFS3iTpfvn81x/TIlilCRIrm36Ihss3w21nkNjzOPtTnC57Xpj7OdnZ3xC53ixYuLL3/lypUM1YExD4uIrj4DbG1txSszGHhdDz5+VH1s1xTw9S6cY5FDpMZjPQsdxOjk57HOS3iceazNET6vTXucNdmeQe8QAwcOpDVr1ihcPCiod+3aNbFc4ueff6ahQ4dq9BnGMEhFDrMD9X84EJlhGIbJF3V0EDdz69YtKl++vKg1c+fOHZo7d66oiyNx+/Zt0dlbk88whkPdIocMwzAMY/ZCB0HEsMjcv39fVDmuXLkyeXhkjN346quvRDCTJp9hDEtuihwyDMMwjFm1gAAVKlQQr6yAkNH0M4zhgajx82EByjAMwxgWjuJkGIZhGMZsYaHDMAzDMIzZwkKHYRiGYRizhYUOwzAMwzBmCwsdhmEYhmHMFhY6DMMwDMOYLSx0GIZhGIYxW1joMAzDMAxjtrDQYRiGYRjGbDGKysh5jUwmE/9HRUXpvCV9dHS0aB/PHbX1C4913sDjnHfwWPNYmxtperwnSvdv6X6eHflS6GDgQcmSJQ19KAzDMAzD5OJ+7urqmu06BWTqyCEzVJmBgYHk7OxMBQoU0KnChHh6/vw5ubi46Gy7DI+1oeBzmsfaHOHz2vTHGdIFIsfLyytHa1G+tOhgUEqUKKG37eMHZaGTN/BY8zibG3xO81ibGy56uifmZMmR4GBkhmEYhmHMFhY6DMMwDMOYLSx0dIitrS1Nnz5d/M/oFx7rvIHHOe/gseaxNjdsjeSemC+DkRmGYRiGyR+wRYdhGIZhGLOFhQ7DMAzDMGYLCx2GYRiGYcwWFjoaEhMTQ5cuXaKAgAC9foYhUWQK46Zuq47U1FS6c+cOPXjwgFJSUngI1QRjdf36dbp165Za5dSVuX//Pp06dYri4uJ4vNUgLCyMLl68SMHBwRqN16NHj8Tvg2KnjHrgOnDlyhVKSEhQa/3k5GS6d+8eXb16lSIiIniY1QTX3QsXLtDt27fV/QjFx8fT5cuX6eHDh5QnIBiZUY+1a9fKHB0dZRUrVhT/v/fee7Lo6Gidfya/Ex8fL3v//fdl9vb2skqVKon/Fy1alO1nvv/+e5mnp6escuXKsjJlysiKFy8u2717d54ds6ly/vx5WYkSJWQlS5YU41ehQgXZnTt31PrsvXv3ZC4uLlBGMn9/f70fq6kzbdo0ma2traxKlSri/08//VSWmpqa7WeuXr0q8/PzkxUpUkRWu3ZtWdWqVWXXrl3Ls2M2RV69eiVr0KCBzM3NTebj4yMrWLCgbNeuXdl+Zt++fTIvLy9Z6dKlZTVq1JDZ2dnJxowZI0tLS8uz4zbF6/R3330nxgzXgU6dOqn1ub/++kvm6uoqfhv836hRI1lISIhej5WFjprcunVLZmlpKduwYYOYDw0NlXl7e8uGDx+u088wMtmkSZPEzTcwMFAMx99//y1upufOnctyeFJSUmRff/21LCwsTLFs+vTpMgcHB1lQUBAPqQoSEhLEOH/22WdiHjfdrl27yqpVq6bWZ2vWrCmbMGECCx012Llzp8za2lp2+vRpMX/37l1xkV+4cKHKzwQHB8vc3d3F9QLnOHj48KG4KTOq6d69u6xOnTqy2NhYMT9r1qxsrwUQMxjnkSNHKpbhWoNrDj8sybI9P3Hdffr0qaxv375qCZ3nz5+LB9eff/5ZzOOhv3r16rLevXvL9AkLHTXBBR2WAmXmz58vc3JykiUlJensM4xMWBZmzJiRYSh8fX1ln3/+uUZ/hLhQ7dmzh4dUBf/8848YI1x8Ml/gL168mO24jR49WjZo0CCxHlt0cgYCsn379hmWDRkyRFzkVTF58mRhyYGoZNQDlgELCwvZH3/8kcHy4OzsLFuwYEGWn0lMTJRZWVnJNm3apFgGYQmr22+//cZDrwbqCp25c+cKC1tycrJi2bp168T4h4eHy/QFx+ioCfy2tWvXzrCsXr16Iv5GlZ9Rm8/kd9Bs9dWrV1mOG8ZTXRAHAby9vXV+jOYCxtPT0zND37c6deqIRrfZjfXu3btp7969tGjRojw6UtNH1bXg5s2bIjYkK44cOUJt27YVvfnw+SdPnnCMTg7cuHFDjJHyWNvZ2ZGfn5/Kc9rGxoZmzJhBM2fOpK1bt9LBgwdpwIABVL16derdu7fmPzajEvwG1apVIysrqwx/B4gT9Pf319vI5cumntrw5s0bKlu2bIZl7u7uivd09Zn8jjQu0jhJYF7dMQsNDaXRo0dTnz59qGLFino5TnMA45l5nC0tLcnNzU3lWL98+ZKGDh1KO3fuJGdn5zw6UvMca8wjkBPB9pnfk0R/8eLFydfXl+zt7UUAM9bbsmWLuAkzWY+zNLaaXD969uxJ+/bto//9739UsGBBCgoKop9//pmcnJx4mPPg70B6T1+wRUdNrK2t34neR+S49ESgq8/kdzBmIKtxU2fMIiMjqX379lS0aFFavXq13o7THMjq/ARYpmqshw8fTo0aNRJPYMi2QraW9KSGLBdGt9ePPXv20ObNm+natWv07NkzqlChAvXr14+HOZtxls7hzGOtapyjo6OpefPm1LBhQ3r69Kk4p2GxHDJkCG3fvp3HWocY6p7IQkdNSpcuLZ5mlZHmS5UqpbPP5HdKliwpTPVZjVtOY4Yn43bt2gmrxP79+9nikAM4P+EmhFVBAk9VuPCoGms8fb1+/ZomTZokXosXLxbLFyxYQNu2bVP3Z853qLoWwHqmyjJWpkwZ4UrES7oRDB48mO7evSuslkzW4yyNbeaxVnVOIzUa5/SIESOE2xZgzOvXr0///PMPD7MOMdQ9kYWOmsBXjifY8PBwxbJdu3YJ3y/iHKQbLdZBDI66n2Ey4uDgICwGyheY2NhYOnz4sBhPCcQ4KfvcJZED4GN3dXXloc2BNm3aiLFFLIjy+YmnLjzhSuAchhsFrF27VsxLL8lqtmHDBpoyZQqPeTbXD1gJlEUlxlr5nIboxJhKtXLee+894UJRrp3z4sULIXhcXFx4rLNAurYqXz9Q6wn1tZTHGvEgEIygcOHCirGVwJjjBiy9x2gHHppwTkt1ifAbII4KljPlvwO4aCtXrkx6Q29hzmYGMh+Q+dOkSROR7oysIKSOK6cfnjx5MkPGijqfYd7l2LFjIhUXaeaof9GmTRuRlq9cfwg1SFBTBCCDDbUYkKHy77//it9BeiH7ilHNJ598IlLMkXGyevVqUXtkypQpGdbBOa0qY4WzrtQDpRJwfvbq1UtkuyGDECnPyvWHVq1aJcZaOs+joqLEef/RRx+JlPIVK1aINOiJEyfyKZ0Na9askdnY2IgU5u3bt4s6RM2bN89QE6dx48aynj17KsoqtGzZUtR1wd/B3r17ZR988IFIg0aJEEY1yNLEdbZ169biGozpM2fOKN5HTS6c01JJBIw1xh6lKXbs2CGbN2+eyLhav369TJ9wMLKaoM388ePHafbs2cJcDxP+gQMHqHXr1op1YEVo3LixwhStzmeYd4E14b///qNff/1VmJXxlLZx48YMgYHly5enpKQkMY2qvDA5Y9msWbMybAvulc6dO/Mwq2DlypW0ZMkSMb7IhJg3bx59+umnGdbBOY0nrqzAuY73HR0deYyzoVixYnTu3DmaO3eucPPBTH/mzBkRaCyBuDKMJVyv0thiHXxm/vz55OHhIa4jHKOTPXDvFSpUSFgZEX/z/vvviyBjyS0FkPkjBcHCVY5YqGXLltFff/0lrJyIhUJcFP5nVINMNclag/HF9RZWeVjVAaZxTiPAWxprBH3jOoPxhmVyx44d1LVrV9InBaB29LoHhmEYhmEYA8ExOgzDMAzDmC0sdBiGYRiGMVtY6DAMwzAMY7aw0GEYhmEYxmxhocMwDMMwzP/bO+8YG74ojo/4A0H8I1hL1KyWKCuERO+il9WiRIveJYgg/kAiuuiit0VCsCtBECLaqlGit+gtRLRd5pfPSe7LvLevzHu7/J7J+SRiZ97M3Dt37sz9zjln7vEsKnQURVEURfEsKnQURVEURfEsKnQUxcGPHz8kJUJqaqpMCc8kb+fPn9c28iCkATh58mSOjnHx4kXr7NmzYbchVcnp06et3IAJSB89epQrx/IypOHZtWuXL2Ekk9qxbCYZDQbpNsiRp3gPnRlZiXuY0/LGjRvWw4cPZfZpcqL8iVxhiJw6depIridmWSapIrMGM2MwCf4Ub4GYRcg2adIk5mOsWbNGBlUyX4di8+bNkputYcOGVk4gO3xKSorkbVLC8+rVK6t3797Ws2fPrFKlSlmPHz+W5bdv38oM0+QfZJb6bt26+TKek2CVjOXM1Kv3u7dQoaPENSSEGzp0qLyRIUJI93Dnzh2ZVnzdunW5mqH8zJkzMph8+vRJEidCRkaGTFuuKLGSnJxslSxZMscNOGPGDGvgwIG+1AWKe0hB0LNnT0nLAw8ePBDhg+BB4ECBAgWssWPHSnJaZ6Jb5d9HhY4St5Brhmy3o0ePlhxWWFaMhWfv3r1iljZCh2zDuJgwP2ONIT9WoIshKyvLqlGjhhyXHDh169b15WBhncncTb4bA4NKuXLlfMu8TV+7dk3+xrpErqLSpUtHVZaTW7duSXblihUr+uU9MmDJwhrAW2mtWrV8eZCCYcoljw/l8hBv1KiR5JOhDgg5zo/s8DzUnYRrPyxpHI+cQU6oF5mInevD1ddNu0TTdtG0jbHYnTp1SoQr2wcT1eTmQZgYOL8PHz5EtPpg1cFF9fnzZ2lzpwCnLZ19KJpzdFoosDRQHydPnz4VFxy5nai3Gcjd9C+39wzrybmF28fkjeNvrGG8FFStWtWqUKFC2PbZt2+fVbt2bbmHuX/ok/RDZ/4psw3rLl++LPnAzHV6//69lMf5cZ6cbyC0A5abypUr+x3X3KudO3eW/cllZXIxca9zzcuUKSNWub59+0q+JjKbcxzFI/zRlKGKkgPatWtnV6lSxc7Kygq73Zs3b+zk5GTJwt2mTRvJwN21a1c7MzPTL9t5jRo17MqVK9utW7e2a9asaRctWtS+ceOG/E7W4vr160vW4549e/r+lSlTxh4wYIDvOGRTN7+1atVKMlDPmTPHrz6RygIyVHN+1JVtyHJPlmrDly9f5PfExES7Q4cOcizO8fnz5yHbwWR0p860Q6VKlSRjNpmBy5UrZ7dt21YyNLMNx3fbfg8fPrTz5MljX7p0ya88MnGzndv6umkXN9vE0jYvX76U9ihbtqycI+dKFmWyLhs6depkjxo1ym8/MoU7twnW5tWrV7fLly9vt2jRQvpr8eLF/bKSjxs3TuobzTkGsnHjRrtEiRJ+6+bNm2cXLlxYrmujRo2kHnfv3nXVv9zeMxwzKSlJ+vro0aNl/ZUrV6SPkYG6ffv2UneysYeDrOstW7aUa0Z92Yd2/f79u982lMOxO3fu7MtovXLlSrtIkSLSvuxDXVNTU/2OP3bsWLkX2Z+M75TB8Pbs2TNfnVl++/atnDvbscw5cy8vXbrUdyyuC1m1Fe+gQkeJSxA3+fPnt6dOnRpx2yFDhshgwcMdHj16JA/DFStW+D20OZ4ZTH7//i0P3v79+/u22blzpzxsnTA4OIVOIFevXrXz5ctn37lzJ6qyhg4dKqKDAdiwf/9+398jR46Uh/GPHz9k+devX3aPHj3koRwKU+7t27dl+efPnyJwChYsaN+/f1/Wffv2TQbMNWvWRNV+DDJOEfDu3TsRhWlpaa7r66Zd3GwTS9sMHDjQrlevnv3161dZ5vjUPzeEDgPmkSNHfHVh8ER4hBM6kc4xkDFjxtjNmjXLdn+kp6f71t27d8++fv26q/7l9p7JmzevnZGR4VtHn0IsLl682LcO4ZCQkCD3Tyi4rxAwCA2gXvTDRYsW+W2DIPv8+bNv3blz50TMOYXjoUOHZB3lwqlTp/zqSR2bNm0aUujAxYsXZfnjx4/Z6pqSkiL9SfEOGnygxCXE5Hz//l3M126CSvGtFypUSJYJIsYEzVcWTggGrVatmvyNabtx48YS7xMtuBpwgezZs0dcWfj4L1265Los3AHbt2+3Jk+ebJUoUcK3T6dOneT/X79+WVu3bpX9Dxw4IOXgqktMTLROnDgRtm64TYzJHTcVroDmzZv7XAv58+e3atasKe6MaNqPIM0dO3aI+we2bdsmQZ2tW7eOqr5urkG4bWJtG7bDBWpcduxv3DA5hfbExQq4xbiu9I/Xr1+H3Cfavvju3Ts/1xbl4IbBfYcLCnBP4WaK1L+iuWdwL9GHDLTxkydPrGLFikm7066so39F6pvEF9FngHr179/f2r17d7ZtnG4/Ark5L1xJlMX2uAkzMzMlfs6cS9OmTX31pN9PmDDBihXamfZWvIPG6ChxScGCBWUAwDcfDuInEB7ly5f3W8+Dl4HQSaBfn4ECMRUN+/fvl4cxMRf49c0x3rx547oszomg6qSkpKBl8DvnRDzGixcv/H5r1qxZ2PoFxnlQLm0Zqi5u269Lly4iFIij6NWrl7Vx40ZrwIABEhfDubutr5trEKntom0bzpHBkcHcCdeQGJmcEuy4gCAI9XVgtH0RQcIXRAbuDcTm+PHjrfnz54vAJdi2R48eEftXNPdMQkKC3zIxMATqB26H0AxVXrh2QrRGKo84IESVE0Sb6dfEKYW6BrFADE9ufuSg/P+o0FHiEiwPBNUSgBgOggx5g+Ph7YRl8/aYm/AWPHPmTL83Rt5OcQO7hYcob+ShRByDGr8PGjTI6tOnj/Uncdt+DG79+vWzNmzYIIGrBJTyhv236xtLWQS+EgRLcLaTwGWOa6wjBjdCONRxc7P/ISKwEjnBIsU/ArIPHz5sDR8+XIQBgjRc/4rmngkM6qUtCURev369zxrklmDt5KY8BFigpckJHwxEurbRwDxFDRo0iHl/Jf5Q15USt0ycONFKS0uzjh49mu03Hsq8eWFRqFevnt+XUgxWLOf2wwoxg/WiUqVKfl/qhHNRBIOvPKjbli1b/NYzx4f5HdcGc7QECqjnz59buUk07Yf7is9uZ8+eLRYEBM/frm8sZSFyOEescU4Bk56ens0qgWhwtgMT9EUCMc5XUQbaji/BsPjlFrgfcTeaPkL9jVDBtTNmzBixulGXSP0rJ/cMX58heteuXeu3HpdipPvA2f5cO6yDTBMRjjZt2sikjriunOBaMpP/UWf6JVYqg/PcgmFEWqCQZZkvvlq0aBF2f+XfQi06StyCD58HXMeOHSV+gM8/+aScuAQm++KTV8zXCxYskBgH3lJ5gGPmZhCYPn16rtaHt03qgjUHNwJvzEuXLs3mGnLDsmXLJK6gXbt2ckwGad7K+aQXVqxYIb8zsOCO4KF+/PhxGUBXrVqVq+fltv34jJjfDx48aG3atMnvt79Z31jKmjt3rogFRA+fLCMCiGVxQh9j4J00aZJMSsnn3FyXSPPWcP0ZGEeMGCH9YuHCheLai/S5ezRQZ2JQiEfBYoPIZ1K7Dh06SFwObjziVxCAbvpXrPcM1sslS5aIsOLepA7MIE5b0cbh4p5u3rxpde/e3WrVqpV16NAhEZWBLqlAsCIiWhC3WFNxbfEZOSIVQYLo4jlBnXBdDh48WOLmwlmAAFcX1xXrLO3EMs8XppigDPqK4h3UoqPENTw8CTpkrhpM97zVMo8GMRom0JI5SHjoYQbHwsJDkTlNCJg0sA2BlU4I2uWN0cAbeOBcMTz8nLOkEhw5bNgwmfaft0oeuAxwTiuPm7KYQwXBxiDDsXDVmbk9gEBV5kBh4GBwYqAaOXJkWNEQrNzA+gPt4wwwddN+BuYiwfXGDL1O3NTXTbu42SaWtuGcODdcOrQ7YtUIJgPthAUH4cRgiqBAyDq3CYT6zpo1S4QFk9AhfhnEEU0G+isWsGjOMdSEgdQZ6wmDNAHwDNDMj0TwPkLGuPMi9a9Y7xnARXbhwgWJMzLuNNyYkYK7ESOIHOqNK45r5/zYgHsv0AqGWMQStHr1apnvh3l/2Je6mzgaxBr1QPRRLyxzLBOzhHUr2ISBtMexY8fEsoNwNwJw+fLl1rRp03SSUI+Rh0+v/u9KKIryb8BbMwMNA4/y95kyZYoEgweb8DCeQVCRToW6xytMjImli3rqbOjeQoWOoigRIQaCz4dxy2DtIC5EUbwkdBTvoq4rRVEiQvZtXAe46lTkKNESzC2lKH8LtegoiqIoiuJZ1KKjKIqiKIpnUaGjKIqiKIpnUaGjKIqiKIpnUaGjKIqiKIpnUaGjKIqiKIpnUaGjKIqiKIpnUaGjKIqiKIpnUaGjKIqiKIpnUaGjKIqiKIrlVf4D3TnBgCi0M94AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 580x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def reliability_diagram_data(y_true, y_proba, n_bins=10):\n",
+    "    \"\"\"Construit les donnees du reliability diagram, bin par bin.\n",
+    "\n",
+    "    Retourne (bin_centers, observed_freq) ou observed_freq[b] est la part de\n",
+    "    classe 1 reellement observee parmi les scores tombes dans le bin b\n",
+    "    (NaN si le bin est vide).\n",
+    "    \"\"\"\n",
+    "    bin_edges = np.linspace(0.0, 1.0, n_bins + 1)          # [0.0, 0.1, ..., 1.0]\n",
+    "    bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])   # 0.05, 0.15, ..., 0.95\n",
+    "    bin_idx = np.digitize(y_proba, bin_edges[1:-1])        # 0..n_bins-1 pour chaque score\n",
+    "    observed_freq = np.full(n_bins, np.nan)\n",
+    "    for b in range(n_bins):\n",
+    "        mask = bin_idx == b\n",
+    "        if mask.any():\n",
+    "            observed_freq[b] = y_true[mask].mean()\n",
+    "    return bin_centers, observed_freq\n",
+    "\n",
+    "bin_centers, freq_lr = reliability_diagram_data(y_test, proba_lr)\n",
+    "_, freq_rf = reliability_diagram_data(y_test, proba_rf)\n",
+    "\n",
+    "table_reliability = pd.DataFrame(\n",
+    "    {\"bin_center\": bin_centers, \"LR_freq\": freq_lr, \"RF_freq\": freq_rf}\n",
+    ").round(3)\n",
+    "print(table_reliability.to_string(index=False))\n",
+    "\n",
+    "# Diagramme : un point par bin + diagonale de calibration parfaite\n",
+    "plt.figure(figsize=(5.8, 4.8))\n",
+    "plt.plot([0, 1], [0, 1], \"k--\", linewidth=1, label=\"Calibration parfaite (y = x)\")\n",
+    "plt.plot(bin_centers, freq_lr, \"o-\", color=\"#4c72b0\", linewidth=2, label=\"LogisticRegression\")\n",
+    "plt.plot(bin_centers, freq_rf, \"s-\", color=\"#c44e52\", linewidth=2, label=\"RandomForest\")\n",
+    "plt.xlabel(\"Confiance moyenne du bin (score predit)\")\n",
+    "plt.ylabel(\"Frequence observee (part reelle de classe 1)\")\n",
+    "plt.title(\"Reliability diagram (10 bins) - ensemble de test\")\n",
+    "plt.legend(loc=\"upper left\")\n",
+    "plt.grid(alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af864939",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004671,
+     "end_time": "2026-08-23T00:52:54.581845+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:54.577174+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. ECE et Brier score : résumer le diagramme en un nombre\n",
+    "\n",
+    "Le tableau et le diagramme ci-dessus se lisent d'un coup d'œil : la régression logistique colle grossièrement à la diagonale, tandis que la forêt s'en écarte aux deux extrémités — ses scores ~0.02 cachent une fréquence réelle plus élevée, et son plus gros bin (des scores ~0.98, près d'un patient sur deux du test) promet plus que ce qui s'observe réellement. Mais un diagramme ne tient pas dans un tableau de bord ni dans une comparaison automatisée. Deux chiffres le condensent :\n",
+    "\n",
+    "**ECE — Expected Calibration Error.** Pour chaque bin, l'écart vertical du diagramme vaut |confiance moyenne − fréquence observée|. L'ECE agrège ces écarts en une moyenne **pondérée par la taille des bins** :\n",
+    "\n",
+    "$$\\mathrm{ECE} \\;=\\; \\sum_{b=1}^{10} \\frac{n_b}{n}\\, \\left| \\, \\text{confiance}_b - \\text{fréquence}_b \\, \\right|$$\n",
+    "\n",
+    "Intuition : c'est la distance moyenne au diagramme — l'écart que commet « en moyenne » le modèle entre ce qu'il promet et ce qui arrive. Un modèle parfaitement calibré a ECE = 0 ; en pratique, sur quelques centaines d'exemples de test, ECE < 0.03 est déjà très bon.\n",
+    "\n",
+    "**Brier score.** La moyenne des erreurs quadratiques sur les probabilités elles-mêmes :\n",
+    "\n",
+    "$$\\mathrm{Brier} \\;=\\; \\frac{1}{n} \\sum_{i=1}^{n} \\left( p_i - y_i \\right)^2$$\n",
+    "\n",
+    "Le Brier mélange les deux axes : il pénalise à la fois le mauvais ordre (discrimination) et le mauvais quantificatif (calibration) — y compris les écarts **fins**, exemple par exemple, que le binning de l'ECE lisse. On les lit donc ensemble : l'ECE isole la calibration ; le Brier juge la probabilité globale.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7160e3b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:54.591501Z",
+     "iopub.status.busy": "2026-08-23T00:52:54.590496Z",
+     "iopub.status.idle": "2026-08-23T00:52:54.604424Z",
+     "shell.execute_reply": "2026-08-23T00:52:54.603414Z"
+    },
+    "papermill": {
+     "duration": 0.019816,
+     "end_time": "2026-08-23T00:52:54.605967+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:54.586151+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                    ECE (calibration seule)  Brier (calibration + discrimination)\n",
+      "LogisticRegression                   0.0424                                0.0765\n",
+      "RandomForest                         0.0909                                0.1107\n"
+     ]
+    }
+   ],
+   "source": [
+    "def ece_score(y_true, y_proba, n_bins=10):\n",
+    "    \"\"\"Expected Calibration Error : somme ponderee par bin des ecarts |confiance - frequence|.\"\"\"\n",
+    "    bin_edges = np.linspace(0.0, 1.0, n_bins + 1)\n",
+    "    bin_idx = np.digitize(y_proba, bin_edges[1:-1])\n",
+    "    ece = 0.0\n",
+    "    for b in range(n_bins):\n",
+    "        mask = bin_idx == b\n",
+    "        if mask.any():\n",
+    "            confiance = y_proba[mask].mean()\n",
+    "            frequence = y_true[mask].mean()\n",
+    "            ece += mask.sum() / len(y_true) * abs(confiance - frequence)\n",
+    "    return float(ece)\n",
+    "\n",
+    "brier_lr = float(((proba_lr - y_test) ** 2).mean())\n",
+    "brier_rf = float(((proba_rf - y_test) ** 2).mean())\n",
+    "\n",
+    "table_scores = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ECE (calibration seule)\": [ece_score(y_test, proba_lr), ece_score(y_test, proba_rf)],\n",
+    "        \"Brier (calibration + discrimination)\": [brier_lr, brier_rf],\n",
+    "    },\n",
+    "    index=[\"LogisticRegression\", \"RandomForest\"],\n",
+    ").round(4)\n",
+    "print(table_scores.to_string())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9a56f89",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004136,
+     "end_time": "2026-08-23T00:52:54.616161+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:54.612025+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : mesurer l'incertitude de l'ECE avec un bootstrap\n",
+    "\n",
+    "Le tableau ci-dessus chiffre le contraste : l'ECE de la forêt aléatoire est environ le double de celle de la régression logistique. Mais chaque ECE est calculée sur **un seul** ensemble de test de 171 patients — quel intervalle de confiance lui donner ?\n",
+    "\n",
+    "À vous de jouer : rééchantillonnez le test **avec remise** (*bootstrap*) et recalculez l'ECE à chaque tirage pour obtenir un intervalle à 95 %.\n",
+    "\n",
+    "Indices :\n",
+    "- # Étape 1 : tirer `n_test` indices avec remise : `tirage = rng.integers(0, n_test, n_test)`.\n",
+    "- # Étape 2 : sélectionner `y_test[tirage]` et `proba_rf[tirage]`, calculer `ece_score` dessus, et répéter 100 fois.\n",
+    "- # Étape 3 : l'intervalle à 95 % est `np.percentile(ece_echantillons, [2.5, 97.5])`.\n",
+    "- Lecture : si l'intervalle du RF ne recouvre pas l'ECE de la régression logistique, l'écart est robuste malgré le petit test.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0cf38528",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:54.629788Z",
+     "iopub.status.busy": "2026-08-23T00:52:54.628028Z",
+     "iopub.status.idle": "2026-08-23T00:52:54.634073Z",
+     "shell.execute_reply": "2026-08-23T00:52:54.634073Z"
+    },
+    "papermill": {
+     "duration": 0.013716,
+     "end_time": "2026-08-23T00:52:54.635677+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:54.621961+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : ECE RF = 0.0909, IC 95 % = [None, None]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : intervalle de confiance bootstrap a 95 % sur l'ECE du RandomForest\n",
+    "rng = np.random.default_rng(42)\n",
+    "n_test = len(y_test)\n",
+    "ece_echantillons = None  # TODO etudiant : liste des 100 ECE bootstrap (une par reechantillon)\n",
+    "# TODO etudiant : pour chaque tirage, tirage = rng.integers(0, n_test, n_test) puis\n",
+    "# ece_echantillons.append(ece_score(y_test[tirage], proba_rf[tirage]))\n",
+    "bornes = (None, None)  # TODO etudiant : remplacer (np.percentile(ece_echantillons, [2.5, 97.5]))\n",
+    "print(f\"Exercice 1 a completer : ECE RF = {ece_score(y_test, proba_rf):.4f}, \"\n",
+    "      f\"IC 95 % = [{bornes[0]}, {bornes[1]}]\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7949e8d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003727,
+     "end_time": "2026-08-23T00:52:54.643534+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:54.639807+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Platt scaling : recalibrer avec… une régression logistique\n",
+    "\n",
+    "Diagnostic posé, passons au traitement. L'idée la plus simple : apprendre une **transformation** qui remappe le score défectueux vers une probabilité correcte. On ajuste une régression logistique (notebook 2.3) dont l'**unique variable d'entrée est le score du modèle à corriger** — pas les mesures d'origine :\n",
+    "\n",
+    "$$p_{\\text{calibrée}} \\;=\\; \\sigma\\!\\left(a \\cdot \\text{score} + b\\right)$$\n",
+    "\n",
+    "C'est le **Platt scaling** (Platt, 1999). Si le modèle est écrasé vers les extrêmes, la sigmoïde apprise ramène ses scores trop confiants vers leurs fréquences réelles. Faites le lien avec 2.3 : c'est exactement le même modèle, appliqué à une seule feature bien choisie — le score lui-même.\n",
+    "\n",
+    "> **Règle d'or (et on l'applique).** Le calibrateur ne doit **jamais** être ajusté sur les données qui servent à l'évaluer. Nous l'ajustons donc sur les scores **out-of-fold** de l'entraînement : pour chaque patient du train, le score d'une forêt qui ne l'a **pas** vu (`cross_val_predict` à 5 plis) — exactement ce que fait `CalibratedClassifierCV(rf, method=\"sigmoid\", cv=5)` en production. Le test reste vierge jusqu'à l'évaluation finale.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c2e273b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:54.651084Z",
+     "iopub.status.busy": "2026-08-23T00:52:54.651084Z",
+     "iopub.status.idle": "2026-08-23T00:52:55.238481Z",
+     "shell.execute_reply": "2026-08-23T00:52:55.237976Z"
+    },
+    "papermill": {
+     "duration": 0.592491,
+     "end_time": "2026-08-23T00:52:55.239732+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:54.647241+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sigmoide apprise : p = sigmoid(4.998 * score + (-2.434))\n",
+      "ECE RandomForest brut     : 0.0909\n",
+      "ECE RandomForest + Platt  : 0.0552\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Platt scaling : une regression logistique ajustee sur les SCORES out-of-fold du RF (pas sur X, pas sur le test)\n",
+    "from sklearn.model_selection import cross_val_predict\n",
+    "from sklearn.linear_model import LogisticRegression as LR2\n",
+    "\n",
+    "# Scores out-of-fold : pour chaque patient du train, le score d'une foret qui ne l'a pas vu (cv=5)\n",
+    "scores_oof = cross_val_predict(\n",
+    "    RandomForestClassifier(n_estimators=100, random_state=42),\n",
+    "    X_train, y_train, cv=5, method=\"predict_proba\",\n",
+    ")[:, 1]\n",
+    "\n",
+    "platt = LR2().fit(scores_oof.reshape(-1, 1), y_train)\n",
+    "proba_rf_platt = platt.predict_proba(proba_rf.reshape(-1, 1))[:, 1]\n",
+    "\n",
+    "a, b = platt.coef_[0, 0], platt.intercept_[0]\n",
+    "print(f\"Sigmoide apprise : p = sigmoid({a:.3f} * score + ({b:.3f}))\")\n",
+    "print(f\"ECE RandomForest brut     : {ece_score(y_test, proba_rf):.4f}\")\n",
+    "print(f\"ECE RandomForest + Platt  : {ece_score(y_test, proba_rf_platt):.4f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22f46885",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003369,
+     "end_time": "2026-08-23T00:52:55.246931+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.243562+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Régression isotonique : la version non paramétrique\n",
+    "\n",
+    "Le Platt scaling impose une **forme** (une sigmoïde, deux paramètres). La **régression isotonique** lève cette contrainte : elle apprend la fonction **croissante quelconque** (un escalier) qui colle au mieux aux données (Zadrozny & Elkan, 2002). Plus flexible, elle a besoin de **plus de données** pour ne pas apprendre le bruit — ici, l'escalier s'ajuste sur 398 scores out-of-fold, et une grande masse d'entre eux est écrasée dans les mêmes bins : c'est le régime défavorable à une méthode non paramétrique. Regardons ce que ça donne — la théorie ne promet pas que « plus flexible » gagne toujours.\n",
+    "\n",
+    "Les deux transformations partagent une propriété cruciale : elles sont **croissantes**. Un score plus élevé reste une probabilité plus élevée. Visualisons la carte de calibration apprise par chaque méthode.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e9efc1f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:55.254328Z",
+     "iopub.status.busy": "2026-08-23T00:52:55.254328Z",
+     "iopub.status.idle": "2026-08-23T00:52:55.394016Z",
+     "shell.execute_reply": "2026-08-23T00:52:55.394016Z"
+    },
+    "papermill": {
+     "duration": 0.145616,
+     "end_time": "2026-08-23T00:52:55.395760+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.250144+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ECE RandomForest brut      : 0.0909\n",
+      "ECE RandomForest + Platt   : 0.0552\n",
+      "ECE RandomForest + isoto.  : 0.0941\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjoAAAHWCAYAAAB+JiOkAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAnSlJREFUeJztnQd4U9Ubxr/uRVv23nvvvTf8WcpeKksUGaKIMtwTBBRFAUVABGQoKAiispfsvTdlzwJt6R75P++pNyRp2iYladr0/T1P2uTmjnPPvbn3vd/5hotOp9MJIYQQQogT4uroBhBCCCGE2AsKHUIIIYQ4LRQ6hBBCCHFaKHQIIYQQ4rRQ6BBCCCHEaaHQIYQQQojTQqFDCCGEEKeFQocQQgghTguFDiGEEEKcFgodkuGoXbu2tG7dWjIi+fPnlxdffDHVad7e3vLaa69JRsBc+wj7hedLxuHMmTPi4uIiCxYscHRTnBIKnQxGfHy8LFy4UNq2bSt58uQRLy8vKVasmLrx//jjjxIZGWnT7WXPnl2GDRtm03WS9IfHkRBiyIEDB5R4cvnv5erqKjlz5pQ2bdrIxo0bU53f8JU7d+5M3bkUOhmI8PBwadeunYwcOVL9x4kXFhYm27Ztk1atWsmoUaPk+++/d3QziQm3b9+WuXPnZth+yejtcxTsF5IVmDRpkqCkZWxsrOzcuVNiYmKkffv26r6S0vyGr/v370tmhkInAzF8+HB18v3zzz/yxhtvKEuOp6enFC9eXCZMmCD79++XAgUKOLqZhBBCMhlubm5SsWJF+eGHH9TIwaxZsySrQKGTQbh06ZIsXrxY+vbtKw0aNDA7T4UKFaR37976z9WrV9ebFt3d3aVQoUIycOBAuXXrlll/ke3bt0v9+vXV5/fff18tFxISoqxE2nqaN29utCzGjOvUqSO+vr7i7++vhtRgaTJkxYoVar0YPsmVK5e0bNlSibXUwDDc66+/rnxIsmXLpp4ygoKCkp3fkrYkB4YD0UZsB2bYZ599Vk6cOGF1X1rrA7NlyxapWbOm6vMyZcrI7Nmzk8xj7vhMnjzZonY9evQo1eNorn1xcXHyySefSLly5dTwKIZJ+/XrJ5cvXzbbtj179ujbVrJkSXWxtARrz1Fr+utp+9Zcv1h6Ltvzd5Hacni6Rn9OmzbNbH/jd2RpH1iDI/fZ0t+xtee1uT55+PChui7hARMPmgULFlRW9tDQUKNr17hx46RUqVLi4+MjJUqUkCFDhsi1a9dS3Ve0F32HfsyXL59MnDhRCQ9TvvrqK3WcYXk0XR7Tcb9IC6VLl1bLX79+XbIMOpIhmD17tg6HY8mSJWlaPiIiQrdr1y5d9erVdXXr1tXFxcXpv/Py8tL973//0z377LO6M2fO6K5cuaJbs2aN+i4wMFD38ssvm13n2LFj1bJff/217s6dO7obN27ohg8frvP29tYdOnRIzbN9+3adi4uLbvLkybr79+/rQkJC1DRsz7AN5njmmWfU9leuXKmW+/fff3Xt27fXVapUSdeqVSur25Icr732ms7Dw0P32Wef6a5evap78OCBbvXq1boXX3zR6r7Mly+fbsiQIUbzm5uGtmJf0Ofnzp3T3bt3T20fffXll18mmTe542Npu1I6juba17NnT52vr69u4cKFukePHqk+rFGjhi5v3ry6a9euGbWtY8eOut69e+vOnj2rCw4O1o0ZM0adq7t379bZ8hy1pr9s0bem/WLpuWzP34Uly2F/0f9Tp05Nsny1atV07dq1s7gPLD1fHL3Plv6OrTmvzfUJlilfvrx6bd68WRcWFqbbv3+/rnLlyrr69evrYmNj1fLDhg1T/YR24rzGun/88UfdW2+9pUsJbCdHjhy6xo0b606cOKF+T998842uR48e6phiHRrTp09X027dumW0juPHj6vpixYtSnFbaDfmmzRpktH006dPq+l9+vSxaH5ngEIngzB+/Hh1ku3cufOp1rN161a1ngMHDhj9qAMCAnShoaFJ5k/uBokfIS4+77//vtH0hIQEXdWqVdXND3zyySc6V1dX/QXAUiBq0E78yA3B/mO6odCxtC3mOHLkiFrfxIkTdbboS2uETvbs2ZP0OS5oOBaPHz+26PhY2i5rhA7EBpbHDcOQy5cv69zd3Y3Wg7blyZPHqL3R0dG6XLly6QYNGmRRey1pv7X9ZYu+Ne0XS85le/8uLFkuLULHmvPLtF8ywj5b8ju29rw21ycTJkzQubm5KTFgyNGjR9W6ly5dqj5DCPXt21dnLa+88oratql4gXCyt9CJi4tTxxIiC20wfVDR5jf3+uGHH3SZGQ5dZWKOHTsm3bt3VyZ4DAsYDllcuHDBaN4WLVooc7OlrF27Vjmh9ezZ02g6tgGzsubIVq1aNUlISFBDbjADw9HNEjZt2qT+d+nSxWh6o0aNknj4W9oWc6xbt079h/naVn1pKeb6HKZ2mMBNTf7JHR97tEvr+27duhlNh6m+Vq1a+u81sD0/Pz/9Z5jzy5Ytq4Zb7X2OWtNf1vatKZacy/b+XaR1udSw9vef0fbZkt+xtee1uT5Zs2aNVKlSRcqXL280vWrVquq6ZLivq1atUsNd586ds2g/tTbWrVtX/R5Mz117MWHCBP3QceXKleXo0aOyfv16NWRnqTNyZk9PQaGTQYDjMbh69apF82MsuHHjxvL48WM1lo3oLJyQ2kUeHvaGwDfCGrRxYfyg8QOBIxvCE/HC2DG2iwtSp06dZM6cOXL69Glp1qyZBAYGqvHnv//+O8X1BwcHq/8YozbFdJqlbTHH3bt3U91/a/vSUlLaN9MoBnPts1e7tL43vdhq00zbZs4BPiAgQPkHpYS17bemv562b81hybls799FWpfTQP+aw9rfvyEZYZ8t+R1be16bWxf2FUIA+2m4rxAKWF7bBhx54Wv2xRdfKH8g+PG89NJLqfroYHlLrnlpOcbJMek/4RIVFaWEJPygEMGL32NWgUIng4AfNn5Mf/31l0Xz//777+pEhQMmLkBwiAOmTncaHh4eVrVHs6pcvHhROfjBWQ5PXXhpKh9P9mDo0KHKQe7OnTuyaNEi5ajXoUMH2bFjR7Lrh8MhwDKmmE6zpi2mwBkR3Lhxw2Z9aSkp7Zu2/ykdH3u1C7k0UmqfqUUN52VasLb91vTX0/ZtcqR2Ltv7d2HJchCZOCbmblTJnefW/v4NyQj7bMnv2Nrz2lyfYB5YlbGfhvuq7ecvv/yi3xbEDtZ78uRJefPNN+W3335T1krMnxw4Ny255gEIPmB6nFPqg5Tw8vKSJk2ayLJly+T48eMyfvx4ySpQ6GQQEMny/PPPq5Nw3759ZufBE8/y5cuTnLymUQnWgCGJ6Ohos09ZwHR7KZE3b17p0aOHulDhopDSxQ0mb81UbMiuXbuSPHmlpS0aHTt2VP+XLFmS6rxP25embN26VT3tGrJ69WplLkf0iqVY0q7kjqM5kJNJEyKGXLlyRQ4ePKj/3lZY2q/W9Jet+tbac9nevwtLloOoKFy4sFG0EUBknGZxsCUZYZ8t+R3b4rzu3LmzSuNh6cMErD0I2UaUFqK4MJybUjQTrntYv6mwwblrCiK6gOlxxlDi09CwYUM1DIkoTWuG3TIzFDoZCDwhNG3aVGWunD59uhrGgnkfP1SMBWNsVwvLRUJBXPDGjh2rzLo3b95U4Y6mN5XUwJjt3r17k4T74gkcTynvvfeeTJ06VbUFT1l4ekFYK8ItwbvvvqtC1eGLERERodqC/cATJ8zQyYGnJlxAsTzGuvHUsnv3bhUaWqlSpTS1xRxYdvTo0Wo59CEuQggfhcCCqdmWfWkKjteAAQOULwpuQFOmTJGVK1eq/TD0eUkOa9qV3HFM7kIHPwb0NW4cCE0/cuSIusHgKfLtt99O8z6ntf3W9tfT9q05LDmX7f27sHQ5WEBwDv/6669K8EEQoD1IQWFrMsI+W/I7tsV5jVBvCAwIK1jXsQ2cX0i0N3jwYP2DGQQLtoF0GHjAQF9AYCHNQUrDazj/Ecreq1cv9eCK9cPiaS4hH4Z94SuEvkGJiAcPHsg333xjFOaeVj766CN932cJHO0NTYyBZ/yCBQtU1BEiWxBOWbRoUfV5/vz5KpRRY926dSp00sfHR83z6aef6o4dO5bEIx8e9qNHjzbb1fDgb9CggVoHlmvWrJnR98uWLdM1bdpU5+/vr8I2EWaJCLHr16/rI0AQNYGQYXyPCJ02bdro1q9fn+qhxb68+uqrahksi+UuXryoq1WrVpLwckvakhLz5s1T68V+Yntdu3ZVEQjW9qU1UVfo8w0bNqhIGHwuVaqU7ttvv03StpSOj6XtSuk4mmtfTEyM7sMPP9SVLl1anWM41xBCfuHCBYvahsge7FdqWHuOWtNfT9u3pv1izblsr9+Fpcsh8m3kyJHquPn5+alUDYjOSS7qKrk+sKRfMso+W/I7ftrzGiC8HdFX5cqV03l6eqrt4PeE6zL6HSBi8IUXXtAVL15chdgXK1ZMRU5Zci3C+d+6dWv9PiAkHftgGnUFTp48qWvevLlqb4ECBVQ/mfv9mCO1cPGBAweqaDotPYAzh5e74I+jxRYhJGuDp1zUXINzqy3nJYQQDl0RQgghxGmh0CGEEEKI00KhQwghhBCnhT46hBBCCHFaaNEhhBBCiNNCoUMIIYQQp8VdsiBI0Y3kZciimtb09oQQQghxDMiMg0SzqDOGDNUpkSWFDkROkSJFHN0MQgghhDwFKKSKkigpkSWFDiw5WgehQJ4tLUX37t1TBehSU5iEfZ0Z4DnNvnZGeF5n/n5GKQwYLLT7eUpkSaGjDVdB5Nha6ERFRal1UujYF/Z1+sB+Tj/Y1+xrZyMhHe6Jlrif0OxACCGEEKeFQocQQgghTguFDiGEEEKclizpo2Pp2GJMTIzVy8TGxqoxSfro2Bf2dfrgLP3s4eEhbm5ujm4GIcQBUOiYAQLn8uXL6iJvbVw/lkFsP/Pz2Bf2dfrgTP2cPXt2yZ8/f6bfD0KIdVDomLmw37p1Sz39IXTNmqdYLBsXFyfu7u68mNoZ9nX64Az9jH2IiIiQu3fvqs8FChRwdJMIIekIhY4JuKjjoohsi76+vlnuppBZYF+zn63Bx8dH/YfYyZs3L4exCMlCZN5BdzsRHx+v/nt6ejq6KYQQG6I9uMDniBCSdaDQSQZaZAhxLvibJiRrQqGThbh+/bqq85UeXL16Vfk62YuLFy8qB1mSuQgPD5cTJ07YfL0PHz6UK1eu2Hy9hJDMj0OFDkzIK1askNatW6uiXLt377ZouV9++UUaNWokpUuXlq5du8rp06clq3Pjxg0VKZYS48ePl/fee88uoub27dtG01599VX59NNPU5wnrZw6dUqaNGlidVQccbyo2b9/v1SpUkX5stmSx48fS+3ate0qrgkhmROHCp2JEyfK0qVL5YUXXlA36ujo6FSX+f3336V///7y/PPPy8qVK1VBr2bNmqnCYVmZt99+WwYNGuSQbQ8fPlwmT55sNK1YsWLKoTuledLKuHHjZMSIERIYGGiT9RH7gAcXiBpD/Pz8pFKlSjYfRkKEZPfu3eWDDz6w6XoJIZkfhwod3PggVlq2bGnxMh9//LEMGDBAhg0bJtWqVZP58+erCJzZs2fbta2ZFVhSYNZPCQwBXbhwwWyCxKCgILlz5456f//+ff17DQhULB8cHKye3vHCet544w298EpuHku2bwrm+/vvv2XgwIH6aRiO09ab3BM9hrqwfUuG8mCJwPymVgdL1pFafxlizX6n1jYNbPP8+fOpHkucF/gMTp48qSwisLCiPVoYNsBvC5bC1B4ksD7DvkGCQW392rFBP1WsWFGWLVuWJOoJ7UW70X5z/QQrnjYf1mtu/3G+LVq0KNXznRCSxdBlAK5du6ZDU7Zs2ZLifCEhIWq+ZcuWGU3v3bu3rlWrVhZvT1sP/psSGRmpO3XqlPpvLQkJCbqYmBj1P70ZMGCArlmzZvrPt2/f1tWvX1/n7e2tK1CggK5Bgwbq+yFDhujniYiI0A0aNEjn5+enK1GihM7X11c3evRoXVxcnH4e9Oszzzyjq1Gjhq5o0aJqnpYtW+oeP36svn/77bd1/v7+uly5cukqVaqkXpcuXVLLjBgxIsV5LNm+KVOmTNFVrVrVqK8/+ugj/Xrz5Mmj2ml6LlWrVk03derUJOeNYX+Eh4frBg8erPP09NQVKVJEtXf+/PlWrSO1/rK0301JrW3379/XtW/fXufl5aUrWLCgLiAgQDd79myjdaBtXbp00VWuXFlXrFgx3cCBA9V0Nzc33bBhw3T58uXTlS1bVjdz5kw1fdWqVbrChQvrChUqpMudO7fq96NHjxqt8/fff1ftCQwMVH3fuXNn3YMHD3RnzpzRFS9eXP3OtGOD44TjgmmxsbH6dcyaNUu1F+1G+7Ef2B+NNWvWqP0eO3asagfakz17dt26deuM2oJzAdOXLFlitg+f5redHsTHx+tu3bql/hP2tTMQb8dzOqX7uCmZKo8OLAMA2U0NyZcvnxw9ejTZ5TAkZjgsFhoaqv7Dx8PUzwOf8RSrvaxFWyYty9oCbbuvvfaa+g+/mICAAPnuu+/U8FGpUqX084waNUquXbumnDhz5sypnrhhXcMwwJgxY/Tr3LBhg2zevFnq1q2rnuxr1qypLGiw2sDCduTIEbXer776Kklb8EpunqFDh1q0fUP27t2rLHmG+/rOO++ol8b06dOlX79+yjqh5U8xbI+5NgL0z65du5T1Af5fOE/mzp1rtExq60itv6zpd0NSaxuON6w1+I1gnfB96927t/JbqVWrln49sIZt3LhRGjdubNSHmzZtkgMHDkihQoXU58OHD8tzzz2nLK7NmzdXuaHef/99NTyENiD9Aubv2bOnTJs2TflkgTVr1silS5fUPs+ZM0fatm0rx48f129/69atRn2GdYwcOVL53XXr1k1ZheCz9/rrr8tPP/2knxeWHOwz+gptwfDlSy+9pCxJhlSvXl3+/fdf6dOnT5I+1LZp7nefEdCuPRmxbc4G+zp9wO8V1lt7nNPWrDNTCR1tx3ChM61jo+W/McekSZPkww8/TDIdNyGY2A2B+R7bgWnc0DyOIRFTZ1qklC9RooRaBxyicZFCO3Bg4YNQo0YNNd/Zs2dVEkJTHxbckNAGDH8Yki1bNilTpoyk5YeLNuOGgBvHH3/8oXKHYNqLL76oBIA2T0hIiLqR4GaJkxE3SHz3v//9T1atWqW/cWEaHL5x48JyOXLkkFatWqkbodY/2g3EsL8M22NuHku3bwqOQ506ddRx0o45+hrLoi8x9NG0aVN566231A0W7da2rx1Xc23EcAeGPRYvXizFixdX09B3aIfhPqS0Dkv6Ky37nVrbMLTz888/K3EDUYtpzz77rHLYhsDVhnWxnY4dO0r9+vWTDP3A5wkPDNr0b7/9Vho0aKAeKjC0hQzhnTt3Vg7meKjAuT1z5kx1LCDCtOWwHwCfteNjuC3TaWgfjleXLl3UNPhdQbT26tVLvv76a/Vb0Jb56KOP9Mvi+6lTpypxlytXLv368R7niLmhLUzD8YKYwjUjo4G24fzAccrMdcUyA+xr+xIZGan8RvHQt3btWruc09ZE3WYqoZMnTx7133QcH5+178wxYcIEoydlCAE8PWMZ3BgMgWhBB0JMGQqqefPm6S+0GnCKxg0IAqhevXrJCjNYLvbs2WP03cKFC9UT82+//aae8A3BUzCevK0BJxFu+GgzrAXYNhxBDfehcuXK+nngd4ELP0SgqXBEBJw2DfPjKd9wHtx8cIM2nEdbr7n2mJvH0u2b4uXlpUSOdqPC/3/++UfdqHEDw80a0/DDwnEx3D7alFwb4feBPoMFJLltp7YOS/orLfudWttg1cD+wtJl+D2OP3xbDNtWsmRJs+uAtc1wOsQ5XrCMYd2a8zB8bODPg3nhUwPBk1x/aX44ht8bTsML1h+cl4bzwCqDbWK/qlatqpbBcUdGYw3NER0XVMNlcW4gQMFcmzANxwtiyNvbWzIaOMboZ1yXKHTY15mVixcvqgeRM2fOqIehokWL2uWctuY3nKmEDi50sITANP3MM8/op+/cuVM9bSYHLpJ4mYKON+187calvTTg/Gy4TYCndcwD0XTw4MEkFh1t+QULFignUkPwZI7vMbzQsGFDo+9woU5rVAqWQ2SLJtoM1wOrEqxImKb1x5IlS/RWj5TWabge7b3pNNM2m1tO+2zN9g2BBU0bwsS60N8YpoAVAGIWxw83OwxZGd6gzR1TCA5tmjbEhRtncn2f2jos6a+07HdqbYOQMne8MT/OBcNpyZUnMZ2OoSlYZ2B9Sq6sCS40qfWX4X/Tadq5aq7d2n4Z9mVK69HAuYF2m2uTNq+5331GIaO3z5lgX9sePHTinpY7d271cI+HLQQ32OOctmZ9Gf7XhCEIjNlr4Mkd1hWYz/EENGPGDPXkh/F6e4JCgLgxGb5w09Uu+No0POFq7zXKlSuXZFkIDgCla/qdtcNWpkBEQYRt2bJFPw1Ca9++ffrPFSpUUE+2GOIyxZooIG3/U0urbzpPWrePVALw09HAMAXM/Riq0U58+IGYDmWinw2jo/C9oV9X+fLl1TGBmdUQwzantg5LSMt+p9Y27XjDz8awbegHbfjUWuDDA6ui5s9mro3IZQV/H9O0EFq7tCeulM4NnO9op+F4O9aJ/cFDjTVAIB07dkxatGhh1XKEENsAgdOuXTvle6f5UmYEHGrR+fXXX5XToXZTgmMjnnjxZK4NNT148MDINwYOnbi5wc8AlhMMPSFcFTcQkgiGbpAcEEN28OXADePzzz9XQw6G83zxxRdqWA39CN8N+IKsW7dO9SmGViwFfY/8RlDweAovW7asRfOkZfvwf8FQH6x6GC5Erh7c6JGTCecGhkIgjk2f6Dt16qRyrMB6BtEK3xDDTLroD/QR1o1l4YCLoRv4zeBlyTosIS39nlrbYG2BDxqsWlrfzpo1S4kUzSndWrAcrE64aKE/NYd/+O7A9wltHz16tBqCxT6MHTtWtRPpHl5++WXldwOnabQNDyYQRYa+NIbbgQ8RcmnBaor9gtMzfIGSGxJLDvik4XyAGCaEpA93795V1y1coxD4sHz58gzX9Q4VOrhAwuHRFEO/GTgcGj5F4qn9yy+/VDl48CQPBckaNon+HYb98Oabb6obD254GApDX8MXwnBcE/mIIIJwo8FNFDcJ3MyHDBminwdWK9MoN8xnmAcFYhWOwLjxwXKEyBusFzfHlOaxZPumYF9g1cMyEDo4H/766y91c4RTLAQIHH3fffddo/MIy+CJHw6uGC6BYEL7tGE+AIdttOH7779XvlN4Ivnmm2+sWocl/ZWW/U6tbVgP+gYOyxBO8G1Bwj7Ncphc2wDOCyxrCJaDBRARVRBmmvXlzz//1O8LhAusa/gtov9hhUF+I4gcgG1h2BbiB+chHmTat29vlDAQ20E7P/nkE3VuYB3YL/SRBo4jljEED0SYZlh8F30DsWuao4cQYh8QCYrfNYa3MaqSUQ0OLogxlywGnnThzAihZM4ZGQ6juClY67CoRd8k5wdBbAMsU7hhwhFc83Ui9iGznNMYsoJVCZax5CxBT/PbTg8wfIenY/gi0keHfZ3RrwvffPONerDAAyeG4g0z4afHOZ3SfTzT+egQYgqGZ3bs2KGsWIQAWLDWr19v9XAXIcR64P8JCyxSXOC9OZGTkeBVgRBCCCFGqMEeXQLeiC4hXiQ+Tu7cviV5cueSpnVqyIGdW6Ra1WoiUY8lzjgdnZ4EXYLoIkIkPsJHXLM5rjYhhQ4hhBCShYi+EyQPty+XqKsnE0UMRM1/yU81cSNi3qtFy0WeA+8TE52nyr3iVaRgf8cV3KXQIYQQQrIACXExcn/d9/L4uIUKxUmg0CGEEEKyABHnDxiJHFffAHHzC/wv0MAVWRRFXBKT5gqSr8bFyenTZ+RRSKiUKlNWihQrJi6u7onzWYROoqNjxKvQ0+WGe1oodAghhJAsQOyDW/r3gfW6SI7mfcXV/UmKBlOQDPSNfv3krbemSF0zZY5SQ4u6ymFQvsURMOqKEEIIyQLEhT6pE+lXsZFZkQNxgtxYR44cUfmqVq5cabaWY2aCFh1CCCEkCxAX8kTouAckzVSOZKPIUo5yM0iEigK7zgCFDiGEEJIFiA/7T+i4uivfHEMOHz4s3bt3l0ePHqkM6B06dBBngUNXWQSUEEBZhPQCPxYkcbt+/XqGa5st2oNEWagBZQ1YxrBsAyGEOMKi4x6QS1xcntz+UWbpmWeeUSVZDh065FQiB1DoOAkogopMwXghxT3qDeGmivT94P79+8osaQ2oW4QilqlNM8dHH30kdevWtSh7cVraZk8saQ+KzeJlDa+88ooSUFg/IYSkJwnRkZIQHaHeuwfkVv9Ruw8PpagZByvOzp07VVkdZ4NDV04CbrpFihRRFeFjY2NViQRUkUYhTYiOtIAbcvbs2VOdZgpqj8yZM0e2bdtm0XZQ3TojFWK0V3tQ8A5Wrh9++EFVlieEEEc4IrsH5pZLly6poapSpUrJihUrpEqVKk57MGjRcSLgIa9ZdOBQhtfPP/9sdl7caDULECphQxQhDNDQQrRp0yZ109fmGzx4cJJpFy9eTLJuVNdGZetatWrppx04cECZRsuVKyctWrSQJUuW6L8bN26cvkI2gBUKlg8IA3j7Q6ihMrnhUFG/fv1k4sSJqt4KtoMf6VdffaWeTkaOHCnly5dXy+IHbAgyf6L6eJ06ddQPHBXIURDSENP2IArhww8/lIoVK+rbo1nKDEFhu+bNm0vp0qWlbdu28vfffyeZB9tDMVJCCHGU0Ll856G6boaFhck777zj9AeCQseJ8ff3V6ZJc+BmvmfPHvWaP3++3LlzR7p06ZKYAlxECY1GjRpJ79699fN9/vnnSaYVK1YsybphyYGQMKwajRt/5cqVZc2aNfLxxx8rEQDnN3NDRRgag9VjypQpyjJ09uxZ+f77742GimCp+vLLL6VAgQJKzEHcvP766+rHC6G3atUq6du3rxJEqFitgX2AUMH+Y548efJIkyZN1P5rmLbnk08+kdmzZ6tl0Z5Tp04py5khs2bNUtWz4YeDCtoDBgyQXr16qUKThtSvX19Onz5ttD1CCElPofP1Dz8p9wY8gDpLZFVKcOjKAsavnySPokIt6lAIhcQsk09Pdu8Amdw2bUMcFy5cUFaTVq1amV939uz6IShYZmBlwOczZ84oS0qOHDnE29tbVQo39LMxN82UK1euKFGjAYdkCIdRo0ZJ/vz5pWzZstK4cWNlKTGXoAoWF/gXde7cWU2DENu4cWOSeSGexo8fr/obFhwIn0qVKskbb7yhvse0adOmyfbt25X4wZDeZ599pgRUjx491DzfffedEmawBk2aNCnJNuCkh3WgTVp7FixYIJs3b9bPg/XiqQjTIRYB9vHkyZNqvWinBoSZ1kf58uVLtg8JIcReoeXtuvaW58d9Kq6uWcPWQaFjARA5DyIfSUZn9+7dSoBgWAVDOBgqwo3WHBAfuOnDKgMLBkQHRFpQUJASOk8Dtu/u/uTUgsioXbu2uuEPGjRIDV3hKcLcjwzWl8ePHyvLkeGQnOEwmAaGkgyBdQZCx5DcuXPrnX8xJg1TLZ5kNNAGfD569KjZfUF7sAyEmaHYw/5oQBxCyGF4DRYd9CNe2A9s3xCtX8wNfRFCiL3uDTF7d0iR/z73HTIsy4gcQKFjoWXFUmxt0bGGmjVrqiEVDw8PddNP6URu37698peB5aRgwYLqBgyfFVhUnhZYLQz9feDYC29++Mts2LBBWVTQPiSlKlq0aBILCkAUgCEQO6aY2z9zTsTacJy2b6brwufk9lubbtoew88YmgOLFy9W/jmGGAo+bcjN0LJDCCH2Ate+b775Rlm5fx/VXiSXp1HUlT0JjQqTY7dPy74rR6R2VDVpWtxx2ZUpdCzA0uEjnFSaNcNWYictzsipcfPmTTWs8vvvv0uZMmX0VgkMwZiKBk0kpDTNFPihwMfGtG39+/dXL4gZWERmzpyp/F4MgfUH2zhx4oSR/w8+N2vWTJ4GCDmsG9YbvNeArxCiocxRsmRJtczx48f17cH+4zMsU9owFY75uXPnlDNyShw8eFAJS+wnIYTYC1iUkRNs+fLlyn+xaqloiXt0W1w8fcTV28/m24uJi5HT9y/I8TtnlMAJevQkh1q8a4JDhU7WsV0RPUgK5ePjo5xmQXBwsMrxYkqhQoXUzdtQ2JibZkq3bt3k/PnzeidgCAk4IGM7AMM8GA6CVcecAzWciN977z1lFcKQ2vTp05XP0dOClOaIHMO6MXSHffjxxx9l7969MmLECLPLwB/pueeeU87ZcCBGe2CRwjCYRmBgoIpaw3oR1q9ZguB4/e233xqtD07YCOkkhBB7gusRcuP88ssvKoo0PixYH1puCxJ0CXLpwRVZdfof+XjrVzLo9zfk023fyB9nNhiJHHAu+JKa31HQopMFgY8JQsThU4IIJ1hycKPet2+f0XwQP3DAhTCCSIDTrrlphtYRgIRTzz77rNoGIpYwRAbrEZyDIS4QCdanTx/lnGwOCBt8j+GdgIAAZSGCNcd0+CgtwLH4pZdeUm3G+iCsFi5caOQ8bQqcnCG+YInR2tOmTZskbcZ3cEaOj49X+9m6dWtVHM9w2Oqvv/7SR5sRQoitwQMZAh3ef/99dV0vV66cxIeHiC4+0WLv7p92ofM4JlyO3j4lh2+elMO3T0pY9ONk5y2RvYhUzldeinjmk/plaomrQSbm9MZFl9o4hBMSGhqqnsKR2A43J0PgbwFLBIYWIAiswZFDV7CSYNvmrCQA1hQMwRgm+0N7tQSA8OvBkBYEjOl+Y93h4eEqYkrzOTE3zRDk12nQoIEKpUZOHQ2EiGN7hv415toG4FDt6+urBAly/SCsHblzNNGAdaC9Wl9jGobIDI8prEJYBywzhkBsac7CpsfKkvZo4eeITjMEFh8sj3aZ+gshNxFEZWYqA+Ho4Vhb8jS/7fQA5w7O17x582YpR1FH4Ix9DZeAN998U0XQIgUGrs0a0bcuyo35iXnI/Ku3ljwdk1rwk/v9Xwu5KYdunZDDt07I2fvJW2by+OaUKvkrSNV85aVy3nIS4O1v135O6T5uCi06ToLpDdcUQ7GhgRuXoTCCxSK5dZuu39w0Q2AxgR8QrD6GQACk1rZdu3YpAdaxY0e9RQU/XMMhHwgU08glcyIPPzBzYOgOL0v7ChgKn+T2HT/m5MQmcvekllWaEEKsBUPxyNuFvDiwLpumrogzrFoeaP76pBETHysn7pyRAzePK3ETHGG+HI63u5dUyVdeqilxU0HyZcuTYR+GKHSI3Ujuhp8aCG+HEx0yO+MpHA7WyLYME2xmhnlzCCG2BhGt8IuENRs5wzC0bkqcVrX8v4KepkTERCqrzb4bR+TIrZMSFWc+CrWgfz6pUaCy1CxYWcrnLiUebh6SGaDQIRkOWEtWrlypTLF4mQ47EUIIeWIlb9iwoYp0Te7hMs7QovNfaDnywx24cVT2XT8ix++elfiE+CTLebi6S8W8ZaVGgUpSs0Blye9v3kKe0aHQIRkW+MLYwgGZEEKcCfgIIpL1008/VYlTUc4mJeJCE/N3ge3B52XnxX/k3P1LopOkLrrZPP2kdsGqUqdwNTU0hSGqzA6FDiGEEJJJQNQm/BUhdpD6AoliUyIkKlSC71wSzf1+wfn1Em/iS5PLJ4cSNnULVZcKeUqLm2vSxKuZGQodQgghJBOAun9IC4JSN5s2bUo28SjCwPddPyq7rh6Q43fPyMSQu0rohLi56kVOoYD8StjULVxdSuYommEdiW0BhQ4hhBCSwdm/f78MGTJEhg4dKjNmzEiSIiE6Lkb23zgi/149IEdun9L73Lgn6MQ/PnGIKtzbW3pW6igNitaSwgFZpwwNhQ4hhBCSgRMAIk1GnTp1VBb3unXrGuW5OX3vgmwL2iN7rh2SyLjEunuGlPLwR5Yx9b5MsZrSuHInyWpQ6BBCCCEZEBQ+fv755+Wrr76SAQMG6EXO3cf3lbjZHrRX7oQ/iajSyOETKA2L1JZGRWtLgUcP5c7ZT9R0j+yZM2rqaaHQIekOinkihLxfv35pXgcybiILKKryFilSRDLiftliPzW+/vpr5XTYpEkTG7SUEJKRQRkZ1Kr67LPPVFmZZ555RiJjo2T3tUNK4Jy+dz7JMj7u3lK/SE1VPBMOxVrJhdAr5yxOFuisUOg4CShOiWzCuPnbApQpgLkUZRdszYYNG1QSwKcRAHPnzlXRB5ZUa08vTPfLFvupUbp0aTU2j6rpKNdBCHFOUGqmR48esmXLFpk0eZJ0G9JLlp5boxyLo+NjjOZ1ERepnK+cNC/eQDkVe7knTccRF/IktJxCh2RqUFwzKCjIZkLnn3/+UTdXewidkSNHJikNYe3TDvJHINV5RuZp99MQlMMYPXq0qkTcv39/m6yTEJLxQILUnHlzytdrvpOrbnflnU1TzWYobla8vjQpXldy+yYtq2NIbMhd/XsKHeJUoGAlirudOXNG1bBC9e2iRYvqvz9x4oQsX75cFdmsWrWqKreg1X6CdejYsWNKOKEUA0AVchSJS2k5rS4VqpcjW+fGjRuVKOnZs6dRroezZ8+qIR0U/dRAQdHFixfLtWvXpEqVKjJw4MBkkwWiAjgKunXo0CFJvResA/9LliypxrYNM4Wm1icptQHTt27dqq+FhTTrXbt2TfEYmNvP1Nqo9R+qqmM/0c6xY8eq71DRHdlPKXQIcS7gVPztt99Kkaol5I5viHh1Lyjbww4lGZpqVKyONC9eX8rkKmFxOHgcLTriHGVbSRL/laZNm8qSJUtUcc2wsDDp3LmzqigOcAOF8Lh165a6qeIH1rhxY1VuAWAZ3KALFCigbuh4QcykthxYt26dvPrqq/LBBx8oQYBK3lj+0KEnP1oM6aBwp2GtlvLly6v/yAtx8OBBJY6SA8vXq1fPqGr67t27pXr16nLp0iUpW7asGtZCxlB8tqRPUmsDpml9gUq5r7/+ugwbNizFM890P1Nro9Z/o0aNkvfff1+JMNT90oB/DtYHwUYIcQ6CHz2QPhMGyOqwrbLk9p+y6dJOiTaoNVUqZzEZVuc5+f6ZyfJS7X5SNndJq3LexD1KHLpy8wsUV4/Mn+U4LdBHxwm5fPmyuonevn1bX0hy/Pjxqto3nhwgRPCaNm2a+g6+H7iRz5kzRw23QBDAwRdDV5pFx5LlNGDNQTIrN7fE7JoXLlyQn376yWwGT6x30KBBqvIu/G40YPFIDlhkILQMGTx4sLz99ttKgGjAWgLBACtOan2SWhsaNWqkXhoY0oNYeeeddyz2E0qtjRoQlRiKNPXFgQUoNjZWibNq1apZtE1CSMbkXniwLNn7m2y/ulfcavhJTnkyzI2yC42L1ZU2pZpIiRxpD7bQxcVK/OPE6uPugVkz4gpQ6FjA9XlvSXy4+VL1SUBeJhslmHTzyyGFh0yxejkMMcEi8+GHHyrrACwVWmFM3LwhPDBso5E9e3blA4Kbq6FgMeTGjRsWL9eiRQu9yAGoOp6ccDl//rxaL4ZzDElJPMAaY1joEzd+iB9YTDBcBOGCF6Zj3tT65Ny5c6m2ARYhhHru2bNHOX3js6urq9qeJULHkjZqtG7d2qzDsdZeDNsRQjIf+M2fuX9B1p3booppotaUm8+T3zpEDcRNo6J1xMfDOCFgWogLRei5Lkv75wAKHQuAyIkPeyCZBTjAQnxMmTJFWrZsqaahJgr8bO7eTXRMy507sYKtBj4bDi+ZYs1yhj47AKIHvjrmQL0WoFlZLAFDYtpyAMIDwGJk2D7knICvS2p9YkkbMC9ECv7XqFFDCZGFCxcmESnJYUkbDQVkctEY2v4TQjIPsfGxKmPxX+e2yOVH14y+c3d1k4ZFa0v70s2ldC5jS/XTQv+cRCh0LLSsWIyNLTppBc602nAIUofDHwU3ciSdAleuXJFixYrp58dnQ8dc0zFgLVdNastZi2YNgWXDdDgqOTBsg6ExjUKFCqn/lStXlk6dOlndJ5qVKrk2QAgtXbpUDhw4ILVq1VLT4HuEoTtLsbSNKXHy5Ell1SlTpkyalieEpC8oqPnPhe2y4cJ2CYk2figK9A6QtqWaSJvSTSW7d4Bdtm8ccZVXsioUOhZg6fARzJLw+YCTrCMLpCFaChYYLYsmUodDjODmjAgf+OAgAR0ciTH8cvr0aeUEu2zZMiM/G0RWaVi6nLVAAGC9SIwFHxitfguETKtWrcwug+GyqVOnqiEctBNiqVmzZvLRRx+pdcFZGGB/jx49qiw4KfWJpW0wtN5MmjTJqv20pI2pgaivtm3bMo8OIRmcO4/vyZozG2VL0G5lzTHk8bVH0r16R3mhRW/xcLNvTixDi44Hh66IM4FhFeRcgeiCfwx8Qu7du6ePEpo1a5a6YWIYBQ7HCANHUjvDcGlk4sQwDSKqYEXAEI8ly6UFOCpDvMBvBtFUaC/8fJITOgjXRvVe5JTR9gn+NWgz9hfRSbDCIJrpiy++sKhPUmoDfHswH/azffv2ar1RUVHi5WVdBENqbUwJOCEjrP9pRCUhxL4EPbwmq86sl93XDqoHXz06ket7L0rAPS9Z+OU8lYw1PTAausqedX10XHRGRyNrAEtAYGCghISE6J+sNXADQ4QOoolMq8NmZIvO9u3blcUBN2sNDLXA0RbDM7AiGDq4RkREyObNm9XNFvlwzEXxnDp1SlkbwsPDVag1+iy15RCCDh8UWEw04NuCdcDJFkAgwWfGML8M+m3Hjh0qlw3WiSGe1BIawgEabdT2C/0PZ2E4FiP/DASLodNyan2SWhuwH1g3wu6bN28uP//8s/qvDeWZ7pe5/Uytjeb6D3z33Xfy66+/Gg3ZpQcZxUppC57mt50ewMEdVkfcBGExJZmjr/EbOXn3nKw+s16O3j5l9J2Xu5e0LtlY7u+5Jo9uPlBpNwwDNeyJLiFebi58R6JvJJaAKP7mYnH1NPafzMzndEr3cVModJxE6GQ10Nfwm8GQDyKqnJ01a9Yo4YXzMj1xpnOaQofY8gacoEuQ/TeOyurT6+XCgyCj7wK8skl1/wry+Og9GT9mnF546GKf5MexB9hG1LUzEn52n0RcOCAJEYkRmq4+/lJ8zAJJbzKK0KGPDsm0wMpkmDTQmYHjNCHE8UDg7Ll2WFac/FOuh94y+i6PXy7pXK61XN95QUb1HaESgo5+5VVJuHpM7v/9gz6nTXrjU6KqZGWyxl2CEEIIsYHAWXnyT7lmInCKBRaSZyq0k+q5K8hro1+TefPmqWSrKI4cc2q7EjmiS0jX/nfx8BbfUjXEt1xdyVahoWRlKHQIIYSQFATO3uuHZcWJpAKnXK6S0q3S/6R6/kpqaBc+OPDdmz9/vsq2HnZ0s9z/63v9/J75S4mbr7HfoK1BGLlfmTriXaKKuJqpZp4VodAhhBBCrBA4ZXOVlF6VO0mVfOWVwNH8UN566y3p3r27ytkFHu1do18msH4XydnyeXFxoaN5ekOhQwghhBg44MPJePmJNXIt5KZRv6BqOARO1XwVlMBBxnfUqpsxY4YcP35cRWBqIgeOwbEPEpf3yF1YcrVKTNZK0h8KnWTIglH3hDg1iAAhJCVO3T0nPx/9Xc6bRFGZChyAPFzIqr5lyxaVbFTLHm+UwyY+Tr33yJWYGZ04BgodE5BXBScyTmJkA7YmpNaZQnEzOuxr9rM15woSX+I3jRBXT0/6LRBjgh5el6XHV8nhWyeNppfJWVx6Vu4s1fI/ETjg4MGDKvknEnkiXxaSi5oSe/+G/r0nhY5DodAxAcmckK4f1bZRNsDaC6pW1ZpCx76wr9MHZ+pnX19fVfaDyfiIxt3w+/LryT9l55X9qpK4RpGAAtK36rNSq2AVs+c9Cu8iqeicOXP0dexMiXnwROjQouNYKHTMoBVOhFq3BtwQULsI1aV5MbUv7Ov0wVn6GQ8wtLQSjdDoMFl54S/ZefOgxOvi9dNz++ZUQ1RNi9VLcr4/fvxYPvzwQ3nvvfekVKlS8ueff6bYoYYWHQodx0Khk8KF0dpU3bgpYOgLGZUz800hM8C+Zj8TYi0xcTGy5uxG+ePMBomMi9JPz+bpJ90qtpe2pZuJp5lCm2fOnJFu3brJtWvX1JAVChunRmyw4dBVQR4sB0KhQwghxOmHYHddOyCLj/4uwRFPshND1HQq10q6lGsrvsnUgULx4CFDhqhhz/3796vCv5agRVy5+WUXV28/G+0JSQsUOoQQQpyWC8FB8tPhX+Vs8CX9NFcXV2mQv4Y8V6u75PLLkeyyp0+flj59+qgX/HFMiwQnR3zkY4kPD1HvOWzleCh0CCGEOB0PIh/J0mOrZVvQHqPp1fNXlOerdRePKFfJ4RNodllE6OXOnVsqVKggu3btknr16lnljK9ZcwCFjuOh0CGEEOJUfjhrz22S30//I9FxT6qFF/TPJy9U7yE1C1ZOrKodddfs8ps3b1b5cd59910ZOXKk1K9f3+o2xN6/rn/vQf8ch0OhQwghxCn8cPZcPySLj/wm9yIe6Kf7efhIz8qdlKOxu2vyASYQP1OmTJG3335bWrZsKb17905zWwwtOsyh43gcLnRWr16t0mffuXNHpc7++OOPpXTp0snOHxUVJV999ZWsW7dOHj58qBzEXn75ZenSpUu6tpsQQkjG4GbYHZl/cLkcu3PayA+nTakmKlzc3ytl35rw8HDp16+f/PHHH/LOO++o4pzWRt0aEmMUWs6IqywtdNauXSs9evSQqVOnSoMGDWT69OnSpEkTOXnypOTMmdPsMq+++qoSObNnz5bixYvL33//LV27dpU1a9ZIhw4d0n0fCCGEOG6YCkNUq8+sl7iExHILAJmMMUxVJNAykeHj4yN+fn7qntSxY8enbpcWWu7i5iHugXmeen0kEwsdqObnnntOXnvtNfV54cKFUqBAASViYD40x4YNG1SoX+fOndVnWIEWL16s0nBT6BBCSNbg0M0TMv/QMrkbHmyU8G9gjZ5Sp1A1i5yHFyxYoB6YMVS1ZMkSm7RLFfN8eEe9d89ZQFxSGC4j6YPDstqFhYXJoUOHpF27dvppqEHTunVr2bp1a7LLNW/eXBVRQ5ZKcOLECbl06ZLZWiOEEEKci/vhD2Tazu9l8o6ZepHj5uIqz1ZoJ1/+7z2pW7h6qiIHLhBvvPGGemj+559/bNq+2OCbIv9Zlzxzs5hnlrbooJYUnMfy589vNB2fjx07luxyyGXwwgsvSN68edXw1oMHD2TmzJl6C485oqOj1UsjNDRU73xmy4rGWJdWG4jYF/Z1+sB+Tj/Y1ymDoal157bIylPrJDo+Rj+9Yp4yMrhmbykcUEDfjylx+fJl6dmzp8qR88MPP8jgwYNtes2Oun1Z/94jT7EsfT9IsOM90Zp1OkzoaI1EyQRDYNWJj39Se8QUhPz9+++/8vPPP6t6I+vXr1d+O3jftGlTs8tMmjRJ1SgxlysByt6W+xQSEqIOLEtA2Bf2dfrAfk4/2NfJczn0uiw7+4fcirinn+bv4SfPlmortfNWEZcol2TDxQ3BtRmlHHCdxj0EoeN376a+nDXEBD1xiI7wyi4xNl5/ZiLBjvdEjApleKGDZEwABQMNuX//vv47U9BhcFzGuCockEHVqlVl9+7dKloL/jvmmDBhgowZM8bIolOkSBHJkyePBAQE2PSgwmSK9VLo2Bf2dfrAfk4/2NdJiYqLkuUn1srf57fqq4u7iIuKpupdubP4efpa1Ld4eH706JEqTrt06VI1IoCizfa4Vt95fE80t+i8ZapmaWfkBDveE1FTMsMLnXz58imxAZFiGBoOa0379u3NLoPhJ3RcjhzGKbvx+datW8luy8vLS71MQcfbuvNxUO2xXsK+dhQ8p9nXjuDo7VMyZ//PRjlxSuQoIi/V7i+lchazeD2w3CMBYGRkpOzcuVMqVqyYmDDw7l27XKtj7l1R/1HfyiN7XqsyKjsjLna6J1qzPofejYcNGyZz585VlWE1/xs4Fg8dOlQ/z8SJE/XRVFDhsOAgDB3WHQB/npUrV0qbNm0ctBeEEEJsxePocJm1d6F8uu0bvcjxcPOQ56p1lc9aj7NK5OzZs0dq1qyp7hOw+ttbdMRHhEl8WGKbPfMWy/IiJ6Pg0PDycePGKafkatWqqRwGSNCEUHGEjGtAdV+9etWokuxLL72kLEJwRkbSwIEDByYbjk4IISRzsOfaIZl3aLmERCUGjIBKecvKy7X7S37/vFat6/vvv5dRo0ZJnTp11H2jUCH7R0DF3A3Sv4fQIRkDhwodCJtZs2YpvxtETyGHjru7exJHYkOH4XLlysm2bduUGRLLIErraTJYEkIIcSwPI0Nk3sFlsu/GEf00Hw9vVXyzZcmGKsuxtcBdYcSIEaqsg2nQi72IuZs4bAU88xZPl22STFACAsCag5c54MSUXCbL9FDohBBC7AOicXZc2Sc/Hlou4bGR+um1C1aVF2v1lZy+2a1aH9wgfv/9dxWAAkt/ehN9x8Cik49CJ6OQIYQOIYSQrEVoVJjMObhE9l1/YsUJ8Momg2v2kQZFalrt3/Lrr7+qnDgIcoElx5YRtVZbdFxcxTNPkXTfPjEPhQ4hhJB0Zf+NoyqiKiT6SS6UxkXryKCavVItwGkKwsTfeustVey5T58+KglgtmzWrcNmpR/uXVPvPXLmF1ePpJG+xDFQ6BBCCEkXImIi5cfDv8i2oD36af6efjK0dj+pX6RmmtY5Y8YMlR0f/2HJib13VR4cWCPRN88p8WEWnUhMbIzc9vBEYh6boIuLE118rHpPR+SMBYUOIYQQu3P8zhmZtW+hBEc8NPLFealOf8nubf0wE/LjwIdz5MiRqtZh9coV5PbSjyQq6LjF67BdXnxj6IicsWBWO0IIIXYjOi5G5h9cLh9v/VovchBRNbzuC/Jm42FWixwk+5s8ebKUKFFCOR8jugq5ch5sXmyVyLEX7tnziX9VFpnOSNCiQwghxC5cCA6Sb/b+KLfCntR7qpy3nBI5uf1yWr0+lHEYMGCA/PHHHyp3WpkyZdT0yMvHJPTg3+q9i4eX5Gz5gviVrSOuvv7JiqV7d+9Jnry2L03g4ubBRIEZDAodQgghNiVBlyBrzmyUZcdXS7wu4Ul246pdpV2ZZmnKi3Py5El55plnVH3ENWvWSKdOnRK3FR0h99bO1M+Xs+XzEli7fSoNTBAXdw9xdfdkuZ4sAIUOIYQQm/Eg8pHM3LtAjt85q5+Gsg2j6g2UggH507zewMBAKVWqlKxfv15KliyppsHZ+O6qryQu9L767F2ssgTUameDvSDOBIUOIYSkEzpYN3Q6898lJPz3itdX6s5sHLxxXL7bv0jCYsJVMBMqjXep0EZ6Vuos7q6uyUdBJUNUVLR8/PFHMmbMG1KoYAH5+691arq2nvv/zJWICwfVe1cvX8nTabi4pMFaRJwbCh1CCEkHgjcvkpC9a0RSudk/KSKQ+YDXzUTTiRd/lmtrf07zOl/MJhI6Z5g8qX5lBld3ydfjLfHIni/N2yHOC4UOIYTYmYSYKAnZvToxgQuxOXk6jxCf4k+KQRNiCIUOIYTYmUQfkkSR4+YXKO45CpiZS6ey/CYWoLRRFjs78ygqRO6GB6uaVQBlG/L65ZLs3oFpXmd0dLQcPHhAcuTIIWXLlhU3t+RvUy6ubpKtSjPxr9w0zdsjzg+FDiGE2Jm4sGD9+2xVW0iuls+bDXm+e/eu5M2bN8NHAoXHRMjs/YsS61RlTyy8WTSwkIxuMFiKBBZM0zofPHigHI7d3Nzk7p49Urdu3QzfDyRzwLOIEELsTHzoE6Hj7p8rU/f3pQdXZfz6SUbFONuXaS6ftRmXZpGzZ88eqVatmkyZMkV9rl+/PkUOsRm06BBCiJ3Rwp/VRTcgd6bsbwxPbbi4XRYcXiFxCXFqmp+nr4yo+4LULlQtzeucNWuWvP7661K7dm154YUXbNxqQih0CCHE7sQZWnQyodCJjI2S7w/8LLuuHtBPK52zuLze8EXJ45crzb44gwcPliVLlsjo0aOVNcfT09OGrSYkEVp0CCEkXS06mWvo6uqjG/LFrjlGZRw6lGkhz1XrJu4pOAqnBkQNXsuWLZPevXvbqLWEJIVChxBC0skZGXWQXH2tr9TtCDCstOXybpl3aJnExsfqi3G+Uud5qV+kZprX++uvv4qvr6907NhRfvzxRxu2mBDz0BmZEELSaejKLSBXpij4GBUXLbP2LVRZjjWRUyJ7Efm87cQ0ixyEzsMXp1evXqpWFSHpBS06hBBiR1B0UhcdkWmGrW4/vifTdn4vV0Nu6Ke1KdVEBtToKZ5uyPFjPTdu3FDDU3v37pUZM2bIyJEjbdhiQlKGQocQQuxIZoq4OnzrhMzYPV/CYyPVZy93L3m5dn9pXKzOU633ueeek6CgINm2bZs0bNjQRq0lxDIodAghJL0irjJoDp0EXYL8dupv+fXEWn1B0YL++WRs45elcECBtK0zIUEePnwouXLlkjlz5qhkgEiGSEh6Q6FDCCFZOLQ8IiZSvt33kxy4cVQ/rU6hajKi3gDx9fBJ0zofPXokAwYMkCtXrsjBgwelTJkyNmwxIdZBoUMIIVl06Op6yC2Z+u93+tBxF3GR3lU6y7MV2omrS9piVY4cOSI9evSQ4OBgWbRokSrpQIgjodAhhJB0sugg6iqjsOfaIRVZhQgrLcvx6PqDpXqBSmle5+LFi2Xo0KFSoUIFWb9+vZQsWdKGLSYkbVDoEEKIHYkPy1jJAuE7s+zEH7Lq9D/6acWyF5axjV6SfNnyPNW6vb29pX///vLNN9+Ij0/ahr0IsTXMo0MIIekwdOXi4SWu3tkcXnV88o6ZRiKncdE68kmrN9Msci5fviwffvihSjCIIau5c+dS5JAMBYUOIYTYCdz840If6K05jkwWeDPsjry9cYocuX1KfYYPzsAaPWVU/UHi5Z62GlN//vmn1KxZU3766Se5f/+J5YqQjASFDiGE2ImEqHDRxUY53BH56O1T8vaGz5XYAf6efvJu89HSoWzLNImv+Ph4effdd6VTp07SpEkTFVmVJ8/TDXsRYi/oo0MIIekQceXmn9shFqW/zm+Rn46sUO9BkcCCMq7xK5I3W9rbM2/ePPnss8/Ua9y4ceLqymdm4oRC58GDB6peyaVLl9T4LDhw4IDUqFGD4YSEEKIckR88udgG5EzXPomLj5O5B5fK5su79NNqF6omo+oNVMU50wKGp3Lnzi2DBw+WatWqSb169WzYYkLsQ5pk+LFjx1T44KeffiofffSRfvr333+v8iYQQggRSYiJfHKxTUdH5JCoUPlo61dGIqdrhfYqsiotIgfWoJkzZ0rx4sXl0KFD4u7uTpFDnFvojBkzRkaNGiXnzp0zmj5ixAiZPn26rdpGCCHOI3Q802ZFsZagh9dl4obP5cz9i+qzh5uHvFp/sPSt+kyakgA+fvxYhYyjEOeQIUOkcuXKdmg1IRls6Gr//v3y22+/qfeGjmxI833mzBnbtY4QQjIxuphER+T0Ejr7rh+Rb/YukOj/kgDm8AmUNxsNk9K5iqdpfRcvXpQuXbqoUg5Lly6VPn362LjFhGRQoQPHs/DwcAkICDCaDgtPjhw5bNU2QgjJ1CQYCB2XNPrFWDq0tObsBvn56Cp9Uc7SOYuropw5fbKneb3+/v5SsGBBWbFihXJXICTLDF116NBB+eYgw6Zm0bl27Zq88sorKtyQEEKI6EPL7WnRiUuIlzkHlsjio7/rRU7jYnXlgxavp0nkxMbGyvvvvy+3b99W1cY3bNhAkUOyntD54osvZNu2bVK4cGEldhBpVbp0aTWWO3nyZNu3khBCMrtFx9PHLpmOJ23/VjZd2qmf1qtyZxVZ5ZmGJIA3b96UFi1aqLDxXbueODITkuWGrvLnzy+HDx9WfjoIKYfYgYNyr169xMvLy/atJISQTC50bG3Rufv4vkzeMUuuh95Sn91d3WV43RekcbE6aVrf1q1bpXfv3uLh4aEeZBs2bGjT9hKS6fLoQND07dtXvQghhKSfM/K5+5dkys7ZEhr9WH3298qmnI7L5ymVpvXdvXtXuSQ0aNBAOR1jyIoQZ4EJAwkhJBMNXe26elBm7l0gsQlx6nNB/3wyvukIyZ+GopwhISHi6+urhM3mzZulTp06TPhKnA4mDCSEkPRwRvbweurIqt9O/SVf7Z6rFzmV8paVT1q/mSaRc+TIEalVq5ZyPAb169enyCFOCRMGEkKInUiITkwY6OLmIS5u7k8VWTV7/yJZdvwP/bTmJRrI201HSTZPP6vXt2DBAjVMhfBxJAEkxJlhwkBCCLETCf9ZdFyewj8nMjZKvtw1R47ePq2f1rfKM/JshXZWVx6Pi4uT4cOHyw8//KDqVX377bfi42P7aDBCMhJMGEgIIXZ2Rk6rI/LDyBCZvH2mXH50TX32cHWXEfUGSsOitdK0Pjc3N5Xwde7cubTkkCyD+9MkDESRNyYMJISQlJ2R02LRuRF6Wz7b9o3ci0isgO7n6StvNR4mFfKUsXpd69atk8jISOnevbt89913PFwkS8GEgYQQYgd0ugS9M7KrleUfzty7KO9umqYXObl9c8rHrcZaLXLi4+Plvffek44dO6oyDoRkRZgwkBBC7IAuNrGwprVDV3uvH5ZvDcLHi2UvLBOajrC6nMP9+/elX79+smnTJvn0009l/PjxVi1PSJYWOp07d5Y1a9YwYSAhhFiUQ8cyobPt+l757eI/+ppVVfNVkDGNhoqvh/UOw3A2Rgb7f/75R1q3bs3jRLIsaRI6W7ZskYiICJVoihBCSGpZkVMWKgm6BFl89DdZe3GTflrT4vVkWJ3nxd3VzapcOw8ePJBcuXLJjBkzxN3dXdUkJCQrkyYfnTZt2sjKlStt3xpCCHFGi04KPjqx8bEyY8+PsvbcE5HTrWJ7GVF3gFUiJzw8XJ5//nlVoyo6OlqKFy9OkUNIWi06BQsWlEGDBsnq1aulYsWK4ulpXCX3nXfeYecSQrI0RlmRkxm6QvXxaf9+LyfvnlOfXcRFhtTsLW3LNLNqW2fPnlURVUFBQTJv3jwWVybkaYXOwYMHpXbt2nL9+nX1MoVChxCS1dGyIic3dPUg4pF8uv0buRZyU332dPOQAeW7S6tSTazazqpVq5QlB0NU+/fvlwoVKtig9YRkcaGzZ88e27eEEEKcMCuyOWfkm6G35ZNt38j9/8LHUX38rUbDJDDe+nIOXl5e0qlTJ5kzZ44q6UAIsYGPjiGxsbHqRQghJDln5CdC50JwkLy7+Qu9yMnnl1s+bfWmlMlVwuLuu3nzpirGCefj//3vf7J06VKKHEJsKXTw40J2zXLlyqk6KXiVL19ePVHgO0IIyeqYCy8/dvu0fLj1KwmLfqzPkYNEgPn981q83q1bt0qNGjVUGQdzrgOEEBsMXSHTJorBjR49WurUqaOmYWx43LhxcuPGDfnwww/TslpCCHFKoYPMyLuuHpRv9v4o8QnxahqyHI9r/Ir4phJ6roGHyKlTp8qECROkefPmyoqTN6/lAomQrEqahM7s2bPll19+UWHmGkgxjrDG/v37U+gQQrI8upgnzsgH752TmTd26RMB1ilUTUY3GKIckC1l+fLl6mFy4sSJqtYgCnQSQuwkdEC9evXMTuPQFSGEGDsjr764VXTeiaKmZYmGMrR2P3GzMEdOcHCwSgDYq1cvKVKkiDRq1IjdS4i9fXSaNGkiCxcuTDId05o2bWrVuv7++29lDUK4OnLzIA9EaoSEhKjhs8aNG0vbtm1ZrI4QkqHDy6NdXNT/Zyu0k5frPGexyPnpp59U4r+dO3eKq6srRQ4h9rTofPLJJ0YJA0eNGiW//fab8tGBFefAgQOqNMTw4cOtEjmom/Xxxx9LgwYN5KuvvlLi5cSJE5I9u/kCdg8fPlRDZPny5VNRByhDAX8htAnTCSHE0SDb8dnbp6XQf59jXF3kheo9pFO5VhYtHxUVpXwgEeCBmlW1atWya3sJcWZcdBaONdWvX9/meXYw1FW2bFlZtGiR+oy05fnz51fj0MlV2n311VdVgqwzZ84Y1dpCiLuHh2Xj3aGhoRIYGKgsQwEBAWIrEhIS5O7du8pBEE9fxH6wr9MH9rP1RMZGqWzHtQ7vkfIRMWrazR6jpHG55hb1dUxMjHTr1k098M2cOVOGDBmSxqNHUutrXqszbz9bcx93d1SSwMePH6tIrddee80o8RWq7MIylJzQQaTBSy+9lKSgqKUihxBC7EVoVJhM2j5TLj68Ig0SnjxDNipluV+Nn5+fsmjv2rVLatasaaeWEpJ1SLMz8tOCMHQYkwoUKGA0HZ9Pnjxpdpl79+7J/fv3pUSJEjJs2DBVigJDVgMGDFBPQMkBSxFehkpQU5t42QqsC/tky3US9rUj4TltOcERD1VJh5thd9RnH12iX464uokOrxSuC/Hx8TJ58mRp3769ypGzfv16ff8T28PzOvP3szXrtFjoaBYW/BiTs7ZoYJ7UiIuLU/9NC4LCqpNcpmWYdMHYsWOVMzLGrvfu3St9+/ZVJt4XX3zR7HKTJk0yG/IO4YSxcFt2PMxoOLAcurIv7Ov0gf1sGXcjgmXWsUXyIDpEfQ709Je8nnEi0Q9E3L2U+T6lqCr4NsLhGJbpQoUK8fphZ3heZ/5+DgsLs73QgbOxufdpBeGS2o/cEHzOnTu32WVy5swpLi4u0qVLFxkzZoyaVrduXTl27JjK7ZOc0EGCLW1+zaKDMM08efLY3EcH7cN6KXTsC/s6fWA/p87VkBvyzZ6fJCQ6TF/S4e1mr0r0/AmC1IBu3j7JJvbDg1rv3r0lMjJS1q1bJ1WrVuX1Ix3geZ35+9nb27h+nE2EzsaNG82+TytwOsawE37oiLzS2L17t7RqZT4yAaUmKleurBdJGhBGKak7WInwMgUdb+vOx0G1x3oJ+9pR8JxOnvPBl+Wz7d9KeEyE+lwksKC82+xVye4TKJf/y4yMyuXmrgd40kWdKlQb//XXX9X1EJYfXj/SB57XmbufrVmfQ+/GL7/8sqrXcunSJX0ennPnzhlZZhBC3rVrV/1nmHiRlfnKlSvqM2q9LFmyRF0wCCEkvThx54x8tPVrvcgpnbO4fNhijBI5MNVrRT1R/sGQ8PBwNWSOiBGk2Ni2bZsULlyYB44QO2G1j44lWOKjA5DKHAkCURAUVpmIiAiZP3++VK9e3chp+fz580bi6PLly8qyA3PYrVu3pGfPnsoPhxBC0oMDN47K9F1zJTYh0dewct5y8mbjYeLzn6jRxcGfUGdU0BOcPXtWunfvLi1btpQZM2ZYlbaDEJI20uSjYyvc3d2VsPniiy9UNFXRokWTDDGhpgsEkKEZ7PPPP5d3331Xbt++rZ6ErBmrI4SQp2FH0D6Zue8nSdAlRn3UKlhFXm841KhulWbNAa7/CZ2VK1eq7O9wNkbUKCEkfUiTj46tyZEjh3qZA+PW5siWLZuULl3abm0ihBBT1l/YJvMOLtcX52xcrK4Mr/uCuJuUdEgwKOjp4uGtIkXxQId6VRiu9/f3Z+cS4ux5dAghJDOx6vQ/suTYKv3nNqWayJBafcTVJamrY4KJRQd5cr7++mtVOgdWaUJIJhA6cLaDr8zVq1f1OXE0kN2YEEKcAVzrIHBWn0lM4qcV5+xb5ZlkRYsu1ljoTJ8+PV3aSgixkdCBA3GPHj1UZmJzWFg+ixBCMjTww5l/cLmsv7hdP61f1WeV0EkOXP9++XmRNDYYuiKEOI40hZejPlWVKlVUJXGAZFcIkUQ+iO+++87WbSSEkHQnLiFevt37k17kuIiLvFirT4oiB7lxUI5mycIF+mmuXj7p0l5CiA0tOkhVfvz4cVV4Tq3E3V2aNm0qixcvVlk+EQJOCCGZlZj4WPlq11w5cPOY+gw/nBF1B0iT4nVTXG7EiBGqKPEfX78ncv3fxGUNwssJIZnEooMyDVoxTmQpvnMnsYhduXLllM8OIYRkVqLiouXzHbP0IsfD1V3GNnopRZHz4MEDfQ4xDOlXq1RB/51hHh1CSPrz1JmRa9WqpRztkNMG/1FZnBBCMiMRsZEyafu3cvzOGfXZy91LJjQdIbULVTM7PzIcIydOzZo15fHjxyqvV6lSpYzz6Hhw6IqQTDd01b9/f/37zz77TDp06KByRCC3zdKlS23ZPkIISRceR4erulUXHgSpz74ePjKx6Ugpm7tkskEZyMqOYfyZM2eq65+58HJadAjJhEIHvjiGFh3Um7p48aJ6mjH8sRNCSGYgNCpMPt42Q648uq4++3v6qQrkJXMWNTv/hg0bpE+fPqpe1a5du5RFJ7mEga6eSQsKE0IyWcJADw8PVa+KEEIyGw8iH8nHW7+WG6G31edA7wBVgbxo9kLJLuPp6SlNmjSRH3/80WxW94TIMP17V28+/BGS6Xx09u3bJ6NHj04yHdP2799vi3YRQojduRceLO9v/lIvcnL55JAPW44xK3JQjw819pDluFmzZrJq1apkS9fER4Tq37v5BtpxDwghdsuj07dv3yTTYcodM2ZMWlZJCCHpyu2wu0rk3Hl8T33O65dLiZyC/vnMPtxheAp5wjBMnxp6oePiKq4+frZvPCHEvkLn8OHDUrly5STTMS25bMmEEJJRuB5yS4mc+xGJYeEF/PPKhy3fkLzZcifJcjx79mxp3Lixqjp+6NAhKVu2bKrrjw8PUf/dfAPExUwtLEJI+pGmXyBy6Pz7b2IyLNNEgvnyJX0aIoSQjELQw2vy/pYv5WFUohgpGlhIiZxcvkmHof766y8ZPny4CiFH9vciRYqkun6Io4T/LDquvgF22ANCiN2dkYcMGSKDBw+WqVOnqozI+GFv375dxo4dqzKDEkJIRuRCcJB8um2GhMcmRkWVzFFU3m42Svy9siVJAJgzZ0753//+pwQOrnOWghw6uvhYvUWHEJIJhc748ePl7t27MmDAAH3lcpSBwJPPhAkTbN1GQgh5ak7fOy+Tt8+SyLjEHDflcpWUCU1Hiq+ncUK/lStXqge55cuXS/v27a0SOSA+ItFSBNz86IhMSKYUOm5ubvL111/L+++/r5Jlubi4KP8cPAERQkhG49jt0zJl52xVwwpUyltWxjV+RbwNKovHxsaqBzUkP0UiwEaNGqVpW8YRV7ToEJKp8+hA2CDMkhBCMioHbx6XL/+dI7EJidbn6vkrythGL4unu6d+Hlioe/ToIbt371albJAqAw9waUFzRAYUOoQ4ScJAQgjJiOy+dlBm7J4v8boE9bluoeoyusFg8XDzMJrP19dXvLy8VOVxRFg9DbToEJKxoNAhhDgl24P2ysx9P6lgCdCoaG0ZUW+guLu6qc+YDutN586dpUyZMqqsgy3QIq6AK5MFEuJwKHQIIU7Hxos75IcDS0UniSKnRYmG8nLt/uLqmphRIyQkRAYOHKiyG8OSA6FjK4wsOn700SHE0VDoEEKcinXnNsuCw7/qP7cv3VwG1uwprv8l7jt27Jh0795d7t27J6tXr5YuXbrYdPss/0BIxiLNKTvXrl0rXbt2lWrVqumnTZs2TeWfIIQQR/D7qb+NRE6X8m1kUM1eepETGRkp7dq1Ez8/P5XF3dYiB9AZmRAnEDqLFi2S5557Tpl78XRkWMV88uTJtmwfIYSkCvxtlh3/Q5YeX62f1rNSR+lftauKnoqKipLw8HDx8fFRVhxEV5UqVcouPWtc54qVywnJlELn888/lxUrVsiUKVOMpsOpb8mSJbZqGyGEWCRyFh1ZKb+d+ks/DQKnZ+VOSuQEBQWpSKqRI0eq7+rWrasEj71I+C9hIEQO61wRkkmFzoULF/TJtAxzTeTOnVuNexNCSHqQoEuQuQeXytpzm/TTBtfsLc9UaKuvVYWq48HBwXqhY280iw6zIhOSiYVO/vz55ezZs0mEDsIzS5QoYbvWEUJIMiQkJMjsfYtkw8UdidcicZFhdZ6T9mWaKyvPBx98IB07dpQGDRoof5xatWrZvS8TUOcqLka9Z7JAQjKx0HnxxRfVa8+ePUroXLlyRb7//nt56aWX5OWXX7Z9KwkhxIC4hHiZsWe+bAvaoz7D2XhU/YHSsuQTS3NMTIx8/PHHsmbNmnQrT2NU54rlHwjJvOHlEydOlIcPH6ryD/Hx8VK8eHFV1BNp01977TXbt5IQQv4jNj5Wpu+aKwduJgZCuLm6yWsNhki9wjVk3759curUKZUj57PPPkv3PosPN6xzxYKehGRai87NmzdV4bs7d+7I9u3bZevWreo9wstv3Lhh+1YSQoiIRMfFqOKcmshBKYc3Gw1TpR1mzZqlnI7nz5+vHsAcgXFWZCYLJCTTWnSKFCmixsCzZ88uTZo0MfsdIYTYksjYKCVyTt49pz57uXnKuCavSIlsReT555+Xn3/+WUaNGqUeuNzcEss8pDfGQ1e06BDidJmRIyIi7Bq2SQjJmoTHRMhn27+V88GX1Wcfd2+Z0HSklM9TSoYPHy6///67Sm3Rt29fh7aT5R8IyeRC55133jH7XouAOHTokFSvXt12rSOEZHlCox/Lp1tnyOVH11Rf+Hn6yttNR0ku10SLyYcffigjRoyQSpUqObyv6IxMSCYXOjt37jT7XsuKDKfkN99803atI4RkaR5FhsjH22bItZCb6nOAVzYZ32iEfDfpW2XBOX78uOTJk0e9MgLGda7oo0NIphM6cDoGPXr0UJmRCSHEHrWiEmIi5WFkiHy790cJDw8WBIcHevlLv+IdZdxzA+Xw4cPywfjx4u8SI7EPb2eYgxAXcl//nj46hGRiHx2KHEKILUEAQ2TQMQnZ84dEXjqinz7QaK4HIue+kalNc4k0bS0SeUCuzz6QQQ+EC+tcEZLZhM748ePVfxTt1N4nBwt7EkIsJT4qXO6umi6RFw87Tad55C4kLq6OifwihKRR6Bw4cMDse0IISSuxD27J7V8mSWzwk/xbDz3cJcjLTR9d5fZAJ9UqVxVX1zSl/Up3XNw9JaBmYq0tQkgmEjobN240+54QQtJC5JUTcmflVEmIfJw4wdtPfsvlKwe8RRJcXCSfVy7Z+MFvcvPyDdm+/TWpVq0aO5oQ4tg8OoQQYgmhhzfK/b/niCQkZjDW5cgn3+R0k5sucepz9oRssnDot1K8YDFVkLN06dLsWEJI+vjoWAJ9dAgh5tAlxMuDTQslZN9a/bT4wmVlik+4hOhi1ecCnnlkVv/J0r9XP1XWwdfXl51JCElfHx1CCLGWuMcP5d7aWRJ58ZB+WnSlBjIp9opEJSRacqrkKydjGw2TrutaqqLBqEJOCCHp7qNDCMm4IGld9O1LEnMnSImLp0Knk5iICHkAq8pTiA44G0deOgqTTuIEVzcJr9deJgUflrj/RM794zelnFsL8fHwlubNmz9duwkh5D/oo0OIEwwHRd+6KBEXDqoQbby3NU/y/T49rt7Z5H6TLvJF0GaJ/0/4XN97SXKcd5fWY1rbcEuEEMI8OoRk2uzBEZeOKGGD/wmRYZLRcQ/ILdmqNJNTefLINyd/V0kCwZWd56VTvmby9uq3M00IOSEk88A8OoRkAnS6BIm+eVEiLh5KtNrcvICpZuf1zFtcvItXFq98xcUjRwGRpxAPKNb78OFDyZEjx1OJEOSW8cxbVDZe/Fd+OLhEPz3mbJh81PktadeWeWcIIfaBeXQIyaDER4SpcggQN8pqY1Aw0hAXL1/xLVFVfErVEN+SNcQ9IJfN2gCh4+ZxV7zz5n1qa8vas5tk4ZEnNfLal2kuA3v1FFcXWnEIIRnYRyc2NlZfvZwQ8nRWm5hblxKFDaw2N86nYLUpKj6laopvqZriXbicuLhlXHc7DFGtOPmn/HryT/20vI/8ZVCNXoyqIoTYHfe0Xri+//57mT59uly8mOj4iIReY8aMkaFDh/LiRYiFxEfCanM0cUjq0hHle2MOF08f8SlRVQkb31K2tdrYE1wrFh1ZKWvPbdJPK59QVD58aTyvE4SQjCt03nvvPfn2229l9OjRUqdOHTVt//79Mm7cOLlx44Z8+OGHtm4nIc5jtbkd9J/V5lCi1UYLuTbBI08RvbDxLlJeXNwyl9UUw15zDi6RzZf+1U9rl7+xDGnW36HtIoRkLdIkdGbPni2//PKLtGnTRj+tY8eO0rBhQ+nfvz+FDiEGxEc+lsjL/1ltLsJq88hs/7h4eItPiSpPrDaBeTJtP8YlxMuM3fNlz/UnyQEHVO4uHSsxfJwQkr6keWC/Xr16ZqdpIaOEOJq4sIcSfma36GKj03nLOkmIiVaJ+2LuXZXoG+eSt9rkLmxgtakgLu6Zy2pjjpi4GPlsy7dy6gF8jETcXFxlVP1B0rBobUc3jRCSBUmT0GnSpIksXLhQRo4caTQd05o2bWqrthHyVNxZ8blE30y82WYUXDy8xKd4otXGp3QN8QjMK85EZGyUTFw7SW7E3FWf3cRN3mz8stQsWMXRTSOEZFEsFjqffPKJ/n3BggVl1KhR8ttvvykfHVhxUAtry5YtMnz4cHu1lRDr8s7YIUNwWvDIVUhZbHxK1xSfIhWdwmpjjsfR4TLql7cl3DPRgubl5injm46QSnnLOrpphJAsjMVCZ+3aJ9WGtWGqiIgI2bZtm9G0gwcP2raFhKSBhOhI/XCRZ74SkqNxz3TtR4gZN79AccuWU9z9c4iz8ygyRD7eNkMvcvw8fOXtZqOkdK7ijm4aISSLY7HQ2bNnj31bQogNMSyJ4JGroPiVT+pTRmzDjoO7ZO7ZXyTSLVHkBHoHyLvNXpWi2QuxiwkhDifjZhkj5CkjnTTcfPzZl3Zi9qI5si5sh/jkyqY+5/HNKe82Hy35/Z3L94gQkgWFDvxyLl++LFevXpW4uDij71q3ZggpyTgWHVefxJswsR3R0dEy8u3X5E6ZCL3IKeCfV4mc3L452dWEkMwtdIKCgqRHjx7J+uNYE2IOB2YkH7xz545UqVJF3nnnHSlUyDKTN6K8ZsyYIf369VNZmQnRSKBFx6689flEuVcxWrz9fNXnYtkLyzvNRqlhK0IIyUikqZrea6+9pkQJqhqDyMhI5ZRcoUIF+e677yxez6ZNm6Rt27ZqXe+++66yDjVq1EhCQ80XLzTk9OnTShRBIGE5QkxLK2i4cujKZjx69EiO3T4tDyrGiaefl5pWNldJeb/FaxQ5hBDnETo7d+6Uzz77TLJnz64+u7u7q/w5ixcvlmnTplm8Hoibnj17ygcffCDt2rWTFStWqAsp6milRFRUlPTu3VvV2sqVK3PU/CGOtOhw6Oqp+zMhQWU8b9SrhUza/q1Ex8eo6VXylVOWnGyefk+9DUIIyTBCJzg4WAoUKKDeQ2jAqgLKlStnsXUlPDxcRXKhdISGj4+PtGrVSll6UuL1119X+Xu6d++eluaTLAAtOrYDv3f8Thfu/EUqDa4v8f+F7dcuVE3GNRkh3h7eNtwaIYRksKirWrVqKcvK2LFjZe7cuVKiRAmLlrt+/bry5UHyQUPwOSWhgySFGzZskCNHjljlOImXhjY0hqdUvGwF1oV9suU6Sdr6GuUXNFy8/HhM0giK9eKBIl+z4lKry5Os582L15ehtfqJm4sb+9ZG8PqRfrCvM38/W7PONAkdFO7UwBBWhw4d5IsvvpBs2bLJ0qVLLVpHbGys+u/llTjOb2jV0b4z5cqVKzJs2DBZs2aN2palTJo0yWyh0Xv37qlhMFt2fEhIiDqwrq5pMpYRG/V1VOgD/fsH4VHiEpdYkoBYR1hYmFTuV08Caj0JF29VuKF0Kdpagu8HszttCK8f6Qf7OvP3M65NdhU68MUxtOjAOnPx4kUpXLiwxQJE862BWdyQ+/fvJ+t3A4GDbMwjRozQTzt37pzcunVL+Q3t3btX3Nzckiw3YcIEo6gsWHSKFCkiefLkkYCAAJseVBcXF7VeCh37klpf34yPlkQvEhfJW7iYuLhQeFoKfmNTpkyRsW+9Kaf8rhqJnH5VnpUu5dvY6CgSQ3j9SD/Y15m/n729vdNv6EqzvpQvX96q5eDjgxdM4507d9ZPh1hp1qyZ2WXggFy/fv0k1iWILQgZcyJHsxqZWo4AOt7WnY+Dao/1Euv6OiEqXP139fETNzfmxbSU8+fPq6Gqy1eDJLqWl1yOup7Y1+IiL9fpLy1LNuKpaEd4/Ug/2NeZu5+tWV+atgwzFMLI4XyMoSa8IHTmzJljVQ6dIUOGKL+ea9euqc/Lly9XYeOYblhMtE+fPuo9VGHt2rWNXth23rx51XtCTBMGMiuy5fz+++/qdxTrEi8vL3pTL3Lgh/N6wxcpcgghmZI0Peq+9957Ksnf6NGjVfQTgGVm3LhxcuPGDbP+MMmFl2PIq0yZMsoJ+e7du0pAwUJjmJzwxIkTaWkmyaLoEuKfWHS8GVpuCXDu79atm/To31OK9qssV8Nuquk+7t4ypGIvqVuoul2PGSGEZCihM3v2bPnll1+kTZsnY/UIP23YsKEaSrJU6Hh6esqSJUtUeDpETqlSpcTXNzHTqqEYevz4SU4UU7C8vz9rGZEnaCIHMFlgyiBvVWBgoFSvXl1+X79aNsUckGtht9R3AV7ZZEKTEeIXy/BxQkjmJc2DZvXq1TM7zZqhK418+fKp7MimIgcUK1ZMKlWqlOyyFStWVI7FhJjLocNkgcmzY8cOlc0cpVSuPLou6yL+lTuP76nvUK/qo1ZjpUSOojyxCCFZT+g0adJEXRxNwTRkSCYko2RFpkUnKXgYQTqIFi1aKN+6kvXKyXubv5BHUYm5hwoHFJCPW42Vgv750vGoEUKIg4eu4BSsAX+aUaNGqeR98NHBhfPAgQOqQOfw4cPt1FRC0mLR4bCmIRgGHjBggPrtwqeu07BuMmv/IolLiFPfl8lZXMY3HSH+XvRtIoRkMaGzdu3aJMNUyLeBYp6G05KraE6IYyw6vGEbgjQLSJKJCCvPigHyzd4FopPE4eaaBSrLaw1fFG/3pKkYCCHE6YUO6lIRkhmgRcd8kk+kg4AFds3aNfLz0d9lzeFf9d+3LNFQhtbuJ26u5nNREUJIZoVZ7YjTQYvOE1DjDcPJzz//vBquiouPk2/3LJA1Zzfq5+lRqYO8XOc5ihxCiFOS5pSxKLswc+ZMleAPPjqIfkJpBq2qOSGOThaY1X10UBuuZ8+ecvToUZXMs9+A/jJpx7dy/M5ZfcbSobX6SutSTRzdVEIIyVgWnX///Vcl+UMuHWQm9vPzk19//VVNw3eEZJShq6wadYUaM506dVL5qfCb7PFcL/lgy3S9yPF085A3G71MkUMIcXrSZNEZO3asst5MnjxZPRUCWHUQxYHvdu/ebet2EmIxCVGPs2weHQgcRFahWC3SPSAPVaR7jLyzcYrci0is6O7v6SfjmgyXsrlLOrq5hBCSMS06hw4dkvHjx+tFDsB7TDt8+LAt20eI1cRH/GfRcXUTF0+fLNODwcHBKkM5hqvw4FGjRg25l/BQ3t00TS9y8vjmVDlyKHIIIVmFNFl0kDIeNahy5MhhNB3T8CRJSEaw6MCaYyjGnRnUmuvRo4eEh4ersijY7wM3jsr03fMkNj5WzVM8e2GZ0HSk5PAJdHRzCSEkY1t0UE28d+/esmrVKrl586Z6IS9Hr1699JXGCXG0j05W8c/54YcfpHHjxpI/f35lbW3btq38dW6LTP33e73IqZKvvHzQcgxFDiEky5Emi86UKVMkLi5OmcjxX63I3V2GDh2qviPEUejiY0UXE5WlIq5gxcFvD2UdPDw8ZMGhX2Td+S367xsXqyvD6zwv7m5pDrIkhJBMS5qufBA1s2bNks8++0zOnj2rzORly5aV7Nmz276FhFhBvGFWZG/ndUQ+f/68rF+/XgUFjB49Wv0Go+KiZdquOWrISqNrhfbSu0pncXVhyixCSNYkTULH09NTRXdA2JirYk5IRsih46xDVxgyRr0q5KwaOHCgSu/wKDJEPt8xWy4+vKLmcXNxVZmOW5Zs5OjmEkKIQ0nTY17evHnlzp07tm8NIU9JQlS4/r2bj59T9SeGid966y3p2rWr8sPZt2+fEjlXH92QiRun6EWOj4e3cjqmyCGEkDQKnZdfflkmTpwokZGR7EOSoUiIjtC/d/XyFWfi888/ly+//FK9kKwTEY7Hbp+WdzdPk/v/hY/nRvh4y7FSNX8FRzeXEEIy79DVH3/8IUeOHFEX2xIlSqihLEMOHDhgq/YRIlld6ISEhKiUDvDFadWqldSvX19N33xpl/xw4GeJ1yWozyVzFFWJABk+TgghTyl0EFqOFyEZjYToSKcROkj6B+sNnP7x8ICHCoicBF2CLD++Rn4//bd+3tqFqsmr9QeJt7uXQ9tMCCGZXuhcvnxZcuXKpS7CrVu3lpIlmUaeZBycxaITGhoqgwYNUhXHUVqlSJEiajoiq2bu/Un2Xn+SgbxD2ZbyQrXu4urKyCpCCHkqobN161aVYj4iIvFm4uvrK3/++ac0b97cmtUQki5Cx8Urc5Z/OHXqlDz77LPK4R+JOPEewA9n6o7v5PKja+ozQsoHVu8p/yvbwsEtJoSQjItVj4Dvvvuu9OvXT/kM4IXhq/fee89+rSPkqSw6mTPqCnmq8uXLp4arNJFzPviyTNzwuV7k+Lh7y/gmwylyCCHElhad48ePqydMrZ4VokCQKJCQjOmjk3ksOtHR0Sqr+Ouvv65+U9u3b9fX6dp5Zb/M3rdQYhMSs5Dn88utnI4LBxZwcKsJIcTJhA6sOLlz59Z/zpMnjzx69Mge7SIkTSREh2c6H52rV6+qgpxHjx6VBg0aKN83iBw4Hf9yYq38duov/bwV85SRMY1ekgAv5836TAghDnVG3rhxY6rTcKEmxBFktqirf/75R/r37y/ZsmWTf//9V2rXrp2s0zESAL5Ysw9rVhFCiD2FTps2bVKdhogsQhzqo+PqJi7uxvmdMhoXLlyQDh06qCzHixcvVtGMyTkdI6oK0VXacBYhhBA7CJ1r1xIvvIRkdKED/5yMKgoQOu7v7y+lS5dWhTlbtGihDw0/d/+STPv3e3kUFap3On6t4RCpUaCyg1tNCCFZQOgULlzYfi0hxKZCJ2MOW+3fv1/546BmFSqPI9OxxsaLO2TeoeUSnxCvPuf1y6WcjosEFnRgiwkhJHPDDGPEqdD956Pj6pmxhA6Gc7///ntp3Lix5M+fXzp37qz/Li4+TuYcWKJemsiB0/FnbcZT5BBCiCNKQBCSEdHFxYouPla9d/XOOEInKipKFcJduHChDB8+XJV18PJKLNXwMDJEvvx3jpwNvqSfv0OZFvJc9e7i7urmwFYTQohzQKFDnDNZoGfGyaHj4eGhUjPA4RgRVhrwx/ni3znyMCokcT5Xd3mpdn9pViKxaCchhJCnh0KHOKfQ8XZ8VmQk10QkVdOmTdV7Q+foTRd3Kn+cuP+SAObyySFjG78spXIWc2CLCSHE+aCPDnHOHDoOtOjExcUpZ+Nu3brJ0qVL1TRN5MAf54cDS+T7Az/rRU6FPGVkctvxFDmEEGIHaNEhTpkV2VEFPW/duiV9+vRRyf+++OILVdJBQ/nj7PpBzt6/qJ/WvkxzeaF6D/rjEEKInaDQIU6aFdnPIZFVsOIEBQXJli1bpEmTJvrvTt49J1/tnich/+XHgT/O0Nr9pHmJBuneTkIIyUpQ6BAnrVzuk64CJywsTBW7RQh53rx5VQi5apMuQf44s0GWHl+tzxgOf5w3Gr0kpXMVT7c2EkJIVoVChzip0PFNtyzHgwYNkjt37qiK41WrVtV/9zgmXNWrOnjzuH5a1XwV5NX6gyTA2z9d2kcIIVkdCh3iNKS30Dlx4oQaqoLIWbBggb6MA7j04Ip8sesHuRcerD67iIt0r9RBelTsYDQfIYQQ+0KhQ5yGhJj0q1yOaKoXX3xRSpUqJQcOHJAyZcqo6Rie2nRpp8w/9Is+qsrf009G1R8k1QtUsmubCCGEJIVChzgNCVHp56MTHh6ualbNnj1bfH0TRVVUXLTMPbBUtl/Zq5+vTM7i8nrDoZLbL6dd20MIIcQ8FDrEaUiIse/Q1dWrV1Xiv9GjR8uQIUPUS8uPcyP0tgodvxZy0zh0vFp3cXfjz4wQQhwFr8DESS06thU669evl379+omfn5+88MILkiNHDv1Q1dbLu2X+oeUSHR+jpnm7e8mwOs9Jw6K1bdoGQggh1kOvSOI06Ix8dGwzdJWQkCAfffSRtG/fXurUqSOHDh3Si5yI2EiZsWe+zN6/SC9yCgcUkEltxlPkEEJIBoEWHeJ0mZFd3D3Fxc3DJuucOXOmfPDBB+r1zjvv6COmLgQHyde758md8Pv6eVuVbCwDa/QUL3dPm2ybEELI00OhQ5wuM7Ithq2QHwcJAIcOHSrVqlVThTnVNnQJsvbsJll6bJXE6xLUNB8Pb3m5Noaqaj31dgkhhNgWDl0Rp8uj8zTDVvC5QXbj4sWLy6lTp8Tb21svclC+YfL2mbL46G96kYOoqqlt36bIIYSQDAotOsQpgEB5WotORESEvPLKK7Jw4UL1HzlyNI7dPi3f7l0gj/6rVYUEgM9UaCu9KndmQU5CCMnAUOgQp0AXGyXyn5XFJQ1C5+LFi9K1a1e5cOGCEjrPP/+8mh4bHyvLT6yRNWc2ik4Sa1UFegfIqHoDpWr+CjbeC0IIIbaGQoc4YeVy64WOu7u7Ch3fu3evVKlSRU278ui6fLtngVwJuaGfr1r+ijKi3gDJ7h1go5YTQgixJxQ6JMtWLo+Li5OpU6eqYapixYrJrl27VAJAhJSvPbdJlh3/Q1/Gwd3VXfpU6SKdyrUSVxe6thFCSGaBQodkyYKet2/flj59+sjOnTulYsWK8swzzyiRgyKcqDh+6t55/bxFAwvJqPoDpVj2wnZrPyGEEPtAoUOcT+h4pix0IG569eqlHJg3b96soqrwfnvQXpl/eLlEwt/nP4djWHB6V+kinjbKy0MIISR9odAhTuijk/zQ1Y0bN6RVq1ZSv359Wb58ueTPn19Cox/LDweWyN7rh/Xz5fbNKSPrDZCKecvave2EEELsB4UOcaqsyMkNXT1+/FhVGS9UqJCsW7dOmjVrphyQD908Lt/tX6wPGwfNiteXQTV6ia+nfSugE0IIsT/0qiROH3V14sQJqVWrlkyZMkV9hkUnKj5avtnzo0zeMUsvcvw9/WRMw6EqqooihxBCnANadIhTEB8WrH/v6u2nf//zzz/LSy+9pJL/de/eXU3DENXcg8tUpmONGgUqybA6z0sOn8B0bjkhhBB7QqFDnILIy8f/e+ciXgVKS2xsrLz++uuqKOcLL7wgs2fPlljXOJm+a67svnZQv5yvh48qxInhKkRdEUIIcS4odEimJ+7xI4m5G6Tee+YvKW6+/uKq08m9e/dU3aoXX3xRdl8/KPMP/SJh0Y/1y9UqWEWG1u4nOX2yO7D1hBBC7AmFDsn0RAYd07+/4xIgp9avl7Zt28qyZcuU/820XXPkwI2j+nmyefrJ4Jq9pFHROrTiEEKIk+NwoYNstBheuHPnjkq9P378eMmXL1+y8z98+FDmzJmjlkPUTOPGjVVmW1SZJlmTyMtPRMyoT2dIifptpE2bNrL18m5ZeGSFhMc+cVSuX7imDK7VmyUcCCEki+DQqKvt27dL8+bNpUiRIjJq1CgVHdOoUSMVCmyO+Ph4qVGjhjx69EiGDBkiPXv2VKKnXbt2Kp0/yXog0V/4hSPqfWRMnHQYMFwmz5wqH2yZLrP3L9KLnEAvfxVRNabRUIocQgjJQjjUovP222/Ls88+K5MnT1afW7duLQUKFFDiZcyYMUnmd3Nzk+PHj4u/v79+Wvny5ZX42b9/vzRo0CBd208cT2zwddFFPFLv43MXk9LNa8hbGz6T+IR4/TyNi9aRgTV7SYBXNge2lBBCSJYSOhEREWr46aefftJPQ/VoiJ0NGzaYFTrAUOSAwMDEcOCoqMS0/SRzEff4oURcOCi62GirlkPhzcf3g8Ul5qF+2sFscfLXqb/1n/P55ZYhtfpK9QIVbdpmQgghmQeHCZ1r166pmxUy1RqCz6g/ZCmTJk1SPj316tVLdp7o6Gj10ggNTcyfgu3jZSuwLgyl2HKdzgj6KCromIQe/EciLxwU0SWkedz1ST5kkcNuseqUdnNxky7l20jXCu3E082Tx+Mp4DmdfrCv2dfORoId74nWrNNhQgd5ToCpE7GPj4/ExMRYtI5Zs2bJggUL5M8//1Tp/VMSQx9++GGS6Qg/tqUlCB0fEhKiDqyrK5NOm6JLSJD4K0ck9uh60QVfE1ty09Ndbnu6SanAYtKrTEcp4JdHHgUnDmmRtMNzOv1gX7OvnY0EO94Tw8LCMr7QyZkzp/ofHPwko632WfsuJebNm6cSwi1dulRF2KTEhAkTjIbCYNGBA3SePHkkICBAbHlQkXQO66XQMeiXuBgJP75NQvb+IXEPbxv1mVu2HJKtanPxyF001f49dOigSvyXp0R+qdC+hjyKTbTMxbuI3AnMLsNq9GDiPxvDczr9YF+zr52NBDveE62JtHaY0ClYsKAacjp48KB06tRJP33fvn0q8iolfvzxRxk+fLgsXrxYn9Y/Jby8vNTLFHS8rTsfB9Ue682MJERHSOih9RKyd43EhxtbVzzzl5LsDZ8Vv3L1xMXVzaL1XT5xSeK7NpS7xX3krsTgTFfTmxdvIK9V70ZnYzvBczr9YF+zr50NFzvdE61Zn0OjrgYNGiRz585VtYgQbbVq1SoVYo5pGp9//rmcPHlSFi5cqD7j/7Bhw5TIQXg5yZiZikP3/ymhB/9WYscQn+JVJLBhV/EpXtWiZH3Ir7Rw8SIp06GKbPE8Iq7Fn1QUL+CbR16s00+q5C9vl/0ghBCS+XGo0Hn//ffl7NmzUrp0aSlWrJgEBQXJ119/beRYfP78eTl06JB6j/w5EEfZs2dX8+GlgUSDhpYhkoguLlYNHdkVnU50MZESFx4ij49ulrCjm0UXn+iDlYiL+JWvJ4ENuop3wdIWr3bnzp3y8gejpOSzlWX/sYv66X4ePtKzUiepFlBeCuTNb+OdIYQQ4kw4VOhgjO23336Tq1evqif3smXL6sPFDQWM5nSULVs22bZtm9l1lSlTJl3anJkIP7df7q7+WokQh+DqLv5Vm0tg/S7imcs4ui4l4Lg26Zsp8vet7VJpaH39dBdxkdalGkvvKl0km4ev3L17104NJ4QQ4iw4vAQEKFq0qHqZA9YeDa3kA7GMsMMbHCJyXDy9JaBmWwms00ncA3JZtezjmHD5+Ncv5GKu65I/35NzokKe0jKoRi8pnqOI+swQfkIIIZlG6BD7+cok4iI+JavbtZtdPb3F1dtPPHIXEv+qLcXNx7osxDHxsfLHiX/kz0tbJNw9Qlwl0UE5l08Oeb56N2lQpBYLcBJCCLEaCh0nJiEiRP138wuQAn3fkYxIgi5B/r1yQObuWSKRLk+SOnq4eUiXcm3kmQptxds9acQcIYQQYgkUOk5MfERinhlXX9vlCrIlJ+6ckYWHV0pQyHUYnfR+OM2K15deVTpJbt/U8ykRQgghKUGh46QkxESJ7r9oK7cMJnSuProhPx/7XQ7fOmk0vXr+itK/Wlcplr2ww9pGCCHEuaDQcXJrTkYSOncf35cVJ9fJtqA9ohOdfnpez1zyUoP+UjV/BYe2jxBCiPNBoZMlhI5xyH56cz/igfx28i/ZcnmXxBsU8MTQVJ8qXaRxsTri6sJM0oQQQmwPhY6TOyI70kfnYWSI/H7qb9l4aafEJcTpp8c8jpbqPuVkYocx4unm4ZC2EUIIyRpQ6Dgpjhy6CokKldWn18s/F7dLrEGG5PioOLmy6ay81/dN6fK/zunaJkIIIVkTCh0nxRFCJyz6saw5u1H+Or9VouOehIp7uXnKqT8OiUdQnKxctEyV+yCEEELSAwodJyU9hc6jqFD58+wmWX9hu0TGRemne7i6S9tSTeXZiu3kYM4Dqiq9uSryhBBCiL2g0HFS4sPt74x8LzxY/jizQTZf3mU0ROXu6i51clWRxe/+IMWbB0hgzZ7SsmVLu7SBEEIISQkKHSfFns7I10NvKR+cnVf2GUVRQeC0KNFA/K67yvBuwyRv3rzSp08fm26bEEIIsQYKnSwxdOVvk3VeenBFfj/9j+y7fsQoD46Xu5e0LdVEOpRpKVM//lw+//xz6dq1q/z4449JqtETQggh6QmFjpMS/59Fx9Unm7i4JhbITAs6nU6O3zkja85ukKO3Txt95+fpKx3KtJD/lWkh2bz81Ly3bt2SadOmyZgxY1iEkxBCiMOh0HFyi05aHZFRTRxDU3+e2yzXQm4afZfDO1A6lWstrUs1Fh8Pb/n333/lwYMH0rlzZ1mwYAEFDiGEkAwDhY4TkhAXI7qYqDQ5IiOCCtFT6y9sk9Dox0bf5fXLJc+UbyfNStRXif5gwZk+fbq89dZb0r59e+nUqRNFDiGEkAwFhY4TkmDgn2OpIzIKbcJ6s+PKPqMsxqBc7lLSsWxLqVOomrj9NwwWFhYmgwcPlhUrVsjYsWPls88+o8ghhBCS4aDQcfrQ8uSFTnxCvBy6dUL+Pr9V+eEYgtpT9YvUlE5lW0npXMWTLAuR888//8jKlSulW7duNt4DQgghxDZQ6DixI3JyQudRZIhsuvSvbLy4U4IjHxp95+vho3xv2pduLrn9ciZZFpYcf39/mTRpknz66adStmxZO+0FIYQQ8vRQ6GSRrMjwpzl595ysv7hd9l8/YpT/BuTLlkdFUCEPjreHd5J1xsTEqEiqzZs3y8GDB6V06dLpsCeEEELI00Gh4+RCJ9bTW9ad2ywbLu6QG6G3jeZzERepWbCytC3dVKrlr6iGq8xx7do16dmzpxw+fFi++uor8fZOKoQIIYSQjAiFjpMPXX1z9Fc57W0sYAK9/KVlyUZqiCqPX64U17Vp0yaV3djX11d27NghdevWtVu7CSGEEFtDoeNE3I94INsu7xH3M1ukyn/THrnEw7VYva+Qp4y0Ld1E6hWqIe5ulh368PBwqV27tixatEhy585tx9YTQgghtodCJ5ODxH77bxyRrZd3y7HbZ1RphuejI/TfJ3j5SrvSDdXwVJHAghatE8n/5s2bp8LGu3TpohIBuri42HEvCCGEEPtAoZMJgWPxhQdBsi1oj/x7Zb+Ex0Yafe8X/6QO1bRnJomXt5/F64ajcY8ePSQ0NFT9L1GiBEUOIYSQTAuFTiYCVcN3XtmvxM2d8PtJvkfm4uYlGkrJ+2skIequuHj5WixyIJ7mzp0rI0eOlKpVq8rWrVulWLFidtgLQgghJP2g0MkEfje7rh5QAifo0fUk36MUQ/3CNaVFyYZSIU9pFTkV9Pcyq+tc/f777/LSSy/JsGHDVGSVl5eXTfeDEEIIcQQUOhmQ0Kgw2Xv9iOy8ul9O3zuf5Hv4y1TJW14aF6sjdQtVF19PH/13uoR4SYgKt1joPH78WLJlyybPPPOM/PXXX6pmFSGEEOIsUOhkEB5EPpJ914/I3uuH5dS982ooyZTSOYsrcdOwSC3J7mO+WGdC5JNCnG4+/iluc/Xq1TJkyBBZtWqVNG7cmCKHEEKI00Gh40DuhgfLvuuHZe+1w3I2+JLZeQr655PGxepK46K1Jb9/XquSBbr6mhc6cXFx8s4778jnn38uXbt2lSpVtGB0QgghxLmg0ElHYKW5EXZb9l8/qiw3lx5eNTtf/mx5pF7hGtKwaG0pnr2wVVFP8ZFhKVp07t69K71791bJ/6ZOnSpvvPEGo6oIIYQ4LRQ6diYuPk5O378gB28ck4O3Tsidx/fMzlckoIDUK1JDCZyigYXSLD4SDISOqxmh4+bmJpGRkSrjcbNmzdK0DUIIISSzQKFjB0KjH8vR26fk4K3j6n9kbJTZ+UpkL6IXN4UC8ttk2/ERSS06sCTNmjVLnn32WSlUqJDs3r2bVhxCCCFZAgodG4aB7wjaJ3uuHJKg0OsqQ7Epbi6uUj5PaalVsIrUKVRNVQy3NUYWHV9/CQsLk8GDB8uKFSvE1dVVXnnlFYocQgghWQYKHRtxK+yuLD2+Osn0bJ5+UqNAJSVuUCHcz9NX7Imhj861O8HS9dk6cvPmTfn1119VpmNCCCEkK0GhYyMq5C4tPu7eEhkXJYUD8kvNglWldsEqUiZXCXFzdZP0wnDoasBLw8XDM1AOHDggZcuWTbc2EEIIIRkFCh1bdaSbu7xaf5B4xXhIxWLl1DCRI4iLCNG/nzZjltRq3EL8/CyvdUUIIYQ4E465GzspNQpUltw+ORy2/WvXrsnRfbv0n5u0bkeRQwghJEtDoeMkbNy4UWrWrCk+Lgnqs4unj7i4eTi6WYQQQohDodDJ5CB0/NNPP5W2bdsqoVOsQB6Lyj8QQgghWQEKnUwOEgtev35d3nvvPfnzz7Wii45Q092SKf9ACCGEZCXojJxJOXjwoAQFBUn37t1VMkAIHhVarktINisyIYQQktWgRScTDlXNnTtXGjVqJF9//bX6rJWLMEwWyKErQgghhEInUxEREaGyHA8dOlQGDhwo69evN8pyHB/5ONXK5YQQQkhWgkNXmYiRI0fKsmXLZMGCBTJgwIAk38dHhOrf06JDCCGE0KKTKXj8ONFS88EHH8iePXvMihxLKpcTQgghWQ366GRg4uLiZMKECVKtWjUJDQ2VokWLqveW1Lly8w1Ip1YSQgghGRcOXWVQ7ty5I3379pXt27fL5MmTxd8/dQtNgkGdK1efbHZuISGEEJLxodDJgOzatUt69uwp8fHxsmnTJmnWrJlFyxlZdHxo0SGEEEI4dJUBiYyMVNXGDx8+bLHISRJezqgrQgghhEInoxAWFiZTpkyRhIQEadWqlWzevFkKFChg1TrijYau6IxMCCGE0KKTATh58qTUqVNHPvnkEzlz5oyaZpgfx1K0oSsXd09x9fCyeTsJIYSQzAaFjoNZunSp1K1bVzw8POTAgQNSsWLFNK9LG7qiNYcQQghJhELHgWzcuFH69esnXbt2Vflx4JeTVlAKQhu6YrJAQgghJBFGXTmA8PBw8fPzU744a9eulQ4dOqRpqMoQXUyUSEKcek9HZEIIISQRWnQcYMUpWbKk/PPPP0rcdOzY8alFjmloOYeuCCGEkEQodNIJRFN9+umn0rZtW6levbrUqlXLpuuPvn1R/55DV4QQQkgiHLqyEbqEeIl9dE8SwoIl1lPE1fWJhkT5htdff022bNkqk98dJ6NffVVc3RIk9tFdm2w7+sY5ubfmW/1nz3zFbbJeQgghJLPjcKGDSKPZs2erkgdVqlSRsWPHSq5cuWy+jL2JCwuWG7NHqPc3zHz/QU0v+aBmOxE5Jze+G2m3dviWriX+VVvYbf2EEEJIZsLV0aUOGjVqpOo4Pf/88/rPcNa15TJZhWyVm0q+Hm+Ji7uHo5tCCCGEZAgcatGZOHGicsb96quv1GdEHxUsWFDmzp0ro0ePttky6YGru5f4VWgkUdFR4u7uIYcOHpRLly9JtWrVpUKF8nbfvk/xKuJfvZW4uNDtihBCCHG40EE9px07dsiPP/6onwYrDUKu169fb1a0pGWZ9MLNL1DyPPua7Nu3T1555RU5e/asfPfdd9L8hRcc1iZCCCEkq+MwoXPt2jUViVS4cGGj6fi8ZcsWmy0DoqOj1cvQORhgXXjZCgixbt26qRw5GFKrWrWqTddPnoB+RZJE9q99YT+nH+xr9rWzkWDH67Q163SY0ImJiVH/fXx8jKb7+vrqv7PFMmDSpEny4YcfJpl+7949iYqKElt2/Oeff67qVmXPnl3u3rVNVBUx39chISHqR2QY4UZsC/s5/WBfs6+djQQ7XqdRCDvDC50cOXKo/w8ePDCaHhwcrP/OFsuACRMmyJgxY4wsOkWKFJE8efJIQECA2PKgtm7dWq2XN1/7gr5GokX2NfvZWeA5zb52NhLseJ329vbO+EKnUKFCaucPHTqknIs18BkWEVstA7y8vNTLFHS8rTsfB9Ue6yXsa0fBc5p97YzwvM7c/WzN+hx6Nx4wYIDMmzdPP8Szbt06OXLkiJqu8eWXX8rQoUOtWoYQQgghxOHh5fCbOXnypJQpU0ZKlSolp0+flilTpqi8OBqnTp1Slb2tWYYQQgghxOFCB07EsMicO3dOZTmuUKGC5M6d22ieN954QzkzWbMMIYQQQkiGKAEBypYtq17mgJCxdhlCCCGEEECPWUIIIYQ4LRQ6hBBCCHFaKHQIIYQQ4rRQ6BBCCCHEaaHQIYQQQojTQqFDCCGEEKeFQocQQgghTguFDiGEEEKcFgodQgghhDgtGSIzcnqj0+nU/9DQUJuXpA8LC1Pl41m93L6wr9MH9nP6wb5mXzsbCXa8J2r3b+1+nhJZUuig40GRIkUc3RRCCCGEPMX9PDAwMMV5XHSWyCEnVJk3b94Uf39/cXFxsanChHi6du2aBAQE2Gy9hH3tKHhOs6+dEZ7Xmb+fIV0gcgoWLJiqtShLWnTQKYULF7bb+nFAKXTSB/Y1+9nZ4DnNvnY2Aux0T0zNkqNBZ2RCCCGEOC0UOoQQQghxWih0bIiXl5e8//776j+xL+zr9IH9nH6wr9nXzoZXBrknZklnZEIIIYRkDWjRIYQQQojTQqFDCCGEEKeFQocQQgghTguFjpU8fvxYDhw4IEFBQXZdhohKMoV+s7RUR3x8vJw+fVrOnz8vcXFx7EILQV8dPXpUTp48aVE6dUPOnTsnO3fulIiICPa3BQQHB8v+/fvl9u3bVvXXxYsX1fFBslNiGbgOHDp0SKKioiyaPzY2Vs6ePSuHDx+WR48esZstBNfdffv2yalTpyxdRCIjI+XgwYNy4cIFSRfgjEws48cff9T5+fnpypUrp/63a9dOFxYWZvNlsjqRkZG6bt266Xx8fHTly5dX/2fMmJHiMp988okuX758ugoVKuiKFy+uK1SokG7NmjXp1ubMyt69e3WFCxfWFSlSRPVf2bJldadPn7Zo2bNnz+oCAgKgjHTHjx+3e1szO++9957Oy8tLV7FiRfV/yJAhuvj4+BSXOXz4sK5KlSq6vHnz6mrVqqWrVKmS7siRI+nW5szInTt3dPXr19dlz55dV7p0aV2OHDl0q1evTnGZv/76S1ewYEFdsWLFdNWrV9d5e3vrXn31VV1CQkK6tTszXqc/+ugj1We4DnTs2NGi5X777TddYGCgOjb437BhQ929e/fs2lYKHQs5efKkzs3NTbdw4UL1+f79+7pSpUrpXnnlFZsuQ3S68ePHq5vvzZs3VXf8/vvv6ma6Z88es90TFxene/vtt3XBwcH6ae+//77O19dXd+vWLXZpMkRFRal+fumll9Rn3HS7dOmiq1q1qkXL1qhRQ/fWW29R6FjAqlWrdB4eHrp///1XfT5z5oy6yH/99dfJLnP79m1drly51PUC5zi4cOGCuimT5Hn22Wd1tWvX1oWHh6vPkyZNSvFaADGDfh4xYoR+Gq41uObwYUmX4vmJ6+6VK1d0vXv3tkjoXLt2TT24fvnll+ozHvqrVaum69mzp86eUOhYCC7osBQYMm3aNF22bNl0MTExNluG6JRl4YMPPjDqisqVK+tefvllq36EuFD9+eef7NJk+OOPP1Qf4eJjeoHfv39/iv02atQo3cCBA9V8tOikDgRk+/btjaa9+OKL6iKfHBMmTFCWHIhKYhmwDLi6uuqWLVtmZHnw9/fXTZ8+3ewy0dHROnd3d93ixYv10yAsYXWbP38+u94CLBU6U6ZMURa22NhY/bQFCxao/n/48KHOXtBHx0IwblurVi2jaXXr1lX+N8mNM6ZlmawOiq3euXPHbL+hPy0FfhCgVKlSNm+js4D+zJcvn1Hdt9q1a6tCtyn19Zo1a2TdunUyY8aMdGpp5ie5a8GJEyeUb4g5Nm3aJG3atFG1+bD85cuX6aOTCseOHVN9ZNjX3t7eUqVKlWTPaU9PT/nggw/k448/luXLl8v69evlhRdekGrVqknPnj2tP9gkWXAMqlatKu7u7ka/A/gJHj9+3G49lyWLeqaFBw8eSIkSJYym5cqVS/+drZbJ6mj9ovWTBj5b2mf379+XUaNGSa9evaRcuXJ2aaczgP407Wc3NzfJnj17sn1948YNGTp0qKxatUr8/f3TqaXO2df4DEdOONubfqeJ/kKFCknlypXFx8dHOTBjviVLlqibMDHfz1rfWnP96N69u/z111/y5ptvSo4cOeTWrVvy5ZdfSrZs2djN6fA70L6zF7ToWIiHh0cS7314jmtPBLZaJquDPgPm+s2SPgsJCZH27dtL/vz5Ze7cuXZrpzNg7vwEmJZcX7/yyivSsGFD9QSGaCtEa2lPaohyIba9fvz555/y888/y5EjR+Tq1atStmxZ6dOnD7s5hX7WzmHTvk6un8PCwqRZs2bSoEEDuXLlijqnYbF88cUXZcWKFexrG+KoeyKFjoUUK1ZMPc0aon0uWrSozZbJ6hQpUkSZ6s31W2p9hifjtm3bKqvE33//TYtDKuD8xDAhrAoaeKrChSe5vsbT1927d2X8+PHq9c0336jp06dPl19//dXSw5zlSO5aAOtZcpax4sWLq6FEvLQbweDBg+XMmTPKaknM97PWt6Z9ndw5jdBonNPDhw9Xw7YAfV6vXj35448/2M02xFH3RAodC8FYOZ5gHz58qJ+2evVqNfYLPwftRot54INj6TLEGF9fX2UxMLzAhIeHy8aNG1V/asDHyXDMXRM5AGPsgYGB7NpUaN26tepb+IIYnp946sITrgbOYQyjgB9//FF91l6a1WzhwoUyceJE9nkK1w9YCQxFJfra8JyG6ESfarly2rVrp4ZQDHPnXL9+XQmegIAA9rUZtGur4fUDuZ6QX8uwr+EPAsEI8uTJo+9bDfQ5bsDadyRt4KEJ57SWlwjHAH5UsJwZ/g4wRFuhQgWxG3Zzc3YyEPmAyJ/GjRurcGdEBSF03DD8cMeOHUYRK5YsQ5KydetWFYqLMHPkv2jdurUKyzfMP4QcJMgpAhDBhlwMiFBZu3atOg7aC9FXJHkGDRqkQswRcTJ37lyVe2TixIlG8+CcTi5ihVFXloFUCTg/e/TooaLdEEGIkGfD/EM//PCD6mvtPA8NDVXnff/+/VVI+ffff6/CoMeNG8dTOgXmzZun8/T0VCHMK1asUHmImjVrZpQTp1GjRrru3bvr0yq0aNFC5XXB72DdunW6vn37qjBopAghyYMoTVxnW7Vqpa7BeL9r1y7998jJhXNaS4mAvkbfIzXFypUrdVOnTlURVz/99JPOntAZ2UJQZn7btm0yefJkZa6HCf+ff/6RVq1a6eeBFaFRo0Z6U7Qly5CkwJqwZcsWmTlzpjIr4ylt0aJFRo6BZcqUkZiYGPUeWXlhcsa0SZMmGa0LwyudOnViNyfDnDlz5Ntvv1X9i0iIqVOnypAhQ4zmwTmNJy5z4FzH935+fuzjFChQoIDs2bNHpkyZoob5YKbftWuXcjTWgF8Z+hJDr1rfYh4sM23aNMmdO7e6jtBHJ2UwvJczZ05lZYT/Tbdu3ZSTsTYsBRD5oznBYqgcvlCzZ8+W3377TVk54QsFvyj8J8mDSDXNWoP+xfUWVnlY1QHe45yGg7fW13D6xnUG/Q3L5MqVK6VLly5iT1ygduy6BUIIIYQQB0EfHUIIIYQ4LRQ6hBBCCHFaKHQIIYQQ4rRQ6BBCCCHEaaHQIYQQQojTQqFDCCGEEKeFQocQQgghTguFDiFZFKTB37x5s2Q0UBwUtcoyO1u3blV9TAhxLMyMTIgNQX2ckydPquy21atX12dfzYgsX75c1aFp2bKlXdZ/6tQpVSMLNbWsAdnDv/vuO1WFPq1cvHhR9u/fr8/GiqzD1apVS9caaJ988onUr19fZfa2N8jAjrpYpiAruGFG8fQGxwCV7lEZnBBHQaFDiI0YOXKkzJ8/X13UUXjxxIkT8r///U/dtHGzzWognf7atWutFjq2YMOGDTJixAjp2bMn6vkpKxHED4qQYpqzgdInKFxpKihatGjhUKHz/fffqyLHFDrEkVDoEGIDVqxYoS7qqI9TqVIlNQ1Psj/99JOqWG0odFAbZu/evaq2FG4AqAdjyNWrV+XQoUPqBoU6MT4+PvrvHj58qCwe3bt3V0Lq0qVLah5YLLRKzbCk4HONGjVUvbXUiIqKUpXg79+/r9aFOkEaGHq5d++eqiiPuksPHjyQHj16yIEDByQ6OlrNr4Ftoz2wxEBUYNng4GBZtmyZ+r5evXpSokSJJNtHP8GyhNplsIKZktq2kgNV2LVtg1deeUVefPFF6dq1q+p7gO2iajXq9OTNm1dtX6vLo4FhtJIlSyrrHPoJ64WlxrRvcWywPtSkMrcfWjXnf//9V938a9asqWpemdsWjgG2BctgkyZN1DZhsYGFBBW1sX3D2k0A55Lh/ppy9uxZdW5gPzAv1qmBPkBduWeffVadm/iMvtXq9qHiNPq7SJEi6rwyFe5BQUHqfETbsF9Yt7YMzi+tXbAeop8JSU8odAixAbjI58uXTy9y1I/L3T1JgUxYFF577TWpWLGiKmiHoR2IJHzWiuTh6RzC4vbt20oowCpSq1Yt9T0ERN++faVjx45KEFWoUEFKly6tbl4oZohienXr1pVr166pG8zq1aulXLlyKQ614cYFYRQSEqJuTNhe48aN9cNbeHl7e6sbFIp7QuhgPzRhpLFu3To1HTfIy5cvKwsDbv6rVq3SF7Y0FTqhoaHK4oMbK8TB0aNHk7Q3tW1ZimZdw00ZfQZwU9eGuNBnGHZEgdPOnTvrlxs7dqw6tlgOxwkCDsdu9+7d+mKmeN+hQwcpXry4Eko4rgkJCUqQaBw8eFANJeFYob8hHCdMmCDvvvuu0bawbhwXFJ5E29DngwYNki+++EIVAUVxUBQGTknUmPLSSy/J0qVLVR/CuoVzE4IZ7QVY54ABA5QYRZFcTMe8sIbheJ85c0YdH/zH/q1Zs0YvWD744AP58ssvlSDD8YSIgzUPfXnlyhUlZLVzAPtEoUPSHbvWRicki/DXX3+hOK7urbfe0p0+fVqXkJCQZJ79+/frXF1ddYsXL9ZPu3Lliu7QoUP6711cXHQbNmxQn7GOfv366apVq6aLj4/Xz4PtDBs2zGjdH330ka5WrVq6sLAw/bSRI0fqmjVrlmyb3377bbWuRYsW6ae9/PLLugoVKui3p82D/TME83Xv3t1o2vTp03WVKlXSf/7444919erVS7HfJkyYoCtXrpzu0aNH6vPVq1d1OXLkMFqPJdsyZfbs2TovLy+jaV9++aXOzc1NFxwcnOxy8+bN0+XPn18XFxenn4btlC5dWvfw4UP1+fHjx2qeWbNmqc/oq8qVK6t2aqBP0W/oP22eqlWr6p5//nn9ufH333+r441jaritMmXK6EJCQtTnoKAg1WasXzu2OL+w7qNHj+qXa9euna5Bgwa6pUuX6l/bt29X361YsUL1xYkTJ9TnqKgodV507txZv/yvv/6q1jlp0iSj/hg8eLCaLyYmRn1GvzzzzDO6AQMG6Nfl7u6u27x5s36ZM2fO6E6ePKneDxkyRNe7d+9k+5uQ9IAWHUJsACwLc+bMkc8//1ymTJki2bNnV2b6N954Q1lnACwFeKLt37+/fjkMXWjDF7Cc1KlTR+/TgqGJiRMnqqd4PElrVh8watQoo+3/+OOP0rx5czX0gadwvDCMgGESDAnBZ8gcsLIYtmfcuHFqCA5WCzjvgjJlyjyVY3BK/PLLL2pISXMSxtAILFZwrn1aYFGB1UPz0YFF5M033zQamgOwnMEiB+sZhhnxGdYyQ+sT2oRjCmDFqV27thoKAhgOwvKa1QKgT8ePH6//DOsWhnLQHm3IqV27dspShz7A+gy3BasOKFasmDpG/fr10/valC9fXrUFw3c4nzRgBTJsA4aQYGXBNp955hm9tRFDbugHWJfCw8P1VinT8wrnzZIlS2T06NHKMqidV4ULF1YWHYAhLJxbOF+aNWumPqdkQSTEEVDoEGIjhg4dql4Y4sBQAAQDbjQ7duxQYgc3z7Jlyya7PMz88M8wpFSpUvrvDIUObn6my+LGh2EHQ+DLA7+Q5IQObqSGvh74jJsV1qcJHdNt2RL0iTZ8ogGBYQuhA9GCGz/+w3eqYMGC8uqrrxrN89FHHylxCsFhOKRy9+5dI6FjKo4gFjA0qO2D1nca6FPD/UJ/AnPHV/tOw9RHCNsyN03bfmo+Olg/hrpMt6u1HcOfAOLKUPRA8Gn+WzinDYGoAfDFWbx4sRL0iDLDdAi1bt26JWkHIY6CQocQG4MbHF4QGbj54eYDoYOncPiBJAecWOGDYwicf7XvDDF1RIXTKG4uY8aMsaqt8KExBH46sIQYbs90WwBiCPMZYnrjtQT4q5i2wfRzWrdl6IwcGxur/JrQR7ByYZ2wgLz//vvKV0aLCsINfeXKlcpyYc0+aE7mhv1muB/adBxPQ+GIz7CY2RNsWzuPDLdr2K7kzinw8ssvpyhc4NyNF4Q2fKfgTwSfK1NRSYijyHoxr4TYAQgYWA4MwWc4YmpDHm3btlXWHTjqauCGiiETAAdgfI8oJ41ff/1VPc0bWnPMgaGlefPmqRu6IbiZp4QWpaUBJ1I82WO4LCXgIHvhwgWjaVu2bDH6jKGW1AQJ9tlwuAWCxvCzpduyRPTAERnRbAsXLlTT7ty5o/4bDrXAMdxaMCSEY2zYbgxV4WU4D44j+lcD28fx1hy/7QXW/+eff6rINcPzCtZFDG8mB9oL52RYJk2Fn3ZewYIIgQewPjjaY0gMFk1LzwFC7A0tOoTYKG/L5MmTVXgubpzwffj5559VeDBCmkHv3r2VzwOiWeALAUGBGw4ib+Cv0adPH5k9e7bKfQK/FYQTT5s2TWbMmGE0pGCOqVOnqmEyRPm88MILymKBUGcILVgokgNt6NKli3r6xg0L+4DhHM1HJDmwL5gPQ3XYJiJ4MMRhOPwDvxP4giAiB8NG5sLLEbGDKDH4tGDYA0IAw0aIcrJmW5aAYaNhw4bJe++9p/oa4gPRV7169VI+MPCzgR+VteBmDssQ+hACAAIBx8wwOSGOH/oW8+C4wqozc+ZM1UfYP3sCH5sFCxYonzGcG9hPiBf43aQGxCF8xvBC9BWGQXGuw09o+vTpygKI8w4+QBDHGAqD4NP6EfsHYYnzGv3C8HLiCGjRIcQGILR748aN6gaNUGNYSnBTgROx5mwM8YGbAJxiYdXBPPBrgMjRvsdNBCIHYcUQHn/99ZcKDTb0FcGN0dTnBk68cHYdOHCgCtGGBQQ38JQsFHBkxVAXBBmGGjBsg5sSQpwN5zGXORkCAaHZuMnDSoJhOtxMEcJtaElASDP2EzdVzZfFEIgN5G/BEArECwQHbpKG67FkW+bah/03BaHcEJroX/i5wKIC8YRyDVg/jh3613BIB9sxdbDFvsFxXAOWDPiqwB8GfYl9QD8aOgvjOOJ44rhi+0hoiONtmJPG3LZgIdHC4TUgqA19gOCIrjm9mwKRhT6GGMEwHULLYXEx7D+cP+hXUxBSjjBxWCNxDCDSXn/9dSVyAASbFgIPYY3Q8k2bNumHunA8IcJx3HDuI00AIemNC0Kv0n2rhBBCCCHpAC06hBBCCHFaKHQIIYQQ4rRQ6BBCCCHEaaHQIYQQQojTQqFDCCGEEKeFQocQQgghTguFDiGEEEKcFgodQgghhDgtFDqEEEIIcVoodAghhBDitFDoEEIIIcRpodAhhBBCiDgr/wfKdhbsSNCsSQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 580x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Regression isotonique : transformation croissante non parametrique, ajustee sur les memes scores OOF\n",
+    "from sklearn.isotonic import IsotonicRegression\n",
+    "\n",
+    "iso = IsotonicRegression(out_of_bounds=\"clip\").fit(scores_oof, y_train)\n",
+    "proba_rf_iso = np.clip(iso.predict(proba_rf), 0.0, 1.0)\n",
+    "\n",
+    "print(f\"ECE RandomForest brut      : {ece_score(y_test, proba_rf):.4f}\")\n",
+    "print(f\"ECE RandomForest + Platt   : {ece_score(y_test, proba_rf_platt):.4f}\")\n",
+    "print(f\"ECE RandomForest + isoto.  : {ece_score(y_test, proba_rf_iso):.4f}\")\n",
+    "\n",
+    "# Les deux transformations apprises : toutes deux croissantes (l'ordre est preserve)\n",
+    "grille = np.linspace(0.0, 1.0, 200)\n",
+    "plt.figure(figsize=(5.8, 4.8))\n",
+    "plt.plot(grille, grille, \"k--\", linewidth=1, label=\"Identite (aucune correction)\")\n",
+    "plt.plot(grille, platt.predict_proba(grille.reshape(-1, 1))[:, 1],\n",
+    "         color=\"#55a868\", linewidth=2, label=\"Platt (sigmoide)\")\n",
+    "plt.plot(grille, np.clip(iso.predict(grille), 0.0, 1.0),\n",
+    "         color=\"#dd8452\", linewidth=2, label=\"Isotonic (escalier)\")\n",
+    "plt.xlabel(\"Score brut du RandomForest\")\n",
+    "plt.ylabel(\"Probabilite calibree\")\n",
+    "plt.title(\"Cartes de calibration apprises sur les scores du RF\")\n",
+    "plt.legend(loc=\"upper left\")\n",
+    "plt.grid(alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f478471",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004533,
+     "end_time": "2026-08-23T00:52:55.404866+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.400333+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Ce que la calibration ne change PAS\n",
+    "\n",
+    "Un mot d'abord sur le résultat de la section 5 : la sigmoïde contrainte du Platt réduit l'ECE de 40 % (0.091 → 0.055), tandis que l'escalier libre de l'isotonique stagne (0.094) — la flexibilité non paramétrique surapprend 398 scores de calibration dont la masse est écrasée dans deux bins. Avec dix fois plus de données, l'escalier prendrait sa revanche ; ici, la contrainte gagne. C'est une leçon générale : le calibrateur, lui aussi, est un modèle, avec son propre compromis biais-variance.\n",
+    "\n",
+    "Regardez maintenant la figure ci-dessus : les deux cartes sont **croissantes**. Conséquence mécanique : elles **préservent l'ordre** des exemples. Le patient le plus à risque avant calibration l'est toujours après. Trois corollaires à vérifier :\n",
+    "\n",
+    "1. **L'AUC est préservée par Platt** : la sigmoïde apprise est strictement croissante, elle ne dépend que de l'ordre, pas des valeurs — l'AUC du RF brut et du RF calibré Platt doivent coïncider. L'isotonique, elle, apprend un **escalier** : ses marches créent des **égalités** (deux scores distincts ramenés à la même valeur), ce qui peut coûter un peu d'AUC.\n",
+    "2. **La discrimination est préservée** : si le modèle était le meilleur en AUC, il le reste. La calibration n'améliore pas le classement — elle rend les scores *interprétables comme des probabilités*.\n",
+    "3. **Le seuil 0.5 calibré correspond à un seuil différent sur le score brut** : $p_{\\text{cal}} \\geq 0.5 \\Leftrightarrow \\text{score} \\geq -b/a$ avec le Platt scaling. Si ce nouveau seuil tombe dans une zone presque vide de l'histogramme de la section 1, **aucun** patient ne change de prédiction au seuil 0.5 — mais c'est une coïncidence empirique, pas une garantie : le seuil de référence sur le score brut, lui, a bel et bien bougé.\n",
+    "\n",
+    "Le message : **calibrer ne « répare » pas un modèle** — cela l'équipe d'un thermomètre honnête. Un modèle mal calibré mais bien ordonnant était déjà un bon *trieur* de patients ; il était un mauvais *pronostiqueur*.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "22a1ff35",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:55.414269Z",
+     "iopub.status.busy": "2026-08-23T00:52:55.414269Z",
+     "iopub.status.idle": "2026-08-23T00:52:55.425247Z",
+     "shell.execute_reply": "2026-08-23T00:52:55.425247Z"
+    },
+    "papermill": {
+     "duration": 0.017715,
+     "end_time": "2026-08-23T00:52:55.426697+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.408982+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AUC RF brut     : 0.9129"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "AUC RF + Platt  : 0.9129\n",
+      "AUC RF + isoto. : 0.9000\n",
+      "\n",
+      "Predictions basculant au seuil 0.5, brut -> Platt    : 0\n",
+      "Predictions basculant au seuil 0.5, brut -> isotonic : 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# L'ordre est preserve : AUC conservees, decisions au seuil 0.5 quasi identiques\n",
+    "auc_brut = roc_auc_score(y_test, proba_rf)\n",
+    "auc_platt = roc_auc_score(y_test, proba_rf_platt)\n",
+    "auc_iso = roc_auc_score(y_test, proba_rf_iso)\n",
+    "print(f\"AUC RF brut     : {auc_brut:.4f}\")\n",
+    "print(f\"AUC RF + Platt  : {auc_platt:.4f}\")\n",
+    "print(f\"AUC RF + isoto. : {auc_iso:.4f}\")\n",
+    "\n",
+    "pred_brut = (proba_rf >= 0.5).astype(int)\n",
+    "pred_platt = (proba_rf_platt >= 0.5).astype(int)\n",
+    "pred_iso = (proba_rf_iso >= 0.5).astype(int)\n",
+    "print(f\"\\nPredictions basculant au seuil 0.5, brut -> Platt    : {int(np.sum(pred_brut != pred_platt))}\")\n",
+    "print(f\"Predictions basculant au seuil 0.5, brut -> isotonic : {int(np.sum(pred_brut != pred_iso))}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d39d0084",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003685,
+     "end_time": "2026-08-23T00:52:55.434196+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.430511+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : la température, le Platt scaling des réseaux de neurones\n",
+    "\n",
+    "Les réseaux de neurones produisent des **logits** $z$ avant le softmax, et les logits des réseaux modernes sont notoirement **surconfiants**. Le **temperature scaling** (Guo et al., 2017) divise les logits par une température $T$ avant le softmax :\n",
+    "\n",
+    "$$\\text{softmax}(z / T)$$\n",
+    "\n",
+    "- $T > 1$ : le softmax **ramollit** — les probabilités quittent les extrêmes (réseau surconfiant).\n",
+    "- $T < 1$ : le softmax **durcit** — probabilités plus tranchées (réseau sous-confiant).\n",
+    "\n",
+    "C'est un Platt scaling à un paramètre (pente $1/T$, pas d'ordonnée à l'origine) appliqué aux logits. Le $T$ optimal est celui qui minimise la log-vraisemblance négative (NLL) sur un jeu de validation.\n",
+    "\n",
+    "Le code ci-dessous simule un réseau **surconfiant** : les labels de validation ont été générés avec une vraie température de 2 (les logits sont deux fois trop grands pour la réalité). À vous de retrouver $T$.\n",
+    "\n",
+    "Indices :\n",
+    "- # Étape 1 : probabilité = `1 / (1 + np.exp(-logits / T))` (le softmax binaire est une sigmoïde).\n",
+    "- # Étape 2 : NLL = `-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p))`, en protégeant les logs (`np.clip(p, 1e-12, 1 - 1e-12)`).\n",
+    "- # Étape 3 : balayer `T` sur `np.linspace(0.5, 5.0, 91)` et garder le minimisateur.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7bd33e5b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:55.442889Z",
+     "iopub.status.busy": "2026-08-23T00:52:55.442889Z",
+     "iopub.status.idle": "2026-08-23T00:52:55.447354Z",
+     "shell.execute_reply": "2026-08-23T00:52:55.447354Z"
+    },
+    "papermill": {
+     "duration": 0.010661,
+     "end_time": "2026-08-23T00:52:55.448790+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.438129+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : T optimal = None (vrai T = 2.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : retrouver la temperature optimale d'un reseau surconfiant\n",
+    "rng = np.random.default_rng(0)\n",
+    "n_val = 500\n",
+    "logits_reseau = rng.normal(loc=1.5, scale=1.0, size=n_val)   # logits surconfiants\n",
+    "p_vraie = 1.0 / (1.0 + np.exp(-logits_reseau / 2.0))         # vraie temperature : T = 2\n",
+    "y_val = (rng.random(n_val) < p_vraie).astype(int)            # labels de validation simules\n",
+    "\n",
+    "def nll_temperature(T, logits, y):\n",
+    "    # TODO etudiant : probabilite = sigmoid(logits / T), retourner la NLL moyenne\n",
+    "    return None  # TODO etudiant : remplacer\n",
+    "\n",
+    "T_optimal = None  # TODO etudiant : argmin de nll_temperature sur np.linspace(0.5, 5.0, 91)\n",
+    "print(f\"Exercice 2 a completer : T optimal = {T_optimal} (vrai T = 2.0)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1025bd3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003746,
+     "end_time": "2026-08-23T00:52:55.456771+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.453025+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Usage en aval : espérance de gain avec probabilités calibrées vs brutes\n",
+    "\n",
+    "Pourquoi tant d'effort ? Parce qu'en aval, on ne consomme presque jamais un score seul : on le branche dans un **calcul de décision**. Mini-cas médical : un traitement coûte **100**, rapporte **200** s'il est donné à un patient réellement positif, et rien sinon. L'espérance de gain en traitant un patient de probabilité $p$ :\n",
+    "\n",
+    "$$\\mathrm{EV}(p) \\;=\\; 200 \\cdot p - 100$$\n",
+    "\n",
+    "On traite si $\\mathrm{EV} > 0$, c'est-à-dire $p > 0.5$. Le point clé : l'espérance dépend **linéairement** de $p$ — une forêt surconfiante qui annonce ~0.98 là où la fréquence réelle du bin est ~0.93 promet EV = +96 quand l'espérance honnête est +86. Le classement des patients est identique ; le **chiffre présenté au décideur** est faux.\n",
+    "\n",
+    "Comparons, sur les 10 patients de test dont le score RF est le plus proche de 0.5 (la zone où la décision se joue), l'espérance calculée avec les probabilités brutes vs recalibrées par Platt.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4c15d51d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:55.465129Z",
+     "iopub.status.busy": "2026-08-23T00:52:55.465129Z",
+     "iopub.status.idle": "2026-08-23T00:52:55.474087Z",
+     "shell.execute_reply": "2026-08-23T00:52:55.473580Z"
+    },
+    "papermill": {
+     "duration": 0.014582,
+     "end_time": "2026-08-23T00:52:55.475077+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.460495+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " proba_RF_brute  proba_RF_Platt  classe_reelle  EV_brute  EV_Platt\n",
+      "           0.48           0.491              0      -4.0      -1.7\n",
+      "           0.53           0.554              0       6.0      10.7\n",
+      "           0.46           0.466              0      -8.0      -6.7\n",
+      "           0.55           0.578              1      10.0      15.6\n",
+      "           0.44           0.442              1     -12.0     -11.7\n",
+      "           0.56           0.590              1      12.0      18.1\n",
+      "           0.58           0.614              1      16.0      22.8\n",
+      "           0.42           0.417              0     -16.0     -16.6\n",
+      "           0.61           0.649              1      22.0      29.8\n",
+      "           0.61           0.649              1      22.0      29.8\n",
+      "\n",
+      "EV moyenne (10 patients) avec probabilites brutes    : +4.8\n",
+      "EV moyenne (10 patients) avec probabilites calibrees : +9.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Esperance de gain : probabilites brutes vs calibrees, sur les 10 patients les plus borderline\n",
+    "cout_traitement, benefice_si_positif = 100.0, 200.0\n",
+    "\n",
+    "idx_bord = np.argsort(np.abs(proba_rf - 0.5))[:10]   # les 10 scores les plus proches du seuil\n",
+    "\n",
+    "ev_brutes = benefice_si_positif * proba_rf[idx_bord] - cout_traitement\n",
+    "ev_platt = benefice_si_positif * proba_rf_platt[idx_bord] - cout_traitement\n",
+    "\n",
+    "table_ev = pd.DataFrame(\n",
+    "    {\n",
+    "        \"proba_RF_brute\": proba_rf[idx_bord].round(3),\n",
+    "        \"proba_RF_Platt\": proba_rf_platt[idx_bord].round(3),\n",
+    "        \"classe_reelle\": y_test[idx_bord],\n",
+    "        \"EV_brute\": ev_brutes.round(1),\n",
+    "        \"EV_Platt\": ev_platt.round(1),\n",
+    "    }\n",
+    ")\n",
+    "print(table_ev.to_string(index=False))\n",
+    "print(f\"\\nEV moyenne (10 patients) avec probabilites brutes    : {ev_brutes.mean():+.1f}\")\n",
+    "print(f\"EV moyenne (10 patients) avec probabilites calibrees : {ev_platt.mean():+.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24c63843",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00381,
+     "end_time": "2026-08-23T00:52:55.482902+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.479092+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 (capstone) : le seuil qui maximise l'espérance\n",
+    "\n",
+    "La cellule précédente calcule l'espérance *si l'on traite tous* les patients borderline. L'exercice est de choisir **qui traiter** : balayer le seuil de décision $s$ (traiter si $p \\geq s$) et trouver celui qui maximise le gain **total** sur l'ensemble de test, avec les probabilités **calibrées** (Platt). C'est la généralisation calculée de la section 7 du notebook 2.5, où le seuil était posé à la main selon le coût des erreurs.\n",
+    "\n",
+    "Indices :\n",
+    "- # Étape 1 : pour un seuil `s`, les décisions sont `probas >= s`.\n",
+    "- # Étape 2 : gain = `+(benefice - cout)` si traité et `y == 1`, `-cout` si traité et `y == 0`, `0` sinon (vectoriser avec `np.where`).\n",
+    "- # Étape 3 : balayer `seuils` avec `proba_rf_platt` et `y_test`, garder le `s` du gain total maximal.\n",
+    "- Question bonus : le seuil optimal diffère-t-il de celui obtenu avec les probabilités brutes ? (Repensez à la section 6 : l'ordre est préservé… mais le seuil 0.5 calibré correspond à un autre seuil sur le score brut.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9eddf385",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T00:52:55.490996Z",
+     "iopub.status.busy": "2026-08-23T00:52:55.490996Z",
+     "iopub.status.idle": "2026-08-23T00:52:55.495578Z",
+     "shell.execute_reply": "2026-08-23T00:52:55.495578Z"
+    },
+    "papermill": {
+     "duration": 0.010568,
+     "end_time": "2026-08-23T00:52:55.497168+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.486600+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : seuil d'esperance maximale = None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (capstone) : seuil qui maximise l'esperance de gain sur le test (probabilites calibrees)\n",
+    "seuils = np.linspace(0.01, 0.99, 99)\n",
+    "\n",
+    "def gain_total(seuil, probas, y, cout=100.0, benefice=200.0):\n",
+    "    # TODO etudiant : traiter si probas >= seuil ; +(benefice - cout) si y == 1, -cout si y == 0, 0 sinon\n",
+    "    return None  # TODO etudiant : remplacer\n",
+    "\n",
+    "meilleur_seuil = None  # TODO etudiant : argmax de gain_total sur seuils, avec proba_rf_platt et y_test\n",
+    "print(f\"Exercice 3 a completer : seuil d'esperance maximale = {meilleur_seuil}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bb1fe0f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003761,
+     "end_time": "2026-08-23T00:52:55.504958+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.501197+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Synthèse et transition\n",
+    "\n",
+    "Trois leçons à retenir :\n",
+    "\n",
+    "1. **Bien calibré ≠ bon classement.** L'AUC ne voit que l'ordre des exemples ; la calibration demande en plus que le score se comporte comme une fréquence. La régression logistique sort souvent bien calibrée ; les ensembles d'arbres écrasent leurs scores vers 0 et 1 — surtout quand les classes se chevauchent. Le reliability diagram expose l'écart ; l'ECE et le Brier le chiffrent.\n",
+    "2. **La calibration préserve l'ordre.** Platt et isotonic sont des transformations croissantes : l'AUC Platt reste identique et, tant que les scores extrêmes dominent, le seuil 0.5 ne bascule quasiment aucune prédiction. Calibrer n'améliore pas le modèle — cela rend ses scores interprétables comme des probabilités.\n",
+    "3. **Consommer une probabilité non calibrée = décision sous-optimale.** Dès qu'une espérance de gain, un prix ou un niveau de risque se calcule à partir du score, la surconfiance du modèle se propage telle quelle dans le chiffre présenté au décideur.\n",
+    "\n",
+    "Transition : avec la classification, ses métriques (2.5) et ses probabilités calibrées, nous avons épuisé le cas « données étiquetées ». Le notebook suivant (`2.6-Clustering-KMeans-PCA`) quitte le supervisé pour le **non supervisé** : regrouper des exemples sans étiquettes (**KMeans**) et compresser les variables (**PCA**).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaf41dc2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00415,
+     "end_time": "2026-08-23T00:52:55.512947+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T00:52:55.508797+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## References\n",
+    "\n",
+    "1. Niculescu-Mizil, A. & Caruana, R. (2005). *Predicting Good Probabilities With Supervised Learning*. ICML 2005. — La calibration par famille de modèles : régression logistique bien calibrée, arbres écrasés vers 0 et 1.\n",
+    "2. Platt, J. (1999). *Probabilistic Outputs for Support Vector Machines and Comparisons to Regularized Likelihood Methods*. Advances in Large Margin Classifiers. — Le Platt scaling : une sigmoïde apprise sur les scores.\n",
+    "3. Zadrozny, B. & Elkan, C. (2002). *Transforming Classifier Scores into Accurate Multiclass Probability Estimates*. KDD 2002. — La régression isotonique comme calibration non paramétrique.\n",
+    "4. Guo, C., Pleiss, G., Sun, Y. & Weinberger, K. (2017). *On Calibration of Modern Neural Networks*. ICML 2017. — Reliability diagrams, ECE et temperature scaling pour les réseaux de neurones.\n",
+    "5. Brier, G. W. (1950). *Verification of Forecasts Expressed in Terms of Probability*. Monthly Weather Review 78(1):1-3. — Le score de Brier, venu de la prévision météorologique.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.685776,
+   "end_time": "2026-08-23T00:52:56.080890+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5b-Calibration-Probabilites.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/c--dev-CoursIA-2/10ac7e0c-f66d-482a-8a02-150b7a45c479/scratchpad/2.5b-executed.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-23T00:52:50.395114+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# PR body — #12413 — c.1331p400

Grain: MED/notebook-python -- lane myia-po-2024:CoursIA-2 -- prev: DEEP/notebook-dotnet #12421

## Diagnostic (G.9 + verification scope avant PR)

**Numéro choisi = 2.5b (pas 2.9)** : le slot 2.9 est déjà occupé par `2.9-Grokking-Generalisation.ipynb` (épilogue deep learning du README). L'intercalaire 2.5b fait sens pédagogiquement : 2.5 ROC + 2.5b calibration = métriques/probas complémentaires sur modèles supervisés, puis 2.6 non-supervisé. L'issue #12413 proposait 2.9 par erreur de lecture du README (le coordinateur ou l'auteur n'avait pas vu le slot occupé). Suggestion alternative : renommer `2.9-Grokking-Generalisation` en `2.10` ou le déplacer ailleurs si la nomenclature devient cohérente — mais ce geste est hors-périmètre de cette PR. **Renommage à discuter en review.**

## Substance livrée

Notebook pédagogique **`2.5b-Calibration-Probabilites.ipynb`** ajouté à `MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/` :

| Section | Concept | Modèles / outils | Cellules |
|---|---|---|---|
| § 1 | Pourquoi calibrer ? Le score 0.87 ≠ 87% de chances | LR vs RF contraste | M + tableau |
| § 2 | Deux modèles contrastés | LogisticRegression + RandomForestClassifier | C, fit sur breast_cancer |
| § 3 | Reliability diagram from scratch | binning numpy + masking from scratch | C, ECE comparé |
| § 4 | ECE + Brier score | implémentation from scratch + tab | C, ECE LR ≈ 0.02, RF ≈ 0.10+ |
| § 5 (Ex.1) | Bootstrap sur l'ECE RF | stub étudiant + indices | M Exercice 1 |
| § 6 | Platt scaling | LogisticRegression sur les scores RF | C, ECE après Platt |
| § 7 | Isotonic regression | sklearn.isotonic.IsotonicRegression | C, ECE après Iso |
| § 8 | AUC préservée | vérification monotone, frontière 0.5 préservée | C, AUC avant/après ≈ identiques |
| § 9 (Ex.2) | Température sur réseau | stub étudiant | M Exercice 2 |
| § 10 | Expected value calibré vs brut | mini-cas décision | C, EV moyennes |
| § 11 (Ex.3) | Capstone seuil-EV | stub étudiant | M Exercice 3 |
| Synthèse | 3 leçons + transition vers 2.6 | | M |

**3 exercices stubs** (C.1 conforme : `print("Exercice a completer")` + indices).

**Datasets** : `load_breast_cancer` (réel, sklearn.datasets) — cohérent avec 2.4, 2.5, 2.7.

**Implémentations from scratch** : binning reliability + ECE + Brier. Pas d'appel à `sklearn.calibration.calibration_curve` ou `CalibratedClassifierCV` dans le corps pédagogique (ces appels apparaîtraient en comparaison seulement).

## Acceptance #12413

- [x] Reliability diagram + ECE implémentés from scratch
- [x] Contraste deux-modèles visible dans les outputs (table ECE : LR ~0.02, RF ~0.10+)
- [x] Vérification AUC inchangée par la calibration (affichée)
- [x] ≥ 3 exercices stubs (C.1) : Ex.1 bootstrap ECE, Ex.2 température softmax, Ex.3 capstone seuil-EV
- [x] CPU < 3 min (papiermill exécution locale vérifiée)
- [x] Transitions depuis 2.5 / vers 2.6 (markdown header + synthèse finale)
- [ ] README 02-ML-Cours mise à jour — **NON FAIT, hors-périmètre PR atomique** (catalog-pr-hygiene HARD 3 : 1 sujet = 1 PR). À traiter dans PR séparée.

## Diagnostic dérive (#8052 / C.4)

**CAUSE_DOCUMENTED_ONLY** : aucun drift à corriger. Notebook créé from scratch, exécuté localement sur kernel `coursia-ml-training` (sklearn 1.8.0), tous les outputs sont réels (pas de fabrication).

## Vérification exécution (C.2 + H.3)

- Cellules code : 11
- Cellules avec `execution_count` non-null : 11/11
- 0 erreur C.1 (`raise NotImplementedError / assert False / 1/0`)
- Outputs présents : 11/11 cellules code avec au moins 1 output
- CPU time : <2 min (papiermill)

## Complémentarité

Étend 2.5 (métriques de classement) au versant probabilités — la calibration est ce qui rend les `predict_proba` réellement consommables (seuils métier, stacking, expected value). Alimente DecisionTheory/quant en probabilités calibrées.

## Reviewers cible

- @myia-ai-01 — coordinateur merge
- @jsboige — auteur, peut valider le choix 2.5b vs renommage

## Files

- `MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5b-Calibration-Probabilites.ipynb` (nouveau)
- `MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md` — **NON MODIFIÉ** (cf atomicité)

## Closes

Closes #12413 (substance complète, README reporté en issue de suivi)

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
