### PR TITLE
fix(ml,#11947): tranche heading_in_list ML — 15 lignes heading-en-puce en code inline (2 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.5-Biais-Variance-CV-ROC.ipynb
@@ -280,9 +280,9 @@
     "À partir du tableau affiché ci-dessus (ou en recalculant), repérez quel modèle présente le **plus grand écart** entre accuracy d'entraînement et accuracy de test. Ce gap `train - test` est l'indice le plus direct d'une variance élevée : le modèle ajuste trop finement l'échantillon d'entraînement pour bien généraliser.\n",
     "\n",
     "Indices :\n",
-    "- # Étape 1 : pour chaque `(nom, modèle)` dans `modèles`, recalculer `acc_train` et `acc_test` (comme dans la cellule précédente).\n",
-    "- # Étape 2 : former la liste `ecarts` des différences `acc_train - acc_test`.\n",
-    "- # Étape 3 : récupérer l'indice du maximum avec `np.argmax(ecarts)`, puis `modèles[indice_max][0]` pour le nom."
+    "- `# Étape 1` : pour chaque `(nom, modèle)` dans `modèles`, recalculer `acc_train` et `acc_test` (comme dans la cellule précédente).\n",
+    "- `# Étape 2` : former la liste `ecarts` des différences `acc_train - acc_test`.\n",
+    "- `# Étape 3` : récupérer l'indice du maximum avec `np.argmax(ecarts)`, puis `modèles[indice_max][0]` pour le nom."
    ]
   },
   {
@@ -607,9 +607,9 @@
     "Le choix de *k* n'est pas anodin. Recalculez le score de validation croisée de la régression logistique avec **`cv=10`** au lieu de 5 et comparez la moyenne à celle de `scores_cv` (cv=5, cellule précédente). Un *k* plus grand utilise davantage de données pour l'entraînement (plis de test plus petits) : la moyenne a tendance à être légèrement optimiste, mais le coût de calcul augmente.\n",
     "\n",
     "Indices :\n",
-    "- # Étape 1 : appeler `cross_val_score(LogisticRegression(max_iter=1000), X, y, cv=10)`.\n",
-    "- # Étape 2 : stocker le résultat dans `scores_cv10` puis `moyenne_cv10 = np.mean(scores_cv10)`.\n",
-    "- # Étape 3 : comparer à `scores_cv.mean()` (cv=5)."
+    "- `# Étape 1` : appeler `cross_val_score(LogisticRegression(max_iter=1000), X, y, cv=10)`.\n",
+    "- `# Étape 2` : stocker le résultat dans `scores_cv10` puis `moyenne_cv10 = np.mean(scores_cv10)`.\n",
+    "- `# Étape 3` : comparer à `scores_cv.mean()` (cv=5)."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8-Theorie-PAC.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.8-Theorie-PAC.ipynb
@@ -470,9 +470,9 @@
     "\n",
     "Indices :\n",
     "\n",
-    "- # Étape 1 : construire `eps_grid = np.linspace(0.01, 0.3, 50)`.\n",
-    "- # Étape 2 : calculer `m_min_grid = np.array([m_min_pac(K_exemple, e, delta_exemple) for e in eps_grid])`.\n",
-    "- # Étape 3 : tracer avec `plt.plot(eps_grid, m_min_grid)`. Que vaut `m_min` pour `ε = 0.01` ? pour `ε = 0.1` ?\n"
+    "- `# Étape 1` : construire `eps_grid = np.linspace(0.01, 0.3, 50)`.\n",
+    "- `# Étape 2` : calculer `m_min_grid = np.array([m_min_pac(K_exemple, e, delta_exemple) for e in eps_grid])`.\n",
+    "- `# Étape 3` : tracer avec `plt.plot(eps_grid, m_min_grid)`. Que vaut `m_min` pour `ε = 0.01` ? pour `ε = 0.1` ?\n"
    ]
   },
   {
@@ -667,9 +667,9 @@
     "\n",
     "Indices :\n",
     "\n",
-    "- # Étape 1 : pour chaque `m` de la liste, rediviser `X_moons, y_moons` avec `train_size=m` (garder le reste en test).\n",
-    "- # Étape 2 : ajuster `make_pipeline(PolynomialFeatures(degree=5, include_bias=False), LogisticRegression(max_iter=5000))`, mesurer l'écart `train - test`.\n",
-    "- # Étape 3 : refaire la même chose pour `degree=1` et tracer les deux courbes d'écart vs `m`.\n"
+    "- `# Étape 1` : pour chaque `m` de la liste, rediviser `X_moons, y_moons` avec `train_size=m` (garder le reste en test).\n",
+    "- `# Étape 2` : ajuster `make_pipeline(PolynomialFeatures(degree=5, include_bias=False), LogisticRegression(max_iter=5000))`, mesurer l'écart `train - test`.\n",
+    "- `# Étape 3` : refaire la même chose pour `degree=1` et tracer les deux courbes d'écart vs `m`.\n"
    ]
   },
   {
@@ -808,9 +808,9 @@
     "\n",
     "Indices :\n",
     "\n",
-    "- # Étape 1 : `m_min_ex3 = m_min_pac(1000, 0.05, 0.1)`.\n",
-    "- # Étape 2 : `X_c, y_c = make_classification(n_samples=..., random_state=...)`, puis diviser en train/test.\n",
-    "- # Étape 3 : sur `T` essais (tirages aléatoires), mesurer l'erreur de test moyenne et la fraction d'essais sous `ε`.\n"
+    "- `# Étape 1` : `m_min_ex3 = m_min_pac(1000, 0.05, 0.1)`.\n",
+    "- `# Étape 2` : `X_c, y_c = make_classification(n_samples=..., random_state=...)`, puis diviser en train/test.\n",
+    "- `# Étape 3` : sur `T` essais (tirages aléatoires), mesurer l'erreur de test moyenne et la fraction d'essais sous `ε`.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #12689 (substance distincte : remédiation rendu ML vs SymbolicAI)

See #11947

## Summary

Tranche ML du registre heading_in_list : les indices/étapes d'exercices écrits `- # Étape 2 : ...` rendaient en H1 géant imbriqué dans une puce (illisible sur GitHub). 2 notebooks corrigés — `2.5-Biais-Variance-CV-ROC.ipynb` (cells 6, 12) et `2.8-Theorie-PAC.ipynb` (cells 10, 15, 19) — selon la convention consolidée #12591/#12678 : `` - `# Étape 2` : ... `` (marqueur en code inline, coupure au premier ` : `).

Markdown-only, aucune cellule code touchée (exception C.2 — pas de re-exec requise).

## Validation

Scanner `detect_markdown_rendering.py` sur `ML/DataScienceWithAgents/02-ML-Cours/` :

```
avant (origin/main) : heading_in_list = 5 findings (2.5 ×2, 2.8 ×3)
après  (branche)    : heading_in_list = 0
```

15 lignes transformées sur exactement les 5 cellules pointées (1 finding/cellule par design). Cellules code, outputs et execution_count intacts. H.3 pre-commit Passed.

Reste sur le registre après cette tranche : 12 findings (GenAI 9, Probas 3, Search 1, hors Lean-11 en cours #12678).

## Scope

2 fichiers, tous sous `MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/` :
- 2.5-Biais-Variance-CV-ROC.ipynb
- 2.8-Theorie-PAC.ipynb
