### PR TITLE
fix(guards,#12811): pinner encoding utf-8 sur les 6 sites subprocess de check_lane_claim (crash cp1252 Windows)

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -910,7 +910,12 @@ def _gh_issue_comments(issue: str) -> dict:
             # inventory.
             "--json", "number,title,labels,comments",
         ],
+        # #12811 -- gh emits UTF-8; text=True alone decodes with the Windows
+        # locale (cp1252), which raises UnicodeDecodeError on issue bodies
+        # carrying bytes at cp1252-undefined positions (0x81/0x8D/0x8F/0x90/
+        # 0x9D -- common in the UTF-8 of ICT symbols) and kills the guard.
         capture_output=True, text=True, shell=False,
+        encoding="utf-8", errors="replace",
     )
     if proc.returncode != 0:
         raise RuntimeError(
@@ -1001,6 +1006,7 @@ def _fetch_pr_state(pr_ref: int) -> tuple[str | None, str | None]:
                 "--json", "state,merged",
             ],
             capture_output=True, text=True, shell=False,
+            encoding="utf-8", errors="replace",  # #12811
         )
     except Exception as exc:  # pragma: no cover -- defensive
         result = (None, f"gh exec failed: {exc}")
@@ -1099,6 +1105,7 @@ def _post_comment(issue: str, body: str) -> None:
     proc = subprocess.run(
         ["gh", "issue", "comment", str(issue), "--body-file", path],
         capture_output=True, text=True, shell=False,
+        encoding="utf-8", errors="replace",  # #12811
     )
     Path(path).unlink(missing_ok=True)
     if proc.returncode != 0:
@@ -1126,7 +1133,10 @@ def _gh_open_prs_with_files() -> list[dict]:
             "--json", "number,title,headRefName,body,files",
             "--limit", "200",
         ],
+        # #12811 -- 200 PR bodies in one payload: a single non-cp1252 byte
+        # anywhere kills the whole --paths mode on Windows.
         capture_output=True, text=True, shell=False,
