### PR TITLE
fix(training,#12681): etf_vol imprime l'aligne du verdict + tests de cablage par executeur

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/etf_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/etf_vol.py
@@ -72,6 +72,10 @@ from dlinear_vol import (                           # noqa: E402
 )
 from gpu_training import thermal_check              # noqa: E402
 from har_model import walk_forward_har              # noqa: E402
+from log_lines import (                              # noqa: E402
+    format_dm_verdict_line,
+    format_har_baseline_line,
+)
 from realized_variance import realized_variance_to_log  # noqa: E402
 
 PANIER_DIR = SCRIPTS_DIR.parent / "datasets" / "panier"
@@ -158,8 +162,8 @@ def eval_one_symbol(
             har_mse = har_out["aggregate_mse_logrv"]
             har_errors = (har_out["forecasts"] - har_out["targets"]).dropna().values
             har_bias_oos = float(np.mean(har_errors)) if len(har_errors) else float("nan")
-            print(f"  h={h} HAR MSE={har_mse:.5f} bias_OOS={har_bias_oos:+.5f} "
-                  f"({har_out['n_total_preds']} preds)")
+            print(format_har_baseline_line(
+                h, har_mse, har_bias_oos, har_out["n_total_preds"]))
         except Exception as exc:
             print(f"  h={h} HAR baseline FAILED: {exc}")
             continue
@@ -191,8 +195,13 @@ def eval_one_symbol(
             dl_bias_oos = float(np.mean(dl_errors)) if len(dl_errors) else float("nan")
 
             dm_info = {}
+            # Le verdict DM porte sur l'echantillon ALIGNE (tronque a la
+            # longueur commune des deux series d'erreurs), pas sur l'agregat
+            # HAR : c'est cette valeur qu'il faut imprimer (#12681).
+            min_len = min(len(dl_errors), len(har_errors))
+            mse_har_aligned = (float(np.mean(har_errors[:min_len] ** 2))
+                               if min_len else float("nan"))
             if len(dl_errors) >= 10 and len(har_errors) >= 10:
-                min_len = min(len(dl_errors), len(har_errors))
                 try:
                     dm = dm_verdict(dl_errors[:min_len], har_errors[:min_len],
                                     horizon=h, loss_fn=loss_fn)
@@ -202,9 +211,10 @@ def eval_one_symbol(
                         "dm_verdict": dm["verdict"],
                         "dm_mean_loss_diff": dm["mean_loss_diff"],
                     }
-                    print(f"  h={h} seed={seed} DLinear MSE={dl_mse:.5f} "
-                          f"bias={dl_bias_oos:+.5f} DM={dm['dm_statistic']:.3f} "
-                          f"p={dm['p_value']:.4f} -> {dm['verdict']}")
+                    print(format_dm_verdict_line(
+                        "DLinear", h, seed, dl_mse, mse_har_aligned,
+                        dl_bias_oos, dm["dm_statistic"], dm["p_value"],
+                        dm["verdict"]))
                 except Exception as exc:
                     print(f"  h={h} seed={seed} DM FAILED: {exc}")
                     dm_info = {"dm_verdict": "DM_FAILED"}
@@ -221,6 +231,7 @@ def eval_one_symbol(
                 "n_predictions": int(dl_out["n_total_preds"]),
                 "dlinear_mse_logrv": float(dl_mse),
                 "har_mse_logrv": float(har_mse),
+                "har_mse_aligned": mse_har_aligned,
                 "mse_reduction_pct": (float((har_mse - dl_mse) / har_mse * 100)
                                       if har_mse > 0 else float("nan")),
                 **dm_info,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/log_lines.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/log_lines.py
@@ -1,0 +1,46 @@
+"""Shared log-line formatters for the vol-forecasting harness (#12681).
+
+The DM verdict is computed on the ALIGNED error sample, while the walk-forward
+aggregate the harness also reports is a different number. Printing only the
+aggregate next to the verdict let a reader invert the model-vs-baseline
+comparison: in the M15 ETF logs, 10 of 12 checkpoint lines showed a model
+MSE sitting BETWEEN the aggregate and the aligned baseline MSE, so the
+side-by-side reading gave the opposite conclusion of the verdict itself.
+
+These formatters keep, next to the verdict, the number the verdict is
+actually computed on. `format_har_baseline_line` labels the aggregate as
+such so it can no longer be mistaken for the verdict's baseline.
+"""
+
+from __future__ import annotations
+
+
+def format_har_baseline_line(
+    h: int,
+    har_mse_aggregate: float,
+    har_bias_oos: float,
+    n_preds: int,
+) -> str:
+    return (
+        f"  h={h} HAR MSE(agrege)={har_mse_aggregate:.5f} "
+        f"bias_OOS={har_bias_oos:+.5f} ({n_preds} preds)"
+    )
+
+
+def format_dm_verdict_line(
+    model_label: str,
+    h: int,
+    seed: int,
+    model_mse: float,
+    mse_baseline_aligned: float,
+    bias: float,
+    dm_stat: float,
+    p_value: float,
+    verdict: str,
+) -> str:
+    return (
+        f"  h={h} seed={seed} {model_label} MSE={model_mse:.5f} "
+        f"vs HAR aligne {mse_baseline_aligned:.5f} "
+        f"bias={bias:+.5f} DM={dm_stat:.3f} "
+        f"p={p_value:.4f} -> {verdict}"
+    )

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_etf_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_etf_vol.py
@@ -54,6 +54,10 @@ from etf_vol import (                                # noqa: E402
 )
 from gpu_training import thermal_check               # noqa: E402
 from har_model import walk_forward_har               # noqa: E402
+from log_lines import (                              # noqa: E402
+    format_dm_verdict_line,
+    format_har_baseline_line,
+)                                                    # noqa: E402
 from m15_lstm_rv import walk_forward_lstm            # noqa: E402
 from realized_variance import realized_variance_to_log  # noqa: E402
 
@@ -106,8 +110,8 @@ def eval_one_symbol(
             har_mse = har_out["aggregate_mse_logrv"]
             har_errors = (har_out["forecasts"] - har_out["targets"]).dropna().values
             har_bias_oos = float(np.mean(har_errors)) if len(har_errors) else float("nan")
-            print(f"  h={h} HAR MSE(agrege)={har_mse:.5f} bias_OOS={har_bias_oos:+.5f} "
-                  f"({har_out['n_total_preds']} preds)")
+            print(format_har_baseline_line(
+                h, har_mse, har_bias_oos, har_out["n_total_preds"]))
         except Exception as exc:
             print(f"  h={h} HAR baseline FAILED: {exc}")
             continue
@@ -160,10 +164,10 @@ def eval_one_symbol(
                         "dm_verdict": dm["verdict"],
                         "dm_mean_loss_diff": dm["mean_loss_diff"],
                     }
-                    print(f"  h={h} seed={seed} LSTM MSE={lstm_mse:.5f} "
-                          f"vs HAR aligne {mse_har_aligned:.5f} "
-                          f"bias={lstm_bias_oos:+.5f} DM={dm['dm_statistic']:.3f} "
-                          f"p={dm['p_value']:.4f} -> {dm['verdict']}")
+                    print(format_dm_verdict_line(
+                        "LSTM", h, seed, lstm_mse, mse_har_aligned,
+                        lstm_bias_oos, dm["dm_statistic"], dm["p_value"],
+                        dm["verdict"]))
                 except Exception as exc:
                     print(f"  h={h} seed={seed} DM FAILED: {exc}")
                     dm_info = {"dm_verdict": "DM_FAILED"}

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_log_lines.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_log_lines.py
@@ -1,0 +1,87 @@
+"""Tests for the #12681 log-line fix -- print the baseline the verdict uses.
+
+The M15 ETF logs showed a model MSE sitting BETWEEN the walk-forward
+aggregate and the aligned HAR MSE: printing only the aggregate next to the
+DM verdict let a reader invert the model-vs-baseline conclusion (10/12
+checkpoint lines, #12681). These tests rebuild exactly that discriminating
+case and check the printed verdict line carries the number the verdict is
+computed on. One wiring test per executor (m15_etf_vol, etf_vol): the shared
+formatter existing is not the fix -- each executor calling it is.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from log_lines import (
+    format_dm_verdict_line,
+    format_har_baseline_line,
+)
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+
+# Real numbers from bg_logs/m15_etf_wA_20260823T204511Z.log (issue #12681):
+# the aggregate says "model 5.9% worse than baseline", the aligned sample the
+# verdict is computed on says "model more precise" -- the sign inverts.
+HAR_MSE_AGGREGATE = 0.70531
+LSTM_MSE = 0.74678
+HAR_MSE_ALIGNED = 0.77957
+
+
+class TestDiscriminatingCase:
+    """The case that made the old line a misleading proof."""
+
+    def test_case_is_discriminating(self):
+        # Guard the fixture itself: aggregate and aligned must sit on
+        # opposite sides of the model MSE, else the case proves nothing.
+        assert HAR_MSE_AGGREGATE < LSTM_MSE < HAR_MSE_ALIGNED
+
+    def test_verdict_line_carries_the_aligned_baseline(self):
+        line = format_dm_verdict_line(
+            "LSTM", 1, 42, LSTM_MSE, HAR_MSE_ALIGNED, 0.04619,
+            -2.147, 0.0319, "BEATS baseline",
+        )
+        assert "vs HAR aligne 0.77957" in line
+        # The aggregate must no longer be the implicit baseline of the
+        # verdict line: the reader comparing the two MSEs on the line must
+        # get the same sign as the verdict (model more precise -> BEATS).
+        assert f"{HAR_MSE_AGGREGATE:.5f}" not in line
+        assert LSTM_MSE < HAR_MSE_ALIGNED
+
+    def test_baseline_line_labels_the_aggregate(self):
+        line = format_har_baseline_line(1, HAR_MSE_AGGREGATE, -0.15566, 4525)
+        assert "HAR MSE(agrege)=0.70531" in line
+        assert "4525 preds" in line
+
+
+class TestWiringM15:
+    """Executor 1: m15_etf_vol must print through the shared formatters."""
+
+    SOURCE = (SCRIPTS_DIR / "m15_etf_vol.py").read_text(encoding="utf-8")
+
+    def test_dm_line_wired(self):
+        assert "format_dm_verdict_line(" in self.SOURCE
+        assert "mse_har_aligned" in self.SOURCE
+
+    def test_har_line_wired(self):
+        assert "format_har_baseline_line(" in self.SOURCE
+
+
+class TestWiringEtfVol:
+    """Executor 2: etf_vol must print through the shared formatters."""
+
+    SOURCE = (SCRIPTS_DIR / "etf_vol.py").read_text(encoding="utf-8")
+
+    def test_dm_line_wired(self):
+        assert "format_dm_verdict_line(" in self.SOURCE
+        # The aligned value fed to the line is computed on the truncated
+        # sample the DM verdict itself uses (min of the two error lengths).
+        assert "mse_har_aligned" in self.SOURCE
+        assert "har_errors[:min_len]" in self.SOURCE
+
+    def test_har_line_wired(self):
+        assert "format_har_baseline_line(" in self.SOURCE
+
+    def test_row_json_carries_aligned(self):
+        assert '"har_mse_aligned": mse_har_aligned' in self.SOURCE


### PR DESCRIPTION
## Summary

Complète l'acceptance #12681 sur les points non couverts par 373b130501 (qui a fixé la ligne m15 + `Closes #12681` au merge de #12695) : le **test discriminant exigé (point 2)** et le **jumeau etf_vol.py (point 3)**.

**ATTENTION : PR empilée** — base = `feature/1454-dlinear-etf-vol` (PR #12695), car `etf_vol.py`/`m15_etf_vol.py` n'existent pas sur `main`. À merger **après** #12695 (ou rebase le contenu dans #12695 directement si préféré).

### Mesure (d'où part le défaut)

`bg_logs/m15_etf_wA_20260823T204511Z.log:14` : `LSTM MSE=0.74678` imprimé à côté de `HAR MSE=0.70531` (agrégat) → lecture "5,9 % moins précis", alors que le verdict DM porte sur l'aligné `0.77957` → le modèle est **plus** précis sur l'échantillon du test. Signe inversé sur 10/12 lignes (#12681).

### Livrable

| Fichier | Changement |
|---|---|
| `scripts/log_lines.py` (nouveau) | 2 formateurs purs partagés ; `format_har_baseline_line` étiquette l'agrégat, `format_dm_verdict_line` porte l'aligné à côté du verdict |
| `scripts/m15_etf_vol.py` | les 2 prints passent par `log_lines` — **sortie byte-identique** au texte de 373b130501, le format devient testable sans run GPU |
| `scripts/etf_vol.py` (jumeau) | ligne HAR étiquetée `(agrege)` ; ligne DM porte `vs HAR aligne {mse_har_aligned}` où `mse_har_aligned = mean(har_errors[:min_len]**2)` — **exactement l'échantillon tronqué que `dm_verdict` juge** (l.197), pas un autre aligné ; row JSON gagne `har_mse_aligned` |
| `scripts/tests/test_log_lines.py` (nouveau) | 8 tests |

### Décisions (pourquoi pas plus)

- `mse_reduction_pct` d'etf_vol reste **agrégat-vs-agrégat** : il compare les champs agrégats du row (`har_mse_logrv`, `dlinear_mse_logrv`), cohérent avec ce qui est imprimé — seule la ligne DM jugeait l'aligné sans l'imprimer.
- L'aligné d'etf_vol est la **troncation `[:min_len]`** (mécanisme du verdict DM de ce script), pas l'intersection de dates de m15 — imprimer un autre "aligné" que celui du verdict réintroduirait la dissociation.
- Observation (non modifiée, à l'attention du reviewer) : `edge_pct` de m15 (373b130501) mélange `mse_har_aligned` (baseline) et `lstm_mse` (agrégat modèle) — asymétrie assumée ? Rien changé sans arbitrage.

### Validation

```
C:/Python313/python.exe -m pytest scripts/tests/test_log_lines.py -q
8 passed in 0.07s
```

- Test discriminant = les **valeurs réelles** de l'issue (`0.70531 < 0.74678 < 0.77957`, le garde `test_case_is_discriminating` protège la fixture) : la ligne du verdict contient l'aligné, pas l'agrégat.
- **Rouge avant le fix** : sur la tête de #12695 sans cette PR, la suite échoue en collection (`log_lines` inexistant) + les tests de câblage ne trouvent pas les appels — vérifié firsthand.
- Un **test de câblage par exécuteur** (TestWiringM15 / TestWiringEtfVol) : le formateur partagé existant ne prouve rien, c'est l'appel dans chaque script qui manquait (leçon du body #12681).
- `py_compile` OK sur les 3 scripts. Aucun notebook touché (H.3/H.4 non applicables).

See #12681, #12684
Stacked on #12695 — merge after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)