### PR TITLE
fix(tooling,#12620): predicat assignment tranche par ast.parse — 6->2, cliquet desbloque

### DIFF
--- a/scripts/notebook_tools/code_in_markdown_cells_baseline.json
+++ b/scripts/notebook_tools/code_in_markdown_cells_baseline.json
@@ -1,12 +1,8 @@
 {
   "_comment": "Baseline of code-in-markdown-cells violations. Burn down, do not grow. Regenerate with: python scripts/notebook_tools/detect_code_in_markdown_cells.py --update-baseline --baseline <this file>",
-  "count": 6,
+  "count": 2,
   "hashes": [
     "14f7007ef0a0fe43",
-    "398012ebec395f7f",
-    "8c9e45215860abf1",
-    "96d844cbbdde350d",
-    "c641f44147b1260e",
-    "ed8aa4e4aa7d554e"
+    "96d844cbbdde350d"
   ]
 }

--- a/scripts/notebook_tools/detect_code_in_markdown_cells.py
+++ b/scripts/notebook_tools/detect_code_in_markdown_cells.py
@@ -114,6 +114,19 @@ def _is_assignment(line: str) -> bool:
     # Skip walrus / equality / annotation-only (no value)
     if rhs.startswith("=") or not rhs:
         return False
+    # Lexical pass kept as the upstream gate (scope unchanged); the AST pass
+    # only adjudicates candidates the regex already retained — prose citing a
+    # parameter twice (`n_est=200 obtient le meilleur...`) parses as a Compare,
+    # not an Assign, and falls through (#12620).
+    import ast as _ast
+    try:
+        tree = _ast.parse(line.strip(), mode="exec")
+    except SyntaxError:
+        return False
+    if len(tree.body) != 1 or not isinstance(
+        tree.body[0], (_ast.Assign, _ast.AnnAssign)
+    ):
+        return False
     return True
 
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: DEEP/notebook-python #12687

## Summary

Durcissement du predicat `markdown_cell_with_python_assignment` dans `scripts/notebook_tools/detect_code_in_markdown_cells.py` : la ligne regex reste le **garde amont** (perimetre inchange), un passage `ast.parse` **tranche** les candidats qu'il retenait — une ligne est une assignation **ssi Python la parse comme `Assign`/`AnnAssign`**. La prose francaise qui cite un parametre (`n_est=200 obtient le meilleur Sharpe`) parse en `Compare`, pas en `Assign`, et tombe.

## Mesures (scan nu sur worktree frais origin/main)

| | avant | apres |
|---|---|---|
| `markdown_cell_with_python_assignment` | 6 | **1** |
| `markdown_cell_with_python_signature` (regle non touchee) | 1 | **1** |
| total (plancher reel) | 7 (dont 4 non burn-down-ables) | **2** |

Les 4 FP de l'issue tombent (XGBoost prose x2, maths cusp `a = -T * s (facteur normal)`, tableau VADER `compound=+0.6`/`pos=0.4`) ; les 2 vrais positifs restent detectes (SemanticKernel `GLOBAL_LLM_SERVICE="OpenAI"`, Pyro `def approx` — regle signature, hors scope du fix et intacte verifiee).

## Livrables

1. `_is_assignment` : garde lexical conserve + adjudication AST (12 lignes effectives). Un `SyntaxError` (prose) tombe egalement — le regex avalait deja des lignes non-Python.
2. `code_in_markdown_cells_baseline.json` regeneree : `count: 6 -> 2`, hashes des 2 vrais positifs. Le cliquet « Burn down, do not grow » est desormais **desbloque** — son plancher reel est atteint.

## Verifications

- `--selfcheck` : **9/9 controls OK** (les faux positifs de prose sont des controls du selfcheck ; aucun n'a saute).
- `--check --baseline <file> MyIA.AI.Notebooks` : **OK rc=0**.
- Tests unitaires : `pytest scripts/notebook_tools/tests/test_detect_code_in_markdown_cells.py` — **10 passed**.
- A/B par cas : chaque ligne FP de l'issue testee iso (`_is_assignment` = False), chaque TP detecte (`_scan_python_assignments` le retourne).

## Hors scope (note)

- La regle `markdown_cell_with_python_signature` garde sa sur-accusation potentielle (`def` Lean hors fence) — l'issue la exclut explicitement ; a traiter separement si le cas represente.
- `--check` sans `--baseline` compare a un ensemble vide (FAIL fantome) = issue #12585 ouverte, distincte.
- Aucun notebook modifie : le correctif est cote outil, les 4 notebooks constates ne sont pas touches (conforme au scope de l'issue).

Closes #12620
