### PR TITLE
feat(probas,#12915): DecPyMC-11 Valeur de l'Information en Souscription — EVPI/EVSI, calibration PyMC, miroir Spence (T5 EPIC #12904)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-11-Valeur-Info-Souscription.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-11-Valeur-Info-Souscription.ipynb
@@ -1,0 +1,1552 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0886c895",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003374,
+     "end_time": "2026-08-25T08:53:27.756147",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:27.752773",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# DecPyMC-11 — Valeur de l'Information en Souscription\n",
+    "\n",
+    "**Série** : Théorie de la Décision, jambe actuarielle (EPIC #12904, tranche T5) — suite directe de\n",
+    "[DecPyMC-9](DecPyMC-9-Prime-Pure-Chargement.ipynb) (T1 : du risque à la prime) et\n",
+    "[DecPyMC-10](DecPyMC-10-Ruine-Lundberg.ipynb) (T4 : ruine et capital).\n",
+    "\n",
+    "Le fil rouge continue. En T1 nous avons vu l'**antisélection** détruire un portefeuille tarifé au\n",
+    "prix moyen : les bons risques quittent le pool, les mauvais y restent. En T4 nous avons vu le\n",
+    "**prix de l'ignorance** : provisionner à la moyenne du posterior ignore la moitié droite de la\n",
+    "distribution. Ce notebook traite la question qui précède les deux autres : *avant* de tarifer,\n",
+    "*avant* de provisionner — **l'assureur peut-il acheter de l'information sur ses candidats, et\n",
+    "combien vaut-elle ?**\n",
+    "\n",
+    "Un questionnaire médical, un examen complet, un boîtier télématique : chacun coûte de l'argent et\n",
+    "chacun renseigne — imparfaitement — sur le type du candidat. La **valeur de l'information**\n",
+    "(EVPI, EVSI — l'appareil de [DecPyMC-5](DecPyMC-5-Value-Information.ipynb)) donne le cadre exact\n",
+    "pour décider si le signal vaut son prix. Et la théorie des jeux regarde la même question par\n",
+    "l'autre bout : chez Spence (GT-17b), c'est *l'assuré* qui paie un signal coûteux pour se signaler\n",
+    "comme bon risque. Miroir marché / miroir assureur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae887d02",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002804,
+     "end_time": "2026-08-25T08:53:27.761781",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:27.758977",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. Poser la **décision de souscription** (accepter / refuser un candidat) comme un problème de\n",
+    "   décision sous incertitude, avec un seuil d'acceptation dérivable à la main.\n",
+    "2. Calculer l'**EVPI** de la classification parfaite des risques — le plafond de toute dépense\n",
+    "   d'information.\n",
+    "3. Calculer l'**EVSI** de trois signaux imparfaits (questionnaire, examen médical, télématique)\n",
+    "   et confronter chacun à son coût : la décision d'achat est un chiffre, pas une intuition.\n",
+    "4. Voir qu'un signal **corrélé au risque peut avoir une EVSI nulle** : seule l'information qui\n",
+    "   change la *décision* a de la valeur.\n",
+    "5. Propager l'**incertitude de calibration** du signal (PyMC) : l'EVSI elle-même devient une\n",
+    "   distribution — la décision d'achat peut être robuste ou en zone grise.\n",
+    "6. Construire le **miroir de Spence** : quand c'est l'assuré qui paie le signal, l'équilibre\n",
+    "   séparateur émerge — le lien explicite avec GT-17b.\n",
+    "7. Comparer **signal et expérience** : combien d'années sans sinistre valent un examen médical ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "116cf5e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:27.768758Z",
+     "iopub.status.busy": "2026-08-25T08:53:27.768358Z",
+     "iopub.status.idle": "2026-08-25T08:53:29.530075Z",
+     "shell.execute_reply": "2026-08-25T08:53:29.529278Z"
+    },
+    "papermill": {
+     "duration": 1.766793,
+     "end_time": "2026-08-25T08:53:29.531217",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:27.764424",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "g++ not available, if using conda: `conda install gxx`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "imports OK — pymc 6.0.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pymc as pm\n",
+    "import arviz as az\n",
+    "\n",
+    "rng = np.random.default_rng(20260825)\n",
+    "plt.rcParams[\"figure.dpi\"] = 110\n",
+    "print(\"imports OK — pymc\", pm.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4405c430",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002765,
+     "end_time": "2026-08-25T08:53:29.537371",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.534606",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "## 1. La décision de souscription sans information\n",
+    "\n",
+    "Rappel du fil rouge T1/T4, à l'échelle d'une **police individuelle** (primes de l'ordre de\n",
+    "quelques milliers d'euros — typique d'une assurance emprunteur ou professionnelle, ce qui rend\n",
+    "les coûts de souscription visibles devant les primes) :\n",
+    "\n",
+    "- deux types de candidats : **bon risque** (fréquence de sinistre $\\lambda_g = 0{,}03$/an) et\n",
+    "  **mauvais risque** ($\\lambda_b = 0{,}09$/an), coût moyen d'un sinistre $E[S] = 50\\,000$ € ;\n",
+    "- prime pure : $\\pi_g = \\lambda_g E[S] = 1\\,500$ €, $\\pi_b = \\lambda_b E[S] = 4\\,500$ € ;\n",
+    "- dans la population des candidats : 30 % de mauvais risques — mais **l'assureur ne voit pas le\n",
+    "  type**, seulement le mélange : $\\pi_{\\text{pool}} = 2\\,400$ € ;\n",
+    "- prime commerciale au pool avec chargement $\\theta = 10\\,\\%$ : $P = 2\\,640$ €.\n",
+    "\n",
+    "La décision de l'assureur pour chaque candidat : **accepter** (résultat $= P - \\pi_{\\text{type}}$)\n",
+    "ou **refuser** (résultat $= 0$). Définissons ces quantités et dérivons la règle optimale sans\n",
+    "information :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e1373832",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:29.544998Z",
+     "iopub.status.busy": "2026-08-25T08:53:29.544348Z",
+     "iopub.status.idle": "2026-08-25T08:53:29.550483Z",
+     "shell.execute_reply": "2026-08-25T08:53:29.549911Z"
+    },
+    "papermill": {
+     "duration": 0.011214,
+     "end_time": "2026-08-25T08:53:29.551329",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.540115",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "prime pure : pi_g = 1500 EUR | pi_b = 4500 EUR | pool = 2400 EUR\n",
+      "prime commerciale au pool : P = 2640 EUR (chargement 10%)\n",
+      "profit par police acceptee : bon risque +1140 EUR | mauvais risque -1860 EUR\n",
+      "regle optimale sans info : accepter tous -> E[profit] = 240 EUR par candidat\n",
+      "seuil de refus : P(mauvais | information) > 0.380\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Parametres du fil rouge (echelle police individuelle)\n",
+    "LAMBDA_G, LAMBDA_B = 0.03, 0.09          # frequences annuelles de sinistre (bon / mauvais)\n",
+    "E_S = 50_000.0                            # cout moyen d'un sinistre (EUR)\n",
+    "P_MAUVAIS = 0.30                          # proportion de mauvais risques parmi les candidats\n",
+    "THETA = 0.10                              # chargement\n",
+    "\n",
+    "PI_G, PI_B = LAMBDA_G * E_S, LAMBDA_B * E_S\n",
+    "PI_POOL = P_MAUVAIS * PI_B + (1 - P_MAUVAIS) * PI_G\n",
+    "PRIME = PI_POOL * (1 + THETA)             # prime commerciale au pool\n",
+    "\n",
+    "PROFIT_G = PRIME - PI_G                   # resultat si le candidat accepte est bon risque\n",
+    "PROFIT_B = PRIME - PI_B                   # ... s'il est mauvais risque (negatif)\n",
+    "\n",
+    "baseline = P_MAUVAIS * PROFIT_B + (1 - P_MAUVAIS) * PROFIT_G   # esperance accepter-tous\n",
+    "\n",
+    "# Seuil d'acceptation : accepter est optimal ssi E[profit | p] = p*PROFIT_B + (1-p)*PROFIT_G > 0\n",
+    "SEUIL = PROFIT_G / (PROFIT_G - PROFIT_B)  # = 0.38 : accepter ssi P(mauvais | info) < SEUIL\n",
+    "\n",
+    "print(f\"prime pure : pi_g = {PI_G:.0f} EUR | pi_b = {PI_B:.0f} EUR | pool = {PI_POOL:.0f} EUR\")\n",
+    "print(f\"prime commerciale au pool : P = {PRIME:.0f} EUR (chargement {THETA:.0%})\")\n",
+    "print(f\"profit par police acceptee : bon risque +{PROFIT_G:.0f} EUR | mauvais risque {PROFIT_B:.0f} EUR\")\n",
+    "print(f\"regle optimale sans info : accepter tous -> E[profit] = {baseline:.0f} EUR par candidat\")\n",
+    "print(f\"seuil de refus : P(mauvais | information) > {SEUIL:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29499145",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002578,
+     "end_time": "2026-08-25T08:53:29.556643",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.554065",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "Trois chiffres structurent tout le notebook. (1) Accepter tout le monde au tarif pool rapporte en\n",
+    "espérance **+240 € par candidat** — le chargement de 10 % paie le mélange. (2) Mais ce profit est\n",
+    "une moyenne écrasée : chaque mauvais risque accepté **coûte 1 860 €**, chaque bon risque en\n",
+    "rapporte 1 140. (3) La règle optimale face à une *probabilité* $p$ que le candidat soit mauvais\n",
+    "risque est triviale à dériver : accepter ssi $p < 0{,}38$ — le **seuil de refus**. Toute\n",
+    "l'information du monde ne sert qu'à déplacer $p$ de part et d'autre de ce seuil ; c'est la clé de\n",
+    "la suite. (Et souvenez-vous de T1 : si l'assureur ne peut refuser personne et tarife au pool, les\n",
+    "bons risques partent chez le concurrent qui, lui, les identifie — l'antisélection travaille\n",
+    "sous vos pieds pendant que vous calculez.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7e23ba1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002613,
+     "end_time": "2026-08-25T08:53:29.561836",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.559223",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "## 2. EVPI : le plafond de la classification parfaite\n",
+    "\n",
+    "Supposons l'information **parfaite** : l'assureur connaît le type de chaque candidat. La règle\n",
+    "optimale devient triviale — refuser les mauvais risques (perte certaine de 1 860 €), accepter les\n",
+    "bons (+1 140 €). La **valeur de l'information parfaite** (EVPI) est le gain d'espérance :\n",
+    "\n",
+    "$$\\text{EVPI} = \\mathbb{E}[\\text{profit} \\mid \\text{info parfaite}] - \\mathbb{E}[\\text{profit} \\mid \\text{aucune info}]$$\n",
+    "\n",
+    "C'est le **plafond absolu** : aucune dépense d'information — questionnaire, examen, data — ne peut\n",
+    "valoir plus que l'EVPI par candidat."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8a862c6a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:29.567619Z",
+     "iopub.status.busy": "2026-08-25T08:53:29.567413Z",
+     "iopub.status.idle": "2026-08-25T08:53:29.571775Z",
+     "shell.execute_reply": "2026-08-25T08:53:29.571201Z"
+    },
+    "papermill": {
+     "duration": 0.008274,
+     "end_time": "2026-08-25T08:53:29.572526",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.564252",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "E[profit | info parfaite] = 798 EUR par candidat\n",
+      "E[profit | aucune info]   = 240 EUR par candidat\n",
+      "EVPI = 558 EUR par candidat  (plafond de toute depense d'information)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EVPI : on refuse les mauvais risques, on accepte les bons\n",
+    "esperance_parfaite = (1 - P_MAUVAIS) * max(PROFIT_G, 0.0) + P_MAUVAIS * max(PROFIT_B, 0.0)\n",
+    "evpi = esperance_parfaite - baseline\n",
+    "print(f\"E[profit | info parfaite] = {esperance_parfaite:.0f} EUR par candidat\")\n",
+    "print(f\"E[profit | aucune info]   = {baseline:.0f} EUR par candidat\")\n",
+    "print(f\"EVPI = {evpi:.0f} EUR par candidat  (plafond de toute depense d'information)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a26b542d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004417,
+     "end_time": "2026-08-25T08:53:29.579716",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.575299",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "L'EVPI vaut **558 € par candidat** : c'est exactement la part des mauvais risques (30 %) que\n",
+    "l'assureur cesse d'absorber, soit $0{,}30 \\times 1\\,860$. Aucun signal, aussi bon soit-il, ne peut\n",
+    "rapporter davantage — un signal parfait *est* ce chiffre. Notons l'ordre de grandeur : tout\n",
+    "processus de sélection qui coûterait plus de 558 € par candidat est condamné d'avance, même s'il\n",
+    "est exact à 100 %. La question devient : à quelle *fraction* de ce plafond chaque signal\n",
+    "imparfait accède-t-il, et pour quel coût ?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53285138",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002488,
+     "end_time": "2026-08-25T08:53:29.584695",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.582207",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : EVPI et structure du portefeuille\n",
+    "\n",
+    "L'EVPI dépend de la proportion de mauvais risques $p$. Complétez la fonction `evpi_p(p)` et la\n",
+    "grille ci-dessous : pour $p \\in \\{0{,}1,\\ 0{,}2,\\ 0{,}3,\\ 0{,}5,\\ 0{,}7\\}$, calculez l'EVPI.\n",
+    "Vérifiez votre intuition : que vaut l'EVPI à $p = 0$ et à $p = 1$ ? Pour quel $p$ intermédiaire\n",
+    "est-elle maximale ? *Indice : sans information, la règle « accepter tous » n'est plus optimale\n",
+    "quand $p$ dépasse le seuil 0.38 — que devient alors la référence « aucune info » ?*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "683dc30f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:29.591333Z",
+     "iopub.status.busy": "2026-08-25T08:53:29.590770Z",
+     "iopub.status.idle": "2026-08-25T08:53:29.594313Z",
+     "shell.execute_reply": "2026-08-25T08:53:29.593945Z"
+    },
+    "papermill": {
+     "duration": 0.007805,
+     "end_time": "2026-08-25T08:53:29.594949",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.587144",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer\n",
+      "  resultats : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : a completer\n",
+    "def evpi_p(p_mauvais):\n",
+    "    \"\"\"EVSI d'une information PARFAITE pour une proportion p_mauvais de mauvais risques.\"\"\"\n",
+    "    pass  # TODO etudiant : (1) profit bons/mauvais au tarif pool, (2) regle optimale SANS info\n",
+    "           #            (accepter tous, ou refuser tous selon le signe de l'esperance),\n",
+    "           #            (3) regle AVEC info parfaite, (4) difference.\n",
+    "\n",
+    "resultats_ex1 = None  # TODO etudiant : dict {p: evpi} pour p dans [0.1, 0.2, 0.3, 0.5, 0.7]\n",
+    "print(\"Exercice 1 a completer\")\n",
+    "print(\"  resultats :\", resultats_ex1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4adca7d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0024,
+     "end_time": "2026-08-25T08:53:29.599736",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.597336",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "## 3. Trois signaux imparfaits : Bayes à la main\n",
+    "\n",
+    "L'information parfaite n'existe pas ; ce qui existe, ce sont des **signaux** — chacun décrit par\n",
+    "sa **sensibilité** (probabilité d'alerter sur un mauvais risque) et sa **spécificité** (probabilité\n",
+    "de ne pas alerter sur un bon risque), et son **coût** par candidat :\n",
+    "\n",
+    "| Signal | Sensibilité | Spécificité | Coût / candidat |\n",
+    "|---|---|---|---|\n",
+    "| Questionnaire médical (déclaratif) | 0,40 | 0,65 | 15 € |\n",
+    "| Examen médical complet | 0,70 | 0,90 | 90 € |\n",
+    "| Télématique (analyse d'un an de conduite) | 0,90 | 0,97 | 500 € |\n",
+    "\n",
+    "Le théorème de Bayes transforme le signal en posterior — c'est *l'application actuarielle* du\n",
+    "cours de DecPyMC-5. Pour un signal positif : $P(\\text{mauvais} \\mid +) = \\frac{p \\cdot \\text{sens}}{p \\cdot \\text{sens} + (1-p)(1-\\text{spec})}$.\n",
+    "Le tableau complet :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6af9561c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:29.605352Z",
+     "iopub.status.busy": "2026-08-25T08:53:29.605167Z",
+     "iopub.status.idle": "2026-08-25T08:53:29.614529Z",
+     "shell.execute_reply": "2026-08-25T08:53:29.614084Z"
+    },
+    "papermill": {
+     "duration": 0.01314,
+     "end_time": "2026-08-25T08:53:29.615265",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.602125",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       signal  P_pos  P_bad_pos  P_bad_neg action_pos action_neg  E_profit\n",
+      "questionnaire  0.365      0.329      0.283   accepter   accepter    240.00\n",
+      "       examen  0.280      0.750      0.125    refuser   accepter    550.80\n",
+      "  telematique  0.291      0.928      0.042    refuser   accepter    718.26\n",
+      "\n",
+      "reference sans information : E[profit] = 240 EUR (seuil de refus = 0.38)\n"
+     ]
+    }
+   ],
+   "source": [
+    "SIGNAUX = {\n",
+    "    \"questionnaire\": dict(sens=0.40, spec=0.65, cout=15.0),\n",
+    "    \"examen\":        dict(sens=0.70, spec=0.90, cout=90.0),\n",
+    "    \"telematique\":   dict(sens=0.90, spec=0.97, cout=500.0),\n",
+    "}\n",
+    "\n",
+    "lignes = []\n",
+    "for nom, s in SIGNAUX.items():\n",
+    "    p_pos = P_MAUVAIS * s[\"sens\"] + (1 - P_MAUVAIS) * (1 - s[\"spec\"])\n",
+    "    p_neg = 1 - p_pos\n",
+    "    p_bad_pos = P_MAUVAIS * s[\"sens\"] / p_pos\n",
+    "    p_bad_neg = P_MAUVAIS * (1 - s[\"sens\"]) / p_neg\n",
+    "    e_pos = max(p_bad_pos * PROFIT_B + (1 - p_bad_pos) * PROFIT_G, 0.0)\n",
+    "    e_neg = max(p_bad_neg * PROFIT_B + (1 - p_bad_neg) * PROFIT_G, 0.0)\n",
+    "    lignes.append(dict(signal=nom, P_pos=p_pos, P_bad_pos=p_bad_pos, P_bad_neg=p_bad_neg,\n",
+    "                       action_pos=\"refuser\" if p_bad_pos > SEUIL else \"accepter\",\n",
+    "                       action_neg=\"refuser\" if p_bad_neg > SEUIL else \"accepter\",\n",
+    "                       E_profit=p_pos * e_pos + p_neg * e_neg))\n",
+    "tbl_bayes = pd.DataFrame(lignes).round(3)\n",
+    "print(tbl_bayes.to_string(index=False))\n",
+    "print(f\"\\nreference sans information : E[profit] = {baseline:.0f} EUR (seuil de refus = {SEUIL:.2f})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e83e1336",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002631,
+     "end_time": "2026-08-25T08:53:29.620670",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.618039",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "Lisez la colonne `P_bad_pos` contre le seuil 0.38 — c'est là que tout se joue. L'**examen médical**\n",
+    "et la **télématique** franchissent le seuil dans les deux sens : signal positif → refus (0.75 et\n",
+    "0.93 de mauvais risque), signal négatif → acceptation (0.13 et 0.04). Ils *changent la décision*.\n",
+    "Le **questionnaire**, lui, reste sous le seuil dans les deux branches (0.33 / 0.28) : même un\n",
+    "signal positif ne suffit pas à refuser le candidat. Le signal bouge la croyance mais pas l'action —\n",
+    "et un signal qui ne change pas l'action ne peut pas changer le résultat. C'est la leçon centrale\n",
+    "de l'EVSI, plus forte que sa version intuitive « plus d'info = mieux » : **la valeur d'un signal\n",
+    "se mesure en décisions changées, pas en corrélations**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3844eb05",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002537,
+     "end_time": "2026-08-25T08:53:29.625720",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.623183",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "## 4. EVSI : la valeur de chaque signal contre son coût\n",
+    "\n",
+    "L'**espérance de valeur d'information imparfaite** (EVSI) est la différence entre le profit\n",
+    "espéré avec la règle bayésienne optimale après le signal et le profit sans information :\n",
+    "\n",
+    "$$\\text{EVSI} = \\sum_{s \\in \\{+,-\\}} P(s) \\cdot \\max\\big(\\mathbb{E}[\\text{profit} \\mid s, \\text{accepter}],\\ 0\\big) - \\text{baseline}$$\n",
+    "\n",
+    "La **décision d'achat** du signal est alors un simple ligne à ligne : EVSI nette = EVSI − coût.\n",
+    "Calculons pour les trois signaux et confrontons au plafond EVPI :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "548cb86e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:29.632105Z",
+     "iopub.status.busy": "2026-08-25T08:53:29.631744Z",
+     "iopub.status.idle": "2026-08-25T08:53:30.133142Z",
+     "shell.execute_reply": "2026-08-25T08:53:30.132675Z"
+    },
+    "papermill": {
+     "duration": 0.50691,
+     "end_time": "2026-08-25T08:53:30.135080",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:29.628170",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       signal  EVSI  cout  EVSI_nette  part_EVPI\n",
+      "questionnaire   0.0  15.0       -15.0        0.0\n",
+      "       examen 310.8  90.0       220.8       55.7\n",
+      "  telematique 478.3 500.0       -21.7       85.7\n",
+      "\n",
+      "EVPI (plafond) = 558 EUR par candidat\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA2QAAAGACAYAAADCoqF1AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAQ6wAAEOsBUJTofAAAX3tJREFUeJzt3Qm8TdX///EPrqHMU+aIMlSmRKQSMjZI5jSISPpqUCqprynRQIMGDag0GIoGJUWKvomUIpJEpsiYISGc/+O9fo99/vuce+58r33d+3o+Hsd11tlnn7X32Xuf/dlrrc/OEQqFQgYAAAAAOOFynviPBAAAAAAIARkAAAAABISADAAAAAACQkAGAAAAAAEhIAMAAACAgBCQAQAAAEBACMgAAAAAICAEZAAAAAAQEAIyAAAAAAgIARkAAAAABISADACAKJs2bbKhQ4fa//73v6CrAgDI4gjIgJPEpZdeapUqVbKsXv/0WM7jx4+7k+nKlStbXFyc5ciRw7K6k337yEyOHTtm1157rb3zzjvWvn1727p1a9BVyrS0b/Xo0cMyo1dffdXV74svvkjTfNi30u73339334WOyyfj/IGMRkAGpJPOnTu7H4RFixaly3TZgU509Ehvr732mg0bNsyaNm1qEyZMsMmTJ1tWoJON9957L+hqZHlDhgyxw4cP29KlS11Adt1117kgP9YJ/1NPPRVIHYHs5ocffnDHQAVfQFYTF3QFgKyid+/eNn36dBcANGrUKOY0u3btsvfff9/OOeecBKfJ7j799FMLhUJpmsdnn31mhQsXtldeeSVLtY4pyLzxxhvt6quvzpD1BrODBw9a3rx5XeCbL18+e/bZZ23s2LG2du1aq1q1aryATCeHd955p2VX//zzj+XKlSvoaiCTq1ixottW1GMhLQGZjoGxWizTY/5AkGghA9LJZZddZmeccYZNnTrVDhw4EHOa119/3Y4cOWI333yznYz27duX4Z+RJ08ed0KcFtu2bbMiRYqkezCmrmw6Yc+M0mO9wezUU0+1hx56yMqWLeue586d2+677754wdjJLr32ZQWtWkdAYtuZjsXaVjIqYMro+QMZjYAMSMcfhF69erlgTEFZLGo900nz9ddf756/8MIL1qpVKytfvrw7oT7ttNOsQ4cO9tNPPyX7c3/77Tc3hkMnkJqH5tWvXz/buXNnxHSaJqEARVcbo7sOemNDNP5CrxUqVMhq166dZH3UkqBuXmqhKliwoLVs2dJ+/PHHZC9PrKufXpkCLa274sWL2ymnnGKXXHKJ61YWPWZk/vz5tmHDBvf/6DEuixcvtiuuuMKKFSvmfsCrV69uI0aMcIGyn7rG6L2rVq2ye++9112B1Xc3bdo0t070mj7vpZdesrPPPtvNSyftCrply5Yt1rVrV1fX/Pnzu1Yt1d9v//797uS/YcOGVrJkSff9aTn/85//2O7du8PTeZ/ndcf0lsv/fSY0ziWly7tmzRr773//G17eGjVq2Jtvvpnk96YufaeffnqCgctXX33l5q/l9Wi+ailW3fR96v3XXHONW+fJsX79etcy7dW1VKlSbntTC6nf6tWr3Xeh1zWdxhbec8898YISbx3E6hIVvX413ZdffhmxnaVlvJK3nWrbbdy4sdtmSpQo4cq2b9+equ0memzNu+++aw0aNHBB51VXXZVofTZv3mx9+vRxF5m03agu9erVs0ceeSRmvf3UUvvkk0/aWWed5dZ3lSpVbNSoUTZv3rzwfhNrn1X3T20/eo8+Vy2T0ZYsWWI9e/a0atWquXWkR/369W3SpEmWVik9di1btsw6duzojtv6DrRd3X///cm+aPPzzz9bt27drEKFCm6ZNZ8LL7zQtez7HTp0yLUMad/Vd6H95corr4w49iU1jirWeLo9e/bYwIED3fek/a9o0aJWs2bNmC2+CxcutHbt2rntTXXVvqpxlvr9if4dWb58uV1++eVuflqXCdXNX6bxmuedd56rR5kyZVwd/Bc2tY3ddNNN7v/qih59bE9o2XVceuaZZ9xvl+at37FmzZrFO0b4669joJZVdS9QoIC1bdvWbRtARuJSApCO9IOh8Sf6QVVw5vfNN9/YypUr3Q+wTtLlscceswsuuMBuu+02d8Lz66+/uvfqx0I/9jqRSaoLh35AdIKlkxSdmGoeCvR08qOTF+8HMTX0g68fSs1bP746EUwqM51OKP766y/r27evO5nXcquO3jKn1t9//20XX3yxOylUQPHnn3+6k742bdrYunXr3AmUAjSNFxs5cqQLSPW6eOvxk08+cSei+lFW0Fq6dGn7+OOPXQDy9ddf20cffWQ5c0Zep+revbu76qrvSD/OOhHU+CJ5/vnnbceOHa7FU/N8+eWXXZdCtRgMGjTI1ffhhx92AcFzzz3nXpszZ0543graFNApCOnSpYs72dJ39uKLL7oA5ttvv3Xz0nrUcikY1Tx1opwcqVle1VEnNrfffrt7TcuoMVRahwoAEqJpb7jhBrfulZlQQYWfdxLunUApGNN8NZ32Ga1brY/PP//cfvnlFxfkJub777+35s2bu5NfzbNOnTpu+9T2NnfuXGvRokV4H9F2cfToUbcOdNKsdTtmzBi3j6iu2n9SKtZ2JvquUkv7vPY3HUe0brQtKABXUK1tQesoJduNn7pKK+DRfqkgNrHurVpXWn/an2+99VYXCOjkWNuxvp8HHngg0eXQBYwnnnjCBX96v/YXBUwzZ85M8D2apwJkLbuWUxc27r77bnehScG0R/PQBSsFQjre7d27110k0TFK+6I+OzVSeuzSvqWLLAqm+vfv74J9BW8KIrVNKcBMrLVG3dcVWChguOWWW1wAqgBpxYoVLtD3elGoVV4Bgeanvwq6dWFHx/iLLrrIZs+e7eaTGhrPrPnqeKL9RxdpFGBp//HTb5LqqGBM9VJdVQetA30X/t8prccmTZq4wFZBePRFqFhmzZrl1pv2T/1uar98+umn3b6r/6tLrD5fgaC2e20r3n6W1G+kjg3aV3Wc0cUEbcdaHl0I1Tam/cxP+5aOFzpuPvroo+73dNy4cS5A03cTfbwE0k0IQLq66qqrdKYTWrlyZUT5zTff7MrnzZsXLjtw4EC89//000+h3Llzh/r16xdR3qRJk1DFihUjyurUqRM644wzQrt27YooX7x4cShXrlyhoUOHhstuvPFG9/mxaL6av5+m1WP27Nmh5Lr++uvde2bOnBlRPmrUKFceXf9YYi2nyvT+Rx55JKL87bffduUvvvhikvM4evRoqFKlSqFTTjkl9Ouvv0a8dtNNN7n5TJ48OVw2ZMgQV3bRRReFjhw5EjH9/Pnz3WulS5cO7d69O1y+bdu2UN68eUM5cuQIPfrooxHvueOOO9x7fvnll3DZ4cOH481bXn75ZTfttGnTIspVpu8xluhlTu3ytmnTJnTs2LFw+caNG9322K1bt1BS9Dmah7Z1v7///jtUqFCh0MUXXxwua9++fahgwYIxlz8px48fD5177rmhuLg4t61H89dfn6nv46uvvoqYZtiwYa6uI0aMiLcO1q9fn+ztMjnbdHJ4+9v06dMjyseOHevKVbfUbDdaFpVpXa1YsSJZdfnxxx/de0aPHp2sevu3SW3fWt+NGzeOqONff/0VqlChgpt+0qRJ4XL9X2W1atUKHTp0KOLYWLx48VCjRo0iPi/WMVPft77nwoULR3ymN2/tr+l57Prnn3/cvt+gQYOIOss777zjpn/11VcT/bz333/fTTdlypREp5swYYKbrnfv3hHlWs861px11lnh7d37rv3bSkLrQt+Hnvft2zfRz9+8ebP7HP3O7NixI9F9TetI83zhhRfiTRerbl6Ztpfo/fj2229PcFuJ9X3Gmr9+a71jmo6Hnu3bt4dOO+20UJEiRUL79++PV/+33nor5jYwZ86cRNcVkBaE+kA609Vn8Xc7UeuOujHqap7/aqa624jOa3R1WFfbdaVVrTC6Kp4YXZnUFURdPdZVVr3Xe6gV4Mwzz4xojUkNdfNo3bp1sqZVHZQIQS0b0Ukn1P3Eu7qfWroyedddd0WUea0g6mKSFLWoqFuLWpm0bvy8bi7q0hVNV+kTGiOjq/LqluPxvjuvhclPV42j66puTt681Sqhq/P6/tSlRpLaBjJiebWO/VeB1QKgZUrOOtbn6Kq9Wiw0wN4zY8YMt337u7ZpjJ9atz788MOYGQwTo5YIbf9qvVQrTDSv/moxUVcrbSfRLXbqsqj9L9Y6CIq666nlx08ts1pX/nqmZrtRF7Jzzz03WfXwWtXVepKcFg4/HQN0PNN25N9vNE+1liVELT/+MZD6btSdNXq7846Zom1MLU3qpqnjlFrL1LqaUik9dqkFSetF27NaZf3HXrWuqMU1qWOvvlNRi7W+v4R437u6LEZvK+q1oBYctdyklLrvqWVV24p6GCREiarUwqlWdfXiiBbdYqTulN5vYHJp/4zejwcPHuz+pmX/9N6r7r3+xDNq6dN+pfWuFjg/tciqF0t0/SQ5x0AgtQjIgHSmLnTlypVz3SS8cToKxvTDre4Y/nE/CxYscMlAdJKhExb9UOihk83osSCxxh+IuoV47/M/dGKibn1pkZJEBhrnomWM1dVMP/xJdS1Jin4oNR8/ryuRTsqS4p10aIxENI2HULc+/3iI5KwDBb7RFKDFqqsXuEXXVd0c69atGx7Doe/OW1dJbQMZsbyxlknrOTnrWNTlTMGXgjB/d0WdpHbq1CnihEufpTGTOtHTmBh1/UvONuudGGnMSWrXgeqj9RxrHQQl1r6j4Ev1jB7DktLtJiX7sroCqhupuk5rW9aFGZ3Axhp3k9A6VzfHaIl150zudqegR13bVC99h9p2tOzeCXxq9pmUHru8Y6/qEX3c1TgwXWhIajtW4KYLOuo2p/ep67ou/kTfDkXrU+tB46qiedt1arZhbVcaW6Xxmlo+XXRRd0Ttt+ommdJ9zaN5pTTrZqz1rvWo5U7L2K3E9v+E1l1C26Ek9xgIpAZjyIB0ph8j/dBqnJPGbegkVK1lGk/gDUqW7777zo2B0Q+AxqLor04wFLDdcccdrlUtMV6rgsYvJDRAXydrnsQyDuoqeyypGVuTURL7kU+PdO8JrZ/E1kFCdUpuXTVOQlfgFZRrrJZOMtVKoO9DgX1KW47SY3kTqnty17G2d22TGvukFiyNKVFLi8ZqaJyf/8RNYyqVZEBXqdWSpVYrXc1Wq4FOWE+01OwjQUjNdpPSfVmtqDpeaYySvhu1NuizNJZG47jSO4Npck7itQ1q7I9ahLSNKZmHglG9V9uMAvqM3Gc83mfouB2rhVb8LecJUZInJdXQOtbYv4kTJ7qxVFo2BUsZvf2qJUu/Hfp8XRxUy5/qpGXSOLboi0rJkZl+MzLj7wyQEAIyIAOoJUw/1vpxUzchXfVUVxglVfAoqYF+JPVjGH1VTlfikvox9F/x1olZUtSVxLuC7P3f6/azdevWeN3aUkpXNHXCHStDnrKE6UpkWhN7pIV3lVtBQDQFDerulNZWvJRS0KLMXure5O/6412BPxmXV9uAWr20fStTn1oAdAIbnYlP1KVN3YG8LkHKznb++ee77lGJZSv0tn0lwUiMt1/FWgfa7nUF3b/d+/eR6IyVmlatCn7pHZTE2ne8RAv+embkdhPdUqYEF3roWKXvUN+rTtYTuqG7t86VAET3W/RLa/0UiKkrroL24cOHR7yWnNa79Dp2edufjtHJOfYmRi2JeqiLp7ZJJe5QEokBAwa471j7qNalWtzUJdrPy8br7cf+7TdaQt0SNU99r3oo4FDCjNGjR9uUKVNcmX9fq1WrlmWEWOtdrZb6HfTfrzOl+5v/GKgWyMTWHRA0uiwCGUAnMjrJ1EmCuv5I9L3HvCtx0Vfdxo8fn6xuW8qKpW4XCvpinehovhpD41GXFInOoKVsc+lxVVknhrp6rh9XjcfwU3a3hO7NdqKoe5dOcNSVVKnK/byTOwUSJ5K3DfjXv7636JNNj8ayJLdLVpDLq5YVLZOCMS94iD6B92+b/i5t6r6bVNcgdaHThY433ngjXupv//pUVzBlpVTgoiyE0du9tkn/OkhoH9Hn6KJFrO9DmfHS68q5uocpy6KfsnNqrIsyKqZ2u0kpBev//vtvRJla+L3bXiT2/egYoBNntVb556F5KjNgWiR0zPzjjz/ipYrPyGOXWukUyDz++OMxx9gpeE1qP9Xr0cdd9Wjwuu9569j73tXjwk9d+d566y2Xst4LlBRUqmujMmH615HmpdY3P3WrjE7Pr+/N65rofb5avNX6qs+PtUzp8duh38no/VMXNMW/3Xtj+ZJ7DPTeq+yK/nqq26v2K43jUy8VIDOghQzIIOoOohNBDYrWvcGik2Pox0LdU9TFSGmH1dVD3Vb0Hl21S6qLlH48daKogfz6EdXVTAVoOglSMgedWCiFuZfAQQOVNc5C9dIVQ51Q6Eq3uk7GGqydGkrxrlTISqfspctW6ugPPvggWcuUkXQypxNCddFRVydd9deVcbVQqruTTrI0SP5E0smObjqsz1YyB50gqTtY9D3CPEo7r2BB6Zg1DkzbgD8leGZZXu+eXaqnxpPpokT01W19vnerAi2Lll1X5RV8PPjgg4nO37uXlbZ9JetQF2EFC+rmq+1NrTT6bFHXL32GptU26aW918ms3qOWCI9aO3RCrBYYXaHXya4CPm2/aqGKDlL0fShltxJSKGW61rk+R+tZ+6DSgyuZS3LvTab9V/uxuo8pOFX6ei2nWinUnTO1201KqYupjhNKXa4gVSeuClZ0sUjjYxNrFdL06k6pgEwJXpSWX/VS2nsFC2qdTW3Loo4nCsR1uxAFSWqB073olO5fx5e0jLlMybFLx2pd6FAQp+9JFyA0vcahqTVN47DUyhSrVdijixU6/qvnhOaveepYrMBS26UuuIluJaHjvAKIjRs3uu/cS3uvoEvL7l+fSiakW25oOn1/uvCh8YbaFv0X+hT8a7/Q52s96uKFWtH0HWu/9IIZfd/ah3T80HRaVs1L+4fWl7ZLrYe00MUjbVMak6djgY5x2p61/Wj5PTqOKXhWsKYLIbp4o7pEt355tC8qqZG+KyXT0vrw0t6r/voO0ppsCkg3acrRCCBBSr+s1LrazR566KGY03zwwQeh888/P3TqqaeGihYtGrryyitduvyUpNjetGlT6LbbbgtVrlw5lCdPHpfKt2bNmi7NenTq/W+//TZ0ySWXhPLly+c+r2vXrqEtW7YkmPY+oRTriVE65nbt2rmU5gUKFAi1aNEitGzZsmSnCE9pevFY9Uxs+kWLFoXatm3r1pPWV9WqVUPDhw93qcT9EkuB7qW996dkTuqzY71HKaOVHl+pq5VaumzZsqFbb73VpdKPtVxr1qxx61Pr1kuTntTnpsfypia9uzc/pbRet25dzBTtrVq1CpUpU8bVq2TJkm7bnDp1arI/Q2n2tY40D6XmL1WqlJvn3LlzI6ZbtWpVqHPnzqESJUq46bQsAwYMcKm/o61du9atr/z587v1rP///PPPMdeB0vn37NnT7ec5c+aMSMm9fPly9/zaa69N1rJ43/fnn38euvDCC93tCrSPKh27bqfgl5LtJrFU6AnR96V06Geffba7XYHqcuaZZ4b69+/vjjex6h19W4LHH388VKVKFffdKmW6blmhlPKa3v8dJ5bKPNatOjZs2OCOW1rnOo7Vrl3bpYaPNZ+UpL1PzbFL24XqWL58ebddafuqV69eaNCgQe52EYnRfHv06OG+Q32Wtrfq1auHBg8eHHErDS/Nvr4/7bveMf6KK64ILVmyJN58ld79gQcecNuEpj3nnHPceoheFzt37gzdddddobp167rtTNuRllF10nJFUwr51q1bu2k139NPPz3UvXv30G+//RaeJtbvSHLS3qtMt2rQbVxUD+3H2tb27dsXbz66nUCNGjXc+vZvewlt59pXnnrqKfebqHlrXTdt2jRmCvuE6p+afQhIqRz6J/3COwAAoK5uukmxxqokJ8OhWjnUou3dQDsrUhc/rRO1PCXUqoHsw2tFVgu615MDyK4YQwYAQDpTd65bbrklRenms4rosUneGDIlq1DXOHVRAwD8f4whAwAgAwKy7Erj8zQWSfeWU0p+jX3SGLItW7a45BLR2SoBILsjIAMAAOlGCSmU2ERBmbL1KXugWsWUiEJBGgAgEmPIAAAAACAgjCEDAAAAgIAQkAEAAABAQBhDlohDhw7ZihUrXFaouDhWFQAAAICk6Ybyujl7zZo1LV++fIlOS5SRCAVjDRo0CLoaAAAAAE5CS5Yssfr16yc6DQFZItQy5q3IMmXKBF0dAAAAACeBrVu3uoYdL55IDAFZIrxuigrGypcvH3R1AAAAAJxEkjPsiaQeAAAAABAQAjIAAAAACAgBGQAAAAAEhIAMAAAAAAJCQAYAAAAAASEgAwAAAICAEJABAAAAQEAIyAAAAAAgIARkAAAAABAQAjIAAAAACEhcUB98Mtm8ebMVL17cTjnllHDZpk2b7Pjx4668QIEC4fItW7bY0aNHrWjRolaoUKFw+bZt2+zw4cNWuHBhK1KkSLj8zz//tEOHDlnBggWtWLFi4fKdO3fa33//baeeeqqVLFkyXL57927bv3+/5cuXz0qVKhUu/+uvv2zv3r2WJ08eK1OmTLh83759tmfPHouLi7Ny5cqFyzVvfUaOHDns9NNPD5f/888/tn37dvd/let1Ud21DKL5aH7y77//2h9//OH+r8/V54vWjdaRqJ6qr2fDhg3ur5ZLy+dfz8eOHXPrQevDo/nrcxJapyrTax7VX8uh70Xfj2fXrl124MAB9z2edtppSa5TrU+t19y5c1vZsmXD5ZpW78mVK5eVL18+XH7w4EHbsWNHouu0QoUKljPn/10HOXLkiG3dutX9X/PX54i2H21Hia1T1d+/PW7cuNFCoZCVKFHC8ufPn+T26K1TbYvaJpPaHrVcWj7NW58Rve6i16m2OW17efPmtdKlSye5Pep70feT0DqVihUrhstVR9VVNL3eF709JrROVR/VS7TOtO5irdOU7uP6LvWdpnQfT2idpnUf99aptjdtd+mxj/vXqfZV7bOp2cdTetxMaB9P63EzoX08LcfNhPbxlB43E9rHU3rcTO4+ntLjZlL7eEqPm4nt4yk9biZ3H0/pcTOl+3hSx82E9vGUHjcT28fTctxMzj6e1uMm50acG2Xlc6M9e/ZYsoWQoE2bNoW0imrUqBH68ssvI1675JJLQrVr1w59+OGHEeVXXHGFK588eXJE+XXXXefKn3322Yjy2267zZWPHDkyovyBBx5w5ffee29E+aOPPurK+/TpE1H+4osvuvKuXbtGlL/99tuuvHXr1hHls2fPduWNGjWKKP/6669duR5HjhwJl69cuTJcvmPHjnD55s2bw+W//vpruPzAgQPh8u+++y7iM+rVq+fK582bF1HerFkzVz5jxoyI8vbt27vySZMmRZT36NHDlT/11FMR5XfccYcrHzp0aET5kCFDXPmAAQMiyseMGePKe/bsGVE+YcIEV96hQ4eI8nfeeceVX3bZZRHln332mSuvX79+RPmSJUvC6+LgwYPh8jVr1oTLt27dGi7ftm1buPznn38Olx86dChc/s0330R8xgUXXODK58yZE1HesmVLVz5t2rSI8k6dOrnyl156KaK8d+/ervyJJ56IKL/77rtd+YMPPhhRPmLECFfev3//iPJnnnnGld9www0R5a+99porb9euXUT5e++958ovvfTSiPIvvvjCldetWzei/Pvvvw+vi71794bL161bFy7fuHFjuHzXrl3h8hUrVoTLjx49Gi7/6quvIj6jcePGrnzWrFkR5Zdffrkrf+uttyLKu3Xr5sqff/75iPJbb73VlY8aNSqi/P7773fl+uun6VSu9/lpvirX5/ipHipXvfxUb5VrOfy0nN4ya/k9Wi9eudaXR+vRK9f69Wi9e+X6Pvz0falc35+fvl+V6/v20/agcm0fftp+VK7tyU/bm8q1/flp+1S5tlc/bc8q1/btp+1f5dof/LS/qFz7j5/2L5Vrf/PT/uitC+2nHu2/Xrn2a4/2d69cxwGPjg9euY4bfjquqFzHGT8dh1Su45Kfjlsq13HMT8c5leu456fjosp1nPTTcVTlOq766birch2H/XScVrmO2346rqtcx3k//Q6oXL8Lfvrd8NaFfk88+p3xyvX749Hvkleu3yuPfse8cv2++en3T+X6PfTT76XK9fvpp99Xlev31k+/xyrX77Offr9Vrt9zP/3eq1y//346P1C5zhf8dD6hcp1f+On8Q+U6H/HT+Yq3zH4//vhjuHzPnj3h8t9//z1crv97NI1Xrvf6eeWcG3Fu5OHcKP650U033eTiCMUTSaHLIgAAAAAEJIeisqA+PLNTM7GaURctWmS1a9emWZ5meYdmebos0mWRLot0WaTLYlLrlC6LnBsJ50bZ99xoz549VrduXVc//zqJhYAsGQFZclYkAAAAAKQ0jqDLIgAAAAAEhIAMAAAAAAJCQAYAAAAAASEgAwAAAICAEJABAAAAQEAIyAAAAAAgIARkAAAAABAQAjIAAAAACAgBGQAAAAAEhIAMAAAAAAJCQAYAAAAAASEgAwAAAICAEJABAAAAQEAIyAAAAAAgIARkAAAAABAQAjIAAAAACAgBGQAAAAAEhIAMAAAAAAJCQAYAAAAAASEgAwAAAICAEJABAAAAQEAIyAAAAAAgIARkAAAAAJCdA7JXX33VcuTIEe9x//33R0w3YcIEq1q1quXLl89q165ts2bNijevvXv3Wq9evaxYsWJWsGBB69ixo23duvUELg0AAAAAJE+cZSKffPKJFS5cOPy8XLly4f9PmTLFevfubYMHD7ZmzZrZ1KlTrX379rZw4UJr2LBheLouXbrYypUrbfz48S5w0/Rt2rSxpUuXWlxcplpcAAAAANlcpopQ6tWrZyVKlIj52pAhQ6xr1642YsQI97xp06a2fPlyGz58uH388ceubNGiRTZnzhz3aNmypSurVq2a1ahRw2bMmGGdO3c+gUsDAAAAACdBl8WkrFu3ztasWRMvoFKANm/ePDt8+LB7Pnv2bCtSpIi1aNEiPI0Csjp16oSDNgAAAADILDJVQHbOOedYrly5rHLlyjZq1Cg7duyYK1+9erX7W7169Yjp1fJ15MgRW79+fXg6BWAafxY9nTePxOzbt882b94cfjD2DAAAAECW77JYpkwZGzZsmF1wwQUumPrggw/swQcftC1bttizzz5re/bscdOp9cuvaNGi7u/u3bvdX00XPY03nTdNYsaOHevqAQAAAKTW1s6Fgq5CtlRm2j47GWWKgKxVq1bu4dH4r1NOOcWefPJJl5TjRBkwYIDdfPPN4edqIWvQoMEJ+3wAAAAA2Uum6rLop/Fi6rL4ww8/hFvClNLez2s5U4p70XTR03jTedMkplChQla+fPnwQy13AAAAAJDtAjI/b+xY9DgwPc+TJ48bc+ZN98svv1goFIo3XfT4MwAAAAAIWqYNyHTfMSX4qFu3rgu4dEPo6dOnR0yje5E1b97cBWWi+42pNUyZFz3Kzrhs2TJr27btCV8GAAAAADgpxpDpZs81a9Z0z5XU46WXXrI77rjDSpcu7cqGDh1q3bt3typVqrh7kCkYW7x4sS1YsCA8n0aNGrl59ezZ08aMGRO+MXStWrXsmmuuCWz5AAAAACDTBmTqTjhhwgSXav748eOuNeypp56y/v37h6fp1q2bHTx40EaPHu0eSm8/c+ZMF4T5KVBTco4+ffrY0aNHXYKQcePGWVxcplhUAAAAAAjLEYoecIUwBYgVKlSwTZs2uSQfAAAAQFJIex+MMpko7X1K4ohMO4YMAAAAALI6AjIAAAAACAgBGQAAAAAEhEwXAAAAWVDNoXOCrkK29WnQFcBJhRYyAAAAAAgIARkAAAAABISADAAAAAACQkAGAAAAAAEhIAMAAACAgBCQAQAAAEBACMgAAAAAICAEZAAAAAAQEAIyAAAAAAgIARkAAAAABISADAAAAAACQkAGAAAAAAEhIAMAAACAgBCQAQAAAEBACMgAAAAAICAEZAAAAAAQEAIyAAAAAAgIARkAAAAABISADAAAAAACQkAGAAAAAAEhIAMAAACAgBCQAQAAAEBACMgAAAAAICAEZAAAAAAQEAIyAAAAAAgIARkAAAAABISADAAAAAACQkAGAAAAAAEhIAMAAACAgBCQAQAAAEBACMgAAAAAICAEZAAAAAAQEAIyAAAAAAgIARkAAAAAnEwBWa5cuWzJkiUxX/vuu+/c6wAAAACADAjIQqFQgq8dPXqUgAwAAAAA0jMg27Ztm33//ffuIb/88kv4uff4+uuv7eWXX7aKFStaWhw4cMDKly9vOXLksKVLl0a8NmHCBKtatarly5fPateubbNmzYr3/r1791qvXr2sWLFiVrBgQevYsaNt3bo1TXUCAAAAgPQWl9wJX3zxRRs2bJgLkvTo0aNHzJYztY49//zzaarUiBEjXEtbtClTpljv3r1t8ODB1qxZM5s6daq1b9/eFi5caA0bNgxP16VLF1u5cqWNHz/eBW6avk2bNi64i4tL9iIDAAAAQIZKdnSiAOzSSy91QZeCoeeee87OPvvsiGny5MnjWq+KFy+e6gqtXr3azXvMmDHWt2/fiNeGDBliXbt2dQGbNG3a1JYvX27Dhw+3jz/+2JUtWrTI5syZ4x4tW7Z0ZdWqVbMaNWrYjBkzrHPnzqmuGwAAAAAEEpCpG6LXFXH+/Pl23nnnue6A6a1///4uEFMQ5bdu3Tpbs2aNPfrooxHlCtAGDhxohw8ftrx589rs2bOtSJEi1qJFi/A0mledOnVc0EZABgAAACCzSFX/vSZNmqR/TczsnXfesRUrVti7774bHqvmbzmT6tWrR5Sr5evIkSO2fv1695qmUwCmbpXR03nzSMi+ffvcw8O4MwAAAAAZKdUDqiZPnuzGlanV6tChQ/Fe9wc2yXHw4EEbMGCAPfLII1aoUKF4r+/Zs8f9VeuXX9GiRd3f3bt3h6eLnsabzpsmIWPHjnXj5AAAAAAg06a9f+ONN1xyjXPPPdd27tzpugF26NDBjSE77bTT7J577knxPB9++GErVaqU3XTTTRYUBYSbNm0KPxK61xoAAAAABNZCpoQbDz30kN1///320ksvWb9+/dyYsv3797tEGgUKFEjR/DZs2ODmOXPmTJey3kt97/3Vw2sJ0+ulS5eO13KmFPei6RRMRdN03jQJUctcrNY5AAAAAMg0LWS//vqrNW7c2KW418PrnqgkH/fdd58988wzKZqfxn9pHNjll1/uAio9rrzyynAmxcsuuyw8dix6HJieq2WucuXK7rmm0z3Som9eremix58BAAAAwEkXkBUuXNhlNZRy5crZqlWrwq8dO3bMdu3alaL5KQOiMjf6H08++aR7TfcS033NFHAppf706dMj3qt7kTVv3twFZaL7jak1bN68eeFpNM5t2bJl1rZt29QsLgAAAABkni6L559/vrv/V6tWreyqq65yiTCOHz9uuXPnttGjR0fcpDk5lIRD9ziLpV69eq47pAwdOtS6d+9uVapUcS1nCsYWL15sCxYsCE/fqFEjV6+ePXu6bpDejaFr1apl11xzTWoWFwAAAAAyT0A2aNAgN+5LdFNm/f/OO+90QVn9+vVd9sWM0K1bN5eNUUGfHkpvr3FnCsL8FKgpQUefPn3s6NGjblzbuHHjLC4u1UklAQAAACDd5QhFD7ZKJXVh1CMrJcXYvHmzVahQwSUJKV++fNDVAQAASLaaQ+cEXYVs69NVnYKuQrZUZlrKbruVWeKIdGsyyps3r3sAAAAAAJIn2QGZxmSlxMSJE1M0PQAAAABkN8kOyJSl0G/Lli3uptC6t5duBr19+3bbvXu3lShRgu59AAAAAJCeae8VkHmPUaNGWf78+V1qeQVlSnuvv3PnznXlI0eOTO5sAQAAACDbStV9yO69916XXVGp5/2aNWvmUtMPHDgwveoHAAAAAFlWqgKyX3/91XVVjEXlv/32W1rrBQAAAABZXqoCsrPPPtvdB+zAgQMR5fv373fleh0AAAAAYOmf9l43WW7durVL3qFui15Sj/nz59uxY8fsk08+Sc1sAQAAACBbSVUL2YUXXui6Lfbt29f27t1rCxYscH/1XOWNGzdO/5oCAAAAQBaT6htDlypVynVPBAAAAACcwBYyAAAAAMAJbCGrVauWvfXWW3buuedazZo1LUeOHAlOq9d+/PHHdKgeAAAAAGRdyQ7I6tWr52767P0/sYAMAAAAAJCOAdmkSZPC/3/11VeT+zYAAAAAQAIYQwYAAAAAmb2FrGfPnima8cSJE1NTHwAAAADINpIdkC1btizi+ZYtW2znzp1WrFix8I2hd+/ebSVKlHA3jAYAAAAApFOXRQVk3mPUqFEuwce8efNcULZq1Sr3d+7cua585MiRyZ0tAAAAAGRbqbox9L333mvDhw+3pk2bRpQ3a9bMhg4dagMHDrQ2bdpYVrZv3z7bu3evHTt2LOiqADHlzJnT8uTJ41qt4+JSfQ94AAAAZLakHr/++qvrqhiLyn/77TfL6sGYumweOnQo6KoACTp69Kjt2bPH1q1bZ3///XfQ1QEAAEAMqbpsfvbZZ9vo0aOtSZMmVqBAgXD5/v37Xblez8rUMqYWh8qVK1uuXLmCrg6QIF002LhxowvMvPsIAgAA4CQPyMaNG2etW7d2yTvUbdFL6jF//nzXhe+TTz6xrEzLmDt3boIxZHr58uVz3RbVWgYAAIAs0mXxwgsvdN0W+/bt61qLFixY4P7qucobN26c/jUFAAAAgCwm1SP9S5Uq5bonAgAAAABOYAsZAAAAACCggOyff/6xBx54wKpWrWqnnnqqG0sV/QAyOyW6OOuss1zWzOSoVKlSssdHqutuvXr1rGDBgjZixAhL70QdOXLksN9//909/89//mMvvfRSun4GAAAAMnFAdtttt9nYsWPdWLFhw4a5/0c/EKxLL73UJXRQFkzvoQBBJ/NFixa1jz76KN57nn32WatRo4b7f48ePVwyCL2vSJEidtFFF9nixYvda1988YWVLl063evs/0zvoQyBiS2T3+eff27nn3++FSpUyE4//XR75JFHEv28xx9/3K699lo3fXp77LHHrGHDhi7z6EMPPWQZ6f7773f3Bfz3338z9HMAAACQScaQffjhh/bEE0+4K/PIvJ566imXaCVa165d7dVXX7XLL788olxlN910U/j5gAED3DjBI0eO2KBBg6x9+/bu/msZyfvMlC7T4cOH7eqrr3bv1etr1661Sy65xN2CQeXRFLy88sor9vXXX1tGWL9+vXXs2NFOBGU7rV69ur3//vsn7DMBAAAQYAuZuiSquyIibdiwwT3UpdNv06ZNrvzAgQMR5QpuVB7dZW7btm2u/K+//sqQeiroUlCtLnuelStX2g8//GDXX399vOnVatWzZ0/bunWr7dq1yzKjnTt3utYotbLlzJnTbZ8XX3yxrVixIub0au1Ta9uZZ54ZLtN7b7nlFmvbtq3ratigQQP76aefYr5/6dKlLtuoWg/VWtivXz8XFIoCQd0C4s4773SteN9++637jnv16uWmVQClwNObXl0P1QVx8uTJdsYZZ7gWzLvuuiv8WcePH3cBccmSJV3L35tvvhmvPrr9hL5TAAAAZIOA7NZbb3Unj4jUrl0799AJuN91113nytXVz08tOSr/4IMPIsoHDhzoymOdeKcHBRpVqlSxt99+O6J1TPeWK1OmTLzp1c1xwoQJLhgoUaJEkvO/4oorXKAS61GrVq1E36uxUMWKFbPatWvbxIkT472u7n/Fixd3y+APQMqVK2edO3d2rV6659aqVatc61eLFi1ifs7y5ctdq1I0bdcKlnbv3m1XXXWVa12LdQ8vXZRQK7ECQQV3X375pbs/n+g2EAoG1ZqnILx+/fp2++23uwB89erVLpj73//+57oZ+s2dO9cFgN99951NmjTJdcEUrfvp06e7z1HgHCvwUldTBdQAAADIBgGZEnksXLjQtRD897//jTd+7Mknn0z/miLFFFj4g6Ebb7wxopXstddeC9/oWsGfv7uiKKDQ+ypWrOhamtQlLjlmzZrlWvdiPRQIJURBy5o1a9xNxvXZ9957r7377rvh1x999FH77bffXEudxk2p6+WSJUvCr3fv3t1GjhzpWr7OOecc6927txvHFYtaB2ONHWvTpo1ddtll7sbfapXS/fW++eabeNPVrVvXbf9xcXFu/fTp08cFZbFo/Sr4Vf29FjWNvXz99dcjplNZ/vz5rXLlyq6V7fvvv3fleu8dd9zhytVyp+miqdzf4gkAAIAsPIbsvvvuc3+VcCHWyaq6X/m7XGUXXsBy2mmnRZS/8cYbrtuZWnb8xo8f71pf1EUtOtmEurMVLlw4TfVRcBxrvJWoa6ICjp9//tmNd9I4sSuvvDJiGnW5O5H3mjvvvPMiuuApeYxahjp06ODKLrjggvDr11xzjVvfM2bMcK1lWo4uXbq46RVUqZuoxlPpfnlq0Y2mdR4ru6JaAf2tYGp5izVuToGjAl61dh08eNB9j2rVi0WtaFq/ytLo0f8VWIZCoXCZP1GKLnp4XVz/+OOPiHopAIym7prR2xEAAACyaAuZgovEHmoRyI50oqzHKaecElFeoUIFVx6dFVAn+yqPbqnRibnK1ZqSURSoKHBRK5keal3SWLH0oPn6MyH6H2q5Si6NBfMHLIm9rq586oap7pIKpBTwKECLlU1S1HVS3Qej+bM6ajtWMKbvKZqCPI0/U2CmwG7UqFEJ1lXdPLVuvTT1ov+re6guXiSlbNmyEfXy/9+jgLROnTpJzgsAAACZCzeGzsa8botqaYrurpgWs2fPdq07sR4KnBIybdo019KjoP6rr75yafiV2VHU3VHzVcIUBUoad6fpNc7L60KoIEf3CVNgpEBKryfUaqVWNc1r3bp1EeV6v8ZuKQujuhiqK6C/Zc6jeiqQ1usKytTamRAFiOpeqRZJLceff/7puh3GSqASiwLLZ555xrVk6nOHDh0abxqNT4zOmgkAAIAsHpAp2YOSJ2isS/QDwfOy/HmP6HuHqTVJXe2U3CIztK4oAFNrorpqKtvhww8/7AIZUYA0ZMgQ1x1UST+8MVi6F56odUzBpcad6f26H5nuu/bggw/G/Cy1WN18883xxnEpAYuSdaj738yZM91D48miaRoFfArIlD2xU6dOiS6bAiq1SlarVs0FjwoINf4yOVRPBaZ6j9L4RwdeCj7VQhYrvT8AAAAytxyhxPqEJUDjYdRlS2OjYmWgk6zQbXHz5s0uQNB4JKUq93hdz/xjgnDyUSZFtX7pAoICK6W9V9B6IsfNpYf+/fvbueee64LYWNheASB7qjl0TtBVyLY+XZX4hVpkjDLT4ucHyGxxRLol9VDrxKeffupSpWvs0XPPPeeywylAUxY8L/03kJmppe3XX3+1kx37GwAAQDbrsqhMdhrHovs+ibpS3XDDDS5Iu+iii7hBLQAAAAAkQ1xqm+CqVq3qkhXonk/++x9pDE63bt3shRdeSM2sgcCoxRcAAADI9C1kStetbHFyxhlnuAxvHmWcAwAAAABkUAvZpZdeagsXLnQ3Eu7du7fdc889LsubMte99957du2116ZmtgCAVGDgfnBWDG0VdBUAANmxhWzkyJFuzJiXWv3xxx+3bdu22S+//GK33367S/GdEh9//LE1adLESpYsaXnz5rXKlSvbgAEDbO/evRHTaWya7iulbpLqMjlp0qSYGSAHDhzosuUp0UiLFi1cvQAAAAAgS7SQKdjx39Pqrrvuco+0ph9XMFe8eHH76aefXNIQ/VWiENGNgnUvJt2T6amnnnI379X9n5SuvGPHjuF5aR5TpkyxsWPHWrly5Vzw2Lx5c3dDYt2fCgAAAABO6oBM+fR37Nhh5513XrzXdE8n3bw3qXz7fkoEEt0lUi1lffr0sT/++MPKli1rI0aMcEHb+PHj3TRNmzZ1KfZ1c10vIFOykVdeecWef/5569mzpyurX7++nX766fbiiy+6mwYDAAAAwEkdkOmm0GeddVbMgOytt95y93Z6//3301QxtZR5XRAPHz5s8+fPt8ceeyximq5du9rbb7/tbnyrm96qNe348ePWqVOniHtNtWzZ0nWLzOiALKPHcZxMYxW+/PJLe/jhh+2zzz5L03z03SpxzD///OO6qqa3d955x2bMmOG2WwAAAOCkGEO2ePFia9asWczX1HK1aNGiVFXm2LFjdujQIdfKNnz4cLvqqqtcoKWWsH///deqV68eMX2NGjXc39WrV4f/qnWuaNGi8abzpknMvn37XCub99i6daudrNTKqACmQIEC4Ue9evXc+tX6+eijj+K959lnnw2vUyVpadOmjQuM1dWzZs2aEWnhc+TIkeg6HTRokD3wwAOW2XXo0MGWLVtmK1asCLoqAAAAyIZSFZAdOHDAcufOHXuGOXPa/v37U1WZihUr2imnnOICB6XW91otvPucFSlSJGJ6L/DSGDRvuuhpvOm8aRKjcWcVKlQIP3TD65OZxtrpu/Ie3333nQvS1LIY655bKrvpppvc/6+44gp3k+8tW7bYzp073WulSpVK1uf+8MMPLqBVUJiZHT161AWW3bt3d11aAQAAgJMiIFMrysyZM2O+pq6K1apVS1Vl1K3w66+/tpdfftm10CitvlrNThRldtT4OO+xZMkSy4oUdCljpf+G3kp6okDq+uuvdwHYunXr3Bg+BXAKvhUkq8UsOWbNmuWCMQU7oq6ml19+ecQ0Kmvbtq37/+zZs13310KFCrlA+KGHHkq0FbNv375ujKISy/znP/9xrX6ioLFhw4YR02sa7z55ShRzzTXXuPGFCtyVHdRr1VWdAQAAgJMiIFOqewVN/fr1s6VLl7rEG/p72223ufLUZlysVauWNWrUyGVSVGCncWMK/LyWsOg0+F5AoXFioumip/Gm86ZJjAICneh7D7XSZUVq+atSpYobf+dRMNO6dWu3zOqmqNsKKDjTGCu1kqXE8uXLI7qX6r50c+fOdYlgPG+++WY4mYtuT6DP183GFZRrG9LnJhRMKgBbtWqV6zKp8YpK+JJcCkQ1plAtptqOvQsMGzZsiAhQAQAAgEwbkOkeZI8++qi9/vrrLvOhWjX097XXXrPRo0fbjTfemOaKKThTy8zatWtd8KD/R49Z8p57J//6++eff8Y7sdZ00ePPsgO1+KklyHv4vxcFNvq+RK2QCpC87opq2VIwrJbOwYMHu+9XLWTffvttsj5X61/BrUfBbePGjW3atGnuuW5noBa4q6++2j2/5JJL3Pet7q4aq9atWzeXFCTa9u3b7YMPPrBx48a5+WuZHnzwwYjAMilaDnXZ1Gepe6zo1glevQEAAIBMH5CJbr6sljG1aEyePNn91XOVpwclDlEiD90kWinw1a0sutVk6tSprnVDiT9ELR860X733XfD0+gkW9kXve5x2YnGxKnVyXt4AZio9UvJU9Q1dM6cOS6bpbqIenSrgaefftrdVFs3/T7nnHNcABUKhZL8XLVUqmuhn1rDFPSJ/uqecqeeemr4u9b3qxuDK4HICy+84LpNxsq4qOBRAaIXZGqsmwK1lIxTjOaNeYxOBgMAAABkyrT3HrVStGqV9lTsGtdz/vnnu1YStVr8+OOPbnyPnnutKBpXpHFJ6ibZuXNn14KjpB8KyvwtMeruqKAwV65c7sbQjzzyiDvJv+WWW9Jcz6xECTo0JkxB2vr1611iizx58sScVpkrdcsABd7q6ufdkiAh+t6iWzN1rziN91KLp743dUv0d2nUrRQU1Ov7V5fXWBkudT+5uLg4F4DFqqsySR48eDD8XAF9dDIXb1ybn4JSBWoEZAAAADhpWsjSe0zT9OnT3Yl5u3btbOLEida7d29buHBh+MRbGf90v6ivvvrKBYE6qddNoP33HBO16vTq1cvuv/9+F8ypq6PGLykoQySv26LG63ndFb1WRQXAa9ascfd107g8pcTXveeSCsZECTzU5dDfmqbgXa1ZCqgVKDVv3jyihUrBkIIxjUVM6J5gStChed9xxx2ujpq/kq988skn7vXatWu7QFDJWNTip5uGq/5JUdKP7NiCCgAAgJO8hSy9KHjSIym6L5keiVH3xieeeMI9TrTMduNmJa245557IlqQ1P3QowBJmRQ1vq5OnTrhcgXBCnQU+CoRh7oWKtmKEmIkR926dV2XRwVl/tT36raogFstYGrB9Dz//PN29913u/o2adLEBdmxuiyKAkiNG1N9FZSpVVRZF5WQRAGjbkatoE0taQoqS5QokWhdFdSpC2VKxqEBAAAA6SVHKDmDgrIp3UtL45UUnOjE3z+WSbyxa4jd6qTuohq/l5lpvKHGJmblgIztNeurOXRO0FXItjLbhTjAj2NDcD5dFdmDCydGmWmROQwyYxyRaVvIkPWoZSyz3xhaOnTo4B4AAADASTGGTPeA0lidzN7yAQAAAABZLiDLly+fu1Gw0ssDAAAAAFIvZ2rT1Hs3+QUAAAAApE6qxpA1btzYHnjgAZelT+nCdU+r6Ps7KWgDAAAAAKRzQObds0o379XNfKMpODt27FhqZg0AAAAA2UaqArL169enf00AAAAAIJtJVUBWsWLF9K8JAAAAAGQzaU6VePDgQdu9e3e8B05u7dq1s5YtW6bLvBo2bGivvvqqpaeFCxdalSpV7ETQDZU/+eSTE/JZAAAAyF5S1UIWCoXs4YcfthdffNGNI4slO44h29q5UJa4+/icOXOsZMmSljdvXvvggw/sqquuighOxo8fb61bt7YgXXzxxfbbb78FWgcAAAAgkBayJ5980saOHWu33XabC84GDx5s//3vf61q1aruhP3ll19Oc8UQnJ07d9oTTzxho0ePtr179wZdHQAAACDLSlVANmHCBBs2bJjde++97vnVV19tQ4YMsZUrV1qNGjVs7dq16V1PpNAff/xhXbt2dbckKFq0qPuOPLNnz7batWtb4cKF7YILLrBFixaFX7v00ktt//79VqRIEStYsKBrKVOQLd26dbONGzda+/btrUCBAi4Qj2XKlClWuXJl97n33HNPxGtDhw519fIcOnTIZeX8/fffY85r8uTJduaZZ7q6VKhQwV0MkC+++MJKly4dnm758uVWv359N51ux9C3b1/r0aOHe03z1mdoXmeccYar11133RWRpKZ58+ZWvHhxK1GihFvOPXv2pHidAwAAACckINMJbp06dSxXrlyWO3du++uvv/5vZjlzWr9+/dJ9vBBSRt1Fr7zySitWrJj9+uuvtn379nAAoucdOnSwRx55xHbt2uVaOdu0aeNaxZLy9ttv2+mnn24zZ860AwcO2MiRI+NNs3r1auvZs6e99NJL7nMV2C1dujRVy/H333+7eU2aNMkFiT/++KMLGKP9+++/bsxbx44d3fjFAQMG2BtvvBFvurlz59pPP/1k3333nZvn559/7srVynvfffe5IFb1Vzfchx56KFV1BgAAADI8IFNLgk7IRSfo33//ffg1ndgr0QeC8+2337pWn6eeesoKFSrkguYmTZq416ZOnWqtWrWyyy+/3OLi4uyGG26w6tWr2/vvv58unz1t2jQX4F122WXucwcNGuRapFJL81i1apXt27fPBZh169aNN41a+LTNDRw40E3frFmzmGPc1KqbP39+13p3ySWXhLdbPVcCE42ZUwuZgtcvv/wy1XUGAAAAMjQga9y4sTvpl2uvvdZ1Q1PXNJ18q3VC3b8QHHUrVKCcJ0+eeK9t2bIl3AXRo+cqTw9qZdJne9SKWq5cuVTNS8GTkoqoRU7dFRVU+rtX+j+zbNmyroXWo+mj+bs4nnrqqeGLCn/++afrRql6KoDt3r17sloMAQAAgEACMgVgynInDzzwgPXq1ct1Z1PWRQVjL7zwQporhtRTQKSgTF35oinoiB6vpede0KSxYf4Wzm3btkVMq7FYiVFgpM/2d5/0B3tJzT+aWtqUcn7Hjh2uVa9z584xP1NB2fHjx8NlmzZtsuTSNqz3ahyaWuLefPNN140RAAAAyJQBWbVq1Vy3MFE3r6efftqddGv8jrrEnXbaaeldT6SAklvo5t1qrdTYKwVmXhc8BTRKa6/EHkePHnVjrTRuSmOwRF0C33nnHdd6pKBm3LhxEfNWkpDE0s136tTJzVvjs/S5jz76aESCDM1f9xBbt26dGyOmboQJUcvVe++95+qirohK2KEWt2iNGjWyfPny2ZgxY9wyKeFHSu4bpnWk1jglOVFgpwyTAAAAQKa9D5nf5s2bXRIEtVKktmtaVnGi7hOWFAUtH374od15551ufJRaqZo2beq6/OnWBBrnpSQW6qan5x999JEbOyUaP6UkHGXKlHGBt7rvPfPMM+F5q1vq7bff7jIs9u/f30aMGBHx2cqy+corr7hWUyV7UVKO888/P/y6WlA1bq1evXou4YfuZ5dQEhi1WmkcnLIlqsVKY93eeuuteNMpWNMYuJtvvtkFeFrOLl26uDFyyaEMoaqT6qOMjtdff709/vjjyV7fAAAAQGrlCKWyb5ay6Olk2t8dTUHZgw8+aLfccotlBQo2NRZJLUXly5cPl3td/qLHYiHzUIufWgq1PWZ3bK9ZX82hc4KuQra1YmiroKsAJIhjQ3A+XdUp6CpkS2UySeNIYnFEunVZHDVqlLvPk1pd1KVMiRb0V8+V9l6vAyfSggUL3MUBtQYqEYi6LOp+aQAAAECW67KocUVKMa7xQX6695XGGOl1dW0DThTdjFzdFJWUQ0lNJk6caOecc07Q1QIAAADSv4VMJ73KfheL7uekJAnAiaSxahrLqEQhP//8sxv7BgAAAGTJgEw3Fp47d27M1z777DPuQwYAAAAAGdVlUdnslLhj+/btdvXVV7s09/q/buCrdOe6H9n3338fnv68886zrERZDA8dOuTGK8VKww5kFtpOjxw54m6EDQAAgCwSkOkGvfLaa6+5h24W7E/WeMUVV7i/KtNrClyyEt2vSvfG0r20lHIdyIx024DDhw+7iwZFixYNujoAAABIr4Bs/vz5lp0VKlTI/d27d2+WCzaRdeg+bGoZ0z3mkntPNgAAAJxYqTpL0413szsFZV5gBgAAAAAnLKkHAAAAACDtCMgAAAAAICAEZAAAAAAQEAIyAAAAAMhKAZk/BT4AAAAA4AQEZLoB7UsvvWTVqlVLz9kCAAAAQJaUorT3v//+u02dOtU2btxolStXth49eljx4sXt0KFDNm7cOHvyySdt27ZtdtFFF2VcjQEAAAAguwVk33zzjbVo0cL+/vvvcNnzzz9v7777rnXu3NnWrl1rjRs3tsmTJ1vz5s0zqr4AAAAAkP26LA4ZMsRKly5t//vf/+zgwYO2atUqq1ixol188cW2Y8cOF5gtXLiQYAwAAAAA0ruF7Mcff3RdEhs1auSeV69e3caPH+/+atxY+/btkzsrAAAAAEBKWsi2b9/uxo35ec9r166d/jUDAAAAgCwuRVkWc+aMnDxHjhzub1xcinKDAAAAAABSGpBde+21VqtWrfCjbt26rrxLly4R5SltMZs+fbq1a9fOypcvb/nz57c6derYxIkT493PbMKECVa1alXLly+f+4xZs2bFm9fevXutV69eVqxYMStYsKB17NjRtm7dmqL6AAAAAMCJkOymrRtvvDFmeb169dJcibFjx1qlSpVszJgxVrJkSfvss8+sd+/etmnTJpdMRKZMmeLKBg8ebM2aNXPp9zVuTYlEGjZsGJ6XgsOVK1e68W0K3DR9mzZtbOnSpbTkAQAAAMhUcoSim6ECsHPnTitRokREWZ8+fVzQtWfPHtdVUjebVvD31ltvhae58MILrUiRIvbxxx+754sWLXJlc+bMsZYtW7qyX375xWrUqOECOqXnT4nNmzdbhQoVXGCo1jsAyIxqDp0TdBWyrRVDWwVdBSBBHBuC8+mqTkFXIVsqM22fZRYpiSNS1GUxo0QHY6LukPv27XP3PVu3bp2tWbMmXkDVtWtXmzdvnh0+fNg9nz17tgvQdL80jwI5dYH0gjYAAAAAyCyS3Ydv+PDhCb6WO3duO+2009w9yTTGKz189dVXVq5cOTcOTN0SRSn2/dTydeTIEVu/fr17bfXq1S4A85KN+KfTa0lRAKiHh7FnAAAAADJFQKZ7kCXk2LFjduDAARcIXXfddS4hR65cudIUjKmLocaUibotilq//IoWLer+7t69Ozxd9DTedN40SY1lGzZsWKrrDQAAAAAZEpB5QVFCFJDNnDnT+vbta2eddZY9+OCDltr+lkrM0bRpU7v99tvtRBowYIDdfPPNES1kDRo0OKF1AAAAAJB9pFvawQIFCtj1119vGzdutNdffz1VAdlff/3lMiIWL17c3n333fB9z7yWMKW0L126dLwgUSnuvek0cC6apvOmSUyhQoXcAwAAAABOhHRP6qEU9Bs2bEjx+/755x+74oorXNCl5ByFCxcOv+aNHYseB6bnefLkscqVK4enU1bF6MSRmi56/BkAAAAAZLmATGO1Tj311BS95+jRoy6D4s8//2yffPKJS+bhp4BLyUJ0A2k/pcVv3ry5C8pErWtqDVPmRY+yMy5btszatm2bpuUCAAAAgPSWrndKPn78uD333HPuXmAp0a9fP5s1a5ZL4qEsh998801E+vu8efPa0KFDrXv37lalShU3vkzB2OLFi23BggXhaRs1amStWrWynj17unl5N4auVauWXXPNNem5qAAAAABw4gIyZSBMLMvitm3b7KOPPnJjuLw09cn16aefur933313vNeU0r5SpUrWrVs3O3jwoI0ePdo9lN5eSUQUhPkpUFNyDt1YWi1vukH0uHHjLC4uXWNPAAAAAEizZEcp99xzT4KvKcV9yZIlrUmTJq5bYc2aNVNUid9//z1Z0/Xq1cs9EqOxZxMmTHAPAAAAAMgSAZm6IwIAAAAAMnFSDwAAAABAOgdkjz32mBsn5vf111+7cV3RY740fgsAAAAAkE4B2aBBg9xNn/2JPC6++OJ49wbbvn0747cAAAAAID0DsuibLSdUBgAAAABIHsaQAQAAAEBACMgAAAAA4GQIyHLkyJGsMgAAAABAOt6HTJo2bWo5c0bGcErs4S/jfmUAAAAAkM4B2ZAhQ5I7KQAAAAAgGQjIAAAAACAgJPUAAAAAgIAQkAEAAABAQAjIAAAAACAgBGQAAAAAEBACMgAAAAAICAEZAAAAAASEgAwAAAAAAkJABgAAAAABISADAAAAgIAQkAEAAABAQAjIAAAAACAgBGQAAAAAEBACMgAAAAAICAEZAAAAAASEgAwAAAAAAkJABgAAAAABISADAAAAgIAQkAEAAABAQAjIAAAAACAgBGQAAAAAEBACMgAAAAAICAEZAAAAAASEgAwAAAAAAkJABgAAAAABISADAAAAgIAQkAEAAABAQAjIAAAAACAgBGQAAAAAEBACMgAAAAAICAEZAAAAAGT3gGzt2rXWt29fq1OnjsXFxdm5554bc7oJEyZY1apVLV++fFa7dm2bNWtWvGn27t1rvXr1smLFilnBggWtY8eOtnXr1hOwFAAAAABwEgZkK1eutI8++sjOPPNMO/vss2NOM2XKFOvdu7d16dLFZs+ebY0aNbL27dvbN998EzGdXv/0009t/Pjx9uabb9ovv/xibdq0saNHj56gpQEAAACApMVZJnHllVdau3bt3P979OhhS5cujTfNkCFDrGvXrjZixAj3vGnTprZ8+XIbPny4ffzxx65s0aJFNmfOHPdo2bKlK6tWrZrVqFHDZsyYYZ07dz6hywUAAAAAmb6FLGfOxKuybt06W7NmTbyASgHavHnz7PDhw+65Ws6KFCliLVq0CE+jgExdIb2gDQAAAAAyg0zTQpaU1atXu7/Vq1ePKFfL15EjR2z9+vXuNU2nACxHjhzxpvPmkZB9+/a5h4dxZwAAAAAy0kkTkO3Zs8f9VeuXX9GiRd3f3bt3h6eLnsabzpsmIWPHjrVhw4alY60BAAAA4CTospgZDBgwwDZt2hR+LFmyJOgqAQAAAMjCTpoWMq8lTCntS5cuHa/lTCnuvekUTEXTdN40CSlUqJB7AAAAAMCJcNK0kHljx6LHgel5njx5rHLlyuHplOY+FArFmy56/BkAAAAABOmkCcgUcOmG0NOnT48onzp1qjVv3twFZaL7jak1TJkXPcrOuGzZMmvbtu0JrzcAAAAAZPouiwcPHgynpd+wYYPLdvjOO++4502aNLGSJUva0KFDrXv37lalShV3DzIFY4sXL7YFCxaE56ObRbdq1cp69uxpY8aMsXz58tngwYOtVq1ads011wS2fACArGdrZ7q5B6HMtP+fERkATnaZJiDbvn27derUKaLMez5//ny79NJLrVu3bi5wGz16tHsovf3MmTNdEOanQE0JOvr06WNHjx51N4geN26cxcVlmsUFAAAAgMwTkFWqVCneuK9YevXq5R6JKVy4sE2YMME9AAAAACCzOmnGkAEAAABAVkNABgAAAAABISADAAAAgIAQkAEAAABAQAjIAAAAACAgBGQAAAAAEBACMgAAAAAICAEZAAAAAASEgAwAAAAAAkJABgAAAAABISADAAAAgIAQkAEAAABAQAjIAAAAACAgBGQAAAAAEBACMgAAAAAICAEZAAAAAASEgAwAAAAAAkJABgAAAAABISADAAAAgIAQkAEAAABAQAjIAAAAACAgBGQAAAAAEBACMgAAAAAICAEZAAAAAASEgAwAAAAAAkJABgAAAAABISADAAAAgIAQkAEAAABAQAjIAAAAACAgBGQAAAAAEBACMgAAAAAICAEZAAAAAASEgAwAAAAAAkJABgAAAAABISADAAAAgIAQkAEAAABAQAjIAAAAACAgcUF9MHAy2dq5UNBVyLbKTNsXdBUAAAAyDC1kAAAAABAQAjIAAAAACEiWDMhWr15tLVq0sPz581vp0qXt3nvvtSNHjgRdLQAAAADI2mPI9uzZY82aNbOzzjrLZsyYYVu2bLEBAwbYwYMH7dlnnw26egAAAACQdQOy8ePH2759+2zmzJlWrFgxV3b06FHr16+fPfDAA1a2bNmgqwgAAAAAWbPL4uzZs+2yyy4LB2PSuXNnO378uH366aeB1g0AAAAAsnQLmcaP9ezZM6KsSJEiVqZMGfdaYtSypodn06ZN7u8PP/xgW7duzaAa42SwY9fRoKuQbW3+9tugq5DpHdzyS9BVyLaWcWwIBMeF5OHYEByODcHYnImODX/++We4p162HEOmACxa0aJFbffu3Ym+d+zYsTZs2LB45VdeeWW61hFACjRoEHQNgARdHnQFsiuOC8jkODYEpEHmOzbs2LHDKlWqlL0CsrRQ8o+bb745/PzQoUOuleyMM86wuDhWVXal1tEGDRrYkiVLXEsrAAjHBgCxcGyA1zKmYKxmzZqWlCwXZaglbO/evTFbzvzjymIpVKiQe/ideeaZ6V5HnJx0UC1fvnzQ1QCQyXBsABALxwZUSqJlLMsm9ahevXq8sWIK0HS1Qq8BAAAAQGaR5QKyNm3a2Ny5c+2vv/4Kl02fPt1y5sxpLVu2DLRuAAAAAJClA7K+fftawYIF7eqrr3Zp7idNmmQDBw505dyDDKmhbqxDhgyJ150VQPbGsQFALBwbkFI5QqFQyLKYn3/+2fr3729ff/21C85uuOEGGzlypOXJkyfoqgEAAABA1g7IAAAAAOBkkOW6LAIAAADAyYKADAAAAAACQkAGAAAAAAEhIAMAAACAgBCQIVt59dVX7a233opXfumll9oVV1xhmd3QoUOtQIECQVcDAIAT5r333rPnn38+xe/7/fffLUeOHPbOO+9YZqJ75er3fNWqVSdFfZHx4k7AZwCZKiBTQHPttddGlOtAnytXLsvsbr75Zrv88suDrgYAACc0IFu6dKn169fPsgIFZMOGDbNzzz3Xzj777HB5mTJlbNGiRVa1atVA64cTj4AMMIs4IGZm5cuXd4/E/PPPP3bKKaecsDoBAIC0y5s3rzVs2DDoaiAAdFlEhnv55ZetUqVKduqpp1rz5s3dVS41yau1SvT/J554IuI9Tz31lCuPvqKkq2O6gqSDVr169ezTTz+NmOZ///ufXXLJJVa4cGF3U/CaNWvaa6+9Fu6W+OWXX9pHH33k5q2Hugwk1GVxwYIFduGFF7rgpkSJEtazZ0/bvXt3vK4Fb7zxhv3nP/+xokWLurrdc889dvTo0XjdDFesWGEXXXSRWw+6KjZnzpyIz3v99dfd68WKFXPzUp2WLFmSaJfFL774wtVBy9SxY0crVKiQderUKdnrC8hqdHW5WbNmlj9/fnccUGv49u3b3WtXX321Va5c2fbv3x+efsqUKW4f+uSTT9zzrVu3un1d02nfP+uss+yBBx6ww4cPR3yO3vPoo4/a4MGD7bTTTrMiRYrYvffea7q157x586xOnTpuX9Uxb9OmTRHv1bw0z4oVK7p9s0aNGvG6Uvfo0cMdJ7SP161b1y1PgwYN7LvvvsvAtQdkPtoX9Du+cuXK8G+3ypLa3xOj849atWpZvnz5rFy5cm4/PnbsWMTr+hydr7Rs2dL9blerVs3mzp1rx48ftwcffNBKlSrlHoMGDXJlntWrV1vXrl2tQoUK7n264DtmzJjwNDp3OOOMM9z/9XvtLZPKY3VZ/Pfff+3OO+905wZaxl69ernzDu89/nMB1ddPxzydS/j9/PPP1q5dOzcvrTf1uvntt99S+e0gvRCQIUPNmjXL+vTpY02bNrWZM2e6kxMvYEiJI0eOWIsWLdz8Ro4caR988IE7yOlAokBH9u3b554rKHn77bddFwd9tgITr1uiTmwaN27sDuJ6qAtgLDrp0ecpqJs+fbo78frwww+tTZs2EQdt0YE8Z86cNm3aNOvbt6878L7yyisR0+iA2r17d/cjovWgE7gOHTrYrl27wtPowHrDDTe4z9PJ2emnn+6CyzVr1iS5frScVapUcfNWQJic9QVkNdqndfKhE42pU6faSy+9ZN9++607+RA9P3DggDu5kT/++MNdtNB+27p1a1e2c+dOd+IzduxYF6QpyNLJoKaJ9uyzz9rGjRtt8uTJNmDAAHv88cfd/nfXXXe5kzSVa//VCZRf586d7cUXX7S7777b7aP67Ouuu85mz54dMd22bdvs9ttvt4EDB7rjy6FDh6x9+/bueAJkFw899JC1bdvWXSTxfrtVltT+nhDt2/rtb9Wqlftdv+++++yZZ55xv+XR9Jusi7X6bS1btqxdc801dscdd7iLLLqIetttt9no0aPdhR3Pli1bXPCmc46PP/7Y/T4PHz7cRowY4V7XRdIZM2a4/z/yyCPhZVJ5LDqWaF7ecUDnIPfff3+q1uW6devchWZdXPbG1O/YscOdm0VfdMIJFgIy0AUXXBC6+OKLI8oeeuihkDa9SZMmuef6/+OPPx4xzZNPPunKPRMnTgzFxcWFVq5cGW/+nTp1cv//9ttv3XuWL1+eYH2aNGkSuvzyy5Msb9++fej0008PHTlyJFw2Z84cN/8PPvjAPV+/fr177n2+f17NmzcPPx8yZIib7qOPPgqXee+dPHlyzHoeO3Ys9O+//4aqVasWGjRoUMS88ufPH34+f/58N5++fftGvD856wvIai655JLQhRdeGDp+/Hi4TPtAjhw5wvvfjBkz3D7z3nvvhVq3bh0688wzQwcOHEhwntoP33zzTbc//f333+FyzaNBgwYR09arV8991qpVq8Jl48aNc9Pu2bPHPf/888/dcx1P/Lp06RKqX79++PmNN97o5vXTTz/F298XLlyYyjUEnJy0P5xzzjkp3t+939rp06e75/v27QsVKFAg4ndVXnjhhdApp5wS2rlzp3uu8xO97/nnnw9Ps2LFClfWsGHDePv91VdfHbPeqpuOISNHjgyVKVMmXB5dr4TKd+3a5eql86boZdd0mt5/bNB5kF+7du3cOYnnhhtuCFWuXDn0zz//hMu2b9/u1slzzz0XcxlwYtBChgyjqzhqadIVXT91rUspdbVT90MNdFV3QO+hViBdERO1EKl17NZbb3VXkXTVJ7UWLlzorrLlzp07XKZuC+qW9NVXX0VMq3I/tURt3rw5okwtaJdddln4ubpwqjuUfzp1I9C6UhcIJRjRZ//yyy/JaiGLTvSRnPUFZCUHDx50XZbVAq9jj7fNax9Q1yFvu9c+pqveXbp0sc8++8xd5Va3HY9iLXWZ1n6sfVT7oVq3NS9dXfbT/uSnz9JVdHVB9JeJt69r31QLnLpZRe+by5Yti2iB17zOOeeceGNdo48vQHaT3P092tdff+1ayfU+//6n32eNv/7pp58S3Me9fVmtSX4q93dLVkv2kCFD7Mwzz3RdknUMUeubukPrs1NCPVpUr+jzKPWwSQ0df6666iqLi4sLL7uGSKj3EOcGwSIgQ4ZRQKSdXd3z/BRwpJS6EelkRQc2/+Phhx8OHwh1UNEJlroZXn/99Va6dGnXnSE1XfT27NkTs54q848jEwVpfnny5HEHZD+d2Kk8oek0pkWB3YYNG1x3CgWEOjjWrl073rxiia5rctYXkJVon9WJmboLRm/36lbo3+41zkTdc8477zxr1KhRxHwUjKkroS7IvP/++24c53PPPedei94XY+37scr879W+qWNIdB3VhUrHS520JTb/WPUAspuU7O9+2v9E+77/PRorKtHv8++D3v6X1G++ukCq+3Lv3r1dl0X9lmvMWWr2Xe94kB7nUd7y6xgXvc50zsG5QbDIsogMU7JkSXcVJnqA7Z9//hnxXFeQNOYp+mDrpyvKGoA7YcKERD9Tg941DkNXlObPn+/Gc2hQa0oHrOrzYg0MVt31WnpT/3Fd9dZ4EgVhnr179yaZVVGiE6Akd30BWYVOkrQfKFmG9vloSswjf//9txv3of1MA+AnTZpkN910U3g6jeHUFeRRo0aFy6LvFZQW2jd1bNSJWizRJ14AUr+/R/N+vzWGSy1p0bxkG2mhY8gtt9ziAjOPEm+lhjeuTOcjSj6S0HmUkpNIrHMp//mBll89amLdPkAXsxEcAjJkGHW701UoDYbVVSxP9A0PFXCou56fWrr81J1AJzDqwqNHUtQipUHACsQ0AFdXpXTAitV6FYuyHSopiBJ0KKj06qQEIXotvSmAFH8rmrpWKNGHv8tScqV0fQEnO3U7VGuXjiVqCU6IWr90kqIrwo899phL8KEuSEqi4+2L0a3Zb775ZrrVU/umPlefoYsmAJIW/dud3P09mt6jzIe6ABrdDTC9RB9D1JLnT/qRktZuDT3Q+YzOo9St0PPuu+9GTOdduNX6UNIOrzXs+++/dxmW/ccfdcvUvE6Ge69mJwRkyFDqN62uP7oCrTSwGlOmzGPRY8rUhF6/fn2XmUjpXJWlyE9jPpSVTF0Q1eqlPtsKjtQtT1eEdDVbV6DUIqSDrE6ulKFs3LhxLquid/VIYzuUMU2ZlXTlKaGARfXWQU3Zlfr37++uRimrkVrgFOilN913RCmydeVen6PlVx90/xWxlEjO+gKyGnUT0tgsjQ/T8UbdmHXipYspOgbp5Ef7hU6OtP9rP1AmRWU/Vap6XUnWmJGnn37aZVDUfqPj0dq1a9Otjpr/lVde6TIrKoOjgjK12imltz4nOkMrgP/77Z44caLLoKzuhWoBS2p/j0737rWsKeOh9j1Nq2kUmGh8qLooK9BRwJbWfVy3+9GYT9VTGRKjMxhqSIXqouVRq5x6CsW6QKMWLWV4VSZHBWa6yK33RPf6UUB2wQUXuJtNK+ukLiQrO7T+76fXda6lDJPK/qiujzpX0i2BLr74YuvWrVualh1pcIKShyAbGz9+fKhChQqhfPnyuWw/ixcvjsiyqAxnN910U6hYsWKhEiVKhAYPHhwaM2ZMRJZF2bt3b+iuu+5y2Q9z587tMha1bds2NGvWLPf66tWrQx06dHCflTdv3lDZsmVDPXr0CG3dujU8j82bN7v3FClSxM1fWQsTyr74xRdfhBo1auTmpbppXsp4lFSWpDvuuCNUsWLFBDMjegoXLhz+fJk9e7bLIqX1VKtWrdDHH38cr14JZVmMzqyUnPUFZEXaF7Sda/9SdrKzzjrLZSHdsGGDOyZ07do13vTKoKjMrrJ//363rxctWtQ9evfuHfrwww/j7WexssPGygQXax89fPhwaNiwYa5uefLkCZUsWTLUtGnT0Ouvv57ovJSp0X/sBLIL/Z5p3y1evLjbB7R/JLa/b9q0KdHf6bfffttlNdV7ChUqFKpbt67LZKiMiP4sizt27Ih4X3L2+23btrmsiwULFgyVKlUqdN9994VefvnlePObOXNmqEaNGu4cw8uYGKu+Ol7079/fnbeorvo8ZWj2Z1mUtWvXuuOIzhGqVKniljE6y6KsWbMm1LlzZ7cu9dmVKlVy2Rf9GV1x4uXQP2kJ6ICUUkuNrmRp7IZ3c0cAAAAkTUMq1Bto/fr1LmszTn5kWQQAAACAgBCQAQAAAEBA6LIIAAAAAAGhhQwAAAAAAkJABgAAAAABISADAAAAgIAQkAEAAABAQAjIAAAAACAgBGQAAAAAEBACMgAAAAAICAEZAAAAAASEgAwAAAAALBj/D7+JVv9b/d10AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 880x396 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def evsi_signal(sens, spec, p_bad=P_MAUVAIS, profit_g=PROFIT_G, profit_b=PROFIT_B):\n",
+    "    \"\"\"EVSI d'un signal binaire (sens, spec) — vectorisable (tableaux numpy OK).\"\"\"\n",
+    "    p_pos = p_bad * sens + (1 - p_bad) * (1 - spec)\n",
+    "    p_pos = np.clip(p_pos, 1e-12, 1.0)\n",
+    "    p_bad_pos = p_bad * sens / p_pos\n",
+    "    p_bad_neg = p_bad * (1 - sens) / (1 - p_pos)\n",
+    "    e_pos = np.maximum(p_bad_pos * profit_b + (1 - p_bad_pos) * profit_g, 0.0)\n",
+    "    e_neg = np.maximum(p_bad_neg * profit_b + (1 - p_bad_neg) * profit_g, 0.0)\n",
+    "    return p_pos * e_pos + (1 - p_pos) * e_neg - (p_bad * profit_b + (1 - p_bad) * profit_g)\n",
+    "\n",
+    "lignes = []\n",
+    "for nom, s in SIGNAUX.items():\n",
+    "    v = evsi_signal(s[\"sens\"], s[\"spec\"])\n",
+    "    lignes.append(dict(signal=nom, EVSI=v, cout=s[\"cout\"], EVSI_nette=v - s[\"cout\"],\n",
+    "                       part_EVPI=100 * v / evpi))\n",
+    "tbl_evsi = pd.DataFrame(lignes).round(1)\n",
+    "print(tbl_evsi.to_string(index=False))\n",
+    "print(f\"\\nEVPI (plafond) = {evpi:.0f} EUR par candidat\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 3.6))\n",
+    "x = np.arange(len(tbl_evsi))\n",
+    "ax.bar(x - 0.18, tbl_evsi[\"EVSI\"], width=0.36, label=\"EVSI (valeur)\", color=\"#2C7FB8\")\n",
+    "ax.bar(x + 0.18, tbl_evsi[\"cout\"], width=0.36, label=\"coût du signal\", color=\"#E6550D\")\n",
+    "ax.axhline(evpi, color=\"#2F2F2F\", ls=\":\", lw=1.5, label=f\"EVPI = {evpi:.0f} (plafond)\")\n",
+    "ax.axhline(0, color=\"black\", lw=0.8)\n",
+    "ax.set_xticks(x, tbl_evsi[\"signal\"])\n",
+    "ax.set_ylabel(\"EUR par candidat\")\n",
+    "ax.set_title(\"Valeur d'information vs coût, par signal de souscription\")\n",
+    "ax.legend(fontsize=8)\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1befc3cf",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002978,
+     "end_time": "2026-08-25T08:53:30.142921",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:30.139943",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "La décision d'achat, chiffrée : le **questionnaire** rapporte une EVSI quasi nulle (le signal ne\n",
+    "change aucune décision, section 3) mais coûte 15 € — **net négatif, on ne l'achète pas**. L'**\n",
+    "examen médical** capte 310 € de valeur (56 % du plafond EVPI) pour 90 € — **net +221 €, on\n",
+    "l'achète**. La **télématique** est le meilleur signal en qualité (86 % du plafond) mais son coût\n",
+    "de 500 € l'emporte sur ses 478 € d'EVSI — **net marginal négatif, on ne l'achète pas** en\n",
+    "souscription une-shot. Notez la forme du problème : le classement des signaux par *qualité\n",
+    "bayésienne* (télématique > examen > questionnaire) n'est PAS le classement par *valeur nette*\n",
+    "(examen > télématique > questionnaire). La meilleure information n'est pas la plus exacte —\n",
+    "c'est celle dont la précision marginale paie encore son coût."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9218b116",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002916,
+     "end_time": "2026-08-25T08:53:30.148735",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:30.145819",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : évaluer un nouveau signal\n",
+    "\n",
+    "Un fournisseur propose un **score de risque basé sur les données ouvertes** (âge du permis,\n",
+    "puissance du véhicule, zone géographique) : sensibilité 0.55, spécificité 0.80, coût 60 € par\n",
+    "candidat. Complétez le calcul de son EVSI nette avec `evsi_signal`, et déterminez : (1) le signal\n",
+    "change-t-il des décisions aux deux issues (vérifiez les posteriors contre le seuil) ? (2) Quelle\n",
+    "sensibilité minimale, à spécificité 0.80 et coût 60 € fixés, rendrait-il l'achat net positif ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "609ea2cd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:30.156051Z",
+     "iopub.status.busy": "2026-08-25T08:53:30.155293Z",
+     "iopub.status.idle": "2026-08-25T08:53:30.159999Z",
+     "shell.execute_reply": "2026-08-25T08:53:30.159306Z"
+    },
+    "papermill": {
+     "duration": 0.009302,
+     "end_time": "2026-08-25T08:53:30.160838",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:30.151536",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer\n",
+      "  EVSI nette du score open-data : None EUR\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : a completer\n",
+    "evsi_score = None   # TODO etudiant : evsi_signal(0.55, 0.80) puis moins le cout 60 EUR\n",
+    "print(\"Exercice 2 a completer\")\n",
+    "print(f\"  EVSI nette du score open-data : {evsi_score} EUR\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4b7110a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002762,
+     "end_time": "2026-08-25T08:53:30.166466",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:30.163704",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "## 5. Validation Monte Carlo\n",
+    "\n",
+    "L'EVSI est une espérance calculée sur deux issues — vérifions-la en simulant des candidats\n",
+    "réels : 20 000 candidats, types et signaux tirés selon le modèle, règles appliquées, profits\n",
+    "réalisés. C'est aussi l'occasion de voir ce que les distributions font derrière les moyennes —\n",
+    "car un assureur ne vit pas d'espérances, il vit de trajectoires :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "faaa84fb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:30.173223Z",
+     "iopub.status.busy": "2026-08-25T08:53:30.173021Z",
+     "iopub.status.idle": "2026-08-25T08:53:30.289429Z",
+     "shell.execute_reply": "2026-08-25T08:53:30.288699Z"
+    },
+    "papermill": {
+     "duration": 0.121829,
+     "end_time": "2026-08-25T08:53:30.291162",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:30.169333",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "               moyenne  ecart_type  part_refuse  perte_P5\n",
+      "sans info        249.6      1370.5          0.0   -1860.0\n",
+      "questionnaire    235.0      1376.9          0.0   -1860.0\n",
+      "examen           553.5       912.8         27.5   -1860.0\n",
+      "telematique      723.6       674.0         29.3       0.0\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA2QAAAGBCAYAAAAJ/nLQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAQ6wAAEOsBUJTofAAAV6ZJREFUeJzt3QncTHX///GPnezKTnZS0UpIdkqSJdnalMhdadEt0l22WymlpKRQ6G5xEy1CIkJl6b7bs/xEQlcoa9nC/B/v7+935j8z1zbXmOua65p5PXtM5jrznTNnzvmeM+dzvt/v5+Ty+Xw+AwAAAABkudxZ/5EAAAAAACEgAwAAAIAYISADAAAAgBghIAMAAACAGCEgAwAAAIAYISADAAAAgBghIAMAAACAGCEgAwAAAIAYISADAAAAgBghIAMAAACAGCEgA2A//fST5cqVy0aMGJGln9unTx/3uelNi+d1kBGxWjeZ6fDhw3bPPffY2WefbXny5LGqVau66S1atPA/zyyavz4HkVu+fLmrk9OnT8+R84+l7LI/Z8W+lpVUV7ReVXeAnIKADIgj3smL99AJbvHixa1OnTrWvXt3e+ONN+z48eNR/0wFMfv377fs7quvvnLLquAL2cMTTzxhEydOtB49ergTqWeffTbVsu+88062DpgR/8cQAMgMeTNlrgBiqlu3btapUyf3/I8//rCtW7fawoUL7YYbbrB//vOf9vbbb1vdunX95atUqWJHjhyxvHnzRnQyNXLkSHe1t0SJEhl675QpU2zy5MmWlQGZljWlK8Knsw4QuY8++sjq1atn48aNC5q+ePFi8/l8yQKyGTNmEJRlI82aNXP7Tb58+SKeR1rHkGjMHwCyO848gDh0wQUX2I033pisJUItELfffrtdeeWV9t1331mxYsXca2pNK1iwYJYsm06y//zzTytSpIg7ycouJ1pZuQ7ikXfSnNGA9tdff3XdFUPlz58/ikuHaDt48KA7fuTOnTtT95vMnj+ylnponDp1im0KhKDLIpBAdAX6gQcesO3bt9sLL7yQ7vip119/3Ro3bmylSpWyQoUKuRPnrl272g8//OBeV0uTrmxLtWrV/F0lvfl4ffmXLFlijz/+uNWuXdsKFChgTz31VLpjKH7//Xe77bbbrHTp0u6ztRxLly4Ne9xX6DgCfdatt97qnrds2dK/rJqe1rx08vDcc8+5IFfLoZPQVq1auZad1MYkbdq0ybVQqruoAs+rr77aNm/ebOHatWuX3XLLLXbmmWda4cKF7fLLL7dly5ZlaBxURsbEBW4ntaBqW2o7qauruhOG8loYt23bZj179rSzzjrLzjjjDNuxY4d7fefOnS7wr1ixogusKlWqZP3797ekpCT/PLRc+ky13n7yySfJ6k5oK6aeq3VMArvlhjO26D//+Y+1adPGrcuSJUvaddddl2a3Va3r9u3bu7JaD2pN1gWNkydPWjhWr15tHTt2tAoVKrj3ly9f3tU5tfAFUhe9QYMG+dd32bJlrVevXvY///M/YY+j8tZj4PfRdtD61nx14qvtc8kll9hjjz2W7P3vvfeeWzf6ripbvXp1t+1+++03fxlvP9FyaLtoH9D+kNqyBU578cUX3frTvLUNtbwnTpzwl03vGJLadz969Kh73znnnOPmrWOU1vkXX3yR7Dt6y7927Vq372qfVEuc6u7u3bstHPv27bPBgwdbrVq13HFA60stu/fdd1/U68+GDRvcsqk+6P3aJn//+99dEJzSfqvPU1df7/iq9Th+/Hg7HVpXOv7qGKD9Ro8GDRrYq6++GvY8vOO7juWqj9oPtO60f3jB2ZNPPmn169f3H1tVF1esWJFsXir7j3/8w/0GaXufe+659vLLL2dovFhGPg/IarSQAQnmjjvucD9K8+fPt4ceeijVcgrG1MqmYGD48OHuJEYn2h9//LFt3LjR/SA+/PDD7kRo3rx59swzz7gTP9EPXiCdyCh5g4IMBViVK1dOdznViqcfzEceecT27t1rL730kl111VX2/vvvu38j+d46WdGP+LBhw/xdNmvUqJHuScVrr73m1oNOaNUFdOrUqW75Zs6cmawlUutI3ayuvfZadxKmk2sFNQrQvv32W3fFPy066briiitcAKf11bBhQ/v+++/tmmuuSXdZT9fQoUPtwIED1q9fP7eu3nzzTZdwQwGiArVAWg9aTp2k6cT40KFD/jqiaTrR1Ym9Tty//vpr1z110aJFtm7dOneiqcC+Zs2adv/997t6o7qUUt3x6IRTJ5krV65028PTpEmTNL/Tf//7X7c9NJ5y4MCBru6pO6QCAbXUhnrllVfccl900UVufejE/dNPP3X7ypdffmlvvfVWmp+nYLx169ZWpkwZu/POO11QpuBGQeHnn39unTt3duW0vlSndHFDQVjTpk3txx9/tEmTJrn1pM/UPpZRCnbatm3rLrr87W9/cwGLtpVO8rXvqu57Hn30URs9erSrV1o3Cpx//vlnt48pqPP2Z1GgM2fOHHeS3rt3b7f86Xn++efdfAYMGOCOE++++66rK/qe3jYM9xgSSIGNLnIoENG/d999t2tpVfCn9aju2QqAA6kOKki6+eab3XhFbQ/txwqKtb7TozG4+jwFFhdeeKE7udf30EWMaNYfdatWfdV2VP1RMLZq1Sp7+umn3QUpzUsXPwJpm+q4oQtO2gd1XNKFN9U9BXaR0PZQLwp1f1d3bh0X/v3vf7vtv2fPHnvwwQfDnpeCHl1c0vrQBa5y5cq576dtp4sxqv+qI/qN+Ne//uWCZl280DHPo+72qn+q2wpOFSDrdymc3xLJ6OcBWc4HIG4sW7ZMg258o0ePTrNc0aJFfWeeeab/761bt7r3DR8+3D+tS5curtzx48fTnJfeo/dqHqFeffVV91qNGjV8hw4dSvb6Lbfc4l5PaVrHjh19J0+e9E//+eeffUWKFPFVr17dPz2l5Q79bK2TtKaltQ6WLl3qprVv39534sQJ//Tdu3f7ypQp4ytRokTQ96pSpYor/8YbbwTN+/HHH3fTP/zwQ196HnnkEVf2mWeeCZr+5ptvuumh60uf2bx587C+T2q89VKpUiXfvn37/NOPHj3qa9iwoS937ty+zZs3+6fr81R+yJAhyeZ10003uddef/31oOkzZsxw0/v27RvW8muaXkuvvqTniiuucMv/xRdfBE2/44473LwCPzspKclXsGBBX+fOnX2nTp0KKv/UU0+58suXL0/z8yZMmODKrV69OqztPGbMmKDpmr+mt27dOtl+re2U3v739ddfu7/Hjh2b5uevXbvWlWvUqJHvjz/+SPZ64L7n1buFCxcmK5fSsnnTzjjjDN9PP/0UNE+t29B9MK1jSErznzZtmpvWr1+/oLIbN270FShQwFerVq1ky58rVy7fp59+mmId0PvSsn//flduwIABaZbLaP1JqT6rvmpZV61aFTR95MiRyY7t3n5bv359t696tD11fG/cuLEvHCnta6nVCS1f8eLF0/1dCPx+PXv2TLY+nn32Wffa3Llzg6ZrvhdddJGvWrVq/mmLFy92Zbt37x40H/0mFC5cOKzjfEY+D4gFuiwCCUgtT7rimRZd2dUVRF0t11XN06Er2LpymxG6ohzYmqQroTfddJNt2bLFXWnOCkp+ImqlUwuLR618d911l7u6HtqNUleldQU2kK7qeq0n4Xym1r2ujgfSlW51l8pM+szApApqJdOVdm3/0O52MmTIkKC/vXLq5qRWlEDadmqJmTt3brJkHZlFV/LVoqYWVXXZC6RtGkpX4NUVTi0c6malli3v4V09//DDD9P8TG/9aT1oXF1a21n7obosBmrevLlr3VFrlloBMkrdZEWtOWo1SqsFXNSVWN3RQoW25KqlM6Mt02o9VutK4Dy9Vnlv34qE916vq6NHXfZU79QqrdboQOryHNqaGu5+qe5t6ia3Zs0ad/xJzenWH6++arnUehpIrULaTimtNx1fta96VE7fN5zjTWoC64Tqsb6PeiqoDui3Q70kwqXjRGjXdLWQqgurWtkD15Pmrd4F6srsLb9a60StcoHz0W+CWs7CkZHPA2KBLotAAlL3Fu/ELTXqSqSuMhpvo7EQOkFQ1w6d8KjLWUboRCmjUuqu5U1Td77QE+zM4J18aaxIKG+aui0FUhejUOquIzqpSY/mp3mnlNRC3z90fFE0pbfOAykoVb0IPaFUV7bzzz8/2Xx0InXeeee5MUsKNNRNLbN52yal76XxbaH7wPr1692/aXVdUvfNtChwVlfPsWPHui546nKqLmiaHrheVLe0PlJKbqDtr4BKJ4mh6zg9CoDUlUtdEXVxQPNSNz51lfQCEPFOPi+++OKY7cOR0rrTPqUxSWntl944t9PdL7UvahypunXqooLWhU7s1QVOXZG9izWnW3/SOt6om6I+O/R4k9Z3C+d4kxoFK+rSqgsLgWM/PQrOwpVS3dG60gU/HUfSWld6r7de1P02VGC24LRk5POAWCAgAxKMftx00pze2Bv9+GvskgZLqxVIV251lVYtCwsWLHAnmeEKHfMQLWndVDUwcUBWCmxJC5UZLUOprYPM/v6ZtU1jyWsJ1tiiwJadQApy0jt51xgmjV1Ta4guaigw0/hDpfZXi2Nm13MlxNB4Ii2H9lu1qmhsmoIHtTZEcjPinL69T3e/1LhKtaRonSoJhMaOTZs2zQXcGpekwDoa9Sfa3y0SWh8aI6tWRgWhGhOqCwP6HB37VZ8z0msipbqj96slXeMMU5PShZ1IZfXnARlFQAYkGCXHEGUkS4/SmOuqundl/ZtvvrFLL73UXTn1slpFcnIXDiU7ULeb0GmiZBDitbKkdLU2pa5FGV1WL4mGAtPLLrss6DUNeA8sEy2an1oPlDQgtJXM+/6BtA7C/f7p0fy9+9elts7ToqvPRYsWdesrpZM8TdeJXUZbfU53+6W03pR8JLTbrnd1XMunRASnQy1PXuuTWgR1AUTJF3SCq+3qbedjx44FdTfz6pa+q7LlRVLPRQGBEhfooaBNyWnUTVHBgxKa6LsquFD3X3WTzAwprfeU6lMk21VJStSiEdpan1n7peiztB71UH3W9lRLqBJ1aNrp1h+vpSul/UfdBrWtw9kPT5cCMV1Q0MW3UaNGBb2WUnbZSGhdKfGM6mJ6t8rw1ou2eWjPCK9VMpqfB8QCY8iABKIUwcrWpdTBGgOVFnU/S6l7iMYWBHaF8caGZaQLSzg0tiXwKqx+TDUOQCepymAmOvlXtyWNtwm8yq3lU7azUBldVmUCFLVuBC6LuvPotgEaL6SMetGkz9TYNLVoBNJJX0rdFXXVVycqCjA8WlZt54zSZ+qzPQoWNB+N/QkN1FKicuoap+XReJpACgbU3UrfL9IgPqPbTwGiuuspi55OMAOFZo30MumppUMtTMpMmNJJcXrZBQPTxXt0gq6TSgXZ3vu1HhQQht5WQC1aqs/qHuwFrqrzujgSmtFP9cEbX+PRPP/666+gaToB9brvefuuN/ZGQUVKY92i0ZqrDHa6NUJgvdR+Hbhvnc5+qW6ZgRTgvvHGG26sZVpZGjNKXd30CKQ67AXc3jo93fqj+qqukGpZVdr5QNoPNU91Ic9sXotbaB345ZdfXOtfNCjbpS5UjBkzJt2unV5mUmUHDlwm/SZ4YyGj+XlALHCZAIhDSvGskyFRam+NRdHVcLVwKahSFyYFM2lRlxWVUddEBXA6IVFQoBN23Q/G06hRI//AbZ3k6YREXT9Ot/uHfvx1lblLly7uRG3y5MnuhEZdTgITDigtuxIFaHlVVoGkUqzrJDb0R1Zdb/Re/Sjrx1nBpcqFtn55dFKsZBQKBJVoQfP30t4rrbvSS2c0WUl61C1UY5CU7EHbS8usVgUFmBpbEpqsQN9f5bWsag3RCYvSU0cS9KgFQJ+n1NZqxdF8lR5c6arDvTKv4FWBgxKbaByUltlLe69B+KmdEIVDdU3bX8lHOnTo4IIUbTuvJSkl6l6lOqwr47oI4aW9V8tQYFp3b1yZWpC9+y/ptgMKpFT/FGQqIYnG1KR037fAQE8BoMYRabkUDKlVSl29NM0bt6RbQWg/1L9aP2pB89Lea2ybxix5VMe0TFo2pWzXtlZ6eu0TCjwCT961ztW9TnVV30EXDVR/VFbfz2u50XZWMKbtpXlobKjWjdLUKz297jel9O6nQ8cabR+l31crn9adgk2NpwtMS5/RY4hOrnV800URrQft+17ae9V/radottxrvJ3qkAIDjftT4KTWKq1THSO9ADEa9UfbXZ+lbaz15qW9V6CpoDo0CUxm0FgtrXsFQDre6TvrN0TfTS2P0bj4du+997qu8Ape1QW0Xbt2ro4oyPrss8/c+vVaf/Wa6rOOazpuq3eH95ugZVP9T297Z+TzgJiISW5HAJnCSxHtPZQ+WanrlQb6+uuvd6nIA9Mjp5UifcqUKb4rr7zSV758eV/+/Pl9pUuX9jVr1sw3a9asZO9/4oknXNrgvHnzBs0nrTTz6aW9/+2333x9+vTxnXXWWS6V9WWXXZZi2nilox82bJivQoUKbjnPO+8897mpffb06dN9devW9eXLl8+9rs9LbR14qZ6VMrlevXpuOZR6v2XLlikuSzRS0Msvv/ziu/HGG30lS5b0FSpUyNekSRPfxx9/nGrad21X7ztVrFjR99BDD/k2bNiQ4bT3H330kW/UqFG+qlWrunmp3ui7h5MmO9D27dtdenvVHdUJbRulKNf3CpWRtPfaFg888ID7jkpln1oq+JRSvGubKQ27UnZ37drVbZPUPlsp67t16+YrW7asWw/6VynElXL8999/T/OzVN969Ojh1qG2XbFixVxacu0jhw8fDiq7d+9e33333eeWQ5+juq4U4SmlYVcacqVdVxmlVr/00kt977//frKU8Vu2bHHlzj33XPfZWoaaNWv6Bg4c6LZLqDlz5rj9WscJzVe3ldC20v7nCdxPMpL2XtNeeOEFX506ddy+WblyZZfuP6WU6akdQ1JL+X/kyBFXpnbt2m7eugXFNddc47Z1qNSWP63bCQTSurj//vtdenTtkzoOaJvp+LR+/fqI609q+/MPP/zgUrxrW+v9+qxBgwa59PuB0jq+ZuQWESnta9u2bXN1Ubf3UL244IIL3O0G0jumZ2QZdOyeNGmSO7bruKrP0X6j/TP0d0a/Wzqu6dYc2t463r388su+5557zn3GmjVr0l0vGfk8IKvl0v9iEwoCALJLV1YlgVDrSlpX74FwaHypWsDUyqaxVUBmUau3WpXVQprR7L9AdsIYMgAAAGRboWP4RN1V1W1cXTkJxpDTMYYMAAAA2ZaSwXz66acuiVKZMmVcQhuNS9WNuHU7CSCnIyADAABAtqVsqQrIJkyY4BJ7KJmKbouixDR6DcjpGEMGAAAAADHCGDIAAAAAiBECMgAAAACIEQIyAAAAAIgRknrEgLICffvtt1a6dGnLm5dNAAAAAMSTEydO2J49e6xevXpWsGDBNMsSDcSAgrGGDRvGejEAAAAAZKK1a9dagwYN0ixDQBYDahnzNlD58uVjvTgAAAAAoigpKck1wHjn/WkhIIsBr5uigrFKlSrFenEAAAAAZIJwhieR1AMAAAAAYoSADAAAAABihIAMAAAAAGKEgAwAAAAAYoSADAAAAABihIAMAAAAAGKEgAwAAAAAYoSADAAAAABihIAMAAAAAGKEgAwAAAAAYiRvrD4Y8WXSpEnWdNPoqM7z6JGjdvLUScsp8uTOYwULFYz6fFfVfsTuvPPOqM8X0UHdp+4nKup+5tR96n32R92n7kcbLWSIijfeeMP+/PPPWC9G3NE61bpF9kXdzxzU/eyPuh991PucgboffX8meN2nhQxRM3h9fVu1alWsFyOuNG3aNNaLgDBQ96OPup8zUPeji3qfc1D3o6tpgtd9WsgAAAAAIEYIyAAAAAAgRgjIAAAAACBGCMgAAAAAIEYIyAAAAAAgRgjIAAAAACBGcnRAtnnzZhswYIBdeOGFljdvXjv//PNTLDdt2jSrXbu2FSxY0C644AKbP39+sjIHDhywvn37WqlSpaxo0aLWrVs3S0pKSlbus88+s8aNG1uhQoWsSpUq9sQTT5jP58uU7wcAAAAgvuXogOz777+3Dz74wGrWrGnnnntuimXeeust69evn/Xo0cMWLlzogqkuXbrY6tWrg8rp9cWLF9vkyZPt9ddft40bN1r79u3txIkTQQHglVdeaeXLl3dB3X333WePPvqoPf3005n+XQEAAADEnxx9Y+iOHTtap06d3PM+ffrYF198kazM8OHDrWfPnjZ69Gj3d8uWLe2bb76xUaNG2YIFC9y0zz//3D788EP3aNeunZtWp04dq1u3rs2dO9e6d+/upo0bN87OPPNMF+Tlz5/fWrdubXv27LExY8bYwIEDrUCBAln47QEAAADkdDm6hSx37rQXf8uWLbZp0yZ/QOVRgLZ06VI7duyY+1stZyVKlLC2bdv6yyggU1dIL2jzynXu3NkFY4Hz2r9/vwvqAAAAACBhArL0bNiwwf17zjnnBE1Xy9fx48dt69at/nIKwHLlypWsnDePP//807Zv355sXvpb7/PKAQAAAEBCdFlMz759+9y/av0KVLJkSffv3r17/eVCy3jlvDJqBUtpXmotO+OMM/zlUnLw4EH38KSULAQAAABA4onrgCy7GD9+vI0cOTLWiwEAAAAgm4nrLoteS5hS2qfUcqYU91650DJeOa+M1zIWWk5dHw8fPuwvl5JBgwa57o7eY+3ataf93QAAAADkfHHdQuaN9/LGiHn0t7oaVq9e3V9uyZIl7n5igePIVK5evXrueeHCha1y5crJxoopPb7eFzq2LFCxYsXcAwAAAAASpoVMAZduCD179uyg6bNmzXIp671sibrfmFrDlHnRo+yMX375pV199dX+aSr37rvv2l9//RU0L7WeNWnSJEu+EwAAAID4kaNbyNRV0EtLv23bNpc4Y86cOe7v5s2bW+nSpW3EiBF2ww03WI0aNdw9yBRArVmzxlasWOGfj24WrRs+33bbbe4mzwULFrSHH37Y6tevb127dvWXGzx4sLtpdK9evezOO++0b7/91t2bTPchC0yFDwAAAABxH5Dt3r3brr/++qBp3t/Lli2zFi1auOBJgdvYsWPdQ10X582b54KwQArUNNarf//+duLECXeD6IkTJ1revP9/FdWsWdMWL17syqnlTAGfknU88MADWfSNAQAAAMSTHB2QVa1a1Y3fSk/fvn3dIy3Fixe3adOmuUda1DVx9erVGV5WAAAAAEioMWQAAAAAkJ0RkAEAAABAjBCQAQAAAECMEJABAAAAQIwQkAEAAABAjBCQAQAAAECMEJABAAAAQIwQkAEAAABAjBCQAQAAAECMEJABAAAAQIwQkAEAAABAjBCQAQAAAECMEJABAAAAQIwQkAEAAABxaHXSavdA9pY31gsAAAAAILp2HNphAz4a4J5/0PUDq1ikYqwXCamghQwAAACIM1O/nWqnfKfcY8o3U2K9OEgDARkAAAAQZ61j72x+x3z/95+e7/xjZ6wXC6kgIAMAAADisHXMQytZ9kZABgAAAMRh65iHVrLsjYAMAAAAiNPWMQ+tZNkXARkAAAAQp61jHlrJsi8CMgAAACCOW8c8tJJlTwRkAAAAQBy3jnloJcueCMgAAACAHG7Wxll20ncy3XIqM2vDrCxZJoQnb5jlAAAAAGRT11S/xr7e83VYZTtU75Dpy4PwEZABAAAAOVydUnVsZvuZsV4MRIAuiwAAAAAQIwRkAAAAABAjBGQAAAAAkNPGkP3++++2du1aS0pKsiNHjtiZZ55pderUsQsvvNBy5coV3aUEAACI0Oqk1e7fRuUbxXpRAOD0ArIDBw7YjBkz3OOrr74yny/4PgcKxIoUKWJdunSxfv362eWXX56R2QMAAET93kwDPhrgnn/Q9QOrWKRirBcJACLrsvjYY49ZtWrVbMKECda2bVubN2+ebd261Q4dOmTHjx+33bt325o1a+yJJ56wffv2WevWra1Nmzb2ww8/hPsRAAAAUTX126l2ynfKPaZ8MyXWiwMAkbeQLV++3ObOnWstWrRI8fWzzjrLPS699FIbMGCAC8qef/55975zzz033I8BAACIWuvYO5vfMZ/9b48ePe9Xvx+tZAByZkC2ePHiDM24ZMmS9sgjj0SyTAAAAFFrHfN4rWQjmoyI6XIBQKZnWVyxYoVlF9OnT3dj20IfQ4cODSo3bdo0q127thUsWNAuuOACmz9/fopj6Pr27WulSpWyokWLWrdu3VxSEwAAkL1bx0TPNW3nHztjumwAkGkB2bvvvmtNmjSxli1bWnazaNEi+/zzz/2Pu+66y//aW2+95ZKQ9OjRwxYuXGiNGzd2iUlWr/7frEweva6WwsmTJ9vrr79uGzdutPbt29uJEydi8I0AAEC4rWMexpIByLEB2alTp+zJJ5+0unXrWuHChe3888+3OXPmuNcUpNSrV8+6du1qu3btspdfftmym0suucQaNWrkf1SuXNn/2vDhw61nz542evRoF0wq4GrQoIGNGjXKX0ZB3Icffuha0rp3727XXnut+/7ffPONG1sHAACyb+uYh1YyADk2IFOCDnXzU3e/jh07ui57CmIefvhh10qkJB4KxNRqpG59OcWWLVts06ZNLsgKpO+2dOlSO3bsmPtbLWclSpRwGSY93n3XFixYkOXLDQAAMtY65qGVDECODMimTp1qvXv3tu+//9518VOL0dixY+3xxx+3pk2b+gOxvHkjvtd0pjrvvPMsT548Vr16dbfMJ0+edNM3bNjg/j3nnHOCyqslUOn8ldrfK6cALPSm1yrnzQMAAGTf1jEPrWQAcmRAppakW265JSggue2229y/Dz30kOvGmB2VL1/eRo4caTNnznStXFdffbX94x//sHvvvde9rpY9UetXaJZI2bt3r79caBmvnFcmNQcPHrQdO3b4HyQCAQAgc8zaOMtO+v73omtaVGbWhllZskwAkJawm7MOHz5sxYsXD5rm/V2mTBnLrq688kr38LRr184KFSpkzzzzjOtumRXGjx/vgkIAAJC5rql+jX295+uwynao3iHTlwcA0pOh/oXqlhjYJTG021+giy++2LIrjRd76qmn7KuvvvK3hCmlfbly5fxlvJYzpbgXldu+fXuyeamcVyY1gwYNsttvv93/t1rIGjZsGLXvAwAA/ledUnVsZvuZsV4MAMicgKxPnz4pTr/xxhv9XRl9Pp977gVr2Z03dswbI+bR3/nz53djzrxyS5Ys8X+/wHLKMJmWYsWKuQcAAAAARBSQLVu2zOKFkpIowcdFF13kWsV0Q+jZs2dbp06d/GVmzZplrVu3dkGZKJOk0uIr82KbNm3cNGVn/PLLL23IkCEx+y4AAAAAEiAga968ueVEGj/WqlUrfyvWe++959LzK6mH10VxxIgRdsMNN1iNGjXcfcgUjK1Zs8ZWrFjhn49uFq15KZHJ008/bQULFnRj0OrXr+/uvwYAAAAAGZU9c9RHkboa6mbOym6om1urNezZZ5+1gQMH+sv06tXLJS1RGn891HVx3rx5LggLpEBN48H69+9vJ06ccAlCJk6cmG1T/QMAAADI3sKOJKpVq5bsHlyefPnyuUyLakVToFO2bFnLLiZMmOAe6dE91NK7obWySiq40wMAAAAAsiwg0/iq1AIyJfD45Zdf7MUXX3Q3kP70009d9z8AAAAAQBQCMnXzS49ugHzFFVe4Gy+/+eab4c4aAAAAABJS7mjOTKndBw8e7DIRAgAAAACyMCCTihUrupssAwAAAACyOCD77rvvrEKFCtGeLQAAAADEnagGZKtWrXI3T+a+XAAAAAAQxaQeurFyWlkWf/31V9u/f781bdrURo0aFe5sAQAAACBhhR2QXXLJJakGZLoxcunSpd19yHSz5NTKAQAAAAAiCMimT58eblEAAAAAQCySegAAAAAAohyQnXvuufbtt9/6//b5fNa/f3/bvn17ULm1a9da/vz5w50tAAAAACSssAOyDRs22JEjR/x/nzp1yqZNm2Z79uwJKqdATUk+gOxqddJq9wAAAAByzBiylCj4AnKSHYd22ICPBrjnH3T9wCoWqRjrRQIAAEACYwwZEsrUb6faKd8p95jyzZRYLw6QpWgdBgAg+yEgQ0K1jr2z+R3z/d9/er7zj52xXiwgS1uH9aDeAwCQQ7ssLl++3Hbs2OEfQ6b7jS1btsx++uknf5lNmzZFfymBKLaOebxWshFNRsR0uYCsrv/UewAAcmhANnTo0GTTBg8enGwaN4ZGdm4d83itZP3q92MsGRKq/lPvAQDIgQHZ1q1bM3dJgCxsHfPQSoZEQOswAABxEJBVqVIlc5cEyMLWMQ+tZIh3tA4DABAnST1OnDgR0QdE+j4gs1vHPGRcRCK3DgMAgBwSkFWrVs2effZZ+/3338Mqv2rVKuvWrZuNHTv2dJYPyLTWMQ8ZF5HIrcPUewAAckhANnnyZJsxY4aVL1/e2rZtayNGjLC5c+faypUrbe3atbZ48WJ76aWXrH///q57Y7t27dy/Awb87014gViYtXGWnfSdTLecyszaMCtLlgnIKrQOAwAQR2PIOnTo4B5Kcz9z5kybNm2a7dy5059V0efzWf78+e2SSy6x++67z2666SY766yzMnPZgXRdU/0a+3rP12GV7VC9Q6YvD5AdW4cZSwYAQA5Jey8tW7Z0D/n1118tKSnJjh49aqVKlbKqVatagQIFMmM5gYjUKVXHZrafGevFALJ96/CgSwdlyXIBAIDTDMgClStXzj0AANkLrcMAACRAQAYAyJ5oHQYAIM6SegAAAAAAoouADAAAAABihIAMAAAAAHJSQLZixQr7448/UnxN0/U6AAAAACATAjKlvf/hhx9SfG3jxo3+tPgAAAAAgCgHZLoJdGr+/PNPK1SoUCSzBQAAAICEEnba+9WrV9tnn33m//uNN96wVatWBZXRDaLfffddq1u3bnSXEgAAAAASOSD78MMPbeTIke55rly57LnnnktWJl++fC4YmzRpUnSXEgAAAAASucvi8OHD7dSpU+6hLotqMfP+9h7Hjh2zr776ypo0aZK5Sw0AAAAAiTqGTMFXw4YNLRFt2LDB2rZta4ULF7Zy5crZgw8+aMePH4/1YgEAAACI5y6LKdGYsS1btrh/Q1188cUWb/bt22etWrWyWrVq2dy5c23nzp02aNAgO3z4sD3//POxXjwAAAAAiRCQqUXob3/7m/3rX/+yEydOpFjm5MmTFm8mT55sBw8etHnz5lmpUqXcNH3/O++804YNG2YVKlSI9SICAAAAiPcui0rusXjxYps+fbobT6bWoVdffdVat25tVatWtffff9/i0cKFC61Nmzb+YEy6d+/uunBqfQAAAABApgdks2fPthEjRrhgRDSe7Oabb3ZBSdOmTeM2INP4sXPOOSdoWokSJax8+fLuNQAAAADI9C6LO3bssNq1a1uePHmsYMGCbmyV58Ybb7RevXrZiy++aPFG31MBWKiSJUva3r17U32fujnq4UlKSgr6Nx4ow6ZXNxA9rNfsj22UOViv2d+nn37q/m3QoEHU5rlt2zY3LjunOOOMM6xKlSpRm9/69evd7YOo99kbdZ+6H46MnOdHFJCpRWj//v3uebVq1Wz58uWuK59s2rQpklnGtfHjx/vv4RYoHjNVVq5cOdaLEJdYr9kf2yhzsF6zvy+++MIS1Z9//ml79uyJ+vqk3ucM1H3qfrREFJC1aNHCVq5caR07drR+/frZ3//+dxfZ5s+f39555x3r3bu3xSO1hB04cCDFlrPAcWWhlInx9ttvD4qYFYytXbvWBbfxoEuXLu5fJTxB9LBesz+2UeZgvQIAcjLvfD/TArIxY8bYb7/95p7fd999LrHHnDlz7MiRI3bPPffYo48+avFI48dCx4opQNMKDx1bFqhYsWLuEUrBWKVKlSweFChQwP0bL98nu2C9Zn9so8zBegUAJIqIAjLdEFkPz/333+8e8a59+/b22GOPue6a3lgyJTjJnTu3tWvXLtaLBwAAACARsiwmqgEDBljRokWtc+fOLqOkUv0PHjzYTeceZAAAAAAyrYVMyTty5coV9oy3bNli8TiGbOnSpTZw4EAXlCk409gwdeEEAAAAgEwLyDp16hQUkGnMmFK5K7ti2bJlbdeuXbZkyRIrXry4devWzeKVUnLqewIAAABAlgVkzz77rP/5uHHjXFrKRYsWBSWrUIILjbNSgAYAAAAAyIQxZM8995w99NBDyTIHqnVs6NChNnHixEhmCwAAAAAJJaKAbO/evSnej0s0XfflAgAAAABkQkDWunVrGzJkiH3yySdB05cvX+5ayPQ6AAAAACATArKXXnrJpXlv1aqVlSpVyurUqeP+VSCmmx1Pnjw5ktkCAAAAQEKJ6MbQCrrWrVvnknqsXbvWkpKS3LSGDRvaVVddFf2lBAAAAIA4FFFA5lHwRQAGAAAAAJkckCmRR4kSJSx37tzueXrUhREAAAAAEIWArHTp0vb555+7bolnnXVW0E2iU3Ly5MlwZw0AAAAACSnsgOyVV16xGjVq+J+nF5ABAAAAAKIUkN1yyy3+53369An3bQAAAACAaKa9BwAAAABkYQtZtWrVMtRNccuWLZEuEwAAAAAkhLADsk6dOgUFZHPmzLGDBw9amzZtrGzZsrZr1y5bsmSJFS9e3Lp165ZZywsAAAAAiReQPfvss/7n48aNs8qVK7sbQxcrVsw//cCBA9a+fXsXoAEAAAAAMmEM2XPPPWcPPfRQUDAmah0bOnSoTZw4MZLZAgAAAEBCiSgg042h1RqWEk3ft2/f6S4XAAAAAMS9iAKy1q1b25AhQ+yTTz4Jmr58+XLXQqbXAQAAAACZEJC99NJLVqFCBWvVqpWVKlXK6tSp4/5VIFa+fHmbPHlyJLMFAAAAgIQSdlKPQAq61q1b55J6rF271pKSkty0hg0b2lVXXRX9pQQAAACAOBRRQOZR8EUABgAAAAAxCMh++eUX27Fjhx09ejTZa82aNTudWQMAAABA3IsoINuyZYvddNNNtnr1ave3z+cLel03kD558mR0lhAAAAAA4lREAVm/fv1cy9grr7xi5557ruXPnz/6SwYAAAAAcS6igEyJPGbMmGFdu3aN/hIBAAAAQIKIKO19xYoVLU+ePNFfGgAAAABIIBEFZGPGjLGxY8fa3r17o79EAAAAAJAgIuqyOH36dDeGrGrVqnbhhRdaiRIlkiX1ePfdd6O1jAAAAAAQlyIKyP744w+rWbOm/+9Dhw5Fc5kAAAAAICFEFJAtW7Ys+ksCAAAAAAkmojFkAAAAAIAYtZDJqVOn7OOPP7ZNmzbZ0aNHk70+aNCg0102AAAAAIhrEQVkv/76q7Vo0cIFY0rg4fP53HQ99xCQAQAAAEAmdFlUsHXmmWfa9u3bXTC2Zs0a++mnn2z06NFWq1YtF6gBAAAAADKhhWzFihX23HPPWfny5d3fCsrOPvtsGzZsmHt+991328KFCyOZNQAAAAAkjIhayA4cOGClS5e23LlzW7FixWz37t3+1xo3bmyrVq2y7KBPnz6uG2XoY9GiRUHljh8/boMHD7Zy5cpZ4cKFrW3btrZx48Zk89uwYYN7TWVU9sEHH3TvBQAAAIAsayGrVq2aJSUluefnnXeevfbaa3bNNde4v+fNm2elSpWy7KJ69er2+uuvB02rW7du0N/33HOPvfXWWzZ+/HirWLGijRkzxlq3bm3ff/+9FS9e3JXZt2+ftWrVynXJnDt3ru3cudN13Tx8+LA9//zzWfqdAAAAACRwQNahQwdbvHixde/e3f7xj39Yp06drEyZMpYvXz6X8OOJJ56w7KJQoULWqFGjVF/fsWOHTZ061SZNmmS33Xabm9agQQPXBfOll15yrWAyefJkO3jwYFDAeeLECbvzzjtdV80KFSpk0TcCAAAAkNBdFh9//HEXxEj79u3ts88+s379+lmPHj1s/vz59ve//91yCgWWSuF//fXX+6cp4GrXrp0tWLDAP01j4tq0aRPU+qeAVO/VPAAAAAAgy+5DFujSSy91j+xo8+bNrtvhkSNHrF69evbII49Y586dg8aFqXWvZMmSybo1Tps2Laic14LmKVGihEtsotcAAAAAIEsCsqVLl9rPP/9st956a7LXpk+fblWqVLGWLVtarF100UWu+6HGue3fv99efPFF69Kli82ePdu6devmHxumwCqUArS9e/f6/w63XErU1VEPjzf+DgAAAEBiiygg88aNpWTPnj02ZcoU+/TTTy3alN0xnGBGiTzy589v9957b9D0a6+91po0aWKPPvqoPyDLCkoWMnLkyCz7PAAAAABxPIZM2QdT66J48cUXu9czg1q21JUwvceWLVtSfL/S9F933XW2fv1614XRa+FSoBdKLWKB48XCLZcSZWPUTbS9x9q1ayP49gAAAADiTUQtZLqXV0rBiRegnDx50jLD7bff7h7RdM4559iuXbvccgeOI9O4ML0WWC50rJjXYhdYLiW6V5seAAAAAHDaLWSXXXaZvfDCC+bz+YKm62+lj9fr2ZEyIqqVTWPKlA5flE1RLWdvv/22v5yCM2VOvPrqq/3TlE1yyZIlbiyaR/PSezUPAAAAAMiSFjKNh1LSjvr161ufPn1cpsFffvnFZs6caZs2bbLly5dbrG3bts1uueUW69Wrl9WsWdMFWUrq8cUXXwQFX5UqVXKtboMHD7Y8efK4G0M/9thjLjPjHXfc4S83YMAAmzhxosvQqPuO6cbQeo+mcw8yAAAAAFkWkDVu3NhlWtRNk4cMGeJantRS5E1P60bMWaVo0aIuqPrnP/9pu3fvdkk+NO5N9xO78sorg8pOmDDBihQpYkOHDrVDhw7Z5Zdf7lrD9H6PujPquw0cONAFZZq/ArkxY8bE4NsBAAAASOj7kCloUSZFJcfwUsKfccYZll0o0ca7774bVtkCBQrYU0895R5pUcIQBWoAAAAAkC1uDK2xWN54LAAAAABAJif1AAAAAACcPgIyAAAAAIgRAjIAAAAAyCkBme41tnfvXjt27FjmLBEAAAAAJIgMB2R//fWXlSlThmyDAAAAAJDVAZnu56WbKZ88efJ0PxsAAAAAElpEY8juuusuGz9+vB09ejT6SwQAAAAACSKi+5D9/PPPtmnTJjv77LOtRYsWVrZsWcuVK5f/dT2fMGFCNJcTAAAAAOJORAHZ/PnzrUCBAu6xbt26ZK8TkAEAAABAJgVkW7dujeRtAAAAAIAA3IcMAAAAAHJSC5ln8+bNbixZSsk9unbtejqzBgAAAIC4F1FAdvDgQevSpYstX77cf7NoCUzsQVp8AAAAAMiELotDhgyxX3/91VauXOmCsXnz5rngrG/fvlatWjVbvXp1JLMFAAAAgIQSUUC2aNEie/jhh+2yyy5zf1eoUMGaNWtmL7/8snXq1MmefvrpaC8nAAAAAMSdiAKy3bt3W+XKlS1PnjxWuHBh+/333/2vXX311S5gAwAAAABkQkCmYOy3335zz2vVqmXvvfee/7XPP//cChYsGMlsAQAAACChRJTUo23btrZkyRKX2OP++++3W265xdasWWP58+e3tWvX2gMPPBD9JQUAAACAOBNRQPbEE0/Y4cOH3fObbrrJihQpYnPmzLEjR47Y888/b3fccUe0lxMAAAAA4k5EAdkZZ5zhHh61lOkBAAAAAMiiG0PrptDqopiUlOQyLTZo0MBq1659OrMEAAAAgIQRUUD2xx9/WP/+/e3f//63nTp1yiXxOHr0qOXOnduuv/56mzJliuvGCAAAAACIcpbFgQMH2vz5813gdeDAATeeTP/qPmQffPCBex0AAAAAkAkB2dtvv+0Se9x6661WtGhRN03/3nbbbTZ27FibO3duJLMFAAAAgIQSUUCmLorVqlVL8bXq1atbvnz5Tne5AAAAACDuRRSQqWXsxRdfNJ/PFzRdf0+aNMm9DgAAAADIhKQepUqVsv/+979Wq1Yt69ixo5UpU8Z2795t77//vh07dsyaNm1q48ePd2Vz5crlbh4NAAAAAIhCQPbQQw/5n0+YMCHZ60OHDvU/JyADAAAAgCgGZEp1DwAAAACIwRgyAAAAAMDpIyADAAAAgBghIAMAAACAGCEgAwAAAIAYybEB2UcffWS9e/e2GjVquEyOd999d4rljh8/boMHD7Zy5cpZ4cKFrW3btrZx48Zk5TZs2OBeUxmVffDBB917Q02bNs1q167tbo59wQUX2Pz58zPl+wEAAACIfxEFZDNnzrTff/89xdf27t3rXs9sixYtsq+//tqaN29uJUqUSLXcPffcY1OmTLHHHnvM5s6d6+6T1rp1aztw4IC/zL59+6xVq1YuAFMZlX355Zdt0KBBQfN66623rF+/ftajRw9buHChNW7c2Lp06WKrV6/O1O8KAAAAID5FFJDdeuut9uOPP6b42tatW93rmW3cuHH2/fff2yuvvGLFixdPscyOHTts6tSp9uSTT9ptt91mV155pb3zzju2f/9+e+mll/zlJk+ebAcPHrR58+a5Miqr92j6L7/84i83fPhw69mzp40ePdpatmzpXm/QoIGNGjUq078vAAAAgPgTUUDm8/lSfU2tTUWLFrXMljt3+ou+ePFid8+066+/3j+tVKlS1q5dO1uwYIF/mlq72rRp417zdO/e3b1X85AtW7bYpk2b3PRACtCWLl3qWt4AAAAAIFNuDK2gRQ/P008/bWXLlg0qc/ToUfv444/twgsvtOxA48LKlCljJUuWDJpet25dNxYssJxaxQKpG2T58uXda14ZOeecc5LNS10d1TIY+hoAAAAARCUgU+vQ+++/754ricbKlSutQIECQWXy589v559/vhuDlR2otS6l8WUK0DTWLSPlVEZCy3nBXuD8Qqk7pB6epKSkiL4PAAAAgAQNyO699173kGrVqrmxWMoyGC1KshFOoFK9enUX+OUk48ePt5EjR8Z6MQAAAADk1IAskLrnRdvs2bNdBsP0rF+/PuyugWq9Csym6FFrV+B4sXDKeS1hKqe0+IFlJHB+oZSt8fbbb/f/rcCzYcOGYX0HAAAAAPEr7IBM6eCVGl5d9vQ8PV27ds3QgihgCQxaokGB265du1zQFDiOTOPBAoM6PffGiIW22HnlvH9Vrk6dOkHzUoudWu5SU6xYMfcAAAAAgIgCsm7durn7ballR8/TojFmJ0+etFhTNkVlY3z77bf9wZ6CM2VOfOSRR/zl2rdv78a9KR2+N0ZMLXZ6r+YhCrh0Q2hN79Spk/+9s2bNcvc1y2ndKAEAAADkoIBM3RQrVKjgfx5r27Zts3Xr1rnnhw8fdvdFmzNnjvvbCxgrVarkArHBgwdbnjx5rGLFii7w0n3L7rjjDv+8BgwYYBMnTrTOnTvbsGHDbOfOne49mu59ZxkxYoTdcMMNVqNGDXcfMgVja9assRUrVmT59wcAAACQQAFZly5d7LXXXrPzzjvPZsyY4QKdwGAlqy1btizoBtSLFi1yj9D7pE2YMMGKFCliQ4cOtUOHDtnll19uS5YsCbqZtLoz6l5iAwcOdEGZ7qOm7zdmzJigz+zVq5cL/saOHese6rqom0k3btw4S74zAAAAgPiSy5fWXZ4DqEueWoIaNWrkWps+//xzElNEaMeOHVa5cmXbvn27a8WLB02bNnX/rlq1KtaLEldYr9kf2yhzsF4BAIlyvh92C1nVqlVt6tSp7ubPiuG+/PJL9zw1zZo1y9hSAwAAAECCCTsg0/ipvn372quvvuqSdvztb3/L9kk9AAAAACAuArLevXu77IJK6FG/fn2bOXOm1atXL3OXDgAAAADiWIZuDF24cGE7//zzbfjw4e6eZLFM6gEAAAAACRWQeRSQicaSbdq0yfbu3WulSpVy9+lSd0UAAAAAQPpyW4QmTZpk5cuXt3PPPddlw9K/ajF78cUXI50lAAAAACSUiFrIXn75Zbv77rvdfbl69OhhZcuWtV27drkbJWt6vnz53H28AAAAAABRDsieeeYZu+eee+zZZ58Nmn7ttdda6dKl7amnniIgAwAAAIDM6LKoTIvXXHNNiq916NDBfvrpp0hmCwAAAAAJJaKATGPHPv/88xRfW716tXsdAAAAAJAJXRZ1g+hRo0bZsWPHrFu3bm4M2e7du2327Nk2btw4e/TRRyOZLQAAAAAklIgCsocfftj27dvngq/HH3/8/88sb14bOHCgex0AAAAAEOWATPceUzA2ZswYGzZsmK1Zs8b9rfuQNWzY0M4888yMzhIAAAAAElKGA7K//vrLypQpY++++65L4HH11VdnzpIBAAAAQJzLcFKP/PnzW6VKlezkyZOZs0QAAAAAkCAiyrJ411132fjx4+3o0aPRXyIAAAAASBARJfX4+eefbdOmTXb22WdbixYtXJbFXLly+V/X8wkTJkRzOQEAAAAg7kQUkM2fP98KFCjgHuvWrUv2OgEZAAAAAGRSQLZ169ZI3gYAAAAAON0xZAAAAACAGLWQyW+//WbPPPOMuw9ZUlKSlS9f3ho1amT33nuvlS5dOgqLBgAAAADxLaIWMgVhtWrVsueff96KFy9uzZs3d/9OnDjRatas6V4HAAAAAGRCC5nS3p933nm2YMECK1asmH/6gQMHrH379nb33XenmOwDAAAAAHCaLWTff/+9DR06NCgYE7WSafp3330XyWwBAAAAIKFEFJCpW+L+/ftTfE2tZNWrVz/d5QIAAACAuBdRQDZu3DgbPny4ffLJJ0HTly9fbiNGjLCnnnoqWssHAAAAAHErojFkgwcPdi1hrVq1ct0UlVVxz549blrJkiVtyJAh7uHdJPrrr7+O9nIDAAAAQGIGZJdccokLtAAAAAAAWRyQTZ8+/TQ+EgAAAAAQ8RgyAAAAAMDpIyADAAAAgBghIAMAAACAGCEgAwAAAIAYISADAAAAgBghIAMAAACAGMmxAdlHH31kvXv3tho1arh7ot19990pltNroY9y5colK7dhwwZr27atFS5c2L3+4IMP2vHjx5OVmzZtmtWuXdsKFixoF1xwgc2fPz9Tvh8AAACA+BfRfciyg0WLFtnXX39tzZs3t71796ZZduDAgS548+TPnz/o9X379lmrVq2sVq1aNnfuXNu5c6cNGjTIDh8+bM8//7y/3FtvvWX9+vWzhx9+2JWfNWuWdenSxVauXGmNGjXKhG8JAAAAIJ7l2IBs3Lhx9vTTT7vnH3/8cZplzz777DQDpsmTJ9vBgwdt3rx5VqpUKTftxIkTduedd9qwYcOsQoUKbtrw4cOtZ8+eNnr0aPd3y5Yt7ZtvvrFRo0bZggULovjtAAAAACSCHNtlMXfu6C36woULrU2bNv5gTLp3726nTp2yxYsXu7+3bNlimzZtctMDKUBbunSpHTt2LGrLAwAAACAx5NiALCMef/xxy5cvn5UoUcJ69OhhP//8c7LxY+ecc07QNJUtX768e80rI6Hl6tat68aabd26NdO/BwAAAID4kmO7LIbr5ptvtmuuucbKli1r3333netu2LRpUzf+rGTJkv4xZArAQul1b3yaykhoOW8eaY1jU3dIPTxJSUlR+nYAAAAAcrJsE5AdOHAgrEClevXqyZJypGXGjBn+582aNXPB2MUXX2xTpkxxmRSzwvjx423kyJFZ8lkAAAAAco5sE5DNnj3bZTBMz/r165N1G8yI+vXrW506dew///lPUCuXAsJQahXzxpV5LWEqF5g232s5Cxx/FkoZG2+//Xb/3wo8GzZsGPF3AAAAABAfsk1ApoAlMGjJSgrwvDFioS12XvDn/atyCug8+lstdmq5S02xYsXcAwAAAAASLqlHoK+++so2btxoDRo08E9r3769LVmyxPbv3x/UYqdMju3atXN/K+DSDaE1PZDuRda6desMdaMEAAAAgGzVQpZR27Zts3Xr1rnnuoHzjz/+aHPmzHF/d+vWzf371FNPuektWrSwMmXKuKQeY8aMscqVKwe1xg0YMMAmTpxonTt3dvcd042hBw8e7KZ79yCTESNG2A033GA1atRw9yBTMLZmzRpbsWJFln9/AAAAADlfjg3Ili1bZrfeeqv/70WLFrmH+Hw+96+6Fr799tsucDp06JCVLl3aOnToYP/85z+DsiVqfJjuJTZw4EAXlBUtWtQFbAreAvXq1csFf2PHjnUPzV83k27cuHGWfW8AAAAA8SPHBmR9+vRxj7R07NjRPcKh+4mp22J6+vbt6x4AAAAAcLoSbgwZAAAAAGQXBGQAAAAAECMEZAAAAAAQIwRkAAAAABAjBGQAAAAAECMEZAAAAAAQIwRkAAAAABAjBGQAAAAAECMEZAAAAAAQIwRkAAAAABAjBGQAAAAAECMEZAAAAAAQIwRkAAAAABAjBGQAAAAAECMEZAAAAAAQIwRkAAAAABAjBGQAAAAAECMEZAAAAAAQIwRkAAAAABAjBGQAAAAAECMEZAAAAAAQIwRkAAAAABAjeWP1wQAAAJkpV65cqb7m8/mydFmArETdz1loIQMAAAl1QhrO60BORd3PeQjIAABAXEnphDOlVgFOTBFvqPs5E10WAQBA3Ao8GfWeczKKREDdzzkIyBAVn376qfu3adOmUZvnjz/+aH/++aflFIULF7YaNWpEdZ7ffPON1a9fP6rzRHRR96n7AACcDrosAtmYTkh79+4d68UAshx1H9GQWvICkhog3lH3cxZayBAV7OBIVNR9IPtS9yzGzyARUfdzFlrIAAAAACBGaCEDAABxy2sRUGsBrQNIJNT9nIMWMgAAEFfC7apFl2PEG+p+zkRABgAA4k56J5yckCJeUfdzHrosAgCAuMSJJxIVdT9nyZEtZCdPnrQnn3zSmjVrZmeddZaVKlXKWrZsaStXrkxW9vjx4zZ48GArV66cu1dO27ZtbePGjcnKbdiwwb2mMir74IMPuveGmjZtmtWuXdsKFixoF1xwgc2fPz/TvicAAACA+JYjA7IjR47Y448/bpdcconNmDHD3njjDStZsqQLyj7++OOgsvfcc49NmTLFHnvsMZs7d64dO3bMWrdubQcOHPCX2bdvn7Vq1coFYCqjsi+//LINGjQoaF5vvfWW9evXz3r06GELFy60xo0bW5cuXWz16tVZ9t0BAAAAxI9cvhzYpqkWsoMHD7ogLHDa+eefbzVr1rT333/fTduxY4dVrVrVJk2aZP3793fT9u7da2effbY9+uijrhVMFNyNGTPGfv75Z9faJgrI7rzzTjetQoUKblqdOnVcEKgA0NOkSRMrUaKELViwIOzl13JVrlzZtm/fbpUqVYrSWgEAAACQHWTkfD9HtpDlyZMnKBjzptWvX99++eUX/7TFixfbqVOn7Prrr/dPU8DVrl27oABKrV1t2rTxB2PSvXt3917NQ7Zs2WKbNm1y0wP17NnTli5d6lreAAAAACAjcmRAlpITJ064roN169YNGhdWpkyZZMGbyui1wHLnnHNOUBm1epUvX95fzvs3tJzmpa6OW7duzZTvBQAAACB+xU2WRSX52Llzp91///1BY8MUWIVSgKauixkppzISWs4L9gLnF0rdK/XwJCUlZfDbAQAAAIhH2SYgU5KNcAKV6tWrW/78+YOmffTRRzZ8+HA3LkxjvLKb8ePH28iRI5NNJzADAAAA4o93nq9efDkmIJs9e7bLYJie9evXB3Ub/O9//2vXXXed9e7d2wVkoa1XgdkUPWrtChwvFk45ryVM5ZQWP7CMBM4vlLI13n777f6/v/rqK+vYsaM1bNgw3e8LAAAAIGfas2ePSzKYIwIyBSyBQUs4Nm/ebO3bt3eZDqdOnZrsdQVuu3btckFT4Diy0DFjeh44piywxc4r5/2rcsq2GDgvtdip5S41xYoVcw+P7p22du1aK126tOXNm202QcLQdlUwrG2gcYJAoqDuI1FR95GoqPuxo5YxBWP16tVLt2zenFzBlC1RKeznzJlj+fLlS1ZGr+fOndvefvttf7Cn4EyZEx955BF/OQV1uvfY/v37/WPE1GKn92oeooBLN4TW9E6dOvnfO2vWLHdfs9BulGnRTaUbNGhwWt8fp08HJm47gERE3Ueiou4jUVH3YyO9lrEcHZDpxtAKon777TebMGGCfffdd/7XChQoYBdddJF7roqnQGzw4MEuLX7FihVd4FW8eHG74447/O8ZMGCATZw40Tp37mzDhg1zyUH0Hk337kEmI0aMsBtuuMFq1KjhbkKtYGzNmjW2YsWKLF4DAAAAAOJBjgzI1A3x66+/ds+vvfbaoNeqVKliP/30k/9vBWxFihSxoUOH2qFDh+zyyy+3JUuWuKDMo+6MupfYwIEDXVBWtGhRF8jpZtGBevXqZYcPH7axY8e6h7ouzps3zxo3bpzp3xkAAABA/Mnl8/l8sV4IICvpFgTKfKlkK4Fj+4B4R91HoqLuI1FR93MGAjIAAAAAiJHcsfpgAAAAAEh0BGQAAAAAECMEZAAAAAAQIwRkAAAAABAjBGRAgBYtWtg111yT4fcdP37cbr31VitdurTlypXLnn322UxZPkCmT59ub7zxRtTqb1bTPR11OxIAyGneeecdmzRpUobfp1sy6fxgzpw5lp3s37/fHZN/+OGHHLG88SpH3ocMyCw6yOom4hk1c+ZMe+2112zGjBnuxuHh3pkdiDQgU0DTu3fvqNTfrKb7PHbo0CHWiwEAEQVkX3zxhd15550WDxSQjRw50s4//3w799xz/dPLly9vn3/+udWuXTumy5coCMiAAIEHo4zYsGGDVahQwW644YaoLxOQ2fU3q1WqVMk90nLkyBErVKhQli0TAOD/K1CggDVq1CjWi5Ew6LKILPX999/b1VdfbWeeeaadccYZVqdOHXvyySf9r+tqzLXXXuuCm8KFC9uFF17oWp4CLV++3DWjf/TRR66FoGjRolalSpWg+YTzWSkJ7fLlda369ttvrWnTpm4+uor04Ycf+suoNezpp5+27du3u+XSQ039smLFCmvSpIk7sTzrrLPstttus7179572ekTWmzJlitvWqgOtW7d2V0i1rdVaJXr+1FNPBb1HXVc1PfRqpK6s6uqjfvAuueQSW7x4cVCZTz/91Jo1a2bFixd39btevXqu9dWro5988ol98MEH/vqmeppal8X06qDXLeVf//qX3X333VayZEm3bH//+9/txIkTGdoXvNZivV6qVCk3Ly3T2rVr0+yy6O3T+k7dunVzNy+9/vrrw15fyJl0vG/VqpU71quu63i+e/du91rnzp2tevXqdujQIX/5t956y9WTRYsWub+TkpJcfVY51e9atWrZsGHD7NixY0Gfo/c88cQT9vDDD1uZMmWsRIkS9uCDD5puw7p06VL3O6P6qP1ax/FAmpfmqd8Y1b+6desm6y7cp08fty+oHl900UXu+zRs2ND+85//ZOLaQyxoW+tYrPML7/iraenV57ToN6R+/fpWsGBBq1ixoqunJ0+eDHpdn6PfnHbt2vnPZ5YsWWKnTp2yf/zjH1a2bFn3eOihh9y0wIvFPXv2tMqVK7v36aKdzle8Mjr+V6tWzT3XMTfwHCalLot//fWX3Xfffe74ru/Yt29f99sReN7jHc+1vIG0T+v3IND69eutU6dObl5ab+o58eOPP1oiIiBDlurYsaPt27fPpk2b5k6+dNL3559/+l/ftm2bXX755TZ16lR7//337brrrnM7vHcyGmjAgAGuKX3evHluvkOGDPH/UIfzWeHSAUgtXzro6rP0g67l+v33393rmtajRw8rV66cOyDroZNH/Ri3bdvWnVDPnj3bnRDoO7Vv3z7oYIvsb/78+da/f39r2bKl2946cfMChoyONVSd0PzGjBlj7733nvuB1I+QAh05ePCg+1tByZtvvum6x+izFZh43RJ10qf9xKtv6gKYkozUQZ0E5M6d2/7973+7fUs/2toPM7IviH6Ub775Zvd5OnE9++yzXXC5adOmdNePvqe6/Gre2l/DWV/ImVRvdXKmE7FZs2bZyy+/bOvWrXMnZ6K///jjD3fyJ7/88osLzFU3r7rqKjftt99+cyeG48ePd8d+BVn6rVCZUM8//7z9/PPP7gLfoEGDbNy4ca6O3X///e4kVtNVR/V7E6h79+720ksv2QMPPODqoT77xhtvtIULFwaV+/XXX+2ee+6xwYMHu33o6NGj1qVLF7fPIH488sgj7kKvLgJ4x19NS68+p0Z1V8fvK6+80h2bdR7z3HPPueNxKB1XdcFNx0ddtO7atavde++97iKCLoTdddddNnbsWHfhwrNz504XvOl3Y8GCBe4YO2rUKBs9erR7Xecqc+fOdc8fe+yxoHOYlGhf0by8eq7fkaFDh0a0Lrds2eIuFuoC4fT/Gxe9Z88e9/saelElIfiALLJnzx6fqtx7770XVvlTp075/vrrL1///v19jRs39k9ftmyZm8/gwYODylatWtXXt2/fiD7L07x5c1+HDh38fw8fPtzN54MPPvBP27p1q5v22muv+afde++9vipVqgTNq0uXLr6zzz7bd/z4cf+0Dz/8MKLlQmxddtllviuuuCJo2iOPPOK25auvvur+1vNx48YFlXnmmWfcdM8rr7ziy5s3r+/7779PNv/rr7/ePV+3bp17zzfffBN2PU1tejh10KvP3ucHzqt169YZ3hcCnTx50u3DderU8T300ENB8ypcuHCyfXrAgAFB7w9nfSFnatasma9Jkybu2O3Rds6VK5e/js2dO9fVi3feecd31VVX+WrWrOn7448/Up2n6trrr7/u6syff/7pn655NGzYMKjsJZdc4j7rhx9+8E+bOHGiK7tv3z7398cff+z+1j4TqEePHr4GDRr4/77lllvcvL777rtkdXrlypURriFkV9re5513Xobrs3e8nD17tvv74MGDviJFigQdG+XFF1/0FSpUyPfbb7+5v/Ubo/dNmjTJX+bbb7910xo1apSsXnfu3DnNc6oxY8b4ypcv758eulypTf/999/dcum3L/S7q5zKB9Z9/ZYF6tSpk/td8dx8882+6tWr+44cOeKftnv3brdOXnjhBV+ioYUMWUZdB9XtQ1dYdBVzx44dycqoRUtXGVUuX7587qErTSldXVfTvUfN4+pK4s0znM8Kl1oN2rRp4/9b3dbUPSa9ea5cudJdHdN3CFxmdZdZtWpVxMuDrKUrgGpp0tXuQOpal1Hqaqfuh2rZVXdA76FWIF1NFbUQqXXsb3/7m7sCqSuGkcpIHQzcn0QtUaF1PJx9QV1QtK7UfUYJRvTZGzduDKuFLDTRRzjrCznP4cOHXbdctTJr//K2q7azulZ521b1SK0C6oGgLupqBVC3Jo9iLXULVl1VPVRdUwuu5qWr74FUZwLps9TKoN+NwGni1WfVP7XAqRtaaP378ssvg1qZNa/zzjsv2XjO0/ntQXzV51CfffaZawXW+wLrl46xGkP73XffpVqHvbqq1qRAmh7Y7VYttcOHD7eaNWu6LrfaR9T6pu6++uyMUK8ELVfob6F6SURC+5eGqOTNm9f/3dXNXT1AEvH4TkCGLKOgSTugfgDVtK4D1aWXXurGuHjUFUrdtNSVRGW1U2qMgA4qoXRSGSh//vz+cuF8Vrj0Q695p/ZZqVFwqZPSUJrGOLKcQwGRfijUPS9QSts2PepipRM572KD9/jnP//p/xHVD5JOPtXN8KabbnJdYdUVJpIuehmpg2ntT+HuCxrvo8BOXY/VFUcBofbhCy64IN39xVuujK4v5DyqlzpxVXfB0G2rboWB21bjcNR96eKLL7bGjRsHzUfBmLoS6qLDu+++68YqvvDCC+610PqWUv1OaVrge1X/tJ+ELqO6mOmYoJPatOaf0nIgsetzINUvUd0OfI/GQkro+wLrmFe/0jtuqwukuuf269fPdVnU8VhjziKpm159j8Zvoff9tQ+HrrOVK1cm5PGdLIvIUrp6o7El6levq0MaLK2xXurnrKsk6qOvE7mBAwf63xM4QDVan5UV90DSldWUBvTu2rXLvYacQfeWU90M3ZbajoF09VFjnkJ/qANpu2vwtsY1pkUJATRGRVcjly1b5i5QaEB0Rgc7Z3Ud1NgDtQhoP1YQ5jlw4EC6WRUlNAFKuOsLOYtOIrWtdUxWvQ6l5DOiMb+6oKa6pAQBr776qrvfo0fHd11hf/zxx/3TQu+ldDpU/7T/60Q2JaEnpkhM4dbnUN4xWGO4dNE4lJds43RoH7njjjtcYObRmPpIeOPK9Jui5COp/RYqOYmk9HsYeIzX91eviJRuH1C0aFFLNARkiAldBWnevLkbDKofVA3Y1lUWBV+BV+B1xV0D+aP9WVlxXw1lmlNCBiVH0Am9qOVDyRn0GnIGdbvTFUwNpNYVUE/ozTIVcKi7XiBt70DqiqKTO3Vv0iM9apHSAHIFYhq8rSua+rELp4U2FnVQAaQE7sO6GKJEH4HducKV0fWFnEHdDtXapf1FrZ2pUeuXTuJ0xVwZcpXgQ120lCjGq2+hLbavv/561JZT9U+fq8/QhQFAQo+/4dbnUHqPMh/qIlZoN8BoCd1H1JIXmPQjI6256j6u3yT9Fqpboeftt98OKuddfNP6UNIOrzXsv//9r8uSG7h/qVum5pUnB9w/M7MRkCHLfPPNN+4HVuMBNE5GV811ZVPjUPS3dsgGDRq4LEFeq4SeK2tROKljM/JZWUH9tHUwUlYktfjpKpKCQrV+6CQbOYe2pbpF6eq8UghrTFno7Rg0pkzdL1SHldVKqYDVGhtI42GUsU1dENXqpQsDCo7ULU9XE1VHdfVSLUL6gdaJp7K3TZw40WVV9K48qiuuxkYqK5euWqYWsGR1HdQ9a9T6rFYNfY6+v8YvBF5NzYhw1hdyJnWj0tgsHaO1T6mrrk5MdcFA+5lODrXtdfKoOq5trUyK6tauVPW60q4xNRMmTHAZFFU3tM9t3rw5asuo+atXhTIrKoOjgjK12inluT4nNAspEoOOv6+88oobXqHuhWoBS68+h6Z791rWlPFQdUtlVUbnQRr/qC64CnQUsJ1uHdYtWzSmUcupDImhGQzVLV7Lou+jVjn19kjpAoRatJTBVOdlCsx0oVLvCe25oYDssssuczeb1vmbzuWU4VfPA+l1/V4qw2T//v3dRXn93um2LldccYX16tXLEkqss4ogcezatct34403uqw6BQoU8JUpU8Z33XXX+TZt2uQv8z//8z++Vq1a+c444wxf5cqVXda61DKypZXBJ5zPCjfLYuBne4oXL+5eSyvLoixfvtxliNQylCpVytenTx+XqQg5z+TJk12dLFiwoKsna9asCcqyqOxvt956q9vOZ511lu/hhx/2Pf3000FZFuXAgQO++++/32U/zJcvn8t2dfXVV/vmz5/vXt+wYYOrq/os1ZsKFSq4epOUlOSfx44dO9x7SpQo4ebv1cWUsi+mVwdTy7AVWqfD3RcWLlzoMpBpPdWvX9+3YMGCdPer1PbpcNYXci5tb21L1SFlb6tVq5bLtLlt2zZX73v27JmsvDIoKnupHDp0yNXnkiVLuke/fv1877//frK6lFIG1JQy5aVUD48dO+YbOXKkW7b8+fP7Spcu7WvZsqVv5syZac5LmRoDjw+IHzomqW6eeeaZbhtr+6dVn7dv357msfbNN990WTv1nmLFivkuuugil8lQGREDsywqe3SgcOr1r7/+6rIuFi1a1Fe2bFnfkCFDfFOmTEk2v3nz5vnq1q3rfie8jIkpLa/2h4EDB7rfHi2rPk9ZdgOzLMrmzZvdfqLjfI0aNdx3DM2yKDon6969u1uX+mxly1b2xcCMpYkil/4X66AQAHIatdToKqjGtXg3BgUAIJGoW7x6dGzdutX1QkJkyLIIAAAAADFCQAYAAAAAMUKXRQAAAACIEVrIAAAAACBGCMgAAAAAIEYIyAAAAAAgRgjIAAAAACBGCMgAAAAAIEYIyAAAAAAgRgjIAAAAACBGCMgAAAAAIEYIyAAAAAAgRgjIAAAAAMBi4/8BJ5LPOWKsYf8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 880x396 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "N_CAND = 20_000\n",
+    "\n",
+    "def simuler_portefeuille(sens=None, spec=None, n=N_CAND, seed=7):\n",
+    "    \"\"\"Simule n candidats ; regle : accepter ssi P(mauvais | signal) < SEUIL (ou tous si pas de signal).\"\"\"\n",
+    "    r = np.random.default_rng(seed)\n",
+    "    types = r.binomial(1, P_MAUVAIS, n)                      # 1 = mauvais risque\n",
+    "    if sens is None:\n",
+    "        accepte = np.ones(n, dtype=bool)\n",
+    "    else:\n",
+    "        alerte = (r.random(n) < np.where(types == 1, sens, 1 - spec))\n",
+    "        p_pos = P_MAUVAIS * sens + (1 - P_MAUVAIS) * (1 - spec)\n",
+    "        p_bad_pos = P_MAUVAIS * sens / p_pos\n",
+    "        p_bad_neg = P_MAUVAIS * (1 - sens) / (1 - p_pos)\n",
+    "        p_bad_post = np.where(alerte, p_bad_pos, p_bad_neg)\n",
+    "        accepte = p_bad_post < SEUIL\n",
+    "    profit = np.where(accepte, PROFIT_G - (PROFIT_G - PROFIT_B) * types, 0.0)\n",
+    "    return profit\n",
+    "\n",
+    "regles = {\"sans info\": dict()}\n",
+    "for nom, s in SIGNAUX.items():\n",
+    "    regles[nom] = s\n",
+    "profits = {nom: simuler_portefeuille(s.get(\"sens\"), s.get(\"spec\"), seed=11 + i)\n",
+    "           for i, (nom, s) in enumerate(regles.items())}\n",
+    "\n",
+    "stats = pd.DataFrame({nom: dict(moyenne=p.mean(), ecart_type=p.std(),\n",
+    "                                part_refuse=100 * (p == 0).mean(),\n",
+    "                                perte_P5=np.percentile(p, 5))\n",
+    "                      for nom, p in profits.items()}).T.round(1)\n",
+    "print(stats.to_string())\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 3.6))\n",
+    "ax.boxplot(list(profits.values()), tick_labels=list(profits.keys()), showmeans=True)\n",
+    "ax.axhline(0, color=\"black\", lw=0.8)\n",
+    "ax.set_ylabel(\"profit par candidat (EUR)\")\n",
+    "ax.set_title(\"Distribution du profit de souscription selon la regle\")\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c8cdf3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003116,
+     "end_time": "2026-08-25T08:53:30.297893",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:30.294777",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "La simulation confirme les espérances analytiques (moyennes MC ≈ EVSI + baseline aux fluctuations\n",
+    "d'échantillonnage près) — mais le tableau montre ce que l'espérance cachait : **le tri des\n",
+    "candidats réduit la queue de pertes, sans la supprimer**. Sans information, 30 % des candidats\n",
+    "acceptés perdent 1 860 € chacun. Avec l'examen, les faux négatifs restent : ~9 % des candidats\n",
+    "sont des mauvais risques au signal négatif, acceptés à tort (d'où `perte_P5` = −1 860 € encore) ;\n",
+    "la télématique, plus précise, tombe à ~3 % — et son `perte_P5` passe à 0 €. Regardez aussi la\n",
+    "ligne `part_refuse` : le questionnaire refuse ~0 % des candidats (conforme : il ne change aucune\n",
+    "décision), l'examen ~28 %, la télématique ~29 % — et pourtant leurs valeurs nettes diffèrent du\n",
+    "tout au tout, parce que la télématique paie 500 € pour ce tri quand l'examen le paie 90 €."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c2f8d1b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004639,
+     "end_time": "2026-08-25T08:53:30.305874",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:30.301235",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "## 6. L'EVSI est elle-même incertaine : calibration bayésienne (PyMC)\n",
+    "\n",
+    "D'où viennent les sensibilité/spécificité de nos signaux ? D'une **étude de calibration** : on a\n",
+    "fait passer le questionnaire à 60 mauvais risques connus (24 alertes) et à 100 bons risques\n",
+    "connus (35 fausses alertes) ; l'examen médical à 100/100 (70 et 10). Les vraies sensibilité et\n",
+    "spécificité sont **estimées**, avec une incertitude qui se propage à l'EVSI — exactement le\n",
+    "mécanisme du prix de l'ignorance de T4, mais appliqué à la *qualité du signal* plutôt qu'au\n",
+    "risque. Modèle PyMC (Beta-Binomial, NUTS) :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "705f8cdb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:30.318011Z",
+     "iopub.status.busy": "2026-08-25T08:53:30.317552Z",
+     "iopub.status.idle": "2026-08-25T08:53:42.520429Z",
+     "shell.execute_reply": "2026-08-25T08:53:42.520007Z"
+    },
+    "papermill": {
+     "duration": 12.20814,
+     "end_time": "2026-08-25T08:53:42.521337",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:30.313197",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\pytensor\\tensor\\rewriting\\elemwise.py:872: UserWarning: Loop fusion failed because the resulting node would exceed the kernel argument limit.\n",
+      "  warn(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (2 chains in 2 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [sens_q, fpr_q, sens_m, fpr_m]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 2 chains for 1_500 tune and 1_500 draw iterations (3_000 + 3_000 draws total) took 4 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean</th>\n",
+       "      <th>sd</th>\n",
+       "      <th>eti89_lb</th>\n",
+       "      <th>eti89_ub</th>\n",
+       "      <th>ess_bulk</th>\n",
+       "      <th>ess_tail</th>\n",
+       "      <th>r_hat</th>\n",
+       "      <th>mcse_mean</th>\n",
+       "      <th>mcse_sd</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>sens_q</th>\n",
+       "      <td>0.406</td>\n",
+       "      <td>0.061</td>\n",
+       "      <td>0.307</td>\n",
+       "      <td>0.506</td>\n",
+       "      <td>4777.332</td>\n",
+       "      <td>2600.155</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>0.001</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>fpr_q</th>\n",
+       "      <td>0.355</td>\n",
+       "      <td>0.047</td>\n",
+       "      <td>0.283</td>\n",
+       "      <td>0.431</td>\n",
+       "      <td>4755.101</td>\n",
+       "      <td>2446.818</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>0.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>sens_m</th>\n",
+       "      <td>0.692</td>\n",
+       "      <td>0.046</td>\n",
+       "      <td>0.617</td>\n",
+       "      <td>0.766</td>\n",
+       "      <td>4308.970</td>\n",
+       "      <td>2603.155</td>\n",
+       "      <td>1.001</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>0.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>fpr_m</th>\n",
+       "      <td>0.116</td>\n",
+       "      <td>0.031</td>\n",
+       "      <td>0.070</td>\n",
+       "      <td>0.169</td>\n",
+       "      <td>4437.837</td>\n",
+       "      <td>2335.694</td>\n",
+       "      <td>1.001</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         mean     sd  eti89_lb  eti89_ub  ess_bulk  ess_tail  r_hat  \\\n",
+       "sens_q  0.406  0.061     0.307     0.506  4777.332  2600.155  1.000   \n",
+       "fpr_q   0.355  0.047     0.283     0.431  4755.101  2446.818  1.000   \n",
+       "sens_m  0.692  0.046     0.617     0.766  4308.970  2603.155  1.001   \n",
+       "fpr_m   0.116  0.031     0.070     0.169  4437.837  2335.694  1.001   \n",
+       "\n",
+       "        mcse_mean  mcse_sd  \n",
+       "sens_q      0.001    0.001  \n",
+       "fpr_q       0.001    0.000  \n",
+       "sens_m      0.001    0.000  \n",
+       "fpr_m       0.000    0.000  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with pm.Model() as modele_calibration:\n",
+    "    sens_q = pm.Beta(\"sens_q\", alpha=2.0, beta=2.0)\n",
+    "    fpr_q = pm.Beta(\"fpr_q\", alpha=2.0, beta=2.0)\n",
+    "    sens_m = pm.Beta(\"sens_m\", alpha=2.0, beta=2.0)\n",
+    "    fpr_m = pm.Beta(\"fpr_m\", alpha=2.0, beta=2.0)\n",
+    "\n",
+    "    pm.Binomial(\"alertes_q_mauvais\", n=60, p=sens_q, observed=24)\n",
+    "    pm.Binomial(\"fausses_q_bons\", n=100, p=fpr_q, observed=35)\n",
+    "    pm.Binomial(\"alertes_m_mauvais\", n=100, p=sens_m, observed=70)\n",
+    "    pm.Binomial(\"fausses_m_bons\", n=100, p=fpr_m, observed=10)\n",
+    "\n",
+    "    trace_calib = pm.sample(1_500, tune=1_500, chains=2, random_seed=20260825,\n",
+    "                            progressbar=False, return_inferencedata=True)\n",
+    "\n",
+    "az.summary(trace_calib, round_to=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b2b8b51",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003598,
+     "end_time": "2026-08-25T08:53:42.528756",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.525158",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation du posterior de calibration\n",
+    "\n",
+    "L'examen médical est calibré serré : sensibilité ~0.70 ± 0.05, taux de faux positifs ~0.10 ±\n",
+    "0.03 — l'étude (100/100 observations) a fait son travail. Le questionnaire est **plus incertain**\n",
+    "(sensibilité ~0.40 avec un intervalle nettement plus large relativement, faux positifs ~0.35 ±\n",
+    "0.05) : 60 observations sur une question plus bruitée. Vérifiez `ess_bulk` et `r_hat` : les deux\n",
+    "doivent indiquer une convergence propre (r_hat ≈ 1.00) avant de propager — un posterior mal\n",
+    "échantillonné propagerait son artefact dans la décision d'achat. Propageons chaque tirage\n",
+    "posterior vers *sa* EVSI :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f65a4a51",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:42.536188Z",
+     "iopub.status.busy": "2026-08-25T08:53:42.535978Z",
+     "iopub.status.idle": "2026-08-25T08:53:42.740921Z",
+     "shell.execute_reply": "2026-08-25T08:53:42.740418Z"
+    },
+    "papermill": {
+     "duration": 0.209544,
+     "end_time": "2026-08-25T08:53:42.741625",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.532081",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABAkAAAFrCAYAAACzA9B3AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAQ6wAAEOsBUJTofAAActpJREFUeJzt3QecU1X6//FnCkNn6B0BBUQpggoCFgQpAhZEFNBVkaruYu+IgFiXoiyuiwXRVRQEQRQBFURBAbGLCGIBpCm914H8X9+z/zu/JJMZhmFm0j7v1+tCJrlJzk1ucp6c85xzEnw+n88AAAAAAEDcSwx3AQAAAAAAQGSgkQAAAAAAADg0EgAAAAAAAIdGAgAAAAAA4NBIAAAAAAAAHBoJAAAAAACAQyMBAAAAAABwaCQAAAAAAAAOjQQAAAAAAMChkQAAAAAAADg0EgBxrEaNGnbhhReGuxgIg08++cQSEhLslVdesWinY9Cx6JgAIJpRLyOeqS7v2bPnMa/LC0OGDHHPtXr16jx/rmhAIwHy9AdIVtuKFSvsp59+cpfbt2+f5eOF2m/Xrl32xBNPWOPGja106dJWpEgRq169unXo0MH++c9/hvzgf/bZZxYNVN533nkn3MVADHwOdS7t2LEj3EUBEGbUyyeGehlAPEkOdwEQ27p27WqXX355yNsqV65sJUqUsBYtWticOXPsjz/+sJNOOinkvuPGjXP/9+3bNz0Qadq0qf3888/WsWNHu/76661YsWK2atUqW7JkiT3++ON27733WrQaOnSo3XDDDda5c+c8fR69fgrSELs/CnQuqQW+ZMmSAbddcMEFtn//fitQoIBFu+uuu866d+9uKSkp4S4KEPGol3OGehkID8UqSUlJ4S5G3KGRAHnqjDPOsL/97W9Z7qMAY+HChfbyyy+7lvpghw4dstdee83KlSuXHti8+OKLriK9/fbb7emnn85wnz///DMXjyK26PU8evSoFSpUyAoWLBju4rjAUkEp8ldiYqI7B2KBgofsBBA+n8/27t3rfrgA8Yp6OfJQLwOZi5VYJdow3ABhd/XVV7vKaPz48a6SDPbuu+/a5s2bXQu+1+v5yy+/uP8vuuiikI9ZsWLFHJfHS4FUKuWdd95pVapUcV9QCqwmTpwY8j6zZ8+2Vq1aueMoXLiwNWrUyP7973+7HyX+1q1bZ/369bOaNWu6xyxbtqydddZZrofFPx1UXn311YA0UH/ffvut6w0qX7686z09+eST7f7777d9+/YF7KceZN1369at7nkrVarkyrd48eIsxz5m9/F1Xz1GKMFjyDTGS9fp9X377bddj5NSUS+77LLjft5w+vXXX+2KK66w1NRUK168uLVr186+//77kK9FZuPoMpsPQIGiUnIbNmzo3iedT23atLH58+dneIwJEyZY8+bNXUqv9lVvX5cuXdx5KyqPer5E55t3HnkBf2ZlOHDggLtf3bp13Tmqx7/00kvtq6++ylAG7/jUS9i6dWv341sZC+rV37RpU8h5A+bNm2fPPPOM1alTxwXDKtuoUaMyPLYes1evXnbqqada0aJF3dakSRP3PZGdOQm869QbqvRn7/lGjBiRvo/Ow5YtW6Z/bpUi/dJLL2V4fCDeUC9TLx/v84bT7t27beDAga6+0Pe86i1lfPzwww/p+2zYsMEdg8q/c+fOgPs/+uij7nXwrx+Opw7yzs/ly5fb3Xff7c5PvY7KyNHjyOeff+7eG9WTalzTeZyWlpbhsf766y8bMGCAew/1eleoUME16gWPkz/eOjUz3vn2448/uqFD+ryUKVPG+vTp4xrV9flXXFKrVi33+PXq1bP3338/5GOpLBpaVKpUKbfvaaedZk899ZQdOXIkw74fffSRNWvWzJ37ej30Wm/ZsiXk42YWSy1YsMA1Uur+ej7FQddcc4399ttv6ft8+OGH1qNHDzvllFPS4yplUr733nvZfo3iFZkEyFOqREJ96NXrpy8R0Rfptddea//5z3/cl0bwOEgvaNcXlkcfdnn99dddQKIPfm5TqqSCCX2RHzx40H0h64tmz549AWVRyqV6XfTldM8997gKYMqUKfaPf/zD/Xh84YUX3H6qDNq2bWtr1661m2++2f0I02NpDOjHH39sDz74oPtCVe+M0qfPP/98F0CECnxU+VWrVs1VJKpA9DyqFFQJ6Us6OTnwo60fmvrSV8WuL/ysgrWcPP7xmD59uqvQbrrpJve6eQFbXj9vbtB7p0pfY/xVfr1fCuxUwer1PRE6P5Si++mnn7rzTI+vz4/Ocf0A11jYSy65JL2BQEHDueeea4MHD3bn3Pr16915pJ68008/3QVMCpSmTZvmevUU+IoaIDKjilxl0Gut/3UOq/dPn83zzjvPZs2a5YJuf3qPFBTo89KtWzf7+uuv3WdWr5He02A6z9VLdeONN7py//e//7W77rrLpTmrccGjcitoUXCqMc0K6t566y0XSOjHSXbTlvWZ1OuoHzMKJHR+iV63Rx55xB2PLus75IMPPnDnpBqCnnzyyWy+c0B0oV6mXo6leln1ieonfW/re14NR9u3b3eZLWpI1w/JM88809UxOjdVX/Xu3dudD6I6Vz/yO3Xq5OqiE6mD9PxqaNJt+oGtRgedXzp/9CNX56jqOdWlqpdVJz3wwAMZYgydgyqjfvirbtfnUD921VgfPPwnu3VqVvQcijN0rOoEWbRokfsMKc1f3wmaN6R///7uO2L06NGuQ2LlypXudfEo60jHp8Z2ndPqMNA5ouNTQ5N/Y54aGbwf9/fdd5+LVaZOnWoXX3xxtt93fQepTHoMPa8aRxSv6JzV++Z9H+k7Qg0vipmqVq3q3js19qkhTGVS3IJM+IA8MG/ePNUwmW7Vq1cP2P+bb75x11911VUB1//xxx++xMRE3/nnnx9w/bZt23zVqlVz90lNTfV16tTJ98gjj/g++ugj36FDhzKUZ/DgwW7fBQsWHLPs3r5nnXWW78CBA+nX79ixw3fSSSf5ihcv7tu5c2f6dcWKFfNVqlTJt3nz5vR9Dx8+7Gvbtm3Ac37//ffu7yeffPKYZdB+N9xwQ4br9+/f76tYsaKvadOmAWWTKVOmuPu98sor6dfpMXRd9+7dfUePHs3weHofWrZsmePH132D38vMjmHVqlXuuuTkZN/SpUtP6LjC5brrrnNlmTZtWsD1TzzxRMjzOrP30ft8jB8/Pv26Z555xl03derUgH11Pjdu3NhXs2bN9OuuuOIKdx6GOtdDnct67bNThnHjxrnr+vbtG7Dvzz//7CtYsKCvdu3aviNHjgQcX0JCgu/zzz8P2L9///7uNt3Po+fRdQ0bNgx4j/fs2eMrU6aMr3nz5gGPoeuD6bn1XaDPvP+xe4+tYwq+7pRTTvHt3r07w/eNyn3rrbdmeI5//OMf7jvnt99+y3AbEM2ol6mXY7Fevv32230FChTwLV68OOD67du3+6pWreq78MILA64fOHCgK/uYMWN8mzZt8lWuXNntt2XLlhzXQd752aFDh4A6UrGCrk9KSspQvkaNGrlz1F/nzp19pUqVylD/6H3SOd2zZ88c16mZ0bmix3nzzTcDrr/88stdPalyHjx4MP36b7/91u3/wAMPpF+3ceNGX6FChVz5g8/pESNGuP0/+eST9NewRo0a7nj0XeJJS0vzdezYMeTnLPi6devWuZhEcZH/Z9zj/x6Eeh/37t3r4pnTTz892zFTPGK4AfKUWk7VCxG8qSfUn1oeld6n1mz/Hg61TKqF3ZsYyaOWTfVYqgVVqXozZ860hx9+2LXYqqUw+PFzQi2x/mMDlV7+97//3aW16RhELbtq8VULu9dTK2pZf+ihh9xlpfB59xe1vOd0bKZSp3Vfva4qh14rb1P6lHp/1BsaTC212ZkIKaePfzzUWl+/fv18f94TpfNQvfnqpQ+euEpjcE90nLt6GpT2p54q/+NX74VavDX5l1ruRS306g1UulyoVOCc8s5Vb5iCR70ZSuFTOvHSpUsDblNPjXo+/OlzKF55/aknz/9zpRROPUbwvrreo94MpeZu27bN9TToNVHGRHbo+YLfG30/KO5QT43/a61Nr7VeU52TQCyiXqZejpV6Wd/jyg5QHaKeY/8yKktEwwGVSaA6xKP6TcPMNCxAx62hcepRDs4GzEkddMcdd7j5fjx6HjnnnHPc5k+v4caNG925KnpMDeNRFp9S4v2PRXWYUvNDvd7ZrVOzEirrQGXX63vLLbcETAqsYTsqn//jKytDQxXVo6/Xyb/sXgakV3Z9R2johLKCvMw+UZaCvjuyY/LkyS6TSN8v/p9xj/974P8+KrtD5VP8pMwJDV/SuY3QGG6APKUvbaXUZYcCDqW66ceSvmj15aSxX/pBpBSoYEoxeuyxx9ym1OYvvvjCBTNKQdKXj35wKR07p/RjMLPrlNYmv//+u/u/QYMGGfb1rvPGRiktS2nNw4YNc1/Iul0pcvrB6f2oOhaNdxN9aWsLRWlVwfQjLy8f/3iEKktuPK8qWq+yzSmdU5lNgKdAQpVJqPNC6YU6109kqUG9Bqq4VIbM6DXQ66ehBEr/u/LKK11grvNcFZ5+yCsdNKd0PitQUoCf1fmsdE6PxncG84ItVcbBMts/eF8FFwoA1DCjQCqYgrUTPd/8jyO3z3MgUlEvUy/HSr3s/RDVvD1Z1Z3ax/tBqsd68803rXbt2vbll1+69z7UOZmTOii4fvOG74Sq97zbVPepEUA/utX4psa0zBrU/H/8ZvacmdWpWcmqfJnd5v/43rniNQhkda54n71Qn2XNd5AdXgOFhpEcixokBg0a5BotQ71nGpqi+aWQEY0EiBj6gaNeAo2DUjCiXoE1a9a4XoJjjW1UwKIxk9oU+CuoUSBzIsFIXtC4N40b03g0tW6rN+O5555zY7M0/u1YvQper7ECME0wFIr3xe5PLf7ZcbyPn1l5Q03Gk1VZcnpc/jT2L7gH/Hiptz6zCZ9yU6jXR6+BJkh69tlnM72f19OjIH/ZsmVuQq25c+e6c0m9Il5FqB6K/JLVqgLBE4Qda3//++mzrKwF9QZqsii9/7qvjk9jObObQZHV+TZjxoxMZxIPFRgB8YZ6mXo5kutlr4yq81T/ZSa4AUH1pnqV5bvvvsu1Oiiz+i079aT3eJo0NDhLJyu5sTRgVo+R2W3+9btXdjUG+s9T4E+NcPlNDVQ6N5Slcdttt7k5mZQFocYWZUSpsSg3szFjDY0EiBhqydMEIvrgajK44DWYs8tLfdZELCdCaUjBPY3ezPGa5VW8iVH0gy24BVUTp/jv49EXqIIlbaq0lcqnVmNNnhNqRuNQrf3quc5uT9DxON7H12QzSh0L5vXk5NXzhqJeKvUAnYisJo7SrMg6R71zwJ/S7NQ6HpyuqNcnVMt1qNdHr4EmLdI5kJ2JoDSjuHq6vN4uzeJ89tlnu54Pb5b/411rW+eqJuxSi39wRkJm53NeUGD2zTffuKBPkwv681KKT4Rea01upIyJ7PREAPGKepl6OZLrZf34V2OUeoOzW0YNE9AklUqb18S1+sGvxnml7edXHRSKzl/9eNXQhrw4j/KSd66oIeVYZfc+e6FiKX1mj+f5NCFiVpMxa/JRxVX63tKEk/40sSWyxpwEiChe4KElU5TipR89oVKCFayoUghFM6Rmlsp0PEaOHOnGPHnUEqnlk5QW5v0w0//6WxWMf3k0S7xa30Up4d79Dx8+HPAc+jHoHZ9/6pYeM9SPS7Vs68fb8OHDQ46fVHCT3TTsUI738dXzrRR8b4kfj+6fl8+bWc+vKqcT2bJai1eVt3qWVLHp3PSnWaFDpVTq9dEswf5LRalBYcyYMSGDKZ1D3nmTVVqnZucNphm4NfYu+DyS7J4TmrFYlH7pT2m8b7zxhkvPzKpCzi1ez0VwJoKWsMqNJQo1S7lo1uXgz6T3WfX/7APxjHr5f6iXs37ecNXLmrVeP+o1Y/2x6k7Vv+qpVwO6VirQ0n5qwFImnn5w5lcdFIo6GTQfgWb+1xwZxzqWSKLXVO+TsnJCxUJq+PDG/qthXo1yWoVBP+A96tH3lh09lquuusplASpWCXUOetkBmb2P6lQJjuOQEZkEyFNaKkeTyoSi1nlNZuRPE7Mopdr78GbWW6FJZrSEkSaQ0X3UmqxgQD2oSiHWGrX+S9nklCoPpVtq/XqlSf7xxx82duxYl67kTXqkH4gqpwIntVTqh5omcdHSL7rea0XXl77+1vIyqsTV+q0fnHo8lde/9VXHpEmDFJRpuRtVaJpURimBGhuqH6v6UagUSS3ZpC9f9WQrENPSbaHWk82O4318LT+joE3jN5XKpfurggtegzi3nzdctJayeqBVIXrLZSkw1mRDah0PTue89dZb3fJcOtfVCKDKUxWjN1mWP71+SoFUJavxlZpwST1CqkQXLlzoeoG8niAFb+rhUxqdzg81QugzoTHA3sRc3nnkTZCl5cxUievzFTxBlUdl1OdVQbfOdT2PtwSiKtnnn3/+uLMTckKvq8qoAE6vmcYpKuVUz6/X+UQCbtFnVe+lXis9j94jfRdp3gkFmxpDrc9mfgw9AfIb9TL1cl48b7io4Ud1pMqhc1ST/+r91nmhOlXDYrwf3Xo99APRa/T2zltlFaheV/aA6ta8roMyo/NO56YaunSOa5iDGkI0xEfDHHQ+a0m/SKPPil4bfdb0OdJSkGog0uuk7ESdK3pv9P2iH+7/+te/3GdOw1iUvaMMBO2T3fkr9Hx6DN1X743OTS2BqDpcMZoafXTeamiTMgb1vaP4SXW65k9QFoHmHwmVcQM/4V5eAfG51FKoZeQ8o0ePdrcXLVrUt2vXrpD7LFu2zPfwww/7zjvvPLd8jZa/0f7169f33XPPPb6//vrrhJda0nPccccdbomalJQUX4MGDXwTJkwIeZ+ZM2e6ZYe0pIuWZdGSNFpex38pmN9//9130003uSVXSpQo4StcuLCvVq1avgEDBvjWrl0b8HgrV650SzVpWSfv9fK3fPlytxyMlu3RsZctW9YtDaUlafyXlPGWWspM8FJLx/v48sEHH7jb9BqVK1fOHaOWoMpsqSW9vpk5nucNFy3rp6WB9N7o/db7pCWBMlt26umnn3bL9Oh4tBzf8OHDfXPnzs2w/KC3BNBzzz3nO+ecc9xja0khLRXUpUsX36RJk9L3e/HFF33t27dPPzf1ul9wwQUB+3ieeuop9/xa4sr/9Q+1BKK37JX2qVOnjnvskiVL+i655BLfkiVLMjz28SzxGGqZwqzO0zVr1rglwsqXL+9ehzPOOMMt0ZjVcofHui7Y7Nmz3ZJLWi5K74++S1q1auUbOXKkex2AWEK9TL0cq/Xyvn37fI8//rirJ/Qe6rzT+3jttde610K0xJ+OtU+fPhnu/95777nl/rp165ajOiirpfMyqyczu4+WEr3//vt9devWdeetzjdd1tLE/ssoHm+derznW1aPn9l9VL6uXbv6KlSo4M4V/a+lGIcNG+bbunVrhvpXy2vqGHVOaXlHLWeYnSUQPYqlLr74YrdspM51LYeq99x/CUkt7al6XvsUKVLE16xZM9/06dNDvv4sgRgoQf/4NxoA8U49uZpoJ78msUNsUAu5ZtHVBgDIPdTLAJC/mJMAAAAAAAA4NBIAAAAAAACHRgIAAAAAAOAwJwEAAAAAAHDIJAAAAAAAAA6NBAAAAAAAwKGRAAAAAAAAOMn/+w85deDAAVu6dKmVK1fOkpN5OQEAsSUtLc02b95sDRo0sEKFClmsoj4HAMSytOOoz6kFT5ACiqZNm4a7GAAA5KklS5ZYkyZNLFZRnwMA4sGSbNTnNBKcIPU4eC92pUqVTuixdu7cadOnT3eXL7/8cktNTbVI5jt80DYNOCP97/JjvreEAgXDWiYAQO7auHGj+/Hs1XexKjfrc+pHxJJoi08BnHh9TiPBCfJSEhVQVK1a9YQe68iRI/bWW2+5y9dee+0JP15eUxCUXOT/prWoWLUqQRAAxKhYT8HPzfqc+hGxJNriUwAnXp/Hdo0fZVJSUuz0009PvwwAAACEE/EpEH9oJIgg6r144403wl0MAAAAwCE+BeIPjQQAEKf27t1r27dvd7PdIr4p9bBUqVJWtGjRcBcFAHCcqM8hSUlJbtWCsmXLWkJCgp2I/xswBwCIGwok1q9fb/v27Qt3URABdB7ofCDABIDoQn0Oz6FDh2zLli3ufPD5fHYiyCSIILt27bL333/fXe7UqZOVKFEi3EUCEKNUiWgyqpo1ax5zrVzEvgMHDtiqVavceVGxYsU8f75ff/3VRowYYYsXL7Yff/zR6tat6/73rF692p2boRQsWNCVN6v9zjnnHPfYAE4c8Wlkoz6Hv61bt9qmTZvceXEiqxLRSBBBlCb01FNPucstWrTgSxhAnrY268cWAQVE54HOB50X+WHZsmXuR4d+zB89etRtwWOgFy1aFHCdekUuvvhia926dYbHe/zxx61Vq1bpfxcvXjwPSw/EF+LTyEZ9Dn9lypSxHTt2pDem5xSNBBE2JtRbVibWl5oCEF76UZaYyIgz/B+dD8E/1vPKpZde6tZbl549e9pXX30VcLsC3mbNmgVc98knn7gezWuuuSbD49WuXTvD/gByB/FpZKM+R6i5CZRdciL4pEeQKlWq2IwZM8JdDAAA8lROAlrNrq4eTDUwAMg/xKdA/ImYZieNT7zpppusUaNGrpWyfv36Abdr3KFmaQy1+afXZLZfqB6GhQsXWvPmza1w4cJWvXp1l0p1opM8AAAig3qq27VrF+5iIBccPnzY3n77bbviiitCptTefPPNruekfPny1rdvX9u2bVtYygkAyH3U53HcSOCNT6xVq5adfvrpGW73xif6b/qRr16FDh06hByf6L/vuHHjMjRKtG/f3j2uWkdvv/12e/jhh23kyJF5epwAgLz3wQcfuAl7lIb+7rvvBtxWo0YNmz17dp48b79+/ezUU091PeVjx44NuM1rxC5WrFj6psbxzAwZMsQKFCgQsL82TUiU2XEoJd9/4sELL7zQ/ajW/TROUWP6V65cadFm1qxZ7od/8FADDUtQA8FLL71kH3/8sd1999321ltv2UUXXeQaFrKioQvr1q1L3zZu3JjHRwEAiJb6fPbs2XbGGWe4+rNx48YZ5smZMmWKnXLKKVakSBFX56xZsybTx9KwupSUlIC6XMsUehQbrFixIuA+r7zySkAnt45VHdu6rxrEr7rqKvvzzz8tr0TMcIP8Hp84fPhwFzBNnDjRvWl6czdv3myPPfaYDRgwwD1fftuzZ499+umn9uzHv1rRGg0sKaVwlvtP6t8838oGANFEs/pq9nz1Lr/zzjv59rwKKLp162YDBw7MsmzZnWDqyiuvdPXUiXjmmWdcY4SWx+rfv7/16tXLPvvssxN6zPw2YcIEq1Chgqur/amh/7nnnkv/u2XLllavXj275JJLbNq0aXb11Vdn+pijRo2yoUOH5mm5gVjgxafeZ0w/UpC5bs8H/pgMRvwe+fX5b7/95n6ET5061U2Wqx/sqld0fcmSJW358uXu96puP//88+3BBx909c0XX3yR6WPeeeed9uSTT55QuVSvqbFfjeZ6PjWMv/766xbTmQT5PT5RvRKdO3d2DQSe7t27u9kgg1uK8nPJCgWWG+eOtyP7doelDAAQKTZs2OC+l/XjsFSpUu472/87XD/IU1NT3Qz5/t/b6j3fvXu3q8g1y716INQCLz169LA//vjDpa0r0M3qx3xO/P3vf3c/ZCNxlmn1duj1/Pbbby3afqC89957rvFFQeKxdOzY0YoWLWpff/11lvspYFu7dm36tmTJklwsNRA7vPhUmy4DsV6fz5492w1Jb9u2rat3evfu7X5z6ke66Ie5fqxrCIR69x955BH7/vvvXWZ8fihdurQ77ryszyMmkyAvxicqoFC2gDIUNN+AXlDZu3evCwi0LrM//e2le+ikDEdDiU7yfYeOKO8k358fQPxy87Gk5c/yd05yivu+zYxm5VUDsAKGX375xVXCGmIm+ls97JMnT3bDxtRgrGFnGkbmn74XyptvvukCEA0FUAWfGQUkmVH2mn/v9fHSsDrNRn3BBRe4rLZq1apZflCgpR55PX80UVC2f//+kFmDJ0IBH0u5AdmPT73LiFz5XpfHaH3u8/kyzFOnv3/44Qd3+ccff7QmTZqk36YGDA090PXKZstryn7X7+C8rM+jtpHgWOMTdaLppFDah4YQaPiCegk0vlPZAqFOGmUVqKclqwmPNLxBmyc3xzAqUFQK6LHSlAAg16Udsj+vLZdvT1dxwmazApkP6/ryyy9t1apVLgDwMr6U5iqTJk1y3/GdOnVyf19//fWukp8+fbpr7c8NXj2RmxTw6Lg0Qa8e/7777nOBk3q8M+shVyqjf12lhm+lOx4P9ZjruVR3KYjxekKihYJGlVsBZnZoniF1BvgHcABOPD5FFMjnujxW6/O2bdvavffe635vtmnTxl5++WWXtaBhe16GW/DvSP2txvishv75z1WkeQ7mzZt3XOXq2rWra6jT85x11ln26quvWl6J2kaCvBifmB2MYQSAvKfK+KSTTgoYEuZZv359erqhR3/r+kimnrizzz47vcFAdZV6H9STEpzZ5unSpUumcxKo0Tt4cj79reuD6y3NSaCeGaXi6/kaNGhg4aRAa+bMme6yJntSA4YmgfLqbaWUer0lc+bMsfvvvz/k49x1110uYNIcRArQ1BnwxBNPuNfZP50VABAe0Vifn3rqqa6BWnWPss/1O1KNBVWrVk2vz3fu3BlwH/2tOj0zmiQ/szkJtLJfdupz1ZPKmlDnt+o4vU55lY0YlTlDJzo+0Wv5CX5zDx065AIXb1hCKIxhBIC8p4BCgUWoGeq1ZrdWCvCnv3W9uGFb/7+1X4Jn/80qLdITvKJAdlckOB7eEr05XXpXr5F6Z/z9/vvvbknfUJSWOHr0aPvHP/7h0vfDSSs0aFIobZqEWPWp97f/mE6tVJCWlpbpUAOthqRVDTQZowKn559/3vU+zZ071wVdAIDwitb6vHPnzm6eAWWYK5NAkxV6k+LXr1/fvvvuu4Dfpsry0/X5UZ+rIVxzMNxyyy05jiGOJSpr0BMdn6gGA7W6BC818fPPP7sXOrMenbwew6hj+uabb2zvH8utcKValphF6g4A5KrklP+lDObj82VFqeKqHNUwqyVtNfeMxjCql1kZYbpOaYBKCVRPu77PvRVylMKn1nYtR7h9+3YbM2ZMwGMrC+1YKfuq8HNCjc2ab0CbftweOHDA9QSoQVvD31R/qIdCPedKZdQP9zp16uToua699lo3nE4zLytjTq+BsgZuu+22TO+jsZ46fv2YVq9GuKinKDuBjSaC1JYZNQjkVkoqgKzjUznzzDPdmHJEqPyuy///c8Ziff7VV1+551dq/0MPPWQ1a9Z0ZZS//e1v7riU6XbeeefZ4MGDrWHDhjmej0D1+aOPPuoeQ6+VhmiMGzfOraqQGTWOa8JEDc3Ii8y5qMwkyI3xiQqU9KL6t2ppXIyyDFq0aGHh6llRMLTu/WctbW9glgMA5CXXq12gYP5tx2j9149qZYxp3peTTz7ZBQL/+te/3G36Ua0eZo2z1xh99Y6///776ZMc3XHHHW6WZA0/0+S2qnz9PfDAA/bPf/7Tfd8PGjQoV19Hb6bjBQsWuOV0dfm1115L7xXQuEulI6oxWr0Tqp+yyojTxETBPR/ebMY33nijqzM06ZMaHxRUKWg4VqaDXjdN5hvubAIA0cGLT7XpMiJXvtflMVyf33333e5x1ait7HPNEeQ57bTTbPz48a7xQhnoqpd1HFlRI35wfe6tFqKsADVAqNFfx6u6XEMTlA2fGc3Dp04BDYPPi2yCBF9e5SicwPjEf//7365VSC9mqPGJlStXdmNEhg0blu3xieq50YQZXvqhxmZq8iilJypVY+nSpa5XR70yOimya926dS4rQamS3jiVnNK4TK/lrGaPoZZSsnxEr7PqO3wwYHIUtVzqywJA5PPS+4LHAiJ+ZXZO5GY9F8ly8zipHxFL/ONTdbBllgKN/znWBOS5Hb9TnyMv6vOIGW7gjU/05/2tmR+9JQmzMz5Rk0G98MILruFBY1qUiqhWFv/xiUrx/PDDD13qi1pp1AihfdTIEC4aj6J5E3q8sJglEAEAABB2XnwqLIEIxIeIaSQIx/hEDStYvHixRQql6yglJ4EvYAAAAERQfAogfvBrFAAAAAAARFYmAcwOHjzo1q/ev2m1FSxdxRKTA9fGBAAAAMIRn0rt2rXdhGkAYhuZBBFEa39qSY0/3n7K0vZsD3dxAAAAEOe8+FRb8Dr1AGITjQQAAAAAAMBhuEEE0UoMH3/8sfX971eWVLBIuIsDAACAOOfFp1KiRIlwFwdAPqCRIIJoicbSpUtbcuHi4S4KAAAAkB6fInd0e37RMfeZ1L95vpQFyAzDDQAAAAAAgEMmQQQ5fPiwmxDm0M7NVqBYKUtI4u0BAABA+ONTqVixohUowOpbQKwjkyCCbNiwwS699FJb9cbDdnj3tnAXBwAiwuuvv26NGjWyIkWKWLly5axnz54BM2wnJCRY0aJFrVixYm7r0KFDWMsLALEYn2rTZSAnqMujC40EAICINXr0aLvjjjts2LBhtmPHDvv+++/tyJEjdt5559nOnTvT9/v6669tz549bps1a1ZYywwAAP4PdXn0oZEgglSuXNmmTZtmNboPtgLFmSAGQP5bs2aN2/bv3x9w/dq1a931qrj9rV+/3l2/a9eugOvVO6DrFQzklB7zoYcesjFjxrgerJSUFPc9+eqrr7rLCjoAAPkTn2rTZUS+vK7L//rrr2yXhbo8OtFIEEE0xqtmzZpWsFRF5iMAEBaXX36527788suA6//2t7+56z/55JOA62+66SZ3/bvvvhtw/T333OOunzBhQo7LsmjRIhfgXHnllQHXJyYmWteuXe2DDz5Iv65169ZWoUIF69Spky1btizHzwkACB2famM+guiQ13W5MgKyi7o8OtFIAACISFu2bLGyZcuGDEorVapkmzdvdpcV7Kxevdp+/fVXa9y4sbVr1y5DbwgAAMh/1OXRie7qCKKxOXv37rUjB/dZYoFClpBIGw6A/DV9+nT3f/ny5TNMOHT06FErU6ZMwPVjx461tLQ0K1WqVMD1w4cPt4MHD1pqamqOy6KgQsGFZtYODi42btzoJj6Sli1buv+Vtvjoo4/aa6+9ZgsXLrSLL744x88NAAiMT0UTyyUlJYW7SAhzXT5o0KBsl4W6PDrRSBBB1q1b51J6pGaPoZZSMvCDDQB5rXr16iGvr1atWsjrq1SpEvJ6LZN1opo3b26FChWyt99+27p3755+vQKcKVOmWJcuXULeTymMPp/vhJ8fABAYn+rHZ2b1BOKnLteQgOyiLo9OdFUDACJSiRIl7JFHHrEBAwbYjBkz7NChQ275rRtuuMFNoqTrNWbxm2++cT0g+/btsyFDhrixjwpKAABAeFGXRycyCSKIWuXGjx9vD09fZsnFSoa7OAAQdnfeeadLVRw4cKBdddVVduDAATdW8dNPP3XfmT/99JPdfPPNbsbmwoUL29lnn+0mQSpZku9QAMjN+NS7DBwv6vLoQyNBBFEqjj4wRZYcCHdRACBiXH/99W4Tzbzcq1ev9GWdWrVqZStWrAhzCQEg9uNT4ERQl0cXhhsAAKLGZZddZi+99JJbUgkAAEQf6vLIRyYBACCqdO7cOdxFAAAAJ4C6PLKRSRBB1qxZY2eeeab9PPYWO7RjU7iLAwBAntA62DfddJM1atTIkpOTrX79+hn2ufDCCy0hISHDFpySunPnTuvdu7eVLl3aihcvbl27dnXLagHI3fhUmy4DiH1kEkQYLQcCAEAs00zW77//vp1zzjmu3sus7jv33HNtxIgRAdfVqFEj4O9u3bq5x9M63xo7rYmxOnToYF999ZVrgABw4ohPgfhC7RlBypUrZ6NHj7Z/zl5hyUVLhLs4AGJYUlKSm134yJEj7jLim86Dw4cPux/Z+eHSSy9NX3e9Z8+e7gd9KJrZulmzZpk+jsazagZsbe3atXPXnXrqqXbaaafZ1KlT7eqrr86jIwDiLz71LiOyUJ/Dn84FLTNZpEgRi4lGAqUeqrdg8eLF9uOPP1rdunXd/8Gph1oqI9jy5cvd/v6ph1pqY9q0aS7oad++vY0ZM8YqVaoUcL+FCxfaXXfdZd99952VL1/ebrnlFrv33ntdOmM46M1s2bKlPbciJSzPDyB+pKam2p49e+z333+3AgUKhLs4CDPVlVqfWudFfkhMzJ3RjrNmzXINCW3btk2/To0EGsYwc+ZMGgmAXIxPEZmoz+Gf8XPw4EHXWFSqVCmLiUaC/E49VKOEGg8UWDz66KP2ww8/2P333+9e1LvvvjsPjxQAwq9EiRLpjarqfUB8U12pQNM7LyKFOgaKFi3qzlHFB8OGDbMLLrgg/XbNT6BGgeDGfWUSsJwWgHhAfQ6PfueqUa9s2bInPNwuYhoJ8jv1cPjw4VamTBmbOHGipaSk2EUXXWSbN2+2xx57zAYMGGAFCxbMk+MEgEgKLCLtRyHgUc+l1tSuXbu2bdiwwXUQtGnTxjUcNG/e3O2zfft2FxcEUw/Ktm3bsnz8Xbt2uc3DZIcAohX1OWJ2dYP8Sj30309Lb6iBwNO9e3fbsWNH2NbsXLdunbVq1cp+HX+PHdq1OSxlAAAgEgwdOtR69epl559/vssQ/OSTT6xy5coumyA3jBo1yqpVq5a+NW3aNFceF4g1XnyqTZcBxL6IaSQ43tRDpUaql2H+/PkBt2cn9XDv3r22du3agHkMRH+HWl4pvyhFSL0iRw7sMTvqC0sZAACIRKr7O3XqZF9//XVAxoBSbIOpLtWSiFnR3EWKBbxtyZIleVJuINp58amLUUlnB+JCxAw3yM/UQ2ULSPB+yirQOI6sUhTzMj1Rwx/Uc/KfT36zpCLFc+1xAQCIRWrcnzNnjvl8voDOATX2N2jQIMv7kp4LHF986l0GEPuiqpHA+4LyXHLJJVavXj2Xeug/lCAvKT0xuBy5pVixYm5ehjf+DM9wBwAAIpWyAGfMmGFNmjRJv06TEisGmDt3rus0kJUrV9q3335r9913XxhLC8QOLz4FED+iqpEgs9TDKVOmBGQMKG0wq9RDL4MgOEVRa0ru27cvyxRFpSf26dMnIJOAcYwAAGSf6lqvcX/NmjUuQ8+ry5U1qEwATTB8xRVXuBWMlD04cuRI+/PPP23y5Mnpj6MsQq1UpLkLdLu3olHDhg2tS5cuYTs+AACiWVQ3EuQ09VCNC5qkKHjugZ9//tndL3iuAn+kJwIAcGI2bdpkV111VcB13t/z5s2zqlWruob7Bx980LZu3erq7RYtWriljYMb5idNmuQa8Pv162dpaWluZaMxY8ac8PJPAADEq6ibuDA7qYfKGlDqocdLPezYsWPAftOnT7fDhw8HBBrKMlAgEg7r1693Ky6senOIHd61NSxlAAAgryk7QI3yobYLL7zQatWqZbNnz3bZemosUL3+/vvvh8zcS01NtXHjxrl9du/ebW+//bZbBQFA7san2nQZQOxLjtfUw3vuuccmTJhgPXr0sFtuucWWLl3qHv+xxx4LWBYxP6kHZPXq1e6y7yizxwIAACC8/ONTXQYQ+5LjNfVQvRQffvih208ZBuXKlXMTEt51110WLppPQeV5bdEaSypcNGzlAAAAAPzjU+8ygNiXHGmph1lR6mF2eKmH2rKiRobFixdbpNBcB1ri8f39rG4AAACAyIlPAcSPqJ6TAAAAAAAA5B4aCQAAAAAAgEMjQQTRJIw33HCDrZk23A7v2Rbu4gAAACDOefGpNl0GEPsiZk4CmB08eNC+//57d9nH7LEAAACIoPhUlwHEPhoJImximN69e9u0b9dbYsEi4S4OAAAA4pwXn3qXAcQ+GgkiiJaVGTBggH32PKsbAAAAIHLiUwDxgzkJAAAAAACAQyMBAAAAAABwGG4QQTZt2mSPPvqorVuz3Sq2vMaSi5YMd5EAAAAQx7z4VB566CErX758uIsEM+uWjeHJk/o3z5eyIPbQSBBB9u/fb/Pnz3eXjx4+FO7iAAAAIM75x6e6HM+y88MciAU0EkSQ4sWLW9euXe2jn/6yxJRC4S4OAAAA4pwXn3qXAcQ+GgkiSOnSpV0a11JaKQEAABBB8SmA+EEjAQAAAIC4xlAC4P+wugEAAAAAAHDIJIggW7ZssdGjR9vGlZutXLPOllwkNdxFAgAAQBzz4lO57bbbrGzZsuEuEoA8RiZBBNm7d6+99957tuvnxXb00MFwFwcAAABxzotPtekygNhHJkEEKVKkiLVp08YW/77NEgsUDHdxAAAAEOe8+NS7jNiZZ2FS/+b5VhZEFxoJIki5cuVsxIgRTJwCAACAiIpPAcQPGgkAAAAAIELQYYhwY04CAAAAAADgkEkQQbZt22bjx4+3TT9ssNKN21ty4eLhLhIAAADimBefyo033milS5cOd5EA5DEyCSLI7t277bXXXrPt38+1owf3h7s4AADkiV9//dVuuukma9SokSUnJ1v9+vUDbt+1a5cNGTLEmjZtaiVLlrQKFSrYpZdeakuXLg3Yb/Xq1ZaQkJBha9asWT4fERD78ak2XQYQ+8gkiCCFChVyAdGP63daQnKBcBcHAIA8sWzZMnv//fftnHPOsaNHj7rN3x9//GHPP/+89e7d2x599FE7cOCAmzhNP/6/+uorO+200wL2f/zxx61Vq1bpfxcvTiYekNvxqXc5EjGLP5C7aCSIIOopeeGFF5isBAAQ05QVcPnll7vLPXv2dD/8/dWsWdN+++23gOXWWrdubdWrV7fnnnvOxowZE7B/7dq1yR4A8jg+BRA/kiMp9VC9BIsXL7Yff/zR6tat6/73Tz0cNWqUzZw501auXGkFCxZ0rZrqPWjQoEFA6qGCi2DqrdBj+1u4cKHddddd9t1331n58uXtlltusXvvvdelKgIAgLyRmJj1aMeiRYtmuK5YsWJWq1Yt27BhQx6WDEAsogMOiNI5CbzUQwUAp59+eobbvdTDdu3a2VtvvWUvvvii7dy50/UcLF++PMP+ajxYtGhR+jZu3LgMjRLt27e3SpUq2YwZM+z222+3hx9+2EaOHJmnxwkAAI7fjh07XOdB8FADufnmmy0pKck1+Pft29dNtAYAAKI8kyC/Uw+HDx9uZcqUsYkTJ1pKSopddNFFtnnzZnvsscdswIABLlMhv6nRQw0gW79eayXrXWBJhTL2pAAAEI+8TD9NeOhRXa0GAjX6a4LDL774wtXjiiGWLFliBQpkPr+PMhS1eTZu3JjnxwBEIy8+lauvvtpSU1PDXSQA8dJIkN+ph7NmzbIuXbq4BgJP9+7d7YknnnCZBxdeeKGFo5fk3//+t7tc/JSzaCQAAMDMLb+mDMJXXnnFqlatmn69sgHVUeBp2bKl1atXzy655BKbNm2a+0GTGQ1hHDp0aJ6XHYh2/vGpMnppJABiX8QMN8jP1MO9e/fa2rVr3bwH/vS3eilWrFhh4aAejzp16ljBMlUtISkpLGUAACCSqFG/X79+NmjQILvhhhuOuX/Hjh1dx8LXX3+d5X533nmniwW8TZkHADKPT7VllZ0DIHZETCZBfqYeqnFBdLs/ZRVoOENWYxnzMj2xcuXKLp2LyVUAADA34XDXrl1d48AjjzySq49dokQJtwHIXnwKIH5EbSNBXqQeZgfpiQAA5L2ffvrJOnXq5OYfGjt2bLbvp8mIlTHYpEmTPC0fAACxKjneUg/VSOBlEGgiFn+HDh2yffv2WenSpbNMT+zTp09AJoGWYgQAANmjulZLGsuaNWtcht6UKVPSG/d9Pp/LCCxcuLDdcccdAZMZq/ffWwVJyxhrTiNNVKy6XRmDmlvo7LPPts6dO4fp6AAAiG7J8Zh6qAaDatWqZZh74Oeff3aBSfBcBfmVnqgg6YMPPrAdy3634rXOtqSC/7eSAwAAsWLTpk121VVXBVzn/T1v3jz3/7p169z/Wn3InxoRPvnkE3dZjQXKHnzhhRdcw0OVKlWsd+/eLuMvOTnqQhwgInnxqajxjmE6QOxLjtfUww4dOtj06dPtn//8Z/okLJMmTXI9ES1atLBw2L59u5s/QYpUqUsjAQAgJtWoUcM1ymflWLeLGgS0Acif+FTZszQSALEvOV5TD++55x6bMGGC9ejRw2655RZbunSpDR8+3H0J+i+LmJ/U61GhQgXbuueQ1oQMSxkAAACA4PjUuwwg9iXHa+phrVq17MMPP3RzDGjOgnLlyrl91MgQLiqr0rlY3QAAAACRwItPAcSP5HhOPdSwAs1xAAAAAAAAzMhpBwAAAAAAkZVJAHOTK37++ee2+7eVVrRaPUtMKRTuIgEAACCOefGpnHvuuW6VMACxjUaCCLJlyxa799573eWaPYZaCo0EAAAAiJD4VCuD0UgAxD4aCSJIQkKCFSpUyA6mHTVLCHdpAAAAEO+8+NS7DCD20UgQQU466SQ3kSKrGwAAACCS4lMA8YOJCwEAAAAAgEMjAQAAAAAAcBhuEEH2799vP/zwg+1dt8IKVzjZEgukhLtIAAAAiGNefCoNGza0woULh7tIAPIYmQQRZNOmTda/f39b995oS9u7I9zFAQAAQJzz4lNtugwg9tFIAAAAAAAAHIYbRJBq1arZF198YX976QtLSEoKd3EAAAAQ57z4VAoUKBDu4gDIBzQSRJDExEQrWLCgJSbzBQwAAIDIiU8BxA+GGwAAAAAAAIdMgghy6NAh+/333+3AlrWWUqqiJSaRUQAAAIDwx6dy8sknW0oKq28BsS7XMgk+//xze+mll+znn3/OrYeMOxs3brTu3bvbmsmPW9ru7eEuDgAAAOKcF59q02UAsS9HmQTXXHONG5s0fvx49/fYsWPtlltucZd1/YwZM+yiiy7K3ZICAAAAAIDIayT47LPPbMSIEel/P/HEE9anTx8bNWqU3XzzzTZ06FAaCXKgSpUq9sEHH9jNr39jyUWKh7s4AAAAiHNefCplypTJ9+fv9vyifH9OIN7laLjB5s2brVKlSu7ysmXLbO3atXbbbbdZsWLF7IYbbrClS5fmdjnjQnJyslWoUMEKFCtpCYksgQgAAIDIiE+16TKA2JejRgK1Iq5Zs8Zdnj17tmswqFevnvv7yJEjdvTo0dwtJQAAAAAAyHM5ag7s0KGD3Xffffb999/bK6+8Ytddd136bT/++KPVrFkzN8sYNw4fPmxbt261w3u2WXLhVEtIIpsAAAAA4Y9PvY7CAgVYfQuIdTlqJNB8BMoYUBZBx44dbciQIem3TZs2zS6++OLcLGPc2LBhg11++eXucs0eQy2lZPlwFwkAAABxzD8+nT59ulWvXj3cRQIQicMNUlNT7eWXX3ZzD7z66qtWokSJgEkNn3zyydwsIwAAiCG//vqr3XTTTdaoUSM3xrl+/foh9xs3bpzVqVPHChUqZGeccYZbPSnYzp07rXfv3la6dGkrXry4de3alWXaAADI70YCz/bt223BggX2xhtvuMty4MAB5iTIIc3tMHnyZKtx9UOWXLxUuIsDAECe0KTH77//vtWqVctOP/30kPtMnDjR+vbta926dbNZs2ZZ8+bN7YorrrDFixcH7KfbP/zwQ7cc84QJE+znn392wyLT0tLy6WiA+IhPtXkTlwOIbTlqJPD5fPbggw9atWrVrGXLlm5OglWrVrnbunTpYsOGDYuKXoWFCxe6oKNw4cIudeqpp55yxxYuKSkpVrt2bStYpoolJjHeCwAQmy699FK3MtKUKVPszDPPDLnP4MGDrXv37i6maNWqlWsEaNKkiT3yyCPp+yxatMgtzabY4Oqrr7bLLrvMPeYPP/xgU6dOzccjAmKXF59q02UAsS9HjQSDBg2yZ5991kaOHGkrV64M+GGtCvq9996L+F4FNUq0b9/etYiqoeH222+3hx9+2B0TAADIO4mJWYcfv//+u4sv9MPfnxoN5s6dawcPHnR/KxYoWbKktW3bNn2fU0891XU4zJw5M49KDwBAbMvRxIVa0eDxxx+3/v37uwkM/Z1yyin222+/5ahXwZsUpWfPnvbVV19l2asg6llQb4F6FbxgwOtV0NauXbv0gOG0005zvQpewDF8+HA3Q6saHtQqetFFF9nmzZvtscceswEDBljBggUtv2mYhgKfo4cPWkJyAUtIOKHRIAAARKUVK1a4/+vWrRtwveryQ4cOuexF3ab9VMcnJCRk2M97DAC5E5+K4uNjNfIBiH45+pRrGRRVwKGo0UBLpUR6r4L269y5c0DalB5rx44drqEhHJR6qeyIX1663Q7v3BKWMgAAEG7ePEeqz/2VKvW/+Xq2bduWvl/wPt5+3j6Z2bVrl61bty59Y7JDIOv4VJsuA4h9OWok0JwAH330UcjbPvnkk0znE8jrXgVvv2P1Kuzdu9d9yQU/lv7W/eh9AAAgto0aNcrNreRtTZs2DXeRAACI3uEGd9xxh5sboECBAm5SQFErvHrg//Wvf7nhCJHcq6BsgVCPpayCIkWKZNn7oJ4HbZ7c7HkoX768vfjii/bIez9ZctGMxwAAQDzw6nZNRFyxYsUMsYAmJvb2C9Wzqf28fTJz5513Wp8+fQLqcxoKgMzjU+8ygNiXo0YCzRmgH9JDhgxxcxOIUveLFi1qjz76aIYhAbHW8zB06NA8eWytsqCZm4t8w7JNAID45WX6edmBHv2tBv2TTz45fb85c+a4CZT9Mwi1X4MGDbJ8jhIlSrgNQPbiUwDxI8czj6gFfsOGDW5s/+uvv+7G+yubQNfnda+Cv1C9CsH7ePt5+3gZBMH7adjCvn37sux90PGp18LblixZcsLHBgAA/o8aATS0Ueuy+5s0aZKbaNibT0grF6l+19xEHs1f9O2331rHjh3zvdwAAMRtJoGnWLFi6SsIRFOvgjIeNP4weO4BLZWo+wXPVeCPngcAAE6MGuS9yYTXrFnjhvFNmTLF/d2yZUsrV66cy1a89tpr3apJWs1IDQRffPGFzZ8/P/1xNJGaljPu1auXW8K4UKFCNnDgQGvYsKF16dIlbMcHANGg2/PHnqx9Uv/m+VIWxEAjwX//+98sVylITU21M844w0466STLi14Fb6nEzHoVtESiehXatGkT0Ktw3333pd9P+02fPt3++c9/urkVvMdSlkGLFi0sHP744w83x8PhI0etRrdBlpLKuC8AQOzZtGmTXXXVVQHXeX/PmzfPLrzwQuvRo4drTHjyySfdpg6CadOmuYYBf6q7leXXr18/S0tLc50XY8aMseTkE+oHARAUn4oa83IzvgcQY3MSeL306nn3+F+ny5qn4LXXXnOTAUZar8I999xjEyZMcEHILbfcYkuXLrXhw4fbY489FrAsYn7S66YhD//7IyxFAAAgz9WoUSMgfshM79693ZYVdUyMGzfObQDyNj7NzucWQJw2EnzzzTducsIbbrjB9eprplP1CqiFX1kGY8eOtdWrV7uW/fvvv9+teBBpvQq1atWyDz/80O2ncYtqhNCEhHfddZeFi8owYsQIG/Xhz5ZclCENAAAACC8vPvUuA4h9OWokUNq+lkBUb7xHDQX169e3ggULuhUPlO6/ZcsW9+M8O40E4ehV0LCCxYsXW6RQxoWGSLz4W9FwFwUAAABIj08BxI8crW7w2WefWaNGjULe1rhx4/Qf3lpvePPmzSdWQgAAAAAAELmNBEo1evvtt0PepokFvVSk3bt3py83CAAAAAAAYnC4wQMPPGA333yz/f7773bppZe6RgFlDGi1gI8//tjNSSC6rGwCZM+6devsxhtvtO37Dlm1zndZSgnGfQEAACD88amMHz/eqlatGu4iAYjERoL+/ftbpUqV3EoAmuhPkwNqUkANNVBDgRoOZPDgwenLC+LYjhw58n/DM44yeywAAAAiJz7VZQCxL8eLCF922WVuO3r0qPviUDZBYmLg6IVSpUrlRhnjRunSpW3QoEH2wvzfLalw8XAXBwAAAHHOi0+9ywBiX44bCTxqGKhQoULulCbOFS9e3K688kp7a8uicBcFAAAASI9PAcSPHDcS7Nixw6ZMmWIrV660AwcOBNyWkJBgo0ePzo3yAQAAAACASG4k+OWXX6xFixZ28OBB27t3rxtqsG3bNjc3gYYYpKam0kgAAAAAAEA8LIF455132jnnnGN//fWX+Xw+mzlzpu3fv99ef/11l5KkZRBx/DZs2GBdu3a1VZOG2eHdW8NdHAAAAMQ5Lz7VpssAYl+OMgmWLFli48aNs4IFC7q/Dx06ZElJSXbNNdfYli1b7NZbb7XPP/88t8sa8w4fPmy//vqru+xj9lgAAABEUHyqywBiX44aCTTMoESJEm7SQs1y6t+qWL9+fXvggQdys4xxo2TJkq6B5Y0v/rCkQkXDXRwAAADEOS8+9S4DiH05aiSoU6eOrVmzxl1u3LixPffcc9a2bVtLTk62559/3ipXrpzb5YwLmsuhV69e9sFhVjcAAABA5MSnAOJHjhoJunfvbt99951dd911NmzYMGvfvr2bsFCrGmiOgldffTX3SwoAAAAAACKvkUATF3qaNWtmP/74o82ePdtNXti6dWs35AAAAAAAAMT46gYHDhxw45K+/PLL9OuqVatmffv2ddfTQJBzWi2id+/e9sf0UXZ4z/ZwFwcAAABxzotPtekygNh33JkEhQoVspdfftmuvPLKvClRHFMDzNdff+0u+9KYPRYAAACRE5/qMoDYl6PhBi1atLDFixdby5Ytc79Ecax48eJ2/fXX23vfb7DEgoXDXRwAAADEOS8+9S4DiH05aiR45JFH7Nprr7WkpCTr2LGjVahQwU1a6E9LI+L46DXTfA9fPM/qBgAAAIic+BRA/MhxJoHce++9dt9994Xc58iRIydWMgAAAAAAEPmNBJqTIDhzAAAAAAAAxGEjQc+ePXO/JLBNmzbZU089Zet/32oVzu9myUVLhrtIAAAAiGNefCrKIC5fvny4iwQg0pZARN7Zv3+/zZ071/as+s6OHj4U7uIAAAAgznnxqTZdBhD7sp1J0LBhQ3vjjTesfv361qBBg2MON/jhhx9yo3xxpVixYta5c2ebt2KTJaYUCndxAAAImwsvvNA+/fTTkLe9+eab1r1790z3Wb58udWtWzcfSgnET3zqXc5N3ZisG4juRoKzzjrLihYt6i6fffbZWe6bV/MV5GbAsHPnTjdT67Rp0+zw4cPWvn17GzNmjFWqVMnCpUyZMjZkyBBbzhcmACDOPffcc7Zr166A65555hl7++23rU2bNunXnXvuuTZixIiA/WrUqJFv5QRinRefAogf2W4kGD9+fEAjwKBBg6xmzZoZ9luzZo0NHTrUIj1g6Natmy1btszGjh1rhQoVsoEDB1qHDh3sq6++suTkHE3VAAAAcsnpp5+e4bolS5ZYu3btrGzZsunXlSxZ0po1a5bPpQMAIHbl6Nfwq6++ajfddFPIRoItW7a427UCQqQGDIsWLbIPPvjAbbqvnHrqqXbaaafZ1KlT7eqrr871sgMAgJxbuHChrVq1yh599NFwFwUAgJiWo0YCn8+X6ZCCX375xaUlRXLAMGvWLNeQ0LZt2/Tr1EjQqFEjmzlzZtgaCbZu3WrPPvus/blik5VtepklFykRlnIAABBpNC+Shj1efvnlAddriKGuP3LkiJ1zzjk2bNgwu+CCC8JWTiDWePGp/OMf/ziuOJ85B4AYbyT4z3/+4zZRA8E111xjhQsXDtjnwIEDtnr1arvqqqsskgOGFStWuEaB4IYOZRLotnDZs2ePmyNBSjdqZ0YjAQAAlpaWZm+99ZZddtll6fMjScuWLe3666+32rVr24YNG9xQQw0/VBzQvHnzLB9Twxf9hzBu3LgxT48BiFb+8amWQc+vzkAAUdBIULlyZTd5ofz444/uR3a5cuUC9klJSXE/tHv37m2RHDBs377dZRIEK1WqlG3bti1sQYUaXTTx4lert1tigZRce1wAAKLZRx99ZJs3b3YdFP6C50C65JJLrF69eq5zQJmBWRk1alSezaEExBIvPvUuA4h92W4kUG+9f4/9ww8/HHJOgmgOGLIjL4OK8uXLu4kYSc0CACAwc1C9l1qJKCvqNOjUqZNNmTLlmI+pFY769OkT0OjftGnTXCkvEEu8+BRA/MjRnAT+Kx1EY8CgjIG1a9dm2FcZBqVLl87y8QgqAADIP/v377d33nnH/va3v1mBAgVy7XFLlCjhNgAAECg5HgOGunXr2pw5czJMwKj5CBo0aJDlfQkqAADIP++++64bEx2cORjK3r17bcaMGdakSZN8KRsAALEo0eIwYOjQoYPLGpg7d276dStXrrRvv/3WOnbsaOGiMo0ePdo2L55mafv3hK0cAABECmUOnnTSSXbeeecFXL9gwQI3L5GyG+fNm2cTJkyw888/3/788083JBJA7san2nQZQOxLjrWAYfjw4XbFFVdYjRo13MSFI0eOdAHD5MmT0/fTBIYaptCrVy93e6FChWzgwIHWsGFD69Kli4WLJkT0hnKk1j3XrHCxsJUFAIBw0w+S2bNn2+23355hRaJKlSrZoUOH7MEHH3RLtGl4YYsWLWzs2LEMAwTyKD7t3LmzG7YLILYlx2vAMGnSJDe/QL9+/dxKCe3atbMxY8ZYcnL4XpKCBQta48aNbcXGXZYQxnIAABAJ9GPk4MGDIW+rVauWiwcA5E986l0GEPuS4zVgSE1NtXHjxrktUlSsWNG11LK6AQAAACIpPgUQP6JyTgIAAAAAAJD7aCQAAAAAAADROdwg1ieGmTp1qm37do2lnn6uJRUsGu4iAQAAII558alogm+WAgdiH40EEUSTMj7zzDPucrGajWgkAAAAQMTEp61ataKRAIgDNBJEkAIFCtjJJ59s67bvt4SkpHAXBwAAAHHOi0+9ywBiH40EEaRy5counYvVDQAAABBJ8SmA+MHEhQAAAAAAwKGRAAAAAAAAOAw3iCC7d++2OXPm2I7lv1nxk8+0pIKFw10kAAAAxDEvPpU2bdpY8eLFw10kAHmMRoIIsm3bNhs6dKi7XKRSbRoJAAAAEDHx6ZlnnkkjARAHaCSIIElJSVamTBnbse+wWWJCuIsDAACAOOfFp95lALGPRoIIUrVqVZs7dy6rGwAAACCi4lMA8YOJCwEAAAAAgEMjAQAAAAAAcBhuEEH27dtnixcvtt2rfraiVetaYoFC4S4SAAAA4pgXn0qzZs2sSJEi4S4SgDxGI0EE2bx5s915553ucs0eQy2lJI0EAAAAiIz4dPr06Va9evVwFwlAHqORIMIkJydb2tGj4S4GAAAAkB6fAogffOIjiFpmv/rqK1Y3AAAAQETFpwDiBxMXAgAAAAAAh0YCAAAAAADgMNwgghw4cMB++ukn27fhFytUvrolJqeEu0gAAACIY158KqeffroVKsTE2vEkO8OgJ/Vvni9lQf4hkyCC/PXXX9arVy9bO32Upe3ZEe7iAAAAIM558ak2XQYQ+2gkAAAAEeeVV16xhISEDNv9998fsN+4ceOsTp06rnfzjDPOsBkzZoStzAAAxAKGG0SQatWq2eeff249X15iCQUYagAAwOzZsy01NTX97ypVqqRfnjhxovXt29cGDhxorVu3tkmTJtkVV1xhCxYssGbNmoWpxEBsxqdSuHDhcBcHQD5IjNdehZ07d1rv3r2tdOnSVrx4cevatatt3LjRwikxMdGKFi1qiSmFLCEhqt4aAADyxFlnneV+8HubfrB4Bg8ebN27d7dhw4ZZq1atbOzYsdakSRN75JFHwlpmIJZ48amLUROJT4F4kByvvQrdunWzZcuWuYBCjQnav0OHDm4d2OTkqHxZAACIG7///rutXLnSnnrqqYDr1Whwzz332MGDB61gwYJhKx8Q67IzoR2A6JQcrb0KZcuWDXmbf6+CqGfhhx9+cL0KM2fOdNctWrTIPvjgA7e1a9fOXXfqqafaaaedZlOnTrWrr77awuHQoUP2xx9/2MFtG6xAajlLTCoQlnIAABAp6tWrZ1u2bLHq1au7ToB7773XkpKSbMWKFe72unXrBuyvulz16apVqzLcBiDn8amcdNJJlpLCkFgg1kVlI8GJ9irMmjXLSpYsaW3btk3fR40EjRo1cg0J4Wok0HAHDXuQmj2GWkrJ8mEpBwAA4VapUiUbOnSonXPOOW5o4bvvvmsPPfSQrV+/3p599lnbvn2720/1ub9SpUq5/7dt25bl4+/atcttnnAPOQQilX98On36dNdgBxxPVglLJEaf5HjsVdB+ahRQ0BG8n/cYAAAgfNq3b+82jzL/NGna008/7YYInqhRo0a5RggAABDFjQS51aug/YL38fYLZ89D5cqV7f3337cBb3xryUUzlg8AgHimTL8RI0bYd999l163ayLiihUrpu/jxQKamDgrd955p/Xp0yegPm/atGmelR2IVl58KuXLk+UKxIOoaiTI616FcPc8FChQwE3CWKDE/8Z9AQCA0LysQS870KO/NWb65JNPzvL+JUqUcBuA7MWnAOJHYiz0Khw5ciRDr4K/4F4F7Re8j7dfdnoe1q5dm74tWbIkF48GAABkRisYaXhh48aNXSOAljuePHlywD5a1eiiiy5icjUAAOIhkyC3ehW035w5c8zn8wXMS6D9GjRoELaeh7S0NNuxY4el7dtpSYWKWUJiUp48DwAAkU6Zg1rK2KuXNcTwhRdesNtuuy19eMGQIUPs2muvtVNOOcWtZqQGgi+++MLmz58f5tIDscOLT0XDdVkqHIh9ifHYq9ChQweXNTB37tz0fbQqwrfffmsdO3a0cNHcCm3atLHfXr3fDu/aGrZyAAAQbmrQHzdunJtVvUuXLrZw4UJ75pln3LA/T48ePezFF1+0N954wzUqfP755zZt2jRr3pyZtIHcjk+16TKA2Jccj70KCh70WL169bKRI0daoUKF3JwGDRs2dIEIAAAIr9GjR7vtWHr37u02AAAQh40EXq/CunXr7OjRoy5rQL0KAwYMCOhV2Ldvnz355JNu07CDUL0KajzQ/AL9+vVzaVSaBHHMmDFhTaFSQ4d6Qx6Y+oMlF/vf/AoAAABAuONT7zKA2Jccr70KqamprsFBW6QoWLCgnX766VZoQcZJFQEAAIBwxacA4kfUz0kAAAAAAADiMJMg1mm1BQ198B05YpaYGLDyAgAAABCu+FQ0LJf4FIh9ZBJEkD/++MOaNGliK1/4hx3euTncxQEAAECc8+JTbboMIPbRSAAAAAAAAByGG0SQ8uXL23/+8x977P3llly0ZLiLAwAAgDjnxafeZQCxj0aCCFK4cGG3VGPRH8JdEgAAAOD/4lMA8YPhBgAAAAAAwKGRAAAAAAAAOAw3iCCaMbZ79+62//ARq3HVg5aSyrgvAAAAhD8+lYkTJ9pJJ50U7iIhynR7ftEx95nUnyEtkYRGgghbh3bfvn3//49wlwYAAADxzj8+1WUAsY9GgghStmxZe/LJJ230nJWWXKREuIsDAACAOOfFp95lALGPRoIIUrRoUbv44ott/JrUcBcFAAAASI9PAcQPJi4EAAAAAAAOjQQAAAAAAMBhuEEEWb9+vfXp08c27zlo1S67w1JKMO4LAAAA4ZuN/tCuLbb23afdZeJTID7QSBBB0tLSbOPGjf/74+jRcBcHAAAA8e7oUUvbvS39MoDYRyNBBClVqpTdf//99vLnqyypcLFwFwcAAABxTjFp+fO7pV8GEPtoJIggJUqUsO7du9u0nf+X4gUAAACES1LBIlaq/oXhLgaAfMTEhQAAAAAAwKGRAAAAAAAAODQSRBBNWtijRw9bPflxO+xNEAMAAACEiWJSxabEp0D8YE6CCHLo0CFbvny5u+w7khbu4gAAACDOKSY9uGVt+mUAsY9MggiSmppqt9xyi5VpcqklFSoS7uIAABA2kydPtssvv9yqVq1qRYsWtUaNGtnLL79sPp8vfZ8LL7zQEhISMmwrVqwIa9mBWKKYVLEp8SkQPxLjNWDYuXOn9e7d20qXLm3Fixe3rl27unT/cCpZsqT169fPyp7d0ZIKscQMACB+jRo1yooUKWIjR4609957zzp06GB9+/a1Rx55JGC/c8891xYtWhSw1ahRI2zlBmKNYlLFpsSnQPxIjraAQRW/AoZy5crZRx995AKGtWvX2uDBgwMChhEjRgTcNzhg6Natmy1btszGjh1rhQoVsoEDB7oA5KuvvrLk5Kh6WQAAiDlqGChbtmz6361bt7atW7e6WGDQoEGWmJiY3sDerFmzMJYUAIDYkhyPAYN6GT744AO3tWvXzl136qmn2mmnnWZTp061q6++Oh+OBgAAZMa/vvc0btzYXnzxRdu7d6/LAgQAAHE+3CCzgGHXrl0uYMiuWbNmuYaEtm3bpl+nRgINX5g5c6aFy19//WX9+/e3te+NtsN7toetHAAARKLPPvvMqlSpEtBA8Omnn7ohiMoKbNmypc2fPz+sZQRijWJSxabEp0D8iKpMguMNGI4cOWLnnHOODRs2zC644IL02zU/gRoFNFeBP2UShHOyowMHDtgXX3zhLvvSDoetHAAARGJ9P3HiRDfk0KNGgeuvv95q165tGzZscEMN27Rp4+KA5s2bZ/l46mDQ5gn3vERAfun2/KLj2l8x6b51/4uPiU+B+JAcjwHD9u3bXSZBsFKlStm2bdvCFlSooeOaa66xWUs3WmLBwrn2uAAARLN169a5uYRatWplt956a/r1Q4cODdjvkksusXr16rnOgWNlBmqoYvD9AWSkmLRUg1bplwHEvqhtJMiLgCE78jKo0EoL9957r319nC28AADEqh07driJhcuUKWNvv/12+vxDoSiLsFOnTjZlypRjPu6dd95pffr0CWj0b9q0aa6VG4gVyYWLW/nzmK8LiCfJ8RgwKGNAKyIEU4aBfqhnhaACAID8sX//ftfYr2WLNelwampqrj12iRIl3AYAiI5hMJP6Zz2MDHHcSJAbAUPdunVtzpw55vP5AuYl0HwEDRo0yPK+BBUAAOS9tLQ0t9rQ8uXLbcGCBW7+oWPRJMYzZsywJk2a5EsZAQCIRYnRGjDMnj07xwGDshCUNTB37tz061auXGnffvutdezY0cJl8+bNdt9999mGj16ytL07w1YOAADC7ZZbbnH198CBA91cQIsXL07fDh486BoOLrvsMhs/frzNmzfPJkyYYOeff779+eef9vDDD4e7+EDMUEyq2JT4FIgfydEYMGiiQi9g8F8KccmSJTZ8+HC74oorrEaNGm7iQu2rgGHy5Mnp+2oCw/bt21uvXr3c7Vo2SUFIw4YNrUuXLmE6OrN9+/bZBx984C6XbXJZ2MoBAEC4ffjhh+7/u+66K8Ntq1atskqVKtmhQ4fswQcftK1bt7rhhS1atLCxY8cyDBDIRUcPH7Tdv37tLhOfAvEhOV4DhkmTJrn5Bfr16+cyFNq1a2djxoyx5OTwvSTe/AkLftlsiSkFw1YOAADCbfXq1cfcR1mFAPKWYtISdf4XRxOfAvEhOV4DBs1lMG7cOLdFirJly9pjjz123OvXAgAAAHkhuUiqVbroxnAXA0A+iqpGAgAAAACZo7MJQFxNXAgAAAAAAPIOmQQRZNu2bW7+hL+W/Wllzu5kyUVYahEAAADhk7Zvl2396n13mfgUiA9kEkSQ3bt321tvvWU7ls23o4cOhLs4AAAAiHOKSRWbEp8C8YNMggiipRjPO+88+/aPHZaQnBLu4gAAACDOKSYtelL99MsAYh+NBBGkQoUK9uyzzzLhDAAAACJCgWIlrWqnv4e7GADyEcMNAAAAAACAQyMBAAAAAABwGG4QQXbs2GETJkywLd+ss1INW1tSoWLhLhIAAADi2JEDe2z7Dx+7y8SnQHygkSCC7Ny501588UV3uUSdZnwJAwAAIKyOHNhnW7+e5S4TnyKcsjNv26T+zfOlLLGORoIIUrBgQWvQoIH98tduS0jmrQEAAEB4KSYtVL5G+mUAsY9PegSpWLGivfbaa6xuAAAAEGcitZe0QLHSVv3K+/L9eQGEDxMXAgAAAAAAh0YCAAAAAADgMNwgguzatcveffdd2/b9akut28ySChYNd5EAAAAQx44c3Gs7Vyx2l4lPgfhAI0EE2b59u40YMcJdLla9AV/CAAAACKsj+/fa5oVT3GXiUyA+0EgQQZKTk61atWr2564DlpCYFO7iAAAAIIKEY3JrxaQFUsulXwYQ+2gkiCBVqlSx9957j9UNAAAAYkg0x3YFSpSxk695JNzFAHLlsxaOFUKiERMXAgAAAAAAh0YCAAAAAADgMNwgguzZs8c++eQT2/nzr1asZkNLSikc7iIBAAAghocTHMuRQ/ttz6of3GXiUyA+kEkQQbZu3WoPPfSQ/fnxK3Zk3+5wFwcAAABxTjGpYlPiUyB+kEkQQRITEy01NdV2H0gzS0gId3EAAAAQ7xISLNFb9pD4FIgLcd1IsGLFChswYIAtXLjQihcvbtdff709+uijlpKSEpbyaPnDTz/9NKZT1gAAiPX6HIglKanlrHavEeEuBpBvumXjt1isr5IQt40E27dvt9atW1vt2rVt6tSptn79ervzzjtt37599uyzz4a7eAAAIBuozwEAyF1x20gwduxY27Vrl02bNs1Kly7trktLS7NbbrnFHnzwQatcubJFuuxmHMR6SxcAIH7FQn2OyEaGJxA7+DxnT9w2EsyaNcvatGmTHlDI1VdfbTfddJN9+OGH1rNnz3wv0/79++3LL7+0PWtWWJHKdSyxQMGI/uAkHT1kI/3+vvalxXYkMWepnTRkAABipT4HYsnRwwdt34aV7nK44lMA+Ss5nscv9urVK+C6kiVLWqVKldxt4bBp0ya79dZb3eWaPYZaSsnycdNilttZEeHKsiC7AwDyVyTW50AsSdu709bPfC7X41MAkSs5nscwKogIVqpUKdu2bVum91NKozbP2rVr3f8bN2484TLpMQ4dOuQu79+5xdJ8FtGUSbBh39H0v/dt35TjTILsuvTJ6RH9eLn9vP/521nZ2u/m178+wRLl7fNm9/EARB6vflMKfySKxPrcd/igbfKrH9PWrbOEGOl9zc73fm585+fX82SH4pt4dnjXlqiKT4FIiOX/k43vp/z+njuu+twXp5KTk31PPPFEhuvr1avn69u3b6b3Gzx4sL4a2djY2NjY4mpbsmSJLxJRn7OxsbGxsVmu1udxm0mgHoadO3eG7JHwH9cYTDMm9+nTJ/3vAwcOuN6HmjVrWnJycq608DRt2tSWLFniUiVjFccZe+LlWDnO2MJxHpt6HDZv3mwNGjSwSBSp9fnxipdzMRjHzXHHA46b444Ex1Ofx20jQd26dTOMVVSQoTdVt2WmRIkSbvNXq1atXC+fTqiqVatarOM4Y0+8HCvHGVs4zqzVqFHDIlWk1+fHK17OxWAcd3zhuOMLxx05slufJ1qc6tChg82ZM8d27NiRft3kyZMtMTHR2rVrF9ayAQCA7KE+BwAgd8VtI4GWRipevLh17tzZLZE0fvx4u+eee9z1rKkMAEB0oD4HACB3xW0jgcYwzp071407VGBx//33u7GJo0aNCmu5lPo4ePDgDCmQsYbjjD3xcqwcZ2zhOKNfpNbnxyuW36OscNwcdzzguDnuaJOg2QvDXQgAAAAAABB+cZtJAAAAAAAAAtFIAAAAAAAAHBoJAAAAAACAQyMBAAAAAABwaCSIICtWrLC2bdta0aJFrWLFinbvvffaoUOHLFppnerLL7/cqlat6o6pUaNG9vLLL1vwXJnjxo2zOnXqWKFCheyMM86wGTNmWDTbs2ePO+aEhAT76quvYu5YX331VWvcuLE7hrJly7o1yvfv359++3vvveeOTbfrWLUcWbR599137ZxzznHLqlWqVMmuvvpq+/333zPsF03v56+//uqWhNPnULPA169fP+R+2TmmnTt3Wu/eva106dLuNeratatt3LjRouE4d+3aZUOGDLGmTZtayZIlrUKFCnbppZfa0qVLY+o4g73zzjvuOynUfpF8nNEuXj53x3vMF154oTsfgzfFQdF4zLkd88Taccfa+z1z5kxr2bKllStXzgoWLGgnn3yy3Xnnna78/rITDynO15Ktivv1+ul3wM8//2yRKDvH3bNnz5Dv9ezZs6P2uHM7zo+W81wfYkSAbdu2+SpVquS74IILfLNnz/aNGzfOl5qa6vv73//ui1bNmjXzde/e3Tdx4kTf3Llzfffff78vMTHRN2TIkPR93nzzTV9CQoLvoYce8n388ce+/v37+5KTk32LFi3yRat7773XV6FCBdWOvi+//DKmjvXRRx/1FS9e3PfEE0/4PvnkE9+UKVN8N998s2/37t3u9gULFviSkpLcsekYdaw65smTJ/uixbx589x52rNnT99HH33kzt86der4TjnlFN++ffui9v185513fFWrVvVdeeWVvgYNGvjq1auXYZ/sHlP79u3dY02aNMk3ffp0X/369X1nnHGG7/Dhw75IP86lS5f6Klas6Bs4cKDvgw8+cOU///zzfUWKFPH99NNPMXOc/nTe1qhRw30vhdovko8z2sXL5+54j7lly5a+c8891x2j/7Z///6oPObcjnli7bhj7f1+7bXXfPfcc4+LgRQzjBkzxlemTBlf27Zt0/fJbjyk2xXvK+5X/K/6qEqVKr4dO3b4Ik12jvuGG27wnXzyyRne6+Djiabjzu04P1rOcxoJIsTjjz/uK1q0qG/r1q3p1z3//PPuC2b9+vW+aLR58+YM1/Xt29dXokQJ35EjR9zf+vHVo0ePgH2aN2/u69Chgy8aLV++3L2PY8eOzfDlEe3HumLFCvdlN3PmzEz3adeuna9FixYB1+mYTzvtNF+00Jd6zZo1fUePHk2/Tl/2ej/nz58fte+n95nzKvFQgXt2jmnhwoXutdAPbP9zQxWjKrxIP849e/b49u7dG3CdGrlKly7t+8c//hEzx+lv0KBBrgE61H6RfpzRLl4+d8d7zPrR2KlTpywfJ5qOOTdjnlg87lh8v4O98MILrvxezJ6deGjt2rUuzle879HvAMWRTz31lC8aBB/3seqjaD/u5ScY50fTec5wgwgxa9Ysa9OmjUs98SjF+ejRo/bhhx9aNFIqejClqSvdd+/evS59e+XKle44/XXv3t3mzp1rBw8etGgzYMAAl2Z56qmnBlwfC8eqNLmaNWu64QWh6BjmzZtnV111VYZjXL58ua1evdqiweHDh136l9LIPKmpqe5/L30yGt/PxMSsv+6ze0z6rlKavlIDPTrflWKqVMRIP06lNRYpUiTgumLFilmtWrVsw4YN6ddF+3F6fvvtNxs5cqT961//Cnl7pB9ntIuXz11Ozs1jiaZjzs2YJ9aOO7ui7biDlSlTJj2NPrvxkOJ7xfn+++l3QLt27aLimIOPO7ui+bgHnGCcH03nOY0EEULjsurWrRtwnU4ijYcOHrMVzT777DOrUqWK+xHmHVfwcZ922mnuy2bVqlUWTaZMmeLGNT/88MMZbouFY128eLE1aNDAHn30UStfvrylpKTYueeea1988UX6jxH9wA51jBIt57HG0/3000/23HPPuXFj+uJ/8MEHXdCj442V9zNYdo9J+6lC829E8faLlvc42I4dO+zHH39MP1dj6Thvu+02u/76693YyFBi5TijVTx/7j799FPXaKexuxrnPH/+/IDbY+GYcxLzxNpxx/L7feTIETtw4IB988039sgjj9hll11mNWrUyHY8pP8VT5UqVSpqjjmr4/afl0SdK4oTzzrrLDcnjr9oPe4puRDnR9N5TiNBhNi+fbtrFAimD9C2bdssFqjSmDhxot19993pxyzBx+19aUTTce/bt89N3vL4449biRIlMtweC8f6559/utbf//73v+4HtDcRmlp+N23aFBPHKOeff75NmzbN7r//fncsp5xyiv3111+u9TcpKcntEyvH6i+7xxSL31WaJFbnsnoHPLFwnJo0a+HChTZs2LBM94mF44xm8fq504/E0aNHu8nMNBmu6lBlUy5atCh9n2g/5pzGPLF23LH8flevXt0KFy7sfgirU++NN96Ii/c6s+MWdagoe2369On21ltvuUyTK664wv3A9kTjce/LpTg/mo49OdwFQHxYt26ddevWzVq1amW33nqrxRr1rmuW9BtvvNFilVLDNKOrvugbNmzormvWrJlrPX722Wetffv2Fgv0o+q6666zvn372iWXXGJbt251P7I6depkCxYscBUjYoeG0bz44ov2yiuvuNmKY4V6eW6//XYbOnRoyHRgIJx0XvrTd229evXcd22kpdzmRKzHPMd73LH6fqvsGlKxbNkyFwdqpZyPPvrIYl1mx62OFGWv+VOWQYsWLVzvu2bxj1aPxkGcH4xMggihFqTgpVO8Fif/eQqiNZVX49g1buntt99OH6/ota4FH7fXGhctx71mzRrXaqpKUMei49WPadH/2mLhWHUMeg+9BgKv3Go1VkURC8coCmxat27t3lMFOqrU3n//fZdW99prr7l9YuVY/WX3mGLpu0rZIf369bNBgwbZDTfcEHBbtB/nM888475re/To4b6TtCnlUY193uVYOM5oF4+fu1CUhq6G2K+//jr9umg95hONeWLtuGP5/VY81Lx5c+vTp4/rOdc8BMpEjPX3OrPjDkXnwZVXXunmYvCWy462416Ti3F+NB07jQQRQmNYQq0Xq3Uzg8e3RBN9IajFWMeigNybAE684wo+bv2tcUxafzUaaJyRAm5VePrwa1OrquhHplLqYuFY1eqfVa+l0vILFCgQ8hglWs5jzUegCWT8qYdZvbEaZyix8H4Gy+4xaT+tZRy89neoeVUifY4NNQCpcUBjKoNF+3GqnBoXqvWsve+lN9980wVquqx1zGPhOKNdvH3ujkc0HnNuxDyxdtzZFY3HHfzDWTGQvnezGw/pfw1n9H5IRtsxBx93dkXbca/KxTg/ms5zGgkihFpf58yZ41qnPJMnT3YtcBrzHY3S0tLcLJ8KSjUOTZPY+NMHpk6dOu44/U2aNMkuuugi96GKBvpBqVZU/+3pp592t40dO9aN34+FY/VS77/77rv06/S3etg1Lq1gwYLuy9J/3Jl3jJqQxX9Sm0imsXY6puBW5C1btqQfQyy8n8Gye0z6rlLFrtl6PZrR99tvv7WOHTtatDQEqbJXxog+o6FE+3FqTo3g7yUNCdI5rMtKAY2F44x28fS5y4pSl2fMmGFNmjRJvy7ajjm3Yp5YO+5Yfb+DaRJnTVao9zm78ZDie8X5yrzw6DXQ/E/RcMzBxx2Kstd0zqujyRuuGW3H3SgX4/yoOs/DvQYj/mfbtm2+SpUqubVktXbmyy+/7CtZsqTv73//uy9aaZ1cnWIjR470LVq0KGA7cOCA2+eNN95wa4M+/PDDvnnz5vluuukmX3JysltHNJrpWILXT432Y9V6x02aNPGdcsopvokTJ/qmT5/ua9asma9MmTK+jRs3un0WLFjg1r69+eab3THqWHXMb731li9aPPPMM+69u/XWW30fffSRO9b69ev7KlSo4NuyZUvUvp979+71TZ482W0XXnihr1q1aul/b9q06biOqX379u7+el/fffddX4MGDXxnnHGG7/Dhw75IP86//vrLV7VqVV+VKlV8c+fODfheWrZsWcwcZyiZrV8dyccZ7eLlc3c8xzx//nzfpZde6uKcjz/+2Pf666/7Gjdu7EtJSfF98cUXUXnMuR3zxNJxx+L7fcUVV/gee+wx33vvveebM2eOO/aKFSv6GjZs6Dt48OBxxUP9+/d38b5eH8X/+h2g+mnHjh2+SHOs4169erUr/9ixY93t+sy3bt3aHffUqVOj9rhzO86PlvOcRoII8tNPP/kuuugiX+HChX3ly5f33X333elfNtGoevXq7gMUalu1alX6fi+99JKvVq1arsLQB0VfPtEu1JdHLBzr5s2bfX/72998qamp7jxt165dhh9WajzQsekYdazjxo3zRZOjR4/6/vOf/7hKr2jRoq4CVMW4fPnyDPtG0/upz1xmn0edr8dzTKrEe/Xq5Sr4YsWK+bp06eJbv369LxqO0/tshtoUpMTKcR5PI0EkH2e0i5fP3fEc8y+//OKCZH23FihQwB1Px44dM/xgjKZjzu2YJ5aOOxbf7yeeeMLXqFEjX/HixV2coO/VQYMG+Xbu3Hnc8ZAaUu666y4X9yuuatOmTch4IxqOe+vWrb7LLrvMNcTrmPUeqqFw9uzZUX3cuR3nR8t5nqB/wp3NAAAAAAAAwo85CQAAAAAAgEMjAQAAAAAAcGgkAAAAAAAADo0EAAAAAADAoZEAAAAAAAA4NBIAAAAAAACHRgIAAAAAAODQSAAAAAAAABwaCYAoM2TIEEtISAi5Pfnkk+n76e8RI0aEfIySJUu6x/H07Nkz4HEqVKhg7dq1s0WLFuXLMUWzRo0audfPo8v169c/7vtlx+rVq937tmHDhhyVFQAQGajLIwt1ORAoOehvAFGgcOHC9vHHH2e4/qSTTsrxY5588sk2YcIE8/l89vvvv9vgwYOtTZs2tnTpUncbsmfQoEG2d+/ePHlsBRZDhw61Sy65xCpXrpwnzwEAyB/U5ZGLuhzxjkYCIAolJiZas2bNcj1Y8R6zefPmVrNmTTv33HNt0qRJ9sADD1i47N+/35UtWpxyyinhLgIAIApQl0cu6nLEO4YbAAipcePG7v8//vgjy/0++eQTl9Y4c+ZM69KlixUtWtQqVapkjz/+eMB+K1assO7du1u1atWsSJEidvrpp9vIkSPt6NGjAa3reqxXXnnF+vbta2XKlLGmTZtm+fz//e9/XVkLFSpkZcuWtY4dO9qaNWvcbRs3brRevXq53hMFJ7Vr17YHH3zQDh48GPAYes5//vOfLv1P6Zl6nBtvvDFDL8LChQvtrLPOcs+lNMRZs2ZlKE+oFMXs3E/poJdddpnrVdBrqBTG1157LeB1btWqlbvcpEmT9HRSAAAyQ11OXQ7kBJkEQJRKS0vLcF1ycu59pL3KWb0Q2dGvXz/r0aOHTZ061ebMmWMDBw600qVL20033eRuX79+vZ166ql27bXXWvHixe27775zaZB79uxx//tTb0enTp3szTffDAg8gg0fPtzuvfde6927tz322GN2+PBhl7q5efNmq169um3ZssWVYdSoUVaqVClbuXKlCx4UcIwfPz7gsZ599lk7//zz7dVXX3X73XPPPS7I8MaG/vnnn9a+fXtr0KCBvfXWW7Z9+3a7+eabXfChICAz2b2fXm/19uj1UgDy+eefu+PS8d9www125pln2r///W/7+9//7spet27dbL0vAIDIRV1OXQ5EJB+AqDJ48GCfPrqhtgULFqTvp7+HDx8e8jFSU1Pd43huuOEGX7169XyHDx/2HTp0yPfzzz/7WrVq5atevbpv06ZNWZZn3rx57rmuu+66gOv1d5UqVXxHjhzJcJ+jR4+653rsscd8lSpVSr9+1apV7rEuvvjiY74OO3bs8BUpUsTXr18/X3bpOSdMmOBLTk727d27N/16PWfTpk0D9tVrcsopp6T/fd999/mKFy/untczd+5cd1/tG/xaHu/9Qr0+OrbmzZtneK2//PLLbB8zACDyUJf/D3U5EJnIJACikNLt5s+fn+H6E2mRXrZsmRUoUCD9b6URLliwwMqVK5et+19xxRUBf3ft2tWl2K1bt85NwnTgwAF74okn3IRKSntUT4FHPRDFihVL/1s9D8eilL59+/a5FvrMKGYYPXq0vfDCC7Zq1SpXBo8mdPJPJWzbtm3AfZVCOXHixPS/v/jiC5cimJqamn5d69atXe9GVrJ7P/VKqBdm+vTprqfmyJEj7nqlaQIAYg91OXU5EKmYkwCI0smOzj777Aybf+WclJSUXjkF0/X+QYQ3Sc+XX35pixcvtueff97dfvXVV7vKOzvKly8f8LfS+0TpgHLfffe5lEKNT9SYRz3XQw895G7zr/D975uVrVu3uv+zmhn4mWeesbvuussuv/xyV2EvWbLEpfmFek4tJeUvJSUlYLyjjiP4GEMdd7Ds3k/jH5WSeffdd9uHH37oXh+NwQwuJwAgNlCXU5cDkYpMAiBGqddAY+iC7d6927X2B1dsGjun4ETOOeccN+HPlVdeaWPGjHFBwbFs2rQp4O+//vrL/a+Jj2Ty5MnWv3//gMd6//33Qz5Wdibx8Vrltc5w1apVQ+6j59QEQur18Pz000+WEzqO4GOUUNcd7/0UPMyYMcONtxwwYED69VmN4QQAxD7qcupyIBzIJABiVMuWLV3FHTwp0jvvvOP+18Q+WdHsxpp85+mnn85WC/i0adMC/p4yZYrrGfAqfS1/pBZ9/x4Q/xTA46WlnZRGGTxpkb/g5xSlSOaEZmaeN2+e7dy5M/06Tay0bdu2E76fejkURPiXVQHgu+++G/BY3u30SABAfKAupy4HwoFMAiAKqRJSKmEw9ShoiSDR8kDqRbjooovcLLoaN6cxdZo5WLMSZ2fMo2YP1vg+LWPkzWycGVWWmkVY+3/00UduDKPSAZVOKbr+xRdfdOMD1bPx3HPPZVi+6HhoXKDG/ak3Q6+H0hD1vypxzcysnhQ9p8YxarbjOnXq2Ouvv26//vprjp7v9ttvd8fToUMHu//++9PHHR5rnGF27qdj0VJImn1ZvUaa2VqXdb1/L4WOQamnL7/8sttHm9djBACILtTl1OXU5YhY4Z45EUDuzYjcu3fvgH01c26HDh3cDMgFChTw1apVyzdkyBA367G/4Fl8/Z133nluZuC0tLSQt3uz9M6YMcN32WWXuVmKK1So4Bs2bFjAfn/++aevc+fObnZg3a6Zgl988UV3382bNwfMiDx58uRsvx4vv/yyr0GDBr6UlBRfmTJlfJdccolvzZo17rbdu3f7evbs6StVqpTb+vbt63vvvfcyzCocavbop59+2l3vb/78+b5GjRq55zrttNPcMZ9xxhlZzoic3fv98ssvvtatW7vXr1q1aq48eq+LFi0a8Fhjx471nXzyyW5WZ77CASA6UZcHoi4HIkuC/gl3QwWA6PXJJ5+4GX81OQ8t4QAARB/qcgD+mJMAAAAAAAA4NBIAAAAAAACH4QYAAAAAAMAhkwAAAAAAADg0EgAAAAAAAIdGAgAAAAAA4NBIAAAAAAAAHBoJAAAAAACAQyMBAAAAAABwaCQAAAAAAAAOjQQAAAAAAMChkQAAAAAAADg0EgAAAAAAAJP/Bz6NmyVd66snAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1045x374 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "questionnaire  EVSI : Q5 =   -0.0 | mediane =    0.0 | Q95 =   25.8 | P(EVSI > cout) = 0.08\n",
+      "examen         EVSI : Q5 =  235.2 | mediane =  296.9 | Q95 =  350.9 | P(EVSI > cout) = 1.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "post = trace_calib.posterior\n",
+    "draws = np.stack([post[\"sens_q\"].values.ravel(), post[\"fpr_q\"].values.ravel(),\n",
+    "                  post[\"sens_m\"].values.ravel(), post[\"fpr_m\"].values.ravel()], axis=1)\n",
+    "idx = np.random.default_rng(20260825).choice(len(draws), size=2_000, replace=False)\n",
+    "evsi_q_draws = evsi_signal(draws[idx, 0], 1 - draws[idx, 1])          # questionnaire\n",
+    "evsi_m_draws = evsi_signal(draws[idx, 2], 1 - draws[idx, 3])          # examen\n",
+    "\n",
+    "fig, ax = plt.subplots(1, 2, figsize=(9.5, 3.4), sharey=False)\n",
+    "for ax_i, (nom, d, cout) in zip(ax, [(\"questionnaire\", evsi_q_draws, SIGNAUX[\"questionnaire\"][\"cout\"]),\n",
+    "                                     (\"examen medical\", evsi_m_draws, SIGNAUX[\"examen\"][\"cout\"])]):\n",
+    "    ax_i.hist(d, bins=40, color=\"#2C7FB8\", alpha=0.8)\n",
+    "    ax_i.axvline(cout, color=\"#E6550D\", lw=2, label=f\"coût = {cout:.0f} EUR\")\n",
+    "    ax_i.axvline(np.percentile(d, 5), color=\"#2F2F2F\", ls=\":\", lw=1.5, label=\"Q5\")\n",
+    "    ax_i.set_title(f\"EVSI posterieure — {nom}\")\n",
+    "    ax_i.set_xlabel(\"EUR par candidat\")\n",
+    "    ax_i.legend(fontsize=8)\n",
+    "ax[0].set_ylabel(\"tirages\")\n",
+    "plt.tight_layout(); plt.show()\n",
+    "\n",
+    "for nom, d, cout in [(\"questionnaire\", evsi_q_draws, 15.0), (\"examen\", evsi_m_draws, 90.0)]:\n",
+    "    print(f\"{nom:14s} EVSI : Q5 = {np.percentile(d, 5):6.1f} | mediane = {np.median(d):6.1f} | \"\n",
+    "          f\"Q95 = {np.percentile(d, 95):6.1f} | P(EVSI > cout) = {(d > cout).mean():.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d1ffa02",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003617,
+     "end_time": "2026-08-25T08:53:42.749080",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.745463",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "La décision d'achat devient elle-même une **statistique bayésienne**. Pour l'**examen médical** :\n",
+    "toute la distribution postérieure de l'EVSI est au-dessus de son coût (P(EVSI > coût) ≈ 1) —\n",
+    "l'achat est **robuste** : même pessimiste sur la calibration, l'examen reste nettement rentable.\n",
+    "Pour le **questionnaire** : la médiane est à ~0 €, mais 8 % des mondes possibles (calibrations\n",
+    "meilleures que l'estimation) dépassent les 15 €, et le quantile 95 atteint 26 € — pas de quoi\n",
+    "acheter en confiance, pas de quoi jeter le signal non plus : la décision est en **zone grise**. La sagesse opérationnelle : en zone grise, la prochaine dépense utile n'est pas\n",
+    "d'acheter le signal, c'est d'**acheter de l'information sur le signal** (agrandir l'étude de\n",
+    "calibration) — la valeur d'information s'applique récursivement à elle-même. C'est aussi une\n",
+    "réponse au point EVSI ≈ 0 de la section 4 : ce n'est pas un verdict définitif, c'est une\n",
+    "estimation entourée d'incertitude, et le calcul dit laquelle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f249f81",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003465,
+     "end_time": "2026-08-25T08:53:42.755877",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.752412",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "## 7. Le miroir de Spence : qui paie le signal ?\n",
+    "\n",
+    "Jusqu'ici l'assureur achetait l'information. La théorie des jeux (GT-17b, Rothschild–Stiglitz et\n",
+    "Spence) regarde la même situation par l'autre bout : **c'est l'assuré qui paie un signal coûteux**\n",
+    "pour se révéler bon risque. Passer la télématique coûte 500 € ; en échange, l'assureur tarife à la\n",
+    "prime du type révélé (prime pure + chargement) au lieu du pool. Calculons ce que chaque type\n",
+    "gagne à porter le boîtier :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d197f801",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:42.763337Z",
+     "iopub.status.busy": "2026-08-25T08:53:42.763131Z",
+     "iopub.status.idle": "2026-08-25T08:53:42.767055Z",
+     "shell.execute_reply": "2026-08-25T08:53:42.766649Z"
+    },
+    "papermill": {
+     "duration": 0.008565,
+     "end_time": "2026-08-25T08:53:42.767765",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.759200",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tarif au pool            : 2640 EUR/an\n",
+      "tarif bon risque revele  : 1650 EUR/an  -> economie nette du boitier : +490 EUR/an\n",
+      "tarif mauvais risque     : 4950 EUR/an  -> surcout du boitier         : +2810 EUR/an\n",
+      "\n",
+      "cout maximal du boitier separateur : c* = economie du bon risque = 990 EUR/an\n",
+      "bon risque adopte le boitier ssi c* > cout ; le mauvais risque ne l'adopte jamais (il paierait\n",
+      "le boitier ET son tarif juste : double penalite). Le boitier separe les types tout seul.\n"
+     ]
+    }
+   ],
+   "source": [
+    "tarif_g = PI_G * (1 + THETA)\n",
+    "tarif_b = PI_B * (1 + THETA)\n",
+    "cout_boitier = 500.0\n",
+    "\n",
+    "economie_bon = PRIME - tarif_g            # ce que le bon risque economise en se revelant\n",
+    "surcout_mauvais = tarif_b - PRIME         # ce que le mauvais risque paierait de plus en se revelant\n",
+    "\n",
+    "print(f\"tarif au pool            : {PRIME:.0f} EUR/an\")\n",
+    "print(f\"tarif bon risque revele  : {tarif_g:.0f} EUR/an  -> economie nette du boitier : {economie_bon - cout_boitier:+.0f} EUR/an\")\n",
+    "print(f\"tarif mauvais risque     : {tarif_b:.0f} EUR/an  -> surcout du boitier         : {surcout_mauvais + cout_boitier:+.0f} EUR/an\")\n",
+    "print(f\"\\ncout maximal du boitier separateur : c* = economie du bon risque = {economie_bon:.0f} EUR/an\")\n",
+    "print(\"bon risque adopte le boitier ssi c* > cout ; le mauvais risque ne l'adopte jamais (il paierait\")\n",
+    "print(\"le boitier ET son tarif juste : double penalite). Le boitier separe les types tout seul.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94bd519a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003485,
+     "end_time": "2026-08-25T08:53:42.775023",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.771538",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "Le boîtier télématique **sépare les types sans que l'assureur ne décide rien** : le bon risque\n",
+    "économise 990 €/an de prime en payant 500 € de boîtier (net +490 : il adopte), le mauvais risque\n",
+    "perdrait 2 310 € de prime plus le boîtier (il refuse). Un équilibre séparateur émerge — et il est\n",
+    "*plus fort* que le tri par l'assureur de la section 4 : la télématique en souscription avait une\n",
+    "EVSI nette négative pour l'assureur, mais **portée par l'assuré elle trie gratuitement** les\n",
+    "candidats à l'entrée. C'est exactement le théorème de Spence lu à l'envers : le signal coûteux\n",
+    "n'a pas besoin d'être *acheté* par celui qui valorise l'information, il suffit que son coût soit\n",
+    "**différentiel** entre types. La limite (Rothschild–Stiglitz, GT-17b) : une fois les bons risques\n",
+    "partis au tarif révélateur, le pool restant est 100 % mauvais risque et le tarif pool 2 640 €\n",
+    "devient intenable — l'assureur doit le monter à 4 950 €, et le pool disparaît. La séparation\n",
+    "complète n'est pas toujours un équilibre de marché viable ; c'est toute la littérature des\n",
+    "contrats d'assurance à l'équilibre, dont GT-17b donne la version complète."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a9961a4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00347,
+     "end_time": "2026-08-25T08:53:42.781772",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.778302",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : le coût séparateur maximal\n",
+    "\n",
+    "Le fabricant du boîtier propose trois formules : Essential (400 €/an, sens 0.80 / spec 0.95),\n",
+    "Premium (500 €/an, 0.90 / 0.97) et Prestige (900 €/an, 0.95 / 0.98). (1) Vérifiez que le seuil\n",
+    "$c^* = 990$ €/an s'applique aux trois formules vues du côté de l'assuré : lesquelles les bons\n",
+    "risques adoptent-ils encore ? (2) Vu de l'assureur (souscription une-shot, section 4), calculez\n",
+    "l'EVSI nette des trois formules avec `evsi_signal` — le classement des deux points de vue\n",
+    "coïncide-t-il ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "869fee9f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:42.789723Z",
+     "iopub.status.busy": "2026-08-25T08:53:42.789513Z",
+     "iopub.status.idle": "2026-08-25T08:53:42.793163Z",
+     "shell.execute_reply": "2026-08-25T08:53:42.792714Z"
+    },
+    "papermill": {
+     "duration": 0.008686,
+     "end_time": "2026-08-25T08:53:42.793809",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.785123",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer\n",
+      "  adoption par le bon risque : None\n",
+      "  EVSI nette assureur         : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : a completer\n",
+    "formules = {\"Essential\": (400.0, 0.80, 0.95), \"Premium\": (500.0, 0.90, 0.97), \"Prestige\": (900.0, 0.95, 0.98)}\n",
+    "adoption_bon_risque = None   # TODO etudiant : dict {formule: bool} — cote assure (c* = 990)\n",
+    "evsi_nette_assureur = None   # TODO etudiant : dict {formule: float} — cote assureur (evsi_signal - cout)\n",
+    "print(\"Exercice 3 a completer\")\n",
+    "print(\"  adoption par le bon risque :\", adoption_bon_risque)\n",
+    "print(\"  EVSI nette assureur         :\", evsi_nette_assureur)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a9391e3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003596,
+     "end_time": "2026-08-25T08:53:42.801065",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.797469",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "## 8. Expérience contre signal : le temps comme source d'information\n",
+    "\n",
+    "Reste une dernière source d'information, gratuite celle-là : **le temps**. Chaque année sans\n",
+    "sinistre est une observation du type du candidat — le mécanisme exact du posterior de T1, appliqué\n",
+    "au renouvellement. La fréquence annuelle est faible (0.03 / 0.09), donc une année muette est une\n",
+    "preuve *faible*. Combien d'années faut-il pour apprendre ce que la télématique dit en un an ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2dffb76b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T08:53:42.809276Z",
+     "iopub.status.busy": "2026-08-25T08:53:42.809078Z",
+     "iopub.status.idle": "2026-08-25T08:53:42.909759Z",
+     "shell.execute_reply": "2026-08-25T08:53:42.909112Z"
+    },
+    "papermill": {
+     "duration": 0.106534,
+     "end_time": "2026-08-25T08:53:42.911039",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.804505",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAy0AAAFrCAYAAADcjmZeAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAQ6wAAEOsBUJTofAAAiTZJREFUeJzt3Qd4U2UXB/DTSVtW2VsEQYaA7C3IkCGIiIiKCIigiAKCDEGQoSxZnzJEkK2IogwXslEQkCEoIqIgIHvv0tKWfM//wA03aZImaUrT9v97nkDGzc3NzU36nnvO+74BFovFIkRERERERH4qMKU3gIiIiIiIyBUGLURERERE5NcYtBARERERkV9j0EJERERERH6NQQsREREREfk1Bi1EREREROTXGLQQEREREZFfY9BCRERERER+jUELERERERH5NQYtRERERETk1xi0EBH50Pr16yUgIEDmzJmT0ptCtz388MNy7733SnqDYxDHIo5JSh78vhPdPQxaiNLxH9p3333X5XKHDh3iH2Qn+2/o0KFy8eLFlN4U8lLHjh3TZSBDzu3atUu/1/jd81fYNmwjtpUovWHQQkTkRdAybNgwh0FLnTp15Pr16/L888+nyLYRGXAM4ljEMUmJQyCA77W/By3YRgYtlB4xaCGiNAWNtLi4uBR7/cDAQAkLC5OgoKAU24b0xGKxyNWrV1N6M/zK5cuX9X8cgzgWcUwSEaV2/CUjIo/cvHlTRo4cqf0E8uXLJ6GhoVKgQAHp0KGD/PfffwmWR3kZSnHWrVsntWrVkowZM0rOnDn1vtOnTzuswV+9erWWrhUpUkQyZMggJUqUkEmTJjntq3D48GF55plndL0RERFy9OhRffzKlSvy1ltv6fOxnuzZs0vLli3l999/d1qXPn/+fClXrpw29vC+Bg4cKPHx8TaviTOdgO3D83BByYb9uswNa2x/hQoVJGvWrJIpUya57777pG3btnLixAnrcnv37pVnn31WChUqpNubO3duqVmzpnz88cde73+89sSJE6V48eK6TrzuqFGjZM2aNQ5L/27cuCHvvfee7oPw8HDJkiWLNGzYUH766SeXx4Wjffnhhx9KqVKldF/ic8I+sg8o//rrL3n11VelTJkyum/wmmXLlpVx48bZ7Hf74wPv4f7779f3hGV95cCBA3ps5s+fX/dtwYIFpVu3bnL27FnrMitXrtSAoFWrVjbPxWfTuHFjCQkJkc2bN3v1HfDkMzDKN7Ffv/rqK6lataoe/y1atHDZp8Wb9S9fvlyqV6+uy+fKlUtefvlluXbtWoJtRwCJ5fF5Ytls2bJJlSpVZPLkyV5tgys4tmfMmKHvG/sUF3xfli5dmmDZH374QerXr6/fKRyP+FybNm0qGzZs0MfxWbzwwgt6vV69etbvNe73hifbZrzO1q1bdRvx+xAZGam/aebjA/sV2wbYVmMb8VtAlB4Ep/QGEFHqgsbGmDFjtMHWrFkzbWgiCJg1a5Y2hHEdwYHZzp075csvv9Q/tO3atdM/znPnzpVffvlFtm3bpn+kzd588025dOmSdOnSRRuln332mfTo0UNOnTqVoB8OGkkPPfSQNowQTCBQwfpwtrl27dqyf/9+bdA/+OCDcuHCBW1I1KhRQxsrFStWtFnXRx99JMeOHZPOnTtrw2zx4sXaOEaDCtsECILw/pYsWaLBABqfgMaXMwgyBg0aJI8++qiuG41hBBhoSB0/flyDj3PnzmmDBA1fNAgREGF7d+/eLT/++KM+z5v9369fP23Uo/H0yiuvSExMjMyePVu33x4CCmwjXg/BU9euXSUqKko++eQTbUyhwdW8eXO3jhM0UhE8Yh3YnmXLlunng6AAgaEBDWo05rFevOfo6Gj5/vvvpW/fvvLvv//K1KlTE6wbj2G78Lnic0KQ5wsouUEDEA3/Tp06SeHCheWff/7R4Av7Fsct9nejRo1kwIABMmLECA1Gu3fvbv2cEdCgMY5jzJvvgDefAfbt//73P10W3xk0mJ3xZv0IWPB54rhE4xr7Yvr06dpgnjZtmnU5fGfxXcQx+9hjj+k+RACH2/guvfbaa15vgyPYl/PmzZPHH39cnnvuOb0Pr/PEE0/oZ4b1AgIhrK906dJ67OTIkUNOnjwpmzZt0s8F24z3ht8avC+cqECwDQjyveHuthl+++03DaLat28vTz/9tOzYsUNPVqAEFb8TgO98bGysHmcvvfSSbjfkyZPHq20kSnUsRJTurFu3Dq0ayzvvvOPxc2/evGm5du1agvtXrVql63zvvfds7sd9uCxatMjm/gkTJuj9Q4YMsd43e/Zsva9gwYKWCxcuWO+Pjo62VK1a1RIYGGjZv3+/9f66devq8v3790+wPa+//rolJCTEsmXLFpv7sV6s/+GHH06wP/LmzWs5f/689f74+HhLqVKlLPny5bNZB7YZyx88eDDB6xrrwnsxVKhQQdfjyrJly/R5Cxcu9Nn+37dvnyUgIMBSq1Yty40bN6z3X7x40VKoUKEE2/m///1P71u8eLHNuvFcvIciRYpYEmO8/4iICMuhQ4ds9mXLli31MSxjuHr1qsP1tG3b1hIUFGQ5ceJEguPjvvvus1y5csXiLhwnhQsXTnS58uXL63s8d+6czf2//PKLbsvQoUOt98XFxel6Q0NDLdu3b7esX79el3n00Uf1M/L2O+DJZ4DjD8sGBwdbdu/eneD9GPvLvL+9WX94eLjlwIEDNss3btxYv1/mz+/VV1/V5cePH59gW/D5e7MNzixdulTXgX1o77HHHrNkyZLFcvnyZb3dq1cvXfbkyZMu1+lofyXG0ffdk20DLIvv6c8//2yz7Msvv6yP4Xvs6vWI0guWhxGRR3B2FWeiAVkBnAlE6Uz58uX1LDTOHNtDGU/r1q1t7kNJEEogUNZiD+U4eMyAM6BvvPGGvp6j8or+/fvb3EY7AGdtcbYbZ0qxfcYFZ3lxphyZFvR/McOZYZSzGNAXoEGDBlrClZR+E3gvyODgzLKrZQBZBlejknmy/7GvsC969eqlZ7wNWA5ZF3vIgKCMC2dwzfsMZ9BRcnTw4EH5+++/3XrPyCYgU2Hel8hOgPkzR9mMAVmg8+fP62s2adJEy8O2b9+eYN04Y2+fnUuqP/74QzMtKMnBfjW//6JFi0qxYsVkxYoV1uVRHrZgwQLdl23atNFSP2TMcHYdn5G33wFvPgNk3FCO5Q5v1o/sAPaB2SOPPKJn/bE8YJ9hf2C5119/PcHrmvvV+OI4wzpQVoashHkduKAEFJlWo0TP+G4tWrRItzm5ebJtBvxWoXzMfh+Du985orSO5WFE5DE0hlECgxIGlCuZodFpD2UZ9lAihYBiz549bi1v3IdyLzOUB5kDDTAaCCgLwePOYBlzaZF9wwxQSgIo3/K2oYwSMzT8UHqEUg401hAMoTQGjV7ACE8ImlDmhcYfStdQ3oaGrn2pkbv7H+VVULJkyQTbZJS/mKFPDcp0XO0zlOihAZ4Ydz9DvN4777wjCxcudDhqk6PjyZ3X9xTeu/FZ4eKI/fGBfi8zZ8609iHB8WYcL95+B7z5DDzZH96sP7HvhfFdQjkjjvHEOv774jjDOnDSAf25XK3DCHK/+eYbLeNDmSe+T9hOBJooSfQ1T7bNk31MlN4xaCEij6B+Hg3wypUry4QJE+See+7Rs4pgnKW+m4ysg5mxDQgEBg8e7PS59o0mVyN+ueonkJhq1appQx0dyNF/AxkX9G94++23taFrBBVoAKPmHn0INm7cqAEM9jEaWx988EGy7388F4MW2HeaNnP3jL67UO+P94Q+O/i80EcoODhYAzI0MB29H0efeVIZr4N9bQQh9oz9bIZtNyBTY/QzuJufgSf7w5v1+/p74YvjDOtAwI/vkTMPPPCA/o8+VchAog8LvoPIsqJ/FS7IiiAj4kuebFty//YQpSUMWojII+g8jNF30PA2N5YwkhDOtDry559/JrgPGQJ0ykbZjaPl0YHV0TocLe8oGEFJCLYHIxL5mqPyn8QYozoZDWJ0rkXH29GjR9uM4IUABheUdOFsLToso7N37969taTGk/1vnL3FCF32jSQjs2CGM9tHjhzRs9AIHJLC0Wdu/xmiHAiNfpSSoQO0GTrA303ms/ruHjOffvqpBpro/I731qdPHy3xqVSpktffAV9+Bo4k1/oRbCLjiQ7laLS7yrb4YhuwDhzXGJHPWXbLDNuDzCUugNdHNhOlpUbQ4s332hfb5glfbSNRasQ+LUTkEZwRxB9O+zPgKPFxdpYfNdn2Zx2nTJmi/THsh40FjBhl7teBvg7jx4/Xhod9MOMIlkNDGKMWoZHvTnmGJ4wyMUelS46cOXMmwX1Gw9Yo/cC67PcfzuwbZUXGcp7sf+wrLItRzsy1/AgWMIKRPYxchMAHo2IldZ+hTxGGojZg24yyK+MzNxq29meSMQIcskh3E/oEYahlBCGOAjpso/lzxDGNEaAwKh2yYChvy5w5szaAjXlSvPkO+PIzcCS51o/PEuVWKEl0NDy5+dj0xTZgHcboeI4yEeZ1OPr+oSwUpZrm0itPv9e+2DZP+WobiVIjZlqI0jFXHcMxtK+js3pPPfWUNr7q1q2rw5/ijzI6KONMsjH8rz00BrEsSqHQlwJDvCK7gDOSODttD40JDGGMPh6o+8eQx0a5kDuZFkCDCOUgeF30AUHZDjp9Y6hhDNmKgAClWt7AfBWAs7Qob0LmA+Uszkpa8J5RIoZhhzE/BBocRjCFYXsBHbjRUEdHXfRzQBbFGPYUDWM0qj3d/yjBQadoBC04w4wGNc7uY8hjdBrH2WbzZ9yzZ0/dN5gPAp8VBixAaQ2Ww75Eg9ToJ5MY4z2jwz/Wgc9g7dq1WsJmzDWBRj463CNjgcEWsDwGPUDgcLeHccV+MIbcxRl47Fsctwj20NcG24/PCvsGwzKj8z188cUX1nk/8JliqF9kXj7//HOvvgO+/AwcSc71YzhyDGGNYw7fLRyj+P6iz86+ffv0dX21DU8++aTuZwxhjuwOvjd58+bVIcTxvcGAFkagjuGB8b3H6yBbicE4vv32W90uYxhmwG8Ogi/8diCowu8F+rzguPSEJ9vmKZzEwPcGJ3bwG4GMMuaewXFLlOal9PBlRHT3GcNmurrExsY6ff7MmTMtZcqUsYSFhVly5cqlw9MeOXJEh5XFMLBmWFeHDh0sa9eutdSsWVOHT82WLZvl+eefTzAEqTHkKIbvHT58uOXee+/VYVWLFy+uw6R6OpRtVFSUZeTIkZYHH3xQXzdjxoyWYsWKWZ577jnLihUr3BpG1NnwxmPGjNGhWTHcrHnYWkfrGjVqlG5r7ty59f1gaOUmTZpYVq5caV1m586dlo4dO+p7zZQpk25ryZIlLW+99ZbNMMye7n8Mvzt27FgdJhjD82KbsU+WLFmi2/n555/bLI+hfKdOnWqpVq2abgdeA59Dq1atEizriPn9T5kyxVKiRAl9XQyxPHjwYJuhlwHDC2No1wIFClgyZMigy2PY5tWrVyfYj94MSevJkMeA/Yihe4sWLarbHRkZaSlbtqylZ8+elj179tgMRfvJJ58keH6fPn30sQ8//NCr74Ann4ExJLF5yGQzZ/vLF+t3tu5Lly5ZBg4caLn//vut+w/DleP1vNmGxCxYsECHL8+aNav1OGvatKnN/v/qq68sjz/+uD6GYwz7Hts0bdo0m6GYYc6cOTo8Ob6nxufmiqvfDne2DZy9jrN1f/fddzo0NN4LHrf/zhOlVQH4J6UDJyJKu3AGG2eo7WdedwTLYFI2nKXlLM/Ja+zYsVq+smXLFo/PJLuCM+3IpCCb4+1s4un5O0BERI6xTwsRURqGoWXtoU8L+h1gwAJ0FiYiIvJ37NNCRJSGYc6XadOmaV8LzCuC2n5kQTDZJYZURp8DIiIif8eghYgoDUMHfnTUReCCkZIwAAGyKxg9DIEMERFRasA+LURERERE5NfYp4WIiIiIiPwagxYiIiIiIvJrDFqIiIiIiMivsSO+FzAb8u7du3W40OBg7kIiIiIiIk/FxcXJmTNnpGzZshIWFuZyWba4vYCApWrVqim9GUREREREqd7WrVulSpUqLpdh0OIFZFiMHZwvX76U3hwiIiIiolTnxIkTmggw2tauMGjxglEShoClYMGCKb05RERERESpljvdLdgRn4iIiIiI/BqDFiIiIiIi8msMWoiIiIiIyK8xaCEiIiIiIr/GoIWIiIiIiPwagxYiIiIiIvJrDFqIiIiIiMivMWghIiIiIiK/luTJJePj4yU6OloyZswo6c1TTz0lYWFhiS5XsWJFGT9+vF5ft26dDB8+XNq3by8vvPCC3vfBBx/IkiVL3H7dWbNmSZEiRfT6k08+KTdu3JBvvvlGbx87dkzatWvn9rqaNWsmffr00esLFiyQGTNmyJtvvimNGzfW+wYMGCBbtmxxe33Lly/XfYJjomnTplK8eHGZPn26PrZ9+3bp27ev2+vq0qWLtG3bVq+PGzdOvvvuO3n//felXLlyel/Hjh3l8OHDbq0re/bs8tVXX+n1gwcPSqdOnaRu3boydOhQvQ/7b8KECW5v29tvvy316tXT62+88Yb8+uuvsmjRIsmZM6feh/2Hz8UdZcqUkUmTJun1TZs2yVtvvSXPPPOMvPzyy3rfRx99JAsXLnR726ZNmyYlSpTQ69h/586dkxUrVujts2fP6nHrrkceeUQGDhyo17/88kuZMmWK9O7dWx577DG9D/vvxx9/dHt9y5YtkyxZsuh17L/ChQvLnDlz9Pbvv/8uPXv2dHtdjr5DY8eOlcqVK+t9L730kvzzzz9urStTpkwJvkPVq1eXUaNG6X3Yf6NHj3Z72xx9hz755BMpUKCA3of9d/XqVbfW5eg79MQTT0iPHj30vtmzZ8u8efPc3jZH3yH8LsHly5fl8ccfd3tdjr5Dr776qrRu3VrvGzlypKxatcrt9dl/h3LkyKG/S7Bv3z7p2rWr2+ty9B0aMWKE1KxZU+/r3r27/PHHH26tKzQ0NMF3yNHvurscfYfsf9fPnz/v1rocfYcc/a67y9F3yP533V2OvkOOftfdZf8dwudi/7vuLkffIUe/6+6y/w45+l13l6PvkP3vOmYRdwcmwbb/Djn6XXeXo++Q/e+6u9g2YtsIsE+SLdOCBhC+iC1atJA8efLojwYO1vDwcHnwwQfltdde86gRQ0RERERE5EqAxWKxiBv+++8/jaBwtgqRGc6gIEhB9JQhQwa5ePGiHDp0SCPGHTt2aLQ7ZMgQee655yStOXr0qBQqVEiOHDkiBQsWTOnNISIiIiJK021qt8vDSpcurSlxpClr164tAQEBTpc9c+aMfPHFF5rqw0YgpUZEREREROQNt4OWPXv2aO2sO3LlyqU1md26dZPjx497tWFEREREREQe9WlxN2AxQzbG6DRHRERERER014Y8xqgEu3fvtt6OiYnRESUwMoMxigkREREREVGKBS0Ybm3+/PnW2/3795dhw4bJX3/9pUMkTp061ScbR0RERERE5FXQsmvXLnnooYf0elxcnMydO1fGjBmjI4dhbOcPP/zQ19tJRERERETplFdBy5UrVyRr1qx6/ZdfftHJlDCRF2BksX///de3W0lEREREROmWV0ELxlE2ZgJdvHixDoeMWVfhwoULEhER4dutJCIiIiKidMvtIY/NXnzxRRk0aJAsWrRIdu7cKRMnTrQ+hmCmVKlSvtxGIiIiIiJKx7wKWjBZZP78+WXbtm06F0vHjh2tjyHT0rlzZ19uIxERERERpWMBFovFktIbkdocPXpUChUqJEeOHNFSOSIiIiIiSr42tVeZFgNmu8eLRUdHJ3isTp06SVk1ERERERGR90ELRgd7/vnnrZ3x7ZM1AQEBEh8f782qiYiIiIiIkh60YHJJZFhmzZqlI4eFhoZ6sxoiIiIiIqLkGfJ469atOmJYhw4dpEqVKvLggw8muHjjr7/+kkceeUQyZswoefPmlX79+smNGzcSfV67du2kePHi+rxs2bJpadrKlSttljl06JBmgOwv1atX92pbiYiIiIjIjzMtBQoUkKCgIJ9uCEYdq1+/vgYfmPvl2LFj0rt3b4mKipLJkye7fC4CGyyL56J/zcyZM+XRRx+VdevWyUMPPWSz7MiRI6VevXrW25kzZ/bp+yAiIiIiIj8IWkaMGCGjR4/WgCB79uw+2ZBp06bJ5cuXZcmSJdZ1xsXF6ZDKAwcO1CGWnfniiy9sbjdt2lSKFCki8+fPTxC0ILBhdoWIiIiIKI0HLXPmzNE+Lffee6+UL19eIiMjbR5H2dWyZcs8Wufy5culYcOGNkFQmzZtpGvXrlrqZZ4LJjHIAmGb3CktIyIiIiKiNNin5erVq1KsWDGpVKmSBghXrlyxuSBj4k1/lpIlS9rch8AjX758+lhiMIIZMjPnzp2TcePGyT///CMvv/xyguVeeeUV3ebcuXPrgALnz5/3eFuJiIiIiMjPMy3oK+Jr6NNin7EBdKx3J7BAPxYEIZApUyb5/PPPpUaNGtbHM2TIoAFL48aN9XV++eUXLXPbvn27DiwQEhLidN0IwsyB2IkTJ7x4h0RERERE5I0kTS7pT1q2bKmlamfPnpVFixZpaRn6x6B/CyBjM3XqVOvydevWlQceeECaN2+uy2F5ZyZMmCDDhg27K++DiIiIiIh8UB4GO3fulKeeekqDAWQx8D8a/rjfG8ioXLp0yWEGxp3O/jlz5pTKlStLkyZNNOuCYKVv374un4MRxjBM8o4dO1wuh5HJjhw5Yr0gM0NERERERH6cadmwYYPOp4K5VJ599lnJkyePnDp1SjMWNWvWlFWrVknt2rU9Wif6s9j3XUEQg1Is+74u7kB/G3Tu94UsWbLohYiIiIiIUknQ8uabb8rDDz8s3377rQQH31nF2LFjpVmzZvr4xo0bPVonMiOYQ+XixYvWvi0o8woMDJRGjRp5vI14/aJFi7pcBtt/7do1nSCTiIiIiIjSUNCCErAvv/zSJmABjMrVo0cPad26tcfrxNDGkyZN0r4pmJcFk0uivAv3m+doadCggRw+fFj279+vt7/77juZN2+e9k0pVKiQdtpfsGCBrFixQj777DPr89544w0NgDBHC4IilHiNGjVKS8rwmkRERERElIaCFvQDOX36tMPHUCaGx73p07JmzRrp3r27BhGYqb5z5846wpdZfHy8Dm1suO+++yQmJkazO+iEj74t5cqVk/Xr12tne0Pp0qW1I/706dMlKipKChQoIC+++KJ2sLcPvoiIiIiIyH8EWDDBiYc6deqkGY5PP/1UJ4Q0rF69Wtq1a6clYugMn1ZhYk1kddApv2DBgim9OUREREREabpN7VWKYfz48bJnzx6d8wQd1DFRIzIvmMsE/UMwuSMREREREZEveBW0oJRr8+bN2pEdHd6NYYkxYhiyLOg7QkRERERE5Ated+ZAYNKiRQu9EBERERERpXjQglG5MOoWghVcT4w7E0ISERERERH5LGjJlSuXloRVrVpVR+gKCAhwuTxG+SIiIiIiIrprQcusWbN0eGHjemJBCxERERER0V0NWjp06GC93rFjR5+8OBERERERUWK8GuaraNGi8ttvvzl87I8//tDHiYiIiIiIUixoOXTokM5C7whmm8cEMURERERERHe1PCw6OloDEovForcxkaT9KGJYZunSpZI/f36fbBwREREREZHbQcuYMWNk+PDheh2d8Bs3bux02aFDh/pm64iIiIiIKN1zO2hp2bKl3HvvvZpp6dSpkwwaNMg6mpghNDRUSpUqJeXLl0+ObSUiIiIionTI7aDlwQcf1IuRaWnevLnkyJEjObeNiIiIiIjI/aDF2fDHREREREREfhe0wE8//STTp0+Xv//+Wzvg2/v999+Tum1ERERERETeDXm8YsUKqV+/vpw9e1a2b98uhQoVkpw5c8q+ffvk2rVrUrlyZd9vKRERERERpUteBS1DhgyR119/Xb777ju9/c4778jatWs16xISEqIBDRERERERUYoFLXv37pWmTZtKYGCgdspHdgUKFy6swx2/++67Ptk4IiIiIiIir4KWsLAwuXnzpgYs+fLlkwMHDlgfy5w5sxw5csSX20hEREREROmYVx3xMfQx+q888sgj0qBBAxkxYoT2aUFpGOZvKVu2rO+3lIiIiIiI0iWvMi3oz4IsC4wcOVKzKy1atNCSsXPnzsmUKVN8vZ1ERERERJROeZVpefTRR63XCxQoIDt27JD9+/fL9evXpWTJkhIaGurLbSQiIiIionTMq0zLqlWrxGKxWG8j61K8eHEpV64cAxYiIiIiIkr5oKVx48aSP39+6dmzp2zZssW3W0RERERERJTUoAWz3Xfq1EnnaalZs6YULVpU3nrrLdm9e7ckxV9//aWd+zNmzCh58+aVfv36yY0bNxJ9Xrt27TTTg+dly5ZN6tSpIytXrkyw3KVLl+TFF1+U7Nmzaz+c1q1by4kTJ5K0zURERERE5IdBS5kyZXTEMPRjQabl8ccfl7lz50r58uV15LBRo0Z5vM4LFy7opJQIUhYvXqwd/KdPny69e/dO9Ll4DpZbtmyZzJ8/X3LkyKH9bjZs2GCz3NNPP63BzLRp0+TTTz/VEdAweEBcXJykFlE34mTBL//JU9M2Sf3x6/V/3Mb9RERERERpUYDF3DklCbCab7/9Vl555RXNXsTHx3v0fAQ6CIT+++8/zYQAgpZu3brpfShHcxdeu0iRItKkSRNdB2zevFmzQitWrJBGjRrpfQhaSpUqJQsXLpQ2bdq4vf6jR49KoUKFdD6aggULyt1y4MxVaffxL3LiUrRg8DZ8csb/+bKGySedq8l9uTLdte0hIiIiIvKWJ21qrzItZjExMfLll1/KU089pZmM06dPW4MCTyxfvlwaNmxoDVgAgQQmsXRU6uVKUFCQREZG2pSWYf24D+VnhhIlSmh26Pvvvxd/h0wKApZTl6P1thFqGv/jfjzOjAsRERERpTVeBS3IZKCh//zzz0vu3Lmtwcr48ePl+PHjGiB4058FwyWbIcjIly+fPuZOpgdlXpgnZty4cfLPP//Iyy+/bLN+BCnG/DIGZFrcWX9KW7rzuGZYbjrJi+F+PL5s1/G7vWlERERERP4XtCBQeeyxx+TPP/+UwYMHy+HDh+Wnn37S0rCcOXN6tSHo04IgxR461p8/fz7R58+cOVNCQkL09YcNGyaff/651KhRwyfrv3z5sqavjIvRef/vv/+2LoNBCTBAgQFlaL/++qv19urVq2Xbtm3W2+vXr9eSNcPGjRtt+uCgr9C6deust3/ftUOeyH1nO2tkvSJP5TlrvV0ly1Vpm++MDP/mT824DJm7QibP/kwmr9mnfV6+WrdNPv3iK9l3/IJcjLoh//77r/YBwtw6gLQcbl+5ckVvI/jEbew3QFCK22fOnNHb2Ge4ffLkSes+wm3sH4iKitLbhw4dsmbkcBv9oIzAF7fNAeM333wjf/zxh/U2gt9du3ZZbyPjhjmBDGvXrpVffvnFehvH4M8//2y9vWnTJvnxxx+tt7du3arPMWBd5izeb7/9ZpN127Nnj26TAeWE2Gaj9BHvBbfx3gDvFbevXbumt7EvcBsDQAD2FW4jsIazZ8/qbexbuHjxot7GvoerV6/qbZRHAj4r3MZnB7GxsXrbOA4RuOP23r17bY5L8wAZP/zwg+zcudPt4xLHpPm4xGNYxoDnYh0GrBuvYcBrYxsM2DZso1GVim3HbbwXsD8u8d5xG/vCfFxiX5mPS+xLwL41H5fY9+bjEp+NO8clPmsDjgEcCwYcIzhWXB2XONYMOAZxLBpwjOJYNeAYdnVc4jtgPhGE74j5uMR3yJ3jEt9J83GJ76z5uDR+B/EdNx+X+A0wH5f4jcBt/GaYj8uDBw/qbWS4cRsnjgDZcvvjEqXE9sel+buOY2r79u3W2/gtNI9UiWMSv5nuHpf4LcZvsgG/1ebjEn/LsI0G47g0+jsax2V09K1MN/7mmY/LY8eO2RyXp06dcuu4xPPM33WsF/A6uH3gwAG9je0wf9fh66+/1u1292/QmjVrPDousb/NxyU+D0x34Olxic/ffFwaFRA4XszHpfE3yDgu8XfWfFwa33XjuDT+Bhl/j42/QcZxafwNsj8uje+6cVx68jcI7998XGL/mI9Ld/4G4XPw5LjE5+zsuMTx4c5xmdjfIByv5r9BiR2Xxt8gR8clbntyXCa1bYTPw/xdx+dl/zcIvzf2f4OM4xK/U46OS7aNVt61tpHxnU62ySV79Oghzz77rNx///3iL1q2bKmlXvgSLlq0SEvLlixZoh3tk2rChAkaCKWkqBvxEuTGctdj42Xj/rNyNfM1KZs5Rj5Z9Y9YJEAeyBQlFbNck2GTNsoNS6CUyhQtNbJdlVkfbZaMGSPkngzXpUB8lMz5+aBki8wqGeMuy7XoOPnv/DWxhGa0lqEREREREfl9R3xE2tWqVZOxY8d61XfFVfYGwxHbjzxWoEABLUMbPXq0R+t74oknNII2olMEMYiYzRE8PPfcc3q2wtV8M4iUjbM/gDM7VatWvasd8TFK2PbDF1wGDyh8yx8ZLg1L5ZZz127I+duXs1dvyIWoGxLvrLbMDYEBItkzhlovOTJmsF7PmQn/37qdQ6+HSraIUAnCk4iIiIiIktgR3+NMS1hYmKYOAwOT3IffBvqz2PctQeoIAYJ9Xxd3VKpUySZ1jXUghYgYzdyvBa+JYZpdyZIli15S0hMVCsq2Q7fSkc4gJHmtfjF5tuo9CR67edMil6NjrcHMuas35Ny1GDmv/98JcG5dj9HrsfF3ghzEOwh+cHEHdnFkeIjkyHQ7mLEGO7f/z5Th1vXbQU72iFAJDvLtMUVEREREaYNX5WGtWrWSL774Qkf78hWUcWFuFtRUGn1PUOaF4MibjA7qIDHppXn977zzjtaTGtuNOkzU4Pfv31/8XcsK+WXS2n90lDBHCRMkNfJkCZPHyzseGjowMEAiI0L1cl+uxF8Pwd3l6LjbwUyMBjlGUHPrekyCYOdG3E3T80UuRMXqxV1ZEeSYsjXI3twJcu5kd3AdmZzQYAY5REREROmBV/O0YCLJgQMHSoUKFXQSxzx58iQYlQuBjSfQqemBBx7QfjJYN7I5mDAS5VuTJ0+2LtegQQPtFGZ0WkInr3nz5knz5s01vYROUAsWLJCvvvpKPvvsM3nmmWesz8W8LegghlHOkDF66623NChCR67gYPfjN87TkhAOo6sxt4IcDWZsgpxbmRvbICdGomPvBDneyBwWnDBzYwpyjKDHCIIyBLvTKyh5YChqjAC3ZOdR3Q/YLmTPEIxGhHp17oCIiIgoVfOkTe1V0JJYaRgCGE8nlzRGdejevbuObJA5c2Zp3769TjgZGhpqXebhhx/WkQiMkRdQ3vXmm2/q6BPohI/Rw8qVK6f31a1bN0G5GQKhxYsX66gXyOBMmjTJo4krUzJoMRq/GNZ46c5jcuZqjOTKlEFaViigGZbU1vjFe7lVpmabzTH64Rhlakawg8EIkiJThmBTnxzbwEbv12zOnQAoLCQozQebRERERGk2aDGGv3OlcOHCklalZNCSnkXHxlszN/bZHCPoMWdzkPlJiojQIMf9cJxkcxwFjQjMGoz/MdGyvjVv1E11QScRERGR33bET+sBCfkvZD4KRIbrxd0gB6OmOcvm2JeuXYm2DXKQ2Ym6cV2OXrju5vYF2oyqhmDm9JVozbA4Y54U1NEACkRERETkZdBiwAQ+KMtCdDRo0CC55557dBKbYsWKeVxyRZQcQU6+rOF6cQcGErgT5NwOZhxkc4zbl67bDjKAPjrHLl7Xi6dGfb9XNh04J9kjQm4NH40sTsSdrM6tYaRDOMIaERERpUteBS2Y+ROTOWJuEyOl07VrVw1aZs2aJRkzZpQpU6b4fmuJkhFGI0OpFi7uiI2/FeRo5gbDQev/tv1w1u077daAAxip7Zvfbs047s4IaxrE3M7mGP/b3BfhvGSNiIiIKLXxqkXz+uuva+CCiRuLFy9u01Eewwm/++67vtxGIr8UEhQouTOH6SWpk4LmzpJBqhXJYS1dMy434m0DHmR3cPn37DW3S9Y0Y2NMAGpkcjIa/5snDA3VoAjDYxMRERGl+qAFwwzPmDFDSpUqlWCUMGRe0KmGiNyfFPT1hvcn6NOCMTKu3Yi/NeBA1J3yNC1hu53dMa5fcNIvB1me45ei9eIOxCvI0mQzBTL22ZtbpWr+MZQ0ERERpQ9eBS0YLhglYM7mWzFnXojSs6RMCoqhwzFMMy735Ihwu1/ORSOoSewSdSvYiTNtGK7qAAXXbrj9HjNilDWbPjh3MjlG0GPO6GQJC04wrxMRERGRz4OWatWqad8VTCxpb+HChVKrVi1vVkuU5qBPCeZhcTZPCwIWPO6rvifol5M7S5he3IFszuXrcQ4zOUb25rzddfv5cpANunb+uhw5794ABMGBATbZG2N+HHP2xlrSdjvrg1K8u40TghIREfkPr/7yos9KvXr1pE6dOtK6dWs9a7p06VIZNWqUlo5t3LjR91tKlEph4kjMw+KPk4Liu5s1IkQvRXI6zp46GkraVfbGmD/nViB0Kwgy9+lBZufMlRi9uAvZmTvZGnOfHNuMjjEgAebYSUo2x9GEoAfPXtNSP2TOOCEoERHR3eXV5JKwefNmnXUes9ejXwsaCDVq1JCxY8fq/2kZJ5ckcl/8TYsOHoBMzvlrt/63z+QYF+O+mLjER1xLLOPksB+OXXBjXCIjQiXo9gAEnBCUiIgojUwuCQhMfvzxR7l+/br2Y4mMjJSICPfq7oko/UAwYAQH7sB5FJSgOc3e3J4s1DrctIM5c9C3B1kSVxN7miGbEhmOrE2oZoLcmRAUWbO21TjRLhER0d2Q5NOE4eHheomKipL9+/fLfffdx062ROQ1/H5kzBCsl0LZIzyaM+fCtVjrxKBG1sZhRifqhsTG30mjIN98ISpWL+56a8kfMmnt/lv9cuxGWUPZmg5AYBqJLTIihCOtERER3c2gZdy4cXLt2jUZMmSI3t6wYYO0aNFCLl++LEWKFJEVK1Zo8EJEdPfnzMnsVjbnSkzcneGkTZmcD9cfSJC5cbgOEY+yOYCR4LKhH44RzJiCGqOE7db1EL1uLlsjIiJKz7wKWj7++GPp27ev9Xbv3r3lgQce0D4u6KQ/cOBA+fzzz325nUREPs3mZAkL0cu9YjsAwZq9p9yaEPS+XBmlQ817tZ+OUapm/d9J35yrMXF6cXekNSStMeGnEdzYZ3GswY4pAOKQ0kRElBZ5FbSgs0yxYsX0+rFjx2THjh3av+Whhx7SOVxeeeUVX28nEZFfTQj64kNFE0wIarOMxSLXb4+0hrI1Y14cm+DGGuTEOpw3B4HTxahYvcjZa24PKY0MjZGtsQ9qctjcvtWPJzwkaaOtERER+WXQgj4sKAWDNWvWSKZMmaRmzZp6Gx3yL1265NutJCJKBROCmiEIwOhiuBTMJu7PmxMddyu4SRDkxNref/v/i9djEwwpffZqjF7clSE40KY87VZQczujY1xSSf8czq9DRJQ2efULXrVqVRk9erQEBgbqEMdNmzaVoKBbf8AOHDggBQoU8PV2EhGlyQlBE8ybEx6iF/uyNfeHlLYtU7sT5NwKenBBfx4zlLH5sn+OUcZmzKVzt/rncH4dIqK0y6t5Wv78809p3ry5HDp0SAoXLiyrVq2ylos1atRI8uXLJ3PnzpW0ivO0EKV9OGPvjxOC+gKGhL4YZRqEwJrVcb9/jqcS65/jqITNk/45nF+HiCj1SfZ5WkqXLi3//vuvnDt3TnLkyGHz2Pjx4yVv3rySXqFsDuVxmHCTiFK3GrlFajTOZ7rnppw+flT8CTLeoaGhkjNnTgkODnZ78s3cWcL04q7rmDvHVLJ2/i70z0FmJpuL/jnm+zf8c9at+XUQiLrqi0RERP4pSaebELAgUXP27Fn9g4kzYmXLlpX0HLBgYAI0HEJCQlJ6c4goHcDgJxiCHr8/KM3NmNG9sjJPhYcGSYHQcCkQGe7W8saw0uZ+OeeuetY/J96L/jmuIGfz8YZ/9T0g2EF5G/6PCOVABEREaTZoWblypQwbNkxHDouNjdVGeqVKleTtt9+Wxo0bS3qEDAsClqJFi1r7+BARJbfo6Gj577//5MKFC8kWtCRlWOnCOTztn3Mnc2PN6LjZP8cVxEMHzlyT9rO2Jsg8ZcPAAwhkIu4MNnDr/zsZHfNj6NPDQIeIyM+DltmzZ0vnzp11iGN0xM+TJ4+cOnVKvvzyS3n00UdlxowZ0qlTJ0lvUBKG4I0BCxHdTWFhYVoihqxLaoZyMGO0Mk/753Sas032HL+sgYkr6Nti3+cF6zh1OUYv7goJuj20dITzACebzXXOoUNEdNc74mPW+/r168vMmTMTPPbCCy/I+vXr5eDBg5LeOg1hYAK49957U3DriCg9Su+/Pwt++U8GLtmd6HKjWpWVVhULaN8aI6ODfji3/sft29fNtz3M6LjuoxPiRrCD/289hkxVYDKPukZElGY74p8+fVqeeeYZh489++yz8sUXX3izWiIiomSfXwdzzOTJgkuYZxmd604CnNula0YgpCOzXbuhc+6Y3eqjc0Mv7sJ2RxoBToRdgHM7uLlz/dbtuzG8NBHR3eZV0FK9enX59ddf5ZFHHknwGO7HPC7e+Ouvv6R79+6yadMmyZw5s7Rv317effddLXtw5sSJEzJx4kTtY4M5YrJmzSp16tSRUaNG6XDMBmR/6tWrl+D5Tz/9tCxcuFBSWnqcEA2TkuJ4uf/++yU1mDNnjkybNk22bNmS0puSrn366aea5V27dm2iy27YsEE6duyovw2UtiX3/Do64lrmML24Ky4egQ5GTLsznLR9sHMrq3O7j05UwsEIEIAZ/Xr+FfdGXcN7RobG2jfHFOzc+v9OgGNkerBcSFCgpJT0+DeQiDzj9i/B+fPnrddHjhypGRV0/mzZsqXkzp1bsy9LliyRefPmyWeffebhZoh2IEXJWfHixWXx4sU6Clfv3r0lKipKJk+e7PR5GAgAy6MPDYIpjGT2zjvvaOD0xx9/SK5cuRL0xylZsqT1NkY9S2npdUK0q1evpvQmUCr03HPP6cUd6HfnTsDCgDRtwO8k5mHxl/l1goMCJWemDHpxF7IxlzEYgV15mg5MgKDm9pDSRjYH2R08Zs4u4W8IBjTAxROZw4LvlKvZZHBuzadj7qtjBEII5pIqvf4NJCLPuP0LbgxpbEBXGIweNnz4cJv7oGbNmh7PU4IGA4bsROCTPXt2vQ+dSrt16yYDBw6U/PnzO3xe7dq1NUNjnp8Ar3/PPfdoAPXGG2/YLF+mTBmpXLmy+AucXcKPNUoawDjDZvyP+/F4WpoQDZ+ru/NJEPkLHrepA34nMQ9Lap2LRfu93J6PRmzPuTl186ZFrkTH3Qp0HAQ7Rr+dO8HOreyPeR4dwDpwOXwuyu3txShqNn1zjD47pmDnTqbnVkYnLCQoXf8NJCLvuH2KZNasWTYXZCxwcXafp5YvXy4NGza0BizQpk0buXnzppZ+ORMZGZmgIYGOPMiwHD9+XFISaqBxtsjV5eMNB/XskqMabPOEaDM3HnS5HryWO06ePKklcRjxDR2fhg4dqvsYw1YjmBsxYoR12VatWukoccaZaGSykP3CPr/vvvts+i7duHFDg0sM0oAAt23btpo9MzoII+DFOvB4uXLl9H7ch4DT3efPnz9fH8+WLZv06tXL5n0hQEVAirLCYsWKyQ8//JDoepNq9OjR+l4cHWcYiKJBgwY6lxFeF5lJ8+uiszQmYsUw4VmyZNFR9zx5v5988om+X3wWyCbs2bMn0c8YMCksMpooo8S2oZTSEZyA6Nu3r64D24fsJEosYfv27XpiAK+NiWRxYiEm5s6oS9j26dOn63PwOu3atdPPATAh7eOPP67vCZdq1appdtSRcePG6fbjM8Uw4kYZp3EsuvN62GbzZLeO1rl7927p2rWrbNu2TUsWccG8J9hv+A4gi4v3ipESk/N4IvIWOupnjQiRIjkzSsV7skmDUnmkdaWC0qVOUenXpKSMalVOpj1fSb54uYas7FVXtg9qKP+MaCq/D20kP/WtJ0tfrSWzX6giE9o8KIObl5bX6hWTttXukUfL5pXqRbNLybyZJXfmDBLqoHzsakycHL1wXX4/ekl++vuMLN11XOZsOiQTVv0tg5ftkdcW7JS2H/8ij36wQaqPWiMlB/8gpd/+QWqNXivNJ22QFpN/dutvIDJnRJS+uX3aAnXhyQmNV/thktFQyJcvn7Vh666///5by9VKlSqV4DE0DtFwwnrRkESmKDzcvcnSPHXs4nWpN+5WQy+pxq/8Wy/OrOvzsP7BcgUN1xYtWmhfpLlz52rJX7NmzXRCui5dumhfATQiGzVqJL///ruW1+3cudP6fDRW8fwzZ87IunXrtPFZoUIFLekbMGCANpx/+eUXbRC+8sor8tprr+k6DQgkfvvtN4cTb7rz/NWrV+s2YXjtihUrymOPPaYN8KVLl0q/fv20TLBGjRo6EoVReubOeu2PuW+//VYzeM6gQY8MHkqJfvzxR218O1qmf//+UrduXbly5Yq0bt1aBg8ebFPqiMBj2bJlGqhjn6Nvljlz6ez9fvPNNzJo0CD9v3Tp0vLxxx/rY0bG0dVn/NZbb2kfohUrVuhrOCuHwokCNOh37dql3xUEYUYmFUN6o/GPEkyUceI7NWnSJOnTp4/1+Rj+/Oeff9aMKz4TvFd8v/E8HId4XoYMGXT9GK7X3r59+3TOJxx/JUqU0L5rroIDZ6/nzjqxD5HpdVQehn2M4BH7GIGZp8cTkb8yz6NzT44It56D34BrN+Id9sUxsjv22RyUsMXYnVSLuhEvUTeu699Idw1c8odMXP2PdaABYwAC83UEbubBCFK6nw4R+VaScq34g79161ZtGKHhhUaMowacu+tCg9Ee1mfuT+POj2qPHj20nAxBiQFnYNGwxZllBCnoxIsG1N69e7WR6grK1nAxoLGTGiHowJByGNwAf7Cwj5A5QXYMDVo05N577z09S3/x4kVt2JonqsNn/Oabb0pgYKA2sps0aSKff/65NoTR4MP60b8J0K8I2RhkQAw4c42z9o4+M3eej3JEbA/OkONzRCd+NOLxXDSYcfYfcCbdnfU6mk8H7zuxEqEOHTpoULxq1SqnE/lhG3EBNM6RKUGgYdazZ08tYwQENfYdy5293w8//FADorJly+pyL7/8sn5uaHAjAHD1GWNQCxy/hw8f1owUsjSOYDn0WUMDHRkFZBYMCFQNGOzipZde0gDLHLQgG4FMDiBowrYjiMB6cdJg//79mqVCpskRBF/4/BC0YR8hcMLFGWevl5R1ArbPGCkR+9bT44koLcFvCsrBcCmU3b1AB67fiDf10bENdmZtPJhglDVnzlyJ0YsnMqN87fZoa7bBju3/xnVOHEqUxoIW4ywyzq6ay0LQOEPAMGbMGEkpaBivWbNGz+qbG5RoaJkbW2j8ocGCs6QIvFyNeDZhwgRtQHqqQGS4ZkBc6fnZTtl9/JLNaDH28NtZtkBWef+ZCi5fKzEoO0KWxBxY4qy30cgHlLugLAgZlypVqti+RoECGrCYG6w4Y451YsAEnOE2w7IoVTIv74i7zzeX+URERFizKZgJHA1wT9eL9+MplFehnAhlR65mHkd2BEEJRq9CpgX7GWfmzZy9n8Qex+eIzwhn/Q0oW8JngYazq88YJU5DhgzRkfSQ8ULAgUDUHh7HMY9gAJlLBKj4HiAIwm0EQmi8Y/8ikHvwwQddbrvxOWK7r1+/Lk8++aSWYKGUCyWJ9tk3BALIFH3wwQc69xOCK5TTmQfRcOf1krJO+2M2OY4novQgPDRICoSGO/w79fP+s7L98AXXfwNFpFjuTPJCrSK3Rli7HfgY/9+679Zt+zIzzK+Dy5Hz1z2aODRruIMAxzqXjpHtYVaHyO+DFowehlIWZC6M2nk00nDWHWd8kTExN6jcgUbWpUuXHGZgzP1cXJkxY4aW12A4VPQnSAz6zCBowQhkroIWNNCMvh2AM9XuDOuMUVUSK9l6puo98nsiE6LhxxydShNbV2Jwdhn9fYxJ6BxB0InSKJRxodwKNf0GNIrRADYCFwQLKFvCmXhkr1Dq42hiO+P1nJ25cvf5rt4Xztx7ul5voLQKxz1K49APy1mmAI197CuU2SEDgDIwZER8Ae8X2+CoZBPZFlefMTIEyNTggv2C7wmCU0ffF/RVwQXfQWRpcKICpVIoiUKWZ8GCBZo5e//9990eMRD9RfAbgQtG9WratKlm+F588UWH309cECggsMI2IAhMCmfrdHZsmu9PjuOJKL3DsMYYJcwVxCGdahdJdHAFY0ACY/ABY2Q1BDaX7AIc8/8oVzOLjcd8OjF68YQxKIFtBsdUznZ7sAJzMMSsDlEyBy2o70Z9PurDDQhcUO6BbAs6xXoatOBsp33fFQQxCBBcnQk1YNQxNKYQtNiXhSQVGmaOypru9oRoSYXGKQYoQEkLAjE0wNBwREdy9L1AvwD0ZUBDG+U1KK9Dh2dj5DaU6aGxif4c6MuBRjvmw0EQgwY5SqCmTp2qGSyUT23evFkb94lJ6vORLXj11Vc12EKGCMEVshI4bpKyXmcQyCHbiL4c2AcI3Owhu4JMDMoSsX9RiugrOM4RQCBziO8cMhboY/Twww8n+hlj8ARkCpB5wckFZGYclTWhUzoyKAjKkLnAxQhW8d7wfUDmCFkXlEzhfboDpZgI/JAZwzqQYXH0+uh/gjI3fKb4TUGwk9TyK1frxO8XjhtkjvFYchynRJS8fwONAQlwuVfcP8kXExd/J8C53RfnToBzJ6tjDnYwnw6Gp7YflMAYmMBdwYEB1kAm0kl/HdugJ0Qiw30z1LQvcH4dupu8OqIQSBj9B+yhQYRMjKdwxhXPQ58Co2/LokWLrP0nXEGpDhrYOGuKYMpdxmhE9mVQaWlCNDM00NCxGGfp0XkejV30l0ADGA02jKCEfYLMFkZye/7557X/hjF6G0YXQyMNjWIsg1HicJbcGEkLAQxKbpB1QyMQWTh3G3NJeT6CCGQDEKyiUYpSIXR4R9Di6XrRkEUg4qyvhwHlTQhccNw6ClxQgoXJUXEso4GOfYnSLF/AtiNTgM8GHeQRUGB7EbS4+owBWUUEM9hfyAC9/vrr+jx76MOF5VAOh34oaOh/9NFH+hgCMASKKBdD4PTUU0+5HOHPDBkxZPPwWSBoQX8R7Bt7CB7QV+rPP//U94T9i+AoKVytE+Wi5cuX10DEGCjAkaQe50SUcn8DnckQHCR5suDi/sShmtWJiUsY4CQIelxndTDstC+yOgkCHPv+OhlDtH+PL7M6nF+H7rYAizEkkAfQGERjDSVi9nAWEo04T0f8QiPqgQce0LOwKK0xJpfEJHLmEZdQxoJOxEY5EDrSG2eO0agy97lA4xp17IDaeTQe0VBBh1p0esb242w5sjSewOhUeD00kFGKYzBKcrwpHcHZCn+ZEM0RTr5H5N+S8vtDlNL8/W+grxhZnTvBjF2Ac3sUtlv3O8/qeONWVsdxgGM/8pr5uqOsDj6vBuN/TDRDxvl1yNs2tSNeHUkITFCigo6pGPUIZxtxBh6ZEdS2o17eU+jTgg703bt3l5YtW2rpCfqRmOcNAQxpirIVA4YeRRkZLrVq1bJZFmei0dgGBEQYlhQdb3HGFaMhITjytIwtuaT2CdGIiIi8lV7+Bvo8q3P9TmbHCHSMbA+Gp06Y1bmhF09kDA26FciYRmE7cyVaMyxOt/n2/DoIRNP6Z0p+nmkBjByGunlMDId0I1aDzAbKs9C5PS1LjkyLv2Omhci/peXfHyLyLqtzSYOcxLM65uDHF1kdQ4bgQCmdP4tEht8ZZQ19chAAZb19n2Z0wm9le7KEcWCC9OaoB5kWr4MWQO03ysCMEb7Qv8FcnpVWpceghYj8G39/iCip0CTUrM61WIejsBmBzeo/T8n1WNtMji8EYTAFBDMa0NgGOrf66GCghVB93Oi3g2DH1/11KA2VhxkQoGA2aSIiIiJK3dDwzxKGjEeI3JPD+QSiT03b5Nb8OgWzh8tj5fLfGnb6uhEA3RqCGtkd+4EJkOU5f+2GXjwNdmwCHZvMTohEYuS1249rHx4EPRlDtfSNwU7qwd5RREREROTz+XW6PVzMZZ+W6Nh4uYzStOu3ytXw/62Stjsla+aBCy7pfbEJsjwIdjDkMi4i17wanCBh0HMn8DECHeN6BIOdFMGghYiIiIju+vw6YSFBesntwcAERrBjBDDWUdasgY4p2Lmd3TGuR8fe9MngBCFBKGO7M7+O+bpN353b5WtG353wEP8IdqJS6fw6/rtlREREROR3Unp+HSPY8WQUNiPYMQc6KFm71VfndoBzLWGgg8dvxNkGO7Hx3s2vExoUeHt46Tv9dBz13bHtxxMqYSGBPgt2UvP8OgxaiIiIiMgjaNhiHpbUNL8OAp28WXEJ82hwAmRoNIC5HdQYo7LduX5nTh1zSduNeNtgB7fPXInRiycwV0420yhrtkGPqe+OdbJRI9gJSpBhQcCCDNmt9yY2/+N+PO6v8+v43xaR38Es8b/++qtO/OkrmIEcQ2bbz62TnKKjoyU8PFxnkccIS127dtU5hoYNG+Zw+bx588rChQsdzhhPItu3b5eePXvKzz//nNKbQkREKSA9zK+DDEd4aJCEh4ZLvqzhHgU76Htj7Y9zO6i5k+W504/nTjnbrevI5Jgh03PqcoxePB1y2jrKWniIXI2OS9Xz6zBooURdvXrVp+tbuXKlThJ6NwMWRzDvjC9/1Pbu3SslS5aU9KJy5cqSMWNG+fbbb6V58+YpvTlERER+A+0CBHW45I/0LNjBqGrG4ATmvjuXbAKdhP140EfHLCbuppy8HK0X97dbNHOWqoMWDG+clHo6NFIpdYmLi5Pg4GCfP3/q1Kny/PPPJ3HryB+0b99egz8GLUREREmHtnbGDMF6KeBhsHMNwY7diGu3RmS71Tfn821H5GpMXCLrES3180duzwS5bt06Wbt2rdcX8g8oixo1apSULVtWsmbNKk8++aRcvHjROjkdvixz5syRIkWKSLly5fR+3IdJROHy5cvy4osvaukUJgHq3bu3xMTEuHy+WWxsrGZaUB5mNm/ePClTpoxkzpxZihUrJj/88IPev3z5cqlYsaJkyZJFJx8aPHiw9TnG682fP19fL1u2bNKrVy+byU8HDBgguXLlknvuuUc+/fRTm9fs2LGjvPnmm9bbEydOlAIFCkju3Lll/PjxCUqhatasKZGRkfreu3XrZn3fuB8qVaqkpXTTp09P8L7Xr1+vz5s0aZLky5dPX2Ps2LHWx2/cuCF9+/bVfYqSNWzbpUuXbN4nytsMzzzzjAwdOlSvY66kRYsW2bzeAw88IF988YVe/+eff6Rp06aSM2dOue+++zRodOd9Jfa6UK9ePVm9erXNMkRERHR3BQQESKYMwVIwW4SUKZBVahfPKY89mF+er15YXqtfXAY3Ly2l8mXWTIrr9Yj2TfJHbp9Gr1u3bvJuSRq2bNkyKV68uHUizu+++04b4EajfsWKFdqwRuMc0AhEQFGlShVrgzdDhgxSo0YNvb1x40aNqB966CGvtgdBBYIBvOazzz4rPXr00KDBgIDht99+k5CQkATPxbInT57UIAYN1ccff1yGDx8uI0aMcOv5aEAj61a0aFHrfUuXLpV+/frJ4sWL9T1idlSjJA3lR9heBDR79uyRRx55RB588EFp3bq19fnYX3/88YecOnVK9+Fjjz2mQdHMmTO1Mf/LL7/oe3WV3Vm1apW8++67+j8+p9dff13Onj1rfTwoKEjGjRsnVatWlWPHjsmjjz6qAUifPn1k06ZN+mOxY8cOl+VhWB9mfD18+LDs2rVLateuLU888YQGaSNHjpQ1a9bI1q1b9T1jWxFA2AdajrRr106Xe+qpp/T2zp07dR+2aNFCoqKipEGDBhq8ff311/Lvv//qPsTxiP9dvS93IMgLDQ3V0rgKFSq49RwiIiLy0/l1LBjSuoCk6kwLpR2vvfaaBg3IaiDY+PzzzzUrYcCZdGQ20GndDMHGZ599JmPGjLGemUcndnPA4+r5cOHCBX1dM5QXoZGMM/5o/COgK1WqlD5Wp04dDe5QnojsEIKsH3/80eb52AY09PGesDwGDQBsKzqKG+/VWYd7Y1lkNxD0hIWFyejRo232CRrk2D6UuxUuXFheeumlBNuRGLwHBEZo5CNIQICD4AU++eQTGTJkiOTPn18D1vfee08/F2RgEvPcc89poIh9CwhgkEHD+0B/E2R2XnnlFQ0iS5QoIV26dNH366v3hX1rvDYRERH5p5YV8ku+rGE6j44juB+PJza/TkphR/y7ANkIs2bNmtncbty4sc3thg0b2ty2H70KZ+iTAqVSBjRU0TA+c+aMzX3OMgVYFiVmBlw/ceKEZn4Sez6ghOvKlSs29/3333+abXAEWRKUcCGTgtdG6RKyE2YIngwRERHWLM3x48cTvFdnsCwyOAYEZQi8DH///beWwqGcCtkL9NcxL++O7Nmza8DiaFuR5bDfrwgSkdVKDN4XgiBklTp37qwBCUrmjBIvZF7wfgxYr5Gl88X7wueJz5WIiIj8V0QKz6+TVMy0pEMIEszXcQYe5VMGZwMuoE8EGt1oCBtwHWfyzc9xNWADghOUJKFMyYDAYv/+/Q6Xb9u2rQZ52E708UDGwBwguYKshf17dXdZ9PNB/x0DXhfbjkY+7ke/IHe3w90yK/v9iswMAjL0kwEEFQb7YAYlYsjWoO8ZnmcEuti3yKTg/RgXBBnff/99ou/LnddFsIVg0siMERERkf/PrzOqVVmpem92KZoro/6P27jfXyeWBAYt6RA6YmOuEjReBw0aJE8//bQ2dBODYAMdsdE/Ao1f9CFByZUnI4Eh6EFfCvTTMaAkCR3ft2zZog1m9McwOv4bZ/FRaoZswIIFC9x+LbyvDz74wPpezR3IHS07d+5cLddCX52BAwfa7BM8H5kXlEKhgW8/XDI6zx84cEC8hRIvzFuDrBWCB2SXsE3YXwgW0UEf24csCfpIbd682eb56M+ybds2LWtDCZ2x7RjVCwEQ+vcgS4VMyu7du3XZxN6XO6+LzxH9h1CKRkRERKlnfp3PX64ha994WP/HbX/NsBgYtKTTYWrRSRsNUgQi77//vtvPRRCABjr6RqA/BMqS3n77bY9eHx3Mzf1gWrVqpX09OnXqpA1ojEiFzupGgIWO/mhUI+gwOpu7A6VSKCXDNqJzvX1Znn2JHoIxLIPsBEbZQqPdgM7qGI0L24HR0+y3A8EbXg9lWDNmzBBPIUjCYBeY+wSZD+wH8yhfCDomT56sJWYYyAGDDZghsMMIYRiUAFkXA7IlGFwAnfDRVwgZNQSJRhYpsfeV2OuiDA3ZGiIiIqLkFGBJYo0Lno6zwxjCNSlzeqQmyASgAYiRoNDwNxjlPea+Cf4G24az6U2aNEnR7UBggkAlpSeYJO8h84WBDn7++eeU3hRKJb8/RERE7rSpfZppwTC91atX17IQnJn+/fff9X6cxXVnmFZK39D3ggFL6oasEAMWIiIiuhu8ClowOhHmc8CEfihhMQ8Ni7Ka2bNn+3IbiYiIiIgoHfMqaEGHYUy+Z8xtYT8TN4anJf8tIUnp0jAiIiIiomQPWjBcLTItjmCSPwxNS0RERERElGJBC+aOMIaktYe+La4m8SMiIiIiIkr2oAUT/mH42TVr1thMKIiysPfee89myFUiIiIiIqKk8GqMYgQse/bs0UkCc+TIofdhjogzZ87oZHaYGI+IiIiIiCjFMi2YpRuzYyPT0qVLF51UDx3yMQwy7vd2vhaUnCEQQr8YlKD169dPbty44fI5mCMGy5UvX14nyMMYz8gEGZMTmh0/flyefPJJXQ6T5WG7jUn2iIiIiIjIP3k9T4sxQeDIkSNl+vTpMnr0aGnYsKHX67pw4YLUr19fg5TFixdb19u7d2+Xz9uxY4cu36ZNGw2YJkyYILt379ZZ0JH5McTGxuqs53///bcsWLBAPvzwQw2yEOCQ66zaM888I/5gw4YNOqQ2eSdTpkx6/Cc3nMBILdlW+32CkzA4oVGiRAmnv1PFixdPkZMd48aNk4EDB9711yUiIkq1Qct///2X6MVTmKUdDYElS5ZocNGpUyftH4P7kSFxpnbt2pqhwR9zBD0IXpYvX64By7x586zLffnll1rShv8fe+wxefrpp2XmzJny3XffydatWyW9wGzZP/zwg6SGoZnRTyo6Otp630MPPSQHDhwQf4RJVdHQDQwM1GPWH129elXuv/9+Sa8cHfvmfYKJMr/55hvN0u7bt8/hOsaOHasnOrJkyWK9b/DgwZIrVy7JmjWrZm9jYmKcbgNm/G3UqJFmkzHP1cKFCx0uN2fOHD3+zcdSt27d9H7zyRgiIqL0ItDbP/74g+vq4ikEGsjU4CynAQEIJq5cuXKl0+dFRkYmKEdDiRgaEeZgB+svV66czRlUlKLh9b7//nuPt5fI7MEHH9SJVpHho9Tp4MGD+tuG8lFHkK39+OOP5fnnn7feh9uffvqp/PLLLzoUPE6gvP32205f49lnn5VixYrJ2bNndRJeZHbs57U6d+6cjBo1Sue8MouIiNCh5ufOnZvk90pERJQughZkQ1CSZb4ga4Eg45577tHyK0/hj33JkiUTBCT58uVzOryyMyj3OH36tJQqVcrl+nEmE/d5un5PxZ3Y7/Jy8+p52+VPH3a5fPzFU15tBxpMyII98cQTWhbz1ltv6f3//POPDqSQM2dOLb9C49uZbdu2SZ06dSRbtmy6f/HZm8uCXnnlFWnZsqWuv0KFCpoZQcYMfZTwWX7++ec2gWTFihX1rHWhQoX0jLWhZs2a+j+2CevCGfL169freszDa1epUkUbmc2aNZOXX37ZOtmp/bJQvXp1PVNt+OSTT6RMmTJ6nCGLg0yct1599VVp0KCBhIWFJbrs9u3b9f3hdbGNOINuPjuP4xKlkTg2cfYeo/El1rfLvO5q1arpPkXg/txzz9ms1zjWz58/r8cB1o9gfsyYMdpgN+D6+PHjpVKlSrouNJZRGmU+lvB54vnYdyjJdAf2Pz4HHHsYxKNAgQLa6DfgfSJrihMf+OyR1TC/Lia0LVq0qB5/ffr0sflMEXTgM8B68Vxso/FcZ8e+sU+wv5ElwfGNxzF5rj0EJvh8EXQYEHighBXbhNcdMmSI3ucIvmdYx4gRIyQ8PFwefvhhadGiRYIgBO8L68R7cFSSi2wQERFReuNV0PL4448nuKCxiAYFGgU//vijx+tE4wKNOHtonKCB5S6LxSI9evSQ/Pnza0PFF+tH2drRo0etF3T+98SZnhVdXq6tnGmz/Pl3H3e5/JVPh4g38PkgqETQibIYNJ6ioqK0oYfGE94Xsk7on7Rq1aoEz8fjTZo00QYVzhSjsYiG3t69e63LoNwF/Rmwv1F2g2zW9evXtSzmgw8+0MACtwElMljHxYsX9XVnzJih5XuwadMm/R+vg23F69qf9cZxh+MNn1/Pnj1l/vz5bu8LNPwGDRqk+wRnthEYoGzQWXCAUfGwX3whKChI+yfgvaERi+/LpEmTbJbBfkC5Ehq6mzdv1gDLHd27d9fPEvsU+xwBkbPl4NixY9oXzNHZe7wmjhVkLLG+iRMnWh9DiRNKqHByANkl83ctMeiHhmDt1KlT+r5xTBh9RAYMGCC//vqr7hdsPwb9eO211/QxBBcvvviiZjfwugjKsC7zd79///66vVgWx6sRCDs69u3L+1CKhSAYj//vf/9LsN0Iku1PfCBLgkFADLiO8i28N3tYFnNY4TfHvLw504JjAd8nZGAcwYmCXbt2ubGXiYiI0pYkdcR3BGdkndVp3w3G/DHoz4JGsS+gcz8yAcYlLZUAffvtt3rGHBmSkJAQLZ9DgwmNPHsIClDCh0wKGt44o4+gYdGiRdZlEEjg7DfWhX5DaFwiOMDtp556SgMWo18KMjY4y49+IGXLltWGr7sBLxry165d0wAJ60YjGn2h3IWBGNDAxevivaDhjLPuW7ZscbqffNW5HBkoZFpQ1ohGLBrM9u8b2Qacuc+dO7dmkdCQdwca+eiTgYY7sgK1atVKsEx8fLx+Zu+8845mFZDVcBTcIBBEQx/LtG7d2mYbXnjhBc3AZMiQQcuhkKVC8OcOZFcQNOH9t2rVSj9/ZEcRdCBwQHCE941sBLYR24pt/uKLL/T3BX3X8Jn37dvXJgBAtgPHAbYJWYpevXp5dQLFGQTi5r4sgADHfDLEuH7lypUEz7df1ljeWBYBMzJ2yHRinziCrCICPJTNEhERpSfejU3sAs6Qu1MiYw+Nj0uXLjlsKJj7ubiCM/XDhw/XUjVkD9xdPwIRV5BZQEbBgDO4ngQuud533eAMzGz7/rIPWiYSH+t0+YBwxzX33nZ437lzp01jCg1ElPw4WhZn5c3LxsXF2dT4m0uyUIOPxiOCAgMaomi8Ac6mIxDAmWY02FAihSDIHWiUo/FrbtwhAEBGwN33jUYvzuwbsA3IPCQ3NNBxTKGUC5ku7EP0iTGz348nT550a92zZs3SEiWU3SET8cYbb+igFmbIBCBTZT7uHX0H7LfB+NxwfKC8CsEE1mV8BsgcGfM2uWJftmesG+vC/qhRo4bN41g/3j8+c/N24n4cAwZkNxBoYZQ5BAJo2Dvrn+IN/IbYjxqGgM78u2Jcd/S69ssayxvLoowSJWP47JzB+0Lg5CyoISIiSqu8ClpQfmUPDT6UNWzcuFFrsj3lqG8J/qAjQLAvyXAEZR/IFiBosW+kGeu3r7vHmV2UuKCEyRU0EuzPsHoiOF8xz5bPXViSC7IJZjiTjrP+6AOSGCyL4Y/N/UKSAv0V8JmhNAzBDM6MG6V39ttpD+V/CDDQMDUacOizYHxOaCCiAWxmbvjjvWB+H6MPzN2E94wMD/p+YXvff/99h5ktb6BPEsq6cGwjy4DMAzJa5n4YCGaQqUD5FfqkAK67C9uNvkwoIUSWBg15BLJ4zaRAgIvjAOVP5v415s8cJVoGfPbmIBPZKdyHZRA8IcBGBs2Q2DGVGGQF7UsE0ScK22tktHAd+zdPnjwJno9lkQVDYG0E/lge98Pq1av1N8ookUTZI04oILg3+sngN9ZcjkZERJReeHW6Dv0B7C9oIKE0BaUNmGPFU+gIjj/a5jPlOJOLBikaXq6gwY3SIpQ1mTtz26//t99+0z4CBpSRoaQFJSfpBRpT5mGD0VcDWQdkp5DpwFl/NJzQIdke+n2g8zw+byyHQBUNKnOfFk/grDHOXqOhiqyDeQAHNPzw2Tsb4hhn4/E8nJ1G1gDHjnk4W/SnQUYAjWts65QpU2wauAgc0ADFMYHGNs704305KutxB/YFhmdGoxmvh+t4fWfvG8EKzrAj6+LpEMlofDsLMlEWiZI8LIOGMf43Z7oAtzHJKjIyeN9oSKNczl3YfpRgITBAuR/K/3wBnzeCDHPwiveC4ANQXogAF+8d+xgDBZg76WO7UBKKQAxZGfQbcnXsewrZVbxfjBJmQNCLcjYMAoAgAydNUDrnCOZ3QZ8Z7C+s56effpKvv/5aOnTooI/jWEWZHQIZXCpXrqwZLXNfIrx3lAsSERGlN14FLfgDbX9BwxVnXtHosG8kuaNr167aiEN/CQxxjDOLKN/B/TjDakDZl/msMV4Xz0GDAGVK6JNgXMwNFNTkYwhRNNbQPwH18cjIoAGQlvqoJAblUGjoo0GLAA8ZCXxuaDyh9AbBAvpYOJo8D0NJo9GITspoAOJzwfpczUvhCgJcNPLwuaMvEhql5pIhNO4wWhK2FROBmiFTgMYszkoj8EHDzlymhqAAwQD6TmBbkWXBSFjmvjdotKPBiPXj+HHVkR9Br6tgHIE1giiUJuE1cd3Z+tCYxvGH942O5eb3nRhkRPA8ZGocwWeJx/C5Yr3Yx46GIJ88ebI2/FFehQEIEPQjEHFH+/bttf8InouO4WiI+woCSZTKoTwR7xNZQGMeJbwWSkARFOA4RTkYsh/GduPzRJYFnydOROB3wdWx7ymclEGZqHn+J9xG9hH7APsZxxGOaWfHDfr7IbuLgA/78aOPPrJmWlAGi9I544LXw3FsZGUQ6GBeqZTIDhIREaW0AEtSazp8CAEIGnzoF4MGC/6oY5Qf/PE2oOYbmQFcAKVKzs5sokFqLmXCmXaUtiEoMjoBo7HraekXRhBDAx8NSDTkDcY2OSptoeSH/jEITnxVvuaPUPqFs/GYx8OX8D1AgxgZq9QCQRca90uXLtVJZu8GZFMwAAUGJfBlfxl3ILOEfkPOPnv+/hARUWrjrE3tsz4t5jOJiUF5irtnNXEmNbFGk31ZDM46unvmEWeGv/rqK7eWJfJHKNHzBZztR58fY8hd9KtBHx9/hxI+ZN9w0gEjiyGjdTczpciGmEtM7yYMqkBERJReBXt7VhY1/MZ8GxgtDDX8gEaEOTPiSdBCRHcHhotGWRPOcKBUCcEQygL9HcoTkYFFfyGUwSHLYv69ISIiorTJq/IwdJpu06aNBiPoK4IyCXSCRcf5d999V2c992Wdu79heRgR+Rv+/hARUWqT7OVhmKEaneTNfUkQuKBjO7IvmCDN6DxLRERERER010cPwzCxjkYkMuaJQI08ERERERFRigUtKD/AcLL2lWW4jSFWMTM5ERERERGRLwR7O5cC+rJgTgLM8ZA7d26dBA4j+2CiOmNGZyIiIiIiohQJWjAxH2ZMR/CCCf4we3W+fPl06FEELBhGlYiIiIiIKMXKwwCBCWZ3/vfff7XzPf7HbQYs6c9///2nM7DHxMRYJwBF+aA7/vrrLx0W+27BHBuVKlXSgSMwz4cv7d+/X2dox3C8d9u4ceNk4MCBd/11iYiIiPw6aHE03CYmhsSM0ZS+3HPPPXL16lXJkCGD+Lv33ntPqlevrkN0+3r+oLffflt69eolQUFBehtzGXXt2lUiIyMlZ86cMmDAgAT9wAzYf3Xq1NHlsmTJosE/sphmkydP1oEuEHBhjhKUYxq6desmc+bMkTNnzvj0PRERERGl2qAFMzO//vrr1ttLliyREiVKSKNGjbSfy44dO3y5jURuiYuLS3SZgwcPaoPf19Cn67vvvtO+Xobhw4fLr7/+Kn///bf+v3jxYqcZKAR8eOzUqVNy+fJl+fDDD3XCx2PHjunjmzZtkv79+8tnn32mj2M+JMyVhOUhIiJCHn30UZk7d67P3xsRERFRqgxaEKRUrlzZehtlKWgw/f7779qvZdCgQb7cRvJxGREm8cHZ+qJFi2pJn+GTTz6RMmXKaGbgoYcekj179lgfQwkXSrkMb775pnTs2NGaZcPj0dHRib4+luncubNkz55dA1xk58zQIEd2AhMM5c2bV+cEcrZeZBaQNUFjHoNBYH4gZDImTJgg999/v74GjktMXATIZKxbt04DbpSzoV+WfSnbDz/8YDM5n6v9ZbZy5Up58MEHdTnD7NmzNfuCbUM2qk+fPjJr1iyHzw8JCZHSpUtrlgbvAfszNjZWB7Ywgq0HHnhAv194DP3K8B4QEBnq1atnk30hIiIiStdBCzreoxEGBw4ckH379mmgggZv9+7dZfv27b7eTvIBfE5oRCNQQHnUzz//rH0wAI1dfIY4k3/u3Dk9y4+R4VDi5EvoR7J7924NgPD6n376qc3jmLAUQcqff/6py6APiqu+JzjWUFKFjMT//vc/LaHCOhFEIAtRsWJFeeaZZ3TZn376SYMxLIdyrCpVqni9v+whYC9ZsqT19oULF+T48eM2fbxwPbE5jLB9YWFhUqNGDQ2yqlWrpvc3a9ZMgxhkXG7evClfffWVBjrm9ZcqVUp27drlcv1ERERE6Wb0sKxZs2o5DKxatUrPaKNzs1Hmgo75JDZnwN2FRvb48eP1OrICKDFq3769Nubhgw8+0EyXGZZzR3BwsJ7FR8MZQSdGfMMFUI6EjIVROvXyyy9r/48tW7Zo49lXEBS9//77mn0wMjYtW7bU6zimvv76a+0XZWQsEEh16NBBRowY4XB9WA8yGMg+oBGP94H9Z2RLhg4dKhkzZtTBAoxA212u9pc9BCn4XhgQFAGyVgZcR0CGMjas25ENGzZooLh8+XLt2G/0j0E/F5SeITOEoAXfs0WLFtlkdnAdmSo8Hhjos+5qRERERCnOq5YNGrE4Az1lyhQZM2aMtdFpnJ32tHFIdwc6caPPAwKfPHny6Nl7o+QLJV59+/bVhrVxQUbN6FPhK8g+mI8P80Sk2AaMvIVyLGMbmjdvbg2QHcGy5tHHsI6nn37a+nxkYdCAN0rEfLW/7GXLlk0DBgNKt+DSpUvW+3AdWRRnAYshNDRUy7++//57DeLg448/1gsyKQhqcLIAgaw5s4JsEIIbBixERESU1niVaZk4caI8//zzepYcmQHzWfD58+driQt5nglxlKGxz9L06NFDL95C521coqKi9PPr0qWLnt1HINGvXz9rPxV7yFbgOYaTJ0969fr58+fXrAf6fwCuG7ANaNAjSEHD3R32wyVjHeijgoyEOxBcuHpfzvaXPZSNTZ8+3SaIwXtFUFGgQAG9D9dRQukuZGRQfmmUnyFoQr8XqFmzpvYrQ+maUSK2d+9eDjlOREREaZJXp2TRCFu7dq2e2f3xxx/1LLRhxYoVMmnSJF9uI/kIsmBo5KJECeVFaLAb5UevvPKKThb622+/aUkUypvQzwWfMVSoUEEDUmRC0K/CfjhedyELMnLkSB2aFxdk6gzoeI+Gec+ePbXcCttx5MgR7RzvLryPt956y9rYx3q++OILp8vjfWFCVLxfvJb52HW1v+w98sgjuu+MsjBAAIj+OHifWDfK1jp16uS0bw6CW8x1g0zKzJkzZfPmzdbgC31bkHkxOt5v3bpVPwcj+IP169fr/iMiIiJKa3xeR4LyFHfPktPdhQYxGvS5cuWSHDlyaH8VY+QslCMNGTJE+4+grAojeyFIMaBEas2aNfoYGt/PPvusV9uAskJ0GMfoXsgW2K8H5VhGB3P0EWncuLHNCFmJwUAQ6HiPsjIci2jUI5B2BvOq4HXQV+WJJ56Q5557zq39ZQ+BO0YqQwBkwP7E62Nf4v1gH2NkNANGAzMGIkAnewwljnI2rGvGjBm6LgRVgIER8NlgWHH0XWnbtq2uH8ESoB8Zhlx2likjIiIiSs0CLM5mu7PTokULbayiAYbrLlcaEOD1mfjUAP0j0JcCZ88xNK+5PwWYh8yl9AMjnT355JOyc+dOpxmZ5ILv5tmzZ2XUqFF39XXJf/D3h4iI0kqbOkl9WlAmhNIgQIdj+74EROkdAnr0PUkJyNIQERERpVXB3nQmR+08ERERERGRX/ZpQadk1Olj8j4iIiIiIiK/C1owzwTm7uBcEEREREREdDd4FXm0atXK5TCy6RUCOcxGTkR0t6HP4d0eAIKIiMivg5ZatWrp8KoYVnbq1Kny1VdfyeLFi20u3sBs4xjCFRMZYs4OTHaIOSsSg23AtmBoWgwQYB521twPB4/ZXzA8rq9gqGcMk4sSOiKiu+XcuXP6W4lMOBERUbruiG/2wgsv6P8nTpzQCe/sIRgwRhpzFyYBrF+/vo7AhKAHJWi9e/fWmcgnT57s8rnz5s3T/zFPhnHdmdmzZ0vJkiWttzEvhq9gXRhZDbO8c64aIrob8FuLgAXz9/jy94yIiCjVBy0HDx70+YZg0j40+JcsWSLZs2fX++Li4qRbt24ycOBAyZ8/v9PnYmZwlGZhnoLEgpYyZcpI5cqVJTkEBwdLgQIFNADDthMRJTecIMFEqghYOBQ9ERGlVV4FLYULF/b5hixfvlwaNmxoDVigTZs2OoM4RipzNdO3Pw0KgNI2XIiIiIiIyDf8prWP/izmsi2IjIyUfPny6WO+ghIydFbFrJt9+/aV69ev+2zdRERERETkJ5mW5ICSKgQp9rJlyybnz59P8vqzZs2qHfvr1Kkj4eHhsnbtWhk3bpzs3btXvv32W5fPRdkaLgb05SEiIiIionQWtCS3ChUq6MWATv/I4rz22muydetWqVq1qtPnTpgwQYYNG3aXtpSIiIiIiPyyPAwZlUuXLjnMwJj7ufgS+szAjh07XC6HUcyOHDlivSDIISIiIiKidJZpQX8W+74rCGJQimXf1+Vuw8g8uBARERERUSrJtCAzsWbNGptsSJcuXaR27doydOhQr2aFb9q0qaxevVouXrxovW/RokU6MlijRo0kOSxcuFD/r1KlSrKsn4iIiIiIUijT0qtXL2nQoIFe4PXXX5elS5fqbPbo3I7RuQYPHuzROjG08aRJk6Rly5Y6Lwsml8ToXrjfPEcLXvPw4cOyf/9+633bt2/XOVrOnDmjt7ds2aL/58qVS+rWravX27VrJ8WKFZOKFSvqrNHoiD9x4kR9veSat4WIiIiIiJIuwGKxWDx9EiYxmz9/vmZHMGQwbmPW+hdeeEGmTJki77//vvz9998ebwxG8urevbtOFonZndu3by8jRoywmV3+4Ycf1gAFFwPmcJk7d26C9SFgWb9+vV4fNWqUfPrppxrwxMTESJEiRaRt27YyYMAAj2evP3r0qBQqVEj7t2DoZCIiIiIikmRrU3sVtEREROhkkAgKUNLVpEkTOX36tHaY37BhgzRu3FiioqIkrWLQQkRERER099rUXvVpKVq0qAYtgOxFpUqVrCN8IXhhp3UiIiIiIkrRPi0YArhz584yc+ZMnfgRpWIGlGOVK1fOZxtIRERERETpm1dBS6dOnbRT+7Zt27Rje7169ayP5ciRQ3r27OnLbSQiIiIionTMqz4t6R37tBARERER3b02tduZll9//VVKlSol4eHhej0xyMAQERERERElldtBC+YywfwnVatW1esBAQEOl0PiBo/Fx8cneeOIiIiIiIjcDlrWrVsnpUuXtl4nIiIiIiLyq6DFmFne/joREREREVFy8mqeFiIiIiIiIr8PWjA3S+3atSV37tw6maT9hYiIiIiIKMWClk8++US6dOkiZcqUkbNnz0qbNm3kySeflNDQUA1i+vTp45ONIyIiIiIi8ipoGT9+vAwePFimTJmit7t16yazZ8+WgwcPSq5cuSRTpky+3k4iIiIiIkqnvApa/vnnH6lVq5YEBQXp5fLly3p/5syZpX///vLBBx/4ejuJiIiIiCid8ipoyZo1q8TExOj1AgUKyJ9//ml9DPOznDt3zndbSERERERE6ZrbQx6bYXLJ33//XRo3biwtWrSQYcOGyc2bNyUkJERGjx4t1atX9/2WEhERERFRuuRV0DJgwAA5fPiwXh8+fLhef/311zVwqVKlinz00Ue+3k4iIiIiIkqnvApakEkxsimRkZGybNkyLRfDhcMdExERERFRivdpmTFjhly6dMnmvgwZMjBgISIiIiIi/whaXnvtNcmTJ4/2Z1m4cKFcv37d91tGRERERETkbdBy8uRJmTRpkly7dk3atWunE0q2bdtWvv32W4mLi/P9VhIRERERUbrlVdCSLVs26dKli6xZs0aOHj0q7777rhw6dEgzL8jAvPzyy77fUiIiIiIiSpe8ClrM8ubNKz179pRNmzbJDz/8IOHh4fLxxx/7ZuuIiIiIiCjd82r0MDNkWtCvBZedO3dK9uzZ5aWXXvLN1hERERERUbrnVdBy5swZWbRokXz22WeyefNmiYiIkJYtW8o777wjjzzyiAQHJzkWIiIiIiIi8r48LH/+/PLGG29oB3xkWE6fPi3z5s2Tpk2bJilg+euvvzToyZgxo5ad9evXT27cuJHo86ZOnSrNmzeXXLlySUBAgHz55ZcOlzt+/Lg8+eSTkjlzZs0Ide7cWS5fvuz19hIRERERUfLzKsJAn5UnnnjCp/OyXLhwQerXry/FixeXxYsXy7Fjx6R3794SFRUlkydPdvlcBEzw6KOPWq/bi42NlcaNG+v1BQsW6Hr79OljHfWMiIiIiIjSUNDSoUMHn2/ItGnTNOuxZMkSzYIAhk/u1q2bDBw4ULM7zmAQgMDAQB3BzFnQguzLnj17ZO/evVKiRAnrKGgIZLZu3SpVq1b1+XsiIiIiIqIUClo6deqU6DKzZs3yaJ3Lly+Xhg0bWgMWaNOmjXTt2lVWrlwpHTt2dPpcBCzurL9cuXLWgAVQiobX+/777xm0EBERERGlpaAFo4Q5Ku86cuSI5MyZUwoUKOBVfxb7YCgyMlLy5cunjyUV1lGyZEmb+9D/Bff5Yv1EREREROTnQQug9OrZZ5+V8ePHe7xOBD0IUuyhhOv8+fPebKbP1o+yNXOH/RMnTiR5e4iIiIiI6C5NLmlWqlQp6d+/v/Tq1UvSkgkTJkihQoWsF5aSERERERGl0qAFsmbNKvv37/f4ech4XLp0yWGGxNzPxVtJWT9GMUPpm3FBx30iIiIiIvLj8jBH5VSYTwXlYRjpq0yZMh6v01HfEgQZKMWy74viDaxj9+7dNvdZLBbZt2+fdsh3BUM7+3J4ZyIiIiIiSuagBZ3t0YndHoIAlE8tXbrU43ViYsqRI0fKxYsXrX1PFi1apCODNWrUyJvNTLD+Tz75RP755x+dCwbWrFkj586d0/ldiIiIiIgoDQUtGM7YPmgJCwuTggULSrVq1SQ42PPVYmjjSZMmScuWLTVbg8kl+/btq/eb52hp0KCBHD582KYEbfv27TpHy5kzZ/T2li1b9P9cuXJJ3bp19Xrr1q01KHryySf1f2NyyWbNmrGPChERERFRWgtaXM2ZkpQ+J8h8dO/eXQOXzJkzS+fOnWXEiBE2y8XHx+ukk2aTJ0+WuXPnWm8bo5chYFm/fr1eDwkJkR9++EF69OihI5whsGrVqpVMnDjR5++FiIiIiIh8J8CCmi7yyNGjR7UMDp3ykV0iIiIiIqLka1N7PXrY/PnzpXbt2pI7d25rR3XzhYiIiIiIyBe8ClrQob1Lly46StjZs2elTZs22lckNDRUgxj0FSEiIiIiIkqxoAV9RgYPHixTpkzR2926dZPZs2fLwYMHtfN7pkyZfLJxREREREREXgUtGDa4Vq1aEhQUpJfLly/r/eg8379/f/nggw98vZ1ERERERJROBXo7631MTIxeL1CggPz55582o3th7hMiIiIiIqIUG/K4cuXK8vvvv0vjxo2lRYsWMmzYMLl586YOKzx69GipXr26TzaOiIiIiIjIq6BlwIABOsEjDB8+XK+//vrrGrhUqVJFPvroI19vJxERERERpVNeBS3IpBjZlMjISFm2bJmWi+HC4Y6JiIiIiCjFgxZHMmTIoBciIiIiIiK/CFq2bNkiixYt0hkso6OjbR4LCAjQ7AsREREREVGKBC3vv/++9OrVSyeSvO+++3RSSSIiIiIiIr8JWsaNGyevvfaa/O9//5PAQK9GTSYiIiIiInKLVxHHtWvX5PHHH2fAQkREREREyc6rqOPpp5+W5cuX+35riIiIiIiIfFEehrKwzp07S9u2baVhw4Y67LG9Vq1aebNqIiIiIiKipActf/31l/z8889y6NAhWbhwYYLHMXpYfHy8N6smIiIiIiJKetDSqVMnyZQpk3zzzTdy//33c/QwIiIiIiLyr6Bl7969snjxYmnSpInvt4iIiIiIiCipHfHLly8vp06d8uapREREREREyR+0TJ06VSZOnCgrV66UuLg4b1ZBRERERESUfOVhDz30kMTGxkrTpk11rpbw8PAEHfEvXbrkzaqJiIiIiIiSHrS88cYbGpgQERERERH5ZdAydOhQ328JERERERGRr/q0JBfM//LII49IxowZJW/evNKvXz+5ceNGos+zWCwyevRoueeee7RUrUaNGrJlyxabZdavX6/ZIfvLM888k4zviIiIiIiI7lqm5emnn5YBAwboyGHuiI6Olo8//lgiIiJ0XpfEXLhwQerXry/FixfX4ZSPHTsmvXv3lqioKJk8ebLL544ZM0aGDBmigUu5cuVkypQp0qhRI9m1a5cULVrUZtnZs2dLyZIlrbdz5szp1vshIiIiIiI/D1qQxahVq5ZOJtm6dWu9jgAhe/bs+jgyIgcPHpQdO3bI8uXL5euvv9Zlp02b5tb6sdzly5dlyZIl1nViZLJu3brJwIEDJX/+/E6Do1GjRmk/m169elkHCsBrjxs3Tkc6MytTpoxUrlzZ3bdNRERERESppTxs7Nixsn//fmnRooXMnDlTsyK5cuWSkJAQzaagLKt06dLSsWNHDT4+/fRT2bZtm1SqVMmt9SPQadiwoTVggTZt2sjNmzd1aGVnNm3apK+HZQ2hoaHSqlUr+f777919e0RERERElBY64ufLl0+GDRumFwQw27dvlxMnTmi2A8FGiRIlpGrVqhrEeNOfxb6MLDIyUl8Tj7l6HphLvqBUqVLy33//yfXr122GZH700Ufl3Llzut5nn31Whg8fnmDIZiIiIiIiSuWjh0GxYsX04ivo04IgxV62bNnk/PnzLp+XIUMGCQsLS/A8dNDH4whKsmbNqh3769Spo7fXrl2r5WN79+6Vb7/91uW2IZODiwGBGhERERER+WHQ8ueff2rfE/RdQR+Tp556Sku6UoMKFSroxYDyNmRbXnvtNdm6datmiJyZMGGCZpeIiIiIiMiP+7Rs3LhRKlasqCNzoa/KrFmzpHHjxm53tE8MMiOXLl1KcD8yJeZ+Lo6eFxMToyVq9s/DkMZ43BmjHwwGD3AFo5gdOXLEekGQQ0REREREfha0YEhh9Bs5dOiQnDx5UvuFtGzZUgYNGuSTDcG67fuuIIhBKZZ9fxX758G+ffts7se6jHlbkipLlixSsGBB6wUZGiIiIiIi8rOgZffu3fL2229LoUKFrA358ePHa38TZB+SqmnTprJ69Wq5ePGi9b5FixZJYGCgzrniTM2aNXVbsKwhNjZW53pBp3tXFi5cqP9XqVIlydtPREREREQp3Kfl7NmzmmUwMwIYPGZc91bXrl1l0qRJmr3BvCyYXLJv3756v3mOlgYNGsjhw4d19DJAB3xMejl06FAdgrls2bI6NwsyQX369LE+r127djpwAErc8Bx0xJ84caK+nrfztsSdOihxQbZlaYbAzNklMNOdsra404dF4mOdrisgPLMEReax3o4/f1wsMVHOlw8Jk6Ccdz6P+MtnxXLtTsCXcIOCJDhPEevNm9cuys3LZ50vLyJBeYpIQGCQXse2YJtcLp+joASE3hoQwRIXK/FnDrtcPjBrbgmMyGK9HXdiv+vlM2WTwMw57ix/5j+RuBse7NMTYom55nz5kAwSlLOQ+/s0IFCC896ZvPRm1CW5eemMy/cQlPteCQgK9mCfFpCA0FvZQkt8nMSfPuTZPj15QMRicb58xmwSmMWDfRqWSYKy5bXejr9wUizRV51vUHCoBOe6x3rz5uVzcvPaBefLBwRIcN777iwfdVluXjrt/j69cV3izx1zvXz2/BKQIcKDfZpLAiOyWm/HnfxXxHLT+VvIGClBWe5MWht/9ohYYmOcL58howRlv5O9jb94SizXr7i/T6+ck5tXXexTPCVfMc/2aa7CEhAcotctN6Il/txR9/fpzXiJP3XQ5fKBWXJKYMZIm99SuRnvwT49KpbYaOfLZ4jQbXJ7nwaFSHDuwtabN6+el5tXnA8Ak2CfXr8iNy+ecrl8UK57JCA4VK/jeMBx4UpgtnwSGJbx1vI3b0r8qX9dL585h/5Gur1PI7JKUNZc1tv43uD743T50HD9PbIuf/G0WK7fGaAmgaBgCc59r/UmjlEcq64E5b1Py7p1+eircvPCSdfL5yykv9vu79O8EhiW6dbyFovE4/fRk32K34r4OKfLB4RnkaDI3N7v00tnxBJ1yf2/4+7s0zxFJSDw1vnpm9HX5OaFE+7v07gbEo+/CS4ERuaRwPDM7v8dZ9uIbSM7cadOJE9HfOPHJDmg78maNWuke/fuGkhkzpxZOnfuLCNGjLBZLj4+XiedNOvfv7/+AGE0sDNnzkj58uVlxYoVUrTonZ32wAMP6NwxyA6hD0yRIkU0OELA461zQ5pKhgjHyapMzwyWzK36Wm+ff/dxiUdjx4nwum0l8tU7/YMufdRDYnY6n58mpEQ1yfnOKuvtq4vHStT3HzpdHgd0npl3GhLXN3whl2fdCeocyTP7P20swI19W+T8uy1dLp9j5DoJLXZrXh58ic/0rOhy+cjuMyT8oaett8/0ruryD0Km1m9K5jYDrbcvjGotcUedD4cdVvspydZjpvX2pY97S8z275wuH3JfBck56kfr7WvL/ifXvvnA5R/9vHPu/JGM3rRELk3vIa7k/vhfa+Prxv4dcn5YM5fL5xi+UkJLVtfraGgmtk+zdvtQIh5+znr7bN9aLn/gMz7RR7I8+7b19oX3npW4w7udLh9WvaVk6z3Pevvy7H4SvWWp0+WDC5eVXGN/tt6++t0UubZknMvGZt75dxoq0Vu/kUtTXxFXck/7y9pAjf33Nzn3tvPMLGQf8p1keOAh6x+oRPfpSx9IRMOO1ttn36zrsmGR8bEekuX5d623L4xvJ7EHdjpdPkPlZpK932fW25fnDZTojXcyx/aCC5aUXBPu9Ku7tvwjufrlaOdvIChY8n12pwEes2O5XJzUxfnyIpJr8m5rIz72vz1ybmA9l8tnH7RUMpSrr9cRHCS2T7N0GicZm7xkvX1uYH2Xja+IR1+RrB3HWG9feP8Fid33i9PlM1RoJNkHfGm9feXTIXL9xwVOlw/KW1Ryf7DLevvayplydeE7Lt9Dvi/uNNhjdq2WixM7uFw+1/u/WgOduGP75Gy/2i6Xz/bmFxJWsYleR8M30X3aYZRkbPaq9fa5t5u4bKBGNOosWTtPsN7GMXHjz41Olw8tW09yDF5mvX1l4Ttyfe1cl0Fa7il/WG9HrZ0nVz4Z7PI95F1wTuR2sHzj9/VyYVxbl8vnHP+LhBQqZT2ZcPaNai6Xz9ZngYRVbX7rRnxcovs0c7t3JFOLntbb54c1d9mID6/fQSK7TrLevji1m9zYvc7p8qGla0uOoXfmk7u6aJRErfzYZSCb56M7pfA4pi/Pdd2GyTPvhATcDn5v/LlBLoy+M6edIznf2ygh95bT63ivif4d7zVXwms8Yb2d2PJsG7FtZO9clPOTgEkKWurVq6flWvYwA735fgQ3jjrVJwZzq6BEzJX169cnuA+vh+DDVQCS2ONEREREROSfAixIUbjB0yF/0XE/rTp69KiWwx3c/pMUzO+4Uz5ToEyBOsLyMJaHJVie5WEsD3OA5WEsD0u4QSwPY9so7bWNjh4/IUUq19H+8fbdULwOWihh0OLODiYiIiIioqS1qd0ePYyIiIiIiCglMGghIiIiIiK/xqCFiIiIiIj8GoMWIiIiIiLyawxaiIiIiIjIrzFoISIiIiIiv8aghYiIiIiI/BqDFiIiIiIi8mu3ppEmj8TF3ZoR98QJ1zPLEhERERGRY0Zb2mhbu8KgxQtnzpzR/6tWrZrSm0JERERElOrb1vfee6/LZQIsFovlrm1RGhEdHS27d++WXLlySXBwcIpFpgiatm7dKvny5UuRbSDP8XNLffiZpU783FInfm6pEz+31OmEH3xuyLAgYClbtqyEhYW5XJaZFi9gp1apUkX8AQ6yggULpvRmkIf4uaU+/MxSJ35uqRM/t9SJn1vqlC+FP7fEMiwGdsQnIiIiIiK/xqCFiIiIiIj8GoOWVCpLliwyZMgQ/Z9SD35uqQ8/s9SJn1vqxM8tdeLnljplSWWfGzviExERERGRX2OmhYiIiIiI/BqDFiIiIiIi8msMWoiIiIiIyK8xaCEiIiIiIr/GoCWV+euvv+SRRx6RjBkzSt68eaVfv35y48aNlN4scmH//v3StWtXKV++vAQHB0uZMmVSepPIDYsWLZLHH39cJ9zC9w2f36xZs4Rjl/i377//XurWrSu5cuWSDBkySNGiRaV3795y6dKllN40ctPVq1f1excQECDbt29P6c0hJ+bMmaOfkf3lzTffTOlNIzfMnTtXKlSooBOm58yZU5o2bSrXr18Xfxac0htA7rtw4YLUr19fihcvLosXL5Zjx47pH+OoqCiZPHlySm8eObFnzx757rvvpFq1anLz5k29kP+bMGGCztI7fvx4bQCvWrVKunTpIkeOHNEhIsk/nT9/Xr9rPXr0kBw5csgff/whQ4cO1f9XrlyZ0ptHbnjnnXckLi4upTeD3PTDDz9I1qxZrbcLFCiQottDiRsxYoSMGTNGBg4cKDVq1JCzZ8/KmjVrJD4+XvwZhzxORUaNGqUH2n///SfZs2fX+6ZPny7dunXT+/Lnz5/Sm0gOIEgJDLyV1OzYsaOeOUQDivwbfsRx9snspZdeks8//1xPIBifKfm/GTNm6GeHEz38nfT/aoLKlSvryQJkqLdt26a3yT8zLS+88IKcOXMmwW8l+a99+/ZpxcfXX3+t2ZXUhH91U5Hly5dLw4YNrQELtGnTRhvFPIPov9i4TZ0c/RFGKv3y5cty7dq1FNkm8g4yLsBSWv/XvXt3DVZKlCiR0ptClCbNnj1bihQpkuoCFmBrKpWdgSpZsqTNfZGRkZIvXz59jIiS18aNG7X0IXPmzCm9KZQIlDlER0fLr7/+KsOHD5cWLVpouR/5ry+//FJ2794tb7/9dkpvCnnggQcekKCgIO0/hooQfy8xSu+2bNkiZcuWlXfffVdy584toaGhUqtWLfnll1/E37FPSyqCkhQEKfayZcumddxElLwBy8KFC7Vshfxf4cKFtRwMmjRpIgsWLEjpTSIX0DcTfTRHjhwpWbJkSenNITfghOmwYcO0Dxk64KPcaNCgQfq9Yz9b/3Xy5EnZsWOHniCYOnWqRERE6PeuUaNG8s8//2gg468YtBARJeLo0aPy9NNPS7169bSDN6WOUcRQxoeBMHBG8bHHHtPBFHBGmPwPPqM8efJoHwlKHRo3bqwXAxq94eHhMnHiRHnrrbc0qCH/c/PmTR2hD5nNcuXK6X3Vq1fXTDSCTWSm/RXLw1IRZFQcDduJDIy5nwsR+c7Fixe19hf9Ir766iv2UUol8McYo+J07txZli1bJuvWrZMlS5ak9GaRA4cPH9YMJs7a428cvnNoVAH+N66T/0M/W5SH7dq1K6U3hVy0JfH3zAhYAG1I9NnESR5/xkxLKoL+LPZ9V/ADf+LEiQR9XYgo6TBmffPmzfV7tnnzZpthPSn1wB/nkJAQnTOJ/M/Bgwd1kIRmzZoleAzZTZQfoQ6fiHzTB+nAgQMOH0M/QH/GU4apCM72rl69Ws9CmSfAw5lfpGWJyHcwTwTOGu7du1fnIeDcA6kXOpjGxsZqR2HyP5i4FZkw8wUlRjBt2jStu6fUAf3+UIKJs/bkn5o3by7nzp2zyYbhNgYtqVSpkvgzztOSiqAMDBHy/fffrxMCGZNLPvfcc+z05ucdTFFfD1OmTNEzHJi4EIyZu8n/YF4PzO+BspWaNWvaPIY/yJhtnfxPq1atdF4PZFdQX//bb7/J2LFjtXMp5vzASDnk/9avX69ZFs7T4r/QnwUTXmMkKkBHfMwd17NnT2vQSf7Zp6V69eo6gBPm/sPvJEZ9Qyd8zCGXN29e8VcMWlIZnPXFOPabNm3SYVfbt2+vBx3/EPuvQ4cO6ZjojuCM4sMPP3zXt4kSh06JqLV3Vs7C4XP90+jRo3UCUJwcwB9nfE4IZPr06cNRqVIRBi3+D8EJ5o/DQCX4ruGEKvqQoY2C0cTIvydP7tWrl3zzzTdamvnQQw9poFm6dGnxZwxaiIiIiIjIr7FPCxERERER+TUGLURERERE5NcYtBARERERkV9j0EJERERERH6NQQsREREREfk1Bi1EREREROTXGLQQEREREZFfY9BCRERERER+jUELERFRMszojlnBt2/f7tHz5syZo8/DjNXuuHjxogwdOlT+/PNPL7eUiCh1CLBYLJaU3ggiIqK05PLlyxpIlC1bVjJmzOj2886cOSMHDhyQypUrS3BwcKLLHzp0SIoUKSKLFi2S1q1bJ3GriYj8V+K/iEREROSRLFmySPXq1T1+Xq5cufSSHK5fvy7h4eHJsm4iouTG8jAiolRg8+bN0qJFC8mfP7+euS9fvrzMnz/fYUnSqlWrpG3btpI5c2YpXLiwvPfeezbLdezYUcqUKaPLV6hQQddXtWpV2bFjh81ySMSPGzdO7r//fsmQIYMULVpUJk6cmGDb9u7dK48//rhkzZpV19WsWTPNFpjNmjVLHnjgAW0058iRQ2rXri3btm1z+Z5Hjx4txYoVk7CwMG3IN2zYUA4ePGh9/M0339RMRqZMmaRAgQLy7LPPyokTJ2zW8fDDD0vz5s3lyy+/lBIlSuiy9evXT7B9ib2WvdjYWOnbt6/cc889um/y5csnjz32mFy6dMlpeRhu47NAOVeePHkkZ86c8sILL8i1a9dcloc52zYjywJPPfWUPg8X3I8LrmN9Xbp00X2OzxhiYmJk4MCBemxg20uVKiULFixw+VkQEaU0ZlqIiFKBw4cPS61ataRr167aeP3555/lxRdflJs3b0qHDh1slsUyzz//vCxZskSWLl0q/fv3l3LlykmTJk2sy5w8eVJ69OihDX8EGwMGDJAnnnhCG/MhISG6TM+ePeXjjz+Wt956S6pVqyabNm3SdSHwwGvAv//+KzVr1tQgCA3kwMBAGTFihDRo0ED27dunjeKffvpJt7VPnz7y6KOPSlRUlGzdulX7Yzgzb948GTx4sAwfPlxq1KihwcCGDRu07Mpw+vRpbXwjkENZ1fjx46Vu3bpalmUurdq1a5eMHTtWG//x8fHSu3dvadeunQaC7r6WvVGjRsm0adNkzJgxGowhyFi5cqUGBK5MnjxZHnroIZk7d678/fffGvgggMG2ebofSpYsKYsXL5ZWrVrJyJEjpV69evocBFBG8IbPFUHkZ599pscKtGnTRjZu3ChDhgzRgOX777/X/ZEtWzZp2rSpy+0nIkox6NNCRESpx82bNy2xsbGWl156yVKjRg3r/evWrUMfRUvfvn1tlr333nstL774ovW+Dh06WAICAix//PFHgudu2LBBb+/fv1+X+eijj2xeu3///pa8efNa4uPj9Xb79u0tRYsWtVy/ft26zOnTpy2ZMmWyTJkyRW+PHTvWkj17do/e46uvvmqpWLGi28vHxcVZjh49qu9hxYoV1vvr1q1ryZgxo26TYfbs2brckSNHvHotaNasmaVVq1ZOHzf257Zt26z34XbVqlVtlsNncd999yXYtjNnzri1bQcPHtTlFy1a5PD+Jk2a2Ny/du3aBPsInn76aUuVKlUSfd9ERCmF5WFERKnAhQsXNDOCkh5kQnCZPn26nq2316hRI+t1lAjhbPrRo0dtlkF2AhkCQ+nSpfV/Y7nVq1fr/08++aTExcVZLyhNQpbmyJEj+jiyCyhbQ2bDWAZn7FF2ZpR/VaxYUc6fP69laShdQ6YlMXjOzp07NSuCrADKsewtX75cszzIFOH1CxYsqPfb7xOU0pn7idi/V3dey9H2IUOBUi+8TyOLkZhHHnnE5ja2xf6zsX8dT7fNDFkWM3xe2bNn1xI58+eK7cLrIBNFROSPGLQQEaUCaPCjxAclVmh4oqHcqVMniY6OTrBsZGSkze3Q0NAEyzlaBozlUO6E5AD6XRhBEi5Go9sIWrDc//73P5tlcEEJk7EMGsjof7Nnzx5p3LixrrN9+/YayLh6v+g/s2LFCi2nQtCBcjV0Jge8f6OPD9aNUq8tW7bYvAd332tir+UISuZQKocyL/QVyZs3rwwbNkz3mSuOtsVVSZk322aG0jMzfF7Y7/afV+fOnTV4se8TRETkL9inhYjIz6Fx/e2338qECROke/fu1vvdPbvvDZyNR5YGZ/eNRr4ZOrUby+Fsfrdu3RIsg4EADOgzgQsazcuWLZNevXppY3nmzJkOXx99Y9A4x+XYsWOycOFC7X+DgAd9PNBfBxmWL774Qpc1+v14I7HXcgR9dZBlwWX//v060ACuY7AC9CfyFW+2zQyfoRk+LwQ+yBI5kjt3bp9tOxGRLzFoISLyczgTjwDFHDxcuXJFvv7662R7TXSkh3PnzumoWM6gXOyPP/7QcrCgoKBE14vGNjrlo9GMUcfcgZHB3njjDR3hyngOMg0IesyN8k8//dSt9Xn6WonByF7oCP/RRx+5/RxfbZt91igx+Lwwghmeh8EZiIhSCwYtRER+DhmFKlWq6AhTOEuO/hu4jvsxglZywDDHr776qmYNMMIVRg9Dfwr0F1m3bp2OSgYoicK2oezrpZde0nIk9Hn58ccftZwJwxBjlCoEPxh+GGfyd+/eLT/88IP203Dm5Zdf1r4xmOsE/2O0tN9++82a0UGZGsrSkHnCqGcoD7MfAtpdib2WIy1btpRKlSpZh4z+5ptvtN8RSuF8KbFtQ1kaSs5QOojhj5EBchWMYL8hCMVIcv369dNlMeQySveQMcJocURE/ohBCxFRKoCz62jAYnhjzLmBTvlXr17VeVSSywcffKBlYMggYMhdzHGC25gTxJxlwPDFgwYN0oY0tglD7tapU8faeEZQgwADpVwYqhcd5hEI4TnOoIP9jBkz9IKO+8YcMcjSAIZOxnDDkyZNktmzZ+tw0CihQ7DlqcReyxG8Ht4PhllGXxDsF2R6kMnwpcS2DeVjeP8Y+hnZMWTlXM0vA5izBkHv1KlTtaQOwS+GrMacMURE/ioAQ4il9EYQERERERE5w9HDiIiIiIjIrzFoISIiIiIiv8aghYiIiIiI/BqDFiIiIiIi8msMWoiIiIiIyK8xaCEiIiIiIr/GoIWIiIiIiPwagxYiIiIiIvJrDFqIiIiIiMivMWghIiIiIiK/xqCFiIiIiIj8GoMWIiIiIiLyawxaiIiIiIhI/Nn/AdJTWnIJx5eUAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 825x374 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P(mauvais) apres k annees sans sinistre :\n",
+      "  k = 0 : 0.300\n",
+      "  k = 1 : 0.288\n",
+      "  k = 2 : 0.275\n",
+      "  k = 3 : 0.264\n",
+      "  k = 4 : 0.252\n",
+      "  k = 5 : 0.241\n",
+      "  k = 6 : 0.230\n"
+     ]
+    }
+   ],
+   "source": [
+    "annees = np.arange(0, 7)\n",
+    "p_bad_experience = (P_MAUVAIS * np.exp(-LAMBDA_B * annees)\n",
+    "                    / (P_MAUVAIS * np.exp(-LAMBDA_B * annees)\n",
+    "                       + (1 - P_MAUVAIS) * np.exp(-LAMBDA_G * annees)))\n",
+    "\n",
+    "p_pos_tel = P_MAUVAIS * SIGNAUX[\"telematique\"][\"sens\"] + (1 - P_MAUVAIS) * (1 - SIGNAUX[\"telematique\"][\"spec\"])\n",
+    "p_bad_tele_neg = P_MAUVAIS * (1 - SIGNAUX[\"telematique\"][\"sens\"]) / (1 - p_pos_tel)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7.5, 3.4))\n",
+    "ax.plot(annees, p_bad_experience, marker=\"o\", label=\"experience : k annees sans sinistre\")\n",
+    "ax.axhline(P_MAUVAIS, color=\"#999\", ls=\":\", lw=1, label=\"prior (candidat nouveau)\")\n",
+    "ax.axhline(p_bad_tele_neg, color=\"#E6550D\", ls=\"--\", lw=1.5,\n",
+    "           label=f\"telematique : 1 an, signal negatif ({p_bad_tele_neg:.2f})\")\n",
+    "ax.axhline(SEUIL, color=\"#2F2F2F\", ls=\"-.\", lw=1.2, label=f\"seuil de refus ({SEUIL:.2f})\")\n",
+    "ax.set_xlabel(\"annees sans sinistre\")\n",
+    "ax.set_ylabel(\"P(mauvais risque | observations)\")\n",
+    "ax.set_title(\"L'apprentissage par l'experience est lent\")\n",
+    "ax.legend(fontsize=8)\n",
+    "plt.tight_layout(); plt.show()\n",
+    "\n",
+    "print(\"P(mauvais) apres k annees sans sinistre :\")\n",
+    "for k, p in zip(annees, p_bad_experience):\n",
+    "    print(f\"  k = {k} : {p:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84ca497e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006165,
+     "end_time": "2026-08-25T08:53:42.922955",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.916790",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "Après **six années sans sinistre**, la probabilité d'être un mauvais risque n'est descendue qu'à\n",
+    "~0.23 — elle ne passe jamais sous le seuil de refus 0.38, et reste au-dessus de ce qu'une seule\n",
+    "année de télématique avec signal négatif apprend (0.04). La fréquence annuelle de sinistre est\n",
+    "trop faible pour que le temps discrimine vite : une année muette est compatible avec les deux\n",
+    "types. Voilà pourquoi l'industrie achète des signaux *à l'entrée* (questionnaires, examens,\n",
+    "données) plutôt que d'attendre l'expérience — et voilà la boucle bouclée avec T1 : le jeune\n",
+    "cabinet qui tarifait à la moyenne du posterior apprend **lentement** ; le cabinet qui achète de\n",
+    "l'information apprend **vite mais cher** ; la théorie de la valeur de l'information est le prix\n",
+    "exact de l'échange."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4365b037",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004344,
+     "end_time": "2026-08-25T08:53:42.931836",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.927492",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "## Conclusion\n",
+    "\n",
+    "| Levier d'information | Valeur (EVSI) | Coût | Verdict |\n",
+    "|---|---|---|---|\n",
+    "| Classification parfaite (EVPI) | 558 €/candidat | n'existe pas | plafond |\n",
+    "| Questionnaire (0.40 / 0.65) | ≈ 0 € | 15 € | non — ne change aucune décision |\n",
+    "| Examen médical (0.70 / 0.90) | 311 € | 90 € | **oui** — net +221 €, robuste en calibration |\n",
+    "| Télématique (0.90 / 0.97) | 478 € | 500 € | non en one-shot — mais sépare les types portée par l'assuré |\n",
+    "| Expérience (k années sans sinistre) | lente | gratuite en euros, chère en temps | 6 ans < 1 an de télématique |\n",
+    "\n",
+    "**Points clés.** (1) La décision de souscription est un problème de décision sous incertitude avec\n",
+    "un seuil d'acceptation dérivable à la main ($p < 0{,}38$ ici) — toute l'information ne sert qu'à\n",
+    "déplacer la croyance de part et d'autre de ce seuil. (2) L'EVPI (558 €) plafonne toute dépense\n",
+    "d'information. (3) Un signal corrélé au risque mais qui ne franchit jamais le seuil a une EVSI\n",
+    "*nulle* : la valeur d'une information se mesure en décisions changées. (4) L'EVSI estimée porte\n",
+    "l'incertitude de sa calibration — propagée par PyMC, elle transforme la décision d'achat en\n",
+    "statistique (robuste / zone grise). (5) Le même signal physique, porté par l'assuré au lieu de\n",
+    "l'assureur, devient un mécanisme de séparation de marché (Spence, GT-17b) — qui paie l'information\n",
+    "change ce qu'elle vaut. (6) L'expérience est une source d'information gratuite mais lente : les\n",
+    "sinistres rares s'apprennent en années, les signaux les lisent en une fois.\n",
+    "\n",
+    "**Apport PyMC.** Le Beta-Binomial de calibration transforme des comptages d'étude en posterior de\n",
+    "sensibilité/spécificité ; la propagation vectorisée des tirages vers `evsi_signal` donne la\n",
+    "distribution postérieure de l'EVSI — le même geste que le prix de l'ignorance de T4, ici appliqué\n",
+    "à la *qualité de l'outil de mesure* plutôt qu'au risque mesuré."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29cefe49",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00789,
+     "end_time": "2026-08-25T08:53:42.944959",
+     "exception": false,
+     "start_time": "2026-08-25T08:53:42.937069",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Références\n",
+    "\n",
+    "- **DecPyMC-5 — Valeur de l'Information** : EVPI/EVSI, hiérarchie, calculateur générique, MCMC — l'appareil formel de ce notebook.\n",
+    "- **DecPyMC-9 — Prime pure et chargement** (T1) : fréquence × sévérité, antisélection, spirale d'Akerlof.\n",
+    "- **DecPyMC-10 — Ruine et capital** (T4) : prix de l'ignorance, propagation de posterior vers la ruine.\n",
+    "- **DecPyMC-7 — Décision séquentielle** : la structure de politique optimale derrière « tester puis décider ».\n",
+    "- Spence (1973), *Job Market Signaling* ; Rothschild & Stiglitz (1976), *Equilibrium in Competitive Insurance Markets* — le côté marché, traité dans la série GameTheory (GT-17a/17b).\n",
+    "- Raiffa & Schlaiffer (1961), *Applied Statistical Decision Theory* — EVPI/EVSI appliqués, chapitre souscription."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 18.080773,
+   "end_time": "2026-08-25T08:53:44.059861",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-11-Valeur-Info-Souscription.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-11-Valeur-Info-Souscription.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-25T08:53:25.979088",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-11-Valeur-Info-Souscription.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-11-Valeur-Info-Souscription.ipynb
@@ -128,7 +128,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 1. La décision de souscription sans information\n",
     "\n",
     "Rappel du fil rouge T1/T4, à l'échelle d'une **police individuelle** (primes de l'ordre de\n",
@@ -247,7 +247,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 2. EVPI : le plafond de la classification parfaite\n",
     "\n",
     "Supposons l'information **parfaite** : l'assureur connaît le type de chaque candidat. La règle\n",
@@ -404,7 +404,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 3. Trois signaux imparfaits : Bayes à la main\n",
     "\n",
     "L'information parfaite n'existe pas ; ce qui existe, ce sont des **signaux** — chacun décrit par\n",
@@ -520,7 +520,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 4. EVSI : la valeur de chaque signal contre son coût\n",
     "\n",
     "L'**espérance de valeur d'information imparfaite** (EVSI) est la différence entre le profit\n",
@@ -710,7 +710,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 5. Validation Monte Carlo\n",
     "\n",
     "L'EVSI est une espérance calculée sur deux issues — vérifions-la en simulant des candidats\n",
@@ -842,7 +842,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 6. L'EVSI est elle-même incertaine : calibration bayésienne (PyMC)\n",
     "\n",
     "D'où viennent les sensibilité/spécificité de nos signaux ? D'une **étude de calibration** : on a\n",
@@ -885,7 +885,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\pytensor\\tensor\\rewriting\\elemwise.py:872: UserWarning: Loop fusion failed because the resulting node would exceed the kernel argument limit.\n",
+      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\pytensor\\tensor\\rewriting\\elemwise.py:872: UserWarning: Loop fusion failed because the resulting node would exceed the kernel argument limit.\n",
       "  warn(\n"
      ]
     },
@@ -1171,7 +1171,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 7. Le miroir de Spence : qui paie le signal ?\n",
     "\n",
     "Jusqu'ici l'assureur achetait l'information. La théorie des jeux (GT-17b, Rothschild–Stiglitz et\n",
@@ -1341,7 +1341,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 8. Expérience contre signal : le temps comme source d'information\n",
     "\n",
     "Reste une dernière source d'information, gratuite celle-là : **le temps**. Chaque année sans\n",
@@ -1463,7 +1463,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## Conclusion\n",
     "\n",
     "| Levier d'information | Valeur (EVSI) | Coût | Verdict |\n",
@@ -1540,8 +1540,8 @@
    "end_time": "2026-08-25T08:53:44.059861",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-11-Valeur-Info-Souscription.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-11-Valeur-Info-Souscription.ipynb",
+   "input_path": "DecPyMC-11-Valeur-Info-Souscription.ipynb",
+   "output_path": "DecPyMC-11-Valeur-Info-Souscription.ipynb",
    "parameters": {},
    "start_time": "2026-08-25T08:53:25.979088",
    "version": "2.6.0"


### PR DESCRIPTION
## Summary

Tranche **T5 de l'EPIC #12904** (jambe actuarielle de la Théorie de la Décision) : **valeur de l'information en souscription** — suite directe de T1 (#12909/PR #12912) et T4 (#12913/PR #12914). Closes #12915 — See #12904 (4/7 de l'EPIC côté notebooks : T1, T3, T4, T5 ; l'EPIC reste ouverte).

Nouveau notebook `DecPyMC-11-Valeur-Info-Souscription.ipynb` (kernel python3, 37 cells : 13 code + 24 md) :

- **Décision de souscription sans information** : fil rouge T1/T4 à l'échelle police individuelle (λ_g=0.03 vs λ_b=0.09, E[S]=50 k€, 30% mauvais risques, pool 2 640 €) — seuil de refus dérivable à la main : accepter ssi P(mauvais|info) < 0.38.
- **EVPI** de la classification parfaite : 558 €/candidat = plafond de toute dépense d'information (= 0.30 × 1 860).
- **EVSI de trois signaux** (Bayes à la main puis vectorisé) : questionnaire (0.40/0.65, 15 €) **EVSI ≈ 0** — corrélé au risque mais ne franchit jamais le seuil : un signal qui ne change pas la décision ne vaut rien ; examen médical (0.70/0.90, 90 €) EVSI 311 € net +221 € ; télématique (0.90/0.97, 500 €) EVSI 478 € net marginal négatif — **le classement par qualité bayésienne n'est pas le classement par valeur nette**.
- **Validation Monte Carlo** : 20 000 candidats, 4 règles — moyennes conformes, boxplot : le tri ne supprime pas la variance, il supprime la queue de pertes.
- **Calibration bayésienne PyMC** (Beta-Binomial, NUTS) : l'incertitude sur sens/spé du questionnaire et de l'examen se propage vers une **distribution postérieure de l'EVSI** — examen robuste (P(EVSI > coût) ≈ 1), questionnaire en zone grise : la décision d'achat devient elle-même une statistique bayésienne.
- **Miroir de Spence (GT-17b)** : le même boîtier télématique, payé par l'assuré au lieu de l'assureur, sépare les types sans intervention (bon risque net +490 €/an, mauvais −2 810 €/an) — EVSI nette négative côté assureur mais séparation gratuite côté marché ; renvoi explicite à Rothschild–Stiglitz/GT-17b.
- **Expérience contre signal** : 6 années sans sinistre n'apprennent (P(mauvais) → 0.23) pas ce qu'une année de télématique à signal négatif apprend (0.04) — boucle bouclée avec le posterior du jeune cabinet T1.
- **3 exercices C.1** répartis (EVPI vs p_mauvais avec bascule de règle ; évaluation d'un nouveau signal open-data ; coût séparateur maximal c* = 990 € vu des deux côtés).

## Preuves d'exécution (C.2 / H.4)

- Papermill kernel `python3` post-dernier-commit : **13/13 cellules code exécutées, 0 erreur, 0 output_type:error**
- 1 modèle PyMC réellement échantillonné (Beta-Binomial calibration 4 paramètres, NUTS 2×1500 draws, seed 20260825) + `az.summary` (ess_bulk, r_hat) interprété
- Monte Carlo vectorisé réel : 20 000 candidats × 4 règles ; EVSI analytique pré-vérifiée standalone avant exécution (questionnaire 0.0 / examen 310.8 / télématique 478.3)
- Verdict SOTA : **SOTA-OK** — PyMC/NUTS pour la calibration, numpy vectorisé pour la décision ; pas de workaround dégradé

## Acceptance #12915

- [x] Notebook nouveau exécuté end-to-end, outputs réels, 0 erreur
- [x] `execution_count` non nul sur toutes les cellules code
- [x] ≥1 modèle PyMC échantillonné + diagnostics ArviZ
- [x] EVSI comparée à son coût pour chaque signal (décision d'achat chiffrée)
- [x] Miroir Spence chiffré (c* = 990 €/an, adoption par type)
- [x] ≥3 exercices C.1 répartis (stubs `None` + `# TODO étudiant`)
- [x] Interprétations après les outputs, prose FR, jargon défini à première apparition
- [x] Catalogue / README / translations byte-identiques à main (1 fichier ajouté)

## Fichiers (1)

| Fichier | Changement |
|---|---|
| `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-11-Valeur-Info-Souscription.ipynb` | nouveau — 37 cells |

Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-python #12914 (c.529)
