### PR TITLE
fix(genai,#12484): Recipe-Maker terminates on delivered PDF, not on ready_to_generate

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
@@ -1097,20 +1097,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 16.947776,
-   "end_time": "2026-08-17T03:47:12.932202",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "receipe_maker.ipynb",
-   "output_path": "receipe_maker.ipynb",
-   "parameters": {
-    "BATCH_MODE": true
-   },
-   "start_time": "2026-08-17T03:46:55.984426",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
@@ -12,10 +12,10 @@
      "shell.execute_reply": "2026-08-17T03:46:57.719436Z"
     },
     "papermill": {
-     "duration": 0.009176,
-     "end_time": "2026-08-17T03:46:57.720515",
+     "duration": 0.010254,
+     "end_time": "2026-08-23T03:37:09.555799",
      "exception": false,
-     "start_time": "2026-08-17T03:46:57.711339",
+     "start_time": "2026-08-23T03:37:09.545545",
      "status": "completed"
     },
     "tags": [
@@ -111,10 +111,10 @@
      "shell.execute_reply": "2026-08-17T03:46:59.063584Z"
     },
     "papermill": {
-     "duration": 1.329081,
-     "end_time": "2026-08-17T03:46:59.065178",
+     "duration": 1.257104,
+     "end_time": "2026-08-23T03:37:10.838122",
      "exception": false,
-     "start_time": "2026-08-17T03:46:57.736097",
+     "start_time": "2026-08-23T03:37:09.581018",
      "status": "completed"
     },
     "tags": []
@@ -171,10 +171,10 @@
      "shell.execute_reply": "2026-08-17T03:46:59.078466Z"
     },
     "papermill": {
-     "duration": 0.008636,
-     "end_time": "2026-08-17T03:46:59.080057",
+     "duration": 0.009495,
+     "end_time": "2026-08-23T03:37:10.854097",
      "exception": false,
-     "start_time": "2026-08-17T03:46:59.071421",
+     "start_time": "2026-08-23T03:37:10.844602",
      "status": "completed"
     },
     "tags": []
@@ -243,10 +243,10 @@
      "shell.execute_reply": "2026-08-17T03:46:59.094124Z"
     },
     "papermill": {
-     "duration": 0.006684,
-     "end_time": "2026-08-17T03:46:59.095166",
+     "duration": 0.008164,
+     "end_time": "2026-08-23T03:37:10.868823",
      "exception": false,
-     "start_time": "2026-08-17T03:46:59.088482",
+     "start_time": "2026-08-23T03:37:10.860659",
      "status": "completed"
     },
     "tags": []
@@ -316,10 +316,10 @@
      "shell.execute_reply": "2026-08-17T03:46:59.182380Z"
     },
     "papermill": {
-     "duration": 0.081455,
-     "end_time": "2026-08-17T03:46:59.183623",
+     "duration": 0.076878,
+     "end_time": "2026-08-23T03:37:10.952967",
      "exception": false,
-     "start_time": "2026-08-17T03:46:59.102168",
+     "start_time": "2026-08-23T03:37:10.876089",
      "status": "completed"
     },
     "tags": []
@@ -424,10 +424,10 @@
      "shell.execute_reply": "2026-08-17T03:46:59.199467Z"
     },
     "papermill": {
-     "duration": 0.007765,
-     "end_time": "2026-08-17T03:46:59.201205",
+     "duration": 0.007515,
+     "end_time": "2026-08-23T03:37:10.967498",
      "exception": false,
-     "start_time": "2026-08-17T03:46:59.193440",
+     "start_time": "2026-08-23T03:37:10.959983",
      "status": "completed"
     },
     "tags": []
@@ -495,10 +495,10 @@
      "shell.execute_reply": "2026-08-17T03:47:01.204049Z"
     },
     "papermill": {
-     "duration": 1.997855,
-     "end_time": "2026-08-17T03:47:01.205476",
+     "duration": 1.683158,
+     "end_time": "2026-08-23T03:37:12.657535",
      "exception": false,
-     "start_time": "2026-08-17T03:46:59.207621",
+     "start_time": "2026-08-23T03:37:10.974377",
      "status": "completed"
     },
     "tags": []
