### PR TITLE
feat(notebook-lean,#11703): 2.8b-PAC-Lean enrichi - import natif du lake + section 10 (Sample/UniformConcentration)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8b-Theorie-PAC-Lean.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8b-Theorie-PAC-Lean.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "3adf5a2c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.025155,
+     "end_time": "2026-08-23T02:22:38.199300+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:22:38.174145+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# 2.8b - Theorie PAC en Lean : l'arc du lake `learning_theory_lean`\n",
     "\n",
@@ -15,19 +24,30 @@
     "Chaque section suit un module du lake, reprend ses **noms de declarations**, et les rend\n",
     "executables.\n",
     "\n",
-    "**Forme assumee** : pour rester executable sans dependance (les `olean` du lake exigent\n",
-    "Mathlib, non builds sur ce poste), chaque section donne une **version simplifiee mais\n",
-    "complete** du contenu du module -- pertes 0/1, espace d'echantillonnage fini, generateur\n",
-    "d'alea deterministe -- et une **verification numerique** du theoreme central. Les enonces\n",
-    "generaux dans le cadre reel (Mathlib) vivent dans le lake, chemin cite dans chaque\n",
-    "section. Les exercices se terminent par `sorry` a completer (patron du compagnon\n",
-    "GameTheory-15b) ; le corps du notebook, lui, ne contient aucun `sorry`."
+    "**Forme** : le lake est désormais **importé nativement** en tête de session (cache\n",
+    "d'oleans Mathlib v4.32.1 construit une fois pour le poste) — la section 10 interroge\n",
+    "ses théorèmes réels par `#check` et `#print axioms`. Les sections 2 à 9 gardent leur\n",
+    "**version simplifiée mais complète** du contenu de chaque module — pertes 0/1, espace\n",
+    "d'échantillonnage fini, générateur d'aléa déterministe — avec une **vérification\n",
+    "numérique** du théorème central : c'est le déroulé pédagogique, la section 10 est la\n",
+    "contre-vérification formelle. Les exercices se terminent par `sorry` à compléter\n",
+    "(patron du compagnon GameTheory-15b) ; le corps du notebook, lui, ne contient aucun\n",
+    "`sorry`."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "11958f3a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.011608,
+     "end_time": "2026-08-23T02:22:38.245631+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:22:38.234023+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Le cadre PAC en une phrase\n",
     "\n",
@@ -49,13 +69,242 @@
     "| 6 | `PacLearning/UnionBound.lean` | `sampleProb`, borne de l'union | 6 |\n",
     "| 7 | `PacLearning/ERM.lean` | `erm_error_bound` | 7 |\n",
     "| 8 | `PacLearning/PacFiniteBound.lean` | `pac_finite_class_bound` | 8 |\n",
+    "| + | `PacLearning/Sample.lean` | `sampleWeight`, `sampleWeight_sum_one` (loi `D^m`) | 10 |\n",
+    "| + | `PacLearning/UniformConcentration.lean` | `uniform_concentration` (borne agnostique) | 10 |\n",
     "| + | `PacLearning/Agnostic.lean` | `pac_agnostic_generalization` | 9 |"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "1c602b6a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.021056,
+     "end_time": "2026-08-23T02:22:38.298347+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:22:38.277291+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Session : le lake chargé nativement\n",
+    "\n",
+    "Avant de dérouler les briques simplifiées, la session **importe le vrai lake**. Le geste\n",
+    "a une histoire : la première mouture de ce compagnon renonçait à l'import — « les\n",
+    "`olean` du lake exigent Mathlib, non construits sur ce poste » — et redéfinissait tout\n",
+    "localement. C'est exactement le constat que le scanner de l'EPIC #11703 adresse aux\n",
+    "notebooks : des modules prouvés, cités en prose, jamais **exécutés**. Le cache\n",
+    "d'oleans est désormais construit (Mathlib v4.32.1, partagé entre les lakes du poste),\n",
+    "et l'import ci-dessous le retourne : chaque nom de déclaration utilisé dans les\n",
+    "sections suivantes renvoie maintenant à une **chose compilée**, dont `#check` rend la\n",
+    "signature exacte et `#print axioms` le certificat.\n",
+    "\n",
+    "L'import tire la chaîne des sept modules amont (`Data` → `Sample` → `SampleExpect` →\n",
+    "`MGF` → `BernoulliMGF` → `Hoeffding` → `UnionBound`) plus Mathlib. Le module\n",
+    "`UniformConcentration` — le théorème agnostique, jamais visité par aucun notebook —\n",
+    "est importé explicitement : le module racine `PacLearning.lean` est un agrégateur\n",
+    "d'imports sans déclaration propre et ne le référence pas. La cellule suivante charge\n",
+    "la session et serre la main du cadre : une `Distribution` (poids normalisés sur un\n",
+    "`Fintype`), son erreur vraie `trueError`, la probabilité d'échantillon `sampleProb` —\n",
+    "et les deux déclarations qui n'avaient jamais été citées.\n",
+    "\n",
+    "Le mécanisme de visibilité, au passage : le scanner de l'EPIC #11703 greffe le nom de\n",
+    "chaque **déclaration distinctive** du lake (longueur ≥ 10 ou contenant `_`) dans le\n",
+    "texte de tous les notebooks du dépôt ; un module dont aucune déclaration n'apparaît\n",
+    "nulle part est « noir » — prouvé mais sans lecteur. Les versions simplifiées des\n",
+    "sections 2 à 9 portent les **mêmes noms** que le lake (`markov_ineq`,\n",
+    "`hoeffding_upper_tail`, `sampleProb`…) : elles rendent les modules visibles en prose.\n",
+    "Mais `sampleWeight` et `uniform_concentration` n'existaient nulle part — d'où la\n",
+    "section 10."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4c6d5c61",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T02:22:38.359473Z",
+     "iopub.status.busy": "2026-08-23T02:22:38.359304Z",
+     "iopub.status.idle": "2026-08-23T02:22:59.557674Z",
+     "shell.execute_reply": "2026-08-23T02:22:59.556869Z"
+    },
+    "papermill": {
+     "duration": 21.231164,
+     "end_time": "2026-08-23T02:22:59.558822+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:22:38.327658+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Tete de session : le vrai lake (import en debut de fichier, pattern Lean-26).</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>UniformConcentration</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Serrement de main du cadre : chaque #check rend la signature du module compile.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>Distribution</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>:<span class=\"w\"> </span>(X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>Hypothesis</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> PacLearning<span class=\"bp\">.</span>Hypothesis<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>trueError</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>trueError<span class=\"w\"> </span>:<span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">  </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Hypothesis<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Hypothesis<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleProb</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleProb<span class=\"w\"> </span>:<span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">  </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(Q<span class=\"w\"> </span>:<span class=\"w\"> </span>(Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>X)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[DecidablePred<span class=\"w\"> </span>Q]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight<span class=\"w\"> </span>:<span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>X)<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℝ</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>uniform_concentration</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>uniform_concentration<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}\n",
+       "<span class=\"w\">  </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Hypothesis<span class=\"w\"> </span>X)<span class=\"w\"> </span>(Hs<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>(PacLearning<span class=\"bp\">.</span>Hypothesis<span class=\"w\"> </span>X))<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ},\n",
+       "<span class=\"w\">  </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">    </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{ε<span class=\"w\"> </span>:<span class=\"w\"> </span>ℝ},\n",
+       "<span class=\"w\">      </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">→</span>\n",
+       "<span class=\"w\">        </span>(PacLearning<span class=\"bp\">.</span>sampleProb<span class=\"w\"> </span>D<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Hs,<span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span><span class=\"bp\">|</span>PacLearning<span class=\"bp\">.</span>empError<span class=\"w\"> </span>f<span class=\"w\"> </span>h<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>trueError<span class=\"w\"> </span>D<span class=\"w\"> </span>f<span class=\"w\"> </span>h<span class=\"bp\">|</span>)<span class=\"w\"> </span><span class=\"bp\">≤</span>\n",
+       "<span class=\"w\">          </span><span class=\"bp\">↑</span>Hs<span class=\"bp\">.</span>card<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Real<span class=\"bp\">.</span>exp<span class=\"w\"> </span>(<span class=\"bp\">-</span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"bp\">↑</span>n<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>ε<span class=\"w\"> </span><span class=\"bp\">^</span><span class=\"w\"> </span><span class=\"mi\">2</span>)))</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Tete de session : le vrai lake (import en debut de fichier, pattern Lean-26).\\nimport PacLearning.UniformConcentration\\n\\n-- Serrement de main du cadre : chaque #check rend la signature du module compile.\\n#check @PacLearning.Distribution\\n#check @PacLearning.Hypothesis\\n#check @PacLearning.trueError\\n#check @PacLearning.sampleProb\\n#check @PacLearning.sampleWeight\\n#check @PacLearning.uniform_concentration\"}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"PacLearning.Distribution : (X : Type u_1) → [Fintype X] → Type u_1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\": \"PacLearning.Hypothesis : Type u_1 → Type u_1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.trueError : {X : Type u_1} →\\n  [inst : Fintype X] → PacLearning.Distribution X → PacLearning.Hypothesis X → PacLearning.Hypothesis X → ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.sampleProb : {X : Type u_1} →\\n  [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Q : (Fin n → X) → Prop) → [DecidablePred Q] → ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 9, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.sampleWeight : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Fin n → X) → ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X}\\n  (f : PacLearning.Hypothesis X) (Hs : Finset (PacLearning.Hypothesis X)) {n : ℕ},\\n  0 < n →\\n    ∀ {ε : ℝ},\\n      0 < ε →\\n        (PacLearning.sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |PacLearning.empError f h S - PacLearning.trueError D f h|) ≤\\n          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\"}],\r\n",
+       " \"env\": 0}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Tete de session : le vrai lake (import en debut de fichier, pattern Lean-26).\n",
+       "import PacLearning.UniformConcentration\n",
+       "\n",
+       "-- Serrement de main du cadre : chaque #check rend la signature du module compile.\n",
+       "#check @PacLearning.Distribution\n",
+       "──────▶  PacLearning.Distribution : (X : Type u_1) → [Fintype X] → Type u_1\n",
+       "#check @PacLearning.Hypothesis\n",
+       "──────▶  PacLearning.Hypothesis : Type u_1 → Type u_1\n",
+       "#check @PacLearning.trueError\n",
+       "──────▶  @PacLearning.trueError : {X : Type u_1} →\n",
+       "  [inst : Fintype X] → PacLearning.Distribution X → PacLearning.Hypothesis X → PacLearning.Hypothesis X → ℝ\n",
+       "#check @PacLearning.sampleProb\n",
+       "──────▶  @PacLearning.sampleProb : {X : Type u_1} →\n",
+       "  [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Q : (Fin n → X) → Prop) → [DecidablePred Q] → ℝ\n",
+       "#check @PacLearning.sampleWeight\n",
+       "──────▶  @PacLearning.sampleWeight : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Fin n → X) → ℝ\n",
+       "#check @PacLearning.uniform_concentration\n",
+       "──────▶  @PacLearning.uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X}\n",
+       "  (f : PacLearning.Hypothesis X) (Hs : Finset (PacLearning.Hypothesis X)) {n : ℕ},\n",
+       "  0 < n →\n",
+       "    ∀ {ε : ℝ},\n",
+       "      0 < ε →\n",
+       "        (PacLearning.sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |PacLearning.empError f h S - PacLearning.trueError D f h|) ≤\n",
+       "          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\n",
+       "--% env 0\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Tete de session : le vrai lake (import en debut de fichier, pattern Lean-26).\\nimport PacLearning.UniformConcentration\\n\\n-- Serrement de main du cadre : chaque #check rend la signature du module compile.\\n#check @PacLearning.Distribution\\n#check @PacLearning.Hypothesis\\n#check @PacLearning.trueError\\n#check @PacLearning.sampleProb\\n#check @PacLearning.sampleWeight\\n#check @PacLearning.uniform_concentration\"}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"PacLearning.Distribution : (X : Type u_1) → [Fintype X] → Type u_1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\": \"PacLearning.Hypothesis : Type u_1 → Type u_1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.trueError : {X : Type u_1} →\\n  [inst : Fintype X] → PacLearning.Distribution X → PacLearning.Hypothesis X → PacLearning.Hypothesis X → ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.sampleProb : {X : Type u_1} →\\n  [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Q : (Fin n → X) → Prop) → [DecidablePred Q] → ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 9, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.sampleWeight : {X : Type u_1} → [inst : Fintype X] → PacLearning.Distribution X → {n : ℕ} → (Fin n → X) → ℝ\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.uniform_concentration : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X}\\n  (f : PacLearning.Hypothesis X) (Hs : Finset (PacLearning.Hypothesis X)) {n : ℕ},\\n  0 < n →\\n    ∀ {ε : ℝ},\\n      0 < ε →\\n        (PacLearning.sampleProb D fun S => ∃ h ∈ Hs, ε ≤ |PacLearning.empError f h S - PacLearning.trueError D f h|) ≤\\n          ↑Hs.card * (2 * Real.exp (-(2 * ↑n * ε ^ 2)))\"}],\r\n",
+       " \"env\": 0}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Tete de session : le vrai lake (import en debut de fichier, pattern Lean-26).\n",
+    "import PacLearning.UniformConcentration\n",
+    "\n",
+    "-- Serrement de main du cadre : chaque #check rend la signature du module compile.\n",
+    "#check @PacLearning.Distribution\n",
+    "#check @PacLearning.Hypothesis\n",
+    "#check @PacLearning.trueError\n",
+    "#check @PacLearning.sampleProb\n",
+    "#check @PacLearning.sampleWeight\n",
+    "#check @PacLearning.uniform_concentration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2dd80053",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.025504,
+     "end_time": "2026-08-23T02:22:59.597735+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:22:59.572231+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. `Concentration.lean` : l'esperance et l'inegalite de Markov\n",
     "\n",
@@ -72,15 +321,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "fb2a7d70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:37.335246Z",
-     "iopub.status.busy": "2026-08-19T08:08:37.334985Z",
-     "iopub.status.idle": "2026-08-19T08:08:37.764858Z",
-     "shell.execute_reply": "2026-08-19T08:08:37.763170Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:22:59.633036Z",
+     "iopub.status.busy": "2026-08-23T02:22:59.632844Z",
+     "iopub.status.idle": "2026-08-23T02:22:59.900714Z",
+     "shell.execute_reply": "2026-08-23T02:22:59.899595Z"
+    },
+    "papermill": {
+     "duration": 0.286401,
+     "end_time": "2026-08-23T02:22:59.901672+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:22:59.615271+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -97,30 +354,30 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 2 : version simplifiee de PacLearning/Concentration.lean (Lean 4 core, sans Mathlib)</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Esperance d&#39;une perte f sur l&#39;espace uniforme {false, true}</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">noncomputable</span><span class=\"w\"> </span><span class=\"kd\">def</span><span class=\"w\"> </span>expect<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">noncomputable</span><span class=\"w\"> </span><span class=\"kn\">def</span><span class=\"w\"> </span>expect<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (f<span class=\"w\"> </span>false<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>f<span class=\"w\"> </span>true)<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span><span class=\"mi\">2</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Markov en forme comptee : a * #{b | f b &gt;= a} &lt;= somme des f b</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- (equivalent exact de markov_ineq quand l&#39;espace est uniforme a deux points)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>markovCounted<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span><span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  a<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(List.countP<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>decide<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>f<span class=\"w\"> </span>b))<span class=\"w\"> </span>[false,<span class=\"w\"> </span>true])</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>markovCounted<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span><span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  a<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(List<span class=\"bp\">.</span>countP<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>decide<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>f<span class=\"w\"> </span>b))<span class=\"w\"> </span>[false,<span class=\"w\"> </span>true])</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">≤</span><span class=\"w\"> </span>[f<span class=\"w\"> </span>false,<span class=\"w\"> </span>f<span class=\"w\"> </span>true]<span class=\"bp\">.</span>sum</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- la forme comptee est decidable : decide la prouve sur chaque instance</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>markovCounted<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>_<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"mi\">0</span>)<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"kd\">by</span><span class=\"w\"> </span>unfold<span class=\"w\"> </span>markovCounted<span class=\"bp\">;</span><span class=\"w\"> </span>decide</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>markovCounted<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>_<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"mi\">7</span>)<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"kd\">by</span><span class=\"w\"> </span>unfold<span class=\"w\"> </span>markovCounted<span class=\"bp\">;</span><span class=\"w\"> </span>decide</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>markovCounted<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span><span class=\"k\">else</span><span class=\"w\"> </span><span class=\"mi\">0</span>)<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"kd\">by</span><span class=\"w\"> </span>unfold<span class=\"w\"> </span>markovCounted<span class=\"bp\">;</span><span class=\"w\"> </span>decide</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>markovCounted<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span><span class=\"mi\">5</span><span class=\"w\"> </span><span class=\"k\">else</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"kd\">by</span><span class=\"w\"> </span>unfold<span class=\"w\"> </span>markovCounted<span class=\"bp\">;</span><span class=\"w\"> </span>decide</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>markovCounted<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span><span class=\"bp\">_</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"mi\">0</span>)<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span><span class=\"w\"> </span>unfold<span class=\"w\"> </span>markovCounted<span class=\"bp\">;</span><span class=\"w\"> </span>decide</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>markovCounted<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span><span class=\"bp\">_</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"mi\">7</span>)<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span><span class=\"w\"> </span>unfold<span class=\"w\"> </span>markovCounted<span class=\"bp\">;</span><span class=\"w\"> </span>decide</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>markovCounted<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span><span class=\"k\">else</span><span class=\"w\"> </span><span class=\"mi\">0</span>)<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span><span class=\"w\"> </span>unfold<span class=\"w\"> </span>markovCounted<span class=\"bp\">;</span><span class=\"w\"> </span>decide</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>markovCounted<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span><span class=\"mi\">5</span><span class=\"w\"> </span><span class=\"k\">else</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span><span class=\"w\"> </span>unfold<span class=\"w\"> </span>markovCounted<span class=\"bp\">;</span><span class=\"w\"> </span>decide</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Section 2 : version simplifiee de PacLearning/Concentration.lean (Lean 4 core, sans Mathlib)\\n-- Esperance d'une perte f sur l'espace uniforme {false, true}\\nnoncomputable def expect (f : Bool \\u2192 Float) : Float :=\\n  (f false + f true) / 2\\n\\n-- Markov en forme comptee : a * #{b | f b >= a} <= somme des f b\\n-- (equivalent exact de markov_ineq quand l'espace est uniforme a deux points)\\ndef markovCounted (f : Bool \\u2192 Nat) (a : Nat) : Prop :=\\n  a * (List.countP (fun b => decide (a \\u2264 f b)) [false, true])\\n    \\u2264 [f false, f true].sum\\n\\n-- la forme comptee est decidable : decide la prouve sur chaque instance\\nexample : markovCounted (fun _ => 0) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun _ => 7) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun b => if b then 3 else 0) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun b => if b then 5 else 1) 2 := by unfold markovCounted; decide\\n\"}</code>\n",
+       "            <code>{\"cmd\": \"-- Section 2 : version simplifiee de PacLearning/Concentration.lean (Lean 4 core, sans Mathlib)\\n-- Esperance d'une perte f sur l'espace uniforme {false, true}\\nnoncomputable def expect (f : Bool \\u2192 Float) : Float :=\\n  (f false + f true) / 2\\n\\n-- Markov en forme comptee : a * #{b | f b >= a} <= somme des f b\\n-- (equivalent exact de markov_ineq quand l'espace est uniforme a deux points)\\ndef markovCounted (f : Bool \\u2192 Nat) (a : Nat) : Prop :=\\n  a * (List.countP (fun b => decide (a \\u2264 f b)) [false, true])\\n    \\u2264 [f false, f true].sum\\n\\n-- la forme comptee est decidable : decide la prouve sur chaque instance\\nexample : markovCounted (fun _ => 0) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun _ => 7) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun b => if b then 3 else 0) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun b => if b then 5 else 1) 2 := by unfold markovCounted; decide\\n\", \"env\": 0}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
-       "            <code>{\"env\": 0}</code>\n",
+       "            <code>{\"env\": 1}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -142,12 +399,12 @@
        "example : markovCounted (fun b => if b then 3 else 0) 1 := by unfold markovCounted; decide\n",
        "example : markovCounted (fun b => if b then 5 else 1) 2 := by unfold markovCounted; decide\n",
        "\n",
-       "--% env 0\n",
+       "--% env 1\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Section 2 : version simplifiee de PacLearning/Concentration.lean (Lean 4 core, sans Mathlib)\\n-- Esperance d'une perte f sur l'espace uniforme {false, true}\\nnoncomputable def expect (f : Bool \\u2192 Float) : Float :=\\n  (f false + f true) / 2\\n\\n-- Markov en forme comptee : a * #{b | f b >= a} <= somme des f b\\n-- (equivalent exact de markov_ineq quand l'espace est uniforme a deux points)\\ndef markovCounted (f : Bool \\u2192 Nat) (a : Nat) : Prop :=\\n  a * (List.countP (fun b => decide (a \\u2264 f b)) [false, true])\\n    \\u2264 [f false, f true].sum\\n\\n-- la forme comptee est decidable : decide la prouve sur chaque instance\\nexample : markovCounted (fun _ => 0) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun _ => 7) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun b => if b then 3 else 0) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun b => if b then 5 else 1) 2 := by unfold markovCounted; decide\\n\"}\n",
+       "{\"cmd\": \"-- Section 2 : version simplifiee de PacLearning/Concentration.lean (Lean 4 core, sans Mathlib)\\n-- Esperance d'une perte f sur l'espace uniforme {false, true}\\nnoncomputable def expect (f : Bool \\u2192 Float) : Float :=\\n  (f false + f true) / 2\\n\\n-- Markov en forme comptee : a * #{b | f b >= a} <= somme des f b\\n-- (equivalent exact de markov_ineq quand l'espace est uniforme a deux points)\\ndef markovCounted (f : Bool \\u2192 Nat) (a : Nat) : Prop :=\\n  a * (List.countP (fun b => decide (a \\u2264 f b)) [false, true])\\n    \\u2264 [f false, f true].sum\\n\\n-- la forme comptee est decidable : decide la prouve sur chaque instance\\nexample : markovCounted (fun _ => 0) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun _ => 7) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun b => if b then 3 else 0) 1 := by unfold markovCounted; decide\\nexample : markovCounted (fun b => if b then 5 else 1) 2 := by unfold markovCounted; decide\\n\", \"env\": 0}\n",
        "Raw output:\n",
-       "{\"env\": 0}"
+       "{\"env\": 1}"
       ]
      },
      "metadata": {},
@@ -176,7 +433,16 @@
   {
    "cell_type": "markdown",
    "id": "39b06518",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.020336,
+     "end_time": "2026-08-23T02:22:59.933964+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:22:59.913628+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Les quatre instances ci-dessus sont prouvees par `decide` : le evaluateur les verifie\n",
     "case par case. L'egalite generale -- pour toute perte et tout seuil -- est le\n",
@@ -186,7 +452,16 @@
   {
    "cell_type": "markdown",
    "id": "0a214bdb",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.019755,
+     "end_time": "2026-08-23T02:22:59.967261+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:22:59.947506+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. `SampleExpect.lean` : l'erreur empirique\n",
     "\n",
@@ -201,15 +476,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "49cb78fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:37.767536Z",
-     "iopub.status.busy": "2026-08-19T08:08:37.767343Z",
-     "iopub.status.idle": "2026-08-19T08:08:37.976131Z",
-     "shell.execute_reply": "2026-08-19T08:08:37.974136Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:23:00.007809Z",
+     "iopub.status.busy": "2026-08-23T02:23:00.007575Z",
+     "iopub.status.idle": "2026-08-23T02:23:00.285660Z",
+     "shell.execute_reply": "2026-08-23T02:23:00.284840Z"
+    },
+    "papermill": {
+     "duration": 0.300053,
+     "end_time": "2026-08-23T02:23:00.286167+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:22:59.986114+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -227,30 +510,30 @@
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 3 : version simplifiee de PacLearning/SampleExpect.lean</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Generateur congruentiel minimal deterministe</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>lcgNext<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=<span class=\"w\"> </span>(<span class=\"mi\">1103515245</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>s<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">12345</span>)<span class=\"w\"> </span><span class=\"bp\">%</span><span class=\"w\"> </span><span class=\"mi\">2147483648</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>lcgNext<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=<span class=\"w\"> </span>(<span class=\"mi\">1103515245</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>s<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">12345</span>)<span class=\"w\"> </span><span class=\"bp\">%</span><span class=\"w\"> </span><span class=\"mi\">2147483648</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>sampleOfSeed<span class=\"w\"> </span>(seed<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(m<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>sampleOfSeed<span class=\"w\"> </span>(seed<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(m<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">let</span><span class=\"w\"> </span>rec<span class=\"w\"> </span>go<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(k<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(acc<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"k\">match</span><span class=\"w\"> </span>k<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>acc.reverse</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>k<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>go<span class=\"w\"> </span>(lcgNext<span class=\"w\"> </span>s)<span class=\"w\"> </span>k<span class=\"w\"> </span>((s<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span><span class=\"mi\">65536</span>)<span class=\"w\"> </span><span class=\"bp\">%</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span>::<span class=\"w\"> </span>acc)<span class=\"w\">  </span><span class=\"c1\">-- bit 16 : le bit 0 du LCG alterne strictement (parite de ax+b)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>acc<span class=\"bp\">.</span>reverse</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>k<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>go<span class=\"w\"> </span>(lcgNext<span class=\"w\"> </span>s)<span class=\"w\"> </span>k<span class=\"w\"> </span>((s<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span><span class=\"mi\">65536</span>)<span class=\"w\"> </span><span class=\"bp\">%</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">::</span><span class=\"w\"> </span>acc)<span class=\"w\">  </span><span class=\"c1\">-- bit 16 : le bit 0 du LCG alterne strictement (parite de ax+b)</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  go<span class=\"w\"> </span>seed<span class=\"w\"> </span>m<span class=\"w\"> </span>[]</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- sampleExpect : erreur empirique = frequence de pertes 1 sur l&#39;echantillon</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>sampleExpect<span class=\"w\"> </span>(loss<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  Float.ofNat<span class=\"w\"> </span>loss.sum<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>Float.ofNat<span class=\"w\"> </span>loss.length</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>sampleExpect<span class=\"w\"> </span>(loss<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>loss<span class=\"bp\">.</span>sum<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>loss<span class=\"bp\">.</span>length</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- sampleExpect_nonneg, forme comptee : la somme d&#39;erreurs nat est &gt;= 0 (trivial en Nat)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">theorem</span><span class=\"w\"> </span>sampleExpect_nonneg_counted<span class=\"w\"> </span>(loss<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>loss.sum<span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  Nat.zero_le<span class=\"w\"> </span>_</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>sampleExpect_nonneg_counted<span class=\"w\"> </span>(loss<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>loss<span class=\"bp\">.</span>sum<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  Nat<span class=\"bp\">.</span>zero_le<span class=\"w\"> </span><span class=\"bp\">_</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"k\">#eval</span><span class=\"w\"> </span>sampleOfSeed<span class=\"w\"> </span><span class=\"mi\">42</span><span class=\"w\"> </span><span class=\"mi\">20</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> [<span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>]</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"k\">#eval</span><span class=\"w\"> </span>sampleExpect<span class=\"w\"> </span>(sampleOfSeed<span class=\"w\"> </span><span class=\"mi\">42</span><span class=\"w\"> </span><span class=\"mi\">1000</span>)<span class=\"w\">  </span><span class=\"c1\">-- frequence de 1, seed 42</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">511000</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>sampleOfSeed<span class=\"w\"> </span><span class=\"mi\">42</span><span class=\"w\"> </span><span class=\"mi\">20</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> [<span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">1</span>]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>sampleExpect<span class=\"w\"> </span>(sampleOfSeed<span class=\"w\"> </span><span class=\"mi\">42</span><span class=\"w\"> </span><span class=\"mi\">1000</span>)<span class=\"w\">  </span><span class=\"c1\">-- frequence de 1, seed 42</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.511000</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Section 3 : version simplifiee de PacLearning/SampleExpect.lean\\n\\n-- Generateur congruentiel minimal deterministe\\ndef lcgNext (s : Nat) : Nat := (1103515245 * s + 12345) % 2147483648\\n\\ndef sampleOfSeed (seed : Nat) (m : Nat) : List Nat :=\\n  let rec go (s : Nat) (k : Nat) (acc : List Nat) : List Nat :=\\n    match k with\\n    | 0 => acc.reverse\\n    | k + 1 => go (lcgNext s) k ((s / 65536) % 2 :: acc)  -- bit 16 : le bit 0 du LCG alterne strictement (parite de ax+b)\\n  go seed m []\\n\\n-- sampleExpect : erreur empirique = frequence de pertes 1 sur l'echantillon\\ndef sampleExpect (loss : List Nat) : Float :=\\n  Float.ofNat loss.sum / Float.ofNat loss.length\\n\\n-- sampleExpect_nonneg, forme comptee : la somme d'erreurs nat est >= 0 (trivial en Nat)\\ntheorem sampleExpect_nonneg_counted (loss : List Nat) : 0 \\u2264 loss.sum :=\\n  Nat.zero_le _\\n\\n#eval sampleOfSeed 42 20\\n#eval sampleExpect (sampleOfSeed 42 1000)  -- frequence de 1, seed 42\", \"env\": 0}</code>\n",
+       "            <code>{\"cmd\": \"-- Section 3 : version simplifiee de PacLearning/SampleExpect.lean\\n\\n-- Generateur congruentiel minimal deterministe\\ndef lcgNext (s : Nat) : Nat := (1103515245 * s + 12345) % 2147483648\\n\\ndef sampleOfSeed (seed : Nat) (m : Nat) : List Nat :=\\n  let rec go (s : Nat) (k : Nat) (acc : List Nat) : List Nat :=\\n    match k with\\n    | 0 => acc.reverse\\n    | k + 1 => go (lcgNext s) k ((s / 65536) % 2 :: acc)  -- bit 16 : le bit 0 du LCG alterne strictement (parite de ax+b)\\n  go seed m []\\n\\n-- sampleExpect : erreur empirique = frequence de pertes 1 sur l'echantillon\\ndef sampleExpect (loss : List Nat) : Float :=\\n  Float.ofNat loss.sum / Float.ofNat loss.length\\n\\n-- sampleExpect_nonneg, forme comptee : la somme d'erreurs nat est >= 0 (trivial en Nat)\\ntheorem sampleExpect_nonneg_counted (loss : List Nat) : 0 \\u2264 loss.sum :=\\n  Nat.zero_le _\\n\\n#eval sampleOfSeed 42 20\\n#eval sampleExpect (sampleOfSeed 42 1000)  -- frequence de 1, seed 42\", \"env\": 1}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -263,7 +546,7 @@
        "   \"pos\": {\"line\": 22, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 22, \"column\": 5},\r\n",
        "   \"data\": \"0.511000\"}],\r\n",
