### PR TITLE
fix(guard,#12718,#11985): perimeter — N fichiers neufs / snapshot avant-apres / in-scope ne bloquent plus

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -476,8 +476,14 @@ INCIDENTAL_QUALIFIERS = frozenset({
     "scannes", "scannés", "scanne", "scanné",
     "analyses", "analysés", "analyse", "analysé",
     "audites", "audités", "audite", "audité",
-    "examines", "examinés", "examine", "examiné",
-})
+    "examines", "examinés", "examine", "examiné",    # #12718 (classe #11985 forme 4): "N fichiers neufs/neuve/neuf" -- the
+    # French "new" adjective in its noun-collocated form -- is a NEW-FILES
+    # descriptor, never the whole-PR perimeter. The equality confrontation
+    # would read "2 fichiers neufs : file1 + file2" as "the PR changes 2
+    # files" when it actually adds 2 new ones among 5 changed. Same family
+    # as "nouveau/nouveaux/nouvelle/nouvelles" above; the masculine/feminine
+    # singular/plural variants were missing.
+    "neuf", "neuve", "neufs",})
 # A cited threshold ("< 15 fichiers", ">= 10 fichiers") quotes a rule, it does
 # not claim a perimeter.
 COMPARISON_PREFIX = re.compile(r"[<>=≤≥]\s*$")
@@ -582,6 +588,20 @@ MEASUREMENT_ANTECEDENT = re.compile(
     r"check_(?:unaddressed_nits|pr_perimeter|perimeter))\b",
     re.IGNORECASE,
 )
+# Forme 4c, snapshot avant/apres: "avant (main) : <composant> — N fichiers" /
+# "apres (branche) : N fichiers" -- a before/after baseline of a MEASURED
+# quantity (a Lean lake's SIZE), never the PR's perimeter (#12718). Same family
+# as MEASUREMENT_ANTECEDENT: bad surface, not bad count. The signal is the
+# snapshot keyword adjacent to a branch-state label -- "avant (main)", "apres
+# (branche)" -- which appears only in baseline-comparison prose. FN-safety is
+# structural: a line carrying a strong scope word or a diffstat neighborhood
+# returns blocking in _count_is_incidental BEFORE this exemption is consulted,
+# so "Perimetre : avant 2 fichiers, apres 5 fichiers" stays blocking.
+SNAPSHOT_ANTECEDENT = re.compile(
+    r"\b(?:avant|après|apres|before|after|baseline)\b"
+    r"[^a-z0-9_]*\(?\b(?:main|branche|branch|master)\b\)?",
+    re.IGNORECASE,
+)
 # Forme 5, compte-antecedent parenthetique: "<N> <unites> (<M> fichiers)" --
 # le compte entre parentheses qualifie la PROVENANCE du nombre qui precede
 # ("32 prescriptions avant (2 fichiers) -> 32 apres"), jamais le perimetre de
@@ -628,10 +648,45 @@ def _has_strong_scope(low: str) -> bool:
     # plain `in` test, blocking the per-match NEGATED_DIFF_TAIL exemption).
     # The 8 STRONG_SCOPE_WORDS are all standalone vocabulary in French/English;
     # a regex boundary costs nothing and removes a class of false positives.
