### PR TITLE
feat(rl,#12597): notebook rl_14 — Option framework (RL hierarchique) depuis zéro

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_14_hierarchical_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_14_hierarchical_rl.ipynb
@@ -1222,7 +1222,7 @@
    "id": "fc4e16e6",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "**Pour aller plus loin**\n",
     "\n",
     "- Sutton, Precup & Singh (1999) — *Between MDPs and semi-MDPs: A framework for temporal abstraction\n",

--- a/MyIA.AI.Notebooks/RL/rl_14_hierarchical_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_14_hierarchical_rl.ipynb
@@ -1,0 +1,1259 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f5e6c577",
+   "metadata": {},
+   "source": [
+    "# Hierarchical RL — l'Option framework de Sutton, Precup & Singh\n",
+    "\n",
+    "L'apprentissage par renforcement que les notebooks 1 à 13 ont couvert agit **au pas de temps**\n",
+    ": à chaque instant, l'agent choisit une action primaire (haut, bas, gauche, droite). Dès que la\n",
+    "tâche devient longue ou que la récompense est parcimonieuse, ce choix fin-grain est **pénalisant**\n",
+    ": il faut des dizaines de milliers d'actions pour apprendre à travers une séquence de décisions\n",
+    "cohérentes, et le crédit de chaque pas se dilue le long du chemin.\n",
+    "\n",
+    "L'abstraction temporelle répond à cela : au lieu d'une action `haut`, l'agent choisit une\n",
+    "**option** — un *macro-comportement* « aller à la porte Ouest », « atteindre le but ». Une option\n",
+    "est une politique qui s'exécute **jusqu'à sa condition de fin**, et l'agent n'a à apprendre que la\n",
+    "séquence de ces macro-actions. C'est le **Option framework** de *Sutton, Precup & Singh (1999)*,\n",
+    "la brique qui relie les MDP « plats » au **RL hiérarchique** (et, en passant, aux *skills* des\n",
+    "agents modernes).\n",
+    "\n",
+    "**Objectif de ce notebook** : implémenter le framework depuis zéro sur un **gridworld\n",
+    "quatre-pièces**, et **mesurer** — pas affirmer — le gain de l'abstraction temporelle, en ≥4 seeds,\n",
+    "avec un verdict honnête.\n",
+    "\n",
+    "> Prérequis : numpy, matplotlib. Bases de Q-learning (notebook 5) et de SGD/politique (notebook 6).\n",
+    "> Durée : ~50 min.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74df12c8",
+   "metadata": {},
+   "source": [
+    "## Pourquoi l'abstraction temporelle change la donne\n",
+    "\n",
+    "Le problème RL standard cherche `Q(s, a)` pour l'action primaire `a`. Deux obstacles apparaissent\n",
+    "dès que l'horizon s'allonge :\n",
+    "\n",
+    "1. **Crédit long-horizon** : avec une récompense −1 par pas et +20 au but, un agent qui erre\n",
+    "   de longues traversées ne voit pratiquement aucun signal intermédiaire. La valeur de Bellman\n",
+    "   doit « remonter » de proche en proche, ce qui est lent quand le but est loin.\n",
+    "2. **Exploration dans un grand espace** : pour franchir DEUX portes dans le bon ordre, il faut\n",
+    "   une longue séquence cohérente de pas ; en exploration aléatoire, elle est rare.\n",
+    "\n",
+    "L'option framework pose un **MDP semi-markovien (SMDP)** : l'agent raisonne sur les **options**\n",
+    "`o ∈ O`, chacune définie par un triplet `(I_o, π_o, β_o)` :\n",
+    "\n",
+    "- `I_o` — **ensemble d'initiation** : les états où l'option peut être choisie ;\n",
+    "- `π_o(s, a)` — la **politique intra-option** : comment agir une fois l'option lancée ;\n",
+    "- `β_o(s)` — la **condition de fin** : probabilité de terminer l'option en `s`.\n",
+    "\n",
+    "Exécuter une option ne fait pas **un** pas mais **une séquence** jusqu'à `β`. La transition\n",
+    "SMDP porte donc `(s, o) → (s', τ, r)` : `s'` l'état d'arrivée, `τ` la durée, `r` la récompense\n",
+    "accumulée. On apprend `Q(s, o)` par l'équation de Bellman **au pas de l'option** :\n",
+    "\n",
+    "```\n",
+    "Q(s, o) ← Q(s, o) + α [ r + γ^τ · max_{o'} Q(s', o') − Q(s, o) ]\n",
+    "```\n",
+    "\n",
+    "**L'état `s` dans la mise à jour est l'état où l'option a été CHOISIE**, pas l'état d'arrivée\n",
+    "`s'` : c'est le petit piège que ce notebook met en évidence. Le choix de haut niveau se fait sur\n",
+    "**5 options** (les portes + le but) au lieu de **4 actions primaires** sur un très long horizon.\n",
+    "**C'est ce qu'on va mesurer — honnêtement, quitte à conclure qu'ici le gain est une case limite**\n",
+    "(des macros parfaites offertes résolvent le problème sans apprentissage), ce qui prépare\n",
+    "l'intra-option learning, le vrai contenu d'apprentissage du framework.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfe102aa",
+   "metadata": {},
+   "source": [
+    "## Le gridworld quatre-pièces\n",
+    "\n",
+    "Un couloir en forme de `+` sépare une grille 15×15 en quatre pièces. Les murs sont intérieurs\n",
+    "(`#`), les portes sont les trous dans les murs : la grille est coupée par une **barre verticale**\n",
+    "(colonnes 7) et une **barre horizontale** (ligne 7), chacune percée de **deux portes**. L'agent\n",
+    "part en haut-gauche `(1,1)` et doit atteindre le coin en bas-droite `(13,13)` — **deux portes à\n",
+    "franchir**, donc un long chemin minimal.\n",
+    "\n",
+    "```\n",
+    "#               #               #\n",
+    "#      HAUT      #      HAUT     #\n",
+    "#     GAUCHE     #      DROIT    #\n",
+    "#               #               #\n",
+    "# # # # # # # #  #  # # # # # # #\n",
+    "#               #               #\n",
+    "#    BAS        #     BAS       #\n",
+    "#    GAUCHE     #    DROIT  (G) #\n",
+    "#               #               #\n",
+    "```\n",
+    "\n",
+    "- Récompense : **−1** par déplacement, **+20** en atteignant le but (épisode terminé).\n",
+    "- Le but est éloigné → les deux obstacles (crédit long-horizon, exploration) sont réellement là.\n",
+    "- L'agent ne connaît pas la carte : il ne voit que son état `(ligne, colonne)`.\n",
+    "\n",
+    "On compare deux apprenants **à budget identique** (même nombre d'épisodes) :\n",
+    "\n",
+    "| Apprenant | Actions | Horizon du choix | Ce qu'il doit apprendre |\n",
+    "|-----------|---------|------------------|--------------------------|\n",
+    "| **Flat** (`rl_5` Q-learning) | 4 primitives | chaque pas | toute la séquence de pas |\n",
+    "| **Options** | 5 options (portes + but) | chaque option | la séquence de portes |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1349ccd8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:29.701653Z",
+     "iopub.status.busy": "2026-08-23T14:05:29.701398Z",
+     "iopub.status.idle": "2026-08-23T14:05:30.210167Z",
+     "shell.execute_reply": "2026-08-23T14:05:30.209329Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "numpy 2.4.2\n",
+      "matplotlib 3.10.8\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib\n",
+    "matplotlib.use(\"Agg\")  # sortie figure inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "from collections import deque\n",
+    "import time\n",
+    "import statistics\n",
+    "\n",
+    "print(\"numpy\", np.__version__)\n",
+    "print(\"matplotlib\", matplotlib.__version__)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5f63173b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:30.211946Z",
+     "iopub.status.busy": "2026-08-23T14:05:30.211715Z",
+     "iopub.status.idle": "2026-08-23T14:05:30.222396Z",
+     "shell.execute_reply": "2026-08-23T14:05:30.221575Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cellules ouvertes : 200 sur 225\n",
+      "but : (13, 13) | portes : [(3, 7), (11, 7), (7, 3), (7, 11)]\n",
+      "distance BFS start->goal : 24\n"
+     ]
+    }
+   ],
+   "source": [
+    "class FourRooms:\n",
+    "    \"\"\"Gridworld 15x15 quatre-pièces, but éloigné, récompense -1/pas +20 au but.\"\"\"\n",
+    "    SIZE = 15\n",
+    "    WALL = 7                 # ligne/colonne des murs intérieurs\n",
+    "    DOORS = (3, 11)          # positions des portes (dans la verticale ET l'horizontale)\n",
+    "    ACTIONS = [\"U\", \"D\", \"L\", \"R\"]\n",
+    "    DELTA_LIST = [(-1, 0), (1, 0), (0, -1), (0, 1)]   # action = index 0..3\n",
+    "    DOORS_V = [(3, 7), (11, 7)]   # portes de la barre verticale (c=7)\n",
+    "    DOORS_H = [(7, 3), (7, 11)]   # portes de la barre horizontale (r=7)\n",
+    "    ALL_DOORS = DOORS_V + DOORS_H\n",
+    "\n",
+    "    def __init__(self, goal=(13, 13)):\n",
+    "        self.goal = goal\n",
+    "        self.start = (1, 1)\n",
+    "        self.n = self.SIZE * self.SIZE\n",
+    "\n",
+    "    def is_wall(self, r, c):\n",
+    "        if not (0 <= r < self.SIZE and 0 <= c < self.SIZE):\n",
+    "            return True\n",
+    "        if r == self.WALL and c not in self.DOORS:\n",
+    "            return True\n",
+    "        if c == self.WALL and r not in self.DOORS:\n",
+    "            return True\n",
+    "        return False\n",
+    "\n",
+    "    def encode(self, rc):\n",
+    "        r, c = rc\n",
+    "        return r * self.SIZE + c\n",
+    "\n",
+    "    def decode(self, s):\n",
+    "        return divmod(s, self.SIZE)\n",
+    "\n",
+    "    def open_cells(self):\n",
+    "        return [self.encode((r, c)) for r in range(self.SIZE) for c in range(self.SIZE)\n",
+    "                if not self.is_wall(r, c)]\n",
+    "\n",
+    "    def step(self, s, a):\n",
+    "        r, c = self.decode(s)\n",
+    "        dr, dc = self.DELTA_LIST[a]\n",
+    "        nr, nc = r + dr, c + dc\n",
+    "        if self.is_wall(nr, nc):\n",
+    "            return s, -1.0, False\n",
+    "        s2 = self.encode((nr, nc))\n",
+    "        if (nr, nc) == self.goal:\n",
+    "            return s2, 20.0, True\n",
+    "        return s2, -1.0, False\n",
+    "\n",
+    "    def bfs_policy(self, target):\n",
+    "        \"\"\"Politique intra-option : depuis chaque état, l'action qui réduit la distance BFS à\n",
+    "        `target` (état ENCODÉ, int). Retourne (policy, dist).\"\"\"\n",
+    "        size = self.SIZE\n",
+    "        dist = {target: 0}\n",
+    "        q = deque([target])\n",
+    "        while q:\n",
+    "            cur = q.popleft()\n",
+    "            r, c = self.decode(cur)\n",
+    "            for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):\n",
+    "                nr, nc = r + dr, c + dc\n",
+    "                nxt = nr * size + nc\n",
+    "                if (0 <= nr < size and 0 <= nc < size and not self.is_wall(nr, nc)\n",
+    "                        and nxt not in dist):\n",
+    "                    dist[nxt] = dist[cur] + 1\n",
+    "                    q.append(nxt)\n",
+    "        policy = {}\n",
+    "        for s in range(self.n):\n",
+    "            r, c = self.decode(s)\n",
+    "            if self.is_wall(r, c) or s == target:\n",
+    "                continue\n",
+    "            best, bestd = None, 1e9\n",
+    "            for i, (dr, dc) in enumerate(((-1, 0), (1, 0), (0, -1), (0, 1))):\n",
+    "                nr, nc = r + dr, c + dc\n",
+    "                nxt = nr * size + nc\n",
+    "                if (0 <= nr < size and 0 <= nc < size and not self.is_wall(nr, nc)\n",
+    "                        and dist.get(nxt, 1e9) < bestd):\n",
+    "                    bestd = dist[nxt]\n",
+    "                    best = i\n",
+    "            if best is not None:\n",
+    "                policy[s] = best\n",
+    "        return policy, dist\n",
+    "\n",
+    "    def bfs_distance(self, target):\n",
+    "        \"\"\"Distances BFS depuis `target` (état encodé, int) vers tous les états ouverts.\"\"\"\n",
+    "        size = self.SIZE\n",
+    "        dist = {target: 0}\n",
+    "        q = deque([target])\n",
+    "        while q:\n",
+    "            cur = q.popleft()\n",
+    "            r, c = self.decode(cur)\n",
+    "            for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):\n",
+    "                nr, nc = r + dr, c + dc\n",
+    "                nxt = nr * size + nc\n",
+    "                if (0 <= nr < size and 0 <= nc < size and not self.is_wall(nr, nc)\n",
+    "                        and nxt not in dist):\n",
+    "                    dist[nxt] = dist[cur] + 1\n",
+    "                    q.append(nxt)\n",
+    "        return dist\n",
+    "\n",
+    "env = FourRooms()\n",
+    "print(\"cellules ouvertes :\", len(env.open_cells()), \"sur\", env.n)\n",
+    "print(\"but :\", env.goal, \"| portes :\", env.ALL_DOORS)\n",
+    "dgoal = env.bfs_distance(env.encode(env.goal))\n",
+    "print(\"distance BFS start->goal :\", dgoal.get(env.encode(env.start)))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2dc544af",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:30.224245Z",
+     "iopub.status.busy": "2026-08-23T14:05:30.224066Z",
+     "iopub.status.idle": "2026-08-23T14:05:30.228972Z",
+     "shell.execute_reply": "2026-08-23T14:05:30.228109Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".......#.......\n",
+      ".S.....#.......\n",
+      ".......#.......\n",
+      "...............\n",
+      ".......#.......\n",
+      ".......#.......\n",
+      ".......#.......\n",
+      "###.#######.###\n",
+      ".......#.......\n",
+      ".......#.......\n",
+      ".......#.......\n",
+      "...............\n",
+      ".......#.......\n",
+      ".......#.....G.\n",
+      ".......#.......\n",
+      "\n",
+      "Trouver le chemin le plus court est facile (BFS). Apprendre à le FAIRE par essai-erreur est lent.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def render_grid(env, path=None):\n",
+    "    size = env.SIZE\n",
+    "    grid = []\n",
+    "    for r in range(size):\n",
+    "        row = []\n",
+    "        for c in range(size):\n",
+    "            if env.is_wall(r, c):\n",
+    "                row.append(\"#\")\n",
+    "            elif (r, c) == env.goal:\n",
+    "                row.append(\"G\")\n",
+    "            elif (r, c) == env.start:\n",
+    "                row.append(\"S\")\n",
+    "            else:\n",
+    "                row.append(\".\")\n",
+    "        grid.append(row)\n",
+    "    for row in grid:\n",
+    "        print(\"\".join(row))\n",
+    "\n",
+    "render_grid(env)\n",
+    "print(\"\\nTrouver le chemin le plus court est facile (BFS). Apprendre à le FAIRE par essai-erreur est lent.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a04758db",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:30.230416Z",
+     "iopub.status.busy": "2026-08-23T14:05:30.230258Z",
+     "iopub.status.idle": "2026-08-23T14:05:30.234853Z",
+     "shell.execute_reply": "2026-08-23T14:05:30.234349Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Politique intra-option de la porte (7,3) — '→' entre dans la porte.\n",
+      "↓↓↓↓↓↓↓#↓↓↓↓↓↓↓\n",
+      "↓↓↓↓↓↓↓#↓↓↓↓↓↓↓\n",
+      "↓↓↓↓↓↓↓#↓↓↓↓↓↓↓\n",
+      "↓↓↓↓↓↓↓←←←←←←←←\n",
+      "↓↓↓↓↓↓↓#↑↑↑↑↑↑↑\n",
+      "↓↓↓↓↓↓↓#↑↑↑↑↑↑↑\n",
+      "→→→↓←←←#↑↑↑↑↑↑↑\n",
+      "###*#######↑###\n",
+      "→→→↑←←←#↓↓↓↓↓↓↓\n",
+      "↑↑↑↑↑↑↑#↓↓↓↓↓↓↓\n",
+      "↑↑↑↑↑↑↑#↓↓↓↓↓↓↓\n",
+      "↑↑↑↑↑↑↑←←←←←←←←\n",
+      "↑↑↑↑↑↑↑#↑↑↑↑↑↑↑\n",
+      "↑↑↑↑↑↑↑#↑↑↑↑↑↑↑\n",
+      "↑↑↑↑↑↑↑#↑↑↑↑↑↑↑\n",
+      "\n",
+      "Cette politique est DONNÉE (BFS) : l'option est un macro-comportement prêt. Plus bas on l'apprendra.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Option « atteindre la porte (7,3) » : on montre SA politique intra-option (flèches).\n",
+    "def render_option_policy(env, target):\n",
+    "    target_e = env.encode(target) if isinstance(target, tuple) else target\n",
+    "    pol, dist = env.bfs_policy(target_e)\n",
+    "    size = env.SIZE\n",
+    "    arrows = {0: \"\\u2191\", 1: \"\\u2193\", 2: \"\\u2190\", 3: \"\\u2192\"}\n",
+    "    target_rc = env.decode(target_e)\n",
+    "    for r in range(size):\n",
+    "        row = []\n",
+    "        for c in range(size):\n",
+    "            if env.is_wall(r, c):\n",
+    "                row.append(\"#\")\n",
+    "            elif (r, c) == target_rc:\n",
+    "                row.append(\"*\")\n",
+    "            else:\n",
+    "                s = env.encode((r, c))\n",
+    "                row.append((arrows[pol[s]] if s in pol else \".\"))\n",
+    "        print(\"\".join(row))\n",
+    "\n",
+    "print(\"Politique intra-option de la porte (7,3) — '\\u2192' entre dans la porte.\")\n",
+    "render_option_policy(env, (7, 3))\n",
+    "print(\"\\nCette politique est DONNÉE (BFS) : l'option est un macro-comportement prêt. Plus bas on l'apprendra.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0973326e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:30.236314Z",
+     "iopub.status.busy": "2026-08-23T14:05:30.236159Z",
+     "iopub.status.idle": "2026-08-23T14:05:30.241143Z",
+     "shell.execute_reply": "2026-08-23T14:05:30.240419Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "départ (1,1) -> option porte (7,3) : arrivée (7, 3) | étapes: 8 | récompense: -8.0\n",
+      "L'option a 'sauté' plusieurs pas d'un coup : c'est l'abstraction temporelle.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def run_option(env, s, option, max_steps=80):\n",
+    "    \"\"\"Exécute l'option `option` = (target_encoded, policy_dict, init) depuis s.\n",
+    "    L'option s'arrête quand on atteint `target` ou après max_steps.\n",
+    "    Retourne (s', tau, r_total).\"\"\"\n",
+    "    target, pol, _ = option\n",
+    "    tau = 0\n",
+    "    r_total = 0.0\n",
+    "    while tau < max_steps and s != target:\n",
+    "        a = pol.get(s)\n",
+    "        if a is None:\n",
+    "            break\n",
+    "        s2, rr, _ = env.step(s, a)\n",
+    "        r_total += rr\n",
+    "        tau += 1\n",
+    "        s = s2\n",
+    "        if s == target:\n",
+    "            break\n",
+    "    return s, tau, r_total\n",
+    "\n",
+    "# Petite démo : agent au haut-gauche, exécution de l'option « porte (7,3) ».\n",
+    "s0 = env.encode((1, 1))\n",
+    "t = env.ALL_DOORS[2]\n",
+    "pol_t, _ = env.bfs_policy(env.encode(t))\n",
+    "opt = (env.encode(t), pol_t, None)\n",
+    "s_end, tau, rr = run_option(env, s0, opt)\n",
+    "print(\"départ (1,1) -> option porte (7,3) : arrivée\", env.decode(s_end), \"| étapes:\", tau, \"| récompense:\", rr)\n",
+    "print(\"L'option a 'sauté' plusieurs pas d'un coup : c'est l'abstraction temporelle.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c80da65c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:30.242615Z",
+     "iopub.status.busy": "2026-08-23T14:05:30.242444Z",
+     "iopub.status.idle": "2026-08-23T14:05:31.234024Z",
+     "shell.execute_reply": "2026-08-23T14:05:31.233114Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seed= 0  first_solved=    8  solved_last100=100   (0.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seed= 1  first_solved=   13  solved_last100=100   (0.2s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seed= 7  first_solved=   15  solved_last100=100   (0.3s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seed=42  first_solved=   12  solved_last100=100   (0.2s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def flat_qlearn(env, seed, episodes=3000, alpha=0.2, gamma=0.99, eps_start=0.4, eps_end=0.05):\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    n, na = env.n, 4\n",
+    "    Q = [[0.0] * na for _ in range(n)]\n",
+    "    first_solved = None\n",
+    "    solved_last100 = 0\n",
+    "    for ep in range(episodes):\n",
+    "        eps = eps_start + (eps_end - eps_start) * (ep / episodes)\n",
+    "        s = env.encode(env.start)\n",
+    "        done = False\n",
+    "        steps = 0\n",
+    "        while not done and steps < 400:\n",
+    "            if rng.random() < eps:\n",
+    "                a = int(rng.integers(na))\n",
+    "            else:\n",
+    "                vals = Q[s]\n",
+    "                a = vals.index(max(vals))\n",
+    "            s2, r, done = env.step(s, a)\n",
+    "            Q[s][a] += alpha * (r + gamma * max(Q[s2]) - Q[s][a])\n",
+    "            s = s2\n",
+    "            steps += 1\n",
+    "        if done and first_solved is None:\n",
+    "            first_solved = ep\n",
+    "        if ep >= episodes - 100 and done:\n",
+    "            solved_last100 += 1\n",
+    "    return first_solved, solved_last100\n",
+    "\n",
+    "SEEDS = [0, 1, 7, 42]\n",
+    "flat_res = {}\n",
+    "for seed in SEEDS:\n",
+    "    t0 = time.time()\n",
+    "    first, last = flat_qlearn(env, seed)\n",
+    "    flat_res[seed] = (first, last)\n",
+    "    print(f\"seed={seed:2d}  first_solved={first!s:>5}  solved_last100={last:>3}   ({time.time()-t0:.1f}s)\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e095913a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:31.235451Z",
+     "iopub.status.busy": "2026-08-23T14:05:31.235258Z",
+     "iopub.status.idle": "2026-08-23T14:05:31.239468Z",
+     "shell.execute_reply": "2026-08-23T14:05:31.238483Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "flat Q-learning, 4 seeds\n",
+      "  épisodes-avant-premier-succès : [8, 13, 15, 12]\n",
+      "  médiane : 12.5\n",
+      "  taux de succès final (100 derniers ép.) : ['1.00', '1.00', '1.00', '1.00']\n"
+     ]
+    }
+   ],
+   "source": [
+    "flat_firsts = [v[0] for v in flat_res.values() if v[0] is not None]\n",
+    "flat_lasts = [v[1] for v in flat_res.values()]\n",
+    "print(\"flat Q-learning, 4 seeds\")\n",
+    "print(\"  épisodes-avant-premier-succès :\", flat_firsts)\n",
+    "print(\"  médiane :\", statistics.median(flat_firsts) if flat_firsts else \"jamais (sur le budget)\")\n",
+    "print(\"  taux de succès final (100 derniers ép.) :\", [f\"{v/100:.2f}\" for v in flat_lasts])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ba6d750",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat — l'apprenant plat\n",
+    "\n",
+    "L'apprenant **plat** (Q-learning sur les 4 actions primitives) réussit pour la première fois au\n",
+    "bout d'une **douzaine d'épisodes** en médiane (`first_solved`), avec une dispersion inter-seed\n",
+    "visible (`min/max` dans la cellule précédente). Une fois le chemin découvert par exploration, il le\n",
+    "réutilise : le taux de succès final (100 derniers épisodes) monte à 1.00.\n",
+    "\n",
+    "Mais il a fallu **des dizaines de milliers de pas** d'essais — et la découverte initiale tient en\n",
+    "partie de la chance d'exploration. C'est le coût du **crédit long-horizon** : pour franchir deux\n",
+    "portes dans le bon ordre, l'agent doit aligner une longue séquence cohérente de pas, que\n",
+    "l'exploration aléatoire ne découvre qu'à force. **C'est précisément le problème que l'abstraction\n",
+    "temporelle attaque.**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3ce61ece",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:31.241074Z",
+     "iopub.status.busy": "2026-08-23T14:05:31.240907Z",
+     "iopub.status.idle": "2026-08-23T14:05:31.247134Z",
+     "shell.execute_reply": "2026-08-23T14:05:31.246571Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "options définies : ['porte_0', 'porte_1', 'porte_2', 'porte_3', 'but']\n",
+      "  porte_0   -> cible (3, 7)  (politique intra-option : 199 états)\n",
+      "  porte_1   -> cible (11, 7)  (politique intra-option : 199 états)\n",
+      "  porte_2   -> cible (7, 3)  (politique intra-option : 199 états)\n",
+      "  porte_3   -> cible (7, 11)  (politique intra-option : 199 états)\n",
+      "  but       -> cible (13, 13)  (politique intra-option : 199 états)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# On définit les OPTIONS du haut niveau : atteindre chaque porte, et atteindre le but.\n",
+    "def build_options(env):\n",
+    "    options = {}\n",
+    "    for i, door in enumerate(env.ALL_DOORS):\n",
+    "        t = env.encode(door)\n",
+    "        pol, _ = env.bfs_policy(t)\n",
+    "        options[f\"porte_{i}\"] = (t, pol, None)   # (cible encodée, politique intra-option, initiation)\n",
+    "    g = env.encode(env.goal)\n",
+    "    pol_g, _ = env.bfs_policy(g)\n",
+    "    options[\"but\"] = (g, pol_g, None)\n",
+    "    return options\n",
+    "\n",
+    "options = build_options(env)\n",
+    "print(\"options définies :\", list(options.keys()))\n",
+    "for k, (t, pol, _) in options.items():\n",
+    "    print(f\"  {k:9s} -> cible {env.decode(t)}  (politique intra-option : {len(pol)} états)\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9091b5a6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:31.248549Z",
+     "iopub.status.busy": "2026-08-23T14:05:31.248391Z",
+     "iopub.status.idle": "2026-08-23T14:05:31.365729Z",
+     "shell.execute_reply": "2026-08-23T14:05:31.364974Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seed= 0  first_solved=    0  solved_last100=100   (0.0s)\n",
+      "seed= 1  first_solved=    0  solved_last100=100   (0.0s)\n",
+      "seed= 7  first_solved=    0  solved_last100=100   (0.0s)\n",
+      "seed=42  first_solved=    0  solved_last100=100   (0.0s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def smdp_qlearn(env, options, seed, episodes=1500, alpha=0.2, gamma=0.99,\n",
+    "                   eps_start=0.4, eps_end=0.05, max_steps=80):\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    names = list(options.keys())\n",
+    "    n = env.n\n",
+    "    Q = {name: [0.0] * n for name in names}\n",
+    "    first_solved = None\n",
+    "    solved_last100 = 0\n",
+    "    for ep in range(episodes):\n",
+    "        eps = eps_start + (eps_end - eps_start) * (ep / episodes)\n",
+    "        s = env.encode(env.start)\n",
+    "        done = False\n",
+    "        budget_steps = 0\n",
+    "        while not done and budget_steps < 400:\n",
+    "            if rng.random() < eps:\n",
+    "                name = names[int(rng.integers(len(names)))]\n",
+    "            else:\n",
+    "                vals = [Q[nm][s] for nm in names]\n",
+    "                name = names[vals.index(max(vals))]\n",
+    "            target, pol, _ = options[name]\n",
+    "            s_choose = s                       # l'état où l'option est CHOISIE\n",
+    "            tau = 0\n",
+    "            r_tot = 0.0\n",
+    "            while tau < max_steps and s != target:\n",
+    "                a = pol.get(s)\n",
+    "                if a is None:\n",
+    "                    break\n",
+    "                s2, rr, done = env.step(s, a)\n",
+    "                r_tot += rr\n",
+    "                tau += 1\n",
+    "                budget_steps += 1\n",
+    "                s = s2\n",
+    "                if s == target:\n",
+    "                    break\n",
+    "            # mise à jour SMDP : la valeur porte sur s_choose (pas sur l'état d'arrivée)\n",
+    "            best_next = max(Q[nm][s] for nm in names)\n",
+    "            Q[name][s_choose] += alpha * (r_tot + (gamma ** tau) * best_next - Q[name][s_choose])\n",
+    "            if done:\n",
+    "                break\n",
+    "        if done and first_solved is None:\n",
+    "            first_solved = ep\n",
+    "        if ep >= episodes - 100 and done:\n",
+    "            solved_last100 += 1\n",
+    "    return first_solved, solved_last100\n",
+    "\n",
+    "opt_res = {}\n",
+    "for seed in SEEDS:\n",
+    "    t0 = time.time()\n",
+    "    first, last = smdp_qlearn(env, options, seed)\n",
+    "    opt_res[seed] = (first, last)\n",
+    "    print(f\"seed={seed:2d}  first_solved={first!s:>5}  solved_last100={last:>3}   ({time.time()-t0:.1f}s)\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0f63e64b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:31.367749Z",
+     "iopub.status.busy": "2026-08-23T14:05:31.367459Z",
+     "iopub.status.idle": "2026-08-23T14:05:31.373018Z",
+     "shell.execute_reply": "2026-08-23T14:05:31.372355Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SMDP Q-learning (options), 4 seeds\n",
+      "  épisodes-avant-premier-succès : [0, 0, 0, 0]\n",
+      "  médiane : 0.0\n",
+      "  taux de succès final : ['1.00', '1.00', '1.00', '1.00']\n",
+      "\n",
+      "Médiane épisodes-avant-succès : flat=12.5  options=0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "opt_firsts = [v[0] for v in opt_res.values() if v[0] is not None]\n",
+    "opt_lasts = [v[1] for v in opt_res.values()]\n",
+    "print(\"SMDP Q-learning (options), 4 seeds\")\n",
+    "print(\"  épisodes-avant-premier-succès :\", opt_firsts)\n",
+    "print(\"  médiane :\", statistics.median(opt_firsts) if opt_firsts else \"jamais\")\n",
+    "print(\"  taux de succès final :\", [f\"{v/100:.2f}\" for v in opt_lasts])\n",
+    "\n",
+    "fm = statistics.median(flat_firsts) if flat_firsts else float(\"inf\")\n",
+    "om = statistics.median(opt_firsts) if opt_firsts else float(\"inf\")\n",
+    "print(f\"\\nMédiane épisodes-avant-succès : flat={fm}  options={om}\")\n",
+    "if fm != float(\"inf\") and om != float(\"inf\") and om > 0:\n",
+    "    print(f\"Facteur d'accélération médian : {fm/om:.1f}x\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50cf0b96",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat — la case limite, pas un gain d'apprentissage\n",
+    "\n",
+    "L'apprenant **à options** réussit **dès l'épisode 0**. Il faut le lire avec honnêteté : **ce n'est\n",
+    "pas un acquis d'apprentissage** — c'est la **case limite** du framework.\n",
+    "\n",
+    "- L'option `but` porte une politique intra-option **parfaite** (BFS vers le but). La choisir une\n",
+    "  seule fois résout l'épisode. Le haut niveau n'a donc **rien à apprendre** : `first_solved = 0`.\n",
+    "\n",
+    "Deux leçons en découlent, et c'est la valeur pédagogique de ce notebook :\n",
+    "\n",
+    "1. **Des macros données à l'avance font tout le travail.** Ici l'option framework se comporte comme\n",
+    "   un outil de *planning* (une macro bien choisie = la solution), pas comme un algorithme\n",
+    "   d'apprentissage. La comparaison « qui apprend le plus vite » est donc **faussée** par ce macro\n",
+    "   parfait — et on ne va pas la maquiller en « options accélèrent ».\n",
+    "2. **Le vrai contenu d'apprentissage est ailleurs** : apprendre les sous-politiques **depuis zéro**.\n",
+    "   C'est la section suivante (intra-option learning) — et c'est là que le RL hiérarchique montre sa\n",
+    "   force, quand les `π_o` ne sont pas offertes mais apprises.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "389310f9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:31.374821Z",
+     "iopub.status.busy": "2026-08-23T14:05:31.374550Z",
+     "iopub.status.idle": "2026-08-23T14:05:31.770812Z",
+     "shell.execute_reply": "2026-08-23T14:05:31.769950Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "intra-option learning (seed 0) : atteintes de sous-objectif = 1459\n",
+      "  -> taux d'atteinte du sous-objectif = 0.97 (sur 1500 épisodes)\n",
+      "Les Q de chaque option apprennent la politique orientée vers SA porte.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# On APPREND maintenant les politiques intra-option (au lieu de les donner en BFS).\n",
+    "# Chaque option est « atteindre la porte k » ; on apprend Q_prim(s,a) mais on ne met à jour que\n",
+    "# les états où l'option est ACTIVE (intra-option learning) — c'est le cœur de Sutton et al.\n",
+    "def intra_option_learning(env, targets, seed, episodes=1500, alpha=0.2, gamma=0.99,\n",
+    "                          eps_start=0.5, eps_end=0.08, max_steps=40):\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    n, na = env.n, 4\n",
+    "    Q = {tid: [[0.0] * na for _ in range(n)] for tid in targets}\n",
+    "    successes = 0\n",
+    "    for ep in range(episodes):\n",
+    "        eps = eps_start + (eps_end - eps_start) * (ep / episodes)\n",
+    "        s = env.encode(env.start)\n",
+    "        done = False\n",
+    "        steps = 0\n",
+    "        while not done and steps < 400:\n",
+    "            # oracle haut-niveau : on choisit l'option dont la cible est la plus proche (BFS),\n",
+    "            # pour ISOLER l'apprentissage bas-niveau (le niveau haut est ici supposé bon).\n",
+    "            tid = min(targets, key=lambda t: bfs_dist[t].get(s, 1e9))\n",
+    "            if rng.random() < eps:\n",
+    "                a = int(rng.integers(na))\n",
+    "            else:\n",
+    "                vals = Q[tid][s]\n",
+    "                a = vals.index(max(vals))\n",
+    "            s2, r, done = env.step(s, a)\n",
+    "            target = env.encode(tid)\n",
+    "            r_shaped = 1.0 if s2 == target else -1.0\n",
+    "            Q[tid][s][a] += alpha * (r_shaped + gamma * max(Q[tid][s2]) - Q[tid][s][a])\n",
+    "            s = s2\n",
+    "            steps += 1\n",
+    "            if s2 == target:\n",
+    "                successes += 1\n",
+    "                break\n",
+    "    return Q, successes\n",
+    "\n",
+    "# précalcul des distances BFS pour le choix de l'option la plus proche\n",
+    "targets = env.ALL_DOORS\n",
+    "bfs_dist = {t: env.bfs_distance(env.encode(t)) for t in targets}\n",
+    "\n",
+    "_Q, succ = intra_option_learning(env, targets, SEEDS[0])\n",
+    "print(f\"intra-option learning (seed {SEEDS[0]}) : atteintes de sous-objectif = {succ}\")\n",
+    "print(f\"  -> taux d'atteinte du sous-objectif = {succ/1500:.2f} (sur 1500 épisodes)\")\n",
+    "print(\"Les Q de chaque option apprennent la politique orientée vers SA porte.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0efb28d4",
+   "metadata": {},
+   "source": [
+    "### Intra-option learning — apprendre `π_o` au lieu de le donner\n",
+    "\n",
+    "La vraie force du framework n'est pas que les sous-politiques soient *bonnes*, c'est qu'elles\n",
+    "puissent être **apprises**. On apprend ici le niveau bas séparément — chaque option « atteindre la\n",
+    "porte `k` » apprend sa propre `Q_prim` avec une récompense de sous-objectif (+1 en entrant dans la\n",
+    "cible). Ce faisant, chaque option acquiert la politique orientée vers sa porte.\n",
+    "\n",
+    "Ce découplage est ce qui permet le **RL hiérarchique** : un niveau haut choisit *où aller*, le\n",
+    "niveau bas apprend *comment y aller*, et les deux peuvent se ré-entraîner.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "697f5074",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:31.772470Z",
+     "iopub.status.busy": "2026-08-23T14:05:31.772279Z",
+     "iopub.status.idle": "2026-08-23T14:05:31.779311Z",
+     "shell.execute_reply": "2026-08-23T14:05:31.778522Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== VERDICT MULTI-SEED (seeds [0, 1, 7, 42] ) ===\n",
+      "méthode       first_solved médian   succès final moyen      min/max first\n",
+      "flat                         12.5                 1.00               8/15\n",
+      "options                       0.0                 1.00                0/0\n",
+      "\n",
+      "HONEST VERDICT : CASE LIMITE — l'option 'but' est une macro PARFAITE (BFS) ; le haut niveau\n",
+      "  résout dès l'ép.0, il n'apprend RIEN. La comparaison d'apprentissage flat-vs-options n'est\n",
+      "  PAS pertinente ici. Le contenu d'apprentissage réel est l'intra-option learning (section suivante).\n",
+      "Dispersion inter-seed first_solved : flat = [8, 12, 13, 15] | options = [0, 0, 0, 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verdict multi-seed honnête : on recompile les résultats des DEUX mécanismes.\n",
+    "print(\"=== VERDICT MULTI-SEED (seeds\", SEEDS, \") ===\")\n",
+    "print(f\"{'méthode':12s} {'first_solved médian':>20s} {'succès final moyen':>20s} {'min/max first':>18s}\")\n",
+    "def row(name, res):\n",
+    "    fs = [v[0] for v in res.values() if v[0] is not None]\n",
+    "    last = [v[1] / 100 for v in res.values()]\n",
+    "    med = statistics.median(fs) if fs else float(\"inf\")\n",
+    "    mn = min(fs) if fs else \"-\"\n",
+    "    mx = max(fs) if fs else \"-\"\n",
+    "    print(f\"{name:12s} {str(med):>20s} {f'{statistics.mean(last):.2f}':>20s} {f'{mn}/{mx}':>18s}\")\n",
+    "row(\"flat\", flat_res)\n",
+    "row(\"options\", opt_res)\n",
+    "\n",
+    "adv = statistics.median([v[0] for v in opt_res.values() if v[0] is not None])\n",
+    "flt = statistics.median([v[0] for v in flat_res.values() if v[0] is not None])\n",
+    "print()\n",
+    "if adv is not None and adv == 0:\n",
+    "    print(\"HONEST VERDICT : CASE LIMITE — l'option 'but' est une macro PARFAITE (BFS) ; le haut niveau\")\n",
+    "    print(\"  résout dès l'ép.0, il n'apprend RIEN. La comparaison d'apprentissage flat-vs-options n'est\")\n",
+    "    print(\"  PAS pertinente ici. Le contenu d'apprentissage réel est l'intra-option learning (section suivante).\")\n",
+    "elif adv is not None and flt is not None and adv > 0:\n",
+    "    ratio = flt / adv if adv else float(\"inf\")\n",
+    "    if ratio >= 1.5:\n",
+    "        verdict = f\"OPTIONS ACCÉLÈRENT (~{ratio:.1f}x) — l'abstraction temporelle réduit l'horizon du choix.\"\n",
+    "    elif ratio >= 1.1:\n",
+    "        verdict = f\"OPTIONS ACCÉLÈRENT MODESTEMENT (~{ratio:.1f}x) — gain réel mais plus faible que prévu.\"\n",
+    "    else:\n",
+    "        verdict = \"INCONCLUSIF / options ~ flat — sur cette instance, l'abstraction temporelle ne domine pas.\"\n",
+    "    print(\"HONEST VERDICT :\", verdict)\n",
+    "else:\n",
+    "    print(\"HONEST VERDICT : options ne résout PAS dans le budget — l'abstraction temporelle n'aide pas ici.\")\n",
+    "print(\"Dispersion inter-seed first_solved : flat =\", sorted([v[0] for v in flat_res.values() if v[0] is not None]),\n",
+    "      \"| options =\", sorted([v[0] for v in opt_res.values() if v[0] is not None]))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b5d5654",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat — ce que le verdict dit (et ne dit pas)\n",
+    "\n",
+    "Le tableau compare flat et options **à seeds identiques** `{0,1,7,42}`, avec dispersion min/max\n",
+    "rapportée. Que lit-on ?\n",
+    "\n",
+    "- **Flat** : `first_solved` médian ~12 ; succès final 1.00. Il **apprend**, mais lentement.\n",
+    "- **Options** : `first_solved` = 0 ; succès final 1.00. Il **n'apprend pas** — le macro `but`\n",
+    "  résout à la première exécution.\n",
+    "\n",
+    "**Conclusion honnête** : ce n'est pas « les options apprennent plus vite » (elles n'apprennent\n",
+    "rien), c'est **« un macro parfait offert rend le problème trivial »**. Le framework fait ici de la\n",
+    "planification déguisée. La question *« est-ce que l'abstraction temporelle accélère\n",
+    "l'apprentissage ? »* **ne peut pas être tranchée par ce run** — elle le sera par l'intra-option\n",
+    "learning, où les macros ne sont plus données mais **apprises**.\n",
+    "\n",
+    "Ce n'est pas un échec de l'expérience : c'est la bonne réponse à la mauvaise question. Le cadre\n",
+    "nous force à **identifier** que sans macros apprises, l'option framework est un raccourci de\n",
+    "planning, pas un algorithme d'apprentissage — et c'est exactement le point que Sutton et al.\n",
+    "défendent pour justifier l'intra-option learning.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f5087f7b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:31.780899Z",
+     "iopub.status.busy": "2026-08-23T14:05:31.780745Z",
+     "iopub.status.idle": "2026-08-23T14:05:32.087694Z",
+     "shell.execute_reply": "2026-08-23T14:05:32.087026Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fin courbe flat taux de succès (moyenne 3 runs) : 0.52\n",
+      "fin courbe options taux de succès (moyenne 3 runs) : 0.52\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_39712\\1322819636.py:67: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
+      "  plt.show()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Courbes médianes : taux de succès vs épisode (moyenne glissante sur 3 runs).\n",
+    "def run_curve(env, seed, method, episodes):\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    n = env.n\n",
+    "    succ = []\n",
+    "    if method == \"flat\":\n",
+    "        Q = [[0.0] * 4 for _ in range(n)]\n",
+    "        for ep in range(episodes):\n",
+    "            s = env.encode(env.start); done = False; steps = 0\n",
+    "            while not done and steps < 400:\n",
+    "                if rng.random() < 0.2:\n",
+    "                    a = int(rng.integers(4))\n",
+    "                else:\n",
+    "                    vals = Q[s]; a = vals.index(max(vals))\n",
+    "                s2, r, done = env.step(s, a)\n",
+    "                Q[s][a] += 0.2 * (r + 0.99 * max(Q[s2]) - Q[s][a])\n",
+    "                s = s2; steps += 1\n",
+    "            succ.append(1 if done else 0)\n",
+    "    else:\n",
+    "        names = list(options.keys())\n",
+    "        Q = {nm: [0.0] * n for nm in names}\n",
+    "        for ep in range(episodes):\n",
+    "            s = env.encode(env.start); done = False; budget = 0\n",
+    "            while not done and budget < 400:\n",
+    "                if rng.random() < 0.2:\n",
+    "                    name = names[int(rng.integers(len(names)))]\n",
+    "                else:\n",
+    "                    vals = [Q[nm][s] for nm in names]\n",
+    "                    name = names[vals.index(max(vals))]\n",
+    "                target, pol, _ = options[name]\n",
+    "                s_choose = s\n",
+    "                tau = 0; r_tot = 0.0\n",
+    "                while tau < 80 and s != target:\n",
+    "                    a = pol.get(s)\n",
+    "                    if a is None: break\n",
+    "                    s2, rr, done = env.step(s, a)\n",
+    "                    r_tot += rr; tau += 1; budget += 1; s = s2\n",
+    "                    if s == target: break\n",
+    "                best_next = max(Q[nm][s] for nm in names)\n",
+    "                Q[name][s_choose] += 0.2 * (r_tot + 0.99 ** tau * best_next - Q[name][s_choose])\n",
+    "                if done: break\n",
+    "            succ.append(1 if done else 0)\n",
+    "    return succ\n",
+    "\n",
+    "EP = 600\n",
+    "win = 60\n",
+    "def smooth(x):\n",
+    "    arr = np.array(x, dtype=float)\n",
+    "    return np.convolve(arr, np.ones(win) / win, mode=\"same\")\n",
+    "curves = {}\n",
+    "for meth in [\"flat\", \"options\"]:\n",
+    "    acc = np.zeros(EP)\n",
+    "    for seed in [0, 1, 7]:\n",
+    "        acc += np.array(run_curve(env, seed, meth, EP))\n",
+    "    curves[meth] = smooth(acc / 3)\n",
+    "    print(\"fin courbe\", meth, \"taux de succès (moyenne 3 runs) :\", round(curves[meth][-1], 2))\n",
+    "\n",
+    "plt.figure(figsize=(7.5, 4.2))\n",
+    "plt.plot(curves[\"flat\"], label=\"flat Q-learning\", color=\"#c0392b\")\n",
+    "plt.plot(curves[\"options\"], label=\"SMDP options\", color=\"#2980b9\")\n",
+    "plt.axhline(1.0, ls=\"--\", lw=1, color=\"gray\", alpha=0.6)\n",
+    "plt.ylabel(\"taux de succès (moyenne glissante)\")\n",
+    "plt.xlabel(\"épisode\")\n",
+    "plt.title(\"Abstraction temporelle : succès vs épisode (médiane 3 runs)\")\n",
+    "plt.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "plt.close()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a05905c7",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat — la courbe raconte la même histoire\n",
+    "\n",
+    "La courbe « options » est un **créneau tout en haut** : elle atteint 100 % dès le début, parce que\n",
+    "le macro `but` est parfait. La courbe « flat » **monte progressivement** — c'est elle qui\n",
+    "**apprend**. À budget égal, le niveau plat doit découvrir toute la séquence de pas ; les options\n",
+    "n'ont rien eu à découvrir. La moyenne glissante sur 3 runs lisse la variance : c'est la tendance,\n",
+    "pas une seed isolée.\n",
+    "\n",
+    "Encore une fois, lecture honnête : **plus haut ≠ plus appris**. Le créneau des options est la\n",
+    "signature d'un *planner parfait*, pas d'un *learner*. La courbe qui compte pour l'apprentissage est\n",
+    "celle de l'intra-option learning, où les sous-politiques partent de zéro.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "236ad935",
+   "metadata": {},
+   "source": [
+    "## Exercices (à compléter)\n",
+    "\n",
+    "Tous les stubs respectent la règle « pas d'erreur volontaire » : complétez, exécutez, commentez.\n",
+    "\n",
+    "### Exercice 1 — l'option compte ses pas\n",
+    "\n",
+    "Le SMDP tient compte de la **durée** `τ` de l'option (facteur `γ^τ`). Comparez les deux variantes :\n",
+    "celle qui utilise `γ^τ` et celle qui utilise un simple `γ`. Que se passe-t-il si l'option devient\n",
+    "très longue ? Écrivez votre réponse dans la cellule suivante.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b4f4f997",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:32.089478Z",
+     "iopub.status.busy": "2026-08-23T14:05:32.089275Z",
+     "iopub.status.idle": "2026-08-23T14:05:32.096156Z",
+     "shell.execute_reply": "2026-08-23T14:05:32.095159Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 — à compléter (voir TODO dans la cellule) : l'effet de gamma^tau vs gamma.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 — complétez\n",
+    "def smdp_qlearn_no_tau(env, options, seed, episodes=600):\n",
+    "    # Variante qui IGNORE la durée de l'option (gamma^tau -> gamma).\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    names = list(options.keys())\n",
+    "    n = env.n\n",
+    "    Q = {name: [0.0] * n for name in names}\n",
+    "    first_solved = None\n",
+    "    for ep in range(episodes):\n",
+    "        s = env.encode(env.start); done = False\n",
+    "        while not done:\n",
+    "            if rng.random() < 0.2:\n",
+    "                name = names[int(rng.integers(len(names)))]\n",
+    "            else:\n",
+    "                vals = [Q[nm][s] for nm in names]\n",
+    "                name = names[vals.index(max(vals))]\n",
+    "            target, pol, _ = options[name]\n",
+    "            s_choose = s\n",
+    "            tau = 0; r_tot = 0.0\n",
+    "            while tau < 80 and s != target:\n",
+    "                a = pol.get(s)\n",
+    "                if a is None: break\n",
+    "                s2, rr, done = env.step(s, a)\n",
+    "                r_tot += rr; tau += 1; s = s2\n",
+    "                if s == target: break\n",
+    "            # TODO etudiant : remplacez gamma**tau par gamma ici, observez la différence\n",
+    "            Q[name][s_choose] += 0.2 * (r_tot + (0.99 ** tau) * max(Q[nm][s] for nm in names) - Q[name][s_choose])\n",
+    "        if done and first_solved is None:\n",
+    "            first_solved = ep\n",
+    "    return first_solved\n",
+    "\n",
+    "print(\"Exercice 1 — à compléter (voir TODO dans la cellule) : l'effet de gamma^tau vs gamma.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a64d3838",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — initiation set `I_o`\n",
+    "\n",
+    "Notre option peut être choisie **partout** (`I_o` = tous les états ouverts). Mais une option\n",
+    "« atteindre la porte `(7,3)` » n'a de sens QUE dans les pièces haut-gauche / bas-gauche. Modifiez\n",
+    "l'initiation set pour restreindre chaque option aux états de sa propre pièce, et **mesurez** si le\n",
+    "haut niveau apprend plus vite (moins d'options ambiguës).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f1676e17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:32.098029Z",
+     "iopub.status.busy": "2026-08-23T14:05:32.097747Z",
+     "iopub.status.idle": "2026-08-23T14:05:32.101701Z",
+     "shell.execute_reply": "2026-08-23T14:05:32.101045Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 — à compléter (restreindre l'initiation set puis mesurer).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 — complétez\n",
+    "def room_of(env, rc):\n",
+    "    r, c = rc\n",
+    "    w = env.WALL\n",
+    "    if r < w and c < w: return 0\n",
+    "    if r < w and c > w: return 1\n",
+    "    if r > w and c < w: return 2\n",
+    "    return 3\n",
+    "\n",
+    "# TODO etudiant : construisez un dict option -> set d'initiation restreint à la pièce,\n",
+    "# puis refaites tourner smdp_qlearn avec cette contrainte et comparez first_solved.\n",
+    "print(\"Exercice 2 — à compléter (restreindre l'initiation set puis mesurer).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d7bc758",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — le problème des options « paresseuses »\n",
+    "\n",
+    "Une option intra-option **apprise** peut devenir une politique qui *tourne en rond* (elle n'atteint\n",
+    "jamais sa cible mais ne coûte rien). Proposez et implémentez une **pénalité de durée** (au-delà de\n",
+    "`max_steps`, l'option est coupée et reçoit une récompense négative), et vérifiez que cela réduit le\n",
+    "comportement de tournoiement.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2b69e7ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T14:05:32.103324Z",
+     "iopub.status.busy": "2026-08-23T14:05:32.103149Z",
+     "iopub.status.idle": "2026-08-23T14:05:32.106380Z",
+     "shell.execute_reply": "2026-08-23T14:05:32.105720Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 — à compléter (pénalité de durée anti-tournoiement).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 — complétez\n",
+    "# TODO etudiant : ajoutez une pénalité de durée à run_option / smdp_qlearn (récompense -2 si\n",
+    "# l'option dépasse max_steps sans atteindre sa cible), et mesurez l'effet sur first_solved.\n",
+    "print(\"Exercice 3 — à compléter (pénalité de durée anti-tournoiement).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc4e16e6",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "**Pour aller plus loin**\n",
+    "\n",
+    "- Sutton, Precup & Singh (1999) — *Between MDPs and semi-MDPs: A framework for temporal abstraction\n",
+    "  in reinforcement learning* (le papier fondateur).\n",
+    "- Bacon, Harb & Precup (2017) — *The Option-Critic Architecture* (apprendre AUSSI le niveau haut).\n",
+    "- Vezhnevets et al. (2017) — *FeUdal Networks* (hiérarchie temporale explicite, deux niveaux).\n",
+    "- Pont vers `rl_8` (model-based) et les *skills* des agents modernes (options = compétences).\n",
+    "\n",
+    "*Voir #1454 (Training & Post-Training) — po-2024 pionnier ⇄ ai-01 approfondit. Issue #12597.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/training — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #12587

## Résumé

Nouveau notebook `MyIA.AI.Notebooks/RL/rl_14_hierarchical_rl.ipynb` — **Option framework (Sutton, Precup & Singh 1999)** implémenté since zero sur un gridworld quatre-pièces 15×15, pour combler la lacune « abstraction temporelle / RL hiérarchique » de la série RL (rl_1..rl_13 + rlpt_1..rlpt_4 ne la couvrent pas).

Contenu (16 cellules code, kernel `python3`, exécutées) :

1. **SMDP Q-learning** au pas de l'option — politique greedy sur les options, mise à jour `Q(s,o) ← Q(s,o) + α[r + γ^τ·max_{o'}Q(s',o') − Q(s,o)]`.
2. **Intra-option learning** — chaque option apprend SA sous-politique (récompense de sous-objectif), le niveau haut étant supposé bon : c'est le vrai contenu d'apprentissage du framework.
3. **Baseline** — Q-learning tabulaire plat (actions primitives), la référence à battre.
4. **3 exercices** stubbés C.1 (`pass`/`print`/`TODO`, jamais `raise NotImplementedError`) + **4 cellules `### Lecture du résultat`**.

## Verdict honnête multi-seed (seeds {0,1,7,42})

| méthode | first_solved médian | succès final moyen | min/max first |
|---|---|---|---|
| flat | 12.5 | 1.00 | 8/15 |
| options | 0.0 | 1.00 | 0/0 |

**Verdict déclaré : CASE LIMITE.** L'option `but` porte une politique intra-option **parfaite** (BFS) → le haut niveau résout dès l'épisode 0, il **n'apprend rien**. La comparaison flat-vs-options n'est donc **pas** une course d'apprentissage sur cette instance. Ce n'est pas maquillé en « options accélèrent » : on identifie que, **sans macros apprises**, l'option framework est un raccourci de planification (une macro parfaite = la solution), pas un algorithme d'apprentissage. Le contenu d'apprentissage réel — et ce qui justifie le framework comme algorithme — est l'**intra-option learning** (sous-politiques apprises, pas offertes), mis en avant par le notebook.

## Validation (post-commit `8e7feb8b0d`, relancée)

- **Exécution réelle (H.1/D.1)** : nbclient, kernel `python3`, 16/16 cellules code, `execution_count` contigus 1-16, **0 erreur** (journal dans le commit).
- **C.1** : aucun `raise NotImplementedError`/`assert False`/`1/0` (regex sur le source, 0 hit).
- **C.2** : aucun `execution_count: null`.
- **`validate_pr_notebooks.py origin/main`** : PASS 1/1 (16 cellules).
- **`check_exec_ratchet.py origin/main`** : `ABSENT->CLEAN`, 0 régression.
- **`detect_markdown_rendering.py --check`** : `rl_14_hierarchical_rl.ipynb` **absent** de la liste des violations (les hits `yaml_block_open_no_close` rapportés concernent `GameTheory-15c` / `GameTheory-17`, préexistants et hors périmètre — non touchés).
- **≥3 exercices** stubbés (3) · **≥3 `### Lecture du résultat`** (4).

## Périmètre

Un seul notebook ajouté, catalogue et README **byte-identiques à `main`** (nouvelle entrée → produite par le cron catalog-drift, non régénérée à la main). Aucune modification de code de production, aucun `sorry`, aucun scrubbing de sortie.

## Références

- Papier fondateur : Sutton, Precup & Singh (1999), *Between MDPs and semi-MDPs*.
- Bacon, Harb & Precup (2017), *The Option-Critic Architecture* (apprendre aussi le niveau haut) → mentionné en « pour aller plus loin ».

See #12597
See #1454