-       " \"env\": 1}</code>\n",
+       " \"env\": 2}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -292,10 +575,10 @@
        "─────▶  [0, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1]\n",
        "#eval sampleExpect (sampleOfSeed 42 1000)  -- frequence de 1, seed 42\n",
        "─────▶  0.511000\n",
-       "--% env 1\n",
+       "--% env 2\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Section 3 : version simplifiee de PacLearning/SampleExpect.lean\\n\\n-- Generateur congruentiel minimal deterministe\\ndef lcgNext (s : Nat) : Nat := (1103515245 * s + 12345) % 2147483648\\n\\ndef sampleOfSeed (seed : Nat) (m : Nat) : List Nat :=\\n  let rec go (s : Nat) (k : Nat) (acc : List Nat) : List Nat :=\\n    match k with\\n    | 0 => acc.reverse\\n    | k + 1 => go (lcgNext s) k ((s / 65536) % 2 :: acc)  -- bit 16 : le bit 0 du LCG alterne strictement (parite de ax+b)\\n  go seed m []\\n\\n-- sampleExpect : erreur empirique = frequence de pertes 1 sur l'echantillon\\ndef sampleExpect (loss : List Nat) : Float :=\\n  Float.ofNat loss.sum / Float.ofNat loss.length\\n\\n-- sampleExpect_nonneg, forme comptee : la somme d'erreurs nat est >= 0 (trivial en Nat)\\ntheorem sampleExpect_nonneg_counted (loss : List Nat) : 0 \\u2264 loss.sum :=\\n  Nat.zero_le _\\n\\n#eval sampleOfSeed 42 20\\n#eval sampleExpect (sampleOfSeed 42 1000)  -- frequence de 1, seed 42\", \"env\": 0}\n",
+       "{\"cmd\": \"-- Section 3 : version simplifiee de PacLearning/SampleExpect.lean\\n\\n-- Generateur congruentiel minimal deterministe\\ndef lcgNext (s : Nat) : Nat := (1103515245 * s + 12345) % 2147483648\\n\\ndef sampleOfSeed (seed : Nat) (m : Nat) : List Nat :=\\n  let rec go (s : Nat) (k : Nat) (acc : List Nat) : List Nat :=\\n    match k with\\n    | 0 => acc.reverse\\n    | k + 1 => go (lcgNext s) k ((s / 65536) % 2 :: acc)  -- bit 16 : le bit 0 du LCG alterne strictement (parite de ax+b)\\n  go seed m []\\n\\n-- sampleExpect : erreur empirique = frequence de pertes 1 sur l'echantillon\\ndef sampleExpect (loss : List Nat) : Float :=\\n  Float.ofNat loss.sum / Float.ofNat loss.length\\n\\n-- sampleExpect_nonneg, forme comptee : la somme d'erreurs nat est >= 0 (trivial en Nat)\\ntheorem sampleExpect_nonneg_counted (loss : List Nat) : 0 \\u2264 loss.sum :=\\n  Nat.zero_le _\\n\\n#eval sampleOfSeed 42 20\\n#eval sampleExpect (sampleOfSeed 42 1000)  -- frequence de 1, seed 42\", \"env\": 1}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
@@ -306,7 +589,7 @@
        "   \"pos\": {\"line\": 22, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 22, \"column\": 5},\r\n",
        "   \"data\": \"0.511000\"}],\r\n",