@@ -573,7 +573,9 @@
     "    name=\"PDFGenerator\",\n",
     "    instructions=\"\"\"Générez un PDF professionnel:\n",
     "    - Structurez en sections claires\n",
-    "    - Utilisez une mise en page aérée\"\"\"\n",
+    "    - Utilisez une mise en page aérée\n",
+    "    - Quand la recette est validée, appelez la fonction generate_pdf avec\n",
+    "      output_path='recette_generee.pdf'\"\"\"\n",
     ")\n",
     "\n",
     "print(\"Imports et configuration OK\")\n"
@@ -610,10 +612,10 @@
      "shell.execute_reply": "2026-08-17T03:47:01.238619Z"
     },
     "papermill": {
-     "duration": 0.027498,
-     "end_time": "2026-08-17T03:47:01.239962",
+     "duration": 0.024121,
+     "end_time": "2026-08-23T03:37:12.688569",
      "exception": false,
-     "start_time": "2026-08-17T03:47:01.212464",
+     "start_time": "2026-08-23T03:37:12.664448",
      "status": "completed"
     },
     "tags": []
@@ -641,12 +643,15 @@
     "        self._state = state\n",
     "\n",
     "    async def should_agent_terminate(self, agent, history):\n",
-    "        return self._state.ready_to_generate\n",
+    "        # Terminer sur le LIVRABLE produit (pdf_path), pas sur la demande\n",
+    "        # de le produire (ready_to_generate) : sinon la conversation\n",
+    "        # s'arrête exactement au tour où PDFGenerator devrait parler.\n",
+    "        return bool(self._state.pdf_path)\n",
     "\n",
     "\n",
     "group_chat = AgentGroupChat(\n",
     "    agents=[input_agent, recipe_agent, pdf_agent],\n",
-    "    termination_strategy=ReadyTerminationStrategy(shared_state),\n",
+    "    termination_strategy=ReadyTerminationStrategy(shared_state, maximum_iterations=12),\n",
     ")\n",
     "\n",
     "print(\"Imports agents OK\")\n"
@@ -683,10 +688,10 @@
      "shell.execute_reply": "2026-08-17T03:47:12.310336Z"
     },
     "papermill": {
-     "duration": 11.065641,
-     "end_time": "2026-08-17T03:47:12.312861",
+     "duration": 16.501652,
+     "end_time": "2026-08-23T03:37:29.197433",
      "exception": false,
-     "start_time": "2026-08-17T03:47:01.247220",
+     "start_time": "2026-08-23T03:37:12.695781",
      "status": "completed"
     },
     "tags": []
@@ -696,60 +701,69 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[InputCollector] Les informations ont été enregistrées avec succès :\n",
-      "\n",
-      "- Régime alimentaire : Végétarien\n",
-      "- Ingrédients exclus : Champignons, Produits laitiers\n",
-      "- Nombre de convives : 6\n",
-      "\n",
-      "Je vais maintenant rechercher une recette qui correspond à ces critères. Un instant, s'il vous plaît.\n"
+      "[Batch] Demande de démonstration : Je souhaite une recette végétarienne pour 6 personnes, sans champignons ni produits laitiers.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[RecipeGenerator] Voici une recette végétarienne pour 6 personnes qui respecte vos contraintes :\n",
+      "[InputCollector] Vos préférences sont enregistrées : \n",
+      "- Régime : Végétarien\n",
+      "- Ingrédients à exclure : Champignons, Produits laitiers\n",
+      "- Nombre de convives : 6\n",
       "\n",
-      "### Risotto aux Légumes\n",
+      "Je vais maintenant chercher une recette qui correspond à ces critères. Un instant, s'il vous plaît.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[RecipeGenerator] Voici une délicieuse recette végétarienne pour 6 personnes, sans champignons ni produits laitiers :\n",
+      "\n",
+      "### Tacos de légumes grillés\n",
       "\n",
       "#### Ingrédients\n",
       "```python\n",
       "ingredients = [\n",
