### PR TITLE
fix(tooling,#12617): preserve twin audit indentation

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -918,17 +918,36 @@ def _legacy_body_as_list_item(body_lines):
     return out
 
 
-def _render_new_audit_entry(entry: dict) -> list[str]:
-    """Rendre une NOUVELLE entree (sortie d'`update_pair`) en item de liste `audits:`."""
+def _render_new_audit_entry(entry: dict, item_indent: str = "    ") -> list[str]:
+    """Rendre une nouvelle entree en preservant la marge de la liste `audits:`."""
     lines = []
     keys = [k for k in _AUDIT_KEYS if entry.get(k) is not None]
+    field_indent = f"{item_indent}  "
     for idx, key in enumerate(keys):
         val = _fmt_audit_value(key, entry[key])
         if idx == 0:
-            lines.append(f"    - {key}: {val}\n")
+            lines.append(f"{item_indent}- {key}: {val}\n")
         else:
-            lines.append(f"      {key}: {val}\n")
+            lines.append(f"{field_indent}{key}: {val}\n")
     return lines
+
+
+def _audit_item_indent(block: list[str]) -> str:
+    """Detecte la marge des items existants, ou derive le style par defaut.
+
+    YAML autorise une sequence indentationless : l'item peut etre au meme niveau
+    que la cle ``audits:``. D'autres registres utilisent une marge de deux espaces
+    supplementaires. Melanger les deux styles dans un meme bloc rend le YAML
+    invalide ; l'append doit donc suivre le premier item existant.
+    """
+    for line in block[1:]:
+        match = re.match(r"^(\s*)-\s+", line)
+        if match:
+            return match.group(1)
+
+    header = re.match(r"^(\s*)audits:\s*$", block[0])
+    header_indent = header.group(1) if header else "  "
+    return f"{header_indent}  "
 
 
 def _transform_audit_block(form: str, block: list[str], new_entry: dict, force: bool = False) -> tuple[list[str], bool]:
@@ -955,7 +974,8 @@ def _transform_audit_block(form: str, block: list[str], new_entry: dict, force: 
             return block, False
         # force=True OU SHAs differents : APPEND une nouvelle entree
         # (avec --force c'est le faux audit designe par ai-01 -- averti sur stderr).
-        return block + _render_new_audit_entry(new_entry), True
+        item_indent = _audit_item_indent(block)
+        return block + _render_new_audit_entry(new_entry, item_indent), True
 
     # form == "last_audit" -> migration vers la forme append-only
     old_pairs = _parse_flat_audit(body)

--- a/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
@@ -537,6 +537,49 @@ def test_indent2_regression_normal_style_still_works():
     assert "sibling indent-2" in out
 
 
+def test_append_preserves_indentationless_audit_items_12617():
+    """Un item au meme niveau que ``audits:`` impose la meme marge a l'append.
+
+    L'ancien rendu ajoutait quatre espaces absolus et melangeait deux styles de
+    sequence dans ce bloc indent-4, ce qui produisait un YAML non parsable.
+    """
+    import yaml
+
+    new = {"date": "2026-08-23", "by": "test-lane",
+           "python_sha": "c" * 40, "csharp_sha": "b" * 40}
+    out, touched = ctp.surgical_rebaseline(_INDENT4_RAW, {"Indent4Pair": new})
+
+    assert touched == 1
+    entry = yaml.safe_load(out)[0]
+    assert len(entry["audits"]) == 2
+    assert entry["audits"][1]["python_sha"] == "c" * 40
+    assert "\n    - date: \"2026-08-23\"\n" in out
+    assert "\n      date: \"2026-08-23\"\n" not in out
+
+
+def test_append_preserves_indented_audit_items_12617():
+    """Le style usuel item-indent = header-indent + 2 reste byte-coherent."""
+    import yaml
+
+    raw = (
+        "- name: IndentedPair\n"
+        "  audits:\n"
+        "    - date: '2020-01-01'\n"
+        "      by: old-auditor\n"
+        "      python_sha: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "      csharp_sha: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+    )
+    new = {"date": "2026-08-23", "by": "test-lane",
+           "python_sha": "c" * 40, "csharp_sha": "b" * 40}
+    out, touched = ctp.surgical_rebaseline(raw, {"IndentedPair": new})
+
+    assert touched == 1
+    entry = yaml.safe_load(out)[0]
+    assert len(entry["audits"]) == 2
+    assert entry["audits"][1]["python_sha"] == "c" * 40
+    assert "\n    - date: \"2026-08-23\"\n" in out
+
+
 def test_touched_zero_when_header_genuinely_absent():
     """Contrat dont depend la garde loud-failure (#10430) du chemin multi-fichiers.
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: MED/notebook-python #12627

## Résumé

- détecte la marge du premier item existant dans chaque bloc `audits:` avant d'ajouter un audit ;
- préserve aussi bien les séquences YAML indentationless que le style usuel avec deux espaces supplémentaires ;
- conserve le style usuel comme défaut pour un bloc vide ;
- ajoute deux tests de falsification qui parsèment le YAML produit et vérifient la marge textuelle.

## Cause corrigée

`_render_new_audit_entry` imposait quatre espaces absolus. Sur les registres où `audits:` et ses items ont la même marge, l'append mélangeait deux styles dans une même séquence et rendait le YAML invalide.

Le correctif dérive désormais la marge depuis le premier item existant. Il ne re-sérialise pas le registre et ne modifie donc ni les commentaires ni les audits antérieurs.

## Validation

```text
python -m pytest \
  scripts/notebook_tools/tests/test_check_twin_parity_bridge_verdict.py \
  scripts/notebook_tools/tests/test_check_twin_parity_surgical.py \
  scripts/notebook_tools/tests/test_check_twin_parity_update_guard.py \
  scripts/notebook_tools/tests/test_twin_registry_integrity.py -q
67 passed in 38.43s
```

```text
python -m py_compile scripts/notebook_tools/check_twin_parity.py \
  scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
SUCCESS
```

Reproduction sur le registre réel `csp-7-soft.yaml`, en mémoire uniquement :

```text
name=CSP-7 Soft touched=1 audits=5
last_by=test-lane
```

Le résultat de `surgical_rebaseline(..., force=True)` est accepté par `yaml.safe_load` ; aucun registre n'a été modifié par cette reproduction.

`git diff --check` : SUCCESS.

Closes #12617

Co-Authored-By: Claude-Code <noreply@anthropic.com>
