### PR TITLE
fix(guard,#12620): une ligne est une assignation ssi Python la parse comme telle

### DIFF
--- a/scripts/notebook_tools/code_in_markdown_cells_baseline.json
+++ b/scripts/notebook_tools/code_in_markdown_cells_baseline.json
@@ -1,12 +1,8 @@
 {
   "_comment": "Baseline of code-in-markdown-cells violations. Burn down, do not grow. Regenerate with: python scripts/notebook_tools/detect_code_in_markdown_cells.py --update-baseline --baseline <this file>",
-  "count": 6,
+  "count": 2,
   "hashes": [
     "14f7007ef0a0fe43",
-    "398012ebec395f7f",
-    "8c9e45215860abf1",
-    "96d844cbbdde350d",
-    "c641f44147b1260e",
-    "ed8aa4e4aa7d554e"
+    "96d844cbbdde350d"
   ]
 }

--- a/scripts/notebook_tools/detect_code_in_markdown_cells.py
+++ b/scripts/notebook_tools/detect_code_in_markdown_cells.py
@@ -54,6 +54,7 @@ Usage
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 import sys
@@ -107,14 +108,28 @@ def _line_evidence(line: str, max_len: int = 120) -> str:
 
 
 def _is_assignment(line: str) -> bool:
-    m = _PY_ASSIGN_RE.match(line.strip())
+    stripped = line.strip()
+    m = _PY_ASSIGN_RE.match(stripped)
     if not m:
         return False
     rhs = m.group("value").strip()
     # Skip walrus / equality / annotation-only (no value)
     if rhs.startswith("=") or not rhs:
         return False
-    return True
+    # The regex alone accepts any ``name = <arbitrary text>``, which French
+    # prose citing a parameter satisfies as soon as two such lines wrap
+    # consecutively ("n_est=200 obtient le meilleur Sharpe (0.600), devant" /
+    # "n_est=100 (0.564) et n_est=50 (0.568)."). Same for an indented maths
+    # block ("a = -T * s   (facteur normal)"). A line is a Python assignment
+    # iff Python parses it as one -- that is the discriminant, and it keeps
+    # real pasted code (``GLOBAL_LLM_SERVICE="OpenAI"  # comment``) flagged.
+    try:
+        tree = ast.parse(stripped)
+    except (SyntaxError, ValueError):
+        return False
+    return len(tree.body) == 1 and isinstance(
+        tree.body[0], (ast.Assign, ast.AnnAssign)
+    )
 
 
 def _finding_hash(f: dict[str, Any]) -> str:


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #12557

Closes #12620

## Le defaut

`_is_assignment` tranchait sur une regex lexicale seule :

```python
_PY_ASSIGN_RE = re.compile(r"^(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<value>\S.*)$")
```

Elle accepte **tout `nom = <texte arbitraire>`**, et `_scan_python_assignments` ne demande que **deux lignes consecutives**. De la prose francaise qui cite un parametre deux fois de suite la satisfait — c'est exactement ce qui se produit sur quatre cellules du depot.

## Mesure — deux polarites, sur `origin/main` 5240f477e, worktree propre

Scan **nu** (sans baseline), predicat **original** : **6** violations.

| # | Notebook / cellule | Ligne declenchante | Verdict |
|---|---|---|---|
| 1 | `GenAI/SemanticKernel/02-SemanticKernel-Advanced` cell#3 | `GLOBAL_LLM_SERVICE="OpenAI"  # ou AzureOpenAI, HuggingFace` | **vrai positif** |
| 2 | `Probas/Pyro_RSA_Hyperbole` cell#38 | `def approx(x, b=10.):` | **vrai positif** (regle *signature*, non touchee) |
| 3 | `QuantConnect/projects/ML-XGBoost/research` cell#15 | `n_est=200 obtient le meilleur Sharpe (0.600), devant` | faux positif — prose FR |
| 4 | `QuantConnect/projects/ML-XGBoost/research` cell#21 | `max_pos=12 obtient le meilleur Sharpe (0.585) et le meilleur MaxDD` | faux positif — prose FR |
| 5 | `IIT/ICT-Series/ICT-23-PersonaCatastrophe` cell#4 | `a = -T * s        (facteur normal)` | faux positif — maths (cusp de Thom) |
| 6 | `QuantConnect/Python/QC-Py-17-Sentiment-Analysis` cell#16 | ``compound=+0.6`. Un texte "good but risky" a `pos=0.4,`` | faux positif — tableau VADER |

Les quatre faux positifs ont ete **ouverts a la main** pour verifier qu'il s'agit bien de prose et non de code colle.

Scan **nu**, predicat **corrige** : **2** violations — exactement les deux vrais positifs, tous deux **preserves**.

Scan **avec baseline** (le gate CI reel), predicat corrige : `OK: no new code-in-markdown-cell violations.`

## Controle positif du predicat lui-meme

Le correctif est compare **ligne a ligne** contre le predicat d'origine, pas seulement mesure en agregat :

| Cas | ORIGINAL | CORRIGE | delta |
|---|---|---|---|
| `GLOBAL_LLM_SERVICE="OpenAI"` (vrai code) | True | True | — |
| `n_est=200 obtient le meilleur Sharpe (0.600), devant` | True | **False** | corrige |
| `a = -T * s        (facteur normal)` | True | **False** | corrige |
| `x: int = 5` (annotee, espaces) | False | False | — |
| `y:int=3` (annotee, compacte) | False | False | — |

Les deux dernieres lignes valent la peine d'etre lues : les assignations **annotees** etaient deja exclues **en amont** par le garde lexical (`x` puis `:` fait echouer la regex avant tout appel a l'`ast`). Le correctif **ne change donc rien** pour elles — c'etait mon attente de sonde qui etait fausse, pas le code. Aucun elargissement de perimetre.

