### PR TITLE
feat(notebook-lean,#11703): Tweety-5b section 4 ArgLattice — le module racine argumentation_lean ouvre sa salle de classe

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5b-Lean-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5b-Lean-Argumentation.ipynb
@@ -5,25 +5,47 @@
    "id": "00b4f9a8",
    "metadata": {
     "papermill": {
-     "duration": 0.006082,
-     "end_time": "2026-06-26T22:33:44.787231+00:00",
+     "duration": 0.007223,
+     "end_time": "2026-08-23T05:42:39.825427+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:33:44.781149+00:00",
+     "start_time": "2026-08-23T05:42:39.818204+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "# Tweety-5b — Théorie de l'argumentation de Dung (companion formel natif)\n\nCe notebook est le **companion formel** du lake [`argumentation_lean`](argumentation_lean/),\ndont la lib `Argumentation` prouve les résultats fondateurs de la théorie de\nl'argumentation abstraite de Dung (1995) — **existence de l'extension grounded comme\npoint fixe de la fonction caractéristique** (Knaster–Tarski) — avec **zéro `sorry`**.\n\nLa théorie de Dung modélise un débat comme un graphe d'arguments reliés par une\nrelation d'attaque, et définit des *sémantiques* (ensembles d'arguments cohérents et\n« défendus ») : admissible, complète, grounded, preferred, stable.\n\n## Convention de vérification — `#check` *natif* dans le kernel Lean\n\nCe notebook est un **notebook Lean natif** (kernel `lean4-wsl`) : il `import`e les\nmodules du lake directement et le compilateur Lean rend les signatures **dans le\nnotebook**. C'est rendu possible par l'UNLOCK (patch `lean4_jupyter` + jonction\nMathlib #2611).\n\n> ⚠️ À l'exécution, la première cellule (`import`) peut prendre **~3 min** :\n> le kernel charge les oleans Mathlib via la jonction NTFS. Les suivantes sont\n> instantanées."
+   "source": [
+    "# Tweety-5b — Théorie de l'argumentation de Dung (companion formel natif)\n",
+    "\n",
+    "Ce notebook est le **companion formel** du lake [`argumentation_lean`](argumentation_lean/),\n",
+    "dont la lib `Argumentation` prouve les résultats fondateurs de la théorie de\n",
+    "l'argumentation abstraite de Dung (1995) — **existence de l'extension grounded comme\n",
+    "point fixe de la fonction caractéristique** (Knaster–Tarski) — avec **zéro `sorry`**.\n",
+    "\n",
+    "La théorie de Dung modélise un débat comme un graphe d'arguments reliés par une\n",
+    "relation d'attaque, et définit des *sémantiques* (ensembles d'arguments cohérents et\n",
+    "« défendus ») : admissible, complète, grounded, preferred, stable.\n",
+    "\n",
+    "## Convention de vérification — `#check` *natif* dans le kernel Lean\n",
+    "\n",
+    "Ce notebook est un **notebook Lean natif** (kernel `lean4-wsl`) : il `import`e les\n",
+    "modules du lake directement et le compilateur Lean rend les signatures **dans le\n",
+    "notebook**. C'est rendu possible par l'UNLOCK (patch `lean4_jupyter` + jonction\n",
+    "Mathlib #2611).\n",
+    "\n",
+    "> ⚠️ À l'exécution, la première cellule (`import`) peut prendre **~3 min** :\n",
+    "> le kernel charge les oleans Mathlib via la jonction NTFS. Les suivantes sont\n",
+    "> instantanées."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "1c48670e",
    "metadata": {
     "papermill": {
-     "duration": 0.003688,
-     "end_time": "2026-06-26T22:33:44.795562+00:00",
+     "duration": 0.0085,
+     "end_time": "2026-08-23T05:42:39.845788+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:33:44.791874+00:00",
+     "start_time": "2026-08-23T05:42:39.837288+00:00",
      "status": "completed"
     },
     "tags": []
@@ -31,10 +53,12 @@
    "source": [
     "## 1. Import des modules du lake `argumentation_lean`\n",
     "\n",
-    "Le lake est structuré en 5 modules (`Basic`, `Characteristic`, `Extensions`,\n",
-    "`Fundamental`, `Grounded`) sous les namespaces `Argumentation` / `Argumentation.AF`.\n",
-    "On importe les 5 modules (la config `submodules` du lake ne build pas l'umbrella\n",
-    "racine — on cible directement les modules qui portent les définitions)."
+    "Le lake est structuré en un **module racine** + **5 sous-modules** (`Basic`,\n",
+    "`Characteristic`, `Extensions`, `Fundamental`, `Grounded`) sous les namespaces\n",
+    "`Argumentation` / `Argumentation.AF`. La racine porte `ArgLattice` — le treillis\n",
+    "complet `(Set α, ⊆)` sur lequel opère la fonction caractéristique (section 4) ;\n",
+    "les cinq sous-modules portent les définitions et théorèmes. Le `lakefile`\n",
+    "builde les deux (globs `.one` + `.submodules`) ; on importe le tout."
    ]
   },
   {
@@ -43,16 +67,16 @@
    "id": "adb210cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T22:33:44.803250Z",
-     "iopub.status.busy": "2026-06-26T22:33:44.803087Z",
-     "iopub.status.idle": "2026-06-26T22:37:49.149052Z",
-     "shell.execute_reply": "2026-06-26T22:37:49.147901Z"
+     "iopub.execute_input": "2026-08-23T05:42:39.864177Z",
+     "iopub.status.busy": "2026-08-23T05:42:39.863994Z",
+     "iopub.status.idle": "2026-08-23T05:46:58.150653Z",
+     "shell.execute_reply": "2026-08-23T05:46:58.149417Z"
     },
     "papermill": {
-     "duration": 244.37555,
-     "end_time": "2026-06-26T22:37:49.174632+00:00",
+     "duration": 258.299616,
+     "end_time": "2026-08-23T05:46:58.154896+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:33:44.799082+00:00",
+     "start_time": "2026-08-23T05:42:39.855280+00:00",
      "status": "completed"
     },
     "tags": []
@@ -70,17 +94,18 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation<span class=\"bp\">.</span>Basic</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation<span class=\"bp\">.</span>Characteristic</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation<span class=\"bp\">.</span>Extensions</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation<span class=\"bp\">.</span>Fundamental</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation<span class=\"bp\">.</span>Grounded</span></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation.Basic</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation.Characteristic</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation.Extensions</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation.Fundamental</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>Argumentation.Grounded</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">open</span><span class=\"w\"> </span>Argumentation</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"import Argumentation.Basic\\nimport Argumentation.Characteristic\\nimport Argumentation.Extensions\\nimport Argumentation.Fundamental\\nimport Argumentation.Grounded\\nopen Argumentation\"}</code>\n",
+       "            <code>{\"cmd\": \"import Argumentation\\nimport Argumentation.Basic\\nimport Argumentation.Characteristic\\nimport Argumentation.Extensions\\nimport Argumentation.Fundamental\\nimport Argumentation.Grounded\\nopen Argumentation\"}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -89,6 +114,7 @@
        "    "
       ],
       "text/plain": [
+       "import Argumentation\n",
        "import Argumentation.Basic\n",
        "import Argumentation.Characteristic\n",
        "import Argumentation.Extensions\n",
@@ -98,7 +124,7 @@
        "--% env 0\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"import Argumentation.Basic\\nimport Argumentation.Characteristic\\nimport Argumentation.Extensions\\nimport Argumentation.Fundamental\\nimport Argumentation.Grounded\\nopen Argumentation\"}\n",
+       "{\"cmd\": \"import Argumentation\\nimport Argumentation.Basic\\nimport Argumentation.Characteristic\\nimport Argumentation.Extensions\\nimport Argumentation.Fundamental\\nimport Argumentation.Grounded\\nopen Argumentation\"}\n",
        "Raw output:\n",
        "{\"env\": 0}"
       ]
@@ -108,6 +134,7 @@
     }
    ],
    "source": [
+    "import Argumentation\n",
     "import Argumentation.Basic\n",
     "import Argumentation.Characteristic\n",
     "import Argumentation.Extensions\n",
@@ -121,10 +148,10 @@
    "id": "0521d05a",
    "metadata": {
     "papermill": {
-     "duration": 0.004111,
-     "end_time": "2026-06-26T22:37:49.183853+00:00",
+     "duration": 0.01131,
+     "end_time": "2026-08-23T05:46:58.180722+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:49.179742+00:00",
+     "start_time": "2026-08-23T05:46:58.169412+00:00",
      "status": "completed"
     },
     "tags": []
@@ -143,16 +170,16 @@
    "id": "c222dd71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T22:37:49.193616Z",
-     "iopub.status.busy": "2026-06-26T22:37:49.193358Z",
-     "iopub.status.idle": "2026-06-26T22:37:49.434881Z",
-     "shell.execute_reply": "2026-06-26T22:37:49.434091Z"
+     "iopub.execute_input": "2026-08-23T05:46:58.203569Z",
+     "iopub.status.busy": "2026-08-23T05:46:58.203358Z",
+     "iopub.status.idle": "2026-08-23T05:46:58.491569Z",
+     "shell.execute_reply": "2026-08-23T05:46:58.490343Z"
     },
     "papermill": {
-     "duration": 0.247833,
-     "end_time": "2026-06-26T22:37:49.435485+00:00",
+     "duration": 0.301938,
+     "end_time": "2026-08-23T05:46:58.492966+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:49.187652+00:00",
+     "start_time": "2026-08-23T05:46:58.191028+00:00",
      "status": "completed"
     },
     "tags": []
@@ -170,7 +197,7 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>AF<span class=\"bp\">.</span>grounded_fixed</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>grounded_fixed&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"k\">#print</span><span class=\"w\"> </span><span class=\"kd\">axioms</span><span class=\"w\"> </span>AF.grounded_fixed</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>Argumentation.AF.grounded_fixed&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span><span class=\"kd\">axioms</span>:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical.choice,<span class=\"w\"> </span>Quot.sound]</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -219,10 +246,10 @@
    "id": "91f6d7f7",
    "metadata": {
     "papermill": {
-     "duration": 0.010005,
-     "end_time": "2026-06-26T22:37:49.454896+00:00",
+     "duration": 0.012387,
+     "end_time": "2026-08-23T05:46:58.510903+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:49.444891+00:00",
+     "start_time": "2026-08-23T05:46:58.498516+00:00",
      "status": "completed"
     },
     "tags": []
@@ -247,16 +274,16 @@
    "id": "6c9e3935",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T22:37:49.462227Z",
-     "iopub.status.busy": "2026-06-26T22:37:49.462077Z",
-     "iopub.status.idle": "2026-06-26T22:37:49.681675Z",
-     "shell.execute_reply": "2026-06-26T22:37:49.680781Z"
+     "iopub.execute_input": "2026-08-23T05:46:58.533415Z",
+     "iopub.status.busy": "2026-08-23T05:46:58.533217Z",
+     "iopub.status.idle": "2026-08-23T05:46:58.804323Z",
+     "shell.execute_reply": "2026-08-23T05:46:58.803455Z"
     },
     "papermill": {
-     "duration": 0.223854,
-     "end_time": "2026-06-26T22:37:49.682244+00:00",
+     "duration": 0.282983,
+     "end_time": "2026-08-23T05:46:58.805013+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:49.458390+00:00",
+     "start_time": "2026-08-23T05:46:58.522030+00:00",
      "status": "completed"
     },
     "tags": []
@@ -274,12 +301,12 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>{u_2}<span class=\"w\"> </span>(α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>conflictFree</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>conflictFree<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>defends</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>defends<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>conflictFree_empty</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>conflictFree_empty<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>conflictFree<span class=\"w\"> </span><span class=\"bp\">∅</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>defends_mono</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>defends_mono<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>T<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>(hST<span class=\"w\"> </span>:<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">⊆</span><span class=\"w\"> </span>T)<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span>α}\n",
-       "<span class=\"w\">  </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>T<span class=\"w\"> </span>a</blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF<span class=\"bp\">.</span>{u_2}<span class=\"w\"> </span>(α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_2</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.conflictFree</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.conflictFree<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.defends</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.defends<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.conflictFree_empty</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.conflictFree_empty<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>af.conflictFree<span class=\"w\"> </span><span class=\"bp\">∅</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.defends_mono</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.defends_mono<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>T<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>(hST<span class=\"w\"> </span>:<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">⊆</span><span class=\"w\"> </span>T)<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span>α}\n",
+       "<span class=\"w\">  </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af.defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>af.defends<span class=\"w\"> </span>T<span class=\"w\"> </span>a</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -379,10 +406,10 @@
    "id": "84702814",
    "metadata": {
     "papermill": {
-     "duration": 0.004102,
-     "end_time": "2026-06-26T22:37:49.691566+00:00",
+     "duration": 0.012094,
+     "end_time": "2026-08-23T05:46:58.821363+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:49.687464+00:00",
+     "start_time": "2026-08-23T05:46:58.809269+00:00",
      "status": "completed"
     },
     "tags": []
@@ -401,44 +428,50 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bf67aa5",
+   "id": "425870f8",
    "metadata": {
     "papermill": {
-     "duration": 0.0043,
-     "end_time": "2026-06-26T22:37:49.700192+00:00",
+     "duration": 0.011696,
+     "end_time": "2026-08-23T05:46:58.843360+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:49.695892+00:00",
+     "start_time": "2026-08-23T05:46:58.831664+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 4. La fonction caractéristique comme morphisme monotone\n",
+    "## 4. Le treillis complet des ensembles d'arguments — `ArgLattice`\n",
     "\n",
-    "Le module `Argumentation/Characteristic.lean` définit la **fonction caractéristique**\n",
-    "de Dung `F(S) = { a | S défend a }`, bundlée comme un **morphisme d'ordre monotone**\n",
-    "`OrderHom` sur le treillis complet `Set α`. L'extension grounded en est le **plus petit\n",
-    "point fixe** `F.lfp` — c'est le théorème phare `grounded_fixed`.\n",
+    "Le module **racine** `Argumentation.lean` nomme le socle sur lequel toute la théorie\n",
+    "opère : `ArgLattice α`, l'`abbrev` du **treillis complet** `(Set α, ⊆)`.\n",
     "\n",
-    "L'identité `a ∈ F(S) ⇔ S défend a` (`mem_characteristic_iff`) rend la réécriture directe."
+    "Knaster–Tarski exige exactement cette structure — un ordre où **toute** famille admet\n",
+    "un sup et un inf — pour garantir qu'un morphisme monotone comme la fonction\n",
+    "caractéristique `F` possède un **plus petit point fixe**. C'est ce treillis qui donne\n",
+    "son sens à l'écriture `grounded = F.lfp` :\n",
+    "\n",
+    "- les **joins** sont les unions arbitraires `⋃₀`, les **meets** les intersections `⋂₀` ;\n",
+    "- l'instance `CompleteLattice` de Mathlib pour `Set α` traverse l'`abbrev`\n",
+    "  sans redéfinition ;\n",
+    "- `ArgLattice` est le nom sous lequel le lake rend cette hypothèse explicite."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "218f80f0",
+   "id": "5cdab94e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T22:37:49.709952Z",
-     "iopub.status.busy": "2026-06-26T22:37:49.709798Z",
-     "iopub.status.idle": "2026-06-26T22:37:49.934968Z",
-     "shell.execute_reply": "2026-06-26T22:37:49.934164Z"
+     "iopub.execute_input": "2026-08-23T05:46:58.865084Z",
+     "iopub.status.busy": "2026-08-23T05:46:58.864885Z",
+     "iopub.status.idle": "2026-08-23T05:46:59.148286Z",
+     "shell.execute_reply": "2026-08-23T05:46:59.146939Z"
     },
     "papermill": {
-     "duration": 0.230942,
-     "end_time": "2026-06-26T22:37:49.935567+00:00",
+     "duration": 0.295238,
+     "end_time": "2026-08-23T05:46:59.149146+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:49.704625+00:00",
+     "start_time": "2026-08-23T05:46:58.853908+00:00",
      "status": "completed"
     },
     "tags": []
@@ -456,16 +489,192 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>characteristic</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>characteristic<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span>o<span class=\"w\"> </span>Set<span class=\"w\"> </span>α</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>mem_characteristic_iff</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>mem_characteristic_iff<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>α)<span class=\"w\"> </span>:\n",
-       "<span class=\"w\">  </span>a<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>af<span class=\"bp\">.</span>characteristic<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">↔</span><span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>characteristic_eq_defendedBy</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>characteristic_eq_defendedBy<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:\n",
-       "<span class=\"w\">  </span>af<span class=\"bp\">.</span>characteristic<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>af<span class=\"bp\">.</span>defendedBy<span class=\"w\"> </span>S</blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Module racine Argumentation.lean : ArgLattice, le treillis ou vit F</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"k\">#check</span><span class=\"w\"> </span>ArgLattice</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.ArgLattice<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>(α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"k\">#check</span><span class=\"w\"> </span><span class=\"bp\">@</span>Argumentation.ArgLattice</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ArgLattice<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- ArgLattice n&#39;est qu&#39;un abbrev de Set alpha : la definition se deplie par rfl</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">example</span><span class=\"w\"> </span>:<span class=\"w\"> </span>ArgLattice<span class=\"w\"> </span>Nat<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>Set<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=<span class=\"w\"> </span>rfl</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- L&#39;instance CompleteLattice de Mathlib traverse l&#39;abbrev sans redefinition :</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- le sup d&#39;une famille est son union (sSup = iUnion id)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"k\">#check</span><span class=\"w\"> </span>(inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>CompleteLattice<span class=\"w\"> </span>(ArgLattice<span class=\"w\"> </span>Nat))</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> inferInstance<span class=\"w\"> </span>:<span class=\"w\"> </span>CompleteLattice<span class=\"w\"> </span>(ArgLattice<span class=\"w\"> </span>ℕ)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kd\">example</span><span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>(ArgLattice<span class=\"w\"> </span>Nat))<span class=\"w\"> </span>:<span class=\"w\"> </span>sSup<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"bp\">⋃₀</span><span class=\"w\"> </span>S<span class=\"w\"> </span>:=<span class=\"w\"> </span>rfl</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"#check AF.characteristic\\n#check AF.mem_characteristic_iff\\n#check AF.characteristic_eq_defendedBy\", \"env\": 2}</code>\n",
+       "            <code>{\"cmd\": \"-- Module racine Argumentation.lean : ArgLattice, le treillis ou vit F\\n#check ArgLattice\\n#check @Argumentation.ArgLattice\\n\\n-- ArgLattice n'est qu'un abbrev de Set alpha : la definition se deplie par rfl\\nexample : ArgLattice Nat = Set Nat := rfl\\n\\n-- L'instance CompleteLattice de Mathlib traverse l'abbrev sans redefinition :\\n-- le sup d'une famille est son union (sSup = iUnion id)\\n#check (inferInstance : CompleteLattice (ArgLattice Nat))\\nexample (S : Set (ArgLattice Nat)) : sSup S = \\u22c3\\u2080 S := rfl\", \"env\": 2}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"Argumentation.ArgLattice.{u_1} (α : Type u_1) : Type u_1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\": \"ArgLattice : Type u_1 → Type u_1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\": \"inferInstance : CompleteLattice (ArgLattice ℕ)\"}],\r\n",
+       " \"env\": 3}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Module racine Argumentation.lean : ArgLattice, le treillis ou vit F\n",
+       "#check ArgLattice\n",
+       "──────▶  Argumentation.ArgLattice.{u_1} (α : Type u_1) : Type u_1\n",
+       "#check @Argumentation.ArgLattice\n",
+       "──────▶  ArgLattice : Type u_1 → Type u_1\n",
+       "\n",
+       "-- ArgLattice n'est qu'un abbrev de Set alpha : la definition se deplie par rfl\n",
+       "example : ArgLattice Nat = Set Nat := rfl\n",
+       "\n",
+       "-- L'instance CompleteLattice de Mathlib traverse l'abbrev sans redefinition :\n",
+       "-- le sup d'une famille est son union (sSup = iUnion id)\n",
+       "#check (inferInstance : CompleteLattice (ArgLattice Nat))\n",
+       "──────▶  inferInstance : CompleteLattice (ArgLattice ℕ)\n",
+       "example (S : Set (ArgLattice Nat)) : sSup S = ⋃₀ S := rfl\n",
+       "--% env 3\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Module racine Argumentation.lean : ArgLattice, le treillis ou vit F\\n#check ArgLattice\\n#check @Argumentation.ArgLattice\\n\\n-- ArgLattice n'est qu'un abbrev de Set alpha : la definition se deplie par rfl\\nexample : ArgLattice Nat = Set Nat := rfl\\n\\n-- L'instance CompleteLattice de Mathlib traverse l'abbrev sans redefinition :\\n-- le sup d'une famille est son union (sSup = iUnion id)\\n#check (inferInstance : CompleteLattice (ArgLattice Nat))\\nexample (S : Set (ArgLattice Nat)) : sSup S = \\u22c3\\u2080 S := rfl\", \"env\": 2}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"Argumentation.ArgLattice.{u_1} (α : Type u_1) : Type u_1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\": \"ArgLattice : Type u_1 → Type u_1\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 6},\r\n",
+       "   \"data\": \"inferInstance : CompleteLattice (ArgLattice ℕ)\"}],\r\n",
+       " \"env\": 3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Module racine Argumentation.lean : ArgLattice, le treillis ou vit F\n",
+    "#check ArgLattice\n",
+    "#check @Argumentation.ArgLattice\n",
+    "\n",
+    "-- ArgLattice n'est qu'un abbrev de Set alpha : la definition se deplie par rfl\n",
+    "example : ArgLattice Nat = Set Nat := rfl\n",
+    "\n",
+    "-- L'instance CompleteLattice de Mathlib traverse l'abbrev sans redefinition :\n",
+    "-- le sup d'une famille est son union (sSup = iUnion id)\n",
+    "#check (inferInstance : CompleteLattice (ArgLattice Nat))\n",
+    "example (S : Set (ArgLattice Nat)) : sSup S = ⋃₀ S := rfl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35db6903",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01318,
+     "end_time": "2026-08-23T05:46:59.168152+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T05:46:59.154972+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le treillis complet, l'hypothèse exacte de Knaster–Tarski\n",
+    "\n",
+    "| Symbole Lean | Lecture |\n",
+    "|--------------|---------|\n",
+    "| `ArgLattice α` | le treillis complet `(Set α, ⊆)`, nommé par le module racine |\n",
+    "| `CompleteLattice (ArgLattice α)` | instance héritée de `Set α` à travers l'`abbrev` |\n",
+    "| `sSup S = ⋃₀ S` | le sup d'une famille d'ensembles est son union |\n",
+    "| `F.lfp` | le plus petit point fixe — existe parce que le treillis est complet |\n",
+    "\n",
+    "La **complétude** — un sup et un inf pour *toute* famille, pas seulement les paires —\n",
+    "est l'hypothèse du théorème de Knaster–Tarski : c'est elle qui garantit l'existence\n",
+    "de `F.lfp`, donc de l'extension grounded. Le module racine la rend explicite en\n",
+    "nommant le treillis sur lequel `F` opère."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bf67aa5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010889,
+     "end_time": "2026-08-23T05:46:59.191611+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T05:46:59.180722+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. La fonction caractéristique comme morphisme monotone\n",
+    "\n",
+    "Le module `Argumentation/Characteristic.lean` définit la **fonction caractéristique**\n",
+    "de Dung `F(S) = { a | S défend a }`, bundlée comme un **morphisme d'ordre monotone**\n",
+    "`OrderHom` sur le treillis complet `Set α`. L'extension grounded en est le **plus petit\n",
+    "point fixe** `F.lfp` — c'est le théorème phare `grounded_fixed`.\n",
+    "\n",
+    "L'identité `a ∈ F(S) ⇔ S défend a` (`mem_characteristic_iff`) rend la réécriture directe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "218f80f0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T05:46:59.218278Z",
+     "iopub.status.busy": "2026-08-23T05:46:59.218055Z",
+     "iopub.status.idle": "2026-08-23T05:46:59.482209Z",
+     "shell.execute_reply": "2026-08-23T05:46:59.481086Z"
+    },
+    "papermill": {
+     "duration": 0.278754,
+     "end_time": "2026-08-23T05:46:59.482967+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T05:46:59.204213+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.characteristic</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.characteristic<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α<span class=\"w\"> </span><span class=\"bp\">→</span>o<span class=\"w\"> </span>Set<span class=\"w\"> </span>α</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.mem_characteristic_iff</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.mem_characteristic_iff<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>α)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>a<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>af.characteristic<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">↔</span><span class=\"w\"> </span>af.defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.characteristic_eq_defendedBy</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.characteristic_eq_defendedBy<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>af.characteristic<span class=\"w\"> </span>S<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>af.defendedBy<span class=\"w\"> </span>S</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"#check AF.characteristic\\n#check AF.mem_characteristic_iff\\n#check AF.characteristic_eq_defendedBy\", \"env\": 3}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -485,7 +694,7 @@
        "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"Argumentation.AF.characteristic_eq_defendedBy.{u_1} {α : Type u_1} (af : AF α) (S : Set α) :\\n  af.characteristic S = af.defendedBy S\"}],\r\n",
-       " \"env\": 3}</code>\n",
+       " \"env\": 4}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -498,10 +707,10 @@
        "#check AF.characteristic_eq_defendedBy\n",
        "──────▶  Argumentation.AF.characteristic_eq_defendedBy.{u_1} {α : Type u_1} (af : AF α) (S : Set α) :\n",
        "  af.characteristic S = af.defendedBy S\n",
-       "--% env 3\n",
+       "--% env 4\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"#check AF.characteristic\\n#check AF.mem_characteristic_iff\\n#check AF.characteristic_eq_defendedBy\", \"env\": 2}\n",
+       "{\"cmd\": \"#check AF.characteristic\\n#check AF.mem_characteristic_iff\\n#check AF.characteristic_eq_defendedBy\", \"env\": 3}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
@@ -519,7 +728,7 @@
        "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"Argumentation.AF.characteristic_eq_defendedBy.{u_1} {α : Type u_1} (af : AF α) (S : Set α) :\\n  af.characteristic S = af.defendedBy S\"}],\r\n",
-       " \"env\": 3}"
+       " \"env\": 4}"
       ]
      },
      "metadata": {},
@@ -537,10 +746,10 @@
    "id": "cc21ebcf",
    "metadata": {
     "papermill": {
-     "duration": 0.003825,
-     "end_time": "2026-06-26T22:37:49.949815+00:00",
+     "duration": 0.011119,
+     "end_time": "2026-08-23T05:46:59.498489+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:49.945990+00:00",
+     "start_time": "2026-08-23T05:46:59.487370+00:00",
      "status": "completed"
     },
     "tags": []
@@ -560,16 +769,16 @@
    "id": "9c55544a",
    "metadata": {
     "papermill": {
-     "duration": 0.004353,
-     "end_time": "2026-06-26T22:37:49.957866+00:00",
+     "duration": 0.010314,
+     "end_time": "2026-08-23T05:46:59.520119+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:49.953513+00:00",
+     "start_time": "2026-08-23T05:46:59.509805+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 5. Les cinq extensions et leur hiérarchie\n",
+    "## 6. Les cinq extensions et leur hiérarchie\n",
     "\n",
     "Le module `Argumentation/Extensions.lean` définit les **cinq sémantiques** de Dung,\n",
     "de la plus faible à la plus forte :\n",
@@ -583,20 +792,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "65ba8e9b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T22:37:49.966847Z",
-     "iopub.status.busy": "2026-06-26T22:37:49.966679Z",
-     "iopub.status.idle": "2026-06-26T22:37:50.179475Z",
-     "shell.execute_reply": "2026-06-26T22:37:50.178826Z"
+     "iopub.execute_input": "2026-08-23T05:46:59.541862Z",
+     "iopub.status.busy": "2026-08-23T05:46:59.541681Z",
+     "iopub.status.idle": "2026-08-23T05:46:59.769351Z",
+     "shell.execute_reply": "2026-08-23T05:46:59.768452Z"
     },
     "papermill": {
-     "duration": 0.217791,
-     "end_time": "2026-06-26T22:37:50.179953+00:00",
+     "duration": 0.240559,
+     "end_time": "2026-08-23T05:46:59.769931+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:49.962162+00:00",
+     "start_time": "2026-08-23T05:46:59.529372+00:00",
      "status": "completed"
     },
     "tags": []
@@ -614,16 +823,16 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>Admissible</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>Admissible<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>Complete</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>Complete<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>grounded</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>grounded<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>Preferred</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>Preferred<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>Stable</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>Stable<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.Admissible</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.Admissible<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.Complete</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.Complete<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.grounded</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.grounded<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.Preferred</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.Preferred<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.Stable</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.Stable<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"#check AF.Admissible\\n#check AF.Complete\\n#check AF.grounded\\n#check AF.Preferred\\n#check AF.Stable\", \"env\": 3}</code>\n",
+       "            <code>{\"cmd\": \"#check AF.Admissible\\n#check AF.Complete\\n#check AF.grounded\\n#check AF.Preferred\\n#check AF.Stable\", \"env\": 4}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -653,7 +862,7 @@
        "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"Argumentation.AF.Stable.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"}],\r\n",
-       " \"env\": 4}</code>\n",
+       " \"env\": 5}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -668,10 +877,10 @@
        "──────▶  Argumentation.AF.Preferred.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\n",
        "#check AF.Stable\n",
        "──────▶  Argumentation.AF.Stable.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\n",
-       "--% env 4\n",
+       "--% env 5\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"#check AF.Admissible\\n#check AF.Complete\\n#check AF.grounded\\n#check AF.Preferred\\n#check AF.Stable\", \"env\": 3}\n",
+       "{\"cmd\": \"#check AF.Admissible\\n#check AF.Complete\\n#check AF.grounded\\n#check AF.Preferred\\n#check AF.Stable\", \"env\": 4}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
@@ -699,7 +908,7 @@
        "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"Argumentation.AF.Stable.{u_1} {α : Type u_1} (af : AF α) (S : Set α) : Prop\"}],\r\n",
-       " \"env\": 4}"
+       " \"env\": 5}"
       ]
      },
      "metadata": {},
@@ -719,16 +928,16 @@
    "id": "aef702ff",
    "metadata": {
     "papermill": {
-     "duration": 0.003484,
-     "end_time": "2026-06-26T22:37:50.190381+00:00",
+     "duration": 0.012173,
+     "end_time": "2026-08-23T05:46:59.787389+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:50.186897+00:00",
+     "start_time": "2026-08-23T05:46:59.775216+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 6. La Fundamental Lemma de Dung\n",
+    "## 7. La Fundamental Lemma de Dung\n",
     "\n",
     "Le module `Argumentation/Fundamental.lean` prouve la **Fundamental Lemma** (Dung 1995,\n",
     "Lemme 1) : si `S` est admissible et défend `a`, alors `S ∪ {a}` est admissible. C'est la\n",
@@ -738,20 +947,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "0b86f3a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T22:37:50.200119Z",
-     "iopub.status.busy": "2026-06-26T22:37:50.199977Z",
-     "iopub.status.idle": "2026-06-26T22:37:50.415593Z",
-     "shell.execute_reply": "2026-06-26T22:37:50.414797Z"
+     "iopub.execute_input": "2026-08-23T05:46:59.809681Z",
+     "iopub.status.busy": "2026-08-23T05:46:59.809442Z",
+     "iopub.status.idle": "2026-08-23T05:47:00.049642Z",
+     "shell.execute_reply": "2026-08-23T05:47:00.048436Z"
     },
     "papermill": {
-     "duration": 0.222032,
-     "end_time": "2026-06-26T22:37:50.416170+00:00",
+     "duration": 0.253111,
+     "end_time": "2026-08-23T05:47:00.050362+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:50.194138+00:00",
+     "start_time": "2026-08-23T05:46:59.797251+00:00",
      "status": "completed"
     },
     "tags": []
@@ -769,17 +978,17 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>fundamental_lemma</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>fundamental_lemma<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span>α}<span class=\"w\"> </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>Admissible<span class=\"w\"> </span>S)\n",
-       "<span class=\"w\">  </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>Admissible<span class=\"w\"> </span>(insert<span class=\"w\"> </span>a<span class=\"w\"> </span>S)</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>fundamental_lemma_defends</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>fundamental_lemma_defends<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>α}<span class=\"w\"> </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>Admissible<span class=\"w\"> </span>S)\n",
-       "<span class=\"w\">  </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>(hb<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>(insert<span class=\"w\"> </span>a<span class=\"w\"> </span>S)<span class=\"w\"> </span>b</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>fundamental_lemma_defends_self</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>fundamental_lemma_defends_self<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span>α}\n",
-       "<span class=\"w\">  </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>Admissible<span class=\"w\"> </span>S)<span class=\"w\"> </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>(insert<span class=\"w\"> </span>a<span class=\"w\"> </span>S)<span class=\"w\"> </span>a</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.fundamental_lemma</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.fundamental_lemma<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span>α}<span class=\"w\"> </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af.Admissible<span class=\"w\"> </span>S)\n",
+       "<span class=\"w\">  </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>af.defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>af.Admissible<span class=\"w\"> </span>(insert<span class=\"w\"> </span>a<span class=\"w\"> </span>S)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.fundamental_lemma_defends</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.fundamental_lemma_defends<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>α}<span class=\"w\"> </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af.Admissible<span class=\"w\"> </span>S)\n",
+       "<span class=\"w\">  </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>af.defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>(hb<span class=\"w\"> </span>:<span class=\"w\"> </span>af.defends<span class=\"w\"> </span>S<span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>af.defends<span class=\"w\"> </span>(insert<span class=\"w\"> </span>a<span class=\"w\"> </span>S)<span class=\"w\"> </span>b</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.fundamental_lemma_defends_self</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.fundamental_lemma_defends_self<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>{S<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α}<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span>α}\n",
+       "<span class=\"w\">  </span>(hS<span class=\"w\"> </span>:<span class=\"w\"> </span>af.Admissible<span class=\"w\"> </span>S)<span class=\"w\"> </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>af.defends<span class=\"w\"> </span>S<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>af.defends<span class=\"w\"> </span>(insert<span class=\"w\"> </span>a<span class=\"w\"> </span>S)<span class=\"w\"> </span>a</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"#check AF.fundamental_lemma\\n#check AF.fundamental_lemma_defends\\n#check AF.fundamental_lemma_defends_self\", \"env\": 4}</code>\n",
+       "            <code>{\"cmd\": \"#check AF.fundamental_lemma\\n#check AF.fundamental_lemma_defends\\n#check AF.fundamental_lemma_defends_self\", \"env\": 5}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -799,7 +1008,7 @@
        "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"Argumentation.AF.fundamental_lemma_defends_self.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a : α}\\n  (hS : af.Admissible S) (ha : af.defends S a) : af.defends (insert a S) a\"}],\r\n",
-       " \"env\": 5}</code>\n",
+       " \"env\": 6}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -813,10 +1022,10 @@
        "#check AF.fundamental_lemma_defends_self\n",
        "──────▶  Argumentation.AF.fundamental_lemma_defends_self.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a : α}\n",
        "  (hS : af.Admissible S) (ha : af.defends S a) : af.defends (insert a S) a\n",
-       "--% env 5\n",
+       "--% env 6\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"#check AF.fundamental_lemma\\n#check AF.fundamental_lemma_defends\\n#check AF.fundamental_lemma_defends_self\", \"env\": 4}\n",
+       "{\"cmd\": \"#check AF.fundamental_lemma\\n#check AF.fundamental_lemma_defends\\n#check AF.fundamental_lemma_defends_self\", \"env\": 5}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
@@ -834,7 +1043,7 @@
        "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"Argumentation.AF.fundamental_lemma_defends_self.{u_1} {α : Type u_1} (af : AF α) {S : Set α} {a : α}\\n  (hS : af.Admissible S) (ha : af.defends S a) : af.defends (insert a S) a\"}],\r\n",
-       " \"env\": 5}"
+       " \"env\": 6}"
       ]
      },
      "metadata": {},
