### PR TITLE
fix(nb,#12585): detect_code_in_markdown_cells --check desarme — baseline canonique par defaut + ligne identite

### DIFF
--- a/scripts/notebook_tools/detect_code_in_markdown_cells.py
+++ b/scripts/notebook_tools/detect_code_in_markdown_cells.py
@@ -140,6 +140,13 @@ def _finding_hash(f: dict[str, Any]) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
+# #12585 : le seul baseline du depot, celui que la CI passe explicitement.
+# Un --check desarme (aucun baseline charge) rend un FAIL fantome sur un main
+# vert -- toutes les violations acceptees ressortent « new ». Le default aligne
+# l'invocation locale sur l'invocation CI.
+DEFAULT_BASELINE = Path(__file__).resolve().parent / "code_in_markdown_cells_baseline.json"
+
+
 def load_baseline(path: Path) -> set[str]:
     if not path or not path.exists():
         return set()
@@ -450,7 +457,15 @@ def main(argv=None) -> int:
         print(f"baseline written: {len(hashes)} violations -> {args.baseline}")
         return 0
 
-    baseline = load_baseline(args.baseline) if args.baseline else set()
+    # #12585 : --check/--report/--json sans --baseline comparent au baseline
+    # canonique, pas a un ensemble vide. --update-baseline exige toujours son
+    # chemin explicitement (garde ci-dessus). L'identite de la reference est
+    # affichee : un baseline vide et un baseline plein ne doivent plus rendre
+    # la meme forme de verdict.
+    baseline_path = args.baseline if args.baseline else DEFAULT_BASELINE
+    baseline = load_baseline(baseline_path)
+    if not args.update_baseline:
+        print(f"baseline: {baseline_path} ({len(baseline)} entries)")
     new_findings = [f for f in findings
                     if _finding_hash(f) not in baseline] if baseline else findings
 

--- a/scripts/notebook_tools/tests/test_detect_code_in_markdown_cells.py
+++ b/scripts/notebook_tools/tests/test_detect_code_in_markdown_cells.py
@@ -188,6 +188,34 @@ def test_baseline_check_exits_zero_on_main():
     )
 
 
+def test_check_without_baseline_defaults_to_canonical_rc0():
+    """#12585 : ``--check`` SANS ``--baseline`` doit comparer au baseline
+    canonique du depot (celui que la CI passe), pas a un ensemble vide.
+    Avant le fix, l'invocation desarmee rendait un FAIL fantome sur un main
+    vert -- toutes les violations acceptees ressortaient « new ». Le test
+    existant passait le chemin explicitement, donc ne pouvait pas voir ce
+    defaut. Exige en outre la ligne d'identite qui nomme la reference."""
+    import subprocess
+    proc = subprocess.run(
+        [
+            sys.executable, str(TOOL),
+            "MyIA.AI.Notebooks",
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, (
+        f"bare --check exited {proc.returncode}\n"
+        f"stdout: {proc.stdout[:500]}\nstderr: {proc.stderr[:500]}"
+    )
+    assert "baseline:" in proc.stdout and "entries)" in proc.stdout, (
+        "l'identite de la reference doit etre affichee "
+        f"(baseline: <path> (<n> entries)); stdout: {proc.stdout[:300]}"
+    )
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2027:CoursIA — prev: MED/notebook-dotnet #12769

## #12585 — `--check` sans `--baseline` : le baseline canonique devient le défaut + ligne d'identité

`detect_code_in_markdown_cells.py --check` **sans** `--baseline` chargeait un ensemble vide et flaggait
toutes les violations acceptées comme « new » — FAIL fantôme sur un `main` vert. Mesuré firsthand sur
`main` d2be9dae871 avant le fix : bare `--check` = `FAIL: 2 new` (SemanticKernel-Advanced c3,
Pyro_RSA_Hyperbole c38) alors que `--check --baseline` = OK (les 2 hashes sont dans le baseline). Un zéro
de dénominateur qui se lit comme un plein de numérateur — une lane qui lance l'outil à la main pouvait
« corriger » des notebooks sains.

### Changements (option préférée de l'issue : aligner l'invocation locale sur la CI)

1. **`DEFAULT_BASELINE`** : `--check`/`--report`/`--json` sans `--baseline` comparent désormais au
   baseline canonique (`scripts/notebook_tools/code_in_markdown_cells_baseline.json`, le seul du dépôt,
   celui que la CI passe), résolu relativement au script (invocation depuis n'importe quel cwd).
2. **Ligne d'identité** : `baseline: <path> (<n> entries)` en tête de sortie — un baseline vide et un
   baseline plein ne rendent plus la même forme de verdict.
3. **`--update-baseline` inchangé** : il exige toujours `--baseline PATH` explicitement (garde RC=2
   préservée — le défaut ne s'applique qu'à la lecture).
4. **Test** (`test_check_without_baseline_defaults_to_canonical_rc0`) : bare `--check` sur le corpus →
   RC=0 + ligne d'identité présente — exactement le garde-fou demandé par l'acceptance (« le test
   existant passait le chemin explicitement, donc ne pouvait pas voir ce défaut »).

### Preuves

- **11/11 tests** passent (`test_detect_code_in_markdown_cells.py`, 10 existants + 1 nouveau), 0 régression.
- Bare `--check` sur le corpus : `baseline: ... (2 entries)` + `OK` + RC=0 (avant : FAIL + RC=1).
- `--check --baseline` explicite : OK + RC=0 (chemin CI inchangé).
- `--update-baseline` sans chemin : `error: --update-baseline requires --baseline PATH` RC=2 (inchangé).
- Aucun appelant CI/script du tool (grep dépôt) — l'identité additive ne casse aucun parseur ; l'outil
  est lancé à la main, précisément le scénario du défaut.

### Notes

- `Closes #12585` — l'acceptance est couverte intégralement (défaut baseline + ligne identité + test
  bare-invocation). La détection (#12064) et le contrat un-fenced (#12556) restent hors scope, conformes.
- Label `candidate-delivered` retiré sur l'issue avec preuve (défaut vivant mesuré, aucune PR mergée ne
  touche l'invocation) — commentaire 5396761784.
