### PR TITLE
fix(tweety,#12789): Tweety-3 jars depuis Maven Central — l'amont builds/ est mort (404)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
@@ -6,10 +6,10 @@
    "metadata": {
     "id": "e69e7c37",
     "papermill": {
-     "duration": 0.005474,
-     "end_time": "2026-06-02T21:43:33.204392+00:00",
+     "duration": 0.006206,
+     "end_time": "2026-08-24T16:57:44.811925",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.198918+00:00",
+     "start_time": "2026-08-24T16:57:44.805719",
      "status": "completed"
     },
     "tags": []
@@ -50,18 +50,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.061044Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.058832Z",
-     "iopub.status.idle": "2026-06-20T11:16:21.352327Z",
-     "shell.execute_reply": "2026-06-20T11:16:21.351829Z"
+     "iopub.execute_input": "2026-08-24T16:57:44.825913Z",
+     "iopub.status.busy": "2026-08-24T16:57:44.825340Z",
+     "iopub.status.idle": "2026-08-24T16:57:48.776981Z",
+     "shell.execute_reply": "2026-08-24T16:57:48.776011Z"
     },
     "id": "25a1db92-e3dd-4fb4-96e0-7db4030b5cf0",
     "outputId": "1033bbf7-96be-45e9-fc20-533f562a5346",
     "papermill": {
-     "duration": 0.267782,
-     "end_time": "2026-06-02T21:43:33.477184+00:00",
+     "duration": 3.960608,
+     "end_time": "2026-08-24T16:57:48.778600",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.209402+00:00",
+     "start_time": "2026-08-24T16:57:44.817992",
      "status": "completed"
     },
     "tags": []
@@ -72,7 +72,14 @@
      "output_type": "stream",
      "text": [
       "Packages Python OK.\n",
-      "JARs Tweety OK (42 fichiers dans libs/).\n"
+      "Telechargement de 13 JAR(s) Tweety 1.30...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  13/13 JAR(s) telecharges dans libs/.\n"
      ]
     }
    ],
@@ -102,7 +109,9 @@
     "# --- 2. JARs Tweety ---\n",
     "LIB_DIR.mkdir(exist_ok=True)\n",
     "\n",
-    "_BASE_URL = f\"https://tweetyproject.org/builds/{TWEETY_VERSION}/\"\n",
+    "# #12789: l'amont builds/ de tweetyproject.org est mort (404 toutes versions) --\n",
+    "# les jars viennent de Maven Central, comme le script canonique scripts/download_tweety_tools.py.\n",
+    "_MAVEN_BASE = \"https://repo1.maven.org/maven2/org/tweetyproject/\"\n",
     "_MODULES = {\n",
     "    \"commons\":         \"commons\",\n",
     "    \"logics-commons\":  \"logics.commons\",\n",
@@ -133,7 +142,9 @@
     "for local_name, artifact in _MODULES.items():\n",
     "    jar = LIB_DIR / f\"{local_name}-{TWEETY_VERSION}.jar\"\n",
     "    if not jar.exists():\n",
-    "        url = f\"{_BASE_URL}org.tweetyproject.{artifact}-{TWEETY_VERSION}.jar\"\n",
+    "        maven_path = artifact.replace(\".\", \"/\")\n",
+    "        maven_name = artifact.split(\".\")[-1]\n",
+    "        url = f\"{_MAVEN_BASE}{maven_path}/{TWEETY_VERSION}/{maven_name}-{TWEETY_VERSION}.jar\"\n",
     "        _to_download.append((url, jar))\n",
     "for name, url in _DEPS.items():\n",
     "    jar = LIB_DIR / name\n",
@@ -164,10 +175,10 @@
    "id": "12deb5a4",
    "metadata": {
     "papermill": {
-     "duration": 0.005669,
-     "end_time": "2026-06-02T21:43:33.489222+00:00",
+     "duration": 0.00419,
+     "end_time": "2026-08-24T16:57:48.790050",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.483553+00:00",
+     "start_time": "2026-08-24T16:57:48.785860",
      "status": "completed"
     },
     "tags": []
@@ -189,18 +200,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.353915Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.353739Z",
-     "iopub.status.idle": "2026-06-20T11:16:21.586264Z",
-     "shell.execute_reply": "2026-06-20T11:16:21.585802Z"
+     "iopub.execute_input": "2026-08-24T16:57:48.803395Z",
+     "iopub.status.busy": "2026-08-24T16:57:48.802980Z",
+     "iopub.status.idle": "2026-08-24T16:57:51.531570Z",
+     "shell.execute_reply": "2026-08-24T16:57:51.529867Z"
     },
     "id": "c9384b5d",
     "outputId": "2d652722-71ed-4994-8bae-245477b19cc4",
     "papermill": {
-     "duration": 0.039835,
-     "end_time": "2026-06-02T21:43:33.534214+00:00",
+     "duration": 2.736796,
+     "end_time": "2026-08-24T16:57:51.533068",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.494379+00:00",
+     "start_time": "2026-08-24T16:57:48.796272",
      "status": "completed"
     },
     "tags": []
