### PR TITLE
feat(genai,#12654): FT-06 LoRA vision-langage Qwen3.5-0.8B — creation

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-06-Vision-Language-LoRA.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-06-Vision-Language-LoRA.ipynb
@@ -1,0 +1,1275 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e8428cff",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# FT-06 : LoRA vision-langage — fine-tune du décodeur de Qwen3.5-0.8B\n",
+    "\n",
+    "**Objectif** : adapter un modèle vision-langage (VLM) avec LoRA/QLoRA en ciblant exclusivement son décodeur de langage. La tâche est volontairement bornée — décrire une image synthétique contenant une forme colorée selon un contrat de sortie strict — pour que l'effet du fine-tuning soit **mesurable** : nous comparons le modèle de base et le modèle adapté sur une métrique de conformité de format et sur la justesse champ par champ, sur des images jamais vues à l'entraînement.\n",
+    "\n",
+    "**Prérequis** :\n",
+    "- FT-01 (panorama du fine-tuning, LoRA sur GPT-2)\n",
+    "- FT-02 (quantization 4-bit NF4, QLoRA)\n",
+    "- FT-03 (SFT instruction-following, boucle entraînement/évaluation)\n",
+    "- Notions de PyTorch et Transformers\n",
+    "\n",
+    "**Plan du notebook** :\n",
+    "1. Modèles vision-langage et Qwen3.5-0.8B\n",
+    "2. La tâche image→texte bornée : contrat de sortie et dataset synthétique\n",
+    "3. Mesure de référence du modèle de base\n",
+    "4. LoRA ciblé sur le décodeur\n",
+    "5. Entraînement QLoRA\n",
+    "6. Évaluation comparative : base vs LoRA\n",
+    "7. Pourquoi le décodeur seulement ?\n",
+    "8. Nettoyage de la mémoire GPU\n",
+    "9. Exercices\n",
+    "10. Résumé\n",
+    "\n",
+    "**Matériel requis** : GPU avec ~8 Go de VRAM (le corps du modèle 0,8 Md est chargé en 4-bit, mais la tour de vision, les activations et les adaptateurs s'ajoutent au budget).\n",
+    "\n",
+    "**Durée estimée** : 45-60 minutes\n",
+    "\n",
+    "**Parcours** : nous chargeons d'abord le modèle multimodal et son processor (section 1), construisons un dataset d'images synthétiques entièrement déterministe — dessinées par PIL, donc reproductibles au pixel près sans aucun téléchargement de données (section 2), mesurons le modèle de base sur un contrat qu'il n'a jamais vu (section 3), greffons des adaptateurs LoRA sur les seules couches du décodeur (section 4), entraînons (section 5), puis comparons chiffres en main base contre LoRA sur les mêmes images held-out (section 6). La section 7 justifie le choix « décodeur seulement » ; trois exercices prolongent : une forme nouvelle, un champ de contrat en plus, et le ciblage de la vision elle-même."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "15bf4e35",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "import warnings\n",
+    "\n",
+    "# Filtres poses AVANT les autres imports (issue #11725) : ils evitent que les\n",
+    "# avertissements de dependances (barres de progression, cache HuggingFace)\n",
+    "# n'encombrent — et ne fuient — dans les sorties du notebook.\n",
+    "warnings.filterwarnings(\"ignore\", message=\"IProgress not found.*\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Unable to fetch remote file.*\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Could not find a config file.*\")\n",
+    "\n",
+    "import os\n",
+    "import gc\n",
+    "import json\n",
+    "import time\n",
+    "import random\n",
+    "\n",
+    "import torch\n",
+    "from PIL import Image, ImageDraw\n",
+    "\n",
+    "# Reproducibilite : graine fixee pour le dataset synthetique et les tirages PyTorch\n",
+    "SEED = 42\n",
+    "random.seed(SEED)\n",
+    "torch.manual_seed(SEED)\n",
+    "\n",
+    "print(f\"PyTorch {torch.__version__}\")\n",
+    "print(f\"CUDA : {torch.cuda.is_available()}\")\n",
+    "if torch.cuda.is_available():\n",
+    "    print(f\"GPU : {torch.cuda.get_device_name(0)}\")\n",
+    "    props = torch.cuda.get_device_properties(0)\n",
+    "    print(f\"VRAM : {props.total_memory / 1e9:.1f} Go\")"
+   ],
+   "execution_count": 1,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PyTorch 2.13.0+cu126\n",
+      "CUDA : True\n",
+      "GPU : NVIDIA GeForce RTX 3070 Laptop GPU\n",
+      "VRAM : 8.6 Go\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a5c904d",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 1. Modèles vision-langage et Qwen3.5-0.8B\n",
+    "\n",
+    "Un modèle **vision-langage** (VLM) juxtapose deux organes : une **tour de vision** — un ViT qui découpe l'image en patchs et les encode en vecteurs — et un **décodeur de langage** qui génère du texte en s'appuyant sur ces vecteurs comme contexte. Entre les deux, un **merger** projette les patchs visuels dans l'espace d'embedding du décodeur : après lui, une image n'est plus qu'une séquence de « tokens visuels » parmi les tokens textuels.\n",
+    "\n",
+    "Qwen3.5-0.8B illustre en miniature deux tendances des architectures récentes :\n",
+    "\n",
+    "- **Hybridation de l'attention** : toutes les couches du décodeur ne sont pas identiques. Les couches d'**attention linéaire** (Gated DeltaNet, module `linear_attn`) ont un coût mémoire constant en longueur de séquence ; les autres gardent l'**attention complète** (softmax classique, modules `q_proj`/`k_proj`/`v_proj`/`o_proj`). Les tokens d'image, nombreux, rendent ce compromis précieux.\n",
+    "- **Multimodalité native** : le checkpoint embarque tour de vision ET décodeur ; la classe `AutoModelForImageTextToText` charge l'ensemble (`Qwen3_5ForConditionalGeneration` en interne).\n",
+    "\n",
+    "Nous le chargeons comme en FT-02/FT-03 : corps quantifié 4-bit NF4 (QLoRA), calculs en bfloat16, double quantization des constantes. La différence nouvelle est le **processor** : pour un VLM, il fait deux travaux à la fois — il tokenise le texte ET prépare les pixels (redimensionnement, normalisation, découpage en patchs). Une image ne passe jamais directement dans le modèle : elle passe par le processor, qui produit les `pixel_values` et insère dans la séquence le nombre exact de tokens visuels correspondant à l'image.\n",
+    "\n",
+    "Le point d'API à retenir : le texte donné au processor doit contenir le marqueur d'image `<|vision_start|><|image_pad|><|vision_end|>`. Le processor remplace ensuite `<|image_pad|>` par autant de tokens d'image que l'image compte de patchs — oublier ce marqueur, c'est soumettre une image que le modèle ne regardera jamais."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "b6d072fd",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Charger le modele vision-langage Qwen3.5-0.8B en 4-bit (QLoRA, comme FT-02/FT-03)\n",
+    "from transformers import (\n",
+    "    AutoModelForImageTextToText,\n",
+    "    AutoTokenizer,\n",
+    "    AutoProcessor,\n",
+    "    BitsAndBytesConfig,\n",
+    ")\n",
+    "\n",
+    "MODEL_NAME = \"Qwen/Qwen3.5-0.8B\"\n",
+    "\n",
+    "bnb_config = BitsAndBytesConfig(\n",
+    "    load_in_4bit=True,\n",
+    "    bnb_4bit_quant_type=\"nf4\",\n",
+    "    bnb_4bit_compute_dtype=torch.bfloat16,\n",
+    "    bnb_4bit_use_double_quant=True,\n",
+    ")\n",
+    "\n",
+    "print(f\"Chargement de {MODEL_NAME} en 4-bit NF4...\")\n",
+    "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\n",
+    "if tokenizer.pad_token is None:\n",
+    "    tokenizer.pad_token = tokenizer.eos_token\n",
+    "tokenizer.padding_side = \"right\"\n",
+    "\n",
+    "# transformers 5.15 : la validation de docstring du module qwen3_vl imprime des\n",
+    "# [ERROR] via un print inconditionnel (pas un warning, non filtrable) qui embarque\n",
+    "# le chemin d'installation du venv -- on redirige stdout le temps de cet import (#11725).\n",
+    "import contextlib, io\n",
+    "with contextlib.redirect_stdout(io.StringIO()):\n",
+    "    processor = AutoProcessor.from_pretrained(MODEL_NAME)\n",
+    "# le processor embarque sa propre instance du tokenizer : memes regles de padding\n",
+    "if processor.tokenizer.pad_token is None:\n",
+    "    processor.tokenizer.pad_token = processor.tokenizer.eos_token\n",
+    "processor.tokenizer.padding_side = \"right\"\n",
+    "\n",
+    "model_base = AutoModelForImageTextToText.from_pretrained(\n",
+    "    MODEL_NAME,\n",
+    "    quantization_config=bnb_config,\n",
+    "    device_map=\"auto\",\n",
+    ")\n",
+    "\n",
+    "nb_params = sum(p.numel() for p in model_base.parameters())\n",
+    "print(f\"Modele charge. Parametres : {nb_params:,}\")\n",
+    "print(f\"Tour de vision presente : {hasattr(model_base, 'model') and hasattr(model_base.model, 'visual')}\")\n",
+    "if torch.cuda.is_available():\n",
+    "    print(f\"VRAM utilisee : {torch.cuda.memory_allocated() / 1e6:.0f} Mo\")"
+   ],
+   "execution_count": 2,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chargement de Qwen/Qwen3.5-0.8B en 4-bit NF4...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "W0823 22:18:35.005000 32672 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:   0%|          | 0/473 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:   0%|          | 1/473 [00:00<01:42,  4.60it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:   6%|▌         | 28/473 [00:00<00:04, 108.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  16%|█▋        | 78/473 [00:00<00:01, 246.47it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  27%|██▋       | 128/473 [00:00<00:01, 326.29it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  36%|███▌      | 171/473 [00:00<00:00, 358.89it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  47%|████▋     | 220/473 [00:00<00:00, 397.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  58%|█████▊    | 273/473 [00:00<00:00, 435.22it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  67%|██████▋   | 319/473 [00:00<00:00, 431.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  92%|█████████▏| 434/473 [00:01<00:00, 641.47it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights: 100%|██████████| 473/473 [00:01<00:00, 434.58it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele charge. Parametres : 555,419,712\n",
+      "Tour de vision presente : True\n",
+      "VRAM utilisee : 832 Mo\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb6e8e37",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du chargement.** La sortie affiche le total de paramètres du checkpoint — **555 419 712** ici, couvrant tour de vision et décodeur réunis, le corps étant stocké en 4-bit pour **832 Mo** de VRAM. Deux points de contrôle : la ligne « tour de vision présente : True » confirme que `AutoModelForImageTextToText` a bien instancié l'architecture multimodale complète (et non le seul décodeur `ForCausalLM`, qui existe aussi pour ce checkpoint) ; la VRAM mesurée juste après chargement donne la référence à partir de laquelle les sections suivantes (adaptateurs, entraînement, génération) seront comparées. Le processor, lui, ne consomme pas de VRAM — mais c'est lui qui fixe combien de tokens une image « coûtera » dans la séquence, donc indirectement la longueur des lots d'entraînement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e3fe624",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 2. La tâche image→texte bornée : contrat de sortie et dataset synthétique\n",
+    "\n",
+    "La question pédagogique du notebook est étroite, et volontairement telle : **que faut-il modifier dans un VLM pour qu'il honore un format de sortie arbitraire sur une tâche visuelle simple ?** La réponse explorée ici : pas la vision — le décodeur.\n",
+    "\n",
+    "La tâche : chaque image 128×128 contient exactement **une forme colorée** sur fond blanc. Le modèle doit répondre selon le contrat strict :\n",
+    "\n",
+    "```\n",
+    "### Assistant: [IMG] forme=<disque|carre|triangle> couleur=<rouge|vert|bleu|jaune> [FIN]\n",
+    "```\n",
+    "\n",
+    "Trois formes, quatre couleurs — **12 combinaisons** possibles. Nous générons :\n",
+    "\n",
+    "- **24 images d'entraînement** (2 par combinaison), avec un léger jitter de taille et de position pour éviter qu'une disposition d'image précise n'apparaisse deux fois à l'identique ;\n",
+    "- **6 images de test held-out** — des combinaisons tirées parmi les 12, jamais vues à l'entraînement, dessinées avec un autre grain aléatoire. C'est cette séparation qui donnera son sens à l'évaluation : mesurer la **généralisation** du contrat, pas sa mémorisation image par image.\n",
+    "\n",
+    "Deux choix de conception à noter. D'abord, le dataset est **synthétique et déterministe** : dessiné par PIL avec un générateur aléatoire local (`random.Random(graine)`), il se reproduit au pixel près d'une session à l'autre — pas de téléchargement de données, pas de variation cachée, la graine suffit. Ensuite, le jitter est **borné** (positions dans une zone centrale, tailles dans un intervalle) : la tâche reste visuellement triviale pour la tour de vision. C'est délibéré — nous voulons que tout écart de mesure soit attribuable au contrat de langage, pas à la difficulté perceptive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "b8f49ba3",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Dataset synthetique — une forme coloree par image 128x128, dessinee par PIL\n",
+    "\n",
+    "FORMES = [\"disque\", \"carre\", \"triangle\"]\n",
+    "COULEURS = {\n",
+    "    \"rouge\": (214, 40, 40),\n",
+    "    \"vert\": (40, 160, 60),\n",
+    "    \"bleu\": (40, 70, 214),\n",
+    "    \"jaune\": (230, 210, 40),\n",
+    "}\n",
+    "FOND = (250, 250, 250)\n",
+    "TAILLE_IMAGE = 128\n",
+    "\n",
+    "def dessiner_forme(forme, couleur_rgb, taille, cx, cy):\n",
+    "    \"\"\"Dessine une forme centree en (cx, cy) sur un canvas blanc 128x128.\"\"\"\n",
+    "    image = Image.new(\"RGB\", (TAILLE_IMAGE, TAILLE_IMAGE), FOND)\n",
+    "    dessin = ImageDraw.Draw(image)\n",
+    "    demi = taille // 2\n",
+    "    if forme == \"disque\":\n",
+    "        dessin.ellipse([cx - demi, cy - demi, cx + demi, cy + demi], fill=couleur_rgb)\n",
+    "    elif forme == \"carre\":\n",
+    "        dessin.rectangle([cx - demi, cy - demi, cx + demi, cy + demi], fill=couleur_rgb)\n",
+    "    elif forme == \"triangle\":\n",
+    "        sommets = [(cx, cy - demi), (cx - demi, cy + demi), (cx + demi, cy + demi)]\n",
+    "        dessin.polygon(sommets, fill=couleur_rgb)\n",
+    "    return image\n",
+    "\n",
+    "def generer_ensemble(nb_par_combinaison, graine):\n",
+    "    \"\"\"Genere les 12 combinaisons forme x couleur, avec jitter borne, de facon deterministe.\n",
+    "\n",
+    "    Le generateur random.Random local ne touche pas l'etat aleatoire global :\n",
+    "    deux appels avec la meme graine produisent les memes images au pixel pres.\n",
+    "    \"\"\"\n",
+    "    gen = random.Random(graine)\n",
+    "    exemples = []\n",
+    "    for forme in FORMES:\n",
+    "        for couleur in COULEURS:\n",
+    "            for _ in range(nb_par_combinaison):\n",
+    "                taille = gen.randint(28, 44)\n",
+    "                cx = gen.randint(48, 80)\n",
+    "                cy = gen.randint(48, 80)\n",
+    "                image = dessiner_forme(forme, COULEURS[couleur], taille, cx, cy)\n",
+    "                exemples.append({\"image\": image, \"forme\": forme, \"couleur\": couleur})\n",
+    "    gen.shuffle(exemples)\n",
+    "    return exemples\n",
+    "\n",
+    "train_brut = generer_ensemble(nb_par_combinaison=2, graine=SEED)             # 12 x 2 = 24\n",
+    "candidats_test = generer_ensemble(nb_par_combinaison=1, graine=SEED + 1000)  # 12 candidats\n",
+    "test_exemples = candidats_test[::2]                                          # 6 held-out\n",
+    "\n",
+    "print(f\"Train : {len(train_brut)} images ({len(FORMES)} formes x {len(COULEURS)} couleurs x 2)\")\n",
+    "print(f\"Test held-out : {len(test_exemples)} images\")\n",
+    "print(\"\\nCombinaisons de test :\")\n",
+    "for ex in test_exemples:\n",
+    "    print(f\"  {ex['forme']:<10} {ex['couleur']}\")"
+   ],
+   "execution_count": 3,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train : 24 images (3 formes x 4 couleurs x 2)\n",
+      "Test held-out : 6 images\n",
+      "\n",
+      "Combinaisons de test :\n",
+      "  disque     jaune\n",
+      "  carre      jaune\n",
+      "  disque     bleu\n",
+      "  carre      rouge\n",
+      "  disque     rouge\n",
+      "  triangle   vert\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ee112dc",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du dataset.** La sortie confirme la structure voulue : 24 images d'entraînement couvrant uniformément les 12 combinaisons (2 chacune), et 6 images de test listées avec leur étiquette. Vérifiez dans la liste que les combinaisons de test recouvrent plusieurs formes **et** plusieurs couleurs — 3 disques, 2 carrés, 1 triangle sur 4 couleurs distinctes : c'est la condition pour que l'accuracy par champ (section 3) puisse distinguer un modèle qui devine toujours « disque » d'un modèle qui regarde vraiment l'image. Remarquez aussi ce que le jitter ne fait **pas** : il varie taille et position dans des bornes étroites, donc deux images d'une même combinaison diffèrent, mais restent perceptivement identiques — l'apprentissage portera sur l'association forme/couleur, pas sur la mémorisation de pixels exacts.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "f270bd9c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Le contrat de sortie : paire (prompt multimodal, reponse attendue)\n",
+    "PROMPT_MODELE = (\n",
+    "    \"### Human: <|vision_start|><|image_pad|><|vision_end|> Decrivez l'image.\\n### Assistant:\"\n",
+    ")\n",
+    "\n",
+    "def construire_reponse(forme, couleur):\n",
+    "    \"\"\"La reponse attendue : le contrat de format que le LoRA doit installer.\"\"\"\n",
+    "    return f\"[IMG] forme={forme} couleur={couleur} [FIN]\"\n",
+    "\n",
+    "train_exemples = [\n",
+    "    {\n",
+    "        \"image\": ex[\"image\"],\n",
+    "        \"texte\": f\"{PROMPT_MODELE} {construire_reponse(ex['forme'], ex['couleur'])}\",\n",
+    "    }\n",
+    "    for ex in train_brut\n",
+    "]\n",
+    "\n",
+    "print(\"Exemple complet (placeholder d'image non encore expande) :\")\n",
+    "print(\"-\" * 60)\n",
+    "print(train_exemples[0][\"texte\"])\n",
+    "print(\"-\" * 60)\n",
+    "\n",
+    "# Longueur de la part texte : le placeholder compte pour 1 jeton ici,\n",
+    "# le processor l'expandra au moment du lot\n",
+    "tailles = [len(processor.tokenizer(t[\"texte\"])[\"input_ids\"]) for t in train_exemples]\n",
+    "print(f\"\\n{len(train_exemples)} paires formatees\")\n",
+    "print(f\"Longueur texte : min {min(tailles)}, max {max(tailles)}, moy {sum(tailles) / len(tailles):.0f} jetons\")"
+   ],
+   "execution_count": 4,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exemple complet (placeholder d'image non encore expande) :\n",
+      "------------------------------------------------------------\n",
+      "### Human: <|vision_start|><|image_pad|><|vision_end|> Decrivez l'image.\n",
+      "### Assistant: [IMG] forme=carre couleur=rouge [FIN]\n",
+      "------------------------------------------------------------\n",
+      "\n",
+      "24 paires formatees\n",
+      "Longueur texte : min 29, max 31, moy 30 jetons\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d74b8845",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du formatage.** L'exemple affiché montre le squelette complet d'un exemple d'entraînement : le prompt `### Human:` contient le **marqueur d'image** encadré de `<|vision_start|>`/`<|vision_end|>` suivi de la consigne, et la cible après `### Assistant:` porte le contrat `[IMG] forme=… couleur=… [FIN]`. Les longueurs affichées — 29 à 31 tokens, moyenne 30 — ne couvrent que la part **textuelle** : au moment où le processor prépare un lot, le marqueur `<|image_pad|>` sera remplacé par le nombre exact de tokens visuels de l'image (les patchs après fusion), allongeant d'autant la séquence réelle. C'est pour cela qu'un VLM « consomme » tant de contexte pour si peu de mots : la part visuelle domine la séquence effective (mesurée à la section 5). Comme en FT-03, ce format (`### Human:` / `### Assistant:`) est un contrat entre entraînement et inférence — identique des deux côtés.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73fd963b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 3. Mesure de référence du modèle de base\n",
+    "\n",
+    "Avant tout fine-tuning, il faut un **point de comparaison honnête**. Nous soumettons au modèle de base les 6 images held-out avec exactement le prompt qui servira à l'entraînement, puis nous mesurons trois indicateurs :\n",
+    "\n",
+    "- **`respecte_format`** — la conformité au contrat : la réponse commence par `[IMG]` et contient `[FIN]`. C'est la métrique centrale du notebook : elle mesure un *comportement de langage* (suivre un format), pas une connaissance.\n",
+    "- **`accuracy_forme`** — le champ `forme=` extrait de la réponse est-il le bon ?\n",
+    "- **`accuracy_couleur`** — le champ `couleur=` est-il le bon ?\n",
+    "\n",
+    "L'extraction est volontairement fruste (découpage sur les espaces, lecture des préfixes `forme=`/`couleur=`) : si le modèle n'émet pas les champs, l'extraction rend `None` et le champ est compté faux — aucune indulgence. Ce protocole étant écrit **une fois** et appliqué tel quel aux deux modèles (section 6), la comparaison base vs LoRA ne dépend d'aucun réglage caché.\n",
+    "\n",
+    "Que prédire pour un modèle de base ? Rien ne l'a jamais exposé à ce contrat arbitraire : il continuera vraisemblablement le prompt en prose libre, ou recyclera des formats vus au pré-entraînement. La mesure dira précisément à quelle distance il est du contrat — c'est cette distance que le LoRA devra combler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "31c7602a",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Fonctions d'evaluation : generation multimodale + metriques de conformite\n",
+    "\n",
+    "def generer_vlm(model, image, prompt, max_new_tokens=40):\n",
+    "    \"\"\"Genere la suite du prompt pour une image donnee (decodage glouton, deterministe).\"\"\"\n",
+    "    entrees = processor(text=prompt, images=image, return_tensors=\"pt\").to(model.device)\n",
+    "    with torch.no_grad():\n",
+    "        sortie = model.generate(\n",
+    "            **entrees,\n",
+    "            max_new_tokens=max_new_tokens,\n",
+    "            do_sample=False,\n",
+    "            pad_token_id=processor.tokenizer.pad_token_id,\n",
+    "        )\n",
+    "    return processor.tokenizer.decode(\n",
+    "        sortie[0][entrees[\"input_ids\"].shape[1]:],\n",
+    "        skip_special_tokens=True,\n",
+    "    ).strip()\n",
+    "\n",
+    "def extraire_champs(texte):\n",
+    "    \"\"\"Extrait les valeurs des champs forme=... et couleur=... (None si absents).\"\"\"\n",
+    "    forme, couleur = None, None\n",
+    "    for mot in texte.split():\n",
+    "        if mot.startswith(\"forme=\"):\n",
+    "            forme = mot.split(\"=\", 1)[1]\n",
+    "        elif mot.startswith(\"couleur=\"):\n",
+    "            couleur = mot.split(\"=\", 1)[1]\n",
+    "    return forme, couleur\n",
+    "\n",
+    "def respecte_format(texte):\n",
+    "    \"\"\"Conformite au contrat : demarre par [IMG] et contient [FIN].\"\"\"\n",
+    "    return texte.startswith(\"[IMG]\") and \"[FIN]\" in texte\n",
+    "\n",
+    "def evaluer_modele(model, exemples, nom=\"modele\"):\n",
+    "    \"\"\"Soumet chaque image au modele, mesure conformite et justesse champ par champ.\"\"\"\n",
+    "    lignes = []\n",
+    "    for ex in exemples:\n",
+    "        sortie = generer_vlm(model, ex[\"image\"], PROMPT_MODELE)\n",
+    "        forme_pred, couleur_pred = extraire_champs(sortie)\n",
+    "        lignes.append({\n",
+    "            \"verite\": f\"{ex['forme']}/{ex['couleur']}\",\n",
+    "            \"sortie\": sortie,\n",
+    "            \"respecte\": respecte_format(sortie),\n",
+    "            \"forme_ok\": forme_pred == ex[\"forme\"],\n",
+    "            \"couleur_ok\": couleur_pred == ex[\"couleur\"],\n",
+    "        })\n",
+    "    n = len(lignes)\n",
+    "    metriques = {\n",
+    "        \"respecte_format\": sum(l[\"respecte\"] for l in lignes) / n,\n",
+    "        \"accuracy_forme\": sum(l[\"forme_ok\"] for l in lignes) / n,\n",
+    "        \"accuracy_couleur\": sum(l[\"couleur_ok\"] for l in lignes) / n,\n",
+    "    }\n",
+    "    print(f\"--- Evaluation : {nom} ({n} images held-out) ---\")\n",
+    "    print(f\"{'Verite':<18}{'Conforme':<10}{'Forme':<7}{'Couleur':<9}Sortie (60 car.)\")\n",
+    "    for l in lignes:\n",
+    "        extrait = l[\"sortie\"][:60].replace(\"\\n\", \" \")\n",
+    "        print(f\"{l['verite']:<18}{str(l['respecte']):<10}{str(l['forme_ok']):<7}{str(l['couleur_ok']):<9}{extrait}\")\n",
+    "    print(f\"\\nConformite de format : {metriques['respecte_format']:.2f}\")\n",
+    "    print(f\"Accuracy forme       : {metriques['accuracy_forme']:.2f}\")\n",
+    "    print(f\"Accuracy couleur     : {metriques['accuracy_couleur']:.2f}\")\n",
+    "    return metriques, lignes"
+   ],
+   "execution_count": 5,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37488562",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### 3a. Passage du modèle de base sur les images held-out\n",
+    "\n",
+    "Chaque image est soumise seule (batch de 1, décodage glouton pour que la mesure soit reproductible). La table affiche la vérité terrain, les trois verdicts booléens et un extrait de la sortie brute — lisez l'extrait avant les métriques : c'est lui qui montre *comment* le modèle échoue (prose libre ? champs déformés ? boucle ?), les nombres ne donnent que l'amplitude."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "697b9a3a",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Mesure de reference : modele de base (avant tout fine-tuning)\n",
+    "metriques_base, lignes_base = evaluer_modele(model_base, test_exemples, nom=\"modele de base\")"
+   ],
+   "execution_count": 6,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Evaluation : modele de base (6 images held-out) ---\n",
+      "Verite            Conforme  Forme  Couleur  Sortie (60 car.)\n",
+      "disque/jaune      False     False  False    <think>  </think>  L'image présente une simple composition g\n",
+      "carre/jaune       False     False  False    <think>  </think>  D'après l'image, il s'agit d'une image si\n",
+      "disque/bleu       False     False  False    <think>  </think>  L'image présente un cercle bleu pur sur u\n",
+      "carre/rouge       False     False  False    <think>  </think>  D'après l'image, il s'agit d'une image si\n",
+      "disque/rouge      False     False  False    <think>  </think>  La image présente un cercle rouge centré \n",
+      "triangle/vert     False     False  False    <think>  </think>  L'image montre un triangle vert simple et\n",
+      "\n",
+      "Conformite de format : 0.00\n",
+      "Accuracy forme       : 0.00\n",
+      "Accuracy couleur     : 0.00\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd4855c6",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la mesure de référence.** Conformité **0.00**, accuracy forme **0.00**, accuracy couleur **0.00** — le plancher, comme attendu. Mais lisez les extraits bruts : c'est le résultat le plus instructif du notebook. Le modèle de base **voit parfaitement les images** — « un cercle bleu pur », « un triangle vert simple », « un cercle rouge centré » : la description en prose contient la bonne forme ET la bonne couleur à chaque fois. Le régime d'échec n'est donc **pas** perceptuel : la tour de vision fonctionne, le décodeur sait nommer ce qu'il voit. Ce qui manque est uniquement le **contrat** — aucun `forme=…`, aucun `[IMG]`, aucune balise. La colonne Couleur affiche 0.00 alors que la couleur est correcte en prose : la métrique ne récompense que le champ formaté, pas la connaissance. C'est précisément ce que le LoRA sur le décodeur va installer, sans toucher à la vision.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "970339dd",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 4. LoRA ciblé sur le décodeur\n",
+    "\n",
+    "Le choix structurant du notebook : nous adaptons **exclusivement le décodeur de langage**. La `LoraConfig` ci-dessous cible trois familles de modules, toutes côté langage :\n",
+    "\n",
+    "| Famille | Modules | Rôle |\n",
+    "|---|---|---|\n",
+    "| Attention complète | `q_proj`, `k_proj`, `v_proj`, `o_proj` | couches softmax du décodeur hybride |\n",
+    "| Attention linéaire | `linear_attn.out_proj` | couches Gated DeltaNet (coût constant en longueur) |\n",
+    "| MLP | `gate_proj`, `up_proj`, `down_proj` | projections feed-forward de chaque couche |\n",
+    "\n",
+    "C'est la même liste que FT-03, adaptée à l'architecture hybride de Qwen3.5 : le rang r=16 fixe la capacité des adaptateurs, `lora_alpha=32` leur échelle (ratio 2:1 usuel), le dropout 0,05 régularise un entraînement court. La tour de vision, elle, reste **gelée** — le pourquoi fait l'objet de la section 7 ; l'extension (cibler aussi le merger visuel) est l'exercice 3.\n",
+    "\n",
+    "Comme en FT-03, `prepare_model_for_kbit_training` prépare le corps 4-bit à recevoir des gradients (gel fin, normes en float32, cache désactivé pour le gradient checkpointing), puis `get_peft_model` greffe les adaptateurs. La sortie de `print_trainable_parameters()` est le chiffre à retenir : la part de paramètres réellement entraînés dans le modèle multimodal complet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "4b27ca19",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# LoRA sur le decodeur : preparer le corps 4-bit puis greffer les adaptateurs\n",
+    "from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training, TaskType\n",
+    "\n",
+    "model_base = prepare_model_for_kbit_training(model_base)\n",
+    "\n",
+    "lora_config = LoraConfig(\n",
+    "    task_type=TaskType.CAUSAL_LM,\n",
+    "    r=16,                    # rang des matrices LoRA\n",
+    "    lora_alpha=32,           # facteur d'echelle (ratio 2:1 usuel)\n",
+    "    lora_dropout=0.05,       # regularisation pour un entrainement court\n",
+    "    target_modules=[\n",
+    "        \"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\",   # attention complete\n",
+    "        \"linear_attn.out_proj\",                   # attention lineaire (Gated DeltaNet)\n",
+    "        \"gate_proj\", \"up_proj\", \"down_proj\",      # MLP\n",
+    "    ],\n",
+    "    bias=\"none\",\n",
+    ")\n",
+    "\n",
+    "model_sft = get_peft_model(model_base, lora_config)\n",
+    "model_sft.print_trainable_parameters()\n",
+    "\n",
+    "if torch.cuda.is_available():\n",
+    "    print(f\"\\nVRAM avant entrainement : {torch.cuda.memory_allocated() / 1e6:.0f} Mo\")"
+   ],
+   "execution_count": 7,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "trainable params: 7,274,496 || all params: 860,260,416 || trainable%: 0.8456\n",
+      "\n",
+      "VRAM avant entrainement : 1385 Mo\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70eefad6",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la configuration LoRA.** `print_trainable_parameters()` affiche **7 274 496** paramètres entraînables sur **860 260 416** au total — **0,8456 %**. Comparez ce rapport à celui du FT-03 (0,8456 % aussi) : les adaptateurs ciblent les mêmes modules du décodeur, mais le dénominateur a grossi — la tour de vision et le merger, bien que gelés, pèsent dans le total. La VRAM avant entraînement (**1385 Mo**) donne le point de départ mémoire : les adaptateurs et leurs états d'optimiseur s'ajouteront à elle, mais le corps 4-bit ne bougera pas — c'est l'économie QLoRA. Vérifiez enfin dans la sortie de PEFT les modules réellement ciblés : `q/k/v/o_proj` pour l'attention complète, `linear_attn.out_proj` pour l'attention linéaire, `gate/up/down_proj` pour les MLP — les deux familles d'attention de l'architecture hybride Qwen3.5.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bb15163",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 5. Entraînement QLoRA\n",
+    "\n",
+    "Le pipeline reprend la mécanique du FT-03 avec une différence de taille : **le collator doit passer par le processor**, car chaque exemple mêle une image et du texte. C'est lui qui, lot par lot, tokenise les textes, prépare les pixels, remplace le marqueur `<|image_pad|>` par le nombre exact de tokens visuels, padde à la longueur du lot — et fabrique les `labels` : les positions de padding sont masquées à −100 (hors loss), ainsi que les tokens d'image eux-mêmes (le modèle n'a pas à apprendre à *émettre* des tokens visuels, seulement la réponse texte).\n",
+    "\n",
+    "**Hyperparamètres clés** :\n",
+    "- `per_device_train_batch_size=1` + `gradient_accumulation_steps=8` — les séquences contiennent les tokens d'image : le batch effectif de 8 est reconstitué par accumulation pour tenir dans 8 Go de VRAM\n",
+    "- `num_train_epochs=5` — 24 exemples × 5 époques ≈ 15 pas d'optimisation, un budget délibérément minuscule\n",
+    "- `learning_rate=2e-4` — taux standard LoRA, ~100× celui d'un pré-entraînement, sûr car seuls les adaptateurs bougent\n",
+    "- `warmup_steps=3` — l'échauffement se compte en pas (transformers 5.x a retiré `warmup_ratio`)\n",
+    "- `bf16=True` + `gradient_checkpointing=True` — précision large et activations recalculées : le duo qui fait tenir l'entraînement d'un VLM sur une carte consumer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "462d4a9f",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Dataset HuggingFace + collator multimodal (le processor traite chaque lot image+texte)\n",
+    "from datasets import Dataset\n",
+    "from transformers import TrainingArguments, Trainer\n",
+    "\n",
+    "train_dataset = Dataset.from_list(train_exemples)\n",
+    "print(f\"Dataset pret : {len(train_dataset)} exemples, colonnes : {train_dataset.column_names}\")\n",
+    "\n",
+    "def collate_fn(exemples):\n",
+    "    \"\"\"Applique le processor aux (image, texte) du lot et fabrique les labels masques.\"\"\"\n",
+    "    lots = processor(\n",
+    "        text=[e[\"texte\"] for e in exemples],\n",
+    "        images=[e[\"image\"] for e in exemples],\n",
+    "        padding=True,\n",
+    "        return_tensors=\"pt\",\n",
+    "    )\n",
+    "    labels = lots[\"input_ids\"].clone()\n",
+    "    # padding hors loss...\n",
+    "    labels[labels == processor.tokenizer.pad_token_id] = -100\n",
+    "    # ...et jetons d'image hors loss : le modele apprend la reponse, pas les tokens visuels\n",
+    "    labels[labels == processor.image_token_id] = -100\n",
+    "    lots[\"labels\"] = labels\n",
+    "    return lots\n",
+    "\n",
+    "# Verifier le collator sur un mini-lot de 2 exemples\n",
+    "apercu = collate_fn([train_exemples[0], train_exemples[1]])\n",
+    "print(f\"Forme input_ids du lot : {apercu['input_ids'].shape}\")\n",
+    "print(f\"Positions hors loss (labels == -100) : {(apercu['labels'] == -100).sum().item()} jetons\")"
+   ],
+   "execution_count": 8,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset pret : 24 exemples, colonnes : ['image', 'texte']\n",
+      "Forme input_ids du lot : torch.Size([2, 94])\n",
+      "Positions hors loss (labels == -100) : 128 jetons\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2deda1c0",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la préparation.** Le mini-lot affiche une vraie longueur de **94 tokens** pour 2 exemples — comparez aux longueurs purement textuelles de la section 2 (29-31 tokens par exemple) : l'écart, ce sont les tokens visuels insérés par le processor à la place du marqueur `<|image_pad|>`, ~35 patches par image après fusion. Les **128 positions masquées** (labels à −100) cumulent le padding d'alignement et ces tokens d'image : la loss ne portera que sur le texte utile — le modèle n'apprend ni à émettre des tokens visuels, ni à prédire le padding. Le `Dataset.from_list` stocke les images PIL (encodage Arrow) et les restitue en objets image au tirage — le collator est le seul endroit où le processor intervient pendant l'entraînement.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "b9e7c78f",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Entrainement QLoRA du decodeur\n",
+    "training_args = TrainingArguments(\n",
+    "    output_dir=\"./results_ft06\",\n",
+    "    num_train_epochs=5,\n",
+    "    per_device_train_batch_size=1,\n",
+    "    gradient_accumulation_steps=8,\n",
+    "    learning_rate=2e-4,\n",
+    "    weight_decay=0.01,\n",
+    "    warmup_steps=3,              # transformers 5.x : warmup_steps, plus warmup_ratio\n",
+    "    logging_steps=5,\n",
+    "    save_strategy=\"epoch\",\n",
+    "    report_to=\"none\",\n",
+    "    bf16=True,\n",
+    "    gradient_checkpointing=True,\n",
+    "    remove_unused_columns=False,\n",
+    ")\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    model=model_sft,\n",
+    "    args=training_args,\n",
+    "    train_dataset=train_dataset,\n",
+    "    data_collator=collate_fn,\n",
+    ")\n",
+    "\n",
+    "print(\"Debut de l'entrainement QLoRA (24 exemples, 5 epoques)...\")\n",
+    "debut = time.time()\n",
+    "resultat_entrainement = trainer.train()\n",
+    "duree = time.time() - debut\n",
+    "\n",
+    "print(f\"\\nEntrainement termine en {duree:.1f}s ({duree / 60:.1f} min)\")\n",
+    "print(f\"Perte finale : {resultat_entrainement.training_loss:.4f}\")\n",
+    "if torch.cuda.is_available():\n",
+    "    print(f\"VRAM apres entrainement : {torch.cuda.memory_allocated() / 1e6:.0f} Mo\")"
+   ],
+   "execution_count": 9,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Debut de l'entrainement QLoRA (24 exemples, 5 epoques)...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[transformers] `use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='15' max='15' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [15/15 04:47, Epoch 5/5]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Step</th>\n",
+       "      <th>Training Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>5</td>\n",
+       "      <td>4.597577</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>10</td>\n",
+       "      <td>0.634687</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>15</td>\n",
+       "      <td>0.070737</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Entrainement termine en 308.4s (5.1 min)\n",
+      "Perte finale : 1.7677\n",
+      "VRAM apres entrainement : 1452 Mo\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "178e0560",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture de l'entraînement.** Trois mesures sortent de cette cellule. La **durée** : **308.4 s (5.1 min)** pour 24 exemples × 5 époques ≈ 15 pas d'optimisation, chacun cumulant 8 micro-lots. La **loss finale : 1.7677** — le contrat est court et répétitif, la descente est nette dès les premiers pas ; mais la leçon du FT-03 reste entière : une loss basse sur un mini-dataset mesure la mémorisation locale, pas la généralisation, et ne dit **rien** de la conformité sur les images held-out. La **VRAM : 1452 Mo** après entraînement (contre 1385 avant) — l'écart de ~67 Mo correspond aux états optimiseur des adaptateurs et aux activations du gradient checkpointing. Le verdict utile se lira à la section 6, sur des images jamais vues.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0aa71270",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 6. Évaluation comparative : base vs LoRA\n",
+    "\n",
+    "Le moment de vérité : nous reprenons **à l'identique** le protocole de la section 3 — mêmes 6 images held-out, même prompt, même fonction d'évaluation, même décodage glouton — sur le modèle affiné. Le tableau croise les trois métriques mesurées avant entraînement (stockées dans `metriques_base`) avec leurs valeurs après entraînement, et affiche le delta signé ; deux sorties brutes côte à côte montrent le changement de régime textuel. Rien n'est reconstruit à la main : chaque nombre du tableau vient des variables mesurées dans les cellules précédentes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "10e57086",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Evaluation comparative : modele de base vs modele LoRA (memes images, meme protocole)\n",
+    "model_sft.eval()\n",
+    "metriques_lora, lignes_lora = evaluer_modele(model_sft, test_exemples, nom=\"modele LoRA\")\n",
+    "\n",
+    "print()\n",
+    "print(\"=\" * 66)\n",
+    "print(\"COMPARATIF : MODELE DE BASE vs MODELE LORA (6 images held-out)\")\n",
+    "print(\"=\" * 66)\n",
+    "print(f\"{'Metrique':<22}{'Base':>12}{'LoRA':>12}{'Delta':>12}\")\n",
+    "print(\"-\" * 66)\n",
+    "for cle in (\"respecte_format\", \"accuracy_forme\", \"accuracy_couleur\"):\n",
+    "    delta = metriques_lora[cle] - metriques_base[cle]\n",
+    "    print(f\"{cle:<22}{metriques_base[cle]:>12.2f}{metriques_lora[cle]:>12.2f}{delta:>+12.2f}\")\n",
+    "\n",
+    "print(\"\\nSorties brutes cote a cote (2 premieres images) :\")\n",
+    "for i in range(min(2, len(lignes_lora))):\n",
+    "    print(f\"\\nImage {i + 1} — verite : {lignes_lora[i]['verite']}\")\n",
+    "    print(f\"  Base : {lignes_base[i]['sortie'][:110]}\")\n",
+    "    print(f\"  LoRA : {lignes_lora[i]['sortie'][:110]}\")"
+   ],
+   "execution_count": 10,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Evaluation : modele LoRA (6 images held-out) ---\n",
+      "Verite            Conforme  Forme  Couleur  Sortie (60 car.)\n",
+      "disque/jaune      True      True   True     [IMG] forme=disque couleur=jaune [FIN]\n",
+      "carre/jaune       True      True   True     [IMG] forme=carre couleur=jaune [FIN]\n",
+      "disque/bleu       True      True   True     [IMG] forme=disque couleur=bleu [FIN]\n",
+      "carre/rouge       True      True   True     [IMG] forme=carre couleur=rouge [FIN]\n",
+      "disque/rouge      True      True   True     [IMG] forme=disque couleur=rouge [FIN]\n",
+      "triangle/vert     True      True   True     [IMG] forme=triangle couleur=vert [FIN]\n",
+      "\n",
+      "Conformite de format : 1.00\n",
+      "Accuracy forme       : 1.00\n",
+      "Accuracy couleur     : 1.00\n",
+      "\n",
+      "==================================================================\n",
+      "COMPARATIF : MODELE DE BASE vs MODELE LORA (6 images held-out)\n",
+      "==================================================================\n",
+      "Metrique                      Base        LoRA       Delta\n",
+      "------------------------------------------------------------------\n",
+      "respecte_format               0.00        1.00       +1.00\n",
+      "accuracy_forme                0.00        1.00       +1.00\n",
+      "accuracy_couleur              0.00        1.00       +1.00\n",
+      "\n",
+      "Sorties brutes cote a cote (2 premieres images) :\n",
+      "\n",
+      "Image 1 — verite : disque/jaune\n",
+      "  Base : <think>\n",
+      "\n",
+      "</think>\n",
+      "\n",
+      "L'image présente une simple composition graphique :\n",
+      "\n",
+      "*   **Contenu central :** Il y a un ce\n",
+      "  LoRA : [IMG] forme=disque couleur=jaune [FIN]\n",
+      "\n",
+      "Image 2 — verite : carre/jaune\n",
+      "  Base : <think>\n",
+      "\n",
+      "</think>\n",
+      "\n",
+      "D'après l'image, il s'agit d'une image simplifiée et abstraite.\n",
+      "\n",
+      "Voici une décomposition de\n",
+      "  LoRA : [IMG] forme=carre couleur=jaune [FIN]\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "baeb40a1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du comparatif.** Le tableau parle de lui-même : conformité **0.00 → 1.00**, accuracy forme **0.00 → 1.00**, accuracy couleur **0.00 → 1.00** — 6/6 images held-out parfaitement décrites, forme et couleur exactes, contrat respecté de bout en bout. Trois choses à remarquer. (1) **Conformité et justesse montent ensemble** : le cas redouté (conformité maximale, accuracy médiocre — le squelette appris sans lire l'image) n'a pas eu lieu ; la loss a bien forcé le contenu des champs. (2) **La vision gelée a suffi** : la tour de vision et le merger, intouchés, extrayaient déjà les bons traits (la section 3 le montrait en prose) — le LoRA a seulement appris au décodeur à les *lire* dans le format du contrat. (3) **La généralisation est réelle** : les 6 images de test ne sont pas dans les 24 d'entraînement (jitter de position/taille différent) — le contrat transfère à des pixels jamais vus, comme le format balise du FT-03 transférait à des reformulations.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e301b82",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 7. Pourquoi le décodeur seulement ?\n",
+    "\n",
+    "La question mérite sa section, car elle généralise au-delà de ce TP : **où faut-il placer ses adaptateurs quand on fine-tune un VLM ?** Notre réponse ici — le décodeur — tient en trois arguments.\n",
+    "\n",
+    "**1. Le comportement à installer est un comportement de langage.** Le contrat `[IMG] forme=… couleur=… [FIN]` n'exige rien de nouveau côté perception : distinguer un disque rouge d'un carré bleu est une tâche que la tour de vision, gelée, résout déjà largement. Ce qui manque au modèle, c'est la **mise en forme** : émettre les délimiteurs, les noms de champs, l'ordre, la fermeture `[FIN]`. Or tout cela vit dans le décodeur — c'est lui qui produit la séquence de tokens. Adapter les projections d'attention et de MLP du décodeur donne à LoRA exactement les degrés de liberté qu'il faut pour réorganiser le langage de sortie.\n",
+    "\n",
+    "**2. Geler la vision préserve un extracteur de traits déjà compétent.** La tour de vision a été pré-entraînée sur des millions d'images ; la recalibrer sur 24 images synthétiques de formes primaires serait au mieux inutile, au pire destructeur — le sur-apprentissage d'un extracteur massif sur un dataset minuscule est la recette classique de la dégradation. Le gel est ici une protection.\n",
+    "\n",
+    "**3. Le budget suit la décision.** Chaque module ciblé ajoute ses matrices LoRA (rang × dimensions). Cibler le décodeur seul garde l'empreinte et l'entraînement dans les bornes d'une carte 8 Go ; ajouter la vision grossit les adaptateurs pour un gain qui, sur une tâche aussi simple perceptuellement, doit être démontré plutôt que présumé.\n",
+    "\n",
+    "La frontière n'est pas dogmatique pour autant : quand la tâche exige une discrimination visuelle que le merger encode mal (nuances fines, positions, relations spatiales), cibler les projections visuelles — le merger `model.visual.merger` (`linear_fc1`, `linear_fc2`) — devient l'extension naturelle. C'est précisément l'exercice 3 : mesurer ce que ce ciblage ajoute (ou non) en paramètres et en métriques."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1a9e21e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 8. Nettoyage de la mémoire GPU\n",
+    "\n",
+    "Nous libérons le modèle et ses adaptateurs avant la section exercices — l'exercice 3 recharge un modèle frais, et une carte 8 Go n'accueillera pas deux copies. La mesure avant/après quantifie ce que pèsent corps 4-bit + adaptateurs + cache d'allocation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "9e8ac1c5",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Liberation de la memoire GPU\n",
+    "if torch.cuda.is_available():\n",
+    "    vram_avant = torch.cuda.memory_allocated() / 1e6\n",
+    "del model_sft, model_base, trainer\n",
+    "gc.collect()\n",
+    "torch.cuda.empty_cache()\n",
+    "if torch.cuda.is_available():\n",
+    "    vram_apres = torch.cuda.memory_allocated() / 1e6\n",
+    "    print(f\"VRAM liberee : {vram_avant - vram_apres:.0f} Mo (residuel : {vram_apres:.0f} Mo)\")\n",
+    "print(\"Memoire GPU liberee.\")"
+   ],
+   "execution_count": 11,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VRAM liberee : 1435 Mo (residuel : 17 Mo)\n",
+      "Memoire GPU liberee.\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c185bf19",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 9. Exercices\n",
+    "\n",
+    "Les trois exercices prolongent chacun un fil du notebook : (1) la **richesse du contrat** — une forme nouvelle exige-t-elle plus de données pour la même conformité ? ; (2) l'**élargissement du contrat** — un champ `position=` teste si le modèle lit l'image, pas seulement le format ; (3) le **périmètre du LoRA** — cibler aussi la vision et mesurer ce que ça change vraiment. Chaque exercice réutilise les cellules précédentes ; rechargez un modèle frais comme en section 1 si vous avez exécuté le nettoyage de la section 8."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3639571b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : une quatrième forme — l'étoile\n",
+    "\n",
+    "Ajoutez une forme `etoile` au dataset (10 sommets en alternant rayon externe et rayon interne pour `ImageDraw.polygon`), régénérez entraînement et test, réentraînez avec les mêmes hyperparamètres, mesurez à nouveau la conformité.\n",
+    "\n",
+    "**Questions** : avec combien d'exemples par combinaison la conformité maximale était-elle atteinte à 3 formes — et ce nombre suffit-il à 4 formes ? La conformité au format reste-t-elle acquise plus vite que la justesse du nouveau champ ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "7201431f",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Exercice 1 : ajouter la forme \"etoile\" au dataset et re-entrainer\n",
+    "# TODO etudiant : completez dessiner_etoile, regenerez le dataset avec 4 formes,\n",
+    "# relancez les cellules des sections 2 a 6, puis relevez la conformite obtenue.\n",
+    "\n",
+    "def dessiner_etoile(cx, cy, rayon_ext, rayon_int):\n",
+    "    \"\"\"Retourne les 10 sommets d'une etoile centree en (cx, cy).\"\"\"\n",
+    "    # Indice : bouclez sur 10 sommets en alternant rayon_ext et rayon_int,\n",
+    "    # angle progressant de pi/5 par sommet (depart en haut : -pi/2),\n",
+    "    # puis dessinez la liste avec draw.polygon(...) dans dessiner_forme.\n",
+    "    pass\n",
+    "\n",
+    "FORMES_ETENDUES = [\"disque\", \"carre\", \"triangle\"]  # TODO etudiant : ajoutez \"etoile\"\n",
+    "\n",
+    "exemples_par_combinaison = None  # TODO etudiant : combien d'exemples pour la conformite ?\n",
+    "\n",
+    "print(\"Exercice a completer : etoile dessinee, dataset regenere, conformite relevee\")"
+   ],
+   "execution_count": 12,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : etoile dessinee, dataset regenere, conformite relevee\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4ab824b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : étendre le contrat au champ position\n",
+    "\n",
+    "Générez des formes positionnées dans la moitié haute ou basse de l'image, étendez la réponse attendue en `[IMG] forme=… couleur=… position=<haut|bas> [FIN]`, ajoutez `accuracy_position` à l'évaluation (même motif que `accuracy_forme`), réentraînez et comparez.\n",
+    "\n",
+    "**Question** : la conformité du nouveau champ vient-elle aussi vite que celle du format — et l'accuracy position du modèle LoRA rejoint-elle celle des autres champs, ou la localisation spatiale résiste-t-elle davantage ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "8ff2b1f5",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Exercice 2 : etendre le contrat au champ position=<haut|bas>\n",
+    "# TODO etudiant : binarisez cy (cy < 64 -> \"haut\", sinon \"bas\") dans generer_ensemble,\n",
+    "# etendez construire_reponse(), ajoutez accuracy_position a evaluer_modele()\n",
+    "# (meme motif que accuracy_forme) ; re-entrainez et comparez avant/apres.\n",
+    "\n",
+    "resultats_position = {\n",
+    "    \"accuracy_position_base\": None,  # TODO etudiant : mesure apres re-evaluation du modele de base\n",
+    "    \"accuracy_position_lora\": None,  # TODO etudiant : mesure apres re-entrainement\n",
+    "}\n",
+    "\n",
+    "# Indice : position et couleur varient independamment — verifiez que vos images\n",
+    "# de test couvrent les deux positions, sinon l'accuracy position ne mesurera rien.\n",
+    "print(\"Exercice a completer : contrat etendu, metrique ajoutee, comparaison faite\")"
+   ],
+   "execution_count": 13,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : contrat etendu, metrique ajoutee, comparaison faite\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "182b4585",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : cibler aussi la vision — le merger dans target_modules\n",
+    "\n",
+    "Rechargez un modèle 4-bit frais et construisez une `LoraConfig` identique à celle de la section 4 **plus** les modules du merger visuel (`visual.merger.linear_fc1`, `visual.merger.linear_fc2`). Comparez trois choses avec le run décodeur-seul : le nombre de paramètres entraînables (`print_trainable_parameters`), la VRAM d'entraînement, et les métriques finales sur les mêmes 6 images.\n",
+    "\n",
+    "**Question** : sur une tâche où la vision était déjà compétente, le surcoût de paramètres achète-t-il un gain de conformité ou d'accuracy mesurable — ou le décodeur seul était-il déjà le bon périmètre ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "7dd8ef55",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Exercice 3 : cibler aussi la vision — ajouter visual.merger aux target_modules\n",
+    "# TODO etudiant : rechargez un modele 4-bit frais, construisez la LoraConfig avec\n",
+    "# les modules du merger en plus, re-entrainez, comparez params / VRAM / metriques.\n",
+    "\n",
+    "config_vision = None  # TODO etudiant : LoraConfig identique + [\"visual.merger.linear_fc1\", \"visual.merger.linear_fc2\"]\n",
+    "\n",
+    "# Indice : apres la section 8 le GPU est libre — rechargez comme en section 1\n",
+    "# (meme BitsAndBytesConfig), puis prepare_model_for_kbit_training, get_peft_model,\n",
+    "# et relevez print_trainable_parameters() et les trois metriques held-out.\n",
+    "print(\"Exercice a completer : run decoder+vision livre et compare au run decoder-seul\")"
+   ],
+   "execution_count": 14,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : run decoder+vision livre et compare au run decoder-seul\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20e30c25",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 10. Résumé du FT-06\n",
+    "\n",
+    "| Concept | Détail |\n",
+    "|---|---|\n",
+    "| **Modèle vision-langage** | Tour de vision (ViT) + merger + décodeur — chargé via `AutoModelForImageTextToText` (555 M params), préparé via `AutoProcessor` |\n",
+    "| **Tâche bornée** | 12 combinaisons forme × couleur sur images PIL déterministes — 24 train / 6 held-out |\n",
+    "| **Contrat de sortie** | `[IMG] forme=… couleur=… [FIN]` — un comportement de langage, mesurable |\n",
+    "| **Métriques** | `respecte_format` (conformité), `accuracy_forme`, `accuracy_couleur` — même protocole avant/après |\n",
+    "| **LoRA décodeur-seul** | 7,3 M paramètres (0,85 %) sur attention hybride + MLP ; tour de vision et merger gelés |\n",
+    "| **Entraînement QLoRA** | Corps 4-bit NF4, bf16, gradient checkpointing — 308.4 s (5.1 min), loss 1.7677, VRAM ≤ 1452 Mo |\n",
+    "| **Résultat** | Conformité **0.00 → 1.00**, forme **0.00 → 1.00**, couleur **0.00 → 1.00** sur 6 held-out — le base *voyait* déjà (prose correcte) mais ignorait le contrat |\n",
+    "\n",
+    "**Bilan du TP** : le modèle de base décrivait chaque image correctement en prose (« un cercle bleu pur », « un triangle vert simple ») — la défaillance était purement contractuelle, pas perceptuelle. En gelant la vision et en adaptant 0,85 % des paramètres du décodeur, le LoRA a installé le contrat **et** la lecture structurée des traits visuels : 6/6 images jamais vues décrites exactement au format. La leçon architecturale : quand la tâche est un *comportement de langage* conditionné par la perception, adapter le décodeur suffit — la perception pré-entraînée est déjà bonne.\n",
+    "\n",
+    "**Prochaines étapes** : les exercices étendent le contrat (4e forme, champ position) puis testent la frontière de cette conclusion (cibler aussi le merger — l'exercice 3 mesure ce que la vision adaptée ajoute quand elle a déjà tout ce qu'il faut).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "cost": {
+   "api_usd_est": 0.0,
+   "api_provider": "local",
+   "cpu_min": 0,
+   "gpu_min": 20,
+   "gpu_required": true,
+   "vram_gb": 8,
+   "vram_tier": "MID",
+   "network": true,
+   "external_account": "none",
+   "free_alternative": null,
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "metadata_written": "2026-08-23",
+   "validator": "none",
+   "notes": "LoRA/QLoRA vision-langage sur Qwen/Qwen3.5-0.8B (tache image->texte synthetique PIL, 24 train / 6 held-out). Dataset deterministe genere localement ; seul telechargement = poids du modele (HuggingFace). GPU requis : RTX 3070 8 Go verifiee (venv ft03-gpu, transformers 5.15.1, peft 0.20.0, torch 2.13.0+cu126)."
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/FineTuning/README.md
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/README.md
@@ -28,7 +28,8 @@ FineTuning/
 ├── FT-02-QLoRA-Quantization.ipynb        # Quantization 4-bit (NF4) + LoRA
 ├── FT-03-Supervised-FineTuning-SFT.ipynb # Instruction-following, format chat
 ├── FT-04-RLHF-DPO.ipynb                  # Alignement préférences, DPO