-       " \"env\": 1}"
+       " \"env\": 2}"
       ]
      },
      "metadata": {},
@@ -341,7 +624,16 @@
   {
    "cell_type": "markdown",
    "id": "b7390996",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.02181,
+     "end_time": "2026-08-23T02:23:00.324588+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:00.302778+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "La monotonie (`sampleExpect_mono` : si `h1` fait au moins autant d'erreurs que `h2`\n",
     "point a point, son erreur empirique est plus grande) et la linearite\n",
@@ -352,7 +644,16 @@
   {
    "cell_type": "markdown",
    "id": "a508deec",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.025846,
+     "end_time": "2026-08-23T02:23:00.371514+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:00.345668+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. `MGF.lean` et `BernoulliMGF.lean` : la fonction generatrice des moments\n",
     "\n",
@@ -372,15 +673,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "b2b63745",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:37.979817Z",
-     "iopub.status.busy": "2026-08-19T08:08:37.979397Z",
-     "iopub.status.idle": "2026-08-19T08:08:38.136669Z",
-     "shell.execute_reply": "2026-08-19T08:08:38.135017Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:23:00.420753Z",
+     "iopub.status.busy": "2026-08-23T02:23:00.420578Z",
+     "iopub.status.idle": "2026-08-23T02:23:00.664798Z",
+     "shell.execute_reply": "2026-08-23T02:23:00.663724Z"
+    },
+    "papermill": {
+     "duration": 0.269605,
+     "end_time": "2026-08-23T02:23:00.665432+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:00.395827+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -397,32 +706,32 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 4 : verification numerique de bernoulli_mgf_half_le</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>powNaive<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>powNaive<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"mi\">1</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>powNaive<span class=\"w\"> </span>x<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>x</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>factNaive<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>factNaive<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"mi\">1</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>Float.ofNat<span class=\"w\"> </span>(n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>factNaive<span class=\"w\"> </span>n</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>(n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>factNaive<span class=\"w\"> </span>n</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- exp approchee par serie tronquee d&#39;ordre 12 (suffisante pour |x| &lt; 3)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>expApprox<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (List.range<span class=\"w\"> </span><span class=\"mi\">13</span>)<span class=\"bp\">.</span>foldl<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>acc<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>acc<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>powNaive<span class=\"w\"> </span>x<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>factNaive<span class=\"w\"> </span>n)<span class=\"w\"> </span><span class=\"mi\">0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>expApprox<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (List<span class=\"bp\">.</span>range<span class=\"w\"> </span><span class=\"mi\">13</span>)<span class=\"bp\">.</span>foldl<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>acc<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>acc<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>powNaive<span class=\"w\"> </span>x<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>factNaive<span class=\"w\"> </span>n)<span class=\"w\"> </span><span class=\"mi\">0</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- MGF centree d&#39;une Bernoulli(p) : E[exp(λ (X - p))]</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>mgfBernoulli<span class=\"w\"> </span>(p<span class=\"w\"> </span>lambda<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>mgfBernoulli<span class=\"w\"> </span>(p<span class=\"w\"> </span>lambda<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (<span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>p)<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>expApprox<span class=\"w\"> </span>(lambda<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(<span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>p))<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>expApprox<span class=\"w\"> </span>(lambda<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(<span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>p))</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- la borne de bernoulli_mgf_half_le</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>boundHalf<span class=\"w\"> </span>(lambda<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=<span class=\"w\"> </span>expApprox<span class=\"w\"> </span>(lambda<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>lambda<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span><span class=\"mi\">8</span>)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>boundHalf<span class=\"w\"> </span>(lambda<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=<span class=\"w\"> </span>expApprox<span class=\"w\"> </span>(lambda<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>lambda<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span><span class=\"mi\">8</span>)</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"k\">#eval</span><span class=\"w\"> </span>mgfBernoulli<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">3</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"bp\">.</span><span class=\"mi\">0</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">1</span><span class=\"bp\">.</span><span class=\"mi\">122699</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"k\">#eval</span><span class=\"w\"> </span>boundHalf<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"bp\">.</span><span class=\"mi\">0</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">1</span><span class=\"bp\">.</span><span class=\"mi\">133148</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>mgfBernoulli<span class=\"w\"> </span><span class=\"mf\">0.3</span><span class=\"w\"> </span><span class=\"mf\">1.0</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">1.122699</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>boundHalf<span class=\"w\"> </span><span class=\"mf\">1.0</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">1.133148</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Section 4 : verification numerique de bernoulli_mgf_half_le\\n\\ndef powNaive (x : Float) : Nat \\u2192 Float\\n  | 0 => 1\\n  | n + 1 => powNaive x n * x\\n\\ndef factNaive : Nat \\u2192 Float\\n  | 0 => 1\\n  | n + 1 => Float.ofNat (n + 1) * factNaive n\\n\\n-- exp approchee par serie tronquee d'ordre 12 (suffisante pour |x| < 3)\\ndef expApprox (x : Float) : Float :=\\n  (List.range 13).foldl (fun acc n => acc + powNaive x n / factNaive n) 0\\n\\n-- MGF centree d'une Bernoulli(p) : E[exp(\\u03bb (X - p))]\\ndef mgfBernoulli (p lambda : Float) : Float :=\\n  (1 - p) * expApprox (lambda * (0 - p)) + p * expApprox (lambda * (1 - p))\\n\\n-- la borne de bernoulli_mgf_half_le\\ndef boundHalf (lambda : Float) : Float := expApprox (lambda * lambda / 8)\\n\\n#eval mgfBernoulli 0.3 1.0\\n#eval boundHalf 1.0\", \"env\": 1}</code>\n",
+       "            <code>{\"cmd\": \"-- Section 4 : verification numerique de bernoulli_mgf_half_le\\n\\ndef powNaive (x : Float) : Nat \\u2192 Float\\n  | 0 => 1\\n  | n + 1 => powNaive x n * x\\n\\ndef factNaive : Nat \\u2192 Float\\n  | 0 => 1\\n  | n + 1 => Float.ofNat (n + 1) * factNaive n\\n\\n-- exp approchee par serie tronquee d'ordre 12 (suffisante pour |x| < 3)\\ndef expApprox (x : Float) : Float :=\\n  (List.range 13).foldl (fun acc n => acc + powNaive x n / factNaive n) 0\\n\\n-- MGF centree d'une Bernoulli(p) : E[exp(\\u03bb (X - p))]\\ndef mgfBernoulli (p lambda : Float) : Float :=\\n  (1 - p) * expApprox (lambda * (0 - p)) + p * expApprox (lambda * (1 - p))\\n\\n-- la borne de bernoulli_mgf_half_le\\ndef boundHalf (lambda : Float) : Float := expApprox (lambda * lambda / 8)\\n\\n#eval mgfBernoulli 0.3 1.0\\n#eval boundHalf 1.0\", \"env\": 2}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -435,7 +744,7 @@
        "   \"pos\": {\"line\": 23, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 23, \"column\": 5},\r\n",
        "   \"data\": \"1.133148\"}],\r\n",
-       " \"env\": 2}</code>\n",
+       " \"env\": 3}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -465,10 +774,10 @@
        "─────▶  1.122699\n",
        "#eval boundHalf 1.0\n",
        "─────▶  1.133148\n",
-       "--% env 2\n",
+       "--% env 3\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Section 4 : verification numerique de bernoulli_mgf_half_le\\n\\ndef powNaive (x : Float) : Nat \\u2192 Float\\n  | 0 => 1\\n  | n + 1 => powNaive x n * x\\n\\ndef factNaive : Nat \\u2192 Float\\n  | 0 => 1\\n  | n + 1 => Float.ofNat (n + 1) * factNaive n\\n\\n-- exp approchee par serie tronquee d'ordre 12 (suffisante pour |x| < 3)\\ndef expApprox (x : Float) : Float :=\\n  (List.range 13).foldl (fun acc n => acc + powNaive x n / factNaive n) 0\\n\\n-- MGF centree d'une Bernoulli(p) : E[exp(\\u03bb (X - p))]\\ndef mgfBernoulli (p lambda : Float) : Float :=\\n  (1 - p) * expApprox (lambda * (0 - p)) + p * expApprox (lambda * (1 - p))\\n\\n-- la borne de bernoulli_mgf_half_le\\ndef boundHalf (lambda : Float) : Float := expApprox (lambda * lambda / 8)\\n\\n#eval mgfBernoulli 0.3 1.0\\n#eval boundHalf 1.0\", \"env\": 1}\n",
+       "{\"cmd\": \"-- Section 4 : verification numerique de bernoulli_mgf_half_le\\n\\ndef powNaive (x : Float) : Nat \\u2192 Float\\n  | 0 => 1\\n  | n + 1 => powNaive x n * x\\n\\ndef factNaive : Nat \\u2192 Float\\n  | 0 => 1\\n  | n + 1 => Float.ofNat (n + 1) * factNaive n\\n\\n-- exp approchee par serie tronquee d'ordre 12 (suffisante pour |x| < 3)\\ndef expApprox (x : Float) : Float :=\\n  (List.range 13).foldl (fun acc n => acc + powNaive x n / factNaive n) 0\\n\\n-- MGF centree d'une Bernoulli(p) : E[exp(\\u03bb (X - p))]\\ndef mgfBernoulli (p lambda : Float) : Float :=\\n  (1 - p) * expApprox (lambda * (0 - p)) + p * expApprox (lambda * (1 - p))\\n\\n-- la borne de bernoulli_mgf_half_le\\ndef boundHalf (lambda : Float) : Float := expApprox (lambda * lambda / 8)\\n\\n#eval mgfBernoulli 0.3 1.0\\n#eval boundHalf 1.0\", \"env\": 2}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
@@ -479,7 +788,7 @@
        "   \"pos\": {\"line\": 23, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 23, \"column\": 5},\r\n",
        "   \"data\": \"1.133148\"}],\r\n",
-       " \"env\": 2}"
+       " \"env\": 3}"
       ]
      },
      "metadata": {},
@@ -514,15 +823,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c80cd797",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:38.139894Z",
-     "iopub.status.busy": "2026-08-19T08:08:38.139615Z",
-     "iopub.status.idle": "2026-08-19T08:08:38.363690Z",
-     "shell.execute_reply": "2026-08-19T08:08:38.362147Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:23:00.707929Z",
+     "iopub.status.busy": "2026-08-23T02:23:00.707752Z",
+     "iopub.status.idle": "2026-08-23T02:23:00.951501Z",
+     "shell.execute_reply": "2026-08-23T02:23:00.950738Z"
+    },
+    "papermill": {
+     "duration": 0.272746,
+     "end_time": "2026-08-23T02:23:00.952601+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:00.679855+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -539,20 +856,20 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Balayage de la grille (p, λ) : la borne tient-elle partout ?</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- tolerance 1e-3 : la serie tronquee sous-estime exp de ~1e-10 sur |x| &lt; 3</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>gridOk<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Bool<span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (List.range<span class=\"w\"> </span><span class=\"mi\">11</span>)<span class=\"bp\">.</span>flatMap<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (List.range<span class=\"w\"> </span><span class=\"mi\">9</span>)<span class=\"bp\">.</span>map<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>j<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"k\">let</span><span class=\"w\"> </span>p<span class=\"w\"> </span>:=<span class=\"w\"> </span>Float.ofNat<span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span><span class=\"mi\">10</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"k\">let</span><span class=\"w\"> </span>l<span class=\"w\"> </span>:=<span class=\"w\"> </span>Float.ofNat<span class=\"w\"> </span>(j<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span><span class=\"mi\">4</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      decide<span class=\"w\"> </span>(mgfBernoulli<span class=\"w\"> </span>p<span class=\"w\"> </span>l<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>boundHalf<span class=\"w\"> </span>l<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">001</span>)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>gridOk<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Bool<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (List<span class=\"bp\">.</span>range<span class=\"w\"> </span><span class=\"mi\">11</span>)<span class=\"bp\">.</span>flatMap<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (List<span class=\"bp\">.</span>range<span class=\"w\"> </span><span class=\"mi\">9</span>)<span class=\"bp\">.</span>map<span class=\"w\"> </span><span class=\"k\">fun</span><span class=\"w\"> </span>j<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"k\">let</span><span class=\"w\"> </span>p<span class=\"w\"> </span>:=<span class=\"w\"> </span>Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span><span class=\"mi\">10</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"k\">let</span><span class=\"w\"> </span>l<span class=\"w\"> </span>:=<span class=\"w\"> </span>Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>(j<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span><span class=\"mi\">4</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      decide<span class=\"w\"> </span>(mgfBernoulli<span class=\"w\"> </span>p<span class=\"w\"> </span>l<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>boundHalf<span class=\"w\"> </span>l<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mf\">0.001</span>)</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"k\">#eval</span><span class=\"w\"> </span>gridOk.length<span class=\"w\">   </span><span class=\"c1\">-- 99 points de grille</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">99</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"k\">#eval</span><span class=\"w\"> </span>gridOk.all<span class=\"w\"> </span>(<span class=\"bp\">·</span><span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>true)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>gridOk<span class=\"bp\">.</span>length<span class=\"w\">   </span><span class=\"c1\">-- 99 points de grille</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">99</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>gridOk<span class=\"bp\">.</span>all<span class=\"w\"> </span>(<span class=\"bp\">·</span><span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span>true)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> true</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Balayage de la grille (p, \\u03bb) : la borne tient-elle partout ?\\n-- tolerance 1e-3 : la serie tronquee sous-estime exp de ~1e-10 sur |x| < 3\\ndef gridOk : List Bool :=\\n  (List.range 11).flatMap fun i =>\\n    (List.range 9).map fun j =>\\n      let p := Float.ofNat i / 10\\n      let l := Float.ofNat (j + 1) / 4\\n      decide (mgfBernoulli p l \\u2264 boundHalf l + 0.001)\\n\\n#eval gridOk.length   -- 99 points de grille\\n#eval gridOk.all (\\u00b7 == true)\", \"env\": 2}</code>\n",
+       "            <code>{\"cmd\": \"-- Balayage de la grille (p, \\u03bb) : la borne tient-elle partout ?\\n-- tolerance 1e-3 : la serie tronquee sous-estime exp de ~1e-10 sur |x| < 3\\ndef gridOk : List Bool :=\\n  (List.range 11).flatMap fun i =>\\n    (List.range 9).map fun j =>\\n      let p := Float.ofNat i / 10\\n      let l := Float.ofNat (j + 1) / 4\\n      decide (mgfBernoulli p l \\u2264 boundHalf l + 0.001)\\n\\n#eval gridOk.length   -- 99 points de grille\\n#eval gridOk.all (\\u00b7 == true)\", \"env\": 3}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -565,7 +882,7 @@
        "   \"pos\": {\"line\": 11, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 11, \"column\": 5},\r\n",
        "   \"data\": \"true\"}],\r\n",
-       " \"env\": 3}</code>\n",
+       " \"env\": 4}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -583,10 +900,10 @@
        "─────▶  99\n",
        "#eval gridOk.all (· == true)\n",
        "─────▶  true\n",
-       "--% env 3\n",
+       "--% env 4\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Balayage de la grille (p, \\u03bb) : la borne tient-elle partout ?\\n-- tolerance 1e-3 : la serie tronquee sous-estime exp de ~1e-10 sur |x| < 3\\ndef gridOk : List Bool :=\\n  (List.range 11).flatMap fun i =>\\n    (List.range 9).map fun j =>\\n      let p := Float.ofNat i / 10\\n      let l := Float.ofNat (j + 1) / 4\\n      decide (mgfBernoulli p l \\u2264 boundHalf l + 0.001)\\n\\n#eval gridOk.length   -- 99 points de grille\\n#eval gridOk.all (\\u00b7 == true)\", \"env\": 2}\n",
+       "{\"cmd\": \"-- Balayage de la grille (p, \\u03bb) : la borne tient-elle partout ?\\n-- tolerance 1e-3 : la serie tronquee sous-estime exp de ~1e-10 sur |x| < 3\\ndef gridOk : List Bool :=\\n  (List.range 11).flatMap fun i =>\\n    (List.range 9).map fun j =>\\n      let p := Float.ofNat i / 10\\n      let l := Float.ofNat (j + 1) / 4\\n      decide (mgfBernoulli p l \\u2264 boundHalf l + 0.001)\\n\\n#eval gridOk.length   -- 99 points de grille\\n#eval gridOk.all (\\u00b7 == true)\", \"env\": 3}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
@@ -597,7 +914,7 @@
        "   \"pos\": {\"line\": 11, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 11, \"column\": 5},\r\n",
        "   \"data\": \"true\"}],\r\n",
-       " \"env\": 3}"
+       " \"env\": 4}"
       ]
      },
      "metadata": {},
