### PR TITLE
fix(notebooks,#12368): heading_in_list + séparateurs YAML — tranche SymbolicAI/Planners (18 notebooks, 0 restant)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/00-Environment/Planners-0-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/00-Environment/Planners-0-Setup.ipynb
@@ -53,7 +53,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Detection de l'environnement\n",
     "\n",
@@ -167,7 +167,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Technologies de planification\n",
     "\n",
@@ -219,7 +219,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Installation des dependances Python\n",
     "\n",
@@ -532,7 +532,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Configuration Docker pour Fast Downward\n",
     "\n",
@@ -931,7 +931,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Resume de l'environnement\n",
     "\n",
@@ -1022,7 +1022,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Premier exemple concret : Blocks World\n",
     "\n",
@@ -1038,7 +1038,7 @@
     "\n",
     "Nous allons définir ce problème en PDDL, puis le resoudre avec unified-planning.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -1055,7 +1055,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Premier exemple : Blocks World\n",
     "\n",
@@ -1645,7 +1645,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Structure de la serie\n",
     "\n",
@@ -1704,7 +1704,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Points cles a retenir\n",
     "\n",
@@ -1750,7 +1750,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [Planners-1-Introduction](../01-Foundation/Planners-1-Introduction.ipynb)"
    ]
@@ -1769,7 +1769,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 9. Conclusion : Environnement pret\n",
     "\n",
@@ -1801,7 +1801,7 @@
     "\n",
     "> **Point cle** : La planification automatique est un domaine de l'IA qui consiste a trouver des sequences d'actions pour atteindre des buts. C'est la base de nombreux systèmes : robots, logistique, jeux video, etc.\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -1818,7 +1818,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Verification de l'environnement de planification\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
@@ -146,7 +146,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -156,10 +155,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -174,7 +170,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -186,8 +181,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -236,13 +229,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -1749,7 +1740,7 @@
     "\n",
     "**Suite** : PDDL (Planners-2 — le langage standard, ici déjà utilisé en Tranche 2), heuristiques (Planners-5 — A*, relaxations pour combattre l'explosion combinatoire).\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "*Tranche 1 from-scratch (BCL .NET seule, 0 NuGet) + Tranche 2 Fast Downward via API Docker. Twin du notebook Python unified-planning [Planners-1-Introduction](Planners-1-Introduction.ipynb). Marathon #4956, parité lib-vs-lib Epic #10382.*"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics-Csharp.ipynb
@@ -27,7 +27,7 @@
    "id": "1926d390",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction : PDDL et le modèle STRIPS\n",
     "\n",
@@ -71,7 +71,7 @@
    "id": "ca92eee1",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Modèle de domaine en C#\n",
     "\n",
@@ -107,7 +107,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -117,10 +116,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -135,7 +131,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -147,8 +142,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -197,13 +190,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -310,7 +301,7 @@
    "id": "b56df42e",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Exemple complet : le domaine Logistics\n",
     "\n",
@@ -444,7 +435,7 @@
    "id": "256d0c4c",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Le problème : objets, état initial, but\n",
     "\n",
@@ -561,7 +552,7 @@
    "id": "48b0f4a7",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Le cœur du planificateur : grounding + recherche BFS\n",
     "\n",
@@ -812,7 +803,7 @@
    "id": "ff8958ba",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Deuxième exemple : le domaine Gripper\n",
     "\n",
@@ -1112,7 +1103,7 @@
    "id": "6c432c7c",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Extensions PDDL au-delà de STRIPS\n",
     "\n",
@@ -1135,7 +1126,7 @@
    "id": "efa31c0f",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Exercices\n",
     "\n",
@@ -1315,7 +1306,7 @@
    "id": "10b517dd",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 9. Résumé\n",
     "\n",
@@ -1340,7 +1331,7 @@
    "id": "d8a9b18c",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion\n",
     "\n",
@@ -1364,7 +1355,7 @@
    "id": "d7b5503d",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Ressources\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
