### PR TITLE
feat(iit,#12477): operationnaliser le complexe majeur (major_complex/complexes, postulat d'exclusion) — re-livraison rebase frais

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
@@ -5,10 +5,10 @@
    "id": "3653fac8",
    "metadata": {
     "papermill": {
-     "duration": 0.006803,
-     "end_time": "2026-06-15T05:29:42.004754",
+     "duration": 0.007009,
+     "end_time": "2026-08-23T04:07:54.084660",
      "exception": false,
-     "start_time": "2026-06-15T05:29:41.997951",
+     "start_time": "2026-08-23T04:07:54.077651",
      "status": "completed"
     },
     "tags": []
@@ -33,7 +33,7 @@
     "\n",
     "### Durée estimée : 60 minutes\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "### **Sommaire**\n",
     "1. [Introduction à l'IIT](#sec1)  \n",
@@ -44,7 +44,7 @@
     "6. [Exploration d'exemples avancés (macro, actual causation…)](#sec6)  \n",
     "7. [Ressources complémentaires](#sec7)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"sec1\"></a>\n",
     "## 1. Introduction à l'IIT\n",
@@ -71,7 +71,7 @@
     "| **MIP** | Le point faible du système (Minimum Information Partition). | Le maillon faible d'une chaîne. |\n",
     "| **CES** | La forme géométrique de l'information intégrée. | La \"forme\" d'une pensée. |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "<a id=\"sec2\"></a>\n",
     "## 2. Installation et importation de PyPhi\n",
@@ -93,6 +93,13 @@
    "cell_type": "markdown",
    "id": "ict-bridge-cadrage",
    "metadata": {
+    "papermill": {
+     "duration": 0.006,
+     "end_time": "2026-08-23T04:07:54.097659",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:54.091659",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -110,16 +117,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:33:58.694612Z",
-     "iopub.status.busy": "2026-07-03T16:33:58.694612Z",
-     "iopub.status.idle": "2026-07-03T16:33:59.450714Z",
-     "shell.execute_reply": "2026-07-03T16:33:59.449773Z"
+     "iopub.execute_input": "2026-08-23T04:07:54.110401Z",
+     "iopub.status.busy": "2026-08-23T04:07:54.110401Z",
+     "iopub.status.idle": "2026-08-23T04:07:54.703462Z",
+     "shell.execute_reply": "2026-08-23T04:07:54.702908Z"
     },
     "papermill": {
-     "duration": 7.929489,
-     "end_time": "2026-06-15T05:29:49.940994",
+     "duration": 0.60128,
+     "end_time": "2026-08-23T04:07:54.704483",
      "exception": false,
-     "start_time": "2026-06-15T05:29:42.011505",
+     "start_time": "2026-08-23T04:07:54.103203",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -181,10 +188,10 @@
    "id": "75ba5ca1",
    "metadata": {
     "papermill": {
-     "duration": 0.005542,
-     "end_time": "2026-06-15T05:29:49.952326",
+     "duration": 0.005989,
+     "end_time": "2026-08-23T04:07:54.715247",
      "exception": false,
-     "start_time": "2026-06-15T05:29:49.946784",
+     "start_time": "2026-08-23T04:07:54.709258",
      "status": "completed"
     },
     "tags": []
@@ -202,16 +209,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:33:59.451219Z",
-     "iopub.status.busy": "2026-07-03T16:33:59.451219Z",
-     "iopub.status.idle": "2026-07-03T16:33:59.466439Z",
-     "shell.execute_reply": "2026-07-03T16:33:59.465511Z"
+     "iopub.execute_input": "2026-08-23T04:07:54.725470Z",
+     "iopub.status.busy": "2026-08-23T04:07:54.725470Z",
+     "iopub.status.idle": "2026-08-23T04:07:54.733635Z",
+     "shell.execute_reply": "2026-08-23T04:07:54.733635Z"
     },
     "papermill": {
-     "duration": 2.181866,
-     "end_time": "2026-06-15T05:29:52.140519",
+     "duration": 0.015081,
+     "end_time": "2026-08-23T04:07:54.734635",
      "exception": false,
-     "start_time": "2026-06-15T05:29:49.958653",
+     "start_time": "2026-08-23T04:07:54.719554",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -243,10 +250,10 @@
    "id": "91886d72",
    "metadata": {
     "papermill": {
-     "duration": 0.005092,
-     "end_time": "2026-06-15T05:29:52.151123",
+     "duration": 0.002547,
+     "end_time": "2026-08-23T04:07:54.741686",
      "exception": false,
-     "start_time": "2026-06-15T05:29:52.146031",
+     "start_time": "2026-08-23T04:07:54.739139",
      "status": "completed"
     },
     "tags": []
@@ -276,16 +283,16 @@
    "id": "5e296ce8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:33:59.466439Z",
-     "iopub.status.busy": "2026-07-03T16:33:59.466439Z",
-     "iopub.status.idle": "2026-07-03T16:33:59.481960Z",
-     "shell.execute_reply": "2026-07-03T16:33:59.481231Z"
+     "iopub.execute_input": "2026-08-23T04:07:54.755448Z",
+     "iopub.status.busy": "2026-08-23T04:07:54.754448Z",
+     "iopub.status.idle": "2026-08-23T04:07:54.765524Z",
+     "shell.execute_reply": "2026-08-23T04:07:54.764960Z"
     },
     "papermill": {
-     "duration": 0.015421,
-     "end_time": "2026-06-15T05:29:52.171910",
+     "duration": 0.017119,
+     "end_time": "2026-08-23T04:07:54.766563",
      "exception": false,
-     "start_time": "2026-06-15T05:29:52.156489",
+     "start_time": "2026-08-23T04:07:54.749444",
      "status": "completed"
     },
     "tags": []
@@ -324,10 +331,10 @@
    "id": "eb86b36c",
    "metadata": {
     "papermill": {
-     "duration": 0.005183,
-     "end_time": "2026-06-15T05:29:52.183398",
+     "duration": 0.004207,
+     "end_time": "2026-08-23T04:07:54.774756",
      "exception": false,
-     "start_time": "2026-06-15T05:29:52.178215",
+     "start_time": "2026-08-23T04:07:54.770549",
      "status": "completed"
     },
     "tags": []
@@ -339,7 +346,7 @@
     "La matrice de connectivité montre les liens (XOR signifie que chaque nœud dépend des deux autres sans boucles sur soi-même).\n",
     "\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "### 3.3. Inspection de la TPM\n",
     "\n",
@@ -352,16 +359,16 @@
    "id": "62301b90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:33:59.483881Z",
-     "iopub.status.busy": "2026-07-03T16:33:59.483881Z",
-     "iopub.status.idle": "2026-07-03T16:33:59.502264Z",
-     "shell.execute_reply": "2026-07-03T16:33:59.501375Z"
+     "iopub.execute_input": "2026-08-23T04:07:54.785294Z",
+     "iopub.status.busy": "2026-08-23T04:07:54.785294Z",
+     "iopub.status.idle": "2026-08-23T04:07:54.796161Z",
+     "shell.execute_reply": "2026-08-23T04:07:54.795548Z"
     },
     "papermill": {
-     "duration": 0.03056,
-     "end_time": "2026-06-15T05:29:52.219097",
+     "duration": 0.017929,
+     "end_time": "2026-08-23T04:07:54.797207",
      "exception": false,
-     "start_time": "2026-06-15T05:29:52.188537",
+     "start_time": "2026-08-23T04:07:54.779278",
      "status": "completed"
     },
     "tags": []
@@ -408,10 +415,10 @@
    "id": "7a35fb70",
    "metadata": {
     "papermill": {
-     "duration": 0.004994,
-     "end_time": "2026-06-15T05:29:52.230771",
+     "duration": 0.003931,
+     "end_time": "2026-08-23T04:07:54.805591",
      "exception": false,
-     "start_time": "2026-06-15T05:29:52.225777",
+     "start_time": "2026-08-23T04:07:54.801660",
      "status": "completed"
     },
     "tags": []
@@ -433,7 +440,16 @@
   {
    "cell_type": "markdown",
    "id": "phi-def-intuitive",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004163,
+     "end_time": "2026-08-23T04:07:54.813439",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:54.809276",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Le Calcul de \\(\\Phi\\) : Définition Intuitive\n",
     "\n",
@@ -451,16 +467,16 @@
    "id": "cfb3a7f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:33:59.505560Z",
-     "iopub.status.busy": "2026-07-03T16:33:59.504561Z",
-     "iopub.status.idle": "2026-07-03T16:34:06.917713Z",
-     "shell.execute_reply": "2026-07-03T16:34:06.917061Z"
+     "iopub.execute_input": "2026-08-23T04:07:54.822328Z",
+     "iopub.status.busy": "2026-08-23T04:07:54.821726Z",
+     "iopub.status.idle": "2026-08-23T04:08:00.605122Z",
+     "shell.execute_reply": "2026-08-23T04:08:00.604123Z"
     },
     "papermill": {
-     "duration": 8.497272,
-     "end_time": "2026-06-15T05:30:00.733028",
+     "duration": 5.78864,
+     "end_time": "2026-08-23T04:08:00.606123",
      "exception": false,
-     "start_time": "2026-06-15T05:29:52.235756",
+     "start_time": "2026-08-23T04:07:54.817483",
      "status": "completed"
     },
     "tags": []
@@ -479,7 +495,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:14,  2.41s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.56s/it]"
      ]
     },
     {
@@ -510,7 +526,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:10,  2.12s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:08,  1.62s/it]"
      ]
     },
     {
@@ -554,10 +570,10 @@
    "id": "388d4d94",
    "metadata": {
     "papermill": {
-     "duration": 0.006241,
-     "end_time": "2026-06-15T05:30:00.745887",
+     "duration": 0.003999,
+     "end_time": "2026-08-23T04:08:00.615123",
      "exception": false,
-     "start_time": "2026-06-15T05:30:00.739646",
+     "start_time": "2026-08-23T04:08:00.611124",
      "status": "completed"
     },
     "tags": []
@@ -582,16 +598,16 @@
    "id": "1748a54f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:34:06.918752Z",
-     "iopub.status.busy": "2026-07-03T16:34:06.918752Z",
-     "iopub.status.idle": "2026-07-03T16:34:12.899434Z",
-     "shell.execute_reply": "2026-07-03T16:34:12.898435Z"
+     "iopub.execute_input": "2026-08-23T04:08:00.623960Z",
+     "iopub.status.busy": "2026-08-23T04:08:00.623960Z",
+     "iopub.status.idle": "2026-08-23T04:08:04.952283Z",
+     "shell.execute_reply": "2026-08-23T04:08:04.951284Z"
     },
     "papermill": {
-     "duration": 7.203649,
-     "end_time": "2026-06-15T05:30:07.956486",
+     "duration": 4.334653,
+     "end_time": "2026-08-23T04:08:04.953283",
      "exception": false,
-     "start_time": "2026-06-15T05:30:00.752837",
+     "start_time": "2026-08-23T04:08:00.618630",
      "status": "completed"
     },
     "tags": []
@@ -610,7 +626,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:12,  2.03s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.54s/it]"
      ]
     },
     {
@@ -678,10 +694,10 @@
    "id": "d1e8755b",
    "metadata": {
     "papermill": {
-     "duration": 0.011789,
-     "end_time": "2026-06-15T05:30:07.979110",
+     "duration": 0.010527,
+     "end_time": "2026-08-23T04:08:04.974365",
      "exception": false,
-     "start_time": "2026-06-15T05:30:07.967321",
+     "start_time": "2026-08-23T04:08:04.963838",
      "status": "completed"
     },
     "tags": []
@@ -696,16 +712,16 @@
    "id": "8be318a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:34:12.903436Z",
-     "iopub.status.busy": "2026-07-03T16:34:12.903436Z",
-     "iopub.status.idle": "2026-07-03T16:34:38.566603Z",
-     "shell.execute_reply": "2026-07-03T16:34:38.566603Z"
+     "iopub.execute_input": "2026-08-23T04:08:04.993408Z",
+     "iopub.status.busy": "2026-08-23T04:08:04.993408Z",
+     "iopub.status.idle": "2026-08-23T04:08:22.626538Z",
+     "shell.execute_reply": "2026-08-23T04:08:22.626538Z"
     },
     "papermill": {
-     "duration": 26.963492,
-     "end_time": "2026-06-15T05:30:34.952999",
+     "duration": 17.645639,
+     "end_time": "2026-08-23T04:08:22.628538",
      "exception": false,
-     "start_time": "2026-06-15T05:30:07.989507",
+     "start_time": "2026-08-23T04:08:04.982899",
      "status": "completed"
     },
     "tags": []
@@ -724,7 +740,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:15,  2.64s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:12,  2.12s/it]"
      ]
     },
     {
@@ -755,7 +771,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:10,  2.08s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:08,  1.62s/it]"
      ]
     },
     {
@@ -793,7 +809,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  2.00s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.57s/it]"
      ]
     },
     {
@@ -824,7 +840,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.99s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:07,  1.58s/it]"
      ]
     },
     {
@@ -862,7 +878,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.91s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.57s/it]"
      ]
     },
     {
@@ -893,7 +909,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.93s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:08,  1.67s/it]"
      ]
     },
     {
@@ -931,6 +947,13 @@
    "cell_type": "markdown",
    "id": "1645edeb",
    "metadata": {
+    "papermill": {
+     "duration": 0.005983,
+     "end_time": "2026-08-23T04:08:22.643549",
+     "exception": false,
+     "start_time": "2026-08-23T04:08:22.637566",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -950,10 +973,10 @@
    "id": "iit1-asym-lead",
    "metadata": {
     "papermill": {
-     "duration": 0.006803,
-     "end_time": "2026-06-15T05:29:42.004754",
+     "duration": 0.005001,
+     "end_time": "2026-08-23T04:08:22.653730",
      "exception": false,
-     "start_time": "2026-06-15T05:29:41.997951",
+     "start_time": "2026-08-23T04:08:22.648729",
      "status": "completed"
     },
     "tags": []
@@ -968,72 +991,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "iit1-asym-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:33:59.466439Z",
-     "iopub.status.busy": "2026-07-03T16:33:59.466439Z",
-     "iopub.status.idle": "2026-07-03T16:33:59.481960Z",
-     "shell.execute_reply": "2026-07-03T16:33:59.481231Z"
+     "iopub.execute_input": "2026-08-23T04:08:22.663885Z",
+     "iopub.status.busy": "2026-08-23T04:08:22.662869Z",
+     "iopub.status.idle": "2026-08-23T04:09:13.203028Z",
+     "shell.execute_reply": "2026-08-23T04:09:13.202028Z"
     },
     "papermill": {
-     "duration": 0.015421,
-     "end_time": "2026-06-15T05:29:52.171910",
+     "duration": 50.546292,
+     "end_time": "2026-08-23T04:09:13.204028",
      "exception": false,
-     "start_time": "2026-06-15T05:29:52.156489",
+     "start_time": "2026-08-23T04:08:22.657736",
      "status": "completed"
     },
     "tags": []
    },
-   "source": [
-    "# Démonstration : une asymétrie de la TPM brise l'invariance de Phi\n",
-    "# Le réseau XOR canonique (cellule précédente) est parfaitement symétrique :\n",
-    "# chaque noeud calcule le XOR des deux autres, donc la structure cause-effet\n",
-    "# coïncide sur les 4 états atteignables -> Phi = 1.875 invariant (cellule 14).\n",
-    "# Perturbons MINIMALEMENT la dynamique : gardons node0 = XOR(b,c) et\n",
-    "# node1 = XOR(a,c), mais modifions node2 en OR(a, AND(b,c)) -- une fonction\n",
-    "# booléenne asymétrique. Cette unique asymétrie suffit à faire varier Phi.\n",
-    "\n",
-    "# Matrice de transition (TPM) du réseau asymétrique -- format état-par-noeud.\n",
-    "tpm_asym = np.zeros((2, 2, 2, 3))\n",
-    "for a in (0, 1):\n",
-    "    for b in (0, 1):\n",
-    "        for c in (0, 1):\n",
-    "            n0 = (b + c) % 2            # node0 = XOR(b, c)    (canonique)\n",
-    "            n1 = (a + c) % 2            # node1 = XOR(a, c)    (canonique)\n",
-    "            n2 = int(a or (b and c))    # node2 = OR(a, AND(b, c))  (PERTURBÉ)\n",
-    "            tpm_asym[a, b, c] = [n0, n1, n2]\n",
-    "\n",
-    "# Connectivité complète (chaque noeud lit les deux autres), comme le canonique.\n",
-    "cm = np.ones((3, 3), dtype=int)\n",
-    "network_asym = pyphi.Network(tpm_asym, cm)\n",
-    "\n",
-    "# Rappel -- réseau SYMÉTRIQUE canonique : Phi invariant\n",
-    "phi_sym = pyphi.compute.phi(pyphi.Subsystem(network, (0, 0, 0), (0, 1, 2)))\n",
-    "print(\"=\" * 62)\n",
-    "print(\"RÉSEAU SYMÉTRIQUE canonique (XOR) : Phi invariant\")\n",
-    "print(\"=\" * 62)\n",
-    "print(f\"  État (0,0,0) -> Phi = {phi_sym:.4f}  (idem sur (0,1,1), (1,0,1), (1,1,0))\")\n",
-    "\n",
-    "print(\"\\n\" + \"=\" * 62)\n",
-    "print(\"RÉSEAU ASYMÉTRIQUE (node2 perturbé) : Phi varie selon l'état\")\n",
-    "print(\"=\" * 62)\n",
-    "phis_asym = []\n",
-    "for s in [(a, b, c) for a in (0, 1) for b in (0, 1) for c in (0, 1)]:\n",
-    "    try:\n",
-    "        val = pyphi.compute.phi(pyphi.Subsystem(network_asym, s, (0, 1, 2)))\n",
-    "        phis_asym.append((s, val))\n",
-    "        print(f\"  État {s} -> Phi = {val:.4f}\")\n",
-    "    except pyphi.exceptions.StateUnreachableError:\n",
-    "        print(f\"  État {s} -> inaccessible (hors dynamique)\")\n",
-    "\n",
-    "vals = sorted({round(v, 4) for _, v in phis_asym})\n",
-    "print(\"-\" * 62)\n",
-    "print(f\"  Valeurs distinctes de Phi : {len(vals)}  ->  {vals}\")\n",
-    "print(f\"  CONSTAT : l'asymétrie d'un seul noeud suffit à briser l'invariance.\")\n",
-    "print(f\"  Phi passe de 1.875 (unique, symétrique) à [{min(vals):.4f} .. {max(vals):.4f}]\")\n",
-    "print(f\"  ({len(vals)} valeurs distinctes sur {len(phis_asym)} états atteignables).\")\n"
-   ],
    "outputs": [
     {
      "name": "stderr",
@@ -1048,7 +1023,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.93s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.55s/it]"
      ]
     },
     {
@@ -1079,7 +1054,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.95s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:07,  1.53s/it]"
      ]
     },
     {
@@ -1124,7 +1099,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.90s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.57s/it]"
      ]
     },
     {
@@ -1155,7 +1130,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.94s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:08,  1.64s/it]"
      ]
     },
     {
@@ -1193,7 +1168,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.90s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.63s/it]"
      ]
     },
     {
@@ -1224,7 +1199,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.91s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:07,  1.56s/it]"
      ]
     },
     {
@@ -1262,7 +1237,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.84s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.53s/it]"
      ]
     },
     {
@@ -1323,7 +1298,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:14,  2.48s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:13,  2.21s/it]"
      ]
     },
     {
@@ -1354,7 +1329,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.99s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:08,  1.63s/it]"
      ]
     },
     {
@@ -1392,7 +1367,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.91s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.56s/it]"
      ]
     },
     {
@@ -1423,7 +1398,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:10,  2.03s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:07,  1.57s/it]"
      ]
     },
     {
@@ -1461,7 +1436,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.95s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.58s/it]"
      ]
     },
     {
@@ -1492,7 +1467,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:10,  2.03s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:08,  1.66s/it]"
      ]
     },
     {
@@ -1530,7 +1505,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.87s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:09,  1.60s/it]"
      ]
     },
     {
@@ -1561,7 +1536,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.92s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:08,  1.64s/it]"
      ]
     },
     {
@@ -1599,7 +1574,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.87s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:10,  1.76s/it]"
      ]
     },
     {
@@ -1630,7 +1605,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.94s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:08,  1.68s/it]"
      ]
     },
     {
@@ -1661,17 +1636,65 @@
      ]
     }
    ],
