### PR TITLE
fix(wsl): wrapper kernel lean4 gere les connection files %LOCALAPPDATA%\Temp mangles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -973,3 +973,6 @@ MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/.dialogues-build/
 # ls-files '*.gv' is empty).
 MyIA.AI.Notebooks/**/Model_[0-9]*.gv
 MyIA.AI.Notebooks/**/Model_[0-9]*.svg
+
+# WSL admin credentials (po-2027 onboarding)
+.secrets/wsl_credentials

--- a/MyIA.AI.Notebooks/GameTheory/scripts/setup_wsl_lean4.sh
+++ b/MyIA.AI.Notebooks/GameTheory/scripts/setup_wsl_lean4.sh
@@ -139,6 +139,15 @@ def convert_windows_path(path):
     # Check for mangled path (backslashes eaten by WSL shell)
     # Pattern: c:UsersjsboiAppDataRoamingjupyterruntimekernel-xxx.json
     if len(path) >= 2 and path[1] == ":":
+        # nbclient place le connection file dans %LOCALAPPDATA%\Temp (tmp*.json),
+        # pas dans le runtime dir Roaming couvert ci-dessous. Cas mangle :
+        # c:Users<u>AppDataLocalTemp<name>.json
+        m_local = re.match(
+            r"([a-zA-Z]):Users([a-zA-Z0-9_]+)AppDataLocalTemp(kernel-[a-f0-9-]+|tmp[a-z0-9_]+)\.json$",
+            path, re.IGNORECASE)
+        if m_local:
+            return "/mnt/{}/Users/{}/AppData/Local/Temp/{}.json".format(
+                m_local.group(1).lower(), m_local.group(2), m_local.group(3))
         if "Users" in path and "\\" not in path and "/" not in path[2:]:
             match = re.match(r"([a-zA-Z]):Users([a-z0-9_]+)AppDataRoaming(.+)", path, re.IGNORECASE)
             if match:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2027:CoursIA — prev: MED/tooling #12613

## Résumé

Le wrapper `~/.lean4-kernel-wrapper.py` déployé par `setup_wsl_lean4.sh` ne convertissait que le cas du connection file **manglé** de `%APPDATA%\Roaming\jupyter\runtime` (`kernel-*.json`, regex existant). **nbclient/papermill** place le connection file dans `%LOCALAPPDATA%\Temp` (`tmp*.json`) : ce cas tombait dans le fallback générique qui reconstruisait un chemin faux (`/mnt/c/UsersJesseAppDataLocalTemp...` — séparateurs perdus), et le kernel mourrait avant `kernel_info` (`RuntimeError: Kernel died before replying to kernel_info`).

Mesuré firsthand 2× lors de l'onboarding po-2027 (2026-08-23), kernels `python3-wsl` et `lean4-wsl` :

- avant : `PermissionError: ... '/mnt/c/UsersJesseAppDataLocalTemptmp4lk31f7b.json'` dans `~/.lean4-wrapper.log` → kernel mort ;
- après : exécution complète de bout en bout.

## Changement

Nouveau cas regex AVANT le bloc Roaming existant dans `convert_windows_path` : `c:Users<u>AppDataLocalTemp<kernel-*.json|tmp*.json>` → `/mnt/c/<u>/AppData/Local/Temp/<name>.json`. Le chemin reconstruit est déterministe (segments canoniques `Users/<u>/AppData/Local/Temp`, nom de fichier sans séparateur).

Inclut aussi `.gitignore` : `.secrets/wsl_credentials` (credentials admin WSL de l'onboarding po-2027, fichier gitignored — 3 lignes).

## Validation

1. **Syntaxe** : heredoc extrait du script (`awk` entre `cat > ... WRAPPER_EOF`) → `python3 -m py_compile` : `SYNTAX OK`.
2. **Conversions** (exec du seul bloc `convert_windows_path`, WSL Ubuntu 26.04, python 3.14.4) :

```
OK  mangled tmp      C:UsersJesseAppDataLocalTemptmpfweyt69w.json -> /mnt/c/Users/Jesse/AppData/Local/Temp/tmpfweyt69w.json
OK  mangled kernel   C:UsersJesseAppDataLocalTempkernel-1a2b3c.json -> /mnt/c/Users/Jesse/AppData/Local/Temp/kernel-1a2b3c.json
OK  mangled roaming  C:UsersJesseAppDataRoamingjupyterruntimekernel-abc.json -> /mnt/c/Users/Jesse/AppData/Roaming/jupyter/runtime/kernel-abc.json  (rétro-compatible)
OK  clean windows    C:\Users\Jesse\AppData\Local\Temp\tmpfweyt69w.json -> /mnt/c/Users/Jesse/AppData/Local/Temp/tmpfweyt69w.json
ALL OK
```

3. **Exécution réelle post-fix** (wrapper patché sur la machine, mêmes modifs que cette PR) :
   - `python3-wsl` : papermill Windows → kernelspec direct, 2/2 cellules, output `platform: linux`, `python: 3.14.4` ;
   - `lean4-wsl` : papermill Windows → kernelspec direct, 1/1 cellule `#eval 21 * 2`, output alectryon rendu (REPL bare-env amont rend `Unknown constant OfNat` — sémantique du kernel upstream sans prelude, hors scope : le pipeline kernel démarre, exécute, rend) ;
   - `validate_lean_setup.py` : **13/13** composants OK.

La voie canonique `wsl_papermill.py` (papermill natif WSL, sans franchir la frontière cross-OS) reste inchangée — ce fix ne rend que le kernelspec direct utilisable depuis Windows.
