### PR TITLE
docs(qc,#3973): retirer BTC-ML du tableau Robuste — artefact in-sample

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/README.md
@@ -14,11 +14,10 @@
 
 ## Performance Summary
 
-### Robuste (Sharpe > 0.5) — 19 stratégies
+### Robuste (Sharpe > 0.5) — 18 stratégies
 
 | Projet | Sharpe | CAGR | MaxDD | Période | Niveau |
 |--------|--------|------|-------|---------|--------|
-| [BTC-ML](BTC-ML/) | **1.647** | 38.1% | 48.8% | 2020-2026 | Intermédiaire |
 | [Framework_Composite_TrendWeather](Framework_Composite_TrendWeather/) | **1.155** | 27.4% | 27.7% | 2015-2026 | Avancé |
 | [CSharp-BTC-EMA-Cross](CSharp-BTC-EMA-Cross/) | **1.094** | 36.2% | 40.7% | 2017-2026 | Débutant |
 | [EMA-Cross-Stocks](EMA-Cross-Stocks/) | **0.872** | 25.7% | 35.7% | 2015-2026 | Débutant |


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2024:CoursIA — prev: MED/notebook-lean #12795

## Résumé

Resync #3973 (partition lane : feuilles QuantConnect) — **doublon BTC-ML** dans `projects/README.md` : la stratégie était listée **deux fois**, en `Robuste` (Sharpe **1.647**, 2020-2026) ET en `Historique` (0.282). Une stratégie ne peut pas relever de deux catégories de Sharpe contradictoires.

**Cause racine** : le 1.647 est un **artefact in-sample** (fenêtre 2020-2026, bull run BTC). La source autoritaire `docs/qc/qc-strategies-status.md` classe `BTC-ML` **Needs-improvement** — Sharpe **OOS 2021-2026 = 0.057**, PSR ~1.5 %, profil quasi-passif post-halving (surapprentissage sur le bull run 2020-2021). C'est précisément le pattern des « stars du catalogue qui s'effondrent » que ce README dénonce lui-même (`PuppiesOfTheDow` 1.99 → 0.30, `HighBookToMarketFScore` 2.09 → 0.41).

## Audit §E — fichier entier (`projects/README.md`, 141 lignes)

- **Robuste** : 19 entrées listées → **18** après retrait de `BTC-ML`. Aucune autre entrée en double avec Historique/Exploratoire.
- **Historique** : 13 entrées (dont `BTC-ML`), tous Sharpe ∈ [0, 0.5] ✓.
- **Exploratoire** : 4 entrées, tous Sharpe < 0 ✓.
- **ML/DL/RL** : « 35+ » (approximation explicite, renvoie STRATEGIES_DETAIL) ✓.
- **QC Library Clones** : « 8 projets » (détail dans STRATEGIES_DETAIL) ✓.
- **Total « 112 projets »** : inchangé — `BTC-ML` reste en Historique.

## Diff

`+1 / −2` — retrait d'UNE ligne de tableau (BTC-ML Robuste) + compte `19 → 18`. Marqueurs `CATALOG-STATUS` non touchés (R1 byte-identique). Un seul fichier, aucune cellule code, aucun notebook.

## Preuves

- Source autoritaire : `docs/qc/qc-strategies-status.md` L309/L318 — `BTC-ML` Sharpe OOS 0.057, verdict **Needs-improvement**.

## Caveat honnêteté (G-VAR-1)

Ce grain est **LIGHT / META** (`readme`) — il **ne tient pas le plancher G-VAR-1** (nécessite un grain CONTENU DEEP/MED). Le pool CONTENU libre est **drainé** à cet instant (vérifié par 2 tirages picker + 4 scans : #5105 GPU-only ai-01 24Go, #11601 veine saturée, #10479/#11798/#10488 CLOSED, #12607 bloqué amont, #9768 claim po-2027, #7357 steps cadrage/port 16Mo). C'est le seul grain de substance réelle et fondée restant dans la partition assignée (#3973 → QuantConnect). Signal provisionnement répété à ai-01 : provisionner un grain CONTENU frais pour que les lanes tiennent G-VAR-1.

See #3973
