### PR TITLE
feat(guard,#12588): sweep-health advisory + dead references rabattage

### DIFF
--- a/.github/workflows/pr-gate-sweep-health-advisory.yml
+++ b/.github/workflows/pr-gate-sweep-health-advisory.yml
@@ -1,0 +1,82 @@
+name: PR gate sweep health advisory
+
+# Form 1 of #11860 / #12588 -- the "last successful sweep run older than 1h"
+# alert. Complement to the dashboard line (form 2, written by ai-01 each
+# /coordinate cycle), which is the floor. See #12588 for the full framing:
+# #12547 removed the event-driven `workflow_run` path of pr-gate-rerun.yml, so
+# pr-gate-stale-sweep.yml is now the ONLY mechanism that re-aggregates a stale
+# `PR gate` verdict. If that sweep's scheduler stops -- saturated runners,
+# accidental disable, plan expiry on a repo inert 60 days -- no rescue remains
+# and nothing says so. This observer exists to say so.
+#
+# Why a DEDICATED schedule and not a job inside pr-gate-stale-sweep.yml: an
+# observer sitting inside the workflow it watches dies with it. The whole
+# point is to detect "the sweep's cron stopped", so this workflow keeps its
+# own cron, offset from the sweep's 7,27,47 so the two never collide. The
+# offset does NOT remove form 1's known limit -- both still share
+# runner-saturation -- which is exactly why #12588 insists form 2 (dashboard,
+# immune to runner failure) is the floor and form 1 is the complement.
+#
+# The workflow name carries "advisory" (ADVISORY_MARKER in scripts/pr_gate.py):
+# the PR gate then treats a red version of this check as non-blocking, so it
+# can rougir to surface the alarm without appearing to block a merge.
+
+on:
+  schedule:
+    # Every 30 minutes on off-:00 minutes, offset from the sweep's 7,27,47.
+    - cron: '13,43 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read       # gh run list --workflow (Actions API)
+
+concurrency:
+  group: pr-gate-sweep-health-advisory
+  cancel-in-progress: false
+
+jobs:
+  health:
+    name: PR gate sweep health advisory
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check age of last successful sweep run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STALE_AFTER_MINUTES: "60"
+        run: |
+          set -uo pipefail
+
+          # Most recent *successful* run of the sweep, with its creation time.
+          # Filtering to conclusion=success keeps a transient failure from
+          # tripping the alarm as long as a success happened inside the window.
+          RUN=$(gh run list --workflow pr-gate-stale-sweep.yml --status success --limit 1 \
+                --json createdAt,conclusion 2>/dev/null) \
+            || { echo "[sweep-health] gh run list failed (upstream) -- skip this check"; exit 0; }
+
+          # No successful run at all -> that absence IS the state this exists
+          # to catch (history purged or scheduler dead). Fail visibly but, being
+          # advisory, non-blocking.
+          AGE_S=$(python - "$RUN" <<'PY'
+          import json, sys
+          from datetime import datetime, timezone
+          runs = json.loads(sys.argv[1])
+          if not runs:
+              print("NO_SUCCESS_IN_HISTORY", file=sys.stderr)
+              sys.exit(1)
+          created = (runs[0].get("createdAt") or "").replace("Z", "+00:00")
+          if not created:
+              print("NO_CREATED_AT", file=sys.stderr)
+              sys.exit(1)
+          age_s = (datetime.now(timezone.utc) - datetime.fromisoformat(created)).total_seconds()
+          print(int(age_s))
+          PY
+          ) || { echo "::error::[sweep-health] no successful pr-gate-stale-sweep run found -- is its schedule alive? (#11860 / #12588)"; exit 1; }
+
+          if [ "$AGE_S" -gt "$((STALE_AFTER_MINUTES * 60))" ]; then
+            echo "::error::[sweep-health] last successful pr-gate-stale-sweep run is ${AGE_S}s old (> ${STALE_AFTER_MINUTES} min). The PR gate now has NO rescue -- the dashboard line (form 2) is the floor. See #12588."
+            exit 1
+          fi
+
+          echo "[sweep-health] last successful sweep run: ${AGE_S}s ago -- OK"

--- a/.github/workflows/unique-check-run-names-guard.yml
+++ b/.github/workflows/unique-check-run-names-guard.yml
@@ -44,7 +44,7 @@ permissions:
 
 jobs:
   # Nom portant `-required` -> is_advisory() = False (pr_gate.py, motif etabli
-  # par variation-tag-guard.yml / pr-gate-rerun-drift-guard.yml).
+  # par variation-tag-guard.yml).
   check-unique-names-required:
     name: 'Require unique rendered check-run names across PR workflows (#11869)'
     runs-on: ubuntu-latest

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -1834,8 +1834,8 @@ def test_perimeter_workflow_file_exists_on_main():
     """The cable's first leg: `.github/workflows/perimeter-review-guard.yml`
     MUST exist on the working tree. A future refactor that renames or
     archives it without updating the workflow list would otherwise leave
-    the gate referencing a phantom name (which pr-gate-rerun-drift-guard
-    catches, but only as a downstream symptom)."""
+    the gate referencing a phantom name, caught only as a downstream
+    symptom."""
     wf = _repo_root() / ".github" / "workflows" / "perimeter-review-guard.yml"
     assert wf.is_file(), f"missing cable leg 1: {wf}"
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/slides #12608

## Sujet

Forme 1 de #12588 : un job **advisory** qui échoue quand le dernier run
**réussi** de `pr-gate-stale-sweep.yml` date de plus de 1 h — pour qu'un
sweep dont le scheduler est mort ne laisse plus le `PR gate` sans rescue,
silencieusement (`#12547` a retiré le chemin `workflow_run`, le sweep est
désormais l'organe unique).

### Décision de placement (à arbitrer en review)

L'issue suggère « un job advisory **dans un workflow déjà cadencé** ». J'ai
évalué les deux hôtes existants et écarté les deux, pour une raison que je
documente ici plutôt que de la taire :

- **Dans `pr-gate-stale-sweep.yml` lui-même** — auto-défait : un observateur
  dans la workflow qu'il surveille meurt avec elle, or c'est précisément
  « le sweep ne tourne plus » qu'on veut détecter. Et un job dans le sweep
  verrait toujours son propre succès récent → jamais d'alerte.
- **Dans `pr-gate-missing-advisory.yml`** (cron quotidien `47 5 * * *`) —
  cadence trop grossière pour un seuil « > 1 h » : un sweep mort le matin
  n'est signalé que le lendemain 05:47. Pauvre complément du plancher
  dashboard (forme 2, cadence 4 h).

Donc un **cron dédié** `13,43 * * * *` (off-:00, décalé du sweep `7,27,47`),
30 min. **Limite assumée, écrite dans le header** : un cron dédié partage
toujours la saturation runner (le mode de défaillance que surveille la forme 1)
— c'est exactement pourquoi #12588 pose la forme 2 (dashboard, immune runner)
comme plancher et la forme 1 comme complément. Si le coordinateur préfère
replier ce job dans la workflow quotidienne au prix d'une granularité plus
grossière, c'est une ligne à changer.

## Contenu

| Fichier | Changement |
|---|---|
| `.github/workflows/pr-gate-sweep-health-advisory.yml` | **+82** : workflow advisory, cron `13,43 * * * *`, job `PR gate sweep health advisory` qui interroge `gh run list --workflow pr-gate-stale-sweep.yml --status success --limit 1 --json createdAt,conclusion` et échoue si âge > 1 h (ou aucun succès en historique). Nom portant `advisory` → `ADVISORY_MARKER` de `scripts/pr_gate.py` le rend non-bloquant mais visiblement rouge |
| `.github/workflows/unique-check-run-names-guard.yml` | **−1** : commentaire ne référence plus `pr-gate-rerun-drift-guard.yml` (supprimé) |
| `scripts/tests/test_check_pr_perimeter.py` | **−2** : docstring ne référence plus `pr-gate-rerun-drift-guard.yml` |

## Validation

- `yaml.safe_load` OK sur les 2 workflows touchés (nouveau + modifié).
- `python -m pytest scripts/tests/test_check_pr_perimeter.py -q` → **111 passed**.
- gitleaks pre-commit → Passed.
- Aucune dépendance fonctionnelle cassée : les 2 références corrigées étaient
  en commentaire/docstring (vérifié `git grep` sur `main` avant suppression).

## Remarque grain

`MED/guard` = META. **Ne tient PAS le plancher G-VAR-1** — il est livré en
second, conformément au steer ai-01 (« prends-le en second »). Le plancher du
cycle est porté par le contenu **PR #12608** (MED/slides, axe 2 #10950).

**See #11860.**
