### PR TITLE
fix(mgs,#12466): check d'API 7c/7d — RangeFor fantôme -> KnownFunctionsBounds.For, check bloquant, bornes mesurées

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7c-RosenbrockGriewank.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7c-RosenbrockGriewank.ipynb
@@ -58,153 +58,38 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       
-       
-       "\r\n",
-       
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       
-       
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '123960.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "RangeFor present: False\r\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
       "RosenbrockFitness charge: MetaGeneticSharp.RosenbrockFitness\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "GriewankFitness charge: MetaGeneticSharp.GriewankFitness\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Rosenbrock: range [-2.048, 2.048] (source canonique)\r\n"
+      "KnownFunctionsBounds.For present: True\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Griewank:   range [-600.0, 600.0] (source canonique)\r\n"
+      "Rosenbrock: range [-2,048, 2,048] (mesure via KnownFunctionsBounds.For)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Griewank:   range [-600, 600] (mesure via KnownFunctionsBounds.For)\r\n"
      ]
     }
    ],
@@ -215,17 +100,24 @@
     "using GeneticSharp;\n",
     "\n",
     "// Verifier que les deux classes sont bien exposees par le submodule.\n",
-    "var rosenbrockOk = typeof(KnownFunctionGenes).GetMethod(\"RangeFor\",\n",
-    "    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static) != null;\n",
     "var rosenbrockType = System.Type.GetType(\"MetaGeneticSharp.RosenbrockFitness, MetaGeneticSharp.Extensions\");\n",
     "var griewankType = System.Type.GetType(\"MetaGeneticSharp.GriewankFitness, MetaGeneticSharp.Extensions\");\n",
-    "Console.WriteLine($\"RangeFor present: {rosenbrockOk}\");\n",
     "Console.WriteLine($\"RosenbrockFitness charge: {rosenbrockType?.FullName ?? \"NOT FOUND\"}\");\n",
     "Console.WriteLine($\"GriewankFitness charge: {griewankType?.FullName ?? \"NOT FOUND\"}\");\n",
     "\n",
