### PR TITLE
fix(tooling,#12714): le picker voit les PRs OUVERTES — 43 % des tirages etaient deja couverts

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -265,48 +265,83 @@ def check_claims(numbers: list[int], lane: str) -> dict[int, str]:
 
 
 def recent_delivery(picks: list[dict]) -> dict[int, str]:
-    """Annote les candidats tires dont une PR mergee les reference plus
-    recemment que la derniere mise a jour de l'issue.
+    """Annote les candidats tires qu'une autre PR couvre deja -- ouverte ou mergee.
 
     #12174 : le label ``candidate-delivered`` est pose par un workflow
     ``schedule:`` quotidien, dans une flotte qui merge plusieurs PRs par heure
     -- au tirage de 16:47Z, #12014 etait classee ``grain`` alors que #12077
     (mergee 16:19Z) avait deja livre 3 de ses 4 items. Le body d'une issue est
     date de sa redaction et un claim ne dit rien d'une livraison : la
-    recherche de PRs mergees est la troisieme surface de grounding, et ce
-    geste doit vivre dans l'outil qui propose le grain, pas dans la discipline
-    de qui le lit. Une requete par candidat tire, jamais un balayage du pool.
+    recherche de PRs est la troisieme surface de grounding, et ce geste doit
+    vivre dans l'outil qui propose le grain, pas dans la discipline de qui le
+    lit. Une requete par candidat tire, jamais un balayage du pool.
+
+    #12504 (rapporte par myia-po-2023:CoursIA, 2026-08-24) : ne regarder que
+    les PRs **mergees** laissait un angle mort plus couteux que celui qu'on
+    fermait. Une issue couverte par une PR encore **OUVERTE** ne porte aucune
+    trace de livraison -- ni label, ni body a jour, ni fusion a trouver -- et
+    ressort donc en tete d'urne comme un grain frais. Le tirage a place #12504
+    en tete (p=2.0) alors que #12519 la couvrait depuis des heures ; la lane
+    qui l'a prise a pose un claim **void**. Les deux etats se lisent dans la
+    **meme** requete (``--state all``), l'invariant "une requete par candidat"
+    est donc preserve.
+
+    Priorite du signal : une PR ouverte l'emporte sur une fusion recente. Une
+    fusion dit "c'est peut-etre deja fait" ; une PR ouverte dit "quelqu'un y
+    est en ce moment, ton claim sera void". Une PR **fermee sans fusion** ne
+    dit rien et est ignoree explicitement.
 
     L'annotation **n'ecarte pas** le candidat (parite avec la doctrine
     ``candidate-delivered`` : signale, ne ferme pas) : elle change ce qu'on
-    en dit, pas s'il est pris.
+    en dit, pas s'il est pris. Le verrou cross-lane reste
+    ``check_lane_claim.py``, que ``--check-claims`` interroge separement.
     """
     notes: dict[int, str] = {}
     for p in picks:
         n = p["number"]
         try:
             out = subprocess.run(
-                ["gh", "pr", "list", "--repo", REPO, "--state", "merged",
+                ["gh", "pr", "list", "--repo", REPO, "--state", "all",
                  "--limit", "20", "--search", f"{n} in:title,body",
-                 "--json", "number,mergedAt"],
+                 "--json", "number,state,isDraft,mergedAt"],
                 capture_output=True, text=True, encoding="utf-8", check=True,
                 timeout=30,
             ).stdout
             prs = json.loads(out)
         except Exception as exc:  # noqa: BLE001 - diagnostic best-effort
-            notes[n] = f"(recherche livraison indisponible: {type(exc).__name__})"
+            notes[n] = f"(recherche PR indisponible: {type(exc).__name__})"
             continue
         if not prs:
             continue
-        latest = max(prs, key=lambda pr: pr.get("mergedAt") or "")
-        merged = latest.get("mergedAt") or ""
+
+        # Une PR fermee-sans-fusion n'atteste de rien : on l'ecarte ici plutot
+        # que de la laisser peser dans les deux partitions ci-dessous.
+        opened = [pr for pr in prs if pr.get("state") == "OPEN"]
+        merged = [pr for pr in prs if pr.get("state") == "MERGED"]
+
+        if opened:
+            first = min(opened, key=lambda pr: pr["number"])
+            others = [pr["number"] for pr in opened if pr["number"] != first["number"]]
+            extra = f" (+{len(others)} autre(s) : " + ", ".join(
+                f"#{x}" for x in others) + ")" if others else ""
+            draft = " [draft]" if first.get("isDraft") else ""
+            notes[n] = (f"TRAVAIL EN COURS : PR #{first['number']}{draft} OUVERTE "
+                        f"couvre cette issue{extra} "
+                        f"-> claim probablement VOID ; lire "
+                        f"`gh pr view {first['number']}` AVANT de claimer")
+            continue
+
+        if not merged:
+            continue
+        latest = max(merged, key=lambda pr: pr.get("mergedAt") or "")
+        when = latest.get("mergedAt") or ""
         # Fusion plus recente que la derniere activite de l'issue = le corps
-        # visible est potentiellement periéme par rapport au reel. Une fusion
+        # visible est potentiellement perime par rapport au reel. Une fusion
         # ANTERIEURE a updatedAt est deja digeree par le body (ou les
         # commentaires) : pas d'annotation, sinon le signal noie.
-        if merged and merged > p.get("updated_at", ""):
-            extra = f" (+{len(prs) - 1} autres)" if len(prs) > 1 else ""
-            notes[n] = (f"LIVRAISON RECENTE : #{latest['number']} mergee {merged}{extra} "
+        if when and when > p.get("updated_at", ""):
+            extra = f" (+{len(merged) - 1} autres)" if len(merged) > 1 else ""
+            notes[n] = (f"LIVRAISON RECENTE : #{latest['number']} mergee {when}{extra} "
                         f"(issue non mise a jour depuis {p.get('updated_at', '?')}) "
                         f"-> confronter le body au reel AVANT de dispatcher")
     return notes

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -5,6 +5,14 @@ fondateur (2026-08-21) : #12014 tiree en urne grain a 16:47Z alors que
 #12077, mergee a 16:19Z, avait deja livre 3 de ses 4 items -- le label
 ``candidate-delivered`` (workflow schedule: quotidien, dernier run 05:49Z)
 n'en savait rien. Le replay ci-dessous rejoue cet etat exact.
+
+Second angle mort, ferme le 2026-08-24 (#12504, rapporte par
+myia-po-2023:CoursIA) : ne regarder que les PRs MERGEES laissait passer
+les issues couvertes par une PR encore OUVERTE, qui ne portent aucune
+trace -- ni label, ni body a jour, ni fusion a trouver. #12504 est
+sortie en tete d'urne (p=2.0) alors que #12519 la couvrait ; la lane qui
+l'a prise a pose un claim void. Une PR ouverte prime une fusion recente :
+la fusion dit "c'est peut-etre fait", l'ouverte dit "quelqu'un y est".
 """
 
 import json
@@ -43,7 +51,7 @@ def test_founding_case_12014_surfaces_12077(monkeypatch):
     """
     calls = []
     _patch_gh(monkeypatch, [[
-        {"number": 12077, "mergedAt": "2026-08-21T16:19:17Z"},
+        {"number": 12077, "state": "MERGED", "mergedAt": "2026-08-21T16:19:17Z"},
     ]], calls)
     notes = pig.recent_delivery([_pick()])
     assert 12014 in notes
@@ -64,7 +72,9 @@ def test_query_shape_bounded_one_per_candidate(monkeypatch):
     pig.recent_delivery([_pick(n=1), _pick(n=2)])
     assert len(calls) == 2
     for cmd, n in zip(calls, (1, 2)):
-        assert "--state" in cmd and "merged" in cmd
+        # --state all depuis #12504 : ouvertes ET mergees dans la MEME
+        # requete, donc l'invariant "une par candidat" tient toujours.
+        assert "--state" in cmd and "all" in cmd
         assert "--limit" in cmd and "20" in cmd
         assert "--search" in cmd
         assert cmd[cmd.index("--search") + 1] == f"{n} in:title,body"
@@ -75,7 +85,7 @@ def test_merge_older_than_update_not_annotated(monkeypatch):
     digeree par le body -- pas d'annotation, sinon le signal noie."""
     calls = []
     _patch_gh(monkeypatch, [[
-        {"number": 12077, "mergedAt": "2026-08-21T04:00:00Z"},
+        {"number": 12077, "state": "MERGED", "mergedAt": "2026-08-21T04:00:00Z"},
     ]], calls)
     notes = pig.recent_delivery([_pick(updated_at="2026-08-21T05:13:00Z")])
     assert notes == {}
@@ -92,7 +102,7 @@ def test_candidate_stays_drawable(monkeypatch):
     la fonction rend des notes, les picks passes ne sont ni filtres ni mutés."""
     calls = []
     _patch_gh(monkeypatch, [[
-        {"number": 12077, "mergedAt": "2026-08-21T16:19:17Z"},
+        {"number": 12077, "state": "MERGED", "mergedAt": "2026-08-21T16:19:17Z"},
     ]], calls)
     picks = [_pick()]
     snapshot = dict(picks[0])
@@ -106,8 +116,8 @@ def test_multiple_prs_latest_named_with_count(monkeypatch):
     note, le compte evite de lire 'la livraison' comme l'unique."""
     calls = []
     _patch_gh(monkeypatch, [[
-        {"number": 12077, "mergedAt": "2026-08-21T16:19:17Z"},
-        {"number": 12065, "mergedAt": "2026-08-20T10:00:00Z"},
+        {"number": 12077, "state": "MERGED", "mergedAt": "2026-08-21T16:19:17Z"},
+        {"number": 12065, "state": "MERGED", "mergedAt": "2026-08-20T10:00:00Z"},
     ]], calls)
     notes = pig.recent_delivery([_pick()])
     assert "#12077" in notes[12014]
@@ -124,6 +134,90 @@ def test_gh_failure_annotated_best_effort(monkeypatch):
     notes = pig.recent_delivery([_pick()])
     assert "indisponible" in notes[12014]
     assert "TimeoutExpired" in notes[12014]
+
+
+# --- PR OUVERTE couvrante (#12504, rapporte 2026-08-24) --------------------
+#
+# Le detecteur precedent se validait sur ses faux negatifs cote FUSION. Il en
+# gardait un cote OUVERTURE, plus couteux : une fusion fait perdre du temps de
+# lecture, une PR ouverte fait perdre un claim. Chaque test nomme le defaut
+# qu'il empeche de revenir.
+
+
+def test_founding_case_12504_open_pr_surfaces_12519(monkeypatch):
+    """Controle positif : #12504 tiree en tete d'urne le 2026-08-24 alors que
+    #12519 (OUVERTE, po-2026) la couvrait -- claim void de la lane suivante."""
+    calls = []
+    _patch_gh(monkeypatch, [[
+        {"number": 12519, "state": "OPEN", "isDraft": False, "mergedAt": None},
+    ]], calls)
+    notes = pig.recent_delivery([_pick(n=12504)])
+    assert 12504 in notes
+    assert notes[12504].startswith("TRAVAIL EN COURS")
+    assert "#12519" in notes[12504]
+    assert "VOID" in notes[12504]
+
+
+def test_open_pr_annotated_even_when_issue_freshly_updated(monkeypatch):
+    """Une PR ouverte est courante par construction : contrairement a une
+    fusion, elle n'est PAS comparee a ``updated_at``. Une issue touchee il y a
+    une minute peut tres bien etre en cours de traitement par une autre lane."""
+    calls = []
+    _patch_gh(monkeypatch, [[
+        {"number": 12519, "state": "OPEN", "isDraft": False, "mergedAt": None},
+    ]], calls)
+    notes = pig.recent_delivery([_pick(n=12504, updated_at="2099-01-01T00:00:00Z")])
+    assert 12504 in notes and notes[12504].startswith("TRAVAIL EN COURS")
+
+
+def test_open_pr_takes_priority_over_recent_merge(monkeypatch):
+    """Les deux signaux coexistent souvent (une tranche livree, une en cours).
+    L'ouverte gagne : elle dit ou est le risque de collision maintenant."""
+    calls = []
+    _patch_gh(monkeypatch, [[
+        {"number": 12077, "state": "MERGED", "isDraft": False,
+         "mergedAt": "2026-08-21T16:19:17Z"},
+        {"number": 12519, "state": "OPEN", "isDraft": False, "mergedAt": None},
+    ]], calls)
+    notes = pig.recent_delivery([_pick()])
+    assert notes[12014].startswith("TRAVAIL EN COURS")
+    assert "#12519" in notes[12014]
+
+
+def test_closed_unmerged_pr_is_not_a_signal(monkeypatch):
+    """Sur-accusation a empecher : une PR fermee SANS fusion n'atteste de rien
+    (abandon, doublon dispose). La compter en 'travail en cours' enverrait la
+    lane chercher une collision inexistante."""
+    calls = []
+    _patch_gh(monkeypatch, [[
+        {"number": 12638, "state": "CLOSED", "isDraft": False, "mergedAt": None},
+    ]], calls)
+    assert pig.recent_delivery([_pick()]) == {}
+
+
+def test_draft_open_pr_marked_as_such(monkeypatch):
+    """Une draft compte (quelqu'un y est) mais se lit differemment d'une PR
+    prete : le marqueur doit le dire plutot que de laisser deviner."""
+    calls = []
+    _patch_gh(monkeypatch, [[
+        {"number": 12519, "state": "OPEN", "isDraft": True, "mergedAt": None},
+    ]], calls)
+    notes = pig.recent_delivery([_pick()])
+    assert "[draft]" in notes[12014]
+
+
+def test_several_open_prs_named_with_count(monkeypatch):
+    """Plusieurs lanes deja dessus : le compte evite de lire 'la PR' comme
+    l'unique, et la plus basse est nommee (la premiere arrivee)."""
+    calls = []
+    _patch_gh(monkeypatch, [[
+        {"number": 12640, "state": "OPEN", "isDraft": False, "mergedAt": None},
+        {"number": 12519, "state": "OPEN", "isDraft": False, "mergedAt": None},
+    ]], calls)
+    notes = pig.recent_delivery([_pick()])
+    assert "#12519" in notes[12014]
+    assert "#12640" in notes[12014]
+    assert "+1 autre(s)" in notes[12014]
 
 
 # --- garde "reparer son rouge d'abord" (mandat user 2026-08-22) ------------


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/tooling #12661

## Summary

`recent_delivery` n'interrogeait que les PRs **mergees**. Une issue couverte par une PR encore **ouverte** ne porte aucun signal — ni label `candidate-delivered` (pose sur reference par PR *mergee*), ni body a jour, ni fusion a trouver — et ressortait donc en tete d'urne comme un grain frais.

**Rapporte par myia-po-2023:CoursIA** (`msg-20260823T235735-xd434f`, 2026-08-24T01:57Z), sur un cas ou une autre lane a paye : #12504 tiree en tete d'urne (grain `notebook-python`, p=2.0) alors que #12519 la couvrait depuis des heures ; po-2025 a pose un claim **void**.

## Ce n'est pas un cas isole — 43 %

Mesure au 2026-08-24T02:5xZ, **5 tirages de 8 candidats** pour `myia-ai-01:CoursIA` (**40 tirages de candidat**, doublons possibles entre tirages) :

| tirage | candidats | PR ouverte couvrante | livraison recente |
|---|---|---|---|
| initial | 8 | **6** | 2 |
| reroll 1 | 8 | 3 | 2 |
| reroll 2 | 8 | 4 | 2 |
| reroll 3 | 8 | 3 | 2 |
| reroll 4 | 8 | 1 | 2 |
| **total** | **40** | **17 = 43 %** | 10 |

Le pool ouvert est, en ce moment, largement adosse a du travail deja engage. Le picker n'en disait rien.

## Pourquoi cet angle mort etait le plus cher des deux

Une **fusion** ratee fait perdre du temps de lecture (« c'est peut-etre deja fait »). Une **PR ouverte** ratee fait poser un **claim void** : la lane edite, pousse, decouvre la collision apres coup. C'est le second qui detruit du travail.

## Le correctif

- **Une seule requete** par candidat, `--state all` au lieu de `--state merged` : les trois etats reviennent ensemble. L'invariant du docstring — « une requete par candidat tire, jamais un balayage du pool » — est **preserve**, pas relache. Controle positif firsthand : `--state all` sur `1454 in:title,body` rend `1 CLOSED / 28 MERGED / 1 OPEN`.
- **Priorite a l'ouverte.** Quand les deux coexistent, la note nomme la PR ouverte.
- **Pas de comparaison a `updated_at`** pour une ouverte : elle est courante par construction. Une issue touchee il y a une minute peut tres bien etre en cours de traitement ailleurs.
- **`CLOSED` sans fusion ignoree** explicitement — sur-accusation a empecher : un abandon ou un doublon dispose n'atteste de rien, et l'annoncer enverrait la lane chercher une collision inexistante.
- **Signale, n'ecarte pas** (parite avec la doctrine `candidate-delivered`). Le verrou cross-lane reste `check_lane_claim.py`.

Rendu reel (extrait du tirage initial) :

```
grain      #12492      0j     0j  notebook-python*   2.0  Planners : la recherche en arriere ...
                                  TRAVAIL EN COURS : PR #12502 OUVERTE couvre cette issue (+1 autre(s) : #12632)
                                  -> claim probablement VOID ; lire `gh pr view 12502` AVANT de claimer
```

## Tests — 26 passent (20 pre-existants + 6)

Les 20 tests de #12174 **passaient a vide** apres le changement de requete : leurs fixtures n'avaient pas de champ `state`, donc ne tombaient dans aucune partition. Fixtures mises a la forme reelle de `gh --json state` — c'est la forme de la requete qui a change, le test devait suivre.

6 ajoutes, chacun nommant le defaut qu'il empeche de revenir : cas fondateur #12504/#12519 · annotation independante de `updated_at` · priorite ouverte sur fusion recente · **`CLOSED`-non-mergee non signalee** (garde de sur-accusation) · draft marquee `[draft]` · compte multi-PR. Non-regression du chemin `LIVRAISON RECENTE` verifiee separement sur un cas reel merged-seul (#11874 -> #12651).

## Portee — ce que ce correctif ne fait pas

Il ne **verrouille** rien : deux lanes peuvent toujours claimer la meme issue dans la meme minute. Il rend visible, **au moment du tirage**, un etat qui ne l'etait qu'apres le push. Le verrou reste `check_lane_claim.py`, avec l'angle mort de decoration ASCII documente en #12711.

## Variation

`MED/tooling`, genre **META** : cette PR **ne tient pas** le plancher G-VAR-1 et ne pretend pas le tenir. Le plat principal du cycle de ma lane est **#12695** (`DEEP/training`, genre CONTENU, verdict NO BEATS sur l'edge ETF), en attente de son `PR gate`.

`prev: MED/tooling #12661` — deuxieme `tooling` consecutif, substance genuinement distincte (garde thermique GPU multi-hote vs angle mort du picker sur les PRs ouvertes), au sens de la clause G-VAR-3 pour un DEEP/MED du domaine-coeur d'une lane. Litmus LIGHT : non — defaut rapporte, cause racine identifiee, 43 % mesures, 6 tests cibles ; il n'est pas generable en serie en scannant l'instance suivante.

Closes #12714
See #12504