@@ -621,7 +938,16 @@
   {
    "cell_type": "markdown",
    "id": "067fb150",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.020108,
+     "end_time": "2026-08-23T02:23:00.986533+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:00.966425+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. `Hoeffding.lean` : la borne de concentration\n",
     "\n",
@@ -640,15 +966,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "dd78bb46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:38.366378Z",
-     "iopub.status.busy": "2026-08-19T08:08:38.366153Z",
-     "iopub.status.idle": "2026-08-19T08:08:38.877271Z",
-     "shell.execute_reply": "2026-08-19T08:08:38.875415Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:23:01.029672Z",
+     "iopub.status.busy": "2026-08-23T02:23:01.029489Z",
+     "iopub.status.idle": "2026-08-23T02:23:01.397745Z",
+     "shell.execute_reply": "2026-08-23T02:23:01.396897Z"
+    },
+    "papermill": {
+     "duration": 0.396125,
+     "end_time": "2026-08-23T02:23:01.398436+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:01.002311+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -665,23 +999,23 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 5 : Monte-Carlo seedee illustrant hoeffding_upper_tail</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>meanOf<span class=\"w\"> </span>(xs<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  Float.ofNat<span class=\"w\"> </span>xs.sum<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>Float.ofNat<span class=\"w\"> </span>xs.length</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>meanOf<span class=\"w\"> </span>(xs<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>xs<span class=\"bp\">.</span>sum<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>xs<span class=\"bp\">.</span>length</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- violation : |moyenne - 1/2| &gt; 0.1 sur un echantillon de bits uniformes seedes</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>violates<span class=\"w\"> </span>(seed<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(m<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>violates<span class=\"w\"> </span>(seed<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(m<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span>:=</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">let</span><span class=\"w\"> </span>bits<span class=\"w\"> </span>:=<span class=\"w\"> </span>sampleOfSeed<span class=\"w\"> </span>seed<span class=\"w\"> </span>m</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">let</span><span class=\"w\"> </span>d<span class=\"w\"> </span>:=<span class=\"w\"> </span>meanOf<span class=\"w\"> </span>bits<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">5</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  decide<span class=\"w\"> </span>(d<span class=\"w\"> </span><span class=\"bp\">&gt;</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">||</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>d<span class=\"w\"> </span><span class=\"bp\">&gt;</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">1</span>)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">let</span><span class=\"w\"> </span>d<span class=\"w\"> </span>:=<span class=\"w\"> </span>meanOf<span class=\"w\"> </span>bits<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span><span class=\"mf\">0.5</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  decide<span class=\"w\"> </span>(d<span class=\"w\"> </span><span class=\"bp\">&gt;</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\"> </span><span class=\"bp\">||</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>d<span class=\"w\"> </span><span class=\"bp\">&gt;</span><span class=\"w\"> </span><span class=\"mf\">0.1</span>)</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"k\">#eval</span><span class=\"w\"> </span>(List.range<span class=\"w\"> </span><span class=\"mi\">2000</span>)<span class=\"bp\">.</span>countP<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>violates<span class=\"w\"> </span>(i<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"mi\">7919</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">42</span>)<span class=\"w\"> </span><span class=\"mi\">200</span>)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">3</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>(List<span class=\"bp\">.</span>range<span class=\"w\"> </span><span class=\"mi\">2000</span>)<span class=\"bp\">.</span>countP<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>i<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>violates<span class=\"w\"> </span>(i<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"mi\">7919</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">42</span>)<span class=\"w\"> </span><span class=\"mi\">200</span>)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">3</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- violations observees sur 2000 essais, m = 200, eps = 0.1</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- (borne de Hoeffding : ~1.8% par cote, les deux cotes jusqu&#39;a ~3.6%)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Section 5 : Monte-Carlo seedee illustrant hoeffding_upper_tail\\n\\ndef meanOf (xs : List Nat) : Float :=\\n  Float.ofNat xs.sum / Float.ofNat xs.length\\n\\n-- violation : |moyenne - 1/2| > 0.1 sur un echantillon de bits uniformes seedes\\ndef violates (seed : Nat) (m : Nat) : Bool :=\\n  let bits := sampleOfSeed seed m\\n  let d := meanOf bits - 0.5\\n  decide (d > 0.1 || 0 - d > 0.1)\\n\\n#eval (List.range 2000).countP (fun i => violates (i * 7919 + 42) 200)\\n-- violations observees sur 2000 essais, m = 200, eps = 0.1\\n-- (borne de Hoeffding : ~1.8% par cote, les deux cotes jusqu'a ~3.6%)\", \"env\": 3}</code>\n",
+       "            <code>{\"cmd\": \"-- Section 5 : Monte-Carlo seedee illustrant hoeffding_upper_tail\\n\\ndef meanOf (xs : List Nat) : Float :=\\n  Float.ofNat xs.sum / Float.ofNat xs.length\\n\\n-- violation : |moyenne - 1/2| > 0.1 sur un echantillon de bits uniformes seedes\\ndef violates (seed : Nat) (m : Nat) : Bool :=\\n  let bits := sampleOfSeed seed m\\n  let d := meanOf bits - 0.5\\n  decide (d > 0.1 || 0 - d > 0.1)\\n\\n#eval (List.range 2000).countP (fun i => violates (i * 7919 + 42) 200)\\n-- violations observees sur 2000 essais, m = 200, eps = 0.1\\n-- (borne de Hoeffding : ~1.8% par cote, les deux cotes jusqu'a ~3.6%)\", \"env\": 4}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -690,7 +1024,7 @@
        "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 12, \"column\": 5},\r\n",
        "   \"data\": \"3\"}],\r\n",
-       " \"env\": 4}</code>\n",
+       " \"env\": 5}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -710,17 +1044,17 @@
        "─────▶  3\n",
        "-- violations observees sur 2000 essais, m = 200, eps = 0.1\n",
        "-- (borne de Hoeffding : ~1.8% par cote, les deux cotes jusqu'a ~3.6%)\n",
-       "--% env 4\n",
+       "--% env 5\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Section 5 : Monte-Carlo seedee illustrant hoeffding_upper_tail\\n\\ndef meanOf (xs : List Nat) : Float :=\\n  Float.ofNat xs.sum / Float.ofNat xs.length\\n\\n-- violation : |moyenne - 1/2| > 0.1 sur un echantillon de bits uniformes seedes\\ndef violates (seed : Nat) (m : Nat) : Bool :=\\n  let bits := sampleOfSeed seed m\\n  let d := meanOf bits - 0.5\\n  decide (d > 0.1 || 0 - d > 0.1)\\n\\n#eval (List.range 2000).countP (fun i => violates (i * 7919 + 42) 200)\\n-- violations observees sur 2000 essais, m = 200, eps = 0.1\\n-- (borne de Hoeffding : ~1.8% par cote, les deux cotes jusqu'a ~3.6%)\", \"env\": 3}\n",
+       "{\"cmd\": \"-- Section 5 : Monte-Carlo seedee illustrant hoeffding_upper_tail\\n\\ndef meanOf (xs : List Nat) : Float :=\\n  Float.ofNat xs.sum / Float.ofNat xs.length\\n\\n-- violation : |moyenne - 1/2| > 0.1 sur un echantillon de bits uniformes seedes\\ndef violates (seed : Nat) (m : Nat) : Bool :=\\n  let bits := sampleOfSeed seed m\\n  let d := meanOf bits - 0.5\\n  decide (d > 0.1 || 0 - d > 0.1)\\n\\n#eval (List.range 2000).countP (fun i => violates (i * 7919 + 42) 200)\\n-- violations observees sur 2000 essais, m = 200, eps = 0.1\\n-- (borne de Hoeffding : ~1.8% par cote, les deux cotes jusqu'a ~3.6%)\", \"env\": 4}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 12, \"column\": 5},\r\n",
        "   \"data\": \"3\"}],\r\n",
-       " \"env\": 4}"
+       " \"env\": 5}"
       ]
      },
      "metadata": {},
