### PR TITLE
ci: sortir les 16 advisory lourds de pull_request, basculer en schedule nocturne (#12817 tranche 1/2)

### DIFF
--- a/.github/workflows/ascii-flowchart-advisory.yml
+++ b/.github/workflows/ascii-flowchart-advisory.yml
@@ -39,15 +39,13 @@ name: ASCII-flowchart detector (advisory)
 # any `${{ }}` expression on purpose.
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'MyIA.AI.Notebooks/**/*.ipynb'
-      - 'scripts/notebook_tools/detect_ascii_flowchart.py'
-      - 'scripts/notebook_tools/tests/test_detect_ascii_flowchart.py'
-      - '.github/workflows/ascii-flowchart-advisory.yml'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '07 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/check-resync-only.yml
+++ b/.github/workflows/check-resync-only.yml
@@ -31,12 +31,13 @@ name: Resync-Only Advisory
 # See #6949, #11884 (this wiring), #1650 (i18n epic).
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'translations/**/*.csv'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '08 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
 

--- a/.github/workflows/cjk-residue-advisory.yml
+++ b/.github/workflows/cjk-residue-advisory.yml
@@ -26,23 +26,13 @@ name: CJK Residue Advisory
 # content criterion runs against student submissions.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
-    paths:
-      # Leak-bearing content -- run whenever any prose/code/notebook changes.
-      - '**/*.ipynb'
-      - '**/*.md'
-      - '**/*.py'
-      - '**/*.cs'
-      # Self-cover (#8822): so this job re-runs on its own modification and can
-      # clean up its label. Without this, a leak-fix commit that touches only
-      # this workflow/script would leave the label stuck.
-      - '.github/workflows/cjk-residue-advisory.yml'
-      - 'scripts/notebook_tools/detect_cjk_residue.py'
-      - 'scripts/notebook_tools/tests/test_detect_cjk_residue.py'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '09 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/degraded-mode-advisory.yml
+++ b/.github/workflows/degraded-mode-advisory.yml
@@ -34,15 +34,13 @@ name: Degraded-mode confession detector (advisory)
 # expression on purpose.
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'MyIA.AI.Notebooks/**/*.ipynb'
-      - 'scripts/notebook_tools/detect_degraded_mode.py'
-      - 'scripts/notebook_tools/tests/test_detect_degraded_mode.py'
-      - '.github/workflows/degraded-mode-advisory.yml'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '10 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/dotnet-nuget-block-advisory.yml
+++ b/.github/workflows/dotnet-nuget-block-advisory.yml
@@ -30,18 +30,13 @@ name: dotnet-nuget-block-advisory
 # Reference RED case: PR #10021 body on App-13b (0 nuget).
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
-    paths:
-      - '**/*.ipynb'
-      # Self-cover (#8822): a paths-filtered label-poser must list its own file,
-      # else it cannot re-run (so cannot remove its own label) once the matching
-      # paths leave the PR diff. Enforced by scripts/check_workflow_label_paths.py.
-      - '.github/workflows/dotnet-nuget-block-advisory.yml'
-      - 'scripts/notebook_tools/check_pr_dotnet_nuget_block.py'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '11 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/exercises-advisory.yml
+++ b/.github/workflows/exercises-advisory.yml
@@ -25,19 +25,13 @@ name: Exercises Convention Advisory
 # scope"), to revisit only once the residual is at 0 and stable.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
-    paths:
-      - '**/*.ipynb'
-      # Self-cover (#8822): a paths-filtered label-poser must list its own file,
-      # else it cannot re-run (so cannot remove its own label) once the matching
-      # paths leave the PR diff -- the bot's label survives its cause. Proven
-      # firsthand on this very workflow (PR #8820: exercises-unparseable posed,
-      # then stuck). Enforced by scripts/check_workflow_label_paths.py.
-      - '.github/workflows/exercises-advisory.yml'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '12 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/h1-hygiene-advisory.yml
+++ b/.github/workflows/h1-hygiene-advisory.yml
@@ -9,14 +9,13 @@ name: h1-hygiene-advisory
 # notebooks are flagged so authors write clean H1s going forward.
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - '**.ipynb'
-      - 'scripts/notebook_tools/h1_hygiene_scan.py'
-      - '.github/workflows/h1-hygiene-advisory.yml'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '13 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/machine-dep-timing-advisory.yml
+++ b/.github/workflows/machine-dep-timing-advisory.yml
@@ -30,12 +30,13 @@ name: machine-dep-timing-advisory
 # regex canonique) + exercises-advisory.yml (le modele advisory label-only).
 
 on:
-    pull_request:
-        paths:
-            - 'MyIA.AI.Notebooks/**/*.ipynb'
-            - 'scripts/notebook_tools/check_machine_dep_timing.py'
-            - 'scripts/notebook_tools/tests/test_check_machine_dep_timing.py'
-
+    schedule:
+      # Nocturnal sweep -- post-merge main verification.
+      # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+      # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+      # "les jobs lourds devraient être payés une fois par fournée".
+      - cron: '14 03 * * *'
+    workflow_dispatch: {}
 concurrency:
   group: machine-dep-timing-advisory-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/markdown-table-guard.yml
+++ b/.github/workflows/markdown-table-guard.yml
@@ -28,19 +28,13 @@ name: Markdown table syntax advisory
 # benevolent review applies, no internal content criterion runs against them.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
-    paths:
-      - '**/*.ipynb'
-      - '**/*.md'
-      - '**/README*'
-      # Self-cover (#8822): a paths-filtered label-poser must list its own file,
-      # else it cannot re-run (so cannot remove its own label) once the matching
-      # paths leave the PR diff. Enforced by scripts/check_workflow_label_paths.py.
-      - '.github/workflows/markdown-table-guard.yml'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '15 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/outputs-text-fragmentation-advisory.yml
+++ b/.github/workflows/outputs-text-fragmentation-advisory.yml
@@ -16,15 +16,13 @@ name: Outputs text fragmentation (advisory)
 # Fondateur : c.354 PR #11664 (Section 2bis XTTS-Voice-Cloning).
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'MyIA.AI.Notebooks/**/*.ipynb'
-      - 'scripts/notebook_tools/check_outputs_text_fragmentation.py'
-      - 'scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py'
-      - '.github/workflows/outputs-text-fragmentation-advisory.yml'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '16 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pedagogy-density-advisory.yml
+++ b/.github/workflows/pedagogy-density-advisory.yml
@@ -27,17 +27,13 @@ name: Pedagogy Density Advisory
 # residual is at 0 and stable (issue #10479 "Hors scope").
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
-    paths:
-      - '**/*.ipynb'
-      # Self-cover (#8822): a paths-filtered label-poser must list its own file,
-      # else it cannot re-run (so cannot remove its own label) once the matching
-      # paths leave the PR diff. Enforced by scripts/check_workflow_label_paths.py.
-      - '.github/workflows/pedagogy-density-advisory.yml'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '17 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/render-volume-delta-advisory.yml
+++ b/.github/workflows/render-volume-delta-advisory.yml
@@ -29,15 +29,13 @@ name: Render volume delta detector (advisory)
 # then: advisory only, never block merge on this signal alone.
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'MyIA.AI.Notebooks/**/*.ipynb'
-      - 'scripts/notebook_tools/check_render_volume_delta.py'
-      - 'scripts/notebook_tools/tests/test_check_render_volume_delta.py'
-      - '.github/workflows/render-volume-delta-advisory.yml'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '18 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/repo-size-advisory.yml
+++ b/.github/workflows/repo-size-advisory.yml
@@ -11,9 +11,13 @@
 name: Repo Size Advisory
 
 on:
-  pull_request:
-    branches: [ main ]
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '19 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
 

--- a/.github/workflows/slides-build-advisory.yml
+++ b/.github/workflows/slides-build-advisory.yml
@@ -50,20 +50,13 @@ name: Slides Build Advisory
 # advisory has run green-and-stable across enough slide PRs to trust it.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
-    paths:
-      - 'slides/**'
-      # The workflow's own file MUST be in the filter, else the gate can never
-      # run on the PR that wires it (this PR touches .github/, not slides/) AND
-      # a live-control revert would strand the label: after revert, base..head
-      # contains no slides/ change, paths blocks re-run, slides-build-failed
-      # sticks dead (the exact defect on exercises-unparseable / #8820). A gate
-      # filtered by paths that also poses a label must self-cover (#8822).
-      - '.github/workflows/slides-build-advisory.yml'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '20 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/slides-composition-advisory.yml
+++ b/.github/workflows/slides-composition-advisory.yml
@@ -32,16 +32,13 @@ name: Slides Composition Advisory
 # l'objet git 6cabc826b, hors d'un checkout shallow CI.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
-    paths:
-      - 'slides/**'
-      # self-cover : la PR qui câble ce workflow ne touche pas slides/, et un
-      # revert ultérieur ne doit pas laisser le gate muet (#8822)
-      - '.github/workflows/slides-composition-advisory.yml'
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '21 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
 

--- a/.github/workflows/translation-parity.yml
+++ b/.github/workflows/translation-parity.yml
@@ -14,13 +14,13 @@ name: Translation parity gate (advisory)
 # Promotes to required when the 14-day advisory period reports 0 defects.
 
 on:
-  pull_request:
-    paths:
-      - "*.ipynb"
-      - "scripts/translation/check_translation_parity.py"
-      - ".github/workflows/translation-parity.yml"
-  workflow_dispatch:
-
+  schedule:
+    # Nocturnal sweep -- post-merge main verification.
+    # Tranche 1 #12817 : sortir les advisory lourds de pull_request
+    # (clone 2.22 Go par run). Stratification user 2026-08-23 :
+    # "les jobs lourds devraient être payés une fois par fournée".
+    - cron: '22 03 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/research-code #12814
See #12817

## Tranche 1/2 — sortir les 16 advisory lourds de `pull_request`

### Contexte (mesure ai-01, 2026-08-24T20:26Z)

| Grandeur | Valeur | Mécanisme |
|---|---|---|
| Runs en file | **2064** | `actions/runs?status=queued .total_count` |
| Attente réelle | **3 h 42** | run `32752142631` créé 16:40Z, job pris à 20:22Z |
| Borne PR gate | **12 min** | en-tête `fast-lane-shadow.yml` |
| Workflows sur `pull_request:` | **97** (sur main) | `grep -lE '^\s+pull_request:' .github/workflows/*.yml \| wc -l` |
| dont `fetch-depth: 0` | **46** | grep, dont **16 advisory** ciblés |
| Pack git | **2,22 Go** | `git count-objects -vH` |

Le PR gate expire sur des PR **saines** à cause de la famine de runners, et le faux rouge fait vieillir 88 PR sur 99 (mesure ai-01).

### La stratification demandée (verbatim user 2026-08-23)

> « Si on a fait une file rapide et une file lente, c'est pour pouvoir stratifier correctement. Les jobs lourds ne devraient être payés qu'une fois par fournée, les légers tournent à chaque fois. »

Un **advisory** qui clone **2,22 Go à chaque push** EST un job lourd.

### Geste — tranche 1

Retirer `pull_request:` (incluant `types:`, `branches:`, `paths:`) sur **chacun des 16 advisory**, et ajouter `schedule: cron: 'MM HH * * *'` (nocturne sur `main`) + `workflow_dispatch:` (pour contrôle positif manuel).

Le passage nocturne tourne sur `main` après merge — **c'est une perte de signal assumée**, et c'est le sens de la directive « une fois par fournée ».

#### Cibles (16) — heures étalées 03:07→03:22 UTC

| # | Fichier | Cron UTC | Note |
|---|---------|----------|------|
| 1 | ascii-flowchart-advisory | `07 03 * * *` | |
| 2 | check-resync-only | `08 03 * * *` | |
| 3 | cjk-residue-advisory | `09 03 * * *` | |
| 4 | degraded-mode-advisory | `10 03 * * *` | |
| 5 | dotnet-nuget-block-advisory | `11 03 * * *` | |
| 6 | exercises-advisory | `12 03 * * *` | |
| 7 | h1-hygiene-advisory | `13 03 * * *` | |
| 8 | machine-dep-timing-advisory | `14 03 * * *` | **indentation 4 préservée** |
| 9 | markdown-table-guard | `15 03 * * *` | |
| 10 | outputs-text-fragmentation-advisory | `16 03 * * *` | |
| 11 | pedagogy-density-advisory | `17 03 * * *` | |
| 12 | render-volume-delta-advisory | `18 03 * * *` | |
| 13 | repo-size-advisory | `19 03 * * *` | **pas de `paths:`/`workflow_dispatch:` à l'origine** |
| 14 | slides-build-advisory | `20 03 * * *` | |
| 15 | slides-composition-advisory | `21 03 * * *` | |
| 16 | translation-parity | `22 03 * * *` | |

### Contrôle positif obligatoire (#12817 acceptance)

Le user a écrit : « Un lot entièrement vert est indiscernable d'un moteur débranché — c'est exactement pourquoi la voie rapide est encore en ombre depuis le 19/08. »

**Avant le merge**, j'ai lancé 2 dispatches manuels sur la branche `feature/12817-advisory-nightly` (les seuls jobs qui peuvent confirmer que la nouvelle YAML structure est ingérable par le parseur GitHub Actions strict) :

| Run | Workflow | Statut | Conclusion |
|---|---|---|---|
| `32775435229` | Resync-Only Advisory (`check-resync-only.yml`) | queued (file #11860) | À compléter |
| `32775472499` | ASCII-flowchart detector (`ascii-flowchart-advisory.yml`) | queued (file #11860) | À compléter |

**Note** : le dispatch manuel n'a PAS échoué avec l'erreur 422 précédente (« failed to parse workflow: A mapping was not expected ») — ce qui prouve que le reformatage au pattern catalogue-cron (`- cron: '...'` list et `workflow_dispatch: {}`) est correct. Avant le reformatage, ces deux mêmes dispatches renvoyaient 422.

**Status report** : les deux runs sont en file d'attente GitHub Actions (file #11860). Je ne suis pas autorisé à forcer leur exécution avant la drainage de la file (interdit ai-01 update-branch fleet-wide gel). Le contrôle positif se complète **automatiquement** : soit ma PR passe → rebase `main` → un des 16 schedule nocturne se déclenche naturellement, soit je re-déclenche le `workflow_dispatch` après merge.

Une fois le `merge` opéré, je relancerai 1 dispatch `workflow_dispatch` sur `main` (post-merge) et mettrai à jour cette section avec la conclusion concrète (`success`/`failure`/`abstain`).

### Acceptance

1. ✅ Les 16 fichiers ne portent plus `pull_request:` dans leur `on:`, et portent `schedule:` + `workflow_dispatch:`.
2. ⏳ **Contrôle positif** : à compléter après merge (cf. section dédiée).
3. ✅ Recompte après merge : 81 sur la branche vs 97 sur main = **-16**, conforme au delta attendu.
4. ✅ Aucun des 82 gates bloquants n'est modifié — `git diff --stat` le prouve (16 fichiers `*.yml` dans `.github/workflows/`, tous `*-advisory*.yml` ou `check-resync-only.yml`/`markdown-table-guard.yml`/`translation-parity.yml`).

### Ce qui n'est PAS demandé

- **Ne touche aucun des 82 gates bloquants**. Un gate hors `pull_request:` cesse de protéger.
- **Ne supprime aucun workflow**. On déplace un déclencheur, on ne retire pas un organe. Un advisory dont le verdict devient constant est un organe éteint — le passage nocturne doit rester **vivant et rouge-capable** (cf. leçon `constant-advisory-verdict-is-an-extinguished-organ`).
- **Ne régénère pas le catalogue** (cf. `catalog-pr-hygiene.md` règle HARD 1).

### Effet attendu sur la file

- 16 advisory × ~10–50 PR ouvertes qui les invoquent = ~200–800 jobs retirés de la file par cycle de push.
- En régime stable : la file tombe de 2064 à ~1300 (estimation conservatrice, sous réserve de la mesure ai-01 post-merge).
- Le `PR gate` expire à 12 min ; avec une file à ~1300, l'attente réelle mesurée tomberait à < 2 h, ce qui laisse de la marge.

### Références croisées

- **#12817** — issue ai-01 (claim déjà posé à mon nom, `paths:` restrictif sur les 16 fichiers).
- **#12690** — issue parente (sortir la CI du goulot, mesure atomique de fetch-depth + 16 advisory).
- **#12810** (c.465, tranche 1/2) — `translation-guard.yml` filtré sur `filter: blob:none + sparse-checkout`. Orthogonal à cette tranche.
- Leçon ancrée (à venir) `gh-workflow-nightly-staggered-minutes-to-flatten-burst`.

### L898 collision guard (look-before-write)

- Vérifié `git worktree list` ✓
- Vérifié `gh pr list --search head:feature/12817-advisory-nightly` ✓ aucune autre PR sur la branche
- Pas de claim concurrent sur le chemin (le claim `[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: ...` a été posé par ai-01 à mon nom le 2026-08-24T20:30:57Z)

### Honnêteté

- Pool narrow structurel persistant c.468 — pas de grain CONTENU viable dans le pool (les 5 premiers grains CONTENU sont tous claim VOID par PRs ouvertes). **Geste META assumé** au sens GRAIN REPAIR (les 2 PRs Reparées antérieures étaient CONTENU : #12760 notebook-python, #12814 research-code), tenant le plancher G-VAR-1 par héritage.
- Vérification YAML validée sur les 16 fichiers via `yaml.safe_load` (0 erreur).
- Vérification recompte : `grep -lE '^\s+pull_request:' .github/workflows/*.yml | wc -l` = 81 sur la branche (vs 97 sur main = -16, conforme).

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
