### PR TITLE
fix(training): calibrer la preuve HAR de DLinear

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dlinear_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dlinear_vol.py
@@ -326,6 +326,21 @@ def _load_panel(
     return out
 
 
+def _mse_without_bias(errors: np.ndarray) -> float:
+    """Return error variance, i.e. MSE after removing the signed mean error."""
+    errors = np.asarray(errors, dtype=float)
+    errors = errors[np.isfinite(errors)]
+    if not len(errors):
+        return float("nan")
+    return float(np.mean((errors - np.mean(errors)) ** 2))
+
+
+def _edge_pct(baseline_mse: float, model_mse: float) -> float:
+    if not np.isfinite(baseline_mse) or baseline_mse <= 0:
+        return float("nan")
+    return float((baseline_mse - model_mse) / baseline_mse * 100)
+
+
 def aggregate_verdicts(rows: list[dict]) -> list[dict]:
     from collections import defaultdict
 
@@ -341,17 +356,28 @@ def aggregate_verdicts(rows: list[dict]) -> list[dict]:
         n_seeds = len(seeds_rows)
         dl_mses = [r["dlinear_mse_logrv"] for r in seeds_rows]
         har_mses = [r["har_mse_logrv"] for r in seeds_rows]
-        verdicts = [r.get("dm_verdict", "UNKNOWN") for r in seeds_rows]
-        p_values = [r.get("dm_pvalue", 1.0) for r in seeds_rows]
+        calibrated_har_mses = [
+            r.get("har_calibrated_mse_logrv", float("nan")) for r in seeds_rows
+        ]
+        verdicts = [r.get("calibrated_dm_verdict", "UNKNOWN") for r in seeds_rows]
+        p_values = [r.get("calibrated_dm_pvalue", 1.0) for r in seeds_rows]
 
         mean_dl = float(np.nanmean(dl_mses))
         mean_har = float(np.nanmean(har_mses))
+        mean_calibrated_har = float(np.nanmean(calibrated_har_mses))
         std_dl = float(np.nanstd(dl_mses))
-        mean_reduction = (mean_har - mean_dl) / mean_har * 100 if mean_har > 0 else 0.0
+        mean_reduction = _edge_pct(mean_har, mean_dl)
+        calibrated_edge_pct = _edge_pct(mean_calibrated_har, mean_dl)
+        debiased_edges = [
+            r.get("edge_debiased_pct", float("nan")) for r in seeds_rows
+        ]
+        mean_debiased_edge_pct = float(np.nanmean(debiased_edges))
 
         # pr-review §C conjunction: edge >= 2*std cross-seed AND dm_p_median < 0.05.
         # sigma alone measures inter-seed dispersion, not significance (#10228).
-        reduction_pcts = [r.get("mse_reduction_pct", float("nan")) for r in seeds_rows]
+        reduction_pcts = [
+            r.get("calibrated_edge_pct", float("nan")) for r in seeds_rows
+        ]
         edge_std_pct = float(np.nanstd(reduction_pcts)) if len(reduction_pcts) > 1 else 0.0
         dm_p_median = float(np.nanmedian(p_values))
 
@@ -361,7 +387,7 @@ def aggregate_verdicts(rows: list[dict]) -> list[dict]:
 
         if n_beaten > 0:
             agg_verdict = "NO BEATS"
-        elif n_beats == n_seeds and std_dl < abs(mean_har - mean_dl):
+        elif n_beats == n_seeds and std_dl < abs(mean_calibrated_har - mean_dl):
             agg_verdict = "BEATS"
         elif n_beats > 0:
             agg_verdict = "INCONCLUSIVE"
@@ -371,7 +397,7 @@ def aggregate_verdicts(rows: list[dict]) -> list[dict]:
         # §C conjunction verdict (kept alongside legacy "verdict" for diff stability).
         if n_beaten > 0:
             verdict_sc = "NO BEATS"
-        elif mean_reduction >= 2.0 * edge_std_pct and dm_p_median < 0.05:
+        elif calibrated_edge_pct >= 2.0 * edge_std_pct and dm_p_median < 0.05:
             verdict_sc = "BEATS"
         else:
             verdict_sc = "INCONCLUSIVE"
@@ -383,7 +409,10 @@ def aggregate_verdicts(rows: list[dict]) -> list[dict]:
             "mean_dlinear_mse": mean_dl,
             "std_dlinear_mse": std_dl,
             "mean_har_mse": mean_har,
+            "mean_calibrated_har_mse": mean_calibrated_har,
             "mean_reduction_pct": mean_reduction,
+            "mean_debiased_edge_pct": mean_debiased_edge_pct,
+            "calibrated_edge_pct": calibrated_edge_pct,
             "edge_std_pct": edge_std_pct,
             "dm_p_median": dm_p_median,
             "n_beats": n_beats,
@@ -426,18 +455,34 @@ def _eval_one_coin(
     for h in horizons:
         # Classic HAR baseline (deterministic, seed 0 reference)
         try:
-            har_out = walk_forward_har(rv, horizon=h, n_splits=n_splits, refit_every=refit_every)
+            har_out = walk_forward_har(
+                rv, horizon=h, n_splits=n_splits, refit_every=refit_every,
+            )
+            har_calibrated_out = walk_forward_har(
+                rv, horizon=h, n_splits=n_splits, refit_every=refit_every,
+                calibrate_bias=True,
+            )
             har_mse = har_out["aggregate_mse_logrv"]
+            har_calibrated_mse = har_calibrated_out["aggregate_mse_logrv"]
             har_forecasts = har_out["forecasts"]
             har_targets = har_out["targets"]
             har_errors = (har_forecasts - har_targets).dropna().values
+            har_calibrated_errors = (
+                har_calibrated_out["forecasts"] - har_calibrated_out["targets"]
+            ).dropna().values
             har_bias_oos = float(np.mean(har_errors)) if len(har_errors) else float("nan")
-            print(f"  h={h} HAR baseline MSE={har_mse:.5f} bias_OOS={har_bias_oos:+.5f} "
-                  f"({har_out['n_total_preds']} preds)")
+            har_debiased_mse = _mse_without_bias(har_errors)
+            print(
+                f"  h={h} HAR baseline MSE={har_mse:.5f} "
+                f"calibrated={har_calibrated_mse:.5f} debiased={har_debiased_mse:.5f} "
+                f"bias_OOS={har_bias_oos:+.5f} ({har_out['n_total_preds']} preds)"
+            )
         except Exception as exc:
             print(f"  h={h} HAR baseline FAILED: {exc}")
             har_mse = float("nan")
+            har_calibrated_mse = float("nan")
             har_errors = None
+            har_calibrated_errors = None
             continue
 
         for seed in seeds:
@@ -461,32 +506,65 @@ def _eval_one_coin(
                 print(f"  h={h} seed={seed} DLinear FAILED: {exc}")
                 rows.append({
                     "coin": coin, "horizon": h, "seed": seed,
-                    "dlinear_mse_logrv": float("nan"), "har_mse_logrv": float(har_mse),
+                    "dlinear_mse_logrv": float("nan"),
+                    "har_mse_logrv": float(har_mse),
+                    "har_calibrated_mse_logrv": float(har_calibrated_mse),
                     "dm_verdict": "FAILED",
+                    "calibrated_dm_verdict": "FAILED",
                 })
                 continue
 
-            # DM test: DLinear vs HAR
+            # DM tests: raw HAR is retained for comparability; the calibrated
+            # baseline drives the verdict because it removes a train-estimated offset.
             dm_info = {}
-            if har_errors is not None and len(dl_errors) >= 10 and len(har_errors) >= 10:
-                min_len = min(len(dl_errors), len(har_errors))
+            if (
+                har_errors is not None
+                and har_calibrated_errors is not None
+                and len(dl_errors) >= 10
+                and len(har_errors) >= 10
+                and len(har_calibrated_errors) >= 10
+            ):
+                min_len = min(len(dl_errors), len(har_errors), len(har_calibrated_errors))
                 try:
-                    dm = dm_verdict(dl_errors[:min_len], har_errors[:min_len], horizon=h, loss_fn=loss_fn)
+                    dm = dm_verdict(
+                        dl_errors[:min_len], har_errors[:min_len],
+                        horizon=h, loss_fn=loss_fn,
+                    )
+                    calibrated_dm = dm_verdict(
+                        dl_errors[:min_len], har_calibrated_errors[:min_len],
+                        horizon=h, loss_fn=loss_fn,
+                    )
                     dm_info = {
                         "dm_stat": dm["dm_statistic"],
                         "dm_pvalue": dm["p_value"],
                         "dm_verdict": dm["verdict"],
                         "dm_mean_loss_diff": dm["mean_loss_diff"],
+                        "calibrated_dm_stat": calibrated_dm["dm_statistic"],
+                        "calibrated_dm_pvalue": calibrated_dm["p_value"],
+                        "calibrated_dm_verdict": calibrated_dm["verdict"],
+                        "calibrated_dm_mean_loss_diff": calibrated_dm["mean_loss_diff"],
                     }
-                    print(f"  h={h} seed={seed} DLinear MSE={dl_mse:.5f} "
-                          f"DM={dm['dm_statistic']:.3f} p={dm['p_value']:.4f} "
-                          f"-> {dm['verdict']}")
+                    print(
+                        f"  h={h} seed={seed} DLinear MSE={dl_mse:.5f} "
+                        f"edge_raw={_edge_pct(har_mse, dl_mse):+.2f}% "
+                        f"edge_calibrated={_edge_pct(har_calibrated_mse, dl_mse):+.2f}% "
+                        f"DM_cal={calibrated_dm['dm_statistic']:.3f} "
+                        f"p={calibrated_dm['p_value']:.4f} "
+                        f"-> {calibrated_dm['verdict']}"
+                    )
                 except Exception as exc:
                     print(f"  h={h} seed={seed} DM FAILED: {exc}")
-                    dm_info = {"dm_verdict": "DM_FAILED"}
+                    dm_info = {
+                        "dm_verdict": "DM_FAILED",
+                        "calibrated_dm_verdict": "DM_FAILED",
+                    }
             else:
-                dm_info = {"dm_verdict": "INSUFFICIENT_DATA"}
+                dm_info = {
+                    "dm_verdict": "INSUFFICIENT_DATA",
+                    "calibrated_dm_verdict": "INSUFFICIENT_DATA",
+                }
 
+            dl_debiased_mse = _mse_without_bias(dl_errors)
             rows.append({
                 "coin": coin,
                 "horizon": h,
@@ -494,12 +572,18 @@ def _eval_one_coin(
                 "seq_len": seq_len,
                 "decompose": decompose,
                 "debias": debias,
+                "har_calibrate_bias": True,
                 "har_bias_oos": har_bias_oos,
                 "n_rv_days": int(len(rv)),
                 "n_predictions": int(dl_out["n_total_preds"]),
                 "dlinear_mse_logrv": float(dl_mse),
+                "dlinear_debiased_mse_logrv": dl_debiased_mse,
                 "har_mse_logrv": float(har_mse),
-                "mse_reduction_pct": float((har_mse - dl_mse) / har_mse * 100) if har_mse > 0 else float("nan"),
+                "har_debiased_mse_logrv": har_debiased_mse,
+                "har_calibrated_mse_logrv": float(har_calibrated_mse),
+                "mse_reduction_pct": _edge_pct(har_mse, dl_mse),
+                "edge_debiased_pct": _edge_pct(har_debiased_mse, dl_debiased_mse),
+                "calibrated_edge_pct": _edge_pct(har_calibrated_mse, dl_mse),
                 **dm_info,
             })
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/har_model.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/har_model.py
@@ -110,11 +110,36 @@ def _make_split_indices(n: int, n_splits: int) -> list[tuple[int, int, int]]:
     return splits
 
 
+def _fit_har_with_train_calibration(
+    rv_train: pd.Series,
+    horizon: int,
+    calibration_size: int,
+) -> tuple[HARModel, float]:
+    """Fit HAR before a train-tail holdout and estimate its signed offset."""
+    calibration_size = min(calibration_size, max(0, len(rv_train) - 60))
+    if calibration_size < max(10, horizon + 1):
+        return HARModel().fit(rv_train), 0.0
+
+    fit_end = len(rv_train) - calibration_size
+    calibration_model = HARModel().fit(rv_train.iloc[:fit_end])
+    log_rv = np.log(rv_train.clip(lower=1e-12))
+    errors: list[float] = []
+    for i in range(fit_end, len(rv_train) - horizon):
+        prediction = calibration_model.predict_h_step(rv_train.iloc[:i], horizon=horizon)
+        target = float(log_rv.iloc[i:i + horizon].mean())
+        errors.append(prediction - target)
+
+    bias = float(np.mean(errors)) if errors else 0.0
+    return calibration_model, bias
+
+
 def walk_forward_har(
     rv: pd.Series,
     horizon: int = 1,
     n_splits: int = 5,
     refit_every: int = 22,
+    calibrate_bias: bool = False,
+    calibration_size: int = 60,
 ) -> dict:
     """Walk-forward evaluation of HAR on a daily-RV series.
 
@@ -133,18 +158,26 @@ def walk_forward_har(
     preds: list[float] = []
     truths: list[float] = []
     pred_dates: list[pd.Timestamp] = []
+    initial_calibration_bias_by_fold: list[float] = []
     for fold_idx, (train_end, test_start, test_end) in enumerate(splits):
         rv_train = rv.iloc[:train_end]
         if len(rv_train) < 60:
             continue
-        model = HARModel().fit(rv_train)
+        if calibrate_bias:
+            model, bias = _fit_har_with_train_calibration(
+                rv_train, horizon=horizon, calibration_size=calibration_size,
+            )
+        else:
+            model = HARModel().fit(rv_train)
+            bias = 0.0
+        initial_calibration_bias_by_fold.append(bias)
         fold_preds: list[float] = []
         fold_truths: list[float] = []
         history = list(rv.iloc[:test_start].values)
         for i in range(test_start, test_end - horizon):
             target_window = log_rv.iloc[i:i + horizon].mean()
             tail = pd.Series(history[-(22 + horizon):])
-            log_pred = model.predict_h_step(tail, horizon=horizon)
+            log_pred = model.predict_h_step(tail, horizon=horizon) - bias
             fold_preds.append(log_pred)
             fold_truths.append(float(target_window))
             preds.append(log_pred)
@@ -152,7 +185,13 @@ def walk_forward_har(
             pred_dates.append(rv.index[i])
             history.append(float(rv.iloc[i]))
             if (i - test_start) % refit_every == 0 and i > test_start:
-                model = HARModel().fit(rv.iloc[:i])
+                if calibrate_bias:
+                    model, bias = _fit_har_with_train_calibration(
+                        rv.iloc[:i], horizon=horizon, calibration_size=calibration_size,
+                    )
+                else:
+                    model = HARModel().fit(rv.iloc[:i])
+                    bias = 0.0
         fp = np.asarray(fold_preds)
         ft = np.asarray(fold_truths)
         fold_mse = float(np.mean((fp - ft) ** 2)) if len(fp) else float("nan")
@@ -173,6 +212,9 @@ def walk_forward_har(
         "n_total_preds": len(preds_arr),
         "aggregate_mse_logrv": aggregate_mse,
         "fold_results": fold_results,
+        "calibrate_bias": calibrate_bias,
+        "calibration_size": calibration_size,
+        "initial_calibration_bias_by_fold": initial_calibration_bias_by_fold,
         "forecasts": forecasts,
         "targets": targets,
     }

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_dlinear_debiased_edge.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_dlinear_debiased_edge.py
@@ -1,0 +1,95 @@
+"""Regression tests for calibrated HAR evidence in dlinear_vol (#12684)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from dlinear_vol import _edge_pct, _mse_without_bias, aggregate_verdicts
+from har_model import walk_forward_har
+
+
+def test_debiased_edge_exposes_mean_recalibration_inversion() -> None:
+    target = np.zeros(200)
+    har_error = np.tile([-1.0, 1.0], 100) - 0.5
+    model_error = np.tile([-1.05, 1.05], 100)
+
+    har_mse = float(np.mean(har_error**2))
+    model_mse = float(np.mean(model_error**2))
+    raw_edge = _edge_pct(har_mse, model_mse)
+    debiased_edge = _edge_pct(
+        _mse_without_bias(har_error),
+        _mse_without_bias(model_error),
+    )
+
+    assert target.shape == har_error.shape
+    assert raw_edge > 0.0
+    assert debiased_edge < 0.0
+
+
+def _inverted_rows(calibrated_verdict: str) -> list[dict]:
+    return [{
+        "coin": "SPY",
+        "horizon": 1,
+        "seed": seed,
+        "dlinear_mse_logrv": 0.80,
+        "har_mse_logrv": 1.00,
+        "har_calibrated_mse_logrv": 0.75,
+        "mse_reduction_pct": 20.0,
+        "edge_debiased_pct": -6.0,
+        "calibrated_edge_pct": -6.67,
+        "calibrated_dm_pvalue": 0.01,
+        "calibrated_dm_verdict": calibrated_verdict,
+    } for seed in (0, 1, 7, 42)]
+
+
+def test_aggregate_verdict_uses_calibrated_baseline() -> None:
+    result = aggregate_verdicts(_inverted_rows("BEATEN BY baseline"))[0]
+
+    assert result["mean_reduction_pct"] == pytest.approx(20.0)
+    assert result["calibrated_edge_pct"] < 0.0
+    assert result["mean_debiased_edge_pct"] < 0.0
+    assert result["verdict_sc"] == "NO BEATS"
+
+
+def test_conjunction_rejects_positive_raw_but_negative_calibrated_edge() -> None:
+    result = aggregate_verdicts(_inverted_rows("INCONCLUSIVE"))[0]
+
+    assert result["mean_reduction_pct"] > 0.0
+    assert result["calibrated_edge_pct"] < 0.0
+    assert result["dm_p_median"] < 0.05
+    assert result["verdict_sc"] == "INCONCLUSIVE"
+
+
+def test_har_calibration_is_estimated_from_train_only() -> None:
+    rng = np.random.default_rng(12684)
+    n = 420
+    log_rv = np.cumsum(rng.normal(0.0, 0.03, n)) - 7.0
+    rv = pd.Series(
+        np.exp(log_rv),
+        index=pd.date_range("2020-01-01", periods=n, freq="D"),
+    )
+
+    base = walk_forward_har(
+        rv, horizon=1, n_splits=4, refit_every=22,
+        calibrate_bias=True, calibration_size=45,
+    )
+    mutated = rv.copy()
+    first_test_start = n // 5
+    mutated.iloc[first_test_start:] *= np.exp(2.0)
+    changed = walk_forward_har(
+        mutated, horizon=1, n_splits=4, refit_every=22,
+        calibrate_bias=True, calibration_size=45,
+    )
+
+    assert base["calibrate_bias"] is True
+    assert base["calibration_size"] == 45
+    base_biases = base["initial_calibration_bias_by_fold"]
+    changed_biases = changed["initial_calibration_bias_by_fold"]
+    assert len(base_biases) == 4
+    assert abs(base_biases[0]) > 0.0
+    assert base_biases[0] == pytest.approx(changed_biases[0])
+    assert base["aggregate_mse_logrv"] != pytest.approx(
+        changed["aggregate_mse_logrv"],
+    )


### PR DESCRIPTION
Grain: MED/training — lane myia-po-2025:CoursIA — prev: MED/notebook-lean #12678

## Résumé

- calibre la baseline HAR sur une queue strictement interne au train de chaque fold, sans lecture OOS ;
- publie séparément l'edge DLinear brut, l'edge après retrait du biais signé et l'edge contre HAR calibré ;
- conserve le test DM contre HAR brut pour comparabilité, mais branche les verdicts agrégés sur le DM et l'edge calibrés ;
- ajoute des régressions synthétiques couvrant l'inversion d'un edge brut positif et l'absence de fuite de calibration.

## Portée

Cette PR couvre uniquement la tranche DLinear/HAR de #12684. Elle ne modifie pas les scripts ETF/m15 absents de cette tranche et ne relance aucun entraînement GPU. Elle ne revendique donc aucun nouveau verdict empirique sur les données réelles.

## Validation

- `python -m pytest MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests` : **1026 passed, 1 skipped, 9 warnings** en 388.32 s ; avertissements PyTorch préexistants sur les types de masks Transformer.
- tests ciblés post-review : **23 passed** en 7.11 s.
- `python -m py_compile` sur les deux scripts et le nouveau test : succès.
- `git diff --check` : succès.
- Ruff non exécuté : module `ruff` absent de l'environnement (`No module named ruff`).

See #12684
