### PR TITLE
fix(tweety,#12789): Tweety-3 télécharge ses JARs via Maven Central — amont tweetyproject.org/builds/ mort (404)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
@@ -6,10 +6,10 @@
    "metadata": {
     "id": "e69e7c37",
     "papermill": {
-     "duration": 0.005474,
-     "end_time": "2026-06-02T21:43:33.204392+00:00",
+     "duration": 0.004057,
+     "end_time": "2026-08-25T16:08:13.566938",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.198918+00:00",
+     "start_time": "2026-08-25T16:08:13.562881",
      "status": "completed"
     },
     "tags": []
@@ -50,18 +50,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.061044Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.058832Z",
-     "iopub.status.idle": "2026-06-20T11:16:21.352327Z",
-     "shell.execute_reply": "2026-06-20T11:16:21.351829Z"
+     "iopub.execute_input": "2026-08-25T16:08:13.574541Z",
+     "iopub.status.busy": "2026-08-25T16:08:13.574333Z",
+     "iopub.status.idle": "2026-08-25T16:08:14.888843Z",
+     "shell.execute_reply": "2026-08-25T16:08:14.888290Z"
     },
     "id": "25a1db92-e3dd-4fb4-96e0-7db4030b5cf0",
     "outputId": "1033bbf7-96be-45e9-fc20-533f562a5346",
     "papermill": {
-     "duration": 0.267782,
-     "end_time": "2026-06-02T21:43:33.477184+00:00",
+     "duration": 1.319264,
+     "end_time": "2026-08-25T16:08:14.889634",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.209402+00:00",
+     "start_time": "2026-08-25T16:08:13.570370",
      "status": "completed"
     },
     "tags": []
@@ -72,7 +72,14 @@
      "output_type": "stream",
      "text": [
       "Packages Python OK.\n",
-      "JARs Tweety OK (42 fichiers dans libs/).\n"
+      "Telechargement de 13 JAR(s) Tweety 1.30...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  13/13 JAR(s) telecharges dans libs/.\n"
      ]
     }
    ],
@@ -102,7 +109,9 @@
     "# --- 2. JARs Tweety ---\n",
     "LIB_DIR.mkdir(exist_ok=True)\n",
     "\n",
-    "_BASE_URL = f\"https://tweetyproject.org/builds/{TWEETY_VERSION}/\"\n",
+    "# Amont /builds/ supprime (404 toutes versions, #12789) : Maven Central,\n",
+    "# meme construction que le script canonique scripts/download_tweety_tools.py\n",
+    "_MAVEN_BASE = \"https://repo1.maven.org/maven2/org/tweetyproject/\"\n",
     "_MODULES = {\n",
     "    \"commons\":         \"commons\",\n",
     "    \"logics-commons\":  \"logics.commons\",\n",
@@ -133,7 +142,8 @@
     "for local_name, artifact in _MODULES.items():\n",
     "    jar = LIB_DIR / f\"{local_name}-{TWEETY_VERSION}.jar\"\n",
     "    if not jar.exists():\n",
-    "        url = f\"{_BASE_URL}org.tweetyproject.{artifact}-{TWEETY_VERSION}.jar\"\n",
+    "        maven_path = artifact.replace(\".\", \"/\")\n",
+    "        url = f\"{_MAVEN_BASE}{maven_path}/{TWEETY_VERSION}/{artifact.split(\".\")[-1]}-{TWEETY_VERSION}.jar\"\n",
     "        _to_download.append((url, jar))\n",
     "for name, url in _DEPS.items():\n",
     "    jar = LIB_DIR / name\n",
