### PR TITLE
fix(search,#12465): A* sous-optimal avec heuristique non admissible (exemple guide 2)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -5,10 +5,10 @@
    "id": "nav-header",
    "metadata": {
     "papermill": {
-     "duration": 0.044748,
-     "end_time": "2026-07-09T22:53:52.328044+00:00",
+     "duration": 0.00592,
+     "end_time": "2026-08-23T02:44:54.335807",
      "exception": false,
-     "start_time": "2026-07-09T22:53:52.283296+00:00",
+     "start_time": "2026-08-23T02:44:54.329887",
      "status": "completed"
     },
     "tags": []
@@ -40,16 +40,16 @@
    "id": "imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T11:24:32.433609Z",
-     "iopub.status.busy": "2026-07-12T11:24:32.433165Z",
-     "iopub.status.idle": "2026-07-12T11:24:33.159157Z",
-     "shell.execute_reply": "2026-07-12T11:24:33.158623Z"
+     "iopub.execute_input": "2026-08-23T02:44:54.345316Z",
+     "iopub.status.busy": "2026-08-23T02:44:54.344925Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.227879Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.227456Z"
     },
     "papermill": {
-     "duration": 1.656798,
-     "end_time": "2026-07-09T22:53:53.999533+00:00",
+     "duration": 0.888585,
+     "end_time": "2026-08-23T02:44:55.228658",
      "exception": false,
-     "start_time": "2026-07-09T22:53:52.342735+00:00",
+     "start_time": "2026-08-23T02:44:54.340073",
      "status": "completed"
     },
     "tags": []
@@ -95,10 +95,10 @@
    "id": "intro-section",
    "metadata": {
     "papermill": {
-     "duration": 0.059391,
-     "end_time": "2026-07-09T22:53:54.128083+00:00",
+     "duration": 0.004341,
+     "end_time": "2026-08-23T02:44:55.237404",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.068692+00:00",
+     "start_time": "2026-08-23T02:44:55.233063",
      "status": "completed"
     },
     "tags": []
@@ -147,10 +147,10 @@
    "id": "framework-section",
    "metadata": {
     "papermill": {
-     "duration": 0.023825,
-     "end_time": "2026-07-09T22:53:54.186622+00:00",
+     "duration": 0.005935,
+     "end_time": "2026-08-23T02:44:55.247377",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.162797+00:00",
+     "start_time": "2026-08-23T02:44:55.241442",
      "status": "completed"
     },
     "tags": []
@@ -169,16 +169,16 @@
    "id": "node-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:54.246240Z",
-     "iopub.status.busy": "2026-07-09T22:53:54.242981Z",
-     "iopub.status.idle": "2026-07-09T22:53:54.278212Z",
-     "shell.execute_reply": "2026-07-09T22:53:54.276808Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.256906Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.256610Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.264469Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.264059Z"
     },
     "papermill": {
-     "duration": 0.064977,
-     "end_time": "2026-07-09T22:53:54.279591+00:00",
+     "duration": 0.013277,
+     "end_time": "2026-08-23T02:44:55.265141",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.214614+00:00",
+     "start_time": "2026-08-23T02:44:55.251864",
      "status": "completed"
     },
     "tags": []
@@ -333,10 +333,10 @@
    "id": "problem-example-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.018388,
-     "end_time": "2026-07-09T22:53:54.309811+00:00",
+     "duration": 0.003951,
+     "end_time": "2026-08-23T02:44:55.273847",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.291423+00:00",
+     "start_time": "2026-08-23T02:44:55.269896",
      "status": "completed"
     },
     "tags": []
@@ -353,16 +353,16 @@
    "id": "graph-problem",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:54.368535Z",
-     "iopub.status.busy": "2026-07-09T22:53:54.367775Z",
-     "iopub.status.idle": "2026-07-09T22:53:54.405634Z",
-     "shell.execute_reply": "2026-07-09T22:53:54.395891Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.282826Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.282636Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.288335Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.287903Z"
     },
     "papermill": {
-     "duration": 0.070027,
-     "end_time": "2026-07-09T22:53:54.411615+00:00",
+     "duration": 0.011218,
+     "end_time": "2026-08-23T02:44:55.289065",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.341588+00:00",
+     "start_time": "2026-08-23T02:44:55.277847",
      "status": "completed"
     },
     "tags": []
@@ -442,10 +442,10 @@
    "id": "heuristic-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.034188,
-     "end_time": "2026-07-09T22:53:54.465452+00:00",
+     "duration": 0.004145,
+     "end_time": "2026-08-23T02:44:55.297653",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.431264+00:00",
+     "start_time": "2026-08-23T02:44:55.293508",
      "status": "completed"
     },
     "tags": []
@@ -465,16 +465,16 @@
    "id": "heuristic-function",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:54.519503Z",
-     "iopub.status.busy": "2026-07-09T22:53:54.519123Z",
-     "iopub.status.idle": "2026-07-09T22:53:54.534467Z",
-     "shell.execute_reply": "2026-07-09T22:53:54.532009Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.306898Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.306660Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.311758Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.311153Z"
     },
     "papermill": {
-     "duration": 0.03869,
-     "end_time": "2026-07-09T22:53:54.537223+00:00",
+     "duration": 0.010961,
+     "end_time": "2026-08-23T02:44:55.312702",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.498533+00:00",
+     "start_time": "2026-08-23T02:44:55.301741",
      "status": "completed"
     },
     "tags": []
@@ -534,10 +534,10 @@
    "id": "greedy-section",
    "metadata": {
     "papermill": {
-     "duration": 0.011821,
-     "end_time": "2026-07-09T22:53:54.562749+00:00",
+     "duration": 0.004372,
+     "end_time": "2026-08-23T02:44:55.321948",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.550928+00:00",
+     "start_time": "2026-08-23T02:44:55.317576",
      "status": "completed"
     },
     "tags": []
@@ -571,16 +571,16 @@
    "id": "greedy-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:54.647371Z",
-     "iopub.status.busy": "2026-07-09T22:53:54.647129Z",
-     "iopub.status.idle": "2026-07-09T22:53:54.665633Z",
-     "shell.execute_reply": "2026-07-09T22:53:54.662554Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.333319Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.332861Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.338636Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.338062Z"
     },
     "papermill": {
-     "duration": 0.082037,
-     "end_time": "2026-07-09T22:53:54.668665+00:00",
+     "duration": 0.011747,
+     "end_time": "2026-08-23T02:44:55.339323",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.586628+00:00",
+     "start_time": "2026-08-23T02:44:55.327576",
      "status": "completed"
     },
     "tags": []
@@ -670,10 +670,10 @@
    "id": "340234eb",
    "metadata": {
     "papermill": {
-     "duration": 0.021805,
-     "end_time": "2026-07-09T22:53:54.736140+00:00",
+     "duration": 0.004868,
+     "end_time": "2026-08-23T02:44:55.349244",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.714335+00:00",
+     "start_time": "2026-08-23T02:44:55.344376",
      "status": "completed"
     },
     "tags": []
@@ -688,16 +688,16 @@
    "id": "greedy-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:54.767140Z",
-     "iopub.status.busy": "2026-07-09T22:53:54.766487Z",
-     "iopub.status.idle": "2026-07-09T22:53:54.795382Z",
-     "shell.execute_reply": "2026-07-09T22:53:54.792373Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.360080Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.359697Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.363417Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.362983Z"
     },
     "papermill": {
-     "duration": 0.053292,
-     "end_time": "2026-07-09T22:53:54.798687+00:00",
+     "duration": 0.010297,
+     "end_time": "2026-08-23T02:44:55.364418",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.745395+00:00",
+     "start_time": "2026-08-23T02:44:55.354121",
      "status": "completed"
     },
     "tags": []
@@ -719,7 +719,7 @@
       "  Noeuds explores  : 2\n",
       "  Noeuds generes   : 8\n",
       "  Frontiere max    : 5\n",
-      "  Temps            : 0.27 ms\n"
+      "  Temps            : 0.07 ms\n"
      ]
     }
    ],
@@ -737,10 +737,10 @@
    "id": "dcjquopv3vv",
    "metadata": {
     "papermill": {
-     "duration": 0.008274,
-     "end_time": "2026-07-09T22:53:54.817362+00:00",
+     "duration": 0.007468,
+     "end_time": "2026-08-23T02:44:55.378815",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.809088+00:00",
+     "start_time": "2026-08-23T02:44:55.371347",
      "status": "completed"
     },
     "tags": []
@@ -767,10 +767,10 @@
    "id": "greedy-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.013762,
-     "end_time": "2026-07-09T22:53:54.842461+00:00",
+     "duration": 0.009564,
+     "end_time": "2026-08-23T02:44:55.396593",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.828699+00:00",
+     "start_time": "2026-08-23T02:44:55.387029",
      "status": "completed"
     },
     "tags": []
@@ -797,10 +797,10 @@
    "id": "astar-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009993,
-     "end_time": "2026-07-09T22:53:54.865462+00:00",
+     "duration": 0.007855,
+     "end_time": "2026-08-23T02:44:55.413179",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.855469+00:00",
+     "start_time": "2026-08-23T02:44:55.405324",
      "status": "completed"
     },
     "tags": []
@@ -848,16 +848,16 @@
    "id": "astar-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:54.896095Z",
-     "iopub.status.busy": "2026-07-09T22:53:54.894389Z",
-     "iopub.status.idle": "2026-07-09T22:53:54.922670Z",
-     "shell.execute_reply": "2026-07-09T22:53:54.921283Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.423349Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.423159Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.428578Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.428153Z"
     },
     "papermill": {
-     "duration": 0.0475,
-     "end_time": "2026-07-09T22:53:54.923758+00:00",
+     "duration": 0.011077,
+     "end_time": "2026-08-23T02:44:55.429398",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.876258+00:00",
+     "start_time": "2026-08-23T02:44:55.418321",
      "status": "completed"
     },
     "tags": []
@@ -950,10 +950,10 @@
    "id": "8a172994",
    "metadata": {
     "papermill": {
-     "duration": 0.011353,
-     "end_time": "2026-07-09T22:53:54.949621+00:00",
+     "duration": 0.004651,
+     "end_time": "2026-08-23T02:44:55.439022",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.938268+00:00",
+     "start_time": "2026-08-23T02:44:55.434371",
      "status": "completed"
     },
     "tags": []
@@ -968,16 +968,16 @@
    "id": "astar-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:54.967661Z",
-     "iopub.status.busy": "2026-07-09T22:53:54.967321Z",
-     "iopub.status.idle": "2026-07-09T22:53:54.973627Z",
-     "shell.execute_reply": "2026-07-09T22:53:54.972563Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.449132Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.448856Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.452336Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.451849Z"
     },
     "papermill": {
-     "duration": 0.016137,
-     "end_time": "2026-07-09T22:53:54.974447+00:00",
+     "duration": 0.009518,
+     "end_time": "2026-08-23T02:44:55.453052",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.958310+00:00",
+     "start_time": "2026-08-23T02:44:55.443534",
      "status": "completed"
     },
     "tags": []
@@ -1000,7 +1000,7 @@
       "  Noeuds explores  : 3\n",
       "  Noeuds generes   : 11\n",
       "  Frontiere max    : 6\n",
-      "  Temps            : 0.12 ms\n"
+      "  Temps            : 0.08 ms\n"
      ]
     }
    ],
@@ -1018,10 +1018,10 @@
    "id": "1mddry1upc6",
    "metadata": {
     "papermill": {
-     "duration": 0.009739,
-     "end_time": "2026-07-09T22:53:54.992062+00:00",
+     "duration": 0.004624,
+     "end_time": "2026-08-23T02:44:55.463445",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.982323+00:00",
+     "start_time": "2026-08-23T02:44:55.458821",
      "status": "completed"
     },
     "tags": []
@@ -1045,10 +1045,10 @@
    "id": "astar-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.010528,
-     "end_time": "2026-07-09T22:53:55.010140+00:00",
+     "duration": 0.004855,
+     "end_time": "2026-08-23T02:44:55.472773",
      "exception": false,
-     "start_time": "2026-07-09T22:53:54.999612+00:00",
+     "start_time": "2026-08-23T02:44:55.467918",
      "status": "completed"
     },
     "tags": []
@@ -1074,10 +1074,10 @@
    "id": "comparison-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009607,
-     "end_time": "2026-07-09T22:53:55.033049+00:00",
+     "duration": 0.004505,
+     "end_time": "2026-08-23T02:44:55.481868",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.023442+00:00",
+     "start_time": "2026-08-23T02:44:55.477363",
      "status": "completed"
     },
     "tags": []
@@ -1094,16 +1094,16 @@
    "id": "comparison-greedy-astar",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:55.055341Z",
-     "iopub.status.busy": "2026-07-09T22:53:55.054937Z",
-     "iopub.status.idle": "2026-07-09T22:53:55.091492Z",
-     "shell.execute_reply": "2026-07-09T22:53:55.090477Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.492700Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.492296Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.502935Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.502467Z"
     },
     "papermill": {
-     "duration": 0.049395,
-     "end_time": "2026-07-09T22:53:55.092307+00:00",
+     "duration": 0.017396,
+     "end_time": "2026-08-23T02:44:55.503834",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.042912+00:00",
+     "start_time": "2026-08-23T02:44:55.486438",
      "status": "completed"
     },
     "tags": []
@@ -1116,8 +1116,8 @@
       "Comparaison : Greedy vs A*\n",
       "======================================================================\n",
       "Algorithme                          Chemin  Cout (km)  Longueur  Noeuds explores Temps (ms)\n",
-      "    Greedy Bordeaux -> Paris -> Strasbourg       1075         2                2       0.04\n",
-      "        A* Bordeaux -> Paris -> Strasbourg       1075         2                3       0.04\n",
+      "    Greedy Bordeaux -> Paris -> Strasbourg       1075         2                2       0.03\n",
+      "        A* Bordeaux -> Paris -> Strasbourg       1075         2                3       0.02\n",
       "\n",
       "======================================================================\n",
       "NOTE : sur ce trajet, Greedy egale A* -- mais rien ne le garantit.\n",
@@ -1172,10 +1172,10 @@
    "id": "6ab7895c",
    "metadata": {
     "papermill": {
-     "duration": 0.008248,
-     "end_time": "2026-07-09T22:53:55.109451+00:00",
+     "duration": 0.004635,
+     "end_time": "2026-08-23T02:44:55.513337",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.101203+00:00",
+     "start_time": "2026-08-23T02:44:55.508702",
      "status": "completed"
     },
     "tags": []
@@ -1201,16 +1201,16 @@
    "id": "ca315179",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:55.128446Z",
-     "iopub.status.busy": "2026-07-09T22:53:55.128206Z",
-     "iopub.status.idle": "2026-07-09T22:53:55.140424Z",
-     "shell.execute_reply": "2026-07-09T22:53:55.139407Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.524670Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.524366Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.531263Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.530748Z"
     },
     "papermill": {
-     "duration": 0.023352,
-     "end_time": "2026-07-09T22:53:55.141396+00:00",
+     "duration": 0.01391,
+     "end_time": "2026-08-23T02:44:55.532067",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.118044+00:00",
+     "start_time": "2026-08-23T02:44:55.518157",
      "status": "completed"
     },
     "tags": []
@@ -1223,8 +1223,8 @@
       "Comparaison : Greedy vs A* sur Nice -> Bordeaux\n",
       "======================================================================\n",
       "Algorithme                                        Chemin  Cout (km)  Longueur  Noeuds explores Temps (ms)\n",
-      "    Greedy Nice -> Grenoble -> Lyon -> Paris -> Bordeaux       1490         4                4       0.06\n",
-      "        A*     Nice -> Marseille -> Toulouse -> Bordeaux        850         3                5       0.04\n",
+      "    Greedy Nice -> Grenoble -> Lyon -> Paris -> Bordeaux       1490         4                4       0.04\n",
+      "        A*     Nice -> Marseille -> Toulouse -> Bordeaux        850         3                5       0.02\n",
       "\n",
       "======================================================================\n",
       "Greedy a trouve un chemin 640 km plus long (75.3% de plus).\n",
@@ -1282,10 +1282,10 @@
    "id": "comparison-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.008629,
-     "end_time": "2026-07-09T22:53:55.158480+00:00",
+     "duration": 0.005304,
+     "end_time": "2026-08-23T02:44:55.542554",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.149851+00:00",
+     "start_time": "2026-08-23T02:44:55.537250",
      "status": "completed"
     },
     "tags": []
@@ -1309,10 +1309,10 @@
    "id": "ida-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009423,
-     "end_time": "2026-07-09T22:53:55.175069+00:00",
+     "duration": 0.004536,
+     "end_time": "2026-08-23T02:44:55.551684",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.165646+00:00",
+     "start_time": "2026-08-23T02:44:55.547148",
      "status": "completed"
     },
     "tags": []
@@ -1346,16 +1346,16 @@
    "id": "idastar-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:55.200657Z",
-     "iopub.status.busy": "2026-07-09T22:53:55.200261Z",
-     "iopub.status.idle": "2026-07-09T22:53:55.212998Z",
-     "shell.execute_reply": "2026-07-09T22:53:55.212292Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.562178Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.561881Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.567189Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.566774Z"
     },
     "papermill": {
-     "duration": 0.03079,
-     "end_time": "2026-07-09T22:53:55.213715+00:00",
+     "duration": 0.01162,
+     "end_time": "2026-08-23T02:44:55.567909",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.182925+00:00",
+     "start_time": "2026-08-23T02:44:55.556289",
      "status": "completed"
     },
     "tags": []
@@ -1449,10 +1449,10 @@
    "id": "40f8a8e5",
    "metadata": {
     "papermill": {
-     "duration": 0.032262,
-     "end_time": "2026-07-09T22:53:55.260556+00:00",
+     "duration": 0.004725,
+     "end_time": "2026-08-23T02:44:55.577539",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.228294+00:00",
+     "start_time": "2026-08-23T02:44:55.572814",
      "status": "completed"
     },
     "tags": []
@@ -1467,16 +1467,16 @@
    "id": "idastar-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:55.287884Z",
-     "iopub.status.busy": "2026-07-09T22:53:55.287486Z",
-     "iopub.status.idle": "2026-07-09T22:53:55.293764Z",
-     "shell.execute_reply": "2026-07-09T22:53:55.292712Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.588027Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.587705Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.590971Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.590574Z"
     },
     "papermill": {
-     "duration": 0.017612,
-     "end_time": "2026-07-09T22:53:55.294601+00:00",
+     "duration": 0.009327,
+     "end_time": "2026-08-23T02:44:55.591686",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.276989+00:00",
+     "start_time": "2026-08-23T02:44:55.582359",
      "status": "completed"
     },
     "tags": []
@@ -1500,7 +1500,7 @@
       "  Noeuds explores  : 8\n",
       "  Noeuds generes   : 24\n",
       "  Frontiere max    : 4\n",
-      "  Temps            : 0.14 ms\n"
+      "  Temps            : 0.08 ms\n"
      ]
     }
    ],
@@ -1518,10 +1518,10 @@
    "id": "0gzwacp0hfbq",
    "metadata": {
     "papermill": {
-     "duration": 0.007979,
-     "end_time": "2026-07-09T22:53:55.312351+00:00",
+     "duration": 0.004421,
+     "end_time": "2026-08-23T02:44:55.600894",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.304372+00:00",
+     "start_time": "2026-08-23T02:44:55.596473",
      "status": "completed"
     },
     "tags": []
@@ -1545,10 +1545,10 @@
    "id": "idastar-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.008091,
-     "end_time": "2026-07-09T22:53:55.328979+00:00",
+     "duration": 0.004352,
+     "end_time": "2026-08-23T02:44:55.610012",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.320888+00:00",
+     "start_time": "2026-08-23T02:44:55.605660",
      "status": "completed"
     },
     "tags": []
@@ -1576,10 +1576,10 @@
    "id": "752d920b",
    "metadata": {
     "papermill": {
-     "duration": 0.011633,
-     "end_time": "2026-07-09T22:53:55.355390+00:00",
+     "duration": 0.004344,
+     "end_time": "2026-08-23T02:44:55.619015",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.343757+00:00",
+     "start_time": "2026-08-23T02:44:55.614671",
      "status": "completed"
     },
     "tags": []
@@ -1605,16 +1605,16 @@
    "id": "b119ca90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:55.375331Z",
-     "iopub.status.busy": "2026-07-09T22:53:55.374967Z",
-     "iopub.status.idle": "2026-07-09T22:53:55.381170Z",
-     "shell.execute_reply": "2026-07-09T22:53:55.380308Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.629685Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.629413Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.633103Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.632664Z"
     },
     "papermill": {
-     "duration": 0.018192,
-     "end_time": "2026-07-09T22:53:55.382047+00:00",
+     "duration": 0.010588,
+     "end_time": "2026-08-23T02:44:55.634806",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.363855+00:00",
+     "start_time": "2026-08-23T02:44:55.624218",
      "status": "completed"
     },
     "tags": []
@@ -1645,10 +1645,10 @@
    "id": "all-comparison-section",
    "metadata": {
     "papermill": {
-     "duration": 0.01584,
-     "end_time": "2026-07-09T22:53:55.407722+00:00",
+     "duration": 0.004739,
+     "end_time": "2026-08-23T02:44:55.644251",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.391882+00:00",
+     "start_time": "2026-08-23T02:44:55.639512",
      "status": "completed"
     },
     "tags": []
@@ -1665,16 +1665,16 @@
    "id": "all-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:55.427618Z",
-     "iopub.status.busy": "2026-07-09T22:53:55.427387Z",
-     "iopub.status.idle": "2026-07-09T22:53:55.436378Z",
-     "shell.execute_reply": "2026-07-09T22:53:55.435198Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.655749Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.655545Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.661697Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.661160Z"
     },
     "papermill": {
-     "duration": 0.021339,
-     "end_time": "2026-07-09T22:53:55.438872+00:00",
+     "duration": 0.013339,
+     "end_time": "2026-08-23T02:44:55.662385",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.417533+00:00",
+     "start_time": "2026-08-23T02:44:55.649046",
      "status": "completed"
     },
     "tags": []
@@ -1772,10 +1772,10 @@
    "id": "all-comparison-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.010812,
-     "end_time": "2026-07-09T22:53:55.470444+00:00",
+     "duration": 0.004857,
+     "end_time": "2026-08-23T02:44:55.672505",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.459632+00:00",
+     "start_time": "2026-08-23T02:44:55.667648",
      "status": "completed"
     },
     "tags": []
@@ -1804,10 +1804,10 @@
    "id": "heuristic-design-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009509,
-     "end_time": "2026-07-09T22:53:55.489185+00:00",
+     "duration": 0.004821,
+     "end_time": "2026-08-23T02:44:55.682135",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.479676+00:00",
+     "start_time": "2026-08-23T02:44:55.677314",
      "status": "completed"
     },
     "tags": []
@@ -1823,10 +1823,10 @@
    "id": "admissibility-section",
    "metadata": {
     "papermill": {
-     "duration": 0.010486,
-     "end_time": "2026-07-09T22:53:55.509286+00:00",
+     "duration": 0.004863,
+     "end_time": "2026-08-23T02:44:55.692561",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.498800+00:00",
+     "start_time": "2026-08-23T02:44:55.687698",
      "status": "completed"
     },
     "tags": []
@@ -1855,10 +1855,10 @@
    "id": "consistency-section",
    "metadata": {
     "papermill": {
-     "duration": 0.008852,
-     "end_time": "2026-07-09T22:53:55.528685+00:00",
+     "duration": 0.004847,
+     "end_time": "2026-08-23T02:44:55.702534",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.519833+00:00",
+     "start_time": "2026-08-23T02:44:55.697687",
      "status": "completed"
     },
     "tags": []
@@ -1890,10 +1890,10 @@
    "id": "dominance-section",
    "metadata": {
     "papermill": {
-     "duration": 0.008869,
-     "end_time": "2026-07-09T22:53:55.545850+00:00",
+     "duration": 0.004823,
+     "end_time": "2026-08-23T02:44:55.712000",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.536981+00:00",
+     "start_time": "2026-08-23T02:44:55.707177",
      "status": "completed"
     },
     "tags": []
@@ -1924,10 +1924,10 @@
    "id": "puzzle-section",
    "metadata": {
     "papermill": {
-     "duration": 0.012204,
-     "end_time": "2026-07-09T22:53:55.569001+00:00",
+     "duration": 0.004975,
+     "end_time": "2026-08-23T02:44:55.722037",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.556797+00:00",
+     "start_time": "2026-08-23T02:44:55.717062",
      "status": "completed"
     },
     "tags": []
@@ -1951,16 +1951,16 @@
    "id": "puzzle-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:55.596323Z",
-     "iopub.status.busy": "2026-07-09T22:53:55.596102Z",
-     "iopub.status.idle": "2026-07-09T22:53:55.608893Z",
-     "shell.execute_reply": "2026-07-09T22:53:55.607906Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.734196Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.733909Z",
+     "iopub.status.idle": "2026-08-23T02:44:55.741312Z",
+     "shell.execute_reply": "2026-08-23T02:44:55.740845Z"
     },
     "papermill": {
-     "duration": 0.029797,
-     "end_time": "2026-07-09T22:53:55.609820+00:00",
+     "duration": 0.015471,
+     "end_time": "2026-08-23T02:44:55.742109",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.580023+00:00",
+     "start_time": "2026-08-23T02:44:55.726638",
      "status": "completed"
     },
     "tags": []
@@ -2098,10 +2098,10 @@
    "id": "b3189c7b",
    "metadata": {
     "papermill": {
-     "duration": 0.017766,
-     "end_time": "2026-07-09T22:53:55.638827+00:00",
+     "duration": 0.005227,
+     "end_time": "2026-08-23T02:44:55.752282",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.621061+00:00",
+     "start_time": "2026-08-23T02:44:55.747055",
      "status": "completed"
     },
     "tags": []
@@ -2116,16 +2116,16 @@
    "id": "puzzle-benchmark",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:55.720734Z",
-     "iopub.status.busy": "2026-07-09T22:53:55.717805Z",
-     "iopub.status.idle": "2026-07-09T22:54:00.870635Z",
-     "shell.execute_reply": "2026-07-09T22:54:00.866598Z"
+     "iopub.execute_input": "2026-08-23T02:44:55.762895Z",
+     "iopub.status.busy": "2026-08-23T02:44:55.762621Z",
+     "iopub.status.idle": "2026-08-23T02:44:56.898702Z",
+     "shell.execute_reply": "2026-08-23T02:44:56.898362Z"
     },
     "papermill": {
-     "duration": 5.21335,
-     "end_time": "2026-07-09T22:54:00.874054+00:00",
+     "duration": 1.142124,
+     "end_time": "2026-08-23T02:44:56.899363",
      "exception": false,
-     "start_time": "2026-07-09T22:53:55.660704+00:00",
+     "start_time": "2026-08-23T02:44:55.757239",
      "status": "completed"
     },
     "tags": []
@@ -2145,8 +2145,8 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees            1        1         0.29\n",
-      "Distance Manhattan            1        1         0.22\n",
+      "Tuiles mal placees            1        1         0.02\n",
+      "Distance Manhattan            1        1         0.01\n",
       "\n",
       "Reduction des noeuds explores : 0.0%\n",
       "\n",
@@ -2157,8 +2157,8 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees          770       16        25.18\n",
-      "Distance Manhattan          220       16         3.49\n",
+      "Tuiles mal placees          770       16         4.31\n",
+      "Distance Manhattan          220       16         1.28\n",
       "\n",
       "Reduction des noeuds explores : 71.4%\n",
       "\n",
@@ -2175,8 +2175,8 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees       143839       31      4181.53\n",
-      "Distance Manhattan        20290       31       829.55\n",
+      "Tuiles mal placees       143839       31       959.00\n",
+      "Distance Manhattan        20290       31       150.60\n",
       "\n",
       "Reduction des noeuds explores : 85.9%\n"
      ]
@@ -2184,8 +2184,8 @@
     {
      "data": {
       "text/plain": [
-       "(<__main__.SearchResult at 0x2547a3aa600>,\n",
-       " <__main__.SearchResult at 0x2547a3a8b90>)"
+       "(<__main__.SearchResult at 0x190fc3f1d00>,\n",
+       " <__main__.SearchResult at 0x190a9007bf0>)"
       ]
      },
      "execution_count": 16,
@@ -2237,10 +2237,10 @@
    "id": "k292t2mslp",
    "metadata": {
     "papermill": {
-     "duration": 0.039432,
-     "end_time": "2026-07-09T22:54:00.953691+00:00",
+     "duration": 0.004496,
+     "end_time": "2026-08-23T02:44:56.908526",
      "exception": false,
-     "start_time": "2026-07-09T22:54:00.914259+00:00",
+     "start_time": "2026-08-23T02:44:56.904030",
      "status": "completed"
     },
     "tags": []
@@ -2265,10 +2265,10 @@
    "id": "puzzle-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.022696,
-     "end_time": "2026-07-09T22:54:01.006554+00:00",
+     "duration": 0.004107,
+     "end_time": "2026-08-23T02:44:56.916954",
      "exception": false,
-     "start_time": "2026-07-09T22:54:00.983858+00:00",
+     "start_time": "2026-08-23T02:44:56.912847",
      "status": "completed"
     },
     "tags": []
@@ -2296,10 +2296,10 @@
    "id": "d7b928ea",
    "metadata": {
     "papermill": {
-     "duration": 0.070472,
-     "end_time": "2026-07-09T22:54:01.155675+00:00",
+     "duration": 0.004446,
+     "end_time": "2026-08-23T02:44:56.925588",
      "exception": false,
-     "start_time": "2026-07-09T22:54:01.085203+00:00",
+     "start_time": "2026-08-23T02:44:56.921142",
      "status": "completed"
     },
     "tags": []
@@ -2331,16 +2331,16 @@
    "id": "b55555ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:54:01.357746Z",
-     "iopub.status.busy": "2026-07-09T22:54:01.357318Z",
-     "iopub.status.idle": "2026-07-09T22:54:01.371272Z",
-     "shell.execute_reply": "2026-07-09T22:54:01.370174Z"
+     "iopub.execute_input": "2026-08-23T02:44:56.936472Z",
+     "iopub.status.busy": "2026-08-23T02:44:56.936109Z",
+     "iopub.status.idle": "2026-08-23T02:44:56.939566Z",
+     "shell.execute_reply": "2026-08-23T02:44:56.939057Z"
     },
     "papermill": {
-     "duration": 0.116103,
-     "end_time": "2026-07-09T22:54:01.372339+00:00",
+     "duration": 0.010157,
+     "end_time": "2026-08-23T02:44:56.940312",
      "exception": false,
-     "start_time": "2026-07-09T22:54:01.256236+00:00",
+     "start_time": "2026-08-23T02:44:56.930155",
      "status": "completed"
     },
     "tags": []
@@ -2374,10 +2374,10 @@
    "id": "visualization-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009292,
-     "end_time": "2026-07-09T22:54:01.400071+00:00",
+     "duration": 0.004424,
+     "end_time": "2026-08-23T02:44:56.949375",
      "exception": false,
-     "start_time": "2026-07-09T22:54:01.390779+00:00",
+     "start_time": "2026-08-23T02:44:56.944951",
      "status": "completed"
     },
     "tags": []
@@ -2394,16 +2394,16 @@
    "id": "puzzle-visualization",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:54:01.423512Z",
-     "iopub.status.busy": "2026-07-09T22:54:01.423058Z",
-     "iopub.status.idle": "2026-07-09T22:54:02.384565Z",
-     "shell.execute_reply": "2026-07-09T22:54:02.383825Z"
+     "iopub.execute_input": "2026-08-23T02:44:56.959428Z",
+     "iopub.status.busy": "2026-08-23T02:44:56.959228Z",
+     "iopub.status.idle": "2026-08-23T02:44:57.198942Z",
+     "shell.execute_reply": "2026-08-23T02:44:57.198424Z"
     },
     "papermill": {
-     "duration": 0.975832,
-     "end_time": "2026-07-09T22:54:02.385285+00:00",
+     "duration": 0.245871,
+     "end_time": "2026-08-23T02:44:57.199666",
      "exception": false,
-     "start_time": "2026-07-09T22:54:01.409453+00:00",
+     "start_time": "2026-08-23T02:44:56.953795",
      "status": "completed"
     },
     "tags": []
@@ -2411,7 +2411,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0cAAAJRCAYAAACOQsyxAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAcnhJREFUeJzt3QeYG9X18OGjsr26rHu3ca+AbcAJYKoxxXRCCxAghdAh9HymBEjoBAKBFP6EEhI6IRCCwSaAAYNtDMYFGzfc+3r7aqX5njNjaaVdSbsraVdlfu/zyFZbaTSaObpnzr13HIZhGAIAAAAANudM9gIAAAAAQCogOQIAAAAAkiMAAAAAsFA5AgAAAACSIwAAAACwUDkCAAAAAJIjAAAAALBQOQIAAAAAkiMAAAAAsFA5AtAmt956qzgcDvPyf//3f7Zbe/fee6/52Tt16iRVVVWSzgYMGBD4LhNNtw3/a+s2Y2fnn39+YF3MmTMn2YuDFNtXUpXGN41z+pk17gF2QXIE2zXogy8lJSUyZcoU+ctf/iKGYSR7MRGH4cOHh3y3n376adTnH3rooWajtS0qKyvlnnvuMa9fdNFFUlBQEHgs+L3XrFkT8nfaIPY/po2sTNqv9PLQQw+JHQR/j3pxuVxSWFgoAwcOlGOOOUb+9Kc/SW1tbbskmv51vXv3bslEus80Xbfr169v9ryxY8eGPO+Pf/yjpLvXXnst8P02jR2teby9aHy7+OKLzeuaHGn8A2zBAGxg5syZmvlEvVxwwQXJXsy0sHbtWuPDDz80L1u2bDFSwYIFC5p9n1dccUWz573wwgvGqlWrzOuHHHKIcd5555nXFy1aZLz11lstvs8jjzwSeP1ly5aFPBb83qtXrw55bPbs2YHH+vfvb6SKzz//PPBdxiLaZ9Jtw//aus1kguDvMdJl2LBhzbaNb7/9NrAudu/e3eb31W010raVKfRzNV2Xt912W8hzPvnkk2bPefzxxztk+XQb979nomkc8r+2bmNtfbw9LV++PPDeGv8AO6ByBNvRI7wffvihvPvuu+bRf7+nnnpKvvjii6h/6/P52uXIcGulQjeufv36yQ9+8APz0q1bN0kFf//735vd9+KLL5rfl5+25bXqM2LECLnhhhvMdbl9+3b56U9/KhMmTJAnn3yyxffRbUSNGjVKhg0bJunKvx3tv//+ge8y0XTb8L+2bjOZpkePHmYc+c9//iN33nmndO/e3bx/+fLlMm3atJAKzz777BNYF1qtRuvo/hZc0dfKHDrW0KFDzXin7NiNGjaV7OwM6OjKkb9aoHw+nzFw4MDAYw888ECz5//lL38x7rjjDqNfv36G0+kMHLnTv33iiSeMyZMnG4WFhUZOTo551PjGG28Me3T4xRdfNEaNGmU+T///xz/+EfI+Tz31VNijlHrU/eSTTzaKi4uNAQMGBJ6zdetW46qrrjKGDBliZGdnG6Wlpcb06dPNo6tN/fGPfzT2228/o6CgwHxur169jMMPP9z43e9+F3iO1+s1fvOb35jLlpubay5n3759zdf885//HHZdBi+zmj9/vnHqqaca3bt3N7Kyssz/TznlFOOLL74IeZ7+nf819PWeeeYZ83112fbZZx9z3bSWfg/63ehr6XLPmDEj4lHWhoYG409/+pPRu3fvwHP0/f75z3+2+D76Pfj/Rtd7U7FWjnT5//rXvxoHHXSQUVRUZH6GsWPHGg899JD5nYR7j6avEa6yEHwkXh//4IMPjAMOOMB8ff8+EOloeEvbS7RKrH/Zmn7Hwf7+978bI0eObNW+0JbP7Pfaa6+Zy6v7hC7/0KFDjVtvvdWorq6O+L0Ex4VIon2P33//vVFSUhJ4/JZbbmnxyL9e1+Xs1KmT4Xa7ja5duxoTJ040Lr/8cjOGtFSp8n/uq6++2jjwwAONHj16mJ9Xv7cJEyYY9957r+HxeEKWM3j5taJ1/PHHm8/XZfjZz35m1NTUNPvczz//vHHooYcG1qf+7TnnnBMS5+rr643777/f2HfffY38/HzzMmnSJHPfbo3g7TUvL89wuVzm9Xfeecd8fM+ePeZy6n26n4SrHL366qvm59E4qTFZY5DGhvPPP7/ZNhL8neh7/PrXvzbjgm6Tui9++eWXIc8P3le2bdtm/r2uD32f008/3dixY0fI81vznYSrlgVfgvehcBf/tnT33Xeb+4Muv+7fuv5GjBhh3HzzzUZVVVXEz7Fp0ybze4z2OdSVV14Z+Jt169a16vsE0hnJEWydHKlx48YFHvvtb3/b7PmDBg1q9oOkDdof/ehHEX+0hg8fbuzcuTPwHi+//LLhcDiaPS/4vSMlR8Hv72+QaUO9T58+Yd9bGwSvv/564LX+9re/RVxO/TH1u/322yM+b8qUKWHXZfAy63vqe7dmmYJ/9JuuX71oEtq0a1IkH330UeDvTjrpJLNh7L/905/+tFlypMlu8LrT5Oill15q8X20gej/m3ANvnCN1tY0qn/84x9HXO9nnHFGQpIjTW600dR0HwiXHLVme4knOdLEKNzfRdoX2vKZlTZyIy3bD3/4Q6Ourq5dkiOlBxf8jw8ePDhqcqTbtzZiIy3rihUrWp0caYO+td2F/ffrwZYuXbo0e742qIP95Cc/afH9NTHSJC/S86677roW123w9qoHVTTJ0eunnXaa+bgmQXpbG/LaiA+XHGlyF2kZ9DWDuwEHfyfhYpAmWMGJZfC+oolH0+efffbZIZ+nNd9JopIjPSgX6TlTp04NWa5Ivy2RPkfTmKD7L5Dp6FYH26qrq5NnnnlGvvrqq8B9Y8aMafa8VatWydlnny3//ve/5W9/+5v07t1b/vnPf8oLL7xgPq6z+WiXrFdffdUcLKyWLVsmN910k3nd6/XKlVdeGegectppp5mvdfnll8uiRYtaXM4tW7bIAw88IP/9738Dr3nJJZcEBiv/+Mc/Nrv2PP744+bgcI/HIz/5yU8CXadef/1183+3220OXn7vvffkueeek2uuucYcSO7nf15paak8++yzMmvWLPPz/vznP5eePXtGXUZ9rwsvvNB8b/WLX/xC3nrrLXM5ld6vj4frFqjrVx9788035fDDDzfv0+5wf/7zn6WtXepOPfVUOfroo6WoqMi8/fLLL0tDQ4N5Xdf/gQceaC7bmWeeaXYpO/bYY+Xggw+W008/XU455ZSo77N06dLA9SFDhkR9rq7X4EHjU6dODfu8l156yVzHSrvp6Wf517/+JQcccIB53z/+8Q/zEq+NGzdKnz59zO9Vv5cTTzwx4nNbs73o9qVdypp2MdOLfqZIdF+49tprA7d/9KMfmfvCVVdd1ap9oSWff/653HHHHeZ13WZ1ohXdN/R7Vrp8Dz74oLQX3b78vvvuu6gD2LVbb01NjXn9iiuuMNezrrvf/OY35rap241299RlHj9+fEh3Uf+69u+XN998s7nt6GfVSSNeeeUVmTx5cqArVLiJDfbs2SNlZWXmPuJfZ+qJJ54IXNfH/vrXv5rXdYIE/e50+9Ft9sgjjwzM3Pbwww+by69029VYqJ/F3/VUu7N+9tlnbVqX/i7Puj1q91d/l7qzzjpL8vLywv7NUUcdZS6/7kO6HnR96Hbrj6ORYsr3338vv/vd78z11rdvX/M+nfjgnXfeCft87TKp+9Jjjz0m2dnZ5n36e1BeXh54Tmu+E/3+9HvUrt5+v//97wPf70knnRT1cd0+lMZo/S3T70bf64033pDp06ebj82ePVvmzp0b9nPo9tfS52ga75YsWRL2tYCMkuzsDEiVCRn2339/s7LQ9PnBVRO/E044Iewg1a+//jpwv3ZT0QrTZ599FrhPu1joUVY/7eYUfJQw3NG9J598MuS9tduDvwqlr+cf6K0XrZz4/85fDfFXuLSby6xZs4zy8vKw68i/LFod0K55TbtjhFuX/mV+5ZVXAvdpd6xgetv/mHZ7UcFHRLVi4Pfpp58G7j/xxBONluj3pUeE9fl6pFa73gR/Zr0ET7Tw3HPPGStXrmw2IYNO6PCvf/0r6nv94he/CLxmuKpWS9tXuIpDcBfA3//+94HvUbv++e8/7rjj4q4cRarEhasctXZ7ibY8kSpHwfuCVrOCj8zrfhZuX2jLZ9ZJOPz33XTTTYH1qd+t//7Ro0cbsWqpcrRkyZKQ73r9+vURK0faddF/n3ah1C5OsU7IoNVT3ZY0Hmj3vKbbXHDVNvj+hQsXBu7Xarf/fn93ueDtU7sLRxJc9dMuqv71HlyNvvTSS9tUOdJ9u2fPnoFqhv8x3VeD12dw5Uhjo3Zn00pKuKqcxke/4NcInrxFew8Efy/h9hV/HFPTpk0L3B/cFa8t30m8EzIsXrzY3G+1Ih6uev/www/H/DnU0qVLA49pHAQynTvZyRmQbHrETCsHOh2xHh1t6rjjjmt237fffhu47j8aqEaPHi35+flSXV0tu3btkm3btpmVEb99991XsrKyQo40tzTl9PHHHx9ye+XKlYEq1ObNm+WHP/xh1ErHBRdcYFYfdJmOOOII8z6tIhxyyCFmRUuPUiut3uiybNiwwVwuPSo8aNAgs5qjR191YG4kkdaHmjRpksyfP7/Z8/x0Ofy6dOkSuN6aKYvff/9984iw/6ixv2Kk1Tl/ZU+P3vqPvOpR53D0CKz/KGxrtDTtux7d12qK38KFC81KYVPB6yPc400rVrHSCQFaO4FEa7eXWATvC1oN0epU8Hby8ccfSzyC1+ddd91lXprSqm570X0nWLTJF2bMmGFWF3bs2GGuV71oFVr3H63M6TbcGvPmzTMrk/6qbTjh9qXi4uKQilTTfU+XPXh9houDfsHP01iaiO1YY7Fui/odauVS7bfffhH3U61K6vaq+1okkWJKW2NQS8+P9TuJxdq1a+Wggw4yK4Ht9bk5zQXshm51sO1sdR999JHZlUd/CLRLQvCPQzD/LFSJEMsJBGN9f38XNk0atNGp56vQhoUmb9qlQxsc+uPob7BqN5a3335bzj33XDPJ06RRuwZpl0F9Xqw/5i19Zm0Q+gU3llvzg+xPgJR2pfF3YwvuIqfdcsLNMKjdT9oy+1LXrl0D1zXxjSZ4Fji9hOuu2VrhuiJqQzCYdjuKpi3bUGu3l0RraTtp62eORLtZapfa9hCc3A0ePNjs5hqJJs960OD66683txGNP7pdaTcsTTCCt+1otOujvxGuCYx2rdL4pt1t/YJnbQy338Wy73XETJt6wCZ4uwieXTTcuvcnRtpd7emnn5b//e9/Id1uw62HWGJQS8+P9TuJhX5Of2KkB7X0nEj6Xtddd13CPndwvAuOg0CmIjmC7finGNaTv+oYoUj916M12oKrKHqU0G/x4sXmEXf/D4/26ddGkp/+eAc38j755JMWl7fp+2v/b/99+tra2Ns7uUrgUl9fL7fffnvIWBtNchYsWCAVFRVy//33m4/psmpjzP88nYJYxxN8/fXX5ngJPZrtr1BF6rcebX00vR2t+tRW+hm1H39LtOGgjZN46RTgwdW7RAheHzo2oOn3qBdNUJtWIrTa4G986diIlqohbUnKW7u9BL9uaxt6Won0+/LLL0P2hUhjUtrymYPXp38a6KYXbaTn5ORIoq1bt84cG+h3xhlnRH2+Lkv//v3lt7/9rdmY1WRPx0z5BW/bTmfjT3XTdR1crbr77rvNgz8a3/wV1XgEr08dG9aa52nyHG69+8cktYVuL/7xepqkR6r8Nl0P+jxNRCJV1dtbW7+TaN9vS48Hv5eOSdWKpL5X03FD8QiOdyNHjkzY6wKpim51QAz0x1cHvar/9//+n9nY0iNqt912W0jjSBuP2pVOB/nqoF8dGK8/2jrBgw72balLXTidO3c2f2y1wa8N5xNOOME8wqpdyrSLhSZg2rDSxGvAgAFmd61NmzaZA6h1OfQIYfBgev9RdJ3MQF9DGxTajUqTruDzPkU72q7VBj3yrQ1Y/ZtLL73UHASvy+h/DV0/ugyJolUufzVL17F2wQn2zTffmEdwlR49Pvnkk+N6P02m/TRp0ApbvHQ78E+AoK+n3ay0C5x2x1yxYoXZINXveubMmYHEWKsNOpBat0GdTEIHUzetqsSjtduL/wDAzp07ze1aK0va2NcqlX6GcLRblE5oog06/75wzjnnmA3nSF3q2vKZ9XGdHEDpJA+6bHoARLcT3Vd0UhNdRv8kA1o99De+zzvvvDZVEnU9aPVZE0ZNanSgvP8Ivr5H8MQT4eg2qdunTo6hE11oEqjdRINfP9wRfp2YQAfb60EdrVDqewU3xPVz6L4RaTKBttDvxr996qQKGhN0fel+rgP5dfn1/XU79k+ooZUSrVpoDNHtSJNYfQ3tmnv++ee3eRn0HFKakOt2oF0BIwleDzqRhCYIWvHQc5p1tLZ+J8Hfr65X7VKoF//5x6I9Hvxeug1qxV8PNOhkJIkS3FUxOA4CGSvZg56AZE/l3dLzm57LR+lECzrNcrxTeY8ZMybs+7R0NvZoU3k3Hbh94YUXRnyODlr+7rvvzOdFm4pXB0j7B2lHWjc6hXYsU3kHT/Pc9Nw80QRPuhDuzO06ONt/rhT9nBUVFUa8/JNLhBvUH27dxzuVd9P1o+fVavq4np8keFuIdJ6jcMJtZ63dXpSew6rpc/z7V1un8o60L7TlM7c0lXfT/T+eqbwjXXRq+KaTX4QbUK/TwUd7neApk3X7bvq4fzvSSS6axha9refYCbc+I22HkSZ9CF72SDFGp0ePFj+aLkNrJmSIJtyEDDqBg54frOn7Bk/0EbwfRJrkINJ2Gykmh3udtn4nwROGBF9a87j+FujkKdE+d6yfw0/PReaftAiwA7rVATHQitDzzz9vHjnVgeQFBQVm9Ui7l+iRSq0IBR/t06qFTv+tXRL0yJ520dK/909d7e820lr9+vUzj+b96le/kuHDh0tubq5Z9dHrejReq1r+KWn1qK4eudQB+Xp0Wo84atdCPWKtFQF/VyeddlurXf6xElox0KP8+vd6hDza4HKl3Tm0WqUVKH19/XvtVqifXbvkaYUrUbRrlL9yp8K9tlbYdKCy0qqD/wh4PPzVKe0+qZWdRI0Z0K6MOp5H17FuH/r96rahR4L906H7x1zceOON5vrVysFhhx1mfofBXTfj1drtRT366KPm+Bj9nltLp+/WqonuA8H7QqTKXls/s3Yn1WnhtYuoVjN1AhTdjvUou3ZhC67uJiIO6H6rR++1eqrT6WsFpTWTX2jXRZ3CW6ueWlXV9azrWyu3OiGGrie/n/3sZ+bYJN0ugrtYKY0/OnW2jmvTODBq1ChzQhBdnkTQapqOyWy6fep24o9xep9Wd3R71eXRWKTLohUxrSBrFUOnpW5Puv600qpxSJdTt0ldv609JUAitfU70WrbfffdZ27TwWN/WvO4fhdaEdX31P1Dn6OV1Wjjs9pCJ9vQKryKpfIHpCOHZkjJXggg0+luFm7ch54TxD/WQrtqtWXGNHQ8HYelDT4dH6Jdh/TcKEiMW2+9NZC46HghGmJA8mmcu/fee81kc/Xq1eaBQCDTUTkCOoAe6dYTj2qfcx0XpEeXf/nLXwYSIz3SPG7cOL6LFKcVNf8sUDphQSwzcAFAOtD45j/5rsY9EiPYBRMyAB1AZxjSqXnDTc+rXVC060rT7jJITdqVUS8AkMk0GWrptAVAJqI1BnQAHaehMz9pf3Ado6Djk3T2pV/84hdmFUm71wEAACC5GHMEAAAAAFSOAAAAAMBCtzoAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOUot559/vjgcjmaXadOmBZ6jt1977TVJFXfeeaccdNBBkp+fL6WlpcleHADtIN1i05o1a+TCCy+UgQMHSl5engwePFhmzpwp9fX1yV40ADaOTeqEE06Qfv36SW5urvTs2VPOPfdc2bhxY7IXC0HcwTeQfLpDP/XUUyH35eTkSKrSxsZpp50mBx54oPzlL39J9uIAaCfpFJuWLVsmPp9PnnjiCRkyZIgsXrxYLr74YqmqqpL77rsv2YsHwKaxSU2dOlVuuukmMzHasGGDXHvttXLqqafK3Llzk71o2ItudSlGd+gePXqEXDp16mQ+NmDAAPP/k046yTwS4r/93XffyYwZM6R79+5SWFgoEydOlFmzZoW8rj73jjvukDPPPFMKCgqkd+/e8oc//CHkObt375aLLrpIysrKpLi4WA477DBZtGhR1OW97bbb5KqrrpIxY8YkeE0ASCXpFJv8jaWjjjpKBg0aZB6p1QbIK6+80g5rBkAypVNsUtpmOuCAA6R///5mz5sbbrhBPv30U/F4PAleM4gVyVEa+fzzz83/9Ud/06ZNgduVlZUyffp0ee+992ThwoVmw+D444+XdevWhfz9vffeK+PGjTOfozvjFVdcIe+++27gca0Abd26Vd5++22ZP3++7LvvvnL44YfLzp07O/iTAkgn6RCbysvLpXPnzgn7zABSX6rHJn3ec889ZyZJWVlZCf3siIOBlHHeeecZLpfLKCgoCLnceeedgefoV/bqq6+2+FqjRo0yHnnkkcDt/v37G9OmTQt5zhlnnGEcc8wx5vUPP/zQKC4uNmpra0OeM3jwYOOJJ55o8f2eeuopo6SkpFWfE0B6SefYpFasWGG+xpNPPtmq5wNID+kam6677jojPz/fXLYDDjjA2L59e6s/M9ofY45SsC/q448/HnJfS0c79QjIrbfeKv/+97/NIyMNDQ1SU1PT7AiIjgtqevuhhx4yr2sZWF+nS5cuIc/R19HyMwB7S9fYpH369aiwHuHVcUcAMks6xqZf/epX5qQxa9euNYcn/PjHP5Y333zT7PqH5CM5SjHar1UHELeF9qXXMq8ONNa/1dmZdHBfW2Zm0h1cBwfOmTOn2WPMQgcgHWOTzgClDSftsvLkk0/yJQIZKB1jU9euXc3L0KFDZcSIEdK3b19z3FHTZAzJQXKUZrRPqtfrDbnv448/Nqez1AGH/h1Wp7JtSne8prd1p1TaT3bz5s3idrsDAxYBIF1jk1aMNDHab7/9zPEGTidDbAE7SrXY1JTOrKnq6upifg0kFslRitGdQ3e2YLrj6REGpTugDiCcMmWKOUOLzsiyzz77mLMw6WBCLcn++te/DuxsTYPBPffcIyeeeKJ5xOTFF180S8rqiCOOMI9Y6GP6HD2aoUdd9XENHvvvv3/Y5dUStA4o1P81+Hz55Zfm/XokRmeAAZAZ0ik2aWJ06KGHmrNB6ZHhbdu2BR7TmawAZI50ik2fffaZOSnED37wA3M5tPudvreei42qUQrpgHFNaMPAQv1Kml6GDRsWeM4bb7xhDBkyxHC73eZgQbV69Wpj6tSpRl5entG3b1/j0UcfNQ455BDjiiuuCPydPve2224zTjvtNHMQYI8ePYyHH3445P337NljXHbZZUavXr2MrKws87XOPvtsY926dW1e5tmzZ/O9Axki3WKTThATbnn5yQMyS7rFpq+++sp8386dOxs5OTnGgAEDjJ///OfG+vXr220doe0c+k+yEzS0Pz1ycuWVV5oXAEgVxCYAqYjYZF90wgYAAAAAkiMAAAAAsNCtDgAAAACoHAEAAACAhTFHaU7n5ddpKP1TaCeTnm26e/fu5vK89tpryV4cAEmWKrFATwCrJ1nUcx35z24PwL6ITYiG5CjF6PmCjj32WMnPz5du3brJr371K2loaOjQZbj77rtl4sSJUlRUZC6DzuG/fPnyqH+zdOlSue222+SJJ56QTZs2yTHHHNOm99RzJV122WUybNgw80zV/fr1k8svv1zKy8vj/DQAEkH3Rz2hqp4nZPz48UlZqXpeEj13iJ59vqCgwFyOZ555Jurf7NmzRy699FK5/vrrzfMf/fSnP41rGX7+85+bDSuSLCA1EJssxKbE4SSwKURPoqqJkZ6kcO7cuWaS8eMf/9g8u/Ndd93VYcvxwQcfyC9/+UszQdLE7KabbpKjjjpKlixZYjZIwtETmakZM2aYDYe20hOn6UVP2Dhy5EhZu3atuaPrfS+99FLcnwlA/H7yk5+YJzH86quvkrI6O3fuLDfffLMMHz5csrOz5c0335QLLrjAPIhz9NFHRzzg5PF4zNjas2fPuN7/1VdflU8//VR69eoV1+sASCxiE7EpoWI4NxKCTv511llnBU4O9sADDzQ7iVhbvPXWW4bT6TQ2b94cuO/xxx83iouLjbq6urB/oycy06/x5ZdfNg499FDzhGZjx4415s6dm7DvaevWreZ7fPDBB2EfnzlzZrucaPGf//ynkZ2dbXg8noS8HmAXiY5NTff3cePGteq5Ggv+9Kc/GSeeeKIZm/REjK+//rqRSBMmTDBuueWWVp8MVmNmLPQkjb179zYWL15snhzywQcfjHPJAfshNlmITamNbnVxuPrqq+Xjjz+WN954Q95991358MMPZcGCBSHP0epHYWFh1IvfJ598ImPGjDHH7fjp0VDtFvLNN99EXRY9mnrttdeaY4+GDh0qZ555ZqA7nh45bWkZolWm/F3b9KhtOPq+Tz31lHldq116Uc8991yL76vrLNr7FhcXi9tNgRNIZmyKh3a3Pf30081q0/Tp0+Xss882u9H6tbQMupzhaO713nvvmV1+Dz744LDPOeOMM2TWrFnm9Xnz5pmxScce6fpo6X01fvn5fD4599xzzW7Oo0aNSsh6AeyI2GQhNqU2Wp0xqqiokKefflqef/55Ofzww837NEFo2t3i9ttvN5OH1ti8eXNIYqT8t/WxaPQ9tNuIvzGiP+ArV640u5/oMrU0YUOkxEcbBVdeeaVMmTJFRo8eHfY52pDQMQBKuwT6nXDCCTJ58uSo79u7d++w92/fvl3uuOOOuMcHAHbTHrEpHueff755sEbpQZjf//73ZqIybdo0876WYpMeIGl60ETjRl1dnbhcLnnsscfkyCOPDPu3On6xS5cu5vWysrJAfNJxSy29b3As/t3vfmcepNGxDQBiQ2wiNqULkqMYrVq1yuzHPmnSpMB9JSUl5oQCwbQvvF7a29ixYwPX/f3qt27daiZH+qM+ZMiQmF5Xxx4tXrxYPvroozb/rU7ooJe20kqZJno69khnwAOQGbFJxyxqsqOxya+tsUljiiY2lZWVZuVIj0QPGjRIDj300Fa/hiZNrX3f+fPny8MPP2xW3mIZTwnAQmwiNqULutW1s7Z0XdGjmlu2bAn5e//t4IpMODppg5//B1yrPvF0q9MZnnTA8+zZs6VPnz5t/uyxdKvTI0t6RFkbQDr4OfhzAUicjupW13Qf1vjkj02xdKvT6bg1sdGZ6q655ho59dRTzRk226It3er0uZrM6QyaeqBJLzphjL73gAED4lo3AJojNhGbko3KUYz0SKX+6H/++efmj6a/u8e3334b0v+9LV1XDjzwQLnzzjvNH2L/EV0dL6BHWrWKEqu2dqvTvvw6rbYmJ3PmzJGBAwfG9L5t7VanFSMdY6VTBetYidzc3JjeF7Cz9ohN7amt3eqa0kRLu9i1RVu61elYoyOOOCLkMY1Ter/OlAegdYhNxKZ0QXIUI61snHfeeeYAXU0sNJmZOXOmeVQzuOtFW7qu6HTZmgTpj+4999xjjjO65ZZbzK5tmjDEqq3d6vT9dLzC66+/bn5O/3gn7Zqj3VHao1udJkb6+aurq+XZZ581b+vFP1ZAxxYASE5sUjqGUbuyaTyoqakJJBcas3Ra7Vi1JTZphUgTm8GDB5sJ0VtvvWWe5+jxxx9v03u2pVudjlnyj1vy0+RTq/lNuyoCiIzYRGxKFyRHcXjggQfM8u9xxx1nHt287rrr5Pvvv4+54qEJgHZj+8UvfmFWkbR/vjZy9AhvR/I3NJr24ddB3Tq4uj1of349f4pq2mhZvXo13VeAJMYmddFFF5nnQPObMGFCh++fVVVVcskll8j69evNBEfHVOrBFJ35CUDqIzYhHTh0Pu9kL0Sm0B9u7SZ2//33y4UXXpjsxQEAE7EJQCoiNiEVUTmKw8KFC2XZsmXmrFDap99f4ZkxY0aivh8AIDYByAi0m5AOSI7idN9995knIdQ+9/vtt585s1HXrl0T8+0AQIyITQBSEbEJqY5udQAAAADAeY4AAAAAwMJJYAEAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALG5JoFqPT3ZWesTrM8TOslwO6VyYJdnu0MLc7iqPVNR6xe4KclzSqcAtDocjcF+D15AdFfVS77X3tuN0iHQqyJL8HFeyFyWjEJssxKboiE2REZvaB7HJQmyKjtjUsbEpIcnR1+sq5P5/r5P3F+80d3RYG/LR47rItcf1kzlLdstzH22Sb9ZXsWr2Gtw9T047oLuccWB3ufdfa+Wthdtld3UD60d3SqdDDh5RKpdN6ydThpWyTohNCUVsio7YFBmxKXFoNzVHbIqO2NRxsclhGEZch+q/XFMhpz64SPbUUBEJJz/bKdX1JIyRFOa6pJJqWlg5bof87ZejZeqozvHsorZFbIqO2BQdsSkyYlN8iE3REZuiIza1f2yKOzk68b4vZe635eZ1l9slBaVF4nDYe54Hn88nVbv3iM8bmhTlFeZLdl6OrnaxL0M8dR6p3lMZcq92sSvsVCxOl727k+nuqOumod5j3h7ULU8+uWNiSBdEtA6xqfWxaVTvPOnbJUfsvJnpL+HWPR5ZsCa0wk9s8q8fYlOiEJuao90UNTrRburg2BRXt7pte+rlkxVWYpSVkyX7TBxjJkgQ80ta9ski80tTZX17SI/BfVk1e21fv0U2rVwXWB/7TBwtOfm5rJ+9PxLfzV8itVU1smprjSzdUCUj+xSybohN7RKbLjq0m1wzvTfb117PfrxN7nx9PbEpDGJT/Gg3tT420W4KRbup42JTXCWe73fUmkfbVFGXUhKjIO7sLPPiV9K9SzyrOuOUdG3sE5pXXEBiFMTpdEpJt8aS8OpttR375WQAYlPrY9Ox4zt1yHeSLo4aUxK4TmwKRWyKH7EpMtpN0dFu6rjYFFdy5AmaWUwXDE0EVfRYP01WTdD2wroJs2MGrZ+GJl2gQGxKZGzKzSJ2B3MTm6IiNsWHdlMLaDdFXjXEpg6LTfwqAgAAAADJEQAAAABYqBwBAAAAAMkRAAAAAFioHAEAAAAAyREAAAAAWKgcAQAAAADJEQAAAABYqBwBAAAAAMkRAAAAAFioHAEAAAAAyREAAAAAWKgcAQAAAADJEQAAAABYqBwBAAAAAMkRAAAAAFioHAEAAAAAyREAAAAAWKgcAQAAAADJEQAAAABYqBwBAAAAgIi4030t9CxwyOTeLhnWxSnDOzulT7FDnA5H4PGrZ9XKoq0+sSO3U2RcN6eMKXPJiK5OKct3SKdch+S5Rao9Imv3+OSTDV55c0WDVDeI7Rw50CVjy1wyuJNDOuc5pDjbIbrp6LrZUOGTL7f45F8rG2RbtZHsRUUaIjYhVsQmtCdiU2S0m6KzS2xK++ToyEFuOW9MVrIXIyUNKnXKPYflhn2sxCUyNtclY7u55ORhbrlpTp2s2p3eG3NbnTs6S3oXNS+eZrtESnNdMqrMJScPd8vtH9XJvI32TLARO2ITYkVsQnsiNkVGuyk6u8SmjOpWV9dgSG2DvRr4reXxGrJku1c+3eCVjRWhG2xZvlNuOzhHsjJqa2gdn2HsPdphrZu15aHrJs/tkOsPyDGPJgGxIjaB2IRURGyKjHaTfdtNaV85+mabV+7/zCfLd/hkdbkh9x6WI+O7u5K9WClje7VPXljSIP9d3SBVnsb7zxntlgvGZgdu9yp0ysSeLpm7wSt28eRCj5kw7qwNvf/gvi6Z+cOcwO3SXIcMLHHIil0k3mg9YhOITUhFxKboaDdFZpd2U9onR/M3p2/Zrr2t3+OT8/5VK7Vh8p1nFzfIsYPd0q2gMbXvV+yQuRvENj5aHz4R/N/3XqmoN6Qou3HsWr19ckYkCLEJsSI2oT0RmyKj3RSdXWJTGhe90BKdZCFcYuS3szY0o68MqizZ2Q/6uEJ2cC0ff1+Rnkc/AGQOYhPQvmg3xSbTYlPaV44Qm655Dhlc6gzpQ6r9R+3o/LFZ0r/YITluh/QqdEjf4sb1sqXKJ3d8VCe+9N3HAaQpYhOQOmg32Sc2kRzZkE68cONB2ZLlaszy31/jlfVpnOXHY7xOd96t+Ti1FTt9cvcndbK23J7rBUByEZuA1EC7yV6xiW51NlOQJXL3oaGTVujgzAfm1Sd1uVLRPp2d8uQxuXLcEI4hAEgdxCag49Busl9sSu+lR5tLwndPzTHn8fdbuNkrv/5fndTZs0ed6cpZdeb/+W6RHoUOOXaIW04cap07y+10yOX7Z8nibV5Zk+ZHQgCkF2ITkFy0m+wZm6gc2cSAEoc8clRoYjRrTYPcMKdOahqSumgpNRBTT4T7yBce+fj7xpXicjrkh32ZHh4AsQmwC9pN9m03UTmygXHdrJO8Bs8k8txij/z1K6ani2R7TejRjs55jesOAJKF2AS0P9pN9o5NJEcZbmp/l1x3QLZk7518ocFnyEPz6uXtVTbuRycixwxySYMhMne9N+TkuGpkV6dM7R+6a2y06WQVADoWsQlILtpN4dkpNqV9cjS5l1POGW31c1T9S0J7Cl4xMVuqPI1f0GX/tfpJ2sE+nRxy00HZ4nQ0Zu/bqg2Z1MtlXpqas84rH6yzR9I0sNQppwzPEo/XkHV7DHO96GrqUeBotg3pic3eW0PfQ7QNsQnEJqQiYlNktJsis1O7Ke2To9Ich4zsGrlfY9MvzE7ysxwhiZHqWeg0L+GsNgfO2SM58tPpzAd30kv4x3fUGOZ8/TtrO3rJkO6ITYgHsQnthdgUGe2mltkhNqV9cgTE4u3vGswjG5pY9ypySEmOw5x1pd4rsrPWkDW7fTJvk09mrW6QWnvliwCSiNgEIBW9baN2U9onR++s9so7q6uTvRgpadFWnxz+POsmUpVsdbmWfNO37IvURmxCLIhNaG/EpshoN0Vmp9hk3z5nAAAAABCE5AgAAAAASI4AAAAAwELlCAAAAABIjgAAAADAQuUIAAAAAEiOAAAAAMBC5QgAAAAASI4AAAAAwELlCAAAAABIjgAAAADAQuUIAAAAAEiOAAAAAMBC5QgAAAAASI4AAAAAwELlCAAAAABIjgAAAADAQuUIAAAAAEiOAAAAAMBC5QgAAAAASI4AAAAAwELlCAAAAABIjgAAAADAQuUIAAAAAEiOAAAAACABlSOX0xG4bhhGPC+VmYJWCeunyaoJ2l5YN9HXT/B+htYhNrU+Nnm8xO5gPsNHbIq26RCb4kJsagHtplbte7Sb2jc2xZUc9eqUE7heuXOPGD5+ZP18Xp80eDyB2xU7dsezqjNO1e6KwPWaiippqG9cV3anO3jFjvKw+xlah9jU+tj04fI9bFZBPltZGbhObCI2JRqxqfWxiXZTKNpNHdduchhxpp9H3blAvlxrNXTd2W7JyskRsfuBbkOkvqZOvA0NIXfnFOSK0+my9/oxRAyfT2qrakLudrpckp2XIw67V0kMkYb6evHUWT8QPUuzZeFvDxCn3ddLDIhNrY9N+3TPlbwcp61Dk6r1+GTF5loJPs5HbNqL2JQwxKYwaDdFRrupw2NT3MnRe1/vkLMfXRzyYwK0lm67bDuRPXzeUDlzSk82KGITOhixKTpiU+xoNyEexKb2j01xz1a3ZEMVjVvEjMQousXfV7F1xYjYhHgQm6IjNsWO2IR4EJvaPzbFVTnSP933hs9kw64683aX3t2kqEupOBz27pyh3cZ2b90pu7fsCNzXtdAtlx3dU/p1yTGzfrvSrW1zuUcem7VJ1u2oD9yv203nnmXidNl7dnndp7Rf8bZ1m8zb+TlOWXr/QZKX7Ur2oqUVYlPrY5M7yy3dB/Yxu7XanaeuXrau2Sj1tdZvmiI2WYhNiUFsirBeiE3EphSKTe6Y/1JEVmyuDiRGhZ2Kpdc+/eN5uYyiP6g6mNDb4DVv//qkvnLUmNJkL1bK6NclW856bEWgcdZ/9BDbJ9V+RZ1LzEaaNmCr63zy+Xd75OARnZL4baUfYlPrY1Ovof2lpKxzh303qS47N0dWfbnMvE5sCkVsih+xKTJiU3TEpo6LTXEdpt9d3TioN6cgL56XykhOtytkwDMa9euaE7Lt2L3a2FRu0P60uyp08DxaRmxqfWwK3tYgkp3XGKuJTcSmRCM2RUdsiozY1HHtpriSo+AOeTRto6Pt32R9sMW0sL0EnUMs+MQPIDYlHNE7dN9jJ4u6tRCb4kK7qS3YGUP3vfi2vUznSGBssvcADwAAAADYi+QIAAAAAEiOAAAAAMBC5QgAAAAASI4AAAAAwELlCAAAAABIjgAAAADAQuUIAAAAAEiOAAAAAMBC5QgAAAAASI4AAAAAwELlCAAAAABIjgAAAADAQuUIAAAAAEiOAAAAAMBC5QgAAAAASI4AAAAAwELlCAAAAABIjgAAAADAQuUIAAAAAEiOAAAAAMDilgyT6xJ5cnqu9C4KLYqd9XqNbKkykrZcSG0TezrliAFuGVnmlE65DvO+8lpDNlYa8vU2n7z+rUfK65K9lEhnxKZGbqfIuG5OGVPmkhFdnVKW7zD3uzy3SLVHZO0en3yywStvrmiQ6gaxNWIT2huxKVS3fIfMGOqW8d2d0qvQKflZIl6fyO46Q1bu8smctV6Zs84rPps3KSdmcLsp45Kjn07IapYYAZEUZIncMiVHJvVyNXssr9AhPQpF9u3hkgWbvVK+zceKBLEpAQaVOuWew3LDPlbiEhmb65Kx3Vxy8jC33DSnTlbttl8rhNiEjkK7qdGknk6Z+cMcyXVbjf3gAzrd3Q7pXuCUKX3cMn2wV26cUyceGzYLCmzQbsqoLGK/Hk6ZMTQr2YuBNKHB7p7DQnfweq8h3+3yyacbvLJ0u1cq6u3XKEPiEZsi83gNWbLda+5zGytCf0jL8p1y28E5kpVRv1QtIzahoxCbGrkcItcdGJoY7akz5LONXlm2wxuy3ib0cMkpwzKuvtAit03aTe5MymSvnZxtXq+sN0S/mqLs0MwfCHbO6CwZ3qVxB9ejHPd/Vi+bg7pfOh0i47s5ZXNl+u/sSA5iU3jbq33ywpIG+e/qBqnyNN5/zmi3XDDWiuVKu7VM7OmSuRtCGyeZjNiEjkBsCjWo1OreG5wYXfBmjeze2zXs/DFZcu6YxgPwY7q55IWl9ur3e45N2k0Zczzu0v2zpVuB9XEe+aJeqjIgc0X79rE+aWjjsYGdNYbc/lFdyA6utE/xgi0+2V7D9oTYEJuaW7/HJ+f9q1Ze/TY0MVLPLm6QrVWhFaR+xfY50EVsQkchNoVq2kVuU6UvkBip5TtDn1DpsVe7INdG7aaMqBxN6eOSowZaH+V/6xpk1hqvXDCW7nWIbGx3pxQGVRb1qHSvIqdM6e2S7oUO8XhFVu/2yQfrvGm9gyO5iE3htTTJws5aQ7oVNN6ubJJAZTJiEzoCsam57/foZAI+s1qthnRyytT+Lpm73islOQ45qUk3uvfW2KtqNNZG7aa0T45KckSummh1wdhVY8hDn9cne5GQBoZ1Di2aTu7llOOGNB8gfvF4Q/6yyCMvLrNXEET8iE2x6ZrnkMGljfunzzDkyy326VJHbEJ7IzaF5zVE7vy4Xm4/OEe65DnE5XSYEw80pWNqnlxYL/M2pudkA7EaZqN2U9p3q7tyYrZ0yrMy2Qfm1afttIHoWKVB/Yr9A7/DyXI55Of7Zsv0wc1nZQGiITa1nU68cONB2eZ+5/f+Gq+sr0jvo5BtQWxCeyM2RbZsh08u+U+tOUlMODr5wAvfeMzpvO2m1EbtprROjo4Y4JKD+1nFr3dWNdhqwC7i49YRg03MXtsgp79aIye9XC0vLQvtx3PhuGxzkCHQGsSm2AaH331ojozv3viD+s02r3nQy06ITWhPxKaWuxv+9bhcGdnVFThvz7yg2eqyXQ65eEK2PDYtV7oX2KtR4LZRu8mZzkcYdTCh2lLlk0e/sNcPKOJT3WQgpddnyEPz6mVHjSF76kSeWOiRXbVGyBGTwaVpupejQxGbYutK99CRueb0uH4LN3vl+tl1UmezY17EJrQXYlN0vYu0G122FGRZv/Wrdvvk3H/VmOcz+uU7dXLPJ41dk/oWO+XyvW1Qu6i2UbspbcccZbsap+ouzXHIsyfkhTxe2GSb/eO0XDEMkUfm18tsG5ZDEWpDk246OiNN8KBvnW1FZ6rppNOz7FWco9ubfbr3IDbEprYZUOIwK0b+2UbVrDUNcu+n9dJgry79JmIT2guxKTqdfEErQ37/XRU6m+Y7q71y6f6G5O9Nnvbv6TTP+2OXOLXBRu2mtE2OguW4HZLTwiexviCR7LStlSGRFm8LTZALs0Sa7sLFTc6TFXxEBGgNYlN047pZJ3kNPifdc4s98tevbDQ9XRPEJnQEYlNzZXvHr/uF+8U3mnQzK8rWtoHYwmIbtZtIFWBLa8qNkDNe6w/F0YMaj3ZM6O6UPsWNu4fOhLh6d3ru5ECqHqX97dTGxKjBZ8h9n9bZOjFSxCYgObZWh/7G6yli8oMOvB810BXocqeqPIatJgFbY6N2U9pWjrTUefjz1REff+6EXOmxd656ddbrNbKlyYmqYG9/mO+Rh45wmtN1qmsmZ8sxg31miXxU19DjBv/3tScNC8NIBmJTy/bp5JCbDtLBuo0NjW3Vhkzq5TIvTc1Z5zXPnWEXxCa0B2JTdBpnzh1tBGbLHNzJKc+ckCff7vRJcY7I8C6hsWnW6gazK5md/MEm7aa0TY6AeC3Z7pO7P6mX6w7INvsZa0NtdFlo8NNzrPz9mwZ5c2X6ztcPpBrtsx+cGKmehU7zEs7qcv2JtU9yRGwCkjOm5sF59XLVpMbTCeikAuEO2Cza4pU/f2m/KvcSm7SbSI5gazo5x9LttXLqcLfs18MlZQUOs6+pzr7y9TafvL6iQZbvsMloSwApg9gEdDyddOHrbbVy3BC3jO/ulF5FTrNrnVZGdPzMyl0+s8Kk5zlK16pIvGbboN2UscnR2W/YZIQc4ra5ypBH5+sRIPsdBULHIzaJLNrqi9otGhZiEzoSscmysdKQJ21YFWqLzRnebmJCBgAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVow5idNQbpQmDNdLC+gGA1ENsApDpsSmu5Cgvq/HPGzwNiViejGL4Gr+qXVWsn2BVtd7A9YZ61k1T3npP4HpetqvdttFMRWxqfWxq8DRuaxDxNhCboiE2xYfYFB2xKcq+R2zqsNgUV3I0pEe+5GdbL1G+badU7tojhsFxJV0He7bvkoagL+rRdzfLjkoaIaqixisPv7MpsG7qqmtk56ZtIUHRzmoqqmTn5u3mdYdDZGy/wmQvUtohNrU+Nm1dszHktp15Gxpky5oNgdvEplDEpvgRm8IjNkVHbOrY2OQw4sxmfv7npfLKvK1xLYTdOMS+SH/a5qChJfLatePb6dvIbMQmoP0Qm2JHbAJSOzbFPeboqun9JMdt5+Z+dFkuR9gEwa6Xpth2InM5Ra47YUBCt0c7ITa1PTahEbEpMmJTfIhN0RGboiM2tX9sirtydN5ji+XtL3cEbmflZovDYe95HgyfTzx19c3udzidkpWTZfvakY4x8nkb+/X7ubOzxOmy+fgaw5D62rrAzX0HFMl/bto3qYuUrohNzRGbojGITVFXD7EpUYhNrW836RitsuIscdr4WI420nVYRmWtr9ljtJukXWKTO54/rqxtkPcX7zSvO11OGTxhhOQW5se1QJmiurxSvlu4NHC7uGsn6TtikLme7E6D4MaV62Tnxm2B+/qP3keKupSIQzuL2lx9TZ2s+nKpeOo8smBNhazbXiv9uuYme7HSCrEpMmJTZMSm6IhN8SM2tT42HTm6RO45c4DkBk3+ZVceryF3vbFeXvjEGlejaDe1X2yKa4tbublG6hqswlNJWWcSoyD5JYV7q0SWsn49SIyCKmhlfXsG1o0m1MVdS0mM9srOy5HSHl0D62fJ+sp4dlNbIjZFRmyKjNgUHbEpfsSm1semiw7tTmIU1NXwokO6BdYN7ab2jU1xJUd1DY0lPpfb5t2hwgmqgrjccRXpMk5wBY1tp7ng7SV4P0PrEJtaQGwiNsWI2BQfYlPrY1NRHu3KYLl7Z4e29kPWTXvGJmqVQAqicyGAVERsAttasvY99r5oErl2SI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxuSWM/HpMl543JavXzv9zilWveqxM76ZbvkBlD3TK+u1N6FTolP0vE6xPZXWfIyl0+mbPWK3PWecVniO1cd0C2HD2o5V1g3kav3DjHXtsN4kNsahmxKTJiE9oLsQnxuM4m7aa0To4Q3aSeTpn5wxzJdTtC7nc7Rbq7HdK9wClT+rhl+mBrI/b4WKMA2h+xCQCQqtI6OVpb7pP/rWuI+PiYbi7plNuYGCzfYZ/Wv8shct2BoYnRnjpDlu7wSUmOyPAursD9E3q45JRhbnlhaeR1mel21xry1VZv2MdW7LLPdoPEIDZFRmxqG2ITEonYhETZncHtprROjj5Y5zUv4WgC8PyMvMBtj9eQV5bbp/E/qNQRkhhqYnTBmzWye2+V8/wxWXJuUJdETSTtnBytKffJbR/VJ3sxkCGITZERm9qG2IREIjYhUdZkcLspY2erO2Efd0jVZPY6r2yvsc/AmqZd5DZV+gKJkVq+M/QJlR77rBsgmYhNoeuD2ASkBrvHJiAjKkeRZDlFZuwTOlHDi0s9Yiff7zFkY6XPnIRBDenklKn9XTJ3vVdKchxy0rDQr/69NfatGqmyfIdcsm+WWW2r81oNtvmbfbLMRl0x0f6ITcSmtiI2oSMQm9BWZRncbsrI5OjIgS7plNd49OPzTV5ZtdteRz+8hsidH9fL7QfnSJc8h7icDrllSk6z51XUG/LkwnqZtzH9N+Z49C5yyinDQwupPxknsnCzV377ST1Hz5AQxCZiE7EJqYjYhLbqncHtpozsVnfqcHtXjfw0e7/kP7WyZHv4cVn1XkNe+MZjTueN8HSyinsPy5GcxvkrgJgRm4hNiUJsQiIRm5AoEzKg3ZRxlaMDejmlf0ljzqfn8tEynx1N6eOS6w/MloIsq4pWXmuYY42K985Wl+1yyMUTsmXaYLdcP7tOtlSlb5YfC/28z3/jMY9yrK8wZFetYZaJjxnslh+NdIvTYa23fiVO81xR/7TxhBWIH7GpEbEpOmITOhKxCa21xSbtpoxLjk4bQdVI9S7SbnTZZgKkVu32yZXv1krV3iLa0QNd5lTfqm+xUy7fP1tu/iB9T9gVi6e/bl5R3FhpyF8WeSTXLXLysMZtaXIvV9ru5EgNxCYLsallxCZ0JGITWutpm7SbMqpb3T6dHDK+e2Mdb0uVT963aZcxnXzBnxip/65qCCRG6p3VXqkOmqFu/55O8+SwsCxoUm3UcVtArIhNxKZEITYhkYhNSJQFGdRucmby0Y9XlzeIz149xQLKmmyU4VZD8H1up0OKssU2gvLGsHoWhj6hiqnOEQdiUyNiU3TEJnQkYhNay2WjdlPGJEfa5/GQfo1Vo8p6Q/69Mj3LeYmwtTp0ozxqoFvygzpRHjXQFRiL5N+Iy23Uq250mVMeOiLHHPvQdIcf2tkp54wKTbQXb7PnuDXEj9gUitgUHbEJHYXYhLYYbaN2U8aMOTp5mNusfvhpYlRt39xI5qzzyrmjDcnauwUP7uSUZ07Ik2+DJmQINmu1/apsY7q5zEuNxzAn7tBpzcvynTK4kyMwqNCfOL6Ypv1mkXzEplDEppYRm9ARiE1oqzE2aTdlRHKkFZHpgxs/isdryCvL0/dLSYQNFYY8OK9erpqUHUiQSnMdMqlX87kVF23xyp+/tNd058F5YF6Ww9zZw9lRY8jtH9Wl9Xz9SB5iU3PEpuiITegIxCa0lWGjdlNGJEfTh7ilMLsxY529zpvWX0qi6KQLX2+rleOGuGV8d6f0KnKaAbHBJ+b0i5r161FcPc+R3dbWV1ut2ft0NpURXZ3Sp8ghxTkO0a2osl5kTblPPt3olbe/C53IAmgLYlN4xCZiE5KL2IS2+spG7aaMSI5eWtZgXiBhp1h80mZVodb6epvPvADthdgUGbEpMmIT2huxCbH42ibtpoyZkAEAAAAA4kFyBAAAAAAkRwAAAABgoXIEAAAAACRHAAAAAGChcgQAAAAAJEcAAAAAYKFyBAAAAAAkRwAAAABgoXIEAAAAACRHAAAAAGChcgQAAAAAJEcAAAAAYKFyBAAAAAAkRwAAAABgoXIEAAAAACRHAAAAAGChcgQAAAAAJEcAAAAAYKFyBAAAAAAkRwAAAABgoXIEAAAAACRHAAAAAGChcgQAAAAAJEcAAAAAkIDKkcPReN2I54VswDBYQ6HrI/hGh38dabW9OIN3NLQKsSm2bQ3EprZsL8SmtiM2tZ6P0BRx36Pd1L6xKa7kqGthVuB6zZ6quBYkE78kb4M3cLumgvUTrLaqOuS6z+fr0O8n1QVvL52D9jO0DrEpMmJTdMSm6IhN8SE2tT42LV7f2E6AyIrNNYHVQLupfWOTO54/Htgtz7ys3loj1XsqZd0330lRlxJxOO09lMnw+aR8607xBe3kG1esE09dvWTn5oQeOrIdQzx1Htn+/ebAPRoMV3+5XDr17CpOl0tszTCkcneFlG/bZd4sznPJxMHFyV6qtENsCo/YFA2xKfrqITYlArGp9e2m37y2Xjbtrpc+nXPEaeNmkxZEtpTXy1//tzVwH+2m9o1NDiPOPhX/98FGue65FXEtBIDwrj62n9wwYyCrJwbEJqD9EJtiR2wCUjs2xV3iOf+QXnLrqYMkP9ve1aJwinJdcvePhsiUoSXJXpSUNKZvoTx83lDpQrexZrLdDrn06L5y/QkDkvHVZARiU2TEpuiITZERm+JHbIqM2BQdsaljYlPclSO/qjqvfLBkl2zcVScNXnuPostyOaR/Wa78cHgnycmyksY122pk7vLdsqemsWRsVwW5Lpk0uFiG9Sowb+v2Mvfb3bJic7V4Guy97WiP1O4l2TJ1ZGcpzo+r1yv2IjY1IjZFR2wiNnUkYlMjYlN0xKaObTclLDkCAAAAgHRGXzgAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOUot559/vjgcjmaXadOmBZ6jt1977TVJNXV1dTJ+/Hhz+b788stkLw4Am8emAQMGNFve3/72t8leLAA2j03q3//+t0yePFny8vKkU6dOcuKJJyZ7kRDEHXwDyac79FNPPRVyX05OjqS66667Tnr16iWLFi1K9qIAaAfpGJtuv/12ufjiiwO3i4qKkro8ABIv3WLTyy+/bMalu+66Sw477DBpaGiQxYsXJ3uxEIRudSlGd+gePXqEXPSogv9IqDrppJPMIyH+2999953MmDFDunfvLoWFhTJx4kSZNWtWyOvqc++44w4588wzpaCgQHr37i1/+MMfQp6ze/duueiii6SsrEyKi4vNnbY1yc7bb78t//3vf+W+++5L4JoAkErSMTZpMhS8vPr6ADJLOsUmTYSuuOIKuffee+XnP/+5DB06VEaOHCmnn356O6wZxIrkKI18/vnn5v96hGTTpk2B25WVlTJ9+nR57733ZOHCheZRlOOPP17WrVsX8ve6M44bN858zg033GDuoO+++27g8dNOO022bt1qJjvz58+XfffdVw4//HDZuXNnxGXasmWLeQTkmWeekfz8/Hb77ABSVyrGJqXd6Lp06SITJkww30MbJgDsI9Vi04IFC2TDhg3idDrNuNSzZ0855phjqBylGgMp47zzzjNcLpdRUFAQcrnzzjsDz9Gv7NVXX23xtUaNGmU88sgjgdv9+/c3pk2bFvKcM844wzjmmGPM6x9++KFRXFxs1NbWhjxn8ODBxhNPPBH2PXw+n/mad9xxh3l79erV5vItXLiwjZ8cQCpLt9ik7r//fmP27NnGokWLjMcff9woLS01rrrqqjZ9bgCpLd1i09///ndzefr162e89NJLxhdffGGceeaZRpcuXYwdO3a0+fOjfTDmKMVMnTpVHn/88ZD7OnfuHPVv9AjIrbfeag7w0yMjenS0pqam2RGQAw88sNnthx56yLyuZWB9HT3KGkxfR8vP4TzyyCNSUVEhN954Y5s+I4D0k06xSV199dWB62PHjpXs7Gz52c9+JnfffXdKj0cAkLmxyefzmf/ffPPNcsoppwSqWn369JEXX3zRjFFIPpKjFKP9WocMGdKmv7n22mvNMq+O+dG/1dlPTj31VKmvr2/1a+gOruXdOXPmNHustLQ07N+8//778sknnzRraOy///5y9tlny9NPP92mzwEgdaVTbApHZ4bSBtCaNWtk2LBhrf47AKktnWKTPl/pOCM/bUMNGjSoWWKG5CE5SjNZWVni9XpD7vv444/N6Sx1wKF/h9UGQFOffvpps9sjRowwr2s/2c2bN4vb7Q4MWGzJ73//e/nNb34TuL1x40Y5+uij5R//+IfZEAFgH6kUm8LRUwxoP/9u3brF/BoA0k8qxab99tvPTIaWL18uP/jBD8z7PB6P+d79+/eP+TMisUiOUvB8QbqzBdMdr2vXruZ13QF1AOGUKVPMHUxnZNlnn33klVdeMQcT6mwsv/71rwOl26bB4J577jHn09cjJlrC1ZKyOuKII8xysT6mz9EZVDTZ0cc1eGg1qKl+/fqF3NYZX9TgwYPNEjGAzJFOsUkr2p999pnZ3UZnrNPbV111lZxzzjmBWawAZIZ0ik06o53OUjdz5kzp27evmRDppA/+yR2QItppLBNiHFioX0nTy7BhwwLPeeONN4whQ4YYbrfbHCzonwhh6tSpRl5entG3b1/j0UcfNQ455BDjiiuuCPydPve2224zTjvtNCM/P9/o0aOH8fDDD4e8/549e4zLLrvM6NWrl5GVlWW+1tlnn22sW7euVcvPhAxAZkq32DR//nxj8uTJRklJiZGbm2uMGDHCuOuuu5oNnAaQ3tItNqn6+nrjmmuuMbp162YUFRUZRxxxhLF48eJ2WT+IjUP/SXaChvanR06uvPJK8wIAqYLYBCAVEZvsi/McAQAAAADJEQAAAABY6FYHAAAAAFSOAAAAAMDCmCMAAAAAIDnKDDpH/2uvvZbsxZAnn3zSnLdfT7T40EMPJXtxACQZsQlAqtETrmps0hNDJ9utt94q3bt3T5lYCQuVoxRz+eWXB86gPH78+KQsg54YTU9eVlpaKgUFBeZyPPPMM1H/Zs+ePXLppZfK9ddfLxs2bJCf/vSncS2DniRNgwVJFpAaiE0WYhOQOhYtWiRnnnmmeWA2Ly9PRowYIQ8//HCHL8fdd98tEydONE863a1bN/PEsMuXL4/6N0uXLpXbbrtNnnjiCdm0aZMcc8wxMb+/npVH/54kKzHcCXodJNBPfvIT8+zuX331VVLWa+fOneXmm2+W4cOHS3Z2trz55ptywQUXmDv80UcfHfZv1q1bJx6PR4499ljp2bNnXO//6quvyqeffiq9evWK63UAJBaxidgEpJL58+ebbZNnn33WTJDmzp1rHpx1uVzmAduO8sEHH8gvf/lLM0FqaGiQm266SY466ihZsmSJeZA5nO+++878f8aMGWZSEw89kBzvayBIjCePxd4zI5911lmBMyc/8MADzc6wHKuZM2ca48aNa9Vz9Wv805/+ZJx44onm2Z71TNCvv/56Qr+jCRMmGLfcckvYx5566qlmZ6fWs0/HYv369Ubv3r3Ns0Xr2akffPDBOJccsB9ik4XYBNgnNvldcsklxtSpUyM+ru0Tbae8/PLLxqGHHmq2m8aOHWvMnTs3YcuwdetW8z0++OCDiG28pu2mWC1cuNBsN23atMl8nVdffTWOJYeiW10crr76avn444/ljTfekHfffVc+/PBDWbBgQbMuGIWFhVEviaCl2dNPP92sNk2fPl3OPvts2blzZ+DxlpZBlzMczb3ee+89szx88MEHh33OGWecIbNmzTKvz5s3zywP6xEcXR8tve9zzz0XeB2fzyfnnnuu/OpXv5JRo0YlZL0AdkRsshCbAPvFpvLycrMHTEu0h8y1115rjj0aOnSo2T1Pqz7+3jAtLcNdd90VdRlUpOXQ933qqafM69pm0ovSNlFL76vrzK+6ulrOOuss+cMf/iA9evRo8TOjdehWF6OKigp5+umn5fnnn5fDDz/cvE839KZdwW6//XZzJ2hv559/vrljK91hf//735uJyrRp08z7Whp4WFxc3GzH7t27t9TV1Znl6ccee0yOPPLIsH+r/Xy7dOliXi8rKwvsoDpuqaX31YGIfr/73e/E7XabYxsAxIbYRGwC7BqbtFvdP/7xD/n3v//d4nP1PXQogP8Asx6UXblypTmkQJeppfZLpMRHD/ReeeWVMmXKFBk9enTY52iSo+O6VXBSc8IJJ8jkyZOjvq+2zfyuuuoqOeigg8yueUgckqMYrVq1yhxjM2nSpMB9JSUlMmzYsJDnaV9YvbS3sWPHBq5r/1ZNdrZu3Rq4b8iQIW16PR1UqIGhsrLSrBzp0Z5BgwbJoYce2urX0KSpte+r/YZ1EKUeQaLfLBA7YhOxCbBjbFq8eLGZJMycOdMc79OWdpN/rLS2mzQ50gO1bW03+enYI12Wjz76qM1/q20vvbSGVt/ef/99WbhwYQxLiWjoVtfOOqpbXVZWVshtTTD06EWs3ep0Om4NDDpT3TXXXCOnnnqqORtLW7SlW50+V4NSv379zKCkl7Vr15rvPWDAgLjWDYDmiE3EJiBTYpNOfKDVKJ2M4ZZbbmlzu8l/UNbfboq1W51OAqGTWM2ePVv69OnT5s/elm51mhjppA5agfK3m9Qpp5zSpgPZaI7KUYy0iqI71ueff2426P1d0b799tuQsTkd1a2uJW3tVteUBgztYtcWbelWp2ONjjjiiJDHdGY8vV9nygPQOsQmYhNgp9j0zTffyGGHHSbnnXee3HnnnQlZ1rZ2q9Px2Zdddpk52+6cOXNk4MCBMb1vW7rV3XDDDXLRRReFPDZmzBh58MEH5fjjj4/p/WEhOYqRlj11R9TJA3QH0RKwlnK14hLcLayt5WHt76pd2TZv3iw1NTWBnXPkyJHmtNqxakt5WCtEmtgMHjzYTIjeeust8zxHjz/+eJvesy3d6nTMkn/ckp8GUe2L27TkDiAyYhOxCbBLbNLua5oY6cFU7f6vbSelY6V1DHSs2tqtTrvS6Viq119/3fyc/uXQboPaFmqPbnXaPgo3CYMmnrEmZ7CQHMXhgQceMMu/xx13nFl5ue666+T777+X3NzcmF9TjwLofPl+EyZMMP9fvXp1h3Uvq6qqkksuuUTWr19v7tTa/1bPIaAzPwFIfcQmAHaITS+99JJs27bNbKPoxa9///6yZs0a6Sj+g8dNu7PphBM6YRbSi0Pn8072QmQKTSq03Hn//ffLhRdemOzFAQATsQlAKiI2IRVROYqDzhCybNkyc+YV7Ter/WQVUyoCSCZiE4BURGxCOiA5itN9991nniBVxwPtt99+5iwiXbt2Tcy3AwAxIjYBSEXEJqQ6utUBAAAAAOc5AgAAAAALJ4EFAAAAAJIjAAAAALBQOQIAAAAAkiMAAAAAsFA5AgAAAACSIwAAAACwUDkCAAAAAJIjAAAAALC4JUF8PkMWrauQ9TvqxGcYYmdul1P6d82VUX0KxOFwmPdV1DTI59/tkYraBrG7ghyXTBhQLF2KsgL3rdhULSs2V4vH6xM7czoc0q0kW/YbWCxul7XtID7EpkbEpuiITcSmjkRsakRsio7Y1LHtpoQkR6/M2yq3v7xKNu6qS8TLZQxNkG47bZC8uWC7vDF/m9Q32DtpDOZyihwxuotcOLWXzHxxlSzdWJXsRUopXYuy5Opj+8tFh/VO9qKkNWJTeMSmyIhN0RGbEoPYFB6xKTJiU8fFJodhxFfmeeOLbXLxn5aIzYtFEWnhiHUTmdMh4mPbieiuHw0hQYoRsYnYFA9iU3TEptgRm6Kj3RQdsan9Y1PcydEht30hSzdYR/3zSwqlqHOpOPWbszGfzyfl23ZJbWV14D7tXtepZ1fJzssVO68d3dg8dfWya9M28QV1ocvJy5WS7p3F5XKJnenuWLW7Qip2lgeOhHx1z4F0sYsBsak5YlOUfY/YRGzqIMSm5ohNkRGbOr7dFFe3unXbawOJUW5BngwaPzwwxsbuyvr2lCUfLwgkAD2H9JMuvbsle7FSRkFJoaz75jvzutPllMH7jRSX296JkV9Zv56y+qtvpXJnuWyv8Mj81Xtk8pCSZC9WWiE2RUZsio7YFGXbITbFjdgUZfui3RQVsanjYlNcU3lvKW8cY1RQWkRiFMThdIgryx2yftAov6RxfeQW5pMYNVEYtL1sLa9n0yE2JQyxKTpiU3TEpvjQboqM2BQdsanjYlNcyVHwWBEqRtGxfpqsD9ZNq7cXu8/+GAtiU+sRm5qsD9ZNq7cXYlPbEZtaj9jUZH2wbjosNnESWAAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAABARd7qvhZ4FDpnc2yXDujhleGen9Cl2iNPhCDx+9axaWbTVJ3bkdoqM6+aUMWUuGdHVKWX5DumU65A8t0i1R2TtHp98ssErb65okOoGsZ0jB7pkbJlLBndySOc8hxRnO0Q3HV03Gyp88uUWn/xrZYNsqzaSvahIQ8SmyIhN0RGb0J6ITZERm6KzS2xK++ToyEFuOW9MVrIXIyUNKnXKPYflhn2sxCUyNtclY7u55ORhbrlpTp2s2p3eG3NbnTs6S3oXNS+eZrtESnNdMqrMJScPd8vtH9XJvI32TLARO2JTZMSm6IhNaE/EpsiITdHZJTZlVLe6ugZDahvs1cBvLY/XkCXbvfLpBq9srAjdYMvynXLbwTmSlVFbQ+v4DGPv0Q5r3awtD103eW6HXH9Ajnk0CYgVsSkyYhOxCclDbIqM2GTfdlPaV46+2eaV+z/zyfIdPlldbsi9h+XI+O6uZC9Wythe7ZMXljTIf1c3SJWn8f5zRrvlgrHZgdu9Cp0ysadL5m7wil08udBjJow7a0PvP7ivS2b+MCdwuzTXIQNLHLJiF4k3Wo/YFB2xidiE5CA2RUdsiswu7aa0T47mb07fsl17W7/HJ+f9q1Zqw+Q7zy5ukGMHu6VbQWNq36/YIXM3iG18tD58Ivi/771SUW9IUXbj2LV6++SMSBBiU2TEpuiITWhPxKbIiE3R2SU2pXHRCy3RSRbCJUZ+O2tDM/rKoMqSnf2gjytkB9fy8fcV6Xn0A0hFxKbYEJuA9kVsik2mxaa0rxwhNl3zHDK41BnSh1T7j9rR+WOzpH+xQ3LcDulV6JC+xY3rZUuVT+74qE586buPA2mF2NSI2ASkDmKTfWITyZEN6cQLNx6ULVmuxiz//TVeWZ/GWX48xut0592aj1NbsdMnd39SJ2vL7blegI5GbApFbAJSA7HJXrGJbnU2U5AlcvehoZNW6ODMB+bVJ3W5UtE+nZ3y5DG5ctwQjiEA7Y3Y1HrEJqDjEJvsF5vSe+nR5pLw3VNzzHn8/RZu9sqv/1cndfbsUWe6clad+X++W6RHoUOOHeKWE4da585yOx1y+f5ZsnibV9ak+ZEQIFURm8IjNgHJRWyyZ2yicmQTA0oc8shRoYnRrDUNcsOcOqlpSOqipdRATD0R7iNfeOTj7xtXisvpkB/2ZXp4oD0Qm4hNQCoiNtm33UTlyAbGdbNO8ho8k8hziz3y16+Yni6S7TWhRzs65zWuOwDEpmQhNgHtj3aTvWMTyVGGm9rfJdcdkC3ZeydfaPAZ8tC8enl7lY370YnIMYNc0mCIzF3vDTk5rhrZ1SlT+4fuGhttOlkF0F6ITeERm4DkIjaFZ6fYlPbJ0eReTjlntNXPUfUvCe0peMXEbKnyNH5Bl/3X6idpB/t0cshNB2WL09GYvW+rNmRSL5d5aWrOOq98sM4eSdPAUqecMjxLPF5D1u0xzPWiq6lHgaPZNqQnNntvDX0P0TbEpsiITcQmJA+xKTJiU2R2ajelfXJUmuOQkV0j92ts+oXZSX6WIyQxUj0LneYlnNXmwDl7JEd+Op354E56Cf/4jhrDnK9/Z21HLxnSHbEpMmJTy4hNaC/EpsiITS2zQ2xK++QIiMXb3zWYRzY0se5V5JCSHIc560q9V2RnrSFrdvtk3iafzFrdILX2yhcBJBGxCUAqettG7aa0T47eWe2Vd1ZXJ3sxUtKirT45/HnWTaQq2epyLfmmb9kXqY3YFBmxKTJiE9obsSkyYlNkdopN9u1zBgAAAABBSI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAASUDnKdjsC131eXzwvlZmMxqs+rzeZS5JyfL7GlcO205w3aHvJclHgbStiUwuITcSmGBGb4kNsagGxKSLaTR0Xm+L66wFleeJ///Ltu8RT54lrYTJJfU2teOob18eOjdvEMIL2ehvT9bBr87bA7ZqKKqneU5XUZUol3oYGKd+yM3B7nx75SV2edERsiozYFBmxKTpiU/yITZERmyIjNnVsbHIYcbbYz3j4K5n9za7AbafLJdJYULInI3ylyOF0iMNJFcDwGWL4mlca2XYsvobGbWdErwL54Nb923VzzVTEpjCITVERm6IjNiUGsSnczke7KRpiU8fGJndcfy0i/+/kQfLxsgVS77VyLLqPhdLKmr/HobVx070uWLbLwbYTgdMhcuvpg+LdRW2L2BQdsSk6YlNkxKb4EJuiIzZFR2xq/9gUdxnjqQ82Bhq3aI6hWNGx7USmw7L++v5GditiU7sgNkVHbIqM2BQf2k3REZuiIza1f2yKq3JU3+CT17/YFsj07z69vxwyotj2A8hrPT75z1e75PZX1wfWVV5hvvQePlCyc3PEYfNuhzo2beOKtVK5a0/gvm4DeknnXt3EZfPJB7STa9XuCvl+6XfmRBWzFu+QHRUe6VKUlexFSyvBsUn1GTFIijuXmF1b7T6gt3zrTnP/8yM2RY9Nlx7ZQ844oKsU5LjEzrw+Qz5fVSnXPr9GquuJTbEiNoVHbIqOdlPHtpviSo6+3VQt5dUN5vUjR5fK8ft2juflMkZetlPOPLBM/vjeZtm6x1o/PQb3NRshEMnJd0nPIX1lxeffmKsjOy9Hug/ozarZq7hrqXTqWSY71m8xj6AtXLNHjhjThfUTY2wqKesknbqz/pTTJdKldzfZunajNOydMIbYFDk29e+aI788sif73l5TR5bIaZO7yNMfbiM2xYjYFB6xKTraTR3bborrMH1VXeP4mR4lHNluKtvduHqzcrLjWdUZx53VuL2wbpoLXifB+xlaJ3idsX01F1xBY/1Ejk38rjXXo4TYFA9iU3TEpshoN3VcuylhfZgcdu8rBiQQexOQfPysAYD92k32HuABAAAAAHuRHAEAAAAAyREAAAAAWKgcAQAAAADJEQAAAABYqBwBAAAAAMkRAAAAAFioHAEAAAAAyREAAAAAWKgcAQAAAADJEQAAAABYqBwBAAAAAMkRAAAAAFioHAEAAAAAyREAAAAAWKgcAQAAAADJEQAAAABYqBwBAAAAAMkRAAAAAFioHAEAAACAiLhZC/aS6xJ5cnqu9C4KzYvPer1GtlQZYlcTezrliAFuGVnmlE65DvO+8lpDNlYa8vU2n7z+rUfK65K9lEhn7Hvhse8ByUVsCtUt3yEzhrplfHen9Cp0Sn6WiNcnsrvOkJW7fDJnrVfmrPOKz75NpoyP3SRHNvPTCVnNEiM7K8gSuWVKjkzq5Wr2WF6hQ3oUiuzbwyULNnulfJsvKcuIzMC+F4p9D0gNxKZGk3o6ZeYPcyTXbTX2/dxOke5uh3QvcMqUPm6ZPtgrN86pE48NmwUFNmg3kRzZyH49nDJjaFayFyNlaLC757AcGd6lcQev9xry/R5DtlUbUpIj0qfYKUXZoUESaCv2PfY9IBURmxq5HCLXHRiaGO2pM2TpDp/ZHghuK0zo4ZJThrnlhaUNYidum7SbSI5slOlfOznbvF5Zb4hWg9N9443XOaOzQnZwPcpx/2f1sjmoe6HTITK+m1M2V9q8fo6Yse81x74HJB+xKdSgUkege5g/MbrgzRrZvbdr2PljsuTcMY0HmMd0c9kuOTrHJu0m+lfZxKX7Z0u3AuvrfuSLeqmqT9+NNlF9rE8a2nhsYGeNIbd/VBeygyvtU7xgi0+219h7fSF27Huh2PeA1EBsCtW0i9ymSl8gMVLLd4Y+odJjr3ZBro3aTVSObGBKH5ccNdD6qv+3rkFmrfHKBWPt3b1ubHenFAZVzuZu8EqvIqdM6e2S7oUO8XhFVu/2yQfrvGm9gyO52PeaY98Dko/Y1Jx2DdtY6TMnYVBDOjllan+XzF3vlZIch5w0LLTJ/N4ae1WNxtqo3URylOG0/+dVE63udLtqDHno8/pkL1JKGNY5tGg6uZdTjhuS2+x5F4835C+LPPLiMnsFQcSPfS889j0guYhN4XkNkTs/rpfbD86RLnkOcTkd5sQDTVXUG/LkwnqZtzE9JxuI1TAbtZvoVpfhrpyYLZ3yrEz/gXn1aTutYqKVBvUrVmX54XeFLJdDfr5vtkwf3HxWFiAa9j32PSAVEZsiW7bDJ5f8p1aWbPeGfVwnH3jhG485nbfdlNqo3URylMGOGOCSg/tZxcF3VjWYJVBY3DpisInZaxvk9Fdr5KSXq+WlZZ6Qxy4cl20OMgTY9+LDvgckD+2Clrsb/vW4XBnZ1RU4b8+8jV5ZtsNqP2W7HHLxhGx5bFqudC+wV6PAbaN2E8lRhspyWoMt1ZYqnzz6Bd3pglU3GUjp9Rny0Lx62VFjyJ46kScWemRXrRFyxGRwaZru5ehQ7HvRse8ByUFsiq53kXajy5aCLOu3ftVun5z7rxrzfEa/fKdO7vmksetN32KnXL63jWUX1TZqNzHmKENluxqn6i7NccizJ+SFPF7YZJ/+47RcMQyRR+bXy2wblIs3VITu5DojTaUndLYVnammk07Psldxjq7P9B5kiPbHvhcd+x6QHMSm6HTyBa0M+f13VYNUBbUL3lntlUv3NyR/b/K0f0+ned6fBpsMPdpgo3YTyZEN5LgdktPCN21twCLZNqklLt4WmgAWZok03YWLm5wHKviICNAa7Hvse0AqIjY1V7Z3fLZfuF98o0k3s6JsbRuILSy2UbvJJk1hINSaciPQh9j/Q3H0oKCzX3d3mmd59tOZ/lbvTs+dHEgl7HsAUtHW6tDfeD0FSn7QgeWjBroCXe5Ulcew1SRXa2zUbqJylKG0FHz489URH3/uhFzpsXcuf3XW6zWypcmJvDLdH+Z75KEjnOZ0neqaydlyzGCfWSIf1TX0uMH/fe1Jw8IwkoF9r2Xse0DHIzZFN2edV84dbZizranBnZzyzAl58u1OnxTniAzvEjr72qzVDWZXMjv5g03aTVSOYFtLtvvk7k/qzak5ldPhkNFlLhnf3RUIjj7DkOcWe+TNlek7Xz+Qatj3AKTimJoH59WLZ2+bwD+pwKRermaJ0aItXvnzl6Gzs9nBEpu0m6gcwdZ08oml22vl1OFu2a+HS8oKHOYRA5195ettPnl9RYMs32GT0ZZAB2LfA5BqdNKFr7fVynFD3DK+u1N6FTnNrnVaGdHxMyt3+cwKk57nKF2rIvGabYN2E8mRTZ39hk1GELbC5ipDHp2vR4DsdxQIHY99rxH7HpA6iE2WjZWGPGnDqlBbbM7wdhPd6gAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxUjgAAAACA5AgAAAAALFSOAAAAAIDkCAAAAAAsVI4AAAAAgOQIAAAAACxUjgAAAAAgkcmRzzBYoU2FrBLWT8jaYHVExepJHNYla6hN20vQBuPzJXBDzBAGwTtx6zJxL5WhWEMha4PVEZWRKslRUa4rcP37HfWJWJ6MUuNp/GWtr6lL6rKkGk99fci64Qc3VH1NbeB6UZ67A7+ZzBAcm9j3mvN5iU2tiU3f7yQ2NbVuZ+P6ITYRmxKN2BQZ7aaOazfF9dfDehVI16Is2V7hkfeXlMtj726U0X0LxOV0iJ15fYbM+65SdlQ2BO7buHKddPc0iCtbV7nN10+DV7at3Ri47amrl/XL10hJ11JxOO3d01OTxLqqWtm1abt5O8ftkImDipO9WGknODZV7NgtW1ZvkPziAhGHvfc93b6qdlWI10Nsak1s2rTbI79+cZ0cMbpUstx233ZEVmyukZfn7TBvE5tiQ2yKtH0Rm6Kh3dSx7SaHEech+zteWSWP/Of7uBYCQHinTu4mj104gtUTA2IT0H6ITbEjNgGpHZviPkw/bVwXcbvsfUQtGpe9CyEtctu8yhiNFjmO3bdrshcjbRGboiM2RUdsiozYFB9iU3TEpuiITe0fm+KuHJ1w75fy6Ypy87oryy2FpUW27xrl8/mkcuce8Xm9Iesqr7hAcnJzbN+1R7vRVe2uCN0QnU4p6lwsTlfjWBE70t2xurxCPHUe8/aAslz57DeTxGHz7mCxIDY1R2yKjtgUGbEpcYhNzRGb2h6bcrMcMmVosRTk2PsofIPXkAVrqmRzeeLaTXGNOdq6p14+W2klRlk52TJ00mjbN24DX5anQZbN/TIw0UBZv57SY1CfeFZ3RtmxYatsXLHWuuFwyNCJoyQ7LzfZi5USDJ8hKxcskdrKalmzrVa+WV8lo/sWJnux0gqxKTJiU3TEpsiITfEjNkVGbGp9bHI7Rd64eoT07ZKTgK0yMxKkMx5dLks21CSk3RRXurl+R21gasGiLqUkRkHcWW5x52QFbpd06xzPqs44xV1LA9fzi/JJjII4nA4pKesUuL12e+MMLGgdYlNkxCZiU6yITfEjNkVGbGp9u0knPyMxaqTDe44aU5qwdlNcyZHH29gjz8nYkegr2uazsDUVXO60+wx1LW0vDUHTLqN1iE2xbWsgNrVleyE2tR2xqfWITZHbTdqlDqFytJyWoNjEryIAAAAAkBwBAAAAgIXKEQAAAACQHAEAAACAhcoRAAAAAJAcAQAAAICFyhEAAAAAkBwBAAAAgIXKEQAAAACQHAEAAACAhcoRAAAAAJAcAQAAAICFyhEAAAAAkBwBAAAAgIXKEQAAAACQHAEAAACAhcoRAAAAAJAcAQAAAICFyhEAAAAAkBwBAAAAgIXKEQAAAACIiDud18KPx2TJeWOyWv38L7d45Zr36sROuuU7ZMZQt4zv7pRehU7JzxLx+kR21xmycpdP5qz1ypx1XvEZYjvXHZAtRw9qeReYt9ErN86x13aD+BCbWkZsiozYhPZCbGoZ+x/SOjlCdJN6OmXmD3Mk1+0Iud/tFOnudkj3AqdM6eOW6YOtxr/HxxoF0P6ITQCAVJXWydHacp/8b11DxMfHdHNJp9zGxGD5Dvu0/l0OkesODE2M9tQZsnSHT0pyRIZ3cQXun9DDJacMc8sLSyOvy0y3u9aQr7Z6wz62Ypd9thskBrEpMmJT2xCbkEjEJvY/ZHhy9ME6r3kJRxOA52fkBW57vIa8stw+jf9BpY6QxFATowverJHde3uHnT8mS84N6pKoiaSdk6M15T657aP6ZC8GMgSxKTJiU9sQm5BIxCb2P9h4QoYT9nGHVE1mr/PK9hr7DKxp2kVuU6UvkBip5TtDn1Dpsc+6AZKJ2BS6PohNQGqwe2wCMqJyFEmWU2TGPqETNby41CN28v0eQzZW+sxJGNSQTk6Z2t8lc9d7pSTHIScNC/3q31tj36qRKst3yCX7ZpnVtjqv1WCbv9kny2zUFRPtj9hEbGorYhM6ArGJ/Q8ZnhwdOdAlnfIaj358vskrq3bb6+iH1xC58+N6uf3gHOmS5xCX0yG3TMlp9ryKekOeXFgv8zbaOwnoXeSUU4aHFlJ/Mk5k4Wav/PaTeo6eISGITcQmYhNSEbEpPNoG9pSR3epOHW7vqpGfVj0u+U+tLNkeflxWvdeQF77xmNN5IzydrOLew3Ikp3H+CiBmxCZiU6IQm5BIxCb2P2Rw5eiAXk7pX9KY8+m5fLR7lB1N6eOS6w/MloIsq4pWXmuYY42K985Wl+1yyMUTsmXaYLdcP7tOtlTZq7qmn/f5bzxmdWh9hSG7ag2zC8sxg93yo5FucTqs9davxGmeK+qfNp6wAvEjNjUiNkVHbEJHIjax/yHDk6PTRlA1Ur2LtBtdtpkAqVW7fXLlu7VStbeIdvRAlznVt+pb7JTL98+Wmz+w14lOn/66eUVxY6Uhf1nkkVy3yMnDGrelyb1cJEeIC7HJQmwiNiG1EJtC0TZARnWr26eTQ8Z3b+z/tKXKJ+/btMuYTr7gT4zUf1c1BBIj9c5qr1QHzVC3f0+neXJYWBY0qTbquC0gVsQmYlOiEJuQSMQm9j8058zkox+vLm8Qn716igWUNWnMh1sNwfe5nQ4pyhbbCMobw+pZGPqEKqY6RxyITY2ITdERm9CRiE3sf8jg5EjHihzSr7FqVFlvyL9X2neMyNbq0HToqIFuyQ/qRHnUQFdgLJK/8V9uo151o8uc8tAROebYh6aNkaGdnXLOqNBEe/E2e45bQ/yITaGITdERm9BRiE3sf8jwMUcnD3Ob1Q8/TYyq7ZsbyZx1Xjl3tCFZe1v+gzs55ZkT8uTboAkZgs1abb8q25huLvNS4zHMiTt0WvOyfKcM7uQITMbgTxxfZDIGxIjYFIrYRGxCaiA2hUfbABmRHGlFZPrgxo/i8RryynIbZ0YisqHCkAfn1ctVk7IDCVJprkMm9Wo+J/WiLV7585f2mu48OA/My3KYwTCcHTWG3P5RHec5QkyITc0Rm4hNSD5iU3i0DZAxydH0IW4pzG480j97nZfG7N5JF77eVivHDXHL+O5O6VXkNANig0/Maau1WqJHcfU8RzYrGslXW63Z+3QWuhFdndKnyCHFOQ7RraiyXmRNuU8+3eiVt78LncgCaAtiU3jEJmITkovYFB5tA2RMcvTSsgbzAgk7NfWTNqsKtdbX23zmBWgvxKbIiE2REZvQ3ohN7H+wwYQMAAAAABAPkiMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAAALlSMAAAAAIDkCAAAAAAuVIwAAAAAgOQIAAAAAC5UjAAAAACA5AgAAAIAEVI5cTkfgumEY8bxUZgpaJayfJqsmaHsxfGw7TfmC1knwfobWITYRm2JFbIqO2BQfYlNLO2D4fRGh66O+gXXTlMfrS1i7Ka7kqHennMD1ip3lYvgaF8zufF6vNHg8gdsVO3YndXlSTeWuPYHrNRVV4qlrXFd2pwGwYmfj9tK7c+N+htYhNkVGbIqO2ERsak/EpsiITa2PTYvXV8u2CtpNwe2mD5buSVi7yWHEmZpPu2uBLFhTYV7PzsuRos4l4nDY+0i3HlnTZMhTVx9yf1GXUnMd2XvtiLleyrftCrnPleWWkq6dxOmy9zA43R2rdldIbVVN4Id0/t2TxUn1qM2ITc0Rm6IjNhGbOgKxqTliU9tjU+cCtxwxukQKclxiZw1eQz5fVSnLNiWu3RR3cvTBkl1yzqNfSx0lvrDcToc00G0somy3g/JwpJ3TIfL4hSPk5End4tlFbYvYFB2xKTpiU2TEpvgQm6IjNkVHbGr/2BT3YfpDRnaSZy8dI/sNLIr3pTLuCzpwnxJ57dpxctm0vtK1KCvZi5RSSvLdct4hPeU/N06QqaM6mcEQjUb2KZA/XTySxCgOxKbwiE3EpngQm+JHbAqP2BQd7aaOi01xV46CbdpVJxt31dm+UpLlckifLrnSrTg7sG68PkO+3VQte2oaxO60BDy0Z75kuxtz811VHlmzrcb2VSTNEbuX5Ei/rrlJ/Y4yDbHJQmyKjtgUGbGpfRCbLMSm6IhNHRubEpocAQAAAEC6svfodwAAAADYi+QIAAAAAEiOAAAAAMBC5QgAAAAASI4AAAAAwELlCAAAAABIjgAAAADAQuUIAAAAAEiOAAAAAMBC5QgAAAAASI4AAAAAwELlCAAAAABIjgAAAADAQuUIAAAAgEDk/wPA1KVKKYM4tQAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0cAAAJRCAYAAACOQsyxAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAciFJREFUeJzt3Qd8G/X9//GPhvdO4jh7OWRPIAmQFggzhBE2ZRUo0EHZUHb/YRRo2RQKhQ5+lFFaNqVQSiChQIBAEgIhg4QMk70db8vS/R+fu0iWbEm2LNuSfK/n4yGwRqTz6e7t+3y/3/uewzAMQwAAAADA5pyJXgAAAAAASAYURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEICa33nqrOBwO8/Z///d/Yjf33nuv+bsXFRVJVVWVpLJBgwYFvsv2ptuG/711m7Gz888/P7Au5s6dm+jFQZLtK8lK801zTn9nzT3ALiiOYLsD+uBbQUGBTJ06Vf7yl7+IYRiJXkzEYcSIESHf7aeffhr19Yceeqh50BqLyspKueeee8yfL7roIsnJyQk8F/zZa9euDfl3ekDsf04PsrrSfqW3hx56SOwg+HvUm8vlktzcXBk8eLAcc8wx8qc//Ulqa2s7pND0r+vdu3dLV6T7TNN1u379+mavGzduXMjr/vjHP0qqe+211wLfb9PsaM3zHUXz7eKLLzZ/1uJI8w+wBQOwgVmzZmnlE/V2wQUXJHoxU8K6deuMDz/80Lxt2bLFSAYLFy5s9n1eccUVzV73wgsvGKtXrzZ/PuSQQ4zzzjvP/Hnx4sXGW2+91eLnPPLII4H3X758echzwZ+9Zs2akOfmzJkTeG7gwIFGsvj8888D32VbRPuddNvwv7duM11B8PcY6TZ8+PBm28a3334bWBe7d++O+XN1W420bXUV+ns1XZe33XZbyGs++eSTZq95/PHHO2X5dBv3f2Z70xzyv7duY7E+35FWrFgR+GzNP8AO6DmC7WgL74cffijvvvuu2frv99RTT8kXX3wR9d/6fL4OaRlurWQYxjVgwAD5wQ9+YN569uwpyeDvf/97s8defPFF8/vy02N57fUZOXKk3HDDDea63L59u/z0pz+ViRMnypNPPtni5+g2okaPHi3Dhw+XVOXfjvbff//Ad9nedNvwv7duM11Nr169zBz5z3/+I3feeaeUlJSYj69YsUKmT58e0sOzzz77BNaF9lajdXR/C+7R1545dK5hw4aZeafsOIwaNpXo6gzo7J4jf2+B8vl8xuDBgwPPPfDAA81e/5e//MW44447jAEDBhhOpzPQcqf/9oknnjCmTJli5ObmGhkZGWar8Y033hi2dfjFF180Ro8ebb5O//+Pf/wj5HOeeuqpsK2U2up+8sknG/n5+cagQYMCr9m6datx1VVXGUOHDjXS09ONwsJCY8aMGWbralN//OMfjf3228/IyckxX9unTx/j8MMPN373u98FXuP1eo3f/OY35rJlZmaay9m/f3/zPf/85z+HXZfBy6wWLFhgnHrqqUZJSYmRlpZm/v+UU04xvvjii5DX6b/zv4e+3zPPPGN+ri7bPvvsY66b1tLvQb8bfS9d7pkzZ0ZsZW1oaDD+9Kc/GX379g28Rj/vn//8Z4ufo9+D/9/oem+qrT1Huvx//etfjYMOOsjIy8szf4dx48YZDz30kPmdhPuMpu8RrmchuCVen//ggw+MAw44wHx//z4QqTW8pe0lWk+sf9mafsfB/v73vxujRo1q1b4Qy+/s99prr5nLq/uELv+wYcOMW2+91aiuro74vQTnQiTRvsfvv//eKCgoCDx/yy23tNjyrz/rchYVFRlut9vo0aOHMWnSJOPyyy83M6Slnir/73311VcbBx54oNGrVy/z99XvbeLEica9995reDyekOUMXn7t0Tr++OPN1+sy/OxnPzNqamqa/d7PP/+8ceihhwbWp/7bc845JyTn6uvrjfvvv9/Yd999jezsbPM2efJkc99ujeDtNSsry3C5XObP77zzjvn8nj17zOXUx3Q/Cddz9Oqrr5q/j+akZrJmkGbD+eef32wbCf5O9DN+/etfm7mg26Tui19++WXI64P3lW3btpn/XteHfs7pp59u7NixI+T1rflOwvWWBd+C96FwN/+2dPfdd5v7gy6/7t+6/kaOHGncfPPNRlVVVcTfY9OmTeb3GO33UFdeeWXg35SVlbXq+wRSGcURbF0cqfHjxwee++1vf9vs9UOGDGn2B0kPaH/0ox9F/KM1YsQIY+fOnYHPePnllw2Hw9HsdcGfHak4Cv58/wGZHqj369cv7GfrAcHrr78eeK+//e1vEZdT/5j63X777RFfN3Xq1LDrMniZ9TP1s1uzTMF/9JuuX71pEdp0aFIkH330UeDfnXTSSeaBsf/+T3/602bFkRa7wetOi6OXXnqpxc/RA0T/vwl3wBfuoLU1B9U//vGPI673M844o12KIy1u9KCp6T4QrjhqzfYST3GkhVG4fxdpX4jld1Z6kBtp2X74wx8adXV1HVIcKW1c8D9fWloatTjS7VsPYiMt68qVK1tdHOkBfWuHC/sf18aW7t27N3u9HlAH+8lPftLi52thpEVepNddd911La7b4O1VG1W0yNGfTzvtNPN5LYL0vh7I60F8uOJIi7tIy6DvGTwMOPg7CZdBWmAFF5bB+4oWHk1ff/bZZ4f8Pq35TtqrONJGuUivmTZtWshyRfrbEun3aJoJuv8CXR3D6mBbdXV18swzz8hXX30VeGzs2LHNXrd69Wo5++yz5d///rf87W9/k759+8o///lPeeGFF8zndTYfHZL16quvmicLq+XLl8tNN91k/uz1euXKK68MDA857bTTzPe6/PLLZfHixS0u55YtW+SBBx6Q//73v4H3vOSSSwInK//4xz82h/Y8/vjj5snhHo9HfvKTnwSGTr3++uvm/91ut3ny8nvvvSfPPfecXHPNNeaJ5H7+1xUWFsqzzz4rs2fPNn/fn//859K7d++oy6ifdeGFF5qfrX7xi1/IW2+9ZS6n0sf1+XDDAnX96nNvvvmmHH744eZjOhzuz3/+s8Q6pO7UU0+Vo48+WvLy8sz7L7/8sjQ0NJg/6/o/8MADzWU788wzzSFlxx57rBx88MFy+umnyymnnBL1c5YtWxb4eejQoVFfq+s1+KTxadOmhX3dSy+9ZK5jpcP09Hf517/+JQcccID52D/+8Q/zFq+NGzdKv379zO9Vv5cTTzwx4mtbs73o9qVDypoOMdOb/k6R6L5w7bXXBu7/6Ec/MveFq666qlX7Qks+//xzueOOO8yfdZvViVZ039DvWenyPfjgg9JRdPvy++6776KewK7Demtqasyfr7jiCnM967r7zW9+Y26but3ocE9d5gkTJoQMF/Wva/9+efPNN5vbjv6uOmnEK6+8IlOmTAkMhQo3scGePXukuLjY3Ef860w98cQTgZ/1ub/+9a/mzzpBgn53uv3oNnvkkUcGZm57+OGHzeVXuu1qFurv4h96qsNZP/vss5jWpX/Is26POvzVP6TurLPOkqysrLD/5qijjjKXX/chXQ+6PnS79edopEz5/vvv5Xe/+5253vr3728+phMfvPPOO2Ffr0MmdV967LHHJD093XxM/x6Ul5cHXtOa70S/P/0edai33+9///vA93vSSSdFfV63D6UZrX/L9LvRz3rjjTdkxowZ5nNz5syRefPmhf09dPtr6fdomndLly4N+15Al5Lo6gxIlgkZ9t9/f7Nnoenrg3tN/E444YSwJ6l+/fXXgcd1mIr2MH322WeBx3SIhbay+ukwp+BWwnCte08++WTIZ+uwB38vlL6f/0RvvWnPif/f+XtD/D1cOsxl9uzZRnl5edh15F8W7R3QoXlNh2OEW5f+ZX7llVcCj+lwrGB63/+cDntRwS2i2mPg9+mnnwYeP/HEE42W6PelLcL6em2p1aE3wb+z3oInWnjuueeMVatWNZuQQSd0+Ne//hX1s37xi18E3jNcr1ZL21e4HofgIYC///3vA9+jDv3zP37cccfF3XMUqScuXM9Ra7eXaMsTqecoeF/Q3qzglnndz8LtC7H8zjoJh/+xm266KbA+9bv1Pz5mzBijrVrqOVq6dGnId71+/fqIPUc6dNH/mA6h1CFObZ2QQXtPdVvSPNDheU23ueBe2+DHFy1aFHhce7v9j/uHywVvnzpcOJLgXj8doupf78G90ZdeemlMPUe6b/fu3TvQm+F/TvfV4PUZ3HOk2ajD2bQnJVyvnOajX/B7BE/eoqMHgr+XcPuKP8fU9OnTA48HD8WL5TuJd0KGJUuWmPut9oiH671/+OGH2/x7qGXLlgWe0xwEujp3ooszING0xUx7DnQ6Ym0dbeq4445r9ti3334b+NnfGqjGjBkj2dnZUl1dLbt27ZJt27aZPSN+++67r6SlpYW0NLc05fTxxx8fcn/VqlWBXqjNmzfLD3/4w6g9HRdccIHZ+6DLdMQRR5iPaS/CIYccYvZoaSu10t4bXZYNGzaYy6WtwkOGDDF7c7T1VU/MjSTS+lCTJ0+WBQsWNHudny6HX/fu3QM/t2bK4vfff99sEfa3Gvt7jLR3zt+zp623/pZXbXUOR1tg/a2wrdHStO/auq+9KX6LFi0yewqbCl4f4Z5v2mPVVjohQGsnkGjt9tIWwfuC9oZo71TwdvLxxx9LPILX51133WXemtJe3Y6i+06waJMvzJw50+xd2LFjh7le9aa90Lr/aM+cbsOtMX/+fLNn0t9rG064fSk/Pz+kR6rpvqfLHrw+w+WgX/DrNEvbYzvWLNZtUb9D7blU++23X8T9VHsldXvVfS2SSJkSawa19Pq2fidtsW7dOjnooIPMnsCO+r25zAXshmF1sO1sdR999JE5lEf/EOiQhOA/DsH8s1C1h7ZcQLCtn+8fwqZFgx506vUq9MBCizcd0qEHHPrH0X/AqsNY3n77bTn33HPNIk+LRh0apEMG9XVt/WPe0u+sB4R+wQfLrfmD7C+AlA6l8Q9jCx4ip8Nyws0wqMNPYpl9qUePHoGftfCNJngWOL2FG67ZWuGGIuqBYDAddhRNLNtQa7eX9tbSdhLr7xyJDrPUIbUdIbi4Ky0tNYe5RqLFszYaXH/99eY2ovmj25UOw9ICI3jbjkaHPvoPwrWA0aFVmm863NYveNbGcPtdW/a9zphpUxtsgreL4NlFw617f2Gkw9Wefvpp+d///hcy7DbcemhLBrX0+rZ+J22hv6e/MNJGLb0mkn7Wdddd126/d3DeBecg0FVRHMF2/FMM68Vf9RyhSOPXox20BfeiaCuh35IlS8wWd/8fHh3TrwdJfvrHO/gg75NPPmlxeZt+vo7/9j+m760He3snVwnc6uvr5fbbbw8510aLnIULF0pFRYXcf//95nO6rHow5n+dTkGs5xN8/fXX5vkS2prt76GKNG492vpoej9a71Os9HfUcfwt0QMHPTiJl04BHtx71x6C14eeG9D0e9SbFqhNeyK0t8F/8KXnRrTUGxJLUd7a7SX4fVt7oKc9kX5ffvllyL4Q6ZyUWH7n4PXpnwa66U0P0jMyMqS9lZWVmecG+p1xxhlRX6/LMnDgQPntb39rHsxqsafnTPkFb9tOZ+Of6qbrOri36u677zYbfzTf/D2q8Qhen3puWGtep8VzuPXuPycpFrq9+M/X0yI9Us9v0/Wgr9NCJFKvekeL9TuJ9v229HzwZ+k5qdojqZ/V9LyheATn3ahRo9rtfYFkxbA6oA30j6+e9Kr+3//7f+bBlrao3XbbbSEHR3rwqEPp9CRfPelXT4zXP9o6wYOe7NvSkLpwunXrZv6x1QN+PXA+4YQTzBZWHVKmQyy0ANMDKy28Bg0aZA7X2rRpk3kCtS6HthAGn0zvb0XXyQz0PfSAQodRadEVfN2naK3t2tugLd96AKv/5tJLLzVPgtdl9L+Hrh9dhvaivVz+3ixdxzoEJ9g333xjtuAqbT0++eST4/o8Lab9tGjQHrZ46XbgnwBB30+HWekQOB2OuXLlSvOAVL/rWbNmBQpj7W3QE6l1G9TJJPRk6qa9KvFo7fbibwDYuXOnuV1rz5Ie7Gsvlf4O4eiwKJ3QRA/o/PvCOeecYx44RxpSF8vvrM/r5ABKJ3nQZdMGEN1OdF/RSU10Gf2TDGjvof/g+7zzzoupJ1HXg/Y+a8GoRY2eKO9vwdfPCJ54IhzdJnX71MkxdKILLQJ1mGjw+4dr4deJCfRke23U0R5K/azgA3H9PXTfiDSZQCz0u/FvnzqpgmaCri/dz/VEfl1+/Xzdjv0TamhPifZaaIbodqRFrL6HDs09//zzY14GvYaUFuS6HehQwEiC14NOJKEFgvZ46DXNOlus30nw96vrVYcU6s1//bFozwd/lm6D2uOvDQ06GUl7CR6qGJyDQJeV6JOegERP5d3S65tey0fpRAs6zXK8U3mPHTs27Oe0dDX2aFN5Nz1x+8ILL4z4Gj1p+bvvvjNfF20qXj1B2n+SdqR1o1Not2Uq7+Bpnptemyea4EkXwl25XU/O9l8rRX/PiooKI17+ySXCndQfbt3HO5V30/Wj19Vq+rxenyR4W4h0naNwwm1nrd1elF7Dqulr/PtXrFN5R9oXYvmdW5rKu+n+H89U3pFuOjV808kvwp1Qr9PBR3uf4CmTdftu+rx/O9JJLppmi97Xa+yEW5+RtsNIkz4EL3ukjNHp0aPlR9NlaM2EDNGEm5BBJ3DQ64M1/dzgiT6C94NIkxxE2m4jZXK494n1OwmeMCT41prn9W+BTp4S7fdu6+/hp9ci809aBNgBw+qANtAeoeeff95sOdUTyXNycszeIx1eoi2V2iMU3NqnvRY6/bcOSdCWPR2ipf/eP3W1f9hIaw0YMMBszfvVr34lI0aMkMzMTLPXR3/W1njt1fJPSaututpyqSfka+u0tjjq0EJtsdYeAf9QJ512W3u7/OdKaI+BtvLrv9cW8mgnlysdzqG9VdoDpe+v/16HFervrkPytIervejQKH/PnQr33trDpicqK+118LeAx8PfO6XDJ7Vnp73OGdChjHo+j65j3T70+9VtQ1uC/dOh+8+5uPHGG831qz0Hhx12mPkdBg/djFdrtxf16KOPmufH6PfcWjp9t/aa6D4QvC9E6tmL9XfW4aQ6LbwOEdXeTJ0ARbdjbWXXIWzBvbvtkQO632rrvfae6nT62oPSmskvdOiiTuGtvZ7aq6rrWde39tzqhBi6nvx+9rOfmecm6XYRPMRKaf7o1Nl6XpvmwOjRo80JQXR52oP2puk5mU23T91O/Bmnj2nvjm6vujyaRbos2iOmPcjai6HTUnckXX/a06o5pMup26Su39ZeEqA9xfqdaG/bfffdZ27Twef+tOZ5/S60R1Q/U/cPfY32rEY7PysWOtmG9sKrtvT8AanIoRVSohcC6Op0Nwt33odeE8R/roUO1YplxjR0Pj0PSw/49PwQHTqk10ZB+7j11lsDhYueL8SBGJB4mnP33nuvWWyuWbPGbAgEujp6joBOoC3deuFRHXOu5wVp6/Ivf/nLQGGkLc3jx49P9GKiBdqj5p8FSicsaMsMXACQCjTf/Bff1dyjMIJdMCED0Al0hiGdmjfc9Lw6BEWHrjQdLoPkpEMZ9QYAXZkWQy1dtgDoijgaAzqBnqehMz/peHA9R0HPT9LZl37xi1+YvUg6vA4AAACJxTlHAAAAAEDPEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFUXI5//zzxeFwNLtNnz498Bq9/9prr0myuPPOO+Wggw6S7OxsKSwsTPTiAOgAqZZNa9eulQsvvFAGDx4sWVlZUlpaKrNmzZL6+vpELxoAG2eTOuGEE2TAgAGSmZkpvXv3lnPPPVc2btyY6MVCEHfwHSSe7tBPPfVUyGMZGRmSrPRg47TTTpMDDzxQ/vKXvyR6cQB0kFTKpuXLl4vP55MnnnhChg4dKkuWLJGLL75Yqqqq5L777kv04gGwaTapadOmyU033WQWRhs2bJBrr71WTj31VJk3b16iFw170XOUZHSH7tWrV8itqKjIfG7QoEHm/0866SSzJcR//7vvvpOZM2dKSUmJ5ObmyqRJk2T27Nkh76uvveOOO+TMM8+UnJwc6du3r/zhD38Iec3u3bvloosukuLiYsnPz5fDDjtMFi9eHHV5b7vtNrnqqqtk7Nix7bwmACSTVMom/8HSUUcdJUOGDDFbavUA5JVXXumANQMgkVIpm5QeMx1wwAEycOBAc+TNDTfcIJ9++ql4PJ52XjNoK4qjFPL555+b/9c/+ps2bQrcr6yslBkzZsh7770nixYtMg8Mjj/+eCkrKwv59/fee6+MHz/efI3ujFdccYW8++67gee1B2jr1q3y9ttvy4IFC2TfffeVww8/XHbu3NnJvymAVJIK2VReXi7dunVrt98ZQPJL9mzS1z333HNmkZSWltauvzviYCBpnHfeeYbL5TJycnJCbnfeeWfgNfqVvfrqqy2+1+jRo41HHnkkcH/gwIHG9OnTQ15zxhlnGMccc4z584cffmjk5+cbtbW1Ia8pLS01nnjiiRY/76mnnjIKCgpa9XsCSC2pnE1q5cqV5ns8+eSTrXo9gNSQqtl03XXXGdnZ2eayHXDAAcb27dtb/Tuj43HOURKORX388cdDHmuptVNbQG699Vb597//bbaMNDQ0SE1NTbMWED0vqOn9hx56yPxZu4H1fbp37x7yGn0f7X4GYG+pmk06pl9bhbWFV887AtC1pGI2/epXvzInjVm3bp15esKPf/xjefPNN82hf0g8iqMko+Na9QTiWOhYeu3m1RON9d/q7Ex6cl8sMzPpDq4nB86dO7fZc8xCByAVs0lngNIDJx2y8uSTT8a07ABSQypmU48ePczbsGHDZOTIkdK/f3/zvKOmxRgSg+IoxeiYVK/XG/LYxx9/bE5nqScc+ndYncq2Kd3xmt7XnVLpONnNmzeL2+0OnLAIAKmaTdpjpIXRfvvtZ55v4HRyii1gR8mWTU3pzJqqrq6uze+B9kVxlGR059CdLZjueNrCoHQH1BMIp06das7QojOy7LPPPuYsTHoyoXbJ/vrXvw7sbE3D4J577pETTzzRbDF58cUXzS5ldcQRR5gtFvqcvkZbM7TVVZ/X8Nh///3DLq92QesJhfp/DZ8vv/zSfFxbYnQGGABdQyplkxZGhx56qDkblLYMb9u2LfCczmQFoOtIpWz67LPPzEkhfvCDH5jLocPv9LP1Wmz0GiWRTjivCTGcWKhfSdPb8OHDA6954403jKFDhxput9s8WVCtWbPGmDZtmpGVlWX079/fePTRR41DDjnEuOKKKwL/Tl972223Gaeddpp5EmCvXr2Mhx9+OOTz9+zZY1x22WVGnz59jLS0NPO9zj77bKOsrCzmZZ4zZ06HrCMAnS/VskkniAm3vPzJA7qWVMumr776yvzcbt26GRkZGcagQYOMn//858b69es7bB0hdg79T6ILNHQ8bTm58sorzRsAJAuyCUAyIpvsi0HYAAAAAEBxBAAAAAAWhtUBAAAAAD1HAAAAAGChOEpxOi+/TkPpn0I7kfRq0yUlJebyvPbaa4leHAAJlixZoBeA1Yss6rWO/Fe3B2BfZBOioThKMnq9oGOPPVays7OlZ8+e8qtf/UoaGho6dRnuvvtumTRpkuTl5ZnLoHP4r1ixIuq/WbZsmdx2223yxBNPyKZNm+SYY46J6TP1WkmXXXaZDB8+3LxS9YABA+Tyyy+X8vLyOH8bAO1B90e9oKpeJ2TChAkJWQa9LoleO0SvPp+Tk2MuxzPPPBP13+zZs0cuvfRSuf76683rH/30pz+Naxl+/vOfmwdWHMgAyYFsspBN7YeLwCYRvYiqFkZ6kcJ58+aZRcaPf/xj8+rOd911V6ctxwcffCC//OUvzQJJC7ObbrpJjjrqKFm6dKm504ejFzJTM2fONHfOWOmF0/SmF2wcNWqUrFu3ztzR9bGXXnop7t8JQPx+8pOfmBcx/OqrrxLy+d26dZObb75ZRowYIenp6fLmm2/KBRdcYDbiHH300REbnDwej5mtvXv3juvzX331Vfn000+lT58+cb0PgPZFNpFN7aoN10ZC0MW/zjrrrMDFwR544IFmFxGLxVtvvWU4nU5j8+bNgccef/xxIz8/36irqwv7b/RCZvo1vvzyy8ahhx5qXtBs3Lhxxrx584z2snXrVvMzPvjgg7DPz5o1q0MutPjPf/7TSE9PNzweT7u8H2AX7Z1NTff38ePHt+q1mgV/+tOfjBNPPNHMJr0Q4+uvv260p4kTJxq33HJLqy8Gq5nZFnqRxr59+xpLliwxLw754IMPxrnkgP2QTRayKbkxrC4OV199tXz88cfyxhtvyLvvvisffvihLFy4MOQ12vuRm5sb9eb3ySefyNixY83zdvy0xUG7Xr/55puoy6ItFtdee6157tGwYcPkzDPPDAzH09aJlpYhWs+Uf2ibtoyEo5/71FNPmT9rb5fe1HPPPdfi5+o6i/a5+fn54nbTwQkkMpviocNtTz/9dLNFd8aMGXL22Webw2j9WloGXc5w9PjmvffeM4f8HnzwwWFfc8YZZ8js2bPNn+fPn29mk47v1/XR0udqfvn5fD4599xzzWHOo0ePbpf1AtgR2WQhm5IbR51tVFFRIU8//bQ8//zzcvjhh5uPaYHQtEvz9ttvN4uH1ti8eXNIYaT89/W5aPQztGvWv8PrTrJq1Sqzi1eXqaUJGyIVPrrj6dWhp06dKmPGjAn7Gt1ZdZyt0iGBfieccIJMmTIl6uf27ds37OPbt2+XO+64I+4xuIDddEQ2xeP88883G2uUNsL8/ve/Nw8Gpk+fbj7WUjZpA0nTRhPNjbq6OnG5XPLYY4/JkUceGfbf6vmL3bt3N38uLi4O5JOeG9DS5wZn8e9+9zuzkUbPbQDQNmRTI7IpuVEctdHq1avNsaKTJ08OPFZQUGBOKBBMx5vqraONGzcu8LN/7OrWrVvN4kh3nKFDh7bpffXcoyVLlshHH30U87/VCR30FivtKdNCT8890hnwAHSNbNJzFvWAQrPJL9Zs0kzRg4fKykqzdVZboocMGSKHHnpoq99DD0xa+7kLFiyQhx9+2Gzdbsv5lAAsZFPLyKbkwLC6DhZL97C2HGzZsiXk3/vvB/fIhKOTNvj5dxLt9YlnWJ3OoqInFc6ZM0f69esX8+/elmF12rKkrTYaMnqCYfDvBaD9dNbQlab7sOaTP5vaMnRFp7zVgwedDeqaa66RU0891ZxhMxaxDF3R1+oBk86gqQ1NetMJY/SzBw0aFNe6AdAc2UQ2JRo9R22krQG6Y33++efmhunvUv32229DxpjG0j184IEHyp133mlu7P5WEx2Tq60Z2ovSVrEOq9PxsjqtthYnc+fOlcGDB7fpc2MdVqc9RnqOlU7HqeORMzMz2/S5gJ11RDZ1pFiHrjSlBzM6jCUWsQxd0fH8RxxxRMhzmlP6uM5GBaB1yKaWkU3JgeKojbRn47zzzjNPgtPCQouZWbNmmS0Hwd2bsXQP63TZWgTphn3PPfeY5xndcsst5tA2LRjaKtZhdfp5Oib49ddfN39P//lO2v2tXb4dMaxOCyP9/aurq+XZZ5817+vNPx5Xx+8CSEw2KT2HUYeLaB7U1NQE/oBrZunUtW0VSzZpK6wePJSWlpoHHW+99ZZ5LZHHH388ps+MZeiKnhfgPzfATw/wtDe/6XAgAJGRTS0jm5IDxVEcHnjgAbNb9bjjjjNbEK677jr5/vvv29zjoQWADmP7xS9+YfYi6RhYDRJtRelM/p256ThZPXFST2DsCDpmVq9RoJoGw5o1a+giBhKYTeqiiy4yr4HmN3HixE7fP6uqquSSSy6R9evXmwcRek6lNqbozE8Akh/ZhFTg0Pm8E70QXYXuHDpM7P7775cLL7ww0YsDACayCUAyIpuQjOg5isOiRYtk+fLl5swrOm7W38Mzc+bMRC8aABsjmwAkI7IJqYDiKE733XefeaEvHde63377mbOH9OjRI9GLBcDmyCYAyYhsQrJjWB0AAAAAcJ0jAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAi1vaUa3HJzsrPeL1GWJnaS6HdMtNk3R3aO25u8ojFbVesbucDJcU5bjF4XAEHmvwGrKjol7qvfbedpwOkaKcNMnOcCV6UboUsslCNkVHNkVGNnUMsslCNkVHNnVuNrVLcfR1WYXc/+8yeX/JTnNHh7UhHz2+u1x73ACZu3S3PPfRJvlmfVWiFytplJZkyWkHlMgZB5bIvf9aJ28t2i67qxsSvVhJwe10yMEjC+Wy6QNk6vDCRC9OSiObmiOboiObIiOb2g/Z1BzZFB3Z1HnZ5DAMI66S88u1FXLqg4tlTw2VfTjZ6U6prif4IsnNdEklrUJhZbgd8rdfjpFpo7slelFSEtkUHdkUHdkUGdkUH7IpOrIpOrKp47Mp7uLoxPu+lHnflps/u9wuySnME4fD3qcy+Xw+qdq9R3ze0J07Kzdb0rMydLWLfRniqfNI9Z7KkEe1qzi3KF+cLnsP2dDdUddNQ73HvD+kZ5Z8csekkK50tA7Z1PpsGt03S/p3zxA7b2b6l3DrHo8sXBvaUk02Wcim9kM2NcdxUzQcN3V2NsU1rG7bnnr5ZKW1g6dlpMk+k8aaOzrE/JKWf7LY/NJUcf9e0qu0f6IXK2lsX79FNq0qC9zfZ9IYycjOTOgyJdMfie8WLJXaqhpZvbVGlm2oklH9chO9WCmFbGp9Nl10aE+5ZkbfRC9W0nj2421y5+vrA/fJpkZkU/zIpsg4boqO46bOy6a4miq+31FrtrapvO6F7OBB3Olp5s2voKR7Qpcn2RT0aBwTmpWfww4exOl0SkHPxi7hNdtqE7o8qYhsan02HTuhKKHLk2yOGlsQ+JlsCkU2xY9siozjpug4buq8bIqrOPIEzZChC4Ymgnr0WD+hHEHrg3XTXPA6aWgyzAAtI5tan02ZaayfYG6yKSqyKT5kUws4boqI46bOyybWLgAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAIuKWFNc7xyFT+rpkeHenjOjmlH75DnE6HIHnr55dK4u3+sSO3E6R8T2dMrbYJSN7OKU42yFFmQ7JcotUe0TW7fHJJxu88ubKBqluENs5crBLxhW7pLTIId2yHJKf7hDddHTdbKjwyZdbfPKvVQ2yrdpI9KIiBZFNaCuyCR2JbIqM46bo7JJNKV8cHTnELeeNTUv0YiSlIYVOueewzLDPFbhExmW6ZFxPl5w83C03za2T1btTe2OO1blj0qRvXvPO03SXSGGmS0YXu+TkEW65/aM6mb/Rnn8o0HZkE9qKbEJHIpsi47gpOrtkU5caVlfXYEhtg7021NbyeA1Zut0rn27wysaK0A22ONsptx2cIWldamtoHZ9h7G3tsNbNuvLQdZPldsj1B2SYrUlAW5FNiBXZhM5ANkXGcZN9synle46+2eaV+z/zyYodPllTbsi9h2XIhBJXohcraWyv9skLSxvkv2sapMrT+Pg5Y9xywbj0wP0+uU6Z1Nsl8zZ4xS6eXOQxg29nbejjB/d3yawfZgTuF2Y6ZHCBQ1bu4g8IWo9sQluRTehIZFN0HDdFZpdsSvniaMHm1O2262jr9/jkvH/VSm2Y/fbZJQ1ybKlbeuY0lvYD8h0yb4PYxkfrwwfa/773SkW9IXnpjWOw6+2TfWgnZBPaimxCRyKbIuO4KTq7ZFMKd3qhJXqyYLgd3G9nbWhFXxnUQmJnP+jnCtnBtfv4+4rUbP0A0HWQTUDH4ripbbpaNqV8zxHapkeWQ0oLnSFjSHX8qB2dPy5NBuY7JMPtkD65Dumf37hetlT55I6P6sSXuvs4gBRFNgHJg+Mm+2QTxZEN6QmENx6ULmmuxir//bVeWZ/CVX48Jui0nT2bj7deudMnd39SJ+vK7bleACQW2QQkB46b7JVNDKuzmZw0kbsPDT35Uk/OfGB+fUKXKxnt080pTx6TKccNpQ0BQPIgm4DOw3GT/bIptZceMXcJ3z0tw5zH32/RZq/8+n91UmfPnmHTlbPrzP9nu0V65Trk2KFuOXGYdQ0It9Mhl++fJku2eWVtireEAEgtZBOQWBw32TOb6DmyiUEFDnnkqNAdfPbaBrlhbp3U2PAqz5FOxNQLuj3yhUc+/r5xpbicDvlhf6Y5BZAYZBPQ+Thusm820XNkA+N7WhcrC55J5LklHvnrV0yzEsn2mtDWjm5ZjesOABKFbAI6HsdN9s4miqMubtpAl1x3QLqk7z2JsMFnyEPz6+Xt1TbuDxaRY4a4RC8KPm+9N+Qib2pUD6dMGxi6a2y06UmXADoX2QQkFsdN4dkpm1K+OJrSxynnjLHGOaqBBaEjBa+YlC5VnsYv6LL/WuMk7WCfIofcdFC6OB2N1fu2akMm93GZt6bmlnnlgzJ77PyDC51yyog08XgNKdtjmOtFV1OvHEezbUgvbPbeWvrQERuyCW1BNqGjkU2RcdwUmZ2yKeWLo8IMh4zqEXlcY9MvzE6y0xwhO7jqnes0b+GsMU+cs8dO7qfTcpYW6S388ztqDHO+/p21nb1kSHVkE+JBNqGjkE2RcdzUMjtkU8oXR0BbvP1dg9myoX8g+uQ5pCDDYc66Uu+1roC9drdP5m/yyew1DVGvlg0A7YlsApCM3rZRNqV8cfTOGq+8s6Y60YuRlBZv9cnhz7NuIrX2rCnXLt/U7fZFciOb0BZkEzoa2RQZx02R2Smb7Nt3CgAAAABBKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAQDsURy6nI/CzYRjxvFXXFLRKWD+hgtcH66a54HUSvJ+hdcimFgStEo+X9RPMZ/gCP7PtNEc2xYdsagHHTRFx3NR52RRXcdSnKCPwc+XOPWL4+LL8fF6fNHg8gfsVO3YndHmSTdXuisDPNRVV0lDfuK7sTnfwih3lYfcztA7Z1Pps+nDFnoQuT7L5bFVl4GeyKRTZFD+yKTKOm6LjuKnzsslhxFl+HnXnQvlynfWFudPdkpaRIWL3xiRDpL6mTrwNDSEPZ+RkitPpsvf6MUQMn09qq2pCHna6XJKelSEOu7dEGiIN9fXiqbNCr3dhuiz67QHitPt6aQOyqfXZtE9JpmRlOG2/emo9Plm5uVaCj1fJpr3IpnZDNoXBcVNkHDd1ejbFXRy99/UOOfvRJSF/TIDW0m2XbSeyh88bJmdO7Z3oxUhJZBPiQTZFRza1HdmEeJBNHZ9NcU/IsHRDFV8S2oxtJ7ol31clehFSFtmEeLDtREc2tR3ZhHiw7XR8NsXVc6T/dN8bPpMNu+rM+9379pS87oXicNi7i0+7P3dv3Sm7t+wIPNYj1y2XHd1bBnTPMKt+u9KtbXO5Rx6bvUnKdtQHHtftplvvYnG67D2Bou5TOq54W9km8352hlOW3X+QZKW7Er1oKYVsan02udPcUjK4nzk8w+48dfWyde1Gqa+1thtFNlnIpvZBNoVHNkVHNnVuNrnb/C9FZOXm6sAOnluUL332GRjP23UputHqyYTeBq95/9cn9ZejxhYmerGSxoDu6XLWYysDAThwzFDb/3Hwy+tWYAah/pGorvPJ59/tkYNHFiV6sVIK2dT6bOozbKAUFHdL9GIljfTMDFn95XLzZ7IpFNkUP7IpMrIpOrKp87IprnJzd3XjiXMZOVnxvFWX5HS7Qk54RqMBPTJCth128FCZQfvT7qrQE1TRMrKp9dkUvK1BJD2rMavJpubIpviQTdGRTZGRTZ2XTXEVR8ED8viKomMbDuVgi4kqOPSM4As/oFXIpliwhoKR1dGRTfEhm2LBGgpGNnVeNtl7oCIAAAAA7EVxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALC4pYvJdIk8OSNT+uaF1n1nvV4jW6qMhC0Xktuk3k45YpBbRhU7pSjTYT5WXmvIxkpDvt7mk9e/9Uh5XaKXEqmMbGrkdoqM7+mUscUuGdnDKcXZDnO/y3KLVHtE1u3xyScbvPLmygapbhBbI5vQ0cimUD2zHTJzmFsmlDilT65TstNEvD6R3XWGrNrlk7nrvDK3zCs++60a22RTlyuOfjoxrdkODkSSkyZyy9QMmdzH1ey5rFyH9MoV2beXSxZu9kr5Nl9ClhFdA9nUaEihU+45LDPscwUukXGZLhnX0yUnD3fLTXPrZPVu+x2FkE3oLGRTo8m9nTLrhxmS6bYO9oMbdErcDinJccrUfm6ZUeqVG+fWiceGu16ODbKpS+0N+/VyysxhaYleDKQIDbt7Dgvdweu9hny3yyefbvDKsu1eqai330EZ2h/ZFJnHa8jS7V5zn9tYEfqHtDjbKbcdnCFpXeovVcvIJnQWsqmRyyFy3YGhhdGeOkM+2+iV5Tu8Ia+d2Mslpwzvcv0LLXLbJJvcXamSvXZKuvlzZb0h+tXkpYdW/kCwc8akyYjujTu4tnLc/1m9bA4aRuB0iEzo6ZTNlam/syMxyKbwtlf75IWlDfLfNQ1S5Wl8/JwxbrlgnLW+lA5rmdTbJfM2hB6cdGVkEzoD2RRqSKE1vDe4MLrgzRrZvXdo2Plj0+TcsY2F5NieLnlhmb3G/Z5jk2zqMu1xl+6fLj1zrF/nkS/qpaoLVK7o2DHWJw1rbBvYWWPI7R/VhezgSscUL9zik+01bE9oG7KpufV7fHLev2rl1W9DCyP17JIG2VoV2oM0IN8+B2xkEzoL2RSq6RC5TZW+QGGkVuwMfUGlx17rK9NG2dQleo6m9nPJUYOtX+V/ZQ0ye61XLhhHNzEiG1filNygFjJtle6T55SpfV1SkusQj1dkzW6ffFDmTekdHIlFNoXX0iQLO2sN6ZnTeL+ySQHVlZFN6AxkU3Pf79HJBHxmb7UaWuSUaQNdMm+9VwoyHHJSk2F07621V6/ROBtlU8oXRwUZIldNsrqFd9UY8tDn9YleJKSA4d1CO02n9HHKcUObnyB+8QRD/rLYIy8ut1cIIn5kU9v0yHJIaWHj/ukzDPlyi32G1JFN6GhkU3heQ+TOj+vl9oMzpHuWQ1xOhznxQFN6Ts2Ti+pl/sbUnGygrYbbKJtSfljdlZPSpSjLqmQfmF+fstMGonMVBo0r9p/4HU6ayyE/3zddZpQ2n5UFiIZsip1OvHDjQenmfuf3/lqvrK9I7VbIWJBN6GhkU2TLd/jkkv/UmpPEhKOTD7zwjceczttuCm2UTSldHB0xyCUHD7A6v95Z3WCrE3YRH7eeMdjEnHUNcvqrNXLSy9Xy0vLQcTwXjk83TzIEWoNsatvJ4XcfmiETShr/oH6zzWsevNkJ2YSORDa1PNzwr8dlyqgersB1e+YHzVaX7nLIxRPT5bHpmVKSY68dz22jbHKmcgujnkyotlT55NEv7PUHFPGpbnIipddnyEPz62VHjSF76kSeWOSRXbVGSItJaWGK7uXoVGRT24bSPXRkpjk9rt+izV65fk6d1Nns2I1sQkchm6Lrm6fD6NIlJ83an1bv9sm5/6oxr2f0y3fq5J5PGrvY+uc75fK969Iuqm2UTSl7zlG6q3HKycIMhzx7QlbI87lNttk/Ts8UwxB5ZEG9zLFhdyhCbWgyTEdnpAk+6VtnW9GZaop0epa98jN0e7PP8B60DdkUm0EFDrPHyD9rlpq9tkHu/bReGuw1pN9ENqGjkE3R6eQL2jPk99/VobNpvrPGK5fub0j23uJp/95O87o/dsmpDTbKppQtjoJluB2S0cJvYn1BIukp21eG9rRkW2jQ56aJNN2F85tc7yG4RQRoDbIpuvE9rYu8Bl9b5bklHvnrVzaanq4JsgmdgWxqrnjveVh+4fYqo8kws7x03f/EFpbYKJtssskDodaWGyFXvNY/FEcPaWztmFjilH75jbuHzuizZndq7uRAsrbS/nZaY2HU4DPkvk/rbF0YKbIJSIyt1aH7kU51nh1UQB412BUYcqeqPIatJrNYa6NsStmeI+3qPPz56ojPP3dCpvTaO1e9Ouv1GtnS5EJVsLc/LPDIQ0c4zek61TVT0uWYUp/ZRT66R2i7wf997UnBjmEkAtnUsn2KHHLTQXqybuOBxrZqQyb3cZm3puaWec1rZ9gF2YSOQDZFpzlz7hgjMFtmaZFTnjkhS77d6ZP8DJER3UOzafaaBnMomZ38wSbZlLLFERCvpdt9cvcn9XLdAenmOGM9UBtTHBp+eo2Vv3/TIG+uSt35+oFko2P2gwsj1TvXad7CWVOuf2LtUxyRTUBizql5cH69XDW58XICOqlAuAabxVu88ucv7dfLvdQm2URxBFvTk0yXba+VU0e4Zb9eLinOcZhjTXX2la+3+eT1lQ2yYodNzrYEkDTIJqDz6aQLX2+rleOGumVCiVP65DnNoXXaM6Lnz6za5TN7mPQ6R6naKxKvOTbIpi5bHJ39hk3OkEPcNlcZ8ugCbQGyXysQOh/ZJLJ4qy/q8B5YyCZ0JrLJsrHSkCdt2CsUi81dPJuYkAEAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOOomR6AVIMgZrJCrWDoBkRDYB6OrZFFdxlJXW+M8bPA3tsTxdiuFr/Kp2VbF+glXVegM/N9Szbpry1nsCP2eluxK6LKmIbGp9NjV4Grc1iHgbyKZoyKb4kE3RkU2RkU2dl01xFUdDe2VLdrr1FuXbdkrlrj1iGLQr6TrYs32XNAR9UY++u1l2VLKjq4oarzz8zqbA/brqGtm5aVtIKNpZTUWV7Ny83fzZ4RAZNyA30YuUcsim1mfT1rUbQ+7bmbehQbas3RC4TzaFIpviRzaFRzZFRzZ1bjY5jDj3yp//eZm8Mn9rXAthNw6xL3bj2Bw0rEBeu3ZCohcjJZFNQMchm9qObAKSO5viPufoqhkDJMNt58P96NJcjrAFgl1vTbHtROZyilx3wqBEL0bKIptizyY0YtuJjGyKD9kUHdkUHdtOx2dT3D1H5z22RN7+ckfgflpmujgc9p7nwfD5xFNX3+xxh9MpaRlptu870rGyPm/j2Fk/d3qaOF02H8NuGFJfWxe4u++gPPnPTfsmdJFSFdnUHNkUDdkUFdnUbsim1meTnqNVnJ8mThtHkx6k62kZlbW+Zs+RTdIh2eSO5x9X1jbI+0t2mj87XU4pnThSMnOz41qgrqK6vFK+W7QscD+/R5H0HznEXE92pyG4cVWZ7Ny4LfDYwDH7SF73AnHoYFGbq6+pk9VfLhNPnUcWrq2Qsu21MqBHZqIXK6WQTZGRTZGRTdGRTfEjm1qfTUeOKZB7zhwkmUGTWNiVx2vIXW+slxc+sc6rUWRTx2VTXFvcqs01UtdgdTwVFHdjBw+SXZC7tyXWUjygFwcfQa3Uxf17B+7rdpPfo5AdfK/0rAwp7NUjcH/p+sqELk8qIpsiI5siI5uiI5viRza1PpsuOrSEwihoqOFFh/QM3CebOjab4trq6hoau/hcbpt364UTtNG63HF10nU5wQdjbDvNBW8vwfsZWodsagHZFBHZFB3ZFB+yqfXZlJfF+gmWuXeWQ8W207HZREkOJCHaggAkI7IJnYVtLZSDNRJVe64diiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAxS0p7Mdj0+S8sWmtfv2XW7xyzXt1Yic9sx0yc5hbJpQ4pU+uU7LTRLw+kd11hqza5ZO567wyt8wrPkNs57oD0uXoIS3vAvM3euXGufbabhAfsqllZFNkZBM6CtmEeFxnk2xK6eII0U3u7ZRZP8yQTLcj5HG3U6TE7ZCSHKdM7eeWGaXWRuzxJWxRAdgI2QQASFYpXRytK/fJ/8oaIj4/tqdLijIb//iu2GGfv7Auh8h1B4YefOypM2TZDp8UZIiM6O4KPD6xl0tOGe6WF5ZFXpdd3e5aQ77a6g373Mpd9tlu0D7IpsjIptiQTWhPZBPay+4unE0pXRx9UOY1b+HoH9nnZ2YF7nu8hryywj5/YIcUOkICTg8+LnizRnbv7eU8f2yanBvUta6BaOcDkLXlPrnto/pELwa6CLIpMrIpNmQT2hPZhPaytgtnU5edkOGEfdwhLZNzyryyvcY+g9ebDkPZVOkLHHyoFTtDX1Dpsc+6ARKJbAq9TzYBycHu2QR0iZ6jSNKcIjP3CT3h8MVlHrGT7/cYsrHSZ57orIYWOWXaQJfMW++VggyHnDQ89Kt/b629W4eKsx1yyb5pZot2ndc6YFuw2SfLGVKAdkQ2kU2xIpvQGcgmxKq4C2dTlyyOjhzskqKsxtaPzzd5ZfVue7V+eA2ROz+ul9sPzpDuWQ5xOR1yy9SMZq+rqDfkyUX1Mn9j6m/M8eib55RTRoR2pP5kvMiizV757Sf1tJ6hXZBNZFOsyCZ0BrIJserbhbOpSw6rO3UErR9Kq/dL/lMrS7eHH19c7zXkhW885pS5CE9PCL/3sAzJaDxHHGgzsslCNsWPbEJ7IpvQXiZ2gWzqcj1HB/RxysCCxppPr5eh3Xx2NLWfS64/MF1y0qzWoPJawxzPn793Rqh0l0Munpgu00vdcv2cOtlSlbpVflvo7/v8Nx6zlWN9hSG7ag2zm/iYUrf8aJRbnA5rvQ0ocJrXY/mnjU8KR/zIpkZkU3RkEzoT2YTW2mKTbOpyxdFpI2n9UH3zdKhKunmQoVbv9smV79ZK1d7VcfRglzmdruqf75TL90+Xmz9I3Qt2tcXTXzffNjZWGvKXxR7JdIucPLxxW5rSx5WyOzmSA9lkIZtaRjahM5FNaK2nbZJNXWpY3T5FDplQ0tiPt6XKJ+/bdFiGnuDsP/hQ/13dEDj4UO+s8Up10CxQ+/d2mhdghGVhk1YzPTcCaCuyqRHZFB+yCe2JbEJ7WdiFssnZlVs/Xl3RID57jcYIKG6yUYZbDcGPuZ0OyUsX2wg6Ngurd27oC6qYThhxIJsakU3RkU3oTGQTWstlo2zqMsWRjnk8ZEBj60dlvSH/XpWa3XntYWt16EZ51GC3ZAcNojxqsCsw3t+/EZfbaOTKmGKnPHREhnnuQ9Mdflg3p5wzOvQPxpJtjL9G25BNocim6MgmdBayCbEYY6Ns6jLnHJ083G22MPrpDl5t4318bplXzh1jSNreLbi0yCnPnJAl3wad9Bxs9hr7tRaN7ekybzUewzwBVacOLs52SmmRI3BSof/g7MUUHTeLxCObQpFNLSOb0BnIJsRqrE2yqUsUR9rqOKO08VfxeA15ZUXqfintYUOFIQ/Or5erJqcHDkIKMx0yuU/zuRUXb/HKn7+01wmYwcdaWWkOc2cPZ0eNIbd/VJfS8/Ujccim5sim6MgmdAayCbEybJRNXaI4mjHULbnpjRXrnDJvSn8p7UVPbP56W60cN9QtE0qc0ifPaQZig0/M6Re16tdWXL2WiN3W1ldbrRmydDaVkT2c0i/PIfkZDtGtqLJeZG25Tz7d6JW3vws9WRyIBdkUHtkUGdmEzkA2IVZf2SibukRx9NLyBvMGCTvF4pM2a3ltra+3+cwb0FHIpsjIpsjIJnQ0sglt8bVNsqnLTMgAAAAAAPGgOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAA7VAcORyNPxvxvJENGAZrKFjI6mDVRN1enME7GlqFbGo9sikU2RQd2RQfsqn1fKygyFnNuunQbIqrOOqRmxb4uWZPVVwL0hW/JG+DN3C/poL1E6y2qjrkZ5/Pl9DlSTbB20u3oP0MrUM2RUY2RUc2RUc2xYdsan02LVnfuC9CZOXmmsDPZFPHZpM7nn88uGeWeVuztUaq91RK2TffSV73AnE47T1az/D5pHzrTvEF7eQbV5aJp65e0jMzQpuObMcQT51Htn+/OfCIhuGaL1dIUe8e4nS5xNYMQyp3V0j5tl3m3fwsl0wqzU/0UqUcsik8sikasikqsqldkE2tz6bfvLZeNu2ul37dMsRp42jSDpEt5fXy1/9tDTxGNnVsNjmMOMdU/N8HG+W651bGtRAAwrv62AFyw8zBiV6MlEQ2AR2HbGo7sglI7myKu6ni/EP6yK2nDpHsdHu3eoSTl+mSu380VKYOK0j0oiSlsf1z5eHzhkl3hmY0k+52yKVH95frTxiU6EVJWWRTZGRTdGRTZGRT/MimyMim6MimzsmmuHuO/KrqvPLB0l2ycVedNHjtfaZYmsshA4sz5YcjiiQjzQq/tdtqZN6K3bKnprHL2K5yMl0yuTRfhvfJMe/r9jLv292ycnO1eBrsve3oyIqSgnSZNqqb5GfHNeoVe5FNjcim6MimyMim9kc2NSKboiObOjeb2q04AgAAAIBURp8uAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOEou559/vjgcjma36dOnB16j91977TVJNnV1dTJhwgRz+b788stELw4Am2fToEGDmi3vb3/720QvFgCbZ5P697//LVOmTJGsrCwpKiqSE088MdGLhCDu4DtIPN2hn3rqqZDHMjIyJNldd9110qdPH1m8eHGiFwVAB0jFbLr99tvl4osvDtzPy8tL6PIAaH+plk0vv/yymUt33XWXHHbYYdLQ0CBLlixJ9GIhCD1HSUZ36F69eoXctFXB3xKqTjrpJLMlxH//u+++k5kzZ0pJSYnk5ubKpEmTZPbs2SHvq6+944475Mwzz5ScnBzp27ev/OEPfwh5ze7du+Wiiy6S4uJiyc/PN3fa1hQ7b7/9tvz3v/+V++67rx3XBIBkkorZpMVQ8PLq+wPoWlIpm7QQuuKKK+Tee++Vn//85zJs2DAZNWqUnH766R2wZtBWFEcp5PPPPzf/ry0kmzZtCtyvrKyUGTNmyHvvvSeLFi0yW1GOP/54KSsrC/n3ujOOHz/efM0NN9xg7qDvvvtu4PnTTjtNtm7dahY7CxYskH333VcOP/xw2blzZ8Rl2rJli9kC8swzz0h2dnaH/e4AklcyZpPSYXTdu3eXiRMnmp+hByYA7CPZsmnhwoWyYcMGcTqdZi717t1bjjnmGHqOko2BpHHeeecZLpfLyMnJCbndeeedgdfoV/bqq6+2+F6jR482HnnkkcD9gQMHGtOnTw95zRlnnGEcc8wx5s8ffvihkZ+fb9TW1oa8prS01HjiiSfCfobP5zPf84477jDvr1mzxly+RYsWxfibA0hmqZZN6v777zfmzJljLF682Hj88ceNwsJC46qrrorp9waQ3FItm/7+97+byzNgwADjpZdeMr744gvjzDPPNLp3727s2LEj5t8fHYNzjpLMtGnT5PHHHw95rFu3blH/jbaA3HrrreYJftoyoq2jNTU1zVpADjzwwGb3H3roIfNn7QbW99FW1mD6Ptr9HM4jjzwiFRUVcuONN8b0OwJIPamUTerqq68O/Dxu3DhJT0+Xn/3sZ3L33Xcn9fkIALpuNvl8PvP/N998s5xyyimBXq1+/frJiy++aGYUEo/iKMnouNahQ4fG9G+uvfZas5tXz/nRf6uzn5x66qlSX1/f6vfQHVy7d+fOndvsucLCwrD/5v3335dPPvmk2YHG/vvvL2effbY8/fTTMf0eAJJXKmVTODozlB4ArV27VoYPH97qfwcguaVSNunrlZ5n5KfHUEOGDGlWmCFxKI5STFpamni93pDHPv74Y3M6Sz3h0L/D6gFAU59++mmz+yNHjjR/1nGymzdvFrfbHThhsSW///3v5Te/+U3g/saNG+Xoo4+Wf/zjH+aBCAD7SKZsCkcvMaDj/Hv27Nnm9wCQepIpm/bbbz+zGFqxYoX84Ac/MB/zeDzmZw8cOLDNvyPaF8VREl4vSHe2YLrj9ejRw/xZd0A9gXDq1KnmDqYzsuyzzz7yyiuvmCcT6mwsv/71rwNdt03D4J577jHn09cWE+3C1S5ldcQRR5jdxfqcvkZnUNFiR5/X8NDeoKYGDBgQcl9nfFGlpaVmFzGAriOVskl7tD/77DNzuI3OWKf3r7rqKjnnnHMCs1gB6BpSKZt0RjudpW7WrFnSv39/syDSSR/8kzsgSXTQuUxo44mF+pU0vQ0fPjzwmjfeeMMYOnSo4Xa7zZMF/RMhTJs2zcjKyjL69+9vPProo8YhhxxiXHHFFYF/p6+97bbbjNNOO83Izs42evXqZTz88MMhn79nzx7jsssuM/r06WOkpaWZ73X22WcbZWVlrVp+JmQAuqZUy6YFCxYYU6ZMMQoKCozMzExj5MiRxl133dXsxGkAqS3VsknV19cb11xzjdGzZ08jLy/POOKII4wlS5Z0yPpB2zj0P4ku0NDxtOXkyiuvNG8AkCzIJgDJiGyyL65zBAAAAAAURwAAAABgYVgdAAAAANBzBAAAAAAWiiMAAAAAoDjqGnSO/tdeey3RiyFPPvmkOW+/XmjxoYceSvTiAEgwsglAstELrmo26YWhE+3WW2+VkpKSpMlKWCiOkszll18euILyhAkTErIMemE0vXhZYWGh5OTkmMvxzDPPRP03e/bskUsvvVSuv/562bBhg/z0pz+Naxn0ImkaFhzIAMmBbLKQTUDyWLx4sZx55plm40dWVpaMHDlSHn744U5fjrvvvlsmTZpkXnS6Z8+e5oVhV6xYEfXfLFu2TG677TZ54oknZNOmTXLMMce0+fN1+gD99xRZ7cPdTu+DdvSTn/zEvLr7V199lZDP79atm9x8880yYsQISU9PlzfffFMuuOACc4c/+uijw/6bsrIy8Xg8cuyxx0rv3r3j+vxXX31VPv30U+nTp09c7wOgfZFNZBOQTBYsWGDu/88++6xZIM2bN89sAHG5XGajSGf54IMP5Je//KVZIDU0NMhNN90kRx11lCxdutRsyAnnu+++M/8/c+ZMs6iJhzbWxPseCNLGi8di75WRzzrrrMCVkx944IFmV1huq1mzZhnjx49v1Wv1a/zTn/5knHjiiebVnvVK0K+//rrRniZOnGjccsstYZ976qmnml2dWq8+3Rbr1683+vbta14tWq9O/eCDD8a55ID9kE0WsgmwTzb5XXLJJca0adMiPq8ZoFnw8ssvG4ceeqiZTePGjTPmzZvXbsuwdetW8zM++OCDiDnaNJvaatGiRWY2bdq0yXyfV199NY4lh2JYXRyuvvpq+fjjj+WNN96Qd999Vz788ENZuHBhsyEYubm5UW/tQbtmTz/9dLNFd8aMGXL22WfLzp07A8+3tAy6nOHo8c17771ndg8ffPDBYV9zxhlnyOzZs82f58+fb3YPawuOro+WPve5554LvI/P55Nzzz1XfvWrX8no0aPbZb0AdkQ2WcgmwH7ZVF5ebvYyt0R7oa+99lrz3KNhw4aZw/O018ff49zSMtx1111Rl0FFWg793Keeesr8WXNJb0pzp6XP1XXmV11dLWeddZb84Q9/kF69erX4O6N1GFbXRhUVFfL000/L888/L4cffrj5mG7oTYdb3H777eZO0NHOP/98c8dWusP+/ve/Nw8Gpk+fbj7W0omH+fn5zXbsvn37Sl1dndk9/dhjj8mRRx4Z9t/qON/u3bubPxcXFwd2UD03oKXP1RMR/X73u9+J2+02z20A0DZkUyOyCbBXNumwun/84x/y73//u8XX6mfocFt/I442fKxatcoctqvL1FJGRCp8tDHlyiuvlKlTp8qYMWPCvkaLHD13UgUXNSeccIJMmTIl6udq/vldddVVctBBB5lD89B+KI7aaPXq1eY49smTJwceKygokOHDh4e8TsfC6q2jjRs3LvCzjm/VA4qtW7cGHhs6dGhM76cnFWowVFZWmq2z2tozZMgQOfTQQ1v9Hnpg0trP1XHDehKltiAxbhZoO7KpZWQT0PWyacmSJWaRMGvWLPN8n1iyyX8+omaTFkfaGBJrNvnpuUe6LB999FHM/1bzTW+tob1v77//vixatKgNS4loGFbXwTpr6EpaWlrIff0jrq0XbR26olPeajDobFDXXHONnHrqqeZsLLGIZeiKvlZDacCAAWYo6W3dunXmZw8aNCiudQOgObKJbAK6SjbpxAfaG6WTMdxyyy0xZ5O/4cOfTW0dVqeTQOhEMXPmzJF+/frF/LvHMqxOCyOd1EF7oPzZpE455ZSYGovQHD1HbaQtlbpjff755+YfTf9wj2+//TZk/HtnDV1pSaxDV5rSwNBhLLGIZeiKjuc/4ogjQp7T2af0cZ2NCkDrkE0tI5uArpNN33zzjRx22GFy3nnnyZ133tkuyxrrsDo9B/Kyyy4zZ7ScO3euDB48uE2fG8uwuhtuuEEuuuiikOfGjh0rDz74oBx//PFt+nxYKI7aSLs9dUfUE3R1B9EuYO3K1VbN4KEXsXYP63hXHS6yefNmqampCeyco0aNMqeubatYuoe1FVYPHkpLS82Djrfeesu8lsjjjz8e02fGMnRFzwvwnxvgpyGqY3GbdrkDiIxsahnZBHSNbNLha1oYaYOFDrHVfFJ6PqKeZ9hWsQ6r06F0ei7V66+/bv6e/uXQYYOaNx0xrE4zKNwkDFp4trU4g4XiKA4PPPCA2f173HHHma2b1113nXz//feSmZnZ5vfUVgCdL99v4sSJ5v/XrFnTaUM4qqqq5JJLLpH169ebO7WOv9VrCOjMTwCSH9kEwA7Z9NJLL8m2bdvMHNCb38CBA2Xt2rXSWfwNNE2Hs+mEEzopDVKLQ+fzTvRCdBX6h1u7O++//3658MILE704AGAimwAkI7IJyYieozjoDCHLly83Z17RcbM6TlYxpSKARCKbACQjsgmpgOIoTvfdd595EUIdc7/ffvuZs4j06NEj0YsFwObIJgDJiGxCsmNYHQAAAABwnSMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAACLW9qJz2fI4rIKWb+jTnyGIXbmdjllYI9MGd0vRxwOh/lYRU2DfP7dHqmobRC7y8lwycRB+dI9Ly3w2MpN1bJyc7V4vD6xM6fDIT0L0mW/wfnidlnbDuJDNjUim6IjmyIjm9of2dSIbIqObOrcbGqX4uiV+Vvl9pdXy8Zdde3xdl2G7ui3nTZE3ly4Xd5YsE3qG+wdfsFcTpEjxnSXC6f1kVkvrpZlG6sSvUhJpUdemlx97EC56LC+iV6UlEY2hUc2RUY2RUc2tQ+yKTyyKTKyqfOyyWEY8TVXvPHFNrn4T0vF5o0eEWkDCOsmMqdDxMf6ieiuHw3lIKSNyKboyKboyKboyKa2I5uiI5uiI5s6PpviLo4Oue0LWbbBql6zC3Ilr1uhOPWbszGfzyfl23ZJbWV14DHtJi7q3UPSszLFzmtHNzZPXb3s2rRNfEFdwRlZmVJQ0k1cLpfYme6OVbsrpGJneaAl5Kt7DmQYSxuQTc2RTZGRTdGRTe2HbGqObIqMbOr8bIprWF3Z9trADp6ZkyVDJowIjBW1u+L+vWXpxwsDG3LvoQOke9+eiV6spJFTkCtl33xn/ux0OaV0v1Hictt7B/crHtBb1nz1rVTuLJftFR5ZsGaPTBlakOjFSilkU2RkU3RkU2RkU/zIpsjIpujIps7Lprhmq9tS3jhWNqcwjx08iMPpEFeaO2T9oFF2QeP6yMzNZgdvIjdoe9laXp/QZUlFZFNkZFN0ZFN0ZFN8yKbIyKboyKbOy6a4iqPgMY/s4NGxfkIFrw3WTXPB68Tusxi1BdnUeqyfUGRTdGRTfMim1mP9hCKbOi+buM4RAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAi4pYU1zvHIVP6umR4d6eM6OaUfvkOcTocgeevnl0ri7f6xI7cTpHxPZ0yttglI3s4pTjbIUWZDslyi1R7RNbt8cknG7zy5soGqW4Q2zlysEvGFbuktMgh3bIckp/uEN10dN1sqPDJl1t88q9VDbKt2kj0oiIFkU2RkU3RkU3oSGRTZGRTdHbJppQvjo4c4pbzxqYlejGS0pBCp9xzWGbY5wpcIuMyXTKup0tOHu6Wm+bWyerdqb0xx+rcMWnSN69552m6S6Qw0yWji11y8gi33P5RnczfaM8/FGg7sikysik6sgkdiWyKjGyKzi7Z1KWG1dU1GFLbYK8NtbU8XkOWbvfKpxu8srEidIMtznbKbQdnSFqX2hpax2cYe1s7rHWzrjx03WS5HXL9ARlmaxLQVmRTZGRTeGQTOgPZFBnZZN9sSvmeo2+2eeX+z3yyYodP1pQbcu9hGTKhxJXoxUoa26t98sLSBvnvmgap8jQ+fs4Yt1wwLj1wv0+uUyb1dsm8DV6xiycXeczg21kb+vjB/V0y64cZgfuFmQ4ZXOCQlbv4A4LWI5uiI5siI5vQkcim6MimyOySTSlfHC3YnLrddh1t/R6fnPevWqkNs98+u6RBji11S8+cxtJ+QL5D5m0Q2/hoffhA+9/3XqmoNyQvvXEMdr19sg/thGyKjGyKjmxCRyKbIiOborNLNqVwpxdaoicLhtvB/XbWhlb0lUEtJHb2g36ukB1cu4+/r0jN1g8gGZFNbUM2AR2LbGqbrpZNKd9zhLbpkeWQ0kJnyBhSHT9qR+ePS5OB+Q7JcDukT65D+uc3rpctVT6546M68aXuPg6kFLKpEdkEJA+yyT7ZRHFkQ3oC4Y0HpUuaq7HKf3+tV9ancJUfjwk6bWfP5uOtV+70yd2f1Mm6cnuuF6CzkU2hyCYgOZBN9somhtXZTE6ayN2Hhp58qSdnPjC/PqHLlYz26eaUJ4/JlOOG0oYAdDSyqfXIJqDzkE32y6bUXnrE3CV897QMcx5/v0WbvfLr/9VJnT17hk1Xzq4z/5/tFumV65Bjh7rlxGHWNSDcTodcvn+aLNnmlbUp3hICJCuyKTyyCUgsssme2UTPkU0MKnDII0eF7uCz1zbIDXPrpMaGV3mOdCKmXtDtkS888vH3jSvF5XTID/szzSnQEcimlpFNQOcjm+ybTfQc2cD4ntbFyoJnEnluiUf++hXTrESyvSa0taNbVuO6A9A+yKbYkU1AxyOb7J1NFEdd3LSBLrnugHRJ33sSYYPPkIfm18vbq23cHywixwxxiV4UfN56b8hF3tSoHk6ZNjB019ho05MugY5CNoVHNgGJRTaFZ6dsSvniaEofp5wzxhrnqAYWhI4UvGJSulR5Gr+gy/5rjZO0g32KHHLTQenidDRW79uqDZncx2Xemppb5pUPyuyx8w8udMopI9LE4zWkbI9hrhddTb1yHM22Ib2w2Xtr6UNHbMimyMimyMgmdDSyKTKyKTI7ZVPKF0eFGQ4Z1SPyuMamX5idZKc5QnZw1TvXad7CWWOeOGePndxPp+UsLdJb+Od31BjmfP07azt7yZDqyKbIyKaWkU3oKGRTZGRTy+yQTSlfHAFt8fZ3DWbLhv6B6JPnkIIMhznrSr3XugL22t0+mb/JJ7PXNES9WjYAtCeyCUAyettG2ZTyxdE7a7zyzprqRC9GUlq81SeHP8+6idTas6Zcu3xTt9sXyY1sioxsioxsQkcjmyIjmyKzUzbZt+8UAAAAAIJQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAACAdiiO0t2OwM8+ry+et+qajMYffV5vIpck6fh8jSuHbac5b9D2kuaiDSNWZFMLyKaIyKboyKb4kE0tIJsiIps6L5vi+teDirPE//nl23eJp84T18J0JfU1teKpb1wfOzZuE8MI2uttTNfDrs3bAvdrKqqkek9VQpcpmXgbGqR8y87A/X16ZSd0eVIR2RQZ2RQZ2RQd2RQ/sikysikysqlzs8lhxLnlnfHwVzLnm12B+06XS6SxYcSejPAtHg6nQxxOWtoMnyGGr3mrB9uOxdfQuO2M7JMjH9y6f0KXJ1WRTWGQTVGRTdGRTe2DbAqDbIqKbOrcbHLH9a9F5P+dPEQ+Xr5Q6r1WjUU3aChtIfL3flobN+snWLrLwbYTgdMhcuvpQxK9GCmLbIqObIqObIqMbIoP2RQd2RQd2dTx2RR3Of7UBxsDXxKaY1hodGw7kenw4r++vzHRi5GyyKboyKbo2HYiI5viQzZFRzZFx7bT8dkUV89RfYNPXv9iW6DSv/v0gXLIyHzbn6RZ6/HJf77aJbe/uj7wWFZutvQdMVjSMzPEYfMuUB1jvXHlOqnctSfwWM9BfaRbn57isvm2o4Ncq3ZXyPfLvjNPuJy9ZIfsqPBI97y0RC9aSgnOJtVv5BDJ71ZgDtGw+wm95Vt3mvufH9kUPZsuPbKXnHFAD8nJcImdeX2GfL66Uq59fq1U15NNbUU2hUc2RcdxU+ceN8VVHH27qVrKqxvMn48cUyjH79stnrfrMrLSnXLmgcXyx/c2y9Y91vrpVdrf3NEhkpHtkt5D+8vKz78x76dnZUjJoL6JXqykkd+jUIp6F8uO9VvMFrRFa/fIEWO7J3qxUkpwNhUUF0lRCetPOV0i3fv2lK3rNkrD3hOfyabI2TSwR4b88sjeiV6spDFtVIGcNqW7PP3hNrKpjcim8Mim6Dhu6tzjprjKzaq6xrGOvQpoPWoq3d24etMy0hO6LMnGnda4vbBumgteJ8H7GVoneJ2xfTUX3ErN+omcTfxda65XAdkUD7IpOrIpMo6bOu+4qd364hx27/ME2hF7E5B4/FkDgNTQnnFt74GKAAAAALAXxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAABExJ3oBUDnynSJPDkjU/rmhdbFZ71eI1uqDLGrSb2dcsQgt4wqdkpRpsN8rLzWkI2Vhny9zSevf+uR8rpELyVSGfteeOx7QGKRTaF6Zjtk5jC3TChxSp9cp2SniXh9IrvrDFm1yydz13llbplXfPZbNbbJboojm/npxLRmAWhnOWkit0zNkMl9XM2ey8p1SK9ckX17uWThZq+Ub/MlZBnRNbDvhWLfA5ID2dRocm+nzPphhmS6rYN9P7dTpMTtkJIcp0zt55YZpV65cW6deGwYTTk2yG6KIxvZr5dTZg5LS/RiJA0Nu3sOy5AR3Rt38HqvId/vMWRbtSEFGSL98p2Slx4akkCs2PdCse8ByYFsauRyiFx3YGhhtKfOkGU7fGYmBefVxF4uOWW4W15Y1iB24rZJdlMc2ajSv3ZKuvlzZb0h2huc6htvvM4Zkxayg2srx/2f1cvmoGEETofIhJ5O2Vxp8/5ztBn7XnPse0DikU2hhhQ6AsPD/IXRBW/WyO69Q8POH5sm545tLCTH9nTZrjg6xybZTT+qTVy6f7r0zLG+7ke+qJeq+tTdaNtrjPVJwxrbBnbWGHL7R3UhO7jSMcULt/hke4291xfajn0vFPsekBzIplBNh8htqvQFCiO1YmfoCyo99lpfmTbKbnqObGBqP5ccNdj6qv9X1iCz13rlgnH27kYfV+KU3KAWsnkbvNInzylT+7qkJNchHq/Imt0++aDMm9I7OBKLfa859j0g8cim5nRo2MZKnzkJgxpa5JRpA10yb71XCjIcctLw0EPm99baq9donI2ym+Koi9Pxn1dNsrrNd9UY8tDn9YlepKQwvFtop+mUPk45bmhms9ddPMGQvyz2yIvL7RWCiB/7Xnjse0BikU3heQ2ROz+ul9sPzpDuWQ5xOR3mxANNVdQb8uSiepm/MTUnG2ir4TbKbobVdXFXTkqXoiyr0n9gfn3KTqvY3gqDxhWr4uzwu0KayyE/3zddZpQ2n5UFiIZ9Lzz2PSCxyKbIlu/wySX/qZWl271hn9fJB174xmNO5203hTbKboqjLuyIQS45eIDVOfjO6gazCxQWt54x2MScdQ1y+qs1ctLL1fLSck/IcxeOTzdPMgRag30vMvY9IHHIppaHG/71uEwZ1cMVuG7P/I1eWb7DWk/pLodcPDFdHpueKSU59gomt42ym+Koi0pzWidbqi1VPnn0C7rNg1U3OZHS6zPkofn1sqPGkD11Ik8s8siuWiOkxaS0MEX3cnQq9r3o2PeAxCCbouubp8Po0iUnzcqb1bt9cu6/aszrGf3ynTq555PGLrb++U65fO+6tItqG2U35xx1Uemuxik5CzMc8uwJWSHP5zbZp/84PVMMQ+SRBfUyxwbdxRsqQndynZGm0hM624rOVFOk07PslZ+h6zO1TzJEx2Pfi459D0gMsik6nXxBe4b8/ru6QaqCsumdNV65dH9DsvcWT/v3dprX/WmwyalHG2yU3RRHNpDhdkhGC9+0tQGLpNukL3HJttCgz00TaboL5ze53kNwiwjQGux7zbHvAYlHNjVXvPc8LL9wqWM0GWaWl675JLawxEbZbZNNHgi1ttwIjCH2/6E4ekjQ1a9LnOZVnv10Rp81u1NzJweSCfsegGS0tTo0Z3Sq8+ygAvKowa7AkDtV5TFsNZnFWhtlNz1HXZR2BR/+fHXE5587IVN67Z3LX531eo1saXIhr67uDws88tARTnO6TnXNlHQ5ptRndpGP7hHabvB/X3tSsGMYicC+1zL2PaDzkU3RzS3zyrljDHO2NVVa5JRnTsiSb3f6JD9DZET30NnXZq9pMIeS2ckfbJLd9BzBtpZu98ndn9SbU3Mqp8MhY4pdMqHEFQhHn2HIc0s88uaq1J2vH0g27HsAkvGcmgfn14tnby75JxWY3MfVrDBavMUrf/4ydHY2O1hqk+ym5wi2pieZLtteK6eOcMt+vVxSnOMwWwx09pWvt/nk9ZUNsmKHTc62BDoR+x6AZKOTLny9rVaOG+qWCSVO6ZPnNIfWac+Inj+zapfP7GHS6xylaq9IvObYILspjmzq7DdscgZhK2yuMuTRBdoCZL9WIHQ+9r1G7HtA8iCbLBsrDXnShr1CsdjcxbObYXUAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAADtWRz5DKO93qrrCFklrJ9gbC7RsXraD+uyJayhSNnk8yVySZKTQXi3G9ZkS1hDwdj1ojOSpTjKy3QFfv5+R317LE+XUuNp/MtaX1OX0GVJNp76+pB1wx/cUPU1tYGf87LcCV2WVBScTex7zfm8ZFNrsun7nWRTU2U7G9cP2RQ7sik6sikyjps677gprn89vE+O9MhLk+0VHnl/abk89u5GGdM/R1xOh9iZ12fI/O8qZUdlQ+CxjavKpMTTIK50XeU2Xz8NXtm2bmPgvqeuXtavWCsFPQrF4bT3SE8Nu7qqWtm1abt5P8PtkElD8hO9WCknOJsqduyWLWs2SHZ+jojD3vuebl9VuyrE6yGbWpNNm3Z75NcvlskRYwolzW3vdaPHYSs318jL83eY98mmtiGbwiObouO4qXOPmxxGnKXnHa+slkf+831cCwEgvFOn9JTHLhyZ6MVISWQT0HHIprYjm4Dkzqa4y83p47uL22Xvij4al70L+ha5bd7LGI02JB67b49EL0bKIpuiI5uiI5siI5viQzZFRzZFRzZ1fDbF3XN0wr1fyqcry82fXWluyS3Ms30Xn8/nk8qde8Tn9YY8npWfIxmZGbbvPtfu4KrdFSGP6TaT1y1fnK7G8dh2pLtjdXmFeOo85v1BxZny2W8mi8Pm20xbkE3NkU3RkU2RkU3th2xqjmyKPZsy0xwydVi+5GTYe9tp8BqycG2VbC5vv2yK65yjrXvq5bNV1g6elpEuwyaPsf0fEL8GT4Msn/dl4IS54gG9pdeQfolerKSxY8NW2bhynXXH4ZBhk0ZLelZmohcrKRg+Q1YtXCq1ldWydlutfLO+Ssb0z030YqUUsikysik6sikysil+ZFNkZFPrs8ntFHnj6pHSv3tGohcraQqkMx5dIUs31LRLNsVVbq7fURuYWjCveyE7eBB3mlvcGWmB+wU9uyV0eZJNfo/CwM/ZedkcfARxOB1SUFwUuL9ue+MMLGgdsikysik6sikysil+ZFNkZFPrs0knP6MwaqTDVI8aW9hu2RRXceTxNo7IczIGMiqnzbvMmwru7rT7cIKWtpeGoKlN0TpkU+uRTaHIpujIpviQTa1HNkXOJh1Sh1AZ2p3WTtnElgcAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAgIi4JYX9eGyanDc2rdWv/3KLV655r07spGe2Q2YOc8uEEqf0yXVKdpqI1yeyu86QVbt8MnedV+aWecVniO1cd0C6HD2k5V1g/kav3DjXXtsN4kM2tYxsioxsQkchm1rG/oeULo4Q3eTeTpn1wwzJdDtCHnc7RUrcDinJccrUfm6ZUWrt4B5fwhYVgI2QTQCAZJXSxdG6cp/8r6wh4vNje7qkKLPxj++KHfb5C+tyiFx3YOjBx546Q5bt8ElBhsiI7q7A4xN7ueSU4W55YVnkddnV7a415Kut3rDPrdxln+0G7YNsioxsig3ZhPZENsWG/c+eUro4+qDMa97C0T+yz8/MCtz3eA15ZYV9/sAOKXSEBJwefFzwZo3s3tsDfP7YNDk3qGtdA9HOByBry31y20f1iV4MdBFkU2RkU2zIJrQnsik27H/21GUnZDhhH3dIy+ScMq9sr7HP4PWmw1A2VfoCBx9qxc7QF1R67LNugEQim0Lvk01AcrB7NgFdoucokjSnyMx9Qk84fHGZR+zk+z2GbKz0mSc6q6FFTpk20CXz1nulIMMhJw0P/erfW2vv1qHibIdcsm+a2aJd57UO2BZs9slymw8pQPsim8imWJFN6AxkU3jsf/bUJYujIwe7pCirsfXj801eWb3bXq0fXkPkzo/r5faDM6R7lkNcTofcMjWj2esq6g15clG9zN9o7x29b55TThkR2pH6k/EiizZ75bef1NN6hnZBNpFNsSKb0BnIpvDY/+ypSw6rO3UErR9KWzYu+U+tLN0efnxxvdeQF77xmFPmIjw9IfzewzIko/EccaDNyCYL2RQ/sgntiWyKDftf19bleo4O6OOUgQWNNZ9eL0O7QO1oaj+XXH9guuSkWa1B5bWGOZ4/f++MUOkuh1w8MV2ml7rl+jl1sqXKXi0g+vs+/43HbAFaX2HIrlrD7EI/ptQtPxrlFqfDWm8DCpzm9Vj+aeOTwhE/sqkR2RQd2YTORDaFYv9DlyuOThtJ64fqm6dDVdLNgwy1erdPrny3Vqr2ro6jB7vM6XRV/3ynXL5/utz8gb0uZvb01823jY2VhvxlsUcy3SInD2/clqb0cRGAiAvZZCGbWkY2oTORTaHY/9ClhtXtU+SQCSWNfZxbqnzyvk2HZegJzv6DD/Xf1Q2Bgw/1zhqvVAfNArV/b6d5AUZYFjZpNdNzI4C2IpsakU3xIZvQnsim2LD/2YOzK7d+vLqiQXz2Go0RUNxkhw23GoIfczsdkpcuthF0bBZW79zQF1QxnTDiQDY1IpuiI5vQmcimUOx/6FLFkY4HPWRAY+tHZb0h/15l367OrdWhO+xRg92SHTSI8qjBrsB4f/8OXm6jkStjip3y0BEZ5rkPTcNwWDennDM69A/Gkm32HX+N+JBNocim6MgmdBayqTn2P3Spc45OHu42Wxj9dAevtvE+PrfMK+eOMSRt795dWuSUZ07Ikm+DTnoONnuN/VqLxvZ0mbcaj2GegKpTBxdnO6W0yBE44dJ/cPYiY4rRRmRTKLKpZWQTOgPZFB77H7pEcaStjjNKG38Vj9eQV1bYe4PdUGHIg/Pr5arJ6YGDkMJMh0zu03zeycVbvPLnL+11AmbwsVZWmsMMwnB21Bhy+0d1XMsAbUI2NUc2RUc2oTOQTeGx/6HLFEczhrolN72xmp9T5mWD3Xti89fbauW4oW6ZUOKUPnlOMxAbfGJOTaktItqKq9cSsdva+mqrNUOWzjQzsodT+uU5JD/DIboVVdaLrC33yacbvfL2d6EniwOxIJvCI5siI5vQGcim8Nj/0GWKo5eWN5g3SNjpJ5+0Wctra329zWfegI5CNkVGNkVGNqGjkU2Rsf+hy0zIAAAAAADxoDgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAAO1QHLmcjsDPhmHE81ZdU9AqYf2ECl4fho9105QvaJ0E72doHbKpBWRTRGRTdGRTfMimFpBNEQWvj/oG1k1THq+v3bIpruKob1FG4OeKneVi+BoXzO58Xq80eDyB+xU7did0eZJN5a49gZ9rKqrEU9e4ruxOA7BiZ+P20rdb436G1iGbIiOboiObIiOb4kc2RUY2tT6blqyvlm0VZFNwNn2wbE+7ZZPDiLM0n37XQlm4tsL8OT0rQ/K6FYjDYe/WJG1Z053aU1cf8nhe90JzHdl77Yi5Xsq37Qp5zJXmloIeReJ02Xukp+6OVbsrpLaqJvCHdMHdU8RJC23MyKbmyKboyKbIyKb2QzY1RzbFnk3dctxyxJgCyclwiZ01eA35fHWlLN/UftkUd3H0wdJdcs6jX0sdXXxhuZ0OaWBoRkTpbgfdwxHo38rHLxwpJ0/umehFSUlkU3RkU3RkU2RkU3zIpujIpujIpo7Ppribwg4ZVSTPXjpW9hucF+9bdbkv6MB9CuS1a8fLZdP7S4+8tEQvUlIpyHbLeYf0lv/cOFGmjS4ywxCNRvXLkT9dPIqDjziQTeGRTdGRTdGRTfEjm8Ijm6Ijmzovm+LuOQq2aVedbNxVZ/uKP83lkH7dM6VnfnrgMa/PkG83VcuemgaxO+0CHtY7W9LdjbX5riqPrN1WY/vWEM26koIMGdAjM9GL0qWQTRayKTqyKTKyqWOQTRayKTqyqXOzqV2LIwAAAABIVfY+wxQAAAAA9qI4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAgEDk/wPA1KVKJZUXZwAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 900x600 with 6 Axes>"
       ]
@@ -2525,10 +2525,10 @@
    "id": "visualization-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.009351,
-     "end_time": "2026-07-09T22:54:02.403951+00:00",
+     "duration": 0.00522,
+     "end_time": "2026-08-23T02:44:57.210517",
      "exception": false,
-     "start_time": "2026-07-09T22:54:02.394600+00:00",
+     "start_time": "2026-08-23T02:44:57.205297",
      "status": "completed"
     },
     "tags": []
@@ -2551,10 +2551,10 @@
    "id": "summary-table-section",
    "metadata": {
     "papermill": {
-     "duration": 0.008664,
-     "end_time": "2026-07-09T22:54:02.421117+00:00",
+     "duration": 0.005313,
+     "end_time": "2026-08-23T02:44:57.221189",
      "exception": false,
-     "start_time": "2026-07-09T22:54:02.412453+00:00",
+     "start_time": "2026-08-23T02:44:57.215876",
      "status": "completed"
     },
     "tags": []
@@ -2571,16 +2571,16 @@
    "id": "final-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:54:02.526700Z",
-     "iopub.status.busy": "2026-07-09T22:54:02.526236Z",
-     "iopub.status.idle": "2026-07-09T22:54:03.236944Z",
-     "shell.execute_reply": "2026-07-09T22:54:03.234843Z"
+     "iopub.execute_input": "2026-08-23T02:44:57.232760Z",
+     "iopub.status.busy": "2026-08-23T02:44:57.232553Z",
+     "iopub.status.idle": "2026-08-23T02:44:57.359211Z",
+     "shell.execute_reply": "2026-08-23T02:44:57.358790Z"
     },
     "papermill": {
-     "duration": 0.731113,
-     "end_time": "2026-07-09T22:54:03.238522+00:00",
+     "duration": 0.133256,
+     "end_time": "2026-08-23T02:44:57.359849",
      "exception": false,
-     "start_time": "2026-07-09T22:54:02.507409+00:00",
+     "start_time": "2026-08-23T02:44:57.226593",
      "status": "completed"
     },
     "tags": []
@@ -2594,15 +2594,15 @@
       "Tableau recapitulatif : Algorithmes de recherche\n",
       "================================================================================\n",
       "Algorithme Complet Optimal Cout  Noeuds explores Temps (ms)\n",
-      "       BFS     Oui     Non 1075                2       0.10\n",
-      "       UCS     Oui     Oui 1075               10       0.20\n",
-      "    Greedy     Non     Non 1075                2       0.09\n",
-      "        A*     Oui     Oui 1075                3       0.10\n"
+      "       BFS     Oui     Non 1075                2       0.03\n",
+      "       UCS     Oui     Oui 1075               10       0.05\n",
+      "    Greedy     Non     Non 1075                2       0.02\n",
+      "        A*     Oui     Oui 1075                3       0.02\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHvCAYAAAAvoP1zAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAe7tJREFUeJzt3QmcTfX7wPFnFmYsY9+zhuyRNUsqlGwRFaVMiFII/SVlS5YIiYRKJEuhqCQl62TfZS0Ssib7NsbM/b+eb537u3fmXmbGnblnZj7vXqe595zvvfd7zz1zfOe5z3m+AQ6HwyEAAAAAAAAAAFsI9HcHAAAAAAAAAAD/Q9AWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAKRpgwYNkoCAALMULVrU391BAj333HPOz++BBx5g/yHJcK4AAADJiaAtAAA2cPLkSXn77bfl/vvvl7x580r69OklU6ZMUq5cOenYsaP88MMP4nA4/N1NpKEAqOsSEhIi+fLlkwcffFDGjh0rV69e9XdXYUPr1q2Tp59+2nz5ERoaas5hhQoVkmrVqpnz2OTJk+M8RgPt1nGmxx8AAAD+FfzfTwAA4CcffvihvPrqq3Lt2jW39VFRUbJ7926zfPrpp3Lw4EEyQZPAww8/LJkzZza3s2bNmhQvkeJdv37dfLGgy4oVK2Tu3LmycuVKCQ5mKIl/ffLJJ9K5c+c4Xy5duXJF/vrrL9m0aZN89dVX8sILL7DLAAAA4oGRNgAAfjRy5Ejp06eP835QUJA0adJEqlSpYjLP9u/fLz/++KMJlsG7CxcuSJYsWRK1i2rVqmUWxPXuu++an5cuXZJZs2bJ77//bu6vWbNGFi5cKC1atEjS3Xbx4kUJCwvjo/GRMWPGSPny5aV+/frmXOMrZ86cke7duzsDtgULFpTHH39c8uTJYz7DnTt3yqpVqySpvlDQ19VscCTtuRIAACQvyiMAAOAnmkH7xhtvOO9rgGPjxo3yzTffyIABA6R///7y2WefyZEjR+Sjjz6SjBkzuj3+6NGj0rt3b6lQoYLJFNXLkfWy5GeeeUY2bNhwy3qMx48fl/DwcMmVK5f5I75Zs2by22+/mbZbtmyRRx55xATMsmfPLk888YTphyvNuHS9hP6PP/4wl86XLVvW9OWOO+6QXr16maBN7ADPa6+9ZgJH2g99DS0HoWUhHnroIfn888/jZOvFfi0NZo8aNUrKlCljgjXt2rUz7bZt2yYvvfSS1KhRw7x+hgwZTF+KFCkirVu3ll9++eWW+8XVoUOHTGZgyZIlnc+lz1u7dm3z3vbs2RPn+ZYuXWoCVhq40r7pvq1cubIMHDjQvPfY9DWt19e+bN68WZo2bSrZsmUzn/l9993nsd8343rJ+e3Uef2///s/s2i/Zs+e7bZt7969cdrf7jH5zz//yMsvv2z2nQYVp0yZ4myrQT99L3rJfY4cOcwxeeDAgVu+B/3CQ3/PKlWqZI417VOJEiXM6xw+fDhO+8QcQzerqxv72P3zzz/N+kmTJjnXpUuXzvzOWfT41vdpbR8yZIj4wrfffisNGzY0JQv0c9qxY4dPnlf3iWvJDL3/3nvvSd++fWXYsGHmdU+fPi1z5syJ89lrxrZFz3ee9lXsEgoaBNYvDHLmzGl+x6zfQ/2SQdffdddd5hjR/aq/R9WrV5ehQ4fK5cuX4/T9119/NcenHn/6XPp5Fy5cWOrVq2f6r8e0N3pu06skdH/qMaLnvg8++MBjKZvo6GhzxYSe9/Scq33T/mvJkY8//lhu3LgRr+PG23kjoedK6/ym5Sy0H/r7WrduXVm2bJlMmzbN7TkAAICfOAAAgF+8+OKL+pe9c/nqq6/i/diVK1c6smfP7vZ41yUwMNAxevRot8cMHDjQuT1HjhyOokWLxnlc7ty5HfPnz3eEhITE2VayZEnH1atXnc+3fPlyt+316tXz2Jdq1aq5Pe7XX3/12m9rad++vVvfY7/Wfffd53a/efPmpt348eNv+rwBAQGOqVOnet0vRYoUca4/efKk2R83e76JEye6PVevXr1u2v6OO+5w7Ny50+0x+prW9urVqzvSpUsX53H6eezevTvex8f999/vfKzejq/w8HC317VcunTJMWDAALdtsffj7R6TuXLlcpQuXdrtMe+9955p99133zmCg4PjPKcexzVr1vT6XtesWWOe11ufsmbN6li1apXbYxJzDLnut9h9iH3sHjx40LlNj1trfYUKFRyRkZGO6OhoR+3atZ3r69ata9b5QqdOnUz/XftTsWJFx6hRoxzHjx9P9PPqucv1Ob/55ptbPsb1s/e2WPvK9Xi+5557HJkyZXJrt3XrVtMuZ86cN30+3ccXL1509mHXrl2OjBkz3vQxP/zwg8c+582b11G1alWPj+nWrZvbe9XfH/0cb/Y6derUcevbzY6b2OcN7VdCz5X6fPny5fP4e9qkSROP5wEAAJC8KI8AAICfaEamRbNZ43up+blz56Rly5Zy9uxZc18zw9q3b28yOjUbUrOnYmJiTIakllnQyc1i04xPzYx75ZVXTPaZ1qNUf//9tzz22GMm66pr167muebNm2e26aXxCxYskDZt2njsl2ZoNW/eXCpWrGgmTtOsYaU/tQyEZg+rwMBAk/Wl2W86uZVmwmk9361bt8p3331nstSmTp0qL774omnjSUREhJmkTbODtb11qbdmkt17770mq9LKHjt//rzZ19oPbauZcZoxqfvtZrT+pu4P6/PRfazPeezYMZNlqn1wpRnCevm5Rfun+1LbawahZtpp1p5+drt27fJYD1azUTXLtG3btiazWUsSqMjISHn//fdNdmZy8pZlV7x4cZNN7MtjUjMxdWnQoIHJZNZ9r9nXWhNVJ7GyMhE1Q7FDhw7mM5kxY4asXbvW62Xg+julz6msTFntmx7T+hnosdGqVStzbFv1jH15DN2KZhLrc+oxohmfgwcPNr8Pq1evNtv1tr5H/Z3xBc3Y1wz+L7/80nwumt27fft2s2iZFs10f/bZZ81+i53ZfzO6r/RYsTJM9Txw5513mv2oWeaaLa6TkbkeT1Yt6YkTJ5osfVW1alWzXy2aLRubnif0d0f7qRnw+ruoWa5Kf3c0c1U/az0+tD9aC1zfr57ndB9rDXHN9Ff6e6nHl/VYzbjVDGetwavZvDqx2s0yuPW41/OU9Tnp49T48ePNcWUd51o6wrU8hL73mjVrmufX8jdWdrK202xcX/J2rtTz+4kTJ5ztGjdubH43v//+e7MAAAAbSOYgMQAA+I9rhleNGjXivV80+9A1C2rRokVu2aGZM2eOk1XlKbNtxowZzm2u2Yq6zJ0716yPiYlxFChQwLleM0m9ZXRpFp/l+vXrjnLlyjm3FSxYMM77OHTokGPevHmODz74wGT6vfvuuyYT1XrM4MGDvb7Wvffe65a9G9v27dvN+3v//ffN8w4ZMsTt8a7Zld4ybceMGeNc/8ILL8R5Dc2eO3HihPO+Zixa7TWL+cqVK85tH374odvrazazp4w5zSA8evSoc1uLFi2c2ypXruxI7kxbT4tmM+7YsSNJjskePXrE6dPs2bPd2nzyySfObZot6JqZ7Ppe9bO31msG8D///OP22blmUWvb2zmGEptpq37++Wdn9qtmE7tmuc+ZM8eRlPbt2+cYNGiQo1SpUm59DAsLczz33HOOPXv2xPu59LO72XFTrFgx53nF27Gq+9ET1za6LFiwwGs/zp07Z46/SZMmmcxu/excs1z1igBL9+7dneuHDx8e57nOnDljFm/H68yZM70ei23btjXrT58+7QgKCnKuf/LJJ91eQ+9b27Sdtvdlpq2nc+WxY8fcMq5bt27t3Hbt2rU4xwMAAPAPMm0BAEhhXDMLc+fOLY0aNXKri6v3586dG6etK81Uc81o0/qIVlvNZNQMUaWZccWKFTOZgMrKpPREM98s+hxPPvmkqeOqNANNM9M0c1Lrlmot3Vtlc1lZa55oxqaVXedKMwe1ZqNmUSb2uS2a7WllD06ePNlkRGrNylKlSpmMQM3o0/ejNFvPtT6o1lt1zcLUPmmdVIvua0+Z1ZqhWKBAAed9fS3LzfZ9bFrX0tcTkS1atMjsA/38tPal1iK9++67fXZMqn79+sVZt2nTJrf7WoPT9bitU6eOLF++PM7jrGxVa99p1qw3OrGaZjn6+hiKD61xqsez7mvNJrYyijWbWI+j+NK6qJoRHFvnzp29TjyltV/1d1QXzWDV7FvNxtXn0bqmmjVfunTpeL2+Zpnr74dmhHvad5rxqucEzVjW353E0onU9PckNs3kfv31183r6+Rk8fncNAN43LhxzmNPa+/q+9XfO61prNu9Tdim57jY51DXY1FrU1vZ85plb9Fznyu9b9X61Xba3vX353Z5Oldq31zr7rrWudVM86eeesqtTi4AAPAPgrYAAPiJTnKkl2UrnQBM/4iOz6QvrpNZWUFDV67rvAX6NJDmenm+TgTmus01UOHaTgMj3ujjvPVD6aXEuk4vdY/P5bdaEsAbT4EkLfegE3jpBGu389wWLc2ggSi9nFyDlhrMc50sSicT0kCkTpKk+9k1CBL7vesl13opuD7PzT6X2BOhaQAlPvs+qWjAx/Lmm2+ay6z1mNXPUgNkGsj11TGp+9NTYFVfy6ITicUuSeDp9WL36VasMhi+OIZiT0IVn2NNJ0UbPXq022esl68nhE60pWUoYtMyFt6CthYtT6AlTRYvXuwW+E3IJFTatlOnTmbRwKgG5zUYPn/+fGe/dN/oBGW3E7T1FkTW4Kv1JcPNuH4eum/0GNdyBrpe++z6pYKWWdBzlR73semxGjug63osWsdt7OMw9vEa+76334/EHFfe9pfr75TSMjU3uw8AAPzDNwWyAABAojLsXP9Q/+abb+L1ONc6j5q9GpvrOq3r6C1LzBtPtVbj49SpU177obTuo9aVXLhwods+OHDggMku1KCE1r2MDw2CxqY1I12DbVp3VINx+ryeZo2Pjx49epj3odmBGhTq1q2bqaOptFaqlTWn+9k1wBX7vevrWwFbq318Phc7zdyufdPapRYNyPnymPT0mVrHjeXixYsmsOrtuV259il//vwmoOdt0WzU2zmGXGvOxu6f9cWMN/rczz//fJygvPYpKipKkooGVvVLCf1yQmsUa1Bea77qFzhan1iDra7Z4Qmh9WE1S1gDtPqFlNawju/+uBVvx4nWrbVotvr69etNYFP3b+/evb0+n37+egzpFxC6P7RGrZXtrsFmb/tAM85dM2hjH4vWcRu7Lm/s4zX2fev3I3YdY9fjSus1ezvu47O/XH+nPJ27XWvdAgAA/yFoCwCAn2gmnWumVpcuXcyEQLFp4EYnCrP+sK5Vq5ZzmwaUNEPOom1c77u2TWo6EZdrn61Lfq2sYs0o0yw+10BHkyZNzIRFuh/27dvnVmIgoTSI4kon89LsTeXal/jSkhAaGNEJmerVq2cCthq4dQ0OHT582LyuttFLyS2agesaZJk+fbrbcyf156LZvxrw1UVv+4IG1rdt2+a87/o5JuUxqaUoXFmTs6k///zTTODkSew+6eRPmlXpumhQVgPR1oR3iT2GXINgehxbmYx6vE+YMOGm708zbH/++Wfn81hZjloWwpq8Lz50X2iAMvbimr2t+0En4tLyFoULFzbv35owUCfG0knBNGCnk/Bp+Y6bfbkT+3J7LS+gk+d5+hLI9fL82AFD19ewJgVLDNfPTo8Z/Uw1AK2THOoEh55oyQb9rHQSOi1J0LNnT7MPPvjgA2cb1+x6V3qOcz0XxD4WdVIvpf1wPc/r5GeuXO9rO+tYjL2fXCdFGz58eJzM24TQvrl+IaRlMSwa6Ha9DwAA/IfyCAAA+Ilecvv222/LG2+8Ye5rsESDDXp59j333GP+qN6/f7+ZXVyDhw0aNDDtNLtTH2cFKXSWcq1/qZdAa0DLyujUx2umaHLRmpoaFNI6pxqkc61rqZdMWyUUNBhhBbWGDBlignoaENRZ0+N7ya8nrvVflc4ErzUnNZjiGlCOL8261KCd1qnUTEHNvtNA5ddff+1so0EhDdgqDYBZdX31NTVrWGsDa/DXNTCjdUQ1WJ0SjBo1yvzULFP9TF2zJLXmryUpj8lHH33U1Mm1ShjolxsaaNSMxBkzZnjNRn3uuefM8aUZ0Xp8aX81+7NEiRLmONPgqtb+1d8trUOqtZsTewy5ZohrFqT+/mrwTevqHj161OvjtI6sZrhaNFioAcRmzZqZ+yNHjpSGDRv6LPCuNWVd6x3rFyb6HrWmqWbbJpZmQGt5hmHDhpmAoNaD1d8XDZguWbLEvE/LI4884vZY/ULHoqUItOyGBsp10c8wvvSzs45PzeZ/4YUXTAB83rx5snfvXo+P0aCr1vPV/asZ9JqRrce6a9AydvDUlR7jERERpk3sY1Gzp60yCvo+pkyZ4gz+6/lPg+QaiNXzu0U/B6tEiJY10HIgum+VZvzq+9J/J25WFzo+9H3qOci66kG/VNIvGPSLJ12nvxsAAMAG/DQBGgAA+I/OTu86Y7y3xXX28JUrVzqyZcvmtW1gYKBj1KhRbvvYdeZznXnclc7a7m2bt9ndY89S3qRJE499qVKliuPKlSvOx73zzjse25UvX960jc9rxZ5J3fLII494fG7X96fL1KlTb7lfZs+efcvPpFevXm6vr/dv1r5AgQKOnTt3xmsW+Ft9Zjfj+pnp7fiKvZ+8LXrsbd++3e2xvj4mXX3zzTeOoKCgOM8ZFhbmqFy5stf3unr1akeuXLlu+X70+LqdY+jq1auOkiVLenxc48aNPR67ly9fdpQuXdq5vlWrVs7n69ixo3N9wYIFHWfOnIn3Z3gzun/0M+rUqZMjIiLC4Suxfz+9LfpZXbhwIc5n66ltuXLl3Prt6bzgSt9PcHBwnOfJnDmzo2XLlh6Ps+HDh9+yz+PGjfN4vOpxpX309JiXXnrJrW+XLl1y1K1b96avU7t2bcfFixfdHtevXz+PbatWrerIkyePx/NGfM+Vuj5fvnxxnjsgIMDtd0DvAwAA/6A8AgAAfqaz1utlujpbt2Z1alahXlKsGZya4amZhZodp5PiWPTy5p07d5rsTs3Y1baa9amXPGt2qNYb1W3JSSfz0UxBnUFeJ9DSbK5XXnlFli1b5jZ5VJ8+fcwl45pxqpdGazacZuKuXLnSTNZ1O/Sybs3k1NfW/aFZlZr9Z2W5JYR+Fpo9qBlpmoWoWW/6uejno7V4p02bZi5td6X3NbNQM00101Dfn74nvQRfJzTT8g+eJjWyO82Q1fevmXi9evUy70Mzql0l5TGp2bZaQkBfQ48lzWxs3ry5qVtaoUIFr4/TEgma8a37XjNANfNXL0HXx+t9LVGin5c+7+0cQ3r5v9Y91kxWfW69r9mmWhfWWz1VvRTfygDVDHS9LN+itWA189eqPWtlqt8uzdzVTM2PPvrIHN++ovtZ379mDWvWqu4z3df6+6KZo7p/x44da44BPY5if7Z63tBzneuEiAml70ezVrUvev7RjOXGjRub1/R2jGgJCC1BoVcxaBkJPWa1z1Ym6rfffmvKonirFavlEHS7Zgtr3zXb9/3333crr2C11f2jZW50Ejatc6uvo9ni999/v0yePNmc42Of/wYPHmyOPT0W9Fyi/wb07dvXnCtjT8iXUPp+NdO3TZs25pjV59PsX8121j7FJ9MYAAAkLfPVaRK/BgAASIU0yOA6C7wGnl3rZwIA7EknvtOyIbED5VoCRgPfGzZsMPcfeugh+emnn/zUSwAA0jZq2gIAAABAGqK1l7WO79NPP22uBNBsb62/rFcQWAFb60oQAADgHwRtAQAAACCN0Un6xo0b57UkyltvvWUmxgQAAP5B0BYAAAAA0hCt36v1cZcvXy5//PGHnD171tTNLVSokKkP/MILL0i1atX83U0AANI0atoCAAAAAAAAgI0E+rsDAAAAAAAAAID/IWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AJLGiRYtKQECAWVKb5557zvneVqxY4e/uAAAAwEb+/PNP51jxgQceSLN9uBXG1AA8IWgLwBYGDRrkHEzpsmjRIq8DmUmTJvmtnwAAAEBSuHz5srz33ntSt25dyZkzp4SGhkqxYsWkadOmMmPGDLl+/Xqy7Php06aZsbku586dS5bXBADEFexhHQD43dChQ6Vx48b+7gYAAACQ5Hbv3i3NmjWTP/74I06WqC7ff/+9lC9fXipVqpQsQduVK1c6EyeyZcuW5K+Z1r355pvy/PPPm9sVKlTwd3cA2ARBWwC2tGbNGlm2bJnUq1fP312Bn8TExJiMEs0yAQAASK3OnDkjjRo1ksOHD5v7BQoUkN69e5vg3cWLF00AderUqf7uJpJQyZIlzQIAriiPAMC2hgwZEq92+/fvl/bt20uhQoUkffr05nIyzdJdunRpnLYOh8MMemvXri1ZsmSRDBkySMWKFeX99983QUJXVjkGrUnrSmthWds088Fy5coV6d69u+TOnVsyZ84sjz76qNv22CZPnixVq1Y1bUNCQuSOO+6QBg0ayMiRI+P1vv/++2/p1auXGeDp47Nnzy5NmjSRdevWOdtERkZK2bJlTV/TpUsn27dvd27Tttb7mD17dpwyFbqf9BK94sWLm8BplSpVZMmSJRJfGnTX18iVK5f5XPTz0WyN33//3a2d62t++umn5nMvUqSI6a/1XhLyuel7bN68ueTJk8c8hx4PmpXy4osvOv8YAgAAsItRo0Y5xyhZs2aVDRs2SI8ePaR+/frSokULMx777bffpHDhws7H6BfbI0aMMGOcTJkyScaMGc3Y6J133olTRiG+Y1qdn0BvW1m2SsszeBr3enLw4EEz/tX+6DjslVdeMePjhNRw1Sxfa72OEeNDx4tPPPGECXbrmDNfvnzmb4Ft27Z5bK9jRd23us+0bb9+/eKMJ6OiomTMmDFm/KvvR5caNWqYMhWxue7fHTt2mPIW+tylS5eWefPmmTb6s1y5cmbMrp+TjpPjsz9cn1vH0Lp/9W+HHDlymLHttWvX4rWPAKRQDgCwgYEDBzr0lKRL1apVnbfXrFljtoeHhzvXTZw40fm49evXO8LCwpzbXJeAgADHhx9+6PY67dq189hWl9atW7u1tdYXKVLEbf3999/v3Hbw4EHn+iZNmsR5zoIFCzpy5MjhvG+ZPn26137ccccdt9xfhw4dMs/t6fHp0qVzfPPNN86269atcwQFBZlt1atXd0RHRztmzZrlbN+qVSuPn0OpUqU8PveqVauc7V0/l+XLlzvXT5gwwex/T/3Tz2vDhg0eX/POO+90a2s9Z3w/t9OnTzty587tte2SJUtuuW8BAACSk+v4Z9CgQbdsf+3aNUfdunW9jnd0W2RkZILHtDru8vacsce9sf3zzz+OQoUKxXnM3Xff7bytr3erMeTUqVOd63WMeCuffvqpc5wbe9HnUtpv17F55syZ47T9+OOPnc95/fp1R/369b3uh9dee82tD9b6bNmyOXLmzBnn75F+/fp5HA+fOXPmlvvDWpclS5Y4z63Lm2++ect9BCDlItMWgO3oN9/33nuvuf322297bafjGM2w1cvG1OOPP27qffXv318CAwPNds1SOHLkiPMb7unTp5vbpUqVMtml3333nfO1vvzyS7Mkxo8//mheW2kW6NixY2XBggXm23u95C22b775xvwMDg42E6tpVvDMmTPl1VdfNRkNt/LSSy/JX3/9ZW63a9dOFi9eLBMnTjTfvGtmQIcOHcxkFkqzAv7v//7P3NbMDc1k1f2iNCtYH+ctg3nw4MGycOFCadiwoVmnz2091hvd3z179jT7Xz8HzV7QfaMZEEo/L80m+Hcc6k7ruLVt29a0189Ks48T8rmtXbvWZCCrp556ymQG6+egGSz333+/BAUF3XLfAgAAJJdLly651bG97777bvkYHWeuWrXK3NYrmWbNmmXGR1Ymrm7T7NyEuueeeyQiIsKtbu7cuXPNOl3y58/v9bHvvvuuc8ytWaE6NtOs2WPHjklSOXr0qHTp0kWio6PNfc1Knj9/vhk7durUyWTdxqbjZ8101bG4XiHnegWcRa/ksq7Y0/Gm9Zw6DlV6Vdz69evjPLdO2qZXwH377bfSpk0bs07Huzr21qvAdExdp04d53hYP7f4unDhghm3f/XVV25/H7n2G0Aq5O+oMQDEzrbs06eP47vvvnPe37Rpk8dM2y1btjjX5cuXz3wrbtHsUWvbe++9Z9Y1b97cuW7cuHGOiIgIs+g369b6pk2bJjgrQXXp0sW5rnfv3s62v/32m9u34ZY2bdqY+xkzZnT8/PPPjvPnz8f7QNBMBiuLVd+39T50eeyxx5yvNW/ePLeMjLJly8b5dv6rr77y+jm0bdvWuf7cuXOmr9a2w4cPe80KGDNmjMcsXv18tL/Wtq1bt8Z5zdq1a8d5vwn53BYvXuyWBaH9jImJife+BQAASE5//fWX29hsz549t3yMa/aqjpktruPnihUrJmpMe7P1N1OmTBnnY77//nvnetfxmq8zbXWMb7WtVauW13aumbbp06d3nDhxwqzXq8+s8a1myVp031nt58yZ4xx7Dh482Lm+a9euzvaun5+O/dXGjRud6/Q1Lly4YNbPnTvXub5Hjx633B+uz22NnVXp0qWd63WcDiB1YiIyALbUtGlT823/1q1bzbfTWt8rNq3tZalcubKpX2qpXr26+SbatZ1re9dv1l3t2bMnUf11zZCoVq2a87Z+2661Zs+ePevWXjOENQNB63xpHVtVsGBBkw2qmaxa69YbzYC1slRPnDjhNSPD9b1o/SzNdtCsW+uxTz75pLRs2dLr62hbi+5/zS7Qz8N6v5rZ4YnrfnZ9Dv189DP94YcfnO1iz4Csn/vNnu9Wn5vuC93nWvNLsyB0CQsLM8eHZvB27NjRZP8CAADYQewxrmamai3Um/E21tLxr6c2ycHbWNi1T77m+h51HoX40H2bN29ec1vHhDpO1/G4Zsl6el4dL8f3b4Zs2bI5JxPTmrMWHUPreFTpXA8W19e8FZ3TwXXcrHM2uD6Pp7+VAKR8/OUKwLbefPNN81MvX9q5c2eCHqsF+xPDKingyrrkynL69Onb7svDDz8sq1evNpduaSBTJyvQy7W0RIIGbl0HvokV+73s27fPrSSB3tdyB0m9TxPyHNYgOrHvVfej7lct61CvXj1TnsKadblz587xnuQNAAAgOWhpqzvvvNN5X8cxSTXOut0xrS/75LretV9J3ScN0rrSUmW++pvBNXDqmiSgAVdPPJUKS0y/E/I8AFIWgrYAbEuzQMuWLWsGIps3b46z/a677nLe1gzQGzduOO+71pmy2rm2X758uXne2MuBAwfiDLz++ecfZ3BTZ83du3dvnL64DrY3bdrklhXrqaatvlbNmjXlo48+ki1btpjA4ujRo802/bZfa9R6U6JECedAt3jx4uZ9x34fOmuwBi4tx48fd2apWnVddebcoUOHen0drX9rOX/+vAnyenq/sbnuZ9fn0H1oZerGbnezgX1CPje9rfW+tK6x1iLT960BcP2DSH399dde+w0AAOAPrVu3dt4eM2aMxzqwp06dco4pvY21PI1/EzqmjR1wjImJidd78DYW9lT71bVP1pVjlpuNgWNzfY+LFi2K9+MS8rw6jvQ09rRq3gJAUiJoC8C2NID3xhtveN2ulwiVKVPG3NbgnF7+rpfeDxo0yEwYoHQCglatWpnbut3y7LPPOicA++KLL0xBf51oQCdRcA2OqqtXr8rTTz8t48ePl0aNGsXJUlCPPvqo8/YHH3xg2uokBK6v6UoDqDpxmk4eoIPMn3/+2UzwYImMjPT6vvVyK+2H0mClvrYGI3XSrU8++URefvllMxGFTs5geeGFF5wlGubMmWOC4WrYsGGybds2j6+jE1poUFf7p5N6WRkFmhnsrTSC0vdllarQfg0cONB8LrrP9XNS+vo6CUR8JORzW7NmjVSpUsW8L504Q4O8+jloIPxW+xUAAMAfdMJYaxIxvdRdSx7oZFjLli0zV5zpBK8aSDx8+LBpo+NSi477dEykZbe6devmXK9jt8SMaWNndX788cdmjOoaiPXEdSzctWtXMw77/PPPnVfOxWb1SemktRMmTDBjvoQEQ3WSWy0BZmUo65hf95f+HaCT9uoVbInhOvbU0l2fffaZ6deMGTNMXytUqGDG0wCQ5PxdVBdA2rNy5UozcVT+/PlN8fz58+e7TUalE0j179/fTFoVEhLiyJAhg1sRfmsiMrV+/XpHWFhYnAm2dNHJuj788EO3127Xrp3Htp4mPJg8eXKc7ZkzZ3YULFjQ4+QMjRo1itM+d+7cjqxZs8aZiKxjx45e+6Dv98CBAzfdh4cOHXLrh6fF6tu0adOc61q3bm3WrV271hEYGOicqMKaxM31c3Cd5MJagoOD3SZH8DZpwoQJE5yTpcVe9PPasGGDs63ra+rkE57E93PTSSJu1m748OE33a8AAAD+sGvXLsedd95503GMNRGVTjB73333eW1Xt25dR2RkZKLHtOPHj4/TPvYkZrGdPn3acccdd8R5XMmSJT1ORKbttQ+x27tOaHaricisic6sMW3sxRpXuk5E5toHpe8r9jhd9139+vVv+lm4jlk97SNvr6njZWu9jqPjOxFZfCeRA5C6kGkLINlpxqZmWeo36p7oZVTjxo0zGZV6yZcW7/dGJzfQ0gnh4eFyxx13mPpOmh3wyCOPyE8//SRdunRxa6/flE+fPt3UjdXLsjQTVzMb6tevb15Tv5W3PP/889K3b1/JkyePZMiQwdRI1UwDLUngiWYUaLaDTgygtVUbNmwoq1atMpMSePoGX/us7037oSUL9HVatGhhXuNm5QeU9llLDfTu3dtMqBAaGmomONDb7dq1M9mlmg2rl9fpxGZK94tmbSjNTrXKJWiZBM1YjU2zOjRrWN+v7ifNsF24cKE88MADciu6HzXzV7M4NDNYP5cCBQqYvunn5TpBRXzE93PTLJQ+ffqY96f1cfV1tTSCvp4eb7oNAADAbvQqpB07dpjyCHXq1DHjJx3v6HhOx5Q6FrKulNLsUh1nvfPOO3L33XebcaqOBTUDdPjw4WYMrI9N7JhWr9DSMZOOteI7gauOf3Xcq5mpOg7W/uvcDTo+9tZ+wYIFpv/aV+2LjtVee+21BO03fW/6XrSsmjX20/epY9DYE97Gl/ZHyzToGFP/1tAxtu7fYsWKmQnPpkyZIo899liinhsAEiJAI7cJegQA+LgEgl7CpMFKpackDe69+uqr5lIxq56qDsKmTZsmbdq0Yf8nIS0t8dZbb5nbU6dOleeee479DQAAAABAMiPTFoCtHDx40ExG0KBBA+c6zazU2l5r1671a98AAAAAAACSA0FbALZizR6rmbWu9L7rzLIAAAAAAACpFUFbAAAAAAAAALARgrYAbCVfvnzm58mTJ93W631rG5K2pq3WFdaFerYAAAAAAPgHQVsAtqKzsmpwdunSpc51Fy5ckPXr10vNmjX92jcAAAAAAIDkEJwsrwIALi5duiT79+93m3xs27ZtkiNHDilcuLD06NFDhgwZIiVLljRB3P79+0uBAgWkRYsW7EcAAAAAAJDqBTj0GthULCYmRo4dOyZhYWESEBDg7+4AEJGIiAhp2rRpnH3x9NNPy8SJE82l+cOGDZNp06bJ+fPn5d5775UxY8ZIiRIl2H8AkIrp+f/ixYvmi7rAQC4ISwjGvAAAAKlrzJvqg7Z//fWXFCpUyN/dAAAAQDwdOXJEChYsyP5KAMa8AAAAqWvMm+rLI2iGrbUjsmTJ4u/uAAAAwAutYa5ftlvjN8QfY14AAIDUNeZN9UFbqySCBmwJ2gIAANgfJa0Sv88Y8wIAAKSOMS/FwgAAAAAAAADARgjaAgAAAAAAAICNELQFAAAAkOqtWrVKmjVrZmZq1ssRFyxY4LZd52ceMGCA5M+fXzJkyCANGjSQ33//3bl9xYoV5nGelo0bN5o2f/75p8ft69atS/b3i6THMQWOJ9gZ56iUj6AtAAAAgFTv8uXLUrFiRZkwYYLH7SNHjpRx48bJpEmTZP369ZIpUyZp2LChXLt2zWyvVauWHD9+3G15/vnnpVixYlK1alW35/r555/d2lWpUiVZ3iOSF8cUOJ5gZ5yjUr5UPxEZAAAAADRq1MgsnmiW7dixY6Vfv37SvHlzs2769OmSN29ek5Hbpk0bSZ8+veTLl8/5mKioKPnmm2+kW7ducSYSyZkzp1tbpE4cU+B4gp1xjkr5yLQFAAAAkKYdPHhQTpw4YUoiWLJmzSo1atSQtWvXenzMt99+K//884+0b98+zrZHH31U8uTJI3Xq1DHtkPZwTIHjCXbGOSplIGgLAAAAIE3TgK3SzFpXet/aFtuUKVNM+YSCBQs612XOnFlGjx4tc+fOle+//94EbVu0aEHgNg3imALHE+yMc1TKQHkEAAAAAEiAv/76S3788UeZM2eO2/pcuXJJr169nPerVasmx44dk3fffddk3wIcU0gOnKPAMZU6kGkLAAAAIE2z6s+ePHnSbb3e91SbdurUqaZubXwCsVpiYf/+/T7sLVICjilwPMHOOEelDARtAQAAAKRpxYoVM3/ALl261LnuwoULsn79eqlZs2acScs0aNuuXTtJly7dLZ9727Ztkj9//iTpN+yLYwocT7AzzlEpA+URAAAAAKR6ly5dcst41UlYNKCaI0cOKVy4sPTo0UOGDBkiJUuWNH/M9u/fXwoUKGBq0rpatmyZeezzzz8f5zU+++wzSZ8+vdxzzz3m/tdffy2ffvqpfPLJJ8nwDpHcOKbA8QQ74xyVCjj8aOXKlY6mTZs68ufP79CuzJ8/3217TEyMo3///o58+fI5QkNDHfXr13f89ttvCXqN8+fPm+fWnwAAALAvxm3su6S0fPly83dB7CU8PNztb4+8efM6QkJCzN8e+/bti/M8Tz31lKNWrVoeX2PatGmOMmXKODJmzOjIkiWLo3r16o65c+cm6fuC/3BMgeMJdsY5KuWPeQP0f/4KGP/www+yevVqqVKlirRs2VLmz5/v9k32iBEjZPjw4eYba+vb7l9//VV2794toaGh8XoNvawpa9ascv78ecmSJUsSvhsAAADcDsZt7DsAAIDU7kI8Y5V+LY/QqFEjs3iiseSxY8dKv379pHnz5mbd9OnTJW/evLJgwQJp06ZNMvcWAAAAAAAAANJwTVutE3XixAlp0KCBc51GoXX21bVr1xK0BQAAAGK7dk0kffq4+yUw0H29tvPmdtpGRmr2hee2AQEiISGJa3v9ukhMjPd+uF6F56+22l/tt4qKEomO9n3bGzf+XXzRVj83/fx83VYnZwsKSnhb3Qe6L7wJDv53SWhb/cz0s/N1Wz129Rj2RVvdB9akdr5sm1y/95wj/sU54t/9wDkifr+fnCPS9jji2k3OsSkhaKsBW6WZta70vrXNk8jISLO4phwDKd3hw4fl9OnT/u4GkkCuXLnM5CcAAPhEu3b/C+i4qlpVZODA/91/5hnvf0yWLy8yfPj/7nfsqIPqOM2uXr0qF/Llk6O9ejnXFR48WNKdOePxaa/nzStH+vZ13i80fLikP3nSY9uoHDnk8IABzvt3jBkjoYcPe2wbnSmT/Dl0qPN+gfHjJcOBAx7bxqRPLwdHjnTez/fRR5Jp927x5sDYsc7beadOlczbt3tt+8eIEeL47w/E3LNmSZYNG7y2Pfj22xITFmZu55o7V7KuXu217aEBA+RGjhzmds5vvpFsy5d7bXu4Tx+Jyp/f3M7+ww+S48cfvbb9q1cvifxvDJJt2TLJ+e23zm06mVqGDBn+13jYMJEKFf69rc85aZLX5xX93KpV+/f2ypUiLvswjj59ROrU+ff22rVyddAgue4laHrq6aflYvXq5nbGXbsk/8cfe33av1u1kgv33Wduh/7+u9wxYYLXtv88+qicq1fP3A45fFgKjhnjte2Zhg3l7H9XiqY7flwKjxjhte25Bx+Uf/67YjT4zBkpMniw17bna9eW0088YW4HXrwoxfr399r2QvXq8vfTT5vbAZGRcqfuQy8uVawoJ9u3d94v3qOH17aXy5aVE507O+8Xe+01CfTyWVwtXlyOdevmvF/0zTcl6PJlj22vFS5szhHOMe9LL4mcOuW5E4UKiXz44f/u9+wpcuSI57Z58ohMmfK/+6+/LvL773H7evWqXE2XjnOEj88RsR19+WW5VrKkuZ0lIkJyf/WV17bHO3WSK+XKmdthGzZInlmzvLY9ER4ul/+b2DHT1q2S77PPvJ+n9PiuX//f21u2iNzkd05efFGkSZN/b+/aJfLGG97b6u9Qy5b/3j5wQK526eL1PMU5IvHnCDuMI3JZ5ykdL+3c6bGtCQTPm/e/+zpe2rRJvPruu//d1n9frH/vb/bFY0oI2iaW1sB96623/N0NwKcB21KlS8m1q/H7JgYpS2iGUNm3dx+BWwBAiqKBkGXLl8u+mBh5deZM5/pPNJbi5TEaennZ5Q8dDaMV8tJWQzrPf/ON8/5oEfk3HBCXhpOfWbzYeX+Yxp29tNUw9RNVqjjv659zVcW7R13aamis9k3aPlGrlnl+9YqI/Bc68OiZBx4w/VYvikjjm7Tt+NBD8vd/tzX89thN2r4cEWH2s3rqv8WbXhERsv+/2/qc7d0SnwKl3oMPugdEktjJkydl0/LlEuMlY2lsRIQs+++2fmb/+1M8rkkREbLov9vl/zsmvJkaESHz/7tdQv+mvknb2RERMrtfP3Nbj13voWCR+RERMvW/oFFuEXEJL8axKCJCJr3zjrmtlQ1n3KTt0ogIeX+0/kaI6FcEc2/SdnVEhIz44APnfe8hN5FNEREyePJk5319XpccNTc7IyLkjWnTnPe1v94qMmoYVc8RzjGvJO95avny5XI2JoZzhI/PEbG9EREhVoir8X/nNW8GR0SIFeLSr0u8f5UgMiIiQqyvtPT86/oVRVBgoDyYzOepY8eOybblyyXay3mKc0TizxF2GEdkCM0ge/ftTdbz1K34dSIyVwEBAW4Tkf3xxx9SvHhx2bp1q1SqVMnZ7v777zf333///Xhn2hYqVIiJyJBibdmyxUzWl/up3JI+j4fLHZFiXT91Xf6e/bds3rxZKleu7O/uAIDfMRGZD/bdyZOeJ7Tw8aXPOkavWauWlHpwlKTPWdq5Pl10lASI5z8vHBIgUUHpEtU2OCZKAm/yZ8v1oPT+bxuYzlmaICjmhgQ5YpKgbbQEOaJ90jYqMFgcAYFx2l4+e0D2rugta9eskXv+y3BLjvIIWzZulFrVq0vuJ3NJ+txxx7w3AkWiA/99b4ExDkl3k6tRXdsGOBySPtr3bfWS3BAftY0OELkR5Pu2MQEiUVZbDcLecPil7eV/ov435tUMy2S69Nk6T01tLVIqv8tDdZ/dJAriCE6itnqoW7stWo+3JGgbIxIQY/O2eioJvL22e/8Waf+luJ+nkqGEypZNm6RWtWrSWp6U3ObrGHcxEmiW/3ovwfrheZGwtgESI0E+b6v/1kY722pW5w2/tw2SG85DKTb9NYh2yT1NWNtor2MOdUzOyGyZ/e95Sq84SuLyCGbcljevvSciu5lixYpJvnz5ZOnSpc6grb6p9evXS5cuXbw+LiQkxCxAaqMB25CCHNsAAEBu/seB6x8IN2sXXx7aahkATZPQgG1Y7grxf6r4v2qC2iZkhETbm+8HDVTrZ2tKPXg6TlyDHbeSkLZBQf++bv4QEQ9j3uAE/PGa0tpquCIoCdoGJuB4T8q26V0CvG6B1ltJSFsPtbyt85QGbCsXjP9Twf40WH7T85R+GWR9eXQr+oVUfP9NDAw0r5td8ks+4aBKTW64nrE9zQ3gTWLb3uyLArsEbS9duiT79+93m3xs27ZtkiNHDnOpcI8ePWTIkCFSsmRJE8Tt37+/FChQwJmNCwAAAAAAAACpjV+Dtps2bTI1SCy9/is+HB4eLtOmTZPXXntNLl++LJ07d5Zz585JnTp1ZPHixRKakMwAAAAAAAAAAEhB/Bq0feCBB+RmJXW1zu3gwYPNAgAAAAAAAABpgVX1GAAAAAAAAABgAwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAwItVq1ZJs2bNpECBAhIQECALFixw2+5wOGTAgAGSP39+yZAhgzRo0EB+//13tzZnzpyRtm3bSpYsWSRbtmzSsWNHuXTpklubHTt2yH333SehoaFSqFAhGTlyJJ8JAABAGkbQFgAAAPDi8uXLUrFiRZkwYYLH7RpcHTdunEyaNEnWr18vmTJlkoYNG8q1a9ecbTRgu2vXLlmyZIksXLjQBII7d+7s3H7hwgV5+OGHpUiRIrJ582Z59913ZdCgQfLRRx/xuQAAAKRRwf7uAAAAAGBXjRo1MosnmmU7duxY6devnzRv3tysmz59uuTNm9dk5LZp00b27Nkjixcvlo0bN0rVqlVNm/Hjx0vjxo1l1KhRJoN35syZcv36dfn0008lffr0Uq5cOdm2bZuMGTPGLbgLAACAtINMWwAAACARDh48KCdOnDAlESxZs2aVGjVqyNq1a819/aklEayArdL2gYGBJjPXalO3bl0TsLVotu6+ffvk7NmzfDYAAABpEJm2AAAAQCJowFZpZq0rvW9t05958uRxH4AHB0uOHDnc2hQrVizOc1jbsmfPHue1IyMjzeJaYgEAAACpB5m2AAAAQAozfPhwk9VrLTp5GQAAAFIPgrYAAABAIuTLl8/8PHnypNt6vW9t05+nTp1y237jxg05c+aMWxtPz+H6GrH17dtXzp8/71yOHDnCZwgAAJCKELQFAAAAEkFLGmhQdenSpW5lCrRWbc2aNc19/Xnu3DnZvHmzs82yZcskJibG1L612qxatUqioqKcbZYsWSKlSpXyWBpBhYSESJYsWdwWAAAApB4EbQEAAAAvLl26JNu2bTOLNfmY3j58+LAEBARIjx49ZMiQIfLtt9/Kr7/+Ku3atZMCBQpIixYtTPsyZcrII488Ip06dZINGzbI6tWrpWvXrtKmTRvTTj399NNmErKOHTvKrl275Msvv5T3339fevXqxecCAACQRjERGQAAAODFpk2b5MEHH3TetwKp4eHhMm3aNHnttdfk8uXL0rlzZ5NRW6dOHVm8eLGEhoY6HzNz5kwTqK1fv74EBgZKq1atZNy4cc7tWpP2p59+kpdfflmqVKkiuXLlkgEDBpjnBAAAQNpE0BYAAADw4oEHHhCHw+F1/2i27eDBg83iTY4cOWTWrFk33cd33323RERE8DkAAADAoDwCAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbsXXQNjo6Wvr37y/FihWTDBkySPHixeXtt98Wh8Ph764BAAAAAAAAQJIIFhsbMWKETJw4UT777DMpV66cbNq0Sdq3by9Zs2aV7t27+7t7AAAAAAAAAJC2grZr1qyR5s2bS5MmTcz9okWLyuzZs2XDhg3+7hoAAAAAAAAApL3yCLVq1ZKlS5fKb7/9Zu5v375dfvnlF2nUqJHXx0RGRsqFCxfcFgAAAAAAAABIKWydafv666+boGvp0qUlKCjI1LgdOnSotG3b1utjhg8fLm+99Vay9hMAAAAAAAAA0kSm7Zw5c2TmzJkya9Ys2bJli6ltO2rUKPPTm759+8r58+edy5EjR5K1zwAAAAAAAACQajNte/fubbJt27RpY+5XqFBBDh06ZLJpw8PDPT4mJCTELAAAAAAAAACQEtk60/bKlSsSGOjeRS2TEBMT47c+AQAAAAAAAECazbRt1qyZqWFbuHBhKVeunGzdulXGjBkjHTp08HfXAAAAAAAAACDtBW3Hjx8v/fv3l5deeklOnTolBQoUkBdeeEEGDBjg764BAAAAAAAAQNoL2oaFhcnYsWPNAgAAAAAAAABpga1r2gIAAAAAAABAWkPQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAASKTo6Gjp37+/FCtWTDJkyCDFixeXt99+WxwOh7ON3h4wYIDkz5/ftGnQoIH8/vvvbs9z5swZadu2rWTJkkWyZcsmHTt2lEuXLvG5AAAApFEEbQEAAIBEGjFihEycOFE++OAD2bNnj7k/cuRIGT9+vLON3h83bpxMmjRJ1q9fL5kyZZKGDRvKtWvXnG00YLtr1y5ZsmSJLFy4UFatWiWdO3fmcwEAAEijgv3dAQAAACClWrNmjTRv3lyaNGli7hctWlRmz54tGzZscGbZjh07Vvr162faqenTp0vevHllwYIF0qZNGxPsXbx4sWzcuFGqVq1q2mjQt3HjxjJq1CgpUKCAH98hAAAA/IFMWwAAACCRatWqJUuXLpXffvvN3N++fbv88ssv0qhRI3P/4MGDcuLECVMSwZI1a1apUaOGrF271tzXn1oSwQrYKm0fGBhoMnMBAACQ9pBpCwAAACTS66+/LhcuXJDSpUtLUFCQqXE7dOhQU+5AacBWaWatK71vbdOfefLkcR+kBwdLjhw5nG1ii4yMNItF+wAAAIDUg0xbAAAAIJHmzJkjM2fOlFmzZsmWLVvks88+MyUN9GdSGj58uMnYtZZChQol6esBAAAgeRG0BQAAABKpd+/eJttWa9NWqFBBnn32WenZs6cJqqp8+fKZnydPnnR7nN63tunPU6dOuW2/ceOGnDlzxtkmtr59+8r58+edy5EjR/gMAQAAUhGCtgAAAEAiXblyxdSedaVlEmJiYsztYsWKmcCr1r11LWWgtWpr1qxp7uvPc+fOyebNm51tli1bZp5Da996EhISIlmyZHFbAAAAkHpQ0xYAAABIpGbNmpkatoULF5Zy5crJ1q1bZcyYMdKhQwezPSAgQHr06CFDhgyRkiVLmiBu//79pUCBAtKiRQvTpkyZMvLII49Ip06dZNKkSRIVFSVdu3Y12bvaDgAAAGkPQVsAAAAgkcaPH2+CsC+99JIpcaBB1hdeeEEGDBjgbPPaa6/J5cuXpXPnziajtk6dOrJ48WIJDQ11ttG6uBqorV+/vsncbdWqlYwbN47PBQAAII0iaAsAAAAkUlhYmIwdO9Ys3mi27eDBg83iTY4cOcxkZgAAAICipi0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAAEhNQdvo6GjZtm2bnD171jc9AgAAAAAAAIA0LMFB2x49esiUKVOcAdv7779fKleuLIUKFZIVK1YkRR8BAAAAAAAAIM1IcNB23rx5UrFiRXP7u+++k4MHD8revXulZ8+e8uabbyZFHwEAAAAAAAAgzUhw0Pb06dOSL18+c3vRokXyxBNPyF133SUdOnSQX3/9NSn6CAAAAAAAAABpRoKDtnnz5pXdu3eb0giLFy+Whx56yKy/cuWKBAUFJUUfAQAAAAAAACDNCE7oA9q3by9PPvmk5M+fXwICAqRBgwZm/fr166V06dJJ0UcAAAAAAAAASDMSHLQdNGiQlC9fXo4cOWJKI4SEhJj1mmX7+uuvJ0UfAQAAAAAAACDNSHDQVj3++ONx1oWHh/uiPwAAAAAAAACQpsUraDtu3Lh4P2H37t1vpz8AAAAAAAAAkKbFK2j73nvvud3/+++/zcRj2bJlM/fPnTsnGTNmlDx58hC0BQAAAAAAAIDbEBifRgcPHnQuQ4cOlUqVKsmePXvkzJkzZtHblStXlrfffvt2+gIAAAAAAAAAaV68grau+vfvL+PHj5dSpUo51+ltzcbt169fmt+hAAAAAAAAAJCsQdvjx4/LjRs34qyPjo6WkydP3lZnAAAAAAAAACCtS3DQtn79+vLCCy/Ili1bnOs2b94sXbp0kQYNGvi6fwAAAAAAAACQpiQ4aPvpp59Kvnz5pGrVqhISEmKW6tWrS968eeWTTz5Jml4CAAAAAAAAQBoRnNAH5M6dWxYtWiS//fab7N2716wrXbq03HXXXUnRPwAAAAAAAABIUxIctLVokJZALQAAAAAAAAD4OWjboUOHW5ZPAAAAAAAAAAAkU9D27NmzbvejoqJk586dcu7cOalXr14iuwEAAAAAAAAASFTQdv78+XHWxcTESJcuXaR48eLsVQAAAAAAAAC4DYE+eZLAQOnVq5e89957vng6AAAAAAAAAEizfBK0VQcOHJAbN2746ukAAAAAAAAAIE1KcHkEzah15XA45Pjx4/L9999LeHi4L/sGAAAAAAAAAGlOgoO2W7dujVMaIXfu3DJ69Gjp0KGDL/sGAAAAAAAAAGlOgoO2y5cvT5qeAAAAAAAAAAASV9NWa9f+/PPPMnnyZLl48aJZd+zYMbl06RK7FAAAAAAAAACSM9P20KFD8sgjj8jhw4clMjJSHnroIQkLC5MRI0aY+5MmTbqd/gAAAAAAAABAmpbgTNtXXnlFqlatKmfPnpUMGTI41z/22GOydOlSX/cPAAAAAAAAANKUBGfaRkREyJo1ayR9+vRu64sWLSpHjx71Zd8AAAAAAAAAIM1JcKZtTEyMREdHx1n/119/mTIJAAAAAAAAAIBkDNo+/PDDMnbsWOf9gIAAMwHZwIEDpXHjxrfRFQAAAAAAAABAgssjjB49Who2bChly5aVa9euydNPPy2///675MqVS2bPns0eBQAAAAAAAIDkDNoWLFhQtm/fLl988YXs2LHDZNl27NhR2rZt6zYxGQAAAOAvUVFRcuLECbly5Yrkzp1bcuTIwYcBAACA1Bu0NQ8KDpZnnnlGkoNObtanTx/54YcfzKC7RIkSMnXqVKlatWqyvD4AAABShosXL8qMGTNMcsGGDRvk+vXr4nA4TDkvTTzQMl+dO3eWatWq+burAAAAgO+DtgcOHDB1bffs2WPulytXTrp37y7FixcXXzp79qzUrl1bHnzwQRO01SwJLcWQPXt2n74OAAAAUrYxY8bI0KFDzXi0WbNm8sYbb0iBAgXMlWBnzpyRnTt3SkREhAnc1qhRQ8aPHy8lS5b0d7cBAAAA3wRtf/zxR3n00UelUqVKJqCqVq9eLZMnT5bvvvtOHnroIfGVESNGSKFChUxmraVYsWI+e34AAACkDhs3bpRVq1aZZAJPqlevLh06dJBJkyaZsaUGcAnaAgAAINUEbV9//XXp2bOnvPPOO3HWaxkDXwZtv/32WzPp2RNPPCErV66UO+64Q1566SXp1KmT18dERkaaxXLhwgWf9QcAAAD2FN8JcUNCQuTFF19M8v4AAAAAtyMwoQ/Qkgg68Vhsmrmwe/du8aU//vhDJk6caLIgNMO3S5cupgzDZ5995vUxw4cPl6xZszoXzdQFAAAAAAAAgFSbaat1Zbdt2xbncjJdlydPHl/2TWJiYsyEY8OGDTP377nnHlOPTC9rCw8P9/iYvn37Sq9evdwybQncAgAApB3Xrl0zNWuXL18up06dMmNKV1u2bPFb3wAAAIAkCdpqaQKddVezYGvVquWsaav1Z12Dpb6QP39+KVu2rNu6MmXKyFdffXXTS950AQAAQNqkV4X99NNP8vjjj5tatgEBAf7uEgAAAJC0Qdv+/ftLWFiYjB492mS1Kp2Zd9CgQaZ0gS/pRGf79u1zW/fbb79JkSJFfPo6AAAASD0WLlwoixYtck6aCwAAAKT6oK1mKuhEZLpcvHjRrNMgblLQ19BsXi2P8OSTT8qGDRvko48+MgsAAADgiU5em1TjUwAAAMCWE5G50sFwUg6Iq1WrJvPnzzezAZcvX17efvttGTt2rLRt2zbJXhMAAAApm14R1qdPHzl06JC/uwIAAAAkT6btyZMn5f/+7/9k6dKlZmIHh8Phtj06Olp8qWnTpmYBAAAA4kMnstXJyO68807JmDGjpEuXzm37mTNn2JEAAABIXUHb5557Tg4fPmxq2+pEYUzsAAAAADt56qmn5OjRo6bEVt68eRmvAgAAIPUHbX/55ReJiIiQSpUqJU2PAAAAgNuwZs0aWbt2rVSsWJH9CAAAgLRR07ZQoUJxSiIAAAAAdlG6dGm5evWqv7sBAAAAJF/QVicCe/311+XPP/9M/KsCAAAASeSdd96RV199VVasWCH//POPXLhwwW0BAAAAUl3QtnXr1mYAXLx4cQkLC5McOXK4LQAAAIA/PfLII6Y8Qv369SVPnjySPXt2s2TLls389DWtn/vMM89Izpw5JUOGDFKhQgXZtGmTc7tepTZgwAAzH4Rub9Cggfz+++9xJkdr27atZMmSxfSzY8eOcunSJZ/3FQAAAKm0pq1m2gIAAAB2tXz58mR7rbNnz0rt2rXlwQcflB9++EFy585tArKuweGRI0fKuHHj5LPPPpNixYqZCX0bNmwou3fvltDQUNNGA7bHjx+XJUuWSFRUlLRv3146d+4ss2bNSrb3AgAAgBQctA0PD0+angAAAAA+UKtWLUmXLp3HbadPn/bpPh4xYoSZ82Hq1KnOdRqYdc2y1aSHfv36SfPmzc266dOnS968eWXBggXSpk0b2bNnjyxevFg2btwoVatWNW3Gjx8vjRs3llGjRkmBAgV82mcAAACkwvIIAAAAgJ1pINTTxLknT56UBx54wKev9e2335pA6xNPPGFKMdxzzz3y8ccfO7cfPHhQTpw4YUoiWLJmzSo1atQwJRyU/tSSCFbAVmn7wMBAWb9+vU/7CwAAgJSBoC0AAABSlcOHD8vzzz/vtk5LD2jAtnTp0j59rT/++EMmTpwoJUuWlB9//FG6dOki3bt3N6UQlAZslWbWutL71jb9qQFfV8HBwWa+CKtNbJGRkUywBgAAkIoRtAUAAECqsmjRIlmzZo306tXL3D927JgJ2OoEYXPmzPHpa8XExEjlypVl2LBhJstW69B26tRJJk2aJElp+PDhJmPXWrREAwAAAFIPgrYAAABIVXQysJ9++km++uorE7jVgK0GVGfPnm1KDvhS/vz5pWzZsm7rypQpY7J9Vb58+ZylGVzpfWub/jx16pTb9hs3bsiZM2ecbWLr27evnD9/3rkcOXLEp+8LAAAA/pXoUev+/fvNJWBXr1419z3VDQMAAAD8QTNPlyxZIjNnzpTq1aubgG1QUJDPX6d27dqyb98+t3W//fabFClSxDkpmQZely5d6tx+4cIFU6u2Zs2a5r7+PHfunGzevNnZZtmyZSaLV2vfehISEiJZsmRxWwAAAJB6BCf0Af/884+0bt3aDCQDAgLk999/lzvvvFM6duwo2bNnl9GjRydNTwEAAAAvdByqY9PYrly5It99953kzJnTuU4zWH2lZ8+eUqtWLVMe4cknn5QNGzbIRx99ZBalferRo4cMGTLE1L3VIG7//v2lQIEC0qJFC2dm7iOPPOIsqxAVFSVdu3Y1E6ppOwAAAKQ9wYkZmOrECHrJlw4wLRrI1cvPCNoCAAAguY0dO9YvO71atWoyf/58U65g8ODBJiirfWnbtq2zzWuvvSaXL1829W41o7ZOnTqyePFiCQ0NdbbRjGAN1NavX9+UcGjVqpWMGzfOL+8JAAAAKTBoq/XBtCxCwYIF3dZr5sChQ4d82TcAAAAgXsLDw/22p5o2bWoWbzTbVgO6uniTI0cOmTVrVhL1EAAAAKm+pq1mCWTMmDHOer3MTGtrAQAAAMlNx6hJ2R4AAACwddD2vvvuk+nTp7tlDugkCSNHjpQHH3zQ1/0DAAAAbqlEiRLyzjvvyPHjx7220YlzdXKyRo0aUXoAAAAAqas8ggZntdbWpk2b5Pr166ZG165du0ym7erVq5OmlwAAAMBNrFixQt544w0ZNGiQVKxYUapWrWom8dK6sWfPnpXdu3fL2rVrzdwMWn/2hRdeYH8CAAAg9QRty5cvL7/99pt88MEHEhYWJpcuXZKWLVvKyy+/LPnz50+aXgIAAAA3UapUKfnqq6/MZLlz586ViIgIWbNmjVy9elVy5col99xzj3z88ccmyzYoKIh9CQAAgNQVtFVZs2aVN9980/e9AQAAAG5D4cKF5dVXXzULAAAAkKqDtjt27Ij3E95999230x8AAAAAAAAASNPiFbStVKmSmXBMJ2/Qnxa9r1zXRUdHJ0U/AQAAAAAAACBNCIxPo4MHD8off/xhfmqtsGLFismHH34o27ZtM4veLl68uNkGAAAAAAAAAEjiTNsiRYo4bz/xxBMybtw4ady4sVtJhEKFCkn//v2lRYsWt9EdAAAAAAAAAEjb4pVp6+rXX381mbax6brdu3f7ql8AAABAohw+fNhZxsuVrtNtAAAAQKoL2pYpU0aGDx8u169fd67T27pOtwEAAAD+pMkEf//9d5z1Z86c8Zh8AAAAAKTI8giuJk2aJM2aNZOCBQuasghqx44dZjKy7777Lin6CAAAAMRb7MlzLZcuXZLQ0FD2JAAAAFJf0LZ69epmUrKZM2fK3r17zbrWrVvL008/LZkyZUqKPgIAAAC31KtXL/NTA7Y610LGjBmd26Kjo2X9+vVSqVIl9iQAAABSX9BWaXC2c+fOvu8NAAAAkEhbt251ZtrqPAzp06d3btPbFStWlP/7v/9j/wIAACB1Bm0BAAAAu1m+fLn52b59e3n//fclS5Ys/u4SAAAAkCgEbQEAAJCqTJ061d9dAAAAAG4LQVsAAACkKvXq1bvp9mXLliVbXwAAAIDEIGgLAACAVEVr17qKioqSbdu2yc6dOyU8PNxv/QIAAACSNGh77tw5mTdvnhw4cEB69+4tOXLkkC1btkjevHnljjvuSMxTAgAAAD7x3nvveVw/aNAguXTpEnsZAAAAtheY0Afs2LFD7rrrLhkxYoSMGjXKBHDV119/LX379k2KPgIAAAC37ZlnnpFPP/2UPQkAAIDUF7Tt1auXPPfcc/L7779LaGioc33jxo1l1apVvu4fAAAA4BNr1651G78CAAAAqaY8wsaNG2Xy5Mlx1mtZhBMnTviqXwAAAECitGzZ0u2+w+GQ48ePy6ZNm6R///7sVQAAAKS+oG1ISIhcuHAhzvrffvtNcufO7at+AQAAAImSNWtWt/uBgYFSqlQpGTx4sDz88MPsVQAAANhegoO2jz76qBnwzpkzx9wPCAiQw4cPS58+faRVq1ZJ0UcAAAAg3qZOncreAgAAQNqqaTt69Ggz626ePHnk6tWrcv/990uJEiUkLCxMhg4dmjS9BAAAABJo8+bNMmPGDLNs3bqV/QcAAIDUm2mrl5stWbJEVq9eLdu3bzcB3MqVK0uDBg2SpocAAABAApw6dUratGkjK1askGzZspl1586dkwcffFC++OILSnoBAAAgdQVto6KiJEOGDLJt2zapXbu2WQAAAAA76datm1y8eFF27dolZcqUMet2794t4eHh0r17d5k9e7a/uwgAAAD4LmibLl06KVy4sERHRyfkYQAAAECyWbx4sfz888/OgK0qW7asTJgwgYnIAAAAkDpr2r755pvyxhtvyJkzZ5KmRwAAAMBtiImJMckGsek63QYAAACkupq2H3zwgezfv18KFCggRYoUkUyZMrlt37Jliy/7BwAAACRIvXr15JVXXjFlEHTMqo4ePSo9e/aU+vXrszcBAACQ+oK2LVq0SJqeAAAAAD6gSQaPPvqoFC1aVAoVKmTWHTlyRMqXLy8zZsxgHwMAACD1BW0HDhyYND0BAAAAfEADtXr1l9a13bt3r1mn9W0bNGjA/gUAAEDqDNpaNm3aJHv27HFO7FClShVf9gsAAABItICAAHnooYfMAgAAAKT6icj++usvue+++6R69eqmVpgu1apVkzp16phtAAAAgD8sW7bMJBNcuHAhzrbz589LuXLlJCIiwi99AwAAAJI0aPv8889LVFSUybI9c+aMWfS2zsSr2wAAAAB/GDt2rHTq1EmyZMkSZ1vWrFnlhRdekDFjxvilbwAAAECSBm1XrlwpEydOlFKlSjnX6e3x48fLqlWrEvp0AAAAgE9s375dHnnkEa/bH374Ydm8eTN7GwAAAKkvaKsTO2imbWzR0dFSoEABX/ULAAAASJCTJ09KunTpvG4PDg6Wv//+m70KAACA1Be0fffdd6Vbt25mIjKL3tbatqNGjfJ1/wAAAIB4ueOOO2Tnzp1et+/YsUPy58/P3gQAAIDtBcenUfbs2c0MvJbLly9LjRo1TLaCunHjhrndoUMHadGiRdL1FgAAAPCicePG0r9/f1MiITQ01G3b1atXZeDAgdK0aVP2HwAAAFJH0FYndQAAAADsrF+/fvL111/LXXfdJV27dnXOwbB3716ZMGGCKef15ptv+rubAAAAgG+CtuHh4fFpBgAAAPhN3rx5Zc2aNdKlSxfp27evOBwOs16vGGvYsKEJ3GobAAAAIFUEbT05deqUWWJiYtzW33333b7oFwAAAJBgRYoUkUWLFsnZs2dl//79JnBbsmRJU+4LAAAASLVB282bN5vM2z179jizFyyaxaCXnQEAAAD+pEHaatWq8SEAAAAgbQRtdbIxrRM2ZcoUc3mZ6wRlAAAAAAAAAIBkDtr+8ccf8tVXX0mJEiVu86UBAAAAAAAAALEFSgLVr19ftm/fntCHAQAAAAAAAACSItP2k08+MTVtd+7cKeXLl5d06dK5bX/00UcT+pQAAAAAAAAAgMQGbdeuXSurV6+WH374Ic42JiIDAAAAAAAAgGQuj9CtWzd55pln5Pjx4xITE+O2REdHS1J65513TGC4R48eSfo6AAAAAAAAAJBigrb//POP9OzZU/LmzSvJaePGjTJ58mS5++67k/V1AQAAAAAAAMDWQduWLVvK8uXLJTldunRJ2rZtKx9//LFkz549WV8bAAAAAAAAAGxd0/auu+6Svn37yi+//CIVKlSIMxFZ9+7dxddefvlladKkiTRo0ECGDBni8+cHAAAAAAAAgBQbtP3kk08kc+bMsnLlSrO40nqzvg7afvHFF7JlyxZTHiE+IiMjzWK5cOGCT/sDAAAAAAAAALYK2h48eFCSy5EjR+SVV16RJUuWSGhoaLweM3z4cHnrrbeSvG8AAAAAAAAAYIuatq4cDodZksrmzZvl1KlTUrlyZQkODjaLZveOGzfO3I6Ojo7zGC3dcP78eeeigV8AAAAAAAAASNVB2+nTp5t6thkyZDDL3XffLZ9//rnPO1e/fn359ddfZdu2bc6latWqZlIyvR0UFBTnMSEhIZIlSxa3BQAAAAAAAABSbXmEMWPGSP/+/aVr165Su3Zts04nJXvxxRfl9OnT0rNnT591LiwsTMqXL++2LlOmTJIzZ8446wEAAAAAAAAgTQZtx48fLxMnTpR27do51z366KNSrlw5GTRokE+DtgAAAAAAAACQ1iQ4aHv8+HGpVatWnPW6TrcltRUrViT5awAAAAAAAABAiqlpW6JECZkzZ06c9V9++aWULFnSV/0CAAAAUpx33nlHAgICpEePHs51165dk5dfftmU+MqcObO0atVKTp486fa4w4cPS5MmTSRjxoySJ08e6d27t9y4ccMP7wAAAAApMtP2rbfektatW8uqVaucNW1Xr14tS5cu9RjMBQAAANKCjRs3yuTJk80kva60fNj3338vc+fOlaxZs5q5IVq2bGnG0Co6OtoEbPPlyydr1qwxV69pKbJ06dLJsGHD/PRuAAAAkKIybTUzYP369ZIrVy5ZsGCBWfT2hg0b5LHHHkuaXgIAAPiR1vPXQFyWLFnMUrNmTfnhhx/4TOB06dIladu2rXz88ceSPXt25/rz58/LlClTzGS+9erVkypVqsjUqVNNcHbdunWmzU8//SS7d++WGTNmSKVKlaRRo0by9ttvy4QJE+T69evsZQAAgDQowUFbpYNNHVRu3rzZLHr7nnvu8X3vAAAAbKBgwYLmsncd92zatMkE35o3by67du3yd9dgE1r+QLNlGzRo4LZej5moqCi39aVLl5bChQvL2rVrzX39WaFCBcmbN6+zTcOGDeXChQtej7HIyEiz3XUBAABAGi6PAAAAkNY0a9bM7f7QoUNN9q1mSpYrV85v/YI9fPHFF7JlyxZTHiG2EydOSPr06SVbtmxu6zVAq9usNq4BW2u7tc2T4cOHm7JlAAAASOOZtoGBgRIUFHTTJTiYGDAAAEjdtP6oBukuX75syiQgbTty5Ii88sorMnPmTAkNDU221+3bt68pvWAt2g8AAACkHvGOss6fP9/rNr2ka9y4cRITE+OrfgEAANjKr7/+aoK0165dk8yZM5uxUdmyZf3dLfiZlj84deqUVK5c2S2wr5P2fvDBB/Ljjz+aurTnzp1zy7Y9efKkmXhM6U+dH8KVbre2eRISEmIWAAAApPGgrdZti23fvn3y+uuvy3fffWcmXhg8eLCv+wcAAGALpUqVkm3btpmsxnnz5kl4eLisXLmSwG0aV79+fRPQd9W+fXtTt7ZPnz5SqFAhSZcunSxdutRM6GuNoQ8fPuzM1NafWnJDg7958uQx65YsWWImveOLAQAAgLQpUfUMjh07JgMHDpTPPvvMTJKgf8CUL1/e970DAACwCa1LWqJECeekrFq/9P3335fJkyf7u2vwo7CwsDjj4EyZMknOnDmd6zt27Ci9evWSHDlymEBst27dTKD23nvvNdsffvhhE5x99tlnZeTIkaaObb9+/czkZmTTAgAApE0JCtpqZsmwYcNk/PjxUqlSJZMxcN999yVd7wAAAGxKy0JFRkb6uxtIAd577z0zP4Rm2uoxo0kPH374oXO7zg2xcOFC6dKliwnmatBXM7m5ig0AACDtinfQVr/1HzFihKmrNXv2bI/lEgAAAFIjnfSpUaNGUrhwYbl48aLMmjVLVqxYYeqVArHpseFKJyibMGGCWbwpUqSILFq0iJ0JAACAhAVttXZthgwZzGWBWhZBF0++/vrr+D4lAABAiqC1Rtu1ayfHjx+XrFmzyt13320Ctg899JC/uwYAAAAgLQdt9Q+VgICApO0NAACADU2ZMsXfXQAAAACQhsQ7aDtt2rSk7QkAAAAAAAAAQALZBwAAAAAAAABgHwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALCRYH93AAAApGyHDx+W06dP+7sbSAK5cuWSwoULs28BAACAZEbQFgAA3FbAtnSp0nL12lX2YiqUITSD7N23l8AtAAAAkMwI2gIAgETTDFsN2D4lT0keycOeTEVOySmZfW22+YzJtgUAAACSF0FbAABw2zRgW1AKsicBAAAAwAeYiAwAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaIsGGDx8u1apVk7CwMMmTJ4+0aNFC9u3bx54EYBucpwAAAAAAKRlBWyTYypUr5eWXX5Z169bJkiVLJCoqSh5++GG5fPkyexOALXCeAgAAAACkZMH+7gBSnsWLF7vdnzZtmsm43bx5s9StW9dv/QIAC+cpAAAAAEBKRqYtbtv58+fNzxw5crA3AdgS5ykAAAAAQEpC0Ba3JSYmRnr06CG1a9eW8uXLszcB2A7nKQAAAABASkN5BNwWrW27c+dO+eWXX9iTAGyJ8xQAAAAAIKUhaItE69q1qyxcuFBWrVolBQsWZE8CsB3OUwAAAACAlIigLRLM4XBIt27dZP78+bJixQopVqwYexGArXCeAgAAAACkZARtkahLjWfNmiXffPONhIWFyYkTJ8z6rFmzSoYMGdijAPyO8xQAAAAAICVjIjIk2MSJE81M7A888IDkz5/fuXz55ZfsTQC2wHkKAAAAAJCSkWmLRF12DAB2xnkKAAAAAJCSkWkLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGbB20HT58uFSrVk3CwsIkT5480qJFC9m3b5+/uwUAAAAAAAAAaTNou3LlSnn55Zdl3bp1smTJEomKipKHH35YLl++7O+uAQAAAAAAAECSCBYbW7x4sdv9adOmmYzbzZs3S926df3WLwAAAAAAAABIk0Hb2M6fP29+5siRw2ubyMhIs1guXLggye3w4cNy+vTpZH9dJL1cuXJJ4cKF2dVI8ThPpV6cpwAAAAAg5UsxQduYmBjp0aOH1K5dW8qXL3/TOrhvvfWW+DMQUqp0Gbl29Yrf+oCkE5oho+zbu4fALVI0PU+VKV1Krly95u+uIAlkzBAqe/bu4zwFAAAAAClYignaam3bnTt3yi+//HLTdn379pVevXq5ZdoWKlRIkotm2GrAtkz9sZIpe4lke10kvctn98uepT3MZ0y2LVIyPYY1YDvjaZEyefzdG/jSnlMiz8y6xnkKSEaaMPD111/L3r17JUOGDFKrVi0ZMWKElCpVytnm2rVr8uqrr8oXX3xhrghr2LChfPjhh5I3b163L9S6dOkiy5cvl8yZM0t4eLh57uDgFDNcBwAAgA+liFFg165dZeHChbJq1SopWLDgTduGhISYxd80YBuWu4K/uwEAXmnAtvLNT6kAgHhOnFutWjW5ceOGvPHGG2bi3N27d0umTJlMm549e8r3338vc+fOlaxZs5qxbcuWLWX16tVme3R0tDRp0kTy5csna9askePHj0u7du0kXbp0MmzYMD4DAACANMjWQVuHwyHdunWT+fPny4oVK6RYsWL+7hIAAAAQ74lzdU6GKVOmyKxZs6RevXqmzdSpU6VMmTKybt06uffee+Wnn34yQd6ff/7ZZN9WqlRJ3n77benTp48MGjRI0qdPzx4HAABIYwLFxjRrYcaMGWaQGxYWJidOnDDL1atX/d01AAAA4JYT52rwNioqSho0aOBsU7p0aVNqae3atea+/qxQoYJbuQQtoaBlvnbt2uVxL2uZBd3uugAAACD1sHXQduLEiWbg+8ADD0j+/Pmdy5dffunvrgEAAAC3nDhXEw40UzZbtmxubTVAq9usNq4BW2u7tc0TrXerpRasJTnncAAAAEDSs315BAAAACA1TZzrC/6efBcAAABpOGgLAAAApOSJc3VysevXr8u5c+fcsm1PnjxptlltNmzY4PZ8ut3aZufJdwEAAJAGyyMAAAAAdr8yTAO2OnHusmXL4kycW6VKFUmXLp0sXbrUuW7fvn1y+PBhqVmzprmvP3/99Vc5deqUs82SJUskS5YsUrZs2WR8NwAAALALMm0BAACA2yiJoJPmfvPNN86Jc5XWmc2QIYP52bFjR1PKQCcn00Bst27dTKD23nvvNW0ffvhhE5x99tlnZeTIkeY5+vXrZ56bbFoAAIC0iaAtAAAAcBsT5yqdONfV1KlT5bnnnjO333vvPQkMDJRWrVpJZGSkNGzYUD788ENn26CgIFNaoUuXLiaYmylTJgkPD5fBgwfzuQAAAKRRBG0BAACAJJw4NzQ0VCZMmGAWb4oUKSKLFi3icwAAAIBBTVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGwn2dwcAAAAAJI/o6GiJioq67edxOBxSpEgRyZsjSDJlveGTvqVFDofIxauBEhlFLg0AAHBH0BYAAABI5TTIeuLECTl37pxPni84OFgmTZok6TPmkcDAyz55zrTIISI3oh2yYV86WbYtozgkwN9dAgAANkHQFgAAAEjlrIBtnjx5JGPGjBIQcHvBwStXrpiM3dAsBSUoKNRn/UxrHOKQmBtXpW7607pXZem2TP7uEgAAsAmCtgAAAEAqL4lgBWxz5szps+dUgUHpJTA4xCfPmVYFBYdK9hwi1Uudkl92xVAqAQAAGBRPAgAAAFIxq4atZtjCngKDM0hwUICEZYjxd1cAAIBNELQFAAAA0oDbLYmApBNg/tPPiL0MAAD+RdAWAAAAAAAAAGyEoC0AAACANGn8e29Li0bVU83rAACA1IOgLQAAAADbOn7siLzRu7PcV72YVCgZJvVql5Shg16Vs2f/SdDzlC4aKj//+K3bug6de8rUWT/4uMcAAAC3j6AtAAAAAFs6cvgPefzR2nLoz/0yetxn8uOKXTJoyAeybs1yadPyfjl37sxtPX+mTJkle/acPusvAACArxC0BQAAAGBLg/v3kHTp0smUz7+X6vfWlQJ3FJa6DzaUT2csklMnjsnYdweadvVq3yUfjhsmvbo9K/eUySF1a9wpM6dPcj6PblddX3jSZNxa92OXLXj91efl5U5PyKQJI6R21cJSrUJemfD+ULlx44aMHNZXalTML/ffW1y+mvOZWz9HDX9TGj5YXiqVzi4N7ist748eJFFRUcm0lwAAQGpE0BYAAABIq65d875cv37TtgGRkRIQeU0CPLTVdbGXhNIs2l9WLZGnnnlBQkMzuG3LnSefNG3RRn5YOE8cDodZN+Wj96R0mbvl6+/XS6cu/yfD3npVVkf8bLbN+3a1+Tns3Y8kYsOfzvuerFu7Qk6dPC6ff/mzvN5/hAnsvtjhMcmSNZt8uSBC2rR9Xga92VVOHP/L+ZhMmTPL8FEfy8IlW+WNgaNl7uyp8tmUcQl+zwAAAJZg5y0AAAAAacsTT3jfVrWqyMB/M1mNZ54RiYw0N0Oio6X4xYsSlC6TBAQGSeRdZeV0nyHOpvn6vCCBly66Pd3RKV8nqGuHDu43AdniJUp73F68eGk5f/6snPnnb3O/cpWa0vml3uZ2sTtLytZNa+WzKeOl9n0NJEfO3GZ9lizZTMD3ZrJmzS79Bo2RwMBAubP4XfLJpDFy7doVefHlPmZ755dek48njpLNG9dIk0efNOu6dOvrfHzBQkXlYOcesui7ufL8i68m6D0DAABYCNoCAAAAsC0rk/ZWKlWuEef+Z5+OT/DrlbyrrAnYWnLmyiN3lSrnvB8UFCTZsueQf/4LFisN0H4+bYIcOXRQrly5ZMopZA7LkuDXBgAAsBC0BQAAANKquXO9b3MJXBozZjhvRl6+LAf27pWM2YtLUFAGccRqe2LE5NvuWuGixSUgIEAOHNgrD0nzONt1vWbFWlm0vhIcnM7tvvYh9jqRAHHExJhbWzevk949npNuPftL7boPSVhYVln03RyZ+vH7Pu0XAABIWwjaAgAAAGlVaGji2kZHiyMkRBwhoeIIjvscjoQ8rxfZs+eUWnXqy+zPP5LnOnZ3q2v796kTsnDBF9K8ZVsTVFXbt25we/y2revdSivohGbRMdHia1u3rDMTpL3Y9XXnumNHD/v8dQAAQNrCRGQAAAAAbKn/4LFy/XqkPN+uqWxcHyHHjx2RiBU/SYdnm0iefAWkR++3nG23bF4rn0waLQf/+F1mTp8kPy76Wp5t39W5vUDBIrJu9XIT8NVauL5StGgJ06/vv50jhw8dkOlTJ8iSH7/12fMDAIC0iaAtAAAAAFsqWqyEzPt2tRQsVEx6vvyMPHx/WRnwxktSo+b98sXXKyVbthzOtu2ff0V2/rpFWjapIZPGvyN9+o2U++5/yLm9z5sjZM0vS+XBWiXkscbu9W9vR72Hmkp4x+7y9sCe0qJxDdm2eZ285DIxGQAAQGJQHgEAAACAbd1RsIi8M/qTW7bLnDmLjJ0w0+v2eg2amMWV1qHVxeLpdT7/ckmcdctW/+Z2v3ffYWZxFd6xm9fXAQAAuBUybQEAAAAAAADARgjaAgAAAAAAAICNUB4BAAAAQIoWu1wBAABASkemLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAABAGhATE+PvLsALh8SIw3xGAewjAABgUNMWAAAASMXSp08vgYGBcuzYMcmdO7e5HxBwe8HByMhI8zMm+roEkAeSaA79LyZKLl/8Ry5cdsi5y+TUAACAfxG0BQAAAFIxDdgWK1ZMjh8/bgK3vnD9+nU5ffq0pL8SKIGB6XzynGmRZtdGx4jsPxooizeHSTSZtgAA4D8EbQEAAIBUTrNrCxcuLDdu3JDo6Ojbfr5du3bJiy++KOUbTpJMOe7ySR/TIodD5Or1QLlyLUAcQmkEAADwPwRtAQAAgDRASyKkS5fOLL54rkOHDknuM9ESFsSfFAAAAL6WIoomTZgwQYoWLSqhoaFSo0YN2bBhg7+7BAAAAPgc414AAACkiKDtl19+Kb169ZKBAwfKli1bpGLFitKwYUM5deqUv7sGAAAA+AzjXgAAAKSYoO2YMWOkU6dO0r59eylbtqxMmjRJMmbMKJ9++qm/uwYAAAD4DONeAAAAWGxdgEpnpd28ebP07dvXbfbbBg0ayNq1az0+JjIy0iyW8+fPm58XLlxIhh6LXLp06d/X+3unREddSZbXRPK4fO4P52ecXMeT9Xrq2tFrEhMZk2yvi6R3/fR1vx5Tm4+KXPrf6RKpwL7TkuzHlHU8HZWjEikcUKnJaTmd7MeT9ToOnZ0pjUnouJcxL5IKY174GmNepIYxr/V6inFv6nM6mce98R7zOmzs6NGj2nvHmjVr3Nb37t3bUb16dY+PGThwoHkMC/uAY4BjgGOAY4BjgGOAYyBlHgNHjhxxpDUJHfcy5vX/ccrCPuAY4BjgGOAY4BjgGJAkHPPaOtM2MTQ7QWvgWmJiYuTMmTOSM2dOM8stfP/tQKFCheTIkSOSJUsWdi84nmArnKPAMZWyaLbBxYsXpUCBAv7uiu0x5k1e/HsCjinYGecocEylzjGvrYO2uXLlkqCgIDl58qTber2fL18+j48JCQkxi6ts2bIlaT8hJmBL0Ba+wvEEX+OYAsdUypE1a1ZJixI67mXM6x/8ewKOKdgZ5yhwTKWuMa+tJyJLnz69VKlSRZYuXeqWOav3a9as6de+AQAAAL7CuBcAAAApJtNWaamD8PBwqVq1qlSvXl3Gjh0rly9flvbt2/u7awAAAIDPMO4FAABAignatm7dWv7++28ZMGCAnDhxQipVqiSLFy+WvHnz+rtr+O/SvIEDB8YpSQEkBscTfI1jChxTSEkY99oX/56AYwp2xjkKHFOpU4DORubvTgAAAAAAAAAAUkBNWwAAAAAAAABIawjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAgAeDBg0yk18CAAAAqRVjXsC+CNoijueee04CAgKcS86cOeWRRx6RHTt2ONu4breWOnXqOLd//PHHUrFiRcmcObNky5ZN7rnnHhk+fDh7O4154IEHpEePHnHWT5s2zRwXlgsXLsibb74ppUuXltDQUMmXL580aNBAvv76a7HmSjx48KA8/fTTUqBAAdOmYMGC0rx5c9m7d2+yvicknRMnTsgrr7wiJUqUMJ9x3rx5pXbt2jJx4kS5cuUKux5+sXbtWgkKCpImTZp43K7nM10ApDyMeeFLjHsRX4x5YUeMee2JoC080iDt8ePHzbJ06VIJDg6Wpk2burWZOnWqs40u3377rVn/6aefmkBd9+7dZdu2bbJ69Wp57bXX5NKlS+xtxHHu3DmpVauWTJ8+Xfr27StbtmyRVatWSevWrc1xc/78eYmKipKHHnrI3NZA7r59++TLL7+UChUqmMcj5fvjjz/Mlzs//fSTDBs2TLZu3WoGDnoMLFy4UH7++WePj9NjA0hKU6ZMkW7dupnz0rFjx5zr33vvPbl48aLzvt7WdQBSFsa8SE6Me8GYF3bFmNemHEAs4eHhjubNm7uti4iI0HRHx6lTp8x9vT1//nyP+04f+9xzz7Ff4bj//vsdr7zySpw9MXXqVEfWrFnN7S5dujgyZcrkOHr0aJx2Fy9edERFRTm2bt1qjrk///yTvZpKNWzY0FGwYEHHpUuXPG6PiYkxP/U4+PDDDx3NmjVzZMyY0TFw4ECzfsGCBY577rnHERIS4ihWrJhj0KBB5tixnD171tGxY0dHrly5HGFhYY4HH3zQsW3bNrfXGD58uCNPnjyOzJkzOzp06ODo06ePo2LFimbbypUrHcHBwY7jx4+7PUaP7zp16vh8f8Ae9Bykx8PevXsdrVu3dgwdOtTtPFajRg1zXOmit3UdgJSDMS98iXEv4oMxL+yIMa99kWmLW9IM2RkzZphLlrVUwq3ope3r1q2TQ4cOsXdxUzExMfLFF19I27ZtTdmD2LS8hmZ5586dWwIDA2XevHkSHR3NXk1l/vnnH5Nh+/LLL0umTJk8ttESLK51tx577DH59ddfpUOHDhIRESHt2rUzpRV2794tkydPNperDx061PmYJ554Qk6dOiU//PCDbN68WSpXriz169eXM2fOmO1z5swxz6tZvps2bZL8+fPLhx9+6Hx83bp15c4775TPP//cLct35syZpg9InfS40LItpUqVkmeeecZcSWKVbNHLqnW7ZoLrord1HYCUizEvkhLjXjDmhV0x5rUxf0eNYc+sg6CgIJP9qIseJvnz53ds3rzZ2UbXhYaGOtvoYmXeHjt2zHHvvfeaNnfddZd5vi+//NIRHR3tx3cFO2YcnDx50hwnY8aMueVzffDBByaz0sqSHDx4sOPAgQNJ1HMkp3Xr1pnj4Ouvv3ZbnzNnTuf55bXXXjPrtF2PHj3c2tWvX98xbNgwt3Wff/65OW9ZVwpkyZLFce3aNbc2xYsXd0yePNncrlmzpuOll15y266Zk1amrRoxYoSjTJkyzvtfffWVycL0lh2MlK9WrVqOsWPHmtuaua2Z2suXL3ceY3qMaFa2Lnpb1wFIORjzwpcY9+JWGPPCrhjz2heZtvDowQcfNPVoddmwYYM0bNhQGjVq5JY9q7X7rDa6aM1RpRlqWotSs+A08+3GjRsSHh5uaobpN8yAy5dG8d4ZmoWpRfs1s7FmzZoyd+5cKVeunCxZsoQdmkrpuUfPLfo5R0ZGOtdXrVrVrd327dtl8ODBJjPbWjp16mRqbesEZrpds6f0SgHXNjq53YEDB8xz7NmzR2rUqOH2vHqcudIsyv3795srCZRm8z755JNes4ORsmntbD0Gn3rqKXNfs/611rbW+1Kaua3nn/vuu88selvXAUhZGPMiuTDuhTeMeeFPjHntLdjfHYA9aRBCyyFYPvnkE8maNat8/PHHMmTIEGcZBNc2sZUvX94sL730krz44ovmj9qVK1eawTHShixZspjJwzxNwqDHk5Y9yJYtm+zduzdezxcWFibNmjUzix6H+mWC/rS+MEDKpOcRLX+gAwZXWo5AZciQwW197CCpBmTfeustadmyZZznDg0NNdv1y6QVK1bE2a7HX3zlyZPHHHs6CWOxYsVMqQVPz4nUQYOz+qWja+kW/YM7JCREPvjgA+nVq1ec81PsdQDsjzEvfIVxL26FMS/siDGvvRG0RbxoQEVril69ejVRe6xs2bLm5+XLl9njaYjWgdRapbFt2bJF7rrrLnNMtWnTxtQJHThwYJy6thps06CbZrh5Oia11uSaNWuS9D0g6WkGrAbeNRDWrVu3BGeuan1aDfh6+xJJt2uWth5HRYsW9dimTJkysn79elMb12Jl1Lp6/vnnTeZlwYIFpXjx4lK7du0E9RUpgwZrp0+fLqNHj5aHH37YbVuLFi1k9uzZ5stIRR1bIHVhzIvEYtyLW2HMC7thzGt/BG3hkV6KrEEOdfbsWRNM0QCaZpndSpcuXUzwrV69eiawoZcoazakZlXGvtwYqZseC3rsdO/e3QS7NEPt+++/NwGP7777zrTRyaI0W1EvTdfbeul7unTpzORSw4cPl40bN8qff/5pgrrPPvus+QIgffr0JmtbJwXq06ePv98mfEAn/dIAqH7+OiHY3XffbYL6+vlrJnaVKlW8PnbAgAHStGlTKVy4sDz++OPmcVoSYefOnebc06BBA3Pu0WDbyJEjzRcGx44dM8eiTmimr6mlXDT4pre1H1qGY9euXc5sX4tmd2smjT6vlmRA6qQTi+m/fR07djRXBbhq1aqVyUiwgrYAUjbGvPAVxr2ID8a8sBPGvCmAv4vqwp6TMuihYS068VO1atUc8+bNc7bR9dbEY7Fpu8aNG5tJgNKnT+8oUKCAo1WrVo4dO3Yk47uAXWzYsMHx0EMPOXLnzm0mH9PJemIfO+fOnXO8/vrrjpIlS5pjJm/evI4GDRqYdjExMY6///7b0b17d0f58uXNxE96TFaoUMExatQoJrhLRXQSw65duzqKFSvmSJcunfmsq1ev7nj33Xcdly9fvum5Z/HixaaAfoYMGcykY/q4jz76yLn9woULjm7dupnzkT53oUKFHG3btnUcPnzY2Wbo0KFmoil9XT0P6uRnrhORWfr3728ma9T+InVq2rSp+XfMk/Xr15vjcPv27cneLwC+xZgXvsa4F/HBmBd2wZjX/gL0f/4OHAMAkFJo9uXff/8t3377rb+7AgAAACQJxryA/1EeAQCAeNBJ9X799VeZNWsWAVsAAACkSox5AfsgaAsAQDw0b95cNmzYYGqZ6sRpAAAAQGrDmBewD8ojAAAAAAAAAICNBPq7AwAAAAAAAACA/yFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAACxj/8Hiol0o4LcYEIAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHvCAYAAAAvoP1zAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAe/9JREFUeJzt3QmcTfX7wPFnFmYsY+xbloTskTVLKpRsEb+ilAlRCqG/pGzJEiGRUIlkKRSVpGSd7LuslYSsyb6NMXP/r+db53bvzL3MjDtzz8x83r1Oc+8533vu95575vrOc5/zfAMcDodDAAAAAAAAAAC2EOjvDgAAAAAAAAAA/kPQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAACka4MGDZKAgACz3H777f7uDhLpmWeecb5/999/v7+7gzSMzwoAAJCSCNoCAGADJ06ckDfffFPuu+8+yZcvn2TMmFGyZMki5cqVk44dO8p3330nDofD391EOgqAui4hISGSP39+eeCBB2Ts2LFy5coVf3cVNrRu3Tp58sknTUAzNDTUfIYVLlxYqlWrZj7HJk+eHO8xGmi3zjM9/wAAAPCP4H9/AgAAP3n//ffl5ZdflqtXr7qtj46Olt27d5vl448/lgMHDpDdlQweeughyZo1q7kdHh7u7+7Y0rVr18wXC7qsWLFC5s6dKytXrpTgYIaS+MdHH30knTt3jvfl0uXLl+XPP/+UTZs2yRdffCHPPfec3/oIAACQmjDSBgDAj0aOHCl9+vRx3g8KCpImTZpIlSpVTObZb7/9Jt9//70JlsG78+fPS7Zs2ZL02Fq1apkF8b399tvm58WLF2XWrFny66+/mvtr1qyRhQsXSosWLZL1+S9cuCBhYWHJ+hzpyZgxY6R8+fJSv35981njK6dPn5bu3bs7A7aFChWS//3vf5I3b17zHu7cuVNWrVolyfWFgj6vZoMjeT8rAQBAyqI8AgAAfqIZtK+99przvgY4Nm7cKF999ZUMGDBA+vfvL5988okcPnxYPvjgA8mcObPb448cOSK9e/eWChUqmExRvRxZM3Gfeuop2bBhw03rMR47dkwiIiIkd+7c5o/4Zs2ayS+//GLabtmyRR5++GETMMuRI4c89thjph+uNOPS9RL633//3Vw6X7ZsWdOX2267TXr16mWCNnEDPK+88ooJHGk/9Dm0HISWhXjwwQfl008/jZetF/e5NJg9atQoKVOmjAnWtGvXzrTbtm2bvPDCC1KjRg3z/JkyZTJ9KVq0qLRu3Vp++umnmx4XVwcPHjSZgSVLlnTuS/dbu3Zt89r27NkTb39Lly41ASsNXGnf9NhWrlxZBg4caF57XPqc1vNrXzZv3ixNmzaV7Nmzm/f83nvv9djvG3G95PxW6rz+3//9n1m0X7Nnz3bbtnfv3njtb/Wc/Pvvv+XFF180x06DilOmTHG21aCfvha95D5nzpzmnNy/f/9NX4N+4aG/Z5UqVTLnmvapRIkS5nkOHToUr31SzqEb1dWNe+7+8ccfZv2kSZOc6zJkyGB+5yx6fuvrtLYPGTJEfOHrr7+Whg0bmpIF+j7t2LHDJ/vVY+JaMkPvv/POO9K3b18ZNmyYed5Tp07JnDlz4r33mrFt0c87T8cqbgkFDQLrFwa5cuUyv2PW76F+yaDr77zzTnOO6HHV36Pq1avL0KFD5dKlS/H6/vPPP5vzU88/3Ze+30WKFJF69eqZ/us57Y1+tulVEno89RzRz7733nvPYymbmJgYc8WEfu7pZ672TfuvJUc+/PBDuX79eoLOG2+fG4n9rLQ+37SchfZDf1/r1q0ry5Ytk2nTprntAwAA+IkDAAD4xfPPP69/2TuXL774IsGPXblypSNHjhxuj3ddAgMDHaNHj3Z7zMCBA53bc+bM6bj99tvjPS5PnjyO+fPnO0JCQuJtK1mypOPKlSvO/S1fvtxte7169Tz2pVq1am6P+/nnn73221rat2/v1ve4z3Xvvfe63W/evLlpN378+BvuNyAgwDF16lSvx6Vo0aLO9SdOnDDH40b7mzhxotu+evXqdcP2t912m2Pnzp1uj9HntLZXr17dkSFDhniP0/dj9+7dCT4/7rvvPudj9XZCRUREuD2v5eLFi44BAwa4bYt7HG/1nMydO7ejdOnSbo955513TLtvvvnGERwcHG+feh7XrFnT62tds2aN2a+3PoWHhztWrVrl9piknEOuxy1uH+KeuwcOHHBu0/PWWl+hQgVHVFSUIyYmxlG7dm3n+rp165p1vtCpUyfTf9f+VKxY0TFq1CjHsWPHkrxf/exy3edXX31108e4vvfeFutYuZ7Pd999tyNLlixu7bZu3Wra5cqV64b702N84cIFZx927drlyJw58w0f891333nsc758+RxVq1b1+Jhu3bq5vVb9/dH38UbPU6dOHbe+3ei8ifu5of1K7Gel7i9//vwef0+bNGni8XMAAACkLMojAADgJ5qRadFs1oRean727Flp2bKlnDlzxtzXzLD27dubjE7NhtTsqdjYWJMhqWUWdHKzuDTjUzPjXnrpJZN9pvUo1V9//SWPPvqoybrq2rWr2de8efPMNr00fsGCBdKmTRuP/dIMrebNm0vFihXNxGmaNaz0p5aB0OxhFRgYaLK+NPtNJ7fSTDit57t161b55ptvTJba1KlT5fnnnzdtPImMjDSTtGl2sLa3LvXWTLJ77rnHZFVa2WPnzp0zx1r7oW01M04zJvW43YjW39TjYb0/eox1n0ePHjVZptoHV5ohrJefW7R/eiy1vWYQaqadZu3pe7dr1y6P9WA1G1WzTNu2bWsym7UkgYqKipJ3333XZGemJG9ZdsWLFzfZxL48JzUTU5cGDRqYTGY99pp9rTVRdRIrKxNRMxQ7dOhg3pMZM2bI2rVrvV4Grr9Tuk9lZcpq3/Sc1vdAz41WrVqZc9uqZ+zLc+hmNJNY96nniGZ8Dh482Pw+rF692mzX2/oa9XfGFzRjXzP4P//8c/O+aHbv9u3bzaJlWjTT/emnnzbHLW5m/43osdJzxcow1c+BO+64wxxHzTLXbHGdjMz1fLJqSU+cONFk6auqVaua42rRbNm49HNCf3e0n5oBr7+LmuWq9HdHM1f1vdbzQ/ujtcD19ernnB5jrSGumf5Kfy/1/LIeqxm3muGsNXg1m1cnVrtRBree9/o5Zb1P+jg1fvx4c15Z57mWjnAtD6GvvWbNmmb/Wv7Gyk7WdpqN60vePiv18/348ePOdo0bNza/m99++61ZAACADaRwkBgAAPzLNcOrRo0aCX6cZh+6ZkEtWrTILTs0a9as8bKqPGW2zZgxw7nNNVtRl7lz55r1sbGxjoIFCzrXayapt4wuzeKzXLt2zVGuXDnntkKFCsV7HQcPHnTMmzfP8d5775lMv7fffttkolqPGTx4sNfnuueee9yyd+Pavn27eX3vvvuu2e+QIUPcHu+aXekt03bMmDHO9c8991y859DsuePHjzvva8ai1V6zmC9fvuzc9v7777s9v2Yze8qY0wzCI0eOOLe1aNHCua1y5cqOlM609bRoNuOOHTuS5Zzs0aNHvD7Nnj3brc1HH33k3KbZgq6Zya6vVd97a71mAP/9999u751rFrW2vZVzKKmZturHH390Zr9qNrFrlvucOXMcyWnfvn2OQYMGOUqVKuXWx7CwMMczzzzj2LNnT4L3pe/djc6bYsWKOT9XvJ2rehw9cW2jy4IFC7z24+zZs+b8mzRpksns1vfONctVrwiwdO/e3bl++PDh8fZ1+vRps3g7X2fOnOn1XGzbtq1Zf+rUKUdQUJBz/eOPP+72HHrf2qbttL0vM209fVYePXrULeO6devWzm1Xr16Ndz4AAAD/INMWAIBUxjWzME+ePNKoUSO3urh6f+7cufHautJMNdeMNq2PaLXVTEbNEFWaGVesWDGTCaisTEpPNPPNovt4/PHHTR1XpRlompmmmZNat1Rr6d4sm8vKWvNEMzat7DpXmjmoNRs1izKp+7ZotqeVPTh58mSTEak1K0uVKmUyAjWjT1+P0mw91/qgWm/VNQtT+6R1Ui16rD1lVmuGYsGCBZ339bksNzr2cWldS19PRLZo0SJzDPT909qXWov0rrvu8tk5qfr16xdv3aZNm9zuaw1O1/O2Tp06snz58niPs7JVrWOnWbPe6MRqmuXo63MoIbTGqZ7Peqw1m9jKKNZsYj2PEkrrompGcFydO3f2OvGU1n7V31FdNINVs281G1f3o3VNNWu+dOnSCXp+zTLX3w/NCPd07DTjVT8TNGNZf3eSSidS09+TuDST+9VXXzXPr5OTJeR90wzgcePGOc89rb2rr1d/77SmsW73NmGbfsbF/Qx1PRe1NrWVPa9Z9hb97HOl961av9pO27v+/twqT5+V2jfXuruudW410/yJJ55wq5MLAAD8g6AtAAB+opMc6WXZSicA0z+iEzLpi+tkVlbQ0JXrOm+BPg2kuV6erxOBuW5zDVS4ttPAiDf6OG/9UHopsa7TS90TcvmtlgTwxlMgScs96AReOsHarezboqUZNBCll5Nr0FKDea6TRelkQhqI1EmS9Di7BkHivna95FovBdf93Oh9iTsRmgZQEnLsk4sGfCyvv/66ucxaz1l9LzVApoFcX52Tejw9BVb1uSw6kVjckgSeni9un27GKoPhi3Mo7iRUCTnXdFK00aNHu73Hevl6YuhEW1qGIi4tY+EtaGvR8gRa0mTx4sVugd/ETEKlbTt16mQWDYxqcF6D4fPnz3f2S4+NTlB2K0Fbb0FkDb5aXzLciOv7ocdGz3EtZ6Drtc+uXypomQX9rNLzPi49V+MGdF3PReu8jXsexj1f49739vuRlPPK2/Fy/Z1SWqbmRvcBAIB/+KZAFgAASFKGnesf6l999VWCHuda51GzV+NyXad1Hb1liXnjqdZqQpw8edJrP5TWfdS6kgsXLnQ7Bvv37zfZhRqU0LqXCaFB0Li0ZqRrsE3rjmowTvfradb4hOjRo4d5HZodqEGhbt26mTqaSmulWllzepxdA1xxX7s+vxWwtdon5H2x08zt2jetXWrRgJwvz0lP76l13lguXLhgAqve9u3KtU8FChQwAT1vi2aj3so55FpzNm7/rC9mvNF9P/vss/GC8tqn6OhoSS4aWNUvJfTLCa1RrEF5rfmqX+BofWINtrpmhyeG1ofVLGEN0OoXUlrDOqHH42a8nSdat9ai2err1683gU09vr179/a6P33/9RzSLyD0eGiNWivbXYPN3o6BZpy7ZtDGPRet8zZuXd6452vc+9bvR9w6xq7nldZr9nbeJ+R4uf5Oefrsdq11CwAA/IegLQAAfqKZdK6ZWl26dDETAsWlgRudKMz6w7pWrVrObRpQ0gw5i7Zxve/aNrnpRFyufbYu+bWyijWjTLP4XAMdTZo0MRMW6XHYt2+fW4mBxNIgiiudzEuzN5VrXxJKS0JoYEQnZKpXr54J2Grg1jU4dOjQIfO82kYvJbdoBq5rkGX69Olu+07u90WzfzXgq4ve9gUNrG/bts153/V9TM5zUktRuLImZ1N//PGHmcDJk7h90smfNKvSddGgrAairQnvknoOuQbB9Dy2Mhn1fJ8wYcINX59m2P7444/O/VhZjloWwpq8LyH0WGiAMu7imr2tx0En4tLyFkWKFDGv35owUCfG0knBNGCnk/Bp+Y4bfbkT93J7LS+gk+d5+hLI9fL8uAFD1+ewJgVLCtf3Ts8ZfU81AK2THOoEh55oyQZ9r3QSOi1J0LNnT3MM3nvvPWcb1+x6V/oZ5/pZEPdc1Em9lPbD9XNeJz9z5Xpf21nnYtzj5Dop2vDhw+Nl3iaG9s31CyEti2HRQLfrfQAA4D+URwAAwE/0kts333xTXnvtNXNfgyUabNDLs++++27zR/Vvv/1mZhfX4GGDBg1MO83u1MdZQQqdpVzrX+ol0BrQsjI69fGaKZpStKamBoW0zqkG6VzrWuol01YJBQ1GWEGtIUOGmKCeBgR11vSEXvLriWv9V6UzwWvNSQ2muAaUE0qzLjVop3UqNVNQs+80UPnll18622hQSAO2SgNgVl1ffU7NGtbawBr8dQ3MaB1RDVanBqNGjTI/NctU31PXLEmt+WtJznPykUceMXVyrRIG+uWGBho1I3HGjBles1GfeeYZc35pRrSeX9pfzf4sUaKEOc80uKq1f/V3S+uQau3mpJ5DrhnimgWpv78afNO6ukeOHPH6OK0jqxmuFg0WagCxWbNm5v7IkSOlYcOGPgu8a01Z13rH+oWJvkataarZtkmlGdBanmHYsGEmIKj1YPX3RQOmS5YsMa/T8vDDD7s9Vr/QsWgpAi27oYFyXfQ9TCh976zzU7P5n3vuORMAnzdvnuzdu9fjYzToqvV89fhqBr1mZOu57hq0jBs8daXneGRkpGkT91zU7GmrjIK+jilTpjiD//r5p0FyDcTq57tF3werRIiWNdByIHpslWb86uvSfyduVBc6IfR16meQddWDfqmkXzDoF0+6Tn83AACADfhpAjQAAPAvnZ3edcZ4b4vr7OErV650ZM+e3WvbwMBAx6hRo9yex3Xmc5153JXO2u5tm7fZ3ePOUt6kSROPfalSpYrj8uXLzse99dZbHtuVL1/etE3Ic8WdSd3y8MMPe9y36+vTZerUqTc9LrNnz77pe9KrVy+359f7N2pfsGBBx86dOxM0C/zN3rMbcX3P9HZCxT1O3hY997Zv3+72WF+fk66++uorR1BQULx9hoWFOSpXruz1ta5evdqRO3fum74ePb9u5Ry6cuWKo2TJkh4f17hxY4/n7qVLlxylS5d2rm/VqpVzfx07dnSuL1SokOP06dMJfg9vRI+PvkedOnVyREZGOnwl7u+nt0Xfq/Pnz8d7bz21LVeunFu/PX0uuNLXExwcHG8/WbNmdbRs2dLjeTZ8+PCb9nncuHEez1c9r7SPnh7zwgsvuPXt4sWLjrp1697weWrXru24cOGC2+P69evnsW3VqlUdefPm9fi5kdDPSl2fP3/+ePsOCAhw+x3Q+wAAwD8ojwAAgJ/prPV6ma7O1q1ZnZpVqJcUawanZnhqZqFmx+mkOBa9vHnnzp0mu1MzdrWtZn3qJc+aHar1RnVbStLJfDRTUGeQ1wm0NJvrpZdekmXLlrlNHtWnTx9zybhmnOql0ZoNp5m4K1euNJN13Qq9rFszOfW59XhoVqVm/1lZbomh74VmD2pGmmYhatabvi/6/mgt3mnTpplL213pfc0s1ExTzTTU16evSS/B1wnNtPyDp0mN7E4zZPX1ayZer169zOvQjGpXyXlOaratlhDQ59BzSTMbmzdvbuqWVqhQwevjtESCZnzrsdcMUM381UvQ9fF6X0uU6Pul+72Vc0gv/9e6x5rJqvvW+5ptqnVhvdVT1UvxrQxQzUDXy/ItWgtWM3+t2rNWpvqt0sxdzdT84IMPzPntK3qc9fVr1rBmreox02Otvy+aOarHd+zYseYc0PMo7nurnxv6Wec6IWJi6evRrFXti37+aMZy48aNzXN6O0e0BISWoNCrGLSMhJ6z2mcrE/Xrr782ZVG81YrVcgi6XbOFte+a7fvuu++6lVew2urx0TI3Ogmb1rnV59Fs8fvuu08mT55sPuPjfv4NHjzYnHt6Luhnif4b0LdvX/NZGXdCvsTS16uZvm3atDHnrO5Ps38121n7lJBMYwAAkLzMV6fJ/BwAACAN0iCD6yzwGnh2rZ8JALAnnfhOy4bEDZRrCRgNfG/YsMHcf/DBB+WHH37wUy8BAEjfqGkLAAAAAOmI1l7WOr5PPvmkuRJAs721/rJeQWAFbK0rQQAAgH8QtAUAAACAdEYn6Rs3bpzXkihvvPGGmRgTAAD4B0FbAAAAAEhHtH6v1sddvny5/P7773LmzBlTN7dw4cKmPvBzzz0n1apV83c3AQBI16hpCwAAAAAAAAA2EujvDgAAAAAAAAAA/kPQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAEhmt99+uwQEBJglrXnmmWecr23FihX+7g4AAABs5I8//nCOFe+///5024ebYUwNwBOCtgBsYdCgQc6Bii6LFi3yOpCZNGmS3/oJAAAAJIdLly7JO++8I3Xr1pVcuXJJaGioFCtWTJo2bSozZsyQa9eupUg/pk2bZsbmupw9ezZFnhMAEF+wh3UA4HdDhw6Vxo0b+7sbAAAAQLLbvXu3NGvWTH7//fd4WaK6fPvtt1K+fHmpVKlSigRtV65c6UycyJ49e7I/Z3r3+uuvy7PPPmtuV6hQwd/dAWATBG0B2NKaNWtk2bJlUq9ePX93BX4SGxtrMko0ywQAACCtOn36tDRq1EgOHTpk7hcsWFB69+5tgncXLlwwAdSpU6f6u5tIRiVLljQLALiiPAIA2xoyZEiC2v3222/Svn17KVy4sGTMmNFcTqZZukuXLo3X1uFwmEFv7dq1JVu2bJIpUyapWLGivPvuuyZI6Moqx6A1aV1pLSxrm2Y+WC5fvizdu3eXPHnySNasWeWRRx5x2x7X5MmTpWrVqqZtSEiI3HbbbdKgQQMZOXJkgl73X3/9Jb169TIDPH18jhw5pEmTJrJu3Tpnm6ioKClbtqzpa4YMGWT79u3ObdrWeh2zZ8+OV6ZCj5Neole8eHETOK1SpYosWbJEEkqD7vocuXPnNu+Lvj+arfHrr7+6tXN9zo8//ti870WLFjX9tV5LYt43fY3NmzeXvHnzmn3o+aBZKc8//7zzjyEAAAC7GDVqlHOMEh4eLhs2bJAePXpI/fr1pUWLFmY89ssvv0iRIkWcj9EvtkeMGGHGOFmyZJHMmTObsdFbb70Vr4xCQse0WktVb1tZtkrLM3ga93py4MABM/7V/ug47KWXXjLj48TUcNUsX2u9jhETQseLjz32mAl265gzf/785m+Bbdu2eWyvY0U9tnrMtG2/fv3ijSejo6NlzJgxZvyrr0eXGjVqmDIVcbke3x07dpjyFrrv0qVLy7x580wb/VmuXDkzZtf3ScfJCTkervvWMbQeX/3bIWfOnGZse/Xq1QQdIwCplAMAbGDgwIEO/UjSpWrVqs7ba9asMdsjIiKc6yZOnOh83Pr16x1hYWHOba5LQECA4/3333d7nnbt2nlsq0vr1q3d2lrrixYt6rb+vvvuc247cOCAc32TJk3i7bNQoUKOnDlzOu9bpk+f7rUft912202P18GDB82+PT0+Q4YMjq+++srZdt26dY6goCCzrXr16o6YmBjHrFmznO1btWrl8X0oVaqUx32vWrXK2d71fVm+fLlz/YQJE8zx99Q/fb82bNjg8TnvuOMOt7bWPhP6vp06dcqRJ08er22XLFly02MLAACQklzHP4MGDbpp+6tXrzrq1q3rdbyj26KiohI9ptVxl7d9xh33xvX33387ChcuHO8xd911l/O2Pt/NxpBTp051rtcx4s18/PHHznFu3EX3pbTfrmPzrFmzxmv74YcfOvd57do1R/369b0eh1deecWtD9b67NmzO3LlyhXv75F+/fp5HA+fPn36psfDWpctW7Z4+9bl9ddfv+kxApB6kWkLwHb0m+977rnH3H7zzTe9ttNxjGbY6mVj6n//+5+p99W/f38JDAw02zVL4fDhw85vuKdPn25ulypVymSXfvPNN87n+vzzz82SFN9//715bqVZoGPHjpUFCxaYb+/1kre4vvrqK/MzODjYTKymWcEzZ86Ul19+2WQ03MwLL7wgf/75p7ndrl07Wbx4sUycONF8866ZAR06dDCTWSjNCvi///s/c1szNzSTVY+L0qxgfZy3DObBgwfLwoULpWHDhmad7tt6rDd6vHv27GmOv74Pmr2gx0YzIJS+X5pN8M841J3WcWvbtq1pr++VZh8n5n1bu3atyUBWTzzxhMkM1vdBM1juu+8+CQoKuumxBQAASCkXL150q2N777333vQxOs5ctWqVua1XMs2aNcuMj6xMXN2m2bmJdffdd0tkZKRb3dy5c+eadboUKFDA62Pffvtt55hbs0J1bKZZs0ePHpXkcuTIEenSpYvExMSY+5qVPH/+fDN27NSpk8m6jUvHz5rpqmNxvULO9Qo4i17JZV2xp+NNa586DlV6Vdz69evj7VsnbdMr4L7++mtp06aNWafjXR1761VgOqauU6eOczys71tCnT9/3ozbv/jiC7e/j1z7DSAN8nfUGADiZlv26dPH8c033zjvb9q0yWOm7ZYtW5zr8ufPb74Vt2j2qLXtnXfeMeuaN2/uXDdu3DhHZGSkWfSbdWt906ZNE52VoLp06eJc17t3b2fbX375xe3bcEubNm3M/cyZMzt+/PFHx7lz5xJ8rDSTwcpi1ddtvQ5dHn30UedzzZs3zy0jo2zZsvG+nf/iiy+8vg9t27Z1rj979qzpq7Xt0KFDXrMCxowZ4zGLV98f7a+1bevWrfGes3bt2vFeb2Let8WLF7tlQWg/Y2NjE3xsAQAAUtKff/7pNjbbs2fPTR/jmr2qY2aL6/i5YsWKSRrT3mj9jZQpU8b5mG+//da53nW85utMWx3jW21r1arltZ1rpm3GjBkdx48fN+v16jNrfKtZshY9dlb7OXPmOMeegwcPdq7v2rWrs73r+6djf7Vx40bnOn2O8+fPm/Vz5851ru/Ro8dNj4frvq2xsypdurRzvY7TAaRNTEQGwJaaNm1qvu3funWr+XZa63vFpbW9LJUrVzb1Sy3Vq1c330S7tnNt7/rNuqs9e/Ykqb+uGRLVqlVz3tZv27XW7JkzZ9zaa4awZiBonS+tY6sKFSpkskE1k1Vr3XqjGbBWlurx48e9ZmS4vhatn6XZDpp1az328ccfl5YtW3p9Hm1r0eOv2QX6flivVzM7PHE9zq770PdH39PvvvvO2S7uDMj6vt9ofzd73/RY6DHXml+aBaFLWFiYOT80g7djx44m+xcAAMAO4o5xNTNVa6HeiLexlo5/PbVJCd7Gwq598jXX16jzKCSEHtt8+fKZ2zom1HG6jsc1S9bTfnW8nNC/GbJnz+6cTExrzlp0DK3jUaVzPVhcn/NmdE4H13Gzztnguh9PfysBSP34yxWAbb3++uvmp16+tHPnzkQ9Vgv2J4VVUsCVdcmV5dSpU7fcl4ceekhWr15tLt3SQKZOVqCXa2mJBA3cug58kyrua9m3b59bSQK9r+UOkvuYJmYf1iA6qa9Vj6MeVy3rUK9ePVOewpp1uXPnzgme5A0AACAlaGmrO+64w3lfxzHJNc661TGtL/vkut61X8ndJw3SutJSZb76m8E1cOqaJKABV088lQpLSr8Tsx8AqQtBWwC2pVmgZcuWNQORzZs3x9t+5513Om9rBuj169ed913rTFntXNsvX77c7Dfusn///ngDr7///tsZ3NRZc/fu3RuvL66D7U2bNrllxXqqaavPVbNmTfnggw9ky5YtJrA4evRos02/7dcatd6UKFHCOdAtXry4ed1xX4fOGqyBS8uxY8ecWapWXVedOXfo0KFen0fr31rOnTtngryeXm9crsfZdR96DK1M3bjtbjSwT8z7pre13pfWNdZaZPq6NQCufxCpL7/80mu/AQAA/KF169bO22PGjPFYB/bkyZPOMaW3sZan8W9ix7RxA46xsbEJeg3exsKear+69sm6csxyozFwXK6vcdGiRQl+XGL2q+NIT2NPq+YtACQngrYAbEsDeK+99prX7XqJUJkyZcxtDc7p5e966f2gQYPMhAFKJyBo1aqVua3bLU8//bRzArDPPvvMFPTXiQZ0EgXX4Ki6cuWKPPnkkzJ+/Hhp1KhRvCwF9cgjjzhvv/fee6atTkLg+pyuNICqE6fp5AE6yPzxxx/NBA+WqKgor69bL7fSfigNVupzazBSJ9366KOP5MUXXzQTUejkDJbnnnvOWaJhzpw5Jhiuhg0bJtu2bfP4PDqhhQZ1tX86qZeVUaCZwd5KIyh9XVapCu3XwIEDzfuix1zfJ6XPr5NAJERi3rc1a9ZIlSpVzOvSiTM0yKvvgwbCb3ZcAQAA/EEnjLUmEdNL3bXkgU6GtWzZMnPFmU7wqoHEQ4cOmTY6LrXouE/HRFp2q1u3bs71OnZLypg2blbnhx9+aMaoroFYT1zHwl27djXjsE8//dR55VxcVp+UTlo7YcIEM+ZLTDBUJ7nVEmBWhrKO+fV46d8BOmmvXsGWFK5jTy3d9cknn5h+zZgxw/S1QoUKZjwNAMnO30V1AaQ/K1euNBNHFShQwBTPnz9/vttkVDqBVP/+/c2kVSEhIY5MmTK5FeG3JiJT69evd4SFhcWbYEsXnazr/fffd3vudu3aeWzracKDyZMnx9ueNWtWR6FChTxOztCoUaN47fPkyeMIDw+PNxFZx44dvfZBX+/+/ftveAwPHjzo1g9Pi9W3adOmOde1bt3arFu7dq0jMDDQOVGFNYmb6/vgOsmFtQQHB7tNjuBt0oQJEyY4J0uLu+j7tWHDBmdb1+fUySc8Sej7ppNE3Kjd8OHDb3hcAQAA/GHXrl2OO+6444bjGGsiKp1g9t577/Xarm7duo6oqKgkj2nHjx8fr33cScziOnXqlOO2226L97iSJUt6nIhM22sf4rZ3ndDsZhORWROdWWPauIs1rnSdiMy1D0pfV9xxuh67+vXr3/C9cB2zejpG3p5Tx8vWeh1HJ3QisoROIgcgbSHTFkCK04xNzbLUb9Q90cuoxo0bZzIq9ZIvLd7vjU5uoKUTIiIi5LbbbjP1nTQ74OGHH5YffvhBunTp4tZevymfPn26qRurl2VpJq5mNtSvX988p34rb3n22Welb9++kjdvXsmUKZOpkaqZBlqSwBPNKNBsB50YQGurNmzYUFatWmUmJfD0Db72WV+b9kNLFujztGjRwjzHjcoPKO2zlhro3bu3mVAhNDTUTHCgt9u1a2eySzUbVi+v04nNlB4XzdpQmp1qlUvQMgmasRqXZnVo1rC+Xj1OmmG7cOFCuf/+++Vm9Dhq5q9mcWhmsL4vBQsWNH3T98t1goqESOj7plkoffr0Ma9P6+Pq82ppBH0+Pd90GwAAgN3oVUg7duww5RHq1Kljxk863tHxnI4pdSxkXSml2aU6znrrrbfkrrvuMuNUHQtqBujw4cPNGFgfm9QxrV6hpWMmHWsldAJXHf/quFczU3UcrP3XuRt0fOyt/YIFC0z/ta/aFx2rvfLKK4k6bvra9LVoWTVr7KevU8egcSe8TSjtj5Zp0DGm/q2hY2w9vsWKFTMTnk2ZMkUeffTRJO0bABIjQCO3iXoEAPi4BIJewqTBSqUfSRrce/nll82lYlY9VR2ETZs2Tdq0aePnHqdtWlrijTfeMLenTp0qzzzzjL+7BAAAAABAukOmLQBbOXDggJmMoEGDBs51mlmptb3Wrl3r174BAAAAAACkBIK2AGzFmj1WM2td6X3XmWUBAAAAAADSKoK2AAAAAAAAAGAjBG0B2Er+/PnNzxMnTrit1/vWNiRvTVutK6wL9WwBAAAAAPAPgrYAbEVnZdXg7NKlS53rzp8/L+vXr5eaNWv6tW8AAAAAAAApIThFngUAXFy8eFF+++03t8nHtm3bJjlz5pQiRYpIjx49ZMiQIVKyZEkTxO3fv78ULFhQWrRo4dd+AwAAAAAApIQAh14Dm4bFxsbK0aNHJSwsTAICAvzdHQAiEhkZKU2bNo23/sknn5SJEyeaS/OHDRsm06ZNk3Pnzsk999wjY8aMkRIlSvilvwCAlKGf/xcuXDBf1AUGckFYYjDmBQAASFtj3jQftP3zzz+lcOHC/u4GAAAAEujw4cNSqFAhf3cjVWHMCwAAkLbGvGm+PIJmG1gHIlu2bP7uDgAAALzQGuYaeLTGb0g4xrwAAABpa8yb5oO21uVhOnhlAAsAAGB/XN6feIx5AQAA0taYl2JhAAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAABI81atWiXNmjUzMzXr5YgLFixw267zMw8YMEAKFCggmTJlkgYNGsivv/7q3L5ixQrzOE/Lxo0bTZs//vjD4/Z169al+OtF8uOcgi9xPsHXOKdSP4K2AAAAANK8S5cuScWKFWXChAket48cOVLGjRsnkyZNkvXr10uWLFmkYcOGcvXqVbO9Vq1acuzYMbfl2WeflWLFiknVqlXd9vXjjz+6tatSpUqKvEakLM4p+BLnE3yNcyr1S/MTkQEAAABAo0aNzOKJZhuNHTtW+vXrJ82bNzfrpk+fLvny5TOZSW3atJGMGTNK/vz5nY+Jjo6Wr776Srp16xZvIpFcuXK5tUXaxDkFX+J8gq9xTqV+ZNoCAAAASNcOHDggx48fN5eGWsLDw6VGjRqydu1aj4/5+uuv5e+//5b27dvH2/bII49I3rx5pU6dOqYd0h/OKfgS5xN8jXMqdSBoCwAAACBd0z9clWYYudL71ra4pkyZYi4jLVSokHNd1qxZZfTo0TJ37lz59ttvzR+vLVq04A/YdIhzCr7E+QRf45xKHSiPAAAAAACJ8Oeff8r3338vc+bMcVufO3du6dWrl/N+tWrV5OjRo/L222+bLCTAG84p+BLnE3yNc8o/yLQFAAAAkK5ZdfhOnDjhtl7ve6rRN3XqVFO/LyF/kOqlpr/99psPe4vUgHMKvsT5BF/jnEodCNoCAAAASNd0Jmz9I3Xp0qXOdefPnzezadesWTPe5C36x2u7du0kQ4YMN933tm3bpECBAsnSb9gX5xR8ifMJvsY5lTpQHgEAAABAmnfx4kW3zB+dhEX/sMyZM6cUKVJEevToIUOGDJGSJUuaP2b79+8vBQsWNLX5XC1btsw89tlnn433HJ988omZbfvuu+8297/88kv5+OOP5aOPPkqBV4iUxjkFX+J8gq9xTqUBDj9auXKlo2nTpo4CBQo4tCvz58932x4bG+vo37+/I3/+/I7Q0FBH/fr1Hb/88kuinuPcuXNm3/oTAAAA9sW4Lek4dje3fPlyc4ziLhEREW5/e+TLl88REhJi/vbYt29fvP088cQTjlq1anl8jmnTpjnKlCnjyJw5syNbtmyO6tWrO+bOnZvsrw3+wTkFX+J8gq9xTqX+cVuA/s9fAePvvvtOVq9eLVWqVJGWLVvK/Pnz3SL6I0aMkOHDh5vIvRX1//nnn2X37t0SGhqaoOfQ9O7w8HA5d+6cZMuWLRlfDQAAAG4F47ak49gBAACkrXGbX8sjNGrUyCyeaCx57Nix0q9fP2nevLlZN336dMmXL58sWLBA2rRpk8K9BQAAAAAAAIB0XNNW62UcP35cGjRo4FynUWidhW7t2rUEbQEAAIC4rl4VyZgx/vrAQPf12s6bW2kbFaXZF57bBgSIhIQkre21ayKxsd774XoVnr/aan+13yo6WiQmxvdtr1//Z/FFW33f9P3zdVudpCYoKPFt9RjosfAmOPifJbFt9T3T987XbfXc1XPYF231GFiT+/iybUr93vMZkbC2fEb8g8+IxLflMyLtfUbc6JikhqCtBmyVZta60vvWNk+ioqLM4ppyDKR2hw4dklOnTvm7G0gGuXPnNkXgAQDwiXbt/vtjzVXVqiIDB/53/6mnvP8hV768yPDh/93v2FEH1fGaXblyRc7nzy9HevVyrisyeLBkOH3a426v5csnh/v2dd4vPHy4ZDxxwmPb6Jw55dCAAc77t40ZI6GHDnlsG5Mli/wxdKjzfsHx4yXT/v0e28ZmzCgHRo503s//wQeSZfdu8Wb/2LHO2/mmTpWs27d7bfv7iBHi+PcPxDyzZkm2DRu8tj3w5psSGxZmbueeO1fCV6/22vbggAFyPWdOczvXV19J9uXLvbY91KePRP87Y3eO776TnN9/77Xtn716SdS/Y5Dsy5ZJrq+/dm7TSWUyZcr0X+Nhw0QqVPjntu5z0iSv+xV936pV++f2ypUiLscwnj59ROrU+ef22rVyZdAgueYlIHLyySflQvXq5nbmXbukwIcfet3tX61ayfl77zW3Q3/9VW6bMMFr278feUTO1qtnboccOiSFxozx2vZ0w4Zy5t8rRTMcOyZFRozw2vbsAw/I3/9eMRp8+rQUHTzYa9tztWvLqcceM7cDL1yQYv37e217vnp1+evJJ83tgKgouUOPoRcXK1aUE+3bO+8X79HDa9tLZcvK8c6dnfeLvfKKBHp5L64ULy5Hu3Vz3r/99dcl6NIlj22vFiliPiOcY94XXhA5edJzJwoXFnn//f/u9+wpcviw57Z584pMmfLf/VdfFfn11/h9vXJFrmTIwGeEjz8j4jry4otytWRJcztbZKTk+eILr22Pdeokl8uVM7fDNmyQvLNmeW17PCJCLv07wVWWrVsl/yefeP+c0vO7fv1/bm/ZInKD3zl5/nmRJk3+ub1rl8hrr3lvq79DLVv+c3v/frnSpYvXzyk+I5L+GWGHcURu63NKx0s7d3psawLB8+b9d1/HS5s2iVfffPPfbf33xfpdvtGXCqkhaJtUWgP3jTfe8Hc3AJ8GbEuVLiVXryTsmxikLqGZQmXf3n0EbgEAqYoGQpYtXy77YmPl5Zkznet1rui8Xh6joZcXXf7Q0TBaYS9tNaTz7FdfOe+PFpF/wgHxaTj5qcWLnfeHadzZS1sNUz9WpYrzvv45V1W8e8Slrf7ZW/sGbR+rVcvsX70kIv+GDjx66v77Tb/V8yLS+AZtOz74oPz172390/rRG7R9MTLSHGf1xL+LN70iI8WaU1z32d4t8SlQ6j3wgHtAJJmdOHFCNi1fLrFeMpbGRkbKsn9v63v235/i8U2KjJRF/94u/+854c3UyEiZ/+/tEvo39Q3azo6MlNn9+pnbeu56DwWLzI+MlKn/BmHyiIhLeDGeRZGRMumtt8xtrWw44wZtl0ZGyruj9TdCRMN/c2/QdnVkpIx47z3nfe8hN5FNkZEyePJk533dr0uOmpudkZHy2rRpzvvaX28VGTWMqp8RzjGvpOzn1PLly+VMbCyfET7+jIjrtchIsUJcjf/tszeDIyPFCnHp1yXew4QiIyIjxQpX67F1DT8GBQbKAyn8OXX06FHZtny5xHj5nOIzIumfEXYYR2QKzSR79+1N0c+pm/HrRGSuAgIC3CYi+/3336V48eKydetWqVSpkrPdfffdZ+6/++67Cc60LVy4MJMyINXasmWLmawvzxN5JGNeD5c7ItW6dvKa/DX7L9m8ebNUrlzZ390BAL9jMi0fHLsTJzwfOx9f1qhj9Jq1akmpB0ZJxlylneszxERLgJmcOj6HBEh0UIYktQ2OjZbAG/zZci0oo//bBmZwXnYcFHtdghyxydA2RoIcMT5pGx0YLI6AwHhtL53ZL3tX9Ja1a9bI3f9muKXEpc9bNm6UWtWrS57Hc0vGPPHHvNcDRWIC/3ltgbEOyXCDq1Fd2wY4HJIxxvdt9ZLcEB+1jQkQuR7k+7axASLRVlsNsFx3+KXtpb+j/xvzaoZlCl36bH1OTW0tUqqAy0P1mN0gCuIITqa2eqpbhy1Gz7dkaBsrEhBr87b6URJ4a233/iXS/nNx/5xKgfIIWzZtklrVqklreVzymFCru1gJNMu/vZdgffO8SFzbAImVIJ+31X9rY5xtNavzut/bBsl156kUl/4axLjkniaubYzXMYc6Kqdltsz+53NKrzhK5vIIZtyWL5+9JyK7kWLFikn+/Pll6dKlzqCtvqj169dLly5dvD4uJCTELEBaowHbkEKc2wAAQG78x4HrHwg3apeYfcahl/hqmoQGbMPyVEj4rhL+rIlqm5gREm1v3FYD1fremsu4PZ0nrsGOm0lM26Cgf563QIiIhzFvcCL+eE1tbTVcEZQMbQMTcU4kZ9uMLgFet0DrzSSmrYda3tbnlAZsKxdK+K5gfxosv+HnlH4ZZH15dDP6hVRC/00MDDTPm0MKSH7hpEpLrrt+YnuaG8CbpLa90RcFdgnaXrx4UX777Te3yce2bdsmOXPmNJcK9+jRQ4YMGSIlS5Y0Qdz+/ftLwYIFndm4AAAAAAAAAJDW+DVou2nTJlODxNLr3+LDERERMm3aNHnllVfk0qVL0rlzZzl79qzUqVNHFi9eLKGJyQwAAAAAAAAAgFTEr0Hb+++/X25UUlfr3A4ePNgsAAAAAAAAAJAeWFWPAQAAAAAAAAA2QNAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAvFi1apU0a9ZMChYsKAEBAbJgwQK37Q6HQwYMGCAFChSQTJkySYMGDeTXX391a3P69Glp27atZMuWTbJnzy4dO3aUixcvurXZsWOH3HvvvRIaGiqFCxeWkSNHpsjrAwAAgD0RtAUAAAC8uHTpklSsWFEmTJjgcbsGV8eNGyeTJk2S9evXS5YsWaRhw4Zy9epVZxsN2O7atUuWLFkiCxcuNIHgzp07O7efP39eHnroISlatKhs3rxZ3n77bRk0aJB88MEHKfIaAQAAYD/B/u4AAAAAYFeNGjUyiyeaZTt27Fjp16+fNG/e3KybPn265MuXz2TktmnTRvbs2SOLFy+WjRs3StWqVU2b8ePHS+PGjWXUqFEmg3fmzJly7do1+fjjjyVjxoxSrlw52bZtm4wZM8YtuAsAAID0g0xbAAAAIAkOHDggx48fNyURLOHh4VKjRg1Zu3atua8/tSSCFbBV2j4wMNBk5lpt6tatawK2Fs3W3bdvn5w5cyZFXxMAAADsgUxbAAAAIAk0YKs0s9aV3re26c+8efO6bQ8ODpacOXO6tSlWrFi8fVjbcuTIEe+5o6KizOJaYgEAAABpB5m2AAAAQCozfPhwk9VrLTp5GQAAANIOgrYAAABAEuTPn9/8PHHihNt6vW9t058nT5502379+nU5ffq0WxtP+3B9jrj69u0r586dcy6HDx/24SsDAACAvxG0BQAAAJJASxpoUHXp0qVuZQq0Vm3NmjXNff159uxZ2bx5s7PNsmXLJDY21tS+tdqsWrVKoqOjnW2WLFkipUqV8lgaQYWEhEi2bNncFgAAAKQdBG0BAAAALy5evCjbtm0zizX5mN4+dOiQBAQESI8ePWTIkCHy9ddfy88//yzt2rWTggULSosWLUz7MmXKyMMPPyydOnWSDRs2yOrVq6Vr167Spk0b0049+eSTZhKyjh07yq5du+Tzzz+Xd999V3r16uXX1w4AAAD/YSIyAAAAwItNmzbJAw884LxvBVIjIiJk2rRp8sorr8ilS5ekc+fOJqO2Tp06snjxYgkNDXU+ZubMmSZQW79+fQkMDJRWrVrJuHHjnNu1Ju0PP/wgL774olSpUkVy584tAwYMMPsEAABA+kTQFgAAAPDi/vvvF4fD4XW7ZtsOHjzYLN7kzJlTZs2adcPnueuuuyQyMvKW+goAAIC0g/IIAAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABsxNZB25iYGOnfv78UK1ZMMmXKJMWLF5c333xTHA6Hv7sGAAAAAAAAAMkiWGxsxIgRMnHiRPnkk0+kXLlysmnTJmnfvr2Eh4dL9+7d/d09AAAAAAAAAEhfQds1a9ZI8+bNpUmTJub+7bffLrNnz5YNGzb4u2sAAAAAAAAAkP7KI9SqVUuWLl0qv/zyi7m/fft2+emnn6RRo0ZeHxMVFSXnz593WwAAAAAAAAAgtbB1pu2rr75qgq6lS5eWoKAgU+N26NCh0rZtW6+PGT58uLzxxhsp2k8AAAAAAAAASBeZtnPmzJGZM2fKrFmzZMuWLaa27ahRo8xPb/r27Svnzp1zLocPH07RPgMAAAAAAABAms207d27t8m2bdOmjblfoUIFOXjwoMmmjYiI8PiYkJAQswAAAAAAAABAamTrTNvLly9LYKB7F7VMQmxsrN/6BAAAAAAAAADpNtO2WbNmpoZtkSJFpFy5crJ161YZM2aMdOjQwd9dAwAAAAAAAID0F7QdP3689O/fX1544QU5efKkFCxYUJ577jkZMGCAv7sGAAAAAAAAAOkvaBsWFiZjx441CwAAAAAAAACkB7auaQsAAAAAAAAA6Q1BWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAIIliYmKkf//+UqxYMcmUKZMUL15c3nzzTXE4HM42envAgAFSoEAB06ZBgwby66+/uu3n9OnT0rZtW8mWLZtkz55dOnbsKBcvXvTDKwIAAIAdELQFAAAAkmjEiBEyceJEee+992TPnj3m/siRI2X8+PHONnp/3LhxMmnSJFm/fr1kyZJFGjZsKFevXnW20YDtrl27ZMmSJbJw4UJZtWqVdO7c2U+vCgAAAP4W7O8OAAAAAKnVmjVrpHnz5tKkSRNz//bbb5fZs2fLhg0bnFm2Y8eOlX79+pl2avr06ZIvXz5ZsGCBtGnTxgR7Fy9eLBs3bpSqVauaNhr0bdy4sYwaNUoKFizox1cIAAAAfyDTFgAAAEiiWrVqydKlS+WXX34x97dv3y4//fSTNGrUyNw/cOCAHD9+3JREsISHh0uNGjVk7dq15r7+1JIIVsBWafvAwECTmQsAAID0h0xbAAAAIIleffVVOX/+vJQuXVqCgoJMjduhQ4eacgdKA7ZKM2td6X1rm/7Mmzev2/bg4GDJmTOns01cUVFRZrFoHwAAAJB2kGkLAAAAJNGcOXNk5syZMmvWLNmyZYt88sknpqSB/kxOw4cPNxm71lK4cOFkfT4AAACkLIK2AAAAQBL17t3bZNtqbdoKFSrI008/LT179jRBVZU/f37z88SJE26P0/vWNv158uRJt+3Xr1+X06dPO9vE1bdvXzl37pxzOXz4cDK9QgAAAPgDQVsAAAAgiS5fvmxqz7rSMgmxsbHmdrFixUzgVeveupYy0Fq1NWvWNPf159mzZ2Xz5s3ONsuWLTP70Nq3noSEhEi2bNncFgAAAKQd1LQFAAAAkqhZs2amhm2RIkWkXLlysnXrVhkzZox06NDBbA8ICJAePXrIkCFDpGTJkiaI279/fylYsKC0aNHCtClTpow8/PDD0qlTJ5k0aZJER0dL165dTfautgMAAED6Q9AWAAAASKLx48ebIOwLL7xgShxokPW5556TAQMGONu88sorcunSJencubPJqK1Tp44sXrxYQkNDnW20Lq4GauvXr28yd1u1aiXjxo3z06sCAACAvxG0BQAAAJIoLCxMxo4daxZvNNt28ODBZvEmZ86cZjIzAAAAQFHTFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAApKWgbUxMjGzbtk3OnDnjmx4BAAAAAAAAQDqW6KBtjx49ZMqUKc6A7X333SeVK1eWwoULy4oVK5KjjwAAAAAAAACQbiQ6aDtv3jypWLGiuf3NN9/IgQMHZO/evdKzZ095/fXXk6OPAAAAAAAAAJBuJDpoe+rUKcmfP7+5vWjRInnsscfkzjvvlA4dOsjPP/+cHH0EAAAAAAAAgHQj0UHbfPnyye7du01phMWLF8uDDz5o1l++fFmCgoKSo48AAAAAAAAAkG4EJ/YB7du3l8cff1wKFCggAQEB0qBBA7N+/fr1Urp06eToIwAAAAAAAACkG4kO2g4aNEjKly8vhw8fNqURQkJCzHrNsn311VeTo48AAAAAAAAAkG4kOmir/ve//8VbFxER4Yv+AAAAAAAAAEC6lqCg7bhx4xK8w+7du99KfwAAAAAAAAAgXUtQ0Padd95xu//XX3+ZiceyZ89u7p89e1YyZ84sefPmJWgLAAAAAAAAALcgMCGNDhw44FyGDh0qlSpVkj179sjp06fNorcrV64sb7755q30BQAAAAAAAADSvQQFbV31799fxo8fL6VKlXKu09uajduvXz9f9w8AAAAAAAAA0pVEB22PHTsm169fj7c+JiZGTpw44at+AQAAAAAAAEC6lOigbf369eW5556TLVu2ONdt3rxZunTpIg0aNPB1/wAAAAAAAAAgXUl00Pbjjz+W/PnzS9WqVSUkJMQs1atXl3z58slHH32UPL0EAAAAAAAAgHQiOLEPyJMnjyxatEh++eUX2bt3r1lXunRpufPOO5OjfwAAAAAAAACQriQ6aGvRIC2BWgAAAAAAAADwc9C2Q4cONy2fAAAAAAAAAABIoaDtmTNn3O5HR0fLzp075ezZs1KvXr0kdgMAAAAAAAAAkKSg7fz58+Oti42NlS5dukjx4sU5qgAAAAAAAABwCwJ9spPAQOnVq5e88847vtgdAAAAAAAAAKRbPgnaqv3798v169d9tTsAAAAAAAAASJcSXR5BM2pdORwOOXbsmHz77bcSERHhy74BAAAAAAAAQLqT6KDt1q1b45VGyJMnj4wePVo6dOjgy74BAAAAAAAAQLqT6KDt8uXLk6cnAAAAAAAAAICk1bTV2rU//vijTJ48WS5cuGDWHT16VC5evOjr/gEAAAAAAABAupLoTNuDBw/Kww8/LIcOHZKoqCh58MEHJSwsTEaMGGHuT5o0KXl6CgAAAAAAAADpQKIzbV966SWpWrWqnDlzRjJlyuRc/+ijj8rSpUt93T8AAAAAAAAASFcSnWkbGRkpa9askYwZM7qtv/322+XIkSO+7BsAAAAAAAAApDuJzrSNjY2VmJiYeOv//PNPUyYBAAAAAAAAAJCCQduHHnpIxo4d67wfEBBgJiAbOHCgNG7c+Ba6AgAAAAAAAABIdHmE0aNHS8OGDaVs2bJy9epVefLJJ+XXX3+V3Llzy+zZs5OnlwAAAAAAAACQTiQ6aFuoUCHZvn27fPbZZ7Jjxw6TZduxY0dp27at28RkAAAAgL9ER0fL8ePH5fLly5InTx7JmTOnv7sEAAAAJF/Q1jwoOFieeuopSQk6uVmfPn3ku+++M4PuEiVKyNSpU6Vq1aop8vwAAABIHS5cuCAzZswwyQUbNmyQa9euicPhMOW8NPFAy3x17txZqlWr5u+uAgAAAL4P2u7fv9/Utd2zZ4+5X65cOenevbsUL15cfOnMmTNSu3ZteeCBB0zQVrMktBRDjhw5fPo8AAAASN3GjBkjQ4cONePRZs2ayWuvvSYFCxY0V4KdPn1adu7cKZGRkSZwW6NGDRk/fryULFnS390GAAAAfBO0/f777+WRRx6RSpUqmYCqWr16tUyePFm++eYbefDBB8VXRowYIYULFzaZtZZixYr5bP8AAABIGzZu3CirVq0yyQSeVK9eXTp06CCTJk0yY0sN4BK0BQAAQJoJ2r766qvSs2dPeeutt+Kt1zIGvgzafv3112bSs8cee0xWrlwpt912m7zwwgvSqVMnr4+Jiooyi+X8+fM+6w8AAADsKaET4oaEhMjzzz+f7P0BAAAAbkVgYh+gJRF04rG4NHNh9+7d4ku///67TJw40WRBaIZvly5dTBmGTz75xOtjhg8fLuHh4c5FM3UBAAAAAAAAIM1m2mpd2W3btsW7nEzX5c2b15d9k9jYWDPh2LBhw8z9u+++29Qj08vaIiIiPD6mb9++0qtXL7dMWwK3AAAA6cfVq1dNzdrly5fLyZMnzZjS1ZYtW/zWNwAAACBZgrZamkBn3dUs2Fq1ajlr2mr9WddgqS8UKFBAypYt67auTJky8sUXX9zwkjddAAAAkD7pVWE//PCD/O9//zO1bAMCAvzdJQAAACB5g7b9+/eXsLAwGT16tMlqVToz76BBg0zpAl/Sic727dvntu6XX36RokWL+vR5AAAAkHYsXLhQFi1a5Jw0FwAAAEjzQVvNVNCJyHS5cOGCWadB3OSgz6HZvFoe4fHHH5cNGzbIBx98YBYAAADAE528NrnGpwAAAIAtJyJzpYPh5BwQV6tWTebPn29mAy5fvry8+eabMnbsWGnbtm2yPScAAABSN70irE+fPnLw4EF/dwUAAABImUzbEydOyP/93//J0qVLzcQODofDbXtMTIz4UtOmTc0CAAAAJIROZKuTkd1xxx2SOXNmyZAhg9v206dP+61vAAAAQLIEbZ955hk5dOiQqW2rE4UxsQMAAADs5IknnpAjR46YElv58uVjvAoAAIC0H7T96aefJDIyUipVqpQ8PQIAAABuwZo1a2Tt2rVSsWJFf3cFAAAASJmatoULF45XEgEAAACwi9KlS8uVK1f83Q0AAAAg5YK2OhHYq6++Kn/88UfSnxUAAABIJm+99Za8/PLLsmLFCvn777/l/PnzbgsAAACQ5oK2rVu3NgPg4sWLS1hYmOTMmdNtAQAAAPzp4YcfNuUR6tevL3nz5pUcOXKYJXv27Oanr2n93Keeekpy5colmTJlkgoVKsimTZuc2/UqtQEDBpj5IHR7gwYN5Ndff403OVrbtm0lW7Zspp8dO3aUixcv+ryvAAAASKM1bTXTFgAAALCr5cuXp9hznTlzRmrXri0PPPCAfPfdd5InTx4TkHUNDo8cOVLGjRsnn3zyiRQrVsxM6NuwYUPZvXu3hIaGmjYasD127JgsWbJEoqOjpX379tK5c2eZNWtWir0WAAAApOKgbURERPL0BAAAAPCBWrVqSYYMGTxuO3XqlE+fa8SIEWbOh6lTpzrXaWDWNctWkx769esnzZs3N+umT58u+fLlkwULFkibNm1kz549snjxYtm4caNUrVrVtBk/frw0btxYRo0aJQULFvRpnwEAAJAGyyMAAAAAdqaBUE8T5544cULuv/9+nz7X119/bQKtjz32mCnFcPfdd8uHH37o3H7gwAE5fvy4KYlgCQ8Plxo1apgSDkp/akkEK2CrtH1gYKCsX7/ep/0FAABA6kDQFgAAAGnKoUOH5Nlnn3Vbp6UHNGBbunRpnz7X77//LhMnTpSSJUvK999/L126dJHu3bubUghKA7ZKM2td6X1rm/7UgK+r4OBgM1+E1SauqKgoJlgDAABIwwjaAgAAIE1ZtGiRrFmzRnr16mXuHz161ARsdYKwOXPm+PS5YmNjpXLlyjJs2DCTZat1aDt16iSTJk2S5DR8+HCTsWstWqIBAAAAaQdBWwAAAKQpOhnYDz/8IF988YUJ3GrAVgOqs2fPNiUHfKlAgQJStmxZt3VlypQx2b4qf/78ztIMrvS+tU1/njx50m379evX5fTp0842cfXt21fOnTvnXA4fPuzT1wUAAAD/SvKo9bfffjOXgF25csXc91Q3DAAAAPAHzTxdsmSJzJw5U6pXr24CtkFBQT5/ntq1a8u+ffvc1v3yyy9StGhR56RkGnhdunSpc7uWMtBatTVr1jT39efZs2dl8+bNzjbLli0zWbxa+9aTkJAQyZYtm9sCAACAtCM4sQ/4+++/pXXr1mYgGRAQIL/++qvccccd0rFjR8mRI4eMHj06eXoKAAAAeKHjUB2bxnX58mX55ptvJFeuXM51msHqKz179pRatWqZ8giPP/64bNiwQT744AOzKO1Tjx49ZMiQIaburQZx+/fvLwULFpQWLVo4M3MffvhhZ1mF6Oho6dq1q5lQTdsBAAAg/QlOysBUJ0bQS750gGnRQK5efkbQFgAAAClt7NixfnneatWqyfz58025gsGDB5ugrPalbdu2zjavvPKKXLp0ydS71YzaOnXqyOLFiyU0NNTZRjOCNVBbv359U8KhVatWMm7cOL+8JgAAAKTCoK3WB9OyCIUKFXJbr5kDBw8e9GXfAAAAgASJiIjw23M3bdrULN5otq0GdHXxJmfOnDJr1qxk6iEAAADSfE1bzRLInDlzvPV6mZnW1gIAAABSmo5Rk7M9AAAAYOug7b333ivTp093yxzQSRJGjhwpDzzwgK/7BwAAANxUiRIl5K233pJjx455baMT5+rkZI0aNaL0AAAAANJWeQQNzmqtrU2bNsm1a9dMja5du3aZTNvVq1cnTy8BAACAG1ixYoW89tprMmjQIKlYsaJUrVrVTOKldWPPnDkju3fvlrVr15q5GbT+7HPPPefvLgMAAAC+C9qWL19efvnlF3nvvfckLCxMLl68KC1btpQXX3xRChQokNjdAQAAALesVKlS8sUXX5jJcufOnSuRkZGyZs0auXLliuTOnVvuvvtu+fDDD02WbVBQkL+7CwAAAPg2aKvCw8Pl9ddfT8pDAQAAgGRTpEgRefnll80CAAAApOmg7Y4dOxK8w7vuuutW+gMAAAAAAAAA6VqCgraVKlUyE47p5A3606L3leu6mJiY5OgnAAAAAAAAAKQLgQlpdODAAfn999/NT60VVqxYMXn//fdl27ZtZtHbxYsXN9sAAAAAAAAAAMmcaVu0aFHn7ccee0zGjRsnjRs3diuJULhwYenfv7+0aNHiFroDAAAAAAAAAOlbgjJtXf38888m0zYuXbd7925f9QsAAABIkkOHDjnLeLnSdboNAAAASHNB2zJlysjw4cPl2rVrznV6W9fpNgAAAMCfNJngr7/+irf+9OnTHpMPAAAAgFRZHsHVpEmTpFmzZlKoUCFTFkHt2LHDTEb2zTffJEcfAQAAgASLO3mu5eLFixIaGuqXPgEAAADJGrStXr26mZRs5syZsnfvXrOudevW8uSTT0qWLFkSuzsAAADAJ3r16mV+asBW51rInDmzc1tMTIysX79eKlWq5MceAgAAAMkUtFUanO3cuXNSHgoAAAAki61btzozbXUehowZMzq36e2KFSvK//3f//mxhwAAAEAyBm0BAAAAu1m+fLn52b59e3n33XclW7Zs/u4SAAAAkCQEbQEAAJCmTJ061d9dAAAAAG4JQVsAAACkKfXq1bvh9mXLlqVYXwAAAICkIGgLAACANEVr17qKjo6Wbdu2yc6dOyUiIsJv/QIAAACSNWh79uxZmTdvnuzfv1969+4tOXPmlC1btki+fPnktttuS8ouAQAAAJ945513PK4fNGiQXLx4McX7AwAAACRWYGIfsGPHDrnzzjtlxIgRMmrUKBPAVV9++aX07ds30R0AAAAAUsJTTz0lH3/8sb+7AQAAAPg+aNurVy955pln5Ndff5XQ0FDn+saNG8uqVasSuzsAAAAgRaxdu9Zt/AoAAACkmfIIGzdulMmTJ8dbr2URjh8/7qt+AQAAAEnSsmVLt/sOh0OOHTsmmzZtkv79+/utXwAAAECyBW1DQkLk/Pnz8db/8ssvkidPnsTuDgAAAPCp8PBwt/uBgYFSqlQpGTx4sDz00EN+6xcAAACQUIkO2j7yyCNmwDtnzhxzPyAgQA4dOiR9+vSRVq1aJXZ3AAAAgE9NnTrV310AAAAAUram7ejRo82su3nz5pUrV67IfffdJyVKlJCwsDAZOnTorfUGAAAA8JHNmzfLjBkzzLJ161Z/dwcAAABIvkxbvdxsyZIlsnr1atm+fbsJ4FauXFkaNGiQ2F0BAAAAPnfy5Elp06aNrFixQrJnz27WnT17Vh544AH57LPPKOkFAACAtBW0jY6OlkyZMsm2bdukdu3aZgEAAADspFu3bnLhwgXZtWuXlClTxqzbvXu3RERESPfu3WX27Nn+7iIAAADgu6BthgwZpEiRIhITE5OYhwEAAAApZvHixfLjjz86A7aqbNmyMmHCBCYiAwAAQNqsafv666/La6+9JqdPn06eHgEAAAC3IDY21iQbxKXrdBsAAACQ5mravvfee/Lbb79JwYIFpWjRopIlSxa37Vu2bPFl/wAAAIBEqVevnrz00kumDIKOWdWRI0ekZ8+eUr9+fX93DwAAAPB90LZFixaJfQgAAACQYjTJ4JFHHpHbb79dChcubNYdPnxYypcvLzNmzPB39wAAAADfB20HDhyY2IcAAAAAKUYDtXr1l9a13bt3r1mn9W0bNGjg764BAAAAyRO0tWzatEn27NnjnNihSpUqSd0VAAAA4FMBAQHy4IMPmgUAAABI8xOR/fnnn3LvvfdK9erVTa0wXapVqyZ16tQx2wAAAAB/WLZsmUkmOH/+fLxt586dk3LlyklkZKRf+gYAAAAka9D22WeflejoaJNle/r0abPobZ2JV7cBAAAA/jB27Fjp1KmTZMuWLd628PBwee6552TMmDF+6RsAAACQrEHblStXysSJE6VUqVLOdXp7/PjxsmrVqsTuDgAAAPCJ7du3y8MPP+x1+0MPPSSbN29O0T4BAAAAKRK01YkdNNM2rpiYGClYsGCSOgEAAADcqhMnTkiGDBm8bg8ODpa//vorRfsEAAAApEjQ9u2335Zu3bqZicgseltr244aNSpJnQAAAABu1W233SY7d+70un3Hjh1SoECBFO0TAAAAkBTBCWmUI0cOMwOv5dKlS1KjRg2TraCuX79ubnfo0EFatGiRpI4AAAAAt6Jx48bSv39/UyIhNDTUbduVK1dk4MCB0rRpU7/1DwAAAPBp0FYndQAAAADsrF+/fvLll1/KnXfeKV27dnXOwbB3716ZMGGCKef1+uuv+7ubAAAAgG+CthEREQlpBgAAAPhNvnz5ZM2aNdKlSxfp27evOBwOs16vGGvYsKEJ3GobAAAAIE0EbT05efKkWWJjY93W33XXXb7oFwAAAJBoRYsWlUWLFsmZM2fkt99+M4HbkiVLmnJfAAAAQJoN2m7evNlk3u7Zs8eZvWDRLAa97AwAAADwJw3SVqtWzd/dAAAAAFImaKuTjWmdsClTppjLy1wnKAMAAAAAAAAApHDQ9vfff5cvvvhCSpQocYtPDQAAAAAAAACIK1ASqX79+rJ9+/bEPgwAAAAAAAAAkByZth999JGpabtz504pX768ZMiQwW37I488kthdAgAAAAAAAACSGrRdu3atrF69Wr777rt425iIDAAAAAAAAABSuDxCt27d5KmnnpJjx45JbGys25LcAdu33nrLBIZ79OiRrM8DAAAAAAAAAKkmaPv3339Lz549JV++fJKSNm7cKJMnT5a77rorRZ8XAAAAAAAAAGwdtG3ZsqUsX75cUtLFixelbdu28uGHH0qOHDlS9LkBAAAAAAAAwNY1be+8807p27ev/PTTT1KhQoV4E5F1795dfO3FF1+UJk2aSIMGDWTIkCE+3z8AAAAAAAAApNqg7UcffSRZs2aVlStXmsWV1pv1ddD2s88+ky1btpjyCAkRFRVlFsv58+d92h8AAAAAAAAAsFXQ9sCBA5JSDh8+LC+99JIsWbJEQkNDE/SY4cOHyxtvvJHsfQMAAAAAAAAAW9S0deVwOMySXDZv3iwnT56UypUrS3BwsFk0u3fcuHHmdkxMTLzHaOmGc+fOORcN/AIAAAAAAABAmg7aTp8+3dSzzZQpk1nuuusu+fTTT33eufr168vPP/8s27Ztcy5Vq1Y1k5Lp7aCgoHiPCQkJkWzZsrktAAAAAAAAAJBmyyOMGTNG+vfvL127dpXatWubdTop2fPPPy+nTp2Snj17+qxzYWFhUr58ebd1WbJkkVy5csVbDwAAAAAAAADpMmg7fvx4mThxorRr18657pFHHpFy5crJoEGDfBq0BQAAAAAAAID0JtFB22PHjkmtWrXirdd1ui25rVixItmfAwAAAAAAAABSTU3bEiVKyJw5c+Kt//zzz6VkyZK+6hcAAACQ6rz11lsSEBAgPXr0cK67evWqvPjii6bEV9asWaVVq1Zy4sQJt8cdOnRImjRpIpkzZ5a8efNK79695fr16354BQAAAEiVmbZvvPGGtG7dWlatWuWsabt69WpZunSpx2AuAAAAkB5s3LhRJk+ebCbpdaXlw7799luZO3euhIeHm7khWrZsacbQKiYmxgRs8+fPL2vWrDFXr2kpsgwZMsiwYcP89GoAAACQqjJtNTNg/fr1kjt3blmwYIFZ9PaGDRvk0UcfTZ5eAgAA+JHW89dAXLZs2cxSs2ZN+e677/zdLdjIxYsXpW3btvLhhx9Kjhw5nOvPnTsnU6ZMMZP51qtXT6pUqSJTp041wdl169aZNj/88IPs3r1bZsyYIZUqVZJGjRrJm2++KRMmTJBr16758VUBAAAg1QRtlQ42dVC5efNms+jtu+++2/e9AwAAsIFChQqZy9513LNp0yYTfGvevLns2rXL312DTWj5A82WbdCggdt6PWeio6Pd1pcuXVqKFCkia9euNff1Z4UKFSRfvnzONg0bNpTz5897PceioqLMdtcFAAAA6bg8AgAAQHrTrFkzt/tDhw412beaKVmuXDm/9Qv28Nlnn8mWLVtMeYS4jh8/LhkzZpTs2bO7rdcArW6z2rgGbK3t1jZPhg8fbsqWAQAAIJ1n2gYGBkpQUNANl+BgYsAAACBt0/qjGqS7dOmSKZOA9O3w4cPy0ksvycyZMyU0NDTFnrdv376m9IK1aD8AAACQdiQ4yjp//nyv2/SSrnHjxklsbKyv+gUAAGArP//8swnSXr16VbJmzWrGRmXLlvV3t+BnWv7g5MmTUrlyZbfAvk7a+95778n3339v6tKePXvWLdv2xIkTZuIxpT91fghXut3a5klISIhZAAAAkM6Dtlq3La59+/bJq6++Kt98842ZeGHw4MG+7h8AAIAtlCpVSrZt22ayGufNmycRERGycuVKArfpXP369U1A31X79u1N3do+ffpI4cKFJUOGDLJ06VIzoa81hj506JAzU1t/askNDf7mzZvXrFuyZImZ9I7zCwAAIH1KUj2Do0ePysCBA+WTTz4xkyToHzDly5f3fe8AAABsQuuSlihRwjkpq9Yvfffdd2Xy5Mn+7hr8KCwsLN44OEuWLJIrVy7n+o4dO0qvXr0kZ86cJhDbrVs3E6i95557zPaHHnrIBGeffvppGTlypKlj269fPzO5Gdm0AAAA6VOigraaWTJs2DAZP368VKpUyWQM3HvvvcnXOwAAAJvSslBRUVH+7gZSgXfeecfMD6GZtnrOaNLD+++/79yuc0MsXLhQunTpYoK5GvTVTG6uYgMAAEi/Ehy01W/9R4wYYepqzZ4922O5BAAAgLRIJ31q1KiRFClSRC5cuCCzZs2SFStWmHqlQFx6brjSCcomTJhgFm+KFi0qixYtSoHeAQAAIE0FbbV2baZMmcxlgVoWQRdPvvzyS1/2DwAAwO+01mi7du3k2LFjEh4eLnfddZcJ2D744IP+7hoAAACA9By01T9UAgICkrc3AAAANjRlyhR/dwEAAABAOpLgoO20adOStycAAAAAAAAAAAn0dwcAAAAAAAAAAP8haAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjQT7uwMAACB1O3TokJw6dcrf3UAyyJ07txQpUsTf3QAAAADSHYK2AADglgK2pUuVlitXr/i7K0gGmUIzyd59ewncAgAAACmMoC0AAEgyzbDVgO0T8oTklbz+7g586KSclNlXZ5v3mKAtAAAAkLII2gIAgFumAdtCUsjf3QAAAACANIGJyAAAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtEm348OFSrVo1CQsLk7x580qLFi1k3759/u4WADjxOQUAAAAASM0I2iLRVq5cKS+++KKsW7dOlixZItHR0fLQQw/JpUuX/N01ADD4nAIAAAAApGbB/u4AUp/Fixe73Z82bZrJZNu8ebPUrVvXb/0CAAufUwAAAACA1IxMW9yyc+fOmZ85c+b0d1cAwCM+pwAAAAAAqQlBW9yS2NhY6dGjh9SuXVvKly/v7+4AQDx8TgEAAAAAUhvKI+CWaM3InTt3yk8//eTvrgCAR3xOAQAAAABSG4K2SLKuXbvKwoULZdWqVVKoUCF/dwcA4uFzCgAAAACQGhG0RaI5HA7p1q2bzJ8/X1asWCHFihXzd5cAwA2fUwAAAACA1IygLZJ0qfGsWbPkq6++krCwMDl+/LhZHx4eLpkyZfJ39wCAzykAAAAAQKrGRGRItIkTJ5qZ2O+//34pUKCAc/n888/93TUAMPicAgAAAACkZmTaIkmXHQOAnfE5BQAAAABIzci0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgI7YO2g4fPlyqVasmYWFhkjdvXmnRooXs27fP390CAAAAAAAAgPQZtF25cqW8+OKLsm7dOlmyZIlER0fLQw89JJcuXfJ31wAAAAAAAAAgWQSLjS1evNjt/rRp00zG7ebNm6Vu3bp+6xcAAAAAAAAApMugbVznzp0zP3PmzOm1TVRUlFks58+fl5R26NAhOXXqVIo/L5Jf7ty5pUiRIv7uBnDL+JxKu/icAgAAAIDUL9UEbWNjY6VHjx5Su3ZtKV++/A3r4L7xxhviz0BIqdJl5OqVy37rA5JPaKbMsm/vHgIiSNX0c6pM6VJy+cpVf3cFySBzplDZs3cfn1MAAAAAkIqlmqCt1rbduXOn/PTTTzds17dvX+nVq5dbpm3hwoUlpWjmmgZsy9QfK1lylEix50Xyu3TmN9mztId5jwmGIDXTc1gDtjOeFCmT19+9gS/tOSny1KyrfE4BKUgTBr788kvZu3evZMqUSWrVqiUjRoyQUqVKOdtcvXpVXn75Zfnss8/MFWENGzaU999/X/Lly+f2hVqXLl1k+fLlkjVrVomIiDD7Dg5ONcN1AAAA+FCqGAV27dpVFi5cKKtWrZJChQrdsG1ISIhZ/E0DtmF5Kvi7GwDglQZsK9/4IxUAkMCJc6tVqybXr1+X1157zUycu3v3bsmSJYtp07NnT/n2229l7ty5Eh4ebsa2LVu2lNWrV5vtMTEx0qRJE8mfP7+sWbNGjh07Ju3atZMMGTLIsGHD/PwKAQAA4A+2Dto6HA7p1q2bzJ8/X1asWCHFihXzd5cAAACABE+cq3MyTJkyRWbNmiX16tUzbaZOnSplypSRdevWyT333CM//PCDCfL++OOPJvu2UqVK8uabb0qfPn1k0KBBkjFjRj+9OgAAAPhLoNiYZi3MmDHDDHLDwsLk+PHjZrly5Yq/uwYAAADcdOJcDd5GR0dLgwYNnG1Kly5tSpisXbvW3NefFSpUcCuXoCUUtMzXrl27PD6PllnQ7a4LAAAA0g5bB20nTpxoBr7333+/FChQwLl8/vnn/u4aAAAAcNOJczXhQDNls2fP7tZWA7S6zWrjGrC1tlvbPNF6t1pqwVpScg4HAAAAJD/bl0cAAAAA0tLEub7g78l3AQAAkI6DtgAAAEBqnjhXJxe7du2anD171i3b9sSJE2ab1WbDhg1u+9Pt1jY7T74LAACAdFgeAQAAALD7lWEasNWJc5ctWxZv4twqVapIhgwZZOnSpc51+/btk0OHDknNmjXNff35888/y8mTJ51tlixZItmyZZOyZcum4KsBAACAXZBpCwAAANxCSQSdNPerr75yTpyrtM5spkyZzM+OHTuaUgY6OZkGYrt162YCtffcc49p+9BDD5ng7NNPPy0jR440++jXr5/ZN9m0AAAA6RNBWwAAAOAWJs5VOnGuq6lTp8ozzzxjbr/zzjsSGBgorVq1kqioKGnYsKG8//77zrZBQUGmtEKXLl1MMDdLliwSEREhgwcPTuFXAwAAALsgaAsAAAAk48S5oaGhMmHCBLN4U7RoUVm0aJGPewcAAIDUipq2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADYS7O8OAAAAAEgZMTExEh0dfcv7cTgcUrRoUcmXM0iyhF/3Sd/SI4dD5MKVQImKJpcGAAC4I2gLAAAApHEaZD1+/LicPXvWJ/sLDg6WSZMmScbMeSUw8JJP9pkeOUTkeoxDNuzLIMu2ZRaHBPi7SwAAwCYI2gIAAABpnBWwzZs3r2TOnFkCAm4tOHj58mWTsRuarZAEBYX6rJ/pjUMcEnv9itTNeEqPqizdlsXfXQIAADZB0BYAAABI4yURrIBtrly5fLZPFRiUUQKDQ3yyz/QqKDhUcuQUqV7qpPy0K5ZSCQAAwGBEAAAAAKRhVg1bzbCFPQUGZ5LgoAAJyxTr764AAACbIGgLAAAApAO3WhIBySfA/Kfvkb97AgAA7IKgLQAAAAAAAADYCEFbAAAAAOnS+HfelBaNqqeZ5wEAAGkHQVsAAAAAtnXs6GF5rXdnubd6MalQMkzq1S4pQwe9LGfO/J2o/ZS+PVR+/P5rt3UdOveUqbO+83GPAQAAbh1BWwAAAAC2dPjQ7/K/R2rLwT9+k9HjPpHvV+ySQUPek3VrlkublvfJ2bOnb2n/WbJklRw5cvmsvwAAAL5C0BYAAACALQ3u30MyZMggUz79VqrfU1cK3lZE6j7QUD6esUhOHj8qY98eaNrVq32nvD9umPTq9rTcXSan1K1xh8ycPsm5H92uuj73uMm4te7HLVvw6svPyoudHpNJE0ZI7apFpFqFfDLh3aFy/fp1GTmsr9SoWEDuu6e4fDHnE7d+jhr+ujR8oLxUKp1DGtxbWt4dPUiio6NT6CgBAIC0iKAtAAAAkF5dvep9uXbthm0DoqIkIOqqBHhoq+viLomlWbQ/rVoiTzz1nISGZnLblidvfmnaoo18t3CeOBwOs27KB+9I6TJ3yZffrpdOXf5Phr3xsqyO/NFsm/f1avNz2NsfSOSGP5z3PVm3doWcPHFMPv38R3m1/wgT2H2+w6OSLTy7fL4gUtq0fVYGvd5Vjh/70/mYLFmzyvBRH8rCJVvltYGjZe7sqfLJlHGJfs0AAACWYOctAAAAAOnLY49531a1qsjAfzJZjaeeEomKMjdDYmKk+IULEpQhiwQEBknUnWXlVJ8hzqb5+zwngRcvuO3uyJQvE9W1gwd+MwHZ4iVKe9xevHhpOXfujJz++y9zv3KVmtL5hd7mdrE7SsrWTWvlkynjpfa9DSRnrjxmfbZs2U3A90bCw3NIv0FjJDAwUO4ofqd8NGmMXL16WZ5/sY/Z3vmFV+TDiaNk88Y10uSRx826Lt36Oh9fqPDtcqBzD1n0zVx59vmXE/WaAQAALARtAQAAANiWlUl7M5Uq14h3/5OPxyf6+UreWdYEbC25cueVO0uVc94PCgqS7Dlyyt//BouVBmg/nTZBDh88IJcvXzTlFLKGZUv0cwMAAFgI2gIAAADp1dy53re5BC6NGTOcN6MuXZL9e/dK5hzFJSgokzjitD0+YvItd63I7cUlICBA9u/fKw9K83jbdb1mxVpZtL4SHJzB7b72Ie46kQBxxMaaW1s3r5PePZ6Rbj37S+26D0pYWLgs+maOTP3wXZ/2CwAApC8EbQEAAID0KjQ0aW1jYsQREiKOkFBxBMffhyMx+/UiR45cUqtOfZn96QfyTMfubnVt/zp5XBYu+Eyat2xrgqpq+9YNbo/ftnW9W2kFndAsJjZGfG3rlnVmgrTnu77qXHf0yCGfPw8AAEhfmIgMAAAAgC31HzxWrl2LkmfbNZWN6yPl2NHDErniB+nwdBPJm7+g9Oj9hrPtls1r5aNJo+XA77/KzOmT5PtFX8rT7bs6txcsVFTWrV5uAr5aC9dXbr+9hOnXt1/PkUMH98v0qRNkyfdf+2z/AAAgfSJoCwAAAMCWbi9WQuZ9vVoKFS4mPV98Sh66r6wMeO0FqVHzPvnsy5WSPXtOZ9v2z74kO3/eIi2b1JBJ49+SPv1Gyr33Pejc3uf1EbLmp6XyQK0S8mhj9/q3t6Leg00lomN3eXNgT2nRuIZs27xOXnCZmAwAACApKI8AAAAAwLZuK1RU3hr90U3bZc2aTcZOmOl1e70GTcziSuvQ6mLx9Dyffr4k3rplq39xu9+77zCzuIro2M3r8wAAANwMmbYAAAAAAAAAYCMEbQEAAAAAAADARiiPAAAAACBVi1uuAAAAILUj0xYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAIB2IjY31dxfghUNixWHeowB/dwUAANgENW0BAACANCxjxowSGBgoR48elTx58pj7AQG3FhyMiooyP2NjrkkAeSBJ5tD/YqPl0oW/5fwlh5y9xLEEAAD/IGgLAAAApGEasC1WrJgcO3bMBG594dq1a3Lq1CnJeDlQAgMz+GSf6ZFm18bEivx2JFAWbw6TGDJtAQDAvwjaAgAAAGmcZtcWKVJErl+/LjExMbe8v127dsnzzz8v5RtOkiw57/RJH9Mjh0PkyrVAuXw1QBxCwBYAAPyHoC0AAACQDmhJhAwZMpjFF/s6ePCg5DkdI2FB/EkBAADga6miaNKECRPk9ttvl9DQUKlRo4Zs2LDB310CAAAAfI5xLwAAAFJF0Pbzzz+XXr16ycCBA2XLli1SsWJFadiwoZw8edLfXQMAAAB8hnEvAAAAUk3QdsyYMdKpUydp3769lC1bViZNmiSZM2eWjz/+2N9dAwAAAHyGcS8AAAAsti5ApbPSbt68Wfr27es2+22DBg1k7dq1Hh8TFRVlFsu5c+fMz/Pnz6dAj0UuXrz4z/P9tVNioi+nyHMiZVw6+7vzPU6p88l6PnX1yFWJjYpNsedF8rt26ppfz6nNR0Qu/vdxiTRg3ylJ8XPKOp+OyBGJEk6otOSUnErx88l6HofOzpTOJHbcy5gXyYUxL3yNMS/SwpjXej7FuDftOZXC494Ej3kdNnbkyBHtvWPNmjVu63v37u2oXr26x8cMHDjQPIaFhYWFhYWFhSV1LocPH3akN4kd9zLmZWFhYWFhYWGRND3mtXWmbVJodoLWArPExsbK6dOnJVeuXGaWW/j+24HChQvL4cOHJVu2bP7uDlI5zif4GucUfI1zKnlptsGFCxekYMGC/u6K7THmTVn87sPXOKfgS5xP8DXOKXuMeW0dtM2dO7cEBQXJiRMn3Nbr/fz583t8TEhIiFlcZc+ePVn7CTG/xPwiw1c4n+BrnFPwNc6p5BMeHi7pUWLHvYx5/YPfffga5xR8ifMJvsY55d8xr60nIsuYMaNUqVJFli5d6pZFoPdr1qzp174BAAAAvsK4FwAAAKkm01bpZV8RERFStWpVqV69uowdO1YuXbpkZtUFAAAA0grGvQAAAEg1QdvWrVvLX3/9JQMGDJDjx49LpUqVZPHixZIvXz5/dw3/Xpo3cODAeJfnAUnB+QRf45yCr3FOITkx7rUvfvfha5xT8CXOJ/ga55Q9BOhsZP7uBAAAAAAAAAAgFdS0BQAAAAAAAID0hqAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAeDBo0CAzCRAAAACQVjHmBeyLoC3ieeaZZyQgIMC55MqVSx5++GHZsWOHs43rdmupU6eOc/uHH34oFStWlKxZs0r27Nnl7rvvluHDh/vpFcFf7r//funRo0e89dOmTTPnheX8+fPy+uuvS+nSpSU0NFTy588vDRo0kC+//FKsuRIPHDggTz75pBQsWNC0KVSokDRv3lz27t2boq8JyUdnSn/ppZekRIkS5j3W2dJr164tEydOlMuXL/u7e0in1q5dK0FBQdKkSROP2/XzTBcAqQ9jXvgS414kFGNe2BFjXnsiaAuPdMB67NgxsyxdulSCg4OladOmbm2mTp3qbKPL119/bdZ//PHHZsDSvXt32bZtm6xevVpeeeUVuXjxop9eDezs7NmzUqtWLZk+fbr07dtXtmzZIqtWrZLWrVub8+bcuXMSHR0tDz74oLmtA9p9+/bJ559/LhUqVDCPR+r3+++/mz90f/jhBxk2bJhs3brVDBz0HFi4cKH8+OOPHh+n5waQnKZMmSLdunUzn0tHjx51rn/nnXfkwoULzvt6W9cBSF0Y8yIlMe4FY17YFWNem3IAcURERDiaN2/uti4yMlK/9nWcPHnS3Nfb8+fP9/h4fewzzzyTIn2Fvd13332Ol156Kd76qVOnOsLDw83tLl26OLJkyeI4cuRIvHYXLlxwREdHO7Zu3WrOuT/++CNF+o2U17BhQ0ehQoUcFy9e9Lg9NjbW/NTz4P3333c0a9bMkTlzZsfAgQPN+gULFjjuvvtuR0hIiKNYsWKOQYMGmXPHcubMGUfHjh0duXPndoSFhTkeeOABx7Zt29yeY/jw4Y68efM6smbN6ujQoYOjT58+jooVK5ptK1eudAQHBzuOHTvm9hg9v+vUqePz4wF70M8gPR/27t3raN26tWPo0KFun2M1atQw55UuelvXAUg9GPPClxj3IiEY88KOGPPaF5m2uCnNFpgxY4a5fEMvG7sZvcRn3bp1cvDgwRTpH1Kv2NhY+eyzz6Rt27bm8q+49FJDzXjJkyePBAYGyrx58yQmJsYvfUXy+fvvv022wYsvvihZsmTx2EYvR3Wtu/Xoo4/Kzz//LB06dJDIyEhp166ducxs9+7dMnnyZHPpztChQ52Peeyxx+TkyZPy3XffyebNm6Vy5cpSv359OX36tNk+Z84cs1/NeNi0aZMUKFBA3n//fefj69atK3fccYd8+umnbhkPM2fONH1A2qTnhV6+WqpUKXnqqadMVp116apeVq3bNStGF72t6wCkXox5kZwY94IxL+yKMa+N+TtqDHtmHQQFBZlvgXXR06RAgQKOzZs3O9voutDQUGcbXawshKNHjzruuece0+bOO+80+/v8888dMTExfnxVsGPGwYkTJ8x5MmbMmJvu67333jPfMlvfGA8ePNixf//+ZOo5UtK6devMefDll1+6rc+VK5fz8+WVV14x67Rdjx493NrVr1/fMWzYMLd1n376qfncsrKmsmXL5rh69apbm+LFizsmT55sbtesWdPxwgsvuG3Xb5GtrAM1YsQIR5kyZZz3v/jiC/ONtLdMCaR+tWrVcowdO9bc1iwWzVpZvny58xzTc0QzVHTR27oOQOrBmBe+xLgXN8OYF3bFmNe+yLSFRw888ICpzaXLhg0bpGHDhtKoUSO3TAKtY2K10UVrLyn9tk7r8ug3gvot4PXr1yUiIsLUDNNvmAGL9e1dQug30lq0X7/lrVmzpsydO1fKlSsnS5YsSdY+wn/0s0c/W/R9joqKcq6vWrWqW7vt27fL4MGDTYaKtXTq1MnUHdTJHHS7Zk9p1pRrG53kY//+/WYfe/bskRo1arjtV88zV/qN8m+//WayqpRmNjz++ONeMyWQumkNQT0Hn3jiCXNfs5+05qDW+1KaxaKfP/fee69Z9LauA5C6MOZFSmHcC28Y88KfGPPaW7C/OwB70g9kvTTM8tFHH0l4eLiZIXfIkCHOS8Jc28RVvnx5s7zwwgvy/PPPm1/wlStXmsEx0ods2bKZSRTi0kkU9HzSy790Nt2EzoQbFhYmzZo1M4ueh/qHlf60/nhC6qSfI3opmA4YXOmlWSpTpkxu6+MOGHVw+sYbb0jLli3j7Vtn5NXt+of1ihUr4m13nc35ZvLmzWvOPZ2QplixYuayM0/7RNqgA1UNwLhewqp/cIeEhMh7770nvXr1ivf5FHcdAPtjzAtfYdyLm2HMCztizGtvBG2RIPqPi9ZWunLlSpIeX7ZsWfPz0qVLPu4Z7Exr4mjdprh0ptw777zTnFNt2rQxNZMGDhwYr76XDjx0AKLf9nk6J7Xuzpo1a5L1NSD5aTaA/gGigwKdsTSx3+JrrS4d/Hr7g1q3a7aKnke33367xzZlypSR9evXmzphFiu7wNWzzz5rvoUuVKiQFC9eXGrXrp2oviJ10IGrzuw9evRoeeihh9y2tWjRQmbPnm0CM4qaXkDawpgXScW4FzfDmBd2w5jX/gjawiO9LEM/8NWZM2fMPyw6kNBv3G6mS5cuZhBSr1498yGvl2vot8L67XLcSy+Qtum5oOdO9+7dzT/8+m3dt99+az78v/nmG9NGC+frN7d6mY7e1suAMmTIYArtDx8+XDZu3Ch//PGHGdw+/fTT5o+hjBkzmgwWLZDep08ff79M+IBOgKCDQX3/dXKEu+66y/xxo++/ZqRUqVLF62MHDBggTZs2lSJFisj//vc/8zi9PGznzp3ms6dBgwbms0cHHiNHjjR/OB09etScizq5gz6nXtaqAxG9rf3QyxF37drlzHywaJaLZtLofvXyNKRNOsmC/tvXsWNHkx3lqlWrViYjwRrAAkjdGPPCVxj3IiEY88JOGPOmAv4uqgv70UkU9NSwFi2AX61aNce8efOcbXS9NQlDXNqucePGpiB6xowZHQULFnS0atXKsWPHjhR8FbCLDRs2OB588EFHnjx5zCQMWrg87rlz9uxZx6uvvuooWbKkOWfy5cvnaNCggWkXGxvr+Ouvvxzdu3d3lC9f3hTB13OyQoUKjlGjRjHZRxqiE7p07drVUaxYMUeGDBnMe129enXH22+/7bh06dINP3sWL15sCuhnypTJTMCgj/vggw+c28+fP+/o1q2b+TzSfRcuXNjRtm1bx6FDh5xthg4daoru6/Pq56BOBOE6KYOlf//+ZuIa7S/SpqZNm5p/xzxZv369OQ+3b9+e4v0C4FuMeeFrjHuREIx5YReMee0vQP/n78AxAACphX4T/ddff8nXX3/t764AAAAAyYIxL+B/lEcAACABdHIRnSF81qxZDF4BAACQJjHmBeyDoC0AAAnQvHlz2bBhg6nrxMzNAAAASIsY8wL2QXkEAAAAAAAAALCRQH93AAAAAAAAAADwH4K2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAABD7+H+KiXSjiGkJMQAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1400x500 with 2 Axes>"
       ]
@@ -2765,10 +2765,10 @@
    "id": "summary-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.026205,
-     "end_time": "2026-07-09T22:54:03.282930+00:00",
+     "duration": 0.005169,
+     "end_time": "2026-08-23T02:44:57.370080",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.256725+00:00",
+     "start_time": "2026-08-23T02:44:57.364911",
      "status": "completed"
     },
     "tags": []
@@ -2807,10 +2807,10 @@
    "id": "exercises-section",
    "metadata": {
     "papermill": {
-     "duration": 0.035479,
-     "end_time": "2026-07-09T22:54:03.359605+00:00",
+     "duration": 0.004713,
+     "end_time": "2026-08-23T02:44:57.379953",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.324126+00:00",
+     "start_time": "2026-08-23T02:44:57.375240",
      "status": "completed"
     },
     "tags": []
@@ -2829,16 +2829,16 @@
    "id": "exercise1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:54:03.432381Z",
-     "iopub.status.busy": "2026-07-09T22:54:03.431871Z",
-     "iopub.status.idle": "2026-07-09T22:54:03.438659Z",
-     "shell.execute_reply": "2026-07-09T22:54:03.437044Z"
+     "iopub.execute_input": "2026-08-23T02:44:57.390436Z",
+     "iopub.status.busy": "2026-08-23T02:44:57.390243Z",
+     "iopub.status.idle": "2026-08-23T02:44:57.393478Z",
+     "shell.execute_reply": "2026-08-23T02:44:57.393075Z"
     },
     "papermill": {
-     "duration": 0.03984,
-     "end_time": "2026-07-09T22:54:03.440521+00:00",
+     "duration": 0.009563,
+     "end_time": "2026-08-23T02:44:57.394156",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.400681+00:00",
+     "start_time": "2026-08-23T02:44:57.384593",
      "status": "completed"
     },
     "tags": []
@@ -2861,10 +2861,10 @@
    "id": "exercise2",
    "metadata": {
     "papermill": {
-     "duration": 0.012043,
-     "end_time": "2026-07-09T22:54:03.463365+00:00",
+     "duration": 0.004614,
+     "end_time": "2026-08-23T02:44:57.403787",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.451322+00:00",
+     "start_time": "2026-08-23T02:44:57.399173",
      "status": "completed"
     },
     "tags": []
@@ -2872,7 +2872,11 @@
    "source": [
     "### Exemple guide 2 : Créer une heuristique non admissible\n",
     "\n",
-    "Modifiez la distance à vol d'oiseau pour créer une heuristique non admissible (par exemple, en multipliant par 2). Observez comment A* se comporte avec cette heuristique. Trouve-t-il toujours une solution ? Est-elle optimale ?\n"
+    "Une heuristique **admissible** garantit l'optimalité d'A*. Que se passe-t-il si on la rend **non admissible** (en multipliant la distance à vol d'oiseau par 2) ?\n",
+    "\n",
+    "Sur le trajet de référence *Bordeaux→Strasbourg*, A* reste optimal **par chance** : la sur-estimation n'y déclenche pas le défaut. Un étudiant qui ne lit que cette sortie retiendrait l'**inverse** du point enseigné.\n",
+    "\n",
+    "La cellule qui suit construit une instance où la sur-estimation **fait réellement rater** le chemin le plus court : *Grenoble→Marseille*. L'heuristique ×2 « séduit » A* vers Nice — qui semble plus proche de Marseille à vol d'oiseau — et lui fait emprunter la côte au lieu du trajet intérieur par Lyon."
    ]
   },
   {
@@ -2881,16 +2885,16 @@
    "id": "exercise2-solution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:54:03.512928Z",
-     "iopub.status.busy": "2026-07-09T22:54:03.512521Z",
-     "iopub.status.idle": "2026-07-09T22:54:03.521915Z",
-     "shell.execute_reply": "2026-07-09T22:54:03.520783Z"
+     "iopub.execute_input": "2026-08-23T02:44:57.414784Z",
+     "iopub.status.busy": "2026-08-23T02:44:57.414597Z",
+     "iopub.status.idle": "2026-08-23T02:44:57.421260Z",
+     "shell.execute_reply": "2026-08-23T02:44:57.420865Z"
     },
     "papermill": {
-     "duration": 0.039114,
-     "end_time": "2026-07-09T22:54:03.522843+00:00",
+     "duration": 0.013325,
+     "end_time": "2026-08-23T02:44:57.421897",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.483729+00:00",
+     "start_time": "2026-08-23T02:44:57.408572",
      "status": "completed"
     },
     "tags": []
@@ -2900,23 +2904,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "A* avec heuristique admissible vs non admissible\n",
+      "A* sur Grenoble -> Marseille : heuristique admissible vs non admissible (x2)\n",
       "======================================================================\n",
-      "Admissible   : coût=1075 km, nœuds=3, chemin=['Bordeaux', 'Paris', 'Strasbourg']\n",
-      "Non admissible (×2) : coût=1075 km, nœuds=2, chemin=['Bordeaux', 'Paris', 'Strasbourg']\n",
+      "        Heuristique                        Chemin  Cout (km)  Noeuds explores\n",
+      "         Admissible Grenoble -> Lyon -> Marseille        425                2\n",
+      "Non admissible (x2) Grenoble -> Nice -> Marseille        530                2\n",
       "\n",
-      "Coût optimal (A* admissible) : 1075 km\n",
-      "→ Par chance, la solution non admissible est ici optimale.\n",
+      "Coût optimal (A* admissible) : 425 km\n",
+      "-> Solution non admissible : SOUS-OPTIMALE, 105 km de plus (24.7%).\n",
       "\n",
-      "Analyse :\n",
-      "  Une heuristique non admissible pousse A* à explorer moins de nœuds\n",
-      "  (car elle semble estimer des coûts élevés et coupe plus tôt la frontière),\n",
-      "  mais au prix de l'optimalité : A* peut rater le chemin le plus court.\n"
+      "Mécanisme — la sur-estimation écrase g, A* se comporte comme Greedy :\n",
+      "  h_x2(Lyon) = 553 km, alors que la vraie distance restante\n",
+      "  via Lyon (Lyon->Marseille) n'est que de 315 km : h sur-estime.\n",
+      "  Cela gonfle f(Lyon) = g + h = 110 + 553 = 663\n",
+      "  et repousse le bon chemin. A* se tourne vers Nice [f = 330 + 315\n",
+      "  = 645] et atteint le but via la côte en\n",
+      "  530 km — 105 km de plus que l'optimal intérieur (425 km).\n",
+      "  Ici l'heuristique non admissible n'a même pas réduit l'exploration : 2\n",
+      "  nœuds des deux côtés. Elle n'a pas rendu A* plus efficace, elle l'a rendu FAUX.\n"
      ]
     }
    ],
    "source": [
-    "# --- Exercice 2 : Heuristique non admissible ---\n",
+    "# --- Exemple guide 2 : Heuristique non admissible ---\n",
     "\n",
     "def make_inadmissible_heuristic(goal, coords, factor=2.0):\n",
     "    \"\"\"Crée une heuristique non admissible en multipliant la distance par factor.\"\"\"\n",
@@ -2926,36 +2936,48 @@
     "    return h\n",
     "\n",
     "\n",
-    "# Heuristique admissible (référence)\n",
-    "h_admissible = make_heuristic(\"Strasbourg\", france_coords)\n",
+    "# Le piège : Grenoble -> Marseille.\n",
+    "# Sur Bordeaux -> Strasbourg, multiplier h par 2 ne dévie pas A* (le trajet reste optimal\n",
+    "# « par chance »). Ici, la sur-estimation fait RATER le chemin le plus court : h_x2 gonfle\n",
+    "# h(Lyon) au lieu des ~315 km réels, repousse le bon chemin, et A* se laisse séduire par\n",
+    "# Nice (plus proche à vol d'oiseau de Marseille) -> chemin côtier plus cher.\n",
+    "problem_gm = GraphProblem('Grenoble', 'Marseille', france_graph)\n",
     "\n",
-    "# Heuristique non admissible (×2)\n",
-    "h_inadmissible = make_inadmissible_heuristic(\"Strasbourg\", france_coords, factor=2.0)\n",
+    "h_admissible   = make_heuristic('Marseille', france_coords)\n",
+    "h_inadmissible = make_inadmissible_heuristic('Marseille', france_coords, factor=2.0)\n",
     "\n",
-    "# Comparer A* avec les deux heuristiques\n",
-    "print(\"A* avec heuristique admissible vs non admissible\")\n",
+    "result_adm   = a_star_search(problem_gm, h_admissible)\n",
+    "result_inadm = a_star_search(problem_gm, h_inadmissible)\n",
+    "\n",
+    "comparison_gm_df = pd.DataFrame([\n",
+    "    {'Heuristique': 'Admissible', 'Chemin': ' -> '.join(result_adm.path),\n",
+    "     'Cout (km)': result_adm.cost, 'Noeuds explores': result_adm.nodes_expanded},\n",
+    "    {'Heuristique': 'Non admissible (x2)', 'Chemin': ' -> '.join(result_inadm.path),\n",
+    "     'Cout (km)': result_inadm.cost, 'Noeuds explores': result_inadm.nodes_expanded},\n",
+    "])\n",
+    "\n",
+    "print(\"A* sur Grenoble -> Marseille : heuristique admissible vs non admissible (x2)\")\n",
     "print(\"=\" * 70)\n",
-    "\n",
-    "result_adm   = a_star_search(problem_bs, h_admissible)\n",
-    "result_inadm = a_star_search(problem_bs, h_inadmissible)\n",
-    "\n",
-    "print(f\"Admissible   : coût={result_adm.cost:.0f} km, nœuds={result_adm.nodes_expanded}, chemin={result_adm.path}\")\n",
-    "print(f\"Non admissible (×2) : coût={result_inadm.cost:.0f} km, nœuds={result_inadm.nodes_expanded}, chemin={result_inadm.path}\")\n",
+    "print(comparison_gm_df.to_string(index=False))\n",
     "print()\n",
     "\n",
     "optimal = result_adm.cost\n",
+    "diff = result_inadm.cost - optimal\n",
     "print(f\"Coût optimal (A* admissible) : {optimal:.0f} km\")\n",
-    "if abs(result_inadm.cost - optimal) < 0.1:\n",
-    "    print(\"→ Par chance, la solution non admissible est ici optimale.\")\n",
-    "else:\n",
-    "    diff = result_inadm.cost - optimal\n",
-    "    print(f\"→ La solution non admissible est SOUS-OPTIMALE : {diff:.0f} km de plus ({diff/optimal*100:.1f}%).\")\n",
-    "\n",
+    "print(f\"-> Solution non admissible : SOUS-OPTIMALE, {diff:.0f} km de plus ({diff/optimal*100:.1f}%).\")\n",
     "print()\n",
-    "print(\"Analyse :\")\n",
-    "print(\"  Une heuristique non admissible pousse A* à explorer moins de nœuds\")\n",
-    "print(\"  (car elle semble estimer des coûts élevés et coupe plus tôt la frontière),\")\n",
-    "print(\"  mais au prix de l'optimalité : A* peut rater le chemin le plus court.\")\n"
+    "\n",
+    "print(\"Mécanisme — la sur-estimation écrase g, A* se comporte comme Greedy :\")\n",
+    "g_lyon = france_graph['Grenoble']['Lyon']\n",
+    "g_nice = france_graph['Grenoble']['Nice']\n",
+    "print(f\"  h_x2(Lyon) = {h_inadmissible('Lyon'):.0f} km, alors que la vraie distance restante\")\n",
+    "print(\"  via Lyon (Lyon->Marseille) n'est que de 315 km : h sur-estime.\")\n",
+    "print(f\"  Cela gonfle f(Lyon) = g + h = {g_lyon} + {h_inadmissible('Lyon'):.0f} = {g_lyon + h_inadmissible('Lyon'):.0f}\")\n",
+    "print(f\"  et repousse le bon chemin. A* se tourne vers Nice [f = {g_nice} + {h_inadmissible('Nice'):.0f}\")\n",
+    "print(f\"  = {g_nice + h_inadmissible('Nice'):.0f}] et atteint le but via la côte en\")\n",
+    "print(f\"  {result_inadm.cost:.0f} km — {diff:.0f} km de plus que l'optimal intérieur ({optimal:.0f} km).\")\n",
+    "print(f\"  Ici l'heuristique non admissible n'a même pas réduit l'exploration : {result_adm.nodes_expanded}\")\n",
+    "print(f\"  nœuds des deux côtés. Elle n'a pas rendu A* plus efficace, elle l'a rendu FAUX.\")\n"
    ]
   },
   {
@@ -2963,10 +2985,10 @@
    "id": "exercise3",
    "metadata": {
     "papermill": {
-     "duration": 0.013426,
-     "end_time": "2026-07-09T22:54:03.546713+00:00",
+     "duration": 0.004776,
+     "end_time": "2026-08-23T02:44:57.431902",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.533287+00:00",
+     "start_time": "2026-08-23T02:44:57.427126",
      "status": "completed"
     },
     "tags": []
@@ -2988,16 +3010,16 @@
    "id": "exercise3-solution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:54:03.583564Z",
-     "iopub.status.busy": "2026-07-09T22:54:03.583070Z",
-     "iopub.status.idle": "2026-07-09T22:54:03.594678Z",
-     "shell.execute_reply": "2026-07-09T22:54:03.593617Z"
+     "iopub.execute_input": "2026-08-23T02:44:57.442195Z",
+     "iopub.status.busy": "2026-08-23T02:44:57.442005Z",
+     "iopub.status.idle": "2026-08-23T02:44:57.447755Z",
+     "shell.execute_reply": "2026-08-23T02:44:57.447385Z"
     },
     "papermill": {
-     "duration": 0.032621,
-     "end_time": "2026-07-09T22:54:03.595475+00:00",
+     "duration": 0.011845,
+     "end_time": "2026-08-23T02:44:57.448354",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.562854+00:00",
+     "start_time": "2026-08-23T02:44:57.436509",
      "status": "completed"
     },
     "tags": []
@@ -3009,8 +3031,8 @@
      "text": [
       "Heuristique MST pour le TSP (sur le graphe des villes françaises)\n",
       "=================================================================\n",
-      "  current=Bordeaux     unvisited={'Paris', 'Lyon', 'Marseille'}                → h=1224 km\n",
-      "  current=Paris        unvisited={'Toulouse', 'Marseille', 'Lyon', 'Nantes'}   → h=1527 km\n",
+      "  current=Bordeaux     unvisited={'Marseille', 'Lyon', 'Paris'}                → h=1224 km\n",
+      "  current=Paris        unvisited={'Nantes', 'Marseille', 'Lyon', 'Toulouse'}   → h=1527 km\n",
       "  current=Lyon         unvisited={'Grenoble', 'Nice'}                          → h=410 km\n",
       "\n",
       "Propriétés :\n",
@@ -3105,10 +3127,10 @@
    "id": "exercise4",
    "metadata": {
     "papermill": {
-     "duration": 0.009143,
-     "end_time": "2026-07-09T22:54:03.613635+00:00",
+     "duration": 0.004752,
+     "end_time": "2026-08-23T02:44:57.457763",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.604492+00:00",
+     "start_time": "2026-08-23T02:44:57.453011",
      "status": "completed"
     },
     "tags": []
@@ -3127,16 +3149,16 @@
    "id": "exercise4-solution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:54:03.633283Z",
-     "iopub.status.busy": "2026-07-09T22:54:03.633056Z",
-     "iopub.status.idle": "2026-07-09T22:54:03.879314Z",
-     "shell.execute_reply": "2026-07-09T22:54:03.878365Z"
+     "iopub.execute_input": "2026-08-23T02:44:57.469455Z",
+     "iopub.status.busy": "2026-08-23T02:44:57.469256Z",
+     "iopub.status.idle": "2026-08-23T02:44:57.544860Z",
+     "shell.execute_reply": "2026-08-23T02:44:57.544297Z"
     },
     "papermill": {
-     "duration": 0.257805,
-     "end_time": "2026-07-09T22:54:03.880106+00:00",
+     "duration": 0.082834,
+     "end_time": "2026-08-23T02:44:57.545609",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.622301+00:00",
+     "start_time": "2026-08-23T02:44:57.462775",
      "status": "completed"
     },
     "tags": []
@@ -3156,7 +3178,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAooAAAIDCAYAAACDyz+cAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOwxJREFUeJzt3QeUFFXaxvF3MgiiZLMgQREVBCS4oiCKiqKiYFhExYiYV8XAiooRFMSEuyZA1iwY2AXRJYmZIMY1AAKCiJLzJPo7z9Xqr6a5M9M9zNAz8P+d04ehu7q6+lZ66t5bt1MikUjEAAAAgBipsU8AAAAABEUAAAAUihpFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOCV7n8aABCv//73v/bBBx9Y/fr17YILLqDggG3A/lS+UKO4E7vwwgstJSXFPaZOnRp9PniuXr160edGjhwZff7OO++0nZXKSWWgsisLKvOgnMsjtoOtff/999atWzcbPXq0dezY0XZWwba7MynsGLojSNa+zv5U/lTooNinT5/ohqzHAw88UOT02tjD4Qfly8KFC906Va1MVlaW1axZ01q3bm33339/qcx/5cqV1q9fP2vSpIlVrlzZMjIybJ999rGzzz7bPv/8cytLM2bMsN69e1uDBg3cZ9eoUcMOP/xwtzz/+9//yvSzd2RffPGF9e3b15o3b27p6enRY4FOcrGWLl1qgwYNshNOOMFtY1oPu+66q7Vr185GjBhRos/fuHGjde/e3fbYYw+bNm2a7bfffgVeX7BggTvu6PHmm2+W+HvuyAErNTXVvvnmmwKvd+jQIfr6O++8k7TlxPZV3P60vemcceutt9oxxxxju+yyS3SbLKyiQL+I/M9//tOOOOIIq1KlilWtWtXatm1r//rXv6wiq7BNz7m5ufb6668XeO7ll1+2W265pcBzH330keXl5dnRRx9d4PnffvvN/v3vf9tFF11kO6v+/fvbJZdc4v4+9NBDk7osH374oXXp0sXWrl1bYCcNHtpZt0V2drbbBmJPSEuWLLFXX33V3n77bbetKLyVNm2TCihhmzdvtlWrVtmcOXPshx9+qDAhQuto+vTp7u9kH8RlypQp9uSTT8Y1rU48sccH+eSTT9xDoXPYsGEJff5XX33lTmyXXnqp7bXXXlu9rqB41113ub/VJH366acnNP+dgU6u9957r7344ovJXhQkWXH70/a2aNGiYiugwhQgn3/++QLPffrpp+7x7bff2n333WcVUYWtUXzvvfdsxYoVBZ7Tgf67774r8Nxrr73mrga08emgrdA4ePBga9SokbvKX79+vZUXGzZs2K6fozI46qij3GO33XazZFm9erX16NHDhcS0tDRXq/jGG2+4moQnnnjCTj755K3eoxqgiRMneuenCwa9P0zTBiFx9913d82EulBo1qxZNLg999xzpf7dHnrooQIhUbWXY8eOdX1wFHBU9hVJnTp1ottMeQiKWpddu3Z1B+C//OUvxU5fqVIlu/jii23MmDFu/Sv4Bh599FGbP39+Qp/fpk0bu+OOO8rFSa0i08Xajz/+mOzFQJLPd+Vtf8rMzHQVDLrALK5SafLkydGQWLduXXfh88orr0S/iwKnWpYqpEgF1atXr4gWX49zzjkn+vcdd9yx1bSTJk2KHHHEEdFpdt9998j9998f2bhxY5GfkZ+fH7nnnnsiTZs2jVSqVCmSlZUV2XfffSNdunSJPPPMM9HpLrjggui8p0yZEn1+xIgR3uU65phjos/PmjUr0rt370jNmjXd/4vz2muvueXRsujfV155xc07mJ8+M7D//vtHn1+4cGHkjDPOiFSrVi1Sr169Ipc7eE7vL+67yPz58yOXXHJJZL/99otkZmZGateuHTnrrLMi3377bSQegwcPjs777rvvLnb6zz//PJKWlhbZZZddIh9++GGB18aPHx/JyMhw5TN37tzo888//3z0M7p37x59/vHHH48+36dPn2I/W+WkaVV2xVmxYkWkatWq0fnfcMMN3unC5RReZ7///rv7HG2vmo/KVPOM9eabb0Y6derkplP5N27cOHLnnXdutX2Ht7uZM2dGevbs6eZbt25dt063bNkS+eKLLyIdOnRw27u29UceeaTAPOLZpjWPq666ym0Hms+JJ54YWbBgQbHlFTufn376KZKIs88+27sfhMv5559/LvDc5s2b3fcP3qf9KR7vv/9+pGvXrpFatWq57U3r7dprry2wfsLfJfYRbD/Tpk1z22PDhg0ju+22m5vXnnvuGenRo4crx7Dwfv7cc89Fhg4dGjnggAPctt6iRYvIu+++u9Vy/vbbb5Hrr7/ezV/bhrYRHb8+/vjjrab9xz/+EWnZsmWkSpUqbtq99trLbVeDBg2Kq0yCbTce4WNP8NBx0Fd2EyZMKPDeGTNmRM4888xInTp1omV/yy23RDZs2BBZvHhx5Pzzz3fbnr5DgwYNIjfddFNk1apVcW1nhR1L5bHHHnPlrW1a5xOdVwo7hupvlV316tUj6enpbjvRe6655prI6tWriy2fnJycyJAhQ9x61XFOj9atW0dGjx5dYDqVWfD5Wr6A1lnw/GWXXRZdpvD2984777j1re1H54SHH364wLyLOub/+OOPkQsvvDCyzz77uHVQo0aNyEknnRT573//W2C62M8cM2ZMpFmzZm7dhOcZz/4ky5cvj1x++eXuXKPpdPxq1KiRywBTp04ttlyLWr/FefLJJ7faf8NuvPHG6Os6/gYeeOCB6PM6T1ZEFTIobtq0KbLrrru6gtcB4ddff3U7o/5/4IEHbjW9NqA2bdoUCIrakTSfogwcOLDQA/1f/vKXUgmKOvCE51sU7WQpKSlbLYt2vOKCYvhzggBYGkFRQVfl6Ssj7cSffvpppDjt27ePvueuu+6KHHLIIe5grIOBTgC+9aQdLliXc+bMcc998MEH7oCq53VyiA2zwTai9+iA++9//ztadqmpqe6kXZpBMRxOFQLWrFlT7HvC66xJkyZblanCXdjtt99e6Daqcs3OzvZudzqBxk5/9dVXe9fle++9t03bdOz+kqygWJjwRaS2ieI8/fTTbnvxlblOWsHJLZ6gqAvWwqbRthy+iAif5HSci51eJ06dcAO6ONSJ3DdvTfvWW295t9XYx957712mQbFVq1bRZQouKAoLimPHjnXT+ZazXbt2hX7fgw46KLJy5coSB8UHH3zQW4bhfTQ4hn733XeRypUrF1qeClnFhUSFzMLe369fv+i0Cp1aP3pelQBLlixxF8jB5ysArl27dqvQpv1fF9ux89b2WNy+rmN6cP6Nfej8NHz48Oi04c+sX79+gfNXMM949yc59thjCy2X/v37JzUoXnrppdHXtb0EFOCD57W9VEQVsulZTUbr1q1zf6vPj6p51fk5uGMqfGPCjTfe6F7bc889XR+hvffe226++Wa755577KCDDiqy6fmtt96KNm+pM6qaC1W1rKZRza+0+kCoql1Now8//HCh0+Xn59t1113n+vOImmr/85//2DXXXOOa3IuzbNkyGzp0qL377rt22223lcqya1lUpmo6lhtuuMHNX02takJW2eoGjmCZC6O+GwGVxddff+2agoP+IaeddtpW81CH4bPOOst9dufOnV1/VTVRqzO0+l2qe0GYbl544YUXXNOp3tOrVy875ZRTXNkdcsghbrlj+7Fuq/B6Oeyww6xatWoJvV/Lqe1u+PDhrgkkaFZfs2aN+1vNGHfffbf7W9vjs88+65rrg6Z69SUsbJvS/vPSSy8V6DPz2GOPuU7kara/4oorCpR1In7//Xf7xz/+4ZZd+07QBzW2f2h58NNPP0WPF+p43r59+yKnV5/Wq666yrZs2eKasYcMGeLKXNuiqPk06Aep8lRzduCkk05y60QP9Q8W3ayl6dRHVv0t1aUm6Kqgbbmw9Td37lwbOHCgOxbq5pyg37aOEQHd5LN48WL39/nnn++WU90d9D01rZrSgua/4FinG4K07iZNmuT2F+3T2nfKkpZt3333dcsU25c3TMcT9V3TdMH30zFQz8nHH3/svq9uUFKZ6piq44+oS1JJ+zmrL/GAAQOi/7/66qvd56obie9GNK3DTZs2ub+vvfZaV5Y6Pumc06pVq2LvDH/kkUfce0Q3Qmh/1PsPPPBA95yOberzJuoy9Mwzz7i/1XVH5wOdn/T5+hx1p1F5xJo3b55bfn2P66+/Pvq8umMtX7680GXTcVhlGpx/1aVL87j99tvdTUl6Xdvgzz//7N3X9P3VHUx9srWvJbI/6TO1j4j6kmufmTBhgttezzzzTHfzSDId+Of6ER37tC3+8ssvNmrUqOjzvnKpECIVkJodgoQ+ceLEaLOJ74pr+vTpkcmTJ0evJoJaMtVCPvXUU0V+Ttu2baNX1GqqUdOGz7bUKN52221xfWddxQXv2WOPPdxVZ+xyxl4lhWunfN91W2sU1QQcPNe8eXNX1sFDV/fhZs6ihK9s1VSj2g099HfwvJpXY6kM1KwZvqpU86y6DPiomTpcsxw8VNPYt2/fSG5ubqnWKAa1nnqotise4XX2xhtvRJ8Pf8+gBlVNM+HtKCj7cePGRZ9X7axvuwtvD+HmcTWniZq9w+s2kW063ISl5vyi1mFpSrRGUc1Yhx12mLfprjD6bsH0t956a/R51dyqyVbPq7YlLy/P2/QWS8cUNVMdeuih0drw8OPwww/31oaEa5ZVqxR+76JFi1wtTFB7o+NFeN/s1q1bdNrXX3/dzSPovqP5qPkwntrv0qpRVE1NUOuiZlDVivlqFFWbGDynJtMwdcMJl3PwXVXDGpSNavWD9ZJIjaK6IwTPqfY5oHmp1SP2GBo+Fw0bNiyydOnShMox3EL06quvRr9LuIVLXTvCLr74Ym8LQVh4W9RyB2UhqvEPXtOxt7B9ffbs2YWeh8Ln5eAYEP5MHWdim5IT2Z/UlSaoeTz++ONdbXs8x+zS8mQxNYrq5qGm89j1EHuuqYgqXI2irip0BSMaYuTYY491f59xxhmuFkvUgTSogVKne9/YZqqFDK5EC6NO76KrHg2hoSvxhg0b2uWXX+7uVC0N6ogfj3An+xYtWrihXQJattL6nESEy0B37+oKMXjo6j5Q3PAvGgonoJos1fbpoSvjgGpzY6kMVGMTrHddkequVV3ZxlKNgrYVXYmrJlk1z7qbWleuusFJtXaxtZDbKnyDkK4sE6WbsAIaKigQ1OCGy181g0HZh9d17M1dAdVkBapXrx79W1f8UqtWra0+r7SWuzzQUDlazi+//NL9/29/+5ur2ShOuMw1bFMwXIa24aB2TseoeNf3ueee62pxdLenahBjFVZm6vQf3s7CtRk6VqjGMTgG/vrrrwX2zfCNXsG+qVoifQ8tw3HHHefmqVq+8847z2bOnGllTa0Aqs3W6AQPPvhgsWUf/v6x27NqcILvqlaCoFxVE6/1nqjwsVfDngR03GnZsuVW06sFJNjuVbum2n6dq1SjrNq04oS/p45PwXcJ12rGHlPVWqTWsoBqgYu6W1f7eXDcjC2/om7oCi9b7HkoPA/f+VE3m6kcSro/aTgr7S9Bre3BBx/shqxR7aLKJmhpSZbatWu781R45Ax9F9V2BoIWloqmwgVFVVmrWVJ0oteGqpWhJkU1zwbj8YWDSkAHZN35nMjBS1XbCi1qnlTzn6rsn3rqKXeSCQ7i4aaEYBmkqCr8cGBNVEkGtS3J52yvu7nDd8/uv//+3r/Dw+aEy1cHZZW5DnraLk499dRos0iY7nLWSSg4KTZu3NgFJDWtBUp7iJrgjmpRIPEtV1HCAU5NgoHimvLDFIKD711YiA0Ha1/zeCKfV1rLXZZ0fNCJN2gKV9OWmrwSpZOUytH3CI5RRVHXCjWfiS5CdbGiQZvDAzerSS4eJR3oOtg31X1D3QN08awTnb6bms7U/KxjXaJ3gydKF3nqJiQ6vqr7QiLi/f7B992WY3Zxn6vAO2vWLNfFSRUVCo1qvg6aVNV9pLSPqepapPNhePg3PRev0hgovbh5FHcOimd/0mgX6gqj47zGpNW6UyWFuuCoKT3ZmjVrZrNnz3bN7OoapJFZ1P0g0LRpU6uIKlxQVL+qeJTGzqgT24knnuj6JeqKX31kgj5AukrXuHuxJ109H4hnoNh4d1DtFAH1qQof3HyhuKSfkwiFrYBOJn/eHFXgoQOaamCLEh7WRCdP39+q3QhTcNS60ZW1dk71a1Rtr2o/VKMW9BHynQDC/VLD4a20h0pSX0EFANHVrvoo+ZR0wO1w+esAWlj5h2tsd3aqSVZI1AVfUIuRyIDu4TJXLaQuFmMf2m419FRsCI8NfWqpCKifoWrTtR/Fs74+++yz6N/atvS9AgcccIDbF4J9XscOXTDEbhs5OTmun6Po/2qZUEjTiU77RRCeVSO3PQa9VguCarL1eeF+y76yD3//2P///e9/L3RfCGpefcdsrR/VVMVSeQbCtas6BvtqW/VZushVjZ76o+rYEx4WRcNjFSX8PRXQfd8l6MMYLLcufnXMC2oJ9V3VIlbYxZmCbHh7DPo8xn7fopZN5yFtV755hKcr6hyU6P6kC8/LLrvM9alVrbkC+JFHHuleUz/z7TXEXHH0wx6qtdVFs4ZIC6hffEVUoQbcVjoPdmR10I0dvFIHvqCGSFX8hTVDxksddfU5OrHoFzy0U4QPDEFNjQ7K4YOUNm6FyPDOvK1Uza+wpM6wqoZXB/CePXu6DtsaLDgZFNBU06qQpsGMtUy6yUa1vKq51cFbzVzamYuruVWnax3U1NleTcOiTsqBcPW9DogKgzrY6QCiA4RqlLVt6Apey6Ll0GcHTSPhKzmNzaiDoa70dfNMQL/uUZrUzKL533TTTe7/atrW+lOtgmru1OyiGhstR0lqM//617+6ju+iDumqUdBNM9r+FIRULjphlcX4kGVFN55p/Ymuyov7JSXVDgYn4eDGDdF+GoR0jZWo2gqFKTVFqrZFtP9oe9FvNIdPXNqWijomqAZS+75uvNDxRRc6CjdaXjU96bWgq0S4dlWfoxYKHVP0OeEac43BpotgnejjudlM02o/Ue3f448/Hj1B6v/BRZWaOsePH++2BdXAKDjos1VmOskrsOgiU2WsmyDULHv88ce79+uEHAysLr5a6dKmmxF0Ia5jqI+WTfuUtnOtX91UonWr0KBjUED7mZZfwTdYLzoWK6iMGzduq2O25qNjkG4M8jWZ6nNV46laLR3TtIwK9qqMCF/MhteNjl260VJNwAqlWr/xlqW2y+BGOAUL/XqTzj9aP+pKou+r81zw6yC64Um1waJl0/6vG9t044dqqa+88sqtPkPbgG5E1DFEZRO8XxcpugAvjI6R+mUrXdxqebSsWg6FxKBLg1rewsfroiS6P+miR/PWuUfjE2pf1nSi84emLeqmFrUqBgPg6+K6uJ9i1XKMHz/e/R2+SVblF/zgh7ojBPuy1rn2QXVJ0Pailqyg1UBdEIIfuKhwIhVIuJOwOs76qON9ME3smE6JKmqIAo29FoyHpU7x4RsCgkd46ITCOv4nMgRIYcPjqCO8rxN/+MYIn7IeHqeoz46l4WwKe//NN99cYFoNP6HP1Dh/GgIkTB2cNSal1o869Qc0RITGkivsM9Rh+uuvvy7Vm1kCWv6iyue0004rdp0Vtq6KGh4ndjkL2+4K+8xEtoOSjEvnk+i+EV6ewh7BfOKZNp5lLGo4Dz30HQLqbK9O/4V9zsknn7zVa+EbC8JlHy7L8E044Y7y4W2jqOFxYsvGdzNE8NBQK/PmzSvTm1kCOqbqppPw58cOjxMMcxX70DiDRX3fE044ocBxwrcONYyOb1sIj4UXPPT+8FBQQdlr6K2iyvyll14qsmx0I0dR557wsulYqKHEguFndHOUxozUWJx6TjeEaGiw2BtLdG7yDTOkcYPLanicwo6ZiexPviF9fOu3MIkej7R/WALHjPCNSOGHhi7S8G0VVWpFbXbWFbJPuCP/tjY/a/gF9XvQVYxqJ3SVqg7DuopS7UDQfBHUCKk2R1dTml61VroSLE26YUe/YKBOvPocXdlp9PdOnTpFp1HNyfakmk71EVGzkWrptFzqsKuaRj0Xb62qagHUCV1XZ/oOeqjDuoYZiO2UreYj3dCkGsTYXwdRmaiWVbVp4eZq1aSo5lVX4qqJUQ2B1qeu1NUHVTUFZdV/RMuv+esKXjUM+mxtOyoj1QRuy29ZB0OkqBZA26FqULWNqqZMnxtcPaP0qFbg/fffd/uj+l1pO9K/6syvYUJUixPQa6pR0PrwDVOiGgdtF2py1X6jbTGo9SqKthvVJOpYo31OtRjaDoJhwkT7hmpBVKMdbPNaBv2t2n8tV7CP6Jim5dC+pW1TNZuqWVUNiWoWi2qOLE36bNVuFqZbt26utUZlr5sHtL2rRlS1Uqq1U82YbsBRP0G9pn91HFFNUlD7HhwnVJuvmkWVn/ZFHVsL6+em/oZ6vz5LtW6qWVPNnm84JdVkql+ajo1arypLfS9NqxstzznnnCLLQMujpn7dqKdtSutM607HDnVnUW2hykFNx6oRC/rvqRZTx01tR8HPWqqm2TdEmearz9DxVt9HNWLqahAM21QUvVetOcFwc9rGVXOuY5COu+GhtUp7f1IrompzddzWcuuhbVbbeDw3CpW1nj17utpElYfWo/ZBNZWrj3o8vxxVXqUoLSZ7IRAfrSpfPw+NtRX0D1H/orL4vWL8QTca6C56HSRHjhxJsWC7SbTZbHtTiFKTHKeU8n3sEo5fSESFqlHc2enKXsMDqMZMB2T1Y1H/kyAk6soqfKctAADATnMzy85OTQ1qTvc1qat5QjVc23LzDgAAQBipogJRPyH1v1G/JPVFUf8M9bFRnxDVLqoJGgAAoLTQRxEAAABe1CgCAADAi6AIAAAAL4IiAAAAvAiKAAAA2LbhcaZ9OctWbVoX7+QIqbylqmVmVKZMSiAvN8fSMzIpO8ptu1m/arltyc9nmyuBGrtXs6pVtu+vQ+0osnNyLCuTYx3ltv0cfujBpRsUFRJv+WXUtizTTuvB2n1tVm7tZC9GhdQsdbHNoOwot+2o/oZFdt/DT23Pj9xhDB/U3/bbb59kL0aF9MPc+ZQd5VYu0fQMAAAAL4IiAAAAvPgJPwAAkPSfqM3Py7NIwu+MWE5OTpksU0WXYmZp6enb/NO+BEUAAJA0mzdvslXLl5fovZXTU23Fb8tKfZl2JNVr1bJKlUp+Qy1BEQAAJK0mUSGxatWqVrNGTUtJUT1Y/LhbvHCRSMRWrFzhyrfuXnuXuGaRoAgAAJJCzc2ikFi5cglqvVJSrFJWVukv2A6iZo2atn79elfOqSUcfombWQAAQFIEfRITrUlEfIJyTbzv5/+jRhEAAJQbSzeusFU56+OaNic3xzLj/FGG6plVbc9dalpp+eijj2zNmtV20kldbEdGUAQAAOUmJJ48pb/lbPmjSbo0Zaam23863ltsWGzYsIFlZWVZVlYl27hxgx188MF244032ZFHHhmdZvLkSfbSSy/bY489VurLuXr1anvqqX9av343W3lA0zMAACgXVJNYFiFRNN94aypfeOFFmz17tn333ffWq9f5duqpXe3TTz+Nvn7ssZ3s6aeftkqVKpXqMubl5bmgOHjwYCsvqFEEAAAoRLdu3WzGjM/s4YeH2ujR/7I77hhgU6ZMsZycXGvcuJENH/6kVa9e3S666CJ3Z/H3339nK1assDZt2trw4cPdTTovvfSSPfbYo+49utN74MC77JRTurr5d+p0rB166GE2c+YMN21mZqatW7fOWrZsaenp6QUCajJQowgAAFCE1q3b2LfffmtDhjxkVapUsY8//sRmzZplhxxyiA0YMCA6nQLl+PET7KuvvrZVq1baI48Mc8937tzZPvzwI5s5c6aNHTvW+vTpY9nZ2dH3/fjjDzZlylR7773/2hNPDLddd93VzT/ZIVGoUQQAAChmTEJ56623bO3atTZ27Bvu/7m5Obb//vtboHv37i7kSe/eF9njjz9mt9xyq/300092/vm9bMmSJZaWlm4rV650zx100EFu2r/+tadlZGRYeURQBAAAKMLMmTOsadOm9tNPC2zYsGF2/PGdExqe5rzzetq9995nZ555pvt/nTq1bfPmzdHpNOB4eUXTMwAAQCHefvtt++c//2nXXXe9nXbaqfbII4/Yxo0b3Wv695tvvolOO2bM2D8GuM7Pt1GjRlqnTp3c86tWrbJ69eq5v1944QX3/8JUq1bNNm3aVG5+w5oaRQAAgJCePf8aHR6nSZMm9vbb46xNmzbuBpPs7LvdUDlBbeFNN93kahulVatW1qXLSbZ8+XJ3M8s111zrnh869GE755yzbbfddreOHTvYfvvtV2h516hRw847r5e1aHG4ValSNen9FAmKAACgXNCg2BrvsKzGUdT8izN37rxCX0tPT7c777zLPXwOPfRQe+aZZ7Z6vmfPnu4RePDBh6J/T5o0eavpVYNZXhAUAQBAuaDBsDUodkX4ZZadBUERAACUGwpz8Qa6zdnZVikry8qD5557znZE3MwCAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIubWQAAQLmR//syi6xdE9+0uTmWF+ddzynVdrO02nWtvJkwYbwbX1FjM5ZHBEUAAFBuQuKqK3uZ5cb/qySb4p0wI9OqPzE6rrC4bt0623fffaxHj7Ps6aefjntZxo0bZ1OnTrEhQ4bGNb1+peWrr760++6738ormp4BAEC54GoSEwiJCcnNibum8tVXX7UWLVrYm2++4X6Sz0c/0xeWl5dnXbt2jTskigbhfuCBQZaaWn7jWPldMgAAgCQYMeI599N87du3d6FRRo0aZccd18nOOquHNW/e3D777DPLyEi3u+6609q2bWv9+9/mpjnzzDPc9CeeeIKNGTMmOs9p06a6n/gLaiwvv/xya9eurR1++OHWp0+f6G87//rrr3buuee41/Q5AwbcntRtgKAIAADwp2+//dYWL15snTufYL17X+RCY0Dh8O6777E5c+ZYu3bt3HNpaWn2ySef2KBBgwuU4QUXXGjPPz8q+v+RI0fZhRde6P5WCD3qqKPs448/sdmzZ9uWLVvsscceda9ddFFvu+KKK9xrM2fOtFmzZtnrr7+etPVDH0UAAIA/KRied955LgCedNJJ1rfvFfa///3PvaZweOCBBxYoqwsv7O0tu9NPP92uv/46W7p0qe266642fvx/7KGH/viN57fffsuFy2HDhrn/b968yX3ehg0bbPLkybZs2W/R+WzYsN5++OH7pK0fgiIAAIC6MebmuhtMMjIy7OWXX3ZlsnHjRhcemzY9xKpWrbpVOfmek8qVK9uZZ3a3F174l9WqVds6duxoNWv+8dOEkUjENWk3bty4wHuC/pAffvihVapUqVysE5qeAQAA/rxruX79+rZw4SKbO3eee3zwwYcuPCpEJuqCCy5w/RbVBB00O8upp55mDz74oLsBRlatWmVz5851obNDhw42ePCg6LS//PKLawpPFoIiAADAn83O55771wJl0aRJE9trr73dDSiJat26tWtSnjdvnh1/fOfo80OGDHE1jq1atXQ3s3Tu3NkWLlzgXnv++dEuoDZv3szdzNKjR3dbsWJF0tYPTc8AAKBc0KDYGu+wTIbIycj8Y/5FGDfu397nZ8yY4f69/vrrCzyfm/tHjWC4BlGPsDlzvthqfqo5fPTRP25eiVWnTh17/vnnrbwgKAIAgHJBg2FrUOx4xzvMzs2xrAr+yyzlHUERAACUGy7MxRno8rKzLT0rq8yXaWdGH0UAAAB4ERQBAADgRVAEAACAF30UAQBAuRFZv9gi2Svjmzgnx7ZkxnkzS1YNS6m6z7Yt3E6IoAgAAMpNSMx+s51Zfnbc74l7IJ20LMs6/eO4wqIGwr7//vvslVdesfT0dEtLS7cjjjjC/aTfwIED3e8vl+Wg31OnTrEhQ4ZaeUBQBAAA5YKrSUwgJCYkP9vNP56geOmll9qqVStt+vQPrHr16u4n98aMGWMrV8ZZ07kNunbt6h7lBX0UAQAA/qSf0hsz5nV75plnXUiUlJQU6969ux1wQH3Lz8+zq666ylq0aGHNmh1mM2fOjJbdu+9OtGOOOdr9Iku7dm1dzaBMmzbV/dLKlVde6X6JRb+48uWXX9pFF13k/j7yyHa2ZMkSN61+8u/MM88o8L7CPm97ICgCAAD86fPPP7eGDRtZrVq1vGXy3XffWa9evWz27NnWt++VNmDA7e75+fPnu2Zp/brLZ599ZqNH/8tNl52dHX2fgqHmf9ppp1rnzsdbv379bM6cOdayZSt79NFHEvq87YWgCAAAEKeGDRtamzZt3N9t27Z1AVEmTpzoftO5Y8eO1rJlSzv77LMtNTXVFi1aFH2fnhcFwwYNGthBBx3k/q/+j6rJTOTzthf6KAIAAPxJTcNz5/5oK1assJo1a25VLllZlaJ/p6WluRtfRP0YjzvuOFeTGOuXX5bEvC/VKlXyzyfez9teqFEEAAAI1eB163aGXXbZpbZ69epoCBw7dqzNn/9ToeXUuXNnmzRpkut7GFATdEVHjSIAAEDIM888Y/fdd6/95S9HuuFxtmzZYkcd1d5OPPHEIgPm6NGjrW/fK2zjxk2Wm5vjblTx1TBWJCkRxeQ4vPnpVLvll1Flv0Q7oAdr97Wvtuyf7MWokJqlLrYvtjBAKuW2/dRfOcvue/ip7fiJO47hg/rbwU0aJ3sxKqQf5s63xg0PsJ1NTk6OrfhtmdXbv55rii3JOIpWBuMo7ig2b95sCxYusJp16lpmzMDkNXerFtc8qFEEAADlgkKcwly8v8yioBkbgAqdN7/MUiIERQAAUK7CYty1ftnZlpqVVdaLtFPjZhYAAAB4ERQBAADgRVAEAACAF0ERAAAAXtzMAgAAyo212fm2MTeukfssJzffMnPj+6WSXTJSrFpWmlU0a9eutZEjR1qfPn3ivsO7NBEUAQBAuQmJT89ebfnx5cQ/bYprqrQUs0tb7F5sWGzYsIFlZWVZpUqVo88pqB166KGWqFGjRtnbb79lY8aMtZLQL8NccUUfu/XW25ISEoWgCAAAygXVJCYWEuOn+Wr+1eIYTeeFF150v6qSDPoVGElNTbXdd9/dXnrpZUsm+igCAAAU4fvvv7d69fa3+fPnu/8PHTrETj65iwt1qjU8/vjjrFu30+2www61jh072IIFC7zzGTLkIWvW7DAXQnv16mVr1qxxzw8ceJeddVYP69LlJGvevJktXbrU3n13oh1zzNHWunVra9eurU2dOiUp64gaRQAAgJCePf9aoOn5gw8+sAceGGTnnnuuDR48yJ588kn76KOPXa2ffPTRRzZz5ixr0qSJPfTQg665eMKEdwqU6TvvTHBN2NOnf+BqCtXn8LbbbrMnnnjCvf7JJ5/YjBkzrW7dui6QDhw40MaPn2DVqlWzuXPnugA6d+481yy+PREUAQAAiml6Puecc2zq1KnWpUsXmzjxXatdu3b0tXbt2rmQKJdccqkNGDDA8vPzC7x/0qRJ1qNHDxcS5fLLL7dzzz0n+vqJJ57kQqJMnDjR5s2bZx07doy+rlC6aNEia9So0XZdVwRFAACAYuTl5dk333xtNWrUsF9++WWbyyslJaXA/6tWrRr9OxKJ2HHHHWejR/8r6euFPooAAADFuO22W61x4wNtypSpdvPN/VxzcEDNxt999537+7nnnrUOHTpYWlrBu6s7depkr7/+uhvuRp5++mk77rjjvZ/VuXNnVwP55ZdfRp/77LPPkrKOqFEEAAAooo/iXXfdae+++67rl7jLLrvYgw8+5PorTp8+Pdr0rCCp5mLVOI4YMXKr8lTT8jfffGPt2x9lKSmpbridxx9/3FvuDRs2tNGjR1vfvlfYxo2bLDc3xzWFJ6OGkaAIAADKBQ2KrfEOy2KIHM1X8y+ObhjxOeWUrtG/u3fv7h4B3XDiGyvxggsucI/ADTfc6B6xBgy4Y6vnOnU6zj2SjaAIAADKBQ2GrUGx4/9llhzLzMjcoX+ZJdkIigAAoNxQmItnUGzZnJ1vlbKSG2UuiKk13NFwMwsAAAC8CIoAAADwIigCAADAi6AIAAAAL25mAQAA5cbSZb/b6jXrSv2u591329X2rPv/P7uH+BAUAQBAuQmJp194jeXk5Jb6vDMzM+zNkY/GFRZzcnLsjjsG2BtvvGEZGRmWlpZuf/vb3+z888+3adOm2t/+doPNmjUr7s/WezZv3mwnnHBiiZd/wYIF1qpVS1u+fIVtTwRFAABQLqgmsSxComi+mn88QfHiiy+y7OxsmzVrtlWpUsWFtK5dT3G/99ygwQEJf/a0adNs9eo12xQUk4U+igAAAH/68ccf7a233rInn/yHC4lSr149Gzx4sN1zz93u//n5eXbhhRda8+bNrHXr1jZnzpzoe48+ur21aNHC/eTegAG3u9eeeuope+mlF61ly5ZuHgqcXbqcZG3atLFmzQ6zXr3Osw0bNkTXwciRI920mo+mUVCNNWPGDDv++OPc661atXK/I10WqFEEAAD4k4Jdw4aNrGbNmgXKpG3bdvbzzz/b778vd7/ZPHToUBfoXnvtNTvvvJ721Vdf2/Dhw+3kk0+2m2++xb1n5cqV7refL7vsMlejqPdIJBJxv9usz9DfV111lT3xxOPWr9/Nrpn63nvvsfffn2577rmnbdy40b3nt99+iy7L6tWr7YorrrBx48a5aZYvX26tWx/hfnN67733JigCAAAkS7169ezYYzu5v3v06GFXXNHHhcj27dvbLbfcbOvXr7ejjz660N9qVjh85JFhNn78BFe7uHbtGhfyZPz48dazZ08XAGWXXXbZ6v0ff/yR/fTTfDvllFMKPP/DD98nLyjWzN1sz+zWpVQ/fGexYu0Kq5+zPNmLUSFtSk+z+nnLkr0YFU5k9+rWLH1xshejQsrOzLRbrrk42YtRIeXm5dsPc+cnezEqpN+Xr7SfFy+1nU1Geprtu0ctW79xo+Xk5dmGTX/UnpUV3SW9OTu7yGmaHHywzZ37oy355ZcCtYrvT3/f9tlnH9ttt91c0AvPJyUlxXJyc63LySdbi5YtbPLkyfbY44/bsGHDbMzYNywvL981Vwfvefnll2zS5Mk2fsIEq1atmj05fLhNe3+aez0vP99NH7uc2Tk57l89n52Tawc1aWKTJk3eavnD79N7FEQXLPpZS1lgunYtm5duUKyalmeNfuoT7+QIGV9jhN03bARlUgI6YT/w6LOUXYLuG3ibfbllH8qtBOrnLGObK6Hhg/pb44aJd/SHuZB499Cndrqi2LNOTbu5by/LWr7SUlPTbPmKVWX6eRpKp1JW0T8kfUjTpq6m7vrrrrWRI0e5Gj31Efx7//7Wv//f3d3TCxcutE8+/sg6dOhoY8aMsbp161qDAw6wuXPnWoMGDeyi3hfZke2OdP0V9XnVq1e3JUuWRD97/br1Vqd2bfdYt26dvfjii7bffvu6108/7TS7+OKL7corryzQ9JyV+ccwQJrmmKOPtquvutI+/GB6tNZSTeYHH3ywZf45nROJWHp6utXbq27B5xNAH0UAAICQESNGuhtRDj+8uQtYaWlpbkic3r17uz6ETZs2tVGjnrfrrrveva7+hqpVHDt2jAt9GRmZtmXLFnviieFufqeffrq98MIL7gaVbt1Ot6uvvsbGjXvbmjY92GrVqmVHHXWULVq00E3bvv3R9ve/325dunRx89T8X3nllQLrR8Hzrbfetptv7mc33dTP8vJybd9997UxY8aW+nokKAIAgHJh16pVLCM93XLz8kp93qoJ1KDb8cjKyrJBgwa7R6xjjulgc+Z84X2fbmIJbmQJq1+/vs2cObPAcxMnvlvo52u8Rj1ihcdQ1B3R7733XytrBEUAAFAu1KpR3R6+u5+tW///Q8UUZY86tSwrs+im5AC/zFIyBEUAAFCuwqIe8dhvnz2tcqVKZb5MOzMG3AYAAIAXQREAACTFlkjEIpR9mdEwPrbVwDiJoekZAAAkhX57ecOGjZabs9kyMhNvQs7Jzt6mELSjh8QVK/+4+SUtveRxj6AIAACSQgNHj3j1P9b7rJOtSpVdEg59eTmbLCMjo4yWbsdQvVYtS00teQMyQREAACTNvIVL7O5HRri7klNTEouKA27oYw325scFfFL+rEnclpAoBEUAAJD0msVlv69M+H3qgVfSXxxBfLiZBQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADglRKJRCIWh0+mjzfLXRfPpIixbFM1W785n3IpgT3q1LLMjHTKLkEb8yKWZ2mUWwlkr11lmzZtouxKYM+6ta1y5SzKrgSW/b7CNmxgu2Ob237atWwe13Rxn4Gz0rdYox/6bssy7bQW1RhhDzw6ItmLUSENH9TfDm7SONmLUeF89vU8+yJ/72QvRoVUP2eZPfDos8lejAq7vzZueECyF6NC+nnxUra7EmCbK3s0PQMAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAKyUSiUQsDp9MH2+Wuy6eSRFj2aZqtn5zPuVSAnvWrW2VK2dRdgn6bflK27gpm3IrgTq1qltmejplVxIpZumUXYks+32Fbdiwie0uQZwjSq5dy+ZxTRf30TArfYs1+qHvNizSzmtRjRH2wKMjkr0YFdLwQf2tccMDkr0YFc7Pi5fafQ8/lezFqLDb3MFNGid7MSqkH+bOZ3/dhn32gUefLd0VshPgHFH2aHoGAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgFdKJBKJWBw+mT7eLHddPJMixpq0fSzHMimXEkjXpUxqOmWXoE1rVtqmTZsotxKolJVp+fn5lF0JpKWnWX4eZVcSqamplp2Ty3aXoD3r1rbKlbMotxJo17J5XNPFfQbOSt9ijX7oW5Jl2elNP3CCfbVl/52+HEqiWcpi+yJ/b8ouQfVzfrUHHn2WciuBW665mLIrIcqu5Ci7khk+qL81bnjANpQ8ikPTMwAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAACvlEgkErE4fDJ9vFnuungmRYzclMqWZnmUSwnkW4alWS5ll2i5RdItZctmyq0EIqlZlrIlm7Kj7LYrtrsSllteVUvL3VLKa2PncGTXU+KaLj3eGWalb7FGP/TdlmXaaX1df7gd8hNlR9lt521uIdscZbd9sd1Rdtvbl7WfsQOeHrrdP3eHEGdQpOkZAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4pkUgk4n8JAAAAOzNqFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAAYD7/B1xQkdUWaqs3AAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAooAAAIDCAYAAACDyz+cAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOy1JREFUeJzt3QeUFFXaxvF3MgiiZLMgQREVBCSoKIiioqgoGBZRMSLmhIEVFSMoiAl3TYCsWTCwC6JLEjNBjGsABAQRJedJ9Heeq9VfTXNnpmeYoafl/zunD0N3dfXt6gpP3XvrVkokEokYAAAAECM19gkAAABACIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAK90/9MAgHj997//tQ8++MDq169v559/fqKLAyQ1tqeKhRrFHdgFF1xgKSkp7jF16tTo88Fz9erViz43cuTI6PN33nmn7ai0nLQMtOzKg5Z5sJwrItaDrX3//ffWrVs3Gz16tHXs2NF2VMG6uyMpbB/6V5CobZ3tqeJJ6qDYp0+f6IqsxwMPPFDk9FrZw+EHFcvChQvdb6qzyKysLKtZs6a1bt3a7r///jKZ/8qVK61fv37WpEkTq1y5smVkZNhee+1lZ511ln3++edWnmbMmGG9e/e2Bg0auM+uUaOGHXrooa48//vf/8r1s//KvvjiC+vbt681b97c0tPTo/sCHeRiLV261AYNGmTHH3+8W8f0O+y8887Wrl07GzFiRKk+f+PGjda9e3fbbbfdbNq0abbPPvsUeH3BggVuv6PHm2++Werv+VcOWKmpqfbNN98UeL1Dhw7R1995552ElRPbV3Hb0/amY8att95qRx99tO20007RdbKwigLdEfmf//ynHXbYYValShWrWrWqtW3b1v71r39ZMkvapufc3Fx7/fXXCzz38ssv2y233FLguY8++sjy8vLsqKOOKvD8b7/9Zv/+97/twgsvtB1V//797eKLL3Z/H3zwwQkty4cffmhdunSxtWvXFthIg4c21m2RnZ3t1oHYA9KSJUvs1VdftbffftutKwpvZU3rpAJK2ObNm23VqlU2Z84c++GHH5ImROg3mj59uvs70TtxmTJlij355JNxTasDT+z+QT755BP3UOgcNmxYiT7/q6++cge2Sy65xPbYY4+tXldQvOuuu9zfakI77bTTSjT/HYEOrvfee6+9+OKLiS4KEqy47Wl7W7RoUbEVUGEKkM8//3yB5z799FP3+Pbbb+2+++6zZJS0NYrvvfeerVixosBz2tF/9913BZ577bXX3NmAVj7ttBUaBw8ebI0aNXJn+evXr7eKYsOGDdv1c7QMjjzySPfYZZddLFFWr15tPXr0cCExLS3N1Sq+8cYbribhiSeesJNOOmmr96gGaOLEid756YRB7w/TtEFI3HXXXV2zhk4UmjVrFg1uzz33XJl/t4ceeqhASFTt5dixY10fHAUcLftkUqdOneg6UxGCon7Lrl27uh3wEUccUez0lSpVsosuusjGjBnjfn8F38Cjjz5q8+fPL9Hnt2nTxu64444KcVBLZjpZ+/HHHxNdDCT4eFfRtqfMzExXwaATzOIqlSZPnhwNiXXr1nUnPq+88kr0uyhwqmUpKUWSVK9evSIqvh5nn3129O877rhjq2knTZoUOeyww6LT7LrrrpH7778/snHjxiI/Iz8/P3LPPfdEmjZtGqlUqVIkKysrsvfee0e6dOkSeeaZZ6LTnX/++dF5T5kyJfr8iBEjvOU6+uijo8/PmjUr0rt370jNmjXd/4vz2muvufKoLPr3lVdecfMO5qfPDOy7777R5xcuXBg5/fTTI9WqVYvUq1evyHIHz+n9xX0XmT9/fuTiiy+O7LPPPpHMzMxI7dq1I2eeeWbk22+/jcRj8ODB0XnffffdxU7/+eefR9LS0iI77bRT5MMPPyzw2vjx4yMZGRlu+cydOzf6/PPPPx/9jO7du0eff/zxx6PP9+nTp9jP1nLStFp2xVmxYkWkatWq0fnfcMMN3unCyyn8m/3+++/uc7S+aj5apppnrDfffDPSqVMnN52Wf+PGjSN33nnnVut3eL2bOXNmpGfPnm6+devWdb/pli1bIl988UWkQ4cObn3Xuv7II48UmEc867TmceWVV7r1QPM54YQTIgsWLCh2ecXO56effoqUxFlnneXdDsLL+eeffy7w3ObNm933D96n7Ske77//fqRr166RWrVqufVNv9s111xT4PcJf5fYR7D+TJs2za2PDRs2jOyyyy5uXrvvvnukR48ebjmGhbfz5557LjJ06NDIfvvt59b1Fi1aRN59992tyvnbb79FrrvuOjd/rRtaR7T/+vjjj7ea9h//+EekZcuWkSpVqrhp99hjD7deDRo0KK5lEqy78Qjve4KH9oO+ZTdhwoQC750xY0bkjDPOiNSpUye67G+55ZbIhg0bIosXL46cd955bt3Td2jQoEHkpptuiqxatSqu9aywfak89thjbnlrndbxRMeVwvah+lvLrnr16pH09HS3nug9V199dWT16tXFLp+cnJzIkCFD3O+q/ZwerVu3jowePbrAdFpmweerfAH9ZsHzl156abRM4fXvnXfecb+31h8dEx5++OEC8y5qn//jjz9GLrjggshee+3lfoMaNWpETjzxxMh///vfAtPFfuaYMWMizZo1c79NeJ7xbE+yfPnyyGWXXeaONZpO+69GjRq5DDB16tRil2tRv29xnnzyya2237Abb7wx+rr2v4EHHngg+ryOk8koKYPipk2bIjvvvLNb8Noh/Prrr25j1P/333//rabXCtSmTZsCQVEbkuZTlIEDBxa6oz/iiCPKJChqxxOeb1G0kaWkpGxVFm14xQXF8OcEAbAsgqKCrpanbxlpI/70008jxWnfvn30PXfddVfkoIMOcjtj7Qx0APD9Ttrggt9yzpw57rkPPvjA7VD1vA4OsWE2WEf0Hu1w//3vf0eXXWpqqjtol2VQDIdThYA1a9YU+57wb9akSZOtlqnCXdjtt99e6Dqq5Zqdne1d73QAjZ3+qquu8v6W77333jat07HbS6KCYmHCJ5FaJ4rz9NNPu/XFt8x10AoObvEERZ2wFjaN1uXwSUT4IKf9XOz0OnDqgBvQyaEO5L55a9q33nrLu67GPvbcc89yDYqtWrWKlik4oSgsKI4dO9ZN5ytnu3btCv2+BxxwQGTlypWlDooPPvigdxmGt9FgH/rdd99FKleuXOjyVMgqLiQqZBb2/n79+kWnVejU76PnVQmwZMkSd4IcfL4C4Nq1a7cKbdr+dbIdO2+tj8Vt69qnB8ff2IeOT8OHD49OG/7M+vXrFzh+BfOMd3uSY445ptDl0r9//4QGxUsuuST6utaXgAJ88LzWl2SUlE3PajJat26d+1t9flTNq87PwRVT4QsTbrzxRvfa7rvv7voI7bnnnnbzzTfbPffcYwcccECRTc9vvfVWtHlLnVHVXKiqZTWNan5l1QdCVe1qGn344YcLnS4/P9+uvfZa159H1FT7n//8x66++mrX5F6cZcuW2dChQ+3dd9+12267rUzKrrJomarpWG644QY3fzW1qglZy1YXcARlLoz6bgS0LL7++mvXFBz0Dzn11FO3moc6DJ955pnuszt37uz6q6qJWp2h1e9S3QvCdPHCCy+84JpO9Z5evXrZySef7JbdQQcd5Mod2491W4V/l0MOOcSqVatWovernFrvhg8f7ppAgmb1NWvWuL/VjHH33Xe7v7U+Pvvss665PmiqV1/CwtYpbT8vvfRSgT4zjz32mOtErmb7yy+/vMCyLonff//d/vGPf7iya9sJ+qDG9g+tCH766afo/kIdz9u3b1/k9OrTeuWVV9qWLVtcM/aQIUPcMte6KGo+DfpBanmqOTtw4oknut9ED/UPFl2spenUR1b9LdWlJuiqoHW5sN9v7ty5NnDgQLcv1MU5Qb9t7SMCushn8eLF7u/zzjvPlVPdHfQ9Na2a0oLmv2BfpwuC9NtNmjTJbS/aprXtlCeVbe+993Zliu3LG6b9ifquabrg+2kfqOfk448/dt9XFyhpmWqfqv2PqEtSafs5qy/xgAEDov+/6qqr3OeqG4nvQjT9hps2bXJ/X3PNNW5Zav+kY06rVq2KvTL8kUcece8RXQih7VHv33///d1z2repz5uoy9Azzzzj/lbXHR0PdHzS5+tz1J1GyyPWvHnzXPn1Pa677rro8+qOtXz58kLLpv2wlmlw/FWXLs3j9ttvdxcl6XWtgz///LN3W9P3V3cw9cnWtlaS7UmfqW1E1Jdc28yECRPc+nrGGWe4i0cSaf8/fx/Rvk/r4i+//GKjRo2KPu9bLkkhkoTU7BAk9IkTJ0abTXxnXNOnT49Mnjw5ejYR1JKpFvKpp54q8nPatm0bPaNWU42aNny2pUbxtttui+s76ywueM9uu+3mzjpjyxl7lhSunfJ9122tUVQTcPBc8+bN3bIOHjq7DzdzFiV8ZqumGtVu6KG/g+fVvBpLy0DNmuGzSjXPqsuAj5qpwzXLwUM1jX379o3k5uaWaY1iUOuph2q74hH+zd54443o8+HvGdSgqmkmvB4Fy37cuHHR51U761vvwutDuHlczWmiZu/wb1uSdTrchKXm/KJ+w7JU0hpFNWMdcsgh3qa7wui7BdPfeuut0edVc6smWz2v2pa8vDxv01ss7VPUTHXwwQdHa8PDj0MPPdRbGxKuWVatUvi9ixYtcrUwQe2N9hfhbbNbt27RaV9//XU3j6D7juaj5sN4ar/LqkZRNTVBrYuaQVUr5qtRVG1i8JyaTMPUDSe8nIPvqhrWYNmoVj/4XUpSo6juCMFzqn0OaF5q9Yjdh4aPRcOGDYssXbq0RMsx3EL06quvRr9LuIVLXTvCLrroIm8LQVh4XVS5g2UhqvEPXtO+t7Btffbs2YUeh8LH5WAfEP5M7Wdim5JLsj2pK01Q83jccce52vZ49tll5cliahTVzUNN57G/Q+yxJhklXY2izip0BiMaYuSYY45xf59++umuFkvUgTSogVKne99YTKqFDM5EC6NO76KzHg2hoTPxhg0b2mWXXeauVC0L6ogfj3An+xYtWrihXQIqW1l9TkmEl4Gu3tUZYvDQ2X2guOFfNBROQDVZqu3TQ2fGAdXmxtIyUI1N8LvrjFRXrerMNpZqFLSu6ExcNcmqedbV1Dpz1QVOqrWLrYXcVuELhHRmWVK6CCugoYICQQ1uePmrZjBY9uHfOvbiroBqsgLVq1eP/q0zfqlVq9ZWn1dW5a4INFSOyvnll1+6/19//fWuZqM44WWuYZuC4TK0Dge1c9pHxft7n3POOa4WR1d7qgYxVmHLTJ3+w+tZuDZD+wrVOAb7wF9//bXAthm+0CvYNlVLpO+hMhx77LFunqrlO/fcc23mzJlW3tQKoNpsjU7w4IMPFrvsw98/dn1WDU7wXdVKECxX1cTrdy+p8L5Xw54EtN9p2bLlVtOrBSRY71W7ptp+HatUo6zatOKEv6f2T8F3Cddqxu5T1Vqk1rKAaoGLulpX23mw34xdfkVd0BUuW+xxKDwP3/FRF5tpOZR2e9JwVtpeglrbAw880A1Zo9pFLZugpSVRateu7Y5T4ZEz9F1U2xkIWliSTdIFRVVZq1lSdKDXiqofQ02Kap4NxuMLB5WAdsi68rkkOy9VbSu0qHlSzX+qsn/qqafcQSbYiYebEoIySFFV+OHAWlKlGdS2NJ+zva7mDl89u++++3r/Dg+bE16+2ilrmWunp/XilFNOiTaLhOkqZx2EgoNi48aNXUBS01qgrIeoCa6oFgUSX7mKEg5wahIMFNeUH6YQHHzvwkJsOFj7msdL8nllVe7ypP2DDrxBU7iattTkVVI6SGk5+h7BPqoo6lqh5jPRSahOVjRoc3jgZjXJxaO0A10H26a6b6h7gE6edaDTd1PTmZqfta8r6dXgJaWTPHUTEu1f1X2hJOL9/sH33ZZ9dnGfq8A7a9Ys18VJFRUKjWq+DppU1X2krPep6lqk42F4+Dc9F6+yGCi9uHkUdwyKZ3vSaBfqCqP9vMak1W+nSgp1wVFTeqI1a9bMZs+e7ZrZ1TVII7Oo+0GgadOmloySLiiqX1U8ymJj1IHthBNOcP0SdcavPjJBHyCdpWvcvdiDrp4PxDNQbLwbqDaKgPpUhXduvlBc2s8pCYWtgA4mf14cVeChHZpqYIsSHtZEB0/f36rdCFNw1G+jM2ttnOrXqNpe1X6oRi3oI+Q7AIT7pYbDW1kPlaS+ggoAorNd9VHyKe2A2+Hlrx1oYcs/XGO7o1NNskKiTviCWoySDOgeXuaqhdTJYuxD662GnooN4bGhTy0VAfUzVG26tqN4fq/PPvss+rfWLX2vwH777ee2hWCb175DJwyx60ZOTo7r5yj6v1omFNJ0oNN2EYRn1chtj0Gv1YKgmmx9Xrjfsm/Zh79/7P///ve/F7otBDWvvn22fh/VVMXS8gyEa1e1D/bVtuqzdJKrGj31R9W+JzwsiobHKkr4eyqg+75L0IcxKLdOfrXPC2oJ9V3VIlbYyZmCbHh9DPo8xn7fosqm45DWK988wtMVdQwq6fakE89LL73U9alVrbkC+OGHH+5eUz/z7TXEXHF0Yw/V2uqkWUOkBdQvPhkl1YDbSufBhqwOurGDV2rHF9QQqYq/sGbIeKmjrj5HBxbdwUMbRXjHENTUaKcc3klp5VaIDG/M20rV/ApL6gyranh1AO/Zs6frsK3BghNBAU01rQppGsxYZdJFNqrlVc2tdt5q5tLGXFzNrTpda6emzvZqGhZ1Ug6Eq++1Q1QY1M5OOxDtIFSjrHVDZ/Aqi8qhzw6aRsJnchqbUTtDnenr4pmA7u5RltTMovnfdNNN7v9q2tbvp1oF1dyp2UU1NipHaWoz//a3v7mO76IO6apR0EUzWv8UhLRcdMAqj/Ehy4suPNPvJzorL+5OSqodDA7CwYUbou00COkaK1G1FQpTaopUbYto+9H6onvKhg9cWpeK2ieoBlLbvi680P5FJzoKNyqvmp70WtBVIly7qs9RC4X2KfqccI25xmDTSbAO9PFcbKZptZ2o9u/xxx+PHiD1/+CkSk2d48ePd+uCamAUHPTZWmY6yCuw6CRTy1gXQahZ9rjjjnPv1wE5GFhdfLXSZU0XI+hEXPtQH5VN25TWc/2+uqhEv61Cg/ZBAW1nKr+Cb/C7aF+soDJu3Lit9tmaj/ZBujDI12Sqz1WNp2q1tE9TGRXsVRkRPpkN/zbad+lCSzUBK5Tq9413WWq9DC6EU7DQ3Zt0/NHvo64k+r46zgV3B9EFT6oNFpVN278ubNOFH6qlvuKKK7b6DK0DuhBR+xAtm+D9OknRCXhhtI/Una10cqvyqKwqh0Ji0KVBLW/h/XVRSro96aRH89axR+MTalvWdKLjh6Yt6qIWtSoGA+Dr5Lq4W7GqHOPHj3d/hy+S1fILbvih7gjBtqzfXNuguiRofVFLVtBqoC4IwQ0ukk4kiYQ7CavjrI863gfTxI7pVFJFDVGgsdeC8bDUKT58QUDwCA+dUFjH/5IMAVLY8DjqCO/rxB++MMKnvIfHKeqzY2k4m8Lef/PNNxeYVsNP6DM1zp+GAAlTB2eNSanfR536AxoiQmPJFfYZ6jD99ddfl+nFLAGVv6jlc+qppxb7mxX2WxU1PE5sOQtb7wr7zJKsB6UZl86npNtGuDyFPYL5xDNtPGUsajgPPfQdAupsr07/hX3OSSedtNVr4QsLwss+vCzDF+GEO8qH142ihseJXTa+iyGCh4ZamTdvXrlezBLQPlUXnYQ/P3Z4nGCYq9iHxhks6vsef/zxBfYTvt9Qw+j41oXwWHjBQ+8PDwUVLHsNvVXUMn/ppZeKXDa6kKOoY0+4bNoXaiixYPgZXRylMSM1Fqee0wUhGhos9sISHZt8wwxp3ODyGh6nsH1mSbYn35A+vt+3MCXdH2n7sBLsM8IXIoUfGrpIw7clq9RkbXbWGbJPuCP/tjY/a/gF9XvQWYxqJ3SWqg7DOotS7UDQfBHUCKk2R2dTml61VjoTLEu6YEd3MFAnXn2Ozuw0+nunTp2i06jmZHtSTaf6iKjZSLV0Kpc67KqmUc/FW6uqWgB1QtfZmb6DHuqwrmEGYjtlq/lIFzSpBjH27iBaJqplVW1auLlaNSmqedWZuGpiVEOg31Nn6uqDqpqC8uo/ovJr/jqDVw2DPlvrjpaRagK35V7WwRApqgXQeqgaVK2jqinT5wZnzyg7qhV4//333faofldaj/SvOvNrmBDV4gT0mmoU9Hv4hilRjYPWCzW5arvRuhjUehVF641qErWv0TanWgytB8EwYaJtQ7UgqtEO1nmVQX+r9l/lCrYR7dNUDm1bWjdVs6maVdWQqGaxqObIsqTPVu1mYbp16+Zaa7TsdfGA1nfViKpWSrV2qhnTBTjqJ6jX9K/2I6pJCmrfg/2EavNVs6jlp21R+9bC+rmpv6Her89SrZtq1lSz5xtOSTWZ6pemfaN+Vy1LfS9Nqwstzz777CKXgcqjpn5dqKd1Sr+ZfjvtO9SdRbWFWg5qOlaNWNB/T7WY2m9qPQpua6maZt8QZZqvPkP7W30f1Yipq0EwbFNR9F615gTDzWkdV8259kHa74aH1irr7UmtiKrN1X5b5dZD66zW8XguFCpvPXv2dLWJWh76HbUNqqlcfdTjuXNURZWitJjoQiA++ql8/Tw01lbQP0T9i8rjfsX4gy400FX02kmOHDky0cXBDqSkzWbbm0KUmuQ4pFTsfZew/0JJJFWN4o5OZ/YaHkA1Ztohqx+L+p8EIVFnVuErbQEAAHaYi1l2dGpqUHO6r0ldzRM6Q9yWi3cAAADCSBVJRP2E1P9G/ZLUF0X9M9THRn1CVLuoJmgAAICyQh9FAAAAeFGjCAAAAC+CIgAAALwIigAAAPAiKAIAAGDbhseZ9uUsW7VpXbyTI6TylqqWmVE50cVISnm5OZaekZnoYiQdllvprV+13Lbk5ye6GEmpxq7VrGqV7Xt3qL+K7Jwcy8pkmy0pllvpHXrwgWUbFBUSb/ll1DYUacf1YO2+Niu3dqKLkZSapS62GSy7EmO5lV79DYvsvoefSnQxktLwQf1tn332SnQxktIPc+ez7EqB5Vb+aHoGAACAF0ERAAAAXtzCDwAAJPwWtfl5eVbyO4BELCcnp1zKlOxSzCwtPX2bb+1LUAQAAAmzefMmW7V8eaneWzk91Vb8tqzMy/RXUr1WLatUqfQX1BIUAQBAwmoSFRKrVq1qNWvUtJQU1YPFj6ueC6c7NK9YucIt37p77FnqmkWCIgAASAg1N4tCYuXKpaj1SkmxSllZZV+wv4iaNWra+vXr3XJOLWWg5mIWAACQEEGfxJLWJCI+wXIted/P/0eNIgAAqDCWblxhq3LWxzVtTm6OZcZ5c4HqmVVt951qWln56KOPbM2a1XbiiV3sr4ygCAAAKkxIPGlKf8vZ8keTdFnKTE23/3S8t9iw2LBhA8vKyrKsrEq2ceMGO/DAA+3GG2+yww8/PDrN5MmT7KWXXrbHHnuszMu5evVqe+qpf1q/fjdbRUDTMwAAqBBUk1geIVE033hrKl944UWbPXu2fffd99ar13l2yild7dNPP42+fswxnezpp5+2SpUqlWkZ8/LyXFAcPHiwVRTUKAIAABSiW7duNmPGZ/bww0Nt9Oh/2R13DLApU6ZYTk6uNW7cyIYPf9KqV69uF154obuy+Pvvv7MVK1ZYmzZtbfjw4e4inZdeeskee+xR9x5d6T1w4F128sld3fw7dTrGDj74EJs5c4abNjMz09atW2ctW7a09PT0AgE1EahRBAAAKELr1m3s22+/tSFDHrIqVarYxx9/YrNmzbKDDjrIBgwYEJ1OgXL8+An21Vdf26pVK+2RR4a55zt37mwffviRzZw508aOHWt9+vSx7Ozs6Pt+/PEHmzJlqr333n/tiSeG28477+zmn+iQKNQoAgAAFDMmobz11lu2du1aGzv2Dff/3Nwc23fffS3QvXt3F/Kkd+8L7fHHH7NbbrnVfvrpJzvvvF62ZMkSS0tLt5UrV7rnDjjgADft3/7W0zIyMqwiIigCAAAUYebMGda0aVP76acFNmzYMDvuuM4lGp7m3HN72r333mdnnHGG+3+dOrVt8+bN0ek04HhFRdMzAABAId5++2375z//addee52deuop9sgjj9jGjRvda/r3m2++iU47ZszYPwa4zs+3UaNGWqdOndzzq1atsnr16rm/X3jhBff/wlSrVs02bdpUYe5hTY0iAABASM+ef4sOj9OkSRN7++1x1qZNG3eBSXb23W6onKC28KabbnK1jdKqVSvr0uVEW758ubuY5eqrr3HPDx36sJ199lm2yy67WseOHWyfffYp9LNr1Khh557by1q0ONSqVKma8H6KBEUAAFAhaFBsjXdYXuMoav7FmTt3XqGvpaen25133uUePgcffLA988wzWz3fs2dP9wg8+OBD0b8nTZq81fSqwawoCIoAAKBC0GDYGhQ7Ge7MsqMgKAIAgApDYS7eQLc5O9sqZWVZRfDcc8/ZXxEXswAAAMCLoAgAAAAvgiIAAAC8CIoAAADw4mIWAABQYeT/vswia9fEN21ujuXFedVzSrVdLK12XatoJkwY78ZX1NiMFRFBEQAAVJiQuOqKXma58d+VZFO8E2ZkWvUnRscVFtetW2d7772X9ehxpj399NNxl2XcuHE2deoUGzJkaFzT6y4tX331pd133/1WUdH0DAAAKgRXk1iCkFgiuTlx11S++uqr1qJFC3vzzTfcLfl8dJu+sLy8POvatWvcIVE0CPcDDwyy1NSKG8cqbskAAAASYMSI59yt+dq3b+9Co4waNcqOPbaTnXlmD2vevLl99tlnlpGRbnfddae1bdvW+ve/zU1zxhmnu+lPOOF4GzNmTHSe06ZNdbf4C2osL7vsMmvXrq0deuih1qdPn+i9nX/99Vc755yz3Wv6nAEDbrdEIigCAAD86dtvv7XFixdb587HW+/eF7rQGFA4vPvue2zOnDnWrl0791xaWpp98sknNmjQ4ALzOf/8C+z550dF/z9y5Ci74IIL3N8KoUceeaR9/PEnNnv2bNuyZYs99tij7rULL+xtl19+uXtt5syZNmvWLHv99dctUeijCAAA8CcFw3PPPdcFwBNPPNH69r3c/ve//7nXFA7333//AtNfcEFv73xOO+00u+66a23p0qW288472/jx/7GHHvrjHs9vv/2WC5fDhg1z/9+8eZP7vA0bNtjkyZNt2bLfovPZsGG9/fDD95YoBEUAAAB1Y8zNdReYZGRk2Msvv+ye27hxowuPTZseZFWrVt3qPb7npHLlynbGGd3thRf+ZbVq1baOHTtazZp/3JowEom4Ju3GjRsXeE/QH/LDDz+0SpUqWUVA0zMAAMCfVy3Xr1/fFi5cZHPnznOPDz740IVHhciSOv/8812/RTVBB83Ocsopp9qDDz7oLoCRVatW2dy5c13o7NChgw0ePCg67S+//OKawhOFoAgAAPBns/M55/ytwHNNmjSxPfbY012AUlKtW7d2Tcrz5s2z447rHH1+yJAhrsaxVauW7mKWzp0728KFC9xrzz8/2gXU5s2buYtZevTobitWrLBEoekZAABUCBoUW+MdlssQORmZf8y/COPG/dv7/IwZM9y/1113XYHnc3P/qBEM1yDqETZnzhdbzU81h48++sfFK7Hq1Kljzz//vFUUBEUAAFAhaDBsDYod73iH2bk5lpXkd2ap6AiKAACgwnBhLs5Al5edbelZWeVeph0ZfRQBAADgRVAEAACAF0ERAAAAXvRRBAAAFUZk/WKLZK+Mb+KcHNuSGefFLFk1LKXqXttWuB0QQREAAFSYkJj9Zjuz/Oy43xP3QDppWZZ12sdxhUUNhH3//ffZK6+8Yunp6ZaWlm6HHXaYu6XfwIED3f2Xy3PQ76lTp9iQIUOtIiAoAgCACsHVJJYgJJZIfrabfzxB8ZJLLrFVq1ba9OkfWPXq1d0t98aMGWMrV8ZZ07kNunbt6h4VBX0UAQAA/qRb6Y0Z87o988yzLiRKSkqKde/e3fbbr77l5+fZlVdeaS1atLBmzQ6xmTNnRt/77rsT7eijj3J3ZGnXrq2rGZRp06a6O61cccUV7k4suuPKl19+aRdeeKH7+/DD29mSJUvctLrl3xlnnF7gfYV93vZAUAQAAPjT559/bg0bNrJatWp5X//uu++sV69eNnv2bOvb9wobMOB29/z8+fNds7Tu7vLZZ5/Z6NH/ctNlZ2dH36dgqPmfeuop1rnzcdavXz+bM2eOtWzZyh599JESfd72QlAEAACIU8OGDa1Nmzbu77Zt27qAKBMnTnT3dO7YsaO1bNnSzjrrLEtNTbVFixZF36fnRcGwQYMGdsABB7j/q/+jajJL8nnbC30UAQAA/qSm4blzf7QVK1ZYzZo1t3o9K6tS9O+0tDR34YuoH+Oxxx7rahJj/fLLkpj3pVqlSv75xPt52ws1igAAAKEavG7dTrdLL73EVq9eHQ2BY8eOtfnzfyr0fZ07d7ZJkya5vocBNUEnO2oUAQAAQp555hm777577YgjDnfD42zZssWOPLK9nXDCCUUGzNGjR1vfvpfbxo2bLDc3x12o4qthTCYpEcXkOLz56VS75ZdR5V+iv6AHa/e1r7bsm+hiJKVmqYvtiy0MkFpSLLfSq79ylt338FOJLkZSGj6ovx3YpHGii5GUfpg73xo33M92NDk5Obbit2VWb996rim2NOMoWjmMo/hXsXnzZluwcIHVrFPXMmMGJq+5S7W45kGNIgAAqBAU4hTm4r0zi4JmbAAqdN7cmaVUCIoAAKDCUJiLO9BlZ1tqVlZ5F2mHxsUsAAAA8CIoAgAAwIugCAAAAC+CIgAAALy4mAUAAFQYa7PzbWNuXCP3WU5uvmXmxnenkp0yUqxaVpolm7Vr19rIkSOtT58+cV/hXZYIigAAoMKExKdnr7b8+HLinzbFNVVaitklLXYtNiw2bNjAsrKyrFKlytHnFNQOPvhgK6lRo0bZ22+/ZWPGjLXS0J1hLr+8j916620JCYlCUAQAABWCahJLFhLjp/lq/tXiGE3nhRdedHdVSQTdBUZSU1Nt1113tZdeetkSiT6KAAAARfj++++tXr19bf78+e7/Q4cOsZNO6uJCnWoNjzvuWOvW7TQ75JCDrWPHDrZgwQLvfIYMeciaNTvEhdBevXrZmjVr3PMDB95lZ57Zw7p0OdGaN29mS5cutXffnWhHH32UtW7d2tq1a2tTp06xRKBGEQAAIKRnz78VaHr+4IMP7IEHBtk555xjgwcPsieffNI++uhjV+snH330kc2cOcuaNGliDz30oGsunjDhnQLzfOedCa4Je/r0D1xNofoc3nbbbfbEE0+41z/55BObMWOm1a1b1wXSgQMH2vjxE6xatWo2d+5cF0Dnzp3nmsW3J4IiAABAMU3PZ599tk2dOtW6dOliEye+a7Vr146+1q5dOxcS5eKLL7EBAwZYfn5+gfdPmjTJevTo4UKiXHbZZXbOOWdHXz/hhBNdSJSJEyfavHnzrGPHjtHXFUoXLVpkjRo1su2JoAgAAFCMvLw8++abr61GjRr2yy+/bPP8UlJSCvy/atWq0b8jkYgde+yxNnr0vyzR6KMIAABQjNtuu9UaN97fpkyZajff3M81BwfUbPzdd9+5v5977lnr0KGDpaUVvLq6U6dO9vrrr7vhbuTpp5+2Y489zvtZnTt3djWQX375ZfS5zz77zBKBGkUAAIAi+ijedded9u6777p+iTvttJM9+OBDrr/i9OnTo03PCpJqLlaN44gRI7eap5qWv/nmG2vf/khLSUl1w+08/vjj3s9v2LChjR492vr2vdw2btxkubk5rik8ETWMBEUAAFAhaFBsjXdYHkPkaL6af3F0wYjPySd3jf7dvXt39wjoghPfWInnn3++ewRuuOFG94g1YMAdWz3XqdOx7pFoBEUAAFAhaDBsDYod/51ZciwzI/MvfWeWRCMoAgCACkNhLp5BsWVzdr5VykpslDk/ptbwr4aLWQAAAOBFUAQAAIAXQREAAABeBEUAAAB4cTELAACoMJYu+91Wr1lX5lc977rLzrZ73f+/7R7iQ1AEAAAVJiSedsHVlpOTW+bzzszMsDdHPhpXWMzJybE77hhgb7zxhmVkZFhaWrpdf/31dt5559m0aVPt+utvsFmzZsX92XrP5s2b7fjjTyh1+RcsWGCtWrW05ctX2PZEUAQAABWCahLLIySK5qv5xxMUL7roQsvOzrZZs2ZblSpVXEjr2vVkd7/nBg32K/FnT5s2zVavXrNNQTFR6KMIAADwpx9//NHeeuste/LJf7iQKPXq1bPBgwfbPffc7f6fn59nF1xwgTVv3sxat25tc+bMib73qKPaW4sWLdwt9wYMuN299tRTT9lLL71oLVu2dPNQ4OzS5URr06aNNWt2iPXqda5t2LAhWoaRI0e6aTUfTaOgGmvGjBl23HHHutdbtWrl7iNdHqhRBAAA+JOCXcOGjaxmzZoFnm/btp39/PPP9vvvy909m4cOHeoC3WuvvWbnntvTvvrqaxs+fLiddNJJdvPNt7j3rFy50t37+dJLL3U1inqPRCIRd99mfYb+vvLKK+2JJx63fv1uds3U9957j73//nTbfffdbePGje49v/32W7Qsq1evtssvv9zGjRvnplm+fLm1bn2Yu+f0nnvuWabLg6AIAABQAvXq1bNjjunk/u7Ro4ddfnkfFyLbt29vt9xys61fv96OOuqoQu/VrHD4yCPDbPz4Ca52ce3aNS7kyfjx461nz54uAMpOO+201fs//vgj++mn+XbyyScXeP6HH75PXFCsmbvZntmlS5l++I5ixdoVVj9neaKLkZQ2padZ/bxliS5G0onsWt2apS9OdDGSUnZmpt1y9UWJLkZSys3Ltx/mzk90MZLS78tX2s+Ll9qOJiM9zfberZat37jRcvLybMOmP2rPyouukt6cnV3kNE0OPNDmzv3RlvzyS4Faxfenv2977bWX7bLLLi7oheeTkpJiObm51uWkk6xFyxY2efJke+zxx23YsGE2ZuwblpeX75qrg/e8/PJLNmnyZBs/YYJVq1bNnhw+3Ka9P829npef76aPLWd2To77V89n5+TaAU2a2KRJk7cqf/h9eo+C6IJFP6uUBaZr17J52QbFqml51uinPvFOjpDxNUbYfcNGJLoYSUkH7AcefTbRxUg69w28zb7csleii5GU6ucsY50rpeGD+lvjhiXv6A9zIfHuoU/Zjmb3OjXt5r69LGv5SktNTbPlK1aV6+dpKJ1KWUXfSPqgpk1dTd11115jI0eOcjV66iP49/79rX//v7urpxcuXGiffPyRdejQ0caMGWN169a1BvvtZ3PnzrUGDRrYhb0vtMPbHe76K+rzqlevbkuWLIl+9vp1661O7drusW7dOnvxxRdtn332dq+fduqpdtFFF9kVV1xRoOk5K/OPYYA0zdFHHWVXXXmFffjB9GitpZrMDzzwQMv8czonErH09HSrt0fdgs+XAE3PAAAAISNGjHQXohx6aHMXsNLS0tyQOL1793Z9CJs2bWqjRj1v1157nXtd/Q1Vqzh27BgX+jIyMm3Lli32xBPD3fxOO+00e+GFF9wFKt26nWZXXXW1jRv3tjVteqDVqlXLjjzySFu0aKGbtn37o+zvf7/dunTp4uap+b/yyisFyqfg+dZbb9vNN/ezm27qZ3l5ubb33nvbmDFjy3xZEBQBAECFsHPVKpaRnm65eXllPm/VBGrQ7XhkZWXZoEGD3SPW0Ud3sDlzvvC+TxexBBeyhNWvX99mzpxZ4LmJE98t9PM1XqMescJjKOqK6Pfe+6+VN4IiAACoEGrVqG4P393P1q3//6FiirJbnVqWlVl0U3KAO7OUDkERAABUqLCoRzz22Wt3q1ypUrmXaUfGgNsAAADwIigCAICE2BKJWCTRhfgLi0T+WLoFB8YpGZqeAQBAQujeyxs2bLTcnM2WkVnyJuSc7OxtCkF/9ZC4YuUfF7+kpZc+7hEUAQBAQmjg6BGv/sd6n3mSVamyU4lDX17OJsvIyCin0v01VK9Vy1JTS9+ATFAEAAAJM2/hErv7kRHuquTUlJJFxQE39LEGe3JzAZ+UP2sStyUkCkERAAAkvGZx2e8rS/w+9cAr7R1HEB8uZgEAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeKVEIpGIxeGT6ePNctfFMyliLNtUzdZvzk90MZLSbnVqWWZGeqKLkXQ25kUsz9ISXYyklL12lW3atCnRxUhKu9etbZUrZyW6GElp2e8rbMMG1ruSYp0rvXYtm8c1XdxH4Kz0Ldboh77bUKQd16IaI+yBR0ckuhhJafig/nZgk8aJLkbS+ezrefZF/p6JLkZSqp+zzB549NlEFyNpt9fGDfdLdDGS0s+Ll7LelQLrXPmj6RkAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXimRSCRicfhk+niz3HXxTIoYyzZVs/Wb8xNdjKS0e93aVrlyVqKLkXR+W77SNm7KTnQxklKdWtUtMz090cVITilm6Sy7Uln2+wrbsGFToouRdDhGlF67ls3jmi7uLTorfYs1+qHvNhRpx7Woxgh74NERiS5GUho+qL81brhfoouRdH5evNTue/ipRBcjade5A5s0TnQxktIPc+ezvW7DNvvAo88muhhJh2NE+aPpGQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeKZFIJGJx+GT6eLPcdfFMihhr0vayHMtMdDGSUrpOZVLTE12MpLNpzUrbtGlToouRlCplZVp+fn6ii5GU0tLTLD+PZVcaqamplp2Tm+hiJJ3d69a2ypWzEl2MpNSuZfO4pov7CJyVvsUa/dB3W8q0w5q+/wT7asu+iS5GUmqWsti+yN8z0cVIOvVzfrUHHn020cVISrdcfRHLrpRYdqXHsiud4YP6W+OG+yW6GH9pND0DAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8EqJRCIRi8Mn08eb5a6LZ1LEyE2pbGmWl+hiJKV8y7A0y010MZJOfiTdUrZsTnQxklIkNctStmQnuhhJiWVXeiy70onkVbW03C2JLkZSOrzryXFNlx7vDLPSt1ijH/puS5l2WF/XH24H/cSyKw2W3TYst4Ust9Jg2ZUey670WHal82XtZ2y/p4cmuhjJKc6gSNMzAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALxSIpFIxP8SAAAAdmTUKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwHz+D1xQkdUjdVVBAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 660x520 with 1 Axes>"
       ]
@@ -3299,10 +3321,10 @@
    "id": "97bc629e",
    "metadata": {
     "papermill": {
-     "duration": 0.009471,
-     "end_time": "2026-07-09T22:54:03.899585+00:00",
+     "duration": 0.005823,
+     "end_time": "2026-08-23T02:44:57.557174",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.890114+00:00",
+     "start_time": "2026-08-23T02:44:57.551351",
      "status": "completed"
     },
     "tags": []
@@ -3335,16 +3357,16 @@
    "id": "2a6adc42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:54:03.936712Z",
-     "iopub.status.busy": "2026-07-09T22:54:03.936235Z",
-     "iopub.status.idle": "2026-07-09T22:54:03.946301Z",
-     "shell.execute_reply": "2026-07-09T22:54:03.944470Z"
+     "iopub.execute_input": "2026-08-23T02:44:57.571009Z",
+     "iopub.status.busy": "2026-08-23T02:44:57.570727Z",
+     "iopub.status.idle": "2026-08-23T02:44:57.575462Z",
+     "shell.execute_reply": "2026-08-23T02:44:57.574723Z"
     },
     "papermill": {
-     "duration": 0.033961,
-     "end_time": "2026-07-09T22:54:03.947881+00:00",
+     "duration": 0.013182,
+     "end_time": "2026-08-23T02:44:57.577000",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.913920+00:00",
+     "start_time": "2026-08-23T02:44:57.563818",
      "status": "completed"
     },
     "tags": []
@@ -3434,10 +3456,10 @@
    "id": "conclusion-section",
    "metadata": {
     "papermill": {
-     "duration": 0.02098,
-     "end_time": "2026-07-09T22:54:03.985199+00:00",
+     "duration": 0.006483,
+     "end_time": "2026-08-23T02:44:57.590416",
      "exception": false,
-     "start_time": "2026-07-09T22:54:03.964219+00:00",
+     "start_time": "2026-08-23T02:44:57.583933",
      "status": "completed"
     },
     "tags": []
@@ -3487,10 +3509,10 @@
    "id": "nav-footer",
    "metadata": {
     "papermill": {
-     "duration": 0.026374,
-     "end_time": "2026-07-09T22:54:04.030612+00:00",
+     "duration": 0.005961,
+     "end_time": "2026-08-23T02:44:57.602498",
      "exception": false,
-     "start_time": "2026-07-09T22:54:04.004238+00:00",
+     "start_time": "2026-08-23T02:44:57.596537",
      "status": "completed"
     },
     "tags": []
@@ -3515,6 +3537,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-28",
+   "network": false,
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -3530,36 +3569,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.14"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 13.902354,
-   "end_time": "2026-07-09T22:54:04.626758+00:00",
+   "duration": 5.380106,
+   "end_time": "2026-08-23T02:44:57.958755",
    "environment_variables": {},
    "exception": null,
    "input_path": "Search-3-Informed.ipynb",
    "output_path": "Search-3-Informed.ipynb",
    "parameters": {},
-   "start_time": "2026-07-09T22:53:50.724404+00:00",
+   "start_time": "2026-08-23T02:44:52.578649",
    "version": "2.6.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "qcc_tokens_est": 0,
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-07-28",
-   "validator": "manual"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary
L'exemple guide 2 de `Search-3-Informed.ipynb` (heuristique non admissible ×2) utilisait **Bordeaux→Strasbourg**, où A* restait optimal *par chance* : la sortie committée concluait « Par chance, la solution non admissible est ici optimale ». Le point enseigné — « une heuristique non admissible peut faire rater le chemin le plus court » — n'était **jamais démontré**.

### Correction
Remplace l'instance par **Grenoble→Marseille**, où la sur-estimation fait réellement rater l'optimal :

| Heuristique | Chemin | Coût (km) | Nœuds explorés |
|-------------|--------|-----------|----------------|
| Admissible (vol d'oiseau) | Grenoble → Lyon → Marseille | **425** | 2 |
| Non admissible (×2) | Grenoble → Nice → Marseille | **530** | 2 |

- **Sous-optimalité démontrée** : 105 km de plus (**24.7 %**), chiffres verbatim dans la sortie committée.
- **Mécanisme nommé** (cellule réécrite) : `h_×2(Lyon)=553 km` sur-estime (vraie distance via Lyon = 315 km) → `f(Lyon)=110+553=663` repousse le bon chemin ; A* se tourne vers Nice (`f=330+315=645`) et atteint le but via la côte en 530 km.
- **Point d'honnêteté** : les **deux** heuristiques explorent le même nombre de nœuds (2). La conclusion committée corrige l'affirmation erronée « une heuristique non admissible pousse A* à explorer moins de nœuds » : ici elle n'a pas rendu A* plus efficace, elle l'a rendu **faux**.

## Validation
- Re-exécution **papermill complète 67/67 SUCCESS** (~5 s, 0 erreur), kernel python3.
- **C.1** : 0 violation (`raise NotImplementedError`/`assert False`/`1/0` absents).
- **C.2** : 24 cellules code toutes avec `execution_count` ; la seule cellule sans output est `exercise1` (stub préexistant qui retourne `None`, pas d'erreur). 3 figures PNG conservées.
- Instance **déterministe** (graphe des villes françaises fixe, aucune graine requise).

## C# twin (issue point 5)
`Search-3-Informed-Csharp.ipynb` cellule 31 reste un **exercice explicitement non résolu** (`// TODO etudiant : construire h_bad(s) = 2 * Haversine...`) — l'acceptation « son exercice reste explicitement marqué non résolu » est satisfaite. Aucune modification du jumeau C# (PR atomique, Python uniquement).

## Périmètre
Un seul fichier : `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb`. Catalogue byte-identique à main (non régénéré). README de série inchangé (les §8/README ne mentionnent pas l'instance spécifique ; les descriptions génériques « l'épreuve de l'admissibilité » deviennent plus vraies). Aucun secret, aucun twin-related.

Closes #12465