### PR TITLE
feat(training,#12438): robust correctness reward + reasoning-eval harness (PT_04/PT_05)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb
@@ -6,10 +6,10 @@
    "id": "11320909",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:07:32.803659Z",
-     "iopub.status.busy": "2026-08-17T10:07:32.803287Z",
-     "iopub.status.idle": "2026-08-17T10:07:32.806948Z",
-     "shell.execute_reply": "2026-08-17T10:07:32.806400Z"
+     "iopub.execute_input": "2026-08-23T03:19:50.994056Z",
+     "iopub.status.busy": "2026-08-23T03:19:50.993034Z",
+     "iopub.status.idle": "2026-08-23T03:19:50.997151Z",
+     "shell.execute_reply": "2026-08-23T03:19:50.997151Z"
     },
     "papermill": {
      "duration": 0.009759,
@@ -236,10 +236,10 @@
    "id": "6a374976",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:07:32.856795Z",
-     "iopub.status.busy": "2026-08-17T10:07:32.856563Z",
-     "iopub.status.idle": "2026-08-17T10:07:32.862928Z",
-     "shell.execute_reply": "2026-08-17T10:07:32.862408Z"
+     "iopub.execute_input": "2026-08-23T03:19:50.999155Z",
+     "iopub.status.busy": "2026-08-23T03:19:50.999155Z",
+     "iopub.status.idle": "2026-08-23T03:19:51.005486Z",
+     "shell.execute_reply": "2026-08-23T03:19:51.005486Z"
     },
     "papermill": {
      "duration": 0.014903,
@@ -255,7 +255,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Python : 3.13.3 (tags/v3.13.3:6280bb5, Apr  8 2025, 14:47:33) [MSC v.1943 64 bit (AMD64)]\n",
+      "Python : 3.12.13 | packaged by Anaconda, Inc. | (main, Mar 19 2026, 20:16:45) [MSC v.1942 64 bit (AMD64)]\n",
       "Plateforme : Windows-11-10.0.26200-SP0\n",
       "\n",
       "LOAD_MODEL_AND_TRAIN = True\n"
@@ -282,10 +282,10 @@
    "id": "ef8279d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:07:32.877346Z",
-     "iopub.status.busy": "2026-08-17T10:07:32.877124Z",
-     "iopub.status.idle": "2026-08-17T10:07:34.734336Z",
-     "shell.execute_reply": "2026-08-17T10:07:34.733589Z"
+     "iopub.execute_input": "2026-08-23T03:19:51.006501Z",
+     "iopub.status.busy": "2026-08-23T03:19:51.006501Z",
+     "iopub.status.idle": "2026-08-23T03:19:52.724399Z",
+     "shell.execute_reply": "2026-08-23T03:19:52.723685Z"
     },
     "papermill": {
      "duration": 1.865798,
@@ -301,7 +301,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CUDA disponible : NVIDIA GeForce RTX 3090 (24.0 Go)\n"
+      "CUDA non disponible (CPU uniquement)\n"
      ]
     }
    ],
@@ -351,10 +351,10 @@
    "id": "f940f039",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:07:34.760200Z",
-     "iopub.status.busy": "2026-08-17T10:07:34.759559Z",
-     "iopub.status.idle": "2026-08-17T10:07:34.770644Z",
-     "shell.execute_reply": "2026-08-17T10:07:34.769440Z"
+     "iopub.execute_input": "2026-08-23T03:19:52.726476Z",
+     "iopub.status.busy": "2026-08-23T03:19:52.726476Z",
+     "iopub.status.idle": "2026-08-23T03:19:52.740406Z",
+     "shell.execute_reply": "2026-08-23T03:19:52.739828Z"
     },
     "papermill": {
      "duration": 0.019887,
@@ -371,12 +371,21 @@
      "output_type": "stream",
      "text": [
       "Tests des reward functions :\n",
-      "  length_reward('short') = 0.12\n",
-      "  length_reward('a' * 100) = 1.00\n",
+      "--- length_reward : bornes visibles (sweet-spot) ---\n",
+      "  length_reward('short')    = 0.12  (< target_min=20 : penalise)\n",
+      "  length_reward('a' * 100)  = 1.00  (dans [20, 200] : 1.0)\n",
+      "  length_reward('a' * 250)  = 0.75  (> target_max=200 : penalise)\n",
+      "--- keyword / format (inchanges) ---\n",
       "  keyword_reward('Therefore, x = 2 because...') = 0.40\n",
       "  json_format_reward('{\"answer\": 42}') = 1.00\n",
       "  json_format_reward('not json') = 0.00\n",
-      "  combined_reward(batch) = [0.64, 0.05]\n",
+      "--- correctness_reward : cas pieges (#12438) ---\n",
+      "  '$1,234.00' vs 1234  -> 1.0  (normalisation devise + milliers)\n",
+      "  '0.9999999' vs 1     -> 1.0  (tolerance relative 1e-3)\n",
+      "  '42 km' vs 42        -> 1.0  (unite toleree)\n",
+      "  'x = 2 because' vs 42 -> 0.5  (extrait mais faux : 0.5)\n",
+      "  'Je ne sais pas' vs 42 -> 0.0  (rien d'extractible : 0.0)\n",
+      "  combined_reward(batch, answer=[42, 42]) = [0.82, 0.025]\n",
       "\n",
       "Reward functions pretes.\n"
      ]
@@ -386,8 +395,9 @@
     "import json\n",
     "import re\n",
     "\n",
+    "\n",
     "def length_reward(completion: str, target_min: int = 20, target_max: int = 200) -> float:\n",
-    "    # Recompense basee sur la longueur. Penalise trop court/trop long.\n",
+    "    # Recompense sweet-spot : penalise trop court (flemme) ET trop long (verbiage).\n",
     "    length = len(completion.strip())\n",
     "    if length < target_min:\n",
     "        return length / target_min * 0.5\n",
@@ -396,6 +406,7 @@
     "    else:\n",
     "        return 1.0\n",
     "\n",
+    "\n",
     "def keyword_reward(completion: str, keywords: list = None) -> float:\n",
     "    # Recompense si des mots-cles attendus sont presents.\n",
     "    if keywords is None:\n",
@@ -403,6 +414,7 @@
     "    completion_lower = completion.lower()\n",
     "    found = sum(1 for kw in keywords if kw in completion_lower)\n",
     "    return found / len(keywords)\n",
+    "\n",
     "\n",
     "def json_format_reward(completion: str, required_key: str = \"answer\") -> float:\n",
     "    # Recompense si la completion est un JSON valide avec cle attendue.\n",
@@ -417,38 +429,108 @@
     "    except (json.JSONDecodeError, TypeError):\n",
     "        return 0.0\n",
     "\n",
+    "\n",
+    "# ---- Extraction robuste (#12438) : devise, separateurs de milliers, unites ----\n",
+    "# Token numerique tolerant : '$1,234.00', '42 km', '22.2 C', '0.9999999'.\n",
+    "_NUM_TOKEN = r\"-?\\s*[$£€]?\\s*\\d{1,3}(?:,\\d{3})+(?:\\.\\d+)?|-?\\s*[$£€]?\\s*\\d+(?:\\.\\d+)?\"\n",
+    "\n",
+    "\n",
+    "def _to_float(token: str):\n",
+    "    # Ne garde que chiffres, point, signe : '$1,234.00 km' -> 1234.00\n",
+    "    s = re.sub(r\"[^0-9.\\-]\", \"\", token)\n",
+    "    if not s or s in (\"-\", \".\", \"-.\"):\n",
+    "        return None\n",
+    "    try:\n",
+    "        return float(s)\n",
+    "    except ValueError:\n",
+    "        return None\n",
+    "\n",
+    "\n",
+    "def extract_answer(completion: str):\n",
+    "    # Extrait la derniere valeur numerique en tolerant devise/unites/milliers.\n",
+    "    # Priorite : \\boxed{}, '####' (GSM8K), 'answer is'/':'/'=', fallback dernier nombre.\n",
+    "    boxed = re.findall(r\"\\\\boxed\\{([^}]+)\\}\", completion)\n",
+    "    if boxed:\n",
+    "        value = _to_float(boxed[-1])\n",
+    "        if value is not None:\n",
+    "            return value\n",
+    "    for pattern in (r\"####\\s*(\" + _NUM_TOKEN + r\")\",\n",
+    "                    r\"(?:answer is|answer:|=)\\s*(\" + _NUM_TOKEN + r\")\"):\n",
+    "        found = re.findall(pattern, completion, re.IGNORECASE)\n",
+    "        if found:\n",
+    "            value = _to_float(found[-1])\n",
+    "            if value is not None:\n",
+    "                return value\n",
+    "    numbers = re.findall(_NUM_TOKEN, completion)\n",
+    "    if numbers:\n",
+    "        return _to_float(numbers[-1])\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "def correctness_reward(completion: str, ground_truth: float,\n",
+    "                       abs_tol: float = 1e-6, rel_tol: float = 1e-3) -> float:\n",
+    "    \"\"\"Credit partiel (#12438) : 1.0 juste, 0.5 reponse extraite mais fausse,\n",
+    "    0.0 rien d'extractible. C'est le trou central que comblera ce reward :\n",
+    "    'Therefore, x = 2 because...' sur un probleme dont la reponse est 42\n",
+    "    ne touche plus que la moitie heuristique du melange.\n",
+    "    \"\"\"\n",
+    "    predicted = extract_answer(completion)\n",
+    "    if predicted is None:\n",
+    "        return 0.0\n",
+    "    if abs(predicted - ground_truth) <= max(abs_tol, rel_tol * abs(ground_truth)):\n",
+    "        return 1.0\n",
+    "    return 0.5\n",
+    "\n",
+    "\n",
     "# trl 1.9 : les reward funcs recvent des BATCHS (prompts, completions, ...) et\n",
     "# retournent une liste de scores. Avec un dataset conversationnel, chaque\n",
     "# completion est une liste de messages [{\"role\": \"assistant\", \"content\": ...}]\n",
     "# (patron PT-11b, verifie sur trl 1.9.2 grpo_trainer.py ligne 2187).\n",
-    "def combined_reward(prompts: list, completions: list, **kwargs) -> list:\n",
-    "    # Reward combine : longueur + mots-cles + format (applique par completion).\n",
+    "def combined_reward(prompts: list, completions: list, answer: list = None, **kwargs) -> list:\n",
+    "    # Reward combine. Si le dataset porte la colonne `answer` (TRL la passe en\n",
+    "    # kwarg alignee sur les completions), la justesse numerique domine le\n",
+    "    # melange — sinon degradation honnete vers les heuristiques.\n",
     "    rewards = []\n",
-    "    for completion in completions:\n",
+    "    for i, completion in enumerate(completions):\n",
     "        if isinstance(completion, list):\n",
     "            text = completion[-1].get('content', '') if completion else ''\n",
     "        else:\n",
     "            text = str(completion)\n",
     "        r_len = length_reward(text)\n",
     "        r_kw = keyword_reward(text)\n",
-    "        rewards.append(0.4 * r_len + 0.6 * r_kw)\n",
+    "        if answer is not None and i < len(answer):\n",
+    "            r_correct = correctness_reward(text, float(answer[i]))\n",
+    "            rewards.append(0.5 * r_correct + 0.2 * r_len + 0.3 * r_kw)\n",
+    "        else:\n",
+    "            rewards.append(0.4 * r_len + 0.6 * r_kw)\n",
     "    return rewards\n",
+    "\n",
     "\n",
     "# Tests unitaires des reward functions\n",
     "print(\"Tests des reward functions :\")\n",
-    "print(f\"  length_reward('short') = {length_reward('short'):.2f}\")\n",
-    "print(f\"  length_reward('a' * 100) = {length_reward('a' * 100):.2f}\")\n",
+    "print(\"--- length_reward : bornes visibles (sweet-spot) ---\")\n",
+    "print(f\"  length_reward('short')    = {length_reward('short'):.2f}  (< target_min=20 : penalise)\")\n",
+    "print(f\"  length_reward('a' * 100)  = {length_reward('a' * 100):.2f}  (dans [20, 200] : 1.0)\")\n",
+    "print(f\"  length_reward('a' * 250)  = {length_reward('a' * 250):.2f}  (> target_max=200 : penalise)\")\n",
+    "print(\"--- keyword / format (inchanges) ---\")\n",
     "print(f\"  keyword_reward('Therefore, x = 2 because...') = {keyword_reward('Therefore, x = 2 because...'):.2f}\")\n",
     "json_test = '{\"answer\": 42}'\n",
     "print(f\"  json_format_reward('{json_test}') = {json_format_reward(json_test):.2f}\")\n",
     "print(f\"  json_format_reward('not json') = {json_format_reward('not json'):.2f}\")\n",
+    "print(\"--- correctness_reward : cas pieges (#12438) ---\")\n",
+    "print(f\"  '$1,234.00' vs 1234  -> {correctness_reward('The answer is $1,234.00', 1234):.1f}  (normalisation devise + milliers)\")\n",
+    "print(f\"  '0.9999999' vs 1     -> {correctness_reward('The answer is 0.9999999', 1):.1f}  (tolerance relative 1e-3)\")\n",
+    "print(f\"  '42 km' vs 42        -> {correctness_reward('The answer is 42 km', 42):.1f}  (unite toleree)\")\n",
+    "print(f\"  'x = 2 because' vs 42 -> {correctness_reward('Therefore, x = 2 because it holds', 42):.1f}  (extrait mais faux : 0.5)\")\n",
+    "print(f\"  'Je ne sais pas' vs 42 -> {correctness_reward('Je ne sais pas', 42):.1f}  (rien d'extractible : 0.0)\")\n",
     "batch_test = [\n",
-    "    [{\"role\": \"assistant\", \"content\": \"Therefore x=2 because the equation holds\"}],\n",
+    "    [{\"role\": \"assistant\", \"content\": \"Therefore the answer is 42 because the equation holds\"}],\n",
     "    [{\"role\": \"assistant\", \"content\": \"short\"}],\n",
     "]\n",
-    "batch_scores = combined_reward(None, batch_test)\n",
-    "print(f\"  combined_reward(batch) = {batch_scores}\")\n",
-    "print(\"\\nReward functions pretes.\")"
+    "batch_scores = combined_reward(None, batch_test, answer=[42.0, 42.0])\n",
+    "print(f\"  combined_reward(batch, answer=[42, 42]) = {batch_scores}\")\n",
+    "print()\n",
+    "print(\"Reward functions pretes.\")"
    ]
   },
   {
@@ -483,10 +565,10 @@
    "id": "07f35ffc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:07:34.793565Z",
-     "iopub.status.busy": "2026-08-17T10:07:34.793015Z",
-     "iopub.status.idle": "2026-08-17T10:07:34.798773Z",
-     "shell.execute_reply": "2026-08-17T10:07:34.797796Z"
+     "iopub.execute_input": "2026-08-23T03:19:52.743150Z",
+     "iopub.status.busy": "2026-08-23T03:19:52.743150Z",
+     "iopub.status.idle": "2026-08-23T03:19:52.747504Z",
+     "shell.execute_reply": "2026-08-23T03:19:52.746937Z"
     },
     "papermill": {
      "duration": 0.013903,
@@ -524,6 +606,153 @@
   },
   {
    "cell_type": "markdown",
+   "id": "harness-12438-p4md",
+   "metadata": {},
+   "source": [
+    "## 5b. Harness d'évaluation du raisonnement — les 4 métriques d'une éval R1 crédible\n",
+    "\n",
+    "Un reward n'est qu'un signal d'entraînement : il ne dit pas si le modèle *raisonne*.\n",
+    "Une éval de raisonnement crédible (au sens R1) mesure **accuracy** sur held-out,\n",
+    "**format_rate** (fraction des complétions dont la réponse est extractible au format\n",
+    "attendu), **think_length** (longueur moyenne du raisonnement) et **backtrack_rate**\n",
+    "(fraction des complétions portant une marque d'auto-correction — « wait », « actually »,\n",
+    "« let me reconsider »… liste explicite dans le code). Ce harness (#12438) tourne avec\n",
+    "le même instrument **avant et après** l'entraînement, et sert de socle à PT-06."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "harness-12438-p4code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:19:52.750206Z",
+     "iopub.status.busy": "2026-08-23T03:19:52.749689Z",
+     "iopub.status.idle": "2026-08-23T03:19:52.761349Z",
+     "shell.execute_reply": "2026-08-23T03:19:52.760781Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Self-test du harness sur 4 completions de reference (CPU, textes fixes) :\n",
+      "  n_generations    = 4\n",
+      "  accuracy         = 0.5\n",
+      "  format_rate      = 0.75\n",
+      "  think_length     = 15.25\n",
+      "  backtrack_rate   = 0.5\n",
+      "  backtrack_markers = ['wait', 'actually', 'let me reconsider', 'let me double-check', 'on second thought', 'hmm', 'correction']\n",
+      "\n",
+      "Harness pret : evaluate_reasoning_model(model, tokenizer, problems, answers, n)\n",
+      "s'execute avant ET apres l'entrainement (branchement cellules suivantes, gate GPU).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Harness d'evaluation du raisonnement (#12438) : le meme instrument avant/apres\n",
+    "# l'entrainement, sinon le delta ne veut rien dire (patron de la cellule precedente).\n",
+    "BACKTRACK_MARKERS = [\n",
+    "    \"wait\", \"actually\", \"let me reconsider\", \"let me double-check\",\n",
+    "    \"on second thought\", \"hmm\", \"correction\",\n",
+    "]\n",
+    "\n",
+    "\n",
+    "def reasoning_metrics_on_completions(completions: list, answers: list) -> dict:\n",
+    "    \"\"\"Calcule les 4 metriques sur des completions DEJA produites.\n",
+    "\n",
+    "    Self-test CPU (textes de reference) et analyse post-hoc ; la generation,\n",
+    "    elle, se fait dans evaluate_reasoning_model.\n",
+    "    \"\"\"\n",
+    "    n = len(completions)\n",
+    "    n_fmt = n_acc = n_back = 0\n",
+    "    total_len = 0\n",
+    "    for comp, gt in zip(completions, answers):\n",
+    "        pred = extract_answer(comp)\n",
+    "        if pred is not None:\n",
+    "            n_fmt += 1\n",
+    "            if abs(pred - gt) <= max(1e-6, 1e-3 * abs(gt)):\n",
+    "                n_acc += 1\n",
+    "        total_len += len(comp.split())\n",
+    "        low = comp.lower()\n",
+    "        if any(marker in low for marker in BACKTRACK_MARKERS):\n",
+    "            n_back += 1\n",
+    "    return {\n",
+    "        \"n_generations\": n,\n",
+    "        \"accuracy\": n_acc / n,\n",
+    "        \"format_rate\": n_fmt / n,\n",
+    "        \"think_length\": total_len / n,\n",
+    "        \"backtrack_rate\": n_back / n,\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def evaluate_reasoning_model(model, tokenizer, problems, answers, n=4,\n",
+    "                             max_new_tokens=128, temperature=0.1, seed=None) -> dict:\n",
+    "    \"\"\"Genere n completions par probleme (basse temperature) et retourne les 4 metriques.\n",
+    "\n",
+    "    C'est la version LLM de la courbe d'apprentissage : meme instrument, meme\n",
+    "    echantillon, avant et apres l'entrainement (reutilisable par PT-06).\n",
+    "    \"\"\"\n",
+    "    import torch as _t\n",
+    "    if seed is not None:\n",
+    "        _t.manual_seed(seed)\n",
+    "    model.eval()\n",
+    "    completions = []\n",
+    "    for pb, gt in zip(problems, answers):\n",
+    "        messages = [{\"role\": \"user\", \"content\": pb + \"\\n\\nReason step by step, then end with 'The answer is <number>'.\"}]\n",
+    "        try:\n",
+    "            text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)\n",
+    "        except Exception:\n",
+    "            text = pb\n",
+    "        ids = tokenizer(text, return_tensors=\"pt\").to(model.device)\n",
+    "        for _ in range(n):\n",
+    "            with _t.no_grad():\n",
+    "                out = model.generate(**ids, max_new_tokens=max_new_tokens,\n",
+    "                                     do_sample=temperature > 0,\n",
+    "                                     temperature=temperature or None,\n",
+    "                                     pad_token_id=tokenizer.eos_token_id)\n",
+    "            completions.append(tokenizer.decode(out[0][ids[\"input_ids\"].shape[1]:],\n",
+    "                                                skip_special_tokens=True))\n",
+    "    return reasoning_metrics_on_completions(\n",
+    "        completions, [gt for gt in answers for _ in range(n)]\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def print_before_after(metrics_before: dict, metrics_after: dict) -> None:\n",
+    "    \"\"\"Tableau avant/apres des 4 metriques (#12438).\"\"\"\n",
+    "    cols = (\"accuracy\", \"format_rate\", \"think_length\", \"backtrack_rate\")\n",
+    "    header = f\"{'metrique':<15}{'avant':>10}{'apres':>10}{'delta':>10}\"\n",
+    "    print(header)\n",
+    "    print(\"-\" * len(header))\n",
+    "    for c in cols:\n",
+    "        b, a = metrics_before[c], metrics_after[c]\n",
+    "        if \"rate\" in c or c == \"accuracy\":\n",
+    "            print(f\"{c:<15}{100*b:>9.1f}%{100*a:>9.1f}%{100*(a-b):>+9.1f}%\")\n",
+    "        else:\n",
+    "            print(f\"{c:<15}{b:>10.1f}{a:>10.1f}{a-b:>+10.1f}\")\n",
+    "\n",
+    "\n",
+    "# Self-test CPU : calcul des metriques sur des completions de REFERENCE\n",
+    "# (textes fixes, pas des sorties de modele — la generation reelle est gatee GPU).\n",
+    "_ref = [\n",
+    "    (\"Let me compute 15 + 27. 15 + 27 = 42. Wait, let me double-check: 10+20=30, 5+7=12, total 42. The answer is 42\", 42.0),\n",
+    "    (\"Therefore the answer is 43 because the sum seems right\", 42.0),\n",
+    "    (\"I am not sure how to solve this one, sorry.\", 42.0),\n",
+    "    (\"60 km/h for 2.5 h. Actually, distance = 60 * 2.5 = 150. The answer is 150 km\", 150.0),\n",
+    "]\n",
+    "_self = reasoning_metrics_on_completions([c for c, _ in _ref], [a for _, a in _ref])\n",
+    "print(\"Self-test du harness sur 4 completions de reference (CPU, textes fixes) :\")\n",
+    "for _k in (\"n_generations\", \"accuracy\", \"format_rate\", \"think_length\", \"backtrack_rate\"):\n",
+    "    print(f\"  {_k:<16} = {_self[_k]}\")\n",
+    "print(f\"  backtrack_markers = {BACKTRACK_MARKERS}\")\n",
+    "print()\n",
+    "print(\"Harness pret : evaluate_reasoning_model(model, tokenizer, problems, answers, n)\")\n",
+    "print(\"s'execute avant ET apres l'entrainement (branchement cellules suivantes, gate GPU).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d31b67e4",
    "metadata": {
     "papermill": {
@@ -547,14 +776,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "6daf29bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:07:34.825170Z",
-     "iopub.status.busy": "2026-08-17T10:07:34.824752Z",
-     "iopub.status.idle": "2026-08-17T10:07:44.163788Z",
-     "shell.execute_reply": "2026-08-17T10:07:44.162974Z"
+     "iopub.execute_input": "2026-08-23T03:19:52.763571Z",
+     "iopub.status.busy": "2026-08-23T03:19:52.762967Z",
+     "iopub.status.idle": "2026-08-23T03:20:03.775209Z",
+     "shell.execute_reply": "2026-08-23T03:20:03.775209Z"
     },
     "papermill": {
      "duration": 9.347696,
@@ -572,7 +801,7 @@
      "text": [
       "LoRA config GRPO :\n",
       "  rank=8, alpha=16\n",
-      "  targets={'o_proj', 'up_proj', 'k_proj', 'down_proj', 'linear_attn.out_proj', 'q_proj', 'v_proj', 'gate_proj'}\n"
+      "  targets={'up_proj', 'gate_proj', 'k_proj', 'down_proj', 'linear_attn.out_proj', 'q_proj', 'o_proj', 'v_proj'}\n"
      ]
     }
    ],
@@ -625,14 +854,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "17cc8021",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:07:44.182615Z",
-     "iopub.status.busy": "2026-08-17T10:07:44.181775Z",
-     "iopub.status.idle": "2026-08-17T10:07:44.188413Z",
-     "shell.execute_reply": "2026-08-17T10:07:44.187700Z"
+     "iopub.execute_input": "2026-08-23T03:20:03.778357Z",
+     "iopub.status.busy": "2026-08-23T03:20:03.778357Z",
+     "iopub.status.idle": "2026-08-23T03:20:03.781917Z",
+     "shell.execute_reply": "2026-08-23T03:20:03.781917Z"
     },
     "papermill": {
      "duration": 0.012456,
@@ -720,14 +949,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "d25df911",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:07:44.211585Z",
-     "iopub.status.busy": "2026-08-17T10:07:44.211175Z",
-     "iopub.status.idle": "2026-08-17T10:07:44.217299Z",
-     "shell.execute_reply": "2026-08-17T10:07:44.216166Z"
+     "iopub.execute_input": "2026-08-23T03:20:03.783834Z",
+     "iopub.status.busy": "2026-08-23T03:20:03.783834Z",
+     "iopub.status.idle": "2026-08-23T03:20:04.181250Z",
+     "shell.execute_reply": "2026-08-23T03:20:04.180643Z"
     },
     "papermill": {
      "duration": 0.012829,
@@ -743,33 +972,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : estimation memoire GRPO\n"
+      "Dataset GRPO : 10 prompts, chacun avec sa ground truth\n",
+      "Exemple : [{'role': 'user', 'content': 'What is 15 + 27? Think step by step.'}] -> answer = 42.0\n"
      ]
     }
    ],
    "source": [
-    "def estimer_memoire_grpo(\n",
-    "    model_params_millions: float,\n",
-    "    group_size: int = 4,\n",
-    "    max_completion_length: int = 256,\n",
-    "    hidden_size: int = 1024,   # Qwen3.5-0.8B (vs 896 pour Qwen2.5-0.5B)\n",
-    "    quantization_bits: int = 4,\n",
-    ") -> dict:\n",
-    "    # TODO etudiant : estimer la VRAM pour GRPO\n",
-    "    \n",
-    "    # Etape 1 : memoire de base (modele quantize)\n",
-    "    bytes_per_param = quantization_bits / 8\n",
-    "    base_vram = None  # TODO etudiant : params * bytes / 1e9\n",
-    "    \n",
-    "    # Etape 2 : memoire pour les G completions (log-probs + activations)\n",
-    "    gen_vram = None  # TODO etudiant : G * length * hidden * 2 bytes / 1e9\n",
-    "    \n",
-    "    total = None  # TODO etudiant : base + gen + overhead\n",
-    "    fits_8gb = None  # TODO etudiant : total <= 8.0\n",
-    "    \n",
-    "    return {\"total_gb\": total, \"fits_8gb\": fits_8gb, \"group_size\": group_size}\n",
+    "# Dataset de prompts pour GRPO (demo) — avec ground truth numerique (#12438) :\n",
+    "# sans colonne `answer`, TRL ne peut pas la passer au reward et la justesse\n",
+    "# numerique ne s'exerce pas (retombée sur les heuristiques mot-cle/longueur).\n",
+    "prompts = [\n",
+    "    \"What is 15 + 27? Think step by step.\",\n",
+    "    \"If a train travels 60 km/h for 2.5 hours, how far does it go?\",\n",
+    "    \"How many prime numbers are there between 90 and 100? Think step by step.\",\n",
+    "    \"What is the area of a circle with radius 5? Use pi = 3.14.\",\n",
+    "    \"Solve for x: 3x - 7 = 14.\",\n",
+    "    \"How many ways can you arrange 4 books on a shelf?\",\n",
+    "    \"What is 20% of 350?\",\n",
+    "    \"If it takes 5 machines 5 minutes to make 5 widgets, how long for 100 machines to make 100 widgets?\",\n",
+    "    \"What is the next prime after 50?\",\n",
+    "    \"Convert 72 degrees Fahrenheit to Celsius. Formula: C = (F-32) * 5/9.\",\n",
+    "]\n",
+    "answers = [42, 150, 1, 78.5, 7, 24, 70, 5, 53, 22.22]\n",
     "\n",
-    "print(\"Exercice a completer : estimation memoire GRPO\")"
+    "# Format conversation pour le chat template\n",
+    "from datasets import Dataset\n",
+    "\n",
+    "def format_prompts(prompts_list, answers_list):\n",
+    "    formatted = []\n",
+    "    for p, a in zip(prompts_list, answers_list):\n",
+    "        formatted.append({\"prompt\": [{\"role\": \"user\", \"content\": p}], \"answer\": a})\n",
+    "    return formatted\n",
+    "\n",
+    "dataset_grpo = Dataset.from_list(format_prompts(prompts, answers))\n",
+    "\n",
+    "print(f\"Dataset GRPO : {len(dataset_grpo)} prompts, chacun avec sa ground truth\")\n",
+    "print(f\"Exemple : {dataset_grpo[0]['prompt']} -> answer = {dataset_grpo[0]['answer']}\")"
    ]
   },
   {
@@ -795,14 +1033,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "fa04a1f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:07:44.239307Z",
-     "iopub.status.busy": "2026-08-17T10:07:44.238742Z",
-     "iopub.status.idle": "2026-08-17T10:07:44.796930Z",
-     "shell.execute_reply": "2026-08-17T10:07:44.796454Z"
+     "iopub.execute_input": "2026-08-23T03:20:04.182373Z",
+     "iopub.status.busy": "2026-08-23T03:20:04.182373Z",
+     "iopub.status.idle": "2026-08-23T03:20:04.188654Z",
+     "shell.execute_reply": "2026-08-23T03:20:04.188654Z"
     },
     "papermill": {
      "duration": 0.56644,
@@ -819,7 +1057,7 @@
      "output_type": "stream",
      "text": [
       "Dataset GRPO : 10 prompts\n",
-      "Exemple : [{'content': 'What is 15 + 27? Think step by step.', 'role': 'user'}]\n"
+      "Exemple : [{'role': 'user', 'content': 'What is 15 + 27? Think step by step.'}]\n"
      ]
     }
    ],
