### PR TITLE
fix(guard,#12728): T1 — caler la cadence du sweep sur son temps de service

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -69,11 +69,29 @@ name: PR gate stale-verdict sweep
 
 on:
   schedule:
-    # Every 20 minutes on off-:00 minutes (anti-stampede convention, as in
-    # pr-gate-missing-advisory.yml). Frequent enough that a PR blocked by a
-    # stale verdict waits minutes, not a day; cheap enough (one short job)
-    # not to add meaningful load to a starved queue.
-    - cron: '7,27,47 * * * *'
+    # Hourly on an off-:00 minute (anti-stampede convention, as in
+    # pr-gate-missing-advisory.yml).
+    #
+    # #12728: this was every 20 minutes, and the cadence was destroying its own
+    # organ. The premise of the old comment -- "cheap enough (one short job) not
+    # to add meaningful load" -- is true of the WORK and false of the WAIT. On 30
+    # runs the job executed in 110-122 s but waited 1.6-2.2 h for a runner (98-99 %
+    # queue). Service ~2 h against a 20 min cadence means 5-6 sweeps are created
+    # behind the one that finally gets a slot; a concurrency group holds exactly
+    # ONE pending, so GitHub drops the rest. Measured outcome: 19 of 30 runs
+    # cancelled, median lifetime 1228 s -- which is 20.5 min, i.e. exactly one
+    # cron interval. That number excludes every cause except the next sweep.
+    #
+    # The loop closed on itself: the busier the queue, the longer the sweep waits,
+    # the more certainly it is cancelled -- so the organ that repairs stale
+    # PR gate verdicts went quiet precisely under the congestion that produces
+    # them. Matching the cadence to the observed service time is what stops the
+    # sweeps killing each other.
+    #
+    # This does NOT fix the 99 % queue wait -- see #12728 T2, which routes this
+    # workflow to the self-hosted runners of #12704. Repair still arrives late;
+    # it just stops failing to arrive at all.
+    - cron: '7 * * * *'
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: DEEP/training #12695

T1 de #12728. Une ligne de cron, `7,27,47 * * * *` → `7 * * * *`, plus le commentaire qui dit
pourquoi — sans quoi quelqu'un la « réoptimisera » dans six semaines.

## Ce qui est mesuré

Le sweep est l'unique organe qui ré-agrège un `PR gate` périmé. Sur ses 30 derniers runs :

| issue | n | durée de vie médiane |
|---|---|---|
| `cancelled` | **19** | **1228 s** |
| `success` | 9 | 3478 s |
| en vol | 2 | — |

**1228 s = 20,5 min = exactement un intervalle de cron.** Ce chiffre exclut toute cause autre que
le sweep suivant : aucune autre horloge du système ne bat à 20,5 min.

Le découpage attente/exécution sur les runs réussis :

```
file= 7832 s   execution= 110 s   (99 % d'attente)
file= 5823 s   execution= 122 s   (98 % d'attente)
```

## Le mécanisme

Le commentaire retiré affirmait « cheap enough (one short job) not to add meaningful load ».
C'est vrai du **travail** et faux de l'**attente**. Service ≈ 2 h contre une cadence de 20 min :
5 à 6 sweeps sont créés derrière celui qui obtient enfin un runner. Un groupe de concurrence
retient exactement **un** pending — GitHub supprime les autres.

`cancel-in-progress: false` est **correct et conservé**. Il protège le run **en cours**, et son
commentaire décrit fidèlement cette intention. Le défaut portait sur le **pending**, dont le
réglage ne dit rien. Ce n'est pas un mauvais réglage qu'on corrige, c'est un cas qu'il ne couvrait
pas.

La boucle se refermait sur elle-même : plus la file est chargée, plus le sweep attend, plus il est
annulé — donc moins il répare les gates périmés que cette même file vient de produire. L'organe de
réparation s'éteignait sous la charge qu'il existe pour traiter.

## Critère d'acceptation, falsifiable

`cancelled` doit tomber à **~0** sur les prochains runs de ce workflow. Vérifiable en 3 h, sur
≥20 runs pour que le contrôle ait un dénominateur. Si les annulations persistent, le diagnostic
est faux et cette PR doit être révoquée — la cadence n'était pas la cause.

## Ce que cette PR ne fait PAS

Elle ne corrige **pas** les 99 % d'attente en file. C'est T2 de #12728 : router ce workflow vers
les runners self-hosted de #12704. La réparation continuera d'arriver tard ; elle cesse seulement
de ne pas arriver du tout.

Et contre-intuitivement, T2 est un argument pour migrer **ce petit job fréquent** avant les suites
lourdes : sa valeur s'effondre avec le délai, celle d'une suite de 40 min non.

## Effet immédiat, indépendant de cette PR

Les 10 PR mesurées ce matin comme `PERIME` (gate rouge, **aucun** autre rouge, suite terminée) ont
reçu un dispatch manuel de `pr-gate-rerun.yml` — le chemin prévu quand le sweep manque :
#12142, #12615, #12616, #12645, #12655, #12660, #12663, #12698, #12701, #12710.

Cette PR fait que ce geste manuel cesse d'être nécessaire.

See #12728
See #12704