-   "execution_count": 8
+   "source": [
+    "# Démonstration : une asymétrie de la TPM brise l'invariance de Phi\n",
+    "# Le réseau XOR canonique (cellule précédente) est parfaitement symétrique :\n",
+    "# chaque noeud calcule le XOR des deux autres, donc la structure cause-effet\n",
+    "# coïncide sur les 4 états atteignables -> Phi = 1.875 invariant (cellule 14).\n",
+    "# Perturbons MINIMALEMENT la dynamique : gardons node0 = XOR(b,c) et\n",
+    "# node1 = XOR(a,c), mais modifions node2 en OR(a, AND(b,c)) -- une fonction\n",
+    "# booléenne asymétrique. Cette unique asymétrie suffit à faire varier Phi.\n",
+    "\n",
+    "# Matrice de transition (TPM) du réseau asymétrique -- format état-par-noeud.\n",
+    "tpm_asym = np.zeros((2, 2, 2, 3))\n",
+    "for a in (0, 1):\n",
+    "    for b in (0, 1):\n",
+    "        for c in (0, 1):\n",
+    "            n0 = (b + c) % 2            # node0 = XOR(b, c)    (canonique)\n",
+    "            n1 = (a + c) % 2            # node1 = XOR(a, c)    (canonique)\n",
+    "            n2 = int(a or (b and c))    # node2 = OR(a, AND(b, c))  (PERTURBÉ)\n",
+    "            tpm_asym[a, b, c] = [n0, n1, n2]\n",
+    "\n",
+    "# Connectivité complète (chaque noeud lit les deux autres), comme le canonique.\n",
+    "cm = np.ones((3, 3), dtype=int)\n",
+    "network_asym = pyphi.Network(tpm_asym, cm)\n",
+    "\n",
+    "# Rappel -- réseau SYMÉTRIQUE canonique : Phi invariant\n",
+    "phi_sym = pyphi.compute.phi(pyphi.Subsystem(network, (0, 0, 0), (0, 1, 2)))\n",
+    "print(\"=\" * 62)\n",
+    "print(\"RÉSEAU SYMÉTRIQUE canonique (XOR) : Phi invariant\")\n",
+    "print(\"=\" * 62)\n",
+    "print(f\"  État (0,0,0) -> Phi = {phi_sym:.4f}  (idem sur (0,1,1), (1,0,1), (1,1,0))\")\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 62)\n",
+    "print(\"RÉSEAU ASYMÉTRIQUE (node2 perturbé) : Phi varie selon l'état\")\n",
+    "print(\"=\" * 62)\n",
+    "phis_asym = []\n",
+    "for s in [(a, b, c) for a in (0, 1) for b in (0, 1) for c in (0, 1)]:\n",
+    "    try:\n",
+    "        val = pyphi.compute.phi(pyphi.Subsystem(network_asym, s, (0, 1, 2)))\n",
+    "        phis_asym.append((s, val))\n",
+    "        print(f\"  État {s} -> Phi = {val:.4f}\")\n",
+    "    except pyphi.exceptions.StateUnreachableError:\n",
+    "        print(f\"  État {s} -> inaccessible (hors dynamique)\")\n",
+    "\n",
+    "vals = sorted({round(v, 4) for _, v in phis_asym})\n",
+    "print(\"-\" * 62)\n",
+    "print(f\"  Valeurs distinctes de Phi : {len(vals)}  ->  {vals}\")\n",
+    "print(f\"  CONSTAT : l'asymétrie d'un seul noeud suffit à briser l'invariance.\")\n",
+    "print(f\"  Phi passe de 1.875 (unique, symétrique) à [{min(vals):.4f} .. {max(vals):.4f}]\")\n",
+    "print(f\"  ({len(vals)} valeurs distinctes sur {len(phis_asym)} états atteignables).\")\n"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "iit1-asym-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.006803,
-     "end_time": "2026-06-15T05:29:42.004754",
+     "duration": 0.007578,
+     "end_time": "2026-08-23T04:09:13.218914",
      "exception": false,
-     "start_time": "2026-06-15T05:29:41.997951",
+     "start_time": "2026-08-23T04:09:13.211336",
      "status": "completed"
     },
     "tags": []
