### PR TITLE
fix(guards,#12944): close-the-loop Hermes reconnu comme levee (LIFT passifs + ref inline)

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -229,6 +229,24 @@ LIFT_MARKERS = (
     # backquotee ; celle-ci lui echappe, et le marqueur de concern se
     # trouve alors *a l'interieur* de la phrase qui le leve.
     "lève la", "leve la", "Lève la", "Leve la",
+    # #12944 : le close-the-loop Hermes (« Mon concern ... est traité et
+    # fermé », PR #12941 fondateur, review 5020777166). Forme PASSIVE de
+    # levee, verbes de FERMETURE uniquement (clos / fermé / résolu) plus
+    # les composes « traité et fermé » qui couvrent le gras markdown
+    # separant l'auxiliaire du participe (« est **traité et fermé** »).
+    # La suggestion « est traité » nue de l'issue a ete REJETTEE sur
+    # contre-exemple mesure : le body pinned #11639 « le point 3 est
+    # traité en argument » (override NU qui ne doit rien lever) matcherait
+    # — « traité » narratif se promene (« traité dans la section 4 »),
+    # les verbes de fermeture s'engagent. Residu assume : une negation
+    # INTERNE au compose (« pas encore traité et fermé ») le matcherait
+    # (limite NLP documentee dans can_lift, pinne par
+    # test_12944_residu_negation_du_compose_documente).
+    "est clos", "sont clos", "sont closes",
+    "est fermé", "sont fermés", "sont fermées",
+    "est résolu", "sont résolus", "sont résolues",
+    "traité et fermé", "traitée et fermée",
+    "traité et clos", "traitée et close",
 )
 
 # Un LIFT en construction CONDITIONNELLE (« corrige X et je merge », « je merge
@@ -446,15 +464,29 @@ _MENTION_VERDICT_LIFTED = re.compile(
 # emission revendique sans pointer. Pas de reference pointable = pas de
 # match = le verdict reste emis. Frontiere elargie a `*` : le mot est
 # souvent en gras (« La **revue** CHANGES_REQUESTED »).
+#
+# #12944 — extension de position : la reference pointable HORS parentheses.
+# Cas fondateur #12941 (review Hermes close-the-loop 5020777166) : « sur ma
+# review REQUEST_CHANGES de #12900 (`ffe18961`) » — le numero de la PR/review
+# source suit directement le verdict, sans parenthese. La forme d'origine ne
+# voyait que la ref entre parentheses immediates, le verdict restait emis et
+# `_formal_concern_precedes_lift` annulait meme la levee passive qui suivait.
+# Meme discriminant que #11984 (le ref pointable designe l'evenement passe
+# rapporte ; une emission ne pointe pas), position differente seulement.
 _MENTION_VERDICT_REVIEW = re.compile(
     r"(?i)(?:^|[\s,;:(*])"  # frontiere (inclut * pour **revue**)
     r"(?:le|la|les|du|mon|ma|ce|cet|cette|ces|the|my)?\s*"
     r"(?:revue|review)(?![:.])"
     r"[^():\n.]{0,60}?(?-i:([A-Z][A-Z_]{3,}))(?![A-Za-z0-9_])"
+    r"(?:"
+    # Forme d'origine : ref pointable entre parentheses immediates.
     r"[^():\n.]{0,12}?"
     r"\([^()\n]{0,80}?"
     r"(?:[a-f0-9]{7,}|#\d+|\d{4}-\d{2}-\d{2}|\d{1,2}:\d{2}(?::\d{2})?Z?)"
-    r"[^()\n]{0,40}\)")
+    r"[^()\n]{0,40}\)"
+    # #12944 : ref pointable inline — « review VERDICT de #N ».
+    r"|\s+(?:de\s+|sur\s+|dans\s+)?(?:la\s+|le\s+)?(?:PR\s+)?#\d+"
+    r")")
 
 
 def _strip_mentioned_verdicts(body: str) -> str:

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -2141,3 +2141,79 @@ def test_13083_blocage_reel_conditionnel_a_un_override_reste_block():
     body = ("**BLOCAGE MERGE (ai-01)** — pas de merge tant que [OVERRIDE] lane "
             "n'est pas pose par le coordinateur.")
     assert mod.classify("myia-ai-01", body) == "BLOCK"
+# --- #12944 : le close-the-loop Hermes. « Mon concern ... est traité et
+# fermé » (PR #12941 fondateur, review 5020777166) : la levee PASSIVE
+# n'etait couverte par aucun LIFT_MARKER, et le verdict mentionne (« ma
+# review REQUEST_CHANGES de #12900 », ref HORS parentheses) echappait aux
+# motifs de mention — l'acquittement etait classe BOT-CONCERN et bloquait
+# le merge. Meme classe que c.504 : un acquittement qui contient des
+# marqueurs formels est mal classe.
+
+def test_12944_levee_passive_est_un_lift_marker():
+    """La forme passive « est traité et fermé » (gras markdown compris, le
+    compose couvre la coupure auxiliaire/participe) et les verbes de
+    fermeture (clos / ferme / resolu) sont des LIFT_MARKERS. « est traité »
+    NU est REJETTE : le body pinned #11639 « le point 3 est traité en
+    argument » est une narration, pas une levee (l'override nu ne leve
+    rien)."""
+    assert mod.has_marker(
+        "Mon concern est **traité et fermé** : registre régénéré.",
+        mod.LIFT_MARKERS)
+    assert mod.has_marker("le point est clos, rien ne bloque", mod.LIFT_MARKERS)
+    assert mod.has_marker("le fil est fermé après vérification", mod.LIFT_MARKERS)
+    assert not mod.has_marker("le point 3 est traité en argument", mod.LIFT_MARKERS)
+    assert not mod.has_marker("Le point 2 n'est pas traité.", mod.LIFT_MARKERS)
+
+
+def test_12944_close_the_loop_leve_la_review_precedente():
+    """End-to-end : la review REQUEST_CHANGES posee par Hermes (self-bot
+    jsboige), puis son close-the-loop (« est traité et fermé », verdict
+    mentionne avec ref inline) par le meme auteur — le gate passe : le
+    close-the-loop est un explicit_lift borne (#11145, meme auteur)."""
+    review = {
+        "author": {"login": "jsboige"},
+        "state": "COMMENTED", "submittedAt": at(10),
+        "body": "[Hermes] — REQUEST_CHANGES : le registre de citations est fabriqué.",
+    }
+    loop = {"author": {"login": "jsboige"}, "createdAt": at(12),
+            "body": "close-the-loop sur ma review REQUEST_CHANGES de #12900 : "
+                    "Mon concern est **traité et fermé**, registre régénéré "
+                    "(commit ffe18961)."}
+    data = {
+        "number": 0, "title": "t", "author": {"login": "myia-po-2026"},
+        "comments": [loop], "reviews": [review],
+        "commits": [{"committedDate": at(13)}],
+    }
+    assert mod.analyse(data, [], MERGED)["blocked"] is False
+
+
+def test_12944_close_the_loop_seul_nest_plus_un_nit():
+    """Le cas mesure sur #12941 : le close-the-loop ETAIT lui-meme l'unique
+    signal bloque (classify BOT-CONCERN sur son propre body). Il doit
+    desormais rendre None — verdict mentionne + levee passive."""
+    body = ("**[Hermes]** — close-the-loop sur ma review REQUEST_CHANGES de "
+            "#12900 (`ffe18961`). Mon concern est **traité et fermé** : "
+            "registre régénéré depuis les diffs réels.")
+    assert mod.classify("jsboige", body) is None
+
+
+def test_12944_revalidation_formelle_avant_levee_reste_bot_concern():
+    """Garde #12798/#12836 intacts : un verdict formel EMIS en tete puis une
+    narration de levee passive en aval reste BOT-CONCERN — le close-the-loop
+    ne debranche pas la revalidation qui REFUTE une levee annoncee."""
+    body = ("[Hermes] COMMENT_WITH_CONCERNS — revalidation : le concern "
+            "précédent est traité et fermé, mais la cassette reste non "
+            "prouvée.")
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_12944_residu_negation_du_compose_documente():
+    """Residu ASSUME (limite NLP, cf can_lift) : une negation INTERNE au
+    compose (« pas encore traité et fermé ») contient le marqueur
+    « traité et fermé » et se leverait a tort. Pin par ecrit : le
+    discriminant exigerait une fenetre de negation cote LIFT, machinery
+    qui n'existe pas (CITERS ne s'applique qu'aux CONCERN_MARKERS via
+    `_is_cited`). Un redacteur futur qui veut fermer ce residu saura que
+    CE test est celui a mettre a jour."""
+    body = "Mon concern n'est pas encore traité et fermé, le registre reste fabriqué."
+    assert mod.has_marker(body, mod.LIFT_MARKERS) is True  # residu assume

--- a/scripts/tests/test_check_unaddressed_nits_mention.py
+++ b/scripts/tests/test_check_unaddressed_nits_mention.py
@@ -312,3 +312,66 @@ def test_11984_forme_11628_non_regie_par_le_nouveau_motif():
     assert m is None, body
     # Le strip global neutralise toujours (via #11636).
     assert "CHANGES_REQUESTED" not in mod._strip_mentioned_verdicts(body)
+
+
+# ---------------------------------------------------------------------------
+# #12944 — extension de la position D : reference pointable HORS parentheses.
+# Instance fondatrice : #12941, review Hermes close-the-loop 5020777166 —
+# « sur ma review REQUEST_CHANGES de #12900 (`ffe18961`) » : le numero de la
+# PR source suit le verdict SANS parenthese. Le verdict mentionne restait
+# emis, et `_formal_concern_precedes_lift` annulait de surcroit la levee
+# passive qui suivait (« est **traité et fermé** », nouveaux LIFT_MARKERS).
+# Meme discriminant que #11984 : le ref pointable designe l'evenement passe
+# rapporte ; sans ref, le verdict reste emis.
+# ---------------------------------------------------------------------------
+
+FOUNDER_12941_BODY = (
+    "**[Hermes]** — close-the-loop sur ma review REQUEST_CHANGES de #12900 "
+    "(`ffe18961`). Mon concern (registre de 18 entrées dont 16 notebooks "
+    "inexistants + test-théâtre) est **traité et fermé** :\n\n"
+    "1. **Registre régénéré depuis les diffs réels** : les 8 entrées "
+    "proviennent de l'extraction mécanique, pas de mémoire.\n\n"
+    "Verdict : le fix répond à la cause racine plutôt qu'à la dérive.\n"
+    "*(contrainte token : COMMENT only — auteur `jsboige`)*\n"
+)
+
+
+def test_12944_fondateur_close_the_loop_nest_plus_un_nit():
+    """Corps (raccourci, structure exacte) de la review 5020777166 de #12941 :
+    le verdict mentionne (« ma review REQUEST_CHANGES de #12900 ») est
+    neutralise, la levee passive (« est **traité et fermé** ») est reconnue —
+    classify rend None au lieu de BOT-CONCERN. AVANT le fix, ce close-the-loop
+    etait l'unique item bloquant du gate sur #12941."""
+    assert mod.classify("jsboige", FOUNDER_12941_BODY) is None
+
+
+def test_12944_ref_hors_parentheses_neutralise_le_verdict():
+    """Unite sur le motif : « review VERDICT de #N » (ref inline, sans
+    parenthese) neutralise le verdict via _strip_mentioned_verdicts."""
+    body = "close-the-loop sur ma review REQUEST_CHANGES de #12900 (`ffe18961`)."
+    assert "REQUEST_CHANGES" not in mod._strip_mentioned_verdicts(body)
+
+
+def test_12944_ref_inline_variante_sans_preposition():
+    """« the review REQUEST_CHANGES #12900 » — la preposition « de » est
+    optionnelle, le # pointable suffit (forme anglaise)."""
+    body = "the review REQUEST_CHANGES #12900 was mine, and it is now addressed."
+    assert "REQUEST_CHANGES" not in mod._strip_mentioned_verdicts(body)
+
+
+def test_12944_ref_inline_sans_numero_reste_vivant():
+    """Controle negatif du discriminant : nominal + verdict SANS ref pointable
+    reste une emission — « Ma review REQUEST_CHANGES tient toujours. »
+    (miroir exact du contre-exemple #11984 « Cette review CHANGES_REQUESTED
+    reste bloquante »)."""
+    body = "Ma review REQUEST_CHANGES tient toujours."
+    assert mod.classify("hermes-bot", body) == "BOT-CONCERN"
+
+
+def test_12944_verdict_emis_titre_hermes_sans_ref_inline_reste_vivant():
+    """Non-regression #12311 : l'emission Hermes en titre (« Review —
+    REQUEST_CHANGES (commentaire, self-review cap) ») ne porte NI ref entre
+    parentheses NI #N inline apres le verdict — l'extension ne l'avale pas."""
+    body = ("**[Hermes] Review — REQUEST_CHANGES (commentaire, self-review cap)**\n\n"
+            "Issue-first check : la methode diverge sur le point central.")
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2027:CoursIA-2

## Summary

Le gate B.0 (`check_unaddressed_nits.py`) classait le close-the-loop Hermes en **BOT-CONCERN** et bloquait le merge au lieu de le liberer. Cas fondateur : PR #12941, review 5020777166 —

> **[Hermes]** — close-the-loop sur ma review REQUEST_CHANGES de #12900 (`ffe18961`). Mon concern (...) est **traité et fermé** : ...

Deux defauts imbriques (issue #12944) :
1. **Aucun LIFT_MARKER ne couvrait la levee PASSIVE** (« est traité et fermé »).
2. **Le verdict mentionne echappait aux motifs de mention** : « ma review REQUEST_CHANGES de #12900 » porte la ref pointable HORS parentheses — `_MENTION_VERDICT_REVIEW` ne voyait que la ref entre parentheses immediates, le verdict restait emis, et `_formal_concern_precedes_lift` (#12836) annulait de surcroit la levee passive qui suivait.

## Fix (2 composants)

**1. LIFT_MARKERS** — verbes de FERMETURE + composes :
- `est clos / sont clos / sont closes`, `est fermé / sont fermés / sont fermées`, `est résolu / sont résolus / sont résolues`
- composes `traité et fermé / traitée et fermée / traité et clos / traitée et close` — ils couvrent le gras markdown separant l'auxiliaire du participe (« est **traité et fermé** »).

**Deviation documentee vs suggestion de l'issue** : « est traité » nu est REJETE sur contre-exemple mesure — le body pinned du test #11639 (« le point 3 est traité en argument », override NU qui ne doit rien lever) matcherait et casserait l'acceptance 2 existante. « traité » narratif se promene (« traité dans la section 4 », « traité en argument ») ; les verbes de fermeture s'engagent. Pinned par `test_12944_levee_passive_est_un_lift_marker`.

**2. `_MENTION_VERDICT_REVIEW`** — extension de position : la ref pointable inline « review VERDICT de #N » (cas fondateur #12941) rejoint la forme entre parentheses. Meme discriminant que #11984 : le ref pointable designe l'evenement passe rapporte ; une emission ne pointe pas (garde : « Ma review REQUEST_CHANGES tient toujours » reste BOT-CONCERN, idem l'emission Hermes en titre #12311).

## Tests (10 nouveaux, gardes intacts)

- `test_check_unaddressed_nits.py` : fondateur rend None ; end-to-end nit review + close-the-loop meme auteur -> gate vert ; garde #12798/#12836 (verdict formel EMIS avant la narration de levee reste BOT-CONCERN) ; negation « n'est pas traité » ne leve pas ; residu du compose pinne par ecrit.
- `test_check_unaddressed_nits_mention.py` : unite sur le motif (ref inline neutralise le verdict, variante sans preposition, sans #N reste vivant, emission titre #12311 preservee).

`176 passed` (les 2 fichiers du gate).

## Validation

| Controle | Resultat |
|----------|----------|
| Repro classify sur body verbatim #12941 | BOT-CONCERN -> **None** |
| Gate live `check_unaddressed_nits.py 12941` | BLOCKED -> **OK (exit 0)** |
| Corpus audit 200 PRs mergees (2026-08-14..25), old vs new | findings **identiques** (5 flags, 0 disparu = 0 FN regression, 0 nouveau) |

Le script partage `scripts/audit/nit_lift_authorship.py` reutilise `nits.LIFT_MARKERS` — l'extension lui propage coherentement (verifie par grep, aucun pinned expectation elsewhere).

Closes #12944 — debloque #12941 (registre arXiv, dont le close-the-loop Hermes etait l'unique item bloque).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
