### PR TITLE
docs(readme,#12467): realigner la promesse App-12 (5 IA + AIMA) et corriger App-11 (speedup 2.78e+24x)

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -170,8 +170,8 @@ Les notebooks d'application GA (EdgeDetection, Portfolio — variants PyGAD Pyth
 | App-8 | MiniZinc | Modélisation déclarative : syntaxe MiniZinc, contraintes globales |
 | App-9 | EdgeDetection | Détection de bords par GA : PyGAD, filtres de convolution |
 | App-10 | Portfolio | Frontière de Pareto : optimisation multi-objectif de portefeuille |
-| App-11 | Picross | Nonogrammes : speedup 27Mx CP-SAT vs naïve |
-| App-12 | ConnectFour | Puissance 4 : 8 algorithmes IA (Minimax, MCTS, DQN-RL) |
+| App-11 | Picross | Nonogrammes : speedup 2.78e+24x CP-SAT vs naïve (Etoile 15x15) |
+| App-12 | ConnectFour | Puissance 4 : 5 IA au tournoi (Random, Glouton, Minimax α-β d=4/d=6, MCTS) + framework AIMA |
 | App-13 | TSP | Voyageur de commerce : SA, GA, ACO, OR-Tools routing |
 | App-14 | ConnectFour-Adversarial | Benchmark adversarial : Minimax vs Alpha-Beta vs MCTS |
 | App-15 | SportsScheduling | Calendrier sportif : contraintes TV, équité, déplacements |
@@ -258,7 +258,7 @@ Problèmes du monde réel adaptés de projets étudiants. Chaque application est
 
 | # | Notebook | Durée | Contenu | Source |
 |---|----------|-------|---------|--------|
-| 1 | [App-12-ConnectFour](Applications/Search/App-12-ConnectFour.ipynb) | ~50 min | Puissance 4 : 8 algorithmes IA (Minimax, MCTS, DQN-RL) | Projet étudiant |
+| 1 | [App-12-ConnectFour](Applications/Search/App-12-ConnectFour.ipynb) | ~50 min | Puissance 4 : 5 IA au tournoi (Random, Glouton, Minimax α-β d=4/d=6, MCTS) + framework AIMA | Projet étudiant |
 | 1b | [App-12-ConnectFour-CSharp](Applications/Search/App-12-ConnectFour-CSharp.ipynb) | ~45 min | **Jumeau C#** — Minimax + Alpha-Beta + MCTS (UCB1) + glouton + iterative deepening from-scratch, heuristique de fenêtres + tournoi round-robin, parité #4956 | Jumeau .NET |
 | 2 | [App-14-ConnectFour-Adversarial](Applications/Search/App-14-ConnectFour-Adversarial.ipynb) | ~45 min | Benchmark adversarial : Minimax, Alpha-Beta, MCTS | Projet étudiant |
 | 2b | [App-14-ConnectFour-Adversarial-CSharp](Applications/Search/App-14-ConnectFour-Adversarial-CSharp.ipynb) | ~40 min | **Jumeau C#** — Minimax + Alpha-Beta (élagage) + MCTS (UCB1) from-scratch, benchmark nœuds + tournoi round-robin, parité #4956 | Jumeau .NET |


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2027:CoursIA-2 — prev: onboarding (première PR de la lane)

## Summary

Réaligne deux lignes du README de la série Search sur le contenu réellement committé, dans l'esprit du mandat doc-honesty (« les données quantitatives tenues par le CI/la sortie committée, pas par la prose » — #9377/#8052/#9434) :

1. **App-12 ConnectFour** (l. 174 et 261) : le README promettait « 8 algorithmes IA (Minimax, MCTS, DQN-RL) ». Le notebook `Applications/Search/App-12-ConnectFour.ipynb` livre en réalité **5 IA au tournoi** (Random, Greedy, Minimax α-β d=4/d=6, MCTS) + le framework AIMA (§8), et le **source ne contient aucune occurrence de DQN** (vérifié sur la source des cellule — les seuls hits `DQN` dans le fichier JSON sont des artefacts base64 dans les images PNG). Corrigé vers « 5 IA au tournoi … + framework AIMA ». Le jumeau C# (l. 262) décrivait déjà honnêtement son contenu.

2. **App-11 Picross** (l. 173) : le README annonçait « speedup 27Mx ». La sortie committée (cellule benchmark) mesure respectivement 0.0x (Losange 5x5), 16.2x (Coeur 10x10), **2.78e+24x** (Etoile 15x15, 2^225 combinaisons), 1.25e+18x (Ancre 20x20). Corrigé vers « 2.78e+24x CP-SAT vs naïve (Etoile 15x15) » — valeur structurelle (ordre de grandeur déterminé par la taille du problème), tirée de la sortie committée, pas de la prose.

## Audit des lignes Applications (l. 170-193) — vérifié contre le disque

- **App-11** : corrigé (voir §2). Drift détecté : `27Mx` ne figure dans aucun output committé.
- **App-12** : corrigé (voir §1). Drift détecté : DQN absent du notebook, effectif réel 5.
- **App-13** (TSP) / **App-14** (ConnectFour-Adversarial) : descriptions exactes (SA/GA/ACO/OR-Tools ; Minimax vs Alpha-Beta vs MCTS) — conformes au contenu, non modifiées.
- **App-9/App-10** : descriptions qualificatives (GA/PyGAD, frontière de Pareto), aucune promesse numérique à re-vérifier.
- **App-20** : description de contenu (dénombrement du travail), pas d'effectif chiffré.
- **CATALOG-STATUS** : marqueurs byte-identiques à `main` (aucun marker généré touché — le diff ne porte que sur 3 lignes de prose).

## Note Search-7

`Search-7-MCTS-And-Beyond` (l. 200) décrit « AlphaGo-style (DQN+MCTS) » : c'est une **esquisse conceptuelle** (« Policy/Value : Fonction aleatoire — Simule un réseau de neurones… », cellule 20), pas un DQN exécuté. Hors du périmètre d'audit Applications de cette issue ; conservé tel quel (description de sujet, non une promesse d'exécution). Sujet distinct si l'on veut un DQN réellement exécuté.

## Verdict SOTA / périmètre

Pure correction documentaire (README uniquement) : aucun notebook modifié, aucune ré-exécution nécessaire (C.2 non applicable). Une seule PR, prose uniquement. Ne remplace ni App-14 (vrai benchmark adversarial) ni Search-7 (esquisse AlphaZero).

Closes #12467

🤖 Generated with [Claude Code](https://claude.com/claude-code)