@@ -210,22 +221,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Verification JVM Tweety + Outils ---\n",
-      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+      "--- Verification JVM Tweety + Outils ---\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JVM demarree avec 42 JARs."
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "JVM demarree avec 13 JARs.\n",
       "\n",
       "JVM prete\n"
      ]
@@ -336,10 +339,10 @@
    "metadata": {
     "id": "8qq8geipre9",
     "papermill": {
-     "duration": 0.006167,
-     "end_time": "2026-06-02T21:43:33.548683+00:00",
+     "duration": 0.00645,
+     "end_time": "2026-08-24T16:57:51.545145",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.542516+00:00",
+     "start_time": "2026-08-24T16:57:51.538695",
      "status": "completed"
     },
     "tags": []
@@ -367,10 +370,10 @@
    "metadata": {
     "id": "f1d9d39c",
     "papermill": {
-     "duration": 0.005281,
-     "end_time": "2026-06-02T21:43:33.559214+00:00",
+     "duration": 0.004785,
+     "end_time": "2026-08-24T16:57:51.554147",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.553933+00:00",
+     "start_time": "2026-08-24T16:57:51.549362",
      "status": "completed"
     },
     "tags": []
@@ -398,18 +401,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.595587Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.594890Z",
-     "iopub.status.idle": "2026-06-20T11:16:21.968193Z",
-     "shell.execute_reply": "2026-06-20T11:16:21.967538Z"
+     "iopub.execute_input": "2026-08-24T16:57:51.567767Z",
+     "iopub.status.busy": "2026-08-24T16:57:51.567163Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.050343Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.049160Z"
     },
     "id": "32a3ee00",
     "outputId": "f2f8dd04-b795-42d1-c0b6-c00775c2cfcf",
     "papermill": {
-     "duration": 0.012545,
-     "end_time": "2026-06-02T21:43:33.579789+00:00",
+     "duration": 0.491466,
+     "end_time": "2026-08-24T16:57:52.051361",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.567244+00:00",
+     "start_time": "2026-08-24T16:57:51.559895",
      "status": "completed"
     },
     "tags": []
@@ -470,10 +473,10 @@
    "metadata": {
     "id": "r8awh2zx0s",
     "papermill": {
-     "duration": 0.00673,
-     "end_time": "2026-06-02T21:43:33.591653+00:00",
+     "duration": 0.005552,
+     "end_time": "2026-08-24T16:57:52.062429",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.584923+00:00",
+     "start_time": "2026-08-24T16:57:52.056877",
      "status": "completed"
     },
     "tags": []
@@ -504,10 +507,10 @@
    "metadata": {
     "id": "249053cb",
     "papermill": {
-     "duration": 0.004846,
-     "end_time": "2026-06-02T21:43:33.601596+00:00",
+     "duration": 0.006265,
+     "end_time": "2026-08-24T16:57:52.074675",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.596750+00:00",
+     "start_time": "2026-08-24T16:57:52.068410",
      "status": "completed"
     },
     "tags": []
@@ -530,18 +533,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.970202Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.969995Z",
-     "iopub.status.idle": "2026-06-20T11:16:21.976106Z",
-     "shell.execute_reply": "2026-06-20T11:16:21.975499Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.088458Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.087910Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.098132Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.096679Z"
     },
     "id": "ccee3f05",
     "outputId": "67f63573-1655-4bfe-fe43-247b56ceafbd",
     "papermill": {
-     "duration": 0.012403,
-     "end_time": "2026-06-02T21:43:33.618771+00:00",
+     "duration": 0.019463,
+     "end_time": "2026-08-24T16:57:52.099221",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.606368+00:00",
+     "start_time": "2026-08-24T16:57:52.079758",
      "status": "completed"
     },
     "tags": []
@@ -600,10 +603,10 @@
    "metadata": {
     "id": "xsjrbzh6vc",
     "papermill": {
-     "duration": 0.005773,
-     "end_time": "2026-06-02T21:43:33.630223+00:00",
+     "duration": 0.005503,
+     "end_time": "2026-08-24T16:57:52.111557",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.624450+00:00",
+     "start_time": "2026-08-24T16:57:52.106054",
      "status": "completed"
     },
     "tags": []
@@ -633,10 +636,10 @@
    "metadata": {
     "id": "61f79f45",
     "papermill": {
-     "duration": 0.005008,
-     "end_time": "2026-06-02T21:43:33.640440+00:00",
+     "duration": 0.004101,
+     "end_time": "2026-08-24T16:57:52.119635",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.635432+00:00",
+     "start_time": "2026-08-24T16:57:52.115534",
      "status": "completed"
     },
     "tags": []
@@ -659,18 +662,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.977831Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.977676Z",
-     "iopub.status.idle": "2026-06-20T11:16:21.991108Z",
-     "shell.execute_reply": "2026-06-20T11:16:21.990527Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.129357Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.129042Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.145698Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.145017Z"
     },
     "id": "c219a0b0",
     "outputId": "61b9825b-ccbe-44ba-a048-db5d843e7005",
     "papermill": {
-     "duration": 0.012349,
-     "end_time": "2026-06-02T21:43:33.657862+00:00",
+     "duration": 0.023463,
+     "end_time": "2026-08-24T16:57:52.147293",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.645513+00:00",
+     "start_time": "2026-08-24T16:57:52.123830",
      "status": "completed"
     },
     "tags": []
@@ -726,10 +729,10 @@
    "metadata": {
     "id": "q8mamrz0awt",
     "papermill": {
-     "duration": 0.005895,
-     "end_time": "2026-06-02T21:43:33.669221+00:00",
+     "duration": 0.005226,
+     "end_time": "2026-08-24T16:57:52.160143",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.663326+00:00",
+     "start_time": "2026-08-24T16:57:52.154917",
      "status": "completed"
     },
     "tags": []
@@ -762,10 +765,10 @@
    "metadata": {
     "id": "67ee6313",
     "papermill": {
-     "duration": 0.005456,
-     "end_time": "2026-06-02T21:43:33.680447+00:00",
+     "duration": 0.003625,
+     "end_time": "2026-08-24T16:57:52.169407",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.674991+00:00",
+     "start_time": "2026-08-24T16:57:52.165782",
      "status": "completed"
     },
     "tags": []
@@ -788,18 +791,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.993361Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.993139Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.005155Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.004306Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.178595Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.178201Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.191882Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.190923Z"
     },
     "id": "86f23e81",
     "outputId": "980732e0-d0c3-42e3-c2d7-907d662b8366",
     "papermill": {
-     "duration": 0.012229,
-     "end_time": "2026-06-02T21:43:33.698279+00:00",
+     "duration": 0.019758,
+     "end_time": "2026-08-24T16:57:52.193015",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.686050+00:00",
+     "start_time": "2026-08-24T16:57:52.173257",
      "status": "completed"
     },
     "tags": []
@@ -857,10 +860,10 @@
    "metadata": {
     "id": "2c53q567ku3",
     "papermill": {
-     "duration": 0.005032,
-     "end_time": "2026-06-02T21:43:33.708826+00:00",
+     "duration": 0.004101,
+     "end_time": "2026-08-24T16:57:52.201161",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.703794+00:00",
+     "start_time": "2026-08-24T16:57:52.197060",
      "status": "completed"
     },
     "tags": []
@@ -894,10 +897,10 @@
    "metadata": {
     "id": "a86b50c4",
     "papermill": {
-     "duration": 0.00505,
-     "end_time": "2026-06-02T21:43:33.719092+00:00",
+     "duration": 0.005601,
+     "end_time": "2026-08-24T16:57:52.211038",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.714042+00:00",
+     "start_time": "2026-08-24T16:57:52.205437",
      "status": "completed"
     },
     "tags": []
@@ -933,18 +936,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.008380Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.008096Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.044718Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.043906Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.222095Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.221498Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.267636Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.266519Z"
     },
     "id": "ca8462d9",
     "outputId": "6bbaf161-0dcb-42e2-fff9-e7264aa4ac37",
     "papermill": {
-     "duration": 0.012159,
-     "end_time": "2026-06-02T21:43:33.736263+00:00",
+     "duration": 0.053248,
+     "end_time": "2026-08-24T16:57:52.269372",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.724104+00:00",
+     "start_time": "2026-08-24T16:57:52.216124",
      "status": "completed"
     },
     "tags": []
@@ -954,7 +957,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- 2.4.1 Logique Modale : Imports ---\n",
+      "--- 2.4.1 Logique Modale : Imports ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Imports ML reussis.\n"
      ]
     }
@@ -994,10 +1003,10 @@
    "metadata": {
     "id": "ax9xqb9l3g9",
     "papermill": {
-     "duration": 0.005236,
-     "end_time": "2026-06-02T21:43:33.746665+00:00",
+     "duration": 0.009081,
+     "end_time": "2026-08-24T16:57:52.284346",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.741429+00:00",
+     "start_time": "2026-08-24T16:57:52.275265",
      "status": "completed"
     },
     "tags": []
@@ -1028,10 +1037,10 @@
    "metadata": {
     "id": "43de1b70",
     "papermill": {
-     "duration": 0.004508,
-     "end_time": "2026-06-02T21:43:33.755838+00:00",
+     "duration": 0.003764,
+     "end_time": "2026-08-24T16:57:52.293667",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.751330+00:00",
+     "start_time": "2026-08-24T16:57:52.289903",
      "status": "completed"
     },
     "tags": []
@@ -1054,18 +1063,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.050811Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.050487Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.070453Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.069772Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.308743Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.308345Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.359553Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.358233Z"
     },
     "id": "31b9b499",
     "outputId": "46ef5a9c-d299-4707-e1ea-e4f1f09a1978",
     "papermill": {
-     "duration": 0.014179,
-     "end_time": "2026-06-02T21:43:33.774700+00:00",
+     "duration": 0.063117,
+     "end_time": "2026-08-24T16:57:52.362541",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.760521+00:00",
+     "start_time": "2026-08-24T16:57:52.299424",
      "status": "completed"
     },
     "tags": []
@@ -1075,7 +1084,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Parsing des formules modales:\n",
+      "Parsing des formules modales:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  [OK] !(<>(p))\n",
       "  [OK] p || r\n",
       "  [OK] !r || [](q && r)\n",
@@ -1130,10 +1145,10 @@
    "metadata": {
     "id": "2tlclzuloxq",
     "papermill": {
-     "duration": 0.004588,
-     "end_time": "2026-06-02T21:43:33.784065+00:00",
+     "duration": 0.005565,
+     "end_time": "2026-08-24T16:57:52.374959",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.779477+00:00",
+     "start_time": "2026-08-24T16:57:52.369394",
      "status": "completed"
     },
     "tags": []
@@ -1164,10 +1179,10 @@
    "metadata": {
     "id": "7e99bbed",
     "papermill": {
-     "duration": 0.004543,
-     "end_time": "2026-06-02T21:43:33.793193+00:00",
+     "duration": 0.004398,
+     "end_time": "2026-08-24T16:57:52.385117",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.788650+00:00",
+     "start_time": "2026-08-24T16:57:52.380719",
      "status": "completed"
     },
     "tags": []
@@ -1198,18 +1213,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.083062Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.082865Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.088685Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.088123Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.396097Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.395677Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.402985Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.402161Z"
     },
     "id": "64bb4a5b",
     "outputId": "09d44228-e27e-4d23-d1dd-05b1a440c86b",
     "papermill": {
-     "duration": 0.012217,
-     "end_time": "2026-06-02T21:43:33.809915+00:00",
+     "duration": 0.014315,
+     "end_time": "2026-08-24T16:57:52.404162",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.797698+00:00",
+     "start_time": "2026-08-24T16:57:52.389847",
      "status": "completed"
     },
     "tags": []
@@ -1340,10 +1355,10 @@
    "metadata": {
     "id": "wiqhhh9vo1",
     "papermill": {
-     "duration": 0.004499,
-     "end_time": "2026-06-02T21:43:33.819016+00:00",
+     "duration": 0.00475,
+     "end_time": "2026-08-24T16:57:52.413181",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.814517+00:00",
+     "start_time": "2026-08-24T16:57:52.408431",
      "status": "completed"
     },
     "tags": []
@@ -1386,10 +1401,10 @@
    "id": "6549fbfc",
    "metadata": {
     "papermill": {
-     "duration": 0.004669,
-     "end_time": "2026-06-02T21:43:33.828178+00:00",
+     "duration": 0.004123,
+     "end_time": "2026-08-24T16:57:52.421785",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.823509+00:00",
+     "start_time": "2026-08-24T16:57:52.417662",
      "status": "completed"
     },
     "tags": []
@@ -1429,16 +1444,16 @@
    "id": "d794b40f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.099084Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.098901Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.102365Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.101771Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.434448Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.433997Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.438684Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.437585Z"
     },
     "papermill": {
-     "duration": 0.011239,
-     "end_time": "2026-06-02T21:43:33.843770+00:00",
+     "duration": 0.013683,
+     "end_time": "2026-08-24T16:57:52.440548",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.832531+00:00",
+     "start_time": "2026-08-24T16:57:52.426865",
      "status": "completed"
     },
     "tags": []
@@ -1469,10 +1484,10 @@
    "metadata": {
     "id": "e781df26",
     "papermill": {
-     "duration": 0.004536,
-     "end_time": "2026-06-02T21:43:33.852916+00:00",
+     "duration": 0.004672,
+     "end_time": "2026-08-24T16:57:52.453365",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.848380+00:00",
+     "start_time": "2026-08-24T16:57:52.448693",
      "status": "completed"
     },
     "tags": []
@@ -1503,18 +1518,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.111960Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.111650Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.142976Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.142330Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.462421Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.462104Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.492491Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.491511Z"
     },
     "id": "d437aa5e",
     "outputId": "2070cbd4-66f8-4d41-8159-679e3a074d63",
     "papermill": {
-     "duration": 0.009837,
-     "end_time": "2026-06-02T21:43:33.867065+00:00",
+     "duration": 0.037017,
+     "end_time": "2026-08-24T16:57:52.494458",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.857228+00:00",
+     "start_time": "2026-08-24T16:57:52.457441",
      "status": "completed"
     },
     "tags": []
@@ -1524,7 +1539,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- 2.5.1 QBF (Quantified Boolean Formulas) ---\n",
+      "--- 2.5.1 QBF (Quantified Boolean Formulas) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Imports QBF reussis.\n"
      ]
     }
@@ -1561,10 +1582,10 @@
    "metadata": {
     "id": "zcsjedqgqsn",
     "papermill": {
-     "duration": 0.004984,
-     "end_time": "2026-06-02T21:43:33.877120+00:00",
+     "duration": 0.004477,
+     "end_time": "2026-08-24T16:57:52.503324",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.872136+00:00",
+     "start_time": "2026-08-24T16:57:52.498847",
      "status": "completed"
     },
     "tags": []
@@ -1606,10 +1627,10 @@
    "metadata": {
     "id": "84cbc8b8",
     "papermill": {
-     "duration": 0.005438,
-     "end_time": "2026-06-02T21:43:33.887872+00:00",
+     "duration": 0.00665,
+     "end_time": "2026-08-24T16:57:52.516434",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.882434+00:00",
+     "start_time": "2026-08-24T16:57:52.509784",
      "status": "completed"
     },
     "tags": []
@@ -1631,18 +1652,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.147114Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.146887Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.152489Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.152089Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.528660Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.527989Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.537282Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.536563Z"
     },
     "id": "3f1eb19c",
     "outputId": "98c7ad80-a908-4588-8216-2b8f1f8545cd",
     "papermill": {
-     "duration": 0.012756,
-     "end_time": "2026-06-02T21:43:33.906083+00:00",
+     "duration": 0.017285,
+     "end_time": "2026-08-24T16:57:52.538521",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.893327+00:00",
+     "start_time": "2026-08-24T16:57:52.521236",
      "status": "completed"
     },
     "tags": []
@@ -1705,10 +1726,10 @@
    "metadata": {
     "id": "j8peljtakkq",
     "papermill": {
-     "duration": 0.005312,
-     "end_time": "2026-06-02T21:43:33.917122+00:00",
+     "duration": 0.005222,
+     "end_time": "2026-08-24T16:57:52.549338",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.911810+00:00",
+     "start_time": "2026-08-24T16:57:52.544116",
      "status": "completed"
     },
     "tags": []
@@ -1747,10 +1768,10 @@
    "id": "3d52cf43",
    "metadata": {
     "papermill": {
-     "duration": 0.005213,
-     "end_time": "2026-06-02T21:43:33.928045+00:00",
+     "duration": 0.005238,
+     "end_time": "2026-08-24T16:57:52.559703",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.922832+00:00",
+     "start_time": "2026-08-24T16:57:52.554465",
      "status": "completed"
     },
     "tags": []
@@ -1784,16 +1805,16 @@
    "id": "1e9afcc4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.154223Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.154098Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.156786Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.156315Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.571488Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.571043Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.576645Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.575282Z"
     },
     "papermill": {
-     "duration": 0.010629,
-     "end_time": "2026-06-02T21:43:33.944069+00:00",
+     "duration": 0.012857,
+     "end_time": "2026-08-24T16:57:52.577901",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.933440+00:00",
+     "start_time": "2026-08-24T16:57:52.565044",
      "status": "completed"
     },
     "tags": []
@@ -1825,10 +1846,10 @@
    "metadata": {
     "id": "bd272720",
     "papermill": {
-     "duration": 0.005041,
-     "end_time": "2026-06-02T21:43:33.955466+00:00",
+     "duration": 0.005006,
+     "end_time": "2026-08-24T16:57:52.587309",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.950425+00:00",
+     "start_time": "2026-08-24T16:57:52.582303",
      "status": "completed"
     },
     "tags": []
@@ -1850,18 +1871,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.158549Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.158433Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.172041Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.171578Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.599760Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.599389Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.620563Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.619692Z"
     },
     "id": "8b153a15",
     "outputId": "5d58d430-c46a-4e35-99af-3b323cc855ef",
     "papermill": {
-     "duration": 0.011721,
-     "end_time": "2026-06-02T21:43:33.971972+00:00",
+     "duration": 0.029196,
+     "end_time": "2026-08-24T16:57:52.621869",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.960251+00:00",
+     "start_time": "2026-08-24T16:57:52.592673",
      "status": "completed"
     },
     "tags": []
@@ -1871,14 +1892,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- 2.5.3 Logique Conditionnelle (CL) ---\n"
+      "--- 2.5.3 Logique Conditionnelle (CL) ---\n",
+      "Imports CL reussis.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports CL reussis.\n",
       "\n",
       "Conditionnel 1: (bird|flies)\n",
       "Conditionnel 2: (penguin|!flies)\n",
@@ -1933,10 +1954,10 @@
    "metadata": {
     "id": "qhrdjt09oj",
     "papermill": {
-     "duration": 0.005506,
-     "end_time": "2026-06-02T21:43:33.982766+00:00",
+     "duration": 0.005631,
+     "end_time": "2026-08-24T16:57:52.632497",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.977260+00:00",
+     "start_time": "2026-08-24T16:57:52.626866",
      "status": "completed"
     },
     "tags": []
@@ -1977,10 +1998,10 @@
    "metadata": {
     "id": "gukci1vj9ze",
     "papermill": {
-     "duration": 0.004981,
-     "end_time": "2026-06-02T21:43:33.992625+00:00",
+     "duration": 0.00512,
+     "end_time": "2026-08-24T16:57:52.642858",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.987644+00:00",
+     "start_time": "2026-08-24T16:57:52.637738",
      "status": "completed"
     },
     "tags": []
@@ -2025,18 +2046,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.173825Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.173693Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.180634Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.180128Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.655008Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.654553Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.663974Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.663171Z"
     },
     "id": "w4l5v5ty69",
     "outputId": "29876fca-fa49-43ae-ebba-0e546d083fee",
     "papermill": {
-     "duration": 0.013973,
-     "end_time": "2026-06-02T21:43:34.012268+00:00",
+     "duration": 0.016765,
+     "end_time": "2026-08-24T16:57:52.664979",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.998295+00:00",
+     "start_time": "2026-08-24T16:57:52.648214",
      "status": "completed"
     },
     "tags": []
@@ -2147,10 +2168,10 @@
    "id": "6ee56fc6",
    "metadata": {
     "papermill": {
-     "duration": 0.004511,
-     "end_time": "2026-06-02T21:43:34.021475+00:00",
+     "duration": 0.004117,
+     "end_time": "2026-08-24T16:57:52.673623",
      "exception": false,
-     "start_time": "2026-06-02T21:43:34.016964+00:00",
+     "start_time": "2026-08-24T16:57:52.669506",
      "status": "completed"
     },
     "tags": []
@@ -2171,10 +2192,10 @@
    "metadata": {
     "id": "4a2b4ad3",
     "papermill": {
-     "duration": 0.004433,
-     "end_time": "2026-06-02T21:43:34.030408+00:00",
+     "duration": 0.004914,
+     "end_time": "2026-08-24T16:57:52.683577",
      "exception": false,
-     "start_time": "2026-06-02T21:43:34.025975+00:00",
+     "start_time": "2026-08-24T16:57:52.678663",
      "status": "completed"
     },
     "tags": []
@@ -2209,10 +2230,10 @@
    "id": "760e58ab",
    "metadata": {
     "papermill": {
-     "duration": 0.004266,
-     "end_time": "2026-06-02T21:43:34.039133+00:00",
+     "duration": 0.004733,
+     "end_time": "2026-08-24T16:57:52.693170",
      "exception": false,
-     "start_time": "2026-06-02T21:43:34.034867+00:00",
+     "start_time": "2026-08-24T16:57:52.688437",
      "status": "completed"
     },
     "tags": []
@@ -2239,16 +2260,16 @@
    "id": "287e261a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.188426Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.188183Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.192569Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.191875Z"
+     "iopub.execute_input": "2026-08-24T16:57:52.707991Z",
+     "iopub.status.busy": "2026-08-24T16:57:52.707476Z",
+     "iopub.status.idle": "2026-08-24T16:57:52.711931Z",
+     "shell.execute_reply": "2026-08-24T16:57:52.710833Z"
     },
     "papermill": {
-     "duration": 0.009467,
-     "end_time": "2026-06-02T21:43:34.053618+00:00",
+     "duration": 0.012491,
+     "end_time": "2026-08-24T16:57:52.713022",
      "exception": false,
-     "start_time": "2026-06-02T21:43:34.044151+00:00",
+     "start_time": "2026-08-24T16:57:52.700531",
      "status": "completed"
     },
     "tags": []
@@ -2274,26 +2295,26 @@
   }
  ],
  "metadata": {
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": null,
-   "qcc_tokens_est": 0,
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": null,
-   "network": true,
-   "external_account": false,
-   "free_alternative": "self",
-   "reduced_pedagogical": false,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-08-03",
-   "validator": "manual-v-provision",
-   "notes": "Advanced logics (modal, default, conditional) via Tweety. Downloads sat4j/args4j + Tweety jars from Maven (cached). Deterministic Java solver. Notebooks executed 16/16 cells."
-  },
   "colab": {
    "provenance": []
+  },
+  "cost": {
+   "api_provider": null,
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": false,
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-03",
+   "network": true,
+   "notes": "Advanced logics (modal, default, conditional) via Tweety. Downloads sat4j/args4j + Tweety jars from Maven (cached). Deterministic Java solver. Notebooks executed 16/16 cells.",
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "validator": "manual-v-provision",
+   "vram_gb": 0,
+   "vram_tier": null
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -2310,18 +2331,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.342964,
-   "end_time": "2026-06-02T21:43:34.606142+00:00",
+   "duration": 10.095592,
+   "end_time": "2026-08-24T16:57:53.063216",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Tweety-3-Advanced-Logics.ipynb",
-   "output_path": "Tweety-3-Advanced-Logics.ipynb",
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb",
+   "output_path": "MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb",
    "parameters": {},
-   "start_time": "2026-06-02T21:43:31.263178+00:00",
+   "start_time": "2026-08-24T16:57:42.967624",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
@@ -2339,8 +2339,8 @@
    "end_time": "2026-08-24T16:57:53.063216",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb",
+   "input_path": "Tweety-3-Advanced-Logics.ipynb",
+   "output_path": "Tweety-3-Advanced-Logics.ipynb",
    "parameters": {},
    "start_time": "2026-08-24T16:57:42.967624",
    "version": "2.6.0"

--- a/scripts/notebook_tools/twin_pairs.d/tweety-3-advanced-logics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-3-advanced-logics.yaml
@@ -21,6 +21,12 @@
       csharp_sha: 52fd778d91449e795a6abe56218dda183b008190
       content_python_sha: 079abdf6ba8ed92125087f2d94ddfc38817c14fe5504e92e8bd593b3f840c691
       content_csharp_sha: 9c3920e259aa31d326dd9ef4c43290314d715449eccc02629d140e497c7efd3b
+    - date: "2026-08-24"
+      by: myia-po-2023:CoursIA
+      python_sha: da446bc362f0930fab59709b542a707562d14aed
+      csharp_sha: 52fd778d91449e795a6abe56218dda183b008190
+      content_python_sha: 7deeaca846ec7ab1188be2520d99bcd98a5768ea36ef552954e1838fb98d3bd3
+      content_csharp_sha: 9c3920e259aa31d326dd9ef4c43290314d715449eccc02629d140e497c7efd3b
   known_differences:
     - "Socle commun : logiques avancees (conditionnelle, modale, QBF) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"org.tweetyproject.tweety-advanced-logics.dll\"` + `using org.tweetyproject.logics.cl.reasoner` etc.). Python via JPype (`from org.tweetyproject.logics.cl.reasoner import SimpleCReasoner`). Meme moteur Java TweetyProject, deux ponts (IKVM traduit vs JPype JVM)."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/guard #12765

## Summary

L'amont TweetyProject a supprime `/builds/` : **404 sur toutes les versions** (verifie firsthand 2026-08-24, probes curl sur root + `org.tweetyproject.logics.pl-1.30.jar`). Repond au proposal ai-01 (dashboard 16:48Z) : diagnostic complet posté sur le dashboard.

**Cartographie** : Tweety-1-Setup et Tweety-12 telechargent via le script canonique `Tweety/scripts/download_tweety_tools.py` (deja Maven Central) — sains. C# `dotnet-build` deja Maven + GitHub tags — sain. **Tweety-3 etait le seul point casse** : cellule inline `_BASE_URL` sur `/builds/1.30/`, fail-soft (ERREUR imprimee, JVM sans classpath, sections sautees) sur fresh checkout ; machines avec `libs/` peuple ne voyaient rien (`if not jar.exists()`).

## Correctif

Cellule 1 : construction d'URL Maven Central identique au script canonique (`artifact.replace('.','/')` + dernier segment), **memes noms de fichiers locaux** (`pl-1.30.jar`, `logics-commons-1.30.jar` — collision commons geree par prefix) → `libs/` interoperable quelle que soit la voie de peuplement.

## Validation (H.1) — profil fresh checkout

- Re-exec Papermill complete avec `libs/` **VIDE** (JVM Zulu 17 portable, kernel python3) : la sortie commitee prouve le download Maven reel — `Telechargement de 13 JAR(s) Tweety 1.30... 13/13 JAR(s) telecharges dans libs/`
- 45 cellules / 16 code, `execution_count` 0 null, **0 erreur kernel**, JVM demarree (mention dans les outputs)
- **0 chemin machine** dans les outputs (scan ratchet MACHINE_PATH manuel : 0 occurrence)
- URLs Maven 1.30 verifiees 200 pre-push : `logics/pl/1.30/pl-1.30.jar`, `commons/1.30/commons-1.30.jar`, `logics/commons/1.30/commons-1.30.jar` ; `maven-metadata.xml` confirme 1.30 publiee
- Scope : 2 fichiers — MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb (+255/-234, source : +6/-2 ; le reste = regeneration des outputs, C.2) + scripts/notebook_tools/twin_pairs.d/tweety-3-advanced-logics.yaml (rebaseline twin #8057 post-normalisation metadata.papermill, cf #8957)

Closes #12789

See (contexte amont cross-workspace) : proposal ai-01 `myia-ai-01:2025-Epita-Intelligence-Symbolique` 2026-08-24T16:48Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Rafraichissement coordinateur (ai-01, 2026-08-25)

Cette PR n'avait **aucun defaut propre** : son seul rouge venait de la voie
ombre, une phase qui se declare observationnelle. Deux mecanismes distincts,
tous deux fermes sur `main` :

- **#12868** -- l'ombre publiait `failure` sur ses check-runs. `pr_gate` ne
  traite en advisory que les noms contenant `advisory`, et `SHADOW_PREFIX` n'en
  contient pas : le verdict entrait dans `bad` et rougissait le seul check
  REQUIS de `main`. Le nom du check est reste inchange **a dessein**, pour
  qu'un re-run ecrase les rouges deja publies -- c'est ce qui se produit ici.
- **#12873** -- quand l'arbre ne revenait pas a son etat apres la bascule,
  l'ombre rendait exit 1. Le check du job ne contient pas non plus `advisory` :
  une panne de l'observateur bloquait une PR saine.

Ce commentaire est une **edition de body volontaire** : `fast-lane-shadow.yml`
ecoute `types: [..., edited]`, donc l'edition redeclenche la voie ombre (et
`perimeter-review-guard`) pour ~7 runs au lieu des ~40 d'un push. Aucun commit,
aucun rebase -- la file est a ~2360 runs et chaque push en coute ~40 a tout le
monde.

Si un rouge subsiste apres ce passage, il est **reel** : postez-le, je tranche.
