### PR TITLE
fix(notebooks,#11112): eval-choisir-son-modele sequence propre 1..10 (re-exec qwen3.6-35b-a3b)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/eval-choisir-son-modele.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/eval-choisir-son-modele.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "6364ca4a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003032,
+     "end_time": "2026-08-24T15:42:46.559282",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:46.556250",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Choisir le modèle derrière son chatbot — une mini-évaluation reproductible\n",
     "\n",
@@ -32,7 +41,16 @@
   {
    "cell_type": "markdown",
    "id": "2f792452",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002579,
+     "end_time": "2026-08-24T15:42:46.566290",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:46.563711",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Les quatre propriétés qu'on mesure, et pourquoi celles-là\n",
     "\n",
@@ -58,7 +76,16 @@
   {
    "cell_type": "markdown",
    "id": "0f384b65",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002024,
+     "end_time": "2026-08-24T15:42:46.570503",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:46.568479",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Configuration\n",
     "\n",
@@ -84,20 +111,28 @@
    "id": "0b95b463",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T13:50:03.746264Z",
-     "iopub.status.busy": "2026-08-07T13:50:03.746264Z",
-     "iopub.status.idle": "2026-08-07T13:50:03.762774Z",
-     "shell.execute_reply": "2026-08-07T13:50:03.761708Z"
-    }
+     "iopub.execute_input": "2026-08-24T15:42:46.576366Z",
+     "iopub.status.busy": "2026-08-24T15:42:46.575812Z",
+     "iopub.status.idle": "2026-08-24T15:42:46.589584Z",
+     "shell.execute_reply": "2026-08-24T15:42:46.588662Z"
+    },
+    "papermill": {
+     "duration": 0.017893,
+     "end_time": "2026-08-24T15:42:46.590546",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:46.572653",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BASE_URL : http://<adresse-IP-privee><:port>/v1\n",
+      "BASE_URL : http://<nom-d-hote><:port>/v1\n",
       "API_KEY  : chargee (32 caracteres)\n",
-      "MODEL    : <sera deduit de /v1/models>\n"
+      "MODEL    : qwen3.6-35b-a3b\n"
      ]
     }
    ],
@@ -146,11 +181,19 @@
    "id": "f795d8b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T13:50:03.765411Z",
-     "iopub.status.busy": "2026-08-07T13:50:03.764893Z",
-     "iopub.status.idle": "2026-08-07T13:50:08.883133Z",
-     "shell.execute_reply": "2026-08-07T13:50:08.882606Z"
-    }
+     "iopub.execute_input": "2026-08-24T15:42:46.595913Z",
+     "iopub.status.busy": "2026-08-24T15:42:46.595490Z",
+     "iopub.status.idle": "2026-08-24T15:42:53.123953Z",
+     "shell.execute_reply": "2026-08-24T15:42:53.122757Z"
+    },
+    "papermill": {
+     "duration": 6.532666,
+     "end_time": "2026-08-24T15:42:53.125357",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:46.592691",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -160,9 +203,9 @@
       "modele        : qwen3.6-35b-a3b\n",
       "contenu       : '2+2 font 4.'\n",
       "finish_reason : stop\n",
-      "tokens generes: 307\n",
-      "raisonnement  : OUI (956 caracteres caches)\n",
-      "aller-retour  : 3.62 s\n"
+      "tokens generes: 435\n",
+      "raisonnement  : OUI (1369 caracteres caches)\n",
+      "aller-retour  : 4.99 s\n"
      ]
     }
    ],
