### PR TITLE
fix(gametheory,#12205): GT-24 renommage épistémologique 'chemin certifié' -> 'témoin construit et vérifié indépendamment'

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-24-Chemin-Minimal-Robinson-Goforth.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-24-Chemin-Minimal-Robinson-Goforth.ipynb
@@ -3,9 +3,18 @@
   {
    "cell_type": "markdown",
    "id": "32877e08",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003935,
+     "end_time": "2026-08-23T03:46:29.516356+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.512421+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "# GameTheory 24 : Le chemin minimal certifié — de Robinson-Goforth au vérificateur séparé\n",
+    "# GameTheory 24 : Le chemin minimal, témoin construit et vérifié indépendamment — de Robinson-Goforth au vérificateur séparé\n",
     "\n",
     "> Grain B2 de l'EPIC #12205 (Chantier 2 — Génération de témoins et synthèse certifiée : franchir la Loi II).\n",
     "\n",
@@ -19,9 +28,10 @@
     "l'univers fini des jeux 2×2 ordinaux de Robinson-Goforth. Si la loi ne tient que sur Life, ce n'est pas une loi.\n",
     "\n",
     "Ici, le vérificateur c'est le solveur qui **reconnaît** qu'un chemin d'échanges élémentaires relie deux jeux.\n",
-    "Le constructeur, c'est la machine qui **produit** ce chemin — puis un **vérificateur séparé** qui certifie,\n",
-    "indépendamment, que le chemin est valide **et minimal**. Le certificat n'est pas une opinion : dans un univers\n",
-    "fini et énumérable, la minimalité se prouve par recherche exhaustive.\n",
+    "Le constructeur, c'est la machine qui **produit** ce chemin — puis un **vérificateur séparé** qui vérifie,\n",
+    "indépendamment, que le chemin est valide **et minimal**. Le chemin produit est un **témoin construit et\n",
+    "vérifié indépendamment**, pas un certificat au sens formel : dans un univers fini et énumérable, la\n",
+    "minimalité se prouve par recherche exhaustive — c'est cette énumération, refaite de zéro, qui fait foi.\n",
     "\n",
     "**Dette de vérification soldée au passage** : les chiffres structurels de l'espace de Robinson-Goforth\n",
     "(75 ordres faibles, 5625 jeux à rangs, 576 chambres) étaient au statut RAPPORTÉ depuis la digestion.\n",
@@ -31,7 +41,16 @@
   {
    "cell_type": "markdown",
    "id": "2332f617",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00298,
+     "end_time": "2026-08-23T03:46:29.522948+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.519968+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 0. Configuration\n",
     "\n",
@@ -47,37 +66,54 @@
    "id": "10c63925",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.015014Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.014865Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.019433Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.018460Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.530210Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.530007Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.537821Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.536853Z"
+    },
+    "papermill": {
+     "duration": 0.012755,
+     "end_time": "2026-08-23T03:46:29.538659+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.525904+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GameTheory 24 : chemin minimal certifie dans l'espace de Robinson-Goforth\n",
+      "GameTheory 24 : chemin minimal (temoin construit et verifie independamment)\n",
       "Representation : jeu = (table_ligne, table_colonne), rangs {1..4}, 4 = meilleur\n",
-      "Loi II : le constructeur PRODUIT le chemin, le verificateur separé le CERTIFIE\n"
+      "Loi II : le constructeur PRODUIT le chemin, le verificateur separé le VERIFIE independamment\n"
      ]
     }
    ],
    "source": [
-    "# === Configuration : GameTheory 24, chemin minimal certifie -- pur stdlib ===\n",
+    "# === Configuration : GameTheory 24, chemin minimal - temoin construit et verifie independamment ===\n",
     "from itertools import product\n",
     "from collections import Counter, deque\n",
     "\n",
-    "print(\"GameTheory 24 : chemin minimal certifie dans l'espace de Robinson-Goforth\")\n",
+    "print(\"GameTheory 24 : chemin minimal (temoin construit et verifie independamment)\")\n",
     "print(\"Representation : jeu = (table_ligne, table_colonne), rangs {1..4}, 4 = meilleur\")\n",
-    "print(\"Loi II : le constructeur PRODUIT le chemin, le verificateur separé le CERTIFIE\")"
+    "print(\"Loi II : le constructeur PRODUIT le chemin, le verificateur separé le VERIFIE independamment\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "6b98abc1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003251,
+     "end_time": "2026-08-23T03:46:29.545514+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.542263+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. L'univers fini, re-dérivé depuis zéro\n",
     "\n",
@@ -93,11 +129,19 @@
    "id": "f21969c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.021402Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.021235Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.027779Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.026408Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.553088Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.552740Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.558360Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.557662Z"
+    },
+    "papermill": {
+     "duration": 0.010373,
+     "end_time": "2026-08-23T03:46:29.558954+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.548581+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -134,7 +178,16 @@
   {
    "cell_type": "markdown",
    "id": "be20f94b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003112,
+     "end_time": "2026-08-23T03:46:29.565611+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.562499+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture de la sortie committée** : **75** ordres faibles — c'est bien le nombre de Fubini F₄,\n",
     "re-dérivé et non récité. Ils se partitionnent en **24 stricts** et **51 avec ex æquo**, d'où :\n",
@@ -146,7 +199,16 @@
   {
    "cell_type": "markdown",
    "id": "939e66a9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003108,
+     "end_time": "2026-08-23T03:46:29.571826+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.568718+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 1.2 Les jeux canoniques, encodés\n",
     "\n",
@@ -163,11 +225,19 @@
    "id": "17f4c51e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.029780Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.029621Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.035385Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.034171Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.580735Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.580437Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.585878Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.585262Z"
+    },
+    "papermill": {
+     "duration": 0.011454,
+     "end_time": "2026-08-23T03:46:29.586471+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.575017+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -227,7 +297,16 @@
   {
    "cell_type": "markdown",
    "id": "34404c7f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003193,
+     "end_time": "2026-08-23T03:46:29.593463+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.590270+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Les six swaps générateurs : le permutaèdre des chambres\n",
     "\n",
@@ -244,11 +323,19 @@
    "id": "822cf47c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.037165Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.036957Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.046772Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.045573Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.600893Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.600702Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.609975Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.609074Z"
+    },
+    "papermill": {
+     "duration": 0.014051,
+     "end_time": "2026-08-23T03:46:29.610646+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.596595+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -304,7 +391,16 @@
   {
    "cell_type": "markdown",
    "id": "2f157fad",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003205,
+     "end_time": "2026-08-23T03:46:29.617352+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.614147+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture de la sortie committée** : le graphe des 576 chambres est **connexe**, de diamètre **12** —\n",
     "six par côté, la distance d'un jeu étant la somme des distances de ses deux tables. La distribution\n",
@@ -316,7 +412,16 @@
   {
    "cell_type": "markdown",
    "id": "7889dc00",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003133,
+     "end_time": "2026-08-23T03:46:29.623868+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.620735+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Le constructeur\n",
     "\n",
@@ -333,11 +438,19 @@
    "id": "1b3ddce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.048537Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.048382Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.054049Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.052969Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.631370Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.631166Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.637104Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.636452Z"
+    },
+    "papermill": {
+     "duration": 0.010722,
+     "end_time": "2026-08-23T03:46:29.637742+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.627020+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -398,7 +511,16 @@
   {
    "cell_type": "markdown",
    "id": "d95f962b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003411,
+     "end_time": "2026-08-23T03:46:29.644747+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.641336+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture de la sortie committée** : le constructeur **produit** le chemin — deux pas exactement :\n",
     "un échange `(1 ↔ 2)` côté ligne (la punition mutuelle P et la soumission S échangent leurs rangs) et\n",
@@ -414,11 +536,19 @@
    "id": "07e53a1e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.055754Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.055593Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.061294Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.060075Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.652348Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.652140Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.657019Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.656309Z"
+    },
+    "papermill": {
+     "duration": 0.0095,
+     "end_time": "2026-08-23T03:46:29.657485+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.647985+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -462,7 +592,16 @@
   {
    "cell_type": "markdown",
    "id": "b397f27b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003363,
+     "end_time": "2026-08-23T03:46:29.664395+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.661032+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture de la sortie committée** : l'antipode exige les **12 pas** du diamètre — chaque paire de\n",
     "positions des deux tables doit être corrigée exactement une fois, et le constructeur les exhume toutes.\n",
@@ -475,12 +614,21 @@
   {
    "cell_type": "markdown",
    "id": "402fcdcb",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00311,
+     "end_time": "2026-08-23T03:46:29.670731+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.667621+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "## 4. Le vérificateur séparé — le certificat\n",
+    "## 4. Le vérificateur séparé — le témoin\n",
     "\n",
-    "Produire un chemin ne suffit pas : encore faut-il **certifier** qu'il est valide et **minimal**.\n",
-    "Le certificat honnête exige un vérificateur qui ne réutilise **aucun état** du constructeur : il\n",
+    "Produire un chemin ne suffit pas : encore faut-il le **vérifier indépendamment** — validité **et**\n",
+    "minimalité. Le témoin honnête exige un vérificateur qui ne réutilise **aucun état** du constructeur : il\n",
     "re-dérive tout. Trois verdicts doivent être distingués — sinon le vérificateur n'est qu'un tampon :\n",
     "\n",
     "- **VALIDE + MINIMAL** : chaque pas est un swap élémentaire, les extrémités sont exactes, et la\n",
@@ -498,11 +646,19 @@
    "id": "1a971f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.063069Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.062901Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.070495Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.069166Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.678370Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.678047Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.684828Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.684350Z"
+    },
+    "papermill": {
+     "duration": 0.011781,
+     "end_time": "2026-08-23T03:46:29.685622+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.673841+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -558,21 +714,39 @@
   {
    "cell_type": "markdown",
    "id": "a6e2dfd3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003383,
+     "end_time": "2026-08-23T03:46:29.692478+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.689095+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture de la sortie committée** : les trois verdicts tombent, distincts. Le chemin du constructeur\n",
     "est **VALIDE + MINIMAL** (2 pas = distance exhaustive). Le même chemin avec un aller-retour greffé est\n",
     "**VALIDE mais NON MINIMAL** — le vérificateur voit le détour. Et le saut direct PD → Cerf est\n",
     "**INVALIDE** : un pas non élémentaire, parce que les deux chambres ne sont pas adjacentes. Le\n",
     "vérificateur n'est pas un tampon : il rend trois réponses différentes sur trois défauts différents.\n",
-    "C'est la séparation constructeur/vérificateur de la Loi II — le même geste que le certificat Lean\n",
-    "`by decide` du translateur de Life, ici sur le substrat fini des jeux."
+    "C'est la séparation constructeur/vérificateur de la Loi II — le même geste que la preuve `by decide`\n",
+    "du translateur de Life, ici sur le substrat fini des jeux."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "cd39468c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003581,
+     "end_time": "2026-08-23T03:46:29.699380+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.695799+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 4.2 La non-unicité : compter les géodésiques\n",
     "\n",
@@ -590,11 +764,19 @@
    "id": "ce6a01f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.072880Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.072682Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.081016Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.079828Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.706853Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.706631Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.713831Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.713182Z"
+    },
+    "papermill": {
+     "duration": 0.012166,
+     "end_time": "2026-08-23T03:46:29.714714+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.702548+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -638,7 +820,16 @@
   {
    "cell_type": "markdown",
    "id": "b01f91b0",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003355,
+     "end_time": "2026-08-23T03:46:29.721817+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.718462+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture de la sortie committée** : la mesure donne **16** géodésiques pour le renversement d'une\n",
     "table — exactement le nombre de mots réduits de w₀ dans S₄ que prédit la théorie des groupes de\n",
@@ -653,7 +844,16 @@
   {
    "cell_type": "markdown",
    "id": "88c84f28",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00351,
+     "end_time": "2026-08-23T03:46:29.728701+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.725191+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. L'univers à rangs complet : traverser les murs\n",
     "\n",
@@ -676,18 +876,33 @@
    "id": "a779f577",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.082800Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.082592Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.147434Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.146030Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.736825Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.736628Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.798625Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.798076Z"
+    },
+    "papermill": {
+     "duration": 0.067118,
+     "end_time": "2026-08-23T03:46:29.799170+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.732052+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Univers complet : 5625 sommets, atteints : 5625 (connexe : True )\n",
+      "Univers complet :"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 5625 sommets, atteints : 5625 (connexe : True )\n",
       "Diametre de l'univers complet : 12\n",
       "  (a comparer au diametre 12 du seul permutaedre des chambres)\n",
       "  repartition : {0: 1, 1: 12, 2: 68, 3: 240, 4: 578, 5: 990, 6: 1232, 7: 1128, 8: 785, 9: 402, 10: 149, 11: 36, 12: 4}\n"
@@ -728,7 +943,16 @@
   {
    "cell_type": "markdown",
    "id": "8b8cf257",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004119,
+     "end_time": "2026-08-23T03:46:29.806919+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.802800+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture de la sortie committée** : l'univers complet est **connexe** — coalescences et\n",
     "traversées relient les 5625 — mais son diamètre **reste 12**, identique au permutaèdre des\n",
@@ -745,11 +969,19 @@
    "id": "ccaa37d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.149465Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.149284Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.236699Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.235838Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.815402Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.815212Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.897002Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.896324Z"
+    },
+    "papermill": {
+     "duration": 0.086874,
+     "end_time": "2026-08-23T03:46:29.897614+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.810740+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -760,7 +992,13 @@
       "Paires ou l'espace complet (murs autorises) est PLUS COURT que le permutaedre : 0\n",
       "\n",
       "Par structure produit, le verdict couvre les 576 x 576 = 330 776 paires de chambres :\n",
-      "  les murs ne raccourcissent AUCUNE distance inter-chambres.\n",
+      "  les murs ne raccourcissent AUCUNE distance inter-chambres.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "PD -> Renversement : univers complet 5 pas dont 0 sur un mur ; chambres seules 5 pas\n"
      ]
@@ -769,14 +1007,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Verificateur (univers complet) :"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " VALIDE + MINIMAL : 5 pas = distance exhaustive d(G,H)\n"
+      "Verificateur (univers complet) : VALIDE + MINIMAL : 5 pas = distance exhaustive d(G,H)\n"
      ]
     }
    ],
@@ -828,33 +1059,51 @@
   {
    "cell_type": "markdown",
    "id": "58371b54",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003505,
+     "end_time": "2026-08-23T03:46:29.905106+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.901601+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture de la sortie committée** : la décision est **nulle et exhaustive** — sur les 576 paires\n",
     "d'ordres stricts comparées côté par côté, **aucune** n'est plus courte par les murs ; et parce que\n",
     "les générateurs ne touchent qu'un côté à la fois (structure produit), ce verdict par côté couvre\n",
     "les 330 776 paires de chambres sans exception. Le mécanisme se voit sur le cas concret : le\n",
     "constructeur lâché dans l'univers complet produit un chemin qui **ne pose jamais le pied sur un\n",
-    "mur** — la même longueur, 5 pas, que dans les chambres seules, et le vérificateur le certifie\n",
+    "mur** — la même longueur, 5 pas, que dans les chambres seules, et le vérificateur séparé l'atteste\n",
     "minimal dans l'univers élargi. Descendre sur un mur coûte un pas, en sortir en coûte un autre,\n",
     "et le swap qui déplace le bloc fusionné ne récupère jamais plus que ces deux pas investis.\n",
     "Les murs de GT-3b ne sont donc pas des tunnels : ce sont des strates que la géométrie des chambres\n",
     "regarde traverser sans jamais y gagner un pas. Un résultat négatif — mais prouvé par énumération\n",
-    "complète, et c'est lui qui donne sa valeur au certificat : la minimalité ne dit pas seulement\n",
+    "complète, et c'est lui qui donne sa valeur au témoin : la minimalité ne dit pas seulement\n",
     "« pas de détour », elle dit « pas de détour, même par les murs »."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "93dbf482",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003352,
+     "end_time": "2026-08-23T03:46:29.911802+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.908450+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Ce que la loi autorise à dire — et ce qu'elle n'autorise pas\n",
     "\n",
     "**Ce qui est acquis** : le passage du vérificateur au constructeur est fait sur un **second substrat**.\n",
     "Étant donnés deux jeux, la machine **produit** la suite d'opérations élémentaires qui transforme\n",
-    "l'un en l'autre, et un vérificateur séparé **certifie** validité et minimalité par énumération\n",
-    "exhaustive de l'univers. Les trois verdicts du vérificateur sont distincts et opposables ; le\n",
+    "l'un en l'autre, et un vérificateur séparé **vérifie indépendamment** validité et minimalité par\n",
+    "énumération exhaustive de l'univers. Les trois verdicts du vérificateur sont distincts et opposables ; le\n",
     "comptage des géodésiques rejoint la combinatoire de Coxeter (16 mots réduits de w₀ par table,\n",
     "composés en 236 544 par entrelacement) ; et le théorème négatif du §5 est **prouvé par énumération\n",
     "complète** : les murs ne raccourcissent aucune distance inter-chambres — le diamètre reste 12.\n",
@@ -864,13 +1113,13 @@
     "**Ce qui n'est PAS acquis** — les frontières honnêtes :\n",
     "\n",
     "- **Ordinal 2×2 uniquement**. L'espace des jeux à payoffs cardinaux, ou même 3×3 ordinaux,\n",
-    "  n'est ni énuméré ni borné ici ; le certificat par exhaustivité meurt avec la finitude.\n",
+    "  n'est ni énuméré ni borné ici ; la vérification par exhaustivité meurt avec la finitude.\n",
     "- **Le chemin est une géométrie, pas une dynamique**. Rien ne dit qu'un processus d'adaptation\n",
     "  suiverait une géodésique ; les swaps ne sont pas des coups que des joueurs jouent.\n",
     "- **La minimalité est relative au jeu de moves**. Avec swaps seuls, ou swaps + murs, les distances\n",
-    "  diffèrent (12 contre 6) : le certificat énonce « minimal pour CES générateurs », jamais « le plus\n",
+    "  diffèrent (12 contre 6) : le verdict énonce « minimal pour CES générateurs », jamais « le plus\n",
     "  court possible dans l'absolu ».\n",
-    "- **Pas de jambe Lean dans ce grain**. Le certificat est l'énumération exhaustive Python ; la\n",
+    "- **Pas de jambe Lean dans ce grain**. La vérification est l'énumération exhaustive Python ; la\n",
     "  formalisation `by decide` de la validité d'un pas est la variante naturelle suivante — c'est\n",
     "  exactement la forme d'itération (`-b`, `-c`) que l'EPIC #12205 prescrit.\n",
     "\n",
@@ -884,7 +1133,16 @@
   {
    "cell_type": "markdown",
    "id": "88e29a44",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003433,
+     "end_time": "2026-08-23T03:46:29.918988+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.915555+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercices\n",
     "\n",
@@ -895,12 +1153,22 @@
   {
    "cell_type": "markdown",
    "id": "55d31968",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003552,
+     "end_time": "2026-08-23T03:46:29.926020+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.922468+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 — Le chemin retour\n",
     "\n",
-    "Construire le chemin **Poule → Dilemme** et le certifier. Vérifier que le constructeur produit\n",
-    "bien le même nombre de pas qu'à l'aller — et expliquer pourquoi la distance est symétrique."
+    "Construire le chemin **Poule → Dilemme** et le soumettre au vérificateur séparé. Vérifier que le\n",
+    "constructeur produit bien le même nombre de pas qu'à l'aller — et expliquer pourquoi la distance est\n",
+    "symétrique."
    ]
   },
   {
@@ -909,11 +1177,19 @@
    "id": "a9081b02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.238552Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.238377Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.242585Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.241368Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.935021Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.934828Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.938161Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.937491Z"
+    },
+    "papermill": {
+     "duration": 0.008928,
+     "end_time": "2026-08-23T03:46:29.938694+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.929766+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -925,7 +1201,7 @@
     }
    ],
    "source": [
-    "# Exercice 1 : chemin retour Poule -> Dilemme, construit puis certifie.\n",
+    "# Exercice 1 : chemin retour Poule -> Dilemme, construit puis verifie independamment.\n",
     "# Etape 1 : chemin_retour = construire_chemin(POULE, PD, lambda g: adj_chambres[g])\n",
     "# Etape 2 : verdict = verifier_chemin(POULE, PD, chemin_retour, lambda g: adj_chambres[g])\n",
     "# Indice : la symetrie vient de ce que chaque swap est sa propre reciproque.\n",
@@ -936,7 +1212,16 @@
   {
    "cell_type": "markdown",
    "id": "a1e1d4a7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003653,
+     "end_time": "2026-08-23T03:46:29.945958+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.942305+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 — Les géodésiques d'une autre paire\n",
     "\n",
@@ -950,11 +1235,19 @@
    "id": "42af7e46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.244465Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.244314Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.247805Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.246829Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.954819Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.954435Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.958236Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.957625Z"
+    },
+    "papermill": {
+     "duration": 0.009285,
+     "end_time": "2026-08-23T03:46:29.958875+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.949590+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -978,12 +1271,22 @@
   {
    "cell_type": "markdown",
    "id": "79a55616",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003569,
+     "end_time": "2026-08-23T03:46:29.966664+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.963095+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 — Un couple antipodal de l'univers complet\n",
     "\n",
     "Trouver un jeu **H** à distance maximale du Dilemme dans l'univers complet (5625), construire le\n",
-    "chemin, et le certifier. Indice : la distribution des distances du §5.1 dit quelle couche chercher."
+    "chemin, et le soumettre au vérificateur séparé. Indice : la distribution des distances du §5.1 dit\n",
+    "quelle couche chercher."
    ]
   },
   {
@@ -992,11 +1295,19 @@
    "id": "75abdf35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T18:44:38.249455Z",
-     "iopub.status.busy": "2026-08-22T18:44:38.249308Z",
-     "iopub.status.idle": "2026-08-22T18:44:38.253022Z",
-     "shell.execute_reply": "2026-08-22T18:44:38.251803Z"
-    }
+     "iopub.execute_input": "2026-08-23T03:46:29.975024Z",
+     "iopub.status.busy": "2026-08-23T03:46:29.974822Z",
+     "iopub.status.idle": "2026-08-23T03:46:29.978154Z",
+     "shell.execute_reply": "2026-08-23T03:46:29.977491Z"
+    },
+    "papermill": {
+     "duration": 0.008415,
+     "end_time": "2026-08-23T03:46:29.978765+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T03:46:29.970350+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1033,7 +1344,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2.068874,
+   "end_time": "2026-08-23T03:46:30.214281+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-24-Chemin-Minimal-Robinson-Goforth.ipynb",
+   "output_path": "GameTheory-24-Chemin-Minimal-Robinson-Goforth.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-23T03:46:28.145407+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #12507

See #12205 — contribution partielle (EPIC Chantier 2) : exécution du steer coordinateur « Review Externe » (décision actée sur le dashboard), renommage épistémologique dans GT-24. Deux grains distincts (#12507 lecteur borné GT-15d / celui-ci renommage GT-24), G-VAR-3 respecté.

## Résumé — « chemin certifié » → « témoin construit et vérifié indépendamment »

La décision (Review Externe, actée) : un chemin vérifié par énumération exhaustive dans un univers fini n'est pas un **certificat** au sens formel — c'est un **témoin**, construit par le constructeur et **vérifié indépendamment** par un vérificateur séparé. Le vocabulaire du notebook doit dire ce qu'il fait.

**19 occurrences renommées sur 20** ('certifi' mesuré sur main : 20), sur 9 cellules. Chaque occurrence est adaptée à son contexte, pas un find-replace :

| Endroit | Avant | Après |
|---|---|---|
| Titre + intro (`32877e08`) | « Le chemin minimal certifié » | « Le chemin minimal, témoin construit et vérifié indépendamment » + paragraphe reformulant le rôle du vérificateur séparé |
| Cellule config (`10c63925`, code) | `chemin minimal (certifie par verificateur externe)` | `chemin minimal (temoin construit et verifie independamment)` ; Loi II reformulée |
| Section 4 (`402fcdcb`) | « Le vérificateur séparé — le certificat » | « Le vérificateur séparé — le témoin » ; « le certifier » → « le vérifier indépendamment » |
| `a6e2dfd3` | « le certificat Lean `by decide` » | « la preuve `by decide` » — `by decide` EST une preuve vérifiée par le noyau, pas un certificat |
| `58371b54`, `93dbf482` (Lectures) | « atteste certifié » | « atteste », « vérifie indépendamment » ; « Pas de jambe Lean dans ce grain » conservé |
| Exercices 1/3 (md + stub code) | « le chemin certifié » | « le soumettre au vérificateur séparé » / `construit puis verifie independamment` |

**2 occurrences conservées intentionnellement** :
1. La citation verbatim du Chantier 2 (« synthèse certifiée », EPIC #12205) — nom propre du chantier.
2. Le disclaimer « **pas un certificat au sens formel** » — c'est précisément la phrase qui nomme ce que le résultat N'EST PAS ; le renommage la rend maintenant cohérente avec le reste.

## Validation

- **Re-exécution complète C.2** (cellule code `10c63925` touchée → due) : `notebook_tools.py execute` → **SUCCESS, 5.6 s**, 13/13 cellules code `execution_count` non-null, 0 erreur.
- **Valeurs déterministes toutes préservées** dans les outputs (graines fixes) : 75 (nombre de Fubini), 576, 5625, diamètre 12, géodésiques 16/2/236544, `VALIDE + MINIMAL : 2 pas`, chambres seules 5 pas — vérifiées par script post-re-exec.
- **Résiduel mesuré** : 0 'certifi' parasite dans la sortie ; 9 'témoin' ; les 2 conservés sont les 2 intentionnels.
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` (stubs Exercices intacts — le stub `a9081b02` garde son pattern `print`).
- **scan_cell_ordering** : 1 clean, 0 finding. **detect_markdown_rendering** : 0 violation.
- **Pre-commit** : Passed après re-stage (normalisation `metadata.papermill` → basename par le hook).

## Périmètre — 1 fichier

`MyIA.AI.Notebooks/GameTheory/GameTheory-24-Chemin-Minimal-Robinson-Goforth.ipynb`. Catalogue byte-identique à `origin/main`. Aucun twin (GT-24 n'a pas de sibling `_en`). Aucun secret. Aucune référence externe au titre ancien (README/docs/catalogue vérifiés).