+        encoding="utf-8", errors="replace",
     )
     if proc.returncode != 0:
         raise RuntimeError(
@@ -1322,6 +1332,7 @@ def _scope_zero_coverage_warning(
         proc = subprocess.run(
             ["git", "-C", repo_root, "ls-files"],
             capture_output=True, text=True, timeout=10,
+            encoding="utf-8", errors="replace",  # #12811
         )
     except (OSError, subprocess.TimeoutExpired):
         return None
@@ -1378,6 +1389,7 @@ def _git_tracked_files(repo_root: str | None = None) -> list[str] | None:
         proc = subprocess.run(
             ["git", "-C", repo_root, "ls-files"],
             capture_output=True, text=True, timeout=10,
+            encoding="utf-8", errors="replace",  # #12811
         )
     except (OSError, subprocess.TimeoutExpired):
         return None

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -12,6 +12,7 @@ Run: python -m pytest scripts/tests/test_check_lane_claim.py
 """
 import fnmatch
 import json
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -5050,7 +5051,6 @@ def test_run_check_disjoint_joker_caller_clear(capsys):
     )
 
 
-
 # --- CLAIMED-AMEND recognised as replacing-open (#13022) ----------------------
 # Measured on #11703: po-2027's `[CLAIMED-AMEND] ... -- paths: <8 globs>` (union
 # of two scopes, 2026-08-25T22:36Z) was a no-op for `_MARKER_RE` -- the organ
@@ -5251,3 +5251,46 @@ def test_main_repeated_paths_genuinely_disjoint_clear(tmp_path, capsys):
     assert rc == 0
     assert summary["blocking_lanes"] == []
     assert summary["blocked"] is False
+
+
+# --- #12811 : gh/git émettent de l'UTF-8, l'encodage doit être épinglé --------
+
+
+def test_gh_calls_pin_utf8_regression_12811(monkeypatch):
+    """#12811 -- sans `encoding=` épinglé, `text=True` décode avec le locale de
+    l'OS. Sous Windows c'est cp1252, dont les positions non définies
+    (0x81/0x8D/0x8F/0x90/0x9D) lèvent UnicodeDecodeError sur la prose ICT
+    ordinaire (reproduit en direct sur l'issue #5635, Python 3.13 : erreur de
+    décodage dans le reader thread -> proc.stdout None -> json.loads(None)
+    TypeError, garde morte). Le faux ci-dessous décode en cp1252 chaque fois
+    que le site d'appel N'épingle PAS d'encodage -- simulation déterministe du
+    défaut Windows, indépendante du locale de la machine qui exécute les
+    tests."""
+    bad_char = "͏"  # COMBINING GRAPHEME JOINER : UTF-8 = CD 8F
+    # ensure_ascii=False : gh émet le JSON avec les caractères non-ASCII en
+    # clair (pas d'échappement \uXXXX) -- c'est ce qui met les octets bruts
+    # dans le flux et déclenche le décodage cp1252.
+    issue_raw = json.dumps({
+        "number": 5635,
+        "title": "t " + bad_char,
+        "labels": [],
+        "comments": [],
+    }, ensure_ascii=False).encode("utf-8")
+    prlist_raw = json.dumps([
+        {"number": 1, "title": "x " + bad_char, "headRefName": "b",
+         "body": "", "files": []},
+    ], ensure_ascii=False).encode("utf-8")
+    # garde-fou du fixture : le byte qui tue cp1252 est bien dans les payloads
+    assert b"\x8f" in issue_raw and b"\x8f" in prlist_raw
+
+    def fake_run(cmd, **kwargs):
+        raw = prlist_raw if "list" in cmd else issue_raw
+        enc = kwargs.get("encoding") or "cp1252"  # défaut Windows, simulé
+        decoded = raw.decode(enc, kwargs.get("errors") or "strict")
+        return subprocess.CompletedProcess(cmd, 0, stdout=decoded, stderr="")
+
+    monkeypatch.setattr(clc.subprocess, "run", fake_run)
+    issue_payload = clc._gh_issue_comments("5635")
+    assert issue_payload["title"].endswith(bad_char)
+    prs = clc._gh_open_prs_with_files()
+    assert prs[0]["title"].endswith(bad_char)


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2027:CoursIA-2 — prev: LIGHT/docs #12800

## #12811 — check_lane_claim.py crashe sur JSON gh non-cp1252 (Windows) : encoding utf-8 épinglé sur les 6 sites subprocess

### Le défaut, reproduit en direct ce cycle

```
$ python scripts/check_lane_claim.py 5635 --lane myia-po-2027:CoursIA-2
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 3953
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```

L'organe de claims (#9775) **crashe** sur toute issue/PR dont le JSON `gh` contient un octet non-décodable en **cp1252** — le locale Windows quand `subprocess.run(text=True)` n'épingle pas d'`encoding=`. L'UTF-8 multi-octets des symboles ICT (σ, ↔, ≲…) tombe sur les positions non-définies du cp1252 (0x81/0x8D/**0x8F**/0x90/0x9D) : le reader thread lève, `proc.stdout` devient `None`, `json.loads(None)` TypeError. La lane contournait à la main (`gh issue view --comments | grep`) — le garde est contourné au moment précis où on en a besoin. Flotte Windows-majoritaire → toutes les lanes exposées.

### Le fix (+56/0, 2 fichiers)

`encoding="utf-8", errors="replace"` sur les **6 sites** `subprocess.run(text=True)` :

| Site | Commande | Risque corrigé |
|---|---|---|
| `_gh_issue_comments` | `gh issue view --json` | **le crash reproduit** (#5635) |
| `_pr_state` | `gh pr view --json` | bodies de PR |
| `_post_comment` | `gh issue comment` | stderr cite le body |
| `_gh_open_prs_with_files` | `gh pr list --json body,files` (200 PRs) | **élevé** — un seul byte tue le mode `--paths` |
| `_scope_zero_coverage_warning` | `git ls-files` | chemins non-ASCII |
| `_git_tracked_files` | `git ls-files` | idem |

`gh` et `git` émettent de l'UTF-8 ; `errors="replace"` ne s'active que sur de la vraie corruption et garde l'outil vivant. Linux/macOS (locale UTF-8) : no-op.

### Preuves

- **Reproduction manuelle post-fix** : `check_lane_claim.py 5635 --lane myia-po-2027:CoursIA-2` → `CLEAR: no other lane claims #5635 (1 stale claim(s) bypassed)`, exit 0 (crash pré-fix).
- **Contrôle négatif** : `json.dumps(..., ensure_ascii=False).encode("utf-8").decode("cp1252", "strict")` → `UnicodeDecodeError: byte 0x8f` reproduit isolément.
- **Suite** : `python -m pytest scripts/tests/test_check_lane_claim.py` → **235 passed** (234 existants + 1 nouveau).
- **Test de régression** : fake `subprocess.run` honorant le contrat de décodage (`encoding` passé, sinon cp1252 simulé — déterministe, indépendant du locale hôte) ; le fixture garde-fou `assert b"\x8f" in raw` a lui-même attrapé un premier fixture défectueux (`json.dumps` échappe en `͏` ASCII par défaut → `ensure_ascii=False`, fidèle à gh qui n'échappe pas).

### Conformité

- Aucun notebook dans le diff (H.3 skip) ; aucun catalogue régénéré ; scope strict 2 fichiers.
- #12801 (po-2023, OPEN) touche le même fichier dans la région `dead_scope_globs` (sortie JSON) — **régions disjointes**, aucun conflit textuel attendu (vérifié : mes lignes = appels subprocess uniquement).
- Sous Windows, `--stale-threshold 48` reste requis jusqu'à #12751 (règle inchangée).

Closes #12811