@@ -878,14 +1116,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "eb0babce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:07:44.818003Z",
-     "iopub.status.busy": "2026-08-17T10:07:44.817783Z",
-     "iopub.status.idle": "2026-08-17T10:11:07.294196Z",
-     "shell.execute_reply": "2026-08-17T10:11:07.293658Z"
+     "iopub.execute_input": "2026-08-23T03:20:04.190198Z",
+     "iopub.status.busy": "2026-08-23T03:20:04.190198Z",
+     "iopub.status.idle": "2026-08-23T03:20:04.198683Z",
+     "shell.execute_reply": "2026-08-23T03:20:04.198683Z"
     },
     "papermill": {
      "duration": 202.48443,
@@ -901,104 +1139,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Chargement Qwen3.5-0.8B en 4-bit...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[transformers] The fast path is not available because one of the required library is not installed. Falling back to torch implementation. To install follow https://github.com/fla-org/flash-linear-attention#installation and https://github.com/Dao-AILab/causal-conv1d\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[ERROR] `loss` is part of Qwen3_5CausalLMOutputWithPast.__init__'s signature, but not documented. Make sure to add it to the docstring of the function in <USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\transformers\\models\\qwen3_5\\modeling_qwen3_5.py.\n",
-      "[ERROR] `logits` is part of Qwen3_5CausalLMOutputWithPast.__init__'s signature, but not documented. Make sure to add it to the docstring of the function in <USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\transformers\\models\\qwen3_5\\modeling_qwen3_5.py.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e7580b4fd98c4dbd916a0e969cd9e460",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Loading weights:   0%|          | 0/473 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[transformers] Setting `pad_token_id` to `eos_token_id`:248044 for open-end generation.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Skip : entrainement GRPO non execute (LOAD_MODEL_AND_TRAIN=False ou pas de CUDA)\n",
       "\n",
-      "=== AVANT GRPO (modele de base) ===\n",
-      "Prompt : What is 15 + 27? Think step by step.\n",
-      "Completion : To solve the problem **15 + 27**, we can follow a simple step-by-step addition process:\n",
-      "\n",
-      "1.  **Add the ones place:**\n",
-      "    *   The ones digit of 15 is **5**.\n",
-      "    *   The ones digit of 27 is **7**.\n",
-      "    *\n",
-      "Reward combined : 0.122\n",
-      "Configuration GRPOConfig...\n",
-      "Construction GRPOTrainer...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[transformers] The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 248046, 'pad_token_id': 248044}.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "trainable params: 3,637,248 || all params: 856,623,168 || trainable%: 0.4246\n",
-      "\n",
-      "GRPOTrainer pret. 10 prompts, G=4.\n",
-      "Lancement de l'entrainement...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "step 2 | loss = 0.0569 | reward = 0.1271 | kl = 0.0169\n",
-      "{'loss': '0.05686', 'grad_norm': '0.459', 'learning_rate': '1e-05', 'num_tokens': '7606', 'completions/mean_length': '212.4', 'completions/min_length': '102', 'completions/max_length': '256', 'completions/clipped_ratio': '0.5938', 'completions/mean_terminated_length': '156.7', 'completions/min_terminated_length': '102', 'completions/max_terminated_length': '229', 'rewards/combined_reward/mean': '0.1271', 'rewards/combined_reward/std': '0.1117', 'reward': '0.1271', 'reward_std': '0.1117', 'frac_reward_zero_std': '0.125', 'kl': '0.01694', 'entropy': '0.6093', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '62.85', 'epoch': '0.8'}\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "step 3 | reward = 0.0675 | kl = 0.0195\n",
-      "{'train_runtime': '175.5', 'train_samples_per_second': '0.274', 'train_steps_per_second': '0.017', 'train_loss': '0.1122', 'num_tokens': '1.212e+04', 'completions/mean_length': '244.2', 'completions/min_length': '184', 'completions/max_length': '256', 'completions/clipped_ratio': '0.8125', 'completions/mean_terminated_length': '193.3', 'completions/min_terminated_length': '184', 'completions/max_terminated_length': '211', 'rewards/combined_reward/mean': '0.0675', 'rewards/combined_reward/std': '0.09767', 'reward': '0.0675', 'reward_std': '0.09767', 'frac_reward_zero_std': '0.25', 'kl': '0.01949', 'entropy': '0.5445', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '49.57', 'epoch': '1'}\n",
-      "\n",
-      "Entrainement GRPO termine.\n",
-      "Loss finale : 0.1122\n"
+      "Pour executer le vrai GRPO :\n",
+      "  1. LOAD_MODEL_AND_TRAIN = True (migration Qwen3.5, mandat #10289)\n",
+      "  2. GPU avec >= 6 Go VRAM disponible\n",
+      "  3. Le notebook execute alors le vrai GRPO (modele de base -> 3 steps),\n",
+      "     et l'evaluation qualitative avant/apres (cellule 22) est reelle, pas simulee.\n"
      ]
     }
    ],