@@ -1695,13 +1718,107 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ff2b833b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00822,
+     "end_time": "2026-08-23T04:09:13.235134",
+     "exception": false,
+     "start_time": "2026-08-23T04:09:13.226914",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Le complexe majeur : la recherche de frontière intégrée\n",
+    "\n",
+    "Jusqu'ici, **nous** avons choisi la frontière : chaque `Subsystem(network, state, nodes)` fixe\n",
+    "des bords à la main. PyPhi embarque aussi la recherche de la frontière qui maximise $\\Phi$ —\n",
+    "le **complexe majeur**, mise en œuvre du postulat d'*exclusion* d'IIT 3.0 (parmi les candidats,\n",
+    "seul le maximiseur compte) :\n",
+    "\n",
+    "```python\n",
+    "pyphi.compute.major_complex(network, state)   # le sous-système de big-Phi maximal\n",
+    "pyphi.compute.complexes(network, state)       # tous les sous-systèmes de big-Phi > 0\n",
+    "```\n",
+    "\n",
+    "Le problème « qui décide des bords ? » reçoit ici sa réponse moteur : la bibliothèque énumère\n",
+    "les candidats et tranche. [IIT-4](IIT-4-Le-Probleme-de-Frontiere.ipynb) consacre un notebook\n",
+    "entier à ce choix de frontière — y compris le cas où le complexe majeur n'est **pas** le réseau\n",
+    "entier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b45ade57",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:09:13.250647Z",
+     "iopub.status.busy": "2026-08-23T04:09:13.250647Z",
+     "iopub.status.idle": "2026-08-23T04:09:59.163714Z",
+     "shell.execute_reply": "2026-08-23T04:09:59.162715Z"
+    },
+    "papermill": {
+     "duration": 45.924626,
+     "end_time": "2026-08-23T04:09:59.166758",
+     "exception": false,
+     "start_time": "2026-08-23T04:09:13.242132",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "major_complex(network, (0,0,0)) :\n",
+      "   noeuds retenus : ('A', 'B', 'C') | big-Phi = 1.87500\n",
+      "\n",
+      "complexes(network, (0,0,0)) — tous les sous-systemes de big-Phi > 0 :\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   ('A', 'B', 'C') big-Phi = 1.87500\n",
+      "   ('B', 'C') big-Phi = 1.00000\n",
+      "   ('A', 'C') big-Phi = 1.00000\n",
+      "   ('A', 'B') big-Phi = 1.00000\n",
+      "\n",
+      "Sur ce reseau XOR, le complexe majeur est le systeme ENTIER (maximiseur unique) ;\n",
+      "les trois paires sont ex aequo a Phi = 1.0 — sous le maximum, pas au sommet.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Le moteur tranche lui-meme : recherche du complexe majeur sur le reseau XOR ---\n",
+    "pyphi.config.PROGRESS_BARS = False   # sorties propres (les cellules precedentes laissent les barres)\n",
+    "complexe_majeur = pyphi.compute.major_complex(network, state)\n",
+    "noeuds_cm = tuple(network.node_labels[i] for i in complexe_majeur.subsystem.node_indices)\n",
+    "print(\"major_complex(network, (0,0,0)) :\")\n",
+    "print(\"   noeuds retenus :\", noeuds_cm, \"| big-Phi = %.5f\" % complexe_majeur.phi)\n",
+    "print()\n",
+    "print(\"complexes(network, (0,0,0)) — tous les sous-systemes de big-Phi > 0 :\")\n",
+    "for sia in pyphi.compute.complexes(network, state):\n",
+    "    noms_c = tuple(network.node_labels[i] for i in sia.subsystem.node_indices)\n",
+    "    print(\"   %-10s big-Phi = %.5f\" % (str(noms_c), sia.phi))\n",
+    "print()\n",
+    "print(\"Sur ce reseau XOR, le complexe majeur est le systeme ENTIER (maximiseur unique) ;\")\n",
+    "print(\"les trois paires sont ex aequo a Phi = 1.0 — sous le maximum, pas au sommet.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c91e98c8",
    "metadata": {
     "papermill": {
-     "duration": 0.009261,
-     "end_time": "2026-06-15T05:30:34.976168",
+     "duration": 0.007517,
+     "end_time": "2026-08-23T04:09:59.182281",
      "exception": false,
-     "start_time": "2026-06-15T05:30:34.966907",
+     "start_time": "2026-08-23T04:09:59.174764",
      "status": "completed"
     },
     "tags": []
@@ -1725,20 +1842,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "42dafeb5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:34:38.568509Z",
-     "iopub.status.busy": "2026-07-03T16:34:38.568509Z",
-     "iopub.status.idle": "2026-07-03T16:34:38.583599Z",
-     "shell.execute_reply": "2026-07-03T16:34:38.583599Z"
+     "iopub.execute_input": "2026-08-23T04:09:59.199763Z",
+     "iopub.status.busy": "2026-08-23T04:09:59.198758Z",
+     "iopub.status.idle": "2026-08-23T04:09:59.210762Z",
+     "shell.execute_reply": "2026-08-23T04:09:59.210762Z"
     },
     "papermill": {
-     "duration": 0.026024,
-     "end_time": "2026-06-15T05:30:35.015203",
+     "duration": 0.023484,
+     "end_time": "2026-08-23T04:09:59.212764",
      "exception": false,
-     "start_time": "2026-06-15T05:30:34.989179",
+     "start_time": "2026-08-23T04:09:59.189280",
      "status": "completed"
     },
     "tags": []
@@ -1772,10 +1889,10 @@
    "id": "63af95b4",
    "metadata": {
     "papermill": {
-     "duration": 0.010517,
-     "end_time": "2026-06-15T05:30:35.035429",
+     "duration": 0.007144,
+     "end_time": "2026-08-23T04:09:59.227419",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.024912",
+     "start_time": "2026-08-23T04:09:59.220275",
      "status": "completed"
     },
     "tags": []
@@ -1791,54 +1908,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "57501e53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:34:38.586236Z",
-     "iopub.status.busy": "2026-07-03T16:34:38.586236Z",
-     "iopub.status.idle": "2026-07-03T16:34:38.615785Z",
-     "shell.execute_reply": "2026-07-03T16:34:38.615096Z"
+     "iopub.execute_input": "2026-08-23T04:09:59.242581Z",
+     "iopub.status.busy": "2026-08-23T04:09:59.242581Z",
+     "iopub.status.idle": "2026-08-23T04:09:59.275115Z",
+     "shell.execute_reply": "2026-08-23T04:09:59.274114Z"
     },
     "papermill": {
-     "duration": 0.055629,
-     "end_time": "2026-06-15T05:30:35.098091",
+     "duration": 0.040657,
+     "end_time": "2026-08-23T04:09:59.275115",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.042462",
+     "start_time": "2026-08-23T04:09:59.234458",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Computing concepts:   0%|          | 0/7 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "                                                         "
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Nombre de concepts dans la CES : 3\n",
       "Liste des mécanismes : (['A', 'B'], ['A', 'C'], ['B', 'C'])\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r"
      ]
     }
    ],
