### PR TITLE
feat(tweety,#12490): confrontation semi-stable/ideal vs CF2 sur le cycle impair (Tweety-5 exemple guide 2bis)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
@@ -18,20 +18,21 @@
     "\n",
     "**Navigation**: [<- Tweety-4-Belief-Revision](Tweety-4-Belief-Revision.ipynb) | [Index](Tweety-1-Setup.ipynb) | [Tweety-6-Structured-Argumentation ->](Tweety-6-Structured-Argumentation.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs pedagogiques\n",
     "\n",
     "1. Comprendre les cadres d'argumentation abstraits de Dung (AF)\n",
-    "2. Maitriser les sémantiques d'acceptabilite (grounded, preferred, stable, complete)\n",
+    "2. Maitriser les sémantiques d'acceptabilite (grounded, preferred, stable, complete, semi-stable, ideal)\n",
     "3. Explorer la sémantique CF2 pour les graphes avec cycles\n",
-    "4. Generer des frameworks d'argumentation aleatoires\n",
+    "4. Confronter les deux stratégies de réparation du vide stable : semi-stable / ideal (conservatrices) et CF2\n",
+    "5. Generer des frameworks d'argumentation aleatoires\n",
     "\n",
     "## Prerequis\n",
     "\n",
     "Executez d'abord [Tweety-1-Setup.ipynb](Tweety-1-Setup.ipynb) pour configurer l'environnement JVM.\n",
     "\n",
-    "### Duree estimee : 55 minutes\n",
+    "### Duree estimee : 60 minutes\n",
     "\n",
     "> **Note:** La section 4.1.4 (Apprentissage depuis Labellisations) est documentee conceptuellement mais desactivee en raison d'un bug interne Tweety.\n",
     "\n",
@@ -1844,7 +1845,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Resume\n",
     "\n",
@@ -1854,6 +1855,7 @@
     "|---------|--------------|\n",
     "| **4.1.1 Bases** | Arguments, attaques, DungTheory, 6 sémantiques |\n",
     "| **4.1.2 CF2** | Decomposition SCC, gestion des cycles impairs |\n",
+    "| **4.1.2bis Reparation du vide stable** | Semi-stable (Caminada 2006), ideal (Dung-Mancarella-Toni 2007) vs CF2 |\n",
     "| **4.1.3 Generation** | DefaultDungTheoryGenerator, tests et benchmarks |\n",
     "| **4.1.4 Apprentissage** | Concept documente (bug Tweety) |\n",
     "| **4.2 Equivalence** (v1.30) | 9 notions d'equivalence (Syntactic, Strong, Standard, Expansion, Deletion, Serialisation) |\n",
@@ -1865,12 +1867,14 @@
     "ConflictFree -> Admissible -> Complete -> Grounded (unique, sceptique)\n",
     "                                      -> Preferred (maximale, credule)\n",
     "                                      -> Stable (attaque tout, pas toujours existant)\n",
+    "                                      -> SemiStable (maximise S u S+, existe toujours)\n",
+    "                                      -> Ideal (unique, incluse dans tous les preferred)\n",
     "```\n",
     "\n",
     "**Points cles a retenir :**\n",
     "- **Grounded** : Extension unique, position sceptique (la plus prudente)\n",
     "- **Preferred** : Extensions maximales, positions credules (peut y en avoir plusieurs)\n",
-    "- **Stable** : N'existe pas toujours (cycles impairs), utiliser **CF2** dans ce cas\n",
+    "- **Stable** : N'existe pas toujours (cycles impairs). Deux reparations mesurees : **semi-stable / ideal** (conservatrices, existent toujours, mais triviales sur le cycle impair) et **CF2** (informative, mais quitte l'admissibilite)\n",
     "- **Equivalence** : Plusieurs notions pour comparer des AFs (syntaxique vs sémantique)\n",
     "- **Explications** : Comprendre \"pourquoi\" un argument est accepte (XAI)\n",
     "- **Causal** : L'argumentation appliquee au raisonnement causal (diagnostics, interventions)\n",
@@ -1879,7 +1883,7 @@
     "\n",
     "Le notebook suivant explore l'**argumentation structuree** avec ASPIC+, DeLP, ABA et ASP.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation**: [<- Tweety-4-Belief-Revision](Tweety-4-Belief-Revision.ipynb) | [Index](Tweety-1-Setup.ipynb) | [Tweety-6-Structured-Argumentation ->](Tweety-6-Structured-Argumentation.ipynb)"
    ]
@@ -1898,7 +1902,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exemples guides et Exercices\n",
     "\n",
