### PR TITLE
fix(nb,#11168): 3e passage arXiv famille QuantConnect — GAE 2016/ICLR -> 2015 arXiv-only + ref Yun 2024

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb
@@ -638,7 +638,7 @@
     "\n",
     "**References :**\n",
     "- Chen et al. (2021), \"Decision Transformer: Reinforcement Learning via Sequence Modeling\"\n",
-    "- arXiv:2411.17900, \"Pretrained LLM Adapted with LoRA as a Decision Transformer for Offline RL in Quantitative Trading\""
+    "- Yun, S. (2024), \"Pretrained LLM Adapted with LoRA as a Decision Transformer for Offline RL in Quantitative Trading\", arXiv:2411.17900"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
@@ -96,7 +96,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : Du DQN au PPO - Pourquoi changer d'approche ? (15 min)"
    ]
@@ -187,7 +187,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2 : Environnement de Trading (10 min)\n",
     "\n",
@@ -688,7 +688,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 3 : Actor-Critic Network et PPO Agent (25 min)"
    ]
@@ -1209,7 +1209,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4 : Entrainement PPO 100K Steps (35 min)"
    ]
@@ -1582,7 +1582,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 5 : Evaluation et Comparaison DQN vs PPO (20 min)"
    ]
@@ -1978,7 +1978,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 6 : Integration QuantConnect (10 min)"
    ]
@@ -2245,7 +2245,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion : PPO pour le Trading Quantitatif"
    ]
@@ -2283,7 +2283,7 @@
     "4. **GAE** : L'estimation d'avantage generalisee reduit la variance tout en controlant le biais,\n",
     "   ameliorant la convergence de l'apprentissage\n",
     "\n",
-    "> **Ancre savante -- PPO & GAE** : Le *clipped surrogate objective* et l'estimation d'avantage generalisee (GAE) sont les deux contributions centrales de PPO. Schulman et al. (2017, *Proximal Policy Optimization Algorithms*, arXiv:1707.06347) introduisent l'objectif tronque qui limite le ratio de probabilite nouveau/ancien a [1-eps, 1+eps] (eps=0.2 ici) pour empecher les mises a jour destructrices -- une alternative simpler et plus robuste aux *trust regions* de TRPO (Schulman et al. 2015, *Trust Region Policy Optimization*, ICML, arXiv:1502.05477). La GAE provient de Schulman et al. (2016, *High-Dimensional Continuous Control Using Generalized Advantage Estimation*, ICLR, arXiv:1506.02438) : elle decompose l'avantage en somme exponentiallement decroissante des residus de Bellman, controlee par lambda (gae_lambda=0.95 ici), offrant un compromis biais-variance. Le cadre actor-critic et les policy gradients remontent a Sutton et al. (2000, *Policy Gradient Methods for Reinforcement Learning with Function Approximation*, NeurIPS) et Williams (1992, *Simple Statistical Gradient-Following Algorithms for Connectionist Reinforcement Learning*, Machine Learning 8:229-256).\n",
+    "> **Ancre savante -- PPO & GAE** : Le *clipped surrogate objective* et l'estimation d'avantage generalisee (GAE) sont les deux contributions centrales de PPO. Schulman et al. (2017, *Proximal Policy Optimization Algorithms*, arXiv:1707.06347) introduisent l'objectif tronque qui limite le ratio de probabilite nouveau/ancien a [1-eps, 1+eps] (eps=0.2 ici) pour empecher les mises a jour destructrices -- une alternative simpler et plus robuste aux *trust regions* de TRPO (Schulman et al. 2015, *Trust Region Policy Optimization*, ICML, arXiv:1502.05477). La GAE provient de Schulman et al. (2015, *High-Dimensional Continuous Control Using Generalized Advantage Estimation*, arXiv:1506.02438) : elle decompose l'avantage en somme exponentiallement decroissante des residus de Bellman, controlee par lambda (gae_lambda=0.95 ici), offrant un compromis biais-variance. Le cadre actor-critic et les policy gradients remontent a Sutton et al. (2000, *Policy Gradient Methods for Reinforcement Learning with Function Approximation*, NeurIPS) et Williams (1992, *Simple Statistical Gradient-Following Algorithms for Connectionist Reinforcement Learning*, Machine Learning 8:229-256).\n",
     "\n",
     "### Resume comparatif DQN vs PPO\n",
     "\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #12824 (famille distincte)

# fix(nb,#11168) : 3ᵉ passage arXiv famille QuantConnect — 2 DRIFT-MINEUR corrigés (GAE 2016/ICLR → 2015 arXiv-only, ref Yun 2024 sans auteur complétée)

