### PR TITLE
fix(scripts,#12751): stale-claims honesty + default 48h threshold

### DIFF
--- a/.claude/rules/lane-claim-protocol.md
+++ b/.claude/rules/lane-claim-protocol.md
@@ -12,7 +12,7 @@ L'issue GitHub ferme les trois d'un coup : locus **unique cross-lane par constru
 
 ## Regle HARD — cote worker
 
-1. **Avant d'EDITER un fichier** pour un grain rattache a une issue #N : verifier les claims — `python scripts/check_lane_claim.py N` (ou `gh issue view N -c`). Un `[CLAIMED]` d'une **autre lane** non leve → ne pas commencer, piocher ailleurs. Le check precede l'**edition**, pas le push (L898 durci : le pre-push est deja trop tard — c'est le cout du correctif ecrit en double).
+1. **Avant d'EDITER un fichier** pour un grain rattache a une issue #N : verifier les claims — `python scripts/check_lane_claim.py N` — la detection de peremption est **active par defaut** (`--stale-threshold 48`, cf. #12751) ; l'ancien comportement (toute claim active bloque) s'obtient explicitement par `--no-stale`. (ou `gh issue view N -c`). Un `[CLAIMED]` d'une **autre lane** non leve → ne pas commencer, piocher ailleurs. Le check precede l'**edition**, pas le push (L898 durci : le pre-push est deja trop tard — c'est le cout du correctif ecrit en double).
 2. **Poser son claim sur l'issue** : `gh issue comment N --body "[CLAIMED] lane <machine:workspace> — <intention en une ligne>"`. Pas de timestamp dans le corps : le `createdAt` serveur fait foi.
 3. **Tout timestamp redige est en UTC explicite.** Le suffixe `Z` sur une heure locale est proscrit. En cas de conflit, l'ordering par `createdAt` serveur **l'emporte toujours** sur un stamp de corps.
 4. Le dashboard **garde le recit de cycle** (`[CLAIMED]` informatif y reste bienvenu) ; il **cesse d'etre le registre de verrous** — seul le commentaire d'issue fait foi cross-lane.

--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -1794,6 +1794,13 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             if age is not None and age >= stale_threshold:
                 stale_others[ln] = ev
         others = {ln: ev for ln, ev in others.items() if ln not in stale_others}
+    else:
+        # #12751 -- a zero of absence-of-measurement must not re-read as a
+        # zero of absence-of-claim. Say the detection is OFF on stderr (the
+        # JSON `stale_detection` field is set to "disabled" alongside).
+        print("STALE_DETECTION disabled -- claims are NOT age-filtered "
+              "(--no-stale or threshold None). Old claims still block.",
+              file=sys.stderr)
 
     # #12327 -- lint qualifier runs AFTER the reducer: the epic-wide marker
     # lint can no longer say `il bloque toutes les autres lanes` for a
@@ -1863,7 +1870,15 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
         "my_lane": my_lane,
         "my_active_claim": bool(mine),
         "blocking_lanes": sorted(others),
-        "stale_claims": sorted(stale_others),
+        "stale_claims": sorted(stale_others) if stale_threshold is not None else None,
+        # #12751 -- l'etat de la detection est nomme explicitement. "active" :
+        # un seuil est pose, les claims plus vieux sont age-filtered (le
+        # comportement par defaut, 48h). "disabled" : --no-stale / threshold
+        # None -- rien n'est mesure du tout, un claim zombie de 415 h bloquerait
+        # indefiniment. `stale_claims` vaut `null` quand disabled -- un zero
+        # d'ABSENCE de mesure ne doit pas se relire comme un zero d'absence de
+        # claim (avant, les deux rendaient `[]`).
+        "stale_detection": "active" if stale_threshold is not None else "disabled",
         # #12156 -- umbrella classifier (`is_umbrella`) and the pathology it
         # describes (`epic_wide_on_umbrella`). Both default False: on a
         # unit-issue the umbrella flag stays False; on a CLEAR umbrella the
@@ -2515,12 +2530,19 @@ def main(argv: list[str] | None = None) -> int:
                    help="your lane, e.g. myia-po-2024:CoursIA")
     p.add_argument("--from-json", metavar="FILE",
                    help="read `gh issue view` JSON from FILE (offline/test mode)")
