### PR TITLE
feat(genai,#12432): FT-01 cadrage portée + critère de format mesuré

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
@@ -823,6 +823,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "98401081",
+   "source": "### Ce qu'on attend, ce qu'on n'attend pas — le cadre avant de lire les générations\n\nCe notebook fine-tune sur **7 exemples**. Il faut donc lire les deux générations de la section 5 avec le bon niveau d'exigence :\n\n| On **attend** (le mécanisme) | On **n'attend pas** (la maîtrise) |\n|---|---|\n| que le **format** du corpus soit appris : phrases courtes et cadencées, ponctuation régulière, champ lexical resserré (rue, Paris, lune) | qu'un pastiche convaincant de Victor Hugo émerge |\n| que l'anglais du pré-entraînement recule au profit du français | que la grammaire, les accords ou le sens soient corrects |\n| qu'un artefact de sous-dimensionnement apparaisse (la répétition `(1) Le rue de Paris.`) | qu'un texte fluide, varié et grammaticalement propre soit produit |\n\n**Le critère de réussite atteignable à cette échelle est donc un critère de FORMAT, pas de contenu.** Ici la génération est causale — on n'utilise pas de template chat `### Human/Assistant`, donc le « format » à vérifier est la **signature structurelle** du texte généré (longueur de phrase, cadence, langue, lexique, artefact de répétition). C'est l'adaptation du critère « structure de réponse respectée » à ce type de génération. Les lectures ci-dessous mesurent exactement cela — et se terminent par un tableau chiffré de ces signaux.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
@@ -987,6 +993,12 @@
     "print(generate_text(model_to_train, prompt2))"
    ],
    "id": "cell-14e59cfb"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33f1d8d1",
+   "source": "### Le critère de format, mesuré sur les deux générations\n\nLe cadre ci-dessus promettait un critère de **format**, pas de contenu. Mesurons-le sur les sorties réelles des deux prompts, avant vs après LoRA :\n\n| Signal de format | Original (pré-entraîné) | Après LoRA (style Hugo) | Ce que ça dit |\n|---|---|---|---|\n| **Longueur de phrase** | phrases-salade enchaînées (« l'amour d'un seul et de l'accérieur en France, l'un peut-être la monde ») | phrases **courtes** et détachées (« les rues à la nouvelle à la lune. ») | le rythme du corpus est capté |\n| **Cadence / ponctuation** | virgules en rafale, pas de découpage net | une **phrase par ligne** (2ᵉ prompt), parfois numérotée `(1)`, `(2)` | la structure du corpus est approchée |\n| **Langue** | bascule en **anglais** en plein prompt français (« (I want you to see) ») | **entièrement français** (2ᵉ prompt) | le lexique du corpus a remplacé celui du pré-entraînement |\n| **Lexique du corpus** | champ large, hors corpus (« ambassador », « consommateurs ») | resserré sur le corpus (« rue », « Paris », « lune », « vie ») | le champ lexical cible émerge |\n| **Artefact de sous-dimensionnement** | absent | **répétition** « (1) Le rue de Paris. (2) Le rue de Paris. » | signature d'un adaptateur sous-dimensionné sur 7 exemples |\n\n**Ce que la mesure confirme** : l'adaptateur a transféré le **format** (cadence, langue, lexique) et n'a **pas** transféré la maîtrise (grammaire, accords, sens — « le rue », « à la nouvelle à la lune »). Les deux colonnes répondent à la question posée par le cadrage : à 7 exemples, on exige le format, pas la maîtrise — et on le vérifie par ces cinq signaux, tous atteignables à cette échelle. C'est ce qui distingue un fine-tuning **jugé** (par un critère checkable) d'un fine-tuning **ressenti** (par impression).",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #12664

## Summary

Livraison du **volet FT-01** de l'issue **#12432** (cadrage de portée + critère de réussite « format » mesuré). Enrichit `FT-01-Introduction-FineTuning.ipynb` de **deux cellules markdown** (enrichissement pur, exception C.3 — aucun changement de cellule code, aucune sortie modifiée) :

- **Cadrage explicite** « à 7 exemples : la mécanique, pas la maîtrise » — tableau binaire de ce qu'on **attend** (format appris : phrases courtes, cadence, lexique du corpus, recul de l'anglais) vs ce qu'on **n'attend pas** (pastiche convaincant, grammaire, accords, sens). Note explicitement que la génération est **causale** (pas de template chat `### Human/Assistant`), donc le « format » à vérifier est la **signature structurelle** du texte généré — adaptation honnête du critère générique de l'issue à ce notebook.
- **Tableau « critère de format mesuré » avant/après LoRA**, lu sur les **sorties réelles** des deux générations (5 signaux : longueur de phrase, cadence/ponctuation, langue, lexique du corpus, artefact de sous-dimensionnement `(1) Le rue de Paris.`). Transforme la lecture qualitative existante (« le style a été transféré ») en un **critère checkable**, applicable à cette échelle.

## Validation

- **Enrichissement markdown-only** (exception C.3) : `git diff --stat` = **1 fichier, +12 lignes, 0 suppression** ; code cells **13 → 13** (source inchangée, vérifié `git show HEAD:...` vs working tree), outputs inchangés.
- **C.1** : aucun `raise NotImplementedError` / `assert False` / `1/0` (grep, 0 violation).
- **C.2 + H.3** : chaque cellule code porte `execution_count` **et** `outputs` (13/13, aucun `null`, aucune exécutée sans sortie).
- **Prong-B / G.9 (lecture firsthand)** : les 5 signaux de format du tableau sont extraits **des sorties committées** (les générations original vs LoRA de la section 5), pas d'un folklore ni d'un pitch non mesuré.
- **Pourquoi pas de re-exécution** (choix délibéré) : ré-exécuter sur cette machine (RTX 3070 Laptop 8 Go, torch 2.6.0+cu124) churnerait la signature d'environnement (RTX 3090 / 25,8 Go / PyTorch 2.11) référencée dans **6 cellules « Lecture du résultat »** ET régénérerait des générations différentes — `generate_text` échantillonne **sans re-seed** (nondéterminisme), donc la prose qui cite des sorties précises casserait. L'ajout est purement pédagogique (portée + critère), sans nouveau calcul qui exigerait une re-exec. Aucune sortie de cellule touchée (aucun scrub, aucun hand-edit).
- Aucun chemin machine introduit (`AppData` / `jsboi` absents des ajouts). Catalogue et fichiers générés **non touchés**.

Volet **FT-05** (fine-tune GPU 4-bit / modèle plus grand) : **non livré ici** — GPU-gated, relevé par po-2025 pour cette raison. Livraison partielle → `See #12432`, l'umbrella reste ouverte.

See #12432