@@ -747,7 +1081,16 @@
   {
    "cell_type": "markdown",
    "id": "a5d2899b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.02401,
+     "end_time": "2026-08-23T02:23:01.437349+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:01.413339+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. `UnionBound.lean` : uniformiser sur une classe finie\n",
     "\n",
@@ -760,15 +1103,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "669e68e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:38.880418Z",
-     "iopub.status.busy": "2026-08-19T08:08:38.880168Z",
-     "iopub.status.idle": "2026-08-19T08:08:39.022426Z",
-     "shell.execute_reply": "2026-08-19T08:08:39.020536Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:23:01.479313Z",
+     "iopub.status.busy": "2026-08-23T02:23:01.479137Z",
+     "iopub.status.idle": "2026-08-23T02:23:01.724817Z",
+     "shell.execute_reply": "2026-08-23T02:23:01.723810Z"
+    },
+    "papermill": {
+     "duration": 0.267338,
+     "end_time": "2026-08-23T02:23:01.725427+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:01.458089+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -786,20 +1137,20 @@
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 6 : borne de l&#39;union, version jouable</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- probabilite d&#39;au moins un defaut (independants) : 1 - produit des (1 - p)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>atLeastOne<span class=\"w\"> </span>(probs<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>probs.foldl<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>acc<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>acc<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(<span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>p))<span class=\"w\"> </span><span class=\"mi\">1</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>atLeastOne<span class=\"w\"> </span>(probs<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>probs<span class=\"bp\">.</span>foldl<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>acc<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>acc<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(<span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>p))<span class=\"w\"> </span><span class=\"mi\">1</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- borne de l&#39;union : la somme</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>unionBound<span class=\"w\"> </span>(probs<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=<span class=\"w\"> </span>probs.sum</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>unionBound<span class=\"w\"> </span>(probs<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=<span class=\"w\"> </span>probs<span class=\"bp\">.</span>sum</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"k\">#eval</span><span class=\"w\"> </span>atLeastOne<span class=\"w\"> </span>[<span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">01</span>,<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">02</span>,<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">005</span>]</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">034651</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"k\">#eval</span><span class=\"w\"> </span>unionBound<span class=\"w\"> </span>[<span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">01</span>,<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">02</span>,<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">005</span>]<span class=\"w\">       </span><span class=\"c1\">-- &gt;= atLeastOne : c&#39;est une borne</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">035000</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"k\">#eval</span><span class=\"w\"> </span>unionBound<span class=\"w\"> </span>(List.replicate<span class=\"w\"> </span><span class=\"mi\">10</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">01</span>)<span class=\"w\">   </span><span class=\"c1\">-- 10 hypotheses a 1% : 10% au lieu de 9.6%</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">100000</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>atLeastOne<span class=\"w\"> </span>[<span class=\"mf\">0.01</span>,<span class=\"w\"> </span><span class=\"mf\">0.02</span>,<span class=\"w\"> </span><span class=\"mf\">0.005</span>]</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.034651</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>unionBound<span class=\"w\"> </span>[<span class=\"mf\">0.01</span>,<span class=\"w\"> </span><span class=\"mf\">0.02</span>,<span class=\"w\"> </span><span class=\"mf\">0.005</span>]<span class=\"w\">       </span><span class=\"c1\">-- &gt;= atLeastOne : c&#39;est une borne</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.035000</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>unionBound<span class=\"w\"> </span>(List<span class=\"bp\">.</span>replicate<span class=\"w\"> </span><span class=\"mi\">10</span><span class=\"w\"> </span><span class=\"mf\">0.01</span>)<span class=\"w\">   </span><span class=\"c1\">-- 10 hypotheses a 1% : 10% au lieu de 9.6%</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.100000</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Section 6 : borne de l'union, version jouable\\n\\n-- probabilite d'au moins un defaut (independants) : 1 - produit des (1 - p)\\ndef atLeastOne (probs : List Float) : Float :=\\n  1 - probs.foldl (fun acc p => acc * (1 - p)) 1\\n\\n-- borne de l'union : la somme\\ndef unionBound (probs : List Float) : Float := probs.sum\\n\\n#eval atLeastOne [0.01, 0.02, 0.005]\\n#eval unionBound [0.01, 0.02, 0.005]       -- >= atLeastOne : c'est une borne\\n#eval unionBound (List.replicate 10 0.01)   -- 10 hypotheses a 1% : 10% au lieu de 9.6%\", \"env\": 4}</code>\n",
+       "            <code>{\"cmd\": \"-- Section 6 : borne de l'union, version jouable\\n\\n-- probabilite d'au moins un defaut (independants) : 1 - produit des (1 - p)\\ndef atLeastOne (probs : List Float) : Float :=\\n  1 - probs.foldl (fun acc p => acc * (1 - p)) 1\\n\\n-- borne de l'union : la somme\\ndef unionBound (probs : List Float) : Float := probs.sum\\n\\n#eval atLeastOne [0.01, 0.02, 0.005]\\n#eval unionBound [0.01, 0.02, 0.005]       -- >= atLeastOne : c'est une borne\\n#eval unionBound (List.replicate 10 0.01)   -- 10 hypotheses a 1% : 10% au lieu de 9.6%\", \"env\": 5}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -816,7 +1167,7 @@
        "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 12, \"column\": 5},\r\n",
        "   \"data\": \"0.100000\"}],\r\n",
-       " \"env\": 5}</code>\n",
+       " \"env\": 6}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -836,10 +1187,10 @@
        "─────▶  0.035000\n",
        "#eval unionBound (List.replicate 10 0.01)   -- 10 hypotheses a 1% : 10% au lieu de 9.6%\n",
        "─────▶  0.100000\n",
-       "--% env 5\n",
+       "--% env 6\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Section 6 : borne de l'union, version jouable\\n\\n-- probabilite d'au moins un defaut (independants) : 1 - produit des (1 - p)\\ndef atLeastOne (probs : List Float) : Float :=\\n  1 - probs.foldl (fun acc p => acc * (1 - p)) 1\\n\\n-- borne de l'union : la somme\\ndef unionBound (probs : List Float) : Float := probs.sum\\n\\n#eval atLeastOne [0.01, 0.02, 0.005]\\n#eval unionBound [0.01, 0.02, 0.005]       -- >= atLeastOne : c'est une borne\\n#eval unionBound (List.replicate 10 0.01)   -- 10 hypotheses a 1% : 10% au lieu de 9.6%\", \"env\": 4}\n",
+       "{\"cmd\": \"-- Section 6 : borne de l'union, version jouable\\n\\n-- probabilite d'au moins un defaut (independants) : 1 - produit des (1 - p)\\ndef atLeastOne (probs : List Float) : Float :=\\n  1 - probs.foldl (fun acc p => acc * (1 - p)) 1\\n\\n-- borne de l'union : la somme\\ndef unionBound (probs : List Float) : Float := probs.sum\\n\\n#eval atLeastOne [0.01, 0.02, 0.005]\\n#eval unionBound [0.01, 0.02, 0.005]       -- >= atLeastOne : c'est une borne\\n#eval unionBound (List.replicate 10 0.01)   -- 10 hypotheses a 1% : 10% au lieu de 9.6%\", \"env\": 5}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
@@ -854,7 +1205,7 @@
        "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 12, \"column\": 5},\r\n",
        "   \"data\": \"0.100000\"}],\r\n",
-       " \"env\": 5}"
+       " \"env\": 6}"
       ]
      },
      "metadata": {},
@@ -879,7 +1230,16 @@
   {
    "cell_type": "markdown",
    "id": "ad97cc47",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.024168,
+     "end_time": "2026-08-23T02:23:01.763340+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:01.739172+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. `ERM.lean` : choisir la meilleure hypothese\n",
     "\n",
@@ -894,15 +1254,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "5123c14b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:39.025642Z",
-     "iopub.status.busy": "2026-08-19T08:08:39.025410Z",
-     "iopub.status.idle": "2026-08-19T08:08:39.242528Z",
-     "shell.execute_reply": "2026-08-19T08:08:39.240512Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:23:01.820326Z",
+     "iopub.status.busy": "2026-08-23T02:23:01.820120Z",
+     "iopub.status.idle": "2026-08-23T02:23:02.103394Z",
+     "shell.execute_reply": "2026-08-23T02:23:02.102377Z"
+    },
+    "papermill": {
+     "duration": 0.311388,
+     "end_time": "2026-08-23T02:23:02.103953+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:01.792565+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -919,36 +1287,36 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 7 : ERM jouable sur une classe finie</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">inductive</span><span class=\"w\"> </span>Hyp<span class=\"w\"> </span>where</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">inductive</span><span class=\"w\"> </span>Hyp<span class=\"w\"> </span><span class=\"kn\">where</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>alwaysTrue<span class=\"w\"> </span><span class=\"bp\">|</span><span class=\"w\"> </span>alwaysFalse<span class=\"w\"> </span><span class=\"bp\">|</span><span class=\"w\"> </span>identity</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>classify<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>Hyp)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool)<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>classify<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>Hyp)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool)<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span>:=</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">match</span><span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"bp\">.</span>alwaysTrue<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>true</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"bp\">.</span>alwaysFalse<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>false</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span><span class=\"bp\">.</span>identity<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>x</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- nombre d&#39;erreurs de h sur l&#39;echantillon (c&#39;est la somme des pertes 0/1)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>lossOf<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>Hyp)<span class=\"w\"> </span>(sample<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>(Bool<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>Bool))<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (sample.filter<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>xy<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>classify<span class=\"w\"> </span>h<span class=\"w\"> </span>xy<span class=\"bp\">.</span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">!=</span><span class=\"w\"> </span>xy<span class=\"bp\">.</span><span class=\"mi\">2</span>))<span class=\"bp\">.</span>length</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>lossOf<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>Hyp)<span class=\"w\"> </span>(sample<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>(Bool<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>Bool))<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (sample<span class=\"bp\">.</span>filter<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>xy<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>classify<span class=\"w\"> </span>h<span class=\"w\"> </span>xy<span class=\"bp\">.</span><span class=\"m\">1</span><span class=\"w\"> </span><span class=\"bp\">!=</span><span class=\"w\"> </span>xy<span class=\"bp\">.</span><span class=\"m\">2</span>))<span class=\"bp\">.</span>length</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- argmin par balayage</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>ermSelect<span class=\"w\"> </span>(sample<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>(Bool<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>Bool))<span class=\"w\"> </span>:<span class=\"w\"> </span>Hyp<span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">let</span><span class=\"w\"> </span>hs<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Hyp<span class=\"w\"> </span>:=<span class=\"w\"> </span>[Hyp.alwaysTrue,<span class=\"w\"> </span>Hyp.alwaysFalse,<span class=\"w\"> </span>Hyp.identity]</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (hs.zip<span class=\"w\"> </span>(hs.map<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>lossOf<span class=\"w\"> </span>h<span class=\"w\"> </span>sample)))<span class=\"bp\">.</span>foldl</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (<span class=\"k\">fun</span><span class=\"w\"> </span>best<span class=\"w\"> </span>cur<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>cur<span class=\"bp\">.</span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>best<span class=\"bp\">.</span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span>cur<span class=\"w\"> </span><span class=\"k\">else</span><span class=\"w\"> </span>best)</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (Hyp.alwaysTrue,<span class=\"w\"> </span>lossOf<span class=\"w\"> </span>Hyp.alwaysTrue<span class=\"w\"> </span>sample)<span class=\"w\"> </span><span class=\"bp\">|&gt;.</span><span class=\"mi\">1</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>ermSelect<span class=\"w\"> </span>(sample<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>(Bool<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>Bool))<span class=\"w\"> </span>:<span class=\"w\"> </span>Hyp<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">let</span><span class=\"w\"> </span>hs<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>Hyp<span class=\"w\"> </span>:=<span class=\"w\"> </span>[Hyp<span class=\"bp\">.</span>alwaysTrue,<span class=\"w\"> </span>Hyp<span class=\"bp\">.</span>alwaysFalse,<span class=\"w\"> </span>Hyp<span class=\"bp\">.</span>identity]</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (hs<span class=\"bp\">.</span>zip<span class=\"w\"> </span>(hs<span class=\"bp\">.</span>map<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>lossOf<span class=\"w\"> </span>h<span class=\"w\"> </span>sample)))<span class=\"bp\">.</span>foldl</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (<span class=\"k\">fun</span><span class=\"w\"> </span>best<span class=\"w\"> </span>cur<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span><span class=\"k\">if</span><span class=\"w\"> </span>cur<span class=\"bp\">.</span><span class=\"m\">2</span><span class=\"w\"> </span><span class=\"bp\">&lt;</span><span class=\"w\"> </span>best<span class=\"bp\">.</span><span class=\"m\">2</span><span class=\"w\"> </span><span class=\"k\">then</span><span class=\"w\"> </span>cur<span class=\"w\"> </span><span class=\"k\">else</span><span class=\"w\"> </span>best)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (Hyp<span class=\"bp\">.</span>alwaysTrue,<span class=\"w\"> </span>lossOf<span class=\"w\"> </span>Hyp<span class=\"bp\">.</span>alwaysTrue<span class=\"w\"> </span>sample)<span class=\"w\"> </span><span class=\"bp\">|&gt;.</span><span class=\"m\">1</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- echantillon seedes ou le concept vrai est l&#39;identite : l&#39;ERM doit retrouver identity</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>s42<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>(Bool<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>Bool)<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>s42<span class=\"w\"> </span>:<span class=\"w\"> </span>List<span class=\"w\"> </span>(Bool<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>Bool)<span class=\"w\"> </span>:=</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (sampleOfSeed<span class=\"w\"> </span><span class=\"mi\">42</span><span class=\"w\"> </span><span class=\"mi\">30</span>)<span class=\"bp\">.</span>map<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>(b<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">==</span><span class=\"w\"> </span><span class=\"mi\">0</span>))</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"k\">#eval</span><span class=\"w\"> </span>ermSelect<span class=\"w\"> </span>s42<span class=\"w\">        </span><span class=\"c1\">-- attendu : Hyp.identity</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Hyp.identity</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>ermSelect<span class=\"w\"> </span>s42<span class=\"w\">        </span><span class=\"c1\">-- attendu : Hyp.identity</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Hyp<span class=\"bp\">.</span>identity</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 7</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Section 7 : ERM jouable sur une classe finie\\n\\ninductive Hyp where\\n  | alwaysTrue | alwaysFalse | identity\\n\\ndef classify (h : Hyp) (x : Bool) : Bool :=\\n  match h with\\n  | .alwaysTrue => true\\n  | .alwaysFalse => false\\n  | .identity => x\\n\\n-- nombre d'erreurs de h sur l'echantillon (c'est la somme des pertes 0/1)\\ndef lossOf (h : Hyp) (sample : List (Bool \\u00d7 Bool)) : Nat :=\\n  (sample.filter (fun xy => classify h xy.1 != xy.2)).length\\n\\n-- argmin par balayage\\ndef ermSelect (sample : List (Bool \\u00d7 Bool)) : Hyp :=\\n  let hs : List Hyp := [Hyp.alwaysTrue, Hyp.alwaysFalse, Hyp.identity]\\n  (hs.zip (hs.map (fun h => lossOf h sample))).foldl\\n    (fun best cur => if cur.2 < best.2 then cur else best)\\n    (Hyp.alwaysTrue, lossOf Hyp.alwaysTrue sample) |>.1\\n\\n-- echantillon seedes ou le concept vrai est l'identite : l'ERM doit retrouver identity\\ndef s42 : List (Bool \\u00d7 Bool) :=\\n  (sampleOfSeed 42 30).map (fun b => (b == 0, b == 0))\\n\\n#eval ermSelect s42        -- attendu : Hyp.identity\", \"env\": 5}</code>\n",
+       "            <code>{\"cmd\": \"-- Section 7 : ERM jouable sur une classe finie\\n\\ninductive Hyp where\\n  | alwaysTrue | alwaysFalse | identity\\n\\ndef classify (h : Hyp) (x : Bool) : Bool :=\\n  match h with\\n  | .alwaysTrue => true\\n  | .alwaysFalse => false\\n  | .identity => x\\n\\n-- nombre d'erreurs de h sur l'echantillon (c'est la somme des pertes 0/1)\\ndef lossOf (h : Hyp) (sample : List (Bool \\u00d7 Bool)) : Nat :=\\n  (sample.filter (fun xy => classify h xy.1 != xy.2)).length\\n\\n-- argmin par balayage\\ndef ermSelect (sample : List (Bool \\u00d7 Bool)) : Hyp :=\\n  let hs : List Hyp := [Hyp.alwaysTrue, Hyp.alwaysFalse, Hyp.identity]\\n  (hs.zip (hs.map (fun h => lossOf h sample))).foldl\\n    (fun best cur => if cur.2 < best.2 then cur else best)\\n    (Hyp.alwaysTrue, lossOf Hyp.alwaysTrue sample) |>.1\\n\\n-- echantillon seedes ou le concept vrai est l'identite : l'ERM doit retrouver identity\\ndef s42 : List (Bool \\u00d7 Bool) :=\\n  (sampleOfSeed 42 30).map (fun b => (b == 0, b == 0))\\n\\n#eval ermSelect s42        -- attendu : Hyp.identity\", \"env\": 6}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -957,7 +1325,7 @@
        "   \"pos\": {\"line\": 27, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 27, \"column\": 5},\r\n",
        "   \"data\": \"Hyp.identity\"}],\r\n",
-       " \"env\": 6}</code>\n",
+       " \"env\": 7}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -990,17 +1358,17 @@
        "\n",
        "#eval ermSelect s42        -- attendu : Hyp.identity\n",
        "─────▶  Hyp.identity\n",
-       "--% env 6\n",
+       "--% env 7\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Section 7 : ERM jouable sur une classe finie\\n\\ninductive Hyp where\\n  | alwaysTrue | alwaysFalse | identity\\n\\ndef classify (h : Hyp) (x : Bool) : Bool :=\\n  match h with\\n  | .alwaysTrue => true\\n  | .alwaysFalse => false\\n  | .identity => x\\n\\n-- nombre d'erreurs de h sur l'echantillon (c'est la somme des pertes 0/1)\\ndef lossOf (h : Hyp) (sample : List (Bool \\u00d7 Bool)) : Nat :=\\n  (sample.filter (fun xy => classify h xy.1 != xy.2)).length\\n\\n-- argmin par balayage\\ndef ermSelect (sample : List (Bool \\u00d7 Bool)) : Hyp :=\\n  let hs : List Hyp := [Hyp.alwaysTrue, Hyp.alwaysFalse, Hyp.identity]\\n  (hs.zip (hs.map (fun h => lossOf h sample))).foldl\\n    (fun best cur => if cur.2 < best.2 then cur else best)\\n    (Hyp.alwaysTrue, lossOf Hyp.alwaysTrue sample) |>.1\\n\\n-- echantillon seedes ou le concept vrai est l'identite : l'ERM doit retrouver identity\\ndef s42 : List (Bool \\u00d7 Bool) :=\\n  (sampleOfSeed 42 30).map (fun b => (b == 0, b == 0))\\n\\n#eval ermSelect s42        -- attendu : Hyp.identity\", \"env\": 5}\n",
+       "{\"cmd\": \"-- Section 7 : ERM jouable sur une classe finie\\n\\ninductive Hyp where\\n  | alwaysTrue | alwaysFalse | identity\\n\\ndef classify (h : Hyp) (x : Bool) : Bool :=\\n  match h with\\n  | .alwaysTrue => true\\n  | .alwaysFalse => false\\n  | .identity => x\\n\\n-- nombre d'erreurs de h sur l'echantillon (c'est la somme des pertes 0/1)\\ndef lossOf (h : Hyp) (sample : List (Bool \\u00d7 Bool)) : Nat :=\\n  (sample.filter (fun xy => classify h xy.1 != xy.2)).length\\n\\n-- argmin par balayage\\ndef ermSelect (sample : List (Bool \\u00d7 Bool)) : Hyp :=\\n  let hs : List Hyp := [Hyp.alwaysTrue, Hyp.alwaysFalse, Hyp.identity]\\n  (hs.zip (hs.map (fun h => lossOf h sample))).foldl\\n    (fun best cur => if cur.2 < best.2 then cur else best)\\n    (Hyp.alwaysTrue, lossOf Hyp.alwaysTrue sample) |>.1\\n\\n-- echantillon seedes ou le concept vrai est l'identite : l'ERM doit retrouver identity\\ndef s42 : List (Bool \\u00d7 Bool) :=\\n  (sampleOfSeed 42 30).map (fun b => (b == 0, b == 0))\\n\\n#eval ermSelect s42        -- attendu : Hyp.identity\", \"env\": 6}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 27, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 27, \"column\": 5},\r\n",
        "   \"data\": \"Hyp.identity\"}],\r\n",
-       " \"env\": 6}"
+       " \"env\": 7}"
       ]
      },
      "metadata": {},
