### PR TITLE
fix(ict,#12388): extract_sae_traces exclut les positions top-k non-finies (défaut BOS-inf 8B) + garde consommateur — script paramétré prêt pour le relais GPU-2

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/sae_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/sae_traces.py
@@ -80,6 +80,16 @@ def load_traces(path: str | Path) -> dict:
         missing = {"ids", "vals"} - set(entry)
         if missing:
             raise ValueError(f"trace {set_name}__{idx} incomplete : manque {missing}")
+        n_bad = int((~np.isfinite(entry["vals"])).sum())
+        if n_bad:
+            # Defaut BOS-inf du run 8B (#12388) : une trace portant des vals
+            # non-finies contamine les panneaux differentiels. Le producteur
+            # (extract_sae_traces.py corrige) exclut ces positions a la
+            # capture — une trace qui en porte est ANTERIEURE au correctif.
+            raise ValueError(
+                f"trace {set_name}__{idx} : {n_bad} vals non-finies — trace "
+                f"pre-correctif (#12388), regenerer via extract_sae_traces.py "
+                f"a jour (il exclut les positions non-finies a la capture)")
     return {"meta": meta, "prompts": prompts}
 
 

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_sae_traces_guard.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_sae_traces_guard.py
@@ -1,0 +1,61 @@
+"""Tests unitaires pour le garde-fou non-fini de ``ict.sae_traces.load_traces`` (#12388).
+
+Le defaut BOS-inf du run 8B-Qwen3 : un token (position 0) portait un residu
+dont TOUT le top-k SAE etait inf/nan. La trace commitee aurait contamine les
+panneaux differentiels (46/64 filtre-a-la-main vs 14/64 contamine). Le
+correctif agit aux deux bouts :
+
+* producteur : ``extract_sae_traces.py`` EXCLUT les positions non-finies a la
+  capture (aligne ids/vals/tokens) et abort au-dela de 5 % ;
+* consommateur : ``load_traces`` REFUSE une trace qui porte encore des vals
+  non-finies — c'est une trace PRE-correctif, il faut la regenerer.
+
+Ces tests attestent le contrat consommateur sur de vrais fichiers ``.npz``
+(ecrits en tmp, relus sans pickle — meme schema que les traces commitees).
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from ict import sae_traces as st
+
+
+def _write_trace(path, vals):
+    arrays = {
+        "setA__0__topk_ids": np.array([[0, 1], [2, 3]], dtype=np.int32),
+        "setA__0__topk_vals": np.array(vals, dtype=np.float16),
+        "setA__0__tokens": np.array(["a", "b"], dtype=str),
+    }
+    meta = json.dumps({"d_sae": 4, "k": 2, "layer": 18, "variant": "test"})
+    np.savez(path, __meta__=meta, **arrays)
+
+
+def test_load_traces_accepts_finite_trace(tmp_path):
+    """Cas nominal : une trace propre (0 val non-finie) passe la garde."""
+    p = tmp_path / "clean.npz"
+    _write_trace(p, [[1.0, 0.5], [0.8, 0.2]])
+    out = st.load_traces(p)
+    assert ("setA", 0) in out["prompts"]
+    assert out["meta"]["layer"] == 18
+
+
+def test_load_traces_refuses_nonfinite_vals_with_value_error(tmp_path):
+    """Defaut BOS-inf : une val non-finie (inf/nan) fait refuser la trace.
+
+    Le refus porte le diagnostic : trace pre-correctif, regenerer — pas un
+    message generique qui laisserait chercher la cause.
+    """
+    p = tmp_path / "bos_inf.npz"
+    _write_trace(p, [[float("inf"), float("inf")], [0.8, 0.2]])
+    with pytest.raises(ValueError, match="non-finies.*regenerer"):
+        st.load_traces(p)
+
+
+def test_load_traces_refuses_nan_vals(tmp_path):
+    """Variante nan du meme defaut : la garde couvre inf ET nan."""
+    p = tmp_path / "nan.npz"
+    _write_trace(p, [[float("nan"), 0.5], [0.8, 0.2]])
+    with pytest.raises(ValueError, match="non-finies"):
+        st.load_traces(p)

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_sae_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_sae_traces.py
@@ -630,13 +630,36 @@ def main() -> None:
                 model(**enc)
             hidden = capture.hidden                      # [T, d_model] fp32 CPU
             ids, vals = sae_encode_topk(hidden, sae, k=k)
+            toks = tokenizer.convert_ids_to_tokens(enc["input_ids"][0].tolist())
+            # Positions non-finies : un token (mesure : le BOS du 8B-Qwen3) peut
+            # porter un residu dont TOUT le top-k est inf/nan. Une telle ligne
+            # contamine les stats L0 et les panneaux differentiels en aval
+            # (#12388 : 46/64 filtre-a-la-main vs 14/64 contamine). On l'exclut
+            # a la capture, alignee sur ids/vals/tokens — la trace produite est
+            # propre par construction, quelle que soit la machine.
+            finite = torch.isfinite(vals).all(dim=-1)    # [T]
+            n_bad = int((~finite).sum())
+            if n_bad:
+                bad_pos = (~finite).nonzero().flatten().tolist()
+                if n_bad > 0.05 * vals.shape[0]:
+                    sys.exit(f"ERREUR: {set_name}__{i} : {n_bad}/{vals.shape[0]} "
+                             f"positions top-k non-finies (> 5%) — chargement de "
+                             f"poids probablement casse, pas un token isole. "
+                             f"Positions : {bad_pos[:10]}")
+                bad_toks = [toks[j] for j in bad_pos if j < len(toks)]
+                print(f"[warn] {set_name}__{i} : {n_bad} position(s) top-k "
+                      f"non-fini(es) EXCLUE(S) de la trace : pos {bad_pos[:5]} "
+                      f"tokens {bad_toks[:5]}")
+                hidden = hidden[finite]
+                ids = ids[finite]
+                vals = vals[finite]
+                toks = [t for t, f in zip(toks, finite.tolist()) if f]
             l0 = (vals > 0).sum(dim=-1).float()
             l0_all.append(l0)
             tok_total += hidden.shape[0]
             key = f"{set_name}__{i}"
             arrays[f"{key}__topk_ids"] = ids.numpy()
             arrays[f"{key}__topk_vals"] = vals.to(torch.float16).numpy()
-            toks = tokenizer.convert_ids_to_tokens(enc["input_ids"][0].tolist())
             # dtype unicode fixe (pas object) : le .npz committe se recharge sans
             # allow_pickle=True cote notebooks GPU-free.
             arrays[f"{key}__tokens"] = np.array(toks, dtype=str)


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/notebook-python #12701 — mission P1 ai-01 (DM 2026-08-24T23:23Z) : « il me manque ton script d'extraction paramétré pour lancer »

See #12388

## Summary

Le défaut BOS-inf du run 8B (mesuré par ai-01 au commentaire du 2026-08-23T11:21Z : « [trained] vals brutes non-finies : 50 » = 1 position dont TOUT le top-k est inf) est corrigé **aux deux bouts** :

1. **Producteur** (`scripts/extract_sae_traces.py`) : après `sae_encode_topk`, les positions dont le top-k est non-fini sont **exclues à la capture**, alignées sur ids/vals/tokens — la trace produite est propre par construction, quelle que soit la machine. Warning explicite nommant les positions et tokens exclus ; **abort à >5 %** de positions non-finies (un chargement de poids cassé ne doit pas produire une trace « presque propre »).
2. **Consommateur** (`ict/sae_traces.py::load_traces`) : une trace portant encore des vals non-finies est **refusée** avec diagnostic (« trace pré-correctif, régénérer ») — il devient impossible de committer par erreur une trace malade à l'avenir.

Le script restait **déjà paramétré** (`--model`, `--layer`/`--layer-frac`, `--sae-repo`, `--out-dir`, `--variant`, `--seed`, `--stage`, `--overwrite`) : c'est le correctif qui manquait, pas la paramétrisation.

## Validation

- `py_compile` producteur OK.
- Nouveau `ict/tests/test_sae_traces_guard.py` : **3/3 PASSED** (trace propre acceptée ; inf → ValueError avec diagnostic ; nan → ValueError).
- Régression consommateurs : `test_jlens_traces.py` + `test_feature_dynamics.py` = **24 passed**.
- Garde vérifiée sur les 6 traces committées (3 échelles × trained/control) : 0 val non-finie → toutes passent la garde (la sanction ne touient que les traces pré-correctif).

```
ict/tests/test_sae_traces_guard.py  3 passed in 0.09s
ict/tests/test_jlens_traces.py + test_feature_dynamics.py  24 passed in 0.21s
```

## Invocation 8B épinglée (pour ai-01, GPU-2, dès libération du créneau)

Depuis `MyIA.AI.Notebooks/IIT/ICT-Series/` (paramètres identiques au run initial — commentaire 2026-08-22T22:23Z, aucun ajustement de seuil) :

```bash
CUDA_VISIBLE_DEVICES=2 python scripts/extract_sae_traces.py \
  --model Qwen/Qwen3-8B-Base \
  --sae-repo Qwen/SAE-Res-Qwen3-8B-Base-W64K-L0_50 \
  --layer-frac 0.5 \
  --variant trained \
  --stage full --overwrite --out-dir traces
# puis idem --variant control
```

Attente du correctif : la ligne `[warn] ... position(s) top-k non-fini(es) EXCLUE(S)` apparaît sur le token malade (attendu : pos 0, le BOS) au lieu de laisser les 50 vals inf contaminer les panneaux — les traces régénérées sont commitables telles quelles (levée de la réserve du [RELEASED] du 2026-08-23T09:13Z).

## Scope

3 fichiers sous `MyIA.AI.Notebooks/IIT/ICT-Series/` : `scripts/extract_sae_traces.py`, `ict/sae_traces.py`, `ict/tests/test_sae_traces_guard.py` (nouveau).
