### PR TITLE
Add: C3 Descent.lean — formaliser l'échec de décroissance comme dissociation (op 11)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Descent.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Descent.lean
@@ -143,4 +143,50 @@ theorem descent_target_before_ceiling
   ⟨hnostall _ hterm,
    Nat.lt_of_le_of_lt (descent_flips_le_barrier hstrict s₀ rest B hbarrier hL) hceiling⟩
 
+/-! ## Échec de décroissance — le défaut comme dissociation
+
+La thèse du chantier (opération 11, « descendre sous budget ») : un **échec de
+décroissance** — un flip accepté qui ne fait pas strictement décroître le coût —
+n'est pas un échec d'expérience à écarter, c'est une **dissociation** à
+enregistrer : l'objet qui fait payer l'hypothèse de stricte décroissance. Plutôt
+qu'un résidu numérique (la Loi I du chantier : « le résidu n'est pas le témoin »),
+on le rend de premier ordre — un témoin extractible dans un run. -/
+
+/-- **Témoin d'échec de décroissance** dans un run : une paire d'états
+consécutifs dont le flip est accepté mais ne fait pas strictement décroître le
+coût. `here` porte le défaut à la frontière du run, `later` le délègue à la
+queue ; un run peut porter plusieurs témoins (il s'agit d'une existence). -/
+inductive DescentFailure (accept : σ → σ → Prop) (cost : σ → Nat) : List σ → Prop
+  | here (s u : σ) (rest : List σ) (hA : accept s u) (hc : ¬ cost u < cost s) :
+      DescentFailure accept cost (s :: u :: rest)
+  | later (s u : σ) (rest : List σ)
+      (hf : DescentFailure accept cost (u :: rest)) :
+      DescentFailure accept cost (s :: u :: rest)
+
+/-- **Stricte décroissance ⇒ aucun témoin.** Si chaque flip accepté décroît
+strictement le coût, alors un run d'états acceptés (`Run`) ne porte aucun échec
+de décroissance : la stricte descente est exactement la négation du témoin. -/
+theorem run_strictdescent_excludes_failure
+    (hstrict : ∀ s t, accept s t → cost t < cost s)
+    {L : List σ} (hL : Run accept L) : ¬ DescentFailure accept cost L := by
+  induction hL with
+  | nil => intro hf; cases hf
+  | single => intro hf; cases hf
+  | cons s u rest _ _ ih =>
+    intro hf
+    cases hf with
+    | here _ _ _ hA hc => exact absurd (hstrict s u hA) hc
+    | later _ _ _ htl => exact ih htl
+
+/-- **Un témoin fait payer l'hypothèse.** Si un run porte un échec de
+décroissance, la propriété globale de stricte décroissance est fausse : le
+témoin est l'objet qui démontre la violation, pas un échec d'expérience vague. -/
+theorem failure_witness_denies_global_strict
+    {L : List σ} (hw : DescentFailure accept cost L) :
+    ¬ (∀ s t, accept s t → cost t < cost s) := by
+  intro hstrict
+  induction hw with
+  | here s u _ hA hc => exact absurd (hstrict s u hA) hc
+  | later _ _ _ htl ih => exact ih
+
 end Mimo

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Descent_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Descent_en.lean
@@ -144,4 +144,50 @@ theorem descent_target_before_ceiling
   ⟨hnostall _ hterm,
    Nat.lt_of_le_of_lt (descent_flips_le_barrier hstrict s₀ rest B hbarrier hL) hceiling⟩
 
+/-! ## Decay failure — the defect as a dissociation
+
+The chantier thesis (operation 11, "descend under budget"): a **decay
+failure** — an accepted flip that does not strictly decrease the cost — is not
+an experiment failure to discard, it is a **dissociation** to record: the object
+that makes the strict-decay hypothesis pay. Rather than a numeric residual (Loi I
+of the chantier: "the residual is not the witness"), we make it first-class — an
+extractable witness inside a run. -/
+
+/-- **Decay-failure witness** in a run: a pair of consecutive states whose flip
+is accepted but does not strictly decrease the cost. `here` carries the defect
+at the run boundary, `later` delegates it to the tail; a run may carry several
+witnesses (this is an existence). -/
+inductive DescentFailure (accept : σ → σ → Prop) (cost : σ → Nat) : List σ → Prop
+  | here (s u : σ) (rest : List σ) (hA : accept s u) (hc : ¬ cost u < cost s) :
+      DescentFailure accept cost (s :: u :: rest)
+  | later (s u : σ) (rest : List σ)
+      (hf : DescentFailure accept cost (u :: rest)) :
+      DescentFailure accept cost (s :: u :: rest)
+
+/-- **Strict decay ⇒ no witness.** If every accepted flip strictly decreases
+the cost, then a run of accepted states (`Run`) carries no decay failure: strict
+descent is exactly the negation of the witness. -/
+theorem run_strictdescent_excludes_failure
+    (hstrict : ∀ s t, accept s t → cost t < cost s)
+    {L : List σ} (hL : Run accept L) : ¬ DescentFailure accept cost L := by
+  induction hL with
+  | nil => intro hf; cases hf
+  | single => intro hf; cases hf
+  | cons s u rest _ _ ih =>
+    intro hf
+    cases hf with
+    | here _ _ _ hA hc => exact absurd (hstrict s u hA) hc
+    | later _ _ _ htl => exact ih htl
+
+/-- **A witness makes the hypothesis pay.** If a run carries a decay failure,
+the global strict-decay property is false: the witness is the object that
+demonstrates the violation, not a vague experiment failure. -/
+theorem failure_witness_denies_global_strict
+    {L : List σ} (hw : DescentFailure accept cost L) :
+    ¬ (∀ s t, accept s t → cost t < cost s) := by
+  intro hstrict
+  induction hw with
+  | here s u _ hA hc => exact absurd (hstrict s u hA) hc
+  | later _ _ _ htl ih => exact ih
+
 end Mimo_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-dotnet #12698

