### PR TITLE
Fix: check_lane_claim fail-OPEN — caller a joker vs claim path-scope (#12656)

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -831,9 +831,13 @@ def compute_active_claims(
                     or (
                         # scoped claim with at least one live glob AND
                         # disjoint from the override's scope -> keep.
+                        # _scopes_intersect (not _path_matches_any): the
+                        # operand order of the old read was inverted when the
+                        # override's scope carried a joker, so a concrete
+                        # claim it covered was never closed (#12656).
                         e.get("paths") is not None
                         and not _claim_scope_effectively_epic_wide(e)
-                        and not _path_matches_any(scope, e.get("paths") or [])
+                        and not _scopes_intersect(scope, e.get("paths") or [])
                     )
                 }
                 state[ev.lane] = ev
@@ -2232,7 +2236,7 @@ def _filter_by_claim_scope(
         if empty and len(empty) >= len(scope):
             filtered[ln] = ev  # lifted to epic-wide -- always blocking
             continue
-        if _path_matches_any(my_scope, scope):
+        if _scopes_intersect(my_scope, scope, tracked):
             filtered[ln] = ev  # scopes intersect -> real collision
         # else: both scoped, disjoint -> free, drop from others
     return filtered
@@ -2243,6 +2247,94 @@ def _path_matches_any(paths: list[str], patterns: list[str]) -> bool:
     for p in paths:
         if _path_matches(p, patterns):
             return True
+    return False
+
+
+def _glob_has_meta(glob: str) -> bool:
+    """True if `glob` carries fnmatch meta (`*`, `?`, `[`) beyond literals."""
+    return any(c in glob for c in "*?[")
+
+
+def _literal_prefix(glob: str) -> str:
+    """Leading run of literal (non-meta) characters in `glob`."""
+    i = 0
+    while i < len(glob) and glob[i] not in "*?[":
+        i += 1
+    return glob[:i]
+
+
+def _prefixes_compatible(pa: str, pb: str) -> bool:
+    """True if two literal prefixes can both prefix a single common string.
+
+    ``''`` (a glob that opens on meta, e.g. ``**``) proves nothing, so it is
+    compatible with anything. Two non-empty prefixes are compatible when they
+    agree on every shared position -- they can then be extended to a common
+    string, so we cannot cheaply prove disjointness.
+    """
+    if not pa or not pb:
+        return True
+    n = min(len(pa), len(pb))
+    return pa[:n] == pb[:n]
+
+
+def _glob_overlap(ga: str, gb: str) -> bool:
+    """Conservative ``True`` if globs `ga` and `gb` MAY match a common string.
+
+    Sound in the disjoint direction: if their literal prefixes conflict, no
+    string matches both. Otherwise we cannot cheaply prove disjointness, so
+    we report overlap (over-block). The fleet's globs are overwhelmingly
+    ``*`` / ``?`` / literal (paths-scoped claims and ``--paths``); character
+    classes are rare and only ever over-approximated here, which is the safe
+    direction for a collision guard.
+    """
+    pa, pb = _literal_prefix(ga), _literal_prefix(gb)
+    if pa and pb and not _prefixes_compatible(pa, pb):
+        return False
+    return True
+
+
+def _scopes_intersect(
+    a: list[str], b: list[str], tracked: list[str] | None = None
+) -> bool:
+    """True if path-scope `a` and path-scope `b` may cover a common file.
+
+    This is the symmetric fix for the operand-order bug that #12656 exposed.
+    The old read was ``_path_matches_any(my_scope, scope)`` -- it fed the
+    CALLER's glob as the ``filename`` operand and the other lane's concrete
+    path as the ``pattern``, so ``fnmatch("dir/**", "dir/file.md")`` is False
+    and a joker caller was told CLEAR against a claim that demonstrably
+    covered its target (fail-OPEN).
+
+    With a `tracked` walk (the normal ``_run_check`` path and every
+    check-level test) the test is EXACT: two scopes intersect iff some real
+    tracked file matches both. Without it (`compute_active_claims`, which has
+    no repo walk) we fall back to a conservative provable-disjoint test:
+    concrete members of either side are matched against the other side's
+    globs, then remaining glob-vs-glob pairs are decided by the literal
+    prefix test of `_glob_overlap`. The fallback never wrongly reports
+    "disjoint" (it over-blocks when unsure), which is the safe direction for
+    a collision guard.
+    """
+    if not a or not b:
+        return False
+    if tracked is not None:
+        for path in tracked:
+            if _path_matches(path, a) and _path_matches(path, b):
+                return True
+        return False
+    # no repo walk: concrete members of each side, matched against the other
+    for side, other in ((a, b), (b, a)):
+        for g in side:
+            if not _glob_has_meta(g) and _path_matches(g, other):
+                return True
+    for ga in a:
+        if not _glob_has_meta(ga):
+            continue
+        for gb in b:
+            if not _glob_has_meta(gb):
+                continue
+            if _glob_overlap(ga, gb):
+                return True
     return False
 
 

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -4628,3 +4628,126 @@ def test_lint_12327_no_supersede_marker_when_only_rele(capsys):
         "pas de SUPERSEDED non plus (pas d'actif pour le supplanter)"
     )
 
+
+# --- #12656 fail-OPEN : caller a joker vs claim path-scope --------------------
+#
+# The guard read `_path_matches_any(my_scope, scope)` with the CALLER's glob
+# as the fnmatch `filename` operand and the other lane's concrete path as the
+# `pattern`, so `fnmatch("dir/**", "dir/file.md")` was False and a joker
+# caller was told CLEAR against a claim that demonstrably covered its target.
+# `_scopes_intersect` is the symmetric replacement. A game of pattern goes by
+# its FALSE NEGATIVES: the six repro rows of the issue table, jokers included,
+# must all report BLOCKED, and genuinely-disjoint jokers must still CLEAR.
+
+_RAG = "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique"
+_RAG_CLAIM = [
+    f"{_RAG}/README.md",
+    f"{_RAG}/02-Retrieval-Avance.ipynb",
+]
+_RAG_TRACKED = _RAG_CLAIM + [f"{_RAG}/01-Introduction.ipynb"]
+
+
+def test_scopes_intersect_six_repro_rows_block():
+    """#12656 table row-by-row: every caller form names the tracked README.md
+    that the po-2025 claim scopes, so it must INTERSECT (block), not clear.
+    The literal form is the control that already worked; the 5 joker forms
+    are the fail-OPEN this test pins closed."""
+    callers = [
+        f"{_RAG}/README.md",                  # literal -- control
+        f"{_RAG}/README*",                    # trailing joker
+        f"{_RAG}/READM?.md",                  # single-char joker
+        f"{_RAG}/**",                         # directory-recursive joker
+        f"{_RAG}/*",                          # single-level joker
+        "MyIA.AI.Notebooks/GenAI/**",         # upstream joker
+    ]
+    for caller in callers:
+        assert clc._scopes_intersect([caller], _RAG_CLAIM, _RAG_TRACKED) is True, (
+            f"repro row {caller!r} did not intersect the claim scope -- fail-OPEN"
+        )
+
+
+def test_scopes_intersect_disjoint_jokers_no_block():
+    """Acceptance #2: genuine disjoint globs (FineTuning/** vs RAG/**) must
+    NOT intersect -- the #10419 acquit must not be paid by over-obstruction."""
+    tracked = [
+        f"MyIA.AI.Notebooks/GenAI/FineTuning/README.md",
+        f"{_RAG}/README.md",
+    ]
+    assert clc._scopes_intersect(
+        ["MyIA.AI.Notebooks/GenAI/FineTuning/**"],
+        [f"{_RAG}/README.md"],
+        tracked,
+    ) is False
+
+
+def test_scopes_intersect_no_tracked_concrete_vs_glob():
+    """Reducer path (`compute_active_claims` has no repo walk): a scoped
+    override with a joker must CLOSE a concrete claim it covers -- the same
+    operand-order bug left it unable to."""
+    assert clc._scopes_intersect(
+        ["MyIA.AI.Notebooks/SymbolicAI/Lean/**"],
+        ["MyIA.AI.Notebooks/SymbolicAI/Lean/Reidemeister.lean"],
+    ) is True
+
+
+def test_scopes_intersect_no_tracked_disjoint_globs():
+    assert clc._scopes_intersect(
+        ["scripts/**"],
+        ["MyIA.AI.Notebooks/SymbolicAI/Lean/**"],
+    ) is False
+
+
+def test_scopes_intersect_no_tracked_identical_glob():
+    assert clc._scopes_intersect(
+        ["MyIA.AI.Notebooks/SymbolicAI/Lean/**"],
+        ["MyIA.AI.Notebooks/SymbolicAI/Lean/**"],
+    ) is True
+
+
+def test_run_check_joker_caller_blocks_scoped_claim(capsys):
+    """#12656 acceptance #1 end-to-end: a `--paths` that carries a joker
+    covering a tracked file named in another lane's `paths:` claim must
+    return exit 1 (BLOCKED) -- the 5 joker forms were the reported fail-OPEN,
+    the literal form is the control."""
+    callers = [
+        f"{_RAG}/README.md",
+        f"{_RAG}/README*",
+        f"{_RAG}/READM?.md",
+        f"{_RAG}/**",
+        f"{_RAG}/*",
+        "MyIA.AI.Notebooks/GenAI/**",
+    ]
+    p = payload(
+        comment(
+            f"[CLAIMED] lane myia-po-2025:CoursIA -- paths: "
+            f"{_RAG}/README.md, {_RAG}/02-Retrieval-Avance.ipynb",
+            "2026-08-23T19:04:33Z",
+        ),
+    )
+    for caller_paths in callers:
+        rc = clc._run_check(p, "myia-po-2023:CoursIA-2", my_paths=[caller_paths])
+        assert rc == 1, (
+            f"joker caller {caller_paths!r} vs a path-scope claim covering "
+            f"README.md returned rc={rc} (expected 1 / blocked) -- #12656 "
+            f"fail-OPEN"
+        )
+
+
+def test_run_check_disjoint_joker_caller_clear(capsys):
+    """Acceptance #2 end-to-end: disjoint joker scopes must CLEAR (exit 0).
+    The caller targets RAG/**, the other lane's claim covers only FineTuning."""
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2025:CoursIA -- paths: "
+            "MyIA.AI.Notebooks/GenAI/FineTuning/README.md",
+            "2026-08-23T19:04:33Z",
+        ),
+    )
+    rc = clc._run_check(
+        p, "myia-po-2023:CoursIA-2",
+        my_paths=[f"{_RAG}/**"],
+    )
+    assert rc == 0, (
+        f"disjoint joker scopes must not block each other (#10419): got rc={rc}"
+    )
+


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/slides #12649