-    "// Echelles recommandees (tirees de KnownFunctions.cs, lignes ~190).\n",
-    "Console.WriteLine($\"Rosenbrock: range [-2.048, 2.048] (source canonique)\");\n",
-    "Console.WriteLine($\"Griewank:   range [-600.0, 600.0] (source canonique)\");"
+    "// Check bloquant : le porteur des bornes est KnownFunctionsBounds.For (KnownFunctions.cs).\n",
+    "var boundsFor = typeof(KnownFunctionsBounds).GetMethod(\"For\",\n",
+    "    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);\n",
+    "if (boundsFor is null)\n",
+    "    throw new InvalidOperationException(\n",
+    "        \"KnownFunctionsBounds.For introuvable dans le submodule : regression de l'API (cf KnownFunctions.cs).\");\n",
+    "Console.WriteLine($\"KnownFunctionsBounds.For present: {boundsFor != null}\");\n",
+    "\n",
+    "// Bornes mesurees depuis l'appel reel : la valeur affichee est une mesure, pas une recopie.\n",
+    "var rosenbrockBounds = KnownFunctionsBounds.For(typeof(RosenbrockFitness));\n",
+    "var griewankBounds = KnownFunctionsBounds.For(typeof(GriewankFitness));\n",
+    "Console.WriteLine($\"Rosenbrock: range [{rosenbrockBounds.min}, {rosenbrockBounds.max}] (mesure via KnownFunctionsBounds.For)\");\n",
+    "Console.WriteLine($\"Griewank:   range [{griewankBounds.min}, {griewankBounds.max}] (mesure via KnownFunctionsBounds.For)\");"
    ]
   },
   {
@@ -262,29 +154,29 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Rosenbrock dim= 2 - pixel(0,0) = Color [A=255, R=255, G=0, B=0] (PNG: assets/landscape_multidim_rosenbrock_d2.png).\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Rosenbrock dim= 5 - pixel(0,0) = Color [A=255, R=106, G=255, B=0] (PNG: assets/landscape_multidim_rosenbrock_d5.png).\r\n"
+      "Rosenbrock dim= 5 - pixel(0,0) = Color [A=255, R=117, G=255, B=0] (PNG: assets/landscape_multidim_rosenbrock_d5.png).\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Rosenbrock dim=30 - pixel(0,0) = Color [A=255, R=255, G=0, B=0] (PNG: assets/landscape_multidim_rosenbrock_d30.png).\r\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "\r\n",
       "warning CS1701: En supposant que la référence d'assembly 'System.Drawing.Primitives, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'MetaGeneticSharp.Infrastructure' correspond à l'identité 'System.Drawing.Primitives, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Drawing.Primitives', il se peut que vous deviez fournir une stratégie runtime\r\n",
@@ -351,29 +243,29 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Griewank dim= 2 - pixel(0,0) = Color [A=255, R=255, G=4, B=0] (PNG: assets/landscape_multidim_griewank_d2.png).\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Griewank dim= 5 - pixel(0,0) = Color [A=255, R=53, G=255, B=0] (PNG: assets/landscape_multidim_griewank_d5.png).\r\n"
+      "Griewank dim= 5 - pixel(0,0) = Color [A=255, R=255, G=18, B=0] (PNG: assets/landscape_multidim_griewank_d5.png).\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Griewank dim=30 - pixel(0,0) = Color [A=255, R=255, G=0, B=0] (PNG: assets/landscape_multidim_griewank_d30.png).\r\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "\r\n",
       "warning CS1701: En supposant que la référence d'assembly 'System.Drawing.Primitives, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'MetaGeneticSharp.Infrastructure' correspond à l'identité 'System.Drawing.Primitives, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Drawing.Primitives', il se peut que vous deviez fournir une stratégie runtime\r\n",
@@ -449,8 +341,7 @@
     "Charger Ackley-d2 et Griewank-d2, comparer le **spectre de fréquences spatiales**\n",
     "(transformée de Fourier 2-D du canal rouge). Le produit de Griewank doit montrer un\n",
     "spectre **plus épars** (fréquences dictées par $\\sqrt{i}$) que la somme d'Ackley\n",
-    "(spectre **continu**).",
-    "\n",
+    "(spectre **continu**).\n",
     "### Exercice 3 : rudesse du paysage et comptage des minima locaux\n",
     "\n",
     "Un pixel de la heatmap est un **minimum local** s'il est strictement inférieur\n",
@@ -494,22 +385,22 @@
  ],
  "metadata": {
   "cost": {
-   "api_usd_est": 0.0,
    "api_provider": "none",
-   "qcc_tokens_est": 0,
+   "api_usd_est": 0.0,
    "cpu_min": 1,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
    "external_account": "none",
    "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-03",
+   "network": false,
+   "notes": "Analyse de paysage Rosenbrock + Griewank. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln. Seed explicite (Random 42/7).",
+   "qcc_tokens_est": 0,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "metadata_written": "2026-08-03",
    "validator": "dotnet-interactive",
-   "notes": "Analyse de paysage Rosenbrock + Griewank. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln. Seed explicite (Random 42/7)."
+   "vram_gb": 0,
+   "vram_tier": "NONE"
   },
   "kernelspec": {
    "display_name": ".NET (C#)",

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7d-MichalewiczDixonPrice.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7d-MichalewiczDixonPrice.ipynb
@@ -70,144 +70,38 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '127524.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "RangeFor present: False\r\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
       "MichalewiczFitness charge: MetaGeneticSharp.MichalewiczFitness\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "DixonPriceFitness charge: MetaGeneticSharp.DixonPriceFitness\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Michalewicz: range [0.0, Math.PI] = [0, 3,1416] (source canonique, m=10)\r\n"
+      "KnownFunctionsBounds.For present: True\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "DixonPrice:  range [-10.0, 10.0] (source canonique, narrow valley non-scalable)\r\n"
+      "Michalewicz: range [0, 3,141592653589793] = [0, 3,1416] (mesure via KnownFunctionsBounds.For, m=10)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "DixonPrice:  range [-10, 10] (mesure via KnownFunctionsBounds.For, narrow valley non-scalable)\r\n"
      ]
     }
    ],
@@ -218,17 +112,24 @@
     "using GeneticSharp;\n",
     "\n",
     "// Verifier que les deux classes sont bien exposees par le submodule.\n",
