### PR TITLE
fix(notebooks): normaliser le rendu markdown TorchLean

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-11-TorchLean-Python.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-11-TorchLean-Python.ipynb
@@ -48,7 +48,7 @@
     "8. [Exercices](#8-exercices)\n",
     "9. [Conclusion](#9-conclusion)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"1-introduction\"></a>\n",
     "## 1. Introduction : Le Semantic Gap\n",
@@ -128,7 +128,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"2-configuration\"></a>\n",
     "## 2. Prérequis et Configuration\n",
@@ -552,7 +552,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"3-ibp\"></a>\n",
     "## 3. Interval Bound Propagation (IBP)\n",
@@ -1526,7 +1526,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"4-robustness\"></a>\n",
     "## 4. Vérification de Robustesse\n",
@@ -1982,7 +1982,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"5-crown\"></a>\n",
     "## 5. CROWN Simplifié\n",
@@ -2268,10 +2268,10 @@
     "3. Testez sur les 3 intervalles de reference : `[-3, -1]`, `[1, 3]`, `[-1, 2]`.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Sigmoid est strictement croissante. Pour une fonction monotone croissante f, f([a, b]) = [f(a), f(b)].\n",
-    "- # Indice 2 : Utilisez `scipy.special.expit` ou implementez manuellement avec `1 / (1 + math.exp(-x))`.\n",
-    "- # Étape 1 : Calculer sigmoid(lower) et sigmoid(upper)\n",
-    "- # Étape 2 : Retourner Interval(sigmoid(lower), sigmoid(upper))"
+    "- `# Indice 1` : Sigmoid est strictement croissante. Pour une fonction monotone croissante f, f([a, b]) = [f(a), f(b)].\n",
+    "- `# Indice 2` : Utilisez `scipy.special.expit` ou implementez manuellement avec `1 / (1 + math.exp(-x))`.\n",
+    "- `# Étape 1` : Calculer sigmoid(lower) et sigmoid(upper)\n",
+    "- `# Étape 2` : Retourner Interval(sigmoid(lower), sigmoid(upper))"
    ]
   },
   {
@@ -2368,7 +2368,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"6-applications\"></a>\n",
     "## 6. Applications Pratiques\n",
@@ -2627,7 +2627,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"7-torchlean\"></a>\n",
     "## 7. Lien avec TorchLean/Formalisation\n",
@@ -2688,7 +2688,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"8-exercices\"></a>\n",
     "## 8. Exercices\n",
@@ -3089,7 +3089,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"9-conclusion\"></a>\n",
     "## 9. Conclusion\n",
@@ -3141,7 +3141,7 @@
     "3. Explorer LiRPA pour des bornes encore plus serrées\n",
     "4. Contribuer au projet TorchLean\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [Index](README.md) | [<< Précédent](Lean-10-LeanDojo.ipynb) | [TorchLean Lean](Lean-11-TorchLean.ipynb) | [Lean-12 Sensitivity >>](Lean-12-Sensitivity-Theorem.ipynb)\n",
     "\n",


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2025:CoursIA — prev: MED/readme #12677

## Résumé

- corrige les 4 listes `- # Indice` / `- # Étape` qui devenaient des titres H1 imbriqués dans une puce dans `Lean-11-TorchLean-Python.ipynb`
- applique la seconde passe obligatoire sur le notebook entier : 10 séparateurs markdown `---` deviennent `***`, évitant leur interprétation comme ouverture YAML ou titre setext
- préserve intégralement les cellules code, outputs, compteurs d'exécution et métadonnées

## Validation

- `fix_hint_headings.py --scan` : 0 occurrence restante
- `fix_hr_separator.py --check` : 0 séparateur restant à convertir
- `detect_markdown_rendering.py --check --baseline scripts/notebook_tools/markdown_rendering_baseline.json` : `OK: no new ERROR-level markdown-rendering violations`
- contrôle positif tracké : injection temporaire de `---` + `title:` dans la cellule 0 du notebook suivi ; le détecteur a échoué en nommant `yaml_block_open_no_close`, puis le fichier a été restauré
- comparaison JSON avant/après : 10 cellules markdown modifiées ; 0 cellule code, 0 output, 0 `execution_count`, 0 metadata modifiés
- `git diff --check` : succès

Modification markdown-only : aucune ré-exécution due selon C.3.

See #12368
