### PR TITLE
feat(lean,#2159): Partie 58 Classifier — le classifieur de sous-objets (Ω le préfaisceau des cribles)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -2,6 +2,7 @@ import Grothendieck.Adjunction
 import Grothendieck.Calibration
 import Grothendieck.CanonicalProps
 import Grothendieck.CategoryAndSites
+import Grothendieck.Classifier
 import Grothendieck.Comma
 import Grothendieck.Conservative
 import Grothendieck.ConstantSheaf

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Classifier.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Classifier.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Partie 58 : Le classifieur de sous-objets — Ω, le préfaisceau des cribles
+
+Alexandre Grothendieck (1928-2014).
+
+Extension de #2159 (EPIC #1646).
+
+Les parties 1-44 ont établi le socle : catégories, cribles, topologies, lois
+de treillis (`SieveLattice`), identités de pullback/pushforward, faisceaux,
+faisceautisation, cohomologie. Les parties 45-57 ont systématisé la forme
+flèche de la couverture pour une collection croissante de topologies nommées.
+
+Cette partie franchit un seuil : elle exhibe le **classifieur de sous-objets**
+du topos des préfaisceaux et du topos des faisceaux — le constituant qui, avec
+la clôture cartésienne et les limites finies, définit un **topos élémentaire**
+(Lawvere–Tierney). La révélation grothendieckienne est que ce classifieur
+n'est pas une construction abstraite : Ω est littéralement **le préfaisceau des
+cribles** `Functor.sieves`, l'objet que toute la Partie 6 (`SieveLattice`) a
+equipé d'un treillis complet (`pullback_imap`, `pullback_iinf`,
+`pushforward_imap`…). Les lois de treillis de la Partie 6 sont la structure
+interne de Ω ; la Partie 58 referme la boucle en montrant que ce même objet
+classe les sous-préfaisceaux.
+
+Constructions clés pontées depuis Mathlib (`CategoryTheory.Topos.Sheaf`) :
+
+  - `Functor.sieves C`        : le préfaisceau `X ↦ Sieve X` — c'est Ω
+  - `Presheaf.truth C`        : le morphisme « vrai » `1 ⟶ Ω`, qui choisit `⊤`
+  - `Presheaf.χ m`            : la caractéristique d'un mono `m : F ⟶ G`
+  - `Presheaf.classifier C`   : le classifieur `Subobject.Classifier` des préfaisceaux
+  - `Sheaf.Ω J`               : le faisceau des cribles **J-clos**
+  - `Sheaf.classifier J`      : le classifieur du topos des faisceaux
+  - instances `HasSubobjectClassifier (Cᵒᵖ ⥤ Type w)` et `HasSubobjectClassifier (Sheaf J (Type w))`
+
+La topologie entre par la porte des cribles clos : pour un mono `m` entre
+faisceaux, les valeurs de `χ m` sont des cribles **J-clos**
+(`GrothendieckTopology.isClosed_χ_app_apply_of_isSheaf_of_isSeparated`),
+et c'est cette fermeture qui permet de faire descendre Ω des préfaisceaux
+aux faisceaux.
+
+Tous les `sorry`s éliminés à la création.
+
+### Note d'accessibilité (Epics #1452/#1453)
+
+Ce module expose **12 vérifications `#check`** et **4 théorèmes propres**,
+organisés en 5 sections : (1) Ω est le préfaisceau des cribles ; (2) le
+morphisme vrai et la caractéristique χ ; (3) le classifieur des préfaisceaux ;
+(4) la topologie filtre Ω — cribles clos ; (5) le classifieur des faisceaux.
+
+### Convention i18n (EPIC #4980 ratifiée par user 2026-07-04)
+
+Ce module est jumelé avec sa version anglaise canonique dans le fichier sibling
+`Classifier_en.lean` (modèle sibling pair). Namespace suffixé `_en` (anti-
+collision). Les `#check`, signatures, variables et univers sont byte-identiques
+entre les deux fichiers ; seules les docstrings et commentaires diffèrent.
+-/
+
+import Mathlib.CategoryTheory.Topos.Sheaf
+
+universe u v w
+
+namespace Grothendieck.Classifier
+
+open CategoryTheory
+
+variable {C : Type u} [Category.{v} C]
+
+/-!
+## Section 1 : Ω est le préfaisceau des cribles
+
+Le classifieur de sous-objets d'une catégorie de préfaisceaux vit dans la
+catégorie elle-même : c'est `Functor.sieves C`, l'objet `X ↦ Sieve X`. Chaque
+composante de Ω est le treillis complet des cribles sur `X` — l'objet que la
+Partie 6 (`SieveLattice`) a parcouru de long en large. La fonctorialité
+(`sieves_map`) tire un crible en arrière le long d'une flèche : c'est le
+`Sieve.pullback` de la Partie 6, qui préserve ⊥, ⊤, ⊔, ⊓, `iSup` et `iInf`.
+-/
+
+-- CALIBRATION : le préfaisceau des cribles, composante par composante.
+#check @CategoryTheory.Functor.sieves          -- Cᵒᵖ ⥤ Type (max u v), X ↦ Sieve X.unop
+#check @CategoryTheory.Functor.sieves_map       -- la fonctorialité est le pullback de cribles
+
+/-!
+## Section 2 : Le morphisme vrai et la caractéristique χ
+
+Le morphisme `truth : 1 ⟶ Ω` est la flèche « vrai » : en chaque composante,
+il choisit le crible maximal `⊤`. La caractéristique `χ m` d'un mono `m : F ⟶ G`
+envoie un élément `x : G(X)` sur le crible des flèches `f : Y ⟶ X` le long
+desquelles `x` remonte dans `F` : `f ∈ χ m x` ssi `∃ a, G(f)(x) = m(a)`.
+-/
+
+-- CALIBRATION : le morphisme vrai choisit le crible maximal.
+#check @CategoryTheory.Presheaf.truth           -- (const PUnit) ⟶ sieves C
+#check @CategoryTheory.Presheaf.χ               -- (m : F ⟶ G) : G ⟶ sieves C
+
+variable {F G : Cᵒᵖ ⥤ Type (max u v)} (m : F ⟶ G) (X : Cᵒᵖ) (x : G.obj X)
+
+/-- VRAI (rfl) : le morphisme vrai choisit exactement le crible maximal.
+    La composante en `X` est constante de valeur `⊤`. -/
+theorem truth_picks_top (X : Cᵒᵖ)
+    (b : ((Functor.const Cᵒᵖ).obj PUnit).obj X) :
+    (Presheaf.truth C).app X b = (⊤ : Sieve X.unop) := rfl
+
+/-- PONT : l'appartenance dans la caractéristique se lit sur la définition —
+    `f` appartient au crible `χ m x` exactement quand `x` remonte dans `F`
+    le long de `f`. C'est la lecture membre à membre du classifieur. -/
+theorem chi_app_mem_iff {Y : C} (f : Y ⟶ X.unop) :
+    Sieve.arrows ((Presheaf.χ m).app X x) f ↔
+      ∃ a : F.obj (Opposite.op Y), G.map f.op x = m.app (Opposite.op Y) a := Iff.rfl
+
+/-- PROPRE : la caractéristique est descendante — si `x` remonte le long de
+    `f`, il remonte le long de toute précomposition `g ≫ f`. C'est la
+    stabilité par tirage arrière qui fait de `χ m x` un crible (et non une
+    simple partie de flèches) : la même preuve que Mathlib intègre dans la
+    définition de `χ`, exposée ici comme loi nommée. -/
+theorem chi_app_downward_closed {Y Z : C} (f : Y ⟶ X.unop) (g : Z ⟶ Y)
+    (hf : Sieve.arrows ((Presheaf.χ m).app X x) f) :
+    Sieve.arrows ((Presheaf.χ m).app X x) (g ≫ f) := by
+  obtain ⟨a, ha⟩ := hf
+  refine ⟨F.map g.op a, ?_⟩
+  simp [ha, NatTrans.naturality_apply]
+
+/-- PROPRE : un élément défini dans `F` a une caractéristique maximale —
+    si `x = m(a)` est dans l'image directe, alors `χ m x = ⊤` : le crible des
+    flèches le long desquelles `x` remonte est tout le crible maximal. -/
+theorem chi_app_eq_top_of_app (a : F.obj X) (h : m.app X a = x) :
+    (Presheaf.χ m).app X x = (⊤ : Sieve X.unop) := by
+  refine Sieve.ext fun Y f => ?_
+  constructor
+  · intro _
+    exact Sieve.top_apply f
+  · intro _
+    refine ⟨F.map f.op a, ?_⟩
+    rw [← h]
+    exact (NatTrans.naturality_apply m f.op a).symm
+
+/-!
+## Section 3 : Le classifieur des préfaisceaux
+
+`Presheaf.classifier C` empaquette Ω, `truth` et χ en un
+`Subobject.Classifier` : chaque mono `m` possède exactement une flèche
+caractéristique (l'universalité `χ_unique`), et le carré de `m`, du terminal,
+de `truth` et de `χ m` est pullback. Sur un site essentiellement petit,
+l'instance `HasSubobjectClassifier` est disponible d'office.
+-/
+
+-- CALIBRATION : l'empaquetage classifieur des préfaisceaux.
+#check @CategoryTheory.Presheaf.classifier      -- Subobject.Classifier (Cᵒᵖ ⥤ Type (max u v))
+#check @CategoryTheory.Presheaf.comp_χ_eq
+#check @CategoryTheory.Presheaf.isPullback_χ_truth
+#check @CategoryTheory.Presheaf.χ_unique
+
+variable [EssentiallySmall.{w} C]
+
+/-- CALIBRATION : l'instance de classifieur pour les préfaisceaux de types. -/
+example : HasSubobjectClassifier (Cᵒᵖ ⥤ Type w) := inferInstance
+
+variable (J : GrothendieckTopology C)
+
+/-!
+## Section 4 : La topologie filtre Ω — les cribles clos
+
+Une topologie de Grothendieck `J` découpe dans Ω son sous-faisceau des
+cribles **J-clos** (`Functor.closedSieves`). Le pont clé : pour un mono `m`
+entre faisceaux, chaque valeur `(χ m) x` est un crible J-clos — c'est
+exactement ce qui autorise `χ` à atterrir dans les cribles clos et donc à
+descendre au niveau faisceaux.
+-/
+
+-- CALIBRATION : le sous-foncteur des cribles J-clos.
+#check @CategoryTheory.Functor.closedSieves     -- sous-foncteur de sieves, cribles J-clos
+#check @CategoryTheory.GrothendieckTopology.IsClosed
+
+-- CALIBRATION (le pont topologie ↔ classifieur) : la caractéristique d'un
+-- mono entre faisceaux prend des valeurs J-closes.
+#check @CategoryTheory.GrothendieckTopology.isClosed_χ_app_apply_of_isSheaf_of_isSeparated
+
+/-!
+## Section 5 : Le classifieur des faisceaux
+
+Au niveau faisceaux, Ω devient le faisceau des cribles clos `Sheaf.Ω J`,
+`truth` choisit toujours `⊤` (le crible maximal est clos), et la
+caractéristique d'un mono de faisceaux est la même qu'au niveau préfaisceaux
+— restreinte aux cribles clos. Sur un site essentiellement petit, le topos
+des faisceaux d'ensembles possède donc un classifieur de sous-objets : avec
+la clôture cartésienne et les limites finies, c'est un **topos élémentaire**
+(Lawvere–Tierney). Mathlib énonce cette conséquence en prose ; l'instance
+`ElementaryTopos` elle-même n'est pas encore disponible dans cette révision
+de Mathlib — la frontière reste honnête, comme la carte de la Partie 4.
+-/
+
+-- CALIBRATION : le faisceau des cribles clos et le classifieur des faisceaux.
+#check @CategoryTheory.Sheaf.Ω                  -- Sheaf J (Type (max u v)), cribles J-clos
+#check @CategoryTheory.Sheaf.truth               -- terminal ⟶ Ω, choisit ⊤ (clos)
+#check @CategoryTheory.Sheaf.classifier          -- Subobject.Classifier (Sheaf J (Type (max u v)))
+
+/-- CALIBRATION : l'instance de classifieur pour le topos des faisceaux. -/
+example : HasSubobjectClassifier (Sheaf J (Type w)) := inferInstance
+
+end Grothendieck.Classifier

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Classifier_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Classifier_en.lean
@@ -1,0 +1,200 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# A Tribute to Grothendieck — Part 58: The subobject classifier — Ω, the presheaf of sieves
+
+Alexandre Grothendieck (1928-2014).
+
+Extension of #2159 (EPIC #1646).
+
+Parts 1-44 established the foundations: categories, sieves, topologies,
+lattice laws (`SieveLattice`), pullback/pushforward identities, sheaves,
+sheafification, cohomology. Parts 45-57 systematized the arrow form of the
+covering for a growing collection of named topologies.
+
+This part crosses a threshold: it exhibits the **subobject classifier** of
+the topos of presheaves and of the topos of sheaves — the ingredient that,
+together with cartesian closure and finite limits, defines an **elementary
+topos** (Lawvere–Tierney). The Grothendieckian revelation is that this
+classifier is not an abstract construction: Ω is literally **the presheaf of
+sieves** `Functor.sieves`, the very object that all of Part 6
+(`SieveLattice`) equipped with a complete lattice (`pullback_imap`,
+`pullback_iinf`, `pushforward_imap`…). The lattice laws of Part 6 are the
+internal structure of Ω; Part 58 closes the loop by showing that this very
+object classifies subpresheaves.
+
+Key constructions bridged from Mathlib (`CategoryTheory.Topos.Sheaf`):
+
+  - `Functor.sieves C`        : the presheaf `X ↦ Sieve X` — this is Ω
+  - `Presheaf.truth C`        : the truth morphism `1 ⟶ Ω`, picking `⊤`
+  - `Presheaf.χ m`            : the characteristic map of a mono `m : F ⟶ G`
+  - `Presheaf.classifier C`   : the `Subobject.Classifier` of presheaves
+  - `Sheaf.Ω J`               : the sheaf of **J-closed** sieves
+  - `Sheaf.classifier J`      : the classifier of the topos of sheaves
+  - instances `HasSubobjectClassifier (Cᵒᵖ ⥤ Type w)` and `HasSubobjectClassifier (Sheaf J (Type w))`
+
+The topology enters through the door of closed sieves: for a mono `m`
+between sheaves, the values of `χ m` are **J-closed** sieves
+(`GrothendieckTopology.isClosed_χ_app_apply_of_isSheaf_of_isSeparated`),
+and it is this closedness that lets Ω descend from presheaves to sheaves.
+
+All `sorry`s eliminated at creation.
+
+### Accessibility note (Epics #1452/#1453)
+
+This module exposes **12 `#check` verifications** and **4 own theorems**,
+organized in 5 sections: (1) Ω is the presheaf of sieves; (2) the truth
+morphism and the characteristic map χ; (3) the classifier of presheaves;
+(4) the topology filters Ω — closed sieves; (5) the classifier of sheaves.
+
+### i18n convention (EPIC #4980 ratified by user 2026-07-04)
+
+This module is paired with its canonical French version in the sibling file
+`Classifier.lean` (sibling pair model). Namespace suffixed `_en`
+(anti-collision). The `#check`s, signatures, variables and universes are
+byte-identical between the two files; only docstrings and comments differ.
+-/
+
+import Mathlib.CategoryTheory.Topos.Sheaf
+
+universe u v w
+
+namespace Grothendieck.Classifier_en
+
+open CategoryTheory
+
+variable {C : Type u} [Category.{v} C]
+
+/-!
+## Section 1: Ω is the presheaf of sieves
+
+The subobject classifier of a presheaf category lives inside the category
+itself: it is `Functor.sieves C`, the object `X ↦ Sieve X`. Each component
+of Ω is the complete lattice of sieves on `X` — the object that Part 6
+(`SieveLattice`) traversed far and wide. The functoriality (`sieves_map`)
+pulls a sieve back along an arrow: this is the `Sieve.pullback` of Part 6,
+which preserves ⊥, ⊤, ⊔, ⊓, `iSup` and `iInf`.
+-/
+
+-- CALIBRATION: the presheaf of sieves, component by component.
+#check @CategoryTheory.Functor.sieves          -- Cᵒᵖ ⥤ Type (max u v), X ↦ Sieve X.unop
+#check @CategoryTheory.Functor.sieves_map       -- the functoriality is the pullback of sieves
+
+/-!
+## Section 2: The truth morphism and the characteristic map χ
+
+The morphism `truth : 1 ⟶ Ω` is the "true" arrow: at each component, it
+picks the maximal sieve `⊤`. The characteristic map `χ m` of a mono
+`m : F ⟶ G` sends an element `x : G(X)` to the sieve of arrows `f : Y ⟶ X`
+along which `x` lifts into `F`: `f ∈ χ m x` iff `∃ a, G(f)(x) = m(a)`.
+-/
+
+-- CALIBRATION: the truth morphism picks the maximal sieve.
+#check @CategoryTheory.Presheaf.truth           -- (const PUnit) ⟶ sieves C
+#check @CategoryTheory.Presheaf.χ               -- (m : F ⟶ G) : G ⟶ sieves C
+
+variable {F G : Cᵒᵖ ⥤ Type (max u v)} (m : F ⟶ G) (X : Cᵒᵖ) (x : G.obj X)
+
+/-- TRUE (rfl): the truth morphism picks exactly the maximal sieve.
+    The component at `X` is constant with value `⊤`. -/
+theorem truth_picks_top (X : Cᵒᵖ)
+    (b : ((Functor.const Cᵒᵖ).obj PUnit).obj X) :
+    (Presheaf.truth C).app X b = (⊤ : Sieve X.unop) := rfl
+
+/-- BRIDGE: membership in the characteristic map reads off the definition —
+    `f` belongs to the sieve `χ m x` exactly when `x` lifts into `F` along
+    `f`. This is the member-by-member reading of the classifier. -/
+theorem chi_app_mem_iff {Y : C} (f : Y ⟶ X.unop) :
+    Sieve.arrows ((Presheaf.χ m).app X x) f ↔
+      ∃ a : F.obj (Opposite.op Y), G.map f.op x = m.app (Opposite.op Y) a := Iff.rfl
+
+/-- OWN: the characteristic map is downward closed — if `x` lifts along
+    `f`, it lifts along any precomposition `g ≫ f`. This is the stability
+    under pullback that makes `χ m x` a sieve (and not a mere set of
+    arrows): the same proof Mathlib bakes into the definition of `χ`,
+    exposed here as a named law. -/
+theorem chi_app_downward_closed {Y Z : C} (f : Y ⟶ X.unop) (g : Z ⟶ Y)
+    (hf : Sieve.arrows ((Presheaf.χ m).app X x) f) :
+    Sieve.arrows ((Presheaf.χ m).app X x) (g ≫ f) := by
+  obtain ⟨a, ha⟩ := hf
+  refine ⟨F.map g.op a, ?_⟩
+  simp [ha, NatTrans.naturality_apply]
+
+/-- OWN: an element defined in `F` has a maximal characteristic —
+    if `x = m(a)` lies in the direct image, then `χ m x = ⊤`: the sieve of
+    arrows along which `x` lifts is the whole maximal sieve. -/
+theorem chi_app_eq_top_of_app (a : F.obj X) (h : m.app X a = x) :
+    (Presheaf.χ m).app X x = (⊤ : Sieve X.unop) := by
+  refine Sieve.ext fun Y f => ?_
+  constructor
+  · intro _
+    exact Sieve.top_apply f
+  · intro _
+    refine ⟨F.map f.op a, ?_⟩
+    rw [← h]
+    exact (NatTrans.naturality_apply m f.op a).symm
+
+/-!
+## Section 3: The classifier of presheaves
+
+`Presheaf.classifier C` packages Ω, `truth` and χ into a
+`Subobject.Classifier`: every mono `m` admits exactly one characteristic
+arrow (the universality `χ_unique`), and the square of `m`, the terminal,
+`truth` and `χ m` is a pullback. On an essentially small site, the
+`HasSubobjectClassifier` instance is available for free.
+-/
+
+-- CALIBRATION: the classifier packaging for presheaves.
+#check @CategoryTheory.Presheaf.classifier      -- Subobject.Classifier (Cᵒᵖ ⥤ Type (max u v))
+#check @CategoryTheory.Presheaf.comp_χ_eq
+#check @CategoryTheory.Presheaf.isPullback_χ_truth
+#check @CategoryTheory.Presheaf.χ_unique
+
+variable [EssentiallySmall.{w} C]
+
+/-- CALIBRATION: the classifier instance for type-valued presheaves. -/
+example : HasSubobjectClassifier (Cᵒᵖ ⥤ Type w) := inferInstance
+
+variable (J : GrothendieckTopology C)
+
+/-!
+## Section 4: The topology filters Ω — closed sieves
+
+A Grothendieck topology `J` carves out of Ω its subsheaf of **J-closed**
+sieves (`Functor.closedSieves`). The key bridge: for a mono `m` between
+sheaves, every value `(χ m) x` is a J-closed sieve — this is exactly what
+allows `χ` to land in the closed sieves and thus descend to the sheaf level.
+-/
+
+-- CALIBRATION: the subfunctor of J-closed sieves.
+#check @CategoryTheory.Functor.closedSieves     -- subfunctor of sieves, J-closed sieves
+#check @CategoryTheory.GrothendieckTopology.IsClosed
+
+-- CALIBRATION (the topology ↔ classifier bridge): the characteristic map
+-- of a mono between sheaves takes J-closed values.
+#check @CategoryTheory.GrothendieckTopology.isClosed_χ_app_apply_of_isSheaf_of_isSeparated
+
+/-!
+## Section 5: The classifier of sheaves
+
+At the sheaf level, Ω becomes the sheaf of closed sieves `Sheaf.Ω J`,
+`truth` still picks `⊤` (the maximal sieve is closed), and the
+characteristic map of a mono of sheaves is the same as at the presheaf
+level — restricted to closed sieves. On an essentially small site, the
+topos of sheaves of sets therefore has a subobject classifier: together
+with cartesian closure and finite limits, this makes it an **elementary
+topos** (Lawvere–Tierney). Mathlib states this consequence in prose; the
+`ElementaryTopos` instance itself is not yet available in this revision of
+Mathlib — the frontier stays honest, as in the map of Part 4.
+-/
+
+-- CALIBRATION: the sheaf of closed sieves and the classifier of sheaves.
+#check @CategoryTheory.Sheaf.Ω                  -- Sheaf J (Type (max u v)), J-closed sieves
+#check @CategoryTheory.Sheaf.truth               -- terminal ⟶ Ω, picks ⊤ (closed)
+#check @CategoryTheory.Sheaf.classifier          -- Subobject.Classifier (Sheaf J (Type (max u v)))
+
+/-- CALIBRATION: the classifier instance for the topos of sheaves. -/
+example : HasSubobjectClassifier (Sheaf J (Type w)) := inferInstance
+
+end Grothendieck.Classifier_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -22,7 +22,7 @@ formalize EGA/SGA. The goal is to give learners a curated entry point into:
 
 ## The arc
 
-The **54 leaf modules** (0 `sorry`, 0 axiom added) trace a coherent path, from
+The **55 leaf modules** (0 `sorry`, 0 axiom added) trace a coherent path, from
 the raw site up to cohomology:
 
 ```mermaid
@@ -85,17 +85,17 @@ missing link between `f^*` and `f_*`. In parallel, the *covering* program
 (Phase 5 of Epic #2159, waves 2026-08-14..16: #10879 → #11244) systematizes
 the arrow and bundled forms of the covering — from `covers_comp_iff` to the
 arrow form of the dense topology (Part 44), through the pullback pseudofunctor
-laws and the lattice of topologies.
+laws and the lattice of topologies. A third vein opens with `Classifier.lean` (Part 58, #2159): the **subobject classifier** Ω — literally the presheaf of sieves of Part 6 — which makes presheaves and sheaves of sets over an essentially small site elementary topoi (Lawvere–Tierney).
 
 ## Code structure
 
-The formalization spans **54 leaf modules** + **1 umbrella** `Grothendieck.lean`
+The formalization spans **55 leaf modules** + **1 umbrella** `Grothendieck.lean`
 (imports-only, bilingual inline FR/EN). The three `SheafCohomology/`
 sub-modules are Parts 20, 22, and 23 of the table.
 
 | Part | File | `_en` | Content | Lines |
 |------|------|-------|---------|-------|
-| root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only + bilingual FR/EN doctring); imports **all 54 leaves** FR + 8 `_en` siblings (full FR coverage, no module pending — `ExceptionalDirect` imported c.2026-08-15, closing #11286) | 218 |
+| root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only + bilingual FR/EN doctring); imports **all 55 leaves** FR + 8 `_en` siblings (full FR coverage, no module pending — `ExceptionalDirect` imported c.2026-08-15, closing #11286) | 218 |
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 243 |
 | 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 196 |
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 139 |
@@ -150,6 +150,7 @@ sub-modules are Parts 20, 22, and 23 of the table.
 | 55c | `Grothendieck/CoversExtensiveArrow.lean` | `CoversExtensiveArrow_en.lean` | Arrow form of the **extensive topology** (`extensiveTopology`, `FinitaryPreExtensive` category): same bridge pattern (Phase 5 of #2159) | 181 |
 | 56 | `Grothendieck/CoversZariskiArrow.lean` | `CoversZariskiArrow_en.lean` | Arrow form of the **Zariski topology** (first named concrete topology of the series): `covers_iff_zariski` + geometric characterization by open covers `covers_iff_exists_cover` (Phase 5 of #2159, standalone on main) | 233 |
 | 57 | `Grothendieck/CoversAtomicArrow.lean` | `CoversAtomicArrow_en.lean` | Arrow form of the **atomic topology** (`GrothendieckTopology.atomic`, right Ore condition): pointwise bridge `atomic_covering` (the missing analogue of `dense_covering`), `covers_iff_atomic` (central), `covers_atomic_of_mem`, stability `covers_atomic_precomp`, collapses `covers_atomic_id`/`covers_atomic_top` (Phase 5 of #2159) | 159 |
+| 58 | `Grothendieck/Classifier.lean` | `Classifier_en.lean` | **The subobject classifier**: Ω = the presheaf of sieves (`Functor.sieves`), `truth`/`χ`, `Presheaf.classifier`, J-closed sieves (`Sheaf.Ω`), `HasSubobjectClassifier` instances for presheaves + sheaves; 4 own theorems (`truth_picks_top`, `chi_app_mem_iff`, `chi_app_downward_closed`, `chi_app_eq_top_of_app`) (Part 58 of #2159) | 202 |
 
 *The `Lines` column counts the **FR file alone**; the `_en` sibling adds
 roughly as much again.*
@@ -157,10 +158,10 @@ roughly as much again.*
 ## Build & status
 
 - **Toolchain**: `leanprover/lean4:v4.32.0`
-- **Build**: `lake build` (WSL required). The default target (`globs := #[`Grothendieck.*]` in `lakefile.lean`) compiles **all** FR and `_en` modules. Last verified build: 2026-08-18, "Build completed successfully" (47 leaves at that date); the structure has since grown to 54 leaves + 54 `_en` siblings + 1 umbrella (Parts 54, 55a-c — Phase 5 of #2159). `ExceptionalDirect` was imported c.2026-08-15 (#11286 closed).
+- **Build**: `lake build` (WSL required). The default target (`globs := #[`Grothendieck.*]` in `lakefile.lean`) compiles **all** FR and `_en` modules. Last verified build: 2026-08-18, "Build completed successfully" (47 leaves at that date); the structure has since grown to 55 leaves + 55 `_en` siblings + 1 umbrella (Parts 54, 55a-c, 58 — Phase 5 and the classifier of #2159). `ExceptionalDirect` was imported c.2026-08-15 (#11286 closed).
 - **Proofs**: **0 `sorry`, 0 axiom added** — every module is complete at creation. (A naive `grep sorry` matches prose mentions in the bilingual docstrings, notably two in `ExceptionalDirect.lean`; CI counts in `real` mode — after comment stripping — and reads 0.)
 - **Dependencies**: Mathlib 4 (via `lakefile.lean`)
-- **i18n** (EPIC #4980, Option A convention ratified 2026-07-04): complete bilingual coverage — **55 FR files** (1 umbrella + 54 canonical leaves) and **54 `_en.lean` siblings**, integral 1:1 ratio (the historical `PullbackFunctor.lean` gap is closed: `PullbackFunctor_en.lean` is present on disk; the earlier prose saying it was missing was stale — found by the Part 56 §E audit, c.2026-08-18). `_en` namespaces anti-collision, non-docstring content byte-identical, CI-detectable. The umbrella is bilingual inline *by design* (FR canonical first, EN mirrored in the same file). **[`README.md`](./README.md)** is the FR canonical sibling of this file. Out-of-scope: `.lake/packages/`, vendored libs.
+- **i18n** (EPIC #4980, Option A convention ratified 2026-07-04): complete bilingual coverage — **56 FR files** (1 umbrella + 55 canonical leaves) and **55 `_en.lean` siblings**, integral 1:1 ratio, 55/55 (the historical `PullbackFunctor.lean` gap is closed: `PullbackFunctor_en.lean` is present on disk; the earlier prose saying it was missing was stale — found by the Part 56 §E audit, c.2026-08-18). `_en` namespaces anti-collision, non-docstring content byte-identical, CI-detectable. The umbrella is bilingual inline *by design* (FR canonical first, EN mirrored in the same file). **[`README.md`](./README.md)** is the FR canonical sibling of this file. Out-of-scope: `.lake/packages/`, vendored libs.
 
 *Coherence note*: the earlier note about a "46/46 discordance + `PullbackFunctor` gap" is obsolete — `PullbackFunctor_en.lean` is present on disk (verified c.2026-08-18) and the FR/`_en` ratio is 1:1. The lakefile `globs` auto-discovers all leaves; the i18n CI checks the target 1:1 ratio.
 
@@ -179,7 +180,7 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 ## See also
 
 - Epic #1646 (Grothendieck tribute) — Issue #2159 (formalization depth: Phase 1 shipped, Phase 2 = #10357, Phase 5 = Parts 35-44)
-- EPIC #4980 — Lean i18n convention (Option A sibling pair; 54 `_en` pairs in this lake)
+- EPIC #4980 — Lean i18n convention (Option A sibling pair; 55 `_en` pairs in this lake)
 - Epic #1453 (prover harness calibration) — Issue #8960 (reconciling the two `Part` numberings)
 - [#11286](https://github.com/jsboige/CoursIA/issues/11286) — pending umbrella import of `ExceptionalDirect`
 - Conway tribute workspace (`../conway_lean/`) — Lean notebook series (`../README.md`)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -23,7 +23,7 @@ d'entrée curaté vers :
 
 ## La trajectoire
 
-Les **54 modules leaf** (0 `sorry`, 0 axiome ajouté) tracent un chemin cohérent,
+Les **55 modules leaf** (0 `sorry`, 0 axiome ajouté) tracent un chemin cohérent,
 du site brut jusqu'à la cohomologie :
 
 ```mermaid
@@ -88,17 +88,17 @@ programme *couverture* (Phase 5 de l'Epic #2159, vagues 2026-08-14..16 :
 #10879 → #11244) systématise la forme flèche et la forme bundlée de la
 couverture — de `covers_comp_iff` jusqu'à la forme flèche de la topologie
 dense (Partie 44), en passant par les lois du pseudofoncteur pullback et le
-treillis des topologies.
+treillis des topologies. Une troisième veine s'ouvre avec `Classifier.lean` (Partie 58, #2159) : le **classifieur de sous-objets** Ω — littéralement le préfaisceau des cribles de la Partie 6 — qui fait des préfaisceaux et des faisceaux d'ensembles sur un site essentiellement petit des topos élémentaires (Lawvere–Tierney).
 
 ## Structure du code
 
-La formalisation couvre **54 modules leaf** + **1 umbrella** `Grothendieck.lean`
+La formalisation couvre **55 modules leaf** + **1 umbrella** `Grothendieck.lean`
 (imports-only, bilingue inline FR/EN). Les trois sous-modules de
 `SheafCohomology/` sont les Parties 20, 22 et 23 du tableau.
 
 | Partie | Fichier | `_en` | Contenu | Lignes |
 |--------|---------|-------|---------|--------|
-| racine | `Grothendieck.lean` | (bilingue inline) | **Racine umbrella** (imports-only + doctring bilingue FR/EN) ; importe **les 54 leaf** FR + 8 siblings `_en` (couverture complète FR ; `ExceptionalDirect` importé c.2026-08-15, fermeture #11286) | 227 |
+| racine | `Grothendieck.lean` | (bilingue inline) | **Racine umbrella** (imports-only + doctring bilingue FR/EN) ; importe **les 55 leaf** FR + 8 siblings `_en` (couverture complète FR ; `ExceptionalDirect` importé c.2026-08-15, fermeture #11286) | 227 |
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Cribles, topologies de Grothendieck (triviale/discrète/dense), trois axiomes | 243 |
 | 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 196 |
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 139 |
@@ -153,6 +153,7 @@ La formalisation couvre **54 modules leaf** + **1 umbrella** `Grothendieck.lean`
 | 55c | `Grothendieck/CoversExtensiveArrow.lean` | `CoversExtensiveArrow_en.lean` | Forme flèche de la **topologie extensive** (`extensiveTopology`, catégorie `FinitaryPreExtensive`) : même patron de ponts (Phase 5 de #2159) | 181 |
 | 56 | `Grothendieck/CoversZariskiArrow.lean` | `CoversZariskiArrow_en.lean` | Forme flèche de la **topologie de Zariski** (première topologie nommée concrète de la série) : `covers_iff_zariski` + caractérisation géométrique par recouvrements ouverts `covers_iff_exists_cover` (Phase 5 de #2159, autonome sur main) | 233 |
 | 57 | `Grothendieck/CoversAtomicArrow.lean` | `CoversAtomicArrow_en.lean` | Forme flèche de la **topologie atomique** (`GrothendieckTopology.atomic`, condition d'Ore à droite) : pont ponctuel `atomic_covering` (analogue manquant de `dense_covering`), `covers_iff_atomic` (central), `covers_atomic_of_mem`, stabilité `covers_atomic_precomp`, retombées `covers_atomic_id`/`covers_atomic_top` (Phase 5 de #2159) | 159 |
+| 58 | `Grothendieck/Classifier.lean` | `Classifier_en.lean` | **Le classifieur de sous-objets** : Ω = le préfaisceau des cribles (`Functor.sieves`), `truth`/`χ`, `Presheaf.classifier`, cribles J-clos (`Sheaf.Ω`), instances `HasSubobjectClassifier` préfaisceaux + faisceaux ; 4 théorèmes propres (`truth_picks_top`, `chi_app_mem_iff`, `chi_app_downward_closed`, `chi_app_eq_top_of_app`) (Partie 58 de #2159) | 202 |
 
 *La colonne `Lignes` compte le **fichier FR seul** ; le sibling `_en` ajoute
 approximativement autant.*
@@ -160,12 +161,12 @@ approximativement autant.*
 ## Build & état
 
 - **Toolchain** : `leanprover/lean4:v4.32.0`
-- **Build** : `lake build` (WSL requis). La cible défaut (`globs := #[`Grothendieck.*]` du `lakefile.lean`) compile **tous** les modules FR et `_en`. Dernier build vérifié : 2026-08-18, « Build completed successfully » (47 leaf à cette date) ; la structure a depuis grandi à 54 leaf + 54 siblings `_en` + 1 umbrella (Parties 54, 55a-c — Phase 5 de #2159).
+- **Build** : `lake build` (WSL requis). La cible défaut (`globs := #[`Grothendieck.*]` du `lakefile.lean`) compile **tous** les modules FR et `_en`. Dernier build vérifié : 2026-08-18, « Build completed successfully » (47 leaf à cette date) ; la structure a depuis grandi à 55 leaf + 55 siblings `_en` + 1 umbrella (Parties 54, 55a-c, 58 — Phase 5 et classifieur de #2159).
 - **Preuves** : **0 `sorry`, 0 axiome ajouté** — tous les modules sont complets à la création. (Un `grep sorry` naïf matche des mentions en prose dans les docstrings bilingues, notamment deux dans `ExceptionalDirect.lean` ; la CI compte en mode `real` — après strip des commentaires — et vaut 0.)
 - **Dépendances** : Mathlib 4 (via `lakefile.lean`)
-- **i18n** (EPIC #4980, convention Option A ratifiée 2026-07-04) : couverture bilingue complète — **55 fichiers FR** (1 umbrella + 54 leaf canoniques) et **54 siblings `_en.lean`**, ratio 1:1 intégral (le gap historique `PullbackFunctor.lean` sans `_en` est comblé : `PullbackFunctor_en.lean` présent sur disque ; c.2026-08-18, l'audit §E de la Partie 56 l'a constaté — la prose antérieure le disant manquant était périmée). Namespaces `_en` anti-collision, contenu non-docstring byte-identique, vérifiable par CI. L'umbrella est bilingue inline *by design* (FR canonique d'abord, EN en miroir dans le même fichier). **[`README.en.md`](./README.en.md)** est le miroir EN du présent fichier. Hors-scope : `.lake/packages/`, libs vendored.
+- **i18n** (EPIC #4980, convention Option A ratifiée 2026-07-04) : couverture bilingue complète — **56 fichiers FR** (1 umbrella + 55 leaf canoniques) et **55 siblings `_en.lean`**, ratio 1:1 intégral (le gap historique `PullbackFunctor.lean` sans `_en` est comblé : `PullbackFunctor_en.lean` présent sur disque ; c.2026-08-18, l'audit §E de la Partie 56 l'a constaté — la prose antérieure le disant manquant était périmée). Namespaces `_en` anti-collision, contenu non-docstring byte-identique, vérifiable par CI. L'umbrella est bilingue inline *by design* (FR canonique d'abord, EN en miroir dans le même fichier). **[`README.en.md`](./README.en.md)** est le miroir EN du présent fichier. Hors-scope : `.lake/packages/`, libs vendored.
 
-*Note de cohérence* : couverture 1:1 intégrale — 54 leaf FR canoniques et 54 siblings `_en` (le gap `PullbackFunctor` sans `_en`, nommé dans une version antérieure de cette note, est comblé sur disque). Le `globs` du lakefile auto-découvre tous les modules présents, FR comme `_en`.
+*Note de cohérence* : couverture 1:1 intégrale — 55 leaf FR canoniques et 55 siblings `_en` (le gap `PullbackFunctor` sans `_en`, nommé dans une version antérieure de cette note, est comblé sur disque). Le `globs` du lakefile auto-découvre tous les modules présents, FR comme `_en`.
 
 ## Références
 
@@ -185,7 +186,7 @@ formalisation d'EGA/SGA.
 ## Voir aussi
 
 - Epic #1646 (hommage à Grothendieck) — Issue #2159 (profondeur de formalisation : Phase 1 shippée, Phase 2 = #10357, Phase 5 = Parties 35-44)
-- EPIC #4980 — convention i18n Lean (Option A sibling pair ; 54 paires `_en` dans ce lake)
+- EPIC #4980 — convention i18n Lean (Option A sibling pair ; 55 paires `_en` dans ce lake)
 - Epic #1453 (calibration du harnais prouveur) — Issue #8960 (réconciliation des numérotations `Partie`)
 - [#11286](https://github.com/jsboige/CoursIA/issues/11286) — import umbrella de `ExceptionalDirect` en attente
 - Workspace hommage Conway (`../conway_lean/`) — série de notebooks Lean (`../README.md`)


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA — prev: DEEP/notebook-python #12525

Périmètre : 5 fichiers : MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Classifier.lean (nouveau), Grothendieck/Classifier_en.lean (nouveau), Grothendieck.lean, README.md, README.en.md

## Résumé

Nouvelle **Partie 58 — `Classifier.lean`** (FR+EN siblings) : le **classifieur de sous-objets** du topos des préfaisceaux et du topos des faisceaux, cible nommée du livrable #2159 (« topos élémentaires ») jamais abordée par le lake (mesuré : 0 référence à `HasSubobjectClassifier`/`Subclassifier` sur origin/main).

Le résultat structurel : **Ω est le préfaisceau des cribles** `Functor.sieves` — l'objet même que la Partie 6 (`SieveLattice`) a équipé d'un treillis complet (`pullback_imap`, `pullback_iinf`, `pushforward_imap`). Les lois de treillis de la Partie 6 sont la structure interne de Ω ; la Partie 58 referme la boucle en montrant que ce même objet classe les sous-préfaisceaux. La topologie entre par les cribles J-clos (`Functor.closedSieves`, `Sheaf.Ω`), ce qui fait descendre le classifieur aux faisceaux : sur un site essentiellement petit, le topos des faisceaux d'ensembles possède un classifieur — constituant du topos élémentaire (Lawvere–Tierney), énoncé en prose car Mathlib v4.32.1 ne fournit pas encore l'instance `ElementaryTopos` (frontière documentée, esprit Partie 4).

## Contenu (12 #check + 4 théorèmes propres, 0 sorry) — FR 202 lignes / EN 200

- **Section 1** : Ω = `Functor.sieves`, fonctorialité = pullback de cribles.
- **Section 2** : `truth` (choisit ⊤) et `χ` (caractéristique d'un mono).
- **Section 3** : `Presheaf.classifier`, universalité (`χ_unique`), instance préfaisceaux.
- **Section 4** : la topologie filtre Ω — cribles clos, pont `isClosed_χ_app_apply_of_isSheaf_of_isSeparated`.
- **Section 5** : `Sheaf.Ω`/`Sheaf.classifier`, instance faisceaux.
- Théorèmes propres : `truth_picks_top` (rfl), `chi_app_mem_iff` (lecture membre à membre), `chi_app_downward_closed` (stabilité par précomposition — la loi qui fait de χ un crible), `chi_app_eq_top_of_app` (un élément de l'image directe a une caractéristique maximale).

## Validation (discipline Lean HARD)

- **`lake build` complet** (WSL, cibles `Grothendieck.Classifier Grothendieck.Classifier_en Grothendieck`) :
  ```
  ℹ [2909/2912] Built Grothendieck.Classifier_en (115s)
  ℹ [2910/2912] Built Grothendieck.Classifier (116s)
  ✔ [2911/2912] Built Grothendieck (198s)
  Build completed successfully (2912 jobs).
  ```
  (Les 2 warnings restants sont préexistants sur `SitePoints*.lean`, hors périmètre — non touchés par cette PR.)
- **Sorry count** (`scripts/lean/count_code_sorry.py --json`, champ `distinct_code_sorry`) : avant = 0, après = **0** (grothendieck_lean ; `naive_sorry` 100 = prose des docstrings uniquement). 0 axiome ajouté.
- **Anti-régression** : aucun fichier existant modifié sauf umbrella (ajout d'un import) + READMEs (counts + ligne table). Aucune preuve touchée.
- **i18n** : sibling `Classifier_en.lean` (namespace `Grothendieck.Classifier_en`), code byte-identique — `scripts/lean/check_i18n_siblings.py` : **1/1 pairs byte-identical**, 0 drift, 0 orphan.
- **Deux passes de correction mesurées** (preuves initialement rouges, jamais laissées en l'état) : (1) docstrings `/- ... -/` devant `#check` illégales en Lean 4 → converties en commentaires `--` (6 par fichier) ; (2) instances `Top`/`Membership` non synthétisables derrière `.app X` opaque → réécriture en forme `Sieve.arrows` explicite (type attendu, zéro inférence), `Sieve.top_apply` canonique, naturalité en `.symm`.
- **Grounding** : cible `pullback_imap` du body #2159 vérifiée OBSOLÈTE (livrée dans `SieveLattice.lean:148`) ; `pullback ⊣ pushforward` déjà couvert (`galoisConnection_pushforward_pullback`, `CoversPushforward.lean`) ; distinct de f^! (PR #12357, po-2026). Claim `[CLAIMED]` posé avec clause `paths:` avant édition (issuecomment-5384197371).

See #2159 (contribution à l'EPIC, pas de clôture)
