### PR TITLE
feat(prover,#12658): refuser les corps de definition — sorry_is_def_body (5 couches, miroir FX-6b)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
@@ -478,6 +478,9 @@ OUTILS D'EDITION:
   → INTERDIT si la plage contient des mots-cles structuels (theorem/section/end/def).
   → Utiliser UNIQUEMENT pour ajuster des lignes dans la PREUVE (pas les bornes).
   → file_replace_sorry est TOUJOURS preferable.
+- REFUSE si la ligne sorry est le CORPS d'une definition (def/abbrev/instance/
+  structure/inductive/class, apres le ':=') : remplir un corps de definition
+  est un acte de DESIGN, pas une preuve (#12658). Cible un theorem/lemma.
 
 STRATEGIE:
 - 3 premiers echecs: explorer (rfl, omega, simp, exact)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -287,6 +287,105 @@ def sorry_is_in_statement(content: str, sorry_line: int) -> bool:
     return False
 
 
+# #12658 — DEF_BODY_SORRY: a sorry that IS the body of a definition-genre
+# declaration. ``_DECL_START_RE`` above does not capture the genre keyword;
+# this twin regex does, so the predicate can gate on def/abbrev/instance/
+# structure/inductive/class while leaving theorem/lemma/example bodies alone.
+_DECL_GENRE_RE = re.compile(
+    r"^\s*(?:@\[[^\]]*\]\s*)?"
+    r"(?:private\s+|protected\s+|noncomputable\s+|partial\s+|unsafe\s+)*"
+    r"(theorem|lemma|def|instance|example|abbrev|structure|inductive|"
+    r"class|opaque)\b"
+)
+
+_DEF_BODY_GENRES = frozenset(
+    {"def", "abbrev", "instance", "structure", "inductive", "class"})
+
+# Proof-local binders whose own ':=' can appear inside a def's body. A sorry
+# governed by one of these is a sub-goal obligation (its type is given), not
+# the definition's value: ``have h : P := by sorry`` must be spared.
+_PROOF_BINDER_RE = re.compile(
+    r"^\s*(?:@\[[^\]]*\]\s*)?"
+    r"(?:private\s+|protected\s+|noncomputable\s+)*"
+    r"(?:have|let|show|suffices|obtain)\b"
+)
+
+
+def sorry_is_def_body(content: str, sorry_line: int) -> bool:
+    """True when the sorry at ``sorry_line`` is the BODY of a definition-genre
+    declaration — def/abbrev/instance/structure/inductive/class — i.e. sits
+    AFTER that declaration's ``:=`` (#12658).
+
+    Filling such a hole is an act of DESIGN, not a proof: the body of
+    ``def alexanderPolynomial (k : Knot) : AlexanderPoly := sorry`` IS the
+    definition of the polynomial — replacing sorry with ``1`` does not prove
+    anything, it silently DEFINES a different (false) object (the trefoil
+    Delta function is t^2 - t + 1, not 1). No prover run can honestly close
+    it: what a definition says belongs to a human.
+
+    Body-form mirror of ``sorry_is_in_statement`` (FX-6b, #1453), which
+    covers the statement side. Theorem/lemma/example bodies remain
+    legitimate proof obligations.
+
+    Deliberately conservative (never blocks a legitimate run):
+    - sorry only inside a comment on the target line → False
+    - no enclosing declaration found → False
+    - enclosing genre is theorem/lemma/example/opaque → False
+    - sorry BEFORE the ':=' (in the type/statement) → False (FX-6b domain)
+    - no ':=' in the declaration (match-syntax ``| pat =>`` bodies) → False
+      (same accepted residual as FX-6b; none in the repo)
+    - the ':=' governing the sorry belongs to a proof binder
+      (have/let/show/suffices/obtain — ``have h := by sorry`` inside a
+      def's proof) → False (a sub-goal, a real obligation)
+    - residual: a multi-line binder header whose ':=' lands on a
+      continuation line (``have h :\\n  P := by\\n    sorry``) reads as a
+      def-body catch; accepted false-positive, documented, none in the repo
+
+    ``--`` line comments ARE stripped per-line before the structural scan.
+    """
+    content = _require_str("content", content, allow_empty=True)
+    lines = content.split("\n")
+    if not (1 <= sorry_line <= len(lines)):
+        return False
+
+    def _code(line: str) -> str:
+        return line.split("--", 1)[0]
+
+    m_sorry = _SORRY_TOKEN_RE.search(_code(lines[sorry_line - 1]))
+    if m_sorry is None:
+        return False
+
+    decl_idx = None
+    genre = None
+    for i in range(sorry_line - 1, -1, -1):
+        m_decl = _DECL_GENRE_RE.match(_code(lines[i]))
+        if m_decl:
+            decl_idx = i
+            genre = m_decl.group(1)
+            break
+    if decl_idx is None or genre not in _DEF_BODY_GENRES:
+        return False
+
+    # Same line: a ':=' before the sorry governs it. One-liner definition
+    # (``def f : T := sorry``) catches; a binder line (``have h := sorry``)
+    # spares; a sorry BEFORE the ':=' is the statement side → FX-6b domain.
+    same = _code(lines[sorry_line - 1]).find(":=")
+    if same >= 0:
+        if m_sorry.start() > same:
+            return not _PROOF_BINDER_RE.match(_code(lines[sorry_line - 1]))
+        return False
+
+    # Below the header: the nearest ':=' at-or-above governs (bounded by the
+    # declaration start). Binder line → sub-goal, spare. Anything else —
+    # including a multi-line definition header — is the definition's own
+    # ':=': the sorry is its body.
+    for j in range(sorry_line - 2, decl_idx - 1, -1):
+        code_j = _code(lines[j])
+        if ":=" in code_j:
+            return not _PROOF_BINDER_RE.match(code_j)
+    return False  # no ':=' in the declaration (match syntax) → not body
+
+
 # FX-5 (#1453) — TRUE_PLACEHOLDER_GOAL: refuse a sorry whose goal is the
 # trivial Prop `True`. Such a goal is never a legitimate proof obligation
 # (True is provable by `trivial` with zero content), so stubbing it with sorry

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -25,8 +25,8 @@ from .decomposition_regression import (
 from .lean_utils import (
     extract_sorry_block, get_goal_state, verify_sorry_replacement,
     extract_hypotheses, extract_local_lemmas, build_def_type_warnings,
-    is_honest_sorry, sorry_is_in_statement, count_real_sorries,
-    is_true_placeholder_goal,
+    is_honest_sorry, sorry_is_in_statement, sorry_is_def_body,
+    count_real_sorries, is_true_placeholder_goal,
 )
 from .tools import SearchTools, TacticTools, CriticTools, CoordinatorTools, DiagnosisTools
 from .agents import (
@@ -215,6 +215,50 @@ def _refuse_in_statement_sorry(filepath: str, sorry_line: int,
         "success": False,
         "skipped": True,
         "reason": "in_statement_sorry",
+        "detail": msg,
+        "demo": demo_name,
+        "sorry_line": sorry_line,
+        "filepath": filepath,
+    }
+
+
+def _refuse_def_body_sorry(filepath: str, sorry_line: int,
+                           demo_name: str) -> Optional[dict]:
+    """Return an early-fail result dict if the target sorry is the BODY of
+    a definition-genre declaration.
+
+    #12658: a sorry after the ':=' of a def/abbrev/instance/structure/
+    inductive/class IS the definition's value — filling it is an act of
+    DESIGN, not a proof. ``def alexanderPolynomial (k : Knot) := sorry``
+    replaced by ``1`` does not prove anything: it silently DEFINES a false
+    object (the trefoil Delta function is t^2 - t + 1). Six live targets
+    (Conway.lean alexanderPolynomial / IsSmoothlySlice / IsTopologicallySlice,
+    FR + EN siblings) are exactly this shape. The downstream
+    STMT_MUTATION_FALSE_SUCCESS guard cannot see it: the file builds, the
+    sorry count drops, no statement was rewritten — a def body was authored.
+    Refusing at entry (before the FX-5 probe compile, unlike FX-5 itself a
+    pure string scan) saves the whole run. Mirrors
+    ``_refuse_in_statement_sorry``. Returns None when the file is unreadable
+    (the run proceeds; downstream guards still apply).
+    """
+    try:
+        content = Path(filepath).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not sorry_is_def_body(content, sorry_line):
+        return None
+    msg = (
+        f"REFUSED: sorry at {filepath}:{sorry_line} is the BODY of a "
+        f"definition (def/abbrev/instance/structure/inductive/class, after "
+        f"its ':='). Filling a definition body is a design decision, not a "
+        f"proof — a human must decide what the object IS, not the prover. "
+        f"(#12658; body-form mirror of FX-6b)"
+    )
+    print(f"\n{'!'*70}\n{msg}\n{'!'*70}\n")
+    return {
+        "success": False,
+        "skipped": True,
+        "reason": "def_body_sorry",
         "detail": msg,
         "demo": demo_name,
         "sorry_line": sorry_line,
@@ -567,6 +611,13 @@ class MultiAgentSorryProver:
         in_stmt = _refuse_in_statement_sorry(filepath, sorry_line, demo["name"])
         if in_stmt is not None:
             return in_stmt
+
+        # #12658: refuse a sorry that IS the body of a definition-genre
+        # declaration — filling a def body is a design act, not a proof.
+        # Pure string scan: fires before the FX-5 probe compile below.
+        def_body = _refuse_def_body_sorry(filepath, sorry_line, demo["name"])
+        if def_body is not None:
+            return def_body
 
         # FX-5 (#1453): refuse a sorry whose goal is the trivial Prop `True`
         # — a degenerate/placeholder goal the TacticAgent loops on ("task
@@ -1380,6 +1431,13 @@ class AutonomousProver:
         in_stmt = _refuse_in_statement_sorry(filepath, sorry_line, demo["name"])
         if in_stmt is not None:
             return in_stmt
+
+        # #12658: refuse a sorry that IS the body of a definition-genre
+        # declaration — filling a def body is a design act, not a proof.
+        # Pure string scan: fires before the FX-5 probe compile below.
+        def_body = _refuse_def_body_sorry(filepath, sorry_line, demo["name"])
+        if def_body is not None:
+            return def_body
 
         # FX-5 (#1453): refuse a sorry whose goal is the trivial Prop `True`
         # — a degenerate/placeholder goal the TacticAgent loops on ("task

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -1949,6 +1949,33 @@ class TacticTools:
 
             indent = len(sorry_text) - len(sorry_text.lstrip())
 
+            # #12658 — DEF_BODY_SORRY edit guard: refuse to author a
+            # definition body. A sorry that IS the body of a
+            # def/abbrev/instance/structure/inductive/class cannot be
+            # "proved" — replacing it writes the definition's VALUE (a
+            # design act). The provers.py entry refusal normally catches
+            # this before any agent runs; this covers direct tool calls.
+            from .lean_utils import sorry_is_def_body as _is_def_body
+            if _is_def_body(content, sorry_line):
+                if self._trace:
+                    self._trace.log(
+                        agent="TacticTools", role="def_body_guard",
+                        content=(f"BLOCKED file_replace_sorry: line "
+                                 f"{sorry_line} is the body of a definition "
+                                 f"(after ':='). Filling it is a design "
+                                 f"decision, not a proof (#12658)."),
+                        duration_s=0.01,
+                    )
+                return json.dumps({
+                    "error": (f"BLOCKED by def-body guard: the sorry at line "
+                              f"{sorry_line} IS the body of a definition "
+                              f"(def/abbrev/instance/structure/inductive/"
+                              f"class, after its ':='). Filling a definition "
+                              f"body is a design decision, not a proof — a "
+                              f"human must decide what the object IS (#12658)."),
+                    "replaced": sorry_text.strip(),
+                }, ensure_ascii=False)
+
             # Preserve relative indentation: find min indent in replacement,
             # strip it, then re-base to the sorry line's indent level.
             raw_lines = replacement.rstrip().split("\n")

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -1104,6 +1104,41 @@ class VerifyExecutor(Executor):
                              f"{_fx6b_err}"),
                 )
 
+        # #12658 — DEF_BODY_SORRY, defense-in-depth mirror of the FX-6b block
+        # above: a sorry that IS the body of a definition-genre declaration
+        # (def/abbrev/instance/structure/inductive/class, after its ':=')
+        # can never be honestly proved — filling it AUTHORS the definition's
+        # value (``def alexanderPolynomial _ := 1`` defines a false object).
+        # The success gates count a sorry-drop + build-pass as progress, and
+        # STMT_MUTATION_FALSE_SUCCESS cannot see this form (the statement is
+        # untouched); the provers.py entry refusal normally fires first —
+        # this covers direct workflow entries, same rationale as FX-6b.
+        try:
+            from .lean_utils import sorry_is_def_body as _def_body_check
+            _db_src = getattr(self._sorry_ctx, "full_file", "") or ""
+            if _db_src and _def_body_check(
+                    _db_src, self._sorry_ctx.sorry_line):
+                msg.error = (
+                    "DEF_BODY_SORRY: the target sorry IS the body of a "
+                    "definition (after its ':='); filling it is a design "
+                    "decision, not a proof (#12658)."
+                )
+                msg.error_type = "def_body_sorry"
+                if self._trace:
+                    self._trace.log(
+                        agent="VerifyExecutor", role="def_body_guard",
+                        content=msg.error,
+                    )
+                await ctx.yield_output(msg)
+                return
+        except Exception as _def_body_err:
+            if self._trace:
+                self._trace.log(
+                    agent="VerifyExecutor", role="def_body_guard_error",
+                    content=(f"def-body check failed, falling through: "
+                             f"{_def_body_err}"),
+                )
+
         # P1 latch-success (Epic #1453, 2026-05-23 forensic): detect the case
         # where TacticAgent has ALREADY proved the target in-place before this
         # verify runs. tools.file_replace_lines edits the REAL target file on

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_lean_utils.py
@@ -163,10 +163,11 @@ class TestContentGuardsRejectNone:
         lu.count_real_sorries,
         lu.strip_lean_comments,
         lu.sorry_is_in_statement,
+        lu.sorry_is_def_body,
     ])
     def test_none_rejected(self, fn):
         with pytest.raises(ValueError, match="expected str"):