@@ -14,11 +14,11 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [<< Planners-1 Introduction C#](Planners-1-Introduction-Csharp.ipynb) | [Index](../../README.md) | [Planners-2 PDDL Basics >>](Planners-2-PDDL-Basics.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "# Planners-3 : Recherche dans l'Espace d'Etats — twin C# (BFS / DFS / Greedy / A*)\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward-Csharp.ipynb
@@ -1253,7 +1253,7 @@
     "- Hoffmann & Nebel (2001), *The FF planning system: Fast plan generation through heuristic search*, JAIR.\n",
     "- Bonet & Geffner (2001), *Planning as heuristic search*, AIJ.\n",
     "\n",
-    "---\n",
+    "***\n",
     "*Marathon #4956 (parite .NET <-> Python). Twin C# du notebook Python [Planners-4-Fast-Downward.ipynb](Planners-4-Fast-Downward.ipynb). Regitre SOTA : EPIC #3801.*\n"
    ]
   }

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : [Index](../../README.md) | [<< State-Space](../01-Foundation/Planners-3-State-Space.ipynb) | [Heuristics >>](Planners-5-Heuristics.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -53,7 +53,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction a Fast Downward\n",
     "\n",
@@ -140,7 +140,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Configuration de l'environnement\n",
     "\n",
@@ -507,7 +507,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Fonction utilitaire pour Fast Downward Docker\n",
     "\n",
@@ -623,7 +623,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Architecture detaillee de Fast Downward\n",
     "\n",
@@ -918,7 +918,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Algorithmes de recherche\n",
     "\n",
@@ -1292,7 +1292,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Heuristiques disponibles\n",
     "\n",
@@ -1481,7 +1481,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Exemples pratiques\n",
     "\n",
@@ -1757,7 +1757,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Integration avec unified-planning\n",
     "\n",
@@ -2080,7 +2080,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 9. Resume et bonnes pratiques\n",
     "\n",
@@ -2155,7 +2155,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Exemple guide 1 : Problème Ferry — Workflow complet de planification\n",
     "\n",
@@ -2452,7 +2452,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 10. Exercices\n",
     "\n",
@@ -2705,7 +2705,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 11. Conclusion\n",
     "\n",
@@ -2727,7 +2727,7 @@
     "- Landmarks et LM-cut\n",
     "- Pattern Databases\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Ressources\n",
     "\n",
@@ -2736,7 +2736,7 @@
     "- [unified-planning](https://github.com/aiplan4eu/unified-planning) - Bibliotheque Python\n",
     "- [PDDL Wiki](https://planning.wiki/) - Reference PDDL\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [Planners-5-Heuristics](Planners-5-Heuristics.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : [Index](../../README.md) | [<< Fast Downward](Planners-4-Fast-Downward.ipynb) | [Domaines >>](Planners-6-Domains.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -53,7 +53,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction aux Heuristiques\n",
     "\n",
@@ -90,7 +90,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Proprietes des Heuristiques\n",
     "\n",
@@ -216,7 +216,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Heuristiques basees sur la Relaxation\n",
     "\n",
@@ -841,7 +841,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Heuristique FF (Fast Forward)\n",
     "\n",
@@ -1115,7 +1115,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Heuristiques basees sur les Landmarks\n",
     "\n",
@@ -1374,7 +1374,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Comparaison des Heuristiques\n",
     "\n",
@@ -1836,7 +1836,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Exemple guide 1 : Problème de Logistics — Comparaison complete des heuristiques\n",
     "\n",
@@ -2014,7 +2014,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Integration avec unified-planning\n",
     "\n",
@@ -2241,7 +2241,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Resume et Guide de Sélection\n",
     "\n",
@@ -2479,7 +2479,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 10. Conclusion\n",
     "\n",
@@ -2500,7 +2500,7 @@
     "- Gripper\n",
     "- Depots\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [Index](../../README.md) | [<< Fast Downward](Planners-4-Fast-Downward.ipynb) | [Domaines >>](Planners-6-Domains.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal-Csharp.ipynb
@@ -1088,7 +1088,7 @@
    "id": "bf574749-2b30-479c-b9ba-f1dd57b5ee3d",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "*Twin C# du notebook Python `Planners-8-Temporal.ipynb`. Marathon parité .NET ⇄ Python (#4956, Prong B). From-scratch BCL .NET, 0 NuGet, 0 unified_planning / ortools.*\n"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : [Index](../../README.md) | [<< OR-Tools](Planners-7-OR-Tools.ipynb) | [HTN >>](Planners-9-HTN.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -52,7 +52,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction a la Planification Temporelle\n",
     "\n",
@@ -125,7 +125,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Syntaxe PDDL 2.1 pour Actions Duratives\n",
     "\n",
@@ -286,7 +286,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Concurrency et Conflits\n",
     "\n",
@@ -428,7 +428,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Planificateurs Temporels\n",
     "\n",
@@ -880,7 +880,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Exemple Pratique : Ordonnancement d'Usine\n",
     "\n",
@@ -1413,7 +1413,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Comparaison des Approches\n",
     "\n",
@@ -1467,7 +1467,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exemple guide : Planification temporelle pour livraisons par drones\n",
     "\n",
@@ -1722,7 +1722,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Exercices\n",
     "\n",
@@ -1928,7 +1928,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Resume et Points Cles\n",
     "\n",
@@ -1981,7 +1981,7 @@
     "- Méthodes et preconditions\n",
     "- HTN vs planification classique\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Ressources\n",
     "\n",
@@ -1990,7 +1990,7 @@
     "- [OR-Tools Scheduling](https://developers.google.com/optimization/scheduling) - Guide CP-SAT\n",
     "- [PDDL2.1: Fox & Long — planification temporelle](https://arxiv.org/abs/1106.4561) - Fondements\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [Planners-9-HTN](Planners-9-HTN.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN-Csharp.ipynb
@@ -848,7 +848,7 @@
     "\n",
     "Twin de parite legitime : les deux langages deroulent le solveur HTN from-scratch. L'intérêt est la traduction du coeur récursif (decomposition + backtracking) et la confirmation sur les domaines canoniques (Logistics, Cafe). Le notebook [Planners-3-State-Space](../01-Foundation/Planners-3-State-Space.ipynb) couvre la planification state-space classique (point de contraste : HTN decompose, state-space cherche).\n",
     "\n",
-    "---\n",
+    "***\n",
     "*Marathon #4956 (parite .NET <-> Python).*\n"
    ]
   }

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : [Index](../../README.md) | [<< Temporal](Planners-8-Temporal.ipynb) | [LLM-Planning >>](../04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -53,7 +53,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction a la Planification Hiérarchique\n",
     "\n",
@@ -144,7 +144,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Fondements Théoriques des HTN\n",
     "\n",
@@ -276,7 +276,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. HDDL - Hierarchical Domain Definition Language\n",
     "\n",
@@ -622,7 +622,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Implementation d'un Solveur HTN Simplifie\n",
     "\n",
@@ -974,7 +974,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Exemple Pratique : Logistics avec HTN\n",
     "\n",
@@ -1706,7 +1706,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Algorithme SHOP2\n",
     "\n",
@@ -1867,7 +1867,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Comparaison HTN vs Planification Classique\n",
     "\n",
@@ -2066,7 +2066,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exemple guide : Domaine HTN \"Preparation de cafe\"\n",
     "\n",
@@ -2299,7 +2299,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Exercices"
    ]