@@ -164,10 +174,10 @@
    "id": "12deb5a4",
    "metadata": {
     "papermill": {
-     "duration": 0.005669,
-     "end_time": "2026-06-02T21:43:33.489222+00:00",
+     "duration": 0.003329,
+     "end_time": "2026-08-25T16:08:14.896916",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.483553+00:00",
+     "start_time": "2026-08-25T16:08:14.893587",
      "status": "completed"
     },
     "tags": []
@@ -189,18 +199,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.353915Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.353739Z",
-     "iopub.status.idle": "2026-06-20T11:16:21.586264Z",
-     "shell.execute_reply": "2026-06-20T11:16:21.585802Z"
+     "iopub.execute_input": "2026-08-25T16:08:14.904584Z",
+     "iopub.status.busy": "2026-08-25T16:08:14.904340Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.043489Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.042877Z"
     },
     "id": "c9384b5d",
     "outputId": "2d652722-71ed-4994-8bae-245477b19cc4",
     "papermill": {
-     "duration": 0.039835,
-     "end_time": "2026-06-02T21:43:33.534214+00:00",
+     "duration": 2.14403,
+     "end_time": "2026-08-25T16:08:17.044271",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.494379+00:00",
+     "start_time": "2026-08-25T16:08:14.900241",
      "status": "completed"
     },
     "tags": []
@@ -210,22 +220,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Verification JVM Tweety + Outils ---\n",
-      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+      "--- Verification JVM Tweety + Outils ---\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JVM demarree avec 42 JARs."
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "JVM demarree avec 13 JARs.\n",
       "\n",
       "JVM prete\n"
      ]
