### PR TITLE
fix(slides,#10950): S3-acculturation — 2 slides débordaient (Jeux, CSPs) : images coupées / grille invisible

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -459,6 +459,8 @@ layout: default
 </div>
 
 
+<div class="dense-list">
+
 **Jeux vs Exploration**
 
 - Arbre de jeu
@@ -474,18 +476,14 @@ layout: default
   - Stochastiques, information imparfaite
   - Libratus (poker), Starcraft 2
 
-
-**Arbre Minimax**
-
-- Actions joueurs Max et Min + utilité terminale
-
 **Techniques**
 
+- Actions joueurs Max et Min + utilité terminale
 - Minimax, Alpha-Beta
 - Avec arrêt + évaluation heuristique
-- Techniques probabilistes
-- Expectiminimax
-- Méthodes de Monte-Carlo
+- Techniques probabilistes (Expectiminimax, Monte-Carlo)
+
+</div>
 
 <img src="./images/img_031.png" class="absolute top-[110px] right-[20px] w-[350px] max-h-[300px] object-contain" alt="Arbre minimax du morpion : niveaux MAX(X) et MIN(O), utilités -1/0/+1" />
 
@@ -537,10 +535,10 @@ layout: default
 - Structure des valeurs
   - Symétrie (rupture de)
 
-<div class="img-grid-2x2">
-<img src="./images/img_035.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Schéma de sémantique : énoncés reliés par « a pour conséquence » et « causent » aux aspects du monde réel" />
-<img src="./images/img_036.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Illustration Winograd : ordinateur échangeant phrases et conclusions avec un humain et un robot" />
-<img src="./images/img_037.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Grammaire de la logique propositionnelle : Énoncé, ÉnoncéAtomique, priorité des opérateurs ¬, ∧, ∨, ⇒, ⇔" />
+<div class="flex gap-2">
+<img src="./images/img_035.png" class="w-[120px] max-w-full max-h-[140px] object-contain" alt="Schéma de sémantique : énoncés reliés par « a pour conséquence » et « causent » aux aspects du monde réel" />
+<img src="./images/img_036.png" class="w-[120px] max-w-full max-h-[140px] object-contain" alt="Illustration Winograd : ordinateur échangeant phrases et conclusions avec un humain et un robot" />
+<img src="./images/img_037.png" class="w-[120px] max-w-full max-h-[140px] object-contain" alt="Grammaire de la logique propositionnelle : Énoncé, ÉnoncéAtomique, priorité des opérateurs ¬, ∧, ∨, ⇒, ⇔" />
 
 </div>
 


### PR DESCRIPTION
Grain: MED/slides -- lane myia-po-2023:CoursIA-2 -- prev: LIGHT/notebook-python #12675

## Summary

QA visuel (`retour visuel` navigateur + lane vision) de `slides/S3-acculturation/slides.md` : **2 slides débordaient le cadre 980x552**, coupant le contenu avec une image invisible. Corrigées, re-rendues, vérifiées à l'oeil.

1. **Slide « Jeux »** — layout `default` sans compression, ~14 puces pleine-largeur → layout monté à **745px** (cadre 552) ; bas de slide sectionné. Fix : `dense-list` (condense les puces, outil prévu par `style.css` du thème) + fusion de puces redondantes (`Techniques probabilistes (Expectiminimax, Monte-Carlo)`, sans perte d'info) → **layoutH 552**.
2. **Slide « Problèmes à satisfaction de contraintes »** — `img-grid-2x2` en flux avec 3 images → le wrap 3→2+1 poussait `img_037` sur la 2e ligne (top 567), **invisible sous le cadre**. Fix : `flex gap-2` 3-across, images `w-[120px] max-h-[140px]` → les **3 images sur une seule ligne** (bottom 480), toutes visibles.

## Preuves (post-fix)

- `slidev build` : **✓ built in 14.94s** (composition CI OK).
- Géométrie Playwright scoped par slide (`_measure3.cjs`) : `layoutH` Jeux 745→552, CSPs 745→552 ; **aucune slide > 552 restante**. Seul reliquat : `img_021` slide « Formulation de problèmes » bottom=556 (4px, imperceptible — jugé clean à l'oeil).
- **Retour visuel** (lane vision `glm-4.6v`) : « Jeux » — toutes bulles visibles, dernière ligne `Techniques probabilistes (Expectiminimax, Monte-Carlo)` visible, diagramme à droite intact, aucun overlap ; « CSPs » — **3 diagrammes visibles en une ligne**, aucun clip, aucun overlap.
- 1 fichier, +10/−12.

Voir #10950 (contribution partielle au QA visuel du deck ; les ~13 slides `layout: two-cols` restantes et le polish esthétique global relèvent de l'umbrella / des tranches).

Note coordination : **#12548** (tranche 6 #10950) est OPEN/CONFLICTING, base stale (`249cfe9c7` vs main `f7500c6b7`), 0 commentaire — semble superseded par les tranches 7/8 mergées. À ré-arbitrer par ai-01.
