### PR TITLE
fix(ci,#12867): la phase ombre de la fast-lane ne peut plus bloquer le gate REQUIS

### DIFF
--- a/scripts/ci/fast_lane.py
+++ b/scripts/ci/fast_lane.py
@@ -235,9 +235,19 @@ def emit_check_run(repo: str, head_sha: str, name: str, conclusion: str,
         print(f"[fast-lane] check-run publie : {name} -> {conclusion}")
 
 
-def conclusion_for(guard: Guard, rc: int) -> str:
+def conclusion_for(guard: Guard, rc: int, shadow: bool = False) -> str:
     if rc == 0:
         return "success"
+    if shadow:
+        # La phase ombre se declare observationnelle : elle ne doit donc pas
+        # pouvoir bloquer une PR. Or `pr_gate` ne traite en advisory que les
+        # check-runs dont le NOM contient `advisory` -- le prefixe ombre n'en
+        # contient pas, donc un `failure` ombre entrait dans `bad` et rendait
+        # le gate REQUIS rouge. Mesure du 2026-08-25 : 2 PR ouvertes (#12791,
+        # #12820) avaient pour SEUL rouge un check ombre, sur 125 PR portant
+        # un check ombre. Le verdict reste visible dans le titre et le resume
+        # du check-run ; seule sa capacite a bloquer est retiree.
+        return "neutral"
     return "failure" if guard.blocking else "neutral"
 
 
@@ -368,11 +378,11 @@ def main(argv: list[str] | None = None) -> int:
     blocking_failed = False
     for guard in selected:
         rc, log = results.get(guard.name, (0, "(aucune sortie)"))
-        conclusion = conclusion_for(guard, rc)
+        conclusion = conclusion_for(guard, rc, shadow=args.shadow)
         if rc == 0:
             title = "OK"
         elif guard.blocking:
-            title = "echec"
+            title = "echec (ombre : non bloquant)" if args.shadow else "echec"
         else:
             title = "signale (advisory)"
         name = (SHADOW_PREFIX + guard.name) if args.shadow else guard.name

--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -3,12 +3,34 @@
 
 ## Why this exists
 
-`main` has NO required status check. Measured firsthand 2026-08-07:
+`main` REQUIRES exactly one status check, and it is this one. Measured
+firsthand 2026-08-25 (as `jsboige` -- the read returns 404 under `myia-ai-01`,
+which is a question, not an absence):
 
-    gh api repos/jsboige/CoursIA/branches/main/protection   -> no required_status_checks
+    gh api repos/jsboige/CoursIA/branches/main/protection
+        required_status_checks.contexts -> ["PR gate"]   strict -> false
+        enforce_admins                  -> false
     gh api repos/jsboige/CoursIA/rulesets                   -> []
 
-So a PR whose CI is red reports `UNSTABLE` (mergeable), never `BLOCKED`. The
+The paragraph below describes the state BEFORE this check was wired, and is
+kept because it is the reason the design is what it is. It is no longer a
+description of `main`: since #9819 landed, a PR whose `PR gate` is red reports
+`BLOCKED`, not `UNSTABLE`.
+
+Two consequences the wiring makes load-bearing, both measured under a deep
+queue on 2026-08-25:
+
+  - `PR gate` being required means that when it cannot render a verdict --
+    queued behind ~2450 runs, or timed out at its 12-minute bound -- NOTHING
+    merges, including PRs whose every other check is green. That is a
+    deadlock, not slowness.
+  - `enforce_admins: false` is the release valve: an admin can `gh pr merge
+    --admin` when the verdict is unobtainable. It is the only one.
+
+## The state this check was built for (2026-08-07)
+
+At the time, a PR whose CI was red reported `UNSTABLE` (mergeable), never
+`BLOCKED`. The
 only thing standing between a red build and `main` is a human reading
 `gh pr checks` at ~180 merges/day. On 2026-08-07 that failed: #9762 was merged
 with `ci / Lean CI (grothendieck_lean) -> fail` AND a body that declared its own

--- a/scripts/tests/test_fast_lane.py
+++ b/scripts/tests/test_fast_lane.py
@@ -108,6 +108,39 @@ def test_success_is_success_for_both_kinds():
         assert fast_lane.conclusion_for(guard, 0) == "success"
 
 
+def test_shadow_failure_cannot_block_the_required_pr_gate():
+    """Le check ombre ne doit pas pouvoir bloquer le gate REQUIS.
+
+    `pr_gate` ne traite en advisory que les check-runs dont le NOM contient
+    `advisory` ; le prefixe ombre n'en contient pas. Un `failure` publie en
+    mode ombre entrait donc dans `bad` et rendait rouge un gate requis, alors
+    que le job, lui, rendait 0. Mesure du 2026-08-25 : 2 PR ouvertes (#12791,
+    #12820) n'avaient pour seul rouge qu'un check ombre.
+
+    Le test verifie les DEUX polarites. Sans le controle positif, un patch qui
+    neutraliserait aussi le mode reel desarmerait le gate et passerait ici
+    pour un correctif.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import pr_gate
+
+    guard = Guard(name="g", argv=["true"], source="s", blocking=True)
+
+    # le nom ombre n'est pas advisory : c'est bien la conclusion qui portait
+    # le defaut, pas seulement le libelle.
+    assert not pr_gate.is_advisory(fast_lane.SHADOW_PREFIX + guard.name)
+
+    ombre = fast_lane.conclusion_for(guard, 1, shadow=True)
+    reel = fast_lane.conclusion_for(guard, 1, shadow=False)
+
+    assert ombre in pr_gate.CONCLUSION_OK, (
+        "un echec en mode ombre ne doit plus bloquer le gate requis")
+    assert reel not in pr_gate.CONCLUSION_OK, (
+        "CONTROLE POSITIF : hors ombre, un garde bloquant doit toujours "
+        "rougir -- sinon le correctif a desarme le gate")
+    assert fast_lane.conclusion_for(guard, 0, shadow=True) == "success"
+
+
 # ---------------------------------------------------------------------------
 # 3. Coherence du registre avec les workflows d'origine
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Grain: MED/guard - lane myia-ai-01:CoursIA - prev: MED/tooling #12833

## Le defaut

La phase ombre de la fast-lane se declare observationnelle -- le job rend `0`,
et le commentaire dit « il observe, il ne juge pas ». C'etait vrai du **job**
et faux des **check-runs** : `conclusion_for` publiait `failure` pour un garde
bloquant meme en ombre. Or `pr_gate` ne traite en advisory que les check-runs
dont le **nom** contient `advisory`, et `SHADOW_PREFIX` ne le contient pas. Le
`failure` ombre entrait donc dans `bad` et rougissait **le seul check REQUIS
de `main`**.

Une phase qui se declare neutre bloquait des PR.

## Mesure (2026-08-25)

```
PR ouvertes lues                   : 128   <-- denominateur
PR portant un check ombre          : 125   <-- controle positif
PR dont TOUS les rouges sont ombre :   2
  #12791   fast-lane (ombre): perimeter-review-guard
  #12820   Fast lane (ombre) -- 9 gardes, 1 checkout
```

Sans le controle positif, un `2` se lirait aussi bien comme « le defaut est
rare » que comme « la lecture des checks a echoue sur 126 PR ».

## Le correctif, et pourquoi pas le renommage

En ombre, un echec rend `neutral` (dans `pr_gate.CONCLUSION_OK`) au lieu de
`failure`. **Le nom du check reste inchange, a dessein** : un re-run ecrase
alors les check-runs rouges deja publies sur les 2 PR bloquees. Renommer le
prefixe aurait aide les PR futures en laissant les rouges existants en place
sous l'ancien nom -- les 2 PR bloquees le seraient restees.

Le verdict reste lisible : le titre passe a `echec (ombre : non bloquant)`.

## Verification -- deux polarites dans la meme invocation

```
--- ce que `pr_gate` pense des NOMS (inchange par le patch) ---
  is_advisory('fast-lane (ombre): banner-guard') = False
  is_advisory('banner-guard')                    = False
  -> le nom ombre n'est PAS advisory : c'est bien la CONCLUSION qu'il
     fallait corriger, pas seulement le nom.

--- conclusions emises, echec du garde (rc=1) ---
  ombre  , rc=1 -> neutral    bloque le gate ? False
  reel   , rc=1 -> failure    bloque le gate ? True
  ombre  , rc=0 -> success    bloque le gate ? False

CONTROLE NEGATIF (l'ombre ne bloque plus)   : OK
CONTROLE POSITIF (le reel bloque toujours)  : OK
```

Le controle **positif** porte le poids : un patch qui neutraliserait aussi le
mode reel **desarmerait** le gate au lieu de le corriger, et un test ne
regardant que l'ombre l'aurait certifie sain. `test_fast_lane.py` importe
`pr_gate` -- le couplage est verifie, pas suppose.

```
python -m pytest scripts/tests/test_fast_lane.py scripts/tests/test_pr_gate.py -q
92 passed in 4.97s
```

## En-tete de `scripts/pr_gate.py` -- mesure perimee corrigee

Le fichier affirmait encore, mesure du 2026-08-07 a l'appui :

> `main` has NO required status check.

C'est faux depuis que #9819 a cable le gate, et **c'est cette phrase qui a
egare le diagnostic du blocage total de ce jour** : lue comme un fait courant,
elle rendait inconcevable que `PR gate` bloque quoi que ce soit. Remplacee par
la mesure firsthand du 2026-08-25 sous `jsboige` (le read rend 404 sous
`myia-ai-01` -- une question, pas une absence), avec les deux consequences que
le cablage rend portantes : un gate requis qui ne peut pas rendre de verdict
bloque TOUT, et `enforce_admins: false` en est l'unique soupape.

Le paragraphe d'origine est conserve, date, comme raison d'etre du design.

## Portee -- ce que cette PR ne fait pas

Elle ne dit rien de la **justesse** des gardes ombre : `perimeter-review-guard`
rouge sur #12791 reste un signal a lire (localement,
`check_pr_perimeter.py 12791 --scan-thread` rend `VERDICT: OK`). Elle retire a
la phase ombre sa capacite a **bloquer**, pas sa capacite a **signaler**.

Elle ne touche pas non plus la parite de declencheurs (P1) ni la borne du
`PR gate` sous file -- ce sont des grains distincts de #12856.

Closes #12867
