### PR TITLE
fix(lane-claim,#12711): classe de decoration non-ASCII invisible aux deux regex

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -112,8 +112,16 @@ from grain_tag import extract_lane
 # bold pair opener, then whitespace, then the bracket. A `[` NOT immediately at
 # a decorator position (e.g. `- Prose with [CLAIMED] mid-line`) still does not
 # match -- the mid-prose non-regression property is preserved.
+# #12711 -- the decor class was ASCII-pure, so a leading non-ASCII decoration
+# (`→` U+2192, `➡` U+27A1, `➜` U+279C, `»` U+00BB, `•` U+2022, `–` U+2013,
+# `—` U+2014) voided the marker to BOTH regexes: the claim was never read (no
+# block) and the bare-marker lint never flagged it (no WARN). Measured on
+# #12465: `→DELIVERED #12465 ...` posted by po-2026 went unread, po-2027 then
+# got CLEAR and delivered the same notebook 15 h later (#12512 / #12638).
+# `_DECOR` is the shared, broadened decoration class for all four regexes.
+_DECOR = r"(?:[#>*+\-→➡➜»•–—]{1,6}[ \t]*)*"
 _MARKER_RE = re.compile(
-    r"(?m)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE|OVERRIDE|DELIVERED)\s*\]",
+    r"(?m)^[ \t]*" + _DECOR + r"(?:\*\*|__)?[ \t]*\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE|OVERRIDE|DELIVERED)\s*\]",
     re.IGNORECASE,
 )
 # #11239 -- malformed-marker lint. A claim line written WITHOUT the brackets
@@ -128,7 +136,7 @@ _MARKER_RE = re.compile(
 # widening -- a malformed line must surface as a warning, never as a claim
 # event. The motif tail is on the same line only (no `[\s\S]` cross-line).
 _MALFORMED_MARKER_RE = re.compile(
-    r"(?m)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*"
+    r"(?m)^[ \t]*" + _DECOR + r"(?:\*\*|__)?[ \t]*"
     r"(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE|OVERRIDE|DELIVERED)\b"
     r"[^\n]*(?:lane\s+\S+:\S+|#\d+)",
     re.IGNORECASE,
@@ -234,7 +242,7 @@ _OVERRIDE = {"OVERRIDE"}
 # indistinguishable from a closing decorator by suffix alone. Trailing `*` in
 # fnmatch matches empty, so a captured `glob**` still matches `glob`.
 _PATHS_CLAUSE_RE = re.compile(
-    r"(?im)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*\[\s*(?:CLAIMED|RELEASED|OVERRIDE)\s*\][^\n]*?paths\s*:\s*([^\n]+?)\s*$"
+    r"(?im)^[ \t]*" + _DECOR + r"(?:\*\*|__)?[ \t]*\[\s*(?:CLAIMED|RELEASED|OVERRIDE)\s*\][^\n]*?paths\s*:\s*([^\n]+?)\s*$"
 )
 # #12320 -- `[DELIVERED] lane <m:w> -- PR #N`. The PR reference is OPTIONAL on
 # a DELIVERED marker (a DELIVERED without a PR is functionally equivalent to a
@@ -280,7 +288,7 @@ _PAREN_ANNOTATION_RE = re.compile(r" \(")
 # claim is NOT re-classified (see #12072: re-reading an off-marker prose line
 # as the machine clause would make the scope depend on an heuristic).
 _OFF_MARKER_SCOPE_RE = re.compile(
-    r"(?im)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*paths?\s*:\s*([^\n]+?)\s*$"
+    r"(?im)^[ \t]*" + _DECOR + r"(?:\*\*|__)?[ \t]*paths?\s*:\s*([^\n]+?)\s*$"
 )
 
 

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -347,6 +347,48 @@ def test_decorated_paths_clause_scopes_claim():
     assert fnmatch.fnmatch("notebooks/b.ipynb", "notebooks/b.ipynb**")  # invariant
 
 
+# --- non-ASCII leading decoration (#12711) -----------------------------------
+# A leading `→` (U+2192) / `➡` / `»` / `•` / `–` / `—` is an agent decoration,
+# not an ASCII decorator. The ASCII-pure decor class voided such a marker to
+# BOTH regexes on #12465 (po-2026's `→DELIVERED` went unread; po-2027 got CLEAR
+# and delivered the same notebook 15 h later). Broadening `_DECOR` re-reads the
+# marker and re-arms the malformed lint for the bracketless form.
+
+def test_parse_marker_non_ascii_arrow_decorated():
+    ev = clc.parse_claim_event(comment(
+        "→[CLAIMED] lane myia-po-2027:CoursIA-2 -- arrow prefix",
+        "2026-08-23T18:21:01Z",
+    ))
+    assert ev is not None
+    assert ev.is_open is True
+    assert ev.marker == "CLAIMED"
+    assert ev.lane == "myia-po-2027:CoursIA-2"
+
+
+def test_parse_non_ascii_decorated_delivered_closes():
+    # The exact #12465 shape, bracketed: an arrow-prefixed DELIVERED with a
+    # lane must register as a close (this is what po-2026's line should have
+    # done before po-2027 delivered the same notebook).
+    ev = clc.parse_claim_event(comment(
+        "→[DELIVERED] lane myia-po-2026:CoursIA -- PR #12512 paths: .../Search-3-Informed.ipynb",
+        "2026-08-23T03:36:33Z",
+    ))
+    assert ev is not None
+    assert ev.marker == "DELIVERED"
+    assert ev.is_open is False
+    assert ev.lane == "myia-po-2026:CoursIA"
+
+
+def test_parse_non_ascii_decoration_mid_prose_still_ignored():
+    # A `→` followed by prose, then a mid-line `[CLAIMED]`, must NOT become an
+    # event (the bracket is not at a decorator position). Non-regression pinned.
+    ev = clc.parse_claim_event(comment(
+        "→ Cette PR reprend un [CLAIMED] discute plus tot",
+        "2026-08-23T09:00:00Z",
+    ))
+    assert ev is None
+
+
 def test_check_no_paths_claim_in_prose_returns_exit_2_not_scoped(capsys):
     # Full-flow regression for the #10228 FN: a claim comment that ALSO mentions
     # a close marker in instructional prose must still BLOCK another lane. This
@@ -688,6 +730,20 @@ def test_decorated_bare_marker_flagged(capsys):
     captured = capsys.readouterr()
     assert rc == 0
     assert '"malformed_markers": 1' in captured.out
+
+
+def test_malformed_marker_non_ascii_decorated_surfaces(capsys):
+    # #12711 -- a `→`-prefixed BARE marker (no brackets) was invisible to the
+    # #11239 lint too: the writer believed their lock was posted yet the organ
+    # answered CLEAR. Broadening `_DECOR` re-arms the WARN.
+    p = payload(comment(
+        "→CLAIMED lane myia-po-2026:CoursIA -- working here",
+        "2026-08-23T03:36:33Z"))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    captured = capsys.readouterr()
+    assert rc == 0                          # WARN-only, never blocks
+    assert '"malformed_markers": 1' in captured.out
+    assert 'WARN: marqueur sans crochets "CLAIMED"' in captured.err
 
 
 def test_malformed_close_marker_flagged(capsys):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: DEEP/notebook-python #12542

## Problème

Un préfixe de décoration **non-ASCII** (`→` U+2192, `➡` U+27A1, `➜` U+279C, `»` U+00BB, `•` U+2022, `–` U+2013, `—` U+2014) en début de ligne rendait le marqueur **invisible aux DEUX regex** de `scripts/check_lane_claim.py` :

- `_MARKER_RE` ne créait pas d'événement → le claim **ne bloquait personne** ;
- le lint `_MALFORMED_MARKER_RE` (#11239) ne le signalait pas → le verrou n'était **ni posé ni signalé comme mal écrit**.

C'est la polarité fail-OPEN : la lane qui écrit croit avoir verrouillé, l'organe répond `CLEAR` à toutes les autres.

**Mesure firsthand sur #12465** : `→DELIVERED #12465 ...` posté par `myia-po-2026:CoursIA` (03:36Z) est resté non lu ; `myia-po-2027:CoursIA-2` a interrogé l'organe (obtenu `CLEAR`), posé un `[CLAIMED]` bien formé (18:21Z) et livré le **même notebook** → 2 PR (#12512 / #12638) à 15 h d'écart sur la même issue, le même contre-exemple.

## Cause

La classe de décoration était **ASCII pure** :

```python
r"(?m)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*"
```

`→` n'est ni un espace, ni un `#>*+-`, ni `**`/`__` : l'ancre `^` échoue, donc ni le parseur ni le lint ne voient le marqueur.

## Correctif

Constante `_DECOR` partagée, élargie à la classe ASCII + les caractères non-ASCII de la famille arrow/bullet/dash, utilisée par **les 4 regex** qui partageaient la même classe (`_MARKER_RE`, `_MALFORMED_MARKER_RE`, `_PATHS_CLAUSE_RE`, `_OFF_MARKER_SCOPE_RE`).

```python
_DECOR = r"(?:[#>*+\-→➡➜»•–—]{1,6}[ \t]*)*"
```

La grammaire du marqueur est inchangée : `→` ne devient jamais un claim valide à lui seul — il devient **visible** (l'événement se crée, le lint se déclenche). Non-régression mid-prose préservée : un `[` après de la prose n'est toujours pas lu.

## Périmètre

```
scripts/check_lane_claim.py
scripts/tests/test_check_lane_claim.py
```

## Validation

- `python -m pytest scripts/tests/test_check_lane_claim.py` → **230/230 PASS** (226 existants + 4 nouveaux).
- 4 nouveaux cas : événement ouvert arrow-prefixé (`→[CLAIMED]` → CLAIMED, lane extraite), DELIVERED arrow-prefixé (`→[DELIVERED]` → close, lane extraite), mention mid-prose arrow ignorée (non-régression), lint malformé arrow-prefixé (`→CLAIMED lane ...` → `malformed_markers: 1`, WARN).
- `python -m py_compile scripts/check_lane_claim.py` → OK.

Closes #12711