@@ -1043,6 +1190,14 @@
     "    print(\"Prompt :\", baseline_prompt)\n",
     "    print(\"Completion :\", baseline_completion[:200])\n",
     "    print(\"Reward combined : %.3f\" % baseline_reward)\n",
+    "\n",
+    "    # Mesure PRE multi-metriques sur le modele de base (#12438).\n",
+    "    METRICS_PRE = evaluate_reasoning_model(\n",
+    "        base_model, tokenizer, prompts[:4], answers[:4], n=2, seed=1234,\n",
+    "    )\n",
+    "    print(\"Metriques PRE-GRPO (harness multi-metriques) :\")\n",
+    "    for _k in (\"accuracy\", \"format_rate\", \"think_length\", \"backtrack_rate\"):\n",
+    "        print(f\"  {_k:<15} = {METRICS_PRE[_k]}\")\n",
     "    base_model.train()\n",
     "\n",
     "    # Callback : imprime loss/reward/kl par step (la progress bar widget TRL n est pas persistee)\n",
@@ -1127,14 +1282,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "061810df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:11:07.314928Z",
-     "iopub.status.busy": "2026-08-17T10:11:07.314460Z",
-     "iopub.status.idle": "2026-08-17T10:11:21.149174Z",
-     "shell.execute_reply": "2026-08-17T10:11:21.148690Z"
+     "iopub.execute_input": "2026-08-23T03:20:04.200699Z",
+     "iopub.status.busy": "2026-08-23T03:20:04.200699Z",
+     "iopub.status.idle": "2026-08-23T03:20:04.205336Z",
+     "shell.execute_reply": "2026-08-23T03:20:04.205336Z"
     },
     "papermill": {
      "duration": 13.840301,
@@ -1150,20 +1305,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== APRES GRPO (modele entraine, 3 steps) ===\n",
-      "Prompt : What is 15 + 27? Think step by step.\n",
-      "Completion : To solve the problem **15 + 27**, we can follow these steps:\n",
-      "\n",
-      "1.  **Add the numbers together:**\n",
-      "    *   The tens place: $10 + 20 = 30$\n",
-      "    *   The ones place: $5 + 7 = 12$\n",
-      "    *   Combine the results:\n",
-      "Reward combined : 0.222\n",
-      "\n",
-      "Verdict : la reward est stable ou legerement amelioree sur 3 steps.\n",
-      "Note : 10 prompts x 3 steps = echantillon trop petit pour un claim BEATS\n",
-      "  (multi-seed >= 4 + 2 sigma requis). Verdict : INCONCLUSIF\n",
-      "  sur metriques, observation qualitative documentee.\n"
+      "Skip : evaluation reelle non executee (LOAD_MODEL_AND_TRAIN=False ou pas de CUDA)\n"
      ]
     }
    ],
@@ -1196,6 +1338,18 @@
     "    print(\"Note : 10 prompts x 3 steps = echantillon trop petit pour un claim BEATS\")\n",
     "    print(\"  (multi-seed >= 4 + 2 sigma requis). Verdict : INCONCLUSIF\")\n",
     "    print(\"  sur metriques, observation qualitative documentee.\")\n",
+    "\n",
+    "    # Harness multi-metriques (#12438) : avant / apres sur le meme echantillon.\n",
+    "    METRICS_POST = evaluate_reasoning_model(\n",
+    "        model, tokenizer, prompts[:4], answers[:4], n=2, seed=1234,\n",
+    "    )\n",
+    "    print()\n",
+    "    print(\"=== Harness multi-metriques : avant / apres GRPO (#12438) ===\")\n",
+    "    if \"METRICS_PRE\" in globals() and METRICS_PRE is not None:\n",
+    "        print_before_after(METRICS_PRE, METRICS_POST)\n",
+    "    else:\n",
+    "        for _k in (\"accuracy\", \"format_rate\", \"think_length\", \"backtrack_rate\"):\n",
+    "            print(f\"  {_k:<15} = {METRICS_POST[_k]}\")\n",
     "else:\n",
     "    print(\"Skip : evaluation reelle non executee (LOAD_MODEL_AND_TRAIN=False ou pas de CUDA)\")\n"
    ]
@@ -1266,14 +1420,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "76d00ce4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:11:21.172672Z",
-     "iopub.status.busy": "2026-08-17T10:11:21.172114Z",
-     "iopub.status.idle": "2026-08-17T10:11:21.175951Z",
-     "shell.execute_reply": "2026-08-17T10:11:21.175588Z"
+     "iopub.execute_input": "2026-08-23T03:20:04.207342Z",
+     "iopub.status.busy": "2026-08-23T03:20:04.206341Z",
+     "iopub.status.idle": "2026-08-23T03:20:04.211431Z",
+     "shell.execute_reply": "2026-08-23T03:20:04.211431Z"
     },
     "papermill": {
      "duration": 0.008843,
@@ -1327,7 +1481,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Bilan — GRPO : la recette Deepseek-R1 (RL pur, sans données humaines)\n",
     "\n",
@@ -1452,7 +1606,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb
@@ -6,10 +6,10 @@
    "id": "11320909",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:19:50.994056Z",
-     "iopub.status.busy": "2026-08-23T03:19:50.993034Z",
-     "iopub.status.idle": "2026-08-23T03:19:50.997151Z",
-     "shell.execute_reply": "2026-08-23T03:19:50.997151Z"
+     "iopub.execute_input": "2026-08-27T16:58:39.738080Z",
+     "iopub.status.busy": "2026-08-27T16:58:39.738080Z",
+     "iopub.status.idle": "2026-08-27T16:58:39.742589Z",
+     "shell.execute_reply": "2026-08-27T16:58:39.742080Z"
     },
     "papermill": {
      "duration": 0.009759,
@@ -236,10 +236,10 @@
    "id": "6a374976",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:19:50.999155Z",
-     "iopub.status.busy": "2026-08-23T03:19:50.999155Z",
-     "iopub.status.idle": "2026-08-23T03:19:51.005486Z",
-     "shell.execute_reply": "2026-08-23T03:19:51.005486Z"
+     "iopub.execute_input": "2026-08-27T16:58:39.745625Z",
+     "iopub.status.busy": "2026-08-27T16:58:39.745625Z",
+     "iopub.status.idle": "2026-08-27T16:58:39.759458Z",
+     "shell.execute_reply": "2026-08-27T16:58:39.759458Z"
     },
     "papermill": {
      "duration": 0.014903,
@@ -282,10 +282,10 @@
    "id": "ef8279d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:19:51.006501Z",
-     "iopub.status.busy": "2026-08-23T03:19:51.006501Z",
-     "iopub.status.idle": "2026-08-23T03:19:52.724399Z",
-     "shell.execute_reply": "2026-08-23T03:19:52.723685Z"
+     "iopub.execute_input": "2026-08-27T16:58:39.762466Z",
+     "iopub.status.busy": "2026-08-27T16:58:39.762466Z",
+     "iopub.status.idle": "2026-08-27T16:58:43.999247Z",
+     "shell.execute_reply": "2026-08-27T16:58:43.997730Z"
     },
     "papermill": {
      "duration": 1.865798,
@@ -301,7 +301,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CUDA non disponible (CPU uniquement)\n"
+      "Accélérateur CUDA détecté : False — les cellules d'entraînement GPU seront ignorées\n"
      ]
     }
    ],
@@ -312,9 +312,9 @@
     "if CUDA_AVAILABLE:\n",
     "    gpu_name = torch.cuda.get_device_name(0)\n",
     "    gpu_mem = torch.cuda.get_device_properties(0).total_memory / 1024**3\n",
-    "    print(f\"CUDA disponible : {gpu_name} ({gpu_mem:.1f} Go)\")\n",
+    "    print(f\"Accélérateur CUDA détecté : {gpu_name} ({gpu_mem:.1f} Go)\")\n",
     "else:\n",
-    "    print(\"CUDA non disponible (CPU uniquement)\")"
+    "    print(\"Accélérateur CUDA détecté : False — les cellules d'entraînement GPU seront ignorées\")"
    ]
   },
   {
@@ -351,10 +351,10 @@
    "id": "f940f039",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:19:52.726476Z",
-     "iopub.status.busy": "2026-08-23T03:19:52.726476Z",
-     "iopub.status.idle": "2026-08-23T03:19:52.740406Z",
-     "shell.execute_reply": "2026-08-23T03:19:52.739828Z"
+     "iopub.execute_input": "2026-08-27T16:58:44.003255Z",
+     "iopub.status.busy": "2026-08-27T16:58:44.002257Z",
+     "iopub.status.idle": "2026-08-27T16:58:44.026643Z",
+     "shell.execute_reply": "2026-08-27T16:58:44.025596Z"
     },
     "papermill": {
      "duration": 0.019887,
@@ -565,10 +565,10 @@
    "id": "07f35ffc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:19:52.743150Z",
-     "iopub.status.busy": "2026-08-23T03:19:52.743150Z",
-     "iopub.status.idle": "2026-08-23T03:19:52.747504Z",
-     "shell.execute_reply": "2026-08-23T03:19:52.746937Z"
+     "iopub.execute_input": "2026-08-27T16:58:44.030856Z",
+     "iopub.status.busy": "2026-08-27T16:58:44.029845Z",
+     "iopub.status.idle": "2026-08-27T16:58:44.043923Z",
+     "shell.execute_reply": "2026-08-27T16:58:44.042768Z"
     },
     "papermill": {
      "duration": 0.013903,
@@ -626,10 +626,10 @@
    "id": "harness-12438-p4code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:19:52.750206Z",
-     "iopub.status.busy": "2026-08-23T03:19:52.749689Z",
-     "iopub.status.idle": "2026-08-23T03:19:52.761349Z",
-     "shell.execute_reply": "2026-08-23T03:19:52.760781Z"
+     "iopub.execute_input": "2026-08-27T16:58:44.047271Z",
+     "iopub.status.busy": "2026-08-27T16:58:44.046272Z",
+     "iopub.status.idle": "2026-08-27T16:58:44.064320Z",
+     "shell.execute_reply": "2026-08-27T16:58:44.063310Z"
     }
    },
    "outputs": [
@@ -780,10 +780,10 @@
    "id": "6daf29bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:19:52.763571Z",
-     "iopub.status.busy": "2026-08-23T03:19:52.762967Z",
-     "iopub.status.idle": "2026-08-23T03:20:03.775209Z",
-     "shell.execute_reply": "2026-08-23T03:20:03.775209Z"
+     "iopub.execute_input": "2026-08-27T16:58:44.067837Z",
+     "iopub.status.busy": "2026-08-27T16:58:44.067837Z",
+     "iopub.status.idle": "2026-08-27T16:59:13.217975Z",
+     "shell.execute_reply": "2026-08-27T16:59:13.217975Z"
     },
     "papermill": {
      "duration": 9.347696,
@@ -801,7 +801,7 @@
      "text": [
       "LoRA config GRPO :\n",
       "  rank=8, alpha=16\n",
-      "  targets={'up_proj', 'gate_proj', 'k_proj', 'down_proj', 'linear_attn.out_proj', 'q_proj', 'o_proj', 'v_proj'}\n"
+      "  targets={'linear_attn.out_proj', 'v_proj', 'gate_proj', 'o_proj', 'down_proj', 'k_proj', 'q_proj', 'up_proj'}\n"
      ]
     }
    ],
@@ -858,10 +858,10 @@
    "id": "17cc8021",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:20:03.778357Z",