-    p.add_argument("--stale-threshold", type=float, metavar="HOURS", default=None,
+    p.add_argument("--stale-threshold", type=float, metavar="HOURS", default=48.0,
                    help="treat OTHER lanes' claims older than HOURS as stale: "
                         "warn and do not block (age from server createdAt, never "
                         "the body). The new claimant must still post its own "
-                        "[CLAIMED] -- this is not a silent bypass. Without the "
-                        "flag every active claim blocks (current behaviour).")
+                        "[CLAIMED] -- this is not a silent bypass. Default 48 "
+                        "(#12751): the canonical invocation now MEASURES. "
+                        "`--no-stale` restores the legacy behaviour (every active "
+                        "claim blocks).")
+    p.add_argument("--no-stale", action="store_true", default=False,
+                   help="#12751: disable staleness detection entirely (legacy "
+                        "behaviour: every active claim blocks, nothing is "
+                        "age-filtered). The detected state is reported as "
+                        "`stale_detection: \"disabled\"`.")
     p.add_argument("--paths", metavar="PATH", nargs="+", default=None,
                    help="path-mode (#9959): one or more file paths/globs. "
                         "Exits 2 if any OPEN PR of a different lane (or with "
@@ -2551,6 +2573,11 @@ def main(argv: list[str] | None = None) -> int:
                         "blocked (#11064). Coordinator arbitration only -- "
                         "the reading side still honours [OVERRIDE] markers.")
     args = p.parse_args(argv)
+    # #12751 -- default is 48 (measuring). `--no-stale`/threshold=None restores
+    # the legacy behaviour (every claim blocks, nothing age-filtered); the
+    # disabled state is reported honestly as `stale_detection: "disabled"`.
+    if args.no_stale:
+        args.stale_threshold = None
 
     # #10881 -- `nargs='+'` on --paths swallows a TRAILING positional issue
     # number (`--lane X --paths a b 10678` puts "10678" into the paths list,

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -836,6 +836,90 @@ def test_stale_threshold_unparseable_not_treated_stale(capsys):
     assert rc == 2
 
 
+def test_stale_claims_null_when_detection_disabled(capsys):
+    # #12751 -- detection OFF (no --stale-threshold): `stale_claims` must be
+    # `null` (not measured), NOT `[]` (measured, nothing stale). Previously
+    # both rendered `[]`, so the fleet ran with detection off and a 415h
+    # claim still read as "alive".
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA -- very old orphan",
+        "2026-08-01T00:00:00Z",
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA", now=NOW)
+    captured = capsys.readouterr()
+    # The summary JSON (indent=2) is followed on stdout by a human-readable
+    # verdict line when the call is CLEAR/PATH_SCOPED (the post-summary
+    # `if others:` block). `raw_decode` parses only the first JSON value and
+    # ignores the trailing prose -- `json.loads` would fail on "Extra data".
+    out = json.JSONDecoder().raw_decode(captured.out)[0]
+    assert out["stale_claims"] is None
+    assert out["stale_detection"] == "disabled"
+    assert "STALE_DETECTION disabled" in captured.err
+
+
+def test_stale_claims_empty_when_detection_enabled_clean(capsys):
+    # Detection ON, no claim old enough -> `stale_claims` is `[]` (measured,
+    # clean) and `stale_detection` is "active" -- the disambiguated state vs
+    # `null`/`"disabled"` (not measured).
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA -- fresh",
+        "2026-08-07T10:00:00Z",
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA",
+                        stale_threshold=24.0, now=NOW)
+    captured = capsys.readouterr()
+    # The summary JSON (indent=2) is followed on stdout by a human-readable
+    # verdict line when the call is CLEAR/PATH_SCOPED (the post-summary
+    # `if others:` block). `raw_decode` parses only the first JSON value and
+    # ignores the trailing prose -- `json.loads` would fail on "Extra data".
+    out = json.JSONDecoder().raw_decode(captured.out)[0]
+    assert out["stale_claims"] == []
+    assert out["stale_detection"] == "active"
+
+
+def test_default_48_flags_17day_claim_stale(capsys):
+    # #12751 acceptance: at the default 48h threshold, a 17-day-old OTHER-lane
+    # claim is flagged STALE and removed from blocking_lanes (the zombie-lock
+    # fix -- a 415h claim was read as "alive" because `stale_claims` was `[]`).
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA -- 17 days old",
+        "2026-07-21T00:00:00Z",   # ~396h before NOW
+    ))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA",
+                        stale_threshold=48.0, now=NOW)
+    captured = capsys.readouterr()
+    # The summary JSON (indent=2) is followed on stdout by a human-readable
+    # verdict line when the call is CLEAR/PATH_SCOPED (the post-summary
+    # `if others:` block). `raw_decode` parses only the first JSON value and
+    # ignores the trailing prose -- `json.loads` would fail on "Extra data".
+    out = json.JSONDecoder().raw_decode(captured.out)[0]
+    assert out["stale_claims"] == ["myia-po-2025:CoursIA"]
+    assert out["blocking_lanes"] == []
+    assert out["stale_detection"] == "active"
+    assert "STALE_CLAIM myia-po-2025:CoursIA" in captured.err
+    assert rc == 0
+
+
+def test_default_48_does_not_flag_2h_claim(capsys):
+    # #12751 acceptance: a fresh (2h) claim is NOT stale at the default 48h
+    # (positive polarity -- only genuinely-old claims age out).
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2025:CoursIA -- fresh 2h",
+        "2026-08-07T10:00:00Z",   # 2h before NOW
+    ))
+    clc._run_check(p, "myia-po-2024:CoursIA",
+                   stale_threshold=48.0, now=NOW)
+    captured = capsys.readouterr()
+    # The summary JSON (indent=2) is followed on stdout by a human-readable
+    # verdict line when the call is CLEAR/PATH_SCOPED (the post-summary
+    # `if others:` block). `raw_decode` parses only the first JSON value and
+    # ignores the trailing prose -- `json.loads` would fail on "Extra data".
+    out = json.JSONDecoder().raw_decode(captured.out)[0]
+    assert out["stale_claims"] == []
+    assert out["stale_detection"] == "active"
+    assert "STALE_CLAIM" not in captured.err
+
+
 # --- --paths mode (#9959) ----------------------------------------------------
 #
 # Replays the R3D 2026-08-08 incident: two lanes of the SAME machine collide


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-python #12685

