### PR TITLE
feat(ci,#12704): enforce self-hosted runner isolation policy

### DIFF
--- a/.github/workflows/fast-lane-shadow.yml
+++ b/.github/workflows/fast-lane-shadow.yml
@@ -47,7 +47,7 @@ concurrency:
 
 jobs:
   fast-lane:
-    name: "Fast lane (ombre) -- 9 gardes, 1 checkout"
+    name: "Fast lane (ombre) -- 10 gardes, 1 checkout"
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -67,6 +67,10 @@ on:
       # its own subject (#10416 pattern, flagged A2 by Hermes on #11845).
       # Mirrored under pull_request: below.
       - '.github/workflows/pr-gate-rerun.yml'
+      # #12704 self-hosted policy: fork PR tokens cannot publish the fast-lane
+      # check-runs. Keep one ordinary CI surface that executes the scanner for
+      # every workflow change, including workflow-only PRs from forks.
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
     paths:
@@ -92,6 +96,8 @@ on:
       - 'MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/syllable_pitch.py'
       # #11835 no-op guard (mirror of the push path above).
       - '.github/workflows/pr-gate-rerun.yml'
+      # Mirror the push path above so fork workflow-only PRs execute the policy.
+      - '.github/workflows/**'
   workflow_dispatch:
 
 permissions:

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -44,9 +45,9 @@ GITHUB_HOSTED_LABELS = {
     "macos-14",
     "macos-13",
 }
-SAME_REPO_REUSABLE_PREFIXES = (
-    "./.github/workflows/",
-    "jsboige/CoursIA/.github/workflows/",
+LOCAL_REUSABLE_PREFIX = "./.github/workflows/"
+SAME_REPO_REUSABLE_PATTERN = re.compile(
+    r"^jsboige/CoursIA/\.github/workflows/[^@]+@(?:main|[0-9a-fA-F]{40})$"
 )
 SAME_REPO_GUARD = (
     "github.event.pull_request.head.repo.full_name == github.repository"
@@ -203,12 +204,17 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
 
             if "uses" in job:
                 reusable = str(job["uses"])
-                if not reusable.startswith(SAME_REPO_REUSABLE_PREFIXES):
+                is_local = reusable.startswith(LOCAL_REUSABLE_PREFIX)
+                is_auditable_same_repo = bool(
+                    SAME_REPO_REUSABLE_PATTERN.fullmatch(reusable)
+                )
+                if not is_local and not is_auditable_same_repo:
                     violations.append(Violation(
                         path.name,
                         str(job_name),
                         "REMOTE_REUSABLE_WORKFLOW",
-                        "reusable workflow must be pinned to jsboige/CoursIA or local",
+                        "reusable workflow must be local or pin jsboige/CoursIA "
+                        "to main or a 40-character commit SHA",
                     ))
                 continue
 

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -28,7 +28,22 @@ EXIT_BROKEN = 2
 
 REQUIRED_GROUP = "coursia-ephemeral"
 REQUIRED_LABELS = {"self-hosted", "coursia-ephemeral"}
-GITHUB_HOSTED_PREFIXES = ("ubuntu-", "windows-", "macos-")
+GITHUB_HOSTED_LABELS = {
+    "ubuntu-latest",
+    "ubuntu-24.04",
+    "ubuntu-22.04",
+    "ubuntu-20.04",
+    "ubuntu-slim",
+    "windows-latest",
+    "windows-2025",
+    "windows-2022",
+    "windows-2019",
+    "macos-latest",
+    "macos-26",
+    "macos-15",
+    "macos-14",
+    "macos-13",
+}
 SAME_REPO_REUSABLE_PREFIXES = (
     "./.github/workflows/",
     "jsboige/CoursIA/.github/workflows/",
@@ -106,8 +121,7 @@ def _contains_expression(value: Any) -> bool:
 
 
 def _is_github_hosted_label(label: str) -> bool:
-    lowered = label.lower()
-    return lowered.startswith(GITHUB_HOSTED_PREFIXES)
+    return label.lower() in GITHUB_HOSTED_LABELS
 
 
 def _runner_selection(runs_on: Any) -> tuple[bool, str | None, set[str]]:

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -28,6 +28,11 @@ EXIT_BROKEN = 2
 
 REQUIRED_GROUP = "coursia-ephemeral"
 REQUIRED_LABELS = {"self-hosted", "coursia-ephemeral"}
+GITHUB_HOSTED_PREFIXES = ("ubuntu-", "windows-", "macos-")
+SAME_REPO_REUSABLE_PREFIXES = (
+    "./.github/workflows/",
+    "jsboige/CoursIA/.github/workflows/",
+)
 SAME_REPO_GUARD = (
     "github.event.pull_request.head.repo.full_name == github.repository"
 )
@@ -100,23 +105,39 @@ def _contains_expression(value: Any) -> bool:
     return False
 
 
+def _is_github_hosted_label(label: str) -> bool:
+    lowered = label.lower()
+    return lowered.startswith(GITHUB_HOSTED_PREFIXES)
+
+
 def _runner_selection(runs_on: Any) -> tuple[bool, str | None, set[str]]:
-    """Return (is_self_hosted, group, labels) for a static selection."""
+    """Return (is_self_hosted, group, labels) for a static selection.
+
+    Any explicit runner group is self-hosted. A scalar/list label is considered
+    GitHub-hosted only when every value names a documented hosted-image family;
+    custom labels route to self-hosted runners even when the implicit
+    ``self-hosted`` label is omitted from the workflow.
+    """
     if isinstance(runs_on, str):
-        return runs_on == "self-hosted", None, {runs_on}
+        labels = {runs_on.lower()}
+        return not _is_github_hosted_label(runs_on), None, labels
     if isinstance(runs_on, list):
-        labels = {str(item) for item in runs_on}
-        return "self-hosted" in labels, None, labels
+        labels = {str(item).lower() for item in runs_on}
+        is_self_hosted = any(not _is_github_hosted_label(item) for item in labels)
+        return is_self_hosted, None, labels
     if isinstance(runs_on, dict):
         group = runs_on.get("group")
         raw_labels = runs_on.get("labels", [])
         if isinstance(raw_labels, str):
-            labels = {raw_labels}
+            labels = {raw_labels.lower()}
         elif isinstance(raw_labels, list):
-            labels = {str(item) for item in raw_labels}
+            labels = {str(item).lower() for item in raw_labels}
         else:
             labels = set()
-        return "self-hosted" in labels, str(group) if group is not None else None, labels
+        is_self_hosted = group is not None or any(
+            not _is_github_hosted_label(item) for item in labels
+        )
+        return is_self_hosted, str(group) if group is not None else None, labels
     return False, None, set()
 
 
@@ -164,9 +185,19 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
             if not isinstance(job, dict):
                 broken.append(f"{path.name}:{job_name}: job is not a mapping")
                 continue
-            if "uses" in job:
-                continue
             jobs_scanned += 1
+
+            if "uses" in job:
+                reusable = str(job["uses"])
+                if not reusable.startswith(SAME_REPO_REUSABLE_PREFIXES):
+                    violations.append(Violation(
+                        path.name,
+                        str(job_name),
+                        "REMOTE_REUSABLE_WORKFLOW",
+                        "reusable workflow must be pinned to jsboige/CoursIA or local",
+                    ))
+                continue
+
             runs_on = job.get("runs-on")
             if runs_on is None:
                 broken.append(f"{path.name}:{job_name}: missing runs-on")
@@ -192,6 +223,20 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
                     str(job_name),
                     "PULL_REQUEST_TARGET",
                     "pull_request_target must never reach a self-hosted runner",
+                ))
+            if "workflow_run" in triggers:
+                violations.append(Violation(
+                    path.name,
+                    str(job_name),
+                    "WORKFLOW_RUN",
+                    "workflow_run artifacts must never reach a self-hosted runner",
+                ))
+            if "workflow_call" in triggers:
+                violations.append(Violation(
+                    path.name,
+                    str(job_name),
+                    "REUSABLE_SELF_HOSTED",
+                    "self-hosted jobs must not hide inside reusable workflows",
                 ))
 
             if group != REQUIRED_GROUP:

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Enforce the isolation policy for future self-hosted Actions jobs (#12704).
+
+The repository is public. A self-hosted job that can receive a fork payload can
+execute untrusted code next to the cluster's credentials. This scanner therefore
+fails closed: every self-hosted job must use the dedicated runner group and
+label, and every pull_request job must carry the exact same-repository guard.
+Dynamic ``runs-on`` expressions are rejected because their target cannot be
+proved statically.
+
+Exit codes:
+  0  policy satisfied (including the explicit baseline of zero self-hosted jobs)
+  1  policy violation
+  2  broken instrument or unreadable workflow
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+EXIT_OK = 0
+EXIT_VIOLATION = 1
+EXIT_BROKEN = 2
+
+REQUIRED_GROUP = "coursia-ephemeral"
+REQUIRED_LABELS = {"self-hosted", "coursia-ephemeral"}
+SAME_REPO_GUARD = (
+    "github.event.pull_request.head.repo.full_name == github.repository"
+)
+DEFAULT_WORKFLOWS_DIR = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+
+@dataclass(frozen=True)
+class Violation:
+    workflow: str
+    job: str
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    workflows_scanned: int
+    jobs_scanned: int
+    self_hosted_jobs: int
+    violations: list[Violation]
+    broken: list[str]
+
+
+def _load_yaml():
+    try:
+        import yaml
+    except ImportError:
+        return None
+    return yaml
+
+
+def _parse_workflow(text: str, yaml: Any) -> dict[str, Any] | None:
+    """Parse Actions YAML while preserving the top-level ``on`` key."""
+    lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("on:") and (
+            len(line) == 3 or line[3] in (" ", "[", "\t")
+        ):
+            lines.append('"on":' + line[3:])
+        else:
+            lines.append(line)
+    try:
+        data = yaml.safe_load("\n".join(lines))
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _triggers(data: dict[str, Any]) -> set[str]:
+    value = data.get("on", data.get(True))
+    if isinstance(value, dict):
+        return {str(item) for item in value}
+    if isinstance(value, list):
+        return {str(item) for item in value}
+    if isinstance(value, str):
+        return {value}
+    return set()
+
+
+def _contains_expression(value: Any) -> bool:
+    if isinstance(value, str):
+        return "${{" in value
+    if isinstance(value, list):
+        return any(_contains_expression(item) for item in value)
+    if isinstance(value, dict):
+        return any(
+            _contains_expression(key) or _contains_expression(item)
+            for key, item in value.items()
+        )
+    return False
+
+
+def _runner_selection(runs_on: Any) -> tuple[bool, str | None, set[str]]:
+    """Return (is_self_hosted, group, labels) for a static selection."""
+    if isinstance(runs_on, str):
+        return runs_on == "self-hosted", None, {runs_on}
+    if isinstance(runs_on, list):
+        labels = {str(item) for item in runs_on}
+        return "self-hosted" in labels, None, labels
+    if isinstance(runs_on, dict):
+        group = runs_on.get("group")
+        raw_labels = runs_on.get("labels", [])
+        if isinstance(raw_labels, str):
+            labels = {raw_labels}
+        elif isinstance(raw_labels, list):
+            labels = {str(item) for item in raw_labels}
+        else:
+            labels = set()
+        return "self-hosted" in labels, str(group) if group is not None else None, labels
+    return False, None, set()
+
+
+def _normalise_condition(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    condition = value.strip()
+    if condition.startswith("${{") and condition.endswith("}}"):
+        condition = condition[3:-2].strip()
+    return " ".join(condition.split())
+
+
+def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
+    yaml = _load_yaml()
+    if yaml is None:
+        return ScanResult(0, 0, 0, [], ["PyYAML is unavailable"])
+
+    paths = sorted([*workflows_dir.glob("*.yml"), *workflows_dir.glob("*.yaml")])
+    if not paths:
+        return ScanResult(0, 0, 0, [], [f"no workflows in {workflows_dir}"])
+
+    violations: list[Violation] = []
+    broken: list[str] = []
+    jobs_scanned = 0
+    self_hosted_jobs = 0
+
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            broken.append(f"{path.name}: cannot read: {exc}")
+            continue
+        data = _parse_workflow(text, yaml)
+        if data is None:
+            broken.append(f"{path.name}: invalid workflow YAML")
+            continue
+
+        triggers = _triggers(data)
+        jobs = data.get("jobs", {})
+        if not isinstance(jobs, dict):
+            broken.append(f"{path.name}: jobs is not a mapping")
+            continue
+
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                broken.append(f"{path.name}:{job_name}: job is not a mapping")
+                continue
+            if "uses" in job:
+                continue
+            jobs_scanned += 1
+            runs_on = job.get("runs-on")
+            if runs_on is None:
+                broken.append(f"{path.name}:{job_name}: missing runs-on")
+                continue
+
+            if _contains_expression(runs_on):
+                violations.append(Violation(
+                    path.name,
+                    str(job_name),
+                    "DYNAMIC_RUNS_ON",
+                    "runs-on contains an expression and cannot be audited statically",
+                ))
+                continue
+
+            is_self_hosted, group, labels = _runner_selection(runs_on)
+            if not is_self_hosted:
+                continue
+            self_hosted_jobs += 1
+
+            if "pull_request_target" in triggers:
+                violations.append(Violation(
+                    path.name,
+                    str(job_name),
+                    "PULL_REQUEST_TARGET",
+                    "pull_request_target must never reach a self-hosted runner",
+                ))
+
+            if group != REQUIRED_GROUP:
+                violations.append(Violation(
+                    path.name,
+                    str(job_name),
+                    "RUNNER_GROUP",
+                    f"runner group must be {REQUIRED_GROUP!r}, got {group!r}",
+                ))
+
+            missing = sorted(REQUIRED_LABELS - labels)
+            if missing:
+                violations.append(Violation(
+                    path.name,
+                    str(job_name),
+                    "RUNNER_LABELS",
+                    f"missing dedicated labels: {', '.join(missing)}",
+                ))
+
+            if "pull_request" in triggers:
+                condition = _normalise_condition(job.get("if"))
+                if condition != SAME_REPO_GUARD:
+                    violations.append(Violation(
+                        path.name,
+                        str(job_name),
+                        "SAME_REPO_GUARD",
+                        "pull_request self-hosted job must use the exact same-repo job guard",
+                    ))
+
+    return ScanResult(len(paths), jobs_scanned, self_hosted_jobs, violations, broken)
+
+
+def _payload(result: ScanResult) -> dict[str, Any]:
+    return {
+        "ok": not result.violations and not result.broken,
+        "workflows_scanned": result.workflows_scanned,
+        "jobs_scanned": result.jobs_scanned,
+        "self_hosted_jobs": result.self_hosted_jobs,
+        "violations": [asdict(item) for item in result.violations],
+        "broken": result.broken,
+    }
+
+
+def _print_text(result: ScanResult) -> None:
+    print(
+        "[self-hosted-policy] "
+        f"workflows={result.workflows_scanned} jobs={result.jobs_scanned} "
+        f"self_hosted={result.self_hosted_jobs}"
+    )
+    for item in result.violations:
+        print(
+            f"  VIOLATION {item.code}: {item.workflow}:{item.job}: "
+            f"{item.message}"
+        )
+    for item in result.broken:
+        print(f"  BROKEN: {item}")
+    if not result.violations and not result.broken:
+        if result.self_hosted_jobs == 0:
+            print("[self-hosted-policy] OK -- explicit baseline: 0 self-hosted jobs.")
+        else:
+            print("[self-hosted-policy] OK -- all self-hosted jobs satisfy isolation policy.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="print a text verdict")
+    parser.add_argument("--json", action="store_true", help="print a JSON verdict")
+    parser.add_argument(
+        "--workflows-dir",
+        type=Path,
+        default=DEFAULT_WORKFLOWS_DIR,
+        help="workflow directory (used by tests and offline audits)",
+    )
+    args = parser.parse_args(argv)
+
+    result = scan_workflows(args.workflows_dir)
+    if args.json:
+        print(json.dumps(_payload(result), indent=2, ensure_ascii=False))
+    else:
+        _print_text(result)
+
+    if result.broken:
+        return EXIT_BROKEN
+    if result.violations:
+        return EXIT_VIOLATION
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -3,10 +3,11 @@
 
 The repository is public. A self-hosted job that can receive a fork payload can
 execute untrusted code next to the cluster's credentials. This scanner therefore
-fails closed: every self-hosted job must use the dedicated runner group and
-label, and every pull_request job must carry the exact same-repository guard.
-Dynamic ``runs-on`` expressions are rejected because their target cannot be
-proved statically.
+fails closed: every self-hosted job must belong to an explicitly allowed
+workflow, use the exact dedicated label set, and avoid runner groups (unavailable
+for this personal-account repository). Every pull_request job must also carry
+the exact same-repository guard. Dynamic ``runs-on`` expressions are rejected
+because their target cannot be proved statically.
 
 Exit codes:
   0  policy satisfied (including the explicit baseline of zero self-hosted jobs)
@@ -27,8 +28,12 @@ EXIT_OK = 0
 EXIT_VIOLATION = 1
 EXIT_BROKEN = 2
 
-REQUIRED_GROUP = "coursia-ephemeral"
-REQUIRED_LABELS = {"self-hosted", "coursia-ephemeral"}
+REQUIRED_LABELS = {
+    "self-hosted",
+    "coursia-ephemeral",
+    "coursia-fast-guards",
+}
+SELF_HOSTED_WORKFLOW_ALLOWLIST = {"pr-gate-stale-sweep.yml"}
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",
     "ubuntu-24.04",
@@ -47,7 +52,7 @@ GITHUB_HOSTED_LABELS = {
 }
 LOCAL_REUSABLE_PREFIX = "./.github/workflows/"
 SAME_REPO_REUSABLE_PATTERN = re.compile(
-    r"^jsboige/CoursIA/\.github/workflows/[^@]+@main$"
+    r"^jsboige/CoursIA/\.github/workflows/[^/@]+@main$"
 )
 SAME_REPO_GUARD = (
     "github.event.pull_request.head.repo.full_name == github.repository"
@@ -125,8 +130,10 @@ def _is_github_hosted_label(label: str) -> bool:
     return label.lower() in GITHUB_HOSTED_LABELS
 
 
-def _runner_selection(runs_on: Any) -> tuple[bool, str | None, set[str]]:
-    """Return (is_self_hosted, group, labels) for a static selection.
+def _runner_selection(
+    runs_on: Any,
+) -> tuple[bool, str | None, set[str], str | None]:
+    """Return (is_self_hosted, group, labels, error) for a static selection.
 
     Any explicit runner group is self-hosted. A scalar/list label is considered
     GitHub-hosted only when every value names a documented hosted-image family;
@@ -135,25 +142,35 @@ def _runner_selection(runs_on: Any) -> tuple[bool, str | None, set[str]]:
     """
     if isinstance(runs_on, str):
         labels = {runs_on.lower()}
-        return not _is_github_hosted_label(runs_on), None, labels
+        return not _is_github_hosted_label(runs_on), None, labels, None
     if isinstance(runs_on, list):
-        labels = {str(item).lower() for item in runs_on}
+        if not runs_on or not all(isinstance(item, str) for item in runs_on):
+            return False, None, set(), "runs-on list must contain labels"
+        labels = {item.lower() for item in runs_on}
         is_self_hosted = any(not _is_github_hosted_label(item) for item in labels)
-        return is_self_hosted, None, labels
+        return is_self_hosted, None, labels, None
     if isinstance(runs_on, dict):
         group = runs_on.get("group")
         raw_labels = runs_on.get("labels", [])
+        if group is None and "labels" not in runs_on:
+            return False, None, set(), "runs-on mapping needs group or labels"
+        if group is not None and not isinstance(group, str):
+            return False, None, set(), "runner group must be a string"
         if isinstance(raw_labels, str):
             labels = {raw_labels.lower()}
-        elif isinstance(raw_labels, list):
-            labels = {str(item).lower() for item in raw_labels}
-        else:
+        elif isinstance(raw_labels, list) and raw_labels and all(
+            isinstance(item, str) for item in raw_labels
+        ):
+            labels = {item.lower() for item in raw_labels}
+        elif raw_labels == [] and group is not None:
             labels = set()
+        else:
+            return False, None, set(), "runner labels must be a string or list"
         is_self_hosted = group is not None or any(
             not _is_github_hosted_label(item) for item in labels
         )
-        return is_self_hosted, str(group) if group is not None else None, labels
-    return False, None, set()
+        return is_self_hosted, group, labels, None
+    return False, None, set(), "runs-on has an unsupported type"
 
 
 def _normalise_condition(value: Any) -> str:
@@ -190,10 +207,20 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
             broken.append(f"{path.name}: invalid workflow YAML")
             continue
 
+        if "on" not in data and True not in data:
+            broken.append(f"{path.name}: missing on trigger")
+            continue
         triggers = _triggers(data)
-        jobs = data.get("jobs", {})
-        if not isinstance(jobs, dict):
-            broken.append(f"{path.name}: jobs is not a mapping")
+        if not triggers:
+            broken.append(f"{path.name}: on trigger is empty or unsupported")
+            continue
+
+        if "jobs" not in data:
+            broken.append(f"{path.name}: missing jobs")
+            continue
+        jobs = data["jobs"]
+        if not isinstance(jobs, dict) or not jobs:
+            broken.append(f"{path.name}: jobs is not a non-empty mapping")
             continue
 
         for job_name, job in jobs.items():
@@ -232,7 +259,10 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
                 ))
                 continue
 
-            is_self_hosted, group, labels = _runner_selection(runs_on)
+            is_self_hosted, group, labels, selection_error = _runner_selection(runs_on)
+            if selection_error is not None:
+                broken.append(f"{path.name}:{job_name}: {selection_error}")
+                continue
             if not is_self_hosted:
                 continue
             self_hosted_jobs += 1
@@ -259,21 +289,35 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
                     "self-hosted jobs must not hide inside reusable workflows",
                 ))
 
-            if group != REQUIRED_GROUP:
+            if path.name not in SELF_HOSTED_WORKFLOW_ALLOWLIST:
                 violations.append(Violation(
                     path.name,
                     str(job_name),
-                    "RUNNER_GROUP",
-                    f"runner group must be {REQUIRED_GROUP!r}, got {group!r}",
+                    "WORKFLOW_NOT_ALLOWED",
+                    "self-hosted runners are restricted to explicitly allowed workflows",
+                ))
+
+            if group is not None:
+                violations.append(Violation(
+                    path.name,
+                    str(job_name),
+                    "RUNNER_GROUP_UNAVAILABLE",
+                    "runner groups are unavailable for this personal-account repository",
                 ))
 
             missing = sorted(REQUIRED_LABELS - labels)
-            if missing:
+            unexpected = sorted(labels - REQUIRED_LABELS)
+            if missing or unexpected:
+                detail = []
+                if missing:
+                    detail.append(f"missing: {', '.join(missing)}")
+                if unexpected:
+                    detail.append(f"unexpected: {', '.join(unexpected)}")
                 violations.append(Violation(
                     path.name,
                     str(job_name),
                     "RUNNER_LABELS",
-                    f"missing dedicated labels: {', '.join(missing)}",
+                    "dedicated labels must match exactly (" + "; ".join(detail) + ")",
                 ))
 
             if "pull_request" in triggers:

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -47,7 +47,7 @@ GITHUB_HOSTED_LABELS = {
 }
 LOCAL_REUSABLE_PREFIX = "./.github/workflows/"
 SAME_REPO_REUSABLE_PATTERN = re.compile(
-    r"^jsboige/CoursIA/\.github/workflows/[^@]+@(?:main|[0-9a-fA-F]{40})$"
+    r"^jsboige/CoursIA/\.github/workflows/[^@]+@main$"
 )
 SAME_REPO_GUARD = (
     "github.event.pull_request.head.repo.full_name == github.repository"
@@ -214,7 +214,7 @@ def scan_workflows(workflows_dir: Path = DEFAULT_WORKFLOWS_DIR) -> ScanResult:
                         str(job_name),
                         "REMOTE_REUSABLE_WORKFLOW",
                         "reusable workflow must be local or pin jsboige/CoursIA "
-                        "to main or a 40-character commit SHA",
+                        "to main",
                     ))
                 continue
 

--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -84,7 +84,7 @@ class Guard:
 NOTEBOOK_GLOBS = ["**/*.ipynb"]
 
 # ---------------------------------------------------------------------------
-# Lot pilote (#11835). Neuf gardes choisis pour couvrir les formes que le
+# Lot pilote (#11835). Dix gardes choisis pour couvrir les formes que le
 # moteur doit savoir traiter, et non pour leur nombre :
 #
 #   - banner-guard        : bloquant, scan global, sans base
@@ -98,6 +98,7 @@ NOTEBOOK_GLOBS = ["**/*.ipynb"]
 #   - notebook-navlink-check   : bloquant, scan global
 #   - notebook-interp-positioning-guard : bloquant, scan global baselined
 #   - markdown-rendering-guard : bloquant, scan global baselined
+#   - self-hosted-runner-policy : bloquant, scan statique des workflows
 #
 # Un lot homogene aurait valide le moteur sur un seul cas de figure -- et un
 # lot entierement vert serait indiscernable d'un moteur debranche.
@@ -215,6 +216,20 @@ PILOT: list[Guard] = [
               "--check",
               "--baseline",
               "scripts/notebook_tools/markdown_rendering_baseline.json"],
+        blocking=True,
+    ),
+    Guard(
+        name="self-hosted-runner-policy",
+        source="fast-lane-shadow.yml",
+        paths=[
+            ".github/workflows/*.yml",
+            ".github/workflows/*.yaml",
+            "scripts/ci/check_self_hosted_runner_policy.py",
+            "scripts/tests/test_check_self_hosted_runner_policy.py",
+            "scripts/ci/fast_lane_registry.py",
+        ],
+        argv=["python", "scripts/ci/check_self_hosted_runner_policy.py",
+              "--check"],
         blocking=True,
     ),
 ]

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+CI_DIR = Path(__file__).resolve().parents[1] / "ci"
+sys.path.insert(0, str(CI_DIR))
+
+import check_self_hosted_runner_policy as policy  # noqa: E402
+
+
+def write_workflow(tmp_path: Path, name: str, body: str, suffix: str = ".yml") -> Path:
+    path = tmp_path / f"{name}{suffix}"
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+def codes(result: policy.ScanResult) -> set[str]:
+    return {item.code for item in result.violations}
+
+
+def test_current_repository_has_explicit_zero_self_hosted_baseline(capsys):
+    result = policy.scan_workflows()
+    assert result.broken == []
+    assert result.violations == []
+    assert result.self_hosted_jobs == 0
+    assert result.workflows_scanned > 0
+    assert policy.main(["--check"]) == policy.EXIT_OK
+    assert "explicit baseline: 0 self-hosted jobs" in capsys.readouterr().out
+
+
+def test_safe_pull_request_job_is_accepted(tmp_path):
+    write_workflow(tmp_path, "safe", """
+        name: safe
+        on: [pull_request]
+        jobs:
+          test:
+            if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+            runs-on:
+              group: coursia-ephemeral
+              labels: [self-hosted, coursia-ephemeral]
+            steps:
+              - run: echo safe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == []
+    assert result.violations == []
+    assert result.self_hosted_jobs == 1
+
+
+def test_safe_workflow_dispatch_job_does_not_need_pr_guard(tmp_path):
+    write_workflow(tmp_path, "manual", """
+        name: manual
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on:
+              group: coursia-ephemeral
+              labels: [self-hosted, coursia-ephemeral]
+            steps:
+              - run: echo safe
+        """, suffix=".yaml")
+    result = policy.scan_workflows(tmp_path)
+    assert result.violations == []
+    assert result.self_hosted_jobs == 1
+
+
+def test_generic_self_hosted_scalar_is_rejected(tmp_path):
+    write_workflow(tmp_path, "unsafe", """
+        name: unsafe
+        on: [pull_request]
+        jobs:
+          test:
+            runs-on: self-hosted
+            steps:
+              - run: echo unsafe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert {"RUNNER_GROUP", "RUNNER_LABELS", "SAME_REPO_GUARD"} <= codes(result)
+
+
+def test_self_hosted_list_without_group_is_rejected(tmp_path):
+    write_workflow(tmp_path, "unsafe", """
+        name: unsafe
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: [self-hosted, coursia-ephemeral]
+            steps:
+              - run: echo unsafe
+        """)
+    assert "RUNNER_GROUP" in codes(policy.scan_workflows(tmp_path))
+
+
+def test_wrong_group_and_missing_label_are_both_named(tmp_path):
+    write_workflow(tmp_path, "unsafe", """
+        name: unsafe
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on:
+              group: Default
+              labels: [self-hosted, windows]
+            steps:
+              - run: echo unsafe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert {"RUNNER_GROUP", "RUNNER_LABELS"} == codes(result)
+
+
+def test_dynamic_runs_on_is_rejected_fail_closed(tmp_path):
+    write_workflow(tmp_path, "dynamic", """
+        name: dynamic
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: ${{ matrix.runner }}
+            strategy:
+              matrix:
+                runner: [ubuntu-latest, self-hosted]
+            steps:
+              - run: echo opaque
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert codes(result) == {"DYNAMIC_RUNS_ON"}
+    assert result.self_hosted_jobs == 0
+
+
+def test_pull_request_job_without_guard_is_rejected(tmp_path):
+    write_workflow(tmp_path, "unguarded", """
+        name: unguarded
+        on:
+          pull_request:
+        jobs:
+          test:
+            runs-on:
+              group: coursia-ephemeral
+              labels: [self-hosted, coursia-ephemeral]
+            steps:
+              - run: echo unsafe
+        """)
+    assert "SAME_REPO_GUARD" in codes(policy.scan_workflows(tmp_path))
+
+
+def test_step_level_guard_does_not_protect_the_job(tmp_path):
+    write_workflow(tmp_path, "step-guard", """
+        name: step-guard
+        on: [pull_request]
+        jobs:
+          test:
+            runs-on:
+              group: coursia-ephemeral
+              labels: [self-hosted, coursia-ephemeral]
+            steps:
+              - if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+                run: echo too-late
+        """)
+    assert "SAME_REPO_GUARD" in codes(policy.scan_workflows(tmp_path))
+
+
+def test_guard_weakened_by_or_is_rejected(tmp_path):
+    write_workflow(tmp_path, "weak", """
+        name: weak
+        on: [pull_request]
+        jobs:
+          test:
+            if: ${{ github.event.pull_request.head.repo.full_name == github.repository || always() }}
+            runs-on:
+              group: coursia-ephemeral
+              labels: [self-hosted, coursia-ephemeral]
+            steps:
+              - run: echo unsafe
+        """)
+    assert "SAME_REPO_GUARD" in codes(policy.scan_workflows(tmp_path))
+
+
+def test_pull_request_target_is_always_rejected(tmp_path):
+    write_workflow(tmp_path, "target", """
+        name: target
+        on: [pull_request_target]
+        jobs:
+          test:
+            if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+            runs-on:
+              group: coursia-ephemeral
+              labels: [self-hosted, coursia-ephemeral]
+            steps:
+              - run: echo unsafe
+        """)
+    assert "PULL_REQUEST_TARGET" in codes(policy.scan_workflows(tmp_path))
+
+
+def test_invalid_yaml_breaks_the_instrument(tmp_path):
+    write_workflow(tmp_path, "broken", "on: [pull_request\njobs: [")
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken
+    assert policy.main(["--check", "--workflows-dir", str(tmp_path)]) == policy.EXIT_BROKEN
+
+
+def test_json_output_names_violations_and_denominators(tmp_path, capsys):
+    write_workflow(tmp_path, "unsafe", """
+        name: unsafe
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: self-hosted
+            steps:
+              - run: echo unsafe
+        """)
+    rc = policy.main(["--json", "--workflows-dir", str(tmp_path)])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == policy.EXIT_VIOLATION
+    assert payload["workflows_scanned"] == 1
+    assert payload["jobs_scanned"] == 1
+    assert payload["self_hosted_jobs"] == 1
+    assert {item["code"] for item in payload["violations"]} == {
+        "RUNNER_GROUP",
+        "RUNNER_LABELS",
+    }
+
+
+def test_missing_runs_on_breaks_instrument_instead_of_silent_skip(tmp_path):
+    write_workflow(tmp_path, "broken-job", """
+        name: broken-job
+        on: workflow_dispatch
+        jobs:
+          test:
+            steps:
+              - run: echo no-runner
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == ["broken-job.yml:test: missing runs-on"]

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -298,7 +298,7 @@ def test_external_reusable_workflow_is_rejected(tmp_path):
     assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
 
 
-def test_same_repository_reusable_workflow_remains_auditable(tmp_path):
+def test_local_reusable_workflow_remains_auditable(tmp_path):
     write_workflow(tmp_path, "caller", """
         name: caller
         on: [pull_request]
@@ -309,6 +309,51 @@ def test_same_repository_reusable_workflow_remains_auditable(tmp_path):
     result = policy.scan_workflows(tmp_path)
     assert result.broken == []
     assert result.violations == []
+
+
+def test_same_repository_reusable_workflow_allows_main(tmp_path):
+    write_workflow(tmp_path, "caller", """
+        name: caller
+        on: [pull_request]
+        jobs:
+          test:
+            uses: jsboige/CoursIA/.github/workflows/callee.yml@main
+        """)
+    assert policy.scan_workflows(tmp_path).violations == []
+
+
+def test_same_repository_reusable_workflow_allows_commit_sha(tmp_path):
+    sha = "0123456789abcdef0123456789abcdef01234567"
+    write_workflow(tmp_path, "caller", f"""
+        name: caller
+        on: [pull_request]
+        jobs:
+          test:
+            uses: jsboige/CoursIA/.github/workflows/callee.yml@{sha}
+        """)
+    assert policy.scan_workflows(tmp_path).violations == []
+
+
+def test_same_repository_reusable_workflow_rejects_branch_ref(tmp_path):
+    write_workflow(tmp_path, "caller", """
+        name: caller
+        on: [pull_request]
+        jobs:
+          test:
+            uses: jsboige/CoursIA/.github/workflows/callee.yml@feature/unsafe
+        """)
+    assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
+
+
+def test_same_repository_reusable_workflow_rejects_short_sha(tmp_path):
+    write_workflow(tmp_path, "caller", """
+        name: caller
+        on: [pull_request]
+        jobs:
+          test:
+            uses: jsboige/CoursIA/.github/workflows/callee.yml@0123456789abcdef
+        """)
+    assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
 
 
 def test_invalid_yaml_breaks_the_instrument(tmp_path):

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -94,6 +94,52 @@ def test_self_hosted_list_without_group_is_rejected(tmp_path):
     assert "RUNNER_GROUP" in codes(policy.scan_workflows(tmp_path))
 
 
+def test_custom_label_without_self_hosted_token_is_still_self_hosted(tmp_path):
+    write_workflow(tmp_path, "custom", """
+        name: custom
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: coursia-ephemeral
+            steps:
+              - run: echo unsafe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.self_hosted_jobs == 1
+    assert {"RUNNER_GROUP", "RUNNER_LABELS"} == codes(result)
+
+
+def test_group_selection_is_self_hosted_even_without_labels(tmp_path):
+    write_workflow(tmp_path, "group", """
+        name: group
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on:
+              group: coursia-ephemeral
+            steps:
+              - run: echo unsafe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.self_hosted_jobs == 1
+    assert codes(result) == {"RUNNER_LABELS"}
+
+
+def test_self_hosted_label_is_case_insensitive(tmp_path):
+    write_workflow(tmp_path, "case", """
+        name: case
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: [Self-Hosted, coursia-ephemeral]
+            steps:
+              - run: echo unsafe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.self_hosted_jobs == 1
+    assert "RUNNER_GROUP" in codes(result)
+
+
 def test_wrong_group_and_missing_label_are_both_named(tmp_path):
     write_workflow(tmp_path, "unsafe", """
         name: unsafe
@@ -190,6 +236,64 @@ def test_pull_request_target_is_always_rejected(tmp_path):
               - run: echo unsafe
         """)
     assert "PULL_REQUEST_TARGET" in codes(policy.scan_workflows(tmp_path))
+
+
+def test_workflow_call_cannot_hide_self_hosted_job(tmp_path):
+    write_workflow(tmp_path, "callee", """
+        name: callee
+        on: workflow_call
+        jobs:
+          test:
+            runs-on:
+              group: coursia-ephemeral
+              labels: [self-hosted, coursia-ephemeral]
+            steps:
+              - run: echo hidden
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert "REUSABLE_SELF_HOSTED" in codes(result)
+
+
+def test_workflow_run_cannot_reach_self_hosted_job(tmp_path):
+    write_workflow(tmp_path, "artifact", """
+        name: artifact
+        on:
+          workflow_run:
+            workflows: [Build]
+            types: [completed]
+        jobs:
+          test:
+            runs-on:
+              group: coursia-ephemeral
+              labels: [self-hosted, coursia-ephemeral]
+            steps:
+              - run: echo artifact
+        """)
+    assert "WORKFLOW_RUN" in codes(policy.scan_workflows(tmp_path))
+
+
+def test_external_reusable_workflow_is_rejected(tmp_path):
+    write_workflow(tmp_path, "caller", """
+        name: caller
+        on: [pull_request]
+        jobs:
+          test:
+            uses: attacker/repo/.github/workflows/run.yml@main
+        """)
+    assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
+
+
+def test_same_repository_reusable_workflow_remains_auditable(tmp_path):
+    write_workflow(tmp_path, "caller", """
+        name: caller
+        on: [pull_request]
+        jobs:
+          test:
+            uses: ./.github/workflows/callee.yml
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == []
+    assert result.violations == []
 
 
 def test_invalid_yaml_breaks_the_instrument(tmp_path):

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -32,15 +32,13 @@ def test_current_repository_has_explicit_zero_self_hosted_baseline(capsys):
 
 
 def test_safe_pull_request_job_is_accepted(tmp_path):
-    write_workflow(tmp_path, "safe", """
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
         name: safe
         on: [pull_request]
         jobs:
           test:
             if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-            runs-on:
-              group: coursia-ephemeral
-              labels: [self-hosted, coursia-ephemeral]
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
             steps:
               - run: echo safe
         """)
@@ -50,21 +48,86 @@ def test_safe_pull_request_job_is_accepted(tmp_path):
     assert result.self_hosted_jobs == 1
 
 
-def test_safe_workflow_dispatch_job_does_not_need_pr_guard(tmp_path):
-    write_workflow(tmp_path, "manual", """
+def test_allowed_workflow_dispatch_job_does_not_need_pr_guard(tmp_path):
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
         name: manual
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
+            steps:
+              - run: echo safe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.violations == []
+    assert result.self_hosted_jobs == 1
+
+
+def test_exact_labels_outside_allowlist_are_rejected(tmp_path):
+    write_workflow(tmp_path, "other-workflow", """
+        name: other
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
+            steps:
+              - run: echo unsafe
+        """)
+    assert codes(policy.scan_workflows(tmp_path)) == {"WORKFLOW_NOT_ALLOWED"}
+
+
+def test_group_is_rejected_even_in_allowed_workflow(tmp_path):
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
+        name: group
         on: workflow_dispatch
         jobs:
           test:
             runs-on:
               group: coursia-ephemeral
-              labels: [self-hosted, coursia-ephemeral]
+              labels: [self-hosted, coursia-ephemeral, coursia-fast-guards]
             steps:
-              - run: echo safe
+              - run: echo unsafe
+        """)
+    assert codes(policy.scan_workflows(tmp_path)) == {"RUNNER_GROUP_UNAVAILABLE"}
+
+
+def test_missing_label_is_rejected_in_allowed_workflow(tmp_path):
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
+        name: labels
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: [self-hosted, coursia-ephemeral]
+            steps:
+              - run: echo unsafe
+        """)
+    assert codes(policy.scan_workflows(tmp_path)) == {"RUNNER_LABELS"}
+
+
+def test_unexpected_label_is_rejected_in_allowed_workflow(tmp_path):
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
+        name: labels
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards, windows]
+            steps:
+              - run: echo unsafe
+        """)
+    assert codes(policy.scan_workflows(tmp_path)) == {"RUNNER_LABELS"}
+
+
+def test_yaml_extension_cannot_alias_allowlisted_workflow(tmp_path):
+    write_workflow(tmp_path, "pr-gate-stale-sweep", """
+        name: extension-alias
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
+            steps:
+              - run: echo unsafe
         """, suffix=".yaml")
-    result = policy.scan_workflows(tmp_path)
-    assert result.violations == []
-    assert result.self_hosted_jobs == 1
+    assert codes(policy.scan_workflows(tmp_path)) == {"WORKFLOW_NOT_ALLOWED"}
 
 
 def test_generic_self_hosted_scalar_is_rejected(tmp_path):
@@ -78,7 +141,7 @@ def test_generic_self_hosted_scalar_is_rejected(tmp_path):
               - run: echo unsafe
         """)
     result = policy.scan_workflows(tmp_path)
-    assert {"RUNNER_GROUP", "RUNNER_LABELS", "SAME_REPO_GUARD"} <= codes(result)
+    assert {"WORKFLOW_NOT_ALLOWED", "RUNNER_LABELS", "SAME_REPO_GUARD"} <= codes(result)
 
 
 def test_self_hosted_list_without_group_is_rejected(tmp_path):
@@ -91,7 +154,7 @@ def test_self_hosted_list_without_group_is_rejected(tmp_path):
             steps:
               - run: echo unsafe
         """)
-    assert "RUNNER_GROUP" in codes(policy.scan_workflows(tmp_path))
+    assert "WORKFLOW_NOT_ALLOWED" in codes(policy.scan_workflows(tmp_path))
 
 
 def test_custom_label_without_self_hosted_token_is_still_self_hosted(tmp_path):
@@ -106,7 +169,7 @@ def test_custom_label_without_self_hosted_token_is_still_self_hosted(tmp_path):
         """)
     result = policy.scan_workflows(tmp_path)
     assert result.self_hosted_jobs == 1
-    assert {"RUNNER_GROUP", "RUNNER_LABELS"} == codes(result)
+    assert {"WORKFLOW_NOT_ALLOWED", "RUNNER_LABELS"} == codes(result)
 
 
 def test_hosted_looking_custom_label_is_rejected_fail_closed(tmp_path):
@@ -121,7 +184,7 @@ def test_hosted_looking_custom_label_is_rejected_fail_closed(tmp_path):
         """)
     result = policy.scan_workflows(tmp_path)
     assert result.self_hosted_jobs == 1
-    assert {"RUNNER_GROUP", "RUNNER_LABELS"} == codes(result)
+    assert {"WORKFLOW_NOT_ALLOWED", "RUNNER_LABELS"} == codes(result)
 
 
 def test_group_selection_is_self_hosted_even_without_labels(tmp_path):
@@ -137,7 +200,11 @@ def test_group_selection_is_self_hosted_even_without_labels(tmp_path):
         """)
     result = policy.scan_workflows(tmp_path)
     assert result.self_hosted_jobs == 1
-    assert codes(result) == {"RUNNER_LABELS"}
+    assert codes(result) == {
+        "RUNNER_GROUP_UNAVAILABLE",
+        "RUNNER_LABELS",
+        "WORKFLOW_NOT_ALLOWED",
+    }
 
 
 def test_self_hosted_label_is_case_insensitive(tmp_path):
@@ -152,7 +219,7 @@ def test_self_hosted_label_is_case_insensitive(tmp_path):
         """)
     result = policy.scan_workflows(tmp_path)
     assert result.self_hosted_jobs == 1
-    assert "RUNNER_GROUP" in codes(result)
+    assert "WORKFLOW_NOT_ALLOWED" in codes(result)
 
 
 def test_wrong_group_and_missing_label_are_both_named(tmp_path):
@@ -168,7 +235,11 @@ def test_wrong_group_and_missing_label_are_both_named(tmp_path):
               - run: echo unsafe
         """)
     result = policy.scan_workflows(tmp_path)
-    assert {"RUNNER_GROUP", "RUNNER_LABELS"} == codes(result)
+    assert {
+        "RUNNER_GROUP_UNAVAILABLE",
+        "RUNNER_LABELS",
+        "WORKFLOW_NOT_ALLOWED",
+    } == codes(result)
 
 
 def test_dynamic_runs_on_is_rejected_fail_closed(tmp_path):
@@ -196,9 +267,7 @@ def test_pull_request_job_without_guard_is_rejected(tmp_path):
           pull_request:
         jobs:
           test:
-            runs-on:
-              group: coursia-ephemeral
-              labels: [self-hosted, coursia-ephemeral]
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
             steps:
               - run: echo unsafe
         """)
@@ -211,9 +280,7 @@ def test_step_level_guard_does_not_protect_the_job(tmp_path):
         on: [pull_request]
         jobs:
           test:
-            runs-on:
-              group: coursia-ephemeral
-              labels: [self-hosted, coursia-ephemeral]
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
             steps:
               - if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
                 run: echo too-late
@@ -228,9 +295,7 @@ def test_guard_weakened_by_or_is_rejected(tmp_path):
         jobs:
           test:
             if: ${{ github.event.pull_request.head.repo.full_name == github.repository || always() }}
-            runs-on:
-              group: coursia-ephemeral
-              labels: [self-hosted, coursia-ephemeral]
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
             steps:
               - run: echo unsafe
         """)
@@ -244,9 +309,7 @@ def test_pull_request_target_is_always_rejected(tmp_path):
         jobs:
           test:
             if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-            runs-on:
-              group: coursia-ephemeral
-              labels: [self-hosted, coursia-ephemeral]
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
             steps:
               - run: echo unsafe
         """)
@@ -259,9 +322,7 @@ def test_workflow_call_cannot_hide_self_hosted_job(tmp_path):
         on: workflow_call
         jobs:
           test:
-            runs-on:
-              group: coursia-ephemeral
-              labels: [self-hosted, coursia-ephemeral]
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
             steps:
               - run: echo hidden
         """)
@@ -278,9 +339,7 @@ def test_workflow_run_cannot_reach_self_hosted_job(tmp_path):
             types: [completed]
         jobs:
           test:
-            runs-on:
-              group: coursia-ephemeral
-              labels: [self-hosted, coursia-ephemeral]
+            runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
             steps:
               - run: echo artifact
         """)
@@ -356,6 +415,104 @@ def test_same_repository_reusable_workflow_rejects_short_sha(tmp_path):
     assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
 
 
+def test_missing_trigger_breaks_instrument(tmp_path):
+    write_workflow(tmp_path, "broken-trigger", """
+        name: broken-trigger
+        jobs:
+          test:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo no-trigger
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == ["broken-trigger.yml: missing on trigger"]
+
+
+def test_empty_runs_on_list_breaks_instrument(tmp_path):
+    write_workflow(tmp_path, "broken-runner", """
+        name: broken-runner
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: []
+            steps:
+              - run: echo no-runner
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == [
+        "broken-runner.yml:test: runs-on list must contain labels"
+    ]
+
+
+def test_missing_jobs_breaks_instrument(tmp_path):
+    write_workflow(tmp_path, "broken-jobs", """
+        name: broken-jobs
+        on: workflow_dispatch
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == ["broken-jobs.yml: missing jobs"]
+
+
+def test_same_repository_reusable_workflow_rejects_path_traversal(tmp_path):
+    write_workflow(tmp_path, "caller", """
+        name: caller
+        on: [pull_request]
+        jobs:
+          test:
+            uses: jsboige/CoursIA/.github/workflows/../evil.yml@main
+        """)
+    assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
+
+
+def test_missing_trigger_breaks_instrument(tmp_path):
+    write_workflow(tmp_path, "broken-trigger", """
+        name: broken-trigger
+        jobs:
+          test:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo no-trigger
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == ["broken-trigger.yml: missing on trigger"]
+
+
+def test_empty_runs_on_list_breaks_instrument(tmp_path):
+    write_workflow(tmp_path, "broken-runner", """
+        name: broken-runner
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: []
+            steps:
+              - run: echo no-runner
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == [
+        "broken-runner.yml:test: runs-on list must contain labels"
+    ]
+
+
+def test_missing_jobs_breaks_instrument(tmp_path):
+    write_workflow(tmp_path, "broken-jobs", """
+        name: broken-jobs
+        on: workflow_dispatch
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.broken == ["broken-jobs.yml: missing jobs"]
+
+
+def test_same_repository_reusable_workflow_rejects_path_traversal(tmp_path):
+    write_workflow(tmp_path, "caller", """
+        name: caller
+        on: [pull_request]
+        jobs:
+          test:
+            uses: jsboige/CoursIA/.github/workflows/../evil.yml@main
+        """)
+    assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
+
+
 def test_invalid_yaml_breaks_the_instrument(tmp_path):
     write_workflow(tmp_path, "broken", "on: [pull_request\njobs: [")
     result = policy.scan_workflows(tmp_path)
@@ -380,7 +537,7 @@ def test_json_output_names_violations_and_denominators(tmp_path, capsys):
     assert payload["jobs_scanned"] == 1
     assert payload["self_hosted_jobs"] == 1
     assert {item["code"] for item in payload["violations"]} == {
-        "RUNNER_GROUP",
+        "WORKFLOW_NOT_ALLOWED",
         "RUNNER_LABELS",
     }
 

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -109,6 +109,21 @@ def test_custom_label_without_self_hosted_token_is_still_self_hosted(tmp_path):
     assert {"RUNNER_GROUP", "RUNNER_LABELS"} == codes(result)
 
 
+def test_hosted_looking_custom_label_is_rejected_fail_closed(tmp_path):
+    write_workflow(tmp_path, "custom-looking", """
+        name: custom-looking
+        on: workflow_dispatch
+        jobs:
+          test:
+            runs-on: ubuntu-custom
+            steps:
+              - run: echo unsafe
+        """)
+    result = policy.scan_workflows(tmp_path)
+    assert result.self_hosted_jobs == 1
+    assert {"RUNNER_GROUP", "RUNNER_LABELS"} == codes(result)
+
+
 def test_group_selection_is_self_hosted_even_without_labels(tmp_path):
     write_workflow(tmp_path, "group", """
         name: group

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -322,7 +322,7 @@ def test_same_repository_reusable_workflow_allows_main(tmp_path):
     assert policy.scan_workflows(tmp_path).violations == []
 
 
-def test_same_repository_reusable_workflow_allows_commit_sha(tmp_path):
+def test_same_repository_reusable_workflow_rejects_commit_sha(tmp_path):
     sha = "0123456789abcdef0123456789abcdef01234567"
     write_workflow(tmp_path, "caller", f"""
         name: caller
@@ -331,7 +331,7 @@ def test_same_repository_reusable_workflow_allows_commit_sha(tmp_path):
           test:
             uses: jsboige/CoursIA/.github/workflows/callee.yml@{sha}
         """)
-    assert policy.scan_workflows(tmp_path).violations == []
+    assert "REMOTE_REUSABLE_WORKFLOW" in codes(policy.scan_workflows(tmp_path))
 
 
 def test_same_repository_reusable_workflow_rejects_branch_ref(tmp_path):

--- a/scripts/tests/test_fast_lane.py
+++ b/scripts/tests/test_fast_lane.py
@@ -157,11 +157,26 @@ def test_advisory_flags_match_the_source_workflows():
     assert by_name["banner-guard"].blocking is True
     assert by_name["pip-leak-guard"].blocking is True
     assert by_name["perimeter-review-guard"].blocking is True
-    # 4 gardes ajoutees (extension 5 -> 9) -- bloquer par defaut
+    # 5 gardes ajoutees (extension 5 -> 10) -- bloquer par defaut
     assert by_name["bare-cross-dir-load-gate"].blocking is True
     assert by_name["notebook-navlink-check"].blocking is True
     assert by_name["notebook-interp-positioning-guard"].blocking is True
     assert by_name["markdown-rendering-guard"].blocking is True
+    assert by_name["self-hosted-runner-policy"].blocking is True
+
+
+def test_self_hosted_policy_guard_is_wired_fail_closed():
+    guard = {item.name: item for item in PILOT}["self-hosted-runner-policy"]
+    assert guard.source == "fast-lane-shadow.yml"
+    assert guard.argv == [
+        "python",
+        "scripts/ci/check_self_hosted_runner_policy.py",
+        "--check",
+    ]
+    assert ".github/workflows/*.yml" in guard.paths
+    assert ".github/workflows/*.yaml" in guard.paths
+    assert "scripts/ci/check_self_hosted_runner_policy.py" in guard.paths
+    assert "scripts/ci/fast_lane_registry.py" in guard.paths
 
 
 def test_iterates_paths_guards_carry_the_placeholder():


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA — prev: MED/tooling #12767

## Résumé

Cette deuxième tranche de #12704 prépare la frontière de sécurité des futurs runners self-hosted sans en enregistrer ni en activer aucun.

Elle ajoute un scanner fail-closed qui audite les workflows GitHub Actions et impose, pour tout futur job self-hosted :

- une allowlist statique de workflows, initialement limitée à `pr-gate-stale-sweep.yml` ;
- les labels exacts `self-hosted`, `coursia-ephemeral` et `coursia-fast-guards` ;
- aucun runner group, car le dépôt appartient à un compte personnel et non à une organisation ;
- une garde job-level exacte refusant les PRs de forks ;
- l'interdiction de `pull_request_target`, `workflow_run` et `workflow_call` ;
- l'interdiction des valeurs `runs-on` dynamiques ;
- des reusable workflows limités aux fichiers locaux ou à `jsboige/CoursIA@main`.

Le garde rejoint la fast lane ombre existante : 10 gardes partagent toujours un seul checkout. Le workflow `scripts-tests.yml` couvre désormais aussi toute modification de `.github/workflows/**`, afin que les PRs workflow-only — y compris les forks — exécutent le scanner sur une surface CI ordinaire.

## Décision de topologie

Le propriétaire `jsboige` est un compte GitHub personnel. Les runner groups personnalisés sont une capacité organisation/enterprise et ne constituent donc pas un mécanisme activable pour ce dépôt.

La politique corrigée utilise le mécanisme disponible au niveau dépôt : labels dédiés stricts + allowlist de workflows. Un label absent ou supplémentaire, un workflow hors allowlist, ou un objet `runs-on.group` font échouer le scanner.

## Périmètre

Six sources sont modifiées :

- `.github/workflows/fast-lane-shadow.yml`
- `.github/workflows/scripts-tests.yml`
- `scripts/ci/check_self_hosted_runner_policy.py`
- `scripts/ci/fast_lane_registry.py`
- `scripts/tests/test_check_self_hosted_runner_policy.py`
- `scripts/tests/test_fast_lane.py`

**PRÉPARER, PAS ACTIVER :**

- aucun runner n'est enregistré ou activé ;
- aucun job n'est déplacé vers un runner self-hosted ;
- aucun `runs-on` self-hosted n'est ajouté ;
- aucun token d'enregistrement ni secret n'est ajouté ;
- aucun workflow nouveau n'est créé.

## Revue sécurité adversariale

Les passes indépendantes ont vérifié puis fait fermer les chemins suivants :

1. callee `workflow_call` self-hosted caché ;
2. job-level `uses:` externe ignoré ;
3. label personnalisé sans chaîne littérale `self-hosted` ;
4. casse trompeuse des labels ;
5. label dédié absent ou label supplémentaire ;
6. workflow self-hosted hors allowlist ;
7. runner group non disponible introduit malgré la topologie personnelle ;
8. PR workflow-only invisible à `scripts-tests` ;
9. artifact poisoning via `workflow_run` ;
10. reusable workflow same-repo épinglé sur une branche ou un SHA latéral non scanné.

## Validation

- `78 passed` : scanner, fast lane et expressions workflow adjacentes ;
- baseline réelle : `113 workflows`, `139 jobs`, `0 self-hosted`, `0 violation`, `0 broken` ;
- `py_compile` réussi ;
- `git diff --check` propre ;
- hooks ciblés réussis, dont gitleaks.

Le hook global `pre-commit --all-files` avait rencontré du drift préexistant dans des notebooks hors scope ; aucun de ces changements n'est conservé dans cette branche. Les validations finales sont ciblées sur les six sources de la PR.

See #12704
