### PR TITLE
feat(notebook,#12441): enrichi 1.3-Pandas — jointures merge (4 how), NaN dropna/fillna + impact aval, resample temporel + figure, read_csv reel, 3 exercices

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/README.md
@@ -13,7 +13,7 @@ Avant d'orchestrer des agents LLM qui *écrivent* du code data science (labs Lan
 | Notebook | Contenu | Durée |
 |----------|---------|-------|
 | [1.2-NumPy](notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb) | `ndarray`, opérations vectorisées, agrégations (`sum`, `mean`), gain de performance vs boucles | ~45 min |
-| [1.3-Pandas](notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb) | `DataFrame`, sélection de colonnes, filtrage booléen, manipulation tabulaire | ~60 min |
+| [1.3-Pandas](notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb) | `DataFrame`, sélection de colonnes, filtrage booléen, **jointures** (`merge`), **données manquantes** (`dropna`/`fillna`), **séries temporelles** (`resample`), **lecture CSV** (`read_csv`) | ~75 min |
 
 > **Numérotation.** La série commence à `1.2` car le `1.1` d'introduction est couvert par le [README parent](../README.md). La continuité logique est `1.2` (NumPy) → `1.3` (Pandas) → [Lab 1](../Track1-LangChain/Day1-Foundations/Labs/Lab1-PythonForDataScience.ipynb) (mise en pratique sur ventes synthétiques) → [02-ML-Cours 2.1](../02-ML-Cours/2.1-Workflow-ML.ipynb).
 
@@ -25,6 +25,7 @@ Avant d'orchestrer des agents LLM qui *écrivent* du code data science (labs Lan
 2. Mesurer l'avantage de performance de la vectorisation NumPy sur le Python natif.
 3. Construire un DataFrame Pandas et y sélectionner des colonnes avec la notation `[]`.
 4. Filtrer des lignes par conditions booléennes et préparer un jeu de données pour l'analyse.
+5. Fusionner deux tables avec `merge` (et comprendre les variantes `how`), diagnostiquer les valeurs manquantes (`isna`, `dropna`, `fillna`), agréger une série temporelle (`resample`) et lire un vrai CSV (`read_csv`).
 
 ## Prérequis
 

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
@@ -5,10 +5,10 @@
    "id": "e7563b95",
    "metadata": {
     "papermill": {
-     "duration": 0.002006,
-     "end_time": "2026-05-13T08:18:13.253908",
+     "duration": 0.003724,
+     "end_time": "2026-08-23T03:01:22.629219",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.251902",
+     "start_time": "2026-08-23T03:01:22.625495",
      "status": "completed"
     },
     "tags": []
@@ -43,10 +43,10 @@
    "id": "9a6a2ba4",
    "metadata": {
     "papermill": {
-     "duration": 0.001001,
-     "end_time": "2026-05-13T08:18:13.256909",
+     "duration": 0.002729,
+     "end_time": "2026-08-23T03:01:22.634748",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.255908",
+     "start_time": "2026-08-23T03:01:22.632019",
      "status": "completed"
     },
     "tags": []
@@ -67,10 +67,10 @@
    "id": "251ff9f5",
    "metadata": {
     "papermill": {
-     "duration": 0.002001,
-     "end_time": "2026-05-13T08:18:13.261904",
+     "duration": 0.002516,
+     "end_time": "2026-08-23T03:01:22.639813",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.259903",
+     "start_time": "2026-08-23T03:01:22.637297",
      "status": "completed"
     },
     "tags": []
@@ -87,16 +87,16 @@
    "id": "fb918b11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:18:13.267014Z",
-     "iopub.status.busy": "2026-05-13T08:18:13.267014Z",
-     "iopub.status.idle": "2026-05-13T08:18:13.568509Z",
-     "shell.execute_reply": "2026-05-13T08:18:13.568509Z"
+     "iopub.execute_input": "2026-08-23T03:01:22.647141Z",
+     "iopub.status.busy": "2026-08-23T03:01:22.646859Z",
+     "iopub.status.idle": "2026-08-23T03:01:22.999233Z",
+     "shell.execute_reply": "2026-08-23T03:01:22.998241Z"
     },
     "papermill": {
-     "duration": 0.306608,
-     "end_time": "2026-05-13T08:18:13.569514",
+     "duration": 0.357174,
+     "end_time": "2026-08-23T03:01:23.000205",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.262906",
+     "start_time": "2026-08-23T03:01:22.643031",
      "status": "completed"
     },
     "tags": []
@@ -128,10 +128,10 @@
    "id": "94f4ece9",
    "metadata": {
     "papermill": {
-     "duration": 0.001999,
-     "end_time": "2026-05-13T08:18:13.573515",
+     "duration": 0.002863,
+     "end_time": "2026-08-23T03:01:23.006411",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.571516",
+     "start_time": "2026-08-23T03:01:23.003548",
      "status": "completed"
     },
     "tags": []
@@ -150,16 +150,16 @@
    "id": "6ceb3338",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:18:13.577104Z",
-     "iopub.status.busy": "2026-05-13T08:18:13.577104Z",
-     "iopub.status.idle": "2026-05-13T08:18:13.581888Z",
-     "shell.execute_reply": "2026-05-13T08:18:13.581888Z"
+     "iopub.execute_input": "2026-08-23T03:01:23.013322Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.012930Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.018853Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.018318Z"
     },
     "papermill": {
-     "duration": 0.008148,
-     "end_time": "2026-05-13T08:18:13.582894",
+     "duration": 0.010902,
+     "end_time": "2026-08-23T03:01:23.020186",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.574746",
+     "start_time": "2026-08-23T03:01:23.009284",
      "status": "completed"
     },
     "tags": []
@@ -200,10 +200,10 @@
    "id": "4cdc0e3c",
    "metadata": {
     "papermill": {
-     "duration": 0.002004,
-     "end_time": "2026-05-13T08:18:13.586088",
+     "duration": 0.002751,
+     "end_time": "2026-08-23T03:01:23.025638",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.584084",
+     "start_time": "2026-08-23T03:01:23.022887",
      "status": "completed"
     },
     "tags": []
@@ -220,16 +220,16 @@
    "id": "171b1e9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:18:13.590118Z",
-     "iopub.status.busy": "2026-05-13T08:18:13.590118Z",
-     "iopub.status.idle": "2026-05-13T08:18:13.599056Z",
-     "shell.execute_reply": "2026-05-13T08:18:13.598545Z"
+     "iopub.execute_input": "2026-08-23T03:01:23.034394Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.034118Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.039218Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.038678Z"
     },
     "papermill": {
-     "duration": 0.01248,
-     "end_time": "2026-05-13T08:18:13.599567",
+     "duration": 0.009549,
+     "end_time": "2026-08-23T03:01:23.039998",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.587087",
+     "start_time": "2026-08-23T03:01:23.030449",
      "status": "completed"
     },
     "tags": []
@@ -258,10 +258,10 @@
    "id": "a1eb8902",
    "metadata": {
     "papermill": {
-     "duration": 0.002115,
-     "end_time": "2026-05-13T08:18:13.603687",
+     "duration": 0.002745,
+     "end_time": "2026-08-23T03:01:23.045464",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.601572",
+     "start_time": "2026-08-23T03:01:23.042719",
      "status": "completed"
     },
     "tags": []
@@ -284,16 +284,16 @@
    "id": "45d01fda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:18:13.608199Z",
-     "iopub.status.busy": "2026-05-13T08:18:13.607200Z",
-     "iopub.status.idle": "2026-05-13T08:18:13.611990Z",
-     "shell.execute_reply": "2026-05-13T08:18:13.611990Z"
+     "iopub.execute_input": "2026-08-23T03:01:23.052769Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.052408Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.056508Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.055916Z"
     },
     "papermill": {
-     "duration": 0.007804,
-     "end_time": "2026-05-13T08:18:13.612996",
+     "duration": 0.008494,
+     "end_time": "2026-08-23T03:01:23.057449",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.605192",
+     "start_time": "2026-08-23T03:01:23.048955",
      "status": "completed"
     },
     "tags": []
@@ -348,10 +348,10 @@
    "id": "c26ac7b1",
    "metadata": {
     "papermill": {
-     "duration": 0.002004,
-     "end_time": "2026-05-13T08:18:13.616171",
+     "duration": 0.002628,
+     "end_time": "2026-08-23T03:01:23.062776",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.614167",
+     "start_time": "2026-08-23T03:01:23.060148",
      "status": "completed"
     },
     "tags": []
@@ -366,16 +366,16 @@
    "id": "5cc1082e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:18:13.672878Z",
-     "iopub.status.busy": "2026-05-13T08:18:13.671873Z",
-     "iopub.status.idle": "2026-05-13T08:18:13.675867Z",
-     "shell.execute_reply": "2026-05-13T08:18:13.675867Z"
+     "iopub.execute_input": "2026-08-23T03:01:23.069425Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.069066Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.072541Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.072094Z"
     },
     "papermill": {
-     "duration": 0.058702,
-     "end_time": "2026-05-13T08:18:13.676872",
+     "duration": 0.007556,
+     "end_time": "2026-08-23T03:01:23.073165",
      "exception": false,
-     "start_time": "2026-05-13T08:18:13.618170",
+     "start_time": "2026-08-23T03:01:23.065609",
      "status": "completed"
     },
     "tags": []
@@ -420,72 +420,913 @@
   {
    "cell_type": "markdown",
    "id": "2269c665",
-   "source": "### Exercice 1 : Filtrage et tri d'un DataFrame\n\nLe filtrage et le tri sont des opérations fondamentales en analyse de données. Vous allez créer un DataFrame de produits et appliquer des filtres combinés avec un tri pour extraire des informations spécifiques.\n\n**Objectif** : Créer un DataFrame de produits, filtrer les produits par prix et catégorie, puis trier les résultats.\n\n**Indices** :\n- Combinez plusieurs conditions avec `&` (ET) ou `|` (OU) en utilisant des parentheses\n- Utilisez `df.sort_values(by='colonne', ascending=False)` pour trier par ordre decroissant\n- `df.reset_index(drop=True)` pour reinitialiser les indices après filtrage",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.002594,
+     "end_time": "2026-08-23T03:01:23.078936",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.076342",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Filtrage et tri d'un DataFrame\n",
+    "\n",
+    "Le filtrage et le tri sont des opérations fondamentales en analyse de données. Vous allez créer un DataFrame de produits et appliquer des filtres combinés avec un tri pour extraire des informations spécifiques.\n",
+    "\n",
+    "**Objectif** : Créer un DataFrame de produits, filtrer les produits par prix et catégorie, puis trier les résultats.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Combinez plusieurs conditions avec `&` (ET) ou `|` (OU) en utilisant des parentheses\n",
+    "- Utilisez `df.sort_values(by='colonne', ascending=False)` pour trier par ordre decroissant\n",
+    "- `df.reset_index(drop=True)` pour reinitialiser les indices après filtrage"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "f8ff78da",
-   "source": "# Exercice 1 : Filtrage et tri\n# Creez un DataFrame de produits et appliquez des filtres combinés\n\n# Etape 1: Creez le DataFrame\nproduits = pd.DataFrame({\n    'Produit': ['Ordinateur', 'Telephone', 'Tablette', 'Casque', 'Souris', 'Clavier'],\n    'Categorie': ['Electronique', 'Electronique', 'Electronique', 'Accessoire', 'Accessoire', 'Accessoire'],\n    'Prix': [999, 699, 399, 89, 49, 79],\n    'Stock': [10, 25, 15, 50, 100, 75]\n})\n\n# Etape 2: Filtrez les produits Electronique avec un Prix > 400\n# Indice: (produits['Categorie'] == 'Electronique') & (produits['Prix'] > 400)\nproduits_chers = None  # Remplacez None\n\n# Etape 3: Triez les resultats par prix decroissant\n# Indice: produits_chers.sort_values(by='Prix', ascending=False)\nproduits_tries = None  # Remplacez None\n\n# Affichage\nif produits_chers is not None:\n    print(\"Produits Electronique avec Prix > 400 :\")\n    print(produits_tries)\nelse:\n    print(\"Exercice 1 a completer : filtrage et tri d'un DataFrame\")",
-   "metadata": {},
    "execution_count": 6,
+   "id": "f8ff78da",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:01:23.085209Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.084807Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.089265Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.088783Z"
+    },
+    "papermill": {
+     "duration": 0.008382,
+     "end_time": "2026-08-23T03:01:23.089969",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.081587",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice 1 a completer : filtrage et tri d'un DataFrame\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice 1 : Filtrage et tri\n",
+    "# Creez un DataFrame de produits et appliquez des filtres combinés\n",
+    "\n",
+    "# Etape 1: Creez le DataFrame\n",
+    "produits = pd.DataFrame({\n",
+    "    'Produit': ['Ordinateur', 'Telephone', 'Tablette', 'Casque', 'Souris', 'Clavier'],\n",
+    "    'Categorie': ['Electronique', 'Electronique', 'Electronique', 'Accessoire', 'Accessoire', 'Accessoire'],\n",
+    "    'Prix': [999, 699, 399, 89, 49, 79],\n",
+    "    'Stock': [10, 25, 15, 50, 100, 75]\n",
+    "})\n",
+    "\n",
+    "# Etape 2: Filtrez les produits Electronique avec un Prix > 400\n",
+    "# Indice: (produits['Categorie'] == 'Electronique') & (produits['Prix'] > 400)\n",
+    "produits_chers = None  # Remplacez None\n",
+    "\n",
+    "# Etape 3: Triez les resultats par prix decroissant\n",
+    "# Indice: produits_chers.sort_values(by='Prix', ascending=False)\n",
+    "produits_tries = None  # Remplacez None\n",
+    "\n",
+    "# Affichage\n",
+    "if produits_chers is not None:\n",
+    "    print(\"Produits Electronique avec Prix > 400 :\")\n",
+    "    print(produits_tries)\n",
+    "else:\n",
+    "    print(\"Exercice 1 a completer : filtrage et tri d'un DataFrame\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ea39352d",
-   "source": "### Exercice 2 : Agrégation et groupby\n\nLes opérations d'agregation permettent de synthetiser les données par groupes. Vous allez utiliser les fonctions `groupby()`, `agg()` et les statistiques descriptives pour analyser un jeu de données de ventes.\n\n**Objectif** : Calculer des statistiques par catégorie (somme, moyenne, nombre) sur un DataFrame de ventes.\n\n**Indices** :\n- `df.groupby('colonne')` créé un groupe par valeur unique de la colonne\n- `df.groupby('cat')['val'].agg(['sum', 'mean', 'count'])` pour plusieurs agregats en une fois\n- `df.groupby('cat').describe()` pour un resume statistique complet par groupe",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.002927,
+     "end_time": "2026-08-23T03:01:23.095670",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.092743",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Agrégation et groupby\n",
+    "\n",
+    "Les opérations d'agregation permettent de synthetiser les données par groupes. Vous allez utiliser les fonctions `groupby()`, `agg()` et les statistiques descriptives pour analyser un jeu de données de ventes.\n",
+    "\n",
+    "**Objectif** : Calculer des statistiques par catégorie (somme, moyenne, nombre) sur un DataFrame de ventes.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `df.groupby('colonne')` créé un groupe par valeur unique de la colonne\n",
+    "- `df.groupby('cat')['val'].agg(['sum', 'mean', 'count'])` pour plusieurs agregats en une fois\n",
+    "- `df.groupby('cat').describe()` pour un resume statistique complet par groupe"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "2e17b996",
-   "source": "# Exercice 2 : Agregation et groupby\n# Analysez des donnees de ventes avec les fonctions d'agregation\n\n# Etape 1: Creez le DataFrame de ventes\nventes = pd.DataFrame({\n    'Vendeur': ['Alice', 'Bob', 'Alice', 'Charlie', 'Bob', 'Alice', 'Charlie', 'Bob'],\n    'Produit': ['A', 'A', 'B', 'B', 'A', 'C', 'C', 'C'],\n    'Montant': [150, 200, 300, 250, 100, 400, 350, 175]\n})\n\n# Etape 2: Calculez le montant total par vendeur\n# Indice: ventes.groupby('Vendeur')['Montant'].sum()\ntotal_par_vendeur = None  # Remplacez None\n\n# Etape 3: Calculez les statistiques par produit (somme, moyenne, nombre)\n# Indice: ventes.groupby('Produit')['Montant'].agg(['sum', 'mean', 'count'])\nstats_par_produit = None  # Remplacez None\n\n# Etape 4: Trouvez le vendeur avec le plus grand chiffre d'affaires\n# Indice: total_par_vendeur.idxmax()\nmeilleur_vendeur = None  # Remplacez None\n\n# Affichage\nif total_par_vendeur is not None:\n    print(\"Montant total par vendeur :\")\n    print(total_par_vendeur)\n    print(f\"\\nStatistiques par produit :\\n{stats_par_produit}\")\n    print(f\"\\nMeilleur vendeur : {meilleur_vendeur}\")\nelse:\n    print(\"Exercice 2 a completer : agregation et groupby\")",
-   "metadata": {},
    "execution_count": 7,
+   "id": "2e17b996",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:01:23.101758Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.101571Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.105718Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.105163Z"
+    },
+    "papermill": {
+     "duration": 0.008088,
+     "end_time": "2026-08-23T03:01:23.106452",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.098364",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice 2 a completer : agregation et groupby\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice 2 : Agregation et groupby\n",
+    "# Analysez des donnees de ventes avec les fonctions d'agregation\n",
+    "\n",
+    "# Etape 1: Creez le DataFrame de ventes\n",
+    "ventes = pd.DataFrame({\n",
+    "    'Vendeur': ['Alice', 'Bob', 'Alice', 'Charlie', 'Bob', 'Alice', 'Charlie', 'Bob'],\n",
+    "    'Produit': ['A', 'A', 'B', 'B', 'A', 'C', 'C', 'C'],\n",
+    "    'Montant': [150, 200, 300, 250, 100, 400, 350, 175]\n",
+    "})\n",
+    "\n",
+    "# Etape 2: Calculez le montant total par vendeur\n",
+    "# Indice: ventes.groupby('Vendeur')['Montant'].sum()\n",
+    "total_par_vendeur = None  # Remplacez None\n",
+    "\n",
+    "# Etape 3: Calculez les statistiques par produit (somme, moyenne, nombre)\n",
+    "# Indice: ventes.groupby('Produit')['Montant'].agg(['sum', 'mean', 'count'])\n",
+    "stats_par_produit = None  # Remplacez None\n",
+    "\n",
+    "# Etape 4: Trouvez le vendeur avec le plus grand chiffre d'affaires\n",
+    "# Indice: total_par_vendeur.idxmax()\n",
+    "meilleur_vendeur = None  # Remplacez None\n",
+    "\n",
+    "# Affichage\n",
+    "if total_par_vendeur is not None:\n",
+    "    print(\"Montant total par vendeur :\")\n",
+    "    print(total_par_vendeur)\n",
+    "    print(f\"\\nStatistiques par produit :\\n{stats_par_produit}\")\n",
+    "    print(f\"\\nMeilleur vendeur : {meilleur_vendeur}\")\n",
+    "else:\n",
+    "    print(\"Exercice 2 a completer : agregation et groupby\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "7f6cbccb",
-   "source": "### Exercice 3 : Transformation et nettoyage de colonnes\n\nEn pratique, les données necessitent souvent des transformations avant analyse : conversion de types, renommage de colonnes, creation de nouvelles colonnes calculees. Vous allez appliquer ces opérations sur un DataFrame d'employes.\n\n**Objectif** : Transformer un DataFrame en ajoutant une colonne calculee, renommant des colonnes et convertissant des types.\n\n**Indices** :\n- `df['nouvelle'] = df['col1'] * df['col2']` pour créer une colonne calculee\n- `df.rename(columns={'ancien': 'nouveau'})` pour renommer\n- `df['col'].astype(float)` ou `pd.to_numeric()` pour convertir des types\n- `df.drop(columns=['col'])` pour supprimer une colonne",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.002715,
+     "end_time": "2026-08-23T03:01:23.112204",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.109489",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Transformation et nettoyage de colonnes\n",
+    "\n",
+    "En pratique, les données necessitent souvent des transformations avant analyse : conversion de types, renommage de colonnes, creation de nouvelles colonnes calculees. Vous allez appliquer ces opérations sur un DataFrame d'employes.\n",
+    "\n",
+    "**Objectif** : Transformer un DataFrame en ajoutant une colonne calculee, renommant des colonnes et convertissant des types.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `df['nouvelle'] = df['col1'] * df['col2']` pour créer une colonne calculee\n",
+    "- `df.rename(columns={'ancien': 'nouveau'})` pour renommer\n",
+    "- `df['col'].astype(float)` ou `pd.to_numeric()` pour convertir des types\n",
+    "- `df.drop(columns=['col'])` pour supprimer une colonne"
+   ]
   },
   {
    "cell_type": "code",
-   "id": "b7be3e19",
-   "source": "# Exercice 3 : Transformation et nettoyage de colonnes\n# Transformez un DataFrame d'employes\n\n# Etape 1: Creez le DataFrame d'employes\nemployes = pd.DataFrame({\n    'nom': ['Alice', 'Bob', 'Charlie', 'Diana'],\n    'salaire_mensuel': ['3000', '2500', '4000', '3500'],  # Type string (a convertir)\n    'prime_percent': [10, 5, 15, 8]\n})\n\n# Etape 2: Convertissez la colonne salaire_mensuel en float\n# Indice: employes['salaire_mensuel'] = employes['salaire_mensuel'].astype(float)\n\n# Etape 3: Calculez le salaire annuel dans une nouvelle colonne 'salaire_annuel'\n# Indice: salaire_mensuel * 12\nsalaire_annuel = None  # Remplacez None\n\n# Etape 4: Calculez la prime en euros (salaire_annuel * prime_percent / 100)\n# Indice: creez une colonne 'prime_euros'\nprime_euros = None  # Remplacez None\n\n# Etape 5: Renommez la colonne 'prime_percent' en 'prime_pourcentage'\n# Indice: employes.rename(columns={'prime_percent': 'prime_pourcentage'})\nemployes_renomme = None  # Remplacez None\n\n# Affichage\nif salaire_annuel is not None:\n    print(\"DataFrame transforme :\")\n    print(employes_renomme)\nelse:\n    print(\"Exercice 3 a completer : transformation et nettoyage de colonnes\")",
-   "metadata": {},
    "execution_count": 8,
+   "id": "b7be3e19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:01:23.118647Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.118308Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.122684Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.122050Z"
+    },
+    "papermill": {
+     "duration": 0.008517,
+     "end_time": "2026-08-23T03:01:23.123510",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.114993",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice 3 a completer : transformation et nettoyage de colonnes\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice 3 : Transformation et nettoyage de colonnes\n",
+    "# Transformez un DataFrame d'employes\n",
+    "\n",
+    "# Etape 1: Creez le DataFrame d'employes\n",
+    "employes = pd.DataFrame({\n",
+    "    'nom': ['Alice', 'Bob', 'Charlie', 'Diana'],\n",
+    "    'salaire_mensuel': ['3000', '2500', '4000', '3500'],  # Type string (a convertir)\n",
+    "    'prime_percent': [10, 5, 15, 8]\n",
+    "})\n",
+    "\n",
+    "# Etape 2: Convertissez la colonne salaire_mensuel en float\n",
+    "# Indice: employes['salaire_mensuel'] = employes['salaire_mensuel'].astype(float)\n",
+    "\n",
+    "# Etape 3: Calculez le salaire annuel dans une nouvelle colonne 'salaire_annuel'\n",
+    "# Indice: salaire_mensuel * 12\n",
+    "salaire_annuel = None  # Remplacez None\n",
+    "\n",
+    "# Etape 4: Calculez la prime en euros (salaire_annuel * prime_percent / 100)\n",
+    "# Indice: creez une colonne 'prime_euros'\n",
+    "prime_euros = None  # Remplacez None\n",
+    "\n",
+    "# Etape 5: Renommez la colonne 'prime_percent' en 'prime_pourcentage'\n",
+    "# Indice: employes.rename(columns={'prime_percent': 'prime_pourcentage'})\n",
+    "employes_renomme = None  # Remplacez None\n",
+    "\n",
+    "# Affichage\n",
+    "if salaire_annuel is not None:\n",
+    "    print(\"DataFrame transforme :\")\n",
+    "    print(employes_renomme)\n",
+    "else:\n",
+    "    print(\"Exercice 3 a completer : transformation et nettoyage de colonnes\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c8e0d101",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003113,
+     "end_time": "2026-08-23T03:01:23.129424",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.126311",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Jointures : rapprocher deux tables\n",
+    "\n",
+    "Une table seule ne suffit presque jamais : on veut associer des **commandes** à leurs **clients**, des **notes** aux **étudiants**... C'est le rôle de `merge` (jointure). Le point clé — et le piège classique — est le paramètre `how` :\n",
+    "\n",
+    "- `how='inner'` : ne garde que les clés présentes **des deux côtés** (intersection).\n",
+    "- `how='left'` : garde **toutes** les lignes de la table de gauche (les clés absentes à droite deviennent `NaN`).\n",
+    "- `how='right'` : symétrique du `left`.\n",
+    "- `how='outer'` : garde **toutes** les clés des deux côtés (union).\n",
+    "\n",
+    "Le nombre de lignes du résultat dépend donc du `how` : le comprendre, c'est éviter les **lignes perdues** ou les **lignes fantômes**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c8e0d102",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:01:23.135898Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.135638Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.149527Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.149097Z"
+    },
+    "papermill": {
+     "duration": 0.018033,
+     "end_time": "2026-08-23T03:01:23.150240",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.132207",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Table 'clients'  : 4 lignes\n",
+      "Table 'commandes': 4 lignes\n",
+      "  -> la commande 104 est portee par un client (6) absent de 'clients'.\n",
+      "merge(..., how='inner') -> 3 lignes\n",
+      "merge(..., how='left') -> 5 lignes\n",
+      "merge(..., how='right') -> 4 lignes\n",
+      "merge(..., how='outer') -> 6 lignes\n",
+      "\n",
+      "Detail du merge how='left' (tous les clients, montant a NaN si aucune commande) :\n",
+      " client_id     nom  ville  cmd_id  montant\n",
+      "         1   Alice  Paris   101.0     50.0\n",
+      "         2     Bob   Lyon   102.0    120.0\n",
+      "         2     Bob   Lyon   103.0     80.0\n",
+      "         3 Charles Nantes     NaN      NaN\n",
+      "         5     Eva  Lille     NaN      NaN\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Jointures : rapprocher deux tables avec merge ---\n",
+    "# Deux tables liees par une colonne commune : client_id.\n",
+    "clients = pd.DataFrame({\n",
+    "    'client_id': [1, 2, 3, 5],\n",
+    "    'nom': ['Alice', 'Bob', 'Charles', 'Eva'],\n",
+    "    'ville': ['Paris', 'Lyon', 'Nantes', 'Lille'],\n",
+    "})\n",
+    "commandes = pd.DataFrame({\n",
+    "    'cmd_id': [101, 102, 103, 104],\n",
+    "    'client_id': [1, 2, 2, 6],       # client 6 absent de 'clients'\n",
+    "    'montant': [50, 120, 80, 200],\n",
+    "})\n",
+    "print(\"Table 'clients'  :\", len(clients), \"lignes\")\n",
+    "print(\"Table 'commandes':\", len(commandes), \"lignes\")\n",
+    "print(\"  -> la commande 104 est portee par un client (6) absent de 'clients'.\")\n",
+    "\n",
+    "# Comptons les lignes obtenues pour chaque how. C'est le comportement a MEMORISER.\n",
+    "resultats = {}\n",
+    "for how in ['inner', 'left', 'right', 'outer']:\n",
+    "    fusion = clients.merge(commandes, on='client_id', how=how)\n",
+    "    resultats[how] = fusion\n",
+    "    print(f\"merge(..., how='{how}') -> {len(fusion)} lignes\")\n",
+    "\n",
+    "print(\"\\nDetail du merge how='left' (tous les clients, montant a NaN si aucune commande) :\")\n",
+    "print(resultats['left'].to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8e0d103",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003381,
+     "end_time": "2026-08-23T03:01:23.156657",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.153276",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Données manquantes : les diagnostiquer avant de décider\n",
+    "\n",
+    "Des `NaN` (valeurs manquantes) sont monnaie courante. Le réflexe à ancrer : **les diagnostiquer d'abord** (`isna().sum()`), puis choisir une stratégie **en connaissance de cause** :\n",
+    "\n",
+    "1. `dropna(subset=[...])` : supprime les lignes concernées — **perd de l'information**, mais ne fabrique rien.\n",
+    "2. `fillna(valeur)` : **impute** (remplace) par une valeur — ne perd pas de ligne, mais **invente** une valeur.\n",
+    "\n",
+    "Le choix a un **impact aval** : la moyenne d'une colonne change selon la stratégie. Le comparer explicitement, c'est comprendre que « lisser les trous » n'est pas neutre."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c8e0d104",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:01:23.164585Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.164285Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.173081Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.172555Z"
+    },
+    "papermill": {
+     "duration": 0.013764,
+     "end_time": "2026-08-23T03:01:23.174024",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.160260",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Valeurs manquantes par colonne :\n",
+      "Nom        0\n",
+      "Age        1\n",
+      "Note       2\n",
+      "Filiere    0\n",
+      "dtype: int64\n",
+      "\n",
+      "--- dropna(subset=['Note']) ---\n",
+      "5 lignes -> 3 lignes (perte de 2)\n",
+      "Note moyenne : 15.17 (sur 3 notes)\n",
+      "\n",
+      "--- fillna(mediane) ---\n",
+      "Note moyenne : 15.30 (sur 5 notes)\n",
+      "\n",
+      "Le choix change la statistique (impact aval) :\n",
+      "  dropna   -> moyenne 15.17\n",
+      "  mediane  -> moyenne 15.30\n",
+      "Aucune n'est 'la' bonne : la decision depend de ce que l'on veut mesurer.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Donnees manquantes : diagnostiquer puis choisir une strategie ---\n",
+    "etudiants = pd.DataFrame({\n",
+    "    'Nom': ['Alice', 'Bob', 'Charles', 'Diana', 'Eva'],\n",
+    "    'Age': [21, 22, None, 24, 23],\n",
+    "    'Note': [15.5, None, 12.0, 18.0, None],\n",
+    "    'Filiere': ['Info', 'Maths', 'Info', 'Physique', 'Maths'],\n",
+    "})\n",
+    "\n",
+    "# 1) Diagnostic : ou sont les trous ?\n",
+    "print(\"Valeurs manquantes par colonne :\")\n",
+    "print(etudiants.isna().sum())\n",
+    "\n",
+    "# 2) Strategie A : supprimer les lignes sans Note.\n",
+    "sans_note = etudiants.dropna(subset=['Note'])\n",
+    "print(\"\\n--- dropna(subset=['Note']) ---\")\n",
+    "print(f\"{len(etudiants)} lignes -> {len(sans_note)} lignes (perte de {len(etudiants)-len(sans_note)})\")\n",
+    "print(f\"Note moyenne : {sans_note['Note'].mean():.2f} (sur {len(sans_note)} notes)\")\n",
+    "\n",
+    "# 3) Strategie B : imputer par la mediane (aucune ligne perdue).\n",
+    "impute = etudiants.copy()\n",
+    "impute['Note'] = impute['Note'].fillna(impute['Note'].median())\n",
+    "print(\"\\n--- fillna(mediane) ---\")\n",
+    "print(f\"Note moyenne : {impute['Note'].mean():.2f} (sur {len(impute)} notes)\")\n",
+    "\n",
+    "# 4) Impact aval : la moyenne differe selon la strategie.\n",
+    "print(\"\\nLe choix change la statistique (impact aval) :\")\n",
+    "print(f\"  dropna   -> moyenne {sans_note['Note'].mean():.2f}\")\n",
+    "print(f\"  mediane  -> moyenne {impute['Note'].mean():.2f}\")\n",
+    "print(\"Aucune n'est 'la' bonne : la decision depend de ce que l'on veut mesurer.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8e0d105",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002798,
+     "end_time": "2026-08-23T03:01:23.179957",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.177159",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Série temporelle : datetime et resample\n",
+    "\n",
+    "Une colonne de dates n'est pas une chaîne : c'est un type `datetime`. L'accesseur `.dt` en extrait des composantes (`year`, `month`, `day`), et `resample` regroupe sur une période (ici mensuelle) pour **agréger** — le seul moyen propre de calculer une moyenne mensuelle sans boucle. La figure qui suit montre la série brute et sa moyenne mensuelle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c8e0d106",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:01:23.186889Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.186550Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.697038Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.696466Z"
+    },
+    "papermill": {
+     "duration": 0.514811,
+     "end_time": "2026-08-23T03:01:23.697782",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.182971",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Donnees de base : 90 jours de ventes.\n",
+      "      date  montant\n",
+      "2024-01-01      152\n",
+      "2024-01-02      142\n",
+      "2024-01-03       64\n",
+      "\n",
+      "Accesseur .dt :       date  annee  mois\n",
+      "2024-01-01   2024     1\n",
+      "2024-01-02   2024     1\n",
+      "2024-01-03   2024     1\n",
+      "\n",
+      "Moyenne du montant par mois :\n",
+      "            montant\n",
+      "date               \n",
+      "2024-01-31    123.3\n",
+      "2024-02-29    119.9\n",
+      "2024-03-31    119.2\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA9kAAAGGCAYAAABv80LhAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzsfQeYZFWZ9lehqzp3T+oJMANDkJwWEWFRUFDAhIBrQkVl9ddVdtUVBRdxMSGKYkJxV1fWXVDXFTEuBkBRCRIEFZCgwDDMTPd0rE6V63/ec/tU36q+4Zx7zw1Vdd7n6ZkOFW7dk77wfu+XqNVqNdLQ0NDQ0NDQ0NDQ0NDQ0PCNpP+X0NDQ0NDQ0NDQ0NDQ0NDQALSTraGhoaGhoaGhoaGhoaGhCNrJ1tDQ0NDQ0NDQ0NDQ0NBQBO1ka2hoaGhoaGhoaGhoaGgognayNTQ0NDQ0NDQ0NDQ0NDQUQTvZGhoaGhoaGhoaGhoaGhqKoJ1sDQ0NDQ0NDQ0NDQ0NDQ1F0E62hoaGhoaGhoaGhoaGhoYiaCdbQ0NDQ0NDQ0NDQ0NDQ0MRtJOtoaGhodHSeOKJJyiRSNA111zj+tg3vvGNtPfeezf8Ds/913/91wCvUENDwwuwprE+scY5TjrpJPaloaGhEWdoJ1tDQ0NDEi972cuot7eXZmdnbR9zzjnnUCaToYmJCeXv/5Of/KQjncLrrruOPvvZz0Z9GR0Dfb81NDQ0NDS8QTvZGhoaGpKAA724uEjf+973LP++sLBA3//+9+m0006jNWvWBOJkX3rppdRpsHP69tprLzYer3/96z29Lp578cUXK7jC9oJ2sjU0NDQ0NLxBO9kaGhoaHjLZAwMDzAmxAhzs+fl55oxrBA/QSbu7uymVSnl6Pp6bTqeVX5eGhoaGhoZGZ0I72RoaGhqS6OnpobPOOotuuukmGhsbW/F3ON9wwuGMA9PT0/Sud72LNm/eTNlslvbbbz+6/PLLqVqtrqgrvuKKK+jf/u3faN9992WPPeaYY+iuu+5qqCm+6qqr2Pd4PP/iwGsi+3jIIYcw53H9+vX0//7f/6OpqamGa7z77rvp1FNPpbVr17LPs3XrVnrzm9/s+tlrtRp99KMfpT333JNR5p/3vOfRAw88wOqccW0coLObr8upxhL40pe+xK4Zn3nTpk30jne8g903DtRg/vjHP6Ynn3yy/pl5bbVdTfYNN9xAhx56KLsP+N+OeWBVk/3000+z+4H7h2vCtf3Hf/xHw2N++ctfsuf+z//8D33sYx9j9wTvdfLJJ9Njjz3W8FhcP67hwQcfZPcM926PPfagT37ykyuup1Ao0Ic+9CE2T/DemDfve9/72O/N+PnPf04nnHACDQ8PU39/Px1wwAH0gQ98gETw3//933T00UezsV+9ejW9+tWvpqeeekroftsBj3nnO99J3/nOd+jggw9mr33cccfRH//4R/b3r3zlK+wz4R7h9ZvnAIDn8uvC3Hzd617HxoLj61//Onuf3//+9yue+/GPf5wFWsyPv/POOxmjZGhoiN3zE088kX772982PI/PVYwZ5jDuJx7/pje9ibFSrD4jn1t8btx4440rrkdkDgV5L1V/drf5Zre2+TrB/7LXJwrRNaOhoaERFnToXkNDQ8MDkKX+z//8T+ZgwRjmmJycpJ/+9Kf0mte8hhnGMFRhPMLghrO7ZcsWuu222+iiiy6inTt3rqDjwkFHrTceC8MUThgc+r/+9a/U1dXFfr9jxw5m8P7Xf/3XiuvC32Hswkj+x3/8R3r88cfpi1/8InNKYMDiNRAYeOELX0jr1q2jCy+8kBnNMIyvv/561899ySWXMCf7RS96Efu699572WsVi0XP9xKGPujvp5xyCr397W+nhx9+mL785S+z4AK/5n/5l3+hmZkZ2r59O1155ZXseTD07fCzn/2Mzj77bOagXHbZZaw2HvcEjrAbRkdH6dnPfnbd0cF9+r//+z8677zzKJfLsYCJGZ/4xCcomUzSe9/7XnaNGDPMDzgRZiDQAacC4/nKV76S/vd//5fe//7302GHHUann356PUiC4MxvfvMbeutb30oHHXQQc6zwmR955BHm3AEIbLzkJS+hww8/nD784Q8zxwKOkoiTgoDABz/4QXYNf//3f0+7d++mL3zhC/Tc5z6XzRPMB9n7zfHrX/+afvCDH7AgCYB7j+uEw4NAyj/8wz+w+4B7BAf05ptvrj+Xz1sElvA8jMPnPvc59pn4db3iFa9gr33ttdfSUUcd1fDe+B0cTgQvALw27iucdjhgGCM46c9//vPZdT7rWc9qeD7uB4JNeG/M669+9as0MjLCAmJmYGywVvBZEEz7/Oc/z+batm3b6uUhsnNI9b1U/dn9zDcryF6fE0TXjIaGhkaoqGloaGhoSKNcLtc2btxYO+644xp+f/XVV9ewtf70pz9lP3/kIx+p9fX11R555JGGx1144YW1VCpV27ZtG/v58ccfZ89bs2ZNbXJysv6473//++z3P/zhD+u/e8c73sF+14xf//rX7PfXXnttw+9vvPHGht9/73vfYz/fddddUp95bGyslslkai9+8Ytr1Wq1/vsPfOAD7PXOPffc+u8+9KEPWV7j17/+dfZ7fF7za77whS+sVSqV+uO++MUvssf9x3/8R/13eN+99tprxWvye4fX5jjyyCPZ+ExPT9d/97Of/Yw9rvk18DtcL8d5553Hnjs+Pt7wuFe/+tW1oaGh2sLCAvv5lltuYc896KCDaoVCof64z33uc+z3f/zjH+u/O/HEE9nvvvGNb9R/h+ds2LChdvbZZ9d/91//9V+1ZDLJxtJqXv32t79lP1955ZXs5927d9dk8MQTT7B597GPfazh97jWdDrd8Hu7+20HXE82m62PLfCVr3yF/R6fM5fL1X9/0UUXNcyDYrFYGxkZqR166KG1xcXF+uN+9KMfscddcskl9d+95jWvqW3atKlhvtx7770NcwDzc//996+deuqpDXMVY7d169baC17wghVz9c1vfnPD5znzzDPZemz+jJivjz32WP13999/P/v9F77wBek5FMS9DOKzi8y35rXNwdcJ/pe9PqvXxFrCl+ya0dDQ0AgTmi6uoaGh4QGgpYJie/vttzfQI5GJBj0UlGEAdM/nPOc5tGrVKhofH69/IWtbqVTo1ltvbXjdV73qVeyxHHgugEy2G/BeoF6+4AUvaHgvZIuQhbzlllvY45ARBH70ox9RqVQS/sy/+MUvWMb6/PPPb6CCi2Tl3F4Tr4FsFsdb3vIWGhwcZJRlWYAhcN9999G5557L7gcH7gsy206Af/Pd736XXvrSl7LvzfcR9Hpkd5HpMwPZVyjJu40ZxgD0Zw48Bxk78+MwhsjEHXjggQ3vjQwf0DyGqP83lx24ARlYPB6ZS/Prb9iwgfbff//663sF5r2ZVn7sscey/5HpRda3+ff8s6N8AQwLZGdBgeZ48YtfzO6FeR684Q1vYGwO87Uiiw3mCN4HwPg/+uij9NrXvpaxGPjnhFYCrhHrrvm+ve1tb2v4GeOI5yLzbAbWLso5OJDdxVzln8XLHFJ5L4P47F7nmxW8XJ8TRNeMhoaGRpjQdHENDQ0NjwAlGJREONaoTQS1FlRH0LS5CBeMyT/84Q+MLmqF5ppu0MnN4A53c021FfBeMOBB83R6L9DXYaiDoo3rB8X25S9/OTN6QQO1A+pzAThjZuCzmQMDMuCvifpOM+CA7rPPPvW/e3nN5uvk7+Pk4IA6jVpw1MXjS+WYgareXKeOx2J+mMfwoYcecp0vCMaA0gu6Nyj/cE5AQwed2hysaAZeH46f1b0BQM33g+Z7wYMcqJG1+j2/R3bzAIDzBCqwOViyceNG5ljjc8Mh++Y3v0lnnHFG3fnE5wQQaLED1op53jqNI5xou8fxx/LP4mUOqbyXQXx2r/PNCl6uz+31RNaMhoaGRpjQTraGhoaGRyBDDAcABj6cbPwPB8asKg4HAE4B6iit8IxnPKPhZzuFbINB6gy8FxxsOB9W4EYoHD3UA99xxx30wx/+kNWQo6bz05/+NPudSO2tG6xEzwBk7+MMnkFDxtnOCUDm0suYiTwO748a7c985jOWj+UOFrK2yPghS4csL4S3vv3tb7PsHerR7d4Lr4+xQX2w1WP8jr3d+/qZ11avhYDQv//7v7PaZNQFI7NtZgnwcfzUpz5FRx55pOXrNH9WVePoZQ6pvJdBfHaR+Sa65r1cnxNE14yGhoZGmNBOtoaGhoYPwKGGiBSykchoI0MI4SYO0Ern5uYYxVQV7IxZvBfo13/7t3/LjGI3QJgJXxDCwrXjs3zrW99i2SoroB81zxwhy8yBzF1z1pZnoZDR41RToDkzzV8TYmfm1wSFHKJt5vtm97mdrrMZeB8nIBCBbCgcA5VjJgqM4f33388yhW6fFxlEPA5fcDCgrg3BMjhCdteO14fjBJGr5gBPM0TvtwqY5wGn+XLgd/zvZso4gkIIEiFggHEDFZuD07mRhQ17HOMwh4L47G7zzbzmzWhe86qvT2bNaGhoaIQFXZOtoaGh4QM8aw3VbdQaNvfGRu0r6raRLW4GjNFyuSz9nn19ffXnN78XDPuPfOQjK56D9+GPh0PcnJ3jGSWnljcwiEEnhhK1+fnNCulmQ9pcc46aSyiyN78mqOFQaDa/5te+9jVGGUVNrvlz43duAJUYnwfvZX48FNnRQssJyMiBSo+a2j/96U8r/o6AQpDAGEKJHlnaZiwuLrJ7yFXsmyEyhqD44jOiVKB5DuBn1MjK3m8VeOYzn8lYGFdffXXD9cOBBhXYPA94JhhfoDBjrKCPYO51DpYJ5iBa4iHIFeY4Rj2HgvjsIvPNas1jP2qmzKu+PtE1o6GhoREmdCZbQ0NDwweQETz++OOZIBDQ7GRfcMEFrA0P2t+gDy0MTBh9aDEDyjZE09APWAZ4DQC138jecRE21FqjhRfa8MDhR2stOMXI6EIcCO2QUEMJ5xM02zPPPJMZu2gZBgMVmSW05XLK0KFNFW8lhMeitRIcoebPgPdGnSdaFuEe4BrRIxivgVZH5tdEOzM4fWhvhVY8yFzi+sAIMFOA8blBUX3Pe97D/gZKKcSlrIBrhGOGvr6gwsNJQHAAvYqtDPvmllzIzkFQCgJsEEvD81HLDaaAlcOhCq9//etZWzgIUeEawEqAo/LnP/+Z/R7BGjikaKMEZwafEVle1J3inqHuG5/ZDhhvtGDDPcfcQy0+sq5gDaCPOFogYYxl77dfYJ6iXRRE5DCP0QKPt/CC+Ne73/3uFc9BNptfq3me8KwrHHC0icKY43XR2gvOGO4r5jqy4EEhyjkUxGcXmW94LzBjMLfw+dB/HcyY5kCi6usTXTMaGhoaoSJULXMNDQ2NNsRVV13FWsU861nPsvz77Owsa7Oz3377sfY/a9eurR1//PG1K664grUuMreh+tSnPrXi+c0tptA+7Pzzz6+tW7eulkgkVrTK+rd/+7fa0UcfXevp6akNDAzUDjvssNr73ve+2o4dO+rtjtAGacuWLaxNEFonveQlL6ndfffdrp8VbZMuvfRS1p4Ir3/SSSfV/vSnP7FWT+YWXsA999xTO/bYY9lnxnt95jOfsW3zg5ZdBx54YK2rq6u2fv362tvf/vba1NRUw2Pm5uZqr33ta2vDw8MNrbisWngB3/3ud1l7LXzGgw8+uHb99deza3Rr4QWMjo6yVmmbN29m14S2SSeffDK7t82tib7zne80PNfqetBy6JBDDllxP62uB3Pi8ssvZ4/Hta9atYqNJ+77zMwMe8xNN91UO+OMM1grK9xf/I8xbW4VZwfcmxNOOIG1l8MX7j0+78MPP+x6v+2Ax+A1rO5F87y2u3ff/va3a0cddRT73KtXr66dc845te3bt1u+386dO1k7smc84xm21/T73/++dtZZZ7F2VHhNfIZXvvKV7P41t7Fqbk9lNVetPiNgNf9F5lCQ91LlZxedb3/5y19qp5xyCns/rGO09/v5z3/e0MJL5vpEWniJrhkNDQ2NMJHAP+G69RoaGhoa7QZkG6FSfs0110R9KRodArRpQmkASjWgi6ChoaGhoREX6JpsDQ0NDQ0NjZYDAjqgBYMurKGhoaGhESfommwNDQ0NDQ2NlsHNN9/MBOygio+acrAoNDQ0NDQ04gTtZGtoaGhoaGi0DCDCddtttzGBK4jZaWhoaGhoxA26JltDQ0NDQ0NDQ0NDQ0NDQxF0TbaGhoaGhoaGhoaGhoaGhiJoJ1tDQ0NDQ0NDQ0NDQ0NDQxF0TTYRVatV2rFjBw0MDFAikYj6cjQ0NDQ0NDQ0NDQ0NDRCBKqoZ2dnadOmTZRM+stFayebiDnYmzdvjvoyNDQ0NDQ0NDQ0NDQ0NCLEU089RXvuuaev19BONhHLYPMbOjg4SHHNtu/evZvWrVvnO7Ki0VrQY68RFvRc62zo8ddwgp4fnQ09/hqdMNdyuRxLvHLf0A+0kw2J9SWKOBzsODvZ+XyeXZ/e3DoLeuw1woKea50NPf4aTtDzo7Ohx1+jk+ZaQkH5sF4lGhoaGhoaGhoaGhoaGhqKoJ1sDQ0NDQ0NDQ0NDQ0NDQ1F0E62hoaGhoaGhoaGhoaGhoYi6JpsCVQqFSqVSpHVJ+C9UaOga2E6C2GPfVdXF6VSqcDfR0NDQ0NDQ0NDQ6MdoZ1swZ5pu3btounp6UivAc4WerfpXt6dhSjGfnh4mDZs2KDnmoaGhoaGhoaGhkYrOdmXXXYZXX/99fTnP/+Zenp66Pjjj6fLL7+cDjjggPpjkL3753/+Z/rWt75FhUKBTj31VPrSl75E69evrz9m27Zt9Pa3v51uueUW6u/vp3PPPZe9djqt5uNxB3tkZIR6e3sjcTzgaJXLZfaZtOPTWQhz7PFeCwsLNDY2xn7euHFjoO+noaGhoaGhoaGh0W6I1Mn+1a9+Re94xzvomGOOYU7EBz7wAXrhC19IDz74IPX19bHHvPvd76Yf//jH9J3vfIeGhobone98J5111ln029/+tk7hfvGLX8yybrfddhvt3LmT3vCGNzDK68c//nHf14jX5w72mjVrKCpoJ7tzEfbYI+AFwNHGvNfUcQ0NDQ0NDQ0NDY0WcbJvvPHGhp+vueYaZtTfc8899NznPpdmZmboa1/7Gl133XX0/Oc/nz3m61//Oh100EF0xx130LOf/Wz62c9+xpzyX/ziFyy7feSRR9JHPvIRev/730//+q//SplMxtc18hpsZLA1NDoFfL5j/msnW0NDQ0NDQ0NDQ6NFa7LhVAOrV69m/8PZhpF/yimn1B9z4IEH0pYtW+j2229nTjb+P+ywwxro46CUgz7+wAMP0FFHHbXifUA7xxdHLpdj/6PuFV9m4GdkEgH+f1SIy3VodMbY81rw5jWh0b7g+50e886EHn8NJ+j50dnQ46/RCXOtqvA9Y+Nk40O9613vor/927+lQw89tF4LjUw0RJjMgEONv/HHmB1s/nf+NyugXvvSSy9d8fvdu3ezGnAz4OTj2kDXxVdUwGQDdR3QdPHOQhRjj7mOeT8xMcFKLzQ6AxhzBDsx53QXg86DHn8NJ+j50dnQ46/RCXNtdna2/Zxs1Gb/6U9/ot/85jeBv9dFF11E73nPexoy2Zs3b6Z169bR4OBgw2PhdOOGox5WlZCaH7SCw/PEE0/QPvvsQ/feey+j71vhl7/8JSsBmJycZEEUlAqg/n5qair0620JJ7taC3XsMdexsUGHoLu7O7T31Yj+YEMgB3uhNqI6D3r8NZyg50dnQ4+/RifMtW6FNm/0XiMREzP70Y9+RLfeeivtueee9d9DzKxYLDLhMXM2e3R0lP2NP+Z3v/tdw+vh7/xvVshms+yrGRjI5sHEzxho/hWlo8XfP06Z7De+8Y1sfG644Yb670DnhwDd2rVrba/V/Fnw9epXv5oJ2MXps8UFhXKVFkpV6s6GN/Z8XKzWhEZ7Q497Z0OPv4YT9PzobOjx12j3uZZU+H6RrhI4jnCwv/e979HNN99MW7dubfj70UcfzbJ3N910U/13Dz/8MGvZddxxx7Gf8f8f//jHessh4Oc//znLSB988MEhfhoNDghlIcAhk/mHojVE7zRWolRBbUrUV6GhoaGhoaGhoaGhEXsnGxTx//7v/2bq4QMDA6yGGl+Li4vs72jZdd555zFqN3pgQwjtTW96E3OsIXoGoOUXnOnXv/71dP/999NPf/pTuvjii9lrW2WrOwnz8/OsnRl6h6Pf8ac//Wk66aSTWO07jxKZM9AAp25zIIABWjecYFCH3/rWt9Lc3Bz7G9Tb//M//5O+//3v1zOfoIGDLo7v77vvvvrr/OQnP6FnPOMZ7HWe97znsceYgfdsrr3H6/7N3/wNo26Afo46enNdPN7jq1/9Kp155plMDXv//fenH/zgB9RuKFdqpH1sDQ0NDQ0NDQ0NjdZApE72l7/8ZVbYDscPTiD/+va3v11/zJVXXkkveclL6Oyzz2ZtvZAhvf766xuypqCa438436973euYY/nhD3+YOh0XXHAB60UOZxWtzuAAo05axkmHUvuqVavorrvuYr3K0SoN7APgve99L73yla+k0047jdHD8XX88ceveJ2nnnqK9TZ/6Utfyhzvv//7v6cLL7zQ8b1//etfs3H8p3/6J9ai7Stf+QpzxD/2sY81PA6ON67hD3/4A73oRS+ic845h9V5twvKUPeuwcnWbraGhoaGhoaGhoZGKyDSmmyRdkTIYl511VXsyw577bUXy5SGiWI5XFl5prAn8Xhkm9FjHEyBk08+mf0OWWdzzbsbwDCA8Ns3vvEN6uvrY7/74he/yJzlyy+/nKm4IzONdmh29e88mLLvvvuyTDpwwAEHsAw5XsMOcJ7hiJ977rnsZ2Sy0f/8fe97H33oQx9qqAl/zWtew77/+Mc/Tp///OdZjT4c/3bJYqeTCapUMQeQvY/6ijQ0NDQ0NDQ0NDQ0Yi981mqAg/2/92wP9T2RyXz54ahzFnv8X/7yFyYad+yxx9Z/h/7jcHBF8dBDD9ERRxxRd7ABtFiD6h9q45tbpzm9jvk6AF5TbwdQ/3/72982ZK7RxgpO/8LCAqOHA4cffnj977hO1OKb6/PboR67K52kQtmYA0Tay9bQ0NDQ0NDQ0NCIM7ST7QGZdJJecbR4RlhdJltt9hw1zc1sAvQFjwOQiUc2GzRzJ3n95rZW+ExRNK8PAhgbZLK70ylKEMYq6ivS0NDQ0NDQ0NDQ0HCDdrJ9ONqhO1wSFHXQs+GA3nnnnaylFoAe1I888gideOKJ7Gf0n0MdNcejjz7KssQcBx10EKuDRm02z2Yjuwx5e54Rz2QyLMPsBLxOsyDZHXfc4fgcCJ4hW77ffvtRpwK9seFXp1NwsZHJ1tDQ0NDQiAYTcwX6/fZZOlV3AtHQ0NBwhW5016aAojiU2SF+hvZof/rTn1j9srn/G1TDUWP9+9//nu6++25629ve1pAZhogYssaoi8bzofB+/vnnMyV3ThXfe++9megYHOLx8XHLTDheFw48rgWPQ623WcHcCpdccgmrBUc2+4EHHmCU829961tMOb5TUKrWmIPNwLxs7WZraGhoaESDmXyZJheWO3xoaGhoaNhDO9ltjE996lP0nOc8hwmVnXLKKXTCCSew3uMcECLbvHkze8xrX/taphbOa50BfI+WaFDrPuaYY+gVr3gFE1GDY87xlre8hWW1n/nMZ7LMODLdzUAm/bvf/S5rF4Ya76uvvpqJlDkBquZQjYcqOt4bLdugNA+Ru05BGfXYS0ERncnW0NDQ0Ij6TCpX9UmkoaGhIYJETUTiu82Ry+VYT260E4NwlhkQ2nr88cdp69atDbXAYcOgi5cpnU6zumOvQLu0I488kj772c8qvT4N9eM9tVCiwe40pZIJmprPU182Q9muVCjvH5d5rxEuoGcA4cCRkZEG1otGZ0CPv4YT/rR9mu585Gl600kH6fnRgdD7g0YnzLWcg08oC71KNDRiWo8NwMEGmPBZxNekoaGhodG5QLcLncnW0NDQEIN2sjU04tq6C4JnS6wF/KdJJxoaGhoaUeqE4ByqakdbQ0NDwxVaXbzD8Mtf/jLqS9AQQKlSa1Cw1zXZGhoaGhpR12QDpWqV0hRO6ZKGhoZGq0JnsjU0YgZWfw9l8SWq+PLvI7skDQ0NDY0OBxhWQLmiDyMNDQ0NN2gnW0MjZoCDDfc6nTJlsjVdXENDQ0MjQhSXnGtdl62hoaHhDu1ka2jEkJJX74+9BC18pqGhoaERC7r40v8aGhoaGvbQTraGRgzrsbtMWezlTHZkl6ShoaGh0eHgNHFNF9fQ0NBwh3ayNTRiV49tKIubYfykDRsNDQ0NjYhrsqs6k62hoaHhBu1ka2jErR47kaBUsmlp6ky2hoaGhkbELbwyqSRjW2loaGhoOEM72RoaceuP3aQqLtLC61//9V/pyCOPrP/8xje+kV7+8pcHdJUaGhoaGh3HsqpUqbsrWa/N1tDQkMc9T05SLl+K+jI0QoDukx0WqhWiJ28jmhsl6l9PtNfxREndZ1KjEcgQZE39sTmQ3daZbA0NDQ2NKMCz193ppFYX19DwgacmF2ltf5YGu7uivhSNgKGd7DDw4A+Ibnw/UW7H8u8GNxGddjnRwS+L8so0YoRqrUYVVo+dtslka8NGQ0NDQyN88DpsBIE1XVxDwzuKlSrlS5oN0gnQdPEwHOz/eUOjgw3kdhq/x98DwEknnUTnn38+vetd76JVq1bR+vXr6d///d9pfn6e3vSmN9HAwADtt99+9H//938Nz/vVr35Fz3rWsyibzdLGjRvpwgsvpHK5zP72jW98g9asWUOFQqHhOaAlv/71r6///P3vf5/+5m/+hrq7u2mfffahSy+9tP4aPCv71a9+lc4880zq7e2l/fffn37wg+X78Mtf/pI95qabbqJnPvOZ7DHHH388Pfzwww3v6/Y+zeAU6o9//OPsfgwPD9OHP/xh9pwLLriAVq9eTXvuuSd9/etfb3jeU089Ra985SvZ4/GYM844g5544okVr3vFFVewe4Z79I53vINKpWU60Je+9CX2OXGteO9XvOIV9b/tvffe9NnPfpYptiZZPXaCUb9BAeeYmZ6mf/yHt9G6detocHCQnv/859P9999PoqhWq3TZZZfR1q1bqaenh4444gj63//9X+Hna2hoaGh0LuBY42yCKCeCwRoaGvKoVlF2UaNCuRL1pWiEAO1kB00RRwbbMgO59LsbLzQeFwD+8z//k9auXUu/+93vmMP99re/nf7u7/6OOaz33nsvvfCFL2TO8cLCAnv8008/TS960YvomGOOYQ7cl7/8Zfra175GH/3oR9nf8dxKpdLgEI+NjdGPf/xjevOb38x+/vWvf01veMMb6J/+6Z/owQcfpK985St0zTXX0Mc+9rGGa4NDDMf1D3/4A3vPc845hyYnJxse8y//8i/06U9/mu6++25Kp9P195B5n2bcfPPNtGPHDrr11lvpM5/5DH3oQx+il7zkJSwQceedd9Lb3vY2+n//7//R9u3b2ePhKJ966qksKIH3/O1vf0v9/f102mmnUbFYrL/uLbfcQn/5y1/Y/7jvuBZ8Abj+f/zHf2QOPQIFN954Iz33uc+16Y9tvSRf+9rX0Pju3fTjn/yE7rnnHhZcOPnkk1fcMzvAwUaQ5Oqrr6YHHniA3v3ud9PrXvc6FlTR0NDQ0NBw0wuB6Fk6mdCZbA0NH1lsQGeyOwQ1jdrMzAxODPZ/MxYXF2sPPvgg+7+Oq59bq11xoPvXJ7bWah8adP/C41xeq3rFgbXKl59Tq1arQp/pxBNPrJ1wwgn1n8vlcq2vr6/2+te/vv67nTt3ss99++23s58/8IEP1A444ICG97jqqqtq/f39tUqlwn5++9vfXjv99NPrf//0pz9d22efferPOfnkk2sf//jHG67lv/7rv2obN26s/4z3vPjii+s/z83Nsd/93//9H/v5lltuYT//4he/qD/mxz/+MfsdHweR92nGueeeW9trr73qnwXA533Oc56z4j5985vfrL9m8z0pFAq1np6e2k9/+tOG18VzOf7u7/6u9qpXvYp9/93vfrc2ODhYy+VylteF51555ZW16YVCLV80XuOII46ofehDH2Lf33rrrez5T4/P1CqV5evYd999a1/5ylfY93gsnmP+rGeccQb7Pp/P13p7e2u33XZbw/ued955tde85jWW12Q57zXaHlgb2BfMa0Sjc6DHX8MOO6cXa9///fbar+7/S+3Xj4xFfTkaEaDT94eFwrKN5xW5xWLt2juerN2qYA0VSpVaqdyeY1GJcK45+YSy0DXZXjA3RjTbRP/2g8UJ14d46ZN8+OGH179PpVKMxnzYYYfVfwfaMs9GAw899BAdd9xxjKrN8bd/+7c0NzfHMrtbtmyht7zlLSzTjaz3HnvswbK1oEvz5yADjmyvOaOM7Hc+n2cZc1C/m6+tr6+PUaD5dVhdP2jY/FpxHaLv04xDDjmEkqb2WLgHhx566Ir7xK8F7/PYY4+xTLYZeB9krs2vi+ear/ePf/wj+/4FL3gB7bXXXozSjgw4vjhVvrE/do26LDLZuAaMwTP22tTw+8XFxYZrsAOuH/cE12EGMvFHHXWU6/M1NDQ0NDobyGQji51OJerZOA2NTsHT04t06yO76ey/2ZMyFuK0oiiW1WWy7902RQPdaTpk05Dv19IIBtrJ9oL+EbHHlQtCDjT1rCFKZx0fwsIqfeuWnG0xdHU1KhfCETb/jjvGqNcVBZwy1POCegy6OajHoItzwBkEFfyss85a8VzUIztdW/N1OF2r6PvI3pPma8H7HH300XTttdeueC3UR4t8HjjooOej1vxnP/sZXXLJJaze+q677mJ13nD6QRVPJRKUXGrfZa7nxjXAab/hJz+j/my6gVKO57sBzwcwTgiMmIHaew0N1UDQaHqhRKv6MlFfioaGhqr2kukkpRMJmtfq4hodhHypQnf+dYJ1eEEttS8neylApaIme7Ho71o0god2sr3g/wnWsaLW+rOHGiJnllnohKEy/q4/urfzgvJ0uRzogB100EH03e9+lxnI3KlFthhOIgTBOP7+7/+eCXUhm33KKafQ5s2b639DrTDqjiGqFiTCfJ9vf/vbNDIywrLtXoGactwrfKEOHM4x6sMRJICzvmPnznoWO5fL0eOPP95wDbt27aJMV5r23W8/y2y3Ew4++GDmTG/bto1OPPFEz59BQ0MUu2cLdPtfJ+iMIxuDOhoaGq0J1GF3IZOdSFC5qDPZGp2D3z0+yVpu4VzjmWivKJVrjBGiIpO9WKpQX0W7cXGGDoEECTjOaNPF0JyDXvr5tE/Epl/2P/zDPzAlbYik/fnPf2bq3XAI3/Oe9zRQrF/72tcy+jjUys1iZACytMhyI8uMLDco6N/61rfo4osvVnqtYb0PBNkgHgdFcQifwflFRhpCZlwczQ0/+tGP6POf/zzdd9999OSTT7LrRpb7gAMOYH+HUvg3r72W7rj9N4xifu655zZQz+GYP/vZz6ZzXvV39LOf/ZQpm992221MGA6iam5AkOS9730vEzuDKBso5sisf+ELX2A/a2ioRqFc9W2MaGi0M3ZMLzIGU0tlspeEz6COrKHRCfjr7jkanyvQs7auZlljv6USxUqF+rvT7HyE0rgfIBveSntIJ0I72UEDfbBf+Q2iQaOmuA5ksPH7GPXJBpX4Jz/5CVMjByUcStvnnXfeCsd1aGiIzj77bKayjdZVZkCJG04laNGo3YZzeOWVV7KaZJUI631QNw0lctSBI+uMbD/uCWqyRTPbyFpff/31zJnG86Hw/c1vfpPVcQPvf/+FdNwJz6GzzjiDXvziF7N7uu+++9afD1YBFN2PP+EEeuvf/z094xnPoFe/+tXMYed19W74yEc+Qh/84AeZyjiuAXXhoI+jpZeGRhAGeUVTSjU0bHHXE5M0NtvYDjPOgGYI6rHRxgvfa2i0O+YKZbrnySk6dp811N2VMpxsn8FjBKBRR82/9wowTpEN12sx3khA/SyqN4fz8qlPfYq1JNq5cyd973vfa3DaUEuKPs033HADTUxMMIcAGUQ4fxxwdv75n/+ZZTHRvxnOF3oSizofnJ4Lx3FmZmaF44TXR/YS7+1U6ytEHX/yNqK5UaL+9UR7HS+VwWbCWKCLp9MNwmRRAe2j4CQiQ6tBvqOR+WKFhnozjmO/WCa2yWOzDxrK5r1GSwEMC4j+oTzCzF6RxcO7Zplx8upjNtd1BjQ6Z/w13HH9vdvp6L1W0V5r+qhVggLpBFFvbYHu312lVx6zJepL0ggZnbQ/wO76xUNjNNzbRcfsvZr97paHx2jP4R7af32jEK4M7ntqmgWhnxifpxccvJ6Gbew+kTrx6+99mjYMZen5B4r7O62CaoRzzcknlEWkq2R+fp5lTK+66irLv4OmjJ7C//3f/83owO9617vone98Z0OfZlBgf/jDH9J3vvMd1vMXPZCtxLAiBxzqrc8hOuwVxv8xoYjLYmpqigVDQJl+xzveEfXltAVAvbPrj20GYivRhcQ0NMQBIwLQUXYNDWtgbfB10jLq4imjJluzVDTaHQ/tnGU1z0dtXhaXzab808V5v/lsV8pXXXZh6bm6Z328EWnF/Omnn86+7IC6U9SnnnTSSeznt771rfSVr3yF0Zlf9rKXsSjD1772NbruuusYFRf4+te/zuiwd9xxB6MQa6gF1MXhaF9++eX1mmIN8r3p9mbcgy7IB9Yk27hpaEQBboiUq1XKxKQq6YEdM7R5dS8Ndjd2AtDQEAWcS7TNeeZeq3wzyvBaxXKttYLBySSlKEFVCLFWa4w6rqHRbpiaL9Kfnp6h5x800pAAUUEXx/P7MmnqTidZNtor8kvq5FofId6Ih/Vjg+OPP55lraFiDerGLbfcQo888ghrHQWAZo5WRxCG4jjwwANZ/eztt98e4ZW3LyC6heAGhLQ0/AOGSqUmmslO6Ey2RkugVI5fJvuJ8QUay7VODaxG/DCzWKJHR+d8Z48geIS9vJX6TddbePE2ky107RoaMjYZOmMcuHGAKYqbocrJ5mV/fmqy0b4LcT4EsjXii1hrv0P9GNlrtI9CLTJ4+VC0fu5zn8v+ztoaZTIregWjHht/swNqt/Fl5t/zGoDmXs34GQ4+/4oS/P2jvg4NdYAyJOh3CZdxZW3VljIIYYw/n+9Wa0KjfbF9cp4eH5untWv9irtUqFarUrFUoaoASyMMFMsVmsuX9Hx2AD/v9D2yxuR8gc3rUrlCftrTwtDG6xRK5Za514VShVJUoxQrW6qxe5DBDxodg07YH+7bNkUJqtHBGwZWfE5Md2Sf/Xz+wtLegbWzUPR+Hi0Wy9TTBaff3/XEFdUI55rK94y9kw3aN7LZUI2GUBrqgDdt2tSQvZYFFJbR+qkZu3fvZoJPZiBTjhsO4Sl8RQVMtkrFoIfEQfhMQ53hAga409ziY1+pVQkJlDCmIa4H8x6Cg11dml7bKXh05xw9PT5D+6/t8SU2Mj4xQ7NzRRodS1G5Lx7zZ2p6hrLVRdqQ0dlsO2DNg6mEPafdhY284ImdczQ7u0i7RseoL+s9eIRazNnZWdqdKtJYb3R2hQwmpqYp112kfGWRFufLtGN0jIaWVJI1OgPtvj/snivSvU/m6KR9h2l8fPeKv8/N5Gn3dJ7Ghrw7YbsnpmhTd4kW5ko0Va7SxkzR0+vsGJunSr5Mk/MlJhDWbqhGONewN6tCbHfIxcVF+sAHPsBEttDWCDj88MNZr+ErrriCOdkbNmygYrFI09PTDdns0dFR9jc7XHTRRUxUzZzJ3rx5M61bt85SXRw3HIOMbHrU0A5Pm6FMlE0nKJ0WMdiSVENdXAjzEPMdX+gRns02UqZEccdfJ2jL6l7aNNyj/Po0gsETcynKzpd8K3r2jddoIFGg4dWraWQoHuPfu61Amd4s+2ydSIG88U+76IWHrGe9jp0MGwRxcRa2oxHtF4kpooGBNK1as8azKjAwmy/RwECR+gZ6aGRkHbUC+p4u0YaR1VRdzNGq+RKtWr1mBZ1Wo73RzvsD2CW379hFzzl4M+1rox5e7FqgiXLO1xnS+3SJNq1fR129BRqbzXte/4/PTVDfQILyu+do7VqMR3sl36oRzjWVHXWi9xptgAwyvppvbiqVqqfyjz76aOZ03nTTTaxvM/Dwww/Ttm3b6LjjjrN9bTgNVo4DdyyabzbeEy3GMNigp0eRSeZtnJDR1Jns9sHiYpES2TRRNek69lVKsjq4QiK4QAveC4ErsDow77FOvG5wuXyZFkvVtjuM2xklKB5Xjcixn3FDqVkikaRqLRGL8We0s1qC8uXOnI/5cplmCxXKl2qU7XL+/Dhf/I5/uwJ7GpvX5G9es+KfRJKtk1a5z7jWbFea8vkEZdOp2KxtjXDRrvvDvU9NssDZgRuHbB/T3ZWun49eAT0HKIv3ZNJUKHt/rUKlRusG4I8kCRxXiBK2GxIRzTWV7xepk40+2I899lj9Z/TlRaZ69erVTLzsxBNPpAsuuIB6enoYXRwtur7xjW/QZz7zGfZ49DE777zzWFYaz0EW+vzzz2cOtiplcdxs9AqGk432YFGB1ybgerST3R7AmC4UK0xZ3GlM+djDMMMG3RNCjWtvby9bg34PkzgJX2m4A0JMKlqCIBiEwHpcxp+3HFooeFdzbWVwsZ6FUpmGSLOhvNZSLharlE0nfbew4s/3K6IUFligtwqBTuOcgqq4Fj7TaCdBw6cmF+hlR+zh+Di/wmfQ4MHSVyF8hpKTgWxXXWEcuRqN+CHSYbn77rvpec97Xv1nTuFG265rrrmGvvWtbzFq9znnnEOTk5PM0f7Yxz5Gb3vb2+rPufLKK5kjgEw2xMxOPfVU+tKXvqT0OpG9hsPBM8lRgNfHrlmzpu0iiJ2K3bMFegJtIvYZERr7Wqaf/rRzlp6/NVi6KzLYoKT7DeZA9VK3l2gtoPemCscYzjqCQTAq4gD+mfA/nCVk4joJXMUaQT0Nb5hZKLE6bNDty4qc7FZxVHngjWfLulKJ2ATQNDT8Yq5Qpv5sl2sCA2sfa4EJ0Xqwj/g+3JVMsmCdnxZeOMe6u5Is8KXXYnwRqZON/tdOSsmoq0bfayeAzn3VVVexryCBBQVqelQ10XC08N74vNrJbg/MTRWpv7fHtf6Dj32yp5vy1Xml9SJBolQG9bg1jEgNA4iswwFAiyGv2wzLelVqNNSTis3hj+uATYT2Q8hmd5qTzZ0ktH3R8IbpxRIN9nSxQFTFZ/CQz8dWaeHFgwFwrgG0nIxLAE1Dwy8WCmXqFRAyRAYawLr1cobAJoJTjPppZLKxLxtnrbzDDgcdtHMW8NJrMbbQ3pqGRkSYXijRcK940CbDDJt4OC2i9EK/tEqNcMGNfj8ZNu7QoQwiLuPPWuUlE9SXTdOCj+xBq4JTHBc78LOrpJQO93SxeVTx2UYR6wJZqPKSkR134DrhHPDsHe6BirISDY04YL5Yob6Me84RmWz4w14p44UKAryG28X/z5fl92S8P47onq4UpZL+mTUawUE72RoaEWF6oUirJBRqOS2oFfqkcwOsVeiQGmBMIANtjJefDBsfc0Tq43L483pS0AGRteg08DGZ78DPrjYomqFUKkEVnwwdONkwkIFWYPvgGnkWGzAo8/G/bg0NEeBMEG3J56cuG3YR7+6A7DVeC8wYWcAxh7OP53dpfYRYQzvZGhoROTQsMyKRyeb1cK2QQeCbflwymRru4I613ywVxh4GOV4nLjQ2zENE/PsyaZa16DTAKMSY+KkB7HQgKMoz2X6DR3g+6KZ+smJhwljTy+airgPVaLea7D6BTHbdyfZ4rmGtg5HIweqyPWSysY8jiL1cuqHXYlyhnWwNjQgwmy9TMpGgfglJSJ5JaIUMAt/09ebfOkBEHQc2Dn4/hj8MEBgiCArFxRBnTkIywSjsC8XOy+ZiTFBPrIXPvAEMAMxl3MNUAsEj/3RxKHRzIaWWoIubRBrwfakFggMaGiJgXV4EM9lYs17PR+ZkL9HEAaYw7iGTjeeg3GQ54KXXYlyhnWwNjQgwtVCkod4uKYVKPLZVauE4BTIuTpaGWL0YouwI5vityYYhwg7/mMxV7tQwJ7sD23jBuEMWFm1fWqEGOI6iZwPdaTaH8FX1WbIDoxh7eVcaTna1JYI0Zro4q0vX80ijDYD9EFoVfTKZbM908UZGiJ9MNkTPuFJ5K9iEnQrtZGtoRGS0weiVheG4xN8o44ZjK1yrxnJ0HIe+kV3z4WQzajIy2fGJsMMIwdrpVOEzjCeysIjpafEzb+27hnsyyqjScFBZTWYq0RJ0cQTLzM4BC8RpJ1ujDcDPA66R4IYsMtkez8eCRSYbgU9Z4DndS+rmCPrpgFd8oZ1sDY2IMtmr+sRFzzhY/U0LbKg8g6kNsdbBMs07wYwBvzXZcTr8cR2guHLhs1YQD1QJOHIIoMCQ1JRxeUwvFuv6Gajt9zuvjfnI6eLxd7JxjQgucKR0C6/YjMudf52I+jJav31XJiXcRstvJttckw3Kd8FD0BPZb97T2y/zTCNYaCdbQyOqzIiE6BkH6kpbIfNRXDLK/KrwaoSbyYYBgeyaH/oZc9YZ7Tw+NDZOz+3tShH8Iz9BhFYEpynCMNO9sr3t10NLzCND0E9NTbYfEaUw0ewcGIrG8VjbnQyUvvxl97wuAfEBCGH2ClLF/TrZzTXZED/Me3gtRhdfep1WSbx0KrSTraERMrBBIpvE6YcyaJUNFUYosmbaEGsdwNg36OIKarLTyVhlsjEfcT1c2K3TWllxmiLLZJc667P7BRyYXL7ENDQAFfOatZRLLgWiyvFYI+4t8JrVxeMfHGh3cO2TVgjUxBU4C/qWssLCwmce7zdneZkz2V46PoAuzunthk6Pv/HfObNI9z017es1NKyhnWwNjZCB1l3oyWiOaIoCG3Qr0PSw6eMQiIvwlYY7QFtjdHG/NdlLWdM4GeJmJwFrr9Mo0wh8IBNpqKt31mf3i9lCmRKUoIGlThAqtAbguEOs24/BHiYMnQWz8JluGxSrsqwWmENxdrJ7s9Fkspm6uMdMNm/hxXrW+1yL0wslmpgr+HoNDWtoJ1sj9sDG9L3fb28JmrTohsaph7KIEwXX1cleig63QlBAg2eyU0tUUL/CZ4lYGeKYg3COgJ5MuqMcTdSfM7ovMtmaLu6JKj7Yk653glCZyUbgoxXONWhrrBA+0/t65OBj0Ao2QVyBs6BfsH0XgDXrde5z3ZMGdXFPmexKQwsvv/sRPk8rMCRbEdrJ1og9RnN5WixW26a/LRM965WnigNxUmx2AjZsHmnVm3drgEfZYUD77pOdihddnAlNLWXiQA2cb5O9RAQwwKHzBiept8MCDKpEz4ZMpT2Y1yrUxXlNdis4qwic8SAVAFZIXNZ2J4PPw1aYQ3EFzgKZmmw4xl41PdgZ2yB8ZrD9ZNYSHos9vZ7JTvpnw+D19HoOBtrJ1og9xmbz7P92MQ6RyfbsZLdKJrtcZZFWJH+0k90agOHAa7KLPuaY0S7LeB2MfRyUvHnmEOi0bC43wDEeoIvrFl7y+7VZpJL1yVaSyU60TEYYgd2GTDbrFW4Y/BrRgbPEWoENEWfxuL4QhM8MRlGtIZPNHW6ZbDZ/LBc+SynKZLfCPtSK0E62RuwxmisQgujtYBxio51BZsSDsnhL1WQv0QtZNrMFggIay1F2332yTS28gDgEWXjmEOjLpDtK+AzjivEA3dkIMHTOZ1eB6cVGJ5uVQfjOZFfZfGyVFl4IupmdbL6WWuHa2xk84K7HwRvgsGIt98rQxRn7RD54zLPN5nWEtmGymXGuLM7LV/yWdwGy2XQNcWgnWyPWwIYCobANQ91tkX3K5Q0Dl4voyAIGXqtksuuZmhagt2sgk20c3n7bxPF2P6CxAXE4vM2qrjCo2iFgJwpejw2ghRnsMS91gJ0IBDTn8uWGThCqarKXW3hFvz5E7kOD8FlKs5TiAF461go2QRwBdqRRIiXuCvHssyxlHGOENdP8XllJhXG0/OJ6N/WOMz7HX9dkBwftZGvEGmO5Ag33dNFwb6YtDGPebxURTC9oFaeV0wtTSV271wqAEQ3nC0522ifN28icJtkcxzSPQ5bFnMnmdclxoLGHWQYAcBq/drLFgAAvF4xr1MXwX5NtBCFbQ/gMRry5hddyv/D4X3s7Q2eyw23fBWAdeDnXmuuxObrTcgrjZtEz43r86/Qgy67ttGCgnWyNWGN0Nk8jg91Gf9c2yGRD9AwBA69Q0a4hDCA7wyLECqhMGsGDU9kwZplUol4/5gVwQNAnG4iL+JlZHRnZXPjX7RC0k2mpxqHFz+ScbAR5zUDwCHTvThE+Q/051nSzg9AqnS46oiY75nMorsA+KNO+y09dNtuHLdq2Smey4WSnlwMDYIxh+P3oRMCmxJkYh7O63aCdbI1YY9dMntYPZg3BnjaoJUR9n1fRs3rUsgUOVN4ySQWVSSN4FErLdbtcRdiL8Y/nGErWxmvwrHjU4DWw3EnqySRpvtAZjiYcoUYnuz0CllHUYwNYH1gafpgQXIgP6wQvE2dHmzOnuDq/ygyaBikoOzDKszS8KYvLZrIBo8xDUSZbslc2q8leUhY3r0s/5+xyKzg9j1RDO9kasQVads0VyjQy0G0I9rRB5mmaZbK9iZ7VswcxcFpE6YUqqJUaIfXIXjq44Wh7FWTiz+HGRFzKBdh8NJVoIJvbDhoPMq3ZzEZdp3x2VeU9ZvBgjZ95jawTJAv4OomzccuDpM21pEwATgdQIwXmTU8mrTPZfpTFPWSyvZR5mMt2zJDtlY2AeANdvC4w6k9HBYjDWd1u0E62RqxVxZH1ZTVxzDCs+m6dIoLHxuZocr6o/HWxKSN71my0yaAV6uDM9EKd7WgN4OA2R9mZEeHFyS4bzqxK5VMVYJnDpmxup/TKLlYqFpnszvjsSnpkW2SyAa/BQ+yPeCqcVMYcgc5GOb7GrVk00Azeok8jOiDIgfKXOOyxrQgkcfok2nf5povbZLJlnGwkm3iPbICzz/yUbvDn6vWsHtrJ1ogtRnN5pioOwMkG8uXgMzAP75pljnYQBhtoquYNUhatQL820wuR9Yn79WoYjhhqwziM/r3y4wbHvCu9bJDHoSYb7w9KbnMmu1MczWK51pBBYU52G7CCggYMXwR2zcriKjLZ3JDlr4PgVqFSaZlyAw5jb9fOXZRAABvrGWtcQx44A2Tad3FkPQShmxlF3oXPkMlOKSsj5AEabEdRn9XtCO1ka8TayUY9Nq+jBEUm6FpCZBlm8yXaMb2o/LWnF1Df570e25w9CCOjr4JeyITaYnytGiYqm8mQ9hKpt4rWx0EciTMpuFPTaXXJzWNi9MrujM/uB7nFEvVlUysMY2SOcDu97mvckOVBH953N67A+mmux47L2u504P5DuEtnsr2tQzisfaFmshOKhM+aSjd82FncXoPjrlmH6qGdbI3Y0nhgCK7rN5xsoDcE43A2X6ZkwugTjPpp1U62H9EzABRDIM6Oq/kwMTKZeuNuCSfblMnO+KjJNjt0cchkcyPCnMnuy6Q7RvisOYPSSfXofkXP7Ep7oDXgNdBZqRn9cnkbR+asxli4ClR2q0y2obcR3+vupEy2drLlgXIhLEFzfXOQTrZjJrsk9lrYc3BWr8hk+9C+KdZFaqM/q9sR2snWiK2q+Jr+bEMdJRPsCZjmiJYtgz1pGhnM0o7pvPr2XT7qsQHuvMbZuDHTC9FeQmc74g9D+dTUFsRj/14Ye+ba7jgY4oaS83KdOACK4GKpQ+jiTRkUGOUw1LRB5R4UtXOy/Ri1lcpyz/bl0owY7+dV6wwczma9t0cL3H+U0sV5/sRZ9AwsAPO5IAovmiV4vJW6OILb2EtE6N6cVm7pZPugi6PESwsZBgPtZGvEEmMmqniY/V2Z0E1PhvYY7qGdM+oo42j3AqVaP8riqkQuwqQXGrVC8b1WjeXD2xxlRz9PL4ZbsSnrFQcNAd6T2AyDFROOkGLUYIEP09iiPhu3o1Nq0v11grBmHvlhaLD90TQfYXjHWR0a84czqFaULsX4utsdsCmY8Fkm5btPcifCa/su1ZlsrpchUpddKEPE0tC6UVW6YXTe0J1ggoJ2sjViidFZONmG6FmYdHFkspG92DjcQ7tnC56yeXb092qtRoPd/pxsgKnRVlqDXhiHTKaGOzDPzeJYOMi912Q3Cp9FfXCznu1NmThkf5ij2QECYM39WRGoa5eWiEGfBXbMIz/7WnPQBwEtVedMEIARbk0X13obUYLfeyQfgDgHamKbyfZQj10PjMk62U3BTvN+LNrGq1lZnMNPFxd+ZqcYXVzPIdXQTrZGLI0bbGBrTfXYy3TxcvBOdm8X9WfT1N+dZuJrKqmHvA7PD+KQHRSlF8b9WjWWI+Qra7Llxw0HPZyGOGW7DLr4SvEqOJoLhXLbZ7swjs3GndESUTvZdpgvlNm8GbRxsrGPe7VHUZNtdrK9rrWwYDgH1i284hzsbXfwc5UzU/RYeGjf5UFZnN9z2aCGXQuvehsvAafdSlkc8EP15telS/va0Mm+9dZb6aUvfSlt2rSJGT033HDDisc89NBD9LKXvYyGhoaor6+PjjnmGNq2bVv97/l8nt7xjnfQmjVrqL+/n84++2waHR0N+ZNoqKaKw8G2ongGSRdHhgHCZ7wOb9NwjzKVcRXK4hyZmBs35sNEZ7JbM9vpVfgMdPFMDIXPmveSsMpPogY3BJuNu0747H5Fzwa605bzxu++ZtAzzTXZ3tZaWOB00mYggBr12u5kIJiNaYSAj1Z6lwfKZfqy6cjp4gDE1woCmWymLG4h1OanZz3X0InDWd2OiNTJnp+fpyOOOIKuuuoqy7//5S9/oRNOOIEOPPBA+uUvf0l/+MMf6IMf/CB1dy/TiN/97nfTD3/4Q/rOd75Dv/rVr2jHjh101llnhfgpNFRjNFdYQRUPgy6O1l2pRKJep7NpCHXZeXWiZz7rsVuFpmc2ygwaU3yvVcPaAGAUVgXq4nGYq2Ub4SbsJ6jLa/dxha5Ps5Pdkwm+HWLL12M39cc2w49BatDFze3yErGm+lqVWwBx1wZpd5hp/F41NDoZ88WKp/Zd5rZ7YAqJrnkMj5XwGZBNp1iWWszJtqKLI5PtnS6O9a1ttWDgbYYpwumnn86+7PAv//Iv9KIXvYg++clP1n+377771r+fmZmhr33ta3TdddfR85//fPa7r3/963TQQQfRHXfcQc9+9rMD/gQaqoFNCxTtAzYMrPgbNhdsbMahnwxIWbyrrja5biBbb+XlNwuNzMj+6/uVXKchJlZtCXqhjo7GH5jjGCIc9H6poM012X5qxYIUPuuUXtmMKm6xV/Z0pWlyXm2Lwrarx3YIivoJHnG1ew6o+se5JttOFTkOa7uTYRYYBbstznMojnYmSoXQZcIL+HqwaqdlBX6W2jnZLJNdFslkV1kpYzOwnywWvdPFcV1gROia7DZzsp1QrVbpxz/+Mb3vfe+jU089lX7/+9/T1q1b6aKLLqKXv/zl7DH33HMPlUolOuWUU+rPQ9Z7y5YtdPvtt9s62YVCgX1x5HK5+nviK47AdWFjiOv1qQIc2lKlQqt60is+Kw6SRKJGc4WSEgGxZkzNF2mwO1V/XxxfIwMZ2j65QIPd3pcKNrFZqJZ3r/xMXsYe52qxXIntXCiWjPpeXF/cr1UDBzeyuTD8l+caYiSgr8mOG57DXwdIUo31AI5y/DH/4NM0X0N3OskCeu08NwulcsN4cHR3JWi+UFrxe1XnDEQjYQyi7r0VgbNgz+Fu2/uQTGBee9vX8Dw8v76fJ2tsz4zrPDSud9k+4vMD7oLe263r+ZFxRAvSIIG9FucrO2eTCeakBT0W7WKHghEJh7I7lfD0WbAeElRj+yvsUjfkWU9uOMG4dyudYQSmMW/crmWxWKbVvSvtSFyP17WI58HJxqdAXXhcxrYa4VxT+Z6xdbLHxsZobm6OPvGJT9BHP/pRuvzyy+nGG29kVPBbbrmFTjzxRNq1axdlMhkaHh5ueO769evZ3+xw2WWX0aWXXrri97t372Y13nEEBh2Ze0y6pEV9VLvgsfFFylSKND6+2/LvpYV5emrHKK3rV1PfbMaTO3NsAxsbW44oZiuL9NC2KVqb9j4vJuZLVFycp9zUBBnhHH9jP5ebpfJiktak4jlXxydzNJhN01imSPOFCk1O59h61ognphfLlJ+fY2PE51oqX6aJqRkaG5MLZk1MTdNMb5kypTn280yuSBNT8zQ25l/wzyt2j8/TQqlKY2ONB+fibIF27F6gseH2ZVrsnCnQ4vzCivW3MF+iXeOzK8ZF1Tnz84cnab+1PbR1TQ+1GtAFYvvYJB0wVKOxpXncjNzMHC2mEjTWtRysF8X4xALlFss0NmbMO7R2HJ/CHhnPgMTuyWlaky7SWHW+YX7MFqs06WGPaHf8aec8E9V69t5Dgb7P2EyB5mcX2bxZmM3RaHWR+qvzgb5nu9ihkwuGTTY5Me75NfILc7Rj1xitEigDxPstLp2xVljILdLobJHG+p2z2aMTUzSc7KWxRKNWUG46TxMzhRVnnAh2Txj2GnudQpnG+uJRQlWNcK7Nzs62v5PNIwlnnHEGq7sGjjzySLrtttvo6quvZk62VyAb/p73vKchk71582Zat24dDQ4OUlzvB2jMuMZW3tzc8Ofp3XTAllU0MmI9DhsmatQ31E8ja/qUv3diV4W27jFMI8PLhmHfUJme+MNOGl691la0wg25sTnasqGLRkZGlIz9unwXoRRoZGQVxRF90wlaP9RNIyMDLGLcv7NEa9fi2qNztDTsUZlZpHWrE2x+8rk2MLya+kYrtGbtOlvxJyv0bC/RxvXraHWfEQSrdefpyfmk57mvAjsK09Rbra1YL+m+Iv11dnek1xY05hJztLaSXfEZe/Il+uN4le0pvDxG1TkDQaFkNk+Dw8O2+3ickUOHicEibd1zQ8O9MQN7cNXjHjxamqF0T5lGRtawn7sXS9QzXo3tPOzbWaaN61fTyGB3w/zoL1Wpd7QS2+uOCqnp3dTdFfx4ztIcra0aa3vdXIoxR0ZGgnXs28UOzU8u0Ia1KV9jtHZXhQZXDdPIkHsgsTy9SOtm7c/BfHqBpqs51+vJ7ijRHhvWslJGMxZT8zRTnfP0efqnEzQyZGggVWfyNDKyjuKAaoRzzaz71bZO9tq1aymdTtPBBx/c8HvUW//mN79h32/YsIGKxSJNT083ZLOhLo6/2SGbzbKvZmAg47xxYMLF/Rr9ADSa3XNFOnzzKtvP2JvponxJfWQLdZsQwljVl2147YGeDA32ZNh1bV7d6+m1Z/LlFa/rZ+wzaaOWNK7zgAl8dKWNa+3CtSepSglLhVqN6IFSviz6Ri+ND+vb2ZVm4wZdI7T2EH+tWsNrdaVThHBplHMVnwFrpvka+ru7qFipMWcpCI2HOABaOt1La9GMvmwX1Six9Pek0nNm91ypPnfiukc5IZevMA2OVMo+s5xOQajI2x6M+YZ1wZ+LtVatwZlPxDIQif3BvH74/DB0N0CaTUgF4toduXy5fo+CBM7UrpQxLthzyyGtt3awQxdR29zd5eszZHDPq2L33DhjV+7D5m4POIvcXgvdO3qzK18H9pbX/ZZfGxg8UZ/VcZlrKt8vPnezCaCBo13Xww8/3PD7Rx55hPbaay/2/dFHH01dXV1000031f+Ox6PF13HHHRf6NWv4V+AGnOg3qPELolc2shcwFKxaOmwc7vbVyou177Lpt+oFXTHvPW0Wv+ICP1ogJ76AeAuMNDOwFuB3yqgeQ4yPORAN6uLRKxA3t0zigGANLnVBoHVKq6JZiI4DQQUwc4IQfkOdO9CqSrXT0M9wUBavCzoKKgtbBXTNzjRnSMVVYZyp81uwuPg616rWy8C9QIkUAjBhvFddXRwtvLTwWSjtu7y08bLbhzlw/hZc1MVZzX3NOLesWwp6FWKssuez14ixXdmqiDSTjZrrxx57rP7z448/Tvfddx+tXr2aiZddcMEF9KpXvYqe+9zn0vOe9zxWk412XWjnBaB39nnnnceo33gOqN7nn38+c7C1snjrYVcuz1p32VH0uCLwxFwxEDVZ3h+7GXsM99Btfxn3Jea2qlcdtZspP8fYaS1Vl1uLYCzj4GhpiPfI5sAYyijW8jE2v1YceunaqYsDPegXXagEIqQYBzj1ZjXU1ct1ar9KJxuv2aoGG4KizXTMZkDV2U8LL/OYYG5iesIQF1EqDptdBh/ais2C68ZR3arBlCCAYD3GEnPfad9RAaZSv+S4Ya/OVeJRS9sKQCDEqk2sDLIpKIKLnY94nFO5YTZtdCtw6pwDZXH8qbkdI2A4yN5sQmTQM/z99VpWjkgz2XfffTcdddRR7AuAs4zvL7nkEvbzmWeeyeqv0cLrsMMOo69+9av03e9+l/XO5rjyyivpJS95CZ199tnMGQdN/Prrr4/sM2l4x5hNf2wzeroMwzBMJ3tdf5Y5EFCclQUEUHDYojWYKrD2MTE2YBFRNx8Euo2XP9zz5BSNz8kLLIkCEXKowVv3AhU/uJGJw7Cbs3Q4/JHwi3L8EZCyyyL0LTma7QqMiZVRVmcFKc5kY7/Da24a7o51m0G3dotO7bv8Zo6snC+ZrFiY4MFcu/Xjx7hvR8CO4EGroLPZKzLZehyEASVvBBn9gK1ZwXvO22Q5OdkIWEHd20lN3i4IZ/TJrvmy1/zsaRoxzWSfdNJJrs3c3/zmN7MvpwL1q666in1ptHg99myBjtrSqBTfDGyMiwEcXjgc7bIXcBo2DHbTjplFWiWZ9UEWGw62yoh23Ptkm/t3tsL1xh07ZxZpoDtNawNqCYMou1Um16Ag1jwZfRzmcoFUMposXaUCp8be0WznXtlw3GDAWaG3S/1eumsmz1oXwRicWihRqwH71Fy+TMOudPEkm1fe+2Q3jonhJMXPwMU1wfi3y67F9bqjDNDARpjNl9m+2hdgFy84VT1dvE+2uMOnQUx/RwVdXDRIiX3YqZ0h00FJJ1lgxqoPNs9k2znZCIJhX4E/5cQEdbLXoAuh+2SrR2xrsjWiw193z9G926ZCfc/x+QJzRCE444TuALIvItkLZGZ2TOcjr8euGzYxjTha0QtZ5j2m19sKwOEaZFbEzhGTNdysnGweXIqSecFrzqzQl0mzrEa7Ag6QUyZbdYBhjJX8ZFs2w4lgK4xnt/7eqYTaTHZcM5GMvuoQIGYBVG2Yr2DEgRkUaiY7jZIsPQ4iwH3CmRduJtt+H+aAA+1EP8+DcWYTMOVBO9k9yWyv6ZrsYKCdbA1LdUxkleNGFefZF+wjKg8wnr2wo4sDG4d6GGVXltIHJ3tIoI+iDFiNcwyphQA/dLpWZLL15u0FOAQx54IILDUIn6VXGhyyhn/ZwpDgNflRBlnMtYuWdcltLHyGuWMlWlVnBSmeV6Ozhq5Gq2Y4WbBVICiaYpkfP5nsZrp4Qri+02qPcGME+tnPnWpJ4166FEn7t54u6k4b6vNBwhysiWuQJo6ABgfWn1/9AxaEFlyzxUrFtQUsz2TbAX9DuaQV6owxybVottd0WV8w0E62hq3TGSYglrNhyJ1bBdoaNgSVxiGCCnhNtFGwA6hFODxBh5RVTF/lkp2XBau/iWn2AAZkM73QcLLieb1xBze8nWq1VLyHlQGANSETVDIM8pXObNSHt5MAEdqhwOhqVzjVAjLRN4X7KLJ4mC8oa2jVDOeMQD12IDXZqZRnJ+muJybpkdE5Ck6ZP+kswqmduwZlceZku2QlVYDttw3q4tpBEsF8sUy9Wf+lSzLCoHbiomZgzjg72fZ0cZQ04uVlBXHN9ho+D7Y0BO001EE72RorgAwEDoiwhFjg1CNLPCKo9ghnWGX2yUn0zIyNQ0ZdtsznQm2WiNEmA2zWsGviuBla0QuNoED8rrUVwA/dSOjiksJnVnTxONTklxwchbYXPnNSF1csIgmqOBxso/1ba2ZFZlDeI7BfG5+vqpAu7t1ZhdhcUPsDc7IdWg/FoXtAXAA7AvsoHKEw6OJsHi2NTWbpjI2jTRDL9l0OCRVRZCXo4lzB2wndXc5q5ZhPTtl3L6wSs0htvbRLzyGl0E62xgrwwx6HdxiYmC8yuqpoG52ejLjghEone9NwDxOhknldbKxOGXIv4EZPHNt4WdELu1gLr/hdaysAdVjs/4AMNtBM7RwxFqmXcbLL1nVnUdfkwxmycxRQewsnPI7Kzn4Bgxv33T6TbXx2VQGQUVPJT6Zl6eKGUKUb/NQvWmkEgNLvdY+EeF1QrAFzttQKxt7eeuMcNAsCdPGgM9nm3sv8fy1+5g6wDfzWY8t2BBDJZMMGdqOLwxG3g5dgtrnzhlmkVEMdtJOtsQJ8kYVFGQcFe2RQXIazpyut3skWyF7wVl6Tgq28oK67SnEW20/9TRiwohe2alYrDigwilhwWRFulNllsmXp4vaZ7GjGH0EEfEQ78SYYNvhbkDXvcdJHMANZEQyXClYQ7jNKfriTnWpB4TOsscVi1VVZ3O+ehueZ29wt13d6ez3QSINydJs7RTSDjbM2ylcE68PIZJvPWjAKeK91DWdA6NKvsvgy00tMD4EFRPxmssv2dHGvgrhmQTbop+BbnclWC+1ka6wADnssttlCOC1YzMaZCFS38RLNZNdbeU27Z7PxmN9vm6Itq3tJNZiYVEzFxKzohTAAdLbDeyYb2RHYTkFkW3GoY61bteiRzUba1f9GWZPPr9+prhT1eajTa0cnO+nQfgmA0aYiwIA9FM7jmqUWh61Y3wfmFgxdN1onn09ePx/u04pMtscWTHgt7AtBnQV27BQOvbc3lhpwOyKsTLb5rG1VscFWbN8F8LPObZyxPuGHi2Sy0QvbDvlihc0rx8CfD7q439aEGtbQTnaL4OFds4zmEgZgEA/1GL0egwYOCmSG4byKwmg9Uw61L2ojZdxZ/OyhnTn6zaPjdMzeq2n/9QMUBFgNXwwzCFb0wlZt5xMHIEs10I0+6wYtNMyaXVkKqxGtj5fwGX9fpzZEfYoFwOICGFBuDmOvos++K5endYPZeoaW3+847lFe1HubwWM2FQ+q3pbCZ1hrHpwyni0N6j6b6aS2/Xn13h56JhvBHWxt5laZfkoOOq8m2z9dXJQ9wP/utI74nLFz2LHGkGHGY1TahM1Mlag7gbQjtJPdIoAj+sjuhVDeC5vC6r5MKHRxUHdgcMhEFmEIqTrAuLK4W19Uc79siLQVlmplm42n2/8yQX/elaOTDxqhvdf2UVCIa+sUK3ohftZ0cW/APOdiOk5RbtXtu7yIMbHMikXGOMoMC+YjDKFmem5QQbs4wa39Ur2FmYLPzuqxB5YDpTx7Hsc9yot6bzP4PJfd17hz1LxOvAqf8cBbcJls6xKQuOgtxAUIViJYNWjOZJeCc3i5M2U+azOS3SA6EVh/GCd0lVABkZIqXjsPBqJXdXFQxfF0uz7ZnoXPQBc37UWt2hUiztBOdovgkE2D9NR0gTmlQQMLb3VfVyjCZyKGoLVRrMbhmF4o0rBEiy1kfhCtHp1p7CMOyuUvHhqlXL5Epx2ykdb0i9eYe0FcW6dY0Qu1IeYdXFHUOIDVj7eTIItMH1DjtaxFtqLMZMPosGvfxdGXSYfGEgoTblRfvpf6DViiJhHK4huGGtlIcS1pcQxoOWSKzMCcgtEru6/xzPfKFl7e6OJ87LwqnYv19NYtvESy2Cg14EEazCPcu6Cy/HxdmRk6ule2WFAKSxCdFZQ52S733IktZgYcaLyU1Rhy0TMnRx37rez4m8Xz/Ao6alhDO9ktAkRINwxm6KFds4G+DwwmLDI4nnBkg6aCmYUXRIHsCxwOFfV+ovXYza28njbVZU/MFeinD+yige40nXzgiHBW3A9g+MTxQLWiF+roqL9MM7IirHY2bLp4SlzYxYkuHmVpAwxdEUdzsdSmmWy3z87aePmbV1wIslnkMa4lLV5b5DQjlZAPHtmVL8iKDJqvGUOMFkFBoNkIbwZrz6iN8hV2BBwm+ENB1WVz7ROz06VrsgV7ZGdSjswmGYgEog22mIiTnWKsK6ugJ9ubHOqx+fjLBv2aBdlYTbZOiCiFdrJbCAeM9NJfd88FqoTLFykcRhgCQWd43OhoVsBmg7NFhdPhxcneY6mVF5yPJyfm6aaHxugZ6wfo+H3XOooMqYThuMZvM7QaT9CR9OHvDTyCrbJEwgyUPdgZANz5Fh07uz7ZUR7cVvWvzeiD8FkbZrJFMigGXbyipHVXc5YlriUtdkDgVrQm2ytDA3s2blOzkS8b0DJfc38WwojVSILgUYoaxrV9F4C1AAcsqLpsq2C2zmS7Y0FR+y55uriYXWhXly1SyuJF+2YFXVzXZCuHdrJbCEPdaZZFfWhXLrD3qIs0JJPU351m9Ocg4RYptwIMFDgeUTnZa/uz9frr3z0+SX+7/1o6eNMghYlMTA9UK3phStdkewbq+rKMLq5mvq94fZdMNhwCURqrnTERJQVNZH9BCUi7tvByc7JZFt+3k23dHaLVqMSLkplsLwwdKPdaBX34upENRuKacU4H1sKrScFaRfasHZGzsCNYiU+QmeymczaTTug+2QKZbBXK4mY7zFVdXKIkEgkku0y2WymLFyZDM/tMt1tVD+1ktxgO3jhIj43OBRchZZt3gjmyyGYHXZctQmm0AjIOfo1DbDDIYMk62bg3G4d6aHy+SC88ZAPLbIeNuNL0rJyarmRrGdtxQV1RNB1cJrvoIHxWP7gFDEWUbmCI7Wqyo8p2GZls92wu7nPQfW3DhkgGhQUYWJ2it70E4757FpnslRoUrUY95KwRUXgxSFGTDZp5M/ieKbtP4gzEOY2zwOsY+jmfW63uPihMLxbromcNfY8Ds9NsMtla+MwRYO0odbIFarJFtDE4DFX6qiXjzC0A6IlZ0xSs8VLXreEM7WS3GCCohVYpfw6oNtvce7E/G4KTDXqxpPAZ0KOg9Qyiz9gkvdRQP2vranrRoRukHXRViGudsxW9kDlZ2hCThllR1El5NEhKsWg2khsaVllj1uYnKuEzi57EzcB8xTW2WzbbKN1w/uwI3sA38yqqNz5fYOvbah/siukepaKFl1eGhlX3BU4v9pL5xzUPLDkNQQQ0jNpfZ7p4pxvl2EMXi9UVawDByyDEKu0YY7om2x2wZ1W075JpvVesVKQy2VadazC/3Guy5TUwmoNo6RYLjLYCtJPdgjh00xA9MjpruRhVHKrcSWKZ7IDbeHkRPuPZJ7/0WS9UcQ5smmHVX1shrnXOVvRC3Ce9cXtv3wUD3C7CHWRNtozqMQxt+LJWa4JlNCNs4eVEd+VAdgNUwnZCoeIuuAMHGY/x2sZrzKYee1mcsTXWPfYnXKuU8JkHg9RJI0AkK2ZHFweCuNdCwmcdvrcji92TSa5gBCGTnQ/ARrM7Z3VNtmBNdsiZbLuuG1awO+dFWDZeNDC4gF4j66yz17NqaCe7BbFuIEtr+jL0yK65QA/Vge4umg04k+2lJntZFdfftU03iZW0EuJK07OiF3IxjSDojG2vLL5k9AcnfObsiImqHjsFy6IURxJp4VUP2rVZJpuxhASMOz/iZ0Y9dral9igrYG259aFthheRIIOeaT0fMVayCuPQbADlHy+peo0hIICP5yZ8hm096C4krVaPDWDvDqpXttV+67UNXMfVZKvMZAusWZmabARqrEoMEKxxFT5j+62XFl5Nwmd6DimFdrJbFIfuMUR/3pXz1PZDdNGBLo6+3CpaZTltQDKGjUrBHj+Z7KgRV1EhK3ohj5TqCKkczNFrHLC4farZK07CZzIUxOZWIHFRwnfr88sBR2W+zZzskqBxZ7Qwq3hywsbnCrS+qT92K7bwMrNGZLQ5vGWy7fvSy2SjcfZjfiMAF4RGBz9fnMotuK3QyXu7nR2B+RRYJhsMnWaF+nQ8bYK4AGcn1gj2elUQCYyxkizBTDYLzHhUF2dntZcWXuY+2VqkVjm0k92iAEUPvawfHZtVb5QubQjIcGD5BUmj9NLCSxVd3C4C3QqIbZ9sS+EzY3z15i0Hc29MrBEYVfmiujFH8AxGh6vwmUhNNjMkrI3xKBVLK4J0cZbNDZi1EzZEW8fA6PSSyYaDDSd+sNt6D22l+j7oH8hQxYG0V+EzmyFBkEpmT4cDh9fCGAQR0ODtxpzKorC24evF8SwK18nOhJ7Jbh4XTRd3p4pjnYhmlUWQFRE+cwhAW71eM2MN5zTOV3e6OPYj8fEHs7CZEcEo5y2yZ7cKtJPdwjh0j0H6885ZpfQORjFcipAiqo96r9kA67K91mQbdPFK6MricQE27bhthnb0QmR8Ot0Q8wJEr81tO7ozKaWZEW4cOBkdom1hnBy6KPUDnOi5qvtFt2KfbD9UebvWXQ1KtS2idozPL6Ms7lld3CGTDQdAhpmWZ9ecCqwnuWgAvNPb/jhlsoPQzQHKturinTsOYbfvEi2nks1kN5/x/Gc34bO05Phz+9G8xjt9LQcB7WS3MNBGCpvGo2PqarOx8MxRt6AVxkWzLVYURxgVXh03HIxctbkVEce2WE70Qr15ywO1WeYsc3c6qbRuGFkWjJVTzbJoWxinYJnRJz2immwHoal2Fj6rOLRUawb2wMWS/GffNePiZLdQVsTMGhGFF60Bp6CPSFbMjkIaRP07MuMieilMYblFau9VA060lbI4kA0wk21VBoO1jt8HWd7XykAQFQFFleBz3+mey7SpNdq+VVesc7wPkhVOkNW+4fZaA11cC58ph3ay2yGbvSunLJvNWniZFvNAwJlsr32y4XzgaV6zT61cjx3XPtmYO3b0Qt1exJ/wmV2U29frVyoNmXLbmjPBTLYdLRuZbLxEFMJ3LGgoKP6FAEa7iPNxA0pkb/WSxcfrT84XXTPZrdLCi/WhlTTAvWey7YXPZDL/i6aWY0HQxUVZZoYicWuMs2rAjsD6sWKMIGiC/SeIYLh1n2zjZy1+Zg3oCynPZC+tD7t7zkuyZITPsKWYs+MiyuJetG9YyUEy0aBDYexpev6ohHayWxx7ruplEfi/js8HkllmCuP5EgUBGLSsZVhaXl2c98r2qrg808LK4nE1YM3t31rheuOO5sMV7A2VbbwQMXdzwoxIvVifbLvX4k5FFEEWBB/F1MXTzLgJqq9tFAEaGFBu2Q+vTvbu2QKbj2A6tVqbQSuI9KFthpd2N0ZNtoOTLXG/mJOdCY4uztpECcyfIN6b47Gx2VhnZmcW7IP1hpCesRbDERhN6rIsB6A8UHUmm99zOyeb/160gw7LWCeWKeIyLBuufSO6Fo1acas2cPFdb60I7WS3AQ7ZNEQP7sgpoeM2O0pB0sWXNyBv09BPXbbT4dgK4NnBOBkgTvRCozVEfK61FYCDtpEurrbNFFP2d4mQGy1Kar7qN7mhHkW5AMtkC6iL++0XHTdYGVBupTcy9cCox97gkMVuxRZeXmqyZfdfZImcnWwZuviy8R1EEFM0kx1UpwvsF797fCpQJp1fIFg/aGNHIENoJWQVlLo4oJ0ke6AcyCkoGERdNs7YpIt4YDMYY800Z0SUxc3aN6L7gFG60nhduqxPPbST3QbYvLqHHbKPK8hmN9OQIHw2ly8HQqPEYYBIr1cn28jAlDuULr6UHYxRdti5V3Lr1GfGBcg0mw1/fK9U+IwJsqQU0cXtx1728FcJRs8VzCL0ZdtH/ExkbDkQyIHBLtOtYTRXcKSKtxp7RaQPrYo9zakmW7bPsZHJTgbmXInqpbDSpQD2du64L3jQCwgLbnaEXUsmv7Dbb2UV6jsJsBVVtu8SYXsh+CyrZt5cl23sTUnlZYRW61vXZKuHdrLbAIiYHrppiB7YMeM7s9m8efdn0oRXDML49Nq+q5E+W/FkgOLz2EWgWwH1/qQxilo70QujFL9qRaBGFEu5uSYbYmjq3kMgk50WFT6DMZGInYZAs8ZEEK2s4girmk0noB5ZlCWB/XNqwbkeGwCDIE77kxOQLeL1zVHVZIsoFdsJIwZRS2lQkhORiXDygEOc16Rb2VmgmWyLsUEbRZk51CnAukNJCAKpqmGwvewz2bJONta0WZXeYNmIXbeMNoPVGWGwj/T8aRsn+9Zbb6WXvvSltGnTJuYo3nDDDbaPfdvb3sYe89nPfrbh95OTk3TOOefQ4OAgDQ8P03nnnUdzc+rUtlsFW1b3svuzfWrR1+s0CxghC4WMcRCUcVlDUBVdHAcjIoOtqize0CInRhuiUzazleoz42L041aa72ePgt7wsq1FRKmgMCacAmZRRchhXIk72am2URgXbd/F0cv2UrHPPjabZ4KYvB641TPZy31ovaiL13yrQnulXZtrsoPYX93WtDmAFgTFlAf3VJbIqAScH+zTdn3irai/Ss9ai3mke2VbA3sbjgHZQJoInIJjaKklm0hC4NusDWIw2sSuW0Yfwcpew/OxlONUhtjqiNTJnp+fpyOOOIKuuuoqx8d973vfozvuuIM5482Ag/3AAw/Qz3/+c/rRj37EHPe3vvWt1GmAM7y2L0OzBX8iZTCKmhceDpEg6qK8Kov77W3b6lRxs1EWJ2qPE71Q1/p4UDtuOlgNg62qrHQD7+HmiGE8MWxu0W0n0bsoFYidnBrLTHYhngZ90HurzF7q1h+bIx1D3Qgr8BIMZB1l4CV7bAifWf9NhuqLPcCcfQ+i/t2qF3OYwV6eyVYZWFSJ3GKJZUad9lBG/Q1M+EzXZIsCexsCUmYlbVXAPms3xsWK+xkrlskWpYuL7wNW9hpn2cTJrmx1qC9QkMDpp5/Ovpzw9NNP0/nnn08//elP6cUvfnHD3x566CG68cYb6a677qJnPvOZ7Hdf+MIX6EUvehFdccUVlk55O0OWbmYbeWsySlGXHYTCuKiwih16PEaJW11ZPK5Rayd6YVDiOO0KRK/Nome8Tzb86+bWXl6BvcLNseCOGmv3kfJev8kCQpGoi4tRXrmjuX2qMzPZoiwJOMxPT+fpqM3DUroR2WR8WUNwVrEORJTYV2bqJeniFTjZSdu1hi3SiVLOgT0Ae0F3wC28BkUy2ajnLwZQd7wkuBjXTLaT6BkH9vCcYtuJBzztnWx9zlq27wqgHrtud9vcc6xT2UQSHGoI83rRizASLz7o4hGKlLYrInWy3VCtVun1r389XXDBBXTIIYes+Pvtt9/OKOLcwQZOOeUUSiaTdOedd9KZZ55p+bqFQoF9ceRyufr74SuOwHUheu10fVjLqNPy+hnw+qVKhVLJxvfp7UrS+FxR+b3JF8sEO9Dr62bTCVoolKlSqUhFKKcXCrR5VW9sx1p07LF1F32Mt2oUyvbjib28WI7PtcYdC4USm9/m+4Xzj/WGL5RY7Z1fLBbL7JA1v4fVXEsmalQoldn12AGRd6e1bLSWCXf8YYzWalVKkvO+ydHTlaS5Qqkt5iir1+1KCn8WBHBAA3c7Z9DFAvdz42DW9bXxONx/7FGo240r5i3WmggSOC/LcjYD1oDdfMSSxv3CWnMzqrEHYL0l2GvVjPWleH/Ffo1rctsfgtrbcR9wP+ZjuiYn5ws0mE05Xhv2aeyzqscF9wUzpPl1MSdw34K6XyJ2aBwxly+x/T2I64ZjimSP1Wtj75O1cTPJBKO383uNIBPmkchrYC2K+gCYRwgAND8We0qx7Hzeh4FqhHNN5XvG2sm+/PLLKZ1O0z/+4z9a/n3Xrl00MjLS8Ds8fvXq1exvdrjsssvo0ksvXfH73bt3Uz6fpzgCgz4zM8MmHYIIVpibWaCpxTKN9XnLxiCyNTs7S1MT4zRnir4V5gr09NgCjQ2pneyj4wusd+HYmLeoGbIIM7kcPbVzlBmJoti2a4I2ZEo0NrZArQC7sV+Yy9Ho7iJly+7UzTCwe3yWRWHHxlZG7mdmlsa6tz0yhUFj5+4FRl1uXhvFhTnavouo2J/x/R7jU9OU669SV7HLca4tzs/RjtExytuwP/DYqekZmp5MUcHGOZjL5Wg0kafeiv8OCKJAFgH72cTEuFBdNiiFYxPTtGs0TckAaIVhYmwiR6t60jSWKQo9fmG2wObc2EDF9pzB/bn90Sk6fu8hGh/fLfa683O0a3SM1XDHFTsm85Sfz9PYmFy2fWqhRNMzORobE/9sk1MzNN1dpmx5zvZ+Pb1z1PV+jc0Wqbg4R2NjY+znmVyBxicXaGxM3bwdn5ymgcQijdGC4/6Qm16k8dkijY2ptQ927V6gUn6Rdi3O09hY/DR6t+2api3D3ZbnHcfcTIHGJjAu6t4X5yh0h6zW4FxunjEzxrrVMw9F7dA44ulRbpuoZ0XM5RZpYr5kaXePjs+xQPbYmLjdM5dbnjM4w5AEzE1laEHgDJvN5ShRmKdVSXdtpt0TORrMpmks23hGzM/N0q6xFC1GvGdXI5xrsBtUIbYn3z333EOf+9zn6N5771VeR3HRRRfRe97znvrPmMSbN2+mdevWMQG1OAITDvcB12g34WZpjopTCysCD6JA9GxgoEibNqxvuOeZ/iI9MjPq+XXt8HR+inprRCMjqzy/xpodJeofWk2r+zLiNMqePO2zecMKOm5cYTf2a6cTNDjUTSMjAxQH9OWStKYvQyMjK9fQZHWWds8WaGRkbSTX1mrYtjhFg0MJGhlppOWun6hR32A/jazt8/0e3dsKtMeGkQbKo9VcW7urQoPDwzQy3GObxR4YKLB9w44yvmYmSUMD2VDnKiiCfD8TATKCAztKNDC8hvoC6KfqFTLqshx9U0QbVvXSyEi/0OMTPQV6cm6c7fF258yvH91Nh+y1ng7aukb4OlY/XaLh1WtoTX+W4orxco42dJVoZET8cwHZxRL1TtSkzsX+nWUaWbeaRmxq2tc8XaKh1Wtorcv9mkvO0/pSpv7ete48bZufVHpG945WaMNI47q32h/mk/M0R3PK7YNdxRnanO5l7eLWrsX7xSvwldheoq17rnUcK6yrJ+aNdaUKUPZfvbti+ZoTlRxNzBcDO2dF7NA4omuSaM/V4vuhDLAWF8fnLccDNtFqG5vIDsneAj0+a8wZVto4VBI+w9bOpxmDqdlusELfdILWW9iP2LNXCexBQaMa4Vzr7laXuPJkSUBc7Pjjj2dZYzPK5TLddttt9NznPtf3hf36179mUdotW7bUfwda8D//8z8zhfEnnniCNmzYUI/kmq8BiuP4mx2y2Sz7agYGMs4bByac0zVmu9KEkmyvn6FSTVBXKkWppv6qgz0ZqtYSVKzUlCpy41pRC+jnnvdmuqhQEY905QpF6s1CGbe1arKtxj6TThHKXOMyZ3Et2S7r8UTdUjVG1xp3FMs1GujvWnG/MN+xDv3eR1Cpsaa7M+kVr9U81zCmTvOsAkp2Msn2Hzt0RTD++HxdafH9BQ/D3pDHve+Jxzwdy+Xpjscn6WVHyOmLoLzaamzt0N/dxT43yIJWe83T04u0e65ELzl8o9QY4v5XyXi9uKJQqVKPxL1q+GyScxq5Xqc5mXFZa+b9AUJ9/HE4C/DaKu8z288trrV5fgR1DkEkbrg3Q6O5IkFsuUdSQCrowBf24VV9WcfP3ZNNs9p21eOCe271mtiDK9VioOvNzQ6NIxZLVervWXmeqgDWCLQ/rF4bNi7GROZ9sRdhbuE+4//erPh1Y/+oCmZ+UUaesbi2NNvX4rFnJyKaayrfz9MrPe95z2OObDOQ2sffVAC12H/4wx/ovvvuq39ByAz12RBBA4477jianp5mWW+Om2++mUVAjj32WOo0+BU+g3BKl0UdBlp0QBRItYCHX+EzANeFmicZRdB2UBbn4xInJVEmMmWzObHWEhGLaUDMA5HhVgCMOCtRMlDeVKjtcqEWEVEWN9Vjp/7o9ddIhT/+rJesZPbL6JUdn5IGUD+RkZdV6HYTomsGV6m2mlsY37ufmKQjNw9JB1mD6qGs+h6LqveagbkF8TGZsTH2SPs5yYSrlgS/nIBxMo9FWvB5QZzPQSlaI5AABwZjE6c1CcwsKYu73R/s4Zj+KntXO52zrGdzzNcbgPEMorWZ0/thbw8CyBzb3XMvHXSwrrGl4LmMxSQRXJJp5WfXQhd7diu0XmwVeJp14MhbUbgnJiaor0+cxoi6kscee6z+8+OPP86cadRUI4O9Zk0jfaurq4tlqA844AD280EHHUSnnXYaveUtb6Grr76aSqUSvfOd76RXv/rVHacsrkLBmfXIttm8+7NpmsuXSSXbU9YQtFXFlVA2bZf2XVxdVLaFTJBg42lzIHhpd6MaO6YX6Q/bZ+jFh2+kuMNOURS/UxHsgtGH/UKEgunUoqRuSLgYAlGMf1lApdlqnwuiXaFX4N7CkUP/7gGHfrx+1cUxD3oy1gGcB3fm2Lzbd5081RLOXxSq8vJ0fHl6IK/bxzyDWJEI3JTDRZ0kiBsNmTQSeM9uO9vMC1jwTLCFVxBGObcPeHs5OTJ/sBC1IxgTICHWLlFJF490/INawO+3TbN18Ox91oSyvnFL+pZ6yofawktyHwYw52EWI/hnBADFr1uqhVfVOoim261G6GSfddZZ7H9s4m984xsbKNegciPzDBq5KO6+++6GzDevkz733HPpmmuuEXqNa6+9ljnWJ598Mkvxn3322fT5z3+eOhF+M9lOvW7RxmuuUI5Vn2yegZGJcuNw3LLafz1rHIB7F4RDsH1qgfYY7pE21phRZGNAxqF/Jw5bZAVbpYWXnZON2nbfr4/2XYKHN/YVp7ETyXgF1ebHCXA6ZIN4MJzBdokLuMGMvVfGybbLUrjtpVCyNRdSIaDz552zdMrBjTodQba5ChvmftMykG13g4w3HurUt130DEcwZIMpMMCdLmPO+3eyK0vXKpTJBkspkEy2MYex54WZ9VQdrEemE3NsQFGZJ2Mc2rbKbI0WXqgbR0AoDODMB6MAAb8ggDWL+c9U/pvsHz6HZYE5j8CMrB6HEWwTbOHFri3Zknt22zrZQ0ND7H8sjoGBAerpWRbEyGQy9OxnP5tllUVx0kknSS001GE3A1nv6667Tvg12hlYMFgbRgRafkNxMsygdmru3acu8+nPIECUG0IgIsCGBxXUo7espnYAIo5BZBB+/eg4nXrIBmExORFnK6hsh6xjicPDi5BUmMBhbfTCDpAuLtG/081wszusV5YLhBvgMHoSy+0vMJyfmoxP1wF+32WCQ0a9vZiD1FwLiIxh1vQ00MT3WdcnvRc0OGAxYttYwet+AIMa08v4fCmhGmPjefaPEXWSsAeAxVV/3tKLGoFy8g1+DSJzKCijfDmTbczLOGF6oUT7rhML1nenDYcpDLq4aLlBlMC9ACsSaycMZmG+DM2F4M57fo4iadSdTK2Yw14YDAgKINCOvUnm2mWYQ6ycysLeZ2d1zNlHbetkf/3rX2f/77333vTe975XihquETz4Yoez40U428lJGsh20fYp97YAYdPFu5eyLyLYNrlAgz3pBppdK4PVuSreDI3ewta1mSLPtaOxsQhrxBs3p3TBYYmzk83polbq96qyOjB0kGERAQJvC4Wqr6xpFNHxkoeabCitI3urknbrBzyrKcNYkam3X6FvUarQqqVU9raJBeZMnLDfOvIVCIyxweYU0BKBDLWSP84pky1a8sVopKb9AQ4/hhtzvkfA4XcDrgFLRyRIhcfUfAT3neYxnA2wDFSz6KLIZKsCK+uz2W+x5rHPWmVV44LJ+SJjRg5k07RrJh+4k21kk4MTzsKcx61mTrbJrvAa7ASyS+c8248lApyimWzsRUz4zCqTrWuylcLTzPvQhz6kHewYApsqFohX4QunzRubompqMiKuKoTPRKPcj4/P0z4e6grbtQbfCpwWLBq4EKUXsghrxBQk7rDELSvSDByuGFsrAxcGJ5wCv1Q7RhcXXHtudaIiZR9GkCXcgxtzUtboh+GHWzsbE6Me9xZzAb1xZfZV7OOyRrZRelOpr5V7tk3S32xZ5auWNIg9KojAm9lhlYFM8Ig72U6OK/ZPN7o4XgePaQ4UqsxAGXW/4vsDe47i/Z0H/ZHJixNdHGcj7r+oc6g8k+1QBsODnXEWP4OTvbo3Q+sHu2lXLh/4+3nNJsvAqszDa7Bzec5UjQCgxN4kWpbH92SrILSuyVYLTzNvdHSUqX9DXAxtvNDyyfyl0Zp12U6ZZQgC4XVVHRaItDLBGN9OdpptRG6bwmy+RBNzBdqyupfaBUE4rvxgkDVq3OiFXIk3ys2bz924ZUWagayHXb00DGvcR7+ZEaMmW5wu7rSnMGPYxYiJQl3eEHKUczThmCKbrbo0xitwb0HVniuIX0+hYq1ML5rJBv60Y4YGu7tob5/92OMQXHMCPi/OTK9ZP4ifie5puA9u8xHj5uYgYW8GyaI5+66yJEempp/T5tUHfA0hTTjZcQqMcmVx0SCE6ky2UzcHXBPmRinuTnZfhjYOddNoLi/dOUEWXuuiZWDollSVBDuX5wyvyRbfy0X3AM5UsZrDuiY7BuriED3btm0bffCDH6SNGzfGglan4V/4wilCik0EBgBqabL9/gMp3JDwu/lhA8L0g7GEQIBTFnuPVT2xpgnLIoj2OPz1ZOnibvRCbhTgcammuqWwgMMWCspxawfTDKe2Hbi/WDOytVpW96JPsKWJu/CZOx0vxZTwa+Fnsj0YOMNwshdLtJmiB+rdQRfE/hV0a0TmzBTKNJMnemysQKcf5r9DB+7/QsiCdzKQNWKtgkcydHE3+rVIJgp7M87iZrtLZfmQnfJwWCry2FMQTMRe1yspbho0ZOuIUfajUkwR88PJjomDyKibk/2M9QM03NvF9ofx+QKNqFKFC0hgV4jt1RSI9hrsBJC9xn1irTwlbFbRFl5OTJUUe4347tkd4WT/5je/oV//+td05JFHqr8ijegy2XBCHBY0Vxhf02/Wn/UGp0iaDGBoMDGoor2TDWotjNRn7t0egmdBtsepO9mSmQNDB8B+LPnfosxk47Bd1YusYHyyIlYwakTt1yGjT/pklGCPWNWrTvgMWdC49UtmmUMPQbzBGCmM454h6/PwrlnhdjAiQnRW6O1KMwfu/qcX6YA9R5TUSgahG6ESLFjlI/AqQ620ExqS6UnvdM0q699l5xArC1BYx8nvAZyXWsY4X1TXfPtxsod7xetkVXWEEJ1HcS7RMDp8VNg5DNttAyjjM/lAnexSwMJndna312Anz2TD1sYwSmeyBenidgmuuAdGWw2eZsDmzZtDk9/XkIOfDRbRaycjDvWKquqy/WxAzeiBcejgFI7mCswQ2jgY3EYeBYI4TPkGLZvJLouKX0VocEOtEw4LsnWtrHaMKLdsEMSSLp4OryY7ijovzDVE5WUB53I6Jk427i36u2JfFi1zEOlbbgUYohijxVKVDtk0SCoQ9/o+7HN+2E28P7W6TLb7nm63P6h0dEUCAl4z+iKAw4L3N4LoRq9pFV0VoslkG9TfMNTF7bKqcQGys+hUw/enDUPdtBPUmQCh0taU6ZUt08GjGZjzCPRi3lsJoNqB7y9u+idOTBWsuzjv2a0GTzPgs5/9LF144YWWLbU0ooWbQey11gdAn1Z1TrZRb6UC5lpCK/x1fI7VFsZVbdMrcNBiL1RZ04S5g71XuiZbgF4YpWolgoLLmexWcLLt76UhBOS3JtuoRZXtA+q9T3b4GU3mKHhY8+g+AAMn6FpBGWXc/mxKuI2XV+POKAlK0WEb+5RlDHEdcc2q1VW6fdDFjTKIqoRzlJA21q2vORXoGmNrWiJApTqA2hy4w57nN7CoCtMLRSknm3WEUCh85lYvH+de2XCy15jUsuFk43cqheGC6GIjlMluuuds7/Zo4yIwg+CdbACQf063wJ8TU0UmcKgREF38Va96FS0sLNC+++5Lvb291NXVuOFMTk56eVmNGAufcbq4KjVIwxBU4/Qawihl2/fZPrlILzxkPbUbzEqizf0ZvQJzAMEUWbqsUK/kCEWQYDSCfINMNr4Xpd5GAfT1dKIjwilQQRcXzWTzeYYsWdZinokEzKIQUzHqzuT3GDB2UO4KhfGg28u4BYaYOGQaTnaXZCbb2976siM20uTEOKkCnNA4G2yFUoWVB3hFKiH++aq1GhNKEwloObWQa+6RzYG5rsq5khE+Y++tuBykOXBnVr6PEnD0cW2D3eKmM/ZrsKjUlsE4tIFz0dCIEnCo1w1kG4RrIbA4livQ5oBEaRG0CrwmO22ULK5QNfeRyTb+l3t+yiRC6OSgOzFVwP6qxHT+dIyTjUy2RjzRJRAJt4NbRgo1zzIqt2FFF3EA2zmFvDe2TA1Vq4Ariao0YqGIiUMP/XHdaMuy9MIoI6SIlOPw6cumjb7PxTJl0pnYGv5OhyvGxK/6tUyQod4HlDnmNk62y9ibaWxh1VUawmfy7wXnBmsAe0qUTjYPDGGfhJqxqJPtpwZR9dhEUYsvAwSrRrq8lxFhT5NSF3eryV66/0aPaOsxhDE/MJi2rn9XtL+6aWwEHUAtNe1PcMbiQBefXjR6PMvcG4wjbo2qwC7bbx3bwMV3zcHJPnDDQMPvNgxlWfImKCc7rBZesJlWOPceg51c+FRG9EymRKdYtu/so/tkx8DJPvfccxVfhobKxe6V0u3UJxtALc1isarEUFZZJwO6OFpBWAGCZ1vXtk9v7KD7DyNbCQVuzAMZJ1uEXhhFr2QOs4EDRxsOS1wDL8hkO9Zkd6VotOydUYJ1jjNYptbLSbFWhJ7MabKGo0GhQKRlkh2GYqAwvtwWL8H23qcmF4WeBwdtKB1dcCBocUaVAPXajyiSTM25UZOddF1nRgumGtk1y7ATPlO5v2Lu9Ql2HwgimNIcuDO6QlRarh4bYC3iEkZAR4Wz59bD3E/JYJBAcAhjiG4JZmwY6qF7npxq7RZeFhR92TVkBsYX61mmR7aMurxTKZVu4aUWvld8Pp+nXC7X8KXRoi28XBxfGPfYrFTUtCrNZNv00eS9sfda0z69sYNu18Fp3zDiZDIHItnMKFuLGFHlZD0oEweDzQ6sbUfaeR0i2OXnXsCQlzH4nFSPnVr/cXCjMMzDG7WybkJTTnXZMKijBF9TyKzzwJDo84KmR4pCZe/moAx/u3Z5IpAxSJmTLdDulO2TDmw0O7E2lfurbKmF6mDKiprsrrRS8TCvQAJDhireUJet6Prd1cWd509UmFwoMlZh81mxfiDLxEhhr7VyJru5TNMvcwEK4170IkT2XKcSr7iLVbYaPM2A+fl5euc730kjIyPU19dHq1atavjSiA5eo5gQ+TGMZeeDFRkVFeJnfuoGLVvPWDhN7dgbO2gjljMMmJMt4YiK0Auj3LzNVGej7CGe4mfIRMFYdWzh5dNg8yKMBf0EK60H3s9WxCBnqqUhBln8sGV4JjtKmFXCMWchfCbS1YOLpcUBYLfgOApSRA6lIF7KJ3BNbu3y3MDqFxWqiwM4g53OcNT3Wl2zyv1VNggeyDnUQBePR2AUa9CuVWgYddmYs5gaTqyxuPbJnpwrMk2UZsBuWNuftWUj+j1PsSSiED6T1TVoBuwVL3uTiACiM1083uyjVoOnmfe+972Pbr75Zvryl79M2WyWvvrVr9Kll15KmzZtom984xvqr1IjcOEzHo1324wgwKPEyS6rzWTj+s2fm/fG3rq2j9oZqjdEblwxNVfJTLYrZTjCWrHGTHaaFmLaK5vrKThnsg3dBa+OC5wSRMlVMGTM/WzdEHatl6hTY+dkR60wbg4S9GXShCsRcTSKFedWjGGiXosf4H18YnyB7nx8wvNa893CS3D/Fe3bnnU4w7He8DpWdHG2RhWtL1kHAU6fUkZVk5PvJG4aJrD+ej042XCYVCho8/F1mkdIXsSxJntivkBr+pZFz8wIqpUXn5OZqFp4+diHYbuu99B2VqQm31n4TGeyVcLTDPjhD39IX/rSl+jss8+mdDpNz3nOc+jiiy+mj3/843TttdcqvUANOXgVveDPcathhOhH3Oji2Mhw3WancGzW6I29aaiH2hmqRU4QjcVrytLbROiFLCAQYSabH7QsKxgDg82JKm6nLAzwOi2vAoeeMtkWkXoulMf72bohbHV5P5kEzBEoQUNhPCqYFfvRfhDZPJE2Xn76s6oGv/9BBlewlnMeAr9Ya7g+r4EY+ZpssfIFp5IvnHEYWivjXcbh96tgHXgLr6Y6WqNtYfSBUaw/9K2XBYKaftsuAvweO9lpXTGtyYbomVUmG9g41E27ZvJCTB0Z4D7gXgXdvtWqzWVzyYMsDtgwYHu//J6zTr3Wse7wfNVj0anwNAPQomufffZh3w8ODtZbdp1wwgl06623qr1CjXAy2RUxY1mVwrjq3oXdTX00/7J7jvZa0369sa021CAyCAZdvKp0PBldOKL6zGJlOXvbK9FzOG6iZwDmNBxxr2q7XiLsRp3fynkmY0iErS7vJ5PNFMZ70r5V3FUGCUTLHERaqoUF3EejvVNw454vVticlnXCIETlR/QMwPwqK+yT7Ub3dRKjNBzdiDLZiuniK2uyU4wmHaWjjTmGcfEyZ1RlskXstDj2yQYLAUHhVb3WonFwJvGZJuaLSt/X6FUdvA3I56o5uBFVm1AREUKnc5ufmTqbrQaeZgAc7Mcff5x9f+CBB9L//M//1DPcw8PDii5NwwuwwWJtyB62PIPpBoh+qKGLQz1V3QbUy/polht6Y++7rr2p4kGounLxOy90cbf5ozLTIgvUw/H5BmcFWYWolM79tO9qED/zaHDC2JFRFnfKjsgEy1jWL6TxR0YB+6CXFl4cgxHXZTf3dxURP+M18nHJZIdBP5xfCq7atXF0Fj3z72Sj/7Xammx7JylftA/CGXRxdS283LpFBFq21OSg4LPhfInSycZ8gYMru3eqrMkGXVxMYDReZ9vEXJGV4NixI+Bgbxg0stkqYZSxBa/JU29zuXTfkQVW2UFH9X5rBGJt1MWX1r1WGFcDTzPgTW96E91///3s+wsvvJCuuuoq6u7upne/+910wQUXKLo0DS/gxpVs5gBRaJENAXRx1CX5NZpUZ7JBpeROx1NT7dsbuxnIWKncDHmEU1ZcS4ReGCVdvMD6zhrXByMVl8qN8zgBzr9IjSiMNq8GJzIqshF2JqhoI3wmmvFipQ0hMRn4PPNDBY5a/Kw5I80y2S4BTj5GQbeskd6jAjT6se8jgJeTVCcWXWuqAoeVmpiTjZpaO7ovPqtVPfbytSjMZEvsETIZfbH3X+mg2HURCQsoS+jz2JIJjjmYE37hRPPlwN5uxTqKK1U8yLpsv+JjXlmkfP1GkckWYTc6zSOsZRAltJOtBp52DDjTHKeccgr9+c9/pnvuuYf2228/OvzwwxVdmoYXgEqKwxaLvIfEDQhWWykQucYBDzsBGRXZfpFBbn5muvhfd7d3b+ygDCtEXzkdDXNHfQuvCIXPSo0RbSZ+VvQ3h4MADDGRTLYfhXFkSAe75Xu9lhZsnGxBQ0JGidkvuMHvZ49BkA6iWlHB6JXc6GTvmF4UbvsVFzC6eIDjvlgs08hAN80slgNZa6qy9KJ927FP2WlGONPF1WSTy7xjgESASnkrSYsgvDmQHgVwXqDUyAuMoKiCTLbAOYuAKOYa2DxxKZeDk73nqh5XJ/vuJyaVJmAMung4ji47I5fsG6wFbMFRZLIxP9w6w7iVeYXJOmt3eJoBUBAvFAr1n/faay8666yzGHVcq4u3Zl02MkwiLbVgvEFh3K/4meq6Qd7ioxN6Ywdl3PDXwWt2ZwyDTdQpFqEXRtrCC5lsk0FttESKXybboLW7G3JZH0620c5MtibbOkCCsg9RWqnq0gYnwMiEDeHH2UQABvtJVArjzcYmWERugn1R1QGGFQhsBtYAXhoqvPKZbHuHVRQy7BwYrQg0uQE0zpKHTLYqwSLRTiNBtvCyEu9Dr2yZtpKqgfMCZWlegHmmpCabBWqcx4U74WGxhkSd7FUumWycyVBuh2it0nM/JEfXzPaKUnzSbU8yJ1PsXyM81lm7wzNdfGZmZsXvZ2dn2d80ooWXmhwRGlKDwriPumw4Wrg8lZsQE+oqVVjbrk3D7d0bOyjjhs8ZHNJw9DA8opkDkaBJlP07Uetsnm+iSs1hQzS75icz4rUm266Fl2i2OMwgS1nQoXECVISZwrgCDQrvfbIbhc8gRujksPpVtA0CQa57rhC+pj8jXZNt129aBphiMpnsVMJnTbaDZoOqWkq8N6aQTKmFyhZeCGrhMzTXjMrqhARCF/fQvgtAUBPzzXcABGrZbtonKXSnkC8ZDApIyGBOrRIo3zNUxp3ZOn76rQcJc3IrSvFJN8agSBANc0gLn6mBp1mAjcIqQ7B9+3YaGhpScV0aYWeyJSg6A6yNV0mBM6fQyV7qowkne58OEDwLQnCmmWrK2ngJZA5E6YWq6/ZkjDZGvTUZpzCW4uhkIxgg4gBL08WrFaLHf030x/+lgZ13UCZZ89DCa+VzZIwJIyAUHl3cbzmKoTAeXV220cZo+d5iPWKNOTEwYpnJVpzlNAPsJez9KH/AfZHJmMNh80sXx/4raoxCIC0lMCft9A9c6eK8J7nP8wB7paxgoMoWXvV6Vgu6eJQ12QvIZHtUo8eYYZr4ba0lKqZldIOIRyZycq5Iw71dQkEbiJ+prMtWrf3jBOy7hThksl3KRszJlLh0AmlnSIXljjrqKGZ44Ovkk09mPbI5KpUKUxw/7bTTgrhODQl4qX2VyUgNZNO03aU20AlFD5FyN/CWU4gYt3tvbDMwZqp6YhoK841GvUjmQJReaLTwCn/jtjLa4GSrFllRAWSnzcEAJeriD/6A6Mb3E+V2sB+Px3593yaiF11OdPDLxNXFLYw23NvBLrH6bhjuXnt7h9m+q5kyPr1YpC0UfvmJlYHIWETQErBphROVom2YytNmwOmC4wNHG3shWAdutFSVdPFAarJtAlp1uriNo4f6Www9aJ4yeiwrrtNDFo5nV41Ma9L3vEect/l1jDM+usDoQqniOZONNYmPw/Z3H4r2CFaJtYGLTv+kGZMLRaEsNoCyD6xh1o/c4702A2eW18CILGB7clvDYItFRRd3DmoaQTRn3Q5dk60OUrP45S9/Ofv/vvvuo1NPPZX6+5fFpTKZDO2999509tlnK7w8DS9gkXBpJ7smnAHxSxdHhFW1IQghK2Dvte3fGzsIsRsrA51T8N2AuYZb7ubUwNiOgsKGAw8fy2y09WWXW77FCaKGv5HJroo52P/zBvCPGn6dnNtp/P6V3xBytM2iLlYt30QQJpNBtCexiJM9Ma+uRlC6/UzTnszaeDnsvfHNZAez7lGji1pdAKwD1GWLONlg42FfsKtvFoVMxqdSxT4kSBe3CEbhmt0U0VUENFiwVXLtcF0Go8uEr7e3DRRFSRfHvV8olH05bMt12X4EY51raf3YgEFhcr5AW1aLBSmxd63py9CuXJ72XdevpiY7pP0Qc5YzLcLMoMvut07tu+qvERHrkDrdyf7Qhz7E/ocz/apXvYq17dJoD7o4ItBwPERgiEaVbcsG3BBEtgXGy9r+DO2nYGNuJRhiN2o2Q5bBMB3gzKgRoouLjaeRyQ5/47ZyPPqYunglVgqsuE6cjSK9e2Gw4fGOGVtQxJHBbnKwgQT/3Q1vJ9r+O6J0N1EqQ5RMU+9ikWhoNVE6a/wu1UXZRJo2js5S+ZGNlO4y/X5ilnppiCg7vPQ74/f175OpQCilKgSCRICM8V/H5ygKoOPDikx2NuVYqtPMRml34TOm+Lzk+IAynhNUGIeDjRIXFZls0QyuaODHLgtZv2YHp8FYY/7utSGKJDeHsIfio+G6/d5Tq+CSma0WxZ6N4Ab2Zh7M91OX7QcYWzsmQ1z0T6x6ZB+5eZXw46Eyjn7ZSpzsABI6dsCcnV4omd43GrvCLdAmEgAwAuLxmD+tDk87xrnnnsv+LxaLNDY2RtUmw3nLli1qrk7DE7CAZGmZMsZZ39JBgz7DcLhlEVSU74WHbKBOg0rBmeb6Whg1Ioq9eJ5IdB3XCvsvbCPJiGY3GiY8gwUKoJc5HASQ5cBtEclE8ug8Mt+2tLonb6tTxG1RnCO67Qv1H/GqgxYPQ+7lJHxzT+Pvj3W70ESy7nDvn0jT3okuomy3tUNe/970u3TG5bHN3xtfmdkyrVmoEW0bsX+s+bVNwQAzhpnCeFkZ/VxW/Km5rg+dHZDlsQOMO2hmxAnY6/OlYFgjWL+8/+5gT7pu5IoKpvkd03odtEAGV3QO4X7Bvm123Pk1OznAzLlSIHzmxUFQxaoy6llXvj/fsyEO6cfZ9Sp6hvp9P/PFT0eIxq4JAnPIhnkUNtCdAfMe+6iMk/3o6LjnJI5IwCYIYK9ebuEVHaPIVfhMQHMB+0hYAfF2h6ed6tFHH6U3v/nNdNtttzX8ni8K1GdrRAcsbllFXBnaJxyk3iXaohcHpVk1V8M7VGQu7NoxISMxNutet8wOFIG5U8/6wHkI0WExxMSSK+cwhHQK3uZwEHCjgjZfv6Ew7uBkz41S5KhVicp59oVPxj6dOvFYW+yx9CUMUzDA7Oz3pTJ0ejFBtXt6iUwZfFen38QCEAsoZBv+XqqlqGdxgrryWaIKf60My2Q7CfZFSVOMQviM0cVNmextEwsSomf+azX5ngZRMyfANoLvK+Ig8b3UoAaL1WObnX6/tZRemWbMuFcwznZzmO95Rh1+OgLRM3/vCYaSX00K0bOWabXEQPgMrbuGezNSQfW1fVmq1Go0tVCqB9BaRfjM3MLLTjcjaLBgl0OgTcT+jrLdarvB067xxje+kYme/ehHP6KNGzd6jjbdeuut9KlPfYruuece2rlzJ33ve9+r132XSiW6+OKL6Sc/+Qn99a9/Zarlp5xyCn3iE5+gTZs21V9jcnKSzj//fPrhD39IyWSS1YR/7nOfa6gX7zR4auElKKjBgWwJopSIOsoijoZgq4JnPVRk2kqWdPGqMnohf+2wN2/jUFl5fX0ZqOSXaYTiAaf2PFZg6u9OhlT/erEXOvUTRCMHElVKVC0XKDe5mwb7eyhZLRNViuz3VCnQg0+N017DXdSXri79rkh/3TVFewymKJuomB5bJCoXlr9f+r9UKlC5WKCeZNNjq9God9sFA5oxjH9mw72cLBGdiW9+2fj7TZSg9ckM0Y/MTvmyc35kKUGZTDcRSrksMvwiTn8PatB3rlkKFLgFFGxeG8yAJbsgSOEzONnc+eE12SIZMJmAlhPwPtj63KiV/O8iezQcEpzF2LfMAmbsml3S5UYm24NzhdISMF/mRim72Efp1UdLv4SqcXZy8hEYjaJXttG+y998gaCl70w2a03YOjXZE/NF1l5PBpj/EEDbObPo38m2KLkJCoZgYTXyVorYO2oONqFIJlvXZEfsZEP4DI7xgQce6OvN5+fn6YgjjmBZ8bPOOqvhbwsLC3TvvffSBz/4QfaYqakp+qd/+id62cteRnfffXf9ceeccw5z0H/+858zxxx9ut/61rfSddddR50KLxss1Exl6C1QGJ/12AIpzDqZdgcPjBi9TVP+2x410cVFhGZE6YXcIPWrfisL1MFZHXjIAEfZEsaKLi6jPGvUKDpc/17HEw1uIsrttKzLRmU2+/uxb12mS1erlB8bo8GREaMJsAlP/HEnDW0epr7hZfX+3/1uG7348I2U7XaP2k/M5OmuJybppUcsB0n5ezJH2+x4L31fKubpF3/cTifuN0S9qWqT8160/X7X1CzVygXa2J9yfSz73uF1K+UiJaolSsYgGIBa+nS1QFSwFmOzovrLACOupglnou5wb02maTMKDpjjL+7sG9l9+8dWk120adss9SfXsxKEgUQXrR+bofyjG6inu8fxPQoLRerGfII16pOSin7sbtljHlgU1Qmw0lUxZ+3tr8WD7kFT94F9iWhz70ail3xSuPuASs0FpyC8VFcF5bX//jPZUwtFBa0JxVp4+XXoVbXv2uqhpSr6ZW+fWqBDNnnfjSo2JTdBAe/T0MIrQnVxJ5tQJMmFpEkg5QbV5WAeSwLARvFpt8YdnnaNgw8+mMbHx32/+emnn86+rIDMNRxnM774xS/Ss571LNq2bRur+37ooYfoxhtvpLvuuoue+cxnssd84QtfoBe96EV0xRVXNGS8Owlehc9kMtlQGB/LeVPd1ZlsdcBmCBtRhUgF6OID3akGJ85VXEuSXhhkVsuxJtsia4XMBDLZrda+SzgzgsPrtMuX1MUxfub7vjSep31C+JBrVj3GnoFpJ6MubsligOORzBqZ0yYs5ks0NTRACyPrqbd/5d/tsP2JSfZ+G7eIC+7Y4ZGdOdo9W6Dn7r+2ntUXcfSXnXeXx9S/X/7dYn6RpnLztGlgZZBgem6e+tNwtle+FpgIyVoc5jRSKfjsheUyAcUd8zDrjsM3f1z+mekG3OX+XKQHDmwKBjjS+Ruy+o1/P3qqRNntg0Q9PIiw8rGJWor22jFPqYc2rnwNC92BvtIUleeTRNnBuiAhapHdmC5wdKWMY5vuA10Lu6S6D7DnKCoLgKNiR2eFoxtFYBTvuW5AfP8JLJPNav/F6vplSwZVA4wStO96Zp/8HgyG5O+3TflqCcfXQWg12WnDtoGeRpQClG42oUhSBL7AYlGxnfZgYzCPAUF+2CgSwbyOcLIvv/xyet/73kcf//jH6bDDDqOupj6pg4N+4+nWmJmZYdmw4WFG4KPbb7+dfc8dbACUctDG77zzTjrzTEa46zh47ZMts5n1scNu3rMzh9pCjXip9zYHP2DQYbN2rPuVLDUIsj7TKZPdZ5GFgME2PhdNeya7TLYMhZXRxd2MNhxeMJQtD7dPSB1uzfsKF9wTzRR42Zf455M1TmFg+OlH29zG67GxOSPjCYcIXwFjfHKBHtgxQ5sO3bjib797YBc9Y/0Aa1fYjO/e/RS94KARGs4mmpxzscAAnPTZqXEa6O02lQvYPZ6/rnMQoVwqULGQp944lgmYggFesRX/POH8GLhnf4tv7hd7zRdY/O7IZIZqtmKAxv+HlZeCBr29TQ68RYAgmSa648vO3Qd++I9EOOcZ/T/JMv/duVmi8WHjZ8YCSLDv1+/MUXY6SzTZZ/p9oun7pPX3S6+B77O7cpRFW7b0wIrHrp6dp3mUMGVW2bzGytdzfW/2Pdk8z/h+cWGB+obSxtw1P0+CBWG08PJfky3ivCFIEbXwWS5vdKCBVoIs8Bzcr91zBdo4tMyckgEcXdyqsAQr+TmI941S+MzNJsS57dbWTHlN9oPWwTzGspMM5nWEkw1HFjj55JNDEz7L5/P0/ve/n17zmtfUnfhdu3bRCGiNJqBWfPXq1exvdigUCuyLI5fLsf+hkt6slB4X4LqYeIrA9WH9QOxJ9LMwJVs42QnjfUQA9U+IRnm5X8VymdI96dje61Yb+5TkeDs5eXgt8+tkUwmaL5SoxyGDgvfGnBN5fwRQiwquVQZQNs6AXtr0nr1dSZpdLMVmHmI9oQZN9HowNhN5ges/8CVEzzidaNvt9NfH/0LVvvW03zNfYBjOTc91mms4uM3zrFAqUzKBQ9OI3rsBhjvLfkvcb9yTWq1Ki5J7TbFcoYFsSsnY4nWgP1Fi6yMcgw33Fu9ldf2oS80tFqlabTQ+MW743AhkVeFA4atLrD8tB95vYfdu6lu3bkW5gFdMzRXo1kfH6cyjmqToQNW2KROwpe/XH1+kiZk5GpuepYNGeuqMgdGpWaqWi7QJZQJVq6CAoRcwNTtP3ckK9SRRquAQRCgXWKlAHJDEdeLL4XLglirF4hTRDW9bvgauUWCBQxS95aEOf9uPosELXf5es3HOzd8jXDaCCoUfp1wDDXYBg1MgwParNNVSKccgweZKjdaVa1T7VabxNdj/7MEO19schDD9npI0XCwSZbNUY89pfg3+2glKFqv0nHyFEk/1GI+1/Mxkex3PyhUo+UiSaoM9wgGUmun7VKlCh0wsUHVxWP5zOo5L4+fkj00mErRl5xRV/rSK1m6bph5aTdVsV+PnlH59wUBR030cnt9N5dEpqvZlV7xGYnqGuru7qDo1Y3sdXYvzVFsoUnXee7CsjmqFEkutRFeenjXjtzdeSDXYKCZWnYzPoxoq39OTk33LLbdQmECt9Stf+Up2w7/8ZURe/eGyyy6jSy+9dMXvd+/ezZz5OAKDjkw+7gEy9U5AtHQml6Mdu0aFMoygBM/OztLUxDjNCrbuQPuusclpGh1NSwvf7Z6Ypp5qN40lQ5AZbgO4jf3C3CztGqtRbdFfhm18corWpAo0Vl1mKBQW52j7zipVh+ypcrvRK7krSWNj7sbo3GyORneXKV30R72Twe7JKVqNz1VbWKEYu2sCczjlu1WICoyOT1O20k1jKbE9aD6Xp12TeRobFDwQep9BDw1soKHuNA2OT0jPtbncHOXnErQ2bVzf5EKJFufnWBtHUTo89qVdo6PMIBHB0+OLNDs7R0+PVWmAxJSjgYnJGeoqZYTvpRuwxv761E4a6glH1XjX+CItzJfI6taWFuZp+0yVRroKlvv49MQEzXns0SpzzogCtNXJ6RkaG3PLaOGas0tf/QbH3IGM8GhygSazZVqz1zJz7qmpPD05lafn7GPnChq4+dEpOnCklzY57GvNwQDmbFdW/n/vk5O0ZShJ8PUTcMyrxaX/S+x/PG5+MU9PTczRQeu6jN8tBQyWX8tw6vnPM/OLlKEyExnkj51byFNvqkLpWtl43NLr8/eLSzCgE8Ey/7WKtfRF/TFGkIJ8sLhZEEVgG+SriKZJKfAZuiWulV3vNm/vtZLD4w7zrtfHAzZ/ptBwAv65j+g5+P/3FBmsmDAcxwg8fz9FAa0aY79gXKrOayf3NE3d/xMq7nFsoGeRKHCOqoIni+HEE0+ksB3sJ598km6++eYGKvqGDRtWGHjlcpkpjuNvdrjooovoPe95T0Mme/PmzbRu3brAqO5+gQkHRwDX6DbhkFUa2F6kVavXugqlAGgJMzBQpE0b10uJSgzsKNHQ6rXSKq29Y1XaMDJII6vksiydCrexXzteo6FVAzSy2t/97N1Zpg0jq2nEpBi/YTpBfYPdNDJinyPpm0myejWnx3CsmSQaWtVHIxZU16DQvaNMe2xYs6Kmbk21Rv07SzS4SmydBI3u0QptXD9MIyZhMSdUsou0qzC9gs3jhN4poo2remlkpF96rq0vZhj1fmRktfH+M4u0JpcUfn9Q6AaeLtLqNeuEqXQ7i9M0MJegvoEBGhkRr+3rnyRat1bdPNtzvEZd/f00siaceTtamqFUd5lGRtas+Ntccp4eH59fcd+hLzA4WJLax/2cM6Loh2jUrjJ7TZXBrO35KdrUTw3zItlboG3z465zsvvpEu25cS2tlajzt0OSxqhrbR+tcphr8zN5Gn1yio45XMx1ePKJSUY/PWLzcrDgpnu30/MPHKFVvSuDqYxPUqvRn3dO0cT0LP3t1kEber/pdzt+T8mb/tX1WqrHvJVozb4s2FCrVmh+bpb6+vqWKOVwLvFVpZ3TC+waNg13L/3O+HsCyv21xseu/H5J4Z9q9OTEHK3uzdBANrnicWDS7JhaoK1re02vWXX4nlzet/l5S9dh+n2lUqWJ+QKNQCW74TVMn4ncPqPxurnFEvtcxipwuvbl+9H8+Y1Ku6b3t3iNGtayaYzqJQAaGiEhwee+AIYRNDbt20GcRaLohkinIngOy09PT9PXvvY1Jj4GHHLIIUwlHIJlqh1s9OVG9nzNmkaD47jjjmPXAaXzo482Wk7AEcfgHHvsckSkGdlsln01AwMZ9mDKABNO5Brx565Uiso14zO5AaWVmXRK6rPjoXgOVMl72WEoDlwXaq7ifK9baezhsGAM/d5PvAYEwsyvg7rlQsU5kliVmD+oJ4MNEObYowap22K+4Uf0e19AzbaHujHVYGspI74u+rJdjLUicy/ZvXB5D7u5lk1Dh6FY/32lmpDaNzKgqiWSLKYt+pwCa8GCWka5aDbK0TIpuT3NCXBscvlKaPMWpZsZmz0S9YoQYmr+G56DOnS/1yh6zogik04vjXuCuhTev3ypxsorzNc53Jtl6whfdsFfOILY03qzXUo+o8ieVl16nOj74XxEUGp5rdUIsgS9GedrRvu2crpKyb6VwZkV2Pocorv+zbX7QPL0ZXFEVk4wNkb9IyMrrmNy+wxrdbXnPgLv7YA/3L+DnrX3ahq0ag9aqtAd9z5NW565p2dBLFlM5PJ05+OT9LLmrgge8NO7nqJTD93AdB5kAV2K6+99ml59zGbXvtMzCyX66QO76JXHbG78Q80tyGD3vfHcarVM47t309q1a4ysvE3QAg7+//1xJz1nvzWGmKprkKUp4EI12p1bpEdHc3T8vmscrs86UIPf75heoInZPB22x6Dr53K/JvdgDL5/eFeOfd7duTwdseeg5edyv9fNwRnRa1oOLOGzo8wJX83P2zG9SMM9KcY+tAvUoMQut1CikYEuh7GriV1TPkc0+RfX+Z0c2LiiREn1WSQKle/nyclGC61TTz2Venp6mNo38JnPfIY+9rGP0c9+9jP6m7/5G6HXmZubo8cee6z+8+OPP87ag6GmGv23X/GKV7A2XujHjTpvXmeNv2cyGTrooIPotNNOo7e85S109dVXM6f8ne98J7361a/uWGVxLwrjMurQZrA+yqWKbY2W7fvpFl5Koa4/aWMLr+Ve2c4aCzI9IY0e7uFF1OttPGwyp4ZaLfh74dHXbQ3/slzvXjwW91JGgRXv4SZ64iSmY24NaPQfTyjvKdxsWA71dkkLn1UEVXhFgWsY9dhNweta7LNpGQQRwvkCauMReEg4rt84gJcsYY9S0Jq6DqzbPVc1sj6wznsyhrKy3VrCGoD9163oXrH912VOu3VosBIJXCgsrzXMf5AA3NTFDYVvwfXl0H0Aec+EZPcBZS28mH1gfa8wpriNC6UKDYZkQ4Dp16eI6QSFcWSjyYOTzYIuCaOPtBu60sY8aN4jlmtrPd476BbN14j6V7Z4NAMO2lxfF/XvsafnFnnJuQLtyu8m2rKnp+fP7MzRzFyRCF0hQsLOh8doIp2kUTjZR3m7bhV45OEx2mO4hwbWr2QX3n3/Dnr21tXUO2ifrc3l8nT7XyfojCObdDS8tu367KHurUTRzqsN4Wmlvfvd72b9qp944gm6/vrr2Rcc5Je85CX0rne9S8pZP+qoo9gXAAo3vr/kkkvo6aefph/84Ae0fft2OvLII5nTzb9uu+22+mtce+21rF83RNjQuuuEE06gf/u3f6NOh+HMiDrZMNLlN0LXPr0++ypriEG6bYuNEYiXaM40ifTKhmElOn+Y6mWIQhY80GTnWPZn07Fo48UNfxkHGI9l6u8SirV++nciM2wO3In2bPUTEIJzgSwy2hfJQEbxXgTIPM0shlfzivsMQ9kKED7DR0PWsPk5YfWElQGMfFxWSfG6x76Ee2GV6c/l7ccKJQ/Yr1RlQkWUeEVbLzX03DXt6VgHxnp3ab2TwvqSuM+8+8BgI429NrBJWvGXdQ9QMMZuyswigV+VAGvEb49sDjBNoE3hBcY5Kx7MBlSvOVGAXr+qL+OrPISrsSMA7XkPDdnOxLxFABRnZZRwSmYgiOU2j5SqiyeXgnkMzeMh30q01eA5k/3v//7vTMm7/kLpNGvrZW6n5YaTTjrJcQGJLC5kta+77jrh9+wUyGSyy14z2QIO2Mr3kuutq+EO3Eu/fbK5k958KIm0iWIOjaiTLZNpUQAopuM97aL/MNKj6LuqwvCHAYPMFsYHwQI3IKthtO/wdpjB6Wto4cWo3JJOtmQLN+wvq3q7aNukuOiZrEEq6mTP5cu++rbKwKlVD8a9byk4NGAqc5BlFrQi28ZsG8DRstJSGOzpYrWvTnNKVkfEzSB129NYRlHC4cD5be5Jj2vGeesGBJZKsvsrHOkDX0z05G1Uye2kW55O0XNOeSllM5nQx1jEPoDDG6aTzTLZilqOYr/GmeQFcJhFnUbcP0w3Y7+n0DE5X2SlHH6AoBJcAOxrXs6sKNpoZZey2P1QFY8QTskMoT7ZLFin0E47WF0r0VaDp+UHcbBt27axDLIZTz31FA0MKG8ioeEBMj1pZei+ZqB+V5bGKdtbV4PEDCufmWxORWt2ILoFAikyGTQYYn57hcoA1+aUHYZzun06epV7ZGq9GP7dafGsDqd6ezU8mtkxeD1ZJ1smQg5HClkfULUxjiuojwrpuW6AYY89Fb1f/RqPwgaiw71lDIx8mWioeR3GMxsgG1xxA/YQTCMrxxOZ7J0z9msaZ5YqqrhUJluizq85E4V1ILI/OPXHdQSySFufQ0V0Dck/TV3pLk9jXPE5xiL2AcY8zMAo3msNRM/ikMmWnUNMqIFCx8R8kQ6woCrLALYIa0/KznD5fQ37IQJuYQL3fLFYpVW90QY77ZIZ2KdEklyGk644GXLwcjCP5kaJ+tcbFPE2zWD7crJf9apX0XnnnUdXXHEFHX+8waP/7W9/SxdccAHrY60RPXBImesnVWUimw87RCxlgGvCAhY1ljUEN/aSPyqrXV0+MkUwCuDw2FG/DCpkUjzr4zMgIAO3GmQmfFaIPpPN6aCy6M6AUlcRvhdYe16dT8NoqwnVDavIdnEK/XBPph6IEKFtYq4aTo3aPYZTxsNwsiHc5RQM6e9eWeYQ5zKcLsWZETg+uD9W+85gT5oeHi0rD2jZgfWPdwkcytdkNwa0WGBAxMn2eZ+RLcUt9XI+q9DbELEPDC2Y8Ep8UJahii7OmEceM9kyZVmyiRaVQDB0eqHI6OJ+AecaLC/hvmEmGBnwcJM5fM+OOolkl8xYZiy608UB5cytpBHM6yR42jngXMPgfsMb3sBaZsGogRDZ29/+dvrEJz6h/io1AqeLy0RIGxywadlMtn2toUZ0BqxdXT4CKXB04GhbUTOxCePvMjS2cOnizpSx/gxEpKKvyRbNVFllskUzI3DGIbzjFTAczGI6XtayTIQcjgXmFcYPX/icFt2LVoC/vkrhs7Drst3EIZHJnoCoj/k5MRU+Ww6u1QKvx+aZbKxpO8fWbi/zRxevqq3Jbjq/GV1c4Jq58JlTUDSI0jHR++AGkT0F494894MEgrB9ypxs79cuQxeXTbSoBPZIzL3Bbv/3DE6yZ3q9j7nsFdy5Dpum3gzsNfMm4cRmxqJbwK8uVsn2rcAusyPgaSbAof7c5z5HU1NTTA38/vvvZ72pr7zySsvWWBrhQyaq7LWWz0tNtlOtoUZ0VEw7yjc2YxwYduPM55hoax4Vhpg8Xdz+lOjNpthBIlv2oBowJLxQWLnCvwj8CmNxw4Ebbl7WcoopEIuNv9mx4LXnIuDUXS+BQycM92ZYhiYMuGWlDcG+0sqAUkz3VlWiWByLxbJtjTLq1VOJhEGnt3wu1prCTDajSbupiyNDnPAU0FrOZLuPLZ/zXjPKRrDVYzlJ0n8mW2RPMeji5dD2ZYwDzgkVgNPo9azxRBcPsZOHmSq+xqfoWYMau8fysiiCjvVMdsRONht7iz1JNIjG9wBl4mcdDKlQE/pgi+A//uM/vF6PhiJgkaONiQiw8DxRVbvsnS87eBFL0gjeuIEhYTcuTsEUWXohy7SEePDDSHI68PCZ8XfQT1VSSEPLZHdhnZfEqfM+MtlwEjDMMF5wrcVyTdqpw1wVz2RX686QkbEX22twfbDvVNZk80z2n3flKGiIiD/BkWze3w2Ro2RHCJ9hvTpldkEZR0YN9fzNAF13raIaWwAOvXsLLzhYclRfHtDqThq6C6LCZ8b7eXeyMx4ZILyFl9csuqh9gEy2rN3hJ4uNsVBls3DFbC+Q7QIDBzMKuviUIqp4A128hdTFgahtXDttBpk5FEhddgdCysm+5ppraK+99mJttrzK6mvEs4WXF/VMHBg4VGXqNryKrGkE25/UKeqLvrN24lqsHYREdJ3VDIa4ceOgdaNZ9mdTjF4aRq2tHeBAwjEIVPhMgTCWmcZaClj4zKwebajcV8V7ZAeg+QAnG+1ZglYYFxF/QiYbj2MlAEuBCMOoTLZtm8GVbZUcnGyHNl6FANTFecbZDmDv9EoI/GB+mQNaaNMncs3mdmk95EWR2VvpmHHNyw6+11INEfsAOhRhqYujHhsBLVXwlcl2CIRbAQ6maMmgSuyeLdChm0yKjBHRxVlNdshCkHGhi9uxGEoSc0hpG68OhtTugZrrb37zm6wn9pve9CZ63etex1poacQPMvU4bkq2dsChD0MAUeUBwedrunh86eJ2UV+nNl7s4Jc4UMKOjiJrYJXNMgOiNs09h8MGrtMLhZXpIggaUkxczUcmu/nw9iK0JeNsGQJVSWnBINn6V5l7DeMJGdI1/cGVRYmIP/E6dTj93MmOc022ai0GOFlO2WinNl5eWSOOWXrXTLb8nDSvtbwE08YPa8AIIHkURjRR1b2y8UUCRb1dKcb0EBWDCzKY46f3s2y2n42NZMlB2JlsOMTTCyUaGVSzP2Jv83I2I+jFqNEh6//wvTjqRJKdTeim9bHiNSJgQrQbpGbCVVddRTt37mT9sH/4wx/S5s2b6ZWvfCX99Kc/1ZntFhY+Mw5Fb5uCTE1o3BVwWxUwbvxGrJ2CH050cWYUSRz8nlvMeIRIHTIyFVGLn3k1GBmNWiCrg3v+5MQCrR/wINNqw5Dx4tSlJaLjZsdCpF87hyF4FYyRE4b4maigHBgY5rpjvzX3QcLIiqjNZPc4iFE5ZbJF65tldAbEWnhJOtlLdF984fkidHG/xrEfphmCQviIfgK+oj188ZgwstmYZ6oz2YAXyriskFcUNdnIYoORpSr4IaPFYQbXfwh7P+RzN+pMtl0WWsb+FgkearhDeiZA2Axtun7+85/Tgw8+SIcccgj9wz/8A+299940Nzcn+3IaAUGmfUPZh+PL+j4WxQ+MOGdbWhV2PRGV1WQ70PNkKWx+W8x4ooy5HPgolUBGMEp4NfyRmcYYuK31h0dn2etvXt2jgL5n9KzGW4oK3nk5uJnwmcnJFq3NY3tMQC0Cw3CyRWnf/dmuhjZehoBlPPdWI6umsia7zDKaTuOUWyxbZtow/VS38HKb00yRXzJzidpozAWsA0wH0bG1Ez0SbxOVjKzTBWPVCXxOsI/CqMteKKB9l0qRPLSdS3iqM5ZttSpTMqgKY7MFGvEZyF1Rk+0hIIF1g+UWZFmPU2/vqIOddjo9MoEaTRdXA18zIZlMMsoLstiVSvS9ZjWWgYNKuCZb0lFaSVcVH/s4K+C2KjB2IJL4yRAbNKKEdCZbll7IDdKwmC9GzapLJjuTDk2t1go4yAzRKnljDp8N/qRTtB/34MEdOTpqyyrfiq/ccOOlKF7o4qJGuJnWK1PLKNuTOJaZbIE9kgWHluYtp0fGdW9V2cILew7Wi5PWAvqIV2q1FQwVBISxB6ksWRLJ0huZ7KQ8G61SlWa5+GELwZHzwzRj5SA+Mtn4vCJjA50QZJmDxnxRXfsuDraXeagzllUXR8eYsFt4jeXgZKsrpfGqLl6KcC983oEjNOxSohY07NgsMuWa2EeiEM5rN0jPwkKhwOqyX/CCF9AznvEM+uMf/0hf/OIXadu2bdTf3x/MVWpIAwsJ60MkEiVTp2HpgEkcdlH0Lmx38PvpJ5vtRBPEGNs5OLL0Qu78hBUhZRRaNyebtUOKLkjIhV28KEPDaXYTBXtgR47W9mdp/WC3MoYM77cpmykwgiwSLbyWnAuZYJ5R/hKMkw3jKQwnWySbN9CdrtPFvQY9WrGF10Kpwuaek+OJfQbrupkyjjnkV5fA2ql1r8kGrdxLQAuBARkn2w9NGB0D/JzPflXkmXMkMPd7utIh0cXLytp3cciwcvyU2rF5EKLwGa4PyuLrVDrZYE55oYtHyJhEJl9F+zI/wNjDxGoWZJRhQ4i0JtRwh1SIDrTwb33rW6wWG+284GyvXbtW5iU0QgJ3fETUlWVpSGaAgioTUXbKmGp4AwzKhEmJ1gucgh9Oaq6y9EJzQEBhq1pLIJIL38MtCAA6INZJVKJ8cJBZRtpj9tWpbg2ZvMdG5+gFB68nFViuE/VmjItS0PAYjEljTbaYYJChLh5cTTZKC4KcK6Kt0YzgkOFkew16tGILL7PqvBMGu9OMMr7RJHQchFiWyJz2VJPNnKQaLZJY+y4VxrGRyU5G1ulCtFRCVgvGC+CgLMQpk83OzPjWZI/PFdhZqraGPcU+Ayu3kFg/hj5F59qZfK/hLQDNZ8tAt4SAonayfUNqNVx99dW0ZcsW2meffehXv/oV+7LC9ddf7//KNHwBGxIWGhaZUysPr7WVHDj8J+aLwo/X6uLBQCSb4rmF15Kaq7ldkNcAjYqAgCg4zcwtQ4zrwP2DQzrcG34br4LP7JqTKNgfts/Qnqt7lPUthfOH/sxeMwWihh8+D+ZJXV08bZREMBV2l3nD5mRAdHG8N+YTstlgBwQB0T0SbbwwZxF4EGFsRAmVSrVwslGT6wamMN6cyS5VpRxW4RZeNXIMAIFOLlvCYNDFUUNek6SLe6/Fle3FrJqxIJqthTM3vSBud3gBd+JVzxcZEUc/WhNh12QbVHF19dgA39OanUU3xFmfIgzwYExzsE3GXtM12RE42W94wxsip0FoqK3L9kszNKhPFTkhqg7e/AIda7/Gjc0BjsMaTgtoi81Otkxk1IvCtB9wx0Nkz2IK48UKDfdS6GC1xz7S+liDVlmdqfkibZucpxcfvolUgdeJes0UiB7crN2YaeyYYFDSEAxydbIrwdVkm+uyg3KyjbpUgTmbSRPuJLJtojTbqOBHjMtSWVzA8cE4PTE+3/C7xYAy2csikHZONlFKWvhsKaCVkMum+hHCZAyVZJR0cTHnyKmESRWgd4D38cowcmvjJQtZ1phMG1dVomf7rOtTvra4UJzMutXJHGtWiVRNtgJBXQ1JJ/uaa64J7ko0lAOLya21ExaRHxVG+RZeuiY7CKiohXMaF0YZL1VoiLp8Zz7C2ryZyJ6g4wERKSjJRgG/FFa7muz7tk/TfiMDLOOpCrzOz6sRI9rT3VyPbZ6DoFk2z0G/tEpZoO+6XQ9mFcD97elxF86B8Y+MHijjojTbdmjhtVgqC9LFrTLZavseA7w0AcEju2XMMtkea7KRyV4jwUTxI3wm2j7O7/q2g2gbOox/0MJnBmNCPdsKwcNZm/ZyStXF04aT5aUnt/S1Vao0MVegZ++zWvlrGx0tMNbiYmJx3w/DgBWrRCaIprrtYqeis2dhm0Mkk83UoX1EantMtZIi0C28goHfWji3cbFTGPdSw6eyPtPtoBVlTZjrW0Wgsq82y9r6oItbZXVGc3kany3QIZsGSSWWhc+8BctEx96sLM4hqjDud09TLfYoCxm2DwIozMn20d84ypYyXrAg6PxAGG6xaLAuODB/gqCLA3YMDdZ9pbpcJym71mSDcH5qcWUVrFW+N+6T6L6C8cce0SzspBLQXlBZX8zhJlSpqqyP38cwstkoGcTnGuhWr6rtJfMvyohoZ1idtTJBNJV7diejs2dhmwOHtFsm22/tCjZAXivpBixwPFYLnwU01l7btgiMi51j4YVeKNPD3Q8Q/Rad270SmRE4sD+4f4eyGlP/dPHkigDI77dN08GbBpVTYzkF0WsmW4Yu3nztPKDnBiZ8FuAeIzNXvEAmgMHKHJYy2XE2KnkQUEXrPlEnm9fPm7PZVsGboHtl8/kuW8LAM9mM1SGRUfWTTZZVsFaZ/eIGvcjc5/tlkOJnTFk8gEw29mveUUIUfG7J9sk29E9qLde6ywyZ9o2y4pHtDCs7S+bc1jXZatDZs7DNIVKTU/IZucZChHEnktnhC95PzZeGNTCGXjfEunHjMC7oS2pl0HihF6YkrxXGjkyWmQOBH9mMoAj+9PQMC0qglZAKwODiAl8qMtnbJhbYzwesHyDVYDXZZaNPNvqwejn4RfqkWzkWooJBXnoSywCiW6rG3i/bh81bLkQXY6OSOwcqjDZRdXFel22m9vsVGfRikHIHSbYm26DJVqUDA36YQn7LuWBzeHXq6vaBgCOJUgm7M0kV5gUF9mQBXRPZTDa/N94U6oMPaI/N5pW27mq+X14y2XHeD8OAlZ0lkxTRNdlq0NmzsCPo4i6tRXyqidpl0qyAdiR4L9VCIhrGhug1OwyHCYe307jYOThe6IWymZaHduboD9unKUjaLXOciu5O9u7ZAqPGMQNPUTbTb3Yta+q7CloharEP3WMokLpkTgc1WvF5y2QDboe3kclOCrcqMwNzK0jhM9azO9BMtng2sYEuHuNMNjfs/BptCM7grBF1fgyF8eV1jTUbSCbbYU/jhq7sesT6QtYe8Sio64s/z9tZsOzk+gu6e3fwjXkvWj8cdNkGNDqCymQjUClDdect4GRrq8NgjeFzTMwVaWRQrbI4R9ZD5t+oye5sO7N5T8LeibUpmhQx1rKuyfaL+J7KGqEInzFVWp/GuF29bjPiXjfYyvDTrkMkG21PF5c/zGAsyGQ7oLCLbJ0s4Hg2q6E7OSuo33TLtP1pxww9Y/0AE1VSVZftN7uGsYERhrX+2O451i95n7VqVV45uAGOTK7XmmzA7T6zbGWz8JngPsMMiQANLH6/ZQ0/1eJPQH+34WSXYm5UIoCHeenX4Df0P8TbKg32pOuZbObYMIc1FXom24tGANgMvIxHxkHHY70EM7hz7EfPwE8LL9lAUQ8LjAabyQ6iJpufSTLZWa+CdGEojCPojPkP1kgQYIwOD5n/OAcdw0BzTTX/XjQpgufrTLZ/dPYsbHOICJ+poNWIttPQFJ7ggPvqvW2L+7jYqch7oRfKUtvhRHihi8sYbcguwLZE2xY7QD11d65AB24YUKpuKxMMsAI+I4YA9+iP22foyM3DgbFFuCO3UPDmZJv7pDshb9EPG86RiGGKdRBkJhv3G1mCILJoMuJPPDgExxNzMe6tEZnz57M+FGwTfE7R8TUrjGP/wm0Nwvg2FL3ta7K9rEe+1mQz72jF6OUsEGE0xYmqjixzUHRxZPAQlAkik425i7GVCdJhDoH+G6YQnQxVfGQwGKq4V7q4TuisFMPlWW3RYCy6IeiabP/o7FnY5hBq4cV6L/qki2dknOz4ZltaGUZ22GMmGzR+lwPciq1QrxPz0MJL9FrhdCBjDEdClrqE/u2iBy1oeL3ZNHMe7fDAjhztt76fGb0Gvdy/gYf7AIPYT002gGv6/bYpRo/dc1Vwzb5xn7CGMSZejRiRPumgY69wsoXp4sG3CQzKwJcRfwJwj3A/pxaKsQ9g+slyyoqecWA9gAUDSiv2gyCo4m46E0yIz4PjyteXrBp62mMdrorSMcOw95jJlixBwX0RKfHxmsXGmAU1X1DiI1OXze6NRzZE0HRx9MceGQiGKt7YwksccReCjGK/5eWaoiUHTmKOGuLo7FnY5hASPmMtmPwdrAaVWExdXLfvCjCT7TWDUHUXsYKxgdc3G1D8/WSF7EScLA4YIrz9jWw2m9VkSziv/Vmj57AVpheKtHNmkQ7aYLTE6suoMfDgNMJ28ht1x/iM5gosix00YLwYvai97Rtugio88NDsXBiGqbuxxXoSB6z7YBj4QTjZctkGThlnZT8x31tVtO5jLbgknGysU9iUs0uBuuCcbKKKjZifkYWUn48whrFWZK/ZqyqwiuAUy5z6YlSJ3yfGrgqILs6UxbPBzBUANfaymWwvGhsiHWb8AMEr6JQEpSy+XJNdDYwN1K5o3m9lbX3dJ1sNOnsWtjmE6OIeBYw81WTrtgqxFD4ToYvD0IOdaB5nr/RCGQrbbKHEMlfoeYvabFkatsx8cxI/+9PTOdp3XX/dwFdl4DEF9C60WvEf6NpzVU9gCq9m8Hvqdd9IuThbdrReZLIxxd1LYLxlDmUQlIHPBXtk5gOvG427UdlMX/QCBDZkMru4j4wyvlhi8yqKTDZoml7nI7J4EFmUXZ8iCv5BiEUZAVTvmWyZQFGQdHH0yA6CKu41k409z0tQ01B7D85Rml4sEa5quDeYeuw6XVzqXsmxgdoVzawS2XJNWe0cDWt09ixsc4hEMVW0uxEVJIJT1ukbX1DwI1IBGpHIuDTXZXulF8pkWmDswIngAk/ymWxxQ8mujdfMYomenl6ggzYaWWzukINS6BdMRVuBENORW4bpWVtXUxjgc8VrwMyoGa1K9cjmxhZ8FbdsttesjwxUlQuoEOzBvAXin8n23r+5kS4uJ0ZlKIyXltZaMPfIqSYbH9lrnTPWmpdMNiBrIKvQTDGo6t4z2TJ7SlBskuUe2epFz7xmshnLIIY12aM5o3WX3yCxW6AJn1+0DMELG6htM9kmO8sQBJUTUNQ12f4R71NZwxdE6nEMx9d/Fk2kpY2uyY5vCy+RcWFtvExlASxj6JHCJlqbiXpKOBFwtGWcbASXkMiRy2SnLGuyH9gxQ3uv6WtQmsVj8R5+W1yoorAiWxdUlq4ZvOTDi9qtSJAFc8zus7gF9PC6GPegM9lsrgRQD+pFsKfuZMc8gOlV9dqMxVJZii4OGJls0MWDzGQnAslkg73RJ+ns8b1cNqBhlID4dLKX6jhls+iALMUX8wCOQxCZWhbcDdDJDiuT7afriAh2B1yPDXBBR1HKuGwruE5p4SVr62MtYxlrR9sf4n0qa/gCjC7sr06LRDa6ZYXujGE8hUFN11BPxYSjKJTJbnJwjMyDl0y2eG0mHGs4EQOSTjayBKzWWSJzhfdpVhefzZfoqckFOnjTchYbgLGOW4ZWVn4Awz/uqtDN4Ae117Xsll3BHLOjBMPpcKIOcqMicLp4QD16vdQSguUBxH1vBYPBr8EvK3xWb+OFTHa5Ku2gq8jSe63JBo7fdy1tWd0rX8vtgeqpItPP56AndXNJ+wDMFrYHB7AOA6/JFhRxbKyX90AXTycCa+GFQAoTPQtQWZzPZ0P8TOxzaNEz6xZeTORYgg3B9yy/7KNOR6Qz8dZbb6WXvvSltGnTJraQbrjhhhWL+JJLLqGNGzdST08PnXLKKfToo482PGZycpLOOeccGhwcpOHhYTrvvPNobm4u5E8ST/DMhhNl3GuE1AuNk9F39eYXCPz0wxQ17Jvp4mzueKCwydTtMSe7e4kuLlGT7eWgZerixQoTczErim9Z3UcD3V2WfVr9OlpGTXY4GWhVwBpGksB7TbZLJtsh4+gmfsaDN6lQMtnB0MVlxSEHu9OsbjfozxyPFl4enOylmmxVpRlWAB28apO99VOSxbQwPIyrF/Ez1pveZxCCB7e8jLNRKiH3WbEHyzirMvOsL1C6uFw9uayD1BDQDEj4DGVUOCtX92YoaBjiZ2L3S7fvsk68eKnJBnQm2x8inYnz8/N0xBFH0FVXXWX5909+8pP0+c9/nq6++mq68847qa+vj0499VTK5/P1x8DBfuCBB+jnP/85/ehHP2KO+1vf+tYQP0V8gcMZC8XJ+ZKtg5Lto9z4XlrxMShYqX+LQnTzbc7esei6h6CJQW0XrckuU182ZWSZC2VhGqJMj2yO3iXHjs9jvN+TE/Mrstjmx+MxfmC0FWqtNYG54idT7Fab65jJTjvTLA2HJniqIOo1ESBRbYB4EZ9CAOjlR+5BrUZflAVTna/UpB1BiCZiv5lZKAW21tz6ZIcdAMG+LHsWOK07GZsDR4mXcTacI7n3D6ouO+hMNtMJWDT6t4vAq/5JkDXZyGKjHttPX/UgxM9kGRGdRBeXCWLhDDXWsnay/SC4UJ0ATj/9dPZlBRjTn/3sZ+niiy+mM844g/3uG9/4Bq1fv55lvF/96lfTQw89RDfeeCPddddd9MxnPpM95gtf+AK96EUvoiuuuIJlyDsdqJt0ougZfbL9b0jN9bpW0C28gs8ughLZLzmeopFfjDFqsBrG08MBi4i8iHOCx8CAGsh2sc9X4xkGU220HXAg42CWAYwFZMlAGcd7PLgzx3pOD/V0BZbNzJcrNJIOtqZNNWDA+KHjuWU0kZla05exp1k6ZDTCcmhwHVhvcEx4TbQKeM3CtEL9IeiLfurYsdZwa2TXNeYbAnWos81GUpPtvd2dVzC6uKRxrKpmHfu7F8fOsA8SkWsj4D7AZOJB1yAA9gnukajAGsbSi+MYZE32WM5wssOADF28FdoZRtHCC9/LMklVtF3sdETqZDvh8ccfp127djGKOMfQ0BAde+yxdPvttzMnG/+DIs4dbACPTyaTLPN95plnWr52oVBgXxy5XI79X61W2VccgetC4EH2+uAE5YtlqlatHYViuUKphPzrNqM7naD5QsnxdZC1wxka13scV4iOfTaVoPl8iXolszVF1jJJ8PVNY2w8T348Md8w79yeN4v2IAm0fcNP6JucpNxikf3vhnypTF0erg2vjffFPXxsbJZOPXi97WvgsW5z3g0LhTK7r3FZEyJzDWsYPoPXa04moN9gP/7snqSt7wk0AJABsntusVRmpSth3E9co5f15oTikqMT1Xzwes6Ijjson15fG/caNcNens80HfKlwNYaZoDdnC5XKqzNUZhjivWJtSDznk7rTmZ+4EwoeRhndp5Irl1cL65b5b3FPME+E+Q+gtfuyyRpar4gVAeP89LL9eCl/aw5p/EfzS3S/iN9ocxrjMcis2Pd36tQKrPPHZczNSokm+ws3Je+TEbqvmDOeVnLcT+L3KDyPWPrZMPBBpC5NgM/87/h/5GRkYa/p9NpWr16df0xVrjsssvo0ksvXfH73bt3N1DR4wQM+szMDJt0CCKIYmFulnaNlSldXBlxROR9JpejqckuWvQZ+Vucm6Udi3O0Krlo+5iJqWmaniKqLcZ22rX02BcW5+jpXVWqLcpFl8cxLgNVShWce13OLZRobCJHY2NGhH9sYo5SiQSNjcllEpBRmprB64w5Pm50tkiV/DxblwC+f3JHmRJ598zvrrF5mi9WaWxMso3Nwhw9tWuR/rK9Sr21KhXnpmnMRuJhcW6RXeNYr/dMytjENM0NVGmsFFyfUdVzrbJYpp5awXX87DA7M88o32Pd1nTJ0Ykp2ru/QmOllTd+Ppen0ck8jQ1ZH4IYj4W5ec/XJoPSwjxt97DenID1taonTWOZ5SBwK5wzIshNL9IE1suYNwNm+1Seiot5T2NbWZyjubk8TU+OUxCYmc7TxEzBcr8Zn5hl7AS7+R4E5mdzNJosUE9lXlzEanKa5qaTVF1I+Zofhs2BdSFXqzsxPUMzkwmqLojbB4uzCzS5UKbNPeru7Y6ZApXyC4HvIbXCPD3+dIlShR7Xx05MTtGaVIHGqmLjyQGmzdT0DI2Odilhu/Dxn82XaWJqhsrzaRpbDJ6lMT87T9OVGm0Q2BfHxucIJI6xsWDau7UKcMbCvt81OkrJRILGJ2coXcrQWErcx5mfy9Goh7Uc97PIDbOzs6QKHentXHTRRfSe97ynIZO9efNmWrduHRNQiyMw4bBJ4hplJty66QQNDHXTyMiAZWZ5YKBAm9aP+KaMbyxlWX3qyMgay79jofT05dl7idB9NeTHfsN0gvoGrcfaCb1PFWnThhFbWjRHf7FM945VaO1aXEeCBuaMWumRkSFpOl7/zlL9dewwXZulPUayNDKyjv28x3ya0Z1GRoZd3+OpxSkaSBCNjKySurZNxQyr3ZzM5+mUg9fTahvaMlDsWqCpSm5FoE8UqB3L9uZp7z03SFNgo5xr+LTP8PEe4+UcTS+WLPcK7BPZJwu058b1ljTsSnaRdhWmbe95Pr1Aq/Npz2Migw0zCerux/xUd2b0TRFtWNVLIyP91ErnjAjmk/M0R3OexwbzZmPaet64YS/qpTnyvlbdsJCap1zN+rMNzKaYwrnsPukHa2aSNDiQFT4LoLUBW2DLpg2Oe7LI/Fg9XqOhVQM0IqGKDgGtXtgHG9ZL1dzjvi+Mep9TVpiqztIm6q6fO0Fhr0KGUaBHRla7PrZvV4XWjwzTyJC7Q24GqOIDT5doeM1aJWcMH/8c9dDWjWnauKExCRYUJio5mpgv0sjIWtfH9s2lmCBemOstjjDGvkirlsa+b6JG60f6aWRNn/BrrB6r0vDqQRpZJdfhIO5nkRu6u9WV8MXW29mwYQP7f3R0lKmLc+DnI488sv6Y5mhjuVxmiuP8+VbIZrPsqxkYyLAHUwaYcLLXiMVVrhmfrRnlGui+Scp0+Z8GcJwnF0q21waHIpFIUrYrHet73Mpjz8SYKnJRPzg1KNlCraLb83oziIYn2Xv0YV6x58mPJ0rQ8DqIMzsppi6UqkzUib/+YE+GJueLQu+Huqyh3uXnimKgO0MP7ZyjTcM9tNal/2d/d4ZFi73OZ/T8zaRhEMQji+1nn5FBVzpF1Zr1XmEoBaM23npe9WW7mGFqd23IYOCehrHH9Hd3Sa83N3hdU60w/hgXlPd5Xi/lKusA4OX5e6zqZfc2sDmdwpy2fv0aJSidCmdOmu+13fVYoVApU3dXmtICjpjb/EA9rOw4F0GpZ/aB3H3qz3YxHRKV9xbzDGs76PFa1Zelh0dnhd4H9zOTlp/72aVxqtSMMVMBjP/4bInWD/WENqfhNJdyBaH3g73bnQl3vcURmQQEQJNUXRp72HmyZ6NxVqubO3GzReyg8v1iOwu3bt3KHOWbbrqpIeOMWuvjjjuO/Yz/p6en6Z577qk/5uabb2YRENRuaxgqo3YiJKpEz5aFz+zpOVx8w0uvRw0JhXdJIS4+N0REVZDhgOATV9/22v6t3n/RRVADLbt4D2CuEjxXEKMFFjy2i4NAEnDoHkNCojtw+LwouvP2ZPhMnQYnlWk42dgj7PYlBA0xZ+1EpsJUcu4OoFe2F/GnVoFfpWPc6z6PbZUQBLbrEqBO+Mz6b5jrQfdtbwbWkIzg1aIi0TOvYkm4VtwiWXuEn3miXSdEsFBAm7jg9+UhCYVxowNIwrsInuI2Xqw/tksQWiUQfBEXPtPq4txBNTp51DyLarp1AtFwR6QWHvpZP/bYYw1iZ/fddx+rqd6yZQu9613voo9+9KO0//77M6f7gx/8IFMMf/nLX84ef9BBB9Fpp51Gb3nLW1ibr1KpRO985zuZKJpWFjeARWW3OZWq3jduS4PToYUXPyRaQQW3VYExQKZXBtwQEzUCzW28mIqnRyVk8+bv2L4r09dgKKMWTLhPtmQ7GGBtf5aO2XsV+98NcOJx2zDvBzzcB3wWZGI6DU7tjlgbIQe6KA+cwBm3KjvBnPTak1gWMMR3TKvV8GhnA9FvCy+oi/ttMRUUnIzRKFp4wVmVcrJZj2w1885o0Sg3zl7be2I+4BiBjaMqSIDuElsywdNj0cYLZ6DRptLZFDcU6r2ND5gFKhXG54sVtv+u7Q+vTtdQF69InP3tuYd665Vd9ZxUM/ZsrS7esk723XffTc973vPqP/M66XPPPZeuueYaet/73sd6aaPvNTLWJ5xwAmvZZebLX3vttcyxPvnkk1mK/+yzz2a9tTUM4OBCxizovtU47ECdRW2VVU2Xl77FGl7GQDaTLRf8AA2LvwfL0HiNrps2fzvMNmV6UaOLOYvD1q2+DEZX1oPqM9bD/uvF6hhxz0BfZW3GuuWdZaxLc6a+UwCHw+7gxh6CXth2wN4Cg8vOya6E2C4piPZB7dzj1Sm4IlpeIdsjOyy4tvAKme6Ie71YrIXevgvA/JU1zNm892AfwGnA+YU9WNX1Y02HMc8wZ3CmzSyWHJ1snJNI1HtlQ2A8YH+pwsR8iVHdVbEghZ1s0T7ZuoVXY7vMpbXohQ3BzmrdwssXIrXwTjrpJEeaD4zYD3/4w+zLDsh6X3fddQFdYesDmw0OMCuAQqSKxsYPODg3VgeUSodew4GyL3gQeQ1+sEy2iS7udUydHC1u9GFzNxsfuE4ctqCRZ/tdnOxSJZRoNnqpeu2VDer7lj5xEZJ2gZMRbmTUUu7z3IGdExY1F9cpG9RyApw0VjfXpvukF+eLA8Fb7G0IbMQRjCLtVMIQcpmUca/l6OKqWAJYfxVJxgLOErRp8gIEYpENdhKplJlni8VqvWwoDMo4nGxogNiBzyuvZ63fMg0rJ3v9unAFghFUx21gWWoXewV2rbY1l1v4Ym1hD8L9k70vTvuahhj0TGxzZByimDiEvUSP7ZwmbH52lHG98YVn9MvUp8kGP5rp4l0eMzRuBjeMJjjUzdeGzK8dM4MDnx/X5iWTHWY2c65QsVTQbncYWT+bmuwyMlLO44a/2zm3RiY7JLp4V4o5xaocbU7pbNcsDMYdW5MXDQPMCzw3rnRxONHOmexwnWzZDJRIcEsqcwr1KQn4YbqBRZTLq2nhtVAy+lGHNc+4ky1Sr+615EC2Pt8N4/MlWjegrm2hCDA38PFFKOOYS1r7x5TJrtRMmkjydHHZgJlGI9rzNNeoAyI6dhusHyfJLcu58r30xhc0utNQkjTYBKKQZTMwoZklR96o8Un4MAKr0lTqAYG6bP75Q8lkL9HFvWRM5juULs6EeGwcgLwA7dOpLILNyZAcGk5VVSV+VvRpTMcd3MDzkhkx6MBQmY3nvUkljAAC1nUzWAlVIv7CZ8oy2Q4BBzv4YUUhky2q1eGGhYJBFQ9LO0bEyfYrUMsSLYqEz7DXoSZ7nYBmiWogaO5m23BqfbsGKr1qRXgN1Pgt8dHQTnbbw2mDVe34QjjFzvj1omyo4c3ol8msybIZuIMjo0puBVynk7HNnGyLLC+cUjinTsBcw2WFkdE0MtkVT+I6WHl9MaW/BgmMi50RLqJyDGPLriwC8zlMJxXiZ8h+qQACXu1sHGJcMDResmow7uNKFW/omGAxr6PIZJtrMUWQV0oXT7KyDRmUyt7LyZDJVuVkw4EMQ1mcY7hXIJPtU6DW6DCjxskem83TUE86kn0KlHE3J5uzNlUmj1oZhgihwezzsr6ctCY0xKBnYpvDaYNlSrwKHRGnljZskbexARkX8EyzKEDrkwl+cBV5Xu/nva2Ic5sX1r7LwslGjbYbXRwCKWEZAQZ9Xt7Aw2dAFrwT1fbhcCDbYHV4w3l2M/YxB1FzbwU4FmEyZuD4eRl/K3SCboVXo40pi4fo/MiCO9FWnw10y9BrspdqMUWBcxuilirgJfuFPtl+MtmirbDcYHS0CC+YgwAB5oxT4Nhg53jfF1TWZKN119reaDpiGOJnFddgDRzLuDJewgbmDeYXMvxeWIe6Jts/2vtE12AOFM5aq8MfC0+lQWoIbznRxfV0CxpQZpahr8qOi1H3XWXsCBhTXp1Et/6LyPRaKa4OCDjZiGa7qY+rAq5xviCfyUQQAZ+lE8EdEqvxF1E5NoTPbGqyK2iXFN4+g/XgVfiuE/dIrwY/dA/inMmGUY9p3TynUVaD8xd08ihqMUWAOleYByrp4rJ197LB3mYnGxlOFZRorGUEP8MMOuH6px2CBH7KslTXZI/PFWlNX1ROtnsmu1AJR/C0VcDH3iuTVGey/UPPxjYHX1hWB5DqzIljTTYTPtPRxbhlsrEByxzgGGNkIeHoot4/KCMQ9D9z+65GunjFceNHtJv3Uw4aMPxx8MseRJ3avquBWts0/qhdZd0JRJxsB7p4mNRcI5OtxsnGZ8/4WFPt3CubCXPFVPTMySDlP4ffJ1v8PueLxhmgyhZggRQPNdle2UdwvrDfzyoQP2PB3ZCDOawue6EUGF3cSfxWBtifITA3GNG5JVKTDZu2nUtuvJaNeK3rN/RTtPCZH+jZ2OZAhB0LxWqT9bt52/XKtkJB12SHAic2ge2hJDEuMBYxZ+AE+6GwGS28qraHOTIKVplszDFcrlM2O8ye7DDuYD/LKozb1Zx3AsB+MJgMjYY4z067BUgg8GcrfBZin2w+H5XVZHdAJtutTMQOCBzGOZNt52TzOR52TTZqUnHkWwmxBSl6BuA8caP1qtaHUSV+xmr/Q96X3cTPlNDFFWT553DG1RBYTMaYLt7+e6gXJ9nr+vIiYqjRCD0bO1hh3FCWToaSRdWbXzhwCnSoMuwxzqiB8yXGwiiF1ps3nJbEUoskKwfNrS6b1WSHNNdwPV4ow3Y1550CK4dkUVBBmtVkl6Eia1X/Crp4iE62wky20Su4vfdIr9RVoya79ZzsKDPZQDkCJxsOL4K3QZYtBdXGK+yabBEnW5ZtZq3L499RwpmPsQ1bKV+GLq672Fi0Sl0SPvNytuiabP9o7xNdgyGTSlnSxZlIkMKMH8uiauGzSAEnRd64kTuUYJAha+DHKDIy2TVbBxTZBDtnC86pk1AMq8kOkVrKFKYlHa3ZgjUdvlNgVbeZL1dd67EBPAb+tZXBxcQcQ6zJ9jL2jmuxzfdIrzV+LMPYFe/1YmWQVmoI+hjBuLjoHgTZI5u9dypJfdmUlNNb9EnzVZHJho2E/SNMdXHuZMOBtQoaLos5+slkq6H8IhAw2BNNPXY9k+1Wk11u/0Cll/3WCNR4q8n2Ut6jsQw9GzsAdpus6qgfHDwcCNb133rzi2tNtnQmG052oeRLmZ5FWO2cbEalTnk2qMLMZAPIfMjQxUF1RnTZig7fKbBySETrbnnJghVlHErOYdLFQWHGficr9KRa/KlVgM8nm1Vj97daa81MdshCfM0lGSL3WqRtnizgjLm1plLJdBtkbbz8ZbKxh2PvCLumF9derdVY+zArMGXoZPQ12RhPBASiglGT7UIXD7FUrJVs/7LHc9GJcaghBj0bOwDYdGyFzxQaAKDz4Jy0Uv7VfbLDAe9jHWQGAa1eFov+AjRGm5eqg5Ntf5jjb8412RV2IIcFWbo4rh0BqU4unzAy2U012RLGvpX4GVdyDrP+ldfkywS2Orkm20tmBMEXjGncjWcrnYEoemTLqnyr7JHdnJ0Vhd+A/2BPmnI+M9lwcvsiaBMHxhZEMO2CEn4Fajll2C5TLorcYjlaJxt0cZdSuE5og+hF+MxrAFeri/uHno0dALtIptfeebKUcWzu2OT9qFFriN9/HDSimTWjLl+eLg74Ocycan1YXZxDJhsGCSjldkBAKcyAjixluNPrse1auBlOdtKzwB/P2oVJF+c1+SrqsjuhnjDtIZO9UCrHPovtVJMddj12s4EdNl2cZ2dFM9k4q3CZfs4T7KewMfysw4UCypSimWfDPRmaXiha/s1rFpKDB6f81GXDhkPQJCplcR7QhB3rFCxgZ3/Mg3FhoqtB+MxbTTbWpoiAIoD1d8+TUx6utH2hZ2MHwEr4QsXBZmf8Nmd1uIOvI4zxy6zhAJetA1XiZDvQkJDpHXDMZDvXZKMuK8xMttHGSTyL0sntuxyFz0rixj6c8WbGDH+9sDOHTGFcmZPd3nukQT+syvcublUnuxadkw0DOwrhs3omW5C+zW0TP4FRBBQwR/xQxhciymS7iZ+pUBfHunNif4ncG8xlCMxFadvYaXF00h7qpVWq10BNvd2moJM9vVikp6cXpd+nnaFnY6dksps2Jr5oVG9IVr2ycYhC90VvfuFk1qwCHVaAQQh7V9a44Y6QH2fGqY8rMr1OmWzUQGP+2mUtmJOdClP4LMV6d4uC9QB3CCJ0AmA0Ngf+QP/uTnuni2M+YUq6qZPHVfzM6JPd3nukF7XaIDKtYbEzjJrsCDPZAgENoyY7qdxpREmRWw0tANsE987vuoVWhx/KOAK3UQVznOj1Khguq/syNGWTKRcBAgAIbkc1l/l8xjxxcrJ1WaK1neWVLs5tPFHKOGy3gQ5n6TVDz8YOAOuT2HTY4mesH9WbJoyhZuNXt+8KF6zFkUAbLz4nZMemWxVd3CKTDYMLh6hTpreetSisNEpAa8LrhumswMnCNQsfRC50+E6AVf9NqUx2eiVFG+MehRFoiA3679HbCfWEXpSOjUx2/A036z7Z/kSr/EBE+IyJIlVqyoXPsP/2ZJJClHE4RipKySC25ieTHaWwl+Fkly2p0Kyu3+e+MNxrT0cXAVgJUdZji4qfwX7QZYnLgOYStlusMS+ZbAS+sH2J6mholt5KtPeJrmErfBaUQccy2U3GbyfUGsaujZdAJttroGWZLp5QLoCEbAJeFyInTkBU3aoum0e5QS0LC6y3c8JQpxXBXKHU8QcRcwCaa7JZn2xxunizseW31Y2/cgH/6r2doIzrRUgH66oV6OJG1ihONdnuInM4J3B5qp1ss+PoBqPziP/399PGC+MEJ3tVX4aiAK4dCuNWlG5mP/mcQ6t6u2hy3kcAYiHa9l0NbbwcEgi6i00j+N6Ds9Xr2chsNcF6fkO0trNtm2bo2dihwmdBiJ7ZCRJpCk+4sAp0WMFroAWOAJwkv707MSWbI/eimzTaX1kZJIx6mPJPPQxK/ArrDg5Zx9PFU4iwL4+90Wak5kv4DA5FJJlsVpPtL5ONz4+l0O7BSINVJedkB6F+HQTQqmtlJjvcvu0ibCEz8gFS8UXFz1QF4VEv7NXJRpYXe1JUDgLOqwGb+8Vqsn3aT6t6Dbq4V4XxqNt3NSiMu9Vkt3mgUgZ8XfkJQDu1W22GFnVdCT0bOwCgzzRT9BhFKwDH1yqL2gk0yDjBoOyLZbK9HkjIxPrJfnDDs9ngFqUbIfJvncmuhJrFlq3LRe02AhStUGMaJIwWbstjj/kK/9iNwWCmDa6oyWb7TCKaTLbPFl710o2IHLI4ZVebgXXVCuuleU4DcLqjGlIRaj7TQQgogCEqfqbKMTIy2SVPjuTUQolW90XrRNqJn6kIHuK1UUrlVfwMte7xcLLt6eJeNWbaGUgA8HIVr2ejDPtoFqK1Hc7Sa4aejZ0qfBY2XVxHF0ODlficfasrbxvvCw9eT+sGsuQVdoIaRvsu900a0VJs6JaiZ5E42SmaF8hmoo6806niVuUCMvXYdplsg5ob/thzFoOfPrSlci10BkZcs6tmwDGAI9gKdPFkIsEov81zMrJMtkAGKghlcY5BwV7ZTPBPgS3Sn0lTbanftSyQ5UW2N0oM9650squKHEfsK3CSpxfkKePY22ArRNm+q7Em2zpwxG1c7WQ3ggdovO5DVoKOVsB5jL1dxH7rJOjZ2DEtvFYKnwVBF4fBiU3Q3FePiVG0OQ0yTrByQKzA5oDXjVfBoW8lqGG07xJwsrut23hFpdBs1OWKZbI1nWqplZNpj8gX5TJqED7D083Bw6hEpuCk4FqcaIxu6JSSGlnhMziB6Ewhqjoft5rscpQ12Us9cp0gG9ySAZw67Hdu16CK6YYzhQVfPYifTc4XmQJ3lLBSGOfzScUcgviZF4VxsBEg1On3zFdGF7epyWbiXgpU6tsN3M73k8kWCYzCdgOTVbNWG6HvRgcAxhvOucYaSG+S/m7gxpC5h60Wo4hC7VigPhh1OhEyDHgPx5XK22KZbGS4VpRBsEx2KrZ0cYie6UivUb/aQBcvi4ueAQikYEsxz3NDhTcRyTzG9fhp4xVU+U7cIJJdNQP3lAkLtoDhbNAqqxaZ7Ij6ZFvsr5bt0QLKZGM9Y124ZbNVCv55ET9DQgA12XBCowQy/8hkmxkxPAitIklhtPGSD0DgmuIgeuZGFzcYk/HfJ6LYB3Augjru9fkie7aux7ZG+5/qGnUHN4ysD4whbITmekkjk62nWljgPYTd6KtRMwxYVstklOJ6kZ0WoVPjM+L5zXXZLCMYUSZbRPyK9ciOAe0uaqSbHBIvxj5rVWcyuKJq4SUz/nYw2hwmOmLcsS2J1vgZ86I11otdTXaU6uJu9xmMp6Bqsp3qjIOa+4b4WUk6UwsHJGo6NBhcWBvmumkkQzCvvDpIzQrjXtp4IUgSh3psN+EzQ0BP25nNwPzxk+QSrcnW7busoWdkBwCOLxaaWWE8yDrp5kyqFj4LF3BWagL01agZBs2bN+YMpmifYE9c1sariTJeKEUlfJYSzGTraK8VtdYw9pPSBhdo5lG38AJE1eU7uX0XwAO7opTxhVJrtO+yM0ajdLIhohclXXxZ/KwcWqkEHGWRtmHNVHHUY6twZP3aaYNNddMqu8AgUw/6vkgp2YpMdndMnGyXmmxtZ9pnsr1CtCYbCQRt26yEnpEdqjDOHN+ABFmaxc8MA7L9szRxAYw6ZAbcjH4WJY/wUGoWQYIDCoNa1ChF1LTZyY4uk23Q150ivjKZ+naHVYBFPpOdbChLQWY8skw2a+Pljy7eCSU12G/gy8i0hGmV8go2p5vYQ1HpBLDrsagRD5MuDgz2pN0z2QqD8CyTLamgjTrlqJXF7TL/RgmMmnuDcxG11SJt1Zoz/fHJZKNPdqWjA5WygIPdFVYmu0X26jChZ2SHIJNKNdLFmYMVzOFvtNepNBmQrZGN6KS6bETJo6SoNgvzyNb0WGeyo3FWWN1oAjWk9gYenDB8XKjgdjqMLFtzJlueLm7eZ9ieFhldXKwm39HR6BAD0aBVi2WykdWD6nIrIH6ZbGfhM9QiIysYpJNtJebVDJWsOpTiIJApWo4ATM6XIlcWt7tf7N4onD/4nMjciwLlOIvFaoyc7BTbK83CuhzFcjA6Q60OJDP82HnwE5pbrdrpzegEwkroGdkhaFZ1DbJ+pbmFlBakCB8YAzdaWNTZs+aaQVDZZLJWVr2y8ZmyARqNdgDV0I0ybLQnS7WEiFMYWTZzTbaXfr1ceyAOSs6ivent0En1hFYq3HFureSnPVk56hZeDsZxXbldskxDBqAZz7k4vcbcV7NuGRMqkRDuBw12kZHJzsQzk62YbbZKUmEc19KTMYQd4wBeCmZFGY+KxdbumWzsX25BKwRNEYwZyMYjGBMnxHpGVioV+uAHP0hbt26lnp4e2nfffekjH/lIg6ATvr/kkkto48aN7DGnnHIKPfroo5FedxyBzcecyTbUbBOhGJydZEC2Uq/sqGvlsXmbI6SsfZdEJLQ/u5IaiMh7FDXZItlMXKumUy1nshHzw/6Nr7yH2tDmQFLUNdm+MtkdInwm0ysbQSmMaVyyaF4y2ci4ReRjLwUz7DPZOB/gYAdZi4ygKe6LkxiZqj7ZAD4Lsmki/bn5noz9Jy41x0O9qGFfVhhn5QYK9wWwQmR6ZaO+PS73BkCAGvuklcK4tjPtmUN+An0pgZpsJEjwPkHqO7QqYj0jL7/8cvryl79MX/ziF+mhhx5iP3/yk5+kL3zhC/XH4OfPf/7zdPXVV9Odd95JfX19dOqpp1I+n4/02uMGHGJm4TMYOYFmss012WUtfBY2ugUya0GK33nJZIu27+JAVnihUF7Rkz2qaDayKPMOdHHd4mIZPOOMIAuMbAxht+S4GV0MzHTxqGuyvauLR80qiWOv7OnFEgu6RTWm3gSC4pPJ5oEsK2ptGPXYHHDS7OqA4UyqtkUYw0kwkz01b7Tuigu7CArjAA8eq9bOWdWXYQEIUTo9xi1uQS4w1awy2Z0UqJTBviP9dOCGgUC7FMwVtdaMHWJ9qt922210xhln0Itf/GLae++96RWveAW98IUvpN/97nf1Dfqzn/0sXXzxxexxhx9+OH3jG9+gHTt20A033BD15ccKcKbMWUPVEdJmGifPouKAh6HRKQZkXIB+5aDvOEElTU9FCy9W0yPjZC/VNi8szTU4WTAqo5prbnRx3eJiGbx2Goc3HGXMBVlaJGPMNLQlDE7MUeRasL+K1hp3sjIuy2QLGPlwgFqFKg7wYIDZII26hRdgd6+Dbt8l0saLB/5VBkYhfiaayebK4nGB0Uqsi2aWss2qtXNwvmI+ioqfxUn0rFH8bOU+W+igQKUMMJ8QXFHZmrCVBSrDRqxn5PHHH0833XQTPfLII+zn+++/n37zm9/Q6aefzn5+/PHHadeuXYwizjE0NETHHnss3X777ZFdd2wz2Wa6uEKKlpMgET9EdYQxfsJnzLCPisvIjNLlWh9e0yPjZCP70Jtdrsvm0e2o6OJ9bnRx9MjWNUv1sYPvgWCfl3psHkgyZ7KZQxPRPoPrx3bKAz6y6CjhM9CYBYIRccyiiQSOzNRKI5OdiM31mOFF0d+7mFfZdt6Dra4ywIQ2XthrW01Z3CoogSC0attJpi4bwQq0FYudk21FF4+QxdbpQVHZBEknIdZ35cILL6RcLkcHHnggpVIpVqP9sY99jM455xz2dzjYwPr16xueh5/536xQKBTYFwfeA6hWq+wrjsB1IXPv9fqw9+RK5frzkcXEGRzE580uGVH5YplthgmqBfZenQAvY48xWCwuj7cVMAdg20Q1LqlEjeZLFfb+c/kSJRI1yqYTUtfTl0lSbrFIIwMZypfKBJuR1/mGje50gn0Ou+vH33ozyVivA7/7jAywJxTLFZovlNi9k31PlH+VyhUqlsosC47XSlI4125n/M3nS9TvoS6tUC4TtCGjnhthjD98BoyV23tMzhVoy+qeyO+JKHDO1WpVNie5InS5Ypx/UX2GZKJGRWSsLZwPlNqgE4jMtXmZHwPZFP11d8HyOQWsXcVnUF8mxc4EkdecmCvQYZsGYzXHBrpTNDVv3C+MnewYuWGoJ83W1tY1vY6Pg32AMwvjx98/zPPBDhkb2wZ7CvaWOI1lOwB7CPY0p/uKYMzGoW6l974a4VxT+Z6xdrL/53/+h6699lq67rrr6JBDDqH77ruP3vWud9GmTZvo3HPP9fy6l112GV166aUrfr979/9v78yjoyrPP/5MkslkT0hIAkFAVESrFNyPqFUrVlul0sWKu611AT0KVrH4cz+uWJdKbdU/RNt6al2x7VFsXVstWrequCBVQVTIgGSfTCaTub/zfYcbJpOZySSZufedeb+fc4aEmcmdO/d97vu+z75Z21xuDHpbW5sSuoIReB872oKyua1H/FURZZWCYaHla68EsmT56+rslA1fbRJEmXR3dYrf78/K55jASMYe3l3/163i9yfe8CP8BzLQmkUZGIr21m7Z0tUr/so+2dQekkgwMGw56Q10yufBLqmSgGzuDEnQRVnrCvRK89ft4vcXJNywbGlplUBboYS79LW2j3aeGQ6Brg7Z1OyRrYFe6e4Oi98/PI8NzrGjo0M2bGxWG+uW1jZp3WqJJ+iO5yUU6JQNG8PiCZYM+2+3trRJW4tHrO6ivB//zvYOCXcXSF1h8rUWUQlfbt4qe9SK+EMdkitg3dvUvFkqfNF5t7WtXbZ+XSRBlwoCYe3d2OyXYII2aBs3t0ljZbH4/aGsykeop0++3Nwim5rR5nDgPY75v7szs3M2Ipr8W1vlq41FKUOtu0J9srW1XUKdXvEH9Im06+3qkQ3+gNqrbdnaLlW+IvEXpz9GQ2EFg7Jua1AmlqYOGW8J9Eow0CXtLV9LuwvrQzICHZ3S2S7S4N3uKAObt7ZKe2VEikJ6ed5zndaOkGxtxT2afLy/9G+V2sIK8Xu6M/a5ERdlDfsKI5TsSy65RHmz582bp/4/ffp0Wb9+vVKSoWSPGzdOPd/c3Kyqi9vg/zNnzkx63CVLlshFF13U/38oGxMnTpT6+nqpqqoSHYHAIV8H5zgSgQsWBaQ10iENDQ0qb7SyskcmjGvMWsGPhrqwVNTUqt/rWkV9LnFu7KsRCrgpLGPqxiYMxbNloCmLMjAUHdIpwcKAko1Wq0OaIj5paKgf1jEm9pXIls6QNDSMVTJeH/S6JmuVoT55298ndWPrB+VhIvevbkxYdmiKzlm6Mtp5ZjjUbuqTmtoaCRYGpaQCc8SYYR+j4auwVNbUytgKn5R+3iPjGhtcCzEe314gZWXF0tAwvDUEdStKy4PSNK5BVajP9/Ef2+1VUQypxhv3S21Nr+y4w/Z1PRcYUxOSMXV1KiQX0VyVlUEZ39jgSltBULsxLDW1tdJQNdjw4/NHZEJjlTTUpvZojlY+VPXu5rCUVdUOCj3ubemWuq7CjM/Z+N4lVWNStubasDUgOzR4ZPy4gZGQblNa1StrWjfJ2LH1UtHqkYbqEmloGHnhqni8FSFZ1+kf8pp3bumSiY1FA97n5PqQjHHhElUUsaGhbsDzmP+bGhu0C2/PdTylPVLeUZBUXnB/F37eI5MnNGa0En3ERVkrKRm+oTwnlexAIDDo4iJs3Hblo7UXFG3kbdtKNRRmVBmfP39+0uP6fD71iAef5dbEkQ4QuJGeIxZ5eLDxt33Sp8Iri4qyt/Bjs9gTjhZ9wWfrfF1zgeGOfamvQOU8h/osFW4WT9hCsanCrMrAUHiLClWhMnynQG9ELY7DlZOq0mLZ0NKt/g7y7aaslfk86pr39FlSEXddA+ghWVKcE/fBaOaZ4YD8uYiFdiyWal0zks8rKS5SMo6/xbGKi9wb//ISryrENtzP742gX3GB+LxFWshHtscfYwRvY6rjtwXDUlvu0+J6DAesq5ZEr58VQb5xgZrn3PoeuNaIJkv0+SgUVeYb/n03EvmoKS2Wjp4+qSkfuO/qxZydhetTXVasPNVjK5Mft7U7LHUV+skY1jQYvrt6I2rsMj2njSnzqW4OWHNT5dF29vRJtTqXAlfWh1Rzfm9naMDnw1CJ+V+XOTSf8KaYQwC6aliWZ9v+JrMOG49LspbJz9NayZ4zZ47KwZ40aZIKF3/77bfltttuk5/97Gf9A4Dw8euuu06mTp2qlG701UY4+dy5c90+fW0Ln6mKlVkW2mjl3z71uaZUzdW1+BmqrSZu3+VuiFxsawiEtzdUDTZ8DQU2CXaRGxTQcqvomT0fRfslD27V1cHCIEkL32GeaPSOzHIc7ZUd6S+k5Wa7J7Rw87cPDGFMh2wUf9IZ3PddPalz3tDLFz19c43YYo72TzdlEkp/osrA0d70Ecf62trFvCY6VPCvMo3iZ1sDIZlQUyq6gXUkWiyuN3p9MjwvQBHC8VG9P9WahPFqHMGa7EbhMxbYzfY+LTJEZXEU/uS1T4TWuz70w4bSvGDBApWzA+X5nHPOkSuvvLL/PYsXL5auri45++yzpbW1VQ4++GBZuXJlRt39+dPCa3vRs2xXslVtvEJ94in2GLN51A14CIJJ2nhF23e5Oy74fHgy7PZWO/nKh30MtMTCRgRVprHQuqlk20pfoKdPpDJBj2y270rQVzhaVX6kVY4RpYGxt6ufulXJGZR5i6S7NzDsvzOpfVf8fZ+M1kBIJtcNfz7QqVc2fmJYoTS5dj4oQprgWkPBRm1IJ6qLA0QpJWqrhXUoG11OELaK9lNDydgeTXqmB+J6QcnNVqvVmm0VxiemSBXAeO3aWCG6gTk/vk+2Xch3uG0gSXpzGlQHGOYSzWXo6U4HQnK0vjKVlZWqDzYeycCgX3vttepBkoOFDDcKrOtKwcryZhSLNxY5bKhM2kDmShuv3nDmLeTDBZZP20LaOcKJGt8BijX+Hr0z4cFwk7Ikbby6QtHQRDJYARhNv178Hbwa/Uq2izJdUlyQsk+6rv3qnSbad3VoT/aMibnoyfZI3zbPMX7Cs+0maNFoG9djwbqAdA2nvE/wnH7RMtgABcNocRYiqrAOfNmavAgT7lMY93TqkR1L1NPcm7WowzHlXmlOEXWDfSLW1Ezm2GbSeRDfJ1u1pGX7rqxgzxFYYxOtU8qBQCU7KZRKQ7CtxZiM4PnL9mbU7pWdrUWUpBtKm3jTH9JgYx/dAEaVLGwmykc4UcNDjIk+KmvuTmllPhg2wol7ZNOTPWjxxnwEr8RIPWrRXtkRpdBkw+MzXAMLlJfhto/DNXA7AkOnvqtQgCATNTlYwMiOzgB9KAjk8rBGDZmJPNnO9Mge4FnuRu6mNai3cTaMvUiRSuQ5jw0Vryotct3QPFR4fbYMcDAuwJOfjI5gr5Kdka7J2aTEG50/Yg112QirJ9v3aSDRPNLvIOHeJimUSkNAHg42AFBEwg4oWConuxc9Q80KhdQJbKKSebKxEXR7XJQnsy9qMcfCOdLzqfQVqWMoa7bL3wl5uV0IF48BRVng3aa1dyAYb4wbGKmSCbmBwtCLsEqXc8LKvIUqBBfz3nDQIXXDjfs+GQhjhUEqF0M/Y5Va/HTbkw0DdzJPdmmxc+eG8YxYlipGFku2lCN8nm3ATQTykWs19WLbSjYUXSiT2bgPUO8A61R8brMNFHwdvdgAazyilmNDxk2bQ53WHXC9E80jo4lCNAVKpUGg0BVulKgXM8uFz7blZNPC6B5QQHQPF7cX9NFYzJUnG+Hi4b6EldSdzsuNDxdHqLhnmwJOBo4/IhAgpyOtShqNmIlsU2jcVbLxHWAswHgPB9PmyGiaQCTvip7Fe+mVguSyTBYmiRrA2jzSFI2R3huYpzHXx5It5QjHhBEhWfEztIgbk6K9l9tAaUFPcRjtsiFDCLlGsSrca4nAOLnVCnEokCIKRTtWye4xLBrInbzsJJ5shounhFJpEMWFhcrbF3ZgU4eNMyY+WJJN2kDqhFJAkuSIOmFoGQr787HQwxs9UjDBY6JHnpbrnuwE4eIwAMCI4GYBJF0X7mgUQ+Go01Ki+WLuzzMwpAw3L9s0L4ydJpIMhLHqmis7FHBc93uyVU62yx0cChJ7sp0OFwd2xexYVIpPlmS/0hf1BieLlkjVQ9ttsFYgnB1ka27APYbrkAiE9tufryPR4md9xs6huhRQtNO9GC6eHEqlQSBEHJNRtipWxudK2q2L3FZ8TMVuo6ZrsSVsQKF3tnWHMuLJVtXFHd44JlayIipE3IaVxZN7/VQboVEp2VFjHtJS3FZohio2mAzT6lZEw8VTeLI19qKlI9O2kq3WWZdlEopHotD8aLi480p2vCdbVdbPkuwna+MFAwNCpXU35Kge1Z7stYBTSnZX7nmyExU/02E/k8/EtiaMBfsuXHeMB0kMtR+DQFEoLGqhsJV1xdcOnYTC4XY/ZlOxewgnKsTkRDRDOmADAU/2aJRQeCwQoo2v6bZBB9cchoNAjKKFFhej8dTnK7ahb1Se7G2LOxZ7txWaVNXlU2Fa3Qp8V+zXYg1RNngO3k6dQ3mHms9sjw82pSNNg8h2aD6iLZz2ZCPH16lwcbv4WSIlG95brDduF8kcCii52TQcIiUjkScb9yAiAPRWsgeGi0eNNXqPZy4T25owFjgQWNA1NZRKg4ACEnLIkw1sS7lJG0idKElRiEmX8CpYQXF+o8npgTcTXwX7Ebc3Tgjzgzc7EJOXS092YmylGOM3UqDEYMy7oGRrIM/xY58OOqRuuDHuKFYXD5QwjGl5jtYviM1dRHVxtw0/yULzuzUJF1d9srM0Z2Pzn6hXtsrHzoGcfyjB2VzPYMjCeMR7KGEUhqFY5zzbqJLd50jaAdlmPEwQfYRI1Qqf/veSm1AqDQKWPiy42eq9GI+9iLut+Jg8MeLaJ6qwqsuiZFffHc2CDsUWE70ucga5D8RUGGf1zcTYc9Bow1ahpOviyVbh4szJTq/vagLlD6HiaN2Vq/ULop7sSP/3czuFAcb0ZC28Shw2ZNgVv+37A+eFfXu21qGqUq8ycMZHciFySvdQcTC+ukQOm9aQteNjTYJ8xkcXQPFGFIDO9yDSwgZWF7e0Wf/zEThDEnmykXZBB0JqKJWmebIRLu6QgmWHgeqgzJlKsjZeamOvQRi/t8CjPNCjrbytU/hffMgwq28mptAOFx9lPhf+Xhclu2wkOdlhy6jKuNi8J2vjhfDVXA0VB1BabAc9lEgnjNmpwHWOL3wGDyCectqTjUiT2Arj9nlly8CEORfRBPH3IzzZOhc9i71Psh2ynaj4me752P2e7JgIPR3ad5qZkw1PNvc2qaBUGgQWMyxseDBc3Ow2Xrp4z7DxKstA5e0KX6E2xTdiK4zbla+5EA3GVopH78lGiHafI3NaWlEM9GSnV4QzUbg42ndpvsEfOncx+r2g4Lk9rKqlWJwxIxiKFmRzQ+aqYpRsGPtxCtny9uO4MHrF5mVDGcP/c0HJdoIx5V5VzT/ek627ko05f1B1cYMMla7MawmMoriXmJOdGkqlgYXPnCp6pfrfZrE6Jkm/X3nCPtkue1nsyTsTRcFgkddFkcXGDmFU9iKEfq065Avrm5M9+nBxRITaqQduAoMB5lfMs+liYmXcZJ6R1u6Q1ORAKG8yCmNzslXvdrfbJA4ufNbtQqj4gLzsbXnSThT8Q7G12DxwKJSYn53sEa4zNQkqjGN8cN1092TH1poxcQ51Kw0mtkAeDMq67Lt0xf1dCXG88JlTExIUPF1CeE0Fm6lYiy9AjprqK6xBuDi8j6Np32WzU32FHLhznehAmXd7uHg0H1vvDYtb2KG0oyl8Fv376IZZh3BxRFPgPIaTl21iZdziBGHMiPpANwrdvWhDeo7tFl6q9onbfbJhzBhYyd2NomcD2ngF7HDx7Bv70eu5PcaTvTXH0xGyHS6OvQF6ZOt+Dw4qfMZwccdzsrtCYcHsNtpUv3yHUmkQUKowGTmxuNlW0obKkqx/DhnKkz1wMwtDC9AhRBWLfEOlT/KJ2HBx5mMnp6S4QOorfaMO87eVdB3CxW3DVmDb+A8FvJ3Yu5i2QYSHNz78EAWpyn25bZhFnYGBnmz3C5+B2NB8N9p3xRYj6w8Xd8CTHW3j1TswHzuHIyUyDZRpyCmMwaAr1KfSHHQPAY4tfAbDAAufOR95BJmBg0TnAnk6oPedRDIKNnK2h8WJDSkm8IOnjs3655DhFT6zN7c6KNl7TqiWfEMVvwpFlPeIlcWTA+X6yG80ZuQ4wO0iUzZoP5WuJ9sOK9fhXnS7f7MqepbjClBsP1nVKtNtJTumkrs9DSlPdrE78oYwZChHiFqAsTfbBf+gLMbmZCM0euKYsqx+Zi4BIxAMHy1dIbVOwQCCa+Z2f/ehgNwgRQjzpyX67GfylWh0VpySzdakaUGpNAiEJNobAB3ycYlDLYXilGzmL2UXVLuGcRfXXSnZXIiyik7h4sMtfpbt4k+6kqh/MzzZ6A2cy0RzsiPaeLL7K7nHeKFU+y6XPNnwNsIIibxfJwr+wZPd1RNWBk/0+cXnsuhZ8pBx5K/rno8NIDe4tRAyjnkE6y2VbGdqTcT2U89EPZ18h1JpEHZIIn7obqkkmVP4gnEbftXCjaFVWQP3FhQt5CyxxUX2scPF3VZoUhm2ktFr6L2YqIVXW3fue7ILPdiMijZKdn8+ZZ8e4eL9xc+6bSXbk/WoEtAZCqse7NgDZaIGSL5VGG/ZliefC+27bHxe5GVHHCmgZzowYMd3g4Anm/fS0FAyDVSyOSGZlfcKL0ZskSGncvJNBooWwhQRNq57fluuYysMush0fJ/0VJjYvitRCy94GuHJrs51T3ahXp5sdU4xxdi2h4u7p2SjGBmUOSfaLsGTH83LDquQaHqxBwPDlt3GKxfad8WmCUHJptMg+6A7Sl+cUZSpcOlByTTMwwaLFNsJmQMWIuzzYj1rtPxmn/LiIvG396j7je1isgvmM1xnHRSa7Tn56RU+U630DLwX4wvpQAkqgEKU45s2yCHsmXYHBx3qBHjhhYr1ZLtYXXy7JzssobDlSMG/aF52ryp6xsrig0GKBlpOIvQaxg/kaOdKBFMPcvtVZXE95v58JbbWRKwnmw6EoXF/BSCOVxjnhGQW8FogD8+GOdnOXHN/R5D52A6x/5RaGaOJF3Q44eLKC2Ogkl0Up/ghJxRe7FyvVGsbeqJV4y3RQMdWRig7NB9h4/jdTcOfXWHcqSgOu/gZZIyVxRMb4lHVf2NrUEW5VeXImmV7sk2NBnIzJxv7SSjd9GQPDSXTMIoL0ceVw24S2FAFY9p4MVzcGW8mvANchJxhx7Hl2kTo2G3zYnsTJ8PUDSK+c2xONvJla3LEg5YKe23FBjTaJ7tAq0ruMP7ADuCqkl3iVekUgVDYEWMvwsWRioAH8o9J4nar677uUsq2LvNoOhXGoexxP+OUJ3v7HhJGK3QoyBVZcRNeIcPAoqZLP1niThsvUzf2TlJeHFWu6ck2DzsUNx1vtqlRJfEtvJATmg+hvLGebF1ysmMrubudjw2g4ENBgtLrxDoEz+yWzh41FjR6JgZRQJvagjmTjz0gJxvh4szJdiwapr9H9rY9DkkNJdMwMBmZGJ5oMvHhq6Zu7J3E3sjmeo4pGWF1+eKCtIqfYYOY7eJPudDCS7XvyqENfjr5i9GcbI9WldwR0aRDjQgocwj0yHafbNuTjZ7KKPCV6+kI2QLXBuORK/nYsdXFkXJDp4Gz4eJoi0cHQnpQMg0DCjZDPMxr44W2LTZclJwJFwdciMyk1Fs04J5LhrE52TGKHwouwSCR65XFYzekMJ7Yv+tUyd3tomc29lg7sQ7B4Al5y4dIiWxhX5vc8mRvL3zmhLHGZGzDIQo62uHilb7ckRU3oWQaBhYcHRZZ4hzwqsUWPsPmlkp2dsE9hs0t8g+JeagK42mFi1tGhjrGhovDi41cUIR/5st3g+FA/a6Bko28cNsLpUO4OLDnRaeiOOCpra/wOfJZuQjC6FGtO5f61LPwmTtpMP3tu+hASAteJcOYsUON26dA3Ch8xnBxx0OGf7DXBEaNGAoUGRR2GgpT2+lB8bM92ao/dg550HLNkw2lv2tb4UtEV+jQdsceb6fWocOn1XMuHoLvz2jKqWukPNn9Srb791k+YxsLVQpMIZTsXtY3SJPcuaNIxjb/eBBzYOEzd8ilDQvJvKfui5buAcatRJi6QRzoyQ7llAdtKAo98GRHVBVvHXKAYw0akEcdcrLRmxnKvlOpEpyL8+8aIScbxizca9zPOCMb8GSjDSC6Z+hgrMsFKJmEGOHJ3t5SKGRoiCohTjG1oUIpji985O8PHU6EqTnZKHyGNtmYk1pQ9CxP8rFt7zU2/jp4sRO18NIhXBxr0pwZTVoYIUhuYqeXIHSZOdkO5WX3Wao1KX7XwViXC2gvmV9++aWccsopUldXJ6WlpTJ9+nR54403+l9HIv6VV14p48ePV6/Pnj1b1q5d6+o5E6ITdg4+Nn4mh6gS4hSIFpq1c52U+4qUom2HDyesLm7gvWi3kYSRoR09svPIk43vhnHVpVXmgBZeIT0KnxEyWmDEsgsomjiHumWs60CoOL3YaaO1ZLa0tMhBBx0kXq9Xnn76afnggw/k1ltvlTFjxvS/Z+nSpXLnnXfK3XffLa+99pqUl5fLUUcdJcFg0NVzJ0SnDT8svXbIuKkhqoQ4fd8dvMtYZfF/YY1f3XexwEBsbOGzbV5e5GNbYuVVq7vCAuSK9qmfOmArIogagKEVBa4IyQdsD7aJbRDdauOlip7l0XydbbS+UjfffLNMnDhRli9f3v/clClTBmxS7rjjDrn88svluOOOU8/9/ve/l8bGRlmxYoXMmzfPlfMmRDew0YeSjUkSUeO0/BLijKJ9yNR6+efHm+XFNZsHFGCyvYsm3osIE4aivaWzRxXByqc6IfheyH3WobJ4rAfKNrKipSMh+RIyjvBlE1Nu3Kjt0AslO8jK4sNB6yv1l7/8RXmljz/+eHnppZdkwoQJsmDBAjnrrLPU65999pls2rRJhYjbVFdXywEHHCCrVq1KqmT39PSoh017e7v6GYkgbzVxWJ/b4LxgVND1/IjeY+8r8kgg2Cs9pUViWRGBI5uyROLhPJN5oGodtHOtvLR2i/JoHzp1rFK0e3rD2+5Ffa63k+OPfbG/PSjVJUXafP9M4BFLukNhNcY6fC/M9aFwn3T19Kp1QCTq1R4JnB/MRrfxLy70aDeH5iuYr3vDfSq9Z0JNSdavd8RFWcvkZ2qtZH/66afyu9/9Ti666CK57LLL5PXXX5cLLrhAiouL5fTTT1cKNoDnOhb8334tETfeeKNcc801g57fvHmztqxk6XAAABVkSURBVGHmGPS2tjYldAWahKGR3Bn7nq4O+SockIIen3R2dsrXWzZn/DxJ7sN5JnvsXmPJvz9rk7+90SYHTK6SzlCfdHd1qnXHxPEPdHZIS2tEdmssF79/6J7iuUJ7W6dsbu+RCl+h+P3ue7Ph6dva2i5fbLSkJxAQv98/4mNxfjAb3ca/u7NDurt6tJpD85XO9jbxF/bIl/6A1BVViN/Tnbey1tHRYYaSjYu87777yg033KD+v9dee8nq1atV/jWU7JGyZMkSpbjHerIRll5fXy9VVVWi67VAiB3OUYfJjeTW2I/vKVY9Dqtry6WuJiINDQ0ZP0+S+3CeyS7fH1svL368WT5uL5DdxlVL3RjR6l50cvxr/RHVvmvnHRqkoaokq5/lJPVBr7SEO6WuqkQaGurdPh0Vul6xsVdKK2tkXGR058T5wWx0G//GoFdChd1azaH5Sl2rR6qqS6So3SOTJzSqNpX5KmslJSVmKNmoGP6Nb3xjwHO77767PPbYY+r3cePGqZ/Nzc3qvTb4/8yZM5Me1+fzqUc8GEgdJo5kQOB0P0ei59iXFhep/EekgRZ7CylDJCmcZ7JHSXGBfHu3Rnn+o2b5z7oW8Wl4Lzo1/sVFheLxFMiYcp9212A0eIsKxRKPKsakw/cqLsKYFkigt0/KfEWjPifOD2aj0/iXeIu0nEPzEW9hoXSF+iAAUlVS7EgdDY9LspbJz9NaMlFZfM2aNQOe+/jjj2Xy5Mn9RdCgaD/33HMDvNKoMn7ggQc6fr6E6AratqB9C1rLII+JEOIOqCZ++G4NqliPyQV7UBistLgg7/qt2v2xdemTbZ9HezDM9l0kr8DcYfIc6vQ8gm4QZcUwaugxt+UCWnuyFy1aJLNmzVLh4j/5yU/kP//5j9x7773qYVs5Fi5cKNddd51MnTpVKd1XXHGFNDU1ydy5c90+fUK0obS4UILhyLb2XVyUCHG7Ku4RuzdKMJw/ucgjqXqdT/2xY6vwgkKPR59K7oUe6QiGZUJNqdunQ0jGmFRbJvWVg6NSSebBHAIlu6Ysu2Hi+YbWSvZ+++0nTzzxhMqhvvbaa5USjZZdJ598cv97Fi9eLF1dXXL22WdLa2urHHzwwbJy5cqMxtQTkg8W32CoT7UNopJNiB4ebRN7ZNvAA1VVkn+eVdtzjE2pLngLPdLVQ082yS9Mn0OdjjzqCUfYI3uYaH+1jj32WPVIZaWFAo4HISQx2Fyh8FlAtZbRZ/NHCDGTvSaNkXyMOtweLl6glXcdrY7yLTSfEOJshA57ZA8PXi1CDADWXjiwETKInBpCCHGTfPVAweMT+1MXT7adNkQIISM1Hlb6GC4+HPJzlSOEDAJejPZgL8PFCSHEkMJnsV51hosTQkZjqKMne3hwt02IQUp2ZzBMJZsQQrJEkYZKNlKEsEnW6ZwIIbmDPXcwJ3t4cLdNiCHAixGxtlskCSGE5L8n21tQwFBxQsiocrJZaG748GoRYgj2JouebEIIyXJ1cc082QwVJ4SMlOpSr0wZW+b2aeQc3G0TYgj2JstLSyQhhJjjyaaSTQgZBdVlXtlncq3bp5FzMLieEEOw27cwXJwQQrLb6kYnJbupplT6kCtECCHEMahkE2JYuHgxw8UJIcQYT/b46lK3T4EQQoyDu21CDKFkW5g4c7IJISTbfbI5zxJCiMlwFSDEME82iuAQQgjJPAUFHoGerZMnmxBCiPNQySbEEMqKi+TQafXiK2IBHEIIyRbf2rVeqkqYjUcIISbDVYAQg5hQw9w8QgjJdqExQgghZkNPNiGEEEIIIYQQkiGoZBNCCCGEEEIIIRmCSjYhhBBCCCGEEJIhqGQTQgghhBBCCCEZgko2IYQQQgghhBCSIahkE0IIIYQQQgghGYJKNiGEEEIIIYQQkiGoZBNCCCGEEEIIIRmCSjYhhBBCCCGEEJIhqGQTQgghhBBCCCEZgko2IYQQQgghhBCSIYoydaBcxrIs9bO9vV10JRKJSEdHh5SUlEhBAW0jJsGxJ05BWTMbjj9JBeXDbDj+xARZa9+mC9q64Wigki2iBhJMnDjR7VMhhBBCCCGEEOKiblhdXT2qY3isTKjqeWAx+eqrr6SyslI8Ho/oCCwrMAJs2LBBqqqq3D4d4iAce+IUlDWz4fiTVFA+zIbjT0yQNcuylILd1NQ0ai86PdlITC8okB122EFyAQgbJzcz4dgTp6CsmQ3Hn6SC8mE2HH+S77JWPUoPtg2TKgghhBBCCCGEkAxBJZsQQgghhBBCCMkQVLJzBJ/PJ1dddZX6ScyCY0+cgrJmNhx/kgrKh9lw/IlT+PJE1lj4jBBCCCGEEEIIyRD0ZBNCCCGEEEIIIRmCSjYhhBBCCCGEEJIhqGQTQgghhBBCCCEZgkp2HDfeeKPst99+UllZKQ0NDTJ37lxZs2bNgPcEg0E577zzpK6uTioqKuRHP/qRNDc397/+zjvvyIknnqgaqZeWlsruu+8uv/71r5N+5iuvvCJFRUUyc+bMIc8PKfRXXnmljB8/Xh179uzZsnbt2gHvuf7662XWrFlSVlYmNTU1aX/3d999Vw455BApKSlR57506dIBr7///vvqu+64447i8XjkjjvukHzC1LHHdzrjjDNk+vTp6lzwveN58cUX1ZjHPzZt2pTWZ5D8krV169bJmWeeKVOmTFGv77zzzqpISSgUGvLYkKW9995bFTTZZZdd5P777x/w+j//+U+ZM2eONDU1KRlbsWKF5Bumjv/GjRvlpJNOkl133VUKCgpk4cKFg94DeYifZ7AmmUSuywf4/ve/L5MmTVJjh/edeuqp8tVXXw15bM4P5o4/5wfnyQdZs+np6VHHhEz897//FR3mGirZcbz00ktKmF599VX5xz/+Ib29vfKd73xHurq6+t+zaNEi+etf/yqPPPKIej8mjh/+8If9r7/55ptKWP/4xz8qxfT//u//ZMmSJfKb3/xm0Oe1trbKaaedJkcccURa5wfF984775S7775bXnvtNSkvL5ejjjpK3QQ22Ogcf/zxMn/+/LS/d3t7u/qekydPVud/yy23yNVXXy333ntv/3sCgYDstNNOctNNN8m4ceMk3zB17Pv6+tTkdcEFF6gJLBWYfLEQ2g98V2KerH300UcSiUTknnvuUZ99++23q/dedtllKY/72WefyTHHHCOHH364WgSxifr5z38uzzzzTP97cA1mzJghd911l+Qrpo4/NkH19fVy+eWXqzFORlVV1YB5Zv369WISuS4fAPf4ww8/rNaMxx57TD755BP58Y9/nPK4nB/MHn/OD86TD7Jms3jxYqUQp4Njcw2qi5Pk+P1+VF+3XnrpJfX/1tZWy+v1Wo888kj/ez788EP1nlWrViU9zoIFC6zDDz980PMnnHCCdfnll1tXXXWVNWPGjJTnEolErHHjxlm33HJL/3M4H5/PZ/3pT38a9P7ly5db1dXVaX3P3/72t9aYMWOsnp6e/ucuvfRSa9q0aQnfP3nyZOv2229P69i5iiljH8vpp59uHXfccYOef+GFF9T3bGlpGfYxSX7Lms3SpUutKVOmpDz24sWLrT322GPQuR111FEJ34/v+8QTT1j5jinjH8uhhx5qXXjhhRmbu/KZfJCPJ5980vJ4PFYoFEr6Hs4PZo9/LJwf3CFXZe2pp56ydtttN+v9999X5/b222+nPLZTcw092UPQ1tamftbW1vZbbGDpifX47bbbbiosZtWqVSmPYx/DZvny5fLpp5+qMLt0LS8Iz4397OrqajnggANSfnY64O+/9a1vSXFxcf9zsBbBCtnS0iImYsrYDweE4iBs58gjj1QhPyQz5IOsJfrsePD38dESmGeclGEdMWX806Wzs1NFVSH88LjjjlPeEZPJdfnYunWrPPjggyqVyev1Jj025wezxz9dOD9kj1yUtebmZjnrrLPkD3/4g0qVTAen5hoq2SlAOBxCCA466CDZc8891XMYcCii8fmujY2NSfNT//3vf8uf//xnOfvss/ufQ07BL3/5SxVegdyEdLCPj89K97PTBX+f6Lixn2sSJo19OkCxRrgOwr7wwOJ22GGHyVtvvZX1z8538kHW/ve//8myZcvknHPOGfLYiY6LdJXu7m4xEZPGPx2mTZsm9913nzz55JPqvHF9sDn/4osvxERyWT4uvfRSFd6JXM7PP/9cjelQx+b8YO74pwPnh+yRi7JmWZaqKXTuuefKvvvum/Z3dWquoZKdAuQprF69Wh566KERHwN/D0sbLDfIc7BzYFHc4ZprrlEFHhIBqx8KDNiPf/3rX5Ip9thjj/7jfve7383YcfMJjv3ghQ0b6H322UctaFjk8BO5mMRsWfvyyy/l6KOPVrUAYE22iT0uFkCSGI7/QA488ECVs4eomUMPPVQef/xxlaeJ/G8TyWX5uOSSS+Ttt9+Wv//971JYWKjGNRp5yfkhXTj+A+H8kD1yUdaWLVsmHR0dKgc8GW7ONemZEwzk/PPPl7/97W+qutwOO+zQ/zwKfqG4FJL3Yy07CFeILwb2wQcfqOR+WHNQyMEGAvHGG2+oyQefY1uQMPnAwoMJCZUZERJhM2HCBFXgwf4seBZjPzudKn02Tz31lAr/ACh4ZX+v2GqB9nHt10zCtLEfKfvvv7+8/PLLozqG6eS6rKEACgqHwOASWyQRxFb3RKGaVPMMXh+tPOYipo3/SEB46V577aW85aaR6/IxduxY9cDGGhWHEQGFAktQlDg/DI1p4z8STJ4fMkmuytrzzz+vQrxRITwWeLVPPvlkeeCBB9yda4adxZ3nINH+vPPOs5qamqyPP/540Ot2EYBHH320/7mPPvpoUBGA1atXWw0NDdYll1wy6Bh9fX3We++9N+Axf/58VWQMv3d2dqYsAvCrX/2q/7m2traMFj6LLUqxZMkSowqfmTr26RQ+S8Ts2bOtH/zgB8P+DJIfsvbFF19YU6dOtebNm2eFw+G0vjeKjey5554DnjvxxBONK2xk6vinU9goHhwb57xo0SLLFPJBPuJZv369Oj8U0UwG5wezxz8Wzg/OkOuytn79+gHHfeaZZ9S54Xw3bNjg+lxDJTsODDyUkxdffNHauHFj/yMQCPS/59xzz7UmTZpkPf/889Ybb7xhHXjggephg4Gur6+3TjnllAHHQNW+ZKRTaQ/cdNNNVk1NjarU+O677yqFCBVdu7u7+98DoUNlvWuuucaqqKhQv+PR0dGR9Li4kRobG61TTz1V3SwPPfSQVVZWZt1zzz3970HlcftY48ePty6++GL1+9q1a618wNSxB6jIiPfNmTPHOuyww/r/zgYGlRUrVqixxnfE4ldQUGA9++yzQ543yT9Zg4K1yy67WEcccYT6PfbzU/Hpp5+qeQULMSqU3nXXXVZhYaG1cuXK/vdAVm35w8J22223qd8h2/mCqeMP7LHdZ599rJNOOkn9jvnHBnMXNkqffPKJ9eabbyolvqSkZMB78p1cl49XX33VWrZsmRrbdevWWc8995w1a9Ysa+edd7aCwWDS43J+MHv8AecHZ8l1WYvns88+S6u6uFNzDZXsOHAhEz3gGbTB4KI8PTy/GCR482I3FxCeRMeA93e0AgfLzhVXXKEUYlhzsMlZs2bNIG9kos8fyoL4zjvvWAcffLA67oQJE5RwJxLe+AcsjvmAyWOP80v0dzY333yzWiCxmNXW1ipFHBMuMVPWcJ7JvsNQQBZnzpxpFRcXWzvttNOA72y/nui4kO18weTxH+qcFy5cqDZ0kA98/ve+9z3rrbfeskwi1+UDm2G078Fagdd33HFHtVGHQWYoOD+YPf6cH5wl12VtpEq2U3ONB/9kLvicEEIIIYQQQggxF1YXJ4QQQgghhBBCMgSVbEIIIYQQQgghJENQySaEEEIIIYQQQjIElWxCCCGEEEIIISRDUMkmhBBCCCGEEEIyBJVsQgghhBBCCCEkQ1DJJoQQQgghhBBCMgSVbEIIIYQQQgghJENQySaEEEIIIYQQQjIElWxCCCEkTzjjjDPE4/Goh9frlcbGRjnyyCPlvvvuk0gkkvZx7r//fqmpqcnquRJCCCH5CpVsQgghJI84+uijZePGjbJu3Tp5+umn5fDDD5cLL7xQjj32WAmHw26fHiGEEJL3UMkmhBBC8gifzyfjxo2TCRMmyN577y2XXXaZPPnkk0rhhoca3HbbbTJ9+nQpLy+XiRMnyoIFC6Szs1O99uKLL8pPf/pTaWtr6/eKX3311eq1np4eufjii9Wx8bcHHHCAej8hhBBCtkMlmxBCCMlzvv3tb8uMGTPk8ccfV/8vKCiQO++8U95//3154IEH5Pnnn5fFixer12bNmiV33HGHVFVVKY84HlCswfnnny+rVq2Shx56SN599105/vjjled87dq1rn4/QgghRCc8lmVZbp8EIYQQQjKTk93a2iorVqwY9Nq8efOUYvzBBx8Meu3RRx+Vc889V7Zs2aL+D4/3woUL1bFsPv/8c9lpp53Uz6ampv7nZ8+eLfvvv7/ccMMNWftehBBCSC5R5PYJEEIIIST7wKaO0G/w7LPPyo033igfffSRtLe3q1ztYDAogUBAysrKEv79e++9J319fbLrrrsOeB4h5HV1dY58B0IIISQXoJJNCCGEGMCHH34oU6ZMUQXRUARt/vz5cv3110ttba28/PLLcuaZZ0ooFEqqZCNnu7CwUN588031M5aKigqHvgUhhBCiP1SyCSGEkDwHOdfwRC9atEgpyWjndeutt6rcbPDwww8PeH9xcbHyWsey1157qef8fr8ccsghjp4/IYQQkktQySaEEELyCIRvb9q0SSnEzc3NsnLlShUaDu/1aaedJqtXr5be3l5ZtmyZzJkzR1555RW5++67Bxxjxx13VJ7r5557ThVMg3cbYeInn3yyOgYUdCjdmzdvVu/55je/Kcccc4xr35kQQgjRCVYXJ4QQQvIIKNXjx49XijIqf7/wwguqkjjaeCHMG0ozWnjdfPPNsueee8qDDz6olPBYUGEchdBOOOEEqa+vl6VLl6rnly9frpTsX/ziFzJt2jSZO3euvP766zJp0iSXvi0hhBCiH6wuTgghhBBCCCGEZAh6sgkhhBBCCCGEkAxBJZsQQgghhBBCCMkQVLIJIYQQQgghhJAMQSWbEEIIIYQQQgjJEFSyCSGEEEIIIYSQDEElmxBCCCGEEEIIyRBUsgkhhBBCCCGEkAxBJZsQQgghhBBCCMkQVLIJIYQQQgghhJAMQSWbEEIIIYQQQgjJEFSyCSGEEEIIIYSQDEElmxBCCCGEEEIIkczw/8zbKi3v6E3oAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1000x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# --- Serie temporelle : datetime, .dt et resample ---\n",
+    "import numpy as np\n",
+    "\n",
+    "np.random.seed(42)\n",
+    "dates = pd.date_range('2024-01-01', periods=90, freq='D')\n",
+    "ventes = pd.DataFrame({\n",
+    "    'date': dates,\n",
+    "    'montant': np.random.randint(50, 200, size=90),\n",
+    "})\n",
+    "print(\"Donnees de base : 90 jours de ventes.\")\n",
+    "print(ventes.head(3).to_string(index=False))\n",
+    "\n",
+    "# Accesseur .dt : extraire des composantes de la date.\n",
+    "ventes['annee'] = ventes['date'].dt.year\n",
+    "ventes['mois'] = ventes['date'].dt.month\n",
+    "print(\"\\nAccesseur .dt :\", ventes[['date', 'annee', 'mois']].head(3).to_string(index=False))\n",
+    "\n",
+    "# Resample mensuel : moyenne du montant par fin de mois ('ME').\n",
+    "resam = ventes.set_index('date')[['montant']].resample('ME').mean()\n",
+    "print(\"\\nMoyenne du montant par mois :\")\n",
+    "print(resam.round(1))\n",
+    "\n",
+    "# Figure : la serie quotidienne vs la moyenne mensuelle.\n",
+    "import matplotlib.pyplot as plt\n",
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "ax.plot(ventes['date'], ventes['montant'], alpha=0.4, linewidth=0.8, label='quotidien')\n",
+    "ax.plot(resam.index, resam['montant'], marker='o', linewidth=2.0, label='moyenne mensuelle')\n",
+    "ax.set_xlabel('Date')\n",
+    "ax.set_ylabel('Montant')\n",
+    "ax.set_title('Ventes quotidiennes et moyenne mensuelle')\n",
+    "ax.legend()\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8e0d107",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003433,
+     "end_time": "2026-08-23T03:01:23.705119",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.701686",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Lire un vrai fichier CSV\n",
+    "\n",
+    "En pratique, les données arrivent dans des fichiers (`read_csv`), pas en dict Python. Deux arguments font échouer la lecture **sans message clair** :\n",
+    "\n",
+    "- `sep` : le séparateur. Par défaut la virgule, mais beaucoup de fichiers exportés (Excel FR, certains logiciels) utilisent `;`.\n",
+    "- `parse_dates` : dire à pandas que telle colonne est une *date*, sinon elle reste une chaîne.\n",
+    "\n",
+    "On écrit ici un CSV, puis on le relit avec ces deux arguments, pour voir les symptômes que l'on serait tenté d'ignorer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c8e0d108",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:01:23.713159Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.712778Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.737913Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.737417Z"
+    },
+    "papermill": {
+     "duration": 0.030279,
+     "end_time": "2026-08-23T03:01:23.738628",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.708349",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fichier ecrit : ventes_sample.csv (separateur ';')\n",
+      "\n",
+      "Lecture SANS sep ni parse_dates :\n",
+      "  colonnes obtenues : ['date;montant']\n",
+      "  date;montant\n",
+      "2024-01-01;152\n",
+      "2024-01-02;142\n",
+      "  -> tout est dans une seule colonne : le separateur n'est pas le bon.\n",
+      "\n",
+      "Lecture AVEC sep=';' et parse_dates=['date'] :\n",
+      "      date  montant\n",
+      "2024-01-01      152\n",
+      "2024-01-02      142\n",
+      "  type de 'date' : datetime64[us]\n",
+      "  nb de lignes   : 90\n",
+      "\n",
+      "Fichier temporaire supprime : ventes_sample.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Lire un vrai fichier CSV : sep + parse_dates ---\n",
+    "import os\n",
+    "\n",
+    "# On ecrit d'abord le CSV (separateur ';'), comme un export Excel FR.\n",
+    "csv_path = 'ventes_sample.csv'\n",
+    "ventes[['date', 'montant']].to_csv(csv_path, index=False, sep=';')\n",
+    "print(f\"Fichier ecrit : {csv_path} (separateur ';')\")\n",
+    "\n",
+    "# Lecture naive (separateur par defaut ',') : la colonne n'est PAS decoupee.\n",
+    "df_naif = pd.read_csv(csv_path)\n",
+    "print(\"\\nLecture SANS sep ni parse_dates :\")\n",
+    "print(f\"  colonnes obtenues : {df_naif.columns.tolist()}\")\n",
+    "print(df_naif.head(2).to_string(index=False))\n",
+    "print(\"  -> tout est dans une seule colonne : le separateur n'est pas le bon.\")\n",
+    "\n",
+    "# Lecture correcte : sep=';' + parse_dates=['date'].\n",
+    "df_csv = pd.read_csv(csv_path, sep=';', parse_dates=['date'])\n",
+    "print(\"\\nLecture AVEC sep=';' et parse_dates=['date'] :\")\n",
+    "print(df_csv.head(2).to_string(index=False))\n",
+    "print(f\"  type de 'date' : {df_csv['date'].dtype}\")\n",
+    "print(f\"  nb de lignes   : {len(df_csv)}\")\n",
+    "\n",
+    "# On nettoie le fichier temporaire pour ne pas laisser d'artefact.\n",
+    "os.remove(csv_path)\n",
+    "print(f\"\\nFichier temporaire supprime : {csv_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8e0d109",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003254,
+     "end_time": "2026-08-23T03:01:23.745263",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.742009",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les trois exercices suivants mobilisent les notions des sections jointures, données manquantes et série temporelle. Complétez-les dans les cellules ci-dessous."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8e0d10a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003178,
+     "end_time": "2026-08-23T03:01:23.751743",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.748565",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : joindre et diagnostiquer les NaN\n",
+    "\n",
+    "Fusionnez `clients` et `commandes` (réutilisés plus haut) avec `how='left'`, puis **comptez** les `NaN` introduits par la jointure (clients sans commande) et affichez les lignes concernées."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c8e0d10b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:01:23.758722Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.758528Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.761927Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.761469Z"
+    },
+    "papermill": {
+     "duration": 0.007804,
+     "end_time": "2026-08-23T03:01:23.762618",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.754814",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 4 a completer : creez la jointure left puis comptez les NaN.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : joindre et diagnostiquer les NaN (a completer)\n",
+    "# Etape 1 : fusionner clients et commandes avec how='left' -> 'fusion_gauche'\n",
+    "# Etape 2 : compter les NaN (fusion_gauche.isna().sum()) -> les clients sans commande\n",
+    "# Etape 3 : afficher les lignes ou 'montant' est NaN (clients sans commande)\n",
+    "\n",
+    "fusion_gauche = None   # TODO etudiant : clients.merge(commandes, on='client_id', how='left')\n",
+    "\n",
+    "if fusion_gauche is None:\n",
+    "    print(\"Exercice 4 a completer : creez la jointure left puis comptez les NaN.\")\n",
+    "else:\n",
+    "    print(fusion_gauche)\n",
+    "    print(f\"\\nLignes avec montant manquant : {fusion_gauche.isna().sum().sum()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8e0d10c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00338,
+     "end_time": "2026-08-23T03:01:23.769142",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.765762",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 5 : moyenne mensuelle par resample\n",
+    "\n",
+    "À partir du DataFrame `ventes` (dates quotidiennes sur 90 jours), calculez la **moyenne mensuelle** du montant avec `resample('ME')`, puis affichez uniquement les mois dont la moyenne dépasse un seuil donné (par ex. 120)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c8e0d10d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:01:23.777113Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.776741Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.780309Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.779767Z"
+    },
+    "papermill": {
+     "duration": 0.008343,
+     "end_time": "2026-08-23T03:01:23.781037",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.772694",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 5 a completer : calculez le resample mensuel puis filtrez.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 5 : moyenne mensuelle par resample (a completer)\n",
+    "# Etape 1 : resample('ME').mean(numeric_only=True) sur ventes.set_index('date') -> 'mois_moyen'\n",
+    "# Etape 2 : filtrer mois_moyen[mois_moyen['montant'] > seuil] avec seuil = 120\n",
+    "\n",
+    "seuil = 120\n",
+    "mois_moyen = None   # TODO etudiant : definir le resample mensuel\n",
+    "mois_forts = None   # TODO etudiant : filtrer les mois au-dessus du seuil\n",
+    "\n",
+    "if mois_moyen is None:\n",
+    "    print(\"Exercice 5 a completer : calculez le resample mensuel puis filtrez.\")\n",
+    "else:\n",
+    "    print(mois_moyen.round(1))\n",
+    "    print(f\"\\nMois au-dessus de {seuil} :\")\n",
+    "    print(mois_forts.round(1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8e0d10e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003803,
+     "end_time": "2026-08-23T03:01:23.788465",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.784662",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 6 : lire un CSV et filtrer\n",
+    "\n",
+    "Créez le fichier `ventes_export.csv` à partir de `ventes[['date','montant']]` (`sep=';'`), relisez-le avec `pd.read_csv(..., sep=';', parse_dates=['date'])`, puis affichez les lignes dont le montant dépasse un seuil (par ex. 150)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c8e0d10f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:01:23.796819Z",
+     "iopub.status.busy": "2026-08-23T03:01:23.796531Z",
+     "iopub.status.idle": "2026-08-23T03:01:23.800137Z",
+     "shell.execute_reply": "2026-08-23T03:01:23.799681Z"
+    },
+    "papermill": {
+     "duration": 0.008816,
+     "end_time": "2026-08-23T03:01:23.801090",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.792274",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 6 a completer : ecrivez puis relisez le CSV et filtrez.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 6 : lire un CSV et filtrer (a completer)\n",
+    "# Etape 1 : ecrire ventes[['date','montant']].to_csv('ventes_export.csv', index=False, sep=';')\n",
+    "# Etape 2 : relire avec pd.read_csv('ventes_export.csv', sep=';', parse_dates=['date'])\n",
+    "# Etape 3 : filtrer les montants > 150 et afficher le resultat\n",
+    "\n",
+    "seuil_vente = 150\n",
+    "df_export = None   # TODO etudiant : lire le CSV ecrit\n",
+    "\n",
+    "if df_export is None:\n",
+    "    print(\"Exercice 6 a completer : ecrivez puis relisez le CSV et filtrez.\")\n",
+    "else:\n",
+    "    print(df_export.head(3))\n",
+    "    print(f\"\\nVentes au-dessus de {seuil_vente} :\")\n",
+    "    print(df_export[df_export['montant'] > seuil_vente])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8e0d110",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003641,
+     "end_time": "2026-08-23T03:01:23.808685",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.805044",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Transition.** Ces quatre verbes — `merge`, `dropna`/`fillna`, `resample`, `read_csv` — sont le socle de la manipulation de données. Ils sont réinvestis dans le notebook suivant de la pile (2.1-Workflow) et, pour la partie numérique, complètent le notebook 1.2-NumPy (traité par un autre segment)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-ced13a1a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003344,
+     "end_time": "2026-08-23T03:01:23.815362",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.812018",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion\n",
     "\n",
@@ -496,23 +1337,48 @@
     "- Les résultats obtenus permettent de valider la comprehension\n",
     "\n",
     "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d autres domaines."
-   ],
-   "id": "cell-ced13a1a"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cell-042df0dd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003408,
+     "end_time": "2026-08-23T03:01:23.821954",
+     "exception": false,
+     "start_time": "2026-08-23T03:01:23.818546",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Références\n",
     "\n",
     "1. W. McKinney, *Data Structures for Statistical Computing in Python*, Proceedings of the 9th Python in Science Conference (SciPy 2010), pp. 51-56, 2010. Article fondateur de Pandas : structures `Series` et `DataFrame`, conçues pour le calcul statistique sur données étiquetées.\n",
     "2. W. McKinney, *Python for Data Analysis: Data Wrangling with Pandas, NumPy, and Jupyter*, O'Reilly Media, 3e édition, 2022. Référence livresque canonique sur l'usage pratique de Pandas (`groupby`, indexation, nettoyage).\n",
     "3. T. Wes McKinney, *pandas: a Foundational Python Library for Data Analysis and Statistics*, 2011. Notes techniques complémentaires sur l'architecture interne de Pandas."
-   ],
-   "id": "cell-042df0dd"
+   ]
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-23T13:00Z",
+   "network": false,
+   "notes": "Introduction à Pandas : DataFrame, Series, lecture CSV (pd.read_csv),\nsélection/filtrage, groupby/agg, merge/concat, opérations sur\ncolonnes (apply/map), gestion des valeurs manquantes (isnull/fillna).\nDataset CSV fourni localement. Aucune API externe, aucun GPU requis.\n---",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "vram_gb": 0,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -528,36 +1394,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.75982,
-   "end_time": "2026-05-13T08:18:13.909883",
+   "duration": 3.302949,
+   "end_time": "2026-08-23T03:01:24.177372",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb",
-   "output_path": "1.3-Analyse_de_Donnees_avec_Pandas.ipynb",
+   "input_path": "D:\\Dev\\CoursIA-12441-pandas\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\01-PythonForDataScience\\notebooks\\1.3-Analyse_de_Donnees_avec_Pandas.ipynb",
+   "output_path": "D:\\Dev\\CoursIA-12441-pandas\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\01-PythonForDataScience\\notebooks\\1.3-Analyse_de_Donnees_avec_Pandas_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-13T08:18:12.150063",
+   "start_time": "2026-08-23T03:01:20.874423",
    "version": "2.7.0"
