### PR TITLE
feat(xplat,#10643): .sh companions for residual setup scripts (IIT, Infer, matching-cv) + fix broken setup_pyphi_env.ps1

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -85,8 +85,11 @@ Le quatrième notebook pose la question d'avant toute analyse de recollement : q
 ### Environnement Python
 
 ```bash
-# Automated setup (creates conda env + registers kernel)
+# Setup automatise (cree l'env conda + enregistre le kernel)
+# Windows (PowerShell) :
 powershell -File scripts/setup_pyphi_env.ps1
+# macOS/Linux :
+bash scripts/setup_pyphi_env.sh
 
 # Manual setup (Python 3.9 required for PyPhi 1.2.0)
 conda create --name pyphi python=3.9 -y
@@ -313,7 +316,8 @@ IIT/
 │   └── README.md               # Documentation de la série ICT
 ├── requirements.txt            # Dépendances Python (partagées IIT + ICT)
 ├── scripts/
-│   ├── setup_pyphi_env.ps1     # Setup conda env + kernel (partagé IIT + ICT)
+│   ├── setup_pyphi_env.ps1     # Setup conda env + kernel — Windows (partagé IIT + ICT)
+│   ├── setup_pyphi_env.sh      # Setup conda env + kernel — macOS/Linux (jumeau)
 │   └── build_notebook.py       # Script de construction notebook 2
 └── README.md                   # Cette documentation
 ```

--- a/MyIA.AI.Notebooks/IIT/scripts/setup_pyphi_env.ps1
+++ b/MyIA.AI.Notebooks/IIT/scripts/setup_pyphi_env.ps1
@@ -1,13 +1,21 @@
 # Setup script for PyPhi conda environment (Python 3.9)
 # PyPhi 1.2.0 requires Python <=3.9 (collections.Iterable removed in 3.10)
 #
-# Usage: .\setup_pyphi_env.ps1
+# Usage: .\setup_pyphi_env.ps1   (Linux/macOS : scripts/setup_pyphi_env.sh)
 #
 # Creates:
 #   - conda env 'pyphi' with Python 3.9
 #   - Jupyter kernel 'pyphi' (Python 3 - PyPhi/IIT)
 #
 # Prerequisites: conda (miniconda3 or anaconda)
+#
+# NOTE conda-forge : ce script utilise -c conda-forge --override-channels
+# partout. Raison (mesure firsthand 2026-08-25) : les canaux defaults
+# Anaconda exigent l'acceptation des ToS (CondaToSNonInteractiveError en
+# non-interactif, qui tuait ce script silencieusement via 2>&1), et PyPI
+# ne publie AUCUN wheel cp39 de pyemd 0.5.1 — pip doit donc compiler une
+# sdist, ce qui exige MSVC (absent par defaut) et echoue. conda-forge
+# fournit pyemd 0.5.1 en binaire prebuilt lie a numpy 1.x.
 
 param(
     [string]$EnvName = "pyphi",
@@ -46,13 +54,13 @@ if (-not $condaExe) {
 
 Write-Host "[1/4] Using conda: $condaExe" -ForegroundColor Cyan
 
-# 2. Create conda env
+# 2. Create conda env (conda-forge, cf. NOTE conda-forge en tete de script)
 $envList = & $condaExe env list 2>$null
 if ($envList -match "$EnvName\s") {
-    Write-Host "[2/4] Conda env '$EnvName' already exists, updating..." -ForegroundColor Yellow
+    Write-Host "[2/4] Conda env '$EnvName' already exists, reusing..." -ForegroundColor Yellow
 } else {
-    Write-Host "[2/4] Creating conda env '$EnvName' with Python $PythonVersion..." -ForegroundColor Cyan
-    & $condaExe create -n $EnvName python=$PythonVersion -y 2>&1 | Out-Null
+    Write-Host "[2/4] Creating conda env '$EnvName' with Python $PythonVersion (conda-forge)..." -ForegroundColor Cyan
+    & $condaExe create -n $EnvName -c conda-forge --override-channels "python=$PythonVersion" -y 2>&1 | Out-Null
 }
 
 # 3. Install packages
@@ -65,11 +73,12 @@ if (-not $envPython) {
     exit 1
 }
 
-# pyemd epingle AVANT pyphi : la dependance sdist de pyphi (pyemd 1.1.0) se
-# compile contre numpy 2.x au build puis echoue a l'import ("numpy.dtype size
-# changed"). Le wheel pyemd 0.5.1 (cp39, numpy 1.x) + numpy<2 = combo known-good.
-& $condaExe run -n $EnvName pip install --quiet "pyemd==0.5.1" "numpy<2"
-& $condaExe run -n $EnvName pip install --quiet pyphi==1.2.0 scipy ipykernel
+# pyemd via conda-forge AVANT pyphi : PyPI n'a AUCUN wheel cp39 de pyemd 0.5.1
+# (seul 1.0.0 en a) — pip compilerait la sdist contre numpy 2.x puis echouerait
+# a l'import ("numpy.dtype size changed") tout en exigeant MSVC. Le binaire
+# conda-forge 0.5.1 (lie numpy 1.x) + numpy<2 = combo known-good.
+& $condaExe install -n $EnvName -c conda-forge --override-channels "pyemd=0.5.1" -y
+& $condaExe run -n $EnvName pip install --quiet "pyphi==1.2.0" "numpy<2" scipy ipykernel matplotlib
 
 # 4. Register Jupyter kernel
 Write-Host "[4/4] Registering Jupyter kernel..." -ForegroundColor Cyan

--- a/MyIA.AI.Notebooks/IIT/scripts/setup_pyphi_env.sh
+++ b/MyIA.AI.Notebooks/IIT/scripts/setup_pyphi_env.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Setup script for PyPhi conda environment (Python 3.9) — Linux/macOS twin
+# of setup_pyphi_env.ps1
+# PyPhi 1.2.0 requires Python <=3.9 (collections.Iterable removed in 3.10)
+#
+# Usage: bash scripts/setup_pyphi_env.sh
+#
+# Creates:
+#   - conda env 'pyphi' with Python 3.9
+#   - Jupyter kernel 'pyphi' (Python 3 - PyPhi/IIT)
+#
+# Prerequisites: conda (miniconda3 or anaconda)
+#
+# NOTE conda-forge : le script utilise -c conda-forge --override-channels
+# partout. Raison (mesure firsthand 2026-08-25, Windows + PyPI) :
+#   1. les canaux defaults Anaconda exigent l'acceptation des ToS
+#      (CondaToSNonInteractiveError en non-interactif) ;
+#   2. PyPI ne publie AUCUN wheel cp39 de pyemd 0.5.1 (seul 1.0.0 en a),
+#      donc `pip install pyemd==0.5.1` compile une sdist — contre numpy 2.x
+#      au build, puis echoue a l'import ("numpy.dtype size changed"), et
+#      exige MSVC/gcc si aucun compilateur n'est present ;
+#   3. conda-forge fournit pyemd 0.5.1 en binaire prebuilt lie a numpy 1.x :
+#      c'est le seul chemin sans compilateur.
+
+set -euo pipefail
+
+ENV_NAME="${1:-pyphi}"
+PYTHON_VERSION="3.9"
+
+echo "=== Setup PyPhi Environment ==="
+echo "Env name: $ENV_NAME"
+echo "Python version: $PYTHON_VERSION"
+echo ""
+
+# 1. Check conda is available
+CONDA_EXE="$(command -v conda || true)"
+if [ -z "$CONDA_EXE" ]; then
+    for p in "$HOME/miniconda3/bin/conda" "$HOME/anaconda3/bin/conda" \
+             "/opt/miniconda3/bin/conda" "/opt/anaconda3/bin/conda" \
+             "/usr/local/miniconda3/bin/conda"; do
+        if [ -x "$p" ]; then
+            CONDA_EXE="$p"
+            break
+        fi
+    done
+fi
+
+if [ -z "$CONDA_EXE" ]; then
+    echo "ERROR: conda not found. Install miniconda3 first." >&2
+    echo "  https://docs.conda.io/en/latest/miniconda.html" >&2
+    exit 1
+fi
+
+echo "[1/4] Using conda: $CONDA_EXE"
+
+# 2. Create conda env (conda-forge, cf. NOTE en tete de script)
+if "$CONDA_EXE" env list | grep -qE "^${ENV_NAME}\s"; then
+    echo "[2/4] Conda env '$ENV_NAME' already exists, reusing..."
+else
+    echo "[2/4] Creating conda env '$ENV_NAME' with Python $PYTHON_VERSION (conda-forge)..."
+    "$CONDA_EXE" create -n "$ENV_NAME" -c conda-forge --override-channels \
+        "python=$PYTHON_VERSION" -y
+fi
+
+# 3. Install packages : pyemd via conda-forge (binaire prebuilt, numpy 1.x),
+#    le reste via pip
+echo "[3/4] Installing packages..."
+
+"$CONDA_EXE" install -n "$ENV_NAME" -c conda-forge --override-channels \
+    "pyemd=0.5.1" -y
+"$CONDA_EXE" run -n "$ENV_NAME" pip install --quiet "pyphi==1.2.0" "numpy<2" scipy ipykernel matplotlib
+
+# 4. Register Jupyter kernel
+echo "[4/4] Registering Jupyter kernel..."
+"$CONDA_EXE" run -n "$ENV_NAME" python -m ipykernel install --user \
+    --name pyphi --display-name "Python 3 (PyPhi/IIT)"
+
+# 5. Verify
+echo ""
+echo "=== Verification ==="
+
+if "$CONDA_EXE" run -n "$ENV_NAME" python -c "import pyphi" 2>/dev/null; then
+    PYVER="$("$CONDA_EXE" run -n "$ENV_NAME" python -c 'import pyphi; print(pyphi.__version__)')"
+    echo "  PyPhi version: $PYVER"
+else
+    echo "  PyPhi: IMPORT FAILED" >&2
+    exit 1
+fi
+
+if jupyter kernelspec list 2>/dev/null | grep -q "pyphi"; then
+    echo "  Kernel 'pyphi': registered"
+else
+    echo "  Kernel 'pyphi': NOT FOUND" >&2
+fi
+
+echo ""
+echo "Setup complete. Activate with: conda activate $ENV_NAME"
+echo "Use kernel 'Python 3 (PyPhi/IIT)' in Jupyter notebooks."

--- a/MyIA.AI.Notebooks/Probas/Infer/scripts/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/scripts/README.md
@@ -21,6 +21,16 @@ Ce répertoire contient les scripts de configuration et de test pour la série d
 .\setup_environment.ps1 -SkipPapermill  # Si vous n'avez pas besoin de papermill
 ```
 
+### macOS / Linux (Bash)
+
+```bash
+# Exécuter le script de configuration (jumeau du .ps1)
+bash setup_environment.sh
+
+# Ou avec des options
+bash setup_environment.sh --skip-papermill  # Si vous n'avez pas besoin de papermill
+```
+
 ### Installation manuelle
 
 1. **Installer l'outil .NET Interactive :**
@@ -98,7 +108,8 @@ python test_notebooks.py -t 1200  # 20 minutes
 
 | Fichier | Description |
 |------|-------------|
-| `setup_environment.ps1` | Script de configuration PowerShell |
+| `setup_environment.ps1` | Script de configuration PowerShell (Windows) |
+| `setup_environment.sh` | Script de configuration Bash (macOS/Linux, jumeau du .ps1) |
 | `test_notebooks.py` | Lanceur de tests Python |
 | `requirements.txt` | Dépendances Python |
 | `README.md` | Ce fichier |

--- a/MyIA.AI.Notebooks/Probas/Infer/scripts/setup_environment.sh
+++ b/MyIA.AI.Notebooks/Probas/Infer/scripts/setup_environment.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Setup script for Infer.NET Notebooks — Linux/macOS twin of setup_environment.ps1
+# This script installs all required dependencies for running the Infer.NET notebook series
+#
+# Usage: bash scripts/setup_environment.sh [--skip-dotnet-interactive] [--skip-papermill]
+
+set -euo pipefail
+
+SKIP_DOTNET_INTERACTIVE=0
+SKIP_PAPERMILL=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-dotnet-interactive) SKIP_DOTNET_INTERACTIVE=1 ;;
+        --skip-papermill) SKIP_PAPERMILL=1 ;;
+        *) echo "Unknown option: $arg" >&2; exit 1 ;;
+    esac
+done
+
+timestamp() { date '+%H:%M:%S'; }
+status()    { echo "[$(timestamp)] $1"; }
+
+status "=== Infer.NET Notebooks Environment Setup ==="
+
+# Check .NET SDK
+status "Checking .NET SDK..."
+if command -v dotnet >/dev/null 2>&1; then
+    DOTNET_VERSION="$(dotnet --version)"
+    status "  .NET SDK found: $DOTNET_VERSION"
+else
+    status "  .NET SDK not found. Please install from https://dotnet.microsoft.com/download" >&2
+    exit 1
+fi
+
+# Check/Install dotnet-interactive
+if [ "$SKIP_DOTNET_INTERACTIVE" -eq 0 ]; then
+    status "Checking dotnet-interactive..."
+    if dotnet tool list -g 2>/dev/null | grep -q "microsoft.dotnet-interactive"; then
+        status "  dotnet-interactive already installed"
+    else
+        status "  Installing dotnet-interactive..."
+        if dotnet tool install -g Microsoft.dotnet-interactive; then
+            status "  dotnet-interactive installed successfully"
+        else
+            status "  Failed to install dotnet-interactive" >&2
+            exit 1
+        fi
+    fi
+
+    # Register Jupyter kernels
+    status "Registering .NET Interactive Jupyter kernels..."
+    if dotnet interactive jupyter install; then
+        status "  Kernels registered successfully"
+    else
+        status "  Warning: Could not register kernels (may already exist)"
+    fi
+fi
+
+# Check Python and pip
+status "Checking Python..."
+if command -v python >/dev/null 2>&1; then
+    PYTHON_VERSION="$(python --version)"
+    status "  Python found: $PYTHON_VERSION"
+else
+    status "  Python not found. Please install Python 3.8+" >&2
+    exit 1
+fi
+
+# Check/Install papermill
+if [ "$SKIP_PAPERMILL" -eq 0 ]; then
+    status "Checking papermill..."
+    if python -c "import papermill" 2>/dev/null; then
+        status "  papermill already installed"
+    else
+        status "  Installing papermill..."
+        if pip install papermill jupyter; then
+            status "  papermill installed successfully"
+        else
+            status "  Failed to install papermill" >&2
+            exit 1
+        fi
+    fi
+fi
+
+# List available Jupyter kernels
+status "Available Jupyter kernels:"
+jupyter kernelspec list
+
+status ""
+status "=== Setup Complete ==="
+status "You can now run the Infer.NET notebooks in:"
+status "  MyIA.AI.Notebooks/Probas/Infer/"
+status ""
+status "To test notebooks with papermill:"
+status "  python scripts/infer-notebooks/test_notebooks.py"

--- a/MyIA.AI.Notebooks/cross-series/matching-cv/README.md
+++ b/MyIA.AI.Notebooks/cross-series/matching-cv/README.md
@@ -62,6 +62,16 @@ Tous les scripts principaux sont situés dans le dossier `/scripts`. Ils sont fo
         ./scripts/run_e2e_tests.sh
         ```
 
+-   **Mettre à jour les dépendances du venv :**
+    -   *Windows :*
+        ```powershell
+        ./scripts/update_venv.ps1
+        ```
+    -   *macOS/Linux :*
+        ```bash
+        ./scripts/update_venv.sh
+        ```
+
 ## Fonctionnalités
 
 -   **Interface Web Simple :** Une application Flask légère pour lancer les comparaisons.

--- a/MyIA.AI.Notebooks/cross-series/matching-cv/scripts/update_venv.sh
+++ b/MyIA.AI.Notebooks/cross-series/matching-cv/scripts/update_venv.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Script pour mettre a jour l'environnement virtuel Python avec les
+# dependances de requirements.txt — jumeau Linux/macOS de update_venv.ps1
+
+set -euo pipefail
+
+# Fonction pour charger les variables d'environnement depuis un fichier .env
+load_env_variables() {
+    local path="${1:-.env}"
+    if [ -f "$path" ]; then
+        while IFS= read -r line || [ -n "$line" ]; do
+            line="$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+            case "$line" in
+                ""|\#*) continue ;;
+            esac
+            key="${line%%=*}"
+            value="${line#*=}"
+            if [ "$key" != "$line" ]; then
+                key="$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+                value="$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed 's/^"//;s/"$//')"
+                export "$key=$value"
+            fi
+        done < "$path"
+    fi
+}
+
+# Definir le chemin de base du projet
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(dirname "$script_dir")"
+echo "Racine du projet: $project_root"
+
+# Charger les variables du fichier .env
+load_env_variables "$project_root/.env"
+
+# Chemin vers l'environnement virtuel Python (lu depuis .env)
+venv_path="${VENV_PYTHON_PATH:-}"
+requirements_path="$project_root/requirements.txt"
+
+echo "Environnement virtuel: $venv_path"
+echo "Fichier de dependances: $requirements_path"
+
+# Verifier si les chemins existent
+if [ -z "$venv_path" ] || [ ! -x "$venv_path" ]; then
+    echo "ERREUR : l'executable Python de l'environnement virtuel n'a pas ete trouve : $venv_path" >&2
+    exit 1
+fi
+if [ ! -f "$requirements_path" ]; then
+    echo "ERREUR : le fichier requirements.txt n'a pas ete trouve : $requirements_path" >&2
+    exit 1
+fi
+
+# Executer la mise a jour des dependances
+echo "Mise a jour des dependances avec pip..."
+"$venv_path" -m pip install -r "$requirements_path" --upgrade
+
+echo "Mise a jour terminee."


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/research-code #12946

## Summary

Tranche reconciliation residuelle de l'Epic xplat #10643 : les 5 filles sont CLOSED, mais un sweep orphelin firsthand (`git ls-files`, 2026-08-25) trouve encore **3 vrais scripts setup Windows-only sans jumeau bash** — les 3 sont livres ici. Corrige aussi `setup_pyphi_env.ps1`, **cassé sur Windows** (mesure firsthand c.507).

- **`IIT/scripts/setup_pyphi_env.sh`** (NEW, +x) — jumeau Linux/macOS. Voie conda-forge intégrale.
- **`IIT/scripts/setup_pyphi_env.ps1`** (FIX) — le script mourrait silencieusement : (1) canaux defaults Anaconda → `CondaToSNonInteractiveError` en non-interactif (masqué par `2>&1` sous PS 5.1) ; (2) PyPI ne publie **aucun wheel cp39 de pyemd 0.5.1** (seul 1.0.0 en a — le commentaire du script claimait l'inverse) → pip compilait une sdist exigeant MSVC. Fix : `-c conda-forge --override-channels` partout + `conda install pyemd=0.5.1` (binaire prebuilt numpy 1.x). **Cette voie exacte a ete executee et verifiee firsthand le 2026-08-25** : env `pyphi` Python 3.9.23, `pyphi 1.2.0` import, Φ calcule.
- **`Probas/Infer/scripts/setup_environment.sh`** (NEW, +x) — jumeau du setup Infer.NET (dotnet SDK check, dotnet-interactive, kernels, papermill), flags `--skip-dotnet-interactive` / `--skip-papermill`.
- **`cross-series/matching-cv/scripts/update_venv.sh`** (NEW, +x) — jumeau du update venv : parseur `.env` (espaces autour de `=`, commentaires, quotes), garde-foux venv/requirements.
- **READMEs croisés** (IIT, Infer/scripts, matching-cv) — sections macOS/Linux + tables/arbre mis a jour, francais d'abord.

## Validation

- `bash -n` sur les 3 nouveaux `.sh` : OK Git Bash **et** WSL bash (Linux reel).
- `update_venv.sh` execute sous WSL : chemin erreur (VENV_PYTHON_PATH vide) → `ERREUR... exit=1` ; chemin heureux (`.env` avec `VENV_PYTHON_PATH = /bin/true`, ligne commentaire, `OTHER=x`) → parse correct, flux complet, `RC=0`.
- Fix `.ps1` : la sequence conda-forge corrigee est celle executee avec succes c.507 sur cette machine (preuve : env pyphi existant, smoke Φ OK).
- `chmod +x` (mode 100755 au commit) — precedent #10844.
- Advisory CI `bash-syntax-advisory.yml` couvrira les 3 nouveaux fichiers automatiquement (glob `scripts/**/*.sh`).

## Contexte Epic (reconciliation #10643)

Sweep orphelin : 29 `.ps1` sans `.sh` sibling **avant** cette PR → 26 apres. Decomposition : 16 Vibe-Coding pedagogique + 3 archives = **hors scope par le body de l'Epic** ; GameTheory (2) et SmartContracts (1) couverts **semantiquement** (split naming entry WSL `.ps1` vs natif `.sh`, READMEs croises existants) ; les 3 restants = cette PR → **0 orphelin reel en scope**.

See #10643 (Epic vivant — jamais Closes : acceptance globale restante a arbitrer par ai-01).

## Note SOTA (§H)

SOTA-OK — les scripts setup ont ete **executes** (pas seulement syntax-check) : `.sh` sous WSL Linux reel, `.ps1` via la session c.507. Aucune sortie degradee.