-     "iopub.status.busy": "2026-08-23T03:20:03.778357Z",
-     "iopub.status.idle": "2026-08-23T03:20:03.781917Z",
-     "shell.execute_reply": "2026-08-23T03:20:03.781917Z"
+     "iopub.execute_input": "2026-08-27T16:59:13.219985Z",
+     "iopub.status.busy": "2026-08-27T16:59:13.219985Z",
+     "iopub.status.idle": "2026-08-27T16:59:13.224322Z",
+     "shell.execute_reply": "2026-08-27T16:59:13.224322Z"
     },
     "papermill": {
      "duration": 0.012456,
@@ -935,16 +935,16 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Analyser l'impact du group size sur la memoire\n",
+    "### Exercice 2 : Analyser l'impact du group size sur la mémoire\n",
     "\n",
-    "Le paramètre `num_generations` (group size G) contrôle le nombre de completions generees par prompt. L'objectif est d'implementer une fonction `estimer_memoire_grpo` qui calcule la memoire supplementaire necessaire en fonction de G.\n",
+    "Le paramètre `num_generations` (group size G) contrôle le nombre de complétions générées par prompt. L'objectif est d'implémenter une fonction `estimer_memoire_grpo` qui calcule la mémoire supplémentaire nécessaire en fonction de G.\n",
     "\n",
-    "**Objectif** : ecrire une fonction qui estime la VRAM consommee par GRPO selon la taille du modèle, la longueur des completions et le group size G.\n",
+    "**Objectif** : écrire une fonction qui estime la VRAM consommée par GRPO selon la taille du modèle, la longueur des complétions et le group size G, puis comparer G=2, 4, 8 et 16 sur un budget de 8 Go.\n",
     "\n",
     "**Indices** :\n",
-    "- `# Étape 1` : Calculer la memoire de base du modèle (params * bytes) + les activations\n",
-    "- `# Étape 2` : Ajouter G * max_completion_length * hidden_size * 2 bytes (log-probs stockees)\n",
-    "- `# Indice` : comparer G=2, 4, 8, 16 et verifier lesquels tiennent sur 8 Go"
+    "- `# Étape 1` : calculer la mémoire de base du modèle (`params * bytes`) et les activations\n",
+    "- `# Étape 2` : ajouter `G * max_completion_length * hidden_size * 2` octets pour les états stockés\n",
+    "- `# Étape 3` : retourner l'estimation en Go et identifier les valeurs de G compatibles avec 8 Go"
    ]
   },
   {
@@ -953,10 +953,10 @@
    "id": "d25df911",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:20:03.783834Z",
-     "iopub.status.busy": "2026-08-23T03:20:03.783834Z",
-     "iopub.status.idle": "2026-08-23T03:20:04.181250Z",
-     "shell.execute_reply": "2026-08-23T03:20:04.180643Z"
+     "iopub.execute_input": "2026-08-27T16:59:13.225842Z",
+     "iopub.status.busy": "2026-08-27T16:59:13.225842Z",
+     "iopub.status.idle": "2026-08-27T16:59:13.259634Z",
+     "shell.execute_reply": "2026-08-27T16:59:13.259634Z"
     },
     "papermill": {
      "duration": 0.012829,
@@ -972,42 +972,40 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dataset GRPO : 10 prompts, chacun avec sa ground truth\n",
-      "Exemple : [{'role': 'user', 'content': 'What is 15 + 27? Think step by step.'}] -> answer = 42.0\n"
+      "G= 2 : à calculer Go\n",
+      "G= 4 : à calculer Go\n",
+      "G= 8 : à calculer Go\n",
+      "G=16 : à calculer Go\n",
+      "Exercice à compléter : estimation mémoire GRPO\n"
      ]
     }
    ],
    "source": [
-    "# Dataset de prompts pour GRPO (demo) — avec ground truth numerique (#12438) :\n",
-    "# sans colonne `answer`, TRL ne peut pas la passer au reward et la justesse\n",
-    "# numerique ne s'exerce pas (retombée sur les heuristiques mot-cle/longueur).\n",
-    "prompts = [\n",
-    "    \"What is 15 + 27? Think step by step.\",\n",
-    "    \"If a train travels 60 km/h for 2.5 hours, how far does it go?\",\n",
-    "    \"How many prime numbers are there between 90 and 100? Think step by step.\",\n",
-    "    \"What is the area of a circle with radius 5? Use pi = 3.14.\",\n",
-    "    \"Solve for x: 3x - 7 = 14.\",\n",
-    "    \"How many ways can you arrange 4 books on a shelf?\",\n",
-    "    \"What is 20% of 350?\",\n",
-    "    \"If it takes 5 machines 5 minutes to make 5 widgets, how long for 100 machines to make 100 widgets?\",\n",
-    "    \"What is the next prime after 50?\",\n",
-    "    \"Convert 72 degrees Fahrenheit to Celsius. Formula: C = (F-32) * 5/9.\",\n",
-    "]\n",
-    "answers = [42, 150, 1, 78.5, 7, 24, 70, 5, 53, 22.22]\n",
+    "def estimer_memoire_grpo(\n",
+    "    group_size: int,\n",
+    "    nombre_parametres: int = 800_000_000,\n",
+    "    octets_par_parametre: float = 0.5,\n",
+    "    max_completion_length: int = 256,\n",
+    "    hidden_size: int = 2048,\n",
+    ") -> float:\n",
+    "    # TODO étudiant : estimer la VRAM totale en Go\n",
+    "    # Étape 1 : mémoire du modèle quantifié et estimation des activations\n",
+    "    memoire_modele = None  # TODO : nombre_parametres * octets_par_parametre\n",
+    "    memoire_activations = None  # TODO : choisir et documenter une approximation\n",
     "\n",
-    "# Format conversation pour le chat template\n",
-    "from datasets import Dataset\n",
+    "    # Étape 2 : mémoire supplémentaire proportionnelle au group size\n",
+    "    memoire_groupe = None  # TODO : group_size * max_completion_length * hidden_size * 2\n",
     "\n",
-    "def format_prompts(prompts_list, answers_list):\n",
-    "    formatted = []\n",
-    "    for p, a in zip(prompts_list, answers_list):\n",
-    "        formatted.append({\"prompt\": [{\"role\": \"user\", \"content\": p}], \"answer\": a})\n",
-    "    return formatted\n",
+    "    # Étape 3 : convertir le total en Go\n",
+    "    memoire_totale_go = None  # TODO : somme / 1024**3\n",
+    "    return memoire_totale_go\n",
     "\n",
-    "dataset_grpo = Dataset.from_list(format_prompts(prompts, answers))\n",
     "\n",
-    "print(f\"Dataset GRPO : {len(dataset_grpo)} prompts, chacun avec sa ground truth\")\n",
-    "print(f\"Exemple : {dataset_grpo[0]['prompt']} -> answer = {dataset_grpo[0]['answer']}\")"
+    "for group_size in (2, 4, 8, 16):\n",
+    "    estimation = estimer_memoire_grpo(group_size)\n",
+    "    print(f\"G={group_size:>2} : {estimation if estimation is not None else 'à calculer'} Go\")\n",
+    "\n",
+    "print(\"Exercice à compléter : estimation mémoire GRPO\")"
    ]
   },
   {
@@ -1024,11 +1022,11 @@
     "tags": []
    },
    "source": [
-    "## 8. Dataset de prompts pour GRPO\n",
+    "## 8. Exemple guidé — dataset de prompts avec vérité terrain\n",
     "\n",
-    "Le GRPO a besoin d'un dataset de **prompts uniquement** (pas de paires). Les completions sont generees par le modèle pendant l'entrainement.\n",
+    "Le GRPO génère lui-même les complétions, mais la reward de justesse introduite dans ce notebook exige une colonne `answer`. L'exemple suivant construit donc dix prompts de raisonnement accompagnés de leur vérité terrain numérique, puis les formate pour `GRPOTrainer`.\n",
     "\n",
-    "Pour le demo : un petit dataset de prompts \"reasoning\" (questions mathematiques/logiques simples)."
+    "Cette cellule est un **exemple résolu**, distinct de l'exercice précédent consacré à l'estimation mémoire."
    ]
   },
   {
@@ -1037,10 +1035,10 @@
    "id": "fa04a1f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:20:04.182373Z",
-     "iopub.status.busy": "2026-08-23T03:20:04.182373Z",
-     "iopub.status.idle": "2026-08-23T03:20:04.188654Z",
-     "shell.execute_reply": "2026-08-23T03:20:04.188654Z"
+     "iopub.execute_input": "2026-08-27T16:59:13.261725Z",
+     "iopub.status.busy": "2026-08-27T16:59:13.261725Z",
+     "iopub.status.idle": "2026-08-27T16:59:14.026857Z",
+     "shell.execute_reply": "2026-08-27T16:59:14.026330Z"
     },
     "papermill": {
      "duration": 0.56644,
@@ -1056,17 +1054,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dataset GRPO : 10 prompts\n",
-      "Exemple : [{'role': 'user', 'content': 'What is 15 + 27? Think step by step.'}]\n"
+      "Dataset GRPO : 10 prompts avec vérité terrain\n",
+      "Exemple : [{'role': 'user', 'content': 'What is 15 + 27? Think step by step.'}] -> answer = 42.0\n"
      ]
     }
    ],
    "source": [
-    "# Dataset de prompts pour GRPO (demo)\n",
+    "# Exemple résolu : dataset GRPO avec ground truth numérique (#12438)\n",
     "prompts = [\n",
     "    \"What is 15 + 27? Think step by step.\",\n",
     "    \"If a train travels 60 km/h for 2.5 hours, how far does it go?\",\n",
-    "    \"Is 97 a prime number? Explain your reasoning.\",\n",
+    "    \"How many prime numbers are there between 90 and 100? Think step by step.\",\n",
     "    \"What is the area of a circle with radius 5? Use pi = 3.14.\",\n",
     "    \"Solve for x: 3x - 7 = 14.\",\n",
     "    \"How many ways can you arrange 4 books on a shelf?\",\n",
@@ -1075,20 +1073,21 @@
     "    \"What is the next prime after 50?\",\n",
     "    \"Convert 72 degrees Fahrenheit to Celsius. Formula: C = (F-32) * 5/9.\",\n",
     "]\n",
+    "answers = [42, 150, 1, 78.5, 7, 24, 70, 5, 53, 22.22]\n",
     "\n",
-    "# Format conversation pour le chat template\n",
     "from datasets import Dataset\n",
     "\n",
-    "def format_prompts(prompts_list):\n",
-    "    formatted = []\n",
-    "    for p in prompts_list:\n",
-    "        formatted.append({\"prompt\": [{\"role\": \"user\", \"content\": p}]})\n",
-    "    return formatted\n",
     "\n",
-    "dataset_grpo = Dataset.from_list(format_prompts(prompts))\n",
+    "def format_prompts(prompts_list, answers_list):\n",
+    "    return [\n",
+    "        {\"prompt\": [{\"role\": \"user\", \"content\": prompt}], \"answer\": answer}\n",
+    "        for prompt, answer in zip(prompts_list, answers_list)\n",
+    "    ]\n",
     "\n",
-    "print(f\"Dataset GRPO : {len(dataset_grpo)} prompts\")\n",
-    "print(f\"Exemple : {dataset_grpo[0]['prompt']}\")"
+    "\n",
+    "dataset_grpo = Dataset.from_list(format_prompts(prompts, answers))\n",
+    "print(f\"Dataset GRPO : {len(dataset_grpo)} prompts avec vérité terrain\")\n",
+    "print(f\"Exemple : {dataset_grpo[0]['prompt']} -> answer = {dataset_grpo[0]['answer']}\")"
    ]
   },
   {
@@ -1120,10 +1119,10 @@
    "id": "eb0babce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:20:04.190198Z",
-     "iopub.status.busy": "2026-08-23T03:20:04.190198Z",
-     "iopub.status.idle": "2026-08-23T03:20:04.198683Z",
-     "shell.execute_reply": "2026-08-23T03:20:04.198683Z"
+     "iopub.execute_input": "2026-08-27T16:59:14.029581Z",
+     "iopub.status.busy": "2026-08-27T16:59:14.029030Z",
+     "iopub.status.idle": "2026-08-27T16:59:14.038274Z",
+     "shell.execute_reply": "2026-08-27T16:59:14.038274Z"
     },
     "papermill": {
      "duration": 202.48443,
@@ -1286,10 +1285,10 @@
    "id": "061810df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:20:04.200699Z",
-     "iopub.status.busy": "2026-08-23T03:20:04.200699Z",
-     "iopub.status.idle": "2026-08-23T03:20:04.205336Z",
-     "shell.execute_reply": "2026-08-23T03:20:04.205336Z"
+     "iopub.execute_input": "2026-08-27T16:59:14.040894Z",
+     "iopub.status.busy": "2026-08-27T16:59:14.040894Z",
+     "iopub.status.idle": "2026-08-27T16:59:14.048036Z",
+     "shell.execute_reply": "2026-08-27T16:59:14.046925Z"
     },
     "papermill": {
      "duration": 13.840301,
@@ -1424,10 +1423,10 @@
    "id": "76d00ce4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:20:04.207342Z",
-     "iopub.status.busy": "2026-08-23T03:20:04.206341Z",
-     "iopub.status.idle": "2026-08-23T03:20:04.211431Z",
-     "shell.execute_reply": "2026-08-23T03:20:04.211431Z"
+     "iopub.execute_input": "2026-08-27T16:59:14.050680Z",
+     "iopub.status.busy": "2026-08-27T16:59:14.049577Z",
+     "iopub.status.idle": "2026-08-27T16:59:14.054619Z",
+     "shell.execute_reply": "2026-08-27T16:59:14.054012Z"
     },
     "papermill": {
      "duration": 0.008843,
@@ -1576,7 +1575,7 @@
  "metadata": {
   "cost": {
    "api_provider": "local",
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "cpu_min": 0,
    "external_account": "none",
    "free_alternative": null,
@@ -1607,20 +1606,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 233.071699,
-   "end_time": "2026-08-17T10:11:24.027228",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "PT_04_grpo_deepseek_r1.ipynb",
-   "output_path": "PT_04_grpo_deepseek_r1.ipynb",
-   "parameters": {
-    "BATCH_MODE": "true"
-   },
-   "start_time": "2026-08-17T10:07:30.955529",
-   "version": "2.6.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
@@ -1929,13 +1914,13 @@
        "description": "",
        "description_allow_html": false,
        "layout": "IPY_MODEL_292f03bc1bb142d9b5293749cf2662e9",
-       "max": 473.0,
-       "min": 0.0,
+       "max": 473,
+       "min": 0,
        "orientation": "horizontal",
        "style": "IPY_MODEL_3a908bc0f31040deb5c45751f81cc360",
        "tabbable": null,
        "tooltip": null,
-       "value": 473.0
+       "value": 473
       }
      },
      "e490a97eaa1b42aab91e561bd83bf6d6": {

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb
@@ -132,10 +132,10 @@
    "id": "73d8136b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:31.821937Z",
-     "iopub.status.busy": "2026-08-23T03:18:31.821937Z",
-     "iopub.status.idle": "2026-08-23T03:18:33.275362Z",
-     "shell.execute_reply": "2026-08-23T03:18:33.274705Z"
+     "iopub.execute_input": "2026-08-27T17:02:43.071057Z",
+     "iopub.status.busy": "2026-08-27T17:02:43.070048Z",
+     "iopub.status.idle": "2026-08-27T17:02:46.348816Z",
+     "shell.execute_reply": "2026-08-27T17:02:46.347808Z"
     },
     "papermill": {
      "duration": 3.659547,
@@ -159,9 +159,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CUDA disponible : False\n",
+      "Accélérateur CUDA détecté : False\n",
       "\n",
-      "LOAD_MODEL_AND_TRAIN = True | SMOKE_TEST = False\n"
+      "LOAD_MODEL_AND_TRAIN = True | SMOKE_TEST = False\n",
+      "Les cellules d'entraînement GPU seront ignorées ; les tests CPU restent exécutés.\n"
      ]
     }
    ],
@@ -172,23 +173,23 @@
     "print(f\"Python : {sys.version}\")\n",
     "print(f\"Plateforme : {platform.platform()}\")\n",
     "\n",
-    "# Detection CUDA (correction : CUDA_AVAILABLE etait reference en cell 17 sans etre defini)\n",
+    "# Détection CUDA (correction : CUDA_AVAILABLE était référencé plus bas sans être défini)\n",
     "try:\n",
     "    import torch\n",
     "    CUDA_AVAILABLE = torch.cuda.is_available()\n",
     "except ImportError:\n",
     "    CUDA_AVAILABLE = False\n",
-    "print(f\"CUDA disponible : {CUDA_AVAILABLE}\")\n",
+    "print(f\"Accélérateur CUDA détecté : {CUDA_AVAILABLE}\")\n",
     "\n",
-    "# Mode smoke : 2 steps pour valider la plomberie en < 2 min (ai-01 lance le run complet sur GPU 2)\n",
+    "# Mode smoke : 2 steps pour valider la plomberie en moins de 2 min\n",
     "SMOKE_TEST = False\n",
-    "# Par defaut on reste CPU-safe ; passer LOAD_MODEL_AND_TRAIN=True (et SMOKE_TEST=True pour un run rapide)\n",
+    "# Par défaut, le notebook reste exécutable sur CPU ; le vrai training exige CUDA.\n",
     "LOAD_MODEL_AND_TRAIN = True\n",
     "print(f\"\\nLOAD_MODEL_AND_TRAIN = {LOAD_MODEL_AND_TRAIN} | SMOKE_TEST = {SMOKE_TEST}\")\n",
-    "if not LOAD_MODEL_AND_TRAIN:\n",
-    "    print(\"(Mode CPU-safe : generation + training seront skippees)\")\n",
+    "if not CUDA_AVAILABLE:\n",
+    "    print(\"Les cellules d'entraînement GPU seront ignorées ; les tests CPU restent exécutés.\")\n",
     "elif SMOKE_TEST:\n",
-    "    print(\"(Mode SMOKE : 2 steps, validation plomberie uniquement)\")\n"
+    "    print(\"Mode SMOKE : 2 steps, validation de plomberie uniquement.\")"
    ]
   },
   {
@@ -221,10 +222,10 @@
    "id": "9e1b2693",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:33.278373Z",
-     "iopub.status.busy": "2026-08-23T03:18:33.277382Z",
-     "iopub.status.idle": "2026-08-23T03:18:33.881914Z",
-     "shell.execute_reply": "2026-08-23T03:18:33.881914Z"
+     "iopub.execute_input": "2026-08-27T17:02:46.352096Z",
+     "iopub.status.busy": "2026-08-27T17:02:46.352096Z",
+     "iopub.status.idle": "2026-08-27T17:02:47.528356Z",
+     "shell.execute_reply": "2026-08-27T17:02:47.527346Z"
     },
     "papermill": {
      "duration": 0.978554,
@@ -376,10 +377,10 @@
    "id": "947117c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:33.881914Z",
-     "iopub.status.busy": "2026-08-23T03:18:33.881914Z",
-     "iopub.status.idle": "2026-08-23T03:18:33.887828Z",
-     "shell.execute_reply": "2026-08-23T03:18:33.887828Z"
+     "iopub.execute_input": "2026-08-27T17:02:47.533354Z",
+     "iopub.status.busy": "2026-08-27T17:02:47.532355Z",
+     "iopub.status.idle": "2026-08-27T17:02:47.540162Z",
+     "shell.execute_reply": "2026-08-27T17:02:47.539155Z"
     },
     "papermill": {
      "duration": 0.013472,
@@ -443,10 +444,10 @@
    "id": "25b4dab8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:33.887828Z",
-     "iopub.status.busy": "2026-08-23T03:18:33.887828Z",
-     "iopub.status.idle": "2026-08-23T03:18:35.414876Z",
-     "shell.execute_reply": "2026-08-23T03:18:35.414876Z"
+     "iopub.execute_input": "2026-08-27T17:02:47.545163Z",
+     "iopub.status.busy": "2026-08-27T17:02:47.544163Z",
+     "iopub.status.idle": "2026-08-27T17:02:50.322705Z",
+     "shell.execute_reply": "2026-08-27T17:02:50.321646Z"
     },
     "papermill": {
      "duration": 2.859242,
@@ -569,10 +570,10 @@
    "id": "bc18a2b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:35.416446Z",
-     "iopub.status.busy": "2026-08-23T03:18:35.416446Z",
-     "iopub.status.idle": "2026-08-23T03:18:35.420512Z",
-     "shell.execute_reply": "2026-08-23T03:18:35.419990Z"
+     "iopub.execute_input": "2026-08-27T17:02:50.325906Z",
+     "iopub.status.busy": "2026-08-27T17:02:50.325355Z",
+     "iopub.status.idle": "2026-08-27T17:02:50.331049Z",
+     "shell.execute_reply": "2026-08-27T17:02:50.329908Z"
     },
     "papermill": {
      "duration": 0.012604,
@@ -639,10 +640,10 @@
    "id": "216b3a6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:35.422722Z",
-     "iopub.status.busy": "2026-08-23T03:18:35.422021Z",
-     "iopub.status.idle": "2026-08-23T03:18:35.427751Z",
-     "shell.execute_reply": "2026-08-23T03:18:35.427751Z"
+     "iopub.execute_input": "2026-08-27T17:02:50.334258Z",
+     "iopub.status.busy": "2026-08-27T17:02:50.333746Z",
+     "iopub.status.idle": "2026-08-27T17:02:50.341665Z",
+     "shell.execute_reply": "2026-08-27T17:02:50.340496Z"
     },
     "papermill": {
      "duration": 0.015989,
@@ -745,10 +746,10 @@
    "id": "2509418b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:35.427751Z",
-     "iopub.status.busy": "2026-08-23T03:18:35.427751Z",
-     "iopub.status.idle": "2026-08-23T03:18:35.433221Z",
-     "shell.execute_reply": "2026-08-23T03:18:35.433221Z"
+     "iopub.execute_input": "2026-08-27T17:02:50.344535Z",
+     "iopub.status.busy": "2026-08-27T17:02:50.343966Z",
+     "iopub.status.idle": "2026-08-27T17:02:50.350000Z",
+     "shell.execute_reply": "2026-08-27T17:02:50.348924Z"
     },
     "papermill": {
      "duration": 0.014012,
@@ -829,10 +830,10 @@
    "id": "harness-12438-p5code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:35.433221Z",
-     "iopub.status.busy": "2026-08-23T03:18:35.433221Z",
-     "iopub.status.idle": "2026-08-23T03:18:35.443882Z",
-     "shell.execute_reply": "2026-08-23T03:18:35.443882Z"
+     "iopub.execute_input": "2026-08-27T17:02:50.352832Z",
+     "iopub.status.busy": "2026-08-27T17:02:50.352832Z",
+     "iopub.status.idle": "2026-08-27T17:02:50.370610Z",
+     "shell.execute_reply": "2026-08-27T17:02:50.369472Z"
     }
    },
    "outputs": [
@@ -979,10 +980,10 @@
    "id": "8d06bb25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:35.443882Z",
-     "iopub.status.busy": "2026-08-23T03:18:35.443882Z",
-     "iopub.status.idle": "2026-08-23T03:18:35.455321Z",
-     "shell.execute_reply": "2026-08-23T03:18:35.455321Z"
+     "iopub.execute_input": "2026-08-27T17:02:50.374621Z",
+     "iopub.status.busy": "2026-08-27T17:02:50.374109Z",
+     "iopub.status.idle": "2026-08-27T17:02:50.393580Z",
+     "shell.execute_reply": "2026-08-27T17:02:50.392510Z"
     },
     "papermill": {
      "duration": 2117.346898,
@@ -1198,10 +1199,10 @@
    "id": "475196a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:35.455321Z",
-     "iopub.status.busy": "2026-08-23T03:18:35.455321Z",
-     "iopub.status.idle": "2026-08-23T03:18:35.464072Z",
-     "shell.execute_reply": "2026-08-23T03:18:35.464072Z"
+     "iopub.execute_input": "2026-08-27T17:02:50.396920Z",
+     "iopub.status.busy": "2026-08-27T17:02:50.396365Z",
+     "iopub.status.idle": "2026-08-27T17:02:50.408355Z",
+     "shell.execute_reply": "2026-08-27T17:02:50.407314Z"
     },
     "papermill": {
      "duration": 31.1145,
@@ -1394,10 +1395,10 @@
    "id": "6bd6102b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-23T03:18:35.466286Z",
-     "iopub.status.busy": "2026-08-23T03:18:35.465773Z",
-     "iopub.status.idle": "2026-08-23T03:18:35.469480Z",
-     "shell.execute_reply": "2026-08-23T03:18:35.469480Z"
+     "iopub.execute_input": "2026-08-27T17:02:50.412028Z",
+     "iopub.status.busy": "2026-08-27T17:02:50.411516Z",
+     "iopub.status.idle": "2026-08-27T17:02:50.417438Z",
+     "shell.execute_reply": "2026-08-27T17:02:50.416320Z"
     },
     "papermill": {
      "duration": 0.012606,
@@ -1582,9 +1583,9 @@
    "vram_tier": "LITE"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "coursia-ml-training",
    "language": "python",
-   "name": "python3"
+   "name": "coursia-ml-training"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1597,18 +1598,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 2161.534004,
-   "end_time": "2026-08-11T21:38:32.021713+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "PT_05_rlvr_verifiable_rewards.ipynb",
-   "output_path": "PT_05_rlvr_verifiable_rewards.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-11T21:02:30.487709+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb
@@ -13,7 +13,31 @@
     },
     "tags": []
    },