-      "    \"500g de riz basmati\",\n",
-      "    \"1 gros poivron rouge\",\n",
-      "    \"1 gros poivron vert\",\n",
-      "    \"2 carottes\",\n",
-      "    \"1 courgette\",\n",
-      "    \"1 oignon\",\n",
-      "    \"3 gousses d'ail\",\n",
+      "    \"12 tortillas de maïs\",\n",
+      "    \"2 poivrons (1 rouge, 1 jaune), coupés en lanières\",\n",
+      "    \"1 courgette, coupée en rondelles\",\n",
+      "    \"1 aubergine, coupée en cubes\",\n",
+      "    \"1 oignon rouge, coupé en fines lamelles\",\n",
       "    \"2 cuillères à soupe d'huile d'olive\",\n",
-      "    \"1 cuillère à café de cumin\",\n",
-      "    \"1 cuillère à café de paprika\",\n",
-      "    \"200g de pois chiches en conserve\",\n",
-      "    \"Sel\",\n",
-      "    \"Poivre\",\n",
-      "    \"Coriandre fraîche\"\n",
+      "    \"2 cuillères à café de cumin en poudre\",\n",
+      "    \"2 cuillères à café de paprika\",\n",
+      "    \"Sel et poivre au goût\",\n",
+      "    \"1 avocat, tranché\",\n",
+      "    \"Coriandre fraîche pour le service\",\n",
+      "    \"1 citron vert, coupé en quartiers\"\n",
       "]\n",
       "```\n",
       "\n",
       "#### Étapes de préparation\n",
-      "1. Rincer le riz basmati sous l'eau froide jusqu'à ce que l'eau soit claire.\n",
-      "2. Dans une grande casserole, faire chauffer l'huile d'olive à feu moyen.\n",
-      "3. Ajouter l'oignon haché et l'ail émincé, faire revenir jusqu'à ce que l'oignon soit translucide.\n",
-      "4. Ajouter les poivrons, les carottes et la courgette coupés en dés, cuire pendant 5 à 7 minutes jusqu'à ce qu'ils soient tendres.\n",
-      "5. Incorporer le cumin et le paprika, bien mélanger.\n",
-      "6. Ajouter le riz et les pois chiches, assaisonner avec du sel et du poivre.\n",
-      "7. Ajouter 1,5 fois le volume du riz en eau, porter à ébullition puis réduire le feu à doux.\n",
-      "8. Couvrir et laisser cuire pendant environ 15 à 20 minutes jusqu'à ce que tout le liquide soit absorbé et le riz tendre.\n",
-      "9. Retirer du feu, égrainer le riz avec une fourchette et incorporer la coriandre fraîche hachée avant de servir.\n",
+      "1. Préchauffer le grill ou une poêle à feu moyen-élevé.\n",
+      "2. Dans un grand bol, mélanger les poivrons, la courgette, l'aubergine, et l'oignon avec l'huile d'olive, le cumin, le paprika, du sel et du poivre.\n",
+      "3. Déposer les légumes assaisonnés sur le grill ou dans la poêle chaude. Faire cuire pendant environ 10-12 minutes, en remuant de temps en temps, jusqu'à ce qu'ils soient tendres et légèrement carbonisés.\n",
+      "4. Pendant que les légumes cuisent, réchauffer les tortillas sur le grill ou dans une autre poêle pendant environ 1-2 minutes de chaque côté.\n",
+      "5. Pour servir, garnir chaque tortilla de légumes grillés, ajouter quelques tranches d’avocat, et saupoudrer de coriandre fraîche. Servir avec des quartiers de citron vert.\n",
       "\n",
       "#### Temps de cuisson\n",
-      "- **Total** : 30 minutes\n",
+      "- Environ 20 minutes\n",
       "\n",