@@ -852,16 +1061,16 @@
    "id": "b2683094",
    "metadata": {
     "papermill": {
-     "duration": 0.004258,
-     "end_time": "2026-06-26T22:37:50.428302+00:00",
+     "duration": 0.013382,
+     "end_time": "2026-08-23T05:47:00.069761+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:50.424044+00:00",
+     "start_time": "2026-08-23T05:47:00.056379+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 7. Théorème phare : le point fixe de l'extension grounded\n",
+    "## 8. Théorème phare : le point fixe de l'extension grounded\n",
     "\n",
     "Le module `Argumentation/Grounded.lean` prouve le résultat central :\n",
     "\n",
@@ -873,20 +1082,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "73c8bb86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-26T22:37:50.438439Z",
-     "iopub.status.busy": "2026-06-26T22:37:50.438288Z",
-     "iopub.status.idle": "2026-06-26T22:37:50.647317Z",
-     "shell.execute_reply": "2026-06-26T22:37:50.646581Z"
+     "iopub.execute_input": "2026-08-23T05:47:00.092876Z",
+     "iopub.status.busy": "2026-08-23T05:47:00.092684Z",
+     "iopub.status.idle": "2026-08-23T05:47:00.349182Z",
+     "shell.execute_reply": "2026-08-23T05:47:00.347488Z"
     },
     "papermill": {
-     "duration": 0.215011,
-     "end_time": "2026-06-26T22:37:50.647864+00:00",
+     "duration": 0.268796,
+     "end_time": "2026-08-23T05:47:00.350297+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:50.432853+00:00",
+     "start_time": "2026-08-23T05:47:00.081501+00:00",
      "status": "completed"
     },
     "tags": []
@@ -904,16 +1113,16 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>grounded_fixed</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>grounded_fixed<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>characteristic<span class=\"w\"> </span>af<span class=\"bp\">.</span>grounded<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>af<span class=\"bp\">.</span>grounded</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>grounded_defends_iff_mem</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>grounded_defends_iff_mem<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>α)<span class=\"w\"> </span>:\n",
-       "<span class=\"w\">  </span>af<span class=\"bp\">.</span>defends<span class=\"w\"> </span>af<span class=\"bp\">.</span>grounded<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">↔</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>af<span class=\"bp\">.</span>grounded</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>AF<span class=\"bp\">.</span>grounded_least_complete</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation<span class=\"bp\">.</span>AF<span class=\"bp\">.</span>grounded_least_complete<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(T<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>af<span class=\"bp\">.</span>Complete<span class=\"w\"> </span>T)<span class=\"w\"> </span>:\n",
-       "<span class=\"w\">  </span>af<span class=\"bp\">.</span>grounded<span class=\"w\"> </span><span class=\"bp\">⊆</span><span class=\"w\"> </span>T</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.grounded_fixed</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.grounded_fixed<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>:<span class=\"w\"> </span>af.characteristic<span class=\"w\"> </span>af.grounded<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>af.grounded</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.grounded_defends_iff_mem</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.grounded_defends_iff_mem<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>α)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>af.defends<span class=\"w\"> </span>af.grounded<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">↔</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>af.grounded</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk16\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk16\"><span class=\"k\">#check</span><span class=\"w\"> </span>AF.grounded_least_complete</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Argumentation.AF.grounded_least_complete<span class=\"bp\">.</span>{u_1}<span class=\"w\"> </span>{α<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u_1}<span class=\"w\"> </span>(af<span class=\"w\"> </span>:<span class=\"w\"> </span>AF<span class=\"w\"> </span>α)<span class=\"w\"> </span>(T<span class=\"w\"> </span>:<span class=\"w\"> </span>Set<span class=\"w\"> </span>α)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>af.Complete<span class=\"w\"> </span>T)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>af.grounded<span class=\"w\"> </span><span class=\"bp\">⊆</span><span class=\"w\"> </span>T</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 7</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"#check AF.grounded_fixed\\n#check AF.grounded_defends_iff_mem\\n#check AF.grounded_least_complete\", \"env\": 5}</code>\n",
+       "            <code>{\"cmd\": \"#check AF.grounded_fixed\\n#check AF.grounded_defends_iff_mem\\n#check AF.grounded_least_complete\", \"env\": 6}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -933,7 +1142,7 @@
        "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"Argumentation.AF.grounded_least_complete.{u_1} {α : Type u_1} (af : AF α) (T : Set α) (h : af.Complete T) :\\n  af.grounded ⊆ T\"}],\r\n",
-       " \"env\": 6}</code>\n",
+       " \"env\": 7}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -946,10 +1155,10 @@
        "#check AF.grounded_least_complete\n",
        "──────▶  Argumentation.AF.grounded_least_complete.{u_1} {α : Type u_1} (af : AF α) (T : Set α) (h : af.Complete T) :\n",
        "  af.grounded ⊆ T\n",
-       "--% env 6\n",
+       "--% env 7\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"#check AF.grounded_fixed\\n#check AF.grounded_defends_iff_mem\\n#check AF.grounded_least_complete\", \"env\": 5}\n",
+       "{\"cmd\": \"#check AF.grounded_fixed\\n#check AF.grounded_defends_iff_mem\\n#check AF.grounded_least_complete\", \"env\": 6}\n",
        "Raw output:\n",
        "{\"messages\":\r\n",
        " [{\"severity\": \"info\",\r\n",
@@ -967,7 +1176,7 @@
        "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
        "   \"data\":\r\n",
        "   \"Argumentation.AF.grounded_least_complete.{u_1} {α : Type u_1} (af : AF α) (T : Set α) (h : af.Complete T) :\\n  af.grounded ⊆ T\"}],\r\n",
-       " \"env\": 6}"
+       " \"env\": 7}"
       ]
      },
      "metadata": {},