@@ -2551,7 +2551,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 9. Resume et Points Cles\n",
     "\n",
@@ -2621,7 +2621,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Ressources\n",
     "\n",
@@ -2639,7 +2639,7 @@
     "- [HTN Planning Tutorial](https://icaps20subpages.icaps-conference.org/tutorials/hierarchical-planning/)\n",
     "- [HDDL Specification](https://github.com/panda-planner-dev/panda-framework)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [Planners-10-LLM-Planning](../04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb)"
    ]
@@ -2681,7 +2681,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice de synthese : Concevoir un reseau HTN complet\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : [Précédent](../03-Advanced/Planners-9-HTN.ipynb) | [Suivant](Planners-11-Unified-Planning.ipynb) | [Index](../README.md)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -1868,7 +1868,7 @@
     "- [unified-planning](https://github.com/aiplan4eu/unified-planning)\n",
     "- [LangChain](https://python.langchain.com/) pour orchestration LLM\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [Précédent](../03-Advanced/Planners-9-HTN.ipynb) | [Suivant](Planners-11-Unified-Planning.ipynb) | [Index](../README.md)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
@@ -70,7 +70,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction a unified-planning\n",
     "\n",
@@ -292,7 +292,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Definition de Problemes avec l'API\n",
     "\n",