-      "Bon appétit ! Si vous avez besoin d'autres recettes ou d'assistance, n'hésitez pas à demander.\n",
-      "\\nTransition vers la génération PDF...\n",
-      "\\nProcessus terminé\n"
+      "Bon appétit ! Si vous avez besoin d'autres recettes ou d'ajustements, n'hésitez pas à demander.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[PDFGenerator] Votre recette de **Tacos de légumes grillés** a été générée avec succès dans un format PDF. Vous pouvez la télécharger ici : [recette_generee.pdf](sandbox:/recette_generee.pdf).\n",
+      "\n",
+      "N'hésitez pas à me demander si vous avez besoin d'autres recettes ou d'assistance supplémentaire ! Bon appétit !\n",
+      "\n",
+      "Processus terminé\n"
      ]
     }
    ],
@@ -761,32 +775,39 @@
     "    print(\"⚠️ group_chat non défini - vérifiez que la cellule précédente a été exécutée\")\n",
     "    group_chat = None\n",
     "\n",
+    "from semantic_kernel.contents import ChatMessageContent, AuthorRole\n",
+    "\n",
     "async def recipe_workflow():\n",
     "    if group_chat is None:\n",
     "        print(\"❌ Impossible d'exécuter: group_chat non initialisé\")\n",
     "        return\n",
-    "        \n",
-    "    recipe_query = (\n",
-    "        \"Je souhaite une recette végétarienne pour 6 personnes, \"\n",
-    "        \"sans champignons ni produits laitiers.\"\n",
+    "\n",
+    "    # En mode batch (Papermill/CI), stdin n'existe pas : demande de recette\n",
+    "    # fixée -- même patron que Medical-Chatbot et Fort-Boyard.\n",
+    "    if BATCH_MODE:\n",
+    "        recipe_query = (\n",
+    "            \"Je souhaite une recette végétarienne pour 6 personnes, \"\n",
+    "            \"sans champignons ni produits laitiers.\"\n",
+    "        )\n",
+    "        print(f\"[Batch] Demande de démonstration : {recipe_query}\")\n",
+    "    else:\n",
+    "        recipe_query = input(\"Décrivez votre demande de recette : \")\n",
+    "\n",
+    "    # Amorcer la conversation (API SK 1.42 : add_chat_message est asynchrone,\n",
+    "    # l'appeler sans await laisse un coroutine jamais attendue).\n",
+    "    await group_chat.add_chat_message(\n",
+    "        ChatMessageContent(role=AuthorRole.USER, content=recipe_query)\n",
     "    )\n",
-    "    \n",
-    "    group_chat.history.add_user_message(recipe_query)\n",
-    "    \n",
+    "\n",
     "    try:\n",
     "        async for message in group_chat.invoke():\n",
     "            print(f\"[{message.name}] {message.content}\")\n",
-    "            \n",
-    "            if shared_state.ready_to_generate:\n",
-    "                print(\"\\\\nTransition vers la génération PDF...\")\n",
-    "                break\n",
-    "                \n",
     "    except Exception as e:\n",
     "        print(f\"Erreur lors de la génération: {str(e)}\")\n",
-    "    \n",
-    "    print(\"\\\\nProcessus terminé\")\n",
     "\n",
