### PR TITLE
feat(pt-03,#12429): interpreter le resultat degrade 40%<hasard du DPO + guide de lecture des metriques DPOTrainer

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb
@@ -1103,6 +1103,26 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "id": "b0eeca23",
+   "source": [
+    "### Lire les métriques du DPOTrainer — la grille qui transforme les logs en diagnostic\n",
+    "\n",
+    "Le `DPOTrainer` ne se résume pas à la loss brute : chaque époque loggue des métriques dont la **direction** EST la leçon. Un `training_loss` (seul) ne dit rien si on ne sait pas où regarder — voici la grille de lecture.\n",
+    "\n",
+    "| Métrique | Direction attendue | Signal / Warning |\n",
+    "|---|---|---|\n",
+    "| `rewards/chosen` | **croît** (la policy préfère les réponses choisies) | plat → LR trop bas, rien n'apprend |\n",
+    "| `rewards/rejected` | **décroît** (les réponses rejetées se dégradent) | ne bouge pas → signal de préférence non transmis |\n",
+    "| `rewards/margins` | **le signal central** : écart chosen − rejected, doit **se creuser** | marges plates → LR trop bas / données trop mélangées |\n",
+    "| `rewards/accuracies` | fraction de paires bien classées, doit **monter** vers 1.0 | bas → beta trop haut / template cassé |\n",
+    "| `logps/chosen` / `logps/rejected` | dérive **contrôlée** vs la référence | les deux divergent ensemble → KL collapse, LR trop haut |\n",
+    "\n",
+    "**Test rapide** : si la loss reste bloquée près de `log(2) ≈ 0.693` alors que les marges ne se creusent pas, le modèle **n'apprend pas** — il faut corriger la cause (hyperparamètre, template, données), pas lire cette loss comme une mesure de progrès. C'est exactement la grille qui permet d'interpréter les 40 % mesurés à l'étape suivante."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8226e598",
    "metadata": {},
    "source": [
@@ -1226,6 +1246,24 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "id": "5837186c",
+   "source": [
+    "### Lecture du résultat dégradé : 40 % < hasard\n",
+    "\n",
+    "Le résultat mesuré (cellule 22) est **honnêtement mauvais** : PrefAcc = **40 % (4/10)**, en-dessous du hasard (50 %). Ce n'est pas un « bruit de petit dataset » à écarter — c'est une leçon.\n",
+    "\n",
+    "**Ce que les logs disent :**\n",
+    "- La loss d'entraînement est **bloquée** : 0.7078 (étape 5) → 0.6910 (étape 10) → **0.7010** (final). Elle n'a jamais quitté le voisinage de `log(2) ≈ 0.693` — le plancher d'un modèle qui **n'apprend rien** (logits uniformes, aucune préférence acquise).\n",
+    "- Les warnings `Mismatch between tokenized prompt and the start of tokenized prompt+chosen/rejected` (répétés des dizaines de fois) signalent un **template de chat incohérent** entre la façon dont `prompt` seul et `prompt+chosen` / `prompt+rejected` sont tokenisés — exactement le **Piège 4** (format / chat template incohérent) de la section 10.\n",
+    "\n",
+    "**Pourquoi 40 % < 50 % :** quand le template casse la correspondance token par token, la loss DPO (qui compare les log-probas de `chosen` vs `rejected`) est **corrompue** : le modèle est poussé par un signal incohérent, et un gradient bruité peut même **dégrader** la policy sous le hasard. Une PrefAcc < 0.5 est le symptôme terminal d'un template cassé, pas d'un modèle « faible ».\n",
+    "\n",
+    "**La leçon à retenir :** un score sous le hasard sur un petit split n'est PAS une conclusion à publier — c'est un **signal de bug**. Le diagnostic correct : vérifier que `tokenizer.chat_template` est **identique** entre entraînement et évaluation, et entre SFT (PT-02) et DPO (PT-03), avant de conclure quoi que ce soit sur l'efficacité du DPO. La règle multi-seed (≥ 4 seeds, section 11) s'applique **une fois** ce bug corrigé — pas avant."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "140a4b84",
    "metadata": {},
    "source": [
@@ -1293,7 +1331,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Bilan — DPO : passer de 4 modèles a 2 sans reward model\n",
     "\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: LIGHT/notebook-lean #12618

## Sujet

PT_03 DPO — interpréter le **résultat dégradé** (PrefAcc **40% < hasard**,
loss bloquée à ~log(2)=0.693) et ajouter le **guide de lecture des métriques
DPOTrainer** que la relecture (#12429) demandait pour transformer les logs en
diagnostic.

## Contenu

| Fichier | Changement |
|---|---|
| `MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb` | **+39/−1** (markdown-only) : 2 cellules markdown ajoutées (guide de lecture des métriques après la cellule d'entraînement, interprétation du 40% après l'évaluation) + correction cellule Bilan `---`→`***` (défaut markdown-rendering pré-existant, non-baseline) |

### Les 2 cellules ajoutées

1. **Guide de lecture des métriques DPOTrainer** — grille `métrique → direction
   attendue → warning sign` (`rewards/chosen` croît, `rewards/rejected`
   décroît, `rewards/margins` se creuse = signal central, `rewards/accuracies`
   monte, `logps` dérive contrôlée) + test rapide « loss bloquée à log(2) =
   le modèle n'apprend pas ».
2. **Lecture du résultat dégradé (40 % < hasard)** — cite les valeurs réelles
   mesurées : loss 0.7078 → 0.6910 → **0.7010** (jamais sortie de log(2)=0.693)
   + warnings `Mismatch between tokenized prompt and prompt+chosen/rejected`
   (répétés des dizaines de fois). Diagnostic : template de chat **incohérent**
   (**Piège 4**), la loss DPO est corrompue → le gradient bruité **dégrade**
   la policy sous le hasard. Un score < 0.5 est un **signal de bug**, pas une
   conclusion à publier.

## Validation

- `nbformat.validate` → **VALID** (12 cellules code, exec_counts 1-12 **intacts**).
- `detect_markdown_rendering.py` → **0 violation** (après fix du `---` Bilan).
- Pré-commit H.3 + gitleaks + block-NEW-markdown-defects → **Passed**.
- **Markdown-only** (C.2 exception) : aucune cellule code touchée, aucune re-exécution.

## Honnêteté — ce qui n'est PAS fait

**Exécution du protocole multi-seed (≥ 4 seeds)** : PAS exécutée. Elle exige un
re-training DPO GPU (Qwen3.5-0.8B, LoRA, ~10 min/seed) — hors fenêtre de ce
cycle et le notebook est déjà exécuté avec les outputs réels. Mais surtout :
exécuter le multi-seed **avant** de corriger le template cassé reviendrait à
mesurer un bug. Le point d'apprentissage de ce grain est justement de
**diagnostiquer** le 40% (template incohérent) — le multi-seed s'applique une
fois le bug corrigé (résiduel noté, à traiter en issue/PR dédiée).

## Note blocage navlink (pré-existant main)

Le check `check-navlinks` échoue sur ce PR parce que `GameTheory-03d` porte 2
navlinks morts (renames zero-pad `3b`/`3c`→`03b`/`03c`), **défaut d'état main
non-baseline** — fixé par **#12618** (ouvert, en attente merge ai-01). Ce PR
n'ajoute AUCUN navlink. Une fois #12618 mergée, re-run → vert.

**See #12429.**