## What

Fixes the fail-OPEN of the lane-claim anti-collision guard (`check_lane_claim`):
a caller whose `--paths` carries a joker (`*`, `?`) was told `blocked: False`
against a claim whose `paths:` clause demonstrably covered the same tracked
file. The literal and epic-wide forms were unaffected — the class was bounded
to **claim path-scope x caller a joker** (the issue's constat).

## Root cause

`_filter_by_claim_scope` read `_path_matches_any(my_scope, scope)`, which fed
the **caller's glob as the `filename` operand** of `fnmatch` and the other
lane's concrete path as the `pattern`:

```python
fnmatch("dir/**", "dir/file.md")  # caller glob as filename -> False
```

So a joker caller was judged DISJOINT from a claim it actually covered. The
latent operand-order bug also lived in the reducer's override branch
(`compute_active_claims`), which left a scoped `[OVERRIDE]` carrying a joker
unable to close a concrete claim.

## Fix

`_scopes_intersect(a, b, tracked=None)` is the symmetric replacement. With the
repo's tracked-file walk (the normal `_run_check` path) the test is **EXACT**:
two scopes intersect iff some real tracked file matches both — this is what
preserves the #10419 disjointness acquit. Without the walk
(`compute_active_claims`, no repo) it falls back to a conservative
provable-disjoint test that never wrongly reports "disjoint" (it over-blocks
when unsure, the safe direction for a collision guard). The literal and
epic-wide paths are untouched (contre-controle #12475 replayed).

## Validation

- **226/226 tests PASS** (`python -m pytest scripts/tests/test_check_lane_claim.py`),
  incl. 6 new repro rows of the issue table (jokers incl.), a disjoint-joker
  control, and reducer-side concrete-vs-glob closure.
- **CLI verdicts** on the issue's repro payload (`--from-json`, lane
  `myia-po-2023:CoursIA-2`):

| `--paths` caller | `blocked` | exit |
|---|---|---|
| `.../RAG-et-Memoire-Semantique/README.md` | `true` | 1 |
| `.../RAG-et-Memoire-Semantique/**` | `true` | 1 |
| `MyIA.AI.Notebooks/GenAI/**` | `true` | 1 |
| `MyIA.AI.Notebooks/GenAI/FineTuning/**` (disjoint) | `false` | 0 |

The three joker forms that were `blocked: False` before are now `true`; the
literal control is unchanged; the disjoint control clears.

## Measurement (acceptance #5)

Scanned the 201 open issues (full pool, `--limit 300` returned 201) for
ACTIVE (non-released) `[CLAIMED]`/`[OVERRIDE]` markers carrying a `paths:`
clause, via the bot token:

> **77 active path-scoped claims** on **63 issues** across **12 lanes**
> (po-2023:4 · po-2024:10 · po-2025:5 · po-2026:8 on `:CoursIA`; po-2023:7 ·
> po-2024:10 · po-2025:13 · po-2026:12 · po-2027:3 on `:CoursIA-2`; ai-01:3+1+1).

Every one of these path-scoped claims could have been mis-read as CLEAR by a
joker-bearing caller before this fix. The 63/201 issues carrying at least one
is the exposed surface the issue's author did not measure; it is material, not
an edge case.

**How to reproduce:** `gh issue list --state open --limit 300 --json number`,
then per issue `gh issue view N --comments --json comments` and keep lanes whose
last marker is `[CLAIMED]`/`[OVERRIDE]` with a `paths:` clause (script in the
coordinator's dashboard comment, not committed per harness-hygiene).

## Notes

- Genre META/guard: this is a guard-organ fix, not a content grain; the
  cycle's content-plank is not met by it (swarm had taken the CONTENU grains),
  flagged honestly per variation-protocol §3.

Closes #12656
