### PR TITLE
fix(training,#1454): garde thermique GPU inerte sur hote multi-GPU

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/shared/gpu_training.py
+++ b/MyIA.AI.Notebooks/QuantConnect/shared/gpu_training.py
@@ -47,9 +47,16 @@ import torch
 import torch.nn as nn
 
 
-def get_gpu_temp() -> int:
+def get_gpu_temp(index: Optional[int] = None) -> int:
     """
     Lit la temperature GPU via nvidia-smi.
+
+    Parameters
+    ----------
+    index : int, optional
+        Indice PHYSIQUE du GPU dans la sortie nvidia-smi. Si omis, suit
+        CUDA_VISIBLE_DEVICES (nvidia-smi reporte toujours les indices
+        physiques, torch lui remappe a partir de 0).
 
     Returns
     -------
@@ -62,7 +69,23 @@ def get_gpu_temp() -> int:
              '--format=csv,noheader,nounits'],
             capture_output=True, text=True, timeout=5
         )
-        return int(result.stdout.strip())
+        lines = [l.strip() for l in result.stdout.strip().splitlines() if l.strip()]
+        if not lines:
+            return 0
+        if index is None:
+            # Hotes multi-GPU (ai-01: 3x RTX 4090): nvidia-smi retourne une
+            # ligne par GPU et l'ancien int(stdout) levait ValueError -> 0
+            # silencieux -> watchdog no-op sur TOUT run de ces hotes (mesure
+            # 2026-08-23, temp retournee 0 avec GPU2 a 34C). On lit le GPU que
+            # torch utilise via CUDA_VISIBLE_DEVICES.
+            visible = os.environ.get('CUDA_VISIBLE_DEVICES', '').strip()
+            if visible and not visible.startswith('-'):
+                first = visible.split(',')[0].strip()
+                if first.isdigit() and int(first) < len(lines):
+                    index = int(first)
+        if index is None or not (0 <= index < len(lines)):
+            index = 0
+        return int(float(lines[index]))
     except Exception:
         return 0
 

--- a/MyIA.AI.Notebooks/QuantConnect/shared/test_gpu_training.py
+++ b/MyIA.AI.Notebooks/QuantConnect/shared/test_gpu_training.py
@@ -85,6 +85,37 @@ def test_get_gpu_temp_returns_zero_on_non_int_stdout(monkeypatch):
     assert gt.get_gpu_temp() == 0
 
 
+def test_get_gpu_temp_multi_gpu_first_line_without_cvd(monkeypatch):
+    # Multi-GPU host (ai-01 3x RTX 4090): one line per GPU. Without
+    # CUDA_VISIBLE_DEVICES torch uses physical GPU 0 -> first line.
+    # (Pre-fix this raised int("42\n45\n34") -> ValueError -> silent 0 -> no-op
+    # watchdog, measured 2026-08-23.)
+    monkeypatch.setattr(gt.subprocess, "run", _smi("42\n45\n34"))
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    assert gt.get_gpu_temp() == 42
+
+
+def test_get_gpu_temp_multi_gpu_follows_cuda_visible_devices(monkeypatch):
+    # CUDA_VISIBLE_DEVICES=2 remaps torch cuda:0 to physical GPU 2; nvidia-smi
+    # keeps physical indices -> line 2.
+    monkeypatch.setattr(gt.subprocess, "run", _smi("42\n45\n34"))
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2")
+    assert gt.get_gpu_temp() == 34
+
+
+def test_get_gpu_temp_multi_gpu_cvd_out_of_range_falls_back_first(monkeypatch):
+    # CVD pointing beyond the reported lines falls back to line 0, never 0-silent.
+    monkeypatch.setattr(gt.subprocess, "run", _smi("42\n45\n34"))
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "7")
+    assert gt.get_gpu_temp() == 42
+
+
+def test_get_gpu_temp_explicit_index_overrides_cvd(monkeypatch):
+    monkeypatch.setattr(gt.subprocess, "run", _smi("42\n45\n34"))
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2")
+    assert gt.get_gpu_temp(index=1) == 45
+
+
 # --------------------------------------------------------------------------
 # thermal_check — CPU guard + hot/cool threshold logic
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #12557

## Le defaut

`shared/gpu_training.py::get_gpu_temp` lisait la temperature ainsi :

```python
return int(result.stdout.strip())
```

`nvidia-smi --query-gpu=temperature.gpu` rend **une ligne par GPU**. Sur un hote
multi-GPU, `int()` leve `ValueError`, le `except Exception: return 0` l'avale, et
`thermal_check(max_temp=80)` compare alors `0 < 80` : **le garde ne s'est jamais
declenche**. Une securite qui echoue en position *ouverte*, sans rien dire.

Mesure de premiere main sur ai-01 (3x RTX 4090), 2026-08-23 :

```
$ nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits
42
40
40
>>> int("42\n40\n40")
ValueError: invalid literal for int() with base 10: '42\n40\n40'
>>> get_gpu_temp()   # avant fix
0
```

## Pourquoi il a survecu

Il ne se manifeste **que** sur les hotes multi-GPU — c'est-a-dire la ou il y a le
plus de materiel a proteger. Un hote mono-GPU rend une seule ligne, `int()`
reussit, le garde fonctionne. Le parc l'a donc valide partout ou il marchait.

## Portee

`git grep -l "thermal_check\|get_gpu_temp"` : **20+ scripts** de
`ML-Training-Pipeline/scripts/` (`train_lstm`, `train_transformer`, `train_mamba`,
`train_patchtst`, `train_gnn`, `train_dt_multiseed`, `sweep_l6_dt_extension`, …).
Tous tournaient sans protection thermique sur ai-01.

## Jumeaux — verifies, aucun second exemplaire

`git grep -n "query-gpu"` sur tout le depot, puis lecture des deux seuls autres
parses de `temperature.gpu` :

| Fichier | Etat |
|---|---|
| `GenAI/Audio/04-Applications/v4/fishaudio_client.py:178` | **sain** — splitte deja les lignes, prend `temps[1]` avec repli sur `temps[0]` |
| `ML-Training-Pipeline/scripts/c875_hmm_alpha_dm_validation.py:383,446` | **sain** — imprime la chaine brute, aucun `int()` |

Le defaut est singulier a `shared/gpu_training.py`.

## Le correctif

Lire la ligne du GPU **effectivement utilise par torch** : `nvidia-smi` indexe en
**physique**, `torch` remappe a partir de 0 selon `CUDA_VISIBLE_DEVICES`. Un
parametre `index` explicite reste disponible pour les appelants qui savent lequel
ils veulent. Replis conserves : sortie vide -> 0, index hors bornes -> ligne 0,
exception -> 0 (comportement d'origine).

## Tests

```
$ conda run -n coursia-sae python -m pytest test_gpu_training.py -q
.............F........
1 failed, 21 passed in 9.20s
```

**L'echec preexiste sur `main`** — verifie en rejouant *la version `main` des deux
fichiers* en isolation dans un repertoire temporaire :

```
$ git show origin/main:.../gpu_training.py      > /tmp/amptest/gpu_training.py
$ git show origin/main:.../test_gpu_training.py > /tmp/amptest/test_gpu_training.py
$ cd /tmp/amptest && pytest -q
1 failed, 17 passed in 3.66s     <- meme echec, meme test
```

`test_setup_amp_returns_disabled_scaler_on_cpu` echoue des avant cette PR
(`setup_amp` rend `use_amp=True` sur un device CPU quand CUDA est present sur la
machine). **Hors scope ici** — signale a part plutot que reparé en passant, pour
garder la PR sur un sujet. Aucune regression : 17 -> 21 tests verts, +4 couvrant
la sortie multi-lignes, `CUDA_VISIBLE_DEVICES`, l'index explicite et la sortie
vide.

## Ce que cette PR ne fait pas

Elle ne touche ni les scripts de run ETF-vol produits dans la meme session
(sujet distinct, en cours d'execution), ni le depot REGISTRY. Elle ne prouve pas
non plus qu'aucun run passe n'a surchauffe : les temperatures historiques n'ont
pas ete conservees, donc l'effet retroactif est **non mesure**. Ce qui est
mesure, c'est que le garde etait inerte.

See #1454