-    "await recipe_workflow()\n"
+    "    print(\"\\nProcessus terminé\")\n",
+    "\n",
+    "await recipe_workflow()"
    ]
   },
   {
@@ -803,9 +824,9 @@
     "tags": []
    },
    "source": [
-    "**Lecture de la génération** — le système multi-agent a produit la **« Salade de Quinoa aux Légumes »**, une recette végétarienne pour **6 personnes** qui respecte les contraintes collectées : **sans champignons** ni **produits laitiers**. Le `[InputCollector]` a d'abord enregistré les trois critères (régime, exclusions, convives), puis le `[RecipeGenerator]` a proposé une recette adaptée — on voit ici les deux agents collaborer à travers l'état partagé.\n",
+    "**Lecture de la génération** — le système multi-agent a produit la recette de cette exécution (ici des **« Tacos de légumes grillés »** — le modèle varie la recette à chaque exécution), une recette végétarienne pour **6 personnes** qui respecte les contraintes collectées : **sans champignons** ni **produits laitiers**. Le `[InputCollector]` a d'abord enregistré les trois critères (régime, exclusions, convives), puis le `[RecipeGenerator]` a proposé une recette adaptée — on voit ici les deux agents collaborer à travers l'état partagé.\n",
     "\n",
-    "**Ce que cet output démontre sur le multi-agent** : la recette n'est pas une réponse libre à « écris une recette végétarienne » — elle est le **résultat d'un protocole** où chaque contrainte a été collectée explicitement puis propagée au générateur via `RecipeState`. Si on changeait « 6 convives » en « 2 convives », les quantités de la recette s'ajusteraient parce que le générateur lit `state.convives`. C'est la valeur ajoutée de l'architecture par rapport à un prompt monolithique : les contraintes sont **structurées et traçables**, pas enfouies dans une phrase. C'est aussi ce qui rend le système réutilisable pour d'autres cas (menu de repas, liste de courses) en changeant les plugins, pas en réécrivant le prompt."
+    "**Ce que cet output démontre sur le multi-agent** : la recette n'est pas une réponse libre à « écris une recette végétarienne » — elle est le **résultat d'un protocole** où chaque contrainte a été collectée explicitement puis propagée au générateur via `RecipeState`. Si on changeait « 6 convives » en « 2 convives », les quantités de la recette s'ajusteraient parce que le générateur lit `state.guests`. C'est la valeur ajoutée de l'architecture par rapport à un prompt monolithique : les contraintes sont **structurées et traçables**, pas enfouies dans une phrase. C'est aussi ce qui rend le système réutilisable pour d'autres cas (menu de repas, liste de courses) en changeant les plugins, pas en réécrivant le prompt."
    ]
   },
   {
@@ -846,10 +867,10 @@
      "shell.execute_reply": "2026-08-17T03:47:12.332199Z"
     },
     "papermill": {
-     "duration": 0.007351,
-     "end_time": "2026-08-17T03:47:12.333495",
+     "duration": 0.008552,
+     "end_time": "2026-08-23T03:37:29.220939",
      "exception": false,
-     "start_time": "2026-08-17T03:47:12.326144",
+     "start_time": "2026-08-23T03:37:29.212387",
      "status": "completed"
     },
     "tags": []
@@ -893,7 +914,9 @@
    "source": [
     "### Génération de pdf\n",
     "\n",
-    "**Pourquoi exporter la recette en PDF (et pourquoi c'est l'étape la plus fragile)** : le PDF est le **livrable final** — ce que l'utilisateur emporte, imprime, partage. Tout le travail multi-agent aboutit à ce document. Mais la génération PDF dépend d'outils externes (librairie de rendu, polices, parfois LaTeX) qui peuvent échouer indépendamment du raisonnement LLM : une recette parfaite peut ne pas se matérialiser en PDF si l'outil de rendu manque. C'est pourquoi le verdict de la cellule suivante (« Échec de la génération : Aucun PDF produit ») **n'invalide pas** la recette elle-même — il signale un échec de l'étape d'export, pas du pipeline agent. Distinguer ces deux échecs (raisonnement vs rendu) est crucial pour diagnostiquer où corriger."
+    "**Pourquoi exporter la recette en PDF** : le PDF est le **livrable final** — ce que l'utilisateur emporte, imprime, partage. Tout le travail multi-agent aboutit à ce document, produit par `PDFGeneratorPlugin.generate_pdf` (`reportlab`, importé avec les plugins).\n",
+    "\n",
+    "**Le piège d'orchestration qui guette cette étape** : la conversation est pilotée par `ReadyTerminationStrategy`, qui interroge l'état partagé à chaque fin de tour. Si la stratégie termine sur `ready_to_generate` — le drapeau que pose `RecipeGenerator` au moment où il **valide** la recette — la conversation s'arrête **exactement au tour où `PDFGenerator` devrait parler** : l'agent figure dans la liste passée à `AgentGroupChat`, mais il est structurellement inatteignable. Aucune exception n'est levée ; la boucle se termine proprement, et l'échec se lit à tort comme un problème d'outil de rendu (librairie PDF, polices) alors que la cause est la **condition d'arrêt**. La règle appliquée ici : **terminer sur le livrable produit** (`state.pdf_path`), pas sur la demande de le produire."
    ]
   },
   {
@@ -908,10 +931,10 @@
      "shell.execute_reply": "2026-08-17T03:47:12.347274Z"
     },
     "papermill": {
-     "duration": 0.007692,
-     "end_time": "2026-08-17T03:47:12.348739",
+     "duration": 0.009427,
+     "end_time": "2026-08-23T03:37:29.238052",
      "exception": false,
-     "start_time": "2026-08-17T03:47:12.341047",
+     "start_time": "2026-08-23T03:37:29.228625",
      "status": "completed"
     },
     "tags": []
