### PR TITLE
feat(ict,#8236): J-lens local fit tooling per size (fit + fidelity scripts)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_jlens_fidelity.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_jlens_fidelity.py
@@ -1,0 +1,113 @@
+"""Fidelite J-lens par taille (sous-grain (c) #8236).
+
+Applique un lens fitte localement (``fit_jlens_local.py``, C:/dev/jlens_fits,
+JAMAIS commite) aux PROMPT_SETS de calibration SAE et mesure l'accord
+lens-vs-modele aux profondeurs de calibration (frac 0.25/0.5) :
+
+  - ``overlap@10`` : |top10(lens) ∩ top10(modele)| / 10, moyen positions+prompts
+  - ``rel_l2``     : ||lens - modele||_2 / ||modele||_2 (lignes positions)
+  - ``kl``         : KL(modele || lens) en nats (log_softmax des deux)
+
+Sortie : ``traces/calib_jlens_<tag>.npz`` — une cle par ``<set>__<layer>``
+(vecteur [overlap, rel_l2, kl] + n_prompts), plus les metadonnees du fit.
+Comparable a ``calib_fidelity_*.npz`` (axe SAE) du meme notebook.
+
+Usage :
+  python extract_jlens_fidelity.py --lens qwen3-1-7b --model Qwen/Qwen3-1.7B-Base
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).parent))
+from extract_sae_traces import PROMPT_SETS  # noqa: E402
+
+import jlens  # noqa: E402
+
+FITS_DIR = Path("C:/dev/jlens_fits")
+TRACES_DIR = Path(__file__).resolve().parent.parent / "traces"
+
+
+def prompt_metrics(lens_logits: torch.Tensor, model_logits: torch.Tensor,
+                   k: int = 10) -> dict[str, float]:
+    """Metrics moyennes sur les positions, une paire [T, vocab]."""
+    top_lens = torch.topk(lens_logits, k, dim=-1).indices
+    top_true = torch.topk(model_logits, k, dim=-1).indices
+    overlap = np.mean([
+        len(set(a.tolist()) & set(b.tolist())) / k
+        for a, b in zip(top_lens, top_true)
+    ])
+    rel_l2 = (torch.norm(lens_logits - model_logits, dim=-1)
+              / torch.norm(model_logits, dim=-1)).mean().item()
+    log_p = torch.log_softmax(model_logits.float(), dim=-1)
+    log_q = torch.log_softmax(lens_logits.float(), dim=-1)
+    kl = (log_p.exp() * (log_p - log_q)).sum(-1).mean().item()
+    return {"overlap10": float(overlap), "rel_l2": float(rel_l2), "kl": float(kl)}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lens", required=True, help="tag du fit (ex qwen3-1-7b)")
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--max-prompts", type=int, default=None,
+                    help="limite par set (debug)")
+    args = ap.parse_args()
+
+    lens_path = FITS_DIR / f"{args.lens}_jacobian_lens.pt"
+    stats_path = FITS_DIR / f"{args.lens}_fit_stats.json"
+    lens = jlens.JacobianLens.load(str(lens_path))
+    print(f"[lens] {lens!r} <- {lens_path.name}", flush=True)
+
+    device = torch.device("cuda")
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(args.model)
+    hf_model = AutoModelForCausalLM.from_pretrained(
+        args.model, torch_dtype=torch.bfloat16, device_map=device
+    )
+    model = jlens.from_hf(hf_model, tok)
+    print(f"[model] {args.model} charge", flush=True)
+
+    arrays: dict[str, np.ndarray] = {}
+    for set_name, prompts in PROMPT_SETS.items():
+        if args.max_prompts:
+            prompts = prompts[: args.max_prompts]
+        per_layer: dict[int, list[dict[str, float]]] = {
+            layer: [] for layer in lens.source_layers
+        }
+        for prompt in prompts:
+            ids = tok(prompt, return_tensors="pt")
+            positions = list(range(ids["input_ids"].shape[1]))
+            lens_logits, model_logits, _ = lens.apply(model, prompt, positions=positions)
+            for layer in lens.source_layers:
+                per_layer[layer].append(prompt_metrics(
+                    torch.as_tensor(lens_logits[layer]).float().cuda(),
+                    torch.as_tensor(model_logits).float().cuda(),
+                ))
+        for layer, rows in per_layer.items():
+            mean = {m: float(np.mean([r[m] for r in rows])) for m in rows[0]}
+            arrays[f"{set_name}__{layer}"] = np.array(
+                [mean["overlap10"], mean["rel_l2"], mean["kl"]], dtype=np.float64
+            )
+            print(f"[{set_name}] layer {layer}: overlap@10={mean['overlap10']:.4f} "
+                  f"rel_l2={mean['rel_l2']:.4f} kl={mean['kl']:.4f}", flush=True)
+
+    fit_stats = json.loads(stats_path.read_text()) if stats_path.exists() else {}
+    arrays["meta_model"] = np.array([ord(c) for c in args.model], dtype=np.int16)
+    arrays["meta_layers"] = np.array(lens.source_layers, dtype=np.int64)
+    arrays["meta_n_fit"] = np.array([fit_stats.get("n_prompts", lens.n_prompts)],
+                                    dtype=np.int64)
+
+    TRACES_DIR.mkdir(parents=True, exist_ok=True)
+    out = TRACES_DIR / f"calib_jlens_{args.lens}.npz"
+    np.savez_compressed(out, **arrays)
+    print(f"[out] {out} ({out.stat().st_size/1024:.1f} KiB)", flush=True)
+    print("EXTRACT_OK", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/fit_jlens_local.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/fit_jlens_local.py
@@ -24,8 +24,8 @@ from pathlib import Path
 import torch
 
 MODELS = {
-    "Qwen/Qwen3-1.7B-Base": [7, 14],   # 28 couches : frac 0.25 / 0.5
-    "Qwen/Qwen3-5-2B-Base": [6, 12],   # 24 couches : frac 0.25 / 0.5
+    "Qwen/Qwen3-1.7B-Base": [7, 14],     # 28 couches : frac 0.25 / 0.5
+    "Qwen/Qwen3.5-2B-Base": [6, 12],     # 24 couches : frac 0.25 / 0.5
 }
 FITS_DIR = Path("C:/dev/jlens_fits")
 

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/fit_jlens_local.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/fit_jlens_local.py
@@ -1,0 +1,99 @@
+"""Fit local J-lens par taille (sous-grain (c) #8236).
+
+Reproduit la construction du lens publie 9B (neuronpedia/jacobian-lens,
+Salesforce-wikitext n=458, min_chars 600) sur Qwen3-1.7B-Base et
+Qwen3-5-2B-Base, aux profondeurs de calibration SAE (frac 0.25/0.5) :
+
+  1.7B (28 couches) : source_layers [7, 14]
+  2B   (24 couches) : source_layers [6, 12]
+
+target = logits finaux (defaut). Le checkpoint de fit est resumable
+(checkpoint_path + resume=True) ; le lens final est sauvegarde via
+JacobianLens.save (fp16) HORS du depot (convention #8236 : les lens fits
+ne sont jamais commites, seules les traces .npz le sont).
+
+Usage :
+  python fit_jlens_local.py --model Qwen/Qwen3-1.7B-Base --tag qwen3-1-7b
+  python fit_jlens_local.py --model Qwen/Qwen3-1.7B-Base --tag test --n-prompts 3 --fresh
+"""
+import argparse
+import json
+import time
+from pathlib import Path
+
+import torch
+
+MODELS = {
+    "Qwen/Qwen3-1.7B-Base": [7, 14],   # 28 couches : frac 0.25 / 0.5
+    "Qwen/Qwen3-5-2B-Base": [6, 12],   # 24 couches : frac 0.25 / 0.5
+}
+FITS_DIR = Path("C:/dev/jlens_fits")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True, choices=sorted(MODELS))
+    ap.add_argument("--tag", required=True, help="suffixe du fichier de sortie")
+    ap.add_argument("--n-prompts", type=int, default=458)
+    ap.add_argument("--min-chars", type=int, default=600)
+    ap.add_argument("--dim-batch", type=int, default=8)
+    ap.add_argument("--max-seq-len", type=int, default=128)
+    ap.add_argument("--fresh", action="store_true", help="ignorer un checkpoint existant")
+    args = ap.parse_args()
+
+    import jlens
+    from jlens.examples import load_wikitext_prompts
+
+    t0 = time.time()
+    device = torch.device("cuda")
+    print(f"[device] {torch.cuda.get_device_name(0)}", flush=True)
+
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(args.model)
+    hf_model = AutoModelForCausalLM.from_pretrained(
+        args.model, torch_dtype=torch.bfloat16, device_map=device
+    )
+    print(f"[load] {args.model} bf16 {time.time()-t0:.1f}s "
+          f"({torch.cuda.memory_allocated()/2**30:.2f} GiB)", flush=True)
+
+    model = jlens.from_hf(hf_model, tok)
+    source_layers = MODELS[args.model]
+    print(f"[wrap] jlens.from_hf OK, source_layers={source_layers}", flush=True)
+
+    prompts = load_wikitext_prompts(args.n_prompts, min_chars=args.min_chars)
+    print(f"[prompts] {len(prompts)} WikiText-103 >= {args.min_chars} chars", flush=True)
+
+    FITS_DIR.mkdir(parents=True, exist_ok=True)
+    ckpt = FITS_DIR / f"{args.tag}_fit_ckpt.pt"
+    out = FITS_DIR / f"{args.tag}_jacobian_lens.pt"
+
+    t1 = time.time()
+    lens = jlens.fit(
+        model,
+        prompts,
+        source_layers=source_layers,
+        dim_batch=args.dim_batch,
+        max_seq_len=args.max_seq_len,
+        checkpoint_path=str(ckpt),
+        resume=not args.fresh,
+    )
+    lens.save(str(out))
+    stats = {
+        "model": args.model,
+        "source_layers": source_layers,
+        "n_prompts": len(prompts),
+        "min_chars": args.min_chars,
+        "fit_seconds": round(time.time() - t1, 1),
+        "vram_peak_gib": round(torch.cuda.max_memory_allocated() / 2**30, 2),
+        "lens_path": str(out),
+    }
+    (FITS_DIR / f"{args.tag}_fit_stats.json").write_text(json.dumps(stats, indent=2))
+    print(f"[fit] {stats['fit_seconds']}s, pic VRAM {stats['vram_peak_gib']}/8.0 GiB", flush=True)
+    print(f"[lens] {out} ({out.stat().st_size/2**20:.1f} MiB)", flush=True)
+    print(f"[lens] {lens!r}", flush=True)
+    print("FIT_OK", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #12938

See #8236 (sous-grain (c) : fit J-lens local par taille — tranche tooling ; le CONTENT traces + section notebook suit au cycle prochain, gated GPU)

## Summary

Deux scripts GPU pour le fit J-lens local par taille, aux profondeurs de calibration SAE (frac 0.25/0.5 → 1.7B couches [7,14], 2B couches [6,12]) :

- **`fit_jlens_local.py`** — charge le modèle bf16, `jlens.from_hf`, corpus WikiText-103-raw via `jlens.examples.load_wikitext_prompts` (n=458, min_chars 600 — construction identique au lens publié 9B `neuronpedia/jacobian-lens`), `jlens.fit(source_layers=[...], dim_batch=8, max_seq_len=128, checkpoint_path=..., resume=True)`, puis `JacobianLens.save` fp16 **hors du dépôt** (`C:/dev/jlens_fits/`, convention #8236 : lens fits jamais committés) + `_fit_stats.json` (temps, pic VRAM).
- **`extract_jlens_fidelity.py`** — applique le lens fitté aux `PROMPT_SETS` de calibration SAE (comparabilité directe avec `calib_fidelity_*.npz`), mesure l'accord lens-vs-modèle par taille × profondeur : `overlap@10`, `rel_l2`, `KL(modele||lens)` ; trace compacte `traces/calib_jlens_<tag>.npz`.

## Validation

- Smoke n=3 firsthand (RTX 3070 8 GiB) : `FIT_OK` — pic VRAM 5,17/8,0 GiB, lens 16,0 MiB fp16 (2 couches, d_model 2048), 110 s incl. streaming dataset
- `py_compile` OK sur les 2 scripts ; `inspect.signature(jlens.fit)` vérifié contre le package installé (jlens 0.1.0 GitHub, API `source_layers/target_layer/dim_batch/max_seq_len/checkpoint_path/resume`)
- Fits complets (n=458) 1.7B puis 2B **en cours d'exécution** au moment de la PR (chaînés, checkpoint resumable, log `C:/dev/jlens_fits/fit_chain.log`) — les traces et la section notebook arriveront avec les livrables mesurés, pas avant

## Note de genre

Tranche tooling d'un grain CONTENT DEEP en vol (gated GPU ~3,5 h de fit) : la PR plancher CONTENT du sous-grain (traces .npz + section ICT-SAE-Calibration) suit à la convergence des fits. Conventions jlens (install GitHub, VRAM, checkpoint) documentées au build-notes #8236 c.5413437238.