@@ -985,10 +1194,10 @@
    "id": "57320792",
    "metadata": {
     "papermill": {
-     "duration": 0.00431,
-     "end_time": "2026-06-26T22:37:50.658140+00:00",
+     "duration": 0.016452,
+     "end_time": "2026-08-23T05:47:00.374609+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:50.653830+00:00",
+     "start_time": "2026-08-23T05:47:00.358157+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1011,24 +1220,25 @@
    "id": "25aac6d1",
    "metadata": {
     "papermill": {
-     "duration": 0.003631,
-     "end_time": "2026-06-26T22:37:50.666232+00:00",
+     "duration": 0.012407,
+     "end_time": "2026-08-23T05:47:00.398931+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:50.662601+00:00",
+     "start_time": "2026-08-23T05:47:00.386524+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 8. La chaîne causale complète\n",
+    "## 9. La chaîne causale complète\n",
     "\n",
-    "Les cinq modules composent une chaîne unique, du cadre abstrait au point fixe :\n",
+    "Les six modules composent une chaîne unique, du treillis au point fixe :\n",
     "\n",
-    "1. **`Basic`** — cadre `AF`, sans-conflit, défense, monotonie (`defends_mono`).\n",
-    "2. **`Characteristic`** — `F : Set α →o Set α` morphisme monotone (la croissance).\n",
-    "3. **`Extensions`** — les 5 sémantiques (Admissible → Complete → grounded → Preferred → Stable).\n",
-    "4. **`Fundamental`** — la Fundamental Lemma (étendre un admissible défendable ⟹ admissible).\n",
-    "5. **`Grounded`** — `F(grounded) = grounded` (point fixe ⟹ grounded est la plus petite complète)."
+    "1. **Racine** — `ArgLattice`, le treillis complet `(Set α, ⊆)` (le socle de Knaster–Tarski).\n",
+    "2. **`Basic`** — cadre `AF`, sans-conflit, défense, monotonie (`defends_mono`).\n",
+    "3. **`Characteristic`** — `F : Set α →o Set α` morphisme monotone (la croissance).\n",
+    "4. **`Extensions`** — les 5 sémantiques (Admissible → Complete → grounded → Preferred → Stable).\n",
+    "5. **`Fundamental`** — la Fundamental Lemma (étendre un admissible défendable ⟹ admissible).\n",
+    "6. **`Grounded`** — `F(grounded) = grounded` (point fixe ⟹ grounded est la plus petite complète)."
    ]
   },
   {
@@ -1036,16 +1246,16 @@
    "id": "60ecf40f",
    "metadata": {
     "papermill": {
-     "duration": 0.004654,
-     "end_time": "2026-06-26T22:37:50.675464+00:00",
+     "duration": 0.011399,
+     "end_time": "2026-08-23T05:47:00.421060+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:50.670810+00:00",
+     "start_time": "2026-08-23T05:47:00.409661+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 9. Exercices\n",
+    "## 10. Exercices\n",
     "\n",
     "### Exercice 1 — Sans-conflit et défense sur un mini-cadre (Python)\n",
     "\n",
@@ -1067,10 +1277,10 @@
    "id": "683873f1",
    "metadata": {
     "papermill": {
-     "duration": 0.00468,
-     "end_time": "2026-06-26T22:37:50.684151+00:00",
+     "duration": 0.011237,
+     "end_time": "2026-08-23T05:47:00.442836+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:50.679471+00:00",
+     "start_time": "2026-08-23T05:47:00.431599+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1092,10 +1302,10 @@
    "id": "a6447b07",
    "metadata": {
     "papermill": {
-     "duration": 0.004296,
-     "end_time": "2026-06-26T22:37:50.695651+00:00",
+     "duration": 0.012594,
+     "end_time": "2026-08-23T05:47:00.468689+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:50.691355+00:00",
+     "start_time": "2026-08-23T05:47:00.456095+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1119,10 +1329,10 @@
    "id": "ee5e472f",
    "metadata": {
     "papermill": {
-     "duration": 0.004124,
-     "end_time": "2026-06-26T22:37:50.704294+00:00",
+     "duration": 0.025125,
+     "end_time": "2026-08-23T05:47:00.505739+00:00",
      "exception": false,
-     "start_time": "2026-06-26T22:37:50.700170+00:00",
+     "start_time": "2026-08-23T05:47:00.480614+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1150,14 +1360,18 @@
    "name": "lean4-wsl"
   },
   "language_info": {
-   "codemirror_mode": "python",
+   "codemirror_mode": "lean4",
    "file_extension": ".lean",
    "mimetype": "text/x-lean4",
    "name": "lean4"
   },
   "papermill": {
-   "input_path": "Tweety-5b-Lean-Argumentation.ipynb",
-   "output_path": "Tweety-5b-Lean-Argumentation.ipynb"
+   "duration": 272.466901,
+   "end_time": "2026-08-23T05:47:01.141555+00:00",
+   "exception": null,
+   "input_path": "t5b_exec_tmp.ipynb",
+   "output_path": "t5b_exec_tmp_out.ipynb",
+   "start_time": "2026-08-23T05:42:28.674654+00:00"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/Argumentation.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/Argumentation.lean
@@ -78,6 +78,11 @@ Knaster–Tarski).
   counterpart.
 - Issue #4046 (Lean roadmap #4038), Argumentum Epic #2137.
 
+Ce fichier racine porte `ArgLattice` — l'`abbrev` du treillis complet
+`(Set α, ⊆)`, socle de Knaster–Tarski sur lequel opère la fonction
+caractéristique — et sert d'umbrella : `import Argumentation` amène
+tout le lake.
+
 Convention i18n (EPIC #4980, décision user 2026-07-04) : ce fichier root
 aggregator est bilingue inline (FR canonique d'abord, EN en miroir).
 Les modules substantiels (`Argumentation.Basic`, `Argumentation.Characteristic`,
@@ -85,8 +90,6 @@ Les modules substantiels (`Argumentation.Basic`, `Argumentation.Characteristic`,
 -/
 
 namespace Argumentation
-
-variable {α : Type*} (af : AF α)
 
 /-- Le treillis complet `(Set α, ⊆)` sur lequel opère la fonction
 caractéristique. -/

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/lakefile.lean
@@ -35,4 +35,4 @@ require mathlib from git
 
 @[default_target]
 lean_lib «Argumentation» where
-  globs := #[.submodules `Argumentation]
+  globs := #[.one `Argumentation, .submodules `Argumentation]


### PR DESCRIPTION
Grain: MED/notebook-lean — lane myia-po-2024:CoursIA — prev: MED/notebook-python #12516

See #11703 — tranche argumentation : rendre visible le module racine `Argumentation.lean`. Claim scopé posé (issuecomment-5384262715, `paths: Tweety-5b-Lean-Argumentation.ipynb`).

## Résumé — le module racine `Argumentation.lean` ouvre sa salle de classe

La mesure instrument (`scan_lake_notebook_visibility.py`, HEAD du cycle) listait `argumentation_lean/Argumentation.lean` comme module **noir** : sa déclaration unique `ArgLattice` (nom distinctif de 10 caractères, jamais cité) n'était montrée par aucun notebook. Le compagnon natif Tweety-5b important uniquement les 5 sous-modules, la racine était invisible — or c'est elle qui **nomme le treillis complet `(Set α, ⊆)`**, le socle exact de Knaster–Tarski.

### Ce que le grain change

1. **`lakefile.lean`** — `globs := #[.one `Argumentation, .submodules `Argumentation]` : l'umbrella racine devient builddable (avant, seule la config `submodules` était buildée, et la cellule 1 du notebook documentait elle-même cette limitation comme une raison de ne pas importer la racine).
2. **Cellule 2 (imports)** — `import Argumentation` ajouté en tête des 5 sous-modules.
3. **Nouvelle section 4 « Le treillis complet des ensembles d'arguments — `ArgLattice` »** (markdown + cellule code + Lecture) :
   - `#check ArgLattice` / `#check @Argumentation.ArgLattice` ;
   - `example : ArgLattice Nat = Set Nat := rfl` — l'`abbrev` se déplie ;
   - `#check (inferInstance : CompleteLattice (ArgLattice Nat))` — l'instance Mathlib traverse l'abbrev ;
   - `example (S : Set (ArgLattice Nat)) : sSup S = ⋃₀ S := rfl` — le sup d'une famille est son union ;
   - la prose enseigne **pourquoi** la complétude (sup/inf pour toute famille) est l'hypothèse exacte de Knaster–Tarski, donc ce qui garantit l'existence de `F.lfp` — et avec lui, de l'extension grounded.
4. **Renumérotation 4→10** des sections suivantes (aucune référence croisée), chaîne causale passée à **6 modules** (la racine en étape 1), cellule 1 réécrite (racine + 5 sous-modules, lakefile `.one` + `.submodules`).

### Contexte du grain

Ce cycle a aussi établi (commentaire issuecomment-5384182689) que 4 des « modules noirs » restants de l'EPIC sont des **artefacts de l'instrument** (modules à noms courts jamais « distinctifs ») : finiteness `Basic.lean` (visible via Lean-14b), erc20 `Ops.lean` (visible via Lean-24b), minimax racine, sudoku lakefile. `Argumentation.lean` était le **seul** dark réel de petite taille : nom distinctif, jamais cité nulle part — ce grain le résout à la source.

## Validation

- **Lake build** : `lake exe cache get` + `lake build` SUCCESS en WSL (toolchain v4.32.1, Mathlib v4.32.1) — prérequis rendu possible par le changement de globs ; le symlink mathlib périmé (v4.31.0-rc1, chemin MSYS illisible depuis WSL) a été retiré pour permettre le re-clone canonique.
- **Re-exécution complète C.2** (cellule code modifiée + nouvelle cellule) : papermill kernel `lean4-wsl`, **4 min 32 s** (chargement réel des oleans Mathlib v4.32.1 via la jonction NTFS) ; 8/8 cellules code `execution_count` non-null, chaîne `--% env N` préservée. **Vérification scriptée des outputs rendus** (strip HTML + unescape) : **0 marqueur d'erreur kernel** (`❌` / `unknown identifier` / `unknown namespace`), **0 chemin machine** (regex `[A-Z]:/Dev`, `/mnt/c/`, `Users/jsboi`). La nouvelle cellule rend les signatures réelles : `Argumentation.ArgLattice.{u_1} (α : Type u_1) : Type u_1`, `inferInstance : CompleteLattice (ArgLattice ℕ)`, et les deux `example … := rfl` passent sans erreur (preuves par `rfl` vérifiées par le noyau).
- **Note d'exécution (détail reproductible)** : le kernel résout le lake depuis le **cwd du processus kernel** (= répertoire du notebook d'entrée). Le notebook vit un niveau au-dessus de son lake (`Tweety/` vs `argumentation_lean/`), donc l'exec depuis son emplacement canonique retombe sur le repl repo (imports no-op — mesuré : `{"env": 0}` + `❌ Unknown identifier`). L'exécution a donc été faite depuis une **copie temporaire dans le lake dir** (même contenu, kernel identique), puis le fichier exécuté a été transplanté au chemin canonique — seule normalisation : `metadata.papermill` paths au basename (sanctionnée). C'est la même raison pour laquelle kelly (#12361) n'a jamais rencontré le problème : son compagnon vit déjà dans son lake.
- **Désolérabilité inchangée** : `count_code_sorry.py --json` → `argumentation_lean : distinct_code_sorry = 0` (naive 18 = prose). Aucune preuve touchée.
- **`#print axioms AF.grounded_fixed`** : toujours `[propext, Classical.choice, Quot.sound]` — 0 `sorryAx` (cellule 2 du notebook, re-exécutée).
- **C.1** : 0 erreur volontaire ; exercices 1-3 stubs intacts.
- **Anti-régression** : le lakefile ne retire rien (`+= .one`), le notebook n'ajoute que du contenu.

## Périmètre — 3 fichiers

1. `MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5b-Lean-Argumentation.ipynb` (section 4 ArgLattice + imports + renumérotation)
2. `argumentation_lean/Argumentation.lean` (docstring racine : rôle umbrella + `ArgLattice` ; retrait d'une `variable` morte non utilisée par l'`abbrev`)
3. `argumentation_lean/lakefile.lean` (globs : `.one Argumentation` ajouté)

Catalogue byte-identique à `origin/main`. Aucun twin. Aucun secret.

