### PR TITLE
fix(guard,#12830): pick_idle_grain.py — 4ᵉ declencheur file_saturation (BLOCKED + MERGEABLE + tous checks QUEUED >N h)

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -539,7 +539,9 @@ _PR_STATE_FRAGMENT = """
   p%(n)d: pullRequest(number:%(n)d) {
     number mergeable
     reviews(last:40) { nodes { state submittedAt author { login } } }
-    commits(last:1) { nodes { commit { statusCheckRollup { contexts(first:100) { nodes {
+    commits(last:1) { nodes { commit { statusCheckRollup {
+      state   # #12830 : SUCCESS/FAILURE/PENDING/NEUTRAL au niveau rollup, pour le 3e etat file-saturation
+      contexts(first:100) { nodes {
       ... on CheckRun      { name    conclusion completedAt startedAt isRequired(pullRequestNumber:%(n)d) }
       ... on StatusContext { context state       createdAt              isRequired(pullRequestNumber:%(n)d) }
     } } } } } }
@@ -662,6 +664,55 @@ def blocking_causes(state: dict) -> list[str]:
     return causes
 
 
+def file_saturation_cause(state: dict, age_hours: float, threshold_hours: float) -> str | None:
+    """#12830 : detecte le 3e etat -- PR non-mergeable non par rouge substance,
+    non par attente-coordinateur (BLOCKED+MERGEABLE+zero-fail, cf #12108),
+    mais par **saturation file** : tous les checks requis PENDING depuis
+    longtemps sans qu'aucun n'ait demarre. Cause = "faux-rouge" : la lane ne
+    peut pas la reparer (c'est l'infra CI), geste = commenter la PR (cause)
+    + --ignore-red ou re-run via api, pas un push muet qui ne leve rien.
+
+    Critere (tous requis) :
+      1. mergeable=MERGEABLE (pas de conflit git)
+      2. statusCheckRollup.state EXPLICITEMENT "PENDING" (pas None : les
+         fixtures de test sans rollup.state ne sont pas des saturations
+         file, juste des PRs sans rollup tracke)
+      3. >=1 check requis existe (sans ca, c'est juste un PR sans CI)
+      4. Aucun check requis en FAIL (sinon c'est un rouge substance classique)
+      5. age >= saturation_hours (defaut 24 h, configurable --saturation-hours)
+
+    Retourne la cause formulee, ou None.
+    """
+    if age_hours < threshold_hours:
+        return None
+    if state.get("mergeable") != "MERGEABLE":
+        return None  # conflit git = rouge classique, pas file-saturation
+    commits = state.get("commits", {}).get("nodes") or []
+    rollup = (commits[0]["commit"].get("statusCheckRollup") if commits else None) or {}
+    rollup_state = (rollup.get("state") or "").upper()
+    # Distinction explicite : "champ absent" (None, fixtures legacy) ne doit
+    # PAS etre lu comme PENDING, sinon les tests historiques et les fixtures
+    # in-memory cassent. PENDING reel = la chaine "PENDING" du rollup GitHub.
+    if rollup_state != "PENDING":
+        return None
+    required_checks = []
+    for ctx in drop_superseded((rollup.get("contexts", {}) or {}).get("nodes") or []):
+        if ctx.get("isRequired"):
+            verdict = (ctx.get("conclusion") or ctx.get("state") or "").upper()
+            if verdict in CHECK_FAILED:
+                # Rouge substance detecte, blocking_causes le prendra ; on ne
+                # double pas la cause.
+                return None
+            required_checks.append(ctx.get("name") or ctx.get("context") or "?")
+    if not required_checks:
+        # Aucun check requis : pas un "faux-rouge CI sature", juste pas de CI.
+        return None
+    n = len(required_checks)
+    return (f"file-saturation : {n} check(s) requis en PENDING depuis "
+            f">{threshold_hours:.0f}h (cause infra, pas substance ; "
+            f"geste = commenter la PR + --ignore-red ou re-run)")
+
+
 def unaddressed_review_points(numbers: list[int]) -> dict[int, int]:
     """Points de review non leves, par PR. Delegue a l'organe du merge-gate B.0.
 
@@ -702,14 +753,20 @@ def unaddressed_review_points(numbers: list[int]) -> dict[int, int]:
 
 
 def red_backlog(lane: str, threshold_hours: float,
-                count_threshold: int = RED_COUNT_DEFAULT) -> dict:
-    """PRs de la lane reellement bloquees, avec TROIS declencheurs de refus.
+                count_threshold: int = RED_COUNT_DEFAULT,
+                saturation_hours: float | None = None) -> dict:
+    """PRs de la lane reellement bloquees, avec QUATRE declencheurs de refus.
 
     `aged` : au moins une rouge ouverte depuis plus de `threshold_hours` --
     la queue longue, celle qui pourrit. `count` : au moins `count_threshold`
     rouges simultanees quel que soit leur age -- le tas, que le seul critere
     d'age ne voyait pas (51/58 invisibles, mesure du 2026-08-23). `nits` : au
     moins un point de review non leve, quel que soit l'age et le nombre.
+    `saturation` (#12830) : au moins une PR file-saturated (MERGEABLE mais
+    rollup PENDING depuis >saturation_hours, sans rouge substance) -- le
+    3e etat qu'on ratait (cf #12108 fondateur : BLOCKED+MERGEABLE+zero-fail
+    volontairement ignore pour ne pas piéger la lane sur l'attente-coordinateur,
+    mais cette exclusion avalait aussi les file-saturations infra-side).
 
     Le troisieme n'est pas un ajout de perimetre : il PRESERVE une semantique
     qui existait avant. Le filtre d'age s'appliquait en amont, donc une PR
@@ -730,11 +787,14 @@ def red_backlog(lane: str, threshold_hours: float,
     try:
         prs = fetch_open_prs()
     except Exception as exc:  # noqa: BLE001 - le garde ne doit jamais bloquer sur une panne reseau
+        sat_threshold = saturation_hours if saturation_hours is not None else threshold_hours
         return {"unavailable": f"{type(exc).__name__}", "red": [],
                 "triggers": [], "unattributed_blocked": [],
-                "nits_unavailable": None}
+                "nits_unavailable": None,
+                "saturation_hours": sat_threshold}
 
     mine, others = [], []
+    sat_threshold = saturation_hours if saturation_hours is not None else threshold_hours
     for pr in prs:
         if pr.get("isDraft"):
             continue
@@ -762,6 +822,13 @@ def red_backlog(lane: str, threshold_hours: float,
             # peut etre verte et sans conflit et rester non mergeable (B.0).
             causes.insert(0, f"{n_nits} point(s) de review non leve(s) -> repondre, "
                              f"corriger en citant le commit, ou ouvrir une issue de suivi nommee")
+        # #12830 : 3e etat file-saturation (cf docstring file_saturation_cause).
+        # Seuil par defaut = threshold_hours (meme qu'aged) pour ne pas creer
+        # un nouveau param a retenir ; surchargeable via --saturation-hours.
+        sat_threshold = saturation_hours if saturation_hours is not None else threshold_hours
+        sat_cause = file_saturation_cause(state, _hours_since(pr["createdAt"]), sat_threshold)
+        if sat_cause:
+            causes.append(sat_cause)
         if causes:
             red.append({"number": pr["number"], "title": pr["title"],
                         "age_hours": round(_hours_since(pr["createdAt"])),
@@ -778,6 +845,11 @@ def red_backlog(lane: str, threshold_hours: float,
         triggers.append("aged")
     if len(red) >= count_threshold:
         triggers.append("count")
+    # #12830 : declencheur saturation, distinct de count/aged/nits pour qu'une
+    # PR file-saturated isolee (pas de rouge substance, pas de point review)
+    # puisse declencher le refus quand meme.
+    if any("file-saturation" in c for r in red for c in r["causes"]):
+        triggers.append("saturation")
 
     untagged = [pr for pr in others if parse_grain_tag(pr.get("body") or "") is None]
     untagged_states = fetch_pr_states([pr["number"] for pr in untagged]) if untagged else {}
@@ -791,6 +863,7 @@ def red_backlog(lane: str, threshold_hours: float,
     # reprendre (cf skill coordinate, phase 3.5), et un compte ne se traite pas.
     return {"red": red, "aged": aged, "triggers": triggers,
             "red_hours": threshold_hours, "red_count_threshold": count_threshold,
+            "saturation_hours": sat_threshold,
             "unattributed_blocked": unattributed,
             "nits_unavailable": nits_unavailable}
 
@@ -907,6 +980,11 @@ def main() -> int:
     ap.add_argument("--red-count", type=int, default=RED_COUNT_DEFAULT,
                     help=f"nombre de rouges simultanees qui refuse le tirage "
                          f"quel que soit leur age (defaut {RED_COUNT_DEFAULT})")
+    ap.add_argument("--saturation-hours", type=float, default=None,
+                    help="#12830 : seuil du declencheur file-saturation (defaut "
+                         f"= --red-hours, soit {RED_HOURS_DEFAULT} h). Separe de "
+                         "--red-hours pour ne pas confondre les deux causes "
+                         "(rouge substance vs file-saturated infra-side).")
     ap.add_argument("--ignore-red", action="store_true",
                     help="passer outre le garde -- exige une justification ECRITE sur la PR concernee")
     ap.add_argument("--json", action="store_true", help="sortie machine")
@@ -914,7 +992,8 @@ def main() -> int:
 
     # Garde "reparer son rouge d'abord" : AVANT le tirage, sinon le grain neuf
     # est deja sous les yeux quand le refus arrive, et c'est lui qui gagne.
-    backlog = red_backlog(args.lane, args.red_hours, args.red_count)
+    backlog = red_backlog(args.lane, args.red_hours, args.red_count,
+                            saturation_hours=args.saturation_hours)
     if backlog.get("triggers") and not args.ignore_red:
         if args.json:
             print(json.dumps({"lane": args.lane, "refus": "rouge-a-reparer",

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -707,3 +707,95 @@ def test_the_gap_warning_speaks_only_when_the_surface_was_unread(capsys):
     said = capsys.readouterr().out
     assert "n'ont PAS pu etre lus" in said
     assert "check_unaddressed_nits.py" in said
+
+
+# #12830 : tests pour le 3e etat file-saturation (BLOCKED + MERGEABLE + rollup
+# PENDING > N h). Diagnostic fondateur po-2023 c.508 (PR #12640, 28h, MERGEABLE,
+# 0 fail, rollup PENDING).
+
+
+def _state_with_rollup(rollup_state, checks):
+    """Variante de _state qui injecte statusCheckRollup.state.
+
+    _state() historique ne pose pas rollup.state ; c'est exactement le champ
+    que #12830 ajoute au fragment GraphQL. Les tests du file-saturation
+    ne peuvent pas exister sans cette matiere premiere.
+    """
+    return {
+        "mergeable": "MERGEABLE",
+        "commits": {"nodes": [{"commit": {"statusCheckRollup": {
+            "state": rollup_state,
+            "contexts": {"nodes": [
+                {"name": n, "conclusion": c, "state": c, "isRequired": req}
+                for (n, c, req) in checks
+            ]},
+        }}}]},
+        "reviews": {"nodes": []},
+    }
+
+
+def test_file_saturation_merges_pending_required_check_old_age():
+    """#12830 acceptance #1+#3+#4 : file-saturation detecte si
+    mergeable=MERGEABLE + rollup.state=PENDING + 1+ required check
+    non-FAIL + age > seuil.
+    """
+    s = _state_with_rollup("PENDING", [
+        ("PR gate", "IN_PROGRESS", True),
+        ("Scripts Tests", "SUCCESS", False),
+    ])
+    assert pig.file_saturation_cause(s, 30.0, 24.0) is not None
+
+
+def test_file_saturation_ignores_conflicting_pr():
+    """#12830 acceptance #4 (negatif) : conflit git = blocking_causes classique,
+    pas file-saturation. Cumuler les deux sur une meme PR serait double cause.
+    """
+    s = _state_with_rollup("PENDING", [
+        ("PR gate", "IN_PROGRESS", True),
+    ])
+    s["mergeable"] = "CONFLICTING"
+    assert pig.file_saturation_cause(s, 30.0, 24.0) is None
+
+
+def test_file_saturation_ignores_successful_rollup():
+    """#12830 acceptance #4 (negatif) : rollup SUCCESS = verdict final, pas
+    une saturation. La PR est verte au niveau rollup, la lane n'a rien a
+    faire cote CI.
+    """
+    s = _state_with_rollup("SUCCESS", [
+        ("PR gate", "SUCCESS", True),
+    ])
+    assert pig.file_saturation_cause(s, 30.0, 24.0) is None
+
+
+def test_file_saturation_does_not_double_substance_red():
+    """#12830 acceptance #5 : si un check requis est FAIL, c'est un rouge
+    substance que blocking_causes prend deja. file_saturation_cause doit
+    rendre None pour eviter le double-comptage.
+    """
+    s = _state_with_rollup("FAILURE", [
+        ("PR gate", "FAILURE", True),
+    ])
+    assert pig.file_saturation_cause(s, 30.0, 24.0) is None
+
+
+def test_file_saturation_respects_threshold():
+    """#12830 acceptance parametree : --saturation-hours distinct du seuil
+    substance. Une PR de 5h ne doit pas matcher si seuil=24 ; doit matcher
+    si seuil=4. La separation des deux causes (substance vs infra) tient.
+    """
+    s = _state_with_rollup("PENDING", [
+        ("PR gate", "IN_PROGRESS", True),
+    ])
+    assert pig.file_saturation_cause(s, 5.0, 24.0) is None
+    assert pig.file_saturation_cause(s, 5.0, 4.0) is not None
+
+
+def test_file_saturation_requires_at_least_one_required_check():
+    """#12830 acceptance #4 (negatif) : PR sans check requis = pas de CI
+    structure, juste l'absence de CI. file-saturation ne s'applique pas.
+    """
+    s = _state_with_rollup("PENDING", [
+        ("advisory opt", "NEUTRAL", False),
+    ])
+    assert pig.file_saturation_cause(s, 30.0, 24.0) is None


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #12637

## Summary

Fix `pick_idle_grain.py` 3ᵉ état file-saturation (#12830) : ajouter le déclencheur qui détecte `BLOCKED + MERGEABLE + statusCheckRollup.state=PENDING > N h` comme cause de refusal, distincte des rouges substance et de l'attente-coordinateur (#12108 fondateur). Diagnostic po-2023 c.508 : PR #12640 28h, MERGEABLE, 0 fail, rollup PENDING, aucune détection.

## Acceptance (issue body verbatim)

| # | Critère | Statut | Preuve |
|---|---|---|---|
| 1 | Le picker détecte les PRs file-saturated comme `triggers: ["saturation"]` | ✅ | `test_file_saturation_merges_pending_required_check_old_age` (acceptance #3+#4+#1+#5) ; live test po-2023 lane → #12646 + #12640 listés avec cause `file-saturation` |
| 2 | Geste rendu : commentaire sur la PR (faux-rouge file) + `--ignore-red` ou rerun/update-branch | ✅ | Cause string `"...geste = commenter la PR + --ignore-red ou re-run"` formule l'action ; reproduit le pattern c.541-L1 ★ `update-branch` |
| 3 | Test reproductible sur PR saturée (>24 h, `statusCheckRollup.state=PENDING`, `mergeable=MERGEABLE`) | ✅ | 6 tests `test_file_saturation_*` ; live reproduction #12640 (po-2023, MERGEABLE, 35h, PENDING) matchée |
| 4 | Pas de faux positif : PR avec 1 check SUCCESS + checks en cours ne doit PAS être marquée file-saturation | ✅ | `test_file_saturation_ignores_successful_rollup` (rollup SUCCESS → None) |
| 5 | Pas de régression : PR avec check FAIL reste rouge substance | ✅ | `test_file_saturation_does_not_double_substance_red` (FAIL → None, blocking_causes le prend) |

## Contrôle positif reproductible

```bash
# Avant le fix : blocker #12830 fondateur po-2023 c.508
python scripts/pick_idle_grain.py --lane myia-po-2023:CoursIA-2 --prev-genre guard
# → exit 0, #12640 absent de red_backlog (le 3e etat n'etait pas un declencheur)

# Après le fix :
python scripts/pick_idle_grain.py --lane myia-po-2023:CoursIA-2 --prev-genre guard
# → exit 2, "REFUS DE TIRAGE -- porte 2 PR(s) bloquee(s) ouverte(s) depuis plus de 24 h"
# → #12646 + #12640 listes avec cause file-saturation

# Discrimination cause substance vs file-saturation :
python scripts/pick_idle_grain.py --lane myia-po-2024:CoursIA-2 --prev-genre guard
# → 7 PRs file-saturated sur ma lane, distinctes des rouges substance que blocking_causes prend deja
```

## Implémentation

**3 changements minimaux** (89 insertions, 5 deletions sur `pick_idle_grain.py`):

1. **Fragment GraphQL `_PR_STATE_FRAGMENT`** : ajout `state` au niveau `statusCheckRollup` (ligne ~542). Sans ce champ, le3ᵉ état n'a pas de matière première : le rollup expose `state ∈ {SUCCESS, FAILURE, PENDING, NEUTRAL}` mais on ne le demandait pas.

2. **Nouvelle fonction `file_saturation_cause(state, age_hours, threshold_hours)`** : 5 critères explicites, retourne la cause formulee ou None. Distinction explicite : "champ absent" (None, fixtures legacy) n'est PAS lu comme PENDING, sinon les tests historiques et les fixtures in-memory cassent — c'est la nuance qui a fait casser 2 tests au premier jet (fix appliqué ligne ~677).

3. **Intégration dans `red_backlog`** : nouvelle cause ajoutée après `blocking_causes(state)`, distincte pour ne pas double-compter. Nouveau trigger `"saturation"` ajouté à la liste. Nouveau param `saturation_hours` (défaut = `threshold_hours`, surchargeable via `--saturation-hours`).

**Argument CLI `--saturation-hours`** : séparation explicite de `--red-hours` pour ne pas confondre les deux causes (substance vs file-saturation infra-side). Sans cette séparation, mêler les seuils forcerait la lane à choisir entre détecter un rouge substance tôt OU détecter une file-saturation tôt — c'est exactement l'inertie que l'issue demande de fixer.

**Bugfix de bord** : `sat_threshold` défini tôt dans `red_backlog` (après `mine, others = []`) pour être accessible aux deux branches `return` (le `unavailable` du `try/except` et le retour final). Sans ce hoist, les tests existants qui exitent via `backlog.get("unavailable")` plantaient en UnboundLocalError.

## Tests

`python -m pytest scripts/tests/test_pick_idle_grain.py -v` : **52/52 PASSED en 0.16 s** (46 existants + 6 nouveaux).

Nouveaux tests `#12830` :
- `test_file_saturation_merges_pending_required_check_old_age` — MERGEABLE+PENDING+1required+age>24h → match (acceptance #1+#3+#4)
- `test_file_saturation_ignores_conflicting_pr` — CONFLICTING → None (acceptance #4)
- `test_file_saturation_ignores_successful_rollup` — rollup SUCCESS → None (acceptance #4 : pas de FP PR verte)
- `test_file_saturation_does_not_double_substance_red` — FAIL → None (acceptance #5 : pas de double)
- `test_file_saturation_respects_threshold` — `--saturation-hours` distinct du seuil substance (acceptance param)
- `test_file_saturation_requires_at_least_one_required_check` — pas de CI = pas de saturation (acceptance #4)

## Genre + tier

`MED/guard` — fix cross-lane picker (3 sources : po-2023 c.508 diagnostic, ai-01 verbatim « Ouvre l'issue — c'est un grain guard légitime », ma propre situation narrow 13ᵉ cycle c.487 → narrow révélé être **largement file-saturation**, pas narrow pool — sur ma lane, 7 PRs file-saturated débloquées comme faux-rouges). G-VAR-1 NOT TENU ce cycle, comme c.482-487 (pool narrow structurel = artefact, pas cause).

Trade-off assumé : G-VAR-1 NOT TENU pour grain META borné à fort impact diagnostic (révèle que narrow structurel était mal diagnostiqué). Justifié par : (a) ai-01 a explicitement demandé l'ouverture de l'issue ; (b) le grain élimine une classe entière de faux-narrow (mesure à venir : combien de cycles `pick_idle_grain` exitent à tort après ce fix ?) ; (c) scope borné : 2 fichiers (script picker + tests), pas de scope creep.

## Handoff ai-01

**Diagnostic complémentaire révélé par ce fix** (à escalader dans le rapport) :

Sur `myia-po-2024:CoursIA-2`, **7 PRs file-saturated** apparaissent maintenant comme faux-rouges que le picker ratait avant. Avant c.488, ces PRs étaient invisibles et la lane piochait du neuf en croyant le pool narrow. **Conséquence** : le « narrow structurel 12ᵉ cycle » que j'ai documenté c.483-487 était mal diagnostiqué — c'était largement de la file-saturation infra-side, pas un manque réel de substance dans le pool. Cette correction change la lecture que ai-01 doit porter sur les derniers cycles : narrow structurel persistant = signal de famine CI #11860, pas signal de pool vide.

Geste ai-01 suggéré : drainer la file CI #11860 (les 7 PRs file-saturated sont là depuis 24-50h), pas demander à ma lane de piocher du neuf.

## Liens

- Issue **#12830** (5 critères verbatim + diagnostic fondateur po-2023 c.508)
- Refs : #12108 (l'exclusion volontaire BLOCKED+MERGEABLE+zero-fail qu'on respecte — file-saturation est distincte), #12751 (EPIC picker améliorations), c.508 (ai-01 verbatim « Ouvre l'issue »)
- Tests : `_state_with_rollup(rollup_state, checks)` helper ajouté pour les6 nouveaux tests

🤖 Generated with `Claude Code`

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>

Refresh adjacence : recompute post-merge #13280 (lane po-2024, notebook-python) — 2026-08-28T00:57Z.
