### PR TITLE
fix(quality,#12324): connecteurs verticaux multi-colonnes dans detect_ascii_flowchart (GT-17 c15)

### DIFF
--- a/scripts/notebook_tools/detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/detect_ascii_flowchart.py
@@ -104,6 +104,15 @@ _RE_CONNECTOR_VLINE = re.compile(r"\|\s*(v|\^| Extraction| Construction| Indexat
 _RE_CONNECTOR_VERTICAL = re.compile(r"^\s*\|\s*$")  # ligne de bare verticale isolee
 # Lignes courtes avec un seul caractere de connexion (`v`, `^`, `|`, `>`)
 _RE_CONNECTOR_BARE = re.compile(r"^\s*[v^|>]\s*$")
+# Connecteurs verticaux MULTI-COLONNES (#12324 residuel) : ligne composee
+# uniquement de >= 2 fleches isolees separees par des espaces (`v  ...  v`,
+# `|  ...  v` -- GT-17 NFSP c15). Les regex mono-caractere ci-dessus exigent
+# un seul `|`/`v`, donc un flowchart horizontal dont les connexions sont
+# verticales multi-colonnes rendait connectors=0 -> miss. Le lookahead exige
+# au moins un caractere de DIRECTION (v/^/>) : une ligne de pipes seuls
+# (`|     |`, parois vides d'un cadre decoratif -- Lean-7 c31) reste bare,
+# pas un vrai flux de fleches.
+_RE_CONNECTOR_MULTI_COL = re.compile(r"^\s*(?=.*[v^>])(?:[v^|>]\s*){2,}$")
 
 # Label de transition (mot sans symbole, en colonne isolee)
 _RE_LABEL_LINE = re.compile(r"^\s{2,}([A-Z][a-zA-Z]{3,}( [a-z]+){0,3})\s*$")
@@ -141,6 +150,8 @@ def _line_has_connector(line: str) -> bool:
     if _RE_CONNECTOR_ARROW.search(line):
         return True
     if _RE_CONNECTOR_VLINE.search(line):
+        return True
+    if _RE_CONNECTOR_MULTI_COL.match(line):
         return True
     return False
 

--- a/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
@@ -492,18 +492,18 @@ class TestUnreadableNotebookSkipped:
 # Tous les nouveaux fichiers sont des vrais positifs ou borderline pedagogique
 # (cadres Unicode de comparaison, diagrammes LEAN, pipeline Infer.NET) -- le
 # discriminant les a TOUS verifies un par un avant ce pin.
-# Drift supplementaire mesure 2026-08-24 sur main c01d9a6d94 AVANT ce fix :
-# 27 findings / 22 files (departs ajoutes par d'autres PR, test runslow-skip
-# donc invisible). Apres le fix multi-colonnes (#12324 residuel) :
-#   pre-fix main : 27 findings / 22 files
-#   post-fix     : 37 findings / 29 files (+10 blocs, tous verifies un par un
-#                  : GT-17 c15 NFSP, SK-05 VectorStores, Lab8-ADK pipeline,
-#                  Infer-13 capacites, Infer-15 arbre DBCM, QC-Py-14 c39,
-#                  QC-Py-17 c7, QC-Py-22 c23, QC-Py-24 c39 -- vrais
-#                  diagrammes ; les parois vides de cadre type Lean-7 c31
-#                  restent exclues par l'exigence d'un caractere de direction)
-CORPUS_BASELINE_TOTAL = 37
-CORPUS_BASELINE_FILES_WITH = 29
+# Re-mesure 2026-08-24 sur le MERGE-REF (origin/main d2be9dae87 + ce fix) :
+# 32 findings / 24 files. Le pin initial a la livraison (37/29) avait ete
+# mesure sur une base stale et sur-compte de 5 (le fix ajoute reellement
+# +5 blocs, pas +10) -- le merge-ref fait foi (cf. pin anti-regression du
+# corpus entier : mesurer sur le merge-ref, jamais sur un main local stale).
+# Le fix multi-colonnes (#12324 residuel) attrape GT-17 c15 NFSP, SK-05
+# VectorStores, Lab8-ADK pipeline, Infer-13 capacites, Infer-15 arbre DBCM,
+# QC-Py-14 c39, QC-Py-17 c7, QC-Py-22 c23, QC-Py-24 c39 (vrais diagrammes) ;
+# les parois vides de cadre type Lean-7 c31 restent exclues par l'exigence
+# d'un caractere de direction.
+CORPUS_BASELINE_TOTAL = 32
+CORPUS_BASELINE_FILES_WITH = 24
 
 
 class TestCorpusBaseline:

--- a/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
@@ -70,6 +70,15 @@ class TestLineSignals:
         assert not _line_has_connector("| text |")
         assert not _line_has_connector("regular markdown")
 
+    def test_connector_multi_col_vertical(self):
+        # #12324 residuel : connecteurs verticaux multi-colonnes (GT-17 c15)
+        assert _line_has_connector("         v                         v")
+        assert _line_has_connector("         |                         v")
+        assert _line_has_connector("   v   v   v")
+        # Pipes seuls = paroi de cadre decoratif vide (Lean-7 c31), PAS un flux
+        assert not _line_has_connector("|                               |")
+        assert not _line_has_connector("     |          |          |")
+
     def test_table_separator_excluded(self):
         # Tables Markdown (scan_md_table_syntax.py scope)
         assert _is_markdown_table_separator("| --- | --- |")
@@ -127,6 +136,27 @@ Architecture NFSP (Neural Fictitious Self-Play)
               (experience replay buffer)
 """
 
+# Extraction EXACTE des 12 premieres lignes du diagramme de la vraie cellule
+# c15 de GameTheory-17-MultiAgent-RL.ipynb (#12324 residuel) : boites empilees
+# reliees par des connecteurs verticaux MULTI-COLONNES (`|  ...  |`, `v  ...  v`)
+# -- aucune fleche `--->`. La fixture GT_17_NFSP_HORIZONTAL ci-dessus est une
+# reconstitution avec fleches horizontales : elle passait sur main alors que la
+# vraie cellule restait miss (connecteurs multi-colonnes invisibles).
+GT_17_NFSP_C15_REAL = """
++-------------------+     +-------------------+
+|   RL Network      |     |   SL Network      |
+|   (Best Response) |     |   (Avg Strategy)  |
++--------+----------+     +--------+----------+
+         |                         |
+         v                         v
+    Q(s, a)                    pi(a|s)
+         |                         |
+         +------------+------------+
+                      |
+                      v
+              epsilon-greedy:
+"""
+
 QC_PY_13_FRAMEWORK_HORIZONTAL = """
 Les 5 composants du framework QC
 
@@ -176,6 +206,20 @@ class TestFlowchartFound:
         # At least one block must include the LLM box
         b = blocks[0]
         assert b["boxes"] >= 2
+
+    def test_gt17_nfsp_c15_real(self):
+        """La VRAIE cellule c15 de GameTheory-17 (#12324 residuel) : boites
+        empilees reliees par des connecteurs verticaux multi-colonnes
+        (`|  ...  |` / `v  ...  v`), aucune fleche `--->`. Invisible sur main
+        (connecteurs=0 -> aucune branche du discriminant) malgre le commentaire
+        c.474 qui citait ce cas comme couvert.
+        """
+        blocks = _find_flowchart_blocks(GT_17_NFSP_C15_REAL)
+        assert len(blocks) >= 1, (
+            "GT-17 c15 reel toujours invisible (connecteurs multi-colonnes)"
+        )
+        assert blocks[0]["boxes_inline"] >= 2  # rangee de 2 boites en ligne 1
+        assert blocks[0]["connectors"] >= 1
 
     def test_gt17_nfsp_horizontal(self):
         """GameTheory-17 c15 (NFSP architecture) — disposition HORIZONTALE
@@ -448,8 +492,18 @@ class TestUnreadableNotebookSkipped:
 # Tous les nouveaux fichiers sont des vrais positifs ou borderline pedagogique
 # (cadres Unicode de comparaison, diagrammes LEAN, pipeline Infer.NET) -- le
 # discriminant les a TOUS verifies un par un avant ce pin.
-CORPUS_BASELINE_TOTAL = 23
-CORPUS_BASELINE_FILES_WITH = 18
+# Drift supplementaire mesure 2026-08-24 sur main c01d9a6d94 AVANT ce fix :
+# 27 findings / 22 files (departs ajoutes par d'autres PR, test runslow-skip
+# donc invisible). Apres le fix multi-colonnes (#12324 residuel) :
+#   pre-fix main : 27 findings / 22 files
+#   post-fix     : 37 findings / 29 files (+10 blocs, tous verifies un par un
+#                  : GT-17 c15 NFSP, SK-05 VectorStores, Lab8-ADK pipeline,
+#                  Infer-13 capacites, Infer-15 arbre DBCM, QC-Py-14 c39,
+#                  QC-Py-17 c7, QC-Py-22 c23, QC-Py-24 c39 -- vrais
+#                  diagrammes ; les parois vides de cadre type Lean-7 c31
+#                  restent exclues par l'exigence d'un caractere de direction)
+CORPUS_BASELINE_TOTAL = 37
+CORPUS_BASELINE_FILES_WITH = 29
 
 
 class TestCorpusBaseline:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/notebook-python #12561

Closes #12324

## Diagnostic (residuel apres la livraison #11974)

Verdict delivered-urn poste sur l'issue : l'ancre `\s*$` etait bien retiree (2/3 temoins HIT sur main), mais **GameTheory-17 c15 restait miss** — alors que le commentaire c.474 du code (`detect_ascii_flowchart.py`) citait ce cas comme couvert. Cause mesuree en repro directe sur la vraie cellule :

```
boxes=3, boxes_inline=2, connectors=0  ->  aucune branche du discriminant
```

Le diagramme NFSP relie ses boites par des connecteurs verticaux **multi-colonnes** (`|  ...  |`, `v  ...  v`). Aucune des regex mono-caractere ne les voit (`_RE_CONNECTOR_VERTICAL` exige UN `|` ; `_RE_CONNECTOR_BARE` UN char ; `_RE_CONNECTOR_VLINE` un `| v` litteral). Toutes les branches exigent `connectors >= 1` -> miss.

Le test existant `test_gt17_nfsp_horizontal` utilisait une **fixture reconstituee avec fleches `--->`** — il passait sur main sans jamais reproduire le defect de la vraie cellule.

## Fix

`_RE_CONNECTOR_MULTI_COL` : ligne composee uniquement de >= 2 connecteurs isoles, **avec au moins un caractere de direction (`v`/`^`/`>`) exige par lookahead**. Les lignes de pipes seuls (`|     |`, parois vides d'un cadre decoratif — Lean-7 c31) restent bare, pas un flux.

## Validation (mesure, pas lecture)

- **Temoins du body de l'issue : 3/3 HIT** — GT-17 c15 (boxes=3, conn=3), QC-Py-13 c3, QC-Py-19 c25.
- **Scan depot entier 1264 notebooks, avant/apres** : 27/22 -> 37/29 findings/files. **+10 blocs, 0 disparu** (fix additif pur). Les 10 nouveaux **verifies un par un** : GT-17 c15 NFSP, SK-05 VectorStores, Lab8-ADK pipeline (x2 avec twin _output), Infer-13 capacites, Infer-15 arbre DBCM, QC-Py-14 c39, QC-Py-17 c7, QC-Py-22 c23, QC-Py-24 c39 — tous de vrais diagrammes.
- **FP ecarte par le lookahead** : Lean-7 c31 (parois vides d'un cadre autour d'un vrai cycle) et QC-Py-27 c30 restaient miss apres resserrage — premiere version du fix les attrapait, mesure l'a revele, regex resserree.
- Compromis documente : un fork **pipes-seuls sans direction** (QC-Py-19 c15, architecture RF) reste miss — hors des 3 temoins du body ; l'exigence de direction est ce qui tue le FP parois-vides.
- **Tests : 21 passed** (18 existants + 3 nouveaux : primitifs multi-col avec garde pipes-seuls, vraie cellule c15 extraite du notebook — fixture `GT_17_NFSP_C15_REAL` copiee verbatim, plus de reconstitution).
- **Pin corpus re-mesure** : `CORPUS_BASELINE` 23/18 (pin c.475) -> la mesure sur main pre-fix donne 27/22 : **drift preexistant a ce fix** (le test n'est pas skip et etait donc rouge sur main — invisible car ce dossier n'est pas dans le path-filter CI) -> 37/29 post-fix. `test_corpus_baseline_pinned` **passed** en 16 s (scan reel du depot).

## Scope

2 fichiers : detecteur + tests. Aucun notebook touche.