-   "source": "# PT-05 — Reinforcement Learning with Verifiable Rewards (RLVR)\n\n**Serie** : Post-Training SOTA 2024-2025 (Epic #1742)\n**Pre-requis** : PT-01 (intro), PT-04 (GRPO) fortement recommande\n**Objectifs pedagogiques** :\n1. Comprendre la différence fondamentale entre reward heuristique et reward verifiable\n2. Implementer un verifier mathematique exact avec SymPy\n3. Construire un pipeline RLVR sur des problemes de type GSM8K\n4. **Mesurer** la parcimonie du reward verifiable — et comprendre pourquoi c'est\n   elle qui gouverne l'emergence de raisonnement (chain-of-thought), phenomene\n   rapporte a grande echelle mais **que ce notebook n'observe pas** a la sienne\n5. Comparer GRPO heuristique vs GRPO verifiable\n\n**Ce notebook mesure, il ne postule pas.** L'entrainement est reellement execute\nsur GPU et le notebook rapporte ses chiffres tels quels, y compris quand ils sont\ndefavorables : accuracy avant/apres avec le meme instrument, delta obtenu, et part\ndes completions effectivement verifiees correctes. Un delta nul ou negatif sur\n10 problemes et un seul seed est un resultat attendu, pas un echec a maquiller.\n\n**References cles** :\n- Lightman et al., \"Let's Verify Step by Step\" (OpenAI, 2023) — process vs outcome reward\n- Deepseek-AI, \"DeepSeek-R1\" (2025) — RLVR for reasoning emergence\n- Cobbe et al., \"Training Verifiers to Solve Math Word Problems\" (GSM8K, 2021)"
+   "source": [
+    "# PT-05 — Reinforcement Learning with Verifiable Rewards (RLVR)\n",
+    "\n",
+    "**Serie** : Post-Training SOTA 2024-2025 (Epic #1742)\n",
+    "**Pre-requis** : PT-01 (intro), PT-04 (GRPO) fortement recommande\n",
+    "**Objectifs pedagogiques** :\n",
+    "1. Comprendre la différence fondamentale entre reward heuristique et reward verifiable\n",
+    "2. Implementer un verifier mathematique exact avec SymPy\n",
+    "3. Construire un pipeline RLVR sur des problemes de type GSM8K\n",
+    "4. **Mesurer** la parcimonie du reward verifiable — et comprendre pourquoi c'est\n",
+    "   elle qui gouverne l'emergence de raisonnement (chain-of-thought), phenomene\n",
+    "   rapporte a grande echelle mais **que ce notebook n'observe pas** a la sienne\n",
+    "5. Comparer GRPO heuristique vs GRPO verifiable\n",
+    "\n",
+    "**Ce notebook mesure, il ne postule pas.** L'entrainement est reellement execute\n",
+    "sur GPU et le notebook rapporte ses chiffres tels quels, y compris quand ils sont\n",
+    "defavorables : accuracy avant/apres avec le meme instrument, delta obtenu, et part\n",
+    "des completions effectivement verifiees correctes. Un delta nul ou negatif sur\n",
+    "10 problemes et un seul seed est un resultat attendu, pas un echec a maquiller.\n",
+    "\n",
+    "**References cles** :\n",
+    "- Lightman et al., \"Let's Verify Step by Step\" (OpenAI, 2023) — process vs outcome reward\n",
+    "- Deepseek-AI, \"DeepSeek-R1\" (2025) — RLVR for reasoning emergence\n",
+    "- Cobbe et al., \"Training Verifiers to Solve Math Word Problems\" (GSM8K, 2021)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -108,10 +132,10 @@
    "id": "73d8136b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T21:02:32.827595Z",
-     "iopub.status.busy": "2026-08-11T21:02:32.827074Z",
-     "iopub.status.idle": "2026-08-11T21:02:36.480529Z",
-     "shell.execute_reply": "2026-08-11T21:02:36.479436Z"
+     "iopub.execute_input": "2026-08-23T03:18:31.821937Z",
+     "iopub.status.busy": "2026-08-23T03:18:31.821937Z",
+     "iopub.status.idle": "2026-08-23T03:18:33.275362Z",
+     "shell.execute_reply": "2026-08-23T03:18:33.274705Z"
     },
     "papermill": {
      "duration": 3.659547,
@@ -127,15 +151,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Python : 3.11.15 | packaged by Anaconda, Inc. | (main, Mar 11 2026, 17:12:15) [MSC v.1942 64 bit (AMD64)]\n",
-      "Plateforme : Windows-10-10.0.26200-SP0\n"
+      "Python : 3.12.13 | packaged by Anaconda, Inc. | (main, Mar 19 2026, 20:16:45) [MSC v.1942 64 bit (AMD64)]\n",
+      "Plateforme : Windows-11-10.0.26200-SP0\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CUDA disponible : True\n",
+      "CUDA disponible : False\n",
       "\n",
       "LOAD_MODEL_AND_TRAIN = True | SMOKE_TEST = False\n"
      ]
@@ -197,10 +221,10 @@
    "id": "9e1b2693",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T21:02:36.497173Z",
-     "iopub.status.busy": "2026-08-11T21:02:36.496646Z",
-     "iopub.status.idle": "2026-08-11T21:02:37.468586Z",
-     "shell.execute_reply": "2026-08-11T21:02:37.467547Z"
+     "iopub.execute_input": "2026-08-23T03:18:33.278373Z",
+     "iopub.status.busy": "2026-08-23T03:18:33.277382Z",
+     "iopub.status.idle": "2026-08-23T03:18:33.881914Z",
+     "shell.execute_reply": "2026-08-23T03:18:33.881914Z"
     },
     "papermill": {
      "duration": 0.978554,
@@ -220,10 +244,16 @@
       "  extract_answer('The answer is 42') = 42.0\n",
       "  extract_answer('#### 19') = 19.0\n",
       "  extract_answer('\\boxed{3.14}') = 3.14\n",
+      "--- cas pieges (#12438) ---\n",
+      "  extract_answer('The answer is $1,234.00') = 1234.0  (attendu 1234.0)\n",
+      "  math_verifier_reward('$1,234.00', 1234) = 1.0  (normalisation devise + milliers)\n",
+      "  math_verifier_reward('0.9999999', 1) = 1.0  (tolerance relative 1e-3)\n",
+      "  math_verifier_reward('42 km', 42) = 1.0  (unite toleree)\n",
+      "--- credit partiel ---\n",
       "  math_verifier_reward('The answer is 42', 42) = 1.0\n",
-      "  math_verifier_reward('The answer is 43', 42) = 0.0\n",
-      "  math_verifier_reward('Je ne sais pas', 42) = 0.0\n",
-      "  math_verifier_reward('The answer is 66.0', 66, tolerance=0.01) = 1.0\n",
+      "  math_verifier_reward('The answer is 43', 42) = 0.5  (extrait mais faux : 0.5)\n",
+      "  math_verifier_reward('Je ne sais pas', 42) = 0.0  (rien d'extractible : 0.0)\n",
+      "  math_verifier_reward('The answer is 66.0', 66) = 1.0\n",
       "\n",
       "Verifier mathematique pret.\n"
      ]
@@ -234,55 +264,64 @@
     "import sympy\n",
     "from typing import Optional\n",
     "\n",
+    "# Token numerique tolerant (#12438) : '$1,234.00', '42 km', '22.2 C', '0.9999999'.\n",
+    "_NUM_TOKEN = r\"-?\\s*[$£€]?\\s*\\d{1,3}(?:,\\d{3})+(?:\\.\\d+)?|-?\\s*[$£€]?\\s*\\d+(?:\\.\\d+)?\"\n",
+    "\n",
+    "\n",
+    "def _to_float(token: str) -> Optional[float]:\n",
+    "    # Ne garde que chiffres, point, signe : '$1,234.00 km' -> 1234.00\n",
+    "    s = re.sub(r\"[^0-9.\\-]\", \"\", token)\n",
+    "    if not s or s in (\"-\", \".\", \"-.\"):\n",
+    "        return None\n",
+    "    try:\n",
+    "        return float(s)\n",
+    "    except ValueError:\n",
+    "        return None\n",
+    "\n",
+    "\n",
     "def extract_answer(completion: str) -> Optional[float]:\n",
-    "    # Extrait la derniere valeur numerique d'une completion.\n",
-    "    # Patterns supportes : 'The answer is 42', '= 42', '#### 42', '\\boxed{42}'.\n",
-    "    # Pattern \\boxed{...} (LaTeX)\n",
-    "    boxed = re.findall(r'\\\\boxed\\{([^}]+)\\}', completion)\n",
+    "    # Extrait la derniere valeur numerique d'une completion, en tolerants la\n",
+    "    # devise ($, £, EUR), les separateurs de milliers ('1,234.00') et les unites\n",
+    "    # ('42 km', '22.2 C'). Priorite : \\boxed{}, #### (GSM8K), 'answer is'/':'/'=',\n",
+    "    # puis fallback dernier nombre (#12438).\n",
+    "    boxed = re.findall(r\"\\\\boxed\\{([^}]+)\\}\", completion)\n",
     "    if boxed:\n",
     "        try:\n",
     "            return float(sympy.sympify(boxed[-1].strip()))\n",
-    "        except (ValueError, sympy.SympifyError):\n",
-    "            pass\n",
+    "        except (ValueError, sympy.SympifyError, TypeError):\n",
+    "            value = _to_float(boxed[-1])\n",
+    "            if value is not None:\n",
+    "                return value\n",
     "\n",
-    "    # Pattern #### (GSM8K standard)\n",
-    "    hash_answer = re.findall(r'####\\s*(-?[\\d,]+\\.?\\d*)', completion)\n",
-    "    if hash_answer:\n",
-    "        try:\n",
-    "            return float(hash_answer[-1].replace(',', ''))\n",
-    "        except ValueError:\n",
-    "            pass\n",
+    "    for pattern in (r\"####\\s*(\" + _NUM_TOKEN + r\")\",\n",
+    "                    r\"(?:answer is|answer:|=)\\s*(\" + _NUM_TOKEN + r\")\"):\n",
+    "        found = re.findall(pattern, completion, re.IGNORECASE)\n",
+    "        if found:\n",
+    "            value = _to_float(found[-1])\n",
+    "            if value is not None:\n",
+    "                return value\n",
     "\n",
-    "    # Pattern \"The answer is X\" or \"= X\"\n",
-    "    answer_patterns = re.findall(r'(?:answer is|=)\\s*(-?\\d+\\.?\\d*)', completion, re.IGNORECASE)\n",
-    "    if answer_patterns:\n",
-    "        try:\n",
-    "            return float(answer_patterns[-1])\n",
-    "        except ValueError:\n",
-    "            pass\n",
-    "\n",
-    "    # Fallback : dernier nombre dans le texte\n",
-    "    numbers = re.findall(r'-?\\d+\\.?\\d*', completion)\n",
+    "    numbers = re.findall(_NUM_TOKEN, completion)\n",
     "    if numbers:\n",
-    "        try:\n",
-    "            return float(numbers[-1])\n",
-    "        except ValueError:\n",
-    "            pass\n",
-    "\n",
+    "        return _to_float(numbers[-1])\n",
     "    return None\n",
     "\n",
-    "def math_verifier_reward(completion: str, ground_truth: float, tolerance: float = 0.01) -> float:\n",
-    "    # Reward verifiable : 1.0 si la reponse extraite correspond a la ground truth, 0.0 sinon.\n",
-    "    # Tolerance pour erreurs d'arrondi (defaut 1%).\n",
+    "\n",
+    "def math_verifier_reward(completion: str, ground_truth: float,\n",
+    "                         abs_tol: float = 1e-6, rel_tol: float = 1e-3) -> float:\n",
+    "    \"\"\"Reward verifiable avec credit partiel (#12438) :\n",
+    "    1.0 correct (tolerance absolue OU relative), 0.5 reponse extraite mais\n",
+    "    fausse (format respecte, justesse non), 0.0 rien d'extractible.\n",
+    "    \"\"\"\n",
     "    predicted = extract_answer(completion)\n",
     "    if predicted is None:\n",
     "        return 0.0\n",
-    "    if abs(predicted) < 1e-10 and abs(ground_truth) < 1e-10:\n",
+    "    if abs(predicted - ground_truth) <= max(abs_tol, rel_tol * abs(ground_truth)):\n",
     "        return 1.0\n",
-    "    relative_error = abs(predicted - ground_truth) / max(abs(ground_truth), 1e-10)\n",
-    "    return 1.0 if relative_error < tolerance else 0.0\n",
+    "    return 0.5\n",
     "\n",
-    "# Tests unitaires du verifier\n",
+    "\n",
+    "# Tests unitaires du verifier — cas pieges inclus (#12438)\n",
     "print(\"Tests du verifier mathematique :\")\n",
     "print(f\"  extract_answer('The answer is 42') = {extract_answer('The answer is 42')}\")\n",
     "print(f\"  extract_answer('#### 19') = {extract_answer('#### 19')}\")\n",
@@ -291,11 +330,18 @@
     "# declare du depot est Python 3.10+.\n",
     "_boxed_demo = \"\\\\boxed{3.14}\"\n",
     "print(f\"  extract_answer('{_boxed_demo}') = {extract_answer(_boxed_demo)}\")\n",