@@ -921,16 +944,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Workflow prêt\n",
-      "Workflow pret\n"
+      "PDF présent sur le disque : recette_generee.pdf (1391 octets)\n"
      ]
     }
    ],
    "source": [
-    "pass\n",
+    "import os\n",
     "\n",
-    "print(\"Workflow prêt\")\n",
-    "print(\"Workflow pret\")\n"
+    "PDF_PATH = \"recette_generee.pdf\"\n",
+    "\n",
+    "# Filet de sécurité : si l'agent PDFGenerator n'a pas invoqué generate_pdf\n",
+    "# pendant la conversation, on produit le livrable directement via le même\n",
+    "# plugin que celui exposé à l'agent -- la capacité démontrée est identique.\n",
+    "if not shared_state.pdf_path:\n",
+    "    pdf_plugin = PDFGeneratorPlugin(shared_state)\n",
+    "    print(pdf_plugin.generate_pdf(PDF_PATH))\n",
+    "\n",
+    "if shared_state.pdf_path and os.path.exists(shared_state.pdf_path):\n",
+    "    taille = os.path.getsize(shared_state.pdf_path)\n",
+    "    print(f\"PDF présent sur le disque : {shared_state.pdf_path} ({taille} octets)\")\n",
+    "else:\n",
+    "    print(\"Aucun PDF produit : ni par l'agent, ni par le filet de sécurité.\")"
    ]
   },
   {
@@ -945,10 +979,10 @@
      "shell.execute_reply": "2026-08-17T03:47:12.358817Z"
     },
     "papermill": {
-     "duration": 0.008898,
-     "end_time": "2026-08-17T03:47:12.360164",
+     "duration": 0.008592,
+     "end_time": "2026-08-23T03:37:29.249328",
      "exception": false,
-     "start_time": "2026-08-17T03:47:12.351266",
+     "start_time": "2026-08-23T03:37:29.240736",
      "status": "completed"
     },
     "tags": []
@@ -958,7 +992,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Échec de la génération: Aucun PDF produit malgré les tentatives\n"
+      "PDF généré avec succès: recette_generee.pdf\n",
+      "Contenu de la recette:\n",
+      "- Régime: végétarien\n",
+      "- Ingrédients: 12 tortillas de maïs, 2 poivrons (1 rouge, 1 jaune), coupés en lanières, 1 courgette, coupée en rondelles, 1 aubergine, coupée en cubes, 1 oignon rouge, coupé en fines lamelles, 2 cuillères à soupe d'huile d'olive, 2 cuillères à café de cumin en poudre, 2 cuillères à café de paprika, Sel et poivre au goût, 1 avocat, tranché, Coriandre fraîche pour le service, 1 citron vert, coupé en quartiers\n"
      ]
     }
    ],
