### PR TITLE
fix(qcpy23,#12430): reparer l'entrainement mort - NaN de feature empoisonnait toutes les metriques

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
@@ -5,10 +5,10 @@
    "id": "d093891b",
    "metadata": {
     "papermill": {
-     "duration": 0.004867,
-     "end_time": "2026-05-04T23:45:15.584056",
+     "duration": 0.006605,
+     "end_time": "2026-08-23T01:41:03.056404",
      "exception": false,
-     "start_time": "2026-05-04T23:45:15.579189",
+     "start_time": "2026-08-23T01:41:03.049799",
      "status": "completed"
     },
     "tags": []
@@ -61,10 +61,10 @@
    "id": "f414a472",
    "metadata": {
     "papermill": {
-     "duration": 0.004162,
-     "end_time": "2026-05-04T23:45:15.592575",
+     "duration": 0.003277,
+     "end_time": "2026-08-23T01:41:03.065600",
      "exception": false,
-     "start_time": "2026-05-04T23:45:15.588413",
+     "start_time": "2026-08-23T01:41:03.062323",
      "status": "completed"
     },
     "tags": []
@@ -81,10 +81,10 @@
    "id": "fb7f8792",
    "metadata": {
     "papermill": {
-     "duration": 0.004795,
-     "end_time": "2026-05-04T23:45:15.601740",
+     "duration": 0.005015,
+     "end_time": "2026-08-23T01:41:03.075430",
      "exception": false,
-     "start_time": "2026-05-04T23:45:15.596945",
+     "start_time": "2026-08-23T01:41:03.070415",
      "status": "completed"
     },
     "tags": []
@@ -106,10 +106,10 @@
    "id": "b317e87d",
    "metadata": {
     "papermill": {
-     "duration": 0.004303,
-     "end_time": "2026-05-04T23:45:15.610875",
+     "duration": 0.005,
+     "end_time": "2026-08-23T01:41:03.084432",
      "exception": false,
-     "start_time": "2026-05-04T23:45:15.606572",
+     "start_time": "2026-08-23T01:41:03.079432",
      "status": "completed"
     },
     "tags": []
@@ -158,16 +158,16 @@
    "id": "baa2eea3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:15.620696Z",
-     "iopub.status.busy": "2026-05-04T23:45:15.620305Z",
-     "iopub.status.idle": "2026-05-04T23:45:19.965552Z",
-     "shell.execute_reply": "2026-05-04T23:45:19.964702Z"
+     "iopub.execute_input": "2026-08-23T01:41:03.094118Z",
+     "iopub.status.busy": "2026-08-23T01:41:03.094118Z",
+     "iopub.status.idle": "2026-08-23T01:41:05.570247Z",
+     "shell.execute_reply": "2026-08-23T01:41:05.570247Z"
     },
     "papermill": {
-     "duration": 4.351432,
-     "end_time": "2026-05-04T23:45:19.966707",
+     "duration": 2.482933,
+     "end_time": "2026-08-23T01:41:05.571362",
      "exception": false,
-     "start_time": "2026-05-04T23:45:15.615275",
+     "start_time": "2026-08-23T01:41:03.088429",
      "status": "completed"
     },
     "tags": []
@@ -229,10 +229,10 @@
    "id": "83a8d765",
    "metadata": {
     "papermill": {
-     "duration": 0.006415,
-     "end_time": "2026-05-04T23:45:19.979538",
+     "duration": 0.004003,
+     "end_time": "2026-08-23T01:41:05.580354",
      "exception": false,
-     "start_time": "2026-05-04T23:45:19.973123",
+     "start_time": "2026-08-23T01:41:05.576351",
      "status": "completed"
     },
     "tags": []
@@ -257,16 +257,16 @@
    "id": "f810e13d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:19.992722Z",
-     "iopub.status.busy": "2026-05-04T23:45:19.992336Z",
-     "iopub.status.idle": "2026-05-04T23:45:20.504069Z",
-     "shell.execute_reply": "2026-05-04T23:45:20.502971Z"
+     "iopub.execute_input": "2026-08-23T01:41:05.590479Z",
+     "iopub.status.busy": "2026-08-23T01:41:05.589451Z",
+     "iopub.status.idle": "2026-08-23T01:41:05.983248Z",
+     "shell.execute_reply": "2026-08-23T01:41:05.982234Z"
     },
     "papermill": {
-     "duration": 0.518655,
-     "end_time": "2026-05-04T23:45:20.505015",
+     "duration": 0.39878,
+     "end_time": "2026-08-23T01:41:05.983248",
      "exception": false,
-     "start_time": "2026-05-04T23:45:19.986360",
+     "start_time": "2026-08-23T01:41:05.584468",
      "status": "completed"
     },
     "tags": []
@@ -371,10 +371,10 @@
    "id": "d4efc713",
    "metadata": {
     "papermill": {
-     "duration": 0.004604,
-     "end_time": "2026-05-04T23:45:20.516715",
+     "duration": 0.004999,
+     "end_time": "2026-08-23T01:41:05.994266",
      "exception": false,
-     "start_time": "2026-05-04T23:45:20.512111",
+     "start_time": "2026-08-23T01:41:05.989267",
      "status": "completed"
     },
     "tags": []
@@ -405,10 +405,10 @@
    "id": "475af7fe",
    "metadata": {
     "papermill": {
-     "duration": 0.006949,
-     "end_time": "2026-05-04T23:45:20.530896",
+     "duration": 0.004615,
+     "end_time": "2026-08-23T01:41:06.003389",
      "exception": false,
-     "start_time": "2026-05-04T23:45:20.523947",
+     "start_time": "2026-08-23T01:41:05.998774",
      "status": "completed"
     },
     "tags": []
@@ -460,16 +460,16 @@
    "id": "ae7dcca0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:20.546237Z",
-     "iopub.status.busy": "2026-05-04T23:45:20.546028Z",
-     "iopub.status.idle": "2026-05-04T23:45:20.937432Z",
-     "shell.execute_reply": "2026-05-04T23:45:20.936764Z"
+     "iopub.execute_input": "2026-08-23T01:41:06.013491Z",
+     "iopub.status.busy": "2026-08-23T01:41:06.013491Z",
+     "iopub.status.idle": "2026-08-23T01:41:06.266371Z",
+     "shell.execute_reply": "2026-08-23T01:41:06.266371Z"
     },
     "papermill": {
-     "duration": 0.399323,
-     "end_time": "2026-05-04T23:45:20.938516",
+     "duration": 0.259198,
+     "end_time": "2026-08-23T01:41:06.267668",
      "exception": false,
-     "start_time": "2026-05-04T23:45:20.539193",
+     "start_time": "2026-08-23T01:41:06.008470",
      "status": "completed"
     },
     "tags": []
@@ -583,10 +583,10 @@
    "id": "4233c830",
    "metadata": {
     "papermill": {
-     "duration": 0.007142,
-     "end_time": "2026-05-04T23:45:20.952921",
+     "duration": 0.005909,
+     "end_time": "2026-08-23T01:41:06.279015",
      "exception": false,
-     "start_time": "2026-05-04T23:45:20.945779",
+     "start_time": "2026-08-23T01:41:06.273106",
      "status": "completed"
     },
     "tags": []
@@ -619,10 +619,10 @@
    "id": "ccea1b74",
    "metadata": {
     "papermill": {
-     "duration": 0.008187,
-     "end_time": "2026-05-04T23:45:20.968346",
+     "duration": 0.006111,
+     "end_time": "2026-08-23T01:41:06.291529",
      "exception": false,
-     "start_time": "2026-05-04T23:45:20.960159",
+     "start_time": "2026-08-23T01:41:06.285418",
      "status": "completed"
     },
     "tags": []
@@ -653,16 +653,16 @@
    "id": "f5c52384",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:20.984278Z",
-     "iopub.status.busy": "2026-05-04T23:45:20.983993Z",
-     "iopub.status.idle": "2026-05-04T23:45:21.000909Z",
-     "shell.execute_reply": "2026-05-04T23:45:21.000285Z"
+     "iopub.execute_input": "2026-08-23T01:41:06.304476Z",
+     "iopub.status.busy": "2026-08-23T01:41:06.304476Z",
+     "iopub.status.idle": "2026-08-23T01:41:06.317130Z",
+     "shell.execute_reply": "2026-08-23T01:41:06.317130Z"
     },
     "papermill": {
-     "duration": 0.026099,
-     "end_time": "2026-05-04T23:45:21.001801",
+     "duration": 0.021616,
+     "end_time": "2026-08-23T01:41:06.318149",
      "exception": false,
-     "start_time": "2026-05-04T23:45:20.975702",
+     "start_time": "2026-08-23T01:41:06.296533",
      "status": "completed"
     },
     "tags": []
@@ -805,7 +805,16 @@
   {
    "cell_type": "markdown",
    "id": "ecf30298",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005942,
+     "end_time": "2026-08-23T01:41:06.329624",
+     "exception": false,
+     "start_time": "2026-08-23T01:41:06.323682",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "### Exercice 1 : Mécanisme d'attention simplifie\n",
@@ -829,8 +838,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "8c2a199a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T01:41:06.343279Z",
+     "iopub.status.busy": "2026-08-23T01:41:06.341759Z",
+     "iopub.status.idle": "2026-08-23T01:41:06.345636Z",
+     "shell.execute_reply": "2026-08-23T01:41:06.345636Z"
+    },
+    "papermill": {
+     "duration": 0.011173,
+     "end_time": "2026-08-23T01:41:06.346641",
+     "exception": false,
+     "start_time": "2026-08-23T01:41:06.335468",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
    "source": [
     "# Exercice 1 : Attention a tete unique from scratch\n",
     "# TODO etudiant : Implementer QKV attention avec masque causal\n",
@@ -842,19 +876,17 @@
     "\n",
     "result = None  # TODO etudiant : remplacer par le mecanisme d'attention\n",
     "print(\"Exercice a completer\")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "3478a141",
    "metadata": {
     "papermill": {
-     "duration": 0.006884,
-     "end_time": "2026-05-04T23:45:21.016081",
+     "duration": 0.006105,
+     "end_time": "2026-08-23T01:41:06.357747",
      "exception": false,
-     "start_time": "2026-05-04T23:45:21.009197",
+     "start_time": "2026-08-23T01:41:06.351642",
      "status": "completed"
     },
     "tags": []
@@ -883,10 +915,10 @@
    "id": "dc423004",
    "metadata": {
     "papermill": {
-     "duration": 0.007058,
-     "end_time": "2026-05-04T23:45:21.029971",
+     "duration": 0.006098,
+     "end_time": "2026-08-23T01:41:06.368862",
      "exception": false,
-     "start_time": "2026-05-04T23:45:21.022913",
+     "start_time": "2026-08-23T01:41:06.362764",
      "status": "completed"
     },
     "tags": []
@@ -934,20 +966,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "21ac35a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:21.048274Z",
-     "iopub.status.busy": "2026-05-04T23:45:21.047997Z",
-     "iopub.status.idle": "2026-05-04T23:45:21.073076Z",
-     "shell.execute_reply": "2026-05-04T23:45:21.072334Z"
+     "iopub.execute_input": "2026-08-23T01:41:06.381150Z",
+     "iopub.status.busy": "2026-08-23T01:41:06.381150Z",
+     "iopub.status.idle": "2026-08-23T01:41:06.403677Z",
+     "shell.execute_reply": "2026-08-23T01:41:06.402675Z"
     },
     "papermill": {
-     "duration": 0.034262,
-     "end_time": "2026-05-04T23:45:21.073965",
+     "duration": 0.030908,
+     "end_time": "2026-08-23T01:41:06.404677",
      "exception": false,
-     "start_time": "2026-05-04T23:45:21.039703",
+     "start_time": "2026-08-23T01:41:06.373769",
      "status": "completed"
     },
     "tags": []
@@ -1149,10 +1181,10 @@
    "id": "67096d4c",
    "metadata": {
     "papermill": {
-     "duration": 0.00739,
-     "end_time": "2026-05-04T23:45:21.088931",
+     "duration": 0.006,
+     "end_time": "2026-08-23T01:41:06.417718",
      "exception": false,
-     "start_time": "2026-05-04T23:45:21.081541",
+     "start_time": "2026-08-23T01:41:06.411718",
      "status": "completed"
     },
     "tags": []
@@ -1187,10 +1219,10 @@
    "id": "829b9031",
    "metadata": {
     "papermill": {
-     "duration": 0.008511,
-     "end_time": "2026-05-04T23:45:21.104813",
+     "duration": 0.005036,
+     "end_time": "2026-08-23T01:41:06.429258",
      "exception": false,
-     "start_time": "2026-05-04T23:45:21.096302",
+     "start_time": "2026-08-23T01:41:06.424222",
      "status": "completed"
     },
     "tags": []
@@ -1221,20 +1253,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "93402b45",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:21.126018Z",
-     "iopub.status.busy": "2026-05-04T23:45:21.125562Z",
-     "iopub.status.idle": "2026-05-04T23:45:21.169583Z",
-     "shell.execute_reply": "2026-05-04T23:45:21.169029Z"
+     "iopub.execute_input": "2026-08-23T01:41:06.445837Z",
+     "iopub.status.busy": "2026-08-23T01:41:06.445837Z",
+     "iopub.status.idle": "2026-08-23T01:41:06.488662Z",
+     "shell.execute_reply": "2026-08-23T01:41:06.487659Z"
     },
     "papermill": {
-     "duration": 0.055888,
-     "end_time": "2026-05-04T23:45:21.170514",
+     "duration": 0.051825,
+     "end_time": "2026-08-23T01:41:06.488662",
      "exception": false,
-     "start_time": "2026-05-04T23:45:21.114626",
+     "start_time": "2026-08-23T01:41:06.436837",
      "status": "completed"
     },
     "tags": []
@@ -1244,13 +1276,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Test de MambaForTrading:\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Test de MambaForTrading:\n",
       "  Input shape: torch.Size([4, 60, 5])\n",
       "  Output shape: torch.Size([4, 1])\n",
       "  Total parameters: 20,449\n",
@@ -1366,7 +1392,16 @@
   {
    "cell_type": "markdown",
    "id": "9993e6a0",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008071,
+     "end_time": "2026-08-23T01:41:06.503742",
+     "exception": false,
+     "start_time": "2026-08-23T01:41:06.495671",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "### Exercice 2 : Simplified Mamba block\n",
@@ -1389,8 +1424,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "373e1bef",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T01:41:06.526827Z",
+     "iopub.status.busy": "2026-08-23T01:41:06.526827Z",
+     "iopub.status.idle": "2026-08-23T01:41:06.530350Z",
+     "shell.execute_reply": "2026-08-23T01:41:06.530350Z"
+    },
+    "papermill": {
+     "duration": 0.016101,
+     "end_time": "2026-08-23T01:41:06.531354",
+     "exception": false,
+     "start_time": "2026-08-23T01:41:06.515253",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
    "source": [
     "# Exercice 2 : Simplified Mamba block\n",
     "# TODO etudiant : Implementer un mini bloc Mamba en PyTorch\n",
@@ -1402,19 +1462,17 @@
     "\n",
     "result = None  # TODO etudiant : remplacer par le bloc Mamba simplifie\n",
     "print(\"Exercice a completer\")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "7e2f6f9c",
    "metadata": {
     "papermill": {
-     "duration": 0.008291,
-     "end_time": "2026-05-04T23:45:21.188537",
+     "duration": 0.011047,
+     "end_time": "2026-08-23T01:41:06.551975",
      "exception": false,
-     "start_time": "2026-05-04T23:45:21.180246",
+     "start_time": "2026-08-23T01:41:06.540928",
      "status": "completed"
     },
     "tags": []
@@ -1446,20 +1504,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "151c464e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:21.208329Z",
-     "iopub.status.busy": "2026-05-04T23:45:21.207879Z",
-     "iopub.status.idle": "2026-05-04T23:45:22.499428Z",
-     "shell.execute_reply": "2026-05-04T23:45:22.498372Z"
+     "iopub.execute_input": "2026-08-23T01:41:06.574482Z",
+     "iopub.status.busy": "2026-08-23T01:41:06.574482Z",
+     "iopub.status.idle": "2026-08-23T01:41:07.672778Z",
+     "shell.execute_reply": "2026-08-23T01:41:07.672275Z"
     },
     "papermill": {
-     "duration": 1.303125,
-     "end_time": "2026-05-04T23:45:22.500243",
+     "duration": 1.111802,
+     "end_time": "2026-08-23T01:41:07.673780",
      "exception": false,
-     "start_time": "2026-05-04T23:45:21.197118",
+     "start_time": "2026-08-23T01:41:06.561978",
      "status": "completed"
     },
     "tags": []
@@ -1515,7 +1573,7 @@
     "        volume = np.abs(returns[:-1]) * 100 + np.random.uniform(50, 150, seq_length)\n",
     "        volume_norm = (volume - volume.mean()) / (volume.std() + 1e-8)\n",
     "        \n",
-    "        volatility = pd.Series(returns[:-1]).rolling(5, min_periods=1).std().values\n",
+    "        volatility = pd.Series(returns[:-1]).rolling(5, min_periods=1).std().fillna(0.0).values\n",
     "        vol_norm = (volatility - volatility.mean()) / (volatility.std() + 1e-8)\n",
     "        \n",
     "        # RSI simplifié\n",
@@ -1576,10 +1634,10 @@
    "id": "1bf45e8b",
    "metadata": {
     "papermill": {
-     "duration": 0.007316,
-     "end_time": "2026-05-04T23:45:22.514737",
+     "duration": 0.006625,
+     "end_time": "2026-08-23T01:41:07.686406",
      "exception": false,
-     "start_time": "2026-05-04T23:45:22.507421",
+     "start_time": "2026-08-23T01:41:07.679781",
      "status": "completed"
     },
     "tags": []
@@ -1606,20 +1664,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "f24434f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:22.530934Z",
-     "iopub.status.busy": "2026-05-04T23:45:22.530695Z",
-     "iopub.status.idle": "2026-05-04T23:45:53.498914Z",
-     "shell.execute_reply": "2026-05-04T23:45:53.498363Z"
+     "iopub.execute_input": "2026-08-23T01:41:07.703447Z",
+     "iopub.status.busy": "2026-08-23T01:41:07.703447Z",
+     "iopub.status.idle": "2026-08-23T01:42:18.724163Z",
+     "shell.execute_reply": "2026-08-23T01:42:18.724163Z"
     },
     "papermill": {
-     "duration": 30.98523,
-     "end_time": "2026-05-04T23:45:53.507199",
+     "duration": 71.035787,
+     "end_time": "2026-08-23T01:42:18.730231",
      "exception": false,
-     "start_time": "2026-05-04T23:45:22.521969",
+     "start_time": "2026-08-23T01:41:07.694444",
      "status": "completed"
     },
     "tags": []
@@ -1638,28 +1696,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 5/20: Train Loss=0.0000, Acc=0.00% | Val Loss=0.0000, Acc=0.00%\n"
+      "Epoch 5/20: Train Loss=0.6929, Acc=51.14% | Val Loss=0.6941, Acc=49.33%\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 10/20: Train Loss=0.0000, Acc=0.00% | Val Loss=0.0000, Acc=0.00%\n"
+      "Epoch 10/20: Train Loss=0.6898, Acc=53.95% | Val Loss=0.6967, Acc=50.00%\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 15/20: Train Loss=0.0000, Acc=0.00% | Val Loss=0.0000, Acc=0.00%\n"
+      "Epoch 15/20: Train Loss=0.6787, Acc=57.71% | Val Loss=0.7106, Acc=49.56%\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 20/20: Train Loss=0.0000, Acc=0.00% | Val Loss=0.0000, Acc=0.00%\n"
+      "Epoch 20/20: Train Loss=0.6731, Acc=59.52% | Val Loss=0.7148, Acc=49.78%\n"
      ]
     }
    ],
@@ -1672,83 +1730,93 @@
     "    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=0.01)\n",
     "    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)\n",
     "    criterion = nn.BCEWithLogitsLoss()\n",
-    "    \n",
+    "\n",
     "    history = {'train_loss': [], 'val_loss': [], 'train_acc': [], 'val_acc': []}\n",
     "    best_val_loss = float('inf')\n",
     "    best_model_state = model.state_dict().copy()\n",
-    "    \n",
+    "\n",
     "    for epoch in range(epochs):\n",
     "        # Training\n",
     "        model.train()\n",
     "        train_loss = 0\n",
     "        train_correct = 0\n",
     "        train_total = 0\n",
-    "        \n",
+    "        train_skipped = 0\n",
+    "\n",
     "        for X_batch, y_batch in train_loader:\n",
     "            X_batch, y_batch = X_batch.to(device), y_batch.to(device)\n",
-    "            \n",
+    "\n",
     "            optimizer.zero_grad()\n",
     "            logits = model(X_batch).squeeze(-1)\n",
     "            loss = criterion(logits, y_batch)\n",
-    "            \n",
+    "\n",
+    "            # Garde NaN : on saute le batch, mais on le COMPTE pour ne pas maquiller\n",
+    "            # une mort silencieuse de l'entrainement en \"loss 0, acc 0\".\n",
     "            if torch.isnan(loss):\n",
+    "                train_skipped += 1\n",
     "                continue\n",
-    "            \n",
+    "\n",
     "            loss.backward()\n",
     "            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)\n",
     "            optimizer.step()\n",
-    "            \n",
+    "\n",
     "            train_loss += loss.item() * len(y_batch)\n",
     "            preds = (torch.sigmoid(logits) > 0.5).float()\n",
     "            train_correct += (preds == y_batch).sum().item()\n",
     "            train_total += len(y_batch)\n",
-    "        \n",
+    "\n",
     "        # Validation\n",
     "        model.eval()\n",
     "        val_loss = 0\n",
     "        val_correct = 0\n",
     "        val_total = 0\n",
-    "        \n",
+    "        val_skipped = 0\n",
+    "\n",
     "        with torch.no_grad():\n",
     "            for X_batch, y_batch in val_loader:\n",
     "                X_batch, y_batch = X_batch.to(device), y_batch.to(device)\n",
     "                logits = model(X_batch).squeeze(-1)\n",
     "                loss = criterion(logits, y_batch)\n",
-    "                \n",
+    "\n",
     "                if torch.isnan(loss):\n",
+    "                    val_skipped += 1\n",
     "                    continue\n",
-    "                \n",
+    "\n",
     "                val_loss += loss.item() * len(y_batch)\n",
     "                preds = (torch.sigmoid(logits) > 0.5).float()\n",
     "                val_correct += (preds == y_batch).sum().item()\n",
     "                val_total += len(y_batch)\n",
-    "        \n",
-    "        # Metrics\n",
-    "        train_loss = train_loss / max(train_total, 1)\n",
-    "        val_loss = val_loss / max(val_total, 1)\n",
-    "        train_acc = train_correct / max(train_total, 1)\n",
-    "        val_acc = val_correct / max(val_total, 1)\n",
-    "        \n",
+    "\n",
+    "        # Metrics (division reelle : si tout a ete saute, on affiche nan, pas 0.0000)\n",
+    "        train_loss = train_loss / train_total if train_total else float(\"nan\")\n",
+    "        val_loss = val_loss / val_total if val_total else float(\"nan\")\n",
+    "        train_acc = train_correct / train_total if train_total else float(\"nan\")\n",
+    "        val_acc = val_correct / val_total if val_total else float(\"nan\")\n",
+    "\n",
     "        history['train_loss'].append(train_loss)\n",
     "        history['val_loss'].append(val_loss)\n",
     "        history['train_acc'].append(train_acc)\n",
     "        history['val_acc'].append(val_acc)\n",
-    "        \n",
+    "\n",
     "        # Best model\n",
     "        if val_loss < best_val_loss and not math.isnan(val_loss):\n",
     "            best_val_loss = val_loss\n",
     "            best_model_state = model.state_dict().copy()\n",
-    "        \n",
+    "\n",
     "        scheduler.step()\n",
-    "        \n",
+    "\n",
     "        if (epoch + 1) % 5 == 0:\n",
     "            print(f\"Epoch {epoch+1}/{epochs}: \"\n",
     "                  f\"Train Loss={train_loss:.4f}, Acc={train_acc:.2%} | \"\n",
     "                  f\"Val Loss={val_loss:.4f}, Acc={val_acc:.2%}\")\n",
-    "    \n",
+    "            if train_skipped or val_skipped:\n",
+    "                print(f\"  [avertissement] {train_skipped} batches train + \"\n",
+    "                      f\"{val_skipped} batches val NaN (loss sautee) — \"\n",
+    "                      f\"metriques possiblement invalides\")\n",
+    "\n",
     "    # Load best model\n",
     "    model.load_state_dict(best_model_state)\n",
-    "    \n",
+    "\n",
     "    return model, history\n",
     "\n",
     "\n",
@@ -1765,12 +1833,12 @@
     ")\n",
     "\n",
     "mamba_model, history = train_mamba_model(\n",
-    "    mamba_model, \n",
-    "    train_loader, \n",
-    "    val_loader, \n",
+    "    mamba_model,\n",
+    "    train_loader,\n",
+    "    val_loader,\n",
     "    epochs=20,\n",
     "    lr=0.001\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -1778,10 +1846,10 @@
    "id": "a83c3bee",
    "metadata": {
     "papermill": {
-     "duration": 0.00828,
-     "end_time": "2026-05-04T23:45:53.523710",
+     "duration": 0.006254,
+     "end_time": "2026-08-23T01:42:18.742169",
      "exception": false,
-     "start_time": "2026-05-04T23:45:53.515430",
+     "start_time": "2026-08-23T01:42:18.735915",
      "status": "completed"
     },
     "tags": []
@@ -1792,20 +1860,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "f01c0292",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:53.542035Z",
-     "iopub.status.busy": "2026-05-04T23:45:53.541736Z",
-     "iopub.status.idle": "2026-05-04T23:45:53.887604Z",
-     "shell.execute_reply": "2026-05-04T23:45:53.886132Z"
+     "iopub.execute_input": "2026-08-23T01:42:18.755510Z",
+     "iopub.status.busy": "2026-08-23T01:42:18.755510Z",
+     "iopub.status.idle": "2026-08-23T01:42:18.914662Z",
+     "shell.execute_reply": "2026-08-23T01:42:18.914662Z"
     },
     "papermill": {
-     "duration": 0.357191,
-     "end_time": "2026-05-04T23:45:53.888976",
+     "duration": 0.16729,
+     "end_time": "2026-08-23T01:42:18.915722",
      "exception": false,
-     "start_time": "2026-05-04T23:45:53.531785",
+     "start_time": "2026-08-23T01:42:18.748432",
      "status": "completed"
     },
     "tags": []
@@ -1813,7 +1881,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW4AAAGGCAYAAADrbBjiAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATutJREFUeJzt3QeYVNX5OOAPqSpiBaw/NRhrFAuiRoxd0aixJ2pURCIqqDGxG2tEY+/GiiUxsWEJaowl1sReMGqsETViwVhAqcL8n3Pyn80uLO4Fl93L7vs+z7Az956ZufNxd+bbb05pU6lUKgEAAAAAQGnM1dwHAAAAAABAXQq3AAAAAAAlo3ALAAAAAFAyCrcAAAAAACWjcAsAAAAAUDIKtwAAAAAAJaNwCwAAAABQMgq3AAAAAAAlo3ALAAAAAFAyCrcA/99RRx0VK6ywwjdeNtlkk2/9PBdeeGF+rL59+87yMe67777RlKqv/6677mrS5wUAaC3kog373e9+VxOLiy66qFmOAaAptWvSZwMosfnnnz+6d++er0+dOjVGjx6dry+44ILRoUOHfL1r167f+nk6d+6cn2dWHqt6jAsttNC3Pg4AAMpDLtqwW265peb6sGHD4sADD4y55tIfDWi52lQqlUpzHwRA2aREuU+fPvn6ddddF+uss060ZqlXQ3LOOefED3/4w+Y+HACAFk0uOr2XXnopdtppp2jX7r/9z77++uu4/PLLY8MNN2zuQwOYbXw1BTCLw8sGDx4cxx9/fPTs2TO22mqrmDRpUvznP/+Jo48+On7wgx/E9773vZxkH3DAAfGvf/3rG4enpWFvadu9994bZ511Vnz/+9+P1VdfPQ466KD45JNPvnF4WnW42HPPPRfHHXdcrL322rHWWmvl4xg3blxNu9Rz4+KLL87Hlo55//33j3/+8581928s999/f+yxxx6x5ppr5kv//v3j2WefrdNm5MiRccghh8QGG2wQq666amy00UY5lp9//nlNmy+//DJ+85vfxGabbRarrbZajkk65ldffbXRjhUAYE7TWnPRam/blD+mS3LTTTfV2zblnv369Ys11lgjH8vuu+8ejz32WJ02H3zwQRx22GGx7rrr5uNJnRPSVAxVTz75ZM2xVXs/J+m1p20pFsm///3vOtOKpYJ7invKiZPf//73sc022+R4puPZfvvt47bbbqtzLBMnToyzzz47/z+k/7eNN944Tj311JwPJ9tuu21+/BNOOKHO/dI5kLYffPDBDcYPmDOZKgFgFj300EP5m/403Oz//u//8hC2QYMGxfPPP597AnTp0iU+++yz+Otf/5oLlX/+858bfMzTTz89J5EdO3aM8ePH5+S5ffv2uadrQw4//PD46KOPom3btjFhwoS49dZbY5FFFolf/vKXef+ZZ54ZQ4cOzdfnnnvueOSRR3Ky3JiuvfbanGQmnTp1iilTpsTf/va3nPief/75uQibEtOUSKfXmV7bfPPNFx9++GHceOON8fbbb9ckzMcee2zcc8890aZNmzxEcMyYMfHggw/m+KbtaRsAQGvVmnLR9Hh33nlnvr7DDjvk6RFSXphi8PHHH0e3bt1q2j799NOxzz77xOTJk/Oxp0sq5A4cODCuuuqqXKj99NNP48c//nE+3pRrpnz0zTffjFNOOSXnnCmOs+LII4/MsUv5birUpsLyr3/967xvgQUWyIXs9JpT0XfZZZfNbdIg6DTlQ7WwnP7f0v9Byqtfe+21/DP1ND7ttNPy/0cqjqf/36+++irHMEnFYKBl0uMWYBalZDD1SHjmmWdysTIlgKmY2KNHj1xYfPzxx+PSSy/NbVMvhy+++KLBx0xJ3l/+8pd46qmnahafePjhhwsdzzzzzJOTtyeeeCJWWWWVOvdNx1YtiO688875mFNy2JjFz9TDIyXkSerVkJ4jvY7UYyD9UZF6hKTX9/rrr+dkNBV2U1E3xSn1oEi9IVICW+1ZUE1Er7jiitzm0UcfzT000iUl2QAArVlrykXTMY0dOzYXP1NumUZrLbzwwjnHTHPd1pZikmLTu3fvfCypA0F6Lalttdfu1VdfnfPJ9BipGJqKvdUCc+oNm3ovz4rUUznFLr3uVLROPXVXWmml3Ps4HUe6LLHEErntCy+8kH+mOFSLtr/97W/zsfzxj3/MBeUXX3wxjzbbbrvtcgE6xTG9piQVrdP/V3oNKT8GWiaFW4BZlL5NT8PSkpQwpUUaUrKVegOkb8DTN+y1h2+lbQ1Jj7fUUkvlxKyaLBe5X5K+iU/HkHowVJO36n3/8Y9/5AQ2SVMUpG/pU9v99tsvGktKHtNzpN4eqbdBeg0pgU89Z6uF3TSELvUImXfeeXPPiV133TX3bBg1alSO3cknn5x7jSQpya323kiP98ADD8SJJ56Yi8Mrrrhiox03AMCcqDXlotWCa5pyIOWa6fhSMbO6r7p0T+rRmoqdyZ577pnzytQ+FbZTsTgVdZNq8XPrrbfOuWmSRoSlwnOa4qC6GNzMSseXehyn/48k9dy9/fbb8zQM9913X1xwwQW5AJ1UOytUj2X55ZeviXmaUiEdR+opnPLeFKvqvjQdQ5KK89XnrM77C7Q8frsBZlFKoFJiVlsa/pV6iFZ7PNSeryvN69WQ2r0OUtKbFF1D8pvum4Z8JWlYWe0VhBdffPFoLKkwm6THT71pq1KvgtRjIB1LmiMtrUachqmlxDklo2noXuqBkRLwNGTtV7/6VW5/7rnn5jluU8E2Jbzpkqy//vr5vs21mjEAQBm0llz03Xffzb1Qq/PFpkttaY7ZNIorzS2biqLV11n7eKbt2VvtfZx68FalYm337t0bPJ40FdiM1H5t1QXVUseDVLhOuW7qiVwtCldjUz2WaY9xySWXrHM79VROPY9TQTd1aqiOTktTRwAtlx63AN+il0NtKXlK84Kl+cBS74b07fm0Cwg0pPa35al42Vj3TUO1kpTIpnnAqlJP18ZSfY40JCz1pq2dTFcT02oym3oRXHbZZfH3v/899zxIPSLSsaVEvDr/Wkqc05xgaUhZGs6WFl9IvRdSYp7uAwDQmrWWXDRNhdBQ8bjaszjND5uKw0ntqbVSR4E//elPNXPqVgu2tY8lTY+Q1lxIHQvS9erjVPdVVXvM1qd254VU4E1z16aibVqILT1uevxpC7LVY5l2KrDUszZNoVBdvDcVphdddNFcBE8j1lK+nQrz1VFqQMukcAswi6ZNSNPcrUlK8lJSlYaDpfmpqor2Vpgd0rf71Z4PqeiZEsnU+7U671lRKWlNQ96mvaQ5w1IymXp9pDbpj4b0+tNwtbSQQrVou+aaa+bCbK9evWLDDTfMC2ZsueWWuShb7UGbeoi8//77+fHSvLdpWFmaLywlvKuttlpNGwCA1qw15KKpXVrkLEm5YJp2q/YlzR2bpAXY0uiv9Bw9e/bM26677rpcZE1xSIurpem3TjrppLwvLVBWnW7grbfeytf/8Ic/5DUZ+vfvn/PZVASuSs+VvPLKK3nBsCL/J6knbbUYmwrXqdCepmtIj5FUewZXjyUVl+++++58PU33kHrV7rvvvvHyyy/X/L9We9cOHz48/9TbFlo+hVuARpJ6kSapkLnpppvmBRFSwlhVZEGI2SUlnqlXa3UesFQ43WCDDXLv2JmRVsBNxddpL6kHQ1rNN81ZVk1803OkGKREOg0NGzJkSB4alp439ZxN83ql+b7WW2+9PP1BOpbU4yDFLk2vsPbaa+fHSkl2epz0eGn14JQQ77jjjrMhSgAAc66WmIumxWmrvWLTXK5pnYTal2233TZ3HEjF2eoiZWmRsZR7jhgxIueZKQ5pioHULnUWqM5nm0Z3pZikeW5T3lntbJAKt2lu3OWWWy7nt0kqoqa8Na3PUO093JDUKWGZZZbJ11MP2XQce+yxR03v3er0ESkPTh0WkkMPPTTHJj1PdYG19BpqzyNcLQ6nHs7p9QMtm8ItQCNJvUNTUpYWOEiJYUoGU6GzuqpumhagOf385z+PAw44ICebqcdF6umapiJIqj0gvq2BAwfGhRdemJPf1CsgJc0pEU1z2KYetklKhNOUCLvvvnue1ywVcNMx9e3bNxd8F1tssdzujDPOyIl3SppTgpuOMT3u5ZdfnlcSBgCgZeei1UXJevToEd/97nen2586A1QLm9VFylK+eM0118Q666yTc9FU4EzF0JRDVgukqaiapi1IxeDUcSDlmmlxsOOOOy4OPvjg3CbFMC32lnrwputphFmaeqK6IFwRF198cT6OtGBv6sCQisQpBrX/P1Ih9pJLLomf/exnOTdOUyCkn/vss0/eXnvKhrRwXLUYnAq+RYvIwJyrTaU5x0sA0CQmTpyYV9NNiWlK3rfYYouc2KZk9Pzzz8/F0eoKtQAA0Jjkoo0j9UAeMGBAvp4W8k2FYKBl+9/s4QC0WGlOrbQwQnWOrJQ0p14DqbdrYn4sAABmF7not5Pm+T3vvPNqppZIvW5T8Rto+UyVANBKpKFWaThYmqsrJclp3qw05CwNoUtzeQEAwOwiF511aSqxFLNOnTrlRXsvu+yyPAUE0PKZKgEAAAAAoGT0uAUAAAAAKBmFWwAAAACAklG4BQAAAAAoGYVbAAAAAICSsQzhDIwePbZJn699+7YxefKUJn3OOZE4FSNODROjYsSpGHEqRpyKEaeGde06X3MfwhxBPltO4lSMOBUjTsWIUzHiVIw4FSNOjZPP6nFbEm3aNPcRzBnEqRhxapgYFSNOxYhTMeJUjDgxp3LuFiNOxYhTMeJUjDgVI07FiFMx4tQ4FG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKpl1zHwAAAP9z0knHx113DZ/h/gsuuDTWXLNX4ccbPHi/WGONtWLffQc20hECAMA3k9M2jjaVSqXSSI/VoowePbZJn69Dh7YxadKUJn3OOZE4FSNODROjYsSpGHEqRpyKmTRpXIwdOy5ff+CB++KGG34fV1xxbc3+Ll3mj/bt2xd+vDFjvoh27drHPPPMEy1F167zNfchzBHks+UkTsWIUzHiVIw4FSNOxYhTMXLaxsln9bgFACiRzp3niw4d/puQdu7cOeaaa65YeOFFZvnxUlIMAABNSU7bOBRuAQDmEB98MCp22WW7GDBg/7jhhutjiy36xqGHHhG/+93VMXz47TF69Mcx//wLxI9+tGP077/fdMPKhgw5Mbp06RKjR4+Ov/3tkdx2v/0OjL59f9jcLw0AgFZCTlucwi0A0KqkWaImfj21SZ+zY7u5ok2bNo32eC++OCKuuup3MXXq1Ljnnrvippv+GCeeOCSWWGLJePLJv8dZZ/0m1l//B7HCCitOd99hw26Kn/3sgBg4cFDccsuNceaZp0afPhvmnhAAAJRfS8hnEzltwxRuAYBWleSefPuIeOOjMU36vMsv2iWO+1HPRkt2d911t5zQJqlHwjHHnBC9evXOt7fffue4+uor4u2336o3yV1uueVjjz32ztcHDBgYN9/8x9x21VV7NsqxAQAw+7SUfDaR0zZM4RYAaFUauaNAs1hsscVrrqfVeF9++aW49NKL4p133o7XX38t/vOf/+SeC/VZcsmlaq7PO+9/eyR8/fXXTXDUAAA0hpaQzyZy2oYp3AIArUbqIZB6CszpQ8s6dOhQcz3NA3bBBefEttv+KDbccJMYNOjncfDB+8/wvvWt3pt6bgAAUH4tJZ9N5LQNU7gFAFqVlHB2at82Worbbx8W++wzIHbffa98e+zYsfHpp/9pkYkrAAAtL59N5LT1U7gFAJiDzT///PHMM0/lxRjGjRsXl19+cR4mNnnypOY+NAAAKEROWz+FWwCAOdghhxwWp556UvTrt3ssuOCCsemmm0enTnPnecEAAGBOIKetX5tKa+9zPAOjR49t0ufr0KFtTJo0pUmfc04kTsWIU8PEqBhxKkacihGnYsSpYV27ztfchzBHkM+WkzgVI07FiFMx4lSMOBUjTsWIU+Pks3MVagUAAAAAQJNRuAUAAAAAKBmFWwAAAACAklG4BQAAAAAoGYVbAAAAAICSUbgFAAAAACgZhVsAAAAAgJJRuAUAAAAAKBmFWwAAAACAklG4BQAokZ/9rH+cdNKv6t13771/jr59N45JkybVu/+DD0ZFnz698s8kXX/uuWfqbZu2p/1F/fWv98dnn32ar1911WUxePB+he8LAEDrceCBA+K4446pd598duYo3AIAlMiWW/aNxx9/LCZPnjzdvr/+9b7YaKNNokOHDoUe64477olVV+35rY/pww8/iOOPPyomTJiQb++2255x6qlnfuvHBQCg5dlssy3jb397VD7bCBRuAQBKZNNNN4vx48fHM888WWf7V199GU899URsvnnfwo+18MKLRPv27b/1MVUqlTq355lnnujSZf5v/bgAALQ8G2+c8tkJ8tmWXridOHFiHHPMMdGrV6/o06dPDB06dIZtX3nlldhll12iZ8+esdNOO8VLL71Ub7s///nPscIKK8zGowYAmHULLrhQ9Oq1Tjz88IN1tj/66MM5ufy//1s6fvWrI/IQs403Xi/6998jXnzxhXofq/bQspQon3DCMbH55j+In/xkx3j11VfqtE2PccAB+8amm64fm23WJw477OD45JNP8r5ddtmu5ufddw+fbmjZSy+9mO+b7pfa3H77LTX7hgw5MS688Jw4/vij82PvuOMP45577orWRE4LALQmCy64YPTu3Vs+29ILt2eccUZOVq+99to44YQT4qKLLop77rlnunbjxo2L/fbbLyfDt956a6yxxhoxcODAvL22MWPGxJAhQ5rwFQAApZO+bZ88sWkv03zD35DNNtsiHnvs4ZgyZUqdObk23XTzOPnk42LKlKlx2WVXx9Ch10fXrt3i7LN/0+BjnnnmafHuuyPjoosuj0MPPTxuuOH6mn1ffvllHHHEz6N373Xjd7+7Kc4556L497//Hb///dV5/xVXXFvzMx1DbSNHvh0HH3xArL76mjF06O+jf//94qKLzquTqA8bdlOssMKKcd11N8aGG24SZ555an7O1kJOCwC0tnx2iy36ymcbQbsoqZSg3nzzzXHFFVfEKquski9vvPFGXH/99dG3b90u1XfffXd07NgxjjjiiGjTpk0ce+yx8cgjj+SEeMcdd6yTNC+11FIxevToZnhFAECzq1RigVtPifYfvtGkTzt5se/G5zv8KqJNm0LtN9xw45yYjhjxfKy5Zq+cFD799BM5iezefbE8L1i3bt1z2x133DUOP/yQb3y8dP8HH7w/Lrjg0pxwJv36DYhzzjk9X584cULsvfeA+MlP9si51OKLL5Gf45//fDnvX2CBBWt+duzYqc5jDx9+Wyy//AoxcOCgfPv//m+ZnPz+4Q/X5deRLLfc8rHHHnvn6wMGDIybb/5jvP32W40yX1nZyWkBgNaYz6Zc8rTThshnW2rh9tVXX42vv/469zSoWmutteLSSy+NqVOnxlxz/a+z8IgRI/K+9B+TpJ9rrrlmvPDCCzVJ7lNPPZUvKQFOPRkAgFaqWK7ZrOaZZ974/vf7xEMPPZAT3UcffSgWW2zxWHHFlaJHj+Xi/vv/kodzvfPOyHjttVdzbvRN3nvvndzb4bvfXb5m20orrVxn7rCtttombrzx+njjjddzovrmm68XSkRHjhwZK6+8Sp1tq666Wtxxx7Ca20suuVTN9Xnn7Zx/pjyvNZDTAgCtMZ+dd175bIsu3KYeBGlOjNqrzC2yyCJ5jrDPP/88FlpooTptl1tuuTr3X3jhhXNvhmTSpElx3HHHxfHHH98oExoDAHOoNm3+21Pg60lN+7ztOhTunVCVFm0477wz49BDj8ir76bVeVNCe+ihg2Ls2LF5iNf66/8gr9Z77LGHz/SiDO3a/S8nGj364xgwYM9YYYWV8vy62223Q/z974/Fyy//o8HHrG9F4DT0LV2q6su/pl0goqWS0wIAjUo+G60pny1t4Tatpjxt4Kq3U9JapG213cUXX5yHpaXFIJ58su6KdgBAK5MSzvYdo+zWW2/9OO20k/JiDM8++3QcfPAvY+TIf8ULLzwXw4ffl4uBya233txg4pgWgGjXrl3885+vRK9evfO2N954rWb/I488GPPNN3+cccZ5NdtuueXGmuvVHqAzeux0TLW9/PKLeTtyWgBgNpDPRmvJZ0tbuE3ze02bzFZvd+rUqVDb1O7111+Pm266KYYPHz5Tz9++fduZ/SLhW2nXrm3TPdkcTJyKEaeGiVEx4lSMOBUjTjMXpw4d5o6NN940Lr74vDycrEePZeOjjz7KQ+sfeui++MEPNoxXXnk5hg697P/fc0rOX5L0s0OH/11fcMH5Y+utt4nzzz8zjjvupNzb8+qrL///z9M2Flpowfj44w/jhReeiSWWWCLuv/++ePjhv+YhY2l/ly7z5rYjR74ZXbsuHG3bzhVzzdUm7/vxj38ct9xyQ1x55SXxwx9uF//4x4icfB9++FF5f2pXfZ7aah9jS9acOa18tpzEqRhxKkacihGnYsSpGHEqHqfOneWzLbZw27179/jss8/yfBGpol4dPpYS1y5dukzX9pNPPqmzLd3u1q1b3HvvvfHFF1/E5pv/d8W46mp2aZ6xk046Kbbbbrt6n3/y5P+tetdUJk1q+uecE4lTMeLUMDEqRpyKEadixGnm4rTJJpvH8OF3xEEHHZq3LbjgIvHLXx4V11xzZVxyyYWx1FJLxyGHHBannHJCvPzyK3lur2oeU32M6vXU7txzz4zBgw+I+eabL3be+Sc5iU77fvCDTePZZ5+No446PPdGSPOFDR7887jqqsviyy/HxzzzdIktt9wqjjnmyDjggIPysLGpUyv5vgst1C1OP/3cuOSS8+P6638X3bsvGoMHHxpbbrlN3p/a1X5NVbWPsSVrzpxWPlte4lSMOBUjTsWIUzHiVIw4FY+TfPbbaVMp6QRjaajYOuusE0OHDo1evXrVDA97/PHH4/e//32dtrfcckteqTetuJv+c9JL2mKLLWL//fePTTfdNCe5tRd9OPzww3Pym+YM69z5vxMKT2v06LHRlFKF3i9+w8SpGHFqmBgVI07FiFMx4lSMODWsa9f5Yk7RnDmtfLacxKkYcSpGnIoRp2LEqRhxKkacGief/d8ytiUz99xzx/bbbx8nnnhivPjii3H//ffnhHevvfaq6akwYcKEfL1v374xZsyYGDJkSLz55pv5Z0qSt9pqq1hggQVi6aWXrrmkngxJuj6joi0AADQGOS0AALOqtIXb5Oijj84LMOy99955CNhBBx2Uex0kaVGGu+++O19Pyepll12Wu0TvuOOOuQfC5ZdfHvPMM08zvwIAAFo7OS0AAC1qqoTmZmhZOYlTMeLUMDEqRpyKEadixKkYcWpZUyU0J/lsOYlTMeJUjDgVI07FiFMx4lSMOLXwqRIAAAAAAForhVsAAAAAgJJRuAUAAAAAKBmFWwAAAACAklG4BQAAAAAoGYVbAAAAAICSUbgFAAAAACgZhVsAAAAAgJJRuAUAAAAAKBmFWwAAAACAklG4BQAAAAAoGYVbAAAAAICSUbgFAAAAACgZhVsAAAAAgJJRuAUAAAAAKBmFWwAAAACAklG4BQAAAAAoGYVbAAAAAICSUbgFAAAAACgZhVsAAAAAgJJRuAUAAAAAKBmFWwAAAACAklG4BQAAAAAoGYVbAAAAAICSUbgFAAAAACgZhVsAAAAAgJJRuAUAAAAAKBmFWwAAAACAklG4BQAAAAAoGYVbAAAAAICSUbgFAAAAACgZhVsAAAAAgJJRuAUAAAAAKBmFWwAAAACAklG4BQAAAAAoGYVbAAAAAICSUbgFAAAAACgZhVsAAAAAgJJRuAUAAAAAKBmFWwAAAACAklG4BQAAAAAoGYVbAAAAAICSUbgFAAAAACgZhVsAAAAAgJJRuAUAAAAAKJlSF24nTpwYxxxzTPTq1Sv69OkTQ4cOnWHbV155JXbZZZfo2bNn7LTTTvHSSy/V7KtUKnH55ZfHJptsEmuuuWbsvffe8eabbzbRqwAAoDWT0wIA0OIKt2eccUZOVq+99to44YQT4qKLLop77rlnunbjxo2L/fbbLyfDt956a6yxxhoxcODAvD254YYbcoJ83HHHxbBhw2LJJZeMn/3sZzF+/PhmeFUAALQmcloAAFpU4TYlqDfffHMce+yxscoqq8Tmm28eAwYMiOuvv366tnfffXd07NgxjjjiiOjRo0e+z7zzzluTEN92223Rv3//2HjjjWPZZZeNE088MT7//PN47rnnmuGVAQDQWshpAQBocYXbV199Nb7++uvc06BqrbXWihEjRsTUqVPrtE3b0r42bdrk2+lnGj72wgsv5Nsp+d1uu+1q2qf9aajZ2LFjm+z1AADQ+shpAQBocYXb0aNHx4ILLhgdOnSo2bbIIovkOcJSz4Jp23br1q3OtoUXXjg+/PDDfD0NN1t00UVr9qVeDymBTokxAADMLnJaAABmVbsoqTRXV+0EN6nenjRpUqG207ar9mQ4/fTTY999942uXbvO8Pnbt28b/7+zQ5No165t0z3ZHEycihGnholRMeJUjDgVI07FiFPL0pw5rXy2nMSpGHEqRpyKEadixKkYcSpGnFp44TbN7zVtklq93alTp0Jtp233/PPP5wUcfvCDH8Qhhxzyjc8/efKUaGqTJjX9c86JxKkYcWqYGBUjTsWIUzHiVIw4tRzNmdPKZ8tLnIoRp2LEqRhxKkacihGnYsSpBU+V0L179/jss8/y8K/aw8dS4tqlS5fp2n7yySd1tqXbtYeaPfnkk3kxh3XXXTfOPvvsmGuu0r50AABaCDktAACzqrSZ3korrRTt2rWrWYwhefbZZ2PVVVedLkHt2bNn7nmQFmdI0s+0um7anrz++utxwAEHxAYbbBDnnXdetG/fvolfDQAArZGcFgCAFle4nXvuuWP77bePE088MV588cW4//77Y+jQobHXXnvV9FSYMGFCvt63b98YM2ZMDBkyJN588838M80RttVWW+X9xx9/fCy22GJx9NFH5x4P6b617w8AALODnBYAgFnVplL9Sr+EUqKaktx77703OnfunBdf6NevX963wgorxGmnnRY77rhjvp0S4RNOOCHeeuutvO+kk06KlVdeOSezffr0qffxa99/WqNHj42m1KFDW3N/FCBOxYhTw8SoGHEqRpyKEadixKlhXbvOF3OS5spp5bPlJE7FiFMx4lSMOBUjTsWIUzHi1Dj5bKkLt81JoltO4lSMODVMjIoRp2LEqRhxKkacWl7htrnIZ8tJnIoRp2LEqRhxKkacihGnYsSpcfLZ0k6VAAAAAADQWincAgAAAACUjMItAAAAAEDJKNwCAAAAAJSMwi0AAAAAQMko3AIAAAAAlIzCLQAAAABAySjcAgAAAACUjMItAAAAAEDJKNwCAAAAAJSMwi0AAAAAQMko3AIAAAAAlIzCLQAAAABAySjcAgAAAACUjMItAAAAAEDJKNwCAAAAAJSMwi0AAAAAQMko3AIAAAAAlIzCLQAAAABAySjcAgAAAACUjMItAAAAAEDJKNwCAAAAAJSMwi0AAK3KkUceGY888khMmTKluQ8FAABmqN2MdwEAQMvTuXPnOPbYY2Py5MmxxRZbxNZbbx3rrLNOtGnTprkPDQAAarSpVCqV/92kavTosU36fB06tI1Jk/T6aIg4FSNODROjYsSpGHEqRpyKEaeGde0637d+jJQCP/3003HPPffEvffem7dttdVW8cMf/jBWX331aAnks+UkTsWIUzHiVIw4FSNOxYhTMeLUOPmswu0MSHTLSZyKEaeGiVEx4lSMOBUjTsWIU9MUbmv78ssv48orr4yrr746Jk2aFIsvvnjsuuuu0a9fv+jYsWPMqeSz5SROxYhTMeJUjDgVI07FiFMx4tQ4+aypEgAAaHW++uqrePDBB3OP28ceeyy6d+8e++yzT542YfTo0XHWWWfFU089FVdddVVzHyoAAK2Uwi0AAK3KAQccEH//+9+jS5cueXqE6667LlZbbbWa/csvv3yMGTMmz4MLAADNReEWAIBWZZFFFonLLrvsGxck69WrV9x8881NfmwAAFA1V801AABoBX7961/HW2+9FXfddVfNtkGDBsUf//jHmttdu3aNHj16NNMRAgCAwi0AAK3MueeeG5deemnMM888NdtS79tLLrkkLr744mY9NgAAqFK4BQCgVRk2bFgu3m6yySY12/baa6+8INmNN97YrMcGAABVCrcAALQq48ePj86dO0+3fcEFF4yxY8c2yzEBAMC0FG4BAGhVNthggxgyZEiMGjWqZttHH30Up59+evTp06dZjw0AAKoUbgEAaFWOP/74mDx5cmy66aax7rrr5stGG20UU6dOzfsAAKAM2jX3AQAAQFNaaKGF4oYbbohXX301Ro4cGe3atYtlllkmlltuueY+NAAAqKFwCwBAq/P111/nOW27dOmSb1cqlXj77bfjn//8Z2y99dbNfXgAAKBwCwBA63L//ffHcccdF59//vl0+7p27apwCwDAnD3H7VtvvVWz6u6jjz4aJ510Utx8882NeWwAANDozj777Nh8883jrrvuyj1u07QJl156aSyxxBLx85//vLkPDwAAZr1we+ONN8Z2222Xh5K98sorccABB8R7770X559/fr4AAEBZpbx1wIAB8Z3vfCe+973vxejRo2PDDTeME044Ia6++urmPjwAAJj1wu2VV14Zp59+evTu3TuGDRsWK620Ut527rnn6nULAECppV6248ePz9eXXXbZvEhZkgq5//73v5v56AAA4FsUbj/66KNYa6218vUHH3wwNttss3x90UUXja+++mpWHhIAAJpE6l2bpvl68803Y5111ok77rgjXn755TyqrFu3bs19eAAAMOuLk6XeCMOHD4+FFlooRo0alQu3kydPjqFDh8aKK644Kw8JAABN4thjj40hQ4bESy+9FD/60Y/iL3/5S+y8884xzzzzxJlnntnchwcAALNeuD3yyCPzwg1ffPFF7L777tGjR484+eST47777ssLOwAAQFk99NBDccQRR8SCCy6Yb5911llx4oknRseOHaN9+/bNfXgAADDrUyWst9568fjjj8eTTz4Zxx9/fN524IEH5mkT0gIPjWXixIlxzDHHRK9evaJPnz65R++MpEXSdtlll+jZs2fstNNOuQdFbXfeeWfuGZz2Dxo0KD799NNGO04AAOYcaZqEzz77rM62zp07z7airZwWAIAmK9wmjz32WHz99df5+i233JKT0YsvvjgmTZoUjeWMM87Iyeq1116bV/m96KKL4p577pmu3bhx42K//fbLyfCtt94aa6yxRgwcODBvT1588cU8JG7w4MF57rIxY8bE0Ucf3WjHCQDAnCPNa5sKoI2Zt34TOS0AALOiTaVSqczsnVKB9sorr4xrrrkm9yDo169f7hnwzDPPRO/evXNC+m2lBHXdddeNK664IifXySWXXJJ7+v7ud7+r0zYVjn/729/G/fffH23atIn0krbccsvYf//9Y8cdd8xD4eaaa674zW9+k9t/8MEHsfHGG+epHZZaaql6n3/06LHRlDp0aBuTJk1p0uecE4lTMeLUMDEqRpyKEadixKkYcWpY167zfav777bbbvH888/n/DCt2ZCmSKjtgQceiMbSnDmtfLacxKkYcSpGnIoRp2LEqRhxKkacGiefnaU5bm+66aa48MIL8xCt9K3/2muvnYec/eMf/4gBAwY0SuH21VdfzT16U0+DqrXWWivPoTt16tSctFaNGDEi70sJbpJ+rrnmmvHCCy/kJDft/9nPflbTfrHFFovFF188b59R4RYAgJZp1113zZemIKcFAGBWzVLhNi1K9p3vfCf3AkiLO1QTyDQ32JQpjVNNHz16dF4wokOHDjXbFllkkdzD9/PPP8+9I2q3XW655ercf+GFF4433ngjX//444+jW7du0+3/8MMPowwqU6fGhHETY7JvIho09eu24lSAODVMjIoRp2LEqRhxaplx6tCpU7SpVXycE+ywww5N9lytJaeVz7bc3/HmIk7FiFMx4lSMOBUjTi0zTh1KmtPOUuF2xRVXjKuuuioWWGCBvCDC5ptvHh999FGcc845sfrqqzfKgY0fP75OgptUb087H9mM2lbbTZgw4Rv3N3eSO/bKY6LH5FHNfSgAADPtrQ6Lx3z7nlrKRHdG9txzz5perfW57rrrGu25WkNOK58FAOZ0b5U0p52lwu2JJ54YRx55ZLz//vvxi1/8IpZYYokYMmRIvn3++ec3yoGlucamTUKrtzt16lSobbXdjPbPPffcM3z+9u3bxjfk842mMrVNRBM8DwDA7JzDrGxJ7jepzjVblaYyeO+99+Lhhx+OAw44oFGfqzlzWvksAMCcndPOco/bO+64o862ww8/fLoeAN9G9+7d47PPPsuJdLt27WqGj6XEtUuXLtO1/eSTT+psS7erQ8lmtL9r164zfP7Jk5uuO3eq6H80dfIc1YW8ubTvMGd1tW8u4tQwMSpGnIoRp2LEqWXGab5OnWLy12mt2znnmAcPHlzv9ltvvTXuvffe2HfffVtETiufLac57Xe8uYhTMeJUjDgVI07FiFPLjNN8Jc1pZ6lwm7zyyit5uoR//etfeV7bZZddNvbYY4/o3bt3oxzYSiutlJPbtBhDr1698rZnn302Vl111TqLOCRpkbS0Um+ac7e6Au9zzz2XV+Ct7k/3TYs6VFfgTZe0vQxSNb9jp3lirnblOjnK+u2HODVMnBomRsWIUzHiVIw4FSNOzae64G5jai05rXy2OL/jxYhTMeJUjDgVI07FiFMx4tQ4Zqn/73333ZdX4k3JZEoc0yUll/3794/777+/UQ4sDfnafvvt87QML774Yn7coUOHxl577VXTUyHN85X07ds3xowZk6drePPNN/PPNEfYVlttlffvtttuuYfwzTffnFf2PeKII2KjjTay+i4AQCs0atSo6S5pAbCLL744TwHWmOS0AADMqjaVVH2dSdtss03svPPO0a9fvzrbr7nmmrjtttumm0ZhVqVENSW5acha586d87C16nOusMIKcdppp9X0OEiJ8AknnBBvvfVW3pd6S6y88sp1hr5dcMEF8cUXX8T6668fv/71r/MKvzMyevTYaOpvIibNQV3Im4s4FSNODROjYsSpGHEqRpyKEaeGde0637e6f5r2q9qjtbpIWbq+2GKLxamnnhrrrbdeNKbmymnls+UkTsWIUzHiVIw4FSNOxYhTMeLUOPnsLBVu03CsP/3pT7H00kvX2f7OO+/EtttumxPOOZ1Et5zEqRhxapgYFSNOxYhTMeJUjDjN/sJtWlC3tlS8bd++fSyyyCI1hdyWQD5bTuJUjDgVI07FiFMx4lSMOBUjTo2Tz87SVAk9evSIRx55ZLrtaSXexh5eBgAAjSnlqw899FA8//zz+friiy+ee7becMMNzX1oAADw7RYnO+igg/JlxIgRNYshpAUX/vKXv8QZZ5wxKw8JAABN4txzz41hw4bFySefXLMtLbB7ySWXxKeffhqDBg1q1uMDAIBZniohefzxx+MPf/hDnn+rY8eOseyyy+a5ulZbbbUWEVlDy8pJnIoRp4aJUTHiVIw4FSNOxYjT7J8qoU+fPnHeeedFr1696mx/8skn4/DDD693ZNmcSD5bTuJUjDgVI07FiFMx4lSMOBUjTo2Tz85Sj9skLdow7cINEydOjPfee8/KtgAAlFZaLCwtEjattMjX2LFNW+wEAIBGneN2Rp566qnYYostGvMhAQCgUW2wwQYxZMiQGDVqVM22jz76KE4//fTcGxcAAFpc4RYAAMru+OOPj8mTJ8cmm2wS6667br5suOGGMWXKlDjhhBOa+/AAAODbTZUAAABzooUWWihuuOGGeO211+Ltt9+Odu3axTLLLBPLLbdccx8aAADUULgFAKBVmTRpUl6cbIkllog99tgjb9txxx3j+9//fhxyyCHRvn375j5EAAAoXrh9+umnG2yTei0AAECZnXLKKfHss8/GySefXLPtwAMPzMXcCRMmxK9+9atmPT4AAJipwu2ee+5ZqF2bNm1EFgCA0rr33nvj6quvjpVWWqlm22abbRbdu3ePgQMHKtwCADBnFW5fffXV2XskAADQBCqVSkycOLHe7WnRMgAAKIO5mvsAAACgKW255ZZx3HHHxTPPPBPjxo3Ll+eeey5OPPHE3PMWAADKwOJkAAC0KkcffXQce+yxsffee8fUqVNzT9t27drF9ttvH4MGDWruwwMAgEzhFgCAVmXuueeOc845J8aMGRPvvPNOTJkyJUaOHBnDhw/PPW5ffvnl5j5EAABQuAUAoHV644034vbbb4977rknvvzyy+jRo0ccc8wxzX1YAACQKdwCANBqvP/++7lYe8cdd8R7770XXbp0yUXbs88+O7beeuvmPjwAAKihcAsAQIs3bNiwXLBNC5J169YtNtlkk9hiiy1i7bXXjp49e8byyy/f3IcIAAB1KNwCANDipcXIll566Tj99NNju+22a+7DAQCABs3VcBMAAJiznXrqqbHkkkvG0UcfHeutt17++cADD8TEiROb+9AAAKBeetwCANDi7bjjjvny6aefxp///Oe4++67Y/DgwdGpU6eYOnVqPPnkk7lHbvv27Zv7UAEAIGtTqVQq/71KbaNHj23S5+vQoW1MmjSlSZ9zTiROxYhTw8SoGHEqRpyKEadixKlhXbvO1yiP8+GHH8add96Zi7ivvPJKLLDAAvGjH/0o98ZtCeSz5SROxYhTMeJUjDgVI07FiFMx4tQ4+aypEgAAaJUWXXTRGDBgQNx6661xzz33xE9/+tN49NFHm/uwAAAgU7gFAKDVW2aZZfLUCan3LQAAlIHCLQAAAABAySjcAgAAAACUjMItAAAAAEDJKNwCAAAAAJSMwi0AAAAAQMko3AIAAAAAlIzCLQAAAABAySjcAgAAAACUjMItAAAAAEDJKNwCAAAAAJSMwi0AAAAAQMko3AIAAAAAlIzCLQAAAABAySjcAgAAAACUjMItAAAAAEDJKNwCAAAAAJSMwi0AAAAAQMko3AIAAAAAlIzCLQAAAABAySjcAgAAAACUjMItAAAAAEDJKNwCAAAAAJRMaQu3lUolzjrrrFh33XWjd+/eccYZZ8TUqVNn2P69996Lfv36xeqrrx5bb711PPbYY3X2Dxs2LPr27RtrrLFG7LLLLvHss882wasAAKA1k9MCANDiCrdXX3113HnnnXHRRRfFBRdcEMOHD8/bZpQQDxo0KBZZZJGczP7oRz+KwYMHx6hRo/L+Rx55JE4++eQ48MAD4/bbb4/1118/9ttvv/joo4+a+FUBANCayGkBAGhxhdvrrrsuDj744OjVq1fuoXDYYYfF9ddfX2/bJ554IvdOSIlsjx49YuDAgbmXQkp4k9tuuy2233772G677WLppZeOn//85zkhfvjhh5v4VQEA0JrIaQEAmFXtooRSr4EPPvgg1l577Zpta621Vrz//vvx8ccfR7du3eq0HzFiRKy88soxzzzz1Gn/wgsv5OsDBgyIeeedd7rnGTt27Gx9HQAAtF5yWgAAWlzhdvTo0fln7WQ29SZIPvzww+mS3NR+2m0LL7xwbpusssoqdfalYWYjR47MvR4AAGB2kNMCADBHFm4nTJgww/m4xo0bl3926NChZlv1+qRJk6ZrP378+Dptq+3ra/vuu+/G0UcfHdtuu+10yS8AAMwMOS0AAC2ucJuGgu2111717jv88MPzz5SkduzYseZ6Mvfcc0/XPrX5/PPP62xL7Tt16lRn29tvvx377LNPLLXUUnHKKad84/G1b9822rSJJtOuXdume7I5mDgVI04NE6NixKkYcSpGnIoRpzlLmXNa+Ww5iVMx4lSMOBUjTsWIUzHiVIw4zeGF23XWWSdee+21evelXgtnnnlmHi625JJL1hlq1rVr1+nad+/ePd5888062z755JM6Q83eeOON6NevX05wr7zyyukS4GlNnjwlmtqkSU3/nHMicSpGnBomRsWIUzHiVIw4FSNOc44y57Ty2fISp2LEqRhxKkacihGnYsSpGHH69uaKEkpJ6+KLLx7PPvtszbZ0PW2bdt6vpGfPnvHyyy/noWq126ftSVr8oX///nn13auuuio6d+7cRK8EAIDWSk4LAECLW5ws2W233eKss86KRRddNN8+++yzc6Ja9emnn+bhZGll3d69e8diiy2W5/k68MAD48EHH4wXX3wxTjvttNz29NNPj6lTp8aQIUPyXGPV+cbSir31rcwLAACNQU4LAMCsalOpVCpRQlOmTIkzzjgjbr311mjbtm3svPPO8ctf/jLa/P+JujbZZJPYYYcd4qCDDsq333nnnTj22GPzPGOpF8IxxxwT3//+9yO9vNVXX71Oz4WqwYMH19x/WqNHj42m1KFDW13ICxCnYsSpYWJUjDgVI07FiFMx4tSwrl3nizlFc+a08tlyEqdixKkYcSpGnIoRp2LEqRhxapx8trSF2+Ym0S0ncSpGnBomRsWIUzHiVIw4FSNOLatw25zks+UkTsWIUzHiVIw4FSNOxYhTMeLUOPlsKee4BQAAAABozRRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkSlu4rVQqcdZZZ8W6664bvXv3jjPOOCOmTp06w/bvvfde9OvXL1ZfffXYeuut47HHHqu33YgRI2KllVaKf//737Px6AEAQE4LAEALLNxeffXVceedd8ZFF10UF1xwQQwfPjxvm1FCPGjQoFhkkUVi2LBh8aMf/SgGDx4co0aNqtNu8uTJ8atf/eobk2UAAGgscloAAFpc4fa6666Lgw8+OHr16pV7KBx22GFx/fXX19v2iSeeyL0TTj755OjRo0cMHDgw91JICW9tV155ZXTu3LmJXgEAAK2dnBYAgBZVuP3oo4/igw8+iLXXXrtm21prrRXvv/9+fPzxx/UOFVt55ZVjnnnmqdP+hRdeqLn99ttv5yT5qKOOaoJXAABAayenBQCgxRVuR48enX9269atZlsaMpZ8+OGH9bav3TZZeOGFa9qmYWfHH398HHTQQXk7AADMbnJaAAC+jXbRTCZMmJB7IdRn3Lhx+WeHDh1qtlWvT5o0abr248ePr9O22r7a9pZbbslzge266665h0MR7du3jTZtosm0a9e26Z5sDiZOxYhTw8SoGHEqRpyKEadixGnOUuacVj5bTuJUjDgVI07FiFMx4lSMOBUjTnN44TYNBdtrr73q3Xf44YfnnylJ7dixY831ZO65556ufWrz+eef19mW2nfq1Cn3XDj33HPjmmuuiTYzkblOnjwlmtqkSU3/nHMicSpGnBomRsWIUzHiVIw4FSNOc44y57Ty2fISp2LEqRhxKkacihGnYsSpGHGagwu366yzTrz22mv17ku9Fs4888ycoC655JJ1hpp17dp1uvbdu3ePN998s862Tz75JA81e+yxx+Kzzz6LH//4xzVDzJJtttkm9t9//3wBAIBZIacFAKDFFW6/SUpaF1988Xj22Wdrktx0PW2bdt6vpGfPnnH55ZfnoWqpR0K1fVrMYfPNN48111yzTgK955575vbLL798E74qAABaEzktAAAtrnCb7LbbbnHWWWfFoosumm+fffbZ0b9//5r9n376aR5ONu+880bv3r1jscUWi6OPPjoOPPDAePDBB+PFF1+M0047LTp37pwvVW3b/neOjZQwL7DAAs3wygAAaC3ktAAAtLjC7b777hv/+c9/YvDgwTkx3XnnnaNfv341+9PtHXbYIa+qm/Zfcsklceyxx8aOO+4YSy+9dFx88cU5kQUAgOYipwUAYFa1qVQnyKKO0aPHNunzdejQ1qTNBYhTMeLUMDEqRpyKEadixKkYcWpY167zNfchzBHks+UkTsWIUzHiVIw4FSNOxYhTMeLUOPnsXIVaAQAAAADQZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASkbhFgAAAACgZBRuAQAAAABKRuEWAAAAAKBkFG4BAAAAAEpG4RYAAAAAoGQUbgEAAAAASqZNpVKpNPdBAAAAAADwP3rcAgAAAACUjMItAAAAAEDJKNwCAAAAAJSMwm0TmThxYhxzzDHRq1ev6NOnTwwdOnSGbV955ZXYZZddomfPnrHTTjvFSy+9FK3BRx99FAcffHD07t07NthggzjttNNy3OpzwAEHxAorrFDn8uCDD0Zrcd999033+lPs6vP3v/89ttlmm3w+7bXXXvHee+9Fa3DrrbdOF6N0WXHFFettv912203X9vXXX4+WatKkSfm8ePLJJ2u2pXOjX79+sfrqq8fWW28djz322Dc+xp133hmbbbZZPrcGDRoUn376abSGOL3wwgvxk5/8JNZYY43Ycsst4+abb/7Gx0jv+9OeW1999VW09Didcsop073u3//+9zN8jGuuuSa/96e4ps/L8ePHR0szbZyOOuqoet+n0nt1fb744ovp2q6zzjpN/CpozeSzxchpi5HPNkw+2zA5bTFy2mLktMXIaZtYWpyM2e/kk0+ubLvttpWXXnqpcu+991bWWGONyp///Ofp2n311VeV9ddfv/Kb3/ym8uabb1Z+/etfV77//e/n7S3Z1KlTK7vuumtlwIABlddff73y9NNPVzbffPMch/qkfXfccUfl448/rrlMnDix0lpccskllYEDB9Z5/V988cV07d5///3K6quvXrnqqqtyXA855JDKNttsk+Pd0o0fP75OfEaNGpXPmyFDhkzX9uuvv66suuqqlaeeeqrOfSZPnlxpiSZMmFAZNGhQZfnll6888cQTeVs6J9J71C9/+cv83nPppZdWevbsmc+h+owYMaKy2mqrVW677bbKP//5z8pPf/rTyn777Vdp6XFK50WvXr0qZ599duXtt9+u3HnnnfncefDBB+t9jA8//DDf/913361zbrWk38H64pT069evctlll9V53ePGjav3Me65557KWmutVfnrX/+az62tt966ctJJJ1VakvriNGbMmDrxef755yvf+973Kvfdd1+9j/HMM89UevfuXec+n3zySRO/Eloz+WzD5LTFyWcbJp/9ZnLaYuS0xchpi5HTNj2F2yaQktT0Jlj7l//iiy/OHwrTuvnmmyubbLJJzRtg+pk+nIcNG1ZpydKHavrFHz16dM224cOHV/r06TNd25TMrrTSSpV//etfldYqJSLpQ7Yh5513Xp3zLH3ApD+yap+LrUVK2jbbbLN6/xgaOXJkZcUVV8wfQi3dG2+8Udluu+1yQlv7w/bvf/97/qOo9h/Ve++9d+WCCy6o93EOP/zwypFHHllzO/0hscIKK+RkriXH6Q9/+EOlb9++ddoed9xxlV/84hf1Ps7f/va3XLxoqWYUp2SDDTaoPProo4UeZ/fdd69zrqVCR/ojakZJcUuKU239+/evHHbYYTN8nJtuuqny4x//eDYeKcyYfLYYOW1x8tmZJ5/9HzltMXLaYuS0xchpm4epEprAq6++Gl9//XXuKl+11lprxYgRI2Lq1Kl12qZtaV+bNm3y7fRzzTXXzMMYWrKuXbvGlVdeGYssskid7V9++eV0bf/1r3/luCy11FLRWr311luxzDLLNNgunU9pSEvV3HPPHausskqLP5+m9fnnn8cVV1wRv/zlL6NDhw7T7X/zzTdjscUWi44dO0ZL99RTT+VhKDfeeON058rKK68c88wzT8229F40o3Nl2nMrxW/xxRfP21tynKpDXqdV33tV9dxadtllo6WaUZxSPNJQ4SLvU1OmTIl//OMfdc6nNLRx8uTJ+fOzJceptscffzyefvrp+MUvfjHDNul8KhJTmB3ks8XIaYuTz84c+Wxdctpi5LTFyGmLkdM2j3bN9LytyujRo2PBBRes8wGbkrk011X6AF5ooYXqtF1uueXq3H/hhReON954I1qyLl265A+PqvQHQJo3Zt111603ye3cuXMcccQR+Y1j0UUXjYMOOig23HDDaA1ST/m33347z9V02WWX5Q+Ivn375jnBpk3i0vnUrVu36c6nDz/8MFqTP/7xjzkOKU4z+sOhffv2MXDgwDwHX0pK0vm12mqrRUuz++6717t9Zs+Vjz/+uEWfWzOK05JLLpkvVf/5z3/irrvuyu9BMzq30rxWe+65Z/69XWmllfJcVy0l8Z1RnNLrTsWISy+9NB555JFYYIEFYp999okddthhurZjxozJn4e1z6d27drl+7T086m2yy+/PMcn/cE4IymuqXC288475z8i0h8GRx999HS/izA7yGeLkdMWI5+defLZuuS0xchpi5HTFiOnbR563DaB9AY3bQJSvZ0mdS7Sdtp2Ld2ZZ56ZF7U49NBD601yJ0yYkBfFSD0aUnKbFnZI3261BqNGjao5T84777w48sgjY/jw4XHGGWdM19b59N8/DNJE+z/96U9n2CYlH2mC9LSISvqg6dGjR+y9997xwQcfRGsxs+dK+h1s7edWikFKblPh4sc//nG9bdL7VTq30nvUJZdcEp06dcqLZcyoN0NLUe1F9p3vfCf/TqXfreOOOy4vRFNfHJPWfD6lRVSeeOKJ/MdQQ3FN505KbM8999z8x+b++++fCx4wu8lnZ42ctn7y2Zkjny1OTjvz5LQzJqedOXLa2UOP2yaQhqtM+4tavZ3e8Iq0nbZdS09wr7322vwLvPzyy0+3/8ADD8xvBPPPP3++nVZVffnll+Omm26KVVddNVq6JZZYIq/emF5/+hBJ33am3hyHH354fuNr27Ztg+dT6g3SWqQ/ftK3eD/84Q9n2ObXv/51/qBNvV6SE088MZ577rm444478gdIa5DOldRjquh7z4zOrTR8sTVIK+im96KRI0fGH/7whxm+7quuuioPj5p33nnz7bPOOiv/YZ5WDN92222jpdp+++1j4403zj0Mqu/TKVapt9Dmm29ep211SGdrPp/+8pe/5PfyaXsoTiv1hEnv+9XfywsuuCAXfNJwzjQMHWYn+ezMk9POmHx25shni5PTzhw57TeT084cOe3socdtE+jevXt89tlnuSt47SEc6SSdNuFIbT/55JM629Lt1tJlPCUcV199dU50t9xyy3rbzDXXXDUJblX6BiwlM61F+uCozhuXpG/U07CM9C1okfMpzb/WWjz66KN56MW050xtaQhLNclNqt+qtqZzambfe1rzuZW+Hd53333zkN/0B/k3zc+UvmGvJrjVhC4NS2vp51b6HaomuFUz+p1K7VJcap9P6fMy/dHVGs6n6vvUpptu2mC7lPTX/sMzDeVM8Wvp5xPlIJ+dOXLahslni5PPFienLU5O2zA57cyR084eCrdNIH3jkD5Ia0+I/uyzz+Zv0lPCVlvPnj3j+eefz8NhkvQzfVOatrd0F110Udxwww1xzjnnfOO3yUcddVT+Jr62NNl3egNtLW+GaULwNAyo6p///Gd+o6s9v1ySzpt0rlWl+6Theq3hfKp68cUXG/zWLvV2SedfVerx8dprr7WacypJ50Tq5VMd4pOkc2dG58q051YahpcuLf3cSufG4MGD49///nf87ne/i+9+97szbJvevzfbbLO49dZba7aNGzcu3nnnnRZ/bp1//vl5+FyR9+n0OZg+D2ufT+nzMn1upl4NLV06T1JPqobep9IfV2uvvXYeflaVkttUSGvp5xPlIJ8tTk7bMPnszJHPFienLUZOW4yctjg57eyjcNsE0rcJqYt9Gq6SPnTvv//+GDp0aOy11141vRWqHyxpsvk0qfWQIUPySnvpZ0pOttpqq2jJ0uTUaa6cn/3sZ3nVzxST6mXaGG2yySZ5Dqzbb789f1ikBCW9OX7TnE8tSVrNOX2T96tf/SrPDfPwww/n+cAGDBiQ54RJsaoOz9hpp53yH0ppPp70TWr64yB9M5oS5dYive5ph2pMG6d0Tl1zzTXxwAMP5JiefPLJMXbs2HonnW+pevfunSeQT+dIilk6Z9L7VZowPkmxSjGrzju022675aF3ab61lLykxS822mijFr8y9i233JKHdp5yyim5h1n1fao6JK92nNI39CkmF154Yb5PimuKU1p8pqUvPJOGlKXVZNOwunfffTcPvUvv2f3798/70/t59f29utBBaps+H9N5lz4vd91111YxrOz999/PwxTrG1JWO06pF1X6fEwrQKcYpT9K05yZaRGkFVZYoRmOnNZGPluMnLYY+ezMkc8WJ6ctRk5bjJy2ODntbFShSYwbN65yxBFHVFZfffVKnz59KldffXXNvuWXX74ybNiwmtsjRoyobL/99pVVV121svPOO1defvnlSkt32WWX5TjUd6kvRjfddFNliy22qHzve9+r7LDDDpWnnnqq0pq8/vrrlX79+uXzaf31169ceOGFlalTp1bee++9HKsnnniipu1DDz2UY7XaaqtV9t5778q7775baU3S79EjjzxSZ9u0cUqx++1vf1vZaKON8jm1xx57VF577bVKSzftuTJy5Mj82lMMfvjDH1b+9re/1exL7VL7FLuq9Du54YYb5vNw0KBBlU8//bTS0uPUv3//et+nfvrTn9YbpwkTJlROO+20/Hvas2fPysCBAyujRo2qtIbz6b777qtsu+22+Xewb9++lb/85S91zp3q+3vtz4H11luvstZaa1WOPvroHLvWEKcXXnghb5s4ceJ0baeN0+eff1456qijKuuss05ljTXWqBx22GF5GzQV+WzD5LTFyWeLk89+MzltMXLaYuS0xchpm06b9M/sLAwDAAAAADBzTJUAAAAAAFAyCrcAAAAAACWjcAsAAAAAUDIKtwAAAAAAJaNwCwAAAABQMgq3AAAAAAAlo3ALAAAAAFAyCrcAAAAAACXTrrkPAID6bbLJJvH+++/Xu++6666LddZZZ7Y871FHHZV//uY3v5ktjw8AQOshpwWYdQq3ACV2zDHHxNZbbz3d9vnnn79ZjgcAAGaWnBZg1ijcApTYfPPNF127dm3uwwAAgFkmpwWYNea4BZiDh51dc801se2228bqq68e++23X4wePbpm/1tvvRX77rtvrLnmmrHBBhvERRddFFOnTq3Zf8cdd0Tfvn2jZ8+e8ZOf/CReeeWVmn1ffvllHHrooXnfRhttFMOHD2/y1wcAQMsnpwWYMYVbgDnYhRdeGAMGDIgbb7wxxo8fHwcddFDe/umnn8buu+8e3bp1i5tvvjlOOOGE+P3vf5/nEUseffTROPbYY2PvvfeOP/3pT/G9730vBg4cGJMmTcr777vvvlhllVXizjvvjK222ioPbxs7dmyzvlYAAFomOS1A/dpUKpXKDPYB0My9D1Jvg3bt6s5qs/jii8ddd92V92+22WY5AU3ee++9fDv1JHjiiSdi6NChcf/999fc/49//GNcfPHF8dhjj8XgwYOjc+fONYs1pOT23HPPjf79+8fZZ58dI0eOjBtuuCHvS8ltr1694qabbsq9FQAAoCg5LcCsM8ctQIkdfPDBscUWW9TZVjvpTUPGqpZaaqlYYIEF8nCydEm9C2q3XWONNXLSPGbMmHj77bfzULKqDh06xJFHHlnnsWrPSZZMnDhxNrxCAABaOjktwKxRuAUosYUXXjiWXnrpGe6ftufClClTYq655oqOHTtO17Y6F1hqM+39ptW2bdvpthmgAQDArJDTAswac9wCzMFeffXVmuvvvPNOHgK2wgorxLLLLhsvv/xyTJ48uWb/888/HwsttFDuwZAS59r3TYlvGqb27LPPNvlrAACgdZPTAtRP4RagxFLSmoaCTXsZN25c3p8WZnjggQdywprmBVt//fVjmWWWyavypjm+jj/++DzELM0LlhZ92G233aJNmzax55575gUcbrvttpwcn3baabn3QRqKBgAAjUlOCzBrTJUAUGKnnnpqvkzrkEMOyT932GGHOOecc2LUqFGx4YYbxkknnZS3p0UarrzyyhgyZEhsv/32uVdCWm03rbKbrL322nlV3rSwQ0qa0wq8l156aXTq1KmJXyEAAC2dnBZg1rSpmOAFYI6UhoGllXR33HHH5j4UAACYJXJagBkzVQIAAAAAQMko3AIAAAAAlIypEgAAAAAASkaPWwAAAACAklG4BQAAAAAoGYVbAAAAAICSUbgFAAAAACgZhVsAAAAAgJJRuAUAAAAAKBmFWwAAAACAklG4BQAAAAAoGYVbAAAAAIAol/8H5iJC1WfrcM0AAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW4AAAGGCAYAAADrbBjiAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAA0etJREFUeJzs3Qd4VNXWBuBvesqkJ6QROiT0XgXpiB2xi4Vrr1jur9gQu1ewlyuKomK5KnYEBSkiSu81EHpCCuk90/9n72SGBBAOkEz93sfzzJkzkzM7yyHZWbPO2iqHw+EAEREREREREREREXkNtacHQEREREREREREREQNMXFLRERERERERERE5GWYuCUiIiIiIiIiIiLyMkzcEhEREREREREREXkZJm6JiIiIiIiIiIiIvAwTt0REREREREREREReholbIiIiIiIiIiIiIi/DxC0RERERERERERGRl2HiloiIiIiIiIiIiMjLMHFLRAHr0UcfRWpq6km3ESNGnPXrvP322/JcY8eOPeMx3nLLLXAn5/c/b948t74uERERUaDgXPTUPvvsM1cs3nnnHY+MgYjIk7QefXUiIg+KiIhAfHy83Lfb7cjPz5f7UVFR0Ov1cj8uLu6sX8doNMrXOZNzOccYHR191uMgIiIiIu/Bueipffvtt6797777DnfffTfUatafEVHgUDkcDoenB0FE5Gliojx48GC5P3v2bPTv3x+BTFQ1CK+99houvPBCTw+HiIiIyK9xLnq8bdu24fLLL4dWW1tvZrVa8cEHH2Do0KGeHhoRkdvwoyoiIoWXl91777146qmn0L17d5x//vkwm80oLCzEY489hnPPPRddunSRk+y77roL+/btO+nlaeKyN3Fs4cKFeOWVVzBo0CD06NED9913HwoKCk56eZrzcrENGzZgypQp6Nu3L3r37i3HUVVV5XqeqNx499135djEmO+8807s3LnT9fWNZdGiRZgwYQJ69eolt5tvvhnr169v8JwDBw7g/vvvx5AhQ9C1a1cMGzZMxrKkpMT1nIqKCvznP//BqFGj0K1bNxkTMeb09PRGGysRERGRrwnUuaiz2lbMH8UmfPPNNyd8rph7Tpw4ET179pRjue666/DXX381eE5OTg7+7//+DwMGDJDjEcUJohWD0+rVq11jc1Y/C+J7F8dELISsrKwGbcVEwl3EXcyJhc8//xwXXXSRjKcYz7hx4/DDDz80GIvJZMKrr74q/z+I/2/Dhw/Hiy++KOfDwsUXXyzPP3Xq1AZfJ94D4vikSZNOGT8i8g9slUBEpNAff/whP+kXl5u1aNFCXsJ2zz33YOPGjbISIDw8HMXFxViyZIlMVP7666+nPOfLL78sJ5EGgwHV1dVy8qzT6WSl66k8/PDDyMvLg0ajQU1NDb7//nvExsbi3//+t3x8+vTpmDVrltwPDg7Gn3/+KSfLjenTTz+Vk0whKCgINpsNf//9t5z4vvnmmzIJKyamYiItvk/xvYWFhSE3Nxdff/019u/f75owP/HEE/jtt9+gUqnkJYJlZWVYunSpjK84Lo4RERERBapAmouK8/3yyy9y/7LLLpPtEcS8UMTgyJEjaNasmeu5a9euxb/+9S9YLBY5drGJRO4dd9yBjz76SCZqi4qKcPXVV8vxirmmmI/u2bMHzz//vJxzijieicmTJ8vYifmuSNSKxPJzzz0nH4uMjJSJbPE9i6Rv69at5XPERc+i5YMzsSz+v4n/B2JevWvXLnkrKo1feukl+f9DJMfF/9/KykoZQ0Ekg4koMLDilohIITEZFBUJ69atk8lKMQEUycS2bdvKxOLKlSsxY8YM+VxR5VBaWnrKc4pJ3oIFC7BmzRrX4hPLli1TNJ6QkBA5eVu1ahU6d+7c4GvF2JwJ0SuuuEKOWUwOGzP5KSo8xIRcEFUN4jXE9yEqBsQfFaIiRHx/u3fvlpNRkdgVSV0RJ1FBIaohxATWWVngnIjOnDlTPmf58uWyQkNsYpJNREREFMgCaS4qxlReXi6Tn2JuKa7WiomJkXNM0eu2PhETEZt+/frJsYgCAvG9iOc6q3Y//vhjOZ8U5xDJUJHsdSaYRTWsqF4+E6JSWcROfN8iaS0qdTt27Cirj8U4xJacnCyfu2nTJnkr4uBM2r733ntyLP/73/9kQnnLli3yarNLLrlEJqBFHMX3JIiktfj/Jb4HMT8mosDAxC0RkULi03RxWZogJkxikQYx2RLVAOITcPEJe/3Lt8SxUxHnS0lJkRMz52RZydcJ4pN4MQZRweCcvDm/duvWrXICK4gWBeJTevHc22+/HY1FTB7Fa4hqD1FtIL4HMYEXlbPOxK64hE5UhISGhsrKiauuukpWNmRnZ8vYPfvss7JqRBCTXGf1hjjf4sWL8fTTT8vkcFpaWqONm4iIiMgXBdJc1JlwFS0HxFxTjE8kM52POZfqERWtItkp3HDDDXJeKZ4vEtsiWSySuoIz+XnBBRfIuakgrggTiWfR4sC5GNzpEuMTFcfi/4cgKnd//PFH2Ybh999/x1tvvSUT0IKzWME5lg4dOrhiLloqiHGISmEx7xWxcj4m2jEIIjnvfE1n318i8n/8105EpJCYQImJWX3i8i9RIeqseKjfr0v09TqV+lUHYtIrKF0z8mRfKy75EsRlZfVXEE5KSkJjEYlZQZxfVNM6iaoCUTEgxiJ6pInViMVlamLiLCaj4tI9UYEhJuDikrUnn3xSPv/111+XPW5FwlZMeMUmnHPOOfJrPbWaMREREZE3CJS56KFDh2QVqrNfrNjqEz1mxVVcoresSIo6v8/64zm2stdZfSwqeJ1EsjY+Pv6U4xGtwP5J/e/NuaCaKDwQiWsx1xWVyM6ksDM2zrEcO8bmzZs3uC8qlUXlsUjoiqIG59VponUEEQUOVtwSEZ1GlUN9YvIk+oKJfmCiukF8en7sAgKnUv/TcpG8bKyvFZdqCWIiK/qAOYlK18bifA1xSZiopq0/mXZOTJ2TWVFF8P7772PFihWy8kBURIixiYm4s/+amDiLnmDikjJxOZtYfEFUL4iJufgaIiIiokAWKHNR0QrhVMljZ2Wx6A8rksNC/dZaolDg559/dvXUdSZs649FtEcQay6IwgKx7zyP8zEnZ8XsidQvXhAJXtG7ViRtxUJs4rzi/McmZJ1jObYVmKisFS0UnIv3isR0QkKCTIKLK9bEfFsk5p1XqRFRYGDilohIoWMnpKJ3qyAmeWJSJS4HE/2pnJRWKzQF8em+s/JBJD3FRFJUvzr7niklJq3ikrdjN9EzTEwmRdWHeI74o0F8/+JyNbGQgjNp26tXL5mY7dOnD4YOHSoXzDjvvPNkUtZZQSsqRA4fPizPJ/reisvKRL8wMeHt1q2b6zlEREREgSwQ5qLieWKRM0HMBUXbrfqb6B0riAXYxNVf4jW6d+8uj82ePVsmWUUcxOJqov3WM888Ix8TC5Q52w3s3btX7n/55ZdyTYabb75ZzmdFEthJvJawY8cOuWCYkv8nopLWmYwViWuRaBftGsQ5BGdlsHMsIrk8f/58uS/aPYiq2ltuuQXbt293/X91VtfOnTtX3rLalijwMHFLRHSGRBWpIBKZI0eOlAsiiAmjk5IFIZqKmHiKqlZnHzCROB0yZIisjj0dYgVckXw9dhMVDGI1X9GzzDnxFa8hYiAm0uLSsBdeeEFeGiZeV1TOir5eot/XwIEDZfsDMRZRcSBiJ9or9O3bV55LTLLFecT5xOrBYkI8fvz4JogSERERke/yx7moWJzWWRUrermKdRLqbxdffLEsHBDJWeciZWKRMTH33Lx5s5xnijiIFgPieaJYwNnPVlzdJWIi+tyKeaez2EAkbkVv3Hbt2sn5rSCSqGLeKtZncFYPn4ooSmjVqpXcFxWyYhwTJkxwVe8620eIebAoWBAefPBBGRvxOs4F1sT3UL+PsDM5LCqcxfdPRIGFiVsiojMkqkPFpEwscCAmhmIyKBKdzlV1RVsAT3rggQdw1113ycmmqLgQla6iFYHgrIA4W3fccQfefvttOfkVVQFi0iwmoqKHraiwFcREWLREuO6662RfM5HAFWMaO3asTPgmJibK502bNk1OvMWkWUxwxRjFeT/44AO5kjARERER+fdc1LkoWdu2bdG+ffvjHhfFAM7EpnORMjFf/OSTT9C/f385FxUJTpEMFXNIZ4JUJFVF2wKRDBaFA2KuKRYHmzJlCiZNmiSfI2IoFnsTFbxiX1xhJlpPOBeEU+Ldd9+V4xAL9ooCBpEkFjGo//9DJGL/+9//4rbbbpNzY9ECQdz+61//ksfrt2wQC8c5k8Ei4as0iUxE/kPl8OT1E0RE1CRMJpNcTVdMTMXkfcyYMXJiKyajb775pkyOOleoJSIiIiJqTJyLNg5RgXzrrbfKfbGQr0gEE1FgOdpNnIiI/IboqSUWRnD2yBKTZlE1IKpdBfbHIiIiIqKmwrno2RF9ft944w1XawlRdSuS30QUeNgqgYjIT4lLrcTlYKJXl5gki75Z4pIzcQmd6OVFRERERNRUOBc9c6KVmIhZUFCQXLT3/fffly0giCjwsFUCERERERERERERkZdhxS0RERERERERERGRl2HiloiIiIiIiIiIiMjLMHFLRERERHSWq6c//vjj6NOnDwYPHoxZs2b943N37dqFa6+9Ft26dcPFF1+MVatWNXj8k08+wZAhQ9CzZ095zurqajd8B0RERETkjZi4JSIiIiI6C9OmTcO2bdvw6aefYurUqXjnnXfw22+/Hfe88vJyuSBPu3btMHfuXIwePRr33nsvCgsL5eMLFiyQX/vss8/Kc23evBnTp0/3wHdERERERN4gIBcny88vd/tr6nQaWCw2t7+uL2KslGOslGOslGGclGOslGOslGOslImLC4O3qKqqwoABAzBz5kz079/ftZL6ypUr8dlnnzV47uzZs+UxkdTVaDTy2OWXX45JkyZh6NChmDBhgjzXfffdJx9bt24dbrnlFlmVGxwc7PE5Ld+fyjFWyjFWyjFWyjFWyjFWyjFWyjFWjTefZcWtm6hUnh6B72CslGOslGOslGGclGOslGOslGOsfE96ejqsVqtsbeDUu3dvWS1rt9sbPHfNmjUYOXKkK2krfPfddzJpa7PZsHXrVtluwalHjx6wWCzyNbwB35/KMVbKMVbKMVbKMVbKMVbKMVbKMVaNh4lbIiIiIqIzlJ+fj6ioKOj1etex2NhY2fe2pKSkwXMzMzMRHR2NKVOm4JxzzsFVV12F9evXy8fKysrk1zRr1sz1fK1Wi8jISOTm5rrxOyIiIiIib6H19ACIiIiIiHyVWDysftJWcN43m83HtVX44IMPcOONN8rWCvPmzZOtEH799dfjvrb+/WPPU/8yRHdWtGi1RyuF6eQYK+UYK+UYK+UYK+UYK+UYK+UYq8bDxC0RERER0RkyGAzHJVad94OCghocFy0SOnbsKHvaCp06dcLff/+Nn376SVbf1v/a+uc6UX9bwRO948xm9qtTirFSjrFSjrFSjrFSjrFSjrFSjrFqHGyVQERERER0huLj41FcXCz73NZvnyCStuHh4Q2eGxcXhzZt2jQ41qpVK+Tk5MiWCCIJXFBQ4HpMnFO0WxBfR0RERESBh4lbIiIiIqIzJCpoRS/aTZs2uY6JvrVdu3aFWt1wqi0WG9u1a1eDY/v27UNycrJ8rvgaZ89bQZxTnDstLc0N3wkREREReRsmbomIiIiIzpBoYzBu3Dg8/fTT2LJlCxYtWoRZs2bJPrbO6tuamhq5f80118jE7dtvv42DBw/izTfflAuWXXrppfLx6667Dh999JE8hziXOKdoofBPrRKIiIiIyL+pHA6HAwEmP7/c7a+p12vY30Mhxko5xko5xkoZxkk5xko5xko5xkqZuLgweNsCZSLJunDhQhiNRrng2MSJE+VjqampeOmllzB+/Hh5X1TUvvDCC8jIyEDbtm3xxBNPoG/fvq5zicXLPvnkE9nbdsyYMZg6dapsoeANc1q+P5VjrJRjrJRjrJRjrJRjrJRjrJRjrBpvPsvErZvwTascY6UcY6UcY6UM46QcY6UcY6UcY+WbiVtPYeLWezFWyjFWyjFWyjFWyjFWyjFWyjFWjTefZasEIiIiIiIiIiIiIi/DxC0RERERERERERGRl2HiloiIiIiIiIiIiMjLaD09ADp7L7zwNH799Zd/fPytt2agV68+is937723o2fP3rjlljsaaYRERETU6Bx2qMuLoCnNhaYkF+qaCsC1dIFD/ufad96pd0x1isePngsNz3vMMWtCO5jaD2j0b48CD+e0RERE5E5mqw3bD5fgUEElhnZMQGSIHt6Gi5P5QWPmiooKmEw1cn/x4t/x1VefY+bMT12Ph4dHQKfTKT5fWVkptFodQkJC4AlsYq0cY6UcY6UM46QcY6UcY3UWsXI4oKoqhbY0TyZn5VaXqNWUHoHKZvHkcGuHqNGh4Lb3AY376gG4OJl/Lk7mT3Na/txTjrFSjrFSjrFSjrFSjrHyj1gVV5qw6WARNhwslElbs9Uuj1/epyUu69PS6+azrLj1A0ajUW7OfbVajZiY2DM+n5gUExERkfuoaiplQlZXcQTagpyjyVlRSWupTWSdiEOtgS0iXm72kEhApQJUrrPW3bgOiDrb44412D/p487H6u1DBUtCW7cmbcl/cU5LREREjc3hcOBgYSU2HiiUydr9+RUNHo8xGtCrZQxGdUmCN+Is28/l5GTjyisvwa233omvvvoCY8aMxYMPPoLPPvsYc+f+iPz8I4iIiMSll47HzTffftxlZeKStfDwcOTn5+Pvv/+Uz7399rsxduyFnv7WiIiIfIvFBE1d5azWVTlbe19d88+Vkw6VCvawWNgiE2SC1ipu5X6CPA41lywg/8c5LREREZ1uCwRRWbvxYCGKKs0NHm/bLAw9W0ajZ8sYtIgJhapBIYN3YeJWYXbeVFc6fabsKsBsUV4mbtCqG/WNs2XLZnz00Wew2+347bd5+Oab/+Hpp19AcnJzrF69Aq+88h+cc865SE1NO+5rv/vuG9x2212444578O23X2P69BcxePBQV0UEERGRV7FZELzld+hydgNqjaxKrb3VNrgPzbHHtHBoam8bfJ2oJnWdQ3yd9gTnrHuORgOVuaZhSwO5nwdNRdHJhx0aBUdUAizh8a4kbe1tM0Cj/PJwIn+dzwqc0xIREdGJlFSZZZJ248EibM8qbjDvEXOSLs2jZLK2R8sYr+xl+0+YuFUwyX32x83IyCtz6+t2SAjHlEu7N9pk96qrrpUTWkFUJDz++FT06dNP3h837gp8/PFM7N+/94ST3HbtOmDChJvk/q233oE5c/4nn9u1a/dGGRsREVGjcDigP7AJxr++gKbsCLyR3RBam4ytVzVri6xtdeDQB3t1PzDyXf4ynxU4pyUiIiLn/OZQYaVsf7DxQBH2HdP7PzpULytqxdYpORJ6rW9epcbErQJeXDGtWGLi0V4dYjXe7du3YcaMd3Dw4H7s3r0LhYWFsnLhRJo3T3Hth4bWViRYrVY3jJqIiEgZTXGOTNjqD22R920hkajufh4cOgNUditgs0FltwFys7r25a18zNrwMdsxzznhMStUttrb+seg0cMqkrENkrO1CVpHEBfVIs/wh/mswDktERFR4DJb7diZXYINBwqx6VARCitMDR5vHWeU/Wp7topBSy9vgaAUE7enIP4ni0qBs7207HQraBr70jK9/mgZuOgD9tZbr+Hiiy/F0KEjcM89D2DSpDv/8WtPtHqv+GSDiIjI01TmaoSs+wnBmxfIxKloYVDdYyyqel8iK1iJyH/ms7Vj4JyWiIgokJRWmWWSViRrtx3TAkFU0XZOjpTJ2h4toxEVaoC/YeJWATHhDNJpzuocep0Gai+ZF/7443f4179uxXXX3Sjvl5eXo6iokBNXIiLyHQ47DLtXInTFV9BUlcpDphbdUDlkAmyRiZ4eHZHX8bf5rMA5LRERkf+2QHD2q913pBz1f7NHhehlkrZXqxiZtNVrz25+4+2YuA1AERERWLdujVyMoaqqCh988K68TMxiabjKHhERkTfSHtkP4/LPoMvdI+9bI+JROXgCzK16eHpoRORGnNMSERH5j4LyGszbnCUra0/UAqGn7FcbjVaxRr9ogaAUE7cB6P77/w8vvvgMJk68DlFRURg5cjSCgoJlXzAiIiJvpaouQ+iqbxG0YxlUcMChNaCyzyWyNQI0x18CTUT+jXNaIiIi32ex2TF/UxZ+2nhI9rAVdBo1ujSPlMnaHi2iEW30vxYISqkcAXgtUf4xK825A1eJVo6xUo6xUo6xUoZxUo6xcmOs7DYEb12MkDXfQ22ukodqOgxC5cCrYDdGw5/wfaVMXBwXefPEnJbvT+UYK+UYK+UYK+UYK+UYK+UYq8aP1ZbMIsz+ay9yS6vl/bTECFzQvblsgWA4yxZP/jKfZcUtEREReS1d1g7ZFkFbdFjet8S2QMWQG2BNSvX00IiIiIiI6AzbInyxYh/W7i+Q9yNC9LhuQGsMat8soNogKMHELREREXkddVkBjCv+B8PetfK+PciIyv5XoKbTMECt9vTwiIiIiIjoDNoi/Lo5Cz9uqG2LoFYBY7okY3yflggxMEV5IowKEREReQ+rGSEb5iFkwy9Q2SxwqFSo6TISlf3GwxFk9PToiIiIiIjoDGzNLMKn9doidEgIx8Qh7dAihnP8k2HiloiIiDzP4YB+3zoY//4fNOW1l0yZk9JQMeR62GJbeHp0RERERER0BgoratsirNlX1xYhWIdrB7bBOWyLoAgTt0RERORRmsIsGP/6HPqsHfK+zRiNykHXwtSuH8DJHBERERGRz7Ha7Ji/JQs/rT8Ek9Uup/WiLcLlbItwWhgpIiIi8giVqRIha39E8JbfoXLY4dDoUNXzfFT1uhjQGTw9PCIiIiIiOgNbDhXhoz92I6fkaFuEmwa3Q8tYtkU4XUzcEhERkXs57AjauRyhq76BurpcHjK17o2Kc66FPaKZp0dHRERERERnoLDChC9X7sPqvfnyfniwDtcMaI3BHeKh5pV0Z4SJWyIiInIbbe4eGJd/Bt2R/fK+NTJR9rG1tOjq6aEREREREdEZtkX4bcth/LD+oKstwujOSbi8byuEsi3CWWH0iIiIqMmpKktgXPUNgtL/kvftuiBU9bsM1V1HAxpOR4iIiIiIfNG2rGLM/msPsuvaIrSPD8dtIzogKSLE00PzC2pPD4DO3t1334pnnnnyhI8tXPgrxo4dDrPZfMLHc3KyMXhwH3kriP0NG9ad8LniuHhcqSVLFqG4uEjuf/TR+7j33tsVfy0REfkJmwX6dfMQ/cUjrqRtddoQFE2Yhuoe5zNpS0QS57NERES+pajChHd+34n//LJVJm3Dg3S4fVgHTBnXHa3iwjw9PL/Bv5b8wKhR5+GDD96FxWKBTqdr8NiSJb9j2LAR0Ov1is7100+/ITw84qzHlJubg6eeehRz5vws71977Q248sprzvq8RETk5Swm6PL2QpezG7rsdOhy90BlrU22WJq1QcWQG2BNaOvpURKRl+F8loiIyHfaIizYKtoiHEKNxSbbIozqlIQr+rVEqKHh73A6e0zc+oHhw0fhzTdfwbp1qzFw4GDX8crKCqxZswrTp7+p+FwxMbGNMiaHw9HgfkgIS+SJiPyRylQFXU4GdDm7oMveBe2RfVDZbQ2eYw+NREX/K2BKGwyoeLEPER2P81kiIiLvt+NwCT79aw8OF1fJ++3iw3DT4HZozQrbJsPErR+IiopCnz79sWzZ0gYT3eXLl8lqgxYtWuLJJx/BunVrYTLVoHXrNnjggYfRrVuP484lLh17660Z6NWrj5woT5v2Ilas+EtOgC+5ZFyD527Zsgnvvfc2du9Oh0qlQo8evfDoo08hNjYWV155iXyOuH388any0rWNG9fjnXc+kMe3bduCd999ExkZuxAVFY0JE27EuHFXyMeeeeYpGI1hyM/Px99//4mIiEjcfvvdGDv2wiaOJBERnYqqqsyVpJWJ2sJDUB2T3LCFRsGSlFq7JaZCk5ACs6Xhc4iI6uN8loiIyHsVV5rw5cp9WLknX94PC9LhmgGtMSQ1HmpRcktNhmUvSog/SC2ms9xqTu/5x/wRfCqjRo3BX38tg81ma9CTa+TI0Xj22Smw2ex4//2PMWvWF4iLa4ZXX/3PKc85ffpLOHTogJycPvjgw/jqqy9cj1VUVOCRRx5Av34D8Nln3+C1195BVlYWPv/8Y/n4zJmfum7FGOo7cGA/Jk26S06MZ836HDfffDveeecNOVF3+u67b5CamobZs7/G0KEjMH36i/I1iYjIvdTlBTDs+hvGpbMQ9eVkxH58LyJ+exshWxZCV3BQJm1t4c1k39qyEbeh8PrpKLrpDZSPuRs1XUbCFtOcVbZE3oDzWc5niYiIzqAtwvzNWXj4q3UyaStStCM7JWL6NX0wNC2BSVs3YMXtqTgciPz+eehyM9z6spbE9ii57EnIZiEKDB06XE5MN2/eKKsLxKRw7dpVchIZH58o+4I1axYvnzt+/FV4+OH7T3o+8fVLly6S1QpiwilMnHgrXnvtZbkvKh1uuulWXHPNBFmdkJSULF9j587t8vHIyCjXrcEQ1ODcc+f+gA4dUnHHHffI+y1atJKT3y+/nC2/D6Fduw6YMOEmuX/rrXdgzpz/Yf/+vejatftpxZGIiE6DwwFNSW5tb9q6ilpNReFxT7PGpMCS2MFVVWsPrf2ZT0ReivNZzmeJiIhO087sEny6fA+y6toitG0WholD2BbB3Zi4VcIHPkAICQnFoEGD8ccfi+VEd/nyP5CYmIS0tI5o27YdFi1aIC/nOnjwAHbtSofdbj/p+TIzD8pqh/btO7iOdezYybUvLjU7//yL8PXXXyAjY7ecqO7Zs1vRRPTAgQPo1Klzg2Ndu3bDTz9957rfvHmKaz801ChvrVarwmgQEZEidrtsdaDL3u1qf6CuLmvwFIdKDWtcq3qtDzrAEVT7c5mIfAjnsxLns0RE5G1sdgcqTBZU1FhRUWNBeY3Yr7tvssJ+mlewNIb8shqs3V8g941BWlzTvzXOZYVt4CVuTSYTnnnmGSxcuBBBQUG4+eab5XasG264AWvWrDnu+Pjx4/HSSy81OPbkk08iPj4e9913X+MMUqWqrRSoWxH7TOn1apjNJ59cNqDVK65OcBo9eizeeGM6HnzwEbn6rlidV0xoH3zwHpSXl8tLvM4551y5Wu8TTzx82osyaLVHVwfMzz+CW2+9AampHWU/sksuuUz2Dtu+fespz3miFYHFpW9iczp2NeFjx0JERGfAZoX2yP6jPWpzdkNtrm7wFIdGB0t826OJ2vh2gL5hpRkR+RjOZ48OifNZIiJqQmarvTbpanImYOsnY0UiVuw3PFZl9s4P9cRv8BGdEnFlv1YwBh3/O40CIHE7bdo0bNu2DZ9++imys7MxefJkJCUlYezYsQ2e9/bbb8vJmdPmzZvxwAMP4LrrrmvwvJkzZ2LOnDm49957G3egYsKpM5zdOXQawNFwle3GNnDgOXjppWewYcM6rF+/FpMm/RsHDuzDpk0bMHfu73LRB+H77+eccuIoFoDQarXYuXMH+vTpJ4+JhRec/vxzKcLCIjBt2huuY99++7VrX1xudrJzizHVt337FnmciIgauaK24AB0mduhz9ohL5NWHZO4seuCGrQ9sDZrDWg4MSPyO5zPymOczxIR0ekSFa8ZuWUorbGguMLkqoZ1VsaWm2oTsWIzWU/jA85jhOi1srpVLPwlEqVhQVqEGnTQqN1f5Spes1+bWLZFCOTEbVVVlUyyimRr586d5ZaRkYEvvvjiuMRtZGSka19c7vT666/j1ltvRdeuXV39qx5//HGsWrUKiYmJCFTik/9zzx2Od955HW3atENKSgscOZIHtVqNxYsXYPDgobJn16xZ78vnm83/XHUhLucSq96KiofHHpsqe4DNmlW7gq4gVvfNy8vFunVr5CVson/YsmVLkJZWe/lZUFCwvBWXm4lVdOu77LIrMWfOV3j//Xfl5WmiqkFMvkVlBRERnWWP2tLco4nawzugNtX2pHKyB4UdraYVidqYFoCai4cRkXfgfJaIiLypevbv3XmYvyULOSUNr1I7GZFnFYlXuRkaJmKNBrF/9FjtVnvcEwla8n4eS9ymp6fLHk89e/Z0HevduzdmzJghL4cSk7MT+f7771FaWorbbrvNdUys/iraLojHHnvsMQSy0aPPw/z5c3HffQ/K+2IBh3//+1F88smHcmKZktIS99//f3j++amy4kD09vonYuXd118Xl6rdg7CwMFxxxTV4993aioQRI0bLhSOefHKyrEYQ/cLuvfcBfPTR+3ICLZLt5513Pp566jHcdVfDthUJCQmYNu11/Pe/b+Krrz5HfHwC7r33QVx44SVNHB0iIv+jriyBLqsuUZu1HZqKogaP2/UhsCSnwdy8MyzNO8EWlXTaly4TEbkT57NERORJZdVmLNqeg0XbslFWU3v1d7BeIxfnElWxDRKx8rY2QetMxIboNSe9aoPodKgcHmq0tGDBAjz77LP4+++/Xcf27t2LCy64ACtXrkR0dPRxXyOGKqpxL7/8ctx+++0nPK/oh9uvX7+T9rjNzy+Hu+n1GpjNTXtpmb9grJRjrJRjrJRhnLw/VipTFXTZ6dBl7YA+czu0xYcbPO5Qa+VK7pbmnWWy1tqsFaDWwJP4vlKOsVImzssu21O6boNw1113YcmSJQ2OicKF4cOHy/OIVmLz58+Xx0ePHo1HH30UISEhXjGn5ftTOcZKOcZKOcZKOcZKOcbqqJySKvy65TCW78qDpa5neYzRgLFdkzG0YwIijQbGSiG+rxpvPuuxitvq6urjmvo77//TJU+rV69Gbm4urrrqKreMkYiIyONsFuhy97iqarV5+6ByHO2d5YAK1riWsKTUJmotCe3Pvo8lETXJug3OQoXp06dj4MCBrmMRERHy9p133pEL8n7wwQeyYEEkbV977TW5+C4RERE1PvH7dlduGeZvzsLGA4VwVja2jjPigu7N0a9NHFsYkEd5LHFrMBiOS9A674tKhX+q0j333HMb9Lw9EzqdKFuHW2m1nq128iWMlXKMlXKMlTKMkxfEymGHOv8QtIe2QXtoO7SH049bUMwWmQBri86wtugCW0onOIKM8rj41Xb8Oueex/eVcoyV7zmddRvEXFe0+BLrNMTFxR13rmXLluHqq692reNw7bXX4uuvjy6WRURERI3DZndg7b4CmbDdV+8Klp4to2XCNi0xgu0OKLATt/Hx8SguLpZ9bsVqr0J+fr5M2oaHh5/wa5YvX4577733rF/bYvFMuTbLxJVjrJRjrJRjrJRhnNwcK4cD6rIjsu2BbH8gFhSrqWjwFHtwBMzNO8GcUtun1h52TD9HH/h/xveVcoyVbzmddRv27dsn/whMSUk54blEcYIoVLj44ovlfdF6oWPHjm74LoiIiAJDtdmKZel5+G1LFgoqTPKYTqPC4A7xOL9bcyRFnbg9EVHAJW7FJFQkbDdt2oQ+ffrIY+vXr5cVBidamKyoqAiZmZlyIkxEROTLVFWldYuJ7YBeLChWXtDgcbsuSC4o5uxTa4tO5oJiRF5KFB5ERUU1aAEWGxsr+9WWlJQ0WLdBJG6NRiMeeeQR2RJBLHAl1mUYOnSofFwcF/f79+8v73fo0AHvvfeeB74rIiIi/1JUYcLCbdlYsiMbVXUfkotFxUZ1TsSoLkmICPbG69aIPJi4DQ4Oxrhx4/D000/jxRdfxJEjRzBr1iy89NJLrkmwWPnV2TZBXHIm2is0b97cU0MmIiI6Ow47jH9+huBtixseVmtgSWhXb0Gx1oDGY7+iiaiJ1m0QiduamhoMHjxYLrT7+++/y8XKRDsEUbxw6NAhJCYm4j//+Y+s4hUL+Yr9559/3q3fExERkb84VFgh2yGs3JMv2yMICRHBOL97MoZ0iIeebarIy3n0r8LHHntMJm5vuukmWX0gKgzGjBkjHxMTWpHEHT9+vLxfWFgoWyiwxwgREfls0nbJRwhOXy7vWmJbuBK1lqRULihG5KNOZ92Gu+++GzfccINrMbK0tDRs374d33zzDVq3bo0nnngCn3zyCbp37y4fF8UN119/PSZNmoRmzZp5fN0G9mBWjrFSjrFSjrFSjrEK7FiJBcc2HyrCLxsysSWz2HW8Y1IELu7VAr1ax0B9Br9A/TFWTYWx8pPErai6ffnll+V2rF27djW4f8EFF8jtVD777LNGHSMREVFjJm0dKhXKR98FU/sBnh4VEbl53QbRDsyZtHVq06YN9uzZI6txxUJnIpnr1KlTJ9knNzc394SJW0+s28AezMoxVsoxVsoxVsoxVoEXK4vNjpUZRzB/SxayiqrkMZGf7d8mDud3b462zcLkMavFjkCPlTswVo2D12ESERG5LWmrRvnoO5m0JfIjp7Nuw6OPPiqvHnO2BnMubiZ62ToTsyKJ27lzZ7kvkrkCW4UREZG3sTscEDWr3nBVdEWNBUt25MgetiVVdVe96DQYlpaA87omIy684RUwRL6EiVsiIqKmYrcjbOlHCGLSlshvnc66DSNGjMBDDz0kFx/r2bMn5s6dK5O8opetWKhsyJAhmDJlirwvLvOcOnUqLrzwwgYLnBEREXnDQl9Pfb8R5TUWhBq0MAbpEBakhdGgO7ovb3Uwuh4Xj2kRatBBo26cZO+Rsmr8tuUwlqXnwmStraKNCtXjvC7JGN4pUY6NyNepHGJWGGDy88vd/pp6vYZl4goxVsoxVsoxVsowTo0Yq+OStqI9Qu1K8YGG7yvlGCtl4uJqL3X0pgXKROJ24cKFct2GW265BRMnTpSPpaamNli3Yc6cOfjwww+RnZ2N9u3byzUf+vbtKx8rLS2Vi5EtW7ZMVjCNHDkSkydPRmhoqFfMafn+VI6xUo6xUo6xUo6xatpYfbf2AH5Yf+iMXzNEr3Uld+snfZ3J3drj2rrEb+1z9NqjV7HsySuTC46t3V8AZ0arRUwoLujeHAPaxkGraXjFS2Ph+0o5xqrx5rNM3LoJ37TKMVbKMVbKMVbKME6NFCuZtP0QQel/BXzSVuD7SjnGyjcTt57CxK33YqyUY6yUY6yUY6yaLlZ2uwMPfrkGhRUm/GtIO7RPCEdFjVVW34qWBXLfVLtfXmOtO1a7X2W2nvE4DVq1TOBq1SrkldW4jndLiZIJ287JkU3etoHvK+UYq8abz7JunIiIqDEdk7QtG3M3zO36eXpURERERERnbdvhYpm0FW0IhqQmNKiEPRWb3YFKmdStl+g1WVFeLW6PJnrlY6ajSV+7A7IVgqnCJM8jkreD2jeTC46lRJ/4qhQif8HELRERUWMmbZfMRNCuv5m0JSIiIiK/syw9T96KxOnpJG0F0ds2PFgvN6XEReJVZpsriSuqdlNijIgMUX4OIl/GxC0REVFjYNKWiIiIiPyYqIRdv79A7g9NS3DLa4r2B6K6V2zxEcFueU0ib9I0HZuJiIgCCZO2REREROTn/t59BFa7Ay1jjWgVa/T0cIgCAhO3REREZ4NJWyIiIiLyc6JlwbL0XLk/zE3VtkTEVglERESNl7Q97x6Y2/b19KiIiIiIiBrV/vwKZBZVQqcRC4PFeXo4RAGDiVsiIqIzTdou/gBBu1fAodbUVtoyaUtEREREfshZbdundSxCDTpPD4coYDBxS0REdLrsdgQvmAk9k7ZERERE5OdMFhtW7Dni1kXJiKgWE7dERERnUGnLpC0RERERBYK1+wtQbbYhLsyATsmRnh4OUUDh4mRERERKsT0CEREREQVom4RzUxOgVqk8PRyigMKKWyIiIqVJ20XvIyhjpUzaVl14H8wtenl6VERERERETSavtBo7s0sh0rVDUuM9PRyigMOKWyIiolOx2xokbcvOuwfWdqy0JSIiIiL/9ueu2mrbLilRiA0L8vRwiAIOE7dERESnTNp+0CBpa27Tx9OjIiIiIiJqUna7A3/uypP7w7goGZFHsFUCERHRKSttV9Ulbe+FuU1vT4+KiIiIiKjJbcksRnGlGcYgLXq1ivH0cIgCEituiYiIToRJWyIiIiIKYM5Fyc5pHw+dhukjIk/gvzwiIqJjMWlLRERERAGsrNqMDQcL5T7bJBB5DhO3RERE9TFpS0REREQB7q/dR2CzO9A6zoiUmFBPD4coYDFxS0RE5MSkLREREREFOIfD4WqTwGpbIs/i4mRERETOpO3vMxC0Z3Vt0nbsfTC37uXpURERERERudXeI+U4XFwFvVaNge2aeXo4RAGNFbdERERM2hIRERERSc5q235tYhFiYL0fkSfxXyAREQU2mbR9D0F71tQlbSfB3Lqnp0dFREREROR2NRYbVu7Jl/vnprJNApGnseKWiIgCF5O2REREREQua/bmy+Rts/AgdEyK8PRwiAIeK26JiChwk7YL30PQXiZtiYiIiIiEZbtq2yQMTUuASqXy9HCIAh4Tt0REFHDUlcUIW/QB9Fnba5O250+CuRWTtkREREQUuHJKqrArpwwiXzukQ7ynh0NETNwSEVGg0e9di7Cls6A2VcKh1aPsvHuYtCUiIiKigLcsPU/edkuJRrTR4OnhEBETt0REFDDMNTD+9QWCdy6Tdy1xrVA++k7YopI8PTIiIiIiIo+y2R1Yvrs2cTssjYuSEXkLJm6JiMjvafP2Iuz3GdCW5sEBFap7XYjKfuMBDX8NEhERERFtPlSE0iozwoN06Nky2tPDIaI6/IuViIj8l92GkPVzEbL2R6gcdtiM0SgfdScsyWmeHhkRERERkddYll67KNk5HZpBq1F7ejhEVIeJWyIi8kvqsnyEL5oBXU6GvF/TfgAqht4EhyHU00MjIiIiIvIaJVVmbDxYKPfZJoHIuzBxS0RE/sXhgGHX3zD+ORtqSw3s+mBUnHsTTKmDPD0yIiIiIiKv89fuPNgdQLv4MCRHs8iByJswcUtERH5DVVMJ47KPEbRnjbxvSeyAslF3wB4e5+mhERERERF5HYfD4WqTMJTVtkReh4lbIiLyC7qsHQhb/AE0FUVwqDWo6nsZqnpdBKjZo4uIiIiI6ER25ZQip6QaBq0a/duy2IHI2zBxS0REvs1mRejq7xC8cT5UcMAaEY/y0XfBGt/G0yMjIiIiIvJqS3bkyNt+beMQomeKiMjb8F8lERH5LE3RYYT9PgO6goPyfnWnYag45zpAH+TpoRERERERebVqsxUrM/LlPhclI/JOTNwSEZHvcTgQtG0xjCu+gspqhj3IiPLht8DcprenR0ZERERE5BNW782HyWJDQkQwOiSEe3o4RHQCbPxHREQ+RVVVivB5ryHsz9kyaWtu0RXF17zIpC0ReYzJZMLjjz+OPn36YPDgwZg1a9Y/Pveuu+5Campqg23p0qWux7/44gsMGzYMvXr1wqRJk1BSUuKm74KIiALNsvQ816JkKpXK08MhohNgxS0REfkM/YFNCFvyIdTVZXBodKgceDWqu40CVPwckog8Z9q0adi2bRs+/fRTZGdnY/LkyUhKSsLYsWOPe+7evXsxffp0DBw40HUsIiJC3s6fP1+eS2ytW7fGE088gWeffRavvfaaW78fIiLyf4eLq5CRVwa1SoUhqfGeHg4R/QMmbomIyPtZTLItQvC2xfKuNSYFZaPvgi2muadHRkQBrqqqCnPmzMHMmTPRuXNnuWVkZMjK2WMTt2azGVlZWejatSvi4o5fuVuc47bbbsN5550n7z/yyCN45plnYLPZoNFo3PY9ERGR/1uWnitve7WKQWSI3tPDIaJ/wBIlIiLyatr8A4ia85QraVvV/TwUXzGVSVsi8grp6emwWq3o2bOn61jv3r2xefNm2O32Bs/dt2+fvBQ1JSXluPNUVFRgx44dGD16tOtY37598csvvzBpS0REjcpqs+Ov3bVtEoZ34qJkRN6MiVsiIvJODjuCN8xD5LfPQFucA1tIJEoueQSVgycAWlYFEJF3yM/PR1RUFPT6oz+XYmNjZd/bY/vTisSt0WiUlbSiF+4VV1yBZcuWyccyMzPlbVFREa655hr5uGi5UFZW5ubviIiI/N3GQ0Uoq7YgIliHnq1iPD0cIjoJJm6JiMjrqMsLEfHTyzCu/Boquw2mNn1QfO0LsKR08fTQiIgaqK6ubpC0FZz3RWuEYxO3NTU1Min74YcfYujQoXKxsq1bt6KyslI+R/S0Fe0S3nzzTdlyQSR5iYiIGtOfdW0SRG9brYZpISJvxh63RETkVQwZq2Bc9gnUpio4tAZUDLkeNR3PBbjSLRF5IYPBcFyC1nk/KCiowfG7774bN9xwg2sxsrS0NGzfvh3ffPMNLr/8cnns9ttvx8iRI+X+Cy+8gHHjxiEvLw/x8ccvHKPTadz6o1GrZcsGpRgr5Rgr5Rgr5Rirf1ZUYcKmQ0Vyf1TXZMbqNDBWyjFWjYeJWyIi8goqczWMf85G0K6/5X1LfFuUjboT9kiucktE3kskVIuLi2WfW61W62qfIJK24eHhDZ6rVqtdSVunNm3aYM+ePa7FysR9p9atW8vb3NzcEyZuLRYb3M1sdv9r+irGSjnGSjnGSjnG6sSWbMuGwwF0SAhHbKgBVquNsToNjJVyjFXjYE08ERF5nDZnN6K+flImbR0qFSr7jEPJZU8waUtEXq9jx44yYbtp0ybXsfXr16Nr164yUVvfo48+iscee+y4xc1EsjYpKQnNmjWT95327t0rFzMTjxEREZ0th8OBZXVtEoamcVEyIl/AilsiInI/mxXaI/uhy06HPnsXdJlboXI4YAuPk1W21sT2nh4hEZEiwcHBsp3B008/jRdffBFHjhzBrFmz8NJLL7mqb8PCwmQF7ogRI/DQQw+hf//+6NmzJ+bOnSuTvKKvrUjQTpw4EW+99RaaN2+OmJgYec5Ro0a5qnGJiIjOxq6cUuSV1SBIp0H/tvzdQuQLmLglIqKmZ7NAl7dPJmp1h9Ohy82AytqwJ2RN6jmoOPdGOPTBHhsmEdGZEFW0Isl60003wWg04r777sOYMWPkY2IhMpHEHT9+vDw2depUvPfee8jOzkb79u3lImUiUSvcfPPNMJlMckGyqqoqmegV5yUiImoMf9RV24qkrUjeEpH3UzlErXyAyc8vd/tr6vUa9vdQiLFSjrFSjrFyc5ysZuhy99QmakVFbe4eqGyWBk+xB4XBkpQKS1IazM07wRZTm7jwFXxPKcdYKcdYKRMXF+bpIQTknJbvT+UYK+UYK+UYK+UYq+NVmay497NVMFvtmDquB9on1PZhZ6yUY6yUY6wabz7LilsiIjp7FpOsohXVtPrsdGjz9kFltzZ4ij04Aubk2kSt2GzRSYCKrdaJiIiIiJraqr35MmmbFBWCdvH8AJTIVzBxS0REp01lroYuZ7er9YE2/wBU9oafqNpCo2qTtMl1idrIBECl8tiYiYiIiIgClXNRsmFpCbKvOhH5BiZuiYjolFSmSuiy6xK12XWJ2mM67diMMa4krTk5DfbwZkzUEhERERF5WGZRJfYeKYdGrcI5HZp5ejhEdBqYuCUiouOoaspre9MerkvUFmRChWMSteHNYBY9auuStfZwrkxLRERERORtlu2srbbt2TIaEcF6Tw+HiE4DE7dERCSpy/IRtHUBQg/tgLYo67jHrZEJrv60IllrN0Z7ZJxERERERKSM1WbHXxl5cn9oWoKnh0NEvpS4NZlMeOaZZ7Bw4UIEBQXh5ptvltuxbrjhBqxZs+a44+PHj8dLL70k9z/55BN89NFHqKiowPnnn48pU6YgODjYLd8HEZGvE60PIua+AnV1meuYNSqpQY9ae2ikR8dIRERERESnZ8OBQlTUWBEVoke3FBZeEPkajyZup02bhm3btuHTTz9FdnY2Jk+ejKSkJIwdO7bB895++21YLBbX/c2bN+OBBx7AddddJ+8vWLAA77zzDqZPn46YmBg89thjcv+pp55y+/dERORrdJnbEf7rm1BbamCLa4GKXpfIRK0jJNzTQyMiIiIiorPwR92iZINT42WPWyLyLR5L3FZVVWHOnDmYOXMmOnfuLLeMjAx88cUXxyVuIyOPVnnZbDa8/vrruPXWW9G1a1d5bPbs2bjpppswfPhweV9U8d5yyy14+OGHWXVLRHQS+j1rEP77DKjsVpiTO6L60odgVhk8PSwiIiIiIjpLhRU12JpZLPfZJoHIN6k99cLp6emwWq3o2bOn61jv3r1lNa3dbv/Hr/v+++9RWlqK2267zZXI3bp1K/r06eN6To8ePWSFrngNIiI6saCtixC+4F2ZtDW17YvSi/4NGEI8PSwiIiIiImoEy3flyeWF0xIjkBDBojYiX+Sxitv8/HxERUVBrz+6omFsbKzse1tSUoLo6ON7rzgcDnz44Ye48cYbERoaKo+VlZXJr2nWrJnreVqtVlbp5ubWXhJARET1OBwIWfM9Qtf9JO9Wdx6BinNvBNQe+yyPiIiIiIgakd3hwLJ0LkpG5Os8lritrq5ukLQVnPfNZvMJv2b16tUyGXvVVVe5jtXU1DT42vrn+qfzEBEFLLsdxmWfInjHUnm3su9lqOo7DlCx3xURERERkb/YmV2C/PIaBOs16Ncm1tPDISJfS9waDIbjEqvO+0FBQSf8GrEI2bnnntug5604T/2vrX+uf+pvq9Np3J6j0Go17n1BH8ZYKcdYKcdYAbCaEbLgv9DtWQsHVKgZMRHW7qNQ/2Mvxkk5xko5xko5xoqIiIgag7PadmC7ZjDoOL8g8lUeS9zGx8ejuLhY9rkVrQ2c7RNE0jY8/MQrmS9fvhz33ntvg2MiiSuStwUFBWjbtq08Js4p2i3ExcWd8DwWiw2eYDZ75nV9EWOlHGOlXCDHSmWqQvj8N6DLTodDrUXZ6DthbtcPOEFMAjlOp4uxUo6xUo6xIiIiorNRabJi7b4Cuc82CUS+zWMNDTt27CgTtps2bXIdW79+Pbp27Qr1CfosFhUVITMzUy5gVp94rvga8bVO4pzi3GlpaU38XRAReT91ZQkif3gR+ux02HVBKL34/2qTtkRERERE5HdWZByBxWZH8+gQtIkzeno4ROSLiVvRxmDcuHF4+umnsWXLFixatAizZs2SC485q2+d/WuFjIwMWVnbvHnz48513XXX4aOPPpLnEOcS5xR9cP+pVQIRUaDQlOQi8vvnoC08BHtwBEovexyW5p08PSwiIiIiImoiy9JrF2oflpYAFdeyIPJpHmuVIDz22GMyyXrTTTfBaDTivvvuw5gxY+RjgwcPxksvvYTx48fL+4WFhbKFwol+6Fx44YU4fPgwnnrqKdnbVpzj4Ycfdvv3Q0TkTbRH9iPil1egri6HLbwZSi55GPaIeE8Pi4iIiIiImsjBggocKKiARq3COe059yfydSqHw+FAgMnPL3f7a+r1GvasU4ixUo6xUi7QYqXL3IbwX9+C2lIDS2xL2R7BERJxyq8LtDidDcZKOcZKOcZKmbi4ME8PISDntHx/KsdYKcdYKcdYKRfIsZr91x4s3JaNfm1iMWnMqa+0C+RYnS7GSjnGqvHmsx6tuCUiosZnyFiNsEUzoLLbYE7uhLIL7odDz9YxRERERET+zGy14++MI3Kfi5IR+QcmbomI/EjQ1kUw/vkZVHDA1LYvykbfCWh0nh4WERERERE1sQ0HClBpsiLGaEDX5lGeHg4RNQImbomI/IHDgZA13yF03c/ybnWXkagYcgOg9tgalERERERE5EZ/1C1KNiQ1Hmo1FyUj8gdM3BIR+Tq7DcZlnyJ4xx/ybmW/8ajqcynAFWSJiIiIiAJCQXkNtmeVyP1zU7koGZG/YOKWiMiXWc0IX/geDPvXw6FSoeLcm1DTZYSnR0VERERERG60LD0XYuX5TsmRaBbO9S2I/AUTt0REPkplqkT4/Degz94Fh1qLsjF3wdy2r6eHRUREREREbmR3OPDnrjy5P4yLkhH5FSZuiYh8kLqyBBFzp0NbmAm7PhhlFzwAS3JHTw+LiIiIiIjcTLRIKKwwIUSvRZ/WMZ4eDhE1Iq5aQ0TkYzQluYj87tnapG1wBErGPc6kLRHRaZg8eTL+/PNP2Gw2Tw+FiIioUdokCIPax0Gv1Xh6OETUiFhxS0TkQ7RH9iPil1egri6HLbwZSi55BPaIZp4eFhGRTzEajXjiiSdgsVgwZswYXHDBBejfvz9UXNSRiIh8TEWNBev2F8j9oWyTQOR3mLglIvIRusxtCP/1LagtNbDEtULpRf+GIyTC08MiIvI5U6ZMwZNPPom1a9fit99+w//93//J4+effz4uvPBC9OjRw9NDJCIiH+JwOLDhQCFySquh16ph0GrkrV6jlhWwcr/+cbnV7qvP8kPDFRlHYLU70DImFK3jwhrteyIi78DELRGRDzBkrELYovehsttgbt4JZeffD4eeq8USEZ0pUV3br18/uT300EP48MMP8fHHH+Pzzz9HUlISrrrqKkycOBEGg8HTQyUiIi9mtzsw++89WLQ954y+XqdRQafRwHBMQlfc12mPPy6SwSIBrKt7zqLt2fI8rLYl8k9M3BIRebmgLQthXP4FVHCgpl0/lI+6A9DoPD0sIiKfVllZiaVLl8qK27/++gvx8fH417/+Jdsm5Ofn45VXXsGaNWvw0UcfeXqoRETkpcxWO95bko61+wog6mb7tol1HTdbbTDbxK0dJsvRfXHcYnO4ziH2LTYrqsxnPg6R/B3Unu3TiPwRE7dERN7K4UDImu8Quu5nebe66yhUDL4eUHNdSSKis3HXXXdhxYoVCA8Pl+0RZs+ejW7durke79ChA8rKymQfXCIiohOpNFnx+m/bkZ5TCq1ahbtGpqF/2zjFVbq1iVxbXTLXDpNI6Mrbhklf52POffGYeI6l7lY8r1+bWBiDWNhB5I+YuCUi8kZ2G4zLPkHwjmXybmX/y1HV+xJxba+nR0ZE5PNiY2Px/vvvn3RBsj59+mDOnDluHxsREXm/4koTps3bhsyiSgTrNXjwvM7olByp+OvVahWC1BoE6TRNOk4i8n0s2yIi8jYWE8J/e0cmbR0qFcqH/QtVfS5l0paIqJE899xz2Lt3L+bNm+c6ds899+B///uf635cXBzatm3roRESEZG3yi6pwjM/bJJJ24gQPZ68pPtpJW2JiE4HE7dERN7C4YBh9wpEfzkZhv3r4dDoUDb2PtR0Hu7pkRER+ZXXX38dM2bMQEhIiOuYqL7973//i3fffdejYyMiIu+1J68Mz/64CQUVJiREBGPquO5oGWv09LCIyI+xVQIRkRfQ5mbA+NeX0OXtlfdtxmiUj74TlqQ0Tw+NiMjvfPfdd3jjjTdkOwSnG2+8EampqXj44Ydl9S0REVF9mw4W4e3fd8i+sm3iwvB/F3RGeLDe08MiIj/HxC0RkQepy/IRuvIbBO1ZLe87tAZU9b4YVd3PA3QGTw+PiMgvVVdXw2g8vkIqKioK5eXlHhkTERF5rz/Tc/Hhst2wO4BuKVGYNKYT+9MSkVswcUtE5AEqczVC1s9F8OYFUNkscECFmo7noqr/5bCHskcWEVFTGjJkCF544QW8/PLLSEpKksfy8vLk/cGDB3t6eERE5CUcDgfmbsrEN6sPyPuDOzTDrUM7QKth10kicg/+tCEicie7HUHblyL684cRsuEXmbQ1J3dC8dXPoWLELUzaEhG5wVNPPQWLxYKRI0diwIABchs2bBjsdrt87HSZTCY8/vjjsvWCSPzOmjXrH5971113yZYM9belS5ce97wPP/wQI0aMOO2xEBFR47A7HPjs772upO1FPZrjjuGpTNoSkVux4paIyE10mdtg/Pt/0BZmyvvWyARUDroW5lY9AJXK08MjIgoY0dHR+Oqrr5Ceno4DBw5Aq9WiVatWaNeu3Rmdb9q0adi2bRs+/fRTZGdnY/LkybKSd+zYscc9d+/evZg+fToGDhzoOhYREdHgOZmZmXjnnXfkOImIyP0sNjtmLNmF1Xvz5f3rB7XB2G7NPT0sIgpATNwSETUxTdFhhK74CoaDm+V9uyEUVX3HobrLSEDDH8NERJ5gtVplT9vw8HDX5bD79+/Hzp07ccEFFyg+T1VVFebMmYOZM2eic+fOcsvIyMAXX3xxXOLWbDYjKysLXbt2RVxc3D+ec+rUqejYsaNs30BERO5VZbbijQU7sONwCTRqlayyHdS+maeHRUQBihkDIqImoqouR+jaHxC0bQlUDjscag2qu45CVZ9L4Qg6flEcIiJyj0WLFmHKlCkoKSk57jGRUD2dxK2o2hVJ4J49e7qO9e7dGzNmzJCtF9Tqo5fU7tu3DyqVCikpKf94vh9//FEunnbFFVfg3XffPa3vi4iIzk5JlRnT52/DwYIKufjY/WM6oWtKlKeHRUQB7Iybs4jLvJyr7i5fvhzPPPOMrDYgIgp4NiuCN/2K6C8eRvDWRTJpa2rVE8XXvojKwROYtCUi8rBXX30Vo0ePxrx582TFrWibIBKtycnJeOCBB07rXPn5+bJyV6/Xu47FxsbKvrfHJoZF4tZoNOKRRx6RvXBFcnbZsmWux4uKivDKK6/g2WeflQleIiJyn9ySajzzwyaZtA0P1uGJS7oxaUtEvllx+/XXX8sJ5ccffywnn2KRBbGow++//y77et1///2NP1IiIm/ncEC/fz2Mf38FTdkRecga0wIVg6+DpXknT4+OiIjq9ZB9//330aJFC3Tp0kUmX0eNGiWrY0W/2vHjxys+l6iOrZ+0FZz3RWuEYxO3NTU1Mml7++23y7mzmEeLubVon/Diiy/isssuQ/v27bF169ZTvrZOp3Fri3StVuO+F/NxjJVyjJV/xspkseH9JbtQY7ZhROdE9GoVA7Va5bWx2ptXhpd+3oKyagviI4LxxKXdkRAZjEDgS+8rT2OslGOsPJy4Favcvvzyy+jXrx+ee+452YNLHFu7di0efPBBJm6JKOBo8w8g9K8voc9Ol/dtIRGo6n8FatKGAPUukyUiIs8TVbYi4Sq0bt1atjsQids2bdrIHrSnw2AwHJegdd4PCgpqcPzuu+/GDTfc4FqMLC0tDdu3b8c333wjq3M3bdqE559/XvFrWyw2uJvZ7P7X9FWMlXKMlX/Fymqz482FO7DxYJG8v25/AWKNBozolIihHRMQEdzwwy5Px2prZpHsaWuy2tEq1oiHL+iCiBC9T8S6sQTS93q2GCvlGCsPJm7FQgmid5ewdOlSXH311XI/ISEBlZWVjTQ0IiLvp64sRuiqOTCk/w0VHHBodKjqeT6qe14Ihz4wPqUnIvI1Q4cOlW2+xBVk/fv3l1W2w4cPx4IFC9Cs2ektQBMfH4/i4mLZ51arrZ1aiwpekbR1LnzmJCp6nUlbJ5Es3rNnD+bPn4/c3FwMHDhQHhfns1gssneuWPisT58+Z/19ExE1NbvDgQ+X7ZZJW51GjSGp8VizNx8FFSZ8s+YAvlt3EP3bxGJk5yR0SAj3eFuYv3fn4YM/dsNmd6BLciTuP68TgvVcCoiIvMcZ/UQSE8y5c+ciOjpatkYQFQpiYjlr1ixZOUBE5PcsJoRs+hUhG36BylpbWVXTYRAqB1wBe1isp0dHREQn8cQTT+CFF17Atm3bcOmll8qEreg3GxISgunTp5/WucSVZyJhK6plncnV9evXy9YH9RcmEx599FGZpHjppZdcx0S1b4cOHXDbbbfhzjvvdB1fuHAhPvvsM7mJ5DARkbdzOBz438p9+Gv3EYiuCJPGdETPljG4flAbrNqbj8Xbc7D3SDlW7MmXW0p0KEZ1TsSg9s08kiydvzkLX67cJ/cHtovDHcNTodXwSjki8i5n9NNx8uTJcuGG0tJSXHfddWjbtq2sWBB9usTCDkREfsthh2HXClllq6kslocsCe1Rcc51sCa09fToiIhIgT/++EMuECYWFRPEgmBPP/20bHug0+lO61zBwcEYN26c/HrRo/bIkSOymMGZnBXVt2FhYbICd8SIEXjooYdkla+opBWFECLJK+bRMTExcnMS+yIh3LJly0b+7omImsYvm7Lw65bDcv+2YakyaSvotRqcm5ogt/355Vi0PQcr9xxBZlElPl6+B/9btR9DOsRjZOdENI8OdUtV8Fer9svErTC2azKuG9QGai4KSUReSOUQH4udAbvdjvLyctflXgUFBXL/dCe7npCfX+7219TrNezvoRBjpRxj5d5Y6bJ3IfTvL6E7sl/et4XFonLg1TC16we3rg7ThPieUo6xUo6xUo6xUiYuLuysvr5v375yQTBxFVljEP1yReJWVMmKhXtvueUWTJw4UT6Wmpoqk7jOBc/mzJkj14YQV62JRcgee+wxOZ5jff/993jnnXewZMkSr5nT8v2pHGOlHGPlH7H6Y2cOPlyWIfevG9gGF3RvftLnV5osWL4rTyZxc0tre44LaYkRsgq3T+vYs6p+/adYif67ojXCiozahYSvGdAaF3Zv7vGWDZ7kze8rb8NYKcdYNd589owTt3/++Sc6d+4sqwG+/fZbOVHt1KmTXHTh2JV1vQ0Tt95NxqrGApXVBJW5GiqLCSpLTb3bmhMeE5euQ6uDQx8KuyEEDkMI7IZQeSv39XX7ou+oxj/6Fvn7+0pVUw5d1k7oM7dBl7cXDpUKDl0wHDoDHLogOPRBtbdyM8j/t67HnFvdc3QhITBBB2h0p51kVZcegXHl1zDsXSvv23VBqOpzCaq7jQG03v3z7nT5+3uqMTFWyjFWyjFW7knc3nvvvbI9gWhN4O3z1pNh4tZ7MVbKMVa+H6u1+wvw1sIdEJmFi3qkyGSoUiIdsf1wiWyjsP5AAex12YmIYB2GdUzEiE4JiDE2XOjxTGNVY7HhzQU7sDWrGBq1CrcN64DBHdiKxlvfV96IsVKOsfJw4vbdd9+VlQKffPIJTCaTrCi48sorsW7dOvTr1w9Tp06FN3P7JPfAJuhLs2GznSTUxyWS6t0/Lsd0zIGTPC4SXfK+uFWp625rj8nHnMflc+DaP/qY8+uPfq3Ddb5/OCdUUNksdUlVpYnXYx6r6xnaVETirTaJe0xyV+zrT5D0rXdcJAJr4+R5fvfD0GqGLicD+qzt0GVugzb/oFzwqzE5VOp6CV+R5P2nZG/tY+qKQgRvWwKV3Srf3zWdhqGy3+VwhDRccMZf+N17qgkxVsoxVsoxVu5J3F577bXYuHGj7EEr1mwQLRLqW7x4MXwBE7fei7FSjrHy7VjtOFyC6fO3wmJzYGhaAm4d2v6Mq1cLK0yycnfpzlyUVNX+PShO1atljKzC7dw8SnE7g2NjVVptxivzt2F/fgUMWjUmjemE7i2iz2ic/sYb31feirFSjrHycOJWrMQrFnQYPHiwXNwhKysLn376KbZu3Ypbb70Vq1evhjdz5yRXVVOB2I/udtvr+Zvjk2zH7tc7ptXXJoxNVVCbKuWt3DeL29r7alGZe9ZjUh1N7srbUNhDwmEPiYA9JLL2NrTuNiQCjiBjkyV6ff6HocMOTUGmTNTKqtqc3ccl7a3RyTCndIElKQ0Oja5egr82ya82i2rrGvn/9uiHANVQmet/GFBz1h8GiDGIPra2mJNf9uXrfP495UaMlXKMlXKMlXsStz/88MNJH7/sssvgC5i49V6MlXKMle/GSvSrfeHnLbKStXerGJkMFZWsZ0u0M9hwoBCLtmdjR3ap63h8eBBGdk7CuanxMAbpFMfqSFk1Xv5lK/LKahAWpMP/nd8ZbeP9swjDH95X3oyxUo6xarz57BldLy4WJRM9wUTOVyzuIFbBFURPL5uN/2PqE0m7inOuhb74MOzO6z6OrSA8We78VHn14x4/wbkdoka29rZ2s9c+77jH7HVfXruvcj7/2K+tO+Z6XN6v+9q6r3OIlgVKkq3HVjrqDNCGhsCM2q+HWtu4vUPtNqhEIrdGJHTrJXediV1x/9jjMvFb95hIDIuYmSoBUyU0Cl7SodbAHhxeL5l7NKl77DF/u+z+RNTlhdDVJWpFwlZd3fCPTltIJCwpnWuTtc07yxg1Br1WBUtVVW0S11w/+VuX7G3QlqNuE0lhhx2mDufA3LKb3/SxJSIKdL6SmCUi8la5JdWYPm+bTNp2TIrAPaM6NkrSVhC9bfu1jZPb4aJKLN6Rg+W782Ti9cuV+zBnzQEMbBeHUZ2T0KbZyRMfBwoqMH3eVpRWWxAXZsAjF3ZFYmRIo4yTiMgdzihxm5aWho8++giRkZEoKirC6NGjkZeXh9deew09evRo/FH6MIvNjil745FdEi4vyTBoNTDonLea2mPy9uh+kFYDvet4vcdP8HXiuepG+gXpLTR6DRxN9cmMWgNHUJjcRPr6tFnNDRK6MplbUwl1dRnUVSVQV5XWbpV1+zXlUNlt0FQWy+1URAWvPfSY5K7YPybBW1vF6xv/30VCVJe1o679wXZoS3IaPO7QGmBOTqtN1jbvAlt0ctN8b2pRvR1c2+O46RerJSIiL3bDDTec9FLe2bNnu3U8RES+pLjShJfnbUFZjQUtY414cGxn+fdrU0iODsWNg9vhqv6tsTLjCH7fno1DhZX4c1ee3NrEhWFk50SZyNVrG5bVbD9cjNd/2yGTyy1iQvHwBV0QFdqwNQ4RkV8mbsWquZMnT8bhw4fx0EMPITk5WbZOEPfffPPNxh+lD7PZHSiqMMFksckNsDT6a+g0KvlL6kRJXp1GLTetRgWNWuyroFXX3hefZGrVzvt1x9TO43XP1ajlJ6fyHM7HXPtHn6ute46/JZGPo9XLlgw2pVWgNuvRpG5lab3kbknDBG9VqazmFW0dxIbihsnNE1bxigSuMQpBwXWJ3dAoOS5xW7tFyjYObk/w2qzQ5u2ta3+wXe6rZJV33dhVKlibtYE5pTMsoqo2vp3fLBZHRES+oX///g3uW61WZGZmYtmyZbjrrrs8Ni4iIm9XabLg5XlbkV9ukq0LHrmgC0L0TT+XD9JpMLxTIoZ1TMCevHLZRmH13nzsyy/Hvj/KZSWuaKEwslMSEiKDsWJ3Ht5euFP+PS4qgh88rzNCDPybg4h8zxn1uD0Rs9nsM6vyursfmNlqQ4XZhopqM0wWO0zW2iSuyWqvu7UdPV7/2Iker/d1jbtkU+MQOUKRyI0K1ctLUBIjgpEYKbYQeRsZoj9ls/qA7IUi2i+IpO0xydx/quJVfFqNri6pGwlbSG0yt35i15XgFVWoZzF2TXG2TNKKFgi6wzuP6yVsjYg/2v4guWNtQtnNAvJ9dQYYJ+UYK+UYK+UYK/f0uP0n33//PRYuXIgZM2bAF7DHrfdirJRjrHwnVuJvUJG03Z1bJv+ue2pcdzQLP4u/I85SWbUZy9LzsGRHtkwkO7WPD8eevDL593K/NrG4a2SaLDIi73xf+RLGSjnGysOLkwk7duyQ7RL27dsn+9q2bt0aEyZMQL9+/eDt3D3JbYo3rfjfJlbuPGkS2GKDxW6H1eaQDd6t9mNuxfG6x8XzbHX3RXsHcUx8Oin3T3YOV99e5Z+UykRuRDAS6pK5IqmbEBEsH2uKWPkdZxVvZQn05jLYSwuhriyW9zUiuVu3fzoJXrsu6ARJXdGWoX4Vb6SrB6+qqlQmamvbH2w7rg2EPcgIc/NOsqLWLPrUhsfB0/i+UoZxUo6xUo6xUo6x8mziVlTdXnTRRdi8eTN8ARO33ouxUo6x8o1Yib/9Xl+wA5sPFckK2ymXdkdKjHf0HxNryWzJLJZVuGJ8zr9QR3dJwg2D2vr/VaFnif8GlWOslGOsPLw42e+//44HH3wQY8aMwfjx42XidtOmTbj55pvxxhtvYNSoUWdyWjoNompVLLYkegmJlTE9RSSQRYJXJHBrE761id+CchNySquQU1Jdt1Uhv7xG9hfan18ht2NF11Xpij5G4rIbkcwVid1YYxB/2dan0cJujJab+mQ/DEXrBZnIrU3myqRuVTHUFXWJ3aq6W3O1rJBVl+QCYjsJuyEUDkMINGX5x1X2WhLb11bUpnSBNbYFoOKn2kRE5J2ys7OPO1ZZWSmLEkQLMCIiOsrucGDmH7tlUlT8/fl/53f2mqStIP5W7NEyWm5HyqqxfFce4iKCMaR9s1Ne7UlE5O3OqOJWVCJcccUVmDhxYoPjn3zyCX744Qf89NNP8Gb+UHHri0RSV6wEKpK4zmSuuM0trUZ5zT/3/hW9duNlEtfZesFZqRuMUIPnktaNEQ9RGS2S2aJKWt7Wu++smj56vLaqusZZTW21I8poQFxYkEx0ixiJzWjQnt4ExVwDjTOJ66zWdVXwHr0vevDWZ4ltebT9QWIHVzWut+K/QWUYJ+UYK+UYK+UYK/dU3IqFdsXvSjENdv7OFPuJiYl48cUXMXDgQPgCVtx6L8ZKOcbKu2MlfjZ+sWIfftt6GKKWRixE1rNlDLwd31fKMVbKMVbKMVYerrgVl5ENHz78uOPi2GuvvXYmp6QAIBYyS44KkduxKmosrmTukfIaZBVVyvt5pdWyJURWUZXcjhUepJPN551J3WB9w5VET8tZfBgrkqi1Cda6W1fC9WgLi6PHa5OyolK5KYhLl+Ij6hK54cGyctl5X8TruKSuPgg2fSJskYn/fFLxh62pqjahW1MOa3QyHMHhTTL+E798bVU3e1MREVFjWLx4cYP74nejTqdDbGwsq7OIiOr5eWOmTNoKtw9P9YmkLRGRPzmjxG3btm3x559/4oYbbmhwXKzEy8vL6EwYg3RonyC28AafzIh+RQUVNQ0qdOVtaTWKK80oq7GgLNciG+T7Ko1aJfv7is2gVcMgb+vuy+NqeV/uO291apkIF99/dlEV8spqk9xFlWZUma3/2I5CnLM2oVubyE2ot3/SheNEVVJQKGxia6TvWySxRaV1abVFLixQLm8ttf9Pq81yXzwuj1WbZQJfJP27pUShW0o0UhMj5KVaREREp0vMV7/44gtERETIK8mEe++9F+eccw6uvfZaTw+PiMgrLNmRgzlrDsj96we1weAO8Z4eEhFRwDmjxO19990nN7FwQ/fu3eUx0eN2wYIFmDZtWmOPkQKY6FckVioVW/cW0Q0eExWs9ZO5zurcU3G42tWf4nmnURCr06obJFXrJ16P7qvrkrMNnycSsI11+YHZasORshrZfkLEQ7SmkLel1SisMMmYHSyokNuxRNLYWaUrK3Tlbe1+VKgB6lNUIInexs4k69GE69HEa/0krLgV1cin63Bxldx+3XJYJm07JkagW4tomcwVSWhWSRERkRKvv/46vvvuOzz77LOuY2KB3f/+978oKirCPffc49HxERF52pp9+fh4eYbcv6RnCsZ2a+7pIRERBaQz6nErrFy5El9++SX27t0Lg8GA1q1by5633bp1g7djj1vvxlg1TaxEYjVfJHLrqnPzSusSvGXVcuG4k/0kEH2Gm9UlcmONhnpJ2rpEbI0F1Wfw/0yrViE8WIfwYD3CgnWICNbJxfbE/drjOtneQTwm2iTsyinD1qwibDlUjOIqc4NzxYUZZCWuSOJ2So5EsL7h51J8XynDOCnHWCnHWCnHWLmnx+3gwYPlgrp9+vRpcHz16tV4+OGH5ZVlvoA9br0XY6UcY+V9sdp+uBjT522TrcqGd0zAzee297kCCb6vlGOslGOslGOsPNzjVhCLNhy7cIPJZJL9b1NSUs70tETURETiMykqRG4nWiitoNzkSurm1qvWFUldUcnsrHY9VduH2sRrbcJV3IY5k7DO43VJWrEfrNOc1iRwQLs4uYnPm0TP4y2ZRdiSWYxdOaXILzdh8Y4cuYlxtI8PR7cWtW0VWnjRqrdEROR51dXVMBqNxx2PiopCebn7P+AnIvIW+/PL8fpvO2TStm/rWPxriO8lbYmI/MkZJ25PZM2aNbj99tuxc+fOxjwtETUx0a5BLPImtmOJRdQKK2qTuLmlNXJftHqoTcQeTcKKalmxMJo7JnbiNVJiQuV2YY8U2QJiZ3aJTOJuOVQkk87pOaVy+2b1ATm27i1j0CU5El2bR8kxExFR4BoyZAheeOEFvPzyy0hKSpLH8vLy5H1RjUtEFIhE+zlRaSvm1p2SInDXyDTZuo6IiPwkcUtE/kdTr89wVy8tphe9g8UKt85VbkWSWSZxM4uw43CJXADtz/RcuYmpZ+u4sNpq3OZRaBsfLr9HIiIKHE899RTuvvtujBgxApGRkfJYSUkJBgwYgKlTp3p6eETUxMTaDwXlNXJOyMVuaxVVmPCfX7bKFmitYo14YGxnxoaIyAswcUtEfkf04h0tti5Jsh/v7txSbM8uxaYDhThUWIl9+eVy+3H9IYToNejSPApdU0RbhSjEGIM8PXwiImpi0dHR+Oqrr7Br1y7s378fWq0WrVq1Qrt27Tw9NCJqYqKadOr3G1FSZZatxDokhKNz80h0To5C61hjQFaYVtRY8PK8rTKhLRb8ffjCLvJKOiIi8jz+NCYivyYm5GIi3rN1LK7q2wrFlSZZjbtVbFnFqDRZsWZfgdyE5lEh6NYiWrZUSE2MYKUBEZEfMpvNcnGy5ORkTJgwQR4bP348Bg0ahPvvvx86HVvqEPmrX7dkyaStSM+KD/i3Hy6RG3BAJis7JUfIuWPn5EgkRgb7fX9Xkch+5ddtci2LqBA9Hr2oKyKC9Z4eFhERnW7idu3atad8jqhaICLyZlGhBgxNS5Cb3e6QlbfOtgp7j5Qjq7hKbvM3Z8mkbcekSJzTvhn6tomVSWAiIvJ9zz//PNavX49nn33WdUy0ThDJ3JqaGjz55JMeHR8RNY3yagvmbcqS+3ePSkOLGCO2Hy7G9qwSuV5CldmKdfsL5SZEheplAteZyI02GuBPxALFby3cgT155Qg1aDH5oq6IDePVZ0RE3kTlEMuzK5CWlqbshCqV1y9Olp/v/tWC9XoNzGab21/XFzFWyjFWjRsrcZnYtiyxyFmRTOaKagwnsRjbuWkJGNEpQfb79Vd8TynHWCnHWCnHWCkTFxd2Vl8vetl+/PHH6NixY4PjW7duxR133IEVK1bAF7h7Tsv3p3KMlXfG6vMVe/HblsNoGWvEc5f3hLpeNa1YkPdAfrmsvt12uAQZuaWw2Br+qZwUGVybxG0eKT/cF8lOX42V3eHAjMXpWLEnXxYriErbDgkR8Bf8N6gcY6UcY6UcY9V481nFv2nS09OVPpWIyCcZg3QY0C5ObuIzrcyiSqzdV4A/0nNRXGnGL5sy5Sb64Y7slCgXQ+PCZkREvkf8jDeZTCc8brFYPDImImpaYjGyRduy5f7V/Vs1SNoKYk4nFq0V2yW9WsBstWF3blltK4WsEuzPL0d2SbXcft+eDfHlrWPD6vrjRsqkp6+02BI/6z7/e69M2orv+/4xnfwqaUtE5E/Y45aI6B+uHhCXz4ltXO+W2HiwEIt35NT2xq3bxOVzwzsmYlhagt9dOkdE5M/OO+88TJkyBVOnTkWnTp1cRQqihcKoUaM8PTwiagLfrzsIq92BjkkRci2DU9FraxewFRv6A5UmC3Zkl2JHlqjILUZOSbVrwdu5GzOh06hk8rO2tUIkWseFee1CZz9tOISFdUns24d1QPcW0Z4eEhERnW2rBH/CVgnejbFSjrFyf6zySquxdGcOlqXnobymtipLzMl7tYqRVbidm0cdV8HhS/ieUo6xUo6xUo6xck+rhOrqajzxxBNYsGAB7Ha7rD7TarUYN24c7rnnHiQmJsIXsFWC92KsvCtWh4sq8eic9RB/+T59WQ+0iw8/63MWVpiwQy5sVtsjt7heiy1BLHQmksSiIrdLclSjLHTWGLFavD0bHy/fI/dvOKctzuuaDH/Ef4PKMVbKMVbKMVaNN59l4tZN+KZVjrFSjrHyXKzEKsSijcKSHTlIzyl1HW8WHoQRHRNxblo8wn1wRV6+p5RjrJRjrJRjrNyTuHUqKyvDwYMHYbPZcODAAcydOxerVq3C9u3b4QuYuPVejJV3xeqNBdvlgmN9WsfggfM6N/r5xZ/UogJ3W4OFzhp+T1EhepnEbdMsDGFBOrmJNl1Gg1beGrTqUyZ2zzZWq/fm453fd0IkAC7t1QJX9msFf8V/g8oxVsoxVsoxVh7ocUtEREfpNGoMat9MbllFlTKBu3x3Ho6U1eCr1fvx7doD6NcmFiM6JyE1IfysKyyIiKjxZWRk4Mcff8Rvv/2GiooKtG3bFo8//rinh0VEjWhPXplM2oqp2JV9myZRKeZ5SVEhchvTJbnBQmdi251bKity/9p9RG7/NLc0BmlrE7p1ydza5K4WRoMOYcE6RBoNCJLPq30sRK9RPMfcllWM/y5Ol0nbEZ0ScUXflo0cBSIiagoerbgVi0I888wzWLhwIYKCgnDzzTfL7UR27dqFp59+WlZAtGzZUl7eJlYEFsQiEm+88QZ++uknWK1WXHbZZfj3v/8tL3k7EVbcejfGSjnGyrtiVWOxyUqGRduzsT+/wnW8eVQIRnROxOD28Qhx8+rDp4vvKeUYK+UYK+UYq6avuD18+LBM1op5Y2ZmJsLDw2Xl7auvvooLLrgAvoQVt96LsfKOWIk/dV/4eYu8Ourc1HjcPjwVnlB/obPckmrZbqvCZEFFjVXui0TvmRDtukRSVyZ3j030OveDdPL8HyzdBZPVLgsL7h3V0Wv77zYW/htUjrFSjrFSjrHyk4rbadOmYdu2bfj000+RnZ2NyZMnIykpCWPHjm3wvPLycpnQHTFiBP7zn//Iifa9994r+5LFxMTgrbfekhPwF198EbGxsTKpK5735JNPeux7I6LAE6TTYGhagtz2HSmXVbgr9xxBVnEVZv+1F1+v2o8B7ZphVOdEuWAFERG5z3fffSfni+vWrUOzZs3kvHLMmDHo27cvunfvjg4dOnh6iETUyLZmFcukrVg4bHwfz1WYNljo7ATJZfHhv0jiimSuTOqK/Zq6fVNtclfcrxT71bXHRRJW5HvLaixyA6pPOQ6xaNpdI9P8PmlLRORPPJa4raqqwpw5czBz5kx07txZbuJytS+++OK4xO0PP/yAkJAQWXGr0WgwadIkLFu2TCZ9zz33XPk1Ilk7dOhQ+XxRxTthwgQ8+OCDCA0N9dB3SESBTPQvE9t1A9vgr4w8LNmeIxO4y9Jz5dY6zigXMxOJXJHwJSKipiXmiuKqrZdffhmXXHKJp4dDRE3M7nDg69UH5P6ozkmIDQuCNxKtDoL1WrnFIUhxBZtYb0Ekc51VuzLRazom6VuXDBa3rWKNuGVoe9mSgYiIfIfHErfp6emyrUHPnj1dx3r37o0ZM2bI1X3V6qO/UNasWYORI0fKpG39qgmhsLAQlZWVslLCKTU1VbZPEInd/v37u+17IiI6lmiNIHqdje6cJC+RW7wjB2v25stWCh8uy8AXK/dhcId4mcRtHs0PmoiImoq4MmvevHl47LHH8NJLL2HYsGEYNWoUBg8e7OmhEVETEO2rDhZUyA/IL+nZAv5GJGCjQg1yIyIi/+WxxG1+fj6ioqKg1x9ddV20ORB9b0tKShAdHe06LvqPdevWDVOmTMGSJUuQnJws2yqIRG9ERAR0Oh3y8vLQrl07+fycnBx5W1xc7IHvjIjoxNUUqYkRcrt+UBv8uStPtlIQi5n9vi1bbqmJ4RjZKQl928SyGoKIqJGNHz9ebkVFRfj1118xf/582XpLrLMgigZWr14tK3LFvJKIfJvVZsecNbXVthf2aC4X9iIiIvJFHkvcVldXN0jaCs77ZrP5uLYKH3zwAW688UbZWkFUS9xyyy1y0p2YmIjRo0fjtddekysBi9YI4hI4sTCZqLo9EZ1OrL4Jt9JqeSm0UoyVcoyVb8YqVh+M8f1aYVzflth6qBi/bzuMdfsKsSunTG5hf+swvFMCerWORfv4cOi06oCMk7djrJRjrJRjrJqeKA4QLbXElpubi19++UUmcZ977jm8/fbbuPTSS2VVLhH5LtGWSnw4Hh6sw/ndmnt6OERERL6XuDUYDMclaJ33ReVDfaJFQseOHWVvW6FTp074+++/5SJld955p1yETPSzFT1uRS/cu+66C1u2bIHRaDzha1ssnlnZjivqKcdYKcdY+XasOiZGyK2owiT/yFiyMwfFlWb8vCFTbqLytl18GNLE85Ii5b5Y4CLQ4uStGCvlGCvlGCv3SUhIwK233iq3AwcOuJK4TNwS+S6TxYbv1x+S++N6t+BaAkRE5NM8lriNj4+XrQxEn1tRHetsnyCStuHh4Q2eGxcXhzZt2jQ41qpVK1dLhJiYGMyePVu2WBAJYbEy56uvvipbKhAR+YJoowGX9WmJS3q1wKaDhVixJx/p2SUorbZgZ3ap3H5YfwhatQptZSI3Eh2TImRFroF/kBARnTUxtxStE8RGRL5rwdbDKK0yIy7MgBEdEz09HCIiIt9M3IoKWpGw3bRpE/r06SOPrV+/Hl27dm2wMJnQo0cPrF27tsGxffv24aKLLpL7Dz/8sLyszbm4hGihIJK5zp63RES+QqNWoXfrWLmJD6FySqqxM6cE6dmlciuuMrtaKvy0ofb5beLCkJYUgU4ikZsQwcoSIiIiCkgVNRb8silT7l/etxW0XDOAiIh8nMcSt8HBwRg3bhyefvppucrvkSNHMGvWLLnKr7P6NiwsTFbgXnPNNfj8889l37FLLrkEP/74o1ywTCRrhcjISLz++uto1qyZrOIVPcpuv/324xLARES+tqBZUlSI3MSiZSKRm1da40rk7swuQVGlGRl5ZXKbuzFTJnJbxRplNa5ordA+IRwheo/9qCciIiJyG5G0rTLbkBIdikHtmnl6OERERGdN5RCZAA8uUCYStwsXLpT9aMWCYxMnTpSPpaamyiSuWP3XWY37wgsvICMjQy5C9sQTT6Bv377yscrKSjzzzDNYsmSJ7HF7/fXXy8TtP8nPL4e76fUa9qxTiLFSjrEK7FiJH9/55TWyjYIzkVtQYWrwHLEQY20it7a1QoeECIQatAEVp6bCWCnHWCnHWCkTFxcGb2IymeRcVMxpRdHBzTffLLcTEWsxiDlrfTNmzMDw4cPleg+iGEEsxCvmyf369cOUKVNkL15vmNPy/akcY+X+WIn1Av79v7Ww2Oz49/md0bNlDPwN31fKMVbKMVbKMVbKMVaNN5/1aOLWU5i49W6MlXKMlXKBEquCukSuSOKm55TKFZXrUwFoGWuUrRXEomipiREwBukCLk6NgbFSjrFSjrHyzcStuNpLtPUSRQfZ2dmYPHmyvKJs7Nixxz13zJgxso/uwIEDXcciIiKg1+vxyiuvYMGCBbJYITo6GtOnT0dhYSHmzJkjr8I4FhO33ouxcn+sPlq2G0t35qJDQjimXNr9hP9mfB3fV8oxVsoxVsoxVsoxVo03n+X1s0REfiQ2LAhDUsUWL+8XVhytyBWJ3NzSahwoqJDbb1sOy0RuSkwo0hJrWyt0bRmFIA175BIRKVVVVSUTqzNnzkTnzp3lJq4Q++KLL45L3IqK2qysLLmmg1h891g//PCDvKpMVNo6E8JDhgzBwYMH5eJpRHRi2SVVWJaeK/ev7t/aL5O2REQUmJi4JSLyYzHGIAzuILbaRG5xpak2kZsjkrklyC6pxqHCSrkt3JYtWyv0bxOHS3u1kAldIiI6ufT0dFitVvTs2dN1rHfv3rL9gd1ub7DmglhcVySUUlJSjjuPeK6osO3UqdNxj5WXu/9qMSJf8u2aA7A7gJ4to+XVRERERP6CiVsiogASFWrAoPbN5CaUVJnrqnFrFzzLKq7Cqr35cuvdKgbjerdAay+7JJmIyJuIBXWjoqJkqwOn2NhY2fe2pKREtjyon7gV6zo88sgjWLNmjexde99992Ho0KEywTto0KAG5549e7Y8t1j7gYhObN+RcqzZVyCvIrqqX2tPD4eIiKhRMXFLRBTAIkP0GNAuTm5Cdmk1vl29H2v3FWD9gUK5dW8RjXG9WqB9Qrinh0tE5HXEImL1k7aC875ojVCfSNzW1NRg8ODBciHd33//XS5W9vXXX8v2CfUtWrQIs2bNkoueHXt+J51OI6+UcBetlq10lGKs3Berb9cekLdD0uLRNtG/5yp8XynHWCnHWCnHWCnHWDUeJm6JiMilVZwRk8Z0wuGiSvy8MRMr9hzB5kNFcuucHClbKHRMimDvOCKiOgaD4bgErfN+UFBQg+N33303brjhBrkYmZCWlobt27fjm2++aZC4FUnbBx54ANdffz2uvPLKf3xti8X9i35woRHlGKumj9W2rGJsySyGRq2SHzIHQswD4XtsLIyVcoyVcoyVcoxV42DiloiIjpMcHYq7Rqbhsj4tMXfjIfy1+wi2Hy6Rm1it+bLeLdCleRQTuEQU8OLj41FcXCz73Gq1Wlf7BJG0DQ9vWP0n2iE4k7ZObdq0wZ49e1z3582bJ1spXHPNNXj88cfd9F0Q+R6Hw4GvV++X+yM7JaJZeLCnh0RERNTojq6WQEREdIyEiGDcNiwVr17bV/5RpFWrsDu3DC/P24anf9iEDQcK5R9ORESBqmPHjjJhu2nTJtex9evXywra+guTCY8++igee+yx4xY3E8lbYeXKlTJpO2HCBEyZMsVN3wGRb1q7vwD78ytg0Kpxae8Wnh4OERFRk2DiloiITik2LAj/Orc9Xp/QD2O7JkOvVWPvkXK89tt2PPHtBqzZmw87E7hEFICCg4Mxbtw4PP3009iyZYurN+2NN97oqr4VfW2FESNGYO7cufjxxx9x8OBBvPPOOzLJK1oiiIpdUWHbt29f3HbbbfLrnNuxrRiIAp3N7sCcNbW9bS/o3hwRwSfuA/1PNAWHoMvc3kSjIyIiajwqRwCWSuXnl7v9NfV6Dft7KMRYKcdYKcdYNW6cSqvN+HXzYSzano2auh6LSVEhuLRnCga0ayZ7zfk7vqeUY6yUY6yUiYsLg7ctUCYStwsXLoTRaMQtt9yCiRMnysdSU1Px0ksvYfz48fL+nDlz8OGHHyI7Oxvt27eXFbgiWSsqdq+++uoTnn/27Nno37+/x+e0fH8qx1g1bayW7szBR8syYAzS4rXr+iFEr7wDoC5rByJ+eRUqmwXFVz4Da7PW8BV8XynHWCnHWCnHWCnHWDXefJaJWzfhm1Y5xko5xko5xqpp4lReY8HCrYexYOthVNV9XXx4EC7p1QLntG8GrcZ/L+zge0o5xko5xso3E7eewsSt92Ksmi5WZqsN//7fWhRXmjFhYBuc37254q/V5mYg8qdpUFlN8n5Nh0EoH30nfAXfV8oxVsoxVsoxVsoxVo03n/Xfv6iJiKjJhQXpcHnfVnhjQn9c2a+VrHzJK6vBzD924//+txaLt2fDYrN7ephERETkJ37fli2TtjFGA0Z2TlL8ddr8A4iY+6pM2lpiW8pjhj2roa4sbsLREhERnR0mbomI6KyFGLS4tFcLmcC9bmAbRATrUFBhwsfL9+ChL9bgty2HYaprqUBERER0JipNVvy8MVPuX96npey5r4Sm6DAifp4OtbkKlsT2KBn/JCyJHaCy2xC0dXETj5qIiOjMMXFLRESNJkinkYuEiEXMbhzcFtGhehRXmfH5ir148Ms1+GVjJqrNVk8Pk4iIiHzQvE2ZMnmbHBWCwR3iFX2NuvQIIn6eBnVNOSxxrVB64b8BnQFV3c+TjwdvXwJYuQAgERF5JyZuiYio0em1GozpkoxXr+uHm89tj7gwA8qqLfhq9X48+MUa/LD+oPzDi4iIiEiJ4kqT7KkviPZMagULoaorihD588vQVBbDGpWM0osfhsMQIh8zt+4NW1gs1DUVCNq9osnHT0REdCaYuCUioiaj06gxolMipl/TF7cP74CEiGBUmKz4bu1BPPDFasxZsx/l1RZPD5OIiIi83E8bDsFktaNdfBh6t4o55fNVVWWI+OllaMryYQtvhtJLJ8MRXG8hGLUa1d1Gy93gzQuAwFuzm4iIfAATt0RE1OS0GjXOTU3AtKv74J5RaWgeFYJqsw0/bciUCdwvV+5jBS4RERGdUF5pNZbuzJX7V/dvDZXq5NW2qppKRP48DdqSHNiM0Si59FHYQyOPe15Nx6Gw64KgLToMXdb2Jhs/ERHRmWLiloiI3EZc1jiwXTO8eFVv3H9eJ7SMNcrqmfmbs/DoN+uw6WCRp4dIREREXua7tQdgszvQLSUKHZOOT8DWpzJXI+KXV6AtPAR7cISstLWHx57wuaJtQk3Hc49W3RIREXkZJm6JiMjt1CoV+raOxfOX98S/z+8sWygUV5rxyq/b8P7SXag0sX0CERERAQcLKrBiT77cv6p/65M/2WpG+Pw3oMvbC7shFCWXPgJbZOJJv6S662g4oILh4GZoinMac+hERERnjYlbIiLyGHGpY8+WMXjhil44v1syxIWPy3fl4dGv12PjwUJPD4+IiIg87JvV++XtwHZxaBVr/Ocn2qwI/+1t6A/vlO0PSi/+P9hiUk55fntkPMytesj94C2suiUiIu/CxC0REXmcQafBhEFtMWVc99rq2yozXv11O2YsSUdFDatviYiIAtHO7BJsziyGRq3C5X1b/fMT7TaE/T5DVs06NDqUXfgQrPFtFb9Odffz5G1Q+l9Q1VQ0xtCJiIgaBRO3RETkNTokRODFK3vhwu7NIdYd+Wv3EUz+Zj3WH2D1LRERUSBxOBz4ZvUBuT8sLUF+sHviJ9oRtnQWgvaugUOtQen598OSnHZar2VJ7ghrTAuorGYE7VjWGMMnIiJqFEzcEhGRV9FrNbh2YBtMHdcDSZHBKK0y4/XftuO/i9NRzupbIiKigLDhQCEy8spg0KoxrneLEz/J4YBx+ecISl8Oh0qNsjF3w9Ky2+m/mEqFqrqq2+Ctv8u2C0RERN6AiVsiIvJK7eLD8fwVvXFRjxRZfbsi4wge/Xod1u4v8PTQiIgCTnm1Bev2FcBud3h6KNTIREuiTQeLsGZfPkwWG7yBeJ99s6a22va8rsmICjWc8Hmhq+YgeOsiuV8+8jaY2/Y949c0te8Pe3A4NBVFMOxbd8bnISIiakzaRj0bERFRI9Jr1bhmQGv0bR2DD/7YjcPFVXhzwQ4MaBeHm85ph7BgnaeHSEQUEH7acAi/bT2MMV2ScOPgdp4eDp0hu8OBnJJqZOSWIiOvXFa0ZhdXuR4P0Wtxblo8RnZKRGJkiMfG+VdGnvydH2rQ4sIeJ15gLGTdzwjZ8IvcLx86EabUc87uRbV6VHcZgdC1PyJ48wKY2g84u/MRERE1AiZuiYjI67WV1be98MO6g/hlUyZW7cnHjqwSTBzSDv3axnl6eEREfq97iyiZuF24LRtdU6LQs2WMp4dECtRYbNh7pAwZubXbniPlqDQd3wZA9I+12uwoqDDhty2H5daleSRGdU6S/6/F4mDuYrHZ8d3ag3L/4p4pMnl7rODNCxG6+lu5XzHoGtR0GdEor13dZSRC1v8CXd5eaHP3wJrADymIiMizmLglIiKfoNOocVX/1ujTOhYf/LELWUVVeOv3nei3Nx83DWmHiGC9p4dIROS3uqZE44IezTF/UxZmLt2NF6/qjcgQ/tz1tsW88strapO0ebWJ2kNFlaIN7HFXs7SJC0P7hHC0jw9Hu/gwhAfrZXuCLZnFWLQ9G5sPFWFbVoncokP1GN4pUS4Q9k8tCxrT4u3ZKKwwISpELyu8jyUWDzP+9bncr+wzDtU9L2i013aERMDUYaDsmSuqbsuZuCUiIg9TOcRv+ACTn1/u9tfU6zUwm72jZ5S3Y6yUY6yUY6z8K06iGufH9Ycwd+MhiHaLYUE63DS4Hfq3jYVKNMR1A1+JlTdgrJRjrJSJiwvz9BACck6rUqvw2NfrcKiwEl2bR+HhC7tA7aafub7GHf+WzVY7DuTXtjtwJmpLq49fxDPGaJBJ2g4ySRuOFjGh0GpOvtTJkbJqLNmRi2Xpua6FQUXVrfjwdFTnRKQlRjTa79v6saoyW/HvL9fK17zl3PYyYVyfIWMVwha+BxUcqOo+FpXnXCsXFmtMmoJDiP76SbnYWdENr8Ie5j3V5fwdoRxjpRxjpRxjpRxj1XjzWSZu3YRvWuUYK+UYK+UYK/+M0/78csz8Y7dMIgh928Ri4uB2iHBDFZivxcqTGCvlGCtlmLj1zJxWvD/355ZhyvcbZdJwwsA2OL97c7eOIZD/LRdXmo5W0+aVYX9+BWzHLBYnkqutYo0NErXRRsNZfVC6Zm8+Fm3Pka/plBwVgpGdEzG4fTxCTtDK4Exj9d3aA/hh/SHZuuHlq/s0aNGg378R4b+9BZXdhupOw1ExbGKjJ22dIn58CfrDO1HV60JUDrwa3oK/I5RjrJRjrJRjrJRjrE6NiduTYOLWuzFWyjFWyjFW/hsn0ZNPLJrz88ZM+QesMUgrq28HtI1r0upbX4yVpzBWyjFWyjBx67nErXh/Lt6RjY//3COTas+M7ykThdS4/5bF77bMokqZqN2dV4Y9uWWy/+yxIoJ1MjnrTNS2iguTrRCawsGCCtlGYUXGEZisdnnMoFXjnA61i5m1PMP3gTNWpdVmWW0r+vJOGt2xQQ97XeZ2RMx7DSqbBTXtB6J81B2Aumm+Tzmm/RsQMf8N2A2hKLzpDUDX9C0ilODvCOUYK+UYK+UYK+UYq1Nj4vYkmLj1boyVcoyVcoyV/8dJ/EH5/tJdrurbPq1jMHFI+ybrwejLsXI3xko5xkoZJm49m7gVfz68sWAH1h8oRFJkMJ69vBeCdBq3jsVf/y2v3puP37dlyytKnMlRJ/FZZIvoUJmkFcnaDgnhiAsLcluLIKcqkxV/7c6TSdzskmrXcTEesZiZuPpF9KU/3Vh99vdeLNh6GK3jjHh2fE/X96XNyUDkzy9DZTXD1LoXys67F9A08VItdjuiv3gEmrIjKB96E2q6jIQ34O8I5Rgr5Rgr5Rgr5RirU2Pi9iSYuPVujJVyjJVyjFVgxElUKM3dmIkfNxyqrb41aHHDOW0xqH2zRv/D1tdj5U6MlXKMlTJM3Ho2cSuIHqSPf7MexVVmDO+YgFuGdnDrWPzt37JYGOybNfvxy6Ys17EQvRbt4+sWEUsIlwuKBeu9Z21p8WfkzuxSmcAVSXxn24bwIB2GdkzAiI6JiAsPUhSrwwWVePirtbDaHXj0oq7o0jxKPqbNP4CIH/8DtbkK5pQuKL3wQUCjgzsEb14oF0GzRiai+LqXRJNneBp/RyjHWCnHWCnHWCnHWDXefNZ7fvMTERGdJbHYymV9WqJ36xh8sHQ3DhRU4L0lu7B6XwH+NaSdW1bDJiIKBGJRyDtHpuI/c7di6c5cdEuJlpWWdPrEglzvLU7HxoNF8v4F3ZtjaFoCEiODvXrxN/GBaKfkSLmJ/rt/7MzFkh05MpkvPkT9ZWMmerSMllW4XVOiTvq9fLfugEzadkmOdCVtNUWHEfHzdJm0tSR2QOn597staSvUdByCkDXfQVuSA/2hrTC37O621yYiInLy/MeGREREjaxFjBFPX9YDV/ZtJXswbjhQiMlfr5eXdgbghSZERE2ic3IULuqZIvc/XLYbhRU1nh6SzzlSVo1nf9gkk7aivcDdI9Nw3cA2cvEvb07aHkt8MCo+OH3j+v64/7xOMgErftuK72v6/G2yd61I5JZXW4772kOFFfh79xG5f2X/1vJWXZqHiJ9ehrqmHJa4Vii98CG395l16INR03Go3A/evMCtr01EROTExC0REflt9e2lvVvg+St6yX55oqJpxpJdePXX7Sg6wQIvRER0+i7v01Jewl9pElWju+Ql/6TMjsMleOr7jcgqrpL92J+8tLts7ePLxIelfVvH4tGLu2HaNX0wtmsyQvQa5JfX4KvV+zHp81WYsSQde/LKXB+kfrViv0zy9msTi7bNwqCuKELkTy9DU1UCa3RzlF7yMByGEI98P9XdRsOhUkGfuQ2awqNtLIiIiNyFPW7dhP09lGOslGOslGOsAjtOou/evM2Z+H7tQXkppvgj8vpBbTEkNf6Me9/6a6yaAmOlHGOlDHvcer7HbX25pdV4Ys56uZjWlf1a4dJeLRDoTvVvWbQU+PSvPfL3k0h8Pzi2k9+28zFZbFhVt+iaaGHk1DLWiB4tovHThkNQq4D/XN0HyXorIn94QbYnsEbEo+SyJ+AIjfTo+MN/fQuGfetQ3WkYKobf7NGx8HeEcoyVcoyVcoyVcoxV481nWXFLRER+T1QAXdKzBV64opes5qky2/DBH7vxyvxtrL4lIjpLCRHBuGlIO7n/3doDspqSTkwkakXCdtafGXJ/YLs4PHlpN79N2goGnUb27H3u8p545rIeGNIhHjqNCgcLKmTSVhCPJwfZEfnzyzJpazNGo/SSyR5P2gpV3c+Tt0G7/oaq2v0FQEREFNiYuCUiooCRHB2Kp8b1wDX9W8s/GjdnFuPRb9ZjRcYR9r4lIjoLIhk3oF0cRKeE/y5Ol+1pqKFKkwXT522VlaeCqE4WPW31Wg0CgbjCpW18OO4YkYq3bhiAawe0Rnx4EGKMBozvFo+Iua9AW5gJe3AESi99FPZw71jszprYQfbZVdksCN6+1NPDISKiAMPELRERBVz1rVhM5/krert634okwzuL0lFec/yiKUREpCwpd/OQ9ogLM+BIWQ1m/7XH00PyKtnFVZj6/SZsO1wCg1aNB87rJFtKnGm7Hl8XFqTDhT1S8Op1/fDejX3Qatl/oTuyD3ZDKEoufQS2yAR4DZUK1c6q262LABs/lCAiIvdh4paIiAKSWLF76rgecmEdkcxdvTdfVt9uPFjo6aEREfmkEIMWd41ME3ku/LX7CP7enefpIXmFzYeK8PQPG2Uv4FijAVMv64E+rb2jmtTjbFaEzH0D+sM7YdcFyYXIbDEp8Damdv1hC4mUC6YZ9qzx9HCIiCiAMHFLREQBS6tR47I+LfH0ZT2QFBWC0iozXv11Oz5athvVvMyXiOi0dUiIwPjeLeX+x8v34EhZNQKVaMHz25YsvPLrNtlbvUNCOJ65vCdaxBg9PTTvYDUjfMG70B3YDIdWj7KL/g1rszbwShotarqOkrvBm38T/3M9PSI6AXVZPoLXz0XkN08hZO7rUJmqPD0kIqKzxsQtEREFvNZxYXj+8p44v1syxEWrS3fm4vE5G5CeU+rpoRER+ZxLerWQScoai022ohGLcAUai9WOD5ftxucr9skcn1h86/GLuyEiWO/poXkFschX5E8vw7B/PRwaLUrPnwRLUiq8WXXnYXBodNDlH4A2Z7enh0N1VFVlsoVF5PfPIeazf8O4ao78f6Tbsw6R3z8PdTmvpCIi38bELRERESAXh5kwqC0eu7ibvJQ1v7wGL/y0GV+u3Aez1e7p4RER+QzRfkYsuhWi12BPXjm+X3cQgaS02oznftyEZel5sm3E9YPa4tah7eVVHgSoS/MQ+d2z0OVmwG4IQeX4R2Fp0Q3ezhEcjprUQXI/ZMtCTw8noKnM1TDs+lsuaBfzySSE/TkbupwMOKCCObkjKs65FvbQSGiLsuR7TVNwyNNDJiI6YypHAC6jnZ9f7vbX1Os1MJttbn9dX8RYKcdYKcdYKcM41RILln2xYq/8o1toHhWCO0emoVXs0ctbGSvlGCvlGCtl4uLCPD2EgJzTnu77c9WefLyzaKe8kuHxS7qhY1Ik/N2hwgq89ut2FFSYZOL63tEd0S0l2tPD8hravL2ImPca1NXlsBljUHrx/0GT0MJnfu5pCrMQ/dXjcKhUKLr+FdjD49z6+gH9O8Jmgf7gFhgyVsKwfyNUtqMLylqatYap/QDZi9hurP33ZqgpQsj306EtPiz7J5eJqu6ULh78BrxXQL+vThNjpRxj1XjzWSZu3YRvWuUYK+UYK+UYK2UYp4Y2HCiUl7qWVVtkBdllvVvg4p4t5D5jpRxjpRxjpQwTt76RuBU+WLoLf+7KQ3SoHi9d1RuhBh381br9BXhvcTpMVjsSI4Px4NjOSIoM8fSwvIZ+/waEL/wvVFYzLLEtZU9bURXpaz/3In6eBn3mNlR1H4vKwde59bV9LVZnzW6HLjsdht0rYdi3Fup6PWutkQkwtR8IU4cBsEUmnjBWlrIyhP/2llz8zqHWoHzYzTB1HOLmb8L7Bdz76iwwVsoxVqfGxO1JMHHr3Rgr5Rgr5RgrZRin45VVm/Hxn3uwdn+BvN+2WRjuGJGKVs3CGCuF+L5SjrFSholb30ncij63T367Abml1ejXJhb3je4Ilegf4EfEn1M/b8zEnDUH5P0uyZF46MIu0KvZGsFJ9CA1Lv9M/PEJU4tuKDvvXkAf5JM/9/QHNiNi3quw64NRdNMbcOiD3ffaPharM+JwQHtkf21lbcZqaKpKXA/ZQqNqK2s7DIQ1tiVkL5JTxcpmQdjiDxGUsVIer+x7Gar6jjvp1waagHhfNRLGSjnGqvHms5xNEBERnUR4sB6TxnTEnSNS5WWve4+UyyTEb5uzYA+8zz6J6ARMJhMef/xx9OnTB4MHD8asWbP+8bl33XUXUlNTG2xLly51Pf7JJ59gyJAh6NmzpzxndXU1fFmQTiP73YorFdbsK8Cy9Fz4E7O1dgE2Z9J2TJckPHxhVxiD/Ley+LQ47Ahd8ZXsQSqSttWdhqLswgddSVtfZG7ZFdbIRKhFn9X05Z4ejt/QFGcjZPX3iPriEUR9+zRCNi+QSVu7IRTVnYahZNxjKLrxdVSecy2sca2UJ141OpSPvgNVvS6Wd0PX/gDjkg8Bm7VpvyEiokaibawTERER+StRHTa4Qzw6JkVg5tLd2Ha4BLOWZWDNnnzcNrwDYoy++wcoEZ29adOmYdu2bfj000+RnZ2NyZMnIykpCWPHjj3uuXv37sX06dMxcOBA17GIiAh5u2DBArzzzjvy8ZiYGDz22GNy/6mnnoIva9MsDFf2bYWvVu/HZ3/vRYfECL9oIVBcacJrv23H/vwKmZi+aXA7jOh0/CXbActqRtjimQjas1rerex/Bap6X+z7lY4qNaq7j0HYsk8RsnkharqMAlhdfUbUFUUwZKySrRB0BUcXMXRo9TC17iVbIZhbdAU0Z5m2UKlROfBK2MJiYPzzUwSnL4emshhlY+9za8U0EdGZYKsEN2GZuHKMlXKMlXKMlTKM06mJKtvF23Pwv1X7YLbaZRXujYPb4Zz2zfzu8t/GwveVcoyV77VKqKqqwoABAzBz5kz0799fHvvvf/+LlStX4rPPPmvwXLPZjB49emDevHlo3br1ceeaMGGCPNd9990n769btw633HILVq1aheDgYJ9slVD/Z+fLv2zF9sMlaBlrxNOX9YBO47vJLnH1xRu/bUdxlRnGIC0mje6ETslHF18L9H/LqpoKhM9/E/qcXbW9RUfcClPqOSd8rk/GymJCzKf3y56rpRc8AHPrXm55WZ+M1TFUNeUw7F1Xm6zN3gUVatMR4n1iTulS27dWxPMsq7L/KVb6AxsRvuBd2WvZGtMCpRc95FrQLFD5w/vKXRgr5RirU2OrBCIioiagVqkwuksSpl3bV/a7rTLbMGPJLry1cKfsh0tEgSU9PR1Wq1W2NnDq3bs3Nm/eDLvd3uC5+/btkx/wpKSkHHcem82GrVu3ynYLTiLJa7FY5Gv4w89O0XJGJDkPFlS4Wgv4ohUZR/D8T5tl0rZ5VAieHd+zQdI20KnL8hH53XMyaSv6wJZe/PA/Jm19ls6Amk7D5W7w5gWeHo33s5hkojZ83muI+XgSwv74GPrsdJm0NSemonzoRBROfEsuWGdKHdSkrTTMrXqi5LLHYQ8Oh7bwECK/exaawswmez0iorPFVglERERnICkqBE+N64FfNmbi+/UH5eJlu3JLccvQDujdKsbTwyMiN8nPz0dUVBT0er3rWGxsrOx7W1JSgujo6AaJW6PRiEceeQRr1qxBQkKCrK4dOnQoysrK5Nc0a9bM9XytVovIyEjk5vpHX9ioUANuG5aK13/bjvmbs9C1eRS6pkTBV4iq4e/WHsBPG2qTPD1bRuOukWkI0fNPKiftkX2I+OV1qKtLYTNGo/Si/4Mtpjn8UXXXUQje9Cv0h3dCk38QtriWnh6S19HmZiB4yyIY9q+XFa5OltgWtZW17fvDHhbr9nFZm7VB8RVTETH3FWhLchD5/fMoO/9+WJp3cvtYiLySxQT9oS2ylYg1JgWOkNqWTuQZnGUQERGdIdHT8NLeLdC9ZTRmLE5HVnGVTEgMTYvHhEFt+cc8UQAQi4fVT9oKzvuiNUJ9InFbU1MjFzC7/fbb8fvvv8vFyr7++muZ7K3/tfXPdex5fJn4YGtU50Qs2p6DGUt34aUre8lFIL1djcWG9xanY/2BQnn/oh4puKpfK6jVbJETqJeg28NiYGrbV/bwDdmyEOUjb/P0kLyKpuAQIn94ESp77aXStvBmqOkwQCZsbdHJnh4e7OFxKLl8CiLmvwFdzm5EzJ1+0pYeRAHBZkXQjj8Qsu4naKpKXYftwWGwRqfAGtMctpjaW2tUsk8vNOlL+BclERHRWWoVa8Szl/eSlViiimxZeh62Z5Xg9uGpvHyWyM8ZDIbjEqvO+0FBDf+gufvuu3HDDTe4FiNLS0vD9u3b8c033+DBBx9s8LX1z3Wi/raCTqdx6zpPWq2mUc4zcWh7pOeUIquoCh8uy8Dki7t6dY/w/LIaTPtlCw4WVMq+vHeMTMW5aQluiZWv0G9ZjKAlH4sFVGBp2RVVF06C1qBsATpfjpW1z/nAntUwZKyE+dxr4Qht2qo0n4mV3Y7QP2bJpK01pRNqzrkatoS2cmE68R2447tQFCt9BKqueAzBC2ZAv3s1whe9j5qqIpj6Xer7i+j54/vKC/htrOx26NL/RtDK72S7G3koLAYOjQ7qkjyoq8uhP7xDbk4OqGCPiIM9NgW22BTYY+puoxIAtcZ/Y+UBTNwSERE1Ar1WjWsHtkHPVjF4f8ku5JfX4MW5WzC2W7KsytJz8kLkl+Lj41FcXCz73IrWBs72CSJpGx4e3uC5arXalbR1atOmDfbs2SNbIogkcEFBAdq2bSsfE+cU7Rbi4uJO+NoWi/sX/WishUbuHpmGqd9vxIYDhZi3MRNjuni+Au9EduWU4s0FO1BWY0FEsA4Pju2MdvHhiuIQEIuyOOwIXfUtgjf8Iu9Wpw1BxbB/ASotcBrfv8/GKqYNDPFtocvbC83G31HV77Imf0lfiFXw5oXQ5u2DXR+C0pF3wB4aBVga9vx2B2Wx0sA86i6EhsYgZON8BK2YA0fJEVQMnSiTT4HCF95X3sKvYuVwQL9/A0JXfwtt0WF5yBYSgao+l6Km0zBAo5VtE7TFh6EpzIK2MBNaeZslW+JoSo/ITbd3/dFTanSwRiXCEdcCjshk2S5HtFuQPwcC6AORxsTELRERUSNKS4zAi1f2wpcr92Hpzlz8tuUwtmQW487hqWjTTNnKoUTkOzp27CgTtps2bXItLLZ+/Xp07dpVJmrre/TRR2Vl6UsvveQ6JhYe69Chg3yu+Brxtf3795ePiXOKc4vKXH/TIsaIawe0wey/9+J/K/ehY2IkUmJC4U3+2JmDj5fvgc3ukFdWPDi2E2KMvCzUxWZB2OIPEZSxUt6t7Dde/rEfaH+YV3c/D7qF/0XwtsWo6nUhoPX+1h9NSV1egNBVc+R+5cCrapM13k6lRuWga2ALi4Vx+WcI3rEM6opilJ13Ly8FJ7+ly9oh/62KD54EuyFU/gyr7jpaLsB49IkG2RdabKZ6X6+qLnMlcTVFRxO6KqsJuoJDQMEh1P9pKM5vjW7uSuTKtgvRzeFQeHVGIGPiloiIqJEF67V1i5TFYuay3cgursLTP2zEuN4tcUnPFGg1DZM5ROS7RBuDcePG4emnn8aLL76II0eOYNasWa7krKi+DQsLkxW4I0aMwEMPPSQTsz179sTcuXNlovbZZ5+Vz73uuuvw1FNPyUSuWKRMnPOqq676x1YJvm50lyRszizG5kNFeHfRTjx7eU+PX51QbbZi48EirMg4gk2HiuSx/m3jcPuwDjDoAqf67lRUpkqE//qWXJjLodagfPjNMKUNQSAytekjF2LTVBTBkLEapo6BGQfJ4YDxz9kycWNJbI+azsPgS2q6jpKJ5vDf34Ph0BZE/vgiyi58CPZQtr0i/6HN2ysTtvqs2rYHDq0eVd3PQ3XPC+AwKP8A1REcLhf0a7Con8MOdVmBrMw1lB4GjhyqTeyW5EJtqoQ+Zxcgtnpsxpi63rnNa/voih7Y9RPHbiLi4K192VUOh8OBAJOfX+7219TrNf5VUt+EGCvlGCvlGCtlGKfGj1V5jQUf/5mBNfsK5P3WcUbcOSINyVGB8+ky31fKMVbKxMWFed0CZSLJunDhQhiNRtxyyy2YOHGifCw1NVUmccePHy/vz5kzBx9++CGys7PRvn17PPbYY+jbt6/rXB988AE++eQT2dt2zJgxmDp1qmyh4A1z2qZ4f5ZWm/H4N+tRWm3B6M5JuGlIO3hi4bFNB4uwem++TNZabEcv6b68T0uM693itHvw+vO/ZVFRGTH3VXnprF0XhLLzJ8GS0uWMz+cPsRKtIowrv5GLshVf/VyTVR17e6z0e9YgYsE7MplffPXzHl2E7Gxipc3di4j5r8m+nqIKt/Sif3vFgmpNxdvfV97El2MlWh2Erv4Ohv21bQ3Ev9PqziNQ1ecSOEIimjZWNgs0xTmuVgsacVuUJT/w8iblw2+ubRHhZfNZjyZuTSYTnnnmGTnJFVUIN998s9xOZNeuXXJCLBZwaNmyJZ544gkMGDDAdZ5p06Zh/vz58v7o0aPlpWghISf+o5iJW+/GWCnHWCnHWCnDODVNrMSv2pV78vHJ8j2oMluh06hwTvt4nNctGSnR3nVpcFPg+0o5xso3E7ee4g+JW2FLZhGmzdsm9x8a2xm9WsWgqZmtNmw+VIxVIll7sBAm69FkbUJEsKyyHdQuDsln+DPaX/8ta/MPIPyX16CpKoEtNKo2oRXb4qzO6Q+xUtVUIObTB6CymlFy6aMNK9AakTfHSlVTiegvH5V9Lyv7jENV/9oPqzzlbGOlLs1DxNxXoC3Ng90QgrLzH4Al2f/a1nj7+8rb+GKsxGJjoWu+h2HXCqjggEOlgin1HFT2vQz28BP30HdXrMTPDZnALTraP1ckeGF3f4wdOgPKR9wCS4tubntNn0jcPvfcc1i7dq2sQhBVB5MnT5aXmI0dO7bB88rLy+UxcXnZrbfeip9++gmzZ8/GggULEBMTg1dffRV//PGH/Frx7Yik7aBBg/Dkk0+e8HWZuPVujJVyjJVyjJUyjFPTxqqowoQPl+2WPW+dujSPxNiuzdGtRRTUftoXkO8r5RgrZZi49a/ErfDFir34dcthGIO0eOnK3ogKbfzLJEUl7ZZDtZW1Gw4WyUpbp2bhQTJZO6BtHFrEhJ52hW0g/FvWHdyC8AXvQG2pkX0KRdJWrDp+tvwlVsZlnyB42xKYWvVE2YUPNslreHOsjEs/RvCOpbBGJtZWHXu4129jxEpVXY6I+a9Dl7sHDrUW5SNvg6nDQPgbb35feRtfipWqsgSh639G0PalUNUlQkVrl8r+l7ulgtyXYuXt81mP9bitqqqSl4rNnDkTnTt3lltGRga++OKL4xK3P/zwg6yeFRW3Go0GkyZNwrJly7Bt2zYMHTpU7l999dVyQQfh2muvxddff+2h74yIiOjEoo0GPHxBF2TkluG3rYexdn8BtmWVyE1UeJ3XNRlDUuMRxD6KRBRgrurfGjuyS3GwoALvL9mFRy7q2igfZlltdmzNKpbJ2vUHClFd74/IWKNBJmvFJtrYnG2y1p8F7VgG4x8fQ+Www9y8E8rGTuKCMseo7jZGJm71BzZBXZIHe2Q8AoUue5dM2goVw//l8aRtY3EEh8kK6vDfZ8Cwb53sfVtRUYjqnhcG3CJ85DtEFWvIxvkI3rJAXgUgmFO6oLL/FbDGt/H08OgMeCxxK1bQtVqtcmEGp969e2PGjBmw2+0NVuFds2YNRo4cKZO2Tt99951rPzIyUlbfXnzxxfK+aL0gVvglIiLyNiIx0CExQm4F5TVYuC1brlyeW1qNT//agzlrDmBEpwS5aA9XLyeiQKHTqHHPqDRM+XYDth0uwa+bs3Bhj5QzTtbuyC6Rydp1+wtRabK6HosK1bsqa9s2C2Oy9lQcDoSs+R6h636Sd2tSz0H58FsADde4PpYtKgmmFt3kolbBW39H5ZDrERBsFhj/mCV3qzsNgyXJz9oJaPUoO+9ehK74H0I2L5C9jDXlBagYcgOg5gft5EUsJgRvWYiQjfOgNlXVHopvi8oBVzZZ+xZyD4/9xhUr7EZFRUGvP/ppXGxsrOxXW1JSgujoo6u5ZWZmolu3bpgyZQqWLFmC5ORk2VZBJHqFRx55BPfdd59coVcQK/G+9957HviuiIiIlIsNC8J1A9vgst4tsHx3HhZsOYy8shr8sikL8zdnoV+bOIztlox28eGeHioRUZNLigzB9ee0xUfLMvDNmgPolByJ1govI7TZHdhZl6wVVzNU1BxN1kaE6NG/TaxM1rZLCPfbtjSNzmZF2NKPELTrb3m3ss+lqOo3npWGJ1HdY6xM3Abt/FPGKhCqkkPWz4W2OAf24AhUDrwafkmtRuXgCbI1SOhf/5OV1eqKIpSNuQfQNX5bF/pnusM7EbpqjvxQyRrTHLboFHlrjUmRFdIByWaV7RBC1/0se0wL1uhkWWFrbt2LP7P9gNaTq+/WT9oKzvtiFd1j2yqIFXZvvPFG2Vrh/9u7D/CoqrQP4P8pmUx6I4RAkCYECBBCR0A6Im0BUdRFQSzY91t1BXVVRBCfLepawYKsdQFFxEpRRKRL7y2EQBJIIL3OZOZ+zzkhISEJucEkc2fu//c8s3hn7kzuvHvmzpn3nvOe7777Tq7W+8MPPyAyMhKJiYny35dfflmO4p0zZ47877lz51b5t728TA3eds1mXo1Ti7FSj7FSj7FSh3FyTaxEDagx3a7BqLjm2HnyAr7ffVqWTxCL5ohb24hAjIqLkqPEzKZLM1LcBduVeowV6d2g9k1kHfDt8efx1trDmDupW7XlY5xOBUfOZmHL8ZJkbXaBveyxQKsXeopk7bXhiG4SBKORP1xrw1CUj8AfX4flzEEoBiNyB01r0JW23ZU9KgbFIc1gzkiC9dB6FHS9EZ7MlJ4kE7dC7oApUKyeveBqQexIOPzDSkonJOxG8IqXkDX6MSi+Qa4+NM/nsMNv65fw2fWDXGBL8Dp3ouIuvkFwhDWXSUuRyHWIhG5IM89Nrjud8D66SS48JkaBC47AcOT1moiitn3lBQfyDC5L3Hp7e1dK0JZuW60Vp4aKEgmi9IGobSt07NgRGzdulIuUTZkyBc888wwWL16M2NhY+bhYpEzcL/Zv3Lhxpb9tL7cQQUNiYWb1GCv1GCv1GCt1GCfXxqpLVIi8JV7Ixap9Sdh0LBXHzmXjPz8eRKifBcM7NcPgDk3gb/WCO2G7Uo+xIj0TpQvuvr4tTpzLliVkPt54HPcOii573Kkosk64GFm7Lf48MvMv/Z4QC5v1bNVIXuTq0DQYJiZrr4ox5wKCvv23XOnb6WWV08TtLRpulW23ZjCgIHYEAn75ED5718i6tx47nV5xyvcpFj0qahGLomt7QQ9sbXoi0ze4ZNGy1JMI+XIOssY8AUdIpKsPzWOZLpyRyXLzhUS5XdBhIOzNY+T95gun5bnKlJ0GU36WvFlO7y97rgIDHEGNSxK6F0fmioSuIzDCfRObigLLyR3w2/KlvEhUmrTO7zkehR0GspSNB3LZ/6MRERHIyMiQI2TNZnNZ+QSRtA0MrDglNDw8HK1bVyyi3LJlS6SkpCA+Pl6OyG3f/lItHZHYFXVyz549W2XiloiISOuuCfOXyQqxYM/PB1Kw9kAy0vNsWLL1JL7acQoD2kXIxcyahnj+NEwi0hdxYeqBoe3x0sq9WH/4HDpHhcjSMmIGwrYTafJcWMrXYkbP1mGyDIJI1rrjrAQtMZ1PlElbU16GTARkj3kcxeEtXX1YbkXUARZTucUIOMvJnTLR56kL1nmlHIVi9kbuwKm6mo5dHNkWmTc9h6Bv/gVTdiqCRfJ21P+huOmli0xUBxSnrNnqt3kZDA47nNYA5AyeDlvrkpKZaHtpV4OtAKb0ZJjTT19K6F44A2NhDsxZ5+RNLDBX9tImLzkyV47KvVhuQSR3nWL0tIbbstfp/fDb8gW8UuPlttPbD/ndRqOg83DPHVlMrkvcihG0ImG7e/du9OjRQ963Y8cOdO7cucLCZELXrl2xffv2CveJhO2YMWPKErPHjx9HTExM2WNCVFRUA70bIiKi+hHkY8GEHi0wJq45Nh9PlXVwT13Iw08HU+QttnmIrIPbKSqEi+wQkccQSdhx3Zrj652n8ebawxUe87GY0L2lSNY2RqcoJmvrMiEQ+MPrMNoL5fTirDGPwxnYyNWH5X7MFhTEDIHfjpVyMStPTNwa8zLht2mJ/O+8PpPgDNBfO3EEN0GGSN6KkbfnTiB45T+QPWwGbDoZeVzfRA3hgJ/eg+XMAbktFv7LGXIPFL/gKvdXLD4obtJG3i7dqcCQnyVH5Iokruni6FxzehIMxTZ4pSXIW3lOq78clVscKhK5F0fohjaTr+9K5rMn5AUhS9JBua2YLciPHYmCuBuheHt2iRICDIqilBQIcYHnnnsOO3fulKUNUlNT5YJj8+fPx4gRI+To24CAADkCNykpSSZpp0+fjnHjxmHFihWyNMKPP/4oR+7ec889SE9Pl7Vtxdt5/vnn5YjcV155pcq/m5aW0+DvVdQv5NRHdRgr9Rgr9RgrdRgn7cdKfM8dTsnCj3uTsDPhwsUqX0CzEF+M7NwM/do1hkVjdVLZrtRjrNQJV7lgladr6D5tQ7fPYocTc1fuwfFzObLObbcWoeh9bWN0aR4Cr/pM1oq6gce2wHJ6n/zhfzVETV1Rg9dtOB1yNJqY9m5r1gHZIx9tsHqlnnjeM+ZlIPSjx2Q8M26ejeLGFWePunusAn98A94ntsPeuBUyb3pek1POGyxW9iIErnkH3id3ys3c/lNkuQx3opV2VcpyfJssw2EsypMJytzrbkVhp6F1NxLW6ZQjpWUiV4zOFaUWRGI366xIkFX5FEdAI5nENVh9G/zcbhTlHy4msBWjSV4Yyu8xTvO1lbXWrty5P+vSxK1YoGz27NlYvXo1/P395YJj06ZNk49FR0fLJO7EiRPLRuPOmzcPx44dQ5s2bWRd2549S65eZmVlycXI1q9fL0cbDR06VCaB/fyq7mwwcattjJV6jJV6jJU6jJN7xepcVgFW70/G+sNnUXixfruo8Ti0YySGxTRFiJ82pkxpIVbugrFSh4lbfSRuBXFui0/NwbURAfV/UUrWDdwpF8ARP+T1qLBtX+QMvQcwNVwddU897wWsWQDr0U0obHcdcobf7zGxEp+RoO9fk4vWZdz8AhzhLaBFDRorpxP+v30Cn31rZU3VrPGzYG/WAe5CC+2qdFFE/w0fw3pko9y2h7eUnx1HSNOGOYBiG8wZyZcSuhdKyi6Y8jPhaorBgKLo/sjrOR7OwHC4A620Ky1zi8StqzBxq22MlXqMlXqMlTqMk3vGKr+oWCZvV+9PQlpOkbxPLMojFui5sUsztHJxkktLsdI6xkodJm71k7htKF5nDsppqKWrlDu9fVEYMxROH/+rej2TyQiHwwl3IkaUydqRhoYdPemp7cqcGo+QZbPlCLn0O1+B0y/E7WMl6oiGfP4UTLnpyI8bjbzrJkOrGjxWigL/dR/A59CvcPiHImPyXCjWqzt/NDRXtyvBK/kIAtYulLWhRZIyv9tYudiWFhbaMog6uReSYMpIglkpbvhzu8EIW/NOsmSDO9FCu/KU/qzrPwVERET0h/h6m3FjbJRcrGzHqQuyDq4op7DpWKq8tWsSKOvgdm/ZiKusExGVYz4XX1I3sHQaqqwbeAMK4kb9obqB/MFKojyCPbKdXMDLuu8n5PeZBHfnu/VLmbR1BDaWI/+oHINBlkkQCUixEJaY6p99w8OaXuhKExzF8Nv2FXx2fgsDFHkBSdQK1tJCb4o1APZm7eWN53ZyBSZuiYiIPISoqdizVSN5O5mWg1X7krD5eBqOns2Wt/AAb9zcqxX6XhvOhcyISNdM6Unw2/oFvON3VKwb2H1stYvfENWWuAgQlHIUPgd+ljUpxcJl7kosjuSzd43875xB07iCfVUsVuQMfwDBy1+UNYC9D29AUYfrXX1Umj4Pi1G2pQuEFbbvj9wBd7h8ITAirWHiloiIyAOJ8gj3D2mPyb1bYe2BFPx8MEWWUXj7p8NYsz8Zf76uNa6NCHT1YRIRNShjdhr8ti2H99FNchGakrqB/ZDXc4Lb1A0k92Fr1U2OIBTTv0XdzsKYwXBLjmIE/LJIjogsjO4He/NOrj4izSqOaI28XhPhv2UZAn79GPbIaDiDI1x9WNqiKLDu/wn+Gz+HwWGH09sPOYPugu3aXq4+MiJNYuKWiIjIg4kFym7u1RLj4prjx71JWLkrEcfOZWP2V7vRr21j3NK7FcL8OWqGiDybIS8TfjtWwnpgHQzOkmmuRa17IK/3TW5XN5DciBjJ3WW4TFD57FmNwo6D3HLqvM/uH+RCTU6rP3L73ebqw9G8grjRsCTugyX5MALXvIPMiX/XRK1WLTDmZSLg5/dhSdwrt0Xt1pyh99ZJDWgiT8WzBxERkQ54e5nwp+7X4Pr2EVi6LQEbjpzDxmOp2H7yPMZ0bY7RsVFyHyIiT2IoyoPvzu/hs3cVDMU2eZ8tKgZ5fW6WI+OI6lthh4Hw3fYVzBlJ8DpzwO1Gqxozz8Fv+wr537n9/wzFh7N1amQ0ImfYDIQseQZeqfHw3b7CI2oc/1GW+N8RsG4RjIW5UExeyOs7GQVdhjX4gohE7oaJWyIiIp2NwJ0xOBrDY5rik00nZO3b5b+fwi+HUmRZhb5tG8PohqOBiIgqsBfBZ+9q+O76Dsai/JK7ItrIhK09qqOrj450RPH2RWH7AfDdtwY+e1a5V+JWURCw/kM5nV1c8Chqd52rj8htOAPCkDvwLgSufgu+O76B/ZpOsDdtDz0y2Arg99un8Dn0q9y2N7oGOcPuhyMsytWHRuQWmLglIiLSodaNA/Dsn2KxLf48Pt8cj/O5RXjn5yNYvT8Zd/Rrw/q3ROSeHMWwHvwFvr9/DVN+lryrOLQZ8npPkvVG3XGaOrm/gi4j4LNvLbxP7YEpIxmOkKZwB95HNsJy5qAcHSkXJOPnp1aK2vZGYeJeWA9vQMCahci4dS4Ubz/oiTnlGALXLoQpOxUKDCjoNkrWAIbJy9WHRuQ2mLglIiLSKYPBgN5twhHXIgw/7j2DlbtO40Rqjqx/e9214ZjcR9S/tbr6MImIauZ0wvvYZrnwmCk7Td7lCAyXCYKitn3l1GUiVxGLU9ladoV3wi45Ejx34DRonaEgG/4bP5P/nddrApxBXGDrauQOmAKv5CMycen/y2LkjHhQHwlwR7G8gOa7Y6VcCNLhHybLR9ib6XPUMdEfwcQtERGRzlnMRozrdg0GREfgi+0J+PXwOWw6nobfEy7I2rejuzaHlfVviUiLFAWWkzvht/ULmNOT5F0O3yDk9/hTyUJQXBCINKIg9gaZuLUe2gB7k7YlZQc0nMDz/+0zWYu0OOwaFMSOdPXhuC3F4oPs4Q8gePmLsB7fCluLWBS17w9PZspMkSOMRX1fobDddci9/k5ZNoSIao89GSIiIiqrf3vvoGgMi2mKTzfF43BKFr7akYhfDp2Vo2+vY/1bItIQr9MH4LdlWVlywOnth/xuo1HQeTjg5e3qwyOqwN6sA4qu6QLvxL1y6nhhwm458laxam/qvFfiPliPbpJT23MGT+cFkD+ouEkb5PeaAL+tX8L/149gj2zrmSOYFQXWA+vkSG2xGKTT21e28aK2fVx9ZERuzaAoigKdSUvLafC/abGYYLM5GvzvuiPGSj3GSj3GSh3GST1Pj5XoHmw/KerfnkRaTqG8r3V4AKb0a412TYJq9VqeHqu6xFipEx4e4OpD0GWfVivt03zuhEzYitqbgmK2ID/2BhTEjdJM/UitxMod6CpWTodcqMp3+woYFCccfiHIGXof7M1jtBMrexFC//e0LDmS32UE8gZMgTvSXLtyOhG84iV4pRyVCyVmTnhGMwnxuoiVIT8LAT+/L+s4C7ZmHZEz7D44/UPhSTTXrjSMsaq7/iwTtw2EjVY9xko9xko9xkodxkk9vcTKVuzEqn1J+HpnIgrtJe+3z7XhuLV3KzQKUFf/Vi+xqguMlTpM3OozcWu6cEaOWPM+uUNuK0YTCmKGIL/HOCi+tbug5Omxcid6jJW4+BCwZgHMWefkdn7sSOT1mQSYLS6Pld+mJfDd9R0c/qHIuG2+nOrvjrTYrozZ5xGy5O8w2vKR12M88ntPhCfESpSrCVj3AYwFOVCMZuT1vQUFsSMAg+fVFtdiu9IqxqpmTNxeARO32sZYqcdYqcdYqcM4qae3WGXm2/DFtgSsP3wWouPgZTJiVGwUxsbVXP9Wb7H6IxgrdZi41Vfi1pidJhcd8z6yCQYoUAwGFEX3Q17PCXAGhkOL+FlWT7exshfJKeU+B9bJzeKw5sgefj8cYc1dFitzWgKCl82Wo4GzRv0VtlZxcFdabVfex7YgcPXb8jwmRt0WR7Zz31iJNvzbZ/A5qL4NuzuttistYqxqxsTtFTBxq22MlXqMlXqMlTqMk3p6jdWp87n4eOMJWf9WCPa14JbeLdG/XUS19W/1GqurwVipw8St5yZuDbYCmNLPwHxB3E7LUbZeZ4/B4Cz5u0WteyCv901whDaDlvGzrJ7eY2U5uQsB694vN1rxZrmQWVWjFes1VmIq/xez4ZWWgMI2vZAz8mG4My23q4C1C2E9shGOgEbImDzX5Yt2XU2sTBkpCPzulUujxrveKM/NNY0ad3dabldaw1jVjInbK2DiVtsYK/UYK/UYK3UYJ/X0HCvRdfg94QI+3xyP1OyS+retwv0x5bo2iI6sPF1Zz7GqLcZKHSZuPSBx6yiGKfOsTM6KJK0p/eK/Oeer3N3WvBPyek9CcURruAN+ltVjrC7WB133AbwTdl+qDzr0XjgDwhosVj57fpSjJ50WX6Tf/jIUv2C4My23K3GBSpRMEHWEC9tdh5zh97tVrMzJRxD0/WswFuXJkhqyTnNUR+iBltuV1jBWNWPi9gqYuNU2xko9xko9xkodxkk9xgqwO0rq367Ycan+be82JfVvwwMv1b9lrNRjrNRh4taNEreKAmPuhZKk7MUkrTn9DEwZyWWjaC8nFmxyhEWhODRKTr0tDm8pt90JP8vqMVYXKQqsB3+B/2+fwlBsg9PbF7kDp6GobZ96j5WovRr6+VMwFBchZ9BdKIwZDHen9XZlPnsMwcvnybIU2cPuR1H0dW4RK8vxbQhcuxAGh10usiZKaii+gdALrbcrLWGs6q4/q41lDImIiMjtiDq3Y7o2x4B2EfhiewJ+OXwWW0+kYWfCedzYpaT+rY+FXQ0ivTAU5sGcXlLe4NJI2jMw2gqq3N/pZb2YoG2O4rAoWRdR/KtY/Rv82IlczmCQCVN7s/YIWLMQXqnxshZqYcJu5F5/BxRvv/r5u4oC/1//K5O2tshoFHYcWD9/hyoobtIW+T3Hy/rdIv72yLaardktKQp8dv8I/02fy82iVt2QPfwBwMvb1UdG5PE44raB8GqDeoyVeoyVeoyVOoyTeoxV1fVvP910AgeTS+rfBon6t71aYmjnpii2O119eG6B7Uodjrh18YjbYpusbyhGzpYlaEU92ryMKp+nGE1wBEfKpKwYQVuarJXTwKupje3u+FlWj7GqgqMYvr+vhO+Or8UPdjj8w5AzbAYMrWLqPFZli2UZzciY/KLm60d7VLtyOhC84iV4pRyDvUlbZE54GjBeecFXl8TK6YTfb5/Cd98auVnQeRhy+08BjJXrMHs6t2hXGsFY1YylEq6AiVttY6zUY6zUY6zUYZzUY6yqJroVOxMu4NNy9W+vCfOTJRTiWoSieagfDB6aqKkLbFfqMHHb8H1aU3oS/HeuhDE1AabMc3J6b1XEYjty9KwcRdusJFEbHAmY9DX6np9l9RirK0+nD1yzEKbsVCgwwNZjNLJ7TABMXnU2Sj70s5kwFmQjr+cE5PeaAE/hLu3KmJ0m692KmQl5vSbKUbiaipW9CIFrFsD75A65mXvdbSjoOtJjL7p5SrvSAsaqZkzcXgETt9rGWKnHWKnHWKnDOKnHWNVc/3bN/mR8teMUCsrFKczfWyZw41qEoUPTYFjM+hutcSVsV+owcdvwfVq/DZ/Ad+/qsm2nt9+l8gahl0bSKhafBjsmLeNnWT3GquaFrPx++ww+h9bLbXuja5Az7P46qfvsv+4D+Bxcj+KQpnK0bV0lhLXAndqV95FNCFy7AIrBiMyJz8gyClqIlaEgG0HfvQqvcyegmLyQPWwGbNf2gp65U7tyNcaqZkzcXgETt9rGWKnHWKnHWKnDOKnHWKmTU2DHrtPp2H4iDQeSMmErvjRKz9tsRExUiEzkdr0mFCF+rJPGdqUOE7cN36c15GXC98we2KwlC4c5/UJ0O+JKDX6W1WOs1LHE70DAug9gLMyVSbS8vpNR0GUYYLi6C6BeSYflNH0hY8IzKG4aDU/ibu0qYPU7sB7bDEdgODImz23Qi2BVxcqUeRZB3/xLjvYWF+qyRv2fx7URPbQrV2KsasbE7RUwcattjJV6jJV6jJU6jJN6jFXtY2Urdsjk7e5T6dh16gLS82wV9msV7i8TuGI0bstwfxh1mBRiu1KHiVsX17ilGjFW6jFW6nnbsmFd9S4siXvltq15J+QMvbfkQkptFNsQsuRZmDNTUBAzGLmD7oKncbd2ZSjKlyUTTDnnURjdT9Y0dlWsRIkOMdJWXCQQieSsMU/AERLZYMejZe7WrlyJsaoZE7dXwMSttjFW6jFW6jFW6jBO6jFWfyxWovuReCFPJnB3nUpHfGoOyndIgn0tF5O4oXJUrtWr4RfrcAW2K3WYuC3BxK12MVbqMVa1jFVRMaz7f4L/xs9hcNjlaMicwdNha9NT9ev4bv0Sfr9/DYdvEDJufxmKtx88jTu2K3PKUQR/NU8uSJc94kEUte3T4LGynNgua9qKtmVv3ApZox+D4hvUIMfhDtyxXbkKY1UzJm6vgIlbbWOs1GOs1GOs1GGc1GOs6jZWWfk27EkUI3HTse9MBgrtl/b3MhnQsWkwurYIk4ncRgFWeCq2K3WYuC3BxK12MVbqMVZXFytTRjIC1iyAV1qC3C5sPwC5A6bUOMXedOEMQpY+C4PTgawbHvbYmqXu2q58ty6H3+8r4LT4ypIJzsBGDRYrnz2rZD1lAxQUteyK7BEPAV4sY+UJ7coVGKuaMXF7BUzcahtjpR5jpR5jpQ7jpB5jVX+xEgubHU7OKhuNm5ZTWOHx5qF+ZQuctWkcAKPRc0oqsF25Z+K2qKgIL7zwAlavXg2r1Yrp06fL25WcOXMGY8eOxYIFC9C7d++y1/nHP/6B77//Xm4PHz4cs2bNgq+vb5WvwcStdjFW6jFWfyBWjmL4bv8Kvju/laM0HQGN5AJS1dYiVZwIXj4PXmePoahlHLJH/Z/H1qp223bldCB4+Vy5IJgtMhpZ458CjPW7kKvFywCvdZ/Ad88quV0QMwS5198BGPUx20kX7coFGKu668+aVe1FRERE1EC8TEZ0bh4ib3f0U5CckS8TuLsSL+Do2WycTs+Tt5W7TiPQ6oXYiyUVOjUPga+FXRtqeCLZun//fvz3v/9FcnIyZs6ciaZNm2LkyJHVPmf27NnIz8+vcN+bb76Jbdu24d1335XlRETS9pVXXsHf//73BngXROR2TGbk97kZtmu6IHDtQlkfVSw4lt9tDPJ7TpCPl2c98ItM2jq9rMi9/k6PTdq6NaMJ2cMfkPVuLSlHZFI+v8e4+vt7xTb4rloIr+Pb5WZu31tQEDeabYNIQ/jrhoiIiDTLYDCgWaifvI2Ja47cQjv2ns7AzlMXsDcxA9mFdmw4ek7eTEYD2kcGlY3GjQhquBWZSb9E8nXZsmV47733EBMTI2/Hjh3Dp59+Wm3iduXKlcjLy6t0//r16zF58mR07txZbt92221YsmRJvb8HInJvYoRtxq3z4L/hY1gP/wa/Hd/AkrgPOcPvhyOkqdzHmJcBv80l55O8PpPgDAhz8VFTdZxBjWViPfCnd+G7bTlsUTEobtKmzv+OoSAHQd+/JpP5itEsF7orate3zv8OEf0x9TvmnoiIiKgO+Vu9cF3bxnh4WAe8PbUPnhnXBaNioxAZ7AOHU8GBpEx8sikej3++HbOW/I4f9pxBTqHd1YdNHuzw4cMoLi5GXFxc2X3du3fHnj174HQ6K+2fkZGBf/7zn5gzZ06lx4KDg7Fq1SpkZWXJmyi90KFDh3p/D0Tk/kRt25yh98m6tWLBMlH7NmTpc7DuWytWBIX/rx/DaCuAPaINCjsNc/XhUg2KovuhsG0fGBQnAte8A4OtoE5f35h1DsFfzilJ2nr7Imvck0zaEmkUR9wSERGRWzKbjOjQNFjebu/bGmczC7A7saQu7uGULJzJyMenm+OxZOtJ9GrdCIM7RsoRuWIUL1FdSUtLQ0hICCwWS9l9jRo1kvVqMzMzERoaWmH/l19+GRMmTEDbtm0rvdaTTz6JRx55pKzmbbt27fDOO+80wLsgIk8hFhvLaHItAn5+H5bT+xHw60ewHvpVJnIVowk5g+6q95qpVAcMBuQOnAqvlGMwZafCb8MnyB16b528tPncCQR99wqMBTlw+Ichf+KTsAdE1slrE1Hd4xmbiIiIPEKTYB+M7BKFp8Z2wTtT+2L69W3RspE/ip0KNh1Pw7yVe/Hkkt/xvRiFW8BRuFQ3CgoKKiRthdJtm81W4f5NmzZhx44dePDBB6t8rcTERERGRspauR988IFM/opELxFRbTj9Q5E19gnk9v8zFJOXTNoKBV1HwdHoGlcfHqmkePvJcheKwQCfwxtgOb7tD7+m5eROBK+YL5O29kYtkDnpeTjDourkeImofnDELREREXkcX28zhnSMlLeTaTn4+WAKNh9PQ0pmAT7bHI+lW0+iZ+tG8nGOwqU/wtvbu1KCtnTbarWW3VdYWIjnnnsOzz//fIX7S+Xm5uKZZ57B4sWLERsbK+976aWXMGXKFDz66KNo3Lhxped4eZkadP0Ys5krjKvFWKnHWNVXrExw9ByF3FZd4PPzh3LRK3u/ibDoJN4e065adkRRz3Gwbvsagb8sQk7zdlCusj6xZfdqWH/5CAZFgb1lLPJHPwqzxeo5sWoAjJV6jFXdYeKWiIiIPFqr8ADcPTBAllPYcjwNPx9Kwcm0XJnIFbcmQT4ygTugXQQCfLxcfbjkZiIiImTdWlHn1mw2l5VPEMnZwMDAsv327t2L06dPyyRseffeey/Gjx+PSZMmyYXO2rdvX/ZYx44dZZ3cs2fPVpm4tdsdaGg2W8P/TXfFWKnHWNVjrAIjUTj+6ZL/FmW3dRRrT2lXtm5/gilhH7xS42H9/m1k/WlW7cpdKE74bV4Kn13fy82CjgORO3CaTO6XtgdPiVVDYKzUY6zqBhO3REREpAs+FrOsczv44ijcdYfOYtOxVJzNqjgKd3CHSHRoylG4pI5YPEwkbHfv3o0ePXrI+0Q5hM6dO8NY7od1ly5d5GJj5Y0YMQJz585Fv379YLeXlO84fvw4YmJi5H/Hx8fLf6OiOI2ViEi3TGZkD38AIUufhSX5MHx2fYeC7mPVPbfYhoCf3oP1+Fa5mdd7EvLFc9nHIXIbTNwSERGRLkfhitttfVpVOwp3cIcmuD66CUfh0hX5+PjIEbOzZ8+WpQ1SU1OxaNEizJ8/v2z0bUBAgByB26JFiypH7IaFlUx7HTBgAJ599lnMmTMHiqLIsgqjR4+utMAZERHpizM4ArkD7kDgz+/Bb9ty2KNiUBzR+orPMRTmIvD7/8CScqRkYboh96Aoul+DHTMR1Q2DInqFOpOWltPgf9NiMXGYuEqMlXqMlXqMlTqMk3qMlefFqvwo3MKLU9DNRgN6iFq4DTQK111i5Wrh4QHQ2gJlInErRtT6+/vj7rvvxrRpYhoqEB0dLZO4EydOrPQ88dhHH32E3r17y+2srCy5GNn69etlWxs6dChmzpwJPz8/TfRp2T7VY6zUY6zUY6x0HitFQcCqt2A9sQ3FQRHIuOVFwFK5ZrpgzE5D0Df/gjkzBU6LD7Jv/AvsUR31E6t6wlipx1jVXX+WidsGwkarHmOlHmOlHmOlDuOkHmPlubESSdvNx1PlgmZiFG4pMQp3UIcmGBAdgSAfS738bXeLlatoLXHrKkzcahdjpR5jpR5jpZ6nxspQmIeQJc/AlJteUqt28N2V9jGnxiPo21dhLMiCwz8UWWOegCMsSnexqg+MlXqMVc2YuL0CJm61jbFSj7FSj7FSh3FSj7HSR6zEKNxfDp3FxnKjcE1GA3q2aoTBHZugQ9NgGOtwFK47x6ohMXFbgolb7WKs1GOs1GOs1PPkWHklHULQipdhgIKskY/A1qZn2WOWhN0IXPUmDMU2FIddg6wxj8HpH6rbWNU1xko9xqru+rOscUtERERUUy3cvq2xRY7CPYv4tBxsOZEmbxGBVrmY2YD29TcKl4iIiKiUvVkHFHQbDd+d3yJg3SJkRLSRyVnrgXXwX79YjM6DrXknZI98BIrFx9WHS0R/EEfcNhBebVCPsVKPsVKPsVKHcVKPsdJvrBLO52LdwZRKo3B7iFG4HZqgY7OrH4XrabGqLxxxW4IjbrWLsVKPsVKPsVLP42PlKEbw8hfhlXoStmYdURzRBr47v5EPFbQfgNxBdwEmdeP0PD5WdYixUo+xqhlLJVwBE7faxlipx1ipx1ipwzipx1ip56mxEklbMQpXLGh2IvVS38LqZYKXyQijATKBazQaINK44l+5bYBceKr0v0seF/uJBLBR7ivyviWPl9tfPr/k/pLnl9vHWPK3nU7AqShwKAqcTkWsYyK35c0p/r207ajh8Qrb8r+rfjy6SSBmjulc7wu3lcfEbQkmbrWLsVKPsVKPsVJPD7EyZaYgZMmzsixCqbxeE5Hf408lHQmV9BCrusJYqcdY1YylEoiIiIjqkUjQDuoQKW+nzufKxcxKR+GWjsTVg7ScQpnANTVc3paIiEj3HMGRyB1wBwLWfQDFaELO4Okoaj/A1YdFRHWMiVsiIiKiP6hFI3/cdX1b3N63Nc7nFskRqUrpCNWLo1UrjG4tv+0EFJSMYDWajLDZHZeeWzpyVo6mvTTqteTxcq8v9lAujfAtHYVbftRuhcdKR+5eti1uouxDhdHCV3i+uIX4WeRziIiIqGEVdrgeTp8AWeO2OLylqw+HiOoBE7dEREREdcTby4RmIb5X/XxOKyMiIiLVDAbYWnVz9VEQUT26WBGNiIiIiIiIiIiIiLSCiVsiIiIiIiIiIiIijWHiloiIiIiIiIiIiEhjmLglIiIiIiIiIiIi0hgmbomIiIiIiIiIiIg0holbIiIiIiIiIiIiIo1h4paIiIiIiIiIiIhIY5i4JSIiIiIiIiIiItIYJm6JiIiIiIiIiIiINIaJWyIiIiIiIiIiIiKNYeKWiIiIiIiIiIiISGOYuCUiIiIiIiIiIiLSGIOiKIqrD4KIiIiIiIiIiIiILuGIWyIiIiIiIiIiIiKNYeKWiIiIiIiIiIiISGOYuCUiIiIiIiIiIiLSGCZu60hRURGefvpp9OjRA/3798eiRYuq3ffgwYO4+eabERsbi5tuugn79++Hnpw7dw6PPvooevXqhQEDBmD+/PkyflV54IEHEB0dXeG2bt066MWaNWsqvX8Ru6ps2rQJY8aMke3qzjvvxOnTp6EXy5cvrxQncWvfvn2V+48bN67SvkePHoUns9lssn1s3bq17D7RRqZNm4auXbti1KhR+O233674Gt9++y2GDRsm29hDDz2E9PR06CVWu3fvxq233oq4uDjccMMNWLZs2RVfQ3wXXN7G8vLyoIdYzZ07t9J7/+STT6p9jcWLF8vvAhFb8T1aUFAAT3R5rGbNmlXleUucv6uSlZVVad/evXs38LsgT8f+rHrsz6rH/qw67M+qwz6teuzTqsc+rXrs07qAWJyM/rg5c+YoY8eOVfbv36+sXr1aiYuLU3744YdK++Xl5Sn9+vVTXn75ZeX48ePKiy++qFx33XXyfj1wOp3KLbfcotxzzz3K0aNHle3btyvDhw+X8aiKeOzrr79WUlNTy25FRUWKXrz99tvKjBkzKrz/rKysSvslJSUpXbt2VT744AMZ17/85S/KmDFjZLz1oKCgoEKMkpOTZduZN29epX2Li4uVzp07K9u2bavwHLvdrniqwsJC5aGHHlLatWunbNmyRd4n2oY4Zz3++OPyXLRgwQIlNjZWtqWq7NmzR+nSpYvy1VdfKYcOHVKmTJmi3HfffYoeYiXaR48ePZR///vfysmTJ5Vvv/1WtqF169ZV+Rpnz56Vz09MTKzQxjzt81hVrIRp06YpCxcurPDe8/Pzq3yNH3/8Uenevbvy888/yzY2atQo5YUXXlA8TVWxys7OrhCjXbt2KZ06dVLWrFlT5Wv8/vvvSq9evSo85/z58w38TsjTsT+rDvuztcP+rDrsz9aMfVr12KdVj31a9dindQ0mbuuA6KSKE175D/lbb70lvwQut2zZMmXIkCFlJzvxr/hC/vLLLxU9EF+m4kOelpZWdt8333yj9O/fv9K+okPboUMHJT4+XtEr0QERX6w1ee211yq0N/GFIn5slW+TeiI6bMOGDavyR1FCQoLSvn17+aWjB8eOHVPGjRsnO7Tlv2A3bdokfxyV/5E9depU5fXXX6/ydf72t78pM2fOLNsWPyaio6NlR87TY/XZZ58pI0eOrLDvs88+qzz22GNVvs7GjRtlQsOTVRcrYcCAAcqGDRtUvc7tt99eoc2J5If4MVVdp9jTYlXe9OnTlSeeeKLa11m6dKkyefLkejxS0jv2Z9Vjf7Z22J+9OuzPVsQ+rXrs06rHPq167NO6Dksl1IHDhw+juLhYDokv1b17d+zZswdOp7PCvuI+8ZjBYJDb4t9u3brJKQt6EB4ejvfffx+NGjWqcH9ubm6lfePj42V8mjdvDr06ceIEWrZsWeN+ol2JaSylfHx8EBMTo5t2VV5mZibee+89PP7447BYLJUeP378OCIjI+Ht7Q092LZtm5x6smTJkkptpmPHjvD19S27T5ybqmszl7cxEcOmTZvK+z09VqVTYC9X1XmrtI21atUKnqy6WImYiOnDas5bDocD+/btq9CuxBRHu90uv1c9PVblbd68Gdu3b8djjz1W7T6iXamJK9HVYn9WPfZna4f92dpjf7Yy9mnVY59WPfZp1WOf1nXMLvzbHiMtLQ0hISEVvlRFR07UuRJfuqGhoRX2vfbaays8PywsDMeOHYMeBAYGyi+MUuKHgKgT06dPnyo7uv7+/njyySflSaJJkyZ45JFHMHDgQOiBGBF/8uRJWaNp4cKF8gth5MiRsibY5R040a4aN25cqV2dPXsWevP555/LWIhYVffjwcvLCzNmzJD1+ERnRLSxLl26wBPdfvvtVd5f2zaTmprq8W2sulhFRUXJW6kLFy7gu+++k+ej6tqYqGl1xx13yM9whw4dZJ0rT+r4Vhcr8d5FgmLBggX49ddfERwcjLvuugsTJkyotG92drb8nizfrsxms3yOHtpVee+++66MkfjxWB0RW5FUmzRpkvwhIX4cPPXUU5U+l0RXi/1Z9difVY/92avD/mxl7NOqxz6teuzTqsc+retwxG0dECezyzsepduicLOafS/fTy/++c9/ysUt/vrXv1bZ0S0sLJSLY4hRDaKDKxZ3EFez9CA5Obmsvbz22muYOXMmvvnmG/zjH/+otC/b1aUfB6LA/pQpU6rdR3Q6REF0saCK+GJp06YNpk6dipSUFOhJbduM+CyyjZXEQXRuRTJj8uTJVe4jzl2ijYnz1dtvvw2r1SoXzKhuNIMnKR1Z1rp1a/n5Ep+zZ599Vi5MU1UsBb23K7GgypYtW+SPoppiK9qQ6Ni++uqr8ofn/fffL5MgRHWB/dmrx/5s9difrT32Z2uHfdqrwz7tlbFPW3vs09YfjritA2KKyuUfyNJtcXJTs+/l++mlk/vf//5XfljbtWtX6fEHH3xQfuiDgoLktlhR9cCBA1i6dCk6d+4MT9esWTO5UqN4/+JLQ1zhFCM6/va3v8mTnMlkqrFdiREheiJ+BImrdqNHj652nxdffFF+uYrRL8Ls2bOxc+dOfP311/ILQy9EmxEjqNSei6prY2Iao16IFXTFeSkhIQGfffZZte/9gw8+kFOj/Pz85Pa//vUv+UNdrCA+duxYeLLx48dj8ODBcoRB6XlbxEuMHBo+fHiFfUund+q9Xa1atUqe3y8fvXg5MSJGfBeUfkZff/11mQgSUzvFFHWiP4r92avD/uyVsT9be+zP1g77tLXHPm3N2KetPfZp6w9H3NaBiIgIZGRkyOHe5adsiIZ4eUdD7Hv+/PkK94ltvQ0LF52NDz/8UHZ2b7jhhir3MRqNZZ3cUuKKl+jI6IX4oiitHyeIq+liGoa48qmmXYkabHqyYcMGOdXi8nZTnpi2UtrJFUqvpOqpXV3NuUjvbUxcFb777rvlNGDxA/1KdZnE1fXSDm5pZ05MS9NDGxOfp9IObqnqPl9iPxGb8u1KfI+KH196aVel562hQ4fWuJ/o+Jf/ESqmdYoY6qFdUcNgf7b22J9Vh/3Z2mF/tnbYp60d9mnVYZ+29tinrT9M3NYBcVVBfHmWL4C+Y8cOeRVddNbKi42Nxa5du+QUGEH8K66Oivv14s0338T//vc/vPLKK1e8kjxr1ix5Jb48UdxbnDD1cuITxb/F9J9Shw4dkie18nXmBNF+RJsrJZ4jpuzpqV0Je/furfEqnRj1ItpgKTHq48iRI7ppV6VE2xAjfkqn9giiDVXXZi5vY2IqnrjpoY2JNvLwww/jzJkz+Pjjj9G2bdtq9xXn9GHDhmH58uVl9+Xn5+PUqVO6aGP/+c9/5BQ6Nedt8f0ovifLtyvxPSq+T8WoBj0Q7UWMrKrpvCV+ZPXs2VNOPyslOrciyaaHdkUNg/3Z2mF/Vh32Z2uP/dnaYZ9WPfZp1WOftnbYp61fTNzWAXHFQAylF1NUxBft2rVrsWjRItx5551loxVKv0hEgXlRvHrevHlyNT3xr+iU3HjjjdADUYha1Me599575WqfIjalt8tjNWTIEFkDa8WKFfILQnROxMnwSvWePIlY1Vlcufv73/8u68CsX79e1gO75557ZP0XEavS6Rg33XST/MEk6u+Iq6fiB4K4Gio6ynoi3vvlUzMuj5VoV4sXL8ZPP/0k4zpnzhzk5ORUWWjek/Xq1UsWjRdtRcRNtB1x/hJF4gURLxG30lpDt912m5x+J2quiU6LWABj0KBBulgl+4svvpDTPOfOnStHnZWes0qn5ZWPlbg6L+LyxhtvyOeI2IpYicVo9LAQjZhSJlaSFVPrEhMT5fQ7cQ6fPn26fFyc30vP96WLHIh9xfemaH/ie/SWW27RzbSypKQkOV2xqill5WMlRlWJ70yxErSIk/iBKmppisWRoqOjXXDk5InYn1WP/Vn12J+tPfZna4d9WvXYp1WPfdraYZ+2nilUJ/Lz85Unn3xS6dq1q9K/f3/lww8/LHusXbt2ypdfflm2vWfPHmX8+PFK586dlUmTJikHDhxQ9GLhwoUyHlXdqorV0qVLlREjRiidOnVSJkyYoGzbtk3Rk6NHjyrTpk2T7apfv37KG2+8oTidTuX06dMyVlu2bCnb95dffpGx6tKlizJ16lQlMTFR0Rvxmfr1118r3Hd5rET83nnnHWXQoEGyXf35z39Wjhw5oujB5W0mISFBvn8Rh9GjRysbN24se0zsJ/YX8SslPpsDBw6U7fGhhx5S0tPTFT3Eavr06VWes6ZMmVJlrAoLC5X58+fLz2xsbKwyY8YMJTk5WdFLu1qzZo0yduxY+XkcOXKksmrVqgptqPR8X/57oW/fvkr37t2Vp556SsZPL7HavXu3vK+oqKjSvpfHKjMzU5k1a5bSu3dvJS4uTnniiSfkfUR1if1ZddifrR32Z2uH/dmasU+rHvu06rFPqx77tA3LIP6nvpPDRERERERERERERKQeSyUQERERERERERERaQwTt0REREREREREREQaw8QtERERERERERERkcYwcUtERERERERERESkMUzcEhEREREREREREWkME7dEREREREREREREGsPELREREREREREREZHGMHFLREREREREREREpDFmVx8AERGVGDJkCJKSkqp87KOPPkLv3r3r5e/OmjVL/vvyyy/Xy+sTERERkT6wP0tEVLeYuCUi0pCnn34ao0aNqnR/UFCQS46HiIiIiKg22J8lIqo7TNwSEWlIQEAAwsPDXX0YRERERERXhf1ZIqK6wxq3RERuNPVs8eLFGDt2LLp27Yr77rsPaWlpZY+fOHECd999N7p164YBAwbgzTffhNPpLHv866+/xsiRIxEbG4tbb70VBw8eLHssNzcXf/3rX+VjgwYNwjfffNPg74+IiIiIPBv7s0REtcPELRGRG3njjTdwzz33YMmSJSgoKMAjjzwi709PT8ftt9+Oxo0bY9myZXj++efxySefyFpiwoYNG/DMM89g6tSpWLlyJTp16oQZM2bAZrPJx9esWYOYmBh8++23uPHGG+UUt5ycHJe+VyIiIiLyPOzPEhGpZ1AURanF/kREVI8jEMSIA7O5YhWbpk2b4rvvvpOPDxs2THZChdOnT8ttMZpgy5YtWLRoEdauXVv2/M8//xxvvfUWfvvtNzz88MPw9/cvW7BBdHBfffVVTJ8+Hf/+97+RkJCA//3vf/Ix0cHt0aMHli5dKkcsEBERERGpwf4sEVHdYo1bIiINefTRRzFixIgK95Xv+IppY6WaN2+O4OBgOaVM3MQIg/L7xsXFyY5zdnY2Tp48KaeTlbJYLJg5c2aF1ypfl0woKiqqh3dIRERERJ6M/VkiorrDxC0RkYaEhYWhRYsW1T5++egFh8MBo9EIb2/vSvuW1gMT+1z+vMuZTKZK93FCBhERERHVFvuzRER1hzVuiYjcyOHDh8v++9SpU3IaWHR0NFq1aoUDBw7AbreXPb5r1y6EhobKUQyi81z+uaLzK6aq7dixo8HfAxERERHpF/uzRETqMXFLRKQhouMqpoNdfsvPz5ePi8UZfvrpJ9lpFbXB+vXrh5YtW8qVeUWdr+eee05OMxO1wcTCD7fddhsMBgPuuOMOuYjDV199JTvI8+fPlyMQxHQ0IiIiIqK6wv4sEVHdYakEIiINeemll+Ttcn/5y1/kvxMmTMArr7yC5ORkDBw4EC+88IK8XyzU8P7772PevHkYP368HJkgVtwVK+0KPXv2lCvzisUdRMdZrMK7YMECWK3WBn6HREREROTJ2J8lIqo7BoVFX4iI3IKYCiZW0504caKrD4WIiIiIqNbYnyUiqh2WSiAiIiIiIiIiIiLSGCZuiYiIiIiIiIiIiDSGpRKIiIiIiIiIiIiINIYjbomIiIiIiIiIiIg0holbIiIiIiIiIiIiIo1h4paIiIiIiIiIiIhIY5i4JSIiIiIiIiIiItIYJm6JiIiIiIiIiIiINIaJWyIiIiIiIiIiIiKNYeKWiIiIiIiIiIiISGOYuCUiIiIiIiIiIiLSGCZuiYiIiIiIiIiIiKAt/w9TReC8XL6jCAAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1400x400 with 2 Axes>"
       ]
@@ -1827,17 +1895,23 @@
      "text": [
       "\n",
       "Évaluation sur le test set:\n",
-      "  Accuracy: 52.44%\n",
+      "  Accuracy: 48.00%\n",
       "\n",
-      "Classification Report:\n",
+      "Classification Report:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "              precision    recall  f1-score   support\n",
       "\n",
-      "        Down       0.52      1.00      0.69       236\n",
-      "          Up       0.00      0.00      0.00       214\n",
+      "        Down       0.50      0.46      0.48       236\n",
+      "          Up       0.46      0.50      0.48       214\n",
       "\n",
-      "    accuracy                           0.52       450\n",
-      "   macro avg       0.26      0.50      0.34       450\n",
-      "weighted avg       0.28      0.52      0.36       450\n",
+      "    accuracy                           0.48       450\n",
+      "   macro avg       0.48      0.48      0.48       450\n",
+      "weighted avg       0.48      0.48      0.48       450\n",
       "\n"
      ]
     }
@@ -1883,8 +1957,54 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d72126b4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005686,
+     "end_time": "2026-08-23T01:42:18.928019",
+     "exception": false,
+     "start_time": "2026-08-23T01:42:18.922333",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : ce que l'entraînement réparé révèle\n",
+    "\n",
+    "La loss nulle est corrigée — l'entraînement produit désormais de vraies courbes. Mais le\n",
+    "résultat est instructif à un autre titre : le modèle **surapprend** (train 59,5 % à l'epoch 20\n",
+    "contre val ~49,8 %, et la loss de validation *remonte* de 0,694 à 0,715) et échoue à\n",
+    "généraliser (48,0 % sur le test, sous la baseline majoritaire de 52,4 % issue de la\n",
+    "distribution 236 Down / 214 Up).\n",
+    "\n",
+    "Ce n'est pas la marque d'un modèle médiocre, c'est celle d'une **tâche au signal trop\n",
+    "faible** : la génération synthétique pose `returns = trend + bruit` avec\n",
+    "`|trend| ∈ [0,03 % ; 0,1 %]` contre un bruit d'écart-type 1,5 % — un rapport signal/bruit de\n",
+    "~1:50 à ~1:15 par échantillon. La direction du lendemain n'est donc prévisible qu'à\n",
+    "`Φ(trend/σ) ≈ 50,8 % - 52,7 %`, et les quatre architectures du benchmark s'y tassent\n",
+    "effectivement (LSTM 53,3 % / Transformer 52,2 % / Mamba 50,9 % / SST 52,2 %), sans qu'aucune\n",
+    "ne se démarque au-delà du bruit d'échantillonnage (~2,4 % sur 450 points).\n",
+    "\n",
+    "La leçon, honnête et pédagogique : **sur des données financières synthétiques quasi-bruit,\n",
+    "aucun modèle ne bat le hasard de façon significative** — le plafond est le signal, pas\n",
+    "l'architecture. Le bug corrigé ici était la loss morte, masquée par le garde `torch.isnan`\n",
+    "qui la convertissait en « Loss=0,0000, Acc=0,00 % » ; la faible performance, elle, est un\n",
+    "résultat valide, à lire comme tel et non comme un échec de code.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1cb1f5c2",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005695,
+     "end_time": "2026-08-23T01:42:18.940719",
+     "exception": false,
+     "start_time": "2026-08-23T01:42:18.935024",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "### Exercice 3 : Benchmark Mamba vs LSTM\n",
@@ -1907,8 +2027,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
    "id": "64a0962d",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T01:42:18.954706Z",
+     "iopub.status.busy": "2026-08-23T01:42:18.954706Z",
+     "iopub.status.idle": "2026-08-23T01:42:18.957211Z",
+     "shell.execute_reply": "2026-08-23T01:42:18.957211Z"
+    },
+    "papermill": {
+     "duration": 0.010639,
+     "end_time": "2026-08-23T01:42:18.958278",
+     "exception": false,
+     "start_time": "2026-08-23T01:42:18.947639",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
    "source": [
     "# Exercice 3 : Benchmark Mamba vs LSTM\n",
     "# TODO etudiant : Comparer performance et vitesse des deux architectures\n",
@@ -1920,19 +2065,17 @@
     "\n",
     "result = None  # TODO etudiant : remplacer par le benchmark\n",
     "print(\"Exercice a completer\")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cc284339",
    "metadata": {
     "papermill": {
-     "duration": 0.030329,
-     "end_time": "2026-05-04T23:45:53.950503",
+     "duration": 0.006001,
+     "end_time": "2026-08-23T01:42:18.970279",
      "exception": false,
-     "start_time": "2026-05-04T23:45:53.920174",
+     "start_time": "2026-08-23T01:42:18.964278",
      "status": "completed"
     },
     "tags": []
@@ -1965,10 +2108,10 @@
    "id": "1143c2d5",
    "metadata": {
     "papermill": {
-     "duration": 0.016062,
-     "end_time": "2026-05-04T23:45:53.990399",
+     "duration": 0.006954,
+     "end_time": "2026-08-23T01:42:18.983845",
      "exception": false,
-     "start_time": "2026-05-04T23:45:53.974337",
+     "start_time": "2026-08-23T01:42:18.976891",
      "status": "completed"
     },
     "tags": []
@@ -2005,20 +2148,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "52359092",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:54.013092Z",
-     "iopub.status.busy": "2026-05-04T23:45:54.012854Z",
-     "iopub.status.idle": "2026-05-04T23:45:54.135972Z",
-     "shell.execute_reply": "2026-05-04T23:45:54.135105Z"
+     "iopub.execute_input": "2026-08-23T01:42:18.997859Z",
+     "iopub.status.busy": "2026-08-23T01:42:18.997859Z",
+     "iopub.status.idle": "2026-08-23T01:42:19.158194Z",
+     "shell.execute_reply": "2026-08-23T01:42:19.157095Z"
     },
     "papermill": {
-     "duration": 0.135946,
-     "end_time": "2026-05-04T23:45:54.136995",
+     "duration": 0.168864,
+     "end_time": "2026-08-23T01:42:19.158710",
      "exception": false,
-     "start_time": "2026-05-04T23:45:54.001049",
+     "start_time": "2026-08-23T01:42:18.989846",
      "status": "completed"
     },
     "tags": []
@@ -2233,10 +2376,10 @@
    "id": "5c19bcf9",
    "metadata": {
     "papermill": {
-     "duration": 0.011072,
-     "end_time": "2026-05-04T23:45:54.157553",
+     "duration": 0.011746,
+     "end_time": "2026-08-23T01:42:19.181029",
      "exception": false,
-     "start_time": "2026-05-04T23:45:54.146481",
+     "start_time": "2026-08-23T01:42:19.169283",
      "status": "completed"
     },
     "tags": []
@@ -2268,10 +2411,10 @@
    "id": "5141a091",
    "metadata": {
     "papermill": {
-     "duration": 0.012714,
-     "end_time": "2026-05-04T23:45:54.180942",
+     "duration": 0.011592,
+     "end_time": "2026-08-23T01:42:19.204654",
      "exception": false,
-     "start_time": "2026-05-04T23:45:54.168228",
+     "start_time": "2026-08-23T01:42:19.193062",
      "status": "completed"
     },
     "tags": []
@@ -2291,10 +2434,10 @@
    "id": "a458e762",
    "metadata": {
     "papermill": {
-     "duration": 0.013625,
-     "end_time": "2026-05-04T23:45:54.206164",
+     "duration": 0.009638,
+     "end_time": "2026-08-23T01:42:19.226361",
      "exception": false,
-     "start_time": "2026-05-04T23:45:54.192539",
+     "start_time": "2026-08-23T01:42:19.216723",
      "status": "completed"
     },
     "tags": []
@@ -2319,20 +2462,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "37c2a9bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:45:54.229218Z",
-     "iopub.status.busy": "2026-05-04T23:45:54.228977Z",
-     "iopub.status.idle": "2026-05-04T23:47:57.423033Z",
-     "shell.execute_reply": "2026-05-04T23:47:57.422232Z"
+     "iopub.execute_input": "2026-08-23T01:42:19.252118Z",
+     "iopub.status.busy": "2026-08-23T01:42:19.252118Z",
+     "iopub.status.idle": "2026-08-23T01:44:12.031148Z",
+     "shell.execute_reply": "2026-08-23T01:44:12.031148Z"
     },
     "papermill": {
-     "duration": 123.213719,
-     "end_time": "2026-05-04T23:47:57.431325",
+     "duration": 112.799195,
+     "end_time": "2026-08-23T01:44:12.038235",
      "exception": false,
-     "start_time": "2026-05-04T23:45:54.217606",
+     "start_time": "2026-08-23T01:42:19.239040",
      "status": "completed"
     },
     "tags": []
@@ -2353,7 +2496,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Time: 2.0s, Accuracy: 52.44%\n",
+      "  Time: 1.3s, Accuracy: 53.33%\n",
       "\n",
       "==================================================\n",
       "Training Transformer...\n",
@@ -2364,7 +2507,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Time: 4.6s, Accuracy: 52.44%\n",
+      "  Time: 3.0s, Accuracy: 52.22%\n",
       "\n",
       "==================================================\n",
       "Training Mamba...\n",
@@ -2375,7 +2518,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Time: 60.9s, Accuracy: 52.44%\n",
+      "  Time: 49.5s, Accuracy: 50.89%\n",
       "\n",
       "==================================================\n",
       "Training SST Hybrid...\n",
@@ -2386,7 +2529,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Time: 55.6s, Accuracy: 52.44%\n"
+      "  Time: 58.8s, Accuracy: 52.22%\n"
      ]
     }
    ],
@@ -2501,10 +2644,10 @@
    "id": "2580e6ee",
    "metadata": {
     "papermill": {
-     "duration": 0.013896,
-     "end_time": "2026-05-04T23:47:57.456638",
+     "duration": 0.00784,
+     "end_time": "2026-08-23T01:44:12.053115",
      "exception": false,
-     "start_time": "2026-05-04T23:47:57.442742",
+     "start_time": "2026-08-23T01:44:12.045275",
      "status": "completed"
     },
     "tags": []
@@ -2515,20 +2658,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "942b3962",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:47:57.488468Z",
-     "iopub.status.busy": "2026-05-04T23:47:57.488052Z",
-     "iopub.status.idle": "2026-05-04T23:47:57.785575Z",
-     "shell.execute_reply": "2026-05-04T23:47:57.784881Z"
+     "iopub.execute_input": "2026-08-23T01:44:12.075201Z",
+     "iopub.status.busy": "2026-08-23T01:44:12.075201Z",
+     "iopub.status.idle": "2026-08-23T01:44:12.371364Z",
+     "shell.execute_reply": "2026-08-23T01:44:12.370272Z"
     },
     "papermill": {
-     "duration": 0.314622,
-     "end_time": "2026-05-04T23:47:57.786804",
+     "duration": 0.310211,
+     "end_time": "2026-08-23T01:44:12.371903",
      "exception": false,
-     "start_time": "2026-05-04T23:47:57.472182",
+     "start_time": "2026-08-23T01:44:12.061692",
      "status": "completed"
     },
     "tags": []
@@ -2543,15 +2686,15 @@
       "RÉSULTATS DU BENCHMARK\n",
       "============================================================\n",
       "      Model  Parameters  Train Time (s)  Test Accuracy\n",
-      "       LSTM       13473        1.978415       0.524444\n",
-      "Transformer       17313        4.554354       0.524444\n",
-      "      Mamba       20449       60.918074       0.524444\n",
-      " SST Hybrid       41697       55.597441       0.524444\n"
+      "       LSTM       13473        1.332286       0.533333\n",
+      "Transformer       17313        2.964049       0.522222\n",
+      "      Mamba       20449       49.487046       0.508889\n",
+      " SST Hybrid       41697       58.845941       0.522222\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABdEAAAGGCAYAAACUkchWAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAl0tJREFUeJzt3QmcjeX///EPw1iTrCHZt7JmLZStohQh0SIhZGsjWbJT1iQqskSUki2USovoG4mQLF9bZQ8RsoyY/+N9fX/3+Z8ZM5phZs6ZOa/n43EeM+fc55y5z7nnnM91f67r+lypIiMjIw0AAAAAAAAAAFwi9aU3AQAAAAAAAAAAIYkOAAAAAAAAAEAsSKIDAAAAAAAAABALkugAAAAAAAAAAMSCJDoAAAAAAAAAALEgiQ4AAAAAAAAAQCxIogMAAAAAAAAAEAuS6AAAAAAAAAAAxIIkOgAAAIA4uXjxYqB3IdnivQMAIPBxkXiMK0USHQiwF1980UqUKHHZS506deL0XPPmzXP3L1OmzCXP37ZtW99tej7dNmnSpER5TY899ph7/n79+lly5r3/S5Ys8d22Y8cOq1u3rpUsWdLWr19/yWP27t3re1xM2wEAwRc/k5vVq1f7XuPhw4ejxB61BRLD1q1bXXzfv39/gjzfqlWrrHTp0m6fmzVrZqdPn7aUKjIy0j766CN7/vnnA70rAJCo53/eRedK+o6vUaOG9enTx/76668E+1t//vmnde3a1SpUqGDlypWLcp6LuJk1a5Y7Tj/++GNA2lNxbVOcOXPGxo8fb/fee6871mXLlrUGDRrYmDFj7O+//47339VjRo8ebZMnT/bF5/r167t2yIULF6749SB0kEQHAuzaa6+13Llzu0vOnDl9t1933XUx3n45GTJkcPe//vrrE3GPQ1vRokVtzpw5Vq1aNXv77bcDvTsAELISMn4md6lSpYrx94Sybds2a9Kkif3www8J8nx79uyxwYMHW61atezdd9+148eP2yuvvGIp1ciRI10S6ciRI4HeFQBIVBkzZnTxN0eOHC4eqaNXnYjt2rVzCcuEMGPGDPv8889d56vOf8PDwxPkeUOFOiFeffVVK1WqlFWqVCnJ21PxaVM89dRT9vrrr7uBbGFhYZYmTRrbtWuXTZw40dq0aRPvxPfjjz/uBhKeO3fOXdf/6COPPGI///yza48A/ybNv94DQKLq1auXu4gaGeqtl9dee82qVq0ar+dSr6wuSFzZsmWzd955J9C7AQAhLSHjZ3Knk9u0adPa+fPn3cluQtNIsIQcoZU/f/4os7yWLVtmKdmpU6cCvQsAkCTuu+8+GzRokPs9IiLCdSIq6b1x40b76aef7JZbbrnqv3Ho0CH3U8/1/vvvX/XzhRoli0+ePGkPPvhgQNpTcW1TaJT8999/735X4vuOO+5wv6tTRh3TmvW9fPnyeI2SjykeN27c2IYPH+4GyD388MN0yuCyGIkOJBMKNkOHDrXatWu7qXGVK1e21q1b24YNGy5bziWuDhw4YM8++6zrjdZUqRYtWtjKlSv/9XGbNm2yRx991E2tUgDTKO1/m3bu0dQ73aYpZLHxppeNGjXKpk6d6oJn+fLl7bnnnnNB8MMPP3R/V/usKWG//fbbJT3d3bp1cyPHtY8PPPCAzZ0795K/s3jxYtcBofdOPeNq5MUWzNVbrefSMdBUwl9//fVf36crfRwA4OrrXurkS6W4FD/1c9y4cS7hHH0a+syZM900X8WMihUrukSAkgBvvvmmO6nU1PFOnTq5UVzRS6QtXLjQXnrpJRdHddKpkdbeSCf5448/3Emf4rhijZ5P5T327dt32f3/559/3Igx3V+xTn9fz+VPJ3zaB/F+imLyPffc41737bffbkOGDIlyAqnRXbq/4uQ333xjjRo1cvumJIhOTL0Y/tBDD/keo/fPi9vea1fHsh6r90fvn3z33XfuZFQxT89Zr149N/3a/32PXl7Oay/o/du9e7drJ+g1a9+jz/5SaQC937feeqt7fp0EK5b789oeGu329NNPu/aDnmv27Nl24sQJ9zqUhNHx1gm0/0l9XJ7f23+NiFQ75bbbbnN/QzHeG3Wuv/HBBx+437Ufur9eJwCkdIpN/vFD55vxjU9dunRxJUIVC3SupljolS1bt25dlDJmZ8+etbFjx9pdd93le17Fcc128vjHGZ1HVqlSxT2nkvzed/rSpUvd31Q7QPFB5UTUFnj55Zfd43S7ks7+ZciOHj3qbtPf1N/W/TSKWqOmo5/XKt5on++++24XX5TM1t/3p/eqe/fu7u/rtaucSfSR0ldy/q7ZAIpJGoF95513Jnh7SsdQM8sU83Xeq7jYsWNHV77l39oU0fm3dfxHwqv0itpCGol+zTXXxPn90PFV20J0TL32kp5D77PidvQ4D0THSHQgmejbt6/7Uk+dOrVlzZrVndypZ/aXX35xwSFdunRX/NzHjh2zli1busCjkWyaFqck8pNPPmlvvfWWr9c3ut9//90lHrwGhBoo2k89PqGpoaGkhaYIqkNBI9i2bNniGiYKfGo06eT0hRde8J2sqne6VatWLomh6V96jzZv3my9e/d2U8J69uzp7vfJJ5/46pR6U8SeeOKJGBPh6rhQQyFTpkzup06c16xZ45InsY3+u9LHAQCunk6gNVJNJ4yasqz6mxMmTHAdmUrq+nvjjTdcLFO8UGxTzVDFWi/W6LYvv/zS0qdPf8ljR4wY4U7A9D2vEV5KyOsEUIkA0QmfpgsrHmk/FNMU13WbYprib0yUWPBG2im+Ktn9n//855L7Re8gVtJZiV1Ru0En+DoBV7tB+6b98GgfNBpcz69EwX//+1975pln7KuvvnJJEM3A8joOdCKr/fenv6Pn0wn2zTff7B7foUMHX9zTa1MJF02/zpw5s7Vv3/6yx0xxWx30er+1Pxp1qL+hGrs1a9Z0tymuKqYrbus51SZQLNcJvE6c/em1qA6qkuR6rgEDBti0adNcLXm9PrWD1FFfoEAB99j4Pr8SImpD6f9GbRTFeL1m/Y/ovVLbRa9Ft+m9ZJQbgFCg71J91/rPQopvfFLMU2eyvodvvPFGF6P1PazvWn2XquSIF7t03ucNMNP99X2vOK5OXZ0f6m959Bz9+/f3nZuptIl/u0EdrTrv1v0UxxWn1W7Q31I80bmpStZ455CdO3d258+KGVmyZHFxRTFUj/n000+jvC+KEYo52kfttxLo6sz+4osvXJxQvFWiWfuvtovaHzp3VXtA+6W/daXn74r3er9VojRXrlwJ3p7SYAF1Qug+Ojba36+//trtm26PS5vCo455b5adEufq8FBSXp0eer/8y9fF5f3Q39J7qv8nHXe9/x4l0VesWOGOmQbUAbFhJDqQDChwqNe4YMGCrgGgE3olX0WBaefOnVf1/BpBpoCjwKTeYSV31fuuk2FvRFlsj9NJoQL7xx9/7EYDKLiqUZPQ1GB67733bO3ata6HX5TU0H4qSa3khJc4V0JddJKsE3EFYHU06LE6kRY1XNRQ85Imoh51NbL0fBrBEJ3eCx0LBWPdR0l7jdZT0L5cffQrfRwA4OroxE6jjnVCpRNexTgli3VipxNiJUn9KWaoY1Xf08WLF3e3ebU39f2t0dYS00hiPXbRokUuFurkzjtR1ugrnSzqxFWUOFcc1zaN0taIqdhqZet2jZST5s2buzimeKZEwuXopF8ntqJ91/7qcYULF3b7p5NEfzoR1qhrPb9GvYviu16zYqhG4nv0fnrTvj1KTHjJfY300qwwjUBr2LCha1Poebxyc7HN9PKndkT16tXdfn/22WcuCS3e6Hi1gXTs9Hp00qv7eaPZNQrRf1Sc5M2b1+2bl9xWm0rtJz23joXaV/7HNb7Pr2Ov59L/jTet3NtXvVeK+aL38ttvv3U/ASAlUhzUuZq+wzXTR6U3xJsVHN/4pO9bJdwVR4YNG+bOhbUQpOjcVd+pii9K7iqBriStzlEVzxYsWODik9oCGnnsT4lUjQDX8yru+3dkq6Pci2nZs2d3t6nTVa9F99ff9Y8ZivFqVxQpUsQlihVXlLj12hDRF1XVDDTFFO2jRpuLzsW3b9/uflfHg5K9+tvewCsvWT9//nyXeL/S83e9x6JO6cRoT+l4iM5x9T4ohur/QRe9pri0KTx58uRxuQX9TXWC6/n02jSzXP8DirueuLwf+t/xOnI0YM7bV/FGpSfU2i9IuRiJDiQD3mgm0RQkNQj8T+CvZGVqf6tWrXI/lVT2TnIVcLxyKGoYqMc4OiWsRSfJXuBRr7kCo/90vYSg5/dq6Gl6loKeRnx5o8H8T0j1fqhsjEaNiRLn3v5rOpkSEkoYqLdfo868BoumjXsjFDR10Ouo8E7ovderBpQ6DcRL2HvvYXRX+jgAwNXTd6wSpopp+v73eFPGdUJ20003+W5X6Q4voaqOVY2o1nUtgOnFGsWGmGpqaqq1l3jXSGudQCoG6CRZsSpfvnzuxFknbhoRpQS6ErIayRYbjU7zSowolml0nuKZZoFp5ldslKj2OrR1EulR4th73f7TuNUZrhFc4t+JHNf2hd4fnUh79Ny66H3SCan2x4vJcX1OvU9KhqjDQCME9T56j/VqpKqtoTIr/tRBrY4L/9J2999/vxt1potmfykZoqnmN9xwg9uu/wElCPz/L+Lz/Go7eSfmSqIrCXS1bTMASI7UAauLRnHrXE2xT9+3Gj19JfFJz+Gdn3oJ7ZjovE5UIkaxXBQ7VFZMA6a0PXrc9DrGoz+v/r4XmzViWyO3FbM108o7F1Vs82KG4rLOf9XWULtB55pKwnsUD/xHW+u81hsprpIu3qh8L25454d6LV6nuWZHaX+9GcxXev7ulUi53Ht5Ne0pL1736NHD19bRwDb9H1wJjQpXB4wS93pPlaxXu0gxW2Xa1FmhNsiVvh8e73irw0P/v17nPRAdSXQgmdBJu062lfzV1CPV3PR4AeJKeXXiFLhjOulTr3FMQUfT1SX6at0K7nFJosdnkTL/6XfeNGidsHvT/fzL2ej9UGPH450ki6Z9KYjrfdR9/BMh/lParr/++ih/Xw07733WCXR0Bw8ejHG/r/RxAICr58U3r4zHv30H+8cab1Sa/4mmF2tiirv+sdAr26GkueKAYpWS6ir74U0r10VJBo2mUv3QmMqyeXFW9/Pfj+gxKrbXLXF53f4JcE1F96ZPx7V9Eb0doJNVTZNXMlnvvUYYeu+nTsLjwn+fvDJx3mO916dETEyz3/Sa/ZPc8T2u8X3+y+0rAIQSDajyFhZNiPikWOpf3iU23owu//M+/+v+54ae2MqZXElbQLOcFee9Uen+65NEj6X+MUOj3qPfzxu5Hv38178E6NWev8c3SRzX9pRms6lNo9J3Gvini2hmgjoLLpfIjonO1RVXNcBNF11XMl2zEnRMVf5HSfQrfT88/u+H3iOS6IgNSXQgGfDqd+uETNPeNB1KU9CuZAHR2E5+1ZurxTm8OuGaJqaEc2w1Wr3Arrro0QNp9Os6+ffoeaMH8bjwfw7P5RpU/iP7NOLMa0DpPfQWcdPrVs06vU7d7t9oi96AU8NJf08NBx0Db1SiTq7V+PGvyZYQjwMAXD0vuasTVv+ZPzrB0qjkq401/vwXCFWM9jpOvZNgTfPWrDLFG00H10gt1WrVNHKN3lLJr+i8x+rEWqPHvBP+f+uA9U9qa+q291pje93RX2P02PRvsco/CSBaVFVT0FW3dOTIke7EVdOpvZlfcXG59917fRrBp0XNRHFW73tMnRExPVdCPr86Hi73XhHrAeDK4lNc1/3S82rGts77/Gk9juh/99+eO74xQzOk1UmuZK9GoWukusq4eCOiL/dcMcUHxX6VRfNfWFPn0CrlopHxygFc6fm7txCn/8LnCdmeUqJfbQAluTXrQG0dldrRAALFU41Kj2tMVJkXjUDXLECVfRENJtQseJXIUwkXr3Mkru9HbH/bf2Cdf+cFEB010YFkQCed3ogmjT7Tl7//6txXOxJd06y8GnZKiotOdhWwHn/88VhHU3n14LRYilcHTQmB6KPQlaiOXodN99fUqsSipLkaGaIR/BoVoNehKV8aha73UFPW1cvsdUZoBIGSHhp999prr11yguyVjFGdOgVaNT403VxlZrwastFd6eMAAFevYsWKLjGu73bFJ9m0aZOLe+qQ9uqUJwTFQj23TJ8+3bfotv6WTiQ1HVm/K/bVrl3bTW33Ssd4C2xFp1ln3uwrLWym+KTRdjpxvBxNOfdOajWN3etA1tRqTXNXHdP48D/hVxxTMtlf9JNSTWcX7YNORpX0V1I9Idos/u0W1R1XyRvRaDTFW9Ufv9q1WRL6+b0ku3eSHv39A4BQEd/4FNeEq1ceRR3TXkkulRHzFuaOab2rhOrg9GKe2hs6V1es9v7ulcxMUntBVF/dW/tMa4Op/I2SxEoOX+n5u1dWJabR5FfbntJxVOe57qvyOVoEVKVfVAvfv63zb20Kj0avi9pQGuXv3U8l1fTeiLcgbFzfD/947P93vZkMOn5x7bhBaGIkOpAMqC6rN7VadcHUy+3fW+rVkLtSWsl8zpw5ro64GhjqofaeUz29sTUwFJDUO6yAqAU+1CBSb7RGyvn3nHurf+s29Qwrka3edY0WT+ja6f7U0FCdcwVeBXQFRC+p0aFDB9+CKqqnphGAqqGmYO31Vqt2nf9CMLqfkt/qfVfjRvfzaqbFNtLgah4HALg6SlI3bdrUxThNL1fHpeKUErmqM6r4mlAUK/W3vFjoxVDFQI1iLlSokOtIfuSRR9xILsVxxXXFJm/hyegUhxTHVGtVo9u0roYe82+1TBXHFdfUiTx58mR38q3H6aL90IltfGhhTp08631T7fSaNWv6RmjHRJ3EmkWnRb/U4a6Y55Vwu9o2i6gurDqm9Te0MJx/vK5bt66vpEqwPL9XL10DCJRc0IhF1QgGgFCT0PHJ8+ijj7oEqhKsqh+uEcve+bLisEqBJBZvwJRiv2KEd67nUfzw4kBcaP9VBkWJbtVF14A0L3Yqia7XdqXn74pBovcpodtT+ptKZqsjQzXRhwwZ4gaPaS0wbVMeIz5tCq01o3aPOrRVCkb3Ufz1L3fz1FNPud/j+n5ooJ06PWbMmOHaVXpuvb/e+8HC3/g3jEQHkgEFXTU0ihUr5npPFTCUBNbiVaKVw6+GTubVW64grRNFBTslmBWsdPIYGyXGNTJLjR0lAfQ8Cqr+i8F4vc1KAGhqm35Xr69qpSZ2Arlq1aoumGo6toKj/q6mzOvk9dlnn/XdTwl2jYTQgnDaPzW0pkyZckmdPCUC1NjTTzWOdF+9do04vNwK51f6OADA1VO8UWemFpLWiZym/GphTnXoJmSZDSW7dRKv51Sc1gndyy+/7LZ5NdG14Kj2QyfXuo9Gb+lEzn9x0+i0788//7ybIq3nVlkwlQf7NzqxVGeyYpvin+K7FsnU34tvrU+VY9HIea9UmjcdPDYvvPCC+1t6jdpnnbQPHTrUbVNi2r+j/Uoolup1qI2i46mR4Uq+9O7d2y3AerUS+vm1sKlGWOp9VwLAv/wLAISahIxP/mXFdD6rkc+KszqfVdxUvFei/t/i1tVQjFPCWMlkxXv93RdffNG3EGl8z9UVc7VuipK/iqMaea736qWXXrJu3bpd1fm7nidPnjxuhHt8R6PHpT01YsQI12bR+bT2WzFPifVJkyb5yprGtU2h51TiXH9T+63riscaTa+E/ty5c32dE3F9P5RD0XMpDutc35tZpkF3onVqgMtJFcmqNwAAAMAVUYe2pjDrpFFJcgAAgGClwWMqXaoFQDWbPNSpQ0CD7zTCX4uWXq6mPMBIdAAAAAAAACCFa9GihZulrYVK8b/a80qka4YECXT8G5LoAAAAAAAAQAqnciqqEb969Wq3Vkeo02LtKv2i+uzAv6GcCwAAAAAAIUq1i7WGw+LFi91IzGbNmrn1g1SDWEk21ULWYnyqczxw4MAEXZQZAIDkgpHoAAAAAACEKC2KqMUPp0yZYqNHj7YPP/zQLWyoRZC11kOlSpVs3rx5VqFCBbcwn24HACDUMBIdAAAAAIAQdPz4catevbpNmzbNqlSp4m6bNGmS7d692ypWrGhvvvmmLVu2zI1KV+rg7rvvto4dO1qTJk0CvesAACQpRqIDAAAAABCC1q5da5kzZ/Yl0EWjz1XeZcOGDS6RrgS66Octt9xi69evD+AeAwAQGCTRAQAAAAAIQXv27LF8+fLZggULrH79+la3bl2bMGGCXbx40Q4fPmy5cuWKcv/s2bPbwYMHA7a/AAAESpqA/eVk5PDhkxZqsmXLZH/++XegdwOx4PgEL45N8ArVY5Mz5zWWEhGbEWw4PsGLYxPcQvH4BFNsVn3z3377zWbPnu1Gnytx3q9fP8uQIYOdOXPGwsPDo9xf17UQaWyOHz9t/zdwPWRkzpzeTp06G+jdQAw4NsGN4xO8QvHYXHttxn+9D0l0XEKNnrCw1O4nFfODD8cneHFsghfHBskd/8PBjeMTvDg2wY3jE3hp0qSxU6dOuQVFNSJd9u/fb++//74VKFDgkoS5rqdPnz7W5zt//oKF4v+wXjf/w8GFYxPcOD7Bi2MTO8q5AAAAAAAQgnLmzGnp0qXzJdClUKFCduDAAcudO7cdOXIkyv11PXqJFwAAQgFJdAAAAAAAQlC5cuXs3Llztnv3bt9tu3btckl1bfvpp58s8v+GIurnunXr3O0AAIQakugAAAAAAISgwoULW61ataxXr162detWW7FihU2aNMlatmzpFho9ceKEDR061Hbs2OF+qk56gwYNAr3bAAAkOZLoAAAAAACEqFGjRtmNN97oEuc9e/a0Rx55xB577DHLnDmzTZw40dauXWtNmjSxDRs2uAR7xoz/vvgaAAApDQuLAgAAAAAQoq655hobMWJEjNvKli1r8+fPT/J9AgAg2DASHQAAAAAAAACAWJBEBwAAAAAAAAAgFiTRAQAAAAAAAACIBUl0AAAAAAAAAABiQRIdAAAAAAAAAIBYkEQHAAAAAAAAACAWJNEBAAAAAAAAAIgFSXQAAJBkIiIibODAgVa5cmW77bbbbMyYMRYZGem2bd682R588EErV66cNW3a1DZt2hTo3QUAAAAAwNIEegcAAMnf8WF7Ldgds+Qha+8bLCUbMmSIrV692qZMmWJ///23Pfvss5Y3b167//77rX379nbffffZK6+8Yu+//7516NDBvvjiC8uYMWOgdxtALOpNfzLQu5BiLHv87UDvAgAAAGJBEh0AACSJ48eP29y5c23atGlWtmxZd1ubNm1sw4YNliZNGkuXLp298MILlipVKuvTp499++23tnTpUmvSpEmgdx0AAAAAEMIo5wIAAJLE2rVrLXPmzFalShXfbRp9/vLLL7tEesWKFV0CXfTzlltusfXr1wdwjwEAAAAAIIkOAACSyJ49eyxfvny2YMECq1+/vtWtW9cmTJhgFy9etMOHD1uuXLmi3D979ux28ODBgO0vAAAAAABCORcAAJAkTp8+bb/99pvNnj3bjT5X4rxfv36WIUMGO3PmjIWHh0e5v65rIVIAAAAAAAKJJDoAAEgSqnt+6tQpGz16tBuRLvv373eLiBYoUOCShLmup0+fPsbnSps2zP6v8ktI8F5reHiYRUYGem8QHccHCUH/P6GGzw4AAEguSKIDAIAkkTNnTrd4qJdAl0KFCtmBAwdcnfQjR45Eub+uRy/x4jl//oKFYqIpIuICiaYgxPFBQtD/T6jhswMAAJKLoKmJroXFXnzxRd/1zZs324MPPmjlypWzpk2b2qZNm6Lcf/HixVavXj23vXPnzvbnn3/6tkVGRtqoUaOsWrVq7qR8xIgRrt6q59ixY9a1a1erUKGC1alTxxYuXJhErxIAgNClmH3u3DnbvXu377Zdu3a5pLq2/fTTTy6Gi36uW7fO3Q4AAAAAgIV6En3JkiW2fPnyKDVTlVSvVKmSzZs3zyW7O3To4G6XjRs3Wp8+faxLly72wQcf2IkTJ6xXr16+x0+bNs0l2cePH2/jxo2zRYsWuds8uu/JkyfdY5966inr27eve04AAJB4ChcubLVq1XJxeOvWrbZixQqbNGmStWzZ0i00qng+dOhQ27Fjh/upOukNGjQI9G4DAAAAAEJcwJPox48fdyPFy5Qp47vtk08+cdO9X3jhBStSpIhLmGfKlMmWLl3qts+cOdOdVDdu3NhKlizpHq8k/J49e9z2GTNmWLdu3VwSXqPRu3fvbrNmzXLbfv/9d/v6669tyJAhVrx4cTfa/f7777f33nsvQO8AAAChQzPFbrzxRpc479mzpz3yyCP22GOPWebMmW3ixIm2du1aa9KkiW3YsMEl2DNmzBjoXQYAAAAAhLiA10QfPny4NWrUyP744w/fbTpxrlixoqX6vyJ5+nnLLbfY+vXrfSfWTz75pO/+efLksbx587rbw8PDXW3VypUr+7brufbt2+f+hu6j+99www1RtuvEHQAAJK5rrrnGdX7HpGzZsjZ//vwk3ycAAAAAAIJ2JPr3339vP/74o3Xq1CnK7YcPH75kIbHs2bPbwYMH3e9Khse2XY8V/+05cuRwP73tMT320KFDCfzqAAAAAAAAAADJXcBGomthsf79+1u/fv0sffr0UbapBqpGlPvT9YiICPf72bNnY92ubd51/22i7f/23DFJmzbMt3J8KPBea3h4mP3f+m4IIhyf4MWxQULQ/w8AAAAAAAgeAUuia9HP0qVLW82aNS/Zpnro0ZPauu4l22PbniFDhigJc93P+120/d+eOybnz1+wUEwERkRcIBEYhDg+wYtjg4Sg/x8AAAAAABA8ApZEX7JkiR05csQqVKjgrnuJ7c8++8waNmzotvnTda8MS+7cuWPcnjNnTrdNVLbFq3vulXjxtsf2WAAAAAAAAAAAgqIm+rvvvmuLFi2yBQsWuEudOnXcRb+XK1fOfvrpJ4v8v6Gc+rlu3Tp3u+jn2rVrfc+lhUR10e1KkmuRUf/t+l23KQlfvnx5t8ioV1/d267bAQAAAAAAAAAIipHo+fLli3I9U6ZM7meBAgXcQp+jR4+2oUOHWosWLWz27NmulnmDBg3cfVq2bGmPPfaYS3yXKVPG3a9WrVqWP39+3/ZRo0bZ9ddf767rudq0aeN+131q1KhhPXr0sD59+tjPP/9sixcvtpkzZybxOwAAAAAAAAAACHYBS6JfTubMmW3ixIlu4dEPP/zQSpQoYZMmTbKMGTO67SoBM2jQIBs3bpz99ddfVr16dRs8eLDv8W3btrWjR49aly5dLCwszJo1a2atW7f2bR8xYoRLoDdv3tyVcRk2bJiVLVs2IK8VAAAAAAAAABC8UkV6NVMQq8OHT1qoLY6YI8c1duTISRZHDEIcn+AVysfm+LC9gd6FFCNr7/+t55FQcua8xlIiYjOCSSgfn3rTnwz0LqQYyx5/20JNqH52UmpsFuIzggXHJrhxfIJXqB6bnHGIzQGriQ4AAAAAAAAAQLAjiQ4AAAAAAAAAQCxIogMAAAAAAAAAEAuS6AAAAAAAhKgvvvjCSpQoEeXSrVs337YGDRpYhQoVrGXLlvbLL78EencBAAiINIH5swAAAAAAINB27NhhtWvXtsGDB/tuS5cunW3fvt2ef/55GzRokN1yyy32zjvvWIcOHVxiPUOGDAHdZwAAkhoj0QEAAAAACFE7d+604sWLW86cOX2XLFmy2HfffWdFixa1xo0b24033mjPPfecHT582CXdAQAINSTRAQAAAAAI4SR6wYIFL7k9a9asLmG+du1au3jxos2bN88yZ87sEuoAAIQayrkAAAAAQApzfNheSw6OWfDL2vsGS6kiIyNt9+7dtnLlSps4caJduHDB6tev72qi33PPPfbVV1/Zww8/bGFhYZY6dWp3n2uvvTbQuw0AQJIjiQ4AAAAAQAjav3+/nTlzxsLDw23s2LG2d+9eGzJkiJ09e9aefPJJV76lX79+Vq5cOXv//fetV69eNn/+fMuePXuMz5c2bZilSmUhw3ut4eFhFhkZ6L2BP45NcOP4BC+OTexIogMAAAAAEILy5ctnq1evdqPLU6VKZaVKlXKlW3r06GF//fWXq5X+yCOPuPtq4dEGDRrY3LlzrX379jE+3/nzFywUk00RERdINgUZjk1w4/gEL45N7KiJDgAAAABAiFLtcyXQPUWKFLFz587Zpk2brGTJkr7bVc5F1zV6HQCAUEMSHQAAAACAELRixQqrWrWqK+ni2bJli0us586d2y066k/102+4IeXWiAcAIDaUcwEAAAAAIARVqFDB0qVLZ3379rXOnTvbnj17bMSIEdauXTtX6uXFF1+00qVLu/vNmTPHjUJ/4IEHAr3bAAAkOZLoAAAAAACEoMyZM9uUKVNs2LBh1rRpU8uUKZO1aNHCJdFV4uXvv/+2iRMn2sGDB1299OnTp8e6qCgAACkZSXQAAAAAAEJUsWLFbNq0aTFue/DBB90FAIBQR010AAAAAAAAAABiQRIdAAAAAAAAAIBYkEQHAAAAAAAAACAWJNEBAAAAAAAAAIgFSXQAAAAAAAAAAGJBEh0AAAAAAAAAgFiQRAcAAAAAAAAAIBYk0QEAAAAAAAAACMYk+m+//WZt27a1ChUqWK1atWzy5Mm+bUOGDLESJUpEucycOdO3ffHixVavXj0rV66cde7c2f7880/ftsjISBs1apRVq1bNqlSpYiNGjLCLFy/6th87dsy6du3q/m6dOnVs4cKFSfiqAQAAAAAAAADJRZpA/WEltdu3b29lypSx+fPnu4T6c889Z7lz57b77rvPdu7cac8//7w98MADvsdkzpzZ/dy4caP16dPHBg4caCVLlrShQ4dar169bOLEiW77tGnTXJJ9/Pjx9s8//1iPHj0se/bsLmEvuu/Zs2ftgw8+sA0bNljfvn2tUKFCVrZs2QC9GwAAAAAAAACAYBSwJPqRI0esVKlSNmDAAJccL1iwoN166622du1aXxJdSe+cOXNe8liNSG/QoIE1btzYXddI89q1a9uePXssf/78NmPGDOvWrZtVqlTJbe/evbu99tpr7vl+//13+/rrr+3LL7+0G264wYoXL27r16+39957jyQ6AAAAAAAAACA4yrnkypXLxo4d6xLoKr+i5PmaNWtc+ZVTp07ZoUOHXGI9Jho97iXIJU+ePJY3b153ux534MABq1y5sm97xYoVbd++ffbHH3+4++j+SqD7b//pp58S+RUDAAAAAAAAAJKbgI1E96e65Pv373ejye+++27btGmTpUqVyt566y379ttvLWvWrPbEE0/4SrsoGa4kvD+Vazl48KAdPnzYXfffniNHDvfT2x7TY5V8BwAAAAAAAAAg6JLo48aNc+VdVNrl5Zdftptvvtkl0QsXLmyPPvqoG6H+0ksvuVHrd955p6tnHh4eHuU5dD0iIsJt8677bxNtP3PmTKyPBQAAAAAAAAAg6JLoWlxUzp075+qXr1u3zo1K1wh00eKhv/76q73//vsuiZ4uXbpLkt66niFDhigJc93P+120PbbHpk+fPtb9S5s2zFKlspDhvdbw8DCLjAz03iA6jk/w4tggIej/JyX74osvrEuXLlFu0yw0dahv3rzZ+vfvb//973+taNGibgHx0qVLB2xfAQAAAAAI+MKiWtCzXr16vtt0wnz+/HlXEz1btmxR7q9R6atWrXK/586d2z0++vNpEVJtE5Vt8eqeeyVevO2xPTY2589fsFBMBEZEXCARGIQ4PsGLY4OEoP+flGzHjh2uo3zw4MG+29TBffr0aWvfvr1bXPyVV15xHecdOnRwSfeMGTMGdJ8BAAAAAKEtYAuL7t27141E869FrlroSp6/++671rp16yj337p1q0ukS7ly5dxCpB4tJKqLbleSXIuM+m/X77pNtdDLly/vFhlVfXT/7bodAAAkrp07d1rx4sVd57V3yZIli33yyScumf7CCy9YkSJFrE+fPpYpUyZbunRpoHcZAAAAABDiUgeyhItqn/fu3duNSlu+fLmNHDnSOnbs6EaoqQ76lClT7Pfff7f33nvPFixYYG3atHGPbdmypS1cuNDmzJnjkus64a5Vq5blz5/ft33UqFG2evVqdxk9erS1atXKbdN9atSoYT169HCP1XMsXrzYHnnkkUC9FQAAhFQSvWDBgpfcvmHDBqtYsaJbE0X085ZbbnGz1gAAAAAACMlyLmFhYfbGG2+46dwPPfSQq1f+2GOPuWS3Tpxfe+01Vx9VP/Ply+cS4RUqVHCP1c9Bgwa57X/99ZdVr149yrTwtm3b2tGjR91Id/2dZs2aRRnZPmLECDfCrXnz5m4E3LBhw6xs2bIBeR8AAAgVkZGRtnv3blu5cqVNnDjRLly4YPXr17du3bq50msq6+Yve/bstn379oDtLwAAAAAAAV9YVKVXxo8fH+M21Ur3r5ceXZMmTdwlJkqc9+rVy11iopPyt9566wr3GgAAXIn9+/fbmTNn3CLgY8eOdaXdhgwZYmfPnvXd7k/Xoy8G7mHRbwQTjg8SQkpfWDo549gAAICAJtEBAEDo0MwylVm79tpr3ayzUqVK2cWLF12JtSpVqlySMNf19OnTx/hcLPqNYMLxQUJI6QtLJ2ccGwAAQBIdAAAkmaxZs0a5rkVEz50758qrHTlyJMo2Xdei4AAAAAAAhOTCogAAILSsWLHCqlat6kq3eLZs2eIS61pU9KeffnJ100U/161bZ+XKlQvgHgMAAAAAQBIdAAAkES0Mni5dOuvbt6/t2rXLli9f7hb7bteunVtg9MSJEzZ06FDbsWOH+6lke4MGDQK92wAAAACAEEcSHQAAJInMmTPblClT7M8//7SmTZtanz597KGHHnJJdG2bOHGirV271i0cvmHDBps0aZJlzJgx0LsNAAAAAAhx1EQHAABJplixYjZt2rQYt5UtW9bmz5+f5PsEAAAAAMDlMBIdAAAAAAAAAIBYkEQHAAAAAAAAACAWJNEBAAAAAAAAAIgFSXQAAAAAAELUF198YSVKlIhy6datm9u2bds2a9mypVu35L777rNVq1YFencBAAgIFhYFAAAAACBE7dixw2rXrm2DBw/23ZYuXTo7efKktWnTxurUqWOvvPKKLVy40Lp06WKfffaZZc+ePaD7DABAUmMkOgAAAAAAIWrnzp1WvHhxy5kzp++SJUsWmz9/vmXMmNEGDBhgBQoUcKPT9XPTpk2B3mUAAJIcI9EBAAAAAAjhJPptt912ye0//PCD1a1b18LCwny3zZ07N4n3DgCA4MBIdAAAAAAAQlBkZKTt3r3bVq5caXfffbfVq1fPRo0aZREREbZnzx7Lli2bvfTSS1a9enVr3ry5rV27NtC7DABAQJBEBwAAAAAgBO3fv9/OnDlj4eHhNnbsWOvZs6ctWrTIRowYYadPn7ZJkya58i5vv/22Va5c2dq2bWsHDhwI9G4DAJDkKOcCAAAAAEAIypcvn61evdquvfZaS5UqlZUqVcouXrxoPXr0sOuvv95dVy10uemmm+y7775zC4x27NgxxudLmzbMUqWykOG91vDwMIuMDPTewB/HJrhxfIIXxyZ2JNEBAAAAAAhRWbNmjXK9SJEidu7cOcudO7cVLlw4yraCBQtediT6+fMXLBSTTRERF0g2BRmOTXDj+AQvjk0ilnNRcN24caOdPHnyap8KAAAAAAAkkRUrVljVqlVdSRfPli1bXGK9fPnytm3btij337Vrlxu9DgBAqIl3En3Hjh1uQZF169bZiRMnrHHjxu767bffbqtWrUqcvQQAAAAAAAmqQoUKli5dOuvbt69LkC9fvtzVQ2/Xrp21aNHCJdFff/11++233+y1115zi402atQo0LsNAEDwJ9EHDhxo+fPnt0KFCtlHH33kRqBrJW/VRBs+fHji7CUAAAAAAEhQmTNntilTptiff/5pTZs2tT59+thDDz3kkugacT558mT7+uuvrWHDhu6nFhpVmRcAAEJNvGuiq3TL4sWL7brrrrNly5bZnXfeaTly5HBB9Y033kicvQQAAAAAAAmuWLFiNm3atBi3VaxY0ebNm5fk+wQAQLIfiX7NNdfYkSNH3GIi69evt1q1avnqpmXPnj0x9hEAAAAAAAAAgOQxEr1Jkyb21FNPWXh4uN1www1Wo0YNe//9913dtKeffjpx9hIAAAAAAAAAgOSQRH/uueesTJkytm/fPlfCJSwszPLmzWtjxoyx2rVrJ85eAgAAAAAAAACQHMq5iOqgN2vWzP744w+LiIhwddKuJIGuFb7btm3rVgRXWRgtWuLRqt+tW7e28uXL2z333OMWL/X3n//8xyXxy5UrZ61atXL39/fOO+9YzZo13XP37t3bzpw549t27tw5d1ulSpXcSPqpU6deydsAAAAAAAAAAEjh4p1EVwK6b9++VqVKFZdIP3TokL344osuGf7XX3/F+XkuXrxo7du3dwuUzp8/3wYOHGhvvvmmLVq0yCIjI61z585uwdK5c+dao0aNrEuXLrZ//373WP3UdpWW+eijjyxbtmzWqVMn9zj57LPPbPz48TZo0CCbPn26bdiwwUaOHOn72yo9s2nTJretf//+7r5Lly6N71sBAAAAAAAAAEjh4p1EVzJ6x44dLvGdLl06d1vXrl3t2LFjNmTIkDg/jxYnLVWqlA0YMMAKFixod9xxh9166622du1aW7VqlRtZriR4kSJFrEOHDm5EuhLqMmfOHCtdurS1adPGrST+8ssvu/IyP/zwg9s+Y8YMe/zxx93o+LJly7oEvR6r0einT592j+/Tp4/dfPPNblR9u3btbNasWfF9KwAAAAAAAAAAKVy8k+iff/65S0CXKFHCd5t+Hzx4sH377bdxfp5cuXLZ2LFjLXPmzG4EuZLna9ascSPcNXL8pptusowZM/rur5Ix69evd79ru0qxeDJkyOAS4tp+4cIF+/nnn6NsVwL+/PnztnXrVnf5559/XJkX/+fWc2p0PAAAAAAAAAAAV5xE//vvv13SOjoloJXAvhJ16tSxhx9+2CW27777bjt8+LBLsvvLnj27HTx40P1+ue0nTpxwJWf8t6dJk8ayZs3qtuuxKiETHh7u266yMXrM8ePHr2j/AQAAAAAAAAApU+orSXi/+uqrdurUKd9tKr2iUi4qyXIlxo0bZ2+99ZZt2bLFlWZR2RX/JLfouhYxlcttP3v2rO96TNtje6x4zw8AAAAAAAAAgKSJ79vQr18/6927tyu7otHnTZs2tZMnT1qNGjXspZdeuqJ3tUyZMu6nRoN3797dPaeS3f6U4E6fPr37XbXYoye8dT1Lliy+Ou0xbdcIeo2Wj2mbeM8fXdq0YZYqlYUM77WGh4fZ/63ViiDC8QleHBskBP3/AAAAAACAZJxE1wKir7/+uht9vnPnTldfvFChQm4B0PjQwqKqYV6vXj3fbUWLFnW1y3PmzGm7du265P5eiZbcuXO76zEtVKqyLUqk67q3T9pHlWrR86r+ul6DblOZF1GJFyXQlYSPyfnzV1amJrknAiMiLpAIDEIcn+DFsUFC0P8PAAAAAABIxkn0li1b2sSJE6106dKWP3/+K/7De/futS5dutjy5ctdUlw2bdpk2bJlcwt9Tp061ZVm8UaHa+FR3S7lypVz1z0atb5582b3fKlTp3Yj27W9atWqbruS9UqYlyxZ8n8vOk0ad5u3+Kjuq8fosQAA4P/79ddfbeXKlfbLL7/Yn3/+aalSpXKd0loA/Pbbb7d8+fIFehcBAAAAAEhU8c4aaxHOo0ePXvUfVtL65ptvdqVhduzY4ZLpI0eOtI4dO7pSMXny5LFevXrZ9u3bbdKkSbZx40Zr1qyZe6zKvaxbt87dru263w033OBLmmuR0ilTptiyZcvc4wYMGGDNmzd35Vx0ady4sbtN23QfJexbtWp11a8JAICUYs2aNda6dWu777777JNPPrG0adNaiRIl3KwxlXObO3eu1a9f39q0aWOrVq0K9O4CAAAAABA8I9E18qxTp04uCa7RZ9EX6dTCoHERFhZmb7zxhg0ePNgeeughl9x+7LHHXDJbo9y0rU+fPtakSRMrUKCATZgwwfLmzeseq4S5SsoMGzbM3V6hQgX3U4+Te++91/bt2+fqt6ve+V133WU9evTw/W0l3ZVEf/zxxy1z5szWtWtXdx8AAGBufZJDhw652Wfjx493sTImp0+fts8++8zGjh3r2gSjR49O8n0FAAAAACDokuhy//33J8gfVxkXnZzHRInzmTNnxvrYO+64w11i0759e3eJiRL2w4cPdxcAABCVOrBvu+22f71fxowZ7YEHHnAXlXwBAAAAACAlSnMlJ9bly5d307r9acT3t99+m5D7BgAAAuDfEuiqjX7dddf5ZoBJjRo1kmDPAAAAAABIBjXRVW7l5MmTl9yuuubPPfdcQu0XAAAIAirr8uyzz9qWLVvs3Llz9uijj1r16tWtTp06tnXr1kDvHgAAAAAAwTES/b333rNBgwa5EWeRkZHu5DkmcZn6DQAAkg+tIaLa51mzZrV58+bZf//7X5s9e7Z9/PHHbl2TWbNmBXoXAQAAAAAIfBL94YcftmLFitnFixfdYpzjxo2za6+91rddyXXVGS9evHhi7isAAEhiq1atcsnzPHny2LJly6xu3bpWrlw5y5YtmzVs2DDQuwcAAAAAQPDURK9cubL7+eWXX1revHmj1EEFAAApU7p06VwZl7/++stWr15to0ePdrfv3bs3Soc6AAAAAAApVbwXFs2XL5+bwv3OO+/Y77//bvPnz7cZM2ZYzpw5rX379omzlwAAICDq1atnzzzzjKVPn94lzWvVqmWffPKJDRs2zB544IFA7x4AAAAAAMG3sKjqo48YMcKaNGli58+fd7eVLl3apkyZYuPHj0+MfQQAAAGsid6iRQs3I2369OluZHpERIR17NiRBcUBAAAAACEhzkn0H3/80Z00v/vuuzZkyBB79NFHLXXq/z28UaNGLrE+Z86cxNxXAACQxNKkSWOtW7e2Pn36uFlnWh9FcV/tgKsp7abZay+++KLv+ubNm+3BBx909dabNm1qmzZtSqBXAAAAAABAEiTRdTLbq1cv9/v+/futSJEil9wnf/78dvz48YTfQwAAEDCRkZH25ptvWtWqVe3WW2+1ffv2WY8ePaxfv36uc/1KLFmyxJYvX+67fvr0aZdUr1SpklvEtEKFCtahQwd3OwAAAAAAySKJnjt3bndSGx4e7kaILViw4JIT7KlTp1rZsmUTaz8BAEAATJgwwa2F8sorr7h2gKgW+nfffedmocWXOtz1uDJlyvhuU411lYl54YUXXEe9Rr1nypTJli5dmqCvBQAAAACAREuiv/HGG3bNNde43/v27Wtz5851o9M1Am3gwIF255132jfffGO9e/e+op0AAADBSQuIDxo0yGrXru0r31K9enUbPny4ffrpp/F+Pj1O5WCKFi3qu23Dhg1WsWJF3/Pr5y233GLr169PwFcCAAAAAMCVSRPfBxQvXtw+++wzNypt165dduHCBatbt67df//9btQYAABIOY4ePWq5cuW65PYsWbLEu9zK999/79ZYWbRokVuw1HP48OEoSXXJnj27bd++/Sr2HAAAAACAACXRRVOutfgXAABI2apVq2ZTpkxxo9E9p06dsjFjxrg66XF17tw569+/v6ulnj59+ijbzpw54ysV49H1y9VcT5s2zK5iXdNkx3ut4eFhFhkZ6L1BdBwfJAT9/yA4BduxOXv2rOuQXrFihf3yyy/2559/ullcWgD8pptusttvv93q169vGTJkCPSuAgAQukl0jSAbMmSIG4V+/vz5S7Zv2bIlofYNAAAEmEaMd+nSxZVwUSK8U6dObpHxvHnzugVH42r8+PFWunRpq1mzZoyd89ET5roePdnu7/z5CxaKSdqIiAskaYMQxwcJQf8/CE7BcmwUGydNmmQzZsywggUL2m233WZ33XWXZc2a1S5evGjHjh2zbdu22QcffODWMnn44YetY8eOLs4CAIAkTqJrsa9ixYrZc889d9mTWwAAkPxdf/319tFHH7lSLOpA/+eff6xQoUJWo0YNS506TkurOEuWLLEjR45YhQoV3HUvaa4ScQ0bNnTb/Ol6TGVkAAAIVS1atLA6deq4Bblz5Mhx2fvu27fPPvzwQ3vooYdswYIFSbaPAACkVPFOov/xxx/21ltvuRNoAAAQGm699VZ3uVLvvvuuS8B7Ro0a5X52797d1qxZY2+//bZFRka66ej6uW7dOjd6DgAA/M/UqVPdqPO4yJcvnz377LP2xBNP/Ot9v/jiCzfrzN/dd99t48aN813fu3ev3XfffS4XEJ9ybgAAhGwSXYFTo8miB1kAAJAylCxZ0iWz4yKuZdx0Mu/PW4y8QIECbhHR0aNH29ChQ90ou9mzZ7s66Q0aNLiCvQcAIGWKawI9vo/ZsWOH1a5d2wYPHuy7LXoJGJV3i++C4gAAhHQSvV27dtasWTObN2+eOyGOfpKt+mwAACD58o/lP//8s02bNs3VQi9TpoylTZvWNm/e7Gqct2rVKkH+XubMmW3ixIlu4VFNPS9RooSr+ZoxY8YEeX4AAFIqrVOixb9/+uknN5OrfPnyrgSrOqnjaufOnVa8eHG3MGlMPv74Y/v7778TcK8BAAiBJLqmXWfLls3q1atHTXQAAFKgKlWq+H7v16+fDR8+3C0s6j9SXR3pvXr1statW1/R39CCZ/7Kli1r8+fPv4q9BgAg9PTs2dPq1q1rPXr0cGXT5s6d69Yv08/4JNG1SGlMtFjpyJEjXSkZrWECAECoincSXat9axR6kSJFEmePAABA0NBaKCq3El2GDBnsxIkTAdknAABC0csvv2zt27ePEpcPHDhg9957r28U+V133WULFy6M83Nq9Pru3btt5cqVblbYhQsXrH79+tatWzcLDw93nd4PPPCAFStWLFFeEwAAKTaJXrFiRddTTRIdAICUr1atWta7d2/r27evG4Guk22VeBkyZAg1ywEASEI33nijPfzwwy42P/nkk5YjRw5XbvWee+6xwoUL28WLF119cy0oGp9yMFqHRAnzsWPHugVEFePPnj1rderUsbVr19rixYvj/Hxp04ZZHJdVSRG81xoeHmaRkYHeG/jj2AQ3jk/w4tgkYBK9Ro0a7mT6888/t/z581tYWFiU7Sw4CgBAyqE6q6pV/thjj7mTc1Hsb9y4sUusAwCApPHII49Y8+bNbc6cOfboo4/a7bff7kama1HQjRs3uvXKbrrpJsubN2+cn1Pl2VavXm3XXnute3ypUqVcvNdI9K+++soGDhwYrzKu589fsFBMNkVEXCDZFGQ4NsGN4xO8ODYJmET/+uuvXWA9dOiQu/iLvsgoAABI3rTo5+jRo91JtKZ7S6FChdztAAAgaWmBb41Gf/DBB13dc3Vya6CbkumxLQz6b7JmzRrlujfrfN++fS6Z7k8j4NWRrk52AABCSbyT6O+++27i7AkAAAhKp06dctPDtWCZyrls2bLFt61y5coB3TcAAEKJBrXt2rXLjTZXIr1Zs2ZuzbLHH3/cLQIe32T6ihUrrHv37vbNN9+49U5EcV6J9Q8//DDKfVVvXaVe/BcbBwAgVMQ7ie4F1e3bt/umdeuEOiIiwjZv3uxGqsWVRrIPHTrUVq1aZenSpXO13LSSuH5XcI6esH/ppZfctDVRXTbVbDt8+LDreR88eLBly5bNtz8aNffRRx+5fVTDQg2D1KlT+1YY79evn1s85brrrrOnn37aGjVqdCVvBQAAKZoWJxswYICrlxqdZqD5J9QBAEDi0Tnsd999Z+XLl3fxWee7U6ZMcSVemjRpYgsWLLAnnnjCqlWrFueSaxUqVHDn37p/586dbc+ePTZixAhXa71AgQKX3D937twxLjgOAEBKF+8k+vjx491Fi5gcPXrUBdEjR464VbzvvPPOOD+PEt2aGpYlSxabNWuW/fXXX67WuhLdPXv2dIuXPv/8824lcI83dVz13vr06eMS9lrkTIn4Xr16udXEZdq0aS7Jrv3UqLkePXq4QN+2bVu3XffVQikffPCBbdiwwTUYNDW9bNmy8X07AABI0V599VU30k0xmxIuAAAEzpIlS9zocJVbOXfunN1yyy32559/usFkadKkcYPHdP6sBHtcKbYrET9s2DBr2rSpZcqUyVq0aOGS6AAA4CqS6Eo8K3n90EMPudW6p0+f7hYh0QrgWi08rjQFbf369a4nXQl50Qn68OHDfUl0Jb1jmoo2c+ZMa9CggavFJuop12Iq6jXXYqczZsxwz1WpUiW3XaPQX3vtNfd8v//+u5sC9+WXX9oNN9xgxYsXd/vx3nvvkUQHACCa48ePW6tWrUigAwAQYCVKlHDntTVr1nSzwHWurJnV/rT4t0alx0exYsXcQLR/s23btnjvMwAAKcX/6pvEg0qhKGiLFhj96aef3GhyJdE/+eSTOD+PAv7kyZN9CXT/uqu6qNRLwYIFY3ysRo97CXLJkyePqwmn2/W4AwcORKnRWrFiRbcoyh9//OHuo/srge6/Xa8DAABEpU7qzz//PNC7AQBAyBs3bpw7l1Vc1kxwDWhTaTUAABCEI9FVvkUjvpW01jQy9YDff//9boSappLFlRLvXjJeVLtcI8xVv02j0NUYeOutt+zbb791i5qotptX2kXJ8Fy5ckV5PpVrOXjwoKuRLv7bvUS9tz2mxyr5DgAALo37Kuny6aefutqoadOmjbL95ZdfDti+AQAQSnReq9KkAAAgGSTRVRdVi3+qZlq9evWsdevWLin9n//8x9Unv1IjR450CXktjvLLL7+4JHrhwoXdQqJr1qxxi4oqUa+666pnHh4eHuXxuq7FTbXNu+6/TbRdC6PF9tjYpE0bZqHUwe+91vDwMIuMDPTeIDqOT/Di2CAh6P8nmGjNkoYNGwZ6NwAACHkqr9a1a9cos64vR+fob775pr377ruJvm8AAKR08U6id+zY0a6//nrLkCGDqyGunvDZs2e70eJKrF9pAl1T0TTSTTXKVZNN08f1nKLk/K+//mrvv/++S6Jr9fDoSW9d1z75J8x1P+930fbYHps+ffpY9+/8+QsWionAiIgLJAKDEMcneHFskBD0/xNMGGkOAEBw0MCyQYMG2dGjR92Atttuu83NDldddM3sVulV1S1fu3atK7WqEqr9+/cP9G4DABCaSfQhQ4a4HnBvEVGNTNflSg0ePNglx5VIv/vuu91tGoXuJdA9GpW+atUq39TyI0eORNmu62okaJuobItX99wr8eJtj+2xAADgUsuWLXPrmGhRcNVgLVSokJsp5i3wDQAAEp8Gm2lUuWZqayDb008/bSdOnIhyH51HV69e3YYOHWpVqlQJ2L4CAGChnkT/+OOPXQmXhDB+/HgX/MeMGWP169f33a4Vx7XQ5zvvvOO7bevWrS6RLuXKlXO9696q41pIVBfdriS56rVru5dE1++6TWVnypcv7xYZVX10jaj3tut2AAAQleL08OHDXdK8ffv2bqTbunXrbODAgXb+/Pmr6kgHAADxp3IuXkmXvXv3urXJNBBNNdO18CgAAAiCJLoS6Dpx1k8lpr2SKR7dFhdaPPSNN95wJ+QVK1b0jRYXlXKZNGmSTZkyxZVvWblypS1YsMBmzJjhtrds2dIee+wxl/guU6aM62WvVauW5c+f37d91KhRviT56NGjrU2bNu533adGjRrWo0cP69Onj/3888+2ePFit6gpAACISiPQNRXcf9S5ppBrNJwWACeJDgBA4GjgmDd4DAAABFESfdy4ce7nihUr3E/1eEtkZKT7fcuWLXF6ni+//NJNCddCJ7r4Ux03jUbX39LPfPnyuUR4hQoV3Hb9VC04bdeCZ5quprIwnrZt27o6cV26dLGwsDBr1qxZlNHzI0aMcAn05s2buzIuquWu+u4AACAqxdOYZmspFmsWGAAAAAAAKV28k+hKficEjUDXJTYa5aZLbFTKxSvnEp0S51rwVJeYZM+e3Y2eAwAAl1eqVCk3G+yZZ56Jcvv8+fOtaNGiAdsvAAAAAACCNomuUeExiYiIcKPQY9sOAACSH5U/02yu1atXu7VHZP369W6tEjqkAQAAAAChIN5JdG8xsR07drjFxaKPAN+0aVNC7h8AAAgglW2ZN2+ezZkzx61norVQtJjZq6++yuJlAAAESM+ePe3ee+91pU11Hg4AABJX6vg+YMiQIW60uUafZciQwV5//XXr27evZc2a1dUaBwAAKcs///xj99xzj7399ts2fvx4u+666+zEiROB3i0AAEJW5syZ3TpfSqL369fPVq1a5dYpAwAAQZJE3759uz3//PNWs2ZNu/nmmy1t2rT2yCOPWP/+/W3KlCmJs5cAACAgPvnkE3vwwQfdTDTPzz//7BbnXrZsWUD3DQCAUPXSSy/Zt99+a+PGjbM0adJY9+7d3Tn60KFDXdk1AAAQ4CS6Rp9708UKFy5s27Ztc7+XLVvWdu/encC7BwAAAkkn5yrjprroHpVyUee5fgIAgMBIlSqVValSxY1EX7p0qTVr1sw+/PBDa9mypdWtW9cmTpxo586dC/RuAgCQIsQ7iV6tWjUbPXq0HTp0yNVJ1Qi148eP21dffWVZsmRJnL0EAAABcfDgQRfvo6tYsaLt2bMnIPsEAADM/v77b1u8eLF16dLFatSoYZ9++qk98cQTtnDhQhs0aJBLrHfq1CnQuwkAQGguLKq6az169LDPP//cWrRoYR999JFLrGt0+oABAxJnLwEAQEDcdNNNNnPmTLf+iT+NdCtZsmTA9gsAgFD21FNP2X/+8x83kK1BgwY2Y8YMNzvcU7x4cbd+ic7fAQBAAJLouXPndgHa8+6779qOHTtc8NY2AACQcrz44ovWtm1bW758uZUqVcrdplJumoU2adKkQO8eAAAhKUeOHK5cS9WqVV1Zl5hUqlTJ5syZk+T7BgBAShTvJLrs3LnT5s6da7t27XIBu0SJEm7RMQAAkLJoVNtnn33mpov/+uuvbvEynbDff//9ds011wR69wAACEmDBw+2WbNm2ZEjR6xhw4buts6dO7uyLqqJLjlz5nQXAAAQgJroqn3eqFEj+/nnn61QoUKWP39+++GHH+zee++1NWvWJMAuAQCAYJItWzZr0qSJW7Ds+eefd+0AEugAAASOFvd+6623LGPGjL7b1Mn9xhtv2IQJEwK6bwAApETxHok+cuRIe/rpp+3JJ5+Mcvubb75pQ4cOtQULFiTk/gEAgAA6d+6cW5xs/vz57rpGpQ8fPtzOnDljY8aMsWuvvTbQuwgAQMjRzPCxY8e6ki2eVq1auVniWsNMo9IBAEAAR6IfOHDA6tate8nt9evXt927dyfUfgEAgCCgznOVcVMSPV26dO62rl272rFjx2zIkCGB3j0AAEKSOrMzZ858ye3XXXednTx5MiD7BABAShbvJLpW/p48ebKdP38+yu1asOSee+5JyH0DAAAB9vnnn1ufPn3cyDaPflct1m+//Tag+wYAQKiqWbOmmwm+f/9+322HDh1ys8VUFx0AAAS4nIumdeuEWifOpUuXtrRp09q2bdtsz549Vq5cOTeFzDNjxowE3l0AAJCU/v77b8uQIcMlt1+8eNEuXLgQkH0CACDU9evXzzp16uRmiXul1f766y+rVq2a2wYAAAKcRC9cuLB17Ngxym3+o9MAAEDKUadOHbd4mUa2edRxrlIud9xxR0D3DQCAUF70e/bs2bZ161b79ddfLU2aNFawYEErWrRooHcNAIAUKd5J9C5duiTOngAAgKCj0Wy9e/e2KlWquNHnTZs2tRMnTrhp5C+99FKgdw8AgJD1zz//uBroWbJkcdcjIyPdOmVbtmyh1CoAAIFOogMAgNBxzTXX2Ouvv+5Gn2uBUZ2wFypUyIoUKRLoXQMAIGQtW7bMdWYfP378km05c+ZMEUn0R99i7ZWEMrPj7Qn+nDkn/P9SvsEshwW3w50TvgxyvelPJvhzhqplj7+d4M95fNheC3bHLPhl7X1D8C8sCgAAQouS51mzZrVatWpZunTpbObMmW5BcQAAEBijR4+2O++805YsWeJGoqu0y1tvvWX58uWzZ555JtC7BwBAikMSHQAAxOqDDz6w+++/300N37x5sz311FNuVPprr73mLgAAIOkpFrdr186tWVa6dGk7fPiwW6ukf//+Nm3atEDvHgAAKc5VJdG1+rfqo6r2GgAASHkmT57sFhVVTfS5c+daqVKl3G1abPRKRqP/9ttv1rZtW6tQoYIb2a7n8k8ItG7d2sqXL++moa9cuTKBXw0AACmDRp+fOXPG/a4ya1pgVJRU37s3+EsFAACQ4pPoSpi/+eabVrVqVbv11ltt37591qNHD7fwWEREROLsJQAACIhDhw5ZxYoV3e9ff/211atXz/1+/fXX299//x2v51LHe/v27d0iaPPnz7eBAwe6NsWiRYtc+6Jz586WI0cOl6xv1KiRW8x8//79ifK6AABIzjTqXHF0x44d7tx84cKF9ssvv7gZZLly5YrXc33xxRdWokSJKJdu3bq5bd98842Lyer8vu++++zLL79MpFcEAEAKS6JPmDDBPv74Y3vllVcsPDzc3fbAAw/Yd999ZyNGjEiMfQQAAAGiEW1Kcn/00Ucuoa0k+vnz523q1KlWsmTJeD3XkSNH3Ej2AQMGWMGCBV0CQB3ya9eutVWrVrmR6IMGDXKLlnbo0MGNSFdCHQAARNWnTx8rUKCAbdq0ycXmcuXKWbNmzWzWrFnWs2fPeD2XEvG1a9d2M8C8y5AhQ9zodnVoN23a1BYsWGAtWrSwp59+2jfqHQCAUJImvg/QyDEl0CtXrmypUqVyt1WvXt1N9VZA7du3b2LsJwAACACdiGuBMpVwe/jhh12CW4lujVrTAmbxoZFxY8eOdb9r5Pm6detszZo1rn7rhg0b7KabbrKMGTP67q8R8OvXr0/w1wQAQHKnEeIvvPCCm90lo0aNcp3UWgA8bdq08V5AvHjx4pYzZ84ot0+aNMmqVatmrVq1cteVtP/qq6/s008/jXdHOgAAITcS/ejRozFOD1NNttOnT8d7irimianOas2aNe3ll1+2c+fOxaku6n/+8x9r2LCh63FXUNf9/b3zzjvuOTXtrHfv3r56caK/odsqVapkNWrUcKPpAADApTRS/Pvvv7fVq1e70m3SqVMnV9pFC5ldqTp16rikvOL03Xff7RZEi96+yJ49ux08ePCqXwMAACmNSrkcO3Ysym2ZM2eOdwLdS6Jrhlh0mnHevXv3S24/efJkvP8GAAAhl0RXT/SUKVOi3Hbq1CkbM2aMq8UWVxqBpgS6ktuacqYFynRCrhFq/1YXVT+1vUmTJm56ebZs2dwJvbfA6WeffWbjx493I+WmT5/uRreNHDnS97dVdkbT3rRNo99036VLl8b3rQAAIEV67bXXXGz3pE6d2q699lrfdcVn/5P0EydOuDgeH+PGjXMj2bds2eI60dUe8MrEeXSd9VYAALiUzr0XL1581XFS59C7d+92g9bUqa3SMBrVrufV7DP/Eefbt293HevqYAcAINTEu5yLpogpoa0SLhrRreS1ktp58+Z1i4PF1a5du9wUbdVS18m4KKmusjC33367G1k+e/ZsN61bwVvBWgn1rl272pw5c9zotzZt2rjH6eRb+/PDDz+4xsSMGTPs8ccfd3XdvF76tm3bugVQ1UjQ499++227+eab3UWNASXy69evH9+3AwCAFCdPnjyuA1szunQyrdgafWSbkt4//fSTO4HX7LCOHTvG62+UKVPG/VRbQqPcVG/Vf9aY6AQ+ffr0MT4+bdow+7+qciHBe63h4WH2f2MGEEQ4PkgI+v9BcArGY6MZ4m+88YbrkNagMpVx8RfXBUB1Lu91ZGtA2969e1099LNnz0Yp1frnn3+6c/FbbrnF6tatm+CvBwCAFJdEv/76693obyW1lQj/559/rFChQq4sikaqxZXqrU2ePNmXQPdo5Nu/1UXVdpVi8WTIkMElw7Vdt//8888u0e9RSRgtgqYFUJRE1z5r+rj/c6vxcfHixXi9BgBJq970JwO9CynCssffDvQuIMg1b97c7rrrLtfBrPJnOnG+4YYbXN1Vxcrjx4+7k2zFci1ipvVSvJqs/7awqGK1EvOeokWLuhit51K7Ivr9YyohJ+fPX7BQTNJGRFwgSRuEOD5ICPr/QXAKxmOjWK3L1cqXL58r2aYZZ1rzTAuAK9ZrAFqvXr0sLCzMxeMnnnjCnUtrJtnlzplDrZM7uQjGjiD8D8cmuHF8gld4AI5NvJPoHk3hupppXKqhrhFuHgXqmTNnunIx/1YX9XLbNaVco9r8t6dJk8ayZs3qtivg60Tff8q4Evl6jJIC6sUHACDUKW6qdJpmnG3bts02b97skuk6wVbMVWe3FiGLDyXe1cm9fPlyy507t7tN5dUUe9WhrTVKNPLNG32+du1adzsAALi0XnlCxnx/mgmu82MtKq6Obm9hUc34/rfz5VDr5E4ugrEjCP/DsQluHJ/gFRGAYxOnJLrqoOmkOS5U2/RKqGa5TtA1yl2Lgl6uLurl6qbq5Nu7HtN29Z7HtE2ouwoAQFSK/2oH+NdEvVIq4aKZYxrdrtFt+/btc/FfpWC0yLjKyOh2b+HSjRs3upJtAAAgqscee+yy5+hKeMfFihUrXFm1b775xs3w9s7plVhXp7bKpGogmp5Ps8YAAAhVcUqi+wdglUqZNm2aO8HVybBqpCr5rcU5vR7q+NIJtBb51KJkGtWmem4aFR5bXVRtj57w1nWNbvdqwcW0XY2CCxcuxLhNqLv6P9T1DG4cH1wtpqQFt5R8fDQlXPVbBw8ebA899JCLy0oCqP2gRIC29enTxy0cXqBAAZswYYJbcwUAAESl9Ur8qWSp1hXTbK+nnnoqzs+jMqc6h1b9c81A03OMGDHC2rVrZxMnTrTff//d3n33Xd+McO+8+ZprrkngVwQAQApIomt0mKdfv35u8U8t5OnR6DTVUtPosdatW8drB3Qi/f7777tEulYDF03x3rFjR6x1UbVd16NvV/029ZirEaDrmobmNSiUlFfPuUaiHzt2zN2mMi9eY0ANASXhYxJqU9Ko6xncOD64WkxJC24p/fgohqvjPSZKnKu0GwAAuDz/NcD8zZs3zz7//HNr27ZtnJ4nc+bMNmXKFBs2bJhb5DtTpkzWokULl0Rv0KCBm+n94IMPXlJK5pVXXkmQ1wEAQHIR75rof/zxh6uFGp1Gk6keeXzoJHr27Nk2ZswYq1+/vu/2cuXK2aRJk2Kti6rtuu5ReReNhldDQlPNNEJe273eeS1ipoS5NxVdv3uLkHrPrcewqCgAAAAAILmqXLmyDRw4MF6PKVasmJttHt3SpUsTcM8AAEje4p01rlWrlqtlum7dOjt9+rT9/ffftmrVKnebeqrjaufOnW7a9pNPPumS4xoN7l3866Ju377dJdRVF7VZs2buseoh19/X7dqu+91www2+pPnDDz/setOXLVvmHjdgwAC3crkS/bo0btzY3aZtuo8WMrvSUjQAAIQSLTSm+Hny5MlA7woAACFr//79l1x0bqxSaJolDgAAAjwSfdCgQda/f39Xw/TixYv/e5I0aaxRo0aujlpcffnll64++Ztvvuku/rZt23bZuqhKmL/++utuypluVx03/fQWVrn33nvdYmUqPaN653fddZf16NHD9/xKuiuJrkVSNH2ta9eu7j4AACAqlVdTR/mLL75oRYsWdbXMd+/e7TqlFb+rVasW6F0EACDk1KlTx53/qlypdx6s3zUYTefJAAAgwEl0JZ1Hjx7tpojpJFoKFSrkbo+P9u3bu0ts/q0u6h133OEuV/L8OvFXXXddAABA7BTv8+fP72L9Rx995Eagr1y50ubOnevi6Pz58wO9iwAAhBwNSvOnRHratGktR44cvqQ6AABIOFdcBFxJc9UR1yW+CXQAAJA8qHTLM888Y9ddd50rgXbnnXe6E/SGDRvarl27Ar17AACEJJVs+eabb+ynn35yv2vWtjq+teYYAABIeKykCQAAYnXNNdfYkSNH7MCBA25Rbq2NIlu2bIlxoXEAAJD4Xn31VVdWLWPGjL7btLaYyqKq1CkAAAhwORcAABA6tDbJU089ZeHh4W5Nkho1atj7779vI0aMsKeffjrQuwcAQEhSWbWxY8dapUqVfLe1atXKSpQo4dYD69y5c0D3DwCAlIYkOgAAiNVzzz3nSrdpwW6VcAkLC3NTxseMGWO1a9cO9O4BABCSzpw5E2NZVZVf0/olAAAgCMq57Nmzxy0m1qlTJ/vjjz/cQmM//vhjAu8aAAAIBqqDrhHoa9eutS+++MItMkoCHQCAwKlZs6YNHTrU9u/f77vt0KFD7jxdMRsAAAR4JPqaNWusffv2LmivWLHCzp075xYWGzBggBuVdtdddyXwLgIAgEBRPfRu3bq5hcuyZMliFy9etFOnTln16tVdPVbVTAcAAEmrX79+blBbnTp1LGvWrO6248ePW7Vq1ax///6B3j0AAFKceCfRR44cac8//7w9+uijVqFCBXfbCy+8YLly5bJx48aRRAcAIAXp06ePpUmTxo1AV010+e2339zt6kAfPXp0oHcRAICQky1bNps9e7Zt27bNdu/e7WJ1wYIFrWjRooHeNQAAUqR4l3P573//a3fcccclt9etW9d+//33hNovAAAQBH744Qd76aWXfAl0KVCggPXt29e+/vrrgO4bAAChKiIiwi3yrbKq9evXt3r16rnBbaNGjbLz588HevcAAEhx4p1Ez5cvn/3888+X3P7NN9+4bQAAIOXInz+/G+UWnWqwaoFRAACQ9IYMGWLLly+3kiVL+m5TeRedl6suOgAACHA5l2eeecZefPFFl0i/cOGCLViwwPbu3WtLlixxPeEAACDlaNq0qQ0cONB++eUXV8ZN08W3bNliM2bMsCZNmrh2gKdx48YB3VcAAELF559/btOmTbNSpUr5btNo9Ny5c1uHDh3cjDEAABDAJPqdd97pRqVNnTrVihUrZl9++aUVKlTIZs2aZeXKlUvAXQMAAIE2ffp0t3joZ5995i6eTJkyRbktVapUJNEBAEgikZGRdu7cuRhvp5wLAABBkETXtLFWrVox6hwAgBDw1VdfBXoXAABANHfffbdbs6R///520003udu2bt3qztc1Ih0AAAQ4if7xxx/b448/nsC7AQAAgpVOynft2uUWMYuO0ecAACS9Xr16WZ8+fdy5+cWLF90IdJVcU1zu3LlzoHcPAIAUJ95J9NatW9ugQYPcTy0oli5duijbWWQMyVnOCa0suchhwe1w5xmB3gUACWDUqFE2efJky549+yUxnxIuAAAERoYMGWzMmDF24sQJ++2339x6Zb/++qstWrTIjUTXWiYAACCASfRx48a5nytWrIhyEq2eb/3UYmMAACBl+OCDD2zo0KFugVEAABBctm/f7hb5Xrp0qZ06dcqKFClivXv3DvRuAQCQ4sQ7ia6FRAEAQGjQoqJlypQJ9G4AAID/s2/fPpc4X7hwoe3Zs8eyZMniEuijR4+2e+65J9C7BwBAihTvJHq+fPncz927d9vOnTstbdq0VrhwYcufP39i7B8AAAignj17ujJu3bp1cyXbUqdOHWU7ZdwAAEgac+fOdcnzH3/80XLlymV16tSxu+66yypXrmzlypWz4sWLB3oXAQBIseKdRD9w4IC98MILtmbNGrv22mtdGZeTJ0+6AK7p3lmzZk2cPQUAAEnu7Nmzrq5qq1atXNk2D2XcAABIWlpItECBAjZ8+HC7//77A707AACElHgn0fv27WthYWGurIs3Kl0LmKjuWr9+/Xw10wEAQPI3cuRIa968ubukT58+0LsDAEDIGjZsmC1ZssR69eplL7/8stWqVcstIlqjRo1A7xoAAClevJPoGoE+b948XwJdChYs6BLoLVq0SOj9AwAAARQREWGPPvooZdsAAAiwJk2auMuff/5pn376qX3yySfWpUsX18l98eJFW716tRuprpKrAAAgYUUtbBoHWu37v//97yW3a0ET/8Q6AABI/tq0aWMTJ060c+fOBXpXAACAmWXLls0eeeQRmzVrln399dfWuXNnK1WqlA0ePNhq1qzpRqkDAIAAjETX4iWeatWquVpsmzdvtjJlyrjSLtu2bbN33nnHnnjiiQTePQAAEEjfffedrV+/3rUFcuTI4eK+P5V3AwAAgXH99ddbu3bt3EVlVhcvXuxGqKvkCwAASOIkevQ659ddd50LzLp4rrnmGrdaeKdOnRJw9wAAQDBMHQcAAMFNZVZV3kUXAAAQgCT6V199lcB/FgAAJAcPPPCA7/e//vrLdZqnSpXKXQAAAAAACAXxrokuW7dudaPQNbU7+uVKFy1r2LChWwjFM2TIECtRokSUy8yZM33bNU1NK5GXK1fO1YDT4iqeyMhIGzVqlCs9U6VKFRsxYoRbaMVz7Ngx69q1q1WoUMHq1KljCxcuvKL9BgAgpVNMffPNN61q1ap266232r59+6xHjx5uQXHFbwAAAAAAUro4jUT3p+T05MmTLXv27JYuXboo2zQqrXHjxvF6Pi1U9vzzz9v27duj3L5z5053u/8IuMyZM7ufGzdudHXZBw4caCVLlrShQ4e6mm9a+EymTZvmkuzjx4+3f/75x53sa3/btm3rtuu+Z8+etQ8++MA2bNhgffv2tUKFClnZsmXj+3YAAJCiTZgwwZYsWWKvvPKKPfvss+42xWYl0dVJrRgKAAAAAEBKFu8kuhLPSlo3bdr0qv/4jh07XKJco9yiUxJdSe+cOXNesk0j0hs0aOBL2Oskvnbt2rZnzx7Lnz+/zZgxw7p162aVKlVy27t3726vvfaae77ff//drWCuhdBuuOEGK168uFsw7b333iOJDgBANPPnz3cJ9MqVK/tKuFSvXt2GDx9uTz/9NEl0AAAAAECKF+9yLqqFWqZMmQT54z/88IObHq7EvL9Tp07ZoUOH3MIoMdHocS9BLnny5LG8efO62/W4AwcOuJN9T8WKFd308z/++MPdR/dXAt1/+08//ZQgrwkAgJTk6NGjlitXrktuz5Ili50+fTog+wQAABLOF198cUkpVQ1Kk82bN9uDDz7oyqhqIN2mTZsCvbsAACSPJHrPnj1t0KBBLgG+d+9e279/f5RLfDz88MPWu3dvy5AhwyWj0DXa7a233rLbb7/d7r//fjcSzqNkePQTepVrOXjwoB0+fNhd99+eI0cO99PbHtNjlXwHAABRaX2RKVOmXNLZPWbMGNcRDgAAkjfNENfM7pUrV/ouWqNMneXt27d3A9jmzZvn1hTr0KEDnegAgJAU73IuqiX+yy+/WKtWrXzTukUlWXR9y5YtV71Tu3btcs9VuHBhe/TRR23NmjX20ksvuZrod955p9uH8PDwKI/RdS1wpm3edf9tou1nzpyJ9bGxSZs2zPxeaornvdbw8DCLodIOECf6/0Fw4tgEt2A4Poq7OlFOkyaNDRgwwLp06eJKuGgdk06dOrlOc80A04KjAAAgedMgNpU5jV5K9aOPPnLroL3wwgvu/Fzrkn377be2dOlSa9KkScD2FwCAZJFEHzlypDVv3txd0qdPnyg7pVrn6gnPmjWru67FQ3/99Vd7//33XRJdgTx60lvXNaLdP2HuLXzq3VfbY3vs5V7L+fMXLJR4SfSIiAsk0XHF9P+D4MSxCW7BcHzUUa5RaJqpdf3117uT6O+//951cmvBbi3GXaNGDUudOt4T2gAAQBAm0W+77bZLblcpVJU+9QbP6ectt9zi1hQjiQ4ACDXxTqIr4azR4VrAM7EoOHsJdI9Gpa9atcr9njt3bjty5EiU7bqunnNtE5Vt8eqeeyVevO2xPRYAAPxvdll0t956q7sAAICUFfN3797tOs8nTpxoFy5csPr167ua6DqPLlq0aJT7q4N9+/btAdtfAACSTRK9TZs2LriqvIo30juhvfbaa26hz3feecd329atW10iXbSoydq1a32931pIVBfdriS5pphru5dE1++6TbXQy5cv7xYZVX10ja7ztut2AADwP/4l2wAAQMqkEm1eydOxY8e6dc9UD11lUimFmnIEQ7lAxIxjE9w4PsErPADHJt5J9O+++85N31qwYIFbsDMsLOpOf/nll1e9UyrlMmnSJLeQmcq3qFdcf2/GjBlue8uWLe2xxx5zie8yZcrY0KFDrVatWr7R8do+atQoX5J89OjRLvkvuo+moPfo0cPVdPv5559t8eLFNnPmzKvebwAAUoqmTZvGqVxLfOK+FvFWzNbMMnXE33PPPfbcc8+53/fs2eM66NXGUMe3Fh5XvAYAAIknX758tnr1arv22mtdB3qpUqXs4sWL7ny5SpUqlEJNIYKhXCBixrEJbhyf4BURgGMT7yS6Rn8ndv2zsmXLutHo48aNcz8V2JUI1yJnop+DBg1y2//66y+32NngwYN9j2/btq0dPXrULYSmJH+zZs2sdevWvu0jRoxwCXTVdVcZl2HDhrm/CQAA/ueJJ56wa665JkGni2tqeJYsWWzWrFkufitRrkS9Fizr3LmzW9Rs7ty5tmzZMhfDP/nkE5dQBwAAiSd6KdUiRYq4xcR1rhxTKVTN8AYAINTEO4n+wAMPuJ+a2vXbb7+5Xuobb7zRMmfOfFU7sm3btijX69Wr5y5XksxX4rxXr17uEhPVcXvrrbeuan8BAEipNBLt3nvvdfEyoWhRUo0y14w2zWQTJdWHDx9ut99+uxuJPnv2bMuYMaM7eddCpkqod+3aNcH2AQAARLVixQrr3r27ffPNN5YhQwZ325YtW1xiXYuKvv32264jXG0D/Vy3bp117Ngx0LsNAECS+/d52tGcP3/ejdyuXLmyS6grkV2tWjWXsL5cbTQAAJB8Fxa9WhrNNnnyZF8C3XPq1CnbsGGD3XTTTS6B7tGJu5LuAAAg8WiWt8qq9e3b13V4L1++3M3cbteunVtg9MSJE64U244dO9xPDaZr0KBBoHcbAIDgT6JrxNjXX39tb775pq1Zs8Z++OEHmzBhgv3444/26quvJs5eAgCAJKNO8oRePFxlXGrWrOm7rplsWo9EHfGHDx++ZGq4RsFrEXAAAJB4NKNca5H9+eefbj0UlT196KGHXBJd2yZOnGhr1651g+fU6a21y/w7vQEACBXxLueiRThVp7xq1aq+2+644w53sq1pYD179kzofQQAAEno5ZdfTvS/MXLkSNu8ebN99NFH9s4771h4eHiU7brODDcAABJfsWLFbNq0aTFu09ph8+fPT/J9AgAg2SfRNcU7phqp2bJls7///juh9gsAAKRQSqBPnz7dzWDTYqLqiD9+/HiU+yiBnj59+lifI23aMEuVykKG91rDw8MsEart4CpxfJAQ9P+D4MSxAQAA8U6ia9r1qFGj3MVbTFR10saMGRNldDpi9+hb3wZ6F1KMmR1vD/QuAADiYfDgwfb++++7RPrdd9/tbsudO7ertervyJEjl5R48Xf+/AULxSRtRMQFkrRBiOODhKD/HwQnjg0AAIh3Er13797WqlUrV9e0UKFC7rbdu3db/vz5XZ10AACAmIwfP95mz57tOt61WJmnXLlyrsbq2bNnfaPPVX9Vi4sCAAAAAJDskugaLaa66N9++61bvVtTsJVMr169uqVOHe91SgEAQAjYuXOnvfHGG9a+fXuXHNdiop4qVapYnjx5rFevXtapUye3gPnGjRuTpDY7AAAAAAAJnkSXtGnTWt26dd0FAADg33z55Zd24cIFN2st+sy1bdu2uQR7nz59rEmTJlagQAGbMGGC5c2bN2D7CwAAAABAvJLoderUsVRxWL1L91m2bFlcnhIAAIQQjUDXJTZKnM+cOTNJ9wkAAAAAgARLonft2jXWbadPn7apU6favn37rEKFCnH6owAAAAAAAAAApJgk+gMPPBDr1OzXX3/dJdKHDBlizZo1S+j9AwAAAAAAAAAgYK6oJrpGnStpvnz5cle7tHv37pY1a9aE3zsAAAAAAAAAAJJLEv2ff/6xKVOmuAXBVLt01qxZlHABAAAAAAAAAKRYcU6ir1692gYNGmSHDh2yZ555xlq1amWpU6dO3L0DAAAAAAAAACDYk+gq17JkyRLLly+fDRgwwHLnzm1r166N8b6VK1dO6H0EAAAAAAAAACB4k+iLFy92P/fu3esS6rFJlSqVbdmyJeH2DgAAAAAAAACAYE+ib926NfH3BAAAAAAAAACAIENRcwAAAAAAAAAAYkESHQAAAAAAAACAWJBEBwAAAAAAAAAgFiTRAQAAAAAAAACIBUl0AAAAAAAAAABiQRIdAAAAAAAAAIBgTqJHRERYw4YNbfXq1b7b9uzZY61bt7by5cvbPffcYytXrozymP/85z/uMeXKlbNWrVq5+/t75513rGbNmlahQgXr3bu3nTlzxrft3Llz7rZKlSpZjRo1bOrUqUnwKgEAAAAAAAAAyU3Ak+hKaD/33HO2fft2322RkZHWuXNny5Ejh82dO9caNWpkXbp0sf3797vt+qntTZo0sY8++siyZctmnTp1co+Tzz77zMaPH2+DBg2y6dOn24YNG2zkyJG+5x8xYoRt2rTJbevfv7+779KlSwPw6gEAAAAAAAAAwSygSfQdO3ZY8+bN7ffff49y+6pVq9zIciXBixQpYh06dHAj0pVQlzlz5ljp0qWtTZs2VqxYMXv55Zdt37599sMPP7jtM2bMsMcff9xq165tZcuWtYEDB7rHajT66dOn3eP79OljN998s915553Wrl07mzVrVkDeAwAAAAAAAABA8ApoEl1J76pVq9oHH3wQ5XaNHL/pppssY8aMvtsqVqxo69ev921XKRZPhgwZXEJc2y9cuGA///xzlO1KwJ8/f962bt3qLv/8848r8+L/3HrOixcvJvIrBgAAAAAAAAAkJ2kC+ccffvjhGG8/fPiw5cqVK8pt2bNnt4MHD/7r9hMnTrgSMf7b06RJY1mzZnXbU6dObdddd52Fh4f7tqtsjB5z/PhxVxoGAAAAAAAAAICAJ9Fjo7Ir/klu0XUtQPpv28+ePeu7HtN21U2PaZt4zw8AAAAAAAAAQNAm0dOlS+dGhftTgjt9+vS+7dET3rqeJUsWt827Hn27yr6o3EtM28R7/ujSpg2zVKkS4IUhwYWHhwV6FxALjk3w4tgEN44PAAAAAADBJSiT6Llz53aLjvo7cuSIr0SLtut69O2lSpVyZVuUSNd1LUoqqoGupHzOnDndSPRjx46521TmxSsPowS6kvAxOX/+QiK9UlytiAiOTbDi2AQvjk1w4/gAAAAAABBcArqwaGzKlStnv/zyi680i6xdu9bd7m3XdY/Ku2zevNndrprnZcqUibJdC44qYV6yZEmXaNfv3iKl3nPrMXosAAAAAAAAAACeoMwaV6lSxfLkyWO9evWy7du326RJk2zjxo3WrFkzt71p06a2bt06d7u263433HCDVa1a1bdg6ZQpU2zZsmXucQMGDLDmzZu7ci66NG7c2N2mbbrP1KlTrVWrVgF+1QAAAAAABE779u3txRdf9F3/4osvrEGDBlahQgVr2bKlG+wGAEAoCsokelhYmL3xxhuuzEqTJk3s448/tgkTJljevHnddiXMX3/9dZs7d65LrKtUi7an+r/C5ffee6916NDB+vXrZ23atLGyZctajx49fM+vpPvNN99sjz/+uA0cONC6du1qd911V8BeLwAAAAAAgbRkyRJbvny577oGrD3//PPu3HrhwoVuVrd+10xwAABCTdDURN+2bVuU6wUKFLCZM2fGev877rjDXS7Xg65LTDQaffjw4e4CAAAAAEAo08C0ESNGuDKnnu+++86KFi3qZnLLc889Z7NmzXLrl/nfDwCAUBCUI9EBAAAAAEDS0ACzRo0auaS5J2vWrC5hrjXELl68aPPmzbPMmTPbjTfeGNB9BQAgpEeiAwAAAACApPX999/bjz/+aIsWLXJrh3nuuece++qrr9yaYyq5mjp1aps4caJde+21Ad1fAAACgZHoAAAAAACEoHPnzln//v3demLp06ePsu3YsWNunTJt+/DDD91Ida0vdvTo0YDtLwAAgcJIdAAAAAAAQtD48eOtdOnSVrNmzUu2jRo1yooXL26PPPKIuz548GBr0KCBzZ07N9b1x9KmDbNUqRJ9txFP4eFhgd4FxIJjE9w4PsErPADHhiQ6AAAAAAAhaMmSJXbkyBGrUKGCux4REeF+fvbZZ5YnTx577LHHfPdVOZeSJUva/v37Y32+8+cvJMFeI74iIjguwYpjE9w4PsErIgDHhiQ6AAAAAAAh6N1337V//vknyuhz6d69uyvzsnPnzij33717t5UpUybJ9xMAgEAjiQ4AAAAAQAjKly9flOuZMmVyPwsUKGDNmze3F1980ZV70Uj1OXPmuFHoDzzwQID2FgCAwCGJDgAAAAAAorjnnnvs77//tokTJ9rBgwetVKlSNn36dMuePXugdw0AgCRHEh0AAAAAANgrr7wS5fqDDz7oLgAAhLrUgd4BAAAAAAAAAACCFUl0AAAAAAAAAABiQRIdAAAkuYiICGvYsKGtXr3ad9uePXusdevWVr58eVeHdeXKlQHdRwAAAAAAhCQ6AABIUufOnbPnnnvOtm/f7rstMjLSOnfubDly5LC5c+dao0aNrEuXLrZ///6A7isAAAAAACwsCgAAksyOHTvs+eefd0lzf6tWrXIj0WfPnm0ZM2a0IkWK2Pfff+8S6l27dg3Y/gIAAAAAwEh0AACQZH744QerWrWqffDBB1Fu37Bhg910000uge6pWLGirV+/PgB7CQAAAADA/8dIdAAAkGQefvjhGG8/fPiw5cqVK8pt2bNnt4MHDybRngEAAAAAEDOS6AAAIODOnDlj4eHhUW7TdS1AGpO0acMsVSoLGd5rDQ8Ps2iVcBAEOD5ICPr/QXDi2AAAAJLoAAAg4NKlS2fHjx+PcpsS6OnTp4/x/ufPX7BQTNJGRFwgSRuEOD5ICPr/QXDi2AAAAGqiAwCAgMudO7cdOXIkym26Hr3ECwAAAAAASY0kOgAACLhy5crZL7/8YmfPnvXdtnbtWnc7AAAAAACBRBIdAAAEXJUqVSxPnjzWq1cv2759u02aNMk2btxozZo1C/SuAQAAAABCHEl0AAAQcGFhYfbGG2/Y4cOHrUmTJvbxxx/bhAkTLG/evIHeNQAAAABAiGNhUQAAEBDbtm2Lcr1AgQI2c+bMgO0PAAAAAAAxYSQ6AAAAAAAAAADJMYn+xRdfWIkSJaJcunXr5rZt3rzZHnzwQbfgWNOmTW3Tpk1RHrt48WKrV6+e2965c2f7888/fdsiIyNt1KhRVq1aNVeDdcSIEXbx4sUkf30AAAAAAAAAgOAW1En0HTt2WO3atW3lypW+y5AhQ+z06dPWvn17q1Spks2bN88qVKhgHTp0cLeLFiLr06ePdenSxT744AM7ceKEW6jMM23aNJdkHz9+vI0bN84WLVrkbgMAAAAAAAAAINkk0Xfu3GnFixe3nDlz+i5ZsmSxTz75xNKlS2cvvPCCFSlSxCXMM2XKZEuXLnWPUz3VBg0aWOPGja1kyZJupPny5cttz549bvuMGTPciHYl4TUavXv37jZr1qwAv1oAAAAAAAAAQLAJ+iR6wYIFL7l9w4YNVrFiRUuVKpW7rp+33HKLrV+/3rddCXJPnjx5LG/evO72Q4cO2YEDB6xy5cq+7Xquffv22R9//JEkrwsAAAAAAAAAkDwEbRJddct3797tSrjcfffdrr656phHRETY4cOHLVeuXFHunz17djt48KD7Xcnw2LbrseK/PUeOHO6n93gAAAAAAAAAACRNsL4N+/fvtzNnzlh4eLiNHTvW9u7d6+qhnz171ne7P11Xgl10n9i2a5t33X+beI8HAAAAAAAAACCok+j58uWz1atX27XXXuvKtZQqVcouXrxoPXr0sCpVqlyS8Nb19OnTu99VLz2m7RkyZIiSMNf9vN9F22OSNm2Y/V/lGASZ8PCwQO8CYsGxCV4cm+DG8QEAAAAAILgEbRJdsmbNGuW6FhE9d+6cW2D0yJEjUbbpuleiJXfu3DFu1+O0TVTW5YYbbvD9Ltoek/PnLyTgq0JCiojg2AQrjk3w4tgEN44PAAAAAADBJWhroq9YscKqVq3qSrd4tmzZ4hLrWgj0p59+cnXTRT/XrVtn5cqVc9f1c+3atb7HaSFRXXS7kuhaZNR/u37XbdHrqAMAAAAAAAAAQlvQJtErVKjgyq307dvXdu3aZcuXL7cRI0ZYu3btrH79+nbixAkbOnSo7dixw/1Usr1BgwbusS1btrSFCxfanDlzbOvWrfbCCy9YrVq1LH/+/L7tWqRU5WJ0GT16tLVq1SrArxgAAAAAAAAAEGyCtpxL5syZbcqUKTZs2DBr2rSpZcqUyVq0aOGS6KqRPnHiROvfv799+OGHVqJECZs0aZJlzJjRl4AfNGiQjRs3zv766y+rXr26DR482Pfcbdu2taNHj1qXLl0sLCzMmjVrZq1btw7gqwUAAAAAAAAABKOgTaJLsWLFbNq0aTFuK1u2rM2fPz/WxzZp0sRdYqLEea9evdwFAAAAAAAAAIBkV84FAAAAAAAAAIBAI4kOAAAAAAAAAEAsSKIDAAAAAAAAABALkugAAAAAAMDat29vL774ou/6tm3brGXLlm5Nsvvuu89WrVoV0P0DACBQSKIDAAAAABDilixZYsuXL/ddP3nypLVp08aKFi1qixYtsjvvvNO6dOliR48eDeh+AgAQCCTRAQAAAAAIYcePH7cRI0ZYmTJlfLfNnz/fMmbMaAMGDLACBQpYt27d3M9NmzYFdF8BAAiENAH5qwAAAAAAICgMHz7cGjVqZH/88Yfvth9++MHq1q1rYWFhvtvmzp0boD0EACCwSKIDAAAgaOWc0MqSixwW3A53nhHoXQAQhL7//nv78ccfXckWjTr37Nmzx9VCf+mll+yrr76yfPnyWc+ePa1ixYoB3V8AAAKBJDoAAAAAACHo3Llz1r9/f+vXr5+lT58+yrbTp0/bpEmTrFWrVvb222+7mult27a1Tz/91PLkyRPj86VNG2apUiXRziPOwsP//2wCBBeOTXDj+ASv8AAcG5LoAAAAAACEoPHjx1vp0qWtZs2al2xTGZdSpUq5Wuhy00032XfffWcLFy60jh07xvh8589fSPR9RvxFRHBcghXHJrhxfIJXRACODUl0AAAAAABCkEaXHzlyxCpUqOCuR0REuJ+fffaZS64XLlw4yv0LFixoBw4cCMi+AgAQSCTRAQAAAAAIQe+++679888/vuujRo1yP7t3724fffSRrVmzJsr9d+3aZQ0bNkzy/QQAINBIogMAAAAAEIK0WKi/TJkyuZ8FChSwFi1a2MyZM+3111+3+++/3xYsWOAWG23UqFGA9hYAgMBJHcC/DQAAAAAAgjTBPnnyZPv666/d6HP91EKjuXPnDvSuAQCQ5BiJDgAAAAAA7JVXXolyvWLFijZv3ryA7Q8AAMGCkegAAAAAAAAAAMSCJDoAAAAAAAAAALEgiQ4AAAAAAAAAQCxIogMAAAAAAAAAEAsWFgUAACHv0be+DfQupBgzO94e6F0AAAAAgATFSHQAAAAAAAAAAGJBEh0AAAAAAAAAgFiQRAcAAAAAAAAAIBYk0QEAAAAAAAAAiEXIJtHPnTtnvXv3tkqVKlmNGjVs6tSpgd4lAABCGrEZAAAAABCM0liIGjFihG3atMmmT59u+/fvt549e1revHmtfv36gd41AABCErEZAAAAABCMQjKJfvr0aZszZ469/fbbdvPNN7vL9u3bbdasWZyoAwAQAMRmAAAAAECwCslyLlu3brV//vnHKlSo4LutYsWKtmHDBrt48WJA9w0AgFBEbAYAAAAABKuQTKIfPnzYrrvuOgsPD/fdliNHDleL9fjx4wHdNwAAQhGxGQAAAAAQrFJFRkZGWohZsGCBvfbaa/b111/7btuzZ4/Vq1fPli9fbtdff31A9w8AgFBDbAYAAAAABKuQHImeLl06i4iIiHKbdz19+vQB2isAAEIXsRkAAAAAEKxCMomeO3duO3bsmKu96j+NXCfpWbJkCei+AQAQiojNAAAAAIBgFZJJ9FKlSlmaNGls/fr1vtvWrl1rZcqUsdSpQ/ItAQAgoIjNAAAAAIBgFZJnpRkyZLDGjRvbgAEDbOPGjbZs2TKbOnWqtWrVKtC7BgBASCI2AwAAAACCVUguLCpnzpxxJ+qff/65Zc6c2dq2bWutW7cO9G4lWxcvXrTPPvvMTp06ZQ8++GCgdwcAgsbu3bvthx9+sIceeijQuxL0iM0Jj/gMAJciNiOQiM0AkDzjc8gm0ZGwDh48aLVq1bJMmTLZmjVrmHqfwl24cMFSpUrFcQb+hULszJkzbfTo0a4xEB4eHuhdQoghPocOYjMQN8RmBBqxOXQQm4GUFZ/5JCPODh06ZO+884598skn7p/b3549e+zGG290QeLnn38O2D4iaYSFhdEQSET6HOmC5EELYU6ePNmdEPmPMDp//rxrNKum9/XXX2/r1q0L6H4i5SI+Q4jNiYvYnLwQmxFoxGYIsTlxEZuTn3+SeXzm04xYHThwwGbMmGFNmjSxTZs22Zw5c+yVV16xESNG2NatW30fAO++uXPntuLFi9tXX30V4D3H1VJDT8c2pokqf/31l33zzTeuxMJ7771H0EqkxpYuSB50rFatWmV//PGH7zY1ltOmTet+T58+vRUsWNCWL18ewL1ESkJ8Dk3E5sAiNicvxGYkNWJzaCI2BxaxOfkJS+bxOU2gdwDB4/Tp0y6I64tevT779++38uXLu0vhwoXt8OHDVrZsWduyZYtNnz7dNQrSpPnfv5Bq16onSTXdaAgkf+oB9I6tegS9L7QVK1bYu+++a0eOHLFbbrnFqlatStCKIwUKNZ7GjRvna0D5v3dqeOl9//PPP12NxNWrV1uJEiXs/vvvt3z58gVwzxETHS/1mHvHUb3p/lTj8tVXX3Wjj2666SbXiFa9b+BKEJ8hxOaER2xOWYjNSErEZgixOeERm1OeyBQUn0miw5k3b54NHjzYsmXL5nrEM2TIYE8//bQ99dRTvvuoN0jTKq677jrbvn27LViwwBo3buy2KXBou3rU1aN04sQJy5IlSwBfEeL6RRZTMFejb+rUqa5RV7RoUVezT408/a4vs3Pnzlnfvn1j7HFHzI4fP+4aBL///rubvhmdGgIbN250iyqK7jN//nzXKH/77bcDsMehbd++fe7/+4YbbnCfk+jTMHW8vM+OGswnT550x+nZZ591tdu+/vpr+/7772348OGuMa3vV4060v9B1qxZA/SqkBwRn0MLsTlpEZuTF2IzggWxObQQm5MWsTn52RdC8ZlyLiHC+9LWF9Ebb7xhbdq0sf79+9uXX37pbq9bt659/vnn7vr48eOtcuXKtm3bNrfN6/1ToNfiJ2os3HrrrTZ37lxX6010X/W0qyGgRoQWAUDw/Q/oWHr/C/5fZOrF9eg+H3zwgavPp4ZglSpVXC/6a6+9Znny5LFSpUr57qvnwOXrs3nvd7FixVxQ+c9//uOCwaBBg9z0Tq8OonpftYhGrly5XMN87NixrvddDQjvs4ikWxH8xRdfdA1i8XrN/f3666/2448/2mOPPWZ33323HT161KZNm2a//PKL2z5lyhTXiL799tvd96WO97XXXuuOP+CP+BzaiM1Ji9icfBGbkZSIzaGN2Jy0iM3J2+4Qi88k0UOEvrTXr19vXbt2dUG6YsWKrgdcPeb6wtE/aM6cOd19FSD0paUpZgoSuu6tKl2oUCF3W82aNd19vQ+KvsjUC1uhQgX32G+//Tagrxf/+/LSJXrw18+zZ8+628eMGeOO2eOPP24ffvihu9+xY8dc8B85cqQbLaFt99xzj7355pvu2GuhB/UW/ve//3X3p1f9f/Re+9e58+qzeQ0mjUK5+eab3SgU9ayqUf7bb7/Zk08+aWvWrLGMGTO67WqA6bP3/vvvu9519dRq9AoSn/e/rAaZGr3eYif6rlTvun+jWcewZ8+e7gRI36EabaJphN99953vMTqmHo1SKleunJvaCfgjPocWYnPSIjYnf8RmBAKxObQQm5MWsTlliAzR+EwSPURERERYv379XK+5pk107tzZXnrpJXvuuefs77//dhf/D4ICvn73evu83iR9OFT/TcFEX1qqP6V/bP2TqzcpXbp07gtN02sQGN4x1BQaXRSMdPzVUFOveI0aNezRRx91dcY0RUZBXjXaXn75ZXefvXv3Wvbs2W327NmuIaCRFWoo3HfffW5qjeqMaVTFhg0bYu1pDMXaXnqv/af4qT6iPmfqlVXPqzfdUw1yNaZUB0x1v+666y53XBRk9H7rM6QRL5qO1rFjR/f+67m8hYhw5fQ50GiRL774wl2PvriP13DT/3eBAgVcLTY1yvS/37BhQ3fipFFHcuedd7oahzqmpUuXdo/V6BP1lqsBp0bBTz/95Hvua665xn2ver3tgIf4HBqIzUmH2Jy8EJsRjIjNoYHYnHSIzckP8TlmJNFT0JdSixYtovzj+VNvt/5p1RDwFrsQrRTdq1cv94/vT9PP1AOoLyT/D4j+uXVf3a5pFppuoSlsquWmRoL2Qx8K1XVTUEHC2bNnj/sS0pQm/2lmsX2Z7dq1yy1gs2zZMmvbtq0NGzbM9Q6qFzBHjhzuZ6VKlaxatWrWvn17d5tGQegLS8/56aefulETEydOtCVLlrjAtHnzZitZsqSbeug19qLXu0op9GXuz3u//Rs/eq+9169ecTW2Vcdr586dNmfOHPc+aeTBCy+84I6bRiMo2D/wwAPuMWoUaNSCauWpBpgClWrmaVSDGgaa0qSFaPS+6zOFq6P3Ww1bBWu95zHVNfzoo4/cKKG8efO6Y6tpZs2bN3eLnKiu5euvv+7+9/XZUf09//8THS8dK51Y6ftRU9a8kyxvRJMa4Fp4CqGD+JyyEZuTFrE55SE2IxCIzSkbsTlpEZtTJuJzzFLmpzgEeQFA/3gx0T+96nLpn3j58uWufpu+fPSlpSATne6rqWVbt251170VpzVVQx8Q1T3SP7jqw6l3ffTo0e6LT/uhqW36wlRNKlw9BaFFixa53jvV0tOx9J9mFv3LTI1BBXfV7duxY4dbHV5Tz7RytQJL7dq17YknnnCrHnuBTVMSdR81NvTlpobgHXfcYe3atXOPURDUFDb17Gqajf439KWmfUlJ9d3Ua62RBOrlViNKok/ri9740YgU9biq0aTPhD5b9957r3s/1Tjo0aOHG32i4KP6bhpt4o1SEX2e9HnTZ0oBQrUSn3nmGdeg1mdz6dKl7nYttoG40fSx6tWru6l/0Uc+KEDrpEgBWaMYFOB1fDxbtmxx03b1/69jrceqdpuO0cCBA12PuBoTRYoUcQ1nNbC9/xFNT9PvmzZtcr3v+izps6jvXDWovc8uxzK0EJ9TJmJz0iE2pwzEZgQTYnPKRGxOOsTmlIP4HD8k0VOQVq1aueDr/bP50z+xpsioodChQwc3tUK9rJpq0bRpU9cjLt4Xu77wvRpuXq+4Ny1GUzD0pacPjFbKVS++tumDJQo+06dPt2bNmlH3KwEoEGvBDPXoKeCowaX3VV9eH3/8sTue3bt39y1Io8CuLyf18mmRDR0PfUEpEHkrG+sLSrd7QUkjLPTFqefQ72owqOGhv6veXU091FQar56fAlX9+vWjfIEmN9FHIoiChRrIXt01/8+E3lP1snbp0sVN6/T+3/UYBQiNLFGDuFOnTq4xpZ5XUb0vvdeauqmRKGqErV271vc3NV1No1103HRcFHw0RXDo0KGuIaH3WY0L9QRH7+UPdRqBoDpq3igTL9jr+0vvlxqv/rd7/7tqcOkxatCqwbZ48WK3Tf/PWtxJJzw6DhoBoSmaHj2vPkv6TtTf1mdKjTiNJhI1DLTdC/Sqj6i/p4a5FsNRjUSNtNBnme/G0EJ8TnmIzYmD2Jz8EZuRXBCbUx5ic+IgNqcMxOeEQRI9BdH0Ik2V8C/g769OnTqut2/UqFGu3pT+MfUlpqkVagh4q417X5JqCCgweDW8vH9c9SKpN0o9RqJ/btVK0rQl3ceriSQpqbc1KUSfaqYGlkYyKFAoECg46xjrfZ0xY4YLSpompus6ppMmTXKBR8dI98+cObN7Hm86lHoZRYFKAUsBTw1HfenpC0t/X1Nq1LhTA1E9xQpGeu6HH37Y1RkT9e6rYan9Sm70GjUtTAtVeKNFvNsVPFSfUFP0FPy9xTFWrlzpRhdoxIHeR60Grs+P915oBIkayFK+fHnLnz+/CxCi90jBwZvGp8aAgpemsYlGPWiKp3radRxUa0+97GqQaMqaemPVMPBq64U6NWDVyNX/pd5XTb30pnh5ox2yZMniGrde/TZ9FrzGgKbl6jOl59F3okYEvfXWW+7kJn369K7Rq8+P9x2oz5D/Ku9qvOn5Tp486UZN6LvQf/qtjr9Gr4g+m1pAZeHCha5HXZ8pfe50HPluDC3E5+SN2Jz4iM3JG7EZyRGxOXkjNic+YnPyR3xOeP+bZ4QUQf+g+mLXl4t6z2OiLyZNlfD30EMPuSCuD40+JPrAaPqNevf0pajpNOrR8/5xFTRUC05fXqL6b7rg6nlTnzz6wlJwVjA6c+aMa6zpi0+rTqt3Xb10999/v+sFVC02LXijUQxapEEBRo0KPZ964XUsFfxVI0xflPpC0vPqi09Tz7Rd/x9qcChg9e7d2y3sof8pfaGlpPdYPaQaDaJRH+oBV/BWw0tf0GpM6T1Sg1qNJ32uFPz1f6/3XhTMu3Xr5npRK1as6J5TC2mIPjdqHHgNLTUe1KuuqZt6PxW89HlRgFCDRM/14IMPugab6L0fNGhQQN+jYPPVV1+5916NM/Vii0Y2qIGq4xOd/uc19UwjTkQBXnSMNOJIx0afIQV/jUhRoNZ0XTV6dSy9kSI6ljqGGoWkmpaiqYIaZaLPixqAagSoUan/A9GUzyZNmvj2RY0Tfa68aXHeokUILcTn5I3YnPiIzckPsRnJHbE5eSM2Jz5ic/JEfE5cjERPYRSwNYUopukOmkajwv9ez573gVKvkHoSFSD8a7gpgChgaBqG/+2asqGee02/QPzFtNCGR8dCizE88sgjLthoKpNW9VZvrr7wtCq1egC9nl41BLwvOvUS69gouGiqjAKb/2I5arj5L8ygLzkFQPXyiUZBaHqO95z6slJvYkpqCHhatmzp3it9iWuKkOj90nuj90GLXHi9pHof9P+uhYQUBN555x0XlBRE1JDS6AQ1LhRY1GDTF70+NwoWWqRGdAz1eVFjWw0P9biqN1h/R8e0T58+rtEAc1PFFPj9/3f1njZo0MDVRlOjV++hRgHpMxHb1C41qrTt3Xffdcfr7rvvdu+3RiyosaaGnhpnajQ89dRTbiEbNbC1yJM3/U///zq248aNcw1C1dnT50sNbu9vqDGpaZwe7ZMeF1tDP9gaAUg6xOfgRmwOPGJz8CI2I6UiNgc3YnPgEZuDG/E56ZFET2H0Ra7aVN6qtv4fEn2YtOiDVpvWF5eCkXqX1IOqOkf6ghTvH1Vfjlr8QV9USDj+C22ol9V/Cpp6ePVlo+CjAKLaXtqu0Q7qkdM0QB1TNeLUUFNvu3+jToFbU23UGFCQ0kgIj6bPqBfRm4qlxoBGUujL0WvoaTSFenxTOr0X+v/Wa1fjWAFB9B7ri14NKzWONTJFx0sNAQX6N954w71/+kyod1WrsotGJOjYePXFFEzUI+tN51QPumq/qVGtoK96X1p5vFGjRm7qVCiKHsB1gqLpkHqf1EAaPHiwawSrN1vH6dlnn3UNAAVZvYd6b/V/H1tgVUDWe6spfWpk67nUa75gwQK3krtu8xZPqVevnmtkqyGg6YQa6SDqMdfnRA1EnWBpKqKCv0ZAeDTNTNMIgX9DfA5uxObAIzYHHrEZoYbYHNyIzYFHbA4OxOfgQTmXFEb/wOoVUn0q1SPyPiQKKCr4//zzz7uFURTg1QurLzvdrtti6gHClfECvDfFTF96OhZqfClg6AtJvXxqEKhnTvW7dF99EWlxDG/aoLZ5oxnUI66AowaEVvlWL5+Cvb6YFMj1paj76gtOQU0NAy0OoZ55UZDXqslqKIgWS/H/QgslChIK1ppqpsCtOnl6n/SeqBGtY6H3y1v4QsdJU/40dUxTjtQQ0GO92oZaOEYNbPXIazqopqGpseb1kuvvaREbT6jXaNOCMPp+8j4X+p9VrbaqVau6RoDeL723jz/+uE2ePNmefPJJ1zjzah3qOGg0g6YPKljHRM+vKWMK9moM+NNnQ8fYawTqvo8++qgtWrTI9eRruptHx1aNEz3Gq5UYnfc6gMshPgcesTm4EZsDi9iMUERsDjxic3AjNgce8Tm4kERPYRQMFAj0IdEHRPWpdu7c6Va8VY+Ut3q0VpNWY0E9izQA4ufw4cP2ySefuC8Y9XRreou+oPynm/jXZ9OXnDd9T1Nf9IWm4KLaXhrVoIVp1HuuBTAUZBSY1FOrY6lApREP6rGtUaOGm06jgKNgo2OnBoXquClwqV6VGoGq9yb6svRWQtbf1JeY6lbhfzTFSfXv2rZt64KQAoCmLem9VIBRo1rvqT4n6k1X40EBQsdKveo6Rurp1aIpOjaaxuTVA1ODYMyYMYF+iUFDDVhNJVNPtqZUKkBr+qx6sfW/qZ5xfa50Xe+dAqvqpM2ePduNDNF9xPt8qZdcDWc11GJrCOgzqGlrWkTIa0CInlufBS3gpBEmmn7oPYca5RMmTHDH3LuvtyiQJ/pn3X+/gMshPicuYnPKQGxOOsRmgNic2IjNKQOxOWkRn4MbSfQUSNM61COlmlWaoqQvKPUUqqdKVNNKPauIGwVT1T/Tl7+Cg+qjaWrMXXfd5Vt0wfuS8e6vFYa16rp6ZPWlpy8YLdagLzcFCY1mUODRRfWl9AWpxoBqq6kxoC8i1QZTgFKQee2111yvnlaHV70w9YorMGlamhYy0ReRphX6TzPT9ERNe0LMtIK3PidqDCgAKeho+pgCv6YYqUGtERBqYOk4KZhpmpQClT5Xeq8V1PTeq+GmY5XcA0Jiee+999x0WAVwBVZNvdS0PDWm9X+sBq6CvU5cRP/7uq5RCx4FZa+Rrc+SPgsK5BpREhs1mhX0NfJEPeI6nt7z6ARIn2v/hoBGqei4q5Eg3vH07y33/6wD8UV8TjjE5pSJ2Jx0iM3A/xCbEw6xOWUiNict4nNwS3mvCG7hhalTp7qeVk2zUBDxeqMQP0OGDHGLIqhHT1P31OPnLc7gH/zVSNBFgUWBYsqUKS7AtGnTxj1etbxmzZrlesa1irWez6PgrVpheh715mpamqYt6ctQwemee+5xKxzreOqLSr3A6sFVralJkya5RVR0X305aiqUh8B0eeoxV2NKgUA1DfUeKzBoKpQay5oWpaCg29Ww0mdKi6Po/o899pjrkff/XPF+x0z12rTSt6aXqQaaqHahplmqZ1puu+0219jWat8K0ArMem/1mdDIEX2OdDLjBWV9DjSSRSvFa4SQ1yiPTvfTVDLVrvQaAl5jQquT6/tRnyNNI9VxXbt2rWtcaNqnP44tEgrxOWEQm1MuYnPSIDYD/x+xOWEQm1MuYnPSIT4HP5LoKZB6kBQwcPX0ZaEAr15U9Y6r/pcCiBoD+kIaPny4m96n61pZWr3jmrKmoO7VhlJvnnrQNe1GvYOaouatEi7qZVcvrr7U9DyqIabGnOq76W/qS8rr3VNPpH8A0vQ2RkZcGfWCK7isX7/eNbh0rFWfTe+3Gn1aFEMNBr3HOj4KKFqpGvGjWoaa5qfGqj//uoIKvBoZovdYK4urd12NMT1ODV5Nq+3Vq5e7n0aY6DOghrU+i2oI6/MZE9XW06I/27Ztu6Qn3Jsq6vWua0SEpog+88wzKT7wI3CIzwmD2JxyEZuTBrEZ+P+IzQmD2JxyEZuTDvE5+JFEBy5Dvd/+wUMBYuXKlW6akr4sND1Mvax33nmnq9umWl9NmjRx05rU063paVrxXV+GCvbqRdSXmRZl0PQbfdmp51BT19Sb2LVrV/elplpUmoqmoKTnUw+66MsQCUfBSDUPNcVQIxvUo65jpR5W8RaXwZVTbTU1phToNS1WPd9ZsmRxnyfVyVMDWQ0ufWbUgNZ9NaJB1BD48ssv3agUfe403daj3nF9xjRNNLaGgGiF+LjQCuP6HMdWJw5A8CA2p2zE5sRHbAaQ0IjNKRuxOWkQn4MfSXQgjjRFTNNoVJPKo6li+hJTz57Xe6eAv3jxYne/IkWKuOkwgwYNsjVr1rgVqsuXL+8CkNdjKLpN91NjQAFfC6foC0496LGtaoyrpy/+0aNHu6lP6mn1FpdBwlHA17RLNZq1oInqTKohrV5sBXyNWFF9NzUAVLdQoxhEx0QNBk0502fJaxx4I0r0mduzZ4/t2LHD9/mLjUZJ+C9a5M/rOfef0gkg+SA2pzzE5sRHbAaQmIjNKQ+xOWkQn4Nf6kDvAJBc6AtIU2bUw6cVxkW94+oFVD0wj6bP6AtPUwP1Jaf6YOpB1LQYBXj1Lmr6mnrYPZoSpd5bb3qM/o6+AGkIJC4trKE6fApWSDyqjacecU0v00IpixYtstdff91Nv9TCNBp1orpqWjBFtdX8A74WNtE0NU3f9Kg+mxoGOnaavvlvYmsEAEj+iM0pD7E5aRCbASQWYnPKQ2xOOsTn4MZIdCAeVHtNveD6ctIUNfXEaZrNd9995wK/aIVwLfqgqTbqDdSXnOqHqXdQK4j36NHDTTPTIhAeTW/TBUip1NDVCBSPGssa0XDfffe5WodaxEk1DDW9s1GjRu7zpc+OGt79+vWLsmCJRrFEfz4AoYvYDFwZYjOAxEJsBq4c8Tl4pYrUuwkgTrQQg1YB17SacePGudu++OILV7NKdcHUM6v6bppa9ssvv7jGwt9//23t2rVzNaz05aY6bkAo0UI/b775plv8x39REo0sUX09faZUW0919fR5UgNA28qUKeN6yzVtEwBiQ2wG4o/YDCAxEZuBK0N8Dm4k0YF4UH0oTa3RtBotfuL1oFevXt31lnu9e2oQfPrpp24qjHoJtZo1EKpOnTpljRs3dqNImjdv7qaXqR6bPkeattmzZ083dVO95P9Whw0AoiM2A/FHbAaQmIjNwJUhPgc3yrkA8aAvJ/WIa4rZxo0brWzZspY9e3a3oIPqtnm0UIq++ACYq1E4bNgwV4dNI1HUa3769Gm3qnerVq0uqa2nz5lqt+mixoHXQACAmBCbgfgjNgNITMRm4MoQn4MbI9GBONJHRdPMtAqyVkzWVJomTZoEereAZGXDhg1uWlrhwoUDvSsAUgBiM3D1iM0AEhKxGUgYxOfgQxIdiCdNl1GjwFugQb8D+HfRPy/+nyUAuBrEZuDKEJsBJBZiM3DliM/BiSQ6ACBJ0YgGACC4EJsBAAg+xOfgQhIdAAAAAAAAAIBYMA8AAAAAAAAAAIBYkEQHAAAAAAAAACAWJNEBAAAAAAAAAIgFSXQAAAAAAAAAAGJBEh0AAAAAAAAAgFiQRAcAAAAAAAAAIBYk0QEAAAAAAAAAiAVJdAAAAAAAAAAAYkESHQAAAAAAAACAWJBEBwAAAAAAAAAgFiTRAQAAAAAAAACwmP0/4mUw4xVmnNMAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABdEAAAGGCAYAAACUkchWAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAl45JREFUeJzt3QmcjeX7x/GLYawha7bsa9myFspWIUW2aJEQZWuzZMlOWZNQZClRSpZCqbSIikRIlp+tsocSZRnb//W9f7/n/M+MmZphZs6ZOZ/363VeM+c855x5znnmnOt+rvu+rzvFpUuXLhkAAAAAAAAAALhMystvAgAAAAAAAAAAQhIdAAAAAAAAAIAYkEQHAAAAAAAAACAGJNEBAAAAAAAAAIgBSXQAAAAAAAAAAGJAEh0AAAAAAAAAgBiQRAcAAAAAAAAAIAYk0QEAAAAAAAAAiAFJdAAAAACxcvHixUDvQpLFewcAQODjIvEYV4okOhBgzz77rJUoUeIfL3Xq1InVcy1YsMDdv0yZMpc9f/v27X236fl029SpUxPkNT300EPu+QcMGGBJmff+L1261Hfbzp07rW7dulayZEnbsGHDZY/Zt2+f73HRbQcABF/8TGrWrFnje41HjhyJFHvUFkgI27Ztc/H9wIED8fJ8q1evthtvvNHtc/Pmze3UqVOWXF26dMnee+89e+aZZwK9KwCQoOd/3kXnSvqOr1GjhvXr18/+/PPPePtbv//+u3Xr1s0qVKhg5cqVi3Sei9iZM2eOO07ff/99QNpTsW1TnD592iZOnGh33XWXO9Zly5a1Bg0a2Lhx4+zvv/+O89/VY8aOHWvTpk3zxef69eu7dsiFCxeu+PUgdJBEBwIsc+bMlitXLnfJkSOH7/Zrr7022tv/Sbp06dz9r7vuugTc49BWtGhRmzdvnlWrVs1ee+21QO8OAISs+IyfSV2KFCmi/T2+bN++3Zo2bWrfffddvDzf3r17bejQoVarVi1788037fjx4/bCCy9YcjV69GiXRDp69GigdwUAElT69Old/M2ePbuLR+roVSdihw4dXMIyPsyaNcs++eQT1/mq89/w8PB4ed5QoU6IF1980UqVKmWVKlVK9PZUXNoUjz/+uL388stuIFtYWJilSpXKdu/ebVOmTLF27drFOfH98MMPu4GEZ8+eddf1P/rAAw/Yjz/+6NojwL9J9a/3AJCg+vTp4y6iRoZ66+Wll16yqlWrxum51CurCxJW1qxZ7fXXXw/0bgBASIvP+JnU6eQ2derUdu7cOXeyG980Eiw+R2jlz58/0iyv5cuXW3L2119/BXoXACBR3H333TZkyBD3e0REhOtEVNJ706ZN9sMPP9hNN9101X/j8OHD7qee6+23377q5ws1ShafPHnSWrRoEZD2VGzbFBol/+2337rflfi+7bbb3O/qlFHHtGZ9r1ixIk6j5KOLx02aNLGRI0e6AXL3338/nTL4R4xEB5IIBZvhw4db7dq13dS4ypUrW9u2bW3jxo3/WM4ltg4ePGhPPfWU643WVKlWrVrZqlWr/vVxmzdvtgcffNBNrVIA0yjtf5t27tHUO92mKWQx8aaXjRkzxmbMmOGCZ/ny5e3pp592QfDdd991f1f7rClhv/zyy2U93d27d3cjx7WP9957r82fP/+yv7NkyRLXAaH3Tj3jauTFFMzVW63n0jHQVMKff/75X9+nK30cAODq617q5EuluBQ/9XPChAku4Rx1Gvrs2bPdNF/FjIoVK7pEgJIAr7zyijup1NTxzp07u1FcUUukvf/++/bcc8+5OKqTTo209kY6yW+//eZO+hTHFWv0fCrvsX///n/c//Pnz7sRY7q/Yp3+vp7Ln074tA/i/RTF5IYNG7rXfeutt9qwYcMinUBqdJfurzj55ZdfWuPGjd2+KQmiE1Mvht93332+x+j98+K299rVsazH6v3R+ydff/21OxlVzNNz1qtXz02/9n/fo5aX89oLev/27Nnj2gl6zdr3qLO/VBpA7/fNN9/snl8nwYrl/ry2h0a7PfHEE679oOeaO3eunThxwr0OJWF0vHUC7X9SH5vn9/ZfIyLVTrnlllvc31CM90ad62+888477nfth+6v1wkAyZ1ik3/80PlmXONT165dXYlQxQKdqykWemXL1q9fH6mM2ZkzZ2z8+PF2xx13+J5XcVyznTz+cUbnkVWqVHHPqSS/952+bNky9zfVDlB8UDkRtQWef/559zjdrqSzfxmyY8eOudv0N/W3dT+Notao6ajntYo32uc777zTxRcls/X3/em96tGjh/v7eu0qZxJ1pPSVnL9rNoBikkZg33777fHentIx1MwyxXyd9youPvbYY658y7+1KaLyb+v4j4RX6RW1hTQS/Zprron1+6Hjq7aF6Jh67SU9h95nxe2ocR6IipHoQBLRv39/96WeMmVKy5Ilizu5U8/sTz/95IJDmjRprvi5//jjD2vdurULPBrJpmlxSiI/+uij9uqrr/p6faP69ddfXeLBa0CogaL91OPjmxoaSlpoiqA6FDSCbevWra5hosCnRpNOTnv16uU7WVXvdJs2bVwSQ9O/9B5t2bLF+vbt66aE9e7d293vww8/9NUp9aaIPfLII9EmwtVxoYZChgwZ3E+dOK9du9YlT2Ia/XeljwMAXD2dQGukmk4YNWVZ9TcnTZrkOjKV1PU3efJkF8sULxTbVDNUsdaLNbrts88+s7Rp01722FGjRrkTMH3Pa4SXEvI6AVQiQHTCp+nCikfaD8U0xXXdppim+BsdJRa8kXaKr0p2f/PNN5fdL2oHsZLOSuyK2g06wdcJuNoN2jfth0f7oNHgen4lCv7zn//Yk08+aZ9//rlLgmgGltdxoBNZ7b8//R09n06wb7jhBvf4Tp06+eKeXptKuGj6dcaMGa1jx47/eMwUt9VBr/db+6NRh/obqrFbs2ZNd5viqmK64raeU20CxXKdwOvE2Z9ei+qgKkmu5xo0aJDNnDnT1ZLX61M7SB31BQoUcI+N6/MrIaI2lP5v1EZRjNdr1v+I3iu1XfRadJveS0a5AQgF+i7Vd63/LKS4xifFPHUm63v4+uuvdzFa38P6rtV3qUqOeLFL533eADPdX9/3iuPq1NX5of6WR88xcOBA37mZSpv4txvU0arzbt1PcVxxWu0G/S3FE52bqmSNdw7ZpUsXd/6smJEpUyYXVxRD9ZiPPvoo0vuiGKGYo33UfiuBrs7sTz/91MUJxVslmrX/aruo/aFzV7UHtF/6W1d6/q54r/dbJUpz5swZ7+0pDRZQJ4Tuo2Oj/f3iiy/cvun22LQpPOqY92bZKXGuDg8l5dXpoffLv3xdbN4P/S29p/p/0nHX++9REn3lypXumGlAHRATRqIDSYACh3qNCxYs6BoAOqFX8lUUmHbt2nVVz68RZAo4CkzqHVZyV73vOhn2RpTF9DidFCqwf/DBB240gIKrGjXxTQ2mt956y9atW+d6+EVJDe2nktRKTniJcyXURSfJOhFXAFZHgx6rE2lRw0UNNS9pIupRVyNLz6cRDFHpvdCxUDDWfZS012g9Be1/qo9+pY8DAFwdndhp1LFOqHTCqxinZLFO7HRCrCSpP8UMdazqe7p48eLuNq/2pr6/NdpaohtJrMcuXrzYxUKd3Hknyhp9pZNFnbiKEueK49qmUdoaMRVTrWzdrpFy0rJlSxfHFM+USPgnOunXia1o37W/elzhwoXd/ukk0Z9OhDXqWs+vUe+i+K7XrBiqkfgevZ/etG+PEhNecl8jvTQrTCPQGjVq5NoUeh6v3FxMM738qR1RvXp1t98ff/yxS0KLNzpebSAdO70enfTqft5odo1C9B8VJ3ny5HH75iW31aZS+0nPrWOh9pX/cY3r8+vY67n0f+NNK/f2Ve+VYr7ovfzqq6/cTwBIjhQHda6m73DN9FHpDfFmBcc1Pun7Vgl3xZERI0a4c2EtBCk6d9V3quKLkrtKoCtJq3NUxbNFixa5+KS2gEYe+1MiVSPA9byK+/4d2eoo92JatmzZ3G3qdNVr0f31d/1jhmK82hVFihRxiWLFFSVuvTZE1EVVNQNNMUX7qNHmonPxHTt2uN/V8aBkr/62N/DKS9YvXLjQJd6v9Pxd77GoUzoh2lM6HqJzXL0PiqH6f9BFryk2bQpP7ty5XW5Bf1Od4Ho+vTbNLNf/gOKuJzbvh/53vI4cDZjz9lW8UenxtfYLki9GogNJgDeaSTQFSQ0C/xP4K1mZ2t/q1avdTyWVvZNcBRyvHIoaBuoxjkoJa9FJshd41GuuwOg/XS8+6Pm9GnqanqWgpxFf3mgw/xNSvR8qG6NRY6LEubf/mk6mhIQSBurt16gzr8GiaePeCAVNHfQ6KrwTeu/1qgGlTgPxEvbeexjVlT4OAHD19B2rhKlimr7/Pd6UcZ2QlS5d2ne7Snd4CVV1rGpEta5rAUwv1ig2RFdTU1OtvcS7RlrrBFIxQCfJilV58+Z1J846cdOIKCXQlZDVSLaYaHSaV2JEsUyj8xTPNAtMM79iokS116Gtk0iPEsfe6/afxq3OcI3gEv9O5Ni2L/T+6ETao+fWRe+TTki1P15Mju1z6n1SMkQdBhohqPfRe6xXI1VtDZVZ8acOanVc+Je2u+eee9yoM100+0vJEE01z5cvn9uu/wElCPz/L+Ly/Go7eSfmSqIrCXS1bTMASIrUAauLRnHrXE2xT9+3Gj19JfFJz+Gdn3oJ7ejovE5UIkaxXBQ7VFZMA6a0PWrc9DrGoz6v/r4XmzViWyO3FbM108o7F1Vs82KG4rLOf9XWULtB55pKwnsUD/xHW+u81hsprpIu3qh8L25454d6LV6nuWZHaX+9GcxXev7ulUj5p/fyatpTXrzu2bOnr62jgW36P7gSGhWuDhgl7vWeKlmvdpFitsq0qbNCbZArfT883vFWh4f+f73OeyAqkuhAEqGTdp1sK/mrqUequenxAsSV8urEKXBHd9KnXuPogo6mq0vU1boV3GOTRI/LImX+0++8adA6Yfem+/mXs9H7ocaOxztJFk37UhDX+6j7+CdC/Ke0XXfddZH+vhp23vusE+ioDh06FO1+X+njAABXz4tvXhmPf/sO9o813qg0/xNNL9ZEF3f9Y6FXtkNJc8UBxSol1VX2w5tWrouSDBpNpfqh0ZVl8+Ks7ue/H1FjVEyvW2Lzuv0T4JqK7k2fjm37Imo7QCermiavZLLee40w9N5PnYTHhv8+eWXivMd6r0+JmOhmv+k1+ye543pc4/r8/7SvABBKNKDKW1g0PuKTYql/eZeYeDO6/M/7/K/7nxt6YipnciVtAc1yVpz3RqX7r08SNZb6xwyNeo96P2/ketTzX/8SoFd7/h7XJHFs21OazaY2jUrfaeCfLqKZCeos+KdEdnR0rq64qgFuuui6kumalaBjqvI/SqJf6fvh8X8/9B6RREdMSKIDSYBXv1snZJr2pulQmoJ2JQuIxnTyq95cLc7h1QnXNDElnGOq0eoFdtVFjxpIo17Xyb9Hzxs1iMeG/3N4/qlB5T+yTyPOvAaU3kNvETe9btWs0+vU7f6NtqgNODWc9PfUcNAx8EYl6uRajR//mmzx8TgAwNXzkrs6YfWf+aMTLI1KvtpY489/gVDFaK/j1DsJ1jRvzSpTvNF0cI3UUq1WTSPX6C2V/IrKe6xOrDV6zDvh/7cOWP+ktqZue681ptcd9TVGjU3/Fqv8kwCiRVU1BV11S0ePHu1OXDWd2pv5FRv/9L57r08j+LSomSjO6n2PrjMiuueKz+dXx8M/vVfEegC4svgU23W/9Lyasa3zPn9ajyPq3/23545rzNAMaXWSK9mrUegaqa4yLt6I6H96rujig2K/yqL5L6ypc2iVctHIeOUArvT83VuI03/h8/hsTynRrzaAktyadaC2jkrtaACB4qlGpcc2JqrMi0agaxagyr6IBhNqFrxK5KmEi9c5Etv3I6a/7T+wzr/zAoiKmuhAEqCTTm9Ek0af6cvff3Xuqx2JrmlWXg07JcVFJ7sKWA8//HCMo6m8enBaLMWrg6aEQNRR6EpUR63DpvtralVCUdJcjQzRCH6NCtDr0JQvjULXe6gp6+pl9jojNIJASQ+NvnvppZcuO0H2SsaoTp0CrRofmm6uMjNeDdmorvRxAICrV7FiRZcY13e74pNs3rzZxT11SHt1yuODYqGeW9544w3fotv6WzqR1HRk/a7YV7t2bTe13Ssd4y2wFZVmnXmzr7SwmeKTRtvpxPGfaMq5d1KraexeB7KmVmuau+qYxoX/Cb/imJLJ/qKelGo6u2gfdDKqpL+S6vHRZvFvt6juuEreiEajKd6q/vjVrs0S38/vJdm9k/So7x8AhIq4xqfYJly98ijqmPZKcqmMmLcwd3TrXcVXB6cX89Te0Lm6YrX3d69kZpLaC6L66t7aZ1obTOVvlCRWcvhKz9+9sirRjSa/2vaUjqM6z3Vflc/RIqAq/aJa+P5tnX9rU3g0el3UhtIof+9+Kqmm90a8BWFj+374x2P/v+vNZNDxi23HDUITI9GBJEB1Wb2p1aoLpl5u/95Sr4bcldJK5vPmzXN1xNXAUA+195zq6Y2pgaGApN5hBUQt8KEGkXqjNVLOv+fcW/1bt6lnWIls9a5rtHh81073p4aG6pwr8CqgKyB6SY1OnTr5FlRRPTWNAFQNNQVrr7datev8F4LR/ZT8Vu+7Gje6n1czLaaRBlfzOADA1VGSulmzZi7GaXq5Oi4Vp5TIVZ1Rxdf4olipv+XFQi+GKgZqFHOhQoVcR/IDDzzgRnIpjiuuKzZ5C09GpTikOKZaqxrdpnU19Jh/q2WqOK64pk7kadOmuZNvPU4X7YdObONCC3Pq5Fnvm2qn16xZ0zdCOzrqJNYsOi36pQ53xTyvhNvVtllEdWHVMa2/oYXh/ON13bp1fSVVguX5vXrpGkCg5IJGLKpGMACEmviOT54HH3zQJVCVYFX9cI1Y9s6XFYdVCiSheAOmFPsVI7xzPY/ihxcHYkP7rzIoSnSrLroGpHmxU0l0vbYrPX9XDBK9T/HdntLfVDJbHRmqiT5s2DA3eExrgWmb8hhxaVNorRm1e9ShrVIwuo/ir3+5m8cff9z9Htv3QwPt1Okxa9Ys167Sc+v99d4PFv7Gv2EkOpAEKOiqoVGsWDHXe6qAoSSwFq8SrRx+NXQyr95yBWmdKCrYKcGsYKWTx5goMa6RWWrsKAmg51FQ9V8MxuttVgJAU9v0u3p9VSs1oRPIVatWdcFU07EVHPV3NWVeJ69PPfWU735KsGskhBaE0/6poTV9+vTL6uQpEaDGnn6qcaT76rVrxOE/rXB+pY8DAFw9xRt1ZmohaZ3IacqvFuZUh258ltlQslsn8XpOxWmd0D3//PNum1cTXQuOaj90cq37aPSWTuT8FzeNSvv+zDPPuCnSem6VBVN5sH+jE0t1Jiu2Kf4pvmuRTP29uNb6VDkWjZz3SqV508Fj0qtXL/e39Bq1zzppHz58uNumxLR/R/uVUCzV61AbRcdTI8OVfOnbt69bgPVqxffza2FTjbDU+64EgH/5FwAINfEZn/zLiul8ViOfFWd1Pqu4qXivRP2/xa2roRinhLGSyYr3+rvPPvusbyHSuJ6rK+Zq3RQlfxVHNfJc79Vzzz1n3bt3v6rzdz1P7ty53Qj3uI5Gj017atSoUa7NovNp7bdinhLrU6dO9ZU1jW2bQs+pxLn+pvZb1xWPNZpeCf358+f7Oidi+34oh6LnUhzWub43s0yD7kTr1AD/JMUlVr0BAAAArog6tDWFWSeNSpIDAAAEKw0eU+lSLQCq2eShTh0CGnynEf5atPSfasoDjEQHAAAAAAAAkrlWrVq5WdpaqBT/rT2vRLpmSJBAx78hiQ4AAAAAAAAkcyqnohrxa9ascWt1hDot1q7SL6rPDvwbyrkAAAAAABCiVLtYazgsWbLEjcRs3ry5Wz9INYiVZFMtZC3GpzrHgwcPjtdFmQEASCoYiQ4AAAAAQIjSooha/HD69Ok2duxYe/fdd93ChloEWWs9VKpUyRYsWGAVKlRwC/PpdgAAQg0j0QEAAAAACEHHjx+36tWr28yZM61KlSrutqlTp9qePXusYsWK9sorr9jy5cvdqHSlDu6880577LHHrGnTpoHedQAAEhUj0QEAAAAACEHr1q2zjBkz+hLootHnKu+yceNGl0hXAl3086abbrINGzYEcI8BAAgMkugAAAAAAISgvXv3Wt68eW3RokVWv359q1u3rk2aNMkuXrxoR44csZw5c0a6f7Zs2ezQoUMB218AAAIlVcD+chJy5MhJCzVZs2aw33//O9C7gRhwfIIXxyZ4heqxyZHjGkuOiM0INhyf4MWxCW6heHyCKTarvvkvv/xic+fOdaPPlTgfMGCApUuXzk6fPm3h4eGR7q/rWog0JsePn7L/DVwPGRkzprW//joT6N1ANDg2wY3jE7xC8dhkzpz+X+9DEh2XUaMnLCyl+0nF/ODD8QleHJvgxbFBUsf/cHDj+AQvjk1w4/gEXqpUqeyvv/5yC4pqRLocOHDA3n77bStQoMBlCXNdT5s2bYzPd+7cBQvF/2G9bv6HgwvHJrhxfIIXxyZmlHMBAAAAACAE5ciRw9KkSeNLoEuhQoXs4MGDlitXLjt69Gik++t61BIvAACEApLoAAAAAACEoHLlytnZs2dtz549vtt2797tkura9sMPP9il/w1F1M/169e72wEACDUk0QEAQKLRNPDBgwdb5cqV7ZZbbrFx48b5Ts63bNliLVq0cCfnzZo1s82bNwd6dwEASNYKFy5stWrVsj59+ti2bdts5cqVNnXqVGvdurVbaPTEiRM2fPhw27lzp/upOukNGjQI9G4DAJDoSKIDAIBEM2zYMPvmm29s+vTprv7qu+++a++8845b2Kxjx45WqVIlW7BggVWoUME6derkbgcAAAlnzJgxdv3117vEee/eve2BBx6whx56yDJmzGhTpkyxdevWWdOmTW3jxo0uwZ4+/b8vvgYAQHLDwqIAACBRHD9+3ObPn28zZ860smXLutvatWvnTsq1sJlqsvbq1ctSpEhh/fr1s6+++sqWLVvmTtwBAEDCuOaaa2zUqFHRblO8XrhwYaLvEwAAwYaR6AAAIFFoJJtGtVWpUsV3m0afP//88y6RXrFiRZdAF/286aabbMOGDQHcYwAAAAAASKIDAIBEsnfvXrdQ2aJFi1yd1bp169qkSZPs4sWLduTIEcuZM2ek+2fLls0OHToUsP0FAAAAAEAo5wIAABKF6pv/8ssvNnfuXDf6XInzAQMGWLp06dxCZeHh4ZHur+taiDQ6qVOH2f8GrYcE77WGh4fZ/9ZhRRDh+AQvjk1w4/gAAICkgiQ6AABIFKp7/tdff7kFRTUiXQ4cOGBvv/22FShQ4LKEua6nTZs22uc6d+6ChWKiKSLiAommIMTxCV4cm+DG8QEAAEkF5VwAAECiyJEjh1s81EugS6FChezgwYOWK1cuO3r0aKT763rUEi8AAAAAACQ2kugAACBRlCtXzs6ePWt79uzx3bZ7926XVNe2H374wS79byiifq5fv97dDgAAAABAIJFEBwAAiaJw4cJWq1Yt69Onj23bts1WrlxpU6dOtdatW7uFRk+cOGHDhw+3nTt3up+qk96gQYNA7zYAAAAAIMSRRAcAAIlmzJgxdv3117vEee/eve2BBx6whx56yDJmzGhTpkyxdevWWdOmTW3jxo0uwZ4+ffpA7zIAAAAAIMSxsCgA4KodH7HPgt0fljRk6ZvPkrNrrrnGRo0aFe22smXL2sKFCxN9nwAgOUoKsTmpxOfkHpsBAMC/YyQ6AAAAAAAAAAAxIIkOAAAAAAAAAEAMSKIDAAAAAAAAABADkugAAAAAAAAAAMSAJDoAAAAAAAAAADEgiQ4AAAAAAAAAQLAn0Tt27GjPPvus7/qWLVusRYsWVq5cOWvWrJlt3rw50v2XLFli9erVc9u7dOliv//+u2/bpUuXbMyYMVatWjWrUqWKjRo1yi5evOjb/scff1i3bt2sQoUKVqdOHXv//fcT6VUCAAAAAAAAAJKSoEiiL1261FasWOG7furUKZdUr1Spki1YsMAluzt16uRul02bNlm/fv2sa9eu9s4779iJEyesT58+vsfPnDnTJdknTpxoEyZMsMWLF7vbPLrvyZMn3WMff/xx69+/v3tOAAAAAAAAAACCKol+/PhxN1K8TJkyvts+/PBDS5MmjfXq1cuKFCniEuYZMmSwZcuWue2zZ8+2Bg0aWJMmTaxkyZLu8UrC7927122fNWuWde/e3SXhNRq9R48eNmfOHLft119/tS+++MKGDRtmxYsXd6Pd77nnHnvrrbcC9A4AAAAAAAAAAIJVwJPoI0eOtMaNG1vRokV9t23cuNEqVqxoKVKkcNf186abbrINGzb4titB7smdO7flyZPH3X748GE7ePCgVa5c2bddz7V//3777bff3H10/3z58kXa/sMPPyTSKwYAAAAAAAAAJBUBTaJ/++239v3331vnzp0j3X7kyBHLmTNnpNuyZctmhw4dcr8rGR7Tdj1W/Ldnz57d/fS2R/dYJd8BAAAAAAAAAPCXygLk7NmzNnDgQBswYIClTZs20rbTp09beHh4pNt0PSIiwv1+5syZGLdrm3fdf5to+789d3RSpw6z/w2KDwneaw0PD7NLlwK9N4iK4xO8ODaID/r/AQAAAAAAwSNgSXQt+nnjjTdazZo1L9umeuhRk9q67iXbY9qeLl26SAlz3c/7XbT93547OufOXbBQTARGRFwgERiEOD7Bi2OD+KD/HwAAAAAAEDwClkRfunSpHT161CpUqOCue4ntjz/+2Bo1auS2+dN1rwxLrly5ot2eI0cOt01UtsWre+6VePG2x/RYAAAAAAAAAACCoib6m2++aYsXL7ZFixa5S506ddxFv5crV84t9Hnpf0M59XP9+vXudtHPdevW+Z5LC4nqotuVJNcio/7b9btuUxK+fPnybpFRr766t123AwAAAAAAAAAQFCPR8+bNG+l6hgwZ3M8CBQq4hT7Hjh1rw4cPt1atWtncuXNdLfMGDRq4+7Ru3doeeughl/guU6aMu1+tWrUsf/78vu1jxoyx6667zl3Xc7Vr1879rvvUqFHDevbsaf369bMff/zRlixZYrNnz07kdwAAAAAAAAAAEOwClkT/JxkzZrQpU6a4hUffffddK1GihE2dOtXSp0/vtqsEzJAhQ2zChAn2559/WvXq1W3o0KG+x7dv396OHTtmXbt2tbCwMGvevLm1bdvWt33UqFEugd6yZUtXxmXEiBFWtmzZgLxWAAAAAAAAAEDwSnHJq5mCGB05ctJCbXHE7NmvsaNHT7I4YhDi+ASvUD42x0fsC/QuJBtZ+v53PY/4kiPHNZYcEZsRTDg+wSuUjw2xOf4Qm2OP+IxgwbEJbhyf4BWqxyZHLGJzwGqiAwAAAAAAAAAQ7EiiAwAAAAAAAAAQA5LoAAAAAAAAAADEgCQ6AAAAAAAh6tNPP7USJUpEunTv3t23rUGDBlahQgVr3bq1/fTTT4HeXQAAAiJVYP4sAAAAAAAItJ07d1rt2rVt6NChvtvSpEljO3bssGeeecaGDBliN910k73++uvWqVMnl1hPly5dQPcZAIDExkh0AAAAAABC1K5du6x48eKWI0cO3yVTpkz29ddfW9GiRa1JkyZ2/fXX29NPP21HjhxxSXcAAEINSXQAAAAAAEI4iV6wYMHLbs+SJYtLmK9bt84uXrxoCxYssIwZM7qEOgAAoYZyLgAAAAAAhKBLly7Znj17bNWqVTZlyhS7cOGC1a9f39VEb9iwoX3++ed2//33W1hYmKVMmdLdJ3PmzIHebQAAEh1JdAAAAAAAQtCBAwfs9OnTFh4ebuPHj7d9+/bZsGHD7MyZM/boo4+68i0DBgywcuXK2dtvv219+vSxhQsXWrZs2aJ9vtSpwyxFCgsZ3msNDw+zS5cCvTfwx7EJbhyf4MWxiRlJdAAAAAAAQlDevHltzZo1bnR5ihQprFSpUq50S8+ePe3PP/90tdIfeOABd18tPNqgQQObP3++dezYMdrnO3fugoVisiki4gLJpiDDsQluHJ/gxbGJGTXRAQAAAAAIUap9rgS6p0iRInb27FnbvHmzlSxZ0ne7yrnoukavAwAQakiiAwAAAAAQglauXGlVq1Z1JV08W7dudYn1XLlyuUVH/al+er58+QKwpwAABBblXAAAAAAACEEVKlSwNGnSWP/+/a1Lly62d+9eGzVqlHXo0MGVenn22WftxhtvdPebN2+eG4V+7733Bnq3AQBIdCTRAQAAAAAIQRkzZrTp06fbiBEjrFmzZpYhQwZr1aqVS6KrxMvff/9tU6ZMsUOHDrl66W+88UaMi4oCAJCckUQHAAAAACBEFStWzGbOnBntthYtWrgLAAChjproAAAAAAAAAADEgCQ6AAAAAAAAAAAxIIkOAAAAAAAAAEAMSKIDAAAAAAAAABADkugAAAAAAAAAAMSAJDoAAEg0n376qZUoUSLSpXv37m7bli1brEWLFlauXDlr1qyZbd68OdC7CwAAAAAASXQAAJB4du7cabVr17ZVq1b5LsOGDbNTp05Zx44drVKlSrZgwQKrUKGCderUyd0OAAAAAEAgkUQHAACJZteuXVa8eHHLkSOH75IpUyb78MMPLU2aNNarVy8rUqSI9evXzzJkyGDLli0L9C4DAAAAAEJcQJPov/zyi7Vv396NNqtVq5ZNmzbNt02j0qJO9549e7Zv+5IlS6xevXpuyneXLl3s999/9227dOmSjRkzxqpVq2ZVqlSxUaNG2cWLF33b//jjD+vWrZv7u3Xq1LH3338/EV81AAChnUQvWLDgZbdv3LjRKlasaClSpHDX9fOmm26yDRs2BGAvAQAAAAD4f6kC9YeV1Na07TJlytjChQtdQv3pp5+2XLly2d133+1Osp955hm79957fY/JmDGj+7lp0yY3Qm3w4MFWsmRJGz58uPXp08emTJnits+cOdMl2SdOnGjnz5+3nj17WrZs2VzCXnTfM2fO2DvvvONO2vv372+FChWysmXLBujdAAAg+VMn9549e1wJF8XsCxcuWP369V1N9CNHjljRokUj3V+xe8eOHQHbXwAAAAAAAppEP3r0qJUqVcoGDRrkkuMalXbzzTfbunXrfEl0Jb01zTsqjUhv0KCBNWnSxF3XSHPVV927d6/lz5/fZs2a5U7IVVdVevToYS+99JJ7vl9//dW++OIL++yzzyxfvnxuSrlGub311lsk0QEASEAHDhyw06dPW3h4uI0fP9727dvnZp6pY9u73Z+uR0REBGx/AQAAAAAIaBI9Z86c7gTaG5m2fv16W7t2rQ0cOND++usvO3z4cLTTvUWjxx999FHf9dy5c1uePHnc7TrhPnjwoFWuXNm3XdPD9+/fb7/99pu7j+6vBLr/dm8UOwAASBh58+a1NWvWWObMmV25FnWma2aaZoyp/FrUhLmup02bNtrnSp06zP5X+SUkeK81PDzMLl0K9N4gKo5P8OLYID7o/wcAAIS2gCXR/akuuUanaTT5nXfeaZs3b3Yn16+++qp99dVXliVLFnvkkUd8pV2UDFcSPuqU70OHDrnp4OK/PXv27O6ntz26xyppDwAAEpZiuj8tInr27Fk380yz1PzpetSY7Tl37oKFYiIwIuICicAgxPEJXhwbxAf9/wAAgNAWFEn0CRMmuBNllXZ5/vnn7YYbbnBJ9MKFC9uDDz7oRqg/99xzruzL7bff7qZ9xzTlW9u86/7bRNuZLg4AQGCsXLnSlVj78ssvLV26dO62rVu3usS6ZoW99tprbnaa2gDeLLXHHnss0LsN4B/Ue+P/Z4fi6ix/+LVA7wIAAACCOYmuxUVFI9F0cq2TZo1K90arafHQn3/+2d5++22XRE+TJk20U751Qu6fMNf9vN9F22N6bEzTxYUp4wgmHJ/gxbFBfEjOU8YrVKjg4rAW9O7SpYtby0TrmnTo0MEtMDp27Fi3WHirVq1s7ty5ruNba6AAAAAAABCyC4tqQc969er5bitatKidO3fO1UTPmjVrpPtrVPrq1avd77ly5Yp2yremgmubqGyLV/fcK/HibY/psTFhyjiCCccneHFsEB+S85RxzSibPn26jRgxwpo1a2YZMmRwCXMl0TX6XOuTaG2Ud99910qUKGFTp0619OnTB3q3AQAAAAAhLmBJ9H379lnXrl1txYoVvsS3aqEref7mm2/aDz/8YK+//rrv/tu2bXOJdClXrpytW7fOmjZt6q5rIVFddLueS4uMaruXRNfvuk11VcuXL+8WGVV99Ouuu863XbcDAICEVaxYMZs5c2a028qWLWsLFy5M9H0CAAAAAOCfpLQAlnBR7fO+ffvazp07XTJ99OjRrvapSrmoDrpGq/3666/21ltv2aJFi6xdu3busa1bt7b333/f5s2b55LrvXr1slq1aln+/Pl928eMGWNr1qxxF00Pb9Omjdum+9SoUcN69uzpHqvnWLJkiT3wwAOBeisAAAAAAAAAAEEqYCPRw8LCbPLkyTZ06FC77777XL3yhx56yCW7NaX7pZdecguO6mfevHldIly1VEU/hwwZ4rb/+eefVr16dfc8nvbt29uxY8fcSHf9nebNm1vbtm1921V/tV+/ftayZUtXxkXTyjX6DQAAAAAAAACAoFlYVKVXJk6cGO021Ur3r5celUq5eOVcolLivE+fPu4SnWzZstmrr756hXsNAAAAAAAAAAgVASvnAgAAAAAAAABAsCOJDgAAAAAAAABADEiiAwAAAAAAAAAQA5LoAAAAAAAAAADEgCQ6AAAAAAAAAAAxIIkOAAAAAAAAAEAMSKIDAAAAAAAAABADkugAAAAAAAAAAMSAJDoAAAAAAAAAADEgiQ4AAAAAQIj69NNPrUSJEpEu3bt3d9u2b99urVu3trJly9rdd99tq1evDvTuAgAQEKkC82cBAAAAAECg7dy502rXrm1Dhw713ZYmTRo7efKktWvXzurUqWMvvPCCvf/++9a1a1f7+OOPLVu2bAHdZwAAEhsj0QEAAAAACFG7du2y4sWLW44cOXyXTJky2cKFCy19+vQ2aNAgK1CggBudrp+bN28O9C4DAJDoGIkOAAAAAEAIJ9FvueWWy27/7rvvrG7duhYWFua7bf78+Ym8dwAABAdGogMAAAAAEIIuXbpke/bssVWrVtmdd95p9erVszFjxlhERITt3bvXsmbNas8995xVr17dWrZsaevWrQv0LgMAEBAk0QEAAAAACEEHDhyw06dPW3h4uI0fP9569+5tixcvtlGjRtmpU6ds6tSprrzLa6+9ZpUrV7b27dvbwYMHA73bAAAkOsq5AAAAAAAQgvLmzWtr1qyxzJkzW4oUKaxUqVJ28eJF69mzp1133XXuumqhS+nSpe3rr792C4w+9thj0T5f6tRhliKFhQzvtYaHh9mlS4HeG/jj2AQ3jk/w4tjEjCQ6AAAAAAAhKkuWLJGuFylSxM6ePWu5cuWywoULR9pWsGDBfxyJfu7cBQvFZFNExAWSTUGGYxPcOD7Bi2OTgOVcFFw3bdpkJ0+evNqnAgAAAAAAiWTlypVWtWpVV9LFs3XrVpdYL1++vG3fvj3S/Xfv3u1GrwMAEGrinETfuXOnW1Bk/fr1duLECWvSpIm7fuutt9rq1asTZi8BAAAAAEC8qlChgqVJk8b69+/vEuQrVqxw9dA7dOhgrVq1ckn0l19+2X755Rd76aWX3GKjjRs3DvRuAwAQ/En0wYMHW/78+a1QoUL23nvvuRHoWslbNdFGjhyZMHsJAAAAAADiVcaMGW369On2+++/W7Nmzaxfv3523333uSS6RpxPmzbNvvjiC2vUqJH7qYVGVeYFAIBQE+ea6CrdsmTJErv22mtt+fLldvvtt1v27NldUJ08eXLC7CUAAAAAAIh3xYoVs5kzZ0a7rWLFirZgwYJE3ycAAJL8SPRrrrnGjh496hYT2bBhg9WqVctXNy1btmwJsY8AAAAAAAAAACSNkehNmza1xx9/3MLDwy1fvnxWo0YNe/vtt13dtCeeeCJh9hIAAAAAAAAAgKSQRH/66aetTJkytn//flfCJSwszPLkyWPjxo2z2rVrJ8xeAgAAAAAAAACQFMq5iOqgN2/e3H777TeLiIhwddKuJIGuFb7bt2/vVgRXWRgtWuLRqt9t27a18uXLW8OGDd3ipf6++eYbl8QvV66ctWnTxt3f3+uvv241a9Z0z923b187ffq0b9vZs2fdbZUqVXIj6WfMmHElbwMAAAAAAAAAIJmLcxJdCej+/ftblSpVXCL98OHD9uyzz7pk+J9//hnr57l48aJ17NjRLVC6cOFCGzx4sL3yyiu2ePFiu3TpknXp0sUtWDp//nxr3Lixde3a1Q4cOOAeq5/artIy7733nmXNmtU6d+7sHicff/yxTZw40YYMGWJvvPGGbdy40UaPHu372yo9s3nzZrdt4MCB7r7Lli2L61sBAAAAAAAAAEjm4pxEVzJ6586dLvGdJk0ad1u3bt3sjz/+sGHDhsX6ebQ4aalSpWzQoEFWsGBBu+222+zmm2+2devW2erVq93IciXBixQpYp06dXIj0pVQl3nz5tmNN95o7dq1cyuJP//88668zHfffee2z5o1yx5++GE3Or5s2bIuQa/HajT6qVOn3OP79etnN9xwgxtV36FDB5szZ05c3woAAAAAAAAAQDIX5yT6J5984hLQJUqU8N2m34cOHWpfffVVrJ8nZ86cNn78eMuYMaMbQa7k+dq1a90Id40cL126tKVPn953f5WM2bBhg/td21WKxZMuXTqXENf2Cxcu2I8//hhpuxLw586ds23btrnL+fPnXZkX/+fWc2p0PAAAAAAAAAAAV5xE//vvv13SOioloJXAvhJ16tSx+++/3yW277zzTjty5IhLsvvLli2bHTp0yP3+T9tPnDjhSs74b0+VKpVlyZLFbddjVUImPDzct11lY/SY48ePX9H+AwAAAAAAAACSp5RXkvB+8cUX7a+//vLdptIrKuWikixXYsKECfbqq6/a1q1bXWkWlV3xT3KLrmsRU/mn7WfOnPFdj257TI8V7/kBAAAAAAAAAJBUcX0bBgwYYH379nVlVzT6vFmzZnby5EmrUaOGPffcc1f0rpYpU8b91GjwHj16uOdUstufEtxp06Z1v6sWe9SEt65nypTJV6c9uu0aQa/R8tFtE+/5o0qdOsxSpLCQ4b3W8PAw+99arQgiHJ/gxbFBfND/DwAAAAAASMJJdC0g+vLLL7vR57t27XL1xQsVKuQWAI0LLSyqGub16tXz3Va0aFFXuzxHjhy2e/fuy+7vlWjJlSuXux7dQqUq26JEuq57+6R9VKkWPa/qr+s16DaVeRGVeFECXUn46Jw7d2VlapJ6IjAi4gKJwCDE8QleHBvEB/3/AAAAAACAJJxEb926tU2ZMsVuvPFGy58//xX/4X379lnXrl1txYoVLikumzdvtqxZs7qFPmfMmOFKs3ijw7XwqG6XcuXKuesejVrfsmWLe76UKVO6ke3aXrVqVbddyXolzEuWLPnfF50qlbvNW3xU99Vj9FgAAPD/fv75Z1u1apX99NNP9vvvv1uKFClcp7QWAL/11lstb968gd5FAAAAAAASVJyzxlqE89ixY1f9h5W0vuGGG1xpmJ07d7pk+ujRo+2xxx5zpWJy585tffr0sR07dtjUqVNt06ZN1rx5c/dYlXtZv369u13bdb98+fL5kuZapHT69Om2fPly97hBgwZZy5YtXTkXXZo0aeJu0zbdRwn7Nm3aXPVrAgAguVi7dq21bdvW7r77bvvwww8tderUVqJECTdrTOXc5s+fb/Xr17d27drZ6tWrA727AAAAAAAEz0h0jTzr3LmzS4Jr9FnURTq1MGhshIWF2eTJk23o0KF23333ueT2Qw895JLZGuWmbf369bOmTZtagQIFbNKkSZYnTx73WCXMVVJmxIgR7vYKFSq4n3qc3HXXXbZ//35Xv131zu+44w7r2bOn728r6a4k+sMPP2wZM2a0bt26ufsAAABz65McPnzYzT6bOHGii5XROXXqlH388cc2fvx41yYYO3Zsou8rAAAAAABBl0SXe+65J17+uMq46OQ8Okqcz549O8bH3nbbbe4Sk44dO7pLdJSwHzlypLsAAIDI1IF9yy23/Ov90qdPb/fee6+7qOQLAAAAAADJUaorObEuX768m9btTyO+v/rqq/jcNwAAEAD/lkBXbfRrr73WNwNMatSoEae/oY5urYPywgsvuOta22TgwIH2n//8x5WMGTx4sFt/BQAAAACAJFcTXeVWTp48edntqmv+9NNPx9d+AQCAIKCyLk899ZRt3brVzp49aw8++KBVr17d6tSpY9u2bbui51y6dKlbC8W/LIyS6lrwe8GCBa5MW6dOndztAAAAAAAkiZHob731lg0ZMsSNOLt06ZI7eY5ObKZ+AwCApENriCiZnSVLFpfg1kjxuXPn2gcffODWNZkzZ06cnu/48eM2atQot7aKRwuXpkmTxnr16uXaGloTRbPbli1b5mbAAQAAAAAQ9En0+++/34oVK2YXL150i3FOmDDBMmfO7NuuE17VGS9evHhC7isAAEhkq1evdsnz3Llz2/Lly61u3bpWrlw5V4qlUaNGcX4+rUfSuHFj++2333y3bdy40SpWrOgrD6OfN910k23YsIEkOgAAAAAg6dREr1y5svv52WefWZ48eSLVQQUAAMmTRoirjMuff/5pa9assbFjx7rb9+3bF6lDPTa+/fZb+/77723x4sVuhLvnyJEjrg66v2zZstmOHTvi6VUAAAAAAJCIC4vmzZvXTeF+/fXX7ddff7WFCxfarFmzLEeOHK6eKQAASD7q1atnTz75pKVNm9YlzWvVquXKr4wYMcLuvffeWD+PEvFaOHTAgAHuufydPn3awsPDI92m61q0PCapU4dZKPXne681PDzMLl0K9N4gKo4P4oP+fxCcODYAACDOSXTVR588ebI99thjNnr0aHfbjTfe6E6mdbLbtWvXhNhPAAAQABoxPnv2bNu/f7/dd999bmS64r3aAQ888ECsn2fixImuvVCzZs3LtnnP6U/Xoybb/Z07d8FCMUkbEXGBJG0Q4vggPuj/B8GJYwMAAGKdRNf067Jly9qbb75pw4YNcyPRvCndqm2qBcc0uowkOgAAyUeqVKmsbdu27neVdNH6KIr7cS3rtnTpUjt69KhVqFDBXfeS5h9//LGrra5t/nQ9Z86c8fY6AAAAAABI0CR6s2bN7MSJE+4E+MCBA1akSJHL7pM/f347fvx4QuwjAAAIkEuXLtmrr77qyridPHnSJb1feuklS58+vfXv3/+yMiwxUSf8+fPnfdfHjBnjfvbo0cPWrl1rr732mvtbSs7r5/r1691odwAAAAAAAi1lbO6UK1cuW7BggTtRLleunC1atCjSdp3szpgxw41UBwAAycekSZPcWigvvPCCL2GuWuhff/21jRo1Kk5rqhQoUMB3yZAhg7vo9/r167vO+uHDh9vOnTvdT9VJb9CgQQK+MgAAAAAA4jGJrhro11xzjftdo87mz5/vRqdrKvbgwYPt9ttvty+//NL69u0byz8LAACSAi0gPmTIEKtdu7avhEv16tVt5MiR9tFHH8XL38iYMaNNmTLF1q1bZ02bNrWNGzfa1KlT3Wh3AAAAAACS3MKixYsXd1O5NSpt9+7dduHCBatbt67dc889bkQZAABIPo4dOxZtbfJMmTLZqVOnrvh5NbLdn2azKWEPAAAAAECST6JLmjRprEWLFvG/NwAAIKhUq1bNpk+f7kaje/766y8bN26cVa1aNaD7BgBAKDpz5owtXrzYVq5caT/99JP9/vvvbrZYjhw5rHTp0nbrrbe6Umnp0qUL9K4CABC6SfTvv//ehg0b5kahnzt37rLtW7duja99AwAAATZo0CDr2rWrK+Fy9uxZ69y5s1tkPE+ePPbKK68EevcAAAgZKqeqcmezZs2yggUL2i233GJ33HGHZcmSxS5evGh//PGHbd++3d555x034+v+++93i3RrEBwAAEjkJHq/fv2sWLFi9vTTT1vatGmv8s8DAIBgdt1119l7771n3377retAP3/+vBUqVMhq1KhhKVPGamkVAAAQD1q1amV16tSxDz/80LJnz/6P992/f7+9++67dt9999miRYsSbR8BAEiu4pxE/+233+zVV191J9AAACA03Hzzze4CAAACY8aMGW7UeWzkzZvXnnrqKXvkkUf+9b6ffvqpm3Xm784777QJEyb4ru/bt8/uvvtulwugnBsAIBTFOYmuwLl06dLLgiwAAEgeSpYs6WqrxgZl3AAASByxTaDH9TE7d+602rVr29ChQ323RS0Bo/JuV7OgOAAAIZdE79ChgzVv3twWLFjgerejnmSrPhsAAEi6/GP5jz/+aDNnznS10MuUKWOpU6e2LVu22MSJE61NmzYB3U8AAEKd1inR4t8//PCDXbp0ycqXL+9KsBYoUCDWz7Fr1y4rXry4W5g0Oh988IH9/fff8bjXAACEQBK9R48eljVrVqtXrx410QEASIaqVKni+33AgAE2cuRIt7Co/0h1daT36dPH2rZtG6C9BAAAvXv3trp161rPnj3duiXz589365fpZ1yS6FqkNDparHT06NGulEyjRo3icc8BAEha4pxE12rfGoVepEiRhNkjAAAQNLQWSrZs2S67PV26dHbixImA7BMAAKHo+eeft44dO0aKywcPHrS77rrLN4r8jjvusPfffz/Wz6nR63v27LFVq1bZlClT7MKFC1a/fn3r3r27hYeH2wsvvGD33nuvFStWLEFeEwAAyTaJXrFiRddTTRIdAIDkr1atWta3b1/r37+/G4Guk22VeBk2bJg1aNAg0LsHAEDIuP766+3+++93sfnRRx+17Nmzu3KrDRs2tMKFC9vFixddfXMtKBqXcjCnT592CfPx48e7BUQV48+cOWN16tSxdevW2ZIlS2L9fKlTh1ksl1VJFrzXGh4eZpcuBXpv4I9jE9w4PsGLYxOPSfQaNWq4k+lPPvnE8ufPb2FhYZG2s+AoAADJh+qsDhw40B566CF3ci6K/U2aNHGJdQAAkDgeeOABa9mypc2bN88efPBBu/XWW93IdC0KumnTJrdeWenSpS1Pnjyxfk6VZ1uzZo1lzpzZPb5UqVIu3msk+ueff26DBw+OUxnXc+cuWCgmmyIiLpBsCjIcm+DG8QleHJt4TKJ/8cUXLrAePnzYXfxFXWQUAAAkbRkzZrSxY8e6k2hN95ZChQq52wEAQOLSAt8ajd6iRQtX91yd3BropmR6TAuD/pssWbJEuu7NOt+/f79LpvvTCHh1pKuTHQCAUBLnJPqbb76ZMHsCAACC0l9//eWmh2vBMpVz2bp1q29b5cqVA7pvAACEEg1q2717txttrkR68+bN3ZplDz/8sFsEPK7J9JUrV1qPHj3syy+/dOudiOK8EuvvvvtupPuq3rpKvfgvNg4AQKiIcxLdC6o7duzwTevWCXVERIRt2bLFjVSLLY1kHz58uK1evdrSpEnjarlpJXH9ruAcNWH/3HPPuWlrorpsqtl25MgR1/M+dOhQy5o1q29/NGruvffec/uohoUaBilTpvStMD5gwAC3eMq1115rTzzxhDVu3PhK3goAAJI1LU42aNAgVy81Ks1A80+oAwCAhKNz2K+//trKly/v4rPOd6dPn+5KvDRt2tQWLVpkjzzyiFWrVi3WJdcqVKjgzr91/y5dutjevXtt1KhRrtZ6gQIFLrt/rly5ol1wHACA5C7OSfSJEye6ixYxOXbsmAuiR48edat433777bF+HiW6NTUsU6ZMNmfOHPvzzz9drXUlunv37u0WL33mmWfcSuAeb+q46r3169fPJey1yJkS8X369HGricvMmTNdkl37qVFzPXv2dIG+ffv2brvuq4VS3nnnHdu4caNrMGhqetmyZeP6dgAAkKy9+OKLbqSbYjYlXAAACJylS5e60eEqt3L27Fm76aab7Pfff3eDyVKlSuUGj+n8WQn22FJsVyJ+xIgR1qxZM8uQIYO1atXKJdEBAMBVJNGVeFby+r777nOrdb/xxhtuERKtAK7VwmNLU9A2bNjgetKVkBedoI8cOdKXRFfSO7qpaLNnz7YGDRq4WmyinnItpqJecy12OmvWLPdclSpVcts1Cv2ll15yz/frr7+6KXCfffaZ5cuXz4oXL+7246233iKJDgBAFMePH7c2bdqQQAcAIMBKlCjhzmtr1qzpZoHrXFkzq/1p8W+NSo+LYsWKuYFo/2b79u1x3mcAAJKL/9Y3iQOVQlHQFi0w+sMPP7jR5Eqif/jhh7F+HgX8adOm+RLo/nVXdVGpl4IFC0b7WI0e9xLkkjt3blcTTrfrcQcPHoxUo7VixYpuUZTffvvN3Uf3VwLdf7teBwAAiEyd1J988kmgdwMAgJA3YcIEdy6ruKyZ4BrQptJqAAAgCEeiq3yLRnwraa1pZOoBv+eee9wINU0liy0l3r1kvKh2uUaYq36bRqGrMfDqq6/aV1995RY1UW03r7SLkuE5c+aM9Hwq13Lo0CFXI138t3uJem97dI9V8h0AAFwe91XS5aOPPnK1UVOnTh1p+/PPPx+wfQMAIJTovFalSQEAQBJIoqsuqhb/VM20evXqWdu2bV1S+ptvvnH1ya/U6NGjXUJei6P89NNPLoleuHBht5Do2rVr3aKiStSr7rrqmYeHh0d6vK5rcVNt8677bxNt18JoMT02JqlTh1kodfB7rzU8PMwuXQr03iAqjk/w4tggPuj/J5hozZJGjRoFejcAAAh5Kq/WrVu3SLOu/4nO0V955RV78803E3zfAABI7uKcRH/sscfsuuuus3Tp0rka4uoJnzt3rhstrsT6lSbQNRVNI91Uo1w12TR9XM8pSs7//PPP9vbbb7skulYPj5r01nXtk3/CXPfzfhdtj+mxadOmjXH/zp27YKGYCIyIuEAiMAhxfIIXxwbxQf8/wYSR5gAABAcNLBsyZIgdO3bMDWi75ZZb3Oxw1UXXzG6VXlXd8nXr1rlSqyqhOnDgwEDvNgAAoZlEHzZsmOsB9xYR1ch0Xa7U0KFDXXJcifQ777zT3aZR6F4C3aNR6atXr/ZNLT969Gik7bquRoK2icq2eHXPvRIv3vaYHgsAAC63fPlyt46JFgVXDdZChQq5mWLeAt8AACDhabCZRpVrprYGsj3xxBN24sSJSPfReXT16tVt+PDhVqVKlYDtKwAAFupJ9A8++MCVcIkPEydOdMF/3LhxVr9+fd/tWnFcC32+/vrrvtu2bdvmEulSrlw517vurTquhUR10e1Kkqteu7Z7SXT9rttUdqZ8+fJukVHVR9eIem+7bgcAAJEpTo8cOdIlzTt27OhGuq1fv94GDx5s586du6qOdAAAEHcq5+KVdNm3b59bm0wD0VQzXQuPAgCAIEiiK4GuE2f9VGLaK5ni0W2xocVDJ0+e7E7IK1as6BstLirlMnXqVJs+fbor37Jq1SpbtGiRzZo1y21v3bq1PfTQQy7xXaZMGdfLXqtWLcufP79v+5gxY3xJ8rFjx1q7du3c77pPjRo1rGfPntavXz/78ccfbcmSJW5RUwAAEJlGoGsquP+oc00h12g4LQBOEh0AgMDRwDFv8BgAAAiiJPqECRPcz5UrV7qf6vGWS5cuud+3bt0aq+f57LPP3JRwLXSiiz/VcdNodP0t/cybN69LhFeoUMFt10/VgtN2LXim6WoqC+Np3769qxPXtWtXCwsLs+bNm0caPT9q1CiXQG/ZsqUr46Ja7qrvDgAAIlM8jW62lmKxZoEBAAAkhAdf/SrQu5BszH7s1kDvAgCEXhJdye/4oBHousREo9x0iYlKuXjlXKJS4lwLnuoSnWzZsrnRcwAA4J+VKlXKzQZ78sknI92+cOFCK1q0aMD2CwAAAACAoE2ia1R4dCIiItwo9Ji2AwCApEflzzSba82aNW7tEdmwYYNbq4QOaQAAAABAKIhzEt1bTGznzp1ucbGoI8A3b94cn/sHAAACSGVbFixYYPPmzXPrmWgtFC1m9uKLL7J4GQAAAdK7d2+76667XGlTnYcDAICElTKuDxg2bJgbba7RZ+nSpbOXX37Z+vfvb1myZHG1xgEAQPJy/vx5a9iwob322ms2ceJEu/baa+3EiROB3i0AAEJWxowZ3TpfSqIPGDDAVq9e7dYpAwAAQZJE37Fjhz3zzDNWs2ZNu+GGGyx16tT2wAMP2MCBA2369OkJs5cAACAgPvzwQ2vRooWbieb58ccf3eLcy5cvD+i+AQAQqp577jn76quvbMKECZYqVSrr0aOHO0cfPny4K7sGAAACnETX6HNvuljhwoVt+/bt7veyZcvanj174nn3AABAIOnkXGXcVBfdo1Iu6jzXTwAAEBgpUqSwKlWquJHoy5Yts+bNm9u7775rrVu3trp169qUKVPs7Nmzgd5NAACShTgn0atVq2Zjx461w4cPuzqpGqF2/Phx+/zzzy1TpkwJs5cAACAgDh065OJ9VBUrVrS9e/cGZJ8AAIDZ33//bUuWLLGuXbtajRo17KOPPrJHHnnE3n//fRsyZIhLrHfu3DnQuwkAQGguLKq6az179rRPPvnEWrVqZe+9955LrGt0+qBBgxJmLwEAQECULl3aZs+e7dY/8aeRbiVLlgzYfgEAEMoef/xx++abb9xAtgYNGtisWbPc7HBP8eLF3folOn8HAAABSKLnypXLBWjPm2++aTt37nTBW9sAAEDy8eyzz1r79u1txYoVVqpUKXebSrlpFtrUqVMDvXsAAISk7Nmzu3ItVatWdWVdolOpUiWbN29eou8bAADJUZyT6LJr1y6bP3++7d692wXsEiVKuEXHAABA8qJRbR9//LGbLv7zzz+7xct0wn7PPffYNddcE+jdAwAgJA0dOtTmzJljR48etUaNGrnbunTp4sq6qCa65MiRw10AAEAAaqKr9nnjxo3txx9/tEKFCln+/Pntu+++s7vuusvWrl0bD7sEAACCSdasWa1p06ZuwbJnnnnGtQNIoAMAEDha3PvVV1+19OnT+25TJ/fkyZNt0qRJAd03AACSoziPRB89erQ98cQT9uijj0a6/ZVXXrHhw4fbokWL4nP/AABAAJ09e9YtTrZw4UJ3XaPSR44caadPn7Zx48ZZ5syZA72LAACEHM0MHz9+vCvZ4mnTpo2bJa41zDQqHQAABHAk+sGDB61u3bqX3V6/fn3bs2dPfO0XAAAIAuo8Vxk3JdHTpEnjbuvWrZv98ccfNmzYsEDvHgAAIUmd2RkzZrzs9muvvdZOnjwZkH0CACA5i3MSXSt/T5s2zc6dOxfpdi1Y0rBhw/jcNwAAEGCffPKJ9evXz41s8+h31WL96quvArpvAACEqpo1a7qZ4AcOHPDddvjwYTdbTHXRAQBAgMu5aFq3Tqh14nzjjTda6tSpbfv27bZ3714rV66cm0LmmTVrVjzvLgAASEx///23pUuX7rLbL168aBcuXAjIPgEAEOoGDBhgnTt3drPEvdJqf/75p1WrVs1tAwAAAU6iFy5c2B577LFIt/mPTgMAAMlHnTp13OJlGtnmUce5SrncdtttcX6+X375xdVYX79+vTvpf/DBB61Dhw6+533uuedsw4YNlidPHuvbty+j6QAAiGHR77lz59q2bdvs559/tlSpUlnBggWtaNGigd41AACSpTgn0bt27ZowewIAAIKORrMpmV2lShU3+rxZs2Z24sQJN41cCe+40OM7duxoZcqUcTXWlVB/+umnLVeuXNaoUSO3CFrx4sXdYmnLly93bY4PP/zQJdQBAEBk58+fdzXQM2XK5K5funTJrVO2detWSq0CABDoJDoAAAgd11xzjb388stulLgWGNUJe6FChaxIkSJxfq6jR49aqVKlbNCgQW4xNI2Yu/nmm23dunWWPXt29zc0qi59+vTu+b/99luXUNdCpgAA4P+ps1md2cePH79sW44cOUiiAwAQ6IVFAQBAaFHyPEuWLFarVi1LkyaNzZ492y0oHlc5c+a08ePHuwS6Rsspeb527Vo3yn3jxo1WunRpl0D3VKxY0ZV2AQAAkY0dO9Zuv/12W7p0qRuJrk7oV1991fLmzWtPPvlkoHcPAIBkhyQ6AACI0TvvvGP33HOPmxq+ZcsWe/zxx92I8ZdeesldrqbW+v33328VKlSwO++8044cOeKS7P6yZctmhw4diodXAQBA8qJYrDVFtGbZjTfe6OKo1ioZOHCgzZw5M9C7BwBAsnNVSXSt/q36phpNBgAAkp9p06a5RUU1WlylVVSORbdpsdErGY3umTBhghsxp+T8888/b6dPn7bw8PBI99H1iIiIeHgVAAAkLxp9rtgpKrOmBUZFSfV9+/YFeO8AAEh+4lwTXQlznfS+/vrrdvLkSfv444/dSDRNv+7fv/9lJ8AAACDpOnz4sCurIl988YXdd9997vfrrrvO/v777yt+Xi0uKmfPnrUePXq4BUu9ZIBHCfS0adNG+/jUqcMsRQoLGd5rDQ8PM8YuBB+OD+KD/n8QnILx2GjU+eDBg23IkCFWtWpVGzVqlNWuXdudn0ed2fVvPv30U7eYtz/NElOH95dffuk6zn/99VfLly+fKxVTt27deH41AAAkwyT6pEmTXN21F154wZ566il327333msDBgxwgVuJdAAAkDxoRNvixYsta9asduDAAatXr56dO3fOZsyYYSVLlozzwqKqca7n8BQtWtQ9nxZB271792X3jykRcO7cBQvFJG1ExAWStEGI44P4oP8fBKdgPDb9+vWz4cOH2+bNm61x48Yued68eXM3uG306NFxeq6dO3e6BPzQoUN9t2kNFI1uV3K9V69eLmm/atUqe+KJJ+y9996LcxsAyU+OSW0sKchuwe1Il1mB3gUksuMjgn+20B8W/LL0zRf8SfSFCxe6BHrlypUtxf/OGKpXr+6meiugkkQHACD56N27txt1phJuqmFepEgRN+pNo9Y0My0uNL1cJ+MrVqywXLlyudt08q8EvUa7KzF/5swZ3+hzLTzqjYIHAAD/TyPEldy+9tpr3fUxY8bYoEGDXPI7derUcV5AvHjx4q5D29/UqVOtWrVq1qbNf5OlBQoUsM8//9w++ugjkugAgJAT55rox44di3ZUmGqynTp1Ks5TxLt37+7qrNasWdPVRNW0bm+hlLZt21r58uWtYcOGrtfb3zfffGONGjWycuXKuaCu+/tTuRk9pxYs69u3b6Qp4vobuq1SpUpWo0YNd9IOAAAud/PNN9u3335ra9ascbPOpHPnzq60ixYyi2sJlxtuuMHFYI16UzJdo+Uee+wx1xbInTu39enTx3bs2OFO3Ddt2uRG1QEAgMhUyuWPPyKPFcyYMWOcE+heEr1gwYKX3a4Z5yq5FpXKugIAEGrinERXT/T06dMj3fbXX3/ZuHHjXC22uNRWVwJdye05c+a4Oms6IR8/frzb1qVLF8uePbtbxEzT0zRyTdPIRT+1vWnTpm4qmUaw6YTeW+BUU9kmTpzoRsq98cYbtnHjxkhT2lR2RiPftE2rl+u+y5Yti+tbAQBAsqS1ThTbPSlTprTMmTP7ris++5+knzhxwsXxfxMWFmaTJ0+2dOnSudrqmor+0EMPuc5wb9uRI0dcfP/ggw9cCbk8efIkwCsEACBp07n3kiVLrnoBbp1D79mzxw1aUx10lVzTqHY9r2af+Y84Vye3OtbVwQ4AQKiJczkXTRFTQlslXDSiW8lrJbV1kvvKK6/E+nlU91R1Ub/++mt3Mi5KqqsszK233upGls+dO9fVdFPwVrBWQr1bt242b948N/qtXbt27nEawa79+e6771xjYtasWfbwww+7um5eL3379u2tZ8+erpGgx7/22mtuNJwuagwokV+/fv24vh0AACQ7GhGuDmzN6NLJtGJr1JFt6gT/4Ycf3Am8ZodpNHlsqIyLOq+jo2nis2fPjpfXAABAcqYZ4up8Vmk1DSpTGRd/n332WayeR+fyiunh4eFuQJtKrw0bNsyVV/Mv1fr777+7c/GbbrqJhUUBACEpzkn06667zo3+VlJbifDz589boUKFXFkUjVSLLdVbmzZtmi+B7tHIN40cL126tEuge1QTVUl30XaVYvFoRJuS4dqu23/88cdIq4urJIwWLdPCKEqia59V5sX/udX4uHjxYpxeA4DEVe+NRwO9C8nC8odfC/QuIMi1bNnS7rjjDtfBrNIrOnHOly+fq7uqWHn8+HF3kq1YrnIrWi/Fq8kKAAASJ1brcrXy5s3rSrZpxpnWPCtVqpSL9RqAphJrmimmhb4feeQRdy49YcKEfzxnTp06zLfYMoJHeHhYoHcBMQjVY+N9T+j1syg7kspnJ85JdI+mcF3NNC7VUNcIN48CtUafqVyMpnJHrbueLVs2O3TokPv9n7ZrSrlGyPtvT5UqlWXJksVtV8DXib562j1K5OsxSgqoFx8AgFCnuKnSaZpxtn37dtuyZYtLpusEWzFXnd1ahAwAACQ+1SuPz5jvTzPBdX6sRcU1GM1bWFQzvv/tfPncuQvxtl+IPxERHJdgFarHxkui6/WTREdS+ezEKomuOmg6aY6NrVu3XtGOqGa5TtA1yl2LgvonuUXXvXpv3nSz6LZr2pl3Pbrt6j2PbptcbT05AACSG8V/tQP8a6ICAIDA0poi/3SOroR3bKxcudItHvrll1+6Gd7eOb0S62nTpnVlUjUQTc+nGWgAAISqWCXR/QOwSqXMnDnTjUwrU6aMq5Gq5Lfqm3o91FeSQNcin1qUTKPaVM9No8L9KcGtIC7aHjXhresa3e7VgotuuxoFFy5ciHabeM8f6lPSmFYT3Dg+uFqhOmUwqeD4AACAf6P1SvypZKnWFVuxYoU9/vjjsX4elTnVObTqn2sGmp5j1KhR1qFDB5syZYr9+uuv9uabb/pmhHvnzddcc008vyIAAJJBEr1KlSq+3wcMGOAW/9RCnh6NTlMtNdVMa9u2bZx2YOjQofb222+7RLpWA/cWHdu5c2ek+6kOm1eiRdt1Pep21W9Tj7kaAbquaWheg0JJefWcayT6H3/84W5TmRevMaCGgJLw0Qm1KWlMqwluHB9crVCdMphUcHwAAMC/8V8DzN+CBQvsk08+sfbt28fqeTJmzGjTp0+3ESNGWLNmzSxDhgzWqlUrl0Rv0KCBm+ndokWLy0rJvPDCC/HyOgAASCriXBP9t99+c7VQo9Iob9UjjwuNXp87d66NGzfO6tev77u9XLlyNnXqVBewvdHh69atcwuAett13aPyLhoNr4aEpppphLy2e73zWnBUCXNvKrp+9xYh9Z5bj2FRUQAAAABAUlW5cmUbPHhwnB5TrFgxN9s8qmXLlsXjngEAkLTFOWtcq1Yt69u3r61fv95OnTplf//9t61evdrdpp7q2Nq1a5dNnjzZHn30UZcc12hw76KR77lz53Yj23fs2OES6ps2bbLmzZu7x6qHXH9ft2u77pcvXz5f0vz+++93venLly93jxs0aJBbuVyJfl2aNGnibtM23WfGjBlXXIoGAIBQooXGFD9PnjwZ6F0BACBkHThw4LKLzo0nTZrkZokDAIAAj0QfMmSIDRw40C1kcvHixf8+SapU1rhxY1dHLbY+++wzV5/8lVdecRd/27dvdwn2fv36WdOmTa1AgQKuMZAnTx63XQnzl19+2U050+2q46af3sIqd911l+3fv9+VnlG98zvuuMN69uzpe34l3ZVE1yIpmr7WrVs3dx8AABCZyqupo/zZZ5+1okWL2n333Wd79uxxndKK39WqVQv0LgIAEHLq1Knjzn9VrtQ7D9bvGoym82QAABDgJLqSzmPHjnVTxHQSLYUKFXK3x0XHjh3dJSZKnM+ePTvG7bfddpu7XMnz68Rfdd11AQAAMVO8z58/v4v17733nhuBvmrVKps/f76LowsXLgz0LgIAEHI0KM2fEumpU6e27Nmz+5LqAAAg/lxxEXAlzVVHXJe4JtABAEDSoNItTz75pF177bWuBNrtt9/uTtAbNWpku3fvDvTuAQAQklSy5csvv7QffvjB/a5Z2+r41ppjAAAg/rGSJgAAiNE111xjR48etYMHD7pFubU2imzdujXahcYBAEDCe/HFF11ZtfTp0/tu09piKouqUqcAACDA5VwAAEDo0Nokjz/+uIWHh7s1SWrUqGFvv/22jRo1yp544olA7x4AACFJZdXGjx9vlSpV8t3Wpk0bK1GihFsPrEuXLgHdPwAAkhuS6AAAIEZPP/20K92mBbtVwiUsLMxNGR83bpzVrl070LsHAEBIOn36dLRlVVV+TeuXAACAICjnsnfvXreYWOfOne23335zC419//338bxrAAAgGKgOukagr1u3zj799FO3yCgJdAAAAqdmzZo2fPhwO3DggO+2w4cPu/N0xWwAABDgkehr1661jh07uqC9cuVKO3v2rFtYbNCgQW5U2h133BHPuwgAAAJF9dC7d+/uFi7LlCmTXbx40f766y+rXr26q8eqmukAACBxDRgwwA1qq1OnjmXJksXddvz4catWrZoNHDgw0LsHAECyE+ck+ujRo+2ZZ56xBx980CpUqOBu69Wrl+XMmdMmTJhAEh0AgGSkX79+lipVKjcCXTXR5ZdffnG3qwN97Nixgd5FAABCTtasWW3u3Lm2fft227Nnj4vVBQsWtKJFiwZ61wAASJbiXM7lP//5j912222X3V63bl379ddf42u/AABAEPjuu+/sueee8yXQpUCBAta/f3/74osvArpvAACEqoiICLfIt8qq1q9f3+rVq+cGt40ZM8bOnTsX6N0DACDZiXMSPW/evPbjjz9edvuXX37ptgEAgOQjf/78bpRbVKrBqgVGAQBA4hs2bJitWLHCSpYs6btN5V10Xq666AAAIMDlXJ588kl79tlnXSL9woULtmjRItu3b58tXbrU9YQDAIDko1mzZjZ48GD76aefXBk3TRffunWrzZo1y5o2beraAZ4mTZoEdF8BAAgVn3zyic2cOdNKlSrlu02j0XPlymWdOnVyM8YAAEAAk+i33367G5U2Y8YMK1asmH322WdWqFAhmzNnjpUrVy4edw0AAATaG2+84RYP/fjjj93FkyFDhki3pUiRgiQ6AACJ5NKlS3b27Nlob6ecCwAAQZBE17SxNm3aMOocAIAQ8Pnnnwd6FwAAQBR33nmnW7Nk4MCBVrp0aXfbtm3b3Pm6RqQDAIAAJ9E/+OADe/jhh+N5NwAAQLDSSfnu3bvdImZRMfocAIDE16dPH+vXr587N7948aIbga6Sa4rLXbp0CfTuAQCQ7MQ5id62bVsbMmSI+6kFxdKkSRNpO4uMISnLMamNJRXZLbgd6TIr0LsAIB6MGTPGpk2bZtmyZbss5lPCBQCAwEiXLp2NGzfOTpw4Yb/88otbr+znn3+2xYsXu5HoWssEAAAEMIk+YcIE93PlypWRTqLV862fWmwMAAAkD++8844NHz7cLTAKAACCy44dO9wi38uWLbO//vrLihQpYn379g30bgEIoHpvPBroXUg2lj/8WqB3AUk5ia6FRAEAQGjQoqJlypQJ9G4AAID/2b9/v0ucv//++7Z3717LlCmTS6CPHTvWGjZsGOjdAwAgWYpzEj1v3rzu5549e2zXrl2WOnVqK1y4sOXPnz8h9g8AAARQ7969XRm37t27u5JtKVOmjLSdMm4AACSO+fPnu+T5999/bzlz5rQ6derYHXfcYZUrV7Zy5cpZ8eLFA72LAAAkW3FOoh88eNB69epla9eutcyZM7syLidPnnQBXNO9s2TJkjB7CgAAEt2ZM2dcXdU2bdq4sm0eyrgBAJC4tJBogQIFbOTIkXbPPfcEencAAAgpcU6i9+/f38LCwlxZF29UuhYwUd21AQMG+GqmAwCApG/06NHWsmVLd0mbNm2gdwcAgJA1YsQIW7p0qfXp08eef/55q1WrlltEtEaNGoHeNQAAkr04J9E1An3BggW+BLoULFjQJdBbtWoV3/sHAAACKCIiwh588EHKtgEAEGBNmzZ1l99//90++ugj+/DDD61r166uk/vixYu2Zs0aN1JdJVcBAED8ilzYNBa02vd//vOfy27Xgib+iXUAAJD0tWvXzqZMmWJnz54N9K4AAAAzy5o1qz3wwAM2Z84c++KLL6xLly5WqlQpGzp0qNWsWdONUgcAAAEYia7FSzzVqlVztdi2bNliZcqUcaVdtm/fbq+//ro98sgj8bx7AAAgkL7++mvbsGGDawtkz57dxX1/Ku8GAAAC47rrrrMOHTq4i8qsLlmyxI1QV8kXAACQyEn0qHXOr732WheYdfFcc801brXwzp07x+PuAQCAYJg6DgAAgpvKrKq8iy4AACAASfTPP/88nv8sAABICu69917f73/++afrNE+RIoW7AAAAAAAQCuJcE122bdvmRqFranfUy5UuWtaoUSO3EIpn2LBhVqJEiUiX2bNn+7ZrmppWIi9XrpyrAafFVTyXLl2yMWPGuNIzVapUsVGjRrmFVjx//PGHdevWzSpUqGB16tSx999//4r2GwCA5E4x9ZVXXrGqVavazTffbPv377eePXu6BcUVvwEAAAAASO5iNRLdn5LT06ZNs2zZslmaNGkibdOotCZNmsTp+bRQ2TPPPGM7duyIdPuuXbvc7f4j4DJmzOh+btq0ydVlHzx4sJUsWdKGDx/uar5p4TOZOXOmS7JPnDjRzp8/7072tb/t27d323XfM2fO2DvvvGMbN260/v37W6FChaxs2bJxfTsAAEjWJk2aZEuXLrUXXnjBnnrqKXebYrOS6OqkVgwFAAAAACA5i3MSXYlnJa2bNWt21X98586dLlGuUW5RKYmupHeOHDku26YR6Q0aNPAl7HUSX7t2bdu7d6/lz5/fZs2aZd27d7dKlSq57T169LCXXnrJPd+vv/7qVjDXQmj58uWz4sWLuwXT3nrrLZLoAABEsXDhQpdAr1y5sq+ES/Xq1W3kyJH2xBNPkEQHAAAAACR7cS7nolqoZcqUiZc//t1337np4UrM+/vrr7/s8OHDbmGU6Gj0uJcgl9y5c1uePHnc7XrcwYMH3cm+p2LFim76+W+//ebuo/srge6//YcffoiX1wQAQHJy7Ngxy5kz52W3Z8qUyU6dOhWQfQIAAPHn008/vayUqgalyZYtW6xFixaujKoG0m3evDnQuwsAQNJIovfu3duGDBniEuD79u2zAwcORLrExf333299+/a1dOnSXTYKXaPdXn31Vbv11lvtnnvucSPhPEqGRz2hV7mWQ4cO2ZEjR9x1/+3Zs2d3P73t0T1WyXcAABCZ1heZPn36ZZ3d48aNcx3hAAAgadMMcc3sXrVqle+iNcrUWd6xY0c3gG3BggVuTbFOnTrRiQ4ACElxLueiWuI//fSTtWnTxjetW1SSRde3bt161Tu1e/du91yFCxe2Bx980NauXWvPPfecq4l+++23u30IDw+P9Bhd1wJn2uZd998m2n769OkYHxuT1KnDzO+lJnveaw0PD7NoKu0AsaL/HwQnjk1wC4bjo7irE+VUqVLZoEGDrGvXrq6Ei9Yx6dy5s+s01wwwLTgKAACSNg1iU5nTqKVU33vvPbcOWq9evdz5udYl++qrr2zZsmXWtGnTgO0vAABJIok+evRoa9mypbukTZs2QXZKtc7VE54lSxZ3XYuH/vzzz/b222+7JLoCedSkt65rRLt/wtxb+NS7r7bH9Nh/ei3nzl2wUOIl0SMiLpBExxXT/w+CE8cmuAXD8VFHuUahaabWdddd506iv/32W9fJrQW7tRh3jRo1LGXKuE1o06wvrauyevVqF48bNmxoTz/9tPtd65qow1zrlChBr5lq+hsAACDhk+i33HLLZberFKpKn3qD5/TzpptucrGaJDoAINTEOYmuhLNGh2sBz4Si4Owl0D0ala6TbsmVK5cdPXo00nZdV8+5tonKtnh1z70SL972mB4LAAD+O7ssqptvvtldruY5VV9VtdTnzJljf/75p0uUKxGvEW5dunRxo+Dmz59vy5cvd6PfP/zwQ5dQBwAACUPxec+ePa7zfMqUKXbhwgWrX7++i9k6jy5atGik+6uDfceOHQHbXwAAkkwSvV27di64arSYN9I7vr300ktuoc/XX3/dd9u2bdtcIl20qMm6det8vd9aSFQX3a4kuU64td1Lout33aZa6OXLl3eLjKo+ukbXedt1OwAA+C//km3xQaPYNXLt66+/9q1VohP0kSNHuvVPNBJ97ty5lj59eitSpIgb+a6Eerdu3eJ1PwAAwP9TiTav5On48ePdumeqh64yqZRCTT6CoVwgosexCW4cn+AVHoBjE+ckuk5+dRK8aNEidxIcFhZ5pz/77LOr3imVcpk6dapbyEzlW9Qrrr83a9Yst71169b20EMPucR3mTJl3NTwWrVq+UbHa/uYMWN8SfKxY8e65L/oPpoe3rNnT1fT7ccff7QlS5bY7Nmzr3q/AQBILpo1axarci2xjfua8TVt2jRfAt1/kVJNFy9durRLoHs0fVztDQAAkHDy5s1ra9asscyZM7sO9FKlStnFixfd+XKVKlUohZpMBEO5QESPYxPcOD7BKyIAxybOSXSN/k7o+mdly5Z1o9EnTJjgfiqwKxGuRc5EP4cMGeK2azq4FjsbOnSo7/Ht27e3Y8eOuangSvI3b97c2rZt69s+atQol0BXXXed1I8YMcL9TQAA8F+PPPKIXXPNNfH2fCrjUrNmTd91naCrA7tatWpuurhmi0WdLq5ZYwAAIGFFLaWqGWFaTFznytGVQo0aswEACAVxTqLfe++97qemdv3yyy/uJPj666+3jBkzXtWObN++PdL1evXqucuVJPOVOO/Tp4+7REcn5q+++upV7S8AAMmVRqLdddddLl4mFC1UvmXLFrdoqcq3MV38n3mvVdMWWfQ7+HB8EB+YMh68kvOxWblypfXo0cO+/PJLS5cunbtt69atLrGuWWGvvfaaq5uutoF+rl+/3h577LFA7zYAAIkuzkn0c+fOuRPft956yy06okCaKlUqu/vuu23w4MGXnQQDAICkv7BofFI74o033rAXX3zRLSaqNVaOHz8e6T5MF48+SatpiyRpgw/HB/GBKePBKzkfG83yVhzu37+/W+Rba5Ro5naHDh3cAqOaEa7yqa1atXJrl2gwXYMGDQK92wAAJLp/L3YahRYA++KLL+yVV16xtWvX2nfffWeTJk2y77//3p0MAwCApE2zzhJq8XCVX5s5c6ZLpN95553uNi0KznRxAAASn2aUay2y33//3a2HorKn9913n0uia9uUKVNs3bp1bha41jDR2mX+a5gAABAq4jwSXYtwqk551apVfbfddttt7mRb08B69+4d3/sIAAAS0fPPP58gzztx4kQ3im3cuHFudJunXLly7qT8zJkzvtHnOmHXNHIAAJCwihUr5jq4o6O1wxYuXJjo+wQAQJIfia4p3tHVSM2aNav9/fff8bVfAAAgGdm1a5dNnjzZHn30UZcc12Ki3qVKlSqWO3dut5bJjh07XEJ906ZNbmFwAAAAAACS3Ej0atWq2ZgxY9zFW0z0xIkTblSZ/+h0xOzBV78K9C4kG7MfuzXQuwAAiIXPPvvMraWicnC6RF1cXAl2TSHXdPECBQq4UnF58uQJ2P4CAAAAAHDFSfS+fftamzZtrGbNmlaoUCF32549eyx//vyXnRQDAABIx44d3SUmSpzPnj07UfcJAAAAAIAESaJr8S/VRf/qq69s9+7drha6kunVq1e3lCnjXB0GAAAAAAAAAIDkk0SX1KlTW926dd0FAAAAAAAAAICQTqLXqVPHUqRI8a/3032WL18eH/sFAAAAAAAAAEDSSKJ369Ytxm2nTp2yGTNm2P79+61ChQrxuW8AAAAAAAAAAAR/Ev3ee++N9vbPPvvMXn75ZZdIHzZsmDVv3jy+9w8AAAAAAAAAgIC5oproGnWupPmKFSusadOm1qNHD8uSJUv87x0AAAAAAAAAAEkliX7+/HmbPn26vfLKK1agQAGbM2cOJVwAAAAAAAAAAMlWrJPoa9assSFDhtjhw4ftySeftDZt2ljKlCkTdu8AAAAAAAAAAAj2JLrKtSxdutTy5s1rgwYNsly5ctm6deuivW/lypXjex8BAAAAAAAAAAjeJPqSJUvcz3379rmEekxSpEhhW7dujb+9AwAAAAAAAAAg2JPo27ZtS/g9AQAAAAAAAAAgyFDUHAAAAAAAAACAGJBEBwAAAAAAAAAgBiTRAQAAAAAAAACIAUl0AAAAAAAAAABiQBIdAAAAAAAAAIAYkEQHAAAAAAAAACCYk+gRERHWqFEjW7Nmje+2vXv3Wtu2ba18+fLWsGFDW7VqVaTHfPPNN+4x5cqVszZt2rj7+3v99detZs2aVqFCBevbt6+dPn3at+3s2bPutkqVKlmNGjVsxowZifAqAQAAAAAAAABJTcCT6EpoP/3007Zjxw7fbZcuXbIuXbpY9uzZbf78+da4cWPr2rWrHThwwG3XT21v2rSpvffee5Y1a1br3Lmze5x8/PHHNnHiRBsyZIi98cYbtnHjRhs9erTv+UeNGmWbN2922wYOHOjuu2zZsgC8egAAAAAAAABAMAtoEn3nzp3WsmVL+/XXXyPdvnr1ajeyXEnwIkWKWKdOndyIdCXUZd68eXbjjTdau3btrFixYvb888/b/v377bvvvnPbZ82aZQ8//LDVrl3bypYta4MHD3aP1Wj0U6dOucf369fPbrjhBrv99tutQ4cONmfOnIC8BwAAAAAAAACA4BXQJLqS3lWrVrV33nkn0u0aOV66dGlLnz6977aKFSvahg0bfNtVisWTLl06lxDX9gsXLtiPP/4YabsS8OfOnbNt27a5y/nz512ZF//n1nNevHgxgV8xAAAAAAAAACApSRXIP37//fdHe/uRI0csZ86ckW7Lli2bHTp06F+3nzhxwpWI8d+eKlUqy5Ili9ueMmVKu/baay08PNy3XWVj9Jjjx4+70jAAAAAAAAAAAAQ8iR4TlV3xT3KLrmsB0n/bfubMGd/16Larbnp028R7fgAAAAAAAAAAgjaJniZNGjcq3J8S3GnTpvVtj5rw1vVMmTK5bd71qNtV9kXlXqLbJt7zR5U6dZilSBEPLwzxLjw8LNC7gBhwbIIXxya4cXwAAAAAAAguQZlEz5Url1t01N/Ro0d9JVq0Xdejbi9VqpQr26JEuq5rUVJRDXQl5XPkyOFGov/xxx/uNpV58crDKIGuJHx0zp27kECvFFcrIoJjE6w4NsGLYxPcOD4AAAAAAASXgC4sGpNy5crZTz/95CvNIuvWrXO3e9t13aPyLlu2bHG3q+Z5mTJlIm3XgqNKmJcsWdIl2vW7t0ip99x6jB4LAAAAAAAAAIAnKLPGVapUsdy5c1ufPn1sx44dNnXqVNu0aZM1b97cbW/WrJmtX7/e3a7tul++fPmsatWqvgVLp0+fbsuXL3ePGzRokLVs2dKVc9GlSZMm7jZt031mzJhhbdq0CfCrBgAAAAAgcDp27GjPPvus7/qnn35qDRo0sAoVKljr1q3dYDcAAEJRUCbRw8LCbPLkya7MStOmTe2DDz6wSZMmWZ48edx2Jcxffvllmz9/vkusq1SLtqf4X+Hyu+66yzp16mQDBgywdu3aWdmyZa1nz56+51fS/YYbbrCHH37YBg8ebN26dbM77rgjYK8XAAAAAIBAWrp0qa1YscJ3XQPWnnnmGXdu/f7777tZ3fpdM8EBAAg1QVMTffv27ZGuFyhQwGbPnh3j/W+77TZ3+acedF2io9HoI0eOdBcAAAAAAEKZBqaNGjXKlTn1fP3111a0aFE3k1uefvppmzNnjlu/zP9+AACEgqAciQ4AAAAAABKHBpg1btzYJc09WbJkcQlzrSF28eJFW7BggWXMmNGuv/76gO4rAAAhPRIdAAAAAAAkrm+//da+//57W7x4sVs7zNOwYUP7/PPP3ZpjKrmaMmVKmzJlimXOnDmg+wsAQCAwEh0AAAAAgBB09uxZGzhwoFtPLG3atJG2/fHHH26dMm1799133Uh1rS927NixgO0vAACBwkh0AAAAAABC0MSJE+3GG2+0mjVrXrZtzJgxVrx4cXvggQfc9aFDh1qDBg1s/vz5Ma4/ljp1mKVIkeC7jTgKDw8L9C4gBhyb4MbxCV7hATg2JNEBAAAAAAhBS5cutaNHj1qFChXc9YiICPfz448/tty5c9tDDz3ku6/KuZQsWdIOHDgQ4/OdO3chEfYacRURwXEJVhyb4MbxCV4RATg2JNEBAAAAAAhBb775pp0/fz7S6HPp0aOHK/Oya9euSPffs2ePlSlTJtH3EwCAQCOJDgAAAABACMqbN2+k6xkyZHA/CxQoYC1btrRnn33WlXvRSPV58+a5Uej33ntvgPYWAIDAIYkOAAAAAAAiadiwof399982ZcoUO3TokJUqVcreeOMNy5YtW6B3DQCAREcSHQAAAAAA2AsvvBDpeosWLdwFAIBQlzLQOwAAAEKPFi5r1KiRrVmzxnfb3r17rW3btla+fHk3+m3VqlUB3UcAAAAAAIQkOgAASFRnz561p59+2nbs2OG77dKlS9alSxfLnj27zZ8/3xo3bmxdu3Z1tVcBAAAAAAgkyrkAAIBEs3PnTnvmmWdc0tzf6tWr3Uj0uXPnWvr06a1IkSL27bffuoR6t27dAra/AAAAAAAwEh0AACSa7777zqpWrWrvvPNOpNs3btxopUuXdgl0T8WKFW3Dhg0B2EsAAAAAAP4fI9EBAECiuf/++6O9/ciRI5YzZ85It2XLls0OHTqUSHsGAAAAAED0GIkOAAAC7vTp0xYeHh7pNl3XAqQAAAAAAAQSI9EBAEDApUmTxo4fPx7pNiXQ06ZNG+39U6cOsxQpLGR4rzU8PMyilJNHEOD4ID7o/wfBiWMDAABIogMAgIDLlSuXW3TU39GjRy8r8eI5d+6ChWKSNiLiAknaIMTxQXzQ/w+CE8cGAABQzgUAAARcuXLl7KeffrIzZ874blu3bp27HQAAAACAQCKJDgAAAq5KlSqWO3du69Onj+3YscOmTp1qmzZtsubNmwd61wAAAAAAIY4kOgAACLiwsDCbPHmyHTlyxJo2bWoffPCBTZo0yfLkyRPoXQMAAAAAhDhqogMAgIDYvn17pOsFChSw2bNnB2x/AAAAAACIDiPRAQAAAAAAAACIAUl0AAAAAAAAAABiQBIdAAAAAAAAAICkmET/9NNPrUSJEpEu3bt3d9u2bNliLVq0sHLlylmzZs1s8+bNkR67ZMkSq1evntvepUsX+/33333bLl26ZGPGjLFq1apZlSpVbNSoUXbx4sVEf30AAAAAAAAAgOAW1En0nTt3Wu3atW3VqlW+y7Bhw+zUqVPWsWNHq1Spki1YsMAqVKhgnTp1crfLpk2brF+/fta1a1d755137MSJE9anTx/f886cOdMl2SdOnGgTJkywxYsXu9sAAAAAAAAAAEgySfRdu3ZZ8eLFLUeOHL5LpkyZ7MMPP7Q0adJYr169rEiRIi5hniFDBlu2bJl73OzZs61BgwbWpEkTK1mypBtpvmLFCtu7d6/bPmvWLDeiXUl4jUbv0aOHzZkzJ8CvFgAAAAAAAAAQbII+iV6wYMHLbt+4caNVrFjRUqRI4a7r50033WQbNmzwbVeC3JM7d27LkyePu/3w4cN28OBBq1y5sm+7nmv//v3222+/JcrrAgAAAAAAAAAkDUGbRFfd8j179rgSLnfeeaerb6465hEREXbkyBHLmTNnpPtny5bNDh065H5XMjym7Xqs+G/Pnj27++k9HgAAAAAAAAAASRWsb8OBAwfs9OnTFh4ebuPHj7d9+/a5euhnzpzx3e5P15VgF90npu3a5l333ybe4wEAAAAAAAAACOoket68eW3NmjWWOXNmV66lVKlSdvHiRevZs6dVqVLlsoS3rqdNm9b9rnrp0W1Ply5dpIS57uf9LtoendSpw+x/lWMQZMLDwwK9C4gBxyZ4cWyCG8cHAAAAAIDgErRJdMmSJUuk61pE9OzZs26B0aNHj0baputeiZZcuXJFu12P0zZRWZd8+fL5fhdtj865cxfi8VUhPkVEcGyCFccmeHFsghvHBwAAAACA4BK0NdFXrlxpVatWdaVbPFu3bnWJdS0E+sMPP7i66aKf69evt3Llyrnr+rlu3Trf47SQqC66XUl0LTLqv12/67aoddQBAAAAAAAAAKEtaJPoFSpUcOVW+vfvb7t377YVK1bYqFGjrEOHDla/fn07ceKEDR8+3Hbu3Ol+KtneoEED99jWrVvb+++/b/PmzbNt27ZZr169rFatWpY/f37fdi1SqnIxuowdO9batGkT4FcMAAAAAAAAAAg2QVvOJWPGjDZ9+nQbMWKENWvWzDJkyGCtWrVySXTVSJ8yZYoNHDjQ3n33XStRooRNnTrV0qdP70vADxkyxCZMmGB//vmnVa9e3YYOHep77vbt29uxY8esa9euFhYWZs2bN7e2bdsG8NUCAAAAAAAAAIJR0CbRpVixYjZz5sxot5UtW9YWLlwY42ObNm3qLtFR4rxPnz7uAgAAAAAAAABAkivnAgAAAAAAAABAoJFEBwAAAAAAAAAgBiTRAQAAAAAAAACIAUl0AAAAAABgHTt2tGeffdZ3ffv27da6dWu3Jtndd99tq1evDuj+AQAQKCTRAQAAAAAIcUuXLrUVK1b4rp88edLatWtnRYsWtcWLF9vtt99uXbt2tWPHjgV0PwEACASS6AAAAAAAhLDjx4/bqFGjrEyZMr7bFi5caOnTp7dBgwZZgQIFrHv37u7n5s2bA7qvAAAEQqqA/FUAAAAAABAURo4caY0bN7bffvvNd9t3331ndevWtbCwMN9t8+fPD9AeAgAQWIxEBwAAAAAgRH377bf2/fffW+fOnSPdvnfvXsuaNas999xzVr16dWvZsqWtW7cuYPsJAEAgMRIdAAAAAIAQdPbsWRs4cKANGDDA0qZNG2nbqVOnbOrUqdamTRt77bXXXM309u3b20cffWS5c+eO9vlSpw6zFCkSaecRa+Hh/z+bAMGFYxPcOD7BKzwAx4YkOgAAAAAAIWjixIl24403Ws2aNS/bpjIupUqVcrXQpXTp0vb111/b+++/b4899li0z3fu3IUE32fEXUQExyVYcWyCG8cneEUE4NiQRAcAAAAAIARpdPnRo0etQoUK7npERIT7+fHHH7vkeuHChSPdv2DBgnbw4MGA7CsAAIFEEh0AAAAAgBD05ptv2vnz533Xx4wZ43726NHD3nvvPVu7dm2k++/evdsaNWqU6PsJAECgkUQHAAAAACAE5c2bN9L1DBkyuJ8FChSwVq1a2ezZs+3ll1+2e+65xxYtWuQWG23cuHGA9hYAgMBJGcC/DQAAAAAAgjTBPm3aNPviiy/c6HP91EKjuXLlCvSuAQCQ6BiJDgAAgKCVY1IbSyqyW3A70mVWoHcBQJB74YUXIl2vWLGiLViwIGD7AwBAsGAkOgAAAAAAAAAAMSCJDgAAAAAAAABADEiiAwAAAAAAAAAQA5LoAAAAAAAAAADEgCQ6AAAAAAAAAAAxIIkOAAAAAAAAAEAMSKIDAAAAAAAAABCDVDFtAAAACBUPvvpVoHch2Zj92K2B3gUAAAAAiFeMRAcAAAAAAAAAIAYhm0Q/e/as9e3b1ypVqmQ1atSwGTNmBHqXAAAIacRmAAAAAEAwCtlyLqNGjbLNmzfbG2+8YQcOHLDevXtbnjx5rH79+oHeNQAAQhKxGQAAAAAQjEIyiX7q1CmbN2+evfbaa3bDDTe4y44dO2zOnDmcqAMAEADEZgAAAABAsArJci7btm2z8+fPW4UKFXy3VaxY0TZu3GgXL14M6L4BABCKiM0AAAAAgGAVkkn0I0eO2LXXXmvh4eG+27Jnz+5qsR4/fjyg+wYAQCgiNgMAAAAAglWKS5cuXbIQs2jRInvppZfsiy++8N22d+9eq1evnq1YscKuu+66gO4fAAChhtgMAAAAAAhWITkSPU2aNBYRERHpNu962rRpA7RXAACELmIzAAAAACBYhWQSPVeuXPbHH3+42qv+08h1kp4pU6aA7hsAAKGI2AwAAAAACFYhmUQvVaqUpUqVyjZs2OC7bd26dVamTBlLmTIk3xIAAAKK2AwAAAAACFYheVaaLl06a9KkiQ0aNMg2bdpky5cvtxkzZlibNm0CvWsAAIQkYjMAAAAAIFiF5MKicvr0aXei/sknn1jGjBmtffv21rZt20DvVpJ18eJF+/jjj+2vv/6yFi1aBHp3ACBo7Nmzx7777ju77777Ar0rQY/YHP+IzwBwOWIzAonYDABJMz6HbBId8evQoUNWq1Yty5Ahg61du5ap98nchQsXLEWKFBxn4F8oxM6ePdvGjh3rGgPh4eGB3iWEGOJz6CA2A7FDbEagEZtDB7EZSF7xmU8yYu3w4cP2+uuv24cffuj+uf3t3bvXrr/+ehckfvzxx4DtIxJHWFgYDYEEpM+RLkgatBDmtGnT3AmR/wijc+fOuUazanpfd911tn79+oDuJ5Iv4jOE2JywiM1JC7EZgUZshhCbExaxOek5n8TjM59mxOjgwYM2a9Ysa9q0qW3evNnmzZtnL7zwgo0aNcq2bdvm+wB4982VK5cVL17cPv/88wDvOa6WGno6ttFNVPnzzz/tyy+/dCUW3nrrLYJWAjW2dEHSoGO1evVq++2333y3qbGcOnVq93vatGmtYMGCtmLFigDuJZIT4nNoIjYHFrE5aSE2I7ERm0MTsTmwiM1JT1gSj8+pAr0DCB6nTp1yQVxf9Or1OXDggJUvX95dChcubEeOHLGyZcva1q1b7Y033nCNglSp/vsvpNq16klSTTcaAkmfegC9Y6seQe8LbeXKlfbmm2/a0aNH7aabbrKqVasStGJJgUKNpwkTJvgaUP7vnRpeet9///13VyNxzZo1VqJECbvnnnssb968AdxzREfHSz3m3nFUb7o/1bh88cUX3eij0qVLu0a06n0DV4L4DCE2xz9ic/JCbEZiIjZDiM3xj9ic/FxKRvGZJDqcBQsW2NChQy1r1qyuRzxdunT2xBNP2OOPP+67j3qDNK3i2muvtR07dtiiRYusSZMmbpsCh7arR109SidOnLBMmTIF8BUhtl9k0QVzNfpmzJjhGnVFixZ1NfvUyNPv+jI7e/as9e/fP9oed0Tv+PHjrkHw66+/uumbUakhsGnTJreooug+CxcudI3y1157LQB7HNr279/v/r/z5cvnPidRp2HqeHmfHTWYT5486Y7TU0895Wq3ffHFF/btt9/ayJEjXWNa368adaT/gyxZsgToVSEpIj6HFmJz4iI2Jy3EZgQLYnNoITYnLmJz0rM/hOIz5VxChPelrS+iyZMnW7t27WzgwIH22Wefudvr1q1rn3zyibs+ceJEq1y5sm3fvt1t83r/FOi1+IkaCzfffLPNnz/f1XoT3Vc97WoIqBGhRQAQfP8DOpbe/4L/F5l6cT26zzvvvOPq86khWKVKFdeL/tJLL1nu3LmtVKlSvvvqOfDP9dm897tYsWIuqHzzzTcuGAwZMsRN7/TqIKr3VYto5MyZ0zXMx48f73rf1YDwPotIvBXBn332WdcgFq/X3N/PP/9s33//vT300EN255132rFjx2zmzJn2008/ue3Tp093jehbb73VfV/qeGfOnNkdf8Af8Tm0EZsTF7E56SI2IzERm0MbsTlxEZuTtj0hFp9JoocIfWlv2LDBunXr5oJ0xYoVXQ+4esz1haN/0Bw5crj7KkDoS0tTzBQkdN1bVbpQoULutpo1a7r7eh8UfZGpF7ZChQrusV999VVAXy/+++WlS9Tgr59nzpxxt48bN84ds4cfftjeffddd78//vjDBf/Ro0e70RLa1rBhQ3vllVfcsddCD+ot/M9//uPuT6/6f+m99q9z59Vn8xpMGoVyww03uFEo6llVo/yXX36xRx991NauXWvp06d329UA02fv7bffdr3r6qnV6BUkPO9/WQ0yNXq9xU70Xanedf9Gs45h79693QmQvkM12kTTCL/++mvfY3RMPRqlVK5cOTe1E/BHfA4txObERWxO+ojNCARic2ghNicuYnPycClE4zNJ9BARERFhAwYMcL3mmjbRpUsXe+655+zpp5+2v//+2138PwgK+Prd6+3zepP04VD9NwUTfWmp/pT+sfVPrt6kNGnSuC80Ta9BYHjHUFNodFEw0vFXQ0294jVq1LAHH3zQ1RnTFBkFedVoe/7559199u3bZ9myZbO5c+e6hoBGVqihcPfdd7upNaozplEVGzdujLGnMRRre+m99p/ip/qI+pypV1Y9r950TzXI1ZhSHTDV/brjjjvccVGQ0futz5BGvGg62mOPPebefz2XtxARrpw+Bxot8umnn7rrURf38Rpu+v8uUKCAq8WmRpn+9xs1auROnDTqSG6//XZX41DH9MYbb3SP1egT9ZarAadGwQ8//OB77muuucZ9r3q97YCH+BwaiM2Jh9ictBCbEYyIzaGB2Jx4iM1JD/E5eiTRk9GXUqtWrSL94/lTb7f+adUQ8Ba7EK0U3adPH/eP70/Tz9QDqC8k/w+I/rl1X92uaRaabqEpbKrlpkaC9kMfCtV1U1BB/Nm7d6/7EtKUJv9pZjF9me3evdstYLN8+XJr3769jRgxwvUOqhcwe/bs7melSpWsWrVq1rFjR3ebRkHoC0vP+dFHH7lRE1OmTLGlS5e6wLRlyxYrWbKkm3roNfai1rtKLvRl7s97v/0bP3qvvdevXnE1tlXHa9euXTZv3jz3PmnkQa9evdxx02gEBft7773XPUaNAo1aUK081QBToFLNPI1qUMNAU5q0EI3ed32mcHX0fqthq2Ct9zy6uobvvfeeGyWUJ08ed2w1zaxly5ZukRPVtXz55Zfd/74+O6q/5/9/ouOlY6UTK30/asqad5LljWhSA1wLTyF0EJ+TN2Jz4iI2Jz/EZgQCsTl5IzYnLmJz8kR8jl7y/BSHIC8A6B8vOvqnV10u/ROvWLHC1W/Tl4++tBRkotJ9NbVs27Zt7rq34rSmaugDorpH+gdXfTj1ro8dO9Z98Wk/NLVNX5iqSYWrpyC0ePFi13unWno6lv7TzKJ+makxqOCuun07d+50q8Nr6plWrlZgqV27tj3yyCNu1WMvsGlKou6jxoa+3NQQvO2226xDhw7uMQqCmsKmnl1Ns9H/hr7UtC/Jqb6beq01kkC93GpESdRpfVEbPxqRoh5XNZr0mdBn66677nLvpxoHPXv2dKNPFHxU302jTbxRKqLPkz5v+kwpQKhW4pNPPuka1PpsLlu2zN2uxTYQO5o+Vr16dTf1L+rIBwVonRQpIGsUgwK8jo9n69atbtqu/v91rPVY1W7TMRo8eLDrEVdjokiRIq7hrAa29z+i6Wn6ffPmza73XZ8lfRb1nasGtffZ5ViGFuJz8kRsTjzE5uSB2IxgQmxOnojNiYfYnHwQn+OGJHoy0qZNGxd8vX82f/on1hQZNRQ6derkplaol1VTLZo1a+Z6xMX7YtcXvlfDzesV96bFaAqGvvT0gdFKuerF1zZ9sETB54033rDmzZtT9yseKBBrwQz16CngqMGl91VfXh988IE7nj169PAtSKPAri8n9fJpkQ0dD31BKRB5KxvrC0q3e0FJIyz0xann0O9qMKjhob+r3l1NPdRUGq+enwJV/fr1I32BJjVRRyKIgoUayF7dNf/PhN5T9bJ27drVTev0/t/1GAUIjSxRg7hz586uMaWeV1G9L73XmrqpkShqhK1bt873NzVdTaNddNx0XBR8NEVw+PDhriGh91mNC/UER+3lD3UagaA6at4oEy/Y6/tL75car/63e/+7anDpMWrQqsG2ZMkSt03/z1rcSSc8Og4aAaEpmh49rz5L+k7U39ZnSo04jSYSNQy03Qv0qo+ov6eGuRbDUY1EjbTQZ5nvxtBCfE5+iM0Jg9ic9BGbkVQQm5MfYnPCIDYnD8Tn+EESPRnR9CJNlfAv4O+vTp06rrdvzJgxrt6U/jH1JaapFWoIeKuNe1+SaggoMHg1vLx/XPUiqTdKPUaif27VStK0Jd3Hq4kkyam3NTFEnWqmBpZGMihQKBAoOOsY632dNWuWC0qaJqbrOqZTp051gUfHSPfPmDGjex5vOpR6GUWBSgFLAU8NR33p6QtLf19TatS4UwNRPcUKRnru+++/39UZE/Xuq2Gp/Upq9Bo1LUwLVXijRbzbFTxUn1BT9BT8vcUxVq1a5UYXaMSB3ketBq7Pj/deaASJGshSvnx5y58/vwsQovdIwcGbxqfGgIKXprGJRj1oiqd62nUcVGtPvexqkGjKmnpj1TDwauuFOjVg1cjV/6XeV0299KZ4eaMdMmXK5Bq3Xv02fRa8xoCm5eozpefRd6JGBL366qvu5CZt2rSu0avPj/cdqM+Q/yrvarzp+U6ePOlGTei70H/6rY6/Rq+IPptaQOX99993Per6TOlzp+PId2NoIT4nbcTmhEdsTtqIzUiKiM1JG7E54RGbkz7ic/z77zwjJAv6B9UXu75c1HseHX0xaaqEv/vuu88FcX1o9CHRB0bTb9S7py9FTadRj573j6ugoVpw+vIS1X/TBVfPm/rk0ReWgrOC0enTp11jTV98WnVavevqpbvnnntcL6BqsWnBG41i0CINCjBqVOj51AuvY6ngrxph+qLUF5KeV198mnqm7fr/UINDAatv375uYQ/9T+kLLTm9x+oh1WgQjfpQD7iCtxpe+oJWY0rvkRrUajzpc6Xgr/97vfeiYN69e3fXi1qxYkX3nFpIQ/S5UePAa2ip8aBedU3d1Pup4KXPiwKEGiR6rhYtWrgGm+i9HzJkSEDfo2Dz+eefu/dejTP1YotGNqiBquMTlf7nNfVMI05EAV50jDTiSMdGnyEFf41IUaDWdF01enUsvZEiOpY6hhqFpJqWoqmCGmWiz4sagGoEqFGp/wPRlM+mTZv69kWNE32uvGlx3qJFCC3E56SN2JzwiM1JD7EZSR2xOWkjNic8YnPSRHxOWIxET2YUsDWFKLrpDppGo8L/Xs+e94FSr5B6EhUg/Gu4KYAoYGgahv/tmrKhnntNv0DcRbfQhkfHQosxPPDAAy7YaCqTVvVWb66+8LQqtXoAvZ5eNQS8Lzr1EuvYKLhoqowCm/9iOWq4+S/MoC85BUD18olGQWh6jvec+rJSb2Jyagh4Wrdu7d4rfYlripDo/dJ7o/dBi1x4vaR6H/T/roWEFARef/11F5QURNSQ0ugENS4UWNRg0xe9PjcKFlqkRnQM9XlRY1sND/W4qjdYf0fHtF+/fq7RAHNTxRT4/f939Z42aNDA1UZTo1fvoUYB6TMR09QuNaq07c0333TH684773Tvt0YsqLGmhp4aZ2o0PP74424hGzWwtciTN/1P//86thMmTHANQtXZ0+dLDW7vb6gxqWmcHu2THhdTQz/YGgFIPMTn4EZsDjxic/AiNiO5IjYHN2Jz4BGbgxvxOfGRRE9m9EWu2lTeqrb+HxJ9mLTog1ab1heXgpF6l9SDqjpH+oIU7x9VX45a/EFfVIg//gttqJfVfwqaenj1ZaPgowCi2l7artEO6pHTNEAdUzXi1FBTb7t/o06BW1Nt1BhQkNJICI+mz6gX0ZuKpcaARlLoy9Fr6Gk0hXp8kzu9F/r/1mtX41gBQfQe64teDSs1jjUyRcdLDQEF+smTJ7v3T58J9a5qVXbRiAQdG6++mIKJemS96ZzqQVftNzWqFfRV70srjzdu3NhNnQpFUQO4TlA0HVLvkxpIQ4cOdY1g9WbrOD311FOuAaAgq/dQ763+72MKrArIem81pU+NbD2Xes0XLVrkVnLXbd7iKfXq1XONbDUENJ1QIx1EPeb6nKiBqBMsTUVU8NcICI+mmWkaIfBviM/BjdgceMTmwCM2I9QQm4MbsTnwiM3BgfgcPCjnkszoH1i9QqpPpXpE3odEAUUF/5955hm3MIoCvHph9WWn23VbdD1AuDJegPemmOlLT8dCjS8FDH0hqZdPDQL1zKl+l+6rLyItjuFNG9Q2bzSDesQVcNSA0Crf6uVTsNcXkwK5vhR1X33BKaipYaDFIdQzLwryWjVZDQXRYin+X2ihREFCwVpTzRS4VSdP75PeEzWidSz0fnkLX+g4acqfpo5pypEaAnqsV9tQC8eoga0eeU0H1TQ0Nda8XnL9PS1i4wn1Gm1aEEbfT97nQv+zqtVWtWpV1wjQ+6X39uGHH7Zp06bZo48+6hpnXq1DHQeNZtD0QQXr6Oj5NWVMwV6NAX/6bOgYe41A3ffBBx+0xYsXu558TXfz6NiqcaLHeLUSo/JeB/BPiM+BR2wObsTmwCI2IxQRmwOP2BzciM2BR3wOLiTRkxkFAwUCfUj0AVF9ql27drkVb9Uj5a0erdWk1VhQzyINgLg5cuSIffjhh+4LRj3dmt6iLyj/6Sb+9dn0JedN39PUF32hKbiotpdGNWhhGvWeawEMBRkFJvXU6lgqUGnEg3psa9So4abTKOAo2OjYqUGhOm4KXKpXpUag6r2Jviy9lZD1N/UlprpV+C9NcVL9u/bt27sgpACgaUt6LxVg1KjWe6rPiXrT1XhQgNCxUq+6jpF6erVoio6NpjF59cDUIBg3blygX2LQUANWU8nUk60plQrQmj6rXmz9b6pnXJ8rXdd7p8CqOmlz5851I0N0H/E+X+olV8NZDbWYGgL6DGramhYR8hoQoufWZ0ELOGmEiaYfes+hRvmkSZPcMffu6y0K5In6WfffL+CfEJ8TFrE5eSA2Jx5iM0BsTmjE5uSB2Jy4iM/BjSR6MqRpHeqRUs0qTVHSF5R6CtVTJapppZ5VxI6Cqeqf6ctfwUH10TQ15o477vAtuuB9yXj31wrDWnVdPbL60tMXjBZr0JebgoRGMyjw6KL6UvqCVGNAtdXUGNAXkWqDKUApyLz00kuuV0+rw6temHrFFZg0LU0LmeiLSNMK/aeZaXqipj0helrBW58TNQYUgBR0NH1MgV9TjNSg1ggINbB0nBTMNE1KgUqfK73XCmp679Vw07FK6gEhobz11ltuOqwCuAKrpl5qWp4a0/o/VgNXwV4nLqL/fV3XqAWPgrLXyNZnSZ8FBXKNKImJGs0K+hp5oh5xHU/veXQCpM+1f0NAo1R03NVIEO94+veW+3/WgbgiPscfYnPyRGxOPMRm4L+IzfGH2Jw8EZsTF/E5uCW/VwS38MKMGTNcT6umWSiIeL1RiJthw4a5RRHUo6epe+rx8xZn8A/+aiToosCiQDF9+nQXYNq1a+cer1pec+bMcT3jWsVaz+dR8FatMD2PenM1LU3TlvRlqODUsGFDt8Kxjqe+qNQLrB5c1ZqaOnWqW0RF99WXo6ZCeQhM/0w95mpMKRCopqHeYwUGTYVSY1nTohQUdLsaVvpMaXEU3f+hhx5yPfL+nyve7+ipXptW+tb0MtVAE9Uu1DRL9UzLLbfc4hrbWu1bAVqBWe+tPhMaOaLPkU5mvKCsz4FGsmileI0Q8hrlUel+mkqm2pVeQ8BrTGh1cn0/6nOkaaQ6ruvWrXONC0379MexRXwhPscPYnPyRWxOHMRm4P8Rm+MHsTn5IjYnHuJz8COJngypB0kBA1dPXxYK8OpFVe+46n8pgKgxoC+kkSNHuul9uq6VpdU7rilrCupebSj15qkHXdNu1DuoKWreKuGiXnb14upLTc+jGmJqzKm+m/6mvqS83j31RPoHIE1vY2TElVEvuILLhg0bXINLx1r12fR+q9GnRTHUYNB7rOOjgKKVqhE3qmWoaX5qrPrzryuowKuRIXqPtbK4etfVGNPj1ODVtNo+ffq4+2mEiT4Daljrs6iGsD6f0VFtPS36s3379st6wr2pol7vukZEaIrok08+mewDPwKH+Bw/iM3JF7E5cRCbgf9HbI4fxObki9iceIjPwY8kOvAP1PvtHzwUIFatWuWmKenLQtPD1Mt6++23u7ptqvXVtGlTN61JPd2anqYV3/VlqGCvXkR9mWlRBk2/0Zedeg41dU29id26dXNfaqpFpaloCkp6PvWgi74MEX8UjFTzUFMMNbJBPeo6VuphFW9xGVw51VZTY0qBXtNi1fOdKVMm93lSnTw1kNXg0mdGDWjdVyMaRA2Bzz77zI1K0edO02096h3XZ0zTRGNqCIhWiI8NrTCuz3FMdeIABA9ic/JGbE54xGYA8Y3YnLwRmxMH8Tn4kUQHYklTxDSNRjWpPJoqpi8x9ex5vXcK+EuWLHH3K1KkiJsOM2TIEFu7dq1bobp8+fIuAHk9hqLbdD81BhTwtXCKvuDUgx7Tqsa4evriHzt2rJv6pJ5Wb3EZxB8FfE27VKNZC5qozqQa0urFVsDXiBXVd1MDQHULNYpBdEzUYNCUM32WvMaBN6JEn7m9e/fazp07fZ+/mGiUhP+iRf68nnP/KZ0Akg5ic/JDbE54xGYACYnYnPwQmxMH8Tn4pQz0DgBJhb6ANGVGPXxaYVzUO65eQNUD82j6jL7wNDVQX3KqD6YeRE2LUYBX76Kmr6mH3aMpUeq99abH6O/oC5CGQMLSwhqqw6dghYSj2njqEdf0Mi2UsnjxYnv55Zfd9EstTKNRJ6qrpgVTVFvNP+BrYRNNU9P0TY/qs6lhoGOn6Zv/JqZGAICkj9ic/BCbEwexGUBCITYnP8TmxEN8Dm6MRAfiQLXX1AuuLydNUVNPnKbZfP311y7wi1YI16IPmmqj3kB9yal+mHoHtYJ4z5493TQzLQLh0fQ2XYDkSg1djUDxqLGsEQ133323q3WoRZxUw1DTOxs3buw+X/rsqOE9YMCASAuWaBRL1OcDELqIzcCVITYDSCjEZuDKEZ+DV4pLejcBxIoWYtAq4JpWM2HCBHfbp59+6mpWqS6YemZV301Ty3766SfXWPj777+tQ4cOroaVvtxUxw0IJVro55VXXnGL//gvSqKRJaqvp8+Uauuprp4+T2oAaFuZMmVcb7mmbQJATIjNQNwRmwEkJGIzcGWIz8GNJDoQB6oPpak1mlajxU+8HvTq1au73nKvd08Ngo8++shNhVEvoVazBkLVX3/9ZU2aNHGjSFq2bOmml6kemz5HmrbZu3dvN3VTveT/VocNAKIiNgNxR2wGkJCIzcCVIT4HN8q5AHGgLyf1iGuK2aZNm6xs2bKWLVs2t6CD6rZ5tFCKvvgAmKtROGLECFeHTSNR1Gt+6tQpt6p3mzZtLqutp8+ZarfposaB10AAgOgQm4G4IzYDSEjEZuDKEJ+DGyPRgVjSR0XTzLQKslZM1lSapk2bBnq3gCRl48aNblpa4cKFA70rAJIBYjNw9YjNAOITsRmIH8Tn4EMSHYgjTZdRo8BboEG/A/h3UT8v/p8lALgaxGbgyhCbASQUYjNw5YjPwYkkOgAgUdGIBgAguBCbAQAIPsTn4EISHQAAAAAAAACAGDAPAAAAAAAAAACAGJBEBwAAAAAAAAAgBiTRAQAAAAAAAACIAUl0AAAAAAAAAABiQBIdAAAAAAAAAIAYkEQHAAAAAAAAACAGJNEBAAAAAAAAAIgBSXQAAAAAAAAAAGJAEh0AAAAAAAAAgBiQRAcAAAAAAAAAIAYk0QEAAAAAAAAAsOj9H6WBUySSO8c7AAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 1500x400 with 3 Axes>"
       ]
@@ -2563,12 +2706,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
       "Analyse:\n",
-      "  - Mamba offre un bon compromis paramètres/performance\n",
-      "  - SST Hybrid capture à la fois long-range et short-range patterns\n",
-      "  - Sur des séquences plus longues (>256), Mamba surpasserait le Transformer\n",
-      "  - LSTM reste compétitif sur séquences courtes\n"
+      "  - Aucune architecture ne bat le hasard de facon significative : toutes les\n",
+      "    accuracies (50.9% a 53.3%) sont dans la bande de bruit autour de la\n",
+      "    baseline majoritaire 52.4% (bruit d'echantillonnage ~2.4% sur 450 points).\n",
+      "  - LSTM est marginalement devant (53.3%) mais l'ecart reste dans le bruit.\n",
+      "  - La contrainte est le signal, pas l'architecture : |trend| <= 0.1% par jour\n",
+      "    contre un bruit de 1.5% (~1:15 a 1:50), donc une prevision au mieux ~52-53%.\n",
+      "  - Sur des sequences plus longues ou un signal plus fort, l'avantage Mamba en\n",
+      "    complexite O(n) vs O(n^2) deviendrait visible ; ici les 4 modeles plafonnent de meme.\n"
      ]
     }
    ],
@@ -2610,11 +2756,15 @@
     "plt.tight_layout()\n",
     "plt.show()\n",
     "\n",
-    "print(\"\\nAnalyse:\")\n",
-    "print(\"  - Mamba offre un bon compromis paramètres/performance\")\n",
-    "print(\"  - SST Hybrid capture à la fois long-range et short-range patterns\")\n",
-    "print(\"  - Sur des séquences plus longues (>256), Mamba surpasserait le Transformer\")\n",
-    "print(\"  - LSTM reste compétitif sur séquences courtes\")"
+    "print(\"Analyse:\")\n",
+    "print(\"  - Aucune architecture ne bat le hasard de facon significative : toutes les\")\n",
+    "print(\"    accuracies (50.9% a 53.3%) sont dans la bande de bruit autour de la\")\n",
+    "print(\"    baseline majoritaire 52.4% (bruit d'echantillonnage ~2.4% sur 450 points).\")\n",
+    "print(\"  - LSTM est marginalement devant (53.3%) mais l'ecart reste dans le bruit.\")\n",
+    "print(\"  - La contrainte est le signal, pas l'architecture : |trend| <= 0.1% par jour\")\n",
+    "print(\"    contre un bruit de 1.5% (~1:15 a 1:50), donc une prevision au mieux ~52-53%.\")\n",
+    "print(\"  - Sur des sequences plus longues ou un signal plus fort, l'avantage Mamba en\")\n",
+    "print(\"    complexite O(n) vs O(n^2) deviendrait visible ; ici les 4 modeles plafonnent de meme.\")"
    ]
   },
   {
@@ -2622,10 +2772,10 @@
    "id": "ea82a7bf",
    "metadata": {
     "papermill": {
-     "duration": 0.011737,
-     "end_time": "2026-05-04T23:47:57.818839",
+     "duration": 0.008126,
+     "end_time": "2026-08-23T01:44:12.393689",
      "exception": false,
-     "start_time": "2026-05-04T23:47:57.807102",
+     "start_time": "2026-08-23T01:44:12.385563",
      "status": "completed"
     },
     "tags": []
@@ -2655,20 +2805,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "7193495f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:47:57.840510Z",
-     "iopub.status.busy": "2026-05-04T23:47:57.840311Z",
-     "iopub.status.idle": "2026-05-04T23:47:57.855615Z",
-     "shell.execute_reply": "2026-05-04T23:47:57.855020Z"
+     "iopub.execute_input": "2026-08-23T01:44:12.411165Z",
+     "iopub.status.busy": "2026-08-23T01:44:12.410172Z",
+     "iopub.status.idle": "2026-08-23T01:44:12.428694Z",
+     "shell.execute_reply": "2026-08-23T01:44:12.427659Z"
     },
     "papermill": {
-     "duration": 0.026333,
-     "end_time": "2026-05-04T23:47:57.856351",
+     "duration": 0.028069,
+     "end_time": "2026-08-23T01:44:12.429718",
      "exception": false,
-     "start_time": "2026-05-04T23:47:57.830018",
+     "start_time": "2026-08-23T01:44:12.401649",
      "status": "completed"
     },
     "tags": []
@@ -2707,10 +2857,10 @@
    "id": "ef74f6a8",
    "metadata": {
     "papermill": {
-     "duration": 0.009179,
-     "end_time": "2026-05-04T23:47:57.874101",
+     "duration": 0.006883,
+     "end_time": "2026-08-23T01:44:12.449441",
      "exception": false,
-     "start_time": "2026-05-04T23:47:57.864922",
+     "start_time": "2026-08-23T01:44:12.442558",
      "status": "completed"
     },
     "tags": []
@@ -2731,20 +2881,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "258b7799",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T23:47:57.894744Z",
-     "iopub.status.busy": "2026-05-04T23:47:57.894418Z",
-     "iopub.status.idle": "2026-05-04T23:47:57.901200Z",
-     "shell.execute_reply": "2026-05-04T23:47:57.900660Z"
+     "iopub.execute_input": "2026-08-23T01:44:12.468317Z",
+     "iopub.status.busy": "2026-08-23T01:44:12.467313Z",
+     "iopub.status.idle": "2026-08-23T01:44:12.475746Z",
+     "shell.execute_reply": "2026-08-23T01:44:12.475746Z"
     },
     "papermill": {
-     "duration": 0.018237,
-     "end_time": "2026-05-04T23:47:57.901966",
+     "duration": 0.019123,
+     "end_time": "2026-08-23T01:44:12.476895",
      "exception": false,
-     "start_time": "2026-05-04T23:47:57.883729",
+     "start_time": "2026-08-23T01:44:12.457772",
      "status": "completed"
     },
     "tags": []
@@ -3086,10 +3236,10 @@
    "id": "b8efdbe7",
    "metadata": {
     "papermill": {
-     "duration": 0.011033,
-     "end_time": "2026-05-04T23:47:57.921926",
+     "duration": 0.00853,
+     "end_time": "2026-08-23T01:44:12.494411",
      "exception": false,
-     "start_time": "2026-05-04T23:47:57.910893",
+     "start_time": "2026-08-23T01:44:12.485881",
      "status": "completed"
     },
     "tags": []
@@ -3150,6 +3300,21 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0,
+   "cpu_min": 90,
+   "external_account": "quantconnect-free",
+   "free_alternative": null,
+   "gpu_required": true,
+   "metadata_written": null,
+   "network": true,
+   "reduced_pedagogical": "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb",
+   "reproducibility": "MEDIUM",
+   "validator": "manual",
+   "vram_gb": 12,
+   "vram_tier": "T4-or-better"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -3165,36 +3330,21 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 165.523107,
-   "end_time": "2026-05-04T23:47:59.287513",
+   "duration": 191.361386,
+   "end_time": "2026-08-23T01:44:13.509263",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb",
    "output_path": "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb",
    "parameters": {},
-   "start_time": "2026-05-04T23:45:13.764406",
+   "start_time": "2026-08-23T01:41:02.147877",
    "version": "2.6.0"
   },
-  "qc_reference": true,
-  "cost": {
-   "api_usd_est": 0,
-   "api_provider": "none",
-   "cpu_min": 90,
-   "gpu_required": true,
-   "vram_gb": 12,
-   "vram_tier": "T4-or-better",
-   "network": true,
-   "external_account": "quantconnect-free",
-   "free_alternative": null,
-   "reduced_pedagogical": "MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb",
-   "reproducibility": "MEDIUM",
-   "metadata_written": null,
-   "validator": "manual"
-  }
+  "qc_reference": true
  },
  "nbformat": 4,
  "nbformat_minor": 5


### PR DESCRIPTION
## Summary

Bug priority-high #12430 : l'entrainement de `QC-Py-23-Attention-Transformers.ipynb` etait **mort** — `Train Loss=0.0000, Acc=0.00%` et `Val Loss=0.0000, Acc=0.00%` sur les 20 epochs, puis un test à 52,44 % presente sans commentaire. Diagnostic = **cause racine dans les DONNEES, pas le modele** : la feature volatilite `pd.Series().rolling(5, min_periods=1).std()` laisse NaN au premier element (std ddof=1 d'une seule observation), la z-score normalisation propage le NaN a toute la colonne `vol_norm` → features NaN partout (`np.isfinite(X).all() == False`) → logits NaN → le garde `torch.isnan(loss): continue` saute **tous** les batches → `train_loss = 0 / max(0,1) = 0.0, train_acc = 0/1 = 0.00%` et `best_model_state` reste l'**init aleatoire** (52,44 % = classe majoritaire constante 236/450). Les 4 architectures du benchmark a exactement 0,524444 = meme predication constante.

## Fix (2 points)

1. **Data** : `volatility = ...rolling(5, min_periods=1).std().fillna(0.0)` (volatilite t=0 inconnue → definie comme deviation 0). Seul point de NaN de la chaine (verifie sur toutes les features).
2. **Garde NaN honnete** : le `if torch.isnan(loss): continue` COMPTE desormais les batches sautes (`train_skipped`/`val_skipped`) et la division de metrique est reelle (`... if train_total else float("nan")`) au lieu de `max(0,1)`. Un entrainement mort devient un echec **visible** (nan + avertissement), plus jamais un « 0.0000 » maquille.

## Resultats mesures (papermill python3, 46/46 cellules, 0 erreur, 3:11)

- **Mamba** : train loss 0,693 → 0,673 (decroissante), train acc 51,1 → 59,5 % — l'entrainement vit
- **MAIS surapprentissage net** : val acc ~49,8 % (hasard), val loss **remonte** 0,694 → 0,715
- **test Mamba : 48,00 %** (SOUS la baseline majoritaire 52,4 % ; f1 0,48/0,48)
- **benchmark** : LSTM 53,3 % / Transformer 52,2 % / Mamba 50,9 % / SST 52,2 % — tous dans le bruit d'echantillonnage (~2,4 % sur 450 pts) autour de la baseline 52,4 %
- Cellule **Interpretation** ajoutee : signal `|trend| ∈ [0,03 % ; 0,1 %]` par jour vs bruit 1,5 % (~1:15 a 1:50) → plafond previsible ≈ 52-53 % ; le bug corrige etait la loss morte, la faible performance est un **resultat financier valide**, pas un echec de code
- Prose « Analyse » du benchmark mise a jour (honnete : aucune arch ne bat le hasard ici ; l'avantage Mamba O(n) vs O(n²) se verrait sur sequences plus longues / signal plus fort)

## Validation

- 0 `Loss=0.0000` / `Acc=0.00%` dans les outputs committes
- Courbe loss/metric coherente avec l'eval finale (train vit, mais generalisation ~hasard — dit explicitement)
- Cellule d'interpretation du niveau de performance reel vs hasard : presente
- Re-exec CLEAN par papermill kernel python3 local (non-quantbook, pre-vol verifie) : 46/46, 0 erreur, C.2 (exec_count + outputs), 3 exos C.1 intacts
- **Point 4** (voisin QC-Py-22) : verifie — **sain**, losses decroissantes reelles (0,083→0,013), aucun pattern de loss morte → non modifie
- Verdict SOTA : **SOTA-OK** — PyTorch (l'outil reel) entraine pour de vrai, pas de workaround degrade

Closes #12430

lane: myia-po-2026:CoursIA · Grain: bugfix/notebook-python · prev: notebook-python (#12458)

🤖 Generated with [Claude Code](https://claude.com/claude-code)