-└── FT-05-ModelMerging-Routing.ipynb      # Fusion d'adaptateurs, routage MoE
+├── FT-05-ModelMerging-Routing.ipynb      # Fusion d'adaptateurs, routage MoE
+└── FT-06-Vision-Language-LoRA.ipynb      # LoRA vision-langage, tâche image->texte
 ```
 
 ## Progression pédagogique
@@ -40,6 +41,7 @@ FineTuning/
 | [FT-03](FT-03-Supervised-FineTuning-SFT.ipynb) | Base model vs Instruct model, format ChatML | FT-01 | ~45 min | Intermédiaire |
 | [FT-04](FT-04-RLHF-DPO.ipynb) | Reward Model, RLHF, DPO | FT-01, FT-02, FT-03 | ~30 min | Avancé |
 | [FT-05](FT-05-ModelMerging-Routing.ipynb) | TIES, DARE, MergeKit, routage MoE | FT-01 à FT-04 | ~45 min | Avancé |
+| [FT-06](FT-06-Vision-Language-LoRA.ipynb) | LoRA vision-langage Qwen3.5-0.8B, conformité image->texte | FT-02, FT-03 | ~45 min | Avancé |
 
 ## Technologies couvertes
 
@@ -71,6 +73,7 @@ pip install mergekit  # Pour FT-05 uniquement
 | FT-03 | 8 GB | 16 GB |
 | FT-04 | 12 GB (DPO 2 modèles en mémoire) | 24 GB |
 | FT-05 | 16 GB (merge) | 24 GB |
+| FT-06 | 8 GB (QLoRA 4-bit) | 12 GB |
 
 ## Concepts clés
 


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #12663

See #12654

## Summary

Tranche 2 de #12654 : création de FT-06 — LoRA vision-langage sur Qwen3.5-0.8B, premier notebook vision de la série FineTuning. Tâche image→texte bornée et auto-contenue : formes géométriques colorées synthétiques (PIL, 3 formes x 4 couleurs, 24 images train + 6 held-out), contrat de sortie structuré `[IMG] forme=<...> couleur=<...> [FIN]` — le fil rouge "contrat de format" de la série (FT-03), transposé du texte pur au conditionnement par image.

Comparatif mesuré base vs LoRA-adapté (conformité de format + exactitude par champ forme/couleur), LoRA ciblant le décodeur (attention hybride + MLP, même cible que PT-02/FT-03), tour de vision laissé gelé (le contrat est un comportement de langage — cellule dédiée l'explique, l'extension vision = exercice 3).

## Validation

- Papermill end-to-end kernel `ft03-gpu` (torch 2.13.0+cu126, transformers 5.15.1, peft 0.20.0, torchvision 0.28.0 installé pour `AutoProcessor`) : 37/37 cellules, RC=0.

```
Executing: 100%|██████████| 37/37 [06:14<00:00, 10.11s/cell]
transplant OK: 14/14 code cells executed, 0 errors
scanned=6 notebooks_with_hits=0 occurrences=0
```

- 0 erreur volontaire (C.1), 3 exercices stubbés (`pass`/`print`), densité pédagogique **1692** chars md/cellule code (seuil 1200).
- Ratchet #11725 : filtres warnings cellule 1 (leçon FT-03) + `redirect_stdout` sur `AutoProcessor.from_pretrained` (le docstring-checker qwen3_vl de transformers 5.15 imprime des `[ERROR]` via `print` inconditionnel embarquant le chemin du venv — pas filtrable via `warnings`) → `scan_machine_path_outputs.py --check` = **0 occurrence**.

**Chiffres réels (greedy `do_sample=False`, éval déterministe)** :
- Base (avant LoRA) : conformité **0.00**, accuracy forme **0.00**, couleur **0.00** — mais les extraits bruts montrent que le base *décrit correctement les images en prose* (« un cercle bleu pur », « un triangle vert simple ») : défaillance purement contractuelle, pas perceptuelle.
- LoRA (après, 6 held-out jamais vues) : conformité **1.00**, forme **1.00**, couleur **1.00** — contrat ET lecture structurée installés.
- Entraînement : 7 274 496 params entraînables (0,8456 %), 308,4 s (5,1 min), loss 1,7677, VRAM max 1452 Mo sur RTX 3070 8 Go.
- Thèse decoder-only validée : la tour de vision gelée suffisait (le base voyait déjà) — le LoRA a appris au décodeur à lire les traits dans le format du contrat.

## Scope

2 fichiers :
- `MyIA.AI.Notebooks/GenAI/FineTuning/FT-06-Vision-Language-LoRA.ipynb` (création)
- `MyIA.AI.Notebooks/GenAI/FineTuning/README.md` (ligne FT-06 arbre + tableau)

## Suivi (hors scope, documentés)

- #12654 reste ouverte (tranche 1 = #12663 migration FT-03, cette PR = tranche 2 création FT-06 ; acceptation complète = les deux mergées).