@@ -1040,7 +1408,16 @@
   {
    "cell_type": "markdown",
    "id": "7779a4b3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.018363,
+     "end_time": "2026-08-23T02:23:02.136614+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:02.118251+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. `PacFiniteBound.lean` : le theoreme PAC\n",
     "\n",
@@ -1057,15 +1434,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "32373861",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:39.246104Z",
-     "iopub.status.busy": "2026-08-19T08:08:39.245813Z",
-     "iopub.status.idle": "2026-08-19T08:08:39.367583Z",
-     "shell.execute_reply": "2026-08-19T08:08:39.366174Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:23:02.182190Z",
+     "iopub.status.busy": "2026-08-23T02:23:02.182003Z",
+     "iopub.status.idle": "2026-08-23T02:23:02.392360Z",
+     "shell.execute_reply": "2026-08-23T02:23:02.391521Z"
+    },
+    "papermill": {
+     "duration": 0.230345,
+     "end_time": "2026-08-23T02:23:02.393014+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:02.162669+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1081,17 +1466,17 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 8 : la complexite d&#39;echantillon de pac_finite_class_bound, calculee</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>sampleComplexity<span class=\"w\"> </span>(k<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(eps<span class=\"w\"> </span>delta<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (Float.log<span class=\"w\"> </span>(Float.ofNat<span class=\"w\"> </span>k)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>Float.log<span class=\"w\"> </span>(<span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>delta))<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>eps<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>eps)</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>sampleComplexity<span class=\"w\"> </span>(k<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(eps<span class=\"w\"> </span>delta<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  (Float<span class=\"bp\">.</span>log<span class=\"w\"> </span>(Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>k)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>Float<span class=\"bp\">.</span>log<span class=\"w\"> </span>(<span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>delta))<span class=\"w\"> </span><span class=\"bp\">/</span><span class=\"w\"> </span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>eps<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>eps)</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"k\">#eval</span><span class=\"w\"> </span>sampleComplexity<span class=\"w\"> </span><span class=\"mi\">10</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">05</span><span class=\"w\">     </span><span class=\"c1\">-- classe de 10, eps = 10%, delta = 5%</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">264</span><span class=\"bp\">.</span><span class=\"mi\">915868</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"k\">#eval</span><span class=\"w\"> </span>sampleComplexity<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">05</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">.</span><span class=\"mi\">01</span><span class=\"w\">   </span><span class=\"c1\">-- classe de 100, eps = 5%, delta = 1%</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">1842</span><span class=\"bp\">.</span><span class=\"mi\">068074</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>sampleComplexity<span class=\"w\"> </span><span class=\"mi\">10</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\"> </span><span class=\"mf\">0.05</span><span class=\"w\">     </span><span class=\"c1\">-- classe de 10, eps = 10%, delta = 5%</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">264.915868</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>sampleComplexity<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mf\">0.05</span><span class=\"w\"> </span><span class=\"mf\">0.01</span><span class=\"w\">   </span><span class=\"c1\">-- classe de 100, eps = 5%, delta = 1%</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">1842.068074</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- second cas : (ln 100 + ln 100) / (2 * 0.05^2) ~ 9.21 / 0.005 ~ 1842</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 7</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 8</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Section 8 : la complexite d'echantillon de pac_finite_class_bound, calculee\\ndef sampleComplexity (k : Nat) (eps delta : Float) : Float :=\\n  (Float.log (Float.ofNat k) + Float.log (1 / delta)) / (2 * eps * eps)\\n\\n#eval sampleComplexity 10 0.1 0.05     -- classe de 10, eps = 10%, delta = 5%\\n#eval sampleComplexity 100 0.05 0.01   -- classe de 100, eps = 5%, delta = 1%\\n-- second cas : (ln 100 + ln 100) / (2 * 0.05^2) ~ 9.21 / 0.005 ~ 1842\", \"env\": 6}</code>\n",
+       "            <code>{\"cmd\": \"-- Section 8 : la complexite d'echantillon de pac_finite_class_bound, calculee\\ndef sampleComplexity (k : Nat) (eps delta : Float) : Float :=\\n  (Float.log (Float.ofNat k) + Float.log (1 / delta)) / (2 * eps * eps)\\n\\n#eval sampleComplexity 10 0.1 0.05     -- classe de 10, eps = 10%, delta = 5%\\n#eval sampleComplexity 100 0.05 0.01   -- classe de 100, eps = 5%, delta = 1%\\n-- second cas : (ln 100 + ln 100) / (2 * 0.05^2) ~ 9.21 / 0.005 ~ 1842\", \"env\": 7}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -1104,7 +1489,7 @@
        "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
        "   \"data\": \"1842.068074\"}],\r\n",
-       " \"env\": 7}</code>\n",
+       " \"env\": 8}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -1118,10 +1503,10 @@
        "#eval sampleComplexity 100 0.05 0.01   -- classe de 100, eps = 5%, delta = 1%\n",
        "─────▶  1842.068074\n",
        "-- second cas : (ln 100 + ln 100) / (2 * 0.05^2) ~ 9.21 / 0.005 ~ 1842\n",
-       "--% env 7\n",
+       "--% env 8\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Section 8 : la complexite d'echantillon de pac_finite_class_bound, calculee\\ndef sampleComplexity (k : Nat) (eps delta : Float) : Float :=\\n  (Float.log (Float.ofNat k) + Float.log (1 / delta)) / (2 * eps * eps)\\n\\n#eval sampleComplexity 10 0.1 0.05     -- classe de 10, eps = 10%, delta = 5%\\n#eval sampleComplexity 100 0.05 0.01   -- classe de 100, eps = 5%, delta = 1%\\n-- second cas : (ln 100 + ln 100) / (2 * 0.05^2) ~ 9.21 / 0.005 ~ 1842\", \"env\": 6}\n",
+       "{\"cmd\": \"-- Section 8 : la complexite d'echantillon de pac_finite_class_bound, calculee\\ndef sampleComplexity (k : Nat) (eps delta : Float) : Float :=\\n  (Float.log (Float.ofNat k) + Float.log (1 / delta)) / (2 * eps * eps)\\n\\n#eval sampleComplexity 10 0.1 0.05     -- classe de 10, eps = 10%, delta = 5%\\n#eval sampleComplexity 100 0.05 0.01   -- classe de 100, eps = 5%, delta = 1%\\n-- second cas : (ln 100 + ln 100) / (2 * 0.05^2) ~ 9.21 / 0.005 ~ 1842\", \"env\": 7}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
@@ -1132,7 +1517,7 @@
        "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
        "   \"data\": \"1842.068074\"}],\r\n",
-       " \"env\": 7}"
+       " \"env\": 8}"
       ]
      },
      "metadata": {},
