### PR TITLE
docs(genai,#12419): cross-ref 09b_Prompt_Security_RedTeam dans README GenAI/Texte (complet acceptation)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -52,6 +52,7 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 |---|----------|-------------|-------|
 | 8 | `8_Reasoning_Models.ipynb` | o4-mini, gpt-5-thinking, reasoning_effort, comparaisons | 60 min |
 | 9 | `9_Production_Patterns.ipynb` | Conversations API, background mode, retry, batch processing | 70 min |
+| 9b | `09b_Prompt_Security_RedTeam.ipynb` | Sécurité LLM : injection de prompt et red-teaming sur la stack self-hosted (3 attaques dont l'indirecte RAG, 2 défenses, tableau attaque×défense mesuré, suite rejouable) — versant adversarial de `9_Production_Patterns` | 90 min |
 | 10 | `10_LocalLlama.ipynb` | vLLM, Qwen3.5-35B-A3B, ZwZ-8B, multi-endpoints, benchmarking | 60 min |
 | 11 | `11_Quantization.ipynb` | AWQ, GPTQ, llmcompressor, modèles vision, déploiement vLLM | 60 min |
 | 12 | `12_Test_Time_Scaling.ipynb` | Best-of-N, Tree-of-Thoughts (BFS/DFS), Reflexion, routeur adaptatif (cf ICR) | 60 min |
@@ -192,7 +193,7 @@ Le fil rouge de cette série est la progression de l'interaction basique avec un
 
 3. **Tier 3** (augmentation) : [5_RAG_Modern](5_RAG_Modern.ipynb) et [6_PDF_Web_Search](6_PDF_Web_Search.ipynb) enrichissent le LLM avec des sources externes. [7_Code_Interpreter](7_Code_Interpreter.ipynb) lui donne la capacité d'exécuter du code.
 
-4. **Tier 4** (production et local) : [8_Reasoning_Models](8_Reasoning_Models.ipynb) exploite les modèles raisonnants. [9_Production_Patterns](9_Production_Patterns.ipynb) couvre les patterns enterprise. [10_LocalLlama](10_LocalLlama.ipynb) et [11_Quantization](11_Quantization.ipynb) déploient en local avec vLLM.
+4. **Tier 4** (production et local) : [8_Reasoning_Models](8_Reasoning_Models.ipynb) exploite les modèles raisonnants. [9_Production_Patterns](9_Production_Patterns.ipynb) couvre les patterns enterprise, et son versant adversarial [09b_Prompt_Security_RedTeam](09b_Prompt_Security_RedTeam.ipynb) enseigne l'injection de prompt et le red-teaming sur notre stack. [10_LocalLlama](10_LocalLlama.ipynb) et [11_Quantization](11_Quantization.ipynb) déploient en local avec vLLM.
 
 5. **Tier 5** (test-time scaling approfondi) : partant de [12_Test_Time_Scaling](12_Test_Time_Scaling.ipynb) (les quatre moteurs en Python pur), l'arc NB-13..18 décompose chaque facette de l'inférence au moment du test — orchestration agentique via function calling ([13](13_Agentic_Orchestration.ipynb)), mémoire persistante par similarité ([14](14_Persistent_Memory.ipynb)), Tree-of-Thoughts sur des problèmes de recherche ([15](15_Tree_of_Thoughts_Search.ipynb)), courbes de scaling de Snell ([16](16_Scaling_Test_Time_Compute.ipynb)), raisonnement natif vs scaling hand-rolled ([17](17_Native_Reasoning_vs_Scaling.ipynb)), puis intégration Semantic Kernel ([18](18_Semantic_Kernel_Plugins.ipynb)).
 


### PR DESCRIPTION
Grain: MED/readme — lane myia-po-2027:CoursIA-2 — prev: DEEP/research-code #12786

## #12419 — completion d'acceptation : cross-ref du notebook 09b dans le README GenAI/Texte

Le notebook `09b_Prompt_Security_RedTeam.ipynb` (Sécurité LLM : injection de prompt + red-teaming) est **deja livre et merge** sur `main` par **#12666** (`feat(genai,#12419)` — 3 attaques dont l'indirecte RAG, 2 defenses, tableau attaque×defense mesure, suite rejouable, ≡3 exercices). Il manquait **un seul critere d'acceptation** : « README GenAI/Texte mis a jour (§E) ; cross-refs vers 9_Production_Patterns, 13_Agentic_Orchestration, serie RAG ». Le claim de cette lane (voir le `[CLAIMED]` sur #12419) avait explicitement differe l'edition du README tant que #12645 l'occupait — **#12645 est merge** (2026-08-24T09:17:54Z), le gate est leve.

### Le changement

`MyIA.AI.Notebooks/GenAI/Texte/README.md` (+2/−1) :
1. Table Tier 4 : ligne `9b | \`09b_Prompt_Security_RedTeam.ipynb\`` inserée juste apres `9_Production_Patterns` (son sibling adverse), description fidele au contenu livre.
2. Prose Tier 4 : « [9_Production_Patterns](...) couvre les patterns enterprise, et son versant adversarial [09b_Prompt_Security_RedTeam](...) enseigne l'injection de prompt et le red-teaming sur notre stack. »

### Preuves

- Les cross-refs internes du notebook sont verifies firsthand : `9_Production_Patterns` (×6), `13_Agentic` (×4), `RAG` (×18) — le notebook satisfait deja les cross-refs ; le README les sublime.
- Diff **markdown-only**, aucun notebook touche (pas de re-exec requise, exception C.2) ; aucun bloc `CATALOG-STATUS` modifie (byte-identique main).
- Pre-commit : **Passed** (H.3 inclus — aucun notebook staged).

### Perimetre

Disjoint des deux claims actifs sur la branche de travail : le notebook lui-meme (livre) est hors perimetre ; le README etait la seule piece manquante. Aucun catalogue regeneré.

See #12419 — **completer l'acceptation** (le notebook deja merge par #12666) ; une PR de contenu, pas une re-livraison.