-            if fn is lu.sorry_is_in_statement:
+            if fn in (lu.sorry_is_in_statement, lu.sorry_is_def_body):
                 fn(None, 1)
             else:
                 fn(None)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2311,6 +2311,142 @@ def test_refuse_in_statement_sorry_none_when_file_missing(tmp_path):
     assert _refuse_in_statement_sorry(str(missing), 8, "demo") is None
 
 
+# --- #12658: sorry_is_def_body + def-body entry refusal ---------------------
+# Filling a DEFINITION body is an act of design, not a proof: the body of
+# ``def alexanderPolynomial (k : Knot) : AlexanderPoly := sorry`` IS the
+# polynomial — replacing sorry with ``1`` silently defines a false object
+# (the trefoil Delta function is t^2 - t + 1). Body-form mirror of the FX-6b
+# section above; STMT_MUTATION_FALSE_SUCCESS cannot see it (the statement is
+# untouched, the file builds, the sorry count drops).
+
+CONWAY_ALEXANDER_SHAPE = (
+    "import Mathlib.Tactic\n"                                         # 1
+    "\n"                                                              # 2
+    "def alexanderPolynomial (k : Knot) : AlexanderPoly := sorry\n"   # 3 <- body
+)
+
+
+@pytest.mark.parametrize("content,line", [
+    # one-liner def body — the shape of the six live Conway.lean targets
+    (CONWAY_ALEXANDER_SHAPE, 3),
+    # def body on its own line, ':=' on the header line
+    ("noncomputable def f (k : Nat) : Nat := by\n  sorry\n", 2),
+    # multi-line header: ':=' lands on a continuation line
+    ("def f (k : Nat)\n    : Nat := sorry\n", 2),
+    # attribute + modifiers stack on a multi-line header
+    ("@[simp]\nprivate noncomputable def g (k : Nat) :\n    Nat := sorry\n", 3),
+    # the remaining definition genres
+    ("abbrev Foo := sorry\n", 1),
+    ("instance : Coe Nat Foo := sorry\n", 1),
+    ("structure Point where\n  x : Nat := sorry\n", 2),
+    ("class Mem (a : Type) where\n  mem : a → a → Prop := sorry\n", 2),
+    ("inductive Edge where\n  | mk (n : Nat) : Edge := sorry\n", 2),
+])
+def test_def_body_detected_on_definition_genres(content, line):
+    from prover.lean_utils import sorry_is_def_body
+
+    assert sorry_is_def_body(content, line) is True
+
+
+@pytest.mark.parametrize("content,line", [
+    # theorem/lemma/example bodies stay proof obligations
+    ("theorem th : True := by\n  sorry\n", 2),
+    ("lemma l : True := by sorry\n", 1),
+    ("example : True := by sorry\n", 1),
+    # have/let sub-goals inside a def's proof: real obligations (type given)
+    ("def f : Nat := by\n  have h : True := by sorry\n  exact 1\n", 2),
+    ("def f : Nat := by\n  have h : True :=\n    sorry\n  exact 1\n", 3),
+    ("def f : Nat := by\n  let x : Nat := sorry\n  exact x\n", 2),
+    # sorry only inside a comment on the def line
+    ("def f : Nat := 1 -- sorry\n", 1),
+    # sorry BEFORE ':=' is the statement side — FX-6b domain, not ours
+    ("def x : sorry := trivial\n", 1),
+    # match-syntax def (no ':='): accepted residual, same as FX-6b
+    ("def f : Nat → Nat\n  | 0 => sorry\n  | _ => 1\n", 2),
+    # degenerate inputs
+    ("-- orphan\nsorry\n", 2),
+    ("", 1),
+])
+def test_def_body_spares_proof_obligations(content, line):
+    from prover.lean_utils import sorry_is_def_body
+
+    assert sorry_is_def_body(content, line) is False
+
+
+def test_def_body_out_of_range_line_not_flagged():
+    from prover.lean_utils import sorry_is_def_body
+
+    assert sorry_is_def_body("def f : Nat := sorry\n", 99) is False
+
+
+def test_refuse_def_body_sorry_returns_skip_dict(tmp_path):
+    from prover.provers import _refuse_def_body_sorry
+
+    f = tmp_path / "Conway.lean"
+    f.write_text(CONWAY_ALEXANDER_SHAPE, encoding="utf-8")
+    result = _refuse_def_body_sorry(str(f), 3, "demo-conway")
+    assert result is not None
+    assert result["success"] is False
+    assert result["skipped"] is True
+    assert result["reason"] == "def_body_sorry"
+    assert result["sorry_line"] == 3
+    assert result["demo"] == "demo-conway"
+
+
+def test_refuse_def_body_sorry_none_for_theorem_target(tmp_path):
+    from prover.provers import _refuse_def_body_sorry
+
+    f = tmp_path / "Thm.lean"
+    f.write_text("theorem t : True := by\n  sorry\n", encoding="utf-8")
+    assert _refuse_def_body_sorry(str(f), 2, "demo") is None
+
+
+def test_refuse_def_body_sorry_none_when_file_missing(tmp_path):
+    from prover.provers import _refuse_def_body_sorry
+
+    missing = tmp_path / "nope.lean"
+    assert _refuse_def_body_sorry(str(missing), 3, "demo") is None
+
+
+def test_file_replace_sorry_blocks_def_body_target(tmp_path):
+    """The edit guard refuses to author a definition body; file untouched."""
+    body = (
+        "import Mathlib.Tactic\n"
+        "namespace T\n"
+        + "\n".join(f"-- padding line {i}" for i in range(50))
+        + "\ndef alexanderPolynomial (k : Nat) : Nat := sorry\n"
+        + "\n".join(f"-- trailing line {i}" for i in range(50))
+        + "\nend T\n"
+    )
+    f = tmp_path / "Conway.lean"
+    f.write_text(body, encoding="utf-8")
+    sorry_line = next(
+        i + 1 for i, line in enumerate(body.split("\n")) if "sorry" in line
+    )
+    state = ProofState(theorem_statement="alexanderPolynomial")
+    sctx = SorryContext(
+        filepath=str(f), sorry_line=sorry_line, indentation=2,
+        indent_str="  ", full_file=body,
+    )
+    tt = TacticTools(state, str(f), sctx)
+    import json
+    result = json.loads(tt.file_replace_sorry(sorry_line, "1", build_check=False))
+    assert "BLOCKED by def-body guard" in result["error"]
+    assert Path(f).read_text(encoding="utf-8") == body  # untouched
+
+
+def test_file_replace_sorry_allows_theorem_target(tactic_tools):
+    """Positive control in the SAME invocation: a theorem-body target (the
+    fixture file) passes the def-body guard — the guard discriminates, it
+    does not refuse everything."""
+    import json
+    result = json.loads(
+        tactic_tools.file_replace_sorry(
+            tactic_tools._test_sorry_line, "trivial", build_check=False)
+    )
+    assert "def-body guard" not in result.get("error", "")
+
+
 # --- FX-5 (#1453): TRUE_PLACEHOLDER_GOAL — refuse a sorry whose goal is True -
 # A goal of `True` is never a legitimate obligation (proves by `trivial`). It
 # arises from a mutated/vacuous statement or a degenerate sub-goal; the agent


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2027:CoursIA — prev: MED/notebook-python #12726

