### PR TITLE
fix(slides,#10950): tranche 9 axe 2 - convertir 3 two-cols en grid-cols-2 (S3-acculturation)

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -674,8 +674,6 @@ layout: default
 </div>
 </div>
 ---
-layout: two-cols
----
 
 
 
@@ -686,6 +684,8 @@ layout: two-cols
 <div class="bg-slate-800 text-white px-4 py-2 text-base font-bold text-center">Qu'est-ce qu'un argument ?</div>
 </div>
 
+<div class="grid grid-cols-2 gap-5 -mt-2">
+<div>
 
 **Code de conduite**
 
@@ -699,9 +699,8 @@ layout: two-cols
   - Suspension du jugement
   - Résolution
 
-
-::right::
-
+</div>
+<div>
 
 **Qu'est-ce qu'un argument?**
 
@@ -720,16 +719,16 @@ layout: two-cols
   - Légal  loi, jurisprudence etc.
   - Esthétique  critère
 
-
-
----
-layout: two-cols
+</div>
+</div>
 ---
 
 
 
 # Analyse rhétorique
 
+<div class="grid grid-cols-2 gap-5 -mt-2">
+<div>
 
 **Un bon argument**
 
@@ -746,9 +745,8 @@ layout: two-cols
 - Renforcer un argument
   - Balayer ces 5 critères
 
-
-::right::
-
+</div>
+<div>
 
 **Un argument fallacieux**
 
@@ -764,8 +762,8 @@ layout: two-cols
 
 </div>
 
-
-
+</div>
+</div>
 ---
 
 
@@ -946,13 +944,13 @@ layout: section
 </div>
 
 ---
-layout: two-cols
----
 
 
 
 # Réseaux bayésiens dynamiques
 
+<div class="grid grid-cols-2 gap-5 -mt-2">
+<div>
 
 **Chaînes de Markov**
 
@@ -970,9 +968,8 @@ layout: two-cols
 <img src="./images/img_057.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Réseau bayésien météo : soleil, nuages, pluie reliés par probabilités conditionnelles" />
 </div>
 
-
-::right::
-
+</div>
+<div>
 
 **Applications**
 
@@ -991,7 +988,8 @@ layout: two-cols
 
 </div>
 
-
+</div>
+</div>
 ---
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2023:CoursIA-2 — prev: MED/slides #12649

## Summary

Tranche 9 axe 2 (#10950) : conversion de 3 layouts `two-cols` en grille `grid grid-cols-2` dans `slides/S3-acculturation/slides.md` — suite directe des tranches 5-8 (#12371, #12548, #12608, #12649).

Slides converties :

1. **Application: argumentation** (avec conservation du bandeau header-strip `grid grid-cols-2 gap-0` au-dessus de la nouvelle grille)
2. **Analyse rhétorique**
3. **Réseaux bayésiens dynamiques**

Motif identique aux tranches précédentes : frontmatter `layout: two-cols` + séparateur `::right::` remplacés par `<div class="grid grid-cols-2 gap-5 -mt-2">` avec deux colonnes `<div>`.

## Validation

- **Diff** : `+18/−20`, 1 fichier (`slides/S3-acculturation/slides.md`), CRLF du blob préservé (diff limité aux segments modifiés, pas de normalisation massive)
- **Compteur two-cols** : 13 → 10 sur le deck
- **Build** : deck servi par Slidev 51.8.2 (dev server port 5199), rendu vérifié
- **QA visuel** : screenshots Playwright 1280×720 des 3 slides converties + slides adjacentes (36-40, 48-51) — deux colonnes nettes, bandeau préservé, aucun débordement horizontal ni vertical
- **Pre-commit** : 8/8 hooks passés

## Cumul axe 2

Tranches 5-9 livrées : 15 slides converties. Reste 10 `two-cols` sur `main`.

See #10950

Co-Authored-By: Claude-Code <noreply@anthropic.com>
