### PR TITLE
feat(notebook,#12441): enrichir 1.3-Pandas — merge/join, NaN, datetime, read_csv reel

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/README.md
@@ -13,7 +13,7 @@ Avant d'orchestrer des agents LLM qui *écrivent* du code data science (labs Lan
 | Notebook | Contenu | Durée |
 |----------|---------|-------|
 | [1.2-NumPy](notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb) | `ndarray`, vectorisation (timing vs boucle), broadcasting, indexation/masques booléens, `axis`, `default_rng(seed)` | ~60-75 min |
-| [1.3-Pandas](notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb) | `DataFrame`, sélection de colonnes, filtrage booléen, manipulation tabulaire | ~60 min |
+| [1.3-Pandas](notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb) | `DataFrame`, sélection de colonnes, filtrage booléen, `merge`/`join` (4 `how=`), données manquantes (`isna`/`fillna`/`dropna`), séries temporelles (`to_datetime`, `.dt`, `resample`), `read_csv` réel | ~45 min |
 
 > **Numérotation.** La série commence à `1.2` car le `1.1` d'introduction est couvert par le [README parent](../README.md). La continuité logique est `1.2` (NumPy) → `1.3` (Pandas) → [Lab 1](../Track1-LangChain/Day1-Foundations/Labs/Lab1-PythonForDataScience.ipynb) (mise en pratique sur ventes synthétiques) → [02-ML-Cours 2.1](../02-ML-Cours/2.1-Workflow-ML.ipynb).
 

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
@@ -25,13 +25,17 @@
     "2. Sélectionner des colonnes avec la notation `[]`\n",
     "3. Filtrer des lignes avec des conditions booléennes\n",
     "4. Manipuler des données tabulaires simples\n",
+    "5. Rapprocher deux tables avec `merge`/`join` et choisir le bon `how`\n",
+    "6. Diagnostiquer des valeurs manquantes (`isna`) et décider entre `dropna` et `fillna`\n",
+    "7. Traiter des séries temporelles (`to_datetime`, `.dt`, `resample`)\n",
+    "8. Lire un fichier réel avec `pd.read_csv` (`sep`, `parse_dates`)\n",
     "\n",
     "### Prérequis\n",
     "- Python 3.10+\n",
     "- Notebook 1.2 (NumPy) complété\n",
     "- Aucune expérience préalable en analyse de données requise\n",
     "\n",
-    "### Durée estimée : 20-25 minutes\n",
+    "### Durée estimée : 40-50 minutes\n",
     "\n",
     "---\n",
     "\n",
@@ -87,10 +91,10 @@
    "id": "fb918b11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:18:13.267014Z",
-     "iopub.status.busy": "2026-05-13T08:18:13.267014Z",
-     "iopub.status.idle": "2026-05-13T08:18:13.568509Z",
-     "shell.execute_reply": "2026-05-13T08:18:13.568509Z"
+     "iopub.execute_input": "2026-08-23T12:07:56.475090Z",
+     "iopub.status.busy": "2026-08-23T12:07:56.474944Z",
+     "iopub.status.idle": "2026-08-23T12:07:56.897470Z",
+     "shell.execute_reply": "2026-08-23T12:07:56.896793Z"
     },
     "papermill": {
      "duration": 0.306608,
@@ -150,10 +154,10 @@
    "id": "6ceb3338",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:18:13.577104Z",
-     "iopub.status.busy": "2026-05-13T08:18:13.577104Z",
-     "iopub.status.idle": "2026-05-13T08:18:13.581888Z",
-     "shell.execute_reply": "2026-05-13T08:18:13.581888Z"
+     "iopub.execute_input": "2026-08-23T12:07:56.898952Z",
+     "iopub.status.busy": "2026-08-23T12:07:56.898781Z",
+     "iopub.status.idle": "2026-08-23T12:07:56.904314Z",
+     "shell.execute_reply": "2026-08-23T12:07:56.903731Z"
     },
     "papermill": {
      "duration": 0.008148,
@@ -220,10 +224,10 @@
    "id": "171b1e9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:18:13.590118Z",
-     "iopub.status.busy": "2026-05-13T08:18:13.590118Z",
-     "iopub.status.idle": "2026-05-13T08:18:13.599056Z",
-     "shell.execute_reply": "2026-05-13T08:18:13.598545Z"
+     "iopub.execute_input": "2026-08-23T12:07:56.905885Z",
+     "iopub.status.busy": "2026-08-23T12:07:56.905714Z",
+     "iopub.status.idle": "2026-08-23T12:07:56.910269Z",
+     "shell.execute_reply": "2026-08-23T12:07:56.909764Z"
     },
     "papermill": {
      "duration": 0.01248,
@@ -255,6 +259,379 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-jd-intro",
+   "metadata": {},
+   "source": [
+    "## Jointure de deux tables : `merge` / `join`\n",
+    "\n",
+    "Une table rarement se suffit à elle-même : les données d'une commande vivent dans une\n",
+    "table, le détail des clients dans une autre. La jointure rapproche deux tables sur une\n",
+    "**clé** commune. Pandas expose `pd.merge(df_gauche, df_droite, on=clé, how=...)`.\n",
+    "\n",
+    "Le paramètre `how` décide **quelles lignes** survivent :\n",
+    "\n",
+    "| `how` | Garde | Image courante |\n",
+    "|---|---|---|\n",
+    "| `inner` | intersection des clés | une commande sans client connu disparaît |\n",
+    "| `left` | toutes les lignes de gauche | la commande reste, `NaN` côté client si absent |\n",
+    "| `right` | toutes les lignes de droite | le client sans commande reste, `NaN` côté commande |\n",
+    "| `outer` | union des clés | tout le monde, `NaN` là où l'information manque |\n",
+    "\n",
+    "Le **nombre de lignes** change selon le `how` : c'est la trace visible du choix.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-jd-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T12:07:56.911944Z",
+     "iopub.status.busy": "2026-08-23T12:07:56.911784Z",
+     "iopub.status.idle": "2026-08-23T12:07:56.927991Z",
+     "shell.execute_reply": "2026-08-23T12:07:56.927430Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== clients ===\n",
+      "   client_id      nom\n",
+      "0          1    Alice\n",
+      "1          2      Bob\n",
+      "2          3  Charles\n",
+      "\n",
+      "=== commandes ===\n",
+      "   client_id  montant\n",
+      "0          1      100\n",
+      "1          3      250\n",
+      "2          4       75\n",
+      "\n",
+      "--- how=inner : 2 lignes ---\n",
+      "   client_id      nom  montant\n",
+      "0          1    Alice      100\n",
+      "1          3  Charles      250\n",
+      "\n",
+      "--- how=left : 3 lignes ---\n",
+      "   client_id      nom  montant\n",
+      "0          1    Alice    100.0\n",
+      "1          2      Bob      NaN\n",
+      "2          3  Charles    250.0\n",
+      "\n",
+      "--- how=right : 3 lignes ---\n",
+      "   client_id      nom  montant\n",
+      "0          1    Alice      100\n",
+      "1          3  Charles      250\n",
+      "2          4      NaN       75\n",
+      "\n",
+      "--- how=outer : 4 lignes ---\n",
+      "   client_id      nom  montant\n",
+      "0          1    Alice    100.0\n",
+      "1          2      Bob      NaN\n",
+      "2          3  Charles    250.0\n",
+      "3          4      NaN     75.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# Deux petites tables : les clients et leurs commandes\n",
+    "clients = pd.DataFrame({\n",
+    "    'client_id': [1, 2, 3],\n",
+    "    'nom': ['Alice', 'Bob', 'Charles']\n",
+    "})\n",
+    "commandes = pd.DataFrame({\n",
+    "    'client_id': [1, 3, 4],          # le client 4 a une commande mais n'est pas en base client\n",
+    "    'montant': [100, 250, 75]\n",
+    "})\n",
+    "\n",
+    "print('=== clients ===')\n",
+    "print(clients)\n",
+    "print('\\n=== commandes ===')\n",
+    "print(commandes)\n",
+    "\n",
+    "# Les 4 variantes de how= sur les MEMES donnees\n",
+    "for how in ['inner', 'left', 'right', 'outer']:\n",
+    "    jointure = pd.merge(clients, commandes, on='client_id', how=how)\n",
+    "    print(f'\\n--- how={how} : {len(jointure)} lignes ---')\n",
+    "    print(jointure)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-jd-read",
+   "metadata": {},
+   "source": [
+    "### Le choix de `how` change le récit\n",
+    "\n",
+    "Observez les quatre sorties : `inner` rend **2** lignes (seuls les clients 1 et 3 ont\n",
+    "une commande **et** un nom), `left` rend **3** (le client 2, sans commande, garde un\n",
+    "`NaN` montant), `right` rend **3** (le client 4, sans nom, garde un `NaN` nom), `outer`\n",
+    "rend **4**. Aucune donnée n'est fausse : c'est le **sens métier** qui dicte le `how`.\n",
+    "Voulez-vous ne garder que les commandes `inner` ? Ou toutes les commandes `left` ?\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-jd-missing-intro",
+   "metadata": {},
+   "source": [
+    "## Données manquantes : `NaN`, `isna`, `fillna`, `dropna`\n",
+    "\n",
+    "Les données réelles arrivent trouées. La première question n'est pas « comment les\n",
+    "combler ? » mais **« où sont-elles ? »** : `df.isna().sum()` compte les manquants par\n",
+    "colonne. Ensuite, deux stratégies opposées : **supprimer** les lignes fautives\n",
+    "(`dropna(subset=[...])`, idée : ces lignes sont inutilisables) ou **imputer** par une\n",
+    "valeur (`fillna`, idée : jeter une ligne jette aussi l'information des autres colonnes).\n",
+    "Le bon choix se juge sur la **statistique aval** qu'on calcule ensuite.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-jd-missing-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T12:07:56.929412Z",
+     "iopub.status.busy": "2026-08-23T12:07:56.929239Z",
+     "iopub.status.idle": "2026-08-23T12:07:56.938720Z",
+     "shell.execute_reply": "2026-08-23T12:07:56.938112Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Etat brut ===\n",
+      "       nom  note   age\n",
+      "0    Alice  10.0  20.0\n",
+      "1      Bob   NaN  21.0\n",
+      "2  Charles  12.0   NaN\n",
+      "3    Diana   NaN  22.0\n",
+      "4      Eve  30.0  19.0\n",
+      "\n",
+      "=== Diagnostic : ou manque-t-il des valeurs ? ===\n",
+      "nom     0\n",
+      "note    2\n",
+      "age     1\n",
+      "dtype: int64\n",
+      "\n",
+      "--- Strategie dropna : 3 lignes restantes ---\n",
+      "note moyenne (dropna) = 17.33\n",
+      "\n",
+      "--- Strategie fillna : note mediane 12.0 ---\n",
+      "note moyenne (fillna) = 15.20\n",
+      "       nom  note   age\n",
+      "0    Alice  10.0  20.0\n",
+      "1      Bob  12.0  21.0\n",
+      "2  Charles  12.0   NaN\n",
+      "3    Diana  12.0  22.0\n",
+      "4      Eve  30.0  19.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "# Reprenons l'esprit du dataset etudiants, mais avec des trous volontaires\n",
+    "notes = pd.DataFrame({\n",
+    "    'nom': ['Alice', 'Bob', 'Charles', 'Diana', 'Eve'],\n",
+    "    'note': [10.0, np.nan, 12.0, np.nan, 30.0],   # distribution asymetrique : la mediane != la moyenne\n",
+    "    'age': [20, 21, np.nan, 22, 19]\n",
+    "})\n",
+    "\n",
+    "print('=== Etat brut ===')\n",
+    "print(notes)\n",
+    "print('\\n=== Diagnostic : ou manque-t-il des valeurs ? ===')\n",
+    "print(notes.isna().sum())\n",
+    "\n",
+    "# Strategie 1 : supprimer les lignes sans note\n",
+    "notes_sans_trou = notes.dropna(subset=['note'])\n",
+    "# Strategie 2 : imputer la note manquante par la mediane des notes existantes\n",
+    "mediane = notes['note'].median()\n",
+    "notes_imputees = notes.copy()\n",
+    "notes_imputees['note'] = notes['note'].fillna(mediane)\n",
+    "\n",
+    "print(f'\\n--- Strategie dropna : {len(notes_sans_trou)} lignes restantes ---')\n",
+    "print(f'note moyenne (dropna) = {notes_sans_trou[\"note\"].mean():.2f}')\n",
+    "print(f'\\n--- Strategie fillna : note mediane {mediane:.1f} ---')\n",
+    "print(f'note moyenne (fillna) = {notes_imputees[\"note\"].mean():.2f}')\n",
+    "print(notes_imputees)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-jd-missing-read",
+   "metadata": {},
+   "source": [
+    "### Imputer ou supprimer : le choix se mesure\n",
+    "\n",
+    "La moyenne des notes change selon la strategie. `dropna` la calcule sur les seules notes\n",
+    "observees (Alice **10**, Charles **12**, Eve **30**) et rend **17.33** : elle est tiree vers\n",
+    "le haut par la note 30. `fillna` a remplace les deux trous par la mediane (**12.0**) et rend\n",
+    "**15.2** : il abaisse la moyenne en *reinserant* une valeur « moyenne ». Aucune des deux\n",
+    "n'est « vraie » : si les manquants sont aleatoires, imputer (garder les lignes) se defend ;\n",
+    "si l'absence est un signal metier, mieux vaut supprimer la ligne et l'asserter.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-jd-dt-intro",
+   "metadata": {},
+   "source": [
+    "## Séries temporelles : `datetime` et `resample`\n",
+    "\n",
+    "Beaucoup de données ont une dimension **temps**. Pandas sait convertir une colonne de\n",
+    "chaînes en dates grâce à `pd.to_datetime`, puis exploiter l'accesseur `.dt` (`.dt.year`,\n",
+    "`.dt.month`) et **agréger par période** avec `resample` (ici mensuel). Le cursus est\n",
+    "massivement temporel — côté ML-5 et QuantConnect, cette étape est le prérequis d'un\n",
+    "backtest propre.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-jd-dt-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T12:07:56.940232Z",
+     "iopub.status.busy": "2026-08-23T12:07:56.940020Z",
+     "iopub.status.idle": "2026-08-23T12:07:57.447890Z",
+     "shell.execute_reply": "2026-08-23T12:07:57.447204Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== .dt.year ===\n",
+      "        date  annee  montant\n",
+      "0 2024-01-15   2024      120\n",
+      "1 2024-01-28   2024       80\n",
+      "2 2024-02-10   2024      200\n",
+      "3 2024-03-05   2024      150\n",
+      "4 2024-03-21   2024       90\n",
+      "\n",
+      "=== Ventes mensuelles (resample ME) ===\n",
+      "date\n",
+      "2024-01-31    200\n",
+      "2024-02-29    200\n",
+      "2024-03-31    240\n",
+      "Freq: ME, Name: montant, dtype: int64\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAikAAAFMCAYAAAAOQixqAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAPc1JREFUeJzt3QlYlNX+B/Cv7Issogga4J6EYC6AC+aSXrWk9EqZpiKolWuaZWr/tD1t+9v15pYmoLmkppe01Ot1NyRwx31BERMBQZZAtpn5P+d4Z/6gqIAM7zDz/TzPPMy78M4ZbHq/c97fOW8djUajAREREZGBMVO6AURERETlYUghIiIig8SQQkRERAaJIYWIiIgMEkMKERERGSSGFCIiIjJIDClERERkkBhSiIiIyCAxpBAREZFBYkghIqpBe/fuRZ06deRPrbCwMDRt2lTRdhEZIoYUohr04osvws7ODrm5uQ/cZ/jw4bCyskJGRka1v/5vv/2GDz/8sNqPS0SkDwwpRDVIBJA7d+5g8+bN5W7Pz89HdHQ0+vfvj/r16+slpHz00UfVflwiIn1gSCGq4Z4UBwcHrFmzptztIqDk5eXJMENEZOoYUohqkK2tLQYPHoxdu3YhLS3tvu0ivIgQI8KMkJWVhalTp8LT0xPW1tZo2bIlvvjiC6jVat3vXL16VdY4fP311/j+++/RokULuW9AQADi4+PL1D0sXLhQPhf7ax9a4pjffvst2rRpAxsbG7i5ueGNN97A7du3y7Tx8OHD6NevHxo0aCDfT7NmzTB69OhHvndRcxEcHCxrMfz9/eXv+vn56WozNm3aJJfFa3fs2BHHjh277xjnzp3DSy+9BBcXF7mfOM4vv/xSZp/IyEj5vn7//XdMmzYNrq6usLe3x9///nekp6dX6r2UVz9S+m8uXquy7asoff97ENUGFko3gMjUiF6SqKgorF+/HpMmTdKtz8zMxI4dOzBs2DB5shGXfnr06IE///xTnpy8vLwQExODWbNmISUlRZ7A7g04otZF7CtOoF9++aUMRImJibC0tJTrb9y4gZ07d2LVqlX3tUtsFyfd8PBwvPnmm7hy5Qq+++47GRbECV8cQwSrvn37yhP/zJkz4ezsLE/YImBUxKVLl/Dqq6/K1xoxYoQMVi+88AKWLFmC9957DxMmTJD7zZ07F0OGDMH58+dhZnb3u9Tp06cRFBSEJ554Qr62CB7ibzho0CD8/PPPMoSUNnnyZNSrVw8ffPCBbKP4e4m/908//SS3P+57uVdl2/coNfHvQWTwNERUo0pKSjSNGjXSdOnSpcz6JUuWaMRHcseOHXL5k08+0djb22suXLhQZr+ZM2dqzM3NNdeuXZPLV65ckb9Xv359TWZmpm6/6OhouX7Lli26dRMnTpTr7nXgwAG5fvXq1WXWb9++vcz6zZs3y+X4+PhKv+8mTZrI342JidGtE+9VrLO1tdUkJSXp1i9dulSu37Nnj25d7969NX5+fpqCggLdOrVarenataumVatWunURERHyd/v06SO3a7311lvy75aVlVXh9yJe/952lP6bi9eqbPvKO+aoUaPk36cm/z2IagNe7iGqYebm5hg6dCgOHTokv/WW7gkRXfq9e/eWyxs2bMAzzzwjewNu3bqle/Tp0wcqlQr79+8vc9xXXnlF7qslflcQPSmPIl7LyckJf/vb38q8lrjsUrduXezZs0fuJ76pC1u3bkVxcXGl37uPjw+6dOmiW+7UqZP8+eyzz8qeonvXa9suepl2794te1dEb5G2fWIElLjUcfHiRdnjVNrrr79e5nKW+HuIv1tSUlK1vJfSqtI+Q/j3IDJ0DClECtAWxmoLaK9fv44DBw7I8CJCjCBObNu3b5dd+aUfIqQI99a0lD7JC9rAcm8NQ3nEa2VnZ6Nhw4b3vd5ff/2ley1x+SkkJESOEBI1EAMHDkRERAQKCwsr9L7vbaM4EQui5qa89dq2i8tEGo0Gs2fPvq994nJOVf4ej/teSqtK+wzh34PI0LEmhUgB4huxt7c31q5dK2sxxE9xkis9qkcUTopv0u+++265x3jyySfLLGvDzb3EcR9FvJY4Ia5evbrc7eLkKIieiY0bNyI2NhZbtmyRNTSiSPObb76R68S3/Id5UBsf1XZtofA777wjeybKI4qKK3PMiryX0j0xpYkemdKq0j5D+PcgMnQMKUQKEYFEfPM+efKk7FFp1aqVHJGjJUbpiG/N2p6T6vCgk654rf/85z+y8FMU7T5K586d5eOzzz6TbRfvZd26dRg7diz0oXnz5vKnKBatzr/Ho96LtvdFjLIqTXvJSF/tM/R/D6Kawss9RArR9prMmTMHx48fv29uFFHfIOpWxLfje4mTZklJSaVfU4w40f7+va8legc++eST+35HvI52f3Gp5N6emXbt2smf+rzEIHoVevbsiaVLl8qRTfe6d2hxRVTkvTRp0kT2yNxb/7No0SK9ts/Q/z2Iagp7UogUIuaz6Nq1q5zATbg3pEyfPl3OsSHmFhFznIhLRGKit4SEBNnFL4puRR1CZYhjCGJIq7gsoS3iFbUNYsirGPorApMY1ip6BURthCji/Mc//iHn/xBDp8UJWgynFd/2RZHosmXL4OjoiOeffx76JOZ46datm5xL5bXXXpO9F6mpqTLIiZqeEydOVOp4FXkvojbm5Zdfxj//+U/ZCyX2E0Wq5dWXVGf7asO/B1FNYEghUpAIJmLuk8DAwPtqFsQ9fvbt24fPP/9cnphWrlwpTz6iFkUUSmqLSytDzJsi5g8RlwJ+/PFH+S1chBRBzFUiQozoDRB1MhYWFnICNjGfibjsoD15xsXFyd8XJ2DRBtF2UTshQpc+iZFBYuIy8d7F/CFi5IzowWjfvr3sjaqsir4XEVDEyBnx9xGT5Ilejq+++gq+vr56bZ+h/3sQ1YQ6YhxyjbwSERERUSWwJoWIiIgMEkMKERERGSSGFCIiIjJIDClERERkkBhSiIiIyCAxpBAREZFB4jwp/71Pxo0bN+Dg4PDAacOJiIjofmImEzGRYOPGjWFmVr19HwwpgAwo996FlYiIiCouOTkZHh4eqE4MKYDsQdH+gcWMnkRERFQxOTk58ou+9lxanRhSSt0ZVgQUhhQiIqLK00e5BAtniYiIyCAxpBAREZFBYkghIiKiKlGpNYhLzIRRhpS5c+ciICBAFtuIW5oPGjQI58+ff+AQp+eee05e8/rXv/5VZtu1a9cwYMAAeWt7cZzp06ejpKSkht4FERGR6dl+KgXdvtiN0VHxxhlS9u3bh4kTJyI2NhY7d+5EcXEx+vbti7y8vPv2/fbbb8stylGpVDKgFBUVISYmBlFRUYiMjMScOXNq6F0QERGZXkAZ/+NRpGQX6PV16mhEF4WBSE9Plz0hIrx0795dt/748eMIDg7G4cOH0ahRI2zevFn2ugjbtm2T28RcJ25ubnLdkiVLMGPGDHk8KyurCg2fcnJyQnZ2Nkf3EBERPeISj+hB0QYUdWE+kr8dopdzqEHVpIg3KLi4uOjW5efn49VXX8XChQvh7u5+3+8cOnQIfn5+uoAi9OvXTwaP06dPl/s6hYWFcnvpBxERET1a3JVMvfegGFxIEVPTT506FUFBQfD19dWtf+utt9C1a1cMHDiw3N+7efNmmYAiaJfFtgfVwoieE+2Ds80SERFVTFpuzQQUg5rMTdSmnDp1CgcPHtSt++WXX7B7924cO3asWl9r1qxZmDZt2n2z5REREdHDuda1Rk0xiJ6USZMmYevWrdizZ0+Zef9FQLl8+TKcnZ1hYWEhH0JISAh69uwpn4tLQKmpqWWOp10u7/KQYG1trZtdlrPMEhERVUyxSo0Nh5NhEiFF1OyKgCIKYUUgadasWZntM2fOxMmTJ2XhrPYhzJ8/HxEREfJ5ly5dkJCQgLS0NN3viZFCInj4+PjU8DsiIiIyTnmFJRgbdRibj9+A2X8H21b/RPgGdLlHXOJZs2YNoqOj5Vwp2hoSUSdia2sre0LK6w3x8vLSBRoxZFmEkZEjR+LLL7+Ux3j//fflsUWPCRERET2ezLwihEfG40RyFmwszbBoeAcUlajx0ZYz+DMtH0Y5BPlBNyMSvSRhYWEP/J3SQ5CFpKQkjB8/Hnv37oW9vT1GjRqFefPm6S4PPQqHIBMREZUvOTMfo1bEIfFWHpztLLEiLAAdvOrphiPvOZmEv7VvppdzqEHNk6IUhhQiIqL7nU3JkQElLbcQTzjbImp0IFo2rFtj51CDGd1DREREhuPQ5Qy8vvIwcgtL0NrNQQYUdyebGm0DQwoRERGVsS0hBVPWHUeRSo3Api5YFuoPJztL1DSGFCIiItJZFZuEOdGnIIpB+vq4YcGw9rCxNIcSGFKIiIgIokR1/s4LWLD7klx+tZMXPhnoC3PteGMFMKQQERGZuBKVGrOjT2Ft3N2J2qb2aYUpvVs9cBRuTWFIISIiMmEFxSpMXnsMO8+kyknaPh7oixGdm8AQMKQQERGZqOz8YoxdGY/4q7dhZWGGBUPbo79v+beUUQJDChERkQlKyb4j50C5kPoXHGwssDzUH52a14chYUghIiIyMZfSchH6QxxuZBfAzdFazoHi7W54k5kypBAREZmQI0m3MSYqHln5xWjuao+VowPhUc8OhoghhYiIyETsOpuKiWuOoqBYjXaezvI+PC72VjBUDClEREQmYP3hZMzalCBvCtirtSsWDu8AOyvDjgGG3ToiIiJ67EnaFu29jK92nJfLIR08MC/ED5bmZjB0DClERERGSq3W4OOtZxAZc1Uuj+/ZAu/2a634JG0VxZBCRERkhApLVJi2/gR+PZkil2cH+2BMt2aoTRhSiIiIjExuQTHeWHUEMZczYGleB98MaYcXn26M2oYhhYiIyIik5RYgbEU8zqTkwN7KHEtH+qNbqwaojRhSiIiIjMSVW3kIXfEHkjPvoEFdK0SEBcLPwwm1FUMKERGRETh5PQvhEfHIyCuCl4sdVo0JRJP69qjNGFKIiIhquf0X0jHuxyPIL1KhTWNHRIYHwtXBGrUdQwoREVEtFn38T7y9/gRK1BoEtayPJSM6wsHGEsaAIYWIiKiWWn4gEZ/+elY+D27bCN8MeRrWFuYwFgwpREREtXCSti+2n8PS/YlyOTyoKWYP8IGZWe2YpK2iGFKIiIhqkWKVGjM2nsSmY3/K5Rn9vTGuR/NaM4tsZTCkEBER1RJ5hSWYsPoo9l1Ih7lZHcwb7IeX/T2VbpbeMKQQERHVApl5RQiPjMeJ5CzYWJph0fAOeNbbDcaMIYWIiMjAJWfmY9SKOCTeyoOznSVWhAWgg1c9GDuGFCIiIgN2NiVHBpS03EI84WyLqNEBaNnQAaaAIYWIiMhAHbqcgddXHkZuYQlauzkganQg3J1sYCoYUoiIiAzQtoQUTFl3HEUqNQKbumBZqD+c7IxjkraKYkghIiIyMKtikzAn+hQ0GqCvjxsWDGsPG0vjmaStohhSiIiIDIRGo8H8nRewYPclufxqJy98MtBXDjc2RQwpREREBqBEpcbs6FNYG5csl6f2aYUpvVsZ5SRtFcWQQkREpLCCYhUmrz2GnWdSITpNPh7oixGdm8DUMaQQEREpKDu/GGNXxiP+6m1YWZhhwdB26O/bSOlmGQSGFCIiIoWkZN+Rc6BcSP0LDjYWWB7qj07N6yvdLIPBkEJERKSAS2m5CP0hDjeyC+DmaC3nQPF2d1S6WQaFIYWIiKiGHUm6jTFR8cjKL0ZzV3usHB0Ij3p2SjfL4DCkEBER1aBdZ1Mxcc1RFBSr0c7TWd6Hx8XeSulmGSSGFCIiohqy/nAyZm1KgEqtQa/Wrlg4vAPsrHgqfhD+ZYiIiGpgkrZFey/jqx3n5XJIBw/MC/GDpbmZ0k0zaAwpREREeqRWa/Dx1jOIjLkql8f1aIEZ/Vub9CRtFaVohJs7dy4CAgLg4OCAhg0bYtCgQTh//m7K1HrjjTfQokUL2NrawtXVFQMHDsS5c+fK7HPt2jUMGDAAdnZ28jjTp09HSUlJDb8bIiKisgpLVJi87pguoMwO9sHM57wZUGpDSNm3bx8mTpyI2NhY7Ny5E8XFxejbty/y8vJ0+3Ts2BERERE4e/YsduzYIbvMxD4qlUpuFz9FQCkqKkJMTAyioqIQGRmJOXPmKPjOiIjI1OUWFCM8Ih6/nkyBpXkdeZPAMd2aKd2sWqWORpz1DUR6errsCRHhpXv37uXuc/LkSTz99NO4dOmS7GHZtm0bgoODcePGDbi5ucl9lixZghkzZsjjWVk9umI6JycHTk5OyM7OhqMjx6gTEdHjScstQNiKeJxJyYG9lTmWjvRHt1YNYIxy9HgONaiKHfEGBRcXl3K3ix4W0avSrFkzeHp6ynWHDh2Cn5+fLqAI/fr1k3+006dPl3ucwsJCub30g4iIqDpcuZWHkMUxMqA0qGuFda93MdqAom8GE1LUajWmTp2KoKAg+Pr6ltm2aNEi1K1bVz5Ez4m4NKTtIbl582aZgCJol8W2B9XCiNSnfWgDDxER0eM4eT0LLy2OQXLmHXi52OHn8V3h5+GkdLNqLYMJKaI25dSpU1i3bt1924YPH45jx47Jy0BPPvkkhgwZgoKCgiq/1qxZs2SvjfaRnHz3tthERERVtf9COoZ+H4uMvCK0aewoA0qT+vZKN6tWM4ghyJMmTcLWrVuxf/9+eHh43Ldd2+PRqlUrdO7cGfXq1cPmzZsxbNgwuLu7Iy4ursz+qamp8qfYVh5ra2v5ICIiqg7Rx//E2+tPoEStQVDL+lgyoiMcbCyVblatp2hPiqjZFQFFBI7du3fLWpOK/I54iLoSoUuXLkhISEBaWppuH3E5SBTv+Pj46LX9REREyw8kYsq64zKgBLdtJKe5Z0Axgp4UcYlnzZo1iI6OlnOlaGtIRK+JmBclMTERP/30kxxyLOZIuX79OubNmye3Pf/883JfsU2EkZEjR+LLL7+Ux3j//fflsdlbQkRE+pyk7Yvt57B0f6JcDg9qitkDfGBmxjlQjKInZfHixbImpGfPnmjUqJHuIYKJYGNjgwMHDshA0rJlS7zyyisyzIj5UMRQZcHc3FxeKhI/Ra/KiBEjEBoaio8//ljJt0ZEREasWKXGOxtO6ALKjP7emBPMgGLU86QohfOkEBFRReUVlmDC6qPYdyEd5mZ1MG+wH172N91Rojl6PIcaROEsERFRbZCZV4TwyHicSM6CjaUZFg3vgGe9y06DQdWHIYWIiKgCkjPzMWpFHBJv5cHZzlIWyHbwqqd0s4waQwoREdEjnE3JkQElLbcQTzjbImp0AFo2dFC6WUaPIYWIiOghYhMz8FrUYeQWlqC1mwOiRgfC3clG6WaZBIYUIiKiB9iWkIIpPx1HUYkagU1dsCzUH052nAOlpjCkEBERlWNVbBLmRJ+CGAPb18cNC4a1h42ludLNMikMKURERKWImTnm77yABbsvyeVXO3nhk4G+crgx1SyGFCIiov8qUakxO/oU1sbdvfHs1D6tMKV3K9Spw4CiBIYUIiIiAAXFKkxeeww7z6RCdJp8PNAXIzo3UbpZJo0hhYiITF52fjHGroxH/NXbsLIww4Kh7dDft5HSzTJ5DClERGTSUrLvyDlQLqT+BQcbCywP9Uen5vWVbhYxpBARkSm7lJaL0B/icCO7AG6O1nIOFG933sPNUDCkEBGRSTqSdBtjouKRlV+M5q72WDk6EB717JRuFpXCkEJERCZn19lUTFxzFAXFarTzdJb34XGxt1K6WXQPhhQiIjIp6w8nY9amBKjUGvRq7YqFwzvAzoqnQ0PEfxUiIjKZSdoW7b2Mr3acl8shHTwwL8QPluZmSjeNHoAhhYiIjJ5arcHHW88gMuaqXB7XowVm9G/NSdoMHEMKEREZtcISFaatP4FfT6bI5dnBPhjTrZnSzaIKYEghIiKjlVtQjDdWHUHM5QxYmtfBN0Pa4cWnGyvdLKoghhQiIjJKabkFCFsRjzMpObC3MsfSkf7o1qqB0s2iSqhStdD+/ftRUlJy33qxTmwjIiJS0pVbeQhZHCMDSoO6Vlj3ehcGFFMJKb169UJmZuZ967Ozs+U2IiIipZy8noWXFscgOfMOvFzs8PP4rvDzcFK6WVRTl3vEMK7yKqIzMjJgb29flUMSERE9tv0X0jHuxyPIL1KhTWNHRIYHwtXBWulmUU2ElMGDB8ufIqCEhYXB2vr//+FVKhVOnjyJrl27VrUtREREVRZ9/E+8vf4EStQaBLWsjyUjOsLBxlLpZlFNhRQnJyddT4qDgwNsbW1126ysrNC5c2e89tprj9MeIiKiSlt+IBGf/npWPg9u2wjfDHka1hbmSjeLajKkREREyJ9NmzbFO++8w0s7RESk+CRtX2w/h6X7E+VyeFBTzB7gAzMzTtJmDOpoRLeIicvJyZG9RKLw19GRt+gmIqoNilVqzNh4EpuO/SmXZ/T3xrgezTmLrBGdQ6s0uic1NRUjR45E48aNYWFhAXNz8zIPIiIifcorLMHYqMMyoJib1cFXL7XF+J4tGFCMTJVG94ii2WvXrmH27Nlo1KgR/6MgIqIak5lXhPDIeJxIzoKNpRkWDe+AZ73dlG4WGUpIOXjwIA4cOIB27dpVf4uIiIgeIDkzH6NWxCHxVh6c7SyxIiwAHbzqKd0sMqSQ4unpKUf4EBER1ZSzKTkyoKTlFuIJZ1tEjQ5Ay4YOSjeL9KhKNSnffvstZs6ciatX797ymoiISJ9iEzMwZMkhGVBauznIWWQZUIxflXpSXnnlFeTn56NFixaws7ODpWXZyXLKmzKfiIioKrYlpGDKT8dRVKJGYFMXLAv1h5MdJ2kzBRZV7UkhIiLSt1WxSZgTfQqiwqCvjxsWDGsPG0uOIjUVVQopo0aNqv6WEBER/Zeoe5y/8wIW7L4kl1/t5IVPBvrK4cZkOqoUUkorKChAUVFRmXWcEI2IiKqqRKXG7OhTWBuXLJen9mmFKb1bcboLE1SlkJKXl4cZM2Zg/fr18s7H9xI3GyQiIqqsgmIVJq89hp1nUiE6TT4e6IsRnZso3SyqTaN73n33XezevRuLFy+Wd0Jevnw5PvroIzkD7cqVK6u/lUREZPSy84sx8oc/ZECxsrg7SRsDimmrUk/Kli1bZBjp2bMnwsPD8cwzz6Bly5Zo0qQJVq9ejeHDh1d/S4mIyGilZN+Rc6BcSP0LDjYWWB7qj07N6yvdLKqNPSliiHHz5s119SfaIcfdunXD/v37q7eFRERk1C6l5SJkUYwMKG6O1tgwrgsDClU9pIiAcuXKFfnc29tb1qZoe1icnZ2rckgiIjJBR5Ju46Ulh3AjuwDNXe3lJG3e7hx8QY8RUsQlnhMnTsjnYubZhQsXwsbGBm+99RamT59e4ePMnTsXAQEBcHBwQMOGDTFo0CCcP39et1300EyePBmtW7eGra0tvLy88Oabb8rbQZcmbnY4YMAAObGcOI5oQ0lJSVXeGhER1ZBdZ1MxfHkssvKL0c7TGRvHdYVHPTulm0W1vSZFhBGtPn364Ny5czhy5IisS2nbtm2Fj7Nv3z5MnDhRBhURKt577z307dsXZ86cgb29PW7cuCEfX3/9NXx8fJCUlIRx48bJdRs3btSNJBIBxd3dHTExMUhJSUFoaKicBffzzz+vytsjIiI9W384GbM2JUCl1qBXa1csHN4BdlaPPSsGGZk6mircKVAUzYqp8cXIntLEfCnr1q2TIaEq0tPTZU+ICC/du3cvd58NGzZgxIgRchi0hYUFtm3bhuDgYBlc3Nzu3qp7yZIlcoi0OJ6VldUjXzcnJwdOTk6yh4ZzvBAR6Y845Szaexlf7bjbax7SwQPzQvxgaV6ljn0yAPo8h1b5cs+9l1yE3Nxcua2qtMd0cXF56D7ijyACinDo0CH4+fnpAorQr18/+Uc7ffp0uccoLCyU20s/iIhIv9RqDT7ackYXUMb1aIGvX27LgEIPZFbVJFzezH/Xr1+Xaaoq1Go1pk6diqCgIPj6+pa7z61bt/DJJ5/g9ddf1627efNmmYAiaJfFtgfVwoh2ah+enp5VajMREVVMYYkKk9cdQ2TMVbk8O9gHM5/z5iyy9FCVugDYvn17+R+UePTu3VvXm6GtDREjfvr371+lhojalFOnTuHgwYPlbhe9HaL2RNSmfPjhh3gcs2bNwrRp08ocm0GFiEg/cguK8caqI4i5nAFL8zr4Zkg7vPh0Y6WbRcYWUsToG+H48ePykkrdunV120TtR9OmTRESElLpRkyaNAlbt26Vc6x4eHiUexlJhB8xCmjz5s2yKFZLFMzGxcWV2T81NVW3rTyilubeehoiIqp+abkFCFsRjzMpObC3MsfSkf7o1qqB0s0iYwwpH3zwgfwpwogonBXDjh+HuGwkhhiL4LF37140a9bsvn1EL4cIRCJU/PLLL/e9ZpcuXfDZZ58hLS1NFt0KO3fulHUroteFiIiUceVWHkJX/IHkzDtoUNcKEWGB8POoWkkAmaYqje4pPZpHhANRT1KamM+kIiZMmIA1a9YgOjpazoWiJepExLwoIqCIIcn5+fkyyIhhyVqurq4wNzeXl5natWsn7xv05ZdfyjqUkSNHYuzYsRUegszRPURE1evk9SyER8QjI68IXi52WDUmEE3q////w8l45OjxHFqlkHLx4kWMHj1azktSXkFtRe+C/KCCqYiICISFhcnelV69epW7j6h/ET06gpg/Zfz48XJ/EWRGjRqFefPmlamZeRiGFCKi6nPgYrqsQckvUqFNY0dEhgfC1YGX2I1Vjh7PoVWaOUcECBEARB1Jo0aNqlyd/ah8JG5gWJEMJW5s+Ntvv1WpDUREVH2ij/+JdzacQLFKg6CW9bFkREc42Px/HSGR3kOKKJwVM8yK+/YQEREJyw8k4tNfz8rnwW0b4ZshT8PawlzpZpGphRRRkCrmLCEiIhKTtH2x/RyW7k+Uy+FBTTF7gA/MzDgHCikwmdsXX3yBd999V9aAZGRkcPZWIiITVaxSy8s72oAyo7835gQzoJCChbNmZnezzb21KJUtnDUULJwlIqq8vMISTFh9FPsupMPcrA7mDfbDy/6cGNPU5Bha4eyePXuqtRFERFS7ZOYVITwyHieSs2BjaYZFwzvgWe+ytyghUiSk9OjR47FfmIiIaqfkzHyMWhGHxFt5cLazxIqwAHTwqqd0s8gIVSmkCFlZWfjhhx9w9uzdSu42bdrIuVOqeoNBIiIyfGdTcmRAScstxBPOtogaHYCWDR2UbhYZqSoVzh4+fBgtWrTA/PnzkZmZKR//+7//K9cdPXq0+ltJRESKi03MwJAlh2RAae3mgJ/Hd2VAIcMrnH3mmWfQsmVLLFu2TDera0lJiZyKPjExUd4osDZh4SwR0cNtS0jBlJ+Oo6hEjcCmLlgW6g8nO07SRjC8afHFfXWOHTt232RuZ86cgb+/v7zXTm3CkEJE9GCrYpMwJ/oUxNmir48bFgxrDxtLTtJG+j+HVulyj2jEtWvX7lufnJwMBwd2/RERGQPxHfZ/d17A7H/dDSjDAr2weERHBhQy7MLZV155BWPGjMHXX3+Nrl27ynW///47pk+fjmHDhlV3G4mIqIaVqNSYHX0aa+PufiGd0rsVpvZpVeV7tRHVWEgR4UT8hxoaGiprUUTatrKyknciFncfJiKi2qugWIXJa49h55lUiIljPx7oixGdmyjdLDJBVapJ0RK1J5cvX5bPxcgeOzs71EasSSEiuis7vxhjV8Yj/uptWFmYYcHQdujv20jpZpEBM5gZZ8U8KBWxYsWKqraHiIgUkpJ9R86BciH1LzjYWGB5qD86Na+vdLPIhFUqpERGRqJJkyZo3769vMRDRETG4VJaLkJ/iMON7AK4OVojanQgvN3Zs0y1KKSImpO1a9fiypUrCA8Px4gRI+Di4qK/1hERkd4dSbqNMVHxyMovRnNXe6wcHQiPerXz8j0Zl0oNQV64cCFSUlLw7rvvYsuWLfD09MSQIUOwY8cO9qwQEdVCu86mYvjyWBlQ2nk6Y+O4rgwoZByFs0lJSfIS0MqVK+Uon9OnT6Nu3bqobVg4S0SmaP3hZMzalACVWoOerV3lnYztrKp8SzcyUTmGUjh7LzMzMzkUWeQclUpVfa0iIiK9Ef/PXrT3Mr7acV4uh3TwwLwQP1iaV2l+TyK9qfR/kYWFhbIu5W9/+xuefPJJJCQk4LvvvpMz0NbGXhQiIlOiVmvw0ZYzuoAyrkcLfP1yWwYUMkiV6kmZMGEC1q1bJ2tRxHBkEVYaNGigv9YREVG1KSxRYdr6E/j1ZIpcnh3sgzHdmindLKLqqUkRl3e8vLzkEOSHTY28adMm1CasSSEiY5dbUIw3Vh1BzOUMWJrXwTdD2uHFpxsr3SwyAjmGUpMipsHnfRuIiGqXtNwChK2Ix5mUHNhbmWPpSH90a8VecDLCydyIiKj2uHorDyNX/IHkzDtoUNcKEWGB8PNwUrpZRBXCsWZEREbq5PUshEfEIyOvCF4udnKStqYN7JVuFlGFMaQQERmhAxfTZQ1KfpEKbRo7IjI8EK4O1ko3i6hSGFKIiIxM9PE/8c6GEyhWaRDUsj6WjOgIBxtLpZtFVGkMKURERmT5gUR8+utZ+Ty4bSN8M+RpWFuYK90soiphSCEiMpJJ2r7Yfg5L9yfK5fCgppg9wAdmZhyRSbUXQwoRUS1XrFJjxsaT2HTsT7k8o783xvVozikjqNZjSCEiqsXyi0owYfVR7D2fDnOzOpg32A8v+3sq3SyiasGQQkRUS2XmFSE8Mh4nkrNgY2km72L8rLeb0s0iqjYMKUREtVByZj5GrYhD4q08ONtZYkVYADp41VO6WUTViiGFiKiWOZuSIwNKWm4hnnC2RdToALRs6KB0s4iqHUMKEVEtEpuYgdeiDiO3sASt3RwQNToQ7k42SjeLSC8YUoiIaoltCSmY8tNxFJWoEdjUBctC/eFkx0nayHgxpBAR1QKrYpMwJ/oUNBqgr48bFgxrDxtLTtJGxo0hhYjIgGk0Gsz/z0Us2HVRLg8L9MKng3zlcGMiY8eQQkRkoEpUasyOPo21cdfk8pTerTC1TytO0kYmgyGFiMgAFRSrMHntMew8kwrRafLxQF+M6NxE6WYR1SiGFCIiA5OdX4yxK+MRf/U2rCzMsGBoO/T3baR0s4hqnBkUNHfuXAQEBMDBwQENGzbEoEGDcP78+TL7fP/99+jZsyccHR1lF2dWVtZ9x8nMzMTw4cPlPs7OzhgzZgz++uuvGnwnRETVIyX7Dl5eGiMDioONBVaNDmRAIZOlaEjZt28fJk6ciNjYWOzcuRPFxcXo27cv8vLydPvk5+ejf//+eO+99x54HBFQTp8+LY+xdetW7N+/H6+//noNvQsioupxKS0XIYticCH1L7g5WmPDuC7o1Ly+0s0iUkwdjSgdNxDp6emyR0WEl+7du5fZtnfvXvTq1Qu3b9+WvSVaZ8+ehY+PD+Lj4+Hv7y/Xbd++Hc8//zyuX7+Oxo0bP/J1c3Jy4OTkhOzsbNkbQ0RU044k3caYqHhk5Rejuas9Vo4OhEc9O6WbRaToOVTRnpR7iTcouLi4VPh3Dh06JEOLNqAIffr0gZmZGf74449yf6ewsFD+UUs/iIiUsutsKoYvj5UBpZ2nMzaO68qAQmRIIUWtVmPq1KkICgqCr69vhX/v5s2bsvelNAsLCxl0xLYH1cKI1Kd9eHrytuZEpIz1h5Px+qojKChWo2drV6x5rRNc7K2UbhaRQTCYkCJqU06dOoV169bp/bVmzZole220j+TkZL2/JhFRaeJK+8I9l/DuxpNQqTUI6eAhp7m3s+KgSyItg/g0TJo0SVfw6uHhUanfdXd3R1paWpl1JSUlcsSP2FYea2tr+SAiUoJarcHHW88gMuaqXB7XowVm9G/NSdqIDKknRXyTEAFl8+bN2L17N5o1a1bpY3Tp0kUOSz5y5IhunTiWuHzUqVOnam4xEdHjKSxRYfK6Y7qAMjvYBzOf82ZAITK0nhRxiWfNmjWIjo6Wc6Voa0hEnYitra18LtaJx6VLl+RyQkKC3NfLy0vWnTz11FNyiPJrr72GJUuWyGHMIvgMHTq0QiN7iIhqSm5BMd5YdQQxlzNgaV4H3wxphxef5v+niAxyCPKDvjlEREQgLCxMPv/www/x0UcfPXQfcWlHBJMtW7bIUT0hISFYsGAB6tatW6F2cAgyEelbWm4BwiPicfpGDuytzLF0pD+6tWqgdLOIHps+z6EGNU+KUhhSiEifrt7Kw8gVfyA58w4a1LVCRFgg/DyclG4WkcGfQw2icJaIyFidvJ4le1Ay8org5WInJ2lr2sBe6WYR1QoMKUREenLgYrqsQckvUqFNY0dEhgfC1YEjC4kqiiGFiEgPoo//iXc2nECxSoOglvWxZERHONhYKt0solqFIYWIqJotP5CIT389K58Ht22Eb4Y8DWsLc6WbRVTrMKQQEVUTMQ5h3vZzWLovUS6HBzXF7AE+MDPjHChEVcGQQkRUDYpVasz4+SQ2Hf1TLs/o741xPZpzkjaix8CQQkT0mPKLSjBh9VHsPZ8Oc7M6mDfYDy/788alRI+LIYWI6DFk5hUhPDIeJ5KzYGNphkXDO+BZbzelm0VkFBhSiIiqKDkzH6NWxCHxVh6c7SyxIiwAHbzqKd0sIqPBkEJEVAVnU3JkQEnLLcQTzraIGh2Alg0dlG4WkVFhSCEiqqTYxAy8FnUYuYUlaO3mgKjRgXB3slG6WURGhyGFiKgStp9KwZvrjqOoRI3Api5YFuoPJztO0kakDwwpREQVtCo2CXOiT0HclrWvjxsWDGsPG0tO0kakLwwpREQVmKRt/n8uYsGui3J5WKAXPh3kK4cbE5H+MKQQET1EiUqN2dGnsTbumlye0rsVpvZpxUnaiGoAQwoR0QMUFKswee0x7DyTCtFp8vFAX4zo3ETpZhGZDIYUIqJyZOcXY+zKeMRfvQ0rCzMsGNoO/X0bKd0sIpPCkEJEdI+U7DtyDpQLqX/BwcYCy0P90al5faWbRWRyGFKIiEq5lJaL0B/icCO7AG6O1nIOFG93R6WbRWSSGFKIiP7rSNJtjImKR1Z+MZq72mPl6EB41LNTullEJoshhYgIwK6zqZi45igKitVo5+ks78PjYm+ldLOITBpDChGZvPWHkzFrUwJUag16tnaVdzK2s+L/HomUxk8hEZn0JG2L9l7GVzvOy+WQDh6YF+IHS3MzpZtGRAwpRGSq1GoNPt56BpExV+XyuB4tMKN/a07SRmRAGFKIyOQUlqgwbf0J/HoyRS7PDvbBmG7NlG4WEd2DIYWITEpuQTHeWHUEMZczYGleB98MaYcXn26sdLOIqBwMKURkMtJyCxAeEY/TN3Jgb2WOpSP90a1VA6WbRUQPwJBCRCbh6q08jFzxB5Iz76BBXStEhAXCz8NJ6WYR0UMwpBCR0Tt5PUv2oGTkFcHLxU5O0ta0gb3SzSKiR2BIISKjduBiuqxByS9SoU1jR0SGB8LVwVrpZhFRBTCkEJHRij7+J97ZcALFKg2CWtbHkhEd4WBjqXSziKiCGFKIyCgtP5CIT389K58Ht22Eb4Y8DWsLc6WbRUSVwJBCREY3i+y87eewdF+iXA4PaorZA3xgZsZJ2ohqG4YUIjIaxSo1Zvx8EpuO/imXZ/T3xrgezTmLLFEtxZBCREYhv6gEE1Yfxd7z6TA3q4N5g/3wsr+n0s0iosfAkEJEtV5mXhHCI+NxIjkLNpZm8i7Gz3q7Kd0sInpMDClEVKslZ+Zj1Io4JN7Kg7OdJVaEBaCDVz2lm0VE1YAhhYhqrbMpOTKgpOUW4glnW0SNDkDLhg5KN4uIqglDChHVSrGJGXht5WHkFpSgtZsDokYHwt3JRulmEVE1Ykgholpn+6kUvLnuOIpK1Ahs6oJlof5wsuMkbUTGxkzpBhiSuMRMqNQapZtBRP8lPo+HLmfImWPFT7G8KjYJ41cflQGlr48bVo4JZEAhMlKKhpS5c+ciICAADg4OaNiwIQYNGoTz58+X2aegoAATJ05E/fr1UbduXYSEhCA1NbXMPteuXcOAAQNgZ2cnjzN9+nSUlJRUuj2jo+LR7Yvd8lsaESlLfA7F53HYslhMWXdc/nz6o39j9r9OQaMBhgV6YfGIjrCx5CyyRMZK0ZCyb98+GUBiY2Oxc+dOFBcXo2/fvsjLy9Pt89Zbb2HLli3YsGGD3P/GjRsYPHiwbrtKpZIBpaioCDExMYiKikJkZCTmzJlTpTbdzC7A+B+PMqgQKUh8/sTnMCW7oMz6vwrvfvkY4NcIn//dV86HQkTGq45GzCFtINLT02VPiAgj3bt3R3Z2NlxdXbFmzRq89NJLcp9z587hqaeewqFDh9C5c2ds27YNwcHBMry4ud2dF2HJkiWYMWOGPJ6VldUjXzcnJwdOTk7wnLoeZtZ2EP/bEwV4e97pyf8JEtUwcUmn51d7cTOnbEAprZGTDQ7OeJafTyIDoD2HinO2o6Oj8RbOijcouLi4yJ9HjhyRvSt9+vTR7ePt7Q0vLy9dSBE//fz8dAFF6NevH8aPH4/Tp0+jffv2971OYWGhfJT+A5cmUpv4Buc9e7te3icRPR7x+Yy7kokuLeor3RQiMoXCWbVajalTpyIoKAi+vr5y3c2bN2VPiLOzc5l9RSAR27T7lA4o2u3abQ+qhRGpT/vw9OTU2US1TVrug3taiMg4GExPiqhNOXXqFA4ePKj315o1axamTZtWpielvKCyfJQ/Apre7dUhopoRfzUTY6MOP3K/hg6cE4XI2BlESJk0aRK2bt2K/fv3w8PDQ7fe3d1dFsRmZWWV6U0Ro3vENu0+cXFxZY6nHf2j3ede1tbW8vEg2pqUXq0b8po3UQ0TnztRcyKK2DUP+XwGNuMXCCJjp+jlHlGzKwLK5s2bsXv3bjRr1qzM9o4dO8LS0hK7du3SrRNDlMWQ4y5dushl8TMhIQFpaWm6fcRIIVG84+PjU+k2aSPJBy/4MKAQKUB87sTnT7j3E8jPJ5FpMVP6Es+PP/4oR++IuVJEDYl43LlzR24X9SJjxoyRl2b27NkjC2nDw8NlMBFFs4IYsizCyMiRI3HixAns2LED77//vjz2w3pLHkR8Q1s8ogP6+zaq9vdLRBUjPn/ic3jvNPf8fBKZFkWHINepU/43oYiICISFhekmc3v77bexdu1aOSJHjNxZtGhRmUs5SUlJcjTP3r17YW9vj1GjRmHevHmwsLCo1PCpnceuoFfbJvyGRmRAw5HFKB5RJCtqUMQlHn4+iUxnCLJBzZNijH9gIiIiY5ajx3OowQxBJiIiIiqNIYWIiIgMEkMKERERGSSDmCdFadqynHunxyciIqKH05479VHiypACICMjQ/7k9PhERERVk5ubKwtoqxNDSqkbGopJ4qr7D0xEjy8gIADx8fFKN4OIyiF6UMTkq40bN0Z1Y0gRhTlmd0tzREDhEGQiw2Nubs7PJpEBEzcD1p5LqxMLZ4nI4IkZpInI9D6jnMyNk7kREREZJPak/PeuyB988EGV7vVDRERE+sGeFCIiIjJI7EkhIiIig8SQQkS1jriD+r/+9S+lm0FEesaQQkSKCAsLk2Hj3selS5eUbhqRyQv77+dz3Lhx5Y7kEdvEPvrGkEJEiunfvz9SUlLKPJo1a6Z0s4gId2dhX7duHe7cuaNbV1BQgDVr1sDLy+uxjl1cXFyh/Yw+pIikN2jQIKWbQUTlECPq3N3dyzzExG3R0dHo0KEDbGxs0Lx5c3z00UcoKSkp87si0Dz33HOwtbWV+2zcuFGx90FkjDp06CCDyqZNm3TrxHMRUNq3b69bt337dnTr1g3Ozs6oX78+goODcfnyZd32q1evyp6Xn376CT169JCf69WrV1eoDUYfUoiodjlw4ABCQ0MxZcoUnDlzBkuXLkVkZCQ+++yzMvvNnj0bISEhOHHiBIYPH46hQ4fi7NmzirWbyBiNHj0aERERuuUVK1YgPDy8zD55eXmYNm0aDh8+jF27dsmZZ//+979DrVaX2W/mzJnycy0+p/369atYAzRGbtSoUZqBAwfK59u2bdMEBQVpnJycNC4uLpoBAwZoLl26pNv3ypUrYji25ueff9b07NlTY2trq2nbtq0mJiZGwXdAZLyfTXNzc429vb3u8dJLL2l69+6t+fzzz8vsu2rVKk2jRo10y+JzOm7cuDL7dOrUSTN+/Pgaaz+RKZw709LSNNbW1pqrV6/Kh42NjSY9PV1uE/uUR2wXn9GEhIQy59Zvv/220u0wqXv3aNNe27Zt8ddff2HOnDky7R0/frzMPQf+53/+B19//TVatWolnw8bNkwW81lYmNSfi0jvevXqhcWLF+uW7e3t5efz999/L9NzolKp5LXw/Px82NnZyXVdunQpcyyxLD7LRFR9XF1dMWDAANmbKb4fiOcNGjQos8/Fixfl+fSPP/7ArVu3dD0o4qa9vr6+uv38/f0r/fomddYVXcOliW4r8Q8gupRL/yHfeecd+Q8hiGvhbdq0kSHF29u7xttMZMxEKGnZsmWZdeILhPjcDR48+L79xbVsIqr5Sz6TJk2SzxcuXHjf9hdeeAFNmjTBsmXL5J2QRUgR59SioqL7Pu+VZVI1KSLtiV4RUWQn7tHTtGlTXdorTXyT02rUqJH8mZaWVsOtJTLdYr3z58/L8HLvo3SPZ2xsbJnfE8tPPfWUAi0mMv5ReEVFRXJEzr21JBkZGfLz+v7776N3797yM3j79u1qe22T6kmpaNqztLTUPRcVycK9BUBEpB+i21iMDhAjCF566SUZTERx7KlTp/Dpp5/q9tuwYYPsPhajCsRIgbi4OPzwww+Ktp3IGJmbm+uK0sXz0urVqydH9Hz//ffyS7340i8KZKuLyfSk6DvtEVH1EN/Utm7din//+98ICAhA586dMX/+fPkFozRxSUjM4SB6PleuXIm1a9fCx8dHsXYTGTNHR0f5uJf4EiE+h0eOHJFf+t966y189dVX1fa6JtOTou+0R0SVIwrxHhZUHjZEUXtf1AkTJuilbUSmLvIhn0+h9G0p+vTpI2s7Syt972JRWlHVexkbfU+KuEwjRuXoO+0RERFR9aojxiHDyAt+RMHdd999p3RTiIiIqBKMtidF1JuI69p79+6VXVFERERUu1gY87ju+Ph4vP322xg4cKDSzSEiIqJKMvrLPURERFQ7Ge3lHiIiIqrdGFKIiIjIIBlFSJk7d66c9MnBwQENGzbEoEGD5MRtpYmbk02cOFHOlVK3bl15H5/U1FTddjGjpZgy39PTE7a2tnKyt3/84x8PfE1xAzQxtLldu3Z6fW9ERESmyihCyr59+2QAEffu2Llzp7y/QN++feVdj7XEvChbtmyRU2mL/W/cuFHmBmZi/hQRcH788UecPn1a3v141qxZ5Q5dzsrKQmhoqJy5loiIiPTDKAtn09PTZeAQYaR79+7Izs6Wdztes2aNvBeIcO7cOdlbcujQITntdnlE8BH3K9i9e3eZ9UOHDkWrVq3kPQzErHu8PTwREVH1M4qelHuJUCK4uLjoeklE70rp+VK8vb3lDcxESHnYcbTH0IqIiEBiYiI++OADvbWfiIiIjHCeFDEN/tSpUxEUFCSnvxdu3rwJKysrODs7l9nXzc1NbitPTEwMfvrpJ/z666+6dRcvXpT3+zlw4ICsRyEiIiL9MbozrbhEI27pfvDgwSofQ/y+mABO9JaI2hZBpVLh1VdflXdeffLJJ6uxxURERGT0IWXSpElyKvz9+/fDw8NDt97d3R1FRUWy4LV0b4oY3SO2lSbu5CgKYl9//XW8//77uvW5ubk4fPgwjh07Jl9H22sjSnpEr4q4rfyzzz5bI++TiIjIFBhFSBFBYfLkydi8ebO8V0+zZs3KbO/YsSMsLS2xa9cuOfRYEEOUr127hi5duuj2E6N6RNAYNWoUPvvsszLHcHR0REJCQpl1ixYtkkW1GzduvO81iYiI6PFYGMslHjFyJzo6Ws6Voq0zcXJyknOeiJ9jxozBtGnTZCGsCBwi1IiAoh3ZIy7xiIDSr18/uZ/2GGIEjxgZZGZmpqtx0RIjiGxsbO5bT0RERI/PKELK4sWL5c+ePXveNxInLCxMPp8/f74MGqInpbCwUIYR0ROiJXpDxNBlMU+KeGg1adIEV69erbH3QkREREY8TwoRERHVfkY5TwoRERHVfgwpREREZJAYUoiIiMggMaQQERGRQWJIISIiIoPEkEJEREQGiSGFiIiIDBJDChERERkkhhQiqpXEfbrq1KkjbxxKRMaJIYWIaoy4TYUIFuPGjSv3Hlxim/ZWFo/StWtXpKSkyHtzEZFxYkghohrl6emJdevW4c6dO7p1BQUF8iahXl5eFT6OlZUV3N3dZbAhIuPEkEJENapDhw4yqGzatEm3TjwXAaV9+/a6deJGoG+++abubuPdunVDfHz8Ay/3JCUl4YUXXkC9evVgb2+PNm3a4Lfffqvhd0dE1YkhhYhq3OjRo+VdyrVWrFiB8PDwMvu8++67+PnnnxEVFYWjR4+iZcuW8u7lmZmZ5R5TXC4SwWb//v1ISEjAF198gbp16+r9vRCR/jCkEFGNGzFiBA4ePCh7P8Tj999/l+u08vLysHjxYnz11Vd47rnn4OPjg2XLlsHW1hY//PBDuce8du0agoKC4Ofnh+bNmyM4OBjdu3evwXdFRNXNotqPSET0CK6urhgwYAAiIyOh0Wjk8wYNGui2X758GcXFxTJ0aFlaWiIwMBBnz54t95ji0tD48ePx73//G3369EFISAjatm1bI++HiPSDPSlEpNglHxFSxOUc8fxxjR07FomJiRg5cqS83OPv749//vOf1dJWIlIGQwoRKaJ///4oKiqSPSai1qS0Fi1ayNE74jKQlthPFM6KSz8PIgpyxfBmUYj79ttvy0tERFR78XIPESnC3Nxcd+lGPC9NjM4Rl26mT58OFxcXOfLnyy+/RH5+PsaMGVPu8aZOnSrrV5588kncvn0be/bswVNPPVUj74WI9IMhhYgU4+jo+MBt8+bNg1qtlpdvcnNz5eWbHTt2yCHG5VGpVHKEz/Xr1+VxRU/N/Pnz9dh6ItK3OhpRtUZERERkYFiTQkRERAaJIYWIiIgMEkMKERERGSSGFCIiIjJIDClERERkkBhSiIiIyCAxpBAREZFBYkghIiIig8SQQkRERAaJIYWIiIgMEkMKERERwRD9HxHIgXmxQvSPAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 600x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Une serie de ventes datées\n",
+    "ventes_dates = pd.DataFrame({\n",
+    "    'date': pd.to_datetime(['2024-01-15', '2024-01-28', '2024-02-10', '2024-03-05',\n",
+    "                            '2024-03-21']),\n",
+    "    'montant': [120, 80, 200, 150, 90]\n",
+    "})\n",
+    "\n",
+    "# L'accesseur .dt : extraire l'annee\n",
+    "ventes_dates['annee'] = ventes_dates['date'].dt.year\n",
+    "print('=== .dt.year ===')\n",
+    "print(ventes_dates[['date', 'annee', 'montant']])\n",
+    "\n",
+    "# Agregation mensuelle : resample apres mise en index temporel\n",
+    "par_mois = ventes_dates.set_index('date')['montant'].resample('ME').sum()\n",
+    "print('\\n=== Ventes mensuelles (resample ME) ===')\n",
+    "print(par_mois)\n",
+    "\n",
+    "# Figure\n",
+    "plt.figure(figsize=(6, 3))\n",
+    "par_mois.plot(marker='o', title='Ventes mensuelles')\n",
+    "plt.ylabel('Montant')\n",
+    "plt.xlabel('Mois')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-jd-csv-intro",
+   "metadata": {},
+   "source": [
+    "## Lecture d'un fichier réel : `read_csv`\n",
+    "\n",
+    "Un `DataFrame` construit à la main ne survit pas au vrai monde : les données arrivent\n",
+    "dans un fichier. `pd.read_csv` est la porte d'entrée, et **deux arguments coincent\n",
+    "toujours** : `sep` (le séparateur n'est pas toujours une virgule — un CSV français peut\n",
+    "utiliser `;`) et `parse_dates` (sans lui, la colonne date reste une chaîne de caractères,\n",
+    "et toute opération temporelle échoue). Ici on **écrit** un fichier pour montrer le\n",
+    "circuit complet, puis on le lit.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-jd-csv-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T12:07:57.449578Z",
+     "iopub.status.busy": "2026-08-23T12:07:57.449388Z",
+     "iopub.status.idle": "2026-08-23T12:07:57.463128Z",
+     "shell.execute_reply": "2026-08-23T12:07:57.462476Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Fichier relu ===\n",
+      "        Date  montant\n",
+      "0 2024-01-15      120\n",
+      "1 2024-02-10      330\n",
+      "2 2024-03-05      240\n",
+      "\n",
+      "=== Types apres parse_dates ===\n",
+      "Date       datetime64[us]\n",
+      "montant             int64\n",
+      "dtype: object\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "# 1. Ecrire un petit CSV (le séparateur est un point-virgule, les dates sont des chaînes)\n",
+    "chemin_csv = os.path.join(os.getcwd(), 'export_ventes_demo.csv')\n",
+    "pd.DataFrame({\n",
+    "    'Date': ['2024-01-15', '2024-02-10', '2024-03-05'],\n",
+    "    'montant': [120, 330, 240]\n",
+    "}).to_csv(chemin_csv, index=False, sep=';')\n",
+    "\n",
+    "# 2. Relire avec les bons arguments : sep=';' et parse_dates=['Date']\n",
+    "df_relu = pd.read_csv(chemin_csv, sep=';', parse_dates=['Date'])\n",
+    "print('=== Fichier relu ===')\n",
+    "print(df_relu)\n",
+    "print('\\n=== Types apres parse_dates ===')\n",
+    "print(df_relu.dtypes)\n",
+    "\n",
+    "# 3. Nettoyer le fichier temporaire (il est regenere a chaque execution)\n",
+    "os.remove(chemin_csv)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a1eb8902",
    "metadata": {
     "papermill": {
@@ -280,14 +657,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "id": "45d01fda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:18:13.608199Z",
-     "iopub.status.busy": "2026-05-13T08:18:13.607200Z",
-     "iopub.status.idle": "2026-05-13T08:18:13.611990Z",
-     "shell.execute_reply": "2026-05-13T08:18:13.611990Z"
+     "iopub.execute_input": "2026-08-23T12:07:57.464793Z",
+     "iopub.status.busy": "2026-08-23T12:07:57.464625Z",
+     "iopub.status.idle": "2026-08-23T12:07:57.468770Z",
+     "shell.execute_reply": "2026-08-23T12:07:57.468193Z"
     },
     "papermill": {
      "duration": 0.007804,
@@ -362,14 +739,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "id": "5cc1082e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:18:13.672878Z",
-     "iopub.status.busy": "2026-05-13T08:18:13.671873Z",
-     "iopub.status.idle": "2026-05-13T08:18:13.675867Z",
-     "shell.execute_reply": "2026-05-13T08:18:13.675867Z"
+     "iopub.execute_input": "2026-08-23T12:07:57.470199Z",
+     "iopub.status.busy": "2026-08-23T12:07:57.470039Z",
+     "iopub.status.idle": "2026-08-23T12:07:57.473285Z",
+     "shell.execute_reply": "2026-08-23T12:07:57.472706Z"
     },
     "papermill": {
      "duration": 0.058702,
@@ -420,71 +797,292 @@
   {
    "cell_type": "markdown",
    "id": "2269c665",
-   "source": "### Exercice 1 : Filtrage et tri d'un DataFrame\n\nLe filtrage et le tri sont des opérations fondamentales en analyse de données. Vous allez créer un DataFrame de produits et appliquer des filtres combinés avec un tri pour extraire des informations spécifiques.\n\n**Objectif** : Créer un DataFrame de produits, filtrer les produits par prix et catégorie, puis trier les résultats.\n\n**Indices** :\n- Combinez plusieurs conditions avec `&` (ET) ou `|` (OU) en utilisant des parentheses\n- Utilisez `df.sort_values(by='colonne', ascending=False)` pour trier par ordre decroissant\n- `df.reset_index(drop=True)` pour reinitialiser les indices après filtrage",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Filtrage et tri d'un DataFrame\n",
+    "\n",
+    "Le filtrage et le tri sont des opérations fondamentales en analyse de données. Vous allez créer un DataFrame de produits et appliquer des filtres combinés avec un tri pour extraire des informations spécifiques.\n",
+    "\n",
+    "**Objectif** : Créer un DataFrame de produits, filtrer les produits par prix et catégorie, puis trier les résultats.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Combinez plusieurs conditions avec `&` (ET) ou `|` (OU) en utilisant des parentheses\n",
+    "- Utilisez `df.sort_values(by='colonne', ascending=False)` pour trier par ordre decroissant\n",
+    "- `df.reset_index(drop=True)` pour reinitialiser les indices après filtrage"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "f8ff78da",
-   "source": "# Exercice 1 : Filtrage et tri\n# Creez un DataFrame de produits et appliquez des filtres combinés\n\n# Etape 1: Creez le DataFrame\nproduits = pd.DataFrame({\n    'Produit': ['Ordinateur', 'Telephone', 'Tablette', 'Casque', 'Souris', 'Clavier'],\n    'Categorie': ['Electronique', 'Electronique', 'Electronique', 'Accessoire', 'Accessoire', 'Accessoire'],\n    'Prix': [999, 699, 399, 89, 49, 79],\n    'Stock': [10, 25, 15, 50, 100, 75]\n})\n\n# Etape 2: Filtrez les produits Electronique avec un Prix > 400\n# Indice: (produits['Categorie'] == 'Electronique') & (produits['Prix'] > 400)\nproduits_chers = None  # Remplacez None\n\n# Etape 3: Triez les resultats par prix decroissant\n# Indice: produits_chers.sort_values(by='Prix', ascending=False)\nproduits_tries = None  # Remplacez None\n\n# Affichage\nif produits_chers is not None:\n    print(\"Produits Electronique avec Prix > 400 :\")\n    print(produits_tries)\nelse:\n    print(\"Exercice 1 a completer : filtrage et tri d'un DataFrame\")",
-   "metadata": {},
-   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T12:07:57.474852Z",
+     "iopub.status.busy": "2026-08-23T12:07:57.474705Z",
+     "iopub.status.idle": "2026-08-23T12:07:57.478766Z",
+     "shell.execute_reply": "2026-08-23T12:07:57.478177Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice 1 a completer : filtrage et tri d'un DataFrame\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice 1 : Filtrage et tri\n",
+    "# Creez un DataFrame de produits et appliquez des filtres combinés\n",
+    "\n",
+    "# Etape 1: Creez le DataFrame\n",
+    "produits = pd.DataFrame({\n",
+    "    'Produit': ['Ordinateur', 'Telephone', 'Tablette', 'Casque', 'Souris', 'Clavier'],\n",
+    "    'Categorie': ['Electronique', 'Electronique', 'Electronique', 'Accessoire', 'Accessoire', 'Accessoire'],\n",
+    "    'Prix': [999, 699, 399, 89, 49, 79],\n",
+    "    'Stock': [10, 25, 15, 50, 100, 75]\n",
+    "})\n",
+    "\n",
+    "# Etape 2: Filtrez les produits Electronique avec un Prix > 400\n",
+    "# Indice: (produits['Categorie'] == 'Electronique') & (produits['Prix'] > 400)\n",
+    "produits_chers = None  # Remplacez None\n",
+    "\n",
+    "# Etape 3: Triez les resultats par prix decroissant\n",
+    "# Indice: produits_chers.sort_values(by='Prix', ascending=False)\n",
+    "produits_tries = None  # Remplacez None\n",
+    "\n",
+    "# Affichage\n",
+    "if produits_chers is not None:\n",
+    "    print(\"Produits Electronique avec Prix > 400 :\")\n",
+    "    print(produits_tries)\n",
+    "else:\n",
+    "    print(\"Exercice 1 a completer : filtrage et tri d'un DataFrame\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ea39352d",
-   "source": "### Exercice 2 : Agrégation et groupby\n\nLes opérations d'agregation permettent de synthetiser les données par groupes. Vous allez utiliser les fonctions `groupby()`, `agg()` et les statistiques descriptives pour analyser un jeu de données de ventes.\n\n**Objectif** : Calculer des statistiques par catégorie (somme, moyenne, nombre) sur un DataFrame de ventes.\n\n**Indices** :\n- `df.groupby('colonne')` créé un groupe par valeur unique de la colonne\n- `df.groupby('cat')['val'].agg(['sum', 'mean', 'count'])` pour plusieurs agregats en une fois\n- `df.groupby('cat').describe()` pour un resume statistique complet par groupe",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Agrégation et groupby\n",
+    "\n",
+    "Les opérations d'agregation permettent de synthetiser les données par groupes. Vous allez utiliser les fonctions `groupby()`, `agg()` et les statistiques descriptives pour analyser un jeu de données de ventes.\n",
+    "\n",
+    "**Objectif** : Calculer des statistiques par catégorie (somme, moyenne, nombre) sur un DataFrame de ventes.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `df.groupby('colonne')` créé un groupe par valeur unique de la colonne\n",
+    "- `df.groupby('cat')['val'].agg(['sum', 'mean', 'count'])` pour plusieurs agregats en une fois\n",
+    "- `df.groupby('cat').describe()` pour un resume statistique complet par groupe"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "2e17b996",
-   "source": "# Exercice 2 : Agregation et groupby\n# Analysez des donnees de ventes avec les fonctions d'agregation\n\n# Etape 1: Creez le DataFrame de ventes\nventes = pd.DataFrame({\n    'Vendeur': ['Alice', 'Bob', 'Alice', 'Charlie', 'Bob', 'Alice', 'Charlie', 'Bob'],\n    'Produit': ['A', 'A', 'B', 'B', 'A', 'C', 'C', 'C'],\n    'Montant': [150, 200, 300, 250, 100, 400, 350, 175]\n})\n\n# Etape 2: Calculez le montant total par vendeur\n# Indice: ventes.groupby('Vendeur')['Montant'].sum()\ntotal_par_vendeur = None  # Remplacez None\n\n# Etape 3: Calculez les statistiques par produit (somme, moyenne, nombre)\n# Indice: ventes.groupby('Produit')['Montant'].agg(['sum', 'mean', 'count'])\nstats_par_produit = None  # Remplacez None\n\n# Etape 4: Trouvez le vendeur avec le plus grand chiffre d'affaires\n# Indice: total_par_vendeur.idxmax()\nmeilleur_vendeur = None  # Remplacez None\n\n# Affichage\nif total_par_vendeur is not None:\n    print(\"Montant total par vendeur :\")\n    print(total_par_vendeur)\n    print(f\"\\nStatistiques par produit :\\n{stats_par_produit}\")\n    print(f\"\\nMeilleur vendeur : {meilleur_vendeur}\")\nelse:\n    print(\"Exercice 2 a completer : agregation et groupby\")",
-   "metadata": {},
-   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T12:07:57.480213Z",
+     "iopub.status.busy": "2026-08-23T12:07:57.480067Z",
+     "iopub.status.idle": "2026-08-23T12:07:57.484339Z",
+     "shell.execute_reply": "2026-08-23T12:07:57.483705Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice 2 a completer : agregation et groupby\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice 2 : Agregation et groupby\n",
+    "# Analysez des donnees de ventes avec les fonctions d'agregation\n",
+    "\n",
+    "# Etape 1: Creez le DataFrame de ventes\n",
+    "ventes = pd.DataFrame({\n",
+    "    'Vendeur': ['Alice', 'Bob', 'Alice', 'Charlie', 'Bob', 'Alice', 'Charlie', 'Bob'],\n",
+    "    'Produit': ['A', 'A', 'B', 'B', 'A', 'C', 'C', 'C'],\n",
+    "    'Montant': [150, 200, 300, 250, 100, 400, 350, 175]\n",
+    "})\n",
+    "\n",
+    "# Etape 2: Calculez le montant total par vendeur\n",
+    "# Indice: ventes.groupby('Vendeur')['Montant'].sum()\n",
+    "total_par_vendeur = None  # Remplacez None\n",
+    "\n",
+    "# Etape 3: Calculez les statistiques par produit (somme, moyenne, nombre)\n",
+    "# Indice: ventes.groupby('Produit')['Montant'].agg(['sum', 'mean', 'count'])\n",
+    "stats_par_produit = None  # Remplacez None\n",
+    "\n",
+    "# Etape 4: Trouvez le vendeur avec le plus grand chiffre d'affaires\n",
+    "# Indice: total_par_vendeur.idxmax()\n",
+    "meilleur_vendeur = None  # Remplacez None\n",
+    "\n",
+    "# Affichage\n",
+    "if total_par_vendeur is not None:\n",
+    "    print(\"Montant total par vendeur :\")\n",
+    "    print(total_par_vendeur)\n",
+    "    print(f\"\\nStatistiques par produit :\\n{stats_par_produit}\")\n",
+    "    print(f\"\\nMeilleur vendeur : {meilleur_vendeur}\")\n",
+    "else:\n",
+    "    print(\"Exercice 2 a completer : agregation et groupby\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "7f6cbccb",
-   "source": "### Exercice 3 : Transformation et nettoyage de colonnes\n\nEn pratique, les données necessitent souvent des transformations avant analyse : conversion de types, renommage de colonnes, creation de nouvelles colonnes calculees. Vous allez appliquer ces opérations sur un DataFrame d'employes.\n\n**Objectif** : Transformer un DataFrame en ajoutant une colonne calculee, renommant des colonnes et convertissant des types.\n\n**Indices** :\n- `df['nouvelle'] = df['col1'] * df['col2']` pour créer une colonne calculee\n- `df.rename(columns={'ancien': 'nouveau'})` pour renommer\n- `df['col'].astype(float)` ou `pd.to_numeric()` pour convertir des types\n- `df.drop(columns=['col'])` pour supprimer une colonne",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Transformation et nettoyage de colonnes\n",
+    "\n",
+    "En pratique, les données necessitent souvent des transformations avant analyse : conversion de types, renommage de colonnes, creation de nouvelles colonnes calculees. Vous allez appliquer ces opérations sur un DataFrame d'employes.\n",
+    "\n",
+    "**Objectif** : Transformer un DataFrame en ajoutant une colonne calculee, renommant des colonnes et convertissant des types.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `df['nouvelle'] = df['col1'] * df['col2']` pour créer une colonne calculee\n",
+    "- `df.rename(columns={'ancien': 'nouveau'})` pour renommer\n",
+    "- `df['col'].astype(float)` ou `pd.to_numeric()` pour convertir des types\n",
+    "- `df.drop(columns=['col'])` pour supprimer une colonne"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
    "id": "b7be3e19",
-   "source": "# Exercice 3 : Transformation et nettoyage de colonnes\n# Transformez un DataFrame d'employes\n\n# Etape 1: Creez le DataFrame d'employes\nemployes = pd.DataFrame({\n    'nom': ['Alice', 'Bob', 'Charlie', 'Diana'],\n    'salaire_mensuel': ['3000', '2500', '4000', '3500'],  # Type string (a convertir)\n    'prime_percent': [10, 5, 15, 8]\n})\n\n# Etape 2: Convertissez la colonne salaire_mensuel en float\n# Indice: employes['salaire_mensuel'] = employes['salaire_mensuel'].astype(float)\n\n# Etape 3: Calculez le salaire annuel dans une nouvelle colonne 'salaire_annuel'\n# Indice: salaire_mensuel * 12\nsalaire_annuel = None  # Remplacez None\n\n# Etape 4: Calculez la prime en euros (salaire_annuel * prime_percent / 100)\n# Indice: creez une colonne 'prime_euros'\nprime_euros = None  # Remplacez None\n\n# Etape 5: Renommez la colonne 'prime_percent' en 'prime_pourcentage'\n# Indice: employes.rename(columns={'prime_percent': 'prime_pourcentage'})\nemployes_renomme = None  # Remplacez None\n\n# Affichage\nif salaire_annuel is not None:\n    print(\"DataFrame transforme :\")\n    print(employes_renomme)\nelse:\n    print(\"Exercice 3 a completer : transformation et nettoyage de colonnes\")",
-   "metadata": {},
-   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T12:07:57.485876Z",
+     "iopub.status.busy": "2026-08-23T12:07:57.485725Z",
+     "iopub.status.idle": "2026-08-23T12:07:57.490594Z",
+     "shell.execute_reply": "2026-08-23T12:07:57.489674Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice 3 a completer : transformation et nettoyage de colonnes\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice 3 : Transformation et nettoyage de colonnes\n",
+    "# Transformez un DataFrame d'employes\n",
+    "\n",
+    "# Etape 1: Creez le DataFrame d'employes\n",
+    "employes = pd.DataFrame({\n",
+    "    'nom': ['Alice', 'Bob', 'Charlie', 'Diana'],\n",
+    "    'salaire_mensuel': ['3000', '2500', '4000', '3500'],  # Type string (a convertir)\n",
+    "    'prime_percent': [10, 5, 15, 8]\n",
+    "})\n",
+    "\n",
+    "# Etape 2: Convertissez la colonne salaire_mensuel en float\n",
+    "# Indice: employes['salaire_mensuel'] = employes['salaire_mensuel'].astype(float)\n",
+    "\n",
+    "# Etape 3: Calculez le salaire annuel dans une nouvelle colonne 'salaire_annuel'\n",
+    "# Indice: salaire_mensuel * 12\n",
+    "salaire_annuel = None  # Remplacez None\n",
+    "\n",
+    "# Etape 4: Calculez la prime en euros (salaire_annuel * prime_percent / 100)\n",
+    "# Indice: creez une colonne 'prime_euros'\n",
+    "prime_euros = None  # Remplacez None\n",
+    "\n",
+    "# Etape 5: Renommez la colonne 'prime_percent' en 'prime_pourcentage'\n",
+    "# Indice: employes.rename(columns={'prime_percent': 'prime_pourcentage'})\n",
+    "employes_renomme = None  # Remplacez None\n",
+    "\n",
+    "# Affichage\n",
+    "if salaire_annuel is not None:\n",
+    "    print(\"DataFrame transforme :\")\n",
+    "    print(employes_renomme)\n",
+    "else:\n",
+    "    print(\"Exercice 3 a completer : transformation et nettoyage de colonnes\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell-jd-exo4-intro",
+   "metadata": {},
+   "source": [
+    "### Exercice 4 : Joindre et diagnostiquer les valeurs manquantes\n",
+    "\n",
+    "Combinez les deux notions de ce notebook : rapprochez deux tables, puis mesurez\n",
+    "l'impact des valeurs manquantes sur le résultat.\n",
+    "\n",
+    "**Objectif** : joindre des commandes à leurs clients et diagnostiquer les `NaN` issus\n",
+    "de la jointure.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `pd.merge(a, b, on='cle', how='left')` pour garder toutes les commandes\n",
+    "- `resultat.isna().sum()` pour compter les manquants après jointure\n",
+    "- `resultat['col'].fillna(valeur)` si vous voulez imputer\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "cell-jd-exo4-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T12:07:57.492359Z",
+     "iopub.status.busy": "2026-08-23T12:07:57.492121Z",
+     "iopub.status.idle": "2026-08-23T12:07:57.496872Z",
+     "shell.execute_reply": "2026-08-23T12:07:57.496243Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 4 a completer : joindre et diagnostiquer les valeurs manquantes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : Joindre et diagnostiquer les NaN\n",
+    "\n",
+    "# Etape 1: Deux tables a rapprocher sur une cle commune\n",
+    "clients2 = pd.DataFrame({\n",
+    "    'id_client': [1, 2, 3],\n",
+    "    'nom': ['Alice', 'Bob', 'Charles']\n",
+    "})\n",
+    "commandes2 = pd.DataFrame({\n",
+    "    'id_client': [1, 3, 99],\n",
+    "    'total': [300, 120, 450]\n",
+    "})\n",
+    "\n",
+    "# Etape 2: Joignez en gardant TOUTES les commandes (how='left')\n",
+    "# Indice: pd.merge(commandes2, clients2, on='id_client', how='left')\n",
+    "resultat_join = None  # Remplacez None\n",
+    "\n",
+    "# Etape 3: Diagnostiquez les NaN resultants\n",
+    "# Indice: resultat_join.isna().sum()\n",
+    "nan_par_colonne = None  # Remplacez None\n",
+    "\n",
+    "# Etape 4: Comptez les commandes sans client connu\n",
+    "# Indice: resultat_join['nom'].isna().sum()\n",
+    "commandes_sans_client = None  # Remplacez None\n",
+    "\n",
+    "# Affichage\n",
+    "if resultat_join is not None:\n",
+    "    print('Resultat de la jointure :')\n",
+    "    print(resultat_join)\n",
+    "    print('\\nNaN par colonne :')\n",
+    "    print(nan_par_colonne)\n",
+    "    print(f'\\nCommandes sans client connu : {commandes_sans_client}')\n",
+    "else:\n",
+    "    print('Exercice 4 a completer : joindre et diagnostiquer les valeurs manquantes')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-ced13a1a",
    "metadata": {},
    "source": [
     "## Conclusion\n",
@@ -496,11 +1094,11 @@
     "- Les résultats obtenus permettent de valider la comprehension\n",
     "\n",
     "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d autres domaines."
-   ],
-   "id": "cell-ced13a1a"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cell-042df0dd",
    "metadata": {},
    "source": [
     "## Références\n",
@@ -508,11 +1106,27 @@
     "1. W. McKinney, *Data Structures for Statistical Computing in Python*, Proceedings of the 9th Python in Science Conference (SciPy 2010), pp. 51-56, 2010. Article fondateur de Pandas : structures `Series` et `DataFrame`, conçues pour le calcul statistique sur données étiquetées.\n",
     "2. W. McKinney, *Python for Data Analysis: Data Wrangling with Pandas, NumPy, and Jupyter*, O'Reilly Media, 3e édition, 2022. Référence livresque canonique sur l'usage pratique de Pandas (`groupby`, indexation, nettoyage).\n",
     "3. T. Wes McKinney, *pandas: a Foundational Python Library for Data Analysis and Statistics*, 2011. Notes techniques complémentaires sur l'architecture interne de Pandas."
-   ],
-   "id": "cell-042df0dd"
+   ]
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-23T13:00Z",
+   "network": false,
+   "notes": "Introduction à Pandas : DataFrame, Series, lecture CSV (pd.read_csv),\nsélection/filtrage, groupby/agg, merge/concat, opérations sur\ncolonnes (apply/map), gestion des valeurs manquantes (isnull/fillna).\nDataset CSV fourni localement. Aucune API externe, aucun GPU requis.\n---",
+   "reduced_pedagogical": "self",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "vram_gb": 0,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -528,7 +1142,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
@@ -541,23 +1155,6 @@
    "parameters": {},
    "start_time": "2026-05-13T08:18:12.150063",
    "version": "2.7.0"
-  },
-  "cost": {
-   "api_provider": "none",
-   "network": false,
-   "cpu_min": 2,
-   "api_usd_est": 0.0,
-   "metadata_written": "2026-07-23T13:00Z",
-   "vram_tier": "LITE",
-   "validator": "papermill",
-   "reproducibility": "HIGH",
-   "gpu_required": false,
-   "gpu_min": 0,
-   "vram_gb": 0,
-   "reduced_pedagogical": "self",
-   "external_account": "none",
-   "free_alternative": "self",
-   "notes": "Introduction à Pandas : DataFrame, Series, lecture CSV (pd.read_csv),\nsélection/filtrage, groupby/agg, merge/concat, opérations sur\ncolonnes (apply/map), gestion des valeurs manquantes (isnull/fillna).\nDataset CSV fourni localement. Aucune API externe, aucun GPU requis.\n---"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
@@ -1143,18 +1143,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.7"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 1.75982,
-   "end_time": "2026-05-13T08:18:13.909883",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb",
-   "output_path": "1.3-Analyse_de_Donnees_avec_Pandas.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-13T08:18:12.150063",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: LIGHT/docs #12582

## Sujet

Enrichir `01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb` : les « verbes cœur » de Pandas manquants. L'existant (création, sélection, filtrage, exemple guidé + 3 exercices) est conservé tel quel. Quatre sections **exécutées** + un exercice 4 viennent combler les trous identifiés par l'issue, et relient le notebook à l'identité séries-temporelles/finance du dépôt.

## Changements

1. **Section jointure** — deux DataFrames (clients / commandes), les **4 variantes `how=`** (inner/left/right/outer) sur les mêmes données, avec le décompte de lignes qui **diffère** (2/3/3/4) : le comportement de `merge` est *montré*, pas décrit.
2. **Section données manquantes** — injection de NaN, `isna().sum()` (diagnostic), puis **deux stratégies comparées sur la statistique aval** : `dropna(subset=['note'])` (moyenne **17.33**) vs `fillna` par médiane (moyenne **15.20**) — distribution asymétrique choisie pour que les deux moyennes **divergent** (leçon du choix, pas un artefact).
3. **Section séries temporelles** — `pd.to_datetime`, accesseur `.dt.year`, `resample('ME')` mensuel agrégeant les ventes + **figure** (matplotlib inline capturée).
4. **Section lecture réelle** — écriture d'un CSV puis `pd.read_csv(...)` avec les deux arguments qui coincent toujours : `sep=';'` et `parse_dates=['Date']` (types vérifiés). Fichier temporaire nettoyé en fin de cellule.
5. **Exercice 4 (stub)** — « joindre et diagnostiquer les NaN du résultat » (`how='left'` + `isna().sum()`), conforme C.1.

## Honnêteté — deux pièges attrapés avant commit

- **Prose vs sortie (inversion)** : la première version de la section « données manquantes » utilisait `[15, NaN, 12, NaN, 18]`, où moyenne dropna = moyenne fillna = **15.00**. La prose disait « la moyenne change selon la stratégie » — **faux**, les deux coïncidaient. Resserré d'un dataset asymétrique (`[10, NaN, 12, NaN, 30]`) pour que 17.33 ≠ 15.20, et prose réécrite sur les valeurs réelles.
- **`resample` en pandas 3.0** : la fréquence `'M'` (mensuelle) est dépréciée → utilisée `'ME'` (month-end), seule forme qui fonctionne sans warning sur pandas 3.0.2.
- **Bloc `metadata.papermill` périmé** : le notebook portait un bloc de run **squelette** (2026-05-13, durée 1.76 s) qui ne décrivait aucune des sorties actuelles → **retiré** (fix sanctionné par `check_papermill_ratchet.py`). Le notebook est exécuté via nbclient, pas Papermill.

## Validation

- Re-exécution **nbclient kernel `python3`** : **13/13** cellules code, `execution_count` **1..13 contigus**, **0 erreur**, 0 erreur volontaire (C.1).
- `validate_pr_notebooks.py origin/main` : **1/1 PASS** (13 cellules).
- `check_exec_ratchet.py origin/main` : **CLEAN→CLEAN**, 0 régression.
- `check_papermill_ratchet.py origin/main` : **0 régression** (`BLOCK_REMOVED`).
- `detect_markdown_rendering.py --check` : **OK, aucune violation NEW**.
- Contenu existant (3 démos, exemple guidé, exercices 1-3) **préservé** — vérifié cellule par cellule.
- Source-leak : 0 chemin machine / secret dans les sorties (grep `/Users/`, `/c/dev`, `192.168.x`, tokens).
- README `01-PythonForDataScience` §Vue d'ensemble mis à jour (contenu + durée ~45 min).

## Résiduel

- Famine gate `PR gate (re-aggregate)` #11860 (0 verdict, ~51,5 % CI) : un `PR gate` QUEUED/cancelled sur une PR verte = faux positif du garde « répare ton rouge d'abord » → `--ignore-red` avec la raison écrite. La PR est prête ; elle n'attend que le merge (gate muet).

Closes #12441
