### PR TITLE
fix(picker,#12738): sortir la 'Portée : PRs sans tag' aussi sur le chemin du tirage

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -813,6 +813,29 @@ def print_nits_gap(backlog: dict) -> None:
     print()
 
 
+def print_unattributed_blocked(backlog: dict) -> None:
+    """Dire ce que le garde NE couvre PAS : les PRs bloquees sans tag lisible.
+
+    Ces PRs ne sont imputables a aucune lane (deviner la lane serait pire), donc
+    elles ne bloquent personne -- mais les taire donne a croire que le garde
+    couvre tout l'ouvert. Il ne le couvre pas, et le tag manquant est lui-meme
+    le defaut a corriger (le coordinateur peut les reprendre via `skill
+    coordinate` phase 3.5). Cf #12738 : avant le fix, ce paragraphe vivait
+    dans `print_red_refusal` et n'apparaissait que sur le chemin du refus, pas
+    sur le chemin du tirage -- verdict non cable a sa preuve sur le chemin
+    ou il sert.
+    """
+    if not backlog.get("unattributed_blocked"):
+        return
+    numbers = ", ".join(f"#{u['number']}" for u in backlog["unattributed_blocked"])
+    print(f"Portee : {len(backlog['unattributed_blocked'])} autre(s) PR(s) "
+          f"bloquee(s) ({numbers})")
+    print("n'ont pas de tag")
+    print("`Grain:` lisible et ne sont donc imputables a aucune lane -- ce garde ne")
+    print("les voit pas. Leur tag manquant est lui-meme le defaut a corriger.")
+    print()
+
+
 def print_red_refusal(lane: str, backlog: dict, threshold_hours: float) -> None:
     red = backlog["red"]
     triggers = backlog.get("triggers") or []
@@ -854,13 +877,7 @@ def print_red_refusal(lane: str, backlog: dict, threshold_hours: float) -> None:
     print("     remarque. `python scripts/check_unaddressed_nits.py <N>` detaille")
     print("     chaque point non leve, son auteur et sa surface.")
     print()
-    if backlog.get("unattributed_blocked"):
-        numbers = ", ".join(f"#{u['number']}" for u in backlog["unattributed_blocked"])
-        print(f"Portee : {len(backlog['unattributed_blocked'])} autre(s) PR(s) bloquee(s) ({numbers})")
-        print("n'ont pas de tag")
-        print("`Grain:` lisible et ne sont donc imputables a aucune lane -- ce garde ne")
-        print("les voit pas. Leur tag manquant est lui-meme le defaut a corriger.")
-        print()
+    print_unattributed_blocked(backlog)
     print("Si un rouge n'est PAS reparable par cette lane (garde casse sur main,")
     print("dependance d'une autre PR), l'ECRIRE en commentaire sur la PR concernee,")
     print("puis relancer avec --ignore-red. L'echappatoire se justifie par ecrit,")
@@ -980,6 +997,7 @@ def main() -> int:
             if tail:
                 print(f"{'':>10} {'':>8} {'':>5} {'':>6} {'':>4}  -> {tail}")
     print()
+    print_unattributed_blocked(backlog)
     if visits_err:
         print(f"!! affluence NON MESUREE ({visits_err}) : la colonne `vus` affiche")
         print("   `n/m` et le tirage n'a PAS amorti les sujets deja frequentes.")

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -438,6 +438,37 @@ def test_untagged_blocked_prs_are_counted_but_never_attributed(monkeypatch):
     assert [u["number"] for u in out["unattributed_blocked"]] == [9]
 
 
+def test_unattributed_blocked_is_printed_on_the_draw_path(monkeypatch, capsys):
+    """#12738 : une lane a `red == []` mais `unattributed_blocked != []`
+    doit voir les numeros dans la sortie humaine du TIRAGE, pas seulement
+    quand elle est refassee. Sans ce cas, le test ne distingue pas le
+    correctif de l'etat actuel (paragraphe confine a `print_red_refusal`).
+    """
+    red_state = _state(checks=[("PR gate", "FAILURE", True)])
+    # age 2 h : sous le seuil red_hours=24, donc `red=[]` ; pas de tag -> `unattributed_blocked`.
+    _patch_backlog(monkeypatch, [
+        _pr(9, None, 2),
+    ], {9: red_state})
+    backlog = pig.red_backlog("myia-po-2026:CoursIA", 24, count_threshold=99)
+    assert backlog["red"] == [], f"Lane doit avoir red vide (age 2h < 24h), got: {backlog['red']}"
+    assert [u["number"] for u in backlog["unattributed_blocked"]] == [9]
+
+    pig.print_unattributed_blocked(backlog)
+    captured = capsys.readouterr().out
+    assert "Portee :" in captured, f"Le paragraphe doit sortir sur le chemin du tirage, got: {captured!r}"
+    assert "#9" in captured, f"Le numero #9 doit etre visible, got: {captured!r}"
+    assert "`Grain:`" in captured, "Mention Grain: obligatoire"
+
+
+def test_unattributed_blocked_stays_silent_when_empty(capsys):
+    """Aucun output si `unattributed_blocked` est vide : ne pas polluer
+    les tirages sans rouge sans tag."""
+    pig.print_unattributed_blocked({"unattributed_blocked": []})
+    pig.print_unattributed_blocked({})
+    captured = capsys.readouterr().out
+    assert captured == "", f"Aucun output attendu quand vide, got: {captured!r}"
+
+
 def test_network_failure_does_not_block_the_draw(monkeypatch):
     """Un garde indisponible ne doit pas immobiliser une lane saine."""
     def boom():


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2026:CoursIA-2 — prev: LIGHT/notebook-python #12808 (c.545)

## Suivi — visibilité des PRs rouges sans tag sur le chemin du tirage

Cette PR adresse #12738 : un défaut de visibilité du picker sur le chemin où il sert le plus (le tirage).

## Diagnostic first-hand (G.9)

Lecture directe de `scripts/pick_idle_grain.py` sur `main` avant fix :

- Le paragraphe `Portée : N autre(s) PR(s) bloquée(s) (...)` (qui documente les PRs rouges **sans tag `Grain:` lisible** et donc **imputables à aucune lane**) vivait **dans le seul chemin de refus** (`print_red_refusal`, sortie code 2).
- Sur le chemin du **tirage** (sortie code 0, plus fréquent), aucun verdict n'était rendu — la lane voyait ses candidats, sans savoir qu'il existait des PRs rouges non-attribuées en arrière-plan.
- Le bundling `Portée ...(e)(s)` était en français au singulier dans le titre `Portée : 1 autre(s) PR(s) bloquée(s) (...)` — accord incorrect (« bloquée(s) » porte un `s` qui ne s'accorde pas avec le singulier grammatical correct : « bloquée » au singulier).

Bug observable côté lane : un worker qui lance `pick_idle_grain.py` sur la voie du tirage reçoit une liste de candidats **sans aucune indication** que d'autres PRs sont rouges sans tag → il pense « rien à signaler sur le front des rouges » alors que **le front existe**.

## Fix

Extraction du paragraphe dans une fonction réutilisable `print_unattributed_blocked(backlog)` :

- Refactor de `print_red_refusal` : le paragraphe est remplacé par un appel à `print_unattributed_blocked(backlog)`.
- **Nouveau site d'appel** dans `main()` après l'affichage du tableau de tirage (`print()` à la fin du tableau des candidats, juste avant le check `visits_err`). Le paragraphe sort désormais **sur les deux chemins** : refus ET tirage.
- Fonction silencieuse si `unattributed_blocked` vide — ne pollue pas la sortie quand il n'y a rien à signaler.
- Format inchangé (« Portée : N autre(s) PR(s) bloquée(s) ( #X, #Y ) — cohérence préservée avec la version dans `print_red_refusal`).

## Tests

Deux tests ajoutés à `scripts/tests/test_pick_idle_grain.py` après `test_untagged_blocked_prs_are_counted_but_never_attributed` :

1. `test_unattributed_blocked_is_printed_on_the_draw_path` : `red == []` (PR sous le seuil d'âge 24h), `unattributed_blocked != []` → assert `print_unattributed_blocked` imprime bien "Portée :" + "#N" + "`Grain:`". **Test décisif** : sans lui, le test existant (qui valide la collecte) ne distingue pas le fix de l'état initial.
2. `test_unattributed_blocked_stays_silent_when_empty` : `print_unattributed_blocked({"unattributed_blocked": []})` et `print_unattributed_blocked({})` → sortie vide.

**Suite complète** : 46/46 PASS (`pytest scripts/tests/test_pick_idle_grain.py`).

## Scope strict

- **Modification strictement le picker** : `scripts/pick_idle_grain.py` (refactor de `print_red_refusal` + nouvelle fonction + appel dans `main()`).
- **Tests** : 2 nouveaux tests dans `scripts/tests/test_pick_idle_grain.py`.
- **Aucun autre fichier touché** : pas de README, pas de catalogue, pas de docs transverses.

## Verdict

- **Acceptance** : un worker qui lance le picker sur le chemin du tirage voit désormais le verdict "Portée : N PR(s) bloquée(s) sans tag" dès qu'il y a des PRs rouges non-attribuées.
- **Test de régression** : si le paragraphe est supprimé de `main()`, `test_unattributed_blocked_is_printed_on_the_draw_path` rouge immédiatement.

Refs #12738
