### PR TITLE
feat(ml,#12442): CV stratifiée + temporelle — KFold naïf trompeur vs StratifiedKFold/TimeSeriesSplit

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
@@ -5,10 +5,10 @@
    "id": "a50c0001",
    "metadata": {
     "papermill": {
-     "duration": 0.019877,
-     "end_time": "2026-06-25T11:44:22.141434+00:00",
+     "duration": 0.003149,
+     "end_time": "2026-08-23T02:18:59.367309",
      "exception": false,
-     "start_time": "2026-06-25T11:44:22.121557+00:00",
+     "start_time": "2026-08-23T02:18:59.364160",
      "status": "completed"
     },
     "tags": []
@@ -47,16 +47,16 @@
    "id": "a50c0002",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:09.158940Z",
-     "iopub.status.busy": "2026-07-03T18:23:09.158940Z",
-     "iopub.status.idle": "2026-07-03T18:23:11.022933Z",
-     "shell.execute_reply": "2026-07-03T18:23:11.022306Z"
+     "iopub.execute_input": "2026-08-23T02:18:59.374425Z",
+     "iopub.status.busy": "2026-08-23T02:18:59.374156Z",
+     "iopub.status.idle": "2026-08-23T02:19:01.154761Z",
+     "shell.execute_reply": "2026-08-23T02:19:01.153827Z"
     },
     "papermill": {
-     "duration": 3.479595,
-     "end_time": "2026-06-25T11:44:25.640281+00:00",
+     "duration": 1.785676,
+     "end_time": "2026-08-23T02:19:01.155762",
      "exception": false,
-     "start_time": "2026-06-25T11:44:22.160686+00:00",
+     "start_time": "2026-08-23T02:18:59.370086",
      "status": "completed"
     },
     "tags": []
@@ -96,10 +96,10 @@
    "id": "a50c0003",
    "metadata": {
     "papermill": {
-     "duration": 0.007193,
-     "end_time": "2026-06-25T11:44:25.677505+00:00",
+     "duration": 0.00304,
+     "end_time": "2026-08-23T02:19:01.161850",
      "exception": false,
-     "start_time": "2026-06-25T11:44:25.670312+00:00",
+     "start_time": "2026-08-23T02:19:01.158810",
      "status": "completed"
     },
     "tags": []
@@ -123,16 +123,16 @@
    "id": "a50c0004",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:11.024543Z",
-     "iopub.status.busy": "2026-07-03T18:23:11.024543Z",
-     "iopub.status.idle": "2026-07-03T18:23:11.040330Z",
-     "shell.execute_reply": "2026-07-03T18:23:11.040330Z"
+     "iopub.execute_input": "2026-08-23T02:19:01.168987Z",
+     "iopub.status.busy": "2026-08-23T02:19:01.168687Z",
+     "iopub.status.idle": "2026-08-23T02:19:01.204955Z",
+     "shell.execute_reply": "2026-08-23T02:19:01.203951Z"
     },
     "papermill": {
-     "duration": 0.03924,
-     "end_time": "2026-06-25T11:44:25.723651+00:00",
+     "duration": 0.041366,
+     "end_time": "2026-08-23T02:19:01.206141",
      "exception": false,
-     "start_time": "2026-06-25T11:44:25.684411+00:00",
+     "start_time": "2026-08-23T02:19:01.164775",
      "status": "completed"
     },
     "tags": []
@@ -169,10 +169,10 @@
    "id": "a50c0005",
    "metadata": {
     "papermill": {
-     "duration": 0.004024,
-     "end_time": "2026-06-25T11:44:25.731675+00:00",
+     "duration": 0.002807,
+     "end_time": "2026-08-23T02:19:01.212021",
      "exception": false,
-     "start_time": "2026-06-25T11:44:25.727651+00:00",
+     "start_time": "2026-08-23T02:19:01.209214",
      "status": "completed"
     },
     "tags": []
@@ -195,16 +195,16 @@
    "id": "a50c0006",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:11.042613Z",
-     "iopub.status.busy": "2026-07-03T18:23:11.041614Z",
-     "iopub.status.idle": "2026-07-03T18:23:11.304737Z",
-     "shell.execute_reply": "2026-07-03T18:23:11.304737Z"
+     "iopub.execute_input": "2026-08-23T02:19:01.218629Z",
+     "iopub.status.busy": "2026-08-23T02:19:01.218095Z",
+     "iopub.status.idle": "2026-08-23T02:19:01.596871Z",
+     "shell.execute_reply": "2026-08-23T02:19:01.596298Z"
     },
     "papermill": {
-     "duration": 1.110889,
-     "end_time": "2026-06-25T11:44:26.848656+00:00",
+     "duration": 0.383023,
+     "end_time": "2026-08-23T02:19:01.597615",
      "exception": false,
-     "start_time": "2026-06-25T11:44:25.737767+00:00",
+     "start_time": "2026-08-23T02:19:01.214592",
      "status": "completed"
     },
     "tags": []
@@ -215,14 +215,14 @@
      "output_type": "stream",
      "text": [
       "Modele                 |   train |    test |   ecart\n",
-      "-------------------------------------------------------\n",
-      "Regression logistique  |   0.967 |   0.942 |   0.026\n"
+      "-------------------------------------------------------\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Regression logistique  |   0.967 |   0.942 |   0.026\n",
       "Foret aleatoire        |   1.000 |   0.936 |   0.064\n",
       "Arbre profond          |   1.000 |   0.918 |   0.082\n"
      ]
@@ -231,11 +231,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -266,10 +265,10 @@
    "id": "a50c0007",
    "metadata": {
     "papermill": {
-     "duration": 0.005006,
-     "end_time": "2026-06-25T11:44:26.858656+00:00",
+     "duration": 0.002761,
+     "end_time": "2026-08-23T02:19:01.603485",
      "exception": false,
-     "start_time": "2026-06-25T11:44:26.853650+00:00",
+     "start_time": "2026-08-23T02:19:01.600724",
      "status": "completed"
     },
     "tags": []
@@ -291,16 +290,16 @@
    "id": "a50c0008",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:11.306743Z",
-     "iopub.status.busy": "2026-07-03T18:23:11.306743Z",
-     "iopub.status.idle": "2026-07-03T18:23:11.309843Z",
-     "shell.execute_reply": "2026-07-03T18:23:11.309843Z"
+     "iopub.execute_input": "2026-08-23T02:19:01.612115Z",
+     "iopub.status.busy": "2026-08-23T02:19:01.611687Z",
+     "iopub.status.idle": "2026-08-23T02:19:01.615865Z",
+     "shell.execute_reply": "2026-08-23T02:19:01.615047Z"
     },
     "papermill": {
-     "duration": 0.011421,
-     "end_time": "2026-06-25T11:44:26.875055+00:00",
+     "duration": 0.008504,
+     "end_time": "2026-08-23T02:19:01.616715",
      "exception": false,
-     "start_time": "2026-06-25T11:44:26.863634+00:00",
+     "start_time": "2026-08-23T02:19:01.608211",
      "status": "completed"
     },
     "tags": []
@@ -329,10 +328,10 @@
    "id": "a50c0009",
    "metadata": {
     "papermill": {
-     "duration": 0.00503,
-     "end_time": "2026-06-25T11:44:26.886017+00:00",
+     "duration": 0.002847,
+     "end_time": "2026-08-23T02:19:01.622445",
      "exception": false,
-     "start_time": "2026-06-25T11:44:26.880987+00:00",
+     "start_time": "2026-08-23T02:19:01.619598",
      "status": "completed"
     },
     "tags": []
@@ -353,16 +352,16 @@
    "id": "a50c000a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:11.309843Z",
-     "iopub.status.busy": "2026-07-03T18:23:11.309843Z",
-     "iopub.status.idle": "2026-07-03T18:23:11.951683Z",
-     "shell.execute_reply": "2026-07-03T18:23:11.951683Z"
+     "iopub.execute_input": "2026-08-23T02:19:01.628982Z",
+     "iopub.status.busy": "2026-08-23T02:19:01.628528Z",
+     "iopub.status.idle": "2026-08-23T02:19:02.777485Z",
+     "shell.execute_reply": "2026-08-23T02:19:02.777008Z"
     },
     "papermill": {
-     "duration": 1.680078,
-     "end_time": "2026-06-25T11:44:28.570887+00:00",
+     "duration": 1.153079,
+     "end_time": "2026-08-23T02:19:02.778238",
      "exception": false,
-     "start_time": "2026-06-25T11:44:26.890809+00:00",
+     "start_time": "2026-08-23T02:19:01.625159",
      "status": "completed"
     },
     "tags": []
@@ -372,19 +371,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -394,19 +391,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -425,11 +426,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -450,10 +450,10 @@
    "id": "a50c000b",
    "metadata": {
     "papermill": {
-     "duration": 0.004904,
-     "end_time": "2026-06-25T11:44:28.580926+00:00",
+     "duration": 0.003081,
+     "end_time": "2026-08-23T02:19:02.784433",
      "exception": false,
-     "start_time": "2026-06-25T11:44:28.576022+00:00",
+     "start_time": "2026-08-23T02:19:02.781352",
      "status": "completed"
     },
     "tags": []
@@ -470,35 +470,21 @@
    "id": "a50c000c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:11.951683Z",
-     "iopub.status.busy": "2026-07-03T18:23:11.951683Z",
-     "iopub.status.idle": "2026-07-03T18:23:13.315397Z",
-     "shell.execute_reply": "2026-07-03T18:23:13.315397Z"
+     "iopub.execute_input": "2026-08-23T02:19:02.791453Z",
+     "iopub.status.busy": "2026-08-23T02:19:02.791125Z",
+     "iopub.status.idle": "2026-08-23T02:19:04.646195Z",
+     "shell.execute_reply": "2026-08-23T02:19:04.645736Z"
     },
     "papermill": {
-     "duration": 2.973963,
-     "end_time": "2026-06-25T11:44:31.561178+00:00",
+     "duration": 1.859577,
+     "end_time": "2026-08-23T02:19:04.647020",
      "exception": false,
-     "start_time": "2026-06-25T11:44:28.587215+00:00",
+     "start_time": "2026-08-23T02:19:02.787443",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
-      "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
-      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
-      "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -511,11 +497,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -525,11 +510,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -539,25 +530,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -593,10 +576,10 @@
    "id": "a50c000d",
    "metadata": {
     "papermill": {
-     "duration": 0.006002,
-     "end_time": "2026-06-25T11:44:31.574297+00:00",
+     "duration": 0.003014,
+     "end_time": "2026-08-23T02:19:04.653202",
      "exception": false,
-     "start_time": "2026-06-25T11:44:31.568295+00:00",
+     "start_time": "2026-08-23T02:19:04.650188",
      "status": "completed"
     },
     "tags": []
@@ -618,16 +601,16 @@
    "id": "a50c000e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:13.317403Z",
-     "iopub.status.busy": "2026-07-03T18:23:13.317403Z",
-     "iopub.status.idle": "2026-07-03T18:23:13.320441Z",
-     "shell.execute_reply": "2026-07-03T18:23:13.320441Z"
+     "iopub.execute_input": "2026-08-23T02:19:04.660623Z",
+     "iopub.status.busy": "2026-08-23T02:19:04.660173Z",
+     "iopub.status.idle": "2026-08-23T02:19:04.663757Z",
+     "shell.execute_reply": "2026-08-23T02:19:04.663162Z"
     },
     "papermill": {
-     "duration": 0.017455,
-     "end_time": "2026-06-25T11:44:31.598880+00:00",
+     "duration": 0.008251,
+     "end_time": "2026-08-23T02:19:04.664662",
      "exception": false,
-     "start_time": "2026-06-25T11:44:31.581425+00:00",
+     "start_time": "2026-08-23T02:19:04.656411",
      "status": "completed"
     },
     "tags": []
@@ -652,39 +635,421 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a50c000f",
+   "id": "b5c0d101",
    "metadata": {
     "papermill": {
-     "duration": 0.006309,
-     "end_time": "2026-06-25T11:44:31.612194+00:00",
+     "duration": 0.003081,
+     "end_time": "2026-08-23T02:19:04.671001",
      "exception": false,
-     "start_time": "2026-06-25T11:44:31.605885+00:00",
+     "start_time": "2026-08-23T02:19:04.667920",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 5. Au-delà de l'accuracy : faux positifs et faux négatifs\n",
+    "## 5. Quand le k-fold naïf se trompe : le split qui va avec les données\n",
+    "\n",
+    "La validation croisée de la section 3 repose sur deux hypothèses : les échantillons sont **indépendants** (i.i.d.) et les classes sont **réparties de façon équilibrée**. En pratique, ces deux hypothèses tombent souvent, et le k-fold naïf produit alors des scores **trompeurs** — pas une simple imprécision, mais une vraie fuite d'information.\n",
+    "\n",
+    "Deux remèdes, un par hypothèse violée :\n",
+    "\n",
+    "- **Classes déséquilibrées** -> `StratifiedKFold` : impose la même proportion de chaque classe dans tous les plis.\n",
+    "- **Données temporelles** -> `TimeSeriesSplit` : n'entraîne que sur le passé, interdit d'utiliser le futur.\n",
+    "\n",
+    "On les teste ici sur deux cas synthétiques où la faille du k-fold naïf est mesurable. En fin de section, un tableau récapitule quel split choisir selon le type de données, et un exercice vous fait appliquer la règle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5c0d102",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003007,
+     "end_time": "2026-08-23T02:19:04.677194",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.674187",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.1 Classes déséquilibrées : le pli qui n'a jamais vu la classe rare\n",
+    "\n",
+    "Sur un jeu de données binaire très déséquilibré, un simple k-fold **par index** (sans rééquilibrage) peut produire un pli de test sans aucun exemple de la classe minoritaire. C'est fréquent quand les données sont triées ou collectées dans l'ordre : les exemples d'une même classe se retrouvent regroupés. Le score de validation croisée devient alors soit trivial (prédire la classe majoritaire partout), soit impossible à calculer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b5c0d103",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T02:19:04.684113Z",
+     "iopub.status.busy": "2026-08-23T02:19:04.683832Z",
+     "iopub.status.idle": "2026-08-23T02:19:04.722500Z",
+     "shell.execute_reply": "2026-08-23T02:19:04.722055Z"
+    },
+    "papermill": {
+     "duration": 0.043147,
+     "end_time": "2026-08-23T02:19:04.723254",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.680107",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Positifs : 40 / 1000 (4.0%)\n",
+      "\n",
+      "Taux de positifs dans le pli de TEST (%). Le k-fold naif :\n",
+      "  ['0.0', '0.0', '0.0', '0.0', '20.0']\n",
+      "Le StratifiedKFold :\n",
+      "  ['4.0', '4.0', '4.0', '4.0', '4.0']\n",
+      "\n",
+      "Score CV (accuracy) par pli, k-fold naif :\n",
+      "  [0.995 0.99  0.995 1.      nan]\n",
+      "Score CV (accuracy) par pli, StratifiedKFold :\n",
+      "  [0.965 0.965 0.96  0.955 0.96 ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import warnings\n",
+    "from sklearn.model_selection import KFold, StratifiedKFold\n",
+    "from sklearn.datasets import make_classification\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "# Dataset binaire tres desequilibre (3.5% de positifs), trie par label : les exemples\n",
+    "# sont groupes par classe, ce qui arrive des qu'une collecte est ordonnee (dates, import).\n",
+    "X_imb, y_imb = make_classification(n_samples=1000, n_features=10, n_informative=6,\n",
+    "                                   n_redundant=0, weights=[0.965, 0.035], random_state=42)\n",
+    "order = np.argsort(y_imb)\n",
+    "X_imb, y_imb = X_imb[order], y_imb[order]\n",
+    "print(f\"Positifs : {int((y_imb == 1).sum())} / {len(y_imb)} ({100*y_imb.mean():.1f}%)\")\n",
+    "\n",
+    "kf = KFold(n_splits=5)   # naif : plis par index (shuffle=False par defaut)\n",
+    "skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)\n",
+    "\n",
+    "def taux_positifs_test(splitter, y):\n",
+    "    return [100*np.mean(y[te] == 1) for _, te in splitter.split(np.zeros(len(y)), y)]\n",
+    "\n",
+    "print(\"\\nTaux de positifs dans le pli de TEST (%). Le k-fold naif :\")\n",
+    "print(\" \", [f\"{r:.1f}\" for r in taux_positifs_test(kf, y_imb)])\n",
+    "print(\"Le StratifiedKFold :\")\n",
+    "print(\" \", [f\"{r:.1f}\" for r in taux_positifs_test(skf, y_imb)])\n",
+    "\n",
+    "# Effet sur le score CV : un pli sans positif rend l'accuracy triviale, et le pli qui\n",
+    "# concentre les positifs echoue en entrainement (train monoclasses -> score nan).\n",
+    "print(\"\\nScore CV (accuracy) par pli, k-fold naif :\")\n",
+    "with warnings.catch_warnings():\n",
+    "    warnings.simplefilter(\"ignore\")\n",
+    "    scores_naif = cross_val_score(LogisticRegression(max_iter=1000), X_imb, y_imb, cv=kf)\n",
+    "print(\" \", np.round(scores_naif, 3))\n",
+    "print(\"Score CV (accuracy) par pli, StratifiedKFold :\")\n",
+    "scores_strat = cross_val_score(LogisticRegression(max_iter=1000), X_imb, y_imb, cv=skf)\n",
+    "print(\" \", np.round(scores_strat, 3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5c0d104",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003026,
+     "end_time": "2026-08-23T02:19:04.729806",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.726780",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Le k-fold naïf produit ici **4 plis de test à 0% de positifs**. Deux conséquences, toutes deux visibles dans la sortie :\n",
+    "\n",
+    "1. L'accuracy y est **trompeuse** : prédire « négatif » partout donne 100% sur un pli qui ne contient que des négatifs (les scores ≈ 0.99-1.0 dans la sortie k-fold naïf).\n",
+    "2. Le dernier pli concentre les 20.0% de positifs restants ; son **train** ne contient alors plus qu'une seule classe, et l'entraînement de la régression logistique échoue (score `nan`).\n",
+    "\n",
+    "Le `StratifiedKFold` répartit la même proportion (≈4.0%) de positifs dans chaque pli : les scores deviennent stables et honnêtes (≈0.96-0.97). Sur un dataset déséquilibré, la validation croisée non stratifiée n'est donc pas seulement imprécise — elle est **trompeuse**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5c0d105",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003033,
+     "end_time": "2026-08-23T02:19:04.735997",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.732964",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 5.2 Données temporelles : le pli qui regarde le futur\n",
+    "\n",
+    "La fuite temporelle est l'erreur de validation la plus coûteuse en apprentissage sur série temporelle : entraîner sur le **futur** pour prédire le **passé**. Un k-fold aléatoire mélange les indices temporels : un pli de test peut contenir des points dont les voisins (futurs et passés) sont dans le train. Le modèle « connaît » alors la réponse. `TimeSeriesSplit` impose une fenêtre glissante : chaque train s'arrête avant le test. On compare les deux sur une série synthétique dont la fin s'accélère (le futur lointain ne se déduit pas du passé)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b5c0d106",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T02:19:04.743232Z",
+     "iopub.status.busy": "2026-08-23T02:19:04.742945Z",
+     "iopub.status.idle": "2026-08-23T02:19:04.755360Z",
+     "shell.execute_reply": "2026-08-23T02:19:04.754811Z"
+    },
+    "papermill": {
+     "duration": 0.017218,
+     "end_time": "2026-08-23T02:19:04.756124",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.738906",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "R2 par pli, k-fold aleatoire : ['0.994', '0.994', '0.995', '0.992']\n",
+      "  moyenne = 0.993\n",
+      "R2 par pli, TimeSeriesSplit  : ['0.999', '0.999', '0.999', '0.512']\n",
+      "  moyenne = 0.877\n",
+      "\n",
+      "Ecart (fuite) = +0.116\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.model_selection import TimeSeriesSplit, KFold\n",
+    "from sklearn.linear_model import LinearRegression\n",
+    "from sklearn.metrics import r2_score\n",
+    "\n",
+    "# Serie temporelle synthetique : drift lineaire + acceleration forte en fin de serie.\n",
+    "# Le futur lointain (zone d'acceleration) ne se deduit pas du passe.\n",
+    "n = 1200\n",
+    "t = np.arange(n).astype(float)\n",
+    "y_ts = 0.5*t + 0.004*np.maximum(t - 0.85*n, 0)**2 + np.random.normal(0, 1.0, n)\n",
+    "X_ts = np.c_[t/n, (t/n)**2]\n",
+    "\n",
+    "kf_ts = KFold(n_splits=4, shuffle=True, random_state=42)\n",
+    "ts_ts = TimeSeriesSplit(n_splits=4)\n",
+    "\n",
+    "def cv_r2(splitter, X, y):\n",
+    "    scores = []\n",
+    "    for tr, te in splitter.split(X):\n",
+    "        m = LinearRegression().fit(X[tr], y[tr])\n",
+    "        scores.append(r2_score(y[te], m.predict(X[te])))\n",
+    "    return scores\n",
+    "\n",
+    "scores_kfold_ts = cv_r2(kf_ts, X_ts, y_ts)\n",
+    "scores_ts = cv_r2(ts_ts, X_ts, y_ts)\n",
+    "\n",
+    "print(\"R2 par pli, k-fold aleatoire :\", [f\"{s:.3f}\" for s in scores_kfold_ts])\n",
+    "print(f\"  moyenne = {np.mean(scores_kfold_ts):.3f}\")\n",
+    "print(\"R2 par pli, TimeSeriesSplit  :\", [f\"{s:.3f}\" for s in scores_ts])\n",
+    "print(f\"  moyenne = {np.mean(scores_ts):.3f}\")\n",
+    "print(f\"\\nEcart (fuite) = {np.mean(scores_kfold_ts) - np.mean(scores_ts):+.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5c0d107",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003037,
+     "end_time": "2026-08-23T02:19:04.762582",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.759545",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Le k-fold aléatoire obtient R² ≈ **0.99**, un score quasi parfait — mais **trompeur** : le modèle a vu la zone d'accélération en fin de série, parce que le tirage aléatoire des plis a mélangé des points du futur dans son entraînement.\n",
+    "\n",
+    "Le `TimeSeriesSplit` refuse cette fuite. Les trois premiers plis restent excellents (≈0.999 : le modèle est bon sur le passé), mais le **dernier pli** — prédire le futur lointain, dans la zone d'accélération jamais observée — s'effondre à ≈0.51.\n",
+    "\n",
+    "L'écart (≈0.99 contre ≈0.88 en moyenne, et surtout 0.51 sur le dernier pli) **est la fuite quantifiée** : le score du k-fold aléatoire sur-estime la capacité réelle à prédire le futur. C'est la raison pour laquelle les notebooks série temporelle (2.6, ML-5, et chaque backtest QuantConnect) imposent un découpage temporel, pas aléatoire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b5c0d108",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T02:19:04.770019Z",
+     "iopub.status.busy": "2026-08-23T02:19:04.769644Z",
+     "iopub.status.idle": "2026-08-23T02:19:04.773699Z",
+     "shell.execute_reply": "2026-08-23T02:19:04.773241Z"
+    },
+    "papermill": {
+     "duration": 0.008813,
+     "end_time": "2026-08-23T02:19:04.774462",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.765649",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Type de donnees                            | Split                | Pourquoi\n",
+      "----------------------------------------------------------------------------------------------------\n",
+      "i.i.d., classes equilibrees                | KFold                | Le plus simple ; evalue la variance de l'evaluation\n",
+      "i.i.d., classes desequilibrees             | StratifiedKFold      | Garde la proportion de la classe rare dans chaque pli\n",
+      "serie temporelle                           | TimeSeriesSplit      | N'entraine que sur le passe ; refuse la fuite du futur\n",
+      "groupes relies (patient, serie par item)   | GroupKFold           | Ne melange pas un meme groupe entre train et test\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tableau de decision : quel split pour quel type de donnees ?\n",
+    "print(f\"{'Type de donnees':42s} | {'Split':20s} | {'Pourquoi'}\")\n",
+    "print(\"-\" * 100)\n",
+    "for typ, split, quoi in [\n",
+    "    (\"i.i.d., classes equilibrees\", \"KFold\", \"Le plus simple ; evalue la variance de l'evaluation\"),\n",
+    "    (\"i.i.d., classes desequilibrees\", \"StratifiedKFold\", \"Garde la proportion de la classe rare dans chaque pli\"),\n",
+    "    (\"serie temporelle\", \"TimeSeriesSplit\", \"N'entraine que sur le passe ; refuse la fuite du futur\"),\n",
+    "    (\"groupes relies (patient, serie par item)\", \"GroupKFold\", \"Ne melange pas un meme groupe entre train et test\"),\n",
+    "]:\n",
+    "    print(f\"{typ:42s} | {split:20s} | {quoi}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5c0d109",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00377,
+     "end_time": "2026-08-23T02:19:04.781485",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.777715",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : choisir le bon split\n",
+    "\n",
+    "Trois jeux de données, trois situations :\n",
+    "\n",
+    "1. **Transactions bancaires** : 0.5% de fraudes, détection au fil de l'eau, une transaction indépendante des autres.\n",
+    "2. **Relevés de capteurs** : un capteur horodaté mesure la température d'un serveur toutes les minutes.\n",
+    "3. **Dossier patients** : plusieurs prélèvements par patient, on veut prédire un risque individuel.\n",
+    "\n",
+    "Pour chaque cas, indiquez le split de validation croisée à utiliser et justifiez en une phrase. Notez que le dernier cas n'est pas un simple i.i.d. : le même patient traverse les plis si l'on ne regroupe pas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b5c0d10a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T02:19:04.788638Z",
+     "iopub.status.busy": "2026-08-23T02:19:04.788436Z",
+     "iopub.status.idle": "2026-08-23T02:19:04.792054Z",
+     "shell.execute_reply": "2026-08-23T02:19:04.791585Z"
+    },
+    "papermill": {
+     "duration": 0.008082,
+     "end_time": "2026-08-23T02:19:04.792703",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.784621",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : choisir le bon split (a completer)\n",
+    "# 1. transactions frauduleuses (0.5% de fraudes) : split = ?  -> justifier\n",
+    "# 2. capteurs horodates                          : split = ?  -> justifier\n",
+    "# 3. patients, plusieurs mesures                 : split = ?  -> justifier\n",
+    "\n",
+    "# TODO etudiant : ecrire le split adapte pour chaque cas et justifier\n",
+    "reponse_split = None  # TODO etudiant : remplir par un dict / des commentaires\n",
+    "\n",
+    "if reponse_split is None:\n",
+    "    print(\"Exercice a completer.\")\n",
+    "else:\n",
+    "    print(\"Reponse :\", reponse_split)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5c0d10b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002995,
+     "end_time": "2026-08-23T02:19:04.799067",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.796072",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Transition.** Le `TimeSeriesSplit` exécuté ici n'est pas un détail : c'est le réflexe attendu dans toute la partie temporelle du cursus — la validation walk-forward des notebooks de trading QuantConnect, et la validation des modèles de séries temporelles (ML-5). Quand une donnée a un ordre, un découpage aléatoire n'est pas une approximation : c'est une fuite."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a50c000f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002881,
+     "end_time": "2026-08-23T02:19:04.804837",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:04.801956",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Au-delà de l'accuracy : faux positifs et faux négatifs\n",
     "\n",
     "L'accuracy globale masque le **type** d'erreurs commises. Or dans un diagnostic de cancer du sein, un **faux négatif** (manquer une tumeur maligne) est bien plus coûteux qu'un faux positif (faire passer un examen complémentaire à un patient sain). Nous avons besoin de la **matrice de confusion** et de la **courbe ROC** pour voir la structure des erreurs, pas seulement leur nombre agrégé."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "id": "a50c0010",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:13.322597Z",
-     "iopub.status.busy": "2026-07-03T18:23:13.321597Z",
-     "iopub.status.idle": "2026-07-03T18:23:13.551867Z",
-     "shell.execute_reply": "2026-07-03T18:23:13.551867Z"
+     "iopub.execute_input": "2026-08-23T02:19:04.811760Z",
+     "iopub.status.busy": "2026-08-23T02:19:04.811551Z",
+     "iopub.status.idle": "2026-08-23T02:19:05.078537Z",
+     "shell.execute_reply": "2026-08-23T02:19:05.077989Z"
     },
     "papermill": {
-     "duration": 0.65754,
-     "end_time": "2026-06-25T11:44:32.276729+00:00",
+     "duration": 0.271588,
+     "end_time": "2026-08-23T02:19:05.079286",
      "exception": false,
-     "start_time": "2026-06-25T11:44:31.619189+00:00",
+     "start_time": "2026-08-23T02:19:04.807698",
      "status": "completed"
     },
     "tags": []
@@ -694,11 +1059,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -706,7 +1070,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAHqCAYAAADyPMGQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAgJpJREFUeJzt3QW4VNX3N/BFd3dJioR0l4B0itIlIN2ClCAtISAgSogIiNKdgoAg0pLSnUpKd533+a7f/8w7d+7cy8xler6f5xm402f2nJmzZu+1145kGIYhRERERPRakV9/EyIiIiJi4ERERETkBPY4ERERETmIgRMRERGRgxg4ERERETmIgRMRERGRgxg4ERERETmIgRMRERGRgxg4ERERETmIgRPR/xk0aJBEihRJbt68yTbxALQ12jyYZMiQQZo3b+7tzQg4ZcqU0ZMvmjlzpu7r58+f9/amkIswcCKvOHPmjLRt21YyZcokMWPGlPjx40uJEiXkm2++kcePHwf0u2J+kZqnqFGjSpo0afSA+s8//9i9D1ZG+vnnn+W9996ThAkTSuzYsSVXrlwyZMgQefjwYZjPtXTpUqlSpYokTZpUokePLqlTp5Z69erJ77//7vKAwHw9kSNH1m3E9rVp00Z27dolwWT79u0aEN65c8fbm0JEbhDVHQ9KFJ7Vq1dL3bp1JUaMGPLxxx/Lu+++K8+ePZOtW7dKz5495ciRIzJ16tSAb0QEPRkzZpQnT57Izp07NaBCGxw+fFiDSdPLly+lUaNGsmDBAilVqpQelBE4/fnnnzJ48GBZuHChbNiwQVKkSBEi0Prkk0/0MfPlyyfdu3eXlClTypUrVzSYKleunGzbtk2KFy/usteTN29e+eyzz/Tv+/fvy7Fjx3TbfvjhB+nWrZuMHTs2xO0RICNoDMTACe8LAmEEkNZOnDihgSUFj6ZNm0qDBg30+44CBBb5JfKUs2fPGnHjxjWyZctm/Pvvv6GuP3XqlDF+/HiPviEPHjzQ/wcOHIgFr40bN2649flmzJihz/PXX3+FuLx37956+fz580NcPnz4cL28R48eoR5rxYoVRuTIkY3KlSuHuHz06NF6n08//dR49epVqPvNmjXL2LVrl8teU/r06Y1q1aqFuvzRo0dGrVq1dFsmTZpkBAOz7c+dO+ftTfE72FexzzirdOnSeiLyBAZO5FHt2rXTg8q2bdscuv3z58+NIUOGGJkyZTKiR4+uB+jPP//cePLkSYjb4TER+NjC7Zs1axYqaNm8ebPRvn17I1myZEbChAlDBE7Hjh0z6tata8SLF89InDix0aVLF+Px48ehHvvnn3828ufPb8SMGdNIlCiRUb9+fePixYsRDpxWrVqllyNQMuEggsfOmjWrtoU9LVq00Pvt2LHDch9sN4LTFy9eGJ4QVuAE9+/f1+1JkyZNiCDO9j07f/68vid4rWhT3KdOnTp2A5CDBw8a7733nt4Ojzt06FBj+vTpoQIWc7v+/PNPo1ChQkaMGDGMjBkzGj/99FOoxzxz5ow+H9o7VqxYRpEiRfQ9sTVhwgQjR44cehvsOwUKFDBmz54dYh+yPZnbZLs/wu3btzXAxXXYx/F6mjZt6lAAj30Qr8vcllKlShnr1q2zXL9s2TKjatWqRqpUqfSx8TnC58l2v0DQkTNnTuPIkSNGmTJl9PFSp05tfPXVV6GeE58FvM63335b2zNlypTGhx9+aJw+fdpym5cvXxrjxo3TdsJtkidPbrRp08a4detWiMcy35+1a9dqO+K2uF94vv/+e30deO/x2rds2RIqcDI/Y7b7zqZNm/Ry/B+ee/fuGV27drW8J/ieKF++vLF3794Qt9u5c6dRqVIlI378+Npm2Ce3bt0a4jb2tsWZ/ZJ8D/uMyaNWrlypeU2ODhG1atVKBgwYIPnz55dx48ZJ6dKlZcSIEdr1/SY6dOggR48e1cfu06dPiOuQA4ThMzxP1apVZcKECZqrY23YsGE6zPj222/rENSnn34qGzdu1BykiOa2mMmjiRIlslyGobvbt2/rUF1Yw1rYDli1apXlPrdu3dL7RIkSRbwtbty48uGHH2r+Fto8LH/99ZcOc+G9RZu3a9dO2xRJv48ePbLcDo9TtmxZHdL9/PPPdRhw9uzZmh9nz+nTp6VOnTpSoUIF+frrr7V9MYyG+5uuXbum++S6det038D7i32gZs2aOrRpwrBjly5dJEeOHDJ+/HgdksMQpZnH9dFHH0nDhg31b+yvyEvDKVmyZHa37cGDBzr8+u2330rFihX1NeB1Hz9+XC5fvhxuu+K5MQwULVo0HfbF+XTp0oXIX8NQLdofQ7V47AIFCtjd5wH7WeXKlSVPnjzaTtmyZZPevXvLr7/+GmLYuHr16vpceCzcrmvXrnL37l0dYjYhfxHD7mbeYosWLfQ9qlSpkjx//jzU8CXaDO8Pbov2DMuPP/6oj41h51GjRunj4z26dOmSuBLeg8mTJ0vt2rVl0qRJ0qNHD4kVK5YOP5vQzvi837t3TwYOHCjDhw/Xz/77778vu3fvfu1zOLJfko/yduRGwePu3bv6y+uDDz5w6PYHDhzQ27dq1SrE5RiywuW///57hHucSpYsGepXt9lbULNmzRCXd+jQQS9HL4fZMxIlShRj2LBhIW536NAhI2rUqKEut2Vuw4YNG7RX4dKlS8aiRYv0Vy1+eeK8CcOWuO3SpUvDfDz8isdtPvroIz3/zTffvPY+nuxxAvQiYJuWL18e5ntmb4gGvWi4HYYWTZ07dzYiRYpk7N+/33LZf//9pz1U9n7Z4zL0SpiuX7+u7fzZZ59ZLkOPD26HHgDrnjL0AmTIkEF7UAD7LnpmIjpUZ7s/DhgwQG+7ZMmSULe1N8RqPaSNIVr09JjbZu9+9tq0bdu2RuzYsUP02qK3xradnz59qr1JtWvXtlxm9uqNHTs2zO1FG+I2Zi+cCb1Ktpeb7w+ue51nz55pz1XevHl120xTp07Vx3Blj1OCBAmMjh07hnk9Xit63NDbZNve2GcqVKgQ7rY4ul+Sb2KPE3kMfplBvHjxHLr9mjVr9H/8WrZmJiAjyTyiWrduHWZvTMeOHUOc79y5c4jtWbJkibx69Up7plC6wDzhVzB6oDZt2uTQNpQvX157ItBLgF+eceLEkRUrVkjatGktt0GS9evazLzObF9n29kT0Oth/XrswS96E3ol/vvvP8mSJYsmWO/bt89y3dq1a6VYsWIheiYSJ04sjRs3tvu46B1Cr44Jbf7OO+/I2bNnLZfhvS1cuLCULFkyxDajpxE9gWZPGbYFPUHoHXOFxYsXaw8PeuRsYYZiWJYtW6b7IHqPbJPNre9n3aZoe+ynaAv04KFXyxpeb5MmTSznMQsTbWLdTthezNA0PxP2nhcTAhIkSKA9KdafD/RQ4TlsPx+YIIGeqNfZs2ePXL9+XXuDsG0m9NLg+VwJ7zN6Ef/991+71x84cEBOnTqlvbrYT83XiBmumHixZcsWfX/C48h+Sb4p8Ka0kM9CyYHXHTytXbhwQQ8KOHhaQ4CCLzZcH1H4sg4Lgh9rmTNn1u0wh9LwhYkOE9vbmTB04oiJEydK1qxZdZhj+vTp+mVrO/PGDH7CazPb4MrZdrbnxo0bOixjwgHPDH4iAkNS1ttoD2bZYXh0xowZOhz3v06p/0EbmfC+I3CyZbufmN56661Ql2FYBENT1o9ZpEiRULfLnj275XrM/sTQFWYwIqDA82F4DQdPDBlFtCwHhoMicj/skzj4hgfDPl988YUOK5kBtb02BQTstsEa2unvv/8O8bw4uIc3GxKfDzx28uTJ7V6P4MfRz6I18/Nu+7nD5w3D/66EYcBmzZrpjxoEfBiyx5C4+Tx4jYDbhAVtYD3sHpH9knwTAyfyGBzQUUfIOhfCEeH98n4d64O/Netf4s4+P35J4jLkftjrtXI0wMDBt2DBgvp3rVq1tLcDB2HkfJiPYR64cfDCbewxD2zmQRS5KXDo0KEw7/M6hQoVChGYIofjTYpVmu95WMENoBcDQRPyxRAYoRcB7Yycp9f9eg9PWD2L1oGZo/B+4P1BPhl6vtADgxwY9Pwg78eXIN8GOYH43CEHCj8AUOYCvXcIAG3b1FXthMdF0IScJnts872c+Sy+6XdGWN8HttCbjN4g5Lf99ttvMnr0aPnqq6+0txl10cy2w+Vh5WS97nvAlfsleRYDJ/IoJJaiRtOOHTvs9hpYS58+vX5B4dedGUCYibw4KOB6619qtknZqA2FukXOwvNZ/wpGEie2A0UeAQcgfLnhNugxcgV8iaK3BUnP3333nSV5F8EUetfmzJkj/fr1s/tlO2vWLEvbmvdBe8ydO1f69u0boQRxHPSsC5G+yS969DbhAIRf79bvo61FixbpL3gkypqQoG37vuJ9x3tiy95ljsJjIiCyZQ5nWe9rGFKtX7++nrCPISEcyeRIVEdg4kygj33J2R8S5v2wT2IIMawD9+bNm3UYCQd7JDGbzp075/TzWT8vhrAwlBpWzypug1459MK5Migy3wN8PpGAbcK24DVhyNNk9vTY7jvO9FKnSpVKJwrghF4yTFDB+4zACa8REJRiyJ2CC3OcyKN69eqlBx7MlkMAZAtDAebsKHSPA2YvWTMLKVarVs1yGb7IMNRlDQGao78wbYfQrGHGE+ALE3CgRDCCHgbbX4c4j4NVRGD2GHqh8HoRMAAKXWJGDw7qCJxsIc8LM6eQI1K0aFHLfdCjgBlA+N/eL9hffvkl3Jk/OOjhgGCeIho4IfjCzC/M8sP2hxdUoE1ttxVtb/se4rUi8EaeiQmPH1YPhyOwr6E98Lgm5KtgH0LAbPbm2b63yLXBddhuc7YY9m9wZHYlhukOHjwYYuaeIz0P6EnEUB16kmx7jsz7mQGz9eMg0EMPWURhe5HLg+A+rO1Fbw3es6FDh4a6zYsXLyI86xS9s+itmjJlir4OE/Z/28c0Axvr7wRskyOFdXE722FM9KCht/zp06d6HsN3eI4xY8ZYhqFth7opcLHHiTwKXzboPcGvdfQ+WFcOx1R0JJaaa3nhFyR6IPBlZw474OD2008/6YEDvTMmBGJIGsUXO5JScTDC1HIksjoLv14xxRlTs3EgRZCBITTzFy1ew5dffqk9DMh7wrYgdwf3wwEQCcUIdiICU7hRVR0HA7weQO/T/v37dagA24PXiF/yKDuAbUM7ok1sHwf5Lei9QTIuks+RG3b16lVNLEY7or1dCXlJ2B7AwQS9IXg/8ZxI6Mc08vCgxwxT9zFEh2AErxU9F0mSJAkVfON58D5jeA+ByrRp0zRnBAFURIZ20cbooUNwjHIDSDZHm+I9xXCcmYCNnCa0IwJLVGpHcIogAkG8mb+FgyogUMQwI3pmatSoYQmobN8n9LThPUeld9wXrwGTBBAgWPeiWMOQJx4fwQmGlBDMIz8OSes4wKP3EuUV0POCzxBeE9oF7fsmQ0H4vKKHExM2sA/huRFg4n1Cz8wHH3ygn1O819gGBLdoM7QBeoqwP+CHEfZHZ+Ex8LnDY6PHCd8heH8wvGsb2OfMmVN/SOAzivbE+zlv3jwN3F4HuYHI98I2ov0x5IbXh7Y1e0OxP2Cfw/6C50K5BSybhM8APm/oiULpFQpQ3p7WR8Hp5MmTRuvWrXWqNwrModhkiRIljG+//TbENGkUfRw8eLBO8Y0WLZqRLl06uwUwMSUblbeTJk2qU60xTRgF+cIqR2BbfNK6HMHRo0e1ECK2CcUQO3XqZLcA5uLFi7WsQZw4cfSEgpOYwnzixIlwX3t424DXkTlzZj1Zl0vA5bgf2gjF9lD8D9Pi0TZm5XN7UOagYsWKOlUfpRJQCBGFOlEA1JXM6dU4oVQAthHbh/c4rArltuUIUAgSxTzxHqK6PN7D48eP2y0aiVIEKPaI6dtp06Y1RowYoYUp8ZhXr159bZkEe5WmzQKYKCSJ9i1cuHCoApgovogih0mSJNHnxvvUs2dPLbVhDQU5UcgSJQNeVwATpRSwj+H2+Czg9eA2N2/efG27ozxAvnz5dFuwr+I1rV+/3nI9Cs0WLVrUUtCyV69eWiDTdkq+WQDTFrYD22wNU+779etn+UyiZAHaDe1nDWUCUNQSz43PUq5cufT5rVcMeF0ZC3tQgR7PjddcsGBBuwUwAduDopW4XYoUKYy+fftq27yuHAFKHeA9zZMnj243Ptv4217le+yHKANi7g94PfXq1TM2btzoUAFMW6yA7h8i4R9vB29ERG8KSeXff/+99nb5QuFPIgpMzHEiIr9jnbhu5h5hGAqJ8QyaiMidmONERH4HMzKRTI/8LkwywFIcqFPUv39/b28aEQU4Bk5E5HcwCw5J1Zg4gKRnTBVH8GQ97Z6IyB2Y40RERETkIOY4ERERETmIgRMRERGRg4IuxwlVdrHiNYrVvckaaERERBQYUJkJxU9RQNYseBuWoAucEDRhzSwiIiIia5cuXdLK8eEJusDJXBYBjYOy+O7o0cI6RVhT6XVRK7Hd/R33d7Z9sOE+H5jtjnIm6FQxY4TwBF3gZA7PIWhyV+CEBVrx2AycPIft7h1sd+9h27Pdg8krDx1bHUnhYZcIERERkYMYOBERERE5iIETERERkYMYOBERERE5iIETERERkYMYOBERERE5iIETERERkYMYOBERERE5iIETERERkYMYOBERERE5iIETERERkT8ETlu2bJEaNWpI6tSpdX2YZcuWvfY+mzdvlvz580uMGDEkS5YsMnPmTI9sKxEREZFXA6eHDx9Knjx5ZOLEiQ7d/ty5c1KtWjUpW7asHDhwQD799FNp1aqVrFu3zu3bSkRERBTVm01QpUoVPTlqypQpkjFjRvn666/1fPbs2WXr1q0ybtw4qVSpkhu3lIiIiMjPcpx27Ngh5cuXD3EZAiZcTkRERIHp5cuX4iu82uPkrKtXr0qKFClCXIbz9+7dk8ePH0usWLFC3efp06d6MuG28OrVKz25Gh7TMAy3PLavWXPoiozbcEoePn3h7U0R4//aPnLkyBLJ2xsTRNjubPtgw33e8x7fuCin5gyVtFXaSNb8JWVFpxIufw5njtl+FThFxIgRI2Tw4MGhLr9x44Y8efLELY1/9+5dDZ5wEA9ko9celwu3Xd+GREREpucPnsmTO9fk/K/TJH7GfHL9+nVxtfv37wdm4JQyZUq5du1aiMtwPn78+HZ7m+Dzzz+X7t27h+hxSpcunSRLlkzv547ACTME8fiBHjg9fXlY/48cSSR5vBhe3Rb+CmS7Bxvu82z3QGYYhh5LVfwsEr/pEImR9C1JmSiOJE+e3OXPFzNmzMAMnIoVKyZr1qwJcdn69ev18rCgbAFOthDUuCuwwZvtzsf3Hf/bqZPHiyk7+5bz6pYgYMWvEHygAr/dfQfbnW0fbLjPu9+VK1ekcePGMmDAAClTpoxe9urV+279jnfmMb16hHnw4IGWFcDJLDeAvy9evGjpLfr4448tt2/Xrp2cPXtWevXqJcePH5dJkybJggULpFu3bl57DUREROQamCmPWo2bNm2SNm3a+FRSuE8ETnv27JF8+fLpCTCkhr8RZZpRpxlEAUoRrF69WnuZUP8JZQmmTZvGUgRERER+PjT3zTffaJ1GTATLmTOnrFq1SqJEiSK+xqtDdeiCQ2OFxV5VcNxn//79bt4yIiIi8tToU6tWrWT+/Pl6vmHDhjJ16lSJGzeuT74BfpXjRK63+u8rMnb9CXn41Pnu0Ov3OaOOiIgi7tatW1KqVCk5evSoRI0aVUeSOnfu/P8Tw30QA6cgh6DpzI2Hb/QYcWL4XlcqERH5vkSJEknevHnl9u3bsnDhQilRwvU1mlyNgVOQM3ua/ldSwPHpmNZB02cV33HDlhERUSB68eKF1lHEUBx6ljAshzpKKDnkDxg4BflwnDnc5gslBYiIKLBdu3ZNc5hQR3HJkiVaBiBOnDh68hcMnIKAI8NxHG4jIiJ32rFjh9StW1f++ecfDZROnDgh2bNn97tGZ+AUBF43HMfhNiIichfDMGTixIlacuj58+eSLVs27W3yx6AJGDgF0ew3DscREZEnPXz4UNq2bSuzZ8/W83Xq1JHp06dLvHjx/PaNYODkJzj7jYiI/E29evV0qTQUshw1apSu9OHLpQYcwcDJT3D2GxER+ZsBAwbI4cOHZdasWVK6dGkJBAyc/AyH24iIyFe9fPlSDh48qOvNQZEiReTUqVMSPXp0CRRcRp6IiIje2M2bN6Vy5cpaxPLAgQOWywMpaAIGTkRERPRGdu/erb1MGzZs0NpMFy5cCNgWZeBEREREES41MGXKFF1v7tKlS/L222/Lrl275IMPPgjYFmWOk59V+CYiIvIFjx8/lvbt28tPP/2k5z/88EOZMWOGJEiQQAIZAycfwgrfRETkL6ZNm6ZBE4bmRowYIT179vT7UgOOYODkQ1jhm4iI/EWHDh10WO6TTz6R999/X4IFAycfxJIDRETki6UGpk6dKi1atJCYMWNqUctffvlFgg2Tw4mIiChc//33n1SrVk17mbp06RLUrcUeJyIiIgrT3r17pXbt2lpiIFasWPLee+8FdWuxx4mIiIjs+vHHH7WgJYKmzJkzy86dO6VJkyZB3VoMnIiIiCiEJ0+eSKtWrfT09OlTqVGjhuzZs0dy584d9C3FwImIiIhCuHbtmixZskTLCwwbNkyWLVsmCRMmZCsxx4mIiIhspU+fXubNm6d/V6xYkQ1khcnhREREQe7Vq1fas1SgQAGpWrWqXsaAyT4GTkREREHs9u3b0rRpU1m9erUOx506dUqSJk3q7c3yWQyciIiIgtSBAwe01MDZs2e1qOW4ceMYNL0GAyciIqIgNGvWLGnbtq3OoMuYMaMsXrxY8uXL5+3N8nmcVUdERBRkS6e0b99emjVrpkFTlSpVtNQAgybHMHAiIiIKIlhjDsngKDUwaNAgWbVqlSROnNjbm+U3OFRHREQUBBAsRY78v/6SCRMmSMOGDaVMmTLe3iy/wx4nIiKiAA+YRowYoYv0YpgOYsSIwaApgtjjREREFKDu3r2ruUzLly/X8/j/o48+8vZm+TUGTkRERAHo0KFDGiSdPn1aokePLhMnTmTQ5AIMnIiIiALM7NmzpU2bNvLo0SN56623ZNGiRVKoUCFvb1ZAYI4TERFRAEE+U5MmTTRoqlChguzdu5dBkwsxcCIiIgogWGsuduzY8sUXX8ivv/7KSuAuxqE6IiIiP3f9+nVJnjy5/p0nTx7Na0qVKpW3NysgsceJiIjITxmGIWPGjJEMGTLIzp07LZczaHIfBk5ERER+6N69e1K3bl3p2bOnPH78WNeaI/fjUB0REZGfOXr0qJYWOHHihESLFk0rgWPBXnI/Bk5ERER+ZP78+dKyZUt5+PChpE2bVksNFClSxNubFTQYOBEREfmJjRs3SoMGDfTv999/X+bNmyfJkiXz9mYFFQZOREREfgLBEobosmbNKkOHDpWoUXkY9zS2OBERkQ/DbLlcuXJJnDhxJFKkSLJgwQKJEiWKtzcraHFWHRERkY+WGhg/fryULFlSl0/BeWDQ5F3scSIiIvIxDx48kFatWmkiuOn58+e6WC95FwMnIiIiH3L8+HGpXbu2lhxADtO4ceOkY8eOOkxH3sfAiYiIyEegiGXz5s21xyl16tSycOFCKV68uLc3i6wwcPKg1X9fkbHrT8jDpy/tXn/9/hNPbg4REfkQBEvoWcL/pUuX1mG6FClSeHuzyAYDJw9C0HTmxsPX3i5ODM6WICIKNnHjxtVgafXq1TJ8+HCWGvBRDJw8yOxpihxJJHm8mGEGTZ9VfMeTm0VERF6yfft2uXnzptSsWVPPo6cJJ/JdDJy8AEHTzr7lvPHURETkA1BaYOLEidKtWzeJGTOm/PXXX5ItWzZvbxY5gIETERGRB2GNOSzIO3v2bD1ftWpVXXOOAjhwunjxoly4cEEePXqka+TkzJlTYsSI4fqtIyIiCiCnTp3SJVMOHz6shSxHjx4tn376KUsNBGLgdP78eZk8ebIuKHj58mVLBVNAQa5SpUppZVPUnogcmQXJiYiIrC1fvlw+/vhjuXfvnqRMmVITwd977z02kp9xKMLp0qWL5MmTR86dOydffvmlFuW6e/euPHv2TK5evSpr1qzRkvADBgyQ3Llz61gtERER/X9btmzRoAnHy3379jFoCuQeJywsePbsWUmSJEmo65InT66rNeM0cOBAWbt2rVy6dEkKFSrkju0lIiLySyNHjpQMGTJIu3btJFq0aN7eHHJnj9OIESPsBk32VK5cWcdviYiIgtnu3bulQYMGusYcIFjq3LkzgyY/x2QkIiIiF0IO8JQpUzT3F3lMX331Fds32Ibq8uXL53DGP8ZtiYiIghFmm3fo0EF++uknPY8RGOQJU5AFTrVq1XL/lhAREfmxM2fO6MzygwcP6uxy5DT16NGDpQaCMXBC0jcRERHZ9/vvv2vQdOfOHZ00hdI9ZcuWZXMFoAjlOGHHmDZtmnz++edy69YtyxDdP//84+rtIyIi8nlp0qSRly9fSrFixfR4yKApcDkdOP3999+SNWtWTXYbM2aMBlGwZMkSDaSchbV6MD0Ta/UUKVJEZyGEZ/z48fLOO+9IrFixJF26dLrOz5MnT5x+XiIiojdhzpYDHJc2b96sJwRRFLicDpy6d+8uzZs317LxCHZMWGsHxb2cgdkGeDwMBSJCR5HNSpUqyfXr1+3efs6cOdKnTx+9/bFjx+THH3/Ux+jbt6+zL4OIiCjC9uzZo4vyYojOlD9/fl1JgwKb04ETqoJjcUJbiLBRRdwZY8eOldatW0uLFi0kR44cOn0zduzYMn36dLu33759u5QoUUIaNWqkvVQVK1aUhg0bvraXioiIyFWwOC9KDaAwdP/+/UMsQUaBz+lFfrGYL0rG2zp58qQu+OsoLNeyd+/eEMN7mIVQvnx52bFjh937FC9eXH755RcNlAoXLqw7LZZ7adq0aZjP8/TpUz2ZzG1/9eqVnlwNj4kPkf3HNj9cYV1P7ml3che2u/ew7T0PaSGdOnWSGTNm6PmaNWvq3/juYfDk3/u7M4/rdOCEHWXIkCGyYMECPY/6ThcvXpTevXvrjAJH3bx5UxPpUqRIEeJynD9+/Ljd+6CnCffDOj9owBcvXmjp+vCG6lD1fPDgwaEuv3Hjhltyo9D4WMcP22e72PHL/3tj8H9Yw5Hk+nYn92G7ew/b3rOwlFjLli3l0KFD+h3Tq1cvrQKOTgB+n/v//n7//n33BU5ff/211KlTR6dbPn78WEqXLq1DdJhJMGzYMHEnJN0NHz5cJk2apInkp0+flq5du8rQoUO1u9Qe9Gghj8q6xwlJ5egdix8/vlveXASTeHzbNzfK/53H/2g/8ky7k/uw3b2Hbe856BzAcmKYRZ40aVL57rvvtKOA3zWBs79b52y7PHBKkCCBrF+/XrZu3aoz7B48eKAJcRhicwZ2vihRosi1a9dCXI7zKVOmtHsfBEcYlmvVqpWez5Urlzx8+FDatGkj/fr1s9uYGFrEyRZu666dHm+u/cc3q6//73ryVLuTO7HdvYdt7xnp06eXKlWqaEoKRltwkOV3TWDt7848ptOBkwnDZThFFGYeFChQQDZu3GipTI6IEucxhhxWKftQvThRouj/HF8mIiJXQe8SjjcJEybUA/bUqVP1eIOFejk0F9wiFLYhuKlevbpkzpxZT/h7w4YNTj8OhtB++OEHXdMH5QXat2+vPUiYZQcff/xxiOTxGjVqyOTJk7Ui67lz57TnC71QuNwMoIiIiN7E/v37pWDBgtKsWTNL0jBmfNsbvaDg43SPE/KLkFeEPCf8Dzt37tQ6TuPGjZOOHTs6/Fj169fXJO0BAwZonlTevHll7dq1loRxjCtb9zB98cUXGvnjf1Qpx1gngiZ351YREVFwmDlzpv6INycP4diUOnVqb28W+ZBIhpNjXGnTptUilLbDaagAjsRtX192BcnhyNNCdr67ksPRjYvkb9thxaLDN8rVe08kZfyYsrNvOZc/dzALr92J7R6IuM+7FsrWdOnSRYfkAJ0BKH+TKFEitnsQ7O/3nIgNnH52LLGC2QW2UIwST0hERORPMLqBgpYImjCqgZI7K1euDBU0EUUocEIdp6VLl4a6fPny5ZrrRERE5C8w6PLhhx/qqhiJEyfWosrInWXPNbksxwlLoyCnCDWVULvJzHHatm2bfPbZZzJhwgTLbdHtSURE5KvQw4RJR59++qmuh4rlvIhcGjhhYV10Xx49elRPJkzZxHXWOyMDJyIi8jVIOcEivWb9QSzhhR//OG4RuTxwQhkAIiIif4TCzR999JFOZMK6qJjNDQyayFFvlJrOhQ2JiMhfYJZc0aJF5cyZM1r2houCk8cCJwzJvfvuu1p2Hif8PW3atAhtABERkTthIV6U0MGSXVhjtVKlSrJ3715dLozI7UN1KFY5duxYXRXaTA5Hd2e3bt10SiemcRIREfmCy5cvS926dXUSE2DG3MCBA7naBHkucMLsAyyT0rBhwxAlCnLnzq3BFAMnIiLypeE5BE2YwPTzzz+zbA55PnB6/vy5ruFjCwv2vnjx4s23iIiIyEV69uwp165d06E6rK1K5PEcJ4wRo9fJFiquNm7c+I03iIiI6E2WzsCyYOZac1gAHuuoMmgir/U4mcnhv/32m85OgF27dml+08cffyzdu3e33A65UERERJ5w5MgRLTVw8uRJrdU0ZcoUNjx5P3A6fPiwZSYCpnRC0qRJ9YTrTKyJQUREnjJv3jxp2bKlPHr0SBejb9GiBRuffCNw2rRpk3u2hIiIKAJ5t8hj+uabb/R8uXLlZO7cuZIsWTK2JfleAUwiIiJv+ffff6Vs2bKWoOnzzz+XdevWMWgi38txwho/CxYs0LwmFBaztmTJEldtGxERUZhw/Dl27JjEjx9fZs2aJR988AFbi3yvxwnjyMWLF9eddenSpdpNioS833//XRIkSOCerSQiIrKRIUMG/bGOH/MMmshnA6fhw4fr1M6VK1dK9OjRtYv0+PHjUq9ePXnrrbfcs5VERBT07t+/Lw0aNJDVq1db2qJ06dLy9ttvB33bkA8HTphJV61aNf0bgdPDhw91Bh2WXEEtJyIiIlfDKEeRIkVk/vz58sknn+jsOSK/CJwSJUqkUT+kSZPGUoIANTO4IxMRkastWrRIChcurMFT6tSpNU0kduzYbGjyj8Dpvffek/Xr1+vfWDixa9eu0rp1a127DtNAiYiIXAHLePXo0UOPNQ8ePJAyZcrIvn37NM+WyG9m1X333XeWUvb9+vWTaNGiyfbt26V27dryxRdfuGMbiYgoyOA4U7lyZfnjjz/0PGo1Icc2atQITQYncpmozkb/q1atkkqVKun5yJEj65pARERErhQzZkzJli2b7N27V2bOnKk/zon8bqgOkX67du0sPU5ERESuYhhGiFxZzNrG0ByDJvLrHCck6B04cMA9W0NEREEJM7QbN24sNWvWlJcvX+plMWLEYKkB8jlODxZ36NBBunfvLpcuXZICBQpInDhxQlyfO3duV24fEREFuJMnT2qvEmZpY2Rj586dUqJECW9vFpFrAicUH4MuXbpYLkMdJ3Sx4n/zlwIREdHroLRA8+bN5d69e5IyZUpdzotBEwVU4HTu3Dn3bAkREQUNTDbCTOyvvvpKz5csWVKDplSpUnl704hcGzilT5/e2bsQERGF0L59e5k2bZr+jZUnEEChvA1RwCWHExERvanOnTtL8uTJdQmVsWPHMmgiv8FKYkRE5HbIgz169KjkzJnTMpEIqR9cOoX8DXuciIjIrVCbCQngefPm1ZUmTAyayB8xcCIiIrc5c+aMFCtWTGbNmqW9TubC8ET+ikN1RETkFliiq0mTJnL37l1LPhMW6iUKuh6natWqyZUrV0L9TUREhHp+/fv3lxo1amjQhB4nLJ3CoImCNnDasmWLPH78ONTfREREixYtki+//NIye27z5s2SJk0aNgwFBA7VERGRS9WrV09Wr14tlSpV0vXniAIJAyciInpj8+bNk+rVq0vcuHF1+S0kgxMFIs6qIyKiCEOqRsuWLaVhw4bSqlUrnTlHFMjY40RERBGCApa1a9eW/fv3S+TIkbVOE1GgY+BERERO+/XXXzV/6fbt25I0aVIdqitXrhxbkgIeh+qIiMhhr169ksGDB2spGgRNhQsX1lIDDJooWEQocEqfPr1lQUbrv4mIKLD9999/MnnyZM1lat++vZakSZcunbc3i8i3h+qsS+azfD4RUfBIliyZLFiwQPObmjVr5u3NIfI45jgREVG4ZsyYIfHixZM6dero+ffee09PRMGIgRMREdn15MkT6dq1q0ydOlXixIkjBQoUkIwZM7K1KKgxcCIiolAuXLigPUx79uzRgpZ9+vTRnFaiYMfAiYiIQli/fr0WtEQieOLEiWXOnDm6fAoRsRwBERFZGT58uAZJCJoKFiyopQYYNBG5oY7TlStXpFOnTq56OCIi8gLUZkKpgdatW8uff/7J4TmiNxmqO3LkiGzatEmiR4+uq18nTJhQbt68KcOGDZMpU6ZIpkyZnHk4IiLyAQiUkMcEI0aMkFKlSknNmjW9vVlE/t3jtGLFCsmXL5906dJF2rVrp124CKKyZ88ux44dk6VLl2pgRURE/uOXX36RihUryrNnz/R81KhRGTQRuSJw+vLLL6Vjx45y7949GTt2rJw9e1aDqDVr1sjatWulcuXKjj4UERF5GQIlfKc3bdpUNmzYID/++KO3N4kosAKnEydO6Icsbty40rlzZ10Je9y4cVKoUCH3biEREbnU5cuXpXTp0jJp0iQ9P3DgQGnTpg1bmciVOU7379+X+PHj699RokSRWLFiMaeJiMjP/P7779KgQQO5ceOG5qnOnj1bqlat6u3NIgrM5PB169ZJggQJLCtkb9y4MdRadUwoJCLyTTNnzpSWLVvq93fevHll8eLF/AFM5M7AyXZBx7Zt24Y4j1kZL1++dHYbiIjIA4oXL67pFh999JEO02HkgIjcFDjhFwoREflfXaZEiRLp31mzZpWDBw9qbSaz/AARubkA5tOnT+Xhw4fO3o2IiDxs7ty5GiQhrcKUIUMGBk1EngickEhYpUoV7eZFknjRokXl9OnTb/LcRETkplIDXbt2lUaNGunEnmnTprGdiTwdOPXu3VsOHDggQ4YMkTFjxsidO3e0JD8REfmOf//9V8qWLSsTJkzQ83379tUil0Tk4RwnrJaNGRnmYo/Vq1fXquEYuosRI4aLNoeIiCLqjz/+kPr168u1a9d0BvSsWbM405nIWz1O+BWTJ08ey/m3335bAyYs7vsmJk6cqGPuMWPGlCJFisju3bvDvT16ulCIM1WqVPr8SHZE9XIiomCGpO9y5cpp0JQrVy7Zs2cPgyYib5cjQOFL2/NYHDKi5s+fL927d9cFghE0jR8/Xnu0UKU8efLkdsftK1SooNctWrRI0qRJIxcuXNAibkREwSx37tya04Tv5O+//15ix47t7U0iCu7ACR9G9O5YT2F98OCBLvyL5VdMt27dcvjJseYd8qRatGih5xFArV69WqZPny59+vQJdXtcjsffvn27RIsWTS9DbxURUTA6efKkRI8eXRInTqzfzVhvDov0stQAkQ8ETjNmzHDpE6P3aO/evfL5559bLkMAVr58edmxY4fd+6xYsUKKFSumQ3XLly+XZMmS6S8sJK7b9oYREQWyBQsWaBXw999/X78P8f1p/qAkIh8InDJmzKhVZ/FrxhVu3rypVcZTpEgR4nKcP378uN37nD17VtdZaty4seY1oRxChw4d5Pnz57pIpT1IXsfJdO/ePUtBT3cU9cRjonfO/mObw5phXU/uaXdyF7a75+H7Dj84sci62fOP7zVzLVFyL+7zgdnuzjyuw1EQprciEdxe7pGn4IXh+adOnao9TAUKFJB//vlHRo8eHWbgNGLECBk8eLDdulRPnjxxyzbevXtX32DrIUx4+X9vDP6/fv26y587mIXX7sR2DxT43sBSVzt37tTzrVq1kv79++t3mTu+zyg0ftcEZruj3plbcpxcKWnSpBr8YAaINZxPmTKl3ftgJh26oq2H5VAS4erVqzr0h7F+W/hlhgR0E36ZpUuXTof53PELDW8u8gvw+LZvbpT/O4//vRmABqLw2p3Y7oFg27ZtWmoAP2DjxYun+UwlS5bkPu9h/K4JzHbHzH5HOTXu5sqEQwQ56DHCUgC1atWyNAzOd+rUye59SpQoIXPmzNHbmQ2H5EgEVPaCJkDJAnt1pnB/dx1g0U72H99sv/9dT55qd3IntrtnhucwiQZBU86cOWXx4sVaEgY9UNznPY/7fOC1uzOP6VTg1Lx589cWu1yyZInDj4eeoGbNmknBggWlcOHCWo4A6+CZs+w+/vhjLTmA4TZo3769fPfdd7qUQOfOneXUqVMyfPhw6dKlizMvg4jIr6CnHevO4fsPte+w9BXz+Yi8w6nACd3DsWLFctmTo9sZuUYDBgzQ4ba8efPK2rVrLQnjFy9eDBEFYoht3bp10q1bN61ZgqAKQRRm1RERBRL0ph8+fFg++ugjPV+oUCH56aefvL1ZREHPqcAJax+5OjcHw3JhDc1t3rw51GUoR2AmRhIRBaKlS5dqbzxyN1G3Ln/+/N7eJCL6Pw4P6rGgGhGRe7148UKL/6KXCbN8kMKAHE4i8h1em1VHRET/HxK9GzRoIJs2bbLkgI4cOZJFLYn8NXDChxll/YmIyLWQflCnTh2tSxcnThxdXqpevXpsZiJ/HaqbN2+elC5d2qGq4ZcuXdJ6I0RE5BhMekHQlC1bNvnrr78YNBH5e+A0efJkLTQ5atQoOXbsWKjrUc0TS6Bg3TgkMf7333/u2FYiooCE6t8Yltu9e7d+1xKRnwdOf/zxh3z11Veyfv16effdd7XiNoqv5cqVS9KmTStJkiSRTz75RN566y2dPluzZk33bzkRkZ/COptNmzaVx48f63mUXUFZFZR8IaIAyXFCMIQTFufdunWrXLhwQT/0WDolX758emLFZiKi8K1YsUKL+6KnHt+f5mK9RBSAdZwAH3RziRQKbc2hKzJ67XF5+vKw1RIr/3P9PhfhJApWL1++1MXIhw0bpueLFy8uPXr08PZmEZG7AycK37gNp+TC7fADpDgx/v8ixUQU+NBTjxxQpDsAlokaPXp0mGtsEpHvYuDkYg+fvtD/I0cSSR4vpt2g6bOK77j6aYnIRx04cEDTHDDjOHbs2DJt2jRp2LChtzeLiCKIgZObJI8XQ3b2LeeuhyciP5EoUSJ59OiRTqjBIuiYYENE/ouBExGRG/KZokT535B8+vTpdfFyBE4JEiRgWxMFy1p14X1BoCv69u3brtkiIiI/dvbsWV1jbuXKlZbLChYsyKCJKFgDp08//VR+/PFHS9CEiuIoepkuXTrZvHmzO7aRiMgvoBBwgQIFZN++fbrWHBbtJaIgD5wWLVokefLk0b/xi+rcuXNy/Phx6datm/Tr188d20hE5BelBqpVqyZ37tyRIkWKyO+//+7QMlVEFOCBE6bVpkyZ0vLrqm7dupI1a1atHH7o0CF3bCMRkc/CElPVq1eXIUOG6PkOHTroagvohSeiwON04JQiRQo5evSo/sJCwmOFChX0cswaMZMhiYiCAXI7MTSH78JYsWLJrFmzZOLEiRIjRgxvbxoRuYnT/cgtWrTQlbtTpUolkSJFkvLly+vlu3bt0pW9iYiCqdRA1apV5bfffpPFixdb0hiIKHA5HTgNGjRIF/e9ePGiDtOZv6zQ29SnTx93bCMRkc948uSJ9rAnTpxYz2OtOazbmTBhQm9vGhH5SuCEL4iTJ0/qOnXIZfrmm29CreLdrFkzd20jEZFPwOLmtWvX1tIC69at0+Rv/Hjk0BxR8HAox+nZs2dy7949/funn37SX1xERMEEgRJKr+zdu1dr150+fdrbm0REvtrjVKxYMalVq5YmQRqGoQtUIhHSnunTp7t6G4mIvObVq1cybNgwLTeA7z8Us0RZFlQEJ6Lg41Dg9Msvv+g4/pkzZzQh/O7du+x1IqKgmDXXtGlTWb16tZ5v06aNpirEjBl6AW8iCg5RHS1BMHLkSP07Y8aM8vPPP0uSJEncvW1ERF7VqFEjLTWAHKZJkyZpjicRBTenZ9WhUjgRUTAYNWqUXLp0SeszIb+JiMihwGnChAnaRY3uafwdHuQ/ERH5o6dPn8qOHTukTJkyeh6lV/7++2+JHPmN10MnomAKnJDf1LhxYw2c8HdYkP/EwImI/BF6lurUqaML9GLJlOLFi+vlDJqIyOnAyXp4jkN1RBRoNm7cKA0aNNC1OFEN/MGDB97eJCLyUU73P2MhS1TNtYXKueYil0RE/gDlBTDxpWLFiho05cuXT+s04TwRkUsCp8GDB9v9NYZgCtcREfkDlFX56KOP5PPPP9daTc2bN5dt27bpzGEiIpcFTviFhlwmWwcPHrSs3URE5Ovmz58vy5Ytk+jRo8v333+vxXvDKuxLROR0OQKM+yNgwilr1qwhgqeXL19qL1S7du0cfTgiIq9q3bq1HDlyRJo0aSKFChXiu0FErg2cxo8fr71NKACHITkscmnCL7YMGTLo0ixERL4Ia26OHj1aZ/5ikXL8+EMVcCIitwROzZo10/8x/o9putGiRXPqiYiIvOWff/6RevXqyfbt27UuE4bpiIjcFjjdu3dP4sePr39j1glm0OFkj3k7IiJfsHnzZqlfv75cv35de8oxNEdE5NbACflNV65ckeTJk0vChAntJoebSePIdyIi8jZ8J3399dfSp08f/V7KnTu3LF68WLJkyeLtTSOiQA+cfv/9d8uMuU2bNrl7m4iI3gh6yZGPiUAJmjZtKlOmTJHYsWOzZYnI/YFT6dKl7f5NROSLHj58qDWZkIuJBHDM+LXXU05E5PY6TmvXrpWtW7dazk+cOFHy5s0rjRo1ktu3bzu9AURErpYqVSrtbdqyZYu0b9+eQRMReS9w6tmzp3aDw6FDh6R79+5StWpVXcMOfxMRedrz58/1+8d6thxm/xYtWpRvBhF5pxyBCQFSjhw59G/8oqtRo4YMHz5cVxRHAEVE5EmYuIJZc3/++afEjRtX3n//fUmWLBnfBCLyjR4nFLs0F/ndsGGDZTFMJI+bPVFERJ6AtIH8+fNr0IRSKD///DODJiLyrR6nkiVLapd4iRIlZPfu3Zau8ZMnT0ratGndsY1ERKFKDSDpG6kDL168kJw5c8qSJUt0OSgiIp/qcfruu+8katSosmjRIpk8ebKkSZNGL//111+lcuXK7thGIiKLV69e6WSUbt26adDUsGFD2bVrF4MmIvLNHqe33npLVq1aFerycePGuWqbiIjCFDlyZEmXLp3+gEOBy86dO3PWHBH5buAEqMK7bNkyOXbsmJ5HN3nNmjUlSpQort4+IiLLIr3IsQRMSEFPE5aAIiLy6cDp9OnTOnsOi2a+8847etmIESP0F+Dq1aslc+bM7thOIgpSGI7r27evFrTEygUIntDbxKCJiPwix6lLly4aHF26dElLEOB08eJFyZgxo15HROQq165dkwoVKsjo0aNl+/btsmbNGjYuEflXj9Mff/whO3futKxdB0mSJJGRI0fqTDsiIlfYsWOH1K1bV3u3UZ9pxowZUqtWLTYuEflXj1OMGDHk/v37oS5/8OCBJf+AiOhNSg1g9i7WxUTQlC1bNi19UqdOHTYqEflf4FS9enVp06aNTv/FFxxO6IHCIppIECciehODBg3SmXJYRgXBEoKm7Nmzs1GJyD8DpwkTJmiOU7FixSRmzJh6whBdlixZtCAdEdGbaNKkiQ7/o9TAggULJF68eGxQIvLfHKeECRPK8uXL5dSpU1qOIFKkSPprEIETEVFEnDlzxjIj9+2339bzCRIkYGMSkf/3OJnw5YYFfjF0x6CJiCJaE65fv35a2gRrX5oYNBFRQAVOP/74o7z77ruWoTr8PW3aNNdvHREFrJs3b+oyTShmiQAKC/YSEQXcUN2AAQNk7NixmryJPCdz2jDWjUI9pyFDhrhjO4kogJiz5FAPLnbs2PpjrEGDBt7eLCIi1wdOWNj3hx9+0OUOTJhNlzt3bg2mGDgRUVgwC3fq1KlaLBdLqGTNmlWWLFmiyzYREQXkUB2mCBcsWDDU5QUKFNClEYiIwrJ582YtXYKg6cMPP5S//vqLQRMRBXbg1LRpU+11soVfkY0bN3bVdhFRACpTpoy0atVKRo0aJYsXL5b48eN7e5OIiNw7VAfIR/jtt9+kaNGieh7FMJHf9PHHH0v37t0tt0MuFBEFN3xXFCpUSBIlSqTlS/AjC/8TEQVF4HT48GHJnz+//o1aK5A0aVI94ToTvxiJghtmyiHnEaeqVavKypUrJXLkyPxuIKLgCpw2bdrkni0hooDx33//6dD9unXr9HyGDBk0kELgREQUdEN1RERh2bt3r9SuXVsuXLggsWLF0qE5LKNCRBQIfOLn38SJE/UXKYppFilSRGu8OGLevHna7V+rVi23byMROZb/iLUrETRhCRUsAM6giYgCidcDp/nz52tC+cCBA2Xfvn2SJ08eqVSpkly/fj3c+50/f1569OghpUqV8ti2ElHYHjx4IEOHDpWnT59qbbc9e/ZofTciokDi9cAJM+9at24tLVq0kBw5csiUKVO0kvD06dPDvA9yJZA/MXjwYMmUKZNHt5eI7IsbN66WGBgxYoQsXbpUFwQnIgo0Xs1xQhE85EN8/vnnlsuQPFq+fHldxiUsmKWTPHlyadmypfz555/hPgd+/eJkunfvnv7/6tUrPbmaYfW/Ox6f7ENboyo129yzfv31Vzl37pwWtYR8+fLpyXxPyH24z3sH2z0w292Zx3U6cPrpp5+09EC1atX0fK9evTT5E71Fc+fOlfTp0zu1yCd6j1KkSBHicpw/fvy43ftgIVDkURw4cMCh58CvX/RM2bpx44Y8efJEXO3Vy1eW/1833EgubPdXr+Tu3bv6weLMLc+09/jx42XMmDESLVo0yZYtmy72TZ7Dfd472O6B2e737993X+CElczNyuHoFUJi97hx42TVqlW60C/WnXIXvDBULsdaeQjeHIHeLOuinOhxSpcunSRLlswtVYsjR4ls+R+9YuS5DxUmCuB9ZeDkXrdv39Zit2vWrNHz9evX1wW/MYOOPIf7vHew3QOz3TE5zW2BE1Yzz5Ili/69bNkynXbcpk0bnUmD5RScgeAnSpQocu3atRCX43zKlClD3R4FN5EUXqNGjVDda1GjRpUTJ07oTB5rMWLE0JMtNLw7Gj+S1f88gHsWPlTuel/pf9DTi8/82bNn9YsGP5xQ3BJBE9vd87jPewfbPfDa3ZnHjByRBFAUtzOXUqhQoYL+jS/Rx48fO/VY0aNH18WBN27cGCIQwnn8grWF4YBDhw7pl7d5wuydsmXL6t/oSSIi95g1a5Z+LhE0ZcyYUbZv3y7NmzdncxNRUHG6xwmBEhbpRALoyZMn9dcmHDlyRGsxOQvDaM2aNZOCBQtK4cKFNW/i4cOHOssOMCSQJk0azVVCcGabR2HO3GF+BZF7obcXeYH4zP/yyy+69hwTwIko2DgdOKFr/osvvtAhO0w9TpIkiV6O2XENGzZ0egOQH4FE7QEDBsjVq1clb968snbtWkvCOBYP5hAAkffhc4+hcHzO+ZkkomAVyUCKehBBcniCBAk0O98dyeFFh2+Qq/eeSsr4MWRn3/Iuf3yyDz0fmMWIhHwe1F1jw4YNMmrUKFm+fHmYid9sd+9h27Pdg8krN3/HOxMbONTj9Pfff+tQGDYWf4eHlYKJ/P8L6quvvtIeJvyN4AmV/YmIyMHACcNnGEZDpIe/kdlu3VFlnsf/qMtERP7pzp07mnO4YsUKPf/JJ59I7969vb1ZRET+FTihMjBqJ5h/E1HgwYzVjz76SE6fPq0lPL777judCEJERE4GTtbVwJ2pDE5E/rN0CuozoaTIW2+9pRM/MNOViIhctFbd0aNHdcYb1puzhrpKRORfcubMqYtrlypVSmbPnu1wZX4iomDjdOCE4ncffvihdutb5zrhb2COE5F/ePDggRa0BfQyoaAlyg2gmj8REdnn9Jy+rl27atVgTAvEL1QUvtyyZYt262/evNnZhyMiL9i0aZMunYRSA6asWbMyaCIicnXghIV9hwwZol355poxJUuW1MreXbp0cfbhiMiD0EM8evRoKV++vK4JOXbs2BAzZImIyMWBE4bi4sWLp38jePr3338tSeNYZJeIfBMKvNWpU0d69eql9ZmwnBGSws1hdiIickOOEwphHjx4UIfrihQposXxsFjv1KlTJVOmTM4+HBF5ACZzoNQAftxEixZNJkyYIG3btmXQRETk7sAJ1YSxCC9gyK569eo6Ewdr1s2fP9/ZhyMiN8O6klhAG5/btGnTyqJFi/RHDxEReSBwqlSpkuVvJJceP35cbt26pSuls8ufyPekS5dOq4Gjt2nu3LmWYrZEROTmwOn58+e62OeBAwd0yM6UOHHiCDw1EbnLlStXdIYclkmCcePG6XmWGiAi8mByOHIjUO+FtZqIfNeff/4p+fPnlwYNGsiLFy/0MuQhMmgiIvLCrLp+/fpJ3759dXiOiHwHygqgZ6ls2bK6KPeNGzfk5s2b3t4sIqLgznHCwp9YBDR16tRagiBOnDghrt+3b58rt4+IHHD//n1dkHfBggV6vlGjRjrT1fbzSUREHg6catWq9YZPSUSuhAkaKDVw7NgxiRo1qvY6dezYkZM1iIh8IXAaOHCgO7aDiCI4PNe0aVMNmtALvHDhQilevDjbkojIV3KcMBzANemIfANKgMycOVOqVaumw+QMmoiIfCxwQsJp5cqVtTZMz549tYo4EXkO1phbsmSJ5XzOnDll1apVkiJFCr4NRES+FjhhNXXUiOnfv7/89ddfOu0ZX9zDhw+X8+fPu2criUht375dP3P169eXbdu2sVWIiHw9cAJUCW/Tpo0O2V24cEGaN28uP//8s1YSJyL35DJ9++23Urp0aV1Y++2339ZljoiIyA8CJ+tK4nv27JFdu3ZpbxOHCohcD2vMNWnSRLp06aIFLevVqye7d++WbNmysbmJiPwhcNq0aZO0bt1aAyX0NsWPH19zLC5fvuz6LSQKYidPnpSiRYvKnDlztPL32LFjZd68eRI3blxvbxoRUVByuhxBmjRptGo4EsRRYK9GjRoSI0YM92wdUZD79ddf5fDhw5IyZUotblmqVClvbxIRUVBzOnAaNGiQ1K1bVxImTOieLSIiCwzP3bt3T8uApEqVii1DRORvQ3UYomPQROQeKPeBiRdYQsWs04QZrAyaiIj8tMeJiNwDkyzq1KmjuYJPnz6Vn376iU1NRBRIs+qIyDWlBqZMmaL5SwiasmbNKr169WLTEhH5IAZORF706NEjnZnavn17Le/x4YcfamFZFJUlIiLfw6E6Ii9B7bNatWrpskWRI0eWkSNHSo8ePTSviYiIAqjHCVXCS5Qooauxo3I4jB8/XpdjISLHxIwZU65fvy7JkiWTDRs26NqPDJqIiAIscJo8ebJ0795dqlatKnfu3JGXL1/q5Zhph+CJiMLPZzKhNtPKlStl3759UrZsWTYbEVEgBk5YL+uHH36Qfv36aSVjU8GCBeXQoUOu3j6igPHff/9JlSpVZO7cuZbLChQoIGnTpvXqdhERkRsDp3Pnzkm+fPlCXY7q4VhTi4hCw5qOCJLWrVunRS35WSEiCpLAKWPGjHLgwIFQl69du1ayZ8/uqu0iChjTpk3TnEDkA2bJkkU2btwoceLE8fZmERGRJ2bVIb+pY8eO8uTJE83XwCrtGHoYMWKEHiCI6H8eP34snTp1kunTp+v5mjVralFLVt4nIgqiwAlrZsWKFUu++OILrUHTqFEjnV33zTffSIMGDdyzlUR+Bj8sUNBy7969Wmrgyy+/lN69e+vfREQUZHWcGjdurCcETg8ePJDkyZO7fsuI/LzUQLly5XR4Dj2y5cuX9/YmERGRC7zRz9/YsWMzaCL6P69evZLbt29b2mPYsGFa3JJBExFRkPU4YRado4X5UJOGKNjcunVLmjZtqiUH/vjjD51lGjVqVB3GJiKiIAucsCyEde7GpEmTJEeOHFKsWDG9bOfOnXLkyBHp0KGD+7aUyEft379fateuraU6MESHHw/mZ4OIiIIwcBo4cGCI5HDUoRk6dGio21y6dMn1W0jkw2bMmKE/GPCDAqU6lixZInnz5vX2ZhERka/kOC1cuFA+/vjjUJc3adJEFi9e7KrtIvJpT58+lbZt28onn3yiQVO1atV0Bh2DJiKiwOZ04IRSBNu2bQt1OS7DMAVRMGjXrp1MnTpVc//Q+7pixQpJlCiRtzeLiIh8rRzBp59+Ku3bt9c8jsKFC+tlu3bt0iJ//fv3d8c2EvkcrNW4ZcsWzferVKmStzeHiIh8NXDq06ePZMqUSQte/vLLL3oZllpBrke9evXcsY1EPlFqAJMgihcvruexdMqJEyd05hwREQWPCH3rI0BikETB4s6dO5rXt2rVKl2TsWLFino5gyYiouDDn8tE4fj777/lo48+kjNnzmhtpuvXr7O9iIiCGBfOIgoDhqKLFi2qQVP69Ol1AgRmjxIRUfBi4ERk49mzZ9KpUyetBP748WNN/kapgQIFCrCtiIiCHAMnIhsrV66UiRMn6t8DBgyQ1atXS5IkSdhORETkfI4Tiv2FVa/pypUrkipVKjYr+TXkNKHsRrly5aR69ere3hwiIvLnHqf8+fPLgQMHQl2OquG5c+d21XYReYxhGFqPCQv1Aopajhs3jkETERG9eeBUpkwZTZj96quv9PzDhw+lefPmmg/St29fZx+OyKvu3bsnderUkY4dO2riN+o1ERERuWyoDr/MsS4XFvtFXRsMz8WNG1d2794t7777Llua/MaRI0d0WO7kyZMSPXp0+eCDD7S3iYiIyKV1nKpUqaIHnMmTJ2sRQCTTMmgifzJv3jxp2bKlPHr0SNKlSyeLFi2yLCFERETksqE61LQpVqyY9jatW7dOevXqJTVr1tT/nz9/7uzDEXkU9lEkfjds2FCDpvLly2upAQZNRETklsApb968kjFjRjl48KBUqFBBvvzyS9m0aZMsWbKEBx/yeQ8ePJBly5bp38jJwxIqyZIl8/ZmERFRIOc4IRHcGhY+3b9/v/6SJ/JliRIl0hmgly9f1pwmIiIitwZOtkGTKV68ePLjjz86+3BEbi81MH78eIkfP77mNAEqgLMKOBEReSRwmjVrVpjXYUZSWIEVkafdv39fZ38uWLBAZ82hlEbmzJn5RhARkecCp65du4ZKtkWSLQ5MsWPHjlDghOUtRo8eLVevXpU8efLIt99+G2a+1A8//KDB2+HDh/U8eg6GDx/O/CoK4dixY1K7dm39P1q0aDJ27FjJlCkTW4mIiDybHH779u0QJyTbnjhxQkqWLClz5851egPmz58v3bt3l4EDB8q+ffs0cMKiqtevX7d7+82bN+uMKCSk79ixQ6eSV6xYUf755x+nn5sCk1laAEFTmjRp5I8//tACl6zRREREPrHI79tvvy0jR44M1RvlCPQEtG7dWlq0aCE5cuSQKVOmaM/V9OnT7d5+9uzZ0qFDB53dly1bNpk2bZpWe964caMLXgn5uz59+kjdunU1oC9btqwG4yifQURE5DOBE6AQ5r///uvUfZ49e6Y1dFBLx7JBkSPrefQmOQLDhBguTJw4sdPbTIEHkxQAdcV+++03SZ48ubc3iYiIgjnHacWKFaFmLWHZle+++05KlCjh1GPdvHlTXr58KSlSpAhxOc4fP37cocfo3bu3pE6dOkTwZe3p06d6sl6bDNBL5Y51yQyr/7numWdgH8IwHPZF7A/vvfeelCpVSq/je+BeaF+0O9vZ89j23sF2D8x2d+ZxnQ6catWqFeI8DlgoIPj+++/L119/LZ6E4UEsnYG8p5gxY9q9zYgRI2Tw4MGhLr9x44Y8efLE5dv06uUry/9h5WmRa+BDhBIYyGlCbSb0YOKyd955h23vIfiyuXv3rrY7eovJc9j23sF2D8x2xyxstwVOroz2kiZNKlGiRJFr166FuBznU6ZMGe59x4wZo4HThg0bJHfu3GHe7vPPP9fkc+seJySUI9hDbR9XixwlsuV/DhO5z8OHD6VNmzYaOAMqgGP9RLyvPIB7Dr4PzB9PbHfPYtt7B9s9MNs9rM4Xly3y6yooYYByAkjsNnuyzETvTp06hXm/UaNGybBhw3StvIIFC4b7HDFixNCTLTS8Oxo/ktX/PJC4x8mTJ7XUAEpSILcOQXS7du20F9Fd7yuFDV9mbHfvYNuz3YNJJDd+1zjzmBEKnLBcBXKdLl68qMMjtrPknIHeoGbNmmkAhCnkqPKM3gTMsoOPP/5Yp5RjyA2++uorGTBggMyZM0cyZMigtZ8gbty4eqLAtnTpUmnevLn2HKJXcuHChVoKgzk2RETkCU4HTugNqlmzphYTRAL3u+++K+fPn9dxx/z58zu9AfXr19eeAgRDCIJQZgDDLmbCOIIz60hw8uTJGqzVqVMnxOOgDtSgQYOcfn7yH99//732LAGSv1EDLFWqVN7eLCIiCiJOB07IGerRo4cmXGPqN5JykcvTuHFjqVy5coQ2AsNyYQ3NIfHbGoI0Ck5Vq1bV8e0mTZpozyMqghMREfl04IRqzGaFcOSXPH78WIfIhgwZoqvNt2/f3h3bSUEKw8Jp06bVv5HUf/ToUZ1UQERE5A1OZ1jFiRPHkteEYZIzZ86EqMtE5AoY+p00aZIuyrts2TLL5QyaiIjILwIn9Cghabto0aKydetWy9DJZ599pjPcPvnkE72O6E2hGjwmDGB9OQTptkVXiYiIfD5wQk4TAifMmitSpIjlsnLlymmSLma4oRgh0ZtADybWlvv555+1xtfo0aO5XxERkf/lOGHoBDCbznrYDovyErnCypUrpWnTplodFhMOEJCXKVOGjUtERP6ZHI7iU0TucOjQIS1zAcWLF5cFCxZo/S4iIiK/DZyyZs362uDp1q1bb7pNFIRy5colnTt31r9RCRxV5YmIiPw6cEJOU4IECdy3NRRU9uzZo6UGzHUJUTWey6UQEVHABE4NGjTgwrX0xpAvN23aNC16ikRwLNSMmmAMmoiIKGBm1TG/iVwBBVNbtmwpbdq00VIDCRMmlCdPnrBxiYgosAInc1YdUUSdO3dOSpQoITNmzNDeJSzcvGTJEi7OTEREgTdUx9Xn6U38+uuvup7h7du3tfr3vHnztAYYERFRQK9VR+SsFy9eaIV5BE0onrpw4UJdd46IiCjg16ojchYSvxctWiRdu3aVP/74g0ETERH5LQZO5Bb79u3TXCZTjhw5tNxAjBgx2OJEROS3OFRHLoeAqX379jpEh6KpSAgnIiIKBOxxIpdBWQGUGfjkk0/k6dOnUqVKFe1pIiIiChQMnMglLly4IKVKlZIffvhBa34NHTpUli9fLokSJWILExFRwOBQHb2x9evXS8OGDeW///6TxIkTy5w5c6RSpUpsWSIiCjgMnOiNHT58WIOmggUL6uy59OnTs1WJiCggMXCiN/bpp59q9e+mTZtKzJgx2aJERBSwmONETjt48KBUq1ZN7t27p+eR09S6dWsGTUREFPAYOJFTZs2aJcWKFZM1a9ZI37592XpERBRUGDiRQ1BeoEOHDtKsWTN5/PixVK5cWQYPHszWIyKioMLAiV7r0qVLUrp0aZk8ebIOyw0cOFBWrVolSZIkYesREVFQYXI4hWv37t2az3Tz5k1JmDChzJ49W6pWrcpWIyKioMTAicKF0gLRo0eXvHnzyuLFiyVTpkxsMSIiCloMnMju0ilmWYEUKVLIxo0bNYCKFSsWW4uIiIIac5woVDHL3Llz65CcKVu2bAyaiIiIGDiRtblz50qRIkXk1KlT8uWXX8qLFy/YQERERFbY40Ty7Nkz6dKlizRq1EgePXok5cuXlz///FOiRuVILhERkTUGTkHu33//lbJly8q3336r51HUcu3atZI0aVJvbxoREZHPYZdCELtz544UKFBArl69KvHjx5eff/5Zatas6e3NIj/y8uVLef78uU4oiByZv8M86dWrV2x7L2C7+2e7R4sWTaJEieKSbWHgFMRQl6lFixZazHLJkiWSJUsWb28S+QnDMDTgvn37tn6h3b9/X4ujkmffA7a957Hd/bfdccxLmTLlG39XMXAKMtjpHjx4IKlSpdLzQ4cOlS+++EJix47t7U0jP4KgCT2WyZMn1zpf+DXHwMnzBxJM4EAuItue7R7ojDfY33Ff5O9ev35dz5vHv4hi4BREjh07Jh999JEOy23ZskVixIihXZcMmsjZ4TkzaEqcODEP3l7CwIntHkyMN/yhYNYhRPCE7643GbZjUkKQWLhwoRQuXFiOHz8u//zzj1y4cMHbm0R+CnkGwICbiPyJ+Z1lfodFFAOnAIcdpHv37lKvXj0dosMMun379knWrFm9vWnk5zg8RETB+J3FwCnA81DKlSsn48aN0/O9evWS3377TbspiShwnD9/Xg8KBw4ccOvzNG/eXGrVquXSx5w5c6Ym7b6JDBkyyPjx48VXvPfeezJnzhxvb0ZQmTJlitSoUcMjz8XAKYBhxhwKWcaLF08X6P3qq69Y1JKCGg78CDBwQkJ7xowZ9QcFpjj7s3Tp0smVK1fk3XffFX9Tv359OXny5BsFWX/99Ze0adNGfMGKFSvk2rVr0qBBg1DXjRgxQnNrRo8eHeq6QYMG6WLqjgTFyPeZOnWqrvQQN25cbZOCBQtq8IgkaHe5ePGiVKtWTYe88AO8Z8+er11hAiMcFSpU0G1MkiSJvk8Y/bB9//AjH7dJlCiRVKpUSQ4ePBjiNuvWrZOSJUtqjm6yZMmkdu3a2jamTz75RJ8Lxzx3Y+AUwL777jspUaKE7pRICicikcqVK2uQcfbsWe2N/f7772XgwIFuT6jHVGp3wcEY06z9sdo/knbftBccB1JfybmbMGGC/mi1V2to+vTpGqjj/zfRtGlT+fTTT+WDDz6QTZs2aVDVv39/Wb58uY4quGsfRtD07Nkz2b59u/z0008ayA4YMCDcAstYiQKlbnbt2qXFlY8cOaI/YEwIovCZfOutt/Q2W7du1R/7CJ7MXKRz585pT2eZMmVk//79GkTdvHkzxHENs3ux+gXa3+2MIHP37l0DLxv/u0ORYeuN9L1X6f+edv/+fWPp0qUhLnv16pURDF6+fGlcuXJF/yf3evz4sXH06FH9H/vXs2fP/GY/a9asmfHBBx+EuOyjjz4y8uXLZzmPfWj48OFGhgwZjJgxYxq5c+c2Fi5cGOI+y5cvN7JkyWLEiBHDKFOmjDFz5kz9Xrl9+7ZeP2PGDCNBggR6u+zZsxtRokQxzp07Zzx58sT47LPPjNSpUxuxY8c2ChcubGzatMnyuOfPnzeqV69uJEyYUK/PkSOHsXr1ar3u1q1bRqNGjYykSZPqduH5f/jhB217PDaef//+/ZbH2rx5s1GoUCEjevToRsqUKY3evXsbz58/t1xfunRpo3PnzkbPnj2NRIkSGSlSpDAGDhzoVPvh9eAxkiVLpm1RokQJY/fu3RFqK9OBAwf0dnHjxjXixYtn5M+f3/jrr7+0nXA/65O5venTpzfGjRtneYyTJ08apUqV0udE+//22296e/P70XwscxsAbYfL0JamP//80yhZsqS2d9q0afW14ns2rH3++vXrRqRIkYzDhw+Hug7vR5o0afS+eP+3bdsW4nq8ljx58oS6n+17O3/+fD2/bNmyULfFNt25c8dwhzVr1hiRI0c2rl69arls8uTJRvz48Y2nT5/avc/3339vJE+ePMT38t9//63bf+rUKT2P9xbnL168GOZt8PmLGjWq7m9mu69YsULbGu1p+uOPP3R/f/To0Wu/u94kNmCPU4A4ceKEdtsiArf+xcEEXqKwHT58WH8949eq9XDKrFmzNGcCv467desmTZo0kT/++MPy67dOnTr6CxjDCW3btpV+/fqFemwMmWB4fNq0afo46FXp1KmT7NixQ+bNmyd///231K1bV39tY2Ft6Nixozx9+lTLhRw6dEjvj6EYQI/C0aNH5ddff9XSIpMmTdKhD3swc7Zq1apSqFAh3cbJkyfLjz/+qIt3W0OvQZw4cfSX/qhRo2TIkCGyfv16h3cZ9J4gDQCPg2ES9Cygp+DWrVtOtZW1xo0bS9q0abWnfO/evdKnTx8dVi1evLgORWGoBj2GOPXo0SPU/dGzh+9BvKd4XXgfe/fuLc46c+aMvjcYEsJ7NX/+fO0N6dy5c5j3wfXo+cqePXuo69D+DRs21NeC/3E+ImbPni3vvPOO9jbZwvd9ggQJwrwv9qXwTu3atQvzvthvc+XKJSlSpLBchvf63r17un/bg30Z74N175tZFgBtBXgt2I/RHujNevz4sf6NNkTuGmCFCzwG9jP0fN29e1dXukBvFtrThOFKDB3ifXcn/+vXpVBQ9RtdnyhuicJe+CIk8rQa326VG/efevx5k8WLISs7l3T49qiUj4MEvmDxxY4vZAxrA84PHz5cNmzYIMWKFdPLMmXKpF/yGNIrXbq0/o8vezNPBX8jABs2bFiI58EwA4KbPHnyWPJDZsyYof+nTp1aL8OBH8MXuBzPi+twoMYBynxuE67Lly+fHhwgffr0YeaX4HmR94TXhYNptmzZdNgEAQSGVswDWe7cuS3DlG+//bbefuPGjZqT8joPHz7UgAzDNVWqVNHLfvjhBw28cOBD/oujbWUNrxP3xTab22VCUIDXg2HJsOC9Q9kVDOeY7Yy2NbfRUQigEcRhSMzcDgwDYR/A/2ZAaw1lXhBY2A7TIbhYtGiRBh+AQLxUqVLyzTff2H2c8CDIRjtGxOsmDyAoDW+ykXXQBOZ5XGfP+++/r7O68f537dpV9xkEwoDAFzAst3nzZg2uUZDZbGu8f+bQM3IRcR75cB06dNDgCZ/PNWvWhHg+BK3YR9xdboeBkx/DlyZ+veGXojmTA7+KwvtSIXIXBE1X7/l+kjVKcuCAjy9x5DjhyxnBCpw+fVp7imwDB/wSRtBi9u6iJ8caaqTZwi9tBCYm9CDhC9+2FAiCNbPnqEuXLtK+fXvtNcavaWyX+Ri4HOfRs1OxYkXtcbD3vIAeKRxYrHucke+IfJLLly9rPglYbx/gh5dZXdmRHhkEh3hcE379Y5vw/M60lTUcaFu1amXpUUCvXObMmcVReG4EjWbQBGYQ7Az0kKGnCT08tst+oCfNDG6tobckZsyYoS6fO3euvgYziEYSOAJffF+3bNnSqe3CNkSUp5fVypkzp/YS4T39/PPPNRcP+7h1cIk2QxtgP0I74TMyZswYzadCryN6qBCYIakcASeCWezH+AGA3kwE6tb7OW7vzgR5YODkp/DlhlkbSAwE7JgjR44M0W1J5OmeH394XvTImgcQJOniYIYeEnx5m7N9Vq9eLWnSpAlxP1Tadwa+wK2/0PHYOHBg+Mm2arHZ64CAAcMfeH4ET+j1+Prrr3V4CD0m+CWNX9k4WCCoQDCF6yPK9vsC2+vOJHZHYHYZknzRBhiWRI8YhjY//PBDlz2HedC2DkJsiyLi/cLQIg701nAf66DMWtKkSXX9RlvYvzCcZZ28j3bG/mcGTujtwRCULVTpB3MIDoE3etQi4nW9WwhMMLRpD36Q7969O8RlmD1oXhcWvJc44bb47GEfGzt2rKU3FWUbMDsOvXHm+4LLMLsOye44zk2cOFFfP45xZuXwX375RQNkDMsVLVrU8nwYJsZkAXdi4OSn0L2PoAk7Ij58KHBJ5E3ODJf5CnxR9+3bV3944Ms9R44cGiBhuAhDMvZgmMR2iAC/jF8HPVb4NY0fPRimCQsOBsg1wQm/0jH8ZebV4IDQrFkzPWFqNnKM7AVOyA9B7hEO8mbwtm3bNh0WQf6QK6AHBb1qeFz0npjBB9rCHN6KaFshOMAJ+WXIB8JQJgInPB/aMDx47ZcuXdKhIHNNsp07d4a4jXlgxW1wgLY3jJU/f37NKbPtpTGX/gjrPTYXvzYfFz2Ne/bs0eEoLFFkfYDHLDEEQRiWRFuhNxABhvWQGHoY0Ytl9hJiP0UwgaDCNs8J24ZhwbDynN5kqA69dhhivf5/S5YAAnjcB5+b1zFfE45XeD1mry56h/A5tP6RYZ43g3jzNtbMHx/WgT56QVFaxOwddhsjyATSrLpBgwbpDAHirDpPCrRZdZhphtlOo0eP1vP9+vUzkiRJorO/Tp8+bezdu9eYMGGCnoezZ88a0aJFM3r16mWcOHFCZzlhxhW+V8wZTbYzxUyNGzfW2XqLFy/Wx9m1a5fO4Fu1apVe37VrV2Pt2rV6HZ63SJEiRr169fS6/v3760wqzDTCrC3MvsOsOXuz6i5fvqyz8jp27GgcO3ZM74fZeNaz5jCrDs9nDW2DNnK0/XB/zBD79ddfjSNHjuj1mKGHGYARaSvMhsI2Y9YbZhhu3brVyJw5s94fMBMN992wYYNx48YN4+HDh6Fm1WEGF2YjVqhQQWfobdmyxShQoECIWXXYZ9OlS2fUrVtXZ+Ch/d95550Qs+oOHjxoxIoVS7cH7YrboR07dOgQ5j7/4sULnWG4cuXKEG2E99EezKrs0aOHZT/MmTOnUbZsWX2dZ86c0dlkqVKl0hmRJjxv/fr1dduGDRums9LQVnjO999/P9TMalfBa3v33XeNihUrartiP8Vr/fzzzy23wf6MdsT+Z/r22291X8b7/9133+l2f/PNN5brsX9i9mP79u31ewX7dpMmTXSf+Pfff/U2Gzdu1Bl0AwYM0MfB41WqVEnfd+sZdNiXMmXKFOZrcNWsOgZOfhI44Quie/fuxs2bN136uIGC5Qg8J9ACJxgxYoQeBB48eKCvZfz48XoAwEEfl+NLGlOdw5pij2nZ+NI1v5DDCpzQVvjyR/CEx8ZB8cMPP9Tp19CpUycNFPC4eN6mTZtaPvNDhw7VqfU48CROnFhfBw4ib1KO4E0DJ7xeTNFHUOZoOYLw2grT2hs0aKBBDbYbQRnaxPpA165dOw1swytHgHZBGQE8RtasWfUgbx04AYKyXLlyaakBlC5AkGJbjgCvBQEYSiPEiRNHS1N8+eWX4e7zCPLwGszXg20dNWqU3dt+9dVXOl3fnFL/zz//aBu/9dZb+j4jABw5cmSIKffm9x3aEe8vAmSUBEBwiIAkrKn4roAArUqVKrpteM9RWsN6nzLLPFi3IfZh7K94L9B+s2bNCvW4KBeBfQf7AQJvBIA7duwIcZs5c+YYefPm1fcBn42aNWtq0GUNQR0+y+4OnCLhHwkiZjcmxpLD65aMqKLDN8jVe08lZfwYsrNveZc8JhJWMb0WXb7Vq1eXlStXuuRxAwm6a80uZHuF58h10BWO5FjMdMGw1pusWB4oMISB3BAMEfnLavHB1FaANlq6dOkbLxnzunbHUB2SojHEZg5h0pt7Xbsjhwyz+FCFPqyhSuvvLtskfmdiA+Y4+TiU7//444/1zcQYMabpEpF3Ybo/ZothNhxyfDDdGjWaiG2FRGkkgyNPjoGT5yBfDfXXwqtj5SoMnHwUEiAxm8Ssd4LibwsXLgxzNgcReQ5q6aCYJBJ8kbT72WefaSI3sa3A1Qsh0+thlqmnMHDyQf/995/OJDEr+GI6LH7RWlc3JiLvQf0nnMh/2irIslLIjRg4+SCM3yKvCVVQsVwDgigiIiLyPgZOPsL8NYSgCbU+kMSIOhXvvvuutzeNiIiI/g+nH/kAlJz/5JNPtNCdCdWMGTQRERH5FgZOXnb27FlN/MZCmai26+g6UUREROR5DJy8CEsRFChQQMvgYwkArNpulrInIiIi38PAyYulBrD6MxZwLFKkiBZLQ/EuIiIi8l1MDvdChWsszIiVv6FDhw66UrSzK68TERGR57HHydMNHjmyrjIdK1YsrXI6ceJEBk1EFKZBgwZJ3rx5X9tC/fv3lzZt2rAlHXDz5k1Ni7h8+TLbi5zGwMlD7t+/b/kbFYb//vtvadq0qaeenohEpHnz5narOm/evFlLgWDo3B9hfbRvvvlG+vXrF+q6HTt2aGkTpAY487ozZMgg48ePD3HZpk2bpGrVqrrUDOrM5ciRQ6um//PPP+IuWF+sY8eO+pxx48aV2rVry7Vr1177PuN1WZ8qV65suT5p0qS6lBVSJoicxcDJzfChb926tZQsWVIePXr0v0aPHFmyZMni7qcmIj/y/PnzCN8XhXIxO9fe2mhYN61z586yZcsW+ffffyP8HN9//70ua4G12BYvXixHjx7VxXqxjubXX38t7tKtWzdd2BxLTv3xxx/6GrDo+esgUML6ZeZp7ty5Ia5v0aKFzJ49W5fNIfK7wAnDVfh1g9WKkSi9e/fucG+PD1C2bNn09rly5dLZab7owoULGjDhS+3QoUOyceNGb28SkVs9fPgwzBN+RDh6W9Q2c+S27l72KE2aNNqzgu8Z2wPvokWL9HIMu6M3BEGFuU1//fWXVKhQQXs2sOho6dKldQKINfSCTJ48WWrWrClx4sSxrEs5cuRIXdA7Xrx40rJly1DtZs+8efOkRo0aoS5/8OCBzJ8/X9q3b689Tih7EhEY0sLSTzhNnz5dypQpo9/Z7733nn6/DRgwQNwBQRkCP+SBYvIMZiHPmDFDtm/fLjt37gz3vsgbRZBnnhIlShTi+pw5c+ranyg2TORXgRM+1N27d9cuU3yxoPBjpUqVwqxnhA8MvtDwhbJ//37tdsfp8OHD4kvunPpL8ufPL3v37tUv1bVr19r9YiMKJBhKCeuEIRZryDEJ67ZVqlQJcVscpO3dzl0QrOAgjUkc+G5B7hCG1s0fdejBwPcQCtceO3ZMh7zQC2KuAICh+WbNmsnWrVv1AP/222/rEJf1kL2Zv/Thhx/qDys81oIFC/Sy4cOHy549eyRVqlQyadKkcLcVPSbo/SlYsGCo6/B4+JH5zjvvSJMmTTToiciabfix+uzZM+nVq5fd6xMmTBjmffFehrdfIIAJC74/0RNnvYArXg8WVsYQZHjwnmAfw2tH4Ihg2FbhwoXlzz//DPdxiEIxvKxw4cJGx44dLedfvnxppE6d2hgxYoTd29erV8+oVq1aiMuKFClitG3b1qHnu3v3Lr419H93KDx0nZGgZGNDIkXS5ylYsKBx/vx5tzwXGSH2mytXruj/5F6PHz82jh49qv+/evXKePbsmf4P2OfDOlWtWjXE48SOHTvM25YuXTrEbZMmTWr3ds5q1qyZESVKFCNOnDghTjFjxtTHu337dpj3xffOZ599pn/v3btXb+/oZxv7Zbx48YyVK1daLsP9P/300xC3K1asmNGhQ4dQ32958uQJ9Zhm2+/bt08f6+LFi6FuU7x4cWP8+PH69/Pnz7UdN23aZLkef4f1utOnT2+MGzdO/27fvr0RP358IyIuX75snDp1KsxTeG04e/ZsI3r06KEuL1SokNGrV68w7zd37lxj+fLlxt9//20sXbrUyJ49u97nxYsXIW7XrVs3o0yZMk69Htt9njzDFe1u/d31JrGBV8sR4BcMflEgWdqE/B/8ugjr1wQuRw+VNfRQLVu2zO7tnz59qifTvXv3LGUBcHK1S+tnyN2t8/Rv5DYhuRJDiu54Lvr/0L44FrGdPdfWZs+F9f+2PSrWkKBs3dsRXoIvvgesb3vu3Dm7t4tI70nZsmVD9eLs2rVLe5TM14Vaa+j1QU8LEp/xXYXvEQzb4frcuXNLuXLldKgO3z8YlqtTp45lOAiv7YsvvtCcHPSe4/GQ44jhe+ttRq+W9Xn0XrVt2zbEZUWLFtXeE3uvFZeZw5oYmrK+zYkTJ7SHbMmSJXo52r9evXo69IWhQ+v2s34/bR/f/FxhaDEi7Y3hsNcJ63Ft9zF722ZP/fr1LX9j6Sq8T8grRXI73jcTvpvxvjj7usLbLnKfN2136/3Z9ljhzLEjqrenhOILBeP51nD++PHjYc4esXd7XG7PiBEjZPDgwaEuv3HjhkO5A85KVqi6XD+wUdK931SGDOmpgZoZrJH7YKdHPgQ+FDjokvtg6ATt/eLFC/0bn2HAgfV19chwH5Mrbmt9G0dgu5GThKE/awhozMfDadSoUTJhwgQZM2aMHniRg9SjRw/9zjCfE7mV+CG3fv16+fbbbzVQwtBcxowZdZgOQ0NImsawErYf+UDW9zcP3LavAe1pfZn5ZW97OzPAQw6V+Z1mnceDtS9xH+RpWd8H2zJu3Di9H14XYFtthz4x0w55VngMBB34fF26dEmHD52BFAW0S1jQPgcPHrR7HVZUQNCKY4X1cCACUwzDOfr+4zmQb3by5ElL0Gi+blzuzH5ktru5z5NnuKLd8T7jOwDve7Ro0UJcF96PvqArgIneLOseKgQx6dKl0w9k/PjxXf586d56S6J+Ol1SJUnA5VM8yPxFjPeVgZN74eCPL5moUaNavnxsv4R8FfYNnLDt1tAbA7gcJ+QlIWkbAZC5f506dUqn31vfF8EQTshLQjCG2V/4vkEuJia9mHmNCDhw8Ld9bjyv9fns2bNrbhNmfJnQa4R923abrXN+8F2GoADbZx4gMGMMgV/FihVD3B45VehJa9eund4X24TAJXPmzCHW0ESghOvxvOipQqkDJGkj6LKFICusPCckj9sm+1vDvhPWa0MOEq5Hz52ZI4eetIsXL0qJEiXCvJ+95HYcLBFEWt8HuWEIpBx9HNvtJs97k3bH+4z9HXnH+NFizfZ8uI8jXoRIH18ctl32OI9ZEPbgcmduj19X9n6tml+grraiUwntmsevIR7APQsHF3e9r/T/oX3N2jhmu1v/7w9st9X6NeCEZG7MmkOPEnpxEDDgewaBCa7H0B5mySIowWcd59HjY16P+//yyy9SqFAh/bHWs2dP7emybjfr5zN17dpVaxDhfggMEPwcOXJEMmXKFGqb8Qvc3OeR3rBt2zYNigBJ7bdv35ZWrVpZeqRMCECQJI6EaQRcuA1603BAwpAWgrzevXvrECG2Ac+BHhsETJ06ddKgGTWQECgiIEEhX/RWhVWSIG3atBF+nxCMYSIQakXhYIftRWkFFBHGyYQAD6MLeP2YSYhRBrxOHBfOnDmjSe3oNUOJArMdMUSHVBEMyTqz75rt7m/7vL8zXNDu5ufN3nHCmeOGV48w0aNH1zF+62n6+GWH89YfCmu43HZaP7rKw7o9EZGzMOyGWbHIX8LUexyArQtn4gCOukiYKZc1a1a9PQIHczYg8ogQuOAxkDuFafyOLOCN3BxUAMeBHt+NGEJEgPM6CH5QksDM08DzI5iyDZoAAQV6tVCEF1A4Ez1rCJYwww2BG3K40HtmfYDC8lC//fab5nwhQEGwgudFWyDwchcEbNWrV9ftRu8e3gvkbVlDLxR6yAA/xvHa0GOI9waBF9oSs+esf0QvX75cA8JSpUq5bdspQBleNm/ePCNGjBjGzJkzNdu9TZs2RsKECY2rV6/q9U2bNjX69Oljuf22bduMqFGjGmPGjDGOHTtmDBw40IgWLZpx6NAhn5hVx9ld3sF2941ZdeQ51m2PE2aNzZkzh2+BgzBbEbP23qTdyXM4q87mFxa6uFFADQneWJMJNY/MBHCMZVt3oaE67pw5c/QXXt++fbVLHDPqkMBJRBSM0DM0depUrQdFr4d8M9TdQi0uImdFQiQnQQT5Bui+RreuO5LD0VXOHCfPY7t7Njkc5QEwewxDH0hERtIl8z08y5xpx7ZnuwcDwwX7u/V3l20yuDOxAbNoiYiIiBzEwImIiIjIQQyciChCgmyUn4j8nOGi7ywGTkQUoQJ0qINDROQvzO+sNy1eGvCVw4nItVAnB4UJMQkCv+BQjw1fREwO9ywmh3sH293/2h33RdCE7yx8d5krBUQUAycicppZqR9fRJjRaFYTJ88xFytl23sW291/2x1BU1irjDiDgRMROQ1fXFjsFcsmof4alsPgUjeeZS5WyrZnuweDV2+4v6NX/E17mkwMnIgowvBFhC8k1ERh4OT5Awnb3vPY7t7hS+3O5HAiIiIiBzFwIiIiInIQAyciIiIiB0UN1gJYWJfGXeOw9+/f94lx2GDCdme7Bxvu82z3YPLKzcdWMyZwpEhm0AVOaHhIly6dtzeFiIiIfCxGwGK/4YlkBNm6CYha//33X4kXL55b6s4gakVQdunSpdeusExsd3/H/Z1tH2y4zwdmuyMUQtCUOnXq1/ZoBV2PExokbdq0bn8evLEMnDyP7e4dbHfvYduz3YNJfDceW1/X02RiEg4RERGRgxg4ERERETmIgZOLxYgRQwYOHKj/k+ew3b2D7e49bHu2ezCJ4UPH1qBLDiciIiKKKPY4ERERETmIgRMRERGRgxg4ERERETmIgVMETJw4UTJkyKCl34sUKSK7d+8O9/YLFy6UbNmy6e1z5cola9asicjTBj1n2v2HH36QUqVKSaJEifRUvnz5175P5Jr93TRv3jwtMlurVi02rYfa/s6dO9KxY0dJlSqVJtFmzZqV3zceaPfx48fLO++8I7FixdIijd26dZMnT55E5KmD1pYtW6RGjRpagBLfG8uWLXvtfTZv3iz58+fXfT1Lliwyc+ZMj2wrqmWSE+bNm2dEjx7dmD59unHkyBGjdevWRsKECY1r167Zvf22bduMKFGiGKNGjTKOHj1qfPHFF0a0aNGMQ4cOsd3d2O6NGjUyJk6caOzfv984duyY0bx5cyNBggTG5cuX2e5ubHfTuXPnjDRp0hilSpUyPvjgA7a5B9r+6dOnRsGCBY2qVasaW7du1fdg8+bNxoEDB9j+bmz32bNnGzFixND/0ebr1q0zUqVKZXTr1o3t7oQ1a9YY/fr1M5YsWYIJa8bSpUvDvf3Zs2eN2LFjG927d9dj67fffqvH2rVr1xruxsDJSYULFzY6duxoOf/y5UsjderUxogRI+zevl69eka1atVCXFakSBGjbdu2EXm/gpaz7W7rxYsXRrx48YyffvrJjVsZeCLS7mjr4sWLG9OmTTOaNWvGwMlDbT958mQjU6ZMxrNnzyL6lBSBdsdt33///RCX4WBeokQJtmcEORI49erVy8iZM2eIy+rXr29UqlTJcDcO1Tnh2bNnsnfvXh32sV7CBed37Nhh9z643Pr2UKlSpTBvT65pd1uPHj2S58+fS+LEidnEbm73IUOGSPLkyaVly5Zsaw+2/YoVK6RYsWI6VJciRQp59913Zfjw4fLy5Uu+D25s9+LFi+t9zOG8s2fP6vBo1apV2e5u5M1ja9CtVfcmbt68qV9C+FKyhvPHjx+3e5+rV6/avT0uJ/e1u63evXvr2LntB41c2+5bt26VH3/8UQ4cOMCm9XDb44D9+++/S+PGjfXAffr0aenQoYP+YEDhQHJPuzdq1EjvV7JkSV0o9sWLF9KuXTvp27cvm9yNwjq2YjHgx48fa76Zu7DHiQLeyJEjNVF56dKlmuxJ7oGVxZs2baqJ+UmTJmUze9irV6+0p2/q1KlSoEABqV+/vvTr10+mTJnC98KNkKCMnr1JkybJvn37ZMmSJbJ69WoZOnQo2z1AscfJCTgYRIkSRa5duxbicpxPmTKl3fvgcmduT65pd9OYMWM0cNqwYYPkzp2bzevGdj9z5oycP39eZ8ZYH8whatSocuLECcmcOTPfAze0PWAmXbRo0fR+puzZs+svcwxBRY8enW3vhnbv37+//mBo1aqVnsfM6YcPH0qbNm00cMVQH7leWMfW+PHju7W3CfiOOgFfPPglt3HjxhAHBpxHboE9uNz69rB+/fowb0+uaXcYNWqU/upbu3atFCxYkE3r5nZHyY1Dhw7pMJ15qlmzppQtW1b/xjRtck/bQ4kSJXR4zgxW4eTJkxpQMWhyX7sjf9I2ODKDV65o5j5ePba6Pf08AKeqYurpzJkzdQpkmzZtdKrq1atX9fqmTZsaffr0CVGOIGrUqMaYMWN0WvzAgQNZjsAD7T5y5EidUrxo0SLjypUrltP9+/fffCcIIs62uy3OqvNc21+8eFFnjnbq1Mk4ceKEsWrVKiN58uTGl19++QZbEXycbXd8p6Pd586dq1Pkf/vtNyNz5sw6o5och+9mlI/BCaHJ2LFj9e8LFy7o9WhztL1tOYKePXvqsRXlZ1iOwIehXsRbb72lB2ZMXd25c6flutKlS+vBwtqCBQuMrFmz6u0xfXL16tVe2Orgavf06dPrh8/2hC85cl+722Lg5Nm23759u5Y7wYEfpQmGDRum5SHIfe3+/PlzY9CgQRosxYwZ00iXLp3RoUMH4/bt22x2J2zatMnud7bZ1vgfbW97n7x58+r7hP19xowZhidEwj/u79ciIiIi8n/McSIiIiJyEAMnIiIiIgcxcCIiIiJyEAMnIiIiIgcxcCIiIiJyEAMnIiIiIgcxcCIiIiJyEAMnIiIiIgcxcCKiCBk0aJDkzZv3jVoP9XexGGrixIklUqRIuqZdoNq8ebO+xjt37oR7uwwZMsj48eMt57FIb4UKFSROnDiSMGHCCD//e++9J3PmzBFPwuLCeD179uzx6PMSuRMDJyIfg4NreCcELIECCzDPnDlTVq1aJVeuXJF3331XAlXx4sX1NSZIkEDP43XbC4T++usvDSZN48aN0/shqMSivRGxYsUKXTm+QYMGlssQ0NjuW2nTprV7PYK2/Pnzy8KFCy3XYz80r8eitljEGdt969atEIvm9ujRQ3r37h2h7SbyRQyciHwMDpLmCT0P8ePHD3EZDkSB4syZM5IqVSoNKlKmTClRo0aVQIUgAq8RgUZ4kiVLJrFjxw7RRgUKFJC3335bkidPHqHnnjBhgrRo0UIiRw75lT9kyJAQ+9b+/fvtXo/LCxUqJPXr15ft27dbrs+ZM6def/HiRZkxY4YGwu3btw/xGI0bN5atW7fKkSNHIrTtRL6GgRORj8HB1TyhdwIHWvP8w4cP9UCUIkUKiRs3rh7MNmzYEOL+uP2yZctCXIaeDfRwwKxZs/S+p06dslzfoUMHyZYtmzx69CjM7Ro5cqQ+b7x48aRly5by5MmTULeZNm2aZM+eXWLGjKmPN2nSpDAfr3nz5tK5c2c96GKb0cMBOPiWLFlStzlJkiRSvXp1DR7CG/JCbwwuO3/+vJ7/5JNPJHfu3PL06VPLkFG+fPnk448/DnN7ypQpI506ddIT2j1p0qTSv39/HU403b59Wx8jUaJEGtxUqVIlRDteuHBBatSoodejlwaBxZo1a0JtN/5GIHP37t1QPYnWQ3X4e/Hixfqe4TZoM2wPbvvWW29JjBgxJHXq1NKlS5cwX9eNGzfk999/1+2yhffSen9D0Gbv+qxZs8rEiRMlVqxYsnLlSsv1CHRxfZo0aaR8+fJSt25dWb9+fYjHQFuUKFFC5s2bF+Y2EvkTBk5EfuTBgwdStWpV2bhxo/YCVK5cWQ+ICD4chQM/HgMB2IsXL2T16tUa8MyePTtET4e1BQsW6MF6+PDhmq+CXiLboAj3HzBggAwbNkyOHTumt0Xg8dNPP9l9zG+++UZ7NDA8hF4LDFEBgsPu3bvr8+B1opfkww8/lFevXjnVw4LH6dOnj57v16+fBizfffdduPfDtiIY2L17t27f2LFjtW1MCFywXRj62rFjhwYxaMvnz5/r9R07dtRgbcuWLXLo0CH56quvNEi1hR42295Eez2JaBO8x/Xq1dPbYJsQSGH47vvvv9egDUFyrly5wnxN6O3B+4qA9k2gXaJFi6ZBqD0IWtetW6c9a7YKFy4sf/755xs9P5HPMIjIZ82YMcNIkCBBuLfJmTOn8e2331rO42O9dOnSELfBY+CxTLdu3TLSpk1rtG/f3kiRIoUxbNiwcJ+jWLFiRocOHUJcVqRIESNPnjyW85kzZzbmzJkT4jZDhw7V+4Zl3LhxRvr06cN97hs3buhrOnTokJ7ftGmTnr99+7blNvv379fLzp07Z7ls+/btRrRo0Yz+/fsbUaNGNf78889wn6d06dJG9uzZjVevXlku6927t14GJ0+e1OfYtm2b5fqbN28asWLFMhYsWKDnc+XKZQwaNMju49tud1jvLdoD7WL64IMPjGbNmlnOf/3110bWrFmNZ8+eGY7AY2XKlMnu80SPHt2IEyeO5fTNN9/Y3Y6nT58aw4cP1+1ftWqVXjZw4EAjcuTIer+YMWPqdTiNHTs21HPhcTNkyODQ9hL5OvY4EflZjxN6JtB7gKEs9Gagd8eZHidz+OTHH3+UyZMnS+bMmS09M2HBcxQpUiTEZcWKFbP8jd4dDKdhCA/bZJ6+/PLLEMNsjkAvSsOGDSVTpkzaI2MO4Tn7GrF9aKuhQ4fKZ599psN/r1O0aNEQOUh4DGzPy5cvtQ3Q62LdDhhKfOedd/Q6wJAZXjOGpgYOHCh///23uBqGwx4/fqzt07p1a1m6dKn2HIYFt8XQqT09e/bUYU7zZDuUiaRuvI/osULvGYZrq1WrZrkerx33Q88YblupUiUdfrWFIb7whoGJ/AkDJyI/gkAAB0oMg2HoAwctDNNYD5/gwG+dlwPmUJI1DCdhNhSGgBD4vGlABz/88EOIA/Hhw4dl586dTj0Whh4xMwuPtWvXLj2B+RrNBGfr12jv9WFob9u2bfoaT58+LZ7QqlUrOXv2rDRt2lSH6goWLCjffvutS58Ds9dOnDihQ6UISJCfhlID9toAkKuF3KywrsuSJYvlZDvLzwysLl++rI9hOzsOw3K4H2ZDIqhCWw8ePDjU8+D9tM2fIvJXDJyI/AgCAeTZIOcHARMSc82EaBMOUAiGTOgxsf21j5lR6EFAoi96FJAQHR70cJkBjMk6IELSOJKUETRYH4hxypgxo8Ov77///tOg4IsvvpBy5crp89oe9M0DsPVrtFf/afTo0XL8+HH5448/NOEcs75ex95rxGw2BATYFvTsWN/G3N4cOXKECGzatWsnS5Ys0Z4uBID2IOhAT1ZEIGBCgIlcLiSaI98KgZo9SIpHLaiwgqfwmIGVI7MBAe/bmDFj5N9//w1xOQJobAdRIGDgRORHcBDHARmBwsGDB6VRo0ahkqbff/99TYJG8jgSmXEQR1Kv6f79+9ojgmElzApDUvf8+fNl0aJFYT5v165dZfr06Rp8oJYQhqFsp5ejp2HEiBF6MMdtcCDH7ZFg7cwQIoa/pk6dqr1EmA2GRHFrOJAjOEGyOoJCJLd//fXXIW6D145EdSR2Y9gM24DXgMAuPBgOxPMhGJo7d672FuF+Ztt/8MEHOjyGhGu0f5MmTXRGGS6HTz/9VBOkz507J/v27ZNNmzaFmZSNIUj01CEB/ubNmw4PZWF2JIZZEYzg9fzyyy8aSKVPn97u7RGwIABC0O1uGNrEbEb0iFpD72jFihXd/vxEnsDAiciPIABAcIFZWehxQE4JChNaQxCBwKJUqVIaWGF4z3q2HAIBTJU3D27oucLfbdu2lX/++cfu86J+D2bI9erVS2sKYdq9bb0eDFMhUEGwhMcsXbq0HuSd6XHCMBymre/du1eHf7p166Y9R9YQBCKoQW8SDtLoOUNekQllEhDQoGfOnIKPwoxly5bVgDG8Xh7k+CAnCLPAMEMObWVdjBKvDa8fJRIQJGC4EOUGzMAUj437IVjCbDhM4w+rJAPeQwS1aFv0oo0aNcqhNsJwGnqxEBDi9aMcBXoOEXDag94ylD5AgOwJeM+wH1y6dEnPozcMZRfq1KnjkecncrdIyBB3+7MQEfk41HHCEjLWy50ECgzVoaYUesHC6plyFwSGefLkkb59+3r0eYnchT1OREQBDjlKGN5zdmbim0JCP3of0QtFFCgCd30DIiKyqFWrlsdbAwnwSBgnCiQcqiMiIiJyEIfqiIiIiBzEwImIiIjIQQyciIiIiBzEwImIiIjIQQyciIiIiBzEwImIiIjIQQyciIiIiBzEwImIiIjIQQyciIiIiMQx/w8pyVjt540L0wAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAHqCAYAAADyPMGQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAgPNJREFUeJzt3QW4VNX3N/BFd3dJioR0l4B0itIlIN2ClCAtISAgSogIiNKdgoAg0pLSnUpKd533+a7f/8w7d+7cy8xler6f5xm403v2nDlnnR1rRzIMwxAiIiIieq3Ir38IEREREQEDJyIiIiIHMXAiIiIichADJyIiIiIHMXAiIiIichADJyIiIiIHMXAiIiIichADJyIiIiIHMXAiIiIichADJ6L/M2jQIIkUKZLcvHnT20UJCqhr1HkwyZAhgzRv3tzbxQg4ZcqU0Ysvmjlzpm7r58+f93ZRyEUYOJFXnDlzRtq2bSuZMmWSmDFjSvz48aVEiRLyzTffyOPHjyWQmTtS8xI1alRJkyaNHlD/+ecfu8/Bykg///yzvPfee5IwYUKJHTu25MqVS4YMGSIPHz4M872WLl0qVapUkaRJk0r06NElderUUq9ePfn9999dHhCYnydy5MhaRpSvTZs2smvXLgkm27dv14Dwzp073i4KEblBVHe8KFF4Vq9eLXXr1pUYMWLIxx9/LO+++648e/ZMtm7dKj179pQjR47I1KlTJdAh6MmYMaM8efJEdu7cqQEV6uDw4cMaTJpevnwpjRo1kgULFkipUqX0oIzA6c8//5TBgwfLwoULZcOGDZIiRYoQgdYnn3yir5kvXz7p3r27pEyZUq5cuaLBVLly5WTbtm1SvHhxl32evHnzymeffaZ/379/X44dO6Zl++GHH6Rbt24yduzYEI9HgIygMRADJ3wvCIQRQFo7ceKEBpYUPJo2bSoNGjTQ/R0FCCzyS+QpZ8+eNeLGjWtky5bN+Pfff0Pdf+rUKWP8+PEeLdODBw/0/4EDB2LBa+PGjRtufb8ZM2bo+/z1118hbu/du7fePn/+/BC3Dx8+XG/v0aNHqNdasWKFETlyZKNy5cohbh89erQ+59NPPzVevXoV6nmzZs0ydu3a5bLPlD59eqNatWqhbn/06JFRq1YtLcukSZOMYGDW/blz57xdFL+DbRXbjLNKly6tFyJPYOBEHtWuXTs9qGzbts2hxz9//twYMmSIkSlTJiN69Oh6gP7888+NJ0+ehHgcXhOBjy08vlmzZqGCls2bNxvt27c3kiVLZiRMmDBE4HTs2DGjbt26Rrx48YzEiRMbXbp0MR4/fhzqtX/++Wcjf/78RsyYMY1EiRIZ9evXNy5evBjhwGnVqlV6OwIlEw4ieO2sWbNqXdjTokULfd6OHTssz0G5EZy+ePHC8ISwAie4f/++lidNmjQhgjjb7+z8+fP6neCzok7xnDp16tgNQA4ePGi89957+ji87tChQ43p06eHCljMcv35559GoUKFjBgxYhgZM2Y0fvrpp1CveebMGX0/1HesWLGMIkWK6Hdia8KECUaOHDn0Mdh2ChQoYMyePTvENmR7Mctkuz3C7du3NcDFfdjG8XmaNm3qUACPbRCfyyxLqVKljHXr1lnuX7ZsmVG1alUjVapU+tr4HeH3ZLtdIOjImTOnceTIEaNMmTL6eqlTpza++uqrUO+J3wI+59tvv631mTJlSuPDDz80Tp8+bXnMy5cvjXHjxmk94THJkyc32rRpY9y6dSvEa5nfz9q1a7Ue8Vg8Lzzff/+9fg589/jsW7ZsCRU4mb8x221n06ZNejv+D8+9e/eMrl27Wr4T7CfKly9v7N27N8Tjdu7caVSqVMmIHz++1hm2ya1bt4Z4jL2yOLNdku9hmzF51MqVK3Vck6NdRK1atZIBAwZI/vz5Zdy4cVK6dGkZMWKENn2/iQ4dOsjRo0f1tfv06RPiPowBQvcZ3qdq1aoyYcIEHatjbdiwYdrN+Pbbb2sX1KeffiobN27UMUgRHdtiDh5NlCiR5TZ03d2+fVu76sLq1kI5YNWqVZbn3Lp1S58TJUoU8ba4cePKhx9+qOO3UOdh+euvv7SbC98t6rxdu3Zapxj0++jRI8vj8Dply5bVLt3PP/9cuwFnz56t4+PsOX36tNSpU0cqVKggX3/9tdYvutHwfNO1a9d0m1y3bp1uG/h+sQ3UrFlTuzZN6Hbs0qWL5MiRQ8aPH69dcuiiNMdxffTRR9KwYUP9G9srxqXhkixZMrtle/DggXa/fvvtt1KxYkX9DPjcx48fl8uXL4dbr3hvdANFixZNu31xPV26dCHGr6GrFvWPrlq8doECBexu84DtrHLlypInTx6tp2zZsknv3r3l119/DdFtXL16dX0vvBYe17VrV7l79652MZswfhHd7ua4xRYtWuh3VKlSJXn+/Hmo7kvUGb4fPBb1GZYff/xRXxvdzqNGjdLXx3d06dIlcSV8B5MnT5batWvLpEmTpEePHhIrViztfjahnvF7v3fvngwcOFCGDx+uv/33339fdu/e/dr3cGS7JB/l7ciNgsfdu3f1zOuDDz5w6PEHDhzQx7dq1SrE7eiywu2///57hFucSpYsGeqs22wtqFmzZojbO3TooLejlcNsGYkSJYoxbNiwEI87dOiQETVq1FC32zLLsGHDBm1VuHTpkrFo0SI9q8WZJ66b0G2Jxy5dujTM18NZPB7z0Ucf6fVvvvnmtc/xZIsToBUBZVq+fHmY35m9Lhq0ouFx6Fo0de7c2YgUKZKxf/9+y23//feftlDZO7PHbWiVMF2/fl3r+bPPPrPchhYfPA4tANYtZWgFyJAhg7agALZdtMxEtKvOdnscMGCAPnbJkiWhHmuvi9W6SxtdtGjpMctm73n26rRt27ZG7NixQ7TaorXGtp6fPn2qrUm1a9e23Ga26o0dOzbM8qIO8RizFc6EViXb283vB/e9zrNnz7TlKm/evFo209SpU/U1XNnilCBBAqNjx45h3o/PihY3tDbZ1je2mQoVKoRbFke3S/JNbHEij8GZGcSLF8+hx69Zs0b/x9myNXMAMgaZR1Tr1q3DbI3p2LFjiOudO3cOUZ4lS5bIq1evtGUKqQvMC86C0QK1adMmh8pQvnx5bYlAKwHOPOPEiSMrVqyQtGnTWh6DQdavqzPzPrN+na1nT0Crh/XnsQdn9Ca0Svz333+SJUsWHWC9b98+y31r166VYsWKhWiZSJw4sTRu3Nju66J1CK06JtT5O++8I2fPnrXchu+2cOHCUrJkyRBlRksjWgLNljKUBS1BaB1zhcWLF2sLD1rkbGGGYliWLVum2yBaj2wHm1s/z7pOUffYTlEXaMFDq5Y1fN4mTZpYrmMWJurEup5QXszQNH8T9t4XEwISJEigLSnWvw+0UOE9bH8fmCCBlqjX2bNnj1y/fl1bg1A2E1pp8H6uhO8ZrYj//vuv3fsPHDggp06d0lZdbKfmZ8QMV0y82LJli34/4XFkuyTfFHhTWshnIeXA6w6e1i5cuKAHBRw8rSFAwY4N90cUdtZhQfBjLXPmzFoOsysNO0w0mNg+zoSuE0dMnDhRsmbNqt0c06dP152t7cwbM/gJr85sgytn69meGzduaLeMCQc8M/iJCHRJWZfRHsyyQ/fojBkztDvuf41S/4M6MuF7R+Bky3Y7Mb311luhbkO3CLqmrF+zSJEioR6XPXt2y/2Y/YmuK8xgRECB90P3Gg6e6DKKaFoOdAdF5HnYJnHwDQ+6fb744gvtVjIDant1CgjYbYM11NPff/8d4n1xcA9vNiR+H3jt5MmT270fwY+jv0Vr5u/d9neH3xu6/10J3YDNmjXTkxoEfOiyR5e4+T74jIDHhAV1YN3tHpHtknwTAyfyGBzQkUfIeiyEI8I7834d64O/NeszcWffH2eSuA1jP+y1WjkaYODgW7BgQf27Vq1a2tqBgzDGfJivYR64cfDCY+wxD2zmQRRjU+DQoUNhPud1ChUqFCIwxRiON0lWaX7nYQU3gFYMBE0YL4bACK0IqGeMeXrd2Xt4wmpZtA7MHIXvA98PxpOh5QstMBgDg5YfjPvxJRhvgzGB+N1hDBROAJDmAq13CABt69RV9YTXRdCEMU322I73cua3+Kb7jLD2B7bQmozWIIxv++2332T06NHy1VdfaWsz8qKZdYfbwxqT9br9gCu3S/IsBk7kURhYihxNO3bssNtqYC19+vS6g8LZnRlAmAN5cVDA/dZnaraDspEbCnmLnIX3sz4LxiBOlANJHgEHIOzc8Bi0GLkCdqJobcGg5++++84yeBfBFFrX5syZI/369bO7s501a5albs3noD7mzp0rffv2jdAAcRz0rBORvskZPVqbcADC2bv192hr0aJFegaPgbImDNC2/V7xveM7sWXvNkfhNREQ2TK7s6y3NXSp1q9fXy/YxjAgHIPJMVAdgYkzgT62JWdPJMznYZtEF2JYB+7NmzdrNxIO9hjEbDp37pzT72f9vujCQldqWC2reAxa5dAK58qgyPwO8PvEAGwTyoLPhC5Pk9nSY7vtONNKnSpVKp0ogAtayTBBBd8zAid8RkBQii53Ci4c40Qe1atXLz3wYLYcAiBb6AowZ0eheRwwe8mamUixWrVqltuwI0NXlzUEaI6eYdp2oVnDjCfADhNwoEQwghYG27NDXMfBKiIwewytUPi8CBgAiS4xowcHdQROtjDOCzOnMEakaNGiluegRQEzgPC/vTPYX375JdyZPzjo4YBgXiIaOCH4wswvzPJD+cMLKlCntmVF3dt+h/isCLwxzsSE1w+rhcMR2NZQH3hdE8arYBtCwGy25tl+txhrg/tQbnO2GLZvcGR2JbrpDh48GGLmniMtD2hJRFcdWpJsW47M55kBs/XrINBDC1lEobwYy4PgPqzyorUG39nQoUNDPebFixcRnnWK1lm0Vk2ZMkU/hwnbv+1rmoGN9T4BZXIksS4eZ9uNiRY0tJY/ffpUr6P7Du8xZswYSze0bVc3BS62OJFHYWeD1hOcraP1wTpzOKaiY2CpuZYXziDRAoGdndntgIPbTz/9pAcOtM6YEIhh0Ch27BiUioMRppZjIKuzcPaKKc6Ymo0DKYIMdKGZZ7T4DF9++aW2MGDcE8qCsTt4Hg6AGFCMYCciMIUbWdVxMMDnAbQ+7d+/X7sKUB58RpzJI+0AyoZ6RJ3Yvg7Gt6D1BoNxMfgcY8OuXr2qA4tRj6hvV8K4JJQHcDBBawi+T7wnBvRjGnl40GKGqfvookMwgs+KloskSZKECr7xPvie0b2HQGXatGk6ZgQBVES6dlHHaKFDcIx0AxhsjjrFd4ruOHMANsY0oR4RWCJTO4JTBBEI4s3xWzioAgJFdDOiZaZGjRqWgMr2e0JLG75zZHrHc/EZMEkAAYJ1K4o1dHni9RGcoEsJwTzGx2HQOg7waL1EegW0vOA3hM+EekH9vklXEH6vaOHEhA1sQ3hvBJj4ntAy88EHH+jvFN81yoDgFnWGOkBLEbYHnBhhe3QWXgO/O7w2WpywD8H3g+5d28A+Z86ceiKB3yjqE9/nvHnzNHB7HYwNxHgvlBH1jy43fD7Urdkaiu0B2xy2F7wX0i1g2ST8BvB7Q0sUUq9QgPL2tD4KTidPnjRat26tU72RYA7JJkuUKGF8++23IaZJI+nj4MGDdYpvtGjRjHTp0tlNgIkp2ci8nTRpUp1qjWnCSMgXVjoC2+ST1ukIjh49qokQUSYkQ+zUqZPdBJiLFy/WtAZx4sTRCxJOYgrziRMnwv3s4ZUBnyNz5sx6sU6XgNvxPNQRku0h+R+mxaNuzMzn9iDNQcWKFXWqPlIlIBEiEnUiAagrmdOrcUGqAJQR5cN3HFaGctt0BEgEiWSe+A6RXR7f4fHjx+0mjUQqAiR7xPTttGnTGiNGjNDElHjNq1evvjZNgr1M02YCTCSSRP0WLlw4VAJMJF9EksMkSZLoe+N76tmzp6basIaEnEhkiZQBr0uAiVQK2MbwePwW8HnwmJs3b7623pEeIF++fFoWbKv4TOvXr7fcj0SzRYsWtSS07NWrlybItJ2SbybAtIVyoMzWMOW+X79+lt8kUhag3lB/1pAmAEkt8d74LeXKlUvf33rFgNelsbAHGejx3vjMBQsWtJsAE1AeJK3E41KkSGH07dtX6+Z16QiQ6gDfaZ48ebTc+G3jb3uZ77EdIg2IuT3g89SrV8/YuHGjQwkwbTEDun+IhH+8HbwREb0pDCr//vvvtbXLFxJ/ElFg4hgnIvI71gPXzbFH6IbCwHgGTUTkThzjRER+BzMyMZge47swyQBLcSBPUf/+/b1dNCIKcAyciMjvYBYcBlVj4gAGPWOqOIIn62n3RETuwDFORERERA7iGCciIiIiBzFwIiIiInJQ0I1xQpZdrHiNZHVvsgYaERERBQaMWkLyUySQNRPehiXoAicETVgzi4iIiMjapUuXNHN8eIIucDKXRUDlIC2+O1q0sE4R1lR6XdRKrsN69w7Wu/ew7r2D9R6Y9Y50JmhUMWOE8ARd4GR2zyFoclfghAVa8dr8UXkO6907WO/ew7r3DtZ7YNe7I0N4+K0TEREROYiBExEREZGDGDgREREROYiBExEREZGDGDgREREROYiBExEREZGDGDgREREROYiBExEREZGDGDgREREROYiBExEREZGDGDgRERER+UPgtGXLFqlRo4akTp1a14dZtmzZa5+zefNmyZ8/v8SIEUOyZMkiM2fO9EhZiYiIiLwaOD18+FDy5MkjEydOdOjx586dk2rVqknZsmXlwIED8umnn0qrVq1k3bp1bi8rERERUVRvvnmVKlX04qgpU6ZIxowZ5euvv9br2bNnl61bt8q4ceOkUqVKbiwpERERkZ+NcdqxY4eUL18+xG0ImHA7ERERBaaXL1+Kr/Bqi5Ozrl69KilSpAhxG67fu3dPHj9+LLFixQr1nKdPn+rFhMfCq1ev9OJqeE3DMNzy2r5mzaErMm7DKXn49IW3iyLG/9V95MiRJZK3CxNEWO/ew7r3Dta75z2+cVFOzRkqaau0kaz5S8qKTiVc/h7OHLP9KnCKiBEjRsjgwYND3X7jxg158uSJWyr/7t27GjzhhxXIRq89Lhduu74OiYiITM8fPJMnd67J+V+nSfyM+eT69eviavfv3w/MwCllypRy7dq1ELfhevz48e22NsHnn38u3bt3D9HilC5dOkmWLJk+zx2BE2YI4vUDPXB6+vKw/h85kkjyeDG8WhaeBXoH6917WPfewXr3DDQ+4Fiq4meR+E2HSIykb0nKRHEkefLkLn+/mDFjBmbgVKxYMVmzZk2I29avX6+3hwVpC3CxhY3eXYENvmx3vr7v+N9GnTxeTNnZt5xXS4IdGc5C8IMK/Hr3Hax372Hdewfr3f2uXLkijRs3lgEDBkiZMmX0tlev3ndrvTvzml791h88eKBpBXAx0w3g74sXL1paiz7++GPL49u1aydnz56VXr16yfHjx2XSpEmyYMEC6datm9c+AxEREbkGZsojV+OmTZukTZs2PjUo3CcCpz179ki+fPn0AuhSw9+IMs2o0wyiAKkIVq9era1MyP+EtATTpk1jKgIiIiI/75r75ptvNE8jJoLlzJlTVq1aJVGiRBFf49WuOjTBobLCYi8rOJ6zf/9+N5eMiIiIPNX71KpVK5k/f75eb9iwoUydOlXixo0rvsivxjiR663++4qMXX9CHj51vjn0+n3OqCMiooi7deuWlCpVSo4ePSpRo0bVnqTOnTv//4HhPoiBU5BD0HTmxsM3eo04MXyvKZWIiHxfokSJJG/evHL79m1ZuHChlCjh+hxNrsbAKciZLU3/Syng+HRM66Dps4rvuKFkREQUiF68eKF5FNEVh5YldMshjxJSDvkDBk5B3h1ndrf5QkoBIiIKbNeuXdMxTMijuGTJEk0DECdOHL34CwZOQcCR7jh2txERkTvt2LFD6tatK//8848GSidOnJDs2bOLv2HgFARe1x3H7jYiInIXwzBk4sSJmnLo+fPnki1bNm1t8segCRg4BdHsN3bHERGRJz18+FDatm0rs2fP1ut16tSR6dOnS7x48cRfMXDyE5z9RkRE/qZevXq6VBoSWY4aNUpX+vDlVAOOYODkJzj7jYiI/M2AAQPk8OHDMmvWLCldurQEAgZOfobdbURE5KtevnwpBw8e1PXmoEiRInLq1CmJHj26BAou7UxERERv7ObNm1K5cmVNYnngwAHL7YEUNAEDJyIiInoju3fv1lamDRs2aG6mCxcuSKBi4EREREQRTjUwZcoUXW/u0qVL8vbbb8uuXbvkgw8+kEDFMU5+luGbiIjIFzx+/Fjat28vP/30k17/8MMPZcaMGZIgQQIJZAycfAgzfBMRkb+YNm2aBk3omhsxYoT07NnT71MNOIKBkw9hhm8iIvIXHTp00G65Tz75RN5//30JFgycfBBTDhARkS+mGpg6daq0aNFCYsaMqUktf/nlFwk2HBxORERE4frvv/+kWrVq2srUpUsXCWZscSIiIqIw7d27V2rXrq0pBmLFiiXvvfeeBDO2OBEREZFdP/74oya0RNCUOXNm2blzpzRp0kSCGQMnIiIiCuHJkyfSqlUrvTx9+lRq1Kghe/bskdy5c0uwY+BEREREIVy7dk2WLFmi6QWGDRsmy5Ytk4QJE3q7WD6BY5yIiIgohPTp08u8efP074oVK3q7OD6FgRMREVGQe/XqlbYsFShQQKpWraq3MWCyj4ETERFRELt9+7Y0bdpUVq9erd1xp06dkqRJk3q7WD6LgRMREVGQOnDggKYaOHv2rCa1HDduHIOm12DgREREFIRmzZolbdu21Rl0GTNmlMWLF0u+fPm8XSyfx1l1REREQbZ0Svv27aVZs2YaNFWpUkVTDTBocgwDJyIioiCCNeYwGBypBgYNGiSrVq2SxIkTe7tYfoNddUREREEAwVLkyP9rL5kwYYI0bNhQypQp4+1i+R22OBEREQV4wDRixAhdpBfddBAjRgwGTRHEFiciIqIAdffuXR3LtHz5cr2O/z/66CNvF8uvMXAiIiIKQIcOHdIg6fTp0xI9enSZOHEigyYXYOBEREQUYGbPni1t2rSRR48eyVtvvSWLFi2SQoUKebtYAYFjnIiIiAIIxjM1adJEg6YKFSrI3r17GTS5EAMnIiKiAIK15mLHji1ffPGF/Prrr8wE7mLsqiMiIvJz169fl+TJk+vfefLk0XFNqVKl8naxAhJbnIiIiPyUYRgyZswYyZAhg+zcudNyO4Mm92HgRERE5Ifu3bsndevWlZ49e8rjx491rTlyP3bVERER+ZmjR49qaoETJ05ItGjRNBM4Fuwl92PgRERE5Efmz58vLVu2lIcPH0ratGk11UCRIkW8XaygwcCJiIjIT2zcuFEaNGigf7///vsyb948SZYsmbeLFVQYOBEREfkJBEvoosuaNasMHTpUokblYdzTWONEREQ+DLPlcuXKJXHixJFIkSLJggULJEqUKN4uVtDirDoiIiIfTTUwfvx4KVmypC6fguvAoMm72OJERETkYx48eCCtWrXSgeCm58+f62K95F0MnIiIiHzI8ePHpXbt2ppyAGOYxo0bJx07dtRuOvI+Bk5EREQ+Akksmzdvri1OqVOnloULF0rx4sW9XSyywsDJg1b/fUXGrj8hD5++tHv/9ftPPF4mIiLyDQiW0LKE/0uXLq3ddClSpPB2scgGAycPQtB05sbD1z4uTgwO/CMiCjZx48bVYGn16tUyfPhwphrwUfxWPMhsaYocSSR5vJhhBk2fVXzHwyUjIiJv2L59u9y8eVNq1qyp19HShAv5LgZOXoCgaWffct4uBhEReQlSC0ycOFG6desmMWPGlL/++kuyZcvm7WKRAxg4EREReRDWmMOCvLNnz9brVatW1TXnKIADp4sXL8qFCxfk0aNHukZOzpw5JUaMGK4vHRERUQA5deqULply+PBhTWQ5evRo+fTTT5lqIBADp/Pnz8vkyZN1QcHLly9bMpgCEnKVKlVKM5si90TkyExITkREZG358uXy8ccfy7179yRlypQ6EPy9997zdrHISQ5FOF26dJE8efLIuXPn5Msvv9SkXHfv3pVnz57J1atXZc2aNZoSfsCAAZI7d27tqyUiIqL/b8uWLRo04Xi5b98+Bk2B3OKEhQXPnj0rSZIkCXVf8uTJdbVmXAYOHChr166VS5cuSaFChdxRXiIiIr80cuRIyZAhg7Rr106iRYvm7eKQO1ucRowYYTdosqdy5craf0tERBTMdu/eLQ0aNNA15gDBUufOnRk0+TkORiIiInIhjAGeMmWKjv3FOKavvvrK20UiT3fV5cuXz+ER/+i3JSIiCkaYbd6hQwf56aef9Dp6YDBOmIIscKpVq5b7S0JEROTHzpw5ozPLDx48qLPLMaapR48eTDUQjIETBn0TERGRfb///rsGTXfu3NFJU0jdU7ZsWW8Xi3xljBM2jGnTpsnnn38ut27dsnTR/fPPP64uHxERkc9LkyaNvHz5UooVK6bHQwZNgcvpwOnvv/+WrFmz6mC3MWPGaBAFS5Ys0UDKWVirB9MzsVZPkSJFdBZCeMaPHy/vvPOOxIoVS9KlS6fr/Dx58sTp9yUiInoT5mw5wHFp8+bNekEQRYHL6cCpe/fu0rx5c00bj2DHhLV2kNzLGZhtgNdDVyAidCTZrFSpkly/ft3u4+fMmSN9+vTRxx87dkx+/PFHfY2+ffs6+zGIiIgibM+ePbooL7roTPnz59eVNCiwOR04ISs4Fie0hQgbWcSdMXbsWGndurW0aNFCcuTIodM3Y8eOLdOnT7f7+O3bt0uJEiWkUaNG2kpVsWJFadiw4WtbqYiIiFwFi/Mi1QASQ/fv3z/EEmQU+Jxe5BeL+SJlvK2TJ0/qgr+OwnIte/fuDdG9h1kI5cuXlx07dth9TvHixeWXX37RQKlw4cK60WK5l6ZNm4b5Pk+fPtWLySz7q1ev9OJqeE38iOy/tvnjCut+ck+9k7uw3r2Hde95GBbSqVMnmTFjhl6vWbOm/o3vgcGTf2/vzryu04ETNpQhQ4bIggUL9DqmWV68eFF69+6tMwocdfPmTR1IlyJFihC34/rx48ftPgctTXge1vlBBb548UJT14fXVYes54MHDw51+40bN9wyNgqVj3X8UD7bxY5f/t8Xg//D6o4k19c7uQ/r3XtY956FpcRatmwphw4d0vru1auXZgFHIwD35/6/vd+/f999gdPXX38tderU0emWjx8/ltKlS2sXHWYSDBs2TNwJg+6GDx8ukyZN0oHkp0+flq5du8rQoUO1udQetGhhHJV1ixMGlaN1LH78+G75chFM4vVtv9wo/3cd/6P+yDP1Tu7Devce1r3noHEAy4lhFnnSpEnlu+++04YC1nvgbO/WY7ZdHjglSJBA1q9fL1u3btUZdg8ePNABcehicwY2vihRosi1a9dC3I7rKVOmtPscBEfolmvVqpVez5Urlzx8+FDatGkj/fr1s1uZ6FrExRYe666NHl+u/dc3k6D9737yVL2TO7HevYd17xnp06eXKlWq6JAU9LbgIMt6D6zt3ZnXdDpwMqG7DJeIwsyDAgUKyMaNGy2ZyRFR4jr6kMNKZR+qFSdKFP2f/ctEROQqaF3C8SZhwoR6wJ46daoeb7BAL7vmgluEwjYEN9WrV5fMmTPrBX9v2LDB6ddBF9oPP/yga/ogvUD79u21BQmz7ODjjz8OMXi8Ro0aMnnyZM3Ieu7cOW35QisUbjcDKCIiojexf/9+KViwoDRr1swyaBgzvu31XlDwcbrFCeOLMK4I45zwP+zcuVPzOI0bN046duzo8GvVr19fB2kPGDBAx0nlzZtX1q5daxkwjn5l6xamL774QiN//I8s5ejrRNDk7rFVREQUHGbOnKkn8ebkIRybUqdO7e1ikQ+JZDjZx5U2bVpNQmnbnYYM4Bi47evLrmBwOMZpYXS+uwaHoxkXg79tuxWLDt8oV+89kZTxY8rOvuVc/t7BLLx6J/dhvXsP6961kLamS5cu2iUHaAxA+ptEiRKFeBzr3TvcXe/OxAZOvzuWWMHsAltIRok3JCIi8ifo3UBCSwRN6NVAyp2VK1eGCpqIIhQ4IY/T0qVLQ92+fPlyHetERETkL9Dp8uGHH+qqGIkTJ9akyhg7y9YkctkYJyyNgjFFyKmE3E3mGKdt27bJZ599JhMmTLA8Fs2eREREvgotTJh09Omnn+p6qFjOi8ilgRMW1kXz5dGjR/ViwpRN3Ge9MTJwIiIiX4MhJ1ik18w/iCW8cPKP4xaRywMnpAEgIiLyR0jc/NFHH+lEJqyLitncwKCJHPVGnbhc2JCIiPwFZskVLVpUzpw5o2lvuEAyeSxwQpfcu+++q2nnccHf06ZNi1ABiIiI3AkL8SKFDpbswhqrlSpVkr179+pyYURu76pDssqxY8fqqtDm4HA0d3br1k2ndGIaJxERkS+4fPmy1K1bVycxAWbMDRw4kKtNkOcCJ8w+wDIpDRs2DJGiIHfu3BpMMXAiIiJf6p5D0IQJTD///DPT5pDnA6fnz5/rGj62sGDvixcv3rxERERELtKzZ0+5du2adtVhbVUij49xQh8xWp1sIeNq48aN37hAREREb7J0BpYFM9eaQ5cc1lFl0ERea3EyB4f/9ttvOjsBdu3apeObPv74Y+nevbvlcRgLRURE5AlHjhzRVAMnT57UXE1TpkzxdpEoADkdOB0+fNgyEwFTOiFp0qR6wX0m5sQgIiJPmTdvnrRs2VIePXqki9G3aNHC20WiAOV04LRp0yb3lISIiCgC424xjumbb77R6+XKlZO5c+dKsmTJvF00ClBcxZCIiPzSv//+K2XLlrUETZ9//rmsW7eOQRP53hgnrPGzYMECHdeExGLWlixZ4qqyERERhQnHn2PHjkn8+PFl1qxZ8sEHH3i7SBQEIkekH7l48eK6sS5dulSbSTEg7/fff5cECRK4p5REREQ2MmTIoCfrOJln0EQ+GzgNHz5cp3auXLlSokePrk2kx48fl3r16slbb73lnlISEVHQu3//vjRo0EBWr15tua106dLy9ttve7VcFFycDpwwk65atWr6NwKnhw8f6gw6LLmCXE5ERESuhl6OIkWKyPz58+WTTz7R2XNEfhE4JUqUSKN+SJMmjSUFAXJmcEMmIiJXW7RokRQuXFiDp9SpU+swkdixY3u7WBSknA6c3nvvPVm/fr3+jYUTu3btKq1bt9a16zANlIiIyBWwjFePHj30WPPgwQMpU6aM7Nu3T8fZEvnNrLrvvvvOksq+X79+Ei1aNNm+fbvUrl1bvvjiC3eUkYiIggyOM5UrV5Y//vhDryNXE8bYRo0aocngRC4T1dnof9WqVVKpUiW9HjlyZF0TiIiIyJVixowp2bJlk71798rMmTP15JzI77rqEOm3a9fO0uJERETkKoZhhBgri1nb6Jpj0ER+PcYJA/QOHDjgntIQEVFQwgztxo0bS82aNeXly5d6W4wYMZhqgHyO053FHTp0kO7du8ulS5ekQIECEidOnBD3586d25XlIyKiAHfy5EltVcIsbfRs7Ny5U0qUKOHtYhG5JnBC8jHo0qWL5TbkcUITK/43zxSIiIheB6kFmjdvLvfu3ZOUKVPqcl4MmiigAqdz5865pyRERBQ0MNkIM7G/+uorvV6yZEkNmlKlSuXtohG5NnBKnz69s08hIiIKoX379jJt2jT9GytPIIBCehuigBscTkRE9KY6d+4syZMn1yVUxo4dy6CJ/AYziRERkdthHOzRo0clZ86clolEGPrBpVPI37DFiYiI3Aq5mTAAPG/evLrShIlBE/kjBk5EROQ2Z86ckWLFismsWbO01clcGJ7IX7GrjoiI3AJLdDVp0kTu3r1rGc+EhXqJgq7FqVq1anLlypVQfxMRESGfX//+/aVGjRoaNKHFCUunMGiioA2ctmzZIo8fPw71NxER0aJFi+TLL7+0zJ7bvHmzpEmTxtvFInIJdtUREZFL1atXT1avXi2VKlXS9eeIAgkDJyIiemPz5s2T6tWrS9y4cXX5LQwGJwpEnFVHREQRhqEaLVu2lIYNG0qrVq105hxRIGOLExERRQgSWNauXVv2798vkSNH1jxNRIGOgRMRETnt119/1fFLt2/flqRJk2pXXbly5bxdLCK3Y1cdERE57NWrVzJ48GBNRYOgqXDhwppqgEETBYsIBU7p06e3LMho/TcREQW2//77TyZPnqxjmdq3b68padKlS+ftYhH5dleddcp8ps8nIgoeyZIlkwULFuj4pmbNmnm7OEQexzFOREQUrhkzZki8ePGkTp06ev29997TC1EwYuBERER2PXnyRLp27SpTp06VOHHiSIECBSRjxozeLhaRVzFwIiKiUC5cuKAtTHv27NGEln369NExrUTBjoETERGFsH79ek1oiYHgiRMnljlz5ujyKUTEdARERGRl+PDhGiQhaCpYsKCmGmDQROSGwOnKlSvSqVMnV70cERF5AXIzIdVA69at5c8//2T3HNGbdNUdOXJENm3aJNGjR9fVrxMmTCg3b96UYcOGyZQpUyRTpkzOvBwREfkABEoYxwQjRoyQUqVKSc2aNb1dLCL/bnFasWKF5MuXT7p06SLt2rXTJlwEUdmzZ5djx47J0qVLNbAiIiL/8csvv0jFihXl2bNnej1q1KgMmohcETh9+eWX0rFjR7l3756MHTtWzp49q0HUmjVrZO3atVK5cmVHX4qIiLwMgRL26U2bNpUNGzbIjz/+6O0iEQVW4HTixAn9kcWNG1c6d+6sK2GPGzdOChUq5N4SEhGRS12+fFlKly4tkyZN0usDBw6UNm3aeLtYRIE1xun+/fsSP358/TtKlCgSK1YsjmkiIvIzv//+uzRo0EBu3Lih41Rnz54tVatW9XaxiAJzcPi6deskQYIElhWyN27cGGqtOvaNExH5ppkzZ0rLli11/503b15ZvHgxT4CJ3Bk42S7o2LZt2xDXMSvj5cuXzpaBiIg8oHjx4jrc4qOPPtJuOvQcEJGbAiecoRARkf/lZUqUKJH+nTVrVjl48KDmZjLTDxCRmxNgPn36VB4+fOjs04iIyMPmzp2rQRKGVZgyZMjAoInIE4ETBhJWqVJFm3kxSLxo0aJy+vTpN3lvIiJyU6qBrl27SqNGjXRiz7Rp07xdJKLgC5x69+4tBw4ckCFDhsiYMWPkzp07mpKfiIh8x7///itly5aVCRMm6PW+fftqkksi8vAYJ6yWjRkZ5mKP1atX16zh6LqLESOGi4pDREQR9ccff0j9+vXl2rVrOgN61qxZnOlM5K0WJ5zF5MmTx3L97bff1oAJi/u+iYkTJ2qfe8yYMaVIkSKye/fucB+Pli4k4kyVKpW+PwY7Ins5EVEww6DvcuXKadCUK1cu2bNnD4MmIm+nI0DiS9vrWBwyoubPny/du3fXBYIRNI0fP15btJClPHny5Hb77StUqKD3LVq0SNKkSSMXLlzQJG5ERMEsd+7cOqYJ++Tvv/9eYseO7e0iEQV34IQfI1p3rGdjPHjwQBf+xfIrplu3bjn85ljzDuOkWrRoodcRQK1evVqmT58uffr0CfV43I7X3759u0SLFk1vQ2sVEVEwOnnypESPHl0SJ06s+2asN4dFejlrjsgHAqcZM2a49I3RerR37175/PPPLbchACtfvrzs2LHD7nNWrFghxYoV06665cuXS7JkyfQMCwPXbVvDiIgC2YIFCzQL+Pvvv6/7Q+w/zRNKIvKBwCljxoyadRZnM65w8+ZNzTKeIkWKELfj+vHjx+0+5+zZs7rOUuPGjXVcE9IhdOjQQZ4/f66LVNqDweu4mO7du2dJ6OmOpJ54TbTO2X9ts1szrPvJPfVO7sJ69zzs73DCiUXWzZZ/7NfMtUTJvbjNB2a9O/O6DkdBmN6KgeD2xh55Cj4Y3n/q1KnawlSgQAH5559/ZPTo0WEGTiNGjJDBgwfbzUv15MkTt5Tx7t27+gVbd2HCy//7YvD/9evXXf7ewSy8eif3Yb17FvYbWOpq586der1Vq1bSv39/3Ze5Y39GoXGbD8x6R74zt4xxcqWkSZNq8IMZINZwPWXKlHafg5l0aIq27pZDSoSrV69q1x/6+m3hzAwD0E04M0uXLp1287njDA1fLsYX4PVtv9wo/3cd/3szAA1E4dU7uQ/r3XO2bdumqQZwAhsvXjwdz1SyZEnWvYdxmw/MesfMfkc51e/mygGHCHLQYoSlAGrVqmWpGFzv1KmT3eeUKFFC5syZo48zKw6DIxFQ2QuaACkL7OWZwvPdtdGjnuy/vll//7ufPFXv5E6sd890z2ESDYKmnDlzyuLFizUlDFqgWPeex20+8Ordmdd0KnBq3rz5a5NdLlmyxOHXQ0tQs2bNpGDBglK4cGFNR4B18MxZdh9//LGmHEB3G7Rv316+++47XUqgc+fOcurUKRk+fLh06dLFmY9BRORX0NKOdeew/0PuOyx9xTE2RN7hVOCE5uFYsWK57M3R7IyxRgMGDNDutrx588ratWstA8YvXrwYIgpEF9u6deukW7dumrMEQRWCKMyqIyIKJGhNP3z4sHz00Ud6vVChQvLTTz95u1hEQc+pwAlrH7l6bA665cLqmtu8eXOo25COwBwYSUQUiJYuXaqt8Ri7ibx1+fPn93aRiOj/ONypx4RqRETu9eLFC03+i1YmzPLBEAaM4SQi3+G1WXVERPT/YaB3gwYNZNOmTZYxoCNHjmRSSyJ/DZzwY0ZafyIici0MP6hTp47mpYsTJ44uL1WvXj1vF4uIItpVN2/ePCldurRDWcMvXbqk+UaIiMgxmPSCoClbtmzy119/MWgi8vfAafLkyZpoctSoUXLs2LFQ9yObJ5ZAwbpxGMT433//uaOsREQBCdm/0S23e/du3dcSkZ8HTn/88Yd89dVXsn79enn33Xc14zaSr+XKlUvSpk0rSZIkkU8++UTeeustnT5bs2ZN95eciMhPYZ3Npk2byuPHj/U60q4grQpSvhBRgIxxQjCECxbn3bp1q1y4cEF/9Fg6JV++fHphFlUiovCtWLFCk/uipR77T3OxXiIKwDxOgB+6uUQKhbbm0BUZvfa4PH152GqJlf+5fp+LcBIFq5cvX+pi5MOGDdPrxYsXlx49eni7WETk7sCJwjduwym5cDv8AClOjP+/SDERBT601GMMKIY7AJaJGj16dJhrbBKR72Lg5GIPn77Q/yNHEkkeL6bdoOmziu94oWRE5A0HDhzQYQ6YcRw7dmyZNm2aNGzY0NvFIqIIYuDkJsnjxZCdfct5uxhE5GWJEiWSR48e6YQaLIKOCTZE5L8YOBERuWE8U5Qo/+uST58+vS5ejsApQYIE3i4aEb2hyK7YQaAp+vbt22/6UkREfu/s2bO6xtzKlSsttxUsWJBBE1GwBk6ffvqp/Pjjj5agCRnFkfQyXbp0snnzZneUkYjILyARcIECBWTfvn261hwW7SWiIA+cFi1aJHny5NG/cUZ17tw5OX78uHTr1k369evnjjISEflFqoFq1arJnTt3pEiRIvL77787tEwVEQV44IRptSlTprScXdWtW1eyZs2qmcMPHTrkjjISEfksLDFVvXp1GTJkiF7v0KGDrraAVngiCjxOB04pUqSQo0eP6hkWBjxWqFBBb8esEXMwJBFRMMDYTnTNYV8YK1YsmTVrlkycOFFixIjh7aIRkZs43Y7cokULXbk7VapUEilSJClfvrzevmvXLl3Zm4gomFINVK1aVX777TdZvHixZRgDEQUupwOnQYMG6eK+Fy9e1G4688wKrU19+vRxRxmJiHzGkydPtIU9ceLEeh1rzWHdzoQJE3q7aETkK4ETdhAnT57Udeowlumbb74JtYp3s2bN3FVGIiKfgMXNa9eurakF1q1bp4O/cfLIrjmi4OHQGKdnz57JvXv39O+ffvpJz7iIiIIJAiWkXtm7d6/mrjt9+rS3i0REvtriVKxYMalVq5YOgjQMQxeoxEBIe6ZPn+7qMhIRec2rV69k2LBhmm4A+z8ks0RaFmQEJ6Lg41Dg9Msvv2g//pkzZ3RA+N27d9nqRERBMWuuadOmsnr1ar3epk0bHaoQM2boBbyJKDhEdTQFwciRI/XvjBkzys8//yxJkiRxd9mIiLyqUaNGmmoAY5gmTZqkYzyJKLg5PasOmcKJiILBqFGj5NKlS5qfCeObiIgcCpwmTJigTdRonsbf4cH4JyIif/T06VPZsWOHlClTRq8j9crff/8tkSO/8XroRBRMgRPGNzVu3FgDJ/wdFox/YuBERP4ILUt16tTRBXqxZErx4sX1dgZNROR04GTdPceuOiIKNBs3bpQGDRroWpzIBv7gwQNvF4mIfJTTp1JYyBJZc20hc665yCURkT9AegFMfKlYsaIGTfny5dM8TbhOROSSwGnw4MF2z8YQTOE+IiJ/gLQqH330kXz++eeaq6l58+aybds2nTlMROSywAlnaBjLZOvgwYOWtZuIiHzd/PnzZdmyZRI9enT5/vvvNXlvWIl9iYicTkeAfn8ETLhkzZo1RPD08uVLbYVq166doy9HRORVrVu3liNHjkiTJk2kUKFC3i4OEQVa4DR+/HhtbUICOHTJYZFLE87YMmTIoEuzEBH5Iqy5OXr0aJ35i0XKcfKHLOBERG4JnJo1a6b/o/8f03SjRYvm1BsREXnLP//8I/Xq1ZPt27drXiZ00xERuS1wunfvnsSPH1//xqwTzKDDxR7zcUREvmDz5s1Sv359uX79uraUo2uOiMitgRPGN125ckWSJ08uCRMmtDs43Bw0jvFORETehn3S119/LX369NH9Uu7cuWXx4sWSJUsWbxeNiAI9cPr9998tM+Y2bdrk7jIREb0RtJJjPCYCJWjatKlMmTJFYseO7e2iEVEwBE6lS5e2+zcRkS96+PCh5mTCWEwMAMeMX3st5UREbs/jtHbtWtm6davl+sSJEyVv3rzSqFEjuX37ttMFICJytVSpUmlr05YtW6R9+/YMmojIe4FTz549tRkcDh06JN27d5eqVavqGnb4m4jI054/f677H+vZcpj9W7RoUa+Wi4iCOB2BCQFSjhw59G+c0dWoUUOGDx+uK4ojgCIi8iRMXMGsuT///FPixo0r77//viRLlszbxSKiAOV0ixOSXZqL/G7YsMGyGCYGj5stUUREnoBhA/nz59egCalQfv75ZwZNRORbLU4lS5bUJvESJUrI7t27LU3jJ0+elLRp07qjjEREoVINYNA3hg68ePFCcubMKUuWLNHloIiIfKrF6bvvvpOoUaPKokWLZPLkyZImTRq9/ddff5XKlSu7o4xERBavXr3SySjdunXToKlhw4aya9cuBk1E5JstTm+99ZasWrUq1O3jxo1zVZmIiMIUOXJkSZcunZ7AIcFl586dOWuOiHw3cAJk4V22bJkcO3ZMr6OZvGbNmhIlShRXl4+IyLJIL8ZYAiakoKUJS0AREfl04HT69GmdPYdFM9955x29bcSIEXoGuHr1asmcObM7yklEQQrdcX379tWElli5AMETWpsYNBGRX4xx6tKliwZHly5d0hQEuFy8eFEyZsyo9xERucq1a9ekQoUKMnr0aNm+fbusWbPG20UioiDndIvTH3/8ITt37rSsXQdJkiSRkSNH6kw7IiJX2LFjh9StW1dbt5GfacaMGVKrVi1vF4uIgpzTLU4xYsSQ+/fvh7r9wYMHlvEHRERvkmoAs3exLiaCpmzZsmnqkzp16ni7aEREzgdO1atXlzZt2uj0X+zgcEELFBbRxABxIqI3MWjQIJ0ph2VUECwhaMqePbu3i0VEFLHAacKECTrGqVixYhIzZky9oIsuS5YsmpCOiOhNNGnSRLv/kWpgwYIFEi9ePG8XiYgo4mOcEiZMKMuXL5dTp05pOgLkT8HZIAInIqKIOHPmjGVG7ttvv63XEyRI4O1iERG9eYuTCTs3LPCLrjsGTUQU0Zxw/fr109QmWPvSxKCJiAIqcPrxxx/l3XfftXTV4e9p06a5vnREFLBu3rypyzQhmSUCKCzYS0QUcF11AwYMkLFjx+rgTYxzMqcNY90o5HMaMmSIO8pJRAHEnCWHfHCxY8fWk7EGDRp4u1hERK4PnLCw7w8//KDLHZgwmy537twaTDFwIqKwYBbu1KlTNVkullDBwrxLlizRZZuIiAKyqw5ThAsWLBjq9gIFCujSCEREYdm8ebOmLkHQ9OGHH8pff/3FoImIAjtwatq0qbY62cJZZOPGjV1VLiIKQGXKlJFWrVrJqFGjZPHixRI/fnxvF4mIyL1ddYDxCL/99psULVpUryMZJsY3ffzxx9K9e3fL4zAWioiCG/YVhQoVkkSJEmn6Epxk4X8ioqAInA4fPiz58+fXv5FrBZImTaoX3GfijpEouGGmHMY84lK1alVZuXKlRI4cmfsGIgquwGnTpk3uKQkRBYz//vtPu+7XrVun1zNkyKCBFAInIqKg66ojIgrL3r17pXbt2nLhwgWJFSuWds1hGRUiokDgE6d/EydO1DNSJNMsUqSI5nhxxLx587TZv1atWm4vIxE5Nv4Ra1ciaMISKlgAnEETEQUSrwdO8+fP1wHlAwcOlH379kmePHmkUqVKcv369XCfd/78eenRo4eUKlXKY2UlorA9ePBAhg4dKk+fPtXcbnv27NH8bkREgcTrgRNm3rVu3VpatGghOXLkkClTpmgm4enTp4f5HIyVwPiJwYMHS6ZMmTxaXiKyL27cuJpiYMSIEbJ06VJdEJyIKNB4dYwTkuBhPMTnn39uuQ2DR8uXL6/LuIQFs3SSJ08uLVu2lD///DPc98DZLy6me/fu6f+vXr3Si6sZVv+74/XJPtQ1slKzzj3r119/lXPnzmlSS8iXL59egN+Fe3Gb9w7We2DWuzOv63Tg9NNPP2nqgWrVqun1Xr166eBPtBbNnTtX0qdP79Qin2g9SpEiRYjbcf348eN2n4OFQDGO4sCBAw69B85+0TJl68aNG/LkyRNxtVcvX1n+f113I7l2o797967+sDhzyzP1PX78eBkzZoxEixZNsmXLpot9k+dwm/cO1ntg1vv9+/fdFzhhJXMzczhahTCwe9y4cbJq1Spd6BfrTrkLPhgyl2OtPARvjkBrlnVSTrQ4pUuXTpIlS+aWrMWRo0S2/I9WMfLcjwoTBfC9cmfmXrdv39Zkt2vWrNHr9evX1wW/MYOOPIfbvHew3gOz3jE5zW2BE1Yzz5Ili/69bNkynXbcpk0bnUmD5RScgeAnSpQocu3atRC343rKlClDPR4JNzEovEaNGqGa16JGjSonTpzQmTzWYsSIoRdbqHh3VH4kq//5o/Is/Kjc9b3S/6ClF7/5s2fP6o4GJ05IbomgifXuedzmvYP1Hnj17sxrRo7IAFAktzOXUqhQoYL+jZ3o48ePnXqt6NGj6+LAGzduDBEI4TrOYG2hO+DQoUO68zYvmL1TtmxZ/RstSUTkHrNmzdLfJYKmjBkzyvbt26V58+beLhYRkUc53eKEQAmLdGIA6MmTJ/VsE44cOaK5mJyFbrRmzZpJwYIFpXDhwjpu4uHDhzrLDtAlkCZNGh2rhODMdhyFOXOH4yuI3AutvRgXiN/8L7/8omvPcYAsEQUbpwMnNM1/8cUX2mWHqcdJkiTR2zE7rmHDhk4XAOMjMFB7wIABcvXqVcmbN6+sXbvWMmAciwezOZTI+/C7R1c4fuf8TRJRsIpkYIh6EMHg8AQJEujofHcMDi86fINcvfdUUsaPITv7lnf565N9aPnALEYMyOdB3TU2bNggo0aNkuXLl4c58Jv17j2se+9gvQdmvTsTGzjU4vT3339rVxgKi7/Dw0zBRP6/g/rqq6+0hQl/I3hCZn8iInIwcEL3GbrREOnhb4xst26oMq/jf+RlIiL/dOfOHR1zuGLFCr3+ySefSO/evb1dLCIi/wqckBkYuRPMv4ko8GDG6kcffSSnT5/WFB7fffedTgQhIiInAyfrbODOZAYnIv9ZOgX5mZBS5K233tKJH5jpSkRELlqr7ujRozrjDevNWUNeJSLyLzlz5tTFtUuVKiWzZ892ODM/EVGwcTpwQvK7Dz/8UJv1rcc64W/gGCci//DgwQNNaAtoZUJCS6QbQDZ/IiKyz+k5fV27dtWswZgWiDNUJL7csmWLNutv3rzZ2ZcjIi/YtGmTLp2EVAOmrFmzMmgiInJ14ISFfYcMGaJN+eaaMSVLltTM3l26dHH25YjIg9BCPHr0aClfvryuCTl27NgQM2SJiMjFgRO64uLFi6d/I3j6999/LYPGscguEfkmJHirU6eO9OrVS/MzYTkjDAo3u9mJiMgNY5yQCPPgwYPaXVekSBFNjofFeqdOnSqZMmVy9uWIyAMwmQOpBnByEy1aNJkwYYK0bduWQRMRkbsDJ2QTxiK8gC676tWr60wcrFk3f/58Z1+OiNwM60piAW38btOmTSuLFi3Skx4iIvJA4FSpUiXL3xhcevz4cbl165aulM6zVyLfky5dOs0GjtamuXPnWpLZEhGRmwOn58+f62KfBw4c0C47U+LEiSPw1kTkLleuXNEZclgmCcaNG6fXOWuOiMiDg8MxNgL5Xpirich3/fnnn5I/f35p0KCBvHjxQm/DOEQGTUREXphV169fP+nbt692zxGR70BaAbQslS1bVhflvnHjhty8edPbxSIiCu4xTlj4E4uApk6dWlMQxIkTJ8T9+/btc2X5iMgB9+/f1wV5FyxYoNcbNWqkM11tf59EROThwKlWrVpv+JZE5EqYoIFUA8eOHZOoUaNqq1PHjh05WYOIyBcCp4EDB7qjHEQUwe65pk2batCEVuCFCxdK8eLFvV0sIqKA5fQYJ3QHcE06It+AVqWZM2dKtWrVtJucQRMRkY8FThhwWrlyZc0N07NnT80iTkSegzXmlixZYrmeM2dOWbVqlaRIkcKr5SIiCgZOB05YTR05Yvr37y9//fWXTnvGjnv48OFy/vx595SSiNT27dv1N1e/fn3Ztm2bt4tDRBR0nA6cAFnC27Rpo112Fy5ckObNm8vPP/+smcSJyD1jmb799lspXbq0Lqz99ttv6zJHRETkB4GTdSbxPXv2yK5du7S1iV0FRK6HNeaaNGkiXbp00YSW9erVk927d0u2bNm8XTQioqATocBp06ZN0rp1aw2U0NoUP358HWNx+fJl15eQKIidPHlSihYtKnPmzNHM32PHjpV58+ZJ3LhxvV00IqKg5HQ6gjRp0mjWcAwQR4K9GjVqSIwYMdxTOqIg9+uvv8rhw4clZcqUmtyyVKlS3i4SEVFQczpwGjRokNStW1cSJkzonhIRkQW65+7du6dpQFKlSuXt4hARBT2nu+rQRcegicg9kO4DEy+whIqZpwkzWBk0ERH5aYsTEbkHJlnUqVNHxwo+ffpUfvrpJ28XiYiIXDmrjohck2pgypQpOn4JQVPWrFmlV69e3i4WERHZwcCJyIsePXqkM1Pbt2+v6T0+/PBDTSyLpLJEROR72FVH5CXIfVarVi1dtihy5MgycuRI6dGjh45rIiKiAGpxQpbwEiVK6GrsyBwO48eP1+VYiMgxMWPGlOvXr0uyZMlkw4YNuvYjgyYiogALnCZPnizdu3eXqlWryp07d+Tly5d6O2baIXgiovDHM5mQm2nlypWyb98+KVu2rFfLRUREbgqcsF7WDz/8IP369dNMxqaCBQvKoUOHnH05oqDx33//SZUqVWTu3LmW2woUKCBp06b1armIiMiNgdO5c+ckX758oW5H9nCsqUVEoWFNRwRJ69at06SW/K0QEQVJ4JQxY0Y5cOBAqNvXrl0r2bNnd1W5iALGtGnTdEwgxgNmyZJFNm7cKHHixPF2sYiIyBOz6jC+qWPHjvLkyRMdr4FV2tH1MGLECD1AENH/PH78WDp16iTTp0/X6zVr1tSklsy8T0QURIET1syKFSuWfPHFF5qDplGjRjq77ptvvpEGDRq4p5REfgYnFkhouXfvXk018OWXX0rv3r31byIiCrI8To0bN9YLAqcHDx5I8uTJXV8yIj9PNVCuXDntnkOLbPny5b1dJCIicoE3Ov2NHTs2gyai//Pq1Su5ffu25fqwYcM0uSWDJiKiIGtxwiw6RxPzIScNUbC5deuWNG3aVFMO/PHHHzrLNGrUqNqNTUREQRY4YVkI67EbkyZNkhw5ckixYsX0tp07d8qRI0ekQ4cO7ispkY/av3+/1K5dW1N1oIsOJw/mb4OIiIIwcBo4cGCIweHIQzN06NBQj7l06ZLrS0jkw2bMmKEnDDihQKqOJUuWSN68eb1dLCIi8pUxTgsXLpSPP/441O1NmjSRxYsXu6pcRD7t6dOn0rZtW/nkk080aKpWrZrOoGPQREQU2JwOnJCKYNu2baFux23opiAKBu3atZOpU6fq2D+0vq5YsUISJUrk7WIREZGvpSP49NNPpX379jqOo3Dhwnrbrl27NMlf//793VFGIp+DtRq3bNmi4/0qVark7eIQEZGvBk59+vSRTJkyacLLX375RW/DUisY61GvXj13lJHIJ1INYBJE8eLF9TqWTjlx4oTOnCMiouARob0+AiQGSRQs7ty5o+P6Vq1apWsyVqxYUW9n0EREFHy45ycKx99//y0fffSRnDlzRnMzXb9+3dtFIiIiL+LCWURhQFd00aJFNWhKnz69ToDA7FEiIgpeDJyIbDx79kw6deqkmcAfP36sg7+RaqBAgQLeLhoREXkZAyciGytXrpSJEyfq3wMGDJDVq1dLkiRJvF0sIiLyxzFOSPYXVr6mK1euSKpUqVxRLiKvwZgmpN0oV66cVK9e3dvFISIif25xyp8/vxw4cCDU7cganjt3bleVi8hjDMPQfExYqBeQ1HLcuHEMmoiI6M0DpzJlyuiA2a+++kqvP3z4UJo3b67jQfr27evsyxF51b1796ROnTrSsWNHHfiNfE1EREQu66rDmTnW5cJiv8hrg+65uHHjyu7du+Xdd991TymJ3ODIkSPaLXfy5EmJHj26fPDBB9raRERE5NI8TlWqVNEDzuTJkzUJIAbTMmgifzJv3jxp2bKlPHr0SNKlSyeLFi2yLCFERETksq465LQpVqyYtjatW7dOevXqJTVr1tT/nz9/7uzLEXkUtlEM/G7YsKEGTeXLl9dUAwyaiIjILYFT3rx5JWPGjHLw4EGpUKGCfPnll7Jp0yZZsmQJDz7k8x48eCDLli3TvzEmD0uoJEuWzNvFIiKiQB7jhIHg1rDw6f79+/VMnsiXJUqUSGeAXr58Wcc0ERERuTVwsg2aTPHixZMff/zR2ZcjcnuqgfHjx0v8+PF1TBMgAzizgBMRkUcCp1mzZoV5H2YkhRVYEXna/fv3dfbnggULdNYcUmlkzpzZ28UiIqJgCpy6du0aarAtBtniwBQ7duwIBU5Y3mL06NFy9epVyZMnj3z77bdhjpf64YcfNHg7fPiwXkfLwfDhwzm+ikI4duyY1K5dW/+PFi2ajB07VjJlyuTtYhERUbANDr99+3aICwbbnjhxQkqWLClz5851ugDz58+X7t27y8CBA2Xfvn0aOGFR1evXr9t9/ObNm3VGFAak79ixQ6eSV6xYUf755x+n35sCk5laAEFTmjRp5I8//tAEl8zRREREPrHI79tvvy0jR44M1RrlCLQEtG7dWlq0aCE5cuSQKVOmaMvV9OnT7T5+9uzZ0qFDB53dly1bNpk2bZpme964caMLPgn5uz59+kjdunU1oC9btqwG40ifQURE5DOBEyAR5r///uvUc549e6Y5dJBLx1KgyJH1OlqTHIFuQnQXJk6c2OkyU+DBJAVAXrHffvtNkidP7u0iERFRMI9xWrFiRahZS1h25bvvvpMSJUo49Vo3b96Uly9fSooUKULcjuvHjx936DV69+4tqVOnDhF8WXv69KlerNcmA7RSuWNdMsPqf6575hnYhtANh20R28N7770npUqV0vv4HbgX6hf1znr2PNa9d7DeA7PenXldpwOnWrVqhbiOAxYSCL7//vvy9ddfiyehexBLZ2DcU8yYMe0+ZsSIETJ48OBQt9+4cUOePHni8jK9evnK8n9Y47TINfAjQgoMjGlCbia0YOK2d955h3XvIdjZ3L17V+sdrcXkOax772C9B2a9Yxa22wInV0Z7SZMmlShRosi1a9dC3I7rKVOmDPe5Y8aM0cBpw4YNkjt37jAf9/nnn+vgc+sWJwwoR7CH3D6uFjlKZMv/7CZyn4cPH0qbNm00cAZkAMf6ifheuTPzHOwPzJMn1rtnse69g/UemPUeVuOLyxb5dRWkMEA6AQzsNluyzIHenTp1CvN5o0aNkmHDhulaeQULFgz3PWLEiKEXW6h4d1R+JKv/+aNyj5MnT2qqAaSkwNg6BNHt2rXTVkR3fa8UNuzMWO/ewbr3DtZ74NW7M68ZocAJy1VgrNPFixe1e8R2lpwz0BrUrFkzDYAwhRxZntGagFl28PHHH+uUcnS5wVdffSUDBgyQOXPmSIYMGTT3E8SNG1cvFNiWLl0qzZs315ZDtEouXLhQU2FwvAEREXmC04ETWoNq1qypyQQxgPvdd9+V8+fPa79j/vz5nS5A/fr1taUAwRCCIKQZQLeLOWAcwZl1JDh58mQN1urUqRPidZAHatCgQU6/P/mP77//XluWAIO/kQMsVapU3i4WEREFEacDJ4wZ6tGjhw64xtRvDMrFWJ7GjRtL5cqVI1QIdMuF1TWHgd/WEKRRcKpatar2bzdp0kRbHpERnIiIyKcDJ2RjNjOEY3zJ48ePtYtsyJAhutp8+/bt3VFOClLoFk6bNq3+jUH9R48e1UkFRERE3uD0CKs4ceJYxjWhm+TMmTMh8jIRuQK6fidNmqSL8i5btsxyO4MmIiLyi8AJLUoYtF20aFHZunWrpevks88+0xlun3zyid5H9KaQDR4TBrC+HIJ026SrREREPh84YUwTAifMmitSpIjltnLlyukgXcxwQzJCojeBFkysLffzzz9rjq/Ro0dzuyIiIv8b44SuE8BsOutuOyzKS+QKK1eulKZNm2p2WEw4QEBepkwZbxeLiIgoYoPDkXyKyB0OHTqkaS6gePHismDBAs3fRURE5LeBU9asWV8bPN26detNy0RBKFeuXNK5c2f9G5nAkVWeiIjIrwMnjGlKkCCB+0pDQWXPnj2aasBclxBZ47mEARERBUzg1KBBAy5cS28M4+WmTZumSU8xEBwLNSMnGIMmIiLydQ4fqTi+iVwBCVNbtmwpbdq00VQDCRMmlCdPnni7WERERK4NnMxZdUQRde7cOSlRooTMmDFDW5ewcPOSJUu4ODMREQVeVx1Xn6c38euvv+p6hrdv39bs3/PmzdMcYERERAG9Vh2Rs168eKEZ5hE0IXnqwoULdd05IiIif8PRuOR2GPi9aNEi6dq1q/zxxx8MmoiIyG8xcCK32Ldvn45lMuXIkUPTDcSIEcOr5SIiInoT7Kojl0PA1L59e+2iQ9JUDAgnIiIKBGxxIpdBWgGkGfjkk0/k6dOnUqVKFW1pIiIiChQMnMglLly4IKVKlZIffvhBc34NHTpUli9fLokSJfJ20YiIiFyGXXX0xtavXy8NGzaU//77TxInTixz5syRSpUqebtYRERELsfAid7Y4cOHNWgqWLCgzp5Lnz69t4tERETkFgyc6I19+umnmv27adOmEjNmTG8Xh4iIyG04xomcdvDgQalWrZrcu3dPr2NMU+vWrRk0ERFRwGPgRE6ZNWuWFCtWTNasWSN9+/b1dnGIiIg8ioETOQTpBTp06CDNmjWTx48fS+XKlWXw4MHeLhYREZFHMXCi17p06ZKULl1aJk+erN1yAwcOlFWrVkmSJEm8XTQiIiKP4uBwCtfu3bt1PNPNmzclYcKEMnv2bKlataq3i0VEROQVDJwoXEgtED16dMmbN68sXrxYMmXK5O0iEREReQ0DJ7K7dIo5Qy5FihSyceNGDaBixYrl7aIRERF5Fcc4Uahklrlz59YuOVO2bNkYNBERETFwImtz586VIkWKyKlTp+TLL7+UFy9eeLtIREREPoWBE8mzZ8+kS5cu0qhRI3n06JGUL19e/vzzT4kalT25RERE1hg4Bbl///1XypYtK99++61eR1LLtWvXStKkSb1dNCIiIp/DJoUgdufOHSlQoIBcvXpV4sePLz///LPUrFnT28UiP/Ly5Ut5/vy5TiiIHJnnYZ706tUr1r0XsN79s96jRYsmUaJEcUlZGDgFMeRlatGihSazXLJkiWTJksXbRSI/YRiGBty3b9/WHdr9+/c1OSp59jtg3Xse691/6x3HvJQpU77x98bAKchgo3vw4IGkSpVKrw8dOlS++OILiR07treLRn4EQRNaLJMnT655vnA2x4OI5w8kmMCBsYise89hvftfveO5GL97/fp1vW4e/yKKgVMQOXbsmHz00UfaLbdlyxaJESOGNl0yaCJnu+fMoClx4sQ8iHgJD+DewXr3z3o3U+ogeMK+60267dhBGyQWLlwohQsXluPHj8s///wjFy5c8HaRyE9hnAEw4CYif2Lus8x9WEQxcApw2EC6d+8u9erV0y46zKDbt2+fZM2a1dtFIz/Hs20iCsZ9FgOnAB+HUq5cORk3bpxe79Wrl/z222/aTElEgeP8+fN6UDhw4IBb36d58+ZSq1Ytl77mzJkzddDum8iQIYOMHz9efMV7770nc+bM8XYxgsqUKVOkRo0aHnkvBk4BDDPmkMgyXrx4ukDvV199xaSWFNRw4EeAgQsGtGfMmFFPKDDF2Z+lS5dOrly5Iu+++674m/r168vJkyffKMj666+/pE2bNuILVqxYIdeuXZMGDRqEum/EiBE6tmb06NGh7hs0aJAupu5IUIzxPlOnTtWVHuLGjat1UrBgQQ0eMQjaXS5evCjVqlXTLi+cgPfs2fO1K0ygh6NChQpaxiRJkuj3hN4P2+8PJ/l4TKJEiaRSpUpy8ODBEI9Zt26dlCxZUsfoJkuWTGrXrq11Y/rkk0/0vXDMczcGTgHsu+++kxIlSuhGiUHhRCRSuXJlDTLOnj2rrbHff/+9DBw40O0D6jGV2l1wMMY0a388McKg3TdtBceB1FfG3E2YMEFPWu3lGpo+fboG6vj/TTRt2lQ+/fRT+eCDD2TTpk0aVPXv31+WL1+uvQru2oYRND179ky2b98uP/30kwayAwYMCDfBMlaiQKqbXbt2aXLlI0eO6AmMCUEUfpNvvfWWPmbr1q16so/gyRyLdO7cOW3pLFOmjOzfv1+DqJs3b4Y4rmF2L1a/QP27nRFk7t69a+Bj4393KDJsvZG+9yr939Pu379vLF26NMRtr169MoLBy5cvjStXruj/5F6PHz82jh49qv9j+3r27JnfbGfNmjUzPvjggxC3ffTRR0a+fPks17ENDR8+3MiQIYMRM2ZMI3fu3MbChQtDPGf58uVGlixZjBgxYhhlypQxZs6cqfuV27dv6/0zZswwEiRIoI/Lnj27ESVKFOPcuXPGkydPjM8++8xInTq1ETt2bKNw4cLGpk2bLK97/vx5o3r16kbChAn1/hw5chirV6/W+27dumU0atTISJo0qZYL7//DDz9o3eO18f779++3vNbmzZuNQoUKGdGjRzdSpkxp9O7d23j+/Lnl/tKlSxudO3c2evbsaSRKlMhIkSKFMXDgQKfqD58Hr5EsWTKtixIlShi7d++OUF2ZDhw4oI+LGzeuES9ePCN//vzGX3/9pfWE51lfzPKmT5/eGDdunOU1Tp48aZQqVUrfE/X/22+/6ePN/aP5WmYZAHWH21CXpj///NMoWbKk1nfatGn1s2I/G9Y2f/36dSNSpEjG4cOHQ92H7yNNmjT6XHz/27ZtC3E/PkuePHlCPc/2u50/f75eX7ZsWajHokx37twx3GHNmjVG5MiRjatXr1pumzx5shE/fnzj6dOndp/z/fffG8mTJw+xX/7777+1/KdOndLr+G5x/eLFi2E+Br+/qFGj6vZm1vuKFSu0rlGfpj/++EO390ePHr123/UmsQFbnALEiRMntNkWEbj1GQcH8BKF7fDhw3r2jLNV6+6UWbNm6ZgJnB1369ZNmjRpIn/88Yfl7LdOnTp6BozuhLZt20q/fv1CvTa6TNA9Pm3aNH0dtKp06tRJduzYIfPmzZO///5b6tatq2fbWFgbOnbsKE+fPtV0IYcOHdLnoysG0KJw9OhR+fXXXzW1yKRJk7Trwx7MnK1ataoUKlRIyzh58mT58ccfdfFua2g1iBMnjp7pjxo1SoYMGSLr1693uP7QeoJhAHgddJOgZQEtBbdu3XKqrqw1btxY0qZNqy3le/fulT59+mi3avHixbUrCl01aDHEpUePHqGej5Y97AfxneJz4Xvs3bu3OOvMmTP63aBLCN/V/PnztTWkc+fOYT4H96PlK3v27KHuQ/03bNhQPwv+x/WImD17trzzzjva2mQL+/sECRKE+VxsS+Fd2rVrF+Zzsd3mypVLUqRIYbkN3/W9e/d0+7YH2zK+B+vWNzMtAOoK8FmwHaM+0Jr1+PFj/Rt1iLFrgBUu8BrYztDydffuXV3pAq1ZqE8TuivRdYjv3Z38r12XQkHWbzR9IrklEnthR0jkaTW+3So37j/1+PsmixdDVnYu6fDjkSkfBwnsYLFjxw4Z3dqA68OHD5cNGzZIsWLF9LZMmTLpTh5deqVLl9b/sbM3x6ngbwRgw4YNC/E+6GZAcJMnTx7L+JAZM2bo/6lTp9bbcOBH9wVux/viPhyocYAy39uE+/Lly6cHB0ifPn2Y40vwvhj3hM+Fg2m2bNm02wQBBLpWzANZ7ty5Ld2Ub7/9tj5+48aNOibldR4+fKgBGbprqlSporf98MMPGnjhwIfxL47WlTV8TjwXZTbLZUJQgM+Dbsmw4LtD2hV055j1jLo1y+goBNAI4tAlZpYD3UDYBvC/GdBaQ5oXBBa23XQILhYtWqTBByAQL1WqlHzzzTd2Xyc8CLJRjxHxuskDCErDm2xkHTSBeR332fP+++/rrG58/127dtVtBoEwIPAFdMtt3rxZg2skZDbrGt+f2fWMsYi4jvFwHTp00OAJv881a9aEeD8ErdhG3J1uh4GTH8NOE2dvOFM0Z3LgrCi8nQqRuyBounrP9wdZIyUHDvjYiWOME3bOCFbg9OnT2lJkGzjgTBhBi9m6i5Yca8iRZgtn2ghMTGhBwg7fNhUIgjWz5ahLly7Svn17bTXG2TTKZb4Gbsd1tOxUrFhRWxzsvS+gRQoHFusWZ4x3xHiSy5cv63gSsC4f4MTLzK7sSIsMgkO8rgln/ygT3t+ZurKGA22rVq0sLQpolcucObM4Cu+NoNEMmsAMgp2BFjK0NKGFx3bZD7SkmcGtNbSWxIwZM9Ttc+fO1c9gBtEYBI7AF/vrli1bOlUulCGiPL2sVs6cObWVCN/p559/rmPxsI1bB5eoM9QBtiPUE34jY8aM0fFUaHVECxUCMwwqR8CJYBbbMU4A0JqJQN16O8fj3TlAHhg4+Sns3DBrAwMDARvmyJEjQzRbEnm65ccf3hctsuYBBIN0cTBDCwl23uZsn9WrV0uaNGlCPA+Z9p2BHbj1Dh2vjQMHup9ssxabrQ4IGND9gfdH8IRWj6+//lq7h9BigjNpnGXjYIGgAsEU7o8o2/0FyuvOQeyOwOwyDPJFHaBbEi1i6Nr88MMPXfYe5kHbOgixTYqI7wtdizjQW8NzrIMya0mTJtX1G21h+0J3lvXgfdQztj8zcEJrD7qgbCFLP5hdcAi80aIWEa9r3UJggq5Ne3BCvnv37hC3YfageV9Y8F3igsfit4dtbOzYsZbWVKRtwOw4tMaZ3wtuw+w6DHbHcW7ixIn6+XGMMzOH//LLLxogo1uuaNGilvdDNzEmC7gTAyc/heZ9BE3YEPHjQ4JLIm9yprvMV2BH3bdvXz3xwM49R44cGiChuwhdMvagm8S2iwBnxq+DFiucTeOkB900YcHBAGNNcMFZOrq/zHE1OCA0a9ZML5iajTFG9gInjA/B2CMc5M3gbdu2bdotgvFDroAWFLSq4XXRemIGH6gLs3sronWF4AAXjC/DeCB0ZSJwwvuhDsODz37p0iXtCjLXJNu5c2eIx5gHVjwGB2h73Vj58+fXMWW2rTTm0h9hfcfm4tfm66Klcc+ePdodhSWKrA/wmCWGIAjdkqgrtAYiwLDuEkMLI1qxzFZCbKcIJhBU2I5zQtnQLRjWOKc36apDqx26WK//35IlgAAez8Hv5nXMz4TjFT6P2aqL1iH8Dq1PMszrZhBvPsaaefJhHeijFRSpRczWYbcxgkwgzaobNGiQzhAgzqrzpECbVYeZZpjtNHr0aL3er18/I0mSJDr76/Tp08bevXuNCRMm6HU4e/asES1aNKNXr17GiRMndJYTZlxhv2LOaLKdKWZq3LixztZbvHixvs6uXbt0Bt+qVav0/q5duxpr167V+/C+RYoUMerVq6f39e/fX2dSYaYRZm1h9h1mzdmbVXf58mWdldexY0fj2LFj+jzMxrOeNYdZdXg/a6gb1JGj9YfnY4bYr7/+ahw5ckTvxww9zACMSF1hNhTKjFlvmGG4detWI3PmzPp8wEw0PHfDhg3GjRs3jIcPH4aaVYd9AGYjVqhQQWfobdmyxShQoECIWXXYZtOlS2fUrVtXZ+Ch/t95550Qs+oOHjxoxIoVS8uDesXjUI8dOnQIc5t/8eKFzjBcuXJliDrC92gPZlX26NHDsh3mzJnTKFu2rH7OM2fO6GyyVKlS6YxIE963fv36WrZhw4bprDTUFd7z/fffDzWz2lXw2d59912jYsWKWq/YTvFZP//8c8tjsD2jHrH9mb799lvdlvH9f/fdd1rub775xnI/tk/Mfmzfvr3uV7BtN2nSRLeJf//9Vx+zceNGnUE3YMAAfR28XqVKlfR7t55Bh20pU6ZMYX4GV82qY+DkJ4ETdhDdu3c3bt686dLXDRQMnDwn0AInGDFihB4EHjx4oJ9l/PjxegDAQR+3YyeNqc5hTbHHtGzsV8wdcliBE+oKO38ET3htHBQ//PBDnX4NnTp10kABr4v3bdq0qeU3P3ToUJ1ajwNP4sSJ9XPgIPIm6QjeNHDC58UUfQRljqYjCK+uMK29QYMGGtSg3AjKUCfWB7p27dppYBteOgLUC9II4DWyZs2qB3nrwAkQlOXKlUtTDSB1AYIU23QE+CwIwJAaIU6cOJqa4ssvvwx3m0eQh89gfh6UddSoUXYf+9VXX+l0fXNK/T///KN1/NZbb+n3jABw5MiRIabcA/ZzqEd8vwiQkRIAwSECkrCm4rsCArQqVapo2fCdI7WG9TZlpnmwrkNsw9he8V2g/mbNmhXqdZEuAtsOtgME3ggAd+zYEeIxc+bMMfLmzavfA34bNWvW1KDLGoI6/JbdHThFwj8SRMxmTPQlh9csGVFFh2+Qq/eeSsr4MWRn3/IueU0MWMX0WjT5Vq9eXVauXOmS1w0kaK41m5DtJZ4j10FTOAbHYqYLurW4UrxoFwbGhqCLyF9Wiw+mugLU0dKlS994yZjX1Tu66jAoGl1sZhcmvbnX1TvGkGEWH7LQh9VVab3vsh3E70xswDFOPg7p+z/++GP9MtFHjGm6RORdmO6P2WKYDYcxPphujRxNFFqw1RUGSmMwOMbJMXDyHIxXQ/618PJYuQoDJx+FAZCYTWLmO0Hyt4ULF4Y5m4OIPAe5dJBMEgN8MWj3s88+04HcFFow1pWrF0Km18MsU09h4OSD/vvvP51JYmbwxXRYnKVZZzcmIu9B/idcyH/qKshGpZAbMXDyQei/xbgmZEHFcg0IooiIiMj7GDj5CPNsCEETcn1gECPyVLz77rveLhoRERH9H04/8gFIOf/JJ59oojsTshkzaCIiIvItDJy87OzZszrwGwtlItuuo+tEERERkecxcPIiLEVQoEABTYOPJQCwaruZyp6IiIh8DwMnL6YawOrPWMCxSJEimiwNybuIiIjId3FwuBcyXGNhRqz8DR06dNCVop1deZ2IiIg8jy1OHoblQLDKdKxYsTTL6cSJExk0EVGYBg0aJHnz5n3t4/r37y9t2rTxSJn83c2bN3VYxOXLl71dFPJDDJw85P79+5a/kTX377//lqZNm3q1TETBpnnz5nazOm/evFlTgaDr3B9hfbRvvvlG+vXrF+q+HTt2aGoTDA1w5nNnyJBBxo8fH+K2TZs2SdWqVXX5FOSZy5Ejh2YC/+eff8RdsL5Yx44d9T3jxo0rtWvXlmvXrr32e8bnsr5UrlzZcn/SpEl1KSsMmSByFgMnN8OPvnXr1lKyZEl59OiRpdUpS5Ys3i4aEfmQ58+fR/i5SJSL2bn21kbDummdO3eWLVu2yL///hvh9/j+++91WQusxbZ48WI5evSoLtaLdTS//vprcZdu3brpwuZYcuqPP/7Qz4BFz18HgRLWLzMvc+fODXF/ixYtZPbs2boUDJHfBU7orsLZDVYrxkDp3bt3h/t4/ICyZcumj8+VK5fOTvNFFy5c0IAJO7VDhw7Jxo0bvV0kIrd6+PBhmBecRDj6WOQ2c+Sx7l72KE2aNNqygv2M7YF30aJFeju63dEagqDCLNNff/0lFSpU0JYNLDpaunRpnQBiDa0gkydPlpo1a0qcOHEs61KOHDlSF/SOFy+etGzZMlS92TNv3jypUaNGqNsfPHgg8+fPl/bt22uLE9KeRAS6tLD0Ey7Tp0+XMmXK6D77vffe0/3bgAEDxB0QlCHwwzhQTJ7BLOQZM2bI9u3bZefOneE+F0MgEOSZl0SJEoW4P2fOnLr2J5INE/lV4IQfdffu3bXJFDsWJH6sVKlSmPmM8IPBDg07lP3792uzOy6HDx8WX3Ln1F+SP39+2bt3r+5U165da3fHRhRI0JUS1gVdLNYwxiSsx1apUiXEY3GQtvc4d0GwgoM0JnFg34KxQ+haN0/q0IKB/RAS1x47dky7vNAKYq4AgK75Zs2aydatW/UA//bbb2sXl3WXvTl+6cMPP9QTK7zWggUL9Lbhw4fLnj17JFWqVDJp0qRwy4oWE7T+FCxYMNR9eD2cZL7zzjvSpEkTDXoismYbTlafPXsmvXr1snt/woQJw3wuvsvwtgsEMGHB/hMtcdYLuOLzYLFgdEGGB98JtjF8dgSOCIZtFS5cWP78889wX4coFMPLChcubHTs2NFy/eXLl0bq1KmNESNG2H18vXr1jGrVqoW4rUiRIkbbtm0der+7d+9ir6H/u0PhoeuMBCUbGxIpkr5PwYIFjfPnz7vlvcgIsd1cuXJF/yf3evz4sXH06FH9/9WrV8azZ8/0f8A2H9alatWqIV4nduzYYT62dOnSIR6bNGlSu49zVrNmzYwoUaIYceLECXGJGTOmvt7t27fDfC72O5999pn+vXfvXn28o79tbJfx4sUzVq5cabkNz//0009DPK5YsWJGhw4dQu3f8uTJE+o1zbrft2+fvtbFixdDPaZ48eLG+PHj9e/nz59rPW7atMlyP/4O63OnT5/eGDdunP7dvn17I378+EZEXL582Th16lSYl/DqcPbs2Ub06NFD3V6oUCGjV69eYT5v7ty5xvLly42///7bWLp0qZE9e3Z9zosXL0I8rlu3bkaZMmWc+jy22zx5hivq3Xrf9SaxgVfTEeAMBmcUGCxtwvgfnF2EdTaB29FCZQ0tVMuWLbP7+KdPn+rFdO/ePUtaAFxc7dL6GXJ36zz9G2ObMLgSXYrueC/6/1C/OBaxnj1X12bLhfX/ti0q1jBA2bq1I7wBvtgPWD/23Llzdh8XkdaTsmXLhmrF2bVrl7YomZ8LudbQ6oOWFgx8xr4K+xF02+H+3LlzS7ly5bSrDvsfdMvVqVPH0h2Ez/bFF1/omBy0nuP1MMYR3ffWZUarlvV1tF61bds2xG1FixbV1hN7nxW3md2a6JqyfsyJEye0hWzJkiV6O+q/Xr162vWFrkPr+rP+Pm1f3/xdoWsxIvWN7rDXCet1bbcxe2Wzp379+pa/sXQVvieMK8XgdnxvJuyb8b04+7nCKxe5z5vWu/X2bHuscObYEdXbU0KxQ0F/vjVcP378eJizR+w9HrfbM2LECBk8eHCo22/cuOHQ2AFnJStUXa4f2Cjp3m8qQ4b01EDNDNbIfbDRYzwEfhQ46JL7oOsE9f3ixQv9G79hwIH1dak18ByTKx5r/RhHoNwYk4SuP2sIaMzXw2XUqFEyYcIEGTNmjB54MQapR48eus8w3xNjK3Eit379evn22281UELXXMaMGbWbDl1DGDSNbiWUH+OBrJ9vHrhtPwPq0/o2c2dv+zgzwMMYKnOfZj2OB2tf4jkYp2X9HJRl3Lhx+jx8LkBZbbs+MdMO46zwGgg68Pu6dOmSdh86A0MUUC9hQf0cPHjQ7n1YUQFBK44V1t2BCEzRDefo94/3wHizkydPWoJG83Pjdme2I7PezW2ePMMV9Y7vGfsAfO/RokULcV94J31BlwATrVnWLVQIYtKlS6c/yPjx47v8/dK99ZZE/XS6pEqSgMuneJB5RozvlYGTe+Hgj51M1KhRLTsf252Qr8K2gQvKbg2tMYDbccG4JAzaRgBkbl+nTp3S6ffWz0UwhAvGJSEYw+wv7G8wFhOTXsxxjQg4cPC3fW+8r/X17Nmz69gmzPgyodUI27Ztma3H/GBfhqAA5TMPEJgxhsCvYsWKIR6PMVVoSWvXrp0+F2VC4JI5c+YQa2giUML9eF+0VCHVAQZpI+iyhSArrHFOGDxuO9jfGradsD4bxiDhfrTcmWPk0JJ28eJFKVGiRJjPsze4HQdLBJHWz8HYMARSjr6ObbnJ896k3vE9Y3vHuGOctFizvR7u64gXIdLHjsO2yR7XMQvCHtzuzONxdmXvbNXcgbraik4ltGkeQRMP4J6Fg4u7vlf6/1C/Zm4csP3fH9iW1foz4ILB3Jg1hxYltOIgYMB+BoEJ7kfXHmbJIijBbx3X0eJj3o/n//LLL1KoUCE9WevZs6e2dFnXm/X7mbp27ao5iPA8BAYIfo4cOSKZMmUKVWacgZvbPIY3bNu2TYMiwKD227dvS6tWrSwtUiYEIBgkjgHTCLjwGLSm4YCELi0Eeb1799YuQpQB74EWGwRMnTp10qAZOZAQKCIgQSJftFaFlZIgbdq0Ef6eEIxhIhByReFgh/IitQKSCONiQoCH3gV8fswkRC8DPieOC2fOnNFB7Wg1Q4oCsx7RRYehIuiSdWbbNevd37Z5f2e4oN7N35u944Qzxw2vHmGiR4+uffzW0/RxZofr1j8Ka7jddlo/msrDejwRkbPQ7YZZsRi/hKn3OABbJ87EARx5kTBTLmvWrPp4BA7mbECMI0LggtfA2ClM43ekBRpjc5ABHAd67BvRhYgA53UQ/CAlgTlOA++PYMo2aAIEFGjVQhJeQOJMtKwhWMIMNwRuGMOF1jPrAxSWh/rtt990zBcCFAQreF/UBQIvd0HAVr16dS03WvfwXWDcljW0QqGFDHAyjs+GFkN8Nwi8UJeYPWd9Er18+XINCEuVKuW2slOAMrxs3rx5RowYMYyZM2fqaPc2bdoYCRMmNK5evar3N23a1OjTp4/l8du2bTOiRo1qjBkzxjh27JgxcOBAI1q0aMahQ4d8YlYdZ3d5B+vdN2bVkedY1z0umDU2Z84cbxfLb2C2ImbtOYvbvHdwVp3NGRaauJFADQO8sSYTch6ZA8DRl23dhIbsuHPmzNEzvL59+2qTOGbUYQAnEVEwQsvQ1KlTNR8UvR7GmyHvFnJxETkrEqInCSIYb4DmazTrumNwOJrKOcbJ81jvnh0cjvQAmD2Grg8MRMagS4738Cxzph3r3rNY7/5b79b7LtvB4M7EBjzCEBERETmIgRMRERGRgxg4EVGEBFkvPxH5OcNF+ywGTkQUoQR0yINDROQvzH3WmyYv9fqsOiLyL8iTg8SEGIyPMzjkY8OOiANlPYuDlL2D9e5/9Y7nImjCPgv7LnOlgIhi4ERETjMz9WNHhBmNZjZx8hxzsVLWvWex3v233hE0hbXKiDMYOBGR07DjwmKvWDYJ+dewHAbTQHiWuVgp696zWO/+We9oFX/TliYTAyciijDsiLBDQk4UHkQ8fyBh3Xse6907fKne+a0TEREROYiBExEREZGDGDgREREROShqsCbAwro07uqHvX//vk/0wwYT1rt3sN69h3XvHaz3wKx3MyZwJElm0AVOqHhIly6dt4tCREREPhYjYLHf8EQygmzdBESt//77r8SLF88tOTgQtSIou3Tp0mtXWCbXYb17B+vde1j33sF6D8x6RyiEoCl16tSvbdEKuhYnVEjatGnd/j74Yvmj8jzWu3ew3r2Hde8drPfAq/fXtTSZ2EFLRERE5CAGTkREREQOYuDkYjFixJCBAwfq/+Q5rHfvYL17D+veO1jv3uFL9R50g8OJiIiIIootTkREREQOYuBERERE5CAGTkREREQOYuAUARMnTpQMGTJo6vciRYrI7t27w338woULJVu2bPr4XLlyyZo1azxW1mCt9x9++EFKlSoliRIl0kv58uVf+z2Ra7Z307x58zTJbK1atdxexkDlbN3fuXNHOnbsKKlSpdJBtFmzZuX+xgP1Pn78eHnnnXckVqxYmqSxW7du8uTJE4+VNxBs2bJFatSooQkosd9YtmzZa5+zefNmyZ8/v27rWbJkkZkzZ3qkrMiWSU6YN2+eET16dGP69OnGkSNHjNatWxsJEyY0rl27Zvfx27ZtM6JEiWKMGjXKOHr0qPHFF18Y0aJFMw4dOuTxsgdTvTdq1MiYOHGisX//fuPYsWNG8+bNjQQJEhiXL1/2eNmDqd5N586dM9KkSWOUKlXK+OCDDzxW3mCu+6dPnxoFCxY0qlatamzdulW/g82bNxsHDhzweNmDqd5nz55txIgRQ/9Hna9bt85IlSqV0a1bN4+X3Z+tWbPG6Nevn7FkyRJMWDOWLl0a7uPPnj1rxI4d2+jevbseW7/99ls91q5du9btZWXg5KTChQsbHTt2tFx/+fKlkTp1amPEiBF2H1+vXj2jWrVqIW4rUqSI0bZtW7eXNZjr3daLFy+MePHiGT/99JMbSxl4IlLvqOvixYsb06ZNM5o1a8bAyUN1P3nyZCNTpkzGs2fPPFjKwONsveOx77//fojbcDAvUaKE28saqMSBwKlXr15Gzpw5Q9xWv359o1KlSm4unWGwq84Jz549k71792q3j/USLri+Y8cOu8/B7daPh0qVKoX5eHJNvdt69OiRPH/+XBInTuzGkgaWiNb7kCFDJHny5NKyZUsPlTTwRKTuV6xYIcWKFdOuuhQpUsi7774rw4cPl5cvX3qw5MFX78WLF9fnmN15Z8+e1e7RqlWreqzcwWiHF4+tQbdW3Zu4efOm7oSwU7KG68ePH7f7nKtXr9p9PG4n99W7rd69e2vfue0PjVxb71u3bpUff/xRDhw44KFSBqaI1D0O2L///rs0btxYD9ynT5+WDh066AkDEgeSe+q9UaNG+rySJUvqQrEvXryQdu3aSd++fT1U6uB0NYxjKxYDfvz4sY43cxe2OFHAGzlypA5UXrp0qQ72JPfAyuJNmzbVgflJkyb1dnGCzqtXr7Slb+rUqVKgQAGpX7++9OvXT6ZMmeLtogU0DFBGy96kSZNk3759smTJElm9erUMHTrU20UjN2GLkxNwMIgSJYpcu3YtxO24njJlSrvPwe3OPJ5cU++mMWPGaOC0YcMGyZ07t5tLGtz1fubMGTl//rzOjLE+mEPUqFHlxIkTkjlzZg+UPDi3ecykixYtmj7PlD17dj0zRxdU9OjR3V7uYKz3/v376wlDq1at9DpmTj98+FDatGmjgSu6+sj1wjq2xo8f362tTcBv1AnY8eBMbuPGjSEODLiOsQX24Hbrx8P69evDfDy5pt5h1KhReta3du1aKViwoIdKG7z1jpQbhw4d0m4681KzZk0pW7as/o1p2uS+bb5EiRLaPWcGq3Dy5EkNqBg0ua/eMX7SNjgyg1euaOY+Xj22un34eQBOVcXU05kzZ+oUyDZt2uhU1atXr+r9TZs2Nfr06RMiHUHUqFGNMWPG6LT4gQMHMh2BB+p95MiROqV40aJFxpUrVyyX+/fve/FTBH692+KsOs/V/cWLF3XmaKdOnYwTJ04Yq1atMpInT258+eWXXvwUgV/v2Kej3ufOnatT5H/77Tcjc+bMOqOaHId9M9LH4ILQZOzYsfr3hQsX9H7UOereNh1Bz5499diK9DNMR+DDkC/irbfe0gMzpq7u3LnTcl/p0qX1YGFtwYIFRtasWfXxmD65evVqL5Q6uOo9ffr0+uOzvWAnR+7d3q0xcPJs3W/fvl3TneDAj9QEw4YN0/QQ5L56f/78uTFo0CANlmLGjGmkS5fO6NChg3H79m0vld4/bdq0ye4+26xr/I+6t31O3rx59XvC9j5jxgyPlDUS/nF/uxYRERGR/+MYJyIiIiIHMXAiIiIichADJyIiIiIHMXAiIiIichADJyIiIiIHMXAiIiIichADJyIiIiIHMXAiIiIichADJyKKkEGDBknevHnf6DWQfxeLoSZOnFgiRYqka9oFqs2bN+tnvHPnTriPy5Ahg4wfP95yHYv0VqhQQeLEiSMJEyaM8Pu/9957MmfOHPEkLC6Mz7Nnzx6Pvi+ROzFwIvIxOLiGd0HAEiiwAPPMmTNl1apVcuXKFXn33XclUBUvXlw/Y4IECfQ6Pre9QOivv/7SYNI0btw4fR6CSizaGxErVqzQleMbNGhguQ0Bje22lTZtWrv3I2jLnz+/LFy40HI/tkPzfixqi0WcUe5bt26FWDS3R48e0rt37wiVm8gXMXAi8jE4SJoXtDzEjx8/xG04EAWKM2fOSKpUqTSoSJkypUSNGlUCFYIIfEYEGuFJliyZxI4dO0QdFShQQN5++21Jnjx5hN57woQJ0qJFC4kcOeQuf8iQISG2rf3799u9H7cXKlRI6tevL9u3b7fcnzNnTr3/4sWLMmPGDA2E27dvH+I1GjduLFu3bpUjR45EqOxEvoaBE5GPwcHVvKB1Agda8/rDhw/1QJQiRQqJGzeuHsw2bNgQ4vl4/LJly0LchpYNtHDArFmz9LmnTp2y3N+hQwfJli2bPHr0KMxyjRw5Ut83Xrx40rJlS3ny5Emox0ybNk2yZ88uMWPG1NebNGlSmK/XvHlz6dy5sx50UWa0cAAOviVLltQyJ0mSRKpXr67BQ3hdXmiNwW3nz5/X65988onkzp1bnj59aukyypcvn3z88cdhlqdMmTLSqVMnvaDekyZNKv3799fuRNPt27f1NRIlSqTBTZUqVULU44ULF6RGjRp6P1ppEFisWbMmVLnxNwKZu3fvhmpJtO6qw9+LFy/W7wyPQZ2hPHjsW2+9JTFixJDUqVNLly5dwvxcN27ckN9//13LZQvfpfX2hqDN3v1Zs2aViRMnSqxYsWTlypWW+xHo4v40adJI+fLlpW7durJ+/foQr4G6KFGihMybNy/MMhL5EwZORH7kwYMHUrVqVdm4caO2AlSuXFkPiAg+HIUDP14DAdiLFy9k9erVGvDMnj07REuHtQULFujBevjw4TpeBa1EtkERnj9gwAAZNmyYHDt2TB+LwOOnn36y+5rffPONtmigewitFuiiAgSH3bt31/fB50QryYcffiivXr1yqoUFr9OnTx+93q9fPw1Yvvvuu3Cfh7IiGNi9e7eWb+zYsVo3JgQuKBe6vnbs2KFBDOry+fPnen/Hjh01WNuyZYscOnRIvvrqKw1SbaGFzbY10V5LIuoE33G9evX0MSgTAil0333//fcatCFIzpUrV5ifCa09+F4R0L4J1Eu0aNE0CLUHQeu6deu0Zc1W4cKF5c8//3yj9yfyGQYR+awZM2YYCRIkCPcxOXPmNL799lvLdfysly5dGuIxeA28lunWrVtG2rRpjfbt2xspUqQwhg0bFu57FCtWzOjQoUOI24oUKWLkyZPHcj1z5szGnDlzQjxm6NCh+tywjBs3zkifPn24733jxg39TIcOHdLrmzZt0uu3b9+2PGb//v1627lz5yy3bd++3YgWLZrRv39/I2rUqMaff/4Z7vuULl3ayJ49u/Hq1SvLbb1799bb4OTJk/oe27Zts9x/8+ZNI1asWMaCBQv0eq5cuYxBgwbZfX3bcof13aI+UC+mDz74wGjWrJnl+tdff21kzZrVePbsmeEIvFamTJnsvk/06NGNOHHiWC7ffPON3XI8ffrUGD58uJZ/1apVetvAgQONyJEj6/Nixoyp9+EyduzYUO+F182QIYND5SXydWxxIvKzFie0TKD1AF1ZaM1A644zLU5m98mPP/4okydPlsyZM1taZsKC9yhSpEiI24oVK2b5G6076E5DFx7KZF6+/PLLEN1sjkArSsOGDSVTpkzaImN24Tn7GVE+1NXQoUPls88+0+6/1ylatGiIMUh4DZTn5cuXWgdodbGuB3QlvvPOO3ofoMsMnxldUwMHDpS///5bXA3dYY8fP9b6ad26tSxdulRbDsOCx6Lr1J6ePXtqN6d5se3KxKBufI9osULrGbprq1WrZrkfnx3PQ8sYHlupUiXtfrWFLr7wuoGJ/AkDJyI/gkAAB0p0g6HrAwctdNNYd5/gwG89LgfMriRr6E7CbCh0ASHwedOADn744YcQB+LDhw/Lzp07nXotdD1iZhZea9euXXoB8zOaA5ytP6O9z4euvW3btulnPH36tHhCq1at5OzZs9K0aVPtqitYsKB8++23Ln0PzF47ceKEdpUiIMH4NKQasFcHgLFaGJsV1n1ZsmSxXGxn+ZmB1eXLl/U1bGfHoVsOz8NsSARVqOvBgweHeh98n7bjp4j8FQMnIj+CQADjbDDmBwETBuaaA6JNOEAhGDKhxcT2bB8zo9CCgIG+aFHAgOjwoIXLDGBM1gERBo1jkDKCBusDMS4ZM2Z0+PP9999/GhR88cUXUq5cOX1f24O+eQC2/oz28j+NHj1ajh8/Ln/88YcOOMesr9ex9xkxmw0BAcqClh3rx5jlzZEjR4jApl27drJkyRJt6UIAaA+CDrRkRQQCJgSYGMuFgeYYb4VAzR4MikcuqLCCp/CYgZUjswEB39uYMWPk33//DXE7AmiUgygQMHAi8iM4iOOAjEDh4MGD0qhRo1CDpt9//30dBI3B4xjIjIM4BvWa7t+/ry0i6FbCrDAM6p4/f74sWrQozPft2rWrTJ8+XYMP5BJCN5Tt9HK0NIwYMUIP5ngMDuR4PAZYO9OFiO6vqVOnaisRZoNhoLg1HMgRnGCwOoJCDG7/+uuvQzwGnx0D1TGwG91mKAM+AwK78KA7EO+HYGju3LnaWoTnmXX/wQcfaPcYBlyj/ps0aaIzynA7fPrppzpA+ty5c7Jv3z7ZtGlTmIOy0QWJljoMgL9586bDXVmYHYluVgQj+Dy//PKLBlLp06e3+3gELAiAEHS7G7o2MZsRLaLW0DpasWJFt78/kScwcCLyIwgAEFxgVhZaHDCmBIkJrSGIQGBRqlQpDazQvWc9Ww6BAKbKmwc3tFzh77Zt28o///xj932Rvwcz5Hr16qU5hTDt3jZfD7qpEKggWMJrli5dWg/yzrQ4oRsO09b37t2r3T/dunXTliNrCAIR1KA1CQdptJxhXJEJaRIQ0KBlzpyCj8SMZcuW1YAxvFYejPHBmCDMAsMMOdSVdTJKfDZ8fqRIQJCA7kKkGzADU7w2nodgCbPhMI0/rJQM+A4R1KJu0Yo2atQoh+oI3WloxUJAiM+PdBRoOUTAaQ9ay5D6AAGyJ+A7w3Zw6dIlvY7WMKRdqFOnjkfen8jdImGEuNvfhYjIxyGPE5aQsV7uJFCgqw45pdAKFlbLlLsgMMyTJ4/07dvXo+9L5C5scSIiCnAYo4TuPWdnJr4pDOhH6yNaoYgCReCub0BERBa1atXy+HtiADwGjBMFEnbVERERETmIXXVEREREDmLgREREROQgBk5EREREDmLgREREROQgBk5EREREDmLgREREROQgBk5EREREDmLgREREROQgBk5ERERE4pj/BynJWO2SHyhPAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 600x500 with 1 Axes>"
       ]
@@ -744,16 +1108,16 @@
    "id": "a50c0011",
    "metadata": {
     "papermill": {
-     "duration": 0.007022,
-     "end_time": "2026-06-25T11:44:32.290848+00:00",
+     "duration": 0.003514,
+     "end_time": "2026-08-23T02:19:05.086958",
      "exception": false,
-     "start_time": "2026-06-25T11:44:32.283826+00:00",
+     "start_time": "2026-08-23T02:19:05.083444",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 6. La courbe ROC et l'AUC\n",
+    "## 7. La courbe ROC et l'AUC\n",
     "\n",
     "La courbe **ROC** (*Receiver Operating Characteristic*) trace le **TPR** (taux de vrais positifs, c'est-à-dire le rappel) en fonction du **FPR** (taux de faux positifs) pour **tous** les seuils de décision possibles. Plus la courbe se rapproche du coin supérieur gauche, meilleur est le classifieur. La diagonale correspond à un classifieur aléatoire (AUC = 0.5).\n",
     "\n",
@@ -764,20 +1128,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "id": "a50c0012",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:13.553872Z",
-     "iopub.status.busy": "2026-07-03T18:23:13.553872Z",
-     "iopub.status.idle": "2026-07-03T18:23:13.556325Z",
-     "shell.execute_reply": "2026-07-03T18:23:13.556325Z"
+     "iopub.execute_input": "2026-08-23T02:19:05.094920Z",
+     "iopub.status.busy": "2026-08-23T02:19:05.094685Z",
+     "iopub.status.idle": "2026-08-23T02:19:05.097599Z",
+     "shell.execute_reply": "2026-08-23T02:19:05.097200Z"
     },
     "papermill": {
-     "duration": 0.017292,
-     "end_time": "2026-06-25T11:44:32.317899+00:00",
+     "duration": 0.007982,
+     "end_time": "2026-08-23T02:19:05.098340",
      "exception": false,
-     "start_time": "2026-06-25T11:44:32.300607+00:00",
+     "start_time": "2026-08-23T02:19:05.090358",
      "status": "completed"
     },
     "tags": []
@@ -792,7 +1156,7 @@
     }
    ],
    "source": [
-    "# Exercice 3 : interpreter l'AUC\n",
+    "# Exercice 4 : interpreter l'AUC\n",
     "# TODO etudiant : l'AUC mesure la probabilite que le modele classe un positif au-dessus d'un negatif\n",
     "# TODO etudiant : reprendre auc_score (cellule precedente) et le comparer a 0.5 (hasard)\n",
     "verdict_auc = None  # TODO etudiant : remplacer par une chaine, ex \"excellent (>0.9)\" ou \"correct (0.7-0.9)\" ou \"faible (<0.7)\"\n",
@@ -804,36 +1168,36 @@
    "id": "a50c0013",
    "metadata": {
     "papermill": {
-     "duration": 0.008549,
-     "end_time": "2026-06-25T11:44:32.334480+00:00",
+     "duration": 0.003511,
+     "end_time": "2026-08-23T02:19:05.105687",
      "exception": false,
-     "start_time": "2026-06-25T11:44:32.325931+00:00",
+     "start_time": "2026-08-23T02:19:05.102176",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 7. Choisir un seuil de décision\n",
+    "## 8. Choisir un seuil de décision\n",
     "\n",
     "Par défaut, un classifieur comme la régression logistique prédit la classe 1 dès que la probabilité estimée dépasse **0.5**. Ce seuil n'a rien de magique. En médecine, on peut vouloir le **baisser** (ex. 0.3) pour rattraper davantage de cas positifs, quitte à déclencher plus de fausses alarmes ; ou au contraire le **monter** si le coût d'un faux positif est élevé. Se déplacer le long de la courbe ROC, c'est exactement **échanger du TPR contre du FPR**. Le bon point de fonctionnement dépend du coût relatif des erreurs."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "id": "a50c0014",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:13.558340Z",
-     "iopub.status.busy": "2026-07-03T18:23:13.558340Z",
-     "iopub.status.idle": "2026-07-03T18:23:13.568180Z",
-     "shell.execute_reply": "2026-07-03T18:23:13.568180Z"
+     "iopub.execute_input": "2026-08-23T02:19:05.113851Z",
+     "iopub.status.busy": "2026-08-23T02:19:05.113641Z",
+     "iopub.status.idle": "2026-08-23T02:19:05.120574Z",
+     "shell.execute_reply": "2026-08-23T02:19:05.120140Z"
     },
     "papermill": {
-     "duration": 0.023502,
-     "end_time": "2026-06-25T11:44:32.367010+00:00",
+     "duration": 0.01179,
+     "end_time": "2026-08-23T02:19:05.121250",
      "exception": false,
-     "start_time": "2026-06-25T11:44:32.343508+00:00",
+     "start_time": "2026-08-23T02:19:05.109460",
      "status": "completed"
     },
     "tags": []
@@ -883,10 +1247,10 @@
    "id": "a50c0015",
    "metadata": {
     "papermill": {
-     "duration": 0.007119,
-     "end_time": "2026-06-25T11:44:32.383110+00:00",
+     "duration": 0.003735,
+     "end_time": "2026-08-23T02:19:05.128599",
      "exception": false,
-     "start_time": "2026-06-25T11:44:32.375991+00:00",
+     "start_time": "2026-08-23T02:19:05.124864",
      "status": "completed"
     },
     "tags": []
@@ -903,20 +1267,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "id": "a50c0016",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T18:23:13.570315Z",
-     "iopub.status.busy": "2026-07-03T18:23:13.570315Z",
-     "iopub.status.idle": "2026-07-03T18:23:14.937092Z",
-     "shell.execute_reply": "2026-07-03T18:23:14.937092Z"
+     "iopub.execute_input": "2026-08-23T02:19:05.136990Z",
+     "iopub.status.busy": "2026-08-23T02:19:05.136633Z",
+     "iopub.status.idle": "2026-08-23T02:19:06.869012Z",
+     "shell.execute_reply": "2026-08-23T02:19:06.868472Z"
     },
     "papermill": {
-     "duration": 3.357242,
-     "end_time": "2026-06-25T11:44:35.750362+00:00",
+     "duration": 1.738308,
+     "end_time": "2026-08-23T02:19:06.870325",
      "exception": false,
-     "start_time": "2026-06-25T11:44:32.393120+00:00",
+     "start_time": "2026-08-23T02:19:05.132017",
      "status": "completed"
     },
     "tags": []
@@ -926,19 +1290,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
-      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
-      "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
-      "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -948,19 +1303,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -970,11 +1323,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "ConvergenceWarning: lbfgs failed to converge after 1000 iteration(s) (status=1):\n",
-      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
       "\n",
-      "Increase the number of iterations to improve the convergence (max_iter=1000).\n",
-      "You might also want to scale the data as shown in:\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
       "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
       "Please also refer to the documentation for alternative solver options:\n",
       "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n"
@@ -982,7 +1341,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArIAAAG4CAYAAAC5CgR7AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAacBJREFUeJzt3Qm8jPX///+XfV+yL8lWkawRCakoIVuSKGuUQllK9jWUCi22slSkJCIlhVAiPpFKIkshuwrZt/nfnu/f/5rvzDlzjnM42xyP++02nJm55pprZq655nW936/3653C5/P5DAAAAAgzKRN7AwAAAIDLQSALAACAsEQgCwAAgLBEIAsAAICwRCALAACAsEQgCwAAgLBEIAsAAICwRCALAACAsEQgCwAAgLBEIAsgQRQpUsTatm3Lu51I7/fy5cstRYoU7v9LufPOO90lLg0ePNg9f3IVm/c3saxdu9bSpk1rO3fuDNpP7r//fktsDz/8sD300EOJvRkIQwSywBXavn27PfHEE1asWDFLnz69Zc2a1apVq2avvfaanTp1ivcXV42TJ0+6gDUpB3NXs379+lmLFi2scOHCCfacCu5DXV588cWg5Z5//nmbM2eO/fTTTwm2bUgeUif2BgDh7PPPP7dmzZpZunTprHXr1la6dGk7e/asrVy50p577jn79ddf7a233krszUwStmzZYilTcu6cWO644w53YqUWufgMZIcMGeL+jtii279/f+vdu7clVwnx/l6JDRs22JIlS2zVqlUJ/tz33HOPOz4GqlChQqTrlSpVsldffdXee++9BN5ChDMCWeAy/fHHH647TK0bX3/9teXPn99/X+fOnW3btm0u0E2OLl686AJ2tUDHlIL9q9n58+fd+5ZYgY5OImLzecW11KlTu0ty3ccT+/29lGnTptl1111nt912W4I/94033miPPvroJZdTasGgQYNs/Pjxljlz5gTZNoQ/mkeAyzRq1Cg7fvy4TZkyJSiI9Vx//fX2zDPPBAUyw4YNs+LFi7ugTrlpffv2tTNnzgQ9zstZU/esWigyZMhgZcqU8XfXzp07113Xj2bFihXtxx9/DHq88iL1I7Bjxw6rU6eOZcqUyQoUKGBDhw41n88XtOwrr7xit99+u+XMmdM9j9b38ccfR3ot6grs0qWLvf/++3bzzTe77V+0aFGs1hExZ/PcuXOu9e6GG25wr0WPr169ui1evDjocTpJqFGjhnsd2bNnt0aNGtlvv/0WMv9SJw96Di2XLVs2a9eunWslvBS1Hqo1fd26de616HUULVrUJk6cGLScApuBAwe616j1a5u0bcuWLQta7s8//3Tbo/dm7Nix/s9806ZNIZ9fz33XXXeFDKYKFixoDz74oP+2mL7fMc3hVI+Btk/rqly5sn377beRHhuT163XnDt3bve3PlevC1mfTVQ5srH9TqinQ9uo/UWpPDFtudP7qFQf73uj7bzvvvvshx9+iNE+ru9Y3bp1XdqQvlu1atWy77///pLv79atW61p06aWL18+97zXXnutO/k9evRo0GNnzJjh3lt9Bjly5HDL7N69O9LrWLNmjdtufQYZM2a0mjVr2nfffRej92DevHl29913xyhP+d1333UnHepViitqrT59+vQlW25PnDgR6RgARMsH4LIULFjQV6xYsRgv36ZNG0WRvgcffNA3btw4X+vWrd31xo0bBy1XuHBhX4kSJXz58+f3DR482DdmzBj3XJkzZ/bNmDHDd9111/lefPFFd8mWLZvv+uuv9124cCHoedKnT++74YYbfK1atfK9+eabvvvvv98914ABA4Ke69prr/U99dRTbpnRo0f7Kleu7Jb77LPPgpbTbTfddJMvd+7cviFDhrjt//HHH2O1Dr0ubZunb9++vhQpUvg6duzoe/vtt32vvvqqr0WLFu51eRYvXuxLnTq178Ybb/SNGjXKPXeuXLl811xzje+PP/7wLzdo0CD3nBUqVPA98MADvvHjx/s6dOjgbuvVq9clP5uaNWv6ChQo4MuTJ4+vS5cuvtdff91XvXp19/gpU6b4lzt06JD7XHr06OGbMGGC2yZ9VmnSpPG/H6Jt02NLlSrl9hG9Jn2OO3fuDPn8Q4cO9aVMmdK3b9++oNtXrFjh1jN79uxYf2YR3+9ly5a55fS/Z/Lkye6222+/3b3mbt26+bJnz+62We9JbF738ePH3X1aX5MmTXzTp093l59++inoM7qS70TevHndfqPXfsstt7j9Z+PGjZf8fNu2bevWW7duXd/YsWN9r7zyiq9Ro0a+N95445L7uNafKVMm9/qHDRvmPsuiRYv60qVL5/v++++jfH/PnDnjltN+9cILL7j3Wuu99dZbfX/++af/cbpPr6N58+Zuv/X28SJFivj+/fdf/3JLly71pU2b1le1alX3XdH+VLZsWXfbmjVron39f/31l9s2fcYR6b2tX7++//qkSZPc9vTr1y9ouX/++cftB5e6nDhxIuhxel69f1qn9x6///77Ibfz3LlzvgwZMvh69uwZ7esBAhHIApfh6NGj7qCsH8OY2LBhg1tewVWgZ5991t3+9ddfB/2w6LZVq1b5b/vyyy/dbTrIBwZD+tGJGJx4wUHXrl39t128eNH9WOlHTz82npMnTwZtz9mzZ32lS5f23X333UG3a30KtH799ddIry2m64gYWJUrVy7oBzSU8uXLu+Dy77//9t+mwEjboqDH4wVJ7du3D3q8AqqcOXP6LkVBmx6vAMGjQMR7fr0mOX/+vLs9kIINBViBz+0FslmzZvUdPHjwks+/ZcsWt3xgYCUKWHUCE/geX+77HTHQ0uP02vQaA1/TW2+95ZYLDGRj+rq1b+mx+jwiihjIXs534ptvvvHfpvdVweSlgh6tR499+umnI92n78Wl9nEF1frebN++3X/b3r17fVmyZPHdcccdUb6/CoIjnoREpIA2VapUvuHDhwfd/ssvv7gTOO92badOTOvUqRO0zdoXFCzfc8890b4HS5YscduyYMGCaAPZ1157zQWcCthDLad1XOoS8bPXSZJOHubPn+9OdLSvajkF7aHopFUnHEBMkVoAXIZjx465/7NkyRKj5RcuXOj+79GjR9DtPXv2dP9HzKUtVaqUVa1a1X+9SpUq7n91DSrPLeLtSiOISN2kEbtN1UWsAR8edWV6/v33X9flqS7j9evXR1qfujG1XRHFZh2B1P2vwXDqfg1l3759boCKUgXU3eopW7as64L03tNAnTp1Crqu7fj777/9n1d01JWq6hMe5bLq+sGDB13KgaRKlcqf46ru6n/++cd1jysFJNTrVbey191+qRzC8uXL26xZs/y3XbhwwaUMNGjQIOg9vtz3OyJ1q+u16T0LzNvV+62u60Cxfd3x9Z3Q6/TofS1RokTIfT+QRsJr/1fuZUQRu9kj7uP6DL766itr3LixS2XwKJWoZcuWLtUhqn3Lew+//PLLKNNblCak91O5oYcPH/ZflIqglBsvdUPfA31P9Jzan73l1A2vNIdvvvnGrScqeoxcc8010aZKKRXqpZdecgPzIlLKhbr8L3WJOKhLqQ9ab8OGDd2+pu+SUmmUQhKqqou2Ua8NiKnwybwHkhDlysl///0Xo+VVt1GDQZQ3G0g/WAroAus6SmCwGvijWKhQoZC3K6AJpOcK/OH1giUvl9Hz2Wef2QsvvOB+KAPzEkPl0SlnNJTYrCOQcnaV76rt0g+bcv9atWrlAlXx3hMFKxHddNNNLkDQD7nyNaN637wfbr0/3mcWFeURB64r4nvmDZJR/qBGVm/evNnl+Ub3/kT1noXSvHlz9+O+Z88elxerXEsFmro9Lt7viLz3VwFToDRp0kTad2L7uhPiO+F9vhH3/VDl8fTZBp4MRSXiazl06JALQqPaBxU8KpdVObWh1qUgffTo0S4IVBCuYE6DnrzvrYJTNQZH/AwCPwtvOWnTpk2U264TmugCVYmYI+9ZsWKFO3FQCayo8mJVUjAu6IRIJ9VeUKu8+IjbmJzrDSPuEcgCl0FBkX4cN27cGKvHxfQArRaw2Nwe1Q9UdDSoRz+sKhukUcJqZdIPp0Y3z5w5M9LygS2Bl7uOQHqMgoz58+e7Vq/JkyfbmDFj3ACrDh062OWIy/cnFA3KUYulWuj0g58nTx73nCNHjnSvJSbvWVQUsPbp08dmz55t3bp1s48++sgFPArw4+L9TsjXnZDfibj6bGP7ecWEAn+9b94+/vTTT7v3TAPFNPBLgbBe/xdffBHy9Xkj973W1pdfftm13IcS3Sh/DQyUqIJ+BeJHjhyx6dOnu16IUCcnCurVQn0p2o5LVRzwTsjVsh+RtjGqwB4IhUAWuEwaRa0R36tXrw5KAwhFJbr0Y6SWFbXkeA4cOOB+QOK6QLmeS12uXoui/P777/4R4F6Xq0ZSq2UzsDSWgqKYutJ1qJVMlQV0UQUIBWga3a5A1ntPVH82IrUK5sqVK1IL6pXYu3dvpBbeiO+ZuvrVWqku4cAALFS3dWwpeNCIfKUXqMVKz6HAMfB9jYvPzOO9v9onlbLiUWurSsuVK1fOf1tMX3dsWtIS6juhigh6vxQ0xaRVNpDSF1QdIKp9UC3KEXtJIlKlBF3UXa8armrZ1MmaWtW1bQrE9dkHfldDvQbvBLp27doWWyVLlnT/63MNRd8lfcZqHVWqglImdKIe6NZbb43USh6K9gmvUkVUvHSQiGk3SldRC7dO1oCYIkcWuEy9evVyQY+CLv34RqSWKpX8kXr16rn/VYopkLodpX79+nH+Obz55pv+v/VjqetqvdMPlagFSIFHYCuLutBVpiemrmQdXt6eR6046mb2usvV2qjWJ3VpK7DxqBVcrVveexpX9CM6adIk/3XlE+u6fmxVGkm8VrPAVkCVRNLJTFxQq6xa66ZOneryBCOmFcTFZ+ZRfqtem4IqvVbPO++8E/R+e88bk9etoE8iPj6UhPpOKE9Z2+1N1BCb1ly97nvvvde1qAam5Oj7rhZwBX5Rpawod1b7VCAFtAp+vX38gQcecM+hbYu4LbrufUe0/ymYVek1nfCFai2NjlJVFHAHlhuLSC3Eyp9X3qpy0CN+Py8nRzbUdikdS5+5gmfve+VReTqV6FJ5OSCmaJEFLpN+WPRjpmBDLUqBM3up5UVdxF7dVLVuKb9NLbj6kdegEs17riBNrW6haoheCbXaqQamnlMDwtR1qRw45WB6rSAKFBQ0qOtag0iUjzlu3DgXTP78888xep4rWYcG1ah+q37M1FKmH1m1CgUOUlNXqup3qsX7sccecz+yb7zxhutyv1SrT2ypBUoDXRSwqHVMLaPKQ9Vn5uUqqhVerZJNmjRxr10tXAoE9VpCBRixpUE/zz77rLvoPYnY+hYXn5lHr0mtgupKVous9mO9HrXuRsyRjenrVte8btN7p/dQr0HfCV0iSqjvhNaj3OvXX3/dtf7qvVNLsNI0dF/g/haK3iMFaApan3rqKTcoUCc4CkY1QCoqqn+sdWvmP70XCmrVda/AVcG1dwzR+pVSov1Or1sDSPX+fvLJJ/b444+7fUHBr1Jv9F1QGoB6MBScKp9aA8IUTC9YsCDa16F8dK0zuhxU7Uc6SdT3UjWo9Rq8QP1ycmS1b+okSwMWleOsAZw6Sdu1a5d7LyJODqL3WSdDCqSBGItxfQMAIf3++++uFqrqPqpMj8ryVKtWzZVSOn36dFCNRNWIVLkc1d8sVKiQr0+fPkHLhKrr6NHXtXPnzkG3eWWeXn75Zf9tKrmkuo0qF3Tvvff6MmbM6MokqSxOYL1ZUY1UlfVRGaOSJUv6pk2bFrLeZ6jnju06IpaDUv1M1UBV3VKVFdNjVW7IK3UVWDpI76eWUTmrBg0a+DZt2hS0jPd8gaXFRNui2wNrzoaiUlM333yz74cffnB1OlWHV9ureqWBVPpoxIgR7j69XtWtVf1WvS7dFt3nElN6raHKUl3p+x2qjqyoDJJXF7VSpUquxJXej8DyWzF93aKycRUrVnTfhcByTKG28Uq/ExG3MyoqH6bPQu+Xtku1YlXiad26dTHax9evX+9KX6kUmr5Pd911V1B5vFDv744dO1xpsuLFi7v9KUeOHO5x2p8jmjNnjqtbrO+tLtpObYvKsgVSSS/VSVZJOX0Oel8eeughV2P2UvQatH3ffvvtJd9b1aX1yotFLPcWG1999ZUrDZYvXz73+eq7rmNSVNtbpUoV36OPPnrZz4erUwr9E/OwF0BSp1ZgtWzGRQvh1UItUOrKj+3gPSCcKK1IPQ9qDU1q1Ptxyy23uHJuUQ1oA0IhRxYAgKvAiBEjXNpHTAZtJbQXX3zRTcVMEIvYIkcWAICrgPLlAwf2JSUffvhhYm8CwhQtsgAAAAhLiRrIalo9jWZUzo5GUcakhIxmu1EejWooaoSlSsWEGimpuo8aua0zUI2EDaTyHp07d3ZFolXyRyNIQ5VPAsKRvhPkx8aOjivkxwJA+EnUQFbFx1WCRYFnTKgkiUq/qGSKEsM1+41qeKrYtUf5P5oWUEWZlTSu9auMiMrUeLp37+5Klag8kqbmUyF01fMDAABA+EgyVQvUIqsad6qjFxXNA61amIEtJw8//LCrQaiamaIWWM1A4hWDV71AFYLu2rWr9e7d281HrTqaqv+pxHJvhhbVAVVxb28+dQAAACRtYTXYS4FmxALham1Vy6woiX3dunWuuLRHhaT1GG8GGt2vKRgD16Pp+1SsObpAVsWvvdlYvABZUx4qPSE20zICAAAgampj1SxwSj1VHJdsAtn9+/db3rx5g27TdU0FqBl//v33Xzd1Y6hl1OrqrUOziWTPnj3SMrovKiNHjgw5xSEAAADi3u7du930yckmkE1MauVV7q1HKQpqxdWbHNVc2wAAAIgdNVAqLVRTNl9KWAWy+fLli1RdQNcVSGqOb81hrUuoZfRYbx1KQVBebWCrbOAyoahKgi4R6bkJZAEAAOJWTFI3w6qObNWqVW3p0qVBty1evNjdLkoZqFixYtAyymXVdW8Z3Z8mTZqgZbZs2WK7du3yLwMAAICkL1FbZFXrctu2bUHltVRWK0eOHK7bXt35e/bssffee8/d36lTJ1eNoFevXta+fXv7+uuv7aOPPnKVDDzq/m/Tpo1VqlTJKleubGPHjnVlvtq1a+fuz5Ytmz322GNuOT2PWlNV0UBBLBULAAAAwkeiBrI//PCDqwnr8XJQFYiqqPu+fftcS6mnaNGiLmhVHdjXXnvNJQBPnjzZVS7wNG/e3A4dOmQDBw50g7c0b7NKcwUOABszZowbBaeJEFSJQI8fP358gr1uAAAAJKM6suGYiKzWXQ36IkcWAAAg4WOssMqRBQAAADwEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEupE3sDAACXZ9++fe4S1/Lnz+8uAJDUEcgCQJiaNGmSDRkyJM7XO2jQIBs8eHCcrxcA4hqBLACEqSeeeMIaNmwY7TKnTp2y6tWru79XrlxpGTJkuOR6aY0FEC4SPZAdN26cvfzyy7Z//34rV66cvfHGG1a5cuWQy547d85Gjhxp7777ru3Zs8dKlChhL730kt13333+ZYoUKWI7d+6M9NinnnrKPZfceeedtmLFikg/CBMnTozz1wcA8SUmKQAnTpzw/12+fHnLlCkTHwiAZCNRB3vNmjXLevTo4bqx1q9f7wLZOnXq2MGDB0Mu379/f9eVpmB306ZN1qlTJ2vSpIn9+OOP/mX+97//+fPGdFm8eLG7vVmzZkHr6tixY9Byo0aNiudXCwAAgLiUwufz+SyRVKlSxW699VZ788033fWLFy9aoUKFrGvXrta7d+9IyxcoUMD69etnnTt39t/WtGlT11U2Y8aMkM/RrVs3++yzz2zr1q2WIkUKf4usWibGjh172dt+7Ngxy5Ytmx09etSyZs162esBgPikFtnMmTO7v48fP06LLIAkLzYxVqK1yJ49e9bWrVtntWvX/r+NSZnSXV+9enXIx5w5c8bSp08fdJuCWOV9RfUcCnDbt2/vD2I977//vuXKlctKly5tffr0sZMnT0a7vXpuvbGBFwAAAFyFObKHDx+2CxcuWN68eYNu1/XNmzeHfIzSDkaPHm133HGHFS9e3JYuXWpz58516wll3rx5duTIEWvbtm3Q7S1btrTChQu7Ft6ff/7Znn/+eduyZYtbV1SUmxsfo4MBAAAQpoO9YuO1115zua0lS5Z0LawKZtu1a2dTp04NufyUKVOsbt26LmAN9Pjjj/v/LlOmjBssUatWLdu+fbtbZyhqtVU+r0ctskqDAAAAQOJItNQCdeunSpXKDhw4EHS7rufLly/kY3Lnzu1aWZXzpcoEarlV7lexYsUiLav7lyxZYh06dIhRrq5s27YtymXSpUvn8jQCLwAAALgKA9m0adNaxYoVXXqAR4O9dL1q1arRPlZ5sgULFrTz58/bnDlzrFGjRpGWmTZtmuXJk8fq169/yW3ZsGGD+5/aiQAAAOEjUVML1FXfpk0bq1SpkqsdqyoCam1VuoC0bt3aBazKT5U1a9a4+rGqOKD/NfOMgt9evXoFrVe3KZDVulOnDn6JSh+YOXOm1atXz3LmzOlyZLt37+7ybsuWLZuArx4AAABhG8g2b97cDh06ZAMHDnQTIihAXbRokX8A2K5du1wlA8/p06ddLdkdO3a4lAIFo9OnT7fs2bMHrVcpBXqsqhWEagnW/V7QrDxXlfDSegEAABA+ErWObDijjiyAcEAdWQDhJizqyAIAAABXgkAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGEpUevIApdj37597hLXNLMbs7sBABA+CGQRdiZNmmRDhgyJ8/UOGjTIzRYHAADCA4Esws4TTzxhDRs2jHaZU6dOWfXq1d3fK1eutAwZMlxyvbTGAgAQXghkEXZikgKg2Yw8mvo4U6ZMCbBlAAAgITHYCwAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYSl1Ym8AAMTGQ7Oe5A2LhfOnz/n/bvXxM5Y6fRrev1j4qPkE3i8gCaNFFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhKdGrFowbN85efvll279/v5UrV87eeOMNq1y5cshlz507ZyNHjrR3333X9uzZYyVKlLCXXnrJ7rvvPv8ygwcPtiFDhgQ9Tstt3rzZf/306dPWs2dP+/DDD+3MmTNWp04dGz9+vOXNm9eSqgY95yf2JoSV8+dO+/9+sM9nljpN+kTdnnCz4NVGib0JAAAk7RbZWbNmWY8ePWzQoEG2fv16F8gqqDx48GDI5fv372+TJk1ywe6mTZusU6dO1qRJE/vxxx+Dlrv55ptt3759/svKlSuD7u/evbstWLDAZs+ebStWrLC9e/faAw88EK+vFQAAAMkokB09erR17NjR2rVrZ6VKlbKJEydaxowZberUqSGXnz59uvXt29fq1atnxYoVsyeffNL9/eqrrwYtlzp1asuXL5//kitXLv99R48etSlTprjnvvvuu61ixYo2bdo0W7VqlX3//ffx/poBAAAQ5oHs2bNnbd26dVa7du3/25iUKd311atXh3yM0gDSpw/uIs6QIUOkFtetW7dagQIFXLD7yCOP2K5du/z36TmVohD4vCVLlrTrrrsuyuf1nvvYsWNBFwAAAFyFgezhw4ftwoULkfJSdV35sqEo7UAtqQpUL168aIsXL7a5c+e69AFPlSpV7J133rFFixbZhAkT7I8//rAaNWrYf//95+7XutOmTWvZs2eP8fOKcnOzZcvmvxQqVOgK3wEAAABcNVULXnvtNbvhhhtcC6qC0S5duri0BLXkeurWrWvNmjWzsmXLusB34cKFduTIEfvoo4+u6Ln79Onj0hK8y+7du+PgFQEAACDsAlnlraZKlcoOHDgQdLuuK681lNy5c9u8efPsxIkTtnPnTleJIHPmzC6FICpqeb3xxhtt27Zt7rrWrbQGBbcxfV5Jly6dZc2aNegCAACAMAlkf/vtN1dhQIOkihcvbvnz53ctn23atLGZM2e6PNKYUouqBlotXbrUf5vSBXS9atWq0T5WebIFCxa08+fP25w5c6xRo6hLBR0/fty2b9/utlX0nGnSpAl63i1btrg82ks9LwAAAMIskFVpLA2OqlChghtYpTzUbt262bBhw+zRRx81n89n/fr1cwOsVNc1pgGtSm+9/fbbri6sgmRVIVBrq9IFpHXr1q5L37NmzRqXE7tjxw779ttvXf1YBb+9evXyL/Pss8+6klp//vmnq0Sg8lxq+W3RooW7X/mtjz32mHvuZcuWucFfej4Fsbfddlts3z8AAAAk5QkRmjZtas8995x9/PHHkQZJBdKof+WxqhyWymRdSvPmze3QoUM2cOBAN9CqfPnybpCWNwBMraSB+a+ayEC1ZBXIKqVApbdUkitwm/766y8XtP79998uFaF69equrJb+9owZM8atV68rcEIEAAAAJLNA9vfff3fd8ZeiVk1dVN4qpjRgS5dQli9fHnS9Zs2abiKE6Gi2rktRaoJmFNMFAAAAyTi1IKogVi2ksVkeAAAASLSqBcpJVW6sBlupe1/d/DJgwAA3YxYAAACQJAPZF154wU04MGrUKFd5wFO6dGmbPHlyXG8fAAAAEDeB7HvvvWdvvfWWm/pV1QA85cqVc3VdAQAAgCQZyO7Zs8euv/76kCkHsRnkBQAAACRoIFuqVClXwzUileZSnVkAAAAgyZTfCqSar5rJSy2zaoXVBAWaGUspB5999ln8bCUAAABwpYGspoNdsGCBDR061DJlyuQC21tuucXdds8998R2dQAAAFds37597hLXNMW9N809kkEgKzVq1LDFixfH/dYAAABchkmTJtmQIUPi/L0bNGiQDR48mM8kOQWycvbsWTt48KBLLwh03XXXxcV2AQAAxNgTTzxhDRs2jHaZU6dOuanrZeXKlZYhQ4ZLrpfW2GQWyG7dutXat29vq1atCrrd5/NZihQp7MKFC3G5fQAAAHGSAnDixAn/3+XLl3cpkrjKAtm2bdta6tSp3cAu7TAKXgEAAIAkH8hu2LDB1q1bZyVLloyfLQIu4fTxf+zMiX+jXeb8+bP+v48e/MNSp/6/Weiiki7TNZY+cw7efwAAkmsgqzqyhw8fjp+tAWJg589f2tbvZ8X4vVo9q0+MlrvhtuZW4vYWfAYAACTXQPall16yXr162YgRI6xMmTKWJk2aoPuzZs0al9sHRFK4bB3LV7xynL8zapEFAADJOJCtXbu2+79WrVpBtzPYCwlF3f+kAAAAgFgHssuWLeNdAwAAQPgFsjVr1oyfLQEAAADie0KEI0eO2Nq1a0NOiNC6devLWSUAAAAQv4HsggUL7JFHHrHjx4+7gV2BdWT1N4EsAAAAEkLK2D6gZ8+ebmYvBbJqmf3333/9l3/++Sd+thIAAAC40hbZPXv22NNPP20ZM2aM7UMBAHHo1L8n7PSRk9Euc+HMef/fR/48bKnSXfqwnz57RstwDVN3AkiGgWydOnXshx9+sGLFisXPFgEAYmTHkk22ac66GL9bywbPj9FypZpWtJub3cqnACD5BbL169e35557zjZt2hRyQoSGDRvG5fYBAKJQrHYpK1CpSJy/P2qRBYBkGch27NjR/T906NBI92mw14ULF+JmywAA0VL3PykAAK5msQ5kI5bbAgAAAMKiakGg06dPx92WAAAAAPEZyCp1YNiwYVawYEHLnDmz7dixw90+YMAAmzJlSmxXBwAAACRMIDt8+HB75513bNSoUZY2bVr/7aVLl7bJkydf3lYAAAAA8R3Ivvfee/bWW2+52b1SpUrlv71cuXK2efPm2K4OAAAASJhAVhMiXH/99SEHgZ07d+7ytgIAAACI70C2VKlS9u2330a6/eOPP7YKFSrEdnU2btw4K1KkiKVPn96qVKlia9eujXJZBcoq+1W8eHG3vFqBFy1aFLTMyJEj7dZbb7UsWbJYnjx5rHHjxrZly5agZe68805XKizw0qlTp1hvOwAAAMKo/NbAgQOtTZs2rmVWrbBz5851gaJSDj777LNYrWvWrFnWo0cPmzhxogtix44d62YO0/oUhEbUv39/mzFjhr399ttWsmRJ+/LLL61Jkya2atUqfxC9YsUK69y5swtmz58/b3379rV7773XTeCQKVOmoHq4gbVwmXIXAAAgmbfINmrUyBYsWGBLlixxgaEC299++83dds8998RqXaNHj3YBZbt27VxLrwJaBZRTp04Nufz06dNdYFqvXj03Re6TTz7p/n711Vf9y6iFtm3btnbzzTe7FlsNTNu1a5etWxc8jaOeJ1++fP5L1qxZY/tWAAAAIJxaZKVGjRq2ePHiK3ris2fPuuCyT58+/ttSpkxptWvXttWrV4d8zJkzZ1xKQaAMGTLYypUro3yeo0ePuv9z5MgRdPv777/vWncVxDZo0MCVD4uuVVbPrYvn2LFjMXiVAAAASDItskor+Oabb674iQ8fPuxq0ubNmzfodl3fv39/yMco7UCtuFu3bnVpDQqmldqwb9++kMtrmW7dulm1atVceTBPy5YtXRC7bNkyF0irpffRRx+NdnuVe5stWzb/pVChQpf1ugEAAJBILbJq4VSraeHChV1KgAJbTY6QEF577TWXiqD8WA3Q0qAvbUNUqQjKld24cWOkFtvHH3/c/3eZMmUsf/78VqtWLdu+fbtbZygKeJXPG9giSzALAAAQRi2y8+bNcwO9lJ+qwVqqOFC3bl1XtSA25bdy5crl6tAeOHAg6HZdV3d/KLlz53bPf+LECdu5c6erW6vZxZQvG1GXLl3c4DO1ul577bXRbosGmsm2bduiXCZdunQujzbwAgAAgDAKZL2AUq2TP/30k61Zs8bVlW3VqpUVKFDAunfv7rr+L0WzglWsWNGWLl0alAqg61WrVo32scqTVSuwqhLMmTPHDUDz+Hw+F8R+8skn9vXXX1vRokUvuS0bNmxw/6tlFgAAAMk4kPUoN1V5qrqodVUVBH755RdXgWDMmDGXfLyCYZXSevfdd13lA7XyqrVV6QLSunXroMFgCpqVE7tjxw5Xy/a+++5zwW+vXr2C0gmU/zpz5kxXS1b5trqcOnXK3a/0gWHDhrmBZn/++ad9+umn7nnuuOMOK1u27JW8HQAAAEjKObJKH1DwN23aNPvqq69c8KcBVRpA5XW3qzW0ffv2rnU2Os2bN7dDhw65El4KNsuXL+/KZ3kDwFQ2S5UMPKdPn3a1ZBXIKqVAgbMGamXPnt2/zIQJE/yTHgTS9qosl1qCVTpMNWsVNCvPtWnTpm69AAAASMaBrLrf1QraokULNwuXgs+I7rrrrqDgMjpKA9AllOXLlwddr1mzppvYIDpKLYiOAldNmgAAAICrLJBVykCzZs0i1XMNpCD2jz/+uNJtAwAAAOIukNWgLs9ff/3l/r9UVQAAAAAg0Qd7Ka1g6NChblIA1ZLVRS2wGkCl+wAAAIAk2SLbr18/mzJlir344otuxizRhAODBw92g7GGDx8eH9sJAAAAXFkgq1JZkydPtoYNG/pvU+UC1XV96qmnCGQBAACQNFML/vnnHzdFbES6TfcBAAAASbJFtly5cvbmm2/a66+/HnS7btN9AAAgYXzXqClvdSycOn/e//fqh1pahtSxDoOuatXmz7GkJtaf4KhRo6x+/fpuUgFvKtnVq1fb7t27beHChfGxjQAAAMCVpxZoUoLff//dmjRpYkeOHHGXBx54wLZs2WI1atSI7eoAAACAy3JZbeoFChRgUBcAAADCL5BVma2ff/7ZDh48GKl2bGA1AwAAACDJBLKLFi2y1q1b2+HDhyPdlyJFCrtw4UJcbRsAAAAQdzmyXbt2tWbNmtm+fftca2zghSAWAAAASTaQPXDggPXo0cPy5s0bP1sEAAAAxEcg++CDD9ry5ctj+zAAAAAgcXNkNfGBUgu+/fZbK1OmjKVJkybo/qeffjoutw8AAACIm0D2gw8+sK+++srSp0/vWmY1wMujvwlkAQAAkCQD2X79+tmQIUOsd+/eljJlrDMTAAAAgDgR60j07Nmz1rx5c4JYAAAAhFcg26ZNG5s1a1b8bA0AAAAQX6kFqhU7atQo+/LLL61s2bKRBnuNHj06tqsEAAAA4j+Q/eWXX6xChQru740bNwbdFzjwCwAAAEhSgeyyZcviZ0sAAACAWKDsAAAAAJJvINupUyf766+/YrRCDQR7//33r3S7AAAAgCtPLcidO7fdfPPNVq1aNWvQoIFVqlTJChQo4CZF+Pfff23Tpk22cuVK+/DDD93tb731VkxWCwAAAMRvIDts2DDr0qWLTZ482caPH+8C10BZsmSx2rVruwD2vvvuu/ytAQAAAOJ6sFfevHndrF66qBV2165ddurUKcuVK5cVL16cigUAAABI2lUL5JprrnEXAAAAILFQtQAAAABhiUAWAAAAYSnRA9lx48ZZkSJFXAWEKlWq2Nq1a6Nc9ty5czZ06FCXk6vly5UrZ4sWLYr1Ok+fPm2dO3e2nDlzWubMma1p06Z24MCBeHl9AAAASIaBrGrO9ujRwwYNGmTr1693gWmdOnXs4MGDIZfv37+/TZo0yd544w1XOUH1bZs0aWI//vhjrNbZvXt3W7Bggc2ePdtWrFhhe/futQceeCBBXjMAAAASOJBV7diJEyfasWPH4uipzUaPHm0dO3a0du3aWalSpdz6M2bMaFOnTg25/PTp061v375Wr149K1asmD355JPu71dffTXG6zx69KhNmTLFLXf33XdbxYoVbdq0abZq1Sr7/vvv4+y1AQAAIIkEsmrZ7NWrl+XPn99atWply5cvv6InPnv2rK1bt87Vn/VvTMqU7vrq1atDPubMmTMuXSBQhgwZ3GQMMV2n7leKQuAyJUuWtOuuuy7K5/WeW0F84AUAAABhEMiqFXP//v0u/3T37t1Wq1Ytu/76623EiBG2Z8+eWD/x4cOH7cKFC64+bSBd1/OEohQBtaRu3brVLl68aIsXL7a5c+favn37YrxO/Z82bVrLnj17jJ9XRo4cadmyZfNfChUqFOvXDAAAgETKkVUXfdu2bV1r7O+//24PP/ywy1nVwKr69eu7oDI+vfbaa3bDDTe4FlQFo5ptTCkEanWNb3369HFpCd5FwTwAAAASz2VHgKoc8MILL9iff/5pH3zwgcsvbdasWYwfrxnBUqVKFalagK7ny5cv5GNy585t8+bNsxMnTtjOnTtt8+bNruqA8mVjuk79rxSEI0eOxPh5JV26dJY1a9agCwAAABLPFTVlqmVWLbS6qEtfg6xiSi2qGmi1dOlS/21KF9D1qlWrRvtY5ckWLFjQzp8/b3PmzLFGjRrFeJ26P02aNEHLbNmyxU25e6nnBQAAQBhPUfvXX3/ZO++84y47duywGjVq2Pjx411rrAZexYbKZLVp08ZVRKhcubKNHTvWtbYqXUBat27tAlblp8qaNWtcPm758uXd/4MHD3aBqgahxXSdym997LHH3HI5cuRwLatdu3Z1Qextt90W27cDAAAAST2Q/eijj1wJK7Vk5smTxwWL7du3dwO+Llfz5s3t0KFDNnDgQDfQSgGqJjjwBmuplTQw/1UTGaiWrAJopRSo9JZKcgUO3LrUOmXMmDFuvZoIQdUINIhMwTgAAADCRwqfz+eLyYLqtteALrVmKoBMiAFWSZnKb6l1VwO/EiJftkHP+fH+HIBnwav/L10nKXpo1pOJvQm4inzUfIIlZd81aprYmxBWTp0/b/cs/NT9vbheQ8uQOtYd01e1avPnJLkYK3VsUgrUEgsAAAAkBTFuVlW5qbvuuivkRACKmHXfTz/9FNfbBwAAAFxZIKtpYBWshmriVfPvPffcYy+//HJMVwcAAAAkTCCrigGNGzeO8v4GDRrYqlWrrmxrAAAAgBiKcY6syl1lyZIlyvtVRcCbKhYAACAhHT59yv4+fTraZc5cuOD/e+vRI5YuVapLrjdn+vSWK33syosiCQaymlVLEwcULVo05P2aZUszawEAACS0+X/+YdN+3xzj5Z/67psYLdfuxpL2WMlSV7BlSBKBbO3atW348OF23333RbpPFbx0n5YBAABIaI2KFLXq+fLH+XrVIotkEMhqIgJN71qlShXr2bOnlShRwt8Sq4Fgv//+u5vtCwAAIKGp+58UgKtPjAPZ4sWL25IlS6xt27b28MMPW4oUKfytsaVKlbLFixdf0SxfAAAAQGzEakqLSpUq2caNG23Dhg22detWF8TeeOONbhpYAAAAICFd1txsClwJXgEAABAWdWQBAACApIRAFgAAAGGJQBYAAABhiUAWAAAAV0cgW6RIERs6dKjt2rUrfrYIAAAAiI9Atlu3bjZ37lwrVqyY3XPPPfbhhx/amTNnYrsaAAAAIOEDWdWRXbt2rd10003WtWtXy58/v3Xp0sXWr19/ZVsDAAAAxHeO7C233GKvv/667d271wYNGmSTJ0+2W2+91dWXnTp1qpssAQAAAEhSEyLIuXPn7JNPPrFp06a56Wlvu+02e+yxx+yvv/6yvn37uulsZ86cGbdbCwAAAFxuIKv0AQWvH3zwgaVMmdJat25tY8aMsZIlS/qXadKkiWudBQAAAJJMIKsAVYO8JkyYYI0bN7Y0adJEWqZo0aL28MMPx9U2AgAAAFceyO7YscMKFy4c7TKZMmVyrbYAAABAkhnsdfDgQVuzZk2k23XbDz/8EFfbBQAAAMRtINu5c2fbvXt3pNv37Nnj7gMAAACSZCC7adMmV3orogoVKrj7AAAAgCQZyKZLl84OHDgQ6fZ9+/ZZ6tSXXc0LAAAAiN9A9t5777U+ffrY0aNH/bcdOXLE1Y5VNQMAAAAgIcS6CfWVV16xO+64w1UuUDqBaMravHnz2vTp0+NjGwEAAIArD2QLFixoP//8s73//vv2008/WYYMGaxdu3bWokWLkDVlAQAAgPhwWUmtqhP7+OOPx/3WAAAAAPGVI+tRhYJFixbZp59+GnSJrXHjxlmRIkUsffr0VqVKFVu7dm20y48dO9ZKlCjhWoILFSpk3bt3t9OnT/vv17pSpEgR6RJYGuzOO++MdH+nTp1ive0AAAAIs5m9mjRpYr/88osLAH0+n7tdf8uFCxdivK5Zs2ZZjx49bOLEiS6IVZBap04d27Jli+XJkyfS8jNnzrTevXvb1KlT7fbbb7fff//d2rZt65579OjRbpn//e9/QduwceNGNwitWbNmQevq2LGjDR061H89Y8aMsX0rAAAAEE4tss8884wVLVrUzfCl4O/XX3+1b775xipVqmTLly+P1boUfCqgVI5tqVKlXECrdSpQDWXVqlVWrVo1a9mypWt5VQUF5eYGtuLmzp3b8uXL57989tlnVrx4catZs2bQuvQ8gctlzZo1tm8FAAAAwimQXb16tWvJzJUrl6VMmdJdqlevbiNHjrSnn346xus5e/asrVu3zmrXrv1/G5Mypbuu5whFrbB6jBe4qnV44cKFVq9evSifY8aMGda+fXt/i7FHg9X0GkqXLu3KiZ08eTLa7T1z5owdO3Ys6AIAAIAwSi1Qt32WLFnc3woE9+7d63JWVY5LKQExdfjwYbcule0KpOubN28O+Ri1xOpxCpyV0nD+/HmX26oatqHMmzfP1bhV+kHE9Wh7CxQo4CowPP/8827b586dG+X2KlAfMmRIjF8fAAAAklggqxZMld1SeoHyWkeNGmVp06a1t956y4oVK2bxSakLI0aMsPHjx7vn3rZtm0t1GDZsmA0YMCDS8lOmTLG6deu6gDVQYMWFMmXKWP78+a1WrVq2fft2l4YQilptlc/rUYusBpsBAAAgTALZ/v3724kTJ9zfSjG4//77rUaNGpYzZ043eCum1JqbKlWqSNPd6rpyVkNRsNqqVSvr0KGDPwjVtigw7devn0tN8OzcudOWLFkSbSurR0GxKDCOKpDV1Ly6AAAAIEwDWVUV8Fx//fUuDeCff/6xa665JlIeanTUiluxYkVbunSpNW7c2N128eJFd71Lly4hH6M81sBgVRQMi1c9wTNt2jRX+aB+/fqX3BbNTCZqmQUAAEAyDGTPnTvn6rcq8FOKgSdHjhyX9eTqqm/Tpo2reFC5cmVXfkstrKpiIK1bt3YziSk/VRo0aOAqHWhqXC+1QK20ut0LaL2AWIGs1p06dfBLVPqAynhpgJhakZUjq1q0mna3bNmyl/U6AAAAkMQDWU1Be91118WqVmx0mjdvbocOHbKBAwfa/v37rXz58m6SBW8A2K5du4JaYJXWoFZf/b9nzx5XaktB7PDhw4PWq5QCPVbVCkK1BOt+L2hWnmvTpk3dOgEAABA+Uvgi9slfggZQKe90+vTpl90SmxxosFe2bNns6NGjCVKDtkHP+fH+HIBnwauNkuyb8dCsJxN7E3AV+aj5BEvKvmvUNLE3AVeRavPnJLkYK9Y5sm+++abr0lclAJWwypQpU9D969evj/0WAwAAALEU60DWG5gFAAAAhFUgO2jQoPjZEgAAACA+p6gFAAAAwrJFVlUEoqsXG1cVDQAAAIA4DWQ/+eSTSLVlf/zxR3v33XdtyJAhsV0dAAAAkDCBbKNGkcvyPPjgg3bzzTe7KWofe+yxy9sSAAAAIDFyZG+77TY3vSwAAAAQNoHsqVOn7PXXX3fTyQIAAABJMrXgmmuuCRrspYnB/vvvP8uYMaPNmDEjrrcPAAAAiJtAdsyYMUGBrKoY5M6d26pUqeKCXAAAACBJBrJt27aNny0BAAAA4jNHdtq0aTZ79uxIt+s2leACAAAAkmQgO3LkSMuVK1ek2/PkyWMjRoyIq+0CAAAA4jaQ3bVrlxUtWjTS7YULF3b3AQAAAEkykFXL688//xzp9p9++sly5swZV9sFAAAAxG0g26JFC3v66adt2bJlduHCBXf5+uuv7ZlnnrGHH344tqsDAAAAEqZqwbBhw+zPP/+0WrVqWerU/+/hFy9etNatW5MjCwAAgKQbyKZNm9ZmzZplL7zwgm3YsMEyZMhgZcqUcTmyAAAAQJINZD033HCDuwAAAABhkSPbtGlTe+mllyLdPmrUKGvWrFlcbRcAAAAQt4HsN998Y/Xq1Yt0e926dd19AAAAQJIMZI8fP+7yZCNKkyaNHTt2LK62CwAAAIjbQFYDuzTYK6IPP/zQSpUqFdvVAQAAAAkz2GvAgAH2wAMP2Pbt2+3uu+92ty1dutQ++OADmz179uVtBQAAABDfgWyDBg1s3rx5rmbsxx9/7MpvlS1b1pYsWWI1a9aM7eoAAACAhCu/Vb9+fXeJaOPGjVa6dOnL2xIAAAAgPnNkI/rvv//srbfessqVK1u5cuWudHUAAABA/AayKrWlaWnz589vr7zyisuX/f777y93dQAAAED8pRbs37/f3nnnHZsyZYortfXQQw/ZmTNnXM4sFQsAAACQJFtkNcirRIkS9vPPP9vYsWNt79699sYbb8Tv1gEAAABXGsh+8cUX9thjj9mQIUPcQK9UqVJZXBg3bpwVKVLE0qdPb1WqVLG1a9dGu7yCaAXUqpZQqFAh6969u50+fdp//+DBgy1FihRBl5IlSwatQ8t37tzZcubMaZkzZ3bT7h44cCBOXg8AAACSWCC7cuVKN7CrYsWKLuB888037fDhw1f05JpYoUePHjZo0CBbv369GyxWp04dO3jwYMjlZ86cab1793bL//bbby7FQevo27dv0HI333yz7du3z3/RtgdS8LtgwQJX93bFihWudVm1cQEAAJAMA9nbbrvN3n77bRcYPvHEE24mrwIFCtjFixdt8eLFLsiNrdGjR1vHjh2tXbt2Lsd24sSJljFjRps6dWrI5VetWmXVqlWzli1bulbce++911q0aBGpFTd16tSWL18+/yVXrlz++44ePeoCYD23BqgpMJ82bZpbN4PVAAAAknHVgkyZMln79u1dK+cvv/xiPXv2tBdffNHy5MljDRs2jPF6zp49a+vWrbPatWv/38akTOmur169OuRjbr/9dvcYL3DdsWOHLVy40OrVqxe03NatW12QXaxYMXvkkUds165d/vv0+HPnzgU9r1IPrrvuuiifVzSoTQPcAi8AAAAI0zqyylUdNWqU/fXXX26K2thQWsKFCxcsb968QbfruqojhKKW2KFDh1r16tUtTZo0Vrx4cbvzzjuDUguU9qDKCosWLbIJEybYH3/8YTVq1PC3GGvdadOmtezZs8f4eWXkyJGWLVs2/0X5uQAAAAjjCRFEA78aN25sn376qcWn5cuXu6lxx48f73Jq586da59//rkNGzbMv0zdunWtWbNmbtpc5duqxfbIkSP20UcfXdFz9+nTx6UleJfdu3fHwSsCAABAgk5RGxeUt6oAOGK1AF1XXmsoAwYMsFatWlmHDh3c9TJlytiJEyfs8ccft379+rnUhIjU8nrjjTfatm3b3HWtW2kNCm4DW2Wje15Jly6duwAAACAZtcheDnXva6DV0qVL/bdp4JiuV61aNeRjTp48GSlY9cqA+Xy+kI85fvy4bd++3c1AJnpOpSUEPu+WLVtcHm1UzwsAAICkJ9FaZEWlt9q0aWOVKlWyypUruxqxamFVFQPRFLgFCxZ0+anepAyqNlChQgWXC6tWVrXS6nYvoH322Wfd9cKFC7uyWirVpftU3UCU36p6uHruHDlyWNasWa1r164uiFVlBgAAAISHRA1kmzdvbocOHbKBAwe6gVbly5d3g7S8AWBqJQ1sge3fv7+b4ED/79mzx3Lnzu2C1uHDh/uX0cAzBa1///23u18Dw1RWS397xowZ49ariRBUjUC5tMq7BQAAQPhI4YuqTx7RUvktte5q4JdadeNbg57z+USQYBa82ijJvtsPzXoysTcBV5GPmk+wpOy7Rk0TexNwFak2f06Si7ESLUcWAAAAuBIEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEuJHsiOGzfOihQpYunTp7cqVarY2rVro11+7NixVqJECcuQIYMVKlTIunfvbqdPn/bfP3LkSLv11lstS5YslidPHmvcuLFt2bIlaB133nmnpUiRIujSqVOneHuNAAAASGaB7KxZs6xHjx42aNAgW79+vZUrV87q1KljBw8eDLn8zJkzrXfv3m753377zaZMmeLW0bdvX/8yK1assM6dO9v3339vixcvtnPnztm9995rJ06cCFpXx44dbd++ff7LqFGj4v31AgAAIO6ktkQ0evRoF1C2a9fOXZ84caJ9/vnnNnXqVBewRrRq1SqrVq2atWzZ0l1XS26LFi1szZo1/mUWLVoU9Jh33nnHtcyuW7fO7rjjDv/tGTNmtHz58sXjqwMAAECybJE9e/asCy5r1679fxuTMqW7vnr16pCPuf32291jvPSDHTt22MKFC61evXpRPs/Ro0fd/zly5Ai6/f3337dcuXJZ6dKlrU+fPnby5Mlot/fMmTN27NixoAsAAACuwhbZw4cP24ULFyxv3rxBt+v65s2bQz5GLbF6XPXq1c3n89n58+ddbmtgakGgixcvWrdu3VwrrgLWwPUULlzYChQoYD///LM9//zzLo927ty5UW6vcm+HDBly2a8XAAAAySi1ILaWL19uI0aMsPHjx7uBYdu2bbNnnnnGhg0bZgMGDIi0vHJlN27caCtXrgy6/fHHH/f/XaZMGcufP7/VqlXLtm/fbsWLFw/53Gq1VT6vRy2yGmwGAACAqyyQVbd+qlSp7MCBA0G363pUuasKVlu1amUdOnTwB6EaxKXAtF+/fi41wdOlSxf77LPP7JtvvrFrr7022m1RUCwKjKMKZNOlS+cuAAAAuMpzZNOmTWsVK1a0pUuXBqUC6HrVqlVDPkZ5rIHBqigYFqUaeP8riP3kk0/s66+/tqJFi15yWzZs2OD+V8ssAAAAwkOiphaoq75NmzZWqVIlq1y5sqsRqxZWr4pB69atrWDBgi4/VRo0aOAqHVSoUMGfWqBWWt3uBbRKJ1CZrvnz57tasvv373e3Z8uWzdWeVfqA7tcAsZw5c7ocWdWiVUWDsmXLJuK7AQAAgLAJZJs3b26HDh2ygQMHuoCzfPnyrnyWNwBs165dQS2w/fv3d5MX6P89e/ZY7ty5XRA7fPhw/zITJkzwT3oQaNq0ada2bVvXErxkyRJ/0Kw816ZNm7p1AgAAIHyk8Hl98ogVDfZSK6/Ke2XNmjXe370GPefH+3MAngWvNkqyb8ZDs55M7E3AVeSj5v+vcSSp+q5R08TeBFxFqs2fk+RirESfohYAAAC4HASyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAIS4keyI4bN86KFCli6dOntypVqtjatWujXX7s2LFWokQJy5AhgxUqVMi6d+9up0+fjtU6tXznzp0tZ86cljlzZmvatKkdOHAgXl4fAAAAkmEgO2vWLOvRo4cNGjTI1q9fb+XKlbM6derYwYMHQy4/c+ZM6927t1v+t99+sylTprh19O3bN1brVPC7YMECmz17tq1YscL27t1rDzzwQIK8ZgAAACSDQHb06NHWsWNHa9eunZUqVcomTpxoGTNmtKlTp4ZcftWqVVatWjVr2bKla3G99957rUWLFkEtrpda59GjR10ArOXuvvtuq1ixok2bNs2t+/vvv0+w1w4AAIArk9oSydmzZ23dunXWp08f/20pU6a02rVr2+rVq0M+5vbbb7cZM2a4wLVy5cq2Y8cOW7hwobVq1SrG69T9586dc7d5SpYsadddd51b5rbbbgv53GfOnHEXjwJiOXbsmCWEc2dOJsjzAAm5X1+OcyfPJvYm4CqSlL8LcuLcucTeBFxFjiXQ98F7Hp/Pl3QD2cOHD9uFCxcsb968Qbfr+ubNm0M+Ri2xelz16tXdizt//rx16tTJn1oQk3Xu37/f0qZNa9mzZ4+0jO6LysiRI23IkCGRbleeLpDcZBuX2FsAJA3Z2ofuIQSuStmyJejT/ffff5btEs+ZaIHs5Vi+fLmNGDHCxo8f7wZxbdu2zZ555hkbNmyYDRgwIF6fW628yr31XLx40f755x83YCxFihTx+ty4/DM6nWjs3r3bsmbNytuIqxbfBYDvQzhRY6WC2AIFClxy2UQLZHPlymWpUqWKVC1A1/PlyxfyMQpWlUbQoUMHd71MmTJ24sQJe/zxx61fv34xWqf+VwrCkSNHglplo3teSZcunbsEitiqi6RJQSyBLMB3AeC3IXxcqiU20Qd7qXtfA62WLl0a1Mqp61WrVg35mJMnT7qc10AKXL3oPSbr1P1p0qQJWmbLli22a9euKJ8XAAAASU+iphaoq75NmzZWqVIlN3hLNWLVwqqKA9K6dWsrWLCgy0+VBg0auGoDFSpU8KcWqJVWt3sB7aXWqQj/sccec8vlyJHDtdR17drVBbFRDfQCAABA0pOogWzz5s3t0KFDNnDgQDfQqnz58rZo0SL/YC21kga2wPbv39/lo+r/PXv2WO7cuV0QO3z48BivU8aMGePWq4kQVIlAdWaVd4vkRakgqiccMSUEuNrwXQD4PiRXKXwxqW0AAAAAJDGJPkUtAAAAcDkIZAEAABCWCGQBAAAQlghkAQAAkiiVEUXUCGQBAACSmH379lnGjBlt5cqVib0pSRqBLJDMXbhwwV08FCpBUqV9U/sq+yiuZtr/z58/72YbzZMnj3333XeJvUlJGoEskMxpshBd1D2lqZhVixlISoGrR/um9lX9r3rghw8fTtTtAxLjO6H9P3Xq1O7/2rVr2xdffEF6QTQIZIFkbsaMGW5q5kKFCrkJQyZPnmz//fdfYm8WrhJ//PGH3XzzzfbXX39FCl69wNWj/XLEiBF23XXXWalSpdzsjpqdEUhu9D0Ilfuq78SxY8ds+vTp7lhdo0YN+/nnn90ET0iCM3sBuHw6CAbOfCd79+51t6lLSpYvX+4Ohg0bNrSHHnrIvvzyS3vzzTftn3/+sV69evnP/oH4omnBNQ24/o8YvKrVtV+/fpYpUyY34+Lnn39us2fPtlGjRrlpwzUro27PlSuXPfroo3xICPtjtvb/wEtEW7dutfvvv9/9XbNmTVu3bp0LbDdt2mQFChRIhK1O+miRBZI4L18wsAtWFLAGntErp+rOO++0wYMH+2+bNm2alSxZ0k3Ve9NNN7mAVoMH3njjDTt16hRBLOKc9snAHNccOXJYp06dLEuWLO66pgUfPXq03XHHHfbhhx+66cZvueUWl0ag/fKFF16whx9+2LXKlilTxrXSvv322/QiIOzpmO0Frxs2bHD7+4oVK4KO4wMGDLC8efO6vNi33nrLnegpT1aNEAiNFlkgCZg0aZKlT5/etTp5rVVei6t34PNu97qkOnTo4PKo9COv2/R3o0aN7Ouvv3bLqStX3VFqnW3ZsqUtXbrUzp07Z2XLlrXnn3+eIBZxyttfI/YSyJIlS6xLly62efNmf862fqjTpUvnWmCzZ89up0+fth9//NHmz59vI0eOdN2puv3uu+92+6+WBZKSr776yubMmWO33XabtWvXzn8Sp2N2qO/Bp59+6hokfvrpJ5fypUYFncD16dPH9Vro8WqRbdy4seuFkAceeMD1rC1evNjOnj1radOmTYRXmrTRIgskIu9MfMuWLe6gFsg7EOoH/YcffrD333/fta7u3LnTBQK5c+f2B62ee+65xy1/8OBBu/baa10rlgJYtYrpwKmDpA6KCioUOAOxtWPHDve/flQj7q/qFVi4cKFrSQrM6VNr7O+//+5+wHXCVaFCBcucObM98sgjLliVI0eOWOXKlV3Lk4IC7afbtm1zuYJ169blBxxJykcffeT206NHj7r92fsO6Nis/0+cOGHbt2+P9BiNU/jll1/csVvHavU+jB8/3v3977//uuO6N8jR64W799577bfffrPdu3cnwitN+ghkgQSmAMA7IKmFVNTV2qxZs6CBL3/++adVqlTJqlWr5u5//fXXXSurAlm577773EAa1Rr0Wm3LlSvnAuJly5a568WLF3fBr7qnFOTmzJnT3a7cQ+UjCqWOEFMKKq+//nr3d8SWoQ8++MCKFSvm0ggmTpzoclw/++wzd1+JEiXc4xYsWOCuK21A++b69ev9j9d+W7RoUbvmmmvssccec+kGeg6lwMybN88FtkBi846XOh4rl1XpMeXLlw9qdVVKjNIDdExX75eO0aIeNwW5Ok7rOyA9e/Z0Aevq1atdg0PhwoVdw4Z4vwc6vuu3QieCiIxAFohDlwoKdcatQVdt27Z119VdqlZZ5Q2qe8n74ZdXX33VHcCU5K8BW3qcWrz+97//uedRzqsCU3VvidajA6FSB1SuRdq0aWMnT550B1TlYqlrV4NnNBLca1ljsBci0r4Uqp6rRlAruFQ3qFpP1e2vEyvt1zrZUjforl27XDeoltUJlIq5q9X19ttv9588aT+tXr26ffPNN/7vTdasWa1Hjx7u8U2aNHEtVgpetQ7tr9r3gcT6LkR04403ulZS7bPq4VLvl1pghw4d6noQFHQ+8cQTNnfuXHv22WfdY2699VaXMqDeCE/BggUtf/78LmdW34NatWq5v5Vy41H6gnzyyScJ8prDjg/AFdu3b59v2bJl7u/z58+7/y9cuOA7d+5cpGVHjRrly5cvn69r166+YsWK+QYMGOBuz5s3r+/ZZ5/1nThxwl2/7rrrfG+88UbQY+vWreu77777fMePH3fPU79+fd8DDzzgv/+///7z3Xvvvb4KFSr4Ll686G5bu3atr0mTJr5y5cr5MmfO7O57/fXXfYcPH+aTR6w0a9bMlyJFCl/hwoV9L730km/Dhg3u9rlz5/oKFizo++mnn/zL7tixw1e9enVf//793fX333/flz59et/Zs2fd9RkzZviyZs3qO3LkiP/7IgsXLvS1bNnSV7p0ad8111zja9CggW/evHm+06dP82kh0Wn/nTlzpvseaH8uX768b9KkSe726dOn+7Jnz+77559//Mt/9NFHbrk//vjDXa9WrZrv8ccf9+/30r17d9/dd9/t+/333931zp07+3Lnzu1r2LChr2rVqr4nn3zSN3bsWF/Pnj39vy/4PwSywBU6efKkr1u3br6mTZtGucyff/7pgl0dqBSw6iBYq1Ytd+DT7dK+fXsXmO7Zs8cdCCtWrOgbOnSou+/UqVPu/7feessd4LZu3equT5s2zZcxY0bfd999565/9dVXvptuusmt/7fffgvahs2bN4cMrHH10UmOfhC94DGir7/+2v146odU+9yBAwfc7du2bXO362Qo0PLly32pU6f2/fvvv/4TKK2/RYsWvkcffdQFodpn06VL51u6dKn/BCt//vwuKBDtm95jtfzevXvj9T0APPoeePueeH8rONVJlAJPNTjo5Ey2bNniTrhSpkzp++abb/yP69ixo/vOqEHB89dff/mKFCniGg/k+eef991+++2+TZs2+ZdZsGCBO27PmjXLXVdDhdbfqlUr38svv+z/jUBopBYAVzhQK0OGDC4N4OOPPw66X/X/lMivXCnlCyp3St1K6iZSgXh1PylnSt2sohlclBul/FmlHGgZ5U0F5iMqz/Dvv/92KQKiFIXSpUtb+/btXT5t9+7dbdy4ce7/iDmMylPUQBtvylpyY5M3DTZ5/PHH3WA/Cfy8vVquEUdWa8CVuvKfeuoply5www03uG59r4ar8lo18ESDVVTb0qOBhdq31J2qdeu74c0mp9w+/a3qGUp78b4nKimkfdLbl72ZjET7v7pbgYQQWB1m1apVLh1L3xcdV7t16+a+S0p1UWqA7ldagY7fXt63UsNEA7WU063xDR6lEWg/13fGG9uggZCBA8FU9UDP7w2gVF1lrf+9995zaQleXfBQKQ4gtQCIlehasXRmvn79eve3WrAefvhhd3b+7bff+n755Rd30eN1tt6mTRtfjRo13LJeV6taoNQ9O2XKlKDWVq/1VVq3bu1aW4cNG+ZaguXQoUOua+vVV18NWhZXN+1npUqV8rVr185dD9xvta8pbeWJJ55w+5vXgqS0lvHjx/tbnuTXX391+9y6devc9e3bt7sUlfnz5we1XimNQL0Su3fvdtf379/vu+GGG3w9evTwt7g+/fTTrgvV2x5v3wcS69it1k99BzZu3OirXbu2a2XVsfq9995zx+MlS5b4vxuNGjVyPWlqkfVSAG699VbXEyFa9uabb3bfIY/WpZ4H9b553wMd14cPHx7UChxq23SbtjtwOURGagFwmZTz9MUXX/i7j3RAUw6rLF682P3Yez/+gXlNOjhNmDDB5f95P+TeQaxy5cq+Ll26uIOr3HHHHb7ixYv7evfu7QKSfv36uZxY5U1Fl+PqdR3j6qHPPGL36JAhQ9z+412XH3/80eX16aIfYv3wKq/ay9k7c+aM79ixY+7k6K677vLlypXLBbIDBw70/6AraFUQLF66itJatC59D0aOHOm6T2vWrBmUIqB1A4np6NGj/lQtWblypTtWX3/99S4PVfu+aP9W0Bq4j3/55ZdurMEHH3zg3+eV/6q0LS8l5rnnnvNlypTJ9/bbb/tWr17t0g2UF6sGB48aN7xjfKCoGkkQPVILgBiMUJXjx4+76V3VNaTZV9R9r6oAovQAlWJRrUxRKoEqCqhbSLUGhwwZ4sq1qB6surHUxar/vdQBr9tXsx39+uuv/q4p1Y7VCHF1D+v5O3bs6MobqZvKK+niCUwXiDiHPZInfd7e/upNeRm4D6gygKpTBJZoU2krdVtq8gHtz99++61LCVDJLM/AgQNdLVhNkam6rtrnlBqjygEqk1W/fn1XdkhdpOqGVWUNlXfzisOrkoYqGkyZMiUoRYBi7kho+n6oLquqB6jkVZEiRVzKjSbkkEKFClmdOnXcsV91jb0Z6NSdrwoagWlkOq4rdcCr86rvh75XXlkspcRoMg9VMVClGX0n9JswYsQI/wQH+n7qe6n0gYhCTaKAGLhEoAskO2ol1cAqtZrG9CxYy6grSKO11TKlM3d1F2nwitcyqq7WLFmy+EeeqoqBulJ79erlnu/aa691rVQamKUWAbW+ajCM17qrlq5Fixa5dWiwTXTbohayqVOnxtE7gqTmclpmNLhPPQRe1QtRN78GB77zzjv+1th69eq5fVOtQtov1Yqq/Un7qWjfS5MmjWt98mi0tHoQlFYgBw8edC26asXSY5XyEjjABYhv6nG6VK+TegDuv/9+Vx1GPV2qnPHZZ5/57rzzTl/RokV9u3btcj0Vffr0cd+TQLNnz/alTZvWX4HA69FQxZnJkyf7l9P34KGHHoo0kJYBWgmHQBZXDe9ApB9wjbpW96cEHgyV46RR2bpoVLVHP9LqQgrMfdJoVgWy3qjrn3/+2f2we6NTI3anKtewZMmSvjfffNNffqhQoUKuioG6otRdpW30yrREpAOlV4JIJbjeffddcqeSMS83LrpKEzqJUr60cvn0Q3zjjTe6QNU7EVL3pX7IGzdu7K4rgNWy2pd1UvbII4+4H/edO3f616kTLQWnXnep9uvbbrvN3aa8bY9O2FSB4O+//47HdwGImVB5pDohHDdunNt31ajg0XFUx94XXnjB3wiRIUMGV10m8LulZRQAK+AVNR4UKFDAt2LFCv9yOp4rhSeq72lMAm5cGQJZXJU5UjqDVq3KQKp3qR933acffgWpChZFBy4Fqcp58ijBXwNXmjdv7m+lUp1NL09Wg7EUDKuFTHlXr7zyiq9SpUpBA2k0QGzVqlUx3naS/q8OaiHSfnip2qlqYX3mmWdc65H2Df3gqpVVpdu8H/IxY8b4cubM6a6rdUktUapbGZH2Sy9vr2zZsq6Oq3Jh1Zo1Z84c3+DBg/21koGEyvkO7J3wAkLtpzoBU/6pGiS8AYahjo86ZqdKlcrls4q3Pg241XgDBawaJKv93Guo8MYuqHFBjQ/qPVO+rL5HClqjei4kDhIykOwonym60lKaQUhlhDTdq5eL+v3339u7777rphOcNWuWm0FFZVdefvlll9eqEluaOnPr1q1BZVVUjkUzF4k3e5HmzBblqGqWl7vuusvlCU6aNMnlTmkaTo9mP1Lelbfdl8IsXMkzh8/77L3Zq1TGZ+/evfbOO++42YE061soyvdTDvWDDz7oymGtWbPG9uzZYxs3bnRlrZRzpymO//nnH5d7rX1Y+XnKi9WsWd7zaiYhld3ycrY1JaxyaZWzralnNWPXoEGD7M4770yw9wXJm3KrJapjtZfzrX1Yy2jf1DFV+7L292HDhrnbVRZLedna30MdHzVtsvJgtY+Ll1OucQrbtm1z3znlr1asWNHlgwdS+UTle2v8g3K+9Z1R/ri3fR5mnUtcBLIIe/9/z4L/gBhYEzAi74dbc2Gr9p+mexX9r4EoOnB5VKNVBzhNt1mqVCkXuCrg9ajupQbRKOD4448/LE2aNK5eoK5rIIHWp8FZmsJQUxkq6d8bHBZx+73txtUnsJ6r9inVb9XUrdqHdGKlE65bbrkl5GN18qSTsr59+7r52/UjqxMlrXPZsmX+H3LN3+5Nf/zCCy+4H3btiwoI9IOu2rDaX73537UOncgNHz7cTUULxJUDBw64usQ6qRcdh71jYGBQq+OogkgNINQ+3Lp1a3d///793f6tAVZvv/22W0b7q/b9Q4cORXo+7+RNg730XDpOezWTdfKnOt8awKi63RrQKN4you+KBvfqO6aa3aHoe4vEwy8nwp535u4Frzpr/uijj9yI6lDLin70dfDSpAXewUrLp0+f3n/GrqLXGsGqUd9egWodVGfOnOkOiGvXrnWTE8iiRYvc/zoYqhVNj5WGDRta8+bN3foDR5iH2iYkT95JVmCLu/f30aNHbdq0ae6EZ9SoUa61ScGpTqjKly/vWkU///xza9asWZTr14+5ehBeeukl1xswYcIENzmGvgei9aklVYXbRcGqCq2rIob2U1XfUNWBwP0WiC86pmbLls1f4UXHXB0DFVQGHgvHjBljHTp0cBNyqOKLqmzoe6NescaNG7tGhGeeecYFqTrpUzDptfIGUlCq6gHqrdAEB5p0RsGvfiM6d+7sltFJ3EMPPWQLFy6MsoWYSWSSsERKaQCipNxT1WUN5A16CZWXpJzXTz/91PfJJ5+4guzKY9J0f8rvCxzEEkg5UJo6U7mwyrtSjpRGans5gF4eldYROEhAUxWqLqcqFmiQlmptKi9Wkx8EPi4QtQERuN+tWbPG/a36qqrTqn21U6dOrtakJjDwBlkp17VBgwb+ASgR931vv1It2CpVqvhv12DGrFmzutw+r6KG9lN9L9gXER+iG8wUahCU9scSJUq4MQSaglX7pgYq6m/v2K9juiq9eJVdRLmwGsyowVuqHqCBjBrMFXE67oh++uknV3VD4xn0GE1IoEobgbVdEb5okUWSo5xStVIF0pm6N4Wlul7VLeTZuXOnyyNU14/yTXWmrlZT3a7Wqoh0xq2z9JIlS7puLrVGaapBdaG++OKLLs1AXb3KfVXKgLpePaq7qRza1157zU0xqLqDarH1agR6+VyBZ/WkDIQ/r0U1qjxm3R6YJxf4+Wsf0r6kuqzqAu3Zs6dr3VFLqKZp1f6nVlQto5Z/5VWL8q3VS6AWpIjrDNyvlGet3gFNTazc1qlTp7rn0OOULyvqllXtS/ZFxIfoalYHdrsrB1WtoeoV0L6vfV25reohUL3t8ePH23PPPeeWVTe+pj4OXLfqdas+t3JiVeNVvQyaTlnHcqUVhEotEPWIFSxY0PU46DuiKWc1JsI7bnuYtjtMJXYkDURsbQqsg+nRqH/NaqXSJyqJoqlfNSOLR2fZOnsPrN2n0dx16tTxbdu2Leg5vFapBQsWuLJCXk1ArU8zEamlQI/LkSOHaxWLOI2m9xwaUa4R4Rrt6rWyIfnTyP9Zs2b5Z8KKyJsZyKOWf1XD0OxZql2sGsIqWaV9VtNgbtq0yffUU0+5ihZqaWrVqpXbtzRlpsrEeeXcomtNVcUN7bfqKejWrZsrF8csWkgIOq6q10r1VL2ShYHHc/WUvfTSS26KVtXIVh1utZCqJ0tl4LypjkW1i/Ud0L4vOv7Wr1/fPx23aDpZlZpTRQGvdrFacTt06OBKGoai707Xrl3dd8y7rpZieiiSB1pkkWgCW7ECc6O83FW1vHp09qzBKpohRUn7OqNWK5OX43rTTTe5ygBezqqoooBabr0qAoEzHolaWpU/qNwp0ehuJftrFLhadpWbqJmJAhP/RaO4NYJVgwTUMtu7d2+Xk4jkS4OvlK+nFiK1JCk3LzAHW/uYWucLFChg9erVc62v3uw/ypNW7qsGXNWuXdvlBOq69lXl7Ok29SJotiHlDap1SjMEKd9a+7RGa+u7otZU5WaHoooCapXVABnlFmpgIrNoISFo31VLqI61ytP+77///MdYHXM1KEvHSOVkq5qGZjnU4NkbbrjB7dMNGjTwL6tBhzqufvHFF+42LafviR7n0XdGAxXVo9G0aVN33NaYB/WMqeU1FD2PKnDo90J56bqulmJ6KJIHAlkkmFBdo163k7pf1cWqH2wl7CsI1cAqjwJGJezrAKagUYn6Cih0u1SpUsU9Vt1UHi2n9XuBrHdw9f5X95amIZSzZ8/6S3NpAIACA3VfBfK6lRXE6mDqpR5ooA4HxORLJdg0WEqpJOq+VxUB/XirQoXoR1z7i068dOKjH0xVBlA5K9GgLf3Aat/yaN9TsKmpXvUDrJMz7UdKcVE6gHdCpgGGmo5Y+5yC21deeSXkNmo/D1w/kFC0r+o4qCmLxStP5R1rvZM3Te2t/V6/A9pfdaKmrv1Vq1a5Zc+dO+evKKN93ksvUEPC+vXrg5ZRCpgGMyqI1UBIVZPRNN767kVFqWMKfr11IBlJ7CZhJG/quolqIIAGtajrKFeuXL48efK4aTC9wta1a9f2tW3b1v29YcMG18X69ttvB3VbqctVsxSJCsGr22jo0KFBz6Gi8roEdk0FiqrgvLaZbid4g0406O/DDz/079OB1DWqguve9K3aPzXbm7pI9+/f727TJBnt2rULmsZVhdw1cFBpCt5+qFndNLhFxd5F6QGff/65268XLlzIB4IkZ8+ePe4Yrn1b03/rb82Q6NGgRqWDaSCXeKla//vf/9zEG7179w5K27njjjtcmoDo90DTeusYHhMcs69OtMgiXqmlUsn6SiHQGbNqsqrrSdT9qtao2bNnu0kH1MqptAKvJUqFrtUKqjqAam1SK1hgi6rO1nWb0gzU4qWzfRW4DkxJ0O3q8gpVikvUyhVxcFbE2p64uikFRYOwvFYh7RfqLv3444/ddRVaV6ural16+6daWtVj4NVuVSuTBh+q5crz9NNPu0Lr+l8TDqhXQb0I6vr01qX0AKUqqI6lvhNAUqPUF+3/GnylesedOnVyg2wDJ4rRvq3jf+DxW/u4Bl/pd0AltpRuo4G0+p4ojUeUyqM63EpNCMUraUgt7qsbv9S4YtHV11NXv3KgdDDTqFTlnaorSgGsAlX9kKvbVnlRyofSqFRRd9Tu3btdbpQCVOUXKk8xsFtIQbFyo7xcRBWGVw6UglmPAgCNlA2cTSuiwBq0QETa93RRjUntlwpQVVlDo6+9/UcjqQNzsVUrU6kHXv610lSOHz/uT33Rd0Ynbaodu2TJEhfAtmrVyp3Q6TsSMa0FSGq8Y76O0zq+6/jtjVfQsdpLg1Fagb433qxxXjqZjvUKgJXWpfxufad69erlcsUDxxwoD7ZChQoht0HfPTU6cPy+ujEdBWLFOwMOLKnilUfRmbTOqnVw0oFFA1OmT5/ucl5VzFrBgIJOHcC0HuVIadpWnbnrPh0MFZiq5UmtYJqmU7MT6W8NpNGZfosWLdzMLmp1VWDRsmVL91jRWXyTJk3cVIMeFd72tpuDHS6X9ku1rmpf1EAUtSapp8C7T8Gn8vR0v/YztU6pwLsGa4kCU+37+jFXTp/3nVGLq3oWopoxCEiqvOOpTsg0nqFmzZouINV03t4kBTq+qzSicllPnz7tGhp0fNZviL4D+g3QDIpaRvmy3piFiLzBjkAo7BmIEW+gk1fPNZC6kdTiqR/0J5980ho1auS6+0Xdr2px1QhVBbQa1a0zdB3s1BqlVig9Tj/omh1L3ayqASs6GHrdURrNqoFdWocGDWhmFx0c9XiPuqlUbSDUAY8gFldCP7hFihRx+5x+iHWC5LVI6TZ1qWpwl1r/FbBqMKL2VVXWEAW0gwcPdq1NQHLy66+/uhMxHXu1/6t+sVf9RXW31eCg478CXm8KWO8YreP4G2+84R7vBbGhevgIYhGdFEqUjXYJXHW8nNFQBw/9OKtFVAGmWks1gluVBHRGrdZRtUJp/naNENW0gpqkQGVXlGOollqdhSvg1NSbCmoD6YxdAavyohTMTpw40RW71qQFap0VrV+pCVGlCtDyivigygRq8VcKgSYciEi9D+o1UPks5cGqd0HF3pVOAyRnShtQIKo818BjsHK99Zug8Q0qKaepZZX+pXEJMf29AWKC1AJEqrEaKmdU+ag6KCnxXgcoBa76sdZ15bmq219BpvKl9KOuFimlAQwbNswl+isAVkCqQTIqNaRBWprFRbNoaUCWWmjVPaVgVkGuqGVXpYjUguvRQdErM6Qzd21n4AGQllfEB51I6UdYrU/aj5XTHUg/zhqoov1brbVaFkjuvKDV64HzUgZE3wMd673A1cuhjYgxCrhSBLJXoVCtlt51tbAquFRXkLrw33nnHXfGrYORcgIVfGpaQLWuilpHlfengVsa7KKBMJoyU61RGqmtg5oC0kDKY1Xhdm+iA/3466LcWdVwVa6V1x2rQPhypkUE4pqmwVTXqHJhtU9H/B5pf1SKAXC10OBbNVIoPSzUMdmrCkMDA+ITgWwymwveO5BEPHgE3h/qoKKDkWYrUuCqOd41L7WCTf1oK5DV4BZVD1BxagWxWp8OYvrh1qhrFYTX7UobiJhDq8ExCkr1WOVQqev11Vdfdfcpx7VOnTruQKj1R6Rt5owdSYFyYfUd0YAu4ccZVzuNbdCgrujwPUF8I5ANc17A6pUhEdVNVbd/oMD71YKq6xq04k2/Om/ePDcqWwOuatWq5QJOlb5Sd79yYpUbqLxXVSEIPIgpAFUqgX7kveoBXvCqvEINdlH9TaUaqKqBAmIN6NJALlHaQeBr8Uanegc/8qaQlAZ86QIgGFUFkJgY7JUMaJS0Ak5VCFBCvUZXP/TQQ+6ikiai3FPNg62EfOWjKuhUGoCKUSvfT4OyFLyqPIpHCfqapEDrV2D8ySefuIFdXm1Xj1psvUFfSidQPq3O0jX4RVMCKs9V69B9oQJTup4AAMDlYJhgmFPwqSR6zXyi3FSN9FdLq+a7Vg0/z4oVK9xgFLWMKmXggw8+cKkBam2VgwcPuuD01KlT/seoBVZBr1cCS62pCn71nKJC1qJR3JonXsupyoBaXrVeleISpSmo5VZBrAYD6BKIricAAHA5aJENcxpFra76O+64w+WpiqoHaFpLBarezEKaAlODt1THUrNqLV++3F544QVXgUCtuBrEpdlYVNvVG8ilXFYFx5qZa8KECS7YVbUCTTGrvFhNOxuYD6vn9SoKAAAAxDdaZMOcBlepHqu6+z379++3TZs2ubJWCi5FU2NqQgHVX9V0f2qt1UArjcJWtQC1viq3VuVSPMqlVeutgl6vnIoGgqmVVgKDWKUHeEGsAtyIra4AAABxjRbZZGD48OEuP1ajqVXG6rfffnOtsTNmzHC1XxVUdunSxeW4arCWuvmVIhBx2tkpU6a4dADVhFXtVgXDatlVnqtaYzXgi6R+AACQVNAimwwoJ1YFqTVQ6/nnn3dTxioF4Ntvv3UDrVStQC2uSiPQQDAviFWwq0FiynFVnqoeozxa5bgqiO3WrZvddNNNrnSWph0U5bkqmGVCOAAAkNhokU0Gdu3a5XJfS5Qo4dIHRIGm5rHWLESarEDzXKuslvJhNSBLaQKqLqA82J49e1rz5s39pbgCab2aIGH+/Pkh67wCAAAkFgLZZEKtqQpoVZUgS5Ys7ja10qolVi22Sj/QzFyTJ092AayWVWD76KOPWqVKlfzr0RSzSkFQbVjVlFW+rQaRqZQXAABAUkIgm0y8/vrrLoh9+eWXrWrVqq40liYsUHWBrl272v333+/uk4jVBgIpgFULraohaD3KsS1dunQCvxoAAIBLI5BNJlRZQGW4Hn74YTe5gQZvKTdW/6s2bObMmYOWV56rN3CL2bMAAEA4YoraZEJTZzZs2NCfJuBNR6v/FcRGnD2LABYAAIQ7WmQBAAAQlii/lcwwEQEAALha0CILAACAsESLLAAAAMISgSwAAADCEoEsAAAAwhKBLAAAAMISgSwAAADCEoEsAAAAwhKBLAAAAMISgSwAAADCEoEsAAAAwhKBLAAAACwc/X9VQM+gKcfbBAAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArIAAAG4CAYAAAC5CgR7AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAachJREFUeJzt3Qm8jPX///+XfV+yL9krkjUi2SpKkS1JlDVKoSwl+5qUCi22slSkJCIlhVAiPpFKIkshuwrZt/nfnu/f/5rvzDlzjnM42xyP++02nLnONddcM+eaa17X+/16v94pfD6fzwAAAIAwkzKxdwAAAAC4HASyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAEkTRokWtXbt2ib0bV+37vXz5ckuRIoX7/1Juv/12d4tLQ4YMcc+fXMXm/U0sa9eutbRp09rOnTuDjpP77rvPEttDDz1kDz74YGLvBsIQgSxwhbZv326PP/64FS9e3NKnT29Zs2a16tWr22uvvWanTp1K7N0DEszJkyddwJqUg7mrWf/+/a1ly5ZWpEiRBHtOBfehbi+++GLQes8995zNmTPHfvrppwTbNyQPqRN7B4Bw9vnnn1vz5s0tXbp01qZNGytTpoydPXvWVq5cac8++6z9+uuv9tZbbyX2biYJW7ZssZQpuXZOLLVq1XIXVmqRi89AdujQoe7niC26AwYMsD59+lhylRDv75XYsGGDLVmyxFatWpXgz33XXXe582OgihUrRrpfuXJle/XVV+29995L4D1EOCOQBS7TH3/84brD1Lrx9ddfW/78+f2/69Kli23bts0FusnRxYsXXcCuFuiYUrB/NTt//rx73xIr0NFFRGz+XnEtderU7pZcj/HEfn8vZdq0aVa4cGG79dZbE/y5b7jhBnvkkUcuuZ5SCwYPHmzjx4+3zJkzJ8i+IfzRPAJcplGjRtnx48dtypQpQUGs57rrrrOnn346KJAZPny4lShRwgV1yk3r16+fnTlzJuhxXs6aumfVQpEhQwYrW7asv7t27ty57r6+NCtVqmQ//vhj0OOVF6kvgR07dli9evUsU6ZMVqBAARs2bJj5fL6gdV955RW77bbbLGfOnO55tL2PP/440mtRV2DXrl3t/ffft5tuusnt/6JFi2K1jYg5m+fOnXOtd9dff717LXp8jRo1bPHixUGP00VCzZo13evInj27NW7c2H777beQ+Ze6eNBzaL1s2bJZ+/btXSvhpaj1UK3p69atc69Fr6NYsWI2ceLEoPUU2AwaNMi9Rm1f+6R9W7ZsWdB6f/75p9sfvTdjx471/803bdoU8vn13HfccUfIYKpgwYL2wAMP+JfF9P2OaQ6negy0f9pWlSpV7Ntvv4302Ji8br3m3Llzu5/1d/W6kPW3iSpHNrafCfV0aB91vCiVJ6Ytd3oflerjfW60n/fcc4/98MMPMTrG9Rm79957XdqQPlt16tSx77///pLv79atW61Zs2aWL18+97zXXnutu/g9evRo0GNnzJjh3lv9DXLkyOHW2b17d6TXsWbNGrff+htkzJjRateubd99912M3oN58+bZnXfeGaM85XfffddddKhXKa6otfr06dOXbLk9ceJEpHMAEC0fgMtSsGBBX/HixWO8ftu2bRVF+h544AHfuHHjfG3atHH3mzRpErRekSJFfCVLlvTlz5/fN2TIEN+YMWPcc2XOnNk3Y8YMX+HChX0vvviiu2XLls133XXX+S5cuBD0POnTp/ddf/31vtatW/vefPNN33333eeea+DAgUHPde211/qefPJJt87o0aN9VapUcet99tlnQetp2Y033ujLnTu3b+jQoW7/f/zxx1htQ69L++bp16+fL0WKFL5OnTr53n77bd+rr77qa9mypXtdnsWLF/tSp07tu+GGG3yjRo1yz50rVy7fNddc4/vjjz/86w0ePNg9Z8WKFX3333+/b/z48b6OHTu6Zb17977k36Z27dq+AgUK+PLkyePr2rWr7/XXX/fVqFHDPX7KlCn+9Q4dOuT+Lj179vRNmDDB7ZP+VmnSpPG/H6J902NLly7tjhG9Jv0dd+7cGfL5hw0b5kuZMqVv3759QctXrFjhtjN79uxY/80ivt/Lli1z6+l/z+TJk92y2267zb3m7t27+7Jnz+72We9JbF738ePH3e+0vaZNm/qmT5/ubj/99FPQ3+hKPhN58+Z1x41e+8033+yOn40bN17y79uuXTu33Xvvvdc3duxY3yuvvOJr3Lix74033rjkMa7tZ8qUyb3+4cOHu79lsWLFfOnSpfN9//33Ub6/Z86ccevpuHr++efde63t3nLLLb4///zT/zj9Tq+jRYsW7rj1jvGiRYv6/v33X/96S5cu9aVNm9ZXrVo191nR8VSuXDm3bM2aNdG+/r/++svtm/7GEem9bdCggf/+pEmT3P70798/aL1//vnHHQeXup04cSLocXpevX/apvcev//++yH389y5c74MGTL4evXqFe3rAQIRyAKX4ejRo+6krC/DmNiwYYNbX8FVoGeeecYt//rrr4O+WLRs1apV/mVffvmlW6aTfGAwpC+diMGJFxx069bNv+zixYvuy0pfevqy8Zw8eTJof86ePesrU6aM78477wxaru0p0Pr1118jvbaYbiNiYFW+fPmgL9BQKlSo4ILLv//+279MgZH2RUGPxwuSOnToEPR4BVQ5c+b0XYqCNj1eAYJHgYj3/HpNcv78ebc8kIINBViBz+0FslmzZvUdPHjwks+/ZcsWt35gYCUKWHUBE/geX+77HTHQ0uP02vQaA1/TW2+95dYLDGRj+rp1bOmx+ntEFDGQvZzPxDfffONfpvdVweSlgh5tR4996qmnIv1On4tLHeMKqvW52b59u3/Z3r17fVmyZPHVqlUryvdXQXDEi5CIFNCmSpXKN2LEiKDlv/zyi7uA85ZrP3VhWq9evaB91rGgYPmuu+6K9j1YsmSJ25cFCxZEG8i+9tprLuBUwB5qPW3jUreIf3tdJOniYf78+e5CR8eq1lPQHoouWnXBAcQUqQXAZTh27Jj7P0uWLDFaf+HChe7/nj17Bi3v1auX+z9iLm3p0qWtWrVq/vtVq1Z1/6trUHluEZcrjSAidZNG7DZVF7EGfHjUlen5999/XZenuozXr18faXvqxtR+RRSbbQRS978Gw6n7NZR9+/a5ASpKFVB3q6dcuXKuC9J7TwN17tw56L724++///b/vaKjrlRVn/Aol1X3Dx486FIOJFWqVP4cV3VX//PPP657XCkgoV6vupW97vZL5RBWqFDBZs2a5V924cIFlzLQsGHDoPf4ct/viNStrtem9ywwb1fvt7quA8X2dcfXZ0Kv06P3tWTJkiGP/UAaCa/jX7mXEUXsZo94jOtv8NVXX1mTJk1cKoNHqUStWrVyqQ5RHVvee/jll19Gmd6iNCG9n8oNPXz4sP+mVASl3HipG/oc6HOi59Tx7K2nbnilOXzzzTduO1HRY+Saa66JNlVKqVAvvfSSG5gXkVIu1OV/qVvEQV1KfdB2GzVq5I41fZaUSqMUklBVXbSPem1ATIVP5j2QhChXTv77778Yra+6jRoMorzZQPrCUkAXWNdRAoPVwC/FQoUKhVyugCaQnivwi9cLlrxcRs9nn31mzz//vPuiDMxLDJVHp5zRUGKzjUDK2VW+q/ZLX2zK/WvdurULVMV7TxSsRHTjjTe6AEFf5MrXjOp987649f54f7OoKI84cFsR3zNvkIzyBzWyevPmzS7PN7r3J6r3LJQWLVq4L/c9e/a4vFjlWirQ1PK4eL8j8t5fBUyB0qRJE+nYie3rTojPhPf3jXjshyqPp79t4MVQVCK+lkOHDrkgNKpjUMGjclmVUxtqWwrSR48e7YJABeEK5jToyfvcKjhVY3DEv0Hg38JbT9q2bRvlvuuCJrpAVSLmyHtWrFjhLhxUAiuqvFiVFIwLuiDSRbUX1CovPuI+Jud6w4h7BLLAZVBQpC/HjRs3xupxMT1BqwUsNsuj+oKKjgb16ItVZYM0SlitTPri1OjmmTNnRlo/sCXwcrcRSI9RkDF//nzX6jV58mQbM2aMG2DVsWNHuxxx+f6EokE5arFUC52+8PPkyeOec+TIke61xOQ9i4oC1r59+9rs2bOte/fu9tFHH7mARwF+XLzfCfm6E/IzEVd/29j+vWJCgb/eN+8Yf+qpp9x7poFiGvilQFiv/4svvgj5+ryR+15r68svv+xa7kOJbpS/BgZKVEG/AvEjR47Y9OnTXS9EqIsTBfVqob4U7celKg54F+Rq2Y9I+xhVYA+EQiALXCaNotaI79WrVwelAYSiEl36MlLLilpyPAcOHHBfIHFdoFzPpS5Xr0VRfv/9d/8IcK/LVSOp1bIZWBpLQVFMXek21EqmygK6qQKEAjSNblcg670nqj8bkVoFc+XKFakF9Urs3bs3UgtvxPdMXf1qrVSXcGAAFqrbOrYUPGhEvtIL1GKl51DgGPi+xsXfzOO9vzomlbLiUWurSsuVL1/evyymrzs2LWkJ9ZlQRQS9XwqaYtIqG0jpC6oOENUxqBbliL0kEalSgm7qrlcNV7Vs6mJNreraNwXi+tsHflZDvQbvArpu3boWW6VKlXL/6+8aij5L+hurdVSpCkqZ0IV6oFtuuSVSK3koOia8ShVR8dJBIqbdKF1FLdy6WANiihxZ4DL17t3bBT0KuvTlG5FaqlTyR+rXr+/+VymmQOp2lAYNGsT5/r355pv+n/VlqftqvdMXlagFSIFHYCuLutBVpiemrmQbXt6eR6046mb2usvV2qjWJ3VpK7DxqBVcrVveexpX9CU6adIk/33lE+u+vmxVGkm8VrPAVkCVRNLFTFxQq6xa66ZOneryBCOmFcTF38yj/Fa9NgVVeq2ed955J+j99p43Jq9bQZ9EfHwoCfWZUJ6y9tubqCE2rbl63XfffbdrUQ1MydHnXS3gCvyiSllR7qyOqUAKaBX8esf4/fff755D+xZxX3Tf+4zo+FMwq9JruuAL1VoaHaWqKOAOLDcWkVqIlT+vvFXloEf8fF5Ojmyo/VI6lv7mCp69z5VH5elUokvl5YCYokUWuEz6YtGXmYINtSgFzuyllhd1EXt1U9W6pfw2teDqS16DSjTvuYI0tbqFqiF6JdRqpxqYek4NCFPXpXLglIPptYIoUFDQoK5rDSJRPua4ceNcMPnzzz/H6HmuZBsaVKP6rfoyU0uZvmTVKhQ4SE1dqarfqRbvRx991H3JvvHGG67L/VKtPrGlFigNdFHAotYxtYwqD1V/My9XUa3wapVs2rSpe+1q4VIgqNcSKsCILQ36eeaZZ9xN70nE1re4+Jt59JrUKqiuZLXI6jjW61HrbsQc2Zi+bnXNa5neO72Heg36TOgWUUJ9JrQd5V6//vrrrvVX751agpWmod8FHm+h6D1SgKag9cknn3SDAnWBo2BUA6SiovrH2rZm/tN7oaBWXfcKXBVce+cQbV8pJTru9Lo1gFTv7yeffGKPPfaYOxYU/Cr1Rp8FpQGoB0PBqfKpNSBMwfSCBQuifR3KR9c2o8tB1XGki0R9LlWDWq/BC9QvJ0dWx6YusjRgUTnOGsCpi7Rdu3a59yLi5CB6n3UxpEAaiLEY1zcAENLvv//uaqGq7qPK9KgsT/Xq1V0ppdOnTwfVSFSNSJXLUf3NQoUK+fr27Ru0Tqi6jh59XLt06RK0zCvz9PLLL/uXqeSS6jaqXNDdd9/ty5gxoyuTpLI4gfVmRTVSVdZHZYxKlSrlmzZtWsh6n6GeO7bbiFgOSvUzVQNVdUtVVkyPVbkhr9RVYOkgvZ9aR+WsGjZs6Nu0aVPQOt7zBZYWE+2LlgfWnA1FpaZuuukm3w8//ODqdKoOr/ZX9UoDqfTRCy+84H6n16u6tarfqtelZdH9XWJKrzVUWaorfb9D1ZEVlUHy6qJWrlzZlbjS+xFYfiumr1tUNq5SpUrusxBYjinUPl7pZyLifkZF5cP0t9D7pf1SrViVeFq3bl2MjvH169e70lcqhabP0x133BFUHi/U+7tjxw5XmqxEiRLueMqRI4d7nI7niObMmePqFutzq5v2U/uismyBVNJLdZJVUk5/B70vDz74oKsxeyl6Ddq/b7/99pLvrerSeuXFIpZ7i42vvvrKlQbLly+f+/vqs65zUlT7W7VqVd8jjzxy2c+Hq1MK/RPzsBdAUqdWYLVsxkUL4dVCLVDqyo/t4D0gnCitSD0Pag1NatT7cfPNN7tyblENaANCIUcWAICrwAsvvODSPmIyaCuhvfjii24qZoJYxBY5sgAAXAWULx84sC8p+fDDDxN7FxCmaJEFAABAWErUQFbT6mk0o3J2NIoyJiVkNNuN8mhUQ1EjLFUqJtRISdV91MhtXYFqJGwglffo0qWLKxKtkj8aQRqqfBIQjvSZID82dnReIT8WAMJPogayKj6uEiwKPGNCJUlU+kUlU5QYrtlvVMNTxa49yv/RtIAqyqykcW1fZURUpsbTo0cPV6pE5ZE0NZ8KoaueHwAAAMJHkqlaoBZZ1bhTHb2oaB5o1cIMbDl56KGHXA1C1cwUtcBqBhKvGLzqBaoQdLdu3axPnz5uPmrV0VT9TyWWezO0qA6oint786kDAAAgaQurwV4KNCMWCFdrq1pmRUns69atc8WlPSokrcd4M9Do95qCMXA7mr5PxZqjC2RV/NqbjcULkDXlodITYjMtIwAAAKKmNlbNAqfUU8VxySaQ3b9/v+XNmzdome5rKkDN+PPvv/+6qRtDraNWV28bmk0ke/bskdbR76IycuTIkFMcAgAAIO7t3r3bTZ+cbALZxKRWXuXeepSioFZcvclRzbUNAACA2FEDpdJCNWXzpYRVIJsvX75I1QV0X4Gk5vjWHNa6hVpHj/W2oRQE5dUGtsoGrhOKqiToFpGem0AWAAAgbsUkdTOs6shWq1bNli5dGrRs8eLFbrkoZaBSpUpB6yiXVfe9dfT7NGnSBK2zZcsW27Vrl38dAAAAJH2J2iKrWpfbtm0LKq+lslo5cuRw3fbqzt+zZ4+999577vedO3d21Qh69+5tHTp0sK+//to++ugjV8nAo+7/tm3bWuXKla1KlSo2duxYV+arffv27vfZsmWzRx991K2n51FrqioaKIilYgEAAED4SNRA9ocffnA1YT1eDqoCURV137dvn2sp9RQrVswFraoD+9prr7kE4MmTJ7vKBZ4WLVrYoUOHbNCgQW7wluZtVmmuwAFgY8aMcaPgNBGCKhHo8ePHj0+w1w0AAIBkVEc2HBOR1bqrQV/kyAIAACR8jBVWObIAAACAh0AWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhKXVi7wAA4PLs27fP3eJa/vz53Q0AkjoCWQAIU5MmTbKhQ4fG+XYHDx5sQ4YMifPtAkBcI5AFgDD1+OOPW6NGjaJd59SpU1ajRg3388qVKy1DhgyX3C6tsQDCRaIHsuPGjbOXX37Z9u/fb+XLl7c33njDqlSpEnLdc+fO2ciRI+3dd9+1PXv2WMmSJe2ll16ye+65x79O0aJFbefOnZEe++STT7rnkttvv91WrFgR6Qth4sSJcf76ACC+xCQF4MSJE/6fK1SoYJkyZUqAPQOAq2Cw16xZs6xnz56uG2v9+vUukK1Xr54dPHgw5PoDBgxwXWkKdjdt2mSdO3e2pk2b2o8//uhf53//+58/b0y3xYsXu+XNmzcP2lanTp2C1hs1alQ8v1oAAADEpRQ+n89niaRq1ap2yy232JtvvunuX7x40QoVKmTdunWzPn36RFq/QIEC1r9/f+vSpYt/WbNmzVxX2YwZM0I+R/fu3e2zzz6zrVu3WooUKfwtsmqZGDt27GXv+7Fjxyxbtmx29OhRy5o162VvBwDik1pkM2fO7H4+fvw4LbIAkrzYxFiJ1iJ79uxZW7dundWtW/f/diZlSnd/9erVIR9z5swZS58+fdAyBbHK+4rqORTgdujQwR/Eet5//33LlSuXlSlTxvr27WsnT56Mdn/13HpjA28AAAC4CnNkDx8+bBcuXLC8efMGLdf9zZs3h3yM0g5Gjx5ttWrVshIlStjSpUtt7ty5bjuhzJs3z44cOWLt2rULWt6qVSsrUqSIa+H9+eef7bnnnrMtW7a4bUVFubnxMToYAAAAYTrYKzZee+01l9taqlQp18KqYLZ9+/Y2derUkOtPmTLF7r33XhewBnrsscf8P5ctW9YNlqhTp45t377dbTMUtdoqn9ejFlmlQQAAACBxJFpqgbr1U6VKZQcOHAharvv58uUL+ZjcuXO7VlblfKkygVpulftVvHjxSOvq90uWLLGOHTvGKFdXtm3bFuU66dKlc3kagTcAAABchYFs2rRprVKlSi49wKPBXrpfrVq1aB+rPNmCBQva+fPnbc6cOda4ceNI60ybNs3y5MljDRo0uOS+bNiwwf1P7UQAAIDwkaipBeqqb9u2rVWuXNnVjlUVAbW2Kl1A2rRp4wJW5afKmjVrXP1YVRzQ/5p5RsFv7969g7arZQpkte3UqYNfotIHZs6cafXr17ecOXO6HNkePXq4vNty5col4KsHAABA2AayLVq0sEOHDtmgQYPchAgKUBctWuQfALZr1y5XycBz+vRpV0t2x44dLqVAwej06dMte/bsQdtVSoEeq2oFoVqC9XsvaFaeq0p4absAAAAIH4laRzacUUcWQDigjiyAcBMWdWQBAACAK0EgCwAAgLBEIAsAAICwRCALAACAsEQgCwAAgLBEIAsAAICwlKh1ZIHLsW/fPneLa5rZjdndAAAIHwSyCDuTJk2yoUOHxvl2Bw8e7GaLAwAA4YFAFmHn8ccft0aNGkW7zqlTp6xGjRru55UrV1qGDBkuuV1aYwEACC8Esgg7MUkB0GxGHk19zGxGAAAkPwz2AgAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWEqd2DsAALHx4KwnEnsXwsr50+f8P7f++GlLnT5Nou5PuPmoxYTE3gUA0aBFFgAAAGGJQBYAAABhiUAWAAAAYYlAFgAAAGGJQBYAAABhKdGrFowbN85efvll279/v5UvX97eeOMNq1KlSsh1z507ZyNHjrR3333X9uzZYyVLlrSXXnrJ7rnnHv86Q4YMsaFDhwY9Tutt3rzZf//06dPWq1cv+/DDD+3MmTNWr149Gz9+vOXNm9eSqoa95if2LoSV8+dO+39+oO9nljpN+kTdn3Cz4NXGib0LAAAk7RbZWbNmWc+ePW3w4MG2fv16F8gqqDx48GDI9QcMGGCTJk1ywe6mTZusc+fO1rRpU/vxxx+D1rvpppts3759/tvKlSuDft+jRw9bsGCBzZ4921asWGF79+61+++/P15fKwAAAJJRIDt69Gjr1KmTtW/f3kqXLm0TJ060jBkz2tSpU0OuP336dOvXr5/Vr1/fihcvbk888YT7+dVXXw1aL3Xq1JYvXz7/LVeuXP7fHT161KZMmeKe+84777RKlSrZtGnTbNWqVfb999/H+2sGAABAmAeyZ8+etXXr1lndunX/b2dSpnT3V69eHfIxSgNInz64izhDhgyRWly3bt1qBQoUcMHuww8/bLt27fL/Ts+pFIXA5y1VqpQVLlw4yuf1nvvYsWNBNwAAAFyFgezhw4ftwoULkfJSdV/5sqEo7UAtqQpUL168aIsXL7a5c+e69AFP1apV7Z133rFFixbZhAkT7I8//rCaNWvaf//9536vbadNm9ayZ88e4+cV5eZmy5bNfytUqNAVvgMAAAC4aqoWvPbaa3b99de7FlQFo127dnVpCWrJ9dx7773WvHlzK1eunAt8Fy5caEeOHLGPPvroip67b9++Li3Bu+3evTsOXhEAAADCLpBV3mqqVKnswIEDQct1X3mtoeTOndvmzZtnJ06csJ07d7pKBJkzZ3YpBFFRy+sNN9xg27Ztc/e1baU1KLiN6fNKunTpLGvWrEE3AAAAhEkg+9tvv7kKAxokVaJECcufP79r+Wzbtq3NnDnT5ZHGlFpUNdBq6dKl/mVKF9D9atWqRftY5ckWLFjQzp8/b3PmzLHGjaMuFXT8+HHbvn2721fRc6ZJkyboebds2eLyaC/1vAAAAAizQFalsTQ4qmLFim5glfJQu3fvbsOHD7dHHnnEfD6f9e/f3w2wUl3XmAa0Kr319ttvu7qwCpJVhUCtrUoXkDZt2rgufc+aNWtcTuyOHTvs22+/dfVjFfz27t3bv84zzzzjSmr9+eefrhKBynOp5bdly5bu98pvffTRR91zL1u2zA3+0vMpiL311ltj+/4BAAAgKU+I0KxZM3v22Wft448/jjRIKpBG/SuPVeWwVCbrUlq0aGGHDh2yQYMGuYFWFSpUcIO0vAFgaiUNzH/VRAaqJatAVikFKr2lklyB+/TXX3+5oPXvv/92qQg1atRwZbX0s2fMmDFuu3pdgRMiAAAAIJkFsr///rvrjr8UtWrqpvJWMaUBW7qFsnz58qD7tWvXdhMhREezdV2KUhM0o5huAAAASMapBVEFsWohjc36AAAAQKJVLVBOqnJjNdhK3fvq5peBAwe6GbMAAACAJBnIPv/8827CgVGjRrnKA54yZcrY5MmT43r/AAAAgLgJZN977z1766233NSvqgbgKV++vKvrCgAAACTJQHbPnj123XXXhUw5iM0gLwAAACBBA9nSpUu7Gq4RqTSX6swCAAAASab8ViDVfNVMXmqZVSusJijQzFhKOfjss8/iZy8BAACAKw1kNR3sggULbNiwYZYpUyYX2N58881u2V133RXbzQEAAFyxffv2uVtc0xT33jT3SAaBrNSsWdMWL14c93sDAABwGSZNmmRDhw6N8+0OHjzYhgwZEufbRSIGsnL27Fk7ePCgSy8IVLhw4bjYLwAAgBh7/PHHrVGjRtGuc+rUKTd1vaxcudIyZMhwye3SGpvMAtmtW7dahw4dbNWqVUHLfT6fpUiRwi5cuBCX+wcAABAnKQAnTpzw/1yhQgWXIomrLJBt166dpU6d2g3s0gGj4BUAAABI8oHshg0bbN26dVaqVKn42SPgEk4f/8fOnPg32nXOnz/r//nowT8sder/m4UuKukyXWPpM+eIk30EAABJMJBVHdnDhw/Hz94AMbDz5y9t6/ezYrz+6ll9Y7Te9be2sJK3tbyCPQMAAEk6kH3ppZesd+/e9sILL1jZsmUtTZo0Qb/PmjVrXO4fEEmRcvUsX4kqcb5dtcgCAIBkHMjWrVvX/V+nTp2g5Qz2QkJR9z8pAAAAINaB7LJly+JnTwAAAID4DGRr164d24cAAAAASWNChCNHjtjatWtDTojQpk2buNo3AAAAIO4C2QULFtjDDz9sx48fdwO7AuvI6mcCWQAAACSElLF9QK9evdzMXgpk1TL777//+m///PNP/OwlAAAAcKUtsnv27LGnnnrKMmbMGNuHAgDi0Kl/T9jpIyejXefCmfP+n4/8edhSpbv0aT999oyW4Rqm7gSQDAPZevXq2Q8//GDFixePnz0CAMTIjiWbbNOcdTFef9mQ+TFar3SzSnZT81uuYM8AIIkGsg0aNLBnn33WNm3aFHJChEaNGsXl/gEAolC8bmkrULlonG9XLbIAkCwD2U6dOrn/hw0bFul3TIgAAAlH3f+kAAC4msU6kI1YbgsAAAAIi6oFgU6fPh13ewIAAADEZyCr1IHhw4dbwYIFLXPmzLZjxw63fODAgTZlypTYbg4AAABImEB2xIgR9s4779ioUaMsbdq0/uVlypSxyZMnX95eAAAAAPEdyL733nv21ltvudm9UqVK5V9evnx527x5c2w3BwAAACRMIKsJEa677rqQg8DOnTt3eXsBAAAAxHcgW7p0afv2228jLf/444+tYsWKsd2cjRs3zooWLWrp06e3qlWr2tq1a6NcV4Gyyn6VKFHCra9W4EWLFgWtM3LkSLvlllssS5YslidPHmvSpIlt2bIlaJ3bb7/dlQoLvHXu3DnW+w4AAIAwKr81aNAga9u2rWuZVSvs3LlzXaColIPPPvssVtuaNWuW9ezZ0yZOnOiC2LFjx7qZw7Q9BaERDRgwwGbMmGFvv/22lSpVyr788ktr2rSprVq1yh9Er1ixwrp06eKC2fPnz1u/fv3s7rvvdhM4ZMqUKagebmAtXKbcBQAASOYtso0bN7YFCxbYkiVLXGCowPa3335zy+66665YbWv06NEuoGzfvr1r6VVAq4By6tSpIdefPn26C0zr16/vpsh94okn3M+vvvqqfx210LZr185uuukm12KrgWm7du2ydeuCp3HU8+TLl89/y5o1a2zfCgAAAIRTi6zUrFnTFi9efEVPfPbsWRdc9u3b178sZcqUVrduXVu9enXIx5w5c8alFATKkCGDrVy5MsrnOXr0qPs/R44cQcvff/9917qrILZhw4aufFh0rbJ6bt08x44di8GrBAAAQJJpkVVawTfffHPFT3z48GFXkzZv3rxBy3V///79IR+jtAO14m7dutWlNSiYVmrDvn37Qq6vdbp3727Vq1d35cE8rVq1ckHssmXLXCCtlt5HHnkk2v1V7m22bNn8t0KFCl3W6wYAAEAitciqhVOtpkWKFHEpAQpsNTlCQnjttddcKoLyYzVAS4O+tA9RpSIoV3bjxo2RWmwfe+wx/89ly5a1/PnzW506dWz79u1um6Eo4FU+b2CLLMEsAABAGLXIzps3zw30Un6qBmup4sC9997rqhbEpvxWrly5XB3aAwcOBC3XfXX3h5I7d273/CdOnLCdO3e6urWaXUz5shF17drVDT5Tq+u1114b7b5ooJls27YtynXSpUvn8mgDbwAAAAijQNYLKNU6+dNPP9maNWtcXdnWrVtbgQIFrEePHq7r/1I0K1ilSpVs6dKlQakAul+tWrVoH6s8WbUCqyrBnDlz3AA0j8/nc0HsJ598Yl9//bUVK1bskvuyYcMG979aZgEAAJCMA1mPclOVp6qbWldVQeCXX35xFQjGjBlzyccrGFYprXfffddVPlArr1pblS4gbdq0CRoMpqBZObE7duxwtWzvueceF/z27t07KJ1A+a8zZ850tWSVb6vbqVOn3O+VPjB8+HA30OzPP/+0Tz/91D1PrVq1rFy5clfydgAAACAp58gqfUDB37Rp0+yrr75ywZ8GVGkAldfdrtbQDh06uNbZ6LRo0cIOHTrkSngp2KxQoYIrn+UNAFPZLFUy8Jw+fdrVklUgq5QCBc4aqJU9e3b/OhMmTPBPehBI+6uyXGoJVukw1axV0Kw812bNmrntAgAAIBkHsup+Vytoy5Yt3SxcCj4juuOOO4KCy+goDUC3UJYvXx50v3bt2m5ig+gotSA6Clw1aQIAAACuskBWKQPNmzePVM81kILYP/7440r3DQAAAIi7QFaDujx//fWX+/9SVQEAAACARB/spbSCYcOGuUkBVEtWN7XAagCVfgcAAAAkyRbZ/v3725QpU+zFF190M2aJJhwYMmSIG4w1YsSI+NhPAAAA4MoCWZXKmjx5sjVq1Mi/TJULVNf1ySefJJAFAABA0kwt+Oeff9wUsRFpmX4HAAAAJMkW2fLly9ubb75pr7/+etByLdPvAABAwviucbPE3oWwcur8ef/Pqx9sZRlSxzoMuqpVnz/HkppY/wVHjRplDRo0cJMKeFPJrl692nbv3m0LFy6Mj30EAAAArjy1QJMS/P7779a0aVM7cuSIu91///22ZcsWq1mzZmw3BwAAAFyWy2pTL1CgAIO6AAAAEH6BrMps/fzzz3bw4MFItWMDqxkAAAAASSaQXbRokbVp08YOHz4c6XcpUqSwCxcuxNW+AQAAAHGXI9utWzdr3ry57du3z7XGBt4IYgEAAJBkA9kDBw5Yz549LW/evPGzRwAAAEB8BLIPPPCALV++PLYPAwAAABI3R1YTHyi14Ntvv7WyZctamjRpgn7/1FNPxeX+AQAAAHETyH7wwQf21VdfWfr06V3LrAZ4efQzgSwAAACSZCDbv39/Gzp0qPXp08dSpox1ZgIAAAAQJ2IdiZ49e9ZatGhBEAsAAIBEFetotG3btjZr1qz42RsAAAAgvlILVCt21KhR9uWXX1q5cuUiDfYaPXp0bDcJAAAAxH8g+8svv1jFihXdzxs3bgz6XeDALwAAACBJBbLLli2Lnz0BAAAAYoERWwAAAEi+gWznzp3tr7/+itEGNRDs/fffv9L9AgAAAK48tSB37tx20003WfXq1a1hw4ZWuXJlK1CggJsU4d9//7VNmzbZypUr7cMPP3TL33rrrZhsFgAAAIjfQHb48OHWtWtXmzx5so0fP94FroGyZMlidevWdQHsPffcc/l7AwAAAMT1YK+8efO6Wb10Uyvsrl277NSpU5YrVy4rUaIEFQsAAACQtKsWyDXXXONuAAAAQGKhagEAAADCEoEsAAAAwlKiB7Ljxo2zokWLugoIVatWtbVr10a57rlz52zYsGEuJ1frly9f3hYtWhTrbZ4+fdq6dOliOXPmtMyZM1uzZs3swIED8fL6AAAAkAwDWdWc7dmzpw0ePNjWr1/vAtN69erZwYMHQ64/YMAAmzRpkr3xxhuucoLq2zZt2tR+/PHHWG2zR48etmDBAps9e7atWLHC9u7da/fff3+CvGYAAAAkcCCr2rETJ060Y8eOxdFTm40ePdo6depk7du3t9KlS7vtZ8yY0aZOnRpy/enTp1u/fv2sfv36Vrx4cXviiSfcz6+++mqMt3n06FGbMmWKW+/OO++0SpUq2bRp02zVqlX2/fffx9lrAwAAQBIJZNWy2bt3b8ufP7+1bt3ali9ffkVPfPbsWVu3bp2rP+vfmZQp3f3Vq1eHfMyZM2dcukCgDBkyuMkYYrpN/V4pCoHrlCpVygoXLhzl83rPrSA+8AYAAIAwCGTVirl//36Xf7p7926rU6eOXXfddfbCCy/Ynj17Yv3Ehw8ftgsXLrj6tIF0X88TilIE1JK6detWu3jxoi1evNjmzp1r+/bti/E29X/atGkte/bsMX5eGTlypGXLls1/K1SoUKxfMwAAABIpR1Zd9O3atXOtsb///rs99NBDLmdVA6saNGjggsr49Nprr9n111/vWlAVjGq2MaUQqNU1vvXt29elJXg3BfMAAABIPJcdAapywPPPP29//vmnffDBBy6/tHnz5jF+vGYES5UqVaRqAbqfL1++kI/JnTu3zZs3z06cOGE7d+60zZs3u6oDypeN6Tb1v1IQjhw5EuPnlXTp0lnWrFmDbgAAAEg8V9SUqZZZtdDqpi59DbKKKbWoaqDV0qVL/cuULqD71apVi/axypMtWLCgnT9/3ubMmWONGzeO8Tb1+zRp0gSts2XLFjfl7qWeFwAAAGE8Re1ff/1l77zzjrvt2LHDatasaePHj3etsRp4FRsqk9W2bVtXEaFKlSo2duxY19qqdAFp06aNC1iVnypr1qxx+bgVKlRw/w8ZMsQFqhqEFtNtKr/10UcfdevlyJHDtax269bNBbG33nprbN8OAAAAJPVA9qOPPnIlrNSSmSdPHhcsdujQwQ34ulwtWrSwQ4cO2aBBg9xAKwWomuDAG6ylVtLA/FdNZKBasgqglVKg0lsqyRU4cOtS25QxY8a47WoiBFUj0CAyBeMAAAAIHyl8Pp8vJiuq214DutSaqQAyIQZYJWUqv6XWXQ38Soh82Ya95sf7cwCeBa/+v3SdpOjBWU8k9i7gKvJRiwmWlH3XuFli70JYOXX+vN218FP38+L6jSxD6lh3TF/Vqs+fk+RirNSxSSlQSywAAACQFMS4WVXlpu64446QEwEoYtbvfvrpp7jePwAAAODKAllNA6tgNVQTr5p/77rrLnv55ZdjujkAAAAgYQJZVQxo0qRJlL9v2LChrVq16sr2BgAAAIihGOfIqtxVlixZovy9qgh4U8UCAAAkpMOnT9nfp09Hu86ZCxf8P289esTSpUp1ye3mTJ/ecqWPXXlRJMFAVrNqaeKAYsWKhfy9ZtnSzFoAAAAJbf6ff9i03zfHeP0nv/smRuu1v6GUPVqq9BXsGZJEIFu3bl0bMWKE3XPPPZF+pwpe+p3WAQAASGiNixazGvnyx/l21SKLZBDIaiICTe9atWpV69Wrl5UsWdLfEquBYL///rub7QsAACChqfufFICrT4wD2RIlStiSJUusXbt29tBDD1mKFCn8rbGlS5e2xYsXX9EsXwAAAEBsxGpKi8qVK9vGjRttw4YNtnXrVhfE3nDDDW4aWAAAACAhXdbcbApcCV4BAAAQFnVkAQAAgKSEQBYAAABhiUAWAAAAYYlAFgAAAFdHIFu0aFEbNmyY7dq1K372CAAAAIiPQLZ79+42d+5cK168uN1111324Ycf2pkzZ2K7GQAAACDhA1nVkV27dq3deOON1q1bN8ufP7917drV1q9ff2V7AwAAAMR3juzNN99sr7/+uu3du9cGDx5skydPtltuucXVl506daqbLAEAAABIUhMiyLlz5+yTTz6xadOmuelpb731Vnv00Uftr7/+sn79+rnpbGfOnBm3ewsAAABcbiCr9AEFrx988IGlTJnS2rRpY2PGjLFSpUr512natKlrnQUAAACSTCCrAFWDvCZMmGBNmjSxNGnSRFqnWLFi9tBDD8XVPgIAAABXHsju2LHDihQpEu06mTJlcq22AAAAQJIZ7HXw4EFbs2ZNpOVa9sMPP8TVfgEAAABxG8h26dLFdu/eHWn5nj173O8AAACAJBnIbtq0yZXeiqhixYrudwAAAECSDGTTpUtnBw4ciLR83759ljr1ZVfzAgAAAOI3kL377rutb9++dvToUf+yI0eOuNqxqmYAAAAAJIRYN6G+8sorVqtWLVe5QOkEoilr8+bNa9OnT4+PfQQAAACuPJAtWLCg/fzzz/b+++/bTz/9ZBkyZLD27dtby5YtQ9aUBQAAAOLDZSW1qk7sY489Fvd7AwAAAMRXjqxHFQoWLVpkn376adAttsaNG2dFixa19OnTW9WqVW3t2rXRrj927FgrWbKkawkuVKiQ9ejRw06fPu3/vbaVIkWKSLfA0mC33357pN937tw51vsOAACAMJvZq2nTpvbLL7+4ANDn87nl+lkuXLgQ423NmjXLevbsaRMnTnRBrILUevXq2ZYtWyxPnjyR1p85c6b16dPHpk6darfddpv9/vvv1q5dO/fco0ePduv873//C9qHjRs3ukFozZs3D9pWp06dbNiwYf77GTNmjO1bAQAAgHBqkX366aetWLFiboYvBX+//vqrffPNN1a5cmVbvnx5rLal4FMBpXJsS5cu7QJabVOBaiirVq2y6tWrW6tWrVzLqyooKDc3sBU3d+7cli9fPv/ts88+sxIlSljt2rWDtqXnCVwva9assX0rAAAAEE6B7OrVq11LZq5cuSxlypTuVqNGDRs5cqQ99dRTMd7O2bNnbd26dVa3bt3/25mUKd19PUcoaoXVY7zAVa3DCxcutPr160f5HDNmzLAOHTr4W4w9Gqym11CmTBlXTuzkyZPR7u+ZM2fs2LFjQTcAAACEUWqBuu2zZMniflYguHfvXpezqnJcSgmIqcOHD7ttqWxXIN3fvHlzyMeoJVaPU+CslIbz58+73FbVsA1l3rx5rsat0g8ibkf7W6BAAVeB4bnnnnP7Pnfu3Cj3V4H60KFDY/z6AAAAkMQCWbVgquyW0guU1zpq1ChLmzatvfXWW1a8eHGLT0pdeOGFF2z8+PHuubdt2+ZSHYYPH24DBw6MtP6UKVPs3nvvdQFroMCKC2XLlrX8+fNbnTp1bPv27S4NIRS12iqf16MWWQ02AwAAQJgEsgMGDLATJ064n5VicN9991nNmjUtZ86cbvBWTKk1N1WqVJGmu9V95ayGomC1devW1rFjR38Qqn1RYNq/f3+XmuDZuXOnLVmyJNpWVo+CYlFgHFUgq6l5dQMAAECYBrKqKuC57rrrXBrAP//8Y9dcc02kPNToqBW3UqVKtnTpUmvSpIlbdvHiRXe/a9euIR+jPNbAYFUUDItXPcEzbdo0V/mgQYMGl9wXzUwmapkFAABAMgxkz5075+q3KvBTioEnR44cl/Xk6qpv27atq3hQpUoVV35LLayqYiBt2rRxM4kpP1UaNmzoKh1oalwvtUCttFruBbReQKxAVttOnTr4JSp9QGW8NEBMrcjKkVUtWk27W65cuct6HQAAAEjigaymoC1cuHCsasVGp0WLFnbo0CEbNGiQ7d+/3ypUqOAmWfAGgO3atSuoBVZpDWr11f979uxxpbYUxI4YMSJou0op0GNVrSBUS7B+7wXNynNt1qyZ2yYAAADCRwpfxD75S9AAKuWdTp8+/bJbYpMDDfbKli2bHT16NEFq0DbsNT/enwPwLHi1sSVVD856IrF3AVeRj1pMsKTsu8bNEnsXcBWpPn9OkouxYp0j++abb7oufVUCUAmrTJkyBf1+/fr1sd9jAAAAIJZiHch6A7MAAACAsApkBw8eHD97AgAAAMTnFLUAAABAWLbIqopAdPVi46qiAQAAABCngewnn3wSqbbsjz/+aO+++64NHTo0tpsDAAAAEiaQbdw4clmeBx54wG666SY3Re2jjz56eXsCAAAAJEaO7K233uqmlwUAAADCJpA9deqUvf766246WQAAACBJphZcc801QYO9NDHYf//9ZxkzZrQZM2bE9f4BAAAAcRPIjhkzJiiQVRWD3LlzW9WqVV2QCwAAACTJQLZdu3bxsycAAABAfObITps2zWbPnh1puZapBBcAAACQJAPZkSNHWq5cuSItz5Mnj73wwgtxtV8AAABA3Aayu3btsmLFikVaXqRIEfc7AAAAIEkGsmp5/fnnnyMt/+mnnyxnzpxxtV8AAABA3AayLVu2tKeeesqWLVtmFy5ccLevv/7ann76aXvooYdiuzkAAAAgYaoWDB8+3P7880+rU6eOpU79/x5+8eJFa9OmDTmyAAAASLqBbNq0aW3WrFn2/PPP24YNGyxDhgxWtmxZlyMLAAAAJNlA1nP99de7GwAAABAWObLNmjWzl156KdLyUaNGWfPmzeNqvwAAAIC4DWS/+eYbq1+/fqTl9957r/sdAAAAkCQD2ePHj7s82YjSpEljx44di6v9AgAAAOI2kNXALg32iujDDz+00qVLx3ZzAAAAQMIM9ho4cKDdf//9tn37drvzzjvdsqVLl9oHH3xgs2fPvry9AAAAAOI7kG3YsKHNmzfP1Yz9+OOPXfmtcuXK2ZIlS6x27dqx3RwAAACQcOW3GjRo4G4Rbdy40cqUKXN5ewIAAADEZ45sRP/995+99dZbVqVKFStfvvyVbg4AAACI30BWpbY0LW3+/PntlVdecfmy33///eVuDgAAAIi/1IL9+/fbO++8Y1OmTHGlth588EE7c+aMy5mlYgEAAACSZIusBnmVLFnSfv75Zxs7dqzt3bvX3njjjfjdOwAAAOBKA9kvvvjCHn30URs6dKgb6JUqVSqLC+PGjbOiRYta+vTprWrVqrZ27dpo11cQrYBa1RIKFSpkPXr0sNOnT/t/P2TIEEuRIkXQrVSpUkHb0PpdunSxnDlzWubMmd20uwcOHIiT1wMAAIAkFsiuXLnSDeyqVKmSCzjffPNNO3z48BU9uSZW6Nmzpw0ePNjWr1/vBovVq1fPDh48GHL9mTNnWp8+fdz6v/32m0tx0Db69esXtN5NN91k+/bt89+074EU/C5YsMDVvV2xYoVrXVZtXAAAACTDQPbWW2+1t99+2wWGjz/+uJvJq0CBAnbx4kVbvHixC3Jja/To0dapUydr3769y7GdOHGiZcyY0aZOnRpy/VWrVln16tWtVatWrhX37rvvtpYtW0ZqxU2dOrXly5fPf8uVK5f/d0ePHnUBsJ5bA9QUmE+bNs1tm8FqAAAAybhqQaZMmaxDhw6ulfOXX36xXr162Ysvvmh58uSxRo0axXg7Z8+etXXr1lndunX/b2dSpnT3V69eHfIxt912m3uMF7ju2LHDFi5caPXr1w9ab+vWrS7ILl68uD388MO2a9cu/+/0+HPnzgU9r1IPChcuHOXziga1aYBb4A0AAABhWkdWuaqjRo2yv/76y01RGxtKS7hw4YLlzZs3aLnuqzpCKGqJHTZsmNWoUcPSpEljJUqUsNtvvz0otUBpD6qssGjRIpswYYL98ccfVrNmTX+LsbadNm1ay549e4yfV0aOHGnZsmXz35SfCwAAgDCeEEE08KtJkyb26aefWnxavny5mxp3/PjxLqd27ty59vnnn9vw4cP969x7773WvHlzN22u8m3VYnvkyBH76KOPrui5+/bt69ISvNvu3bvj4BUBAAAgQaeojQvKW1UAHLFagO4rrzWUgQMHWuvWra1jx47uftmyZe3EiRP22GOPWf/+/V1qQkRqeb3hhhts27Zt7r62rbQGBbeBrbLRPa+kS5fO3QAAAJCMWmQvh7r3NdBq6dKl/mUaOKb71apVC/mYkydPRgpWvTJgPp8v5GOOHz9u27dvdzOQiZ5TaQmBz7tlyxaXRxvV8wIAACDpSbQWWVHprbZt21rlypWtSpUqrkasWlhVxUA0BW7BggVdfqo3KYOqDVSsWNHlwqqVVa20Wu4FtM8884y7X6RIEVdWS6W69DtVNxDlt6oerp47R44cljVrVuvWrZsLYlWZAQAAAOEhUQPZFi1a2KFDh2zQoEFuoFWFChXcIC1vAJhaSQNbYAcMGOAmOND/e/bssdy5c7ugdcSIEf51NPBMQevff//tfq+BYSqrpZ89Y8aMcdvVRAiqRqBcWuXdAgAAIHyk8EXVJ49oqfyWWnc18EutuvGtYa/58f4cgGfBq40tqXpw1hOJvQu4inzUYoIlZd81bpbYu4CrSPX5c5JcjJVoObIAAADAlSCQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWEr0QHbcuHFWtGhRS58+vVWtWtXWrl0b7fpjx461kiVLWoYMGaxQoULWo0cPO336tP/3I0eOtFtuucWyZMliefLksSZNmtiWLVuCtnH77bdbihQpgm6dO3eOt9cIAACAZBbIzpo1y3r27GmDBw+29evXW/ny5a1evXp28ODBkOvPnDnT+vTp49b/7bffbMqUKW4b/fr186+zYsUK69Kli33//fe2ePFiO3funN1999124sSJoG116tTJ9u3b57+NGjUq3l8vAAAA4k5qS0SjR492AWX79u3d/YkTJ9rnn39uU6dOdQFrRKtWrbLq1atbq1at3H215LZs2dLWrFnjX2fRokVBj3nnnXdcy+y6deusVq1a/uUZM2a0fPnyxeOrAwAAQLJskT179qwLLuvWrft/O5Mypbu/evXqkI+57bbb3GO89IMdO3bYwoULrX79+lE+z9GjR93/OXLkCFr+/vvvW65cuaxMmTLWt29fO3nyZLT7e+bMGTt27FjQDQAAAFdhi+zhw4ftwoULljdv3qDlur958+aQj1FLrB5Xo0YN8/l8dv78eZfbGphaEOjixYvWvXt314qrgDVwO0WKFLECBQrYzz//bM8995zLo507d26U+6vc26FDh1726wUAAEAySi2IreXLl9sLL7xg48ePdwPDtm3bZk8//bQNHz7cBg4cGGl95cpu3LjRVq5cGbT8scce8/9ctmxZy58/v9WpU8e2b99uJUqUCPncarVVPq9HLbIabAYAAICrLJBVt36qVKnswIEDQct1P6rcVQWrrVu3to4dO/qDUA3iUmDav39/l5rg6dq1q3322Wf2zTff2LXXXhvtvigoFgXGUQWy6dKlczcAAABc5TmyadOmtUqVKtnSpUuDUgF0v1q1aiEfozzWwGBVFAyLUg28/xXEfvLJJ/b1119bsWLFLrkvGzZscP+rZRYAAADhIVFTC9RV37ZtW6tcubJVqVLF1YhVC6tXxaBNmzZWsGBBl58qDRs2dJUOKlas6E8tUCutlnsBrdIJVKZr/vz5rpbs/v373fJs2bK52rNKH9DvNUAsZ86cLkdWtWhV0aBcuXKJ+G4AAAAgbALZFi1a2KFDh2zQoEEu4KxQoYIrn+UNANu1a1dQC+yAAQPc5AX6f8+ePZY7d24XxI4YMcK/zoQJE/yTHgSaNm2atWvXzrUEL1myxB80K8+1WbNmbpsAAAAIHyl8Xp88YkWDvdTKq/JeWbNmjffna9hrfrw/B+BZ8GpjS6oenPVEYu8CriIftfh/jSNJ1XeNmyX2LuAqUn3+nCQXYyX6FLUAAADA5SCQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWCKQBQAAQFgikAUAAEBYIpAFAABAWEr0QHbcuHFWtGhRS58+vVWtWtXWrl0b7fpjx461kiVLWoYMGaxQoULWo0cPO336dKy2qfW7dOliOXPmtMyZM1uzZs3swIED8fL6AAAAkAwD2VmzZlnPnj1t8ODBtn79eitfvrzVq1fPDh48GHL9mTNnWp8+fdz6v/32m02ZMsVto1+/frHapoLfBQsW2OzZs23FihW2d+9eu//++xPkNQMAACAZBLKjR4+2Tp06Wfv27a106dI2ceJEy5gxo02dOjXk+qtWrbLq1atbq1atXIvr3XffbS1btgxqcb3UNo8ePeoCYK135513WqVKlWzatGlu299//32CvXYAAABcmdSWSM6ePWvr1q2zvn37+pelTJnS6tata6tXrw75mNtuu81mzJjhAtcqVarYjh07bOHChda6desYb1O/P3funFvmKVWqlBUuXNitc+utt4Z87jNnzribRwGxHDt2zBLCuTMnE+R5gIQ8ri/HuZNnE3sXcBVJyp8FOXHuXGLvAq4ixxLo8+A9j8/nS7qB7OHDh+3ChQuWN2/eoOW6v3nz5pCPUUusHlejRg334s6fP2+dO3f2pxbEZJv79++3tGnTWvbs2SOto99FZeTIkTZ06NBIy5WnCyQ32cYl9h4ASUO2DqF7CIGrUrZsCfp0//33n2W7xHMmWiB7OZYvX24vvPCCjR8/3g3i2rZtmz399NM2fPhwGzhwYLw+t1p5lXvruXjxov3zzz9uwFiKFCni9blx+Vd0utDYvXu3Zc2aNbF3B0g0fBaA/8PnIelTY6WC2AIFClxy3UQLZHPlymWpUqWKVC1A9/PlyxfyMQpWlUbQsWNHd79s2bJ24sQJe+yxx6x///4x2qb+VwrCkSNHglplo3teSZcunbsFitiqi6RJJypOVgCfBSAQn4ek7VItsYk+2Evd+xpotXTp0qBWTt2vVq1ayMecPHnS5bwGUuDqRe8x2aZ+nyZNmqB1tmzZYrt27YryeQEAAJD0JGpqgbrq27Zta5UrV3aDt1QjVi2sqjggbdq0sYIFC7r8VGnYsKGrNlCxYkV/aoFaabXcC2gvtU1F+I8++qhbL0eOHO5qrFu3bi6IjWqgFwAAAJKeRA1kW7RoYYcOHbJBgwa5gVYVKlSwRYsW+QdrqZU0sAV2wIABLh9V/+/Zs8dy587tgtgRI0bEeJsyZswYt11NhKBKBKozq7xbJC9KBVE94YgpIcDVhs8C8H/4PCQvKXwxqW0AAAAAJDGJPkUtAAAAcDkIZAEAABCWCGQBAAAQlghkAQAAkiiVEUXUCGQBAACSmH379lnGjBlt5cqVib0rSRqBLJDMXbhwwd08FCpBUqVjU8cqxyiuZjr+z58/72YbzZMnj3333XeJvUtJGoEskMxpshDd1D2lqZhVixlISoGrR8emjlX9r3rghw8fTtT9AxLjM6HjP3Xq1O7/unXr2hdffEF6QTQIZIFkbsaMGW5q5kKFCrkJQyZPnmz//fdfYu8WrhJ//PGH3XTTTfbXX39FCl69wNWj4/KFF16wwoULW+nSpd3sjpqdEUhu9DkIFZzqM3Hs2DGbPn26O1fXrFnTfv75ZzfBE5LgzF4ALp9OgoEz38nevXvdMnVJyfLly93JsFGjRvbggw/al19+aW+++ab9888/1rt3b//VPxBfNC24pgHX/xGDV7W69u/f3zJlyuRmXPz8889t9uzZNmrUKDdtuGZl1PJcuXLZI488ksivBLjyc7aO/8BbRFu3brX77rvP/Vy7dm1bt26dC2w3bdpkBQoUSIS9TvpokQWSOC9fMLALVhSwBl7RK6fq9ttvtyFDhviXTZs2zUqVKuWmY7zxxhtdQKvBA2+88YadOnWKIBZxTsdkYI5rjhw5rHPnzpYlSxZ3X9OCjx492mrVqmUffvihm2785ptvdmkEOi6ff/55e+ihh1yrbNmyZV0r7dtvv00vAsKeztneOXfDhg3ueF+xYkXQeXzgwIGWN29elxf71ltvuQs95cmqEQKh0SILJAGTJk2y9OnTu1Ynr7XKa3H1Tnzecq9LqmPHji6PSl/yWqafGzdubF9//bVbT1256o5S62yrVq1s6dKldu7cOStXrpw999xzBLGIU97xGrGXQJYsWWJdu3a1zZs3+3O29UWtue7VAps9e3Y7ffq0/fjjjzZ//nwbOXKk607V8jvvvNMdv1oXSEq++uormzNnjt16663Wvn17/0Wczq2hPgeffvqpa5D46aefXMqXGhV0Ade3b1/Xa6HHq0W2SZMmrhdC7r//fteztnjxYjt79qylTZs2EV5p0kaLLJCIvCvxLVu2uJNaIO9EqC/0H374wd5//33Xurpz504XCOTOndsftHruuusut/7Bgwft2muvda1YCmDVKqYTp06SOikqqFDgDMTWjh073P/6Uo14vKpXYOHCha4lKTCnT62xv//+u/sC1wVXxYoVLXPmzPbwww+7YFWOHDliVapUcS1PCgp0nG7bts3lCt577718gSNJ+eijj9xxevToUXc8e58BnZv1/4kTJ2z79u2RHqNxCr/88os7d+tcrd6H8ePHu5///fdfd173Bjl6vXB33323/fbbb7Z79+5EeKVJH4EskMAUAHgnJLWQirpamzdvHjTw5c8//7TKlStb9erV3e9ff/1118qqQFbuueceN5BGtQa91tXy5cu7gHjZsmXufokSJVzwq+4pBbk5c+Z0y5V7qHxEodQRYkpB5XXXXed+jhhYfvDBB1a8eHGXRjBx4kSX4/rZZ5+535UsWdI9bsGCBe6+0gZ0bK5fv97/eB23xYoVs2uuucYeffRRl26g51AKzLx581xgCyQ273yp87FyWZUeU6FChaBWV6XEKD1A53T1fukcLepxU5Cr87Q+A9KrVy8XsK5evdo1OBQpUsQ1bIj3faDzu74rdCGIyAhkgTh0qaBQV9wadNWuXTt3X92lapVV3qC6l7wvfnn11VfdCUxJ/hqwpcepxet///ufex7lvCowVfeWaDs6ESp1QOVapG3btnby5El3QlUulrp2NXhGI8G9ljVSDBCRjqVQ9Vw1glrBpbpB1Xqqbn9dWOm41sWWukF37drlukG1ri6gVMxdra633Xab/+JJx2mNGjXsm2++cff1PFmzZrWePXu6xzdt2tS1WCl41TZ0vOrYBxLrsxDRDTfc4FpJdcyqh0u9X2qBHTZsmOtBUND5+OOP29y5c+2ZZ55xj7nllltcyoB6IzwFCxa0/Pnzu5xZfQ7q1KnjflbKjUfpC/LJJ58kyGsOOz4AV2zfvn2+ZcuWuZ/Pnz/v/r9w4YLv3LlzkdYdNWqUL1++fL5u3br5ihcv7hs4cKBbnjdvXt8zzzzjO3HihLtfuHBh3xtvvBH02Hvvvdd3zz33+I4fP+6ep0GDBr7777/f//v//vvPd/fdd/sqVqzou3jxolu2du1aX9OmTX3ly5f3Zc6c2f3u9ddf9x0+fDge3xEkR82bN/elSJHCV6RIEd9LL73k27Bhg1s+d+5cX8GCBX0//fSTf90dO3b4atSo4RswYIC7//777/vSp0/vO3v2rLs/Y8YMX9asWX1Hjhzxf15k4cKFvlatWvnKlCnju+aaa3wNGzb0zZs3z3f69OlEeMVAMB2/M2fOdJ8DHc8VKlTwTZo0yS2fPn26L3v27L5//vnHv/5HH33k1vvjjz/c/erVq/see+wx/3EvPXr08N15552+33//3d3v0qWLL3fu3L5GjRr5qlWr5nviiSd8Y8eO9fXq1cv//YL/QyALXKGTJ0/6unfv7mvWrFmU6/z5558u2NWJSgGrToJ16tRxJz4tlw4dOrjAdM+ePe5EWKlSJd+wYcPc706dOuX+f+utt9wJbuvWre7+tGnTfBkzZvR999137v5XX33lu/HGG932f/vtt6B92Lx5c8jAGlcfXeToC9ELHiP6+uuv3Zenvkh1zB04cMAt37Ztm1uui6FAy5cv96VOndr377//+i+gtP2WLVv6HnnkEReE6phNly6db+nSpf4LrPz587ugQHRseo/V+nv37o3X9wDw6HPgHXvi/azgVBdRCjzV4KCLM9myZYu74EqZMqXvm2++8T+uU6dO7jOjBgXPX3/95StatKhrPJDnnnvOd9ttt/k2bdrkX2fBggXuvD1r1ix3Xw0V2n7r1q19L7/8sv87AqGRWgBc4UCtDBkyuDSAjz/+OOj3qv+nRH7lSilfULlT6lZSN5EKxKv7STlT6mYVzeCi3CjlzyrlQOsobyowH1F5hn///bdLERClKJQpU8Y6dOjg8ml79Ohh48aNc/9HzGFUnqIG2nhT1pIbm7xpsMljjz3mBvtJ4N/bq+UacWS1BlypK//JJ5906QLXX3+969b3argqr1UDTzRYRbUtPRpYqGNL3anatj4b3mxyyu3Tz6qeobQX73OikkI6Jr1j2ZvJSHT8q7sVSAiB1WFWrVrl0rH0edF5tXv37u6zpFQXpQbo90or0Pnby/tWaphooJZyujW+waM0Ah3n+sx4Yxs0EDJwIJiqHuj5vQGUqqus7b/33nsuLcGrCx4qxQGkFgCxEl0rlq7M169f735WC9ZDDz3krs6//fZb3y+//OJueryu1tu2beurWbOmW9fralULlLpnp0yZEtTa6rW+Sps2bVxr6/Dhw11LsBw6dMh1bb366qtB6+LqpuOsdOnSvvbt27v7gcetjjWlrTz++OPuePNakJTWMn78eH/Lk/z666/umFu3bp27v337dpeiMn/+/KDWK6URqFdi9+7d7v7+/ft9119/va9nz57+FtennnrKdaF6++Md+0BinbvV+qnPwMaNG31169Z1raw6V7/33nvufLxkyRL/Z6Nx48auJ00tsl4KwC233OJ6IkTr3nTTTe4z5NG21POg3jfvc6Dz+ogRI4JagUPtm5ZpvwPXQ2QEssBlUs7TF1984e8+0glNOayyePFi92XvffkH5jXp5DRhwgSX/+d9kXsnsSpVqvi6du3qTq5Sq1YtX4kSJXx9+vRxAUn//v1dTqzypqLLcfW6jnH10N88Yvfo0KFD3fHj3Zcff/zR5fXppi9iffEqr9rL2Ttz5ozv2LFj7uLojjvu8OXKlcsFsoMGDfJ/oStoVRAsXrqK0lq0LX0ORo4c6bpPa9euHZQioG0Dieno0aP+VC1ZuXKlO1dfd911Lg9Vx77o+FbQGniMf/nll26swQcffOA/5pX/qrQtLyXm2Wef9WXKlMn39ttv+1avXu3SDZQXqwYHjxo3vHN8oKgaSRA9UguAGIxQlePHj7vpXdU1pNlX1H2vqgCi9ACVYlGtTFEqgSoKqFtItQaHDh3qyrWoHqy6sdTFqv+91AGv21ezHf3666/+rinVjtUIcXUP6/k7derkyhupm8or6eIJTBeIOIc9kif9vb3j1ZvyMvAYUGUAVacILNGm0lbqttTkAzqev/32W5cSoJJZnkGDBrlasJoiU3VddcwpNUaVA1Qmq0GDBq7skLpI1Q2ryhoq7+YVh1clDVU0mDJlSlCKALVgkdD0+VBdVlUPUMmrokWLupQbTcghhQoVsnr16rlzv+oaezPQqTtfFTQC08h0XlfqgFfnVZ8Pfa68slhKidFkHqpioEoz+kzoO+GFF17wT3Cgz6c+l0ofiCjUJAqIgUsEukCyo1ZSDaxSq2lMr4K1jrqCNFpbLVO6cld3kQaveC2j6mrNkiWLf+SpqhioK7V3797u+a699lrXSqWBWWoRUOurBsN4rbtq6Vq0aJHbhgbbRLcvaiGbOnVqHL0jSGoup2VGg/vUQ+BVvRB182tw4DvvvONvja1fv747NtUqpONSrag6nnScio69NGnSuNYnj0ZLqwdBaQVy8OBB16KrViw9VikvgQNcgPimHqdL9TqpB+C+++5z1WHU06XKGZ999pnv9ttv9xUrVsy3a9cu11PRt29f9zkJNHv2bF/atGn9FQi8Hg1VnJk8ebJ/PX0OHnzwwUgDaRmglXAIZHHV8E5E+gLXqGt1f0rgyVA5ThqVrZtGVXv0Ja0upMDcJ41mVSDrjbr++eef3Re7Nzo1Yneqcg1LlSrle/PNN/3lhwoVKuSqGKgrSt1V2kevTEtEOlF6JYhUguvdd98ldyoZ83Ljoqs0oYso5Usrl09fxDfccIMLVL0LIXVf6ou8SZMm7r4CWK2rY1kXZQ8//LD7ct+5c6d/m7rQUnDqdZfquL711lvdMuVte3TBpgoEf//9dzy+C0DMhDoX6oJw3Lhx7thVo4JH51Gde59//nl/I0SGDBlcdZnAz5bWUQCsgFfUeFCgQAHfihUr/OvpfK4Unqg+pzEJuHFlCGRxVeZI6QpatSoDqd6lvtz1O33xK0hVsCg6cSlIVc6TRwn+GrjSokULfyuV6mx6ebIajKVgWC1kyrt65ZVXfJUrVw4aSKMBYqtWrYrxvhO4Xh3UQqTj8FK1U9XC+vTTT7vWIx0b+sJVK6tKt3lf5GPGjPHlzJnT3VfrklqiVLcyIh2XXt5euXLlXB1X5cKqNWvOnDm+IUOG+GslAwmV8x3YO+EFhDpOdQGm/FM1SHgDDEOdH3XOTpUqlctnFW97GnCr8QYKWDVIVse511DhjV1Q44IaH9R7pnxZfY4UtEb1XEgcJGQg2VE+U3SlpTSDkMoIabpXLxf1+++/t3fffddNJzhr1iw3g4rKrrz88ssur1UltjR15tatW4PKqqgci2YuEm/2Is2ZLcpR1Swvd9xxh8sTnDRpksud0jScHs1+pLwrb78vhVm4kmcOn/e392avUhmfvXv32jvvvONmB9Ksb6Eo30851A888IArh7VmzRrbs2ePbdy40ZW1Us6dpjj+559/XO61jmHl5ykvVrNmec+rmYRUdsvL2daUsMqlVc62pp7VjF2DBw+222+/PcHeFyRvyq2WqM7VXs63jmGto2NT51Qdyzrehw8f7parLJbysnW8hzo/atpk5cHqGBcvp1zjFLZt2+Y+c8pfrVSpkssHD6Tyicr31vgH5XzrM6P8cW//PMw6l7gIZBH2/v+eBf8JMbAmYETeF7fmwlbtP033KvpfA1F04vKoRqtOcJpus3Tp0i5wVcDrUd1LDaJRwPHHH39YmjRpXL1A3ddAAm1Pg7M0haGmMlTSvzc4LOL+e/uNq09gPVcdU6rfqqlbdQzpwkoXXDfffHPIx+riSRdl/fr1c/O360tWF0ra5rJly/xf5Jq/3Zv++Pnnn3df7DoWFRDoC121YXW8evO/axu6kBsxYoSbihaIKwcOHHB1iXVRLzoPe+fAwKBW51EFkRpAqGO4TZs27vcDBgxwx7cGWL399ttuHR2vOvYPHToU6fm8izcN9tJz6Tzt1UzWxZ/qfGsAo+p2a0CjeOuIPisa3KvPmGp2h6LPLRIP35wIe96Vuxe86qr5o48+ciOqQ60r+tLXyUuTFngnK62fPn16/xW7il5rBKtGfXsFqnVSnTlzpjshrl271k1OIIsWLXL/62SoVjQ9Vho1amQtWrRw2w8cYR5qn5A8eRdZgS3u3s9Hjx61adOmuQueUaNGudYmBae6oKpQoYJrFf3888+tefPmUW5fX+bqQXjppZdcb8CECRPc5Bj6HIi2p5ZUFW4XBasqtK6KGDpOVX1DVQcCj1sgvuicmi1bNn+FF51zdQ5UUBl4LhwzZox17NjRTcihii+qsqHPjXrFmjRp4hoRnn76aRek6qJPwaTXyhtIQamqB6i3QhMcaNIZBb/6jujSpYtbRxdxDz74oC1cuDDKFmImkUnCEimlAYiSck9VlzWQN+glVF6Scl4//fRT3yeffOIKsiuPSdP9Kb8vcBBLIOVAaepM5cIq70o5Uhqp7eUAenlU2kbgIAFNVai6nKpYoEFaqrWpvFhNfhD4uEDUBkTgcbdmzRr3s+qrqk6rjtXOnTu7WpOawMAbZKVc14YNG/oHoEQ89r3jSrVgq1at6l+uwYxZs2Z1uX1eRQ0dp/pccCwiPkQ3mCnUICgdjyVLlnRjCDQFq45NDVTUz965X+d0VXrxKruIcmE1mFGDt1Q9QAMZNZgr4nTcEf3000+u6obGM+gxmpBAlTYCa7sifNEiiyRHOaVqpQqkK3VvCkt1vapbyLNz506XR6iuH+Wb6kpdraZartaqiHRVrav0UqVKuW4utUZpqkF1ob744osuzUBdvcp9VcqAul49qrupHNrXXnvNTTGouoNqsfVqBHr5XIFX7qQMhD+vRTWqPGYtD8yTC/z76xjSsaS6rOoC7dWrl2vdUUuopmnV8adWVK2jln/lVYvyrdVLoBakiNsMPK6UZ63eAU1NrNzWqVOnuufQ45QvK+qWVe1LjkXEh+hqVgd2uysHVa2h6hXQsa9jXbmt6iFQve3x48fbs88+69ZVN76mPg7ctup1qz63cmJV41W9DJpOWedypRWESi0Q9YgVLFjQ9TjoM6IpZzUmwjtve2hxDVOJHUkDEVubAutgejTqX7NaqfSJSqJo6lfNyOLRVbau3gNr92k0d7169Xzbtm0Leg6vVWrBggWurJBXE1Db00xEainQ43LkyOFaxSJOo+k9h0aUa0S4Rrt6rWxI/jTyf9asWf6ZsCLyZgbyqOVf1TA0e5ZqF6uGsEpW6ZjVNJibNm3yPfnkk66ihVqaWrdu7Y4tTZmpMnFeObfoWlNVcUPHrXoKunfv7srFMYsWEoLOq+q1Uj1Vr2Rh4PlcPWUvvfSSm6JVNbJVh1stpOrJUhk4b6pjUe1ifQZ07IvOvw0aNPBPxy2aTlal5lRRwKtdrFbcjh07upKGoeiz061bN/cZ8+6rpZgeiuSBy3MkmsBWrMDcKC93VS2vHl09a7CKZkhR0r6uqNXK5OW43njjja4ygJezKqoooJZbr4pA4IxHopZW5Q8qd0o0ulvJ/hoFrpZd5SZqZqLAxH/RKG6NYNUgAbXM9unTx+UkIvnS4Cvl66mFSC1Jys0LzMHWMabW+QIFClj9+vVd66s3+4/ypJX7qgFXdevWdTmBuq9jVTl7WqZeBM02pLxBtU5phiDlW+uY1mhtfVbUmqrc7FBUUUCtshogo9xCDUxkFi0kBB27agnVuVZ52v/995//HKtzrgZl6RypnGxV09Ashxo8e/3117tjumHDhv51NehQ59UvvvjCLdN6+pzocR59ZjRQUT0azZo1c+dtjXlQz5haXkPR86gCh74vlJeu+2oppocieeCviAQTqmvU63ZS96u6WPWFrYR9BaEaWOVRwKiEfZ3AFDQqUV8BhZZL1apV3WPVTeXRetq+F8h6J1fvf3VvaRpCOXv2rL80lwYAKDBQ91Ugr1tZQaxOpl7qgQbqcEJMvlSCTYOllEqi7ntVEdCXtypUiL7EdbzowksXPvrCVGUAlbMSDdrSF6yOLY+OPQWbmupVX8C6ONNxpBQXpQN4F2QaYKjpiHXMKbh95ZVXQu6jjvPA7QMJRceqzoOasli88lTeuda7eNPU3jru9T2g41UXauraX7VqlVv33Llz/ooyOua99AI1JKxfvz5oHaWAaTCjglgNhFQ1GU3jrc9eVJQ6puDX2waSkcRuEkbypq6bqAYCaFCLuo5y5crly5Mnj5sG0ytsXbduXV+7du3czxs2bHBdrG+//XZQt5W6XDVLkagQvLqNhg0bFvQcKiqvW2DXVKCoCs5rn+l2gjfoRIP+PvzwQ3c/4nGhrlEVXPemb9Xxqdne1EW6f/9+t0yTZLRv3z5oGlcVctfAQaUpeMehZnXT4BYVexelB3z++efuuF64cGGCvWYgpvbs2ePO4Tq2Nf23ftYMiR4NalQ6mAZyiZeq9b///c9NvNGnT5+gtJ1atWq5NAHR94Gm9dY5PCY4Z1+daEZCvFJLpZL1lUKgK2bVZFXXk6j7Va1Rs2fPdpMOqJVTaQVeS5QKXasVVHUA1dqkVrDAFlVdrWuZ0gzU4qWrfRW4DkxJ0HJ1eYUqxSVq5Yo4OCtibU9c3ZSCokFYXquQjgt1l3788cfuvgqtq9VVtS6941Mtreox8Gq3qpVJgw/VcuV56qmnXKF1/a8JB9SroF4EdX1621J6gFIVVMdSnwkgqVHqi45/Db5SvePOnTu7QbaBE8Xo2Nb5P/D8rWNcg6/0PaASW0q30UBafU6UxiNK5VEdbqUmhOKVNKQW99WNvzquWHT19dTVrxwoncw0KlV5p+qKUgCrQFVf5Oq2VV6U8qE0KlXUHbV7926XG6UAVfmFylMM7BZSUKzcKC8XUYXhlQOlYNajAEAjZQNn04oosAYtEJGOPd1UY1LHpQJUVdbQ6GvRsaOR1IG52KqVqdQDL/9aaSrHjx/3p77oM6OLNtWOXbJkiQtgW7du7S7o9BmJmNYCJDXeOV/naZ3fdf72xivoXO2lwSitQJ8bb9Y4L51M53oFwErrUn63PlO9e/d2ueKBYw6UB1uxYsWQ+6DPnhodOH9f3ZiOArHiXQEHllTxyqPoSlpX1To56cSigSnTp093Oa8qZq1gQEGnTmDajnKkNG2rrtz1O50MFZiq5UmtYJqmU7MT6WcNpNGVfsuWLd3MLmp1VWDRqlUr91jRVXzTpk3dVIMeFd729puTHS6Xjku1rupY1EAUtSapp8D7nYJP5enp9zrO1DqlAu8arCUKTHXs68tcOX3eZ0YtrupZiGrGICCp8s6nuiDTeIbatWu7gFTTeXuTFOj8rtKIymU9ffq0a2jQ+VnfIfoM6DtAMyhqHeXLemMWIvIGOwKhcGQgRryBTl4910DqRlKLp77Qn3jiCWvcuLHr7hd1v6rFVSNUFdBqVLeu0HWyU2uUWqH0OH2ha3YsdbOqBqzoZOh1R2k0qwZ2aRsaNKCZXXRy1OM96qZStYFQJzyCWFwJfeEWLVrUHXP6ItYFktcipWXqUtXgLrX+K2DVYEQdq6qsIQpohwwZ4lqbgOTk119/dRdiOvfq+Ff9Yq/6i+puq8FB538FvN4UsN45WufxN954wz3eC2JD9fARxCI6KZQoG+0auOp4OaOhTh76claLqAJMtZZqBLcqCeiKWq2jaoXS/O0aIappBTVJgcquKMdQLbW6ClfAqak3FdQG0hW7AlblRSmYnThxoit2rUkL1Dor2r5SE6JKFaDlFfFBlQnU4q8UAk04EJF6H9RroPJZyoNV74KKvSudBkjOlDagQFR5roHnYOV66ztB4xtUUk5Tyyr9S+MSYvp9A8QEqQWIVGM1VM6o8lF1UlLivU5QClz1Za37ynNVt7+CTOVL6UtdLVJKAxg+fLhL9FcArIBUg2RUakiDtDSLi2bR0oAstdCqe0rBrIJcUcuuShGpBdejk6JXZkhX7trPwBMgQSzigy6k9CWs1icdx8rpDqQvZw1U0fGt1lqtCyR3XtDq9cB5KQOiz4HO9V7g6uXQRsQYBVwpAtmrUKhWS+++WlgVXKorSF3477zzjrvi1slIOYEKPjUtoFpXRa2jyvvTwC0NdtFAGE2ZqdYojdTWSU0BaSDlsapwuzfRgb78dVPurGq4KtfK645VIHw50yICcU3TYKprVLmwOqYjfo50PCrFALhaaPCtGimUHhbqnOxVhSFQRXwikE1mc8F7J5KIJ4/A34c6qehkpNmKFLhqjnfNS61gU1/aCmQ1uEXVA1ScWkGstqeTmL64NepaBeG1XGkDEXNoNThGQakeqxwqdb2++uqr7nfKca1Xr547EWr7EWmfuWJHUqBcWH1GNKBLOCZxtdPYBg3qig6fE8Q3Atkw5wWsXhkSUd1UdfsHCvy9WlB1X4NWvOlX582b50Zla8BVnTp1XMCp0lfq7ldOrHIDlfeqKgSBJzEFoEol0Je8Vz3AC16VV6jBLqq/qVQDVTVQQKwBXRrIJUo7CHwt3uhU7+RH3hSS0oAv3QAEo6oAEhODvZIBjZJWwKkKAUqo1+jqBx980N1U0kSUe6p5sJWQr3xUBZ1KA1AxauX7aVCWgleVR/EoQV+TFGj7Cow/+eQTN7DLq+3qUYutN+hL6QTKp9VVuga/aEpA5blqG/pdqJMdXU8AAOBycAkV5hR8KoleM58oN1Uj/dXSqvmuVcPPs2LFCjcYRS2jShn44IMPXGqAWlvl4MGDLjg9deqU/zFqgVXQ65XAUmuqgl89p6iQtWgUt+aJ13qqMqCWV21XpbhEaQpquVUQq8EAugUiiAUAAJeDFtkwp1HU6qqvVauWy1MVVQ/QtJYKVL2ZhTQFpgZvqY6lZtVavny5Pf/8864CgVpxNYhLs7Gotqs3kEu5rAqONTPXhAkTXLCragWaYlZ5sZp2NjAfVs/rVRQAAACIb7TIhjkNrlI9VnX3e/bv32+bNm1yZa0UXIqmxtSEAqq/qun+1FqrgVYaha1qAWp9VW6tyqV4lEur1lsFvV45FQ0EUyutBAaxuh7yglgFuBFbXQEAAOIaLbLJwIgRI1x+rEZTq4zVb7/95lpjZ8yY4Wq/Kqjs2rWry3HVYC118ytFIOK0s1OmTHHpAKoJq9qtCobVsqs8V7XGasAXSf0AACCpICJJBpQTq4LUGqj13HPPuSljlQLw7bffuoFWqlagFlelEWggmBfEKtjVIDHluCpPVY9RHq1yXBXEdu/e3W688UZXOkvTDoqCWAWzXP8AAIDERotsMrBr1y6X+1qyZEmXPiD6s2oea81CpMkKNM+1ymopH1YDspQmoOoCyoPt1auXtWjRwl+KK5C2qwkS5s+fH7LOKwAAQGIhkE0m1JqqgFZVCbJkyeKWqZVWLbFqsVX6gWbmmjx5sgtgta4C20ceecQqV67s346mmFUKgmrDqqas8m01iEylvAAAAJISAtlk4vXXX3dB7Msvv2zVqlVzpbE0YYGqC3Tr1s3uu+8+9zuJWG0gkAJYtdCqGoK2oxzbMmXKJPCrAQAAuDQC2WRClQVUhuuhhx5ykxto8JZyY/W/asNmzpw5aH3luXoDtxi8BQAAwhFT1CYTmjqzUaNG/jQBbzpa/a8gNuLsWQSwAAAg3NEiCwAAgLBEk1wyw0QEAADgakGLLAAAAMISLbIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAAAISwSyAAAACEsEsgAAAAhLBLIAAACwcPT/AVVAz6AWsXW2AAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 700x450 with 1 Axes>"
       ]
@@ -1015,9 +1374,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c3db5aed",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014131,
+     "end_time": "2026-08-23T02:19:06.890029",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:06.875898",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### Exercice 4 (capstone) : diagnostiquer biais et variance avec une courbe d'apprentissage\n",
+    "### Exercice 5 (capstone) : diagnostiquer biais et variance avec une courbe d'apprentissage\n",
     "\n",
     "Les exercices précédents comparent des modèles par *validation croisée* et lisent une *courbe ROC*. Il reste un outil de diagnostic central pour le compromis **biais / variance** : la **courbe d'apprentissage** (*learning curve*). Elle trace le score — en entraînement **et** en validation — en fonction de la taille du jeu d'entraînement, et permet de distinguer deux régimes :\n",
     "\n",
@@ -1033,8 +1402,24 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
-   "execution_count": 12,
+   "execution_count": 16,
+   "id": "d62474a2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T02:19:06.900419Z",
+     "iopub.status.busy": "2026-08-23T02:19:06.899944Z",
+     "iopub.status.idle": "2026-08-23T02:19:06.904098Z",
+     "shell.execute_reply": "2026-08-23T02:19:06.903305Z"
+    },
+    "papermill": {
+     "duration": 0.010853,
+     "end_time": "2026-08-23T02:19:06.905267",
+     "exception": false,
+     "start_time": "2026-08-23T02:19:06.894414",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1045,7 +1430,7 @@
     }
    ],
    "source": [
-    "# Exercice 4 (capstone) : courbe d'apprentissage de la regression logistique\n",
+    "# Exercice 5 (capstone) : courbe d'apprentissage de la regression logistique\n",
     "# et de l'arbre de decision sur breast_cancer.\n",
     "# Etape 1 : importer learning_curve depuis sklearn.model_selection.\n",
     "# Etape 2 : pour chacun des 2 modeles, calculer train_sizes + train_scores + test_scores\n",
@@ -1063,10 +1448,10 @@
    "id": "a50c0017",
    "metadata": {
     "papermill": {
-     "duration": 0.012005,
-     "end_time": "2026-06-25T11:44:35.769465+00:00",
+     "duration": 0.004446,
+     "end_time": "2026-08-23T02:19:06.914451",
      "exception": false,
-     "start_time": "2026-06-25T11:44:35.757460+00:00",
+     "start_time": "2026-08-23T02:19:06.910005",
      "status": "completed"
     },
     "tags": []
@@ -1084,10 +1469,10 @@
    "id": "a50c0018",
    "metadata": {
     "papermill": {
-     "duration": 0.008007,
-     "end_time": "2026-06-25T11:44:35.785464+00:00",
+     "duration": 0.004306,
+     "end_time": "2026-08-23T02:19:06.922954",
      "exception": false,
-     "start_time": "2026-06-25T11:44:35.777457+00:00",
+     "start_time": "2026-08-23T02:19:06.918648",
      "status": "completed"
     },
     "tags": []
@@ -1104,6 +1489,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-23T13:00Z",
+   "network": false,
+   "notes": "Diagnostique biais vs variance avec validation croisee KFold sur plusieurs\ncomplexites de modele (polynomial features). Trace AUC-ROC et precision-recall\npour classification binaire.",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "vram_gb": 0,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -1119,36 +1521,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 16.173901,
-   "end_time": "2026-06-25T11:44:36.237693+00:00",
+   "duration": 9.784594,
+   "end_time": "2026-08-23T02:19:07.373552",
    "environment_variables": {},
    "exception": null,
-   "input_path": "2.5-Biais-Variance-CV-ROC.ipynb",
-   "output_path": "2.5-Biais-Variance-CV-ROC.ipynb",
+   "input_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb",
+   "output_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb",
    "parameters": {},
-   "start_time": "2026-06-25T11:44:20.063792+00:00",
+   "start_time": "2026-08-23T02:18:57.588958",
    "version": "2.7.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "LITE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reduced_pedagogical": "self",
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-07-23T13:00Z",
-   "validator": "papermill",
-   "notes": "Diagnostique biais vs variance avec validation croisee KFold sur plusieurs\ncomplexites de modele (polynomial features). Trace AUC-ROC et precision-recall\npour classification binaire."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Étend `2.5-Biais-Variance-CV-ROC.ipynb` avec une section 5 « Quand le k-fold naïf se trompe : le split qui va avec les données ». La CV k-fold générique (section 3) supposait des données i.i.d. et équilibrées ; deux démonstrations exécutées montrent ce qui arrive quand ces hypothèses tombent.

**5.1 — StratifiedKFold (classes déséquilibrées).** Dataset binaire déséquilibré (40 positifs / 1000 = 4.0%, trié par classe). KFold naïf (`shuffle=False`) → **4 plis de TEST à 0% de positifs** + dernier pli à 20.0% :

- Taux de positifs (test) naïf : `[0.0, 0.0, 0.0, 0.0, 20.0]`  → Stratifié : `[4.0, 4.0, 4.0, 4.0, 4.0]`
- Score CV naïf : `[0.995, 0.99, 0.995, 1.0, nan]` — accuracy ~1.0 **trompeuse** sur les plis sans positif (prédire « négatif » partout = 100%) et `nan` sur le dernier (train monoclasse → échec du fit)
- Score CV stratifié : `[0.965, 0.965, 0.96, 0.955, 0.96]` — stable, honnête

**5.2 — TimeSeriesSplit (données temporelles).** Série synthétique à drift linéaire + accélération en fin (futur lointain non déductible du passé) :

- KFold aléatoire : R² moyen **0.993** (le modèle « voit » le futur dans son train)
- TimeSeriesSplit : R² moyen **0.877** — 3 premiers plis ≈0.999, **dernier pli (futur lointain) 0.512**
- **Écart = +0.116** — la fuite temporelle quantifiée (le score du k-fold aléatoire sur-estime la vraie capacité à prédire le futur)

**Tableau de décision** split↔données (iid équilibré → KFold ; iid déséquilibré → StratifiedKFold ; temporel → TimeSeriesSplit ; groupes → GroupKFold) + **transition** vers ML-5/QuantConnect (le walk-forward des notebooks trading).

## Test plan

- Re-exécution **papermill complète** (37/37 cellules, `python3` kernel), **0 erreur**. Taux de positifs par fold + écart de score committés dans les outputs (preuves ci-dessus).
- C.1 : aucun `raise NotImplementedError`/`assert False`/`1/0` ; nouvel exercice stub (« choisir le bon split ») en pattern `result = None # TODO etudiant`.
- C.2 : les 16 cellules code portent `execution_count` + `outputs` réels.
- Exercices existants **préservés** ; renumérotation cosmétique 3→4, 4→5 pour insérer le nouvel Exercice 3 (aucun stub modifié).

Closes #12442

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>