Troisième passage de la famille QuantConnect de l'EPIC citations arXiv (#11168) : passe 1 po-2023 (16/08), passe 2 #11235 (16/08, 36/36 identité + 9 fragments). Motivation : **63 notebooks QC modifiés depuis le 16/08** (re-validations BTC, RL series, attention/transformer series) dont les citations n'avaient jamais été re-vérifiées.

## Méthode (protocole EPIC, garde-fous appliqués)

- Sweep fichier-entier `MyIA.AI.Notebooks/QuantConnect/**/*.ipynb` (hors `_archive`, `.ipynb_checkpoints`), cellules markdown, sur worktree frais `origin/main` (5d272714805) : **30 IDs distincts / 63 occurrences**.
- Requête groupée `https://export.arxiv.org/api/query?id_list=…` — **garde-fou : `totalResults=30 == len(ids)=30`, corps non vide**.
- Comparaison par ID : titre, auteurs, année, **et venue quand la prose en nomme une**.

## Verdicts (30 IDs)

| Verdict | IDs |
|---|---|
| **OK** | 28 — `1211.5063` `1312.6114` `1409.0473` `1502.05477` `1509.06461` `1511.06581` `1602.01783` `1603.02754` `1606.08415` `1608.03983` `1706.03762` `1707.06347` `1711.05101` `1801.01290` `1812.05905` `1908.10063` `2004.05150` `2005.14165` `2008.07669` `2009.14794` `2011.04006` `2111.00396` `2201.11903` `2205.13504` `2211.14730` `2310.06625` `2312.00752` `2405.14616` |
| **DRIFT-MINEUR corrigé** | 2 — voir ci-dessous |
| MAUVAISE-ATTRIBUTION / ID-FANTÔME | 0 |

Note de méthode : les citations à l'**année de conférence** avec la conférence nommée (ex. Bahdanau « (2015), ICLR » pour v1 2014-09 ; AdamW « (2019), ICLR » pour v1 2017-11) sont **OK par convention académique** — la divergence v1/venue n'est un drift que quand la venue affirmée est fausse (cas GAE ci-dessous).

## Les 2 corrections

1. **`arXiv:1506.02438` — GAE, Schulman et al.** : la prose disait « Schulman et al. **(2016**, *High-Dimensional Continuous Control Using Generalized Advantage Estimation*, **ICLR**, arXiv:1506.02438) » — deux défauts : v1 arXiv = **2015-06-08**, et le papier n'a **jamais été publié à ICLR** (arXiv-only). Corrigé : « (2015, *…*, arXiv:1506.02438) » (`QC-Py-33-RL-PPO-Trading.ipynb` c44, ancre savante PPO & GAE).
2. **`arXiv:2411.17900` — LoRA Decision Transformer** : citée en bibliographie **sans auteur ni année** (« - arXiv:2411.17900, "Pretrained LLM Adapted with…" ») — l'acceptance de l'EPIC exige la source **auteur inclus**. Corrigé : « - **Yun, S. (2024)**, "Pretrained LLM Adapted with LoRA as a Decision Transformer for Offline RL in Quantitative Trading", arXiv:2411.17900 » (`ML-Training-Pipeline/research_l4_decision_transformer.ipynb` c12).

Aucune désattribution (piège #11163) : les deux corrections ajoutent de la précision, les auteurs restent nommés.

## Conformité

- **Markdown-only** : 2 lignes de citation corrigées sur 2 fichiers, aucune cellule code touchée, aucun output modifié — pas de re-exécution requise (règle EPIC §4 + exception C.2 markdown). Pre-commit H.3 **Passed**. Diff total +10/−10 : les 2 corrections + 7 séparateurs décoratifs `---`→`***` auto-fixés par le pre-commit (`fix_hr_separator.py`, #12075) + 1 newline final.
- **Note transport** : `git push` rejeté 7× par GitHub (« Unable to determine if workflow can be created or updated due to timeout » — endpoint dégradé par la charge CI, mes 2 pushes précédents ce soir sont passés avec le même token) ; la branche a été créée via l'API REST git (`blobs→trees→commits→refs`), contenu identique au commit local, base = `origin/main` frais (51e111582d).
- L898 vérifié avant édition : **0 PR ouverte** touchant `MyIA.AI.Notebooks/QuantConnect/**.ipynb`. `[CLAIMED]` paths-scoped posé sur #11168 (c.5401559866) avant édition.
- Catalogue byte-identique à main. 1 push ce cycle (régime fournées ai-01 respecté).

See #11168 (tranche QC passe 3 livrée ; l'EPIC reste ouverte — FallacyDetection sans passe 2, familles susceptibles de re-dériver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
