### PR TITLE
feat(iit,#11601): ICT-1 PhiTrajectories densite round 2 (1209 -> 1756 chars/cell, +45%)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb
@@ -97,7 +97,18 @@
     "l'evolution dans l'espace d'etats sans dependre de PyPhi). On desactive le\n",
     "parallelisme de PyPhi (sous Windows le `multiprocessing` provoque sinon une\n",
     "avalanche de processus) et la validation des etats accessibles, pour pouvoir\n",
-    "calculer $\\Phi$ sur **tous** les etats, y compris transitoires."
+    "calculer $\\Phi$ sur **tous** les etats, y compris transitoires.\n",
+    "Deux roles bien distincts dans ce notebook :\n",
+    "\n",
+    "- **PyPhi** calcule $\\Phi$ : pour un etat donne, il considere toutes les\n",
+    "  facons de couper le reseau en deux parties, evalue pour chaque coupe la\n",
+    "  perte d'information *cause* et *effet*, et retient la coupe minimale — le\n",
+    "  *minimum information partition* (MIP). $\\Phi$ est l'information qui survit\n",
+    "  a la meilleure coupe : c'est le calcul couteux du notebook, fait une fois\n",
+    "  pour toutes en section 1.\n",
+    "- **`ict.trajectories`** ne connait que la TPM : il fait avancer les etats,\n",
+    "  detecte attracteurs et bassins, sans jamais dependre de PyPhi. Les\n",
+    "  sections 2 et 3 ne font que relire la carte de $\\Phi$ precalculee.\n"
    ]
   },
   {
@@ -205,7 +216,19 @@
     "\n",
     "Pour chacun, `network.tpm` est la matrice de transition au format *state-by-node*\n",
     "de PyPhi : indexee par un tuple d'etat, elle donne l'etat suivant (les reseaux\n",
-    "sont déterministes)."
+    "sont déterministes).\n",
+    "La cellule suivante affiche aussi la **connectivite** des deux reseaux, et\n",
+    "l'opposition est nette : chez AND/OR la matrice est **pleine** (chaque noeud\n",
+    "ecoute les deux autres, portes logiques mixtes oblige), chez XOR c'est un\n",
+    "**anneau** sans auto-connexion (diagonale nulle). Deux choix deliberes : la\n",
+    "connexion dense autorise des interactions asymetriques — donc des etats aux\n",
+    "roles tres inegaux — tandis que l'anneau parfaitement symetrique traite les\n",
+    "etats de facon interchangeable.\n",
+    "\n",
+    "Trois noeuds, c'est le plus petit systeme ou la question devient interessante\n",
+    ": a deux elements une seule coupe est possible et le MIP est trivial ; a\n",
+    "trois, les partitions se diversifient et $\\Phi$ peut vraiment varier d'un\n",
+    "etat a l'autre — le relief que la section 1 va mesurer.\n"
    ]
   },
   {
@@ -281,7 +304,19 @@
     "\n",
     "La fonction ci-dessous calcule $\\Phi$ pour chacun des $2^n$ etats. C'est le seul\n",
     "endroit ou PyPhi travaille vraiment ; le reste du notebook ne fait que relire\n",
-    "cette carte."
+    "cette carte.\n",
+    "Concretement, chaque appel de $\\Phi$ est lourd : pour l'etat considere, PyPhi\n",
+    "examine **toutes** les partitions du systeme en deux parties, construit pour\n",
+    "chacune les repertoires de cause et d'effet (les distributions de passe et de\n",
+    "futur compatibles avec la mecanique du reseau), et retient la coupe qui\n",
+    "detruit le moins d'information. Ici $2^3 = 8$ etats a cartographier, c'est\n",
+    "jouable ; la meme carte a $2^5$ etats demanderait deja quatre fois plus\n",
+    "d'appels.\n",
+    "\n",
+    "La sortie texte donne les valeurs exactes, la figure qui suit en donne la\n",
+    "lecture visuelle — huit barres par reseau. Tout le reste du notebook (les\n",
+    "trajectoires de la section 2, la robustesse de la section 3) relira cette\n",
+    "carte sans plus jamais invoquer PyPhi.\n"
    ]
   },
   {
@@ -449,7 +484,20 @@
     "Un reseau déterministe, lache depuis un etat de depart, suit un chemin unique\n",
     "jusqu'a tomber dans un **attracteur** (un point fixe ou un cycle). Le module\n",
     "`ict.trajectories` reconstruit ce chemin en lisant la TPM, puis on relit la carte\n",
-    "de $\\Phi$ le long du chemin."
+    "de $\\Phi$ le long du chemin.\n",
+    "Un argument de structure precede toute simulation : l'espace d'etats est\n",
+    "fini ($2^3 = 8$ etats) et la dynamique deterministe — chaque etat a un\n",
+    "successeur **unique**. Un chemin qui visite au neuvieme pas un etat deja\n",
+    "visite (principe des tiroirs) est donc condamne a boucler : toute\n",
+    "trajectoire se decompose en un **transitoire** suivi d'un **attracteur**\n",
+    "(point fixe ou cycle).\n",
+    "\n",
+    "Les quatre departs choisis balayent les cas de figure : l'un demarre sur le\n",
+    "cycle, deux autres le rejoignent apres des transitoires de longueurs\n",
+    "differentes, et le dernier est l'exception qui tombe dans le point fixe\n",
+    "isole. La sortie affiche pour chacun le chemin, l'attracteur atteint, la\n",
+    "courbe de $\\Phi$, puis le recensement des bassins — c'est ce recensement\n",
+    "qui dit si la destination depend du depart ou de la structure du paysage.\n"
    ]
   },
   {
@@ -592,7 +640,13 @@
     "Le huitieme etat, `000`, est un **point fixe** isole ($\\Phi$ constant a $0{,}19$) :\n",
     "un petit bassin a part. Sur XOR, au contraire, toutes les trajectoires atteignent\n",
     "un point fixe en un ou deux pas, et comme le paysage est plat, $\\Phi$ y reste\n",
-    "**rigoureusement constant** a $1{,}875$ : un film sans relief."
+    "**rigoureusement constant** a $1{,}875$ : un film sans relief.\n",
+    "Le recensement des **bassins** complete le tableau : AND/OR separe ses huit\n",
+    "etats de depart en $1 + 7$ — le point fixe `000` n'attire que lui-meme, le\n",
+    "cycle capte tout le reste. XOR, lui, eclate en **quatre points fixes** de\n",
+    "bassin 2 chacun (`000`, `011`, `101`, `110`) : la symetrie du OU-exclusif se\n",
+    "retrouve jusque dans la geographie des bassins, exactement comme elle\n",
+    "fabriquait le plateau de $\\Phi$.\n"
    ]
   },
   {
@@ -617,7 +671,16 @@
     "attracteur, sa trajectoire de $\\Phi$ se reconstitue-t-elle ?\n",
     "\n",
     "On part du cycle AND/OR, on bascule **un seul noeud** (perturbation 1-bit), puis\n",
-    "on laisse le système re-evoluer."
+    "on laisse le système re-evoluer.\n",
+    "Pourquoi ce protocole exactement : l'etat de reference `110` est **sur le\n",
+    "cycle** — on perturbe le regime asymptotique du systeme, pas un transitoire\n",
+    "qui aurait de toute facon disparu. Le flip d'un seul bit est la\n",
+    "perturbation **minimale** qui puisse rediriger une dynamique deterministe :\n",
+    "moindre, rien ne change ; plus forte, on ne saurait plus attribuer un\n",
+    "eventuel changement de destination a la fragilite du systeme plutot qu'a la\n",
+    "violence du coup. La cellule suivante essaie les trois flips possibles\n",
+    "(noeuds 0, 1 et 2) et compare, pour chacun, l'attracteur atteint a\n",
+    "l'attracteur de reference.\n"
    ]
   },
   {
@@ -737,7 +800,16 @@
     "\n",
     "Trois exercices pour manipuler vous-même le paysage et les trajectoires de $\\Phi$.\n",
     "Completez le corps de chaque fonction (remplacez le `return None`). Le notebook\n",
-    "s'execute de bout en bout même sans les completer."
+    "s'execute de bout en bout même sans les completer.\n",
+    "Les trois exercices se repondent : le premier relit le **paysage** (statique\n",
+    "— l'amplitude mesuree en section 1 : $2{,}125$ pour AND/OR, $0$ pour XOR),\n",
+    "le deuxieme resume un **cycle** par un seul nombre (la moyenne de $\\Phi$ sur\n",
+    "le cycle AND/OR vaut $\\approx 0{,}90$, contre $1{,}875$ sur le plateau de\n",
+    "XOR), le troisieme detecte les **evenements** de la courbe (un pic de $\\Phi$\n",
+    "tous les trois pas sur le cycle AND/OR). Chaque fonction retourne un nombre,\n",
+    "et la cellule qui suit chaque stub affiche la valeur attendue quand le\n",
+    "resultat n'est pas `None` — vous pouvez verifier votre reponse sans attendre\n",
+    "la correction.\n"
    ]
   },
   {
@@ -758,7 +830,11 @@
     "\n",
     "Le paysage AND/OR est accidente (amplitude $\\approx 2{,}12$), celui de XOR est\n",
     "plat (amplitude $0$). Ecrivez une fonction qui **mesure** cet ecart : l'amplitude\n",
-    "$\\max \\Phi - \\min \\Phi$ sur tout le paysage d'un reseau."
+    "$\\max \\Phi - \\min \\Phi$ sur tout le paysage d'un reseau.\n",
+    "La moyenne de $\\Phi$ sur tout le paysage AND/OR ($\\approx 0{,}52$ d'apres la\n",
+    "section 1) dit autre chose que l'amplitude : deux reseaux peuvent avoir la\n",
+    "meme moyenne et des personnalites causales opposees. L'amplitude est la\n",
+    "bonne statistique pour separer « accidente » de « plat ».\n"
    ]
   },
   {
@@ -825,7 +901,11 @@
     "Sur le cycle AND/OR, $\\Phi$ pulse ($2{,}31 \\to 0{,}19 \\to 0{,}19$). Le $\\Phi$\n",
     "*moyen* sur l'attracteur resume \"l'integration soutenue\" d'un regime. Ecrivez une\n",
     "fonction qui, depuis un etat de depart, retourne la moyenne de $\\Phi$ sur les\n",
-    "etats du cycle attracteur."
+    "etats du cycle attracteur.\n",
+    "Avec les valeurs de la section 2, la reponse attendue pour un depart sur le\n",
+    "cycle AND/OR est $(2{,}312 + 0{,}188 + 0{,}188) / 3 \\approx 0{,}896$ : la\n",
+    "moyenne masque la pulsation — c'est precisement ce que ce chiffre apprend,\n",
+    "par contraste avec le $1{,}875$ constant du plateau XOR.\n"
    ]
   },
   {
@@ -892,7 +972,12 @@
     "Un \"pic\" de $\\Phi$ le long d'une trajectoire est un **maximum local**. La fonction\n",
     "`T.detect_events` renvoie les indices des minima et maxima locaux d'une courbe.\n",
     "Ecrivez une fonction qui compte le nombre de **pics** de $\\Phi$ le long de la\n",
-    "trajectoire issue d'un etat de depart."
+    "trajectoire issue d'un etat de depart.\n",
+    "Sur le cycle AND/OR, la courbe de $\\Phi$ monte en fleche un pas sur trois :\n",
+    "le nombre de pics croit donc lineairement avec la longueur de simulation,\n",
+    "tandis qu'une trajectoire du point fixe `000` n'en montre aucun. Deux\n",
+    "dynamiques, deux signatures — c'est ce contraste que votre compteur doit\n",
+    "reproduire.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-python #12576

## Tranche densite round 2 — ICT-1-PhiTrajectories

**Perimetre : 1 fichier — `MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb`, aucune autre modification.**

See #11601 (tranche round 2, contribution partielle a l'umbrella — la bande 1200-2000 compte 887 vivants, priorites du body perimees mesurees 3065/2916).

### Mesures

| Mesure | Avant | Apres |
|---|---|---|
| Prose/code-cell (`pedagogy_density.py`) | 1209 (12090 c / 10 code cells) | **1756** (17568 c / 10) |
| Cellules markdown etendues | — | 10 (+5478 c) |
| Cellules code touchees | — | **0** |

Cible umbrella (>=1500) depassee ; alignee sur les livraisons round 2 sœurs (PyMC-5 1200->1603, PyMC-8 1219->1612, QC-Py-24 1324->2372).

### Conformite

- **C.3 exemption** : markdown-only — `git diff` montre 0 ligne `execution_count`/`outputs` modifiee, exec_counts 1..10 byte-intacts (re-exec non exigee).
- **C.1** : scan nbformat sur sources parsees — NONE (stubs existants `result = None  # TODO etudiant` non touches).
- **Regle 4bis** (interpretation apres la cellule porteuse) : les 6 additions d'intro ([2],[4],[6],[10],[14],[17]) sont de la prose de mise en place **sans valeur mesuree anticipee** ; les valeurs chiffrees n'apparaissent qu'en references ARRIERE — [13] recense les bassins de l'output [11] (AND/OR 1+7, XOR 4 points fixes de bassin 2), [17]/[18]/[20]/[22] citent les mesures des sections 1-2 (amplitude 2.125 / moyenne paysage 0.5156 / moyenne cycle (2.312+0.188+0.188)/3 = 0.896 / plateau XOR 1.875).
- **nbformat validate** : OK. **Detecteur code-in-markdown** (`detect_code_in_markdown_cells.py --check --baseline`) : OK, 0 nouvelle violation.
- **Registre twin** : ICT-1 hors `twin_pairs.d` — aucune attestation requise.

### Contenu ajoute (ancrages)

- [2] Mise en place : division du travail PyPhi (MIP, repertoires cause/effet) vs `ict.trajectories` (lecture TPM seule).
- [4] Deux reseaux : opposition connectivite pleine (AND/OR) vs anneau sans auto-connexion (XOR), 3 noeuds = plus petit systeme ou le MIP devient non trivial.
- [6] Paysage : cout d'un appel de Phi (partitions x repertoires), 2^3=8 jouable vs 2^5 = 4x plus d'appels.
- [10] Trajectoire : argument principe des tiroirs (fini + deterministe => transitoire + attracteur), roles des 4 departs.
- [13] Lecture : recensement des bassins (1+7 vs 4x2).
- [14] Robustesse : protocole (etat sur-cycle, flip 1-bit minimal, 3 flips, comparaison de signature).
- [17] Exercices : fil des 3 exercices + valeurs attendues en references arriere.
- [18]/[20]/[22] : distinction moyenne vs amplitude, calcul attendu 0.896, signature pics-vs-aucun.

**Verdict SOTA-OK** (aucune substitution — prose uniquement, aucun outil remplace).