## Résumé

Sous-grain **C3** du chantier ICT #12206 (opération 11, « descendre sous budget ») : faire de `Descent.lean` une **primitive transversale** dont la face négative — l'**échec de décroissance** — est un objet de premier ordre (une **dissociation** enregistrée), pas un échec d'expérience à écarter.

Ajout au cœur Lean pur (sans Mathlib, cohérent avec la conception Phase 1) :

1. `DescentFailure` — **témoin d'échec de décroissance** : paire d'états consécutifs dont le flip est accepté mais ne fait pas strictement décroître le coût (`here` porte le défaut en tête du run, `later` le délègue à la queue). Témoin extractible, première classe.
2. `run_strictdescent_excludes_failure` — **stricte décroissance ⇒ aucun témoin** : la stricte descente est exactement la négation du témoin.
3. `failure_witness_denies_global_strict` — **un témoin fait payer l'hypothèse** : si un run porte un échec de décroissance, la propriété globale de stricte décroissance est fausse. C'est la Loi I du chantier appliquée à la descente : « le résidu n'est pas le témoin, le témoin est l'objet qui fait payer ».

Miroir i18n `Descent_en.lean` mis à jour (namespace `Mimo_en`, docstrings EN, preuves byte-identiques).

## Honnêteté — périmètre

- **Le canal d'enregistrement des dissociations est bien `docs/ict/dissociations-matrix.md` (dans le repo)** — mais il est **scopé aux notebooks ICT** (une entrée par `(notebook ICT, claim)`). `Descent.lean` est le lake **MIMO** (détection par descente à flips), un module distinct des notebooks ICT : y forcer une rangée serait une **erreur de catégorie** et violerait la discipline propre de la matrice (« pas de nouveau dispatch », « pas d'unification forcée »). L'enregistrement de l'échec de décroissance pour ce module se fait donc **au niveau formel Lean** — le témoin `DescentFailure` est l'objet enregistré (dissociation), pas la matrice ICT.
- **Pas de rebuild du lake ni de mathlib** : `Descent.lean` / `Descent_en.lean` restent sans import (cœur Lean 4 pur), conforme à la Phase 1. Les modules Mathlib (`Objective`, `Lmmse`) ne sont pas touchés.

## Preuves

- Compte `sorry` réel (`count_code_sorry.py --json`) : `MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean` → `distinct_code_sorry` **0 avant**, **0 après** (les 3 théorèmes sont prouvés, aucune régression).
- `check_i18n_siblings.py Descent_en.lean` : **1/1 byte-identical, 0 drift, 0 orphan, 0 unbuilt**.
- Typecheck compilation : `lean Descent.lean` et `lean Descent_en.lean` sous `leanprover/lean4:v4.32.1` → **exit 0** sur les deux siblings (module sans import, cœur Lean pur).
- **Lake build `Descent` : infra-bloqué (honnêtement déclaré).** Le `lake build Descent` a été lancé mais le **premier clone de mathlib4** est dégradé au moment du build (machine I/O-saturée, lane grothendieck `cache get` bloquée 35+ min, clone mathlib en cours > 25 min) — bouteille d'infra réseau/disque, **pas un échec du module** (Descent n'importe rien ; il typecheck via `lean` en quelques secondes). 👉 ai-01 à confirmer au **lake build local** avant merge (lean-merge-discipline §1 : le lake build local est le gate coordinator au merge). Si l'infra a re-calmé au moment de la revue, `wsl lake build Descent` depuis `MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean` doit passer.
- Proof integrity (CI `lean-axiom.yml`) : aucun `sorry`/`native_decide`/`Classical.choice` introduit — preuves constructives (`absurd`, `cases`, `induction`, `simp`). À confirmer au run CI.

## Dispositions réglementaires

- **B.1** : comptage `sorry` réel (pas `grep -c`) — 0/0 pour ce module, purement additif.
- **B.3** : état du job `proof-integrity` sur `mimo_lean` (à compléter après le build).
- **Anti-régression** : aucune preuve supprimée — uniquement 3 théorèmes ajoutés (additions > deletions).
- **Atomique** : 1 sujet (formalisation C3), 2 fichiers (FR + `_en`).

See #12206