-    "var michalewiczOk = typeof(KnownFunctionGenes).GetMethod(\"RangeFor\",\n",
-    "    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static) != null;\n",
     "var michalewiczType = System.Type.GetType(\"MetaGeneticSharp.MichalewiczFitness, MetaGeneticSharp.Extensions\");\n",
     "var dixonPriceType = System.Type.GetType(\"MetaGeneticSharp.DixonPriceFitness, MetaGeneticSharp.Extensions\");\n",
-    "Console.WriteLine($\"RangeFor present: {michalewiczOk}\");\n",
     "Console.WriteLine($\"MichalewiczFitness charge: {michalewiczType?.FullName ?? \"NOT FOUND\"}\");\n",
     "Console.WriteLine($\"DixonPriceFitness charge: {dixonPriceType?.FullName ?? \"NOT FOUND\"}\");\n",
     "\n",
-    "// Echelles recommandees (tirees de KnownFunctions.cs, RangeFor method, lignes ~244).\n",
-    "Console.WriteLine($\"Michalewicz: range [0.0, Math.PI] = [0, {Math.PI:F4}] (source canonique, m=10)\");\n",
-    "Console.WriteLine($\"DixonPrice:  range [-10.0, 10.0] (source canonique, narrow valley non-scalable)\");\n"
+    "// Check bloquant : le porteur des bornes est KnownFunctionsBounds.For (KnownFunctions.cs).\n",
+    "var boundsFor = typeof(KnownFunctionsBounds).GetMethod(\"For\",\n",
+    "    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);\n",
+    "if (boundsFor is null)\n",
+    "    throw new InvalidOperationException(\n",
+    "        \"KnownFunctionsBounds.For introuvable dans le submodule : regression de l'API (cf KnownFunctions.cs).\");\n",
+    "Console.WriteLine($\"KnownFunctionsBounds.For present: {boundsFor != null}\");\n",
+    "\n",
+    "// Bornes mesurees depuis l'appel reel : la valeur affichee est une mesure, pas une recopie.\n",
+    "var michalewiczBounds = KnownFunctionsBounds.For(typeof(MichalewiczFitness));\n",
+    "var dixonPriceBounds = KnownFunctionsBounds.For(typeof(DixonPriceFitness));\n",
+    "Console.WriteLine($\"Michalewicz: range [{michalewiczBounds.min}, {michalewiczBounds.max}] = [0, {Math.PI:F4}] (mesure via KnownFunctionsBounds.For, m=10)\");\n",
+    "Console.WriteLine($\"DixonPrice:  range [{dixonPriceBounds.min}, {dixonPriceBounds.max}] (mesure via KnownFunctionsBounds.For, narrow valley non-scalable)\");"
    ]
   },
   {
@@ -272,29 +173,29 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Michalewicz dim= 2 - pixel(0,0) = Color [A=255, R=255, G=255, B=255] (PNG: assets/landscape_multidim_michalewicz_d2.png).\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Michalewicz dim= 5 - pixel(0,0) = Color [A=255, R=37, G=255, B=0] (PNG: assets/landscape_multidim_michalewicz_d5.png).\r\n"
+      "Michalewicz dim= 5 - pixel(0,0) = Color [A=255, R=80, G=255, B=0] (PNG: assets/landscape_multidim_michalewicz_d5.png).\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Michalewicz dim=30 - pixel(0,0) = Color [A=255, R=255, G=255, B=255] (PNG: assets/landscape_multidim_michalewicz_d30.png).\r\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "\r\n",
       "warning CS1701: En supposant que la référence d'assembly 'System.Drawing.Primitives, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'MetaGeneticSharp.Infrastructure' correspond à l'identité 'System.Drawing.Primitives, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Drawing.Primitives', il se peut que vous deviez fournir une stratégie runtime\r\n",
@@ -370,29 +271,29 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Dixon-Price dim= 2 - pixel(0,0) = Color [A=255, R=255, G=0, B=0] (PNG: assets/landscape_multidim_dixon_price_d2.png).\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Dixon-Price dim= 5 - pixel(0,0) = Color [A=255, R=0, G=255, B=132] (PNG: assets/landscape_multidim_dixon_price_d5.png).\r\n"
+      "Dixon-Price dim= 5 - pixel(0,0) = Color [A=255, R=0, G=255, B=135] (PNG: assets/landscape_multidim_dixon_price_d5.png).\r\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Dixon-Price dim=30 - pixel(0,0) = Color [A=255, R=255, G=26, B=0] (PNG: assets/landscape_multidim_dixon_price_d30.png).\r\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "\r\n",
       "warning CS1701: En supposant que la référence d'assembly 'System.Drawing.Primitives, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'MetaGeneticSharp.Infrastructure' correspond à l'identité 'System.Drawing.Primitives, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Drawing.Primitives', il se peut que vous deviez fournir une stratégie runtime\r\n",
@@ -553,29 +454,29 @@
   }
  ],
  "metadata": {
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "qcc_tokens_est": 0,
-   "cpu_min": 1,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-08-03",
-   "validator": "dotnet-interactive",
-   "notes": "Analyse de paysage Michalewicz + Dixon-Price. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln. Seed explicite (Random 42/7)."
-  },
   "authors": [
    {
     "name": "myia-po-2024"
    }
   ],
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 1,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-03",
+   "network": false,
+   "notes": "Analyse de paysage Michalewicz + Dixon-Price. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln. Seed explicite (Random 42/7).",
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "dotnet-interactive",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",