-  },
-  "cost": {
-   "api_provider": "none",
-   "network": false,
-   "cpu_min": 2,
-   "api_usd_est": 0.0,
-   "metadata_written": "2026-07-23T13:00Z",
-   "vram_tier": "LITE",
-   "validator": "papermill",
-   "reproducibility": "HIGH",
-   "gpu_required": false,
-   "gpu_min": 0,
-   "vram_gb": 0,
-   "reduced_pedagogical": "self",
-   "external_account": "none",
-   "free_alternative": "self",
-   "notes": "Introduction à Pandas : DataFrame, Series, lecture CSV (pd.read_csv),\nsélection/filtrage, groupby/agg, merge/concat, opérations sur\ncolonnes (apply/map), gestion des valeurs manquantes (isnull/fillna).\nDataset CSV fourni localement. Aucune API externe, aucun GPU requis.\n---"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Résumé

Enrichit `1.3-Analyse_de_Donnees_avec_Pandas.ipynb` (série `01-PythonForDataScience`) avec les verbes Pandas demandés par l'issue, sous forme d'**exemples guidés** — solutions complètes, comportement **montré en sortie réelle**, pas seulement décrit :

1. **Jointures** — `clients.merge(commandes, how=...)` : les 4 variantes `inner/left/right/outer` comparées par comptage de lignes (3/5/4/6) + détail du `left` montrant les clients sans commande à `NaN`.
2. **Données manquantes** — `isna().sum()` diagnostique les trous, puis `dropna(subset=['Note'])` vs `fillna(médiane)` comparés sur la moyenne aval (15.17 vs 15.30).
3. **Série temporelle** — `df['date'].dt` (extraction année/mois) + `resample('ME')` (moyenne mensuelle du montant) + figure `matplotlib` quotidien vs mensuel.
4. **Lecture CSV réelle** — écriture d'un CSV à `;` puis `read_csv(sep=';', parse_dates=['date'])` : le symptôme du mauvais séparateur (colonne unique `date;montant`) est **montré** (sans lever d'erreur), puis corrigé.

**3 nouveaux exercices** (`Exercice 4` jointure + diagnostic NaN, `Exercice 5` resample + filtrage par seuil, `Exercice 6` read_csv + filtrage) — stubs `TODO` conformes à C.1.

**README** série `01-PythonForDataScience` : ligne `1.3` enrichie (4 verbes ajoutés) + objectif d'apprentissage n°5.

## Validation

- **C.1** : 0 occurrence de `raise NotImplementedError` / `assert False` / `1/0`.
- **C.2** : 15/15 cellules code exécutées (`execution_count` renseigné + `outputs` cohérents), 0 erreur, figure PNG présente.
- Exécution réelle : `scripts/notebook_tools.py execute` (papermill) → **SUCCESS** (~5 s).
- `validate_pr_notebooks.py` → **1/1 PASS** (15 cells).
- Aucun artefact `_output` committé (gitignoré `*_output.ipynb`) ; CSV temporaire supprimé dans la cellule (aucun stray file).

## Closes

Closes #12441

## Voir aussi

- See #12440 (1.2-NumPy, autre segment) — cohérence des cross-refs conservée.