### PR TITLE
fix(slides,#11508): deck S8-semantic-web L3 debordement 13 slides hors-canvas -> 0

### DIFF
--- a/slides/S8-semantic-web/slides.md
+++ b/slides/S8-semantic-web/slides.md
@@ -185,6 +185,7 @@ layout: section
 
 # SW-4 — SPARQL : Le SQL du Web Sémantique
 
+<div class="dense-list">
 ## Types de requêtes SPARQL
 
 | Requête | Usage |
@@ -215,10 +216,13 @@ foreach (var result in results)
 
 > **Notebooks** : `SW-4-CSharp-SPARQL.ipynb` — 45 min | `SW-4b-Python-SPARQL.ipynb` — 30 min
 
+</div>
+
 ---
 
 # SW-5 — Linked Data : DBpedia et Wikidata
 
+<div class="dense-list">
 ## Les 5 etoiles du Linked Data (Berners-Lee, 2010)
 
 | Etoiles | Critere |
@@ -249,6 +253,8 @@ SELECT ?scientist ?birth WHERE {
 - Wikidata SPARQL endpoint : `https://query.wikidata.org/sparql`
 
 > **Notebooks** : `SW-5-CSharp-LinkedData.ipynb` — 50 min | `SW-5b-Python-LinkedData.ipynb` — 35 min
+
+</div>
 
 ---
 layout: section
@@ -293,6 +299,7 @@ Console.WriteLine($"Apres inference : {dataGraph.Triples.Count} triplets");
 
 # SW-7 — OWL 2 : Ontologies et Logiques de Description
 
+<div class="dense-list">
 ## OWL 2 : au-dela de RDFS
 
 | Feature | RDFS | OWL 2 |
@@ -307,10 +314,8 @@ Console.WriteLine($"Apres inference : {dataGraph.Triples.Count} triplets");
 
 ```csharp
 using VDS.RDF.Ontology;
-
 var ontology = new OntologyGraph();
 ontology.LoadFromFile("foaf.owl");
-
 // Explorer la hierarchie
 var person = ontology.CreateOntologyClass(
     new Uri("http://xmlns.com/foaf/0.1/Person"));
@@ -324,6 +329,8 @@ foreach (var sub in person.DirectSubClasses)
 
 > **Notebooks** : `SW-7-CSharp-OWL.ipynb` — 55 min | `SW-7b-Python-OWL.ipynb` — 45 min
 
+</div>
+
 ---
 layout: section
 ---
@@ -334,6 +341,7 @@ layout: section
 
 # SW-8 — SHACL : Validation des Données RDF
 
+<div class="dense-list">
 ## SHACL vs OWL : deux philosophies
 
 | | OWL | SHACL |
@@ -366,10 +374,13 @@ print(results[2])  # rapport Turtle
 
 > **Notebook** : `SW-8-Python-SHACL.ipynb` — 40 min
 
+</div>
+
 ---
 
 # SW-9 — JSON-LD : Le Web Sémantique rencontre JSON
 
+<div class="dense-list">
 ## JSON-LD : bridge entre JSON et Linked Data
 
 ```python
@@ -403,10 +414,13 @@ compacted = jsonld.compact(doc, {"foaf": "http://xmlns.com/foaf/0.1/"})
 
 > **Notebook** : `SW-9-Python-JSONLD.ipynb` — 40 min
 
+</div>
+
 ---
 
 # SW-10 — RDF 1.2 (RDF-Star) : Assertions sur des Assertions
 
+<div class="dense-list">
 ## Le problème de la reification classique
 
 **But** : annoter un triplet (confiance, source, date...)
@@ -439,6 +453,8 @@ g.parse(data=turtle_star, format="turtle")
 
 > **Notebook** : `SW-10-Python-RDFStar.ipynb` — 45 min
 
+</div>
+
 ---
 layout: section
 ---
@@ -449,6 +465,7 @@ layout: section
 
 # SW-11 — Knowledge Graphs : Construction et Exploration
 
+<div class="dense-list">
 ## Qu'est-ce qu'un Knowledge Graph ?
 
 Un **graphe de connaissances** = graphe RDF a grande echelle, oriente metier
@@ -480,10 +497,13 @@ results = g.query("SELECT ?p WHERE { <http://mykg.../Turing> ?rel ?p }")
 
 > **Notebook** : `SW-11-Python-KnowledgeGraphs.ipynb` — 55 min
 
+</div>
+
 ---
 
 # SW-12 — GraphRAG : Graphes et LLMs
 
+<div class="dense-list">
 ## RAG classique vs GraphRAG
 
 | | RAG classique | GraphRAG |
@@ -498,7 +518,6 @@ results = g.query("SELECT ?p WHERE { <http://mykg.../Turing> ?rel ?p }")
 ```python
 from rdflib import Graph
 from openai import OpenAI
-
 # 1. Extraire des triplets depuis un texte (LLM)
 def extract_triples(text: str) -> list[tuple]:
     response = client.chat.completions.create(
@@ -506,21 +525,22 @@ def extract_triples(text: str) -> list[tuple]:
         messages=[{"role": "user",
                    "content": f"Extrais des triplets (sujet, predicat, objet) du texte : {text}"}])
     return parse_triples(response.choices[0].message.content)
-
 # 2. Stocker dans un graphe RDF
 kg = Graph()
 for s, p, o in extract_triples(document):
     kg.add((URIRef(s), URIRef(p), Literal(o)))
-
 # 3. Retrieval par SPARQL + reponse par LLM
 ```
 
 > **Notebook** : `SW-12-Python-GraphRAG.ipynb` — 50 min
 
+</div>
+
 ---
 
 # SW-13 — Comparaison des Raisonneurs OWL
 
+<div class="dense-list">
 ## Raisonneurs OWL : panorama
 
 | Raisonneur | Langage | Points forts |
@@ -536,15 +556,11 @@ for s, p, o in extract_triples(document):
 ```python
 import owlrl
 from rdflib import Graph
-
 g = Graph()
 g.parse("pizza.owl")
-
 # Appliquer la cloture RDFS + OWL RL
 owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(g)
-
 print(f"Triplets apres inference : {len(g)}")
-
 # Verifier la coherence
 # (avec HermiT via JPype/TweetyProject)
 from org.semanticweb.owlapi.apibinding import OWLManager
@@ -553,6 +569,8 @@ ontology = manager.loadOntologyFromOntologyDocument(File("pizza.owl"))
 ```
 
 > **Notebook** : `SW-13-Python-Reasoners.ipynb` — 45 min
+
+</div>
 
 ---
 layout: section

--- a/slides/S8-semantic-web/style.css
+++ b/slides/S8-semantic-web/style.css
@@ -1,0 +1,87 @@
+/* S8-semantic-web — tenir dans le cadre 980x552.
+ *
+ * Mesuré au rendu headless (scan_slidev_composition, 28 slides) :
+ * 13 slides hors canvas. Deux familles : blocs de code Turtle/SPARQL
+ * trop hauts (PRE 600-712px, slides SW-2b/SW-3/SW-4/SW-8), et listes
+ * denses sous H2 empilés (SW-1, RDFS, etc.).
+ *
+ * Correctif pattern #11536 (S3) : compression typographique verticale
+ * + compression des blocs de code + utilitaire .dense-list. Aucun
+ * contenu n'est retiré.
+ */
+
+/* 1. Titres : récupérer l'espace vertical des marges. */
+.slidev-layout h1 {
+  margin-bottom: 0.35em;
+}
+.slidev-layout h2 {
+  margin-top: 0.45em;
+  margin-bottom: 0.2em;
+}
+
+/* 2. Listes et paragraphes : interligne resserré. */
+.slidev-layout li {
+  line-height: 1.3;
+  margin: 0.1em 0;
+}
+.slidev-layout p {
+  margin: 0.35em 0;
+}
+.slidev-layout blockquote {
+  margin: 0.4em 0;
+  padding: 0.2em 0.8em;
+  font-size: 0.85em;
+  line-height: 1.2;
+}
+.slidev-layout blockquote p {
+  margin: 0.1em 0;
+  line-height: 1.2;
+}
+
+/* 3. Blocs de code : compression verticale (pattern deck 02). */
+.slidev-layout pre {
+  font-size: 0.64em !important;
+  line-height: 1.2 !important;
+  margin: 0.4em 0;
+  padding: 0.5em 0.8em;
+}
+.slidev-layout pre code,
+.slidev-layout pre span {
+  line-height: 1.2 !important;
+}
+
+/* 4. Utilitaire densité maximale : <div class="dense-list">. */
+.slidev-layout .dense-list ul,
+.slidev-layout .dense-list ol {
+  font-size: 0.82em;
+  line-height: 1.22;
+}
+.slidev-layout .dense-list li {
+  margin: 0.02em 0;
+}
+.slidev-layout .dense-list h2 {
+  margin-top: 0.15em;
+}
+.slidev-layout .dense-list p {
+  margin: 0.2em 0;
+  font-size: 0.85em;
+  line-height: 1.2;
+}
+.slidev-layout .dense-list pre {
+  font-size: 0.58em;
+  line-height: 1.2;
+  padding: 0.3em 0.6em;
+}
+.slidev-layout .dense-list blockquote {
+  font-size: 0.86em;
+  line-height: 1.1;
+  margin: 0.15em 0;
+  padding: 0.1em 0.5em;
+}
+.slidev-layout .dense-list table {
+  font-size: 0.78em;
+}
+.slidev-layout .dense-list table th,
+.slidev-layout .dense-list table td {
+  padding: 0.1em 0.4em;
+}


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA — prev: MED/slides #12826

## Résumé

Tranche deck **S8-semantic-web** du lot L3 (EPIC #11508) : résolution des débordements hors-cadre mesurés par `scan_slidev_composition` (rendu headless 980×552, clicks complets, 28 slides).

**Résultat : 13 slides hors-canvas → 0** (résiduels `container_only` = div conteneur seul sans contenu franchissant la limite — classe acceptée par le scanner).

## Méthode (pattern #11536 S3 / #12822 / #12826)

1. **`style.css` deck-level** (nouveau fichier) : compression typographique (marges H1/H2, `li` 1.3, `p`, `blockquote` 0.85em), **compression des blocs de code** (`pre` 0.64em base, `line-height: 1.2 !important` — nécessaire car les styles shiki du thème forcent 1.5), tables 0.78em.
2. **9 slides SW-N** (SW-4/5/7/8/9/10/11/12/13) enveloppées `<div class="dense-list">` (listes 0.82em, pre 0.58em, tables 0.78em, blockquotes 0.86em).
3. **3 slides résiduelles** (SW-7/12/13) : compaction des **lignes vides dans les fences de code** (2-4 lignes par slide, whitespace-only — aucun token modifié).

## Validation

- `scan_slidev_composition.py` post-fix : **HC=0**, 28 slides, rapport `scan_s8_fix11.json` (scratchpad).
- Préservation de contenu : texte normalisé **delta 0** (16552 → 16552 chars), sondes SPARQL/SHACL/GraphRAG/JSON-LD/dotNetRDF/Wikidata/HermiT toutes présentes, 28 slides inchangé.
- Diff : +114/−9 (style.css neuf + divs d'enrobage + blank-lines compactés).

## QA visuel

Rendu final à confirmer par lane vision (planche-contact) — la mesure DOM est l'advisory de l'outil ; la barre de qualité EPIC reste le rendu visuel (lanes MiniMax/ai-01).

See #11508 (tranche partielle — restent S2-ia-exploratoire 9, 04-probabilites 3, 05-theorie-des-jeux 3, S4-trading-exercices 4, S4-d1 1)
