### PR TITLE
feat(iit,#12672): ICT-15d certification Čech par entrelacement — verdict honnête 0/4

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15j-NerveDiscriminant.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15j-NerveDiscriminant.ipynb
@@ -5,16 +5,16 @@
    "id": "ab85b44c",
    "metadata": {
     "papermill": {
-     "duration": 0.004232,
-     "end_time": "2026-08-22T03:49:47.246868",
+     "duration": 0.003192,
+     "end_time": "2026-08-24T00:22:05.305959",
      "exception": false,
-     "start_time": "2026-08-22T03:49:47.242636",
+     "start_time": "2026-08-24T00:22:05.302767",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "# ICT-15d — Discriminant Čech par nerf simplicial (gudhi)\n",
+    "# ICT-15d — Discriminant Čech par nerf simplicial : calcul Vietoris-Rips, certification Čech par entrelacement (gudhi)\n",
     "\n",
     "**Issue** : [#12257](https://github.com/jsboige/CoursIA/issues/12257)\n",
     "**Epic** : [#4588](https://github.com/jsboige/CoursIA/issues/4588) (IIT -> ICT)\n",
@@ -57,16 +57,16 @@
    "id": "f22b81e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T03:49:47.252441Z",
-     "iopub.status.busy": "2026-08-22T03:49:47.252250Z",
-     "iopub.status.idle": "2026-08-22T03:49:47.674088Z",
-     "shell.execute_reply": "2026-08-22T03:49:47.673647Z"
+     "iopub.execute_input": "2026-08-24T00:22:05.311272Z",
+     "iopub.status.busy": "2026-08-24T00:22:05.310979Z",
+     "iopub.status.idle": "2026-08-24T00:22:05.780240Z",
+     "shell.execute_reply": "2026-08-24T00:22:05.779714Z"
     },
     "papermill": {
-     "duration": 0.425375,
-     "end_time": "2026-08-22T03:49:47.674916",
+     "duration": 0.473185,
+     "end_time": "2026-08-24T00:22:05.781387",
      "exception": false,
-     "start_time": "2026-08-22T03:49:47.249541",
+     "start_time": "2026-08-24T00:22:05.308202",
      "status": "completed"
     },
     "tags": []
@@ -156,10 +156,10 @@
    "id": "666b3c3b",
    "metadata": {
     "papermill": {
-     "duration": 0.00172,
-     "end_time": "2026-08-22T03:49:47.679096",
+     "duration": 0.002211,
+     "end_time": "2026-08-24T00:22:05.786858",
      "exception": false,
-     "start_time": "2026-08-22T03:49:47.677376",
+     "start_time": "2026-08-24T00:22:05.784647",
      "status": "completed"
     },
     "tags": []
@@ -168,8 +168,8 @@
     "### Le nerf simplicial : b1 comme discriminant Čech\n",
     "\n",
     "On construit, pour chaque substrat, un **nuage de 30 points** dans\n",
-    "R³ (un point par fenêtre × 3 proxys). Le **nerf simplicial Čech** (ici\n",
-    "l'approximation Rips, gudhi) sur ce nuage retient les simplexes dont les\n",
+    "R³ (un point par fenêtre × 3 proxys). Le **nerf simplicial** (filtration **Vietoris-Rips**, gudhi) sur ce nuage\n",
+    "retient les simplexes dont les\n",
     "arêtes sont de longueur ≤ ε ; **b1** est le nombre de **cycles 1-dim**\n",
     "persistants dans la filtration.\n",
     "\n",
@@ -195,16 +195,16 @@
    "id": "a22b1cd5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T03:49:47.683996Z",
-     "iopub.status.busy": "2026-08-22T03:49:47.683537Z",
-     "iopub.status.idle": "2026-08-22T03:49:48.068604Z",
-     "shell.execute_reply": "2026-08-22T03:49:48.068219Z"
+     "iopub.execute_input": "2026-08-24T00:22:05.792824Z",
+     "iopub.status.busy": "2026-08-24T00:22:05.792354Z",
+     "iopub.status.idle": "2026-08-24T00:22:06.245616Z",
+     "shell.execute_reply": "2026-08-24T00:22:06.245066Z"
     },
     "papermill": {
-     "duration": 0.388327,
-     "end_time": "2026-08-22T03:49:48.069280",
+     "duration": 0.458391,
+     "end_time": "2026-08-24T00:22:06.247329",
      "exception": false,
-     "start_time": "2026-08-22T03:49:47.680953",
+     "start_time": "2026-08-24T00:22:05.788938",
      "status": "completed"
     },
     "tags": []
@@ -270,10 +270,10 @@
    "id": "19b8680e",
    "metadata": {
     "papermill": {
-     "duration": 0.001719,
-     "end_time": "2026-08-22T03:49:48.072921",
+     "duration": 0.002268,
+     "end_time": "2026-08-24T00:22:06.253387",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.071202",
+     "start_time": "2026-08-24T00:22:06.251119",
      "status": "completed"
     },
     "tags": []
@@ -302,16 +302,16 @@
    "id": "ff929034",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T03:49:48.077027Z",
-     "iopub.status.busy": "2026-08-22T03:49:48.076841Z",
-     "iopub.status.idle": "2026-08-22T03:49:48.113990Z",
-     "shell.execute_reply": "2026-08-22T03:49:48.113324Z"
+     "iopub.execute_input": "2026-08-24T00:22:06.259009Z",
+     "iopub.status.busy": "2026-08-24T00:22:06.258720Z",
+     "iopub.status.idle": "2026-08-24T00:22:06.296248Z",
+     "shell.execute_reply": "2026-08-24T00:22:06.295765Z"
     },
     "papermill": {
-     "duration": 0.040206,
-     "end_time": "2026-08-22T03:49:48.114763",
+     "duration": 0.04205,
+     "end_time": "2026-08-24T00:22:06.297693",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.074557",
+     "start_time": "2026-08-24T00:22:06.255643",
      "status": "completed"
     },
     "tags": []
@@ -349,10 +349,10 @@
    "id": "6ca8ab6f",
    "metadata": {
     "papermill": {
-     "duration": 0.001696,
-     "end_time": "2026-08-22T03:49:48.118440",
+     "duration": 0.002264,
+     "end_time": "2026-08-24T00:22:06.302196",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.116744",
+     "start_time": "2026-08-24T00:22:06.299932",
      "status": "completed"
     },
     "tags": []
@@ -379,16 +379,16 @@
    "id": "0413df92",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T03:49:48.123116Z",
-     "iopub.status.busy": "2026-08-22T03:49:48.122813Z",
-     "iopub.status.idle": "2026-08-22T03:49:48.137915Z",
-     "shell.execute_reply": "2026-08-22T03:49:48.137476Z"
+     "iopub.execute_input": "2026-08-24T00:22:06.310731Z",
+     "iopub.status.busy": "2026-08-24T00:22:06.310511Z",
+     "iopub.status.idle": "2026-08-24T00:22:06.328101Z",
+     "shell.execute_reply": "2026-08-24T00:22:06.327629Z"
     },
     "papermill": {
-     "duration": 0.018425,
-     "end_time": "2026-08-22T03:49:48.138568",
+     "duration": 0.022716,
+     "end_time": "2026-08-24T00:22:06.329137",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.120143",
+     "start_time": "2026-08-24T00:22:06.306421",
      "status": "completed"
     },
     "tags": []
@@ -410,7 +410,7 @@
     }
    ],
    "source": [
-    "# --- Calcul du b1 sur chaque substrat (filtration Rips complete) ---\n",
+    "# --- Calcul du b1 sur chaque substrat (filtration Vietoris-Rips complète) ---\n",
     "import time\n",
     "\n",
     "t0 = time.time()\n",
@@ -431,10 +431,10 @@
    "id": "ee8924b3",
    "metadata": {
     "papermill": {
-     "duration": 0.001695,
-     "end_time": "2026-08-22T03:49:48.142895",
+     "duration": 0.003207,
+     "end_time": "2026-08-24T00:22:06.335845",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.141200",
+     "start_time": "2026-08-24T00:22:06.332638",
      "status": "completed"
     },
     "tags": []
@@ -442,7 +442,7 @@
    "source": [
     "### Lecture du résultat : b1(axl)=0 falsifie la SVD\n",
     "\n",
-    "**Mesures brutes** (4 substrats, gudhi Rips filtration complète) :\n",
+    "**Mesures brutes** (4 substrats, gudhi, filtration Vietoris-Rips complète) :\n",
     "\n",
     "| Substrat | b1 (instantané) | b1_max_persistence | b1_n_classes |\n",
     "|----------|-----------------|---------------------|--------------|\n",
@@ -481,16 +481,16 @@
    "id": "dc93de06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T03:49:48.148008Z",
-     "iopub.status.busy": "2026-08-22T03:49:48.147547Z",
-     "iopub.status.idle": "2026-08-22T03:49:48.151853Z",
-     "shell.execute_reply": "2026-08-22T03:49:48.151427Z"
+     "iopub.execute_input": "2026-08-24T00:22:06.342603Z",
+     "iopub.status.busy": "2026-08-24T00:22:06.342345Z",
+     "iopub.status.idle": "2026-08-24T00:22:06.346431Z",
+     "shell.execute_reply": "2026-08-24T00:22:06.345975Z"
     },
     "papermill": {
-     "duration": 0.0078,
-     "end_time": "2026-08-22T03:49:48.152633",
+     "duration": 0.008157,
+     "end_time": "2026-08-24T00:22:06.347152",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.144833",
+     "start_time": "2026-08-24T00:22:06.338995",
      "status": "completed"
     },
     "tags": []
@@ -538,10 +538,10 @@
    "id": "f880df55",
    "metadata": {
     "papermill": {
-     "duration": 0.001852,
-     "end_time": "2026-08-22T03:49:48.156456",
+     "duration": 0.004086,
+     "end_time": "2026-08-24T00:22:06.354158",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.154604",
+     "start_time": "2026-08-24T00:22:06.350072",
      "status": "completed"
     },
     "tags": []
@@ -576,21 +576,159 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c6febcb2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007476,
+     "end_time": "2026-08-24T00:22:06.366559",
+     "exception": false,
+     "start_time": "2026-08-24T00:22:06.359083",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Certification Čech par entrelacement : le seuil cesse d'être un réglage\n",
+    "\n",
+    "Le calcul ci-dessus est une filtration **Vietoris-Rips** ; le titre du notebook\n",
+    "parle de Čech. Ce n'est pas un abus de langage si on l'ancre : dans tout espace\n",
+    "métrique, les deux complexes sont **entrelacés**,\n",
+    "\n",
+    "$$\\\\text{Cech}_\\\\varepsilon \\\\subseteq \\\\text{VR}_{2\\\\varepsilon} \\\\subseteq \\\\text{Cech}_{2\\\\varepsilon}$$\n",
+    "\n",
+    "Justification en deux lignes : un simplexe Čech à ε (des boules de rayon ε\n",
+    "d'intersection non vide) a ses distances deux à deux ≤ 2ε — c'est un simplexe\n",
+    "VR à 2ε ; réciproquement, un simplexe VR de diamètre 2ε a tous ses points dans\n",
+    "la boule de rayon 2ε centrée sur n'importe lequel de ses sommets — l'intersection\n",
+    "des boules à 2ε est non vide. Conséquence exploitable : **toute classe H¹ née à\n",
+    "`birth` et morte à `death ≥ 2×birth` traverse une fenêtre de facteur 2, et par\n",
+    "l'entrelacement témoigne d'une classe Čech authentique**. Les classes qui meurent\n",
+    "avant peuvent n'être que des artefacts de l'approximation Rips. Le seuil de\n",
+    "persistance (0.05, un réglage) est remplacé par un critère géométrique."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "328c9b42",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T00:22:06.376842Z",
+     "iopub.status.busy": "2026-08-24T00:22:06.376488Z",
+     "iopub.status.idle": "2026-08-24T00:22:06.386687Z",
+     "shell.execute_reply": "2026-08-24T00:22:06.385992Z"
+    },
+    "papermill": {
+     "duration": 0.017562,
+     "end_time": "2026-08-24T00:22:06.388510",
+     "exception": false,
+     "start_time": "2026-08-24T00:22:06.370948",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Certification par entrelacement : Cech_e <= VR_2e <= Cech_2e\n",
+      "Une classe H^1 est CERTIFIEE si death >= 2 * birth (fenetre facteur 2).\n",
+      "\n",
+      "    substrat | n_classes | Cech-certifiees |  Rips-seules | max_pers_cert\n",
+      "------------------------------------------------------------------------------\n",
+      "  gray_scott |         0 |               0 |            0 |        0.0000\n",
+      "     axelrod |         0 |               0 |            0 |        0.0000\n",
+      "    grokking |         1 |               0 |            1 |        0.0000\n",
+      "         may |         3 |               0 |            3 |        0.0000\n",
+      "\n",
+      "Detail des classes (birth, death, certifiee) :\n",
+      "      grokking : birth=1.0386 death=1.0839 -> Rips-seule (fenetre 2x birth = 2.0772)\n",
+      "           may : birth=0.5576 death=0.6433 -> Rips-seule (fenetre 2x birth = 1.1151)\n",
+      "           may : birth=0.6222 death=0.6711 -> Rips-seule (fenetre 2x birth = 1.2444)\n",
+      "           may : birth=1.2665 death=1.3651 -> Rips-seule (fenetre 2x birth = 2.5331)\n",
+      "\n",
+      "Classes Cech-certifiees au total : 0  -> AUCUNE classe certifiee : le verdict doit se lire 'Vietoris-Rips'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Certification Cech par entrelacement : fenetre facteur 2 (issue #12672) ---\n",
+    "from ict.nerve_discriminant import cech_certification_substrats\n",
+    "\n",
+    "certifs = cech_certification_substrats(substrats_sections)\n",
+    "\n",
+    "print(\"Certification par entrelacement : Cech_e <= VR_2e <= Cech_2e\")\n",
+    "print(\"Une classe H^1 est CERTIFIEE si death >= 2 * birth (fenetre facteur 2).\")\n",
+    "print()\n",
+    "print(f\"{'substrat':>12} | {'n_classes':>9} | {'Cech-certifiees':>15} | {'Rips-seules':>12} | \"\n",
+    "      f\"{'max_pers_cert':>13}\")\n",
+    "print(\"-\" * 78)\n",
+    "for name, c in certifs.items():\n",
+    "    print(f\"{name:>12} | {c.n_classes:>9} | {c.n_certified:>15} | {c.n_rips_only:>12} | \"\n",
+    "          f\"{c.max_certified_persistence:>13.4f}\")\n",
+    "print()\n",
+    "print(\"Detail des classes (birth, death, certifiee) :\")\n",
+    "for name, c in certifs.items():\n",
+    "    if c.n_classes:\n",
+    "        for birth, death, cert in c.intervals:\n",
+    "            tag = \"Cech-certifiee\" if cert else \"Rips-seule\"\n",
+    "            print(f\"  {name:>12} : birth={birth:.4f} death={death:.4f} -> {tag}\"\n",
+    "                  f\" (fenetre 2x birth = {2*birth:.4f})\")\n",
+    "print()\n",
+    "n_cert_total = sum(c.n_certified for c in certifs.values())\n",
+    "print(f\"Classes Cech-certifiees au total : {n_cert_total}\"\n",
+    "      + (\"  -> le titre 'Cech' est justifie par l'entrelacement\" if n_cert_total else\n",
+    "         \"  -> AUCUNE classe certifiee : le verdict doit se lire 'Vietoris-Rips'\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae994403",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00637,
+     "end_time": "2026-08-24T00:22:06.400028",
+     "exception": false,
+     "start_time": "2026-08-24T00:22:06.393658",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : **aucune** des 4 classes H¹ observées ne\n",
+    "traverse la fenêtre facteur 2. Grokking meurt à 1.04× sa naissance, les trois\n",
+    "classes de may à 1.08–1.15× — toutes loin du facteur 2 exigé. L'entrelacement ne\n",
+    "garantit donc **aucune** d'elles comme classe Čech authentique : toutes sont\n",
+    "étiquetées **Rips-seules**. Deux conséquences honnêtes. D'abord, le verdict du\n",
+    "discriminant se lit « **Vietoris-Rips** » — le titre garde « Čech » pour\n",
+    "l'objet mathématique visé, la certification dit ce que le calcul garantit\n",
+    "(rien, ici). Ensuite, la garantie est unidirectionnelle : une classe morte\n",
+    "avant 2×birth peut être un artefact Rips **ou** une classe Čech trop courte\n",
+    "pour être certifiée — mais la classe la plus persistante de may (persistance\n",
+    "0.0986, au-dessus du seuil 0.05) meurt à 1.08× sa naissance : vue par le\n",
+    "critère géométrique, la non-trivialité de may **affichée par le seuil n'est pas\n",
+    "confirmée**. Le seuil de persistance reste affiché pour comparaison ; le\n",
+    "critère géométrique le remplace en autorité, et il est plus sévère."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "id": "273791bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T03:49:48.161231Z",
-     "iopub.status.busy": "2026-08-22T03:49:48.161027Z",
-     "iopub.status.idle": "2026-08-22T03:49:48.380726Z",
-     "shell.execute_reply": "2026-08-22T03:49:48.380244Z"
+     "iopub.execute_input": "2026-08-24T00:22:06.411324Z",
+     "iopub.status.busy": "2026-08-24T00:22:06.410960Z",
+     "iopub.status.idle": "2026-08-24T00:22:06.543015Z",
+     "shell.execute_reply": "2026-08-24T00:22:06.542398Z"
     },
     "papermill": {
-     "duration": 0.222917,
-     "end_time": "2026-08-22T03:49:48.381556",
+     "duration": 0.139234,
+     "end_time": "2026-08-24T00:22:06.543973",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.158639",
+     "start_time": "2026-08-24T00:22:06.404739",
      "status": "completed"
     },
     "tags": []
@@ -632,10 +770,10 @@
    "id": "5fdf607f",
    "metadata": {
     "papermill": {
-     "duration": 0.001985,
-     "end_time": "2026-08-22T03:49:48.385801",
+     "duration": 0.002459,
+     "end_time": "2026-08-24T00:22:06.549025",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.383816",
+     "start_time": "2026-08-24T00:22:06.546566",
      "status": "completed"
     },
     "tags": []
@@ -664,10 +802,10 @@
    "id": "ca31dde6",
    "metadata": {
     "papermill": {
-     "duration": 0.003968,
-     "end_time": "2026-08-22T03:49:48.391673",
+     "duration": 0.003465,
+     "end_time": "2026-08-24T00:22:06.554836",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.387705",
+     "start_time": "2026-08-24T00:22:06.551371",
      "status": "completed"
     },
     "tags": []
@@ -694,20 +832,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "059e675d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T03:49:48.396970Z",
-     "iopub.status.busy": "2026-08-22T03:49:48.396759Z",
-     "iopub.status.idle": "2026-08-22T03:49:48.400551Z",
-     "shell.execute_reply": "2026-08-22T03:49:48.400022Z"
+     "iopub.execute_input": "2026-08-24T00:22:06.563425Z",
+     "iopub.status.busy": "2026-08-24T00:22:06.563090Z",
+     "iopub.status.idle": "2026-08-24T00:22:06.567056Z",
+     "shell.execute_reply": "2026-08-24T00:22:06.566410Z"
     },
     "papermill": {
-     "duration": 0.007581,
-     "end_time": "2026-08-22T03:49:48.401385",
+     "duration": 0.009172,
+     "end_time": "2026-08-24T00:22:06.567912",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.393804",
+     "start_time": "2026-08-24T00:22:06.558740",
      "status": "completed"
     },
     "tags": []
@@ -740,10 +878,10 @@
    "id": "98c12c36",
    "metadata": {
     "papermill": {
-     "duration": 0.00191,
-     "end_time": "2026-08-22T03:49:48.405172",
+     "duration": 0.00303,
+     "end_time": "2026-08-24T00:22:06.573704",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.403262",
+     "start_time": "2026-08-24T00:22:06.570674",
      "status": "completed"
     },
     "tags": []
@@ -769,20 +907,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "14c8ddb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T03:49:48.410003Z",
-     "iopub.status.busy": "2026-08-22T03:49:48.409791Z",
-     "iopub.status.idle": "2026-08-22T03:49:48.413083Z",
-     "shell.execute_reply": "2026-08-22T03:49:48.412548Z"
+     "iopub.execute_input": "2026-08-24T00:22:06.581604Z",
+     "iopub.status.busy": "2026-08-24T00:22:06.581319Z",
+     "iopub.status.idle": "2026-08-24T00:22:06.584741Z",
+     "shell.execute_reply": "2026-08-24T00:22:06.584085Z"
     },
     "papermill": {
-     "duration": 0.006832,
-     "end_time": "2026-08-22T03:49:48.413876",
+     "duration": 0.009397,
+     "end_time": "2026-08-24T00:22:06.585798",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.407044",
+     "start_time": "2026-08-24T00:22:06.576401",
      "status": "completed"
     },
     "tags": []
@@ -809,10 +947,10 @@
    "id": "60ccd67e",
    "metadata": {
     "papermill": {
-     "duration": 0.002259,
-     "end_time": "2026-08-22T03:49:48.418285",
+     "duration": 0.003837,
+     "end_time": "2026-08-24T00:22:06.592855",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.416026",
+     "start_time": "2026-08-24T00:22:06.589018",
      "status": "completed"
     },
     "tags": []
@@ -838,20 +976,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "cc5b7790",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T03:49:48.422983Z",
-     "iopub.status.busy": "2026-08-22T03:49:48.422806Z",
-     "iopub.status.idle": "2026-08-22T03:49:48.425923Z",
-     "shell.execute_reply": "2026-08-22T03:49:48.425491Z"
+     "iopub.execute_input": "2026-08-24T00:22:06.601075Z",
+     "iopub.status.busy": "2026-08-24T00:22:06.600845Z",
+     "iopub.status.idle": "2026-08-24T00:22:06.604238Z",
+     "shell.execute_reply": "2026-08-24T00:22:06.603709Z"
     },
     "papermill": {
-     "duration": 0.006448,
-     "end_time": "2026-08-22T03:49:48.426625",
+     "duration": 0.009149,
+     "end_time": "2026-08-24T00:22:06.605559",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.420177",
+     "start_time": "2026-08-24T00:22:06.596410",
      "status": "completed"
     },
     "tags": []
@@ -878,10 +1016,10 @@
    "id": "f71c6053",
    "metadata": {
     "papermill": {
-     "duration": 0.002119,
-     "end_time": "2026-08-22T03:49:48.430826",
+     "duration": 0.004143,
+     "end_time": "2026-08-24T00:22:06.613844",
      "exception": false,
-     "start_time": "2026-08-22T03:49:48.428707",
+     "start_time": "2026-08-24T00:22:06.609701",
      "status": "completed"
     },
     "tags": []
@@ -907,6 +1045,8 @@
     "  avec un rang spectral trompeur (la matrice est bien de rang 2 mais le\n",
     "  contenu est plat) ; le nerf Čech détecte correctement l'absence de\n",
     "  structure de boucle.\n",
+    "\n",
+    "**Certification** (section précédente) : 0/4 classes observées ne traversent la fenêtre facteur 2 — aucune n'est garantie Čech par l'entrelacement, et le verdict du discriminant se lit « Vietoris-Rips » (tableau de certification ci-dessus) ; la non-trivialité de may au seuil 0.05 n'est pas confirmée par le critère géométrique.\n",
     "\n",
     "**Valeur ajoutée du discriminant Čech** : pas un remplacement de la SVD,\n",
     "mais un **garde-fou contre les faux positifs spectraux**. Quand la SVD\n",
@@ -954,14 +1094,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.174901,
-   "end_time": "2026-08-22T03:49:48.673428",
+   "duration": 3.41506,
+   "end_time": "2026-08-24T00:22:06.963130",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15j-NerveDiscriminant.ipynb",
    "output_path": "MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15j-NerveDiscriminant.ipynb",
    "parameters": {},
-   "start_time": "2026-08-22T03:49:45.498527",
+   "start_time": "2026-08-24T00:22:03.548070",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/nerve_discriminant.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/nerve_discriminant.py
@@ -320,9 +320,111 @@ def discrimination_verdict(
     }
 
 
+# ---------------------------------------------------------------------------
+# Certification Cech par entrelacement (issue #12672)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CechCertification:
+    """Classes H^1 de la filtration Vietoris-Rips triees par la fenetre facteur 2.
+
+    Entrelacement (valable dans tout espace metrique) :
+
+        Cech_eps  <=  VR_{2 eps}  <=  Cech_{2 eps}
+
+    Un simplexe Cech a eps a ses distances deux a deux <= 2 eps ; reciproquement
+    un simplexe VR de diametre 2 eps a tous ses points dans la boule de rayon
+    2 eps centree sur n'importe lequel de ses sommets. Une classe H^1 nee a
+    ``birth`` et morte a ``death >= 2 * birth`` traverse donc une fenetre de
+    facteur 2 : par l'entrelacement elle temoigne d'une classe Cech
+    authentique (**certifiee**). Une classe morte avant ``2 * birth`` peut
+    n'etre qu'un artefact de l'approximation Rips (**Rips-seule**).
+
+    Sur un nuage de points fini, la filtration Rips se termine en simplexe
+    complet contractile : toute classe H^1 est finie, le tri est exhaustif.
+    """
+
+    substrat: str
+    n_classes: int
+    n_certified: int
+    n_rips_only: int
+    max_certified_persistence: float
+    intervals: tuple  # ((birth, death, certified), ...)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "substrat": self.substrat,
+            "n_classes": self.n_classes,
+            "n_certified": self.n_certified,
+            "n_rips_only": self.n_rips_only,
+            "max_certified_persistence": self.max_certified_persistence,
+        }
+
+
+def cech_certification(
+    sections: Dict[str, Sequence[float]],
+    substrat_name: str,
+) -> CechCertification:
+    """Certifie les classes H^1 de la filtration Vietoris-Rips par l'entrelacement.
+
+    Meme normalisation (z-score par proxy) et meme filtration Rips complete
+    que :func:`nerve_b1` ; la difference est que les paires (birth, death)
+    sont exposees individuellement pour le tri par la fenetre facteur 2.
+    """
+    points = np.column_stack(
+        [np.asarray(sections[p], dtype=float) for p in sections]
+    )
+    means = points.mean(axis=0, keepdims=True)
+    stds = points.std(axis=0, keepdims=True)
+    stds = np.where(stds > 1e-12, stds, 1.0)
+    points_norm = (points - means) / stds
+
+    dmat = _pairwise_distance(points_norm)
+    triu = dmat[np.triu_indices(dmat.shape[0], k=1)]
+    rips_full = RipsComplex(distance_matrix=dmat, max_edge_length=float(np.max(triu)))
+    st_full = rips_full.create_simplex_tree(max_dimension=2)
+    st_full.compute_persistence()
+    h1 = st_full.persistence_intervals_in_dimension(1)
+    finite = h1[np.isfinite(h1).all(axis=1)] if h1.size else np.zeros((0, 2))
+
+    intervals = []
+    n_certified = 0
+    max_cert = 0.0
+    for birth, death in finite:
+        certified = bool(death >= 2.0 * birth)
+        if certified:
+            n_certified += 1
+            max_cert = max(max_cert, float(death - birth))
+        intervals.append((float(birth), float(death), certified))
+
+    n_classes = int(finite.shape[0])
+    return CechCertification(
+        substrat=substrat_name,
+        n_classes=n_classes,
+        n_certified=n_certified,
+        n_rips_only=n_classes - n_certified,
+        max_certified_persistence=float(max_cert),
+        intervals=tuple(intervals),
+    )
+
+
+def cech_certification_substrats(
+    substrats_sections: Dict[str, Dict[str, Sequence[float]]],
+) -> Dict[str, CechCertification]:
+    """Applique cech_certification sur plusieurs substrats."""
+    return {
+        name: cech_certification(sections, name)
+        for name, sections in substrats_sections.items()
+    }
+
+
 __all__ = [
     "NerveB1Result",
     "nerve_b1",
     "nerve_b1_substrats",
     "discrimination_verdict",
+    "CechCertification",
+    "cech_certification",
+    "cech_certification_substrats",
 ]


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: DEEP/notebook-python #12542

## Summary

ICT-15d-NerveDiscriminant calculait une filtration Vietoris-Rips (gudhi `RipsComplex`) en se nommant « discriminant Čech » (42 occurrences Cech / 0 Vietoris). Cette PR ancre le vocabulaire par l'**entrelacement métrique** `Cech_e ⊆ VR_2e ⊆ Cech_2e` au lieu de l'aveu inline non ancré.

**Module** (`ict/nerve_discriminant.py`, +102 lignes) :
- `CechCertification` (dataclass frozen) : `n_classes`, `n_certified`, `n_rips_only`, `max_certified_persistence`, `intervals` ((birth, death, certified), ...)
- `cech_certification()` / `cech_certification_substrats()` : même normalisation z-score + filtration Rips complète que `nerve_b1`, expose les paires (birth, death) individuelles et certifie `death >= 2*birth` (fenêtre facteur 2)

**Notebook** (23 cellules, +3) :
- Section « Certification Čech par entrelacement » : énoncé `Cech_e ⊆ VR_2e ⊆ Cech_2e` + justification en deux lignes (simplexe Čech à ε → distances 2-à-2 ≤ 2ε ; simplexe VR de diamètre 2ε → boules de rayon 2ε centrées sur n'importe quel sommet s'intersectent)
- Cellule code : tableau par substrat avec colonnes Cech-certifiées / Rips-seules + détail (birth, death, fenêtre 2×birth) par classe
- Vocabulaire réconcilié : titre « calcul Vietoris-Rips, certification Čech par entrelacement », cellules 2/7/8 nomment la filtration Vietoris-Rips

**Verdict mesuré — honnête, pas arrangé** :
- **0/4 classes** H¹ traversent la fenêtre facteur 2 (grokking meurt à 1.04× sa naissance, may à 1.08–1.15×)
- Toutes étiquetées **Rips-seules** ; le verdict du discriminant se lit « Vietoris-Rips » (affiché dans la sortie committée)
- La non-trivialité de may au seuil 0.05 n'est **pas confirmée** par le critère géométrique — la garantie est unidirectionnelle (une classe morte avant 2×birth peut être artefact Rips ou classe Čech trop courte)

## Acceptance #12672

- [x] Entrelacement énoncé avec justification en deux lignes (cellule markdown dédiée)
- [x] `b1_max_persistence` confronté à la fenêtre facteur 2 : labels Cech-certifiées / Rips-seules, colonne dans le tableau par substrat
- [x] Vocabulaire mis d'accord : « Vietoris-Rips » là où le calcul est Rips ; « Čech » réservé à l'objet visé + la certification qui dit ce que le calcul garantit
- [x] Re-exécution complète, sorties committées (C.2)

## Validation (H.1)

- Papermill end-to-end : `23/23 cellules, kernel python3, ~3 s` — **0 erreur kernel**
- `execution_count` = `[1..10]` strictement croissant, **0 null**
- Smoke module pré-commit : cercle bruité → 1 classe (0.505, 2.369) **certifiée** (le critère discrimine : il certifie quand c'est justifié, refuse ici)
- gudhi 3.13.0 (API `compute_persistence()` + `persistence_intervals_in_dimension(1)`)

Closes #12672

🤖 Generated with [Claude Code](https://claude.com/claude-code)