### PR TITLE
feat(genai,#12958): notebook 23 TAL -- pipeline spaCy FR du mot aux dépendances et entités

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/23_TAL_Du_Mot_Aux_Dependances.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/23_TAL_Du_Mot_Aux_Dependances.ipynb
@@ -1,0 +1,1998 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a0472f5a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008011,
+     "end_time": "2026-08-25T17:24:11.797356+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:11.789345+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# TAL — du mot aux dépendances : le pipeline linguistique français\n",
+    "\n",
+    "La série Texte traite le langage **côté modèle** : prompts, RAG, fine-tuning. Le notebook [`RAG-et-Memoire-Semantique/04-Tokenisation-From-Scratch.ipynb`](../RAG-et-Memoire-Semantique/04-Tokenisation-From-Scratch.ipynb) y construit la tokenisation **sous-mot** (BPE) qui alimente les LLM. Il existe une seconde tradition — le **traitement automatique du langage (TAL) classique** — qui analyse le français **au niveau du mot** : lemmes, parties du discours, traits morphologiques, relations de dépendance, entités nommées.\n",
+    "\n",
+    "Les deux traditions répondent à des questions différentes :\n",
+    "\n",
+    "- le **BPE** découpe pour *compresser* : aucun mot n'est inconnu, mais aucune structure linguistique n'est captée ;\n",
+    "- le **pipeline TAL** annote pour *analyser* : qui fait quoi, quel mot porte quel rôle, quel nom désigne quelle entité.\n",
+    "\n",
+    "Ce notebook exécute un pipeline spaCy français sur un corpus fil rouge **à deux domaines**, compare la représentation en mots à la tokenisation BPE du notebook 04, mesure les **erreurs du modèle contre des annotations de référence**, et débouche sur un cas d'usage borné : la **recherche lemmatisée**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7600fcfc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006039,
+     "end_time": "2026-08-25T17:24:11.809307+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:11.803268+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Corpus fil rouge — deux domaines, un seul fil\n",
+    "\n",
+    "Le domaine **littéraire** reprend *exactement* le même texte que le notebook 04 (fables de La Fontaine, domaine public) — la comparaison mots/BPE de la section 6 porte donc sur des données identiques. Le domaine **juridico-technique** est un texte original (RGPD, registre de traitement) : phrases longues, groupes nominaux denses, entités réelles (organismes, dates, référentiels).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "258c11bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:11.824584Z",
+     "iopub.status.busy": "2026-08-25T17:24:11.824584Z",
+     "iopub.status.idle": "2026-08-25T17:24:11.838001Z",
+     "shell.execute_reply": "2026-08-25T17:24:11.837481Z"
+    },
+    "papermill": {
+     "duration": 0.022708,
+     "end_time": "2026-08-25T17:24:11.839016+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:11.816308+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "littéraire (fables)           299 mots-espace, 1671 caractères\n",
+      "juridique (registre RGPD)     135 mots-espace, 894 caractères\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Corpus A (litteraire) : identique a RAG-et-Memoire-Semantique/04-Tokenisation-From-Scratch.ipynb\n",
+    "FABLES_TEXT = \"\"\"\n",
+    "Maître Corbeau, sur un arbre perché, tenait en son bec un fromage.\n",
+    "Maître Renard, par l'odeur alléché, lui tint à peu près ce langage.\n",
+    "Hé bonjour, Monsieur du Corbeau. Que vous êtes joli, que vous me semblez beau.\n",
+    "Sans mentir, si votre ramage se rapporte à votre plumage, vous êtes le Phénix des hôtes de ces bois.\n",
+    "Le corbeau, honteux et confus, jura, mais un peu tard, qu'on ne l'y prendrait plus.\n",
+    "La cigale ayant chanté tout l'été, se trouva fort dépourvue quand la bise fut venue.\n",
+    "Pas un seul petit morceau de mouche ou de vermisseau, elle alla crier famine chez la fourmi sa voisine.\n",
+    "Je vous paierai, lui dit-elle, avant l'août, foi d'animal, intérêt et principal.\n",
+    "La fourmi n'est pas prêteuse, c'est là son moindre défaut.\n",
+    "Que faisiez-vous au temps chaud, dit-elle à cette emprunteuse.\n",
+    "Nuit et jour à tout venant je chantais, ne vous déplaise.\n",
+    "Vous chantiez, j'en suis fort aise, eh bien dansez maintenant.\n",
+    "Le lièvre et la tortue firent une course, et la tortue, lente mais obstinée,\n",
+    "gagna contre le lièvre trop confiant.\n",
+    "Rien ne sert de courir, il faut partir à point, la patience vaut mieux que la force.\n",
+    "Le lion, roi des animaux, apprit un jour que les bêtes de son royaume le craignaient.\n",
+    "Le rat des villes et le rat des champs se rencontrèrent et partagèrent leur repas.\n",
+    "Le loup et l'agneau se désaltéraient au même ruisseau, le loup chercha une querelle à l'agneau.\n",
+    "Le corbeau et le renard se parlèrent longtemps, le renard eut le fromage.\n",
+    "Le chêne et le roseau se disputaient la force, le vent les départagea.\n",
+    "Perrette et le pot au lait, la poule aux œufs d'or, le coq et le renard.\n",
+    "Le savetier et le financier, le sage et le fou, le laboureur et ses enfants.\n",
+    "\"\"\".strip()\n",
+    "\n",
+    "# Corpus B (juridico-technique) : texte original, redige pour ce notebook.\n",
+    "REGISTRE_TEXT = \"\"\"\n",
+    "La CNIL a vérifié en mars 2024 que la société Acme SAS conservait les données personnelles\n",
+    "de ses clients européens conformément au RGPD et à la loi Informatique et Libertés.\n",
+    "Le registre des traitements mentionne la finalité, la base légale et la durée de conservation\n",
+    "de chaque catégorie d'informations. La durée maximale de conservation des historiques\n",
+    "d'achat a été fixée à trois ans après le dernier contact commercial.\n",
+    "Les personnes concernées peuvent exercer leurs droits d'accès, de rectification\n",
+    "et d'effacement auprès du délégué à la protection des données, par courriel\n",
+    "à l'adresse dpo@acme.example. En cas de violation de données, Acme SAS notifie\n",
+    "la CNIL dans les soixante-douze heures et informe les clients concernés.\n",
+    "Les sous-traitants hébergeant les données en dehors de l'Union européenne\n",
+    "doivent garantir un niveau de protection adéquat selon les clauses contractuelles types.\n",
+    "\"\"\".strip()\n",
+    "\n",
+    "CORPUS = {\"littéraire (fables)\": FABLES_TEXT, \"juridique (registre RGPD)\": REGISTRE_TEXT}\n",
+    "for nom, texte in CORPUS.items():\n",
+    "    mots = len(texte.split())\n",
+    "    print(f\"{nom:28s} {mots:4d} mots-espace, {len(texte)} caractères\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc7267b6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005048,
+     "end_time": "2026-08-25T17:24:11.849770+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:11.844722+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Le corpus littéraire compte ~21 lignes de prose versifiée retranscrite ; le corpus juridique ~13 lignes denses. **Fils rouges** : toutes les analyses des sections 2 à 6 portent sur ces deux textes, jamais sur d'autres.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3278c27",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005488,
+     "end_time": "2026-08-25T17:24:11.861387+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:11.855899+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Tokenisation en mots — ce que « un mot » veut dire\n",
+    "\n",
+    "Avant tout calcul, il faut trancher : « l'odeur » est-il **un** mot ou **deux** ? La tokenisation linguistique sépare l'élision (`l'` + `odeur`), isole la ponctuation, et distingue les formes fléchies (`chantait`, `chantiez`) comme des tokens distincts. C'est le premier écart avec le BPE — qui découpe *sous* le mot — et avec `str.split()`, qui ne découpe *qu'à l'espace*.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1305854e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:11.872987Z",
+     "iopub.status.busy": "2026-08-25T17:24:11.872987Z",
+     "iopub.status.idle": "2026-08-25T17:24:20.413136Z",
+     "shell.execute_reply": "2026-08-25T17:24:20.412131Z"
+    },
+    "papermill": {
+     "duration": 8.548165,
+     "end_time": "2026-08-25T17:24:20.414641+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:11.866476+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pipeline: ['tok2vec', 'morphologizer', 'parser', 'attribute_ruler', 'lemmatizer', 'ner']\n",
+      "littéraire (fables):\n",
+      "  spaCy            :  373 tokens (299 alphabétiques),  186 types\n",
+      "  str.split()      :  299 tokens,  196 types\n",
+      "  écart tokens     :  +74 (élisions + ponctuation)\n",
+      "juridique (registre RGPD):\n",
+      "  spaCy            :  151 tokens (131 alphabétiques),   86 types\n",
+      "  str.split()      :  135 tokens,   91 types\n",
+      "  écart tokens     :  +16 (élisions + ponctuation)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import spacy\n",
+    "\n",
+    "# Modele installe dans l'environnement (python -m spacy download fr_core_news_sm),\n",
+    "# aucun telechargement au chargement. fr_core_news_sm : pipeline leger, CPU.\n",
+    "nlp = spacy.load(\"fr_core_news_sm\")\n",
+    "print(\"Pipeline:\", nlp.pipe_names)\n",
+    "\n",
+    "DOCS = {nom: nlp(texte) for nom, texte in CORPUS.items()}\n",
+    "\n",
+    "for nom, doc in DOCS.items():\n",
+    "    toks = [t for t in doc if not t.is_space]\n",
+    "    mots = [t for t in toks if t.is_alpha]\n",
+    "    split = CORPUS[nom].split()\n",
+    "    print(f\"{nom}:\")\n",
+    "    print(f\"  spaCy            : {len(toks):4d} tokens ({len(mots)} alphabétiques), {len(set(t.text.lower() for t in mots)):4d} types\")\n",
+    "    print(f\"  str.split()      : {len(split):4d} tokens, {len(set(w.lower() for w in split)):4d} types\")\n",
+    "    print(f\"  écart tokens     : {len(toks) - len(split):+4d} (élisions + ponctuation)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c684f011",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005,
+     "end_time": "2026-08-25T17:24:20.425646+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:20.420646+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "spaCy produit **plus de tokens** que `str.split()` (+74 sur les fables) : chaque signe de ponctuation et chaque élision (`l'`, `qu'`, `n'`) devient un token. Les *types* (tokens distincts), eux, **diminuent** (186 contre 196) : dans `split()`, la ponctuation collée au mot fabrique des faux types (`perché,` ≠ `perché`), alors que spaCy l'isole systématiquement. La baisse suivante viendra de la lemmatisation : les formes fléchies du verbe `chanter` (`chantais`, `chantiez`, `chanté`) comptent pour trois types en surface, pour un seul une fois lemmatisées — c'est ce que la section suivante mesure.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e945fb4d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006,
+     "end_time": "2026-08-25T17:24:20.437474+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:20.431474+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Lemmes, parties du discours et traits morphologiques\n",
+    "\n",
+    "La **lemmatisation** ramène chaque forme fléchie à sa forme canonique (`tint` → `tenir`, `alléché` → `allécher`). L'étiquetage **morphosyntaxique** (POS) attribue une catégorie à chaque token, et les **traits morphologiques** précisent genre, nombre, temps, personne.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8a4b725b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:20.451209Z",
+     "iopub.status.busy": "2026-08-25T17:24:20.450197Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.022572Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.021062Z"
+    },
+    "papermill": {
+     "duration": 0.579981,
+     "end_time": "2026-08-25T17:24:21.023342+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:20.443361+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>TEXT</th>\n",
+       "      <th>LEMMA</th>\n",
+       "      <th>POS</th>\n",
+       "      <th>MORPH</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Maître</td>\n",
+       "      <td>maître</td>\n",
+       "      <td>NOUN</td>\n",
+       "      <td>Gender=Masc|Number=Sing</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Corbeau</td>\n",
+       "      <td>Corbeau</td>\n",
+       "      <td>PROPN</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>,</td>\n",
+       "      <td>,</td>\n",
+       "      <td>PUNCT</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>sur</td>\n",
+       "      <td>sur</td>\n",
+       "      <td>ADP</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>un</td>\n",
+       "      <td>un</td>\n",
+       "      <td>DET</td>\n",
+       "      <td>Definite=Ind|Gender=Masc|Number=Sing|PronType=Art</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>arbre</td>\n",
+       "      <td>arbre</td>\n",
+       "      <td>NOUN</td>\n",
+       "      <td>Gender=Masc|Number=Sing</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>perché</td>\n",
+       "      <td>percher</td>\n",
+       "      <td>ADJ</td>\n",
+       "      <td>Gender=Masc|Number=Sing</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>,</td>\n",
+       "      <td>,</td>\n",
+       "      <td>PUNCT</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>tenait</td>\n",
+       "      <td>tenir</td>\n",
+       "      <td>VERB</td>\n",
+       "      <td>Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbFo...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>en</td>\n",
+       "      <td>en</td>\n",
+       "      <td>ADP</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>son</td>\n",
+       "      <td>son</td>\n",
+       "      <td>DET</td>\n",
+       "      <td>Number=Sing|Poss=Yes</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>bec</td>\n",
+       "      <td>bec</td>\n",
+       "      <td>NOUN</td>\n",
+       "      <td>Gender=Masc|Number=Sing</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>un</td>\n",
+       "      <td>un</td>\n",
+       "      <td>DET</td>\n",
+       "      <td>Definite=Ind|Gender=Masc|Number=Sing|PronType=Art</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>fromage</td>\n",
+       "      <td>fromage</td>\n",
+       "      <td>NOUN</td>\n",
+       "      <td>Gender=Masc|Number=Sing</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>.</td>\n",
+       "      <td>.</td>\n",
+       "      <td>PUNCT</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>Maître</td>\n",
+       "      <td>maître</td>\n",
+       "      <td>NOUN</td>\n",
+       "      <td>Gender=Masc|Number=Sing</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>Renard</td>\n",
+       "      <td>Renard</td>\n",
+       "      <td>PROPN</td>\n",
+       "      <td>Gender=Masc|Number=Sing</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       TEXT    LEMMA    POS                                              MORPH\n",
+       "0    Maître   maître   NOUN                            Gender=Masc|Number=Sing\n",
+       "1   Corbeau  Corbeau  PROPN                                                   \n",
+       "2         ,        ,  PUNCT                                                   \n",
+       "3       sur      sur    ADP                                                   \n",
+       "4        un       un    DET  Definite=Ind|Gender=Masc|Number=Sing|PronType=Art\n",
+       "5     arbre    arbre   NOUN                            Gender=Masc|Number=Sing\n",
+       "6    perché  percher    ADJ                            Gender=Masc|Number=Sing\n",
+       "7         ,        ,  PUNCT                                                   \n",
+       "8    tenait    tenir   VERB  Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbFo...\n",
+       "9        en       en    ADP                                                   \n",
+       "10      son      son    DET                               Number=Sing|Poss=Yes\n",
+       "11      bec      bec   NOUN                            Gender=Masc|Number=Sing\n",
+       "12       un       un    DET  Definite=Ind|Gender=Masc|Number=Sing|PronType=Art\n",
+       "13  fromage  fromage   NOUN                            Gender=Masc|Number=Sing\n",
+       "14        .        .  PUNCT                                                   \n",
+       "15   Maître   maître   NOUN                            Gender=Masc|Number=Sing\n",
+       "16   Renard   Renard  PROPN                            Gender=Masc|Number=Sing"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def table_annot(doc, phrases=2, max_tok=14):\n",
+    "    \"\"\"Tableau TEXT | LEMMA | POS | MORPH des premiers tokens de chaque phrase.\"\"\"\n",
+    "    seen = []\n",
+    "    for sent in list(doc.sents)[:phrases]:\n",
+    "        rows = [(t.text, t.lemma_, t.pos_, str(t.morph)) for t in sent if not t.is_space][:max_tok]\n",
+    "        seen.extend(rows)\n",
+    "    return seen\n",
+    "\n",
+    "import pandas as pd\n",
+    "rows = table_annot(DOCS[\"littéraire (fables)\"])\n",
+    "display(pd.DataFrame(rows, columns=[\"TEXT\", \"LEMMA\", \"POS\", \"MORPH\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "577f3e3d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.035744Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.035218Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.047806Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.046744Z"
+    },
+    "papermill": {
+     "duration": 0.020146,
+     "end_time": "2026-08-25T17:24:21.048866+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.028720+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>TEXT</th>\n",
+       "      <th>LEMMA</th>\n",
+       "      <th>POS</th>\n",
+       "      <th>MORPH</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>La</td>\n",
+       "      <td>le</td>\n",
+       "      <td>DET</td>\n",
+       "      <td>Definite=Def|Gender=Fem|Number=Sing|PronType=Art</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>CNIL</td>\n",
+       "      <td>cnil</td>\n",
+       "      <td>NOUN</td>\n",
+       "      <td>Gender=Fem|Number=Sing</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>a</td>\n",
+       "      <td>avoir</td>\n",
+       "      <td>AUX</td>\n",
+       "      <td>Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbF...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>vérifié</td>\n",
+       "      <td>vérifier</td>\n",
+       "      <td>VERB</td>\n",
+       "      <td>Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>en</td>\n",
+       "      <td>en</td>\n",
+       "      <td>ADP</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>mars</td>\n",
+       "      <td>mars</td>\n",
+       "      <td>NOUN</td>\n",
+       "      <td>Gender=Masc|Number=Sing</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>2024</td>\n",
+       "      <td>NUM</td>\n",
+       "      <td>NumType=Card</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>que</td>\n",
+       "      <td>que</td>\n",
+       "      <td>SCONJ</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>la</td>\n",
+       "      <td>le</td>\n",
+       "      <td>DET</td>\n",
+       "      <td>Definite=Def|Gender=Fem|Number=Sing|PronType=Art</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>société</td>\n",
+       "      <td>société</td>\n",
+       "      <td>NOUN</td>\n",
+       "      <td>Gender=Fem|Number=Sing</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>Acme</td>\n",
+       "      <td>Acme</td>\n",
+       "      <td>PROPN</td>\n",
+       "      <td>Gender=Masc|Number=Sing</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>SAS</td>\n",
+       "      <td>SAS</td>\n",
+       "      <td>PROPN</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>conservait</td>\n",
+       "      <td>conserver</td>\n",
+       "      <td>VERB</td>\n",
+       "      <td>Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbFo...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>les</td>\n",
+       "      <td>le</td>\n",
+       "      <td>DET</td>\n",
+       "      <td>Definite=Def|Number=Plur|PronType=Art</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>données</td>\n",
+       "      <td>donnée</td>\n",
+       "      <td>NOUN</td>\n",
+       "      <td>Gender=Fem|Number=Plur</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>personnelles</td>\n",
+       "      <td>personnel</td>\n",
+       "      <td>ADJ</td>\n",
+       "      <td>Gender=Fem|Number=Plur</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            TEXT      LEMMA    POS  \\\n",
+       "0             La         le    DET   \n",
+       "1           CNIL       cnil   NOUN   \n",
+       "2              a      avoir    AUX   \n",
+       "3        vérifié   vérifier   VERB   \n",
+       "4             en         en    ADP   \n",
+       "5           mars       mars   NOUN   \n",
+       "6           2024       2024    NUM   \n",
+       "7            que        que  SCONJ   \n",
+       "8             la         le    DET   \n",
+       "9        société    société   NOUN   \n",
+       "10          Acme       Acme  PROPN   \n",
+       "11           SAS        SAS  PROPN   \n",
+       "12    conservait  conserver   VERB   \n",
+       "13           les         le    DET   \n",
+       "14       données     donnée   NOUN   \n",
+       "15  personnelles  personnel    ADJ   \n",
+       "\n",
+       "                                                MORPH  \n",
+       "0    Definite=Def|Gender=Fem|Number=Sing|PronType=Art  \n",
+       "1                              Gender=Fem|Number=Sing  \n",
+       "2   Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbF...  \n",
+       "3    Gender=Masc|Number=Sing|Tense=Past|VerbForm=Part  \n",
+       "4                                                      \n",
+       "5                             Gender=Masc|Number=Sing  \n",
+       "6                                        NumType=Card  \n",
+       "7                                                      \n",
+       "8    Definite=Def|Gender=Fem|Number=Sing|PronType=Art  \n",
+       "9                              Gender=Fem|Number=Sing  \n",
+       "10                            Gender=Masc|Number=Sing  \n",
+       "11                                                     \n",
+       "12  Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbFo...  \n",
+       "13              Definite=Def|Number=Plur|PronType=Art  \n",
+       "14                             Gender=Fem|Number=Plur  \n",
+       "15                             Gender=Fem|Number=Plur  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rows_jur = table_annot(DOCS[\"juridique (registre RGPD)\"], phrases=1, max_tok=16)\n",
+    "display(pd.DataFrame(rows_jur, columns=[\"TEXT\", \"LEMMA\", \"POS\", \"MORPH\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f758085c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006092,
+     "end_time": "2026-08-25T17:24:21.060786+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.054694+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Sur le corpus littéraire : `tint` → `tenir`, `alléché` → `allécher`, `êtes` → `être` — la lemmatisation traverse l'irrégularité des verbes du 3ᵉ groupe. Sur le corpus juridique : `conservait` → `conserver` avec `Number=Sing|Person=3|Tense=Imp`, `européens` → `européen` avec `Number=Plur`. Les traits `Gender=Fem|Number=Sing` sur `la durée` préparent les **accords** — information qu'aucun tokenizer BPE ne transporte.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd7ddabe",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006412,
+     "end_time": "2026-08-25T17:24:21.073430+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.067018+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Dépendances syntaxiques — qui dépend de qui\n",
+    "\n",
+    "L'analyse en dépendances relie chaque token à son **gouverneur** par une relation typée (`nsubj`, `obj`, `obl:mod`, `det`…). C'est la structure qui permet d'extraire des tripleaux *sujet-verbe-objet*, indépendamment de l'ordre des mots.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "16d0706a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.088025Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.088025Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.105632Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.104605Z"
+    },
+    "papermill": {
+     "duration": 0.027185,
+     "end_time": "2026-08-25T17:24:21.106633+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.079448+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xml:lang=\"fr\" id=\"facf44e1b683413f8020627ea6b4e9a2-0\" class=\"displacy\" width=\"350\" height=\"212.0\" direction=\"ltr\" style=\"max-width: none; height: 212.0px; color: #000000; background: #ffffff; font-family: Arial; direction: ltr\">\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"122.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"50\">Maître</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"50\">NOUN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"122.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"200\">Corbeau,</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"200\">PROPN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-facf44e1b683413f8020627ea6b4e9a2-0-0\" stroke-width=\"2px\" d=\"M62,77.0 62,52.0 200.0,52.0 200.0,77.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-facf44e1b683413f8020627ea6b4e9a2-0-0\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">flat:name</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M200.0,79.0 L204.0,71.0 196.0,71.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "</svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xml:lang=\"fr\" id=\"ffe2e61f9d0844338f2e8f8a8883237e-0\" class=\"displacy\" width=\"4850\" height=\"512.0\" direction=\"ltr\" style=\"max-width: none; height: 512.0px; color: #000000; background: #ffffff; font-family: Arial; direction: ltr\">\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"50\">La</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"50\">DET</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"200\">CNIL</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"200\">NOUN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"350\">a</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"350\">AUX</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"500\">vérifié</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"500\">VERB</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"650\">en</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"650\">ADP</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"800\">mars</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"800\">NOUN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"950\">2024</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"950\">NUM</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"1100\">que</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"1100\">SCONJ</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"1250\">la</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"1250\">DET</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"1400\">société</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"1400\">NOUN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"1550\">Acme</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"1550\">PROPN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"1700\">SAS</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"1700\">PROPN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"1850\">conservait</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"1850\">VERB</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"2000\">les</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"2000\">DET</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"2150\">données</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"2150\">NOUN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"2300\">personnelles</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"2300\">ADJ</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"2450\">\n",
+       "</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"2450\">SPACE</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"2600\">de</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"2600\">ADP</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"2750\">ses</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"2750\">DET</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"2900\">clients</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"2900\">NOUN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"3050\">européens</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"3050\">ADJ</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"3200\">conformément</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"3200\">ADV</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"3350\">au</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"3350\">ADP</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"3500\">RGPD</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"3500\">PROPN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"3650\">et</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"3650\">CCONJ</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"3800\">à</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"3800\">ADP</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"3950\">la</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"3950\">DET</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"4100\">loi</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"4100\">NOUN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"4250\">Informatique</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"4250\">PROPN</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"4400\">et</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"4400\">CCONJ</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"4550\">Libertés.</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"4550\">PUNCT</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<text class=\"displacy-token\" fill=\"currentColor\" text-anchor=\"middle\" y=\"422.0\">\n",
+       "    <tspan class=\"displacy-word\" fill=\"currentColor\" x=\"4700\">\n",
+       "</tspan>\n",
+       "    <tspan class=\"displacy-tag\" dy=\"2em\" fill=\"currentColor\" x=\"4700\">SPACE</tspan>\n",
+       "</text>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-0\" stroke-width=\"2px\" d=\"M62,377.0 62,352.0 188.0,352.0 188.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-0\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">det</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M62,379.0 L58,371.0 66,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-1\" stroke-width=\"2px\" d=\"M212,377.0 212,327.0 491.0,327.0 491.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-1\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">nsubj</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M212,379.0 L208,371.0 216,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-2\" stroke-width=\"2px\" d=\"M362,377.0 362,352.0 488.0,352.0 488.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-2\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">aux:tense</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M362,379.0 L358,371.0 366,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-3\" stroke-width=\"2px\" d=\"M662,377.0 662,352.0 788.0,352.0 788.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-3\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">case</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M662,379.0 L658,371.0 666,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-4\" stroke-width=\"2px\" d=\"M512,377.0 512,327.0 791.0,327.0 791.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-4\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">obl:mod</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M791.0,379.0 L795.0,371.0 787.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-5\" stroke-width=\"2px\" d=\"M812,377.0 812,352.0 938.0,352.0 938.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-5\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">nmod</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M938.0,379.0 L942.0,371.0 934.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-6\" stroke-width=\"2px\" d=\"M1112,377.0 1112,302.0 1844.0,302.0 1844.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-6\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">mark</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M1112,379.0 L1108,371.0 1116,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-7\" stroke-width=\"2px\" d=\"M1262,377.0 1262,352.0 1388.0,352.0 1388.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-7\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">det</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M1262,379.0 L1258,371.0 1266,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-8\" stroke-width=\"2px\" d=\"M1412,377.0 1412,327.0 1841.0,327.0 1841.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-8\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">nsubj</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M1412,379.0 L1408,371.0 1416,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-9\" stroke-width=\"2px\" d=\"M1412,377.0 1412,352.0 1538.0,352.0 1538.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-9\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">appos</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M1538.0,379.0 L1542.0,371.0 1534.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-10\" stroke-width=\"2px\" d=\"M1562,377.0 1562,352.0 1688.0,352.0 1688.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-10\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">flat:name</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M1688.0,379.0 L1692.0,371.0 1684.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-11\" stroke-width=\"2px\" d=\"M512,377.0 512,277.0 1847.0,277.0 1847.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-11\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">ccomp</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M1847.0,379.0 L1851.0,371.0 1843.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-12\" stroke-width=\"2px\" d=\"M2012,377.0 2012,352.0 2138.0,352.0 2138.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-12\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">det</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M2012,379.0 L2008,371.0 2016,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-13\" stroke-width=\"2px\" d=\"M1862,377.0 1862,327.0 2141.0,327.0 2141.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-13\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">obj</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M2141.0,379.0 L2145.0,371.0 2137.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-14\" stroke-width=\"2px\" d=\"M2162,377.0 2162,352.0 2288.0,352.0 2288.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-14\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">amod</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M2288.0,379.0 L2292.0,371.0 2284.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-15\" stroke-width=\"2px\" d=\"M2312,377.0 2312,352.0 2438.0,352.0 2438.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-15\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">dep</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M2438.0,379.0 L2442.0,371.0 2434.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-16\" stroke-width=\"2px\" d=\"M2612,377.0 2612,327.0 2891.0,327.0 2891.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-16\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">case</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M2612,379.0 L2608,371.0 2616,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-17\" stroke-width=\"2px\" d=\"M2762,377.0 2762,352.0 2888.0,352.0 2888.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-17\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">det</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M2762,379.0 L2758,371.0 2766,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-18\" stroke-width=\"2px\" d=\"M2312,377.0 2312,302.0 2894.0,302.0 2894.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-18\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">obl:arg</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M2894.0,379.0 L2898.0,371.0 2890.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-19\" stroke-width=\"2px\" d=\"M2912,377.0 2912,352.0 3038.0,352.0 3038.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-19\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">amod</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M3038.0,379.0 L3042.0,371.0 3034.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-20\" stroke-width=\"2px\" d=\"M1862,377.0 1862,277.0 3197.0,277.0 3197.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-20\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">advmod</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M3197.0,379.0 L3201.0,371.0 3193.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-21\" stroke-width=\"2px\" d=\"M3362,377.0 3362,352.0 3488.0,352.0 3488.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-21\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">case</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M3362,379.0 L3358,371.0 3366,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-22\" stroke-width=\"2px\" d=\"M3212,377.0 3212,327.0 3491.0,327.0 3491.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-22\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">obl:arg</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M3491.0,379.0 L3495.0,371.0 3487.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-23\" stroke-width=\"2px\" d=\"M3662,377.0 3662,302.0 4094.0,302.0 4094.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-23\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">cc</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M3662,379.0 L3658,371.0 3666,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-24\" stroke-width=\"2px\" d=\"M3812,377.0 3812,327.0 4091.0,327.0 4091.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-24\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">case</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M3812,379.0 L3808,371.0 3816,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-25\" stroke-width=\"2px\" d=\"M3962,377.0 3962,352.0 4088.0,352.0 4088.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-25\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">det</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M3962,379.0 L3958,371.0 3966,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-26\" stroke-width=\"2px\" d=\"M3512,377.0 3512,277.0 4097.0,277.0 4097.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-26\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">conj</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M4097.0,379.0 L4101.0,371.0 4093.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-27\" stroke-width=\"2px\" d=\"M4112,377.0 4112,352.0 4238.0,352.0 4238.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-27\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">amod</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M4238.0,379.0 L4242.0,371.0 4234.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-28\" stroke-width=\"2px\" d=\"M4412,377.0 4412,352.0 4538.0,352.0 4538.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-28\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">cc</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M4412,379.0 L4408,371.0 4416,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-29\" stroke-width=\"2px\" d=\"M512,377.0 512,252.0 4550.0,252.0 4550.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-29\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">punct</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M4550.0,379.0 L4554.0,371.0 4546.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "\n",
+       "<g class=\"displacy-arrow\">\n",
+       "    <path class=\"displacy-arc\" id=\"arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-30\" stroke-width=\"2px\" d=\"M4562,377.0 4562,352.0 4688.0,352.0 4688.0,377.0\" fill=\"none\" stroke=\"currentColor\"/>\n",
+       "    <text dy=\"1.25em\" style=\"font-size: 0.8em; letter-spacing: 1px\">\n",
+       "        <textPath xlink:href=\"#arrow-ffe2e61f9d0844338f2e8f8a8883237e-0-30\" class=\"displacy-label\" startOffset=\"50%\" side=\"left\" fill=\"currentColor\" text-anchor=\"middle\">dep</textPath>\n",
+       "    </text>\n",
+       "    <path class=\"displacy-arrowhead\" d=\"M4688.0,379.0 L4692.0,371.0 4684.0,371.0\" fill=\"currentColor\"/>\n",
+       "</g>\n",
+       "</svg>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from spacy import displacy\n",
+    "from IPython.display import HTML, display\n",
+    "\n",
+    "# Deux phrases exemplaires : une fable, une phrase juridique longue.\n",
+    "sent_fable = next(DOCS[\"littéraire (fables)\"].sents)\n",
+    "sent_jur = next(DOCS[\"juridique (registre RGPD)\"].sents)\n",
+    "\n",
+    "for s in (sent_fable, sent_jur):\n",
+    "    svg = displacy.render(s, style=\"dep\", jupyter=False, options={\"collapse_punct\": True, \"compact\": True})\n",
+    "    display(HTML(svg))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d7f18910",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.121906Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.121906Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.130078Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.129070Z"
+    },
+    "papermill": {
+     "duration": 0.016375,
+     "end_time": "2026-08-25T17:24:21.130078+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.113703+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- littéraire (fables)\n",
+      "    ('—', 'tenir', 'fromage Maître')\n",
+      "    ('—', 'tenir', 'lui')\n",
+      "    ('vous', 'sembler', 'me beau')\n",
+      "    ('ramage', 'rapporter', '—')\n",
+      "    ('on', 'prendre', \"l' y\")\n",
+      "    ('cigale', 'chanter', 'été')\n",
+      "    ('bise', 'venir', '—')\n",
+      "    ('elle', 'aller', '—')\n",
+      "--- juridique (registre RGPD)\n",
+      "    ('CNIL', 'vérifier', '—')\n",
+      "    ('société', 'conserver', 'données')\n",
+      "    ('—', 'mentionner', 'finalité')\n",
+      "    ('durée', 'fixer', '—')\n",
+      "    ('personnes', 'pouvoir', '—')\n",
+      "    ('—', 'exercer', 'droits')\n",
+      "    ('Acme', 'notifier', 'CNIL')\n",
+      "    ('—', 'héberger', 'données')\n"
+     ]
+    }
+   ],
+   "source": [
+    "def svo(doc):\n",
+    "    \"\"\"Tripleaux (sujet, verbe, objet) detectes par les relations de dependance.\"\"\"\n",
+    "    out = []\n",
+    "    for t in doc:\n",
+    "        if t.pos_ == \"VERB\":\n",
+    "            sujets = [w.text for w in t.children if w.dep_ in (\"nsubj\", \"nsubj:pass\")]\n",
+    "            objets = [w.text for w in t.children if w.dep_ in (\"obj\", \"iobj\")]\n",
+    "            if sujets or objets:\n",
+    "                out.append((\" \".join(sujets) or \"—\", t.lemma_, \" \".join(objets) or \"—\"))\n",
+    "    return out\n",
+    "\n",
+    "for nom, doc in DOCS.items():\n",
+    "    print(f\"--- {nom}\")\n",
+    "    for t in svo(doc)[:8]:\n",
+    "        print(\"   \", t)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61688f80",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005535,
+     "end_time": "2026-08-25T17:24:21.143189+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.137654+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Les tripleaux du corpus juridique sont denses et réguliers (`CNIL | vérifier | —`, `Acme | notifier | CNIL`) : la voix passive `a été fixée` produit un `nsubj:pass` (`durée | fixer | —`). Sur les fables, les phrases coordonnées sans sujet explicite (`— | tenir | fromage Maître` : le sujet de `tint` est le renard de la phrase précédente) illustrent les sujets elliptiques du français — un phénomène que l'exercice 2 fera chercher systématiquement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03da90fc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005599,
+     "end_time": "2026-08-25T17:24:21.154647+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.149048+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Entités nommées — les référents du texte\n",
+    "\n",
+    "Le NER (named entity recognition) étiquette les mentions de personnes (`PER`), lieux (`LOC`), organisations (`ORG`), montants, dates et divers (`MISC`). Nos deux domaines exercent des comportements opposés : le corpus juridique contient des entités *réelles* (CNIL, RGPD, Acme SAS, mars 2024) ; les fables contiennent des entités *fictionnelles* (Maître Corbeau) et des majuscules non-entités (Hé, Nuit).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "746ff7a5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.168162Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.168162Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.175345Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.174341Z"
+    },
+    "papermill": {
+     "duration": 0.014708,
+     "end_time": "2026-08-25T17:24:21.175345+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.160637+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- littéraire (fables) : 6 entités\n",
+      "    PER      ×3 : ['Corbeau', 'Maître Renard', 'Perrette']\n",
+      "    LOC      ×2 : ['le Phénix', 'jura']\n",
+      "    MISC     ×1 : ['Monsieur du Corbeau']\n",
+      "--- juridique (registre RGPD) : 8 entités\n",
+      "    ORG      ×5 : ['CNIL', 'Acme SAS', 'RGPD', 'CNIL', 'Union européenne']\n",
+      "    PER      ×2 : ['Libertés', 'Acme SAS']\n",
+      "    LOC      ×1 : ['Informatique']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "for nom, doc in DOCS.items():\n",
+    "    ents = [(e.text, e.label_) for e in doc.ents]\n",
+    "    par_label = Counter(l for _, l in ents)\n",
+    "    print(f\"--- {nom} : {len(ents)} entités\")\n",
+    "    for lbl, n in par_label.most_common():\n",
+    "        print(f\"    {lbl:8s} ×{n} : {[t for t, l in ents if l == lbl][:6]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cbda2452",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.188848Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.188848Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.196106Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.195598Z"
+    },
+    "papermill": {
+     "duration": 0.015763,
+     "end_time": "2026-08-25T17:24:21.197108+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.181345+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"entities\" style=\"line-height: 2.5; direction: ltr\">La  <mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;\">     CNIL     <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-left: 0.5rem\">ORG</span> </mark>  a vérifié en mars 2024 que la société  <mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;\">     Acme SAS     <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-left: 0.5rem\">ORG</span> </mark>  conservait les données personnelles<br>de ses clients européens conformément au  <mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;\">     RGPD     <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-left: 0.5rem\">ORG</span> </mark>  et à la loi  <mark class=\"entity\" style=\"background: #ff9561; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;\">     Informatique     <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-left: 0.5rem\">LOC</span> </mark>  et  <mark class=\"entity\" style=\"background: #ddd; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;\">     Libertés     <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-left: 0.5rem\">PER</span> </mark> .<br>Le registre des traitements mentionne la finalité, la base légale et la durée de conservation<br>de chaque catégorie d'informations. La durée maximale de conservation des historiques<br>d'achat a été fixée à trois ans après le dernier contact commercial.<br>Les personnes concernées peuvent exercer leurs droits d'accès, de rectification<br>et d'effacement auprès du délégué à la protection des données, par courriel<br>à l'adresse dpo@acme.example. En cas de violation de données,  <mark class=\"entity\" style=\"background: #ddd; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;\">     Acme SAS     <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-left: 0.5rem\">PER</span> </mark>  notifie<br>la  <mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;\">     CNIL     <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-left: 0.5rem\">ORG</span> </mark>  dans les soixante-douze heures et informe les clients concernés.<br>Les sous-traitants hébergeant les données en dehors de l' <mark class=\"entity\" style=\"background: #7aecec; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;\">     Union européenne     <span style=\"font-size: 0.8em; font-weight: bold; line-height: 1; border-radius: 0.35em; vertical-align: middle; margin-left: 0.5rem\">ORG</span> </mark> <br>doivent garantir un niveau de protection adéquat selon les clauses contractuelles types.</div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Rendu surligne des entites du registre RGPD (meme moteur que les arcs de la section 4).\n",
+    "svg_ents = displacy.render(DOCS[\"juridique (registre RGPD)\"], style=\"ent\", jupyter=False)\n",
+    "display(HTML(svg_ents.replace(\"\\n\", \" \")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5906b61",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006473,
+     "end_time": "2026-08-25T17:24:21.210649+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.204176+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "À confronter à la section 7 (analyse d'erreurs) : le modèle détecte les organisations du registre (`CNIL`, `Acme SAS`, `RGPD`), mais — typique d'un pipeline `sm` entraîné sur de la prose journalistique — il est **erratique dans les zones grises** : `Acme SAS` étiquetée `ORG` à une occurrence et `PER` à l'autre ; `Libertés` (de la *loi Informatique et Libertés*) vue comme une personne et `Informatique` comme un lieu ; sur les fables, le verbe `jura` étiqueté `LOC` et les personnages fictionnels (`Corbeau`, `Maître Renard`) vus comme des personnes réelles. Chaque affirmation de cette lecture se **vérifie** dans la section suivante contre un jeu d'or annoté à la main.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "422c6133",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006043,
+     "end_time": "2026-08-25T17:24:21.223689+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.217646+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Mots vs BPE — la comparaison frontale\n",
+    "\n",
+    "Le notebook 04 construisait un BPE *from scratch* sur ce même corpus de fables et mesurait le compromis *taille de vocabulaire ↔ tokens par mot*. Ici nous reconstruisons ce mini-BPE (même algorithme, mêmes données) et comparons les **trois représentations** : mots spaCy, mots `split()`, sous-mots BPE.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "fc8e89b5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.241557Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.240597Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.293294Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.293294Z"
+    },
+    "papermill": {
+     "duration": 0.062584,
+     "end_time": "2026-08-25T17:24:21.294298+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.231714+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokens mots (spaCy, formes) :  299 tokens,  186 types\n",
+      "Tokens mots (lemmes)        :  299 tokens,  167 types\n",
+      "Sous-mots BPE (60 fusions)  :  658 tokens,   33 types\n",
+      "\n",
+      "'anticonstitutionnellement' : 25 caractères = 1 lemme = 25 sous-mots BPE non fusionnés\n"
+     ]
+    }
+   ],
+   "source": [
+    "import re, collections\n",
+    "\n",
+    "# Mini-BPE identique a la pedagogie du notebook 04 : fusions par paires les plus frequentes.\n",
+    "WORDS = re.findall(r\"[a-zà-ÿ'éèêëïôöûüç0-9-]+\", FABLES_TEXT.lower())\n",
+    "\n",
+    "def train_bpe(words, n_merges):\n",
+    "    seqs = [list(w) for w in words]\n",
+    "    merges = []\n",
+    "    for _ in range(n_merges):\n",
+    "        pairs = collections.Counter()\n",
+    "        for s in seqs:\n",
+    "            for a, b in zip(s, s[1:]):\n",
+    "                pairs[(a, b)] += 1\n",
+    "        if not pairs:\n",
+    "            break\n",
+    "        best = max(pairs, key=pairs.get)\n",
+    "        merges.append(best)\n",
+    "        seqs = [[a + b[1:] if (a, b) == best and j < len(s) - 1 and (s[j], s[j+1]) == best else s[j]\n",
+    "                 for j in range(len(s)) if not (j < len(s) - 1 and (s[j], s[j+1]) == best)]\n",
+    "                for s in seqs]\n",
+    "    vocab = {tok for s in seqs for tok in s}\n",
+    "    return merges, vocab, seqs\n",
+    "\n",
+    "merges, vocab_bpe, seqs = train_bpe(WORDS, 60)\n",
+    "\n",
+    "mots_spacy = [t.text.lower() for t in DOCS[\"littéraire (fables)\"] if t.is_alpha]\n",
+    "lemmes = [t.lemma_.lower() for t in DOCS[\"littéraire (fables)\"] if t.is_alpha]\n",
+    "\n",
+    "print(f\"Tokens mots (spaCy, formes) : {len(mots_spacy):4d} tokens, {len(set(mots_spacy)):4d} types\")\n",
+    "print(f\"Tokens mots (lemmes)        : {len(lemmes):4d} tokens, {len(set(lemmes)):4d} types\")\n",
+    "print(f\"Sous-mots BPE (60 fusions)  : {sum(len(s) for s in seqs):4d} tokens, {len(vocab_bpe):4d} types\")\n",
+    "\n",
+    "# Le mot emblematique : decoupage BPE vs lemme.\n",
+    "exemple = \"anticonstitutionnellement\"\n",
+    "print(f\"\\n{exemple!r} : {len(exemple)} caractères = 1 lemme = {len(train_bpe([exemple]*1, 0)[2][0])} sous-mots BPE non fusionnés\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8802ac2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007012,
+     "end_time": "2026-08-25T17:24:21.308242+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.301230+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Trois représentations, trois compromis mesurés sur **le même texte** :\n",
+    "\n",
+    "- **mots (formes)** : vocabulaire le plus large — 186 types, chaque flexion compte ;\n",
+    "- **lemmes** : 167 types (−10 %) — la lemmatisation *compresse* le vocabulaire, mais par **connaissance linguistique** (un seul type pour `chantais/chantiez/chanté`) au lieu de **fréquence statistique** ;\n",
+    "- **BPE** : aucun mot inconnu (un mot nouveau se décompose en sous-mots vus), au prix d'une perte totale des frontières de mots et des traits morphologiques.\n",
+    "\n",
+    "Le pont avec le notebook 04 : le BPE répond à « comment tout encoder sans rien connaître » ; le pipeline TAL répond à « quoi dire de ce que l'on a encodé ». Les systèmes de recherche et de GraphRAG (cas d'usage, section 8) utilisent le **second** sur le texte une fois retrouvé, le **premier** pour retrouver le texte.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c41d100",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007521,
+     "end_time": "2026-08-25T17:24:21.322273+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.314752+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Analyse d'erreurs — mesurer contre un jeu d'or\n",
+    "\n",
+    "Un modèle `sm` (léger, CPU) fait des erreurs ; l'important est de les **mesurer**. Nous annotons à la main un petit jeu d'or sur les phénomènes annoncés, puis comparons annotation et prédiction, phénomène par phénomène.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "bbf965f6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.339952Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.338393Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.351139Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.349574Z"
+    },
+    "papermill": {
+     "duration": 0.022235,
+     "end_time": "2026-08-25T17:24:21.352102+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.329867+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lemmatisation : 8/8 corrects\n",
+      "   tint             → tenir          (attendu tenir) OK\n",
+      "   alléché          → allécher       (attendu allécher) OK\n",
+      "   êtes             → être           (attendu être) OK\n",
+      "   chantiez         → chanter        (attendu chanter) OK\n",
+      "   désaltéraient    → désaltérer     (attendu désaltérer) OK\n",
+      "   conservait       → conserver      (attendu conserver) OK\n",
+      "   vérifié          → vérifier       (attendu vérifier) OK\n",
+      "   européens        → européen       (attendu européen) OK\n",
+      "\n",
+      "NER juridique : entités prédites = 6\n",
+      "   CNIL                   → ORG    (attendu ORG) OK\n",
+      "   Acme SAS               → PER    (attendu ORG) confondue (PER)\n",
+      "   RGPD                   → ORG    (attendu ORG) OK\n",
+      "   mars 2024              → None   (attendu DATE) manquée\n",
+      "   Union européenne       → ORG    (attendu LOC) confondue (ORG)\n",
+      "NER : 2/5 strictement corrects\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Jeu d'or annote a la main (gold) : (token/entite, phenomene, valeur attendue).\n",
+    "GOLD_LEMMES = [(\"tint\", \"tenir\"), (\"alléché\", \"allécher\"), (\"êtes\", \"être\"),\n",
+    "               (\"chantiez\", \"chanter\"), (\"désaltéraient\", \"désaltérer\"),\n",
+    "               (\"conservait\", \"conserver\"), (\"vérifié\", \"vérifier\"), (\"européens\", \"européen\")]\n",
+    "GOLD_NER_JUR = [(\"CNIL\", \"ORG\"), (\"Acme SAS\", \"ORG\"), (\"RGPD\", \"ORG\"),\n",
+    "                (\"mars 2024\", \"DATE\"), (\"Union européenne\", \"LOC\")]\n",
+    "\n",
+    "doc_jur = DOCS[\"juridique (registre RGPD)\"]\n",
+    "doc_fab = DOCS[\"littéraire (fables)\"]\n",
+    "lemmas_all = {t.text: t.lemma_ for doc in DOCS.values() for t in doc}\n",
+    "ner_jur_text = {e.text: e.label_ for e in doc_jur.ents}\n",
+    "\n",
+    "ok_l = sum(1 for tok, gold in GOLD_LEMMES if lemmas_all.get(tok) == gold)\n",
+    "print(f\"Lemmatisation : {ok_l}/{len(GOLD_LEMMES)} corrects\")\n",
+    "for tok, gold in GOLD_LEMMES:\n",
+    "    pred = lemmas_all.get(tok, \"—\")\n",
+    "    print(f\"   {tok:16s} → {pred:14s} (attendu {gold}) {'OK' if pred == gold else 'ECHEC'}\")\n",
+    "\n",
+    "ok_n = 0\n",
+    "print(f\"\\nNER juridique : entités prédites = {len(ner_jur_text)}\")\n",
+    "for ent, gold in GOLD_NER_JUR:\n",
+    "    pred = ner_jur_text.get(ent)\n",
+    "    verdict = \"OK\" if pred == gold else (\"manquée\" if pred is None else f\"confondue ({pred})\")\n",
+    "    ok_n += pred == gold\n",
+    "    print(f\"   {ent:22s} → {str(pred):6s} (attendu {gold}) {verdict}\")\n",
+    "print(f\"NER : {ok_n}/{len(GOLD_NER_JUR)} strictement corrects\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eae489ca",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007289,
+     "end_time": "2026-08-25T17:24:21.367375+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.360086+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Le verdict est **mesuré, pas affirmé** : la lemmatisation réussit sur la totalité du jeu d'or (verbes irréguliers du 3ᵉ groupe inclus), tandis que le NER n'obtient que 2/5 — `mars 2024` plongée dans un groupe prépositionnel n'est pas détectée comme `DATE`, `Union européenne` est étiquetée `ORG` alors que le jeu d'or attend `LOC`, et `Acme SAS` est `PER` à cette occurrence alors qu'elle était `ORG` à la première. **Conclusion opérationnelle** : pour de la recherche ou de l'indexation, les lemmes d'un pipeline `sm` sont fiables ; pour du NER fin, un pipeline `md`/`trf` serait nécessaire — c'est un choix documenté, pas une lacune cachée (cf. §H : le pipeline installé est celui que le notebook exécute réellement).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cda9d51e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008045,
+     "end_time": "2026-08-25T17:24:21.383434+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.375389+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Cas d'usage borné — la recherche lemmatisée\n",
+    "\n",
+    "Question pratique : une requête `conserver` doit-elle retrouver `conservait` ? Une requête `donnée` (singulier) doit-elle retrouver `données` (pluriel) ? Avec des **mots surface**, non. Avec un **index de lemmes**, oui. C'est le mécanisme qui sous-tend la recherche juridique, la veille et le GraphRAG (les nœuds du graphe portent des lemmes, pas des flexions).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8c48b894",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.401505Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.400506Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.409877Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.408872Z"
+    },
+    "papermill": {
+     "duration": 0.020901,
+     "end_time": "2026-08-25T17:24:21.410880+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.389979+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "requête 'conserver'    → ['conservait']\n",
+      "requête 'donnée'       → ['données']\n",
+      "requête 'protection'   → ['protection']\n",
+      "requête 'vérifier'     → ['vérifié']\n",
+      "conserver   : surface 0 forme(s) exacte(s) | lemmatisé 1 forme(s) fléchie(s)\n",
+      "donnée      : surface 0 forme(s) exacte(s) | lemmatisé 1 forme(s) fléchie(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def index_lemmes(doc):\n",
+    "    \"\"\"Index lemme -> formes surface observees (positions).\"\"\"\n",
+    "    idx = collections.defaultdict(set)\n",
+    "    for t in doc:\n",
+    "        if t.is_alpha:\n",
+    "            idx[t.lemma_.lower()].add(t.text.lower())\n",
+    "    return idx\n",
+    "\n",
+    "IDX_JUR = index_lemmes(doc_jur)\n",
+    "\n",
+    "for requete in [\"conserver\", \"donnée\", \"protection\", \"vérifier\"]:\n",
+    "    formes = IDX_JUR.get(requete)\n",
+    "    print(f\"requête {requete!r:14s} → {sorted(formes) if formes else 'AUCUN match'}\")\n",
+    "\n",
+    "# Contre-preuve : recherche surface (formes exactes, ponctuation retiree) sur le meme corpus.\n",
+    "mots_surface = [m.strip('.,;:') for m in REGISTRE_TEXT.lower().split()]\n",
+    "for requete in [\"conserver\", \"donnée\"]:\n",
+    "    n_surface = sum(1 for m in mots_surface if m == requete)\n",
+    "    n_lemmes = len(IDX_JUR.get(requete, set()))\n",
+    "    print(f\"{requete:12s}: surface {n_surface} forme(s) exacte(s) | lemmatisé {n_lemmes} forme(s) fléchie(s)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffc3b502",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008004,
+     "end_time": "2026-08-25T17:24:21.428026+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.420022+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "La requête lemmatisée `conserver` retrouve la forme fléchie `conservait`, et `donnée` retrouve le pluriel `données` — la recherche surface, elle, trouve **zéro** forme exacte pour les deux requêtes (0 occurrence de `conserver` et 0 de `donnée` singulier dans le registre). Limite mesurable de l'autre côté : `conservation` reste un lemme **séparé** — la lemmatisation ne dérive pas le nom depuis le verbe, elle généralise à l'intérieur du paradigme de chaque lemme. C'est la complémentarité de la section 6 : le BPE garantit la couverture de tout mot, le lemme garantit la généralisation *à l'intérieur* du lexique connu.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcf1c1e0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007,
+     "end_time": "2026-08-25T17:24:21.442332+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.435332+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Exercices\n",
+    "\n",
+    "Trois exercices sur les données du notebook. Le notebook doit s'exécuter de bout en bout : les stubs ne lèvent **jamais** d'erreur (règle C.1) — ils affichent un message et rendent `None`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5070c366",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007547,
+     "end_time": "2026-08-25T17:24:21.455918+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.448371+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — le lemme le plus polymorphe\n",
+    "\n",
+    "Quel lemme du corpus littéraire apparaît sous le plus de **formes surface** distinctes ? Complétez `top_lemmes` pour construire l'index inverse de la section 8 sur `doc_fab` et afficher le top-3. *Indice : `collections.Counter` sur `idx[lemme]` par longueur.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "75c31dbb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.471337Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.470335Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.475839Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.475839Z"
+    },
+    "papermill": {
+     "duration": 0.014607,
+     "end_time": "2026-08-25T17:24:21.477350+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.462743+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : top-3 des lemmes par nombre de formes surface distinctes (corpus litteraire).\n",
+    "def top_lemmes(doc, k=3):\n",
+    "    # Etape 1 : construire l'index lemme -> formes (cf. index_lemmes, section 8).\n",
+    "    # Etape 2 : trier par nombre de formes decroissant, garder les k premiers.\n",
+    "    # Etape 3 : retourner la liste [(lemme, formes_triees)].\n",
+    "    # TODO etudiant\n",
+    "    print(\"Exercice a completer\")\n",
+    "    return None\n",
+    "\n",
+    "top_lemmes(doc_fab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c373881",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006952,
+     "end_time": "2026-08-25T17:24:21.490315+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.483363+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — les sujets elliptiques du corpus juridique\n",
+    "\n",
+    "La fonction `svo` (section 4) rend `—` quand aucun sujet n'est détecté. Complétez `phrases_sans_sujet` pour lister les **verbes conjugués sans nsubj** du corpus juridique (`t.pos_ == \"VERB\"` et aucun enfant `nsubj*`). *Indice : itérer sur `doc_jur` puis sur `t.children`.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "dba42a1d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.506976Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.506976Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.512847Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.512306Z"
+    },
+    "papermill": {
+     "duration": 0.017273,
+     "end_time": "2026-08-25T17:24:21.514592+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.497319+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : verbes conjuges sans sujet explicite (corpus juridique).\n",
+    "def phrases_sans_sujet(doc):\n",
+    "    # Etape 1 : pour chaque token VERB, examiner ses enfants.\n",
+    "    # Etape 2 : si aucun enfant n'a dep_ commencant par \"nsubj\", retenir le token.\n",
+    "    # Etape 3 : retourner la liste des (texte du verbe, lemme).\n",
+    "    # TODO etudiant\n",
+    "    print(\"Exercice a completer\")\n",
+    "    return None\n",
+    "\n",
+    "phrases_sans_sujet(doc_jur)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dd578f0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008532,
+     "end_time": "2026-08-25T17:24:21.532198+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.523666+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — recherche par étiquette morphosyntaxique\n",
+    "\n",
+    "Étendez la recherche de la section 8 : une fonction `recherche_par_pos(doc, pos)` qui retourne tous les tokens du POS donné (par ex. `\"ADJ\"`) groupés par lemme. *Indice : même index que la section 8, mais clé = `t.pos_` puis `t.lemma_`.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ac11f6ce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T17:24:21.550352Z",
+     "iopub.status.busy": "2026-08-25T17:24:21.550352Z",
+     "iopub.status.idle": "2026-08-25T17:24:21.556904Z",
+     "shell.execute_reply": "2026-08-25T17:24:21.555501Z"
+    },
+    "papermill": {
+     "duration": 0.017579,
+     "end_time": "2026-08-25T17:24:21.557924+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.540345+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : recherche par POS, groupement par lemme.\n",
+    "def recherche_par_pos(doc, pos):\n",
+    "    # Etape 1 : filtrer les tokens du POS demande (t.pos_ == pos).\n",
+    "    # Etape 2 : les regrouper par lemme.\n",
+    "    # Etape 3 : retourner un dict {lemme: [formes surface]}.\n",
+    "    # TODO etudiant\n",
+    "    print(\"Exercice a completer\")\n",
+    "    return None\n",
+    "\n",
+    "recherche_par_pos(doc_jur, \"ADJ\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29250305",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007037,
+     "end_time": "2026-08-25T17:24:21.572952+00:00",
+     "exception": false,
+     "start_time": "2026-08-25T17:24:21.565915+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Le pipeline linguistique français exécuté ici — tokenisation, lemmes, POS, morphologie, dépendances, NER — est la **face analyse** du traitement du langage, là où le BPE du notebook 04 est sa **face encodage**. Les mesures de ce notebook :\n",
+    "\n",
+    "- la lemmatisation **fiable à 8/8** sur le jeu d'or (verbes irréguliers inclus) — utilisable en production d'index ;\n",
+    "- le NER d'un pipeline `sm` **mesuré limité** (2/5 : dates non détectées, étiquettes ORG/PER/LOC instables d'une occurrence à l'autre) — choix documenté, upgrade `md`/`trf` possible ;\n",
+    "- la recherche lemmatisée **démontrée supérieure** à la recherche surface sur le registre RGPD : elle retrouve flexions verbales (`conservait`) et pluriels (`données`) que la forme exacte ne matche pas.\n",
+    "\n",
+    "**Ponts** : [`RAG-et-Memoire-Semantique/04-Tokenisation-From-Scratch.ipynb`](../RAG-et-Memoire-Semantique/04-Tokenisation-From-Scratch.ipynb) (l'autre moitié de la comparaison), série `RAG-et-Memoire-Semantique` (où les lemmes alimentent le chunking), et le futur axe GraphRAG (nœuds lemmatisés) cité en §8.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (coursia-ml-training)",
+   "language": "python",
+   "name": "coursia-ml-training"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 12.743385,
+   "end_time": "2026-08-25T17:24:22.588963+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GenAI/Texte/23_TAL_Du_Mot_Aux_Dependances.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GenAI/Texte/23_TAL_Du_Mot_Aux_Dependances.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-25T17:24:09.845578+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -21,6 +21,7 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 - **Production enterprise** : gestion de sessions, retry, batch processing
 - **Déploiement local** : vLLM, quantification, optimisation des coûts
 - **Test-time scaling (ICR)** : routeur agentique, mémoire persistante, Tree-of-Thoughts sur CSP, courbes de scaling, raisonnement natif, plugins Semantic Kernel (notebooks 13 à 18, arc approfondi au-delà de NB-12)
+- **Analyse linguistique (TAL)** : lemmatisation, dépendances syntaxiques, entités nommées avec spaCy, et leur comparaison à la tokenisation BPE (notebook 23)
 
 ## Contenu détaillé
 
@@ -107,6 +108,14 @@ Le fil rouge est volontairement discriminant : enseigner au modèle un **format 
 |---|----------|-------------|-------|
 | 21 | `21_LoRA_FineTuning.ipynb` | **QLoRA** (NF4 4-bit + double quant, bf16) sur Qwen2.5-0.5B-Instruct : fil rouge = format balisé `[T]/[D]/[E]` que le base échoue à produire ; adaptateurs LoRA via `peft` + `bitsandbytes` + `trl` + `datasets`, GPU CUDA requis (pont PostTraining / #10247) | 75 min |
 | 22 | `22_TensorSharp_DotNet_Inference.ipynb` | Pilote diagnostique .NET : TensorSharp CUDA charge Gemma 4 E4B et répond en OpenAI-compatible, mais le contrôle qualitatif détecte une répétition de `<pad>` (`RECOVERABLE-LOCAL`, adoption différée) | 55 min |
+
+### Tier 7 : Analyse linguistique (TAL)
+
+Les tiers précédents traitent le langage **côté modèle** (prompts, RAG, fine-tuning). Ce tier exécute la seconde tradition — le **traitement automatique du langage classique** — sur un corpus français fil rouge à deux domaines (fables de La Fontaine, registre RGPD) : tokenisation en mots, lemmatisation, morphosyntaxe, dépendances syntaxiques, entités nommées, puis **comparaison frontale avec la tokenisation BPE** du notebook [`RAG-et-Memoire-Semantique/04`](../RAG-et-Memoire-Semantique/04-Tokenisation-From-Scratch.ipynb) sur le même corpus. Analyse d'erreurs mesurée contre des jeux d'or annotés à la main (lemmes 8/8, NER 2/5), cas d'usage borné : recherche lemmatisée.
+
+| # | Notebook | Description | Durée |
+|---|----------|-------------|-------|
+| 23 | `23_TAL_Du_Mot_Aux_Dependances.ipynb` | Pipeline **spaCy** `fr_core_news_sm` (CPU) : lemmes/POS/morphologie, arcs de dépendance + tripleaux SVO (displacy), NER avec rendu surligné, comparaison mots/lemmes/BPE (60 fusions) sur le corpus exact du NB-04, analyse d'erreurs contre gold (lemmes 8/8, NER 2/5 : dates manquées, ORG/PER instables), recherche lemmatisée vs surface | 60 min |
 
 ## Prérequis
 


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/tooling #12978

Closes #12958

## Summary

Nouveau notebook `GenAI/Texte/23_TAL_Du_Mot_Aux_Dependances.ipynb` (36 cellules) : le pipeline TAL classique français exécuté de bout en bout sur un corpus fil rouge à deux domaines, et confronté à la tokenisation BPE du notebook 04.

- **Corpus** : domaine littéraire = *exactement* le `FABLES_TEXT` de `RAG-et-Memoire-Semantique/04-Tokenisation-From-Scratch.ipynb` (la comparaison mots/BPE porte sur des données identiques) ; domaine juridico-technique = registre RGPD original (CNIL, Acme SAS, mars 2024).
- **Sections** : tokenisation mots vs `str.split()` (mesuré : +74 tokens, types 196→186) ; lemmes/POS/morphologie (tables pandas) ; dépendances — arcs displacy SVG + tripleaux SVO ; NER — liste + rendu surligné displacy `style="ent"` ; comparaison mots/lemmes/BPE (mini-BPE 60 fusions reconstruit à l'identique du NB-04 : 299 mots = 186 types formes / 167 types lemmes / 658 sous-mots 33 types) ; **analyse d'erreurs contre jeux d'or annotés à la main** ; cas d'usage borné = recherche lemmatisée ; 3 exercices.

## Analyse d'erreurs — mesurée, pas affirmée

- **Lemmatisation : 8/8** (`tint→tenir`, `alléché→allécher`, `êtes→être`, `chantiez→chanter`, `désaltéraient→désaltérer`, `conservait→conserver`, `vérifié→vérifier`, `européens→européen`).
- **NER : 2/5** — `CNIL`/`RGPD` OK ; `Acme SAS` étiquetée `PER` à une occurrence alors qu'elle est `ORG` à l'autre ; `mars 2024` (dans un groupe prépositionnel) non détectée ; `Union européenne` étiquetée `ORG` alors que le jeu d'or attend `LOC`. Sur les fables : verbe `jura` étiqueté `LOC`, personnages fictionnels en `PER`.
- **Recherche lemmatisée** : requêtes `conserver`/`donnée` → 0 forme surface exacte chacune, mais l'index de lemmes retrouve `conservait` et `données`. Limite documentée : `conservation` reste un lemme séparé (pas de dérivation nom←verbe).

## Validation (H.1)

- **Papermill end-to-end** : kernel `coursia-ml-training`, 36/36 cellules exécutées, 0 erreur :
  ```
  Input Notebook:  MyIA.AI.Notebooks/GenAI/Texte/23_TAL_Du_Mot_Aux_Dependances.ipynb
  Executing notebook with kernel: coursia-ml-training
  100% |██████████| 36/36 [00:12<00:00,  2.82cell/s]
  ```
- **C.2** : chaque cellule code porte `execution_count` + `outputs` (vérifié par script : 0 null, 0 vide) ; sorties displacy SVG commitées (`text/html`, cellules arcs + entités).
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` (vérifié par script) ; les 3 stubs affichent `Exercice a completer` et rendent `None`.
- **Prose alignée sur les sorties** : chaque `### Lecture du résultat` cite les valeurs réellement mesurées (corrections faites post-première-exécution : gold `tint` (pas `tin`), span `Union européenne` (pas `l'Union européenne`), types qui *diminuent* vs `split()`).

## SOTA (§H)

**SOTA-OK** — spaCy 3.8.16 + `fr_core_news_sm` 3.8.0 installés dans l'environnement `coursia-ml-training` (pip, préalable à la session), chargés via `spacy.load` sans téléchargement au runtime. Pipeline `sm` assumé et documenté comme choix (limites NER mesurées en section 7 ; upgrade `md`/`trf` citée).

## Critères d'acceptation #12958

- [x] Pipeline spaCy installé par l'environnement, aucun téléchargement caché
- [x] Même corpus fil rouge pour toutes les analyses (`DOCS`)
- [x] Comparaison explicite mots/sous-mots avec le NB-04 (section 6, corpus identique)
- [x] Visualisation des arcs **et** des entités (displacy `dep` + `ent`) + analyse d'erreurs sur annotations vérifiables (gold annoté à la main)
- [x] Deux domaines de textes français
- [x] Cas d'usage interne borné : recherche lemmatisée
- [x] ≥3 exercices + exécution complète avec outputs committés

## Files

- `MyIA.AI.Notebooks/GenAI/Texte/23_TAL_Du_Mot_Aux_Dependances.ipynb` (nouveau, 36 cellules)
- `MyIA.AI.Notebooks/GenAI/Texte/README.md` (+9 : ligne « Ce que vous apprendrez » + section Tier 7 avec la ligne du notebook 23)

Catalogue laissé byte-identique à main (règle catalog-pr-hygiene — le cron inscrit l'entrée).