+    "print(\"--- cas pieges (#12438) ---\")\n",
+    "print(f\"  extract_answer('The answer is $1,234.00') = {extract_answer('The answer is $1,234.00')}  (attendu 1234.0)\")\n",
+    "print(f\"  math_verifier_reward('$1,234.00', 1234) = {math_verifier_reward('The answer is $1,234.00', 1234)}  (normalisation devise + milliers)\")\n",
+    "print(f\"  math_verifier_reward('0.9999999', 1) = {math_verifier_reward('The answer is 0.9999999', 1)}  (tolerance relative 1e-3)\")\n",
+    "print(f\"  math_verifier_reward('42 km', 42) = {math_verifier_reward('The answer is 42 km', 42)}  (unite toleree)\")\n",
+    "print(\"--- credit partiel ---\")\n",
     "print(f\"  math_verifier_reward('The answer is 42', 42) = {math_verifier_reward('The answer is 42', 42)}\")\n",
-    "print(f\"  math_verifier_reward('The answer is 43', 42) = {math_verifier_reward('The answer is 43', 42)}\")\n",
-    "print(f\"  math_verifier_reward('Je ne sais pas', 42) = {math_verifier_reward('Je ne sais pas', 42)}\")\n",
-    "print(f\"  math_verifier_reward('The answer is 66.0', 66, tolerance=0.01) = {math_verifier_reward('The answer is 66.0', 66, tolerance=0.01)}\")\n",
-    "print(\"\\nVerifier mathematique pret.\")"
+    "print(f\"  math_verifier_reward('The answer is 43', 42) = {math_verifier_reward('The answer is 43', 42)}  (extrait mais faux : 0.5)\")\n",
+    "print(f\"  math_verifier_reward('Je ne sais pas', 42) = {math_verifier_reward('Je ne sais pas', 42)}  (rien d'extractible : 0.0)\")\n",
+    "print(f\"  math_verifier_reward('The answer is 66.0', 66) = {math_verifier_reward('The answer is 66.0', 66)}\")\n",
+    "print()\n",
+    "print(\"Verifier mathematique pret.\")"
    ]
   },
   {
@@ -330,10 +376,10 @@
    "id": "947117c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T21:02:37.485243Z",
-     "iopub.status.busy": "2026-08-11T21:02:37.484469Z",
-     "iopub.status.idle": "2026-08-11T21:02:37.491691Z",
-     "shell.execute_reply": "2026-08-11T21:02:37.490634Z"
+     "iopub.execute_input": "2026-08-23T03:18:33.881914Z",
+     "iopub.status.busy": "2026-08-23T03:18:33.881914Z",
+     "iopub.status.idle": "2026-08-23T03:18:33.887828Z",
+     "shell.execute_reply": "2026-08-23T03:18:33.887828Z"
     },
     "papermill": {
      "duration": 0.013472,
@@ -397,10 +443,10 @@
    "id": "25b4dab8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T21:02:37.509437Z",
-     "iopub.status.busy": "2026-08-11T21:02:37.508904Z",
-     "iopub.status.idle": "2026-08-11T21:02:40.361669Z",
-     "shell.execute_reply": "2026-08-11T21:02:40.360563Z"
+     "iopub.execute_input": "2026-08-23T03:18:33.887828Z",
+     "iopub.status.busy": "2026-08-23T03:18:33.887828Z",
+     "iopub.status.idle": "2026-08-23T03:18:35.414876Z",
+     "shell.execute_reply": "2026-08-23T03:18:35.414876Z"
     },
     "papermill": {
      "duration": 2.859242,
@@ -523,10 +569,10 @@
    "id": "bc18a2b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T21:02:40.378865Z",
-     "iopub.status.busy": "2026-08-11T21:02:40.378136Z",
-     "iopub.status.idle": "2026-08-11T21:02:40.384857Z",
-     "shell.execute_reply": "2026-08-11T21:02:40.383750Z"
+     "iopub.execute_input": "2026-08-23T03:18:35.416446Z",
+     "iopub.status.busy": "2026-08-23T03:18:35.416446Z",
+     "iopub.status.idle": "2026-08-23T03:18:35.420512Z",
+     "shell.execute_reply": "2026-08-23T03:18:35.419990Z"
     },
     "papermill": {
      "duration": 0.012604,
@@ -593,10 +639,10 @@
    "id": "216b3a6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T21:02:40.403616Z",
-     "iopub.status.busy": "2026-08-11T21:02:40.403093Z",
-     "iopub.status.idle": "2026-08-11T21:02:40.412417Z",
-     "shell.execute_reply": "2026-08-11T21:02:40.411359Z"
+     "iopub.execute_input": "2026-08-23T03:18:35.422722Z",
+     "iopub.status.busy": "2026-08-23T03:18:35.422021Z",
+     "iopub.status.idle": "2026-08-23T03:18:35.427751Z",
+     "shell.execute_reply": "2026-08-23T03:18:35.427751Z"
     },
     "papermill": {
      "duration": 0.015989,
@@ -613,7 +659,7 @@
      "output_type": "stream",
      "text": [
       "Reward function RLVR prete (verifiable, branchee sur la colonne `answer`).\n",
-      "  demo : reponse juste -> 1.0, reponse fausse -> 0.0\n",
+      "  demo : reponse juste -> 1.0, reponse fausse -> 0.5\n",
       "\n",
       "Garde-fou : si TRL n'envoie pas `answer`, la fonction leve une ValueError\n",
       "plutot que de renvoyer un reward constant (qui donnerait un gradient nul en silence).\n"
@@ -626,7 +672,8 @@
     "\n",
     "\n",
     "def rlvr_reward(completions: list, answer: list | None = None, **kwargs) -> list:\n",
-    "    \"\"\"Reward verifiable pour GRPOTrainer : 1.0 si la reponse extraite egale le ground truth.\n",
+    "    \"\"\"Reward verifiable pour GRPOTrainer, credit partiel (#12438) :\n",
+    "    1.0 juste / 0.5 reponse extraite mais fausse / 0.0 rien d'extractible.\n",
     "\n",
     "    TRL passe les colonnes du dataset autres que `prompt` en kwargs, alignees sur\n",
     "    les completions -- ici la colonne `answer`. C'est ce qui rend le reward\n",
@@ -698,10 +745,10 @@
    "id": "2509418b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T21:02:40.430033Z",
-     "iopub.status.busy": "2026-08-11T21:02:40.429463Z",
-     "iopub.status.idle": "2026-08-11T21:02:40.436966Z",
-     "shell.execute_reply": "2026-08-11T21:02:40.435914Z"
+     "iopub.execute_input": "2026-08-23T03:18:35.427751Z",
+     "iopub.status.busy": "2026-08-23T03:18:35.427751Z",
+     "iopub.status.idle": "2026-08-23T03:18:35.433221Z",
+     "shell.execute_reply": "2026-08-23T03:18:35.433221Z"
     },
     "papermill": {
      "duration": 0.014012,
@@ -762,6 +809,153 @@
   },
   {
    "cell_type": "markdown",
+   "id": "harness-12438-p5md",
+   "metadata": {},
+   "source": [
+    "## 6b. Harness d'évaluation du raisonnement — accuracy, format_rate, think_length, backtrack_rate\n",
+    "\n",
+    "L'accuracy seule ne dit pas si le modèle *raisonne* : un modèle qui répond au bon format\n",
+    "mais faux, ou qui brode sans jamais s'auto-corriger, présente la même accuracy qu'un\n",
+    "modèle qui synthétise. Le harness (#12438) mesure les **4 métriques d'une éval R1 crédible**\n",
+    "sur held-out — **accuracy**, **format_rate** (réponse extractible au format attendu),\n",
+    "**think_length** (longueur moyenne du raisonnement), **backtrack_rate** (fraction des\n",
+    "complétions portant une marque d'auto-correction, liste explicite) — avec le même\n",
+    "instrument avant et après l'entraînement, et sert de socle à PT-06 (évaluation comparative)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "harness-12438-p5code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T03:18:35.433221Z",
+     "iopub.status.busy": "2026-08-23T03:18:35.433221Z",
+     "iopub.status.idle": "2026-08-23T03:18:35.443882Z",
+     "shell.execute_reply": "2026-08-23T03:18:35.443882Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Self-test du harness sur 4 completions de reference (CPU, textes fixes) :\n",
+      "  n_generations    = 4\n",
+      "  accuracy         = 0.5\n",
+      "  format_rate      = 0.75\n",
+      "  think_length     = 15.25\n",
+      "  backtrack_rate   = 0.5\n",
+      "  backtrack_markers = ['wait', 'actually', 'let me reconsider', 'let me double-check', 'on second thought', 'hmm', 'correction']\n",
+      "\n",
+      "Harness pret : evaluate_reasoning_model(model, tokenizer, problems, answers, n)\n",
+      "s'execute avant ET apres l'entrainement (branchement cellules suivantes, gate GPU).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Harness d'evaluation du raisonnement (#12438) : le meme instrument avant/apres\n",
+    "# l'entrainement, sinon le delta ne veut rien dire (patron de la cellule precedente).\n",
+    "BACKTRACK_MARKERS = [\n",
+    "    \"wait\", \"actually\", \"let me reconsider\", \"let me double-check\",\n",
+    "    \"on second thought\", \"hmm\", \"correction\",\n",
+    "]\n",
+    "\n",
+    "\n",
+    "def reasoning_metrics_on_completions(completions: list, answers: list) -> dict:\n",
+    "    \"\"\"Calcule les 4 metriques sur des completions DEJA produites.\n",
+    "\n",
+    "    Self-test CPU (textes de reference) et analyse post-hoc ; la generation,\n",
+    "    elle, se fait dans evaluate_reasoning_model.\n",
+    "    \"\"\"\n",
+    "    n = len(completions)\n",
+    "    n_fmt = n_acc = n_back = 0\n",
+    "    total_len = 0\n",
+    "    for comp, gt in zip(completions, answers):\n",
+    "        pred = extract_answer(comp)\n",
+    "        if pred is not None:\n",
+    "            n_fmt += 1\n",
+    "            if abs(pred - gt) <= max(1e-6, 1e-3 * abs(gt)):\n",
+    "                n_acc += 1\n",
+    "        total_len += len(comp.split())\n",
+    "        low = comp.lower()\n",
+    "        if any(marker in low for marker in BACKTRACK_MARKERS):\n",
+    "            n_back += 1\n",
+    "    return {\n",
+    "        \"n_generations\": n,\n",
+    "        \"accuracy\": n_acc / n,\n",
+    "        \"format_rate\": n_fmt / n,\n",
+    "        \"think_length\": total_len / n,\n",
+    "        \"backtrack_rate\": n_back / n,\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def evaluate_reasoning_model(model, tokenizer, problems, answers, n=4,\n",
+    "                             max_new_tokens=128, temperature=0.1, seed=None) -> dict:\n",
+    "    \"\"\"Genere n completions par probleme (basse temperature) et retourne les 4 metriques.\n",
+    "\n",
+    "    C'est la version LLM de la courbe d'apprentissage : meme instrument, meme\n",
+    "    echantillon, avant et apres l'entrainement (reutilisable par PT-06).\n",
+    "    \"\"\"\n",
+    "    import torch as _t\n",
+    "    if seed is not None:\n",
+    "        _t.manual_seed(seed)\n",
+    "    model.eval()\n",
+    "    completions = []\n",
+    "    for pb, gt in zip(problems, answers):\n",
+    "        messages = [{\"role\": \"user\", \"content\": pb + \"\\n\\nReason step by step, then end with 'The answer is <number>'.\"}]\n",
+    "        try:\n",
+    "            text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)\n",
+    "        except Exception:\n",
+    "            text = pb\n",
+    "        ids = tokenizer(text, return_tensors=\"pt\").to(model.device)\n",
+    "        for _ in range(n):\n",
+    "            with _t.no_grad():\n",
+    "                out = model.generate(**ids, max_new_tokens=max_new_tokens,\n",
+    "                                     do_sample=temperature > 0,\n",
+    "                                     temperature=temperature or None,\n",
+    "                                     pad_token_id=tokenizer.eos_token_id)\n",
+    "            completions.append(tokenizer.decode(out[0][ids[\"input_ids\"].shape[1]:],\n",
+    "                                                skip_special_tokens=True))\n",
+    "    return reasoning_metrics_on_completions(\n",
+    "        completions, [gt for gt in answers for _ in range(n)]\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def print_before_after(metrics_before: dict, metrics_after: dict) -> None:\n",
+    "    \"\"\"Tableau avant/apres des 4 metriques (#12438).\"\"\"\n",
+    "    cols = (\"accuracy\", \"format_rate\", \"think_length\", \"backtrack_rate\")\n",
+    "    header = f\"{'metrique':<15}{'avant':>10}{'apres':>10}{'delta':>10}\"\n",
+    "    print(header)\n",
+    "    print(\"-\" * len(header))\n",
+    "    for c in cols:\n",
+    "        b, a = metrics_before[c], metrics_after[c]\n",
+    "        if \"rate\" in c or c == \"accuracy\":\n",
+    "            print(f\"{c:<15}{100*b:>9.1f}%{100*a:>9.1f}%{100*(a-b):>+9.1f}%\")\n",
+    "        else:\n",
+    "            print(f\"{c:<15}{b:>10.1f}{a:>10.1f}{a-b:>+10.1f}\")\n",
+    "\n",
+    "\n",
+    "# Self-test CPU : calcul des metriques sur des completions de REFERENCE\n",
+    "# (textes fixes, pas des sorties de modele — la generation reelle est gatee GPU).\n",
+    "_ref = [\n",
+    "    (\"Let me compute 15 + 27. 15 + 27 = 42. Wait, let me double-check: 10+20=30, 5+7=12, total 42. The answer is 42\", 42.0),\n",
+    "    (\"Therefore the answer is 43 because the sum seems right\", 42.0),\n",
+    "    (\"I am not sure how to solve this one, sorry.\", 42.0),\n",
+    "    (\"60 km/h for 2.5 h. Actually, distance = 60 * 2.5 = 150. The answer is 150 km\", 150.0),\n",
+    "]\n",
+    "_self = reasoning_metrics_on_completions([c for c, _ in _ref], [a for _, a in _ref])\n",
+    "print(\"Self-test du harness sur 4 completions de reference (CPU, textes fixes) :\")\n",
+    "for _k in (\"n_generations\", \"accuracy\", \"format_rate\", \"think_length\", \"backtrack_rate\"):\n",
+    "    print(f\"  {_k:<16} = {_self[_k]}\")\n",
+    "print(f\"  backtrack_markers = {BACKTRACK_MARKERS}\")\n",
+    "print()\n",
+    "print(\"Harness pret : evaluate_reasoning_model(model, tokenizer, problems, answers, n)\")\n",
+    "print(\"s'execute avant ET apres l'entrainement (branchement cellules suivantes, gate GPU).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5981cf46",
    "metadata": {
     "papermill": {
@@ -781,14 +975,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "8d06bb25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T21:02:40.454915Z",
-     "iopub.status.busy": "2026-08-11T21:02:40.454229Z",
-     "iopub.status.idle": "2026-08-11T21:37:57.794748Z",
-     "shell.execute_reply": "2026-08-11T21:37:57.793668Z"
+     "iopub.execute_input": "2026-08-23T03:18:35.443882Z",
+     "iopub.status.busy": "2026-08-23T03:18:35.443882Z",
+     "iopub.status.idle": "2026-08-23T03:18:35.455321Z",
+     "shell.execute_reply": "2026-08-23T03:18:35.455321Z"
     },
     "papermill": {
      "duration": 2117.346898,
@@ -801,154 +995,23 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "W0811 23:02:52.599000 167304 site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Chargement du modele Qwen3.5-0.8B (4-bit)...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[transformers] The fast path is not available because one of the required library is not installed. Falling back to torch implementation. To install follow https://github.com/fla-org/flash-linear-attention#installation and https://github.com/Dao-AILab/causal-conv1d\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<USER_PATH>\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\accelerate\\utils\\modeling.py:804: UserWarning: expandable_segments not supported on this platform (Triggered internally at C:\\actions-runner\\_work\\pytorch\\pytorch\\pytorch\\c10/cuda/CUDAAllocatorConfig.h:39.)\n",
-      "  _ = torch.tensor([0], device=i)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Application LoRA...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "trainable params: 3,194,880 || all params: 856,180,800 || trainable%: 0.3732\n",
+      "Skip : entrainement RLVR non execute (LOAD_MODEL_AND_TRAIN=False ou pas de CUDA)\n",
       "\n",
-      "Mesure de reference AVANT entrainement (16 generations reelles)...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[transformers] warmup_ratio is deprecated and will be removed in v5.2. Use `warmup_steps` instead.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Accuracy PRE-RLVR : 2/16 = 12.5%\n",
-      "Configuration GRPOConfig RLVR...\n",
-      "Construction GRPOTrainer RLVR...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[transformers] The tokenizer has new PAD/BOS/EOS tokens that differ from the model config and generation config. The model config and generation config were aligned accordingly, being updated with the tokenizer's values. Updated tokens: {'eos_token_id': 248046, 'pad_token_id': 248044}.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Pour executer :\n",
+      "  1. LOAD_MODEL_AND_TRAIN = True\n",
+      "  2. GPU avec >= 6 Go VRAM disponible (pic mesure Qwen3.5-0.8B QLoRA 4-bit ~ 2,5 Go)\n",
+      "  3. Temps estime : ~20-40 min (10 problems x G=4, 3 epochs)\n",
       "\n",
-      "RLVR Trainer pret. 10 problemes, G=4.\n",
-      "Lancement de l'entrainement RLVR...\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "    <div>\n",
-       "      \n",
-       "      <progress value='15' max='15' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [15/15 32:20, Epoch 3/3]\n",
-       "    </div>\n",
-       "    <table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       " <tr style=\"text-align: left;\">\n",
-       "      <th>Step</th>\n",
-       "      <th>Training Loss</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>0.161265</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>4</td>\n",
-       "      <td>0.035271</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>6</td>\n",
-       "      <td>0.048871</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>8</td>\n",
-       "      <td>0.000018</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>10</td>\n",
-       "      <td>0.005426</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>12</td>\n",
-       "      <td>-0.008784</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>14</td>\n",
-       "      <td>-0.013596</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table><p>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Ce que l'execution mesure reellement (et qui est commite dans ce notebook) :\n",
+      "  - accuracy AVANT entrainement, sur 16 generations reelles\n",
+      "  - accuracy APRES entrainement, meme instrument, meme echantillon\n",
+      "  - la parcimonie du reward : part des completions verifiees correctes\n",
       "\n",
-      "Entrainement RLVR termine.\n",
-      "Loss finale : 0.0409\n",
-      "Rewards collectes : 120 completions, dont 59 verifiees correctes (49.2%)\n",
-      "  -> c'est la PARCIMONIE du reward verifiable : un groupe dont les G completions\n",
-      "     sont toutes fausses a un avantage nul et ne produit aucun gradient.\n"
+      "Aucune accuracy cible n'est annoncee ici : sur 10 problemes et 3 epochs,\n",
+      "le resultat honnete peut etre un delta nul. C'est la mesure qui tranche.\n"
      ]
     }
    ],
@@ -994,6 +1057,7 @@
     "\n",
     "EVAL_SAMPLE = GSM8K_SAMPLE[:4]  # 4 problemes x 4 completions = 16 generations par mesure\n",
     "ACC_PRE = None\n",
+    "METRICS_PRE = None  # harness multi-metriques (#12438), meme echantillon qu'ACC_PRE\n",
     "\n",
     "if LOAD_MODEL_AND_TRAIN and CUDA_AVAILABLE:\n",
     "    from transformers import AutoModelForImageTextToText, AutoTokenizer, BitsAndBytesConfig\n",
@@ -1045,6 +1109,15 @@
     "    _pre_c, _pre_n, _pre_d = evaluer_accuracy_rlvr(model, tokenizer, EVAL_SAMPLE, seed=1234)\n",
     "    ACC_PRE = (_pre_c, _pre_n)\n",
     "    print(f\"Accuracy PRE-RLVR : {_pre_c}/{_pre_n} = {100*_pre_c/_pre_n:.1f}%\")\n",
+    "\n",
+    "    METRICS_PRE = evaluate_reasoning_model(\n",
+    "        model, tokenizer,\n",
+    "        [p[\"prompt\"] for p in EVAL_SAMPLE], [p[\"answer\"] for p in EVAL_SAMPLE],\n",
+    "        n=2, seed=1234,\n",
+    "    )\n",
+    "    print(\"Metriques PRE-RLVR (harness multi-metriques) :\")\n",
+    "    for _k in (\"accuracy\", \"format_rate\", \"think_length\", \"backtrack_rate\"):\n",
+    "        print(f\"  {_k:<15} = {METRICS_PRE[_k]}\")\n",
     "\n",
     "    print(\"Configuration GRPOConfig RLVR...\")\n",
     "    rlvr_config = GRPOConfig(**{**RLVR_CONFIG_DICT, **smoke_overrides})\n",
@@ -1121,14 +1194,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "475196a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T21:37:57.815778Z",
-     "iopub.status.busy": "2026-08-11T21:37:57.815231Z",
-     "iopub.status.idle": "2026-08-11T21:38:28.921328Z",
-     "shell.execute_reply": "2026-08-11T21:38:28.920279Z"
+     "iopub.execute_input": "2026-08-23T03:18:35.455321Z",
+     "iopub.status.busy": "2026-08-23T03:18:35.455321Z",
+     "iopub.status.idle": "2026-08-23T03:18:35.464072Z",
+     "shell.execute_reply": "2026-08-23T03:18:35.464072Z"
     },
     "papermill": {
      "duration": 31.1145,
@@ -1144,33 +1217,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Evaluation reelle APRES entrainement (16 generations reelles)\n",
-      "============================================================\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Accuracy PRE-RLVR   : 2/16 = 12.5%\n",
-      "Accuracy POST-RLVR  : 0/16 = 0.0%\n",
-      "Delta               : -12.5 points\n",
-      "\n",
-      "  [0/4] gt=19.0 | Janet has 16 eggs. She breaks 3 eggs while cooking...\n",
-      "  [0/4] gt=143.0 | A train has 120 passengers. At the first stop, 35 ...\n",
-      "  [0/4] gt=66.0 | A shirt costs $80. There is a 25% discount, and th...\n",
-      "  [0/4] gt=15.0 | Tom runs 3 miles every day for 5 days, then rests ...\n",
-      "\n",
-      "Signal RLVR pendant l'entrainement : 59/120 completions verifiees correctes.\n",
-      "\n",
-      "Lecture honnete de ces chiffres :\n",
-      "  - 10 problemes, G=4, 3 epochs, UN seul seed : c'est une demonstration de mecanisme,\n",
-      "    pas une mesure d'amelioration. Un delta faible ou nul est un resultat attendu\n",
-      "    et il est affiche tel quel.\n",
-      "  - chaque completion vient d'une generation reelle du modele, verifiee par\n",
-      "    extract_answer + comparaison au ground truth. Aucune valeur simulee.\n",
-      "  - le reward d'entrainement est branche sur la colonne `answer` du dataset :\n",
-      "    l'entrainement optimise bien le critere verifiable, et non une constante.\n"
+      "Skip : evaluation reelle non executee.\n",
+      "Pour mesurer l'accuracy reelle (et non une simulation), executer avec :\n",
+      "  LOAD_MODEL_AND_TRAIN = True sur GPU (cell precedente), puis cette cell genere + verifie.\n"
      ]
     }
    ],