### PR DESCRIPTION
## Résumé

Corrige le check d'API cassé des cellules de câblage de `MGS-7c-RosenbrockGriewank.ipynb` et `MGS-7d-MichalewiczDixonPrice.ipynb` (les deux committeurs de « RangeFor present: False » en silence).

**Vérifications préalables (première main)** :
- `grep -rn "RangeFor" MetaGeneticSharp/src --include="*.cs"` → **0 hit** (méthode fantôme).
- Le porteur réel : `KnownFunctionsBounds.For(Type fitnessType)` à `KnownFunctions.cs:236` (namespace `MetaGeneticSharp`), bornes Michalewicz `(0.0, π)` / DixonPrice `(-10.0, 10.0)` confirmées dans le switch.

## Changements (cellules `be70e72d` / `becac2e6` uniquement)

1. Check réflexif corrigé : `typeof(KnownFunctionsBounds).GetMethod("For", Public|Static)`.
2. Check **bloquant** : `throw new InvalidOperationException(...)` si le symbole est absent — plus de « False » silencieux (exigé par l'issue ; ne se déclenche pas sur l'état actuel, 0 erreur committée).
3. Bornes affichées **depuis l'appel réel** `KnownFunctionsBounds.For(typeof(XFitness))` — la valeur devient une mesure, pas une recopie :
   - Rosenbrock `[-2.048, 2.048]`, Griewank `[-600, 600]` (7c)
   - Michalewicz `[0, π]`, DixonPrice `[-10, 10]` (7d)
4. Référence fantôme de la prose 7d (« KnownFunctions.cs, RangeFor method, lignes ~244 ») supprimée — remplacée par la source réelle du check.

## Validation

- **Re-exécution réelle** : `exec_dotnet_persist.py` (.NET Interactive, kernel `.net-csharp`) → 2 notebooks × 3 cellules, **0 erreur**, sorties persistées sur disque.
- Sorties committées : `KnownFunctionsBounds.For present: True` (les deux), C.2 : 3/3 cellules code avec `execution_count` + outputs.
- `validate_pr_notebooks.py` → **PASS** sur les deux notebooks.
- Structure : 9/9 cellules identiques (ids + types), seules les 2 cellules de câblage ont changé de source ; stubs exercices intacts (TODO 2→2 et 3→3).
- **0 référence `RangeFor`** restante dans `Part4-Metaheuristics/*.ipynb`.
- **PNG assets inchangés** : la re-exécution régénère les heatmaps seeded ; les drifts d'octets `*_d5.png` (rendering drift du submodule, hors scope) ont été **revertés** — `#12456` en est le propriétaire.
- Submodule non modifié (gitlink identique à `origin/main` ; build local `dotnet build` 0 erreur pour produire la DLL référencée).

## Closes

Closes #12466

## Hors scope (issues sœurs)

- `#12456` : PNG `landscape_multidim_*` d=2 ≡ d=30 — fichiers non touchés.
- `#12457` : tell visuel MGS-7c jamais confronté aux images.