@@ -662,7 +662,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Resolution et Comparaison de Solveurs\n",
     "\n",
@@ -1119,7 +1119,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Fonctionnalites Avancees\n",
     "\n",
@@ -1860,7 +1860,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Integration PDDL\n",
     "\n",
@@ -2185,7 +2185,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Bonnes Pratiques\n",
     "\n",
@@ -2343,7 +2343,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Resume et Points Cles\n",
     "\n",
@@ -2548,7 +2548,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Ressources\n",
     "\n",
@@ -2557,7 +2557,7 @@
     "- [AIPlan4EU Project](https://www.aiplan4eu-project.eu/)\n",
     "- [Tutoriels](https://unified-planning.readthedocs.io/en/latest/tutorials/index.html)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [Planners-12-LOOP](Planners-12-LOOP.ipynb) - Learning to Plan avec modèles neuronaux"
    ]
@@ -2599,7 +2599,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice de synthese : Comparer deux solveurs sur un problème original\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/planners-1-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-1-introduction.yaml
@@ -31,6 +31,12 @@
       csharp_sha: 6c10bba6cbdf6afb8f60a6e56567a273e0eb8e34
       content_python_sha: 42be332ed5fccaefb9e41df6cdddc41cc15f57ce070ac0a167307f4f9da050bf
       content_csharp_sha: 6f667c0b3ea21776c9ee58f81ba3f6fed750f7b6d8148ea7e77ac7fe55009e39
+    - date: "2026-08-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: dc8823f08ff572c954c1e76a900b56a51b8485ef
+      csharp_sha: 5eeab26867e2fcc80b0fdc54680d1094c5966e79
+      content_python_sha: 42be332ed5fccaefb9e41df6cdddc41cc15f57ce070ac0a167307f4f9da050bf
+      content_csharp_sha: 34c0af00dd7d7d862a4a7c9d333f7e2584809569abe18dc3ec779a2804beae00
   known_differences:
     - "Concept : introduction a la planification classique (domaine, probleme, plan = sequence d'actions)."
     - "Python : unified-planning (API moderne, modelisation Fluent/Action). C# : Tranche 1 from-scratch BCL .NET (dataclasses d'Action/Etat, 0 NuGet) + Tranche 2 Fast Downward via API Docker (depuis 2026-08-15, #10382)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-2-pddl-basics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-2-pddl-basics.yaml
@@ -22,6 +22,12 @@
       csharp_sha: 9e4f2381178788134c11a90ad6cf40aa8c8c473a
       content_python_sha: d0d6e07211d4f8a63514d45cf4ec4350e2f4563b3fe69738877353fa0be27c4c
       content_csharp_sha: 119bcb4b69575be84bc0bfa222091ee17e20d1db74be38463561c3bb7f7b3d8d
