### PR TITLE
perf(ci,#11835): filter blob:none sur les 35 clones fetch-depth:0 restants

### DIFF
--- a/.github/workflows/ascii-flowchart-advisory.yml
+++ b/.github/workflows/ascii-flowchart-advisory.yml
@@ -63,6 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/bare-cross-dir-load-gate.yml
+++ b/.github/workflows/bare-cross-dir-load-gate.yml
@@ -100,6 +100,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/cell-order-gate.yml
+++ b/.github/workflows/cell-order-gate.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/check-resync-only.yml
+++ b/.github/workflows/check-resync-only.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/cjk-residue-advisory.yml
+++ b/.github/workflows/cjk-residue-advisory.yml
@@ -58,6 +58,7 @@ jobs:
           # the merge-base and the diff would fail instead of scoping to this
           # PR's own apport.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/degraded-mode-advisory.yml
+++ b/.github/workflows/degraded-mode-advisory.yml
@@ -61,6 +61,7 @@ jobs:
           # resolve sur une branche en retard (cf. #11646/#11658 : un
           # fetch-depth limite fait echouer merge-base silencieusement).
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/dotnet-nuget-block-advisory.yml
+++ b/.github/workflows/dotnet-nuget-block-advisory.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           # Need base..head history for `git diff` of changed notebooks.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/exercises-advisory.yml
+++ b/.github/workflows/exercises-advisory.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           # Need base..head history for `git diff` of changed notebooks.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/fabricated-output-gate.yml
+++ b/.github/workflows/fabricated-output-gate.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/fast-lane-shadow.yml
+++ b/.github/workflows/fast-lane-shadow.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/machine-dep-timing-advisory.yml
+++ b/.github/workflows/machine-dep-timing-advisory.yml
@@ -52,6 +52,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  filter: blob:none
 
             - name: Set up Python
               uses: actions/setup-python@v5

--- a/.github/workflows/manifest-description-visuelle-gate.yml
+++ b/.github/workflows/manifest-description-visuelle-gate.yml
@@ -62,6 +62,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/markdown-table-guard.yml
+++ b/.github/workflows/markdown-table-guard.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/md-content-loss-gate.yml
+++ b/.github/workflows/md-content-loss-gate.yml
@@ -59,6 +59,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/notebook-exec-sequence-ratchet.yml
+++ b/.github/workflows/notebook-exec-sequence-ratchet.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/notebook-execution-required.yml
+++ b/.github/workflows/notebook-execution-required.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Detect changed notebooks
         id: detect
@@ -97,6 +98,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/notebook-interp-positioning.yml
+++ b/.github/workflows/notebook-interp-positioning.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/notebook-output-failure-ratchet.yml
+++ b/.github/workflows/notebook-output-failure-ratchet.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/notebook-papermill-ratchet.yml
+++ b/.github/workflows/notebook-papermill-ratchet.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/orphan-branch-scan.yml
+++ b/.github/workflows/orphan-branch-scan.yml
@@ -51,7 +51,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          filter: blob:none
 
       - name: Fetch ALL remote heads
         # actions/checkout@v4 only fetches the default branch. The scan diffs

--- a/.github/workflows/orphan-branch-scan.yml
+++ b/.github/workflows/orphan-branch-scan.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Fetch ALL remote heads
         # actions/checkout@v4 only fetches the default branch. The scan diffs

--- a/.github/workflows/outputs-text-fragmentation-advisory.yml
+++ b/.github/workflows/outputs-text-fragmentation-advisory.yml
@@ -42,6 +42,7 @@ jobs:
           # completes (sinon le diff est vide et l'advisory short-circuit en
           # "no .ipynb changed" sur toute PR ; cf. finding NanoClaw #11668).
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pedagogy-density-advisory.yml
+++ b/.github/workflows/pedagogy-density-advisory.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           # Need base..head history for `git diff` of changed notebooks.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/quarto-pages-deploy.yml
+++ b/.github/workflows/quarto-pages-deploy.yml
@@ -186,6 +186,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/render-volume-delta-advisory.yml
+++ b/.github/workflows/render-volume-delta-advisory.yml
@@ -58,6 +58,7 @@ jobs:
           # ferait echouer merge-base silencieusement sur les branches >50
           # commits de retard comme #11646 / #11642).
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -124,6 +124,7 @@ jobs:
           # would false-fail. Consistent with the other git-aware gates
           # (catalog-cron/catalog-drift/cell-order-gate/exercise-leak-ci).
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/slides-build-advisory.yml
+++ b/.github/workflows/slides-build-advisory.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           # Need base..head history for `git diff` of changed slides.
           fetch-depth: 0
+          filter: blob:none
 
       # Runs BEFORE the Node setup, deliberately: the two defects it catches are
       # invisible to `slidev build`, so this step must survive an install failure.

--- a/.github/workflows/translation-drift.yml
+++ b/.github/workflows/translation-drift.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/translation-parity.yml
+++ b/.github/workflows/translation-parity.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Python setup
         uses: actions/setup-python@v5

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -151,6 +151,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          filter: blob:none
           persist-credentials: true
 
       # Prepare the long-lived branch from origin/main. The bot NEVER touches

--- a/.github/workflows/twin-parity-cron.yml
+++ b/.github/workflows/twin-parity-cron.yml
@@ -64,6 +64,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
           # Sur cron on lit l'etat courant de main. Les PR-checking workflows
           # utilisent le PR merge ref ; ici on n'a PAS de PR, juste l'arbre.
           ref: main

--- a/.github/workflows/twin-parity-drift-audit.yml
+++ b/.github/workflows/twin-parity-drift-audit.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -182,6 +183,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/readme #12923

## Defaut mesure

Le depot pese ~2,1 Go. L'en-tete de `fast-lane-shadow.yml` porte deja la mesure
firsthand qui fonde cette PR :

```
#   perimeter-review       checkout  64,0 s   analyse   2 s   94,8 %
#   solution-leak          checkout  63,5 s   analyse 5,5 s   89,4 %
# Le depot pese 2,1 Go et 46 workflows le clonent avec `fetch-depth: 0`. Un
# push sur une branche notebook declenche ~46 workflows pour ~235 min de temps
# de runner, contre 17 runners
```

**235 runner-min demandes par push contre 17 runners** : la file est structurellement
sur-souscrite. Mesure de file au 2026-08-25T17:25Z : **2722 runs `queued`, 16
`in_progress`** — en croissance continue (1940 a 13:57Z). Le goulot est le
**job-seconde**, pas le nombre de runs, et 94,8 % du job-seconde est du clonage.

## Ce que fait la PR

`filter: blob:none` ajoute apres chacun des 35 `fetch-depth: 0` restants qui n'en
avaient pas (10 l'avaient deja — `translation-guard`, `regression-guard`,
`stale-base-warning`, tranches #12690/#12383).

**Le changement est non-semantique.** `filter: blob:none` conserve le graphe de
commits **complet** : `git merge-base`, `git log`, `git diff origin/main...HEAD`
(3-dot), `git rev-list --count` sont inchanges. Seules les **revisions historiques
de blobs** ne sont plus transferees d'avance — elles sont tirees a la demande si
une commande les demande. Aucune commande git ne perd d'information ; seule la
latence d'acces aux blobs anciens change.

C'est la raison pour laquelle le gisement etait sur : les gardes lisent 3 a 5
fichiers de la tete, jamais l'historique de leurs contenus.

## Deux exclusions deliberees

Les seuls jobs pour lesquels `blob:none` serait une **regression** — ils parcourent
l'historique des *contenus*, donc tireraient les blobs un par un a la demande :

| Workflow | Pourquoi exclu |
|---|---|
| `secret-scan.yml` | gitleaks scanne l'historique des contenus |
| `repo-size-advisory.yml` | mesure precisement le poids du pack |

`bare remaining = 2` apres la PR, et ce sont exactement ces deux-la.

## Verification

- `33 files changed, 35 insertions(+), 0 deletions(-)` — aucune suppression.
- YAML re-parse (`yaml.safe_load`) sur chacun des 33 fichiers : **0 invalide**.
- `filter: blob:none` est deja en production sur 10 clones du depot depuis #12690 /
  #12383 : la forme est prouvee sur ce runner, pas supposee.
- Portee : `.github/workflows/*.yml` uniquement. Le catalogue est byte-identique a
  `main` (aucun fichier genere touche).

## Ce que cette PR ne fait PAS

Elle ne touche **ni** les filtres `paths:` (69/81 workflows `pull_request` en ont
deja un ; les 12 sans en sont pour la plupart des gardes transverses qui doivent
tirer sur chaque PR), **ni** `concurrency`/`cancel-in-progress` — sous file
profonde, un `cancel-in-progress` eteint les organes sans les faire rougir
(un run annule ne poste aucun check-run).

See #11835
