### PR TITLE
fix(ict,#12940): normaliser W_dec [d_model, d_sae] des releases W32K — clamp indexait des lignes du residual stream

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_sae_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_sae_traces.py
@@ -455,11 +455,32 @@ def fetch_sae_config(sae_repo: str) -> dict:
     }
 
 
+def normalize_w_dec(w_dec: torch.Tensor, w_enc: torch.Tensor) -> torch.Tensor:
+    """Normalise W_dec vers [d_sae, d_model] (lignes = features), #12940.
+
+    Layout heterogene des releases : les checkpoints W32K (1.7B et 2B,
+    verifies firsthand) stockent W_dec [d_model, d_sae] ; les autres
+    [d_sae, d_model]. Sans normalisation, l'indexation ``W_dec[clamp_ids]``
+    du hook de clamp designe des LIGNES du residual stream (0..d_model-1)
+    au lieu des directions decodees des features visees — IndexError si un
+    clamp_id depasse d_model, silencieusement faux sinon. d_model se deduit
+    de W_enc [d_sae, d_model] ; la normalisation est non ambigue car
+    d_model != d_sae sur toutes les releases visees. Meme correctif que
+    ``extract_sae_fidelity.py`` (PR #12938).
+    """
+    d_model = w_enc.shape[1]
+    if w_dec.shape[0] == d_model:
+        return w_dec.t().contiguous()
+    return w_dec
+
+
 def load_sae(sae_repo: str, layer: int, device: torch.device):
     """Telecharge et charge le checkpoint SAE de la couche demandee.
 
     Convention Qwen-Scope (app.py officiel) : dict avec W_enc [d_sae, d_model],
-    b_enc [d_sae] (+ W_dec/b_dec pour la reconstruction/le clamp)."""
+    b_enc [d_sae] (+ W_dec/b_dec pour la reconstruction/le clamp). W_dec est
+    rendu en [d_sae, d_model] quelle que soit la release (cf
+    :func:`normalize_w_dec`, #12940) — l'indexation par feature est garantie."""
     from huggingface_hub import hf_hub_download
     path = hf_hub_download(sae_repo, f"layer{layer}.sae.pt")
     sae = torch.load(path, map_location="cpu", weights_only=True)
@@ -469,7 +490,7 @@ def load_sae(sae_repo: str, layer: int, device: torch.device):
     b_enc = sae["b_enc"].to(torch.float32)          # [d_sae]
     w_dec = sae.get("W_dec")
     if w_dec is not None:
-        w_dec = w_dec.to(torch.float32)
+        w_dec = normalize_w_dec(w_dec.to(torch.float32), w_enc)
     return {"W_enc": w_enc, "b_enc": b_enc, "W_dec": w_dec, "path": path}
 
 
@@ -518,7 +539,10 @@ class ResidCapture:
         self.hidden = out.detach()[0].to(torch.float32).cpu()      # [T, d]
         if not self.clamp_ids:
             return output
-        # Clamp causal : h' = h - somme_i acts_i * W_dec[i]  (features forcees a 0)
+        # Clamp causal : h' = h - somme_i acts_i * W_dec[i]  (features forcees a 0).
+        # W_dec est garanti [d_sae, d_model] par load_sae/normalize_w_dec
+        # (#12940) : indexer par clamp_ids (features) y designe les directions
+        # decodees, pas des lignes du residual stream.
         h32 = out.detach().to(torch.float32).cpu()                 # [B, T, d]
         w_enc = self.sae["W_enc"][self.clamp_ids]                  # [C, d]
         b_enc = self.sae["b_enc"][self.clamp_ids]                  # [C]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sae_traces_layout.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sae_traces_layout.py
@@ -1,0 +1,99 @@
+"""Regression #12940 : layout heterogene de W_dec dans ``extract_sae_traces``.
+
+Sonde firsthand de l'issue (checkpoints W32K locaux) :
+
+* ``SAE-Res-Qwen3-1.7B-Base-W32K-L0_50/layer14.sae.pt`` : W_dec (2048, 32768)
+* ``SAE-Res-Qwen3-2B-Base-W32K-L0_50/layer12.sae.pt`` : W_dec (2048, 32768)
+
+Le hook de clamp indexait ``W_dec[clamp_ids]`` ou clamp_ids sont des indices
+de FEATURES (jusqu'a d_sae-1 = 32767) : sur ces layouts, l'indexation prenait
+des lignes = dimensions du residual stream (0..2047). Un clamp_id > 2047 ->
+IndexError ; tous < 2048 -> silencieusement faux (directions residuelles
+soustraites au lieu des directions decodees des features visees).
+
+``normalize_w_dec`` (meme correctif que ``extract_sae_fidelity.py``, PR
+#12938) ramene W_dec en [d_sae, d_model] : l'indexation par feature designe
+les directions decodees quel que soit le layout de la release. torch est
+autorise dans CE fichier de tests (precedent : test_lens_agreement.py) ; la
+bibliotheque ``ict/`` reste numpy-only.
+"""
+
+import os
+import sys
+
+import torch
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SERIES = os.path.dirname(_HERE)
+sys.path.insert(0, os.path.join(_SERIES, "scripts"))
+
+import extract_sae_traces as est  # noqa: E402
+
+
+def _sae_pair(d_model=64, d_sae=1024):
+    """W_enc [d_sae, d_model] + W_dec stocke en [d_model, d_sae] (layout W32K).
+
+    Dimensions compactes preservant l'invariant semantique du fondateur
+    (d_model < clamp_id < d_sae, ex. reel : 2048 < 5000 < 32768). Valeurs
+    identifiants : arange — chaque ligne i du stockage (dimension residual)
+    et chaque colonne j (feature) portent leur index, de sorte qu'une
+    mauvaise lecture transposition-dependante est detectable par le contenu,
+    pas seulement par la forme."""
+    w_enc = torch.arange(d_sae * d_model, dtype=torch.float32).reshape(d_sae, d_model)
+    w_dec_stored = torch.arange(d_model * d_sae, dtype=torch.float32).reshape(d_model, d_sae)
+    return w_enc, w_dec_stored
+
+
+def test_w32k_layout_is_transposed_to_sae_rows():
+    """Le layout fondateur [d_model, d_sae] (W32K : 2048x32768 reels, 64x1024
+    ici) : normalise vers [d_sae, d_model], contenu = transpose exacte."""
+    w_enc, w_dec_stored = _sae_pair()
+    out = est.normalize_w_dec(w_dec_stored, w_enc)
+    assert tuple(out.shape) == (1024, 64)  # [d_sae, d_model]
+    assert torch.equal(out, w_dec_stored.t())
+
+
+def test_canonical_layout_passes_through_unchanged():
+    """Une release stockant deja [d_sae, d_model] : inchangee (pas de double
+    transposition)."""
+    d_model, d_sae = 64, 1024
+    w_enc = torch.zeros(d_sae, d_model)
+    w_dec = torch.arange(d_sae * d_model, dtype=torch.float32).reshape(d_sae, d_model)
+    out = est.normalize_w_dec(w_dec, w_enc)
+    assert tuple(out.shape) == (d_sae, d_model)
+    assert torch.equal(out, w_dec)
+
+
+def test_clamp_indexing_selects_feature_directions_not_resid_rows():
+    """LA semantique du bug : apres normalisation, W_dec[feature_id] rend la
+    direction decodee de la FEATURE (ligne du layout canonique), pas la
+    ligne d_model du stockage W32K. Cas mesure de l'issue (reel : clamp_id
+    5000 valide feature, > d_model 2048) — IndexError avant, direction
+    correcte apres."""
+    w_enc, w_dec_stored = _sae_pair()
+    w_dec = est.normalize_w_dec(w_dec_stored, w_enc)
+    clamp_id = 500  # > d_model (64) et < d_sae (1024) : levait IndexError avant
+    row = w_dec[clamp_id]                       # [d_model]
+    assert torch.equal(row, w_dec_stored[:, clamp_id])
+    # Le clamp a 2 features rend [C, d_model] (l'arite du hook ResidCapture).
+    sel = w_dec[[3, clamp_id]]
+    assert tuple(sel.shape) == (2, 64)
+    assert torch.equal(sel[0], w_dec_stored[:, 3])
+
+
+def test_resid_row_misread_is_detectably_different():
+    """Controle du faux silencieux (tous clamp_ids < d_model) : sans
+    normalisation, W_dec_stored[3] rend la ligne 3 du residual stream — une
+    direction DIFFERENTE de la direction decodee de la feature 3. Ce test
+    documente pourquoi le bug etait invisible a la forme seule."""
+    _, w_dec_stored = _sae_pair()
+    wrong = w_dec_stored[3]                     # l'ancienne lecture (ligne)
+    right = w_dec_stored.t()[3]                 # la lecture corrigee (feature)
+    assert not torch.equal(wrong, right)
+    # L'ancienne lecture levait IndexError des qu'un clamp_id depassait
+    # d_model — les 32768 features ne tiennent pas dans 2048 lignes (reel).
+    try:
+        w_dec_stored[500]  # clamp_id > d_model=64 mais < d_sae
+        raise AssertionError("d_model=64 doit refuser l'index 500")
+    except IndexError:
+        pass

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sae_traces_layout.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sae_traces_layout.py
@@ -13,13 +13,25 @@ soustraites au lieu des directions decodees des features visees).
 
 ``normalize_w_dec`` (meme correctif que ``extract_sae_fidelity.py``, PR
 #12938) ramene W_dec en [d_sae, d_model] : l'indexation par feature designe
-les directions decodees quel que soit le layout de la release. torch est
-autorise dans CE fichier de tests (precedent : test_lens_agreement.py) ; la
-bibliotheque ``ict/`` reste numpy-only.
+les directions decodees quel que soit le layout de la release. Ces
+regressions manipulent des tenseurs torch ET importent le module sous test
+(``extract_sae_traces`` importe torch au module-level : script d'extraction
+GPU) ; le runner CI ubuntu est sans torch, ou la simple COLLECTE plantait
+(ModuleNotFoundError, PANNE D'INFRA). ``importorskip`` en tete de module :
+collecte reussie partout (module skippe proprement sans torch, convention
+serie cf ``test_lens_agreement.py`` numpy-only en collection), regressions
+completes sur toute machine a torch.
 """
 
 import os
 import sys
+
+import pytest
+
+pytest.importorskip(
+    "torch",
+    reason="regressions torch (normalize_w_dec sur tenseurs) : collectees partout, executes seulement ou torch est installe",
+)
 
 import torch
 


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA

## Summary

Le hook de clamp (Gate 24) de [extract_sae_traces.py](MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_sae_traces.py) indexait `W_dec[clamp_ids]` où `clamp_ids` sont des indices de **features** (jusqu'à d_sae−1 = 32767). Les checkpoints W32K sondés firsthand dans l'issue (1.7B layer14, 2B layer12 : `W_dec (2048, 32768)`) stockent W_dec en **[d_model, d_sae]** : l'indexation prenait des **lignes = dimensions du residual stream** (0..2047).

- un clamp_id > 2047 → **IndexError immédiat** ;
- tous clamp_ids < 2048 → **silencieusement faux** : le clamp soustrait des directions du residual stream au lieu des directions décodées des features visées.

Latent car le path clamp n'a jamais été exécuté (ICT-21 a livré les traces plaines `trained/control`).

## Fix

`normalize_w_dec(w_dec, w_enc)` dans le script : si `w_dec.shape[0] == d_model` (déduit de `W_enc` [d_sae, d_model]), transpose vers **[d_sae, d_model]** (lignes = features). Non ambigu car d_model ≠ d_sae sur toutes les releases visées. **Même correctif que `extract_sae_fidelity.py` (PR #12938)**, appliqué dans `load_sae` : tous les consommateurs (le hook `ResidCapture`) recouvrent le layout garanti. torch reste confiné au script — la bibliothèque `ict/` reste numpy-only (règle d'architecture de la série).

## Tests

Nouveau [tests/test_sae_traces_layout.py](MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_sae_traces_layout.py) (précédent torch : `test_lens_agreement.py`), 4 tests :

1. **Layout W32K transposé** vers [d_sae, d_model], contenu = transposée exacte ;
2. **Layout canonique inchangé** (pas de double transposition) ;
3. **Sémantique clamp** — LA correction : `W_dec[feature_id]` rend la direction décodée de la feature, pas une ligne residuelle ; clamp_id entre d_model et d_sae (reél : 2048 < 5000 < 32768) — IndexError avant, direction correcte après ; arité [C, d_model] du hook ;
4. **Contrôle du faux silencieux** : la lecture ligne ≠ lecture feature (contenu), et l'index > d_model lève IndexError sur le layout brut.

Dimensions compactes (64/1024) préservant l'invariant `d_model < clamp_id < d_sae` — les dimensions réelles du fondateur (2048/32768) sont documentées dans les docstrings.

## Validation

- [x] `python -m pytest tests/test_sae_traces_layout.py tests/test_sae_traces.py ict/tests/test_sae_traces_guard.py -q` → **17 passed**
- [x] `python -m py_compile scripts/extract_sae_traces.py` → OK
- [x] Diff : +27/−3 sur le script, fichier de tests neuf

## Résiduel documenté (issue)

Le layout du **couple 9B/W64K** de référence ICT-21 n'est pas sondable localement (checkpoint absent du cache) — **à confirmer avant le Gate 24**. La normalisation couvre les deux layouts possibles (transpose seulement si shape[0] == d_model), donc un 9B en layout canonique passe à l'identique.

Closes #12940

🤖 Generated with [Claude Code](https://claude.com/claude-code)