+    - date: "2026-08-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: d2eafd8859047317683669935243124be552c5ed
+      csharp_sha: 211154c8b8bb654a3d4d4000f94cd7de63e57e48
+      content_python_sha: d0d6e07211d4f8a63514d45cf4ec4350e2f4563b3fe69738877353fa0be27c4c
+      content_csharp_sha: 71d30f19c837a92897c911e417c137e208428803188393eebec58fd332dfc70d
   known_differences:
     - "Concept : syntaxe PDDL (domain.pddl + problem.pddl), predicats, actions, etat initial/but."
     - "Lib-vs-lib : Python invoque unified-planning (qui wrap Fast Downward). C# : Tranche 1 from-scratch (grounding + BFS forward, BCL .NET) + Tranche 2 invoque Fast Downward 24.06.1 via API Docker (port 8200). Mêmes domaines PDDL (Logistics, Gripper)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-3-state-space.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-3-state-space.yaml
@@ -22,6 +22,12 @@
       csharp_sha: 0830e858e97d1a942f6dc1cf62593734b0ee2337
       content_python_sha: 6d3b47331c520f4dad3ff444d24c19b0c5ccf486e2a744c69e004b5e6d1afe93
       content_csharp_sha: 94624542d6462542d48a5a163fe05a6c56e8b680c5d270e97e1d0af49dab50e4
+    - date: "2026-08-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 27c9d31ceb1d4f1a58eb36c0d79ff25475afd9e2
+      csharp_sha: 45e5c20ebfcbebfb6d9fbb3900dad550dd73b03b
+      content_python_sha: 6d3b47331c520f4dad3ff444d24c19b0c5ccf486e2a744c69e004b5e6d1afe93
+      content_csharp_sha: bbc68b3eb99939418bebbe93c76ae9587cdbec5e0507ea5c388ac8f6c7c957b6
   known_differences:
     - "Concept : recherche dans l'espace d'etats (BFS/DFS/A* sur le graphe des etats reachables) + recherche de plan PDDL (8-puzzle)."
     - "Tranche 1 (from-scratch) : Python BFS/DFS/Greedy/A* via networkx + matplotlib heatmap terrain ; C# from-scratch BCL .NET 9 + PriorityQueue (meme algorithme, implementation idiomatic)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-4-fast-downward.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-4-fast-downward.yaml
@@ -26,6 +26,12 @@
       csharp_sha: defc0e484993e6dd8f966430dea7ea5c8f7430bc
       content_python_sha: ab27cda5ddec5f8a1d557db0d21925e45ecc01dd5291d36de61c8d1f21f1ea6f
       content_csharp_sha: f9d39130590fea705a6fe028c15e6e43cb0ec1a74d0251fae8a85cc92e9e469f
+    - date: "2026-08-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 90853b19dc0d5375a47c21372a4664aa4bff5786
+      csharp_sha: 57c2555a1b978c066c1fa3954a4c536ec2f1be63
+      content_python_sha: e2274aa89c2aca8823dd3cc1b2f8a5e3f61158a6fd9f3847251e11ddaa97d551
+      content_csharp_sha: e1a7b9d0d6fd86c42228c274b2b64e71bf0077688bc8064fe4886575345e4f34
   known_differences:
     - "2026-08-20 : conversion markdown-only ASCII->Mermaid du diagramme de pipeline Fast Downward (PDDL->Translator->Preprocessor->Search->Plan, cell 3 cote python, PR #12011 / #11962) - 0 cellule code touchee, parite engine native-both intacte, rebaseline d'attestation."
     - "Concept : planificateur classique Fast Downward (SAS+, heuristic search, A*/GBFS/EHC)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-5-heuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-5-heuristics.yaml
@@ -34,6 +34,12 @@
       csharp_sha: 8ba8324e142f82679434c709fbe34c7ca61fd2f3
       content_python_sha: 2cef7aa82bc3b01d9b0975e32d589612f5cdfec894a13ce82377e9a3b2729a52
       content_csharp_sha: f8b4bbc24b725ca7f401bbe794f03dae8eaa70fb51a5155254d74df73e3f0fc4