@@ -1152,7 +1537,16 @@
   {
    "cell_type": "markdown",
    "id": "1096f082",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.028219,
+     "end_time": "2026-08-23T02:23:02.441853+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:02.413634+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 9. `Agnostic.lean` : relacher la realisabilite\n",
     "\n",
@@ -1165,8 +1559,368 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d759b48b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023527,
+     "end_time": "2026-08-23T02:23:02.490999+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:02.467472+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 10. `Sample.lean` et `UniformConcentration.lean` : la concentration uniforme, nativement\n",
+    "\n",
+    "Les huit sections précédentes déroulaient des versions simplifiées. Celle-ci descend\n",
+    "dans le lake. Deux modules y restaient noirs — cités par personne, exécutés par\n",
+    "personne — et ils portent précisément le cœur probabiliste du récit.\n",
+    "\n",
+    "**`Sample.lean` — la distribution produit `D^m`.** L'espace des échantillons\n",
+    "`Fin n → X` (suites de `n` instances tirées i.i.d. selon `D`) reçoit sa loi : le poids\n",
+    "d'un échantillon `S` est le produit des poids de ses composantes, `sampleWeight D S =\n",
+    "∏ i, D.weight (S i)` — le pendant discret de la densité du produit tensoriel\n",
+    "`D ⊗ … ⊗ D`. Deux propriétés ferment le cercle. `sampleWeight_nonneg` : un produit de\n",
+    "poids positifs est positif (cas `n = 0` : produit vide = 1 ≥ 0). Et surtout\n",
+    "`sampleWeight_sum_one`, la **normalisation** : la masse totale des échantillons de\n",
+    "taille `n` vaut 1 — donc `D^m` est bien une distribution. Sa preuve est une identité\n",
+    "de Fubini discrète, `(∑ x, w x)^n = ∑ S, ∏ i, w (S i)`, que Mathlib fournit comme\n",
+    "`sum_pow'` : le développement multinomial d'un produit de sommes sur un type fini.\n",
+    "C'est la brique qui donne un **sens** à `sampleProb` (section 6) : la probabilité\n",
+    "d'un ensemble d'échantillons n'est un nombre ≤ 1 que parce que la masse totale fait 1.\n",
+    "\n",
+    "**`UniformConcentration.lean` — le doublement fini.** Le théorème central du cas\n",
+    "agnostique, dans l'énoncé exact où le lake le prouve : la probabilité qu'**il existe**\n",
+    "une hypothèse `h` de la classe finie `Hs` dont l'erreur empirique dévie de son erreur\n",
+    "vraie d'au moins `ε` est majorée par `2 · |Hs| · exp(−2nε²)`. La preuve assemble trois\n",
+    "briques des sections 4 à 6 : l'union bound (`sampleProb_union_bound`) transforme « il\n",
+    "existe » en somme sur la classe ; Hoeffding ponctuel (`hoeffding_concentration`)\n",
+    "borne chaque terme par `2·exp(−2nε²)` ; la somme constante se factorise\n",
+    "(`Finset.sum_const`). Chaque hypothèse « coûte » individuellement sa queue\n",
+    "exponentielle, et la classe finie paie le prix **multiplicatif** `|Hs|` : c'est le\n",
+    "sens profond du `ln |H|` dans la complexité d'échantillon, et la raison pour laquelle\n",
+    "le cas agnostique exige `(1/ε²)(ln|H| + ln(1/δ))` exemples là où le réalisable\n",
+    "(sect. 8) se contentait de `(1/ε)(ln|H| + ln(1/δ))`. Comparé au flagship ponctuel de\n",
+    "la section 5, c'est le même théorème **doublé** : uniformiser sur une classe finie,\n",
+    "c'est payer le ponctuel fois le cardinal.\n",
+    "\n",
+    "Ce théorème est la **brique 6/6-agnostic, étape a** de l'itération 2 du lake : sa\n",
+    "docstring raconte la construction par briques numérotées (Markov → MGF → Hoeffding →\n",
+    "union bound → concentration uniforme), et annonce ce qui manque encore — l'argument\n",
+    "ERM (brique 6b : `ĥ = argmin empError` ⟹ `trueError ĥ ≤ trueError h* + 2ε`), qui\n",
+    "fermera la boucle vers la borne agnostique finale. Le lake n'est pas un décor\n",
+    "figé : c'est un chantier dont ce notebook lit l'état présent, briques posées et\n",
+    "briques manquantes.\n",
+    "\n",
+    "Les cellules suivantes interrogent les déclarations, lisent leurs **certificats**\n",
+    "(`#print axioms` — la preuve de `sampleWeight_sum_one` passe par Fubini et\n",
+    "`D.sum_one`, celle de `uniform_concentration` enchaîne union bound et Hoeffding sans\n",
+    "rien demander au lecteur), puis **évaluent le prix de l'uniformité** : la borne\n",
+    "`2·|Hs|·exp(−2nε²)` côte à côte avec sa version ponctuelle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b724ecca",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T02:23:02.535883Z",
+     "iopub.status.busy": "2026-08-23T02:23:02.535703Z",
+     "iopub.status.idle": "2026-08-23T02:23:02.743885Z",
+     "shell.execute_reply": "2026-08-23T02:23:02.742881Z"
+    },
+    "papermill": {
+     "duration": 0.230586,
+     "end_time": "2026-08-23T02:23:02.744829+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:02.514243+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 10 : les declarations des deux modules noirs, interrogees nativement.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Le module Sample : la distribution produit D^m et sa normalisation.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight_nonneg</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight_nonneg<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}\n",
+       "<span class=\"w\">  </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Fin<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>X),<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>sampleWeight<span class=\"w\"> </span>D<span class=\"w\"> </span>S</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>{X<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>[inst<span class=\"w\"> </span>:<span class=\"w\"> </span>Fintype<span class=\"w\"> </span>X]<span class=\"w\"> </span>{D<span class=\"w\"> </span>:<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>Distribution<span class=\"w\"> </span>X}<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ),\n",
+       "<span class=\"w\">  </span><span class=\"bp\">∑</span><span class=\"w\"> </span>S,<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>sampleWeight<span class=\"w\"> </span>D<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">1</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Les certificats : de quoi chaque preuve depend-elle, exactement ?</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>PacLearning<span class=\"bp\">.</span>sampleWeight_sum_one&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk16\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk16\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>PacLearning<span class=\"bp\">.</span>uniform_concentration</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>PacLearning<span class=\"bp\">.</span>uniform_concentration&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 9</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Section 10 : les declarations des deux modules noirs, interrogees nativement.\\n-- Le module Sample : la distribution produit D^m et sa normalisation.\\n#check @PacLearning.sampleWeight_nonneg\\n#check @PacLearning.sampleWeight_sum_one\\n\\n-- Les certificats : de quoi chaque preuve depend-elle, exactement ?\\n#print axioms PacLearning.sampleWeight_sum_one\\n#print axioms PacLearning.uniform_concentration\", \"env\": 8}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.sampleWeight_nonneg : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} {n : ℕ}\\n  (S : Fin n → X), 0 ≤ PacLearning.sampleWeight D S\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.sampleWeight_sum_one : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (n : ℕ),\\n  ∑ S, PacLearning.sampleWeight D S = 1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'PacLearning.sampleWeight_sum_one' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'PacLearning.uniform_concentration' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 9}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Section 10 : les declarations des deux modules noirs, interrogees nativement.\n",
+       "-- Le module Sample : la distribution produit D^m et sa normalisation.\n",
+       "#check @PacLearning.sampleWeight_nonneg\n",
+       "──────▶  @PacLearning.sampleWeight_nonneg : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} {n : ℕ}\n",
+       "  (S : Fin n → X), 0 ≤ PacLearning.sampleWeight D S\n",
+       "#check @PacLearning.sampleWeight_sum_one\n",
+       "──────▶  @PacLearning.sampleWeight_sum_one : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (n : ℕ),\n",
+       "  ∑ S, PacLearning.sampleWeight D S = 1\n",
+       "\n",
+       "-- Les certificats : de quoi chaque preuve depend-elle, exactement ?\n",
+       "#print axioms PacLearning.sampleWeight_sum_one\n",
+       "──────▶  'PacLearning.sampleWeight_sum_one' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "#print axioms PacLearning.uniform_concentration\n",
+       "──────▶  'PacLearning.uniform_concentration' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "--% env 9\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Section 10 : les declarations des deux modules noirs, interrogees nativement.\\n-- Le module Sample : la distribution produit D^m et sa normalisation.\\n#check @PacLearning.sampleWeight_nonneg\\n#check @PacLearning.sampleWeight_sum_one\\n\\n-- Les certificats : de quoi chaque preuve depend-elle, exactement ?\\n#print axioms PacLearning.sampleWeight_sum_one\\n#print axioms PacLearning.uniform_concentration\", \"env\": 8}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.sampleWeight_nonneg : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} {n : ℕ}\\n  (S : Fin n → X), 0 ≤ PacLearning.sampleWeight D S\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"@PacLearning.sampleWeight_sum_one : ∀ {X : Type u_1} [inst : Fintype X] {D : PacLearning.Distribution X} (n : ℕ),\\n  ∑ S, PacLearning.sampleWeight D S = 1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'PacLearning.sampleWeight_sum_one' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'PacLearning.uniform_concentration' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 9}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Section 10 : les declarations des deux modules noirs, interrogees nativement.\n",
+    "-- Le module Sample : la distribution produit D^m et sa normalisation.\n",
+    "#check @PacLearning.sampleWeight_nonneg\n",
+    "#check @PacLearning.sampleWeight_sum_one\n",
+    "\n",
+    "-- Les certificats : de quoi chaque preuve depend-elle, exactement ?\n",
+    "#print axioms PacLearning.sampleWeight_sum_one\n",
+    "#print axioms PacLearning.uniform_concentration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7e6302d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T02:23:02.787503Z",
+     "iopub.status.busy": "2026-08-23T02:23:02.787322Z",
+     "iopub.status.idle": "2026-08-23T02:23:03.015508Z",
+     "shell.execute_reply": "2026-08-23T02:23:03.014484Z"
+    },
+    "papermill": {
+     "duration": 0.254178,
+     "end_time": "2026-08-23T02:23:03.016138+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:02.761960+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Section 10 : le prix de l&#39;uniformite, evalue.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- La borne agnostique 2*|Hs|*exp(-2*n*eps^2), cote a cote avec la ponctuelle (cardH = 1).</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>tailBound<span class=\"w\"> </span>(cardH<span class=\"w\"> </span>n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>(eps<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)<span class=\"w\"> </span>:<span class=\"w\"> </span>Float<span class=\"w\"> </span>:=</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>cardH<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Float<span class=\"bp\">.</span>exp<span class=\"w\"> </span>(<span class=\"bp\">-</span>(<span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>Float<span class=\"bp\">.</span>ofNat<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>eps<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>eps))</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk17\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk17\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\">   </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- ponctuel : 2*exp(-2) ~ 0.27</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.270671</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk18\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk18\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">10</span><span class=\"w\">  </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- classe de 10 : ~2.7, borne vide (&gt; 1)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">2.706706</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk19\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk19\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- classe de 100 : ~27, le facteur |Hs| se paie comptant</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">27.067057</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1a\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1a\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mi\">415</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">    </span><span class=\"c1\">-- ~0.05 : la borne retombe sous delta = 5%</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.049703</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1b\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>tailBound<span class=\"w\"> </span><span class=\"mi\">100</span><span class=\"w\"> </span><span class=\"mi\">600</span><span class=\"w\"> </span><span class=\"mf\">0.1</span><span class=\"w\">   </span><span class=\"c1\">-- queue exponentielle : ~0.0012</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mf\">0.001229</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 10</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Section 10 : le prix de l'uniformite, evalue.\\n-- La borne agnostique 2*|Hs|*exp(-2*n*eps^2), cote a cote avec la ponctuelle (cardH = 1).\\ndef tailBound (cardH n : Nat) (eps : Float) : Float :=\\n  2 * Float.ofNat cardH * Float.exp (-(2 * Float.ofNat n * eps * eps))\\n\\n#eval tailBound 1   100 0.1    -- ponctuel : 2*exp(-2) ~ 0.27\\n#eval tailBound 10  100 0.1    -- classe de 10 : ~2.7, borne vide (> 1)\\n#eval tailBound 100 100 0.1    -- classe de 100 : ~27, le facteur |Hs| se paie comptant\\n#eval tailBound 100 415 0.1    -- ~0.05 : la borne retombe sous delta = 5%\\n#eval tailBound 100 600 0.1   -- queue exponentielle : ~0.0012\", \"env\": 9}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
+       "   \"data\": \"0.270671\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 5},\r\n",
+       "   \"data\": \"2.706706\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 5},\r\n",
+       "   \"data\": \"27.067057\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 9, \"column\": 5},\r\n",
+       "   \"data\": \"0.049703\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 5},\r\n",
+       "   \"data\": \"0.001229\"}],\r\n",
+       " \"env\": 10}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Section 10 : le prix de l'uniformite, evalue.\n",
+       "-- La borne agnostique 2*|Hs|*exp(-2*n*eps^2), cote a cote avec la ponctuelle (cardH = 1).\n",
+       "def tailBound (cardH n : Nat) (eps : Float) : Float :=\n",
+       "  2 * Float.ofNat cardH * Float.exp (-(2 * Float.ofNat n * eps * eps))\n",
+       "\n",
+       "#eval tailBound 1   100 0.1    -- ponctuel : 2*exp(-2) ~ 0.27\n",
+       "─────▶  0.270671\n",
+       "#eval tailBound 10  100 0.1    -- classe de 10 : ~2.7, borne vide (> 1)\n",
+       "─────▶  2.706706\n",
+       "#eval tailBound 100 100 0.1    -- classe de 100 : ~27, le facteur |Hs| se paie comptant\n",
+       "─────▶  27.067057\n",
+       "#eval tailBound 100 415 0.1    -- ~0.05 : la borne retombe sous delta = 5%\n",
+       "─────▶  0.049703\n",
+       "#eval tailBound 100 600 0.1   -- queue exponentielle : ~0.0012\n",
+       "─────▶  0.001229\n",
+       "--% env 10\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Section 10 : le prix de l'uniformite, evalue.\\n-- La borne agnostique 2*|Hs|*exp(-2*n*eps^2), cote a cote avec la ponctuelle (cardH = 1).\\ndef tailBound (cardH n : Nat) (eps : Float) : Float :=\\n  2 * Float.ofNat cardH * Float.exp (-(2 * Float.ofNat n * eps * eps))\\n\\n#eval tailBound 1   100 0.1    -- ponctuel : 2*exp(-2) ~ 0.27\\n#eval tailBound 10  100 0.1    -- classe de 10 : ~2.7, borne vide (> 1)\\n#eval tailBound 100 100 0.1    -- classe de 100 : ~27, le facteur |Hs| se paie comptant\\n#eval tailBound 100 415 0.1    -- ~0.05 : la borne retombe sous delta = 5%\\n#eval tailBound 100 600 0.1   -- queue exponentielle : ~0.0012\", \"env\": 9}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 5},\r\n",
+       "   \"data\": \"0.270671\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 5},\r\n",
+       "   \"data\": \"2.706706\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 5},\r\n",
+       "   \"data\": \"27.067057\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 9, \"column\": 5},\r\n",
+       "   \"data\": \"0.049703\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 5},\r\n",
+       "   \"data\": \"0.001229\"}],\r\n",
+       " \"env\": 10}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Section 10 : le prix de l'uniformite, evalue.\n",
+    "-- La borne agnostique 2*|Hs|*exp(-2*n*eps^2), cote a cote avec la ponctuelle (cardH = 1).\n",
+    "def tailBound (cardH n : Nat) (eps : Float) : Float :=\n",
+    "  2 * Float.ofNat cardH * Float.exp (-(2 * Float.ofNat n * eps * eps))\n",
+    "\n",
+    "#eval tailBound 1   100 0.1    -- ponctuel : 2*exp(-2) ~ 0.27\n",
+    "#eval tailBound 10  100 0.1    -- classe de 10 : ~2.7, borne vide (> 1)\n",
+    "#eval tailBound 100 100 0.1    -- classe de 100 : ~27, le facteur |Hs| se paie comptant\n",
+    "#eval tailBound 100 415 0.1    -- ~0.05 : la borne retombe sous delta = 5%\n",
+    "#eval tailBound 100 600 0.1   -- queue exponentielle : ~0.0012"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e241a04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01633,
+     "end_time": "2026-08-23T02:23:03.044826+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:03.028496+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": "**Lecture du prix de l'uniformité.** À `n = 100` exemples et `ε = 0.1`, l'hypothèse\nseule porte une queue d'environ 0.27 : c'est Hoeffding ponctuel, déjà lâche. Dix\nhypothèses : environ 2.7 — la borne dépasse 1 et n'enseigne plus rien ; cent :\nenviron 27. Le facteur `|Hs|` se paie comptant, et c'est exactement ce que la\ncomplexité d'échantillon traduit en `ln |H|` : il faut `n ≈ ln(2|H|/δ)/(2ε²)`\nexemples pour que le produit `|H| · exp(−2nε²)` passe sous `δ`. À `|Hs| = 100`,\n`δ = 5%` : `n = 415` suffit (quatrième ligne, rendu `0.049703`), et `n = 600`\nl'écrase (cinquième ligne, rendu `0.001229`) — la queue exponentielle gagne\ntoujours à la fin. La comparaison avec la\nsection 8 est le recto de la même feuille : là, la cellule de complexité résout le\nbudget `m` requis ; ici, on évalue la borne résiduelle à `m` donné.\n\n**Réalisable contre agnostique, en nombres.** Les deux régimes ne paient pas le même\nprix par chiffre : pour `|H| = 100`, `ε = 0.1`, `δ = 5%`, le budget réalisable est\n`ln(|H|/δ)/ε ≈ 76` exemples, l'agnostique `ln(2|H|/δ)/(2ε²) ≈ 415` — un rapport de\n5.5. L'écart n'est pas une subtilité : le réalisable profite d'une concentration\n**géométrique** `(1−μ)^n ≤ e^{−εn}` (l'hypothèse cible est parfaitement apprise, il\nne reste que le risque qu'une mauvaise hypothèse paraisse bonne), l'agnostique paie\nla concentration **quadratique** de Hoeffding sur les deux directions de la\ndéviation. C'est toute la différence entre « il existe une hypothèse parfaite » et\n« on ne garantit que la meilleure disponible »."
+  },
+  {
+   "cell_type": "markdown",
    "id": "d2ef4b1c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.015803,
+     "end_time": "2026-08-23T02:23:03.080303+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:03.064500+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 1 : esperance d'une perte bornee\n",
     "\n",
@@ -1176,15 +1930,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "64d7074a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:39.370302Z",
-     "iopub.status.busy": "2026-08-19T08:08:39.369980Z",
-     "iopub.status.idle": "2026-08-19T08:08:39.485331Z",
-     "shell.execute_reply": "2026-08-19T08:08:39.483543Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:23:03.113811Z",
+     "iopub.status.busy": "2026-08-23T02:23:03.113618Z",
+     "iopub.status.idle": "2026-08-23T02:23:03.328224Z",
+     "shell.execute_reply": "2026-08-23T02:23:03.327405Z"
+    },
+    "papermill": {
+     "duration": 0.232675,
+     "end_time": "2026-08-23T02:23:03.328839+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:03.096164+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1201,16 +1963,16 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 1 : esperance bornee</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : completer la preuve</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"kd\">theorem</span><span class=\"w\"> </span>expectBounded<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float)<span class=\"w\"> </span>(c<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (h<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>b,<span class=\"w\"> </span>f<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>c)<span class=\"w\"> </span>:<span class=\"w\"> </span>expect<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>c<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"kd\">by</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1c\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>expectBounded<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float)<span class=\"w\"> </span>(c<span class=\"w\"> </span>:<span class=\"w\"> </span>Float)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    (h<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∀</span><span class=\"w\"> </span>b,<span class=\"w\"> </span>f<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>c)<span class=\"w\"> </span>:<span class=\"w\"> </span>expect<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>c<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice a completer (voir indice ci-dessus)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 8</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 11</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 0</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 1 : esperance bornee\\n-- TODO etudiant : completer la preuve\\ntheorem expectBounded (f : Bool \\u2192 Float) (c : Float)\\n    (h : \\u2200 b, f b \\u2264 c) : expect f \\u2264 c := by\\n  sorry\\n-- Exercice a completer (voir indice ci-dessus)\", \"env\": 7}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 1 : esperance bornee\\n-- TODO etudiant : completer la preuve\\ntheorem expectBounded (f : Bool \\u2192 Float) (c : Float)\\n    (h : \\u2200 b, f b \\u2264 c) : expect f \\u2264 c := by\\n  sorry\\n-- Exercice a completer (voir indice ci-dessus)\", \"env\": 10}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -1225,7 +1987,7 @@
        "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 21},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 8}</code>\n",
+       " \"env\": 11}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -1237,11 +1999,11 @@
        "    (h : ∀ b, f b ≤ c) : expect f ≤ c := by\n",
        "  sorry\n",
        "-- Exercice a completer (voir indice ci-dessus)\n",
-       "--% env 8\n",
+       "--% env 11\n",
        "--% prove 0\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 1 : esperance bornee\\n-- TODO etudiant : completer la preuve\\ntheorem expectBounded (f : Bool \\u2192 Float) (c : Float)\\n    (h : \\u2200 b, f b \\u2264 c) : expect f \\u2264 c := by\\n  sorry\\n-- Exercice a completer (voir indice ci-dessus)\", \"env\": 7}\n",
+       "{\"cmd\": \"-- Exercice 1 : esperance bornee\\n-- TODO etudiant : completer la preuve\\ntheorem expectBounded (f : Bool \\u2192 Float) (c : Float)\\n    (h : \\u2200 b, f b \\u2264 c) : expect f \\u2264 c := by\\n  sorry\\n-- Exercice a completer (voir indice ci-dessus)\", \"env\": 10}\n",
        "Raw output:\n",
        "{\"sorries\":\r\n",
        " [{\"proofState\": 0,\r\n",
@@ -1254,7 +2016,7 @@
        "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 21},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 8}"
+       " \"env\": 11}"
       ]
      },
      "metadata": {},
