### PR TITLE
feat(notebooks,#12417): notebook ML 2.10 — méthodologie HPO grid/random/bayésien (TPE Optuna) + critère d'arrêt

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.10-Optimisation-Hyperparametres.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.10-Optimisation-Hyperparametres.ipynb
@@ -1,0 +1,895 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-001",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003485,
+     "end_time": "2026-08-23T08:20:51.271261+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:20:51.267776+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 2.10 — Optimisation d'hyperparamètres : grille, hasard, bayésien — et quand s'arrêter\n",
+    "\n",
+    "**Navigation** : [<< 2.9-Grokking](2.9-Grokking-Generalisation.ipynb) | [2.13-Analyse-Erreurs >>](2.13-Analyse-Erreurs.ipynb) | [Index](../README.md)\n",
+    "\n",
+    "**Kernel** : Python 3 · **Bibliothèque** : scikit-learn + Optuna · **Niveau** : intermédiaire · **Durée** : ~30 min · **CPU** : < 3 min\n",
+    "\n",
+    "***\n",
+    "\n",
+    "Le tuning d'hyperparamètres est le geste le plus répété et le moins enseigné du machine learning : on le croise partout — dans une recherche de données, dans le pipeline d'un agent, dans un sweep de production. Et pourtant il se réduit souvent à « je lance plein de combinaisons et je garde la meilleure ». Ce notebook montre que le *choix de la stratégie* et *le moment où l'on s'arrête* sont des décisions, pas des automatismes :\n",
+    "\n",
+    "1. comment poser proprement le problème (modèle, budget d'essais, espace de recherche mixte) ;\n",
+    "2. pourquoi la **grille exhaustive** explose en dimension, et ce qu'elle coûte ;\n",
+    "3. pourquoi le **hasard** (random search) bat la grille en dimension ≥ 3 — l'intuition géométrique ;\n",
+    "4. ce que fait réellement un **search bayésien** (TPE/Optuna), consommé, pas réécrit ;\n",
+    "5. le **protocole honnête** : variance inter-essais, gain marginal, critère d'arrêt explicite.\n",
+    "\n",
+    "**Concept-phare** : la malédiction de la dimension et le gain marginal — *savoir s'arrêter* est une compétence, pas une paresse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-002",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T08:20:51.279940Z",
+     "iopub.status.busy": "2026-08-23T08:20:51.279440Z",
+     "iopub.status.idle": "2026-08-23T08:21:00.185545Z",
+     "shell.execute_reply": "2026-08-23T08:21:00.184530Z"
+    },
+    "papermill": {
+     "duration": 8.911594,
+     "end_time": "2026-08-23T08:21:00.186321+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:20:51.274727+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X = (1000, 20), y = (1000,) (classes [497 503])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration : imports, graine aléatoire et jeu de données\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.datasets import make_classification\n",
+    "from sklearn.neural_network import MLPClassifier\n",
+    "from sklearn.model_selection import cross_val_score, KFold\n",
+    "\n",
+    "import optuna\n",
+    "\n",
+    "RANDOM_STATE = 42\n",
+    "SEEDS = [0, 1, 7]          # multi-seed : >= 3 (métrique médiane, bande min/max)\n",
+    "N_TRIALS = 45              # budget commun des 3 stratégies\n",
+    "\n",
+    "# Jeu synthétique : 6 variables informatives, 14 parasites -> le tuning compte.\n",
+    "X, y = make_classification(\n",
+    "    n_samples=1000, n_features=20, n_informative=6, n_redundant=2,\n",
+    "    n_clusters_per_class=1, n_classes=2, flip_y=0.05, class_sep=0.5,\n",
+    "    random_state=RANDOM_STATE,\n",
+    ")\n",
+    "print(f\"X = {X.shape}, y = {y.shape} (classes {np.bincount(y)})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-003",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002214,
+     "end_time": "2026-08-23T08:21:00.191272+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:21:00.189058+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le problème posé proprement\n",
+    "\n",
+    "On veut entraîner un classifieur sur un jeu **synthétique** (6 variables informatives parmi 20, ~5 % de bruit d'étiquetage). L'objectif n'est pas de battre un leaderboard : il est de montrer que la **qualité du réglage** dépend du choix de stratégie et du budget.\n",
+    "\n",
+    "**Pourquoi un MLP ?** Un `MLPClassifier` est volontairement *sensible* à ses hyperparamètres : un réseau trop petit **sous-apprend**, un réseau trop grand et trop peu régularisé **surapprend**. Il existe donc un vrai optimum de complexité — c'est exactement le terrain où un search a de la matière, contrairement à un modèle très régularisé dont presque toute configuration raisonnable donne le même score.\n",
+    "\n",
+    "**Budget.** On s'impose un budget comparable et modeste — `N_TRIALS = 45` évaluations — identique pour les trois stratégies. C'est la contrainte du monde réel : on ne peut pas se payer 6 000 entraînements.\n",
+    "\n",
+    "**Espace de recherche mixte.** Le problème se formule sur 5 hyperparamètres, mêlant continu, discret et *conditionnel* :\n",
+    "\n",
+    "| Hyperparamètre | Type | Domaine | Rôle |\n",
+    "|---|---|---|---|\n",
+    "| `hidden_layer_sizes` | discret | {8, 16, 32, 64, 128, 256} | capacité (levier de complexité) |\n",
+    "| `alpha` | continu | [1e-4, 1] (log) | régularisation L2 |\n",
+    "| `learning_rate_init` | continu | [1e-4, 1e-2] (log) | taille de pas |\n",
+    "| `batch_size` | discret (no-op) | {16, 32, …, 1024} | quasi sans effet ici |\n",
+    "| `max_iter` | discret (no-op) | {100, …, 1000} | quasi sans effet ici |\n",
+    "\n",
+    "Le caractère **conditionnel** (un paramètre n'a de sens que si un autre prend une valeur) apparaît dès qu'on ajoute `solver ∈ {adam, sgd}` : `momentum` n'est échantillonné **que** si `solver == \"sgd\"`. On reverra ce point dans la section bayésienne ; les deux dernières colonnes *no-op* sont là pour une raison précise — ce sont elles qui font enfler la grille sans rien apprendre, et qui expliquent la supériorité du hasard."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-004",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T08:21:00.197303Z",
+     "iopub.status.busy": "2026-08-23T08:21:00.196905Z",
+     "iopub.status.idle": "2026-08-23T08:21:03.599164Z",
+     "shell.execute_reply": "2026-08-23T08:21:03.598128Z"
+    },
+    "papermill": {
+     "duration": 3.406617,
+     "end_time": "2026-08-23T08:21:03.600197+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:21:00.193580+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "baseline (config par défaut) : AUC = 0.8343\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Fabrique de modèle + score CV partagé par les 3 stratégies\n",
+    "from sklearn.model_selection import KFold\n",
+    "\n",
+    "def make_model(p):\n",
+    "    return MLPClassifier(\n",
+    "        hidden_layer_sizes=p[\"hidden_layer_sizes\"],\n",
+    "        alpha=p[\"alpha\"],\n",
+    "        learning_rate_init=p[\"learning_rate_init\"],\n",
+    "        batch_size=p[\"batch_size\"],\n",
+    "        max_iter=p[\"max_iter\"],\n",
+    "        early_stopping=True, n_iter_no_change=10,\n",
+    "        random_state=RANDOM_STATE,\n",
+    "    )\n",
+    "\n",
+    "CV = KFold(n_splits=3, shuffle=True, random_state=0)\n",
+    "\n",
+    "def cv_auc(p):\n",
+    "    \"\"\"AUC moyennée sur 3 fold, GPU-free, mesurée hors des données vues.\"\"\"\n",
+    "    m = make_model(p)\n",
+    "    return cross_val_score(m, X, y, cv=CV, scoring=\"roc_auc\", n_jobs=-1).mean()\n",
+    "\n",
+    "# Espace : 5 hyperparamètres (valeurs de grille -> on indexe le même espace)\n",
+    "HIDDEN = [8, 16, 32, 64, 128, 256]\n",
+    "ALPHA = [1e-4, 1e-3, 1e-2, 1e-1, 1.0]\n",
+    "LRI = [1e-4, 3e-4, 1e-3, 3e-3, 1e-2]\n",
+    "BATCH = [16, 32, 64, 128, 256, 512, 1024]\n",
+    "MAXITER = [100, 200, 300, 500, 800, 1000]\n",
+    "\n",
+    "default = dict(hidden_layer_sizes=(32,), alpha=1e-3, learning_rate_init=1e-3,\n",
+    "               batch_size=128, max_iter=300)\n",
+    "print(f\"baseline (config par défaut) : AUC = {cv_auc(default):.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-005",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003079,
+     "end_time": "2026-08-23T08:21:03.608222+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:21:03.605143+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Grid search : la malédiction de la dimension\n",
+    "\n",
+    "La grille exhaustive énumère le **produit cartésien** des valeurs possibles. Avec 5 hyperparamètres à 5 valeurs chacun, cela fait :\n",
+    "\n",
+    "$$5^{5} = 3125$$\n",
+    "\n",
+    "configurations. Notre grille réelle est même plus grande (6 × 5 × 5 × 7 × 6 = **6300**). Le problème est double :\n",
+    "\n",
+    "1. **Le coût.** Évaluer tout est infaisable dès que le budget est de quelques dizaines d'entraînements.\n",
+    "2. **La couverture illusoire.** Avec un budget de 45 essais sur une grille de 6300, on n'en couvre que **0,7 %** — et surtout, les points évalués sont **structurellement alignés** sur les axes de la grille. Si le bon réglage vit dans une région que les mailles de la grille ne croisent pas, la grille ne le trouvera *jamais*, quel que soit le nombre d'essais.\n",
+    "\n",
+    "**Règle d'or de la dimensionnalité** : chaque hyperparamètre ajouté *multiplie* la taille de la grille sans ajouter d'information. La grille est une stratégie de dimension 1–2, pas de dimension 5."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-006",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T08:21:03.615914Z",
+     "iopub.status.busy": "2026-08-23T08:21:03.615588Z",
+     "iopub.status.idle": "2026-08-23T08:21:03.624026Z",
+     "shell.execute_reply": "2026-08-23T08:21:03.622949Z"
+    },
+    "papermill": {
+     "duration": 0.013706,
+     "end_time": "2026-08-23T08:21:03.625043+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:21:03.611337+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "taille de la grille exhaustive : 6300\n",
+      "couverture avec un budget de 45 essais : 0.7 % du produit cartésien\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Construction de la grille exhaustive et mesure de la couverture\n",
+    "import itertools\n",
+    "\n",
+    "grid = [dict(hidden_layer_sizes=(h,), alpha=a, learning_rate_init=l,\n",
+    "             batch_size=b, max_iter=m)\n",
+    "        for h in HIDDEN for a in ALPHA for l in LRI for b in BATCH for m in MAXITER]\n",
+    "print(f\"taille de la grille exhaustive : {len(grid)}\")\n",
+    "print(f\"couverture avec un budget de {N_TRIALS} essais : \"\n",
+    "      f\"{100.0 * N_TRIALS / len(grid):.1f} % du produit cartésien\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-007",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004333,
+     "end_time": "2026-08-23T08:21:03.634432+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:21:03.630099+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Random search : pourquoi l'aléatoire bat la grille en dimension ≥ 3\n",
+    "\n",
+    "L'intuition, formalisée par Bergstra & Bengio (2012), est **géométrique**. Dans un espace de recherche réel, *la plupart des hyperparamètres n'ont presque aucun effet* — ce qui compte, c'est un petit nombre de directions. Appelons `p` la fraction de configurations « bonnes » (celle dont un tirage aléatoire a une chance de tomber dedans).\n",
+    "\n",
+    "- **La grille** fixe une maille par axe. Si une dimension est *importante mais à maille grossière*, la grille la rate ; et elle gaspille la grande majorité de ses essais à faire varier les dimensions *sans effet*.\n",
+    "- **Le hasard** échantillonne toutes les dimensions **simultanément** : chaque essai teste un point de l'espace complet. Pour toucher la même région « bonne », il faut `log(1 - tolérance) / log(1 - p)` essais — avec `p = 0.1`, environ **28 essais**, indépendamment du nombre de dimensions *total*.\n",
+    "\n",
+    "C'est pourquoi le hasard n'est pas plus bête que la grille : il est **plus robuste à la malédiction de la dimension**, car il ne s'encombre pas d'un maillage qui se dilue.\n",
+    "\n",
+    "**À vérifier par l'expérience** : ce que dit l'intuition (random ≥ grid) se *mesure* dans la section 5 — et il faut être honnête si le problème ne la reproduit pas.\n",
+    "\n",
+    "> **Référence.** Bergstra & Bengio, *Random Search for Hyper-Parameter Optimization*, JMLR 2012 — l'article qui formalise l'argument de couverture : en dimension élevée, l'échantillonnage aléatoire alloue le budget *par dimension importante*, là où la grille le dilue sur le produit cartésien.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-008",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002854,
+     "end_time": "2026-08-23T08:21:03.640431+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:21:03.637577+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Bayésien (TPE/Optuna) : le search qui *concentre*\n",
+    "\n",
+    "Le search bayésien ne tire pas au hasard : il **modélise** la fonction `score(configuration)` à partir des évaluations déjà faites, et propose l'essai suivant là où le gain attendu est maximal.\n",
+    "\n",
+    "L'algorithme **TPE** (Tree-structured Parzen Estimator) construit deux distributions : `P(score | config)` pour les configurations *bonnes* et *mauvaises* observées, et propose un point qui maximise le rapport des deux. On **consomme** l'implémentation (ici Optuna) au lieu de la réécrire — la réécriture serait le signe d'un problème déjà résolu.\n",
+    "\n",
+    "**Espace conditionnel.** Optuna gère nativement le cas « `momentum` n'a de sens que pour `solver == sgd` » : on n'échantillonne le paramètre que *dans* la branche. C'est le troisième ingrédient (conditionnel) d'un espace mixte complet, et là où une grille produit des combinaisons *invalides* qu'il faut ensuite exclure à la main.\n",
+    "\n",
+    "Le code ci-dessous fait tourner, pour chaque graine, une étude TPE avec le **même** budget `N_TRIALS` et **le même** score CV."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-009",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T08:21:03.648489Z",
+     "iopub.status.busy": "2026-08-23T08:21:03.648084Z",
+     "iopub.status.idle": "2026-08-23T08:22:16.180803Z",
+     "shell.execute_reply": "2026-08-23T08:22:16.180203Z"
+    },
+    "papermill": {
+     "duration": 72.53802,
+     "end_time": "2026-08-23T08:22:16.181700+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:21:03.643680+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- scores finaux (médiane sur graines) ---\n",
+      "grille                 final médian = 0.9603\n",
+      "hasard                 final médian = 0.9544\n",
+      "bayésien               final médian = 0.9623\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- démonstration espace conditionnel (15 essais) ---\n",
+      "essais avec solver=sgd (donc momentum échantillonné) : 4/15\n",
+      "meilleur paramètre : {'h': 256, 'alpha': 0.021427933232410643, 'learning_rate_init': 0.0033459258875204088, 'batch_size': 64, 'max_iter': 500, 'solver': 'adam'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Les 3 stratégies sur le même budget, multi-seed (GPU-free)\n",
+    "optuna.logging.set_verbosity(optuna.logging.WARNING)   # on garde nos summaries, pas les logs\n",
+    "\n",
+    "def sample_random(rng):\n",
+    "    \"\"\"Un point aléatoire de l'espace (toutes les dimensions à la fois).\"\"\"\n",
+    "    return dict(\n",
+    "        hidden_layer_sizes=(int(rng.choice(HIDDEN)),),\n",
+    "        alpha=float(rng.choice(ALPHA)),\n",
+    "        learning_rate_init=float(rng.choice(LRI)),\n",
+    "        batch_size=int(rng.choice(BATCH)),\n",
+    "        max_iter=int(rng.choice(MAXITER)),\n",
+    "    )\n",
+    "\n",
+    "def best_so_far(sequence):\n",
+    "    \"\"\"Meilleur score atteint après 1, 2, ..., len(sequence) essais.\"\"\"\n",
+    "    best, curve = -np.inf, []\n",
+    "    for s in sequence:\n",
+    "        best = max(best, s)\n",
+    "        curve.append(best)\n",
+    "    return np.asarray(curve)\n",
+    "\n",
+    "def objective(trial, conditional=False):\n",
+    "    \"\"\"Espace mixte : continu (log), discret (categorical) et conditionnel.\"\"\"\n",
+    "    p = dict(\n",
+    "        hidden_layer_sizes=(trial.suggest_categorical(\"h\", HIDDEN),),\n",
+    "        alpha=trial.suggest_float(\"alpha\", 1e-4, 1.0, log=True),\n",
+    "        learning_rate_init=trial.suggest_float(\"learning_rate_init\", 1e-4, 1e-2, log=True),\n",
+    "        batch_size=trial.suggest_categorical(\"batch_size\", BATCH),\n",
+    "        max_iter=trial.suggest_categorical(\"max_iter\", MAXITER),\n",
+    "    )\n",
+    "    if conditional:\n",
+    "        solver = trial.suggest_categorical(\"solver\", [\"adam\", \"sgd\"])\n",
+    "        if solver == \"sgd\":                      # paramètre conditionnel\n",
+    "            p[\"momentum\"] = trial.suggest_float(\"momentum\", 0.0, 0.99)\n",
+    "    return cv_auc(p)\n",
+    "\n",
+    "grid_curves, rand_curves, bayes_curves = [], [], []\n",
+    "for seed in SEEDS:\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    idx = rng.permutation(len(grid))[:N_TRIALS]              # ordre de parcours de la grille\n",
+    "    grid_curves.append(best_so_far([cv_auc(grid[i]) for i in idx]))\n",
+    "\n",
+    "    rand_curves.append(best_so_far([cv_auc(sample_random(rng)) for _ in range(N_TRIALS)]))\n",
+    "\n",
+    "    study = optuna.create_study(\n",
+    "        direction=\"maximize\", sampler=optuna.samplers.TPESampler(seed=seed))\n",
+    "    study.optimize(lambda t: objective(t), n_trials=N_TRIALS, show_progress_bar=False)\n",
+    "    bayes_curves.append(np.maximum.accumulate(\n",
+    "        np.asarray([study.trials[i].value for i in range(N_TRIALS)])))\n",
+    "\n",
+    "grid_curves = np.asarray(grid_curves); rand_curves = np.asarray(rand_curves)\n",
+    "bayes_curves = np.asarray(bayes_curves)\n",
+    "\n",
+    "def report(c, label):\n",
+    "    final = np.median(c[:, -1])\n",
+    "    print(f\"{label:22s} final médian = {final:.4f}\")\n",
+    "    return final\n",
+    "\n",
+    "print(\"--- scores finaux (médiane sur graines) ---\")\n",
+    "report(grid_curves, \"grille\"); report(rand_curves, \"hasard\"); report(bayes_curves, \"bayésien\")\n",
+    "\n",
+    "# graine qui illustre le conditionnel (démonstration, hors comparaison)\n",
+    "demo = optuna.create_study(direction=\"maximize\", sampler=optuna.samplers.TPESampler(seed=0))\n",
+    "demo.optimize(lambda t: objective(t, conditional=True), n_trials=15, show_progress_bar=False)\n",
+    "n_sgd = sum(1 for t in demo.trials if t.params.get(\"solver\") == \"sgd\")\n",
+    "print(\"\\n--- démonstration espace conditionnel (15 essais) ---\")\n",
+    "print(f\"essais avec solver=sgd (donc momentum échantillonné) : {n_sgd}/15\")\n",
+    "print(\"meilleur paramètre :\", demo.best_params)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-010",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002537,
+     "end_time": "2026-08-23T08:22:16.186897+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.184360+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Les trois courbes superposées\n",
+    "\n",
+    "La figure qui fait la leçon : **meilleur score atteint** en fonction du **nombre d'essais** (médiane sur les 3 graines, bande min–max). Chaque stratégie consomme le **même** budget ; seule la manière de choisir les essais change.\n",
+    "\n",
+    "* Si la **grille** monte lentement, c'est qu'elle explore un coin structuré de l'espace — et que les essais passent sur des dimensions sans effet.\n",
+    "* Si le **hasard** la dépasse, c'est le mécanisme de la section 3.\n",
+    "* Si le **bayésien** monte le plus vite, c'est qu'il concentre — il propose tôt de bons points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-011",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T08:22:16.192493Z",
+     "iopub.status.busy": "2026-08-23T08:22:16.192323Z",
+     "iopub.status.idle": "2026-08-23T08:22:16.360102Z",
+     "shell.execute_reply": "2026-08-23T08:22:16.359416Z"
+    },
+    "papermill": {
+     "duration": 0.171766,
+     "end_time": "2026-08-23T08:22:16.360914+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.189148+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3kAAAIcCAYAAABLvmeIAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAvVhJREFUeJzs3Qd8G+X5B/Df3Wl7xomz904gAxISwt5hr5ZRoIQVVhkl7BYI0LIhUEbL3pRRNn82aVIIhBUgjJCE7D2cxNuad//P88qyJVmyJVtOZPv3pWqsdTqdXp3uued9n1ezLMsCERERERERtQv6jl4BIiIiIiIiyhwGeURERERERO0IgzwiIiIiIqJ2hEEeERERERFRO8Igj4iIiIiIqB1hkEdERERERNSOMMgjIiIiIiJqRxjkERERERERtSMM8oiIiIiIiNoRBnlEREQ70Keffoqbb74ZZWVlO3pVstKqVatw44034qefftrRq0JE1GYwyKMW22+//dQlYsWKFdA0DU8//XTdbfIDLbdR2zN79mz12b366qvb7bXk32zXltY1XqLvKO0YK1euxLHHHou8vDwUFBS0ubZ45513Yvjw4TBNs1WWHwgEcOKJJ+LHH3/ETjvtlNJzzjjjDPTv3z/mNtk+8jtEqZHtJ9uRKNvbyO67746rrrpqR69GVmKQ187JQZz8uMllzpw5De63LAt9+vRR9x955JE7ZB2Jtrdbb70Vb775ZsaXKz940Sc8qPneeOMNTJ48GT179oTT6UTv3r3x+9//Hj///HNGll9dXa0O+lsrMHrvvfeaDCokgDnppJNUu7nsssvQ1pSXl+OOO+7A1VdfDV1vncMJOXgzDAMvvPBCq70GtY533nlHfWYbNmzY0avSJqxbtw6nnXYahg0bpk76FBYWYsKECXjmmWfUsRolJvufhx56iO0sAVuiG6n9cblc+Pe//4299tor5vb//e9/WLNmjTqIaq6PPvooA2tItH2DPAkYJIPSEfXr1w81NTWw2+3IVtI1r1OnTrj00kvRpUsX9QP+5JNPqoOeuXPnYsyYMS0O8m666Sb1d2sE5hLkyYFHY4HeL7/8gpNPPlm9x5bYZ5991OfpcDiwPcnnEQwG8Yc//KFVll9aWqrawNtvvw23292iZcn2sdl4yJOqRYsWtTiofvfddzFu3Dh07949Y+vVnpWUlKjjMflt6tu3rzoJ9PHHH6uTQPJ5yO9We2sjmXDMMccgPz8f//znP1W3d6rHPV4Hcfjhh+M///kP7r///pgfOgn8ZCcsO5fm2t4HFunwer1q/bJhR5SIHCBJN6ds3obU/kjmXk78ZLMbbrihwW3nnHOOyuj961//wsMPP7xd16eqqgo5OTkZXebYsWPVpaVk/7YjPs+nnnoKRx99dKu9tmQyErWD5sj29p6IHNxL1+od0Q23JSd+o090nHXWWRlZn/aisf3I6NGjG3zWF110EY466ih17Pa3v/1NZbVbgxyH+P3+tL4nmWgjmSD7PwmMn332WXXijkOD6mXnkS9lnJxp3bJlizorFCFfaBlndcoppyT90t93331qHIR88bt164bzzjsP27Zta3RMXjqef/55FWTKWdqioiJ1Vnv16tUp9fuOf93IuJSXXnoJ1113HXr16gWPx6O6FCUjj5XXl64RciZo1KhR+Mc//tHgbLJ0pZL1iHQbO/3002MC402bNuHss89W20i2lWQZpItFonFQd999t9qugwYNUstbsGCBun/hwoVqRyXbQZYxfvx4dQa7MXKmTx5/5plnNrhP3rcs54orrqi77YEHHlCfp2wXOUMuryGBfipCoRD+8pe/qLOy8iMlB3fN/ayEnLGUTJosq2vXrmob+3y+hK8tGZGBAweqdiKZnM8++yzhMuX506dPx+DBg9W2la7I0t0rernyGcgPrXw+ka7MTY0rSGddm/s9+vbbb1X3RMlayfscMGBAgwOkptrr1q1b1ectt+fm5qrHHHbYYZg/f36TY/IkUybtSNq3bLsePXqoM6Ty2Gwh217arnwnm9LY9pT3VFxcrP6OHBREj9mS9iDbb+nSpeoEmWzvU089Vd0nbe+EE05QZ9ojbUzag2SKIuT50mZFZNnRBx6ptgl5nKyTdFmV973//vur/UX89yzZmLyvvvoKhx56qBrrJ8/fd9998fnnn8c8pqKiAn/+85/r9m+yjQ8++GB89913jW7f5cuXq3FyBx10UNL9XOR7K699yCGHqP2FdDuTg1VpZ/K5SBuTdhvv/fffx957762+c7L9jzjiCJX5jCfdrnfeeWe1HeVf6eabSPyYPBkLeeGFF6qucbIenTt3Vp9rfHuPDHmQ7TZt2jTVbmSdjjvuOGzevLnZ692aIu3hlVdeUe1bfgtlXeT3RYr7yL5LPnP5rKWdy/c+fn8W38bS3Q6SiZfPW95/ptZJTioccMAB6jHSVkeOHKlO+ET773//qw76408OyO+cvH784+P99ttv+N3vfqd+56RNSTuV45JIUaTGxjPHt7FILQL5zspxlvzmxvemSoV8FtLzQI7ZmiLbWX7XZd3lGOORRx5JWBNBrksAKd2gZT8k2/ODDz5Q98l3d4899lDfCfluyG9OojH5LW0jqXxXUv1dkn2WfKd/+OGHFLZox8FMXgchX8ZJkybhxRdfVAd9kS+Y7LhkByZnieLJQYd8aeULdskll6gf9QcffBDff/+9+hK3tKvXLbfcguuvv14Nqpcz9LITkCBEuh7Ja8hZ3OaQAwjJjMnBrvxIJMuSScArwe+BBx6oxpWIX3/9Vb23SPepyspKtROS2+UAcdddd1XBnQRfcuAvB5BycCfBxpIlS9ROUw4mJWsqOz85GI3viiU/VJJhPPfcc9VOS4I02bHtueee6ofvmmuuUTs9+TGUwOK1115TO8lE5DOQ+15//XW1M49+r3LwI+9fPl/x2GOPqc9RflRlnWQd5CBNDgSTBfrxn5fswKX/uwS1cpAqB3iyU023K5VsM9nuUjVP1kkOYp977jn1Ax1PfpRlu8rnIAfTsnOX7SI/mLLjjz4glsBTxp7Kth0xYoQ60Lj33nuxePHiujF48jrS3iRYlMcJ+THMxLomksr3SLanHATLj6J8/tL25X3K55pOe122bJl6n3KwKu1w48aNql3Iwb0caMi6JyMHNtIOL774YrW/kHWS15T3HV/EYnuS75CczJAfe2lzcvJCtkFjmtqecru0qwsuuEB9f44//vi6M+nRWXYJEuWgTA56JFAR8t2WAy55rhwEff3112q/JfsDuS/ymcv4Gtl+0laau2+99tprVWETOZMv6yLBuvwr392mSPuUfb0coMmJDznwjRwkS6Aq7V+cf/756gBOvmNy0CwnA+U7JG1L9nfJfPHFF+rfZI+Rg0c5KJX2JEGcvA/Z18vry4Go7EdknynbTvbV0vUzQrbZlClT1HuVti7bWz4v+SxkG0XaowwVkHYr633bbbepdY8cEDblm2++Ue9B9o/yeGkf8hqyL5fvSuTzjpD3Ifsc2ZbyWGmLss1efvnltNc7Edl/xQe7sv+Wth/f00aC9lR+f2WbyL5ZvgORbS3Pk7YgJxTk4P/LL79UbVH2F6lkTVPZDpEsngRjEnBkap1kW0pAIvt56ZEkY/4kUJdt96c//Uk9RtqX3CavI78T0j7Xr1+v1lt+r6S9JyPtVT472e7yeAn01q5di//7v/9T+6HmFkaS/fGQIUNUd8tUxtbJb46ciJTjDxlSI99bOX5r6ndW2pic1JFASAJpOTEr3RcjJ7QS7SPkOEM+PzmWibRPOXEo21hObMk2kZOL8h5kO0SC9sZk8ruS6u+S7OeE7D932WWXJtexw7CoXXvqqadkj2J988031oMPPmjl5eVZ1dXV6r4TTjjB2n///dXf/fr1s4444oi653322WfqeS+88ELM8j744IMGt++7777qErF8+XL1GHntiOnTp6vbIlasWGEZhmHdcsstMcv/6aefLJvNFnO7rNuUKVMavLf41501a5Z6jYEDB9a9x8ZceumlVn5+vhUMBpM+5oYbblDLfP311xvcZ5qm+ve+++5Tj3n++efr7vP7/dakSZOs3Nxcq7y8PGa7yGtu2rQpZlkHHnigNWrUKMvr9cYsf4899rCGDBnS6Pv48MMP1XLfeeedmNsPP/xwtS0ijjnmGGunnXay0hXZrr169ap7L+KVV15Rt//jH/9I+7OKbDNZRkRVVZU1ePBgdbu8pvD5fFbnzp2t3XbbzQoEAnWPffrpp9Xjopf53HPPWbquq7Yb7eGHH1aP/fzzz+tuy8nJSbieiaS6romk+j1644036r6nLWmv0n5CoVDMbdLunE6ndfPNNyf9jm7btk1dv+uuu6xsM2zYMLVucpHv03XXXdfgPcZLZXtu3rxZPUb2TfGkbch911xzTYP7Eu1bbrvtNkvTNGvlypV1t/3pT3+K2eel2yY2bNig9oXHHntszONuvPFG9bjo9hv5jkbaouw7ZL8xefLkuv1UZN0HDBhgHXzwwXW3FRQUqHVNl3wO8poVFRUxt0faVnFxsVVaWlp3+7XXXqtuHzNmTMx3+Q9/+IPlcDjq9n2yvMLCQmvq1Kkxy5XtIesaffvYsWOtHj16xLzORx99pF5H9kXR4j/rRJ/j3Llz1eOeffbZBr+hBx10UMy2vOyyy9RvWOS101nvRCLbLZVLY/uc6Paw8847q9+i6G0t7fSwww6Lebz8VsVvr/h9earbIWLvvfdO2EZbsk6JPjNp49G/c9H7Z/m9k3Ylxzay74z+fiby/fffq3X8z3/+k/QxiY5vkrWxyHGPvMd0yP4k+vOW44NVq1Y1+byjjjrK8ng81tq1a+tu++2339R+JH5fJNfl9/KXX35psJz47Syfl3xuBxxwQEbaSKrflXR/l2Q/csEFF6T02I6C3TU7EDmLKmeI5GyMdNGRf5NlcOSMtJy1khS4nEWMXORsiXSlmDVrVovWRc6oy9k3Wafo5cuZMznj1ZLly9mhVDJLcnZfzpZFd2GNJ1k06XqZKJMW6f4gZyxlvaOLD8iZSTlDHzkTF03OTEWfWZOzt3JGTbaFfC6RbSFnpeUsl3QfkbOJyciZSzkLF32WTM6IyvuSyn3R71eyDXIGuzmki6p0qYiQjKCcMZT3ny55jjxXlhEhZ84jmbXoLneyHaZOnRozllTOMMqZwvg2K9k7Kece3aZk+4jmtqlU17Ul36NI1lq+k3LmvrntVTLDkfGnchZXtp28jnRJa6z7nXxfJAssGZb4LoM7mpzFlm5EMqhePl/Zh8l7a0wq2zMVkq2LF71vkc9DPk/p2iTHTXIGOlNtYubMmSqbKFmJaHJGuymSXZf9huzfpQ1EXkPWV7KgMi9fZMoD2VaSzZfMYzpkufKdlHVORM78R2c+Jk6cqP6V6oHR32W5XbIFkX2ctG/Jmsj+NHr7yFgkeWxk+0h2Rt6n7O+jX0e2q2T2mhL9OUobkfcj3bxleyT6rsj3PbrLm/QskHYoXcTSWe9k5DdElhF9kWy0ZJfjb0+16JDss6MzfrIe0k7ju4HL7dK1UtpbU5raDkK2gxRHSpT1ack6RX9m0gtJtq/0UpAeDNFzTMr+WTKBko2WnkFSAEZ6dEgX68ZE2tGHH36oMkuZ0lj2MBFpQ/I5SxfTyDFadHfwROQz+OSTT1T2MrrHhrTpSO+teLLtEn1Xorez/B7ItpXPuaku3Jn+rqT7uyTHBC2pL9EesbtmByKBhXRXkB2H7MDkSxd94BpNDhDkiy3dLRKRlHlLyPJlxy4BXSIt6QoqXTxSIQdP0lVBdoDSTVJ+UCXQku4OETImR4KyxsiOS95HfHEXOSCN3N/Y+kmXFdkW0nVVLsm2t6xjInLAJOson6t0M5EDfQmiI+XZI6R7lPwISDct2fHL+5UfEOkmmor4z0p24rKc5ozZkm0iz40fJyDBSPzjhDw2/j3Hd32SNiU/6sm6pjS3zaa6ri35HsmPrXyG0sVGDkaky5j8WMvnExncnkp7lQN36WojAZF0AYwOhqRrYTLyGtJl5vLLL1fjw2TeIZlSRQ7IGquMJwcezZ3AW37AU+n+JN2UIqRrXeR7JV0ok0llezZF2liibn/STUi6kEmX7fgDj1S2RaptIlnbl+7d8Sc4Er2GkAAoGVkHWY50o5THydhCCTRlDKJ87jKWriXiD6gjn7W8TqLbI9sysu6RkzPxZJxp9PZJ9BvS1EmNSNuVLn1yEkECzOhudIk+x/j3E/kM0l3vZGQMVfz4RhmzLvv0+Ntb4zOQfYe878b2E6lsh0iQJGQflcl1kq540gVQAsj4IEweF70/kd81OUkj40LlZGkqBWDkt1nGks2YMUN1N5bgRLotyomJ5nbVjCw33erHchESCEnQJG1AqlkmO4Et+w1p0/H7C5HotsbWS06O/f3vf1cnUeLHs6ciU9+VdH+X5DvMoiuxGOR1MHKQI1kRGd8iB4vJxr3JzlUOQmRHl0iyA+lUyfLlyyjjAhNVi4o+O5zsSysHsImem+r4MHl/shOTHyRZD7nID77sQOKLpmRS/PpFzqjLuBT5MUok2U46+uBXxl7Je5CDWQkGJKMVfcZXDo7lR0J24JIZkSylBANywBopJd9S6X5WmSTbUQqOyA90IvEHEdtDqt+jyGTzMhZFxplIm5SDknvuuUfdJt+HVNqrjPmQEwXyXBmbKgGBnHyQggZNTVYtj5GxXzKmT15DliMHwZJlTjbGQbLHiYr+pEICi3QnY5eDBTkwkO3ZWJCXyvZsSnRWNLodS6ZIsu9y0kS+YzJ+VoIEGYObyoTgrb1vjbyGuOuuu5JW74xsAzlRIAezUrBExrjJc+TASk4UJcsACDnwliyL9D6IzvBHJPu+J7s9EmRF1l3G7CQ6kMvUNAiSEZXvj7R7OZEgB/HSbmRfmuhzzJb1TkdzP4PmLDP6udL7QYKsRIFRc9dJTrhKFlq+c7KPl/25ZHnkteRETvxnJsFJpBCRPFeCwvhxlonIPkK+y2+99Zb6PkiPHNkPyn5DTvo09huXTEun/5CT8TKmXjLwyY4RmiPResl4XQlsJQMqxwfSi0VOust3JdUibZn8rqTzuyTZQenVRPUY5HUw0u1QBv3LDit+oHQ0KUQhWR/ZUbd0B5Vs+fKFlzNJQ4cObfLALlE1PTmT29KzzfIjITsQuciOR7IlEizJjkQCK1nPpiZfljNuUsBEnh99UCjVMiP3NybyHmRH2twztrJDlp2xfKYycFl2gH/9618bPE4OSCW7JxfpIiUFJ6SgihR4aKp0cuTsW4R8fpKFjC5WkepnJdtEtmv8mTcJQqNFtp28jlQWjJCDS8kgRr+2fFZSmEIOBJo6m5fO2b5U1zUT3yM5UykX+UzkB1W6pcqgdykUk0p7lcBGttMTTzzRrB8/WV85ayoX+bwlQJCDHskoJCIHHI11H21MY0VgGpNO9rCx7dmcM75SyEeK+EhQLcF1RKJtkGz5qbaJ6LYffcZduhU21XUpUkhIzoinsk+RfYe0JblIRkCKVcg2ayzIk4NtIRnj6O9hS0XWXQLhxtY9sn3i90upfjfluyInGqR9R0hBm1Qqt7Zkvds72U/KScToqs6ZICdrJHCTDHp0pihZN1jJ+EnPDjkZJCdkpNBLogJzicjJQrlIlW4pziPfVZmyRbJbkaxUfDuJ77GTSZGumo3t96TdyW+47C/iJbotGTn5K8uRgCq614MEeZmS7nclld8lOdEmxzSRnh4UxjF5HYycvZUKRlLBSg4Uk5Gzu3JmSrIB8eQAu7k/hBESXMjZHskgxZ89lOtyIBP9BZegNLp8sGSj4sv3pyv6NYQEaJGDlUgXBenyJYFDorLckfWW7k2SGY0OmmUbSdUw2d7SdawxsqOT7mRysC7jTOIlKj2cbJ4Y+SGUs2Py+tFdNRO9XwkYpD++vI9Uxi3JHDRy1j76IEnWN/pAMNXPSraZjAGKLsssZ1offfTRmMdJZTbJGMhZzOixGZIFiT/QlTYrO3p5bLJqZdHBbqptONV1bcn3SN5L/PcgkoGJtMVU2qt8p+KXI2PAGhvTGXk/8RUb5bOUDE1jU0VIcCA/0s25NDVuKlH3WgnsZaxafMW+eKlsz8hZ/XT2ZZEz1NHLlr/jp10Rkbmw4pefapuQkxVyRju+5LtU4WyKdLuUz08OcGVccLJ9iqxH/IGj7I8kAG9qipBIN1oZN5tJcuJAglPJSifaL0XWXdqefKYScEe/Bwm4I9PSNCbRd0X22U2N92zpeqdDMt07Yo68lpAx3/LdTaUKYzoSfffkc08UfMgYU2n7kgWSwODKK69U35v48fHxpHJv/LhECfZkXxv5PshnLCfMJKsWTbJeLZWsjchJOzlp1Fi1W9k+sl+VjFf0+FoJ8KTXR6pkOfJa0d8D2e9GqlNnQqrflXR+l+bNm6f+lfHRVI+ZvA6osXEaERKYSMZP0uLSRUz61kumSc6iyEGjHNQkG8+XCvmiylkxySBFSuLLF1fOCktAJX3QI2cC5ay7HGDL2CM5QJKuF3IGp7Gy96mQ5Uq3K+n+Jd0w5Eyc/MjLgUPkbJD8OMhrSxEB6e4lB0/yHDmbKGf2pDukrKsEaNLFQ3Y0MlZMniPjB6R0cKKuTPFk3IBk4OQHRbrTStZLyt/L2AMplhI/z1kiEtTJ+ssZTFlO/Bkt+Qyla4SclZT+7XKWU3745Mc4lXWUrn+yjtI9T9ZN3ptkj2R9o7dpKp+VPEdeW7Ihss3kgE2C0/juNBKIygkJ6Voln5MsU9qLHPzIMqOzJX/84x9VN1UZ5C5nd+V9yg+VZFTldjkzGQkO5HOUbIp0+5EDWsmURApDxEt1XVvyPZIDVTlIkEy7vC8JpiVYlR9CCTJTba8yXkFKZstnJD92knmSgLipjLdkpySokO0rwZcEF/I9lM85MgXH9iZtWNZJ3p+cPZdtJgc7clBw++23N/rcVLanZNHkvcrJGelNIO1b5lmTS2PZK1me7JskcJblyZnvRJm1SElv6e4lBzVy8CTbMtU2Id9RmRpDzlhL9yn5Tsl+QA7Y5CCzsUykHJQ+/vjj6gSMlJyX9iDjOGWd5bsh6y0nhGS7SFuS15N9mZyUku+FHKhHZ7gSkTYl20oen8kJr2XdJLCV77Mc1Mo2ky6sMhZSCmjI9zoS6Mo2lP2X7JdkHeT7EZkLNFFwG02+K/I9li6F0g5kXyvvpakxaZlY70TkJFSyOf7iSZdhaR/ZSN6r/AamUvwmHfI9ifRkkO+PfL7ynZaTEtEnRyUokGMcGasp2WghJ5Olvcv3QPaJySYjlx4wUupffu9lnyABn7QR+e5Gj82XfbHsg+Rf+U2RgE/2oS0l6yvHDfJdl2yltGfZv8j3UX4Dmxq2Ib+V0sU0Mh5Rfv+kzcn3NNX54+T7JL+Lsg4yvEcCdjk+kdeWHkuZkOp3JZ3fJTm5I9uM0yfE2dHlPWn7TaHQmPgpFCIeffRRa9y4cZbb7VbTL0iZ/6uuuspat25di6ZQiHjttdesvfbaS5W0l8vw4cNVOe9FixbFPO6ee+5RJfylFPyee+5pffvtt0mnUGis/HG0V1991TrkkEOsrl27qtK7ffv2tc477zxr/fr1MY/bsmWLddFFF6nXl8f17t1blQ0uKSmpe8zGjRutM8880+rSpYt6jGyn+BLLke2SrBzw0qVLrdNPP93q3r27Zbfb1esdeeSRaj1TISWL+/Tpo17j73//e4P7H3nkEWufffZRUxLIdhw0aJB15ZVXWmVlZY0uN7JdX3zxRVUGXbaXtAdpL4lKUqfyWQl57tFHH61KPst2kykCImXk40uE33///aqNyjInTJigpkOQdnnooYc2KPV8xx13qNLZ8thOnTqpx910000x73PhwoVqW8j7iC9Hn0g665pIU9+j7777TpXZljYo6y3bWD572XbptFcpF3755ZersvLyWrL9pSx8U99RacvyvZPvn3wPpYz1xIkTY6aN2N5knzF+/Hj1GUoJ8J49e1onn3yy9eOPPzb53FS2p/jiiy/U5yLbM7r8ubQH2Q6JLFiwQJUIl+kcpC1Iue/58+c32OfJVBcXX3yxmkpASsTH7/9S2bfKMq6//nq1T5DHSQnzX3/9VX2Hzz///KRTKESXhD/++OPrvvPyHTrxxBOtmTNn1k1RIvsAmdZA1kHes/z9z3/+00rFjBkz1HaILrmebD+XbP+c7DdKHi/l8aUtulwutb8644wzGnyG8hsyYsQI9f5GjhyppruRz6+pKRSkPHtkny3vQV5L9gvJysInWr9E2zzV9d4eUyikuq0jv88yrUhEc7eDfGcvvPDCVlmnt99+2xo9erTarv3791f7+ieffFI9TrZfdLn+r776KmZ5sv1lP9JYif1ly5ZZZ511lvrM5DWKiorUNFOffPJJzOOkvZ999tnqM5bvjXynZFqkZFMoRL+Hxsj0H7Kfkn2dHAPIsmUfLtsoekqCxsh3e5dddlH7NHkfjz/+uPpNkPcTTdYr2dQpTzzxhJqCRb5T8psgr5/oGK61vyup/i7JlDrymyfTulAsTf4vPvAjIspmMh5NzvxJt99E3TOJ2ivpzimZTekJkWjc7fYk3eUkoycVOs8+++wdui6040mGRXo6SBf9SMacdjzpKSUTiicav9oeSFdSyTpKzyFpf1SPY/KIKKtJ95v4c1EyPlC6sshYRqL2KtHcWNJNWmRD25eujldddZWqyJlKZVFq3yTol2rN0UWyaMfuMySwkwqk2bC/aC1SDVi62TLAa4iZPCLKalJ44LLLLlPjJGS8jMx/JWOzZByajJGTcRpE7ZGMPZWLZEVkvNycOXPw4osvqvFJkbnIiIgiJNCR+gCSYZdx2zL2TYqUfP/990nnJab2i4VXiCirySB+mRNJyl9L9k4KZEgRFBn4zgCP2jOpnirFBqQ7pFT+ixRjka6aRETxpGCKnAiSit8yBYJUwZUqlgzwOiZm8oiIiIiIiNoRjskjIiIiIiJqRxjkERERERERtSMdbkyeVABbt26dmvy5sclkiYiIiIiIsomMtKuoqEDPnj2h68nzdR0uyJMAT4o4EBERERERtUWrV69G7969k97f4YI8yeBFNkx+fn7GsoObN29WkzM3FlET7Shso5Tt2EYp27GNUrZjG+0YysvLVcIqEtMk0+GCvEgXTQnwMhnkyYTNsjx+qSgbsY1StmMbpWzHNkrZjm20Y9GaGHbGFkBERERERNSOMMgjIiIiIiJqRxjkERERERERtSMM8oiIiIiIiNoRBnlERERERETtCIM8IiIiIiKidoRBHhERERERUTvCII+IiIiIiKgdYZBHRERERETUjjDIIyIiIiIiakcY5BEREREREbUjDPKIiIiIiIjaEQZ5RERERERE7QiDPCIiIiIionaEQR4REVEWOPzww7Fo0SL193777Yc333wz4eMau68x//d//4fhw4djyJAhOP7441FeXp7wcRs3blT3jx49GiNGjMB9991Xd9/TTz+NgoICjB07Vl3233//Bs+vqanByJEj1f3xLMvCAQccgMLCwrTXn4iIUscgj4iIKAu89957GDZsWKssu7KyEmeffbYKDn/77Tf07NkTf/vb3xI+dtq0aSpI+/HHH/Htt9+qwO6bb76pu18Cux9++EFdZs2a1eD5V199Nfbcc8+Ey7733nsxaNCgDL4zIiJKhEEeERHRdjR37lzstddeGDNmjMqWvfXWW+r2/v37q8ApYubMmdhtt90wePBgXH755SoLFq+iogJTp07FhAkT1LLOPfdc+P3+Bo97//33scsuu6hMnrjwwgvx4osvJly/+fPnq6yiyMnJwT777IPnnnsupff2ySefYO3atTj11FMb3PfLL7+oIPOaa65JaVlERNR8thY8l4iI2qiAGcDysuVYvG0xSr2lO3p1VABTUVmBvC150DQN7VVlaSWuPvpqXHLvJRg2bhhM08T68vV4fsHzqApU4d2l7+Jnx8/YWL0Rm7/ZjCsfvxKhYAi3TLkFNd1qsMeRe6j7Zq+ejcoFlXhi+hMYtuswXHLZJWobyvUpf5mCI846IuZ13/vmPfjz/ep1hK/Gh3Xr1+GZH5+BYTNiHttpUCdMf3A6/pj/R7W+/3nnP+jRv4d67hdrv8DM/81Ev+H94HA7cOjph2Li5InqeVXlVbjtkttw5SNX4uOlH2Obd1vd6wUDQdxyxi045+Zz8Payt1X7i9zXVrSnNmrJf5ZV968JM/a6JbeY8sC6++S26MfLfZlaj0Svn+g+dXuC9aZaFuD1eeFyuoC23UTVZ9zkY2o/+/j2LMzaNprKcpqiazqu3u1q9MjtgbZEszrYt0PGIMh4grKyMuTn52dkmfIjvWnTJnTt2hW6zuQoZZ+22EbVQUbUD3rkusjETrsjKfOVYUnpEvy27Tf8Vvqb+lcCPDnQpu2r4ocKbH5vMwb+ZWCD+xZdvgh9L+kLdz83lt22DJ327oROe3VS95V8WALvGi96n91b3dflkC7IH5ePXy/+FbYCW13QYQZM5AzPQa8zesUsu+T9Evg2+upuN30mFpy/ADs9vhM0I/ZoMFgRxIaXNsC7ygsj34Cj2IFQRQh9L+6r7tMdOnSnDu86L1bcvQJ9L+wLz2APVj+yGvm75qNgtwJU/lqJDf/egMF/G6yWufG1jTA8Broc1gX+zX4suWEJRv5rZKttZyKiTHrt6NcwtNNQtKVYhpk8ImpVITOEoBVEIBRA0AyqvyOBm9wXssKXSBAnj4k+k1t3RjfBmbq2TL2HUFCi2YwtU7bVxupNWF25Gqsq16h/V1euwVbftoy9BmWfvhf1hbO7s9HH2DvbUflLZd11f4kftkJbgwBP2PJs6D21d931tU+vhbOns+6+CFdPF/JG56H6t2oV5FUvrlYXCRCtgIVQVQiLr1mMobcPRdWiKgS2BLDlky2wTAum11RB7aDpg2DL56EIEWW34JYtQPicW5vBPSsRZSS4kKyQBGgqmLOC8Aa96uIP+dX1kpoSLCtdph4jWQcJcuRf9V9tFkKvHSYcfbv8F31b+H9a2wzqgkFYgSCsYACm1wsEguH+NS1QGqzASt96dVnt2wCf1XR2TrZfT0cx+jl7qEuxvVN2dDMKWnDZwp9xe1WVW4Ppz96Hw0omYcio/irLXlPpRU6+B9fa7sIpxYeiT4+euNv5OIx5Oi487kSYIRN3z3sMRx5/CCb0GKPuO7BoD+zSYySe3fMNWLMsnHbpMTAMA1UVNagqr0bXXp1jXtd7sA9/feEenBA4CD36FuPfr72NAQd0xwk9DmuwjpXl1XB5nLDZDKxasg73z38G1z50Lgo752NbSRk6dSlQjyvfVok7Fz+KUw47HMN7DAL+Xb+MRfOX4eWH38UN/7o4fMMD9feVbNiGv134IP7x7+vRprSzNir7AemGFtnLhq+r/w/vk1V3SAtBORGHEDRLg123w607kGO44dDtcGj2DKyHDr12vx6zDlG/AUbtOtU9pu5x9b8RJL/FFkp9XhQ6XWr7tHWJPt10u0pbcnI4FFLtWb7D8mxL12BWV8O/ahUCy5bDv2wZ/CtXqt/oZLoVlwDhjgltBoM8ykqS4VH9qSkj5EBSBWBmoC6Qag7ZWdYFc2YAvqAP3pBX/SuBXCQLJ3whnxrvtWDLAvy85WesrlidwXdEqfLobvR390I/d6+6f/u4usOpO5BNpN1U1gSR667vetgudQN63NcDd9zzT7xVPVMdiF3yp7Owz5A94NSd2LVoLEZ0G4zH7K9g2NCB+NdV/0ZZeTkO2G9PXH7S+WrbyH07FQzHPt32wLgbdsE9/3gUMy5+Epquw2YYuOLP52GPbuMavLTtJgfuuuURhEIhDBk0ALf+7Wrk5eWq+4498Rw88uDt6Na1Cz797SvccscDaqxejseDh+7+O3YbOUY9bsbLj+G/s1+GzWZTB5TnTzkNp0w+tsFrOTt58K5ttlrHeGuCG2DTjIT3ZbOO0EYDZhB+0w+/FVCfrwRyLt2BfFsu3IZL/S2BHmUn+cxyKivRJTe3XQR56bzvQMhCwIL6N2ha8AZN+EIW/KYFS9Ogb90MffFC6It/hf7bQuhr10Baslw8CZZp5ebBHDocwQGD4By5EzodNBltDcfkddDxTtlGmqEEC9WBalQs/hXVK5fXjb+ilpMujr5KH5y5zhaf9ZQzutLmhZwFXhJaDy8CGGMfiCXmevzkX4n5geX4LbhWnQWm7adbwIP+/nz08+eH/w3kozjobiNnui34AiacdtmHtoX1pY6n/bVRydVJpk4u8jtsaDoMzQanblfBnF2zqdta+n59loatlk1dtpj2ur+3mjaezs2wYMiEzWj7x6IWNHUEEYKm2khILpaGoHSKgab+Dt8WuS7FVsK3yb9m7fPg90Pz+cLDIxpjs8NyuQCnK/yvLXwyQ453DE3DE+fuiQFdcpANOCavCRs2bEBVVVXddZfLhU6dOiEYDGLz5s0NHt+jR7iiTklJCQKB2O5QkQ0sy5O5iKI5HA507txZNRKZYDaeBIbSxWbr1q3wSSOMkpeXh9zcXDWxbGlpbPU7OYtaXFys/l6/fn3UGB9p3kCXLl1gt9tRWlaGmurqmOdKSWxZZ3k9ed1oumGgW9eu6u+NmzbBrF1eRFFREZxOp2pg0dtPuD0eFBYUqO0j26lO7XmEHt27qy/s5pISBAPhbJAv5EdN+VZg8QLo33wH//yF8FXFbgd7IIDcykqYmoayBBPoFpSWQpeqZ7m5CNpjzzC6q6vh8vngczhQnRP75TSCQeRXVKi/t3Vq2F0tv6wMhmmiMicHAUds1sNVUwO314uAzYbKvLzYbRgKoaB2kuHSwgJY6geyXm5FBezBIKrdbvhkRxLF4fMhp7oaQcNARfwX17LQqbYdlOXnwzRiK+LJ2TtHIIAalwtetzvmvvPOr8BTM4LQAjrKC8JdraIVbtumfsIr8vIQtMXuFjxVVXD6/Q22oew8vxziw5wRXuR4gSe7doLfXn8gkI8ClDnKYGkWcv0eaCE/JixxoltpeL21UA20kBeWbodly417ryHogfA2NB2FDQ4wtEA5NDkosXlg6eGxQms7BfBjPx/KckwMXWNi3BIDlj382Szq6cOS7uHvrWaGMHKVhf5b8gAtdhtqgQpoMmbQcMEyYrchTD/0YJX6PC17w22o+8Pj3kx5TS12G2rBKmimX62rrHPsew1AD1SGf9DUe42l+UvVT51pywHism9aqBqeGh96brOhqCYXLvUW5XtZBSO0Bvm17XBrp4bbMK+8HLZQCFUeD/zO2PFcTq8XnpqahO1bM00UlpWpv0sLCmDpGWrfsNBpW6naR5Tn5yOUpH17XU7UuGO3IfcRLd9H2P1+5FZVIaRnbh8hbMEg8ioq1Oda2sxt6LfbUZWbm3QbbpPPXMtQ+7ZMFJaWJd2G8tlYwWCzt6Gp6SjLy0MowTZ0+APwOR2o8cS2b1sgqNq3pSFh+84vLVPtuzI3p0H7dlXXqPYt27A6N6fBNswvD7fvCrUN0WAbGiET1WobOhpsQ5fXh62ePGzqVIwyRw4qHB5UOHJQbvegBLnY5spDwONEpcONGnt9Oy6zXAjCgAd+uLXY4ykvbKiynDBgolCriblP9pFbrfC2KdBqEB8eVlhO+GGDCwHkaLHTiPhhoMJyqcP+orjlClmuLD9f88KuwoR6lZYDPtjhQBB5WuzxSQAGyq3we+usxR4TiVLLjRB05Go+OBEbZFRbdtTAoV5PXjeaPEeeKzpp1dDjTpg2uQ0Dsg1DKIxbbqrb0I0APHHb0AcbKi0ndJjolGAbblHLbXwbqveDKtU9t+E2tNBZiz1eFdssN8yk29CBmiSfTRA6ymQbOnJQ5KyuDRmBAdvW4ojfPsdNu52BztVleGTW3TjvyGvVfc+/MR3nHnENtoQ0VMOCDSEU1G7Dbxcux6EfrMKxo4pxx0m7qdskwSM9I7ZWB3Da879iVI8cPDZlN3WcvPm//0XJRRfDdcH5cP3+9+HP5q67Efz2W+i18YZ9/Di4zz8/pVijsLAQbrdbHXtLDJOKDhvkPfXUUyqwixg1ahSOP/54Fbw8+uijDR4/ffp09a/MZ7RmzZqY+4455hh0794dCxYswAcffBBzn0z6etppp6kPK9Fyr7jiChV0ffjhh1i8eHHMfYcccggmTZqEZcuW4dVXX425T17vvPPOU38/8cQTqpFFO+vgg9ElPx+z5s3DTytWxNw3cdgw7Lvzzli1eTNe+vTTmPty3W5cWDs/0gvvvYfKmtgv8sn77IO+xcWY+/PP+GrRopj7RvXvj8PGjUNJeTme/PjjmPsMXcdlRx8Fn+nHf2Z/hi3lscHwpDmfo8/q1Vg6bBjm771LzH0916zFXp99Br/DgY8PbZguP+4/r0IPBvHd+HHYWPsFidjl228x5Lcl2NCzB76aNCnmvs4lJTjw40/U34mWe9g7/4e8ykr8PHoUVvXvH3PfyJ9+xs4//4wtXbrg0/33i92GFRU4/P/eVX//b//9GxykHfDRx+iyZQsWDx+GxbVzVkUMWvwbxs2bpw7e4tfJFgjg+FdfU3/P3WvPBgcRe376KXqtXYcVAwfgpzHhrlX1wu3H53QmfK+/e/kVdaD17W67YXO3cJAfMf6rrzFw2TKs7d0b306cEHPfZudmLO3xP+iWjuNXHtxguVVb38HOy6pR031nbOjdF8gD/LXHVKPmz8eIBb9iba8u+HyffRoc+B363vvq79d/f0CDA5eDP/gQnbZtw7xxw7F06BB1m8tWgXHlIVRvmo/CrRux55J8/PeQ8Dp5XBuxX0kRcmtC2POTN3H1WQa623aF7uwWs9x9Zs1G9w0b8PPOg7Bg1M4x9/VdsQK7f/0lKnLdeP+oQxq81xNffEn9O/PgCapdRJs4dy76rViJ34b0xvfjx8fc1239euz7+f8QsBl444SGyz369TfUQdqcvXfBut6xFRPHfPc9hi5ahJV9e+CzA2O7vnnKKjDs8x/gN+xYcPCEBsGY+4d1CPotBAYUAcWxB6vm+mpY66qAXDuMYbEHlZY/BPOn8MkhfVQRNEfsQXBoUSlQGYDWMwd6j9iDVbOkBtbKSsBlwNipKHa5Uozj+/DJIX1EITRP7GceWloGlPqhdXVD7xN7wG+V+mAuLQdsGowxsdtePVeWa1rQBxdAK4g9WDVXVcDa7IVW5IQ+IDZosioDMOX9yD5sXHHD5f68BfCZ0PrnQe8c+z0311XBWl8N5NthDInbht4QzF9qt+HoztBUZihquQu3AVVBaL1zoHeL24abamCtrgTcNhgjY4MmK2TC/GFLeLkjO0Fzx/7Eh5aUAWV+aN3d0HvFbcNtPpjLygG7DmN07Hg+9dzvNqvxLPrQAmh5cdtwRQWsLV5onV3Q+8cGTVaFH6HfylV3KfsuDZe7bWENQiENub0dcBXEbodtm4FtpQZcOUDPnrG/cXJOdNXqcBsZODCA+MTFqtU2+HwairuEUFgYeyC7rVRHSYkBl8tEn96xyw2GgOXLw8vt1zeAuLgTq9fZUe6zo3OnILoXxh4Eb6jx4MeKLnDYLOxX1LB7+lM14e/+Ec5f0VWPDQj+5x+AZaHOGG5swiTHqpj71oby8ZF/qDpwPs39fYPl/rtmjDqAPtDxG/oa4QA14utAb/wS7I7++lbs71wWc98W04O3feEKp6e75sHQYgOJN7w7qUBjT/sKDLVFnbgF8GOgO+YFe6O7Xo7DnPXHLnLsbrPs+NQb/g060TUfOXFByPu+odhg5mOEbRNG22MPVhcHu+DzQH91wH6069eY+yRz86w33A15X8dydNZjA4JZvoFYYRZhkG0LJthjj9NWhQow0z8EDoQaLFc8X7OLCjZ2t69CLyN88iBirr8vFoa6ordRpl432iYzB+/6Rqi/Ey33Ve/OKrjc1bYWg2yxJ9W/D/TAD8FeKNYrMdn5W8x95aYTr/lGqb8PdS6GS4sNbv7PNxybzVzsZN+InW2xCYRfg8X4MtBPBXjx6+S3dLzg3VX9vb9jKTrpsUHgJ77BWG0WYrCtBOPta2PuWx7qhNn+QZDwMtF7faZmV5U928O+Aj2M2GO8Of5++C0U3oce5loMp1b/vVsfysUH/uEqkE203JdrRqMaDoy3r8EAI7aI2LeBXvgp2APd9Eoc5FwSc1+p6cI7NcPVfmuyZyFcuqlOUlo9dKzqMQoSp8p+Q04oRL+urN98vQ/mhfqgi1aDwxwLYVoa7n7PRC/Nj19/le9COMh76aWXsG3bNsz0DUIXLYgVK2xYvbo7BnTrhvV33InN3btj4xdz8VttQuWQDesx7OyzgKOOwgMP1A5UjooNGos1jjvuODUXqsw3+sYbbyAVHba75qJFi1SmLFOZPJmQVoK1HZnJ861ZA7OiAprLhc55ebDbbCirqkJN3MS4OU4n8jwe+AIBbItbX0lJF9eeKdxcWopQXPPolJsLp92OiupqVMWtr9vhQIGcjQ0GsaX27LfK1lkBeKvK4Vy2COb8X1C9dC2sKm/is/Q5OagZMRjo1xswwgcoDljIVZ1KgNIE48kK1TkeoAIaAtBQafix3laFSiMAXQvC0KRyo46QFXvQKGf0bHr4swyYDSvT2TQ/NE36dttgIfZAtrHlyh7Froe3ecCUI4TY06OG5oeuWQhZMqYlbrkIwdBlXJt0SWg4Zsqu+xpZrrxfEyHLgGnFHtw93OMbjK3oglWuSgQ0CztVdUNvfwECmolvclejwlYDU7PgNO0YVF0M3TKwzF0Cw9KRZ9rgtfnUWa2t9mrk+8MHwl7Di4AegKmH56LpXdMFw3xFCGh+LPRshsMy1DY+b/PO6FpTiKv6/w9Hr9sTxf5CVBlezCr+AeX2KgS1EAZW9cReW8JB1WP938PI8n5Y7dmISpsXO5cNwO7bwj+iQn5ELEtXZxvl3JwX8rcOn7pNx8LOP8CrB9F1477QNBM+GOp29RjYsMnKgT7gAdg3TYa9ul+Ds5jyQy9nMaPPjmq1Z4IjZzHjz46KyNlROYsZe3ZUU2cxZX1l6fEHPDJKMnyG2Up4dlTOYsrZVzmLKQco8WeCq2FXZxuTnsWUDLxWfxYz/gxzjuZTP9rRatRyHTFnMaO3/7ba99qsM8w8S9/ys/RWdp6ll/adG7fcVj9Ln7R9u2Rv2qL2LW1U2mo0eS/hfYQfnrjPJrINE7Xv8DYMZ9ISbcPIZ9PYNpT3KO813la1j9CRp3kb7COqLAe8zd6GLd9HdDeqUWCzIAVUC2yAFGfNd7pQ5DCQq4e3odSxibDpNjjtznBBokD8NtSQ4wwvt8Zf02BIh9PmhM2wIRAMqIJf0QzdgMvuUs+R58bzODxqnKU34FU1AaI5bA7YDTuCoaAafx5N1wy4HeF9RJWv4T5CXlN+2av9NQiEgjAj1ZQ1DS6bHQ67UwXXQdMHQ48UmJHlash1hd9rhbcq0iGqfn2dLth0A96AD/6oYiGWFEHz+1FU0En17qryxX42suw8OWsi31tfdf361HI7nLAbNviCfnWMGM1uhN+rbMNKb8NtmOcKb8NqXw2CtUM66reDAw6bHafNC+Lo4iDmV+ioDGk4vDiIvYvk/bjxwuoQfimX4yp1HhCn9giiu9NSr/noKmBFlXSbtFQ7+svgAMqDwEMrHaorsK/ai1Frf8H5K2fBGDoUH68LYuaEI1Gc48KSFRsxrWATti1fgyd67glbXg7GrfgBH/ebgNeOH4DAmacg/43X1XqWHXyI+ju3Wze4tm3D+ttug3/TZjzdeRd0Hj4I1UNHotJvxmTy3pi/Ecu3ejG4ixufLi1VmbyS66+HfZ99Uf7xxzAGD4rJ5BWMGY38U09NO9aIzuStXbsWw4YNY3fNZCQTlmjDSPAU2ciJSDfIeLIzigR50YFjNBmr19hypRtkMvKhyiWZyHK9ZWUwXS4YUd1aOknwmmy5LhfccevrDflQbYV3cDldGm4fuacaJox8F/IRe+YatffJHlt2iuVLFiIw7wdo3y+A57eV6gyKaBC6dO0M7LUbsOvOyJmwKwqKu0DzuKHFdWES0ee0ZQe2uWYz5pcuxdKypVhaugzLypZhqzd8Jpti/ZBXfyb2y4LYM8URVUYQW+Pui+8UUOYMnym2aTaM7DQGQwpHYFP1etQEQhiYfyKeWnEFdnNei8qqPJRUBHCz5kdpyA6X9SX+FRoJM9gT7h5PwL/lcISqZa6wENb3eQaz3Q4EK0Yjx/oEn2qd4FsxBZpRhdJBd+LDbUfDChbAXvglNFs5/CUNM14RDmu5Cv2WoUfCwpWG5ze4DC9Kq4cACQJpUQmnOlhLTMcmK657aZTIQXYiQTjUQVdimgpAk5GD1mTk4HBLXGCf6jpJwFCFxO9VAo3IgWkikQO5ROQAUA7SE5EDx8aWGznwTEQOWL0NTqyEWU0sNxKwNWcbNrZcaSvSZhIJtNo2NJq9DSVwkoP0RMwWbEMJ9HxJlivtu7nbcEe170ggnogE8DVRn43d0NRBep6uwzA0aLpLjYuy6Vr4YugoloN4uWgNu3KmrmF3zfr8fvOWayV8roWeKTw3z2VHoduOTjkOFHkcKPSE/+4k/3occNljT2S2Z3JMIifGA0EpUCZzvIaDNWkb8vm77QY8DgNOu6Fuc9h0OIzaSqYZkvU1Iua9i1G7jcL9+wzEkk2VOObBOZj+p0PU9hlR6UPn3PB39e356/DqvDV49vQJ+ODnDTCqVuKLqyaq+0qr/Sj0OOANhLC3acFZWYbfDj8Sd0y5HcumnYN9lnwJPPIGFvmdmHHB3rBOOgbeSXvjtKFH4j/nT0LPFb/iiX9WorQmAM0w1PZ/6ddqdM13QfLE3Xv1gp6TgxVTz0XPu+7EAlsnrHj/V5z97h14vfcVMPOLsO6665B3wAHwjd0d7y5ajFfOm4R35q+D0+WFb9Zsdfza9cgjEJwzB678fBTVHqevcziw9dnnUPra67D36IHiP18K14j6k9iNxRoREmtIDJOKDhvktTdSHlbGCUiDbepxUjbWlPErVVUwKyoRqqpEoKIcVeVbUFm5DWZtkNdc+qatsP24CHpZZW0P7DgOOzBySPgyaiT0Qf1gKyiAlpMDPa5bXoTMo7auch2WqoBuGZZsW4oV5ctQGYjNRFLmhctVy/naALo4BqCzvhNWeb9ByDSxcPNG/LJhQ3ieu0An/G91JVy9BuEz4zkEK4YjWDUMlj+um5vmh5GzFE5b/Wen6X7ojvqzWoGysepfK5QDM1AE3b4NoWABAqW7N+s9yEGWFEtwuDci1PU15Jefha6ds2DagAyQsQ12Q1cXOWCwycGDXLfpsOta7b9yPXy7/Jiq+w2t7nly4LmjqcqtNRWwu/PabeXCjkyamBzwqote/3cka6Hu12vvr72t/r7wbVnRRqvK4CnoBJuqZCoBXG35/7baZmtXO3rttYS31U5lE/eYpvik/2sHIm01z20LB3M2Q+1/ZX8rF2nfBByzS/j0weCuueq3Z3OlDz0K3JizpARPf7ECVb6gyuaVVoczWSN75GPppkpc9+ZPmDigM/YfHh5SIkH07e8vxFc/r0Jwr4tQvjWA4evKcdRxxwKPv41duudgUHEupBPnit0PxvD1OoZ0y0PVCuCwssV4sPe+des07ZBh6t9Ip03/8uXwLVmCpZdfhav6HYUb134Cq6oKwa3bgPwi9Pz739X+YOpjX+Kmo3eqO5lh+Xwoefhh9Hv2mYTvvfiyP8NWXKwqIUuWb9W552LwBx+ooLI1MMhrJwKbNqH8vfcQqqqG5a2BWVkVDuJqg7mQ/CsDt+PG2EXb6O6EJYW91MDw5pIufzWuIKwufYDoExGFBUDvHkDPrkBxkepSqtdetHILKJfuqPVdUiv8pVhdtQwbvCtR4l+JsuBqmIjtfpGIFXIh5O0JUy4BOYjPwjNZO4Cr+1vwbjoUVjBPKoPAXvQZQtUDYAUL4eg8GzVrTwRC+dDdy+Ho/DmqV5wPWDYYnmVwdP4UwfIxMDzLsXzdyZARCZ7+P8C3+RCEqoY2eC3v2tOgu9aq53r6PA1sOxQ9jEnYajewx/CuyLd1x8fVwKFFt8DQorIU8nENAGZV27DPiF7IN8KTMc+pcWHE8CJ0rr0uBxtOm64uKrCJ+tdhaPhy248IohonTB6HHIcNOU4b3A4Dm70rccNX9+Cq8bdgUs9JHaq8dFsgZ6C3lGxG5y7F2XkGmjq8cBu10LlLUbtqo4kCt/r5SRM8PsHjKExlahnMNUqC3wjZVsGQhbWlNbjhrV/w9kV7ol/nHPy6vhwnPjJXPaZvZw8+nrYvvli6BZ8vKVGB3XuX7I1n567Aliof/j3RiarnPsKz+18dc1LBEzXWWXdIhjB6CEYTI9Wk0qzUPfjXk9jy2Fe4qvuZ6ubyLQFYJWtQVhPAjUfvhIUbKnDRv8PjZKv9QdR4A5jW/SDcfexx6rZgaSkqZs1SwWHXy/4Me7f6OgD5Bx+MzffMgG/5Crh33gmtgUFelpAzAjKvR3OtPu98+OMKt6TCazjwec+d8XHf3TC/OFzAIn0WdNc62Au+gy1/PvSoDE1CgdpLeNhes5nBPBXMRYK6kLcXLBXYcQebKMjTtAACZeOg2bfC5dgC77o/QHduCGfLaqTbpAlnt3cBGSdohrs/haqGQev2Hhxd/ouatafULS9YMRKOojmoqe4Pt82F4nwdnfIr0CunHzw5ZRhYeCC65B6GL7blQR/gxx8GjcKVX9lwyE7d0Dd3MFb/uAsc+f/DMf3DO85SX4maF7HI2RVffWXggJFd0Tc3HNT98p0dew8sxvDC8HURnjA30kUqHOBJVxgJ/DYtzEF10MKeg7uos+zymOVly3HzZ5fj5j1vxJ699tzu259SO4CuthvIddra1QE0tR9so0Sto8IbUL/VXfNc6nhYAriI9WU1KHDbcfDIbth3aDE++mUD1pXVqECrONeJwl3HYsnNt+Ld71fjsLG9Ufb223WV5iPGdnXhL19tVV1EpePk+wXD4A8ln7zDMWAA9NxcFH/+Cb67/nh1m0yW/uCPZaiAgelHhYOyH26oHzryn29X46MFG/HY6UcA+JO6bd0118I1YjiKpkxR1wMbNsBe29Wy5ocfECothaNfX7QWBnlZQtLV60sbFnNISTAIRyMBnmW3w/LkwPTkqH+Dbhfm5/fEf/MH4mtnX/jiyr2nSrOVwV7wPWwF38FwbkJrMv1FMcGc/GuF8tSBvtOuwWMDnB7p4w7VLc1uWOoMEcO9MBll1zXPQnXR/bC0AIr8x6OgZx9oWm+st/0C17B7YUMOcswRqNR/wmipuFirRN8HZcbXGNVjFzXOolu+C8V55+JX72v4retTtdtZw1EDT8Oe3Qfixm//jIXbymGUGih0dsJV425AV0+O6ibYrygHQzvl4Y69b8cD82fglh/OVp+Ry+bGleP+isGFeSor179zDoYUhseLSjeIvp08GNY1D28ufRUlNZsxddSF4XEO0mVKunjpGr5c/yX+OvOvqArIIHUL/1s7E9dNvA77990ft319GyoCFbh33r3qIi4bdxkDPiIioh1sePd8HDm6Jw6+939qLOchI+szXpItu/ODReExj6aF43bthRE98nHmXgNw4fPzcNgzW9D5qMsxZslPKFv9A3yDdWgOB7So4T9FLgN3/m40znvuWxg+L3Z15KvjmYgZHy2qG5MnNJsNfR7+Fzbeehu2PvMMLDMEW2EnWL+/DDCMujF5cknHumuvRahki1qG7nSi1333wUhSyyMTOmx1zWybDH1DmRcrSiqR7042aL0R5WXQjg2XxTf7DUTwxFMAjwea2wPN44FeWwN6XbUP76+pwKfrTJR4G65nV7eF8d0seGzJm0QQPmzUfsE6/Qds1ZZJC4q5X7MMFJr9VTc81Yc/PPgi7eyaTXOiyNEbXZx90M3VBwXOXHWw77LramyVx25TXfEctvAZ1UBQgy9gqcGuHocdnT1O5LnttZO4kpSnL5PuAsVd4bS71STmqbrsfxfj4L6TcfiAI1U3HXVB7LiZNjsehbJG1hcMoA6PbZSyXUdto6HKKhi180BWfPIJNs24F4PeC09l1R5xMvQ2SLIRzalEZUkJ3dq/jZ494di3ft42b9DE7OVb8cGiEvy8wVvbC7n+i++yaZjYz4G9BrowpNiW8GBdyuUuqvgVX2/5AvPLvoffbDg2blDOEOzWeXcMzx2JPHs+uuf3VePtUh6dnYCuSglL0Q9dLUeX0EKTQe7h9Q/IJK2+kEq55zh0FBRINS8ncpyGyhpR7I5fqwmg0JOb8o7/l5JfcOWnV2JQwSAcO+RIVYKaiIiIKJtse/55lL//PmCGoOfkqqqYxCCvXZCKP3Xy8qDn5+PnteX44JcNmL1oE2oCsf2OJewa2cuFvYflYXx/j8qMJbKmciW+3vQZvtk0B2X+2AkoRbGrGyZ22wcTuu6NLu5uKpVe6t+KLrn9kOtMPiVES5iWhUpfEDV+mU9OU5nPPjkONUaiI5Vq3h526rIT3jv+vR29GkRERERJdTn/PHWhWAzy2oPqcJC3yV2Ime4hmPnkN6pSUbxu+TYV2O05JBddZEbSBMr8pfh20xx8tfFTrKla2eB+jy0H44r3UMHdgLwhMZm/mlA13DYPcu2Z6QYbTeZDkbK6MtmvlCbuW+RR3TFzHOE5ToiIiIiIKIxBXntQXYVnRhyKl4ceAEu6MkYFeC67homDcrD30DwM7e5sNCB6bemz+O/a92DFlZY1NAM7F+2KCd32Vv/a9YbjBiWL5wt50Su3L2x6ZppVdHdMGYtXnOdkd0wiIiIioiYwyMsSVYFKbPFuhqVHzRuWogWrNuGlYQfF3DaipwP7DivAuAEeFSA1pcy3DTPXxg5S7ZMzCGM774XRRRPhsYWr/1R6JQBsOCbPG6wGNAM+nxMlAR9azApPmJvnsqFProfdMYmIiIiIUsQgL0vUBKuxsWY1Qlp6s95LOdnH1rnrrh/i3oRDj90VxfnpVelcWbms7u8xXXbFKUPPRPecnik9V7J423w16JnTG8UemacuM2QCa3bHJCIiIiJKD4O8LGLT7Chwphckvf9jGdYFXervYVtX4ozxFkJpBnhiZcXSur8nDzgII7v2T/m51YFqOJ15GNypGxxG+plIIiIiIiLKHA5sasNKq4N4/dtw1UvNMnHBj29Cy6nP6qVjRXl9Jm9w4eC0nlsdrEYXdxcGeEREREREWYBBXhv28lfb4A2Ei6RMXvk1hpWuhuXxpL2ckGliTdVy9XeOPQfdPd3Ty+IZTnRyZa6bJhERERERNR+DvDbqtw1ezFlcqf7OsfyYsuB99beVk36Qt6a8BBWBUvW3THydzhi4SBZPAj0iIiIiItrxGOS1QaZp4dnPt9Rd/0Plzyj0h+fKs9zpddf0BkPY6F1Rd31Q4aA0nutlFo+IiIiIKMswyGuDZi+swIqS8DQGfYrsOHTLT3X3pZPJk/nwqnwhbAusbtZ4vKpAFTq7O8NlCxd+ISIiIiKiHY9BXhtT6Q3hP9+Ei62IP+7ZGfbq6mYFeRLgycTi66pXpB3kSRbPbtiZxSMiIiIiyjIM8tqY177dhkqvqf7efVAORvR0Q6v2quuWzQAcqVW4NC0LgZCJ4lwnlpWFp0/w2DzontM95SxekasIblvzqnkSEREREVHrYJDXhqzc4sPMBRXqb6dNwx92L1JdLjVvjbrNdLmgIbWiKRXeIArcdphaJbZ4t9SNx9O1ppuEL+RTWTwJ8oiIiIiIKLswyGsjLMvCc3O2wArPmIBjdi1EUa4NCIageX3hx7hSGxvnC4aga0CXPMniLUu76EploBKdnJ3gsadfyZOIiIiIiFoXg7w2Yu6SKizaEA7muhfYcOjoAvW3ZZnQvbXdNd2ulIutdMpxIsdhw5LSJWmNx/OH/LDpNhS5mcUjIiIiIspGDPLagBq/iRe/3Fp3/bQ9OsNu1HbL9HqhBUMpZ/Jq/CG4HDqKcsJj96KDPJkjrykVgQqVxZNJ04mIiIiIKPswyGsD3vquFKXV4UBul34ejOlb301Sq6yvrGl63E0WW/EGpdiKC05b+KNfWlt0RQqo9Mzt2ejzA6GAGrPHsXhERERERNmLQV6WW1/qxwc/lam/JXt36qTYAEurqqz7u6mJ0CPFVgo9dnW9zFeGkpoS9ffAgoFNFl2pDIbH4jGLR0RERESUvRjkZXuxlc+3IhSeMQGHjc5Ht4JwgBahVdfUP76RMXkyXYLonOuEroW7eqYzHi9gBsLPd3eGVvt8IiIiIiLKPjs8yHvooYfQv39/uFwuTJw4EV9//XXSxwYCAdx8880YNGiQevyYMWPwwQcfoL36bmU1floTDuI65xo4apfChg+qiMrkeTyNZvE65ziR6zTqbksnyKv0V6LQUYhce266b4OIiIiIiDpKkPfyyy9j2rRpmD59Or777jsVtE2ePBmbNm1K+PjrrrsOjzzyCB544AEsWLAA559/Po477jh8//33aG/8QRMvfFFfbOUPu3eGy57g46qsbDKTVx0IwinFVnIdMfPoLS0Nj8dravqEoBlUVTk7e5jFIyIiIiLKdjs0yJsxYwamTp2KM888EyNHjsTDDz8Mj8eDJ598MuHjn3vuOfzlL3/B4YcfjoEDB+KCCy5Qf99zzz1ob96bX4bNFUH194ieLkwYmDhLp1XVF16xEhReMWHB6zdRnOOsK7YSn8mToiu9cnslXZcKfwUKnYXIs+c1+/0QEREREdH2YcMO4vf7MW/ePFx77bV1t+m6joMOOghz585N+Byfz6e6aUZzu92YM2dO0teR58glory8XP1rmqa6ZIIsR8bPtWR58nyZ6Vz+LakI4u3vw8VWZNLyP+5RVP+YmOeYMKpiq2vGP6bSG0Cey0CB2wbLrL+v3FeOzTWb1d8D8gdAs7QGzxUhKwTTMlXBFbk/0WMo+2WijRK1JrZRynZso5Tt2EY7BjPFz3eHBXklJSUIhULo1q1bzO1yfeHChQmfI105Jfu3zz77qHF5M2fOxOuvv66Wk8xtt92Gm266qcHtmzdvhrd2EvFMbOyysjL1xZJAtTmqS8th1AQRMKrwwpwyBELhYOrAoW50swcQqAgXPolmhUzYogqvhHQbAhVV9ddNC6GACU++E1Xb6rt1ip+2/VT3dx9XH5RvDQe/8aoCVSrTV2PVwKfVB8vUtmSijRK1JrZRynZso5Tt2EY7hoqKiuwO8prjH//4h+reOXz4cDU2TAI96eqZrHunkEyhjPuLzuT16dMHxcXFyM/Pz9iXStZHltncL9Vmy4dQzWYsKtMxb7Vf3Zbv1vG7ScWwOxIv0/T7YIsKVLXCfNjz6qc3qKz2o3OhA10L3TFj8cS6Levq/h7ZbSTyi/ITZvECvgD6F/ZHgbOgWe+LskMm2ihRa2IbpWzHNkrZjm20Y3DF9WrMuiCvS5cuMAwDGzdujLldrnfv3j3hc6TRvvnmmyoDt2XLFvTs2RPXXHONGp+XjNPpVJd40vgz+QWQL1VLlinPl+Td81HFVk6aWIScqGqYDZ5jWtCis5E5nrrCKF4ptmI30CXPlXCdIpOgi8GdBkOTfqFxqnxVKHQXosBV0OQcepT9WtpGiVob2yhlO7ZRynZso+2fnuJnu8NagMPhwLhx41SXy+gzEHJ90qRJTUawvXr1QjAYxGuvvYZjjjkG7cGXvwWxrjTcLXNwVyf2GtrEdAVmCLq3vgulWTuFghRbqfab6JLrgMueOEiMFF1xGS70yuuVOItnBtDZ1ZkBHhERERFRG7JDu2tKN8opU6Zg/PjxmDBhAu677z5UVVWpLpji9NNPV8GcjKsTX331FdauXYuxY8eqf2+88UYVGF511VVo67ZVBfDfn8MBnuTU/riXBFdNTFcQCkGLCvIi1TWrvCHkuAwUehwJn1buL8em6vA0FQMKBsDQjITz4uU785HvyEyXViIiIiIi6gBB3kknnaQKoNxwww3YsGGDCt5kcvNIMZZVq1bFpCSlm6bMlbds2TLk5uaq6RNkWoXCwgSThLcxT8/ZAF94xgTsOzwPA4sbdjGNJ9UydV9skCdBb9C00DvXDVuSdG70/HiJJkGXLF7QCqKLuwsMPXl3USIiIiIiyj47vPDKRRddpC6JzJ49O+b6vvvuqyZBb2/mrdyKmb+Wqr89Dh0nTOiU0vOsQABadJCX40G5N4RCjx157uQfbaSrZrIgTypq5thymMUjIiIiImqDONhqB5NpDqa//Uvd9d/v1gn57tSyZ2YwUDcmz7Tb4YMOm6GhONfZoJpmskzeoMJBscu0TARCARR7imHTd/g5ACIiIiIiShODvB1s0YYKLN0Untuue4GGA0bmpfQ8CxYQDNaNybNcTlQHLFVsxe1oPEiMBHkOw4Heub1j7qsOVCPHnsMpE4iIiIiI2igGeTvYyJ75+O8V+2KfoQU4YlcHjARTGSRkmmoy9Egmz3K5IHVaklXTjC6osqF6g/p7YMHABmPuvCEvuni6MItHRERERNRGMcjLAj0K3Ljq8L4Y0DX1IicS4Knqmr7wPHmmywld15IWW0k4P15B7Hg8y7LU/CoyrQIREREREbVNDPLaKjME+PzQJNhTQZ5LTS7fVCYwuuhK/Hi8oBmEXbczi0dERERE1IYxyGurQia0mur6qy6nKrpiN1IP8uIra8q0CTJnngR6RERERETUNjHIa6ssM2aOvJDTBbuhNzmBenTRlT55fRpk8uR2zo1HRERERNR2Mchrq4KhuqIrIuR2w2k0XXRlfdV69feA/AENgjkJ8tw2dyutMBERERERbQ8M8toos3ZMXkTI5YLT3vjHuaxsWdLxeGqZlgmn4czwmhIRERER0fbEIK+NsgIBGP76IM90u9IquhI/Hk/IBOocj0dERERE1LYxyGujrIBMhB4V5HncMAw9pfF4iYI8yeJBAytrEhERERG1cQzy2iBL/pM58qIyeXC7YU8xkyfZuviiKyEzpAI8u8FMHhERERFRW8Ygry0KhWRQHnRveCJ0oeV4Gu2uWRWowrqqdervAQUDGmTsAmYANs3G7ppERERERG0cg7w2yDItNRm67g/U3+hxq3nykllW2njRFZkjz2lzQtfYJIiIiIiI2jIe0bdFoRAs04QWNYWCkZujCqcks7QsajxeQcOiK9Jd02W4WmFliYiIiIhoe2KQ1xaFTMCyYrprOvI9LaqsqaZPsHH6BCIiIiKito5BXltkhdQ/WlSQZ8vNSSnIk7F4ffJji65EcDweEREREVHbxyCvDbJCJjQL0Gvqgzw9N3kmrzpQjXWV4aIr/fP7NwjmQlYIuq5z+gQiIiIionaAQV4bZAUDsHQtZkxeY5m8ZWXL1LQLybpqqukTWFmTiIiIiKhdYJDXBlmBADRdh1ZTo66bDgfsDluzx+MFzaDK4jGTR0RERETU9jHIa4OsYAjQjbrCK6bLCcMwkj5+aenSRqdPkDnynAanTyAiIiIiag94VN/GWJYJy5QgT4NWE+6uaUmQp+tNTp8gmbp++f0a3C9j8tw2dyuuNRERERERbS8M8tpg0RU1hYImY/LCmTzL5VJBXyI1wRqsqViTtOiKMGHCbnA8HhERERFRe8BBWG2NZPEsE3rQgmaFi6lobmfSIC+66MqggoZdNdXzobHoChERERFRO8Egr60xzfAUCqHwXHmK26VCteaMx5PKmjIWj0EeEREREVH7wO6abY2aI8+CHjV9guZ2Q9O05lXWtIKcPoGIiIiIqB1hkNfWmCFYGuoqawpNMnlJCq9EgjwJ5GRMXqLpEyTA4/QJRERERETtA4O8NsYKWapjplYTFeR5XKoQSzxv0Iu1FWvV333z+yYsriJBnsvmSpoJJCIiIiKitoVBXhtjBf2w1ETo9UGerjJ5DYO05WXLVeXMZF01o4M8IiIiIiJqHxjktTFmMAhN02O7a3rcqkJmuuPxIjgej4iIiIio/WCQ19YEAoARm8lDjifhQ6ODvESVNYVMr8A58oiIiIiI2g8GeW2IJUVXTFMVWdGiqmsix53w8UvLwtMnGJqRtOiKFFyRoixERERERNQ+MMhrQ2R+PDWFgmZA99bETKGQqOjK6vLV6u++eX3hMBxJgzxm8oiIiIiI2g8GeW2JGZJ0nqTmgOqoMXl5uQ0euqJ8RUpFVzhHHhERERFR+8Igry0Jmaq7piZz4kUVXoHH3azxeDIRutueuKsnERERERG1TQzy2hLLhGaF/9SiMnnIzWnw0KWl4fF4jWXyQlYIbhuDPCIiIiKi9oRBXlsSDMGqnSlBi55CIUF1zUgmT9d09C9oWHQlQsbkERERERFR+8Egrw0xpbIm4oI8TQPczpjH+UI+rKpYVVd0xWnE3i8sy5L5Ezgej4iIiIionWGQ15YEAtAMQ/2pR+bJczmhG7HZuBVlK2BKgZYmxuPZDBszeURERERE7QyDvDbEDAYALfyR6ZF58lzOcDYvSdGVpOPxzBAraxIRERERtUMM8toIS/4LhtRE6NLVUo9015QgT6ptpll0pW4idGbyiIiIiIjaFQZ5bUUoJIPypJIKzJAJw1efyYtL5NUXXYGO/vmJi64EzAAraxIRERERtUMM8toIy7RUkKfpBkKR8XjC7YrprukP+euKrvTJ7wOXzZVweTJROoM8IiIiIqL2h0Fem8vk6UB1Tf3takxe/ce4onyFmv9ODCpIXHRFsTh9AhERERFRe8Qgr60ImbBkMnRdgxUpulKXydPTGo+npk/QOH0CEREREVF7xCCvrZDsnFX7Z3V8d830KmtK0RUJ8JjJIyIiIiJqfxjktRFWyKyL5fSaqEyeqq6pJSy6MqBgQPI58jh9AhERERFRu8Qgr42wggFYtcFc3fQJwuOuK7wSCAWwqjxcdKVXXq+kRVdUJs+ww9DDE6sTEREREVH7wSCvjbCCQWi6DtOyYPPFd9fU64quSJausa6akSCPlTWJiIiIiNonBnlthBUIqmAuZAJGXJCn1WbylpY1XXRFmJaZNMtHRERERERt2w4P8h566CH0798fLpcLEydOxNdff93o4++77z4MGzYMbrcbffr0wWWXXQZvdPfFdsiS/8wQYEiQZ8EWU12zvrtmdNGVQYWNTJ8AqDF5RERERETU/uzQIO/ll1/GtGnTMH36dHz33XcYM2YMJk+ejE2bNiV8/L///W9cc8016vG//vornnjiCbWMv/zlL2jXgiE1hYLMkRdS3TWjg7z6wiuR6RM0aBhYMDBpFk8yfzImj4iIiIiI2p+00znLly/HZ599hpUrV6K6uhrFxcXYZZddMGnSJJWNS8eMGTMwdepUnHnmmer6ww8/jHfffRdPPvmkCubiffHFF9hzzz1xyimnqOuSAfzDH/6Ar776Cu2ZzI8HNUeejlAQMWPyNI8bmqYjYAbUmDzRO6930jF3Mh5Ppk7g9AlERERERB08k/fCCy9gwoQJGDRoEK6++mq8+eabKth7/PHHceihh6Jbt2648MILVfCXCr/fj3nz5uGggw6qXxldV9fnzp2b8Dl77LGHek6kS+eyZcvw3nvv4fDDD0e7FgrBMiOZPMR21/TkqH9Wlq9UAZwYVJC8q2ZkjjxOn0BERERE1D6llM6RTJ3D4cAZZ5yB1157TY2Fi+bz+VRg9tJLL2H8+PH45z//iRNOOKHRZZaUlCAUCqngMJpcX7hwYcLnSAZPnrfXXnvBsiwEg0Gcf/75jXbXlHWTS0R5ebn61zRNdckEWY6sT0uWJ8+HZYX/jb9PddeMzIRuQYsag2jluGCZFpZsixqPVzBI3ZaIZPxy7DlqYnXpukkdQybaKFFrYhulbMc2StmObbRjMFP8fFMK8m6//XY1Vi4Zp9OJ/fbbT11uueUWrFgR7jaYabNnz8att96qgkgp0rJkyRJceuml+Nvf/obrr78+4XNuu+023HTTTQ1u37x5c8YKtsjGLisrU18syUY2R3VpOYyaIAJGVYP7rJoaBC0Nui8ILWgCVTV191VpDvi3luPXjb/W3dZD74HyreFgNl5loBJ2px2bfInHPVL7lIk2StSa2EYp27GNUrZjG+0YKioqUnqcZiVKHW0H0l3T4/Hg1VdfxbHHHlt3+5QpU1BaWoq33nqrwXP23ntv7L777rjrrrvqbnv++edx7rnnorKyMmGDTpTJk0zktm3bkJ+fn7EvlQSNMj6xOV+qi/57EdZVbER1wAeHLUHcHQyFp1AwZJ48wLl+PTSfP3zf4P7QHU6sqVyD6mC1Krry4uEvwmPzJHytLd4t6JffD53dndNeT2q7WtpGiVob2yhlO7ZRynZsox1DeXk5OnXqpAL6xmKZlDJ5kS6OqUg1cJLun+PGjcPMmTPrgjxpnHL9oosuSvgcKfQS32gNw1D/JotVJcsol3iynEx+AaRiZXOXuWjrImyqSSGzFh5yB6j4LFxRE9Urger6h/TK7YUcR07y9dQ1OGwOfvk7oJa0UaLtgW2Ush3bKGU7ttH2T0/xs00pyCssLKybcLspMs4uVTJ9gmTuZByfFHWROfCqqqrqqm2efvrp6NWrl+pyKY466ihVkVPGCEa6a0o3Tbk9Eux1ZDLW7qRhJyW9P2SFoGs6i64QEREREbVjKQV5s2bNqvtbxtvJ9AZShEWmTRBSdOWZZ56pC8ZSddJJJ6m08g033IANGzZg7Nix+OCDD+qKsaxatSomWr3uuutUsCn/rl27VqWjJcCTcYBt2cwTZ+LnDavww/ql6FcYW4hG+NesVsVXqgw7ch06ep43DZDumj27wfbY3bB36ZLS66jpEzROn0BERERE1J6lPSbvwAMPxDnnnKPmp4ufqPzRRx9VxVGymXQ9LSgoaLIfazqkm6lM4N61a9dmp8eTBXkyR55/1So1fUK5aaCbU0PRmReH7xzUD/YHboGtc2rj66oD1SpIHl40POXMLLUPmWijRK2JbZSyHdsoZTu20Y6hPMVYJu0WIFk76V4ZT26LzF9HmWOFTEAumq6mPbAFAvV3up1pBWsyfYLTSO85RERERETUtqQd5Ellyscee6zB7TIpevz8eZQBZgiwTGiGLjEe7NHTPjhdMsI25UXJmDy3zd0660lERERERFkh7cFZ9957L373u9/h/fffV8VPhGTwfvvtNzVROmVYyIQlk1uqajqA4aufIw9uV/jGFJkwYTdYdIWIiIiIqD1LO5N3+OGHY/HixargydatW9VF/pbb5D7KMDMEzQJMS4OhSZBXP+cfXI60MnkSKbKyJhERERFR+9asMovSLfPWW2/N/NpQQ6EQLE0SehZsmgbDGxXkuV0px3ghMwRDNxjkERERERG1cykFeT/++GPKCxw9enRL1ofimFJ0RY2ns+C06dC9PpjR3TWlIEuKRVdk+gQGeURERERE7VtKQZ7MXycVGZuabUEek85k6JSCYBCaYSBkAU4pvlIdNSbP6Ux5TJ4UXZEAj3PkERERERG1bykd8S9fvrz114QSMoMBla2TIM8hg/JqoqprSiYPWsoToec4czh9AhERERFRO5dSkNevX7/WXxNqwJJKKcFgXbbOpicI8uS2FIM8l02CQiIiIiIias+a1Xdv6dKluO+++/Drr7+q6yNHjsSll16KQYMGZXr9OjYpuiJTKOiaqrBpk3guurumR8bkpb44jscjIiIiImr/0p5C4cMPP1RBncyNJ0VW5PLVV19hp512wscff9w6a9lBWabMnWDC0ozwHHmStYueDN3tTrnwiuAceURERERE7V/ambxrrrkGl112GW6//fYGt1999dU4+OCDM7l+HZsUsTFNBGXqBGjh7prVsd01UxljJ101OX0CEREREVHHkHYmT7ponn322Q1uP+uss7BgwYJMrRcJyeJZpozMgyGBngZYNdHdNSWTl1qQJ1U1WVmTiIiIiKj9SzvIKy4uxg8//NDgdrmta9eumVovEpYp1VcQlOkTbOEpKlDjix2Tl8IUChLkSRaPmTwiIiIiovYv7dTO1KlTce6552LZsmXYY4891G2ff/457rjjDkybNq011rHjCoZUXRWZD90VCeYimTzDAOz2lKprBq0g8mx5rbyyRERERETUJoO866+/Hnl5ebjnnntw7bXXqtt69uyJG2+8EZdccklrrGOHZZohVVlTsnk2ozbIi4zJc7ug6zq0FMprykTobpu7ldeWiIiIiIjaTHfNt99+G4FAQP0tXQal8MqaNWtQVlamLvK3TKHAibYzy/L7oem6GpOnpk8QkXnyXM6UumpGcDweEREREVHHkFKUcNxxx6G0tFT9bRgGNm3apP6WjJ5cqHVYwRAsaLXTJyC2u6ZMhF53YyPLsCRE5Bx5REREREQdhZ5qsZUvv/yyLmhgxq71WfJfKISQpquqmjJ9ghUIAnIRLie0FObIk/F4ksVjkEdERERE1DGk1Ifv/PPPxzHHHKOCO7l079496WNDMrcbtVywdo48mR9PSzRHnhOaFF9JZfoEjdMnEBERERF1FCkd+UtRlZNPPhlLlizB0UcfjaeeegqFhYWtv3YdmMyPBzMEU7fDYWjQNQ1WddQcea7Upk8ImSE4bA4GeUREREREHUTKR/7Dhw9Xl+nTp+OEE06Ax+Np3TXr6EIhWKaJkK7DGRl7Fz1HnhReSSGTFzADyDfyW3FFiYiIiIioTU+GLkFeJMC7/fbb6wqyUIbJ5HiWBVPTVCYvpuiKcDpU5c1UxvZx+gQiIiIioo4j7SAv2q233oqtW7dmbm2onnTXrKXG40VPnxDJ5KVQ/0YK5bCrJhERERFRx9GiIC9Snp8yz5JMnikTKNTPkWdFB3luV5PVNU3LVIVyWFmTiIiIiKjjaFGQR63HCgQQ0iJz5NVGedGFVzxumZm+yaIravoEg0EeEREREVFH0aJ+fAsWLEDPnj0ztzZUxwwGYKo58mqnTxDRmTyHo8nqmlJ0RU2foLG7JhERERFRR9GiTF6fPn1QUlKCVatWZW6NKCwYrJ0IXVOToSsNums2voiQFYLT5oShN12Fk4iIiIiIOliQV1FRgdNOOw39+vXDlClT4Pf78ac//Qk9evTAgAEDsO+++6K8vLx117YDzZGnpk/QdDht0iszQSbP7Wqyu6ZMhO40nK28tkRERERE1CaDvL/85S+YN28errjiCpW5O/HEE/Hpp5/is88+w6xZs1RG74477mjdte1IRVdCJkLQ4IrukhlTXdMBNFF4RQrjuGyuVlxTIiIiIiLKNikP1nrrrbfwzDPPYP/998fvfvc79O7dG2+//Tb23HNPdf+dd96Jyy+/HLfccktrrm/HYIbCUyjIeLrIROjNKLwic+RxPB4RERERUceSciZv06ZNGDx4sPpbiq243W4MHTq07v6dd94Zq1evbp217GhCpsrmWbpeN31CgykUXI1315TpE3RdZ2VNIiIiIqIOJuUgr3Pnzti8eXPd9WOOOQaFhYV11ysrK+F0cvxXRpghWKYFSeJFJ/Jiumt6nECk6maS8XiGZnCOPCIiIiKiDiblIG/06NH45ptv6q7/+9//RteuXeuuy30jRozI/Bp2RKEQQoCqqlk3fUJ0kGe3Q7PLmLzGgzwJ8GSePCIiIiIi6jhSjgBeeOEF1f0vmW7dunE8XoZIFi9oyni6qDnyRE3tmDx3bca0kcIrQSuIHFsO9CaKsxARERERUQcN8oqKihq9/7DDDsvE+pAEeYEAQpoGp6FBj87WVXvrp0/QdTRWdkUyeW6bu9XXlYiIiIiIsgvTPFnIDAZhQoI8PWY6BHi9sUVXGsmsyuMdhmN7rC4REREREWURBnlZRqY9QFAyeQYcMigvIhAEgqH67ppyVyOFV+R+Fl0hIiIiIup4GORlGzM8fYJm6ImLrgi3C5pk8pIUXglZITUWj0EeEREREVHHwyAvy6j58cwQNC12jry6oivCJZk8GZOnJR2PJ5Ogs7ImEREREVHHk3KQN378eDz88MMoLy9v3TXq6MwQzKAJw9Bg6AmKrkTG5DUyHi9khlQWj5k8IiIiIqKOJ+Ugb8yYMbjqqqvQo0cP/PGPf8Ts2bNbd806qpCJoGXBsBnJu2tKJs8wki4iYAZU0RXVpZOIiIiIiDqUlIO8J554Ahs2bMBDDz2E1atX48ADD8TgwYNx6623Yu3ata27lh2JZcI0LRiapiZDT9Zds7EAjtMnEBERERF1XGmNyfN4PDjjjDNUFm/x4sU4+eST8cgjj6B///444ogj8Prrr7femnYUwRCCFuC0ISaQs2IKrzihNZLJszROn0BERERE1FE1u/DKoEGD8Pe//x0rVqzAiy++iC+//BInnHBCZteuAzLNEEIW4Iofcxcd5DmdjY7Jk1kYWHSFiIiIiKhjalEkIBm9p556Cq+99hpsNhumTp2auTXroKxAAJauwRY1EXrDwivJgzwpuiIBHouuEBERERF1TGkHeWvWrMHTTz+tLsuWLcPee++Nf/7znyqL53ZzHFhLWYFgw+kTEhRe0ZIEeVJ0xdAMBnlERERERB1UykHeK6+8gieffBIzZ85E165dMWXKFJx11lmq+AplhmVZCAWD0HUd8Ym8VAuvyEToEuCxuyYRERERUceUciRw2mmnqeIqb7zxBg4//HAViFArVNYMmdBteuz0CfGZPI9bqrIkrayZ68zl9AlERERERB2ULZ1umpLBo9ZjhSwEg0HYnc4GQZ6VYuGVoBWE0+Zs7VUlIiIiIqIslXI6TubG23///VFeXt7gvrKyMnXf/PnzM71+HYtlIhiyYLMZ0OMzcdXR3TUdSTN5UlmT0ycQEREREXVcKQd599xzjwrk8vPzG9xXUFCAgw8+GHfddVezVkImWJe59lwuFyZOnIivv/466WP3228/1RUx/iJdSdu8kImQacFlT5Bg9frixuQlHtMnOB6PiIiIiKjjSjnI++qrr3Dssccmvf+oo47CF198kfYKvPzyy5g2bRqmT5+O7777DmPGjMHkyZOxadOmhI+XCdfXr19fd/n5559hGEb7mKPPNGGqTFyCCC6SyXM6AJkIXdMTFl2xGZw+gYiIiIioI0s5yFu7di3y8vKS3p+bm6uCrnTNmDFDza935plnYuTIkXj44Yfh8XhUJc9EioqK0L1797rLxx9/rB7fLoI8hNT/Nyi6IiJj8tQ0FVrC7ppSdEWmT2Amj4iIiIio40o5GiguLsaiRYswYMCAhPcvXLgQXbp0SevF/X4/5s2bh2uvvbbuNqnaedBBB2Hu3LkpLeOJJ57AySefjJycnIT3+3w+dYmIjCk0JWtmmsgEWY50lWzJ8tTz/SEZUgcDVl3Xy4ZBXrioigUNlqT9ogRCAdgNOwwYGXtv1D5koo0StSa2Ucp2bKOU7dhGOwYzxc835SBPAq9bbrkFhx56aIP7pEHJffKYdJSUlCAUCqFbt24xt8t1CRqbImP3pLumBHrJ3Hbbbbjpppsa3L5582Z4vVEVK1u4saX4jGyH5k4tUV1aDsMXgk23w+8LwgpGfYCWBXd1jeTvEHI64Q1Y8JVXQ6sJxCyjKlCFXEcuNgUSd3WljisTbZSoNbGNUrZjG6VsxzbaMVRUVGQ2yLvuuuswbtw4VRjl8ssvx7Bhw9TtEoxJUZbFixfj6aefxvYkwd2oUaMwYcKEpI+RLKGM+YvO5PXp00dlJhMVkWnul0qKv8gym/ul2mz5UBMKIt/uQF6OI6bLpuXz1WX2DI8bOS4djk450B2umGUEfAF0y+2GYk9xC98RtTeZaKNErYltlLId2yhlO7bRjsHlij3+b3GQN2jQIHzyySc444wzVPfIyGTbEnzIWDoZGzd48OC0VlK6d0rRlI0bN8bcLtdlvF1jqqqq8NJLL+Hmm29u9HFOp1Nd4knjz+QXQLZHi5Yp3UcRgs1mUwFezGTmNT7VjVNxu6BpOjTdgBY3dk+eI4VX+MWmVmmjRK2MbZSyHdsoZTu20fZPT/GzTatCx/jx41X3yB9++AG//fabCvCGDh2KsWPHNmslHQ6Hyg7OnDmzrnKnnIWQ6xdddFGjz/3Pf/6jxtqddtppaA8sy1SBnsNuxAZ4InoidLcrXHQlQeEVzdJU4RUiIiIiIuq4mlWGUYK65gZ28aQr5ZQpU1QAKd0u77vvPpWlk2qb4vTTT0evXr3U2Lr4rpoSGHbu3BntQkiCPAtuR4LoPDrIcznV9AkNAkEJkGHyzA0RERERUQeXUpB3++2349JLL4Vble9vnMynJwVVUp2c/KSTTlJFUG644QZs2LBBBY8ffPBBXTGWVatWNQhcpMrnnDlz8NFHH6G9sEIhqZcJm82efI68SHVNie/itokaZKvpkP+IiIiIiKjjSinIW7BgAfr27avmopNJzyXrJoM6RTAYVPdL0PX8889j3bp1ePbZZ9NaCemamax75uzZsxvcJkVfGkwx0NaZIfVh2BPNkedN1F0z7umWGQ7yEkySTkREREREHUdKQZ4EbfPnz8eDDz6IU045RVWolIIpUtCkurpaPWaXXXbBOeecowqzpFr1hepZIelqCRgJYjSrOra7pnTVlOIriYI8Q+eYPCIiIiKijizlMXljxozBY489hkceeQQ//vgjVq5ciZqaGlUhU7pYpjsROjXsrinhWfTUCXVqorprSqXQBNk6GY+nQWMmj4iIiIiog0u78IqMj8tk4RWKsFQWL3GQF1d4xZYgyLNMVVmTY/KIiIiIiDo2RgRZxJC5TRJUzUR0d01VeCVxkMfumkRERERExCAviziSxWfeuDF5euIgz6Y3a0YMIiIiIiJqRxjkZQmpqulOVHUlfgoFpxOa0TAaZJBHRERERESCQV6W6OS2Iz/RROgyWi9+TB4zeURERERElKkg76yzzkJFRUWD26uqqtR91Aqigzyng5k8IiIiIiLKXJD3zDPPqKkT4slt6U6CTs0I8hz2BhOhC5k7T6prEhERERFRx5Zy6kcmQLcsS10kkxc94XkoFMJ7772Hrl27ttZ6dmyRIM/tAgxDzYeXaJ48zpFHREREREQpB3mFhYUqWySXoUOHNrhfbr/pppsyvX4UXXhFgjyZYiHBmDzNYiaPiIiIiIjSCPJmzZqlsngHHHAAXnvtNRQVFdXd53A40K9fP/Ts2bO11rNji87kmVbCIE+SexJoExERERFRx5ZykLfvvvuqf5cvX44+ffpATxRoUMZZpgl4feErbpdK5DV4jGWpLpzM5BERERERUdrlGCVjV1paiq+//hqbNm2CKUFIlNNPPz2T60c+v0Rx4b/dbshfmq41qKwpWTyOySMiIiIiorSDvHfeeQennnoqKisrkZ+fH9NFUP5mkNeKlTU9tcVu4oI5KboiWTxDZyaPiIiIiKijSzv1c/nll6v58CTIk4zetm3b6i5bt25tnbXsyCJFV4RUNJWgWkuQyYMGnXPbExERERF1eGlHBWvXrsUll1wCj8fTOmtEyTN5bmd4+oQEQZ501WR3TSIiIiIiSjsqmDx5Mr799tvWWRtqIshzhT+xuCBPCq9Id00GeURERERElPaYvCOOOAJXXnklFixYgFGjRsFut8fcf/TRR2dy/aimvrumprpr6kCCwit2w84pFIiIiIiIKP0gb+rUqerfm2++ucF9EmSEQqHMrBkpVlQmz1LdNRsWXglZIdj0tD9KIiIiIiJqh9KODOKnTKBWVh3VXdPlVBOhx+frJJPHOfKIiIiIiEhwEFcb6q6pqmtKiBc3Eb0FC3Y9ttssERERERF1TCll8u6//36ce+65cLlc6u/GSOVNyqAaX/3fbkfiwiuw2F2TiIiIiIiUlCKDe++9V02ALkGe/J2MjMljkNeKmTynK1xcRW8Y5LHoChERERERpRzkLV++POHftJ2nUJAxeWqmvNiATiZB55g8IiIiIiJq0Zg8v9+PRYsWIRgMcku2Iium8IoDMBoGc5LJ4xx5REREREQk0o4MqqurcfbZZ8Pj8WCnnXbCqlWr1O0XX3wxbr/9dm7VVi284gSMuKIrlqX+ZSaPiIiIiIiaFeRde+21mD9/PmbPnq3G6EUcdNBBePnll7lVW6u7pozDs9sbdNU0YaosHjN5REREREQk0i7J+Oabb6pgbvfdd48p9iFZvaVLl3KrtlaQ55KiK4BmszWYI49BHhERERERRaQdGWzevBldu3ZtcHtVVRUrPLZmkOdxwzKtBpU1VZDHwitERERERNTcIG/8+PF49913665HArvHH38ckyZNSndxlHImz1n7iRkNxuRJFo8BNhERERERNau75q233orDDjsMCxYsUJU1//GPf6i/v/jiC/zvf//jVs0gK2QC3trJ0D1uwDSh6XrC7prM5BERERERUbMyeXvttRd++OEHFeCNGjUKH330keq+OXfuXIwbN45bNZO8UdMnuF3hoitxCTsJ8gzdYCaPiIiIiIial8kTgwYNwmOPPdacp1JzJ0J3u2DpGrS4AitSXdOmNetjJCIiIiKidijtTJ5hGNi0aVOD27ds2aLuo9YJ8jTprilz4iXormnTGeQREREREVEzg7zI5NvxfD4fHA5HuoujlCdCd0GTbR/XLVOCPLtu3/7rRkREREREWSnlFND999+v/pWxX1JJMzc3t+6+UCiETz/9FMOHD2+dteyoqqO6a3pk4nnprhn7EAuWGpNHRERERESUVpB377331mXyHn744ZiumZLB69+/v7qdWmtMnhuWBHgJJj3nROhERERERJR2kLd8+XL17/7774/XX38dnTp1SvWp1ExWTJAn8+RJdc2GVTQ5fQIREREREUWknQKSIM/prJ2YO0pNTQ1uvvnmdBdHaVTXVNMnMJNHRERERESNSDs6uOmmm1BZWdng9urqanUftVbhFWd4LrwE0+ExyCMiIiIiohZV10w08fb8+fNRVFSU7uIo1cIrksnTtfClVsgKqQCP3TWJiIiIiCjtMXkyBk+CO7kMHTo0JtCT6pqS3Tv//PNTXRyl213TGa6uGd1dU6ZPkCCPmTwiIiIiIko7yLvvvvtUFu+ss85S3TILCgoaVNecNGlSqoujNLtrWm5HbXfN+uBaPg9d/mOQR0RERERE6QZ5U6ZMUf8OGDAAe+yxB+x2TsDd2qwaX/0VKXZTm0mNzuTJdQZ5RERERESUdpAXse+++9b97fV64ff7Y+7Pz89Pd5GUSuEVmUIhLpMnQZ6Mx+OYPCIiIiIiikg7BSRVNC+66CJ07doVOTk5aqxe9IVaofCKTDxvM8IBXlThlciYvESFcIiIiIiIqGNKO8i78sor8d///hf/+te/1Hx5jz/+uBqj17NnTzz77LOts5YdvfCK2wVN/lOJvKjCKzBh19ltloiIiIiIWtBd85133lHB3H777YczzzwTe++9NwYPHox+/frhhRdewKmnnpruIqmp7poyfYJlAVrsx6W6a+rsqklERERERC3I5G3duhUDBw6sG38n18Vee+2FTz/9NN3FUYqZPBXk2WI/LqmuyUweERERERG1KMiTAG/58uXq7+HDh+OVV16py/AVFhamuzhKwgoGAX8gKsgzY+bIi3TXtOlpJ2OJiIiIiKgdSzvIky6a8+fPV39fc801eOihh+ByuXDZZZep8XrpkufLHHuyjIkTJ+Lrr79u9PGlpaX405/+hB49eqgxgTIx+3vvvYd2J3r6BI8bkN6aetzHZUkdFk6fQERERERE9dJOA0kwF3HQQQdh4cKFmDdvnhqXN3r06LSW9fLLL2PatGl4+OGHVYAnE65PnjwZixYtUtU748l0DQcffLC679VXX0WvXr2wcuXK9plBjHTVBKC5XaprpmbEBXSq2CaDPCIiIiIiqtfivn5ScEUuzTFjxgxMnTpVZQeFBHvvvvsunnzySZUljCe3yxjAL774om4ydskCtv858iKFVxpm8jhHHhERERERRdthA7okKycZwGuvvbbuNl3XVXZw7ty5CZ/z9ttvY9KkSaq75ltvvYXi4mKccsopuPrqq2HIXHIJ+Hw+dYkoLy9X/5qmqS6ZIMuRTFtLlifPlzhO/lXXq+uDPEsyebJsw4BlWjHPkUAvU++D2q9MtFGi1sQ2StmObZSyHdtox2Cm+PnusCCvpKQEoVAI3bp1i7ldrksX0ESWLVum5uiTaRpkHN6SJUtw4YUXIhAIYPr06Qmfc9ttt6l5/OJt3rwZXm99l8iWbuyysjL1xZJAtTnKyqvhDxqorA4XW9FLK+GqvS9gs8Pvt2BUeqEjHKTKa/mCPmwLbUONLSrrR9RKbZSoNbGNUrZjG6VsxzbaMVRUVKT0OFtba7wyHu/RRx9Vmbtx48Zh7dq1uOuuu5IGeZIplHF/0Zm8Pn36qCygTAGRqfXSNE0ts7lfqqC3BNu2hpDrCXdDtcygJOkUR34O7A4N9jw3jE7hdQ5aQSAIFBcWw21zZ+R9UPuViTZK1JrYRinbsY1StmMb7RhcrkgaKEuDvC5duqhAbePGjTG3y/Xu3bsnfI5U1JSxeNFdM0eMGIENGzao7p8Oh6PBc6QCp1ziSePP5BdAvlQtWaY8X9PC/worqvCKqq4p9xsGNL32/pCliq7YDTu/yLRd2ihRa2MbpWzHNkrZjm20/dNT/GxTbgHr1q3DFVdcUTemLZqkhmX6hPiArTESkEkmbubMmTFnIOS6jLtLZM8991RdNKP7oi5evFgFf4kCvDYtOsiTwitSSrM2ABSmZaogj9U1iYiIiIgomp5OJUwJ8BJ1cSwoKFD9Q+Ux6ZBulI899hieeeYZ/Prrr7jgggtQVVVVV23z9NNPjynMIvdLdc1LL71UBXdSifPWW29VhVjac3VNze2GpibKiw3ypLImgzwiIiIiImpWd80PPvhATXGQjARkMh3CHXfckeoicdJJJ6kCKDfccIPqcjl27Fj1OpFiLKtWrYpJScpYug8//FDN1Sdz8sk8eRLwSXXN9j0ZukuNz4t01YwEeTbNxiCPiIiIiIiaF+QtX74cffv2TXp/7969sWLFCqTroosuUpdEZs+e3eA26cr55Zdfot2LmkJBdddUWbz6IM+CpcbjERERERERRUs5DeR2uxsN4uQ+eQxlfkyeJVV0JJUXldVUmTy9TRVHJSIiIiKibAryJk6ciOeeey7p/c8++ywmTJiQqfXq8GKqa7octVU3G3bXJCIiIiIiipZylCCVNQ8++GBVZEUqaUbGzUlFzTvvvBNPP/00Pvroo1QXR2kUXoHbCfj9QNyYPHbXJCIiIiKiZgd5+++/Px566CFV6OTee+9VVTYluyTTJ8jcdQ888AAOOOCAVBdHTYlk8uw2aIYNlhaICfI0aCy6QkREREREDaTV3++8887DkUceiVdeeUXNV2dZFoYOHYrf//73qvAKZVC1t77oiozHQ8PCKwzyiIiIiIgoXtqDumTaApnCgFqZNxLkuWFZpiq6Eh6XV0/mySMiIiIiImpWkHf//fcnvF3G6Ek2T6Y2oNbI5DkBS82SF1NdU8QHfURERERERCkHeTIOL5HS0lI1Lm+PPfbA22+/jaKiokyuX4dkBQJAMBi+oqalsMJ1UGuDOim6IgEeM3lERERERBRPT2cy9ESXbdu2qfF5pmniuuuuS3Vx1Jjo6RM8LonqajN59UGejMfjmDwiIiIiIoqXkShh4MCBuP322zmFQqa7akpoJxOh13bNlP+EFLxhkEdERERERIlkLEro27cvNmzYkKnFdWyRoivC4wZMEzDqu2aGrBCDPCIiIiIiSihjUcJPP/2Efv36ZWpxHVt19EToMoWCBRj1H5XqrgmdY/KIiIiIiKj5hVfKy8sT3i5FV+bNm4fLL78cU6ZMSXVxlOqYPAnyYNV11YzMkScBHjN5RERERETU7CCvsLAwacl+uf2cc87BNddck+riqBFWTOEVt8rkaTZbTCbPZQuP1SMiIiIiImpWkDdr1qyEt+fn52PIkCHIzc1NdVGURuEVuJywpLpmVIAtQZ5NS3seeyIiIiIi6gBSjhT23XffJh/z888/Y+edd27pOlFU4RXN45ZZ8mIKr0iQZ+gcj0dERERERA21eFBXRUUFHn30UUyYMAFjxoxp6eIoUeEV04SmxxZesev2HbNuRERERETUPoO8Tz/9VBVa6dGjB+6++24ccMAB+PLLLzO7dh1VXOEVNRYybjgkM3lERERERJRIWgO7ZB68p59+Gk888YSqtnniiSfC5/PhzTffxMiRI9NZFDUmrvCKdNfU4ippsrImERERERElknKkcNRRR2HYsGH48ccfcd9992HdunV44IEHWnftOqro7pqu2iqaUYVXZDoFmSePiIiIiIio2Zm8999/H5dccgkuuOACVU2TWo/l9dVf8bigBQNA9Jg8mNCjrhMREREREUWkHCnMmTNHFVkZN24cJk6ciAcffBAlJSWpPp1aUnglagYFy7JUV02ZDJ2IiIiIiKjZQd7uu++Oxx57DOvXr8d5552Hl156CT179oRpmvj4449VAEgZHpPncEAzDFgS4NVGeVJZU4I86bJJREREREQUL+0+fzk5OTjrrLNUZu+nn37C5Zdfjttvvx1du3bF0Ucfne7iqLEgz1M7Hk/UFlqJBHmsrklERERERIm0aGCXFGK58847sWbNGrz44ostWRRFq6ntrulywbLMcBavNsgLWaFw4RVW1yQiIiIiogQyEikYhoFjjz0Wb7/9diYW16HJmDvU+OozeZYVM0+eBUuNx2N1TSIiIiIiSoSRQrbxB4BQKKboigrw9NgxeeyuSUREREREiTDIy+aJ0N1ulclTXTWjCq/Y9LTmsCciIiIiog6EQV4WB3maR8bk1c6fEFV4hUEeERERERFlJMgLBAKqsuby5cvTeRo1p+iKcLkAM1x4RY3LY5BHRERERESZDPLsdjtee+21dJ5CLemuGZlCQWXyGOQREREREVErdNeUKppvvvlmuk+jVFXHj8kzYwqvSEZPqmsSERERERElknZKaMiQIbj55pvx+eefY9y4cWpy9GiXXHJJuoukKFZ0d83a6pqaHpXJQ7i6JhERERERUUaCvCeeeAKFhYWYN2+eukSTLBODvExW1wzPkwfNpiZAF5rFTB4REREREWUwyGPRle1YXdNdW13TqM/cyWTokSIsRERERERE8djvL9tUR3XX9NTOk6eHPyYJ+NRE6MzkERERERFRpjJ5MoVCY5588sl0F0nRanwNumtGT58gf3NMHhERERERZSzI27ZtW4O5837++WeUlpbigAMOSHdxFC+u8Ipk7zTDqCu6Ilk8Q2cmj4iIiIiIMhTkvfHGGw1uM00TF1xwAQYNGpTu4iiOFT9PXlR3TZXJgwadvWyJiIiIiCiJjEQLuq5j2rRpuPfeezOxuI4tOshz1QZ5kUyeFZ4+gd01iYiIiIgomYxFC0uXLkUwGMzU4jqu6MIrLpeaOCF6TJ5012SQR0REREREGeuuKRm7aDJmbP369Xj33XcxZcqUdBdHyTJ5Lic0Q5e50OuCPNnWhmFwCgUiIiIiIspckPf999836KpZXFyMe+65p8nKm5RGkCeVNdW8eCrKU3+HrBBsetofGRERERERdSBpRwyzZs1qnTWhuCDPXXuDFlN4hUEeERERERE1plmDu2Ts3SeffIJHHnkEFRUV6rZ169ahsrKyOYujCCmyUhfkOdU/mmXWZfIsWLBpDPKIiIiIiCi5tCOGlStX4tBDD8WqVavg8/lw8MEHIy8vD3fccYe6/vDDD6e7SIrwBcKBnvCEM3mWpkVivHCQx0weERERERFlMpN36aWXYvz48WpSdHddl0LguOOOw8yZM9NdHEXRfL76K7Vj8lSEV1tNU4I8VtYkIiIiIqLGpJ0W+uyzz/DFF1/A4XDE3N6/f3+sXbs23cVRFK2mPsjT3C5VTVNVXqkdkyeToDPIIyIiIiKixqQdMZimiVAo1OD2NWvWqG6b1Hya119/RWVJrdrpEurH5DHIIyIiIiKixqQdMRxyyCG477776q5LECIFV6ZPn47DDz883cVRFM0b111TMnkS3+laOKsHqMnQiYiIiIiIMhbkyXx4n3/+OUaOHAmv14tTTjmlrqumFF9pjoceekgtw+VyYeLEifj666+TPvbpp59WgWX0RZ7X7oI8j0vmTFABngR6JkyVxWMmj4iIiIiIMjomr3fv3pg/fz5eeukl/PjjjyqLd/bZZ+PUU0+NKcSSqpdffhnTpk1TVTklwJMs4eTJk7Fo0SJ07do14XPy8/PV/RHhLo3tsLtmeCZ0VXhF5siTLB6DPCIiIiIiakyz6vHbbDacdtppyIQZM2Zg6tSpOPPMM9V1CfbeffddPPnkk7jmmmsSPkeCuu7du6M9F16RefKs2jny5P1KkKdBY3dNIiIiIiJqeZD39ttvI1VHH310yo/1+/2YN28err322rrbdF3HQQcdhLlz5yZ9nmQP+/Xrp4rA7Lrrrrj11lux0047oa3TfPWZPM3tDo/Dk8ydFh6Tx+6aRERERESUkSDv2GOPTeVhKuOUqPJmMiUlJerx3bp1i7ldri9cuDDhc4YNG6ayfKNHj0ZZWRnuvvtu7LHHHvjll19UV9J4MkG7XCLKy8vVvxIgyiUTZDkShLVkeSqgi8rkWa5IJs9SE6LLdlIBnhV+PaLt3UaJWhPbKGU7tlHKdmyjHYOZ4uebUpCXTY1l0qRJ6hIhAd6IESPwyCOP4G9/+1uDx99222246aabGty+efNmVTgmE2T7SMCpsm21c9qlq6y8GlZ1fSavRrcjVB1UWTz/tkp4g17YDBs2BzdnZJ2pY8lEGyVqTWyjlO3YRinbsY12DBUVFa03Ji9TunTpAsMwsHHjxpjb5XqqY+7sdjt22WUXLFmyJOH90hVUCrtEZ/L69OmD4uJiVcAlU18qyWLKMpv7pQp6S+D312fy3J1yYbkMaLoOZ1E+LL+FPEceuhYkLkZD1NptlKg1sY1StmMbpWzHNtoxuFKcVSClIO/+++9P+YUvueSSlB/rcDgwbtw4zJw5s65LqDRQuX7RRReltAzpxvjTTz8lnaPP6XSqSzxp/Jn8AsiXqiXLVM+PmkJB80h1TQuaIYFeeBoFu2Hnl5Z2WBslam1so5Tt2EYp27GNtn96ip9tSkHevffem3LDSifIE5JlmzJlCsaPH48JEyaoKRSqqqrqqm2efvrp6NWrl+p2KW6++WbsvvvuGDx4MEpLS3HXXXdh5cqVOOecc9C+plCQefJCgBH+IKW6pl2377iVIyIiIiKiNiGlIG/58uWttgInnXSSGh93ww03YMOGDRg7diw++OCDumIsq1atiolYt23bpqZckMd26tRJZQK/+OILNTl7u5kMXeb9czmBqkpotdU0LViw6Tu0dy0REREREbUBWRE1SNfMZN0zZ8+e3SCrmGpmsc3Ok+d2qayoVdtds71N+k5ERERERDs4yJMulVK5MicnJ6aISbLJzamF8+RJV001rYLqeFt3PydCJyIiIiKijAR533//PQKBQN3fyTDTlLlMXl2UF5XJ40ToRERERESUkSBv1qxZCf+mzLGk7G1cJg9yW1Qmj0EeERERERE1pdlRg8xL9+GHH6KmpkZdl/Fj1AI1UROzy/QJktmr/b+QFVIBHrtrEhERERFRU9IO8rZs2YIDDzwQQ4cOVXPTrV+/Xt1+9tln4/LLL093cVTLqg4Hy0rtJIeWpqnqmjJ9ggR5zOQREREREVFT0o4aLrvsMtjtdjW1gcfjiZkKQaY+oOaxajOiQvPUdteUMY61VTZ1+Y9BHhERERERZXoKhY8++kh10+zdu3fM7UOGDFGTklPzWNXV9VfqxuRZqromM3lERERERJSqtKOGqqqqmAxexNatW+F0OtNdHEVUexsEeVptMi8S5HFMHhERERERZTzI23vvvfHss8/GTJtgmibuvPNO7L///ukujhJl8moLr8iYPInyIkEep6ggIiIiIqKMd9eUYE4Kr3z77bfw+/246qqr8Msvv6hM3ueff57u4qiRwiuABUjhFYRg1+07atWIiIiIiKg9Z/J23nlnLF68GHvttReOOeYY1X3z+OOPV5OkDxo0qHXWsiOIKrwCjys8JUVUJs/Q2VWTiIiIiIhaIZMnCgoK8Ne//rU5T6UkrKqo6poyJs8yoaG+uiYzeURERERE1GpBntfrxY8//ohNmzap8XjRjj766OYsssOLnkIBbrfqqanyrHo4k2fTm/VRERERERFRB5N25CBz4Z1++ukoKSlpcJ8UBgmFQplat447Jk/myVPdNfXa8poS63H6BCIiIiIialrakcPFF1+ME044AevXr1dZvOgLA7wWiK6u6aodkydUoAdOn0BERERERK0T5G3cuBHTpk1Dt27d0n0qpZzJk+6a4YnQ1Vx50JjJIyIiIiKilKQdOfz+97/H7Nmz030apRPkuZ213TU1FehJVo9BHhERERERtcqYvAcffFB11/zss88watQo2O2xVR8vueSSdBdJ0UGergMOB+Dzqm6aIc2EruvsrklERERERK0T5L344ov46KOP4HK5VEZPiq1EyN8M8popUl3T41LbMVx3RQsX2dT0mO1MRERERESUsSBP5se76aabcM0116gME2U4k+dy1d4gUZ6humrKmDxm8oiIiIiIKBVpR2l+vx8nnXQSA7zWCvKk6Iq6IVx4RebIk0wex+QREREREVEq0o4cpkyZgpdffjndp1EjrGAQ8PnCV9xRmTzDUEGeZPEY5BERERERUat015S58O688058+OGHGD16dIPCKzNmzEh3kR2eWVVVfyUqyJNxeBLk2TQbgzwiIiIiImqdIO+nn37CLrvsov7++eefY+5jcZCWB3laJMiDBU0yeTBhN2IDaSIiIiIioowFebNmzUr3KdSEUGVl/ZXaIM8yZUyeVNm0YNPT/piIiIiIiKiDYh/AbOuuGVN4JTwmz64zk0dERERERKlhkJcFzMqoIK92CgXp+KrVVtdkJo+IiIiIiFLFIC8LmFVR3TU9kcIr9WMcWXSFiIiIiIhSxegh66prhrtrWromUZ5K6THIIyIiIiKiVDF6yAJmTOEVZ/hfSz4dXf0r8+QRERERERGlgkFeFghFT6FQW3hFs8xwJo/dNYmIiIiIKA2MHrKt8EpknjxNgwUTuq4zyCMiIiIiopQxesi67pq18+TJ7arKpsYgj4iIiIiIUsboIUsLr0h4Z9UWXeGYPCIiIiIiShWDvCzM5FmWqaZPkEyeBHmRqRSIiIiIiIiawiAv2zJ5Mk+eJZPkASHNgg5m8oiIiIiIKHUM8rKouqZlM6DZ7bXTJ9QWXtFYeIWIiIiIiFLH6CGLumtaTkftDRLlhbtr2g37jl05IiIiIiJqUxjkZVF3Tat2InRLUnlqTJ4Fm2bbwWtHRERERERtCSOILJB/xBGoWLMcXvigcnmmTISuq2DPpvMjIiIiIiKi1DGCyALd//oXhFb+gk0r5iNH3RIuvGLqYJBHRERERERpYXfNbKSqa4anTTB0VtYkIiIiIqLUMcjLRirG06CxsiYREREREaWJEUQ2qh2Tp0FT8+QRERERERGlihFEtrLpMGWePJ0fERERERERpY4RRDayJLyT+dB1GBrH5BERERERUeoY5GUjmQtd11SQJ102iYiIiIiIUsUgLwtZlgWrNshjdU0iIiIiIkoHg7xsZFkwNZkqLxzoERERERERpYoRRDaSTJ4RHo/H6ppERERERJQORhBZSJNMnlTWZHdNIiIiIiJqi0HeQw89hP79+8PlcmHixIn4+uuvU3reSy+9pCYNP/bYY9GeWJqmxuXZdNuOXhUiIiIiImpjdniQ9/LLL2PatGmYPn06vvvuO4wZMwaTJ0/Gpk2bGn3eihUrcMUVV2DvvfdGeyRj8uy6fUevBhERERERtTE7PMibMWMGpk6dijPPPBMjR47Eww8/DI/HgyeffDLpc0KhEE499VTcdNNNGDhwINodC6q6JrtqEhERERFRunZof0C/34958+bh2muvrbtN13UcdNBBmDt3btLn3XzzzejatSvOPvtsfPbZZ42+hs/nU5eI8vJy9a9pmuqSCbIc6V7ZkuWpaRMkuJP/g4WQGYIBI2PrSB1bJtooUWtiG6VsxzZK2Y5ttGMwU/x8d2iQV1JSorJy3bp1i7ldri9cuDDhc+bMmYMnnngCP/zwQ0qvcdttt6mMX7zNmzfD6/UiUxu7rKxMfbEkSG2OsvJq+IMGKqsDMP2AtzKIiq0V0Ko4GTplRxslak1so5Tt2EYp27GNdgwVFRUpPc7W1t7UH//4Rzz22GPo0qVLSs+RLKGM+YvO5PXp0wfFxcXIz8/P2JdKCsDIMpv7pQp6S7Btawi5HjtCfgAFThR1KUKRuygj60gdWybaKFFrYhulbMc2StmObbRjcLlc2R/kSaBmGAY2btwYc7tc7969e4PHL126VBVcOeqooxqkLG02GxYtWoRBgwbFPMfpdKpLPGn8mfwCyJeqJcuU52u1STtN12FpgM2w8UtKWdNGiVob2yhlO7ZRynZso+2fnuJnu0NbgMPhwLhx4zBz5syYoE2uT5o0qcHjhw8fjp9++kl11Yxcjj76aOy///7qb8nQtXmWCQ2amiOPX1AiIiIiIkrXDu+uKV0pp0yZgvHjx2PChAm47777UFVVpaptitNPPx29evVSY+skPbnzzjvHPL+wsFD9G397W2ZpFjQJ8nZ88VMiIiIiImpjdniQd9JJJ6kiKDfccAM2bNiAsWPH4oMPPqgrxrJq1aqOldEyLZgS5Bm6yuYRERERERG1qSBPXHTRReqSyOzZsxt97tNPP432RJW+taS/rY3z5BERERERUdqYKso2EuTJROjsrklERERERM3AKCIbgzxY0A2D3TWJiIiIiChtjCKyjozJM6FrBrtrEhERERFR2xyTR1FkQJ4GGIZ9R68JERERUYcSCoUQCATQFsk0ZLLuXq+3YxUtbGfsdruaR7ylGORlG1V4xYLDcOzoNSEiIiLqEKTwnVR5Ly0tRZsu3meaqKioUJOiU9slU8R17969RZ8jg7xsLbzCrppERERE20UkwOvatSs8Hk+bDJIkyAsGg7DZbG1y/QnqM6yursamTZvU9R49ejR7WQzyso1lwTI02DR+NERERETbo4tmJMDr3Lkz2ioGee2D2+1W/0qgJ22yuV032WE3G4M8ib51BnlERERErS0yBk8yeETZINIWWzI+lEFe1rGgcfoEIiIiou2K2S9qT22RkUSWsUxLfbAM8oiIiIiIqDkYSWQjZvKIiIiIqBWsWLFCJRR++OEHdX327NnqeqSy6NNPP62qO2bTOmaTp7Ng+6SCkUSWsUIhaJoOQ2N1TSIiIiLKrD59+mD9+vXYeeedd/SqZL3+/fvjvvvui7ntpJNOwuLFi5HtWN0jy0jRFZnAkpk8IiIiIsokv98Ph8Oh5mCj5le/jFTAzGaMJLKMqVvQdRuDPCIiIiJKSiY9P/XUU5GTk6PmU7v33ntx0EEH4c9//nNMJupvf/sbTj/9dOTn5+Pcc89tVlfIt956C7vuuitcLhcGDhyIm266SU3X0JjHH38cI0aMUM8ZPnw4/vnPf9bdd9ZZZ2H06NHw+Xx1wecuu+yi1jPasmXLsP/++6tqk2PGjMHcuXPr7tuyZQv+8Ic/oFevXur+UaNG4cUXX2wyEzd27FjceOONddNOyN99+/aF0+lEz549cckll6j79ttvP6xcuRKXXXaZ2l6RYijR3TUloye3L1y4MOY15LMYNGhQ3fWff/4Zhx12GHJzc9GtWzf88Y9/RElJCVoTI4ksY5omdN1gd00iIiIiSmratGn4/PPP8fbbb+Pjjz/GnDlz8P333zd43N13360CJLnv+uuvT/t1PvvsMxV8XXrppViwYAEeeeQRFejccsstSZ/zwgsv4IYbblCP+fXXX3Hrrbeq137mmWfU/ffffz+qqqpwzTXXqOt//etf1ZjABx98MGY5cvsVV1yhAtKhQ4eqoC4SXHq9XowbNw7vvvuuCqIkgJXg6euvv075vb322msqIJP39Ntvv+HNN99UwaJ4/fXX0bt3b9x8882qe6tc4sk6jR8/Xr3f+Pd/yimnqL/lfR1wwAEqiP3222/xwQcfYOPGjTjxxBPRmthdM8uYVggGu2sSERER7VDLf/d7BFs52xLP1qULBrz2akpZPAmY/v3vf+PAAw9Utz355JMqqxVPAozLL7+87rpk8tIhWTsJxqZMmaKuSyZPsoNXXXUVpk+fnvA5cvs999yD448/Xl0fMGBAXYAoy5GM1vPPP499990XeXl5Kts2a9YslW2MJgHeEUccUbceO+20E5YsWaIyg/Je5f6Iiy++GB9++CFeeeUVTJgwIaX3tmrVKtV1VTKgdrtdZfQizy0qKlITkcv6Nda9VbKpEpzKNolk9+bNm6fen5D7JMCTQDdCPisZGymPlUCxNTDIy8IxeZLFY5BHREREtONIgBfcuBHZSLoxykTZ0cFMQUFBwoBBMk0tMX/+fJUxjM7chUIhlUmrrq5uMIm8ZOiWLl2Ks88+G1OnTq27XTJwso4RkyZNUkGaBEdXX3019tprrwavLV06I6RLqti0aZMK8mQdJHCSoG7t2rWqy6d0/0xnUvsTTjhBBZgSuB566KE4/PDDcdRRR8FmSz1EOvnkk9X7+PLLL7H77rurLJ50bZV1jGw/CWAlsI0n24lBXgcRQnhMHifkJCIiItpxJKvWHl5Txuy1RGVlpcqiRbJy0WS8XaLHi8ceewwTJ06MuU8yY9FDlCR4lNskO5eIZNciIsfG8jxx11134R//+IcK0qSLpbxPGY8owV6EFDOUcXfRJDiOkGzaokWL8Mknn6gurxdeeKFa7v/+97+Y126MZPkkWypZVQny5N8LLrggZntI4HjHHXc0eG4kcG0NDPKyiWXB1CzYDceOXhMiIiKiDi2VbpM7imSeJAj55ptvVBdDUVZWpsaV7bPPPhl9LclKSSA0ePDglB4vhUWkgIlkG6UrYzISTEnBEgmoJk+ejKeeegpnnnlmyuslAeIxxxyD0047rS74k+6PI0eOrHtMcXFxzFi68vJyLF++PGY5UilTgjC5/OlPf1IZuJ9++km9b6lEKhnDpsj7lO6rMmZQ3rdk9yJkOTL2T4rApJMhbCn2CcwmlvzPgs1I7cwBEREREXU8Mk5MxrZdeeWVqivgL7/8gnPOOUdlrjLdG0wKqDz77LMqmyevI4VUXnrpJVx33XVJnyOPve2221SBFQm8JGiSIG7GjBnqfikCI8uVCpx77rmnul0Ku0iAlKohQ4ao7NsXX3yh1um8885TBU2iHXDAAXjuuedU8RhZB9lm0dlEKSDzxBNPqMIt8toyjk6Cvn79+qn7JTD79NNPVXfQxqphSpZTxklKBk+qgUqQGyGB49atW1UAKEG5dNGUsYMS0KYSQDYXg7ysYsLSLDh0BnlERERElJwERjKu7cgjj1SFQ/bYYw+VhUrUhbIlJMv2f//3f/joo4+w2267qS6JUpEyEgglIgGnBHAS2ElXSimwIgGVFGCRsXySfTvjjDNU9kxIZUwJjqQ6ZqqBjwSZkiWT9ZPpDqTb5LHHHhvzmGuvvVa9tmwjKeAi90dPbSBTIUi3Ugk0ZfyfdNt855130LlzZ3W/VNaUQjXyHMkKNhZ0y3uR8Xfx2UsJ+CTrKO/rkEMOUdtDupXKa0tQ3lo0K76jajsnaVoZ9Ckp7fgKPs0l6WEZBNq1a9dmf1hrV/6C5UvnQXM4MHjknuhW1Ccj60aUqTZK1JrYRinbsY22XxJ0SBc+CUAyHSBtTzL2S0r+y5QJEmRR+2yTqcYyHJOXTSwZVKpDj0ojExERERHFky6PMqZNKmzKAb9knYSMUyNikJdNzHBSVSZDJyIiIiJqjGTtpCiKFAiRicH/+9//ossOqApK2YdBXval8mDT+bEQERERUXIywbZMuh0hI7BkLjoiwU7lWcSyTInxVJdNIiIiIiKi5mA0kUVMqYGj22BwCgUiIiIiImomBnlZxJQ58qDBMNhdk4iIiIiImodBXhYxYUI3bDA0Fl4hIiIiIqLmYZCXRWTArAR5mgzMIyIiIiIiagYGeVlEJlDQdIOZPCIiIiIiajYGeVnGxkweEREREaVgv/32w5///GdkuxUrVqjj2x9++GFHr0qHwSAvy9htzh29CkRERERE1IYxyMsyhs7pE4iIiIio7fH7/Tt6FagWg7ws43Awk0dEREREqTFNE1dddRU6d+6MPn364MYbb6y7b8aMGRg1ahRycnLUfRdeeCEqKyvr7l+5ciWOOuoodOrUST1mp512wnvvvafuC4VCOPvsszFgwAC43W4MGzYM//jHP2Je+4wzzsCxxx6LW265BT179lSPEV9//TV22WUXuFwujB8/Ht9///122x4UxgnZsoiuabDp/EiIiIiIKDXPPPMMpk2bhi+//BJz5szBOeecg7322gsHH3wwdF3H/fffrwK1ZcuWqSBPAsJ//vOf6rl/+tOfVPbt008/VUHeggULkJubWxc89u7dG//5z39UAPnFF1/g3HPPRY8ePXDiiSfWvf7MmTORn5+Pjz/+WF2XIPLII49Ur//8889j+fLluPTSS3fQ1um4GFFkEVVZU2dlTSIiIqId7agH5mBzhW+7vmZxnhPvXLxXWs8ZPXo0pk+frqbikmDu4YcfVoGXBFnRRVn69++Pv//97zj//PPrgrxVq1bhd7/7ncr2iYEDB9Y93m6346abbqq7LsueO3cuXnnllZggT4LDxx9/HA6HQ11/9NFHVYD4xBNPqEyeZAfXrFmDCy64oAVbhtLFIC+LGLqu5skjIiIioh1LArwN5V5kOwnyokmmbdOmTervTz75BLfddhsWLlyI8vJyBINBeL1eVFdXw+Px4JJLLlHB10cffYSDDjpIBXzRy3vooYfw5JNPqmCwpqZGZf3Gjh0b83oSIEYCPPHrr7+qZUiAFzFp0qRW3AKUCCOKLKLBgM458oiIiIh2OMmqtYXXlIxbNJmqQDJpMm2BdJuUIE7GzBUVFanunDLOToI1CfKka+fkyZPx7rvvqkBPAsJ77rkHF198MV566SVcccUV6roEaXl5ebjrrrvw1VdfxbyeZPIo+zDIy7IxeTq7axIRERHtcOl2m8w28+bNU8GeBGkyNk9IV8t4UpBFunDK5dprr8Vjjz2mgrzPP/8ce+yxhxrHF7F06dImX3fEiBF47rnnVMYwks2T8YK0fbG6ZpZ115TJ0ImIiIiIWmLw4MEIBAJ44IEHVNEVCbxkvF40GbP34YcfquIo3333HWbNmqWCNDFkyBB8++236v7Fixfj+uuvxzfffNPk655yyikqmzh16lRVyEWqdd59992t9j4pMQZ5WVZ4RWN3TSIiIiJqoTFjxqgpFO644w7svPPOeOGFF1R3zGgyTYJU2JTA7tBDD8XQoUPrirKcd955OP7443HSSSdh4sSJ2LJlS0xWLxmpzvnOO+/gp59+UtMo/PWvf1XrQNuXZkkpng5EBp0WFBSgrKxMlXvNBEmFywDXrl271qXD07V25S/qMmrMQXAXFGVkvYgy2UaJWhPbKGU7ttH2S7oVSiZLqkdGFwtpa+SQXgqr2Gw2lUmj9tkmU41luJfKIoams/AKERERERG1CIO8LOuuyTF5RERERETUEgzysohNxuQZzOQREREREVHzMcjLIoZ01WQfaiIiIiIiagEGeVnErnOgLBERERERtQyDvCxi0x0AK3YREREREVELMKLIErqmw25zsLsmERERERG1CEs5ZokiRyGCthAzeURERERE1CJZEVE89NBD6N+/v5rsb+LEifj666+TPvb111/H+PHjUVhYiJycHIwdOxbPPfcc2kMmzzAMjskjIiIioqy0bds23HTTTVi/fv2OXhXK9iDv5ZdfxrRp0zB9+nR89913GDNmDCZPnoxNmzYlfHxRURH++te/Yu7cufjxxx9x5plnqsuHH36INo/TJxARERFRCvbbbz/8+c9/3m6vZ1kWpkyZgpqaGvTo0SOl5zz99NMqMbM9LFq0CN27d0dFRQW2p5NPPhn33HMPss0OD/JmzJiBqVOnqkBt5MiRePjhh+HxePDkk08mbdDHHXccRowYgUGDBuHSSy/F6NGjMWfOHLR57KpJRERERFnorrvuQn5+Pm677baUn3PSSSdh8eLF/9/enUBHVZ5/HH9YwiKEoGCAFBAUhErdQLaKooIgAgcKVVQqIngUDRZxAW0VULEgtGUrWFpaqKeyiBaoKJvsdWFTrCBSa0HiQVaNARQIyfzP723v/GeGSSALmZuZ7+ecOcmde+fe9955CfPM87zvtZLw1FNP2cMPP2zJycnWv39/Vx2X10MVhF5c4T2nikLFItOmTQsLUqO9Xtt6nn76aXvhhRfs22+/NT+J6Zi8kydP2pYtW9yb4ilbtqx17NjRZerO5huFVatWucj9xRdfjLrNiRMn3MOTlZXlfubm5rpHcdB+1Jai7C83ELBAmTLF1iaguPsocC7RR+F39NH4f2+9R2kS2Wbv93NxHk888cRpxzkTBUN6nOvrumfPHlu8eLFNnjzZHWvixIlhwWhaWppLIN1yyy1uWUOkvDbdd9999txzz9l3331nL7/8sqWnp7vs45133um2UWD76aefhh1PgZ73+mbNmrnEk4aP6bXF+b5Gi1fO9m9QTIO8Q4cOWU5OjtWqVSvseS1HXsxQipR/8IMfuOBNb5Ii7ptvvjnqtnqDVTsc6eDBg3b8+PFiOIv/Xmy1SW+GgtTCOJWZaYGTJy0pjzJVINZ9FDiX6KPwO/po/MrOznbv76lTp9yjtFBfVNsVWLzyyiuWlJTkAhZ97vX66F//+lf73e9+57JpmstCmSuVFqamprrXK3OlijoNnfJs3brVWrVqZZ988ok1atTIMjMzbfjw4fbGG2+4z94tWrRwWT0NsZKPPvrIHn/8cZe4UfCj1+izubZT0PTYY4+5z92ev//97zZ69GjbsWOHC75+9rOfuYRP+fL/DUsqVKjgKvveeustW7FihfvMr2RO9+7d87wWc+fOdZV9iiH0HlapUsU9QinDV7NmzeCyttM1qFy5cvB5ZeVmz55tixYtsttuu831C51T6OtCX++59dZbXRseeOCBQr2X0fatYx8+fNi9r6HOthy1VM6uqTdJHfDo0aO2cuVK1zEvvvhi13EjqdOEdlxl8urVq2cXXnihi8yLg9cBtM/C/uHP1j/Wk9lWITW1WNoEFHcfBc4l+ij8jj4av/Slvz44K8jwAo3SQP1R2aMBAwbYhg0bbPPmzS7I0GdiBW5ev33++eetSZMmbr4LBVxa9+abb7r1Gi6lQGzYsGHB/Wqf119/vTVt2tQt33XXXS4QUtCVkpJi06dPdxkxVdJprgyVRl599dX20ksvueSLPqMre6dr6f1b8a7r+vXrXXsnTZpk1113nX3++eeuzdpO83N4FAQqsPv1r39tU6ZMcWMBd+/e7Y4XzbvvvusmZszv/StXrtxp673yy9DnNWxMQVa09uelTZs2NnbsWJe8qlixohWVd+waNWqElYZK5HKe+7AYUlSsC75///6w57WsgZN50UnrWwLR7Jr6JkAZu2hBni50tIutfRTnH2l1kKLss6zSvkn/35mA4lbUPgqca/RR+B19ND7p/Qwdb+Xps7iPHfr+UIm2pWblmjav27yz3l6JC5Umqt0K5JRV0/L999/v1g8cODC4rUoKVc7YsmVLO3bsmFWtWtUFeQquNm3a5LJ3ygzOmTPHBVfap+a80Kz3ChC9z9PKBCrT9frrr7vjqFRSpZyaL0MuvfTS4DG96+n9VFnkk08+6QJDr00KQhVkjho1Kvg6rVdwKfqMr0BPbfTKLSN98cUXLsjLb5b6MhHvb+TzCtB07prYUeflPa8MvhJMoRSgLlmyJLisbKOGoSmGueiii6yovGNH+3tztn9/YhrkKR2rVK6ycT179gx+46DlwYMHn/V+9JrQcXelkt5MZtcEAADwBQV4B77z9zAaZZBCAxctK8hTwKJEikooFTwp+NPtD7zxXArMVKqpcsmuXbu68WoK8rySTJUqil6nyjlllEJphk1l4UQVcyoTVQZQ82rotQreotH+3nnnHTdRiUdtVTZVY+KURROVXnpUdqnqu7xm3vfac7YZrkgqLZ0xY4YL0nTNhg4dag8++GBwvQI83QEglDKb0ZZ1Dn4R85y0OoZSsIq+1bnUMfXtgr5ZkH79+rno2Bs8qZ/aVp1HnVCpY3UqpYhLs/IR/3gAAAAQO8qqleZj6vO0bkumh8bsqdRYwZ2WFdB4FKDdfffdNmHCBJs5c6abEdMLthTg6XYJa9asOW3/3q0RFEQq66YSUGW3lBnU+DTNhh9J+9OYwV69ep22LjRIixyHpkA2vwlHVB2oILYw+vbt627PpkBN5xotc+ZVEObl66+/dj91jf0i5kGeOpIGY44YMcL27dvnyi+XLl0anIxFnTH0YqvDPvTQQ/bll1+6N0P1whpUqv2UZmTxAAAA/KMgZZOxorF4kcuNGzd2GSlNYqiJOzRWTGWdonF7kTRpiLJlSpjoM/i6deuC65o3b+4+n2uMmHfbgWhUoqmHsmCalVLBYrQgT/vTWL4zBU0FpTGBmiimMFJSUorcnm3btlndunWjTtCSsEGeqDQzr/LMyG8ONBBTDwAAACCRKRmiqjhNXqLSTJUeajyd1K9f3w2N0ni2QYMGuUBE498iKSDUGDhNVqgAsW3btsF1Kr/UsoZVjRs3zgVye/fudVk7BXG6fYDG4/30pz+1hg0buiSMxs717t07anuV1OnWrZtrm16jRI5KONW2ony+V3ZSGUmvTLU4aQZOBbqRNEOpl4jShDKdOnUyP2HkMAAAAFAKaViTxqNpyJOXNPEmXVHpoG7mPX/+fDf+Thk9LwCMpAlaVMLpDZcKLZPU0CjNtql1CvLuuOMON9GJqu4UUClbqHZo3e23325dunSJevsyLxjT/eyWL1/uJoDRGEKViRZ1shIdU9nGt99+24pbVlaWK+OMfHhjBDWecOHChcEZTf2iTKC03fWxGN4opWU1U05x3kJBb3RoRA/4CX0Ufkcfhd/RR+OXPqTv2rXLZaIKO3mHH+gjvTf1f36zTEajTFSHDh0sIyPjtPtXlxZTp0519+BbtmxZiR5XZa4LFixwgWtJ9MmzjWV8Ua4JAAAAoGRpEkPNjaHJUzQrZmkN8EQlq7pxu+55mBxxy4NzSZPEqCTWb/gqCgAAAEhAui+cSiUVHGnMXWmmDKZmySzJAE80FlD3KPQbgjwAAAAgAWnCFU1WoklbdMsyxA+CPAAAAACIIwR5AAAAABBHCPIAAACQ8BJswnnEeV8kyAMAAEDC0uyI8t1338W6KUBYX/T6ZmFwCwUAAAAkLN3Qu3r16sGbW5933nkFvs9cab9PHvzzHirAU19Un1TfLCyCPAAAACS02rVru59eoFdaA4Tc3FwrW7YsQV4ppwDP65OFRZAHAACAhKagqE6dOpaammrZ2dlWGinAO3z4sNWoUcMFeiidVKJZlAyehyAPAAAA+F/pZnF8wI5VkKcAoVKlSgR5YOIVAAAAAIgnBHkAAAAAEEcI8gAAAAAgjpRP1JsLZmVlFWsN9JEjR6iBhm/RR+F39FH4HX0UfkcfTQxZ/4thznTD9IQL8tT5pV69erFuCgAAAAAUKqZJSUnJc32ZwJnCwDj8lmPv3r2WnJxcbPcQUUStoDEjI8OqVatWLPsEihN9FH5HH4Xf0Ufhd/TRxBAIBFyAl5aWlm/GNuEyeboYdevWPSf71j8o/lHBz+ij8Dv6KPyOPgq/o4/Gv/wyeB4KdgEAAAAgjhDkAQAAAEAcIcgrBhUrVrSRI0e6n4Af0Ufhd/RR+B19FH5HH0VCT7wCAAAAAPGMTB4AAAAAxBGCPAAAAACIIwR5AAAAABBHCPKKaOrUqdagQQOrVKmStW7d2jZu3BjrJiFBrVu3zrp37+5ujlmmTBlbuHBh2HoNvx0xYoTVqVPHKleubB07drTPPvssZu1F4hkzZoy1bNnSkpOTLTU11Xr27Gk7d+4M2+b48eOWnp5uNWrUsKpVq1rv3r1t//79MWszEstLL71kV1xxRfA+Y23btrUlS5YE19M/4Tdjx451/+c/8sgjwefopxCCvCKYN2+ePfroo24mow8++MCuvPJK69y5sx04cCDWTUMCOnbsmOuD+uIhmnHjxtnkyZPt97//vW3YsMGqVKni+qv+MwBKwtq1a90Hj/fff99WrFhh2dnZ1qlTJ9d3PUOHDrU33njD5s+f77bfu3ev9erVK6btRuKoW7eu+9C8ZcsW27x5s910003Wo0cP2759u1tP/4SfbNq0yaZPn+6+mAhFP4Wj2TVROK1atQqkp6cHl3NycgJpaWmBMWPGxLRdgP5pL1iwILicm5sbqF27dmD8+PHB5zIzMwMVK1YMzJkzJ0atRKI7cOCA66tr164N9smkpKTA/Pnzg9vs2LHDbfPee+/FsKVIZOeff35gxowZ9E/4ypEjRwKNGzcOrFixItC+ffvAkCFD3PP0U3jI5BXSyZMn3Td9KnnzlC1b1i2/9957MW0bEGnXrl22b9++sP6akpLiSozpr4iVb7/91v284IIL3E/9TVV2L7SfNm3a1OrXr08/RYnLycmxuXPnukyzyjbpn/ATVUV07do1rD8K/RSe8sHfUCCHDh1y/wHUqlUr7Hktf/rppzFrFxCNAjyJ1l+9dUBJys3NdWNIrr32WvvRj37knlNfrFChglWvXj1sW/opStLHH3/sgjqVsms804IFC+yyyy6zrVu30j/hC/ryQcOEVK4Zib+j8BDkAQBi8i30tm3b7B//+EesmwKEadKkiQvolGl+7bXX7J577nHjmgA/yMjIsCFDhrhxzZr0D8gL5ZqFVLNmTStXrtxpsxVpuXbt2jFrFxCN1yfpr/CDwYMH2+LFi2316tVuoguP+qJK4TMzM8O2p5+iJCkL0qhRI2vRooWbEVYTWk2aNIn+CV9QOaYm+GvevLmVL1/ePfQlhCZW0+/K2NFPIQR5RfhPQP8BrFy5Mqz8SMsq8wD8pGHDhu6Pe2h/zcrKcrNs0l9RUjQnkAI8lb+tWrXK9ctQ+pualJQU1k91i4U9e/bQTxEz+r/9xIkT9E/4QocOHVxJsbLN3uOaa66xvn37Bn+nn0Io1ywC3T5BZRz6B9WqVSubOHGiG6B97733xrppSEBHjx61f//732GTregPvia10IBrjX8aPXq0NW7c2H24fuaZZ9w99XSvMqCkSjRnz55tixYtcvfK88aHaBIg3btRPwcOHOj+tqrf6j5lDz/8sPtg0qZNm1g3Hwngqaeesi5duri/mUeOHHH9dc2aNbZs2TL6J3xBfzu9ccwe3RJJ98TznqefQgjyiqBPnz528OBBd4NpfVi56qqrbOnSpadNbgGUBN3T6cYbbwwu6w+86IuIWbNm2bBhw9yXEPfff78r42jXrp3rr9T0oyRvNC033HBD2PMzZ860/v37u98nTJjgZirWzXuVPdG9HKdNmxaT9iLxqAyuX79+9tVXX7mgTvcfU4B38803u/X0T5QG9FNIGd1HgUsBAAAAAPGBMXkAAAAAEEcI8gAAAAAgjhDkAQAAAEAcIcgDAAAAgDhCkAcAAAAAcYQgDwAAAADiCEEeAAAAAMQRgjwAAOLc1q1bbfz48Xbq1CnzE7+2CwBKO4I8AEDMlClTxhYuXBiz499www32yCOPmB/179/fevbsWeT9fP3119a7d2/74Q9/aOXLl7fi1KBBA5s4caLv2gUAiY4gDwCAkKBv1qxZ5geTJk0qclsCgYD169fPhg8fbt26dTO/8Gu7ACBe8NUZAKBUyc7OtqSkJIt3KSkpxZIpXbx4sfmNX9sFAPGCTB4AJDhlr37+85/bsGHD7IILLrDatWvbqFGjwrbZs2eP9ejRw6pWrWrVqlWz22+/3fbv3x9cr+2vuuoq+/Of/2z169d32z300EOWk5Nj48aNc/tMTU21F1544bTjf/XVV9alSxerXLmyXXzxxfbaa68F1+3evdsFBPPmzbP27dtbpUqV7JVXXnHrZsyY4Ur99FzTpk1t2rRp+Z7nsWPHXPZIbatTp4795je/OeO1yczMtPvuu88uvPBCd9433XSTffTRR8H1+v3GG2+05ORkt75Fixa2efNmt+6LL76w7t272/nnn29VqlSxZs2a2VtvveXW6boMHDjQGjZs6M67SZMmLnOXX7mmrsvll1/utq9Ro4Z17NjRnVNetm3b5q6rzrdWrVp2991326FDh9y6P/zhD5aWlma5ublhr9F7PGDAAPf7559/7pb1Wu2jZcuW9vbbb+d5PO+90ji70Oun59asWXNW7SrMeQIATkeQBwCwv/zlLy4Q2bBhgwvKnnvuOVuxYoVbp0BAH/Y1hmrt2rXu+f/85z/Wp0+fsH0oKFiyZIktXbrU5syZY3/605+sa9eu9uWXX7rXvfjii/b000+7Y4R65pln3NgsBUx9+/a1O+64w3bs2BG2zZNPPmlDhgxxz3fu3NkFeiNGjHBBo5771a9+5faj88jLE0884dqxaNEiW758uQs8Pvjgg3yvy2233WYHDhxw57VlyxZr3ry5dejQwV0LUXvr1q1rmzZtcuvVTi/LmJ6ebidOnLB169bZxx9/7M5fgY13TfW6+fPn2yeffOLO5Re/+IW9+uqrUduhQPjOO+90AZjOV23v1auXK3uMRsGVAtKrr77aBZ16TxSUKzj3zuvw4cO2evXq4Gt0TtpO5yRHjx61W2+91VauXGkffvih3XLLLS5oVcBfWGdqV0HPEwCQhwAAIKG1b98+0K5du7DnWrZsGRg+fLj7ffny5YFy5coF9uzZE1y/fft2feoObNy40S2PHDkycN555wWysrKC23Tu3DnQoEGDQE5OTvC5Jk2aBMaMGRNc1j4GDRoUduzWrVsHHnzwQff7rl273DYTJ04M2+aSSy4JzJ49O+y5559/PtC2bduo53jkyJFAhQoVAq+++mrwucOHDwcqV64cGDJkSNTXrF+/PlCtWrXA8ePHTzv29OnT3e/JycmBWbNmRX395ZdfHhg1alTgbKWnpwd69+4dXL7nnnsCPXr0cL9v2bLFXYfdu3ef1b50LTp16hT2XEZGhtvHzp073bL2PWDAgOB6nVNaWlrY+xWpWbNmgSlTpgSXL7roosCECRPC3qsPP/wwuP6bb75xz61evfqs2lXQ8wQAREcmDwBgV1xxRdiyyhmVwRJlVOrVq+censsuu8yqV68elnHTTIsqW/SoFE/blS1bNuw5b7+etm3bnrYcmcm75pprgr+rdE9ZQ5U7KjPmPUaPHu2ej0bPnzx50lq3bh18TqWpKpPMizKLymapZDD0OLt27Qoe59FHH3XlnCopHDt2bNjxVQKrNl177bU2cuRI++c//xm2/6lTp7ryTpWCar8qocwrS3bllVe6DKLKGJWF++Mf/2jffPNNvm1Xli603Spp9a6FKGP3+uuvu2yjKDuqLKr3funcH3/8cVcSq/da+9D7UpRM3pnaVdDzBABER5AHADhtIhONo4ocr1WYfRTHfkWlpB4FH6IAQOO/vIfGer3//vtWXHQcBbuhx9Bj586drvTTG4u4fft2V5a6atUqF9QuWLDArVPwp7JWjTlTuaYC1SlTprh1c+fOdQGUAlWVjmq/9957rwtEoylXrpwrk1XZqI6h/ShAVcCZV9tVWhnZ9s8++8yuv/56t43WK5n65ptvWkZGhq1fvz5Yqilqn85FpbBap9cr+MqrjV5wGFpaqUlyCtKugp4nACA6gjwAQL6UyVEQoIdH48g0vkofxIsqMjDTso6ZF2UDNWmIAqhGjRqFPTSRSTSXXHKJCzhDxwMqQ/Svf/0rz+No/N2+ffvcPdwij1OzZs3gdpdeeqkNHTrUBWsaPzZz5szgOmU/Bw0aZH/729/ssccec4GpvPPOO/bjH//YTU6j8WnaZ15ZyNAAWVnBZ5991o2Rq1ChQjCgjNZ2BZ/Krka23QuYNWGN2qsMnsZQKpjS6zxqoyZ/+clPfuKCO02eo8lV8qKMpDeuzhM6CcvZtqsg5wkAiI4gDwCQL5Ui6kO+sjyaqGTjxo1ulkrNdhlaRllYmnxEs3Iq4FJZo/Y/ePDgfF+jAGDMmDE2efJk9zplyhRc/fa3v426vcoClTVTBk4ZN2X9FMCElpJGO2+VjmqGSwVwCnDeffdd++Uvf+kmDfn+++9dOzU5iGbSVFCkCVi8AFU3WV+2bJnLQum6qUzRW9e4cWO3D61X+zVpjF6bFwWnyqjpNSqXVNB48ODBPINhTfqiiVQ0iYn2qwBSx1K2UDN7evSeKpOn6x+axfPaqOMoUFOZ5V133ZVvFlazYbZp08aVraqsU5PcaKKdgrSroOcJAIiOIA8AkC9lVjQjpW4FoJI6BT+61YFua1AcFLCpfFHjAl9++WWXVTpThlClkLqFggI7BaAKOHXj8LwyeTJ+/Hi77rrrXLmgzqFdu3ZuTFx+561bHuicFYQoY6cxawrolE1UaaFmqFTAq3WaIVK3BtD5iIIWBTUKUDQzpbbxbvPwwAMPuCyaZijVOEHtR1m9vOj2DJqlU7Ndaj8KnnQLCB0vGmU6FXSqDZ06dXLXSEGnxtaFBraa6VJjE1WCqiAulAJmvefKOOqaaVbT0ExfNAoWT5065a6rjqcxiQVpV0HPEwAQXRnNvpLHOgAAAABAKUMmDwAAAADiCEEeAAAAAMQRgjwAAAAAiCMEeQAAAAAQRwjyAAAAACCOEOQBAAAAQBwhyAMAAACAOEKQBwAAAABxhCAPAAAAAOIIQR4AAAAAxBGCPAAAAACIIwR5AAAAAGDx4/8AxulQntj51HkAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 900x550 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- essais nécessaires pour atteindre la cible commune 0.9544 (médiane) ---\n",
+      "grille    : essai 45\n",
+      "hasard    : essai 44\n",
+      "bayésien  : essai 12\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Figure : meilleur score vs nombre d'essais (médiane + bande)\n",
+    "trials = np.arange(1, N_TRIALS + 1)\n",
+    "\n",
+    "def med_band(c):\n",
+    "    return np.median(c, axis=0), c.min(axis=0), c.max(axis=0)\n",
+    "\n",
+    "plt.figure(figsize=(9, 5.5))\n",
+    "labels = []\n",
+    "for curve, color, name in [(grid_curves, \"#d62728\", \"grille exhaustive\"),\n",
+    "                           (rand_curves, \"#1f77b4\", \"hasard\"),\n",
+    "                           (bayes_curves, \"#2ca02c\", \"bayésien (TPE)\")]:\n",
+    "    m, lo, hi = med_band(curve)\n",
+    "    plt.plot(trials, m, color=color, lw=2, label=name)\n",
+    "    plt.fill_between(trials, lo, hi, color=color, alpha=0.15)\n",
+    "\n",
+    "# cible commune = pire des trois optima finaux (le premier que grid atteint en dernier)\n",
+    "target = min(np.median(grid_curves[:, -1]), np.median(rand_curves[:, -1]),\n",
+    "             np.median(bayes_curves[:, -1]))\n",
+    "plt.axhline(target, ls=\"--\", color=\"gray\", lw=1)\n",
+    "plt.text(N_TRIALS * 0.52, target + 0.002, f\"cible {target:.4f}\", fontsize=8)\n",
+    "\n",
+    "def reach(c):\n",
+    "    hit = np.where(np.median(c, axis=0) >= target)[0]\n",
+    "    return int(hit[0]) + 1 if hit.size else N_TRIALS\n",
+    "\n",
+    "for curve, color, name in [(grid_curves, \"#d62728\", \"grille\"),\n",
+    "                           (rand_curves, \"#1f77b4\", \"hasard\"),\n",
+    "                           (bayes_curves, \"#2ca02c\", \"bayésien\")]:\n",
+    "    at = reach(curve)\n",
+    "    plt.annotate(f\"{name}: {at}\", xy=(at, target), xytext=(at, target - 0.012),\n",
+    "                 fontsize=8, color=color, ha=\"center\")\n",
+    "\n",
+    "plt.xlabel(\"nombre d'essais évalués\")\n",
+    "plt.ylabel(\"meilleur AUC atteint (CV 3-fold)\")\n",
+    "plt.title(\"Meilleur score vs budget d'essais — 3 stratégies (médiane ± min/max sur 3 graines)\")\n",
+    "plt.legend(loc=\"lower right\"); plt.grid(alpha=0.3); plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"--- essais nécessaires pour atteindre la cible commune \"\n",
+    "      f\"{target:.4f} (médiane) ---\")\n",
+    "for curve, name in [(grid_curves, \"grille\"), (rand_curves, \"hasard\"),\n",
+    "                    (bayes_curves, \"bayésien\")]:\n",
+    "    print(f\"{name:10s}: essai {reach(curve)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-012",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004069,
+     "end_time": "2026-08-23T08:22:16.368824+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.364755+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Trois constats, lus sur la figure et le résumé ci-dessus — pas sur une intuition :\n",
+    "\n",
+    "1. **Le bayésien s'installe tôt.** Il atteint la cible commune vers le douzième essai, quand la grille et le hasard n'y arrivent qu'en toute fin de budget. C'est la concentration : chaque essai est choisi *à partir* des précédents, là où les deux autres stratégies dépensent leur budget sans mémoire.\n",
+    "2. **Grille et hasard finissent dans le même voisinage.** À ce budget, leur écart final reste faible au regard de l'amplitude totale entre configurations — qui va, sur ce problème, d'un MLP quasi dégénéré (pire que le hasard) à ~0.96 d'AUC. Le résultat « hasard ≥ grille » de Bergstra est un argument de **couverture** : il se manifeste quand l'espace est très large face au budget et que la bonne région est petite. Ici, le message dominant est la concentration du TPE, pas la hiérarchie grille/hasard.\n",
+    "3. **La bande min–max est là pour rappeler le protocole.** L'ordre entre deux stratégies proches se juge sur la médiane de plusieurs graines, jamais sur un run isolé — c'est exactement le point d'entrée de la section suivante."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-013",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004936,
+     "end_time": "2026-08-23T08:22:16.377244+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.372308+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Le protocole qui évite de se mentir : variance, gain marginal, quand s'arrêter\n",
+    "\n",
+    "Un search honnête ne se résume pas à « la meilleure AUC ». Trois pièges à fermer :\n",
+    "\n",
+    "1. **La métrique doit être honnête.** On *tune* sur un score mesuré en **validation**, jamais sur le test final. Le test, s'il existe, est un *report d'honnêteté*, pas un guide. Un search qui optimise le test (ou pire, le train) **fabrique** un résultat — cf. [2.5](2.5-Biais-Variance-CV-ROC.ipynb) (validation croisée) et [2.9](2.9-Grokking-Generalisation.ipynb) (la métrique qu'on optimise doit être la bonne).\n",
+    "2. **La variance inter-essais.** Une seule graine peut, par chance, faire paraître une stratégie meilleure qu'elle ne l'est. D'où le multi-seed et la bande min–max : on juge sur la **médiane**, pas sur le meilleur run.\n",
+    "3. **Le gain marginal.** Après un certain point, chaque essai supplémentaire n'améliore presque plus le meilleur score : la courbe s'aplatit. On définit explicitement un **critère d'arrêt** : *arrêter dès que, sur les `K` derniers essais, le meilleur score n'a pas gagné au moins `δ` points d'AUC.* Le `δ` se choisit en fonction du prix d'un essai et de la valeur métier d'un point d'AUC — c'est un arbitrage explicite, pas un réglage magique. C'est le geste qui économise le budget et qui distingue un search d'un puits sans fond."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-014",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T08:22:16.385638Z",
+     "iopub.status.busy": "2026-08-23T08:22:16.385267Z",
+     "iopub.status.idle": "2026-08-23T08:22:16.391787Z",
+     "shell.execute_reply": "2026-08-23T08:22:16.390958Z"
+    },
+    "papermill": {
+     "duration": 0.011878,
+     "end_time": "2026-08-23T08:22:16.392501+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.380623+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- règle : arrêt si gain < 0.002 d'AUC sur 10 essais (bayésien) ---\n",
+      "seed  0: 1er essai=0.9335  final=0.9623  stop à l'essai 24 (meilleur=0.9546, coût de l'arrêt=+0.0076, budget économisé=21 essais)\n",
+      "seed  1: 1er essai=0.3098  final=0.9643  stop à l'essai 21 (meilleur=0.9621, coût de l'arrêt=+0.0022, budget économisé=24 essais)\n",
+      "seed  7: 1er essai=0.7954  final=0.9623  stop à l'essai 14 (meilleur=0.9569, coût de l'arrêt=+0.0054, budget économisé=31 essais)\n",
+      "\n",
+      "variance inter-seeds du meilleur final (bayésien) : std = 0.0010\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Critère d'arrêt explicite : gain marginal absolu sur les K derniers essais\n",
+    "K, DELTA = 10, 0.002       # si le meilleur n'a pas gagné 0.002 d'AUC en 10 essais -> stop\n",
+    "\n",
+    "def stop_trial(best, K=10, delta=0.002):\n",
+    "    \"\"\"Premier essai t tel que best[t] - best[t-K] < delta : la fenêtre de K\n",
+    "    essais n'a plus rien payé. S'arrêter là est le geste budget-honnête.\"\"\"\n",
+    "    for t in range(K, len(best)):\n",
+    "        if best[t] - best[t - K] < delta:\n",
+    "            return t\n",
+    "    return len(best)       # jamais déclenché : le search paie encore\n",
+    "\n",
+    "print(f\"--- règle : arrêt si gain < {DELTA} d'AUC sur {K} essais (bayésien) ---\")\n",
+    "for seed, curve in zip(SEEDS, bayes_curves):\n",
+    "    t = stop_trial(curve, K, DELTA)\n",
+    "    print(f\"seed {seed:>2}: 1er essai={curve[0]:.4f}  final={curve[-1]:.4f}  \"\n",
+    "          f\"stop à l'essai {t} (meilleur={curve[t-1]:.4f}, \"\n",
+    "          f\"coût de l'arrêt={curve[-1] - curve[t-1]:+.4f}, \"\n",
+    "          f\"budget économisé={N_TRIALS - t} essais)\")\n",
+    "\n",
+    "# variance inter-seeds du meilleur final (à rapporter, pas à ignorer)\n",
+    "finals = np.array([c[-1] for c in bayes_curves])\n",
+    "print(f\"\\nvariance inter-seeds du meilleur final (bayésien) : std = {finals.std():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-015",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003558,
+     "end_time": "2026-08-23T08:22:16.399652+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.396094+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Pont vers le reste du dépôt\n",
+    "\n",
+    "Cette méthodologie n'est pas un cas isolé : c'est la lecture qu'on applique aux **sweeps de production** du dépôt.\n",
+    "\n",
+    "* **ML-Training-Pipeline (QuantConnect)** : le `sweep` des modèles de trading (walk-forward 5-fold, ≥4 seeds, Diebold–Mariano) est exactement ce protocole — budget d'essais, validation hors train, **critère d'arrêt** sur le gain marginal, multi-seed. Ce notebook en donne le *pourquoi* : pourquoi un sweep qui ne s'arrête pas dépense du budget pour rien, et pourquoi on juge sur la médiane.\n",
+    "* **AgenticDataScience / Lab14** : l'*ablation* répond à « ce paramètre sert-il ? » — c'est la version ciblée du search (on gèle tout sauf une dimension). Les lunettes de la section 6 (variance, gain marginal) s'appliquent telles quelles.\n",
+    "* **ML-3** : le contraste *boîte-noire* — un AutoML .NET encapsule exactement la boucle « proposer → évaluer → modéliser » que l'on a déroulée à la main ici. L'avoir fait à la main rend l'AutoML lisible, pas magique.\n",
+    "* **2.5** (validation croisée) et **2.9** (choix de métrique) : les deux prérequis de la section 6 — impossible d'optimiser honnêtement sans eux."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-016",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003478,
+     "end_time": "2026-08-23T08:22:16.406498+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.403020+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — le coût de la grille (stub)\n",
+    "\n",
+    "Compléter pour rendre *visible* le coût de la grille : calculer le nombre de combinaisons d'une grille à 6 hyperparamètres × 6 valeurs chacun, et afficher en combien d'essais un budget de 60 couvre le produit cartésien. Aucune exécution de modèle ici : de la simple arithmétique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-017",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T08:22:16.415101Z",
+     "iopub.status.busy": "2026-08-23T08:22:16.414872Z",
+     "iopub.status.idle": "2026-08-23T08:22:16.418463Z",
+     "shell.execute_reply": "2026-08-23T08:22:16.417673Z"
+    },
+    "papermill": {
+     "duration": 0.009115,
+     "end_time": "2026-08-23T08:22:16.419125+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.410010+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 (stub) : coût de la grille\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-018",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003392,
+     "end_time": "2026-08-23T08:22:16.426058+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.422666+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — du hasard au bayésien (stub)\n",
+    "\n",
+    "Transformer le `sample_random` ci-dessus en une étude Optuna **TPE** (`solver == \"adam\"` seulement), avec un budget de 30 essais, et comparer le *meilleur* final au meilleur du hasard sur la même graine. Que conclut-on sur le coût de la modélisation bayésienne ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cell-019",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T08:22:16.434175Z",
+     "iopub.status.busy": "2026-08-23T08:22:16.433837Z",
+     "iopub.status.idle": "2026-08-23T08:22:16.437992Z",
+     "shell.execute_reply": "2026-08-23T08:22:16.437084Z"
+    },
+    "papermill": {
+     "duration": 0.009248,
+     "end_time": "2026-08-23T08:22:16.438741+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.429493+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 (stub) : random -> TPE\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-020",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003557,
+     "end_time": "2026-08-23T08:22:16.445955+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.442398+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — le critère d'arrêt (stub)\n",
+    "\n",
+    "Écrire une fonction `admissible_stop(best_scores, K, TOL)` qui retourne l'essai à partir duquel le gain marginal relatif devient inférieur à `TOL`, et l'appliquer à la courbe bayésienne. Vérifier que le critère est **strict** (il ne triche pas en s'arrêtant trop tôt) en le comparant au gain réellement observé ensuite."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cell-021",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T08:22:16.454651Z",
+     "iopub.status.busy": "2026-08-23T08:22:16.454309Z",
+     "iopub.status.idle": "2026-08-23T08:22:16.458840Z",
+     "shell.execute_reply": "2026-08-23T08:22:16.457866Z"
+    },
+    "papermill": {
+     "duration": 0.010267,
+     "end_time": "2026-08-23T08:22:16.459741+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.449474+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 (stub) : critère d'arrêt strict\n",
+    "def admissible_stop(best_scores, K=10, TOL=0.01):\n",
+    "    # TODO etudiant\n",
+    "    return None\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-022",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003764,
+     "end_time": "2026-08-23T08:22:16.467417+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T08:22:16.463653+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Synthèse\n",
+    "\n",
+    "| Stratégie | Quand elle marche | Piège |\n",
+    "|---|---|---|\n",
+    "| **Grille** | dimension 1–2, espace bien compris | explose en dimension, maille aveugle aux bonnes régions |\n",
+    "| **Hasard** | dimension ≥ 3, peu de directions utiles | n'apprend pas du passé : budget mal réparti si fort coût d'évaluation |\n",
+    "| **Bayésien (TPE)** | budget serré, coût d'évaluation élevé | modélise la surface : réglages, mais coût de la modélisation |\n",
+    "\n",
+    "**Le geste à retenir** : le search n'est pas une loterie, c'est un arbitrage budget ↔ gain. On fixe un *budget*, on choisit une *stratégie* adaptée (grille faible dimension, hasard par défaut, bayésien quand l'évaluation coûte cher), on juge sur la *médiane* d'un *multi-seed*, et on **s'arrête** quand le gain marginal devient négligeable. Savoir s'arrêter n'est pas paresse : c'est la différence entre un search et un puits sans fond.\n",
+    "\n",
+    "## Conclusion et transition\n",
+    "\n",
+    "Ce notebook a déroulé la **méthodologie** du tuning : poser le problème, mesurer le coût de la grille, comprendre pourquoi le hasard la bat, consommer un search bayésien, et fermer le protocole par un critère d'arrêt. Le [2.13](2.13-Analyse-Erreurs.ipynb) prend le relais sur le *diagnostic* : une fois le modèle réglé, comment lit-on ses erreurs ? La boucle est complète — réglage, puis lecture honnête.\n",
+    "\n",
+    "## Références\n",
+    "\n",
+    "* Bergstra & Bengio, *Random Search for Hyper-Parameter Optimization* (JMLR 2012) — le résultat géométrique « le hasard bat la grille en dimension ≥ 3 ».\n",
+    "* Akiba et al., *Optuna: A Next-generation Hyperparameter Optimization Framework* (KDD 2019) — le TPE consommé ici.\n",
+    "* Bergstra et al., *Algorithms for Hyper-Parameter Optimization* (NeurIPS 2011) — l'algorithme TPE.\n",
+    "* [2.5-Biais-Variance-CV-ROC](2.5-Biais-Variance-CV-ROC.ipynb) · [2.9-Grokking-Generalisation](2.9-Grokking-Generalisation.ipynb) — prérequis de la section 6."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 87.713436,
+   "end_time": "2026-08-23T08:22:17.582640+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.10-Optimisation-Hyperparametres.ipynb",
+   "output_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.10-Optimisation-Hyperparametres.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-23T08:20:49.869204+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.13-Analyse-Erreurs.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.13-Analyse-Erreurs.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# 2.13 — Analyse d'erreurs : diagnostiquer un modèle entraîné\n",
     "\n",
-    "**Navigation** : [<< 2.9-Grokking](2.9-Grokking-Generalisation.ipynb) | [Index](../README.md)\n",
+    "**Navigation** : [<< 2.10-Optimisation-Hyperparametres](2.10-Optimisation-Hyperparametres.ipynb) | [Index](../README.md)\n",
     "\n",
     "**Kernel** : Python 3 · **Durée** : 25 min · **CPU** : < 3 min\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.9-Grokking-Generalisation.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.9-Grokking-Generalisation.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# 2.9 — Grokking : la généralisation qui arrive en retard\n",
     "\n",
-    "**Navigation** : [<< 2.8-Théorie-PAC](2.8-Theorie-PAC.ipynb) | [Index](../README.md)\n",
+    "**Navigation** : [<< 2.8-Théorie-PAC](2.8-Theorie-PAC.ipynb) | [2.10-Optimisation-Hyperparametres >>](2.10-Optimisation-Hyperparametres.ipynb) | [Index](../README.md)\n",
     "\n",
     "**Kernel** : Python 3\n",
     "\n",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md
@@ -27,6 +27,7 @@ La thèse est volontairement classique : on ne peut évaluer ce qu'un agent gén
 | [2.8b-Theorie-PAC-Lean](2.8b-Theorie-PAC-Lean.ipynb) | *Compagnon Lean* (kernel `lean4-wsl`) — la même borne, **démontrée** plutôt que mesurée | **Ce que 2.8 constate, le lake le prouve** : Hoeffding, borne de l'union, ERM, complexité d'échantillon | aucun (arithmétique exacte) |
 | [2.8c-Borne-Temoin-Concentration](2.8c-Borne-Temoin-Concentration.ipynb) | *Extension formelle* — borne, témoin extrémal, concentration : ce que [`learning_theory_lean/`](../../learning_theory_lean/README.md) sait déjà faire | **La borne atteinte** : un objet qui réalise l'égalité, pas seulement l'inégalité | arithmétique exacte |
 | [2.9-Grokking-Generalisation](2.9-Grokking-Generalisation.ipynb) | *Épilogue* — grokking : la généralisation qui arrive en retard (premier réseau de neurones) | **L'horloge cachée** : embeddings rangés en cercle après le grok (ACP + Fourier) | synthétique `(a+b) mod 97` |
+| [2.10-Optimisation-Hyperparametres](2.10-Optimisation-Hyperparametres.ipynb) | La méthodologie du réglage : grille, hasard, bayésien (TPE) — et quand s'arrêter | **Le budget qui s'aplatit** : le bayésien s'installe dès le premier tiers du budget ; le critère d'arrêt économise la moitié des essais | synthétique `make_classification` (MLP) |
 | [2.13-Analyse-Erreurs](2.13-Analyse-Erreurs.ipynb) | Le geste du praticien : diagnostiquer un modèle entraîné (tranches, worst-k, plan d'action) | **La poche invisible** : 67.6% d'erreur sur ~5% de la population, cachée dans un score global correct (82.2%) | synthétique télécom (churn, incident d'étiquetage) |
 
 > **Épilogue — au-delà du socle scikit-learn.** Les huit chapitres ci-dessus posent le socle canonique. Le notebook [2.9](2.9-Grokking-Generalisation.ipynb) fait un pas de côté vers le **deep learning** : il entraîne le premier réseau de neurones de la série (PyTorch, quelques minutes sur CPU) pour montrer le **grokking** — la généralisation qui surgit longtemps *après* la mémorisation parfaite, un phénomène que la borne PAC (2.8) ne laissait pas prévoir — et réutilise l'ACP du 2.6 pour révéler la structure apprise.
@@ -34,6 +35,8 @@ La thèse est volontairement classique : on ne peut évaluer ce qu'un agent gén
 > **Le compagnon formel.** Le notebook [2.8b](2.8b-Theorie-PAC-Lean.ipynb) tourne sous kernel **Lean 4** (`lean4-wsl`) et suit module par module le lake [`learning_theory_lean/`](../../learning_theory_lean/README.md), qui vit à la racine de la série ML. Là où 2.8 *observe* que la borne PAC prédit la courbe d'erreur empirique, 2.8b en rend les étapes exécutables — `expect`/Markov, MGF de Bernoulli, Hoeffding, borne de l'union, ERM, complexité d'échantillon — avec les **noms de déclarations du lake**, de sorte qu'un lecteur puisse passer du notebook au fichier `.lean` sans traduction. C'est la même paire empirique/formel que la série ML annonce dans sa section [Théorie formelle (Lean)](../../README.md#théorie-formelle-lean) (EPIC #11703).
 
 > **Le geste du praticien.** Le notebook [2.13](2.13-Analyse-Erreurs.ipynb) ferme la boucle : mesurer (2.4, 2.5) ne suffit pas, il faut **diagnostiquer**. Sur un modèle au score global correct (accuracy 82.2%, aucune alerte), l'analyse par tranches révèle une **poche** à 67.6% d'erreur — 115 étiquettes d'entraînement corrompues par un incident d'intégration, invisibles de toute métrique globale. Le workflow : tranches → worst-k (les deux côtés de la matrice) → confiance → cause → correction **mesurée** (−42.3 points sur la poche) — ce qui distingue un praticien d'un tourneur d'hyperparamètres (le tuning, lui, ne répare rien : 67.6% → 67.6%).
+
+> **La méthodologie du réglage.** Le notebook [2.10](2.10-Optimisation-Hyperparametres.ipynb) assume le rôle que le 2.13 laisse en creux — celui du « tourneur d'hyperparamètres » — et le fait **honnêtement** : un espace de recherche mixte (continu, discret, conditionnel) sur un MLP, un budget commun de 45 essais, et les trois stratégies superposées sur la courbe *meilleur score vs nombre d'essais* (médiane sur 3 graines, bande min–max). La grille exhaustive y explose en dimension (6300 configurations, 0.7 % couvertes), le hasard tient l'argument de couverture de Bergstra & Bengio, et le search bayésien (TPE/Optuna, **consommé**, pas réécrit) s'installe dès le premier tiers du budget. Le vrai concept-phare est le **critère d'arrêt** : un gain marginal explicite (arrêter si le meilleur n'a pas gagné δ sur les K derniers essais) qui économise 21 à 31 essais sur 45 pour un coût de 2 à 8 millièmes d'AUC. C'est la méthodologie transverse que réutilisent les sweeps du ML-Training-Pipeline et l'ablation du Lab14.
 
 ## Aperçu — les concepts-phare en images
 
@@ -91,6 +94,8 @@ flowchart TD
     H -. "au-delà du socle : deep learning" .-> I
     J["2.13 - Analyse d'erreurs (praticien)<br/>diagnostiquer un modèle entraîné<br/>tranches, worst-k, plan d'action"]
     E -. "après les métriques : diagnostiquer" .-> J
+    K["2.10 - Optimisation d'hyperparamètres (méthodologie)<br/>grille, hasard, bayésien (TPE)<br/>budget, gain marginal, critère d'arrêt"]
+    E -. "après l'évaluation : régler" .-> K
 ```
 
 ## Pédagogie
@@ -116,6 +121,7 @@ Chaque notebook suit les mêmes conventions :
 7. **Aller au-delà des modèles paramétriques** : SVM (maximisation de la marge, kernel trick, vecteurs supports) et k plus proches voisins, et comprendre pourquoi la standardisation devient indispensable.
 8. **Formaliser le cadre théorique** : théorie PAC (Valiant 1984), complexité d'échantillon `m ≥ (1/ε)(ln|H| + ln(1/δ))`, dimension VC (Vapnik-Chervonenkis 1971) — combien d'exemples suffisent pour généraliser, et le pont entre borne théorique et erreur empirique.
 9. **Diagnostiquer un modèle entraîné** : analyse par tranches (heatmap tranches × métrique, effectifs lus), inspection worst-k des deux côtés de la matrice, erreurs affirmées vs hésitantes (pont vers la calibration), et plan d'action cause → remède dont le gain est **mesuré par tranche** (2.13).
+10. **Régler les hyperparamètres honnêtement** : poser un espace de recherche mixte (continu, discret, conditionnel), mesurer pourquoi la grille exhaustive explose en dimension, lire l'argument de couverture du hasard, consommer un search bayésien (TPE/Optuna), et s'arrêter sur un critère de gain marginal explicite — budget, multi-seed, médiane (2.10).
 
 ## Prérequis
 
@@ -128,7 +134,7 @@ Cette série est le **référent manuel** des labs agentic qui suivent. Une fois
 
 ## Références transverses
 
-Les citations canoniques ancrées dans la série (cellule `## References` de chaque notebook) incluent : Mitchell 1997 (généralisation), Cauchy 1847 (descente de gradient), Nelder & Wedderburn 1972 (modèles linéaires généralisés), Cox 1958 (régression logistique), Breiman et al. 1984 (CART), Breiman 2001 (forêts aléatoires), Friedman 2001 (gradient boosting), Stone 1974 (validation croisée), Bradley 1997 (AUC), MacQueen 1967 (k-means), Pearson 1901 (ACP), Cortes & Vapnik 1995 (réseaux de vecteurs supports), Cover & Hart 1967 (k plus proches voisins), Valiant 1984 (théorie PAC), Vapnik & Chervonenkis 1971 (dimension VC), Hastie/Tibshirani/Friedman 2009 (*The Elements of Statistical Learning*) et Pedregosa et al. 2011 (scikit-learn).
+Les citations canoniques ancrées dans la série (cellule `## References` de chaque notebook) incluent : Mitchell 1997 (généralisation), Cauchy 1847 (descente de gradient), Nelder & Wedderburn 1972 (modèles linéaires généralisés), Cox 1958 (régression logistique), Breiman et al. 1984 (CART), Breiman 2001 (forêts aléatoires), Friedman 2001 (gradient boosting), Stone 1974 (validation croisée), Bradley 1997 (AUC), MacQueen 1967 (k-means), Pearson 1901 (ACP), Cortes & Vapnik 1995 (réseaux de vecteurs supports), Cover & Hart 1967 (k plus proches voisins), Valiant 1984 (théorie PAC), Vapnik & Chervonenkis 1971 (dimension VC), Bergstra et al. 2011 (TPE), Bergstra & Bengio 2012 (random search), Akiba et al. 2019 (Optuna), Hastie/Tibshirani/Friedman 2009 (*The Elements of Statistical Learning*) et Pedregosa et al. 2011 (scikit-learn).
 
 ## Conclusion — ce que vous emportez
 


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA — prev: LIGHT/docs #12341

## Summary

Création du notebook **ML 2.10 — Méthodologie d'optimisation d'hyperparamètres** (issue #12417) : grille, hasard, bayésien — et quand s'arrêter. La série 02-ML-Cours touchait l'HPO par touches dispersées (AutoML ML-3, ablations, sweeps) sans jamais enseigner la méthodologie ; ce notebook la pose comme sujet, sur un terrain où le réglage compte vraiment.

**Contenu (6 sections + lecture + pont dépôt)** :

1. **Le problème posé proprement** — MLP volontairement sensible aux hyperparamètres (sous-apprentissage ↔ sur-apprentissage), budget commun `N_TRIALS = 45`, espace de recherche **mixte** : 2 continu (log), 3 discret, + démonstration **conditionnelle** (`momentum` échantillonné seulement si `solver == "sgd"`, via Optuna).
2. **Grid search** — la malédiction de la dimension rendue visible : grille réelle 6 × 5 × 5 × 7 × 6 = **6300 configurations**, dont un budget de 45 essais couvre **0.7 %**.
3. **Random search** — l'intuition géométrique (Bergstra & Bengio 2012) : les dimensions importantes sont rares ; l'argument de couverture (≈ 28 essais pour toucher une région de 10 %) contre le produit cartésien.
4. **Bayésien (TPE/Optuna)** — **consommé, pas réécrit** (`optuna.samplers.TPESampler`) ; même budget, même score CV, multi-seed.
5. **Les trois courbes superposées** — la figure qui fait la leçon : meilleur score vs nombre d'essais, médiane sur 3 graines (0/1/7) + bande min–max.
6. **Le protocole honnête** — métrique en validation (2.5/2.9), variance inter-essais, **critère d'arrêt explicite** : arrêter si le meilleur n'a pas gagné `δ = 0.002` d'AUC sur `K = 10` essais, avec le **coût de l'arrêt mesuré**.

## Validation (H.1 — exécution réelle)

- **Papermill end-to-end** : kernel `python3`, `--cwd` normalisé, **~90 s au total** (critère CPU < 8 min ✓ avec large marge).
- **0 erreur** dans les outputs ; toutes les cellules code portent `execution_count` **et** des outputs (C.2 ✓, H.3 pre-commit Passed).
- **Résultats (exécutés, reproductibles — graines fixées)** :
  - baseline config par défaut : AUC **0.8343** (le tuning a de la matière) ;
  - finales médianes : grille **0.9603**, hasard **0.9544**, bayésien **0.9623** ;
  - cible commune (0.9544) atteinte : bayésien essai **12**, hasard **44**, grille **45** ;
  - critère d'arrêt : stop aux essais 24/21/14 selon la graine → **21 à 31 essais économisés sur 45** pour un coût de **+0.0022 à +0.0076 d'AUC** ;
  - démonstration conditionnelle : essais `solver=sgd` → `momentum` échantillonné (compteur affiché).
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` ; 3 stubs d'exercice (`print("Exercice a completer")` + `# TODO etudiant`).

## Honnêteté des résultats (G.2)

Le classement « hasard > grille » de Bergstra & Bengio **ne se reproduit pas** à ce budget sur ce problème (grille 0.9603 ≥ hasard 0.9544) : la cellule « Lecture du résultat » le **dit explicitement** — l'argument de Bergstra est un argument de *couverture* qui se manifeste quand la bonne région est petite face à l'espace ; ici le message dominant est la **concentration du TPE** (essai 12 vs 44-45). Aucun nombre de prose non exécuté : les valeurs chiffrées du markdown proviennent des outputs committés.

## Verdict SOTA

**SOTA-OK** — vrais outils invoqués : scikit-learn 1.8.0 (`MLPClassifier`, `cross_val_score`), Optuna 4.7.0 (`TPESampler`) réellement consommé. Stratégies grid/random implémentées from-scratch (c'est le sujet pédagogique), le bayésien se consomme — conformément au critère d'acceptation.

## README 02-ML-Cours (§E — audit fichier entier)

- Table « Vue d'ensemble » : ligne 2.10 ajoutée → **14 lignes = 14 notebooks sur disque** (hors artefact `_output`), réconcilié.
- Blockquote « La méthodologie du réglage » (lien narratif avec le 2.13 : « le tourneur d'hyperparamètres »), nœud `K` dans le mermaid (arc depuis 2.5), objectif d'apprentissage n° 10, références transverses (Bergstra 2011/2012, Akiba 2019).
- Chaîne de navigation : header 2.10 (`<< 2.9 | 2.13 >>`), lien suivant ajouté dans 2.9, lien précédent de 2.13 retargeté (2.9 → 2.10) — diffs **markdown-only** sur les deux voisins, outputs intacts.
- **Dérive pré-existante signalée (hors scope, non touchée)** : le README parent `DataScienceWithAgents/README.md` dit « 9 notebooks » et sa table omet 2.8b/2.8c/2.13 (et maintenant 2.10) — ouverture d'une issue de suivi séparée (règle : ne pas toucher au non-lié sans auditer le fichier parent entier).

## Critères d'acceptation (issue #12417)

- [x] Courbes meilleur-score-vs-essais des 3 stratégies, multi-seed ≥ 3 (graines 0/1/7, médiane + bande), dans les outputs
- [x] Optuna réellement utilisé (TPE consommé ; grid/random from-scratch assumés)
- [x] Section budget/gain marginal avec critère d'arrêt explicite (δ/K + coût mesuré)
- [x] ≥ 3 exercices stubs (C.1), CPU ~90 s (≪ 8 min)
- [x] README 02-ML-Cours mis à jour (§E complet)

Closes #12417