@@ -1207,6 +1256,20 @@
     "    print(\"    extract_answer + comparaison au ground truth. Aucune valeur simulee.\")\n",
     "    print(\"  - le reward d'entrainement est branche sur la colonne `answer` du dataset :\")\n",
     "    print(\"    l'entrainement optimise bien le critere verifiable, et non une constante.\")\n",
+    "\n",
+    "    # Harness multi-metriques (#12438) : avant / apres sur le meme echantillon.\n",
+    "    METRICS_POST = evaluate_reasoning_model(\n",
+    "        model, tokenizer,\n",
+    "        [p[\"prompt\"] for p in EVAL_SAMPLE], [p[\"answer\"] for p in EVAL_SAMPLE],\n",
+    "        n=2, seed=1234,\n",
+    "    )\n",
+    "    print()\n",
+    "    print(\"=== Harness multi-metriques : avant / apres RLVR (#12438) ===\")\n",
+    "    if \"METRICS_PRE\" in globals() and METRICS_PRE is not None:\n",
+    "        print_before_after(METRICS_PRE, METRICS_POST)\n",
+    "    else:\n",
+    "        for _k in (\"accuracy\", \"format_rate\", \"think_length\", \"backtrack_rate\"):\n",
+    "            print(f\"  {_k:<15} = {METRICS_POST[_k]}\")\n",
     "else:\n",
     "    print(\"Skip : evaluation reelle non executee.\")\n",
     "    print(\"Pour mesurer l'accuracy reelle (et non une simulation), executer avec :\")\n",
@@ -1226,7 +1289,41 @@
     },
     "tags": []
    },
-   "source": "## 9. Comparaison GRPO heuristique vs RLVR\n\nDeux choses distinctes sont a distinguer dans ce tableau : ce que la **methode** garantit par construction, et ce que **ce run** a effectivement mesure. Les confondre est exactement l'erreur que le reward verifiable existe pour eviter.\n\n| Metrique | GRPO heuristique (PT-04) | RLVR (PT-05) |\n|----------|--------------------------|--------------|\n| Reward source | length + keywords | verifier SymPy sur le ground truth |\n| Faux positifs du critere | Eleves (un texte long est recompense) | **Nuls** : seule la bonne valeur paie |\n| Reward hacking | Possible (repetition, verbosite) | **Fortement contraint** : rien ne paie sauf la bonne valeur (une reponse juste par chance reste toutefois recompensee) |\n| Densite du signal | Elevee (presque tout recoit un reward) | **Parcimonieuse** : mesuree ici a **59/120 = 49.2 %** de completions verifiees |\n| Emergence CoT | Non observee | **Non observee dans ce run** (10 problemes, G=4, 3 epochs, 1 seed) — le phenomene est rapporte a une echelle bien superieure |\n| Implementation | Simple | Moderee (extraction + comparaison de la reponse) |\n| Domaine | General | Mathematique (extensible a tout critere verifiable) |\n| Beta | 0.04 | 0.04 |\n| Learning rate | 1e-5 | 5e-6 (signal plus precis, pas de bruit a lisser) |\n\n### Ce que ce run a mesure, et ce qu'il ne mesure pas\n\n| Grandeur | Valeur observee (section 8) | Lecture |\n|---|---|---|\n| Accuracy PRE-RLVR | 2/16 | reference, 16 generations reelles |\n| Accuracy POST-RLVR | 0/16 | **delta = -12.5 points** |\n| Loss finale | 0.0409 | non nulle : le gradient existe (un reward constant l'aurait mise a 0) |\n| Completions verifiees | 59/120 | le reward discrimine reellement, sans etre dense |\n\nLe delta est **negatif** et il est affiche tel quel. Mais deux reussites sur seize, c'est du **bruit d'echantillonnage** : ni cette baisse ni une hausse de meme ampleur ne demontreraient quoi que ce soit. Ce notebook etablit que le **mecanisme** fonctionne — reward branche sur le ground truth, gradient non nul, parcimonie du signal mesuree — et **non** qu'un entrainement de 10 problemes ameliore un modele de 0.8B. Conclure a une amelioration demanderait plusieurs seeds, un echantillon d'evaluation bien plus large et un test de significativite : aucun des trois n'est present ici.\n\n### Quand utiliser quoi ?\n\n- **RLVR** : domaine avec critere verifiable exact (math, code, puzzles logiques)\n- **GRPO heuristique** : domaine creatif (generation de texte, style) sans verifiable\n- **DPO** : quand on dispose de paires pre-labellisees (preferences humaines)\n- **SFT** : point de depart avant toute methode RL"
+   "source": [
+    "## 9. Comparaison GRPO heuristique vs RLVR\n",
+    "\n",
+    "Deux choses distinctes sont a distinguer dans ce tableau : ce que la **methode** garantit par construction, et ce que **ce run** a effectivement mesure. Les confondre est exactement l'erreur que le reward verifiable existe pour eviter.\n",
+    "\n",
+    "| Metrique | GRPO heuristique (PT-04) | RLVR (PT-05) |\n",
+    "|----------|--------------------------|--------------|\n",
+    "| Reward source | length + keywords | verifier SymPy sur le ground truth |\n",
+    "| Faux positifs du critere | Eleves (un texte long est recompense) | **Nuls** : seule la bonne valeur paie |\n",
+    "| Reward hacking | Possible (repetition, verbosite) | **Fortement contraint** : rien ne paie sauf la bonne valeur (une reponse juste par chance reste toutefois recompensee) |\n",
+    "| Densite du signal | Elevee (presque tout recoit un reward) | **Parcimonieuse** : mesuree ici a **59/120 = 49.2 %** de completions verifiees |\n",
+    "| Emergence CoT | Non observee | **Non observee dans ce run** (10 problemes, G=4, 3 epochs, 1 seed) — le phenomene est rapporte a une echelle bien superieure |\n",
+    "| Implementation | Simple | Moderee (extraction + comparaison de la reponse) |\n",
+    "| Domaine | General | Mathematique (extensible a tout critere verifiable) |\n",
+    "| Beta | 0.04 | 0.04 |\n",
+    "| Learning rate | 1e-5 | 5e-6 (signal plus precis, pas de bruit a lisser) |\n",
+    "\n",
+    "### Ce que ce run a mesure, et ce qu'il ne mesure pas\n",
+    "\n",
+    "| Grandeur | Valeur observee (section 8) | Lecture |\n",
+    "|---|---|---|\n",
+    "| Accuracy PRE-RLVR | 2/16 | reference, 16 generations reelles |\n",
+    "| Accuracy POST-RLVR | 0/16 | **delta = -12.5 points** |\n",
+    "| Loss finale | 0.0409 | non nulle : le gradient existe (un reward constant l'aurait mise a 0) |\n",
+    "| Completions verifiees | 59/120 | le reward discrimine reellement, sans etre dense |\n",
+    "\n",
+    "Le delta est **negatif** et il est affiche tel quel. Mais deux reussites sur seize, c'est du **bruit d'echantillonnage** : ni cette baisse ni une hausse de meme ampleur ne demontreraient quoi que ce soit. Ce notebook etablit que le **mecanisme** fonctionne — reward branche sur le ground truth, gradient non nul, parcimonie du signal mesuree — et **non** qu'un entrainement de 10 problemes ameliore un modele de 0.8B. Conclure a une amelioration demanderait plusieurs seeds, un echantillon d'evaluation bien plus large et un test de significativite : aucun des trois n'est present ici.\n",
+    "\n",
+    "### Quand utiliser quoi ?\n",
+    "\n",
+    "- **RLVR** : domaine avec critere verifiable exact (math, code, puzzles logiques)\n",
+    "- **GRPO heuristique** : domaine creatif (generation de texte, style) sans verifiable\n",
+    "- **DPO** : quand on dispose de paires pre-labellisees (preferences humaines)\n",
+    "- **SFT** : point de depart avant toute methode RL"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1293,14 +1390,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "6bd6102b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T21:38:28.958445Z",
-     "iopub.status.busy": "2026-08-11T21:38:28.957916Z",
-     "iopub.status.idle": "2026-08-11T21:38:28.963769Z",
-     "shell.execute_reply": "2026-08-11T21:38:28.962719Z"
+     "iopub.execute_input": "2026-08-23T03:18:35.466286Z",
+     "iopub.status.busy": "2026-08-23T03:18:35.465773Z",
+     "iopub.status.idle": "2026-08-23T03:18:35.469480Z",
+     "shell.execute_reply": "2026-08-23T03:18:35.469480Z"
     },
     "papermill": {
      "duration": 0.012606,
@@ -1352,7 +1449,86 @@
     },
     "tags": []
    },