@@ -1853,10 +1947,10 @@
    "id": "560d96b0",
    "metadata": {
     "papermill": {
-     "duration": 0.014337,
-     "end_time": "2026-06-15T05:30:35.122516",
+     "duration": 0.007505,
+     "end_time": "2026-08-23T04:09:59.290271",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.108179",
+     "start_time": "2026-08-23T04:09:59.282766",
      "status": "completed"
     },
     "tags": []
@@ -1869,20 +1963,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "1083ab9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:34:38.618272Z",
-     "iopub.status.busy": "2026-07-03T16:34:38.618272Z",
-     "iopub.status.idle": "2026-07-03T16:34:38.631950Z",
-     "shell.execute_reply": "2026-07-03T16:34:38.630649Z"
+     "iopub.execute_input": "2026-08-23T04:09:59.306281Z",
+     "iopub.status.busy": "2026-08-23T04:09:59.305280Z",
+     "iopub.status.idle": "2026-08-23T04:09:59.321136Z",
+     "shell.execute_reply": "2026-08-23T04:09:59.321136Z"
     },
     "papermill": {
-     "duration": 0.03173,
-     "end_time": "2026-06-15T05:30:35.163552",
+     "duration": 0.024861,
+     "end_time": "2026-08-23T04:09:59.322136",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.131822",
+     "start_time": "2026-08-23T04:09:59.297275",
      "status": "completed"
     },
     "tags": []
@@ -1923,10 +2017,10 @@
    "id": "a9a149d4",
    "metadata": {
     "papermill": {
-     "duration": 0.009625,
-     "end_time": "2026-06-15T05:30:35.184241",
+     "duration": 0.011006,
+     "end_time": "2026-08-23T04:09:59.342966",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.174616",
+     "start_time": "2026-08-23T04:09:59.331960",
      "status": "completed"
     },
     "tags": []
@@ -1946,20 +2040,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "5658a6b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:34:38.634006Z",
-     "iopub.status.busy": "2026-07-03T16:34:38.634006Z",
-     "iopub.status.idle": "2026-07-03T16:34:38.646460Z",
-     "shell.execute_reply": "2026-07-03T16:34:38.645857Z"
+     "iopub.execute_input": "2026-08-23T04:09:59.372172Z",
+     "iopub.status.busy": "2026-08-23T04:09:59.371171Z",
+     "iopub.status.idle": "2026-08-23T04:09:59.383176Z",
+     "shell.execute_reply": "2026-08-23T04:09:59.382176Z"
     },
     "papermill": {
-     "duration": 0.022976,
-     "end_time": "2026-06-15T05:30:35.215270",
+     "duration": 0.027191,
+     "end_time": "2026-08-23T04:09:59.384173",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.192294",
+     "start_time": "2026-08-23T04:09:59.356982",
      "status": "completed"
     },
     "tags": []
