### PR TITLE
fix(tooling,#12549): update_navigation.py - 3 defauts qui rendaient le script inoperant (nested link, base_dir, zero-pad)

### DIFF
--- a/scripts/tests/test_update_navigation.py
+++ b/scripts/tests/test_update_navigation.py
@@ -1,6 +1,8 @@
 """Tests for scripts/update_navigation.py — GameTheory navigation link updater."""
 
 import json
+import os
+import re
 import sys
 from pathlib import Path
 
@@ -10,8 +12,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from update_navigation import (
     STRUCTURE,
     SIDE_TRACKS,
+    _pad_track,
     create_main_navigation,
     create_side_track_navigation,
+    get_gametheory_dir,
     get_notebook_filename,
     get_side_track_filename,
     update_internal_references,
@@ -138,3 +142,34 @@ class TestStructureConsistency:
     def test_structure_has_17_entries(self):
         assert len(STRUCTURE) == 17
         assert set(STRUCTURE.keys()) == set(range(1, 18))
+
+
+# ---------------------------------------------------------------------------
+# Regressions #12549 : nested-link, base_dir, zero-pad side tracks
+# ---------------------------------------------------------------------------
+
+class TestRegressions12549:
+    def test_side_track_parent_href_is_filename_not_nested_link(self):
+        """Defaut 1 : l'URL du lien parent doit etre un nom de fichier, pas un lien markdown."""
+        nav = create_side_track_navigation("8b")
+        assert "(GameTheory-08-CombinatorialGames.ipynb)" in nav
+        # l'ancre ne doit PAS contenir de '[' dans son URL (lien imbrique)
+        assert "]([" not in nav
+
+    def test_gametheory_dir_resolves_to_notebooks(self):
+        """Defaut 2 : get_gametheory_dir() doit pointer sur MyIA.AI.Notebooks/GameTheory,
+        pas sur scripts/."""
+        d = get_gametheory_dir()
+        norm = os.path.normpath(d)
+        assert norm.endswith(os.path.join('MyIA.AI.Notebooks', 'GameTheory'))
+        assert os.path.isdir(norm), f"{norm} n'existe pas"
+
+    def test_side_track_loop_filenames_are_padded(self):
+        """Manifestation 3 : les noms construits pour la boucle side-tracks doivent
+        porter le zero-pad (#12241)."""
+        for track_id in SIDE_TRACKS:
+            for num, (name, tracks) in STRUCTURE.items():
+                for t in tracks:
+                    if t.startswith(track_id):
+                        filename = f"GameTheory-{_pad_track(t)}.ipynb"
+                        assert re.match(r'GameTheory-\d{2}', filename), filename

--- a/scripts/update_navigation.py
+++ b/scripts/update_navigation.py
@@ -87,7 +87,8 @@ def create_side_track_navigation(track_id):
     """Create navigation markdown for a side track notebook."""
     parent_num, desc = SIDE_TRACKS[track_id]
     parent_name = STRUCTURE[parent_num][0]
-    parent_link = f"[{parent_num}-{parent_name}]({get_notebook_filename(parent_num, parent_name)})"
+    # Le parent est un notebook du track principal : son href est le nom de fichier,
+    # PAS un lien markdown complet (sinon l'ancre externe imbrique un lien dans l'URL).
 
     # Find sibling side tracks
     siblings = STRUCTURE[parent_num][1]
@@ -97,7 +98,7 @@ def create_side_track_navigation(track_id):
         if s_id != track_id:
             sibling_links.append(f"[{s}](GameTheory-{_pad_track(s)}.ipynb)")
 
-    lines = [f"**Navigation** : [<< {parent_num}-{parent_name} (track principal)]({parent_link}) | [Index](README.md)"]
+    lines = [f"**Navigation** : [<< {parent_num}-{parent_name} (track principal)]({get_notebook_filename(parent_num, parent_name)}) | [Index](README.md)"]
     if sibling_links:
         lines.append(f"\n**Autres side tracks** : {' | '.join(sibling_links)}")
 
@@ -187,8 +188,15 @@ def update_internal_references(filepath, old_to_new_map):
 
     return modified
 
+def get_gametheory_dir():
+    """Repertoire GameTheory : scripts/ -> ../MyIA.AI.Notebooks/GameTheory."""
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), os.pardir,
+        'MyIA.AI.Notebooks', 'GameTheory',
+    )
+
 def main():
-    base_dir = os.path.dirname(os.path.abspath(__file__))
+    base_dir = get_gametheory_dir()
 
     # Mapping of old names to new names for reference updates
     old_to_new = {
@@ -234,7 +242,7 @@ def main():
         for num, (name, tracks) in STRUCTURE.items():
             for t in tracks:
                 if t.startswith(track_id):
-                    filename = f"GameTheory-{t}.ipynb"
+                    filename = f"GameTheory-{_pad_track(t)}.ipynb"
                     filepath = os.path.join(base_dir, filename)
                     if os.path.exists(filepath):
                         try:


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2023:CoursIA -- prev: DEEP/genai #12642

Quoi: les 2 defauts signales de scripts/update_navigation.py + une manifestation tierce du meme blocage. Avant : le script ne touchait AUCUN notebook reel (base_dir = scripts/) et produisait des ancres cassees quand il etait appelle manuellement sur un fichier.

1. **Nested link** (defaut 1 de l'issue) : create_side_track_navigation reinjectait parent_link (lien markdown COMPLET) comme URL de l'ancre externe -> href = `[8-CombinatorialGames](GameTheory-08-...ipynb)` litteral. Fix : href = nom de fichier directement.
2. **base_dir faux** (defaut 2) : main() cherchait les notebooks dans scripts/. Nouvelle get_gametheory_dir() -> ../MyIA.AI.Notebooks/GameTheory. Mesure : 17/17 notebooks principaux resolus (avant : 0).
3. **Zero-pad absent de la boucle side-tracks** (manifestation) : `GameTheory-{t}.ipynb` sans _pad_track alors que #12241 a zero-pade les fichiers -> 0 side-track trouve meme avec base_dir corrige. Fix : _pad_track(t).

Preuve: pytest scripts/tests/test_update_navigation.py -> **20 passed** (17 existants + 3 regressions nouveaux : href sans imbrication `]([`, resolution du repertoire reel assert isdir, format zero-pad des noms side). Simulation de resolution main() sur disque : 17/17 principaux, 7/9 side-tracks (les 2 manquants = derive STRUCTURE pre-existante, voir residual).

Perimetre: 2 fichiers (script + tests). Hors scope : la derive STRUCTURE revelee (16b-Lean-SocialChoice declare vs 16b-Automated-Mechanism-Design sur disque ; 16c-SocialChoice-Python declare, absent ; Csharp/15d/16d/3d non declares) -- le fix la REND VISIBLE (avant, base_dir faux masquait tout en "Missing" uniforme), correction des donnees = sujet separe.

Closes #12549

Co-Authored-By: Claude-Code <noreply@anthropic.com>