+    - date: "2026-08-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: af7bfa0456b38defe4806c919fc4304576b155c9
+      csharp_sha: 8ba8324e142f82679434c709fbe34c7ca61fd2f3
+      content_python_sha: c6385a26111765afb7ec553f91383737de2e0188f9c99d0e2bbfbd0a27d9fbae
+      content_csharp_sha: f8b4bbc24b725ca7f401bbe794f03dae8eaa70fb51a5155254d74df73e3f0fc4
   known_differences:
     - 'PR #12108 (2026-08-22, reprise #12104) : cote C#, normalisation source_list_missing_newlines (backslash-n manquants sur elements de liste source, 16 cellules NO_AUTO_FIX reprises manuellement) -- drift de forme JSON uniquement, contenu pedagogique et cellules code inchanges.'
     - "Concept : heuristiques admissibles (relaxation, h_add, h_max, delete-relaxation)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-8-temporal.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-8-temporal.yaml
@@ -30,6 +30,12 @@
       reason: "Re-exec seq only (#11112 etage 3): csharp DUPLICATE -> CLEAN 1..10 (dotnet_executor, Google.OrTools), sources byte-identiques, 0 erreur, outputs deterministes (0 derive), probe banner strip L532. Cote python non touche."
       content_python_sha: cdd2d4c542af4a175ee483624f05abe745a6a8a0283eb1082b24b7fbc6be2a1f
       content_csharp_sha: e632c8b243ed22203671ec0dad4a8bcc54df2ae108f9afefcdfd7574de5f3816
+    - date: "2026-08-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: b08fd59774e2608cb07ee18dc2076a25c4503155
+      csharp_sha: 91e719eb433c502dcf1e0b3993ec4d288db4fe98
+      content_python_sha: e02f2d24b43877c40cf8f5958aa1dc9cb25d9d3bf5ec2524e45131b8e16ef795
+      content_csharp_sha: e917a9bb27b010e0e989a11d7fd04dc676bc0e0b83d334933e08f6daf16770c2
   known_differences:
     - "Concept : planification temporelle (actions duratives, ordonnancement avec parallelisme)."
     - "Python : unified-planning temporal + CP-SAT + Gantt. C# : deux tranches — Tranche 1 from-scratch BCL .NET (PDDL duratives, Allen, STN Floyd-Warshall, RCPSP glouton LPT) + Tranche 2 Google.OrTools CP-SAT natif .NET (moteur de production, depuis 2026-08-11, contrainte cumulative AddCumulative)."

--- a/scripts/notebook_tools/twin_pairs.d/planners-9-htn.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-9-htn.yaml
@@ -29,6 +29,12 @@
       content_python_sha: 33e78fe34ea0d7d7ebd418fb7018268c2499b691ec6f093b819597abb2484778
       content_csharp_sha: 6650c05a8bc89978437d49fdd10c93a1adf4a5a8eaaa61c5d1f0be21a2c5f364
       reason: "Re-exec seq CLEAN 1..16 (#11112 etage 3, cote Python, commit 2ebe8cbff) : moteur HTN up_aries 0.5.0 installe regle F (premier run KO : UPNoSuitableEngineAvailable -- aucun moteur HIERARCHICAL present ; unified_planning 1.3.0 preserve). Divergences documentees C.4 cause (a) env : (1) le run main (python 3.13.12) avait un stdout sans accents alors que le source imprime des chaines accentuees -- le run frais (3.11.9) produit la vraie sortie accentuee, 10 cellules restaurees ; (2) plan aries cell 9 : les deux cotes SOLVED_SATISFICING 7 actions, memes livraisons, ordre des actions different (plans optimaux equivalents, tie-breaking sensible a la version moteur/env). csharp_sha inchange (jumeau C# rebaseline par #11282 plus tot dans la journee)."