@@ -1273,7 +2035,16 @@
   {
    "cell_type": "markdown",
    "id": "90ed226c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.016006,
+     "end_time": "2026-08-23T02:23:03.361212+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:03.345206+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 : linearite de l'esperance\n",
     "\n",
@@ -1284,15 +2055,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "8f85a3ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:39.488448Z",
-     "iopub.status.busy": "2026-08-19T08:08:39.488195Z",
-     "iopub.status.idle": "2026-08-19T08:08:39.603419Z",
-     "shell.execute_reply": "2026-08-19T08:08:39.601908Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:23:03.396247Z",
+     "iopub.status.busy": "2026-08-23T02:23:03.396067Z",
+     "iopub.status.idle": "2026-08-23T02:23:03.602042Z",
+     "shell.execute_reply": "2026-08-23T02:23:03.601278Z"
+    },
+    "papermill": {
+     "duration": 0.225279,
+     "end_time": "2026-08-23T02:23:03.602830+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:03.377551+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1309,16 +2088,16 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 2 : linearite de l&#39;esperance</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"kd\">theorem</span><span class=\"w\"> </span>expectAdd<span class=\"w\"> </span>(f<span class=\"w\"> </span>g<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float)<span class=\"w\"> </span>:</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    expect<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>f<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>g<span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>expect<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>expect<span class=\"w\"> </span>g<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"kd\">by</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1d\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>expectAdd<span class=\"w\"> </span>(f<span class=\"w\"> </span>g<span class=\"w\"> </span>:<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>Float)<span class=\"w\"> </span>:</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    expect<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>f<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>g<span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>expect<span class=\"w\"> </span>f<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>expect<span class=\"w\"> </span>g<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice a completer</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 9</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 12</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 1</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 2 : linearite de l'esperance\\n-- TODO etudiant\\ntheorem expectAdd (f g : Bool \\u2192 Float) :\\n    expect (fun b => f b + g b) = expect f + expect g := by\\n  sorry\\n-- Exercice a completer\", \"env\": 8}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 2 : linearite de l'esperance\\n-- TODO etudiant\\ntheorem expectAdd (f g : Bool \\u2192 Float) :\\n    expect (fun b => f b + g b) = expect f + expect g := by\\n  sorry\\n-- Exercice a completer\", \"env\": 11}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -1333,7 +2112,7 @@
        "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 17},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 9}</code>\n",
+       " \"env\": 12}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -1345,11 +2124,11 @@
        "    expect (fun b => f b + g b) = expect f + expect g := by\n",
        "  sorry\n",
        "-- Exercice a completer\n",
-       "--% env 9\n",
+       "--% env 12\n",
        "--% prove 1\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 2 : linearite de l'esperance\\n-- TODO etudiant\\ntheorem expectAdd (f g : Bool \\u2192 Float) :\\n    expect (fun b => f b + g b) = expect f + expect g := by\\n  sorry\\n-- Exercice a completer\", \"env\": 8}\n",
+       "{\"cmd\": \"-- Exercice 2 : linearite de l'esperance\\n-- TODO etudiant\\ntheorem expectAdd (f g : Bool \\u2192 Float) :\\n    expect (fun b => f b + g b) = expect f + expect g := by\\n  sorry\\n-- Exercice a completer\", \"env\": 11}\n",
        "Raw output:\n",
        "{\"sorries\":\r\n",
        " [{\"proofState\": 1,\r\n",
@@ -1362,7 +2141,7 @@
        "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 17},\r\n",
        "   \"data\": \"declaration uses `sorry`\"}],\r\n",
-       " \"env\": 9}"
+       " \"env\": 12}"
       ]
      },
      "metadata": {},
@@ -1381,7 +2160,16 @@
   {
    "cell_type": "markdown",
    "id": "35069cac",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.019198,
+     "end_time": "2026-08-23T02:23:03.641365+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:03.622167+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 : budget d'uniformite\n",
     "\n",
@@ -1391,15 +2179,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "bb413c79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T08:08:39.606583Z",
-     "iopub.status.busy": "2026-08-19T08:08:39.605964Z",
-     "iopub.status.idle": "2026-08-19T08:08:39.719034Z",
-     "shell.execute_reply": "2026-08-19T08:08:39.717127Z"
-    }
+     "iopub.execute_input": "2026-08-23T02:23:03.688055Z",
+     "iopub.status.busy": "2026-08-23T02:23:03.687872Z",
+     "iopub.status.idle": "2026-08-23T02:23:03.888443Z",
+     "shell.execute_reply": "2026-08-23T02:23:03.887635Z"
+    },
+    "papermill": {
+     "duration": 0.222993,
+     "end_time": "2026-08-23T02:23:03.889014+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:03.666021+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1416,13 +2212,13 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : capacite maximale sous budget</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : remplacer 0 par le calcul (budget 0.05 / delta0 0.001)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">def</span><span class=\"w\"> </span>kMax<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mi\">0</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"k\">#eval</span><span class=\"w\"> </span>kMax<span class=\"w\">   </span><span class=\"c1\">-- doit rendre 50</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 10</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>kMax<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"mi\">0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1e\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1e\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>kMax<span class=\"w\">   </span><span class=\"c1\">-- doit rendre 50</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 13</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 3 : capacite maximale sous budget\\n-- TODO etudiant : remplacer 0 par le calcul (budget 0.05 / delta0 0.001)\\ndef kMax : Nat := 0\\n#eval kMax   -- doit rendre 50\", \"env\": 9}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 3 : capacite maximale sous budget\\n-- TODO etudiant : remplacer 0 par le calcul (budget 0.05 / delta0 0.001)\\ndef kMax : Nat := 0\\n#eval kMax   -- doit rendre 50\", \"env\": 12}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -1431,7 +2227,7 @@
        "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
        "   \"data\": \"0\"}],\r\n",
-       " \"env\": 10}</code>\n",
+       " \"env\": 13}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -1441,17 +2237,17 @@
        "def kMax : Nat := 0\n",
        "#eval kMax   -- doit rendre 50\n",
        "─────▶  0\n",
-       "--% env 10\n",
+       "--% env 13\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 3 : capacite maximale sous budget\\n-- TODO etudiant : remplacer 0 par le calcul (budget 0.05 / delta0 0.001)\\ndef kMax : Nat := 0\\n#eval kMax   -- doit rendre 50\", \"env\": 9}\n",
+       "{\"cmd\": \"-- Exercice 3 : capacite maximale sous budget\\n-- TODO etudiant : remplacer 0 par le calcul (budget 0.05 / delta0 0.001)\\ndef kMax : Nat := 0\\n#eval kMax   -- doit rendre 50\", \"env\": 12}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
        "   \"data\": \"0\"}],\r\n",
-       " \"env\": 10}"
+       " \"env\": 13}"
       ]
      },
      "metadata": {},
@@ -1468,14 +2264,34 @@
   {
    "cell_type": "markdown",
    "id": "1b5b7d4e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.025931,
+     "end_time": "2026-08-23T02:23:03.931607+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T02:23:03.905676+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Ce que ce compagnon couvre -- et ce qu'il ne couvre pas\n",
     "\n",
     "**Couvert** (declarations du lake rendues visibles, par section) :\n",
     "`Concentration.lean` (section 2), `SampleExpect.lean` (3), `MGF.lean` et\n",
     "`BernoulliMGF.lean` (4), `Hoeffding.lean` (5), `UnionBound.lean` (6), `ERM.lean` (7),\n",
-    "`PacFiniteBound.lean` (8), `Agnostic.lean` (9) -- soit 9 des 15 modules invisibles.\n",
+    "`PacFiniteBound.lean` (8), `Agnostic.lean` (9) — et, nativement cette fois (import\n",
+    "réel et `#check`), `Sample.lean` et `UniformConcentration.lean` (section 10) : les\n",
+    "versions simplifiées des sections 2-9 étaient les doubles pédagogiques, la section 10\n",
+    "exécute les originaux. Le module racine `PacLearning.lean` restera « invisible » au\n",
+    "scanner par construction : c'est un agrégateur d'imports sans déclaration propre,\n",
+    "il n'a rien à citer.\n",
+    "\n",
+    "**L'arc, en une phrase** : une perte bornée (Markov) → sa fonction génératrice (MGF)\n",
+    "→ la queue exponentielle d'une hypothèse (Hoeffding) → la somme sur la classe finie\n",
+    "(union bound) → la concentration **uniforme** exécutée en section 10. Chaque brique\n",
+    "est un module, chaque module est une section, et la section 10 referme le cercle en\n",
+    "faisant tourner le tout — non plus en copie simplifiée, mais dans le compilateur.\n",
     "\n",
     "**Non couvert ici** : la partie `Perceptron` du lake (`Perceptron.lean`, `Data.lean`,\n",
     "`Convergence.lean`, `Tightness.lean` -- 21 declarations) et la formalisation complete\n",
@@ -1492,10 +2308,22 @@
    "name": "lean4-wsl"
   },
   "language_info": {
-   "codemirror_mode": "python",
+   "codemirror_mode": "lean4",
    "file_extension": ".lean",
    "mimetype": "text/x-lean4",
    "name": "lean4"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 33.348895,
+   "end_time": "2026-08-23T02:23:07.010040+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "2.8b-Theorie-PAC-Lean.ipynb",
+   "output_path": "2.8b-Theorie-PAC-Lean.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-23T02:22:33.661145+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2025:CoursIA — prev: DEEP/notebook-lean #12426

## Summary

Enrichissement du compagnon `2.8b-Theorie-PAC-Lean.ipynb` (EPIC #11703, vague V5 `learning_theory_lean`) : le lake est désormais **importé nativement** en tête de session, et une **section 10** interroge par `#check` / `#print axioms` / `#eval` les deux seuls vrais modules noirs du lake : `PacLearning/Sample.lean` et `PacLearning/UniformConcentration.lean`.

Le caveau de la version précédente était explicite dans sa cellule d'intro : « les `olean` du lake exigent Mathlib, non construits sur ce poste » — d'où des versions simplifiées re-définies localement. Le cache d'oleans est construit (Mathlib v4.32.1 partagé depuis `conway_lean`), le caveat est levé : les sections 2-9 restent le déroulé simplifié, la section 10 exécute les **originaux**.

## Mesure de visibilité (preuve du grain, scanner de l'EPIC)

```text
$ python scripts/lean/scan_lake_notebook_visibility.py --lake learning_theory_lean
learning_theory_lean   105 decl   cite_strict 27 -> 32   modules noirs 3 -> 1/16
```

Mesuré sur le corpus branch (tirage depuis le worktree, 1081 notebooks) : `cite_strict`
27 → **32**, modules noirs de learning_theory_lean 3 → **1**, et sur tout le dépôt les
modules invisibles passent de 25 → **23** (le seul delta du dépôt vient de ce notebook).

- `Sample.lean` et `UniformConcentration.lean` quittent la liste noire (+3 noms distinctifs cités : `sampleWeight`, `sampleWeight_sum_one`, `uniform_concentration`).
- Le restant, `PacLearning.lean` (racine), porte une **seule** déclaration et elle est non-citable : `abbrev Status : Prop := True` (l.155, marqueur de chantier — 6 caractères, sans `_`, jamais « distinctive » au sens du scanner). Le module est donc invisible **par construction**, pas par lacune : il n'a rien de mathématiquement distinctif à offrir à un lecteur. Faux-noir signalé pour l'EPIC.

## Contenu ajouté (6 cellules nouvelles + 3 étendues)

1. **Imports en tête de session** (pattern Lean-26/Lean-16h) : `import PacLearning.UniformConcentration` — tire la chaîne `Data → Sample → SampleExpect → MGF → BernoulliMGF → Hoeffding → UnionBound` + Mathlib. Le module racine n'est PAS importé (il ne référence pas `UniformConcentration` et n'a qu'un marqueur `Status` trivial à offrir). Handshake : `#check` sur `Distribution`, `Hypothesis`, `trueError`, `sampleProb`, `sampleWeight`, `uniform_concentration`.
2. **Section 10** : prose de fond (distribution produit `D^m`, Fubini discret `sum_pow'`, le doublement fini `2·|Hs|·exp(−2nε²)`, réalisable `1/ε` vs agnostique `1/ε²`) + cellule d'interrogation (`#check` + `#print axioms` des deux preuves) + cellule d'évaluation (`tailBound` sur grille `|Hs| × n`, `Float.exp`) + interprétation ancrée aux valeurs rendues.
3. Table des modules (cellule 1), paragraphe « Forme » (cellule 0) et conclusion étendus (11 modules couverts ; l'arc Markov → MGF → Hoeffding → union bound → uniformité refermé).

## Exécution réelle (H.1/C.2)

- `lake build PacLearning.UniformConcentration PacLearning.Sample` local (WSL, oleans Mathlib v4.32.1 partagés depuis `conway_lean`) : **SUCCESS, 8663 jobs, exit 0**.
- Papermill kernel `lean4-wsl`, cwd = `~/ltbuild` (dossier du lake — recette EPIC : le lake n'est pas ancêtre du notebook) : **33/33 cellules**, exec 1..14, 0 `execution_count` null.
- Vérification scriptée des sorties rendues (piège connu du kernel lean4-wsl : les erreurs vivent dans les outputs HTML, le « N/N OK » de papermill est aveugle) : **0 marqueur `❌`/`error:`/`unknown constant`**.
- **Valeurs ancrées** — l'interprétation de la section 10 cite les valeurs rendues (pas une prédiction). `#print axioms` confirme `[propext, Classical.choice, Quot.sound]` (le standard d'une preuve constructive : pas de `sorry`). `#eval tailBound` rend :
  `cardH=1 → 0.270671` · `10 → 2.706706` · `100 → 27.067057` · `100,415 → 0.049703` · `100,600 → 0.001229`.

## Validation

- Densité (outil officiel `pedagogy_density.py`) : **821 → 1210** c/cell — le notebook sort du label `pedagogy-density-below-threshold` ; md_pct 59.5 → 69.1 (calculé : 14 cellules code, 16940 caractères markdown / 24512).
- C.1 : aucun `sorry` ajouté (les 3 exercices existants, patron GameTheory-15b, inchangés) ; aucune erreur volontaire.
- C.3 : seul ce notebook est modifié ; re-exécution complète (cellules sources ajoutées).
- Prose accentuée dès la rédaction (leçon #2876).

See #11703 (EPIC — vague V5, pas de clôture)