Closes #12751

## The defect

`check_lane_claim.py` rendered `"stale_claims": []` when staleness detection
was **disabled** — exactly the same value as when detection is active and finds
nothing. The two states — « measured, nothing found » and « not looked » —
shared one return value, and nothing in the output distinguished them.

`--stale-threshold` had `default=None` (`scripts/check_lane_claim.py:2518`),
and the whole staleness block is skipped when it is `None` (`:1790`).

## Why it was fleet-wide, not anecdotal

The documented invocation — the one every lane runs before editing —
omitted the flag:

    .claude/rules/lane-claim-protocol.md:15
    « verifier les claims — `python scripts/check_lane_claim.py N` »

So the **whole fleet ran with detection off**. Direct consequence: the protocol
clause

    « un claim d'une lane morte > 48 h sans commit ni PR se re-arbitre par le
      coordinateur, pas par auto-service »

had **no organ behind it by default**. The organ exists; it was simply dormant —
and a dead claim blocks indefinitely without anyone seeing it is dead.

## Measurement (issue #9768, 2026-08-24)

Same issue, same calling lane, only the presence of the flag changes:

| Invocation | `stale_claims` | `blocking_lanes` |
|---|---|---|
| `--lane myia-ai-01:CoursIA` (documented) | `[]` | `["myia-po-2025:CoursIA", "myia-po-2025:CoursIA-2"]` |
| `--lane … --stale-threshold 48` | the **two** lanes | `[]` |

With the threshold set, the organ said it itself:

    STALE_CLAIM myia-po-2025:CoursIA   (415.8h >= 48h threshold) -- reprise autorisee
    STALE_CLAIM myia-po-2025:CoursIA-2 (416.5h >= 48h threshold) -- reprise autorisee

**415 h = 17 days.** Two claims dead for seventeen days presented themselves
as live locks to any lane applying the procedure to the letter. This is a silent
self-blocking producer: a lane does its check as asked, reads « blocked by
another lane », and goes elsewhere — when the lock has been dead for weeks.

## The fix

1. **A default that measures.** `--stale-threshold` now defaults to `48` (the
   value the protocol already writes). The canonical invocation now measures.
   Opting back into the legacy behaviour is explicit (`--no-stale`).
2. **Never render a silent zero.** When detection is disabled, the output says
   so — JSON field `stale_detection: "disabled"` and a `STALE_DETECTION
   disabled` line on stderr, on the model of what `pick_idle_grain.py` already
   does with `visits_measured` / `n/m` (#12635). `stale_claims` is `null` when
   disabled — a zero of absence-of-measurement can no longer be re-read as a
   zero of absence-of-claim.
3. **Align the docs.** `lane-claim-protocol.md:15` now cites the canonical
   invocation as the measuring one.
4. **Regression tests on both polarities**: a 17-day claim is flagged STALE
   **and** a 2-hour claim is not.

## Acceptance (#12751)

- [x] `python scripts/check_lane_claim.py 9768 --lane <L>` (no other flag)
      flags the two 415h claims as STALE and renders `blocking_lanes: []`
- [x] the output names the detection state (`active` / `disabled`) in both cases
- [x] `lane-claim-protocol.md:15` cites the measuring invocation
- [x] tests cover old-claim-flagged AND recent-claim-not-flagged

## Validation

- `python -m pytest scripts/tests/test_check_lane_claim.py -q` → **230 passed**
- CLI live check (issue 9768, default 48):
  - `STALE_CLAIM myia-po-2025:CoursIA (418.9h >= 48h threshold)`
  - `STALE_CLAIM myia-po-2025:CoursIA-2 (419.6h >= 48h threshold)`
  - `"blocking_lanes": []`, `"stale_detection": "active"`
- CLI live check `--no-stale`: `"stale_claims": null`,
  `"stale_detection": "disabled"`, stderr `STALE_DETECTION disabled -- claims
  are NOT age-filtered`.

## Scope

3 files: `scripts/check_lane_claim.py` (default 48 + `--no-stale` + honest
reporting), `scripts/tests/test_check_lane_claim.py` (4 tests), 
`.claude/rules/lane-claim-protocol.md:15` (doc aligned).
