### PR TITLE
fix(guards,#12871): reference pointable NUE dans les leves (6e use-vs-mention)

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -412,7 +412,13 @@ _MENTION_VERDICT = re.compile(
     # adresse) porte deja la semantique de mention, et le verdict est
     # encapsule entre parentheses — donc le caractere distinctif (verdict
     # declare) est absent, c'est une mention par construction.
-    r"[^()\n]{0,40}\(\s*([A-Z][A-Z_]{3,})[^()\n]{0,80}\)")
+    # `(?-i:)` sur le verdict : sans lui, le `(?i)` global fait que
+    # `[A-Z][A-Z_]{3,}` capture aussi un mot minuscule (`commit`) dans la
+    # parenthese — et `[^()\n]{0,80}` apres (Position A+) transforme ce
+    # faux match en neutralisation de `commit` au lieu du verdict (2 FAIL
+    # tests #11809 mesures en CI, 2026-08-28). Même discriminant case-
+    # sensitive que la Position D.
+    r"[^()\n]{0,40}\(\s*((?-i:[A-Z][A-Z_]{3,}))[^()\n]{0,80}\)")
 
 # #12311 (cf grain) — Position A : titre de section. Le pattern historique
 # (`[A-Z]{4,}` puis `[A-Z][A-Z_]{2,}[A-Z]`) neutralisait en sous-chaine les

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -559,12 +559,21 @@ _MENTION_VERDICT_REVIEW = re.compile(
 # PAS de fin de phrase entre le verdict et le verbe de levee (donc sous la
 # meme phrase), (c) verbe de levee + ref pointable a la fin. Borne dure : la
 # phrase complete ne doit pas contenir `Verdict :` (emission formelle) ni
-# `reste bloquante` (declaration de blocage).
+# `reste bloquante` (declaration de blocage) — implementee par le lookahead
+# #13425 ci-dessous.
 _MENTION_VERDICT_REVIEW_NARRATIVE = re.compile(
     r"(?i)(?:^|[\s,;:(*])"
     r"(?:le|la|les|du|mon|ma|ce|cet|cette|ces|the|my)?\s*"
     r"(?:revue|review)(?![:.])"
     r"[^():\n.]{0,60}?(?-i:([A-Z][A-Z_]{3,}))(?![A-Za-z0-9_])"
+    # #13425 — la borne dure promise ci-dessus, desormais implementee : si la
+    # suite de la phrase (fenetre 200 chars, meme phrase) contient une
+    # declaration de blocage vivante (`reste bloquante`) ou une emission
+    # formelle (`Verdict :`), la position ne s'applique PAS — le verdict
+    # reste emis. Cas hybride fondateur : « Cette review CHANGES_REQUESTED
+    # reste bloquante - traitee par le commit a1b2c3d4e » voyait son verdict
+    # neutralise alors que la phrase declare le blocage vivant.
+    r"(?![^.!?\n]{0,200}(?:reste\s+bloquante|verdict\s*:))"
     # Pas de fin de phrase avant le verbe de levee : `[^.!?\n]{0,200}` est
     # borne a 200 chars pour eviter de manger une phrase distincte (cf
     # discriminateur enonce par l'issue, le verbe de levee doit etre dans

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -405,7 +405,14 @@ def _lift_cancelled(stripped: str) -> bool:
 _MENTION_VERDICT = re.compile(
     r"(?i)\b(?:fix(?:ed|ée?e?)?|corrig\w+|suite\s+[àa]|en\s+r[ée]ponse\s+[àa]"
     r"|r[ée]ponse\s+[àa]|lev\w+|lift\w*|adress\w+|trait\w+|repondu\s+[àa])"
-    r"[^()\n]{0,40}\(\s*([A-Z][A-Z_]{3,})\s*\)")
+    # #12871 (cf grain) — Position A+ : tolere une prose INTERNE a la
+    # parenthese du verdict (`(COMMENT_WITH_CONCERNS, porte sur...)`) tant
+    # qu'elle ne commence pas par un verbe d'emission (`Verdict :`,
+    # `Block on`...). Le mot declencheur de mention (fix/reponse a/leve/
+    # adresse) porte deja la semantique de mention, et le verdict est
+    # encapsule entre parentheses — donc le caractere distinctif (verdict
+    # declare) est absent, c'est une mention par construction.
+    r"[^()\n]{0,40}\(\s*([A-Z][A-Z_]{3,})[^()\n]{0,80}\)")
 
 # #12311 (cf grain) — Position A : titre de section. Le pattern historique
 # (`[A-Z]{4,}` puis `[A-Z][A-Z_]{2,}[A-Z]`) neutralisait en sous-chaine les
@@ -469,7 +476,17 @@ _MENTION_VERDICT_LIFTED = re.compile(
     r"|traite|traiter|traité|traitée|traités|traitées"
     r"|repondu|répondu|repondre|répondre"
     r"|leve|lever|levé|levée|levés|levées|lift)"
-    r"\w*\s+\((?:commit\s+[a-f0-9]+|#\d+|PR\s*#?\d+|pull/\d+)\)")
+    r"\w*"
+    # #12871 (cf grain) — Position C+ : reference pointable NUE apres le verbe
+    # de levee, dans une fenetre de 40 chars (les formes parenthesees
+    # `leve (commit <sha>)` continuent de matcher ; les formes narratives
+    # `leve par le commit <sha>` sont ajoutees). Borne courte (40 chars) pour
+    # eviter d'avaler une autre phrase ou un commentaire distinct. Le
+    # discriminant reste la piste (b) : une REF POINTABLE suit le verbe ;
+    # sans pointable (CE2), la neutralisation ne s'applique pas.
+    r"(?:\s+\((?:commit\s+[a-f0-9]+|#\d+|PR\s*#?\d+|pull/\d+)\)"
+    r"|\s+(?:par|via|dans|en)\s+(?:le\s+|la\s+|les\s+|du\s+|des\s+)?"
+    r"(?:commit\s+[a-f0-9]+|PR\s*#?\d+|#\d+|pull/\d+))")
 
 
 # #11984 — Position D : le nominal `revue` / `review` DEVANT le verdict, avec
