### PR TITLE
fix(ci,#12383): sparse-checkout + blob:none sur regression-guard + translation-guard

### DIFF
--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -55,10 +55,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout (full history)
+      # Tranche 1 clone partiel (#11860, pilote #11843/#12016, grain #12383) :
+      # ce garde tire sur CHAQUE pull_request sans filtre paths: et clone en
+      # fetch-depth: 0. Or son travail entier est :
+      #   - `git diff origin/main...HEAD -- 'MyIA.AI.Notebooks/**/*.ipynb'`
+      #   - `python scripts/notebook_tools/regression_scan.py --base ... --head ...`
+      # Le graphe de commits doit rester complet (fetch-depth: 0) pour le
+      # diff 3-dot, mais l'arbre de travail ne materialise que ce qui est
+      # utile : `MyIA.AI.Notebooks/` (chemin du diff) + `scripts/` (le scan).
+      # `filter: blob:none` rend les blobs paresseux (~1 Gio de blobs
+      # historiques non materialises sur ~2 Gio transferes).
+      - name: Checkout (sparse, garde-partial)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
+          sparse-checkout: |
+            MyIA.AI.Notebooks
+            scripts
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/translation-guard.yml
+++ b/.github/workflows/translation-guard.yml
@@ -43,10 +43,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout base
+      # Tranche 1 clone partiel (#11860, pilote #11843/#12016, grain #12383) :
+      # ce garde tire sur CHAQUE pull_request sans filtre paths: et clone en
+      # fetch-depth: 0. Son travail est :
+      #   - `git diff origin/main...HEAD -- 'translations/**' '*_<lang>.ipynb'`
+      #   - `git cat-file -e origin/<base>:$f` (sur le base, graphe d'objets)
+      #   - `python3 scripts/ci/translation_override_required.py --pr-number N`
+      # Le graphe de commits reste complet (fetch-depth: 0 + filter: blob:none
+      # garde le graphe d'objets accessible pour `git cat-file -e` meme si
+      # l'arbre de travail est sparse). L'arbre materialise :
+      # `translations/` + `MyIA.AI.Notebooks/` (chemin du diff) +
+      # `scripts/ci/` (override resolver).
+      - name: Checkout base (sparse, garde-partial)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
+          sparse-checkout: |
+            translations
+            MyIA.AI.Notebooks
+            scripts
 
       - name: Check for translation-owned file changes
         id: check


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/guard #12864

## Summary

Suite de la serie clone partiel (#11860, pilote #11843/#12016 MERGED) — tranche 1 sur les **always-on restants** apres #12817 (tranche 0 = sortir les advisory lourds de pull_request).

Avant cette PR : **3 always-on pull_request restants** (regression-guard + translation-guard + repo-size-advisory). Apres #12817 (MERGED 23/08) : **repo-size-advisory.yml** est passe en schedule-only cron 03:19, donc plus **2 always-on pull_request restants**. C'est eux qui sont patcher ici.

| workflow | ce qu'il lit | sparse-checkout |
|---|---|---|
| `regression-guard.yml` | `git diff origin/main...HEAD -- 'MyIA.AI.Notebooks/**/*.ipynb'` + `python scripts/notebook_tools/regression_scan.py --base ... --head ...` | `MyIA.AI.Notebooks` + `scripts` |
| `translation-guard.yml` | `git diff origin/main...HEAD -- 'translations/**' '*_<lang>.ipynb'` + `git cat-file -e origin/<base>:$f` + `python3 scripts/ci/translation_override_required.py --pr-number N` | `translations` + `MyIA.AI.Notebooks` + `scripts` |

Le graphe de commits reste complet (`fetch-depth: 0` + `filter: blob:none` conserve le graphe, paresse les blobs). Le sparse-checkout limite l'arbre de travail materialise aux seuls chemins lus. **`git cat-file -e`** sur le base fonctionne avec `filter: blob:none` car il interroge le graphe d'objets, pas l'arbre de travail.

## Verification

- **YAML** : `yaml.safe_load` OK sur les 2 fichiers. Structure step `Checkout (...)` confirme `with.fetch-depth`, `with.filter`, `with.sparse-checkout` presents.
- **Scripts references** : `scripts/notebook_tools/regression_scan.py` et `scripts/ci/translation_override_required.py` existent dans le sparse-checkout (`scripts/` est inclus).
- **bash -n** : sort en erreur `syntax error near unexpected token '('` sur les noms de step (`Checkout (sparse, ...)`) — c'est un faux positif : YAML != bash. Le `bash -n` est deploye dans `Shebang + dry-run advisory` qui parse les scripts `.sh`, pas les YAML.
- **Mesure de gain** : pas mesurable en local (clone ne se reproduit pas), a lire dans la duree step `Checkout` des runs GitHub avant/apres. Pilote #11843 a mesure -49 % transfer (2,12 -> 1,08 Gio) avec `filter: blob:none` seul ; le sparse-checkout ici descend plus bas (chemin minimal pour chaque garde).

## Scope reduit vs #12383 initial

Le commentaire po-2027 du 24/08 (`[CLAIMED]` puis `[RELEASED]`) listait 3 cibles. **repo-size-advisory.yml** etait un candidat, contrairement a ce que #11843 supposait (verifie 2026-08-22). Mais entre-temps #12817 a bascule ce workflow en schedule-only. La tranche 1 sur ce qui RESTE always-on = 2 workflows.

## Pre-conditions au merge

- Le pilote #11843 MERGED sert de reference (meme scheme : filter:blob:none + sparse-checkout narrowly scoped au paths du workflow).
- PR ne touche QUE les 2 fichiers `.github/workflows/*.yml` cibles.
- Pas de pollution catalogue (cf `catalog-pr-hygiene.md`).
- Validation de l'acceptance **post-fix dans les runs CI** : un PR de test doit montrer (a) transfert reduit dans la step Checkout, (b) verdict des 2 gardes inchange (vert ou rouge comme avant).

## Files

- `.github/workflows/regression-guard.yml` : +14 /-1 (checkout step + commentaire)
- `.github/workflows/translation-guard.yml` : +16 /-1 (checkout step + commentaire)

Closes #12383

Co-Authored-By: Claude-Code <noreply@anthropic.com>
