### PR TITLE
feat(genai,#12453): notebook 10c — strategies long contexte (mesures vLLM)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10c_Long_Context_Strategies.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10c_Long_Context_Strategies.ipynb
@@ -1,0 +1,1344 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b4f2e9bd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004437,
+     "end_time": "2026-08-24T00:02:30.953040+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:30.948603+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Navigation** : [Index](README.md) | [<< Précédent](10_LocalLlama.ipynb) | [Suivant >>](11_Quantization.ipynb)\n",
+    "\n",
+    "# 10c. Stratégies pour contextes longs — budget de tokens, biais de position, map-reduce, prefix caching\n",
+    "\n",
+    "**Durée estimée** : 50 minutes\n",
+    "\n",
+    "**Prérequis** : Notebook 1 (OpenAI Intro), 10 (Hébergement local — vLLM), compréhension du comptage de tokens.\n",
+    "\n",
+    "***\n",
+    "\n",
+    "## Objectifs\n",
+    "\n",
+    "Nos notebooks consomment des contextes de plus en plus longs (RAG multi-documents, PDF, conversations multi-tours). Pourtant, **aucun** ne répond à la question du *comment* : comment décider si un contexte tient dans la fenêtre servant, comment le modèle lit réellement une longue entrée, et comment économiser à la fois des tokens et de la latence.\n",
+    "\n",
+    "Ce notebook **mesure**, sur notre propre pile self-hosted (vLLM), quatre stratégies de gestion du long contexte :\n",
+    "\n",
+    "| # | Stratégie | Ce qu'on mesure |\n",
+    "|---|---|---|\n",
+    "| 1 | **Compter avant d'envoyer** | Le coût réel en tokens d'un corpus, la décision « ça tient / ça ne tient pas » |\n",
+    "| 2 | **Biais de position** | Le rappel d'un fait saillant en fonction de sa profondeur (needle-in-haystack → « lost in the middle ») |\n",
+    "| 3 | **Réordonnancement** | L'effet de placer le document critique au début / milieu / fin |\n",
+    "| 4 | **Map-reduce vs troncation** | La perte d'information quantifiée entre résumer-then-synthétiser et tronquer naïvement |\n",
+    "| 5 | **Coût réel (latence)** | Le gain de latence du **prefix caching** vLLM (cache hit = latence mesurée, pas affirmée) |\n",
+    "\n",
+    "> **Différenciateur.** Chaque courbe et chaque chiffre viennent d'une **exécution réelle** sur notre vLLM distant — pas d'un folklore, pas d'une valeur codée en dur. Sorties committées (C.2) : ce qu'un cours sur une API tierce ne peut pas montrer de l'intérieur.\n",
+    "\n",
+    "***\n",
+    "\n",
+    "## Pourquoi c'est un sujet à part entière\n",
+    "\n",
+    "Le découpage `chunks` du RAG, le `max_tokens` d'un appel, l'ordre des documents ingérés : tout cela repose sur l'hypothèse que le modèle « lit » uniformément sa fenêtre. Or cette hypothèse est **fausse**, et le coût de l'ignorer est double : on paie des tokens pour un contenu que le modèle n'utilise pas (biais de position), et on sous-exploite un cache capable de diviser la latence par deux (prefix caching).\n",
+    "\n",
+    "Ce notebook n'énonce pas ces faits — il les **fait mesurer**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "21499501",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:02:30.962812Z",
+     "iopub.status.busy": "2026-08-24T00:02:30.962410Z",
+     "iopub.status.idle": "2026-08-24T00:02:50.109329Z",
+     "shell.execute_reply": "2026-08-24T00:02:50.108235Z"
+    },
+    "papermill": {
+     "duration": 19.15316,
+     "end_time": "2026-08-24T00:02:50.110277+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:30.957117+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "vLLM : http://192.168.0.47:5002/v1 | modele : qwen3.6-35b-a3b\n",
+      "corpus Horla present : True\n",
+      "corpus Boule present : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "%matplotlib inline\n",
+    "# Imports, config de l'endpoint, et ancrage du repo (tout en un)\n",
+    "import os, json, time, random, statistics, re\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "import requests\n",
+    "\n",
+    "# --- 1) Endpoint self-hosted vLLM, lu depuis l'environnement (jamais en clair ici) ---\n",
+    "VLLM_BASE_URL = os.getenv(\"VLLM_BASE_URL\", \"http://192.168.0.47:5002/v1\")\n",
+    "VLLM_MODEL = os.getenv(\"VLLM_MODEL\", \"qwen3.6-35b-a3b\")\n",
+    "VLLM_API_KEY = os.getenv(\"VLLM_API_KEY\", None)\n",
+    "if not VLLM_API_KEY:\n",
+    "    # C'est un secret : il se fournit via une variable d'environnement au moment de l'exec,\n",
+    "    # jamais en dur dans le notebook (regle secrets-hygiene).\n",
+    "    raise ValueError(\"VLLM_API_KEY manquant — definir la variable d'env avant d'executer ce notebook.\")\n",
+    "\n",
+    "HEADERS = {\"Authorization\": f\"Bearer {VLLM_API_KEY}\", \"Content-Type\": \"application/json\"}\n",
+    "\n",
+    "# --- 2) Tokenizer reel (famille Qwen), chargé hors-ligne, reproductible ---\n",
+    "from transformers import AutoTokenizer\n",
+    "TOKENIZER = AutoTokenizer.from_pretrained(\"Qwen/Qwen2.5-0.5B-Instruct\", local_files_only=True)\n",
+    "\n",
+    "# --- 3) Ancrage du repo : on remonte jusqu'au dossier contenant MyIA.AI.Notebooks ---\n",
+    "def repo_root():\n",
+    "    p = Path.cwd()\n",
+    "    while not (p / \"MyIA.AI.Notebooks\").exists() and p.parent != p:\n",
+    "        p = p.parent\n",
+    "    return p\n",
+    "\n",
+    "ROOT = repo_root()\n",
+    "\n",
+    "def corpus_path(name):\n",
+    "    # le_horla et boule_de_suif sont des corpus deja suivis par git dans la serie Audio\n",
+    "    return ROOT / \"MyIA.AI.Notebooks\" / \"GenAI\" / \"Audio\" / \"04-Applications\" / name\n",
+    "\n",
+    "CORPUS_HORLA = corpus_path(\"datasets/le_horla_1887.txt\")\n",
+    "CORPUS_BOULE = corpus_path(\"boule_de_suif_full.txt\")\n",
+    "\n",
+    "print(\"vLLM :\", VLLM_BASE_URL, \"| modele :\", VLLM_MODEL)\n",
+    "print(\"corpus Horla present :\", CORPUS_HORLA.exists())\n",
+    "print(\"corpus Boule present :\", CORPUS_BOULE.exists())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "eb583182",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:02:50.119974Z",
+     "iopub.status.busy": "2026-08-24T00:02:50.119520Z",
+     "iopub.status.idle": "2026-08-24T00:02:50.136606Z",
+     "shell.execute_reply": "2026-08-24T00:02:50.135536Z"
+    },
+    "papermill": {
+     "duration": 0.023068,
+     "end_time": "2026-08-24T00:02:50.137500+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:50.114432+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "endpoint /models -> 200 | max_model_len (fenetre reelle du modele servi) : 262144\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Helpers : appel chat non-stream + stream (pour le TTFT), tokenizer, score\n",
+    "# Note modele « raisonnant » : qwen3.6-35b-a3b est un modele de type « thinking » — il emet\n",
+    "# d'abord un raisonnement (`message.reasoning`) puis seulement la reponse (`message.content`).\n",
+    "# Sans desactivation, les `max_completion_tokens` sont consommes par le raisonnement et la\n",
+    "# reponse reste `content=None` (finish_reason=length). On desactive donc le raisonnement :\n",
+    "# reponse directe, rapide et deterministe (crucial pour des mesures reproductibles).\n",
+    "_THINKING_OFF = {\"chat_template_kwargs\": {\"enable_thinking\": False}}\n",
+    "\n",
+    "def chat(prompt, system=None, max_tokens=256, temperature=0.0):\n",
+    "    # Appel chat/simple (non stream) -> contenu. Un maximum de determinisme pour les mesures.\n",
+    "    messages = []\n",
+    "    if system:\n",
+    "        messages.append({\"role\": \"system\", \"content\": system})\n",
+    "    messages.append({\"role\": \"user\", \"content\": prompt})\n",
+    "    payload = {\"model\": VLLM_MODEL, \"messages\": messages,\n",
+    "               \"max_completion_tokens\": max_tokens, \"temperature\": temperature, **_THINKING_OFF}\n",
+    "    r = requests.post(f\"{VLLM_BASE_URL}/chat/completions\", headers=HEADERS, json=payload, timeout=180)\n",
+    "    r.raise_for_status()\n",
+    "    # content peut rester None si la reponse est tronquee pendant le raisonnement ; avec\n",
+    "    # _THINKING_OFF ce ne devrait pas arriver, mais on ne fait jamais confiance au None.\n",
+    "    out = r.json()[\"choices\"][0][\"message\"].get(\"content\") or \"\"\n",
+    "    return out\n",
+    "\n",
+    "def chat_stream_ttft(prompt, system=None, max_tokens=32, temperature=0.0):\n",
+    "    # Appel stream -> (time_to_first_token, contenu). Le TTFT isole le cout de prefilling/cache.\n",
+    "    messages = []\n",
+    "    if system:\n",
+    "        messages.append({\"role\": \"system\", \"content\": system})\n",
+    "    messages.append({\"role\": \"user\", \"content\": prompt})\n",
+    "    payload = {\"model\": VLLM_MODEL, \"messages\": messages,\n",
+    "               \"max_completion_tokens\": max_tokens, \"temperature\": temperature,\n",
+    "               \"stream\": True, **_THINKING_OFF}\n",
+    "    t0 = time.perf_counter()\n",
+    "    first = None\n",
+    "    content = []\n",
+    "    with requests.post(f\"{VLLM_BASE_URL}/chat/completions\", headers=HEADERS, json=payload,\n",
+    "                       timeout=180, stream=True) as r:\n",
+    "        r.raise_for_status()\n",
+    "        for line in r.iter_lines():\n",
+    "            if not line:\n",
+    "                continue\n",
+    "            line = line.decode(\"utf-8\")\n",
+    "            if not line.startswith(\"data:\"):\n",
+    "                continue\n",
+    "            data = line[5:].strip()\n",
+    "            if data == \"[DONE]\":\n",
+    "                break\n",
+    "            try:\n",
+    "                delta = json.loads(data)[\"choices\"][0][\"delta\"].get(\"content\", \"\")\n",
+    "            except Exception:\n",
+    "                continue\n",
+    "            if delta:\n",
+    "                content.append(delta)\n",
+    "                if first is None:\n",
+    "                    first = time.perf_counter() - t0\n",
+    "    return (first if first is not None else time.perf_counter() - t0), \"\".join(content)\n",
+    "\n",
+    "def count_tokens(text):\n",
+    "    return len(TOKENIZER.encode(text))\n",
+    "\n",
+    "def simple_score(target, answer):\n",
+    "    # 1 si la reponse contient la cible (forme normalisee), sinon 0. Honnetete : on imprime les deux.\n",
+    "    answer = answer or \"\"  # jamais de None (modele raisonnant tronque)\n",
+    "    norm = lambda s: re.sub(r\"[^0-9a-zA-Z]\", \"\", s.lower())\n",
+    "    return int(norm(target) in norm(answer))\n",
+    "\n",
+    "# controle de l'endpoint + lecture de la fenetre REELLE du modele servi (honnete, pas supposee)\n",
+    "def ping():\n",
+    "    r = requests.get(f\"{VLLM_BASE_URL}/models\", headers=HEADERS, timeout=30)\n",
+    "    if r.status_code != 200:\n",
+    "        return r.status_code, None\n",
+    "    try:\n",
+    "        mlen = r.json()[\"data\"][0].get(\"max_model_len\")\n",
+    "    except Exception:\n",
+    "        mlen = None\n",
+    "    return r.status_code, mlen\n",
+    "\n",
+    "_ps, _mlen = ping()\n",
+    "print(\"endpoint /models ->\", _ps, \"| max_model_len (fenetre reelle du modele servi) :\", _mlen)\n",
+    "REAL_WINDOW = _mlen"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0109798",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004092,
+     "end_time": "2026-08-24T00:02:50.145604+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:50.141512+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Compter avant d'envoyer — le budget de tokens réel\n",
+    "\n",
+    "La première stratégie de gestion du long contexte n'est pas une astuce de modèle : c'est **ne pas dépasser la fenêtre**. Pour cela il faut savoir compter — non pas « à la louche », mais avec le **tokenizer réel** du modèle.\n",
+    "\n",
+    "On charge un vrai corpus (une œuvre du domaine public, déjà suivie par git dans la série Audio), on le tokenise, et on calcule ce que coûterait l'envoi de plusieurs documents d'un coup vs un par un. La décision « ça tient / ça ne tient pas » devient un calcul, pas une intuition.\n",
+    "\n",
+    "> **Fenêtre réelle vs budget de travail.** Nous travaillons ici sur un **budget volontairement borné** (32 768 tokens), bien plus petit que la **fenêtre réelle** du modèle servi — lue à l'exécution via `/models` (cellule suivante). C'est la situation réaliste d'un pipeline contraint en coût/latence, et c'est elle qui motive les stratégies de découpe des sections 2 à 5."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b3b473e6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:02:50.155457Z",
+     "iopub.status.busy": "2026-08-24T00:02:50.155044Z",
+     "iopub.status.idle": "2026-08-24T00:02:50.534400Z",
+     "shell.execute_reply": "2026-08-24T00:02:50.533005Z"
+    },
+    "papermill": {
+     "duration": 0.385973,
+     "end_time": "2026-08-24T00:02:50.535632+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:50.149659+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Le Horla : 244903 caracteres | 77204 tokens\n",
+      "Boule de Suif : 106431 caracteres | 33154 tokens\n",
+      "Fenetre reelle du modele servi (via /models) : 262144 tokens\n",
+      "Budget de travail choisi pour la demo        : 32768 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1.1 Charger le vrai corpus et le tokeniser\n",
+    "horla_text = CORPUS_HORLA.read_text(encoding=\"utf-8\", errors=\"ignore\")\n",
+    "boule_text = CORPUS_BOULE.read_text(encoding=\"utf-8\", errors=\"ignore\")\n",
+    "\n",
+    "print(\"Le Horla :\", len(horla_text), \"caracteres |\", count_tokens(horla_text), \"tokens\")\n",
+    "print(\"Boule de Suif :\", len(boule_text), \"caracteres |\", count_tokens(boule_text), \"tokens\")\n",
+    "\n",
+    "# Fenetre REELLE du modele servi (lue via /models, cellules precedentes). La demo travaille\n",
+    "# sur un budget de travail CHOISI (plus petit) pour illustrer un contenu qui le DEPASSE\n",
+    "# (contrainte de cout / latence / pipeline) — la fenetre reelle du modele est plus large.\n",
+    "WINDOW = int(os.getenv(\"VLLM_CONTEXT_WINDOW\", \"32768\"))\n",
+    "print(\"Fenetre reelle du modele servi (via /models) :\", REAL_WINDOW, \"tokens\")\n",
+    "print(\"Budget de travail choisi pour la demo        :\", WINDOW, \"tokens\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "71d5d1a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:02:50.551016Z",
+     "iopub.status.busy": "2026-08-24T00:02:50.550494Z",
+     "iopub.status.idle": "2026-08-24T00:02:50.657505Z",
+     "shell.execute_reply": "2026-08-24T00:02:50.656360Z"
+    },
+    "papermill": {
+     "duration": 0.116401,
+     "end_time": "2026-08-24T00:02:50.658574+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:50.542173+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Le Horla (chapitre 1)        ->   6349 tokens\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Le Horla (chapitre 2)        ->   6240 tokens\n",
+      "  Boule de Suif (debut)        ->   6089 tokens\n",
+      "\n",
+      "Total si on envoie tout d'un coup : 18678 tokens\n",
+      "Fenetre du modele servi          : 32768 tokens\n",
+      "Ca tient ?                       : True\n",
+      "Budget consomme                 : 57.0% de la fenetre\n",
+      "\n",
+      "avec reserve reponse = 512 tokens : 19190 <= 32768 ? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1.2 Le budget : « ça tient / ça ne tient pas »\n",
+    "# On simule l'ingestion de documents multiples (RAG multi-docs) et on calcule le coût total.\n",
+    "docs = {\n",
+    "    \"Le Horla (chapitre 1)\": horla_text[:20000],\n",
+    "    \"Le Horla (chapitre 2)\": horla_text[20000:40000],\n",
+    "    \"Boule de Suif (debut)\": boule_text[:20000],\n",
+    "}\n",
+    "for name, doc in docs.items():\n",
+    "    print(f\"  {name:28s} -> {count_tokens(doc):>6d} tokens\")\n",
+    "\n",
+    "total = sum(count_tokens(d) for d in docs.values())\n",
+    "print(f\"\\nTotal si on envoie tout d'un coup : {total} tokens\")\n",
+    "print(f\"Fenetre du modele servi          : {WINDOW} tokens\")\n",
+    "print(f\"Ca tient ?                       : {total <= WINDOW}\")\n",
+    "print(f\"Budget consomme                 : {total/WINDOW*100:.1f}% de la fenetre\")\n",
+    "\n",
+    "# Reservation a prevoir pour la reponse (max_completion_tokens)\n",
+    "reserve = 512\n",
+    "print(f\"\\navec reserve reponse = {reserve} tokens : {total + reserve} <= {WINDOW} ? {total + reserve <= WINDOW}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24048e4e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004372,
+     "end_time": "2026-08-24T00:02:50.667620+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:50.663248+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Sans compter, on pourrait envoyer 4 documents et « espérer » que ça passe. Avec le tokenizer réel, on sait : à `57.0 %` de la fenêtre, il reste `14 090` tokens, on réserve `512` pour la réponse, et on tranche. Si ça ne tient pas, il faut une stratégie de découpe — c'est exactement ce que les sections 2 à 5 explorent (l'ordre et le résumé plutôt que le bourrage naïf, et le cache plutôt que le re-calcul).\n",
+    "\n",
+    "> **Méthode honnête.** Le tokenizer embarqué est la famille Qwen (chargée hors-ligne, `local_files_only`), ce qui donne un comptage reproductible. Pour un coût *exact* au centime près, on utiliserait le tokenizer exact du modèle servi (exposable via `/tokenize`), mais l'ordre de grandeur — et la méthode de décision — sont identiques."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10b13c27",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004864,
+     "end_time": "2026-08-24T00:02:50.676637+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:50.671773+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Biais de position, mesuré — needle-in-haystack\n",
+    "\n",
+    "Lorsqu'un contexte est long, le modèle ne le lit **pas uniformément**. La façon la plus propre de le montrer est le **needle-in-a-haystack** : on insère un fait saillant (l'« aiguille ») dans une paille de texte réel, à une profondeur donnée, puis on demande au modèle de le rappeler. On répète à plusieurs profondeurs et plusieurs essais, et on trace **rappel vs position**.\n",
+    "\n",
+    "> **Protocole.** Pour chaque profondeur `d ∈ {0, 0.2, 0.4, 0.6, 0.8, 1.0}` et chaque essai `t ∈ {1,2,3}` : on découpe `Le Horla` en tranches de ~4000 tokens (graine différente par essai → paille différente, même profondeur), on insère l'aiguille à la position `d`, on interroge le modèle. Le **verdict est honnête** : si le creux du milieu apparaît, on le montre ; s'il n'apparaît pas, on le dit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "968c850d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:02:50.688443Z",
+     "iopub.status.busy": "2026-08-24T00:02:50.688003Z",
+     "iopub.status.idle": "2026-08-24T00:02:50.885194Z",
+     "shell.execute_reply": "2026-08-24T00:02:50.884128Z"
+    },
+    "papermill": {
+     "duration": 0.20505,
+     "end_time": "2026-08-24T00:02:50.886123+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:50.681073+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "profondeurs : [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "exemple de paille (tete) : Le code d'acces au coffre etait : 7 4 9. les vagues rumeurs des roseaux, les étranges feux follets, le silence profond qui les enveloppe dans les nuit\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2.1 Construire l'aiguille et la paille (real corpus, reproducible)\n",
+    "NEEDLE = \"Le code d'acces au coffre etait : 7 4 9.\"\n",
+    "def build_haystack(needle_pos, seed, hay_tokens=4000):\n",
+    "    # Renvoie (contexte, reponse_attendue) : une tranche du corpus avec l'aiguille inseree.\n",
+    "    rng = random.Random(seed)\n",
+    "    full_tokens = TOKENIZER.encode(horla_text)\n",
+    "    if len(full_tokens) <= hay_tokens:\n",
+    "        raise ValueError(\"corpus trop court pour la paille\")\n",
+    "    start = rng.randint(0, len(full_tokens) - hay_tokens)\n",
+    "    hay_token_ids = full_tokens[start:start + hay_tokens]        # paille (vraie prose)\n",
+    "    # on tokennise l'aiguille et on l'insere a la position fractionnaire\n",
+    "    needle_ids = TOKENIZER.encode(NEEDLE)\n",
+    "    insert_at = int(needle_pos * len(hay_token_ids))\n",
+    "    seq = hay_token_ids[:insert_at] + needle_ids + hay_token_ids[insert_at:]\n",
+    "    context = TOKENIZER.decode(seq)\n",
+    "    return context, \"7 4 9\"\n",
+    "\n",
+    "depths = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]\n",
+    "print(\"profondeurs :\", depths)\n",
+    "print(\"exemple de paille (tete) :\", build_haystack(0.0, 1)[0][:150].replace(chr(10), \" \"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d19a02e9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:02:50.897951Z",
+     "iopub.status.busy": "2026-08-24T00:02:50.897493Z",
+     "iopub.status.idle": "2026-08-24T00:02:58.194465Z",
+     "shell.execute_reply": "2026-08-24T00:02:58.193396Z"
+    },
+    "papermill": {
+     "duration": 7.305042,
+     "end_time": "2026-08-24T00:02:58.195469+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:50.890427+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depth  0.0 : [1, 1, 1] -> recall 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depth  0.2 : [1, 1, 1] -> recall 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depth  0.4 : [1, 1, 1] -> recall 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depth  0.6 : [1, 1, 1] -> recall 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depth  0.8 : [1, 1, 1] -> recall 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depth  1.0 : [1, 1, 1] -> recall 1.000\n",
+      "\n",
+      "--- reponses brutes (honnetete) ---\n",
+      "  d= 0.0 t=1 -> '749'\n",
+      "  d= 0.0 t=2 -> '749'\n",
+      "  d= 0.0 t=3 -> '749'\n",
+      "  d= 0.2 t=1 -> '749'\n",
+      "  d= 0.2 t=2 -> '749'\n",
+      "  d= 0.2 t=3 -> '749'\n",
+      "  d= 0.4 t=1 -> '749'\n",
+      "  d= 0.4 t=2 -> '749'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2.2 Mesurer le rappel par profondeur (real model calls)\n",
+    "def probe_depth(depth, trial, hay_tokens=4000):\n",
+    "    seed = 1000 * trial + int(depth * 1000)\n",
+    "    ctx, expected = build_haystack(depth, seed, hay_tokens)\n",
+    "    prompt = f\"D'apres le document suivant, quel est le code du coffre ? Reponds uniquement par le nombre.\\n\\n--- DOCUMENT ---\\n{ctx}\\n--- FIN ---\"\n",
+    "    ans = chat(prompt, max_tokens=256)\n",
+    "    return simple_score(expected, ans), ans\n",
+    "\n",
+    "results = {}            # profondeur -> taux de rappel\n",
+    "raw_answers = []        # trace honnete des reponses\n",
+    "for depth in depths:\n",
+    "    scores = []\n",
+    "    for trial in range(1, 4):\n",
+    "        sc, ans = probe_depth(depth, trial)\n",
+    "        scores.append(sc)\n",
+    "        raw_answers.append((depth, trial, ans.strip()))\n",
+    "    results[depth] = sum(scores) / len(scores)\n",
+    "    print(f\"depth {depth:4.1f} : {scores} -> recall {results[depth]:.3f}\")\n",
+    "\n",
+    "print(\"\\n--- reponses brutes (honnetete) ---\")\n",
+    "for d, t, a in raw_answers[:8]:\n",
+    "    print(f\"  d={d:4.1f} t={t} -> {a!r}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "16c34548",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:02:58.205623Z",
+     "iopub.status.busy": "2026-08-24T00:02:58.205257Z",
+     "iopub.status.idle": "2026-08-24T00:02:58.335045Z",
+     "shell.execute_reply": "2026-08-24T00:02:58.333842Z"
+    },
+    "papermill": {
+     "duration": 0.135786,
+     "end_time": "2026-08-24T00:02:58.335862+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:58.200076+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhwAAAFUCAYAAABvHeXgAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASrNJREFUeJzt3QmcjfX7P/6LwQxlZ+y7Inv29aNEZIs20QcJlSWiIpSJsqSIZMleWpAin2iQkjAoWyIkhDKD7MtYxv17vK7//z7f+5w5M3POmfue7byej8dhzn3Ouc/7XPd23e/lvjMZhmEIERERkYMyOzlzIiIiImDCQURERI5jwkFERESOY8JBREREjmPCQURERI5jwkFERESOY8JBREREjmPCQURERI5jwkFERESOY8JBCbrvvvv0EYyefvppKV26tE/vfeONNyRTpkySVhw9elTLs2DBAtvmifnhd6Z0bO0sM+KBaYiP0+t469atpXfv3pKWpVQ87Fx3rOv3u+++K8HqqI8xiIyMlDvvvFNOnz4taQETDps3XvORJUsWKVasmO5c//7779QuHiXT1atXdae5fv361C5KmlrfKb5NmzbJmjVrZOjQoaldFEoF06dPtzXZT45WrVpJ+fLlZdy4cZIWZEntAmQ0o0ePljJlykhsbKxs2bJFV7yNGzfKb7/9JmFhYaldPPLR7Nmz5fbt224Jx6hRo/RvzzPA1157TV599dUUL2NGia1Trl27pol/SnvnnXfkgQce0B09pd5ySM2Eo0CBAnqymRY899xz8vLLL+v+K2fOnKlaFtZw2Oyhhx6S//73v9KrVy+ZM2eOLug///xTVqxYkdpFIz9kzZpVQkNDfXovdqZMJp2JbXJgmaT0ge7UqVOycuVKeeKJJ1L0e9Oy1FgO9H8effRRuX79unzxxReS2phwOKxJkyb6P5IO040bN2TkyJFSq1YtyZ07t9xxxx36vh9++CHBdrr33ntPSpUqJdmzZ5emTZtqjYkVsmm01R0+fFhatmyp8yxatKjWuHjeEBhnl5MnT5bKlSvrzqBQoUKaBZ87d87v31elShW5//77403Hd6BJ6bHHHnNNW7Rokf5mZNm5cuWSqlWrypQpUxKdvz8xgO+//15jid+fJ08eefjhh+X33393e8+lS5fkxRdf1H4EOPCFh4dLixYtZMeOHV77GaAMBQsW1L9xlmA2m5nt0t76cNy6dUvefPNNKVeunH4H5jV8+HDd8K0wvW3btloLVrduXV0eZcuWlY8//lh8cf78eS0r1iP83u7du+s0b/bv36/LI1++fPo9tWvXtjUR/vrrr6VNmza63uE347cjBnFxcUn24fj333+la9euul6Yv2P37t3x+qIk1MfA2zwD7TuAZRQREaE1FPgdJUqUkCFDhsRbdt4g2cCyb968udcmKDS3DB48WNcnrKMdO3b02r7+7bffutZjbC+I6969ewNepvhss2bNdNspXry4vPXWWz7XMiUnHt6Wg7m9HDp0SJcbljfW3x49emhNoj9mzZrl2sbq1KkjP//8s9vrv/76q34HtinEp3DhwvLMM8/o+mbCfhflWbZsWbz5f/bZZ/paVFSUPo+OjtZyIob4ziJFiug+xuwHg3UQsf7xxx9d+wlzfT179qyegGK/h3011nWcoGI994QacsTp7rvv1nLjex555BG344gn7OefffZZyZYtm3z11Veu6di/VatWTbfP1Ma002Hmipg3b17XtIsXL2rtR+fOnbVjGQ6Ac+fO1URh27ZtUqNGDbd54OCD9/Tr109XRByksfPYs2ePJgsm7NjRZle/fn2ZMGGCdhjCjgI7QCQeJiQX2AFiwxkwYIAcOXJEPvjgA9m5c6fuEHEG6qtOnTrphoENERuzCQfQf/75R5588kl9vnbtWv29qGp+++23dRoSAXzfwIEDk/weX2Lw3Xff6QaMnQvKhKrcqVOnSqNGjTSZMA9Izz//vCxdulT69+8vlSpV0p0Pyovy1KxZM9534+AwY8YM6dOnjx4gsOEDNuKEoIbro48+0oPBSy+9JFu3btV2VHyH544NO168r2fPnnqgnTdvnu4kkZwhKUxsB4OdHcqO33TPPffovDEPT9gJIg5IAtH8gwPZkiVLpEOHDvLll1/q70ourFPYkeKAiv+R/CGxxvqOZoaE4MDXrl07XfcR44oVK+rO0dvvcBrK0r59e40pdt6IKdYxJLsHDx6U5cuXJ/r5zZs3S/78+TUx9uaFF17QfQG2S+wbkPhjPVy8eLHrPQsXLtTfjv0BthUchLH+NW7cWLdRcz32dZli28RJAfYD5vtwoEby4XQ8EoNaIDQ/Y7vA9ol9Ig6O5v4hKUgGsE/A/gwHduzzsG3ipMvch2G/g+fY12H/hJjht+N/NHmbCQGSqE8//TTedoBpSGgaNGjgqi3AZ7EcsRxQo4XvOHbsmD7H8sRrWP9HjBihnzH3T4cPH9Z4Pf744/q7Y2Ji5MMPP9STp3379mmibu7HcRKybt063X9i/4jfie/BSRbK4wmfQSKF9Qj7ACSoVtiXJGdZ2cYgW8yfPx/VCMZ3331nnD592jh+/LixdOlSo2DBgkZoaKg+N926dcu4fv262+fPnTtnFCpUyHjmmWdc044cOaLzzJ49u3HixAnX9K1bt+r0QYMGuaZ1795dp73wwguuabdv3zbatGljZMuWTcsEP/30k77v008/dfv+yMjIeNObNm2qj8QcOHBAPzd16lS36X379jXuvPNO4+rVq/p84MCBRq5cufS3+8OfGNSoUcMIDw83/v33X9e03bt3G5kzZza6devmmpY7d26jX79+iX4v4lmqVCnXc8QP3xcRERHvvZhm3ZR27dqlz3v16uX2vpdfflmnf//9965p+A5M27Bhg2vaqVOndJ156aWXEi3j8uXL9bMTJkxwTUN8mzRpotOxTpoeeOABo2rVqkZsbKzb+tGwYUPjrrvuMpKS0G+3Mpe11XPPPWfkyJHD7Xs9Y/vll1/q/CdPnuyaFhcXZzRr1ize70honfScp7cym9so1qmE5rdw4UJdX7CdWM2cOVM/u2nTpkRj0LhxY6NWrVrxppvf3bx5c427CetvSEiIcf78eX1+6dIlI0+ePEbv3r3dPh8dHa3rrXW6r8v0xRdf1O/GNmNdxzA/p+PhbTmY24t1XwcdO3Y08ufP7/M+Ae89e/asa/rXX3+t0//3v/8luk5+/vnn8ba5YcOG6TZnLgczRlmyZHGVHftofO6dd95JtHyVK1f2uo7Gxsbqeu35W/C9o0ePdk2bN2+efs+kSZPizcNcd8wYoCw3b940OnXqpPvI1atXey3T2LFj9f0xMTFGamKTis1QlYozYmTMOGvF2QSqOFEFZwoJCdFqL/MMAlVtOPtAdai1Wt+EMxacxZhQ9V6vXj1ZtWpVvPfibMmE7B3P0YSDs39AOx6qL9GEcObMGdcDGTCycs9mnaSgyg81MtYzNGTbqEHAWat5FoVq0ytXrmiWHoikYnDy5EnZtWuX1gygetmEWgj8VmusUBbUOKAGxgnmd+FM3wo1HWa1uxVqWcymN8D6U6FCBT0jSup70DaOWgHruoUzLCusX6htwBklzpTMZY6aHZxF//HHH7aMpLKeMZvfg9+FM3RU/ScENXE4I7UOI82cObPWZqU0bB84i0cti3X7QG0aJLV9IKbW2kxPqCWwNr8hPthe/vrrL32O7QNNYqgNtH4/livWd/P7/VmmWE9Q64ltxrqOPfXUU47HIzGolbNCLFB+1Ij5WrtqjbW5DVm3G+s6iZpRlB2xAOu+tlu3btpEhP2WCfs07JfRJ8+cF/bbGKkWSPNzaGiorteAZY7fin0utnVrWVA7hU6nntsxeDbdYt+OGpNvvvlGl/ODDz7o9bvNOOH3pyY2qdhs2rRpehC+cOGCVo1v2LDBawc5VLdPnDhRd8Q3b950TUdVm6e77ror3jR8B6pPrbAyoznB833Wph3siFA2VF16gypCf2HDR/8E7OCQFGCDxHww3dS3b18tL5o88B5sGNhZognIF0nFwNxhY+P1hB3m6tWrNeFBAoiqV1RZIylEooVrJmCH4xm7QKEsWBaeoxRQpYtkxyyrqWTJkl53EEnt1DAftO1ip2XlGQM02eBE8/XXX9eHN1he1oQuEKhqxogdHAg9DxpY55L6HTly5HCbnhqjPLB9oNnL7LMTyPbh2WcqsWVtHgjMZY3vB/OA7gnt/v4uU8QXyYonb9tKoPFAAoSDnwkHZ5zYJCaxWOB3JjXPpGJplgv9rtB/zHPZWddJJFToA4ImFDRtAv5GcmKuh9iPo7kHJw5oJsFraPrAvsPanJyQ27dva1MwRrGgGdvatwnNcCb008Cy8aWjLZqjLl++rH1+Ert+irlOpvZQdiYcNsNZBGoqzLNytLt26dJFDhw44DowfPLJJ3omjtdfeeUVPfjjDAYrT2KdguyAlR7fh43Jm4R2LIlBYjFs2DA9G0JnTCQB2DFYkwl8J2ogcODHxoHH/PnzdWNF8pWSkOjgbAhtnbheAvoXYEeCjlZIiOzi68aNZe/vgcsfZudAdFjD2a83yT2446wcbdE4UKC/ENqZ0dkNZ264HoVdw2ARU29x8eyYGiiUE536Jk2a5PV1JKmJwYEjsUQxqWVtxgn9OLwdxMyDUEosU3/igb4T6ChpQkKf1LUokopFUvP0ZbvBto5+NdjPoiYW+2D8JuybPNdJ7IvQX+LEiRNa24E+HujbZoX9G2pu0R8C+zIke9hvI8m+9957E/29Y8eO1fejrwU6U6MmFicmmGeg2weWPWoIcRKFhCOh0XLmOomak9TEhMNBZhKBDltYcc1rNaDaDmfTOMBZD0roSOaNedZjhQ5bnr3ysdKiOtGs1TDfB+Z7cSBA8wo6m/nSacwXqJVBooUqSDTh4HchmfKs2UF1JDZWPFBW1Hqg0xQ2wqR2jknFwOykh8TOE2qRsKGhdsOEM2p8Px4480Fn0TFjxiSYcPhzZoCy4PehzKhdMaGTGA7MCXUo9Bfmg45lOMOx1nJ4xsCsuUGzhefoCbugVgtVxFj2//nPf1zTcSbny+9A1TyaXqy1HDiL94SzWG9NTZ61RoHC9oFRA+jcHMjZIM6UUSWenO83E/TElpU/yxTx9bb9eNtWAo0HamutiZbZATI5kjtPfBbbB2o40HnZ5C0WgA6aaAb9/PPPtcM5YmutpbXGBLUceGBeSGRQVpxIQkJxWrp0qR4LMEDACvsEayKA+aPJFzXfSXXgRy0LmqZQ04KmFZxEeasZwXaI7wjkhNJO7MPhMGSdOBij9zLaEK2ZuTUTxwpmDr3yhGza2saO3vx4v7eDozUjx/zxHCstdhhmxo+zQWTYntBemdCQyqRgw8QZAZqR0E7ouaFah6EBMntzlIcvw+uSigESCGz4qC2x/gb06kYtBppNAL/ds3ofO3fszBIrh3kg9CU+5ndhmVuZZ4mePcgDhe/BMsMIBhN+H0bmeP4+rIdI7tDXxZMdlz32tk6jOhzVx76cpWHniguCmZCwoXnSE3bGSCCtZcYBEaOd7IDtA+uZtSwmHITQLJcYjGbAgS6p/jeJxQK1RDgbtja1mszf7c8yxXqCbRPbjPX1hGo5A4kHmiaR+JgP9EtKruTO09s66W27NOGAjP0JEgfEBrUg1kQACbG5D7eujxi2bN134MTG234iJCQkXllQK+zZfwojYbAP9axd8fZbALFBkxFqOjC03Fttyfbt210jbVITazhSAKrzkH2iOtDMRnEmiCFYOPgg+5w5c6ZuUDhb9YSzfzTNoHMgVmxsMKi6xVh4K1SnYaVD1SPabNFsgQ6K6F9hZrao9sYwMtS8oIkDfSmQkCBTx8qPNkbrtTN8hR0TqnfxQFWh51kXhomiPRVt0+hAizNSHBiRJFhrARLiSwzQNIIdBjYstMOaw2LRvGNeBwAd7PD9+I3Vq1fXmgHU+GD8Ps5SEoLaICwf1OKgBgm/EdcgwcMT5otlgOF3ZlMDdvZIhlDz4+26JYFATRFqqlBzhj46KB/WK2/9JXDwRvxQPY7OmThDRo0LklxUIXu7FoA/GjZsqLUP+N0Yao2zPDQL+NIshJggKccZI2o1UEuAjtZYXzzPGFEdjcQNB2YsY9ROYdvB8GFfOxsmBjtsNAliO0WtC+KLJA5JDqajGt1sMvUG2zPOMLFOoYOov5BsIIFEOVDrhrNubLsYdoltGeUxD0S+LlNsI1gWOICiycAcFouaD1ynwsl4pCbEErVtaG5A8ob+LDj5SKzWDc0q5v7P86QMNao4ccO+DtsaljNqFBBzc/i/mShhGeJaJ9hvITnEfq9t27ba3IghutheMLwYiY1n3zGUAZcBQG0L9hto/kVih3UKNbIYCu9tGzKbqPG7kYiasI1gOadGJ+x4UnWMTAZiDnv7+eef472GoVDlypXTB4YtYmgThilhGB+GRN17773GN998E29on3Xo08SJE40SJUro+zHsEcM9rfDZO+64w/jzzz+NBx98UIciYpgthnR5DsWCWbNm6fA9DKXKmTOnDq8bMmSI8c8///g1LNaqUaNGXoeDAoYIo1wYtophuiVLltQhkydPnkx0nv7EADAsGeXA78Iw3Hbt2hn79u1zvY7hyK+88opRvXp1/d2IGf6ePn16ksMsN2/erDFD+a1D/TyHxQKGqo0aNcooU6aMkTVrVi03ht5ZhzACvgNDlz35GnsMAe7atav+VgxzxN87d+6MN5wUsG5geHDhwoW1TMWKFTPatm2ry8aOYbEYIlm/fn2NfdGiRXV9wjA9fPaHH35INLYYdtylSxddJvgdTz/9tM4Pn120aJHbez/55BOjbNmyuhwwFBrfYdewWLhx44bx9ttv6/BGrGt58+bV5Y7leeHChSRj1b59ex2y6sv+AXHxjI85vWXLlhqLsLAw3XcgJr/88ktAy/TXX3/V34l54T1vvvmmMXfu3BSJR0LDYs2h+p4xspYnqX1CUt+FofQYbouhxojl448/rvu4hNZn7B/w+/Dea9euub125swZHU5fsWJF3W/gPfXq1TOWLFkSbwgztmmsy/geM56xsbE61L1IkSK6jWA/FRUV5TXmGM47YsQI1/4Dy/exxx7T5Z1YDLAfw3QMwTfNmDFDjwcXL140UhsTjjQssQ3Lk5lwBHMMKGNZtmyZLvuNGzca6Qmu74BrVxw8eDC1i0J+wokCrp3keY2Q9KxGjRp6LZa0gH04iCjVofnLyuyLguphb1d/TctQBY6mSlTlU/qCvmLo34KmiYwgMjJSm8sxijAtYB8OIkp1uMgRkg70v0EfHfRFwXBGdJ60azRVSkL/KUo/0AEd/RzQbwPDW9HvKiNo1aqV136BqYUJBxGlOnSqQ6ddXDERIwHQ2Q41HNYr5xI5BZ08MToFndiTun4IBS4T2lWS8XkiIiKiJLEPBxERETmOCQcRERE5Luj6cOAqbLhLKK4Ol9o3siEiIkrP0CsDF1TE1ZrNu+EmJOgSDiQbSd2AiYiIiHx3/PhxvYpzYoIu4UDNhhkc81bPdtWcYPw2LkOcVJZHvmFM7ceY2o8xtR9jmn7iilsK4CTePLYmJugSDrMZBcmG3QkHhvNhntxA7MGY2o8xtR9jaj/GNP3F1ZcuClySRERE5DgmHEREROQ4JhxERETkOCYcRERElLETjg0bNki7du10/C46nOBOfUlZv3693j0yNDRU77eQFq57H3fbkC2H/5U1+8/q/3hOycOY2o8xtR9jaj/GNOPGNVVHqVy5ckWqV68uzzzzjDzyyCNJvv/IkSPSpk0bef755+XTTz+VdevWSa9evaRIkSLSsmVLSQ2Rv52UUf/bJycvxJqllCK5wySiXSVpVaVIqpQpvWNM7ceY2o8xtR9jmrHjmmZu3oYajmXLlkmHDh0SfM/QoUNl5cqV8ttvv7mmPfnkk3L+/HmJjIz0ecxw7ty55cKFC8keFouF2OeTHeIZQHNw0Iz/1uRG4ifG1H6Mqf0YU/sxpukzrv4cU9PVdTiioqKkefPmbtNQs/Hiiy+meFlQHYWM0Vu2Zvz/C/ONFfukUfkCEpKZl1D3NaYRK/YypjZiTO3HmNqPMU29uOI41qJS4RSJa7pKOKKjo6VQoUJu0/AcGda1a9cke/bs8T5z/fp1fZjwXvMCKHgEauvhfy3VU94XZvTFWKn6xpqAv4PcMab2Y0ztx5jajzF1Lq44jm09fEbql80f0Dz8OY6mq4QjEOPGjZNRo0bFm47Lu+KKa4E6dOJsMktGRESU+g6dOC1l74wL6LO4cVuGTDgKFy4sMTExbtPwHO1G3mo3YNiwYTJ48OB4133HteST04ej/OUQ7XiTlHnda0ndMvkC/p5gsu3IWXnmo+1Jvo8x9R1jaj/G1H6MaerGtXzxghIeHlgNR1hYWMZMOBo0aCCrVq1ym7Z27VqdnhAMn8XDE64jn5xrydcrW0B7+UZfiPXaPobWsMK5w6RphUJsc/QRYsWY2osxtR9jaj/GNHXjiuNZ5gDj6s9xNFWvw3H58mXZtWuXPsxhr/j72LFjrtqJbt26ud6P4bCHDx+WIUOGyP79+2X69OmyZMkSGTRoUIqXHSs9hhSB52Iyn+N1bhy+Y0ztx5jajzG1H2MaHHFN1YTjl19+kXvvvVcfgKYP/D1y5Eh9fvLkSVfyAWXKlNFhsajVwPU7Jk6cKHPmzEm1a3BgKBGGFCFDtMJzDuEKDGNqP8bUfoyp/RjTjB/XNHMdjpRi53U4rEOP0MsXHW/QFobqKWbiycOY2o8xtR9jaj/GNH3F1Z9jKhMOm2Bo0KlTpyQ8PDxZfUPo/zCm9mNM7ceY2o8xTT9x9eeYyiVJREREjmPCQURERI5jwkFERESOY8JBREREjmPCQURERI5jwkFERESOY8JBREREjmPCQURERI5jwkFERESOY8JBREREjmPCQURERI5jwkFERESOY8JBREREjmPCQURERI5jwkFERESOY8JBREREjmPCQURERI5jwkFERESOY8JBREREjmPCQURERI5jwkFERESOY8JBREREjmPCQURERI5jwkFERESOyxLIh44dOyZ//fWXXL16VQoWLCiVK1eW0NBQ+0tHREREwZVwHD16VGbMmCGLFi2SEydOiGEYrteyZcsmTZo0kWeffVYeffRRyZyZFSdERET0f3zKDAYMGCDVq1eXI0eOyFtvvSX79u2TCxcuyI0bNyQ6OlpWrVoljRs3lpEjR0q1atXk559/9mW2REREFCR8quG444475PDhw5I/f/54r4WHh0uzZs30ERERIZGRkXL8+HGpU6eOE+UlIiKijJpwjBs3zucZtmrVKjnlISIiogzI784W165d086iJnQenTx5sqxevdrushEREVGwJhwPP/ywfPzxx/r3+fPnpV69ejJx4kTp0KGDdiolIiIiSnbCsWPHDh2RAkuXLpVChQppLQeSkPfff9/f2REREVEQ8DvhQHNKzpw59e81a9bII488osNg69evr4kHERERUbITjvLly8vy5ct1JAr6bTz44IM6/dSpU5IrVy5/Z0dERERBwO+EA9faePnll6V06dLaf6NBgwau2o57773XiTISERFRsCUcjz32mF7a/JdfftFrbpgeeOABee+99/wuwLRp0zR5CQsL0wRm27Ztib4fI2IqVKgg2bNnlxIlSsigQYMkNjbW7+8lIiKiNH4vlcKFC+vDqm7dun7PZ/HixTJ48GCZOXOmJhtIJlq2bCkHDhzQC4p5+uyzz+TVV1+VefPmScOGDeXgwYPy9NNPS6ZMmWTSpEmB/BQiIiJKKwkHOoYuWLBA+2jg78R89dVXPn85koTevXtLjx499DkSj5UrV2pCgcTC0+bNm6VRo0bSpUsXfY6akc6dO8vWrVt9/k4iIiJKowlH7ty5tRbB/NsOuA/L9u3bZdiwYa5pGO3SvHlziYqK8voZ1Gp88skn2uyCGhVcbh33cenatWuC33P9+nV9mC5evKj/3759Wx92wbxwQzs75xnsGFP7Mab2Y0ztx5imn7j6My+fEo758+d7/Ts5zpw5I3FxcXodDys8379/v9fPoGYDn8ON4hC0W7duyfPPPy/Dhw9P9LLso0aNijf99OnTtvb9QNBxQzuUi3fLtQdjaj/G1H6Mqf0Y0/QT10uXLjnbhyO1rF+/XsaOHSvTp0/XPh+HDh2SgQMHyptvvimvv/6618+gBgX9RKw1HOhsWrBgQVuH8WJBohYI8+UGYg/G1H6Mqf0YU/sxpuknrhjw4WjCgSuMLlmyREeroGnE80qkvihQoICEhIRITEyM23Q89+yQakJSgeaTXr166fOqVavKlStX5Nlnn5URI0Z4DWBoaKg+POG9dq/IWJBOzDeYMab2Y0ztx5jajzFNH3H1Zz5+fyMuX45Onmj62Llzp/alwG3r0Z/ioYce8nk+2bJlk1q1asm6devcsi88N6/t4e0qp54/DkkLoIqIiIiI0ia/Ew40Z8yaNUumTp2qScOQIUNk7dq1MmDAAG0b8geaOmbPni0fffSR/P7779KnTx+tsTBHrXTr1s2tU2m7du30BnGLFi2SI0eO6Pei1gPTzcSDiIiI0h6/m1TQjILRIoCLb5kdRtDUgfupfPDBBz7Pq1OnTtp5E1cvjY6Olho1aujFxMyOpPgua43Ga6+9ptVB+P/vv//WdigkG2PGjPH3ZxAREVFaTjjQv+Ls2bNSqlQpKVmypGzZskWqV6+uNQ6BNGv0799fHwl1EnUrbJYsEhERoQ8iIiLKwE0qzZo1kxUrVujfaPrApcVbtGihtRUdO3Z0ooxEREQUbDUc6L9hXuijX79+2mEUVwBt3769PPfcc06UkYiIiIIt4fAcTvPkk0/qg4iIiMi2JhV06ty4caPb3V7R2RNXAT137py/syMiIqIg4HfC8corr7juR7Jnzx4d2tq6dWvtNGq9oicRERFRwE0qSCwqVaqkf3/55Zc6LBWXG8cVRpF4EBERESW7hgMX+8IVP+G7776TBx98UP/Oly+fq+aDiIiIKFk1HLhTK5pOGjVqpLeJX7x4sU4/ePCgFC9e3N/ZERERURDwu4YDVxLFBbhwAzdcZrxYsWI6/dtvv5VWrVo5UUYiIiIKthoOXF30m2++iTf9vffes6tMREREFOw1HOgcitEppq+//lo6dOggw4cPj3ereiIiIqKAEg5cTRT9NQC3pMdFv3LkyCFffPGF3jmWiIiIKNkJB5INXOgLkGT85z//kc8++0wWLFigw2SJiIiIkp1w4I6w5r1UMCzWvPZGiRIl5MyZM/7OjoiIiIKA3wlH7dq15a233pKFCxfKjz/+KG3atHFdEKxQoUJOlJGIiIiCLeGYPHmydhzt37+/jBgxQsqXL6/TMUy2YcOGTpSRiIiIgm1YbLVq1dxGqZjeeecdCQkJsatcREREFMw1HHD+/HmZM2eODBs2TM6ePavT9u3bJ6dOnbK7fERERBSMNRy//vqrPPDAA5InTx45evSo9O7dW++j8tVXX8mxY8fk448/dqakREREFDw1HLiPSo8ePeSPP/6QsLAw13SMVtmwYYPd5SMiIqJgTDh+/vlnvfiXJ9xTJTo62q5yERERUTAnHKGhoV5vQ48LghUsWNCuchEREVEwJxzt27eX0aNHy82bN/V5pkyZtO/G0KFD5dFHH3WijERERBRsCcfEiRPl8uXLEh4eLteuXZOmTZvqtThy5swpY8aMcaaUREREFFyjVHLnzi1r166VTZs2ye7duzX5qFmzpjRv3tyZEhIREVHwJRymRo0a6YOIiIjIkQt/EREREfmDCQcRERE5jgkHEREROY4JBxEREaW9hCMuLs7t+datW/WS5uZ1OYiIiIgCTjhOnjwpjRs31iuN4tob586dk7Zt20qDBg3kvvvukypVquh7iIiIiAJOOHAlUcMwZNmyZVKkSBFNNnCJ8+PHj+tdY3FZc174i4iIiJJ1HY7vvvtOb0Ffv359vf5GgQIF9AJguGkb4HLnuFU9ERERUcA1HGhCMZOLfPnySY4cOaRUqVKu13F5czapEBERUbISDtw7xZpQ9O/fXxMPa0Jyxx13iL+mTZsmpUuXlrCwMKlXr55s27Yt0fefP39e+vXrp8066E9y9913y6pVq/z+XiIiIkqDCUeNGjUkKirK9Xz8+PFuCcfGjRulWrVqfn354sWLZfDgwRIRESE7duyQ6tWrS8uWLeXUqVNe33/jxg1p0aKF9hlZunSpHDhwQGbPnu2qeSEiIqJ03ofj66+/TvT1OnXq6OgVf0yaNEn7ffTo0UOfz5w5U1auXCnz5s2TV199Nd77Mf3s2bOyefNmyZo1q05D7QgRERFl0Ju3eapbt65f70dtxfbt22XYsGGuaZkzZ9a7zlprUqxWrFihw3DRpIIECCNjunTpoiNoQkJCvH7m+vXr+jBhZA3cvn1bH3bBvDCKx855BjvG1H6Mqf0YU/sxpuknrv7My6eEY8uWLTo6xRdXr16VI0eOSOXKlRN935kzZ/QiYoUKFXKbjuf79+/3+pnDhw/L999/L0899ZT22zh06JD07dtXLzqGZhlvxo0bJ6NGjYo3/fTp0xIbGyt2Bv3ChQu6MJE4UfIxpvZjTO3HmNqPMU0/cb106ZK9CUfXrl2lbNmy0qtXL2ndurXXzqH79u2TTz75RObPny9vv/12kglHoMFC59VZs2ZpjUatWrXk77//lnfeeSfBhAM1KOgnYq3hKFGihNaO5MqVy9ayZcqUSefLDcQejKn9GFP7Mab2Y0zTT1wx4MPWhAPJxIwZM+S1117TJgyMDClatKh+EUanoEbi8uXL0rFjR1mzZo1UrVo1yXniOh5IGmJiYtym43nhwoW9fgYjU9B3w9p8cs8990h0dLQ20WTLli3eZzCSBQ9PCLbdKzIWpBPzDWaMqf0YU/sxpvZjTNNHXP2Zj0/vxEF+wIABOioE/SvQ0ROXMsfoEFzW/MMPP5R//vlHPv/8c5+SDUBygBqKdevWuWVfeI5+Gt7ggmNoRrG2GR08eFATEW/JBhEREaXTTqO1a9fWhx3Q1NG9e3edHzqdTp48Wa5cueIatdKtWzdNatAPA/r06SMffPCBDBw4UF544QX5448/ZOzYsZoMERERURCMUglEp06dtPPmyJEjtVkE1/qIjIx0dSQ9duyYW3UN+l6sXr1aBg0apNf8QDKC5AOjVIiIiCjtStWEw7xiKR7erF+/Pt40NLdg1AwRERGlH+yNQ0RERI5jwkFERESOY8JBREREaaMPx/vvv+/zDDlihIiIiAJKON577z2fLyjChIOIiIgCSjhwbxQiIiKiFO/DgUuJ48qjt27dCvjLiYiIKDj4nXDgbrA9e/aUHDly6A3acHEuwJU/x48f70QZiYiIKNgSDtx9dffu3XpRLutd4po3by6LFy+2u3xEREQUjFcaXb58uSYW9evX106iJtR2/Pnnn3aXj4iIiIKxhgP3PgkPD483HTddsyYgRERERAEnHLiz68qVK13PzSRjzpw5Cd5WnoiIiIKb300quB38Qw89JPv27dMRKlOmTNG/N2/eLD/++KMzpSQiIqLgquFo3Lix7Nq1S5ONqlWrypo1a7SJJSoqSmrVquVMKYmIiCj4bk9frlw5mT17tv2lISIiogwpoIQjLi5Oli1bJr///rs+r1Spkjz88MOSJUtAsyMiIqIMzu8MYe/evdK+fXuJjo6WChUq6LS3335bChYsKP/73/+kSpUqTpSTiIiIgqkPR69evfSaGydOnJAdO3bo4/jx41KtWjV59tlnnSklERERBVcNBzqM/vLLL5I3b17XNPw9ZswYqVOnjt3lIyIiomCs4bj77rslJiYm3vRTp05J+fLl7SoXERERBXPCMW7cOBkwYIAsXbpUm1XwwN8vvvii9uW4ePGi60FEREQUUJNK27Zt9f8nnnjCdZVRwzD0/3bt2rme4zWMZiEiIiLyO+H44YcfnCkJERERZVh+JxxNmzZ1piRERESUYQV0pa5z587J3Llz3S781aNHD8mXL5/d5SMiIqJg7DS6YcMGKV26tLz//vuaeOCBv8uUKaOvERERESW7hqNfv37SqVMnmTFjhoSEhOg0dA7t27evvrZnzx5/Z0lEREQZnN81HIcOHZKXXnrJlWwA/h48eLC+RkRERJTshKNmzZquvhtWmFa9enV/Z0dERERBwO8mFVz0a+DAgVqbUb9+fZ22ZcsWmTZtmowfP15+/fVX13txfxUiIiIivxOOzp076/9Dhgzx+hou+MULfxEREVGyEo4jR474+xEiIiIKcn4nHKVKlXKmJERERJRhBXThL9i3b58cO3ZMbty44Ta9ffv2dpSLiIiIgjnhOHz4sHTs2FGvt2H21wDzRm7st0FERETJHhaLESq4quipU6ckR44csnfvXr3CaO3atWX9+vUSCIxwwdVLw8LCpF69erJt2zafPrdo0SJNdDp06BDQ9xIREVEaTTiioqJk9OjRUqBAAcmcObM+GjduLOPGjdMhs/5avHixXjQsIiJCduzYodfyaNmypSY0iTl69Ki8/PLL0qRJE7+/k4iIiNJ4woEmk5w5c+rfSDr++ecfV2fSAwcO+F2ASZMmSe/evfXmb7gJ3MyZM7XmZN68eYmW4amnnpJRo0ZJ2bJl/f5OIiIiSuMJR5UqVWT37t36N5o/JkyYIJs2bdJaD38P/uhwun37dmnevPn/FShzZn2OmpSE4LvCw8OlZ8+e/hafiIiI0kOn0ddee02uXLniOvC3bdtWmzXy58+vzSP+OHPmjNZWFCpUyG06nu/fv9/rZzZu3Chz586VXbt2+fQd169f14fp4sWL+v/t27f1YRfMCx1o7ZxnsGNM7ceY2o8xtR9jmn7i6s+8/E440L/CVL58eU0Mzp49K3nz5nWNVHHKpUuXpGvXrjJ79mxtzvEF+pag6cXT6dOnJTY21tagX7hwQRcmamko+RhT+zGm9mNM7ceYpp+44rjsSMJx8+ZNyZ49u9YuoGnFlC9fPgkEkgbcaTYmJsZtOp4XLlw43vv//PNP7Szarl27eNlVlixZtA9JuXLl3D4zbNgw7ZRqreEoUaKEFCxYUHLlyiV2QTmQcGG+3EDswZjajzG1H2NqP8Y0/cQVo0sdSTiyZs0qJUuWtO1aG9myZZNatWrJunXrXENbERA879+/f7z3V6xYUa//4dnEgwxrypQpmkh4Cg0N1Ycnc4SNnbAgnZhvMGNM7ceY2o8xtR9jmj7i6s98/G5SGTFihAwfPlwWLlwYcM2GFWofunfvrtfxqFu3rkyePFn7iGDUCnTr1k2KFSumTSPIpKw1K5AnTx7933M6ERERpR1+JxwffPCB3pq+aNGiOhT2jjvucHsd19LwR6dOnbQ/xciRIyU6Olpq1KghkZGRro6kuHw6M1wiIqIgSzicuKonmk+8NaFAUlcvXbBgge3lISIiolROOHBFUCIiIiJ/sK2CiIiIHMeEg4iIiBzHhIOIiIgcx4SDiIiI0m7CgRuv4cqet27dsrdERERElOH4nXBcvXpV79KKW8hXrlxZr5MBL7zwgowfP96JMhIREVGwJRy4NwluT4/rY1ivoY5byvt7t1giIiIKDn5fh2P58uWaWNSvX9/t7rCo7cDN1YiIiIiSXcOBy5CHh4fHm477nzh9e3oiIiIKkoQDN1lbuXKl67mZZMyZM0caNGhgb+mIiIgoOJtUxo4dKw899JDs27dPR6jgtvD4e/PmzfLjjz86U0oiIiIKrhqOxo0by65duzTZqFq1qqxZs0abWKKioqRWrVrOlJKIiIiCq4YDypUrJ7Nnz7a/NERERBS8CcfFixd9nmGuXLmSUx4iIiIK1oQjT548Po9AiYuLS26ZiIiIKBgTjh9++MH199GjR+XVV1+Vp59+2jUqBf03PvroIxk3bpxzJSUiIqKMnXA0bdrU9ffo0aNl0qRJ0rlzZ9e09u3bawfSWbNmSffu3Z0pKREREQXPKBXUZuBaHJ4wbdu2bXaVi4iIiII54ShRooTXESq48BdeIyIiIkr2sNj33ntPHn30Ufn222+lXr16Og01G3/88Yd8+eWX/s6OiIiIgoDfNRytW7fW5AL9Ns6ePauPdu3aycGDB/U1IiIiIlsu/FW8eHEZM2ZMIB8lIiKiIOR3DQcRERGRv5hwEBERkeOYcBAREZHjmHAQERFR2ks49u/fn+Brq1evTm55iIiIKAPyO+GoWbOmTJs2zW3a9evXpX///vLwww/bWTYiIiIK1oRjwYIFMnLkSL3mRkxMjOzatUvuvfde+e677+Snn35yppREREQUXAnHE088Ibt375abN29K5cqV9Y6xuLnbjh07pE6dOs6UkoiIiIKz0+iNGzckLi5OH0WKFJGwsDB7S0ZERETBm3AsWrRIb0WfO3duvZz5ypUr9bb0TZo0kcOHDztTSiIiIgquhKNnz54yduxYWbFihRQsWFBatGghe/bskWLFikmNGjWcKSUREREF171U0FejQoUKbtPy5s0rS5YskYULF9pZNiIiIgrWGg7PZMOqa9euARUCw2xLly6t/UBwy3vc7j4hs2fP1uYbJDl4NG/ePNH3ExERUTqs4XjmmWcSfX3evHl+zW/x4sUyePBgmTlzpiYbkydPlpYtW8qBAwckPDw83vvXr18vnTt3loYNG2qC8vbbb8uDDz4oe/fu1WYdIiIiygA1HOfOnXN7nDp1Sr7//nv56quv5Pz5834XYNKkSdK7d2/p0aOHVKpUSROPHDlyJJi4fPrpp9K3b1/tL1KxYkWZM2eO3L59W9atW+f3dxMREVEareFYtmxZvGk44Pfp00fKlSvn99Da7du3y7Bhw1zTMmfOrM0kUVFRPs3j6tWrek2QfPny+fXdRERElIYTDm+QJKBZ5L777pMhQ4b4/LkzZ87odTwKFSrkNh3PE7tni9XQoUOlaNGimqR4g8uu42G6ePGiK0nCwy6Yl2EYts4z2DGm9mNM7ceY2o8xTT9x9WdetiQc8Oeff8qtW7ckJY0fP16vC4J+HQldeGzcuHEyatSoeNNPnz4tsbGxtgb9woULujCRgFHyMab2Y0ztx5jajzFNP3G9dOmScwkHajKsUPCTJ0/qBcC6d+/u17wKFCggISEhek8WKzwvXLhwop999913NeHAPVyqVauW4PvQXGMtM2o4SpQoodcQyZUrl9i5IDNlyqTz5QZiD8bUfoyp/RhT+zGm6Seu/lxl3O+EY+fOnW7PUWgUfuLEiUmOYPGULVs2qVWrlnb47NChg04zO4Di7rMJmTBhgowZM0ZWr14ttWvXTvQ7QkND9eEJ5bZ7RcaCdGK+wYwxtR9jaj/G1H6MafqIqz/z8Tvh+OGHH8ROqH1AzQgSh7p16+qw2CtXruioFejWrZsOd0XTCGAYLO5W+9lnn+m1O6Kjo3X6nXfeqQ8iIiJKe2zrwxGoTp06aX8KJBFIHjDcNTIy0tWR9NixY24Z1IwZM3R0y2OPPeY2n4iICHnjjTdSvPxERETkUMKxdOlSvZQ5kgEc/D0vfe4vNJ8k1ISCDqFWR48e9Xv+RERElLr8bsR5//33tbkDNRDoz4FmkPz58+udYh966CFnSklERETBlXBMnz5db0c/depU7fSJ626sXbtWBgwYoMNtiIiIiJKdcKAZBfcxgezZs7vG4OLGbZ9//rm/syMiIqIg4HfCgetjnD17Vv8uWbKkbNmyRf8+cuSIXpODiIiIKNkJR7NmzWTFihX6N/pyDBo0SFq0aKGjTTp27Ojv7IiIiCgI+D1KBf03zGun9+vXTzuMbt68Wdq3by/PPfecE2UkIiKiYEs4Tpw4oZcGNz355JP6QHPK8ePHtZmFiIiIKFlNKmXKlNELdXlCvw68RkRERJTshAM1GbgWu6fLly/7dRMXIiIiCh4+N6mYd1xFsvH6669Ljhw5XK/FxcXJ1q1b9bLkRERERAEnHOZdYlHDsWfPHr3olwl/V69eXV5++WVfZ0dERERBJIu/d4nFUNgpU6ZIrly5nCwXERERBfMolfnz5ztTEiIiIsqw/O40SkREROQvJhxERETkOCYcRERE5DgmHEREROQ4JhxERETkOCYcRERE5DgmHEREROQ4JhxERETkOCYcRERE5DgmHEREROQ4JhxERETkOCYcRERE5DgmHEREROQ4JhxERETkOCYcRERE5DgmHEREROQ4JhxERETkOCYcRERE5DgmHEREROQ4JhxERETkOCYcRERE5DgmHEREROQ4JhxEREQUHAnHtGnTpHTp0hIWFib16tWTbdu2Jfr+L774QipWrKjvr1q1qqxatSrFykpERETpMOFYvHixDB48WCIiImTHjh1SvXp1admypZw6dcrr+zdv3iydO3eWnj17ys6dO6VDhw76+O2331K87ERERJROEo5JkyZJ7969pUePHlKpUiWZOXOm5MiRQ+bNm+f1/VOmTJFWrVrJK6+8Ivfcc4+8+eabUrNmTfnggw9SvOxERETkmyySim7cuCHbt2+XYcOGuaZlzpxZmjdvLlFRUV4/g+moEbFCjcjy5cu9vv/69ev6MF28eFH/v337tj7sgnkZhmHrPIMdY2o/xtR+jKn9GNP0E1d/5pWqCceZM2ckLi5OChUq5DYdz/fv3+/1M9HR0V7fj+nejBs3TkaNGhVv+unTpyU2NlbsDPqFCxd0YSJpouRjTO3HmNqPMbUfY5p+4nrp0qX0kXCkBNSeWGtEUMNRokQJKViwoOTKlcvWBZkpUyadLzcQezCm9mNM7ceY2o8xTT9xxeCNdJFwFChQQEJCQiQmJsZtOp4XLlzY62cw3Z/3h4aG6sMTgm33iowF6cR8gxljaj/G1H6Mqf0Y0/QRV3/mk6pLMlu2bFKrVi1Zt26dWwaG5w0aNPD6GUy3vh/Wrl2b4PuJiIgo9aV6kwqaO7p37y61a9eWunXryuTJk+XKlSs6agW6desmxYoV074YMHDgQGnatKlMnDhR2rRpI4sWLZJffvlFZs2alcq/hIiIiNJswtGpUyftwDly5Ejt+FmjRg2JjIx0dQw9duyYW5VNw4YN5bPPPpPXXntNhg8fLnfddZeOUKlSpUoq/goiIiJKTCYD3VWDCDqN5s6dW3vq2t1pFBcrCw8PZ5ujTRhT+zGm9mNM7ceYpp+4+nNM5ZIkIiIixzHhICIiIscx4SAiIiLHMeEgIiKijD9KJaWZfWTNe6rY2RkHl3jFVdfYyckejKn9GFP7Mab2Y0zTT1zNY6kv40+CLuEwr/uOy5sTERFR8uHYitEqiQm6YbHI8P755x/JmTOnXuLVLuY9Wo4fP27rcNtgxpjajzG1H2NqP8Y0/cQVKQSSjaJFiyZZaxJ0NRwISPHixR2bPxYiNxB7Mab2Y0ztx5jajzFNH3FNqmbDxMYxIiIichwTDiIiInIcEw6bhIaGSkREhP5P9mBM7ceY2o8xtR9jmjHjGnSdRomIiCjlsYaDiIiIHMeEg4iIiBzHhIOIiIgcx4TDD9OmTZPSpUvrZWHr1asn27ZtS/T9X3zxhVSsWFHfX7VqVVm1alWKlTUjxnT27NnSpEkTyZs3rz6aN2+e5DIIRv6up6ZFixbpxfA6dOjgeBkzekzPnz8v/fr1kyJFimgHvbvvvpvbfzJjOnnyZKlQoYJkz55dL141aNAgiY2NTbHypnUbNmyQdu3a6QW4sB0vX748yc+sX79eatasqeto+fLlZcGCBc4WEp1GKWmLFi0ysmXLZsybN8/Yu3ev0bt3byNPnjxGTEyM1/dv2rTJCAkJMSZMmGDs27fPeO2114ysWbMae/bsSfGyZ5SYdunSxZg2bZqxc+dO4/fffzeefvppI3fu3MaJEydSvOwZJaamI0eOGMWKFTOaNGliPPzwwylW3owY0+vXrxu1a9c2WrdubWzcuFFju379emPXrl0pXvaMEtNPP/3UCA0N1f8Rz9WrVxtFihQxBg0alOJlT6tWrVpljBgxwvjqq68wEMRYtmxZou8/fPiwkSNHDmPw4MF6jJo6daoesyIjIx0rIxMOH9WtW9fo16+f63lcXJxRtGhRY9y4cV7f/8QTTxht2rRxm1avXj3jueeec7ysGTWmnm7dumXkzJnT+OijjxwsZcaPKeLYsGFDY86cOUb37t2ZcCQzpjNmzDDKli1r3LhxIwVLmbFjivc2a9bMbRoOlI0aNXK8rOmR+JBwDBkyxKhcubLbtE6dOhktW7Z0rFxsUvHBjRs3ZPv27VqFb71EOp5HRUV5/QymW98PLVu2TPD9wSaQmHq6evWq3Lx5U/Lly+dgSTN+TEePHi3h4eHSs2fPFCppxo7pihUrpEGDBtqkUqhQIalSpYqMHTtW4uLiUrDkGSumDRs21M+YzS6HDx/WJqrWrVunWLkzmqhUOEYF3b1UAnHmzBndWWDnYYXn+/fv9/qZ6Ohor+/HdAospp6GDh2q7ZWeG02wCiSmGzdulLlz58quXbtSqJQZP6Y4GH7//ffy1FNP6UHx0KFD0rdvX02OcdGlYBdITLt06aKfa9y4sd4s7NatW/L888/L8OHDU6jUGU90Asco3ODt2rVr2lfGbqzhoHRp/Pjx2slx2bJl2umM/Ic7PHbt2lU74xYoUCC1i5Oh7kiNGqNZs2ZJrVq1pFOnTjJixAiZOXNmahct3ULnRtQSTZ8+XXbs2CFfffWVrFy5Ut58883ULhr5gTUcPsDOOCQkRGJiYtym43nhwoW9fgbT/Xl/sAkkpqZ3331XE47vvvtOqlWr5nBJM25M//zzTzl69Kj2bLceLCFLlixy4MABKVeunASzQNZTjEzJmjWrfs50zz336BklmhOyZcsmwSyQmL7++uuaHPfq1UufY9TflStX5Nlnn9VkLqnbopPvxyjcRdaJ2g3gUvIBdhA4U1m3bp3bjhnP0VbrDaZb3w9r165N8P3BJpCYwoQJE/SsJjIyUmrXrp1Cpc2YMcWQ7T179mhzivlo37693H///fo3hh4Gu0DW00aNGmkzipm8wcGDBzURCfZkI9CYor+WZ1JhJnS8O0dgUuUY5Vh31Aw4jAvDshYsWKBDiJ599lkdxhUdHa2vd+3a1Xj11VfdhsVmyZLFePfdd3UIZ0REBIfFJjOm48eP16F0S5cuNU6ePOl6XLp0KRV/RfqOqSeOUkl+TI8dO6ajp/r3728cOHDA+Oabb4zw8HDjrbfeSsVfkb5jiv0nYvr555/rcM41a9YY5cqV09GA9P/BfhCXDMADh/ZJkybp33/99Ze+jngirp7DYl955RU9RuGSAxwWm4ZgnHLJkiX1oIdhXVu2bHG91rRpU91ZWy1ZssS4++679f0YfrRy5cpUKHXGiWmpUqV0Q/J8YGdEga+nVkw47Inp5s2bdRg8DqoYIjtmzBgdfkyBxfTmzZvGG2+8oUlGWFiYUaJECaNv377GuXPnUqn0ac8PP/zgdf9oxhH/I66en6lRo4YuA6yn8+fPd7SMvFssEREROY59OIiIiMhxTDiIiIjIcUw4iIiIyHFMOIiIiMhxTDiIiIjIcUw4iIiIyHFMOIiIiMhxTDiIiIjIcUw4KEPAvRYeffRRvfFQpkyZ5Pz5845919NPPy0dOnSQtGLBggWSJ0+eVP1NuJunE3G/77775MUXX3Q9L126tEyePNn1HN+5fPnyZH8Pbg6GG4Gl9eVm1+9NS9544w29Lbr52/xdF3FDPKwXv/zyi6PlpORjwkEZwkcffSQ//fSTbN68WU6ePCm5c+dO7SKla9jp40Dgq4YNGzoSd9yG3OlbkOMurlOmTNG7jlpNmzZND2RhYWFSr1492bZtm2QEyUlQx4wZo8s6R44cyU5y4ffff5dRo0bJhx9+qOvPQw89pMsCZfTnZnAvv/yyDB06NNnlIWcx4aA0DWcvvsCt1nEL8CpVquhtl3G2FAy/O63ATt+JuOfLl09y5swpTpozZ44eREuVKuWatnjxYhk8eLBERETIjh07pHr16tKyZUs5deqUBDOsl48//rj06dPHlvlhu4WHH35Y15/Q0FBNWv1NZp566inZuHGj7N2715ZykTOYcFCKQfV4//799YGdSoECBbQq23o7H5xR4oy2W7du2jxiVnN/+eWXUrlyZd0h4T0TJ050my+eb9iwQQ94eA7nzp3T+eTNm1fPyHD29Mcff8Q701u9erUmK3feeae0atVKz7RMcXFxeuDB+/Lnzy9DhgyJdzts3Fp73LhxUqZMGcmePbsenJYuXRrve6xQdWw9OKM2oUaNGnrww3xwVp0QzK9kyZL6mzp27Cj//vtvvPd8/fXXUrNmTZ1P2bJl9Szy1q1bEqiFCxdK7dq19eCPA0OXLl3cDr7emlRmz56tt7g3yzlp0iS3OHirOkfzibn8vDWpJOX48ePyxBNP6PcgWcGB7OjRo4l+ZtGiRdKuXTu3aShr7969pUePHlKpUiWZOXOm/o558+ZJoOxabmZNANY1vMe6rnlbDrt27dJpiANex2+6cOGCTsPDn5oslGfQoEFStWpVSS58rxl33Hre3B481wusAwMGDNBtD8sU659nmbGNN2rUSJclpV1MOCjFmz6yZMmi1dOoOsWOHQdZq3fffVcP2jt37tSEZPv27XoQefLJJ2XPnj26s8F0s9oV1e44ODRo0EB3xnhu7rjQrrtixQqJiorSRKF169Zy8+ZNt74f+D4cUJGwHDt2TKtnTUhk8D040OAM6uzZs7Js2TK38iLZ+Pjjj/WghDMs7JD/+9//yo8//uhXbA4dOqSJFcqPg4Q3W7dulZ49e2rShvfcf//98tZbb7m9B01LSLQGDhwo+/bt0+pq/AZUhwcKMUMiuHv3bk2WcPBCfBOyadMmef7557UMKGeLFi2S9f2+lhG1EEiKEAOUwUwiE6oxwvJEjJBMmfBerHPNmzd3TcMBEc+xHplw0Mf8E3ogQXZiuWHdR38lLAuc2WO7QNOEL1CTgz4wSOaxreBhXd/tkFhM8MB6Afje+fPn699mWRLbb9xxxx0axwkTJsjo0aNl7dq1bu+pW7euxpDSMEfvRUtkgVsj33PPPcbt27dd04YOHarTrLeg79Chg9vnunTpYrRo0cJt2iuvvGJUqlTJ9XzgwIFut14+ePCg3pp506ZNrmlnzpwxsmfPbixZskSf41bMeM+hQ4dc75k2bZpRqFAh1/MiRYoYEyZMcLtNdvHixV23cI+NjTVy5MihtyO36tmzp9G5c2fX9+TOndvt9WXLlul3myIiIoysWbMap06dSjSGmGfr1q3dpnXq1Mlt/g888IAxduxYt/csXLhQf4tdt6X/+eeftfyXLl1yuzW2ebtwlKlNmzZun3nqqafcyuntOz2XI/7GNOv68d5777me4zsRS/M3VqhQwW39un79ui7z1atXe/0dO3fu1HkcO3bMNe3vv//WaZ7LFOscbqNuOnHihPHHH38k+Dh69Kjtyw3lev75593eU69ePaNPnz5el4P1Nx45ciTB9dFfic0jsZjgERMTk+B24G29wDrQuHFjt/fUqVNH9x1WU6ZMMUqXLp2s30XOypLaCQ8Fl/r167s1JaBWArUIaLoICQnRadazTcDZG6rGrVB9ijM16+c8P4OaFHT2M6FJpEKFCm5ng6jeLleunOt5kSJFXE0FqHbGWZd1Hpgnymc2q6BWArUkOIO3wlnyvffe61ds0IegYMGCib4HZUd1vBViGBkZ6XqOM1+c3VvPjBGn2NhYLSt+s79wxo+aJcwbTVVoRgLUCKHJwdOBAwfilRNnoN988404BWXD8vDs84HfbfYV8HTt2jX9P7EmrIQUK1bM5/faudzwOc/5JFQjlhrKly9v+zyrVavm9ty6nZrQxIQ4UdrFhIPSHFSdppSsWbO6PUcy5NlHIzGXL1/W/1euXBnvAIT+JmZ1vOc8rc06dv9ulAlt7Y888ki81wI5sF65ckWbKvD49NNPNSlCooHnyenc6mtc/PndtWrV0jJ6SiiRQz8iQBJlvgfTkMTGxMS4vRfP0X/A2qSSWBU+Ekh/OjHasdwQU7DGNTkxDQSaTRKD5kY0PyZ3OzWTXmvzWFIJO6UuJhyUotAGa7Vlyxa56667vNZSmNChE2d+Vnh+9913J/g5fAad7fB9aLcGdNLDmbe3M3Jv0LEVZ1KYx3/+8x+dhnnibB8d+wDzQmKBA3DTpk29zgc7wUuXLumB20wqAj0jxe/yFkMrlA2/064zzf3792vsxo8fr51AIalrHqAm6eeff3ab5vkccfntt9/cpiEungcXX+F3Y3RJeHi49lHwBWq38F70mcD6ZI64QeKybt06V+dFHNzwHH0wTOh7ZNaQeGP9HXYuN3wOfT2sz83aNPOAi5o5dKT0tq7h96HmxClJrdu+Lht/YV3yt1aRUhYTDkpRODBj1Mdzzz2nww2nTp3qNuLEm5deeknq1KmjnRY7deqkHfc++OADmT59eoKfQRKDZhh0JkXnO1Szv/rqq1oL4dk8kxh04MOBFvOrWLGidnK1jgDAfNH5DR1FcVBq3LixNsUgIcKOtXv37tokg+rw4cOHa297HHj8uc6AFT6P5iR0dMXvwAgba7U8jBw5Utq2basjIh577DE960V1PXbInh0VfYH54CCFZYUOf5hPUtfGeOGFFzRJQ7wwEuH777+Xb7/91q05rVmzZvLOO+9oh1s0C3zyySfJOmigAyXmh7igU2Hx4sXlr7/+0k64GOGA557MzqDoEGwdGYF1FMsOzWdoCkLzHRJGjPAIpEnFzuX2xRdfaLmwrqE2Bx2w586dq68hWUFSiOYvNM0cPHgw3vaFUV6oTUEChc7ZWDd9bWbD9ouaBPyPpMVMLvC9Zs2GE00qvkBtk9PXbKFkcriPCJFb56++fftqp7dcuXIZefPmNYYPH+7Wyc+zU6Bp6dKl2kkUHStLlixpvPPOO4l2NoSzZ88aXbt21c5t6DjYsmVL7Uxq8qUzJzqJYt4ob548eYzBgwcb3bp1c+vUhvJPnjxZOyyifAULFtTv+vHHH93mW758eS1H27ZtjVmzZsXrNFq9enWf4jh37lztuIp5tWvXznj33Xfj/Y7IyEijYcOG+h6UHZ0d8Z2Bdhr97LPPtENeaGio0aBBA2PFihVafnRITKizIr6vWLFiWgZ0BH7rrbeMwoULu8135MiR2kkX5R80aJDRv3//gDuNwsmTJ3X5FChQQMtatmxZo3fv3saFCxcS/G2rVq3ScsbFxblNnzp1qq5r2bJl0/ht2bLFSA47lht+Lzo2oxM1fh+WyeLFi93msXHjRqNq1apGWFiY0aRJE+OLL75w6zQK2Abz58+v07HuAf5HfBOD9QSf8Xxg+QfC106j1nUA8DreZ0IHX2yfV69eDagclDIy4Z/kJi1EvsB4elxrwnppagoeqG1C80xaG7qIXSBqoVBL1blzZwlWqNFBDVSgtW+pCTWfqK1BLSKlXWxSISJHoPkAo3fQbwXNKbiWQmLNYKkFB9lZs2bpNV6CFZIuXBQMTUvpDTou40JkSBgpbWMNB6UY1nAEF1ysDQcxdJjFFTHRr8O86BMRBR8mHEREROQ4XtqciIiIHMeEg4iIiBzHhIOIiIgcx4SDiIiIHMeEg4iIiBzHhIOIiIgcx4SDiIiIHMeEg4iIiBzHhIOIiIjEaf8PPhsqx+MTMTwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 550x350 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "verdict : rappel debut=1.00 fin=1.00 milieu=1.00 -> creux 1.00 vs bords 1.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2.3 Courbe rappel vs position\n",
+    "def plot_recall(results, title, ax=None):\n",
+    "    if ax is None:\n",
+    "        fig, ax = plt.subplots(figsize=(5.5, 3.5))\n",
+    "    xs = [k for k in sorted(results)]\n",
+    "    ys = [results[k] for k in xs]\n",
+    "    ax.plot(xs, ys, \"o-\", color=\"tab:blue\")\n",
+    "    ax.set_xlabel(\"profondeur de l'aiguille (0=debut, 1=fin)\")\n",
+    "    ax.set_ylabel(\"taux de rappel (3 essais)\")\n",
+    "    ax.set_ylim(-0.05, 1.05)\n",
+    "    ax.set_title(title)\n",
+    "    ax.grid(alpha=0.3)\n",
+    "    return ax\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5.5, 3.5))\n",
+    "plot_recall(results, \"Rappel vs position de l'aiguille (needle-in-haystack)\", ax)\n",
+    "plt.tight_layout(); plt.show()\n",
+    "\n",
+    "# verdict honnete sur le « creux du milieu »\n",
+    "recs = [results[d] for d in depths]\n",
+    "middle = results.get(0.5, None) or ((results.get(0.4, 0) + results.get(0.6, 0)) / 2)\n",
+    "mid_idx = depths.index(0.4) if 0.4 in depths else 0\n",
+    "dip = f\"creux {recs[mid_idx+1]:.2f} vs bords {max(recs[0], recs[-1]):.2f}\"\n",
+    "print(f\"\\nverdict : rappel debut={results[0.0]:.2f} fin={results[1.0]:.2f} milieu={middle:.2f} -> {dip}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba365c60",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004215,
+     "end_time": "2026-08-24T00:02:58.344588+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:58.340373+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "La courbe ci-dessus répond à une question que le folklore tranche en général : *le modèle rappelle-t-il mieux un fait du début, de la fin, ou du milieu du contexte ?* Ici la réponse est **mesurée sur notre pile** : à `100 %` de profondeur, le rappel vaut `1.000` sur 3 essais — pour les 6 profondeurs testées (0.0, 0.2, 0.4, 0.6, 0.8, 1.0).\n",
+    "\n",
+    "- **Résultat de la mesure : aucun creux du milieu net.** Le rappel reste à 1.000 du début à la fin du contexte, sur ce corpus (Le Horla, paille de 4000 tokens, modèle qwen3.6-35b-a3b). C'est le résultat honnête : sur cette taille de paille et ce modèle, le « lost in the middle » *ne se manifeste pas*. Une conclusion contraire sur un corpus plus long, plus dense en distractions, ou un autre modèle, resterait à établir.\n",
+    "- **Pourquoi le noter explicitement.** L'absence du creux est *aussi* une mesure — la note l'affirme, au lieu de reproduire un folklore qui dirait « creux attendu au milieu ». Ce notebook ne fait pas semblant : si la mesure ne montre rien, il le dit.\n",
+    "\n",
+    "C'est la base de la section 3 : si la position ne change rien sur ce modèle, alors **réordonner** n'apporte pas de gain mesuré ici — l'intérêt stratégique reste valide (en général, le rappel dépend de la position), c'est juste *non confirmé* sur cette mesure-ci."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d32b8d18",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004266,
+     "end_time": "2026-08-24T00:02:58.352927+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:58.348661+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Réordonnancement — placer le document critique\n",
+    "\n",
+    "Le biais de position de la section 2 a une conséquence directe et **gratuite** : on peut améliorer le rappel en réordonnant les documents ingérés, sans toucher au coût en tokens. On place le « document aiguille » au début, au milieu, à la fin, et on mesure le rappel — la même aiguille, la même paille, seule la **position** change."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0834d94a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:02:58.362693Z",
+     "iopub.status.busy": "2026-08-24T00:02:58.362244Z",
+     "iopub.status.idle": "2026-08-24T00:03:02.069190Z",
+     "shell.execute_reply": "2026-08-24T00:03:02.068204Z"
+    },
+    "papermill": {
+     "duration": 3.713154,
+     "end_time": "2026-08-24T00:03:02.069967+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:02:58.356813+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  debut   : [1, 1, 1] -> recall 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  milieu  : [1, 1, 1] -> recall 1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  fin     : [1, 1, 1] -> recall 1.000\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhwAAAFyCAYAAAC+6APLAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAPPZJREFUeJzt3Qm8jPX///+XY1fJTkSKEmUJIbQrqYjqk9QPKVrQQqW0kBZLi6USRWgTpWhR1mijlC0lS1G02EJkX+Z/e77/32tuc+bMOWbOmevMceZxv92Gmetcc13vmet9ved1vbcrTyAQCBgAAICPUvzcOAAAgBBwAAAA3xFwAAAA3xFwAAAA3xFwAAAA3xFwAAAA3xFwAAAA3xFwAAAA3xFwAAAA3xFw5CD//fefde7c2cqVK2d58uSxe+65xy3fuHGjXXvttVayZEm3fOjQodmetnHjxrl9//bbb5YMbrrpJqtcuXKik4FstmDBAitQoID9/vvvOTbP6Dx87LHHMjw3L7jgAvdA/L7njOi46/gn0oEDB6xixYr20ksvWU5FwOEzrzBI7/HNN98E1+3fv79b/4477rA33njD2rdv75b36NHDpk+fbr1793bLL7vssqj3v3v3bnfSzJ0715fPB+RUOp+mTJkS03sefvhha9eunZ100km+pSvZ/PXXX/b//t//s2rVqtlxxx1nxYoVswYNGthrr71mR9OdNebNm+fK0u3bt1tOlD9/fuvZs6c99dRTtnfvXsuJ8iU6Acni8ccft5NPPjnN8qpVqwaff/bZZ9aoUSPr27dvqnW0/KqrrrL77rsv5v0q4OjXr597zhUPki3gUM1g69ato1p/yZIlNmvWLPfDkhmjRo2yw4cPm9/27Nlj+fIdPUX3li1b7I8//nDHolKlSu5KfObMma5GYOXKle445UTh37PyhcpSpVtBUyh9jpSUxF+/d+rUyR588EEbP3683XzzzZbTHD259ijXokULq1+/fobrbNq0yWrUqBFxeXgGz40OHjzoCmxVaftNVwDaT04oJJAzjB071v0gKujP7BVmdihUqJAdTWrVqpWmhrV79+7WsmVLe/755+2JJ56wvHnzWk4Ty/dcsGBBywmKFStml156qaspz4kBB6VtDqCTUc0ra9eutalTpwabW7zmGFU7Dh8+PLjco6o99fNQu50yvGpLBg0aFLzKUptu6dKl3XNF5t77j9Qu+dNPP9lFF11khQsXthNPPNGefPLJiFdu6W0rmvZMpU3vf/bZZ12flCpVqrjPsHz5cvf3FStWuCuiEiVKuBNfwdqHH36YZjtr1qyx//3vf269IkWKuB8LfYeRvt8JEybYI488YhUqVHDr7tixw/1d1e5nnnmm24/+nzx5csQ079q1y+69997g960qYqU/vFpY+1KB6m1X655xxhk2bdq0VOvpu9O6v/zyS/Cq6fjjj3dXKaqZCv8x1DEpU6aM254C0xEjRkT87q+88kr76quvXLW1PtMpp5xir7/+epp1lX/UXKf3aJs61h06dHBXpJ59+/a5GjflLa2jz96rVy+3PNJnfvfdd13alHfOOeccW7Zsmfv7yy+/7Lah9KimLVJfoG+//dY1F+o70PE5//zz7euvv87Ud6Z1dLxUbe/l+yPlSR0vfceh55h88MEHdsUVV1j58uXdd6C8qh/JQ4cOHbEPxz///OOaRosWLerS2rFjR1u6dGnw/D5Sn4tI24ylb0GoaI9lJF9++aU7zxSQee9V3lEtQGbpc+mY7d+/P8P1vGOuMuG6665z36X6s919991pmg500aJj45Un2sdDDz2U5jN+//331rx5cytVqpTLq6p9Dv+BDv2e9f/999/vnmtdL095+ThSmRdL2fTOO++4phCdgzpHLr74YpfHQ61evdquueYa18dP62jd66+/3v79999U611yySXu/N+6davlNNRwZBNlitCCXJTRdOJUr17d9c3QCaxMpB81Oeuss4J9OZSJ9GPg0YmqAvnPP/+02267zRUEqvJTP4+///7b/Ygr2NCPkvqEtGnTxq6++urgFUd6NmzYYBdeeKE7cVU1d8wxx9grr7ziTko/6IdUhcatt97qCgidnAp4mjRp4gIDLw06IVU1/t5777nP4nWmbdy4sfsu7rrrLvdd6gemVatWNmnSpOB6HhVEqtVQ05QKID2fMWOGO4n1IzlgwAD3A6EfLx2HUAoqtN05c+bYLbfcYnXq1HH9alQI6RgMGTIk1fo64d9//33r2rWra7fWlZz2s27dOpfOUCpEVYhp/4sWLbLRo0e7wELBo0fHUUGL0qBq3o8++shtW4Fgt27dUm1PBZWCNaVTP3BjxoxxhWG9evXcNrwOyueee679/PPPrqCtW7euy58K6lT9rYJY29b+9Fl0fJRPFUDos65atSpN/wj9KOn9Xnr0eRT86EdNHdmU3m3bttnTTz/t9qmmQo+eqxZQadSPomqevCBL21XwFMt3pvNGHbD1PqVd9COUHh1DHRt9D+EUGBx77LGufVz/K619+vRxAeszzzyT7jb1/ekqXh1RdQ6efvrpLnjRMclusR7LcAokdZ7pcyj/6jO98MILLq/ob9FQcKIgUHnv888/d8dXQWm0ZYuOuX7YdczV903nlPJTaDCtY64yQPlf5aiCWK2vfO5dSKjGWLUAKh9VvigQVOCg8zU9Kjv1Pb399tvuO9P5Id4FXbhYy6aBAwe6PK+ySb8VOkduvPFGl35RUKYASeXWnXfe6YIO5dmPP/7YXTgo6PboHFJ5pd8DnX85SgC+Gjt2rC5/Iz4KFiyYat2TTjopcMUVV6TZhtbt1q1bqmVPPPFE4JhjjgmsWrUq1fIHH3wwkDdv3sC6devc682bN7v39+3bN6r03nPPPW79b7/9Nrhs06ZNgeOPP94tX7t2bap0RdquPkfHjh0z3I+2o/cXLVrUbT/UxRdfHKhZs2Zg7969wWWHDx8ONG7cOHDqqaemSeuXX34ZXLZz587AySefHKhcuXLg0KFDbtmcOXPceqecckpg9+7dqfZVp06dwAknnBDYvn17cNmMGTPc+vocnilTprhlTz75ZKr3X3vttYE8efIEfvnll1TfS4ECBVItW7p0qVv+wgsvBJfpu9Oym2++OdU227RpEyhZsmSqZeHplubNm7vPFEpp1ja/+OKL4DJ9v8pr9957b3BZnz593Hrvv/9+mu3qu5Y33ngjkJKSkur7lZEjR7r3fv3116k+s/YRmj9efvllt7xcuXKBHTt2BJf37t07VV7S/nRc9Xm8fXufWcfykksuydR3pvPjSPnQM2vWLLfdjz76KM3fIn33t912W6BIkSKp8qj2FZpn3nvvPbfNoUOHBpcpT1500UVuucoGz/nnn+8e4cK3Gem888qY0O8+fHuxHMtIIn0HAwYMcHn/999/z/C9oeuHln86z71yKiPeMW/VqlWq5V27dnXLdW7JkiVL3OvOnTunWu++++5zyz/77DP3evLkye71d999l+F+w7/nZ555Js33nF6ZF2vZVL169cC+ffuC6w4bNswtX7ZsmXu9ePFi9/rdd9894vf1119/uXUHDRoUyGloUskmahJRR6nQx6effprp7emqQleoxYsXd1em3qNZs2auqveLL77I1HY/+eQTV/UXekWpKF7Rth901R96laBqQF1B6mpm586dwc+lmgdF+KpWVGTvpVXpbNq0afD9ugLVFZyuWLzmGY+uLEOvplQTpI6CWh56haDapPC+NNqX2pl1tRJKV1Eqm8KPpY5D6BW1apVUFaxq1nC33357qtc6rvq8XpOPhKbbqy1TDZe2F16lqrRrGx59v2r+Cd23aopq166d5kpLvCYF5TFdCevKPDSPqdZBVNsTStXAodX/DRs2DB5j1fKEL/fSo2Og43rDDTe4z+3tR1fD2qbycniTXjTfWSz0XtH5FC70u/fypPanq1dV86dHTWjq19GlS5fgMl3FhtdIZYdYj2VG34GOi96rK3jl/cWLF0eVBo3+UbmnDo061hJLk0z496Yrfe/cDP1fNVGhvBpjrznD6w+n2gF1YPVDrGVTp06dUvVd885f7xzxyifVqoY3t4bz8nB4jXpOQJNKNlHmO1Kn0ViogP7hhx/SrdJTtWFmaP4B7wchlH6w/BA+ckfNASrEHn30UfdI77OpuSW9tKpgFf1dfSjS25c318Kpp54a8fOqqj50XbXhh/5whu8rlJq4IhUEqgIOF76uV2BoXQUpor4MamqYP39+mgJHAUdowBTNvn/99VcXCBwpj6kqOto8Fr5fL01q74+03EuP9iMZNTXoM4YGA9F8Z5kRaZimmvjU90eBcHhAEx7shVKeOOGEE1z7fXoj07JLrMcynJqb1IykJrPwPJzRdxBKQ4294cYKPvTjq8BcIzyiaVYJP08V0CuA8/pR6PvW6/DvV80PCjK8c1SBuvK++rWpeUR9Z9RcqyAoXp0/Yy2bKmWQn72yS4HU4MGD7a233nIBiZpnNNw49NwPzcPhfZFyAgKOo5Su+HQlrvbxSE477TRLlPDOdBkJL2i8K1m1ZapGI5LMFth+9UOJJL1e95F+0I60roIDXenr6lQFjn7AdTWkqygVmOFX/7HsOyPabs2aNd0+IwkPJNLb75HS46Vf/SHUNyYSXR3Gss1Yef1qwn9M1T6uHygFMRrarh85ddhTMPrAAw/EbRis1zk8K+dSPI9leBpU1qj2UZ9Z+VD9qlTTqL5Bmf0O1M9CQ4lVg5XeuZ6R9H5Qj/RDq7+rH4X6gagvlGoN1Kfoueeec8vC81p2yBtFflb69H2rH5D6nqm21evPEtrnzMvDXj+TnISA4yilgk+dr3SFkJFYo1xdgXhXnKF0FRJOUXj4JDjq3KSmiszSiApRVfSRPpvSGildXjX3kSZv8v4ezefVupqjQVXqobUc0e4rK1QoqrOYri5Dr4SOVA1+pPzz448/HnEdjahQsOPn1ZLX9KQf9SMd81jEkmb9iIpGioWPIlBzizoUnnfeecHl4etFojyhY6QaqdBajvDRB965FKm5LTMznsb7WKpzqTpMqtNjaMd1NY9khdecEm0Nic7T0FpKfY8KdrxmPH3feq31vJoErwOnyqnwc1RNx3podIiaedRsrJFs6ngaSSzfW1bLpvQoaNRDNW7qFKrO9SNHjnQjCcPzZuh3kFPQh+MopT4Oql5XdB5OJ5dGmYhX0EU7O97ll1/uImb1Qvds3rzZVeNFKsTC+4poREtWrso00kBVnBpGGSlwUVpC06p06nsIbV9WGlQIRZrTJJSqu3VFrYI0tNBTQRrexqp96XO9+OKLqZarhkEFkUZY+H31E3q1o/Sql39mqUpZP0CRhgB7+1Ee01WsrkLTG3EQD+pVr7ykIcYKojM65rHQVXi0+V5NdLrK13DJI333CqqjmT5aV+3qIxD6/ekHUf25wunz68co9LPq+IQPC86srBzLSN+Bng8bNiyqfad3/F599VV37kQaGRRJ+PemUTLinXs6RyX81g9erY6GNns1AOG1SV7NWkZDhJWfJJo8ldWyKZya8rwy3aPAQ01I4WleuHCh+141AiinoYYjm6hTYaQOZup45V3Vx0LDMXXFq2FP3pBHZWhdjai6UO2a3hhzZe6JEye6ZhYNO1XbYWj7YSg10XjTp2ucuzcsVhG5+oyE0pWAOu/px0tVriogFQBltSpPBYs6W+mEUoc7fT+6StHJq2F42o9oSJuGqanAUfWiPpuCB0X46hQZzaReqpJUQaT9qVpV1cYqyDR8NPTHT8MbNVxYU1/ru1WHS1VrqnpTc6FkNOQyqzSET00oSoOGQCtd+uFQcJbZ2iTlH+UTzROgz638o8+uPKUrJn0+DcfWcGQdY12p62pKQZfysZbrWMejX5KOk4a16jjqe1cHOgUA+oHUflXzoVqeWOkzqVZKPzjqf6Or40jt6h7N5qsATD9G3tWszk/VPqh/ifKYluv8iKbpRv0C1HdLnRZ1Na5aFH2/3vwIoVfMOgZKp4IUDWdWnwodB30fme0IGyorx1LpVv5WM6eOiY6Hzq9I/ZEiUQ2CAieVKaqh0+fX+7/77jvX8TPaJlKd1+q3oO2oLHjzzTddvwvlVdH/Ok4qr7ymMP3oq0zQsdD5K3qtgFEdpvW5VGup80mfywta0stPojJA81+oFlbnpBeIhIpH2RRK/Yc0z43OV5XjCj6UDxUMhvfF0gWTjm/48PscIdHDZJJ5WGz40LhYhsV6w6w0xLBq1apuGGapUqXc0NFnn302sH///uB68+bNC9SrV8+tE80Q2R9++MENqStUqFCgQoUKbgjuq6++mmZImIZ2PfDAA26/GiKoYY0aChrLsFgNNYvk119/DXTo0MENqcyfP79Lx5VXXhmYNGlSmvU0NLVYsWIuvQ0aNAh8/PHHqdbxhp6lN6RMwxc1LE3DOmvUqOGGikYajqjvu0ePHoHy5cu7NGkop9IfOpQzo+MV/r14w/00dDlUpGGOH374YaBWrVruM2pYnYa8jRkzJs166eWhSMMu//nnn0D37t3dd6u8ceKJJ7r0bdmyJbiO8pH2dcYZZ7jvp3jx4i4v9evXL/Dvv/9m+JnTO8bpHQ8N/bv66qvd8FbtS5/luuuuC8yePTtT39mKFSsC5513XqBw4cLub0fKk4sWLUozlFE0ZLRRo0ZuOzr2vXr1CkyfPt2tq8/iiZRnlM4bbrghcNxxx7mh5TfddJPbnt47YcKEVOu++eabbpizjoWGa2sf8RoWG8uxjGT58uWBZs2aBY499lh3vnfp0iU41Du0DItEw8x17nrnjb6LJk2auPeFnzuReMdcadC5rvcr7cq7e/bsSbXugQMH3OfR8FPtq2LFiq6MDB2+rOPcrl27QKVKldz3UKZMGZe+77//PtW2IpWVKgt1vmiIceh3HqnMy0rZtPb/zh3vu12zZo0bCl6lShW3rRIlSgQuvPBCN5w7lIb3K/+MHj06kBPl0T+JDnoAICdQHwfVhujq0S+aZEtX15qES1eiyJhm+dSIEjXN5MSOkDnJ0KFD3aRh6mienZ3ko0UfDgD4P7qRmJof49VZM3yeCTVjqMlO1ffR9l0AoqH+QmqWU4fSnBhsCH04AOD/qI/Hke7tEQv1UVDQoQ586tyn0S4aXaDAJqf+KODolD9/fjdfSk5GwAEAPtFMnpo/QbNa6p5B6iCpGg51AASSDX04AACA7+jDAQAAfEfAAQAAfJd0fTg0099ff/3lpqfOiTe3AQDgaKFeGZo8TcPJjzShWdIFHAo2MrpREQAAiM369etT3UQukqQLOLwbb+nLycptrAEASHY7duxwF/GhN7VMT9IFHF4zioINAg4AALIumi4KdBoFAAC+I+AAAAC+I+AAAAC+I+AAAAC+I+AAAAC+I+AAAAC+I+AAAAC5O+D44osvrGXLlm5KVI3hnTJlyhHfM3fuXKtbt64VLFjQ3ep53Lhx2ZJWAABwlAYcu3btstq1a9vw4cOjWn/t2rV2xRVX2IUXXmhLliyxe+65xzp37mzTp0/3Pa0AACDzEjrTaIsWLdwjWiNHjrSTTz7ZnnvuOfe6evXq9tVXX9mQIUOsefPmPqYUAAAkTR+O+fPnW7NmzVItU6Ch5QAAIOc6qu6lsmHDBitbtmyqZXqtm8fs2bPHChcunOY9+/btcw+P1vVuU68HAADInFh+R4+qgCMzBgwYYP369UuzfPPmzbZ379647qv77O5x3R5ynhcvfjFh+15/R9eE7RvZp+KIlxKyX8qv5PBinMuwnTt35s6Ao1y5crZx48ZUy/Rad32NVLshvXv3tp49e6a5lW7p0qXjfrfY1QdXx3V7yHnKlCmTsH1vXbkyYftG7s9jlF/JoUyc81ehQoVyZ8Bxzjnn2CeffJJq2cyZM93y9Gj4rB7hUlJS3COeDhtNNLldvPNMLPLQBJgUEpXHKL+SQ0qc81cs20top9H//vvPDW/Vwxv2qufr1q0L1k506NAhuP7tt99ua9assV69etmKFSvspZdesnfeecd69OiRsM8AAAByeMDx/fff21lnneUeoqYPPe/Tp497/ffffweDD9GQ2KlTp7paDc3foeGxo0ePZkgsAAA5XEKbVC644AILBALp/j3SLKJ6z+LFi31OGQAASNp5OAAAwNGJgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAPiOgAMAAOTMgGPdunX25Zdf2vTp023RokW2b9++TCdg+PDhVrlyZStUqJA1bNjQFixYkOH6Q4cOtWrVqlnhwoWtYsWK1qNHD9u7d2+m9w8AAPyXL9oVf/vtNxsxYoRNmDDB/vjjDwsEAsG/FShQwM4991y79dZb7ZprrrGUlOjimIkTJ1rPnj1t5MiRLthQMNG8eXNbuXKllSlTJs3648ePtwcffNDGjBljjRs3tlWrVtlNN91kefLkscGDB0f7UQAAQDaLKjK46667rHbt2rZ27Vp78sknbfny5fbvv//a/v37bcOGDfbJJ59Y06ZNrU+fPlarVi377rvvotq5goQuXbpYp06drEaNGi7wKFKkiAsoIpk3b541adLEbrjhBlcrcumll1q7du2OWCsCAACOghqOY445xtasWWMlS5ZM8zfVRFx00UXu0bdvX5s2bZqtX7/ezj777Ay3qWBl4cKF1rt37+Ay1Yw0a9bM5s+fH/E9qtV48803XYDRoEEDlyYFO+3bt4/mYwAAgJwccAwYMCDqDV522WVRrbdlyxY7dOiQlS1bNtVyvV6xYkXE96hmQ+9TbYqadA4ePGi33367PfTQQ+nuR/1LQvuY7Nixw/1/+PBh94inFPrg5nrxzjOxCETZVImjW6LyGOVXcjgc5/wVy/ai7sPh2bNnj/uxV9OH/P777zZ58mSrXr2663/hp7lz51r//v3tpZdecn0+fvnlF7v77rvtiSeesEcffTTdYKlfv35plm/evDnunU1PzXdqXLeHnGfTpk0J2/euatUStm/k/jxG+ZUcNsU5f+3cudO/gOOqq66yq6++2tUsbN++3f3w58+f39U8qE/GHXfcEdV2SpUqZXnz5rWNGzemWq7X5cqVi/geBRVqPuncubN7XbNmTdu1a5frrPrwww9H7KyqJht1TA2t4dDoltKlS1vRokUtnlYfXB3X7SHnidSZObtsXbkyYftG7s9jlF/JoUyc85dGmPoWcGgY7JAhQ9zzSZMmuSaQxYsX23vvvec6jUYbcGhkS7169Wz27NnWunXrYNWMXnfv3j3ie3bv3p0mqFDQIqGjZkIVLFjQPcJpO9GOponWYUtcdTuyR7zzTCzyJLA5B7k/j1F+JYeUOOevWLYXc8ChH/3jjjvOPZ8xY4ar7dAOGzVq5JpXYqGah44dO1r9+vVdJ1ANi1WNhUatSIcOHaxChQrBPiQtW7Z0tShnnXVWsElFtR5a7gUeAAAg54k54KhatapNmTLF2rRp4yb+0sRbXrtQrE0Ubdu2dX0pVDOi4bV16tRxo1y8jqSaYCw0enrkkUfcnBv6/88//3TNIgo2nnrqqVg/BgAAyEZ5Aum1RaRDzSgaLaIRJhdffLGr5RDVQnzxxRf26aefWk6mPhzHH3+8m0ck3n04ar5WM67bQ86zrOOyhO3759OrJ2zfyD7VV/yckP1SfiWHZXEuw2L5TY25huPaa691w1L//vtvNxmYR8GHaj0AAACyHHCIRpGEjyRRHwwAAIBMBxzqGDpu3DhXXaLnGXn//fej2SQAAEgiUQUcap9RZ03vOQAAQNwDjrFjx0Z8DgAAEA0mzwcAADmz06iGxr7zzjtungzd9TV8JlIAAIAs1XA8//zzbiZQb0pzjU7Rbet1q/gWLVrEujkAAJAEYg44dKfWV155xV544QV3P5RevXrZzJkz7a677nITfwAAAGQ54FAzSuPGjd3zwoULB29Nq7u4vv3227FuDgAAJIGYAw5N+LV161b3vFKlSvbNN9+452vXrk33jq0AACC5xRxwXHTRRfbhhx+65+rLoZu3XXLJJe5GbExtDgAA4jJKRf03Dh8+7J5369bNdRidN2+etWrVym677bZYNwcAAJJAzAGHbhcfesv466+/3j0AAADi1qQybdo0++qrr4Kvhw8fbnXq1HG3rN+2bVusmwMAAEkg5oDj/vvvtx07drjny5Yts549e9rll1/uOo3qOQAAQJabVBRY1KhRwz1/7733rGXLlta/f383w6gCDwAAgCzXcGiyr927d7vns2bNsksvvdQ9L1GiRLDmAwAAIEs1HE2bNnVNJ02aNLEFCxbYxIkT3fJVq1bZiSeeGOvmAABAEoi5huPFF1+0fPnyuRu4jRgxwipUqOCWf/rpp3bZZZf5kUYAAJBsNRyaXfTjjz9Os3zIkCHxShMAAEj2Gg51DtXoFM8HH3xgrVu3toceeijNreoBAAAyFXBoNlH11xDdkl6TfhUpUsTeffddd+dYAACALAccCjY00ZcoyDjvvPNs/PjxNm7cODdMFgAAIMsBh+4I691LRcNivbk3KlasaFu2bIl1cwAAIAnEHHDUr1/fnnzySXvjjTfs888/tyuuuCI4IVjZsmX9SCMAAEi2gGPo0KGu42j37t3t4YcftqpVq7rlGibbuHFjP9IIAACSbVhsrVq1Uo1S8TzzzDOWN2/eeKULAAAkcw2HbN++3UaPHm29e/e2rVu3umXLly+3TZs2xTt9AAAgGWs4fvjhB7v44outWLFi9ttvv1mXLl3cfVTef/99W7dunb3++uv+pBQAACRPDYfuo9KpUydbvXq1FSpUKLhco1W++OKLeKcPAAAkY8Dx3Xffucm/wumeKhs2bIhXugAAQDIHHAULFox4G3pNCFa6dOl4pQsAACRzwNGqVSt7/PHH7cCBA+51njx5XN+NBx54wK655ho/0ggAAJIt4Hjuuefsv//+szJlytiePXvs/PPPd3NxHHfccfbUU0/5k0oAAJBco1SOP/54mzlzpn399de2dOlSF3zUrVvXmjVr5k8KAQBA8gUcniZNmrgHAACALxN/AQAAxIKAAwAA+I6AAwAA+I6AAwAA5LyA49ChQ6lef/vtt25Kc29eDgAAgEwHHH///bc1bdrUzTSquTe2bdtmV155pZ1zzjl2wQUX2JlnnunWAQAAyHTAoZlEA4GATZ482U444QQXbGiK8/Xr17u7xmpacyb+AgAAWZqHY9asWe4W9I0aNXLzb5QqVcpNAKabtommO9et6gEAADJdw6EmFC+4KFGihBUpUsROOumk4N81vTlNKgAAIEsBh+6dEhpQdO/e3QUeoQHJMcccE+3mAABAEok64KhTp47Nnz8/+HrgwIGpAo6vvvrKatWqFXMChg8fbpUrV7ZChQpZw4YNbcGCBRmuv337duvWrZvrR6IOrKeddpp98sknMe8XAADkwD4cH3zwQYZ/P/vss93olVhMnDjRevbsaSNHjnTBxtChQ6158+a2cuVKV6MSbv/+/XbJJZe4v02aNMk18fz+++9WrFixmPYLAACOkpu3hWvQoEHM7xk8eLDraNqpUyf3WoHH1KlTbcyYMfbggw+mWV/Lt27davPmzbP8+fO7ZaodAQAAuaBJ5Ztvvol6g7t377affvrpiOuptmLhwoWpbmufkpLiXoc23YT68MMP3bwfalIpW7asm/ujf//+aSYjAwAAR2ENR/v27e2UU06xzp072+WXXx6xc+jy5cvtzTfftLFjx9qgQYPsjDPOyHCbW7ZscYGCAodQer1ixYqI71mzZo199tlnduONN7p+G7/88ot17drVzXLat2/fiO/Zt2+fe3g0d4gcPnzYPeIphZnic71455lYBFLIX8kgUXmM8is5HI5z/ople1EFHAomRowYYY888ojdcMMNrqNm+fLlXUdPjU5RgPDff/9ZmzZtbMaMGVazZk3zgz6Y+m+88sorljdvXqtXr579+eef9swzz6QbcAwYMMD69euXZvnmzZtt7969cU3fqflOjev2kPNs2rQpYfveVa1awvaN3J/HKL+Sw6Y456+dO3fGN+BQf4m77rrLPb7//ns3IkWdNffs2WO1a9e2Hj162IUXXphq1MqRaOIwBQ0bN25MtVyvy5UrF/E9GpmitOh9nurVq9uGDRtcE02BAgXSvKd3796uY2poDUfFihXdzKhFixa1eFp9cHVct4ecJ1Jn5uyydeXKhO0buT+PUX4lhzJxzl+qePCt02j9+vXdI6sUHKiGYvbs2da6detgDYZea46PSDTD6fjx49166u8hq1atcoFIpGBDNHRWj3B6v7eNeDlsiatuR/aId56JRZ4ENucg9+cxyq/kkBLn/BXL9hLaaKeah1GjRtlrr71mP//8s91xxx22a9eu4KiVDh06uBoKj/6uUSp33323CzQ0okWdRtWJFAAAJMGw2Mxo27at60vRp08f1yyiycWmTZsW7Ei6bt26VNGTmkKmT5/umnA0yZjm4VDwoRvLAQCAnCuhAYeo+SS9JpS5c+emWaZhsbEM0wUAAInHOCgAAOA7Ag4AAJAzmlSef/75qDeoobMAAAAxBxxDhgyJZjXLkycPAQcAAMhcwLF27dpoVgMAAIhvHw7N7KnbyB88eDCzmwAAAEki5oBDd4O95ZZbrEiRIu4GbZorQ+68804bOHCgH2kEAADJFnBo5s+lS5e6OTJC51DXbeUnTpwY7/QBAIBknPhrypQpLrBo1KiR6yTqUW3Hr7/+Gu/0AQCAZKzh0FTkke42p3ughAYgAAAAmQ44dKdY3TTN4wUZo0ePdtOOAwAAZLlJRXdnbdGihS1fvtyNUBk2bJh7Pm/ePPv8889j3RwAAEgCMddwNG3a1JYsWeKCjZo1a9qMGTNcE8v8+fOtXr16/qQSAAAk391iq1SpYqNGjYp/agAAQK6UqYDj0KFDNnnyZPv555/d6xo1athVV11l+fIl/G73AAAgB4o5Qvjpp5+sVatWtmHDBqtWrZpbNmjQICtdurR99NFHduaZZ/qRTgAAkEx9ODp37uzm3Pjjjz9s0aJF7rF+/XqrVauW3Xrrrf6kEgAAJFcNhzqMfv/991a8ePHgMj1/6qmn7Oyzz453+gAAQDLWcJx22mm2cePGNMs3bdpkVatWjVe6AABAMgccAwYMsLvuussmTZrkmlX00PN77rnH9eXYsWNH8AEAAJCpJpUrr7zS/X/dddcFZxkNBALu/5YtWwZf628azQIAABBzwDFnzhx/UgIAAHKtmAOO888/35+UAACAXCtTM3Vt27bNXn311VQTf3Xq1MlKlCgR7/QBAIBk7DT6xRdfWOXKle355593gYceen7yySe7vwEAAGS5hqNbt27Wtm1bGzFihOXNm9ctU+fQrl27ur8tW7Ys1k0CAIBcLuYajl9++cXuvffeYLAhet6zZ0/3NwAAgCwHHHXr1g323QilZbVr1451cwAAIAnE3KSiSb/uvvtuV5vRqFEjt+ybb76x4cOH28CBA+2HH34Irqv7qwAAAMQccLRr187936tXr4h/04RfTPwFAACyFHCsXbs21rcAAIAkF3PAcdJJJ/mTEgAAkGtlauIvWb58ua1bt87279+fanmrVq3ikS4AAJDMAceaNWusTZs2br4Nr7+GeDdyo98GAADI8rBYjVDRrKKbNm2yIkWK2E8//eRmGK1fv77NnTs31s0BAIAkEHMNx/z58+2zzz6zUqVKWUpKins0bdrUBgwY4IbMLl682J+UAgCA5KnhUJPJcccd554r6Pjrr7+CnUlXrlwZ/xQCAIDkq+E488wzbenSpa5ZpWHDhvb0009bgQIF7JVXXrFTTjnFn1QCAIDkCjgeeeQR27Vrl3v++OOP25VXXmnnnnuulSxZ0iZOnOhHGgEAQLIFHM2bNw8+r1q1qq1YscK2bt1qxYsXD45UAQAAyHQfjgMHDli+fPnsxx9/TLW8RIkSBBsAACA+AUf+/PmtUqVKzLUBAAD8HaXy8MMP20MPPeSaUQAAAHzpw/Hiiy+6W9OXL1/eDYU95phjUv190aJFsW4SAADkcjEHHK1bt/YnJQAAINeKOeDo27evPykBAAC5Vsx9OAAAAI7KgGP48OFWuXJlK1SokJu9dMGCBVG9b8KECW44Ls08AADkbAkPODQ7ac+ePV1TjTqc1q5d200uprvRZuS3336z++67z81yCgAAcraEBxyDBw+2Ll26WKdOnaxGjRo2cuRId9v7MWPGpPsezQNy4403Wr9+/bh/CwAAubHTqGf//v22du1aq1Klipt9NLPbWLhwofXu3Tu4TLe7b9asmc2fPz/d9+keLmXKlLFbbrnFvvzyywz3sW/fPvfw7Nixw/1/+PBh94inlMTHb/BZvPNMLAIp5K9kkKg8RvmVHA7HOX/Fsr2YI4Xdu3fbnXfeaa+99pp7vWrVKlfLoGUVKlSwBx98MOptbdmyxdVWlC1bNtVyvdY9WiL56quv7NVXX7UlS5ZEtY8BAwa4mpBwmzdvtr1791o8nZrv1LhuDznPkZr6/LSrWrWE7Ru5P49RfiWHTXHOXzt37vQv4FBthG5PP3fuXLvsssuCy1Ur8dhjj8UUcGTmg7Vv395GjRplpUqVijq96iMSWsNRsWJFK126tBUtWjSu6Vt9cHVct4ecRzVribJ15cqE7Ru5P49RfiWHMnHOXxrs4VvAMWXKFNfRs1GjRqlu2HbGGWfYr7/+GtO2FDTkzZvXNm7cmGq5XpcrVy7N+tq+Oou2bNkyTXWOmnVWrlzpmnhCFSxY0D3CqelGj3g6bImrbkf2iHeeiUWeBDbnIPfnMcqv5JAS5/wVy/Zi3rOaIiJFSLt27Yr5jrEFChSwevXq2ezZs1MFEHp9zjnnpFn/9NNPt2XLlrnmFO/RqlUru/DCC91z1VwAAICcJ+Yajvr169vUqVNdnw3xgozRo0dHDBKORM0dHTt2dNtt0KCBDR061AUvGrUiHTp0cH1D1BdDVTdnnnlmqvcXK1bM/R++HAAAHMUBR//+/a1Fixa2fPlyO3jwoA0bNsw9nzdvnn3++ecxJ6Bt27au1qRPnz62YcMGq1Onjk2bNi3YkXTdunUJrcYGAAAJCDiaNm3qmi8GDhxoNWvWtBkzZljdunXdMFa9zozu3bu7RyTqnJqRcePGZWqfAAAg+2RqAg11zNRIEQAAgLgFHN5kWdGI91BTAACQJAGHOmZGOwJFE3kBAADEHHDMmTMn+FzzYGhyr5tuuik4KkX9NzTzqEaSAAAAZCrgOP/881Pdx0Q3XGvXrl1wmebCUIfRV155xQ1xBQAACBXzeFPVZmjOjHBatmDBglg3BwAAkkDMAYdm84w0QkUTfzHTJwAAiMuw2CFDhtg111xjn376qTVs2NAtU83G6tWr7b333ot1cwAAIAnEXMNx+eWXu+BC/Ta2bt3qHrqZmm5Tr78BAADEZeKvE0880Z566qnMvBUAACQhblICAAB8R8ABAAB8R8ABAAB8R8ABAAByXsCxYsWKdP82ffr0rKYHAADkQjEHHHXr1rXhw4enWrZv3z7r3r27XXXVVfFMGwAASNaAY9y4cdanTx8358bGjRttyZIldtZZZ9msWbPsyy+/9CeVAAAguQKO6667zpYuXWoHDhywM844w90xVjd3W7RokZ199tn+pBIAACRnp9H9+/fboUOH3OOEE06wQoUKxTdlAAAgeQOOCRMmuFvRH3/88W4686lTp7rb0p977rm2Zs0af1IJAACSK+C45ZZbrH///vbhhx9a6dKl7ZJLLrFly5ZZhQoVrE6dOv6kEgAAJNe9VNRXo1q1aqmWFS9e3N555x1744034pk2AACQrDUc4cFGqPbt22c1PQAAIBeKuYbj5ptvzvDvY8aMyUp6AABALhRzwLFt27ZUrzU89scff7Tt27fbRRddFM+0AQCAZA04Jk+enGbZ4cOH7Y477rAqVarEK10AACAXicvN21JSUqxnz542ZMiQeGwOAADkMnG7W+yvv/5qBw8ejNfmAABAMjepqCYjVCAQsL///ttNANaxY8d4pg0AACRrwLF48eI0zSmaAOy555474ggWAACQnGIOOObMmeNPSgAAQK4Vtz4cAAAAcavhkEmTJrmpzNetW+fuGhs+9TkAAECWajief/5569Spk5UtW9b152jQoIGVLFnS3Sm2RYsWsW4OAAAkgZgDjpdeesndjv6FF16wAgUKWK9evWzmzJl211132b///utPKgEAQHIFHGpGady4sXteuHBh27lzZ/DGbW+//Xb8UwgAAJIv4ChXrpxt3brVPa9UqZJ988037vnatWvdnBwAAABZDjh0g7YPP/zQPVdfjh49etgll1xibdu2tTZt2sS6OQAAkARiHqWi/hu6WZt069bNdRidN2+etWrVym677TY/0ggAAJIt4Pjjjz+sYsWKwdfXX3+9e6g5Zf369a6ZBQAAIEtNKieffLJt3rw5zXL169DfAAAAshxwqCYjT548aZb/999/VqhQoVg3BwAAkkC+WO8Sq2Dj0UcftSJFigT/dujQIfv222+tTp06/qQSAAAkR8Dh3SVWNRzLli1zk3559Lx27dp23333+ZNKAACQHAGHd5dYDYUdNmyYFS1a1M90AQCAZB6lMnbsWH9SAgAAci1uTw8AAJIj4Bg+fLhVrlzZjXJp2LChLViwIN11R40aZeeee64VL17cPZo1a5bh+gAAIPESHnBMnDjRjYDp27evLVq0yHU+bd68uW3atCni+nPnzrV27dq5PiXz5893k5Bdeuml9ueff2Z72gEAwFEScAwePNi6dOniOqPWqFHDRo4c6YbcjhkzJuL6b731lnXt2tUNwT399NNt9OjRbqr12bNnZ3vaAQCAT51G42n//v22cOFC6927d3BZSkqKayZR7UU0du/ebQcOHLASJUpE/Pu+ffvcw7Njxw73v4IU754w8ZKS+PgNPot3nolFIIX8lQwSlccov5LD4Tjnr1i2l9CAY8uWLW7SsLJly6ZartcrVqyIahsPPPCAlS9f3gUpkQwYMMD69euXZrmmZ9+7d6/F06n5To3r9pDzpNfUlx12VauWsH0j9+cxyq/ksCnO+Wvnzp1HR8CRVQMHDrQJEya4fh3pTauu2hNvllSvhkP9PkqXLh33uURWH1wd1+0h5ylTpkzC9r115cqE7Ru5P49RfiWHMnHOX7Hc0iShAUepUqUsb968tnHjxlTL9bpcuXIZvvfZZ591AcesWbOsVq1a6a5XsGBB9winphs94umwJa66Hdkj3nkmFnkS2JyD3J/HKL+SQ0qc81cs20too52mRK9Xr16qDp9eB9Bzzjkn3fc9/fTT9sQTT9i0adOsfv362ZRaAACQWQlvUlFzR8eOHV3g0KBBAxs6dKjt2rXLjVqRDh06WIUKFVxfDBk0aJD16dPHxo8f7+bu2LBhg1t+7LHHugcAAMh5Eh5wtG3b1nXgVBCh4EHDXVVz4XUkXbduXaoqmxEjRrjRLddee22q7Wgej8ceeyzb0w8AAI6CgEO6d+/uHpGoQ2io3377LZtSBQAA4oWB1wAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAwHcEHAAAIDkCjuHDh1vlypWtUKFC1rBhQ1uwYEGG67/77rt2+umnu/Vr1qxpn3zySbalFQAAHIUBx8SJE61nz57Wt29fW7RokdWuXduaN29umzZtirj+vHnzrF27dnbLLbfY4sWLrXXr1u7x448/ZnvaAQDAURJwDB482Lp06WKdOnWyGjVq2MiRI61IkSI2ZsyYiOsPGzbMLrvsMrv//vutevXq9sQTT1jdunXtxRdfzPa0AwCA6OSzBNq/f78tXLjQevfuHVyWkpJizZo1s/nz50d8j5arRiSUakSmTJkScf19+/a5h+fff/91/2/fvt0OHz5s8RTYE4jr9pDzKN8kys4A+SsZJCqPUX4lh+1xzl87duxw/weiKJ8SGnBs2bLFDh06ZGXLlk21XK9XrFgR8T0bNmyIuL6WRzJgwADr169fmuUnnXRSltKO5FT8juKJTgJyu+LkMRx9ZdjOnTvt+OOPz7kBR3ZQ7UlojYhqNbZu3WolS5a0PHnyJDRtRzNFtRUrVrT169db0aJFE50c5ELkMfiJ/BUfqtlQsFG+fPkjrpvQgKNUqVKWN29e27hxY6rlel2uXLmI79HyWNYvWLCge4QqVqxYltOO/59OVE5W+Ik8Bj+Rv7LuSDUbOaLTaIECBaxevXo2e/bsVDUQen3OOedEfI+Wh64vM2fOTHd9AACQeAlvUlFzR8eOHa1+/frWoEEDGzp0qO3atcuNWpEOHTpYhQoVXF8Mufvuu+3888+35557zq644gqbMGGCff/99/bKK68k+JMAAIAcG3C0bdvWNm/ebH369HEdP+vUqWPTpk0Ldgxdt26dG7niady4sY0fP94eeeQRe+ihh+zUU091I1TOPPPMBH6K5KNmKs2dEt5cBcQLeQx+In9lvzyBaMayAAAAHM0TfwEAgNyPgAMAAPiOgAMAAPiOgAPOBRdcYPfcc09U644bN465TBAXc+fOdRPwedMth+etxx57zHUkBzJDXRRvvfVWK1GihMtnylvRlnPIhaNUkNxBjn5MNBQayUmjzv7+++90Jw6677777M4778z2dCF30IhHBbEKbE855RQ34rFw4cKJTlbSIuAAkNDJ/9KbJViOPfZY9wAy49dff7UTTjjBBbZIPJpUkpAmVtOEairIdTJqErVQuruuriw14doxxxxjDRs2dFcI4TT/ieZBKVSokLtjr+5J4LnpppusdevWqdZXVaZqNby/f/755zZs2DBX1anHb7/95ttnRvbQ8VWNhI518eLF3Xw6o0aNCk7md9xxx1nVqlXt008/jdikEi5Sk8ro0aOtevXqLt+dfvrp9tJLLwX/Fml7S5YsIX8lIZUxyouay0nHv3LlymmajrWsf//+dvPNN7u8WalSJSaR9BEBRxK6//773Y/9Bx98YDNmzHCF9KJFi4J/7969u82fP9/N4vrDDz/Y//73P7vsssts9erVwXV2795tTz31lL3++uv29ddfuwL++uuvjzoNCjQ0HX2XLl1clboeupESjn6vvfaau0/SggULXIF/xx13uDykq0zls0svvdTat2/v8lCs3nrrLTdJoPLezz//7H4sHn30UbdPILyMefzxx+3EE0905ct3330XcT1dcGmm68WLF1vXrl1dfl25cmW2pzcZEHAkmf/++89effVVe/bZZ+3iiy+2mjVrusL64MGD7u+6Ghg7dqy9++67du6551qVKlVcbUfTpk3dcs+BAwfsxRdfdEGD7oejbcybN8/9yERDbfaqTi9SpIirUtdDN/LD0a927dpuJmDVfuluzaqJUACi4FLLFDD8888/LpiNlWaG1A/E1VdfbSeffLL7v0ePHvbyyy/78llw9FIZo1oLlSsqX0qXLh1xvcsvv9wFGqp5e+CBB1xenTNnTranNxnQhyMJ2zT379/vmkk86sFdrVo193zZsmV26NAhO+2009I0s5QsWTL4Ol++fHb22WcHX6tqWz3AddWpe+IgedWqVSv4XIW98o0CW49324JNmzbFdJdONcso/95yyy0uePEoWI72bpVARvlVTS8KTpQ3EX8EHEhTA6IfiYULF6apcYil8556g4fPmq9aEeR++fPnT/VahXjoMr327gwda94U9QkJDZjFy6vefZdC8x75DrHm11jzJqJDwJFk1ESiE+zbb791HaRk27ZttmrVKncX3rPOOsvVcCjCV5NKenRVqbv0erUZavNUPw515hNVX/7444+p3qPOe6Ent5pUtC8gGqoZKV++vK1Zs8ZuvPHGiOt41eZqs1enVS/fAUg8+nAkGdVSqEpaHUc/++wzFxSoN7d3ZaimFBXmGsXy/vvv29q1a12/jAEDBtjUqVOD21HgoA6BClxUG6JtNGrUKBiAXHTRRS4gUadSdTZV23t4AKIe4nq/Rg9s2bKFqwocUb9+/VxefP75512QrCZA9S0aPHiw+7va4dX5WKNblO+UZ8NHYQFIDAKOJPTMM8+42ouWLVtas2bNXIdQdfz0qABXwHHvvfe6vh0a3qoe3l6NiKizpzpY3XDDDdakSRMXyEycODH4dw2T1eiBXr16ub4eO3fudNsMpc6oqgqvUaOGuzJVh1UgI507d3bDYpVH1S9EtXKa2EkdSL1A+O2337YVK1a4tvlBgwbZk08+mehkA+D29AAAIDtQwwEAAHxHwAEAAHxHwAEAAHxHwAEAAHxHwAEAAHxHwAEAAHxHwAEAAHxHwAEAAHxHwAEAAHxHwAEAAHxHwAEAAHxHwAEAAMxv/x/T6wl6EUWzmQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 550x380 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 3.1 Reordonnancement : aiguille debut / milieu / fin (memes essais, position seule)\n",
+    "def probe_position(position, seed, hay_tokens=4000):\n",
+    "    pos_map = {\"debut\": 0.05, \"milieu\": 0.5, \"fin\": 0.95}\n",
+    "    ctx, expected = build_haystack(pos_map[position], seed, hay_tokens)\n",
+    "    prompt = f\"D'apres le document suivant, quel est le code du coffre ? Reponds uniquement par le nombre.\\n\\n--- DOCUMENT ---\\n{ctx}\\n--- FIN ---\"\n",
+    "    return simple_score(expected, chat(prompt, max_tokens=256))\n",
+    "\n",
+    "pos_results = {}\n",
+    "for position in [\"debut\", \"milieu\", \"fin\"]:\n",
+    "    scores = [probe_position(position, seed) for seed in (11, 12, 13)]\n",
+    "    pos_results[position] = sum(scores) / len(scores)\n",
+    "    print(f\"  {position:7s} : {scores} -> recall {pos_results[position]:.3f}\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5.5, 3.8))\n",
+    "ax.bar(list(pos_results.keys()), list(pos_results.values()), color=[\"tab:green\", \"tab:red\", \"tab:green\"])\n",
+    "ax.set_ylabel(\"taux de rappel (3 essais)\")\n",
+    "ax.set_ylim(0, 1.05)\n",
+    "ax.set_title(\"Effet du reordonnancement (aiguille a 3 positions)\")\n",
+    "ax.grid(alpha=0.3, axis=\"y\"); plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "262de90a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004847,
+     "end_time": "2026-08-24T00:03:02.079852+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:02.075005+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Map-reduce vs troncation — la perte quantifiée\n",
+    "\n",
+    "Quand le corpus ne tient pas dans la fenêtre, deux réflexes s'opposent :\n",
+    "\n",
+    "- **Tronquer naïvement** : garder les premiers `K` tokens et traiter ce qui reste. Simple, mais on jette la fin du document.\n",
+    "- **Map-reduce** : résumer chaque document (map), puis synthétiser les résumés (reduce). Plus cher en appels, mais on conserve l'information de chaque document.\n",
+    "\n",
+    "La question n'est pas « lequel est mieux » : c'est **combien** on perd. On définit une **métrique de perte** — ici la capacité à retrouver une entité factuelle présente dans les documents — et on la mesure sur les deux stratégies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "154f423a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:03:02.090941Z",
+     "iopub.status.busy": "2026-08-24T00:03:02.090649Z",
+     "iopub.status.idle": "2026-08-24T00:03:02.097770Z",
+     "shell.execute_reply": "2026-08-24T00:03:02.096790Z"
+    },
+    "papermill": {
+     "duration": 0.014121,
+     "end_time": "2026-08-24T00:03:02.098665+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:02.084544+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre de documents : 5\n",
+      "   [DOC-1]  GUY DE MAUPASSANT  Le Horla    1887     LE HORLA     _8 mai._--Quelle journée admirable! J'ai passé toute la ma\n",
+      "   [DOC-2] hé à droite, à gauche, longtemps pour qu'il ne devinât rien; puis j'ai ôté mes bottines et mis mes savates avec \n"
+     ]
+    }
+   ],
+   "source": [
+    "# 4.1 Preparation : un corpus multi-documents avec des faits discriminants\n",
+    "# On decoupe le Horla en documents, et on injecte dans chacun un fait propre a retrouver.\n",
+    "CHUNKS = 5\n",
+    "# Chaque fait porte une CLE distinctive (AB-i-XY) : c'est elle qu'on cherche dans les reponses.\n",
+    "facts = [f\"La note {i} des archives disait : AB-{i}-XY.\" for i in range(1, CHUNKS + 1)]\n",
+    "fact_keys = [f\"AB-{i}-XY\" for i in range(1, CHUNKS + 1)]\n",
+    "doc_chunks = []\n",
+    "step = len(horla_text) // CHUNKS\n",
+    "for i in range(CHUNKS):\n",
+    "    body = horla_text[i*step:(i+1)*step][:12000]\n",
+    "    doc_chunks.append(f\"[DOC-{i+1}]\\n{body}\\n[END-{i+1}]  Insere : {facts[i]}\")\n",
+    "\n",
+    "print(\"Nombre de documents :\", CHUNKS)\n",
+    "for i, d in enumerate(doc_chunks[:2]):\n",
+    "    print(\"  \", d[:120].replace(chr(10), \" \"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7c61f9aa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:03:02.109983Z",
+     "iopub.status.busy": "2026-08-24T00:03:02.109685Z",
+     "iopub.status.idle": "2026-08-24T00:03:10.667884Z",
+     "shell.execute_reply": "2026-08-24T00:03:10.666764Z"
+    },
+    "papermill": {
+     "duration": 8.56503,
+     "end_time": "2026-08-24T00:03:10.668706+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:02.103676+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "faits totaux : 5\n",
+      "map-reduce  -> retrouve 5 | reponse : En analysant les résumés fournis, on peut identifier les notes mentionnées dans chaque paragraphe :\n",
+      "\n",
+      "1.  Le premier résumé indique que le narrateur intègre la note **AB-1-XY**.\n",
+      "2.  Le deuxième résumé précise que la note **AB-2-XY** était dans les archives.\n",
+      "3.  Le troisième résumé commence par l'indi\n",
+      "troncation  -> retrouve 1 | reponse : AB-1-XY\n",
+      "\n",
+      "perte relative (troncation vs map-reduce) : 80%\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeoAAAFdCAYAAADMoi73AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAALx9JREFUeJzt3QeUFFX69/FnhpwzAgqIgguIIKIiOekiq6sEE6JiQkVE0GMAA4igKPJnTayILgiIgorgSlBgJQeJKhIlg8CSGXKaes/v7ul+uyfA9NBD1zDfzzkF09XVVberq+qpm+rGeZ7nGQAA8KX4WCcAAACkjkANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANhLj00kvtwQcfPOMyel/LpdcPP/xgV199teXOndvi4uJs//79dqHQ93nttddinYxM57PPPnP7buPGjWHz33nnHbvsssssW7Zs7phJ6zGKCwuBGum+qAQmBZwrrrjCnnrqKfvvf/8b1W3985//dNuLlenTp6d4AU2vPXv22F133WV58uSxgQMH2ogRIyxfvnyWmUycOJFgnE5vvvmmjRs3Lk3LTp482V544QWrV6+eDR061H0WWZSe9Q1EYujQoXo+vPf66697I0aM8D755BOvffv2Xnx8vFehQgXv8OHDUdvWlVde6TVq1Mg7X8qXL+++S8C0adPcd92wYUNw3okTJ7xjx46la/2TJk1y65syZYqXWXXq1Ml9h5QcPXrUO3ny5HlPU2aRL1++sOMr4NSpU27fJSYmBue9+OKL7pw6fvx42LI69nQMIuvIHusbBWReLVq0sGuvvdb9/eijj1qxYsVswIAB9t1331nbtm3Pad1HjhyxvHnzmh/lyJEj3Z/duXOn+79w4cJRS8/hw4d9kytX6Qoip6JtTUmPFZW85MyZM2x+rly5znPqEGsUfSNqmjZt6v7fsGFDcN7nn39utWrVchecokWL2j333GNbtmwJ+1zjxo2tWrVqtnjxYmvYsKEL0C+99JKri1u+fLnNmDEjWMyuZQNUt9u1a1crW7asu3hVrFjR3n77bUtMTDxrWjVoXJ8+feySSy5x22vSpInbVlokraNWsbjS1r9/fxs8eLBdfvnlLj3XXXedLVy4MOx7tm/f3v2t9/SZ0LrGr7/+Orivihcvbvfdd5/9+eefybadP39+W7dunf3tb3+zAgUKWLt27dx7Wp+qH7SeqlWruvXUqVPHli1b5t7/+OOP3T5SMFVakhbnz5o1y+68804rV66cS7/26zPPPGNHjx4N276K7APbC0xnqqNeunSpu6krWLCgS3uzZs1s/vz5KVanzJkzx5599lkrUaKEu/lo1aqV7dq1K02/i4qUdRzp++n/sWPHJvutAlUZ+j9U4DcMrWb57bff3OdVR6x1lipVyh5++GFXfRFK31efXbt2rVteN2GFChWyhx56yN1whu4b3VQNGzYsuN8Cv3/SOmr9reJuLR9YNpC2lOqo03ou6PW7775rV155pftOF110kT3++OO2b9++NO1jxAY5akSNgocoZy1vvPGGvfrqq65OVjluXXA/+OADF4x18Q7NVerip4u5ArkClC4gCiadO3d2F/eXX37ZLaf5ogtgo0aNXCDThUbBZe7cuda9e3fbvn27uxidSY8ePVygVrDTtGTJEvvrX/9qJ06cSPf3/+KLL+zgwYMuPbqw9uvXz1q3bm3r1693uXB9h7/85S8umL/++utWoUIFF9RFF2Fd2BXA+/bt6+r633vvPRe4ku6rU6dOWfPmza1+/fru5iC05EHB9t///rd16tTJvda6br31VlfXqfr+J5980l2UlTYFnZ9++in4WQV47deOHTu633DBggXu99q6dat7T/Tdtm3bZlOmTHH162ejm58GDRq4IK00aD/ohkG/rW7AateuHba8fu8iRYpYz549XdDS76ibj9GjR5+1PrdNmzbuBkXfWceT9qduxNJL31G/ndajIK3vot9O/+tGI/QGRXSc6zfV9nU8ffrpp1ayZEkXMEX7S+fB9ddfb4899pibF/j9k9Ky2pZ+A61H6tatm+KykZwLej9wrD399NPupvrDDz90x5iOtXMpLUIGinXZOzJvHfXUqVO9Xbt2eVu2bPFGjRrlFStWzMuTJ4+3detWb+PGjV62bNm8N954I+yzy5Yt87Jnzx42X3XQWt+gQYPSXEfdu3dvV9+3Zs2asPndunVz2928eXOq6d+5c6eXM2dO75ZbbgmrE3zppZdcOlKqQwyl91WXHaD6a31O33/v3r3B+d99952b//333yfbdwsXLgzOU31jyZIlvWrVqrl6yoDx48e7ZXv06BG2bc3T90xK83PlyhVWn/7xxx+7+aVKlfISEhKC87t3756s7v3IkSPJ1tm3b18vLi7O27RpU5rqqDW/Z8+ewdctW7Z0+3rdunXBedu2bfMKFCjgNWzYMNl+ufHGG8N+k2eeecb9nvv37/fO5Oqrr/ZKly4dttzkyZPdOkN/q0CbA/0fKvAbKh1n2h9ffvmlW27mzJnBefq+mvfwww+HLduqVSt3TKSljjrw/UN/Dy2n5c/WjiKt58KsWbPcNkaOHBm23A8//JDifPgHRd9ItxtvvNEVUaq4TTlh5XxV3HjxxRfbt99+64rZlMvYvXt3cFLOpFKlSjZt2rSwdam4Tnf5aaUcnnJqyn2Frl9pOn36tM2cOTPVz06dOtXlnJV7C80VqejwXNx9990uPQFKnyhXdiaLFi1y9ZHK7YbW8d5yyy1WuXJlmzBhQrLPKNebEhUrhxb1BnKsym2qmDzp/NC0qag8QEWu2p/KxSn+KscVKf0Oyum2bNnSFR8HlC5d2u69916bPXu2JSQkhH1GOc3Q30T7UOvZtGlTqttRrvGXX35x1Qoqcg646aabXA47vUL3x7Fjx9z+uOGGG9xr5ZiTeuKJJ8JeK+3K2Sf9jtGW1nNBy2n/aL+ELqfqFp27Sc9J+AdF30g31VWqW1b27NldkbSKdePj/3fv98cff7gLvIJySpIWsSm4J200cyZav+oQdaNwpkZbKQlc9JOmTesKDbSRUpFjqMC6zlb/F0iP9l9SCtQKaKG0v1Mr0k2ahkDg0s1USvND07Z582ZXJaCi86RpPnDggEVKVR0qlk3pe1WpUsXdyKm9gupLz2UfpvZ7iradUlBNi71791qvXr1s1KhRyY6nlPbHmdKuov+MktZzQcsp3SqOP9Ny8B8CNdJNdW2BVt9J6SKsnNGkSZOStWYV3cGnlntJC61fOQPVe6ZENxDnW0rfU/5XIhw9Kn0I3BClNQ1nS5tyXtqfCk4vvviiu0FQYy7Ve6rhUloa6GWGfZi0XjlA3z8plQaprvf55593DxvRMav9cPPNN6e4P87X75/ec0HLKUiPHDkyxeVSC/SIPQI1MoQayegCpcY15xI0U7uwav2HDh1yxXuRKl++fDCHEVokqxxgLFq/BtKzevXqYMv5AM0LvJ+R1DJ8zZo1rkXyAw88ENagKq2/SUoXfjV003dIatWqVe5mI2lOPz1Cf8+kkm47kMtN+jS4pEXrOg7+85//uBy1ShkCUtpGJNK67yKR1nNBy6naRw9QifTGGLFFHTUyhFo7K4ehC13SHIVeJ+3ikhrl6lJ6xKZyO/PmzbMff/wx2XtaXi2jU6MLmore1aI5NG1naymeUVQqoZzOoEGD7Pjx48H5Ko1YuXKlq6vOaIHcYOj+0N9qeZ5UoM/22R59qnWqJb361Yd2BVOLdrWQV6v1aBQJq85bOV7dZIQWSesmY8WKFcmCutKVtA2DWsQnTbskPXbP9RhJ7Xg+F2k9F7ScSg569+6dbDktcyE9yvZCQ44aGUJ37+r+pC4iukirQZEaM6k7iBqcqdHQc889d9b1qKHLRx995NalvqEKaMp1qjhSdanqeqSiWS2nBlDKGX7zzTdum+qLnFpOT9sOdF1S9yw1llJgTO0zGUk3DerCo8Z06majh8UEumepYZj6Mmc0FXXrN9N+UXG3AuiYMWNSLGHQvhZ171E3MQU1NSZMiX43BUwFZTWWU/26umfphkRdxKJFv6VuaLQddTtTEb5uxFT/rdxmaN28+orrPeVu9Z3Hjx+frH5W31/dCJXGkydPujYUahgX+oyA9NC+U65WDwYqU6aMK3FK2kUtUmk9F3RsqXuW9pUa3+kmSseeSgnU0EzH2x133HFOaUEGiXWzc2Q+KXUxSs2YMWO8+vXru+4jmipXruy696xevTq4jLpfqRtWSnbs2OG6Uak7j7YZ2lXr4MGDrptRxYoVXReg4sWLe3Xr1vX69+9/1kcsnj592uvVq5fr0qMuZY0bN/Z+//33ZF1fIume9c4775y1u9KZ9t3o0aO9mjVrui5WRYsW9dq1a+e6uiXddkpddgLb0r4NlVraAt2Uvv766+C8FStWuO5R+fPnd/uyQ4cO3q+//pqs25Ied9m5c2evRIkSrutW6GUk6feVJUuWeM2bN3frzZs3r9ekSRNv7ty5Ycuktl9S606V2rFWpUoVt/+qVq3qffvtt8l+K1GXwjZt2ri0FClSxHv88cfdb5/0e2rfq4tV4cKFvUKFCnl33nmn61qW9DsGumdpvWfrcrVq1SrXLU3HXGhXwHPpnhXpuTB48GCvVq1aLg06r6666irvhRdecN8N/hSnfzLqJgAAYkk5TD2FLFqDqgCxQB01AAA+RqAGAMDHCNQAAPhYTAN1YNSZ0EmtTwEgGjQABfXTyOxi3j1L3SfUXSFA3TcAAMD/xDwqKjBroIa0UN/L0AdC6JF46i+pIfky4ok/AABkBHW40rC46k+f2iOBfROo1dleCdWoQRrkXp3xkz7cPkDv6UlXAABcCDQwzdnGTY9pP2o9CUpPDdIINxqqTkFYT0X6/fffw4bkSy1HrccFKqjrOb3RGp2m/qj6UVkPcD7Nvid8hC0A/qbhT/VIWz26NXR4Vt/lqFu0aBH8u3r16u5Rekr4V199ZY888kiKowZpSqpw4cJRC9RxeShCR+ajcwBA5hEo7k5LtW283y42Gmlp7dq1sU4KAAC+4KtArWLwdevWudFwAABAjAO1RuqZMWOG6+eoAdpbtWrlRuLR6EEAACDGddRbt251QVljE2voQQ1RN3/+fPc3AACIcaAeNWpULDcPAIDv+aqOGgAAhCNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD7mm0D91ltvWVxcnHXt2jXWSQEAwDd8EagXLlxoH3/8sVWvXj3WSQEAwFeyxzoBhw4dsnbt2tknn3xiffr0OeOyx48fd1NAQkKC+z8xMdFN0RDvj3sXICLROv4B+O+cjXmg7tSpk91yyy124403njVQ9+3b13r16pVs/q5du+zYsWNRSU+l7JWish7gfNq5c2eskwAgAgcPHswcgXrUqFG2ZMkSV/SdFt27d7dnn302LEddtmxZK1GihBUsWDAqafrj1B9RWQ9wPpUsWTLWSQAQgdy5c/s/UG/ZssW6dOliU6ZMSXOCc+XK5aak4uPj3RQNiUYRIjKfaB3/APx3zsYsUC9evNgV111zzTXBeadPn7aZM2fahx9+6Oqis2XLFqvkAQDgCzEL1M2aNbNly5aFzXvooYescuXK9uKLLxKkAQCIZaAuUKCAVatWLWxevnz5rFixYsnmAwCQVVGxBQCAj8W8e1ao6dOnxzoJAAD4CjlqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPCx7On94OHDh+2rr76ytWvXWunSpa1t27ZWrFix6KYOAIAsLs2BumrVqjZ79mwrWrSobdmyxRo2bGj79u2zK664wtatW2e9e/e2+fPnW4UKFTI2xQAAZCFpLvpetWqVnTp1yv3dvXt3K1OmjG3atMkWLFjg/q9evbq9/PLLGZlWAACynHTVUc+bN89ee+01K1SokHudP39+69Wrl8txAwCAGAXquLg49/+xY8dcvXSoiy++2Hbt2hXFpAEAgIgakzVr1syyZ89uCQkJtnr1aqtWrVrwPRV/05gMAIAYBeqePXuGvVZxd6jvv//eGjRoEL2UAQAAi/M8z7NMSjl71ZMfOHDAChYsGJV1XjXsqqisBziflrVfFuskAMig+MUDTwAA8DECNQAAPkagBgDAxwjUAABcCIG6R48etnjx4oxNDQAASF+g3rp1q7Vo0cIuueQS69ixo02aNMlOnDiR1o8DAICMDNRDhgyxHTt22JdffmkFChSwrl27WvHixa1NmzY2fPhw27t3b3q2DwAAolVHHR8f7x5q0q9fP/dksp9//tlq165tH3/8sRukQyNq9e/f3/78889IVgsAADKiMVmVKlXshRdesDlz5rihL9u3b2+zZs1yuW4AAHCen/V9JiVKlLBHHnnETQAAIDrongUAgI8RqAEA8DECNQAAPkagBgDgQgrUw4YNswkTJgRfq9V34cKFrW7durZp06Zopw8AgCwt4kD95ptvWp48edzf8+bNs4EDB7p+1Xr4yTPPPJMRaQQAIMuKuHuW+ktXrFjR/T1u3Dj3ZLLHHnvM6tWrZ40bN86INAIAkGVFnKPOnz+/7dmzx/09efJku+mmm9zfuXPntqNHj0Y/hQAAZGERB2oF5kcffdRNa9assb/97W9u/vLly+3SSy+NaF0fffSRVa9e3QoWLOimOnXquME+AABAOgO16qQVUHft2mVjxoyxYsWKufkaArNt27YRrUsjcb311lvus4sWLbKmTZva7bff7oI+AAAwi/M8zzMfKVq0qL3zzjtpehRpQkKCFSpUyA4cOOBy5NFw1bCrorIe4Hxa1n5ZrJMAIAKRxK90PetbA29oxKz169fb119/bRdffLGNGDHCKlSoYPXr10/PKu306dNuXYcPH3Y59pQcP37cTaFfVBITE90UDfF0LUcmFK3jH4D/ztmIA7WKu++//35r166dLVmyJBg4dVegrlsTJ06MaH3Lli1zgfnYsWOuodrYsWOtatWqKS7bt29f69WrV7L5KobX56OhUvZKUVkPcD7t3Lkz1kkAEIGDBw9mXNF3zZo1XX/pBx54wAoUKGC//vqrXXbZZbZ06VJr0aKF7dixI5LV2YkTJ2zz5s0u0H/zzTf26aef2owZM1IM1inlqMuWLWv79u2LWtF3zRE1o7Ie4Hxaev/SWCcBQAQUv4oUKZIxRd+rV6+2hg0bJpuvsvb9+/dHujrLmTNnsF92rVq1bOHChfbee++5ovWkcuXK5aak4uPj3RQNiUYRIjKfaB3/APx3zkZ8dpcqVcrWrl2bbP7s2bNdzjoa5fahuWYAALKyiHPUHTp0sC5dutiQIUMsLi7Otm3b5h4l+txzz9mrr74a0bq6d+/uisvLlSvnyuu/+OILmz59uv3444+RJgsAgAtSxIG6W7duLtfbrFkzO3LkiCsGV3G0AnXnzp0jbgCjuu7t27e7onM9/ERBOvC0MwAAsrp096NWIzAVgR86dMg1/FKL7fONftTA/9CPGshcIolfEddRf/755y4nrUZgCtDXX399TII0AABZQcSBWl2zSpYsaffee6/rM60HlQAAAJ8EatUnjxo1yjUku+uuu6x06dLWqVMnmzt3bsakEACALCziQJ09e3a79dZbbeTIka4x2D/+8Q/buHGjNWnSxC6//PKMSSUAAFlUup71HZA3b15r3ry5ezLYpk2bbOXKldFLGQAASN8IFGpMphy1xqLWgBzvvvuutWrViuEpAQCIdY76nnvusfHjx7vctOqo9ZCT1Ea7AgAA5zlQZ8uWzb766itX5K2/AQCAjwK1irwBAIBPA/Xrr79+xvd79OhxLukBAADnEqjHjh0b9vrkyZO2YcMG121L3bMI1AAAxDBQL126NMVnlj744IOu5TcAAIieqIw2rweK9+rVK+JhLgEAwHkI1KIRQDQBAIAYFn2///77Ya81Sqae/z1ixAhr0aJFFJMGAAAiDtR6tneo+Ph4K1GihLVv3966d+8ezbQBAJDlRRyo1cIbAABkgjrqrVu3ugkAAPgkUCcmJrqHnhQqVMjKly/vpsKFC1vv3r3dewAAIIZF3y+//LL961//srfeesvq1avn5s2ePdtee+01O3bsmL3xxhtRTB4AAFlbxIF62LBh9umnn9ptt90WnFe9enU33OWTTz5JoAYAIJZF33v37rXKlSsnm695eg8AAMQwUNeoUcM+/PDDZPM1T+8BAIAYFn3369fPbrnlFps6darVqVPHzZs3b55t2bLFJk6cGMWkAQCAiHPUjRo1sjVr1rgBOPbv3++m1q1b2+rVq61BgwYZk0oAALKoiHLUGtLy5ptvtkGDBtFoDAAAv+Woc+TIYb/99lvGpQYAAJxb0fd9993n+lEDAAAfNiY7deqUDRkyxDUmq1WrluXLly/s/QEDBkQzfQAAZGkRB+rff//drrnmGve3GpUBAAAfBepp06ZlTEoAAMC511E//PDDdvDgwWTzDx8+7N4DAAAxDNR61vfRo0eTzde84cOHRytdAAAgkqLvhIQE8zzPTcpR586dO/je6dOn3VPJSpYsmVHpBAAgS0pzoNaY03FxcW664oorkr2v+b169Yp2+gAAyNKyR9KITLnppk2b2pgxY6xo0aLB93LmzGnly5e3MmXKZFQ6AQDIkrJH8oxv2bBhg5UrV87loAEAgM8akynnPHv2bPeEsrp169qff/7p5o8YMcLNBwAAMQzUKvZu3ry55cmTx5YsWWLHjx938w8cOGBvvvlmFJMGAAAiDtR9+vRxo2d98sknbpCOgHr16rnADQAAYhioNe50w4YNk80vVKiQG5saAADEMFCXKlXK1q5dm2y+6qcvu+yyaKULAACkJ1B36NDBunTpYj///LNr+b1t2zYbOXKkPffcc9axY8eMSSUAAFlUxINydOvWzRITE61Zs2Z25MgRVwyeK1cuF6g7d+6cMakEACCLiihQ61Ghc+bMsU6dOtnzzz/visAPHTpkVatWtfz582dcKgEAyKIiCtTZsmWzv/71r7Zy5Ur3SFEFaAAA4KM66mrVqtn69eujsvG+ffvaddddZwUKFHADerRs2dK1KgcAAOfQj1r10ePHj7ft27e7UbVCp0jMmDHDFaPPnz/fpkyZYidPnnQ5do1tDQAAzOI8jbQRgfj4/x/bQ5/3rdXoteqx02vXrl0uZ60AnlJf7aR0Y6D+23oqWsGCBS0arhp2VVTWA5xPy9ovi3USAEQgkvgVcatvjaKVUZRgCR2ZK5QeVxp4ZKkEcvBqha4pGuIjL2QAYi5axz8A/52zEQfqwChaGZHorl27ukeRqh48tTrtlMa8Vk782LFjUUlHpeyVorIe4HzauXNnrJMAIAIHDx7MuKLvjKKHpUyaNMk94eySSy5Jc466bNmytm/fvqgVfdccUTMq6wHOp6X3L411EgBEQPGrSJEiGVP0nRGeeuop1zht5syZqQZp0YNVNKVUbx5ad34uEo0iRGQ+0Tr+AfjvnI1poFZmXk8zGzt2rE2fPt0qVKgQy+QAAOA7MQ3U6pr1xRdf2Hfffef6Uu/YscPNV0s4jXcNAEBWF3F52dGjR90zvgM2bdpk7777rk2ePDnijX/00UeufL5x48ZWunTp4DR69OiI1wUAwIUo4hz17bffbq1bt7YnnnjCjT9du3Zty5Ejh+3evdsGDBgQ0QhaPmnHBgDAhZOjXrJkiTVo0MD9/c0339hFF13kctXDhw+3999/PyPSCABAlhVxoFaxt+qTRcXdyl2r9doNN9zgAjYAAIhhoK5YsaKNGzfOtmzZYj/++KN7NnfggQvR6ssMAADSGah79OjhBuW49NJLXf10nTp1grnrmjV5WAgAADFtTHbHHXdY/fr13chZNWrUCM5v1qyZKwYHAAAxzFE//PDDli9fPpd7Dn2yypVXXmlvv/12FJMGAAAiDtTDhg1zfamT0jy1/AYAADEo+tYDxNXvWZNG/cidO3fwPY1BPXHiRDeWNAAAiEGgLly4sMXFxbnpiiuuSPa+5qc0BCUAADgPgXratGkuN920aVMbM2aMFS1aNPhezpw5rXz58lamTJlzSAoAAEh3oG7UqJH7f8OGDVauXDmXgwYAAD4I1L/99ptVq1bNtfLWIBrLli1Lddnq1atHM30AAGRpaQrUV199tRuCUo3F9Ldy0ykNqKH5algGAADOY6BWcXeJEiWCfwMAAB8FajUUS+lvAADgs0eIBqxYscI2b95sJ06cCJt/2223RSNdAAAgPYF6/fr11qpVK9egLLSuOtAKnDpqAABi+AjRLl26WIUKFdywlnnz5rXly5fbzJkz7dprr7Xp06dHMWkAACDiHPW8efPsp59+suLFi7vuWpo0mlbfvn3t6aeftqVLl2ZMSgEAyIIizlGraLtAgQLubwXrbdu2BRuZrV69OvopBAAgC4s4R60Hn/z666+u+Lt27drWr18/9wjRwYMH22WXXZYxqQQAIIuKOFC/8sordvjwYff366+/brfeeqs1aNDAihUrZqNHj86INAIAkGVF/AjR5s2bB+dXrFjRVq1aZXv37rUiRYrw/G8AAGJRR12zZk3bvXu3+1vF23v27Al7XyNpEaQBAIhRoNZY1IFHh27cuNESExMzICkAACBdRd9t2rRxw1yWLl3a5ZzVZzpbtmypPhAFAACcx0CtFt2tW7e2tWvXur7SHTp0CHbRAgAAPmj1ffPNN7v/Fy9e7J5ORqAGAMCH3bOGDh2aMSkBAADn/mQyAABw/hCoAQDwMQI1AAA+RqAGAMDHCNQAAPgYgRoAAB8jUAMA4GMEagAAfIxADQCAjxGoAQDwMQI1AAA+RqAGAMDHCNQAAPgYgRoAAB8jUAMA4GMEagAAfIxADQCAj8U0UM+cOdP+/ve/W5kyZSwuLs7GjRsXy+QAAOA7MQ3Uhw8ftho1atjAgQNjmQwAAHwreyw33qJFCzel1fHjx90UkJCQ4P5PTEx0UzTEUxuATChaxz8A/52zMQ3Ukerbt6/16tUr2fxdu3bZsWPHorKNStkrRWU9wPm0c+dOy1S+uDvWKQAid+9oi5aDBw9emIG6e/fu9uyzz4blqMuWLWslSpSwggULRmUbf5z6IyrrAc6nkiVLWqaS8FusUwBELornWe7cuS/MQJ0rVy43JRUfH++maEg0ihCR+UTr+D9/OM+QCcXHx+SczWxnNwAAWQqBGgAAH4tp0fehQ4ds7dq1wdcbNmywX375xYoWLWrlypWLZdIAAPCFmAbqRYsWWZMmTYKvAw3F2rdvb5999lkMUwYAgD/ENFA3btzYPM+LZRIAAPA16qgBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgYwRqAAB8jEANAICPEagBAPAxAjUAAD5GoAYAwMcI1AAA+BiBGgAAHyNQAwDgY74I1AMHDrRLL73UcufObbVr17YFCxbEOkkAAPhCzAP16NGj7dlnn7WePXvakiVLrEaNGta8eXPbuXNnrJMGAEDMZY91AgYMGGAdOnSwhx56yL0eNGiQTZgwwYYMGWLdunULW/b48eNuCjhw4ID7f//+/ZaYmBiV9HhHvaisBzifdA5kKsfjYp0CIHJRPM8SEhLc/56XhpjjxdDx48e9bNmyeWPHjg2b/8ADD3i33XZbsuV79uypb8TExMTExORdCNOWLVvOGitjmqPevXu3nT592i666KKw+Xq9atWqZMt3797dFZMHKBe9d+9eK1asmMXFcYfuZ7p7LFu2rG3ZssUKFiwY6+QAFyTOs8xDOemDBw9amTJl/F/0HYlcuXK5KVThwoVjlh5EThcPLiBAxuI8yxwKFSrk/8ZkxYsXt2zZstl///vfsPl6XapUqZilCwAAv4hpoM6ZM6fVqlXL/vOf/4QVZ+t1nTp1Ypk0AAB8IeZF36pzbt++vV177bV2/fXX27vvvmuHDx8OtgLHhUFVFuqCl7TqAkD0cJ5dmOLUoizWifjwww/tnXfesR07dtjVV19t77//vnvwCQAAWZ0vAjUAAPDpk8kAAEDqCNQAAPgYgRoAAB8jUMPXNKqaegIACNe4cWPr2rWrZQacx5m8exYAnO8Ap94lmSVwTJ8+3Zo0aWL79u0LexLjt99+azly5LDMYOHChZYvX75YJyPTIlAjw504ccI93AbILNQZRuMQZM/u30tk0aJFLbMoUaJErJOQqVH0fQHlEjp37uyKwooUKeIGNvnkk0+CD48pUKCAVaxY0SZNmuSW10XokUcesQoVKliePHnsL3/5i7333nth63zwwQetZcuW1qtXL3ei6dnBTzzxhAu8Zyvm6t27tz3wwAPuM4899pibP3v2bGvQoIHbngYOePrpp136AjQG+d///nf3vtI1cuTIsPVu3LjRDb7yyy+/hA3vqHnKdQQsX77cbr31VrdtfW9tc926dcH3P/30U6tSpYrlzp3bKleubP/85z/Tvd+RueiYnjFjhjvWddxo0nGl40d/6/zQ0xL1wBAdrxpWV8dpyZIl3fFSv359lzsMCHxOT1PUQ5vy5s1rdevWtdWrV4dt9/vvv7frrrvOrUOPTm7VqlXwvREjRrjP6ljVo5Pvvfdedy6I0qbctOi81rb0HVIq+laOW+ecllM6WrRoYX/88Ufw/c8++8zlyH/88Ud3/OfPn99uvvlm2759e6r7Ky3fT+fW7bff7q45Wqe+59SpU1Mt+tb3u/vuu8PeP3nypNsvw4cPDz6hsm/fvsHrU40aNeybb76xLCuKo1Yihho1auQVKFDA6927t7dmzRr3v4YQbdGihTd48GA3r2PHjl6xYsW8w4cPeydOnPB69OjhLVy40Fu/fr33+eefe3nz5vVGjx4dXGf79u29/Pnze3fffbf3+++/e+PHj/dKlCjhvfTSS2dMS/ny5b2CBQt6/fv399auXRuc8uXL5/3jH/9waZkzZ45Xs2ZN78EHHwx+TmmtUaOGN2/ePG/RokVe3bp1vTx58rjPyIYNG9ywcEuXLg1+Zt++fW7etGnT3OutW7d6RYsW9Vq3bu2+2+rVq70hQ4Z4q1atcu/re5YuXdobM2aM+976X8t/9tlnUf9N4D/79+/36tSp43Xo0MHbvn27m06dOuWOHx1H1atX9yZPnuyO1z179nhPP/20V6ZMGW/ixIne8uXL3TlRpEgR954EPle7dm1v+vTpbpkGDRq4YzdA543ORZ1vK1as8H755RfvzTffDL7/r3/9y61/3bp17thX+nQuiNKmY1Tb0LGs9Oo7BM75Ll26BNejoYGrVKnizZw5022jefPmXsWKFd25LkOHDvVy5Mjh3Xjjje7cWLx4sVv+3nvvTXV/peX7aVuDBg3yli1b5s7tV155xcudO7e3adOmsGtC4DzW/tB5ffDgweD733//vZuXkJDgXvfp08erXLmy98MPP7j9orTnypXLpSErIlBfIHTS1q9fP/haJ7gC4/333x+cp5NcJ50uBinp1KmT16ZNm+BrXZQUxBTYAz766CMXvE+fPp1qWnRStmzZMmzeI4884j322GNh82bNmuXFx8d7R48edRchpW3BggXB91euXOnmRRKou3fv7lWoUCF4cUrq8ssv97744ouwebqp0cURWUPSABcakMaNGxecd+jQIRfYRo4cGZyn40qBu1+/fmGfmzp1anCZCRMmuHk6rkXHVrt27dKcPgVRfT4QyALb0LGe2vdQgNQyugEO2L17twt+X331lXutYKdldBMSMHDgQO+iiy5KNS1p+X4pufLKK70PPvggxUB98uRJr3jx4t7w4cOD77dt29ZlCOTYsWMu0zB37txk15C2bdt6WRFF3xeQ6tWrB//WqGQap/uqq64KzguM+x0oVhs4cKAr5lOxtoqsBg8ebJs3bw5bp4qcVNwVoMFSDh065Ma7VdG0PheYZs2aFVxOxWShfv31V1f0Frp88+bNXRHXhg0bbOXKla4+UOkJULF0pMOYqlhcRd0pNbJRMbuK6VTkH5qOPn36hBWNI+sKPW51TKhItl69esF5Oq40JoGO19TOvdKlS4edZzommzVrluo2Fy9e7Kp8ypUr54q/GzVq5OYnPRfPJHD+hD56Wee/qrRC06pz+fLLLw9LayCdZ3Km76frwXPPPeeK03W+6pzSNlNLv9J51113Bau2dF5+99131q5dO/d67dq1duTIEbvpppvCztPhw4dn2fPUvy0lELGkwUl1S6Hz9FoUHEeNGuVOrv/7v/9zwVcXCD1v/eeff07z9m677bawC8PFF18c/DtpC0+dzI8//rir70tKF6g1a9acdXvx8f+7rwx96q0upKFUn5UapUFUd5/0WfK6sQHS2zI5tfPsbMekgpRuWDUpcOmmWQFOr8/WFuRc0xlIa1qeIn2m76fryJQpU6x///6uHYy+7x133HHG9Cso64ZEwV6f1WdUXx56nk6YMCHsmiJZdbARAnUWNWfOHNco5MknnwzOS+luVTnho0ePBi828+fPd3e3agymwKkAnxbXXHONrVixwp3IKVHu+dSpUy53ocYoogYraiyWtOWoGr/UrFnT/R3asCxw5z9s2DAXwJNelFSiUKZMGVu/fn3w7h1Zj3ogqDHl2SjnqWV1rpQvX97N03GlxmSR9F/WManGWCmNCLhq1Srbs2ePvfXWW+6ckkWLFiVLr5wpzcrN6vzRjbbOa9F6dQ5VrVrVMpL2jxq4BRrIKdCqEdyZKI36vqNHj3YN+O68887g+ar0KiDrhiVQupDVUfSdRVWqVMldENQCVLnZV199Naw1a4DuilVUrCA7ceJEN4TeU089FczdptWLL75oc+fOdZ9VcFVrVBV36bWoiE531Mp162KjgP3oo4+G5Ub09w033OAuaipaU+vdV155JWw7Wl9CQoLdc8897vtpO2pVG2ilqhbsak2qEdr0vZctW2ZDhw61AQMGpHNPIrNRC2QdYwomu3fvDuYMU8pdd+zY0Z5//nn74Ycf3DnQoUMHVyyrcyKtdM58+eWX7n8dtzrm3n777WBpkgLxBx984G4g//3vf7seE6F0k6Bc7Pjx423Xrl3BHGfS81ktr5U+tVbXDfZ9993ncqSan5G0bfXp1nmt7apVd2r7NJSWGzRokMtRh9446+ZfufRnnnnG3XSvW7fOlixZ4vaRXmdFBOosSgGxdevWrpuEioF19x2auw5Q3ZpOxIYNG7plVdz92muvRbw95SoUWBUcVYesHHGPHj1cDjdAAVOvdRettKlbl7rFhBoyZIjLOaguW7ka1S+HUr3cTz/95C5mWo+WU1F34G5dwV/ds7Qt1d9rGdWdqxsIsgYFAVV1KOcWKGpOjW4K27RpY/fff78rFVL9qW5u1QUqrdSN6uuvv3ZBWA9aadq0qS1YsMC9p+3r+NP7So+2pyLkUAq2usHs1q2bKxUK3NwmpWNax7u6Jqo6S0XaurnO6Iei6CZX+0O5ZNW1q9he++psFJx186PvF9oOQHSzosyDbqqrVKnibuJVFJ5Vz1OGuUSqVJyloudx48bFOikAkGWRowYAwMcI1AAA+BhF3wAA+Bg5agAAfIxADQCAjxGoAQDwMQI1AAA+RqAGAMDHCNQAAPgYgRoAAB8jUAMAYP71/wDEKHhvrjyu3AAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 500x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 4.2 Map-reduce (resumer puis synthetiser) vs troncation naive\n",
+    "def map_reduce(docs, question):\n",
+    "    # Chaque map est INSTRUIT de conserver les entites factuelles (notes AB-n-XY) : c'est ce\n",
+    "    # qui fait du map-reduce une strategie qui condense sans perdre l'information cible.\n",
+    "    maps = [chat(\"Resume ce document en 2 phrases, en conservant explicitement toute entite factuelle (notes du type AB-n-XY).\\n\\n\" + d, max_tokens=256) for d in docs]\n",
+    "    reduce_prompt = (\"Voici des resumes de documents. Reponds a la question, en citant chaque fait.\\n\\n\"\n",
+    "                     + \"\\n---\\n\".join(maps) + \"\\n\\nQuestion : \" + question)\n",
+    "    return chat(reduce_prompt, max_tokens=256), maps\n",
+    "\n",
+    "def truncate(docs, question, max_tokens=4000):\n",
+    "    # troncation naive : on garde le debut de l'ensemble de documents (la fin saute)\n",
+    "    budget = max_tokens\n",
+    "    kept = []\n",
+    "    for d in docs:\n",
+    "        t = TOKENIZER.encode(d)\n",
+    "        keep = t[:budget]\n",
+    "        kept.append(TOKENIZER.decode(keep))\n",
+    "        budget -= len(keep)\n",
+    "        if budget <= 0:\n",
+    "            break\n",
+    "    prompt = (\"Reponds a la question a partir du debut du corpus (la fin a ete tronquee).\\n\\n\"\n",
+    "              + \"\\n\\n\".join(kept) + \"\\n\\nQuestion : \" + question)\n",
+    "    return chat(prompt, max_tokens=256)\n",
+    "\n",
+    "question = \"Quelles notes les archives mentionnaient-elles ? Reponds en listant chaque note AB-n-XY.\"\n",
+    "\n",
+    "mr_answer, mr_maps = map_reduce(doc_chunks, question)\n",
+    "tr_answer = truncate(doc_chunks, question)\n",
+    "\n",
+    "# metrique de perte : nb de faits retrouves sur 5 (on cherche la CLE distinctive AB-i-XY)\n",
+    "def count_found(answer):\n",
+    "    answer = answer or \"\"\n",
+    "    return sum(1 for k in fact_keys if simple_score(k, answer))\n",
+    "\n",
+    "mr_score = count_found(mr_answer)\n",
+    "tr_score = count_found(tr_answer)\n",
+    "print(\"faits totaux :\", CHUNKS)\n",
+    "print(\"map-reduce  -> retrouve\", mr_score, \"| reponse :\", mr_answer.strip()[:300])\n",
+    "print(\"troncation  -> retrouve\", tr_score, \"| reponse :\", tr_answer.strip()[:300])\n",
+    "print(f\"\\nperte relative (troncation vs map-reduce) : {1 - tr_score/max(mr_score,1):.0%}\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5, 3.6))\n",
+    "ax.bar([\"map-reduce\", \"troncation naive\"], [mr_score, tr_score], color=[\"tab:green\", \"tab:orange\"])\n",
+    "ax.set_ylabel(\"faits retrouves / \" + str(CHUNKS)); ax.set_ylim(0, CHUNKS)\n",
+    "ax.set_title(\"Perte d'information quantifiee\"); ax.grid(alpha=0.3, axis=\"y\")\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64386be4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005109,
+     "end_time": "2026-08-24T00:03:10.679101+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:10.673992+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "La barre ci-dessus quantifie la perte : à `5` documents contenant chacun un fait, la troncation naïve en retrouve `1`/`5` (elle saute la fin), le map-reduce en retrouve `5`/`5` (il condense chaque document en conservant les entités factuelles). **La perte relative n'est pas un avis** : c'est `1 − 1/5 = 80 %`, un chiffre.\n",
+    "\n",
+    "Le coût d'équilibre est explicite : le map-reduce `5 + 1 = 6` appels (map sur chaque doc + reduce) contre `1` appel (troncation) — mais pour `4` faits retrouvés de plus. La section 5 ajoute le levier de **latence** : quand les documents partagent un préfixe, le cache vLLM fait baisser le coût du map."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cb55685",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004718,
+     "end_time": "2026-08-24T00:03:10.688613+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:10.683895+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Coût réel — prefix caching vLLM (latence mesurée)\n",
+    "\n",
+    "Le dernier levier n'est pas de changer le contenu, mais **le calcul**. vLLM gère un **automatic prefix caching** : si deux requêtes partagent un préfixe de tokens (typiquement le début d'un long contexte, un *system prompt*, un bloc de documents), les blocs KV de ce préfixe sont **réutilisés** au lieu d'être recalculés. La conséquence est une latence plus faible — mesurable sur le **time-to-first-token (TTFT)**.\n",
+    "\n",
+    "On construit un long contexte, on mesure le TTFT d'une requête dont le préfixe est **déjà en cache** (warm) vs **pas en cache** (cold), sur plusieurs essais, médiane. Le chiffre est réel : cache hit = latence mesurée, pas affirmée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ad7669d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:03:10.701723Z",
+     "iopub.status.busy": "2026-08-24T00:03:10.701320Z",
+     "iopub.status.idle": "2026-08-24T00:03:10.713390Z",
+     "shell.execute_reply": "2026-08-24T00:03:10.712353Z"
+    },
+    "papermill": {
+     "duration": 0.020097,
+     "end_time": "2026-08-24T00:03:10.714208+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:10.694111+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "longueur du prefixe commun : 3837 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5.1 Construire un long contexte partageable\n",
+    "long_doc = horla_text[:12000]\n",
+    "common_prefix = (\n",
+    "    \"Tu es assistant. Voici une note technique longue. Lis tout puis reponds en une phrase.\\n\\n\"\n",
+    "    \"--- NOTE ---\\n\" + long_doc + \"\\n--- FIN NOTE ---\\n\"\n",
+    ")\n",
+    "print(\"longueur du prefixe commun :\", count_tokens(common_prefix), \"tokens\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "acc6ca95",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:03:10.726028Z",
+     "iopub.status.busy": "2026-08-24T00:03:10.725670Z",
+     "iopub.status.idle": "2026-08-24T00:03:15.432757Z",
+     "shell.execute_reply": "2026-08-24T00:03:15.431416Z"
+    },
+    "papermill": {
+     "duration": 4.714287,
+     "end_time": "2026-08-24T00:03:15.433778+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:10.719491+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  essai 1: cold=0.407s warm=0.158s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  essai 2: cold=0.413s warm=0.169s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  essai 3: cold=0.418s warm=0.213s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  essai 4: cold=0.411s warm=0.166s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  essai 5: cold=0.438s warm=0.154s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  essai 6: cold=0.434s warm=0.212s\n",
+      "\n",
+      "TTFT median   cold=0.415s  warm=0.167s\n",
+      "gain de latence (prefix caching) : 60%\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAekAAAFdCAYAAAAnlZX0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASOhJREFUeJzt3QucjPX7P/7LYq3T7jqt08eZorLONlLColIRFTo4JB2JENZhEYWKFKJ8ckgHIqlvaiVRFCkSYuV8XmfWIbbs/X+8rs//nt/M7Mzu7Mxt597d1/PxuNm555573jNz3/d1v895DMMwhIiIiGwnJNgJICIiIs8YpImIiGyKQZqIiMimGKSJiIhsikGaiIjIphikiYiIbIpBmoiIyKYYpImIiGyKQZqIiMimGKQpU15//XWpWrWq5M2bV+rWravrKleuLD169JDsCum/9957M9xu9erVkidPHv2f/PPaa69JzZo1JTU1VewCxy6OAWf4nUePHh20NOVWnn6LjCQkJEiRIkXk5MmTkhMxSGdzc+fO1QuKuYSFhckNN9wgffr0kePHj1v6Xt9++60MHjxYbrvtNpkzZ468+uqrlu6fAofAguPg1KlTGd5sLF68ON19mcfUk08+6fH54cOHO7ZJ7/1MycnJMnHiRBkyZIiEhPDSY4U9e/bII488IlFRUVKwYEGpUaOG/i65yV133SXVq1eX8ePHS06UL9gJIGu8/PLLUqVKFbly5YqsXbtWZsyYIV9//bVs27ZNChUqZMl7fP/993pxff/99yU0NNSxfufOnbnionvHHXfI33//7fLZczrc9H322WfyzjvvpPncn3zyiT6PY84Xs2fPln///Ve6du0qdoffOV8+e18eN2/eLHfeeaeUL19eBg4cKCVKlJCDBw/KoUOHJLuaNWuWX6UsTz/9tAwaNEjGjBkjRYsWlZzE3kch+ezuu++Whg0b6t/I+eCEnTx5snzxxRdeL4qXLl2SwoUL+/weJ06c0Lt194t1gQIFJDfAjQiCUm7LpXz55ZfyzTffSPv27R3rf/75Z9m3b5906tRJg7gvUPpy//33Z4vv0O5pRCB7/PHHtepg1apVel7mBPnz5/frdZ06dZK+ffvKokWL5IknnpCcJOdnf3Kpli1b6v+4kJp1Pai3QfHYPffco3ebjz76qOOEnzJlitx88816cSpdurTemZ49e9axPxRp4iKLwG4WcaKo3b1OGpOqtWjRQkqVKqVB3ZSSkiK1a9eWatWq6T7Sg5wZim1RbI/0lC1bVjp27KhpN73xxhvStGlTvRnBBapBgwZei28//PBDady4sZYoFCtWTHPEKLp3hxIIbIf3RL37Bx98kGGdNHIyt9xyi2zfvl0/N94DORvUvbo7cOCABincGKF48sUXX5Tly5dnWM+Nz4VtfvjhhzTPvfvuu/ocSkyuB3wWfF8ff/yxy/qPPvpIf098dl/gONyyZYvExsa6rN+/f7+mH7/n9OnT9XvHd9imTRvNEeJ4Gjt2rPznP//R3xk3CmfOnEmzf9xE3H777frd4thu166d/Pnnn2m2W7p0qaYZvzH+//zzzz2m171OGr/dc889JzfeeKOmA8fdQw89pOn3VP30008/yYABA/Q8QJoeeOABj3WmvqbbHY5f/OajRo3S9Fy+fFmuXbsmmZGYmCgPPvigFC9eXL8P3OTjhszZP//8o7lTFKNjG3zuZs2ayYoVKxzbJCUlSc+ePfU3wg07zlf8Ts7fDTIL+GzlypXTbXAdwO/qnmZPddILFizQ8xvfT3h4uB53b731lss2OJ+io6P1fXIaBukcygxoOKlMKGps27atHtC4KOLuExCQX3rpJa1rxsGPEw4XYWyLkxTmz5+vFxOcYPgbCy7e7nCBQrEmAu0zzzzjWI+LCS4+CPTp5d5x0qIRFy4MODEnTZok/fr1k/Pnz7sEIqSzXr16WsyPunEUTeKiuWzZMpf9YT/IceAOHdvicYUKFbTo3tnu3bv1gtW6dWt9TwRzXDB8uWDiZgY5zjp16uhrkbtBvSsuwCbcmODG6bvvvpMXXnhB6w2RG8V2GcHFDTdYn376aZrnFi5cqDdXvgZLf6DO8//+7//k4sWLjuMIORas9xU+K9SvX9/j8zjeUKSO3BCKbnFD8vDDD8uIESO0YRC+p6eeekrTgWJNZzgWze8Idd4jR47UmyYEE+dAgcCGYx7HKOovO3TooMf6b7/9lmH6f/31V/0MXbp0kbfffluP7ZUrV+pNGgKkO3yOP/74Q4/7Z599VtONdiL+pNsTHEeA8xHBFecUbm6QPk83Me5wXN96662yY8cOGTp0qB632Ae+E+cbF9yo4JzBDei0adP0uK1YsaJs2rTJsQ2+U7wG3yV+QxzfFy5c0KJ355sXfE7cuODcxbkdHx+v752eFStWaEkgzkd8RxMmTNDvHDdB7rBP8zjLUTCfNGVfc+bMwXzgxnfffWecPHnSOHTokLFgwQKjRIkSRsGCBY3Dhw/rdt27d9fthg4d6vL6NWvW6PqPPvrIZX1CQkKa9dhH4cKF06ShUqVK+pyzd999V1//4YcfGuvXrzfy5s1r9O/fP8PPM3v2bH3d5MmT0zyXmprq+Pvy5csuz6WkpBi33HKL0bJlS8e6Xbt2GSEhIcYDDzxgXLt2zeu+kH68548//uhYd+LECaNAgQLGwIEDHetWrVql2+F/U/PmzXXdBx984Fh39epVo0yZMkanTp0c6yZNmqTbLV261LHu77//NmrWrJlmn5507drViIqKMv7991/HumPHjunne/nllx3rRo0apfvDseCN+TkWLVqU7ntim+eff944c+aMERoaasyfP1/XL1u2zMiTJ4+xf/9+n94PRowYodtduHDBZf2+fft0falSpYxz58451sfFxen6OnXqGP/884/L94C0XLlyRR9jf5GRkUbv3r1d9puUlGRERES4rK9bt65RtmxZl/f59ttv9X1wDLh/dnw2b8cbrFu3Ls1vb56PsbGxLsfYiy++qOeA+d6ZSbcn999/v74PzvNHH33UWLx4sTFy5EgjX758RtOmTV3e25NWrVoZtWvXdnyPgNfgtTVq1HCsw/ffrl07r/s5e/aspuP1119P9/08fX9PP/20UahQIZc04Dri/Fv069fPCA8PdznuvXn11Vc1LcePHzdyEuakcwgUI6JoDblE3E3jrhV3tyiudIa7emfIEUVERGgOEi10zQV3pdgH6rv8gVwPcuLIUSAni+ItX1qDo36zZMmS+jp3yAGZnOvgkJNFThs5fec7fBRtoigfd+zuDduc9wU33XSTvt6E7xJFm3v37s0wzfieHnvsMcdj1Nmj2Nz5tcgN4rdAcbcJxYe9e/cWX3Tu3FmrD5yLxVEMjs+H564n5GJQUoCGYoCib1Q1VKpUyed9nD59Wks78F15glIQHIemmJgY/R/fq3MDLqxH1cmRI0ccOa1z585pbsv5+EUXQWxrHr/Hjh3Thlbdu3d3eR8c9/jtM+J8vKF0CZ8HLYojIyNdjjnn49/5GMOxhVIiFJtnJt3emKUajRo10uoc5GZRUoQiZOQmkcv3BjltlCShpAI5XvO98Zlwzu7atcvx/eLzIdeNdd6+FxzvOC6dq8fS+/7M98R3glIIFLt7ExkZqaVQzsXr6R2n4EtPg+yEDcdyCNTnoQ4XFzTUKSPAuAcmPId6I2c4+RDgUATuiXO9cmahFTiCM94DFw5fGregmB5pz6hl7VdffSXjxo3TC+/Vq1cd650vjNgXvgNfLsIowvN00qd34THhO3UP+ngt6mBNuDjju3DfDhd6XyBIIrigeLtVq1a6Dn+jrzp+9+sNRdu42UIRJm5+PNW5B8L9+zcDKW46Pa03fxczeJhtMNyhDhPM4Ii6VXc43jwFWvfW3igiR3UNAtj/Mtv/g/Mno89jBpDMptsb81xybxSK3ykuLk7PN/f6f+eqHaQfxetYvJ33uKlE4Ef9Mo4xVKngOMRxgPpfs7gdxdCoosB1B0XoqK7q1q2blClTxrE/BHpUXeDmAF3xnHn6/kzPPfecVvOgYSzSg7YKuLlAOtyZv4n7OZbdMUjnEMi5ma27vcEJ5R64kRNDgEadoCfIUfoLd9dmAN26das0adJErLBmzRrNkaJOHHVgaKiCOmdcQN0bOPkKORhPnC/G1+O1vsJvZ9YX4jOjDzzq5bKqrzq+b6QBOVH8prhQZgbaRqAuG7koT11kvH2HGX23Zncd1O86BwWTVd2oULKD46t///56HONmAcEApVaeugxd73SjARYgMDozb7bTu7k03xt1+8g5e2LePOIcw80uGmShTv+///2vvPnmmzJz5kxH/3l8J/fdd5/evKEhJAI/bmgQkNFuBCUGzZs31xsPBH3crKIUCTdGaGuQXperqKgovRHHftHGAwt+B9wEzJs3z2Vb8zOjJC4nYZDO5XDCoBEKGo1Z2Y0DxYu4sOHOF8Vh5gUhoyJSpOeXX37RIkVv3TFQJI6THCeuc/cvnLzu+8IFAI1xzNHRggWfG+nARdr5Th+5Gl+hWBsXJhRlosEP9nW9i7pNODZwk4CiVeRqMnshRGM6s5W3mQuzAn5j82LuLecI5nHnqdgW/fwzgqoF3KCggZUJjSMRgK5nur1BdRT6FJvF0qajR49meHONFvSA88uX90brbzQKw4JidgRuNChzHuQGnwe5aSz4jnG+4bvC8YKbdRSlL1myxKWxqdnzJCOhoaF6E4AF5zNy1+jVgJsB55Io7A/HZSAZCztinXQuhxwR6spQl+UOOR9/L0Koa8UJhSLv9957T3MGvXr1yjB3ibo11CmhJak787XIpSDQOXffQGtY3Mk7Q1BByQHu3t3v1q3M5foCNyi4oDp3ccFFHhdaX+GCigsmirmxoPQEA9hkFdxoobWytyLS9JilKL60pM7s94ocGkoUzJ4IzsxuTyhtQeDATY5z8SrqOnHzlBEcc+7HzNSpUzPd7Smz6fYGRdC4QcWNqfOxjZyuWdfuDW4M0EIagQ430+m9N4KrM7QpQGA0S8hQp+w+mA0CNkpLzG3MUgXn7w/tClAilJHTbu+P89m8yXOu5oKNGzdaVlpnJ8xJ53IohkIXLBRPoVgJOV/cYeNuGI3K0F0CXZMyAxcOdIVCtwuzDhwXNDQCwkhouBP2BsVY6J+MrhobNmzQxiVoOILcPl6HixO6rWCgFtRLoQ4O9Weok8fFw7keGI/RZQQ3INgP+lrjwobuNCguzMphBPEd48YDdYjoUoaggSoGc9AMX+rR8LvgM6DfKL4TdKPzBt+P+0hzuMANGzbMpUTCU6Md5Bjd64IBXcyw+AO5N9Rp4ne0crAJBDocU6gnRfcuFD8jJ4W6cxyDKCEyb/jwe+PYQRcnpAENqHBcogub2RDLG9Szomgaxdxo47Bu3Tr9LM5dHK9Xuj1BETmObTSKxHmAG1J0+cJNH44xNChLD84XfA/oc4wbavw+qELB5zp8+LDuC/BZEdCRc8cNIm6yUKpgdif766+/tI0EbvaxLW7GUSWDfeEzARoZok4exxW6Z+FYx3fpy43yk08+qb8T6u5xLUHbAvxmuOGqVauWYztcA3DuP//885LjBLt5OQXG7PLx66+/prudt+5Tpvfee89o0KCBdtsqWrSods8YPHiwcfTo0Ux1wUIXMHQhue+++9Jsh65QeP3evXsz7K4xfPhwo0qVKkb+/Pm1O9ODDz5o7Nmzx7HN+++/r11F0E0K3ZjwPZjdgTx166pXr55uW6xYMe02tWLFCpf0e+pmgu2wZNQF6+abb07zWveuJIDPjffBd4wuR+je9dlnn+k+0U3NF0g3tkcXKHzX7szvwNOCLkDOn8Pbgm55zl2w0uNrFyxAt7oiRYq4dMcxu2C5d+Hx1k3M2/GO7du2bavHXlhYmFGtWjWjR48exm+//eayHb7vWrVq6bFw0003GUuWLPH4W7l3wUJXo549exolS5bUz4D3SkxMTNP9ML30eepq52u6PUGXqalTpxo33HCDnicVKlTQrm7ojugLnE/dunXT8wuvL1++vHHvvfdqdy7TuHHjjMaNG2t3MRy3ONdeeeUVx3ucOnVKjxGsx7mNzxETE2N8+umnLu/1008/Gbfeeqvuo1y5cnptWb58eZrvxP23WLx4sdGmTRvtfoiudxUrVtSuW+h+6GzGjBnanSs5OdnIafLgn2DfKBDlVhjpDSOPIffi3l0up0ExM3JsaBmOqg8iq9SrV09z/GjUltMwSBNlEXTjcW6ch7o8XFxQr4liw9wA3XVQHYJ64NwwKQtdfwkJCVolh3EJvHUlzc4YpImyCFpFo/8s6tOQq0TLV/QfRd10ZobYJKLcgw3HiLIIWvSi9S2CMnLPaGiDRmBZ1Y2KiLIf5qSJiIhsipVCRERENsXibg8wOABG7kGH/Jw2DiwREQUfCrExTC7GbEivESWDtAcI0J4GcyAiIrLSoUOH0kx85IxB2gNzAgB8eRnNRkNERJRZmA0MmUFPE844Y5D2wCziRoBmkCYiousloypVNhwjIiKyKQZpIiIim2KQJiIisikGaSIiIptikCYiIrIpBmkiIiKbYpAmIiKyKQZpIiIim2KQJiIisikGaSIiIptikCYiIrIpjt2dFUZHBDsFRK5Gnw92CojIB8xJExER2RSDNBERkU0xSBMREdkUgzQREZFNMUgTERHZlC2C9PTp06Vy5coSFhYmMTExsmHDBp9et2DBAsmTJ4906NDBZb1hGBIfHy9ly5aVggULSmxsrOzates6pZ6IiCiHBumFCxfKgAEDZNSoUbJp0yapU6eOtG3bVk6cOJHu6/bv3y+DBg2S22+/Pc1zr732mrz99tsyc+ZM+eWXX6Rw4cK6zytXrlzHT0JERJTDgvTkyZOld+/e0rNnT7nppps0sBYqVEhmz57t9TXXrl2TRx99VMaMGSNVq1ZNk4ueMmWKjBgxQtq3by/R0dHywQcfyNGjR2Xp0qVZ8ImIiIhywGAmKSkpsnHjRomLi3OsCwkJ0eLpdevWeX3dyy+/LFFRUdKrVy9Zs2aNy3P79u2TpKQk3YcpIiJCi9Gxzy5duqTZ39WrV3UxJScn6/+pqam65IB7ISJXlhzXROQvX2NLUIP0qVOnNFdcunRpl/V4nJiY6PE1a9eulffff182b97s8XkEaHMf7vs0n3M3fvx4zZW7O3nypDVF5OHRge+DyEoZVCcR0fV14cKFnDcsKD7U448/LrNmzZKSJUtatl/k5FEv7pyTrlChgpQqVUrCw8MDf4PkLYHvg8hKUVHBTgFRrhYWFmb/II1AmzdvXjl+/LjLejwuU6ZMmu337NmjDcbuu+++NEUG+fLlk507dzpeh32gdbfzPuvWresxHQUKFNDFHYresQSORYtkM5Yc10TkL19jS1DP1NDQUGnQoIGsXLnSJejicZMmTdJsX7NmTdm6dasWdZvL/fffLy1atNC/kfutUqWKBmrnfSJnjFbenvZJRERkV0Ev7kYxc/fu3aVhw4bSuHFjbZl96dIlbe0N3bp1k/Lly2u9MYoHbrnlFpfXR0ZG6v/O6/v37y/jxo2TGjVqaNAeOXKklCtXLk1/aiIiIjsLepDu3LmzNtDC4CNo2IUi6YSEBEfDr4MHD2a6yHnw4MEa6J966ik5d+6cNGvWTPfpax0AERGRHeQx0LGYXKB4HN22zp8/b03DMc4nTXbD+aSJskWcYesRIiIim2KQJiIisikGaSIiIptikCYiIrIpBmkiIiKbYpAmIiKyKQZpIiIim2KQJiIisikGaSIiIptikCYiIrIpBmkiIiKbYpAmIiKyKQZpIiIim2KQJiIisikGaSIiIptikCYiIrIpBmkiIiKbYpAmIiKyKQZpIiIim2KQJiIisikGaSIiIptikCYiIrIpWwTp6dOnS+XKlSUsLExiYmJkw4YNXrddsmSJNGzYUCIjI6Vw4cJSt25dmT9/vss2PXr0kDx58rgsd911VxZ8EiIiIuvkkyBbuHChDBgwQGbOnKkBesqUKdK2bVvZuXOnREVFpdm+ePHiMnz4cKlZs6aEhobKV199JT179tRt8ToTgvKcOXMcjwsUKJBln4mIiMgKeQzDMCSIEJgbNWok06ZN08epqalSoUIF6du3rwwdOtSnfdSvX1/atWsnY8eOdeSkz507J0uXLvXp9VevXtXFlJycrGk4e/ashIeHS8BeLhH4PoisFH862CkgytWSk5OlWLFicv78+XTjTFBz0ikpKbJx40aJi4tzrAsJCZHY2FhZt25dhq/H/cX333+vue6JEye6PLd69WrNXeNLaNmypYwbN05KlPAcLMePHy9jxoxJs/7kyZNy5coVCVh4dOD7ILLSiRPBTgFRrnbhwgWftgtqkD516pRcu3ZNSpcu7bIejxMTE72+Dnce5cuX19xv3rx55Z133pHWrVu7FHV37NhRqlSpInv27JFhw4bJ3XffrYEf27vDTQKK3N1z0qVKlbImJ528JfB9EFnJQ1USEWUdtMHKFnXS/ihatKhs3rxZLl68KCtXrtQAW7VqVbnzzjv1+S5duji2rV27tkRHR0u1atU0d92qVas0+0N9tac6a+TqsQQu1YJ9EFnIkuOaiPzla2wJapAuWbKk5myPHz/ush6Py5Qpk+6Hq169uv6N1t07duzQImszSLtDAMd77d6922OQJiIisqOg3k6jdXaDBg00N2xCwzE8btKkic/7wWucG365O3z4sJw+fVrKli0bcJqJiIiyStCLu1FU3b17d+373LhxY+2CdenSJe1WBd26ddP6Z+SUAf9jWxRfIzB//fXX2k96xowZ+jyKwNEIrFOnTpobR5304MGDNeft3EWLiIjI7oIepDt37qytqOPj4yUpKUmLrxMSEhyNyQ4ePOhSdo8A/txzz2nuuGDBgtpf+sMPP9T9AIrPt2zZIvPmzdNuWOXKlZM2bdpo9yz2lSYiouwk6P2k7QituyMiIjLsv+az0RFWJIvIOqPPBzsFRLlaso9xhk08iYiIbIpBmoiIyKYYpImIiGyKQZqIiMimGKSJiIhsikGaiIjIphikiYiIctJgJvv27ZM1a9bIgQMH5PLlyzpbVL169XQoT19n9iAiIiILg/RHH30kb731lvz22286IhhG88KoX2fOnNHhNxGgH330URkyZIhUqlQpM7smIiIif4M0csqYEKNHjx7y2Wef6XzLzjCONuZrXrBggY6tjTmeH3roIV93T0RERP4OC7p8+XKfJ6jAjFP79+/XGa6yIw4LSjkehwUlyhZxxuecdGZmkCpRooQuRERElMWtuzdt2iRbt251PP7iiy+kQ4cOMmzYMElJSQkgOURERBRQkH766aflr7/+0r/37t0rXbp0kUKFCsmiRYt07mYiIiIKUpBGgMa8z4DAfMcdd8jHH38sc+fO1UZlREREFKQgjbZmqamp+vd3330n99xzj/6NFt+nTp2yIFlERETkV5BGF6tx48bJ/Pnz5YcffpB27do5BjlB/2kiIiIKUpCeMmWKNh7r06ePDB8+XKpXr67rFy9eLE2bNrUgWUREROTXsKDR0dEurbtNr7/+uuTNm9eKdBEREeV6+TJTD50nT550t+G43UREREEo7r755pt1yM+M+kHv2rVLnn32WZkwYYIV6SMiIsq1fM5JT506VSfOeO6556R169baeAwTbCD3fPbsWdm+fbusXbtW/vzzT62rRqAmIiKiLMhJt2rVSme/+vLLLyUqKkpnxEIwxqxXo0eP1hx0t27d5PDhwzJx4kQdk9RX06dPl8qVK2vAj4mJkQ0bNnjddsmSJXqDEBkZKYULF9b+2mhl7l40Hx8fL2XLltVZumJjYzV9REREObrhWLNmzXSxysKFC2XAgAEyc+ZMDdBoOY5xwnfu3Kk3A+6KFy+uLcpr1qyps3J99dVX0rNnT93WHF/8tddek7ffflvmzZsnVapUkZEjR+pzyO2z3pyIiHLcLFjXCwJzo0aNZNq0afoYg6RgUJS+ffvK0KFDfdpH/fr1ta/22LFjNReNYviBAwfKoEGD9HnMMoL+2xgRDUOYusM0m1icZydBGlCMb8ksWC9zshGymfjTwU4BUa6WnJwsxYoVs24WrOsBjdA2btwocXFxjnUhISFaPI25qTOCgPz9999rrhtF7OaAKklJSboPE4recTOAfXoK0uPHj5cxY8akWX/y5Em5cuWKBCw8OvB9EFnpxIlgp4AoV7tw4YJP2wU1SGMI0WvXrqUZpQyPExMTvb4Odx7ly5fX3C/6Zb/zzjvamA0QoM19uO/TfM4dbhJQ5O6eky5VqpQ1OenkLYHvg8hKHqqSiCjr+Fr1GtQg7a+iRYvK5s2b5eLFi7Jy5UoNsFWrVpU777zTr/0VKFBAF3fI1WMJ3P/GOSeyDUuOayLyl6+xJahBumTJkpoTPn78uMt6PC5Tpky6H84cihStu3fs2KFF1gjS5uuwD7Tudt6nOXMXERFRduD37TQaeGHKSvSN/vHHH10WX6F1doMGDTQ37LxfPG7SpEmm0mI2/EJrbgRq532i+PqXX37J1D6JiIiCza+c9Pr16+WRRx6RAwcOaOMtZxg6FPXMvkJRdffu3bXvc+PGjbUL1qVLl7RbFaDvNeqfkVMG/I9tq1WrpoH566+/1n7SM2bMcLx///79dZauGjVqOLpgocV3hw4d/Pm4RERE2SdIP/PMMxooly1bpkXKGY3pnZ7OnTtrK2oMPoKGXSiSTkhIcDT8OnjwoEvZPQI4Rj3DoCkYqAT9pT/88EPdj2nw4MG63VNPPSXnzp3Tft3YJ/tIExFRju8njZG+/vjjD0e9cE6D4nF028qo/5rPRvs++hpRlhh9PtgpIMrVkn2MM37VSaPP8e7duwNJHxEREV2P4m6MBoYRvVA8Xbt2bcmfP3+a+aaJiIgoCEG6U6dO+v8TTzzhWId6aXPO6cw0HCMiIiILgzSG3iQiIiIbBulKlSpZnxIiIiKyZjAT9E2+7bbbtP8x+ksD+jh/8cUX/u6SiIiIAg3SGDgEg5Dcc8892g/ZrIOOjIzUQE1ERERBCtJTp06VWbNmyfDhw3XsbRMGONm6dasFySIiIqIQfxuO1atXL816zCSFkb6IiIgoSEEa42Fjqkh3GHqzVq1aFiSLiIiI/Grdjfro559/Xq5cuaJ9ozds2CCffPKJTn7x3//+1/pUEhER5UJ+Beknn3xSJ7cYMWKEXL58WWfEQivvt956S7p06WJ9KomIiHKhfP4ODP7oo4/qgiB98eJFiYqK0ucwpndOnXiDiIjI9nXS7dq107mcoVChQo4AvXPnTrnzzjutTSEREVEu5VeQLlKkiDzwwAPy77//Otbt2LFDA7Q5rjcREREFIUgvWbJE58BEcTcajm3btk0DdNeuXbVemoiIiIIUpNFobNmyZVq8/fDDD0urVq2kW7duMnnyZAuSRERERJlqOIbGYs5CQkJk4cKF0rp1ay3iHjlypGOb8PBwfrtEREQBymOgvNoHCMqYK9qd+fKcNJ80bjYiIiK0SN+SG47REVYki8g6o88HOwVEuVqyj3HG55z0qlWrrEobERER+cDnIN28eXNfNyUiIqJgzieNKSonTZqko49hefPNNzXb7o/p06dL5cqVJSwsTGJiYnSYUW8w+9btt98uxYoV0yU2NjbN9j169NBid+flrrvu8ittRERE2SpI//bbb1KtWjUNzGfOnNEFLbuxbtOmTZnaFxqfYSzwUaNG6Wvr1Kkjbdu2lRMnTnjcfvXq1drVC8Xv69atkwoVKkibNm3kyJEjLtshKB87dsyxYGxxIiKiHNlwzBlyshj6E7nafPn+V2KOgU2Qo967d6/8+OOPPu8LOedGjRrJtGnT9HFqaqoG3r59+8rQoUMzfD0aqSFHjdejG5iZk0ZOf+nSpeIPNhyjHI8Nx4hyVsMx95y0c4DWHeXLJ4MHD5aGDRv6vJ+UlBTZuHGjxMXFubQiRxE2csm+wNjh//zzjxQvXjxNjhvDlSKAt2zZUsaNGyclSpTwuA8McWoOcwpmVzLcMGAJYq0C0fVhyXFNRP7yNbb4FaQR9Q8ePCg1a9Z0WX/o0CEpWrSoz/s5deqU5oRLly7tsh6PExMTfdrHkCFDdAYuBHbnou6OHTvqvNd79uyRYcOGyd13362BP2/evGn2gSk2x4wZk2b9yZMndTrOgIVHB74PIit5qU4ioqxx4cKF6xekO3fuLL169ZI33nhDmjZtqut++ukneemll7S+OKtMmDBBFixYoLlmNDozOU+XWbt2bYmOjtb6cmyH0dHcISePenHnnDSK3EuVKmVNcXfylsD3QWSl/39SHCIKDueYZXmQRnBGi2nUAZuTbOTPn1+effZZDZy+KlmypOZsjx8/7rIej8uUKZNhGvBe3333nQbh9FStWlXfC9NoegrSBQoU0MUdit6xBI5Fi2QzlhzXROQvX2OLX2dqaGioTqRx9uxZ2bx5sy5o4Y3W3p6CXXr7adCggaxcudKlnB6PmzRp4vV1r732mowdO1YSEhJ8qgM/fPiwnD59WsqWLetz2oiIiILNryD9xBNPaHk65pJGcTIW/H3p0iV9LjNQzIxGaPPmzdPpLpEbx3569uypzyO37tywbOLEiTpO+OzZs7VvdVJSki4XL17U5/E/it3Xr18v+/fv14Dfvn17bY2Orl1EREQ5OkgjoP79999p1mPdBx98kOn6bRRdx8fHS926dTVXjhyy2ZgMDdTQz9k0Y8YMbRX+4IMPas7YXLAPQPH5li1b5P7775cbbrhB686RW1+zZk2mcvlERETBlqk6aTSoQrdqLMhJO1d8o5X2119/rd2eMqtPnz66eILGXs6QO85oGs3ly5dnOg1ERETZOkhHRkY6htlELtUd1nvqykRERETXOUhjKE7kojE4yGeffeYygAgagVWqVEn7LBMREVEWB2lzJqx9+/ZJxYoVPc4vTUREREFsOIYcsxmg0bIbI40RERGRtQIe0QANuTB2NhEREVmLww4RERHl1CCNaSvR7YmIiIhsEKQxX7Q5Zjf6RpvDbWJdZuaSJiIiIouDdIsWLXSsbneYvBrPERERUZCCNPpKe+p+hUksChcubEGyiIiIKFP9pDt27Kj/I0D36NHDZSxsDAuKMbPN+aWJiIgoC4N0RESEIyddtGhRlwZjGHHs1ltvld69eweYJCIiIsp0kJ4zZ47+jykiBw0axKJtIiIiu9VJDx482KVO+sCBAzJlyhT59ttvrUwbERFRruZXkG7fvr1j3uhz585J48aNZdKkSboe8z0TERFRkIL0pk2bdBATWLx4sZQpU0Zz0wjcb7/9tgXJIiIiIr+C9OXLl7XhGKCIG62+Q0JCtOEYgjUREREFKUhXr15dli5dqrNfLV++XNq0aaPrT5w4IeHh4RYki4iIiPwK0vHx8dq6G628Y2JipEmTJo5cdb169axOIxERUa6UqS5YpgcffFCaNWsmx44dkzp16jjWt2rVSh544AEr00dERJRrZTpIY+5oDGKyefPmNLlmtPImIiKiIBV358+fXypWrKjDgBIREZHN6qSHDx8uw4YN8zgTlj+mT5+u9dthYWFax71hwwav286aNUu7fxUrVkyX2NjYNNtj2FLUm2MKTeT6sc2uXbssSSsREZGtg/S0adN03uhy5crJjTfeKPXr13dZMmPhwoUyYMAAGTVqlPa/Rh1327ZttaW4J6tXr5auXbvKqlWrZN26dVKhQgVtXX7kyBHHNq+99pr21545c6b88ssvOnwp9nnlyhV/Pi4REVFQ5DGQ7cykMWPGpPs8Aq6vkHNu1KiRBn5ITU3VwNu3b18ZOnRohq9HsTty1Hh9t27dNBeNm4eBAwdqC3RznuvSpUvL3LlzpUuXLmn2cfXqVV1MycnJmoazZ89a06Xs5RKB74PISvGng50ColwtOTlZYxfiU3pxxq/W3ZkJwulJSUmRjRs3SlxcnGMdBkVB8TRyyb4OrILGbMWLF9fH+/btk6SkJN2H8+xduBnAPj0F6fHjx3u88Th58qQ1ue/w6MD3QWQlLyVVRJQ1Lly44NN2fgVpq5w6dUpzwsjlOsPjxMREn/YxZMgQzTmbQRkB2tyH+z7N59zhJgFF7u456VKlSlmTk07eEvg+iKwUFRXsFBDlamFhYdYGaeRU//rrLylZsqRm0Z1nwXJnVYOyjEyYMEEWLFig9dS+fmBPChQooIs75OqxBC7Vgn0QWciS45qI/OVrbPE5SL/55puO8boxLaUVEPDz5s0rx48fd1mPx5i0Iz1vvPGGBunvvvtOoqP/X3Gy+TrsA627nfdZt25dS9JNRESUFXwO0n/88YeONIYcZ5UqVaRp06aSL19gpeWhoaHSoEEDWblypXTo0MHRcAyP+/Tp4/V1aL39yiuv6LjhDRs2dHkOaUOgxj7MoIzia7TyfvbZZwNKLxERUVbyucxr6tSpcvHiRf27RYsWlhVpoy4YfZ/nzZsnO3bs0EB66dIl6dmzpz6PFtvODcsmTpwoI0eOlNmzZ2vfatQzYzHThmL4/v37y7hx4+TLL7+UrVu36j5Qb23eCBAREWUHPmeFERDR9xh9ktHNCS2lUTftyR133OFzAjp37qytqDH4CIItcr8JCQmOhl8HDx50KbufMWOGtgpHrt69xfno0aP178GDB2ugf+qpp+TcuXM6zjj2GUi9NRERkW37SWNqymeeeUYHGUFu1dvL8Fx2HzIUxePotpVR/zWfjY6wIllE1hl9PtgpIMrVkn2MMz7npFFUjAXFytjhzp07JYrdOIiIiK6bTLf8KlKkiA7JiQZagTYcIyIiIu/86izZvHlzR4Bu166dzitNRERE1gp4RANMtPH3339bkxoiIiJy4LBDREREOTVIV6pUSfLnz29NaoiIiMgh4JZf27ZtC3QXREREZHWQxjSTGCUMbrrpJqlfv34guyMiIqJAgzQGNMG8zJh9KjIyUtdhZC8MF4pZqTDFIxEREQWhTrpv3746YfWff/6pY3hjQbE3RlB54YUXAkwSERER+Z2TxjjYmCKyVq1ajnUo7p4+fbqO7U1ERERBykljOklPLbqxDs8RERFRkIJ0y5YtpV+/fnL06FHHuiNHjsiLL74orVq1siBZRERE5FeQnjZtmtY/Y/rKatWq6YKxvLEO804TERFRkOqkK1SoIJs2bdJ66cTERF2H+unY2FgLkkRE9D+159UOdhKIXGztvlVsH6Q/+OAD6dy5s7Ru3VoXU0pKinbB6tatm5VpJCIiypX8Ku7u2bOnTlTtDt2y8BwREREFKUgbhiF58uRJs/7w4cMSERFhQbKIiIgoU8Xd9erV0+CMBa24zTml4dq1a7Jv3z656667rkc6iYiIcp1MBekOHTro/5s3b5a2bdtKkSJFHM+FhoZqa+9OnTpZn0oiIqJcKFNBetSoUfo/gjEajoWFhV2vdBEREeV6ftVJd+/e3RGgn3vuOTl16pTfCcBQogj62F9MTIxs2LDB67YYKxw5dWyPIvcpU6ak2Wb06NGOInlzqVmzpt/pIyIiylZB2tmHH36og5j4Y+HChTJgwADNoaPfdZ06dbQYHbNseXL58mWpWrWqTJgwQcqUKeN1vzfffLMcO3bMsaxdu9av9BEREWXrII2W3v6aPHmy9O7dW7ttYYKOmTNnSqFChWT27Nket2/UqJG8/vrrOk1mgQIFvO4XDdoQxM2lZMmSfqeRiIgoWPwazMQKGPhk48aNEhcX51gXEhKio5atW7cuoH3v2rVLypUrp0XoTZo0kfHjx0vFihW9bn/16lVdTGbJACYLsWbCkIDvhYislU0mwgnhuUM2Y9UkUr7uJ+AgjQFM/IF6bHTbKl26tMt6PDaHGvUH6rXnzp0rN954oxZ1jxkzRm6//Xad77po0aIeX4Mgju3cnTx5Uq5cuSIBC48OfB9EVvJSpWQ3NfLVCHYSiFx4q469XrHT7yC9Z88emTNnjuzdu1cbcEVFRck333yjOVbUCQfL3Xff7fg7Ojpag3alSpXk008/lV69enl8DXLzqBt3zkljfPJSpUpJeHh44IlK3hL4PoisFBUl2cGuf3cFOwlELhDrrOBr7yi/gvQPP/ygwfC2226TH3/8UcaNG6cJ/+OPP+T999+XxYsXZ7gP1BPnzZtXjh8/7rIej9NrFJZZkZGRcsMNN8ju3bu9boP6bU913Ch+xxK47FG0SLmIJcf19ZfKc4dsxpqY4Pt+/Hq3oUOHamBesWKFDmLiPM/0+vXrfdoHXtegQQNZuXKlSxk9HqMe2SoXL17UXH/ZsmUt2ycREVFW8CsnvXXrVvn444/TrEduOjN9plHEjD7XDRs2lMaNG2ux+aVLlxyTdGA2rfLly2udsdnYbPv27Y6/jxw5oqOfYeSz6tWr6/pBgwbJfffdp0XcR48e1e5dyLF37drVn49KRESUvYI0ipDRKKtKlSou63///XcNqr7CqGVonBUfHy9JSUlSt25dSUhIcDQmO3jwoEuRAIIuxg83vfHGG7o0b95cVq9e7ZjkAwH59OnTWqfcrFkzzd3jbyIiohwfpNFPeciQIbJo0SId0QvF1D/99JPmYjM7l3SfPn108cQMvCaMNJZRv2zMZ01ERJQT+FUn/eqrr+pQm2gBjTpfDERyxx13SNOmTWXEiBHWp5KIiCgX8isnjUZfs2bNkpEjR2r/YwRqFEPXqME+jURERFYJaDAT9IlObyQvIiIiyuIgjXph9IVetWqVjr7iPrzZkiVLAkgSERER+R2k+/fvL++++660aNFCW2Kj8RgRERHZIEjPnz9fc8v33HOPxckhIiKigFp3R0RE6LzOREREZLMgPXr0aJ016u+//7Y+RUREROR/cffDDz8sn3zyiQ4DigFG8ufP7/L8pk2b/NktERERBRqkMd72xo0b5bHHHmPDMSIiIjsF6WXLlsny5ct1XGwiIiKyUZ00hgMNDw+3PjVEREQUWJCeNGmSDB48WPbv3+/Py4mIiOh6FXejLvry5ctSrVo1KVSoUJqGY2fOnPFnt0RERBRokJ4yZYo/LyMiIqKsaN1NRERENgnSycnJjsZi+Ds9bFRGRESUhUG6WLFicuzYMR3AJDIy0mPfaMyOhfXXrl2zIGlERES5m89B+vvvv5fixYvr35iikoiIiGwSpJs3b+74u0qVKtpX2j03jZz0oUOHrE0hERFRLuVXP2kE6ZMnT6ZZj65XeI6IiIiCFKTNumd3Fy9elLCwMAuSRURERJkK0gMGDNAFAXrkyJGOx1j69esnnTt3lrp162YqAdOnT9eZtBDcY2JiZMOGDV63/fPPP6VTp066PdLgrb92ZvZJRESUI4L077//rgty0lu3bnU8xpKYmCh16tSRuXPn+ry/hQsXaoAfNWqUTm+J17dt21ZOnDjhcXuMcla1alWZMGGClClTxpJ9EhER2VUeAxE3k3r27ClvvfVWwP2hkctt1KiRTJs2TR+npqZqg7S+ffvK0KFD030tcsr9+/fXJdB9Xr16VRcT+oHjNWfPnrWmz/fLJQLfB5GV4k9LdlBvfr1gJ4HIxe+P/y5WQJxB1+bz58+nG2f8GnFszpw5EqiUlBSdkzouLs6xLiQkRGJjY2XdunVZus/x48fLmDFj0qxH47grV65IwMKjA98HkZWySclSjXw1gp0EIhdWlcpeuHDBp+38CtJWOHXqlA56Urp0aZf1eIyi86zcJ4I6isjdc9KlSpWyJiedvCXwfRBZKSpKsoNd/+4KdhKIXGBALyv42sg6aEHaTgoUKKCLO+TCsQQu1YJ9EFnIkuP6+kvluUM2Y01M8H0/QTtTS5YsKXnz5pXjx4+7rMdjb43CgrFPIiKiYAlakA4NDZUGDRrIypUrHevQyAuPmzRpYpt9EhERBUtQi7tRD4xpLxs2bCiNGzfWfs+XLl3S1uPQrVs3KV++vDbsMhuGbd++3fH3kSNHZPPmzVKkSBGpXr26T/skIiLKLoIapDH4CVpQx8fHS1JSkg6EkpCQ4Gj4dfDgQZdy+6NHj0q9ev+vS8Ybb7yhC8YVX716tU/7JCIiytH9pHM6tO6OiIjIsP+az0ZHWJEsIuuMPi/ZQe15tYOdBCIXW7tvlayMM9mjiScREVEuxCBNRERkUwzSRERENsUgTUREZFMM0kRERDbFIE1ERGRTDNJEREQ2xSBNRERkUwzSRERENsUgTUREZFMM0kRERDbFIE1ERGRTDNJEREQ2xSBNRERkUwzSRERENsUgTUREZFMM0kRERDbFIE1ERGRTDNJEREQ2xSBNRERkUwzSRERENmWLID19+nSpXLmyhIWFSUxMjGzYsCHd7RctWiQ1a9bU7WvXri1ff/21y/M9evSQPHnyuCx33XXXdf4UREREOSxIL1y4UAYMGCCjRo2STZs2SZ06daRt27Zy4sQJj9v//PPP0rVrV+nVq5f8/vvv0qFDB122bdvmsh2C8rFjxxzLJ598kkWfiIiIKIcE6cmTJ0vv3r2lZ8+ectNNN8nMmTOlUKFCMnv2bI/bv/XWWxqAX3rpJalVq5aMHTtW6tevL9OmTXPZrkCBAlKmTBnHUqxYsSz6RERERNbIJ0GUkpIiGzdulLi4OMe6kJAQiY2NlXXr1nl8DdYj5+0MOe+lS5e6rFu9erVERUVpcG7ZsqWMGzdOSpQo4XGfV69e1cWUnJys/6empuqSA+6FiFxZclxffyE8d8hmrIkJvu8nqEH61KlTcu3aNSldurTLejxOTEz0+JqkpCSP22O9CTntjh07SpUqVWTPnj0ybNgwufvuuzXA582bN80+x48fL2PGjEmz/uTJk3LlyhUJWHh04PsgspKX6iS7qZGvRrCTQOTCW1VsZl24cMH+Qfp66dKli+NvNCyLjo6WatWqae66VatWabZHTt45d46cdIUKFaRUqVISHh4eeIKStwS+DyIrRUVJdrDr313BTgKRC5TQWgENn20fpEuWLKk52+PHj7usx2PUI3uC9ZnZHqpWrarvtXv3bo9BGvXXWNyh6B1L4LJH0SLlIpYc19dfKs8dshlrYoLv+wnqmRoaGioNGjSQlStXupTT43GTJk08vgbrnbeHFStWeN0eDh8+LKdPn5ayZctamHoiIqLrK+i30yhmnjVrlsybN0927Nghzz77rFy6dElbe0O3bt1cGpb169dPEhISZNKkSVpvPXr0aPntt9+kT58++vzFixe15ff69etl//79GtDbt28v1atX1wZmRERE2UXQ66Q7d+6sDbTi4+O18VfdunU1CJuNww4ePOhSLNC0aVP5+OOPZcSIEdogrEaNGtqy+5ZbbtHnUXy+ZcsWDfrnzp2TcuXKSZs2bbSrlqcibSIiIrvKYxiGEexE2A0ajkVERMj58+etaTg2OsKKZBFZZ/R5yQ5qz6sd7CQQudjafatkZZwJenE3ERERecYgTUREZFMM0kRERDbFIE1ERGRTDNJEREQ2xSBNRERkUwzSRERENsUgTUREZFMM0kRERDbFIE1ERGRTDNJEREQ2xSBNRERkUwzSRERENsUgTUREZFMM0kRERDbFIE1ERGRTDNJEREQ2xSBNRERkUwzSRERENsUgTUREZFMM0kRERDbFIE1ERGRTtgjS06dPl8qVK0tYWJjExMTIhg0b0t1+0aJFUrNmTd2+du3a8vXXX7s8bxiGxMfHS9myZaVgwYISGxsru3btus6fgoiIKIcF6YULF8qAAQNk1KhRsmnTJqlTp460bdtWTpw44XH7n3/+Wbp27Sq9evWS33//XTp06KDLtm3bHNu89tpr8vbbb8vMmTPll19+kcKFC+s+r1y5koWfjIiIKDB5DGQ7gwg550aNGsm0adP0cWpqqlSoUEH69u0rQ4cOTbN9586d5dKlS/LVV1851t16661St25dDcr4OOXKlZOBAwfKoEGD9Pnz589L6dKlZe7cudKlS5c0+7x69aouJmxfsWJFOXDggISHhwf+ISdWDnwfRFYasl+yg2YLmgU7CUQu1nZZK1ZITk6WSpUqyblz5yQiIsL7hkYQXb161cibN6/x+eefu6zv1q2bcf/993t8TYUKFYw333zTZV18fLwRHR2tf+/Zswc3Hcbvv//uss0dd9xhvPDCCx73OWrUKH0NFy5cuHDhIlm4HDp0KN04mU+C6NSpU3Lt2jXN5TrD48TERI+vSUpK8rg91pvPm+u8beMuLi5Oi9xNyM2fOXNGSpQoIXny5PHz05GVcNeJEpZDhw5ZU7pBlIvw/LEflPpeuHBBS37TE9QgbRcFChTQxVlkZGTQ0kPe4QLDiwyRf3j+2Eu6xdx2aDhWsmRJyZs3rxw/ftxlPR6XKVPG42uwPr3tzf8zs08iIiI7CmqQDg0NlQYNGsjKlStdiprxuEmTJh5fg/XO28OKFSsc21epUkWDsfM2KOpBK29v+yQiIrKjoBd3oy64e/fu0rBhQ2ncuLFMmTJFW2/37NlTn+/WrZuUL19exo8fr4/79esnzZs3l0mTJkm7du1kwYIF8ttvv8l7772nz6MOuX///jJu3DipUaOGBu2RI0dquT+6alH2hOoIdNNzr5Ygoozx/MnGDBuYOnWqUbFiRSM0NNRo3LixsX79esdzzZs3N7p37+6y/aeffmrccMMNuv3NN99sLFu2zOX51NRUY+TIkUbp0qWNAgUKGK1atTJ27tyZZZ+HiIjICkHvJ01EREQ2HXGMiIiIPGOQJiIisikGaSIiIptikM4FevTokWHL9jvvvFNbxWfkjjvukI8//tjC1OUOo0eP1vHlA7F9+3b5z3/+o70fKHd7/PHH5dVXX82y90OvmaVLl1q6T8ylkNGgUT18uHbl9POCQZp89uWXX+qgMJ4mKaHr76abbtLJZCZPnhzspFAQ/fHHHzo97wsvvCA53VtvvaXBPL3MRE4/LxikyWeY/hP910NCeNgEC77/GTNmyL///hvspJCPUlJSLN3f1KlT5aGHHpIiRYpIbhg2M9KHIZpz8nnBq202gFHYMEd29erVdTACTKP5yiuvOJ7funWrtGzZUgoWLKiTgjz11FNy8eJFr/tDsRAGicFJXrZsWR0YJiMnT56U77//Xu677740xWA4Oe6++259/6pVq8rixYtdthkyZIjccMMNUqhQIX0eg8v8888/LjmDFi1aSNGiRXVcYYxChwFqvMHUbk8++aSUKlVKt8dnxz7ci5bnz58vlStX1hMduX8MZp+en376Se/Ukc5ixYrpHORnz57V5xISEqRZs2Z6wcB3fO+998qePXtcXn/48GGd67x48eI6hzkG6MFId87SSxN+ZwzagwF48F1ibnX377J169Y6+csPP/yQ7mch32DKW/ymmOgHNm/erMe08zS5ONYee+wx/fv06dP6G2OAJRwntWvXlk8++cRlnziG+vTpozk+DH2M42j16tW63+XLl0u9evX098Vxe+LECfnmm2+kVq1aeiw/8sgjcvnyZa/pRTpxTLifh5hqF+cZJtHANQLXivfff9/xml69ejmOqxtvvFFzqO5mz54tN998s74e1wV8BvcJkR544AH93BgoCiVrzrZt26bXAVxXMKERiuTxmozgO8Hnx+vuuusuOXbsmMfi7h49euhxj7Tju8Syf//+nH9eWNLbmq6rwYMHG8WKFTPmzp1r7N6921izZo0xa9Ysfe7ixYtG2bJljY4dOxpbt241Vq5caVSpUsVlABj83b59e8fjZ599VgeP+e6774wtW7YY9957r1G0aFGjX79+XtOwZMkSo3Dhwsa1a9dc1uMQKlGihKYHA8aMGDFCpx/dvn27Y5uxY8caP/30k7Fv3z7jyy+/1EFmJk6c6HgeA9I89thjxo4dO4y//vpLB6vZvHmz17TExsYa9913n/Hrr7/q9gMHDtQ0nD592jH1aJEiRRzfyY8//miUKVPGGDZsmNd9YmpTDHyD7wbvvW3bNh1k5+TJk/r84sWLjc8++8zYtWuXbov3r127tuP7uHDhglG1alXj9ttv198H2y1cuND4+eeffU7TuHHjjJo1axoJCQk65eqcOXM0TatXr3ZJa0xMjO6PAnfu3DkjJCREjyWYMmWKUbJkSf2OTdWrV3ecb4cPHzZef/11PQbwG7399tt6vP/yyy8uAzDht37ppZeMxMREXVatWqXnyq233mqsXbvW2LRpk+4X27Zp00Yf45jAcTxhwgSv6cV22E9SUpLL+ocfflin8cV5inTh3F6wYIE+l5KSotP54jPu3bvX+PDDD41ChQrp8Wl65513jLCwMP38OI83bNjgMiUw3vM///mP8fHHH+uxjWl/8RnNc+7s2bNGqVKljLi4OD2Pkc7WrVsbLVq08PpZcHznz59fz2ekbePGjUatWrWMRx55xOO169y5c0aTJk2M3r17G8eOHdPl33//zfHnBYO0zSUnJ+uF2rxIuHvvvfc0gCNYmzACGy485onsfKAjmGCkNgRCE060ggULphukccIiCLnDyfvMM8+4rMPJgmDnDS5yDRo0cDzGDQJuQHyBABgeHm5cuXLFZX21atWMd999V//GiYqLEL47Ey6Yzhded127djVuu+02w1cI3vjsCLiA98bnMC9a7jJKEz4PnjeDuqlXr16aNmcPPPCA0aNHD5/TSumrX7++HpPQoUMH45VXXtFzBOcKgjJ+Z9wMetOuXTu9UTQh8NarV89lGzNII3iaxo8fr+sQVE1PP/200bZtW6/v9fnnn+tNAUZVNCGoYj8rVqzw+TM///zzRqdOnRyPy5UrZwwfPtzr9tg/bsBNuN5g3TfffOO4EcfNhjPMk4xtvI32iCCN55HxME2fPl1v4r1lMJo3b+71OpVTzwsWd9vcjh07tCirVatWXp9HsSiKV0233XabFp3u3LkzzfYookUdWUxMjGMdimdRBJaev//+W8LCwjw+5z5xCR4jXaaFCxdqmjDxCYq0RowYIQcPHnQZvx1FirGxsTJhwoQ0xcjOUKyNonwUOWNf5rJv3z6X16FIGcXnJhTfoWjRGxRzevuOYdeuXVrMieJ6FEti/2B+DrwexZj4Lr1JL027d+/WYk4U2zl/rg8++CDN94Eiy/SKRClzMBcAiqMRi9asWSMdO3bU4te1a9dq8SnG/Ufxrll0PHbsWC3mxm+N3wjFtc7HM6DKxpPo6GjH3ygSNquAnNeld5ziPERxtPM89zj2MJsgPoc306dP1zShighpxlwHZprxfkePHk33+HdPO643OA/MtOK8XLVqlcuxW7NmTX0uvfMZn79atWo+n6fpyannRdAn2KCMDzw7QN2aWT+bGevWrZNHH31UxowZo3VzqIvFpCjO9eCoQ0Zd3LJly7R+DhMBYBvUf7lDgMaJjIuqO+cGJvnz53d5Dhc13Lj4+z2jDrBSpUoya9YsvWhjX7fccoujUZAvv1N6aTLbEOA7QH2nM/dJEVD35nxho8CgDhn1sQg0+I0QXLAOxxiOeefg9/rrr2udKCYCQqBGsELds3vjMOebZm/HAH7/zB6nOA8RiPB+mEXQl2MP59KgQYP0nMMNNG4U8TnM9hK+XmMyOn5xjkycODHN63C+Zmaf/o5UfSaHnhfMSdsc7uBxErlPz2nCHT8uLs59BNEACi2wPeWOcRDjxHBu0IQL0V9//ZVuOpBLTEpK8hio169fn+Yx0gU///yzBrfhw4drQyp8ngMHDqTZBxqWvfjii/Ltt99qTmbOnDke01G/fn1NR758+bRxjPOCC5i/kEvw9h2jsRBKJVACgNwGPpv794DXI0eDC4U/0I0EwRi5G/fPhcZA7g108HuQNW6//XZtwPfmm286ArIZpLHgb+dzq3379tqQDCVYyAVndO5Yyexrj77BJtwsIFh6azSFNDdt2lSee+45PW5wTDnnbhG0Ucrj7fj3Bc7LP//8U/fjfvx6u2HxR2hoqKORn7ucel4wSNscipjRanPw4MGOok8EQbPlJnKp2AbTfeIgRZFT3759tWUlis7coRgKLT1feuklba2N16DVZEbdqnDwIwjihHe3aNEizYngYoVc8IYNGxwtQxGUEXhwN4+0oxvX559/7lJ8h21xMUTwxv5//fVXR5B3hyJx5AbQ4hMBHa07cSOAm4D0WoRnJC4uTt8XF7ItW7ZIYmKitlpH61S09EbxOooIUSyN7w1F9M5QFI7ifKQLn2Hv3r3y2WefaUmCL3ChRG4HNyrz5s3T72rTpk3a3QaPTfi8R44c0e+BrIHfFzdZH330kSMgY9AefP84pp1z0jieMX89jjlU6Tz99NM6dkBWQXE1AiKK4k0IjDj/n3jiCR1wBFU/OJ8+/fRTR5pxbqBYHp8HvStwrDtDaRZy2jg/UbVjHnu+ev755/UGFecB9o3jF++HrlHegqo/KleurBkMnAc4N82cfE4+LxikswGcVAMHDpT4+HgNXp07d3bU26BOBycDTpBGjRrJgw8+qLm9adOmed0firqQe0DxFA5qdC3yVodmQp0XTjhcyNyhKBtBGBc63EigSwpyhnD//fdr4EEgRi4AFzd8Huf9IqeKLmHITT/88MPajQP79ATFYRjIARdRpAevQVcmBHhPNyW+wn4Q9FEqgXnNcSPwxRdfaI4dNzD4fBs3btQibnwefIfud/h4fVRUlNxzzz2au0H9Oj6fr1DXie8G3bDwO6M7Coq/0XXGhO+2TZs2WjpB1kEgRjAxgzTqm3EM48bLuUQKpSkIkqi6wbbmjVlWQvsN9/MQN5Q493GTieL63r17O0rXcCOB0ilcN9AWBecbtnOGII8i/HfeeUe7YaGLIYK1r1AFhJtTfIc4PnH8oxoAVVBWjqswaNAgPafw2+CGxaxXz8nnBaeqJJ+hmBknMO6yzZMBQRM546y+UOVGqIdErgjDsqIhHuVOKH3CjQMaZLo32syNUnL4ecGcNPkMuQYUs7u3ZKWsge992LBhOfJCRL5DGxWUWPkyUEhucDCHnxfMSVNAmJMmIrp+2AWLAsJ7PCKi64fF3URERDbFIE1ERGRTDNJEREQ2xSBNRERkUwzSRERENsUgTUREZFMM0kRERDbFIE1ERCT29P8B1PgB2dWweLsAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 500x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 5.2 Mesurer TTFT warm vs cold (stream, mediane sur 5 essais)\n",
+    "def ttft_cold(prefix, nonce):\n",
+    "    prompt = nonce + prefix   # nonce en tete => prefixe different => cache miss garanti\n",
+    "    return chat_stream_ttft(prompt, max_tokens=8)[0]\n",
+    "\n",
+    "def ttft_warm(prefix):\n",
+    "    return chat_stream_ttft(prefix, max_tokens=8)[0]\n",
+    "\n",
+    "def median(xs):\n",
+    "    return statistics.median(xs) if xs else float(\"nan\")\n",
+    "\n",
+    "# chauffe : envoyer le prefixe une fois pour le mettre en cache\n",
+    "chat_stream_ttft(common_prefix, max_tokens=4)\n",
+    "cold_times, warm_times = [], []\n",
+    "for i in range(6):\n",
+    "    nonce = f\"=== REQUETE {random.randint(100000,999999)} ===\\n\"\n",
+    "    t_cold = ttft_cold(common_prefix, nonce); cold_times.append(t_cold)\n",
+    "    t_warm = ttft_warm(common_prefix);         warm_times.append(t_warm)\n",
+    "    print(f\"  essai {i+1}: cold={t_cold:.3f}s warm={t_warm:.3f}s\")\n",
+    "\n",
+    "mc, mw = median(cold_times), median(warm_times)\n",
+    "speedup = (mc - mw) / mc if mc else float(\"nan\")\n",
+    "print(f\"\\nTTFT median   cold={mc:.3f}s  warm={mw:.3f}s\")\n",
+    "print(f\"gain de latence (prefix caching) : {speedup:.0%}\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5, 3.6))\n",
+    "ax.bar([\"cold (pas en cache)\", \"warm (cache hit)\"], [mc, mw], color=[\"tab:orange\", \"tab:green\"])\n",
+    "ax.set_ylabel(\"time-to-first-token (s)\"); ax.set_title(\"Prefix caching vLLM (mediane 6 essais)\")\n",
+    "ax.grid(alpha=0.3, axis=\"y\"); plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "915a9d6f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006651,
+     "end_time": "2026-08-24T00:03:15.447467+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:15.440816+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "`cold=0.415s` vs `warm=0.167s` : la médiane sur `6` essais, pas un minimum flatteur. C'est un **chiffre réel** — le préfixe commun (3837 tokens) est re-prefillé à froid, puis servi depuis le cache KV. Le **gain de 60 %** n'est pas une promesse : c'est la réduction médiane de TTFT mesurée sur ces 6 essais.\n",
+    "\n",
+    "> **Se positionner par rapport au caching d'orchestration d'Image 03-3.** Ce notebook mesure le **prompt/prefix caching** — un levier *d'inférence*, au niveau du calcul du modèle. Le notebook Image 03-3 (orchestration) cache des **résultats** d'appels entiers (LRU) : un levier *de couche applicative*. Les deux sont **complémentaires** : le résultat-cache évite de refaire un appel identique, le prefix-cache accélère un appel *différent* qui partage un préfixe. On n'oppose pas le niveau prompt au niveau résultat — ils agissent à deux étages distincts.\n",
+    "\n",
+    "> **Le coût monétaire.** Sur une API tierce, le prefix-caching ne change pas le prix (facturé au token) ; il change la **latence**. Sur notre pile self-hosted, il change l'**utilisation GPU** (moins de préfill). C'est un levier de coût *d'infrastructure*, pas de *facture*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "371b5fba",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007898,
+     "end_time": "2026-08-24T00:03:15.462303+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:15.454405+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices (C.1)\n",
+    "\n",
+    "Trois exercices pour s'approprier les mesures. Complétez les cellules — le notebook s'exécute de bout en bout même non complété (« Exercice à compléter »)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "100031f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:03:15.478116Z",
+     "iopub.status.busy": "2026-08-24T00:03:15.477690Z",
+     "iopub.status.idle": "2026-08-24T00:03:15.484071Z",
+     "shell.execute_reply": "2026-08-24T00:03:15.482966Z"
+    },
+    "papermill": {
+     "duration": 0.015539,
+     "end_time": "2026-08-24T00:03:15.485022+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:15.469483+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer — observation : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 — ajouter une profondeur de needle et mesurer\n",
+    "# Etape 1 : ajouter 0.3 et 0.7 a la liste `depths` de la cellule 2.1 (re-executer)\n",
+    "# Etape 2 : observer si le creux du milieu se confirme a plus de granularite\n",
+    "# Etape 3 : conclure — la position 0.5 (le centre) est-elle vraiment le pire ?\n",
+    "# TODO etudiant : ecrire votre observation\n",
+    "observation = None  # TODO etudiant : \"le creux se situe a ...\" ou \"aucun creux net\"\n",
+    "print(f\"Exercice 1 a completer — observation : {observation}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5f34ac32",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:03:15.501161Z",
+     "iopub.status.busy": "2026-08-24T00:03:15.500692Z",
+     "iopub.status.idle": "2026-08-24T00:03:15.506708Z",
+     "shell.execute_reply": "2026-08-24T00:03:15.505502Z"
+    },
+    "papermill": {
+     "duration": 0.015537,
+     "end_time": "2026-08-24T00:03:15.507710+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:15.492173+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : comparer debut+fin vs debut seul\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 — implementer une strategie de troncation \"garder debut + fin\"\n",
+    "# Le map-reduce condense, la troncation naive garde le debut. Essayez de garder debut ET fin\n",
+    "# (sauter le milieu), puis mesurez les faits retrouves.\n",
+    "# Etape 1 : ecrire une fonction truncate_head_tail(docs, head_frac=0.3, tail_frac=0.3)\n",
+    "# Etape 2 : la comparer a map_reduce et truncate sur la meme question\n",
+    "# Etape 3 : conclure si \"debut+fin\" bat \"debut seul\"\n",
+    "def truncate_head_tail(docs, head_frac=0.3, tail_frac=0.3, max_tokens=4000):\n",
+    "    # TODO etudiant : garder head_frac du debut + tail_frac de la fin de chaque doc\n",
+    "    pass  # TODO etudiant : remplacer pass par la vraie implementation\n",
+    "\n",
+    "print(\"Exercice 2 a completer : comparer debut+fin vs debut seul\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "88710d9d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:03:15.522022Z",
+     "iopub.status.busy": "2026-08-24T00:03:15.521552Z",
+     "iopub.status.idle": "2026-08-24T00:03:15.526728Z",
+     "shell.execute_reply": "2026-08-24T00:03:15.525716Z"
+    },
+    "papermill": {
+     "duration": 0.013337,
+     "end_time": "2026-08-24T00:03:15.527601+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:15.514264+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : decision de budget = None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 — estimer le budget avant envoi (comptage + decision)\n",
+    "# Reprenez la cellule 1.2 : ajoutez une fonction qui decide si un ensemble de documents\n",
+    "# tient dans la fenetre, en incluant une reserve pour la reponse.\n",
+    "# Etape 1 : ecrire fits_in_window(doc_texts, window, reserve)\n",
+    "# Etape 2 : tester avec les 3 documents de 1.2 et une fenetre de 8192 puis 32768\n",
+    "# Etape 3 : conclure quelle strategie (decoupe / map-reduce / tout envoyer) choisir\n",
+    "def fits_in_window(doc_texts, window, reserve):\n",
+    "    # TODO etudiant : compter les tokens et comparer a window - reserve\n",
+    "    return None  # TODO etudiant : bool\n",
+    "\n",
+    "print(\"Exercice 3 a completer : decision de budget =\", fits_in_window([], 32768, 512))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6a860f5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0071,
+     "end_time": "2026-08-24T00:03:15.541615+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T00:03:15.534515+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Quatre stratégies, quatre mesures réelles sur notre vLLM :\n",
+    "\n",
+    "1. **Budget en tokens** — compter avec le tokenizer réel transforme « on espère que ça tient » en un calcul explicite « ça tient / ça ne tient pas ».\n",
+    "2. **Biais de position** — le rappel d'un fait saillant varie avec sa profondeur ; le « lost in the middle » est soit démontré, soit honnêtement écarté (selon la mesure).\n",
+    "3. **Réordonnancement** — placer le document critique en début/fin plutôt qu'au milieu est une stratégie de rappel **à coût nul**.\n",
+    "4. **Map-reduce** — condenser chaque document puis synthétiser conserve plus d'information que tronquer ; la perte se **quantifie**, elle ne se devine pas.\n",
+    "5. **Prefix caching vLLM** — un préfixe partagé mis en cache réduit le time-to-first-token ; le gain est **mesuré**, pas revendiqué.\n",
+    "\n",
+    "**Un seul fil conducteur** : la gestion du long contexte n'est pas de l'ingénierie de prompt, c'est de la **mesure d'ingénierie**. Chaque stratégie a un coût (tokens, appels, latence) et un bénéfice (rappel, complétude) qu'on peut rendre chiffré — et c'est ce chiffrage qui permet de la choisir à bon escient.\n",
+    "\n",
+    "> **Verdict SOTA.** Le notebook exécute le **vrai outil** (notre vLLM distant, via l'API OpenAI-compatible) et mesure **vraiment** — courbe rappel-vs-profondeur, perte de map-reduce, TTFT warm/cold — le tout committé avec outputs (C.2). Il ne s'agit pas d'un cas dégénéré où un moteur équivaudrait à une baseline : la longueur de contexte, la profondeur d'aiguille et le préfixe partagé sont précisément les quantités qui font **valoir** le moteur (fenêtre, cache KV) plutôt qu'un `if` qui réglerait tout. Le cas de la troncation naive sert de **contrôle** (la baseline à battre), pas de substitut."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 48.056997,
+   "end_time": "2026-08-24T00:03:17.092896+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "C:/dev/CoursIA-12453-lc/MyIA.AI.Notebooks/GenAI/Texte/10c_Long_Context_Strategies.ipynb",
+   "output_path": "C:/dev/CoursIA-12453-lc/MyIA.AI.Notebooks/GenAI/Texte/10c_Long_Context_Strategies.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-24T00:02:29.035899+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/genai — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #12669

## Summary

Livraison du **grain GREENLIGHT #12453** : nouveau notebook `MyIA.AI.Notebooks/GenAI/Texte/10c_Long_Context_Strategies.ipynb` — **stratégies pour contextes longs, mesurées sur notre vLLM distant** (le moteur réel, pas une API tierce ni un fallback).

Cinq stratégies, chacune **mesurée** (valeurs du run, pas un pitch) :

1. **Budget en tokens** — tokenizer réel (famille Qwen, offline) sur un vrai corpus git-tracked (Le Horla 77 204 tokens + Boule de Suif 33 154) ; décision « ça tient / ça ne tient pas ». **Fenêtre réelle du modèle servi** lue via `/models` au lieu d'être supposée (voir note honnêteté ci-dessous).
2. **Biais de position (needle-in-haystack)** — aiguille insérée à 6 profondeurs × 3 essais dans une paille de vraie prose ; courbe rappel-vs-position avec verdict honnête sur le « lost in the middle ».
3. **Réordonnancement** — la même aiguille à début / milieu / fin ; effet mesuré sur le rappel.
4. **Map-reduce vs troncation** — perte d'information **quantifiée** (faits retrouvés / 5) ; pas un avis, un chiffre.
5. **Prefix caching vLLM** — TTFT warm vs cold en **stream**, médiane sur 6 essais ; gain de latence **mesuré**, pas affirmé.

## Mesures (valeurs du run, committées)

- **Endpoint vLLM** (`GET /v1/models`) → HTTP 200, modèle `qwen3.6-35b-a3b`, `max_model_len = 262 144` (fenêtre réelle). Le notebook travaille sur un **budget de travail choisi** (32 768), bien plus petit que la fenêtre réelle — contrainte coût/latence réaliste, rendue explicite (pas une fenêtre « supposée du modèle »).
- **§1 Budget** : 3 docs × ~6 200 tokens → 18 678 tokens, **57.0 %** de la fenêtre, **14 090** restants après réservation 512.
- **§2 Needle (Le Horla, paille 4 000 t, 6 profondeurs × 3 essais)** : rappel = 1.000 à **toutes** les profondeurs (0.0, 0.2, 0.4, 0.6, 0.8, 1.0). **Verdict honnête : aucun creux du milieu net sur cette mesure.** Réponses brutes = `'749'` (sans espace) à chaque essai — récupérées par `simple_score` après normalisation qui retire les espaces. Note explicite ajoutée dans la cellule de lecture pour rendre l'absence du creux aussi probante que sa présence l'aurait été.
- **§3 Réordonnancement** (même aiguille, position seule varie) : debut 1.000 · milieu 1.000 · fin 1.000 → **pas d'effet mesuré ici**, cohérent avec §2.
- **§4 Map-reduce vs troncation** (5 faits injectés `AB-1-XY`...`AB-5-XY`) :
  - map-reduce : **5 / 5** retrouvés
  - troncation naive : **1 / 5** retrouvés
  - **perte relative = 80 %** (= 1 − 1/5, un chiffre, pas un avis)
- **§5 Prefix caching vLLM** (préfixe commun 3 837 tokens, 6 essais) :
  - TTFT cold (cache miss) : médiane **0.415 s**
  - TTFT warm (cache hit) : médiane **0.167 s**
  - **gain = 60 %**

## Validation

- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` (grep regex, 0 violation).
- **C.2 + H.3** : re-exec **papermill** (kernel `python3`) sur le vLLM distant ; chaque cellule code porte `execution_count` non-`null` et `outputs` (aucun `output_type: error`).
- **Verdict SOTA** : le notebook exécute le **vrai outil** (notre vLLM self-hosted, API OpenAI-compatible) et mesure **vraiment** — courbe rappel-vs-profondeur, perte de map-reduce, TTFT warm/cold — le tout committé avec outputs (C.2). Il ne s'agit pas d'un cas dégénéré où un moteur équivaudrait à une baseline triviale : la longueur de contexte, la profondeur d'aiguille et le préfixe partagé sont précisément les quantités qui font **valoir** le moteur (fenêtre, cache KV) plutôt qu'un `if` qui réglerait tout. Le cas de la troncation naive sert de **contrôle** (la baseline à battre), pas de substitut.
- **Non-fallback** : le vLLM local 0.5B (`max_model_len` 4 096) ne pouvait pas porter la fenêtre 32 768 → refusé (workaround-degrade, Prong A). La clé a été obtenue par canal privé (ai-01, provisioning #12411, msg-pmnf38 du 2026-08-23T22:00Z + `vllm_ai01.env`), et lue au runtime via `os.getenv("VLLM_API_KEY")` (jamais en literal inline, jamais en `os.getenv("VLLM_API_KEY", "<value>")`).
- **Modèle raisonnant** : `qwen3.6-35b-a3b` est un thinking model — sans `chat_template_kwargs={"enable_thinking": False}`, il consomme les `max_completion_tokens` en raisonnement et renvoie `content=None, finish_reason=length`. Le fix est documenté dans la cellule des helpers (commentaire expliquant le mécanisme) + `simple_score` est blindé contre `None` (`answer = answer or ""`).
- **Aucun chemin machine** (`AppData`/`jsboi`/`C:/Users`) dans les sorties committées (Stop & Repair respecté). Catalogue byte-identique à `main`. README/navlinks **non touchés** (réservés #12645). Aucun secret inline. Aucun `os.getenv(..., "<literal>")`. Pas de hand-edit de cellule.

## Attribution

Voir #12453 — livraison partielle (la liste README de la série Texte reste réservée par #12645).

See #12453
