### PR TITLE
feat(guard,#12363): regle source_list_broken_words — le defaut inverse de source_list_missing_newlines

### DIFF
--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -67,6 +67,18 @@ Rules
     ``**bold**`` paragraphs are common and must NOT be flagged. A corpus sweep found ~43
     pre-existing single-element instances (Tweety-10, CSP-9, Planners, Lean-8) in addition
     to the multi-element ones — all baselined for burn-down.
+- ``source_list_broken_words`` (ERROR): markdown cell whose ``source`` list splits a
+  word mid-word — the INVERSE of ``source_list_missing_newlines`` (#12363). A repair
+  that re-splits a list can cut a word in half across two segments; the GitHub render
+  re-joins them so the defect is INVISIBLE on render, but every segment-by-segment
+  consumer (diff, translation, twin-parity content-SHA, pedagogical grep) sees the
+  word broken. Detected when a segment does not end with ``\n``, ends with a letter,
+  and the next segment starts with a letter (the boundary glues two word-halves with
+  nothing between). Runs AFTER the missing-newlines early-returns: the ratchet targets
+  the post-repair shape ('\n' adequate everywhere, ONE mid-word boundary), where the
+  missing-newlines rule is silent and only this rule sees the split. Corpus measure
+  2026-08-25: 0 hits repo-wide — a pure cliquet, ERROR is safe because ``--check``
+  only blocks NEW violations.
 
 The correct fix for frontmatter cells is to move the metadata into the notebook
 ``metadata`` (invisible, machine-readable) OR render it inside a fenced ```yaml block
@@ -140,6 +152,15 @@ RULE_SEVERITY = {
     # cosmetic rendering defect, not a page-breaking one (unlike the ERRORs).
     "unclosed_bold": WARN,
     "source_list_missing_newlines": ERROR,
+    # #12363: ERROR (bloquant) -- the corpus measure is 0 hits repo-wide on
+    # 2026-08-25 (903 total findings across the other 4 rules, none of them
+    # broken-words). A pure ratchet: the rule is the INVERSE of
+    # source_list_missing_newlines (a repair that re-splits a list may cut a
+    # word mid-word, invisible on render but breaking segment-by-segment
+    # consumers). Count 0 + delta-vs-baseline --check = only NEW violations
+    # block, which is exactly the cliquet the issue asks for ("la prochaine
+    # tranche ne puisse pas l'introduire sans rougir").
+    "source_list_broken_words": ERROR,
     # #12064: ERROR (bloquant) -- the corpus measure is 1 hit / 20,576 markdown
     # cells (the true positive (A) PT_11 cell 5), reproduced by this lane. That
     # precision is what buys blocking status; a wider pattern set would need
@@ -297,6 +318,31 @@ def _as_text(source) -> str:
 
 def _nonblank(lines):
     return [ln for ln in lines if ln.strip() != ""]
+
+
+def _broken_words_in_list(src: list[str]) -> str | None:
+    """First consecutive pair whose join splits a word mid-word (#12363).
+
+    The INVERSE of the missing-newlines artifact: a repair that re-splits a
+    markdown list may cut a word in half, leaving the two halves on adjacent
+    segments. GitHub re-joins them on render (so it looks correct) but any
+    segment-by-segment consumer (diff, translation, twin-parity content-SHA,
+    pedagogical grep) sees the word broken. Detected when a segment does NOT
+    end with '\\n', ends with a letter, and the next segment starts with a
+    letter -- the boundary recreates the word with nothing between.
+
+    Returns a quote of the offending pair, or None. A segment ending with '\\n'
+    is a normal line break and is never flagged; a segment ending with space
+    followed by a letter is a legit join (space preserved) and is not flagged.
+    """
+    for a, b in zip(src, src[1:]):
+        if not a or not b:
+            continue
+        if a.endswith("\n"):
+            continue
+        if a[-1].isalpha() and b[0].isalpha():
+            return f"{a!r} + {b!r}"
+    return None
 
 
 def _cell_hash(rule: str, text: str) -> str:
@@ -569,6 +615,45 @@ def _selfcheck() -> int:
           "(QC-Py-21 mid-suffix, Video mid-prose) and is silent on fenced CJK; "
           "multilingual-stem exclusion tested via scan_notebook; code-cell "
           "exclusion is the markdown-only filter in scan_cell itself")
+
+    # ---- source_list_broken_words (#12363) ------------------------------------
+    # The ratchet for the INVERSE of the missing-newlines artifact: a repair
+    # that re-splits a list may cut a word mid-word. Two positive controls:
+    # (a) the realistic post-repair shape -- '\n' everywhere EXCEPT one
+    # boundary that cuts a word, so missing-newlines is silent (breaks ==
+    # expected) and ONLY this rule sees the split; (b) the verbatim issue
+    # witness ["une phrase cou", "pee au milieu"], checked on the helper --
+    # through scan_cell that shape also trips the co-occurring missing-
+    # newlines collapse (0 breaks < expected), which claims the diagnosis
+    # first; the organ detects the cell either way. Negatives: newline-
+    # terminated segments, space-preserved join.
+    broken_fixtures: list[tuple[str, list[str], bool]] = [
+        ("post-repair shape: \\n adequate, ONE mid-word boundary",
+         ["ligne un\n", "une phrase cou", "pee au milieu\n", "ligne trois\n"],
+         True),
+        ("newline-terminated segments (legit)",
+         ["ligne complete\n", "suivante\n"],
+         False),
+        ("space-preserved join (legit)",
+         ["foo ", "bar"],
+         False),
+    ]
+    for name, src, expected in broken_fixtures:
+        fired = any(f["rule"] == "source_list_broken_words"
+                    for f in scan_cell({"cell_type": "markdown", "source": src}))
+        if fired != expected:
+            failed.append(f"{name}: source_list_broken_words fired={fired}, expected={expected}")
+    if _broken_words_in_list(["une phrase cou", "pee au milieu"]) is None:
+        failed.append("verbatim #12363 witness ['une phrase cou', 'pee au milieu'] "
+                      "not seen by _broken_words_in_list")
+    if failed:
+        print("selfcheck FAIL:", file=sys.stderr)
+        for f in failed:
+            print(f"  !! {f}", file=sys.stderr)
+        return 1
+    print("selfcheck OK: source_list_broken_words fires on the post-repair "
+          "mid-word boundary and the verbatim #12363 witness (helper level); "
+          "silent on newline-terminated and space-preserved joins")
     return 0
 
 
@@ -752,6 +837,28 @@ def scan_cell(cell) -> list[dict]:
                             f"chars with no '\\n' (heading + body collapsed into one string, "
                             f"renders as a giant heading); line structure lost"),
                 "evidence": single.strip()[:100],
+                "hash": _cell_hash(rule, text),
+            }]
+    # ---- source-list broken-words (#12363) -----------------------------------
+    # INVERSE of the missing-newlines rule above: a repair that re-splits a
+    # markdown list may cut a word mid-word. Placed AFTER the missing-newlines
+    # early-returns because the ratchet targets a cell that HAS proper '\n'
+    # (the fix was applied) but was re-split at a wrong spot -- so it does not
+    # trigger the missing-newlines rule but DOES break a word. Runs before the
+    # line-based rules (which reason on the JOINED text, hiding the split).
+    if isinstance(src, list) and len(src) >= 2:
+        broken = _broken_words_in_list(src)
+        if broken:
+            rule = "source_list_broken_words"
+            return [{
+                "rule": rule,
+                "severity": RULE_SEVERITY[rule],
+                "message": (f"markdown cell source list splits a word mid-word at "
+                            f"boundary {broken}: segment does not end with '\\n' and "
+                            f"both neighbors start/end with a letter, so the render "
+                            f"join glues two word-halves (invisible on render, breaks "
+                            f"segment-by-segment consumers)"),
+                "evidence": text.strip()[:100],
                 "hash": _cell_hash(rule, text),
             }]
     lines = text.split("\n")


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: collision #12830 (c.513, verification sur PR #12841)

## Summary

Ajoute l'organe manquant demande par #12363 (souleve par Hermes en review de #12108) : la regle `source_list_broken_words` dans `scripts/notebook_tools/detect_markdown_rendering.py`, cliquet du **defaut inverse** de `source_list_missing_newlines`.

Le defaut : une reparation qui re-decoupe une liste `source` peut couper un mot en deux moities reparties sur deux segments. Le rendu GitHub recolle les segments (defaut **invisible au rendu**) mais tout traitement segment-par-segment (diff, traduction, twin-parity content-SHA, grep pedagogique) voit le mot casse.

## Detection

Pour chaque paire de segments consecutifs `(a, b)` d'une cellule markdown dont `source` est une liste : signaler quand `a` ne se termine PAS par `\n` ET `a` finit par une lettre ET `b` commence par une lettre (la jointure recolle deux moities de mot).

Placement : **apres** les early-returns de `missing_newlines`. Le cliquet cible la forme post-reparation ('\n' adequat partout, UNE frontiere mi-mot) — dans cet etat, `missing_newlines` est silencieux (breaks == expected) et seule cette regle voit la coupe. Le temoin verbatim 2-segments de l'issue (`["une phrase cou", "pee au milieu"]`, 0 `\n`) declenche AUSSI le collapsus missing-newlines co-occurrent qui reclame le diagnostic en premier ; la cellule est detectee de toute facon, et le helper voit la paire (controle au niveau helper).

## Mesure repo-wide datee (acceptance 3)

**2026-08-25, branche basee sur origin/main `59d209115c`, scope = notebooks git-tracked sous `MyIA.AI.Notebooks` (marcheur canonique #8650) : 0 hit `source_list_broken_words`** (rapport : 903 findings totaux = yaml_block_open_no_close 732 + oversized_hint 154 + heading_in_list 15 + unclosed_bold 2 ; aucun broken-word).

Compte nul -> **acceptance 4 vacuite** : aucune tranche a nommer, aucune entree baseline a ajouter. La regle est un pur cliquet : elle ne peut que rougir sur du NOUVEAU.

## Severite : ERROR (justifiee par la mesure)

L'issue demandait "au minimum WARNING, ERROR si la mesure repo-wide rend un compte faible". Compte = 0 -> ERROR, sur parce que `--check` est delta-vs-baseline et ne bloque que les violations NOUVELLES (le cliquet exact demande : "la prochaine tranche ne puisse pas l'introduire sans rougir").

## Selfcheck (acceptance 2) — tenu par le workflow markdown-rendering-guard

- **Controle positif realiste** : `["ligne un\n", "une phrase cou", "pee au milieu\n", "ligne trois\n"]` -> detecte (missing-newlines silencieux, seule la nouvelle regle voit la coupe).
- **Temoin verbatim de l'issue** : `["une phrase cou", "pee au milieu"]` vu par `_broken_words_in_list` (helper).
- **Temoin negatif 1** : `["ligne complete\n", "suivante\n"]` -> non detecte.
- **Temoin negatif 2** (jointure legitime avec espace preserve) : `["foo ", "bar"]` -> non detecte.

## Validation locale (post-fix, relancee)

- `python -m py_compile` OK
- `python scripts/notebook_tools/detect_markdown_rendering.py --selfcheck` -> **OK, 5/5 familles** (les 4 existantes + la nouvelle)
- `python -m pytest scripts/tests/test_detect_markdown_rendering_repair.py -q` -> **7/7 PASS** (garde anti-derive RULE_REPAIR intacte)
- HARD gate CI exacte : `--check --baseline scripts/notebook_tools/markdown_rendering_baseline.json` -> **exit 0** ("no new ERROR-level violations") sur l'arbre de la PR

## Portee

1 fichier, +107 lignes, aucune edition de notebook, catalogue byte-identique a main.

Closes #12363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>