### PR TITLE
fix(ci,#12931): runner-manager platform-neutral — confinement Windows pur + drapeau IS_WINDOWS

### DIFF
--- a/scripts/ci/manage_self_hosted_runner.py
+++ b/scripts/ci/manage_self_hosted_runner.py
@@ -17,6 +17,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import ntpath
 import tempfile
 import urllib.request
 import zipfile
@@ -29,6 +30,9 @@ EXIT_REFUSED = 1
 EXIT_BROKEN = 2
 PROFILE_PATH = Path(__file__).with_name("self_hosted_runner_profiles.json")
 REPO_ROOT = Path(__file__).resolve().parents[2]
+# Captured at import so tests can fake the Windows host without patching the
+# global os.name (which flips pathlib.Path dispatch and crashes on posix).
+IS_WINDOWS = os.name == "nt"
 REQUIRED_LABELS = {
     "self-hosted",
     "coursia-ephemeral",
@@ -115,6 +119,12 @@ def _is_within(child: Path, parent: Path) -> bool:
         return False
 
 
+def _within_windows(child: str, parent: str) -> bool:
+    child_norm = ntpath.normpath(child).rstrip("\\/").lower()
+    parent_norm = ntpath.normpath(parent).rstrip("\\/").lower()
+    return child_norm == parent_norm or child_norm.startswith(parent_norm + "\\")
+
+
 def _validate_profile(name: str, raw: Any) -> Profile:
     required = {
         "hostname", "repository", "runner_name", "account", "root", "work",
@@ -156,13 +166,13 @@ def _validate_profile(name: str, raw: Any) -> Profile:
     root = _canonical_absolute(raw["root"], "root")
     work = _canonical_absolute(raw["work"], "work")
     log_root = _canonical_absolute(raw["log_root"], "log_root")
-    if not _is_within(work, root):
+    if not _within_windows(str(work), str(root)):
         raise Refused(f"profile {name!r} work directory must be below its runner root")
-    if _is_within(root, REPO_ROOT):
+    if _within_windows(str(root), str(REPO_ROOT)):
         raise Refused(f"profile {name!r} runner root must be outside the repository")
     # Le checkout du runner lui-meme vit par construction sous <root>/_work :
     # la clause REPO_ROOT-sous-root ne doit refuser que HORS de la zone work (#13238).
-    if _is_within(REPO_ROOT, root) and not _is_within(REPO_ROOT, work):
+    if _within_windows(str(REPO_ROOT), str(root)) and not _within_windows(str(REPO_ROOT), str(work)):
         raise Refused(f"profile {name!r} runner root must be outside the repository")
     sensitive = raw["sensitive_paths"]
     if (
@@ -429,7 +439,7 @@ def _sensitive_paths(profile: Profile) -> tuple[tuple[Path, Path], ...]:
             probe = Path(probe_template.format(**values))
         except KeyError as exc:
             raise Broken(f"unknown sensitive path template key: {exc}") from exc
-        if not _is_within(probe, deny) and probe != deny:
+        if not _within_windows(str(probe), str(deny)) and probe != deny:
             raise Refused("sensitive probe must be the denied path or one of its children")
         result.append((deny, probe))
     return tuple(result)
@@ -507,7 +517,7 @@ def _default_download(url: str, target: Path) -> None:
 
 
 def apply_install(profile: Profile, run: CommandRunner = subprocess.run, download: Downloader = _default_download) -> None:
-    if os.name != "nt":
+    if not IS_WINDOWS:
         raise Refused("install --apply is supported only on Windows")
     password = os.environ.get(ACCOUNT_PASSWORD_ENV)
     if not password:

--- a/scripts/tests/test_manage_self_hosted_runner.py
+++ b/scripts/tests/test_manage_self_hosted_runner.py
@@ -112,6 +112,14 @@ def PureWindows(path: Path) -> str:
     return "C:\\" + "\\".join(path.parts[-3:])
 
 
+@pytest.fixture(autouse=True)
+def _probe_env(monkeypatch, tmp_path):
+    # The isolation-probe templates resolve {user_profile}/{appdata}; native
+    # Windows always defines them, the posix CI host does not.
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "user"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+
+
 def test_run_powershell_delivers_scripts_via_file_not_stdin():
     # Regression (measured on pwsh 7.5, 2026-08-25): `-Command -` fed over
     # stdin silently stops executing at a PowerShell here-string (@'...'@)
@@ -317,7 +325,7 @@ def completed(argv=None, **kwargs):
 def test_install_refuses_bad_checksum_before_extraction(tmp_path, monkeypatch):
     data = make_runner_archive()
     target = profile(tmp_path / "runner", digest="0" * 64)
-    monkeypatch.setattr(mod.os, "name", "nt")
+    monkeypatch.setattr(mod, "IS_WINDOWS", True)
     monkeypatch.setenv(mod.ACCOUNT_PASSWORD_ENV, "local-password")
     calls = []
 
@@ -339,7 +347,7 @@ def test_install_extracts_atomically_and_never_logs_password(tmp_path, monkeypat
     data = make_runner_archive()
     target = profile(tmp_path / "runner", digest=hashlib.sha256(data).hexdigest())
     password = "local-password-never-log"
-    monkeypatch.setattr(mod.os, "name", "nt")
+    monkeypatch.setattr(mod, "IS_WINDOWS", True)
     monkeypatch.setenv(mod.ACCOUNT_PASSWORD_ENV, password)
     calls = []
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/guard #12776

G-VAR-3 : deux MED/guard consecutifs, substances distinctes — #12776 corrigeait la resolution de predecesseur dans `check_lane_claim` ; ce grain repare un organe different (`manage_self_hosted_runner`) sur une classe de defaut differente (portabilite plateforme CI).

Closes #12931

## Diagnostic

Depuis le merge de #12833 (2026-08-25T00:18Z, merge avec `Scripts Tests (CPU)` rouge), **tout PR frais declenchant ce check est rouge** sur les runners Linux : session pytest avortee par `INTERNALERROR: cannot instantiate 'WindowsPath' on your system`. Mesure firsthand : 6 PRs de ma lane bloquees par ce rouge (#12685 #12730 #12787 #12790 #12795 #12835) ; signature identique sur le run de #12833 lui-meme (run 32783297084).

## Repro (WSL, avant le fix)

```
scripts/ci/manage_self_hosted_runner.py:160: in _validate_profile
    raise Refused(f"profile {name!r} work directory must be below its runner root")
E   manage_self_hosted_runner.Refused: profile 'myia-po-2023-fast-guards' ...
1 failed in 1.20s
```

Puis session avortee vers le 22e test (`test_install_refuses_bad_checksum...`) : le patch global `os.name='nt'` fait echouer tout constructeur `Path()` en `WindowsPath` sur posix — y compris dans le formatage d'echec de pytest lui-meme.

## Livrable (2 fichiers, +24/-6)

| Changement | Pourquoi |
|---|---|
| `_within_windows(child, parent)` via `ntpath.normpath` (case-insensitive, cross-plateforme) ; reroutage des 2 sites de `_validate_profile` et du site probe/deny de `_sensitive_paths` | le confinement de chemins Windows validates ne doit pas dependre de la flavor `Path` de l'hote |
| `IS_WINDOWS = os.name == "nt"` capture a l'import ; garde `apply_install` sur `IS_WINDOWS` ; tests patchent le drapeau au lieu de `os.name` | patcher `os.name` globalement deraille le dispatch pathlib sur les runners Linux |
| Fixture autouse `_probe_env` (USERPROFILE/APPDATA -> tmp) | ces vars n'existent pas sur hote posix ; le garde protectif du script reste intact |

## Verifications

- `pytest scripts/tests/test_manage_self_hosted_runner.py` : **38/38 Windows** (0.58s) **ET 38/38 Linux WSL** (1.13s) — avant : 1 failed + INTERNALERROR abort sur WSL.
- Tests lies : `-k "self_hosted or runner"` -> 89 passed, 1 skipped.
- Aucun appelant workflow du script (cycle de vie prepare, non active — #12704) ; semantique de garde inchangee sur hote Windows (les memes Refused se declenchent, verifie par les parametrises negatifs).

## Impact

Debloque le check `Scripts Tests (CPU)` pour toute la flotte. Les 6 PRs rouges de ma lane necessiteront `update-branch` (ou push) pour regenerer leur merge-ref avec le main corrige — ~41 runs chacune sous saturation CI : a etaler, pas a faire en bloc ce cycle.

🤖 Generated with [Claude Code](https://claude.com/claude.com)


---

**Arbitrages coordinateur (ai-01, 2026-08-26) — deux verrous leves cote issue/PR, aucun changement de code :**

1. **Verrou de lane** — le blocage venait d'un `paths:` mort sur l'issue (deux chemins separes par un espace au lieu d'une virgule, donc glob unique matchant zero fichier, donc portee epic-wide par le fail-safe #10958). Arbitrage ecrit : jsboige/CoursIA#12931 (issuecomment-5429177738). `check_lane_claim.py` re-lance apres coup : `blocking_lanes: []`, rc=0.
2. **G-VAR-3** — override ecrit ci-dessus (issuecomment-5429211389), motive par l'amendement §3 « on ne jette pas du travail ecrit » et par la portee flotte du correctif. `next: notebook-dotnet` pour le prochain grain **neuf** de la lane ; les reparations de PR existantes heritent de leur genre d'origine.

Cette modification du corps sert aussi de declencheur : les gardes republient leur verdict sur une tete rafraichie.