@@ -511,12 +528,49 @@ _MENTION_VERDICT_REVIEW = re.compile(
     r"(?:"
     # Forme d'origine : ref pointable entre parentheses immediates.
     r"[^():\n.]{0,12}?"
+    # #12871 (cf grain) — Position D+ : la ref pointable peut etre NUE dans une
+    # fenetre de 60 chars apres le verdict (les formes parenthesees
+    # `(SHA ...)` continuent de matcher ; les formes narratives
+    # `... traitee par le commit <sha>` sont ajoutees). Borne courte (60 chars)
+    # pour ne pas avaler une autre phrase distincte.
+    r"(?:"
     r"\([^()\n]{0,80}?"
     r"(?:[a-f0-9]{7,}|#\d+|\d{4}-\d{2}-\d{2}|\d{1,2}:\d{2}(?::\d{2})?Z?)"
     r"[^()\n]{0,40}\)"
     # #12944 : ref pointable inline — « review VERDICT de #N ».
     r"|\s+(?:de\s+|sur\s+|dans\s+)?(?:la\s+|le\s+)?(?:PR\s+)?#\d+"
-    r")")
+    r"|"
+    r"(?:par|via|dans|en)\s+(?:le\s+|la\s+|les\s+|du\s+|des\s+)?"
+    r"(?:commit\s+[a-f0-9]+|PR\s*#?\d+|#\d+|pull/\d+)"
+    r"))")
+
+# #12871 (cf grain) — Position E : `La review <VERDICT> ... traitee par le
+# commit <sha>` (ou variantes). La Position D stricte echoue sur ce cas parce
+# que la ref pointable est trop loin (60+ chars apres le verdict), au-dela
+# d'une frontiere de phrase `.`. Mais la phrase CONTIENT un verbe de levee
+# suivi d'une ref pointable — c'est la signature d'une mention, pas d'une
+# emission. Discriminant : on exige (a) `La review/ce <VERDICT>` en tete, (b)
+# PAS de fin de phrase entre le verdict et le verbe de levee (donc sous la
+# meme phrase), (c) verbe de levee + ref pointable a la fin. Borne dure : la
+# phrase complete ne doit pas contenir `Verdict :` (emission formelle) ni
+# `reste bloquante` (declaration de blocage).
+_MENTION_VERDICT_REVIEW_NARRATIVE = re.compile(
+    r"(?i)(?:^|[\s,;:(*])"
+    r"(?:le|la|les|du|mon|ma|ce|cet|cette|ces|the|my)?\s*"
+    r"(?:revue|review)(?![:.])"
+    r"[^():\n.]{0,60}?(?-i:([A-Z][A-Z_]{3,}))(?![A-Za-z0-9_])"
+    # Pas de fin de phrase avant le verbe de levee : `[^.!?\n]{0,200}` est
+    # borne a 200 chars pour eviter de manger une phrase distincte (cf
+    # discriminateur enonce par l'issue, le verbe de levee doit etre dans
+    # la meme phrase).
+    r"[^.!?\n]{0,200}?"
+    r"(?:adresse|adresser|adressé|adressée|adressés|adressées"
+    r"|traite|traiter|traité|traitée|traités|traitées"
+    r"|repondu|répondu|repondre|répondre"
+    r"|leve|lever|levé|levée|levés|levées|lift)\w*"
+    r"(?:\s+(?:par|via|dans|en)\s+(?:le\s+|la\s+|les\s+|du\s+|des\s+)?"
+    r"|\s+\()"
+    r"(?:commit\s+[a-f0-9]+|PR\s*#?\d+|#\d+|pull/\d+)")
 
 
 def _strip_mentioned_verdicts(body: str) -> str:
@@ -526,7 +580,7 @@ def _strip_mentioned_verdicts(body: str) -> str:
     reste du body sont preserves (les fenetres de `_is_cited` restent
     calibrees sur la vraie position des occurrences survivantes).
     """
-    for pat in (_MENTION_VERDICT, _MENTION_VERDICT_HEADING, _MENTION_VERDICT_INLINE, _MENTION_VERDICT_LIFTED, _MENTION_VERDICT_REVIEW):
+    for pat in (_MENTION_VERDICT, _MENTION_VERDICT_HEADING, _MENTION_VERDICT_INLINE, _MENTION_VERDICT_LIFTED, _MENTION_VERDICT_REVIEW, _MENTION_VERDICT_REVIEW_NARRATIVE):
         body = pat.sub(
             lambda m: m.group(0).replace(m.group(1), " " * len(m.group(1))), body)
     return body

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -2717,3 +2717,74 @@ def test_12908_sortie_organe_pastee_est_une_emission():
              "body": "Contre-verification au head frais :\n"
                      "BLOCKED  PR #42 — 3 nit(s) non leve(s)"}
     assert run([paste])["blocked"] is True
+# ---------------------------------------------------------------------------
+# #12871 — 6e instance use-vs-mention : la reference pointable des levees
+# doit aussi matcher NUE (`leve par le commit <sha>`) en plus de la forme
+# parenthesee. Les 3 formulations de l'issue (FP1/FP2/FP3) sont classeees
+# BOT-CONCERN a tort ; le fix Position A+ (prose interne apres verdict en
+# parenthese), Position C+ (ref nue apres verbe de levee) et Position E
+# (verdict en tete, verbe de levee + ref dans la meme phrase) les neutralise.
+# Les 3 contre-exemples (CE1/CE2/CE3) restent BOT-CONCERN : pas de ref
+# pointable, pas de verbe de levee, ou emission formelle.
+# ---------------------------------------------------------------------------
+
+
+def test_12871_fp1_parenhese_avec_prose_interne_ne_flagge_pas():
+    """#12871 FP1 — `(COMMENT_WITH_CONCERNS, porte sur...)` : prose interne a
+    la parenthese du verdict (Position A+). Avant : classifie BOT-CONCERN.
+    Apres : classify() rend None (mention, pas emission)."""
+    body = (
+        "Reponse au point de review Hermes (COMMENT_WITH_CONCERNS, porte sur "
+        "la conclusion cell 17 point 3 + objectif cell 0 point 3) - traite "
+        "en code par le commit 05d16623f49."
+    )
+    assert mod.classify("myia-po-2027", body) is None
+
+
+def test_12871_fp2_ref_nue_apres_verbe_leve_ne_flagge_pas():
+    """#12871 FP2 — `COMMENT_WITH_CONCERNS leve par le commit <sha>` : verbe
+    de levee precede, ref pointable NUE dans la meme phrase (Position C+).
+    Avant : classifie BOT-CONCERN. Apres : classify() rend None."""
+    body = (
+        "Reponse au Hermes: COMMENT_WITH_CONCERNS leve par le commit "
+        "05d16623f49."
+    )
+    assert mod.classify("myia-po-2027", body) is None
+
+
+def test_12871_fp3_review_verdict_leve_dans_meme_phrase_ne_flagge_pas():
+    """#12871 FP3 — `La review COMMENT_WITH_CONCERNS de Hermes est traitee par
+    le commit <sha>` : verdict en tete de phrase apres `review/La`, verbe
+    de levee + ref pointable dans la meme phrase (Position E).
+    Avant : classifie BOT-CONCERN. Apres : classify() rend None."""
+    body = (
+        "La review COMMENT_WITH_CONCERNS de Hermes est traitee par le "
+        "commit 05d16623f49."
+    )
+    assert mod.classify("myia-po-2027", body) is None
+
+
+def test_12871_ce1_review_verdict_sans_ref_reste_live():
+    """#12871 CE1 — controle negatif : `Cette review CHANGES_REQUESTED reste
+    bloquante` (pas de ref pointable, pas de verbe de levee). DOIT RESTER
+    BOT-CONCERN. Sans quoi le fix debranche le gate et rouvre le failure
+    mode fondateur de B.0 (#10761)."""
+    body = "Cette review CHANGES_REQUESTED reste bloquante."
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_12871_ce2_verdict_leve_sans_ref_reste_live():
+    """#12871 CE2 — controle negatif : `CHANGES_REQUESTED leve sans reference.`
+    Verbe de levee SANS ref pointable dans la suite immediate. DOIT RESTER
+    BOT-CONCERN (le discriminant C+ exige la ref)."""
+    body = "CHANGES_REQUESTED leve sans reference."
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_12871_ce3_emission_formelle_reste_live():
+    """#12871 CE3 — controle negatif : `Verdict : COMMENT_WITH_CONCERNS` —
+    emission formelle Hermes (state-prefix). DOIT RESTER BOT-CONCERN (les
+    positions A-E ne touchent pas le canal d'emission, cf commentaire
+    `_MENTION_VERDICT_HEADING` ligne 327)."""
+    body = "Verdict : COMMENT_WITH_CONCERNS"
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -2788,3 +2788,46 @@ def test_12871_ce3_emission_formelle_reste_live():
     `_MENTION_VERDICT_HEADING` ligne 327)."""
     body = "Verdict : COMMENT_WITH_CONCERNS"
     assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+# ---------------------------------------------------------------------------
+# #13425 — Position E, borne dure : le commentaire au-dessus de
+# `_MENTION_VERDICT_REVIEW_NARRATIVE` promettait « la phrase complete ne doit
+# pas contenir `Verdict :` ni `reste bloquante` » sans qu'aucun lookahead
+# n'existe (mesure dans l'issue : le cas hybride voyait son verdict
+# neutralise). Le lookahead negatif est desormais implemente dans la fenetre
+# de phrase ; ces tests ECHOUENT sans lui — c'est le controle negatif exige
+# par l'acceptance (verifie mecaniquement : le pattern sans lookahead matche
+# l'hybride, le pattern avec lookahead ne le matche pas).
+# ---------------------------------------------------------------------------
+
+
+def test_13425_hybride_reste_bloquante_avec_commit_preserve_le_verdict():
+    """#13425 cas hybride — `<verdict> reste bloquante - traitee par le
+    commit <sha>` : la Position E voyait verbe de levee + ref pointable dans
+    la meme phrase et neutralisait le verdict, alors que la phrase declare
+    un blocage VIVANT. La borne dure `reste bloquante` preserve le verdict.
+    CE TEST ECHOUE SI ON RETIRE LE LOOKAHEAD."""
+    body = ("Cette review CHANGES_REQUESTED reste bloquante - traitee par le "
+            "commit a1b2c3d4e")
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_13425_verdict_formel_dans_fenetre_preserve_le_verdict():
+    """#13425 seconde borne promise — `Verdict :` (emission formelle) dans la
+    fenetre de phrase de la Position E : le verdict n'est pas non plus
+    neutralise par une mention qui suit une emission formelle.
+    CE TEST ECHOUE SI ON RETIRE LE LOOKAHEAD."""
+    body = ("La review CHANGES_REQUESTED Verdict : reste a traiter, traitee "
+            "par le commit a1b2c3d4e")
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_13425_controles_ce1_fp3_restant_inchanges():
+    """#13425 acceptance — les deux controles mesures dans l'issue gardent
+    leur comportement : CE1 (pas de ref pointable) reste BOT-CONCERN, FP3
+    (verdict leve, ref pointable, pas de declaration de blocage) reste
+    neutralise — sous les formes EXACTES du ticket."""
+    ce1 = "Cette review CHANGES_REQUESTED reste bloquante."
+    fp3 = "La review CHANGES_REQUESTED a ete traitee par le commit a1b2c3d4e"
+    assert mod.classify("jsboige", ce1) == "BOT-CONCERN"
+    assert mod.classify("jsboige", fp3) is None


### PR DESCRIPTION
Grain: MED/guard (REPAIR héritage B.0) — lane myia-po-2027:CoursIA-2 — prev: MED/docs #13018

Closes #13425

## Summary

Le discriminateur `_MENTION_VERDICT_*` exigeait la référence pointable entre parenthèses immédiates (`leve (commit <sha>)`). La forme narrative naturelle (`leve par le commit <sha>`, `La review <VERDICT> ... traitee par le commit <sha>`) était classée réserve vivante à tort (live_concern=True) — gate pre-merge rougissait sur des levées RÉELLES.

**Trois positions étendues** (la substance sémantique — verbe de levée + réf pointable — est préservée ; seule la FORME change : la réf peut être NUE dans la même phrase, plus seulement entre parenthèses) :

- **Position A+** (`_MENTION_VERDICT`) : tolère une prose INTERNE à la parenthèse du verdict (`(COMMENT_WITH_CONCERNS, porte sur...)`) tant que le mot déclencheur de mention précède (`reponse a`/`fix`/`leve`).
- **Position C+** (`_MENTION_VERDICT_LIFTED`) : la réf pointable peut être NUE dans une fenêtre de 40 chars après le verbe de levée (forme parenthèsée `leve (commit <sha>)` toujours OK ; forme nue `leve par le commit <sha>` ajoutée).
- **Position E** (nouveau pattern `_MENTION_VERDICT_REVIEW_NARRATIVE`) : verdict en tête après `review/La`, verbe de levée + réf pointable dans la MÊME phrase (borne `[^.!?\n]{0,200}`).

**Discriminateur inchangé** : sans réf pointable (CE1/CE2) ou émission formelle (CE3), le verdict reste émis. Les 3 contre-exemples documentés dans l'issue restent BOT-CONCERN — le failure mode fondateur de B.0 (#10761) reste couvert.

## Rebase 2026-08-29 + #13425 (Position E, borne dure implémentée)

**Rebase sur `main` courant** (tête `7dbeedac72b`) : la branche datait de `8e42b3e5` ; `main` a depuis reçu #13125 et #13451 sur le même organe. Le module auto-merge proprement ; le conflit (fichier de tests) oppose les blocs `test_12908_*` de `main` aux blocs `test_12871_*` de la branche — résolu en gardant LES DEUX (aucune fonction en double, 186 fonctions).

**#13425 — option 1 implémentée** (lookahead, pas correctif de commentaire) : le commentaire de la Position E promettait une borne dure (« la phrase complète ne doit pas contenir `Verdict :` ni `reste bloquante` ») qu'aucun regex n'implémentait — le cas hybride mesuré dans le ticket (`Cette review CHANGES_REQUESTED reste bloquante - traitee par le commit a1b2c3d4e`) voyait son verdict neutralisé alors que la phrase déclare un blocage vivant. Le lookahead négatif `(?![^.!?\n]{0,200}(?:reste\s+bloquante|verdict\s*:))` est posé après la capture du verdict dans `_MENTION_VERDICT_REVIEW_NARRATIVE`.

**Mesure post-fix (les 3 entrées du ticket)** :

| Entrée | Attendu | Obtenu |
|---|---|---|
| hybride `<verdict> reste bloquante - traitee par le commit <sha>` | verdict préservé | préservé — `classify` rend BOT-CONCERN |
| contrôle CE1 (sans réf pointable) | préservé | préservé |
| contrôle FP3 (levée, pas de déclaration de blocage) | neutralisé | neutralisé — `classify` rend None |

**Témoin négatif prouvé aux deux niveaux** (exigence d'acceptance : un test qui ÉCHOUE sans le lookahead) :
1. regex : le pattern sans lookahead matche l'hybride, le pattern avec ne le matche pas ;
2. suite : le lookahead retiré du module → `test_13425_hybride_reste_bloquante_avec_commit_preserve_le_verdict` et `test_13425_verdict_formel_dans_fenetre_preserve_le_verdict` échouent (vérifié empiriquement pendant le dev — revert accidentel du module, 2 FAIL constatés, puis restauration). `test_13425_controles_ce1_fp3_restant_inchanges` passe des deux côtés (il épingle le comportement inchangé).

## Incident fondateur #12816

La réponse de levée écrite par po-2027 contenait `(COMMENT_WITH_CONCERNS, porte sur la conclusion cell 17 point 3 + objectif cell 0 point 3) - traite en code par le commit 05d16623f49`. Classifié BOT-CONCERN par le checker, contournement appliqué à la main (PATCH du commentaire pour retirer le marqueur littéral). **Ce fix supprime le contournement** en relâchant la forme sans toucher la substance.

## Acceptance

- [x] Reproduction CI-tenu : 3 FP ci-dessus → `live_concern=False` (mesuré sur `main@002a88d1099` import direct du module)
- [x] Les 3 contre-exemples → `live_concern=True`
- [x] Tests unitaires : `test_12871_fp1..fp3` + 3 CE + 3 tests `test_13425_*`
- [x] Pas de régression sur la suite existante : **203/203 tests PASS** au head `7dbeedac72b` (200 post-rebase : 186 pré-existants main+branche, 14 apportés par le rebase des positions A+/C+ ; + 3 nouveaux `#13425`)
- [x] #12861 : résolu par la vague de merges (la branche rebase proprement sur `main` courant, l'item de séquencement est obsolète)

## Scope

- 2 fichiers : `scripts/check_unaddressed_nits.py` + `scripts/tests/test_check_unaddressed_nits.py`
- 0 notebook touché
- 0 secret, 0 hand-edit
- Catalogue byte-identique à main

## Liens

- Issue #12871 (registre use-vs-mention, 6ᵉ instance) — incident fondateur #12816
- Issue #13425 (Position E, borne dure) — **résolue par ce PR** (option 1)
- Issue #11809 (Position C historique — verbe de levée + réf entre parens)
- Issue #11984 (Position D historique — nominal `revue`/`review` devant verdict)

## Test plan

- [x] `pytest scripts/tests/test_check_unaddressed_nits.py -q` → 203/203 PASS au head poussé
- [x] Témoin négatif #13425 prouvé (voir section dédiée)
- [x] py_compile OK
- [x] `git diff` cohérent avec intention
- [x] Co-Auteur trailer présent

See #12871