## Le correctif

Une ligne est une assignation Python **ssi Python la parse comme telle** :

```python
try:
    tree = ast.parse(stripped)
except (SyntaxError, ValueError):
    return False
return len(tree.body) == 1 and isinstance(tree.body[0], (ast.Assign, ast.AnnAssign))
```

Le garde lexical est **conserve en amont** : l'`ast` ne fait que trancher les candidats que la regex retenait deja. C'est un resserrement, jamais un elargissement.

## Burn-down de la baseline : 6 -> 2

`code_in_markdown_cells_baseline.json` porte le commentaire **« Burn down, do not grow »**. Il etait structurellement bloque a 6 : quatre de ses entrees ne sont pas des defauts a corriger, mais de la prose que le predicat lisait mal. Le plancher reel du cliquet est **2**. Regenere via `--update-baseline`, comme le prescrit son propre `_comment`.

## Adjacence de genre — declaree, pas habillee

`prev: MED/guard #12557` porte sur **le meme fichier** : c'est une adjacence `guard`/`guard`, et je la declare plutot que de la deguiser en `tooling`. L'argument de distinction, a juger a decouvert :

- **#12557** corrigeait un defaut de **sous-application** — le detecteur n'appliquait pas son contrat « un-fenced » et accusait du code correctement clôturé.
- **Celle-ci** corrige une **sur-accusation** d'un predicat different (`assignment`, pas la gestion des fences), etablie par une mesure a deux polarites et un burn-down de cliquet.

Defauts opposes, predicats differents, evidences differentes. Le litmus LIGHT (« pourrais-je en generer une douzaine en scannant l'instance suivante ? ») est **non** : il a fallu ouvrir quatre notebooks et concevoir un discriminant. Mais l'adjacence est reelle et c'est au merge-gate de trancher, pas a moi de la faire disparaitre par choix de mot. **La prochaine PR de cette lane ne sera pas un `guard`.**

## Hors perimetre, dit explicitement

- La regle `markdown_cell_with_python_signature` n'est **pas** modifiee. Elle porte sa propre sur-accusation potentielle : un `def` **Lean** (`def isStillLife (g : Grid) : Bool := step g == g`) a ete signale par elle sur une fenetre transitoire de `main` le 2026-08-23, absorbee depuis par #12557. A traiter separement si le cas se represente hors fence.
- **Aucun notebook n'est modifie** : le correctif est cote outil. Les quatre cellules de prose constatees restent telles quelles — elles n'ont jamais eu de defaut.

## Validation

- `pytest scripts/notebook_tools/tests/test_detect_code_in_markdown_cells.py` : **10 passed**, dont `test_baseline_check_exits_zero_on_main` qui rejoue le gate CI exact.
- Les deux scans nus et le scan baseline ci-dessus tournes dans un **worktree detache sur `origin/main`**, hors de l'arbre de travail partage.