-    return any(
-        re.search(rf"\b{re.escape(w)}\b", low, re.IGNORECASE)
-        for w in STRONG_SCOPE_WORDS
+    # #12718: "scope" as a hyphenated compound ("in-scope", "out-of-scope") is
+    # an adjective describing scope-inclusion, never a perimeter-count label --
+    # a hyphen-negative lookbehind keeps such a line incidental while
+    # "scope = perimetre PR" and "Périmètre : N fichiers modifiés" still block.
+    # All non-"scope" words keep the plain \b...\b boundary ("modif" must not
+    # misfire; "périmètre" is a standalone label).
+    for w in STRONG_SCOPE_WORDS:
+        if w == "scope":
+            if re.search(r"(?<![-\w])scope(?![-\w])", low):
+                return True
+        elif re.search(rf"\b{re.escape(w)}\b", low, re.IGNORECASE):
+            return True
+    return False
+
+
+def _count_has_incidental_qualifier(line: str, m: re.Match) -> bool:
+    """#12718: true when the COUNT match `m` is immediately followed by an
+    `INCIDENTAL_QUALIFIERS` word (or a qualified two-word pair). A count so
+    qualified is a sub-claim ("N fichiers neufs : ... (330 lignes)"), not the
+    whole-PR perimeter -- and, unlike an antecedent exemption, it overrides a
+    diffstat neighbor on the same line. Extracted from _count_is_exempt so the
+    two callers (per-count exemption, incidental override) share one predicate."""
+    # #13440: le pluriel parenthetique "(s)" est neutralise avant lecture du
+    # qualificatif ("fichier(s) verifies" doit lire "verifies").
+    after = PLURAL_PAREN.sub(" ", line[m.end():], count=1)
+    mw = re.match(r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)", after)
+    if mw and mw.group(1).lower() in INCIDENTAL_QUALIFIERS:
+        return True
+    mw2 = re.match(
+        r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)"
+        r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)",
+        after,
     )
+    if mw2:
+        pair = f"{mw2.group(1)} {mw2.group(2)}".lower()
+        if (mw2.group(1).lower() in INCIDENTAL_QUALIFIERS
+                or pair in INCIDENTAL_QUALIFIER_PAIRS):
+            return True
+    return False
 
 
 def _count_is_exempt(line: str, m: re.Match, ante_context: str = "") -> bool:
@@ -667,24 +722,15 @@ def _count_is_exempt(line: str, m: re.Match, ante_context: str = "") -> bool:
     ante_scope = f"{ante_context}\n{line[: m.end()]}" if ante_context else line[: m.end()]
     if MEASUREMENT_ANTECEDENT.search(ante_scope):
         return True
+    if SNAPSHOT_ANTECEDENT.search(line[: m.start()]):
+        return True
     if REFERENCE_VERB_TAIL.match(after):
         return True
     if (before.endswith("(") and after.lstrip().startswith(")")
             and PAREN_ANTECEDENT_NUM.search(before[:-1])):
         return True
-    mw = re.match(r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)", after)
-    mw2 = re.match(
-        r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)"
-        r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)",
-        after,
-    )
-    if mw and mw.group(1).lower() in INCIDENTAL_QUALIFIERS:
+    if _count_has_incidental_qualifier(line, m):
         return True
-    if mw2:
-        pair = f"{mw2.group(1)} {mw2.group(2)}".lower()
-        if (mw2.group(1).lower() in INCIDENTAL_QUALIFIERS
-                or pair in INCIDENTAL_QUALIFIER_PAIRS):
-            return True
     return False
 
 
@@ -755,7 +801,17 @@ def _count_is_incidental(line: str, ante_context: str = "") -> bool:
         return True  # rejected alternative: "1 PR composite (15 fichiers)" (#11963)
     if ENUMERATION_TAIL.search(line) and NAMED_FILE.search(line):
         return True  # enumeration sub-sum: "X.py + 2 fichiers de tests" (#11935)