## Summary

Issue #12658 : le harnais prover traite le remplissage d'un **corps de définition** (`def alexanderPolynomial (k : Knot) := sorry` → `:= 1`, faux — le Delta du trèfle est t²−t+1) comme du progrès de sorry-élimination. Aucun des 4 gardes ne tire : le fichier build, le compte de sorry baisse, aucun énoncé n'est réécrit — STMT_MUTATION_FALSE_SUCCESS est structurellement aveugle à cette forme (il exige `not proof_found` + 0 tactic vérifiée, mais un corps de def « rempli » passe les deux). C'est un acte de **design**, pas une preuve : ce qu'un objet EST appartient à un humain.

Correctif en 5 couches, miroir de FX-6b (#4917 / #1453) pour la forme « body » :

| # | Couche | Fichier |
|---|---|---|
| 1 | Prédicat `sorry_is_def_body(content, sorry_line)` — genre ∈ def/abbrev/instance/structure/inductive/class ET sorry après le `:=` de SA déclaration | `prover/lean_utils.py` |
| 2 | Refus d'entrée `_refuse_def_body_sorry` (reason `def_body_sorry`), inséré aux DEUX entrées (multi-agent + autonomous), **avant la sonde FX-5** (scan de chaîne pur → refus gratuit, sans compile) | `prover/provers.py` |
| 3 | Garde d'édition dans `file_replace_sorry` — refuse d'auteur un corps de def, fichier intact (couvre les appels d'outil directs) | `prover/tools.py` |
| 4 | Miroir defense-in-depth dans le VerifyExecutor, après le bloc FX-6b (couvre les entrées workflow directes, mêmes raisons : les gates de succès comptent un sorry-drop + build-pass) | `prover/workflow.py` |
| 5 | Ligne prompt dans AUTONOMOUS_PROVER_INSTRUCTIONS (« REFUSE si la ligne sorry est le CORPS d'une définition ») | `prover/instructions.py` |

**Épargnes par design** (jamais bloquer un run légitime) : corps de theorem/lemma/example (obligations de preuve légitimes) · sous-buts `have`/`let`/`show`/`suffices`/`obtain` dans la preuve d'un def (le binder a son propre `:=` — le type du sous-but est donné) · sorry en commentaire · sorry avant le `:=` (domaine FX-6b, déjà couvert) · def match-syntax sans `:=` (résiduel accepté, même famille que FX-6b). Résiduel documenté : binder multi-ligne dont le `:=` tombe sur ligne de continuation — faux positif accepté, aucun cas dans le repo.

## Validation §B (research-code) — preuves

1. **Prédicat, matrice attrape/épargne** (9 formes attrapées × 12 épargnées, `pytest tests/test_prover_guards.py -q`) :
   - attrapées : one-liner def (forme exacte des 6 cibles Conway live), corps sur ligne propre après `:= by`, header multi-lignes, pile `@[simp] private noncomputable`, abbrev, instance, champ `structure ... where`, champ `class ... where`, `inductive`;
   - épargnées : theorem/lemma/example, `have` one-liner ET multi-lignes dans un def, `let`, sorry en commentaire, sorry dans le type, match-syntax, orphelin, contenu vide ;
   - **positive control dans la même invocation** : `test_file_replace_sorry_allows_theorem_target` (le fixture theorem passe le garde — le garde discrimine, il ne refuse pas tout) à côté de `test_file_replace_sorry_blocks_def_body_target` (fichier def inchangé après blocage).
2. **Refus d'entrée** : `_refuse_def_body_sorry` rend le skip-dict `{"success": False, "skipped": True, "reason": "def_body_sorry"}` sur cible def, `None` sur cible theorem, `None` sur fichier manquant (3 tests).
3. **6 cibles Conway FR/EN refusées à l'entrée via dispatch `--file/--line`** (preuve live, logs ci-dessous dans les commentaires de PR) :
   - FR `knot_lean/Knots/Conway.lean` : alexanderPolynomial L294, IsSmoothlySlice L323, IsTopologicallySlice L331 — mode `multi`;
   - EN `knot_lean/Knots/Conway_en.lean` : alexanderPolynomial L302, IsSmoothlySlice L331, IsTopologicallySlice L339 — mode `autonomous`;
   - les DEUX points d'insertion prouvés (multi + autonomous), refus AVANT tout appel LLM et avant la sonde compile FX-5.
4. **Gardes existants intacts** : la suite complète `tests/test_prover_guards.py` + `tests/test_lean_utils.py` passe (FX-6b, FX-5, P1 latch, stub/axiom/relocation guards inchangés) — `_DECL_START_RE` et `sorry_is_in_statement` byte-identiques (seul ajout : `sorry_is_def_body` + ses 2 regex privées `_DECL_GENRE_RE`/`_PROOF_BINDER_RE`).
5. **Runs theorem-target inchangés** : le refus rend `None` pour tout genre ∉ {def, abbrev, instance, structure, inductive, class} — chemin de code identique à avant (couche purement additive, aucun garde existant modifié).

## Détails

- Environnement : `agent-framework` installé dans le venv repo (règle F — dépendance d'import du harnais, absente localement).
- Aucun fichier `.lean` touché — règle FR/EN siblings non applicable ; `count_code_sorry` inchangé par construction (0 diff Lean).
- Origine du diagnostic : issue #12658 (analyse 7 gardes, aucun ne tire sur les 6 cibles exposées). Ancres spec ↔ code vérifiées firsthand avant implémentation (lean_utils.py:235, provers.py:188/567/1380, tools.py:2007-2048, workflow.py:1070, instructions.py:478).

Closes #12658
