### PR TITLE
feat(lean,#12340): Partie 35 triple adjoint f_! ⊣ f^* ⊣ f_* — ExceptionalTriple (adjonction + effondrement f^!)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/ExceptionalTriple.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/ExceptionalTriple.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+## Partie 35 — `Grothendieck.ExceptionalTriple` : le triple adjoint `f_! ⊣ f^* ⊣ f_*`
+## et l'effondrement de l'image inverse exceptionnelle au niveau préfaisceau
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 2+ (#2159, Epic #1646). La Partie 34 (`ExceptionalDirect.lean`)
+a livré `f_!` au niveau préfaisceau (extension de Kan à gauche le long de
+`f.op`) et son adjonction `f_! ⊣ f^*`. Cette partie complète la vue en
+assemblant le **triple adjoint** `f_! ⊣ f^* ⊣ f_*` : la troisième patte
+`f^* ⊣ f_*` est l'image directe ordinaire (extension de Kan à droite le long
+de `f.op`), et c'est leur enchâssement en un **triple** qui est ici la substance.
+
+### Ce que le niveau préfaisceau offre de non dégénéré
+
+Aucune des deux adjonctions prise isolément n'est neuve : `f_! ⊣ f^*` est la
+Partie 34, et `f^* ⊣ f_*` n'est qu'une réinstanciation de `Functor.ranAdjunction`
+(Mathlib). Ce qui n'est **pas** du Mathlib recopié, c'est le **triple** et les
+propriétés qui n'existent que parce qu'il y en a un :
+
+  - **`presheafSixOpsTriple`** : l'enchâssement `f_! ⊣ f^* ⊣ f_*` comme
+    `CategoryTheory.Adjunction.Triple`.
+  - **La cohérence** : `f_!` est pleinement fidèle **si et seulement si**
+    `f_*` l'est (`Adjunction.Triple.fullyFaithfulEquiv`). C'est un énoncé sur
+    `f_!` prouvé *via* `f_*` — hors de portée de la Partie 34 seule.
+  - **`exceptionalInverse_collapses_to_pullback`** : pour tout `G` tel que
+    `f_! ⊣ G`, on a `G ≅ f^*` (`rightAdjointUniq`). C'est le plafond honnête :
+    au niveau préfaisceau, il n'y a **pas** d'image inverse exceptionnelle
+    `f^!` distincte de `f^*`.
+
+### Le plafond (honnête, conformément au point d'acceptance 5)
+
+Ce triple vit au niveau **préfaisceau**. Le `f_!` faisceautique à support propre
+des six opérations exige une faisceautification et une hypothèse de propreté sur
+`f` ; son adjoint à droite `f^!` demande la **dualité de Verdier**.
+L'effondrement `G ≅ f^*` ci-dessus rend cette impossibilité **prouvable** en
+Lean, pas seulement déclarée en prose — c'est exactement la borne que la Partie
+34 annonçait.
+
+Epic #1646, See #2159. Tous les `sorry` éliminés à la création.
+
+### i18n — convention #4980 ratifiée 2026-07-04
+
+Ce module est jumelé avec sa version anglaise canonique dans le fichier sibling
+`ExceptionalTriple_en.lean` (modèle **jumeau consommateur** : le `_en` importe
+le module FR `Grothendieck.ExceptionalDirect` et ne re-déclare pas ses
+définitions — cf `CoversLattice_en.lean`). Les énoncés de théorèmes/lemmes, les
+noms de lemmes, les tactiques Lean et les références Mathlib restent en anglais
+(Mathlib 4, tactic DSL standard) ; le namespace porte le suffixe `_en`. Seules
+les **docstrings `/-- ... -/`** et les **commentaires `-- ...`** diffèrent entre
+les deux fichiers. Anti-§D byte-identity garanti sur les signatures, preuves et
+tactiques (vérifiable par diff).
+-/
+
+import Mathlib.CategoryTheory.Functor.KanExtension.Basic
+import Mathlib.CategoryTheory.Functor.KanExtension.Adjunction
+import Mathlib.CategoryTheory.Adjunction.Triple
+import Mathlib.CategoryTheory.Adjunction.Unique
+import Mathlib.CategoryTheory.Whiskering
+import Grothendieck.ExceptionalDirect
+
+universe v₁ v₂ v₃ u₁ u₂ u₃
+
+namespace Grothendieck.ExceptionalTriple
+
+open CategoryTheory
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+  {H : Type u₃} [Category.{v₃} H]
+
+/-!
+## 1. `f_*` au niveau préfaisceau : extension de Kan à droite le long de `f.op`
+
+La troisième patte du triple. L'image directe ordinaire `f_*` étend un
+préfaisceau `F : Cᵒᵖ ⥤ H` en `f_* F : Dᵒᵖ ⥤ H` comme le meilleur relèvement de
+`F` par la droite — l'extension de Kan à droite `(f.op).ran`. Elle est adjointe
+à **droite** de l'image réciproque `f^*` : c'est l'analogue préfaisceau de
+l'adjonction fondamentale `f^* ⊣ f_*` des faisceaux de modules, instanciée ici
+par `Functor.ranAdjunction`.
+-/
+
+/-- **`f_*` au niveau préfaisceau.** L'image directe d'un préfaisceau
+    `F : Cᵒᵖ ⥤ H` le long de `f : C ⥤ D`, définie comme l'extension de Kan à
+    droite le long de `f.op : Cᵒᵖ ⥤ Dᵒᵖ`. C'est un foncteur covariant
+    `(Cᵒᵖ ⥤ H) ⥤ (Dᵒᵖ ⥤ H)`. L'hypothèse `[∀ G, f.op.HasRightKanExtension G]`
+    garantit l'existence pointwise des extensions. -/
+noncomputable def directImagePresheaf (f : C ⥤ D)
+    [∀ (G : Cᵒᵖ ⥤ H), f.op.HasRightKanExtension G] : (Cᵒᵖ ⥤ H) ⥤ (Dᵒᵖ ⥤ H) :=
+  f.op.ran
+
+/-- **L'adjonction `f^* ⊣ f_*` au niveau préfaisceau.** Prouvée en instanciant
+    `Functor.ranAdjunction` de Mathlib (`f.op.ranAdjunction H`), qui établit
+    formellement `(whiskeringLeft Cᵒᵖ Dᵒᵖ H).obj f.op ⊣ (f.op).ran` — c'est-à-dire
+    exactement `f^* ⊣ f_*`. -/
+noncomputable def directImagePresheafAdjunction (f : C ⥤ D)
+    [∀ (G : Cᵒᵖ ⥤ H), f.op.HasRightKanExtension G] :
+    ExceptionalDirect.pullbackPresheaf (H := H) f ⊣ directImagePresheaf (H := H) f :=
+  f.op.ranAdjunction H
+
+/-!
+## 2. Le triple `f_! ⊣ f^* ⊣ f_*`
+
+L'enchâssement des deux adjonctions en un **triple adjoint**. La Partie 34
+fournit `adj₁ : f_! ⊣ f^*` ; cette partie fournit `adj₂ : f^* ⊣ f_*`. Leur
+réunion est le triple `f_! ⊣ f^* ⊣ f_*`, la brique des six opérations (au niveau
+préfaisceau).
+-/
+
+/-- **Le triple adjoint `f_! ⊣ f^* ⊣ f_*` au niveau préfaisceau.** Assemble
+    l'adjonction de la Partie 34 (`exceptionalDirectImageAdjunction`, `adj₁`)
+    avec l'adjonction `f^* ⊣ f_*` de la section 1
+    (`directImagePresheafAdjunction`, `adj₂`) en un
+    `CategoryTheory.Adjunction.Triple`. -/
+noncomputable def presheafSixOpsTriple (f : C ⥤ D)
+    [∀ (F : Cᵒᵖ ⥤ H), f.op.HasLeftKanExtension F]
+    [∀ (G : Cᵒᵖ ⥤ H), f.op.HasRightKanExtension G] :
+    CategoryTheory.Adjunction.Triple
+      (ExceptionalDirect.exceptionalDirectImage (H := H) f)
+      (ExceptionalDirect.pullbackPresheaf (H := H) f) (directImagePresheaf (H := H) f) where
+  adj₁ := ExceptionalDirect.exceptionalDirectImageAdjunction (H := H) f
+  adj₂ := directImagePresheafAdjunction (H := H) f
+
+/-!
+## 3. Cohérence : `f_!` et `f_*` sont simultanément pleinement fidèles
+
+Un énoncé que **ni l'une ni l'autre des deux moitiés ne donne** : `f_!` est
+pleinement fidèle **si et seulement si** `f_*` l'est. Il se prouve *via*
+`Adjunction.Triple.fullyFaithfulEquiv`, qui relie les deux extrémités du triple.
+-/
+
+/-- **`f_!` pleinement fidèle ssi `f_*` pleinement fidèle.** Énoncé de cohérence
+    du triple, prouvé par `presheafSixOpsTriple.fullyFaithfulEquiv`
+    (`Adjunction.Triple.fullyFaithfulEquiv`). C'est la seule propriété du triple
+    qui ne soit pas recopiée d'une moitié : un énoncé sur `f_!` prouvé *via*
+    `f_*`. -/
+noncomputable def exceptionalDirectImage_fullyFaithful_iff_directImage (f : C ⥤ D)
+    [∀ (F : Cᵒᵖ ⥤ H), f.op.HasLeftKanExtension F]
+    [∀ (G : Cᵒᵖ ⥤ H), f.op.HasRightKanExtension G] :
+    (ExceptionalDirect.exceptionalDirectImage (H := H) f).FullyFaithful ≃
+      (directImagePresheaf (H := H) f).FullyFaithful :=
+  (presheafSixOpsTriple (H := H) f).fullyFaithfulEquiv
+
+/-!
+## 4. Le plafond : l'image inverse exceptionnelle s'effondre sur `f^*`
+
+C'est le résultat de méthode. Au niveau préfaisceau, il n'y a **pas** de `f^!`
+distinct de `f^*` : si un foncteur `G` est adjoint à droite de `f_!`, alors
+`G ≅ f^*`. La preuve utilise `rightAdjointUniq` (unicité de l'adjoint à droite)
+appliqué à l'adjonction de la Partie 34 (et à l'adjonction donnée `adj`). Ce
+fait documente durablement pourquoi le lake n'aura de `f^!` qu'avec la dualité
+de Verdier.
+-/
+
+/-- **L'image inverse exceptionnelle s'effondre sur `f^*`.** Pour tout
+    `G : (Dᵒᵖ ⥤ H) ⥤ (Cᵒᵖ ⥤ H)` tel que `f_! ⊣ G`, on a `G ≅ f^*`. C'est
+    l'unicité de l'adjoint à droite (`rightAdjointUniq`) appliquée à
+    `exceptionalDirectImageAdjunction` (Partie 34) et à l'adjonction donnée
+    `adj`. Plafond honnête : au niveau préfaisceau, `f^! = f^*`. -/
+noncomputable def exceptionalInverse_collapses_to_pullback (f : C ⥤ D)
+    [∀ (F : Cᵒᵖ ⥤ H), f.op.HasLeftKanExtension F]
+    (G : (Dᵒᵖ ⥤ H) ⥤ (Cᵒᵖ ⥤ H))
+    (adj : ExceptionalDirect.exceptionalDirectImage (H := H) f ⊣ G) :
+    G ≅ ExceptionalDirect.pullbackPresheaf (H := H) f :=
+  (CategoryTheory.Adjunction.rightAdjointUniq
+    (ExceptionalDirect.exceptionalDirectImageAdjunction (H := H) f) adj).symm
+
+end Grothendieck.ExceptionalTriple

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/ExceptionalTriple_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/ExceptionalTriple_en.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+## Part 35 — `Grothendieck.ExceptionalTriple_en`: the adjoint triple `f_! ⊣ f^* ⊣ f_*`
+## and the collapse of the exceptional inverse image at the presheaf level
+
+Alexander Grothendieck (1928-2014).
+
+Phase 2+ extension (#2159, Epic #1646). Part 34 (`ExceptionalDirect.lean`)
+delivered `f_!` at the presheaf level (left Kan extension along `f.op`) and its
+adjunction `f_! ⊣ f^*`. This part completes the picture by assembling the
+**adjoint triple** `f_! ⊣ f^* ⊣ f_*`: the third leg `f^* ⊣ f_*` is the ordinary
+direct image (right Kan extension along `f.op`), and it is their nesting into a
+**triple** that constitutes the substance here.
+
+### What the presheaf level offers as non-degenerate
+
+Neither adjunction taken in isolation is new: `f_! ⊣ f^*` is Part 34, and
+`f^* ⊣ f_*` is but a re-instantiation of `Functor.ranAdjunction` (Mathlib).
+What is **not** copied Mathlib is the **triple** and the properties that exist
+only because there is one:
+
+  - **`presheafSixOpsTriple`**: the nesting `f_! ⊣ f^* ⊣ f_*` as a
+    `CategoryTheory.Adjunction.Triple`.
+  - **The coherence**: `f_!` is fully faithful **if and only if** `f_*` is
+    (`Adjunction.Triple.fullyFaithfulEquiv`). This is a statement about `f_!`
+    proved *via* `f_*` — out of reach of Part 34 alone.
+  - **`exceptionalInverse_collapses_to_pullback`**: for every `G` with
+    `f_! ⊣ G`, we have `G ≅ f^*` (`rightAdjointUniq`). This is the honest
+    ceiling: at the presheaf level there is **no** exceptional inverse image
+    `f^!` distinct from `f^*`.
+
+### The ceiling (honest, per acceptance point 5)
+
+This triple lives at the **presheaf** level. The sheaf-theoretic proper-support
+`f_!` of the six operations requires sheafification and a properness hypothesis
+on `f`; its right adjoint `f^!` requires **Verdier duality**. The collapse
+`G ≅ f^*` above makes this impossibility **provable** in Lean, not merely
+asserted in prose — exactly the bound Part 34 announced.
+
+Epic #1646, See #2159. All `sorry` eliminated at creation.
+
+### i18n — convention #4980 ratified 2026-07-04
+
+This module is the English canonical sibling of `ExceptionalTriple.lean`
+(**consumer-twin** model: the `_en` imports the FR module
+`Grothendieck.ExceptionalDirect` and does not re-declare its definitions —
+cf `CoversLattice_en.lean`). Theorem/lemma statements, lemma names, Lean
+tactics and Mathlib references remain in English (Mathlib 4, standard tactic
+DSL); the namespace carries the `_en` suffix. Only the **docstrings `/-- ... -/`**
+and **comments `-- ...`** differ between the two files. Anti-§D byte-identity
+guaranteed on signatures, proofs and tactics (verifiable by diff).
+-/
+
+import Mathlib.CategoryTheory.Functor.KanExtension.Basic
+import Mathlib.CategoryTheory.Functor.KanExtension.Adjunction
+import Mathlib.CategoryTheory.Adjunction.Triple
+import Mathlib.CategoryTheory.Adjunction.Unique
+import Mathlib.CategoryTheory.Whiskering
+import Grothendieck.ExceptionalDirect
+
+universe v₁ v₂ v₃ u₁ u₂ u₃
+
+namespace Grothendieck.ExceptionalTriple_en
+
+open CategoryTheory
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+  {H : Type u₃} [Category.{v₃} H]
+
+/-!
+## 1. `f_*` at the presheaf level: right Kan extension along `f.op`
+
+The third leg of the triple. The ordinary direct image `f_*` extends a presheaf
+`F : Cᵒᵖ ⥤ H` to `f_* F : Dᵒᵖ ⥤ H` as the best right extension of `F` — the
+right Kan extension `(f.op).ran`. It is **right adjoint** to the pullback
+`f^*`: this is the presheaf analogue of the fundamental adjunction
+`f^* ⊣ f_*` on sheaves of modules, instantiated here by `Functor.ranAdjunction`.
+-/
+
+/-- **`f_*` at the presheaf level.** The direct image of a presheaf
+    `F : Cᵒᵖ ⥤ H` along `f : C ⥤ D`, defined as the right Kan extension along
+    `f.op : Cᵒᵖ ⥤ Dᵒᵖ`. This is a covariant functor `(Cᵒᵖ ⥤ H) ⥤ (Dᵒᵖ ⥤ H)`.
+    The hypothesis `[∀ G, f.op.HasRightKanExtension G]` guarantees pointwise
+    existence of the extensions. -/
+noncomputable def directImagePresheaf (f : C ⥤ D)
+    [∀ (G : Cᵒᵖ ⥤ H), f.op.HasRightKanExtension G] : (Cᵒᵖ ⥤ H) ⥤ (Dᵒᵖ ⥤ H) :=
+  f.op.ran
+
+/-- **The adjunction `f^* ⊣ f_*` at the presheaf level.** Proved by instantiating
+    Mathlib's `Functor.ranAdjunction` (`f.op.ranAdjunction H`), which formally
+    establishes `(whiskeringLeft Cᵒᵖ Dᵒᵖ H).obj f.op ⊣ (f.op).ran` — that is,
+    exactly `f^* ⊣ f_*`. -/
+noncomputable def directImagePresheafAdjunction (f : C ⥤ D)
+    [∀ (G : Cᵒᵖ ⥤ H), f.op.HasRightKanExtension G] :
+    ExceptionalDirect.pullbackPresheaf (H := H) f ⊣ directImagePresheaf (H := H) f :=
+  f.op.ranAdjunction H
+
+/-!
+## 2. The triple `f_! ⊣ f^* ⊣ f_*`
+
+The nesting of the two adjunctions into an **adjoint triple**. Part 34 supplies
+`adj₁ : f_! ⊣ f^*`; this part supplies `adj₂ : f^* ⊣ f_*`. Their union is the
+triple `f_! ⊣ f^* ⊣ f_*`, the brick of the six operations (at the presheaf
+level).
+-/
+
+/-- **The adjoint triple `f_! ⊣ f^* ⊣ f_*` at the presheaf level.** Assembles
+    the Part 34 adjunction (`exceptionalDirectImageAdjunction`, `adj₁`) with the
+    `f^* ⊣ f_*` adjunction of section 1 (`directImagePresheafAdjunction`,
+    `adj₂`) into a `CategoryTheory.Adjunction.Triple`. -/
+noncomputable def presheafSixOpsTriple (f : C ⥤ D)
+    [∀ (F : Cᵒᵖ ⥤ H), f.op.HasLeftKanExtension F]
+    [∀ (G : Cᵒᵖ ⥤ H), f.op.HasRightKanExtension G] :
+    CategoryTheory.Adjunction.Triple
+      (ExceptionalDirect.exceptionalDirectImage (H := H) f)
+      (ExceptionalDirect.pullbackPresheaf (H := H) f) (directImagePresheaf (H := H) f) where
+  adj₁ := ExceptionalDirect.exceptionalDirectImageAdjunction (H := H) f
+  adj₂ := directImagePresheafAdjunction (H := H) f
+
+/-!
+## 3. Coherence: `f_!` and `f_*` are simultaneously fully faithful
+
+A statement that **neither half gives**: `f_!` is fully faithful **if and only
+if** `f_*` is. It is proved *via* `Adjunction.Triple.fullyFaithfulEquiv`, which
+relates the two ends of the triple.
+-/
+
+/-- **`f_!` fully faithful iff `f_*` fully faithful.** Coherence statement of
+    the triple, proved by `presheafSixOpsTriple.fullyFaithfulEquiv`
+    (`Adjunction.Triple.fullyFaithfulEquiv`). This is the only property of the
+    triple that is not copied from one half: a statement about `f_!` proved
+    *via* `f_*`. -/
+noncomputable def exceptionalDirectImage_fullyFaithful_iff_directImage (f : C ⥤ D)
+    [∀ (F : Cᵒᵖ ⥤ H), f.op.HasLeftKanExtension F]
+    [∀ (G : Cᵒᵖ ⥤ H), f.op.HasRightKanExtension G] :
+    (ExceptionalDirect.exceptionalDirectImage (H := H) f).FullyFaithful ≃
+      (directImagePresheaf (H := H) f).FullyFaithful :=
+  (presheafSixOpsTriple (H := H) f).fullyFaithfulEquiv
+
+/-!
+## 4. The ceiling: the exceptional inverse image collapses onto `f^*`
+
+This is the methodological result. At the presheaf level, there is **no** `f^!`
+distinct from `f^*`: if a functor `G` is right adjoint to `f_!`, then
+`G ≅ f^*`. The proof uses `rightAdjointUniq` (uniqueness of the right adjoint)
+applied to the Part 34 adjunction (and to the given adjunction `adj`). This fact
+durably documents why the lake will only have a `f^!` with Verdier duality.
+-/
+
+/-- **The exceptional inverse image collapses onto `f^*`.** For every
+    `G : (Dᵒᵖ ⥤ H) ⥤ (Cᵒᵖ ⥤ H)` with `f_! ⊣ G`, we have `G ≅ f^*`. This is
+    the uniqueness of the right adjoint (`rightAdjointUniq`) applied to
+    `exceptionalDirectImageAdjunction` (Part 34) and to the given adjunction
+    `adj`. Honest ceiling: at the presheaf level, `f^! = f^*`. -/
+noncomputable def exceptionalInverse_collapses_to_pullback (f : C ⥤ D)
+    [∀ (F : Cᵒᵖ ⥤ H), f.op.HasLeftKanExtension F]
+    (G : (Dᵒᵖ ⥤ H) ⥤ (Cᵒᵖ ⥤ H))
+    (adj : ExceptionalDirect.exceptionalDirectImage (H := H) f ⊣ G) :
+    G ≅ ExceptionalDirect.pullbackPresheaf (H := H) f :=
+  (CategoryTheory.Adjunction.rightAdjointUniq
+    (ExceptionalDirect.exceptionalDirectImageAdjunction (H := H) f) adj).symm
+
+end Grothendieck.ExceptionalTriple_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap.lean
@@ -95,10 +95,14 @@ open AlgebraicGeometry CategoryTheory
 Les concepts fondamentaux de Grothendieck qui ne sont PAS encore dans Mathlib :
   - Cohomologie étale (site étale, cohomologie l-adique)
   - Motifs (motifs purs, catégorie DM de Voevodsky)
-  - Six opérations (formalisme complet de Grothendieck) — Mathlib fournit
-    l'instance de base `f^* ⊣ f_*` sur les faisceaux de modules
-    (`AlgebraicGeometry.Modules.Sheaf`, indexée par `DirectImage.lean`) ;
-    `f_!` / `f^!` et le formalisme complet restent absents
+  - Six opérations (formalisme complet de Grothendieck) — Mathlib ne fournit
+    que l'instance de base `f^* ⊣ f_*` sur les faisceaux de modules
+    (`AlgebraicGeometry.Modules.Sheaf`, indexée par `DirectImage.lean`). Le
+    formalisme complet reste hors de Mathlib ; au niveau préfaisceau, cette lake
+    a livré le triple `f_! ⊣ f^* ⊣ f_*` (Parties 34-35,
+    `ExceptionalDirect.lean` / `ExceptionalTriple.lean`), et `f^!` s'y effondre
+    sur `f^*` (`exceptionalInverse_collapses_to_pullback`) — il n'existe qu'avec
+    la dualité de Verdier.
   - Grothendieck-Riemann-Roch
   - Dualité de Grothendieck
   - Cohomologie cristalline

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap_en.lean
@@ -89,10 +89,14 @@ Mathlib 4 has a rich category theory library built on these ideas.
 The following are foundational Grothendieck concepts NOT yet in Mathlib:
   - Etale cohomology (site etale, l-adic cohomology)
   - Motives (pure motives, Voevodsky's DM category)
-  - Six operations (Grothendieck's full formalism) — Mathlib provides the base
-    instance `f^* ⊣ f_*` on module sheaves (`AlgebraicGeometry.Modules.Sheaf`,
-    indexed by `DirectImage_en.lean`); `f_!` / `f^!` and the full formalism
-    remain absent
+  - Six operations (Grothendieck's full formalism) — Mathlib provides only the
+    base instance `f^* ⊣ f_*` on module sheaves
+    (`AlgebraicGeometry.Modules.Sheaf`, indexed by `DirectImage_en.lean`).
+    The full formalism remains outside Mathlib; at the presheaf level, this lake
+    has delivered the triple `f_! ⊣ f^* ⊣ f_*` (Parts 34-35,
+    `ExceptionalDirect.lean` / `ExceptionalTriple.lean`), and `f^!` collapses
+    there onto `f^*` (`exceptionalInverse_collapses_to_pullback`) — it exists
+    only with Verdier duality.
   - Grothendieck-Riemann-Roch
   - Grothendieck duality
   - Crystalline cohomology


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: DEEP/guard #12099

## Contexte

Issue **#12340** (sous-grain de l'EPIC **#2159**), **re-scopée par ai-01** (commentaire `issuecomment-5384749048`, décision du 2026-08-23). Le livrable littéral originel — `f^!` comme adjoint à droite *nouveau* de `f_!` — est **mathématiquement dégénéré** : puisque la Partie 34 a déjà établi `f_! ⊣ f^*`, l'unicité de l'adjoint à droite force `f^! ≅ f^*`. Le finding c.496 le démontre ; ai-01 tranche (ni voie A seul, ni voie B Verdier) : le grain devient la **Partie 35 — triple adjoint**, et l'argument de dégénérescence devient **du contenu formalisé** (point 4 ci-dessous).

## Ce que livre ce PR

Modèle exact de la Partie 34 (`ExceptionalDirect.lean`), un module + son sibling `_en`, convention i18n #4980 (docstrings FR, `_en` byte-identiques en signatures/preuves).

**`Grothendieck/ExceptionalTriple.lean`** (+ `ExceptionalTriple_en.lean`), 5 livrables demandés :

1. **`directImagePresheaf`** (`:90`) — `f_* := f.op.ran` (extension de Kan à droite = image directe classique), et **`directImagePresheafAdjunction`** (`:98`) — `f^* ⊣ f_*` via `Functor.ranAdjunction`. La troisième patte du sandwich, pas une fin en soi.
2. **`presheafSixOpsTriple`** (`:117`) — `CategoryTheory.Adjunction.Triple f_! f^* f_*`, avec `adj₁ :=` l'adjonction de la Partie 34 (`exceptionalDirectImageAdjunction`) et `adj₂ :=` celle du point 1. C'est **le sandwich entier** (une moitié est du Mathlib recopié ; le triple ne l'est pas).
3. **`exceptionalDirectImage_fullyFaithful_iff_directImage`** (`:139`) — la cohérence `f_!` pleinement fidèle **ssi** `f_*` l'est, via `Adjunction.Triple.fullyFaithfulEquiv`. Un énoncé sur `f_!` prouvé *via* `f_*` — strictement hors de portée de la Partie 34 seule.
4. **`exceptionalInverse_collapses_to_pullback`** (`:162`) — **la formalisation du finding c.496** : pour tout `G` tel que `f_! ⊣ G`, on a `G ≅ f^*`, via `CategoryTheory.Adjunction.rightAdjointUniq` appliqué à `exceptionalDirectImageAdjunction`. C'est le plafond honnête du niveau préfaisceau **énoncé en Lean**, pas seulement en prose — la justification durable pour tout lecteur ultérieur de l'absence de `f^!` sans dualité de Verdier.
5. **`MathlibMap.lean:101` + `MathlibMap_en.lean`** mis à jour ensemble : la ligne « `f_!` / `f^!` [...] restent absents » était fausse pour `f_!` depuis la Partie 34 ; elle distingue désormais `f_!` (livré, Parties 34-35) de `f^!` (hors de portée préfaisceau, renvoi au point 4).

Ce qui **n'est pas** du Mathlib recopié : le `Triple` et les propriétés qui n'existent que parce qu'il y en a un (point 2, 3, 4). L'adjonction `f^* ⊣ f_*` seule (point 1) est bien du Mathlib (`ranAdjunction`), et c'est précisément pour cela qu'elle n'est pas le livrable.

## SOTA / anti-régression

Aucun `sorry` ajouté, aucun `native_decide`, aucune preuve existante modifiée. Les deux modules sont **nouveaux** (ajout net) ; seul `MathlibMap` est modifié, et en **prose** (bloc `/-! ... -/`), ce qui ne peut pas casser la compilation.

## Validation

- `lake build Grothendieck.ExceptionalTriple` + `Grothendieck.ExceptionalTriple_en` → **SUCCESS, 685 jobs, BUILD_EXIT 0** (local, toolchain du lake). Le `lake build Grothendieck` complet (toutes cibles) est laissé à la CI — elle seule fait autorité sur le full target (toolchain `v4.32.1` non installée sur cette machine).
- `python scripts/lean/count_code_sorry.py --lake .../grothendieck_lean --json` → `distinct_code_sorry: 0` (**inchangé à 0** — le lake y reste).
- `python scripts/lean/check_i18n_siblings.py` → les **deux** paires (`ExceptionalTriple` et `MathlibMap`) `1/1 byte-identical`, `0 drift`, `0 orphan`, exit 0.
- `native_decide` : interdit — aucun dans les nouveaux modules.
- Job CI `proof-integrity` : sera vert sur les modules ajoutés (à confirmer par la CI au push).

## Grain

`DEEP/lean` — genre **CONTENU** (preuve Lean), il tient le plancher G-VAR-1. `prev: DEEP/guard #12099` (dernier grain mergé de la lane, 2026-08-23). G-VAR-3 OK (guard → lean, genres distincts).

**`Closes #12340`** (livraison complète du grain re-scopé). **`See #2159`** (EPIC parent, reste ouverte). ai-01 corrigera le titre de l'issue au merge (« image inverse exceptionnelle » → « triple adjoint »), comme annoncé dans sa décision.
