### PR TITLE
feat(lean,#12904): T6 cohérence tarifaire — Coherence/Premium + sibling _en

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence.lean
@@ -1,6 +1,7 @@
 import Coherence.Basic
 import Coherence.DutchBook
 import Coherence.Probability
+import Coherence.Premium
 
 /-!
 # Decision Theory — Dutch Book / cohérence (de Finetti)
@@ -25,6 +26,14 @@ perte sûre. La cohérence *force* donc les axiomes de probabilité.
   probabilistes (`priceFromWeights_coherent_on`), par l'argument d'espérance
   `E_p[gain] = 0` (`sum_weights_mul_ind` → `expected_ticket_gain_zero` →
   `expected_ieGain_zero` → contradiction sur un état chargé, `exists_pos_weight`).
+- `Coherence.Premium` (T6 EPIC #12904) : la **lecture actuarielle** — barème de primes
+  (`PremiumSchedule`), résultat net de l'assureur (`InsurerNet`), arbitrage de
+  tarification (`TariffArbitrage`). Trois théorèmes 0 `sorry` : barème incohérent ⟹
+  perte sûre de l'assureur (`incoherent_premium_sure_insurer_loss`), additivité sur
+  risques disjoints — la règle de segmentation `π(A∪B) = π A + π B`
+  (`coherent_premium_disjoint_additive`), et prime pure inarbitrable
+  (`pure_premium_tariff_unarbitrageable`), via la symétrie comptoir
+  `coherent_on_iff_no_sure_profit`.
 
 ## Statut
 - Prouvé sans `sorry` : la direction constructive (violation de l'inclusion–exclusion

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/Premium.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/Premium.lean
@@ -1,0 +1,175 @@
+import Mathlib
+import Coherence.Basic
+import Coherence.DutchBook
+import Coherence.Probability
+
+/-!
+# Coherence.Premium — lecture actuarielle du Dutch Book : cohérence d'un barème
+
+T6 de l'EPIC #12904 (jambe actuarielle Decision Theory). Le théorème de de Finetti
+prouvé dans `DutchBook.lean` reçoit ici sa lecture **actuarérielle** : le « ticket
+payant 1 € si A se réalise » devient un **contrat de couverture** (indemnité unitaire
+sur l'événement A), la « fonction de prix » devient un **barème de primes**, et le
+Dutch Book devient un **arbitrage de tarification** — un courtier (ou un client
+instruit, ou un concurrent) qui assemble un portefeuille de contrats à **profit sûr**,
+c'est-à-dire une **perte stricte et sûre pour l'assureur** en tout état du monde.
+
+Trois résultats, 0 `sorry`, chacun une lecture métier du socle `DutchBook.lean` /
+`Probability.lean` :
+
+1. **`incoherent_premium_sure_insurer_loss`** — un barème qui viole
+   l'inclusion–exclusion sur deux garanties expose l'assureur à une perte sûre :
+   le witness de `non_additive_implies_dutch_book`, lu de l'autre côté du comptoir
+   (les mises changent de signe), est le portefeuille d'arbitrage du courtier.
+2. **`coherent_premium_disjoint_additive`** — la règle de tarification quotidienne :
+   pour deux risques **disjoints** (deux segments de clientèle, deux garanties non
+   chevauchantes), un barème à la fois cohérent au sens des livrets à quatre tickets
+   et au sens mono-ticket satisfait `π(A ∪ B) = π(A) + π(B)` — la prime du risque
+   combiné est la somme des primes des segments. La démonstration combine
+   `coherent_on_implies_additive` (inclusion–exclusion) et la normalisation
+   `π ∅ = 0` forcée par le mono-ticket (`single_coherent_iff_prob_bounds`).
+3. **`pure_premium_tariff_unarbitrageable`** — un barème calculé par espérance
+   (prime pure `π(A) = Σ_{ω ∈ A} p(ω)`, poids non négatifs sommant à 1) n'offre
+   **aucun** portefeuille à profit sûr : conséquence immédiate de
+   `priceFromWeights_coherent_on` et de la symétrie `coherent_on_iff_no_sure_profit`.
+
+**Cadrage honnête (G.3/G.9).** Le point 2 est une equivalence de deux cohérences
+(quatre tickets sur `(A, B)` + mono-ticket global), pas le `coherent_iff_probability`
+complet — dont la réciproque générale reste le jalon ouvert de `DutchBook.lean`
+(séparation d'hyperplans / dualité LP). Les résultats sont énoncés sur le barème
+unitaire (indemnité 1 €) ; l'extrapolation à des montants quelconques (contrats
+`(α, β)` couverture × capital) suit par linéarité des mises et n'est pas re-développée
+ici. Voir la sous-série PyMC `DecisionTheory/` (EPIC #12904, tranches T1-T5) pour la
+face numérique (prime pure, chargement, partial pooling).
+-/
+
+namespace Coherence
+
+variable {Ω : Type*} [Fintype Ω] [DecidableEq Ω]
+
+/-! ## Barème de primes, résultat de l'assureur, arbitrage de tarification -/
+
+/-- Un **barème de primes** : chaque événement `A` (garantie) est couvert à hauteur
+    de 1 € d'indemnité pour une prime unitaire `π A`. C'est exactement le cadre de
+    de Finetti (`Price`) relu côté assureur : le ticket devient contrat, le prix
+    devient prime. -/
+abbrev PremiumSchedule (Ω : Type*) [Fintype Ω] [DecidableEq Ω] := Event Ω → ℝ
+
+/-- **Résultat net de l'assureur** à l'état `ω` sur un portefeuille client de quatre
+    contrats `(A, B, A∩B, A∪B)` avec souscriptions `(sA, sB, sAB, sAU)` (souscription
+    positive = le client achète la couverture, négative = il la place côté assureur) :
+    primes encaissées moins indemnités versées. C'est l'opposé exact du gain du livret
+    client (`ieGain`) — les deux parties du comptoir voient des résultats opposés. -/
+def InsurerNet (π : PremiumSchedule Ω) (A B : Event Ω) (sA sB sAB sAU : ℝ) (ω : Ω) : ℝ :=
+  -ieGain π A B sA sB sAB sAU ω
+
+/-- Un **arbitrage de tarification** : un portefeuille client dont le résultat est
+    strictement positif en tout état — donc un résultat strictement négatif (perte
+    sûre) pour l'assureur en tout état. C'est le Dutch Book de `DutchBook.lean` lu du
+    point de vue de la compagnie : « un jeu de primes incohérent est un pari perdant
+    sûr » — pour celui qui l'a affiché. -/
+def TariffArbitrage (π : PremiumSchedule Ω) (A B : Event Ω) (sA sB sAB sAU : ℝ) : Prop :=
+  ∀ ω : Ω, InsurerNet π A B sA sB sAB sAU ω < 0
+
+/-- Un barème n'offre **aucun profit sûr** (au sens des livrets à quatre tickets sur
+    `(A, B)`) : aucun portefeuille client n'est un arbitrage de tarification. C'est le
+    miroir exact de `CoherentOn` (aucune perte sûre côté client). -/
+def NoSureProfit (π : PremiumSchedule Ω) (A B : Event Ω) : Prop :=
+  ∀ sA sB sAB sAU : ℝ, ¬ TariffArbitrage π A B sA sB sAB sAU
+
+/-! ## Symétrie comptoir : aucune perte sûre pour le client ⟺ aucun profit sûr -/
+
+/-- Les mises de signe opposé donnent le gain de signe opposé : le livret `(-sA, -sB,
+    -sAB, -sAU)` est l'exacte contrepartie du livret `(sA, sB, sAB, sAU)`. C'est la
+    linéarité des mises dans `ieGain` — la clé du changement de point de vue
+    client/assureur. -/
+lemma ieGain_neg (q : Price Ω) (A B : Event Ω) (sA sB sAB sAU : ℝ) (ω : Ω) :
+    ieGain q A B (-sA) (-sB) (-sAB) (-sAU) ω = -ieGain q A B sA sB sAB sAU ω := by
+  simp only [ieGain]
+  ring
+
+/-- **Changement de côté du comptoir.** Un barème est cohérent (aucun Dutch Book côté
+    client, `CoherentOn`) si et seulement s'il n'offre aucun profit sûr (aucun
+    arbitrage côté client, `NoSureProfit`) : les deux lectures sont la même propriété,
+    reliée par l'inversion des signes des mises (`ieGain_neg`). Pour l'assureur, la
+    cohérence de son barème et l'absence d'arbitrage contre lui sont donc une seule et
+    même exigence. -/
+theorem coherent_on_iff_no_sure_profit (π : PremiumSchedule Ω) (A B : Event Ω) :
+    CoherentOn π A B ↔ NoSureProfit π A B := by
+  constructor
+  · intro hc sA sB sAB sAU harb
+    refine hc (-sA) (-sB) (-sAB) (-sAU) ?_
+    intro ω
+    have h := harb ω
+    simp only [InsurerNet] at h
+    rw [ieGain_neg]
+    linarith
+  · intro hnp sA sB sAB sAU harb
+    refine hnp (-sA) (-sB) (-sAB) (-sAU) ?_
+    intro ω
+    have h := harb ω
+    simp only [InsurerNet]
+    rw [ieGain_neg]
+    linarith
+
+/-! ## Théorèmes cibles (lecture actuarielle) -/
+
+/-- **Barème incohérent ⟹ perte sûre de l'assureur.** Si le barème `π` viole
+    l'inclusion–exclusion sur deux garanties `A, B`, un courtier construit un
+    portefeuille de contrats à profit strict en tout état — l'assureur subit une
+    perte stricte et sûre. C'est le théorème `non_additive_implies_dutch_book` lu de
+    l'autre côté du comptoir : le witness du Dutch Book (mises à perte sûre côté
+    client) devient, par inversion des signes, le portefeuille d'arbitrage du
+    courtier. -/
+theorem incoherent_premium_sure_insurer_loss (π : PremiumSchedule Ω) (A B : Event Ω)
+    (h : π (A ∪ B) + π (A ∩ B) ≠ π A + π B) :
+    ∃ sA sB sAB sAU : ℝ, TariffArbitrage π A B sA sB sAB sAU := by
+  obtain ⟨sA, sB, sAB, sAU, hloss⟩ := non_additive_implies_dutch_book π A B h
+  refine ⟨-sA, -sB, -sAB, -sAU, ?_⟩
+  intro ω
+  have h' := hloss ω
+  simp only [InsurerNet]
+  rw [ieGain_neg]
+  linarith
+
+/-- **Additivité sur risques disjoints — la règle de segmentation.** Pour deux
+    garanties **disjointes** (`A ∩ B = ∅` : deux segments de clientèle sans
+    chevauchement, deux risques exclusifs), un barème à la fois cohérent au sens des
+    livrets à quatre tickets (sur `(A, B)`) et cohérent au sens mono-ticket satisfait
+
+    `π (A ∪ B) = π A + π B` :
+
+    la prime du risque combiné est exactement la somme des primes des segments.
+    La preuve combine l'inclusion–exclusion forcée par la cohérence
+    (`coherent_on_implies_additive` : `π(A∪B) + π(∅) = π A + π B` ici) et la
+    normalisation `π ∅ = 0` forcée par le mono-ticket (`probBounds_empty` via
+    `single_coherent_iff_prob_bounds`). Une prime de pool supérieure (ou inférieure)
+    à la somme des primes de segments est donc soit une incohérence exploitable,
+    soit le signe qu'un chargement non tarifé s'est glissé dans le barème. -/
+theorem coherent_premium_disjoint_additive [Nonempty Ω] (π : PremiumSchedule Ω)
+    (A B : Event Ω) (hdj : A ∩ B = ∅)
+    (hc4 : CoherentOn π A B) (hc1 : SingleCoherent π) :
+    π (A ∪ B) = π A + π B := by
+  have hIE := coherent_on_implies_additive π A B hc4
+  have hb : ProbBounds π := (single_coherent_iff_prob_bounds π).mp hc1
+  have h0 : π (∅ : Event Ω) = 0 := probBounds_empty π hb
+  rw [hdj] at hIE
+  rw [h0] at hIE
+  linarith
+
+/-- **La prime pure est inarbitrable.** Un barème construit par espérance sous des
+    poids `p` non négatifs sommant à 1 — la **prime pure** `π(A) = Σ_{ω ∈ A} p(ω)` de
+    la théorie actuarielle — n'offre aucun portefeuille à profit sûr : aucun courtier
+    ne peut arbitrer une tarification espérance-consistante. Conséquence immédiate de
+    `priceFromWeights_coherent_on` (aucun Dutch Book côté client) et de la symétrie
+    `coherent_on_iff_no_sure_profit` (c'est alors aussi aucun profit sûr côté
+    courtier). La prime pure est ainsi le seul barème à la fois break-even en
+    espérance et inarbitrable — le point de départ obligatoire du chargement de
+    sécurité (tranches T1/T2 de l'EPIC #12904). -/
+theorem pure_premium_tariff_unarbitrageable (p : Ω → ℝ) (hnn : ∀ ω, (0:ℝ) ≤ p ω)
+    (hsum : ∑ ω, p ω = 1) (A B : Event Ω) :
+    NoSureProfit (priceFromWeights p) A B :=
+  (coherent_on_iff_no_sure_profit (priceFromWeights p) A B).mp
+    (priceFromWeights_coherent_on p hnn hsum A B)
+
+end Coherence

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/Premium_en.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/Premium_en.lean
@@ -1,0 +1,181 @@
+import Mathlib
+import Coherence.Basic_en
+import Coherence.DutchBook_en
+import Coherence.Probability_en
+
+/-!
+# Coherence.Premium — the actuarial reading of the Dutch Book: coherence of a tariff
+
+T6 of EPIC #12904 (Decision Theory actuarial leg). The de Finetti theorem proven in
+`DutchBook.lean` receives its **actuarial** reading here: the "ticket paying 1 if A
+occurs" becomes a **coverage contract** (unit indemnity on event A), the "price
+function" becomes a **premium schedule**, and the Dutch Book becomes a **tariff
+arbitrage** — a broker (or an informed client, or a competitor) assembling a
+portfolio of contracts at **sure profit**, i.e. a **strict and sure loss for the
+insurer** in every state of the world.
+
+Three results, 0 `sorry`, each a business reading of the `DutchBook.lean` /
+`Probability.lean` bedrock:
+
+1. **`incoherent_premium_sure_insurer_loss`** — a schedule violating
+   inclusion–exclusion on two coverages exposes the insurer to a sure loss: the
+   witness of `non_additive_implies_dutch_book`, read from the other side of the
+   counter (stakes flip sign), is the broker's arbitrage portfolio.
+2. **`coherent_premium_disjoint_additive`** — the everyday pricing rule: for two
+   **disjoint** risks (two customer segments, two non-overlapping coverages), a
+   schedule coherent both in the four-ticket sense and in the single-ticket sense
+   satisfies `π(A ∪ B) = π(A) + π(B)` — the premium of the combined risk is the sum
+   of the segment premiums. The proof combines `coherent_on_implies_additive`
+   (inclusion–exclusion) with the normalisation `π ∅ = 0` forced by the
+   single-ticket coherence (`single_coherent_iff_prob_bounds`).
+3. **`pure_premium_tariff_unarbitrageable`** — a schedule computed by expectation
+   (pure premium `π(A) = Σ_{ω ∈ A} p(ω)`, non-negative weights summing to 1) offers
+   **no** sure-profit portfolio: immediate consequence of
+   `priceFromWeights_coherent_on` and the symmetry
+   `coherent_on_iff_no_sure_profit`.
+
+**Honest scoping (G.3/G.9).** Point 2 is an equivalence of two coherences (four
+tickets on `(A, B)` + global single-ticket), not the full
+`coherent_iff_probability` — whose general converse remains the open milestone of
+`DutchBook.lean` (hyperplane separation / LP duality). Results are stated on the
+unit schedule (indemnity 1); scaling to arbitrary amounts (contracts `(α, β)`
+coverage × capital) follows by linearity of stakes and is not re-developed here.
+See the PyMC sub-series `DecisionTheory/` (EPIC #12904, tranches T1-T5) for the
+numerical side (pure premium, loading, partial pooling).
+
+English mirror of `Coherence/Premium.lean` (French canonical). Convention EPIC #4980:
+siblings `Foo.lean` (FR) + `Foo_en.lean` (EN), both compile in one lake.
+Drift-CI: non-docstring content byte-identical between siblings.
+Sibling namespace: `Coherence_en` (the canonical FR remains `Coherence`).
+-/
+
+namespace Coherence_en
+
+variable {Ω : Type*} [Fintype Ω] [DecidableEq Ω]
+
+/-! ## Premium schedule, insurer's result, tariff arbitrage --/
+
+/-- A **premium schedule**: each event `A` (coverage) is covered up to 1 of
+    indemnity for a unit premium `π A`. This is exactly the de Finetti framework
+    (`Price`) read on the insurer's side: the ticket becomes a contract, the price
+    becomes a premium. -/
+abbrev PremiumSchedule (Ω : Type*) [Fintype Ω] [DecidableEq Ω] := Event Ω → ℝ
+
+/-- **Insurer's net result** at state `ω` on a client portfolio of four contracts
+    `(A, B, A∩B, A∪B)` with subscriptions `(sA, sB, sAB, sAU)` (positive
+    subscription = the client buys the coverage, negative = they place it on the
+    insurer's side): premiums collected minus indemnities paid. This is the exact
+    opposite of the client book's gain (`ieGain`) — the two sides of the counter see
+    opposite results. -/
+def InsurerNet (π : PremiumSchedule Ω) (A B : Event Ω) (sA sB sAB sAU : ℝ) (ω : Ω) : ℝ :=
+  -ieGain π A B sA sB sAB sAU ω
+
+/-- A **tariff arbitrage**: a client portfolio whose result is strictly positive in
+    every state — hence a strictly negative result (sure loss) for the insurer in
+    every state. This is the Dutch Book of `DutchBook.lean` read from the company's
+    viewpoint: "an incoherent schedule of premiums is a sure-losing bet" — for the
+    one who posted it. -/
+def TariffArbitrage (π : PremiumSchedule Ω) (A B : Event Ω) (sA sB sAB sAU : ℝ) : Prop :=
+  ∀ ω : Ω, InsurerNet π A B sA sB sAB sAU ω < 0
+
+/-- A schedule offers **no sure profit** (in the four-ticket sense on `(A, B)`): no
+    client portfolio is a tariff arbitrage. This is the exact mirror of `CoherentOn`
+    (no sure loss on the client side). -/
+def NoSureProfit (π : PremiumSchedule Ω) (A B : Event Ω) : Prop :=
+  ∀ sA sB sAB sAU : ℝ, ¬ TariffArbitrage π A B sA sB sAB sAU
+
+/-! ## Counter symmetry: no sure client loss ⟺ no sure profit --/
+
+/-- Opposite-sign stakes give the opposite-sign gain: the book `(-sA, -sB, -sAB,
+    -sAU)` is the exact counterparty of the book `(sA, sB, sAB, sAU)`. This is the
+    linearity of stakes in `ieGain` — the key to switching client/insurer
+    viewpoint. -/
+lemma ieGain_neg (q : Price Ω) (A B : Event Ω) (sA sB sAB sAU : ℝ) (ω : Ω) :
+    ieGain q A B (-sA) (-sB) (-sAB) (-sAU) ω = -ieGain q A B sA sB sAB sAU ω := by
+  simp only [ieGain]
+  ring
+
+/-- **Switching sides of the counter.** A schedule is coherent (no Dutch Book on the
+    client side, `CoherentOn`) if and only if it offers no sure profit (no arbitrage
+    on the client side, `NoSureProfit`): the two readings are the same property,
+    related by inverting the signs of the stakes (`ieGain_neg`). For the insurer, the
+    coherence of its schedule and the absence of arbitrage against it are therefore
+    one and the same requirement. -/
+theorem coherent_on_iff_no_sure_profit (π : PremiumSchedule Ω) (A B : Event Ω) :
+    CoherentOn π A B ↔ NoSureProfit π A B := by
+  constructor
+  · intro hc sA sB sAB sAU harb
+    refine hc (-sA) (-sB) (-sAB) (-sAU) ?_
+    intro ω
+    have h := harb ω
+    simp only [InsurerNet] at h
+    rw [ieGain_neg]
+    linarith
+  · intro hnp sA sB sAB sAU harb
+    refine hnp (-sA) (-sB) (-sAB) (-sAU) ?_
+    intro ω
+    have h := harb ω
+    simp only [InsurerNet]
+    rw [ieGain_neg]
+    linarith
+
+/-! ## Target theorems (actuarial reading) -/
+
+/-- **Incoherent schedule ⟹ sure insurer loss.** If the schedule `π` violates
+    inclusion–exclusion on two coverages `A, B`, a broker builds a portfolio of
+    contracts with strict profit in every state — the insurer suffers a strict and
+    sure loss. This is `non_additive_implies_dutch_book` read from the other side of
+    the counter: the Dutch Book witness (stakes at sure loss on the client side)
+    becomes, by sign inversion, the broker's arbitrage portfolio. -/
+theorem incoherent_premium_sure_insurer_loss (π : PremiumSchedule Ω) (A B : Event Ω)
+    (h : π (A ∪ B) + π (A ∩ B) ≠ π A + π B) :
+    ∃ sA sB sAB sAU : ℝ, TariffArbitrage π A B sA sB sAB sAU := by
+  obtain ⟨sA, sB, sAB, sAU, hloss⟩ := non_additive_implies_dutch_book π A B h
+  refine ⟨-sA, -sB, -sAB, -sAU, ?_⟩
+  intro ω
+  have h' := hloss ω
+  simp only [InsurerNet]
+  rw [ieGain_neg]
+  linarith
+
+/-- **Additivity on disjoint risks — the segmentation rule.** For two **disjoint**
+    coverages (`A ∩ B = ∅`: two non-overlapping customer segments, two exclusive
+    risks), a schedule coherent both in the four-ticket sense (on `(A, B)`) and in
+    the single-ticket sense satisfies
+
+    `π (A ∪ B) = π A + π B`:
+
+    the premium of the combined risk is exactly the sum of the segment premiums.
+    The proof combines the inclusion–exclusion forced by coherence
+    (`coherent_on_implies_additive`: `π(A∪B) + π(∅) = π A + π B` here) with the
+    normalisation `π ∅ = 0` forced by single-ticket coherence (`probBounds_empty`
+    via `single_coherent_iff_prob_bounds`). A pool premium above (or below) the sum
+    of segment premiums is thus either an exploitable incoherence, or the sign that
+    an untariffed loading has slipped into the schedule. -/
+theorem coherent_premium_disjoint_additive [Nonempty Ω] (π : PremiumSchedule Ω)
+    (A B : Event Ω) (hdj : A ∩ B = ∅)
+    (hc4 : CoherentOn π A B) (hc1 : SingleCoherent π) :
+    π (A ∪ B) = π A + π B := by
+  have hIE := coherent_on_implies_additive π A B hc4
+  have hb : ProbBounds π := (single_coherent_iff_prob_bounds π).mp hc1
+  have h0 : π (∅ : Event Ω) = 0 := probBounds_empty π hb
+  rw [hdj] at hIE
+  rw [h0] at hIE
+  linarith
+
+/-- **The pure premium is unarbitrageable.** A schedule built by expectation under
+    non-negative weights `p` summing to 1 — the actuarial **pure premium**
+    `π(A) = Σ_{ω ∈ A} p(ω)` — offers no sure-profit portfolio: no broker can
+    arbitrage an expectation-consistent tariff. Immediate consequence of
+    `priceFromWeights_coherent_on` (no Dutch Book on the client side) and of the
+    symmetry `coherent_on_iff_no_sure_profit` (hence also no sure profit on the
+    broker side). The pure premium is thereby the only schedule both break-even in
+    expectation and unarbitrageable — the mandatory starting point of the security
+    loading (tranches T1/T2 of EPIC #12904). -/
+theorem pure_premium_tariff_unarbitrageable (p : Ω → ℝ) (hnn : ∀ ω, (0:ℝ) ≤ p ω)
+    (hsum : ∑ ω, p ω = 1) (A B : Event Ω) :
+    NoSureProfit (priceFromWeights p) A B :=
+  (coherent_on_iff_no_sure_profit (priceFromWeights p) A B).mp
+    (priceFromWeights_coherent_on p hnn hsum A B)
+
+end Coherence_en

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence_en.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence_en.lean
@@ -1,6 +1,7 @@
 import Coherence.Basic
 import Coherence.DutchBook
 import Coherence.Probability
+import Coherence.Premium
 
 /-!
 # Decision Theory — Dutch Book / coherence (de Finetti)
@@ -25,6 +26,13 @@ sure loss. Coherence therefore *forces* the probability axioms.
   probabilistic weights (`priceFromWeights_coherent_on`), via the expectation
   argument `E_p[gain] = 0` (`sum_weights_mul_ind` → `expected_ticket_gain_zero` →
   `expected_ieGain_zero` → contradiction on a charged state, `exists_pos_weight`).
+- `Coherence.Premium` (T6 EPIC #12904): the **actuarial reading** — premium schedule
+  (`PremiumSchedule`), insurer's net result (`InsurerNet`), tariff arbitrage
+  (`TariffArbitrage`). Three 0-`sorry` theorems: incoherent schedule ⟹ sure insurer
+  loss (`incoherent_premium_sure_insurer_loss`), additivity on disjoint risks — the
+  segmentation rule `π(A∪B) = π A + π B` (`coherent_premium_disjoint_additive`),
+  and unarbitrageable pure premium (`pure_premium_tariff_unarbitrageable`), via the
+  counter symmetry `coherent_on_iff_no_sure_profit`.
 
 ## Status
 - Proved without `sorry`: the constructive direction (inclusion–exclusion


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2023:CoursIA-2 — prev: MED/readme #12923 (c.533)

## Summary

T6 de l'EPIC #12904 (jambe actuarielle Decision Theory) : **lecture actuarielle du Dutch Book de de Finetti**, formalisée dans le lake `decision_theory_lean` — nouveau module `Coherence/Premium.lean` (FR canonique) + sibling `Coherence/Premium_en.lean` (convention #4980).

Le ticket de pari devient **contrat de couverture**, la fonction de prix devient **barème de primes**, le Dutch Book devient **arbitrage de tarification** — un portefeuille client à profit sûr = perte stricte et sûre de l'assureur en tout état.

## Contenu (3 theorems + 2 lemmas/defs + 2 defs, 0 sorry)

| Énoncé | Lecture métier |
|---|---|
| `incoherent_premium_sure_insurer_loss` | un barème qui viole l'inclusion–exclusion sur deux garanties expose l'assureur à une perte sûre (witness de `non_additive_implies_dutch_book` lu de l'autre côté du comptoir) |
| `coherent_premium_disjoint_additive` | **règle de segmentation** : risques disjoints ⟹ `π(A∪B) = πA + πB` (pont `coherent_on_implies_additive` + normalisation `π∅=0` du mono-ticket `single_coherent_iff_prob_bounds`) |
| `pure_premium_tariff_unarbitrageable` | un barème d'espérance (prime pure) n'offre aucun profit sûr (pont `priceFromWeights_coherent_on`) |
| `coherent_on_iff_no_sure_profit` | symétrie comptoir : aucune perte sûre client ⟺ aucun profit sûr courtier (`ieGain_neg`) |
| `InsurerNet`, `TariffArbitrage`, `NoSureProfit`, `PremiumSchedule` | vocabulaire actuariel du socle |

## Preuves (B.2 obligatoire)

1. **`grep -c sorry` avant/après** (`count_code_sorry.py --lake decision_theory_lean`) :
   - AVANT : `code=4, distinct=2`
   - APRÈS : `code=4, distinct=2` — **inchangé**, mes 2 modules ajoutent 0 sorry (grep naïf 45→49 = 4 occurrences de « 0 `sorry` » en docstring, FP connu).
2. **Lake build SUCCESS** : `lake build Coherence Coherence_en Coherence.Premium Coherence.Premium_en` → **`Build completed successfully (8665 jobs)`** (ext4, mathlib 8275 oleans chauds @ `520045ab14` = rev exact du manifest).
3. **Proof integrity (axiom check)** : `#print axioms` sur les 5 résultats = `[propext, Classical.choice, Quot.sound]` — pas de `sorryAx`.
4. **i18n #4980** : `check_i18n_siblings.py` → **4/4 pairs byte-identical** (0 drift, 0 orphan) — code des deux siblings identique, docstrings traduites, namespace `Coherence_en`, imports `*_en`.
5. Racines agrégateurs `Coherence.lean` / `Coherence_en.lean` : +import +bullet (17 lignes).

## Cadrage honnête (G.3)

L'additivité dis jointe est une équivalence de deux cohérences (quatre tickets + mono-ticket), pas le `coherent_iff_probability` complet (réciproque générale = jalon ouvert de `DutchBook.lean`, séparation d'hyperplans). Résultats sur barème unitaire (indemnité 1 €) ; extrapolation à montants quelconques par linéarité des mises, non re-développée. Le module le dit explicitement.

## Scope

- 4 fichiers : 2 nouveaux (`Premium.lean`, `Premium_en.lean`), 2 racines modifiées (+17 l.). `COURSE_CATALOG.*` byte-identique à main. Aucun workflow touché.
- Fix build initial : identifiant `h∅` invalide (∅ n'est pas un caractère d'identifiant) → `h0` dans les deux siblings.

See #12904 (T6 livrée — T7 pont GT↔DT et READMEs gated restent)
