### PR TITLE
fix(guards,#12905): un claim scopé sur un chemin inexistant est nommé comme verrou epic-wide dans le BLOCKED

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -2159,6 +2159,47 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             f"`[CLAIMED] paths: ...`, or wait for release.",
             file=sys.stderr,
         )
+        # #12905 -- name the dead-scope lock. A blocker whose declared scope
+        # is ENTIRELY dead (every glob matches zero tracked files) was lifted
+        # to epic-wide by the #10958 fail-safe: it locks the WHOLE issue for
+        # every lane, including callers whose live scope is provably disjoint
+        # (#12905's reproduction on #12844: lane A live on the GT-17b
+        # notebook, blocked by lane B reserving asymmetric_information_lean/**
+        # before the path exists). The fail-closed verdict stays -- a dead
+        # scope must not DE-unlock -- but the blocking text now NAMES the
+        # mechanism: `WARN: glob sans correspondance` alone reads as "stale
+        # worktree", not as "this claim locks the whole umbrella". Same shape
+        # as the LOCKED (v2) sub-message below: explainer only, no exit-code
+        # change.
+        dead_scope_blockers = [
+            ev for ev in others.values()
+            if ev.get("paths") and _claim_scope_effectively_epic_wide(ev)
+        ]
+        if dead_scope_blockers:
+            lines = []
+            for ev in dead_scope_blockers:
+                dead = ", ".join(
+                    repr(g) for g in (ev.get("empty_scope") or ev.get("paths") or [])
+                )
+                ln = ev.get("lane") or "?"
+                lines.append(
+                    f"  - lane {ln} -- declared scope matches zero tracked "
+                    f"files ({dead})"
+                )
+            print(
+                f"\nDEAD-SCOPE LOCK (#12905): the blocker(s) above hold a "
+                f"`paths:` scope that matches NO tracked file yet. By the "
+                f"#10958 fail-safe such a claim is treated as EPIC-WIDE and "
+                f"locks the whole issue #{payload.get('number')} for every "
+                f"lane -- including yours, even when your scope is provably "
+                f"disjoint (the nominal case of a lane reserving a path it "
+                f"is about to create). The lock lifts when the blocking lane "
+                f"re-issues its claim once the path exists, posts "
+                f"`[RELEASED]`, or a coordinator writes an "
+                f"`[OVERRIDE] lane <m:w>` comment (cf #10223).\n"
+                + "\n".join(lines),
+                file=sys.stderr,
+            )
         # #12386 -- v2 LOCKED verdict. When the blocker is a `[DELIVERED]`
         # whose PR reached main (`locked: True`), a plain re-claim is NOT a
         # path forward -- the issue is resolved. We surface a tailored message

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -3385,6 +3385,107 @@ def test_check_caller_scope_fail_closed_when_no_blockers(capsys, monkeypatch):
     assert "dead/nowhere.ipynb" in captured.out
 
 
