### PR TITLE
feat(gametheory,#12679): GT-20 le témoin de retenue — dual du témoin d'obstruction

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-20-Commitment-Stackelberg.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-20-Commitment-Stackelberg.ipynb
@@ -5,10 +5,10 @@
    "id": "gt20c00",
    "metadata": {
     "papermill": {
-     "duration": 0.003042,
-     "end_time": "2026-08-22T10:05:48.473491+00:00",
+     "duration": 0.003008,
+     "end_time": "2026-08-23T22:17:28.670267",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.470449+00:00",
+     "start_time": "2026-08-23T22:17:28.667259",
      "status": "completed"
     },
     "tags": []
@@ -41,16 +41,16 @@
    "id": "gt20c01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T10:05:48.478733Z",
-     "iopub.status.busy": "2026-08-22T10:05:48.478514Z",
-     "iopub.status.idle": "2026-08-22T10:05:48.485252Z",
-     "shell.execute_reply": "2026-08-22T10:05:48.484325Z"
+     "iopub.execute_input": "2026-08-23T22:17:28.675838Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.675562Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.684425Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.683824Z"
     },
     "papermill": {
-     "duration": 0.010319,
-     "end_time": "2026-08-22T10:05:48.485807+00:00",
+     "duration": 0.012806,
+     "end_time": "2026-08-23T22:17:28.685469",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.475488+00:00",
+     "start_time": "2026-08-23T22:17:28.672663",
      "status": "completed"
     },
     "tags": []
@@ -112,10 +112,10 @@
    "id": "gt20c02",
    "metadata": {
     "papermill": {
-     "duration": 0.001773,
-     "end_time": "2026-08-22T10:05:48.489349+00:00",
+     "duration": 0.002614,
+     "end_time": "2026-08-23T22:17:28.691132",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.487576+00:00",
+     "start_time": "2026-08-23T22:17:28.688518",
      "status": "completed"
     },
     "tags": []
@@ -134,16 +134,16 @@
    "id": "gt20c03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T10:05:48.493522Z",
-     "iopub.status.busy": "2026-08-22T10:05:48.493379Z",
-     "iopub.status.idle": "2026-08-22T10:05:48.497486Z",
-     "shell.execute_reply": "2026-08-22T10:05:48.496905Z"
+     "iopub.execute_input": "2026-08-23T22:17:28.698641Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.698386Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.703264Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.702577Z"
     },
     "papermill": {
-     "duration": 0.007327,
-     "end_time": "2026-08-22T10:05:48.498320+00:00",
+     "duration": 0.009042,
+     "end_time": "2026-08-23T22:17:28.704248",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.490993+00:00",
+     "start_time": "2026-08-23T22:17:28.695206",
      "status": "completed"
     },
     "tags": []
@@ -187,10 +187,10 @@
    "id": "gt20c04",
    "metadata": {
     "papermill": {
-     "duration": 0.001712,
-     "end_time": "2026-08-22T10:05:48.501712+00:00",
+     "duration": 0.002491,
+     "end_time": "2026-08-23T22:17:28.709282",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.500000+00:00",
+     "start_time": "2026-08-23T22:17:28.706791",
      "status": "completed"
     },
     "tags": []
@@ -209,16 +209,16 @@
    "id": "gt20c05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T10:05:48.505744Z",
-     "iopub.status.busy": "2026-08-22T10:05:48.505608Z",
-     "iopub.status.idle": "2026-08-22T10:05:48.510354Z",
-     "shell.execute_reply": "2026-08-22T10:05:48.509468Z"
+     "iopub.execute_input": "2026-08-23T22:17:28.716168Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.715858Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.721285Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.720688Z"
     },
     "papermill": {
-     "duration": 0.008099,
-     "end_time": "2026-08-22T10:05:48.511414+00:00",
+     "duration": 0.010573,
+     "end_time": "2026-08-23T22:17:28.722482",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.503315+00:00",
+     "start_time": "2026-08-23T22:17:28.711909",
      "status": "completed"
     },
     "tags": []
@@ -292,10 +292,10 @@
    "id": "gt20c06",
    "metadata": {
     "papermill": {
-     "duration": 0.001832,
-     "end_time": "2026-08-22T10:05:48.515276+00:00",
+     "duration": 0.002293,
+     "end_time": "2026-08-23T22:17:28.730014",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.513444+00:00",
+     "start_time": "2026-08-23T22:17:28.727721",
      "status": "completed"
     },
     "tags": []
@@ -322,10 +322,10 @@
    "id": "gt20c07",
    "metadata": {
     "papermill": {
-     "duration": 0.001751,
-     "end_time": "2026-08-22T10:05:48.518829+00:00",
+     "duration": 0.002252,
+     "end_time": "2026-08-23T22:17:28.734771",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.517078+00:00",
+     "start_time": "2026-08-23T22:17:28.732519",
      "status": "completed"
     },
     "tags": []
@@ -353,16 +353,16 @@
    "id": "gt20c08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T10:05:48.523426Z",
-     "iopub.status.busy": "2026-08-22T10:05:48.523243Z",
-     "iopub.status.idle": "2026-08-22T10:05:48.526467Z",
-     "shell.execute_reply": "2026-08-22T10:05:48.525446Z"
+     "iopub.execute_input": "2026-08-23T22:17:28.740283Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.740046Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.743115Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.742570Z"
     },
     "papermill": {
-     "duration": 0.006464,
-     "end_time": "2026-08-22T10:05:48.527108+00:00",
+     "duration": 0.006887,
+     "end_time": "2026-08-23T22:17:28.743936",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.520644+00:00",
+     "start_time": "2026-08-23T22:17:28.737049",
      "status": "completed"
     },
     "tags": []
@@ -393,16 +393,16 @@
    "id": "gt20c09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T10:05:48.531847Z",
-     "iopub.status.busy": "2026-08-22T10:05:48.531693Z",
-     "iopub.status.idle": "2026-08-22T10:05:48.536501Z",
-     "shell.execute_reply": "2026-08-22T10:05:48.535587Z"
+     "iopub.execute_input": "2026-08-23T22:17:28.750079Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.749644Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.754784Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.754036Z"
     },
     "papermill": {
-     "duration": 0.008053,
-     "end_time": "2026-08-22T10:05:48.537124+00:00",
+     "duration": 0.00926,
+     "end_time": "2026-08-23T22:17:28.755760",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.529071+00:00",
+     "start_time": "2026-08-23T22:17:28.746500",
      "status": "completed"
     },
     "tags": []
@@ -450,10 +450,10 @@
    "id": "gt20c10",
    "metadata": {
     "papermill": {
-     "duration": 0.002021,
-     "end_time": "2026-08-22T10:05:48.541107+00:00",
+     "duration": 0.002547,
+     "end_time": "2026-08-23T22:17:28.761661",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.539086+00:00",
+     "start_time": "2026-08-23T22:17:28.759114",
      "status": "completed"
     },
     "tags": []
@@ -472,16 +472,16 @@
    "id": "gt20c11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T10:05:48.545867Z",
-     "iopub.status.busy": "2026-08-22T10:05:48.545690Z",
-     "iopub.status.idle": "2026-08-22T10:05:48.550475Z",
-     "shell.execute_reply": "2026-08-22T10:05:48.549544Z"
+     "iopub.execute_input": "2026-08-23T22:17:28.768355Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.768022Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.772702Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.772228Z"
     },
     "papermill": {
-     "duration": 0.00802,
-     "end_time": "2026-08-22T10:05:48.551018+00:00",
+     "duration": 0.009255,
+     "end_time": "2026-08-23T22:17:28.773457",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.542998+00:00",
+     "start_time": "2026-08-23T22:17:28.764202",
      "status": "completed"
     },
     "tags": []
@@ -540,10 +540,10 @@
    "id": "gt20c12",
    "metadata": {
     "papermill": {
-     "duration": 0.001881,
-     "end_time": "2026-08-22T10:05:48.554899+00:00",
+     "duration": 0.002649,
+     "end_time": "2026-08-23T22:17:28.778774",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.553018+00:00",
+     "start_time": "2026-08-23T22:17:28.776125",
      "status": "completed"
     },
     "tags": []
@@ -561,10 +561,10 @@
    "id": "gt20c13",
    "metadata": {
     "papermill": {
-     "duration": 0.00189,
-     "end_time": "2026-08-22T10:05:48.558734+00:00",
+     "duration": 0.002444,
+     "end_time": "2026-08-23T22:17:28.783577",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.556844+00:00",
+     "start_time": "2026-08-23T22:17:28.781133",
      "status": "completed"
     },
     "tags": []
@@ -590,16 +590,16 @@
    "id": "gt20c14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T10:05:48.563460Z",
-     "iopub.status.busy": "2026-08-22T10:05:48.563295Z",
-     "iopub.status.idle": "2026-08-22T10:05:48.566610Z",
-     "shell.execute_reply": "2026-08-22T10:05:48.565641Z"
+     "iopub.execute_input": "2026-08-23T22:17:28.789650Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.789305Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.792782Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.792286Z"
     },
     "papermill": {
-     "duration": 0.006892,
-     "end_time": "2026-08-22T10:05:48.567492+00:00",
+     "duration": 0.007523,
+     "end_time": "2026-08-23T22:17:28.793526",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.560600+00:00",
+     "start_time": "2026-08-23T22:17:28.786003",
      "status": "completed"
     },
     "tags": []
@@ -628,10 +628,10 @@
    "id": "gt20c15",
    "metadata": {
     "papermill": {
-     "duration": 0.002081,
-     "end_time": "2026-08-22T10:05:48.571646+00:00",
+     "duration": 0.002822,
+     "end_time": "2026-08-23T22:17:28.798847",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.569565+00:00",
+     "start_time": "2026-08-23T22:17:28.796025",
      "status": "completed"
     },
     "tags": []
@@ -657,16 +657,16 @@
    "id": "gt20c16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T10:05:48.576670Z",
-     "iopub.status.busy": "2026-08-22T10:05:48.576521Z",
-     "iopub.status.idle": "2026-08-22T10:05:48.579705Z",
-     "shell.execute_reply": "2026-08-22T10:05:48.578825Z"
+     "iopub.execute_input": "2026-08-23T22:17:28.804330Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.804132Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.807118Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.806550Z"
     },
     "papermill": {
-     "duration": 0.00637,
-     "end_time": "2026-08-22T10:05:48.580179+00:00",
+     "duration": 0.006731,
+     "end_time": "2026-08-23T22:17:28.807962",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.573809+00:00",
+     "start_time": "2026-08-23T22:17:28.801231",
      "status": "completed"
     },
     "tags": []
@@ -692,13 +692,336 @@
   },
   {
    "cell_type": "markdown",
+   "id": "658e805b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002727,
+     "end_time": "2026-08-23T22:17:28.813282",
+     "exception": false,
+     "start_time": "2026-08-23T22:17:28.810555",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Le témoin de retenue : le dual du témoin d'obstruction\n",
+    "\n",
+    "Les régimes précédents définissent l'agence par ce qu'un joueur **peut** faire : s'engager,\n",
+    "annoncer, cautionner. Il manque le revers, et c'est lui qui porte la substance — **un coup\n",
+    "strictement profitable est disponible, et le joueur ne le joue pas** :\n",
+    "\n",
+    "```\n",
+    "pouvoir disponible  ≠  pouvoir exercé\n",
+    "```\n",
+    "\n",
+    "Le piège : une abstention observée admet **trois causes indiscernables sur la seule trajectoire** —\n",
+    "la retenue (l'objet cherché), un barème erroné (la déviation *croyait-on* profitable), l'incapacité\n",
+    "(l'action n'était pas atteignable). Un détecteur qui ne sépare pas les trois certifie de la retenue\n",
+    "partout où il y a une erreur de modèle. Le témoin ne vaut donc que s'il produit d'abord le\n",
+    "**certificat de disponibilité** : le coup énuméré dans l'ensemble d'actions ET strictement\n",
+    "améliorant au barème courant — *calculé et affiché* — avant de constater qu'il n'a pas été joué.\n",
+    "\n",
+    "Le dispositif : le duopole accommodant de la section 1, répété. En coopération accommodante,\n",
+    "l'entrant tenté par un coup de guerre de prix éphémère (un « hit-and-run ») doit être distingué\n",
+    "d'un entrant qui s'y **abstient** alors que le coup était disponible et profitable. Le verdict se\n",
+    "lit **depuis la trajectoire** — l'historique des actions — jamais depuis une utilité déclarée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0829dd3e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T22:17:28.819341Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.819137Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.823892Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.823300Z"
+    },
+    "papermill": {
+     "duration": 0.008725,
+     "end_time": "2026-08-23T22:17:28.824582",
+     "exception": false,
+     "start_time": "2026-08-23T22:17:28.815857",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Certificat de disponibilite du coup 'Raider' pour l'entrant :\n",
+      "  1. ENUMERATION : 'Raider' figure dans l'ensemble d'actions atteignables = [('In', 'Acc'), ('Raider', 'Acc'), ('Out', 'Acc')]\n",
+      "  2. GAIN STRICT : raider une periode rapporte 5 > cooperer 2 (delta immediat = +3)\n",
+      "  3. La deviation est donc DISPONIBLE et STRICTEMENT PROFITABLE au bareme courant.\n",
+      "\n",
+      "Le certificat pose, l'experience peut commencer : que fait l'entrant ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section retenue A : le certificat de disponibilite — le coup hit-and-run ===\n",
+    "\n",
+    "# Le duopole accommode : (In, Acc) chaque periode -> (2, 1) par periode.\n",
+    "# L'entrant possede une action supplementaire, ephemere : 'Raider' (guerre de prix UNE periode,\n",
+    "# puis le marche se ferme a jamais pour lui). Convention : (u_entrant, u_incumbent).\n",
+    "GAINS_DUOPOLE = {('In', 'Acc'): (2, 1), ('Raider', 'Acc'): (5, -3), ('Out', 'Acc'): (0, 0)}\n",
+    "HORIZON = 10  # periodes de duopole accommodant\n",
+    "\n",
+    "def gain_entrant(histoire):\n",
+    "    \"\"\"Gain total de l'entrant LU DEPUIS LA TRAJECTOIRE (suite d'actions, pas d'utilites).\"\"\"\n",
+    "    total = 0\n",
+    "    for ae, ai in histoire:\n",
+    "        total += GAINS_DUOPOLE[(ae, ai)][0]\n",
+    "    return total\n",
+    "\n",
+    "def actions_atteignables():\n",
+    "    return list(GAINS_DUOPOLE.keys())\n",
+    "\n",
+    "# --- Le certificat de disponibilite, calcule et affiche ---\n",
+    "actions = actions_atteignables()\n",
+    "coup_raider = ('Raider', 'Acc')\n",
+    "gain_raider_1p = GAINS_DUOPOLE[coup_raider][0]\n",
+    "gain_in_1p = GAINS_DUOPOLE[('In', 'Acc')][0]\n",
+    "\n",
+    "print(\"Certificat de disponibilite du coup 'Raider' pour l'entrant :\")\n",
+    "print(f\"  1. ENUMERATION : 'Raider' figure dans l'ensemble d'actions atteignables = {actions}\")\n",
+    "print(f\"  2. GAIN STRICT : raider une periode rapporte {gain_raider_1p} > cooperer {gain_in_1p}\"\n",
+    "      f\" (delta immediat = +{gain_raider_1p - gain_in_1p})\")\n",
+    "print(f\"  3. La deviation est donc DISPONIBLE et STRICTEMENT PROFITABLE au bareme courant.\")\n",
+    "print()\n",
+    "print(\"Le certificat pose, l'experience peut commencer : que fait l'entrant ?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f97a5c1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004037,
+     "end_time": "2026-08-23T22:17:28.831141",
+     "exception": false,
+     "start_time": "2026-08-23T22:17:28.827104",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : le certificat tient en deux lignes vérifiables — l'action\n",
+    "est dans l'ensemble énuméré, et son gain immédiat (5 > 2) est **calculé au barème courant**,\n",
+    "pas déclaré. Sans ces deux lignes, tout ce qui suit ne prouverait rien : une abstention sans\n",
+    "certificat de disponibilité peut être de l'incapacité déguisée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "de4eca85",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T22:17:28.840442Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.839984Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.845369Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.844717Z"
+    },
+    "papermill": {
+     "duration": 0.010434,
+     "end_time": "2026-08-23T22:17:28.846402",
+     "exception": false,
+     "start_time": "2026-08-23T22:17:28.835968",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "trajectoire EXPLOIT    : raider observe dans la trajectoire = True\n",
+      "                         gain total de l'entrant (lu, non declare) = 9\n",
+      "                         actions distinctes jouees = ['In', 'Out', 'Raider']\n",
+      "trajectoire RETENUE    : raider observe dans la trajectoire = False\n",
+      "                         gain total de l'entrant (lu, non declare) = 20\n",
+      "                         actions distinctes jouees = ['In']\n",
+      "\n",
+      "Divergence des deux histoires : MEME jeu, MEME certificat de disponibilite,\n",
+      "deux pouvoirs exercés différents — la retenue est le second.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section retenue B : deux trajectoires sur le MEME jeu — exploit vs abstention ===\n",
+    "\n",
+    "def trajectoire_exploit():\n",
+    "    \"\"\"L'entrant raide a la periode 3, puis le marche se ferme pour lui (Out force).\"\"\"\n",
+    "    h = [('In', 'Acc')] * 2 + [('Raider', 'Acc')] + [('Out', 'Acc')] * (HORIZON - 3)\n",
+    "    return h\n",
+    "\n",
+    "def trajectoire_retenue():\n",
+    "    \"\"\"L'entrant NE joue PAS le coup disponible : duopole accommodant sur tout l'horizon.\"\"\"\n",
+    "    h = [('In', 'Acc')] * HORIZON\n",
+    "    return h\n",
+    "\n",
+    "def lire_raider_depuis_trajectoire(h):\n",
+    "    \"\"\"Detecteur : le coup Raider apparaît-il dans l'historique des ACTIONS ?\"\"\"\n",
+    "    return any(ae == 'Raider' for ae, _ in h)\n",
+    "\n",
+    "for nom, h in [(\"trajectoire EXPLOIT\", trajectoire_exploit()),\n",
+    "               (\"trajectoire RETENUE\", trajectoire_retenue())]:\n",
+    "    lu = lire_raider_depuis_trajectoire(h)\n",
+    "    print(f\"{nom:22s} : raider observe dans la trajectoire = {lu}\")\n",
+    "    print(f\"{'':22s}   gain total de l'entrant (lu, non declare) = {gain_entrant(h)}\")\n",
+    "    print(f\"{'':22s}   actions distinctes jouees = {sorted(set(ae for ae, _ in h))}\")\n",
+    "print()\n",
+    "print(\"Divergence des deux histoires : MEME jeu, MEME certificat de disponibilite,\")\n",
+    "print(\"deux pouvoirs exercés différents — la retenue est le second.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7bd7ca4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002833,
+     "end_time": "2026-08-23T22:17:28.852177",
+     "exception": false,
+     "start_time": "2026-08-23T22:17:28.849344",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : les deux trajectoires divergent sur un seul fait lisible —\n",
+    "la présence ou l'absence du coup certifié disponible dans **l'historique des actions**. Le gain\n",
+    "total de l'entrant est *calculé depuis* cet historique (jamais demandé au joueur). C'est la\n",
+    "divergence des deux histoires qui constitue la sortie, conformément à l'acceptance : l'une\n",
+    "exploite (+9 : deux périodes de duopole (4), un raid à 5, sept périodes dehors à 0), l'autre\n",
+    "s'abstient (+20 : dix périodes à 2) — et l'exploit **rapporte plus** au barème courant. La retenue\n",
+    "n'est pas de l'optimisation : c'est précisément ce qui la distingue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b8d40b38",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T22:17:28.861070Z",
+     "iopub.status.busy": "2026-08-23T22:17:28.860702Z",
+     "iopub.status.idle": "2026-08-23T22:17:28.866097Z",
+     "shell.execute_reply": "2026-08-23T22:17:28.865535Z"
+    },
+    "papermill": {
+     "duration": 0.009646,
+     "end_time": "2026-08-23T22:17:28.867019",
+     "exception": false,
+     "start_time": "2026-08-23T22:17:28.857373",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- vraie retenue\n",
+      "    bareme de 'Raider' : (5, -3)\n",
+      "    certificat : DISPONIBLE : enumere, +3 strictement ameliorant\n",
+      "    verdict    : RETENUE (abstention + coup disponible)\n",
+      "--- abstention par BAREME errone\n",
+      "    bareme de 'Raider' : (2, -3)\n",
+      "    certificat : BAREME : le coup rapporte 2 <= 2 (non profitable)\n",
+      "    verdict    : ABSTENTION EXPLIQUEE SANS RETENUE : BAREME : le coup rapporte 2 <= 2 (non profitable)\n",
+      "--- abstention par INCAPACITE\n",
+      "    bareme de 'Raider' : ABSENT de l ensemble\n",
+      "    certificat : INCAPACITE : l'action n'est pas dans l'ensemble enumere\n",
+      "    verdict    : ABSTENTION EXPLIQUEE SANS RETENUE : INCAPACITE : l'action n'est pas dans l'ensemble enumere\n",
+      "\n",
+      "Verdicts distincts sur les trois cas : 3/3\n",
+      "Un detecteur qui rendait le meme verdict trois fois serait rejete (acceptance #3).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section retenue C : les trois controles negatifs — separer les causes d'abstention ===\n",
+    "\n",
+    "def certificat_disponibilite(action, bareme, br_actuelle, gain_actuel):\n",
+    "    \"\"\"Un coup n'est DISPONIBLE que s'il est atteignable ET strictement ameliorant au bareme.\"\"\"\n",
+    "    atteignable = action in bareme\n",
+    "    if not atteignable:\n",
+    "        return False, \"INCAPACITE : l'action n'est pas dans l'ensemble enumere\"\n",
+    "    delta = bareme[action][0] - gain_actuel\n",
+    "    if delta <= 0:\n",
+    "        return False, f\"BAREME : le coup rapporte {bareme[action][0]} <= {gain_actuel} (non profitable)\"\n",
+    "    return True, f\"DISPONIBLE : enumere, +{delta} strictement ameliorant\"\n",
+    "\n",
+    "CAS = [\n",
+    "    # (nom, action_testee, bareme, gain_actuel, abstention_reelle)\n",
+    "    (\"vraie retenue\", ('Raider', 'Acc'), GAINS_DUOPOLE, 2, True),\n",
+    "    (\"abstention par BAREME errone\", ('Raider', 'Acc'), {('In', 'Acc'): (2, 1), ('Raider', 'Acc'): (2, -3), ('Out', 'Acc'): (0, 0)}, 2, True),\n",
+    "    (\"abstention par INCAPACITE\", ('Raider', 'Acc'), {('In', 'Acc'): (2, 1), ('Out', 'Acc'): (0, 0)}, 2, True),\n",
+    "]\n",
+    "\n",
+    "verdicts = []\n",
+    "for nom, action, bareme, gain_actuel, abstention in CAS:\n",
+    "    dispo, motif = certificat_disponibilite(action, bareme, None, gain_actuel)\n",
+    "    if abstention and dispo:\n",
+    "        verdict = \"RETENUE (abstention + coup disponible)\"\n",
+    "    elif abstention and not dispo:\n",
+    "        verdict = f\"ABSTENTION EXPLIQUEE SANS RETENUE : {motif}\"\n",
+    "    else:\n",
+    "        verdict = \"COUP JOUE (pas une abstention)\"\n",
+    "    verdicts.append((nom, verdict, motif))\n",
+    "    print(f\"--- {nom}\")\n",
+    "    print(f\"    bareme de 'Raider' : {bareme.get(action, 'ABSENT de l ensemble')}\")\n",
+    "    print(f\"    certificat : {motif}\")\n",
+    "    print(f\"    verdict    : {verdict}\")\n",
+    "\n",
+    "print()\n",
+    "uniques = set(v for _, v, _ in verdicts)\n",
+    "print(f\"Verdicts distincts sur les trois cas : {len(uniques)}/3\")\n",
+    "print(\"Un detecteur qui rendait le meme verdict trois fois serait rejete (acceptance #3).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37fbdeb0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003089,
+     "end_time": "2026-08-23T22:17:28.873215",
+     "exception": false,
+     "start_time": "2026-08-23T22:17:28.870126",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : les trois cas rendent **trois verdicts distincts** — le\n",
+    "certificat sépare ce que la trajectoire seule ne peut pas séparer. La « vraie retenue » exige la\n",
+    "conjonction *abstention observée* + *coup énuméré* + *gain strictement supérieur au barème*.\n",
+    "Retirer n'importe lequel des trois clauses dégrade le verdict vers une explication sans retenue.\n",
+    "C'est le dual exact du régime de la section précédente : là, la caution rendait l'annonce\n",
+    "contraignante au prix exact ; ici, le certificat rend l'abstention *significative* au barème exact.\n",
+    "\n",
+    "**Ce que ce témoin n'est pas** : pas un score de coopération (coopérer sans avantage disponible\n",
+    "n'est pas de la retenue — voir le contrôle « incapacité ») ; pas une norme morale encodée (l'objet\n",
+    "est la non-conversion d'un avantage disponible en coup joué, **mesurée**, pas jugée)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "gt20c17",
    "metadata": {
     "papermill": {
-     "duration": 0.001966,
-     "end_time": "2026-08-22T10:05:48.584522+00:00",
+     "duration": 0.002356,
+     "end_time": "2026-08-23T22:17:28.878157",
      "exception": false,
-     "start_time": "2026-08-22T10:05:48.582556+00:00",
+     "start_time": "2026-08-23T22:17:28.875801",
      "status": "completed"
     },
     "tags": []
@@ -740,19 +1063,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.3"
   },
   "metadata_written": "2026-08-22",
   "papermill": {
    "default_parameters": {},
-   "duration": 1.231492,
-   "end_time": "2026-08-22T10:05:48.701968+00:00",
+   "duration": 2.319699,
+   "end_time": "2026-08-23T22:17:29.114300",
    "environment_variables": {},
    "exception": null,
    "input_path": "GameTheory-20-Commitment-Stackelberg.ipynb",
-   "output_path": "GameTheory-20-Commitment-Stackelberg.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/2b36da1d-b3d6-48d7-97f2-37a6d5c34555/scratchpad/exec_gt20_retenue.ipynb",
    "parameters": {},
-   "start_time": "2026-08-22T10:05:47.470476+00:00",
+   "start_time": "2026-08-23T22:17:26.794601",
    "version": "2.7.0"
   },
   "reproducibility": "EXACT - aucun tirage aleatoire, tout est arithmetique entiere/deterministe sur matrices finies."


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA — prev: DEEP/notebook-python #12686

## Summary

Le **témooin de retenue** ajouté à `GameTheory-20-Commitment-Stackelberg.ipynb` : le dual du témooin d'obstruction — **un coup strictement profitable est certifié disponible, et le joueur ne le joue pas** (`pouvoir disponible ≠ pouvoir exercé`). Le notebook portait la menace crédible (7 occ. `menace`, 4 `crédib`) et zéro occurrence de `retenue`/`déviation`/`pardon` : l'accroche Stackelberg existait, le revers manquait — c'est livré.

Le cœur non trivial (Prong B de l'issue) : une abstention observée admet **trois causes indiscernables sur la seule trajectoire** (retenue / barème erroné / incapacité). Un détecteur qui ne sépare pas les trois certifie de la retenue partout où il y a une erreur de barème. La section produit donc le **certificat de disponibilité** avant tout verdict.

## Les trois livrables (chacun avec sa sortie)

1. **Certificat de disponibilité** — `Raider` est énuméré dans l'ensemble d'actions atteignables ET son gain immédiat (5 > 2, delta +3) est **calculé au barème courant et affiché**. Jamais déclaré.
2. **Deux trajectoires sur le MÊME jeu** — exploit (raid période 3 puis marché fermé : total +9) vs retenue (duopole accommodant : total +20), gains **lus depuis l'historique des actions** (`gain_entrant(histoire)` parcourt la trajectoire, aucune utilité déclarée). La divergence des deux histoires est la sortie.
3. **Trois contrôles négatifs aux verdicts DISTINCTS** — vraie retenue → `RETENUE (abstention + coup disponible)` ; barème erroné (Raider rapporterait 2 ≤ 2) → `ABSTENTION EXPLIQUEE SANS RETENUE : BAREME` ; incapacité (Raider absent de l'ensemble) → `ABSTENTION EXPLIQUEE SANS RETENUE : INCAPACITE`. Sortie : `Verdicts distincts sur les trois cas : 3/3` — un détecteur qui rendrait le même verdict trois fois serait rejeté.

## Anti-claims respectés (issue)

Pas un score de coopération (coopérer sans avantage disponible n'est pas de la retenue — le contrôle incapacité le montre) ; pas une norme morale encodée (la non-conversion d'un avantage est **mesurée**, pas jugée). Prose explicite en fin de section.

## Preuves d'exécution (C.2 / H.1)

- Papermill end-to-end, kernel python3, rc=0 : **11 cellules code, 0 `execution_count` null, 0 erreur kernel** (le notebook passe de 8 à 11 cellules code).
- C.1 : 0 occurrence `raise NotImplementedError` / `assert False` / `1/0`.
- Sorties clés committées : `DISPONIBLE : enumere, +3 strictement ameliorant` · `Verdicts distincts sur les trois cas : 3/3` · totaux +9/+20 lus depuis trajectoire.
- Convention du notebook conservée (matrice dict `(u_entrant, u_incumbent)`, style Loi II témoin/vérificateur séparés) ; insertion avant le résumé final, rien d'autre touché.

See #12207 (grain D4 dual — contribution à l'epic, ne la ferme pas)
Closes #12679
