### PR TITLE
fix(notebooks,#12368): heading_in_list + yaml separator — GenAI/CaseStudies receipe_maker

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
@@ -77,7 +77,7 @@
     "- `RecipeGenerator` → Crée la recette via LLM  \n",
     "- `PDFGenerator` → Génère le document final\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -226,9 +226,9 @@
     "**Objectif** : etendre `RecipeState` avec ces nouveaux attributs et créer les méthodes de mise a jour correspondantes.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Ajouter les attributs `difficulty`, `max_prep_time` et `cuisine_type` dans `__init__`\n",
-    "- # Étape 2 : Créer les méthodes `set_difficulty`, `set_max_prep_time` et `set_cuisine`\n",
-    "- # Indice : suivre le pattern existant des autres attributs (type hints + valeur par defaut)"
+    "- `# Étape 1` : Ajouter les attributs `difficulty`, `max_prep_time` et `cuisine_type` dans `__init__`\n",
+    "- `# Étape 2` : Créer les méthodes `set_difficulty`, `set_max_prep_time` et `set_cuisine`\n",
+    "- `# Indice` : suivre le pattern existant des autres attributs (type hints + valeur par defaut)"
    ]
   },
   {
@@ -407,9 +407,9 @@
     "**Objectif** : créer une classe `NutritionPlugin` avec une méthode `estimate_nutrition` annotee `@kernel_function` qui retourne une estimation des calories par portion.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir un dictionnaire approximatif de calories par ingredient de base\n",
-    "- # Étape 2 : Calculer la somme des calories et diviser par le nombre de convives\n",
-    "- # Indice : le dictionnaire peut contenir des valeurs moyennes (ex: poulet = 165 kcal/100g, riz = 130 kcal/100g)"
+    "- `# Étape 1` : Définir un dictionnaire approximatif de calories par ingredient de base\n",
+    "- `# Étape 2` : Calculer la somme des calories et diviser par le nombre de convives\n",
+    "- `# Indice` : le dictionnaire peut contenir des valeurs moyennes (ex: poulet = 165 kcal/100g, riz = 130 kcal/100g)"
    ]
   },
   {
@@ -829,9 +829,9 @@
     "**Objectif** : ecrire une fonction qui detecte les incoherences (par exemple : regime vegane + demande de fromage, nombre de convives negatif, ingredients exclus qui font partie du regime).\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir les règles de validation (liste de conditions a verifier)\n",
-    "- # Étape 2 : Retourner un tuple `(est_valide, liste_erreurs)` pour guider l'utilisateur\n",
-    "- # Indice : utiliser des conditions if/elif pour chaque règle et accumuler les messages d'erreur"
+    "- `# Étape 1` : Définir les règles de validation (liste de conditions a verifier)\n",
+    "- `# Étape 2` : Retourner un tuple `(est_valide, liste_erreurs)` pour guider l'utilisateur\n",
+    "- `# Indice` : utiliser des conditions if/elif pour chaque règle et accumuler les messages d'erreur"
    ]
   },
   {
@@ -1067,8 +1067,8 @@
    "end_time": "2026-08-17T03:47:12.932202",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:/Dev/CoursIA-11112-cs/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb",
-   "output_path": "D:/Dev/CoursIA-11112-cs/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb",
+   "input_path": "receipe_maker.ipynb",
+   "output_path": "receipe_maker.ipynb",
    "parameters": {
     "BATCH_MODE": true
    },


### PR DESCRIPTION
Grain: LIGHT/notebook-python -- lane myia-po-2023:CoursIA-2 -- prev: MED/guard #12547

## Summary

Tranche famille `GenAI/CaseStudies` du rollout #12368 (heading_in_list + yaml_block_open_no_close) : un notebook réparé — `GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb`.

Deux défauts de rendu markdown, un seul commit :

1. **heading_in_list** : 9 commentaires d'exercice (`# Étape 1/2`, `# Indice`) recopiés sous une puce dans des cellules markdown → titres ATX dans la liste (la plus grosse police de la page au rendu GitHub). Corrigé en entourant le marqueur de backticks : `- \`# Étape 1\` : ...` (forme saine du corpus).
2. **yaml_block_open_no_close** : un séparateur `---` orphelin en tête de cellule markdown → bloc YAML jamais refermé (casse `quarto render`). Corrigé par `fix_hr_separator.py`.

Processus : `fix_hint_headings.py --apply` puis `fix_hr_separator.py --apply` sur le notebook ENTIER (les deux passes, dans cet ordre, comme prescrit par #12368), puis normalisation LF (le script réécrit en CRLF).

## Preuves (post-fix)

- `fix_hint_headings.py --scan` : 9 occ → `detect_markdown_rendering.py` : **0 violation** (du 9 → 0).
- `check_papermill_ratchet.py origin/main` : **`OUTPUTS_UNCHANGED`, 0 régression** (modif markdown-only, outputs intacts).
- `validate_pr_notebooks.py origin/main <notebook>` : **1/1 PASS, 12 cellules code** (H.1/H.3/C.1).
- Pré-commit **8/8 Passed** (gitleaks, strip-probe, strip-machine, scrub-papermill, yaml-block auto-fix, oversized-md block, source-list auto-fix, H.3).
- `detect_markdown_rendering.py --selfcheck` OK.
- 1 fichier, +13/−13.

See #12368 (contribution partielle à l'umbrella rollout ; les autres familles restent ouvertes).
