### PR TITLE
fix(ict,#12560): differential_features exclut les colonnes a score non fini du top-k (+ controle negatif, + warning)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/sae_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/sae_traces.py
@@ -30,6 +30,7 @@ le GPU est confine au script d'extraction).
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -123,11 +124,29 @@ def differential_features(traces: dict, k: int = 64) -> np.ndarray:
     C'est la selection ``acts_topk`` du schema amende de #5101 : les features
     qui *discriminent les regimes* (code vs prose vs dialogue...), pas les plus
     actives en absolu (qui seraient dominees par la ponctuation/le formatage).
+
+    Les colonnes a score non fini (une seule activation ``inf``/``NaN`` en
+    amont suffit) sont **exclues** du classement et signalees par
+    ``RuntimeWarning`` : sans ce garde, ``var`` rend ``inf``/``NaN`` pour ces
+    colonnes et ``argsort()[::-1]`` les promeut **en tete** du top-k au lieu
+    de les ecarter — une donnee polluee devient une corruption de classement
+    invisible (#12560 : facteur 3,3 sur ``overlap_diff64`` des traces 8B).
+    S'il reste moins de ``k`` colonnes finies, la sortie est tronquee d'autant.
     """
     means = mean_activation_by_set(traces)
     stack = np.stack(list(means.values()))               # [n_sets, d_sae]
     score = stack.var(axis=0)
-    return np.argsort(score)[::-1][:k].astype(np.int64)
+    finite = np.isfinite(score)
+    if not finite.all():
+        warnings.warn(
+            f"differential_features : {int(np.count_nonzero(~finite))} colonne(s) "
+            "a score non fini (activation inf/NaN en amont) exclue(s) du "
+            "classement — la trace est polluee, corriger la cause avant "
+            "d'interpreter le top-k.",
+            RuntimeWarning, stacklevel=2)
+    finite_idx = np.flatnonzero(finite)
+    order = finite_idx[np.argsort(score[finite_idx])[::-1][:k]]
+    return order.astype(np.int64)
 
 
 def acts_topk_panels(traces: dict, feature_ids: np.ndarray) -> dict[tuple[str, int], np.ndarray]:

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sae_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sae_traces.py
@@ -80,6 +80,42 @@ def test_differential_features_finds_planted_not_ubiquitous(synthetic_npz):
     assert stack.var(axis=0)[2] < 1e-6
 
 
+def test_differential_features_inf_excluded_never_ranked_head(synthetic_npz):
+    """Controle negatif fondateur (#12560) : reproduit le defaut des traces 8B
+    (un +inf sur UN seul token d'un seul prompt) et verifie que la colonne
+    polluee n'est PAS classee — avant le garde, argsort()[::-1] promouvait le
+    score inf/NaN en TETE du top-k, corrompant overlap_diff64 d'un facteur 3,3."""
+    tr = st.load_traces(synthetic_npz)
+    e = tr["prompts"][("setA", 0)]
+    e["ids"][0, 2] = 999                      # feature jamais plantee
+    e["vals"][0, 2] = np.inf                  # un seul token pollue
+    with pytest.warns(RuntimeWarning, match="non fini"):
+        top64 = st.differential_features(tr, k=64).tolist()
+    assert 999 not in top64                   # jamais classe, ni en tete ni ailleurs
+    assert top64.index(7) < 2 and top64.index(13) < 2   # les plantees restent en tete
+    assert len(top64) == 64                   # assez de colonnes finies -> k respecte
+
+
+def test_differential_features_truncated_when_all_polluted():
+    """Cas borne : si TOUTES les colonnes discriminantes candidates sont non
+    finies, la sortie est tronquee (jamais remplie d'indices pollues)."""
+    rng = np.random.default_rng(1)
+    traces = {"meta": {"d_sae": 8}, "prompts": {}}
+    for set_name in ("setA", "setB"):
+        for i in range(2):
+            ids = np.tile(np.arange(8), (3, 1))
+            vals = rng.uniform(0.1, 0.5, size=(3, 8)).astype(np.float32)
+            if set_name == "setA":
+                vals[:] = np.where(np.arange(8) % 2 == 0, np.inf, vals)
+            traces["prompts"][(set_name, i)] = {"ids": ids, "vals": vals}
+    with pytest.warns(RuntimeWarning):
+        feats = st.differential_features(traces, k=4)
+    # colonnes paires -> score inf (moyenne inf en setA) : exclues ; seules les
+    # impaires restent, la sortie ne depasse pas leur nombre.
+    assert set(feats.tolist()) <= {1, 3, 5, 7}
+    assert np.isfinite(np.stack(list(st.mean_activation_by_set(traces).values())).var(axis=0)[feats]).all()
+
+
 def test_densify_exact(synthetic_npz):
     tr = st.load_traces(synthetic_npz)
     e = tr["prompts"][("setB", 1)]


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #12565

## Summary

Fix du défaut ouvert par ai-01 ce matin (#12560) sur la contamination mesurée pendant la mission #12388 (PR #12565) : `differential_features` (`ict/sae_traces.py:120`) transformait silencieusement une donnée polluée en **corruption de classement**.

**Mécanisme (avant)** : `score = stack.var(axis=0)` rend `inf`/`NaN` pour toute colonne touchée par une activation non finie ; `np.argsort` place les NaN **en fin de tri ascendant**, donc le `[::-1]` les remonte **en tête** du top-k. Le consommateur recevait un tableau de la bonne forme et du bon dtype, rempli d'indices arbitraires avant les features réellement discriminantes. Mesuré sur les traces 8B : `top64(trained)` = 50 NaN + 14 réels → `overlap_diff64` brut 14/64 (artefact) contre 46/64 défendable (facteur 3,3).

**Fix (après)** — les deux options de l'issue (« rougir OU exclure ») sont appliquées ensemble :

```python
finite = np.isfinite(score)
if not finite.all():
    warnings.warn(f"... {n} colonne(s) à score non fini ... exclue(s) du classement — "
                  "la trace est polluée, corriger la cause avant d'interpréter le top-k.",
                  RuntimeWarning, stacklevel=2)
finite_idx = np.flatnonzero(finite)
order = finite_idx[np.argsort(score[finite_idx])[::-1][:k]]
```

- Jamais d'indice à score non fini dans le top-k (acceptance #1 ✓) ;
- `RuntimeWarning` au moment de la sélection — la pollution devient **visible** là où elle était invisible ;
- si moins de `k` colonnes finies existent, la sortie est tronquée d'autant (jamais remplie d'indices pollués) ;
- sur données propres : ordering identique à l'ancien code (même argsort descendant sur le même sous-ensemble).

## Tests (acceptance #2 — contrôle négatif fondateur)

- `test_differential_features_inf_excluded_never_ranked_head` : injecte un `+inf` sur **un seul token d'un seul prompt** (reproduction exacte du cas BOS 8B), vérifie (a) la colonne polluée **absente** du top-k, (b) les features plantées **toujours en tête**, (c) `len == 64`, (d) le `RuntimeWarning` levé (`pytest.warns`).
- `test_differential_features_truncated_when_all_polluted` : cas borné — colonnes paires toutes non finies → sortie tronquée aux colonnes finies, toutes à variance finie.
- **Suites** : `test_sae_traces.py` **10/10 PASS** (8 existantes intactes + 2 nouvelles) · suites consommatrices `test_synthesis.py` + `test_lens_agreement.py` **25/25 PASS**.

## Audit des autres consommateurs (acceptance #3)

| Consommateur | Voie | Effet de la pollution avant fix | Effet après fix |
|---|---|---|---|
| ICT-21 `e60f2afa` / `442d9199` | `differential_features` → `overlap_diff64` | **silencieux** — c'est le défaut mesuré (14/64 vs 46/64) | colonnes polluées exclues + warning affiché avant la cellule |
| ICT-21 corr inter-registres | `mean_activation_by_set` → `np.corrcoef` | corrélations `NaN` **visibles** dans l'output (pas silencieux) ; inchangé — le warning du panel amont couvre désormais la cellule |
| ICT-22 cell 6 | `differential_features` (panel figé) + var imprimée | panel corrompu silencieusement | panel propre + warning |
| ICT-24 Gate 22/23 | `differential_features` → `acts_topk_panels` → `binarize_quantile` | panel continu et discret corrompus en silence | panels propres (une val `inf` rendait aussi `binarize_quantile` muet : seuil `inf` → feature toute à `False`) |
| `scripts/extract_sae_traces.py` | **aucun** appel aux deux fonctions (vérifié grep) | — | — |

Le point unique `differential_features` protège donc tout l'aval : les 3 notebooks consomment soit lui directement, soit `mean_activation_by_set` uniquement pour des impressions où un `NaN` est déjà **visible** dans l'output.

## Note

Le défaut de **génération** (BOS à `+inf` sur un prompt, 1 token sur 205) reste suivi côté extraction GPU par ai-01 — distinct de ce défaut d'**analyse**, conformément au découpage « deux défauts, pas un » de l'issue.

Closes #12560
