### PR TITLE
fix(guards): require third-party nit author lift

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -34,16 +34,15 @@ Ce qui leve un nit — et ce qui ne le leve PAS
   - une **reponse ecrite** capable de repondre (cf `can_lift` : ni bot de CI,
     ni tag de protocole nu) ;
   - pour un thread inline : `isResolved: true` ou `isOutdated: true` ;
-  - **de la bonne personne** (borne d'auteur #11145) : l'auteur de la reserve,
-    ou l'auteur de la PR qui repond a son reviewer. Une reponse ou une
-    approbation d'un tiers (ni l'un ni l'autre) n'eteint pas la reserve —
-    c'est la classe #10761 que l'organe existe pour bloquer (mesure #11494 :
-    24,3 % des levees etaient BYSTANDER). L'echappement B.0 (issue de suivi
-    nommee) reste le chemin quand la reserve exige l'arbitrage d'un tiers —
-    et depuis #11639, l'arbitrage ECRIT du coordinateur porte une trappe
-    nommee : `[OVERRIDE] lane <machine:workspace>` + phrase de levee (meme
+  - **de la bonne personne** (borne d'auteur #11145, durcie #12836) : l'auteur
+    de la reserve. L'auteur de la PR ne peut pas lever lui-meme une reserve
+    posee par un tiers — sa phrase documente une reponse, mais seule une
+    re-review/levee du tiers confirme qu'il la tient pour traitee. Une reponse
+    ou une approbation d'un autre tiers n'eteint pas davantage la reserve.
+    L'echappement B.0 reste l'arbitrage ECRIT du coordinateur, par la trappe
+    nommee `[OVERRIDE] lane <machine:workspace>` + phrase de levee (meme
     convention ecrite que les claims #10223). Pas une ouverture generale :
-    la borne tient pour tout autre tiers, et un override POST-marge ne peut
+    la borne tient pour tout autre tiers, et un override POST-merge ne peut
     pas avoir eteint une reserve avant la decision de merge.
 
 Ne levent RIEN :
@@ -577,6 +576,34 @@ def has_marker(body: str, markers: tuple[str, ...]) -> bool:
     return any(_unaccent(m) in normalised for m in markers)
 
 
+def _formal_concern_precedes_lift(body: str) -> bool:
+    """Un verdict Hermes formel precede-t-il la narration de sa levee ?
+
+    #12798 contient ``COMMENT_WITH_CONCERNS`` en tete de revalidation puis
+    raconte plus bas qu'une ancienne reserve avait ete « levee ». Ce mot ne
+    retracte pas le verdict vivant qui le precede. A l'inverse, « je leve ma
+    CHANGES_REQUESTED » est une levee explicite historique : le marqueur nomme
+    vient APRES le verbe et doit rester admissible.
+    """
+    stripped = _strip_mentioned_verdicts(_strip_quoted(body))
+    normalised = _unaccent(stripped)
+    concern_positions = [
+        normalised.find(_unaccent(marker))
+        for marker in ("COMMENT_WITH_CONCERNS", "REQUEST_CHANGES", "NEEDS_CHANGES")
+    ]
+    concern_positions = [position for position in concern_positions if position >= 0]
+    lift_positions = [
+        normalised.find(_unaccent(marker))
+        for marker in LIFT_MARKERS
+    ]
+    lift_positions = [position for position in lift_positions if position >= 0]
+    return (
+        bool(concern_positions)
+        and bool(lift_positions)
+        and min(concern_positions) < min(lift_positions)
+    )
+
+
 def _excerpt(body: str) -> str:
     """Tete + queue : le verdict d'un reviewer vit en QUEUE de body.
 
@@ -753,7 +780,13 @@ def classify(author: str, body: str) -> str | None:
     # table de distribution d'ai-01 reste exacte.
     if (has_marker(body, LIFT_MARKERS)
             and not _lift_cancelled(_strip_quoted(body))
-            and not has_live_marker(_strip_quoted(body), SEVERITY_GLYPHS)):
+            and not has_live_marker(_strip_quoted(body), SEVERITY_GLYPHS)
+            # #12836 / #12798 : une revalidation COMMENT_WITH_CONCERNS peut
+            # narrer la levee anterieure qu'elle REFUTE. Seul un verdict Hermes
+            # formel place AVANT le mot de levee garde la reserve vivante ; les
+            # levees explicites historiques (« je leve ma CHANGES_REQUESTED »)
+            # restent admissibles parce que leur ordre est inverse.
+            and not _formal_concern_precedes_lift(body)):
         return None  # annonce de levee / de merge : resolution, pas reserve
     # (construction conditionnelle « et je merge » : voir _lift_cancelled —
     # l'annonce conditionnee n'est pas une levee, SAUF levee explicite d'auteur
@@ -829,12 +862,13 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     commits = [c for c in commits if c]
     last_commit = max(commits) if commits else None
 
-    # #11145 — borne d'auteur : seules les levees de l'auteur de la reserve OU
-    # de l'auteur de la PR comptent. Mesure #11494 (850 PRs) : SELF 22/37
-    # (59,5 %) + PR_AUTHOR 6/37 (16,2 %) = flux sain preserve ; BYSTANDER 9/37
-    # (24,3 %) = la classe #10761 que l'organe bloque (un tiers — approbation
-    # ou reponse — n'eteint pas une reserve posee par un autre).
-    pr_author = (pr_data.get("author") or {}).get("login", "")
+    # #11145 — borne d'auteur, durcie par #12836 : seule une levee de l'auteur
+    # de la reserve compte. #12798 a montre pourquoi PR_AUTHOR n'est pas une
+    # confirmation : l'auteur de la PR avait declare la reserve Hermes levee,
+    # l'organe etait vert, mais le livrable committe restait un stub sans sortie
+    # vLLM. Une reponse de PR_AUTHOR documente le traitement ; elle ne remplace
+    # pas la re-review du tiers. L'arbitrage coordinateur nomme [OVERRIDE]
+    # ci-dessous reste le seul echappement tiers.
 
     # Fenetre 05-29..06-04 (#1958) : la RE-REVIEW APPROVED. Le reviewer qui
     # revient approuver apres sa demande de changements A dit que la reserve
@@ -854,7 +888,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
 
     def _lift_eligible(lift_author: str, nit_author: str,
                        lift_body: str = "") -> bool:
-        if lift_author in (nit_author, pr_author):
+        if lift_author == nit_author:
             return True
         # #11639 : l'override NOMME du coordinateur — l'arbitre tiers de B.0.
         # La restriction d'auteur reste la regle pour tout le monde (elle
@@ -885,6 +919,10 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         if can_lift(c)
         and has_marker(c.get("body", ""), LIFT_MARKERS)
         and not _lift_cancelled(_strip_quoted(c.get("body", "")))
+        # #12836 / #12798 : une reserve qui narre une ancienne levee reste
+        # une reserve, pas un evenement de levee du signal precedent.
+        and classify((c.get("author") or {}).get("login", ""),
+                     c.get("body", "")) is None
     ]
     explicit_lifts = [x for x in explicit_lifts if x[0] is not None]
 

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -771,13 +771,13 @@ def test_cr_cas3_commentaire_tiers_hors_sujet_ne_leve_pas():
     assert run_cr([bystander])["blocked"] is True
 
 
-def test_cr_cas4_phrase_de_levee_leve():
-    """La reponse ecrite que B.0 exige : l'auteur de la PR repond AVEC un
-    marqueur de levee (« sont adresses ») — l'etat se leve."""
+def test_cr_cas4_phrase_auteur_pr_ne_leve_pas_la_review_tierce():
+    """#12836 : l'auteur de la PR documente le fix, mais ne confirme pas a la
+    place du reviewer tiers que sa CHANGES_REQUESTED est levee."""
     fix = {"author": {"login": "jsboige"}, "createdAt": at(12),
            "body": "Les 2 points sont adresses : cellule 19 remplacee par "
                    "strip_lean_comments, commit abc123."}
-    assert run_cr([fix])["blocked"] is False
+    assert run_cr([fix])["blocked"] is True
 
 
 def test_cr_cas5_rereview_approved_meme_auteur_leve():
@@ -826,12 +826,12 @@ def test_nit_commentaire_garde_le_regime_general():
     assert run([USER_NIT, reply])["blocked"] is False
 
 
-# --- #11145 : la borne d'auteur. Une levee ne compte que si elle vient de
-# l'auteur de la reserve OU de l'auteur de la PR (mesure #11494 sur 850 PRs :
-# SELF 22/37 = 59,5 % + PR_AUTHOR 6/37 = 16,2 % = flux sain preserve ;
-# BYSTANDER 9/37 = 24,3 % = la classe #10761 que l'organe bloque — une
-# approbation ou une reponse d'un tiers n'eteint pas une reserve posee par un
-# autre). Echappement B.0 : issue de suivi nommee.
+# --- #11145 / #12836 : la borne d'auteur. Une levee ne compte que si elle
+# vient de l'auteur de la reserve. #12798 a prouve que PR_AUTHOR n'est pas un
+# tiers de confirmation : l'auteur avait declare la reserve Hermes levee alors
+# que le notebook committe restait un stub sans sortie vLLM. Une reponse de
+# PR_AUTHOR documente le traitement mais ne remplace pas la re-review du tiers.
+# Echappement borne : override coordinateur nomme (tests #11639 ci-dessous).
 
 HERMES_NIT = {
     "author": {"login": "clusterManager-Myia"}, "createdAt": at(10),
@@ -929,14 +929,55 @@ def test_auteur_du_nit_leve_son_nit():
     assert run([HERMES_NIT, reply])["blocked"] is False
 
 
-def test_auteur_pr_repond_a_son_reviewer_leve():
-    """PR_AUTHOR (16,2 %) : le worker (auteur de la PR) repond au reviewer
-    AVEC une phrase de levee — le flux sain que la borne preserve
-    (#12319 : la phrase est desormais exigee, l'auteur seul ne suffit plus)."""
+def test_auteur_pr_ne_leve_pas_la_reserve_d_un_tiers():
+    """#12798 : PR_AUTHOR peut documenter le fix, pas confirmer a la place du
+    reviewer tiers que sa reserve est levee. La reserve reste bloquante jusqu'a
+    une re-review/levee de son auteur ou un override coordinateur nomme."""
     reply = {"author": {"login": "jsboige"}, "createdAt": at(12),
              "body": "Les 2 cellules d'interp sont ajoutees, commit abc — "
                      "les points sont adresses."}
-    assert run([HERMES_NIT, reply])["blocked"] is False
+    assert run([HERMES_NIT, reply])["blocked"] is True
+
+
+def test_auteur_pr_puis_levee_du_reviewer_tiers_leve():
+    """Controle positif obligatoire #12836 : le durcissement ne rend pas toute
+    reserve indelebile. PR_AUTHOR repond, puis le reviewer tiers confirme la
+    levee : le gate devient vert."""
+    reply = {"author": {"login": "jsboige"}, "createdAt": at(12),
+             "body": "Les 2 cellules d'interp sont ajoutees, commit abc — "
+                     "les points sont adresses."}
+    reviewer_lift = {
+        "author": {"login": "clusterManager-Myia"},
+        "createdAt": at(13),
+        "body": "Levee de ma reserve apres verification du commit abc.",
+    }
+    assert run([HERMES_NIT, reply, reviewer_lift])["blocked"] is False
+
+
+def test_deux_reserves_du_meme_auteur_ne_s_auto_levent_pas():
+    """#12798 live : deux commentaires COMMENT_WITH_CONCERNS du meme auteur a
+    quelques secondes d'intervalle restent deux emissions, pas une levee. Le
+    second narre une levee anterieure qu'il REFUTE : le verdict formel vivant
+    doit l'emporter sur ce LIFT_MARKER narratif."""
+    first = {
+        "author": {"login": "jsboigeEpita"}, "createdAt": at(10),
+        "body": "[Hermes] COMMENT_WITH_CONCERNS — sortie vLLM absente.",
+    }
+    second = {
+        "author": {"login": "jsboigeEpita"}, "createdAt": at(11),
+        "body": (
+            "[Hermes] COMMENT_WITH_CONCERNS — revalidation apres la levee "
+            "annoncee : cassette toujours non prouvee."
+        ),
+    }
+    data = {
+        "number": 12798, "title": "t", "author": {"login": "jsboige"},
+        "comments": [first, second], "reviews": [],
+        "commits": [{"committedDate": at(19)}],
+    }
+    result = mod.analyse(data, [], MERGED)
+    assert result["blocked"] is True
+    assert len(result["blocking"]) == 2
 
 
 def test_bystander_explicit_lift_ne_leve_pas_changes_requested():


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: LIGHT/notebook-python #12619

## Objet

Durcit la borne d’auteur B.0 : une phrase écrite par l’auteur de la PR ne peut plus lever une réserve posée par un tiers. Seuls comptent désormais :

- une levée ou re-review de l’auteur de la réserve ;
- un `[OVERRIDE] lane ...` explicite du coordinateur accompagné d’une phrase de levée ;
- la résolution native d’un thread inline.

Le patch ferme aussi le faux vert observé sur #12798 : un second commentaire `COMMENT_WITH_CONCERNS` du même auteur n’est plus réinterprété comme événement de levée, et un verdict formel vivant placé avant la narration d’une ancienne « levée » reste bloquant.

## Validation post-fix

Commande unique : 131 tests + `py_compile` + `git diff --check` + les deux contrôles live appariés. `py_compile` et `git diff --check` ont terminé avec `rc=0` dans cette même invocation.

```text
============================= test session starts =============================
platform win32 -- Python 3.13.14, pytest-9.0.3, pluggy-1.6.0
rootdir: D:\dev\CoursIA-2-c12836-b0-author
configfile: pytest.ini
plugins: anyio-4.13.0
collected 131 items

..\CoursIA-2-c12836-b0-author\scripts\tests\test_check_unaddressed_nits.py . [  0%]
........................................................................ [ 55%]
..........................................................               [100%]

============================= 131 passed in 0.21s =============================
```

Contrôles live appariés, sorties verbatim :

```text
{
 "pr": 12798,
 "title": "fix(gametheory,#12580): call_llm_provider reel vLLM + cassette rejouable (lift Hermes reserve)",
 "blocking": [
  {
   "kind": "BOT-CONCERN",
   "author": "jsboigeEpita",
   "src": "comment",
   "at": "2026-08-24T20:38:26+00:00",
   "gap_hours": 3.3,
   "code_pushed_after": true,
   "excerpt": "[Hermes] COMMENT_WITH_CONCERNS — preflight adjoint sur head `69fb4cfd0f` La réparation C.2/C.3 a bien réexécuté les 11 cellules code (counts 1..11, 0 output `error`) et retiré le pseudo-token. En reva [...] utées, (4) 0 erreur, (5) absence de pseudo-token. Ne pas hand-editer les outputs. Séquençage inchangé : #12580 doit être intégré avant retarget de #12798 vers `main`; décision finale réservée à ai-01."
  },
  {
   "kind": "BOT-CONCERN",
   "author": "jsboigeEpita",
   "src": "comment",
   "at": "2026-08-24T20:38:32+00:00",
   "gap_hours": 3.3,
   "code_pushed_after": true,
   "excerpt": "[Hermes] COMMENT_WITH_CONCERNS — preflight adjoint sur head `69fb4cfd0f` La réparation C.2/C.3 a bien réexécuté les 11 cellules code (counts 1..11, 0 output `error`) et retiré le pseudo-token. En reva [...] utées, (4) 0 erreur, (5) absence de pseudo-token. Ne pas hand-editer les outputs. Séquençage inchangé : #12580 doit être intégré avant retarget de #12798 vers `main`; décision finale réservée à ai-01."
  },
  {
   "kind": "BOT-CONCERN",
   "author": "jsboigeEpita",
   "src": "comment",
   "at": "2026-08-24T21:40:15+00:00",
   "gap_hours": 2.3,
   "code_pushed_after": true,
   "excerpt": "[Hermes] COMMENT_WITH_CONCERNS — revalidation adjoint du head `0d6c415cda` La corruption de source signalée sur `69fb4cfd0f` est réparée, mais la réserve n’est pas encore entièrement levée. Vérificati [...] ec le SHA et les mesures 11/11, 0 erreur, symboles AST présents, cassette avant/après inchangée au rejeu. Le séquençage reste #12580 puis retarget #12798 vers `main`; décision finale réservée à ai-01."
  },
  {
   "kind": "BOT-CONCERN",
   "author": "jsboigeEpita",
   "src": "comment",
   "at": "2026-08-24T21:40:17+00:00",
   "gap_hours": 2.3,
   "code_pushed_after": true,
   "excerpt": "[Hermes] COMMENT_WITH_CONCERNS — revalidation adjoint du head `0d6c415cda` La corruption de source signalée sur `69fb4cfd0f` est réparée, mais la réserve n’est pas encore entièrement levée. Vérificati [...] ec le SHA et les mesures 11/11, 0 erreur, symboles AST présents, cassette avant/après inchangée au rejeu. Le séquençage reste #12580 puis retarget #12798 vers `main`; décision finale réservée à ai-01."
  }
 ],
 "blocked": true
}
{
 "pr": 11628,
 "title": "fix(qc,#11112): QC-Py-32-RL-DQN-Trading — re-exec sequence CLEAN 1..15 (NOT_FROM_1 -> CLEAN)",
 "blocking": [],
 "blocked": false
}
PR #12798 rc=1
PR #11628 rc=0
PAIRED_RESULT expected=(1,0) actual=(1,0)
```

## Tests ajoutés ou adaptés

- l’auteur de la PR ne lève pas une review tierce ;
- l’auteur de la PR ne lève pas un commentaire Hermes tiers ;
- une levée ultérieure du reviewer tiers reste valide ;
- deux réserves successives du même auteur ne s’auto-lèvent pas ;
- un verdict `COMMENT_WITH_CONCERNS` vivant précédant la narration d’une ancienne levée reste bloquant.

## Ordre d’intégration

Trois PR ouvertes touchent les deux mêmes fichiers et leurs changements sont complémentaires :

1. #12804 — égalité stricte du citer numérique ;
2. #12819 — exige une phrase explicite de levée ;
3. **cette PR** — exige en plus que cette phrase vienne de l’auteur de la réserve, sauf override coordinateur nommé.

Cette PR doit donc être rebasée après intégration de #12804 et #12819, en conservant leurs tests et leur logique. La PR documentaire #12836 peut précéder ce patch ; elle décrit la règle que celui-ci rend mécanique.

See #12836

Co-Authored-By: Claude <noreply@anthropic.com>