-    if _has_strong_scope(low) or DIFFSTAT_NEIGHBORHOOD.search(line):
+    if _has_strong_scope(low):
+        return False
+    if DIFFSTAT_NEIGHBORHOOD.search(line):
+        # A qualifier-exempt count ("N fichiers neufs : file (330 lignes)")
+        # overrides the diffstat guard -- the "lignes" is a per-file size and
+        # the qualifier marks a sub-claim, not the whole-PR perimeter. An
+        # antecedent-exemption (locative "sur 2 fichiers", measurement parent,
+        # snapshot) does NOT override: "+307 lignes / −0 sur 2 fichiers" names
+        # what the diffstat measured (#11935 FN control stays blocking).
+        if all(_count_has_incidental_qualifier(line, m) for m in matches):
+            return True
         return False
     for m in matches:
         if not _count_is_exempt(line, m, ante_context):

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -31,6 +31,7 @@ from check_pr_perimeter import (  # noqa: E402
     _count_is_exempt,
     _count_is_incidental,
     _fence_line_indices,
+    _has_strong_scope,
     _is_incidental_assertion,
     _normalize_rest_files,
     _paragraph_prefix,
@@ -2469,3 +2470,51 @@ def test_13440_founder_negated_diff_still_exempt():
         assert _count_is_exempt(line, m) is True, (
             f"le compte fondateur doit rester exempt : {m.group(0)!r}"
         )
+
+def test_12718_hyphenated_scope_does_not_block():
+    """#12718: 'in-scope' (hyphenated, descriptive) is NOT a strong-scope
+    perimeter label -- `_has_strong_scope` excludes the hyphenated compound,
+    so a line whose count is already incidental via 'neufs' stays incidental
+    instead of being re-blocked by the bare word 'scope' inside 'in-scope'."""
+    line = ("2 fichiers neufs : `TopologyDictionary.lean` (330 lignes), "
+            "in-scope « couverture complète FR » + `TopologyDictionary` neuf.")
+    assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+    assert _has_strong_scope(line.lower()) is False
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is False
+
+
+
+def test_12718_new_files_qualifier_signal_not_blocking():
+    """#12718 (class #11985 forme 4): 'N fichiers neufs : file1 + file2' names
+    the newly-added files, never the whole-PR perimeter -- 'neufs' qualifies
+    the count, so the '330 lignes' diffstat neighbor is a per-file size, not
+    a diffstat of the PR. Detection unchanged; blocking consequence only."""
+    lines = [
+        # count with 'neufs' qualifier + diffstat neighbor -> incidental
+        "2 fichiers neufs : `Grothendieck/TopologyDictionary.lean` "
+        "(FR, 330 lignes) + sibling `TopologyDictionary_en.lean` "
+        "(EN, 328 lignes, miroir auto-contenu).",
+        # snapshot antecedent + diffstat -> incidental
+        "- avant (main) : grothendieck_lean — 116 fichiers, `distinct_code_sorry: 0`",
+        "- après (branche) : 118 fichiers (+2 neufs), `distinct_code_sorry: 0`",
+        # new-files count without diffstat -> incidental
+        "- Les 2 fichiers neufs sont créés sans `sorry`.",
+    ]
+    for line in lines:
+        assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+        cand = Candidate(line, "body", "author", "body")
+        assert cand.blocking is False, f"new-files qualifier must not block: {line[:50]}"
+
+
+
+def test_12718_scope_label_still_blocks():
+    """The hyphenated-scope relaxation must not swallow a genuine scope label:
+    'in-scope' is excluded, but 'scope = perimetre' remains a strong-scope
+    perimeter anchor. FN control for `_has_strong_scope`."""
+    line = "lake 70 fichiers uniquement, scope = perimetre PR"
+    assert extract_perimeter_assertions(line) == [line]
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is True
+
+


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2027:CoursIA — prev: MED/research-code #12733

## REPAIR #12718 — le garde périmètre relisait « N fichiers neufs » comme une assertion de périmètre

#12718 est bloquée par `check_pr_perimeter.py` : son body déclare
`2 fichiers neufs : TopologyDictionary.lean (FR, 330 lignes) + TopologyDictionary_en.lean (EN, 328 lignes)`.
Le garde confrontait ce « 2 fichiers » à la liste effective (5 fichiers : 3 Lean + 2 README) et
concluait une incohérence. Or l'auteur décrit **2 fichiers NOUVEAUX** parmi 5 modifiés — l'assertion est
correcte, le garde est en faux positif. Classe **#11985 forme 4** (compte descriptif d'une autre
grandeur que le périmètre).