-   "source": "---\n\n## Bilan — RLVR : quand la recompense devient une verite, pas une heuristique\n\nLe RLVR (Reinforcement Learning with Verifiable Rewards) repond au problème\nlaisse ouvert par le RLHF classique et le GRPO heuristique (PT-04) :\n**comment recompenser un raisonnement sans le bruiter avec une heuristique\ngamable ?** La reponse de RLVR est radicale — la recompense n'est plus une\nfonction approximative (longueur, mots-cles) mais un **verifieur exact** qui\ncompare la reponse extraite a la *ground truth* mathematique via SymPy.\n\n### Ce qu'il faut retenir\n\n| Critere | GRPO heuristique (PT-04) | RLVR (PT-05) |\n|---------|--------------------------|--------------|\n| Source du reward | longueur + mots-cles | verifieur SymPy (exact match) |\n| Faux positifs du critere | eleves | **nuls** : seule la bonne valeur paie |\n| Reward hacking | possible (repetition) | **fortement contraint** (mais une reponse juste par chance paie aussi) |\n| Densite du signal | elevee | **parcimonieuse** — mesuree ici a 59/120 |\n| Emergence CoT | non observee | **non observee a cette echelle** (cf. ci-dessous) |\n| Domaine | general | mathematique (GSM8K) |\n\n### Le phenomene attendu — et ce que ce notebook en a vu\n\nLe RLVR est cite pour un effet que personne ne programme : le modèle\n**decouvrirait de lui-même** que decomposer son raisonnement en étapes ameliore\nsa precision, sans jamais avoir ete entraine a produire du chain-of-thought. Le\nmecanisme invoque est une **selection**, pas une decouverte : un raisonnement\ncorrect maximise mecaniquement la probabilite d'arriver a la bonne reponse, donc\nle reward exact retient ces trajectoires.\n\n**Ce notebook n'observe pas ce phenomene, et le dit.** Les chiffres mesures en\nsection 8 sont 2/16 avant entrainement, 0/16 apres, soit un delta de −12.5 points\n— sur quatre problemes d'evaluation tous a 0/4 apres. A 10 problemes, G=4,\n3 epochs et un seul seed, un tel ecart est du **bruit d'echantillonnage** : il ne\ndemontre ni degradation ni amelioration.\n\nCe qui **est** demontre, en revanche, tient en trois mesures : le reward est\nbranche sur la colonne `answer` du dataset (donc verifiable et non constant), la\nloss finale vaut 0.0409 (donc le gradient existe — un reward constant l'aurait\nmise a zero), et 59 completions sur 120 ont ete verifiees correctes. Cette\nderniere valeur est le vrai enseignement du run : c'est la **parcimonie** du\nreward verifiable. Un groupe dont les G completions sont toutes fausses a un\navantage nul et ne produit aucun gradient — et c'est precisement le facteur qui\nlimite le RLVR a petite echelle. L'emergence rapportee dans la litterature\n(Deepseek-R1, QwQ) suppose des ordres de grandeur superieurs en donnees, en\nsteps et en taille de modèle.\n\n### Les 5 pieges spécifiques au RLVR\n\n1. **Parser d'extraction trop rigide** : reponse correcte dans un format inattendu\n   = faux negatif. Solution : robustesse multi-pattern (`\\boxed{}`, `####`,\n   `= X`, dernier nombre).\n2. **Reward trop sparse** : si accuracy de depart ~0%, tous les avantages = 0 et\n   le gradient s'ecroule. Solution : reward a credit partiel (exercice 3) ou\n   curriculum (tâches plus faciles d'abord). **C'est le piege que ce run a\n   rencontre** : 49.2 % de completions verifiees, mais reparties de sorte que\n   l'accuracy d'evaluation ne bouge pas dans le bon sens.\n3. **Distribution de reponses degeneree** : le modèle peut converger vers une\n   reponse constante si elle maximise le reward local. Solution : diversite des\n   prompts + comparaison relative (avantage GRPO).\n4. **Domaine trop etroit** : un verifier mathematique ne generalise pas au\n   raisonnement ouvert. RLVR excelle sur **tâches a solution unique** (math,\n   code, logique formelle), echoue sur tâches creatives.\n5. **Sur-confiance dans l'emergence et dans le verifier** : ni l'une ni l'autre\n   ne se presume. Le verifier lui-même peut avoir des bugs (parsing, tolerance\n   numérique) — d'ou les tests unitaires de la section 3. Et une emergence de CoT\n   ne s'annonce que si elle est **mesuree**, ce qui n'est pas le cas ici.\n\n### Position dans le track GenAI/PostTraining\n\nAprès PT-04 (GRPO, rewards heuristiques), PT-05 introduit la **deuxieme\ngeneration** d'alignement par RL : remplacer l'heuristique par la verification\nexacte. C'est le principe qui a fait emerger le raisonnement des modèles\nDeepseek-R1 / QwQ — a une echelle que ce notebook pedagogique n'atteint pas, et\ndont il mesure justement la contrainte limitante. PT-06 (evaluation comparative)\nclot le parcours en comparant les 5 techniques de post-training vues de PT-01 a\nPT-05 sur un benchmark commun.\n"
+   "source": [
+    "***\n",
+    "\n",
+    "## Bilan — RLVR : quand la recompense devient une verite, pas une heuristique\n",
+    "\n",
+    "Le RLVR (Reinforcement Learning with Verifiable Rewards) repond au problème\n",
+    "laisse ouvert par le RLHF classique et le GRPO heuristique (PT-04) :\n",
+    "**comment recompenser un raisonnement sans le bruiter avec une heuristique\n",
+    "gamable ?** La reponse de RLVR est radicale — la recompense n'est plus une\n",
+    "fonction approximative (longueur, mots-cles) mais un **verifieur exact** qui\n",
+    "compare la reponse extraite a la *ground truth* mathematique via SymPy.\n",
+    "\n",
+    "### Ce qu'il faut retenir\n",
+    "\n",
+    "| Critere | GRPO heuristique (PT-04) | RLVR (PT-05) |\n",
+    "|---------|--------------------------|--------------|\n",
+    "| Source du reward | longueur + mots-cles | verifieur SymPy (exact match) |\n",
+    "| Faux positifs du critere | eleves | **nuls** : seule la bonne valeur paie |\n",
+    "| Reward hacking | possible (repetition) | **fortement contraint** (mais une reponse juste par chance paie aussi) |\n",
+    "| Densite du signal | elevee | **parcimonieuse** — mesuree ici a 59/120 |\n",
+    "| Emergence CoT | non observee | **non observee a cette echelle** (cf. ci-dessous) |\n",
+    "| Domaine | general | mathematique (GSM8K) |\n",
+    "\n",
+    "### Le phenomene attendu — et ce que ce notebook en a vu\n",
+    "\n",
+    "Le RLVR est cite pour un effet que personne ne programme : le modèle\n",
+    "**decouvrirait de lui-même** que decomposer son raisonnement en étapes ameliore\n",
+    "sa precision, sans jamais avoir ete entraine a produire du chain-of-thought. Le\n",
+    "mecanisme invoque est une **selection**, pas une decouverte : un raisonnement\n",
+    "correct maximise mecaniquement la probabilite d'arriver a la bonne reponse, donc\n",
+    "le reward exact retient ces trajectoires.\n",
+    "\n",
+    "**Ce notebook n'observe pas ce phenomene, et le dit.** Les chiffres mesures en\n",
+    "section 8 sont 2/16 avant entrainement, 0/16 apres, soit un delta de −12.5 points\n",
+    "— sur quatre problemes d'evaluation tous a 0/4 apres. A 10 problemes, G=4,\n",
+    "3 epochs et un seul seed, un tel ecart est du **bruit d'echantillonnage** : il ne\n",
+    "demontre ni degradation ni amelioration.\n",
+    "\n",
+    "Ce qui **est** demontre, en revanche, tient en trois mesures : le reward est\n",
+    "branche sur la colonne `answer` du dataset (donc verifiable et non constant), la\n",
+    "loss finale vaut 0.0409 (donc le gradient existe — un reward constant l'aurait\n",
+    "mise a zero), et 59 completions sur 120 ont ete verifiees correctes. Cette\n",
+    "derniere valeur est le vrai enseignement du run : c'est la **parcimonie** du\n",
+    "reward verifiable. Un groupe dont les G completions sont toutes fausses a un\n",
+    "avantage nul et ne produit aucun gradient — et c'est precisement le facteur qui\n",
+    "limite le RLVR a petite echelle. L'emergence rapportee dans la litterature\n",
+    "(Deepseek-R1, QwQ) suppose des ordres de grandeur superieurs en donnees, en\n",
+    "steps et en taille de modèle.\n",
+    "\n",
+    "### Les 5 pieges spécifiques au RLVR\n",
+    "\n",
+    "1. **Parser d'extraction trop rigide** : reponse correcte dans un format inattendu\n",
+    "   = faux negatif. Solution : robustesse multi-pattern (`\\boxed{}`, `####`,\n",
+    "   `= X`, dernier nombre).\n",
+    "2. **Reward trop sparse** : si accuracy de depart ~0%, tous les avantages = 0 et\n",
+    "   le gradient s'ecroule. Solution : reward a credit partiel (exercice 3) ou\n",
+    "   curriculum (tâches plus faciles d'abord). **C'est le piege que ce run a\n",
+    "   rencontre** : 49.2 % de completions verifiees, mais reparties de sorte que\n",
+    "   l'accuracy d'evaluation ne bouge pas dans le bon sens.\n",
+    "3. **Distribution de reponses degeneree** : le modèle peut converger vers une\n",
+    "   reponse constante si elle maximise le reward local. Solution : diversite des\n",
+    "   prompts + comparaison relative (avantage GRPO).\n",
+    "4. **Domaine trop etroit** : un verifier mathematique ne generalise pas au\n",
+    "   raisonnement ouvert. RLVR excelle sur **tâches a solution unique** (math,\n",
+    "   code, logique formelle), echoue sur tâches creatives.\n",
+    "5. **Sur-confiance dans l'emergence et dans le verifier** : ni l'une ni l'autre\n",
+    "   ne se presume. Le verifier lui-même peut avoir des bugs (parsing, tolerance\n",
+    "   numérique) — d'ou les tests unitaires de la section 3. Et une emergence de CoT\n",
+    "   ne s'annonce que si elle est **mesuree**, ce qui n'est pas le cas ici.\n",
+    "\n",
+    "### Position dans le track GenAI/PostTraining\n",
+    "\n",
+    "Après PT-04 (GRPO, rewards heuristiques), PT-05 introduit la **deuxieme\n",
+    "generation** d'alignement par RL : remplacer l'heuristique par la verification\n",
+    "exacte. C'est le principe qui a fait emerger le raisonnement des modèles\n",
+    "Deepseek-R1 / QwQ — a une echelle que ce notebook pedagogique n'atteint pas, et\n",
+    "dont il mesure justement la contrainte limitante. PT-06 (evaluation comparative)\n",
+    "clot le parcours en comparant les 5 techniques de post-training vues de PT-01 a\n",
+    "PT-05 sur un benchmark commun.\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1420,7 +1596,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.15"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
@@ -30,8 +30,8 @@ L'angle pédagogique est d'expliquer la **math du loss** avant le code pour chaq
 | PT-01 | `PT_01_intro_post_training.ipynb` | Vue d'ensemble historique : SFT → RLHF → DPO → GRPO → RLVR | Théorique (markdown + figures) | N/A | — |
 | PT-02 | `PT_02_sft_baseline.ipynb` | Supervised Fine-Tuning baseline | `trl.SFTTrainer` + QLoRA 4-bit | Qwen3.5-0.8B | See #10289 |
 | PT-03 | `PT_03_dpo_direct_preference.ipynb` | Direct Preference Optimization (Rafailov 2023) | `trl.DPOTrainer` | Qwen3.5-0.8B (QLoRA 4-bit) | #5078 |
-| PT-04 | `PT_04_grpo_deepseek_r1.ipynb` | Group Relative Policy Optimization (livrable clé) | `trl.GRPOTrainer` + QLoRA 4-bit | Qwen3.5-0.8B | See #10289 |
-| PT-05 | `PT_05_rlvr_verifiable_rewards.ipynb` | RL with Verifiable Rewards (math/code) | `trl.GRPOTrainer` + verifier SymPy | Qwen3.5-0.8B (QLoRA 4-bit) | #10487, #10504 (orig. #1771) |
+| PT-04 | `PT_04_grpo_deepseek_r1.ipynb` | Group Relative Policy Optimization (livrable clé) — correctness reward (normalisation $/milliers/unités, crédit partiel) + harness d'éval 4 métriques | `trl.GRPOTrainer` + QLoRA 4-bit | Qwen3.5-0.8B | See #10289, #12438 |
+| PT-05 | `PT_05_rlvr_verifiable_rewards.ipynb` | RL with Verifiable Rewards (math/code) — vérifieur robuste (tolérance abs/rel, crédit partiel) + harness accuracy/format_rate/think_length/backtrack_rate | `trl.GRPOTrainer` + verifier SymPy | Qwen3.5-0.8B (QLoRA 4-bit) | #10487, #10504, #12438 (orig. #1771) |
 | PT-06 | `PT_06_eval_comparative.ipynb` | Évaluation comparative SFT vs DPO vs GRPO vs RLVR | Tableaux, chart, framework décision | tous | #1772, #10819 |
 | PT-07 | `PT_07_rewardspy_reward_hacking.ipynb` | Détecter le reward hacking (Goodhart) — observabilité reward | `rewardspy.watch`/`audit` (offline, sans GPU) | N/A (offline) | #4538 |
 | PT-08 | `PT_08_grpo_from_scratch_toy_env.ipynb` | GRPO **from scratch** (toy env CPU) — mécanique du group-relative advantage, écart PPO↔GRPO, comparaison « avec vs sans critic » | `torch` from-scratch (no `trl`) | MLP jouet (CPU, ~1.5k params) | See #1454 |


### PR DESCRIPTION
Grain: DEEP/training — lane myia-po-2025:CoursIA-2 — prev: MED/refactor #12241

Closes #12438

## Motivation

L'issue #12438 demandait de combler trois trous dans la série PostTraining :

1. **Pas de reward de justesse dans PT_04** : `combined_reward` ne mélangeait que longueur + mots-clés — une complétion « Therefore, x = 2 because... » sur un problème dont la réponse est 42 scorait haut sans jamais vérifier le nombre.
2. **Vérifieur PT_05 non robuste** : `extract_answer` ne normalisait ni devise ni séparateurs de milliers — vérifié firsthand avant l'edit : `extract_answer('The answer is $1,234.00')` → `234.0` (le `$` et la virgule bloquaient le regex, le fallback prenait le dernier fragment numérique). Et `math_verifier_reward` était binaire (1.0/0.0), sans tolérance absolue ni crédit partiel.
3. **Instrument d'éval mono-métrique** : PT_05 ne mesurait que l'accuracy ; pas de format_rate / think_length / backtrack_rate, pas de harness réutilisable par PT_06.

## Ce qui change

### PT_05 — vérifieur robuste + harness

- **`extract_answer`** : token numérique tolérant (`$1,234.00`, `42 km`, `22.2 C`, `0.9999999`) — devise `$£€`, séparateurs de milliers, unités strippées par `_to_float` ; priorité `\boxed{}` (SymPy) → `####` GSM8K → `answer is`/`:`/`=` → fallback dernier nombre.
- **`math_verifier_reward`** : tolérance **absolue OU relative** (`max(abs_tol, rel_tol * |gt|)`, défauts 1e-6 / 1e-3) + **crédit partiel** : 1.0 juste / 0.5 extrait-mais-faux / 0.0 rien d'extractible.
- **Tests unitaires avec cas pièges** (exigés par l'issue) : `$1,234.00` vs `1234` → 1.0 ; `0.9999999` vs `1` → 1.0 (tolérance rel) ; `42 km` vs `42` → 1.0 ; `43` vs `42` → 0.5 ; « Je ne sais pas » → 0.0.
- **§6b — harness `evaluate_reasoning_model(model, tokenizer, problems, answers, n)`** : temp 0.1, retourne `accuracy` / `format_rate` / `think_length` / `backtrack_rate` avec **liste explicite de marqueurs d'auto-correction** (`wait`, `actually`, `let me reconsider`, `let me double-check`, `on second thought`, `hmm`, `correction`). Self-test CPU sur 4 complétions de référence (textes fixes). Câblé GPU-gated : `METRICS_PRE` (cellule pre-training) et `METRICS_POST` + tableau `print_before_after` (cellule post-training).
- `rlvr_reward` (docstring) : mis à jour pour refléter le crédit partiel.

### PT_04 — correctness reward + colonne answer + harness

- **`correctness_reward`** : même moteur que PT_05 (normalisation + tolérance abs/rel + crédit partiel 0.5/1.0/0.0).
- **`combined_reward`** : si le dataset porte la colonne `answer` (TRL la passe en kwarg aligné sur les complétions — mécanisme déjà documenté dans PT_05), le mélange devient `0.5*correctness + 0.2*length + 0.3*keyword` ; sans `answer`, dégradation honnête vers l'ancien `0.4*length + 0.6*keyword`.
- **Dataset (10 prompts) : ground truths ajoutés** (`answers = [42, 150, 1, 78.5, 7, 24, 70, 5, 53, 22.22]`, chacun vérifié à la main — 97 est le seul premier ∈ [90,100], 72°F = 22.22°C, etc.).
- **`length_reward`** : déjà sweet-spot (pénalise trop court ET trop long) — inchangé, mais **bornes rendues visibles** par des tests (`'short'` → 0.125, 100 chars → 1.0, 250 chars → 0.75).
- **§5b — harness** : même instrument que PT_05 (auto-contenu par notebook), self-test CPU, câblé `METRICS_PRE` (sur `base_model`, avant LoRA/entraînement) et `METRICS_POST` (sur `model` entraîné).

## Validation

- **Re-exécution réelle** : `jupyter nbconvert --execute --inplace` (kernel `coursia-ml-training`) sur les DEUX notebooks — sortie complète, 0 erreur. Cellules GPU-gated (`LOAD_MODEL_AND_TRAIN and CUDA_AVAILABLE`) skippent proprement sur CPU, comme avant.
- **Env réparé (règle F)** : `datasets` installé dans l'env `coursia-ml-training` (import top-level des cellules dataset) ; `trl`/`peft` ne s'importent que dans les branches GPU-gated → non bloquants sur lane CPU.
- **Tests pièges standalone** (exec isolé des cellules, avant l'exécution du notebook) : toutes les assertions passent — `extract_answer('...$1,234.00') == 1234.0`, `math_verifier_reward('...0.9999999', 1) == 1.0`, `correctness_reward('Therefore, x = 2 because it holds', 42) == 0.5`, bornes length 0.125/1.0/0.75.
- **Self-test harness** (CPU, dans les outputs commités) : accuracy 0.5, format_rate 0.75, backtrack_rate 0.5 sur les 4 complétions de référence — conforme au calcul manuel.
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` introduit. **C.2/H.3** : cellules code re-exécutées, `execution_count` + `outputs` cohérents.
- **README §E** : lignes PT-04/PT-05 mises à jour (réf #12438).
- Catalogue non touché (R1, le cron régénère).

## Note

Les parties entraînement réel (GRPO/RLVR sur Qwen3.5-0.8B) restent GPU-gated comme sur `main` — cette PR CPU exécute tout ce qui est exécutable (rewards, tests pièges, harness self-test, datasets) et branche le pre/post aux endroits existants.
