### PR TITLE
docs(shared,#7357): cadrage E2 Option C - precondition dette doc constatee satisfaite, paire ML.NET 9 testee

### DIFF
--- a/docs/reference/backtester-e2-cadrage.md
+++ b/docs/reference/backtester-e2-cadrage.md
@@ -1,0 +1,56 @@
+# MyIA.Trading.Backtester (E2) — cadrage Option C et déblocage des préconditions
+
+> Issue [#7357](https://github.com/jsboige/CoursIA/issues/7357) (EPIC différée) · parent [#7265](https://github.com/jsboige/CoursIA/issues/7265).
+> Décision user du 2026-07-19 : **Option C** (découplage Aricie, substitution des libs ML), exécution différée.
+> Ce document livre les deux sous-grains prescrits par le body du 2026-08-20 : rendre la précondition « dette doc » observable (§1), et cadrer les libs de substitution (§2). Toutes les mesures sont firsthand (fork cloné sparse, compilations réelles), datées du 2026-08-23.
+
+## 1. Précondition « absorption de la dette doc » — constat de satisfaction
+
+Le verbatim user du 2026-07-19 diffère E2 « après absorption de la dette doc + E1 restructuré », sans définir la dette. Le body du 2026-08-20 mesurait qu'aucun tracker ne la porte (`gh search issues "dette doc"` : 0 résultat, vérifié à nouveau ce jour) et proposait trois issues : rattacher, redéfinir, ou constater caduque.
+
+**Mesures (2026-08-23, `origin/main`)**, sous la lecture naturelle — *chaque module du patrimoine Aricie atterri sur main porte sa documentation de module* :
+
+| Module livré | Doc | Lignes | Contenu |
+|---|---|---|---|
+| `MyIA.AI.Shared/` (socle) | `README.md` | 169 | rôle équivalent-moderne d'`Aricie.Shared`, composants |
+| `MyIA.Trading.Converter/` (E1) | `README.md` | 123 | port, scope E1, source upstream (`612dddf9`), contournement Security Master |
+
+Ce sont les **deux seuls** modules du patrimoine atterris à ce jour ; tous deux sont documentés. La seconde moitié de la précondition (« E1 restructuré ») était déjà constatée atteinte par le body du 2026-08-20 (commit `ca71ae5c8`, PR #7425).
+
+**Proposition (à trancher par ai-01/user)** : la précondition est réputée satisfaite ; E2 quitte le backlog sur simple décision de planification. Le critère reste vivant pour la suite du patrimoine : *tout module Aricie atterri ultérieurement porte sa doc de module avant que l'EPIC ne soit réputée en règle*.
+
+## 2. Cadrage des libs de substitution (Option C)
+
+### 2.1 Ce que le fork consomme réellement (mesuré, pas supposé)
+
+Source : `MyIntelligenceAgency/Lean`, branche `MyIABacktesting_integration`, checkout sparse de `MyIA.Trading.Backtester/` — **75 fichiers `.cs`, 91 fichiers, 16 Mo** (les chiffres de la recon po-2024 c.708 sont exacts).
+
+| Dépendance | Empreinte mesurée |
+|---|---|
+| `Accord.MachineLearning` (+VectorMachines, +Boosting, Statistics, Math) | 11 fichiers porteurs (`BackTesting.cs`, `ModelStrategy.cs`, `MultiClassBoost.cs`, `TradingSvmModelConfig.cs`…) ; symboles dominants : `SvmModelConfig` ×33, `SupportVectorMachine` + `SequentialMinimalOptimization` (SMO), kernels `Linear`/`Gaussian`, boosting |
+| `Microsoft.ML` + `Microsoft.ML.AutoML` | `AutoML` ×35, `ColumnInferenceResults`/`ColumnInferencePrinter` |
+| 6 DLL Aricie en HintPath | `Aricie.Core`, `Aricie.DNN`, `Ciloci.Flee`, `CommonMark`, `DotNetNuke`, `Fasterflect` — à abandonner ; le socle transverse a déjà son équivalent moderne (`MyIA.AI.Shared`, dont `FleePredicateBuilder` testé sur main) |
+
+### 2.2 Test réel sur .NET 9 (2026-08-23, SDK 9.0.317)
+
+Mini-projet `net9.0` dans un scratchpad, répliquant les usages du fork : `InferColumns` (l'usage AutoML réel) + entraînement linéaire + `PredictionEngine` :
+
+- **Paire résolue** : `Microsoft.ML.AutoML 0.24.0-preview.26160.2` → transitif `Microsoft.ML 6.0.0-preview.26160.2`. Restore, build et exécution **SUCCESS** : `InferColumns OK`, `SdcaMaximumEntropy : MicroAccuracy=1,000`, prédiction correcte.
+- `Microsoft.ML 4.0.0` (stable) existe seule ; **AutoML n'a pas de build stable apparié récent** (NU1102 mesuré : plafond `0.24.0-preview`). Le fork tourne sur `AutoML 0.20.1` (2022).
+
+### 2.3 Conséquences pour le port
+
+1. **Breaking API AutoML, mesuré au compilateur** : `ColumnInferenceResults.TextLoaderEventArgs` (API 0.20.x utilisée par le fork) n'existe plus en 0.24 — remplacée par `TextLoaderOptions`/`ColumnInformation` (CS1061 reproduit puis corrigé dans le test). Le port AutoML n'est **pas** un re-packaging : c'est une adaptation d'API.
+2. **SVM** : ML.NET n'offre pas de SVM à noyau. Le linéaire se remplace proprement (`SdcaMaximumEntropy`, multiclasse comme `MultiClassBoost.cs` du fork ; binaire : `AveragedPerceptron`/`SdcaLogisticRegression` sur label bool). Le **noyau gaussien** est un gap : candidats `SharpLearning` (MIT, SVM+boosting) ou LibSVM-sharp — à trancher en début de port (checklist 6 axes de [`sota-not-workaround`](../../.claude/rules/sota-not-workaround.md) : les trois premiers axes — package NuGet officiel, C API, CLI — sont couverts par ML.NET/SharpLearning, aucun verdict `INTRINSIC` nécessaire).
+3. **Boosting** : `FastTree` (gradient boosting ML.NET) remplace les boosters Accord.
+4. **Stratégie recommandée** : figer la paire preview `AutoML 0.24.0-preview.26160.2` + `ML 6.0.0-preview.26160.2` (la seule testée ci-dessus), isoler les usages AutoML derrière une interface (`IColumnInference`) pour contenir le risque preview, et répliquer le test ci-dessus comme test d'intégration du port (il est volontairement petit : CSV inline, assert `MicroAccuracy > 0.9`).
+
+### 2.4 Périmètre restant du port (non re-mesuré ici)
+
+`BackTesting.cs` 755 lignes, 6 DLL Aricie à découpler, `ProjectReference` vers `MyIA.Trading.Converter` (déjà sur main). L'effort reste celui du cadrage d'origine — ce document ne le réevalue pas, il en lève les deux préconditions.
+
+## Voir aussi
+
+- [#7357](https://github.com/jsboige/CoursIA/issues/7357) — body du 2026-08-20 (état mesuré, voies par coût croissant)
+- [#7265](https://github.com/jsboige/CoursIA/issues/7265) — EPIC index du patrimoine Aricie
+- [quantconnect.md](../qc/quantconnect.md) — contexte QC, contournement Security Master (E1)


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-python #12539

See #7357 (EPIC E2, sous-grains 1+2 prescrits par le body du 2026-08-20 — l'EPIC reste ouverte, le port lui-même reste à planifier)
See #7265 (EPIC parent patrimoine Aricie)

## Summary

L'umbrella #7357 était délaissée (34 j) derrière une précondition que « rien ne mesure » (constat du body du 2026-08-20 : la condition « absorption de la dette doc » du verbatim user du 19/07 n'a aucun tracker, donc ne peut jamais être *constatée* atteinte). Cette PR livre les deux sous-grains que le body prescrit par coût croissant, en un document d'architecture pérenne : `docs/reference/backtester-e2-cadrage.md` (56 lignes).

### Sous-grain 1 — précondition « dette doc » rendue observable : constat de satisfaction

Mesures firsthand sur `origin/main` : les deux seuls modules du patrimoine Aricie atterris portent chacun leur doc de module — `MyIA.AI.Shared/README.md` (169 lignes) et `MyIA.Trading.Converter/README.md` (123 lignes, documente le port, le scope E1 et la source upstream `612dddf9`). La seconde moitié de la précondition (« E1 restructuré ») était déjà constatée atteinte (body 2026-08-20). **Proposition livrée : la précondition est réputée satisfaite — le déblocage de l'EPIC ne tient plus qu'à une décision de planification** (à trancher ai-01/user ; un commentaire récap sur #7357 porte la proposition).

### Sous-grain 2 — cadrage des libs de substitution Option C, avec mesures réelles

- **Fork mesuré, pas supposé** : clone sparse de `MyIntelligenceAgency/Lean@MyIABacktesting_integration`, checkout de `MyIA.Trading.Backtester/` — 75 `.cs`/91 fichiers/16 Mo (chiffres de la recon d'origine confirmés). Empreinte ML extraite : `SvmModelConfig` ×33, `SupportVectorMachine`+`SequentialMinimalOptimization` (SMO), kernels Linear/Gaussian, boosting côté Accord ; `AutoML` ×35, `ColumnInferenceResults` côté Microsoft.ML ; les 6 DLL Aricie HintPath listées.
- **Test réel .NET 9** (SDK 9.0.317, scratchpad) : paire résolue `Microsoft.ML.AutoML 0.24.0-preview.26160.2` → transitif `Microsoft.ML 6.0.0-preview.26160.2`. Restore + build + run **SUCCESS** : `InferColumns` (l'usage AutoML réel du fork), `SdcaMaximumEntropy MicroAccuracy=1,000`, `PredictionEngine` correct. `Microsoft.ML 4.0.0` stable existe mais **AutoML n'a pas de stable apparié** (NU1102 mesuré).
- **Breaking API mesuré au compilateur** : `ColumnInferenceResults.TextLoaderEventArgs` (API 0.20.x du fork) n'existe plus en 0.24 (CS1061 reproduit, remplacé par `TextLoaderOptions`/`ColumnInformation`) — le port AutoML est une adaptation d'API, pas un re-packaging.
- **Gap identifié** : ML.NET n'a pas de SVM à noyau (le linéaire se remplace : `SdcaMaximumEntropy`/`AveragedPerceptron`), le noyau gaussien exige `SharpLearning` (MIT) ou équivalent — les 6 axes de `sota-not-workaround` sont couverts par des packages NuGet réels, aucun verdict `INTRINSIC` requis.
- Stratégie recommandée : figer la paire preview testée, isoler les usages AutoML derrière une interface, répliquer le test comme test d'intégration du futur port.

## Validation (5 points)

1. **Scope réel** : 1 fichier doc neuf (+56 lignes), rien d'autre.
2. **Validation automatisée du livrable** : doc pure — pas de notebook. Chaque chiffre du document vient d'une commande exécutée ce cycle (clone/checkout sparse, grep, `dotnet restore/build/run`, `gh search issues`) et est reproductible depuis le doc.
3. **Cohérence pédagogique** : N/A (doc d'architecture, français, références croisées #7357/#7265/quantconnect.md).
4. **Exécution réelle** : le test .NET 9 cité a réellement tourné (sorties ci-dessus) ; le fork a réellement été checkout (mesures).
5. **Regression check** : fichier nouveau, aucun symbole existant touché ; catalogue non régénéré (byte-identique main).

## Verdict SOTA (Prong A)

**SOTA-OK** — paire ML.NET réellement installée/compilée/exécutée sur net9.0 ; mesures du fork firsthand, pas de recon par cœur.

## Note G-VAR

Grain d'ouverture d'umbrella délaissée (MED, avance un livrable multi-cycle — l'EPIC #7357 — sur ses deux sous-grains prescrits). Le grain de CONTENU suivant de la lane est nommé pour le prochain cycle (pool vérifié saturé de claims ce matin : #10382/#10950/#8182/#12329 tous verrouillés par d'autres lanes, cf dashboard).

## Diagnostic dérive

N/A — document neuf, aucune re-exécution de notebook concernée.

