### PR TITLE
fix(picker): crash UnicodeEncodeError cp1252 sur titres d'issues non-ASCII (reroll 10)

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -573,6 +573,13 @@ def print_red_refusal(lane: str, backlog: dict, threshold_hours: float) -> None:
 
 
 def main() -> int:
+    # Console Windows cp1252 : un titre d'issue portant un caractere hors table
+    # (fleche U+2192 etc.) fait crasher le print en UnicodeEncodeError et perd
+    # le tirage entier. UTF-8 + replace : le titre s'affiche degrades, le
+    # tirage vit.
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--lane", required=True, help="machine:workspace, ex. myia-po-2026:CoursIA")


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2027:CoursIA — prev: none

## Resume

`pick_idle_grain.py` crashe en `UnicodeEncodeError` (cp1252) des qu'un titre d'issue du tirage porte un caractere hors table Windows-1252. Reproduit firsthand ce cycle (onboarding po-2027) : `--reroll 10` sans `PYTHONIOENCODING=utf-8` meurt au print de la ligne 657 sur le caractere U+2192 (fleche) d'un titre — le tirage entier est perdu, la lane croit a une panne de l'organe alors qu'il suffirait d'un encodage.

## Fix

Reconfiguration de `sys.stdout`/`sys.stderr` en UTF-8 (`errors="replace"`) au debut de `main()`, guard `hasattr(stream, "reconfigure")`. Un titre non affichable s'affiche degrade, le tirage vit. Le script encodait deja tous ses subprocess en `encoding="utf-8"` — ses propres prints etaient le seul chemin cp1252.

## Validation (post-fix, relancee)

```
venv/Scripts/python scripts/pick_idle_grain.py --lane myia-po-2027:CoursIA --reroll 10   # crashait avant
-> tirage complet affiche, RC=0
venv/Scripts/python scripts/pick_idle_grain.py --lane myia-po-2027:CoursIA --json
-> JSON valide, 8 picks
```

Avant le fix : traceback `UnicodeEncodeError: 'charmap' codec can't encode character '→' in position 71` (cp1252.py), exit en cours d'affichage.

## Perimetre

1 fichier modifie, 7 insertions : `scripts/pick_idle_grain.py` uniquement. Aucun changement de logique de tirage (graine deterministe intacte — le reroll 10 rend les memes candidats, simplement affichables).
