### PR TITLE
feat(slides,#10950): axe 2 tranche 7 — 3 two-cols vers motif cible (layout default + grille corps)

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -367,7 +367,7 @@ layout: section
 
 
 ---
-layout: two-cols
+layout: default
 ---
 
 
@@ -492,7 +492,7 @@ layout: two-cols
 
 
 ---
-layout: two-cols
+layout: default
 ---
 
 
@@ -505,6 +505,10 @@ layout: two-cols
 </div>
 
 
+<div class="grid grid-cols-2 gap-8">
+
+<div>
+
 **Définition CSPs**
 
 - Jusqu'ici: représentation atomique
@@ -516,9 +520,9 @@ layout: two-cols
 - Exemple
   - Coloration de carte
 
+</div>
 
-::right::
-
+<div>
 
 **Techniques**
 
@@ -537,6 +541,10 @@ layout: two-cols
 <img src="./images/img_035.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Schéma de sémantique : énoncés reliés par « a pour conséquence » et « causent » aux aspects du monde réel" />
 <img src="./images/img_036.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Illustration Winograd : ordinateur échangeant phrases et conclusions avec un humain et un robot" />
 <img src="./images/img_037.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Grammaire de la logique propositionnelle : Énoncé, ÉnoncéAtomique, priorité des opérateurs ¬, ∧, ∨, ⇒, ⇔" />
+
+</div>
+
+</div>
 
 </div>
 
@@ -566,13 +574,17 @@ layout: section
 
 
 ---
-layout: two-cols
+layout: default
 ---
 
 
 
 # Représentation et logique
 
+
+<div class="grid grid-cols-2 gap-8">
+
+<div>
 
 **Enoncés**
 
@@ -586,9 +598,9 @@ layout: two-cols
 - Propriétés
 - correction, consistance, complétude
 
+</div>
 
-::right::
-
+<div>
 
 **Bases de connaissances**
 
@@ -596,6 +608,10 @@ layout: two-cols
 
 <img src="./images/img_035.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Schéma de sémantique : énoncés reliés par « a pour conséquence » et « causent » aux aspects du monde réel" />
 <img src="./images/img_036.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Illustration Winograd : ordinateur échangeant phrases et conclusions avec un humain et un robot" />
+
+</div>
+
+</div>
 
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2023:CoursIA-2 — prev: MED/slides #12548 (c.482)

# #10950 axe 2 tranche 7 — 3 slides `two-cols` → motif cible (layout default + grille corps)

Suite du rollout axe 2 de #10950 (steer ai-01 : le plancher CONTENU de cette lane, « l'axe 2 reste valide et prioritaire », rétractation 2026-08-20). Trois slides de plus converties au motif cible défini par ai-01 (3 règles : layout `default` → filet du titre pleine largeur ; le texte reste en grille de corps `grid grid-cols-2 gap-8` **sous** le titre, jamais dans la grille ; chaque image posée comme à l'origine, classes conservées).

## Livrable

| Slide | Avant | Après | Fichier |
|---|---|---|---|
| Stratégies d'exploration (1/2) | `layout: two-cols` | `layout: default` (déjà grid-based) | `slides/S3-acculturation/slides.md` |
| Problèmes à satisfaction de contraintes | `two-cols` + `::right::` | `layout: default` + grille corps 2 colonnes | idem |
| Représentation et logique | `two-cols` + `::right::` | `layout: default` + grille corps 2 colonnes | idem |

Diff : **23 insertions / 7 deletions**, 1 fichier. `::right::` du deck : 18 → 16 (combien restent de `two-cols` : 16).

## Validation

- **slidev build SUCCESS** (`npx @slidev/cli build`, 940 modules, `✓ built in 2.45s`). Les 3 slides parsent et compilent (un déséquilibre `<div>` détecté par le build sur le slide 495 a été corrigé avant validation).
- **CRLF préservé** (L268-IRREVERSÉ) : le deck est stocké CRLF (`-text`, `.gitattributes` sans règle `eol`) ; écrit en bytes CRLF, `git diff --stat` = 23/7 (≈ les 3 slides, PAS la taille du fichier).
- **Canvas 980×552** (mesure ai-01 2026-08-20) : les images conservent leurs classes d'origine (`w-[150px]`/`w-[300px]`, `img-grid-2x2`), qui étaient déjà calibrées pour le deck ; aucun `top-[...]` nouveau introduit (pas de risque d'overlay hors 552).

## Résiduel / route

- **QA visuel** du rendu (filet pleine largeur, absence d'overflow, colonnes qui ne débordent pas) : **à router vers une lane vision** (c.399-L5 — cette lane est text-only). ai-01 ou la lane vision doit valider le rendu à l'écran avant merge (revue Hermes post-push).
- "32/38" des tranches précédentes était une métrique gonflée : ai-01 mesurait **26** `two-cols` (2026-08-18), et ~7 seulement avaient été réellement convertis. Compte honnête désormais : **16 `two-cols` restants** (26 − 10 convertis au total). Le rollout reste long (16 slides), pas « presque fini ».

Refs #10950 · #12547 (merge tempête CI) · #12548 (tranche 6)
