### PR TITLE
fix(guard,#12636): page merged window so a low-activity lane resolves its real predecessor

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -855,10 +855,16 @@ jobs:
           # `notebook-python`). Same data source as the G-VAR-2 job above
           # (`gh pr list --state merged`); no `merged:$TODAY` search here --
           # the predecessor may sit on any past day, the script sorts by
-          # mergedAt itself. A fetch failure degrades to the declared `prev:`
-          # (the flag stays absent), never to a crash or a silent pass.
-          gh pr list --state merged --limit 100 \
-            --json number,body,mergedAt \
+          # mergedAt itself. But a raw `--limit 100` is CREATION-capped: with
+          # ~100 merges/day it covers roughly one day of creations, so a
+          # low-activity lane's grain merged a few days ago falls out of the
+          # batch and the guard would silently fall back to the frozen `prev:`
+          # (#12636). Fetch through `fetch_merged_prs_since.py`, which pages the
+          # `merged:>=` window (merge-time, not creation) so any lane merged
+          # since the cutoff is captured. A fetch failure degrades to the
+          # declared `prev:` (the flag stays absent), never to a crash or a
+          # silent pass.
+          python3 scripts/ci/fetch_merged_prs_since.py --days 21 \
             > /tmp/merged_prs.json 2>/dev/null || rm -f /tmp/merged_prs.json
 
           MERGED_ARG=""
@@ -1038,9 +1044,10 @@ jobs:
           fi
 
           # Merged PRs for the lane's REAL predecessor (#12095) -- same
-          # plumbing as the pull_request job above.
-          gh pr list --state merged --limit 100 \
-            --json number,body,mergedAt \
+          # plumbing as the pull_request job above. `--limit 100` is
+          # creation-capped and misses a lane's grain merged a few days ago
+          # (#12636): page the merge-time window instead.
+          python3 scripts/ci/fetch_merged_prs_since.py --days 21 \
             > /tmp/merged_prs.json 2>/dev/null || rm -f /tmp/merged_prs.json
           MERGED_ARG=""
           if [ -s /tmp/merged_prs.json ]; then

--- a/scripts/ci/fetch_merged_prs_since.py
+++ b/scripts/ci/fetch_merged_prs_since.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+r"""fetch_merged_prs_since.py -- fetch merged PRs merged since a date (paginated).
+
+## Why
+
+The G-VAR-3 adjacency guard resolves a lane's REAL predecessor from the merged
+sequence (`variation_adjacency_guard.py --merged-prs-file`). The workflow used
+to fetch it with `gh pr list --state merged --limit 100`, which GitHub orders
+by CREATION date: with a fleet merging ~100 PRs/day, `--limit 100` covers
+roughly ONE DAY of creations, so a low-activity lane's grain merged a few days
+ago falls out of the batch and the guard silently falls back to the frozen
+`prev:` field -- the exact post-#12095 regression (#12636).
+
+Fetching with the `merged:>=` qualifier (merge-time, not creation) and
+paginating the window guarantees any lane that merged since the cutoff appears,
+whatever its creation date. The guard still sorts by mergedAt itself. A fetch
+failure emits nothing and exits nonzero, so the caller's `|| rm -f` degrades to
+the declared `prev:` (never a crash, never a silent pass).
+
+## Output
+
+A single JSON array on stdout:
+
+    [{"number": 123, "body": "...", "mergedAt": "2026-08-24T09:32:39Z"}, ...]
+
+## Usage
+
+    python3 scripts/ci/fetch_merged_prs_since.py --days 21 > /tmp/merged_prs.json
+    python3 scripts/ci/fetch_merged_prs_since.py --since 2026-08-01 > /tmp/merged_prs.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import date, timedelta
+
+# Default page cap: 40 pages x 100 = 4000 PRs, ~40 days at the observed ~100
+# merges/day. A lane merged within the window is captured; the guard sorts by
+# mergedAt. Cap is a safety net, not the normal path.
+MAX_PAGES = 40
+PAGE_SIZE = 100
+
+DEFAULT_DAYS = 21
+
+
+def since_date(days: int) -> str:
+    """Return the ISO cutoff ``today - days``."""
+    return (date.today() - timedelta(days=days)).isoformat()
+
+
+def run_gh(page: int, since: str) -> list[dict]:
+    """One page of merged PRs: ``gh pr list --state merged --search merged:>=since``.
+
+    Reached externally so tests can inject a fake ``gh``.
+    """
+    out = subprocess.run(
+        [
+            "gh", "pr", "list",
+            "--state", "merged",
+            "--search", f"merged:>={since}",
+            "--limit", str(PAGE_SIZE),
+            "--page", str(page),
+            "--json", "number,body,mergedAt",
+        ],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(out.stdout)
+
+
+def fetch(since: str, run=run_gh, max_pages: int = MAX_PAGES) -> list[dict]:
+    """Paginate the merged window ``[since, now]`` into a single PR list.
+
+    ``run`` is dependency-injected for tests; the default shells out to ``gh``.
+    Stops early on a short page (< PAGE_SIZE) or at ``max_pages``.
+    """
+    acc: list[dict] = []
+    seen: set[int] = set()
+    for page in range(1, max_pages + 1):
+        batch = run(page, since)
+        for pr in batch:
+            n = pr.get("number")
+            if n is not None and n not in seen:
+                seen.add(n)
+                acc.append(pr)
+        if len(batch) < PAGE_SIZE:
+            break
+    return acc
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--days", type=int, default=None,
+                   help=f"fetch PRs merged within the last N days (default {DEFAULT_DAYS})")
+    p.add_argument("--since", metavar="YYYY-MM-DD", default=None,
+                   help="fetch PRs merged on or after this date (overrides --days)")
+    args = p.parse_args(argv)
+
+    if args.since:
+        since = args.since
+    else:
+        since = since_date(args.days if args.days is not None else DEFAULT_DAYS)
+
+    try:
+        prs = fetch(since)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError) as e:
+        print(f"fetch_merged_prs_since: {e}", file=sys.stderr)
+        return 1
+
+    json.dump(prs, sys.stdout, ensure_ascii=False)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/variation_adjacency_guard.py
+++ b/scripts/ci/variation_adjacency_guard.py
@@ -422,17 +422,34 @@ def main(argv: list[str] | None = None) -> int:
                   file=sys.stderr)
 
     merged_prev = None
+    merged_fallback_note = None
     if args.merged_prs_file:
         try:
             with open(args.merged_prs_file, encoding="utf-8") as f:
                 merged_prs = json.load(f)
             g = gt.parse_grain_tag(body)
             merged_prev = resolve_merged_prev_genre(merged_prs, g["lane"] if g else None)
+            if merged_prev[0] is None and merged_prs:
+                # #12636: the merged window was fetched and is non-empty, but the
+                # lane has no grain in it. The guard falls back to the declared
+                # `prev:` -- that fallback must be VISIBLE, never silent (the
+                # pre-#12095 silent fallback is exactly the defect fixed here,
+                # and a window that misses the lane deserves a note, not a mute).
+                merged_fallback_note = (
+                    f"lane {g['lane'] if g else None} absente du window merge "
+                    f"({len(merged_prs)} PRs) -- predecesseur resolu depuis le "
+                    f"prev: declare (#12636)"
+                )
         except (OSError, ValueError) as e:
             print(json.dumps({"warning": f"merged-prs unreadable: {e}"}),
                   file=sys.stderr)
 
     verdict = check(body, override=override, merged_prev=merged_prev)
+    if merged_fallback_note:
+        verdict = dict(verdict)
+        verdict["prev_source"] = "declared"
+        verdict["prev_fallback"] = merged_fallback_note
+        verdict["reason"] = f"{verdict.get('reason', '')} {merged_fallback_note}".strip()
     print(json.dumps(verdict, ensure_ascii=False))
     return 0 if verdict["guard_pass"] else 1
 

--- a/scripts/tests/test_fetch_merged_prs_since.py
+++ b/scripts/tests/test_fetch_merged_prs_since.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Unit tests for fetch_merged_prs_since.py -- the merge-window fetcher (#12636).
+
+The G-VAR-3 adjacency guard resolves a lane's REAL predecessor from the merged
+sequence. The old fetch (`gh pr list --state merged --limit 100`) is ordered by
+CREATION date, so with ~100 merges/day it covers roughly one day of creations
+and a low-activity lane's grain merged a few days ago falls out of the batch
+(the pre-#12095 regression, #12636). This helper pages the `merged:>=` window
+(merge-time, not creation); these tests pin its pagination/dedup contract.
+
+Run:
+    python -m pytest scripts/tests/test_fetch_merged_prs_since.py
+"""
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+import fetch_merged_prs_since as fmps  # noqa: E402
+
+
+def _pr(n: int, merged_at: str) -> dict:
+    return {"number": n, "body": "some body", "mergedAt": merged_at}
+
+
+def test_since_date_default_and_days():
+    today = date.today()
+    assert fmps.since_date(0) == today.isoformat()
+    assert fmps.since_date(21) == (today - timedelta(days=21)).isoformat()
+
+
+def test_fetch_paginates_and_dedupes():
+    # Page 1 full, page 2 short -> both collected; a duplicate across pages dedupes.
+    calls = []
+
+    def fake_run(page, since):
+        calls.append(page)
+        if page == 1:
+            return [_pr(i, f"2026-08-{i:02d}T00:00:00Z") for i in range(1, fmps.PAGE_SIZE + 1)]
+        # short page carrying one duplicate of page-1's number 1
+        return [_pr(1, "dup"), _pr(fmps.PAGE_SIZE + 1, "2026-08-31T00:00:00Z")]
+
+    prs = fmps.fetch("2026-08-01", run=fake_run, max_pages=3)
+
+    assert calls == [1, 2]                 # stopped on the short page
+    nums = [p["number"] for p in prs]
+    assert len(nums) == fmps.PAGE_SIZE + 1  # no duplicate kept
+    assert 1 in nums and fmps.PAGE_SIZE + 1 in nums
+
+
+def test_fetch_stops_at_max_pages():
+    def fake_run(page, since):
+        return [_pr(i + page * fmps.PAGE_SIZE, f"2026-08-{(i % 28) + 1:02d}T00:00:00Z")
+                for i in range(1, fmps.PAGE_SIZE + 1)]
+
+    prs = fmps.fetch("2026-08-01", run=fake_run, max_pages=3)
+
+    assert len(prs) == fmps.PAGE_SIZE * 3


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #12596

Closes #12636.

## Why

The G-VAR-3 adjacency guard (`variation_adjacency_guard.py`) resolves a lane's
REAL predecessor from the merged sequence (`--merged-prs-file`). The workflow
fed it with:

```bash
gh pr list --state merged --limit 100 --json number,body,mergedAt
```

GitHub orders `gh pr list --state merged` by **creation** date. With a fleet
merging ~100 PR/day, `--limit 100` covers roughly **one day of creations** — so a
low-activity lane's grain merged a few days ago falls out of the batch, the
guard's `resolve_merged_prev_genre` finds nothing, and it silently falls back to
the frozen `prev:` field: the exact pre-#12095 regression (#12636).

`sorted by mergedAt` does not fix it — `--sort merged` is unsupported for `gh pr
list`, and filtering by `merged:>=` still returns the most recent **creations**,
not merges (verified empirically). The merge-time window must be **paginated**.

## What changed

1. **`scripts/ci/fetch_merged_prs_since.py`** (new) — pages the `merged:>=`
   (merge-time) window so any lane merged since the cutoff is captured whatever
   its creation date. `run_gh` is dependency-injected for tests. A fetch failure
   exits 1 so the caller's `|| rm -f` degrades to the declared `prev:` — never a
   crash, never a silent pass.
2. **`.github/workflows/variation-tag-guard.yml`** — both merged-PR fetch sites
   (pull_request job, the G-VAR-3 gate) now call
   `python3 scripts/ci/fetch_merged_prs_since.py --days 21` instead of the raw
   `--limit 100` fetch.
3. **`scripts/ci/variation_adjacency_guard.py`** — when the merged window is
   non-empty but the lane is absent from it, the guard used to fall back to an
   undeclared `prev:` silently. It now emits a `prev_fallback` note and reports
   `prev_source: declared`, making the fallback **visible** rather than silent
   (same defect class as `stale-zero-absence-vs-measure`).
4. **`scripts/tests/test_fetch_merged_prs_since.py`** (new) — pins the
   pagination/dedup contract (`since_date`, short-page stop, max-pages cap).

## Validation

```bash
python -m pytest scripts/tests/test_fetch_merged_prs_since.py \
  scripts/tests/test_variation_adjacency_guard.py -q
# 39 passed in 0.27s  (3 new + 36 existing)
```

The guard's fallback-trigger logic (non-empty window, lane absent → `(None,None)`,
then `prev_source: declared`) is covered by the existing
`test_merged_sequence_other_lane_ignored` / `test_no_merged_pr_falls_back_to_declared`.

## Note on tier/genre

`guard` is a META genre; this is a genuine defect fix (not a convenience guard),
verified by tests. It does not hold the G-VAR-1 CONTENU plancher on its own — it
is this cycle's substantive repair of a live bug.
