### PR TITLE
fix(slides,#10950): tranche 6 axe 2 — convert 3 two-cols to grid-cols-2 (FOL, Représentation, CSPs)

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -492,8 +492,6 @@ layout: two-cols
 
 
 ---
-layout: two-cols
----
 
 
 
@@ -504,6 +502,8 @@ layout: two-cols
 <div class="bg-slate-800 text-white px-4 py-2 text-base font-bold text-center">Techniques</div>
 </div>
 
+<div class="grid grid-cols-2 gap-5 -mt-2">
+<div>
 
 **Définition CSPs**
 
@@ -516,9 +516,8 @@ layout: two-cols
 - Exemple
   - Coloration de carte
 
-
-::right::
-
+</div>
+<div>
 
 **Techniques**
 
@@ -538,6 +537,9 @@ layout: two-cols
 <img src="./images/img_036.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Illustration Winograd : ordinateur échangeant phrases et conclusions avec un humain et un robot" />
 <img src="./images/img_037.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Grammaire de la logique propositionnelle : Énoncé, ÉnoncéAtomique, priorité des opérateurs ¬, ∧, ∨, ⇒, ⇔" />
 
+</div>
+
+</div>
 </div>
 
 
@@ -566,13 +568,14 @@ layout: section
 
 
 ---
-layout: two-cols
----
 
 
 
 # Représentation et logique
 
+
+<div class="grid grid-cols-2 gap-5 -mt-2">
+<div>
 
 **Enoncés**
 
@@ -586,9 +589,8 @@ layout: two-cols
 - Propriétés
 - correction, consistance, complétude
 
-
-::right::
-
+</div>
+<div>
 
 **Bases de connaissances**
 
@@ -596,6 +598,9 @@ layout: two-cols
 
 <img src="./images/img_035.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Schéma de sémantique : énoncés reliés par « a pour conséquence » et « causent » aux aspects du monde réel" />
 <img src="./images/img_036.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Illustration Winograd : ordinateur échangeant phrases et conclusions avec un humain et un robot" />
+
+</div>
+</div>
 
 
 
@@ -626,13 +631,14 @@ layout: two-cols
 <img src="./images/img_040.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Réseau sémantique : Mammals, Persons, Mary, John reliés par liens d'héritage et propriétés" />
 </div>
 ---
-layout: two-cols
----
 
 
 
 # Logique du premier ordre (FOL)
 
+
+<div class="grid grid-cols-2 gap-5 -mt-2">
+<div>
 
 - Modélise
   - Objets, Propriétés
@@ -643,9 +649,8 @@ layout: two-cols
 - Sémantiques multiples
   - de base de données
 
-
-::right::
-
+</div>
+<div>
 
 **Exemple: investigation**
 
@@ -655,6 +660,9 @@ layout: two-cols
 - Américain(x) ET Arme(y) ET Vend(x,y,z) ET Hostile(z) => Criminel(x)
 
 <img src="./images/img_040.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Réseau sémantique : Mammals, Persons, Mary, John reliés par liens d'héritage et propriétés" />
+
+</div>
+</div>
 
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2023:CoursIA-2 — prev: MED/guard #12547 (c.481)

# PR #10950 (tranche 6, axe 2) — convert 3 `two-cols` à `grid grid-cols-2`

## Le grain

Tranche 6 de l'axe 2 (#10950 : refactor `two-cols` → `position: absolute`, 38 slides héritées). Convertit **3 slides** du cluster « logique » de `slides/S3-acculturation/slides.md` :

| Slide | Conversion |
|---|---|
| Logique du premier ordre (FOL) | `layout: two-cols` + `::right::` → `grid grid-cols-2` |
| Représentation et logique | idem |
| Problèmes à satisfaction de contraintes (CSPs) | idem |

**Méthode** : remplacement du marker `layout: two-cols` / `::right::` par des wrappers `<div class="grid grid-cols-2 gap-5 -mt-2"><div>…</div><div>…</div></div>` — le pattern déjà utilisé par les blocs convertis (« Sommaire », « Jeux »). La pédagogie côte-à-côte est **préservée** ; les diagrammes de contenu (img_035/036/037/040) restent adjacents au texte qu'ils illustrent. **Aucun changement géométrique** (pas de reflow d'images), donc le risque se limite au wrapper de colonnes.

## État axe 2

- `two-cols` avant tranche 6 : **19** → après : **16**.
- Cumul axe 2 #10950 : **32/38** (tranche 5 mergée, #12371).
- Les 16 restantes sont hors de ce grain (tranches suivantes).

## Validation

```bash
$ python scripts/check_slidev_structure.py slides/S3-acculturation/slides.md
decks scannes : 1 | constats : 0
```

- **Détecteur Slidev structurel : 0 constat.**
- Build : `slides-build-advisory.yml` (CI) validera `slidev build` au push.
- Composition (HORS_CANVAS / CHEVAUCHEMENT) : `slides-composition-advisory.yml` (CI, sert le deck en headless) — aucune reflow d'image n'a été introduit, donc pas de nouveau risque hors-canvas.
- **QA visuel** : les 3 slides converties sont à visualiser — routé vers ai-01 (lane vision) à la review, cf c.399-L5 (les images sont conservées dans leur contexte pédagogique, pas d'overlay pour des diagrammes liés à un texte).

## Ce que je ne fais PAS

- Je ne retire pas les 16 autres `two-cols` (hors tranche), je ne tasse pas en une composite.
- Je ne convertis pas les diagrammes de contenu (img_035/036/037/040) en overlay absolu : ils illustrent un texte précis et restent côte-à-côte. Pour les slides où l'image est décorative (pas liée à un texte spécifique), un overlay serait attendu — ce cluster n'en a pas.
- Pas de changement du thème, de la config, ni du contenu textuel.

## Plank G-VAR

- **G-VAR-1 : TENU** (`MED/slides` = CONTENU — substance : structure du deck améliorée, 3 slides converties, validées).
- **G-VAR-3 : respecté** (c.481 `MED/guard` → c.482 `MED/slides`, genres distincts).

-- po-2023:CoursIA-2 (cron worker, c.482, grain #10950 tranche 6 axe 2)