+# --- #12905: the dead-scope BLOCKER is named as an epic-wide lock ------------
+# Reproduction of the live case (#12844, 2026-08-25): a lane reserves a path
+# it is about to create (`paths: <chemin inexistant>/**`). The #10958
+# fail-safe lifts the entirely-dead claim to epic-wide -- it then blocks
+# every OTHER lane on the umbrella, including callers whose live scope is
+# provably disjoint. The verdict stays fail-CLOSED (a dead scope must not
+# DE-unlock); what #12905 adds is the CONSEQUENCE in the blocking text:
+# `WARN: glob sans correspondance` alone reads as "stale worktree", not as
+# "this claim locks the whole umbrella".
+
+def test_12905_dead_scope_blocker_names_epic_wide_lock(capsys, monkeypatch):
+    """The exact #12905 shape: caller LIVE + disjoint, blocker ENTIRELY dead.
+    Verdict BLOCKED at exit 1 (fail-closed unchanged) + a dedicated
+    `DEAD-SCOPE LOCK` stderr message naming the blocking lane, its dead
+    globs verbatim, and the epic-wide mechanism."""
+    monkeypatch.setattr(clc, "_git_tracked_files",
+                        lambda: ["MyIA.AI.Notebooks/GameTheory/GameTheory-17b.ipynb"])
+    blocker = comment(
+        "[CLAIMED] lane B:CoursIA -- lake asym -- paths: "
+        "MyIA.AI.Notebooks/GameTheory/asymmetric_information_lean/**",
+        "2026-08-25T09:00:00Z",
+    )
+    p = payload(blocker, number=12844, title="[EPIC] umbrella")
+    rc = clc._run_check(
+        p, "A:CoursIA",
+        my_paths=["MyIA.AI.Notebooks/GameTheory/GameTheory-17b.ipynb"],
+    )
+    captured = capsys.readouterr()
+    # Fail-closed verdict UNCHANGED: the dead-scope blocker still blocks a
+    # provably-disjoint live caller (it was lifted to epic-wide).
+    assert rc == 1
+    assert "BLOCKED: another lane holds an active claim" in captured.err
+    # The new explainer fires and names the mechanism + the dead glob.
+    assert "DEAD-SCOPE LOCK" in captured.err
+    assert "EPIC-WIDE" in captured.err
+    assert "B:CoursIA" in captured.err
+    assert "asymmetric_information_lean" in captured.err
+    # The escape paths are named (re-issue / RELEASED / coordinator OVERRIDE).
+    assert "[RELEASED]" in captured.err
+    assert "[OVERRIDE] lane" in captured.err
+
+
+def test_12905_live_scope_blocker_gets_no_dead_scope_lock_message(capsys, monkeypatch):
+    """Selectivity pin (positive control): a blocker whose scope is LIVE
+    produces the plain BLOCKED message with NO `DEAD-SCOPE LOCK` explainer --
+    without this pin, an always-on explainer would be indistinguishable from
+    the targeted one."""
+    monkeypatch.setattr(clc, "_git_tracked_files",
+                        lambda: ["x/a.ipynb", "y/01.ipynb"])
+    blocker = comment(
+        "[CLAIMED] lane A:CoursIA -- tranche x -- paths: x/**",
+        "2026-08-15T00:00:00Z",
+    )
+    p = payload(blocker, number=11064, title="t")
+    rc = clc._run_check(p, "B:CoursIA", my_paths=["x/a.ipynb"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "BLOCKED: another lane holds an active claim" in captured.err
+    assert "DEAD-SCOPE LOCK" not in captured.err
+
+
+def test_12905_partially_dead_blocker_gets_no_dead_scope_lock_message(capsys, monkeypatch):
+    """Asymmetry pin (mirror of the #11098 reducer asymmetry): a blocker
+    whose scope is PARTIALLY dead (at least one live glob) stays SCOPED --
+    the epic-wide lift only fires when the WHOLE scope is dead. A partial
+    block is a genuine scope intersection, not a reservation lock."""
+    monkeypatch.setattr(clc, "_git_tracked_files",
+                        lambda: ["x/a.ipynb"])
+    blocker = comment(
+        "[CLAIMED] lane A:CoursIA -- tranche x -- paths: x/**, dead/**",
+        "2026-08-15T00:00:00Z",
+    )
+    p = payload(blocker, number=11064, title="t")
+    rc = clc._run_check(p, "B:CoursIA", my_paths=["x/a.ipynb"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "BLOCKED: another lane holds an active claim" in captured.err
+    assert "DEAD-SCOPE LOCK" not in captured.err
+
+
+def test_12905_no_tracked_walk_no_dead_scope_lock_message(capsys, monkeypatch):
+    """Degradation pin: outside a git repo (`tracked=None`) no `empty_scope`
+    witness exists, `_claim_scope_effectively_epic_wide` degrades to False
+    and the explainer stays silent. To still reach the BLOCKED branch under
+    degradation, the caller's scope must INTERSECT the declared one (a
+    disjoint scope would drop the blocker entirely, pre-#10958 semantics):
+    the conflict is then genuine on its face and the plain BLOCKED message
+    is emitted without the dead-scope explainer."""
+    monkeypatch.setattr(clc, "_git_tracked_files", lambda repo_root=None: None)
+    blocker = comment(
+        "[CLAIMED] lane A:CoursIA -- reserve -- paths: newdir/**",
+        "2026-08-25T09:00:00Z",
+    )
+    p = payload(blocker, number=12844, title="t")
+    rc = clc._run_check(p, "B:CoursIA", my_paths=["newdir/f.ipynb"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "BLOCKED" in captured.err
+    assert "DEAD-SCOPE LOCK" not in captured.err
+
+
 def test_claim_paths_roundtrip_reads_back_scoped(monkeypatch):
     # #11064 acceptance (4): a claim posted with --paths is read back by the
     # check as SCOPED -- a disjoint lane stays free (exit 0), an intersecting


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/guard #12925

## Défaut (issue #12905, mesuré sur #12844)

Une lane qui réserve un chemin à créer (`paths: <chemin inexistant>/**`) voit son claim relevé en epic-wide par le fail-safe #10958 : il bloque **toute** l'issue-parapluie, y compris les lanes dont le scope est vivant et prouvablement disjoint. Le verdict fail-closed reste le bon défaut — mais le **texte de blocage ne nommait pas la conséquence** : un coordinateur lisant `WARN: glob sans correspondance` pense « worktree en retard », pas « ce claim verrouille toute l'issue ».

## Fix — piste 1 de l'issue (message explicite, la moins invasive)

Sous-message dédié `DEAD-SCOPE LOCK` dans la branche BLOCKED de `check_lane_claim.py`, même forme que l'explainer `LOCKED (v2)` existant (exit code inchangé, verdict fail-closed inchangé) :

- nomme la lane bloqueuse et ses globs morts **verbatim** ;
- nomme le mécanisme : « treated as EPIC-WIDE and locks the whole issue for every lane — including yours, even when your scope is provably disjoint (the nominal case of a lane reserving a path it is about to create) » ;
- nomme les échappatoires : ré-émission du claim quand le chemin existe, `[RELEASED]`, `[OVERRIDE] lane <m:w>` coordinateur (#10223).

Sélectivité (3 pins) : blocker à scope **vivant** → pas de message ; blocker à scope **partiellement** mort → pas de message (l'asymétrie #11098 tient : seule la mort du scope ENTIER relève en epic-wide) ; `tracked=None` (hors repo git) → dégradation silencieuse, BLOCKED simple.

La piste 2 de l'issue (marqueur `[RESERVED]` non bloquant) change la sémantique du protocole de claim — arbitrage coordinateur/user, hors scope worker ; non implémentée ici.

## Preuves

**Tests** : `python -m pytest scripts/tests/test_check_lane_claim.py -q` → **240 passed** (236 préexistants + 4 nouveaux #12905), relancés après le dernier commit :
- `test_12905_dead_scope_blocker_names_epic_wide_lock` — le scénario exact de l'issue (blocker entièrement mort `asymmetric_information_lean/**`, appelant vivant disjoint `GameTheory-17b.ipynb`) : rc=1 BLOCKED + DEAD-SCOPE LOCK + EPIC-WIDE + lane + glob + échappatoires nommés ;
- `test_12905_live_scope_blocker_gets_no_dead_scope_lock_message` — contrôle positif de sélectivité ;
- `test_12905_partially_dead_blocker_gets_no_dead_scope_lock_message` — pin d'asymétrie ;
- `test_12905_no_tracked_walk_no_dead_scope_lock_message` — pin de dégradation.

**Live** : `check_lane_claim.py 12844` rejoué ce cycle — l'état a évolué depuis la mesure du matin de l'issue (le claim dead-scope de po-2024 n'est plus actif ; seul le claim vivant de po-2025 bloque, intersection réelle avec `GameTheory-17b-*.ipynb`) : la reproduction live n'est plus atteignable, le scénario exact vit dans les tests avec le payload de l'issue (mock `_git_tracked_files`, convention #12345).

Catalogue byte-identique à main (2 fichiers scripts, +142/−0).

See #12905

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>