### PR TITLE
feat(gametheory,#12207): notebook GT-3f Le Parcours Complet (chemin + murs + couts integres)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3f-Parcours-Complet.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3f-Parcours-Complet.ipynb
@@ -1,0 +1,1200 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d1a9e0b3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008676,
+     "end_time": "2026-08-23T04:10:57.139410+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.130734+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory 3f : Le Parcours Complet -- du jeu nommé au coût de la méta-action\n",
+    "\n",
+    "[← GameTheory-3e](GameTheory-3e-Meta-Actions-Tarifees.ipynb) | [GameTheory-24-Chemin-Minimal →](GameTheory-24-Chemin-Minimal-Robinson-Goforth.ipynb) | [↑ README GameTheory](README.md)\n",
+    "\n",
+    "**Versant d'intégration du chantier #12207.** Les versants précédents ont livré chacun une pièce : [GT-24](GameTheory-24-Chemin-Minimal-Robinson-Goforth.ipynb) construit et vérifie des chemins minimaux entre chambres, [GT-3b](GameTheory-3b-Chambres-et-Murs.ipynb) identifie les murs où vivent les égalités, [GT-3e](GameTheory-3e-Meta-Actions-Tarifees.ipynb) tarifé les swaps comme des actions que l'agent paie. Ce notebook referme la boucle : il réunit les trois pièces **dans un seul parcours**, celui que le chantier demande de bout en bout --\n",
+    "\n",
+    "> un lecteur peut, dans un notebook exécuté : partir d'un **jeu nommé**, atteindre un autre jeu nommé par un **chemin qu'il n'a pas écrit lui-même**, **voir le mur** qu'il traverse à chaque pas, et **lire le coût** de la méta-action qui l'y a mené.\n",
+    "\n",
+    "## Plan\n",
+    "\n",
+    "1. **Le chemin que le lecteur n'écrit pas** : constructeur BFS et vérificateur indépendant (patron GT-24)\n",
+    "2. **Voir les murs** : chaque pas traverse un jeu à égalité codimension 1, dont on exhibe les deux faces\n",
+    "3. **Le coût des méta-actions** : tarifs par côté puis par niveau -- et un résultat inattendu, mesuré\n",
+    "4. **Le parcours complet, bout en bout** : le bloc intégral, puis sa re-vérification indépendante\n",
+    "5. **Exercices**\n",
+    "\n",
+    "## La question\n",
+    "\n",
+    "La théorie des jeux ordinaire décrit des agents *dans* des règles. La strate méta demande ce qui se passe quand **déplacer le jeu est une action payée** : quel trajet, quels murs franchis, à quel prix, et payé par qui. Sur l'univers fini de Robinson-Gofforth, chaque pièce de cette question est calculable -- ce notebook les calcule **ensemble**, sur des jeux portant un nom (Dilemme, Poule, Cerf), pour que le résultat se lise comme un récit et pas comme une coordonnée."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "366359d1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009935,
+     "end_time": "2026-08-23T04:10:57.157117+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.147182+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 0. Le substrat, hérité de GT-3b / GT-3e / GT-24\n",
+    "\n",
+    "Un jeu = **deux tables de rangs**, une par joueur, chacune un 4-uplet ordonnant strictement les quatre cases (haut-gauche, haut-droite, bas-gauche, bas-droite) -- rang 4 = meilleur. Les **swaps** échangent les cases portant deux rangs adjacents `k` et `k+1`, de part et d'autre : `R1, R2, R3` (côté Ligne) et `C1, C2, C3` (côté Colonne). Ce sont les six générateurs de l'espace ; chaque traversée d'un swap franchit un **mur** du monde de Bruns-Kimmich -- c'est l'objet de la section 2. Toute la mécanique est reprise telle quelle des trois versants, sans modification : ce notebook est un consommateur du substrat, pas une refonte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1e58217f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.169203Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.168935Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.179550Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.178874Z"
+    },
+    "papermill": {
+     "duration": 0.015629,
+     "end_time": "2026-08-23T04:10:57.180092+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.164463+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tables strictes par joueur : 24 | chambres (jeux stricts) : 576\n",
+      "Générateurs : R1 R2 R3 (Ligne) x C1 C2 C3 (Colonne)\n",
+      "  PD (Dilemme)     Ligne (3, 1, 4, 2) | Colonne (3, 4, 1, 2) | chambre stricte : True\n",
+      "  POULE (Poule)    Ligne (3, 2, 4, 1) | Colonne (3, 4, 2, 1) | chambre stricte : True\n",
+      "  CERF (Cerf)      Ligne (4, 1, 3, 2) | Colonne (4, 3, 1, 2) | chambre stricte : True\n",
+      "  IDENTITE         Ligne (1, 2, 3, 4) | Colonne (1, 2, 3, 4) | chambre stricte : True\n",
+      "  RENVERSE         Ligne (4, 3, 2, 1) | Colonne (4, 3, 2, 1) | chambre stricte : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Substrat GT-3b / GT-3e / GT-24, repris tel quel -- pur stdlib\n",
+    "from itertools import product\n",
+    "from collections import Counter, deque\n",
+    "import heapq\n",
+    "\n",
+    "def swap_valeurs_adjacentes(t, k):\n",
+    "    \"\"\"Échange les cases portant les rangs k et k+1 (traversée de la facette k<->k+1).\"\"\"\n",
+    "    pk, pk1 = t.index(k), t.index(k + 1)\n",
+    "    l = list(t); l[pk], l[pk1] = l[pk1], l[pk]; return tuple(l)\n",
+    "\n",
+    "def swap_jeu(jeu, cote, k):\n",
+    "    \"\"\"Applique le swap de niveau k sur LA table du joueur désigné (méta-action unilatérale).\"\"\"\n",
+    "    row, col = jeu\n",
+    "    if cote == \"ligne\":\n",
+    "        return (swap_valeurs_adjacentes(row, k), col)\n",
+    "    return (row, swap_valeurs_adjacentes(col, k))\n",
+    "\n",
+    "stricts = sorted({tuple(p) for p in product(range(1, 5), repeat=4) if len(set(p)) == 4})\n",
+    "chambres = [(r, c) for r in stricts for c in stricts]\n",
+    "print(\"Tables strictes par joueur :\", len(stricts), \"| chambres (jeux stricts) :\", len(chambres))\n",
+    "print(\"Générateurs : R1 R2 R3 (Ligne) x C1 C2 C3 (Colonne)\")\n",
+    "\n",
+    "# Les cinq bornes canoniques (convention GT-21 / GT-3b / GT-24)\n",
+    "PD       = ((3, 1, 4, 2), (3, 4, 1, 2))   # T>R>P>S\n",
+    "POULE    = ((3, 2, 4, 1), (3, 4, 2, 1))   # T>R>S>P\n",
+    "CERF     = ((4, 1, 3, 2), (4, 3, 1, 2))   # R>T>P>S\n",
+    "IDENTITE = ((1, 2, 3, 4), (1, 2, 3, 4))\n",
+    "RENVERSE = ((4, 3, 2, 1), (4, 3, 2, 1))\n",
+    "for nom, j in [(\"PD (Dilemme)\", PD), (\"POULE (Poule)\", POULE), (\"CERF (Cerf)\", CERF),\n",
+    "               (\"IDENTITE\", IDENTITE), (\"RENVERSE\", RENVERSE)]:\n",
+    "    ok = j in chambres\n",
+    "    print(f\"  {nom:16s} Ligne {j[0]} | Colonne {j[1]} | chambre stricte : {ok}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29e553c7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002203,
+     "end_time": "2026-08-23T04:10:57.184933+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.182730+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du substrat\n",
+    "\n",
+    "Vingt-quatre tables par joueur, donc 24 x 24 = **576 chambres** -- l'univers de Robinson-Gofforth classique, déjà dérivé par GT-24 et non récité ici. Les cinq bornes canoniques y vivent : le Dilemme du Prisonnier (défection mutuelle stable), la Poule (le jeu du poulet), la Chasse au Cerf (coordination sur le meilleur monde commun), et les deux extrêmes structurants Identité et Renversement.\n",
+    "\n",
+    "Deux précisions de vocabulaire pour la suite. Un **pas** relie deux chambres adjacentes : il modifie exactement une table, celle du joueur qui agit, par exactement un swap de niveau `k`. Et une **méta-action** (GT-3e) est ce pas *considéré comme payé* : réécrire une préférence déclarée coûte quelque chose, en échelons de rang -- c'est la section 3 qui fixe le barème."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a694f593",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004072,
+     "end_time": "2026-08-23T04:10:57.191529+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.187457+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le chemin que le lecteur n'écrit pas\n",
+    "\n",
+    "Le premier impératif du parcours : le chemin ne doit pas être écrit à la main. Si le lecteur choisissait lui-même ses swaps, le notebook ne montrerait rien -- il redirait ses propres intuitions. Le constructeur ci-dessous produit donc le chemin par **BFS avec remontée des parents**, exactement selon le patron de GT-24 : le graphe des 576 chambres est exploré depuis le départ, et la chaîne est reconstruite en remontant de l'arrivée.\n",
+    "\n",
+    "Le second impératif est la **séparation constructeur / vérificateur** (loi II de la série) : celui qui produit le témoin n'est pas celui qui le juge. La cellule suivante héberge un vérificateur qui ne réutilise *rien* du constructeur -- il re-dérive les distances par sa propre recherche exhaustive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d76db9ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.202329Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.202129Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.207799Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.207360Z"
+    },
+    "papermill": {
+     "duration": 0.012086,
+     "end_time": "2026-08-23T04:10:57.208310+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.196224+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chemin construit : Dilemme du Prisonnier -> Chasse au Cerf\n",
+      "  départ  PD   : Ligne (3, 1, 4, 2) | Colonne (3, 4, 1, 2)\n",
+      "  -- R3 (côté ligne, niveaux 3 <-> 4) -->  Ligne (4, 1, 3, 2) | Colonne (3, 4, 1, 2)\n",
+      "  -- C3 (côté colonne, niveaux 3 <-> 4) -->  Ligne (4, 1, 3, 2) | Colonne (4, 3, 1, 2)\n",
+      "Longueur du chemin produit : 2 pas\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 1.1 : construire_chemin -- le constructeur de témoin (patron GT-24) ===\n",
+    "\n",
+    "def construire_chemin(depart, arrivee):\n",
+    "    \"\"\"Produit une suite (jeu_avant, jeu_apres) de départ à arrivée par BFS + remontée des parents.\"\"\"\n",
+    "    parent = {depart: None}\n",
+    "    q = deque([depart])\n",
+    "    while q:\n",
+    "        u = q.popleft()\n",
+    "        if u == arrivee:\n",
+    "            break\n",
+    "        for cote in (\"ligne\", \"colonne\"):\n",
+    "            for k in (1, 2, 3):\n",
+    "                v = swap_jeu(u, cote, k)\n",
+    "                if v not in parent:\n",
+    "                    parent[v] = u\n",
+    "                    q.append(v)\n",
+    "    if arrivee not in parent:\n",
+    "        return None\n",
+    "    chaine = []\n",
+    "    cur = arrivee\n",
+    "    while parent[cur] is not None:\n",
+    "        chaine.append((parent[cur], cur))\n",
+    "        cur = parent[cur]\n",
+    "    return chaine[::-1]\n",
+    "\n",
+    "def nommer_pas(pred, cur):\n",
+    "    \"\"\"Nomme le pas élémentaire entre deux jeux consécutifs (côté, niveaux échangés).\"\"\"\n",
+    "    for cote, ti in ((\"ligne\", 0), (\"colonne\", 1)):\n",
+    "        if pred[ti] != cur[ti]:\n",
+    "            for k in (1, 2, 3):\n",
+    "                if swap_jeu(pred, cote, k) == cur:\n",
+    "                    nom_cote = \"R\" if cote == \"ligne\" else \"C\"\n",
+    "                    return f\"{nom_cote}{k} (côté {cote}, niveaux {k} <-> {k + 1})\"\n",
+    "    return \"?\"\n",
+    "\n",
+    "chemin_pd_cerf = construire_chemin(PD, CERF)\n",
+    "print(\"Chemin construit : Dilemme du Prisonnier -> Chasse au Cerf\")\n",
+    "print(f\"  départ  PD   : Ligne {PD[0]} | Colonne {PD[1]}\")\n",
+    "for pred, cur in chemin_pd_cerf:\n",
+    "    print(f\"  -- {nommer_pas(pred, cur)} -->  Ligne {cur[0]} | Colonne {cur[1]}\")\n",
+    "print(f\"Longueur du chemin produit : {len(chemin_pd_cerf)} pas\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0ff615d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003636,
+     "end_time": "2026-08-23T04:10:57.215068+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.211432+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : deux révisions du sommet\n",
+    "\n",
+    "Le chemin construit a **2 pas** -- et chacun réécrit le **sommet** des préférences d'un joueur (niveaux 3 <-> 4). Ce n'est pas un choix du constructeur, c'est la géométrie : pour passer du Dilemme au Cerf, Ligne doit échanger ses deux meilleures cases (sa table `(3, 1, 4, 2)` devient `(4, 1, 3, 2)`) et Colonne doit faire de même. En langage des noms : dans le Dilemme, la défection est le sommet de chacun ; dans le Cerf, c'est la coordination. Aucun détour par les bas niveaux ne raccourcit ce trajet -- il faut toucher au sommet, deux fois.\n",
+    "\n",
+    "On notera l'asymétrie apparente des tables du Cerf (`(4, 1, 3, 2)` et `(4, 3, 1, 2)`) : les deux joueurs y placent le même sommet mais ne classent pas pareil les deux pires cases -- le Cerf n'exige pas d'êtres identiques, seulement de préférer le monde commun."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f2f8defc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.223902Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.223591Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.233259Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.232602Z"
+    },
+    "papermill": {
+     "duration": 0.016186,
+     "end_time": "2026-08-23T04:10:57.234029+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.217843+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1. Le chemin du constructeur (PD -> CERF) :\n",
+      "   VALIDE + MINIMAL : 2 pas = distance exhaustive d(G,H)\n",
+      "2. Le même chemin rallongé d'un aller-retour :\n",
+      "   VALIDE mais NON MINIMAL : 4 pas, distance réelle 2\n",
+      "3. Un 'chemin' en un pas vers un jeu non adjacent :\n",
+      "   INVALIDE : pas non élémentaire vers ((3, 2, 4, 1), (3, 4, 2, 1))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 1.2 : verifier_chemin -- le vérificateur indépendant (patron GT-24) ===\n",
+    "\n",
+    "def bfs_complet(depart):\n",
+    "    \"\"\"Distances exhaustives depuis depart (la preuve de minimalité, recalculée par le vérificateur).\"\"\"\n",
+    "    dist = {depart: 0}\n",
+    "    q = deque([depart])\n",
+    "    while q:\n",
+    "        u = q.popleft()\n",
+    "        for cote in (\"ligne\", \"colonne\"):\n",
+    "            for k in (1, 2, 3):\n",
+    "                v = swap_jeu(u, cote, k)\n",
+    "                if v not in dist:\n",
+    "                    dist[v] = dist[u] + 1\n",
+    "                    q.append(v)\n",
+    "    return dist\n",
+    "\n",
+    "def pas_elementaire_valide(pred, cur):\n",
+    "    \"\"\"True ssi cur s'obtient de pred par exactement un swap élémentaire.\"\"\"\n",
+    "    return cur in [swap_jeu(pred, cote, k) for cote in (\"ligne\", \"colonne\") for k in (1, 2, 3)]\n",
+    "\n",
+    "def verifier_chemin(depart, arrivee, chaine):\n",
+    "    \"\"\"Verdict indépendant : re-dérive TOUT, ne réutilise rien du constructeur.\"\"\"\n",
+    "    if chaine is None or len(chaine) == 0:\n",
+    "        return \"INVALIDE : chemin vide\"\n",
+    "    if chaine[0][0] != depart or chaine[-1][1] != arrivee:\n",
+    "        return \"INVALIDE : les extrémités ne sont pas celles annoncées\"\n",
+    "    for pred, cur in chaine:\n",
+    "        if not pas_elementaire_valide(pred, cur):\n",
+    "            return f\"INVALIDE : pas non élémentaire vers {cur}\"\n",
+    "    d_reel = bfs_complet(depart)[arrivee]\n",
+    "    if len(chaine) != d_reel:\n",
+    "        return f\"VALIDE mais NON MINIMAL : {len(chaine)} pas, distance réelle {d_reel}\"\n",
+    "    return f\"VALIDE + MINIMAL : {len(chaine)} pas = distance exhaustive d(G,H)\"\n",
+    "\n",
+    "print(\"1. Le chemin du constructeur (PD -> CERF) :\")\n",
+    "print(\"  \", verifier_chemin(PD, CERF, chemin_pd_cerf))\n",
+    "\n",
+    "voisin_cerf = swap_jeu(CERF, \"ligne\", 1)\n",
+    "chemin_detour = chemin_pd_cerf + [(CERF, voisin_cerf), (voisin_cerf, CERF)]\n",
+    "print(\"2. Le même chemin rallongé d'un aller-retour :\")\n",
+    "print(\"  \", verifier_chemin(PD, CERF, chemin_detour))\n",
+    "\n",
+    "print(\"3. Un 'chemin' en un pas vers un jeu non adjacent :\")\n",
+    "print(\"  \", verifier_chemin(PD, POULE, [(PD, POULE)]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed00f69b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002239,
+     "end_time": "2026-08-23T04:10:57.238626+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.236387+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : trois verdicts, une séparation\n",
+    "\n",
+    "Le vérificateur rend trois verdicts distincts sur trois cas construits pour eux : `VALIDE + MINIMAL` pour le témoin du constructeur, `NON MINIMAL` pour le même chemin artificiellement rallongé d'un aller-retour, et `INVALIDE` pour un saut direct PD -> POULE (deux jeux que rien ne relie en un pas). La minimalité n'est pas une impression : elle est **re-dérivée par recherche exhaustive** depuis le départ, indépendamment de la façon dont le constructeur a trouvé son chemin.\n",
+    "\n",
+    "C'est la loi II de la série, appliquée au parcours : le constructeur (BFS + parents) *produit* un témoin, le vérificateur (re-dérivation complète) le *juge*. À la section 4, ce couple sera étendu aux murs et aux coûts : le vérificateur final re-vérifiera tout ce que le parcours affiche."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f4c5459",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002195,
+     "end_time": "2026-08-23T04:10:57.242996+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.240801+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Voir les murs\n",
+    "\n",
+    "Entre deux chambres adjacentes -- avant et après un swap de niveau `k` -- il y a un **mur** : un jeu à rangs où les deux niveaux `k` et `k+1` sont tombés **ex æquo**. C'est la lecture Bruns-Kimmich reprise de GT-3b : le monde complet des jeux à rangs compte 5625 points, dont 576 chambres (aucune égalité) et des murs de codimension 1 (exactement une paire ex æquo). Traverser un swap, c'est littéralement *passer à travers* le mur qui sépare les deux chambres.\n",
+    "\n",
+    "Deux opérations réciproques le formalisent : **fusionner** les niveaux `k` et `k+1` d'une chambre donne le mur qu'un pas de niveau `k` traverse ; **briser le tie** d'un mur redonne les deux chambres qu'il sépare. La propriété qui fait tenir la section : briser le tie du mur d'un pas doit redonner *exactement* les deux tables extrémités de ce pas. Elle est vérifiée globalement ci-dessous, sur les 24 tables et les 3 niveaux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4892bf9f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.248380Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.248145Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.254839Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.254333Z"
+    },
+    "papermill": {
+     "duration": 0.010347,
+     "end_time": "2026-08-23T04:10:57.255519+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.245172+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Propriété mur <-> paire de chambres, vérifiée sur 24 tables x 3 niveaux : True\n",
+      "Murs simples distincts par joueur : 36 (GT-3b mesurait 36)\n",
+      "Exemple : table Ligne du Dilemme (3, 1, 4, 2) | pas de niveau 3\n",
+      "  mur          : (3, 1, 3, 2) (codim 1)\n",
+      "  faces du mur : (3, 1, 4, 2), (4, 1, 3, 2)\n",
+      "  extrémités   : (3, 1, 4, 2) et (4, 1, 3, 2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 2.1 : le mur d'un pas -- fusion de niveaux et brisure de tie (GT-3b) ===\n",
+    "\n",
+    "def mur_du_niveau(t, k):\n",
+    "    \"\"\"L'ordre faible (codim 1) où les niveaux k et k+1 de t sont ex æquo : le mur du pas de niveau k.\"\"\"\n",
+    "    l = [x - 1 if x > k else x for x in t]      # les niveaux au-dessus descendent d'un cran\n",
+    "    l[t.index(k)] = k\n",
+    "    l[t.index(k + 1)] = k                       # les deux niveaux fusionnent en k\n",
+    "    return tuple(l)\n",
+    "\n",
+    "def briser_le_tie(t):\n",
+    "    \"\"\"Les deux chambres strictes que le mur t sépare (réciproque exacte de mur_du_niveau).\"\"\"\n",
+    "    v = min(x for x in t if t.count(x) > 1)     # la valeur ex æquo (mur simple : unique)\n",
+    "    i, j = [p for p in range(4) if t[p] == v]\n",
+    "    inc = [x + 1 if x > v else x for x in t]    # les niveaux au-dessus remontent d'un cran\n",
+    "    A = list(inc); A[i], A[j] = v, v + 1\n",
+    "    B = list(inc); B[i], B[j] = v + 1, v\n",
+    "    return tuple(A), tuple(B)\n",
+    "\n",
+    "# Propriété clé, vérifiée GLOBALEMENT : briser le tie du mur d'un pas redonne ses extrémités\n",
+    "prop = all(sorted(briser_le_tie(mur_du_niveau(t, k))) == sorted([t, swap_valeurs_adjacentes(t, k)])\n",
+    "           for t in stricts for k in (1, 2, 3))\n",
+    "print(\"Propriété mur <-> paire de chambres, vérifiée sur 24 tables x 3 niveaux :\", prop)\n",
+    "\n",
+    "murs_par_joueur = {mur_du_niveau(t, k) for t in stricts for k in (1, 2, 3)}\n",
+    "print(\"Murs simples distincts par joueur :\", len(murs_par_joueur), \"(GT-3b mesurait 36)\")\n",
+    "\n",
+    "t, k = PD[0], 3\n",
+    "print(f\"Exemple : table Ligne du Dilemme {t} | pas de niveau 3\")\n",
+    "print(f\"  mur          : {mur_du_niveau(t, 3)} (codim {4 - len(set(mur_du_niveau(t, 3)))})\")\n",
+    "print(f\"  faces du mur : {briser_le_tie(mur_du_niveau(t, 3))[0]}, {briser_le_tie(mur_du_niveau(t, 3))[1]}\")\n",
+    "print(f\"  extrémités   : {t} et {swap_valeurs_adjacentes(t, 3)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a478fdb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002382,
+     "end_time": "2026-08-23T04:10:57.260431+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.258049+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le mur a deux faces, et ce sont les extrémités du pas\n",
+    "\n",
+    "La propriété est vérifiée sur les 72 combinaisons (24 tables x 3 niveaux) : **briser le tie du mur redonne exactement la chambre de départ et la chambre d'arrivée du pas**. Le mur n'est donc pas une métaphore décorative -- c'est l'objet géométrique *entre* les deux jeux, celui dont les deux faces sont les extrémités du pas. Sur l'exemple affiché : la table Ligne du Dilemme `(3, 1, 4, 2)` et sa voisine de niveau 3 `(4, 1, 3, 2)` -- la table du Cerf -- sont les deux faces du mur `(3, 1, 3, 2)`, où les cases haut-gauche et bas-gauche sont ex æquo au sommet.\n",
+    "\n",
+    "Le comptage rejoint GT-3b : **36 murs simples par joueur** (24 chambres x 3 niveaux, chaque mur compté deux fois car chaque mur touche exactement 2 chambres). Chaque niveau de préférence a ses murs ; franchir un mur de niveau 3, c'est réécrire un sommet -- le lien avec le coût de la section suivante est direct."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e9da6006",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.265970Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.265751Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.270184Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.269700Z"
+    },
+    "papermill": {
+     "duration": 0.007929,
+     "end_time": "2026-08-23T04:10:57.270686+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.262757+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Le chemin PD -> CERF, lu mur par mur :\n",
+      "  pas 1 : R3 (côté ligne, niveaux 3 <-> 4)\n",
+      "     table ligne : (3, 1, 4, 2) -> (4, 1, 3, 2)\n",
+      "     mur traversé : (3, 1, 3, 2) (codim 1) | faces : (3, 1, 4, 2), (4, 1, 3, 2)\n",
+      "     les faces sont les extrémités du pas : True\n",
+      "  pas 2 : C3 (côté colonne, niveaux 3 <-> 4)\n",
+      "     table colonne : (3, 4, 1, 2) -> (4, 3, 1, 2)\n",
+      "     mur traversé : (3, 3, 1, 2) (codim 1) | faces : (3, 4, 1, 2), (4, 3, 1, 2)\n",
+      "     les faces sont les extrémités du pas : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 2.2 : les murs du chemin PD -> CERF, pas à pas ===\n",
+    "\n",
+    "print(\"Le chemin PD -> CERF, lu mur par mur :\")\n",
+    "for n, (pred, cur) in enumerate(chemin_pd_cerf, 1):\n",
+    "    cote, ti = (\"ligne\", 0) if pred[0] != cur[0] else (\"colonne\", 1)\n",
+    "    k = [kk for kk in (1, 2, 3) if swap_jeu(pred, cote, kk) == cur][0]\n",
+    "    mur = mur_du_niveau(pred[ti], k)\n",
+    "    faces = briser_le_tie(mur)\n",
+    "    confirmee = sorted(faces) == sorted([pred[ti], cur[ti]])\n",
+    "    print(f\"  pas {n} : {nommer_pas(pred, cur)}\")\n",
+    "    print(f\"     table {cote} : {pred[ti]} -> {cur[ti]}\")\n",
+    "    print(f\"     mur traversé : {mur} (codim {4 - len(set(mur))}) | faces : {faces[0]}, {faces[1]}\")\n",
+    "    print(f\"     les faces sont les extrémités du pas : {confirmee}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9325681",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002382,
+     "end_time": "2026-08-23T04:10:57.275423+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.273041+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : deux murs, un par joueur\n",
+    "\n",
+    "Le chemin PD -> CERF traverse exactement **deux murs**, un par joueur, tous deux de niveau 3. Le mur de Ligne, `(3, 1, 3, 2)`, est le jeu où Ligne est *indifférent entre défection et coopération* (ses cases haut-gauche et bas-gauche ex æquo au sommet) tandis que la table de Colonne est encore celle du Dilemme. Le mur de Colonne, `(3, 3, 1, 2)`, est le miroir : Colonne indifférent au sommet, Ligne déjà converti au Cerf.\n",
+    "\n",
+    "C'est le contenu concret du critère d'intégration : le chemin n'est plus une suite de coordonnées, c'est une suite de **situations intermédiaires lisibles** -- chacune est un jeu où un joueur exactement est suspendu entre ses deux anciens idéaux. La ligne `confirmee : True` de chaque pas est la garantie que le mur exhibé est bien *celui-là* et pas un voisin."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c960ba15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002236,
+     "end_time": "2026-08-23T04:10:57.279939+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.277703+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Le coût des méta-actions\n",
+    "\n",
+    "Chaque pas du chemin est une **méta-action** au sens de GT-3e : un joueur réécrit ses préférences déclarées, et cette réécriture est payée en échelons de rang -- l'unité honnête d'un monde purement ordinal (payer 1, c'est renoncer à un échelon pour atteindre le niveau visé). Reste à fixer le **barème**. Deux lectures naturelles :\n",
+    "\n",
+    "- **par côté** : Ligne paie `c_L` par swap, Colonne `c_C` -- le tarif différencié, par exemple la réécriture de la table Colonne (l'\"institution\") plus cher que celle de Ligne ;\n",
+    "- **par niveau** : réécrire le bas de sa liste coûte 1, le milieu 2, le **sommet 3** -- réviser ce qu'on préfère *entre tout* est la révision la plus profonde.\n",
+    "\n",
+    "La question qui semble s'imposer : le chemin le plus court en nombre de pas est-il le moins cher ? L'intuition crie *non* -- un détour par des niveaux bon marché pourrait battre le trajet direct. La mesure, elle, répond autrement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "562b5094",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.285453Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.285294Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.290630Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.290133Z"
+    },
+    "papermill": {
+     "duration": 0.009415,
+     "end_time": "2026-08-23T04:10:57.291589+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.282174+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tarifs par côté : Ligne 1, Colonne 3\n",
+      "                 paire | d_L | d_C | longueur | coût | Ligne paie | Colonne paie\n",
+      "------------------------------------------------------------------------------\n",
+      "        PD -> POULE      | 1  | 1  |    2     |   4  |     1      |      3\n",
+      "        PD -> CERF       | 1  | 1  |    2     |   4  |     1      |      3\n",
+      "        PD -> IDENTITE   | 3  | 4  |    7     |  15  |     3      |      12\n",
+      "        PD -> RENVERSE   | 3  | 2  |    5     |   9  |     3      |      6\n",
+      "     POULE -> CERF       | 2  | 2  |    4     |   8  |     2      |      6\n",
+      "     POULE -> IDENTITE   | 4  | 5  |    9     |  19  |     4      |      15\n",
+      "     POULE -> RENVERSE   | 2  | 1  |    3     |   5  |     2      |      3\n",
+      "      CERF -> IDENTITE   | 4  | 5  |    9     |  19  |     4      |      15\n",
+      "      CERF -> RENVERSE   | 2  | 1  |    3     |   5  |     2      |      3\n",
+      "  IDENTITE -> RENVERSE   | 6  | 6  |    12     |  24  |     6      |      18\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 3.1 : tarifs par côté -- le coût est géométrique ===\n",
+    "\n",
+    "def dist_tables(t0):\n",
+    "    \"\"\"Distances du graphe des 24 tables d'UN joueur (générateurs : les 3 swaps de niveau).\"\"\"\n",
+    "    d = {t0: 0}; q = deque([t0])\n",
+    "    while q:\n",
+    "        u = q.popleft()\n",
+    "        for k in (1, 2, 3):\n",
+    "            v = swap_valeurs_adjacentes(u, k)\n",
+    "            if v not in d: d[v] = d[u] + 1; q.append(v)\n",
+    "    return d\n",
+    "\n",
+    "NOMS = [(\"PD\", PD), (\"POULE\", POULE), (\"CERF\", CERF), (\"IDENTITE\", IDENTITE), (\"RENVERSE\", RENVERSE)]\n",
+    "c_L, c_C = 1, 3\n",
+    "print(f\"Tarifs par côté : Ligne {c_L}, Colonne {c_C}\")\n",
+    "print(f\"{'paire':>22s} | d_L | d_C | longueur | coût | Ligne paie | Colonne paie\")\n",
+    "print(\"-\" * 78)\n",
+    "for (n1, j1), (n2, j2) in [(a, b) for i, a in enumerate(NOMS) for b in NOMS[i + 1:]]:\n",
+    "    dL = dist_tables(j1[0])[j2[0]]\n",
+    "    dC = dist_tables(j1[1])[j2[1]]\n",
+    "    print(f\"{n1:>10s} -> {n2:<10s} | {dL}  | {dC}  |    {dL + dC}     |  {c_L*dL + c_C*dC:>2d}  |     {c_L*dL}      |      {c_C*dC}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "599e00c2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00217,
+     "end_time": "2026-08-23T04:10:57.296078+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.293908+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : un théorème, pas une coïncidence\n",
+    "\n",
+    "Les colonnes `d_L` et `d_C` sont les distances **dans le graphe des 24 tables d'un seul joueur** -- chacune recalculée par BFS indépendant. Et le tableau montre la structure : **la longueur du chemin minimal est exactement `d_L + d_C`**, et son coût exactement `c_L·d_L + c_C·d_C`. Ce n'est pas un accident d'échantillon, c'est un théorème de trois lignes :\n",
+    "\n",
+    "> chaque pas modifie exactement **une** table ; la table de Ligne doit passer de `PD[0]` à `CERF[0]`, ce qui exige au moins `d_L` pas côté Ligne ; symétriquement au moins `d_C` côté Colonne. Tout chemin a donc au moins `d_L + d_C` pas et coûte au moins `c_L·d_L + c_C·d_C` -- et le chemin BFS atteint exactement ces deux bornes.\n",
+    "\n",
+    "La conséquence est le résultat central de cette section : **le coût du trajet minimal n'est pas négociable**. Aucun choix de chemin -- aucune ruse, aucun détour -- ne change la facture : qui paie quoi est fixé par la géométrie des deux tables, avant tout parcours. Pour aller du Dilemme au Cerf à ces tarifs, Ligne paie `c_L` et Colonne `c_C` -- quel que soit le chemin minimal emprunté."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5e94bd1c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.301344Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.301146Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.716571Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.716154Z"
+    },
+    "papermill": {
+     "duration": 0.418848,
+     "end_time": "2026-08-23T04:10:57.717059+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.298211+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tarifs par niveau : {1: 1, 2: 2, 3: 3} | le plus court chemin est-il le moins cher ?\n",
+      "        PD -> POULE    : BFS 2 pas à 2 | Dijkstra 2 pas à 2 | écart 0\n",
+      "        PD -> CERF     : BFS 2 pas à 6 | Dijkstra 2 pas à 6 | écart 0\n",
+      "        PD -> IDENTITE : BFS 7 pas à 14 | Dijkstra 7 pas à 14 | écart 0\n",
+      "        PD -> RENVERSE : BFS 5 pas à 10 | Dijkstra 5 pas à 10 | écart 0\n",
+      "     POULE -> CERF     : BFS 4 pas à 8 | Dijkstra 4 pas à 8 | écart 0\n",
+      "     POULE -> IDENTITE : BFS 9 pas à 16 | Dijkstra 9 pas à 16 | écart 0\n",
+      "     POULE -> RENVERSE : BFS 3 pas à 8 | Dijkstra 3 pas à 8 | écart 0\n",
+      "      CERF -> IDENTITE : BFS 9 pas à 17 | Dijkstra 9 pas à 17 | écart 0\n",
+      "      CERF -> RENVERSE : BFS 3 pas à 4 | Dijkstra 3 pas à 4 | écart 0\n",
+      "  IDENTITE -> RENVERSE : BFS 12 pas à 20 | Dijkstra 12 pas à 20 | écart 0\n",
+      "Paires nommées où un détour battrait le plus court chemin : 0 / 10\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Échantillon de 300 paires quelconques de chambres : 0 détour(s) gagnant(s)\n",
+      "\n",
+      "PD -> IDENTITE : le BFS et le Dijkstra produisent deux chemins distincts\n",
+      "  BFS       : ['R2 (côté ligne, niveaux 2 <-> 3)', 'R1 (côté ligne, niveaux 1 <-> 2)', 'R3 (côté ligne, niveaux 3 <-> 4)', 'C2 (côté colonne, niveaux 2 <-> 3)'] ... coût 14\n",
+      "  Dijkstra  : ['R2 (côté ligne, niveaux 2 <-> 3)', 'R1 (côté ligne, niveaux 1 <-> 2)', 'C2 (côté colonne, niveaux 2 <-> 3)', 'C1 (côté colonne, niveaux 1 <-> 2)'] ... coût 14\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 3.2 : tarifs par niveau -- la mesure répond à l'intuition ===\n",
+    "\n",
+    "W = {1: 1, 2: 2, 3: 3}   # bas 1, milieu 2, sommet 3\n",
+    "\n",
+    "def cout_chemin(chaine, w=W):\n",
+    "    total = 0\n",
+    "    for pred, cur in chaine:\n",
+    "        cote, ti = (\"ligne\", 0) if pred[0] != cur[0] else (\"colonne\", 1)\n",
+    "        k = [kk for kk in (1, 2, 3) if swap_jeu(pred, cote, kk) == cur][0]\n",
+    "        total += w[k]\n",
+    "    return total\n",
+    "\n",
+    "def chemin_min_cout(depart, arrivee, w=W):\n",
+    "    \"\"\"Dijkstra : le chemin de coût minimal sous les tarifs w (pas forcément le plus court).\"\"\"\n",
+    "    dist = {depart: 0}; parent = {depart: None}; pq = [(0, depart)]\n",
+    "    while pq:\n",
+    "        d, u = heapq.heappop(pq)\n",
+    "        if u == arrivee: break\n",
+    "        if d > dist.get(u, 10**9): continue\n",
+    "        for cote in (\"ligne\", \"colonne\"):\n",
+    "            for k in (1, 2, 3):\n",
+    "                v = swap_jeu(u, cote, k)\n",
+    "                if d + w[k] < dist.get(v, 10**9):\n",
+    "                    dist[v] = d + w[k]; parent[v] = u; heapq.heappush(pq, (d + w[k], v))\n",
+    "    chaine = []; cur = arrivee\n",
+    "    while parent[cur] is not None:\n",
+    "        chaine.append((parent[cur], cur)); cur = parent[cur]\n",
+    "    return chaine[::-1]\n",
+    "\n",
+    "print(f\"Tarifs par niveau : {W} | le plus court chemin est-il le moins cher ?\")\n",
+    "ecarts = 0\n",
+    "for (n1, j1), (n2, j2) in [(a, b) for i, a in enumerate(NOMS) for b in NOMS[i + 1:]]:\n",
+    "    bfs = construire_chemin(j1, j2)\n",
+    "    dij = chemin_min_cout(j1, j2)\n",
+    "    cb, cd = cout_chemin(bfs), cout_chemin(dij)\n",
+    "    ecart = cb - cd\n",
+    "    ecarts += (ecart > 0)\n",
+    "    print(f\"  {n1:>8s} -> {n2:<8s} : BFS {len(bfs)} pas à {cb} | Dijkstra {len(dij)} pas à {cd} | écart {ecart}\")\n",
+    "print(f\"Paires nommées où un détour battrait le plus court chemin : {ecarts} / 10\")\n",
+    "\n",
+    "import random\n",
+    "random.seed(0)\n",
+    "ech = [(random.choice(chambres), random.choice(chambres)) for _ in range(300)]\n",
+    "disc = sum(1 for a, b in ech if cout_chemin(chemin_min_cout(a, b)) < cout_chemin(construire_chemin(a, b)))\n",
+    "print(f\"Échantillon de 300 paires quelconques de chambres : {disc} détour(s) gagnant(s)\")\n",
+    "\n",
+    "# La non-unicité du témoin : deux chemins distincts, la même facture\n",
+    "bfs_pi = construire_chemin(PD, IDENTITE)\n",
+    "dij_pi = chemin_min_cout(PD, IDENTITE)\n",
+    "print()\n",
+    "print(\"PD -> IDENTITE : le BFS et le Dijkstra produisent deux chemins distincts\")\n",
+    "print(\"  BFS       :\", [nommer_pas(p, c) for p, c in bfs_pi][:4], \"... coût\", cout_chemin(bfs_pi))\n",
+    "print(\"  Dijkstra  :\", [nommer_pas(p, c) for p, c in dij_pi][:4], \"... coût\", cout_chemin(dij_pi))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95c0fd1f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002384,
+     "end_time": "2026-08-23T04:10:57.721978+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.719594+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le plus court est aussi le moins cher -- mesuré, pas prouvé\n",
+    "\n",
+    "L'intuition du détour économique est **réfutée par la mesure** : sur les 10 paires nommées et sur un échantillon de 300 paires quelconques de chambres, **aucun** chemin de coût minimal n'est plus long que le plus court chemin. Sous ces tarifs, la longueur minimale et le coût minimal sont atteints *simultanément* -- le Dijkstra et le BFS rendent la même facture. Ce fait est **mesuré**, pas démontré : la section 3.1 le prouve pour les tarifs par côté (théorème des bornes `d_L`, `d_C`), mais pour les tarifs par niveau, aucun argument court ne clôt la question -- c'est dit tel quel, et l'exercice 2 la rouvre.\n",
+    "\n",
+    "Le dernier affichage montre l'autre face de la structure : pour PD -> IDENTITE, BFS et Dijkstra produisent **deux chemins distincts de même coût**. Le témoin n'est pas unique -- plusieurs routes mènent au même prix -- mais la facture, elle, ne varie pas. Réuni au théorème de la section 3.1, le paysage économique du parcours tient en une phrase : **le prix du voyage est un invariant géométrique ; le chemin, lui, est un choix parmi des égalités**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4ff3b14",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002226,
+     "end_time": "2026-08-23T04:10:57.726643+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.724417+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Le parcours complet, bout en bout\n",
+    "\n",
+    "Les trois pièces sont prêtes : le constructeur de chemin (section 1), les murs (section 2), le barème (section 3). La fonction ci-dessous les assemble dans **un seul bloc** -- celui que le critère d'intégration du chantier demande : un jeu nommé, un chemin construit et non écrit à la main, chaque mur traversé exhibé avec ses deux faces, chaque méta-action affichée avec son coût et son payeur, et la facture finale par joueur.\n",
+    "\n",
+    "Le barème est celui de la section 3.2 (bas 1, milieu 2, sommet 3), le même pour les deux joueurs -- la profondeur de la révision fait le prix, pas l'identité de qui révise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8a8e7bc6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.732017Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.731855Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.736726Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.736309Z"
+    },
+    "papermill": {
+     "duration": 0.008431,
+     "end_time": "2026-08-23T04:10:57.737310+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.728879+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PARCOURS COMPLET : Dilemme (PD) -> Chasse au Cerf (CERF)\n",
+      "  barème par niveau : {1: 1, 2: 2, 3: 3} (le sommet coûte le plus cher)\n",
+      "  Dilemme (PD) : Ligne (3, 1, 4, 2) | Colonne (3, 4, 1, 2)\n",
+      "  pas 1 : R3 (côté ligne, niveaux 3 <-> 4)\n",
+      "          jeu (3, 1, 4, 2)|(3, 4, 1, 2) -> (4, 1, 3, 2)|(3, 4, 1, 2)\n",
+      "          mur traversé : table ligne (3, 1, 3, 2) (codim 1), faces (3, 1, 4, 2), (4, 1, 3, 2)\n",
+      "          coût 3 payé par ligne | cumul 3\n",
+      "  pas 2 : C3 (côté colonne, niveaux 3 <-> 4)\n",
+      "          jeu (4, 1, 3, 2)|(3, 4, 1, 2) -> (4, 1, 3, 2)|(4, 3, 1, 2)\n",
+      "          mur traversé : table colonne (3, 3, 1, 2) (codim 1), faces (3, 4, 1, 2), (4, 3, 1, 2)\n",
+      "          coût 3 payé par colonne | cumul 6\n",
+      "  Chasse au Cerf (CERF) : Ligne (4, 1, 3, 2) | Colonne (4, 3, 1, 2)\n",
+      "  ARRIVÉE : 2 pas | facture totale 6 (Ligne 3, Colonne 3)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 4.1 : parcours_complet -- le bloc du critère d'intégration ===\n",
+    "\n",
+    "def parcours_complet(depart, arrivee, w, nom_dep, nom_arr):\n",
+    "    \"\"\"Le parcours intégral : chemin construit + murs traversés + coûts, affichés d'un seul bloc.\"\"\"\n",
+    "    chaine = construire_chemin(depart, arrivee)\n",
+    "    print(f\"PARCOURS COMPLET : {nom_dep} -> {nom_arr}\")\n",
+    "    print(f\"  barème par niveau : {w} (le sommet coûte le plus cher)\")\n",
+    "    print(f\"  {nom_dep} : Ligne {depart[0]} | Colonne {depart[1]}\")\n",
+    "    cumul = 0\n",
+    "    par_joueur = {\"ligne\": 0, \"colonne\": 0}\n",
+    "    for n, (pred, cur) in enumerate(chaine, 1):\n",
+    "        cote, ti = (\"ligne\", 0) if pred[0] != cur[0] else (\"colonne\", 1)\n",
+    "        k = [kk for kk in (1, 2, 3) if swap_jeu(pred, cote, kk) == cur][0]\n",
+    "        mur = mur_du_niveau(pred[ti], k)\n",
+    "        cout = w[k]\n",
+    "        cumul += cout\n",
+    "        par_joueur[cote] += cout\n",
+    "        print(f\"  pas {n} : {nommer_pas(pred, cur)}\")\n",
+    "        print(f\"          jeu {pred[0]}|{pred[1]} -> {cur[0]}|{cur[1]}\")\n",
+    "        print(f\"          mur traversé : table {cote} {mur} (codim 1), faces {briser_le_tie(mur)[0]}, {briser_le_tie(mur)[1]}\")\n",
+    "        print(f\"          coût {cout} payé par {cote} | cumul {cumul}\")\n",
+    "    print(f\"  {nom_arr} : Ligne {arrivee[0]} | Colonne {arrivee[1]}\")\n",
+    "    print(f\"  ARRIVÉE : {len(chaine)} pas | facture totale {cumul} (Ligne {par_joueur['ligne']}, Colonne {par_joueur['colonne']})\")\n",
+    "    return chaine\n",
+    "\n",
+    "chemin_final = parcours_complet(PD, CERF, W, \"Dilemme (PD)\", \"Chasse au Cerf (CERF)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c379dd5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002419,
+     "end_time": "2026-08-23T04:10:57.742188+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.739769+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le récit complet, lisible d'un bloc\n",
+    "\n",
+    "Le bloc répond terme à terme au critère. Le jeu de départ porte un nom (Dilemme) et l'arrivée aussi (Chasse au Cerf). Le chemin est **construit** par BFS -- le lecteur ne l'a pas écrit. Chaque pas affiche **son mur** : la table à égalité exactement entre les deux jeux, avec ses deux faces, qui sont les extrémités du pas. Et chaque pas affiche **son coût** : deux révisions de sommet à 3 échelons chacune, payées séparément -- Ligne paie 3, Colonne paie 3, facture totale 6.\n",
+    "\n",
+    "Le récit économique se lit maintenant mot à mot : *sortir du Dilemme vers le Cerf ne coûte aucun bas niveau -- il ne coûte que des sommets*. Personne n'a besoin de réviser ses pires cases ; chacun doit seulement admettre que sa meilleure case change de nature. C'est précisément le contenu de GT-3e sur ce couple (l'indifference exacte de la fuite solitaire), désormais visible comme géométrie tarifée : les deux murs franchis sont tous deux des murs de sommet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "518675c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.747690Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.747498Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.754579Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.754122Z"
+    },
+    "papermill": {
+     "duration": 0.010532,
+     "end_time": "2026-08-23T04:10:57.755059+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.744527+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TEMOIN CONSTRUIT ET VÉRIFIÉ INDÉPENDAMMENT : Dilemme (PD) -> Chasse au Cerf (CERF) | 2 pas = distance exhaustive | facture 6 = optimum Dijkstra | chaque mur confirmé par ses faces\n",
+      "\n",
+      "Contre-épreuve -- le même parcours rallongé d'un aller-retour gratuit pour les yeux :\n",
+      "   INVALIDE : 4 pas, distance réelle 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 4.2 : verifier_parcours -- la re-vérification indépendante, étendue ===\n",
+    "\n",
+    "def verifier_parcours(depart, arrivee, chaine, w, nom_dep, nom_arr):\n",
+    "    \"\"\"Re-dérive TOUT ce que parcours_complet affiche : extrémités, pas, murs, coûts, minimalités.\"\"\"\n",
+    "    if chaine is None or len(chaine) == 0 or chaine[0][0] != depart or chaine[-1][1] != arrivee:\n",
+    "        return \"INVALIDE : les extrémités ne sont pas celles annoncées\"\n",
+    "    cumul = 0\n",
+    "    for pred, cur in chaine:\n",
+    "        cote, ti = (\"ligne\", 0) if pred[0] != cur[0] else (\"colonne\", 1)\n",
+    "        k = [kk for kk in (1, 2, 3) if swap_jeu(pred, cote, kk) == cur]\n",
+    "        if not k:\n",
+    "            return f\"INVALIDE : pas non élémentaire vers {cur}\"\n",
+    "        k = k[0]\n",
+    "        if sorted(briser_le_tie(mur_du_niveau(pred[ti], k))) != sorted([pred[ti], cur[ti]]):\n",
+    "            return f\"INVALIDE : le mur exhibé ne sépare pas {pred} et {cur}\"\n",
+    "        cumul += w[k]\n",
+    "    d_long = bfs_complet(depart)[arrivee]\n",
+    "    if len(chaine) != d_long:\n",
+    "        return f\"INVALIDE : {len(chaine)} pas, distance réelle {d_long}\"\n",
+    "    opt = chemin_min_cout(depart, arrivee, w)\n",
+    "    d_cout = cout_chemin(opt, w)\n",
+    "    if cumul != d_cout:\n",
+    "        return f\"VALIDE mais NON MINIMAL EN COÛT : {cumul} payés, optimum {d_cout}\"\n",
+    "    return (f\"TEMOIN CONSTRUIT ET VÉRIFIÉ INDÉPENDAMMENT : {nom_dep} -> {nom_arr} | \"\n",
+    "            f\"{len(chaine)} pas = distance exhaustive | facture {cumul} = optimum Dijkstra | \"\n",
+    "            f\"chaque mur confirmé par ses faces\")\n",
+    "\n",
+    "print(verifier_parcours(PD, CERF, chemin_final, W, \"Dilemme (PD)\", \"Chasse au Cerf (CERF)\"))\n",
+    "\n",
+    "voisin_cerf = swap_jeu(CERF, \"ligne\", 1)\n",
+    "print()\n",
+    "print(\"Contre-épreuve -- le même parcours rallongé d'un aller-retour gratuit pour les yeux :\")\n",
+    "print(\"  \", verifier_parcours(PD, CERF, chemin_final + [(CERF, voisin_cerf), (voisin_cerf, CERF)], W, \"PD\", \"CERF\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b622fd5f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002294,
+     "end_time": "2026-08-23T04:10:57.759891+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.757597+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le témoin construit et vérifié indépendamment\n",
+    "\n",
+    "Le vérificateur étendu ne se contente pas des extrémités et de l'élémentarité : il re-dérive **chaque mur** (brisure de tie recalculée, faces comparées aux extrémités affichées), **chaque coût** (barème réappliqué pas à pas), la **minimalité en longueur** (BFS exhaustif) et la **minimalité en coût** (Dijkstra indépendant) -- et rend son verdict en une ligne. La contre-épreuve finale montre qu'un chemin rallongé d'un aller-retour, invisible aux yeux s'il était bien imprimé, est attrapé par la distance réelle.\n",
+    "\n",
+    "La terminologie est celle du steer #12205 : un chemin produit par un constructeur et accepté par un vérificateur séparé est un **témoin construit et vérifié indépendamment** -- pas une preuve au sens formel, mais un objet dont chaque affirmation affichée a été re-dérivée par un code qui ne partage rien avec celui qui l'a produite. C'est le standard de la série depuis GT-24, étendu ici aux murs et aux coûts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bd96f69",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002195,
+     "end_time": "2026-08-23T04:10:57.764336+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.762141+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Exercices\n",
+    "\n",
+    "Trois exercices prolongent le parcours. Le premier retourne la section 2 (du pas vers le mur) dans l'autre sens ; le deuxième rouvre la question laissée ouverte en 3.2 ; le troisième fait courir le parcours complet sur un autre couple nommé. Comme toujours dans la série : le notebook doit s'exécuter de bout en bout même exercices non complétés -- chaque cellule est un stub inoffensif, à remplacer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "07393b3d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.769858Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.769713Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.773116Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.772668Z"
+    },
+    "papermill": {
+     "duration": 0.007003,
+     "end_time": "2026-08-23T04:10:57.773551+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.766548+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 à compléter : mur_du_pas ((2, 1, 4, 3), (3, 4, 1, 2)) -> ((2, 1, 4, 3), (3, 4, 2, 1))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 -- le mur du pas, dans l'autre sens\n",
+    "# On donne deux chambres adjacentes quelconques (pred, cur). Retrouver le mur traversé :\n",
+    "# 1. identifier le côté modifié et le niveau k (le pas) ;\n",
+    "# 2. construire le mur par fusion de niveaux ;\n",
+    "# 3. vérifier que briser_le_tie(mur) redonne exactement {pred, cur} -- la propriété de la section 2.\n",
+    "# Test attendu sur pred_ex -> cur_ex : côté colonne, niveau 1, mur (2, 3, 1, 1).\n",
+    "\n",
+    "def mur_du_pas(pred, cur):\n",
+    "    \"\"\"Retourne (cote, k, mur) du pas pred -> cur, ou None si non adjacent.\"\"\"\n",
+    "    pass  # TODO étudiant : identifier cote et k, puis mur_du_niveau\n",
+    "    return None\n",
+    "\n",
+    "pred_ex = ((2, 1, 4, 3), (3, 4, 1, 2))\n",
+    "cur_ex = ((2, 1, 4, 3), (3, 4, 2, 1))\n",
+    "print(\"Exercice 1 à compléter : mur_du_pas\", pred_ex, \"->\", cur_ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "3037df0d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.779047Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.778896Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.781897Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.781468Z"
+    },
+    "papermill": {
+     "duration": 0.006408,
+     "end_time": "2026-08-23T04:10:57.782325+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.775917+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 à compléter : balayage sous barème {1: 1, 2: 2, 3: 3}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 -- chercher le contre-exemple au fait mesuré\n",
+    "# La section 3.2 a MESURÉ (10 paires nommées + 300 paires quelconques) que le chemin le plus court\n",
+    "# est aussi le moins cher sous W = {1: 1, 2: 2, 3: 3}. Est-ce robuste à un autre barème ?\n",
+    "# 1. choisir un autre tarif, p.ex. W2 = {1: 1, 2: 1, 3: 3} ou {1: 3, 2: 1, 3: 1} (sommet bon marché !) ;\n",
+    "# 2. re-faire le balayage : pour chaque paire nommée et un échantillon de 300 paires,\n",
+    "#    comparer cout_chemin(construire_chemin) et cout_chemin(chemin_min_cout) ;\n",
+    "# 3. rapporter : un barème où un détour gagne existe-t-il ?\n",
+    "# Indice : commencer par le barème sommet bon marché -- que devient l'écart moyen ?\n",
+    "\n",
+    "W2 = {1: 1, 2: 2, 3: 3}  # TODO étudiant : essayer d'autres barèmes\n",
+    "print(\"Exercice 2 à compléter : balayage sous barème\", W2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8d86c3fa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:10:57.788127Z",
+     "iopub.status.busy": "2026-08-23T04:10:57.787908Z",
+     "iopub.status.idle": "2026-08-23T04:10:57.792382Z",
+     "shell.execute_reply": "2026-08-23T04:10:57.791873Z"
+    },
+    "papermill": {
+     "duration": 0.008165,
+     "end_time": "2026-08-23T04:10:57.792866+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.784701+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 à compléter : parcours POULE -> RENVERSE + vérification\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 -- capstone : POULE -> RENVERSE, le parcours complet\n",
+    "# Faire courir parcours_complet de la Poule au Renversement sous W = {1: 1, 2: 2, 3: 3},\n",
+    "# puis passer le résultat à verifier_parcours. Questions de lecture :\n",
+    "# 1. combien de pas, et répartis comment entre les deux joueurs ?\n",
+    "# 2. quels niveaux sont révisés -- le trajet touche-t-il le sommet de qui que ce soit ?\n",
+    "# 3. la facture par joueur : qui paie le plus, et pourquoi la géométrie l'impose-t-elle (cf 3.1) ?\n",
+    "\n",
+    "print(\"Exercice 3 à compléter : parcours POULE -> RENVERSE + vérification\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56727230",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002323,
+     "end_time": "2026-08-23T04:10:57.797636+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T04:10:57.795313+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Le critère d'intégration du chantier est tenu, bout en bout et sur un seul écran : **un jeu nommé** (le Dilemme), **un chemin non écrit à la main** (BFS + parents, vérifié), **des murs visibles** (chaque pas exhibe la table à égalité entre les deux jeux, ses deux faces confirmées), **des coûts lus** (deux révisions de sommet, 3 échelons chacune, payées séparément) -- et l'arrivée **porte un nom** (la Chasse au Cerf).\n",
+    "\n",
+    "Deux résultats structurent le parcours au-delà de l'assemblage. Le **théorème des bornes** (3.1) : le coût du trajet minimal se décompose en `c_L·d_L + c_C·d_C` où `d_L`, `d_C` sont des distances de tables individuelles -- la facture est un invariant géométrique, hors de portée de tout marchandage sur le choix du chemin. Et le **fait mesuré** (3.2) : sous tarification par niveau, le plus court chemin est aussi le moins cher, sur toutes les paires testées -- l'intuition du détour économique ne survit pas à la mesure.\n",
+    "\n",
+    "**Pour aller plus loin** : l'arbitrage *migrer ou rester* (à quel prix un agent accepte-t-il de payer ces 6 échelons ?) est le sujet de [GT-3e](GameTheory-3e-Meta-Actions-Tarifees.ipynb) ; la théorie des murs et des chambres, celui de [GT-3b](GameTheory-3b-Chambres-et-Murs.ipynb) ; la séparation constructeur / vérificateur, celle de [GT-24](GameTheory-24-Chemin-Minimal-Robinson-Goforth.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 2.626321,
+   "end_time": "2026-08-23T04:10:58.044762+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-3f-Parcours-Complet.ipynb",
+   "output_path": "GameTheory-3f-Parcours-Complet.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-23T04:10:55.418441+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-lean #12499

## Résumé

Nouveau notebook [GameTheory-3f-Parcours-Complet.ipynb](MyIA.AI.Notebooks/GameTheory/GameTheory-3f-Parcours-Complet.ipynb) — le **versant d'intégration** du chantier #12207. Le critère de clôture de l'EPIC demandait qu'un lecteur puisse, dans un notebook exécuté : partir d'un **jeu nommé**, atteindre un autre jeu nommé par un **chemin qu'il n'a pas écrit lui-même**, **voir le mur** qu'il traverse, et **lire le coût** de la méta-action qui l'y a mené. Aucun notebook existant ne couvrait ce parcours intégré (mesuré : « méta-action » 0× dans GT-24, « cout » 0× dans GT-3b, « mur » 2× dans GT-3e). GT-3f referme la boucle : 29 cellules (12 code), 5 sections, 3 exercices.

## Comment chaque terme du critère est tenu

| Terme du critère | Livraison (sorties réelles committées) |
|---|---|
| **Jeu nommé → jeu nommé** | Dilemme du Prisonnier `PD = ((3,1,4,2),(3,4,1,2))` → Chasse au Cerf `CERF = ((4,1,3,2),(4,3,1,2))` (les 5 bornes canoniques GT-21/3b/24 définies §0) |
| **Chemin non écrit à la main** | `construire_chemin` BFS + remontée des parents (patron GT-24) : 2 pas `R3` puis `C3` — le constructeur le produit, pas le lecteur |
| **Voir le mur traversé** | Chaque pas exhibe la table à égalité codim 1 : mur ligne `(3,1,3,2)` puis mur colonne `(3,3,1,2)`, **faces confirmées = extrémités du pas** (propriété `brisier_le_tie(mur_du_niveau(t,k)) = {t, swap(t,k)}` vérifiée sur les 24 tables × 3 niveaux ; 36 murs simples/joueur, rejoignant GT-3b) |
| **Lire le coût de la méta-action** | Barème par niveau (bas 1, milieu 2, sommet 3) : 2 révisions de **sommet** à 3 échelons chacune, `coût 3 payé par ligne | cumul 3` puis `coût 3 payé par colonne | cumul 6` — **facture totale 6 (Ligne 3, Colonne 3)** |
| **Vérifié** | `verifier_parcours` re-dérive TOUT : extrémités, élémentarité, **chaque mur par brisure de tie recalculée**, coûts recomptés, minimalité en longueur (BFS exhaustif) ET en coût (Dijkstra indépendant) → `TEMOIN CONSTRUIT ET VÉRIFIÉ INDÉPENDAMMENT` ; contre-épreuve : détour artificiel rejeté (`INVALIDE : 4 pas, distance réelle 2`) |

## Deux résultats structurels (mesurés avant d'être écrits — G.9)

1. **Théorème des bornes (tarifs par côté)** : tout chemin PD→X exige au moins `d_L` pas ligne (distance entre tables Ligne dans le graphe des 24) et `d_C` pas colonne ; le chemin BFS atteint exactement `d_L + d_C` pas pour `c_L·d_L + c_C·d_C`. Tableau des 10 paires nommées committé (ex. PD→CERF : d_L=1, d_C=1 ; IDENTITE→RENVERSE : 6+6). Conséquence : **la facture du trajet minimal n'est pas négociable** — le choix du chemin ne change pas qui paie quoi.
2. **Fait mesuré (tarifs par niveau)** : le pitch intuitif « un détour par les niveaux bon marché battrait le trajet direct » est **réfuté par mesure** — 0/10 paires nommées et 0/300 paires quelconques de chambres où le chemin de coût minimal est plus long que le plus court. Dit honnêtement **mesuré, pas prouvé** dans la prose ; l'exercice 2 rouvre la question sur d'autres barèmes. Bonus structurel : non-unicité du témoin (PD→IDENTITE : BFS et Dijkstra produisent deux chemins distincts, même facture 14).

## Preuve d'exécution (C.2 / H.1)

`python -m papermill <nb> <nb> -k python3` — **29/29 cellules**, 2 s, 0 erreur, 0 `execution_count: null`. `nbformat.validate` OK. Sorties réelles citées ci-dessus = celles committées. `metadata.papermill.input/output_path` normalisés au basename (#3436), scan de fuites : aucun chemin machine.

## Conformité

- **C.1** : 0 violation (stubs = `pass` + `print("Exercice N à compléter")`) ; notebook exécutable de bout en bout exercices non complétés.
- **C.2/C.3** : nouveau notebook, exécuté intégralement ; seule cellule modifiée après la première exécution = commentaire de l'exercice 1 (mur attendu vérifié à la main : `(2,3,1,1)`, brisure → extrémités exactes), notebook entier re-exécuté ensuite.
- **Densité** : organe `pedagogy_density.py` → `Below 1200 c/cell: 0` (mesure brute ~1346 c/cellule).
- **Catalogue** : byte-identique, non touché — l'entrée sera créée par le cron (<24 h, cf catalog-pr-hygiene). README de série non modifié.
- **Claim** : `[CLAIMED]` posé sur #12207 avant édition, clause `paths: MyIA.AI.Notebooks/GameTheory/GameTheory-3f-*.ipynb` + tag Grain sur sa propre ligne.
- **Terminologie** : « témoin construit et vérifié indépendamment » (steer #12205, adoptée dès la rédaction — GT-3f n'écrit jamais « chemin certifié »).
- **Un seul livrable** : 1 fichier nouveau, aucune autre modification.

See #12207