@@ -1994,10 +2088,10 @@
    "id": "50f14939",
    "metadata": {
     "papermill": {
-     "duration": 0.010777,
-     "end_time": "2026-06-15T05:30:35.234305",
+     "duration": 0.012598,
+     "end_time": "2026-08-23T04:09:59.406774",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.223528",
+     "start_time": "2026-08-23T04:09:59.394176",
      "status": "completed"
     },
     "tags": []
@@ -2021,10 +2115,10 @@
    "id": "5d067a10",
    "metadata": {
     "papermill": {
-     "duration": 0.009497,
-     "end_time": "2026-06-15T05:30:35.252110",
+     "duration": 0.011535,
+     "end_time": "2026-08-23T04:09:59.431914",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.242613",
+     "start_time": "2026-08-23T04:09:59.420379",
      "status": "completed"
     },
     "tags": []
@@ -2046,10 +2140,10 @@
    "id": "0f04c796",
    "metadata": {
     "papermill": {
-     "duration": 0.009175,
-     "end_time": "2026-06-15T05:30:35.271108",
+     "duration": 0.011582,
+     "end_time": "2026-08-23T04:09:59.454593",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.261933",
+     "start_time": "2026-08-23T04:09:59.443011",
      "status": "completed"
     },
     "tags": []
@@ -2064,20 +2158,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "e55f113d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:34:38.649154Z",
-     "iopub.status.busy": "2026-07-03T16:34:38.649154Z",
-     "iopub.status.idle": "2026-07-03T16:34:38.669457Z",
-     "shell.execute_reply": "2026-07-03T16:34:38.668255Z"
+     "iopub.execute_input": "2026-08-23T04:09:59.475500Z",
+     "iopub.status.busy": "2026-08-23T04:09:59.475500Z",
+     "iopub.status.idle": "2026-08-23T04:09:59.507060Z",
+     "shell.execute_reply": "2026-08-23T04:09:59.506059Z"
     },
     "papermill": {
-     "duration": 0.046093,
-     "end_time": "2026-06-15T05:30:35.326938",
+     "duration": 0.044564,
+     "end_time": "2026-08-23T04:09:59.509059",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.280845",
+     "start_time": "2026-08-23T04:09:59.464495",
      "status": "completed"
     },
     "tags": []
@@ -2136,7 +2230,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "57023831",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010206,
+     "end_time": "2026-08-23T04:09:59.531983",
+     "exception": false,
+     "start_time": "2026-08-23T04:09:59.521777",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 6.1bis Causalite evenementielle sur un reseau probabiliste (discrimination)\n",
     "\n",
@@ -2145,8 +2249,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": 15,
+   "id": "e45e368c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:09:59.546987Z",
+     "iopub.status.busy": "2026-08-23T04:09:59.546987Z",
+     "iopub.status.idle": "2026-08-23T04:09:59.584360Z",
+     "shell.execute_reply": "2026-08-23T04:09:59.584360Z"
+    },
+    "papermill": {
+     "duration": 0.046361,
+     "end_time": "2026-08-23T04:09:59.585341",
+     "exception": false,
+     "start_time": "2026-08-23T04:09:59.538980",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2218,7 +2338,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "13e02a02",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007697,
+     "end_time": "2026-08-23T04:09:59.600036",
+     "exception": false,
+     "start_time": "2026-08-23T04:09:59.592339",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : la causalite evenementielle discrimine\n",
     "\n",
@@ -2235,10 +2365,10 @@
    "id": "ad58565a",
    "metadata": {
     "papermill": {
-     "duration": 0.010491,
-     "end_time": "2026-06-15T05:30:35.345547",
+     "duration": 0.005998,
+     "end_time": "2026-08-23T04:09:59.613041",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.335056",
+     "start_time": "2026-08-23T04:09:59.607043",
      "status": "completed"
     },
     "tags": []
@@ -2256,16 +2386,16 @@
    "id": "0b0d592b",
    "metadata": {
     "papermill": {
-     "duration": 0.008584,
-     "end_time": "2026-06-15T05:30:35.364646",
+     "duration": 0.006121,
+     "end_time": "2026-08-23T04:09:59.627284",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.356062",
+     "start_time": "2026-08-23T04:09:59.621163",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Exploration de la structure cause-effet\n",
     "\n",
@@ -2287,20 +2417,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "53ad8dc0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T16:34:38.671664Z",
-     "iopub.status.busy": "2026-07-03T16:34:38.671120Z",
-     "iopub.status.idle": "2026-07-03T16:34:38.683602Z",
-     "shell.execute_reply": "2026-07-03T16:34:38.682974Z"
+     "iopub.execute_input": "2026-08-23T04:09:59.642883Z",
+     "iopub.status.busy": "2026-08-23T04:09:59.642883Z",
+     "iopub.status.idle": "2026-08-23T04:09:59.646947Z",
+     "shell.execute_reply": "2026-08-23T04:09:59.646399Z"
     },
     "papermill": {
-     "duration": 0.03672,
-     "end_time": "2026-06-15T05:30:35.410514",
+     "duration": 0.013139,
+     "end_time": "2026-08-23T04:09:59.647952",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.373794",
+     "start_time": "2026-08-23T04:09:59.634813",
      "status": "completed"
     },
     "tags": []
@@ -2332,7 +2462,16 @@
   {
    "cell_type": "markdown",
    "id": "67e8f08a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007017,
+     "end_time": "2026-08-23T04:09:59.662970",
+     "exception": false,
+     "start_time": "2026-08-23T04:09:59.655953",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion\n",
     "\n",
@@ -2346,6 +2485,7 @@
     "| Decoupage | `Subsystem` | Fixe un etat de fond et isole les éléments analyses |\n",
     "| Integration | $\\Phi$ | Mesure l'irreductibilite du tout a ses parties (la partition qui « coute » le moins) |\n",
     "| Structure | CES (concepts) | Decompose *ce que* le système distingue : repertoires cause-effet de chaque mécanisme |\n",
+    "| Recherche | `complexes` / `major_complex` | Applique l'exclusion : trouve le sous-système qui maximise $\\Phi$ — la frontière n'est plus choisie à la main |\n",
     "\n",
     "Le point conceptuel central est que $\\Phi$ ne mesure pas une quantite d'information *transmise*, mais une information **integree** : ce qui serait perdu si l'on coupait le système en morceaux. Un système dont les parties sont independantes a un $\\Phi$ nul, même s'il calcule des choses complexes -- l'integration, pas la performance, est le critere.\n",
     "\n",
@@ -2367,6 +2507,13 @@
    "cell_type": "markdown",
    "id": "ict-bridge-transition",
    "metadata": {
+    "papermill": {
+     "duration": 0.00751,
+     "end_time": "2026-08-23T04:09:59.677486",
+     "exception": false,
+     "start_time": "2026-08-23T04:09:59.669976",
+     "status": "completed"
+    },
     "tags": []
    },
    "source": [
@@ -2378,10 +2525,10 @@
    "id": "d0948bcb",
    "metadata": {
     "papermill": {
-     "duration": 0.044366,
-     "end_time": "2026-06-15T05:30:35.479105",
+     "duration": 0.007509,
+     "end_time": "2026-08-23T04:09:59.691993",
      "exception": false,
-     "start_time": "2026-06-15T05:30:35.434739",
+     "start_time": "2026-08-23T04:09:59.684484",
      "status": "completed"
     },
     "tags": []
@@ -2401,6 +2548,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 3,
+   "external_account": "none",
+   "free_alternative": null,
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-24",
+   "network": false,
+   "notes": "PyPhi 1.2.0 (local, CPU-only). Reseaux toy 3-noeuds (copy, XOR symetrique) :\ncalcul de EI (information efficace) et Phi micro en quelques secondes chacun.\nLe cout de PyPhi est exponentiel en N (nombre de noeuds), mais N=3 ici -> rapide.\nAucun appel API, aucun GPU. Estime G.1 firsthand (lecture des tailles de reseau),\nnon relance ce cycle (markdown-only, exception C.2).",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual",
+   "vram_gb": 0,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3 (PyPhi/IIT)",
    "language": "python",
@@ -2420,14 +2584,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 56.017619,
-   "end_time": "2026-06-15T05:30:36.038340",
+   "duration": 126.717176,
+   "end_time": "2026-08-23T04:09:59.925722",
    "environment_variables": {},
    "exception": null,
    "input_path": "IIT-1-IntroToPyPhi.ipynb",
-   "output_path": "IIT-1-IntroToPyPhi.ipynb",
+   "output_path": "IIT-1-out.ipynb",
    "parameters": {},
-   "start_time": "2026-06-15T05:29:40.020721",
+   "start_time": "2026-08-23T04:07:53.208546",
    "version": "2.6.0"
   },
   "polyglot_notebook": {
@@ -2440,23 +2604,6 @@
      }
     ]
    }
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "cpu_min": 3,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "LITE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-07-24",
-   "validator": "manual",
-   "notes": "PyPhi 1.2.0 (local, CPU-only). Reseaux toy 3-noeuds (copy, XOR symetrique) :\ncalcul de EI (information efficace) et Phi micro en quelques secondes chacun.\nLe cout de PyPhi est exponentiel en N (nombre de noeuds), mais N=3 ici -> rapide.\nAucun appel API, aucun GPU. Estime G.1 firsthand (lecture des tailles de reseau),\nnon relance ce cycle (markdown-only, exception C.2)."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/IIT/IIT-4-Le-Probleme-de-Frontiere.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-4-Le-Probleme-de-Frontiere.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "0e07d473",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003006,
+     "end_time": "2026-08-23T04:07:00.718564",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:00.715558",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# IIT-4. Le problème de frontière — qui décide où sont les bords ?\n",
     "\n",
@@ -36,7 +45,16 @@
   {
    "cell_type": "markdown",
    "id": "0f7339ea",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00291,
+     "end_time": "2026-08-23T04:07:00.724501",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:00.721591",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 0. Setup — configuration de `pyphi`\n",
     "\n",
@@ -52,17 +70,49 @@
    "id": "09d95c41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T00:45:53.615832Z",
-     "iopub.status.busy": "2026-08-22T00:45:53.615832Z",
-     "iopub.status.idle": "2026-08-22T00:45:54.546099Z",
-     "shell.execute_reply": "2026-08-22T00:45:54.545261Z"
-    }
+     "iopub.execute_input": "2026-08-23T04:07:00.731004Z",
+     "iopub.status.busy": "2026-08-23T04:07:00.731004Z",
+     "iopub.status.idle": "2026-08-23T04:07:01.541263Z",
+     "shell.execute_reply": "2026-08-23T04:07:01.541263Z"
+    },
+    "papermill": {
+     "duration": 0.816442,
+     "end_time": "2026-08-23T04:07:01.543263",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:00.726821",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
+      "Welcome to PyPhi!\n",
+      "\n",
+      "If you use PyPhi in your research, please cite the paper:\n",
+      "\n",
+      "  Mayner WGP, Marshall W, Albantakis L, Findlay G, Marchman R, Tononi G.\n",
+      "  (2018). PyPhi: A toolbox for integrated information theory.\n",
+      "  PLOS Computational Biology 14(7): e1006343.\n",
+      "  https://doi.org/10.1371/journal.pcbi.1006343\n",
+      "\n",
+      "Documentation is available online (or with the built-in `help()` function):\n",
+      "  https://pyphi.readthedocs.io\n",
+      "\n",
+      "To report issues, please use the issue tracker on the GitHub repository:\n",
+      "  https://github.com/wmayner/pyphi\n",
+      "\n",
+      "For general discussion, you are welcome to join the pyphi-users group:\n",
+      "  https://groups.google.com/forum/#!forum/pyphi-users\n",
+      "\n",
+      "To suppress this message, either:\n",
+      "  - Set `WELCOME_OFF: true` in your `pyphi_config.yml` file, or\n",
+      "  - Set the environment variable PYPHI_WELCOME_OFF to any value in your shell:\n",
+      "        export PYPHI_WELCOME_OFF='yes'\n",
+      "\n",
       "pyphi 1.2.0\n"
      ]
     }
@@ -87,7 +137,16 @@
   {
    "cell_type": "markdown",
    "id": "2cafa7ea",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002288,
+     "end_time": "2026-08-23T04:07:01.548551",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:01.546263",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Le substrat — un réseau 4 nœuds, le même pour tout le notebook\n",
     "\n",
@@ -110,11 +169,19 @@
    "id": "b13bfadb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T00:45:54.548186Z",
-     "iopub.status.busy": "2026-08-22T00:45:54.548186Z",
-     "iopub.status.idle": "2026-08-22T00:45:54.562622Z",
-     "shell.execute_reply": "2026-08-22T00:45:54.561389Z"
-    }
+     "iopub.execute_input": "2026-08-23T04:07:01.554145Z",
+     "iopub.status.busy": "2026-08-23T04:07:01.554145Z",
+     "iopub.status.idle": "2026-08-23T04:07:01.572584Z",
+     "shell.execute_reply": "2026-08-23T04:07:01.572584Z"
+    },
+    "papermill": {
+     "duration": 0.021981,
+     "end_time": "2026-08-23T04:07:01.573609",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:01.551628",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -148,7 +215,16 @@
   {
    "cell_type": "markdown",
    "id": "dac7ac3c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003111,
+     "end_time": "2026-08-23T04:07:01.579693",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:01.576582",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. La frontière est un choix — l'énumérer\n",
     "\n",
@@ -164,11 +240,19 @@
    "id": "c97c49f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T00:45:54.564692Z",
-     "iopub.status.busy": "2026-08-22T00:45:54.563164Z",
-     "iopub.status.idle": "2026-08-22T00:45:54.576327Z",
-     "shell.execute_reply": "2026-08-22T00:45:54.576327Z"
-    }
+     "iopub.execute_input": "2026-08-23T04:07:01.584743Z",
+     "iopub.status.busy": "2026-08-23T04:07:01.584743Z",
+     "iopub.status.idle": "2026-08-23T04:07:01.587795Z",
+     "shell.execute_reply": "2026-08-23T04:07:01.587795Z"
+    },
+    "papermill": {
+     "duration": 0.007061,
+     "end_time": "2026-08-23T04:07:01.588755",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:01.581694",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -191,7 +275,16 @@
   {
    "cell_type": "markdown",
    "id": "fee240bc",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001983,
+     "end_time": "2026-08-23T04:07:01.593754",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:01.591771",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Faire varier la frontière — ce qui change, ce qui reste\n",
     "\n",
@@ -214,11 +307,19 @@
    "id": "17470d5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T00:45:54.578991Z",
-     "iopub.status.busy": "2026-08-22T00:45:54.577748Z",
-     "iopub.status.idle": "2026-08-22T00:45:54.953041Z",
-     "shell.execute_reply": "2026-08-22T00:45:54.951891Z"
-    }
+     "iopub.execute_input": "2026-08-23T04:07:01.600771Z",
+     "iopub.status.busy": "2026-08-23T04:07:01.599769Z",
+     "iopub.status.idle": "2026-08-23T04:07:01.963461Z",
+     "shell.execute_reply": "2026-08-23T04:07:01.962457Z"
+    },
+    "papermill": {
+     "duration": 0.367706,
+     "end_time": "2026-08-23T04:07:01.964460",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:01.596754",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -407,7 +508,16 @@
   {
    "cell_type": "markdown",
    "id": "f5307c43",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005989,
+     "end_time": "2026-08-23T04:07:01.973482",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:01.967493",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Ce qui change** : les deux colonnes — la frontière n'est pas une valeur neutre, elle\n",
     "détermine ce qu'on voit. **Ce qui reste** : le substrat (TPM inchangée), l'état, la structure\n",
@@ -428,7 +538,16 @@
   {
    "cell_type": "markdown",
    "id": "c1599ef8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006138,
+     "end_time": "2026-08-23T04:07:01.982605",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:01.976467",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. La frontière qui maximise\n",
     "\n",
@@ -438,7 +557,10 @@
     "mesure donnée **privilégie** une frontière, et cette préférence est elle-même mesurable.\n",
     "\n",
     "Le maximiseur est-il unique ? Des **ex æquo** signifient que la mesure ne tranche pas — le choix\n",
-    "reste ouvert entre plusieurs bords, et c'est un résultat, pas un échec."
+    "reste ouvert entre plusieurs bords, et c'est un résultat, pas un échec.\n",
+    "\n",
+    "Le § 4bis montre comment le moteur PyPhi tranche lui-même ce maximiseur : le **complexe\n",
+    "majeur** (`pyphi.compute.major_complex`), mise en œuvre du postulat d'exclusion."
    ]
   },
   {
@@ -447,11 +569,19 @@
    "id": "dfc7b72f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T00:45:54.954557Z",
-     "iopub.status.busy": "2026-08-22T00:45:54.954557Z",
-     "iopub.status.idle": "2026-08-22T00:45:54.968435Z",
-     "shell.execute_reply": "2026-08-22T00:45:54.967298Z"
-    }
+     "iopub.execute_input": "2026-08-23T04:07:01.995137Z",
+     "iopub.status.busy": "2026-08-23T04:07:01.995137Z",
+     "iopub.status.idle": "2026-08-23T04:07:02.009142Z",
+     "shell.execute_reply": "2026-08-23T04:07:02.008142Z"
+    },
+    "papermill": {
+     "duration": 0.023006,
+     "end_time": "2026-08-23T04:07:02.010141",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:01.987135",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -484,8 +614,202 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cc36ab02",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004998,
+     "end_time": "2026-08-23T04:07:02.020139",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:02.015141",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4bis. Le complexe majeur — quand la théorie tranche elle-même\n",
+    "\n",
+    "Le § 4 a mesuré l'ex æquo et l'a enregistré comme un résultat : la mesure ne tranche pas. Mais\n",
+    "la théorie, elle, doit trancher. Le **postulat d'exclusion** (Oizumi, Albantakis & Tononi 2014,\n",
+    "déjà en références) pose que parmi toutes les frontières candidates d'un substrat, une seule\n",
+    "porte l'expérience : celle qui maximise $\\Phi$. Ce maximiseur, IIT l'appelle le **complexe\n",
+    "majeur** (*major complex*) ; les candidats de $\\Phi > 0$, les **complexes** du réseau.\n",
+    "\n",
+    "PyPhi embarque cette recherche comme primitive — nous avions écrit la boucle en section 3 pour\n",
+    "*mesurer* chaque frontière ; la voici côté moteur :\n",
+    "\n",
+    "```python\n",
+    "pyphi.compute.complexes(network, state)      # tous les sous-systèmes de big-Phi > 0\n",
+    "pyphi.compute.major_complex(network, state)  # le SIA du maximiseur — LA frontière\n",
+    "```\n",
+    "\n",
+    "(ce sont les noms exposés par le pin 1.2.0 affiché au setup ; les deux prennent le **réseau**\n",
+    "et l'**état** — la frontière est précisément ce que la recherche décide. Documentation :\n",
+    "[pyphi.readthedocs.io](https://pyphi.readthedocs.io), module `compute`.)\n",
+    "\n",
+    "Appliquées au même substrat, dans le même `ETAT` que la table de la section 3 :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "99247918",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:07:02.027974Z",
+     "iopub.status.busy": "2026-08-23T04:07:02.026954Z",
+     "iopub.status.idle": "2026-08-23T04:07:02.942222Z",
+     "shell.execute_reply": "2026-08-23T04:07:02.941066Z"
+    },
+    "papermill": {
+     "duration": 0.920594,
+     "end_time": "2026-08-23T04:07:02.943275",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:02.022681",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "major_complex(substrat, ETAT) :\n",
+      "   frontiere retenue : BD | big-Phi = 1.0\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   BD    big-Phi = 1.0000\n",
+      "   AC    big-Phi = 1.0000\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "big-Phi du substrat ENTIER (ABCD) : 0.0000 -> absent de complexes() car nul\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Le moteur tranche : recherche du complexe majeur sur le MEME substrat, MEME ETAT ---\n",
+    "complexe_majeur = pyphi.compute.major_complex(substrat, ETAT)\n",
+    "noms_cm = \"\".join(NOMS[i] for i in complexe_majeur.subsystem.node_indices)\n",
+    "\n",
+    "print(\"major_complex(substrat, ETAT) :\")\n",
+    "print(\"   frontiere retenue :\", noms_cm, \"| big-Phi =\", round(complexe_majeur.phi, 4))\n",
+    "print()\n",
+    "complexes_non_nuls = {}\n",
+    "for sia in pyphi.compute.complexes(substrat, ETAT):\n",
+    "    nom = \"\".join(NOMS[i] for i in sia.subsystem.node_indices)\n",
+    "    complexes_non_nuls[nom] = sia.phi\n",
+    "    print(\"   %-5s big-Phi = %.4f\" % (nom, sia.phi))\n",
+    "print()\n",
+    "phi_abcd = pyphi.compute.phi(pyphi.Subsystem(substrat, ETAT, (0, 1, 2, 3)))\n",
+    "print(f\"big-Phi du substrat ENTIER (ABCD) : {phi_abcd:.4f} -> absent de complexes() car nul\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "20ffceec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:07:02.951664Z",
+     "iopub.status.busy": "2026-08-23T04:07:02.951146Z",
+     "iopub.status.idle": "2026-08-23T04:07:02.957520Z",
+     "shell.execute_reply": "2026-08-23T04:07:02.956442Z"
+    },
+    "papermill": {
+     "duration": 0.012137,
+     "end_time": "2026-08-23T04:07:02.958563",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:02.946426",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "complexes de la table : ['AC', 'BD']\n",
+      "complexes du moteur   : ['AC', 'BD']\n",
+      "egalite des deux sources : True\n",
+      "\n",
+      "le majeur est dans l'ex aequo de la table : True\n",
+      "le tout (Phi = 0) est bien ecarte         : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Confrontation programmatique : notre table (sec. 3-4) vs la recherche du moteur ---\n",
+    "complexes_table = set(gagnants_phi)          # l'ex aequo Phi de la section 4 : AC, BD\n",
+    "complexes_moteur = set(complexes_non_nuls)   # ce que complexes() rend\n",
+    "print(\"complexes de la table :\", sorted(complexes_table))\n",
+    "print(\"complexes du moteur   :\", sorted(complexes_moteur))\n",
+    "print(\"egalite des deux sources :\", complexes_table == complexes_moteur)\n",
+    "print()\n",
+    "print(\"le majeur est dans l'ex aequo de la table :\", noms_cm in complexes_table)\n",
+    "print(\"le tout (Phi = 0) est bien ecarte         :\", \"ABCD\" not in complexes_moteur)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7b101e5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003118,
+     "end_time": "2026-08-23T04:07:02.965406",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:02.962288",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : l'exclusion à l'œuvre — et son arbitrage\n",
+    "\n",
+    "Trois faits, par ordre d'importance :\n",
+    "\n",
+    "1. **Le tout est écarté.** $\\Phi(ABCD) = 0$ : le substrat entier se décompose en deux paires\n",
+    "   indépendantes, il est parfaitement réductible — le postulat d'**exclusion** le rejette des\n",
+    "   complexes. Le complexe majeur est une **paire transversale**, plus petite que le système :\n",
+    "   la frontière qui compte n'est pas la plus grande, c'est la plus intégrée. C'est le\n",
+    "   renversement exact du verdict EI (§ 5), qui privilégiait $ABCD$.\n",
+    "2. **La table et le moteur disent la même chose.** L'égalité programmatique ci-dessus montre\n",
+    "   que les complexes du moteur sont exactement les maximiseurs $\\Phi$ de notre énumération\n",
+    "   manuelle : deux lectures indépendantes du même postulat.\n",
+    "3. **L'ex æquo demeure — et `major_complex` tranche quand même.** `complexes` rend $AC$ ET\n",
+    "   $BD$ ($\\Phi = 1.0$ chacun), mais `major_complex` rend un SIA unique : $BD$. Le départage\n",
+    "   est dans le code du pin : `major_complex` prend le `max()` Python de la liste des\n",
+    "   complexes, qui — à égalité parfaite — garde le **premier** élément de l'ordre\n",
+    "   d'énumération interne ($BD$ avant $AC$). Déterministe et reproductible, mais un artefact\n",
+    "   d'implémentation : rien dans la théorie ne préfère $BD$ à $AC$. Le verdict du § 4 tient\n",
+    "   donc toujours (l'ex æquo est un résultat) ; ce que ce § 4bis ajoute, c'est le fait moteur :\n",
+    "   sur une égalité dégénérée, l'outil tranche par convention d'énumération — il faut le savoir\n",
+    "   avant de lire un `major_complex` comme un choix théorique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b3092a6f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003434,
+     "end_time": "2026-08-23T04:07:02.972591",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:02.969157",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Le désaccord — deux mesures, deux bords ?\n",
     "\n",
@@ -497,15 +821,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "9d7e4b17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T00:45:54.970536Z",
-     "iopub.status.busy": "2026-08-22T00:45:54.970536Z",
-     "iopub.status.idle": "2026-08-22T00:45:54.983429Z",
-     "shell.execute_reply": "2026-08-22T00:45:54.982853Z"
-    }
+     "iopub.execute_input": "2026-08-23T04:07:02.982623Z",
+     "iopub.status.busy": "2026-08-23T04:07:02.982623Z",
+     "iopub.status.idle": "2026-08-23T04:07:03.003610Z",
+     "shell.execute_reply": "2026-08-23T04:07:03.002608Z"
+    },
+    "papermill": {
+     "duration": 0.027207,
+     "end_time": "2026-08-23T04:07:03.004619",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:02.977412",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -563,7 +895,16 @@
   {
    "cell_type": "markdown",
    "id": "09631787",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005293,
+     "end_time": "2026-08-23T04:07:03.015500",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.010207",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Le verdict de ce substrat est une **double dissociation**, et c'est le résultat le plus\n",
     "instructif du notebook :\n",
@@ -586,18 +927,36 @@
   {
    "cell_type": "markdown",
    "id": "1839fa47",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006116,
+     "end_time": "2026-08-23T04:07:03.025599",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.019483",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Exercices\n",
     "\n",
-    "Trois exercices sur le même socle méthodologique — chacun sur **votre** substrat. Les stubs\n",
+    "Quatre exercices sur le même socle méthodologique — chacun sur **votre** substrat. Les stubs\n",
     "s'exécutent sans erreur (consigne imprimée) ; compléter, pas remplacer.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "e98f6fd5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004181,
+     "end_time": "2026-08-23T04:07:03.034468",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.030287",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 — Faire varier la frontière, sur votre substrat\n",
     "\n",
@@ -608,15 +967,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "04471cbc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T00:45:54.986064Z",
-     "iopub.status.busy": "2026-08-22T00:45:54.985524Z",
-     "iopub.status.idle": "2026-08-22T00:45:54.999267Z",
-     "shell.execute_reply": "2026-08-22T00:45:54.997998Z"
-    }
+     "iopub.execute_input": "2026-08-23T04:07:03.045634Z",
+     "iopub.status.busy": "2026-08-23T04:07:03.045120Z",
+     "iopub.status.idle": "2026-08-23T04:07:03.049657Z",
+     "shell.execute_reply": "2026-08-23T04:07:03.049657Z"
+    },
+    "papermill": {
+     "duration": 0.011687,
+     "end_time": "2026-08-23T04:07:03.050662",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.038975",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -643,7 +1010,16 @@
   {
    "cell_type": "markdown",
    "id": "75d299c7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004003,
+     "end_time": "2026-08-23T04:07:03.057716",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.053713",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 — La frontière qui maximise, sur votre substrat\n",
     "\n",
@@ -653,15 +1029,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "2d221b36",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T00:45:55.001883Z",
-     "iopub.status.busy": "2026-08-22T00:45:55.001374Z",
-     "iopub.status.idle": "2026-08-22T00:45:55.013464Z",
-     "shell.execute_reply": "2026-08-22T00:45:55.012853Z"
-    }
+     "iopub.execute_input": "2026-08-23T04:07:03.066071Z",
+     "iopub.status.busy": "2026-08-23T04:07:03.065069Z",
+     "iopub.status.idle": "2026-08-23T04:07:03.081645Z",
+     "shell.execute_reply": "2026-08-23T04:07:03.081082Z"
+    },
+    "papermill": {
+     "duration": 0.021182,
+     "end_time": "2026-08-23T04:07:03.082651",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.061469",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -685,7 +1069,16 @@
   {
    "cell_type": "markdown",
    "id": "f5542d1a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003504,
+     "end_time": "2026-08-23T04:07:03.089667",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.086163",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 — Le désaccord, verdict explicite\n",
     "\n",
@@ -697,15 +1090,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "567a13ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-22T00:45:55.016153Z",
-     "iopub.status.busy": "2026-08-22T00:45:55.016153Z",
-     "iopub.status.idle": "2026-08-22T00:45:55.028194Z",
-     "shell.execute_reply": "2026-08-22T00:45:55.028194Z"
-    }
+     "iopub.execute_input": "2026-08-23T04:07:03.097674Z",
+     "iopub.status.busy": "2026-08-23T04:07:03.097674Z",
+     "iopub.status.idle": "2026-08-23T04:07:03.113676Z",
+     "shell.execute_reply": "2026-08-23T04:07:03.112696Z"
+    },
+    "papermill": {
+     "duration": 0.021002,
+     "end_time": "2026-08-23T04:07:03.113676",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.092674",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -728,8 +1129,91 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8e359a34",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005028,
+     "end_time": "2026-08-23T04:07:03.122215",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.117187",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 — Le complexe majeur, sur votre substrat\n",
+    "\n",
+    "Le § 4bis a laissé le moteur chercher le complexe majeur et a confronté le résultat à la table.\n",
+    "Sur **votre** substrat de l'Exercice 1 : prédisez d'abord le complexe majeur **à partir de votre\n",
+    "table** (maximum de $\\Phi$ et ses ex æquo éventuels), puis vérifiez avec\n",
+    "`pyphi.compute.major_complex` — et expliquez l'éventuel départage.\n",
+    "\n",
+    "**Indices :**\n",
+    "- *Indice 1* : `major_complex(reseau, etat)` prend le **réseau** et l'**état**, pas un\n",
+    "  `Subsystem` — la frontière est précisément ce que la recherche décide.\n",
+    "- *Indice 2* : confrontez avec `complexes(reseau, etat)` : l'ensemble des $\\Phi > 0$ doit\n",
+    "  correspondre à ce que votre table prédit... si votre table couvrait toutes les frontières.\n",
+    "- *Etape 1* : la prédiction (une chaîne, AVANT d'exécuter la recherche) ; *Etape 2* : la\n",
+    "  recherche ; *Etape 3* : le verdict — confirmé ? ex æquo ? comment le moteur a-t-il\n",
+    "  départagé ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "7852faf3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-23T04:07:03.129975Z",
+     "iopub.status.busy": "2026-08-23T04:07:03.129356Z",
+     "iopub.status.idle": "2026-08-23T04:07:03.144391Z",
+     "shell.execute_reply": "2026-08-23T04:07:03.144391Z"
+    },
+    "papermill": {
+     "duration": 0.019697,
+     "end_time": "2026-08-23T04:07:03.145390",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.125693",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : complexe majeur prediction + verification\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : complexe majeur sur VOTRE substrat (celui de l'Exercice 1)\n",
+    "# TODO etudiant : predire le maximiseur depuis la table, puis verifier avec le moteur\n",
+    "# Etape 1 : prediction = \"...\"  (AVANT de lancer la recherche)\n",
+    "# Etape 2 : sia = pyphi.compute.major_complex(votre_reseau, votre_etat)\n",
+    "#           noeuds -> \"\".join(vos_noms[i] for i in sia.subsystem.node_indices)\n",
+    "# Etape 3 : verdict -- confirme / ex aequo / comment le moteur a departage\n",
+    "prediction = None  # TODO etudiant : votre prediction depuis la table de l'Exercice 1\n",
+    "if prediction is None:\n",
+    "    print(\"Exercice a completer : complexe majeur prediction + verification\")\n",
+    "else:\n",
+    "    print(\"Prediction :\", prediction)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "bae5a296",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003658,
+     "end_time": "2026-08-23T04:07:03.152578",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.148920",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion\n",
     "\n",
@@ -738,11 +1222,12 @@
     "| Qui décide des bords ? | La frontière est un argument (`nodes`) de `Subsystem` — un choix explicite, jamais une donnée du substrat | sections 2-3 |\n",
     "| Ce qui change avec le bord | $\\Phi$ et EI : calculés pour 11 frontières d'un même substrat — table, pas discussion | section 3 |\n",
     "| Un bord privilégié ? | Le maximiseur de chaque mesure est extrait ; l'ex æquo est un résultat (la mesure ne tranche pas) | section 4 |\n",
+    "| Le complexe du moteur ? | `major_complex` rend BD (Φ = 1) ; Φ(ABCD) = 0 écarte le tout — l'ex æquo AC/BD est départagé par l'ordre d'énumération, pas par la théorie | section 4bis |\n",
     "| Deux mesures, un bord ? | Verdict explicite imprimé — la dissociation éventuelle est le résultat enregistré | section 5 |\n",
     "\n",
     "Le problème de frontière ne se résout pas en choisissant la bonne mesure — il se **montre** :\n",
     "chaque mesure répond à sa manière, et l'écart entre les réponses est une propriété du couple\n",
-    "(substrat, mesure), pas du substrat seul. C'est la dette que toute analyse de recollement porte\n",
+    "(substrat, mesure), pas du substrat seul. Le § 4bis a montré le moteur trancher là où la mesure ex æquo ne le faisait pas — et pourquoi ce tranchage est une convention d'énumération, pas un verdict. C'est la dette que toute analyse de recollement porte\n",
     "en amont d'elle-même (cf. #12206) : mesurer un défaut de recollement mesure aussi le choix\n",
     "arbitraire du découpage — sauf à rendre ce choix visible d'abord.\n"
    ]
@@ -750,7 +1235,16 @@
   {
    "cell_type": "markdown",
    "id": "ccd6e5bb",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003975,
+     "end_time": "2026-08-23T04:07:03.159575",
+     "exception": false,
+     "start_time": "2026-08-23T04:07:03.155600",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Références\n",
     "\n",
@@ -784,6 +1278,18 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.25"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.629211,
+   "end_time": "2026-08-23T04:07:03.502593",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "IIT-4-Le-Probleme-de-Frontiere.ipynb",
+   "output_path": "IIT-4-out.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-23T04:06:59.873382",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -17,7 +17,7 @@ Le premier notebook couvre le spectre fondamental : construction de graphes caus
 À l'issue de cette série, vous serez capable de :
 
 1. **Construire et manipuler des réseaux causaux** binaires avec PyPhi (TPM, nœuds, connexions)
-2. **Calculer Phi** pour un sous-système et interpréter sa valeur (intégration vs séparabilité)
+2. **Calculer Phi** pour un sous-système et interpréter sa valeur (intégration vs séparabilité), puis rechercher le **complexe majeur** (postulat d'exclusion : `major_complex` / `complexes`)
 3. **Analyser une Cause-Effect Structure (CES)** : identifier les concepts, mécanismes et purviews
 4. **Appliquer le partitionnement MIP** pour localiser le "maillon faible" d'un système
 5. **Différencier big Phi et small phi** et comprendre leur rôles respectifs dans la théorie
@@ -28,10 +28,10 @@ Le premier notebook couvre le spectre fondamental : construction de graphes caus
 
 | # | Notebook | Contenu | Durée |
 |---|----------|---------|-------|
-| 1 | [IIT-1-IntroToPyPhi](IIT-1-IntroToPyPhi.ipynb) | Réseau XOR 3-nœuds : TPM, calcul de Φ, CES, états inaccessibles, causation | 60-90 min |
+| 1 | [IIT-1-IntroToPyPhi](IIT-1-IntroToPyPhi.ipynb) | Réseau XOR 3-nœuds : TPM, calcul de Φ, CES, états inaccessibles, causation, complexe majeur | 60-90 min |
 | 2 | [IIT-2-AdvancedTopics](IIT-2-AdvancedTopics.ipynb) | MIP et bipartitions, répertoires cause-effet, MICE, big Φ sur réseau 4-nœuds, coarse-graining | 60-90 min |
 | 3 | [IIT-3-CoarseGrainingMacroPhi](IIT-3-CoarseGrainingMacroPhi.ipynb) | Module `pyphi.macro` : information efficace (Hoel), énumération des regroupements, comparaison Φ micro/macro, causal emergence | 45-60 min |
-| 4 | [IIT-4-Le-Probleme-de-Frontiere](IIT-4-Le-Probleme-de-Frontiere.ipynb) | Le problème de frontière : faire varier le découpage du même substrat, maximiseur de Φ, double dissociation Φ vs EI | 45-60 min |
+| 4 | [IIT-4-Le-Probleme-de-Frontiere](IIT-4-Le-Probleme-de-Frontiere.ipynb) | Le problème de frontière : faire varier le découpage du même substrat, maximiseur de Φ, complexe majeur (`major_complex`), double dissociation Φ vs EI | 45-60 min |
 
 ## Parcours recommandés
 
@@ -54,7 +54,7 @@ Notebook 4 (Le problème de frontière)
 | Maîtrise complète | Notebook 1 puis 2, puis 3, puis 4 |
 | Focus philosophie | Notebook 1 (sections CES + débats) + Notebook 2 (section IIT 4.0) |
 | Focus emergence & échelle | Notebook 1 + Notebook 3 (causal emergence de Hoel) |
-| Focus frontières & dissociation | Notebook 1 + Notebook 4 (Φ vs EI selon le découpage) |
+| Focus frontières & dissociation | Notebook 1 + Notebook 4 (Φ vs EI selon le découpage, complexe majeur) |
 
 ### Parcours d'apprentissage
 
@@ -72,7 +72,7 @@ Le troisième notebook opérationnalise le module `pyphi.macro` resté conceptue
 
 **Phase 4 : Le problème de frontière (~60 min, notebook 4)**
 
-Le quatrième notebook pose la question d'avant toute analyse de recollement : qui décide où sont les bords ? Sur un substrat inchangé (deux paires d'échange), vous énumérez les 11 frontières candidates et mesurez $\Phi$ et l'EI induit pour chacune — découpages **calculés**, jamais discutés. Le résultat est une **double dissociation** mesurée : $\Phi$ privilégie les frontières transversales (ex æquo, la mesure ne tranche pas), l'EI induit privilégie le tout, et les favorites de $\Phi$ coupent une dépendance — hors du domaine même de l'EI. Le *boundary problem* (Gómez Emilsson, cité comme proposition) devient un objet de mesure. Les 3 exercices refont la démarche sur votre propre substrat, jusqu'au verdict explicite.
+Le quatrième notebook pose la question d'avant toute analyse de recollement : qui décide où sont les bords ? Sur un substrat inchangé (deux paires d'échange), vous énumérez les 11 frontières candidates et mesurez $\Phi$ et l'EI induit pour chacune — découpages **calculés**, jamais discutés. Le résultat est une **double dissociation** mesurée : $\Phi$ privilégie les frontières transversales (ex æquo, la mesure ne tranche pas), l'EI induit privilégie le tout, et les favorites de $\Phi$ coupent une dépendance — hors du domaine même de l'EI. Le § 4bis ajoute le verdict du moteur : `pyphi.compute.major_complex` tranche l'ex æquo (BD, $\Phi = 1$) pendant que $\Phi(ABCD) = 0$ écarte le tout — le postulat d'exclusion opérationnalisé, arbitrage d'énumération à l'appui. Le *boundary problem* (Gómez Emilsson, cité comme proposition) devient un objet de mesure. Les 4 exercices refont la démarche sur votre propre substrat, jusqu'au verdict explicite et à la vérification du complexe majeur.
 
 ## Prérequis
 
@@ -162,6 +162,7 @@ flowchart TD
 | Réseaux | Réseau XOR 3-nœuds de référence, inspection des `node_labels` |
 | TPM | Conversion *state-by-node*, dimensions de la matrice de transition |
 | Sous-systèmes & Φ | Calcul de Φ d'un sous-système à un état donné, boucle sur plusieurs états |
+| Complexe majeur | `major_complex` / `complexes` sur le réseau XOR : la recherche de frontière intégrée (postulat d'exclusion) |
 | États inaccessibles | Validation via `StateUnreachableError`, option `VALIDATE_SUBSYSTEM_STATES` |
 | CES | `pyphi.compute.ces`, décompte des concepts d'un sous-système |
 | Causation actuelle | Liens causaux d'une transition (`account`), mécanisme d'un concept |
@@ -199,6 +200,7 @@ flowchart TD
 | Énumération | 11 frontières candidates (≥ 2 nœuds) — le découpage comme choix explicite |
 | Table centrale | Φ et EI induit calculés pour les 11 frontières du même substrat |
 | Maximiseur | Extraction de argmax — l'ex æquo AC/BD est un résultat (la mesure ne tranche pas) |
+| Complexe majeur | `major_complex` rend BD (Φ = 1) ; Φ(ABCD) = 0 écarte le tout — l'ex æquo est départagé par l'ordre d'énumération du moteur, pas par la théorie |
 | Double dissociation | Φ privilégie les frontières transversales, EI le tout — et les favorites de Φ sont hors du domaine de l'EI (frontières coupantes) |
 | Boundary problem | Gómez Emilsson cité comme proposition, jamais comme réponse établie |
 


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA-2 — prev: FIX/env-amont-mort #12948

## Summary

**Re-livraison de #12477** (claim lane actif, posé 2026-08-23T19:16Z). La PR précédente (#12524, même branche `feature/12477-iit-major-complex`) a été fermée le 2026-08-25T12:35Z lors du passage de nettoyage, avec deux motifs qui ne portaient pas sur la substance : un advisory MD hierarchy drift listant des fichiers **absents de cette PR** (GameTheory-04b, PT_11, Texte/22 — drift du merge-ref, pas du diff) et un piège de closing-keyword dans le body (citation du correctif navlink déjà mergé `b01ca3e3e`, sans rapport avec le périmètre).

**Ce que fait cette PR** (inchangée sur le fond — commit de substance `588083b9b2`, +1 merge update vers origin/main courant `852cf04aea` qui re-ancre la baseline MD drift) :

- **IIT-4 §4bis** : le moteur PyPhi tranche lui-même le problème de frontière — `pyphi.compute.major_complex(substrat, ETAT)` exécuté sur le même substrat, même état : **BD retenu (big-Phi = 1.0)**, l'ex æquo AC (1.0) exposé par `complexes()`, **Phi(ABCD) = 0 écarté du tout** (postulat d'exclusion). Confrontation programmatique table-vs-moteur True ×3 ; arbitrage de l'ex æquo expliqué (max() Python, ordre d'énumération — artefact d'implémentation documenté).
- **IIT-1** : exécution minimale sur XOR — majeur = système ENTIER (Phi = 1.875, maximiseur unique), miroir exact du cas IIT-4 ; +1 ligne de conclusion pipeline.
- **README** IIT : complexe majeur opérationnalisé.
- Exercice 4 stub C.1 (prédire puis vérifier) ; conclusion +1 ligne.
- API vérifiée par introspection contre le pin 1.2.0 : `pyphi.compute.major_complex(network, state)` ET `pyphi.compute.complexes(network, state)`.

## Validation

- `validate_pr_notebooks.py origin/main <2 notebooks>` : **2/2 PASS** (28 cellules code, kernel pyphi) — outputs committés intacts après merge : IIT-1 ec 1..16, IIT-4 ec 1..12, 0 erreur, 0 output vide.
- Sorties byte-committées (cellule 13 IIT-4) : `major_complex(substrat, ETAT) : frontiere retenue : BD | big-Phi = 1.0` / `big-Phi du substrat ENTIER (ABCD) : 0.0000 -> absent de complexes() car nul`.
- Diff vs origin/main : 3 fichiers (+1019/−364), un seul sujet, catalogue non touché.
- Résiduel documenté : la twin parity #8057 reste à traiter sur le fond (hors périmètre).

Closes #12477

See #8057 (twin parity, résiduel)