@@ -2319,6 +2323,94 @@
     "**CF2 retourne 5 extensions.** La sémantique CF2 décompose le graphe en composantes fortement connexes (SCC) — ici une seule SCC contenant les 5 arguments. À l'intérieur, elle retient les ensembles \"conflict-free\" maximaux : les paires d'arguments non adjacents dans le cycle, `{a,c}`, `{a,d}`, `{b,d}`, `{b,e}`, `{c,e}`.\n",
     "\n",
     "La différence fondamentale : Stable impose une contrainte **globale** (attaquer tout l'extérieur), CF2 impose une contrainte **locale** (pas de conflit interne à la SCC). CF2 garantit toujours au moins une extension, même là où Stable échoue."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sol-ex2b-md",
+   "metadata": {},
+   "source": [
+    "### Exemple guide 2bis : réparer le « vide stable » — semi-stable et ideal contre CF2\n",
+    "\n",
+    "L'exemple précédent laisse un problème ouvert : **stable retourne 0 extension** sur le cycle impair. La littérature propose deux familles de réparation, aux philosophies opposées :\n",
+    "\n",
+    "1. **La réparation conservatrice** — rester dans la hiérarchie de Dung (l'admissibilité), affaiblir la contrainte de maximalité :\n",
+    "   - **semi-stable** (Caminada, 2006) : extension *complète* qui maximise `S ∪ S⁺` — l'ensemble lui-même plus tout ce qu'il attaque. Elle existe **toujours**, et coïncide avec stable dès que stable existe.\n",
+    "   - **ideal** (Dung, Mancarella & Toni, 2007) : le plus grand ensemble *admissible* inclus dans l'intersection de tous les preferred. Unique, toujours défini — la position sceptique maximale.\n",
+    "\n",
+    "2. **La réparation structurelle** — quitter l'admissibilité et découper le graphe : **CF2** (Baroni, Giacomin & Guida, 2005) décompose par composantes fortement connexes et n'impose la conflict-freedom que localement (exemple guide 2 ci-dessus).\n",
+    "\n",
+    "La question : sur le **même cycle impair de longueur 5**, que rend chacune ? Et sur un cadre où stable existe, la réparation conservatrice dégrade-t-elle quoi que ce soit ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "sol-ex2b-code",
+   "metadata": {},
+   "execution_count": 20,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stable     : 0 extension(s) -> []\n",
+      "Complete   : 1 extension(s) -> [{}]\n",
+      "Preferred  : 1 extension(s) -> [{}]\n",
+      "SemiStable : 1 extension(s) -> [{}]\n",
+      "Ideal      : 1 extension(s) -> [{}]\n",
+      "CF2        : 5 extension(s) -> [{a,c}, {a,d}, {b,d}, {b,e}, {c,e}]\n",
+      "\n",
+      "Controle sur a -> b <- c (stable existe) :\n",
+      "Stable     : [{a,c}]\n",
+      "SemiStable : [{a,c}]\n",
+      "Coïncidence avec stable : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple guide 2bis : les deux réparations du vide stable, sur le MEME cycle impair\n",
+    "from org.tweetyproject.arg.dung.reasoner import (\n",
+    "    SimpleStableReasoner, SimpleCompleteReasoner, SimplePreferredReasoner,\n",
+    "    SimpleSemiStableReasoner, SimpleIdealReasoner, SccCF2Reasoner\n",
+    ")\n",
+    "\n",
+    "af_cycle5, _ = construire_af(\"abcde\", [(\"a\", \"b\"), (\"b\", \"c\"), (\"c\", \"d\"), (\"d\", \"e\"), (\"e\", \"a\")])\n",
+    "\n",
+    "for nom, reasoner in [\n",
+    "    (\"Stable    \", SimpleStableReasoner()),\n",
+    "    (\"Complete  \", SimpleCompleteReasoner()),\n",
+    "    (\"Preferred \", SimplePreferredReasoner()),\n",
+    "    (\"SemiStable\", SimpleSemiStableReasoner()),\n",
+    "    (\"Ideal     \", SimpleIdealReasoner()),\n",
+    "    (\"CF2       \", SccCF2Reasoner()),\n",
+    "]:\n",
+    "    exts = reasoner.getModels(af_cycle5)\n",
+    "    print(f\"{nom} : {exts.size()} extension(s) -> {exts}\")\n",
+    "\n",
+    "# Controle : quand stable existe, semi-stable doit coïncider avec stable (théorème)\n",
+    "af_temoin, _ = construire_af(\"abc\", [(\"a\", \"b\"), (\"c\", \"b\")])\n",
+    "temoin_stable = SimpleStableReasoner().getModels(af_temoin)\n",
+    "temoin_semistable = SimpleSemiStableReasoner().getModels(af_temoin)\n",
+    "print(\"\\nControle sur a -> b <- c (stable existe) :\")\n",
+    "print(\"Stable     :\", temoin_stable)\n",
+    "print(\"SemiStable :\", temoin_semistable)\n",
+    "print(\"Coïncidence avec stable :\", str(temoin_stable) == str(temoin_semistable))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sol-ex2b-interp",
+   "metadata": {},
+   "source": [
+    "#### Lecture des résultats\n",
+    "\n",
+    "**La réparation conservatrice existe… mais de façon vide.** Semi-stable et ideal retournent chacun **1 extension : l'ensemble vide**. Ce n'est pas un artefact : sur ce cycle, chaque argument exige pour sa défense l'argument situé deux crans en amont (`a` exige `d`, qui exige `b`, en conflit avec `a`) — l'exigence fait le tour complet du cycle et le seul ensemble admissible complet est `{}`. Maximiser `S ∪ S⁺` dans une famille réduite à l'ensemble vide ne peut rien rendre d'autre. La garantie d'existence tient (le théorème est vérifié : il y a bien une extension semi-stable), mais elle est ici *triviale* : la sémantique existe et ne dit rien.\n",
+    "\n",
+    "**CF2 reste seule informative : 5 extensions.** En relâchant l'admissibilité au profit d'une contrainte locale par SCC, CF2 rend les paires non adjacentes du cycle — mais ses extensions ne se défendent pas nécessairement elles-mêmes.\n",
+    "\n",
+    "**Le contrôle confirme la coïncidence.** Sur `a -> b <- c`, où stable existe, semi-stable = stable = `{a, c}` : la réparation conservatrice ne dégrade rien là où stable fonctionne déjà.\n",
+    "\n",
+    "**Le compromis.** Semi-stable et ideal restent dans la hiérarchie de Dung — toutes les garanties dialectiques s'appliquent — au prix d'une trivialité possible sur les cycles impairs ; CF2 achète l'informativité en quittant cette hiérarchie. Aucune ne domine l'autre : le choix dépend de ce que le débat exige — des positions tranchées (CF2) ou des garanties dialectiques (semi-stable / ideal)."
    ]
   },
   {
@@ -2786,7 +2878,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Resume et Conclusion\n",
     "\n",
@@ -2857,7 +2949,7 @@
     "\n",
     "Ces approches combinent la puissance des sémantiques de Dung avec la richesse de la logique formelle.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [<- Tweety-4-Belief-Revision](Tweety-4-Belief-Revision.ipynb) | [Index](Tweety-1-Setup.ipynb) | [Tweety-6-Structured-Argumentation ->](Tweety-6-Structured-Argumentation.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
@@ -2347,7 +2347,7 @@
    "cell_type": "code",
    "id": "sol-ex2b-code",
    "metadata": {},
-   "execution_count": 20,
+   "execution_count": 15,
    "outputs": [
     {
      "name": "stdout",
@@ -2433,7 +2433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "ex4-stub-code",
    "metadata": {
     "execution": {
@@ -2489,7 +2489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "ex5-stub-code",
    "metadata": {
     "execution": {
@@ -2546,7 +2546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "sol-ex3-code",
    "metadata": {
     "ExecuteTime": {
@@ -2658,7 +2658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "sol-ex4-code",
    "metadata": {
     "ExecuteTime": {
@@ -2754,7 +2754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "sol-ex5-code",
    "metadata": {
     "ExecuteTime": {

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
@@ -2972,18 +2972,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 9.277713,
-   "end_time": "2026-05-31T22:55:02.293900+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation_output.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-31T22:54:53.016187+00:00",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml
@@ -33,6 +33,12 @@
       csharp_sha: 1cb02535990e166e31594dd2d5b852dd04877aff
       content_python_sha: 449db30767529e8f4f23ac7d08cb2b3efbdd7d096e7d0912a15388b723e6f72b
       content_csharp_sha: 2b766fb4ebc5f6c7b97d4acf0996cf2b023b46063778f938737d648ac15e37a6
+    - date: "2026-08-24"
+      by: myia-po-2024:CoursIA
+      python_sha: f803bc3e5b5c232e2fc2b33106b7ef2def0c2383
+      csharp_sha: 1cb02535990e166e31594dd2d5b852dd04877aff
+      content_python_sha: 14d6a065c69819c7653e8fb33b6f5454c3696c4d42c45df2bfec685f6aac40c5
+      content_csharp_sha: 2b766fb4ebc5f6c7b97d4acf0996cf2b023b46063778f938737d648ac15e37a6
   known_differences:
     - "Socle commun : argumentation abstraite de Dung (semantiques grounded/preferred/stable) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"org.tweetyproject.tweety-dung.dll\"`). Python via JPype (`from java.util import Collection, HashSet`). Meme moteur Dung de TweetyProject."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: LIGHT/notebook-lean #12555

## Summary

Extension Tweety-5 de #12490 (items 4/6 résiduels après la moitié Dung de po-2026, PR #12510) : le problème motivant — « stable : AUCUNE » sur le cycle impair — était posé **deux fois** dans le notebook avec outputs committés, tandis que **semi-stable** (Caminada 2006) et **ideal** (Dung-Mancarella-Toni 2007) comptaient **0 occurrence** dans tout le corpus. La récap disait « utiliser CF2 dans ce cas » sans jamais nommer la réparation conservatrice.

**Nouvelle section « Exemple guide 2bis : réparer le vide stable — semi-stable et ideal contre CF2 »** (3 cellules insérées après l'exemple guide 2, avant l'Exercice 4) :

1. **Markdown d'introduction** — les deux philosophies de réparation : conservatrice (rester dans la hiérarchie de Dung, affaiblir la maximalité : semi-stable maximisant `S ∪ S⁺`, ideal ⊆ ∩preferred) vs structurelle (CF2, décomposition SCC).
2. **Code sur le MÊME cycle impair de longueur 5** que l'exemple guide 2, avec les **vrais reasoners Tweety** (`SimpleSemiStableReasoner`, `SimpleIdealReasoner`, `SccCF2Reasoner`, etc.) + un **témoin** `a -> b <- c` où stable existe, pour instancier le théorème de coïncidence.
3. **Lecture des résultats** interprétant les outputs réels.

**Résultats mesurés (outputs committés)** — sur le cycle impair :

```
Stable     : 0 extension(s) -> []
Complete   : 1 extension(s) -> [{}]
Preferred  : 1 extension(s) -> [{}]
SemiStable : 1 extension(s) -> [{}]
Ideal      : 1 extension(s) -> [{}]
CF2        : 5 extension(s) -> [{a,c}, {a,d}, {b,d}, {b,e}, {c,e}]
```

La leçon : la réparation conservatrice **existe mais de façon vide** (le seul ensemble complet du cycle impair est `{}` — chaque argument exige pour sa défense l'argument deux crans en amont, l'exigence fait le tour du cycle) ; CF2 reste **seule informative** (5 extensions) mais quitte l'admissibilité. Sur le témoin, semi-stable = stable = `{a, c}` (coïncidence vérifiée `True`) : la réparation conservatrice ne dégrade rien là où stable fonctionne.

**Mises à jour d'ancrage** : objectifs pédagogiques (point 2 étendu semi-stable/ideal, nouveau point 4 « Confronter les deux stratégies de réparation », durée 55→60 min) · récap (nouvelle ligne 4.1.2bis, hiérarchie + `SemiStable`/`Ideal`, point clé Stable réécrit avec les deux réparations mesurées).

## Validation (H.1 — exécution réelle)

- **Vrai kernel python3 via papermill** (contexte complet : cellule d'init JVM + helper `construire_af` + nouvelle cellule), `--cwd` normalisé, **JAVA_HOME = JDK 17** : `rc = 0`, 0 erreur.
- Outputs **transplantés depuis l'exécution réelle** (pattern one-cell re-exec, churn minimal) : cellule `sol-ex2b-code` `execution_count: 20` (continuation des 1-19 committés) + 1 output stream complet.
- **nbformat 4.5 : VALIDE** · 64 cellules · ids uniques · **toutes** les cellules code portent `execution_count` et outputs (H.3 pre-commit Passed) · **C.1 : 0** `raise NotImplementedError` / `assert False` / `1/0`.
- Diff chirurgical : 2 fichiers (le notebook + l'attestation twin `tweety-5-abstract-argumentation.yaml`), 103 insertions / 11 suppressions (dont 6 `---`→`***` = auto-fix du pre-commit hook `fix-hr-separator` sur les openers décoratifs du fichier) ; aucune cellule existante modifiée au-delà des ancrages décrits (cellules 0 et 30, markdown-only).

## Environnement (règle F — réparer, jamais contourner)

Les 42 JARs Tweety 1.30 (détruits du git en `d6932b1396` / #1437) ont été **re-téléchargés via le downloader canonique** `scripts/download_tweety_tools.py --jars --version 1.30 --no-interactive` — `dung-1.30.jar` rétabli, JVM démarre avec 42 JARs comme l'output committé de la cellule d'init. Les reasoners semi-stable/ideal ont été sondés firsthand avant la rédaction (SOTA-OK : la vraie lib, pas de réimplémentation).

## Verdict SOTA

**SOTA-OK** — TweetyProject 1.30 réel via jpype1 (`SimpleSemiStableReasoner`, `SimpleIdealReasoner`, `SimpleStableReasoner`, `SimpleCompleteReasoner`, `SimplePreferredReasoner`, `SccCF2Reasoner`), aucune réimplémentation.

See #12490

