### PR TITLE
fix(notebooks,#11947): tranche CaseStudies heading_in_list — 27 indices/étapes en backticks sur 3 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb
@@ -235,7 +235,18 @@
   {
    "cell_type": "markdown",
    "id": "994f885c",
-   "source": "### Exercice 1 : Ajout de contraintes linguistiques personnalisees\n\nLa liste `CONTRAINTES` contient actuellement trois styles (Rime, Shakespeare, Chanson). L'objectif est d'enrichir cette liste avec de nouvelles contraintes originales pour varier les debats.\n\n**Objectif** : ajouter au moins deux nouvelles contraintes a la liste, par exemple un style \"Haiku japonais\" (3 lignes, 5-7-5 syllabes) ou \"Code Python\" (repondre en utilisant la syntaxe Python).\n\n**Indices** :\n- # Étape 1 : Définir le nom et la description de chaque nouvelle contrainte\n- # Étape 2 : Ajouter les tuples `(nom, description)` a la liste `CONTRAINTES`\n- # Indice : respecter le format existant `(\"Nom\", \"Description de la règle\")`",
+   "source": [
+    "### Exercice 1 : Ajout de contraintes linguistiques personnalisees\n",
+    "\n",
+    "La liste `CONTRAINTES` contient actuellement trois styles (Rime, Shakespeare, Chanson). L'objectif est d'enrichir cette liste avec de nouvelles contraintes originales pour varier les debats.\n",
+    "\n",
+    "**Objectif** : ajouter au moins deux nouvelles contraintes a la liste, par exemple un style \"Haiku japonais\" (3 lignes, 5-7-5 syllabes) ou \"Code Python\" (repondre en utilisant la syntaxe Python).\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Étape 1` : Définir le nom et la description de chaque nouvelle contrainte\n",
+    "- `# Étape 2` : Ajouter les tuples `(nom, description)` a la liste `CONTRAINTES`\n",
+    "- `# Indice` : respecter le format existant `(\"Nom\", \"Description de la règle\")`"
+   ],
    "metadata": {}
   },
   {
@@ -468,7 +479,18 @@
   {
    "cell_type": "markdown",
    "id": "404418f6",
-   "source": "### Exercice 2 : Creation d'un troisieme agent\n\nLe debat oppose actuellement Barbie et l'Ane de Shrek. L'objectif est d'ajouter un **troisieme personnage** au debat : un **Arbitre** qui commente les performances des deux duellistes a chaque tour.\n\n**Objectif** : créer un agent `ChatCompletionAgent` nomme \"Arbitre\" avec un kernel separe et des instructions système qui lui demandent de juger la qualite des repliques (respect de la contrainte, creativite, humour).\n\n**Indices** :\n- # Étape 1 : Créer un kernel dedie pour l'Arbitre avec `create_kernel()`\n- # Étape 2 : Définir les instructions de l'Arbitre (rôle, comportement attendu)\n- # Indice : s'inspirer des instructions de Barbie et l'Ane pour le format du prompt",
+   "source": [
+    "### Exercice 2 : Creation d'un troisieme agent\n",
+    "\n",
+    "Le debat oppose actuellement Barbie et l'Ane de Shrek. L'objectif est d'ajouter un **troisieme personnage** au debat : un **Arbitre** qui commente les performances des deux duellistes a chaque tour.\n",
+    "\n",
+    "**Objectif** : créer un agent `ChatCompletionAgent` nomme \"Arbitre\" avec un kernel separe et des instructions système qui lui demandent de juger la qualite des repliques (respect de la contrainte, creativite, humour).\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Étape 1` : Créer un kernel dedie pour l'Arbitre avec `create_kernel()`\n",
+    "- `# Étape 2` : Définir les instructions de l'Arbitre (rôle, comportement attendu)\n",
+    "- `# Indice` : s'inspirer des instructions de Barbie et l'Ane pour le format du prompt"
+   ],
    "metadata": {}
   },
   {
@@ -915,7 +937,18 @@
   {
    "cell_type": "markdown",
    "id": "f27b1648",
-   "source": "### Exercice 3 : Stratégie de terminaison personnalisee\n\nL'implementation actuelle arrete le debat après un nombre fixe de tours (`MAX_TURNS = 5`). Imaginez un scénario ou le debat doit s'arreter dynamiquement selon le contenu des messages.\n\n**Objectif** : implementer une stratégie de terminaison qui detecte quand un des deux personnages utilise un mot spécifique (par exemple \"capituler\" ou \"abandon\") dans sa reponse, et arrete le debat immediatement.\n\n**Indices** :\n- # Étape 1 : Définir une liste de mots-cles declencheurs\n- # Étape 2 : Dans `should_terminate`, verifier si le dernier message contient un mot-cle\n- # Indice : utiliser `str(history[-1].content).lower()` pour lire le dernier message",
+   "source": [
+    "### Exercice 3 : Stratégie de terminaison personnalisee\n",
+    "\n",
+    "L'implementation actuelle arrete le debat après un nombre fixe de tours (`MAX_TURNS = 5`). Imaginez un scénario ou le debat doit s'arreter dynamiquement selon le contenu des messages.\n",
+    "\n",
+    "**Objectif** : implementer une stratégie de terminaison qui detecte quand un des deux personnages utilise un mot spécifique (par exemple \"capituler\" ou \"abandon\") dans sa reponse, et arrete le debat immediatement.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Étape 1` : Définir une liste de mots-cles declencheurs\n",
+    "- `# Étape 2` : Dans `should_terminate`, verifier si le dernier message contient un mot-cle\n",
+    "- `# Indice` : utiliser `str(history[-1].content).lower()` pour lire le dernier message"
+   ],
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb
@@ -296,9 +296,9 @@
     "**Objectif** : ecrire les instructions système pour ces deux nouveaux personnages et configurer les agents correspondants.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Rediger le prompt du Temoin (rôle, règles, interdictions)\n",
-    "- # Étape 2 : Rediger le prompt du Detective (stratégie de questionnement)\n",
-    "- # Indice : le Temoin ne doit jamais reveler le mot directement, mais peut donner des indices indirects\n"
+    "- `# Étape 1` : Rediger le prompt du Temoin (rôle, règles, interdictions)\n",
+    "- `# Étape 2` : Rediger le prompt du Detective (stratégie de questionnement)\n",
+    "- `# Indice` : le Temoin ne doit jamais reveler le mot directement, mais peut donner des indices indirects\n"
    ]
   },
   {
@@ -495,9 +495,9 @@
     "**Objectif** : implementer `RenoncementTerminationStrategy` qui combine la detection du mot secret avec la detection de phrases d'abandon.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir une liste de phrases d'abandon typiques\n",
-    "- # Étape 2 : Verifier si le dernier message contient une de ces phrases (en minuscules)\n",
-    "- # Indice : combiner les deux conditions avec `or` dans `should_agent_terminate`\n"
+    "- `# Étape 1` : Définir une liste de phrases d'abandon typiques\n",
+    "- `# Étape 2` : Verifier si le dernier message contient une de ces phrases (en minuscules)\n",
+    "- `# Indice` : combiner les deux conditions avec `or` dans `should_agent_terminate`\n"
    ]
   },
   {
@@ -1190,9 +1190,9 @@
     "**Objectif** : ecrire une fonction `evaluer_partie` qui prend l'historique des messages et retourne un dictionnaire contenant le nombre de questions posees, si le mot a ete trouve, et un score (moins de questions = meilleur score).\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Compter les messages ou le rôle est celui de Laurent Jalabert\n",
-    "- # Étape 2 : Verifier si le mot secret apparait dans le dernier message\n",
-    "- # Indice : le score peut etre `max(0, 100 - nb_questions * 10)`\n"
+    "- `# Étape 1` : Compter les messages ou le rôle est celui de Laurent Jalabert\n",
+    "- `# Étape 2` : Verifier si le mot secret apparait dans le dernier message\n",
+    "- `# Indice` : le score peut etre `max(0, 100 - nb_questions * 10)`\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
@@ -546,9 +546,9 @@
     "**Objectif** : implementer une classe `AllergyPlugin` avec une méthode `check_allergy` annotee `@kernel_function` qui retourne un avertissement si le medicament est incompatible avec une allergie connue.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir un dictionnaire associant des allergies a des medicaments contre-indiques\n",
-    "- # Étape 2 : Implementer la méthode `check_allergy` avec les annotations de type `Annotated`\n",
-    "- # Indice : utiliser le pattern des plugins existants (DoctorPlugin, PharmacistPlugin)"
+    "- `# Étape 1` : Définir un dictionnaire associant des allergies a des medicaments contre-indiques\n",
+    "- `# Étape 2` : Implementer la méthode `check_allergy` avec les annotations de type `Annotated`\n",
+    "- `# Indice` : utiliser le pattern des plugins existants (DoctorPlugin, PharmacistPlugin)"
    ]
   },
   {
@@ -832,9 +832,9 @@
     "**Objectif** : ecrire les trois prompts système adaptes au contexte pediatric.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Modifier le prompt du medecin pour un langage accessible aux enfants\n",
-    "- # Étape 2 : Adapter le prompt de l'IA medicale pour les dosages et signes pediatric\n",
-    "- # Indice : ajouter des contraintes comme \"toujours mentionner le poids recommande pour la posologie\""
+    "- `# Étape 1` : Modifier le prompt du medecin pour un langage accessible aux enfants\n",
+    "- `# Étape 2` : Adapter le prompt de l'IA medicale pour les dosages et signes pediatric\n",
+    "- `# Indice` : ajouter des contraintes comme \"toujours mentionner le poids recommande pour la posologie\""
    ]
   },
   {
@@ -1134,9 +1134,9 @@
     "**Objectif** : créer `DiagnosticTerminationStrategy` qui arrete la conversation des qu'un diagnostic est emis ou après 8 echanges maximum.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir une liste de mots-cles indicatifs d'un diagnostic\n",
-    "- # Étape 2 : Verifier leur presence dans le contenu du dernier message\n",
-    "- # Indice : combiner la condition de diagnostic avec un compteur maximum d'echanges"
+    "- `# Étape 1` : Définir une liste de mots-cles indicatifs d'un diagnostic\n",
+    "- `# Étape 2` : Verifier leur presence dans le contenu du dernier message\n",
+    "- `# Indice` : combiner la condition de diagnostic avec un compteur maximum d'echanges"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-lean (#12491)

Tranche CaseStudies (solde) de l'ombrelle `heading_in_list` : les 27 dernières lignes `- # Étape N : ...` / `- # Indice : ...` de **Medical-Chatbot**, **Fort-Boyard** et **Barbie-Schreck** (3 cellules d'exercice × 3 lignes × 3 notebooks) passent en forme canonique (A) — marqueur backtiqué — via l'outil mandaté par la consolidation du 2026-08-22 :

```bash
python scripts/notebook_tools/fix_hint_headings.py <3 notebooks> --apply
# 27 occurrence(s) corrigee(s) dans 3 fichier(s)
```

**Pourquoi ces 3** : la tranche po-2023 d'origine (#11949, claim libéré par arbitrage ai-01 le 2026-08-22) couvrait Diagnostic-Medical + Oncology-Planning + DecInfer. Le solde CaseStudies au HEAD était 4 notebooks / 39 lignes ; **Recipe-Maker est exclu** de cette tranche (PR #12514 ouverte sur ce fichier — pas de chevauchement).

## Preuves (relancées après le commit caf843868)

```
$ detect_markdown_rendering.py CaseStudies/Medical-Chatbot/  → violations: 0 total
$ detect_markdown_rendering.py CaseStudies/Fort-Boyard/      → violations: 0 total
$ detect_markdown_rendering.py CaseStudies/Barbie-Schreck/   → violations: 0 total
$ validate_pr_notebooks.py <3 notebooks>                     → 2/2 passed (23 code cells)
```

- **Markdown-only** : `git diff | grep outputs|execution_count` → **0** — aucune cellule code touchée, pas de re-exec due (C.3 scope strict, tranche md-only).
- **Invariant round-trip** : l'outil n'insère que des backticks et refuse d'écrire si le contenu privé de backticks n'est pas byte-identique. Barbie-Schreck porte en outre une normalisation `source` string→liste de lignes (représentation JSON canonique, contenu identique).
- **Burn-down corpus** : 39 → **12 lignes** restantes (`heading_in_list` sur tout `MyIA.AI.Notebooks/`), toutes dans Recipe-Maker (12 lignes / 4 cellules, hors de cette tranche pour #12514).

## Défaut distinct signalé, non réparé ici (scope 1 sujet/PR)

`scan_md_hierarchy` signale sur Fort-Boyard un `[H1-DEEP] cell 2 "Jeu de devinette : Père Fouras vs Laurent Jalabert"` — **préexistant sur origin/main** (vérifié par comparaison complète des deux versions : le finding est identique avant/après). C'est un H1 de titre en cellule 2, classe de défaut différente de `heading_in_list` — à traiter par grain séparé si jugé utile.

See #11947 (contribution partielle — ombrelle multi-tranches : restent Recipe-Maker et le burn-down des familles déjà claimées).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