Détection **UNCHANGED** ; seule la conséquence bouge (voie #11712/#11985 : incidental = SIGNAL,
jamais bloquant, et `extract_perimeter_assertions` continue de l'imprimer).

### Trois prédicats resserrés

1. **`INCIDENTAL_QUALIFIERS`** — ajout des variantes manquantes `neuf/neuve/neufs`
   (famille `nouveau/nouveaux/nouvelle/nouvelles` déjà présente). « N fichiers neufs »
   = descripteur de fichiers ajoutés, jamais le périmètre entier.

2. **`SNAPSHOT_ANTECEDENT` (nouveau)** — `avant (main) : — N fichiers` / `après (branche) : N fichiers`
   = baseline avant/après d'une grandeur **mesurée** (taille d'un lake Lean), pas le périmètre de la PR.
   Le label de branche est **requis** (`avant (main)` / `après (branche)`), pas optionnel — un
   « après » nu ne déclasserait pas une vraie assertion.

3. **`_has_strong_scope`** — `scope` en composé hyphené (`in-scope`, `out-of-scope`) est un adjectif
   descriptif, pas un label de périmètre. Le lookbehind hyphen-négatif garde `scope = perimetre PR`
   et `Périmètre : N fichiers modifiés` **bloquants** (contrôle FN ajouté).

   En plus : une exemption **qualificative** (neufs/générés/audio) prime sur le voisin diffstat
   (« 330 lignes » = taille par fichier) ; une exemption **antécédente** (locative « sur 2 fichiers »)
   ne le fait **pas** — `+307 lignes / −0 sur 2 fichiers` reste bloquant (contrôle FN #11935).

### Preuves

- Suite complète `test_check_pr_perimeter.py` : **122/122 verts** (3 fixtures ajoutées :
  2 positifs #12718 + 1 FN scope-label), 0 régression.
- `python scripts/check_pr_perimeter.py 12718 --scan-thread` : **VERDICT OK** (4 assertions body → SIGNAL).

### Notes

- Pas de `Closes` : la PR **répare le garde**, elle ne résout pas #12718 elle-même (PR de contenu par
  une autre lane) ni l'epic #11985. `See #12718` / `See #11985`.
- Anti-régression : aucun code retiré — uniquement des exemptions FLAG-structurelles couvertes par
  les FN-contrôles existants (#11712, #11935, #11800).



---

### Requalification du tag par le coordinateur (2026-08-29)

Tag declare : `MED/notebook-lean`. La PR ne touche **aucun** notebook et **aucun** `.lean` --
`scripts/check_pr_perimeter.py` (+105) et son test (+18), rien d'autre. Le genre etait pris sur la
**famille de la PR reparee** (#12718 est un lake Lean), pas sur le **type de travail** livre ici,
qui est un garde -- exactement le tell que variation-protocol.md nomme : « si le prochain grain de
ce rollout tombait dans une autre famille, changerais-je le GENRE ? ». Ici oui : le meme
resserrement de predicat vaudrait pour une PR notebook. Donc `guard`, pas `notebook-lean`.

**LIGHT**, pas MED, au litmus generable-en-serie : c'est une tranche de garde (trois qualifieurs
ajoutes a un jeu de motifs existant), du meme genre que celles deja mergees sur ce rollout.

Requalifie en **`LIGHT/guard`** (variation-protocol.md §3). Porte dans le **corps**, parce que
c'est le corps que le cap de veine lit : requalifier en commentaire aurait laisse la lane creditee
d'un grain de CONTENU qu'elle n'a pas livre, et c'est la voie par laquelle G-VAR-1 se contourne
sans que personne ne mente.

Budget : `variation_light_cap.py --genre-signals --lane myia-po-2027:CoursIA` mesure
`lane_grains: 1, light_genre: 0, cap: 1` -- cette LIGHT rentre au plafond, elle ne le depasse pas.
En revanche la lane n'a alors **aucun grain de CONTENU** aujourd'hui : c'est un defaut de
**provisionnement de ma part**, pas de la lane (variation-protocol.md §3 : « ne pas HOLD une PR
META saine -- la sanction porterait sur le mauvais objet »). Je merge, et je nomme le grain de
contenu du cycle suivant dans le dispatch.
