### PR TITLE
feat(lean,#12205): B3 AMD compagnon Lean — M* certifié (DSIC, IR, J*=2, optimalité) + impossibilité générale

### DIFF
--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -105,7 +105,7 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/GameTheory/game_theory_lean
       display-name: game_theory_lean
-      target-modules: "SocialChoice.Arrow,SocialChoice.Arrow_en,SocialChoice.Basic,SocialChoice.Basic_en,SocialChoice.Framework,SocialChoice.Framework_en,SocialChoice.MechanismDesign,SocialChoice.MechanismDesign_en,SocialChoice.Sen,SocialChoice.Sen_en,SocialChoice.SortedListCounting,SocialChoice.SortedListCounting_en,SocialChoice.Voting,SocialChoice.Voting_en"
+      target-modules: "SocialChoice.AMD,SocialChoice.Arrow,SocialChoice.Arrow_en,SocialChoice.Basic,SocialChoice.Basic_en,SocialChoice.Framework,SocialChoice.Framework_en,SocialChoice.MechanismDesign,SocialChoice.MechanismDesign_en,SocialChoice.Sen,SocialChoice.Sen_en,SocialChoice.SortedListCounting,SocialChoice.SortedListCounting_en,SocialChoice.Voting,SocialChoice.Voting_en"
       # allow-axioms inherits the workflow default (named standard set:
       # propext, funext, Classical.choice, Quot.*) -- same contract as conway.
       fail-on-sorry: true

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/AMD.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/AMD.lean
@@ -1,0 +1,139 @@
+/-
+  Design de mécanismes automatisé (AMD) — Compagnon Lean
+  ======================================================
+
+  Certificat formel du compagnon Lean du notebook
+  `GameTheory-16b-Automated-Mechanism-Design.ipynb` (PR #12259) : le
+  mécanisme M* produit par le générateur Python (énumération + argmax sur
+  le bien-être social, paiements nuls) est certifié par le noyau Lean
+  (`simp` énumérant le domaine fini) — DSIC, IR, J* = 2, optimalité
+  de J — au sens STANDARD
+  (point de départ = report sincère), et l'impossibilité « paiement
+  strictement positif ⇒ IR violé » est prouvée en général (miroir de
+  l'exercice 3 du notebook).
+
+  Chaîne Loi II (issue #12205, grain B3) :
+
+      spécification (Θ, O, U, J)  ->  générateur Python (hors Lean)  ->  M*
+      ->  certificat Lean `by decide`  (ce fichier)
+
+  Ce qui est certifié est le TÉMOIN, pas le chercheur : le moteur de
+  synthèse reste hors Lean (dette assumée, #12205 B1).
+
+  Domaine : 2 agents, types θ ∈ {F, T} (valeur 1 ↔ T), issue o ∈ {F, T},
+  paiements ∈ ℤ. Utilité u_i = θ_i * o(r) - p_i(r).
+
+  Référence : Sandholm, « Automated Mechanism Design: A New Initiative »
+  Référence : #12205 (chantier 2, B3), #12211 (gate distillation, satisfaite par #12259)
+-/
+
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Card
+import Mathlib.Tactic
+
+namespace SocialChoice.AMD
+
+/-! ## Domaine fini et définitions
+
+  Un profile de types est `(θ₀, θ₁) : Bool × Bool`. Un mécanisme est la
+  donnée d'une table d'issues `o : Bool × Bool → Bool` et de deux tables
+  de paiements `p₀ p₁ : Bool × Bool → ℤ`. -/
+
+/-- Type de l'agent (booléen pédagogique : T = type 1 qui veut o = T, F = type 0 indifférent). -/
+abbrev AgentType := Bool
+
+/-- Profile de types reportés par les deux agents. -/
+abbrev Profile := Bool × Bool
+
+/-- Valeur numérique d'un type (θ = 1 ↔ T), en arithmétique signée. -/
+def thetaVal (t : AgentType) : ℤ := if t then 1 else 0
+
+/-- Valeur numérique d'une issue (o = 1 ↔ T). -/
+def issueVal (o : Bool) : ℤ := if o then 1 else 0
+
+/-- Utilité de l'agent 0 : son type VRAI `t`, le profile REPORTÉ `r` détermine issue et paiement. -/
+def u0 (o : Profile → Bool) (p0 : Profile → ℤ) (t : AgentType) (r : Profile) : ℤ :=
+  thetaVal t * issueVal (o r) - p0 r
+
+/-- Utilité de l'agent 1 (symétrique). -/
+def u1 (o : Profile → Bool) (p1 : Profile → ℤ) (t : AgentType) (r : Profile) : ℤ :=
+  thetaVal t * issueVal (o r) - p1 r
+
+/-- **DSIC au sens standard** : pour tout profile vrai, rapporter son type
+    sincèrement est optimal (l'autre agent étant sincère), pour chaque agent
+    et toute déviation unilatérale. Le point de départ de la comparaison
+    est le report SINCÈRE — pas un report arbitraire (cf. réserve #12211 :
+    le vérificateur Python initial comparait depuis tout report r). -/
+def DSIC (o : Profile → Bool) (p0 p1 : Profile → ℤ) : Prop :=
+  ∀ x : AgentType × AgentType × AgentType,
+    u0 o p0 x.1 (x.1, x.2.1) ≥ u0 o p0 x.1 (x.2.2, x.2.1) ∧
+    u1 o p1 x.2.1 (x.1, x.2.1) ≥ u1 o p1 x.2.1 (x.1, x.2.2)
+
+/-- **IR au sens standard** : pour tout profile vrai, l'utilité du report
+    sincère est non négative pour chaque agent. -/
+def IR (o : Profile → Bool) (p0 p1 : Profile → ℤ) : Prop :=
+  ∀ x : AgentType × AgentType,
+    u0 o p0 x.1 (x.1, x.2) ≥ 0 ∧ u1 o p1 x.2 (x.1, x.2) ≥ 0
+
+/-- Bien-être social au profile vrai : somme des θ_i * o(profile). -/
+def J (o : Profile → Bool) (t0 t1 : AgentType) : ℤ :=
+  thetaVal t0 * issueVal (o (t0, t1)) + thetaVal t1 * issueVal (o (t0, t1))
+
+/-! ## Le mécanisme M* du générateur (GameTheory-16b, cellule 3)
+
+  Le générateur Python (true_types = [1, 1]) produit exactement :
+  `issue_table = {(0,0):0, (0,1):0, (1,0):0, (1,1):1}`, paiements nuls
+  partout. Encodage : `o* (θ₀, θ₁) = θ₀ ∧ θ₁`. -/
+
+/-- Table d'issues de M* : l'issue vaut T uniquement au profile (T, T). -/
+def o_star (r : Profile) : Bool := r.1 && r.2
+
+/-- Table de paiements de M* : paiements nuls partout. -/
+def p_star (_r : Profile) : ℤ := 0
+
+/-- **Certificat 1** : M* est DSIC au sens standard, sur tout le domaine fini. -/
+theorem amd_star_DSIC : DSIC o_star p_star p_star := by
+  simp [DSIC, u0, u1, thetaVal, issueVal, o_star, p_star]
+
+/-- **Certificat 2** : M* est IR sur tout le domaine fini. -/
+theorem amd_star_IR : IR o_star p_star p_star := by
+  simp [IR, u0, u1, thetaVal, issueVal, o_star, p_star]
+
+/-- **Certificat 3** : le bien-être social de M* au profile vrai (T, T) vaut 2
+    — la valeur J* annoncée par le générateur. -/
+theorem amd_star_J : J o_star true true = 2 := by
+  simp [J, thetaVal, issueVal, o_star]
+
+/-- **Certificat 4 (optimalité)** : aucun mécanisme du domaine ne fait mieux
+    que 2 au profile (T, T) — la valeur 2 de M* est l'optimum du bien-être
+    social sur ce domaine, ce que le générateur atteint par énumération. -/
+theorem amd_star_J_optimal (o : Profile → Bool) : J o true true ≤ 2 := by
+  unfold J thetaVal issueVal
+  split_ifs <;> norm_num
+
+/-! ## Impossibilité : paiement strictement positif ⇒ IR violé
+
+  Miroir formel de l'exercice 3 du notebook (témoin d'impossibilité par
+  énumération en Python) : ici la preuve est GÉNÉRALE — aucun mécanisme de
+  paiement strictement positif ne satisfait IR, quel que soit le nombre de
+  candidats énumérés. C'est le complémentaire constructeur/vérificateur :
+  Python montre le vide par énumération, Lean le prouve pour tout M. -/
+
+/-- **Impossibilité** : si chaque paiement est ≥ 1 en tout profile, alors IR
+    échoue — l'agent de type F a une utilité `-p ≤ -1 < 0` au profile
+    sincère (F, F), quelle que soit la table d'issues. -/
+theorem impossibility_strict_payments
+    (o : Profile → Bool) (p0 p1 : Profile → ℤ)
+    (h0 : ∀ r : Profile, 1 ≤ p0 r) (_h1 : ∀ r : Profile, 1 ≤ p1 r) :
+    ¬ IR o p0 p1 := by
+  intro hir
+  obtain ⟨hu0, _⟩ := hir (false, false)
+  have hp := h0 (false, false)
+  have hu_reduced : (0 : ℤ) - p0 (false, false) ≥ 0 := by
+    have : u0 o p0 false (false, false) = 0 - p0 (false, false) := by
+      simp [u0, thetaVal, issueVal]
+    rw [this] at hu0
+    exact hu0
+  omega
+
+end SocialChoice.AMD

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/CERTIFIED.txt
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/CERTIFIED.txt
@@ -12,7 +12,8 @@
 # Instrument: count_code_sorry.scan_file (comment-stripped — a `sorry` inside
 # a docstring does not count; a real tactic `sorry` fails the gate).
 
-# FR modules (7)
+# FR modules (8)
+AMD.lean
 Arrow.lean
 Basic.lean
 Framework.lean


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: MED/notebook-python #12637

See #12205

## Summary

Grain **B3** du chantier 2 (Loi II : passer du vérificateur au constructeur) — **le compagnon Lean conditionnel que #12259 n'avait pas livré**. La gate #12211 (distillation Sandholm) est satisfaite depuis #12259 (merged 2026-08-22T12:57Z), B3 est débloqué.

Nouveau module `game_theory_lean/SocialChoice/AMD.lean` (namespace `SocialChoice.AMD`) :

1. **Domaine fini** : 2 agents, types `Bool`, issues `Bool`, paiements `ℤ` ; utilité `u_i = θ_i·o(r) − p_i(r)` en arithmétique signée (aucun piège de soustraction `Nat`).
2. **Définitions au sens STANDARD** : `DSIC` (le point de départ de la comparaison est le report **sincère**, l'autre agent étant sincère) et `IR` (utilité du report sincère ≥ 0). La réserve documentée dans l'analyse d'acceptance de #12211 pointait que le vérificateur Python initial comparait depuis **tout** report `r` (définition sur-durcie) — ces définitions Lean tranchent le sens de référence.
3. **M\* littéral, celui du générateur Python** (GameTheory-16b cellule 3, `true_types = [1,1]`) : `o*(θ₀,θ₁) = θ₀ ∧ θ₁`, paiements nuls. Certificats kernel :
   - `amd_star_DSIC` : M\* est DSIC sur tout le domaine (8 cas × 2 agents) ;
   - `amd_star_IR` : M\* est IR sur tout le domaine ;
   - `amd_star_J` : `J o* (T,T) = 2` — la valeur J\* annoncée par le générateur ;
   - `amd_star_J_optimal` : ∀ table d'issues `o`, `J o (T,T) ≤ 2` — l'optimum que l'énumération Python atteint est bien l'optimum du domaine (preuve structurelle : `split_ifs` + `norm_num`, aucun enumérateur caché).
4. **Impossibilité GÉNÉRALE** `impossibility_strict_payments` : si chaque paiement est ≥ 1 en tout profile, alors ¬IR — miroir formel de l'exercice 3 du notebook (qui montre le vide par énumération Python) : ici la preuve vaut pour **tout** mécanisme, sans énumération (réduction au profile (F,F) + `omega`).

Chaîne Loi II livrée : `spécification -> générateur Python (hors Lean) -> M* -> certificat Lean`. Ce qui est certifié est le **témoin**, pas le chercheur (dette assumée, #12205 B1).

## Validation

- **Compilation `lean` v4.32.1 exit 0** contre les oleans Mathlib du manifeste (SHA `520045ab`, réutilisées du lake knotbuild, toolchain pinné via `elan run`) — log :
  ```
  knotbuild Mathlib: 520045ab | game_theory_lean Mathlib: 520045ab
  COMPILE_RC=0
  ```
- **`count_code_sorry`** : AMD.lean **0 sorry** (grep) ; game_theory_lean global `code_sorry 0` inchangé.
- **B.3 câblé dans la même PR** : `AMD.lean` ajouté à `SocialChoice/CERTIFIED.txt` (FR modules → 8) et à `target-modules` du job `fail-on-sorry` de `lean-social-choice.yml`. Gate local :
  ```
  python scripts/lean/check_certified_sorry.py --lake MyIA.AI.Notebooks/GameTheory/game_theory_lean --subdir SocialChoice --json
  → "ok": true, "failures": [] — AMD.lean certified, code_sorry 0
  ```
- 0 `native_decide`, 0 `axiom`, 0 `Classical.choice` (preuves : `simp` sur domaine fini énuméré + `split_ifs`/`norm_num` + `omega`).

## Scope

- `MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/AMD.lean` (nouveau, +139)
- `MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/CERTIFIED.txt` (+1 entrée, compteur 7→8)
- `.github/workflows/lean-social-choice.yml` (target-modules +1 module)

## Suivi (hors scope, documentés)

- **Tranche 2 (réserve #12211)** : calibrer le vérificateur Python de 16b sur la définition standard (report sincère comme point de départ) + prose sur la divergence — les définitions Lean de ce module servent de référence. Notebook à re-exécuter (papermill) — grain séparé.
- **Sibling `_en`** : non livré (traduction optionnelle par la convention #4980 pour ce lake ; FR-first).
- Claim scopé posé sur #12205 avant édition (`check_lane_claim` CLEAR PATH_SCOPED, disjoint du claim po-2026 sur `Lean-16b-*` SymbolicAI / `Translateur*.lean`).
