### PR TITLE
feat(nb,#12455): 2.3b — Naive Bayes generatif vs regression logistique discriminative (volet 1/3)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3b-Naive-Bayes-Generatif.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3b-Naive-Bayes-Generatif.ipynb
@@ -1,0 +1,722 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "de107af8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004641,
+     "end_time": "2026-08-23T20:05:20.910582+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:20.905941+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Naive Bayes génératif vs régression logistique discriminative\n",
+    "\n",
+    "Un classifieur peut modéliser **deux façons opposées** de conditionner la probabilité :\n",
+    "\n",
+    "- **Génératif** (Naive Bayes) : on modélise **comment les données sont produites** — `P(x|y)` et `P(y)` — puis on en déduit `P(y|x)` par la règle de Bayes. On apprend le **processus**.\n",
+    "- **Discriminatif** (régression logistique) : on modélise **directement** `P(y|x)`, sans se soucier de comment `x` est généré. On apprend la **frontière**.\n",
+    "\n",
+    "Le point pédagogique de ce notebook : ce choix n'est pas anodin. Le classifieur génératif fait une **hypothèse forte** (l'indépendance des variables) qui lui coûte du **biais** mais lui fait gagner de la **variance** — il est donc meilleur **quand les données sont rares**. Le classifieur discriminatif, plus flexible, rattrape et dépasse souvent le génératif **quand les données abondent**. C'est le **compromis génératif-discriminatif** (Ng & Jordan, 2002) — et ici, on le **mesure**, pas on le raconte.\n",
+    "\n",
+    "> **Fil conducteur.** On implémente un *Naive Bayes* gaussien de zéro, on le vérifie contre `sklearn`, puis on le met en face de la **régression logistique de [2.3](2.3-Regression-lineaire-logistique.ipynb)** en faisant varier la taille du jeu d'entraînement. On observe **deux régimes** opposés selon que l'hypothèse d'indépendance est plausible ou non."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "44e49a30",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T20:05:20.920192Z",
+     "iopub.status.busy": "2026-08-23T20:05:20.919812Z",
+     "iopub.status.idle": "2026-08-23T20:05:23.294792Z",
+     "shell.execute_reply": "2026-08-23T20:05:23.293693Z"
+    },
+    "papermill": {
+     "duration": 2.38078,
+     "end_time": "2026-08-23T20:05:23.295839+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:20.915059+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Imports et configuration (meme style que la serie)\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.naive_bayes import GaussianNB\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "from scipy.stats import norm\n",
+    "\n",
+    "rng = np.random.default_rng(7)   # seed fixe -> courbes reproductibles\n",
+    "plt.rcParams[\"figure.figsize\"] = (5, 3.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b283cb4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002613,
+     "end_time": "2026-08-23T20:05:23.301431+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:23.298818+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 1. Le classifieur génératif — Naive Bayes gaussien from scratch\n",
+    "\n",
+    "Le Naive Bayes gaussien modélise chaque classe par des **gaussiennes indépendantes** :\n",
+    "`P(x|y=c) = ∏_j N(x_j ; μ_{c,j}, σ²_{c,j})`. L'**indépendance** (le « naive ») fait qu'on estime chaque variable séparément par sa moyenne et sa variance, puis on combine par le produit.\n",
+    "\n",
+    "À la prédiction, on applique Bayes :\n",
+    "`P(y=c|x) ∝ P(y=c) · ∏_j N(x_j ; μ_{c,j}, σ²_{c,j})`.\n",
+    "On choisit la classe de **log-vraisemblance postérieure** maximale — c'est un produit, on travaille donc en log pour éviter les underflows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3d1cb266",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T20:05:23.308281Z",
+     "iopub.status.busy": "2026-08-23T20:05:23.307817Z",
+     "iopub.status.idle": "2026-08-23T20:05:23.314226Z",
+     "shell.execute_reply": "2026-08-23T20:05:23.313328Z"
+    },
+    "papermill": {
+     "duration": 0.011217,
+     "end_time": "2026-08-23T20:05:23.315130+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:23.303913+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# 1.1 Implementation Naive Bayes gaussien de zero\n",
+    "class MyGaussianNB:\n",
+    "    def fit(self, X, y):\n",
+    "        self.classes = np.unique(y)\n",
+    "        self.means, self.vars, self.priors = {}, {}, {}\n",
+    "        for c in self.classes:\n",
+    "            Xc = X[y == c]\n",
+    "            self.means[c] = Xc.mean(axis=0)                # mu_c,j\n",
+    "            self.vars[c]  = Xc.var(axis=0) + 1e-9          # sigma^2_c,j (eps de stabilite)\n",
+    "            self.priors[c] = len(Xc) / len(y)              # P(y=c)\n",
+    "        return self\n",
+    "\n",
+    "    def log_likelihood(self, X):\n",
+    "        # matrice (n_classes, n) de log-vraisemblance\n",
+    "        L = np.zeros((len(self.classes), len(X)))\n",
+    "        for i, c in enumerate(self.classes):\n",
+    "            s2 = self.vars[c]\n",
+    "            L[i] = norm.logpdf(X, loc=self.means[c], scale=np.sqrt(s2)).sum(axis=1) \\\n",
+    "                   + np.log(self.priors[c])\n",
+    "        return L\n",
+    "\n",
+    "    def predict(self, X):\n",
+    "        return self.classes[np.argmax(self.log_likelihood(X), axis=0)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3f309779",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T20:05:23.321985Z",
+     "iopub.status.busy": "2026-08-23T20:05:23.321640Z",
+     "iopub.status.idle": "2026-08-23T20:05:23.334575Z",
+     "shell.execute_reply": "2026-08-23T20:05:23.333569Z"
+    },
+    "papermill": {
+     "duration": 0.017522,
+     "end_time": "2026-08-23T20:05:23.335388+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:23.317866+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "accuracy from scratch : 0.925\n",
+      "accuracy sklearn      : 0.925\n",
+      "predictions identiques (0/1) : True\n",
+      "moyenne classe1 (from scratch), 3 premieres dims : [1.262 0.913 1.16 ]\n",
+      "moyenne classe1 (sklearn),      3 premieres dims : [1.262 0.913 1.16 ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1.2 Verifier contre sklearn sur un petit jeu 2 classes\n",
+    "d = 6\n",
+    "Xs = rng.normal(0, 1, (200, d))\n",
+    "ys = rng.integers(0, 2, 200)\n",
+    "Xs[ys == 1] += 1.2                     # classe 1 decalee\n",
+    "\n",
+    "mine = MyGaussianNB().fit(Xs, ys)\n",
+    "sk   = GaussianNB().fit(Xs, ys)\n",
+    "print(\"accuracy from scratch :\", round(accuracy_score(ys, mine.predict(Xs)), 4))\n",
+    "print(\"accuracy sklearn      :\", round(accuracy_score(ys, sk.predict(Xs)), 4))\n",
+    "print(\"predictions identiques (0/1) :\", np.array_equal(mine.predict(Xs), sk.predict(Xs)))\n",
+    "print(\"moyenne classe1 (from scratch), 3 premieres dims :\", np.round(mine.means[1][:3], 3))\n",
+    "print(\"moyenne classe1 (sklearn),      3 premieres dims :\", np.round(sk.theta_[1][:3], 3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c30d379f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002631,
+     "end_time": "2026-08-23T20:05:23.340907+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:23.338276+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture — la vérification vaut preuve\n",
+    "\n",
+    "Le from-scratch et `sklearn` donnent la **même précision** (0.925) et **exactement les mêmes prédictions** (les classes coïncident bit à bit). Les moyennes de classe apprises sont identiques : sur la classe 1, chaque dimension est décalée de **l'ordre de +1** par rapport à la classe 0 — précisément le `+1.2` imposé à la génération, les moyennes échantillonnées s'en écartant légèrement (`[1.26, 0.91, 1.16]` sur les trois premières valeurs). Le code de 10 lignes **reproduit** la lib de référence, sur les mêmes données : la série gagne la même exigence de preuve que le reste du catalogue."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "309eea1b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002893,
+     "end_time": "2026-08-23T20:05:23.346486+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:23.343593+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2. Le compromis génératif-discriminatif (mesuré, pas raconté)\n",
+    "\n",
+    "On met Naive Bayes face à la **régression logistique** (le discriminatif de [2.3](2.3-Regression-lineaire-logistique.ipynb)) sur des données **gaussiennes corrélées**, en faisant varier la taille du jeu d'entraînement `n`. On mesure la **précision** de chaque modèle sur un même jeu de test fixe, moyennée sur plusieurs graines.\n",
+    "\n",
+    "Deux scénarios, deux régimes :\n",
+    "\n",
+    "- **Scénario A — corrélation homogène, modérée.** L'hypothèse d'indépendance est *à peu près* vraie. On attend l'avantage génératif en petit `n`, puis convergence.\n",
+    "- **Scénario B — corrélation en bloc, forte.** L'hypothèse d'indépendance est **fausse**. Naive Bayes est plafonné par son **biais** ; la logistique, plus flexible, continue de progresser avec les données."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "740a1dc0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T20:05:23.352917Z",
+     "iopub.status.busy": "2026-08-23T20:05:23.352664Z",
+     "iopub.status.idle": "2026-08-23T20:05:23.359668Z",
+     "shell.execute_reply": "2026-08-23T20:05:23.358756Z"
+    },
+    "papermill": {
+     "duration": 0.011427,
+     "end_time": "2026-08-23T20:05:23.360466+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:23.349039+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# 2.1 Fonctions de tirage + courbe de performance vs taille du train set\n",
+    "def make_corr(n, d, shift, rho, rng):\n",
+    "    # correlation homogene : un facteur latent z commun -> toutes les paires correlatees a rho\n",
+    "    z = rng.normal(0, 1, n)\n",
+    "    X = np.sqrt(rho) * z[:, None] + np.sqrt(1 - rho) * rng.normal(0, 1, (n, d))\n",
+    "    y = rng.integers(0, 2, n)\n",
+    "    X[y == 1] += shift\n",
+    "    return X, y\n",
+    "\n",
+    "def make_block(n, d, shift, rho, rng):\n",
+    "    # correlation en bloc : la moitie des variables partagent un facteur, l'autre est independante\n",
+    "    d1 = d // 2\n",
+    "    z = rng.normal(0, 1, n)\n",
+    "    X = np.empty((n, d))\n",
+    "    X[:, :d1] = np.sqrt(rho) * z[:, None] + np.sqrt(1 - rho) * rng.normal(0, 1, (n, d1))\n",
+    "    X[:, d1:] = rng.normal(0, 1, (n, d - d1))\n",
+    "    y = rng.integers(0, 2, n)\n",
+    "    X[y == 1] += shift\n",
+    "    return X, y\n",
+    "\n",
+    "def eval_curve(make, d, shift, rho, ns, n_seeds=40, test_n=2000, seed=1):\n",
+    "    gen = np.random.default_rng(seed)\n",
+    "    Xt, yt = make(test_n, d, shift, rho, gen)       # jeu de test fixe\n",
+    "    acc_nb, acc_lr = {n: [] for n in ns}, {n: [] for n in ns}\n",
+    "    for _ in range(n_seeds):\n",
+    "        X, y = make(max(ns) * 2, d, shift, rho, gen)\n",
+    "        for n in ns:\n",
+    "            y_n = y[:n]\n",
+    "            acc_nb[n].append(accuracy_score(yt, GaussianNB().fit(X[:n], y_n).predict(Xt)))\n",
+    "            acc_lr[n].append(accuracy_score(yt, LogisticRegression(max_iter=8000, C=1e6).fit(X[:n], y_n).predict(Xt)))\n",
+    "    return {n: (np.mean(acc_nb[n]), np.mean(acc_lr[n])) for n in ns}, acc_nb, acc_lr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2bb275ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T20:05:23.367030Z",
+     "iopub.status.busy": "2026-08-23T20:05:23.366791Z",
+     "iopub.status.idle": "2026-08-23T20:05:25.759251Z",
+     "shell.execute_reply": "2026-08-23T20:05:25.757658Z"
+    },
+    "papermill": {
+     "duration": 2.397149,
+     "end_time": "2026-08-23T20:05:25.760403+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:23.363254+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgEAAAFUCAYAAAC9Te+4AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAcYNJREFUeJztnQd4FFUXhr/0EErovVfpHQTpgqCIYEGqICooRREVBf0FURAFRRAQREVBQZAi0nvvSJMiIL0TQgmhhLT9n+8us+xudpPdZJPZct7n2WR2dnb2zp0795x7zrnn+hkMBgMEQRAEQfA5/PUugCAIgiAI+iBKgCAIgiD4KKIECIIgCIKPIkqAIAiCIPgoogQIgiAIgo8iSoAgCIIg+CiiBAiCIAiCjyJKgCAIgiD4KKIECIIgCIKPIkqAh+Dn54dPPvlE72IIqeSXX35R9/D06dMW+0ePHo2SJUsiICAA1apVg96wfCwny6vBdsd95hQvXhwvv/yyDiX0LWzdD0FwJV6hBBw4cAAvvPACihUrhtDQUBQqVAgtWrTA+PHj9S6a23Pz5k1VZ+xo/v33X72L4/F8/vnnWLBggUPHrly5Eu+//z4ee+wx/Pzzz+q7gm8yc+ZMjB071qFjly5dKgMCwWX4efraAVu3bkXTpk1RtGhRdO/eHfnz58e5c+ewfft2nDhxAsePH4c3EBMTg8DAQPVyJT/88APeeustZM+eHa+++iqGDx/u0vP7GlmyZFEKqfXILSEhAXFxcQgJCTGNqgcNGqQsAffu3UNwcDDcAXYH9+/fR1BQkLJOEAqcYcOGqc/MLQFNmjSREaqLePrpp3Hw4MEkliJb96Nfv36YOHGixf0QhNTiWomiAyNGjEB4eDh27dqlBJk5ERER8GQSExMRGxurRup8pQe//fYbnnrqKWVF4WhElADb9Z9W2IFrnbh5+8yUKZPbKACECkp6tTVXcOfOHWTOnBm+grvfD2/DYDCoARefS1/B490BHO1XrFgxiQJA8ubNa1Po1alTB2FhYciRIwcaNWqkzLLmLFu2DA0bNlSdTdasWdG6dWscOnTI4hj6Qznqu3DhAtq1a6e28+TJg/fee0+N+sz56quvUL9+feTKlUs1rpo1a2Lu3Lk2H3hq+TNmzFDXxFHj8uXLTZ9ZmwD37t2LJ598EtmyZVO///jjjysLiKOcPXsWmzZtQseOHdXr1KlTyrLiKEeOHFHncIT169ejVq1aqkMrVaoUvv/+e5u+Zu0esY5YVzlz5lRlo3XHHI5CK1WqhMOHDytLEO8n3UCjRo1Kcj6OpIYOHYrSpUurOi1SpIgyw3O/o/XvyD3k9ymkpk2bprb50vzm1jEB3KYLgMdrxyY3qtau959//kHjxo3V9fJ6tDJs2LABdevWVWUrV64cVq9eneQcbKuvvPIK8uXLp66N1zh16lSX+aDpWnr77bdV/fL8LN+XX36plCnzdsDz839Kv6s9Y3zGqajyWezSpUuyZXDkGrUy/PHHH2oQUbhwYdUu+fw4YjnU2i3b/4svvqieP7aL/v37KwHibHvmvV2yZAnOnDljagu0tNiqF9YJrQBEO9bWM2QOz0VLw+bNm1Xfx2tlHMr06dORFnbs2KHuC/tR9pVVqlTBuHHjLI5Zu3atqS9lH922bdskbketPln3vD4ex4Fdjx49cPfuXdNxbP981q1h++KzTwuc+T66V3j/eb1sD6+//jpu3Lhhs25WrFih+ifeI/ZNhPfjmWeeUWWnLBkwYIA6zlb7ZV20atVKlZvPJp/RLVu2pOo6XS2rUsTg4TzxxBOGrFmzGg4cOJDisZ988gntZ4b69esbRo8ebRg3bpyhc+fOhg8++MB0zPTp0w1+fn6GVq1aGcaPH2/48ssvDcWLFzdkz57dcOrUKdNx3bt3N4SGhhoqVqxoeOWVVwyTJk0yPP/88+r83333ncXvFi5c2NCnTx/DhAkTDGPGjDHUqVNHHbd48WKL47ivfPnyhjx58hiGDRtmmDhxomHv3r2mz4YOHWo69uDBg4bMmTMbChQoYPjss88MX3zxhaFEiRKGkJAQw/bt2x2qO34nS5Yshrt376r3pUqVUuV0FJapcePGKR63Z88eVS7WI39zxIgRhoIFCxqqVq2qzmHO8OHDVf136NBB1SPrIXfu3Oq7N27cMB3H3+U5ihQpYujfv786tlmzZup8S5cuNR2XkJCg2khYWJjh7bffNnz//feGfv36GQIDAw1t27Z1uP4duYe//vqrus6GDRuqbb62bt2qPvv555/V8Vob4mc8jsdrx544ccJuHZpf78CBA1XbrFChgiEgIMAwa9YsQ/78+VX7Hjt2rKFQoUKG8PBww61bt0zfv3z5sroGfv/TTz9V7fWZZ55RZfrmm29Mx7F83MfyarDdWd+nYsWKqWdA486dO4YqVaoYcuXKZfjwww8NkydPNnTr1k3dS94fjXXr1qlz8b85tn6X52f9sF1ym+fk82kPR69RK0P16tUNNWvWVJ+x7thGeF9TQquPypUrG9q0aaPaRNeuXdW+l156yen2vHLlSkO1atXUfq0t/Pnnnzbrhe2pRYsWap92LF/JwXtVrlw5Q758+dS9YXlr1KihysV+JDWwzMHBwercrA/W9VtvvWVo3ry56ZhVq1ap56xs2bKGUaNGma49R44cFn2pVp+8H88995yqp9dee03te//9903H8Z76+/sbLl26ZFGWDRs2qGPnzJlj2sfv87d79uyp2g37ePaXtWvXNsTGxlrUTenSpVWZBg0apI5l+7h9+7ahZMmShkyZMqn9fK7YNrQ+y7z9rlmzRtVFvXr1DF9//bVqT3wWuG/Hjh1OX6erZVVKeLwSwMbIjpAv3gRW5ooVKyxuNPnvv/9UA3r22WeVYDAnMTFR/Y+OjlYVyIZj3bmwUzXfz06JN4kN0xytYzFHE7IaLFulSpWU0DKH52MZDx06lOQ6rZWAdu3aqUZmLjguXryoFKJGjRoZHIGdWJcuXUzv2UHwIY2Li3OpEsCOkh3shQsXLO4HH1Jz4XL69Gl1H6kkmEMFj8ea7+fv8rvmQuH+/ftKGFIZ02AHyTrdtGmTxTn5sPP7W7Zscaj+Hb2H7GjMhaOGtRJAeByPdwTtemfOnGnad+TIEVOZzRU/tn9rgfrqq68qhTEyMtLivB07dlRtW7u+1CoBVER5LceOHbM4jh0o7+nZs2dTpQRwH8/hCI5eo1YGKnxsMxrsaLk/pQGFVh9UMMyhksj9+/fvd7o9t27dWtWpNbbqpW/fvknuR3LwvDx+48aNpn0RERFKwXr33XcNzhIfH68GHDyvuWJu3pcSKjZ58+Y1XLt2zbSPdcP2SgXRuj45mDKHfTWVSo2jR4+q4yjwrOvdfDDDZ53HzZgxw+K45cuXJ9lf7EHd8DNzKMy5f8GCBaZ99+7dMzzyyCMW7ZfXW6ZMGUPLli0trp1lYR1RYXP2Ol0tq1LC490BnAWwbds2ZbbZv3+/Mge3bNlSmYcWLlxoOo4R2zQRDRkyBP7+lpetmdNWrVqlTJqdOnVCZGSk6UVfLk2t69atS/L7b7zxhsV7mmZOnjxpsc/cv0RzVFRUlDpuz549Sc5HM1KFChWSvWa6G2gWohuCZj2NAgUKoHPnzsrsd+vWrWTPQbMyZ1XwWjW066bJyxEoN63NYrbKStM0y1qwYEHTfpqK6cowZ/78+eoe0cRqXv8M9ixTpkyS+qepuGvXrqb39K3TfGZe/3PmzEH58uXxyCOPWJyzWbNm6nPrc9qrf2fuYXrB66UpWYNmf5oUeX1snxratlYPvE/z5s1DmzZt1LZ5PfBZ4bWk9TpYz6wPmi3Nz9+8eXPVBjZu3Jjqc/fu3TvFY1JzjTTDmsdjsPzE+vm1R9++fS3ev/nmm6bo/dS05/SEbVq7PkLXJduPo9dq7Yak65CuH2s3rNaXXrp0Cfv27VNmb7pANOgyYJ+t1VFKfem1a9dMfVnZsmXVNNrZs2ebjmHbokuM9117RtkWaWbn75jXO10yfIas671EiRKqjZhDNyBlCOWKBt0KPXv2tDiO1/jff/+pfpdl1X6Lbj66l9juzd1hjlxneskqrw0MJLVr11YPHIO4qAj8+eef+Oabb5SPiDeJDwD9iqzQ5AQsbybRBIQ19P2Zw0bBh8kcdoLWfqfFixergDuWxdwPbcuXxwaZElevXlU+JD7E1lAgsAHR50h/mD3ob6IfiUqE5gfl9dBHRp84fUuugMFvjH6n0LfGeh/rnx04O0hbMELaHPpyreuQ9U8Fx/yc9EFa3yfz8jlS/87cw/TC1vWys6MP3nof0doh2ws7jClTpqiXLdIaRMt6Zr07Ws+OwtkwvO6USM01ckaRddsh1s+vPazbKWNd2MdocR/Otuf0xPpa7fVVjsC+VPPR24P+dGKvj+JAwzrIM7n7ofW9HTp0wIcffqhiPyikOQjhfeV+DdY7lT5bMWGOPvNnzpxR99P6ebPVZxHOTLMHy6JdiyPXmR6yyuuVAA1q9VQI+KLWSE2fWiGDwhxB09h+/fVXpa1bYz09zzra2xYMvKM2yaCO7777To3W+fAzKIzR+NZkRFQqO6bff/9dPYS2Ghofktu3byutOSNh/fOhY7CLrbq1Lo+9+jefOsVzVq5cGWPGjLF5rLUAtVX/zt7D9MLe9aZUD1q7ptXEXmfFEVpa4G9w5MWAS1vweUxOabIOptVgcJ/1aMje7zt7jY60H2ewvjZn23N64upr1auMFPaDBw9W/TotEQzupNLLoDzzeqcCwMGMLawV1Uxp6HO1dsepvvaSfaWm33K1rPIZJcAcRnpqZilCrY4Vx2hyezeLxxA2IJoxXQFNlBxhU/Nlh6ZBAZJa2IgZMXr06NEknzFimZ2mtXAzh5Hk58+fx6effqq0cnOojfbq1UuZpMxN7amFdcnrtxV1bb2P9c8HgZq5JjTSCs9J6xBNc6kdtTtzDzPSMuBMe2HkMAWtq9q1rXqm4pjS+bVRD0fttkaO7nyNtkZj5qNItmf2MVpkvzPt2Zl2o3cb0/pJ5jWwV9ecckzs9VG5c+dO1VRP1iVdfnQJcCYPLcB0NZo/lywfXZBMwpVaAV+sWDElK3j/zOvbVp+ljbxd1e4yWlZ5fEwAfR+2NCjN56SZo9hQKBwp+Kx9NNr36RfizWTmNiZ2sWVydBZqfWxE5iMdmgsdzSpn75xPPPEE/vrrL4vkIleuXFEj0wYNGiRrDtJcAQMHDlQuE/MXfV40X9rTop2dIsiyspHyei9evGjxMHGEZM5zzz2njrdOTEP4nn4zZ6E/lqZDJkWyhm4KWkNceQ9Zr9YCTm9Y/ueff14pM+y4XdGubdUzY3NsxZOwPuLj402dK8tjHSNAC4u7X6M12lQ9DS1DqRbr4kx7Zruh2dgRNOGpVzurUaOGEsacgmddBu06aS2jAON0WfNjeG8Yz8SphamF1gBOhebUT/rBzV0BWlvks/rZZ58l+S7boSP11rJlS9VvmMeVcfqndT/COAMKZE4hphLsinaX0bLK4y0BDMahf/zZZ59VwV+MC+Bcd2qK1MjpEtB8OR999JFqGAzE4ANK7ZFJhhiwNnLkSFWpkyZNwksvvaQaOoOwOMKgoOM8XmqWEyZMcKp89K3TFE1zFYNHaGpn58HymPuunYX+aQaHUOD36dNHmX84v5X+altz5TX4OTtKmm7tJSGh6ZvzfVlWe341QisCA+lSCg7k/Fg++Kw/BnnxAWU90qdIH7sGHyZeF819FLJ8GDi6YxAS4zxooWAeBmfgvaTJkME4VBhZBv4+FRju1+YHu+oeslPgKITHs12xszQP2tOLL774Ql0/y0JFj26g69evq2A5lpfbaYEKJTtMzrlmMBjrgQoWg08ZuMX7ydEfTbft27dXApOKFe854y1ckdgrva/RGrZLPitsF1SAqFyzfVStWtXp9sz6Yp/1zjvvKHcmTcgMdrMFjyXM9ElhQEXDPGA0LZjnJ7AHBRT7SZaPgp59LIU+nynOUdcUQZrIqRDVq1dPZSOl0s37zjaQlrTHFPKsN74YdGg9EmafxJwA7NPZv3DARPcdLTd0I7BvM88pYAt+n30UA++Y/4HXx4GR1mdq1gHWxY8//qiukzFYrAvGKlCBYFukTFm0aBGcIcNllcHDWbZsmZpywakbnCbCaXOc9/nmm28arly5kuT4qVOnqml8nB7DuaGcesX5rOZw+genfHCqBXMBcJ7yyy+/bPj7779TnN5lazrVTz/9pKaR8DdZTk73sXUc33P6jy2spwhq8+9ZTl43p+A1bdrUNC/dHvPmzVPnYpnssX79enUMp0y5YoqgNpeW9c77w/r88ccf1fQk1q+tMjZo0EDVL1+sM9YLpwhp8HeZo8Ea3hfrqVaczsc5tDxeu++cxsl5y1FRUQ7Vv6P3kNP2OEWT84v5mTaNzhVTBG1dL6+V08ussXUtfB64j/Pog4KC1HTKxx9/3DBlyhTTMamdIqhNWxo8eLB6/nifOd2U85y/+uoriym7V69eVdM42WZ5L15//XU1X93WFEFH68eZa9SmCJrPK7d37bbQ6uPw4cOGF154QU3L5XUw/wSnkaWmPXNeOueBc9oXz621YVtl4hQ99m/MZ8F54il14/baCNuU9fPLe/boo48aHGHz5s1qChyvn9fFufHW0/dWr15teOyxx9TzkC1bNjVdmPVmqz7ZLsyx9cxo8Jz8jPPs7cF7zuecv80ycko0p5BzKnVKdUNOnjypPuP3Wdfsr7T+0zoXC/OJcO4/p/qxj+B5X3zxRdXvpfY6XSWrUsLj1w4QPBeOjDhy0CJdBcET0NZSoMmV1g1vgT5ojmZpmXHV7CBvY+zYsSpzIGOqOOL3Bjw+JkDwDGgKNIeCn3EbTJkqCIL+0HxN070oALb7LMYE0OXKmClvUQC8IiZA8AyYj4C+Yv5nJDj9WZzSaW9KmSAIGQuTH1knQPJlnnvuOTWnn3EPDNpkzAfjHhwJmvYkRAkQMgQGTzE3weXLl1WQC0ccjGy1l0hFEARBT1q2bKmC/ij0GUzMQNNZs2YlmY3g6UhMgCAIgiD4KBITIAiCIAg+iigBgiAIguCjSEyADZilidntmNhD7xSdgiAIgvdhMBgQHR2tEgA5sj5GeiFKgA2oACSXe18QBEEQXAFXfHVkpcz0QpQAG9ACoN0cZ5ZkFIT0skwxMQ3Tguo5YhCE1CJtOCm3bt1Sg01N3uiFKAE20FwAVABECRDcoQNlohK2RelABU9E2rB99HY5y90QBEEQBB9FlABBEARB8FFECRAEQRAEH0WUAEEQBEHwUSQwUBAEQXApCYkG7Dx1HRHRMcibNRS1imWHt11TnRI5EeDv+XlkRAkQBEEQXMbyg5cwbNFhXIqKMe3Lny0U/RsVRIe8eeEt11QgPBRD21RAq0oF4MmIEiD4PN6q4Xsj3nivvOmaKCx7/7YH1qvSXbkVg8GLTyI8WzieqlIQ3nBNl6Ni1P5JXWt4tCIgSoDg03irhu9NgsWb75W3XFNiogF3YxMw9K9DSYQl0fYNWXgI+cIzgU2R+x6uYWtQ29pbtW0wWByj3j04xnyf9j1tQVz11/DwM9P5Hhxj/hswP8Z03MN9fI4m/7UeFfxu2LxuPlGTF0ajRYUOHvt8yVLCdjI5hYeHIyoqSpIFeTH2NHztUXYXDZ+JViIiIpA3b16HEq14i2DxxHul9zVRaMXEJeB+fKLD/+/b2h+XiJj45P/fN3sfl+CdYqQgIrE25F2E+sXZPSbGEIRDz69FzSpVPFLOiCVA8EnYWVJQ2hu1sCPm5y0q5PcoDd8bTZfpfa84DopPNKjfSTQY/5teBgMSE4H4xET1P8Hqc+34eLNtjorjTd+1PJf2ndj4RHy+9Eiyo+Z3/tiP1f9eQWy8QQncmAeC1/jftvDm77o7OcKCkDkkEEyU5/dA5TFuP8yep/7a2Gf9HeN/bc+Dz22cF0nOYf+8MH0O5Ii6gtA79hUAQgUh+voVeCqiBAg+CU3l5iNla9iV8vP2k7chX7YQBAX4IzDAD8EP/vO98eWHQH9/BAf6I9Bf2++HQLPP1Xf5WaA/gvwffm55Lj+r3zB+h9t6CkuDmZCLS0hUI754/ue+B++5P57/Ex/8V/uN2xSe9o95eC7j5w/2PTgm9sF3rty659C9ajx6LUICA0A5aBLaZsJXE9B8H2+27a62UJrX5+6+kOrvs+2EBPojJChA/Q8N4vuA5P8HBSDU7Dvm75P8t/r+P+dv4uWfd6VYru+61ES9UrngCfyzMxZYmvJxOcOC4amIEiD4FOz4D128hV+3nXbo+D1nbfsCMxLK6yBNiXigIJgrEEpZCPTHvdh4h4Tlk+M2IlNQAGIfCOGHAv6hgOY+TRB7Cudv2L/2tMD69fensueHAD/jdoD28jP+p5eGyiDvlXrvR0Xv4fHqHA+O5Svy9n38eyk6xd9+ukoBVC+a44EQD3D4P9tDRluwGpbJg2rZohEfHWlTESVBWXOr+BRdoLZ3Pxq4ew24dx24e+PB/+tm+66b7buOyncjHTp1xUKe6zYWJUDweqLuxmHT8atYf9T4YgfsKD0blkDRnGEmgamNYDVBSbOuGu3GG0e5ptGt1ShZjWrNjjMfDZuPgm0JXY5s7ycYcD8hgeP9NNfHsSu30/R9mklp0TC3YlAAmltK+P6hReShsmL5XjvmoWXFdMwDpYfvz9+4h1+2pqy0ffRUeVQqFK7OZxK4ZoKXRhUlnCms/WFDkFsJ6wcCPD3YduIaOv2wPcXjutQt5jGj5oBb5zEv/k0EhMTaPSYhPhgBtx4DsqdxqfbEBODeDSuhbVuQW+xLjHfqZ/wcPI5txVMRJUDwOmjC5ihr3dEIrD8agT1nbypTsEbm4ADUL5ULO07dwK0Y2/4+PtL5w0Mx6MnyGTqiMje/a+bw+3HxuBxxFdmy51QKgbbfUiFJxIHzt/DN6mMp/saA5mUeCEujsLUQzGYCXHtvKfAzfoTJ+lhx6LKKazAkc69eaVDCY+I3OBpmsGZK16TbqDk13L2GgET7CgBRn1NYmysBcTHJCPIbtoV7zM3UlzMwExCWE8iU0/jffFv9z/Vw+/ZlYFZneDOiBAheQXRMHLYcj8S6I1ex/lgErtyyHO2XzpsFTcvlQdNyeVGreE5lLtWC6Ih5R6yJEUbTZ7RQYbCSEsQBUGZdkpgYCL+YEOTNnTnZ2QGNy+bFrF1nUxQs/ZqV8RhhSVhW3gveKz83uldpwRuvyWGWvAMkxD0U6nF3U3+ukPBkBHkO28I9KJPj57+4D96OKAGCR8IRM83aHOlzxP/36RsWkdH0eXO03+SRvGhSNg+K5AxLcg5GyTNaPkl2Mw+dTufNgsXb7pVXXBMF+Y3TQOQxIPI/4GzK7g3Fhd1J9/kF2BDkKYzSM+UAAkSEpRXJE+DG8zcFS+7cjzeO9o9exYajEbhoFQRXMndmNH4w2qcZVRtJe3piHckT4Dn3yiuviSP2a8cfCnv1OgbcOOW0j13R9COgYPUHQv3BaD00/OGcP3fi5jlgQk0gPpk4osAQoN9up+Mc3EXOiBLgxjfH12HTPHH1jmm0v+vUDYvAOUZCM2iKQr9JuTwoliszvBFnlQCPECyCe8FAu5tnHgp4c2GfXIR8UGYgd2kgd1kgOCuwe2rKv9VrA1CwGjyGm+eMcQn2oHUiFYGO7iJnxJYiuBX3YhOw7aTRt0/Bz8hwcxipT98+zfz1SuZyeLTva1Dge0pUuZCBxNwCrmkC3kzgXz8BJCQT1JetEJC7jFHY5yrzcDtbwYcjePrPHVECPI3sRdI+m8GNESVA0J1TkXew7kgE1h+7iu0nr6lpdxqccla3ZE40KZdXCf8SuTObMn0JgkeTTiNMlSXp1vmkI3r+Z7S7PQJDgVwc1Zd5IOjLPtguDYRkcb4cgkcgSoCQ4TC9KYW9cd5+BE5fs4wOLpQ9E5o+kgdNyuZF/dK5EBYszVTwMlzha46988BXb2XC5754SwuaBVnymQl4M2EfXgQqgUJqodLCMidzTYbAEPjxOMFtkN5VyBDOXrurpu5xxL/t5DWV/1yDc9JrF89p8u1zOp+M9gWvhhaA5BQAws/pj/cPsD2q52jfHv5BQK5SVoKer9LGILz0gMoKlRYb1g2ul3D9+nXkLFwafl5sWvdERAkQnMLRgDMudMLjONqnb//k1TsWnzNanQKfZv7HSudGlhBpioKQhKlPJj+q56ha+ekfBOdpo/rsxfSZPmfPf84smQERQHjejC+TkCzS8woOk9LUs/M37ppM/FtPXFMLoGhQUahVLIfRt/9IHpTLl1VG+4Lv4uikLCoAnEOfs4RlQJ4m7DlnXhDSgCgBQpqWqKVC8MZve1AgWygu3bKct58na4gxkv/BaD88U1CGllkQ3IqbZ4ET64CT64ETaxz7zovTgbJPAoGeu0qd4N6kIQrEdUycOBHFixdHaGgo6tati507d9o9tkmTJsb1o61erVu3tphfPmTIEBQoUACZMmVC8+bN8d9//2XQ1XgfyS1Rq0EFgON6jvYHtiyHxW82wM4PH8eoF6riqcoFRAEQfI97N4F/FwGL3wG+rQGMrQwsegs4NB+IiXLsHDTriwIgeLMlYPbs2XjnnXcwefJkpQCMHTsWLVu2xNGjR1VyFGvmz5+P2NiH81mvXbuGqlWron379qZ9o0aNwrfffotp06ahRIkS+Pjjj9U5Dx8+rBQNwTno209uiVqNKd1qqrXqBcEniY8Fzu8CTq4zjvgv7gEMZqtC0qxfuBZQsqlx3v2iN/UsrSC4hxIwZswY9OzZEz169FDvqQwsWbIEU6dOxaBBg5IcnzOnpQ9s1qxZCAsLMykBtAJQkfjf//6Htm3bqn3Tp09Hvnz5sGDBAnTs2DFDrsubYBCgI5jHAAiCT/j1I/41mvcp+E9vAeIsA2CVH79UU6PgL/7Yw8h8H1iYRvAMdFUCOKLfvXs3Bg8ebNrHtKg032/bts2hc/z0009KsGfObEwZe+rUKVy+fFmdQ4OpGWll4DlFCXAezgJw5XGC4LHcuvRA6D94WSffCcsNlGzyQPA3AcILp3pOvfpc5tQL3qwEREZGIiEhQY3SzeH7I0eOpPh9xg4cPHhQKQIaVAC0c1ifU/vMmvv376uXeU5nLWc7X75OrWLZ1ap89+Jsj/S1JWp5nNSX62Gd0sIldasDsbfVCN/vlFHo+1217JcMXJu+WH0YSjQ2Cv18FQE/s1Are/eM7oC+u4yL89iDkf88zgvuu7ThpLhLXejuDkgLFP6VK1dGnTp10nSekSNHYtiwYUn2X716FTExjpnCvZnFhyLtKgCEAYNvNSyIa5FXM7RcvtRZcJERdqKOLiAkpJLEeARdPYjg81sQcn4rgq7sg5/ZSnkG+CE+T0XcL1wfsXzlq2EcsWtcTWaxnSSEAAHJrOrIcUlEBLwBacNJiY6OBnxdCcidOzcCAgJw5coVi/18nz9/8gFmd+7cUfEAn376qcV+7Xs8B2cHmJ+zWjXbK1fRHcHgRHNLQJEiRZAnTx6fX0Xw8MVbGL3unNp+unJ+/H3mJi7fsswT8HHr8mhVSQIC07MD5QwYtkfpQNPBr8/FczjKp3n/9Cb43b9leQgj9Es2gYEj/eKNEBCWE2EcqOtWaM9D2nBS3CVIXVclIDg4GDVr1sSaNWvQrl07U2Ph+379+iX73Tlz5igTfteuXS32czYAFQGeQxP6FOo7duxA7969bZ4rJCREvaxhY/XlBht1Lw59Zu7F/fhEld3v20411KhflqjNeNiB+np7dBl3Ii39+lFGJddEaHagRCNTQJ8fE/U8cHsJqUfasCXuUg+6uwM4Au/evTtq1aqlzPqM7OcoX5st0K1bNxQqVEiZ7K1dAVQccuXKlaShvf322xg+fDjKlCljmiJYsGBBk6IhpExiogHv/rEPZ6/fReEcmTC2QzX4PxD2skSt4FEr7sXdA85ue5io5/I/lp8HBANF6j4M6CtQzZivXxB8AN2VgA4dOijfO5P7MHCPo/fly5ebAvvOnj2bRGNiDoHNmzdj5cqVNs/5/vvvK0WiV69euHnzJho0aKDO6S7mF09g0oYTWP1vBIID/TGpS01kD5OEJYKHrLjHgCsKem2+/tntQILVd/NVMgp9Tt0rVg8INs4uEgRfw8/ASA3BAroPOK2QgSy+GBOw5XgkXvppBxINwBfPVUbHOkX1LpJPQxdZRESESp7lLibEDIVz6qc0Tvm4hgOB68eBkxuAe1ZR91kLPpy2x1cWWcgmI/H5NuzGckZ3S4DgXlyKuoe3ft+rFID2NQujQ21Z9lPwEDaNfrgdnBUo3uCh4OeCO7JglSAkQZQAwURsfCL6zNiDa3diUaFANnzWrpKs9Cd4DjTxP/K0UfAXqgkEyHoVgpASogQIJkYsOYy9Z28iW2ggJnetidAgCY4SPIi2E4GCtqcBC4JgG3HOCIq/9l3AtG1n1PY3HaqhaC6ZBS24UdY+QRDSBVECBBy7Eo1B8w6o7X5NS+Px8pYplwVBNy7uBea9pncpBMFrEXeAjxMdE4c3ft2t0gI3KJ0bA1qU1btIgmDM5LdzCrDyf0DCw6XDBUFwLWIJ8GE4O/T9uf/gZOQdlf53XMdqkv1P0J97N4E/XgKWvW9UAEo9DgQkzehpgay4JwipQiwBPsyPm05h2cHLCArww3ddaiBXlhQ6WkFIby7sBub0AG6eAfyDgCeGA3VfB6LOpz5joCAIdhElwEfZcfIavlhuXBZ1yNMVUL1oDr2LJPi6+X/HZGDlx0BiHMBFe9r/bJzqRyjgRcgLgssRJcAHibgVg36/70VCogHtqhVE10eL6V0kwZe5dwP4qx9wZLHxffk2wDMTgEzZ9S6ZIHg9ogT4GHEJieg3cy+uRt9HuXxZ8flzlSUhkKAf53cDc18Gbp41LuTzxAigTk/J7icIGYQoAT7GqOVHsPP0dWQJCcSkrjUQFixNQNDJ/L/9O2DVUKP5P0dxoP0vQMHqepdMEHwKkQA+xNIDl/DDplNq+6v2VVAyTxa9iyT4InevA3/1BY4uNb6v0BZ4ZjwQGq53yQTB5xAlwEc4cfU2Bs7Zr7Zfb1QSrSoV0LtIgi9ybhcwtwcQdc5o/m/5OVD7NTH/C4JOiBLgA9y5H68SAt2JTUCdEjkxsGU5vYsk+KL5f9tEYDXN//FAjhIPzP+S618Q9ESUAB9ICDR4/gH8F3EbebOGYELn6ggMkBxRQgab/xf0AY4tM76v+CzQ5lsgVL811AVBMCJKgJczfdsZLNx/UWUCnNilBvJmDdW7SIIvcW4nMPeVB+b/EKDVSKDWK2L+FwQ3QZQAL2b3mRsYvuSw2h785COoXTyn3kUSfIXERGDbBGDNMKP5P2dJo/m/QFW9SyYIghmiBHgpkbfvo++MPYhLMKB15QJ4tUEJvYsk+JL5/883gP9WGN9Xeh54eqyY/wXBDRElwAuJT0jEW7/vxeVbMSiZJzO+fKGKJAQSMoazO4zR/7cuGM3/T34J1HxZzP+C4KaIEuCFjFl1DFtPXENYcAC+71pTJQYShHQ3/2/9FljzKWBIAHKVNpr/81fWu2SCICSDU9Lh33//xaxZs7Bp0yacOXMGd+/eRZ48eVC9enW0bNkSzz//PEJCZCU6PVl1+Aq+W39CbX/xfBWUyZdV7yIJ3s6da8CfrwPHVxnfV3oBaDMWCJG2JwjujkNzxfbs2YPmzZsrYb9582bUrVsXb7/9Nj777DN07dpVTUP76KOPULBgQXz55Ze4f/9++pdcSMLpyDt45499avvl+sXxTNWCehdJ8HbObAMmNzAqAIGhQJtxwPM/igIgCN5kCeAIf+DAgZg7dy6yZ7e/ste2bdswbtw4fP311/jwww9dWU4hBe7FJuCN33YjOiYeNYvlwIdPlde7SIK3m/+3jAXWDjcz/08D8lfSu2SCILhaCTh27BiCgoJSPK5evXrqFRcX50wZhDRCS8z/FhzEkcvRyJU5GBM710BwoCQEEtKJO5EPzP+rje+rdABajwFCZC0KQfBKJcCeAhATE4PQ0KTJZxxRGATX8fvOc5i35zz8/YDxnaojf7gkBBLSiTNbjcl/oi8Zzf9PfQVU7yrR/4LgoTg9XExMTFSxAIUKFUKWLFlw8uRJtf/jjz/GTz/9lB5lFJLhn/M38cnCQ2p7YMtHUL90br2LJHir+X/jV8AvrY0KQO6yQM+1QI2XRAEQBF9SAoYPH45ffvkFo0aNQnBwsGl/pUqV8OOPP7q6fEIy3LgTi96/7UFsQiJaVMiHNxqX1LtIgjdy+yow43lg7WeAIRGo0hHouQ7IV1HvkgmCkNFKwPTp0zFlyhR06dIFAQEBpv1Vq1bFkSNH0loewUESEg3oP3sfLty8h+K5wvD1i1UlIZDgek5vNkb/n1gLBGYC2k4Enp0s/n9B8BKcziJz4cIFlC5d2qabQAICM45v1/yHjceuIjTIH5O61kS2UInDEFxs/t/8NbDuc+PoP3c54MVpQF6ZdSIIPq0EVKhQQSULKlasmMV+Th9kHgEh/Vl3NALfrv1PbY9oVxnlC0hOdsHF5v/5PYGT64zvq3YGWn8FBGfWu2SCIOitBAwZMgTdu3dXFgGO/ufPn4+jR48qN8HixYtdXT7BinPX72LA7H0wGIAudYvi+ZqF9S6S4E2c2gTMew24fRkICgNafw1U66x3qQRBcJeYgLZt22LRokVYvXo1MmfOrJQCphPmvhYtWqRPKQVFTFwC+szYg5t341C1cDiGtKmgd5EEbyExAVj/JTD9GaMCkOcRY/CfKACC4NWkKqNMw4YNsWrVKkRERKj1A5hK+IknnlBJa5xl4sSJKF68uMo3wHTEO3fuTPb4mzdvom/fvihQoIBap6Bs2bJYunSp6fOEhAQ1XbFEiRLIlCkTSpUqpaY0pqZs7sawRYdx4EIUcoQF4buuNRES+DAwUxBSze0I4NdngfUP/P/Vuhqn/+V9RO+SCYLgbkrAyy+/jDt37iTZf/r0aTRq1Mipc82ePRvvvPMOhg4dqtYn4AwDLkRE5cIWsbGxytrA32IMAt0QP/zwg8pZoMG1CyZNmoQJEyYoCwXfczrj+PHj4cnM+fscft95Vk3JHtuxOgplz6R3kQRv4OQGY/T/qQ1G83+7yUC7ieL/FwQfwWklYP/+/ahSpYpaJ0Bj2rRpSoDnzu1copoxY8agZ8+e6NGjhwo4nDx5MsLCwjB16lSbx3P/9evXsWDBAjz22GPKgtC4cWP12xpbt25VLovWrVurz1944QVlpUjJwuDOHLoYpdICk7cfL4vGZfPoXSTBK8z/XwDT2wK3rwB5ygO91gPVOuldMkEQ3DkwkMKUiwM1adIE7777Lo4fP45ly5aZBLqjcFS/e/duDB482LTP399frVZormCYs3DhQrU2Ad0Bf/31l1rGuHPnzvjggw9MOQvq16+v8hhwvQO6Cqi00F3B8tmDqx6ar3x469Yt9Z+Bj3zpya17cej9227cj09Uwr9vk5K6l0nIWHi/6c5y2X2/fQV+83vB7/RG9dZQ/SUYWn1htARI2xI8oQ17AYluUhdOKwFcF2D06NFqxE5fe2BgIDZs2KCEszNERkYq/32+fPks9vO9vaRDTFG8du1alaiIcQBUQPr06aPyE9ClQAYNGqSE+COPPKIUA/7GiBEj1HfsMXLkSAwbNizJ/qtXr6r1EfQi0WDA+4tO4Oz1eyiQLRgfNiuIyMirupVH0K+ziIqKUp0oFeXk8I++CP+YG3Y/D7x5Clm3joT/vUgkBobhVqNPEFO2LXDjNrWDdCi9IDjXhn2F6OhoeKQSQIFLQcuAPo7iOcp+7rnn1LoBTz31FNK7IeXNm1eN9Cnga9asqaYqUinRlIA//vgDM2bMwMyZM1GxYkXs27cPb7/9NgoWLKimNtqC18HYBA0qEUWKFFGWhmzZ9JuD/936E9h8MkqtCDj5pVooUyhct7II+sF2z2yQbI/JdqBR5+D3Yyv4xT+0alnD8FjmlTTkrQC88DOy5S4LyTIhuE0b9iFCbSy+5xFKQK1atdSMgPXr1+PRRx9Vmh0D76gIvPLKK/juu+8cOg/jByjIr1y5YrGf7/Pnz2/zO5wRQEuEebri8uXL4/Lly8q9wLUMBg4cqJSUjh07qs8rV66MM2fOqNG+PSWAswz4soaNVa8Gu+V4JMasOqa2P32mIqoWyaFLOQT3gB1oiu3x3g0gGQVAnYd/Hnkafs//CL8gCS4V3KwN+xD+blIP/qlRAji6pgKg3Vj65OnH37jR6GN0BApsjuTXrFljoS3yvT3XAoMB6QIw96XQ90/lQFvMiAqKdeVSaXAX/4sjXIq6hzd/34tEA9C+ZmF0qF1E7yIJ3kSjgYAoAIIgpEYJoNmfSYKsYcpgBvo5A03wnOLH2QWczte7d281/ZCzBUi3bt0sAgf5OWcH9O/fXwn/JUuW4PPPP1eBghpt2rRRMQD8jFMJ//zzTxUU+Oyzz8ITiI1PVAmBrt+JRYUC2fBZu0qyMJAgCIKgnzuAPnLNN65FztvDllndHh06dFDBd8w6SJN+tWrVsHz5clOw4NmzZy1G9fTTr1ixAgMGDFDTFJkfgAoBLREazAfAZEEMGGS+AcYCvP766+o3PIERSw5j79mbyBYaiMldayI0SBICCYIgCOmDn8GBVHo0p1+6dEkF5VEo2xqZ8jTcz2h8T4eKTnh4uIpmzcjAwL/2XUD/WfvU9k/da+Hx8pYzJwTfhK4sKrTa82eXi/uAKY1TPmGvDUDBai4toyC4pA37ELd0kjOpsgRwWl7OnDnV9rp1D1YWE1zK0cvRGDTvgNru17S0KACCIAiCeygB48aNUz5/aiuMtKcZ3xmzv5A80THGhED34hLQoHRuDGhRVu8iCZ5ICjMDBEEQrHHILsMlgrX1Ahi0R/OF4BroRnl/7j84GXkHBcJDMa5jNQT4SyCg4CSc/bLpq5SPCwwBwnJlRIkEQfAWSwCz7zFKv2nTpkpoMSGPPR8GI/oFx/lx0yksO3gZQQF++K5LDeTKIhYWIRWsGwH8txLwCwSe/hooYMfnTwUgu0w5FQTBicBALsrD6XwnTpxQU/SyZs1qMziQ+/i5p5NRARs7Tl5D5x93ICHRgM/aVsRL9Yqn228JXhxUte93YMEbxu12k4BqnTO8jIKQHBIY6OGBgVyUZ/v27WqbN5Bz9HkzhdQTcSsG/X7fqxSAdtUKouujxfQukuCJnNkKLHzTuN3gHVEABEFwCqdVslOnTqn8z0LqiUtIRN+Ze3A1+j7K5cuKz5+rLAmBBOe5dgKY1QVIjAMqtAWafax3iQRB8DCcXjugWDEZsaaVL5cdwa7TN5AlJBCTutZAWLDTt0HwdbhOwMwXgXvXgYI1gHaTaabTu1SCIHgY0mtkMEsPXMKPm0+p7a/aV0HJPFn0LpLgaSTEAX90A64dB7IVBjrNAoLD9C6VIAgeiCgBGciJq7cxcM5+tf16o5JoVamA3kUSPA3G8S4eAJzaCARnATrPBrJKYilBEFKH2KHTEQb97Tx1HRHRMcgWGqTWBbgTm4A6JXJiYMtyehdP8ES2fgvs/RXw8wdemArkr6R3iQRB8CUloFmzZpg/fz6yZ8+eZLpDu3btVIphAVh+8BKGLTqMS1ExFvu5MNCEztURGCBGGMFJjiwBVg01brccCZRtqXeJBEHwcJyWROvXr0dsbGyS/TExMdi0aZOryuXxCkDv3/YkUQDIrZh47DlzQ5dyCZ5L4NVD8PuzF/0BQO3XgLqv610kQRB8yRLwzz//mLYPHz6slv7V4MqBXAKYS/v6OnQB0AJgLwMTJwLy8xYV8kt6YMExbl1AjmVvwC/uLlDqcaDVl8zMpXepBEHwJSWgWrVqai47X3QJWJMpUyaMHz8evg5jAGxZADSoHPBzHlevlORwF1Lg/m34zeoE/7sRMOR5BH7tfwYCJJRHEATXEOhMkiBmGC5ZsiR27txpkTAoODhYZRAMCAiAr8MgQFceJ/gwiQnA/J7wu3wACZlywa/TbPiFhutdKkEQfFEJ0JIEMQe0YJ+8WUNdepzgw6waAhxdCkNACG62nIgc2YvqXSJBEHw9MHDatGlYsmSJ6f3777+vZgpwfYEzZ87A1+H0Py4JbM9jy/38nMcJgl3+/hnYNkFtGtp9h7j81fUukSAIXojTSsDnn3+u/P9k27ZtmDBhAkaNGoXcuXNjwIAB8HUY7De0TQW1ba0IaO/5uQQFCnY5sQ5Y8q5xu+lHQMXn9C6RIAheitNKwLlz51C6dGm1vWDBArzwwgvo1asXRo4cKVMEH8BMgFwTIH+4pcmf77lfMgUKdrl6FPijO2BIAKp0ABoN1LtEgiB4MU6HGWfJkgXXrl1D0aJFsXLlSrzzzjtqf2hoKO7du5ceZfRIKOg5DVDLGMgYALoAxAIg2OVOpHFRoPtRQJFHgWfGG6cCMlWwIAiCOygBLVq0wGuvvYbq1avj2LFjeOqpp9T+Q4cOoXjx4ulRRo+FAl+mAQoOEX/fuCzwjdNAjuJAxxlAYIjepRIEwctx2h0wceJE1KtXD1evXsW8efOQK5dRyO3evRudOnVKjzIKgnfDkf7CN4Fz24GQcKDzHCBzbr1LJQiCD+Bn4OR/Ick6COHh4YiKikK2bNn0Lo7g7WwYBawbAfgFAF3nAaWaWnzMabkREREqF4e/v6w5IXge0obdV86k6m4wALBr165qWuCFCxfUvl9//RWbN292dfkEwbs5MNeoAJCnxyRRAARBENxKCaALoGXLlmqa4J49e3D//n21n9oMpw8KguAg53YCC/oYt+v1A2q+rHeJBEHwMZxWAoYPH47Jkyfjhx9+QFBQkGn/Y489ppQCQRAc4MYZ4PdOQMJ9oNxTQItP9S6RIAg+iNNKwNGjR9GoUaMk++nbuHnzpqvKJQjeS0wUMLMDcDcSyF8ZeO4HwF/W3RAEwQOUgPz58+P48eNJ9jMegIsLCYKQDAnxwJyXgav/AlkLAJ1mAyFZ9C6VIAg+itNKQM+ePdG/f3/s2LFDLSt88eJFzJgxA++99x569+6dPqUUBG+AE3GWfwCcWAsEhQGdZgHhhfQulSAIPozTyYIGDRqkpns8/vjjuHv3rnINhISEKCXgzTffTJ9SCoI3sON7YNePxlUk6AIoWE3vEgmC4OOkOk9AbGyscgvcvn0bFSpUUOmEvQV3mb8peBHHVgC/dwQMiUCLz4DH3nL4qzLHWvB0pA27r5xx+m688soriI6ORnBwsBL+derUUQrAnTt31GepyUDIdMNce6Bu3brYuXNnsscz+LBv374oUKCAskCULVsWS5cutTiGuQuYx4DZDDmVsXLlyvj777+dLpsguITLB4G5rxgVgBrdgPpiMRMEwT1wWgmYNm2azYWCuG/69OlOnWv27NlqAaKhQ4eq6YVVq1ZVOQioMdqzPnDtgtOnT2Pu3LlqpgKnKhYq9NCveuPGDTVdkdMXly1bhsOHD+Prr79Gjhw5nL1UQUg70ZeNMwFibwMlGgGtxxgXBRIEQfCkmACaLug54IuWAI7cNRISEtRonKYeZxgzZowKNOzRo4d6z/wDS5YswdSpU1XsgTXcf/36dWzdutWUo8B60aIvv/wSRYoUwc8//2zaV6JECafKJQguIfauMRfArfNArjLAi9OBgIe5NQRBEDzGEpA9e3bkzJlTzQigCZ4ja+2VO3du5Qqgmd5ROKrnokPNmzd/WBh/f/V+27ZtNr+zcOFCtXgRfydfvnyoVKmSylJIJcT8mFq1aqF9+/ZKKeFqh7QWCEKGkpgI/Pk6cHEPkCkn0Hk2kEmsUYIgeKglYN26dcoK0KxZM5U6mAqBBuMDihUrhoIFCzr8w5GRkUp4U5ibw/dHjhyx+Z2TJ09i7dq16NKli7I8MDCxT58+iIuLUy4F7ZhJkyYpN8OHH36IXbt24a233lJl7N69u83zMvWxlv5Ys3powSx8CYKz+K35FH7/LoTBPwiGF38FcpQwKgapgG2Qz560RcFTkTacFHepC4eVgMaNG6v/p06dQtGiRZVFQI9K4+h+ypQpCAgIQM2aNVUQ4OjRo01KAI+hJUBbx4CWgIMHDypXgz0lYOTIkRg2bFiS/VwuOSYmJp2vSvA2Mh2Zj/At36jtqMbDEZOpNGAnzsUR2KYZQcxOVCKrBU9E2nBS6Fb3GCXg7NmzSvATjvhTgoLZPFjPFnQhUJBfuXLFYj/fMyuhLTgjgLEA/J5G+fLlcfnyZeVe4Gifx3DWgjk8htYLewwePFhZDswtAYwryJMnj0wRFJzj9Bb4bRyiNg0N30O2hr2QzQUdKJVutkfpQAVPRNpwUszj6txeCahduzbatWuH1157TW3bglreH3/8gXHjxqFXr17KBJ8cFNgcya9Zs0adW2sofN+vXz+b32HU/8yZM9VxWkM6duyYEvw8n3YMZw2Yw2OSU1441ZAva/gb0mAFh7l2ApjzEpAYB1R8Fn5NP4Kfi9oPO1Bpj4InI23YEnepB4eUAE6zGzFihJqeR+2Fwpv+f25zSh4/P3ToEGrUqIFRo0bhqaeecujHOfqmiZ7me+YbGDt2rMo3oM0W6Natm7Io0FxPmJZ4woQJKm0xsxP+999/yuxvrnAMGDAA9evXV/tffPFFlXeA7gO+BCHduHsdmNEeuHcDKFQLaDeJT7nepRIEQXBdxkDmAuAUPi4WdObMGfWeZn363Tm/n9H6zkKhTp8+TfrVqlXDt99+q5IGkSZNmqgpgL/88ovpeM4coKDft2+fUhBeffVVfPDBBxYugsWLFysTP5UETg+kssGpiJ6WyUnwEOJjgd+eA05vAsKLAD3XAlmcmy6bHJJtTfB0pA27r5xJddpgb8Zdbo7gAfDx+asfsO83IDgr8OoKIF9Fl/6EdKCCpyNt2H3ljNwNQUgLW8YaFQA/f6D9Ly5XAARBENITUQIEIbUcXgis/sS43epLoMzDxFeCIAiegCgBgpAaLuwB5vcybtd5Haj7YFsQBMGDECVAEJwl6rxxWeD4e0DpFkBLY2IqQRAET0OUAEFwhvu3gZkdgdtXgLwVgBemAgEOJ94UBEFwK1LVe3HqHdcSYLSndf7jIUOM2dIEwetITADmvQpcOQBkzmtcFChUZo8IguBDSgBX5GPSHuYHYHpf8zUEuC1KgOC1rPwfcGw5EBgKdPodyG5MpS0IguAzSsDw4cNV9kAm6BEEn2HXT8D274zbz04GCtfSu0SCIAgZHxPANMHt27dP+y8LgqdwfA2wdKBxu9n/1LoAgiAIPqkEUAFYuXJl+pRGENyNiCPAnJcBQwJQtRPQ8D29SyQIgqCfO6B06dL4+OOPsX37dlSuXFkt7WtOSqsHCoLHcPsqMLM9cP8WULQ+0GYcA1/0LpUgCIJ+awdwQR67J/Pzw8mTJ+HpuEtOZ0FH4mKAaW2A8zuBHCWA19YAmXPpUhTJuy54OtKG3VfOOG0JOHXqVPqURBDcalGgvkYFIDQc6DJHNwVAEAQhPUlTlhPNiGA+TVAQPIab54C715Lu//tn4OBcwC8AePFXIHcZPUonCILgnkrA9OnTMXr0aJU0iJQtWxYDBw7ESy+95OryCUL6KQATagLx9+0fQ+U2Z8mMLJUgCIJ7KwFjxoxRgYH9+vXDY489pvZt3rwZb7zxBiIjIzFgwID0KKcguBZaAJJTAEhivPG47EUyqlSCIAjurQSMHz8ekyZNQrdu3Uz7nnnmGVSsWBGffPKJKAGCIAiC4CE4HaZ56dIl1K9fP8l+7uNngiAIgiB4qRLAPAF//PFHkv2zZ89GmTISQCUIgiAIXusOGDZsGDp06ICNGzeaYgK2bNmCNWvW2FQOBEEQBEHwEkvA888/jx07dqhVBBcsWKBe3N65cyeefVZyqguCIAiCV08RrFmzJn777TfXl0YQBEEQBPdSApjeUEtryO3kkDS7gkcQ4EDTDwwBwiRToCAIPq4E5MiRQ0X+M+9z9uzZbWYIZPZA7k9ISEiPcgqCa9n5g/F/9qLA81OBAMuFsBRUACRHgCAIvq4ErF27Fjlz5lTb69atS+8yCUL6cmYbsPsX43a7yUCR2nqXSBAEwX2VgMaNG9vcFgSPIz4WWPy2cbv6S0Bx4wwXQRAEX8Tp2QHLly9XaYI1Jk6ciGrVqqFz5864ceOGq8snCK5lyzjg6hEgcx6gxad6l0YQBMGzlAAuFKQFBx44cADvvPMOnnrqKbXEMLcFwW2JPA5sHG3cbjkSCDO6uARBEHwVp6cIUthXqFBBbc+bNw9t2rTB559/jj179ihlQBDcEi57TTdAwn2gVDOg8gt6l0gQBMHzLAHBwcG4e/eu2l69ejWeeOIJtc3AwZSmDwqCbuz/HTi9CQjMBLQeY1wmWBAEwcdx2hLQoEEDZfZnymBmCeSaAeTYsWMoXLhwepRRENLGnWvAio+M200+AHKW0LtEgiAInmkJmDBhAgIDAzF37ly1pHChQoXU/mXLlqFVq1bpUUZBSBsrPwLuXQfyVQLq9dO7NIIgCJ5rCShatCgWL16cZP8333zjqjIJgus4ud7oCoAf0Gac7aRAgiAIPopDlgBzXz+3k3ulBk4zLF68OEJDQ1G3bl3lZkiOmzdvom/fvihQoABCQkJQtmxZLF261OaxX3zxhcpk+PbbD+aGC75D3D1g8QDjdp2eQOFaepdIEATBrdA9bTBjChhjMHnyZKUAjB07Fi1btsTRo0fV71kTGxuLFi1aqM/okqA74syZM6pc1uzatQvff/89qlSp4lSZBC+B0wGvnwSyFgSafax3aQRBENwO3dMGjxkzBj179kSPHj3UeyoDS5YswdSpUzFo0KAkx3P/9evXsXXrVgQFGU27tCJYc/v2bXTp0gU//PADhg8f7tIyCx7AlcPGxEDkqVFAqCxsJQiC4FZpgzmq3717NwYPHmza5+/vj+bNm2Pbtm02v7Nw4ULUq1dPuQP++usv5MmTR2Ur/OCDDxAQEGA6jp+3bt1anSslJeD+/fvqpaG5NRITE9VL8DAMifBb1B9+ifEwlHsKhnKteTPhqbAN0tImbVHwVKQNJ8Vd6sLpwMCff/4ZWbJkQfv27S32z5kzR+UP6N69u8PnioyMVO6DfPnyWezn+yNHjtj8zsmTJ5VlgqN8xgEcP34cffr0QVxcHIYOHaqOmTVrlkpeRHeAI4wcORLDhg1Lsv/q1auIiYlx+HoE9yDTod8Rfn4nEoPCEFn7fSRGRMDTO4uoqCjViVJJFgRPQ9pwUqKjo+GRSgAFJv3s1tBH36tXL6eUgNQ2Jv7WlClT1Mi/Zs2auHDhAkaPHq2UgHPnzqF///5YtWqVCjR0BFoizFMe0xJQpEgRZWXIlk3MyB5F9GX47Rxj3G42BLlLVoWnwzbPeBu2R+lABU9E2nBSHJVPbqcEnD17FiVKJE22UqxYMfWZM+TOnVsJ8itXrljs5/v8+fPb/A5nBDAWwNz0X758eVy+fNnkXoiIiECNGjVMn9PasHHjRpXjgGZ/8+8SzjDgyxo2VmmwHsaKwcD9W0DBGvCv24s3Ed4AO1Bpj4InI23YEnepB6dLwVH4P//8k2T//v37kStXLqdTEHMkv2bNGguNke/p97cFMxXSBWDuT2G2QioHPN/jjz+uFjbat2+f6VWrVi3lPuC2tQIgeBHHVgCHFwB+AcacAP5yrwVBEFxqCejUqRPeeustZM2aFY0aNVL7NmzYoEzwHTt2dPZ0ygxPFwIFdZ06ddQUwTt37phmC3Tr1k1NA6QbgvTu3VuN6Pl7b775Jv777z+1gBHLRFiuSpUqWfxG5syZlYJivV/wIu7fBpa8a9yu1wcoINNCBUEQXK4EfPbZZzh9+rQacTN9MOGonMKawthZOnTooALwhgwZokz61apVw/Lly03BgnQxmJtN6KtfsWIFBgwYoOb/U0GgQsDZAYIPs34kEHUOCC8KNHk420QQBEGwj5+B4ZqpgCZ4ugAyZcqEypUrq5gAb4GBgeHh4SqaVQIDPYCL+4AfmqqpgegyFyjTAt4ElWzGudAV5y5+REFwBmnD7itnnLYEaDBBD/WHUqVKmSwCgpDhJMQDi/obFYBKz3udAiAIgpCeOK2SMRfAq6++irCwMFSsWNE0I4D+eebpF4QMZef3wKV9QGg40EranyAIQroqAZxTTzfA+vXrLeY5MjMf1wEQhAzj5jlg7QjjdotPgSxJ15oQBEEQ7OO0HX/BggVK2D/66KMWCwnRKnDixAlnTycIqYOhLEvfA+LuAEXrAdW76V0iQRAE77cEMJLf1up+nNZna3VBQUgXDv8FHFsO+Ac9yAkgwUaCIAjO4nTPyfn8XOVPQxP8P/74o90EP4LgUmKigGUPpoQ2GADkKad3iQRBEHzDHcBcAE8++SQOHz6M+Ph4jBs3Tm1zaV8mDRKEdGf1MOD2ZSBXaaDhgwRBgiAIQvpbAho0aKACA6kAMD/AypUrlXuAS/8yBbAgpCvndgJ/TzVuP/0NEOQei3AIgiB4vSWAy/W+/vrr+Pjjj/HDDz+kX6kEwRYJccacADAA1boAJYxpqwVBEIQMsARw9b558+al8qcEIY1s/RaIOAyE5QKeGK53aQRBEHzPHdCuXTs1TVAQMpTrJ4ENo4zbLT8HwnLqXSJBEATfCwwsU6YMPv30U2zZskXFAHCFPnO01fwEwaU5ARYPAOJjgJJNgCod9C6RIAiCby4gVKJECfsn8/PDyZMn4em4y8IOwgP2zwL+fB0IDAX6bANyloQvIYuvCJ6OtGH3lTNOWwJOnTqVPiURBFvcuQas+NC43fh9n1MABEEQ0pM0qWQ0IqRyJWJBcIxVHwN3rwF5KwD1xdUkCIKguxLw008/oVKlSmoBIb64zYyBguBSTm0E9s2go8mYGjggSO8SCYIgeBVOuwOGDBmCMWPGqKWDtTTBTBQ0YMAAtawwgwYFIc3ExQCL3jZu13oFKFJH7xIJgiB4HU4rAZMmTVKJgjp16mTa98wzz6BKlSpKMRAlQHAJm74Grp8AsuQHmg/VuzSCIAheidPuAGYN5CJC1nC6IFMJC0KaiTgCbP7GuP3kl0BouN4lEgRB8EqcVgJeeuklZQ2wZsqUKejSpYuryiX4KomJwOK3gcQ4oGwroEJbvUskCILgtTjtDtACA7lw0KOPPqre79ixQ8UDdOvWDe+8847pOMYOCIJT7J0OnN0GBGUGnvqKySf0LpEgCILX4rQScPDgQdSoUUNtnzhxQv3PnTu3evEz88RBguAU0VeAVUOM280+ArIX0btEgiAIXo3TSsC6devSpySCsGIwEBMFFKgK1Hld79IIgiB4PZK/UXAP/lsFHJwH+PkDbb4FAlLlqRIEQRCcQJQAQX9i7wCLH8SSPNoHKFhN7xIJgiD4BKIECPqzfiQQdRYILwI0Gax3aQRBEHwGsbkK+nLpH2Dbd8bt1l8DIVn0LpFXk5CQoHJ9CEJGryLIdhcTE+MzqwgGBQUhICAA7o4oAYJ+JCYAi94CDAlAhXZA2ZZ6l8hr4UJfly9fxs2bN/UuiuCj7Y+KQHR0tE/NHMuePTvy58/v1tcsSoCgHzt/AC7uBULCjZkBhXRDUwC4nntYWJhbd0qCdyoBzCgbGBjoE23PYDDg7t27iIiIUO8LFCgAd0WUAEEfos4Daz8zbnNtgKz59S6RV7sANAUgV65cehdH8EF8TQkgmTJlUv+pCPDZc1fXgG84ZwT3Y+n7QOxtoEhdoGYPvUvj1WgxALQACIKQcYQ9eObcOQ5HlAAh4/l3EXB0CeAfCDw9FvCRQCG98ZURmCC4C34e8My5Re87ceJEFC9eHKGhoahbty527tyZ7PE0bfbt21f5WUJCQlC2bFksXbrU9PnIkSNRu3ZtZM2aVZlh2rVrh6NHj2bAlQgpEnPLaAUgj/UH8lXQu0SCIAg+i+5KwOzZs9WiQ0OHDsWePXtQtWpVtGzZ0hRQYU1sbCxatGiB06dPY+7cuUq4//DDDyhUqJDpmA0bNiglYfv27Vi1apUyxTzxxBO4c+dOBl6ZYBPGAURfBHKWBBoN1Ls0gg/RpEkTvP3223oXw635+OOP0atXL3g769evV6P0m2azZRYsWIDSpUsr3z3byfLly1GtWjU1q8GrMehMnTp1DH379jW9T0hIMBQsWNAwcuRIm8dPmjTJULJkSUNsbKzDvxEREWHgpW7YsMGh46OiotTx/C+4kLM7DYah4QbD0GwGw4l1epfGY+AzcenSJfU/Ndy7d89w+PBh9T+txCckGrYejzQs2Hte/ef79KR79+7qWbTuD/7880+13xmuXbtmuHXrliEjyqu9cubMaWjZsqVh//79BneHbSxr1qyG06dPu/zciYmJqs/m/4ymcePGhv79+1vsu3//vrreRLPy5M2b1/DBBx8YLly4YGontWrVMkyfPj3Vv53cs+cuckZXSwBH9bt370bz5s1N+5hIgu+3bdtm8zsLFy5EvXr11Eg/X758qFSpEj7//HMVAW2PqKgo9T9nzpzpcBWCQyTEAYv6G/vGqp2Akk30LpHgJMsPXkKDL9ei0w/b0X/WPvWf77k/PaGb8Msvv8SNGzfSdB4+/3QRpjetWrXCpUuX1GvNmjUqIv7pp5+Gu/Pjjz+ifv36KFasGDyBtATbBQcHW8zfv337trI+0wpdsGBBUzt5+eWX8e2338Kb0VUJiIyMVMKbwtwcvue8ZlucPHlSuQH4PcYB0Hz19ddfY/jw4TaPpymHpp3HHntMKQy2uH//Pm7dumXx0r4rLxe9to4HIg7BkCknElt8pn95POylJVtJy/fT8lp24BJ6/7YHl6JiLJ6dy1Exaj8/T+tv2HoRDgrYYVPZt/5M22Zf0qlTJ+UWZER25cqVMXPmTIvj6Q7o37+/2h48eLCKP7L+Pbojhw0bZnpPV2P58uWVIvLII4+o+KWUyss4JfZhfPF8H3zwAc6dO6eEjHbc+++/r2KZWNaSJUvif//7nxoU8bNTp06pwdCuXbsszv3NN98oAc2+j+8PHDiAJ598ElmyZFG/9dJLL+Hq1aum4+fMmaPqgVPVODWU9UhhZ6/ss2bNUsqK+T72hV26dEHmzJlVDNaYMWMs6pEvZgF89913Vd3zONYrV5vVPv/555+RI0cOrFixAhUqVFDlpaJ08eJFi99Krq5ZJxTYLGPjxo3VMb/99luK951CnO7hcePGqe/zxXOxfNy+ceOG2taEfrNmzdR+rfysj7///hvHjx9PUzu291y6Ax6XJ4AVx2C/KVOmKN9NzZo1ceHCBYwePVrFFVhDi8HBgwexefNmu+dkICEffGv4QLGBC2kj4NY55N5gTAYU9ej7iLmdANy2HfMh2G7ztGaxM0lNylWOmHgOztPmi/Bc9+LsW8/MSUg04JOFh5R92xru41jqk0WHULd4OAL8U46GzhQU4HDUNMvNYz/99FN069YNffr0QeHChU2WP+16KNzov2V8UbZs2bBs2TJ1PAOOGSSsXbM2X71Dhw744osvVExRqVKl1OeHDh3CP//8owQNj6EwYZ8yduxYde59+/ahd+/eSgDx3PbKq9W1Vq5ff/1V+ZrDw8NN+yksOfKmYGX/xPNy33vvvaeu7/HHH8fUqVPV72pQmFLQ8/zXr19Xx/To0QOjRo3CvXv38NFHH+HFF1/EypUrlRWic+fOqm9r27atytS3ZcsW1Ra0MpjD8x0+fBjVq1e3+HzAgAHqe/Pnz1f9LvtJxm5VqVLFdBz72H///VcJZV7PX3/9pZQTHlemTBlVXibOoRLDa2K/3b17d6U4TJ8+XZ0jpbrWfovKG61CVBj4WUr3/auvvlL3uGLFiib5kCdPHpw4ccLUfurUqaPuAQeJjFGjpZlWI35GqwAVLCoSqbGQ8By8/mvXrqk0wubwnsDXlYDcuXOrBnHlyhWL/XxPzd8WbGTWOZmpPdJyQE2aZh6Nfv36YfHixdi4caN6sOzBhsVGpEHtt0iRIqqxsGEJacBggN/K3vCLj4GheCNka9AL2Txg2ow7oQlCtsfUKAFUZNnh0CzNF7kbG4+qn611SfmoCFy5dR81Rqxz6PhDw55AWJBjXQ+vl68XXnhBjUI/++wz/PTTT6bnX7sedtAcXWtwlL169WrMmzdPdepEGwnyOxyh8/XHH38oayKhAOAolqNQwt+iEGnfvr16T4FGgcLff+WVV+yWlxZKjnwJg5HZZy1atMiibxoyZIhpmwoCR5r8/UGDBql9r732mhKCFJy0LFCgUlBRwLL8kydPVgKbiowGBWzRokWVtZTCkQKI9aYJLx5vD21Uzn5Pq1O2GSowM2bMUIHV5JdfflGjbq0ez549i2nTpuHMmTNKYBLeBwZk87u03rBOqHxMmDDBVLfsm1m/2m+lVNfacbRAaMdoJHffaQFh/VHBMpcB5u0nLCzMVHY+Y9aygp/RkqOVwRn4HV4/y0GlxRzr9z6pBPCh4EiefjNO49M6PL5nI7EFzfrUGnmc1iEeO3ZMPWjaQ8bG/Oabb+LPP/9UUaAlSpRIthxsJHzZ64CENPDPHODkWiAgBH5txsLPTbNmuTvsdFPbHvkdTQBqI3A95y+bl8OZ73AESHPtwIEDk1wHLQMUOBTqtAxyQEA3n3WKZPPfppmbgpMCWTOHczDAzym8OVqkMDaPlqdg5Yg+ufI3bdoUkyZNUts0N3/33Xd46qmn1NRnTSBT4NPXzN/QBDYHHNp5n332WdUHMmK9Y8eOStDyvFpfRouFuRnbHCoBFNq0FHDETj8331Mh0JQTazSLJ10HWhloNqfwpmKk7WMu/HLlypnqkYoJ6577zGHdU/Bpx/E+UNnR7gEFK90jjta19vsc3ZvXfWruu3m78bPxXFjfW9YJLS2peWa089l6dt1FtujuDuBDR9NQrVq1lFmG5iA2Cpq5CE071Dxp1iLUjqlRUiOkoP/vv/9UI3jrrbdM56R5iooCtWY+JFp8ARuUlspRyADuXgeWG0c2ajpgLqPZVdAfmuQPf+rYgk07T13Hyz/vSvG4X3rURp0SOR367dTQqFEjJdBouaOv1xy6A+n3Zf9BvzBHfowFolCwB33J9NdzlM1OnqM9ugkIBTOh2ZlC0JyU0r/ytzWBR2j2Z9/DczF2iUHPVEBoWuf18DMqIIxt0uCAhn0fXQDPPfec6s94fRosX5s2bZRiZA0HRCwjR+Nbt25V7oHx48crd8GOHTtsDopoldWUFo6GHYXl4G8xwNu6Xuj717A2hVMwajEUztQ16zat991Zrl+/7lSdeBq6KwF86Oh7pzZOYU3/DudnasGCNDeZa0w0VzHAhL4qarlUEKgQ8GHW0LRwBrCYwwfKuvMQ0pFVQ4C7kUCeR4yJgQS3QY3Ogh17/BuWyYMC4aEqCNBWXADHR/nDQ9VxjsQEpAWav9lHWI886bem77tr167qPS2FtBAyEM0eNPsyyIzmbioBzD9Cvzdh/8PRKkfVFNhpQRsJ8jcIBTMtAhTKGjSnW8ORMf3UtCRwVExlQKNGjRrK5E3ftz0zNX+XllO+2L/yN2kdNXd9ajAugpYIxgXQpE4YsEjhzQBFuhkIY1NYr1TINBcDR+Mc1Tds2DBV9ZOWunbkvlOhSm72WHLQQkIrRXKuFE9HdyWA0Oxlz/xPc7419PUwEZA9NA1T0JHTW4C9vxq3mRo48KE/VPAsKNiHtqmgZgFQxJs/XZrI5+fprQAQjvYoKKynbdGHzFlDFLA0eTN+gLFFySkBhOdiwBhHjvS/m8OROi2MHKkzmp1mZkaKc7RsS5Bq8DjN+shjabnURu5aWTm44eif5u0lS5Yo4WwNY50effRRNcChX9zciklrJ0fOtGbQJ85ANsYV8Jy0PLCcdKvSDUDFhhYADrZ4TltoU7MZQK25ZmlFpZWW7heen+dhXWnuJUKFgXVIqwUtGRSW/B3+NgdprVu3Trb+01rXjtx3Kkq8fiaYo3XCmani27dvV65iLa7EG3EPp4TgXcTff5ATAEDNl4Fi3vsA+QqtKhXApK411IjfHL7nfn6eUXCmgPX0Kk6x4+iY5nVaABlYrAmz5KCfnJHbjF63Pp4jcQpUWhCpfNBqwMC4lGKMaMmkSZ4vmrc5kuZ0Pc0y+cwzzyhLJgc+tGpQgGnBida8+uqrSkGxDkTkyJmjYI5wKehZPprB6bOnkOaongHRjEWgoGb9UEgzat8evF4qEeZ1S6FKAcipclQSaFXQpvFpsH6oBDDanxYa1qO59cARUlvXjtx3zrigW4GKAc36VMAc5ffff1dKjjcvvuXHjEF6F8Ld4OwAaqQ0fcnsgFSw/gtg/Uggc16g304gk+1gJMEx2Clry5GmdnYAg7zYoaY1IpnTBRkjEBEdg7xZQ1UMQEZYAHwVRs1TgWAgYHpDUUClhQoKLQy2YLwWXbBUKKigePNSwpGRkUqpoUUiJWUkNc+eu8gZt3AHCF7E1WPApgcBTk9+IQqAl0GBX69ULr2L4fXQfUDzNV0J9hKhuRoKZ+ZfYRIijb179+LIkSMqaJvCilYYQj+8t3P69GkVj5FaBcBTECVAcB00Iy5+G0iIBUq3ACo+DGQSBMFx6CqgKZqmbXs5CdIDuifMExQRLeGONqV706ZNptkE3kytWrXUy9sRJUBwHft+A85sAYLCgNZfc2ihd4kEwSOhP5wvvWGgH6f/Cd6LBAYKruH2VWDlg+Cmph8COTxjERJBEARfRpQAwTWsGAzE3ATyVwHq9ta7NIIgCIIDiBIgpJ3jq4EDcwA/f6DNOCBAvEyCIAiegCgBQtqIvQssfpDMo87rQKEaepdIEARBcBBRAoS0wSWCb54BshUCmj1MgyoIgiC4P2K3FRzj5jng7jXLfddOAFsepG9tPAgISbqimSAIguC+iCVAcEwBmFATmNLY8jWP85cfpBhd9p7xOEHwMJhbnqvQpRZO5WO6XneBefuZ2je5RXM++eQTi3wAXFjNkTTLqYVrwDDPwM2bN3W9V84kCvLz88O+fftM+5immSmNuagS64qLLXERKmZR9GTEEiCkDC0AXA8gOfg5j8teJKNKJehtCTInLFe63HsKJwqOBQsWIL1gnnvrJWqTE0LM0c+X+UqozNHvLnBBIebUT2nJY3O4HG96ZpCvX7++ytnPNLkZda/S0saKFCmCS5cuWSRF4kJGVJyWLVumFiKi4scFnri+gr21HzwBUQIEQXDMEpScIhgYAvTb7ZFKYFrXiufqfuYr/OkJVwHk0rfPP/+8U99Lq3BOjri4OGUF4OI+aV03IK33ylECAgJUec1hvb7xxhtq9K/Ro0cP9OzZE4MHD7a7pLO7I+4AQRBcZwnKYDZs2KDy2nO5V67aN2jQILVQjUZ0dLRaBY6jR37O5YK52pz5SN7cxMzRME3lXAGP5+RqfVzilvB7Z86cUQvsUJhpAs2WO+CLL75Avnz51HK8XGiH5TI3v1uXgdDEzFGpBpfT5Qp4XLCH5efiPraWVjeHqwC2aNEiyWI11uXhwjbmWLsDuDwvTd9UbnLlyqVWEDQ3e0+dOhUVK1Y01bv5UvCsl0mTJqnVElnuESNGJHEHaHW2ePFitUgPV+njio5czXHatGnqnnBpYNa9uVvD2h3A3+Lqg88++6w6B5cWXrhwoelzfpfXy/z/vBb+Fq0eGp988on6vb/++st0T1lWc3eAts3VJpnCmdtaNkfW9fXr11U79FRECRCSEnsHOLsD2DEFWNAXmOv4amGCh0DTL++zI6/4e46dk8c5cj4XmZ0vXLigzPC1a9fG/v37leD56aefLBbcoQmXvlwKhlWrVqm893v27LF7znnz5ilF4fvvv8d///2nTMQUhmT+/PlqFMhFdGgq5ssWf/zxhxIun3/+uVqBjkKSC9E4CwXrtm3blGDnKoLt27dHq1atVLnsweuzznfvbHl4XVxFkALv33//VULxueeeM7kLWM99+/ZFr1691GJDrNvSpUtbnIO/R8HMz+2tfUCB/+2336rr4/LL/B1+Z+nSper166+/qvtAhSQ5hg0bhhdffFHVEdsDlT4KZm0FTt4zrsRIH/6QIUPw4Ycfqjoh7733nvou61W7p3RdmKO5BrjSHxUQbtMFRKjYULljvXsqnmm/EFzHvZvA5QPApf0PX5HHKCX0LpmQnsTdBT4v6NpzTm3l2HEfXgSC0+7XpSBjB82V9jg6e+SRR3Dx4kV88MEHqrPnyJWjvJkzZ+Lxxx9X3+F69Rzd24N+a5qBOfJlABgtArQ0kJw5cyozMUfT1qZicygoOPrUltqlUrJ69eoko+/kYDlYVv7XykuBRWHJ/RTotqClwvr6nC0PhRytKRT8xYoZ039ripD2/XfffRf9+/c37aMiZk7nzp2VqdzclG7LTUCFolSpUuo9LQEU/FeuXFE+9woVKqBp06ZYt26dSejaglYMbelj1gsVi507dyrBzntIJUGDFgEqVlQCKPyzZMmiLAS0uti7p5prgG2MbhPr41jfrHdPRZQAX+JOpKWw5+vGKdvHZskPFKhqfIVkA1b9L6NLKwjJwlFqvXr1LPzMjz32mFqG9/z587hx44YSNJoQJ+zEaRK2B0fbFJolS5ZUQoQjyzZt2jjl72W56Ds2h+WkMHMUjqBpyi5btqzFfgormuftce/evSSuAGfLU7VqVaU0UfC3bNkSTzzxhBLQNM9HREQoRUtTquzhyOp7NN9rCgChu4Lmfgpm8338zeSoUqWKaZvuB47Yzb8zceJE5b6gQsX6iY2NTbJSYlqgEkGrhqciSoA3QrNd9OWkAv/WedvHhxcFClQBClR7IPirAFnNtN2LD6fJCF4CV3rkiNwRLv/j2Cj/leXGtSMc+W03hZYFLpvLkTLdB3369MHo0aOVz5ejSlfh7++fJBqfCosGFRmOQLmCn3WUv7mQtIbR7FR+0gJ/j9e+detWrFy5EuPHj8dHH32EHTt2OLyEsCMR/Nb1SWXO1j6a9J09j/YduhpoQfn666+V4kMrDu8nr8VVXL9+3UKZ8TRECfB02JHcPJtU4N+xoz3nLPVwhK+9wnIm/xuc/sXo75Siw3mc4Blw9OyoST4wk+PHucDM7yicC08fPoWpZg2g/58dPf3AHLlSQHBaGc36JCoqCseOHUOjRo2SHdlx9M8Xfd90M3BkXqNGDeUDTm7+vVYuCplu3bqZ9m3fvj1JlLt5TAHPefDgQWX+1pbw5T6OaBs2bOhwnfB79H07Wx5rWJ+0qvBF1wrdAn/++aeKseBonbkItLK6M2wP9PFTmbPnmgh24J4mB+8bLSWeiigBngS12+sngUv7LAU+V++zhov55C5nKezzVwZCszn/u5z2xelfOswTFwQKbvOkLYQmcXbsNN2/+eabKoiOI/ihQ4cqQcWRNpWB7t27Y+DAgcqfnzdvXvU5P7M3VY1R3xQIjMSnufq3335TSoHmG6cA3LhxIzp27Kgi422NjOkrp5+aJnEK0RkzZuDQoUPKxaDRrFkzVc4lS5aoUSTnmpsn0qEbgAFuFNwcxVK4X716VQlfmr9bt25ts/w03zMOwtnymEOFgb9DNwDrjO/521QmtKA/uhf42ZNPPqlmYFDY8j64G5wtMH36dKxYsULFAzDmgEohtzWKFy+uPmf7YbtyZrokZw4wQJUxJJ6KKAHumlglId4YoGcu7GmWjb2d9Fj/ICBveTOBXw3IVxEIdqHZleUVIe+b6GwJYtQ4haA5DHLj1DBGkVPI049NQc/9TJSjQeFKgfX0008rXzET6Zw7dy6J31yD09Y4nY4CmsoA/eKLFi0y+eE5M+D1119Xgpv+eVsJdhjExtEmf4vBd5yz37t3byVoNBgxzxkNFPKMN+C0Q+uRNQMAtSA8ChoqHExOw2uxBxUH/i4Fmhb74Eh5zGE9UdGhgnXr1i2lAFERocAnVKx4Hs6ioKmd5XLXkTDv1d69e1UdUPFjACGVRyb80ejZs6dqY1SS6IZhrAQVA0f4/ffflbKkKYmeiJ8hPdNEeShs+NQGOQLhA5HuiVV4bMS/lgL/ykEg3kb0bmAokK+S5QifCgDPKXgl9G/SLMyRF0exzsIO+9SpU2r0Y0/4uWvGQFfDGQOcd0+hpkXLZwQcPXO6obVFIz2gUsQ+jNPr3AWKGc44oMKT1oRB7kJsbKyyNHD2CS0szj57aZIzLkQsAXolVtn1o/FYCnwqAIkPg4JMBGcxBlqZC/zcZYEAuW1CBuOhliCOAo8cOaJmCLCz5UietG3bFt4Kg/g4fZLKY2qURsExONuAOQfsKQCegkgTvdhitQhGaHargL1qQM6SDCPWq4SC4BV89dVXyjzOALCaNWuqxC6ORrl7InRpUDgJ6Uvp0qWTJEnyREQJ0IsijwLFGzwU+tmLGiO2BUFwGYwl4DQ7vaE7gC9BcDdECdCLJ78ECrouYYUgCIIgOIvYmgXBR5AYYEHIWAwe8MyJEiAIXo6WUc2TU5sKgidy98Ez58psk65G3AGC4OUwDSyDxbR86kyC4y3TtATPwBunCKZ0vVQA+Mzx2bNO/exOiBLgaiTFruCGaCufpbQYiyCkl1DUpiz6ghKgQQUguRUn3QFRAlyNpNgV3BB2vFxHngmHzBeqEYSMgArAtWvXVOZFX8ldEBQU5NYWALdSArjUI1d2unz5skr/yVWrzJf/tIY5tpkQY/78+WoFJ6ZsZIpLLvuZ2nO6FA9NrCJ4P+yUPKFjErxPCaBQZNY8X1ECPAXd78bs2bNVnm4u7LFnzx4lsLkIhj2zJVM1tmjRQi3cMHfuXJUE5IcfflCpQFN7TkEQBEHwRXRfO4CrddWuXRsTJkwwaYxc05srUg0aNCjJ8ZMnT1YjfKYCtRdx6ew5rXGXnM6C4Iq1AwRBb6QNu6+c0fVucFTPbF7myzCygfD9tm3bbH5n4cKFqFevnlrnO1++fKhUqRI+//xz03rQqTmnIAiCIPgiusYEREZGKuFNYW4O33Okb4uTJ09i7dq1aslMLiN6/PhxtTQkg51o/k/NObkkKF8a1My02ANqsIKgJ2yDHDUw972MogRPRNpwUlgf7pBQyC0CA51tTDQpTZkyRQU4cUEQrrVNFwGVgNQwcuRIDBs2LMl+T14jWhAEQXB/oqOjlVvAJ5UAruRFQX7lyhWL/Xxvb24lpzlZT70oX768mgVAV0Bqzjl48GAVSGiuaHDWAaezuPOcVsY97Nq1y6t+2xXnTe05nP2eo8c7clxyx3DEwJiWc+fOeV2MirRh155D2nDGUzuV94oWACoABQsWhJ7oqgRoS3uuWbMG7dq1Mwlgvu/Xr5/N73Dt5pkzZ1qslX3s2DGlHPB8xNlzhoSEqJd1kgd3h8qOXg9Uev22K86b2nM4+z1Hj3fkOEeO4efe1oFKG3btOaQNZzwBabjfeloANHR3znAEzil+06ZNw7///ovevXvjzp076NGjh/q8W7duaqSuwc85Su/fv78S/kuWLFGBgQwUdPSc3oL5NXvLb7vivKk9h7Pfc/R4R47T817qibRh155D2nDG09fTr9vgBowfP95QtGhRQ3BwsKFOnTqG7du3mz5r3LixoXv37hbHb9261VC3bl1DSEiIoWTJkoYRI0YY4uPjHT6nIHgSUVFRjBxS/wXBE5E27L7onidAEITk4cwVBq/SImbtthIET0DasPsiSoAgCIIg+Ci6xwQIgiAIgqAPogQIgiAIgo8iSoAgCIIg+CiiBAiCIAiCjyJKgCB4MMzA1qRJE1SoUAFVqlTBnDlz9C6SIDgF12ipVasWqlWrphaEY44XIeOQ2QGC4MFcunRJpcRmB8rU2cyWySRamTNn1rtoguAQXPCNUwjDwsJUUjcqAn///bdK2y6kPx63gJAgCA9humy+CNfG4NoZzKgpSoDgSWl3qQAQKgMcl8rYNOMQd4Ag6MjGjRvRpk0btYgIF6tasGBBkmMmTpyI4sWLIzQ0FHXr1sXOnTttnmv37t1qVMWFWgTBk9owXQJVq1ZF4cKFMXDgQKXMChmDKAGCoCM0f7LzYydpi9mzZ6u1MLhM9p49e9SxLVu2REREhMVxHP1znQ0usS0IntaGuWDb/v37cerUKbVAnPUqsEI6onfeYkEQjPBx/PPPPy32cd2Lvn37mt4nJCQYChYsaBg5cqRpX0xMjKFhw4aG6dOnZ2h5BcFVbdic3r17G+bMmZPuZRWMiCVAENyU2NhYZeJv3ry5aR+Xz+b7bdu2qffsd19++WU0a9YML730ko6lFYTUtWGO+qOjo9V2VFSUci+UK1dOtzL7GqIECIKbEhkZqXz8+fLls9jP95wJQLZs2aLMrfTDcoYAXwcOHNCpxILgfBs+c+YMGjZsqNwE/P/mm2+icuXKOpXY95DZAYLgwTRo0ACJiYl6F0MQUk2dOnWwb98+vYvhs4glQBDcFEZIc/qUdZAU33M6oCC4O9KG3R9RAgTBTQkODlbJf9asWWPax1E/39erV0/XsgmCI0gbdn/EHSAIOnL79m0cP37c9J5TpGgazZkzJ4oWLaqmVnXv3l2lVaXZdOzYsWpKVo8ePXQttyBoSBv2cB7MEhAEQQfWrVunplVZv7p37246Zvz48YaiRYsagoOD1XSr7du361pmQTBH2rBnI2sHCIIgCIKPIjEBgiAIguCjiBIgCIIgCD6KKAGCIAiC4KOIEiAIgiAIPoooAYIgCILgo4gSIAiCIAg+iigBgiAIguCjiBIgCIIgCD6KKAGCIAiC4KOIEiAIOvLyyy+jXbt2pvdNmjTB22+/bXpfvHhxlWvdlZw+fRp+fn5utXzr+vXrVZlu3rypd1EEwacQJUAQXIC18HaUcePG4ZdffoGn4WpFon79+rh06RLCw8PhLgqZIPgCsoqgIOiInkIvI4iNjVXLyaYEj5H15QUh4xFLgCC4YAS5YcMGNarn6JgvjpQTEhLw6quvokSJEsiUKRPKlSunjknL6JPm8tdeew158uRBtmzZ0KxZM+zfvz/Z7+zcuRPVq1dHaGioWs517969Fp/TEpE9e3aLfQsWLFDXYQ9eE+F5eRwtIebXM2LECBQsWFBdM/n111/Vb2fNmlUJ+86dOyMiIsKuO0Ar04oVK1C+fHlkyZIFrVq1UtYCe9y4cQNdunRRdcP6LlOmDH7++WfT5+fOncOLL76ozstlbtu2bavuE/nkk08wbdo0/PXXX6Z7yDLZgtf61ltv4f3331fn4fXw+4LgiYgSIAhphIK9Xr166NmzpxJSfBUpUgSJiYkoXLgw5syZg8OHD2PIkCH48MMP8ccff6T6t9q3b6+E57Jly7B7927UqFEDjz/+OK5fv253rfenn34aFSpUUMdTWL333ntIK1QsyOrVq9X1zp8/3/TZmjVrcPToUaxatQqLFy9W++Li4vDZZ58phYUKBoUvFYbkuHv3Lr766iulQGzcuBFnz55Ntuwff/yxqmfWzb///otJkyYhd+7cpt9v2bKlUkI2bdqELVu2mBQLWit4XioImqLBF10U9qDCkDlzZuzYsQOjRo3Cp59+qq5XEDwNcQcIggtM+jRnh4WFWZi0AwICMGzYMIvR87Zt25QSQIHjLJs3b1bCl0pASEiI2kchSaE6d+5c9OrVK8l3Zs6cqZSRn376SVkCKlasiPPnz6N3795ICxxtk1y5ciUx41M4/vjjjxZugFdeecW0XbJkSXz77beoXbu2UlIojG1BwT158mSUKlVKve/Xr58StvagkkDLBC0OWlClxuzZs1U9sFyahYNWAloFOOJ/4oknlPXg/v37DrklqlSpgqFDh6ptWhwmTJiglJ8WLVqk+F1BcCdECRCEdGTixImYOnWqElD37t1To85q1aql6lwcRVNoUvCaw/OeOHHC5nc4IqbAogKgQatFelK5cuUkcQCaFYLXQLM9BTJhvdBKYQsqVZoCQAoUKGDhQrCGis3zzz+PPXv2KKFOt4Q2mufvHj9+XFkCzImJibFbd8nBOjUnpbIJgrsiSoAgpBOzZs1SZuavv/5aCV4KoNGjRysTcmqgAkBhY8tXbe3TdwZ/f38YDIYko/DUQkuAOXfu3FGmeL5mzJihrAgU/nxPpcgeQUFBFu85grcupzlPPvkkzpw5g6VLlyrTPN0kffv2VdYS1l3NmjXV79uzajiDrbJpio0geBKiBAiCC+DIl4GA5tDvzJFonz59TPtSM+rUoP//8uXLCAwMtDB1JweD6uhT54hXswZs3749iRCMjo5WwloT4ClN/dNG+tbXbIsjR47g2rVr+OKLL1SsBPn777+RHvBaunfvrl4NGzbEwIEDlRLAuqNLIG/evCqg0tF7KAjejgQGCoILoFDmCJ8Bb5GRkWpUSF8xhR0j3I8dO6YC13bt2pXq32jevLmyKNDMvXLlSvVbW7duxUcffWRXqDIKn6NUBi0yaI6jZApFc+rWratM7wxapJLCOIKUchdQmNKHvnz5cly5cgVRUVF2jy1atKgSsOPHj8fJkyexcOFCFSToahh4yeh+mv0PHTqkghKpBBHOGmCQIGcEMDDw1KlTyqLCKH/GSGj38J9//lFBjbyHabGGCIKnIEqAILgAmv0ZCEj/tmbufv311/Hcc8+hQ4cOStByNGxuFXAWCnMK8UaNGqFHjx4oW7YsOnbsqEzg+fLls/kdBt0tWrQIBw4cUEFzVBi+/PJLi2M4ze23335T56Y///fff09xyhutEQzu+/7779VUQApXe7A+qFRwlgTrhxYBa0XEFVDRGDx4sPLXs454P+iSIVRyOMOACgnvCZUDTt+khUSzDFBR4pRGBhayzLTkCIK342dIzskmCIIgCILXIpYAQRAEQfBRRAkQBEEQBB9FlABBEARB8FFECRAEQRAEH0WUAEEQBEHwUUQJEARBEAQfRZQAQRAEQfBRRAkQBEEQBB9FlABBEARB8FFECRAEQRAEH0WUAEEQBEHwUUQJEARBEAT4Jv8HzJwnrF5N5UsAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 500x350 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scenario A (rho=0.6, d=12)  — precision moyenne sur 40 graines\n",
+      "     n       NB       LR    NB-LR\n",
+      "    15   0.6699   0.6051  +0.0647\n",
+      "    30   0.7015   0.6099  +0.0916\n",
+      "    60   0.7085   0.6489  +0.0596\n",
+      "   120   0.7080   0.6778  +0.0302\n",
+      "   240   0.7085   0.6961  +0.0124\n",
+      "   480   0.7088   0.7027  +0.0061\n",
+      "   960   0.7096   0.7065  +0.0032\n",
+      "  1920   0.7097   0.7083  +0.0014\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2.2 Scenario A : correlation homogene, hypothese a peu pres vraie\n",
+    "ns = [15, 30, 60, 120, 240, 480, 960, 1920]\n",
+    "resA, acc_nbA, acc_lrA = eval_curve(make_corr, d=12, shift=0.9, rho=0.6, ns=ns, seed=1)\n",
+    "nA = np.array(ns)\n",
+    "nbA = np.array([resA[n][0] for n in ns]); lrA = np.array([resA[n][1] for n in ns])\n",
+    "\n",
+    "plt.figure(figsize=(5, 3.5))\n",
+    "plt.plot(nA, nbA, \"o-\", label=\"Naive Bayes (generatif)\")\n",
+    "plt.plot(nA, lrA, \"s-\", label=\"Logistique (discriminatif)\")\n",
+    "plt.xscale(\"log\"); plt.xlabel(\"taille du train set n\"); plt.ylabel(\"precision (test fixe)\")\n",
+    "plt.title(\"Scenario A : generatif meilleur en petit n, convergence\"); plt.legend()\n",
+    "plt.grid(alpha=0.3); plt.tight_layout(); plt.show()\n",
+    "\n",
+    "print(\"Scenario A (rho=0.6, d=12)  — precision moyenne sur\", 40, \"graines\")\n",
+    "print(f\"{'n':>6} {'NB':>8} {'LR':>8} {'NB-LR':>8}\")\n",
+    "for n in ns:\n",
+    "    a, b = resA[n]\n",
+    "    print(f\"{n:>6} {a:>8.4f} {b:>8.4f} {a-b:>+8.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "926d3509",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005381,
+     "end_time": "2026-08-23T20:05:25.771440+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:25.766059+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture A — l'avantage génératif est une signature du petit échantillon\n",
+    "\n",
+    "En petit `n`, Naive Bayes **dépasse nettement** la logistique : à `n = 30`, l'écart atteint environ **+0.09 point de précision**. La raison : le modèle génératif partage l'information entre toutes les variables (estimation de `P(x|y)` par bloc), ce qui lui donne de **fortes contraintes** et donc une **variance faible** quand les données manquent. La logistique, sans cette contrainte, bavarde plus en petit échantillon.\n",
+    "\n",
+    "Mais l'avantage **fond avec `n`** : à `n = 1920`, l'écart tombe à **~0.001** — les deux ont convergé. C'est la signature du compromis : **l'avantage génératif se paie en petit échantillon, il s'efface dès que les données abondent**. Ici, l'hypothèse d'indépendance est *à peu près* vraie, donc le génératif n'est jamais battu — il n'est que rattrapé."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "482ecafc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T20:05:25.785154Z",
+     "iopub.status.busy": "2026-08-23T20:05:25.784585Z",
+     "iopub.status.idle": "2026-08-23T20:05:28.317080Z",
+     "shell.execute_reply": "2026-08-23T20:05:28.316101Z"
+    },
+    "papermill": {
+     "duration": 2.540952,
+     "end_time": "2026-08-23T20:05:28.317961+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:25.777009+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjQAAAFUCAYAAAAzl6bEAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAfOlJREFUeJztnQeYE8Ubxt/r9N6RDiIdpImCAoIURRFERBDEXih2wYIi9l6wC+hfQBBQUVAEEQuKoCC9SRGQ3jnK9fyfd8KGvVxylxzJ5XL3/p4nT7Ilu7OzszvvfN83MxEOh8MBIYQQQogwJjLUCRBCCCGEOFskaIQQQggR9kjQCCGEECLskaARQgghRNgjQSOEEEKIsEeCRgghhBBhjwSNEEIIIcIeCRohhBBChD0SNEIIIYQIeyRosiAiIgJPPvkk8hK8Hl6XnerVq+PGG28MeTrOFl4DryVUeMrHf/75B5dddhmKFy9urverr75CqPGUT+5l/eOPPzbr/v33X+R2ckuZzg5WPv/111+hTooI8vspu7Rv3958RBAFzapVq3DNNdegWrVqKFCgACpXrozOnTvjrbfeOpvD5mn4gNg/hQsXRv369fH000/j5MmToU6e8IHff//dvOyOHDni0/6DBg0yz8ozzzyDTz/9FC1atAh6GkXg+Omnn8JG2AmRn4k+m5d6hw4dULVqVdx6662oUKECduzYgT/++ANvvPEGhg4dirzAqVOnEB2d7WzyCEXfwIEDze/jx4/j119/xeOPP44VK1Zg2rRpCAUbNmxAZGTOGuwee+wxjBgxIqDH/PDDD5GWloZgwrI/evRo0/ovUaJEpvnI8rNo0SI8+uijGDJkCHILOZFP4V6WhBDhRbZrarY2aUL/888/M7zU9+3bh3CGL/qkpCRjdeIn0Jx77rkYMGCAa/mOO+4w5/viiy+QkJAQlHNmRVxcXI6d68SJE8YyRaEYaLEYExODUOKej/v37zff7s9IqAl1PmVGSkqKeQZjY2N9/k8wypIQIrzIdpN88+bNaNCggccXdbly5TKsmzhxIlq1aoVChQqhZMmSuPjiizF37tx0+3z33Xdo166dqeyKFi2Kyy+/HGvWrEm3D1vFRYoUwc6dO9GzZ0/zu2zZsnjggQeQmpqabt+XX34ZF154IUqXLo2CBQuiefPmmD59eoa00ZzM1vOkSZPMNbFSmjNnjtcYmr///hvdunVDsWLFzPkvvfRSY5k6G2jh4rl8eSmvX78e27dv9+m4CxcuRMuWLY1IqlWrFt5//32P+7nHGyQnJxsrRJ06dcx/mYdt27bFvHnzMqTl2muvNfeAeVy3bl1jjXD3Q69duxbXX3+9ufc8jn2bp3tBSxVdcTxmmzZtjMuGMP21a9c2aaJP2d0N4B4bwu08JsvCBx98YPKA95d5QjFuZ+XKleb/NWvWNMfnPbnppptw8ODBdNfz4IMPmt81atRwuQ6tdNjzkfvSHUv4H+6XWXyP5dr4/PPPTd7ThcvngG7do0ePIjExEffcc495vljuBg8ebNZ5etZY1pl3pUqVwnXXXWesp5nlkz/48px68/lndn9ef/111/1hecmpeIcpU6aY/OK18Jlu1KiRsTJnxeLFi9G1a1fTsON77ZJLLsFvv/2WYT++q26++WZUqlTJXBvLzZ133mkaMXZ4L++77z7zLDFvr776apcgtpg5c6bJb+tYzK8xY8ZkePcx7xs2bIilS5eadyDLAs/73nvveSxzU6dOxSOPPGLKPM995ZVXZigz/lyzO7zWUaNGmXzmf3kOlqEFCxake+ewvLJcu3Ps2DHzTPI9b8+vJ554wrwPmBdVqlTBQw895PWZyKr+8RVfni/GzfXu3dvkJ9N9zjnnmP34HGeF9Z7i8ZlmWvA9QcMBy1X58uXNOZo0aYJPPvkk3T7+vP/8qVvZ4ODzyvqS52Yabr/9dhw+fDhb74s9e/aY+858YvoqVqyIq666ym83b7abNHxR05S+evVq8+BkBl/OfOHwwXrqqadMy4sPxo8//miCJQljCxhr0KVLF7zwwgsmnuTdd981lR8FhP0lyMzlfq1btzY36ocffsArr7xibhZfFBZ8KfHB7N+/v3mg+OLq06cPZs2aZTLVDtPCioSVaZkyZby+7HkjeHP44uPDw5YuK1m+QH7++WeTpqygFebAgQMuawVfCCyIrPB9ETT16tUzLxK+jDKDIoD5y0LJ/GfLly8AFr6s4P7PPfccbrnlFvNQ8YXCoMVly5YZl5klAJgXzIPbbrvN5BmF7jfffGMseHaY7xRHzz77LBwOR6bn5gP89ddf4+677zbLTMcVV1xh8vudd97BXXfdZR6cF1980QgO3rusmDx5MuLj481Dxwec/+3Vqxe2bNnislZQrHGZDxZfRLzXfAnwm4KV/+N/Nm7ciM8++wyvvfaaKSuEeewO96Xgv/fee9GvXz90797dvCSygtfLlxldKJs2bTIxaUwjXVm8bt4bpofBpKykWFFYMN/pvqTI5L1jhcj/8wXO5+hsLUX+PKf+MGHCBPNcsBzxhcaKIifgPee9YaOE10PWrVtnnsnhw4d7/R/LHBs1rNj4TPHe8Bo6duxoyi+fGbJr1y7zm/FWvLbzzjvPVBhsWDHv7FYouulZ2fJ4fJGzwuD7iGLDgvecZYjCh99MB+8/n8+XXnopXRpZVljmWBZ4jXy/8f3Ic/K5scNyw/L98MMPm4qS5+7UqROWL19uyqI/1+wJpu+jjz4y6WCIAp/FcePGmXK0ZMkSNG3a1JRxijhaqvlOtecNA+kpVCgKrAqV73Y22JivfCfyfcdnks+nPfDel/rHV3x5vljX8LqYXt5Tvkt4z1nvsBxQ0HmDecJ3FNPKxgvfR7xOPg8UbHZXNuscvh9YRvgemDZtmhElPId72fXl/edP3crjsCzyXTls2DBs3boVY8eONXnAZ8c6pq/vC4o/vmeZX1zHMshnkw13v94pjmwyd+5cR1RUlPm0adPG8dBDDzm+//57R1JSUrr9/vnnH0dkZKTj6quvdqSmpqbblpaWZr7j4+MdJUqUcNx6663ptu/Zs8dRvHjxdOsHDRrE2tDx1FNPpdu3WbNmjubNm6dbd/LkyXTLTFvDhg0dHTt2TLeex2Ma16xZk+E6ue2JJ55wLffs2dMRGxvr2Lx5s2vdrl27HEWLFnVcfPHFmeTYmeN5+vC4CQkJWf7fOsYll1yS5X48ZoECBRzbtm1zrVu7dq25Z+63vlq1aiZvLZo0aeK4/PLLMz0+r5fXbT++/b4S5h3P1a9fvwz/t7a5X1tcXJxj69atrnXvv/++WV+hQgXHsWPHXOtHjhxp1tv35TXwWiy4jfuULl3acejQIdf6mTNnmvXffPON1/JCPvvsM7PfL7/84lr30ksvZTivt3y0zs//ZMWCBQvMviyj9ueIeRcREeHo1q1buv353Nmv9d9//zX39plnnkm336pVqxzR0dHp1rvnk6eyPmHChHTX6c9zyvLpqYx6uz/FihVz7Nu3z5FdPJUl93vhieHDh5tzp6Sk+Hwulu86deo4unTpkq6ss/zUqFHD0blzZ9e6gQMHmnfLn3/+6fE49nzu1KlTuuPde++95n4eOXIk3Tncuf322x2FChVK9/5g3vOYr7zyimtdYmKio2nTpo5y5cq5ypdV5ipXrpzu2fr888/N+jfeeMPva/YE85fnt3P48GFH+fLlHTfddJNrHesQ9+eSdO/e3VGzZk3X8qeffmry9ddff02333vvvWf+/9tvv/lc//hapnx9vv7++2/zv2nTpjn8gfeE94b3yJ5XH3zwQYZ3/uuvv27WTZw4Md3/27Rp4yhSpIjrXvrz/vO1bmWec79Jkyal22/OnDnp1vv6vmA58PUdmRXZdjmxlU4LDdUjg1mp+KjCaCZn69qCSplqmq0I96BTy0RMJUZVSfVOy4X1iYqKMkrRbpa0x53YoaWAatOO1bKwWis093E/WhncocWDLo7MoHqlmZLmOLolLGgeo3WFrQW2RLKCpjReMz80IY8cOdK4uHiMrKwXhPtkZZ1hWr///nuTVgZuW7Alw/uUFWxpUDHTdOoJtkx++eUX09KzH594Mv2736/MYGvZrsotqxdVPE2W7uvd77sn+vbta1q/FiwH7v+1lxfLinbBBReYZU9lJlgwYNzeauJ18p67t6q5nqZuWt4IW7Z81th6tD9HbCHSOubpOfKH7DynvsJ768nKFWxYzmkldXelZgatFnwu+LzSHWnlA4/DssvngveBH77/evTo4bFnm/tzQkuDfR3LKJ/jbdu2eSyjbHHzvNyPLV+6f+3Q2suWtAUtE1xm65euKPcyZ3+26Obke+3bb7/165q9wTJiWVy436FDh0y5Zb7Yny1ae2j1tFul+O7m/eEzbEFrBN9ltHjZyyL/T6yy6Ev94yu+Pl+WBYbvX396rtICznvDd6XdOkWri7tVh/eF5+WzaBETE2OsJexoQm+Bv+8/X+tW5j3TQw1gzwda7mg1tPLB1/cFyzSvl3WaJ5eVP5xVFB39cLzJNLFR1Hz55ZfG5MeHgQ8ABQJdECxImYkFq9K0CqM7dO/Yoc/O/eXHm+WeGTTxsTs002L3q3oqyDTZZQUrcRZQxom4w4eLhZ0VDP2KmUE/Ic25FhSFjFGhr5Jp5gvwbGFaaZbkg+YO02+9qLxB0yyFFwOY6VKk3/yGG25A48aNzXargGflbvQnfy3cBZL1MNtNrvb1vjwE7se0Hm77f/mSpXmarkn3wHZffN+Bwp/rZ5lj2lh++BxR+Hi654EIBPb3OfUHf8pHIKH7kq4YulLYGKMLghUWy3tW+UBTujd4T/heZAPH12fElzLKRgZ7dNFd4t54ci+jjLNh3IIdPs+ELi1LrBP3MsN3JGNTrBgGX6/ZXmm6Q7c63RcUXoyX8XTvKcIobuki4Tub7kfWMdzfLmiYHroGvYlg6/n1pf7xFV+fL14PXYKvvvqqicukIOA7nh1BMnM3WcLV/fg8rr0Bbe3L/dxFWr169dIdy5+y5WvdynzgvfYUK2vPe1/fF7zHdEfdf//9JhyC5ZIhBhTZFG3+EJBuAVRXFDf88IGhX40qjn5WX7CUPf1tni7APa6ECi8r6NNlIaJvk3EXbG2wYNDny4fFHXvLJxSwlUPY0gmEoDlbmG98GdCCRKsU/d8UqwwqpO/YX/zJX2/319t6X6xavvyXFRm7ZDOAlz59tjZYNlm55WQX5+xeP9PIiohBeJ729SV+J1DPKdPh6b64BxeG+vnjS5kNHrammW/88B3Bl6l7gKV7PjBmheXEE8xrCmR/yOr+srVLSzIrAjY4GNfACogWDsa+BLOM+nrNmQXS0tJAizGfL+Y7r5fxYnzP2GGcDGNoeC+4PwUnLTEMerWnh8HbFA2ecBf/gcCf54vCjddrvT9pOeG1MvaNDdqcJsrHd6cvdSvzgfePYs0TliDy533BeCHWe7So8VlknBLzi8K9WbNmWabJdUwEGMu0unv3bvPNh44Xxl4L3h4E7kOYSXbLxdkwY8YM87Azc+xdafmyyi68UYyS51gj7rDVQbWc3QfJchvQXBgIrF5HnlxGntLvCavHAT9MF0UOg+soaKwWA4PC8wJsgcyfP99YaOxBtp7yL7eMHurpOeILii1EqyUe6OP7+pyyVefJnO3ecswNsEHGlyk/fFfRasMKlS9VWim85QOFRWb5wGeQ+wTqGaFJnu4eWiz4LFowINMTDEi2hkiwYMAscQ+0dC/nLEcMOLUssr5eszcYBM13BtNuf348NXp5bWyA0u3E4FFWavaek1Z66BVgQzCz59GX+idYzxcFFz+0qLGhdNFFF5kGIb0GnrB6RPJe2K0atE7xHtsFHfdlpwxem91Ks/6029E6VjBgPjBYmNeTWUPE33qd+9NKww/zgPeLwpBi2FeyHUND/5enFpjlyrDcMlTYzHC2KNxbENb/GdPBB4U9YOymSAv3rou+QKXJgm5vEdJ8ejbDzvOYNElTddu7k+3du9dYffjwZdfszp5BxF5oz6bbNtPKfOX12velmZYiLyvsXZWt1gdf7pbrji9rvnjGjx+fIS2+WExyG1bLxD3t7O3hjlVB+DpScE7BXgu8Dooy9+vgsvs99Rd/nlO+nFhO7etYAfnSxTcncc8TvqusStxT91/CWAFeH3uBeGqAWNfMY/H9x2fb07QG/j4nnsoo3Vq0QHtrJNmHaeC+XOazy2uw87///c/E5NgFCBuldMX5c83+pJ09jRiH6Q7zjWELzDe27nkddneTZU1lzyEOEOkOXe0Ucr7WP4F+vugKtBqoFhQ2TIe3MmUZA3hvKHrsXfrZm8j9XcPea+zqbI81SklJMT2u+K6mJS9YMO9Zr3K4AHeYBiutvr4vGMbBmEU7LGuM6cosvwJqoWH3KiaE3exoDuQNoAplBlP9W2MJsBKkuubF05fIQkGLCfvA08dLsxIvml25GKNx/vnnG5MjbywrytmzZxslyC5h/sBu2TRH0l3AQDb69d5++22THirb7EJ1zWAnihe25Gg240uCGc/AaF9gK8lSncxDmiFp3mbamAeB6rbNB4/Bxsx3ptUq8IzxySoP6HNmt0C+yGip4QuZLzn7aLdvvvmmyQfeMwY0suVCocd7RjN+OMEySIHGe8iHj/EUNBV7av1alQHLNcsqXZls3bvHK+Q0fAmwfDLInPeBL3O+FHgNjG/jPbKP4+Ev/jynDGDm88eXGsfK4PPHFzXLni+B8xbWcAjBEsm0NtI1xBYxXQG0IPEZYevQikdwhxUTXbCs7Hk9fNexvLCCZUOP+WQ1UPgyZzni82p1L6ZQoEuenQj86UbPrry0fDGOhS4MNthY4XvLG75fGZvAskCLAt/NfC45FIF7PBWfcT7LvBY20Cjk+T5iF2t/r9kTjImgdYb1Bd/NLJMsD3zPeBJIFDC8D7TgUAy43wuWQbqiGMDK87PssZKliOZ6NtooEHypfwL9fNGixPckh6pgvvO9y/tEMcT4IG/wnvD4DNxmeWQe8Nj0KrjH0PBcrHfo1mKAN+vc6dOnmwYD7509wDvQsCwzjcw7lic28pl2WlVYrjlcCgWpr+8L1oe0tFEosTywTmV+shxa3fR9Jrvdo7777jvT3e68884z3cTYlbl27dqOoUOHOvbu3Zth//Hjx5vuX+ySW7JkSdMFbd68een2YRdCdgtkly52N65Vq5bjxhtvdPz111/pupYVLlzYp26b48aNM10NeU6mk90jvXUVvvvuuz1ep3tXVrJs2TKTTl43u0t26NDB8fvvv/uUb+7dtdkN8JxzznHcdtttHvPtbLptk59//tl0ueP9YbdHdmv0pYvr008/7WjVqpXpdlewYEGTf+yW6N4tf/Xq1aZLJPfjPatbt67j8ccfd223zrV///4MafP1Xnjr+mx1ObV3j/TWLdhTl0D3e/vff/+5roVlsE+fPqZLvqcyMGbMGNPVlV1C7V2bA9Ft2727p9Wt173rr7e8nTFjhqNt27bmOeGH9455umHDBq/55Eu3bX+eU8IupSxzLHvsisouuf7cH8Kyy+76weq2PX36dMdll11mussynVWrVjXdoHfv3p3lOdk9t1evXqZLLN8xPN+1117rmD9/frr9OKwBu2+XLVvW7Mc84f2wuuZ6u79WeeC3BbsjX3DBBeaZrFSpkmu4DPf9+H5o0KCBuSfsysv7xPSNHTvW4zk4PAGHQWA+8NgcssF9OAZ/rtkddpF+9tlnzf78H+uCWbNmeSyH1v5VqlQxaeO7yBN8F73wwgvmOq16heVl9OjRjqNHj/pd//hSpnx5vrZs2WLqRj4XzPdSpUqZOuKHH35w+MI777xjusIzrS1atDBDRngaBoH1xeDBgx1lypQxZbdRo0amLNnx5/3nT91qdSdnfrO8cPgOnp/lke9Mf94XBw4cMPnHfOT5uV/r1q3N0AH+EnH6woQQIldBFwgtB2xxWoMsCt8tW+wim1X8Dq28nJOPLWu2qoUIZ3J2NkIhhPAR9vijW8NyewghRGZI0AghciWMtWCsgj+TVAoh8i8SNEIIIYQIexRDI4QQQoiwRxYaIYQQQoQ9EjRCCCGECHsCPvVBfoGjTnJocQ5glFuHwhdCCBG+MCKEwxdwEED3iShFRiRosgnFTDAmQBNCCCHs7NixIySTWoYbEjTZxBpamgUtu/M3CRFIiyHnRuHQ4mrJiXBEZTgjnCaEDedgTmWQlwi5oOH8SpySnhNtcWJGzt/RqlUrr/tz1FDOD8H5IMqUKWNGt+ScEpxZm/A35wzhnB6cCZTzn3A+E2uyTPv8MHY4NwXnFvEVy81EMSNBI3JDZcAJ3lgWVRmIcERl2DsKa/CNkJYaTpZ23333mQnIli1bZgQNJ7PjRHae4IzWI0aMMPtz1uhx48aZYzzyyCOufShUOEw6J3zkJJKcaJCTZ1mzr1pw9FFOEmd9fJ1YUgghhBC5j5BaaDgbL4WFNTM3LSSchXP8+PFGuLjD2bw5QydnzyacYbRfv35mGnoLzi5th1OvlytXzsxIytmULQoVKoQKFSoE8eqEEEIIkectNElJSUZkdOrU6UxiIiPN8qJFizz+h+4j/mfJkiVmecuWLfj222/RvXt3r+c5evSo+eYkd3YmTZpkXFYNGzY008GfPHkyQFcmhBBCiHxjoeFMsKmpqShfvny69Vxm/IsnaJnh/9q2bWu6s6WkpOCOO+5I53Jy98nec889xqpD4WI/TrVq1UxXuJUrV+Lhhx/Ghg0bTOyNNxITE83HHqxlnYMfIUIJyyCfCZVFEa6oDGdEeRFmQcH+wKnun332Wbzzzjto3bo1Nm3ahOHDh2PMmDF4/PHHM+zPWJrVq1dj4cKF6dbfdtttrt+NGjVCxYoVcemll2Lz5s2oVauWx3Mz2Hj06NEZ1jMqn4FsQoT6xUdrJCsEBVSKcCScy3Bk/C5EJhz2uj2tQEmkFa3k93E5Bo0IA0FDd09UVBT27t2bbj2XvcW2ULTccMMNuOWWW1xihMG+FCiPPvpouodgyJAhmDVrFn755Zcs++9THBEKJG+Chm4pBjC7d6djF0P1chK5oTJgTwh1eRXhStiW4aM7EPFRV0SknLHgu+OIjoPj7j+B4v6NXWb13hW5XNDExsaiefPmmD9/Pnr27Okq0FymGPEE41zcCzpFEbHm2OT30KFD8eWXXxqLTo0aNbJMy/Lly803LTXeiIuLMx93mJ6wevhEnoWVgcqjCGfCsgyfOgxkImYIxU4E9ytZza9Dh1U+5HeXEy0egwYNQosWLczYMxxjhhYXq9fTwIEDUblyZePuIT169DA9o5o1a+ZyOdFqw/WWsKGbid27Z86caQYj4vg2pHjx4mZcGrqVuJ2BxKVLlzYxNPfee6/pAdW4ceMQ5oYQQuQDjuwATh7MuN7hQPShQ0Bcot8Vf0hITQGS4oHj6b0MIp8Kmr59+5oYlFGjRhnh0bRpU9Pt2goU5uB5doX62GOPGQXP7507dxrTJMXMM88849qHg+5Zg+fZmTBhAm688UZjGfrhhx9c4oluo969e5tjCiGECLKYGdvco0WDb/oyp90zGLIUKBGEqWVoyU86ASTGA0nHgcRjzt/mc/z09zHb9njPH25LVs/Y3EaEw/LVCL9gDA2tPgxiUwyNCDV013JASo65JDO1yLXsWg58cEnW+932M1Cp6ZllCiC72HCJD4oLd8Fx3Lso4bIjwD2HImOAtGT/r8kHVM/k4V5OQgghwhhfrRrTb3aKBEuI+CIY/CEiEogrCsQVA2KLnP7Nj/W7mPM73Ta3T+zp/fet802kiaAjQSOEEOLsoKGfQa/HdgLHdrl9dgLxu52/aTnxhUObPK+PKexZfGQqPNxECv8XU4gRyAHNAhF6JGiEECLcAmgtCpUOTqyJnbRU4Pg+pyCJt4mUY7vTC5aUAI7H1e0loFIzm2g5LUwinZ0/hPCEBI0QQoRZAK2Lsw2gTUk6Yz2xrCtm2bK07HYuO1J9O16hMkCxSkCxykCximd+F+XvysDJA8CEblkfp0orv+NNQgZFJe9DVveJ+4mgIkEjhBC5EVpmshjfxGznfp4EDYNjXeLELlJslpYT+32POaEoMcLEEiyV0n+4jRV3ZuzKgz2DmPcUlaG2pAkJGiGECGvWfQNs+DZj7Eqic2LeLImKTS9SLGuKXawULgdEqbrwCsWKBEvIUQkVQohciY8javz6svdtjDvxaE2xflcGCpXKuQBZH9wzHIcmQu4ZkQ0kaIQQIjf0Ejq6A9i5DNj1t/Ozc6lv/63SBih3nue4lQLFwsY9k+Zw4NChQyh1Tm1EyNohsoEEjRBC5DSMabGEy67TIiazGIzM6PZ8+ATQZuaeSUtDStQ+oHi5UKRK5AEkaIQQIpicOGATL6c/DNZ1JzIaKN/A2V2ZH4658sUtoUixEGGJBI0QQgSKU0eA3cttrqPlwNHtnnsNlT0PqHS+07rCb4qZmAJn9uF/hRA+I0EjhBDZgd2id69I7zo6tMXzvqXrnLG8VD4fqNAIiC2c+fE1vokQfiFBI4QQWZF8Ctiz+ky8Cz/7N3juiVSimlO0WAKmYhOgQHH/z6nxTYTwCwkaIUT4E8gpAjh67r41p3saUcAsB/at9TxaLnsTGeFy2m3E3+wGHSg0vokQPiNBI4TIv1MEpKYA+9enD9jduxpITcp4jMJlz4gW61O0fOCvRwiRLSRohBD5Y4oA9jai68jeVXr3SiDlVMb9C5Q4E+9iiRdaYzRDsxC5FgkaIUT+YEJ3IMXDXEKxRU+7jJqeFi/nAyWrS7wIEWZI0Agh8gcUM9EFgYqN07uOStcGIiNDnTohxFkiQSOEyB9cMwGod6UmWRQij6JmiRAivNm3zrf9StWUmBEiD6OnWwgRnhzfB8wfDfw9MdQpEULkAiRohBDhRWoysORD4KfngMRjoU6NECKXIJeTECJ82PIz8F474PuRTjHDUXivnegcZyYzNEWAEHkeWWiEELmfI9uBuY8Ba2c6lwuWAjo9ATS7AYiMAippigAh8jsSNEKI3AsHwvvtTWDha84B8DhLdctbgA6PAAVLntlPUwQIke+RoBFC5D4cDmD9bKdridYZUq0t0O0FoELDUKdOCJELCXkMzdtvv43q1aujQIECaN26NZYsWZLp/q+//jrq1q2LggULokqVKrj33nuRkJDg1zG5/913343SpUujSJEi6N27N/bu3RuU6xNC+Mn+jcDEXsDU/k4xwykHrhkP3DhLYkYIkTsFzdSpU3HffffhiSeewLJly9CkSRN06dIF+/bt87j/5MmTMWLECLP/unXrMG7cOHOMRx55xK9jUgR98803mDZtGn7++Wfs2rULvXr1ypFrFkJ4IeEY8P2jwLttgM0/AlGxQLv7gSF/Ag17ayoCIUSmRDgctO2GBlpPWrZsibFjx5rltLQ0Y3UZOnSoES7uDBkyxAiZ+fPnu9bdf//9WLx4MRYuXOjTMY8ePYqyZcsacXTNNdeYfdavX4969eph0aJFuOCCC3xK+7Fjx1C8eHFzvGLFigUkP4TILiznFO3lypVDZLgN45+WBqycCvzwBHD8tKX03G5A12edg+GJfEFYl+EgoXrGP0JWapKSkrB06VJ06tTpTGIiI80yhYUnLrzwQvMfy4W0ZcsWfPvtt+jevbvPx+T25OTkdPucd955qFq1qtfzCiGCBGe8Ht8F+OoOp5gpVQvoPx24forEjBAiPIKCDxw4gNTUVJQvXz7dei7TYuKJ66+/3vyvbdu2oGEpJSUFd9xxh8vl5Msx9+zZg9jYWJQoUSLDPtzmjcTERPOxK2erVcGPEKGEZZDPRNiUxRMHELHgaWDZ/xABBxwxheG4+AGg9Z3OMWPC5TpE/i3DOYDyIg/3cvrpp5/w7LPP4p133jGupU2bNmH48OEYM2YMHn/88aCe+7nnnsPo0aMzrN+/f3+GoGQhQvHio1maFUKuNtenpaDQms9Q5M83EZHkbBScqtMD8Rc8iLTC5YFDR0OdQhEiwqYM5yDx8fGhTkJYETJBU6ZMGURFRWXoXcTlChUqePwPRcsNN9yAW265xSw3atQIJ06cwG233YZHH33Up2Pym66pI0eOpLPSZHZeMnLkSBNsbLfQMDaH8TjybYrcUBlERESY8phrK4N/FyJizsOI2LfWLDoqNIKj6wuIq9oGWYzzK/IBYVGGcxj21BVhIGjo9mnevLkJ8O3Zs6erQHOZwb+eOHnyZIaCTgFDqOp9OSa3x8TEmHXsrk02bNiA7du3o02bNl7TGxcXZz7uMD16+ERugJVBriyPR/9zjvK75kvnMgfE6/gYIpoPRgRH+RUit5fhEKF8CCOXEy0egwYNQosWLdCqVSszxgwtLoMHDzbbBw4ciMqVKxt3D+nRowdeffVVNGvWzOVyotWG6y1hk9UxGTF+8803m/1KlSplrCvsAUUx42sPJyGEDyQnAIveAn59FUg+6Rzlt/lgI2ZQqFSoUyeEyGOEVND07dvXxKCMGjXKBOQ2bdoUc+bMcQX10mpiV6iPPfaYUfD83rlzpzFNUsw888wzPh+TvPbaa+a4tNAw0Jfj1DAuRwgRADgSxMY5wJwRwOF/neuqtgG6vQhUbBzq1Akh8ighHYcmnNH4ACI3kWvG8DiwCZjzMLDpB+dy0YpA5zFAo2s0MJ4IjzKci1A9k4d7OQkhcimJ8cAvLwGL3gHSkoHIGKDN3QC7YscVDXXqhBD5AAkaIUT2oYF31TRg7uPA8dPjONXuDHR9HihTO9SpE0LkIyRohBDZY/cK4NuHgB1/OJdL1nAKmXO7yL0khMhxJGiEEP5x8hDw4xhg6ceAIw2IKeScRLLNECBG42YIIUKDBI0QwjfSUoG/xgM/Pg0kHHGua9ALuGwMUPycUKdOCJHPkaARQmTNtt+d7qW9q5zL5RoA3V8EqrcNdcqEEMIgQSOE8M6xXcC8Uc7AX1KgONDhMaDFTUCUXh9CiNyD3khCiIykJAKL3gZ+eRlIPsEhq4Dmg4COo4DCpUOdOiGEyIAEjRD5jSM7gJMHvW/fuwb49RXg0Gbn8jmtnO6lSs1yLIlCCOEvEjRC5DcxM7a50wKTFUXKA52fAhpdy1nyciJ1QgiRM4Jm3bp1mDJlCn799Vds27bNzH7N+ZQ4WSTnQ+LcSJ5mpBZC5BJomfFFzDTuC3R/GSig4daFEOGBT82uZcuWoVOnTka4LFy40Mx0fc8992DMmDEYMGAAOB3Uo48+ikqVKuGFF14wEz4KIcKYC+6SmBFC5D0LDS0vDz74IKZPn44SJUp43W/RokV444038Morr+CRRx4JZDqFEEIIIc5O0GzcuBExMTFZ7temTRvzSU5O9uWwQgghhBA553LyJmYSEhL82l8IEWJSkkKdAiGECAp+d11IS0szsTOVK1dGkSJFsGXLFrP+8ccfx7hx44KRRiFEIDh1BPj2wVCnQgghcoegefrpp/Hxxx/jxRdfRGxsrGt9w4YN8dFHHwU6fUKIQHB0JzChG7BneahTIoQQuUPQ/O9//8MHH3yA/v37IyoqyrW+SZMmWL9+faDTJ4Q4W/atA8Z1BvatBQqVBaLONEQ8Eh0HFNJowEKIPD6w3s6dO1G7dm2PrigFAwuRCyeV/Ow6IOEoUOZcYMAM5zQGmY0UTDFTokpOplIIIXJe0NSvX98MrFetWrV069mlm+PUCCFyCWtnAjNuBVITgSqtgX5TgEKlnNskWIQQ+V3QjBo1CoMGDTKWGlplvvjiC2zYsMG4ombNmhWcVAoh/GPxB8B3DwFwAHUvB64ZB8QUDHWqhBAi98TQXHXVVfjmm2/www8/oHDhwkbgcEoEruvcuXNwUimE8A2HA/hhNPAdezM5gBY3AX0/lZgRQuR5sjU5Zbt27TBv3rwM6zkFQkRERCDSJYTwl9RkRMy8C1g5xbnc4THg4gcAPZNCiHyA3xaaG2+8ESdOnMiw/t9//8XFF18cqHQJIfwhMR4l59yBCIqZiCjgyrHAJQ9KzAgh8g1+C5oVK1agcePGZt4mi08++cR02y5Tpkyg0yeEyIrj+xDxvysRt2MhHDGFnMG/598Q6lQJIUTudjktWbLETDzZvn173H///di0aRO+++47vPrqq7j11luDk0ohhGcObgYm9kLE4X+RVqAk0H8aIqq0DHWqhBAi9wsaztP00ksvoVChQmYKhOjoaPz8889mUkohRA7y31Jgch8zpoyjZHUc7PI+SlduHupUCSFEeLicOHgeLTMvvPACRo4caYRMr1698O2332Y7EW+//TaqV6+OAgUKoHXr1sYK5A1ahhh47P65/PLLXft42s4PhZgFz+e+/fnnn8/2NQiRo2ycC3xyhXOAvIpN4Bj8PVJLVA91qoQQInwsNC1atMDJkyfx008/4YILLjA9mzivE0XNTTfdhHfeecev402dOhX33Xcf3nvvPSNmXn/9dXTp0sWMbVOuXLkM+3Pcm6SkMzMGHzx40MTv9OnTx7Vu9+7d6f5Dl9jNN9+M3r17p1v/1FNPpXOTFS1a1K+0CxESln0KfDMccKQCtS4Frv0EiCkMnNwX6pQJIUT4WGgoaJYvX27EDKFl4+GHHzZBwr/88ovfCbBibwYPHmxGIaawoTtr/PjxHvcvVaoUKlSo4Pqw+zj3twsa+3Z+Zs6ciQ4dOqBmzZrpjkUBY9+P4+oIkavHmPn5JeDrIU4x06QfcP1UIE5CXAghIhw0sQSIxMRExMXF+bw/LS0UI5w2oWfPnq71HIn4yJEjRohkRaNGjYzbixNmemLv3r0455xzTE+s66+/Pp3LKSEhwbjQqlatarbde++9JibI27XxY3Hs2DFUqVIFhw8fRrFixXy+ZiGyRVoqIr57EBFLJ5hFx0X3wtHxcVe3bI7avX//fpQtWxaRkX63U4QIOSrDGWE9U7JkSRw9elT1TKBcTsxUKzP5OzP8ETQHDhxAamoqypcvn249l32ZuZuxNqtXr8a4ceO87kMhQ0sMXWJ2hg0bhvPPP99YfH7//XcTD0RXFS1GnnjuuecwevToDOv5AFIYCRE0UhJQ4of7UODf+XAgAvFtH8PJhgNY+NJVBnzpsX2iykCEIyrDGYmPjw91EvKeoKFCZGXPmJYSJUp4HA3YGiWYAiWnoJChhaZVq1Ze96Hrqn///ibg2A7jdiw4rk5sbCxuv/12I1w8iTIKHvt/LAsNWxNSziJonDyEiCm3IuK/JXBExcHR6wMUqXclinioDPj8qXUrwhWV4Yy411siAILmxx9/NJYMsmDBAgQKDsQXFRVl3EJ2uMyYlszgaMVTpkwxgb3e4KzgDC5m4HFWMCA5JSXFjHhct27dDNspcjwJHT54evhEUDiyHZjYGziwEShQHBH9piCi2oVed2dloPIowhmV4fQoH4IgaN544w00a9bMWCK2bduGvn37+uVa8gatIs2bN8f8+fNdMTRU6VweMmRIpv+dNm2aiWkZMGBAphYcHp+9oLKCgc4sPJ56VgmR4+xZBUy8Bji+ByhWGRgwAyhXL9SpEkKIXItP8m/WrFmu+ZvYG4l+zkBBN86HH35oYl04a/edd95pzsXzkIEDBxp3jyexQhFUunRpj8elS4ii55ZbbsmwjT2y2D2c0zhs2bIFkyZNMgHBFEd0rwkRUrb8DEzo7hQz5eoDN8+TmBFCiEBYaM477zwjKtj1mbEyn3/+ude4EQoQf6C1h4G1o0aNwp49e9C0aVPMmTPHFSi8ffv2DGY3upEWLlyIuXPnej0u3VFMa79+/TJso3WJ25988klj5alRo4YRNPYYGSFCwqrpwJd3AGnJQLWLgOsmAwVLhDpVQgiRN7ptsxcQK/vNmzfj0KFDpteQp8BgruP2/AAtQMWLF1d3OhE4fh8LzH3U+bt+T+Dq94EY34IC6ardt2+fcZnK7y7CEZXhjKieCYKF5sILL8Qff/xhfrOgbdy4UbEmQgSKtDRg3uPAorHO5dZ3AF2e48MW6pQJIUTenfpg69atpludECIApCQCX90JrJ7hXO78FHDhMNeAeUIIIYIkaKpVq+bvX4QQnkg4CkzpD/z7KxAZDVz1DtCkb6hTJYQQ+UPQCCECwLHdwKRrgL2rgdgiQN9PgVodQ50qIYQIWyRohMhp9m9wDph3dAdQuBwwYDpQMeuxkoQQQnhHgkaInGT7YuCzvsCpw0CpWsANXwAlq4c6VUIIEfb43Y2iY8eOZiZsT93LuE0I4YX1s4H/XekUM5VbOAfMk5gRQojQWGh++uknJCUlZVjPGac5d5IQwgN/jQdm3w840oBzuwLXjAdiC4c6VUIIkf8EzcqVK12/165da0b1teAM2xzdt3LlyoFPoRDhDMetXPAM8MtLzuXzBwKXvwZEydsrhBCBxOe3Kqck4EjA/HhyLRUsWBBvvfVWQBMnRFiTmgzMugf4e6Jz+ZIRQPsRGmNGCCFCKWg4oB5nSahZsyaWLFmSbnA9zprNkYOjoqKCkUYhwo+kE8C0G4F/5gIRkcAVrwHNbwx1qoQQIs8S7e+AepxvQwiRCScOAJP6ALuWAdEFgT4TgLrdQp0qIYTI0/jdy+mTTz7B7NmzXcsPPfQQSpQoYeZ72rZtW6DTJ0R4cWgLMK6zU8wULAUM+lpiRgghcqOgefbZZ028DFm0aBHGjh2LF198EWXKlMG9994bjDQKER7s+hsYd5lT1BSvCtw8F6jSKtSpEkKIfIHfXS127NiB2rVrm99fffUVrrnmGtx222246KKL0L59+2CkUYjcz6YfgKkDgeQTQIVGQP/pQNEKoU6VEELkG/y20BQpUgQHDx40v+fOnYvOnTub3wUKFMCpU6cCn0IhcjvLPwMm93WKmRqXADd+KzEjhBC53UJDAXPLLbegWbNm2LhxI7p3727Wr1mzBtWra9RTkc/GmFn4GjB/tHO5UR/njNnRsaFOmRBC5Dv8FjRvv/02HnvsMeN6mjFjBkqXLm3WL126FP369QtGGoUIHUd2ACedFsl0cMTf394E1n7pXL5wGNBpNBDpt9FTCCFEAIhwcHAZ4Tecu6p48eI4evQoihUrFurkiGCJmbHNgZTEzPfjgHkdRiKUcDiFffv2mfGgIiWqRBiiMpwR1TP+ka1SwzmbBgwYYLpq79y506z79NNPsXDhwuwcTojcCS0zWYkZom7ZQggRfoKGbqYuXbqYrtvLli1DYqLzhU8FyS7dQgghhBC5XtA8/fTTeO+99/Dhhx8iJibGtZ7dtilwhBBCCCFyvaDZsGEDLr744gzr6ec7cuRIoNIlhBBCCBE8QVOhQgVs2rQpw3rGz3DiSiGEEEKIXC9obr31VgwfPhyLFy9GREQEdu3ahUmTJuGBBx7AnXfeGZxUChEKdiwJdQqEEEIEaxyaESNGmO51l156KU6ePGncT3FxcUbQDB061N/DCZE7WTsTmBParthCCCGCaKGhVebRRx/FoUOHsHr1avzxxx/Yv38/xowZg+zCwfo4yjCnT2jdujWWLPHeMuZ8UUyD++fyyy937XPjjTdm2N61a9d0x2H6+/fvb/r2c7bwm2++GcePH8/2NYg8xPLJwLQbAUcKEJHFIxIdBxRyDi4phBAijCw0N910E9544w0ULVoU9evXd60/ceKEsdCMHz/er+NNnToV9913n+k5RTHz+uuvm27hDD7mAEvufPHFF0hKSnItc16pJk2aoE+fPun2o4CZMGGCa5lWJDsUM7t378a8efOQnJyMwYMHm0k2J0+e7Ff6RR5j8fvAdw85fze7Abj4QeDUYe/7U8yUqJJjyRNCCBGgkYKjoqKMEHAXGwcOHDABwykpKf4czoiYli1bYuzYsWaZ7qwqVaoYcUT3VlZQAI0aNcqkqXDhwi4LDXtccTZwT6xbt86IsT///BMtWrQw6+bMmWPmpfrvv/9QqVKlLM+rERzzGHwMfn0Z+PFp5/IFdwFdnqVJEuGARlkV4Y7KcEZUz/hHpD8Zy0yl/omPjzfL1ufw4cP49ttvPVpUMoOWFs4B1alTpzMJiow0y4sWLfLpGOPGjcN1113nEjMWP/30k0lP3bp1TbCyNUM44bHpZrLEDOE5eW4GO4t8KGbmjTojZjiVQRiJGSHCkdQ0BxZtPoiZy3eaby4LkSMuJwoAKx7l3HPPzbCd60ePPj3rsI/QqpOamory5cunW8/l9evXZ/l/xtowjoeixt3d1KtXL9SoUQObN2/GI488gm7duhkhQwvTnj17Moiv6OholCpVymzzBEdEtkZFJhRyVquCHxGmpKUi4rsHELH0Y+fiZc84rTMUOWE0zRnLIBsbKot5E1b2f/57CPviE1GuaBxaVi+FqMjwFdxzVu/BU7PWYc+xBNe6CsXiMLxdJfQpUyakactN6HkOkqBZsGCBeWF27NjRTH/Ayt8iNjYW1apV88lVE0goZBo1aoRWrVqlW0+LjQW3N27cGLVq1TJWG/bOyg7PPfecR8HGgOiEhDMPpQgjUpNRfMEIFNw0Cw5E4NglY3Cq5jXAvn0IxxefZUGVuT5vsWDTYbz20w7sO57sWleuSAzubV8FHWqXRDhez8hZWzKs33MsESNnbzXtiI7nnqlf8jP0hoggCJpLLrnEfG/duhVVq1Y1FpmzpUyZMsZisnfv3nTrucx4nMxgEPKUKVPw1FNPZXkeDvjHc3FAQAoaHpu+WjuM/WHPJ2/nHTlypAletltoGOtTtmxZ+TbDkZQEREwfjIhNc+CIjIbj6vdRtEEvFEV4QkHDZ5Ll0VdBk9da/XkRWjIembUF7rbC/ceTzfq3r2+Grg0zf1fmJljm3hi/JtN93vptN/pcWDcsy2Kgnyn2/BUBFjTbt283IobQEpMVnIG7cuXKWe5Hy07z5s0xf/589OzZ0/Vi5vKQIUMy/e+0adOMC4izfmcFA30ZQ1OxYkWz3KZNGxM0zPgdnp/8+OOP5twMUvYEe0m595QirDzUIg4zEuOBz/oB//4KRBdAxLX/Q8S5XRDuUND4Wh7nrN6N0d+sxe6jZ6yLFYsXwBM96qNrQ+dzEo6wQlmylRVKAsoVLYBWNcJXpPFaxsxel0HMEK7jVXF7l4YVM71GWu1S0hxISeV3mvlOTkszxze/U52/k63t1r6pp3+npZltzn2c/ze/Tx/Lub/tf679nd9cto6/+8ipdG4mT7BMjpm1Dg0rF0fhuGgUjotCEfMdjcKxzmX+jouODEjDOlAE45lS3RKEXk6MaaHguOWWW0yPJE/Q3P3555+bLt3s/jxs2DCfu20PGjQI77//vnEdsdcSj8MYGp534MCBRhzR5WOnXbt2Zj2tNHY4lgxdQ7179zbWFsbQPPTQQ8Z0t2rVKpcoYUwNLUHsLm5122aQsK/dthV9HqacPARM6gPs/AuILQJcPxWo3hb5qYcIX7x3TlyWoaK0qoZ3B5wflqImHEQaBcHJxFQcT0rBycQUHE9MwcmkVJxITMGJpBScSEzFySSuT8WmvfH4drXnmD475YvFIToy0ilQ3MVHmvN3XiQ6MsIIG4qdQrFOkeMUPmd+F4rlt3P5zHYKI/v+zv/ERUdlOy3BeqZUzwTBQrN27Vo888wz6Ny5szGB0arBeBn+Zg8nbl+zZg3OP/98vPjii6b7s6/07dvXxKGw6zUDcps2bWq6UFuBwrQOub+gOUYN546aO3duhuPRhbVy5Up88sknxgrDdF522WVm4D+7hYXTNdAKRBcUj08B9Oabb/qcbhGGxO8FPr0a2LcGKFgSGDADqOy00OUXWLmx0s+s1c/tnetXCCvLhrcKZc/RBLM+OxVKWprDiAwKDiM8ElNPiw6Kj9T0guT0eiNW3NZZIoXfSamBD/Lce+xMZwV/iImKMEKIwiCav6PO/I6JjDT3n+u4H39zXbT127avOYb5Pr1/JPdx/s+5v3Mdt+08fBITF2/PMm0X1CyFgjFRJs+Yn/a8PJWcavahWDt6Ktl8AgHT6xRA6UVR4dhoFLJZiZzrzmwvEBOFR79cneeeqTw/Ds2pU6cwe/ZsIya2bdtmlhmb0qxZMzMYXsOGDZFfkHIOM45sB/53FXBoC1CkPHDDV0D5MwND5hcLDbvH9vvwjyyP16hyMZQqHGdewJERrJRg+x2BKOPe4nL69a7t9v+d3tf1bf9t/d9a59oHGc7F73T7nj42uWvSMhw8cWbATXeKF4zB8Etr41RymlN4WCLltNBwiRQPFWcwiI2KNJWmVYGywixsuVNOV6CsqL9ZsTvLYz3Zoz6aVCnhFBmWsHCJjMgzAuX0Nu7H+xYKdw0FddsXfjRC01vFQ6vawoc7eq38eYwzAsdpzbLEJddz2Skuz/w+btvf3O/Ty/xPQnLO9CT67NYL0KaWf6OKq54J4kjBBQsWxDXXXGM+QoQNB/4B/tcTOPYfUKIqMHAmUCr/zQyfmJKKH9enD8D3xqqdzmEJ8goUB+wmnB1Yr7rHb9DFYbk0LBdGIdNid4oUS5hYrg7X9thoFIyNQmx01rERrLj/+vew18qf1X2F4gVwQ5vqYdPyZzrpAqTVjCm2X5e1/Pjl9TK9Hm4rViDGfAIB439OJp8WtXYRdFrwWsuudaddhta6nUcSsOvIqSzPw7gukcumPhAirNi90ulmOnkAKHOu0zJTPOuA9bxCUkoaftt0ALNW7sbctXsQn+DbSN53d6iFGmWKGLdLqsMZh5F2+vvMb3hY59zf/M++3bXO+Zt2Yff1Z/Z1unvSbbd9m+Pa1h1LSMaB496tMxZNq5TAueWLnBEcLpHiQZDkguDTrCp/wu3hImYs6PqjC9A93onibFi7Sjnea4uusGL8ZFMg+Wr1ZJC6CC4SNCLvsmMJMPEaIPEoUKExcMOXQOG8P2gXg0F/33wQs1bswvdr9uCYTcSUKxrrNNEneXanWK3++zqHT7dZXyuUh7ue57fJP9RkVvnnpmBnf2G6GVNi75HWoloJHDywH+EGe9LRTZaVJY37ieAiQSPyJpsXAFP6A8kngCoXOHszFSyBvArN5ku2H8NvC/fi+7V7ceTkmUDJskXj0L1hBVzeuBJaVCtpLDVs9SOPtPrzeoXiqfIP5+7oFky/XWCG66i4edWSli8mpxROFKyVi1k/G5h2I5CaBNTqCPSdCMSmn+srL0CXzOKtB407ac6q3ThkEzGlC8eiW6MKuLxRJY+VXzh0cc5OLyd4qVDCtSt6fiLcJ6cMxjOlesY/JGiyiQpaLmXFVOCrOwFHKlCvB9B7HBCdcUDEcMUaiXT2yt34bvUeHDh+pstu8QJR6N6oEq5oUgmta5QysQFZHSsvtfrzmkjLb4S7oAnGM6V6JgcEzT///GPmdmLhczcTcjyZ/IAKWi7kz4+A2Q842+hNrgeufAuICn+vKgNfl24/bETMt6t2m2HV7d2RuzaogO6NKqBWkVRUqlg+bCuDQJDXRFp+Ii8ImkCjesY//H7bf/jhh7jzzjvN+DMcidce/c/f+UXQiFzGr68C809PHtrqNqDrCxw3HOEsYv7eccQlYuzDxRctEI0uDSrgisYVcVHtMmZcEasyyO+4x2UIIfIPfguap59+2owa/PDDDwcnRUL4Aw2MFDILX3Mut3sA6PgY1TXCDRpLV/x3FLNX7jJCZpfNdVI0LhqdG5Q3IqZt7bI+jWMihBD5Cb8FDac66NOnT3BSI4Q/0N353YNOVxPp/BRw0XCEm4hZvfMYZq3cZYJ7d9oG6OLYKJ3rlze9k9rVKWOGWBdCCBEgQUMxwzmU7rjjDn//KkTgSE0BZt4NrOTkpBHAFa8CLW5CuIiYtbspYnYbS8z2Qydd2zgC7aX1yuPyRhXRvm5ZiRghhAiWoKlduzYef/xx/PHHH2jUqBFiYtKPrujrLNtCZJuURGD6TcD6WUBEFHD1+0DjPrlexKzfE28EzOxVu7H1wAnXtgIxkbj0PKc7qX3dcmZofCGEEEHu5VSjRg3vB4uIwJYtW5AfUPR5iEg64Rwwb8sCICoOuPYToG435FY27o0/bYnZhc37z4gYDqffoW45XNGkIjqeV84Mt382qIeICHdUhjOiesY//H6Lbt261d+/CBEYTh0BJl8L7FgMxBQG+n0G1Lwk13UH3rTv+GlLzC5s3HvctZ6BvO3PLYvLG1c0biVObiiEECIwnNUb1TLuhGLiNpHPOL4fmHg1sGcVUKA40H8GUKVlrhmwjS4kWmFojaFrySImKgKXnBYxneqVR9EAzRAshBAiAILmf//7H1566SUzwB4599xz8eCDD+KGG27IzuGEyJyj/wH/6wkc/AcoXM45yWSFhjk6pL67X5bzBt0xcRmualoJ/+w9boJ8LaIjI0yvJPZOYi8lDn4nhBAilwmaV1991QQFDxkyBBdddJFZt3DhQtPr6cCBA7j33nuDkU6RXzm4GfjfVcDRHUDxKsDAmUDpWjnmZqJlxlOQmbVu5vJd5pvuJw5yd0WjirisQXmUKBSbI2kUQgiRTUHz1ltv4d1338XAgQNd66688ko0aNAATz75pASNCBx71wCfXg0c3wuUrg3c8BVQokqOnZ4xM3Y3kzdubVcDd7avjVKFJWKEECJsBM3u3btx4YUXZljPddwmRED4bykwsReQcAQo3wi44QugSLkcTcLqnUd92q9h5eISM0IIEWIiszMOzeeff55h/dSpU1GnTp1ApUvkZ7b+CvzvSqeYOaclcOM3OSZmUlLTMGf1Hgz4aDGe+XadT/9hrychhBBhZqEZPXo0+vbti19++cUVQ/Pbb79h/vz5HoWOEH6xYQ7w+UAgNRGocQlw3WQgrkjQT7v3WAI+W7IdU5bsSDcRJMeLSUxJP6O8Bfv2VSju7MIthBAizARN7969sXjxYrz22mv46quvzLp69ephyZIlaNasWTDSKPILq6YDX94OpKUAdS8HrhkPxATP+sFhB37ffBAT/9iGuWv3miBgUrpwLK5tWQXXt6qKNbuOml5OZn/bf62BCth129t4NEIIIXJ5t+3mzZtj4sSJgU+NyL/8NQGYxYByB9DoWqDnO0BUcLo7Hz2ZjGlLd2Dy4u3YYpuCoFX1Uuh/QVV0bVgBcdHO6QeqlCqEdwecn2Ecmgpu49AIIYQIA0HD4ZetYZf5OzM0PLPwm9/fAuY+5vzNCSa7vwIEYejzFTuOGGvMNyt3ISHZ6UbiaL1XN6tshMx5FTyXXYqWzvUr+DxSsBBCiFwqaEqWLGl6MHGOjRIlSngcGZjme65PTU0NRjpFXoQjTS94FvjlRefyRfcAnZ7k0NMBO8WppFR8s2IXJi7ehpX/nem1dF6FohhwQTX0bFbZpykIKF7a1CodsHQJIYQIgaD58ccfUaqUM/BxwYIFAU6CyJekpQHfjwQWv+dcvnQU0O7+gB1+8/7jmPTHdkxfugPHElLMutioSDMFwYALquL8qiU1ZYcQQuQ3QXPJJZd4/B0o3n77bTOVwp49e9CkSRMzeF+rVq087tu+fXv8/PPPGdZ3794ds2fPRnJyMh577DF8++23ZuZvzlTaqVMnPP/886hUqZJr/+rVq2Pbtm3pjvHcc89hxIgRAb8+4UZaKvD1MGD56Tis7i8DrW4968Mmp6Zh3tq9xq3EYF+LKqUKon/raujT/ByULhJ31ucRQgiRB4KC58yZgyJFiqBt27YuMfLhhx+ifv365jfdU/7A8Wvuu+8+vPfee2jdujVef/11dOnSBRs2bDAuLne++OILJCUluZYPHjxoRFCfPn3M8smTJ7Fs2TIzPQPXHz58GMOHDzejGf/111/pjvXUU0/h1lvPVKRFixb1NzuEv6QkAV/cAqydCUREOYN/m1x3VofcffQUPluyA1OWbMe++ESzjuEtHc8rh/4XVMMldcoiUvEuQgiRp/Fb0HASyhdeeMH8XrVqlREj999/v3FF8feECRP8nhuKomLw4MFmmcKGlpbx48d7tJZYri+LKVOmoFChQi5BQ4vMvHnz0u0zduxYY/HZvn07qlatmk7AVKhQwa/0irMg6STw+Q3Aph+AqFhnt+x6PbJ1qLQ0B37bfACfLtqG+ev3ubpclykSi+taVkW/1lVRuUTBAF+AEEKIPCNotm7daqwxZMaMGejRoweeffZZYxWh28cfaGlZunQpRo4c6VoXGRlpXESLFi3y6Rjjxo3Dddddh8KFC3vd5+jRoyZeggHNduiGGjNmjBE5119/vZmHKjo6Wz3ZRVYkHAUmXwds/x2IKQRcNwmo1dHvwxw5mYTpS/8zbqV/D550rW9do5QJ8u3SoAJiowPfQ0oIIUTuxu/aOzY21rh1yA8//OCapJKWk6y6dLvD2bnZK6p8+fLp1nN5/fr1Wf6fg/mtXr3aiBpvJCQk4OGHH0a/fv3SdSkfNmwYzj//fJPu33//3Ygq9uSixcgTiYmJ5mNhXWtaWpr5CCrHHcDJQxnXJxxBxHcPIuLAP3DEFYOj31Sg6gXOwGAfYA+6Ff8dxaTF2zFr5W7XyL3sndSrWWVc37oKzi1/xl2YH+8Hr5n5lB+vXeQNVIYzorwIsqBh7AxdS5z2gIKCMTBk48aNOOecc5CTUMg0atTIawAxA4SvvfZa85BwhnA7vAaLxo0bG6F2++23m8DguLiMgaNcz2kf3Nm/f78RTfmdyPhdKDulCyJSz8Q3uUOn0OFLX0ZSgZrAvn1ZHvNUcirmbjiML1bux4Z9Z6wx55YtiF6Ny+KyuqVQKJYD4J3Cvn2nkN9ffLREsqzTyilEuKEynJH4+PhQJyFvCxrGo9x1112YPn26EQmVK1c267/77jt07drVr2OVKVMGUVFR2Lt3b7r1XM4qtuXEiRMmfoaBvZmJGfZkYrfzrAb8Y0BySkoK/v33X9StWzfDdlpw7CKIFpoqVaqgbNmyGkyQpO7OVMwQhuWWqHwu4CHY286mfcfNKL4z/t6JeKvLdXQkrmhUEf1bV0HTKp7HQsrvlQHzhOVRlYEIR1SGM1KggCa+DaqgYbzJrFmzMqzn3E7+QqsIp1HgxJY9e/Z0FWouDxkyJNP/Tps2zbiABgwY4FXM/PPPPyZYuXTprAdEW758uXmIPPWsIrTaeLLc8D96+KhWfBMYkdzPQ34lpaRh7to9Jjbmjy1n3FbVShdC/9ZV0ad5FZQsHBvQJOc1WBmoPIpwRmU4PcqHMJv6gFaPQYMGoUWLFsZ1xG7btL5YvZ4Yo0MrEF0+7u4miiB3sUIxc80115ggZQovxuhwfBvCeBmKKAYcc4LNDh06mJ5OXGZAMMWRv93Oxdmx6wi7XG/HlD93YL+ty/Wl9cqbIN92tcuoy7UQQojcP/VB3759TRzKqFGjjPBo2rSpGevGChRmV2t3lcoxahYuXIi5c+dmON7OnTvx9ddfm988lh1aazgwHy0tdFc9+eSTxspTo0YNI2jsLiURPNjl+tdNB4w1Zv66vTjd4xpli8ahX8squK5VVVRSl2shhBB+EOGgEskCjszLIGB2afY0Sq+dYIwknBuhpYpj3jCILd/H0HCwvO8fAf78MMtdZ7SchDfXFsY2W5frNjVLG2vMZQ3KIyZKJtbsQFftvn37TKNDZmoRjqgMZ0T1TBhOfSDCmK2/ArPvBw5s8Gn38Qv/xTZHDRQtEI3e559j5lWqXU4jNAshhMjhoGCOBMypD6yRee1BuhyfhvEwIh9wfB8w9zFgpbPbvqNACUQkHMnyb7XKFsLAdo3Qo0klFIrVIIZCCCECg992PQbnsru1OzQTcsRgkQ8mlvzzI2Bsi9NiJgJoeQtWXDoZCY6YTP/K7YM6tUDfllUlZoQQQgQUv2sVBukyiNadatWqmW0iD7Prb2DWfcCuZc7lik2BK14FKjfHtuU7cVfiKygZ4X0gqMOOong4rTSa51yKhRBC5BP8FjS0xKxcuRLVq1dPt37FihU+jfciwnQeph+fdlpmHGlAXDGg4+NAy5uBSI7UC5QrWgC7UAa7HBmtd3a4nxBCCBFyQcM5kTgPEsdvufjii8069nwaPny4mSRS5CHYAW7VdGcPphOnpypo1Ae47BmgaPr5t1rVKIXiBWNw9FSyx0Oxo3+F4gXMfkIIIUTIBQ1np+b0AJdeeqlrZmp2t+MAeIqhyUMc+MfZe2nr6W76pesAl78C1PTcy23rgeM4meScpsAda9SiJ3rUR5QGyRNCCJFbZtvmhJQUNnQzFSxY0EwQyRgakQdIPgX88jLw2xtAWjIQXQC4+AHgwmFAdMapH0hCciqGfrYcyakO1KtYFIdPJGPPsTMTdtIyQzHTtWHFHLwQIYQQ+YlsdzVhDA3H5KtVq5bLUiPCnI1zgW8fAI5scy7XuQzo9iJQKmMQuJ0X5qzHut3HULpwLD65qRVKF47Dkq2HsC8+wcTM0M0ky4wQQohg4rcS4VgzQ4cOxSeffGKWN27ciJo1a5p1nHNpxIgRwUinCCZH/wO+exhYf3rS0WKVgW4vAOddkeWkkwvW78OE3/41v1/u08QV9NumlgLEhRBC5OJxaEaOHGlcTT/99FO6qc07depkXFEijEhNBn57ExjbyilmIqOdrqW7lwD1emQpZvYdS8AD01aY34Mvqo4O53meqVwIIYTIdRaar776ygiXCy64IN0klQ0aNMDmzZsDnT4RLLYtAmbfB+xb61yu2ga4/FWgfH2fJ5i8f9oKHDyRhHoVi2FEt/OCm14hhBAikIKGM2NzLBp3Tpw44XEWbpHLOHEAmPcEsHyic7lQaaDzGKBJP8CPCeE+WrgFv/5zAAViIvFWv6aIi3aORyOEEEKEhcupRYsWmD17tmvZEjEfffQR2rRpE9jUicCRlgYs/dg5ZYElZs4fBAz5C2jW3y8xs+q/o3jpe+dklKOuaKDJJYUQQoSfhYZjzXTr1g1r165FSkoK3njjDfP7999/NwPsiVzInlXOKQv+W+JcLt8IuOI1oEpLvw91IjEFw6b8bbpod21QAf1aVQl8eoUQQohgW2jatm1rgoIpZjj+zNy5c40LatGiRWjeXLP05CoS44E5I4H3L3aKmdgiQJfngNt+ypaYIU98vQZbD5xAxeIF8HzvRnIzCiGECD8LTXJyMm6//XY8/vjj+PDDD4OXKnH2Uxas/copZuJ3O9c1uBro8ixQrFK2D/v1il2YvvQ/cEiZ1/s2RYlCsYFLsxBCCJFTFpqYmBjMmDHjbM4ngs3BzcDE3sC0G51iplRNYMAXQJ+Pz0rM7Dh0Eo9+scr8HtKhNlrX1DgzQgghwtjl1LNnT9N1W+QykhOAn54H3mkDbJ4PRMUB7UcCdy4Cal96VodOSU3D8Cl/Iz4xBc2rlcSwS+sELNlCCCFESIKC69Spg6eeegq//fabiZkpXLhwuu2ciVvkMJvmO6csOLTFuVyrI9D9ZaB0rYAc/s35/2DZ9iMoWiDauJqio/zWwUIIIURQiXBwQiY/qFHD+7w+DBDdsuV0pZrHOXbsGIoXL46jR4+iWLFiIUrELuD7R4A1XzqXi1YEuj4H1O+Z5Si/vrJ4y0H0+/APpDmAt/o1Q48m2XdbieDBGe/37dtnAvQj/eiCL0RuQWU4l9YzedlCs3Xr1uCkRPhOagqw5ANgwbNAUjwQEQm0vsPpYioQuEJ/5GQS7pm63IiZPs3PkZgRQgiRazmrabIt44667uYgO/4EZt/rHFuGnNMKuPwVoGLjgJ6G93bEjFXYfTQBNcsUxpNXNgjo8YUQQohAki273rhx49CwYUMzOSU//M2RgkUQOXkI+HoYMK6TU8wULAn0eBO46fuAixny2ZIdmLNmD2KiIvBmv2YoHHdW2lcIIYQIKn7XUqNGjcKrr76KoUOHuqY64KB69957L7Zv324ChkUAoRVs+WRg3uPAyYPOdU0HAJ1HA4XLBOWU/+yNx1Oz1pjfD3U5Dw0rFw/KeYQQQoiQCZp3333XDKrXr18/17orr7wSjRs3NiJHgiaA7F3rnBF7+yLncrn6zhmxqwVvzqyE5FQM/exvJCSnoV2dMri5rfcgcCGEECJsBQ1HC+YEle6wCzenQxA+cGTHGWuLJ6ILOieQ/OMdIC0FiCkMtB8BXHAnEBUT1KQ9/916rN8TjzJFYvHKtU0QyWGBhRBCiLwWQ3PDDTcYK407H3zwAfr375+tRLz99tuoXr26icdp3bo1liw5PYmiB9q3b2+CkN0/l19+ebqAVrrGKlasiIIFC6JTp074559/0h3n0KFDJr3sCleiRAncfPPNOH78OHJEzIxtDnxwiffPO62A3990ipl6PYAhS4CLhgVdzPy4fi8+/v1f8/ulPk1QrmiBoJ5PCCGECBTR2Q0K5qSUF1xwgVlevHixiZ8ZOHAg7rvvPtd+jLXJiqlTp5r/vPfee0bMvP766+jSpQs2bNhgxiNw54svvkBSUpJr+eDBg2jSpAn69OnjWvfiiy/izTffxCeffGLGzeHcUzwmZwWnaCIUM7t378a8efOM1Wnw4MG47bbbMHnyZAQVWmZSErPer0gF4Mq3gHMvQ06w71gCHpi20vy+6aIa6FA3Y94LIYQQeWZgvQ4dOvh24IgI/Pjjj1nuRxHTsmVLjB071jW4UpUqVUw8zogRI7L8PwUQrTEUJxy1mJdTqVIl3H///XjggQfMPhyUqHz58vj4449x3XXXYd26dahfvz7+/PNPl/tszpw56N69O/777z/z/6ANeLRrudMKkxXsvVTVKRiDTVqaAwPHL8HCTQdQr2IxfHX3hYiLjsqRc4vAoEHJRLijMpwRDawXZAvNggULEChoaVm6dClGjhzpWseCTBcRe075ai2iSLGmYODAf3v27DHHsGCBoHDiMbkvv+lmsscCcX+em9amq6++OsN5EhMTzcde0KyHkB+fcTh88vOlcS4mf457FnzwyxYjZgrEROKNvk0QExnh3zWJkMP7RTGv+ybCFZXhjCgv/COkg4scOHAAqampxnpih8vr16/P8v+MtVm9erURNRYUM9Yx3I9pbeO3uzsrOjoapUqVcu3jznPPPYfRo0dnWL9//34kJCRkmVbXeQ4dgi+drRnjkxK1D8Fm3d4TeGnuBvP7novPQTGcxL59J4N+XhH4Fx9bcawQ1LoV4YjKcEbi4+NDnYSwIqxHS6OQadSoEVq1ahX0c9GKZI8PooWGrrGyZcv6ZwpM3e3TbhRX8BBDFEiOJ6bgyU/XITUN6NqgPG7tWF+jPodxZcB7x/KoykCEIyrDGbFiPkUYCJoyZcogKioKe/fuTbeeyxUqVMj0vydOnMCUKVMyjHtj/Y/HYC8n+zGbNm3q2oe+Wjvsck6riLfzxsXFmY87fPD8evh8FAyR3C/ID/Xob9Zh28GTqFS8AF7o3cTcCxG+sDLwuzwKkYtQGU6P8iGMBE1sbKwZv2b+/Pno2bOnS6VzeciQIZn+d9q0aSamZcCAAenWs1cTRQmPYQkYWlMYG3PnnXeaZY5wfOTIERO/w/MTBjDz3Iy1yQ/MXL4TM5b9Bw4z8/p1zVC8UHC7hIvwgW5g9vwTIifh+5flji78/FKRx8TEqCGZl1xOdOMMGjTIBOjSdcReS7S+sBs1YVfwypUrmxgWd3cTRVDp0qUzKPx77rkHTz/9NOrUqePqts2eS5ZoqlevHrp27Ypbb73VdBfnQ0QBxYBhX3o4nRWFSgPRcZl33eZ27hckdhw6ice+XG1+D+lYB61qlArauUT4wNgFxpBR7AuR01gBwYwbyU+ub3ZQYSM8P11znhU0ffv2NYG17HrNlymtKuxCbQX1cnwbd7XOMWoWLlxoxsLxxEMPPWREEceV4cu5bdu25ph2f+SkSZOMiLn00kvN8Xv37m3Grgk6JaoAQ5ZmPlIwxQz3CwIpqWkYPuVvxCemoEW1khjWsXZQziPCD0vMMGC+UKFCesGKHBc0dP2zg0Z+KHu83pMnT7rCH+whEiKHxqER4T0+wCtzN+CtHzehaIFofDe8Hc4pWSjUSRK5YAwPupk2btxo/u9u9RQiJ8hvgsY+OCyf3XPPPTeD+ylc65lQkT8clcLwx5aDGLtgk/n9XK9GEjPChRUzQ8uMECLnsJ45xa2dPRI0+YQjJ5Nw79TlHNcP17Y4B1c0DnKskAhL8lPLWIjcgJ65wCFBk09MuQ/PWIndRxNQs0xhPHllg1AnSQghhAgoEjT5gMlLtuP7NXsRExWBN/s1Q6HYkMeCC5HraN++vekhKbzDHqPsbJHX+emnn4zlxN7j76uvvkLt2rVNnAvLCTuasBOLpifIPUjQ5HH+2RuPMbPWmt8Pdz0PDSsXD3WSRB4mNc2BRZsPmnGO+M3lYHLjjTeaiuf5559Pt56Vj7+m/C+++AJjxoxBTqTX+jAAm0NIrFzpnOk+t/eCe+ONN/Doo48irwvZCy+80Ex4zIBci9tvvx3XXHMNduzYYcoJ7xvHkWGPWZE7kKDJwyQkp2LoZ38jITkNF59bFjddVCPUSRJ5mDmrd6PtCz+i34d/YPiU5eaby1wfTDgcwwsvvIDDhw+f1XE43UjRokURbFgRsrLkhwOAslfPFVdcgdzORx99ZCr6atWqIRw4myBbDvpqHxvm+PHjpidSly5dzFhlVjmhQM2R4T6ET0jQ5GGe/2491u+JR5kisXi5T2NEclhgIYIARcudE5eZOC07e44mmPXBFDWdOnUylY/74JvuXWP79etnBulkrxLOAffZZ595bak/8sgjHkcNb9KkSbrpVljJc6BOiqrzzjsP77zzTpbp5RQqTC8/dFmMGDHCtPo5HpfFww8/bLrxMq01a9Y0rh6rgv73339N1/y//vor3XE5KCnFhuUC4cS93bp1Q5EiRcy4XjfccIOZENhi+vTpJh8KFixoLEXMR47f5Q1ONdOjR4906zgIXv/+/VG4cGEzjsprr72WweLBEd0feOABk/fcj/lKl47Fxx9/bAaX+/777016KBYs0Wcns7xmnlB8TJ06FZdcconZh5aTrO47BcnPP/9sLE+W1YzHsruc+NsSMB07djTrrfQzP3gfNm/enOV9F8FHgiaPMn/dXnz8+7/m90t9mqBcUU1yJvwc9CspxadPfEIynvh6DTw5l6x1T3691uzny/H8HRqLMQ3PPvss3nrrLfz3338e9+Fw+pzmZPbs2aaiZxwIK/glS5Z43J+VNLfZK6o1a9YY19D1119vlllhckDQZ555BuvWrTNpoPD45JNPfE47W/4TJ040sRn28X9YgbKiX7t2ralsP/zwQyMWSPXq1Y34mDBhQrpjcZkVNMUOK2JWvs2aNTMVLuM9OJ/dtddea/alWGBFf9NNN5m0s4Lu1auX17znPHdMC0d0dx/p/bfffsPXX3+NefPm4ddff8WyZcvS7cMBTBctWmQEEfOvT58+RrD8888/rn04wNwrr7xirpkCgwOqUgRZ+JrXFIfDhw83+9CaktV9Z95yKhyOGm9ZzTjpsB1apTiYK5kxY4bZh+tI1apVjVjkdYvQo+jQPMi+Ywl4cLrTJ083U4e6wZ21W+Q9TiWnov6o7wNyLFaRe44loNGTnkf2dmftU138Dly/+uqrjbXjiSeeMNOiuMMWur2CHDp0qLEIfP7552bKFXcaNGhgrDGTJ082FadVqdK6QPFBeC5WwhQChNOssNJ///33zXQu3pg1a5axmhBaRGjZ4Dr7gIiPPfaY6zcFDNNOQcBR0Mktt9yCO+64A6+++qqx+FBErFq1CjNnzjTbx44da8QMK36L8ePHm8qaAyhSSHEQO6bdciHReuENCgyKHfvUMLTOUFAwjzjiuiWq7Pvwf1zHb2s9r4UCi+ut9NH69O6775q00AVHEWS3hPma17QMWftYZHbfGSND9xKtN94mJuZ2DjhpuSXd9+N1bdu2zWveiZxDFpo8RlqaA/d9vgKHTiShfsVieLhb3VAnSYgcgXE0rGDZOvc0EjIDOVlps1KioGDFxorWG7TSsLImrMzpquA6S4jQenPzzTebY1kfziGXlfuhQ4cOWL58ufnQUkBLAl1D9kqRrpOLLrrIVJ48LgWOPa2cl46WqS+//NIs07LB41L8kBUrVmDBggXp0kY3DWH6KNYoQpgftJjQApRZDNKpU6fMt336mC1bthghYheEFAh1655551BkMe/pPrOnhVYYez5RUNSqVcu1TJFnTQngT167W5Cyc9/9hS47WphE6JGFJo/xwa9bsHDTARSMiTJdtOOiNZOr8B+WH1pKfGHJ1kO4ccKfWe738eCWPk2EynNnh4svvtiIg5EjRxrXi52XXnrJuBcYZ8LKjbEcbM0nJSV5PR5dMoxlofWDFTrjXDj3HKGFg1AIuMfaZDV7Ms9tWXms2BAKAR6LlTTdMxROo0ePNtfDbbTO0EJhtxpw4l5aOWiRoPDi9VkwfYzvoMhzh2KBaaSL6Pfffzdz4tFdx95LixcvNtYPd8qUKWO+KXrKli0LX2E6eK6lS5dmyBfLSkXYW8gO41Qs95c/ec28Pdv77i90x/mTJyJ4SNDkIVbsOIKXv3f6ep/oUR+1y515YQjhD6xQfHX7tKtTFhWLFzABwJ4iMBiKXqF4AbNfVJAD09l9m64nu5WAMM7jqquuwoABA8wyA2fpeqlfv77XY51zzjkmwJSuJgqazp07u1wPjJugq4FWCstqczZ5TXeTZQWhyKDrxd492pNLg26nhg0bmuBYy31kcf7555t4D1ps6MLxdl5agfhhfArPSYsP42LcofWEcwnRzUNrC2GwMoXIn3/+aWJJCOccYr5SXBK6vWglobWlXbt22cqfs8lrX+47xSHTmB0Yo0MrEa9ThB4JmjzC8cQUM4t2SpoD3RtVQN+WwZmtWwh3KFIooNmbiXLFLmos+cLtwRYzhK1wVnruXWnr1KljevVQLJQsWdLEnjBINjNBQ3gsxm+wRW8F5VrQgjJs2DBjQWGQK3vzMACXVgxPosCC+3FMF8J9Ge9iWVSstNIlQqtMy5YtTUCr5Vqywx4/F1xwgbEiMbiXrg+Lu+++21g0aGVi3A3dLZs2bTLHpEWI6WSX8csuu8yINFpm2MuKx/QEBRcDkRcuXGjcXVbgMuNXHnzwQXN8Hod5xX2t7s4UP8xDWpNoYWLFz/Pw3I0bN8bll1+eaf6fbV77ct8p+nj97N1EqxGvxVf++OMPE8PEwGIRehRDk0d4YuYa/HvwJCqXKIjnrm6s+UFEjtK1YUW8O+B8Y4mxw2Wu5/acgsGk7qO3MgaFVgu6cNitmLEpVsWcGRxIjV1/GSPhvj8tJBQHdPtQSNGaw1gWTy4bOwyIpduHH7pQaOGYNm2aSRe58sorce+995rAWFqbWBlbgcnuMK6EYouCxg4tGrRO0PJA0cL00dXC7tEUHLS2/PLLL+jevbsRHcwfCg7G8niD10tBZM9bCgRW5hxHh4KH1h6ra7UF84eC5v777zeWM+aj3arjC9nNa1/uO4OG6bqiyKHryJ/4GiuuSpO65g4iHP72kRS5blp3jsrKgczYAJ56exu0rO57C0PkDVjJ0KzPVrK9t4w/pvOtW7eaCsJeGfkLRwZmTM2++AQzVABjZnLCMpNfYcArxVBOjDTMqoICjGKLlh9PMICXPcoojii2/D0+XWd0kYVDg4xj+lCg0VKUlbDK7rOXm+qZcEAupzBnx6GTeOzL1eb30I51JGZESKF4aVPrzHgqIjjQRUUXCd1VDCTOCSgyPvjgA9NzyeLvv//G+vXrTU8nVrpWV2vGreR1mP+MXzobMSMCiwRNGJOcmoZhU/5GfGIKWlQriaEdz/ScEELkXeiOoruD7hN3d1MwoQuMHzsvv/yyGXiOwbUcxI6DzFm9ovIy7CLu3k1chBYJmjDmjR/+wd/bj6BogWi8fl1TREcpJEqI/ADjR/gJNQzyZZdsIXIDqgHDFM5k/PZPm8zv53s1xjklFZQmhBAi/yJBE4YcPpGEe6cuB8O5+7aogssb51wPEiGEECI3IkETZrAnwMMzVpq5cWqWLYwnrsx8HA0hhBAiPyBBE2ZMWrwdc9fuRUxUBN68rpnfk/gJIYQQeREJmjBi4954jJm11vx+uOt5aFi5eKiTJIQQQuQKJGjChITkVAz77G8kpqTh4nPL4qaLNPaBEEIIYSFBEyY89+06rN8TjzJFYvFKnyaI1OirQuQInOuHszVnF3av5pQDuQXOo8TpCTKbkPHJJ59MN94MZy/3ZaqI7PLTTz+ZEa6PHDkS0nvlz6B6HGhw+fLlrnWcaoLTMnDCTuYVJ/LkBKccPVnkDArACAN+WLsXnyxyzrb7cp8mKFs0LtRJEiI9R3YAJw96316oNFAi8BOmsqJlJfjVV18hWHDeocKFC/tcoXLOJH4s+vbta+ZMyi1wskrOccT5i3zljTfeMB0SgsWFF16IXbt2mWH+c+penU0Zq1KlCnbv3p1uAEFOkkkR+N1335lJLiliOXko57vyNheXyGMWmrffftu8BDiHBecJWbJkSab7s2BxJllO7MZZTjmx2rfffuvazmNRObt/+B8LTlLmvv2OO+5AbmTvsQQ8OH2F+X1z2xpoX7dcqJMkREYxM7Y58MEl3j/czv3CEE5YeDaTD3IWbM6xlRvgbNmbN29G7969/fofhUawrEzJyclmlGFOHHm2czid7b3yFYpBppfzTlkwXzt27GisMlZeDR48GO+++66Zo0rkcUEzdepUo2o55fyyZcvQpEkTMysqJ9nzBGeV7dy5szH3cUp4Drf94YcfmsnQ7Aqdytn6zJs3z6zv06dPumPdeuut6fZ78cUXkdtIS3Pgvs+X4/DJZDSoVAwPda0b6iQJkRFaZlISM9+H2zOz4ASJn3/+2cwzxMYPG0EjRoxIV7nEx8eb2ZLZquf21157zTR47BYWuxuDVgq6YzhTNI/JWa2HDRtmtvF/27ZtM5M3Wg0lby6n559/HuXLl0fRokXNJI5Ml93F454GQjcGrQUWiYmJZqZovv+YfjYI6brJDM6WzXeo+ySI7unhhIl23F1OfP/SvUKxVrp0aTPTtt21Mn78eDRo0MCV75yqwYL5wkqes4oz3c8880wGl5OVZ7NmzTITQFKkcOZzznr+ySefmHtSsmRJk/d215m7y4nn4izdV199tTlGnTp18PXXX7u287+8Xs7HxGvhuWiNsuC95vlmzpzpuqdMq93lZP3mrOychoK/rVGcmdeHDh0y5VDkcUFDUxyFBVUsp25/7733TKHjw+AJrmfhoOmP09Sz8HIaeQohu0KncrY+fCBq1apl9rPD89j3y40zmX7w6xb8tukgCsZE4c1+zRAX7buJWIizgu6FpBO+fVJO+XZM7ufL8QLk2ti5c6dx9bRs2RIrVqwwlei4cePSTebIBhVjH1jJsfHDeYjYuPLGjBkzjOh5//338c8//5h3ESt28sUXX5jWOSdotBpKnvj8889NRfnss8+amZpZ4XOSQ3+hSFi0aJERKZxtm422rl27mnR5g9fnPv+Qv+nhdXG2bVbe69atMxV8r169XC4p5jMt4rfddpuZyJJ5W7t2+nnmeD6KDG73NhcVxcubb75prm/OnDnmPPwPLfL8fPrpp+Y+UFxlxujRo3HttdeaPGJ5oIBlPWLNUs97xhnLGfMyatQoPPLIIyZPCAUj/8t8te4p3WN2LPcT6xCKKf6mm5HQ8kShynwXeTiGhtYWzgEycuRI1zoqdCp9PqSe4IPRpk0b87BQMVO8XH/99Xj44Yc9+oN5jokTJ5qXlrspc9KkSWYbxUyPHj2MjzMzUyVbQ/zYp3W3Hgh+As2K/47g5e83mN+jetRDjdKFgnIekTdg2WCFkt0yYv3f+lBYRDx3xvIZEMZ39Wk3x8idQKx/cRCe4jvozmZl89Zbb5nnn61vihxaQ/i806LA1jffBXQVmCSOH28sHq58sB2fH1pg+M649NJLTfAnj0/BxG20GPA9xPgJWjvs/7OnkZUeK3GrIh8zZgx++OEHYxXxdE5P17p9+3ZMmDDBpIdWInL//febip/XQHHiCe5PwWI/rq/psc7NWBdauSguqlWrZtY3bNjQtZ2Cke9cy3JFKKLsx6Igslub6K6x5xG/6YqisGKDlNBNxnf2nj17TB4zsLlDhw748ccfjejwlm+DBg3CddddZ37TGkSRtHjxYiNS6DKiuLJgI/n33383goYCkRYkWm747rfuqXs6WW9xG8sYRY393hPeH+a7txgkK72e6hK988NE0Bw4cMCY++yFhHCZ09F7YsuWLabwUmFToW/atAl33XWXKfh0W7nD1hNNmPYHh1AE8UFkQaNqpyCi+4otLG8899xzRum7s3///gzm2bPlRFIqhk5ah5Q0By6tUxLtq8R6dcMJYb34jh496nrB+gufIR6DFZVxyaSkIAahwZw/0reYA6sS8BSjwBY33TB2lwSXjx8/btwEhw8fNtd9/vnnu/7PCoxxecxH+zGtc7ASp0uClexll11mKsUrrrgiXSyFe3qsSslaR6vGLbfckm4fy11krbMqOffjWMemq4PXRZFmhxUvhZW3mI1Tp04ZIWbf7kt67OemK4kCsHHjxsalwg8tNDwv31MUPHSZZRY3wkkt7dute8Rvqyyygcn3tLUfG7BcprvMvm7v3r0e75UF02st0wVG0UErirWOFiW6iHbs2GHyhw1hWv09XbuF9dv1vHg5t3VOljlv+cH1/B9dVrw3dugSFXm0lxNvOoPrPvjgA9MS4lT1bHG99NJLHgUNzcvdunVztWAsaAq1oLmYLRa2uNhKsFoD7tCSxFaH3ULD1hkfqEC7qx6YthL/HU1EpRIF8Mp1zVGsYKiqFhFOzwZbiCyP2RE0FOV8ebJiNpVzVDGnpcQX9qxCxISsrS+OwXOACk73TGZExxRi8INPp+a18mMXFJlts367rtPtN7FiJezrrOMw1oINLlow6KKiFYIuKFb+VmXkfk7rftjX8f2V2Tkti7N9H1b21rFZ8XIfuojcrdO0XnjKD8JeOXx3uW/PKj32vOSH105Lxty5c40Vha6aP/74w9Xrx/147vCd6Z4f1jfzkefit/s+dOF4+p+ne2VBAeTt2ujOYoP25ZdfNtZ/xhCxPmHnFE/XbuGt7Hgqi2xU16xZ02t+cD3/x1gk99gm92WRSwUNCz4LI9W1HS7TpOsJCg8WcvsDTLMjTZBU1SzsFjTx8aWTmdXF3hohtPh4EzRU2fy4YxX2QDFz+U588fdOcJgZTm1QorC6aAvf4Es6u+WR/7H3+jOCIq6Ib3+OKehb+rifr8f0E0+9Y/huYMyLfTsrYVZabIyUKlXKvE8oCizXCa1cGzduxMUXX5zumPYgX1oOGNDKD+NYzjvvPKxevdpYevgOssSle9qsb6aLFSZdIRZ0gdj3oTDle81appjhOehi4Tqei+toIW7Xrp3P+UTLCC0y9vT5kh5P19K2bVvzYWOS+UeLOBt9dNvQkm658Txhz09PeeT+7W2d+zZvx/Z0HfywPDAmxt4Llp4A+zF5T5nX3tKS1bl43xjQ7K0Hl/UfT89uIOuW/EDIcouFhBYWDvJkwRcBl6mUPcFAYIoOu1+RLx8KHbuYIfQv05pz+eWXZ5kWa3AkHieUbD94Eo9+udr8HnZpHbSoXiqk6REiHKAI4TNs/9B9QHc0v4cOHWqsKoy7Y+XLSpcVBYUNK/EHH3wQCxYswJo1a0yPF0vceYKuCVp+WUmx4mNMB2MsLEHEyvyXX34xlmO61T0xfPhwE+fCdxTfX0wTz22HYmD27Nnmw7Tfeeed6Qado1uMrveBAweaRtvWrVuNKKFrnP/xBnuRsuu2v+mxQ7FjBRAzlofnp7CiMCKMSXnllVdMrAoDlBlkzTim3Ah7PfE6vv/+e3PtjK1iT1k7vKcMTWBYAu8pXWK+QtcmywJjQ0XwCan844uF3a4ZmMdWAx9aBuqx1xPhw2oPGuZ2RqfzAWTh44PLB8uurgkFDx9OvqzczXx0KzHojQHJLGwMNOZ52CKjTzgnSU1zYNHmg8Yqs/Cf/Rj62TIcT0xBy+olMaRD+l4BQuRaOGhedBaWRG7nfkGA7h5aHuwfxrsxuJexdqzoGRPBsaYoWDionL2nJRtQjINhpcNGEytmb6Z+diXmO4v78X1BK/A333xj3AWEPZz4XqGll1YWT7AHDCtODnDHRh2tyXy32WGALt9ffDexhyZdFrTO2OE7jtsZDMxYGnarZmXMLuXeoAiiWGHl7E963N1FFG3sMURhxfykgKF7nzDdDDSmK4rxK8zbzHpehZLbb7/dxP8wD2ipZxwLhbAd9sRl/jKwmfeUveJ85bPPPjOxVpbgFcElwhHM4R99YOzYscZnSfMqu7dR1VsuIAaWUR1bffoJe0BxnAe2wvjC4gvKvZcT/bpsifCh5QNnhy22AQMGmBYWxRNNzwz040PpTywM/dAcbIqtw+zE0MxZvRujv1mL3UfTBxQXjInED/e3R+USvpnxhbBEPAMyaZXMbgwNW/mMEcmW3z5EIwUHGr4T+F5hBc13S05BqwZdNvah9IMFLVJ8f7HLc27CCoJmI/RsB9jLDTAMghagyZMnGwGcnWfvbOuZ/EbIg4Lpg7YPumTH0yBRbE0x+CwzqIi96TQKmFAPckQxc+fEZfCUwlPJaVj13xEJGhFeUKyEgWBx5++//zYuHQ6+x0qDFhZy1VVXIa/y6KOPGusJRbBiNIIH3XEc0yYzMSPymKDJb9DNRMuMN7MY2yXc3rl+BURpAkohgg57uNCaa8X1cRA0+xw9eQ26zVjRiuDCwQTdBxQUwUWCJodZsvVQBjeTHQodbud+bWoFJ+ZACOGE8TaMpws1dDnZB3gTQviP7I05zL74hIDuJ4QQQggJmhynXNECAd1PiEAS4j4CQuQ79MwFDgmaHKZVjVKoWLyAiZXxBNdzO/cTIqewRrnlhIBCiJzDeubcpz0Q/qMYmhyGgb5P9KhvejlRvNi1uSVyuF0BwSIn4bAHDBa15gzjaLh5oeusCB/yWrdtX66XYobPHJ89TxMsC/+QoAkBXRtWxLsDzs8wDk2F4gWMmOF2IXIaa8oRTYQqQoE143RmIzXnRShmvE33I/xDgiZEULSwazZ7MzEAmDEzdDPJMiNCBSsRTv/Bwfn8Gd5diEBgzTjNUZfzy/g47nMTirNDgiaEULyoa7bIbfAFq5esCIWgYQXP0XLzi6ARgUWlRgghhBBhjwSNEEIIIcIeCRohhBBChD2KoTnLwZA4G6oQuSH+ID4+XvEHImxRGc6IVb9o8D3fkKDJJnzwrNm7hRBCiGDWN8WLFw91MnI9EQ5Jv2y3Jnbt2oWiRYvm2jETWrZsiT///DPPnT8Qx83uMfz9n6/7+7JfZvuwJUdxvWPHDhQrVgx5hVCW4WCeW2U4IyrDGWH1TDFTqVIlWa18QBaabMLCdc455yA3w663oXwxBOv8gThudo/h7/983d+X/XzZh9vzUmUQyjIczHOrDHtHZTg9ssz4jiRfHubuu+/Ok+cPxHGzewx//+fr/r7sF+r7GQpCec3BPLfKcP4hP15zqJDLSYg8AM31bMkdPXo0T7VuRf5BZVicLbLQCJEHiIuLwxNPPGG+hQhHVIbF2SILjRBCCCHCHllohBBCCBH2SNAIIYQQIuyRoBFCCCFE2CNBI4QQQoiwR4JGiDwOR15t37496tevj8aNG2PatGmhTpIQPnPkyBG0aNECTZs2RcOGDfHhhx+GOkkil6JeTkLkcXbv3o29e/eaCmHPnj1o3rw5Nm7ciMKFC4c6aUJkSWpqKhITE1GoUCGcOHHCiJq//voLpUuXDnXSRC5DUx8IkcepWLGi+ZAKFSqgTJkyOHTokASNCJupAyhmCIUN2+BqhwtPyOUkRC7nl19+QY8ePcwEdZwI9auvvsqwz9tvv43q1aujQIECaN26NZYsWeLxWEuXLjUtXs0SL8Kp/NLt1KRJEzN/3oMPPmhEuRDuSNAIkcuhmZ0vc770PTF16lTcd999ZpTVZcuWmX27dOmCffv2pduPVpmBAwfigw8+yKGUCxGY8luiRAmsWLECW7duxeTJk40LVQh3FEMjRBjBFu6XX36Jnj17utaxRduyZUuMHTvWLKelpRkLzNChQzFixAiXqb5z58649dZbccMNN4Qs/SJ/k93ya+euu+5Cx44dcc011+Ro2kXuRxYaIcKYpKQk40bq1KmTa11kZKRZXrRokVlmm+XGG280lYDEjAi38ktrTHx8vPnNiSvpwqpbt27I0ixyLxI0QoQxBw4cMDEx5cuXT7eey+zRRH777Tdj1mfsAns68bNq1aoQpVgI/8rvtm3b0K5dO+OK4jctN40aNQpRikVuRr2chMjjtG3b1pjxhQhHWrVqheXLl4c6GSIMkIVGiDCGvT3YrdU9SJLL7KItRG5G5VcEEgkaIcKY2NhYM1De/PnzXetojeFymzZtQpo2IbJC5VcEErmchMjlHD9+HJs2bXIts+sqTfClSpVC1apVTZfXQYMGmeHhaZ5//fXXTVfZwYMHhzTdQhCVX5FjsNu2ECL3smDBAg6tkOEzaNAg1z5vvfWWo2rVqo7Y2FhHq1atHH/88UdI0yyEhcqvyCk0Do0QQgghwh7F0AghhBAi7JGgEUIIIUTYI0EjhBBCiLBHgkYIIYQQYY8EjRBCCCHCHgkaIYQQQoQ9EjRCCCGECHskaIQQQggR9kjQCCGEECLskaARIpdz4403omfPnq7l9u3b45577nEtV69e3cx/E0j+/fdfREREmDl3cgs//fSTSdORI0dCnRQhRC5EgkaIHMJdiPjKG2+8gY8//hjhRqBF0YUXXojdu3ejePHiyC3iUgiRe9Bs20LkckJZgecESUlJiI2NzXI/7lOhQoUcSZMQIvyQhUaIHGrZ//zzz8baQqsFP7RgpKam4uabb0aNGjVQsGBB1K1b1+xzNlYBumRuueUWlC1bFsWKFUPHjh2xYsWKTP+zZMkSNGvWDAUKFECLFi3w999/p9tOC1GJEiXSrfvqq6/MdXiD10R4XO5HC5X9ep555hlUqlTJXDP59NNPzbmLFi1qhMv111+Pffv2eXU5WWn6/vvvUa9ePRQpUgRdu3Y1VhxvHD58GP379zd5w/yuU6cOJkyY4Nq+Y8cOXHvttea4pUqVwlVXXWXuE3nyySfxySefYObMma57yDR5gtc6bNgwPPTQQ+Y4vB7+XwgRPCRohMgBKFLatGmDW2+91VS4/FSpUgVpaWk455xzMG3aNKxduxajRo3CI488gs8//zzb5+rTp48RAt999x2WLl2K888/H5deeikOHTrkcf/jx4/jiiuuQP369c3+rHgfeOABnC0USeSHH34w1/vFF1+4ts2fPx8bNmzAvHnzMGvWLLMuOTkZY8aMMeKLYolCguInM06ePImXX37ZiKFffvkF27dvzzTtjz/+uMln5s26devw7rvvokyZMq7zd+nSxQiqX3/9Fb/99ptLJNGKxONS7FiiiR+6wbxB8VO4cGEsXrwYL774Ip566ilzvUKI4CCXkxA55Daiy6RQoULp3CZRUVEYPXp0OqvGokWLjKBh5ekvCxcuNEKCgiYuLs6sY4VPgTB9+nTcdtttGf4zefJkI6zGjRtnLDQNGjTAf//9hzvvvBNnA60gpHTp0hlcRazoP/roo3Supptuusn1u2bNmnjzzTfRsmVLI7goLDxBEfLee++hVq1aZnnIkCFGOHiDgocWI1qCrIBqi6lTp5p8YLosyxOtN7TW0BJz2WWXGatOYmKiT66vxo0b44knnjC/aQkaO3asEXKdO3fO8r9CCP+RoBEixLz99tsYP368qWxPnTplrAFNmzbN1rFo3aAAoIiww+Nu3rzZ439oqWDlSzFjQWtSMGnUqFGGuBnLOsRroGuI4oIwX2g98gQFoiVmSMWKFdO5qdyhSOvduzeWLVtmBApdX5aVhefdtGmTsdDYSUhI8Jp3mcE8tZNV2oQQZ4cEjRAhZMqUKcaV8corrxgRwcr0pZdeMm6K7EAxw4rTU2yHewyMP0RGRsLhcGSwjmQXWmjsnDhxwrh7+Jk0aZKx7lDIcJkCzxsxMTHplmlZcU+nnW7dumHbtm349ttvjfuHrri7777bWLGYd82bNzfn92Zt8gdPabNEmhAi8EjQCJFD0CLBIGA7jNOgheCuu+5yrcuONcCC8TJ79uxBdHR0OndKZjCgljEotERYVpo//vgjQ4UeHx9vhIclRrLqjm1ZYNyv2RPr16/HwYMH8fzzz5vYIvLXX38hGPBaBg0aZD7t2rXDgw8+aAQN845up3Llyplgal/voRAid6CgYCFyCAoMWl4Y7HrgwAHTWmdsBStu9tTZuHGjCVr9888/s32OTp06GUsPXSlz58415/r999/x6KOPehUI7E1E6wEDlhkwS+sFK3g7rVu3Nu4dBixTcDHuJquxcSgMGHMyZ84c7N27F0ePHvW6b9WqVY1YeOutt7BlyxZ8/fXXJkA40DDomr2U6Fpas2aNCUimoCPs/cQAYfZsYlDw1q1bjaWLvZUYU2Tdw5UrV5qAZt7Ds7FSCSECiwSNEDkEXUsMAmY8iOVSuf3229GrVy/07dvXiAZaKezWGn+hMKEgufjiizF48GCce+65uO6664ybpXz58h7/w4Dbb775BqtWrTIBsxQ/L7zwQrp92PV44sSJ5tiMf/nss8+y7IZMKxEDe99//33TPZtCwRvMDwok9vZi/tBS4y6qAgFF08iRI018C/OI94NuP0LBxp5SFFe8JxQ67FJPy5VlsaHoYzdzBhUzzbSwCSFyBxGOzBzOQgghhBBhgCw0QgghhAh7JGiEEEIIEfZI0AghhBAi7JGgEUIIIUTYI0EjhBBCiLBHgkYIIYQQYY8EjRBCCCHCHgkaIYQQQoQ9EjRCCCGECHskaIQQQggR9kjQCCGEECLskaARQgghBMKd/wOjS40OHquAKwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 500x350 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scenario B (bloc rho=0.85, d=12)  — precision moyenne sur 40 graines\n",
+      "     n       NB       LR    NB-LR\n",
+      "    15   0.6694   0.7002  -0.0308\n",
+      "    30   0.7188   0.7221  -0.0033\n",
+      "    60   0.7335   0.7557  -0.0222\n",
+      "   120   0.7455   0.7876  -0.0420\n",
+      "   240   0.7451   0.8086  -0.0635\n",
+      "   480   0.7468   0.8159  -0.0690\n",
+      "   960   0.7475   0.8197  -0.0723\n",
+      "  1920   0.7457   0.8216  -0.0759\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2.3 Scenario B : correlation en bloc forte, hypothese d'independance FAUSSE\n",
+    "resB, _, _ = eval_curve(make_block, d=12, shift=0.7, rho=0.85, ns=ns, seed=2)\n",
+    "nB = np.array(ns)\n",
+    "nbB = np.array([resB[n][0] for n in ns]); lrB = np.array([resB[n][1] for n in ns])\n",
+    "\n",
+    "plt.figure(figsize=(5, 3.5))\n",
+    "plt.plot(nB, nbB, \"o-\", label=\"Naive Bayes (generatif)\")\n",
+    "plt.plot(nB, lrB, \"s-\", label=\"Logistique (discriminatif)\")\n",
+    "plt.xscale(\"log\"); plt.xlabel(\"taille du train set n\"); plt.ylabel(\"precision (test fixe)\")\n",
+    "plt.title(\"Scenario B : discriminatif meilleur, il s'echappe avec les donnees\"); plt.legend()\n",
+    "plt.grid(alpha=0.3); plt.tight_layout(); plt.show()\n",
+    "\n",
+    "print(\"Scenario B (bloc rho=0.85, d=12)  — precision moyenne sur 40 graines\")\n",
+    "print(f\"{'n':>6} {'NB':>8} {'LR':>8} {'NB-LR':>8}\")\n",
+    "for n in ns:\n",
+    "    a, b = resB[n]\n",
+    "    print(f\"{n:>6} {a:>8.4f} {b:>8.4f} {a-b:>+8.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12ac1f7a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003427,
+     "end_time": "2026-08-23T20:05:28.325219+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:28.321792+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture B — quand l'hypothèse est fausse, le génératif est plafonné\n",
+    "\n",
+    "Ici la corrélation **en bloc** (la moitié des variables se ressemblent fortement) **viole l'indépendance** que Naive Bayes suppose. La conséquence est le **miroir exact** du scénario A :\n",
+    "\n",
+    "- Naive Bayes **stagne autour de ~0.745** dès `n ≈ 120` : il fait son **biais** (une frontière imposée par une hypothèse fausse) et **plus de données ne l'aident pas** — c'est un mur de biais, pas un manque de données.\n",
+    "- La logistique, plus **flexible**, **continue de progresser** : elle passe de ~0.70 en petit `n` à **~0.82** à `n = 1920`, **creusant l'écart** (jusqu'à **~-0.076**) qu'elle menait déjà.\n",
+    "\n",
+    "Le contraste entre les deux scénarios **est** la leçon : le génératif n'est pas « meilleur » ni « pire » en soi — il est **meilleur quand son hypothèse tient et que les données sont rares**, et il est **dépassé quand son hypothèse est fausse et que les données abondent**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d8754f8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003264,
+     "end_time": "2026-08-23T20:05:28.331718+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:28.328454+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3. Quand choisir lequel — la table de décision mesurée\n",
+    "\n",
+    "| Situation | Le compromis dit | Mesure ici |\n",
+    "|---|---|---|\n",
+    "| Données **rares**, variables à peu près indépendantes | génératif (NB) : variance faible gagne | Scénario A : NB +0.09 à n=30 |\n",
+    "| Données **abondantes** | discriminatif (logistique) : plus flexible | A : convergence ; B : LR +0.076 à n=1920 |\n",
+    "| Variables **fortement corrélées** | l'indépendance est fausse → NB plafonné par biais | Scénario B : NB figé ~0.745 |\n",
+    "| Besoin d'une **probabilité calibrée** | le discriminatif l'apprend directement | logistique |\n",
+    "\n",
+    "> **La règle de pouce.** Si le jeu est petit **et** que l'indépendance des variables est plausible → Naive Bayes. Si le jeu est grand, ou si les variables interagissent → régression logistique (ou un modèle plus expressif). **Mesurer** la courbe (comme ici) vaut mieux que trancher au doigt mouillé."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d380e36",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003054,
+     "end_time": "2026-08-23T20:05:28.338136+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:28.335082+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Multinomial Naive Bayes (variables discrètes)\n",
+    "\n",
+    "Le gaussien convient aux variables continues. Pour des **comptages** (mots, fréquences), on utilise le Naive Bayes **multinomial** : `P(x|y=c) = ∏_j θ_{c,j}^{x_j}`. Implémente-le de zéro (estime `θ_{c,j}` par lissage Laplace) puis vérifie-le contre `sklearn.naive_bayes.MultinomialNB`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c98b587f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T20:05:28.346558Z",
+     "iopub.status.busy": "2026-08-23T20:05:28.346197Z",
+     "iopub.status.idle": "2026-08-23T20:05:28.351142Z",
+     "shell.execute_reply": "2026-08-23T20:05:28.350111Z"
+    },
+    "papermill": {
+     "duration": 0.010487,
+     "end_time": "2026-08-23T20:05:28.351887+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:28.341400+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : Multinomial NB de zero (voir code ci-dessus)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Multinomial Naive Bayes de zero\n",
+    "# Etape 1 : estimer theta_{c,j} = P(x_j | y=c) avec lissage Laplace (alpha=1)\n",
+    "# Etape 2 : prediction par log-vraisemblance + log-prior, argmax\n",
+    "# Etape 3 : comparer a sklearn.naive_bayes.MultinomialNB sur les memes donnees de comptage\n",
+    "theta = None  # TODO etudiant : table (n_classes, n_features) des probabilites lissee\n",
+    "print(\"Exercice 1 a completer : Multinomial NB de zero (voir code ci-dessus)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b81c29ba",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003268,
+     "end_time": "2026-08-23T20:05:28.358617+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:28.355349+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — faire varier la dimension\n",
+    "\n",
+    "Les courbes ci-dessus utilisent `d = 12`. Dans le scénario A, fais varier `d` (ex. `d = 4`, `d = 24`) et observe comment l'avantage de Naive Bayes en petit `n` **change**. Que se passe-t-il quand la dimension augmente ? Pourquoi ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1d97f0f0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T20:05:28.366862Z",
+     "iopub.status.busy": "2026-08-23T20:05:28.366510Z",
+     "iopub.status.idle": "2026-08-23T20:05:28.371357Z",
+     "shell.execute_reply": "2026-08-23T20:05:28.370409Z"
+    },
+    "papermill": {
+     "duration": 0.010289,
+     "end_time": "2026-08-23T20:05:28.372141+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:28.361852+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : ecart NB-LR a n=30 par dimension = None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : effet de la dimension sur l'avantage generatif\n",
+    "# Etape 1 : reprendre eval_curve(make_corr, d=?, rho=0.6, ns=[15, 30, 60, 120, 240, 480, 960, 1920])\n",
+    "# Etape 2 : comparer l'ecart NB-LR a n=30 pour d=4, d=12, d=24\n",
+    "# Etape 3 : conclure sur le role de la dimension dans le compromis\n",
+    "ecart_d = None  # TODO etudiant : dictionnaire {d: ecart NB-LR a n=30}\n",
+    "print(\"Exercice 2 a completer : ecart NB-LR a n=30 par dimension =\", ecart_d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0280cc0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003409,
+     "end_time": "2026-08-23T20:05:28.379195+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:28.375786+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — reconnaître le régime\n",
+    "\n",
+    "Deux jeux de données réels : (a) **spam vs non-spam** (comptages de mots, très haute dimension, petites corrélations), (b) **série temporelle financière** où les variables sont fortement liées. Pour chacun, dis quel classifieur (génératif ou discriminatif) est le plus adapté **et** quelle hypothèse de Naive Bayes est en jeu. Justifie par le compromis mesuré ci-dessus."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f27d09b0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T20:05:28.387405Z",
+     "iopub.status.busy": "2026-08-23T20:05:28.387066Z",
+     "iopub.status.idle": "2026-08-23T20:05:28.391950Z",
+     "shell.execute_reply": "2026-08-23T20:05:28.391016Z"
+    },
+    "papermill": {
+     "duration": 0.010146,
+     "end_time": "2026-08-23T20:05:28.392691+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:28.382545+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : (a) None, (b) None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : reconnaitre le regime generatif vs discriminatif\n",
+    "# (a) spam vs non-spam (comptages de mots, haute dimension, faible correlation)\n",
+    "#      -> quel classifieur ? quelle hypothese de NB est en jeu ?\n",
+    "# (b) finance (variables fortement liees)\n",
+    "#      -> quel classifieur ? pourquoi le NB serait-il plafonne ?\n",
+    "reponse_a = None  # TODO etudiant : \"generatif\" ou \"discriminatif\" + hypothese en jeu\n",
+    "reponse_b = None  # TODO etudiant : idem\n",
+    "print(f\"Exercice 3 a completer : (a) {reponse_a}, (b) {reponse_b}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "297a4b03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003559,
+     "end_time": "2026-08-23T20:05:28.400058+00:00",
+     "exception": false,
+     "start_time": "2026-08-23T20:05:28.396499+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Conclusion\n",
+    "\n",
+    "Naive Bayes (génératif) et régression logistique (discriminative) modélisent la probabilité **à l'envers l'un de l'autre**. Le choix n'est pas esthétique : il dépend de **la taille du jeu de données** et de **la validité de l'hypothèse d'indépendance**.\n",
+    "\n",
+    "Mesuré, le compromis devient lisible :\n",
+    "\n",
+    "1. **Petit échantillon + hypothèse plausible → génératif.** L'avantage de Naive Bayes (jusqu'à **+0.09** à `n=30`) est la signature de sa **variance faible**.\n",
+    "2. **Données abondantes → convergence, puis discriminatif.** Quand l'hypothèse est fausse, le génératif est **plafonné par son biais** (figé à ~0.745) pendant que la logistique **s'échappe** (+0.076 à `n=1920`).\n",
+    "\n",
+    "Le point d'entrée pour la suite : [2.4-Arbres-Forets-Ensembles](2.4-Arbres-Forets-Ensembles.ipynb) montre le même compromis sous un autre angle (réduction de variance par les ensembles), et [2.3](2.3-Regression-lineaire-logistique.ipynb) reste la référence de la régression logistique confrontée ici."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 9.515853,
+   "end_time": "2026-08-23T20:05:28.856370+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3b-Naive-Bayes-Generatif.ipynb",
+   "output_path": "MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.3b-Naive-Bayes-Generatif.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-23T20:05:19.340517+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #12659

## Résumé

Nouveau notebook `2.3b-Naive-Bayes-Generatif.ipynb` (02-ML-Cours, volet 1/3 de #12455) : le **classifieur génératif Naive Bayes** n'était jamais enseigné dans la série. On l'implémente de zéro, on le vérifie contre `sklearn`, puis on le met en face de la **régression logistique** (le discriminatif de [2.3](2.3-Regression-lineaire-logistique.ipynb)) sur le **compromis génératif-discriminatif** (Ng & Jordan, 2002) — **mesuré, pas raconté** (Prong-B).

- **§1 — Naive Bayes gaussien from scratch** : classe `MyGaussianNB` (~15 lignes, log-vraisemblance + priors). Vérification contre `GaussianNB` : même précision **0.925**, prédictions **identiques bit à bit**, moyennes de classe égales (décalage de l'ordre de +1 sur la classe 1).
- **§2 — Deux scénarios mesurés, deux régimes** (40 graines, jeu de test fixe) :
  - **Scénario A** (corrélation homogène, hypothèse à peu près vraie) : NB **+0.09** à n=30, écart fond à **~0.001** à n=1920 → l'avantage génératif est une signature du **petit échantillon**.
  - **Scénario B** (corrélation en bloc forte, hypothèse d'indépendance **fausse**) : NB **figé ~0.745** dès n≈120 (mur de **biais**), logistique **s'échappe** ~0.70→**0.82**, écart jusqu'à **~-0.076** → le discriminatif gagne quand son hypothèse est fausse et que les données abondent.
- **§3 — Table de décision** mesurée : 4 situations, le compromis, la mesure.
- **3 exercices** (C.1 conformes : `None  # TODO etudiant` + `print`) : multinomial NB de zéro, effet de la dimension, reconnaissance du régime.

## Validation

- **Ré-exécuté end-to-end via papermill** (kernel `python3`), RC=0, 9 cellules code sans erreur.
- **C.1** : aucun `raise NotImplementedError` / `assert False` / `1/0`.
- **C.2 + H.3** : chaque cellule code porte `execution_count` **et** `outputs` (séquence 1–9, aucun `null`).
- **Prong-B mesuré (G.9)** : prose **alignée sur les sorties réelles** après re-exécution — valeurs affichées, pas un folklore. La signature `make_block(n, d, shift, rho, rng)` est fixée pour que les scénarios tournent avec les paramètres annoncés (rho/shift non inversés).
- **Aucun chemin machine** dans les sorties (`AppData` / `jsboi` / `C:/Users` absents).
- Catalogue et fichiers générés **non touchés** (un seul fichier dans le diff).

Complète le volet 1/3 : #12455 (socle classique ML) est désormais entièrement livré via #12652 (clustering, 2/3), #12659 (hypothèses régression, 3/3) et cette PR (naive Bayes, 1/3).

See #12455