+    - date: "2026-08-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 36a7f54da3e2fc5c02493dc0ba6bd180be3f1ffe
+      csharp_sha: 75c3e0a625790319f6d60cef068f33f63d48d794
+      content_python_sha: cd33d236d0686bce192411af06f83f00372db3337c42824e9ed49571cf535d32
+      content_csharp_sha: 971d4c3bc3e282bb174f45c80b536bfa8ac6e81084c320b53cee74d3be3e058a
   known_differences:
     - "Concept : Hierarchical Task Network (decomposition de taches, methodes, backtracking)."
     - "Python : unified-planning HTN. C# : from-scratch BCL .NET (Predicat grounde, Etat, decomposition de methodes)."


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2023:CoursIA-2 — prev: LIGHT/docs #13461

## Summary

Tranche **SymbolicAI/Planners** du rollout #12368 (469 occurrences de `heading_in_list` partitionnées par famille). C'était la plus grosse famille restante du tableau de l'issue. narrow REPAIR Tell c.635-L1 ★★ perimeter v2 — reformulation body + twin parity attestation (cf c.647).

## Périmètre du diff

Le diff couvre la sous-famille `MyIA.AI.Notebooks/SymbolicAI/Planners/` (sous-familles Environment, Foundation, Classical, Advanced, NeuroSymbolic — modifs markdown-only) et les entrées du registre `scripts/notebook_tools/twin_pairs.d/planners-*.yaml` (attestation `check_twin_parity.py --update` c.647). Périmètre vérifiable via `gh pr view 12875 --json files` (cf truth source perimeter guard #11268).

## Mesures firsthand (scan sur `main` frais 2026-08-25)

- Corpus total restant avant cette PR : ~50 occurrences (vs 469 au scan du 22/08 — déjà réduit par #12675 CaseStudies, #12678 SymbolicAI/Lean, + tranches antérieures).
- Après cette PR : **0 occurrence sur Planners** (scan re-exécuté sur la sous-famille Planners complète).

## Les deux passes, notebook ENTIER (procédure de l'issue)

| Passe | Outil | Résultat |
|---|---|---|
| 1. headings | `fix_hint_headings.py --apply MyIA.AI.Notebooks/SymbolicAI/Planners` | corrections appliquées |
| 2. séparateurs | `fix_hr_separator.py --apply MyIA.AI.Notebooks/SymbolicAI/Planners` | séparateurs `---` convertis |

## Validation

- **Diff markdown-only** (notebooks Planners) : `git diff | grep -cE '^\+\s*"(execution_count|outputs)"'` = **0** — aucune cellule code/output/exécution modifiée (règle C.3 : pas de re-exécution requise, modifs uniquement markdown → outputs précédents valides).
- **Twin parity attestation** (registre `twin_pairs.d/planners-*.yaml`) : `check_twin_parity.py --update --pair "Planners-X" --by "myia-po-2023:CoursIA-2"` → 7 paires attestées (Planners-1/2/3/4/5/8/9, cf c.647 narrow REPAIR twin parity).
- **Gate HARD** : `detect_markdown_rendering.py --check --baseline scripts/notebook_tools/markdown_rendering_baseline.json` → `OK: no new ERROR-level markdown-rendering violations.` (commande exacte du workflow `markdown-rendering-guard.yml`).
- **Contrôle positif tracké** (critère d'acceptance 1 de l'issue) : violation `heading_in_list` fabriquée injectée dans `Planners-2-PDDL-Basics.ipynb` (fichier tracké) → gate **FAIL et nomme** `cell#0 [heading_in_list] - # Violation fabriquee pour le controle positif` → témoin retiré (checkout + re-apply des passes) → gate re-verte. Preuve que le garde voit les nouvelles violations, pas seulement les anciennes.

## Résiduel du rollout (autre lanes / prochains cycles)

Reste ~18 occurrences sur 4 notebooks hors Planners : GenAI/Vibe-Coding (02-Claude-CLI-Sessions, 04-Claude-CLI-Agents), GenAI/PostTraining (PT_11b), SymbolicAI/SymbolicLearning (SL-2).

See #12368
