### PR TITLE
fix(guards,#12719): extract_lane refuse la lane fantôme date nue — 5 auto-blocages guéris, point final traité

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -75,7 +75,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 # Shared lane reader (#9485) -- see scripts/grain_tag.py.
-from grain_tag import extract_lane
+from grain_tag import extract_lane, lane_marker_residues
 
 # --- markers -----------------------------------------------------------------
 
@@ -434,6 +434,19 @@ class ClaimEvent(dict):
         return self.get("unparseable_scope") or []
 
     @property
+    def lane_scope_residue(self) -> list[str]:
+        """Malformed-lane residues on the marker line (#12719).
+
+        A bare date after the token (`myia-po-2023:CoursIA 2026-08-23`) or a
+        trailing sentence period (`myia-po-2023:CoursIA.`). The lane regex
+        fix makes both parse to the bare lane, so the claim is NOT blocked
+        anymore; this witness lists the residue so the declaring lane can SEE
+        its marker was malformed instead of the organ silently reinterpreting
+        it. Report-only -- a malformed marker that parses is functional.
+        """
+        return self.get("lane_scope_residue") or []
+
+    @property
     def empty_scope(self) -> list[str]:
         """Subset of `paths` matching ZERO tracked files in the repo (#10958).
 
@@ -545,8 +558,12 @@ def _parse_claim_events(comment: dict) -> list[ClaimEvent]:
         lane = extract_lane(line, marker_line=line)
         if lane is None:
             lane = extract_lane(body, marker_line=line)
+        # #12719 -- malformed-lane witness (bare date / trailing period).
+        # Report-only: the claim is attributed to the bare lane either way.
+        lane_residue = lane_marker_residues(line)
         events.append(ClaimEvent(
             lane=lane,
+            lane_scope_residue=lane_residue,
             action=action,
             marker=marker,
             created_at=created_at,
@@ -2109,6 +2126,11 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
                 # scope is fully parseable) or non-empty (the claim carries
                 # patterns fnmatch cannot match).
                 "unparseable_scope": ev.get("unparseable_scope") or [],
+                # #12719 -- malformed-lane witness (bare date after the
+                # token, trailing sentence period). The claim still parses to
+                # the bare lane; the residue is surfaced so the declaring
+                # lane sees its marker was malformed (report, not block).
+                "lane_scope_residue": ev.get("lane_scope_residue") or [],
                 # #10958 -- the dead-glob witness: globs of this claim that
                 # match zero tracked files. Empty when every glob locks
                 # something (or the walk was impossible). Non-empty means the

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -163,10 +163,19 @@ _GRAIN_FULL_RE = re.compile(
 # match by construction: none of their opening characters is in the
 # continuation class -- the same bounds `_extract_paths_clause` already uses
 # in check_lane_claim.py.
+#
+# #12719 -- the continuation class admits `[A-Z0-9]`, therefore a DIGIT,
+# therefore a bare date: `myia-po-2023:CoursIA 2026-08-23` parsed as the lane
+# `myia-po-2023:CoursIA 2026-08-23` (a lane that exists nowhere), and
+# `check_lane_claim` then blocked the declaring lane on its OWN claim -- five
+# times in one night. A full ISO timestamp (`2026-08-23T00:52Z`) was already
+# rejected by the `(?![:@])` guard; only the BARE date passes. The negative
+# lookahead below refuses the bare-date form as a continuation while keeping
+# every legitimate one (a workspace word never starts `NNNN-NN-NN`).
 _LANE_RE = re.compile(
     r"lane\s*:?\s+"
     r"([A-Za-z0-9._-]+:[A-Za-z0-9._-]+"
-    r"(?:[ \t]+(?-i:[A-Z0-9])[A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})",
+    r"(?:[ \t]+(?!\d{4}-\d{2}-\d{2})(?-i:[A-Z0-9])[A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})",
     re.IGNORECASE,
 )
 
@@ -190,9 +199,14 @@ _LANE_RE = re.compile(
 # half of a duplicated mechanism and not grepping for the other is the
 # recurring shape of this class of bug (#12145). No IGNORECASE on this one,
 # so `[A-Z0-9]` already means upper case.
+#
+# #12719 -- same bare-date guard as `_LANE_RE` above: the five real-world
+# malformed markers of the founder night carried NO `lane` keyword, so it is
+# THIS regex that swallowed `2026-08-23` into the lane token. The sibling
+# moves with the fix.
 _LANE_FALLBACK_RE = re.compile(
     r"\b(myia-[A-Za-z0-9._-]+:[A-Za-z][A-Za-z0-9._-]*"
-    r"(?:[ \t]+[A-Z0-9][A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})"
+    r"(?:[ \t]+(?!\d{4}-\d{2}-\d{2})[A-Z0-9][A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})"
 )
 
 # `prev` (case-insensitive), optional colon, whitespace, then the SAME
@@ -402,7 +416,7 @@ def parse_grain_tag(body: str | None) -> dict | None:
     return {
         "tier": m.group(1).upper(),
         "genre": m.group(2).lower(),
-        "lane": lane_m.group(1) if lane_m else None,
+        "lane": lane_m.group(1).rstrip(".") if lane_m else None,
     }
 
 
@@ -427,21 +441,67 @@ def extract_lane(body: str | None, marker_line: str | None = None) -> str | None
 
     Returns the `machine:workspace` string, or None when no lane token is
     found.
+
+    #12719 -- a trailing sentence period is NOT part of the lane. The token
+    class admits `.` (hostnames need it), so `lane myia-po-2023:CoursIA.`
+    (the founder Grain tag of PR #12530) parsed as `myia-po-2023:CoursIA.` --
+    a lane that matches nothing. No cluster lane ends in a period, so the
+    residue is stripped here; `lane_marker_residues` reports it so the organ
+    can surface the malformed form instead of silently reinterpreting it.
     """
     if not body:
         return None
     flat = _strip_title_hashes(body.translate(_NOISE))
     m = _LANE_RE.search(flat)
     if m:
-        return m.group(1)
+        return m.group(1).rstrip(".")
     # Fallback for claim comments that omit the literal `lane` keyword (#10395
     # Variante 1). Restricted to the marker line by the caller -- see docstring.
     if marker_line is not None:
         flat_line = _strip_title_hashes(marker_line.translate(_NOISE))
         m2 = _LANE_FALLBACK_RE.search(flat_line)
         if m2:
-            return m2.group(1)
+            return m2.group(1).rstrip(".")
     return None
+
+
+# #12719 -- what the lane regexes REFUSED to swallow but the marker still
+# carries: a bare date right after the token (`myia-po-2023:CoursIA
+# 2026-08-23 -- ...`, five founder markers), or a trailing sentence period
+# (`myia-po-2023:CoursIA.`). The regex fix makes both forms parse to the bare
+# lane; this witness lists them so the organ can REPORT the malformed form
+# (acceptance #4: "un marqueur presque-juste qui le DIT ne coute rien").
+# Modelled on `_unparseable_scope_in` (check_lane_claim.py #12052): a pure
+# witness function the claim-event builder calls on the marker line.
+_LANE_RESIDUE_BARE_DATE_RE = re.compile(r"^\s+(\d{4}-\d{2}-\d{2})(?![0-9-])")
+
+
+def lane_marker_residues(marker_line: str | None) -> list[str]:
+    """Audit witness (#12719): malformed-lane residues on a marker line.
+
+    Returns a list of human-readable residue descriptions -- empty when the
+    line carries a clean lane token (or no lane token at all, which other
+    organs already flag as `variation-tag-lane-missing`). Entries:
+      * `"bare-date:2026-08-23"` -- a bare date immediately after the lane
+        token, which the continuation guard refused and the declaring lane
+        did not intend as part of the lane;
+      * `"trailing-period:<token>"` -- the token ended in a sentence period
+        that `extract_lane` strips before comparing.
+    """
+    if not marker_line:
+        return []
+    flat = _strip_title_hashes(marker_line.translate(_NOISE))
+    residues: list[str] = []
+    m = _LANE_FALLBACK_RE.search(flat) or _LANE_RE.search(flat)
+    if not m:
+        return []
+    token = m.group(1)
+    if token.endswith("."):
+        residues.append("trailing-period:" + token)
+    dm = _LANE_RESIDUE_BARE_DATE_RE.match(flat[m.end(1):])
+    if dm:
+        residues.append("bare-date:" + dm.group(1))
+    return residues
 
 
 # --- short-header trio (#9861) ----------------------------------------------

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -2317,6 +2317,32 @@ def test_parse_claim_event_unparseable_scope_empty_when_clean():
     assert ev.unparseable_scope == []
 
 
+def test_parse_claim_event_lane_residue_reported_not_blocking():
+    """#12719 -- a marker writing a bare date after the lane parses to the
+    BARE lane (no phantom `myia-po-2023:CoursIA 2026-08-23`), and the residue
+    is witnessed in `lane_scope_residue`. Founder marker of the 5-auto-blocage
+    night (issue #12485 form)."""
+    line = ("[CLAIMED] #12485 — myia-po-2023:CoursIA 2026-08-23 — "
+            "Medical-Chatbot : amorcage batch")
+    ev = clc.parse_claim_event(comment(line, "2026-08-23T04:00:00Z"))
+    assert ev is not None
+    # The lane is the BARE token -- the declaring lane is no longer blocked
+    # against its own claim.
+    assert ev.lane == "myia-po-2023:CoursIA"
+    # And the malformed form is REPORTED, not silently reinterpreted.
+    assert ev.lane_scope_residue == ["bare-date:2026-08-23"]
+
+
+def test_parse_claim_event_lane_residue_empty_when_clean():
+    """#12719 regression -- a well-formed marker yields an empty
+    `lane_scope_residue`. The witness must not fire on clean claims."""
+    line = "[CLAIMED] lane myia-po-2023:CoursIA -- paths: scripts/foo.py"
+    ev = clc.parse_claim_event(comment(line, "2026-08-23T04:00:00Z"))
+    assert ev is not None
+    assert ev.lane == "myia-po-2023:CoursIA"
+    assert ev.lane_scope_residue == []
+
+
 def test_filter_by_claim_scope_lifts_unparseable_to_epic_wide():
     """CORE #10597 hardener -- control positif (rouge->vert).
 

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -682,3 +682,61 @@ def test_lane_fallback_twin_moves_with_the_primary(  ):
 def test_lane_fallback_historical_form_unchanged():
     line = "[CLAIMED] #9764 - myia-po-2025:CoursIA 2026-08-07T00:52Z"
     assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-po-2025:CoursIA"
+
+
+# --- #12719: the bare-date phantom lane --------------------------------------
+#
+# Founder night (5 auto-blockages): a marker writing a bare date where the
+# organ expects the lane produced a lane THAT EXISTS NOWHERE, and
+# check_lane_claim then blocked the declaring lane on its OWN claim. The five
+# real-world forms below are the founder markers (issues #12485 #12484 #12466
+# #12518 #12461), verbatim prefixes.
+_REAL_FOUNDER_MARKERS_12719 = [
+    "[CLAIMED] #12485 — myia-po-2023:CoursIA 2026-08-23 — Medical-Chatbot : amorcage batch",
+    "[CLAIMED] #12484 — myia-po-2023:CoursIA 2026-08-23 — Recipe-Maker : terminaison sur livrable",
+    "[CLAIMED] #12466 — myia-po-2023:CoursIA 2026-08-23 — MGS-7c/7d : check réflexif corrigé",
+    "[CLAIMED] #12518 — myia-po-2023:CoursIA 2026-08-23 — rl_6 : ablation exécutée",
+    "[CLAIMED] #12461 — myia-po-2023:CoursIA 2026-08-23 — QC 03-Framework-Composite",
+]
+
+
+def test_lane_bare_date_not_swallowed_founder_markers():
+    # Acceptance #12719-1: the five real markers parse to the BARE lane.
+    for line in _REAL_FOUNDER_MARKERS_12719:
+        assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-po-2023:CoursIA", line
+
+
+def test_lane_bare_date_with_keyword_not_swallowed():
+    # Same defect via the PRIMARY regex (keyword form).
+    line = "[CLAIMED] lane myia-po-2023:CoursIA 2026-08-23 — grain"
+    assert gt.extract_lane(line, marker_line=line) == "myia-po-2023:CoursIA"
+
+
+def test_lane_spaces_workspace_survives_date_guard():
+    # Acceptance #12719-2 (explicit): the space-tolerant lane is NOT truncated
+    # by the date lookahead -- a legitimate multi-word workspace never starts
+    # `NNNN-NN-NN`.
+    line = "[CLAIMED] lane myia-po-2025:Microsoft VS Code 2026-08-23"
+    assert gt.extract_lane(line, marker_line=line) == "myia-po-2025:Microsoft VS Code"
+
+
+def test_lane_trailing_period_stripped():
+    # Acceptance #12719-3: founder Grain tag of PR #12530.
+    body = "- Grain `MED/genai-video` — lane `myia-po-2023:CoursIA`."
+    assert gt.extract_lane(body, marker_line=body) == "myia-po-2023:CoursIA"
+    # parse_grain_tag strips it too (same single-reader discipline, #9485).
+    assert gt.parse_grain_tag(body)["lane"] == "myia-po-2023:CoursIA"
+
+
+def test_lane_marker_residues_report_malformed_forms():
+    # Acceptance #12719-4: a malformed marker is REPORTED, not silently
+    # reinterpreted.
+    line = _REAL_FOUNDER_MARKERS_12719[0]
+    residues = gt.lane_marker_residues(line)
+    assert residues == ["bare-date:2026-08-23"]
+    # Trailing period is witnessed as well.
+    body = "- Grain `MED/genai-video` — lane `myia-po-2023:CoursIA`."
+    assert any(r.startswith("trailing-period:") for r in gt.lane_marker_residues(body))
+    # A clean marker carries no residue.
+    clean = "[CLAIMED] lane myia-po-2023:CoursIA -- paths: foo.py"
+    assert gt.lane_marker_residues(clean) == []


### PR DESCRIPTION
- Grain: MED/tooling — lane myia-po-2023:CoursIA
- Quoi: `extract_lane` ne fabrique plus une lane inexistante quand le marqueur porte une date nue ; le point final de phrase est strippé ; le marqueur mal formé est signalé.
- Preuve: `pytest scripts/tests/test_grain_tag.py scripts/tests/test_check_lane_claim.py` = **292 passed** (+149 picker/nits, +125 variation consumers) ; smoke des 5 marqueurs fondateurs verbatim → `'myia-po-2023:CoursIA'` + résidu `['bare-date:2026-08-23']`.
- Perimetre: 4 fichiers au total -- scripts/grain_tag.py, scripts/check_lane_claim.py, scripts/tests/test_check_lane_claim.py, scripts/tests/test_grain_tag.py. Rien d'autre.

## Summary

**Le défaut** (5 auto-blocages en une nuit, fondateurs #12511 #12484 #12538 #12542 #12605) : un marqueur écrivant une date nue à la place attendue de la lane (`[CLAIMED] #12485 — myia-po-2023:CoursIA 2026-08-23 — ...`) produisait la lane fantôme `myia-po-2023:CoursIA 2026-08-23` — et `check_lane_claim` bloquait alors la lane déclarante **contre son propre claim**.

**Cause** : la classe de continuation des regex de lane admet `[A-Z0-9]`, donc un chiffre, donc `2026-08-23`. Un timestamp ISO complet (`2026-08-23T00:52Z`) était déjà rejeté par le garde `(?![:@])` — seule la date nue passe.

**Fix** (les DEUX regex — les 5 marqueurs fondateurs ne portent PAS le keyword `lane`, c'est le jumeau fallback qui avalait les dates) :
- `_LANE_RE` + `_LANE_FALLBACK_RE` : lookahead négatif `(?!\d{4}-\d{2}-\d{2})` sur la continuation.
- **Sibling dans la même PR** : point final (`lane myia-po-2023:CoursIA.`, tag Grain de PR #12530) strippé dans `extract_lane` **et** `parse_grain_tag` (discipline single-reader #9485) — le `.` est dans `[A-Za-z0-9._-]`, même classe de défaut.

**Acceptance 4 — signaler, pas réinterpréter en silence** : nouveau témoin `lane_marker_residues()` (modèle `_unparseable_scope_in` #12052) → champ `lane_scope_residue` sur `ClaimEvent`, exposé dans le summary JSON. Report-only : le claim parse vers la lane nue dans tous les cas.

## Acceptance #12719

1. [x] Les 5 marqueurs réels rendent `myia-po-2023:CoursIA` (lignes verbatim des issues #12485 #12484 #12466 #12518 #12461, test `test_lane_bare_date_not_swallowed_founder_markers`)
2. [x] `myia-po-2025:Microsoft VS Code` reste **intact** — test explicite nouveau (`test_lane_spaces_workspace_survives_date_guard`) + les 3 tests existants de la zone (un workspace légitime à espaces ne commence jamais par `NNNN-NN-NN`)
3. [x] Point final → lane sans le point (`test_lane_trailing_period_stripped`, + `parse_grain_tag`)
4. [x] Marqueur mal formé **signalé** : `lane_scope_residue` = `["bare-date:2026-08-23"]` / `["trailing-period:..."]`, vide sur marqueur propre (2 tests)
5. [x] `pytest scripts/tests/test_check_lane_claim.py` vert (292 passed sur les deux fichiers lane)

## Validation

- 292 + 149 + 125 tests passed (fichiers lane + consommateurs picker/nits/variation qui lisent `extract_lane`/`parse_grain_tag`)
- Smoke exécuté avant commit : 5 marqueurs fondateurs → lane nue + résidu signalé ; lane à espaces intacte ; ISO timestamp déjà rejeté (résidu witnessé) ; ligne propre → zéro résidu

Closes #12719

🤖 Generated with [Claude Code](https://claude.com/claude-code)