@@ -336,10 +338,10 @@
    "metadata": {
     "id": "8qq8geipre9",
     "papermill": {
-     "duration": 0.006167,
-     "end_time": "2026-06-02T21:43:33.548683+00:00",
+     "duration": 0.003156,
+     "end_time": "2026-08-25T16:08:17.051277",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.542516+00:00",
+     "start_time": "2026-08-25T16:08:17.048121",
      "status": "completed"
     },
     "tags": []
@@ -367,10 +369,10 @@
    "metadata": {
     "id": "f1d9d39c",
     "papermill": {
-     "duration": 0.005281,
-     "end_time": "2026-06-02T21:43:33.559214+00:00",
+     "duration": 0.003492,
+     "end_time": "2026-08-25T16:08:17.060114",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.553933+00:00",
+     "start_time": "2026-08-25T16:08:17.056622",
      "status": "completed"
     },
     "tags": []
@@ -398,18 +400,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.595587Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.594890Z",
-     "iopub.status.idle": "2026-06-20T11:16:21.968193Z",
-     "shell.execute_reply": "2026-06-20T11:16:21.967538Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.068113Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.067812Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.473722Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.472943Z"
     },
     "id": "32a3ee00",
     "outputId": "f2f8dd04-b795-42d1-c0b6-c00775c2cfcf",
     "papermill": {
-     "duration": 0.012545,
-     "end_time": "2026-06-02T21:43:33.579789+00:00",
+     "duration": 0.411148,
+     "end_time": "2026-08-25T16:08:17.474647",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.567244+00:00",
+     "start_time": "2026-08-25T16:08:17.063499",
      "status": "completed"
     },
     "tags": []
@@ -470,10 +472,10 @@
    "metadata": {
     "id": "r8awh2zx0s",
     "papermill": {
-     "duration": 0.00673,
-     "end_time": "2026-06-02T21:43:33.591653+00:00",
+     "duration": 0.003444,
+     "end_time": "2026-08-25T16:08:17.481991",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.584923+00:00",
+     "start_time": "2026-08-25T16:08:17.478547",
      "status": "completed"
     },
     "tags": []
@@ -504,10 +506,10 @@
    "metadata": {
     "id": "249053cb",
     "papermill": {
-     "duration": 0.004846,
-     "end_time": "2026-06-02T21:43:33.601596+00:00",
+     "duration": 0.003538,
+     "end_time": "2026-08-25T16:08:17.489632",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.596750+00:00",
+     "start_time": "2026-08-25T16:08:17.486094",
      "status": "completed"
     },
     "tags": []
@@ -530,18 +532,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.970202Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.969995Z",
-     "iopub.status.idle": "2026-06-20T11:16:21.976106Z",
-     "shell.execute_reply": "2026-06-20T11:16:21.975499Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.502093Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.501627Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.510868Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.509856Z"
     },
     "id": "ccee3f05",
     "outputId": "67f63573-1655-4bfe-fe43-247b56ceafbd",
     "papermill": {
-     "duration": 0.012403,
-     "end_time": "2026-06-02T21:43:33.618771+00:00",
+     "duration": 0.01873,
+     "end_time": "2026-08-25T16:08:17.511993",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.606368+00:00",
+     "start_time": "2026-08-25T16:08:17.493263",
      "status": "completed"
     },
     "tags": []
@@ -600,10 +602,10 @@
    "metadata": {
     "id": "xsjrbzh6vc",
     "papermill": {
-     "duration": 0.005773,
-     "end_time": "2026-06-02T21:43:33.630223+00:00",
+     "duration": 0.007505,
+     "end_time": "2026-08-25T16:08:17.525204",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.624450+00:00",
+     "start_time": "2026-08-25T16:08:17.517699",
      "status": "completed"
     },
     "tags": []
@@ -633,10 +635,10 @@
    "metadata": {
     "id": "61f79f45",
     "papermill": {
-     "duration": 0.005008,
-     "end_time": "2026-06-02T21:43:33.640440+00:00",
+     "duration": 0.004715,
+     "end_time": "2026-08-25T16:08:17.536693",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.635432+00:00",
+     "start_time": "2026-08-25T16:08:17.531978",
      "status": "completed"
     },
     "tags": []
@@ -659,18 +661,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.977831Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.977676Z",
-     "iopub.status.idle": "2026-06-20T11:16:21.991108Z",
-     "shell.execute_reply": "2026-06-20T11:16:21.990527Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.549797Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.549554Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.564908Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.564347Z"
     },
     "id": "c219a0b0",
     "outputId": "61b9825b-ccbe-44ba-a048-db5d843e7005",
     "papermill": {
-     "duration": 0.012349,
-     "end_time": "2026-06-02T21:43:33.657862+00:00",
+     "duration": 0.024275,
+     "end_time": "2026-08-25T16:08:17.566203",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.645513+00:00",
+     "start_time": "2026-08-25T16:08:17.541928",
      "status": "completed"
     },
     "tags": []
@@ -726,10 +728,10 @@
    "metadata": {
     "id": "q8mamrz0awt",
     "papermill": {
-     "duration": 0.005895,
-     "end_time": "2026-06-02T21:43:33.669221+00:00",
+     "duration": 0.0035,
+     "end_time": "2026-08-25T16:08:17.574961",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.663326+00:00",
+     "start_time": "2026-08-25T16:08:17.571461",
      "status": "completed"
     },
     "tags": []
@@ -762,10 +764,10 @@
    "metadata": {
     "id": "67ee6313",
     "papermill": {
-     "duration": 0.005456,
-     "end_time": "2026-06-02T21:43:33.680447+00:00",
+     "duration": 0.003455,
+     "end_time": "2026-08-25T16:08:17.581900",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.674991+00:00",
+     "start_time": "2026-08-25T16:08:17.578445",
      "status": "completed"
     },
     "tags": []
@@ -788,18 +790,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:21.993361Z",
-     "iopub.status.busy": "2026-06-20T11:16:21.993139Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.005155Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.004306Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.590556Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.590245Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.604986Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.604040Z"
     },
     "id": "86f23e81",
     "outputId": "980732e0-d0c3-42e3-c2d7-907d662b8366",
     "papermill": {
-     "duration": 0.012229,
-     "end_time": "2026-06-02T21:43:33.698279+00:00",
+     "duration": 0.021104,
+     "end_time": "2026-08-25T16:08:17.606612",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.686050+00:00",
+     "start_time": "2026-08-25T16:08:17.585508",
      "status": "completed"
     },
     "tags": []
@@ -857,10 +859,10 @@
    "metadata": {
     "id": "2c53q567ku3",
     "papermill": {
-     "duration": 0.005032,
-     "end_time": "2026-06-02T21:43:33.708826+00:00",
+     "duration": 0.003598,
+     "end_time": "2026-08-25T16:08:17.614581",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.703794+00:00",
+     "start_time": "2026-08-25T16:08:17.610983",
      "status": "completed"
     },
     "tags": []
@@ -894,10 +896,10 @@
    "metadata": {
     "id": "a86b50c4",
     "papermill": {
-     "duration": 0.00505,
-     "end_time": "2026-06-02T21:43:33.719092+00:00",
+     "duration": 0.003766,
+     "end_time": "2026-08-25T16:08:17.622108",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.714042+00:00",
+     "start_time": "2026-08-25T16:08:17.618342",
      "status": "completed"
     },
     "tags": []
@@ -933,18 +935,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.008380Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.008096Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.044718Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.043906Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.633618Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.633161Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.675114Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.674326Z"
     },
     "id": "ca8462d9",
     "outputId": "6bbaf161-0dcb-42e2-fff9-e7264aa4ac37",
     "papermill": {
-     "duration": 0.012159,
-     "end_time": "2026-06-02T21:43:33.736263+00:00",
+     "duration": 0.050303,
+     "end_time": "2026-08-25T16:08:17.676059",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.724104+00:00",
+     "start_time": "2026-08-25T16:08:17.625756",
      "status": "completed"
     },
     "tags": []
@@ -994,10 +996,10 @@
    "metadata": {
     "id": "ax9xqb9l3g9",
     "papermill": {
-     "duration": 0.005236,
-     "end_time": "2026-06-02T21:43:33.746665+00:00",
+     "duration": 0.004157,
+     "end_time": "2026-08-25T16:08:17.684408",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.741429+00:00",
+     "start_time": "2026-08-25T16:08:17.680251",
      "status": "completed"
     },
     "tags": []
@@ -1028,10 +1030,10 @@
    "metadata": {
     "id": "43de1b70",
     "papermill": {
-     "duration": 0.004508,
-     "end_time": "2026-06-02T21:43:33.755838+00:00",
+     "duration": 0.003636,
+     "end_time": "2026-08-25T16:08:17.692413",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.751330+00:00",
+     "start_time": "2026-08-25T16:08:17.688777",
      "status": "completed"
     },
     "tags": []
@@ -1054,18 +1056,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.050811Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.050487Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.070453Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.069772Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.702030Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.701670Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.745669Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.744953Z"
     },
     "id": "31b9b499",
     "outputId": "46ef5a9c-d299-4707-e1ea-e4f1f09a1978",
     "papermill": {
-     "duration": 0.014179,
-     "end_time": "2026-06-02T21:43:33.774700+00:00",
+     "duration": 0.049561,
+     "end_time": "2026-08-25T16:08:17.746573",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.760521+00:00",
+     "start_time": "2026-08-25T16:08:17.697012",
      "status": "completed"
     },
     "tags": []
@@ -1076,7 +1078,13 @@
      "output_type": "stream",
      "text": [
       "Parsing des formules modales:\n",
-      "  [OK] !(<>(p))\n",
+      "  [OK] !(<>(p))\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  [OK] p || r\n",
       "  [OK] !r || [](q && r)\n",
       "  [OK] [](r && <>(p || q))\n",
@@ -1130,10 +1138,10 @@
    "metadata": {
     "id": "2tlclzuloxq",
     "papermill": {
-     "duration": 0.004588,
-     "end_time": "2026-06-02T21:43:33.784065+00:00",
+     "duration": 0.003975,
+     "end_time": "2026-08-25T16:08:17.754997",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.779477+00:00",
+     "start_time": "2026-08-25T16:08:17.751022",
      "status": "completed"
     },
     "tags": []
@@ -1164,10 +1172,10 @@
    "metadata": {
     "id": "7e99bbed",
     "papermill": {
-     "duration": 0.004543,
-     "end_time": "2026-06-02T21:43:33.793193+00:00",
+     "duration": 0.003675,
+     "end_time": "2026-08-25T16:08:17.763461",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.788650+00:00",
+     "start_time": "2026-08-25T16:08:17.759786",
      "status": "completed"
     },
     "tags": []
@@ -1198,18 +1206,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.083062Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.082865Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.088685Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.088123Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.771733Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.771336Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.777333Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.776669Z"
     },
     "id": "64bb4a5b",
     "outputId": "09d44228-e27e-4d23-d1dd-05b1a440c86b",
     "papermill": {
-     "duration": 0.012217,
-     "end_time": "2026-06-02T21:43:33.809915+00:00",
+     "duration": 0.011695,
+     "end_time": "2026-08-25T16:08:17.778784",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.797698+00:00",
+     "start_time": "2026-08-25T16:08:17.767089",
      "status": "completed"
     },
     "tags": []
@@ -1340,10 +1348,10 @@
    "metadata": {
     "id": "wiqhhh9vo1",
     "papermill": {
-     "duration": 0.004499,
-     "end_time": "2026-06-02T21:43:33.819016+00:00",
+     "duration": 0.004331,
+     "end_time": "2026-08-25T16:08:17.787226",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.814517+00:00",
+     "start_time": "2026-08-25T16:08:17.782895",
      "status": "completed"
     },
     "tags": []
@@ -1386,10 +1394,10 @@
    "id": "6549fbfc",
    "metadata": {
     "papermill": {
-     "duration": 0.004669,
-     "end_time": "2026-06-02T21:43:33.828178+00:00",
+     "duration": 0.003701,
+     "end_time": "2026-08-25T16:08:17.794715",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.823509+00:00",
+     "start_time": "2026-08-25T16:08:17.791014",
      "status": "completed"
     },
     "tags": []
@@ -1429,16 +1437,16 @@
    "id": "d794b40f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.099084Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.098901Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.102365Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.101771Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.804152Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.803725Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.807223Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.806554Z"
     },
     "papermill": {
-     "duration": 0.011239,
-     "end_time": "2026-06-02T21:43:33.843770+00:00",
+     "duration": 0.009322,
+     "end_time": "2026-08-25T16:08:17.808175",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.832531+00:00",
+     "start_time": "2026-08-25T16:08:17.798853",
      "status": "completed"
     },
     "tags": []
@@ -1469,10 +1477,10 @@
    "metadata": {
     "id": "e781df26",
     "papermill": {
-     "duration": 0.004536,
-     "end_time": "2026-06-02T21:43:33.852916+00:00",
+     "duration": 0.003958,
+     "end_time": "2026-08-25T16:08:17.815992",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.848380+00:00",
+     "start_time": "2026-08-25T16:08:17.812034",
      "status": "completed"
     },
     "tags": []
@@ -1503,18 +1511,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.111960Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.111650Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.142976Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.142330Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.826077Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.825591Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.849053Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.848385Z"
     },
     "id": "d437aa5e",
     "outputId": "2070cbd4-66f8-4d41-8159-679e3a074d63",
     "papermill": {
-     "duration": 0.009837,
-     "end_time": "2026-06-02T21:43:33.867065+00:00",
+     "duration": 0.029096,
+     "end_time": "2026-08-25T16:08:17.850067",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.857228+00:00",
+     "start_time": "2026-08-25T16:08:17.820971",
      "status": "completed"
     },
     "tags": []
@@ -1561,10 +1569,10 @@
    "metadata": {
     "id": "zcsjedqgqsn",
     "papermill": {
-     "duration": 0.004984,
-     "end_time": "2026-06-02T21:43:33.877120+00:00",
+     "duration": 0.003851,
+     "end_time": "2026-08-25T16:08:17.865937",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.872136+00:00",
+     "start_time": "2026-08-25T16:08:17.862086",
      "status": "completed"
     },
     "tags": []
@@ -1606,10 +1614,10 @@
    "metadata": {
     "id": "84cbc8b8",
     "papermill": {
-     "duration": 0.005438,
-     "end_time": "2026-06-02T21:43:33.887872+00:00",
+     "duration": 0.004338,
+     "end_time": "2026-08-25T16:08:17.874176",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.882434+00:00",
+     "start_time": "2026-08-25T16:08:17.869838",
      "status": "completed"
     },
     "tags": []
@@ -1631,18 +1639,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.147114Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.146887Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.152489Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.152089Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.884451Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.883948Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.891137Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.890490Z"
     },
     "id": "3f1eb19c",
     "outputId": "98c7ad80-a908-4588-8216-2b8f1f8545cd",
     "papermill": {
-     "duration": 0.012756,
-     "end_time": "2026-06-02T21:43:33.906083+00:00",
+     "duration": 0.013908,
+     "end_time": "2026-08-25T16:08:17.892117",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.893327+00:00",
+     "start_time": "2026-08-25T16:08:17.878209",
      "status": "completed"
     },
     "tags": []
@@ -1705,10 +1713,10 @@
    "metadata": {
     "id": "j8peljtakkq",
     "papermill": {
-     "duration": 0.005312,
-     "end_time": "2026-06-02T21:43:33.917122+00:00",
+     "duration": 0.004038,
+     "end_time": "2026-08-25T16:08:17.900548",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.911810+00:00",
+     "start_time": "2026-08-25T16:08:17.896510",
      "status": "completed"
     },
     "tags": []
@@ -1747,10 +1755,10 @@
    "id": "3d52cf43",
    "metadata": {
     "papermill": {
-     "duration": 0.005213,
-     "end_time": "2026-06-02T21:43:33.928045+00:00",
+     "duration": 0.003959,
+     "end_time": "2026-08-25T16:08:17.908552",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.922832+00:00",
+     "start_time": "2026-08-25T16:08:17.904593",
      "status": "completed"
     },
     "tags": []
@@ -1784,16 +1792,16 @@
    "id": "1e9afcc4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.154223Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.154098Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.156786Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.156315Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.918087Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.917566Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.921275Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.920629Z"
     },
     "papermill": {
-     "duration": 0.010629,
-     "end_time": "2026-06-02T21:43:33.944069+00:00",
+     "duration": 0.009507,
+     "end_time": "2026-08-25T16:08:17.922335",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.933440+00:00",
+     "start_time": "2026-08-25T16:08:17.912828",
      "status": "completed"
     },
     "tags": []
@@ -1825,10 +1833,10 @@
    "metadata": {
     "id": "bd272720",
     "papermill": {
-     "duration": 0.005041,
-     "end_time": "2026-06-02T21:43:33.955466+00:00",
+     "duration": 0.003833,
+     "end_time": "2026-08-25T16:08:17.930003",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.950425+00:00",
+     "start_time": "2026-08-25T16:08:17.926170",
      "status": "completed"
     },
     "tags": []
@@ -1850,18 +1858,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.158549Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.158433Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.172041Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.171578Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.938641Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.938228Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.955868Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.954873Z"
     },
     "id": "8b153a15",
     "outputId": "5d58d430-c46a-4e35-99af-3b323cc855ef",
     "papermill": {
-     "duration": 0.011721,
-     "end_time": "2026-06-02T21:43:33.971972+00:00",
+     "duration": 0.023505,
+     "end_time": "2026-08-25T16:08:17.957198",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.960251+00:00",
+     "start_time": "2026-08-25T16:08:17.933693",
      "status": "completed"
     },
     "tags": []
@@ -1933,10 +1941,10 @@
    "metadata": {
     "id": "qhrdjt09oj",
     "papermill": {
-     "duration": 0.005506,
-     "end_time": "2026-06-02T21:43:33.982766+00:00",
+     "duration": 0.004016,
+     "end_time": "2026-08-25T16:08:17.965243",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.977260+00:00",
+     "start_time": "2026-08-25T16:08:17.961227",
      "status": "completed"
     },
     "tags": []
@@ -1977,10 +1985,10 @@
    "metadata": {
     "id": "gukci1vj9ze",
     "papermill": {
-     "duration": 0.004981,
-     "end_time": "2026-06-02T21:43:33.992625+00:00",
+     "duration": 0.004016,
+     "end_time": "2026-08-25T16:08:17.973287",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.987644+00:00",
+     "start_time": "2026-08-25T16:08:17.969271",
      "status": "completed"
     },
     "tags": []
@@ -2025,18 +2033,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.173825Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.173693Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.180634Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.180128Z"
+     "iopub.execute_input": "2026-08-25T16:08:17.982803Z",
+     "iopub.status.busy": "2026-08-25T16:08:17.982437Z",
+     "iopub.status.idle": "2026-08-25T16:08:17.990565Z",
+     "shell.execute_reply": "2026-08-25T16:08:17.989683Z"
     },
     "id": "w4l5v5ty69",
     "outputId": "29876fca-fa49-43ae-ebba-0e546d083fee",
     "papermill": {
-     "duration": 0.013973,
-     "end_time": "2026-06-02T21:43:34.012268+00:00",
+     "duration": 0.014074,
+     "end_time": "2026-08-25T16:08:17.991736",
      "exception": false,
-     "start_time": "2026-06-02T21:43:33.998295+00:00",
+     "start_time": "2026-08-25T16:08:17.977662",
      "status": "completed"
     },
     "tags": []
@@ -2147,10 +2155,10 @@
    "id": "6ee56fc6",
    "metadata": {
     "papermill": {
-     "duration": 0.004511,
-     "end_time": "2026-06-02T21:43:34.021475+00:00",
+     "duration": 0.004274,
+     "end_time": "2026-08-25T16:08:18.001814",
      "exception": false,
-     "start_time": "2026-06-02T21:43:34.016964+00:00",
+     "start_time": "2026-08-25T16:08:17.997540",
      "status": "completed"
     },
     "tags": []
@@ -2171,10 +2179,10 @@
    "metadata": {
     "id": "4a2b4ad3",
     "papermill": {
-     "duration": 0.004433,
-     "end_time": "2026-06-02T21:43:34.030408+00:00",
+     "duration": 0.004634,
+     "end_time": "2026-08-25T16:08:18.010963",
      "exception": false,
-     "start_time": "2026-06-02T21:43:34.025975+00:00",
+     "start_time": "2026-08-25T16:08:18.006329",
      "status": "completed"
     },
     "tags": []
@@ -2209,10 +2217,10 @@
    "id": "760e58ab",
    "metadata": {
     "papermill": {
-     "duration": 0.004266,
-     "end_time": "2026-06-02T21:43:34.039133+00:00",
+     "duration": 0.005509,
+     "end_time": "2026-08-25T16:08:18.021232",
      "exception": false,
-     "start_time": "2026-06-02T21:43:34.034867+00:00",
+     "start_time": "2026-08-25T16:08:18.015723",
      "status": "completed"
     },
     "tags": []
@@ -2239,16 +2247,16 @@
    "id": "287e261a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-20T11:16:22.188426Z",
-     "iopub.status.busy": "2026-06-20T11:16:22.188183Z",
-     "iopub.status.idle": "2026-06-20T11:16:22.192569Z",
-     "shell.execute_reply": "2026-06-20T11:16:22.191875Z"
+     "iopub.execute_input": "2026-08-25T16:08:18.033512Z",
+     "iopub.status.busy": "2026-08-25T16:08:18.033265Z",
+     "iopub.status.idle": "2026-08-25T16:08:18.036574Z",
+     "shell.execute_reply": "2026-08-25T16:08:18.035693Z"
     },
     "papermill": {
-     "duration": 0.009467,
-     "end_time": "2026-06-02T21:43:34.053618+00:00",
+     "duration": 0.010258,
+     "end_time": "2026-08-25T16:08:18.037433",
      "exception": false,
-     "start_time": "2026-06-02T21:43:34.044151+00:00",
+     "start_time": "2026-08-25T16:08:18.027175",
      "status": "completed"
     },
     "tags": []
@@ -2274,26 +2282,26 @@
   }
  ],
  "metadata": {
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": null,
-   "qcc_tokens_est": 0,
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": null,
-   "network": true,
-   "external_account": false,
-   "free_alternative": "self",
-   "reduced_pedagogical": false,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-08-03",
-   "validator": "manual-v-provision",
-   "notes": "Advanced logics (modal, default, conditional) via Tweety. Downloads sat4j/args4j + Tweety jars from Maven (cached). Deterministic Java solver. Notebooks executed 16/16 cells."
-  },
   "colab": {
    "provenance": []
+  },
+  "cost": {
+   "api_provider": null,
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": false,
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-03",
+   "network": true,
+   "notes": "Advanced logics (modal, default, conditional) via Tweety. Downloads sat4j/args4j + Tweety jars from Maven (cached). Deterministic Java solver. Notebooks executed 16/16 cells.",
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": false,
+   "reproducibility": "HIGH",
+   "validator": "manual-v-provision",
+   "vram_gb": 0,
+   "vram_tier": null
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -2310,18 +2318,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.342964,
-   "end_time": "2026-06-02T21:43:34.606142+00:00",
+   "duration": 6.490005,
+   "end_time": "2026-08-25T16:08:18.283923",
    "environment_variables": {},
    "exception": null,
    "input_path": "Tweety-3-Advanced-Logics.ipynb",
-   "output_path": "Tweety-3-Advanced-Logics.ipynb",
+   "output_path": "Tweety-3-Advanced-Logics_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-02T21:43:31.263178+00:00",
+   "start_time": "2026-08-25T16:08:11.793918",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: FIX/env-amont-mort — lane myia-po-2023:CoursIA-2 — prev: FIX/garde-fou-layout #12945

## Summary

Fix de #12789 : l'amont TweetyProject a supprimé `/builds/` (404 sur toutes les versions), cassant `Tweety-3-Advanced-Logics.ipynb` sur tout fresh checkout — la cellule 1 construisait ses URLs de téléchargement sur `https://tweetyproject.org/builds/{version}/`, les 11 modules échouaient en fail-soft (« ERREUR » imprimé, JVM sans classpath, sections Tweety sautées), et les machines avec `libs/` déjà peuplée ne voyaient rien (download skippé).

**Le fix (1 fichier, notebook)** : la cellule 1 construit désormais ses URLs **Maven Central** exactement comme le script canonique `Tweety/scripts/download_tweety_tools.py` — `https://repo1.maven.org/maven2/org/tweetyproject/{artifact avec points→slashes}/{version}/{dernier-segment}-{version}.jar`. Les noms de fichiers locaux sont inchangés (dont le préfixe collision `logics-commons-1.30.jar` vs `commons-1.30.jar`), donc un `libs/` peuplé par l'une ou l'autre voie reste compatible.

**Preuve pre-exec** : HEAD sur les 11 URLs construites par la nouvelle cellule → **11/11 × HTTP 200** (vérifié depuis la machine, y compris la paire collision `commons` / `logics.commons` qui pointent vers deux chemins Maven distincts).

## Validation

- **Re-exec complète C.2** (papermill via `scripts/notebook_tools/notebook_tools.py execute`, kernel python3, JVM Temurin 17) sur un **worktree frais sans `libs/`** — le profil exact du fresh-checkout cassé : la cellule 1 télécharge les JARs depuis Maven Central et le notebook s'exécute de bout en bout.
- ```
[Tweety-3-Advanced-Logics.ipynb] (kernel: python3)
  [+] SUCCESS
Success: 1 | Failed: 0
```
Sorties committes byte-exact :
- cellule 1 : `Telechargement de 13 JAR(s) Tweety 1.30... 13/13 JAR(s) telecharges dans libs/.` (fresh libs/, aucune ligne ERREUR dans tout le notebook)
- cellule 3 : `JVM demarree avec 13 JARs. / JVM prete`
- substance verifiee sur cellules echantillonnees (DL : `Female = Human ? True` ; ML : parsing `[OK] !([](p))` ; CL : conditionnels `(bird|flies)` ; FOL : TBox/ABox + requetes) — 16/16 cellules code, ec monotones 1..16, 0 erreur kernel
- 0 référence résiduelle à `tweetyproject.org/builds/` dans Tweety-3 (acceptance 1) ; URLs Maven identiques au canonique (acceptance 2) ; C.1 vérifié (0 `raise NotImplementedError`/`assert False`/`1/0`).
- Env réparé localement (règle F) : la machine n'avait plus de JDK (PATH java = runtime Freeplane 1.8) — **Temurin 17 JDK installé** user-scope (`%LOCALAPPDATA%\CoursIA\jdk17`) pour l'exécution.

See #12789 (contexte amont : amont /builds/ supprimé)

Verdict SOTA (Prong A) : **SOTA-OK** — les JARs sont les artefacts officiels Maven Central (`repo1.maven.org`, meme construction que le script canonique), pas un miroir deconne ; JVM Temurin 17.0.20.1 reelle (installee user-scope sur la machine, regle F).