@@ -987,9 +1024,9 @@
     "tags": []
    },
    "source": [
-    "**Lecture de l'échec PDF** — la cellule renvoie `Échec de la génération : Aucun PDF produit malgré les tentatives`. C'est un **échec d'export**, pas un échec de raisonnement : la recette (Salade de Quinoa) a bien été générée et validée par les agents, mais l'outil de rendu PDF n'a pas pu la matérialiser.\n",
+    "**Lecture du livrable PDF** — la conversation a déroulé les trois rôles attendus : `[InputCollector]` a enregistré les contraintes dans l'état partagé, `[RecipeGenerator]` a validé la recette (drapeau `ready_to_generate` armé), puis **`[PDFGenerator]` a joué son tour** en invoquant `generate_pdf` — c'est précisément le tour que la condition d'arrêt d'origine (`ready_to_generate`) coupait. La cellule de vérification confirme le fichier sur le disque (chemin + taille en octets), puis la cellule suivante affiche la branche succès avec le contenu structuré de l'état partagé.\n",
     "\n",
-    "**Pourquoi cet échec est pédagogiquement plus intéressant qu'un succès** : il illustre la **frontière entre le raisonnement LLM et l'exécution d'outils**. Le multi-agent a fait son travail (recette correcte, contraintes respectées) ; le pipeline casse à l'interface avec une dépendance externe (librairie PDF, polices, permissions d'écriture). Diagnostiquer cet échec demande de séparer les deux couches : vérifier d'abord que `RecipeState` contient la recette (couche agent = OK), puis inspecter l'exception de l'outil PDF (couche rendu = KO). C'est la discipline de debug que tout système LLM-outils exige — et ce notebook, en assumant l'échec honnêtement plutôt qu'en le masquant, enseigne cette distinction au lieu de la cacher."
+    "**Ce que cet exemple démontre** : la stratégie de terminaison d'un `AgentGroupChat` n'est pas un détail cosmétique — c'est elle qui décide quels agents **existent effectivement** dans la conversation. Un drapeau armé un tour trop tôt rend un agent de la liste inatteignable sans aucune erreur visible : la boucle se termine proprement, l'état reste incomplet, et l'instinct porte à accuser l'outil externe. Diagnostiquer ce défaut exige de lire la **séquence** des tours (qui a parlé ? qui n'a jamais parlé ?), pas les exceptions — il n'y en a aucune. La frontière raisonnement/exécution reste réelle (le plugin `reportlab` peut échouer indépendamment du LLM), mais l'échec observé avant correction était un **défaut d'orchestration**, pas un défaut de rendu."
    ]
   },
   {
@@ -1015,7 +1052,7 @@
     "- **Etat partage** : la classe `RecipeState` sert de memoire commune aux trois agents. Chaque plugin lit et ecrit dans cette instance unique, ce qui permet de transmettre les contraintes utilisateur jusqu'a la generation du PDF.\n",
     "- **Plugins et `@kernel_function`** : le decorateur `@kernel_function` expose les méthodes Python comme outils appelables par le LLM (`set_diet`, `submit_recipe`, `generate_pdf`).\n",
     "- **Orchestration `AgentGroupChat`** : les agents `InputCollector`, `RecipeGenerator` et `PDFGenerator` dialoguent dans une conversation de groupe, chacun avec son propre kernel et son service de chat.\n",
-    "- **Stratégie de terminaison** : `ReadyTerminationStrategy` interroge l'etat partage (`ready_to_generate`) pour arreter la boucle des que la recette est validee.\n",
+    "- **Stratégie de terminaison** : `ReadyTerminationStrategy` interroge l'etat partage (`pdf_path`) pour arreter la boucle des que le livrable PDF est produit -- terminer plus tot (sur `ready_to_generate`) rendrait l'agent `PDFGenerator` inatteignable.\n",
     "- **Configuration du service** : chaque kernel doit recevoir un service via `add_service` (ici `OpenAIChatCompletion`), faute de quoi l'invocation echoue avec `No service found`.\n",
     "\n",
     "**Pour aller plus loin** :\n",


### PR DESCRIPTION
## Summary

Recipe-Maker (`receipe_maker.ipynb`) committed a PDF-generation **failure** (`Échec de la génération: Aucun PDF produit`) while its prose blamed external PDF tooling. Root cause is an orchestration defect, not a tooling one: `ReadyTerminationStrategy` terminated on `ready_to_generate` — the flag `RecipeGenerator` arms when it *validates* the recipe — which cuts the conversation **exactly at PDFGenerator's turn**. The agent is listed in `AgentGroupChat` but structurally unreachable; `generate_pdf` is fully implemented and was never invoked.

### Corrections

1. **Termination on the delivered artifact**: `should_agent_terminate` returns `bool(self._state.pdf_path)` instead of `self._state.ready_to_generate` (+ `maximum_iterations=12` safety bound).
2. **Premature break removed**: `recipe_workflow` no longer breaks on `ready_to_generate` mid-loop (it cut the conversation at the same point a second time).
3. **Generation cell implemented** (was bare `pass` + prints): disk verification (path + size) + dormant safety net calling the same `PDFGeneratorPlugin.generate_pdf` if the agent didn't.
4. **`pdf_agent` instructions** now explicitly instruct invoking `generate_pdf` with `output_path='recette_generee.pdf'`.
5. **BATCH_MODE wired** (was declared, never read): fixed demo query in batch, `input()` in interactive — same pattern as Medical-Chatbot / Fort-Boyard.
6. **SK 1.42 re-exec breaker fixed**: `group_chat.history.add_user_message(...)` no longer exists on `AgentGroupChat` (verified against installed 1.42.0) → `await group_chat.add_chat_message(ChatMessageContent(role=AuthorRole.USER, ...))`.
7. **Prose re-anchored on the real cause**: markdown blaming "librairie de rendu, polices, parfois LaTeX" rewritten to name the termination-condition trap; the "échec pédagogiquement plus intéressant" cell rewritten as lecture of the now-successful sequence; conclusion bullet coherent (`pdf_path`, not `ready_to_generate`); markdown 19 anchored on this run's recipe + `state.guests` (was phantom `state.convives`).

## Execution proof (EXEC_PROVED)

Re-executed end-to-end via papermill with real `gpt-4o-mini` calls:

```
[Batch] Demande de démonstration : Je souhaite une recette végétarienne pour 6 personnes, sans champignons ni produits laitiers.
[InputCollector] Vos préférences sont enregistrées : Régime : Végétarien, ...
[RecipeGenerator] Voici une délicieuse recette végétarienne... ### Tacos de légumes grillés ...
[PDFGenerator] Votre recette de **Tacos de légumes grillés** a été générée avec succès dans un format PDF...
PDF présent sur le disque : recette_generee.pdf (1391 octets)
PDF généré avec succès: recette_generee.pdf
```

- The `[PDFGenerator]` turn **appears** in the conversation (was the structurally-cut turn).
- The safety net stayed **dormant** (no `PDF généré :` line from cell 23's fallback) → the agent itself invoked `generate_pdf`.
- Cell 24 takes the success branch with the structured recipe state.
- All 12 code cells: `execution_count` set, outputs committed (C.2). H.3 check: 0 violations. C.1 scan: 0 `raise NotImplementedError`/`assert False`/`1/0`. Path-leak scan of outputs: clean. API key: never present in file (verified `-1` literal scan).
- Exercise stubs preserved untouched: `ExtendedRecipeState` (26b00761), `NutritionPlugin` (2772b5c3), `valider_contraintes` (7d996ec0).

## Regression check

`grep` of touched symbols (`ReadyTerminationStrategy`, `ready_to_generate`, `pdf_path`, `generate_pdf`) across the repo: no other notebook references this strategy pattern; GenAI CaseStudies siblings (Medical-Chatbot #12511, Fort-Boyard, Barbie-Schreck) use their own terminations — no cross-impact.

Grain: MED/genai-casestudies -- lane myia-po-2023:CoursIA

Closes #12484

🤖 Generated with [Claude Code](https://claude.com/claude-code)