### PR TITLE
fix(lean): setup_wsl_python.sh installe ipykernel (exige par kernel python3-wsl + validateur)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/setup_wsl_python.sh
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/setup_wsl_python.sh
@@ -21,7 +21,10 @@ echo "Installation des dependances Python..."
 pip install --quiet --upgrade pip
 
 # Dependances de base pour LLM
-pip install --quiet python-dotenv openai anthropic matplotlib
+# ipykernel : exige par le kernel python3-wsl ET par validate_lean_setup.py
+# (check "Packages dans venv" : import ipykernel) — sans lui le kernelspec
+# pose sur ~/.python3-wsl-venv meurt au demarrage (ModuleNotFoundError).
+pip install --quiet python-dotenv openai anthropic matplotlib ipykernel
 
 # Semantic Kernel pour orchestration multi-agents (Lean-8)
 echo "Installation de Semantic Kernel..."


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2027:CoursIA — prev: MED/tooling #12622

## Résumé

`setup_wsl_python.sh` crée le venv `~/.python3-wsl-venv` mais n'installe pas `ipykernel`, alors que :

1. le README du même répertoire le liste comme dépendance WSL (« Installées dans `~/.python3-wsl-venv/` : ipykernel… ») ;
2. `validate_lean_setup.py` l'exige (check « Packages dans venv » : `import ipykernel`) ;
3. le kernelspec `python3-wsl` pointe sur `~/.python3-wsl-venv/bin/python3` → sans ipykernel le kernel meurt au démarrage (`ModuleNotFoundError: No module named 'ipykernel'`, mesuré firsthand 2026-08-23 onboarding po-2027, traceback dans `~/.python3-wrapper.log`).

## Changement

Une ligne : `ipykernel` ajouté au `pip install` des dépendances de base (+3 lignes de commentaire pourquoi). Rien d'autre.

## Validation

- Reproduit firsthand lors de l'onboarding : venv créé par le script → kernel `python3-wsl` mort au démarrage → `pip install ipykernel` (7.3.0) dans le venv → probe papermill 2/2 cellules avec output `platform: linux` (preuve exécution WSL réelle).
- Post-fix complet : `validate_lean_setup.py` **13/13**.
