### PR TITLE
fix(notebook-tools,#9768): lire stream.text en liste dans extract_output_numbers (D1 FP massifs)

### DIFF
--- a/scripts/notebook_tools/scan_d1_d3_d4_d5.py
+++ b/scripts/notebook_tools/scan_d1_d3_d4_d5.py
@@ -322,7 +322,8 @@ def extract_output_numbers(notebook_json: str) -> tuple[int, list[float]]:
     """Parse un notebook Jupyter, retourne (n_cells_code, liste_nombres_outputs).
 
     Couvre les formats de sortie varies :
-    - outputs[*].text : str directe
+    - outputs[*].text : str OU liste de str (les sorties Jupyter "stream"
+      stockent leur texte en LISTE de str, quasi systematiquement)
     - outputs[*].data."text/plain" : str OU liste de str
     Les erreurs (output_type == "error") sont ignorees (l'erreur ne produit
     pas de nombre significatif).
@@ -334,6 +335,13 @@ def extract_output_numbers(notebook_json: str) -> tuple[int, list[float]]:
     cells = nb.get("cells", [])
     code_cells = [c for c in cells if c.get("cell_type") == "code"]
     nums: list[float] = []
+
+    def _extract_from(chunk: object) -> None:
+        """Ajoute les nombres d'un morceau de texte (str) ou de chunk (str)."""
+        for item in ([chunk] if isinstance(chunk, str) else chunk):
+            if isinstance(item, str):
+                nums.extend(_extract_numbers_from_text(item))
+
     for c in code_cells:
         outputs = c.get("outputs") or []
         for out in outputs:
@@ -341,16 +349,15 @@ def extract_output_numbers(notebook_json: str) -> tuple[int, list[float]]:
                 continue
             if out.get("output_type") == "error":
                 continue
-            if "text" in out and isinstance(out["text"], str):
-                nums.extend(_extract_numbers_from_text(out["text"]))
+            if "text" in out:
+                # nbformat stocke le texte des sorties "stream" en LISTE de str.
+                # L'ancien code ne lisait que le cas str -> 0 nombre pour tout
+                # notebook dont les valeurs vivent dans stdout -> faux D1+.
+                _extract_from(out["text"])
             elif "data" in out and isinstance(out["data"], dict):
                 t = out["data"].get("text/plain")
-                if isinstance(t, str):
-                    nums.extend(_extract_numbers_from_text(t))
-                elif isinstance(t, list):
-                    for item in t:
-                        if isinstance(item, str):
-                            nums.extend(_extract_numbers_from_text(item))
+                if isinstance(t, (str, list)):
+                    _extract_from(t)
     return len(code_cells), nums
 
 

--- a/scripts/tests/test_scan_d1_stream_text.py
+++ b/scripts/tests/test_scan_d1_stream_text.py
@@ -1,0 +1,58 @@
+"""Regression : extract_output_numbers doit lire les sorties stream en LISTE.
+
+Bug (EPIC #9768, tranche GameTheory 2026-08-23) : nbformat stocke le texte
+des sorties ``stream`` en LISTE de str, mais extract_output_numbers ne lisait
+que le cas ``str``. Tout notebook dont les valeurs numeriques vivent dans
+stdout etait donc vu comme "0 nombre dans les outputs" -> faux D1+ "notebook
+non execute ?" (37/37 verdicts D1+ de GameTheory etaient des faux positifs).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "notebook_tools"))
+
+from scan_d1_d3_d4_d5 import extract_output_numbers, extract_prose_numbers
+
+
+def _nb_stream(text_repr):
+    """Notebook minimal : 1 cellule code avec 1 sortie stream, 1 cellule md."""
+    return json.dumps({
+        "cells": [
+            {"cell_type": "code", "outputs": [
+                {"output_type": "stream", "name": "stdout", "text": text_repr},
+            ]},
+            {"cell_type": "markdown", "source": "Phi = 0.69 et Gain = 12.5"},
+        ],
+    })
+
+
+def test_stream_text_liste_est_lue():
+    _, nums = extract_output_numbers(_nb_stream(["Phi = 0.69\n", "Gain = 12.5\n"]))
+    assert 0.69 in nums
+    assert 12.5 in nums
+
+
+def test_stream_text_str_reste_lu():
+    _, nums = extract_output_numbers(_nb_stream("Phi = 0.69\n"))
+    assert 0.69 in nums
+
+
+def test_data_text_plain_liste_reste_lu():
+    nb = json.dumps({"cells": [
+        {"cell_type": "code", "outputs": [
+            {"output_type": "execute_result", "data": {"text/plain": ["42"]}},
+        ]},
+    ]})
+    _, nums = extract_output_numbers(nb)
+    assert 42.0 in nums
+
+
+def test_prose_et_stream_liste_se_repondent():
+    """Le pairing D1 : chaque nombre de prose a un candidat dans les outputs."""
+    nb = _nb_stream(["Phi = 0.69\n", "Gain = 12.5\n"])
+    prose = [v for _, v in extract_prose_numbers(nb)]
+    _, outputs = extract_output_numbers(nb)
+    for v in prose:
+        assert any(abs(v - ov) / abs(ov) <= 0.05 for ov in outputs if abs(ov) > 1e-6), v


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2027:CoursIA — prev: LIGHT/tooling #12623

## Résumé

Le détecteur D1 de `scan_d1_d3_d4_d5.py` produisait **100 % de faux positifs sur la famille GameTheory** (tranche #9768, verdicts postés : c.5387676555). Cause racine : `extract_output_numbers` ne lisait le champ `text` des sorties **que comme `str`**, alors que nbformat stocke le texte des sorties `stream` en **liste de str**.

Deux chemins de faux D1+ :
1. **« 0 nombre dans les outputs »** (16 notebooks) : notebook pourtant exécuté (GT-24 : 13/13 cellules avec outputs, 318 chiffres réels dans le stdout) → faux « notebook non execute ? » ;
2. **ratio d'orphelins gonflé** (21 notebooks) : les nombres du stdout étant droppés, le ratio dépasse artificiellement le seuil de 30 % (GT-12 : 86 % buggé → 14 % réel ; GT-16 : 82 % → 10 %).

## Changement

- `extract_output_numbers` : lecture de `outputs[*].text` en `str` **ou liste** (via helper `_extract_from`), alignée sur la branche `data."text/plain"` qui gérait déjà les deux formes.
- 4 tests régression (`scripts/tests/test_scan_d1_stream_text.py`, purs, sans git) : stream-list lu, stream-str toujours lu, data/plain-list toujours lu, pairing prose↔outputs.

## Validation (post-fix, relancée après le dernier commit)

- `pytest scripts/tests/test_scan_d1_stream_text.py` → **4 passed**.
- Re-scan complet des 77 notebooks GameTheory avec le détecteur corrigé : **62 SAIN / 8 INDETERMINE / 0 D1+** (contre 37 D1+ avant fix) — les 37 étaient tous des faux positifs du bug.
- D3/D4/D5 inchangés : 0 finding avant et après (le biais est constant d'une révision à l'autre, donc non différentiel).

## Portée

Aucun notebook modifié. Les verdicts D1+ des tranches antérieures (#9787 IIT/ICT, Probas) doivent être re-scannés avec l'instrument corrigé — signalé sur #9768.

See #9768

🤖 Generated with [Claude Code](https://claude.com/claude-code)