@@ -200,7 +243,16 @@
   {
    "cell_type": "markdown",
    "id": "c0384815",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002767,
+     "end_time": "2026-08-24T15:42:53.131144",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:53.128377",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Le corpus fictif et les scénarios\n",
     "\n",
@@ -221,11 +273,19 @@
    "id": "ed741bdf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T13:50:08.886817Z",
-     "iopub.status.busy": "2026-08-07T13:50:08.886299Z",
-     "iopub.status.idle": "2026-08-07T13:50:08.897524Z",
-     "shell.execute_reply": "2026-08-07T13:50:08.896456Z"
-    }
+     "iopub.execute_input": "2026-08-24T15:42:53.138016Z",
+     "iopub.status.busy": "2026-08-24T15:42:53.137507Z",
+     "iopub.status.idle": "2026-08-24T15:42:53.148590Z",
+     "shell.execute_reply": "2026-08-24T15:42:53.148032Z"
+    },
+    "papermill": {
+     "duration": 0.016176,
+     "end_time": "2026-08-24T15:42:53.149933",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:53.133757",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -307,11 +367,19 @@
    "id": "fe91780d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T13:50:08.900724Z",
-     "iopub.status.busy": "2026-08-07T13:50:08.900200Z",
-     "iopub.status.idle": "2026-08-07T13:50:08.911257Z",
-     "shell.execute_reply": "2026-08-07T13:50:08.910208Z"
-    }
+     "iopub.execute_input": "2026-08-24T15:42:53.156749Z",
+     "iopub.status.busy": "2026-08-24T15:42:53.156450Z",
+     "iopub.status.idle": "2026-08-24T15:42:53.163946Z",
+     "shell.execute_reply": "2026-08-24T15:42:53.163019Z"
+    },
+    "papermill": {
+     "duration": 0.011967,
+     "end_time": "2026-08-24T15:42:53.165163",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:53.153196",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -403,7 +471,16 @@
   {
    "cell_type": "markdown",
    "id": "ex1-md-2161",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002423,
+     "end_time": "2026-08-24T15:42:53.170460",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:53.168037",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 — Écrire un validateur pour une propriété non couverte\n",
     "\n",
@@ -431,9 +508,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "ex1-code-2161",
-   "metadata": {},
-   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T15:42:53.178576Z",
+     "iopub.status.busy": "2026-08-24T15:42:53.178262Z",
+     "iopub.status.idle": "2026-08-24T15:42:53.182877Z",
+     "shell.execute_reply": "2026-08-24T15:42:53.181753Z"
+    },
+    "papermill": {
+     "duration": 0.010335,
+     "end_time": "2026-08-24T15:42:53.184109",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:53.173774",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def v_concision(rep, _tc):\n",
@@ -451,7 +543,16 @@
   {
    "cell_type": "markdown",
    "id": "e74ebe08",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003044,
+     "end_time": "2026-08-24T15:42:53.189973",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:53.186929",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Deux pièges rencontrés en écrivant ce notebook\n",
     "\n",
@@ -521,7 +622,7 @@
     "> C'est la raison d'être de la colonne `extrait` dans les résultats — un banc\n",
     "> qui ne conserve pas les réponses brutes ne se débogue pas.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Exécution\n",
     "\n",
@@ -536,120 +637,128 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "23ad81c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T13:50:08.914410Z",
-     "iopub.status.busy": "2026-08-07T13:50:08.914410Z",
-     "iopub.status.idle": "2026-08-07T13:51:58.662712Z",
-     "shell.execute_reply": "2026-08-07T13:51:58.661587Z"
-    }
+     "iopub.execute_input": "2026-08-24T15:42:53.196814Z",
+     "iopub.status.busy": "2026-08-24T15:42:53.196176Z",
+     "iopub.status.idle": "2026-08-24T15:44:31.423086Z",
+     "shell.execute_reply": "2026-08-24T15:44:31.421593Z"
+    },
+    "papermill": {
+     "duration": 98.232063,
+     "end_time": "2026-08-24T15:44:31.424671",
+     "exception": false,
+     "start_time": "2026-08-24T15:42:53.192608",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ancrage_present  rep 1/3  PASS      3.86s   332 tok  fin=stop\n"
+      "  ancrage_present  rep 1/3  PASS      2.89s   319 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ancrage_present  rep 2/3  PASS      7.14s   611 tok  fin=stop\n"
+      "  ancrage_present  rep 2/3  PASS      3.30s   364 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ancrage_present  rep 3/3  PASS      4.13s   362 tok  fin=stop\n"
+      "  ancrage_present  rep 3/3  PASS      7.75s   879 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ancrage_absent   rep 1/3  PASS      8.64s   794 tok  fin=stop\n"
+      "  ancrage_absent   rep 1/3  PASS      9.49s  1088 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ancrage_absent   rep 2/3  PASS      6.15s   533 tok  fin=stop\n"
+      "  ancrage_absent   rep 2/3  PASS      8.27s   944 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ancrage_absent   rep 3/3  PASS      5.95s   540 tok  fin=stop\n"
+      "  ancrage_absent   rep 3/3  PASS      4.51s   505 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  format_json      rep 1/3  PASS     12.89s  1216 tok  fin=stop\n"
+      "  format_json      rep 1/3  PASS      8.41s   949 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  format_json      rep 2/3  PASS     12.50s  1148 tok  fin=stop\n"
+      "  format_json      rep 2/3  PASS     10.83s  1226 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  format_json      rep 3/3  PASS     13.16s  1230 tok  fin=stop\n"
+      "  format_json      rep 3/3  PASS     10.70s  1209 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  langue_fr        rep 1/3  PASS      8.42s   748 tok  fin=stop\n"
+      "  langue_fr        rep 1/3  PASS      9.35s  1067 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  langue_fr        rep 2/3  PASS     10.58s   948 tok  fin=stop\n"
+      "  langue_fr        rep 2/3  PASS      4.73s   537 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  langue_fr        rep 3/3  PASS     10.29s   964 tok  fin=stop\n"
+      "  langue_fr        rep 3/3  PASS     13.82s  1600 tok  fin=stop\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  appel_outil      rep 1/3  PASS      2.31s   200 tok  fin=tool_calls\n"
+      "  appel_outil      rep 1/3  PASS      1.42s   158 tok  fin=tool_calls\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  appel_outil      rep 2/3  PASS      2.33s   210 tok  fin=tool_calls\n"
+      "  appel_outil      rep 2/3  PASS      2.20s   250 tok  fin=tool_calls\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  appel_outil      rep 3/3  PASS      1.37s   102 tok  fin=tool_calls\n",
+      "  appel_outil      rep 3/3  PASS      0.56s    56 tok  fin=tool_calls\n",
       "\n",
       "15 appels effectues.\n"
      ]
@@ -706,15 +815,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "14579731",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T13:51:58.665879Z",
-     "iopub.status.busy": "2026-08-07T13:51:58.665359Z",
-     "iopub.status.idle": "2026-08-07T13:51:59.416452Z",
-     "shell.execute_reply": "2026-08-07T13:51:59.415931Z"
-    }
+     "iopub.execute_input": "2026-08-24T15:44:31.432644Z",
+     "iopub.status.busy": "2026-08-24T15:44:31.432364Z",
+     "iopub.status.idle": "2026-08-24T15:44:33.453334Z",
+     "shell.execute_reply": "2026-08-24T15:44:33.452588Z"
+    },
+    "papermill": {
+     "duration": 2.027114,
+     "end_time": "2026-08-24T15:44:33.454853",
+     "exception": false,
+     "start_time": "2026-08-24T15:44:31.427739",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -758,8 +875,8 @@
        "      <td>3</td>\n",
        "      <td>0</td>\n",
        "      <td>100</td>\n",
-       "      <td>6.15</td>\n",
-       "      <td>540.0</td>\n",
+       "      <td>8.27</td>\n",
+       "      <td>944.0</td>\n",
        "      <td>ACQUIS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -770,8 +887,8 @@
        "      <td>3</td>\n",
        "      <td>0</td>\n",
        "      <td>100</td>\n",
-       "      <td>4.13</td>\n",
-       "      <td>362.0</td>\n",
+       "      <td>3.30</td>\n",
+       "      <td>364.0</td>\n",
        "      <td>ACQUIS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -782,8 +899,8 @@
        "      <td>3</td>\n",
        "      <td>0</td>\n",
        "      <td>100</td>\n",
-       "      <td>2.31</td>\n",
-       "      <td>200.0</td>\n",
+       "      <td>1.42</td>\n",
+       "      <td>158.0</td>\n",
        "      <td>ACQUIS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -794,8 +911,8 @@
        "      <td>3</td>\n",
        "      <td>0</td>\n",
        "      <td>100</td>\n",
-       "      <td>12.89</td>\n",
-       "      <td>1216.0</td>\n",
+       "      <td>10.70</td>\n",
+       "      <td>1209.0</td>\n",
        "      <td>ACQUIS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -806,8 +923,8 @@
        "      <td>3</td>\n",
        "      <td>0</td>\n",
        "      <td>100</td>\n",
-       "      <td>10.29</td>\n",
-       "      <td>948.0</td>\n",
+       "      <td>9.35</td>\n",
+       "      <td>1067.0</td>\n",
        "      <td>ACQUIS</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -823,14 +940,14 @@
        "4        langue_fr         Stabilite de langue          3        3          0   \n",
        "\n",
        "   taux_pct  sec_med  tok_med verdict  \n",
-       "0       100     6.15    540.0  ACQUIS  \n",
-       "1       100     4.13    362.0  ACQUIS  \n",
-       "2       100     2.31    200.0  ACQUIS  \n",
-       "3       100    12.89   1216.0  ACQUIS  \n",
-       "4       100    10.29    948.0  ACQUIS  "
+       "0       100     8.27    944.0  ACQUIS  \n",
+       "1       100     3.30    364.0  ACQUIS  \n",
+       "2       100     1.42    158.0  ACQUIS  \n",
+       "3       100    10.70   1209.0  ACQUIS  \n",
+       "4       100     9.35   1067.0  ACQUIS  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -871,15 +988,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "e5afefc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T13:51:59.419122Z",
-     "iopub.status.busy": "2026-08-07T13:51:59.419122Z",
-     "iopub.status.idle": "2026-08-07T13:51:59.430811Z",
-     "shell.execute_reply": "2026-08-07T13:51:59.430301Z"
-    }
+     "iopub.execute_input": "2026-08-24T15:44:33.470254Z",
+     "iopub.status.busy": "2026-08-24T15:44:33.469765Z",
+     "iopub.status.idle": "2026-08-24T15:44:33.479874Z",
+     "shell.execute_reply": "2026-08-24T15:44:33.478785Z"
+    },
+    "papermill": {
+     "duration": 0.014999,
+     "end_time": "2026-08-24T15:44:33.480983",
+     "exception": false,
+     "start_time": "2026-08-24T15:44:33.465984",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -891,7 +1016,7 @@
       "  INSTABLE   : 0/5\n",
       "  ECHEC      : 0/5\n",
       "  NON MESURE : 0/5\n",
-      "  latence mediane  : 7.14 s\n",
+      "  latence mediane  : 7.75 s\n",
       "  mesures invalides: 0/15\n",
       "\n",
       "Les cinq proprietes sont acquises sur ce banc.\n"
@@ -922,7 +1047,16 @@
   {
    "cell_type": "markdown",
    "id": "18053026",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003761,
+     "end_time": "2026-08-24T15:44:33.487467",
+     "exception": false,
+     "start_time": "2026-08-24T15:44:33.483706",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Lire le tableau\n",
     "\n",
@@ -985,7 +1119,16 @@
   {
    "cell_type": "markdown",
    "id": "ex2-md-2161",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005428,
+     "end_time": "2026-08-24T15:44:33.498052",
+     "exception": false,
+     "start_time": "2026-08-24T15:44:33.492624",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 — Durcir un cas : une réponse voisine mais fausse\n",
     "\n",
@@ -1013,9 +1156,24 @@
   },
   {
    "cell_type": "code",
-   "id": "ex2-code-2161",
-   "metadata": {},
    "execution_count": 9,
+   "id": "ex2-code-2161",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T15:44:33.509644Z",
+     "iopub.status.busy": "2026-08-24T15:44:33.509177Z",
+     "iopub.status.idle": "2026-08-24T15:44:33.513565Z",
+     "shell.execute_reply": "2026-08-24T15:44:33.512656Z"
+    },
+    "papermill": {
+     "duration": 0.012091,
+     "end_time": "2026-08-24T15:44:33.515110",
+     "exception": false,
+     "start_time": "2026-08-24T15:44:33.503019",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Exercice 2 -- un scenario \"voisin mais faux\".\n",
@@ -1036,7 +1194,16 @@
   {
    "cell_type": "markdown",
    "id": "c962a6a7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005113,
+     "end_time": "2026-08-24T15:44:33.525012",
+     "exception": false,
+     "start_time": "2026-08-24T15:44:33.519899",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Transposition à AI-Engine (et à Open WebUI)\n",
     "\n",
@@ -1080,7 +1247,16 @@
   {
    "cell_type": "markdown",
    "id": "ex3-md-2161",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004178,
+     "end_time": "2026-08-24T15:44:33.534353",
+     "exception": false,
+     "start_time": "2026-08-24T15:44:33.530175",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 — Du verdict au levier de plateforme\n",
     "\n",
@@ -1105,9 +1281,24 @@
   },
   {
    "cell_type": "code",
-   "id": "ex3-code-2161",
-   "metadata": {},
    "execution_count": 10,
+   "id": "ex3-code-2161",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T15:44:33.546180Z",
+     "iopub.status.busy": "2026-08-24T15:44:33.545784Z",
+     "iopub.status.idle": "2026-08-24T15:44:33.550173Z",
+     "shell.execute_reply": "2026-08-24T15:44:33.549194Z"
+    },
+    "papermill": {
+     "duration": 0.012385,
+     "end_time": "2026-08-24T15:44:33.551667",
+     "exception": false,
+     "start_time": "2026-08-24T15:44:33.539282",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def levier_pour(propriete, verdict):\n",
@@ -1128,7 +1319,16 @@
   {
    "cell_type": "markdown",
    "id": "ae401718",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005962,
+     "end_time": "2026-08-24T15:44:33.563070",
+     "exception": false,
+     "start_time": "2026-08-24T15:44:33.557108",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Voir aussi\n",
     "\n",
@@ -1143,6 +1343,22 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "local",
+   "api_usd_est": 0.0,
+   "cpu_min": 10,
+   "external_account": "self",
+   "free_alternative": "self",
+   "gpu_required": false,
+   "metadata_written": "2026-08-09T00:00Z",
+   "network": true,
+   "notes": "Local OpenAI-compatible endpoint (EVAL_BASE_URL env var). Default targets vLLM/Ollama/local — free; user may override EVAL_BASE_URL to OpenAI/Anthropic cloud (paid) but must set api_usd_est accordingly. api_usd_est=0 sentinel for env-driven local default.",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual",
+   "vram_gb": null,
+   "vram_tier": null
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -1158,23 +1374,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.3"
   },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "local",
-   "cpu_min": 10,
-   "gpu_required": false,
-   "network": true,
-   "external_account": "self",
-   "free_alternative": "self",
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-08-09T00:00Z",
-   "validator": "manual",
-   "vram_gb": null,
-   "vram_tier": null,
-   "notes": "Local OpenAI-compatible endpoint (EVAL_BASE_URL env var). Default targets vLLM/Ollama/local — free; user may override EVAL_BASE_URL to OpenAI/Anthropic cloud (paid) but must set api_usd_est accordingly. api_usd_est=0 sentinel for env-driven local default."
+  "papermill": {
+   "default_parameters": {},
+   "duration": 110.097839,
+   "end_time": "2026-08-24T15:44:34.137596",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "eval-choisir-son-modele.ipynb",
+   "output_path": "eval-choisir-son-modele.out.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-24T15:42:44.039757",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/slides #12781

## Summary

Tranche résiduelle étage 3 de #11112 : re-exécution complète de `GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/eval-choisir-son-modele.ipynb`, dernier DIRTY CPU du rollout, désigné lane naturelle par le diagnostic po-2025 du 2026-08-23T10:43Z (« lane po-2023 stack + clés »).

- **Séquence** : `[1,2,3,4,8,5,6,7,9,10]` → **`1..10`** (check_exec_sequence : 0 DUPLICATE, 0 UNORDERED, 0 NOT_FROM_1, 0 GAP)
- **Modèle identique aux outputs précédents** : `qwen3.6-35b-a3b`, servi par l'endpoint vLLM ai-01:5002 (VIVANT) — le blocage RECOVERABLE-MACHINE constaté par po-2025 (endpoint localhost:8000 éteint chez eux, aucune clé TGWUI) est levé par cette lane : port 5002 joignable depuis po-2023, clé VLLM présente dans `.secrets/master.env`
- **Aucun contournement** : pas de changement de modèle/endpoint pédagogique (OpenRouter écarté à juste titre par po-2025), le banc évalue le même modèle que la run committée d'origine

## Validation

- **Papermill 2.6.0**, kernel python3, cwd = dir du notebook (`.env` gitignored, effacé après run) — 21/21 cellules, 1 min 50 s
- **0 erreur** d'exécution ; sources inchangées (le diff = execution_counts + outputs + metadata papermill, convention en vigueur sur main)
- **0 leak** : `detect_papermill_path_leak.py --scan` = `[]` ; le masquage propre du notebook tient dans les outputs (URL masquée `<nom-d-hote><:port>`, clé jamais affichée) ; seule occurrence « jsboi » = URL GitHub légitime issue #9734 dans une source inchangée
- **Pre-commit** : 8/8 passés (1 séparateur `---`→`***` auto-fixé par le hook markdown-rendering, convention repo)
- **Line endings** : blob LF préservé (0 CR dans le fichier committé, ré-écrit en bytes LF après dump — c.423-L1)
- **Verdict du banc** (outputs réels, 15 mesures, 0 invalide) : `ACQUIS 5/5, INSTABLE 0/5, ECHEC 0/5` — latence médiane 7,75 s

## Cumul étage 3

Rollout #11112 : 126 DIRTY (référence) → 8 restants (diagnostic 2026-08-23) → **7 après cette PR**. Les 7 restants : 6 notebooks stack Forge/ComfyUI/vLLM-image (`GenAI/Image/01-4`, `01-5`, `02-4`, `04-1/04-2/04-3`) + 1 training GPU interdit non supervisé (`PT_11_grpo_qwen35_rlvr`) — tous GPU/stack-bound, hors CPU.

See #11112

Co-Authored-By: Claude-Code <noreply@anthropic.com>
