### PR TITLE
fix(slides,#10950): tranche 8 axe 2 — convert 3 two-cols to grid-cols-2 (FOL, Agir dans l'incertitude, Probabilité)

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -642,13 +642,14 @@ layout: default
 <img src="./images/img_040.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Réseau sémantique : Mammals, Persons, Mary, John reliés par liens d'héritage et propriétés" />
 </div>
 ---
-layout: two-cols
----
 
 
 
 # Logique du premier ordre (FOL)
 
+
+<div class="grid grid-cols-2 gap-5 -mt-2">
+<div>
 
 - Modélise
   - Objets, Propriétés
@@ -660,8 +661,8 @@ layout: two-cols
   - de base de données
 
 
-::right::
-
+</div>
+<div>
 
 **Exemple: investigation**
 
@@ -672,8 +673,8 @@ layout: two-cols
 
 <img src="./images/img_040.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Réseau sémantique : Mammals, Persons, Mary, John reliés par liens d'héritage et propriétés" />
 
-
-
+</div>
+</div>
 ---
 layout: two-cols
 ---
@@ -867,13 +868,14 @@ layout: section
 
 
 ---
-layout: two-cols
----
 
 
 
 # Agir dans l'incertitude
 
+
+<div class="grid grid-cols-2 gap-5 -mt-2">
+<div>
 
 **Le monde est incertain**
 
@@ -887,8 +889,8 @@ layout: two-cols
   - Inférence incomplète
 
 
-::right::
-
+</div>
+<div>
 
 **Agent fondé sur l'utilité**
 
@@ -899,17 +901,19 @@ layout: two-cols
 
 <img src="./images/img_051.png" class="w-[350px] max-w-full max-h-[300px] object-contain" alt="Nuage de points en croix sur un repère f(x) en fonction de x (données à ajuster)" />
 
+</div>
+</div>
 
 
-
----
-layout: two-cols
 ---
 
 
 
 # Probabilité
 
+
+<div class="grid grid-cols-2 gap-5 -mt-2">
+<div>
 
 **Fondements**
 
@@ -923,8 +927,8 @@ layout: two-cols
 - P(Cause | Effet) = P(Effet | Cause) x P(Cause) / P(Effet)
 
 
-::right::
-
+</div>
+<div>
 
 **Programmation probabiliste**
 
@@ -940,8 +944,8 @@ layout: two-cols
 <img src="./images/img_054.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Courbe gaussienne centrée en 0, largeur σ (distribution normale)" />
 
 </div>
-
-
+</div>
+</div>
 
 ---
 layout: two-cols


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-python #12640

## Sujet

#10950 (axe 2, S3-acculturation) — tranche 7 : convertir 3 slides
`layout: two-cols` (Marp legacy) vers le motif cible CSS grid utilisé depuis les
tranches 5/6.

## Changement

| Fichier | Changement |
|---|---|
| `slides/S3-acculturation/slides.md` | +21 / −17 : 3 slides converties |

### Slides converties

1. **Logique du premier ordre (FOL)** — grille 2 colonnes (définition vs exemple
   investigation + img_040).
2. **Agir dans l'incertitude** — grille 2 colonnes (monde incertain vs agent fondé
   sur l'utilité + img_051).
3. **Probabilité** — grille 2 colonnes (fondements/Bayes vs programmation
   probabiliste + img-grid 052/053/054).

### Motif appliqué (identique tranches 5/6)

```
layout: two-cols  →  (supprimé : frontmatter Marp)
::right::         →  </div><div>
corps             →  <div class="grid grid-cols-2 gap-5 -mt-2"><div>…</div><div>…</div></div>
```

## Validation

- `check_slidev_structure.py slides/S3-acculturation/slides.md` → **0 constats**.
- `slidev build S3-acculturation/slides.md` (local) → **SUCCESS (15,49 s)** ; les
  titres convertis (`Logique du premier ordre`, `Agir dans l'incertitude`) et la
  classe `grid grid-cols-2 gap-5 -mt-2` sont présents dans `dist/assets/`.
- **CRLF préservé** : 2502 LF, 2502 CRLF, 0 lone LF (c.482-L268).
- Diff borné aux 3 slides (38 lignes), aucun `--no-verify`, gitleaks Passed.
- Contenu par colonne inchangé (mêmes blocs, mêmes images) — seule la brique de
  layout change. Le QA visuel final (rendu Slidev) est confirmé par
  `slides-build-advisory` (CI) au push, comme les tranches 5/6.

## Hors-périmètre

- Les 13 slides `two-cols` restantes (dont les 3 à header-grid imbriqué
  `Application: argumentation`, `Théorie des jeux`) restent en deux-cols —
  tranches suivantes.
- Le deck `slides.marp.md` n'est pas touché (source de référence, hors axe 2).

**See #10950.**

> **Note séquence** : #12608 (mergée, `layout: default` + `gap-8`) est la tranche 7 de l'axe 2 ; la présente est la **tranche 8** (motif `gap-5 -mt-2` des tranches 5/6, slides FOL/Agir/Prob, distinctes de celles de #12608 — vérifié sur origin/main : les 3 y sont encore `two-cols`).
