### PR TITLE
fix(guards,#12817): advisory nocturnes — 9 organes éteints ranimés (tranche 2)

### DIFF
--- a/.github/workflows/cjk-residue-advisory.yml
+++ b/.github/workflows/cjk-residue-advisory.yml
@@ -22,8 +22,12 @@ name: CJK Residue Advisory
 # paths leave the PR diff. Proven firsthand on exercises-advisory (PR #8820).
 # Enforced structurally by scripts/check_workflow_label_paths.py.
 #
-# Fork PRs are skipped (student-pr-reviews.md): benevolent review, no internal
-# content criterion runs against student submissions.
+# Tranche 2 #12817: the per-PR fork guard below died with the pull_request
+# trigger -- `github.event.pull_request.*` is absent under schedule, so the
+# guard evaluated false and the job ran SKIPPED (extinguished organ: 7 nights
+# of "success" without a single scan). The nocturne now resolves a 24 h window
+# on main and measures the day's merged apport; label side-effects are
+# PR-only and skipped when there is no PR context.
 
 on:
   schedule:
@@ -45,9 +49,6 @@ jobs:
   cjk-residue-advisory:
     name: "CJK residue advisory (label, non-blocking)"
     runs-on: ubuntu-latest
-    # Same-repo PRs only (agents/staff). Fork PRs are student submissions under
-    # student-pr-reviews.md -- benevolent review, no content gate.
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR
@@ -70,12 +71,28 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Without GH_REPO, gh pr edit/label create cannot infer the target repo.
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
+          # '' under schedule/dispatch (no PR context) -> nocturne window below.
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          BASE: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD: ${{ github.event.pull_request.head.sha || '' }}
           LABEL: cjk-residue
         run: |
           set -uo pipefail
+
+          # ---- Nocturne window (#12817 tranche 2) ----
+          # Under schedule/dispatch there is no PR: BASE is empty. Resolve the
+          # last 24 h of main so the sweep measures the day's merged apport
+          # ("attrape la dérive après merge"). The verdict stays state-dependent:
+          # the window's leak count varies with what actually merged.
+          NOCTURNE=0
+          if [ -z "${BASE:-}" ]; then
+            NOCTURNE=1
+            BASE=$(git rev-list -1 --before="24 hours ago" HEAD)
+            [ -n "$BASE" ] || BASE=$(git rev-list --max-parents=0 HEAD | tail -1)
+            HEAD=$(git rev-parse HEAD)
+            PR_NUMBER=""
+            echo "Nocturne window: $(git rev-parse --short "$BASE")..$(git rev-parse --short "$HEAD") (24 h of main)"
+          fi
 
           # The label is decided on what THIS PR changes (#8829 review), not on
           # the state of main. A whole-fleet scan would pose `cjk-residue` on
@@ -87,6 +104,9 @@ jobs:
           # 3-point diff (#10403): "$BASE...$HEAD" diffs from the merge-base of
           # BASE and HEAD, i.e. strictly what THIS branch introduced -- not the
           # union of both directions that a 2-point "$BASE" "$HEAD" reports.
+          # 3-point diff (#10403): under a PR, diffs from the merge-base of
+          # BASE and HEAD (strictly this branch's apport); under the nocturne,
+          # BASE is an ancestor of HEAD so the range IS the 24 h window.
           git diff --name-only --diff-filter=d "$BASE...$HEAD" > changed.txt || true
 
           python scripts/notebook_tools/detect_cjk_residue.py --json --check --stdin \
@@ -119,15 +139,23 @@ jobs:
             FILES=$(python -c \
               "import json; d=json.load(open('pr_payload.json')); \
                print('\n'.join('- '+r['path'] for r in d['results'] if r['allowed'] is None and r['hits']))")
-            echo "::notice::CJK residue in THIS PR ($PR_LEAKS leak line(s)): $FILES -- see the '$LABEL' label (#8826/#8428)."
-            gh label create "$LABEL" \
-              --description "CJK residue: a Chinese/Japanese word soldered into Latin prose (#8428/#8826)" \
-              --color "D93F0B" --force 2>/dev/null || true
-            gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "::warning::CJK residue in the last-24h window on main ($PR_LEAKS leak line(s)): $FILES (#8826/#8428)."
+            else
+              echo "::notice::CJK residue in THIS PR ($PR_LEAKS leak line(s)): $FILES -- see the '$LABEL' label (#8826/#8428)."
+              gh label create "$LABEL" \
+                --description "CJK residue: a Chinese/Japanese word soldered into Latin prose (#8428/#8826)" \
+                --color "D93F0B" --force 2>/dev/null || true
+              gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
+            fi
           else
-            echo "No CJK residue introduced by this PR."
-            # A label from an earlier push is now stale -- remove it so the signal
-            # stays trustworthy (self-cover lets this branch run on the fix commit).
-            gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "No CJK residue in the last-24h window on main."
+            else
+              echo "No CJK residue introduced by this PR."
+              # A label from an earlier push is now stale -- remove it so the signal
+              # stays trustworthy (self-cover lets this branch run on the fix commit).
+              gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+            fi
           fi
           exit 0

--- a/.github/workflows/dotnet-nuget-block-advisory.yml
+++ b/.github/workflows/dotnet-nuget-block-advisory.yml
@@ -21,7 +21,11 @@ name: dotnet-nuget-block-advisory
 # the PR + the PR body (fetched via gh). It does NOT re-implement detection
 # (acceptance: the label and the canonical tool must not diverge).
 #
-# Hors scope (student-pr-reviews.md): forks (student PRs) are skipped.
+# Tranche 2 #12817: the per-PR fork guard died with the pull_request trigger
+# (false under schedule -> job SKIPPED, organ extinguished). The nocturne
+# replays the per-PR semantics over the last 24 h of main: each commit is a
+# squash-merged PR whose message carries the PR body, so the body half of the
+# detection survives post-merge. Labels are PR-only and skipped at night.
 #
 # Falsifiability ([gate-must-verify-detector-fp-before-wiring]):
 #   - .NET notebook WITH `#r nuget` + body block -> SILENT (block may be legit)
@@ -49,9 +53,6 @@ jobs:
   dotnet-nuget-block-advisory:
     name: ".NET exec-block-without-nuget advisory (label, non-blocking)"
     runs-on: ubuntu-latest
-    # Same-repo PRs only (agents/staff). Fork PRs are student submissions
-    # under student-pr-reviews.md -- benevolent review, no content gate.
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR
@@ -72,12 +73,60 @@ jobs:
           # Without GH_REPO, `gh pr edit` / `gh pr view` cannot infer the target
           # repo and fail silently (variation-tag-guard documented this trap).
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
+          # '' under schedule/dispatch (no PR context) -> nocturne replay below.
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          BASE: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD: ${{ github.event.pull_request.head.sha || '' }}
           LABEL_NAME: dotnet-block-without-nuget
         run: |
           set -uo pipefail
+
+          # ---- Nocturne replay (#12817 tranche 2) ----
+          # Under schedule/dispatch there is no PR context, and the detection
+          # needs a PR BODY -- unavailable post-merge -- except that this repo
+          # squash-merges: each main commit's message IS its PR body. Replay
+          # the per-PR semantics commit by commit over the last 24 h.
+          NOCTURNE=0
+          if [ -z "${BASE:-}" ]; then
+            NOCTURNE=1
+            BASE=$(git rev-list -1 --before="24 hours ago" HEAD)
+            [ -n "$BASE" ] || BASE=$(git rev-list --max-parents=0 HEAD | tail -1)
+            HEAD=$(git rev-parse HEAD)
+            PR_NUMBER=""
+            echo "Nocturne window: $(git rev-parse --short "$BASE")..$(git rev-parse --short "$HEAD") (24 h of main, per-commit replay)"
+            NIGHT_FLAGGED=0
+            NIGHT_COMMITS=0
+            for c in $(git rev-list "$BASE..$HEAD"); do
+              NIGHT_COMMITS=$((NIGHT_COMMITS + 1))
+              # Body of the squash-merged PR = commit message.
+              git log -1 --format=%B "$c" > night_body.md 2>/dev/null || true
+              # Files of that commit only (deletions excluded; root commit -> empty).
+              git diff --name-only --diff-filter=d "${c}^" "$c" -- '*.ipynb' \
+                | grep -v $'\r$' > night_changed.txt 2>/dev/null || true
+              N=$(wc -l < night_changed.txt | tr -d ' ')
+              [ "$N" -gt 0 ] || continue
+              python scripts/notebook_tools/check_pr_dotnet_nuget_block.py \
+                --json --stdin --pr-body-file night_body.md \
+                < night_changed.txt > night_payload.json 2>/dev/null || true
+              F=$(python -c "import json; print(json.load(open('night_payload.json'))['summary']['dotnet_block_without_nuget'])" 2>/dev/null || echo "")
+              if ! [ "${F:-}" -eq "${F:-}" ] 2>/dev/null; then
+                echo "::error::night payload illisible at $(git rev-parse --short "$c") -- the gate measured NOTHING there."
+                continue
+              fi
+              if [ "$F" -gt 0 ]; then
+                echo "::warning::$F .NET notebook(s) with 0 #r nuget merged at $(git rev-parse --short "$c") under a body invoking a .NET exec block (#10024):"
+                cat night_changed.txt
+                NIGHT_FLAGGED=$((NIGHT_FLAGGED + F))
+              fi
+            done
+            echo "Commits replayed: $NIGHT_COMMITS"
+            if [ "$NIGHT_FLAGGED" -gt 0 ]; then
+              echo "RESULT: $NIGHT_FLAGGED occurrence(s) of the anti-pattern merged in the last 24 h (see warnings above)."
+            else
+              echo "RESULT: no .NET exec-block-without-nuget anti-pattern merged in the last 24 h (verified, per-commit replay)."
+            fi
+            exit 0
+          fi
 
           # Added/modified *.ipynb in the PR (deletions excluded).
           # 3-point diff (#10403): merge-base...HEAD -- strictly this PR's apport.

--- a/.github/workflows/exercises-advisory.yml
+++ b/.github/workflows/exercises-advisory.yml
@@ -18,8 +18,9 @@ name: Exercises Convention Advisory
 # count_exercises.py, never re-implemented here (acceptance 4) -- the label and
 # the canonical tool must not diverge.
 #
-# Hors scope (student-pr-reviews.md): forks (student PRs) are skipped -- a
-# benevolent review applies, no internal content criterion runs against them.
+# Tranche 2 #12817: the per-PR fork guard died with the pull_request trigger
+# (false under schedule -> job SKIPPED, organ extinguished). The nocturne
+# scans the last-24h window of main; labels are PR-only and noop'd at night.
 #
 # Promoting to a blocking gate is a separate decision (issue #8814 "Hors
 # scope"), to revisit only once the residual is at 0 and stable.
@@ -44,9 +45,6 @@ jobs:
   exercises-advisory:
     name: "Exercises >= 3 advisory (label, non-blocking)"
     runs-on: ubuntu-latest
-    # Same-repo PRs only (agents/staff). Fork PRs are student submissions
-    # under student-pr-reviews.md -- benevolent review, no content gate.
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR
@@ -68,13 +66,29 @@ jobs:
           # cannot infer the target repo and fail silently (variation-tag-guard
           # documented this trap firsthand after #8765).
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
+          # '' under schedule/dispatch (no PR context) -> nocturne window below.
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          BASE: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD: ${{ github.event.pull_request.head.sha || '' }}
           LABEL_BELOW: exercises-below-threshold
           LABEL_UNPARSEABLE: exercises-unparseable
         run: |
           set -uo pipefail
+
+          # ---- Nocturne window (#12817 tranche 2) ----
+          # Under schedule/dispatch there is no PR: BASE is empty. Resolve the
+          # last 24 h of main so the sweep measures the day's merged apport.
+          # Labels are PR-only -- noop'd when there is no PR to label; the
+          # nocturne payload is the annotations + RESULT line below.
+          NOCTURNE=0
+          if [ -z "${BASE:-}" ]; then
+            NOCTURNE=1
+            BASE=$(git rev-list -1 --before="24 hours ago" HEAD)
+            [ -n "$BASE" ] || BASE=$(git rev-list --max-parents=0 HEAD | tail -1)
+            HEAD=$(git rev-parse HEAD)
+            PR_NUMBER=""
+            echo "Nocturne window: $(git rev-parse --short "$BASE")..$(git rev-parse --short "$HEAD") (24 h of main)"
+          fi
 
           # Added/modified *.ipynb in the PR (deletions excluded -- a deleted
           # notebook has nothing to count).
@@ -90,6 +104,12 @@ jobs:
           }
           set_label() { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
           unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+          if [ "$NOCTURNE" -eq 1 ]; then
+            # No PR to label at night: the signal stays in the run output.
+            ensure_label() { true; }
+            set_label()   { true; }
+            unset_label() { true; }
+          fi
 
           if [ "$COUNT" -eq 0 ]; then
             echo "No modified notebooks to check."
@@ -137,14 +157,22 @@ jobs:
           fi
 
           if [ "$SUB" -gt 0 ]; then
-            echo "::notice::$SUB modified notebook(s) below the >=3 exercises convention (#2161). See the '$LABEL_BELOW' label."
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "::notice::$SUB notebook(s) below the >=3 exercises convention merged in the last 24 h (#2161)."
+            else
+              echo "::notice::$SUB modified notebook(s) below the >=3 exercises convention (#2161). See the '$LABEL_BELOW' label."
+            fi
             set_label "$LABEL_BELOW"
           else
             unset_label "$LABEL_BELOW"
           fi
 
           if [ "$PARSE" -gt 0 ]; then
-            echo "::warning::$PARSE modified notebook(s) could not be parsed -- NOT verified by the exercises gate (#8819). See the '$LABEL_UNPARSEABLE' label."
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "::warning::$PARSE notebook(s) in the last-24h window could not be parsed -- NOT verified by the exercises gate (#8819)."
+            else
+              echo "::warning::$PARSE modified notebook(s) could not be parsed -- NOT verified by the exercises gate (#8819). See the '$LABEL_UNPARSEABLE' label."
+            fi
             set_label "$LABEL_UNPARSEABLE"
           else
             unset_label "$LABEL_UNPARSEABLE"

--- a/.github/workflows/h1-hygiene-advisory.yml
+++ b/.github/workflows/h1-hygiene-advisory.yml
@@ -42,13 +42,32 @@ jobs:
       - name: Scan notebooks ADDED by the PR (advisory)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          # '' under schedule/dispatch (no PR context) -> nocturne window below.
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -euo pipefail
+
+          # ---- Nocturne window (#12817 tranche 2) ----
+          # Under schedule, BASE_SHA was empty: `git diff ""..HEAD` failed into
+          # `|| true`, ADDED came out empty and the job printed "No notebooks
+          # added" every night -- a green no-op masquerading as a scan. Resolve
+          # the last 24 h of main so the sweep measures the day's merged apport.
+          NOCTURNE=0
+          if [ -z "${BASE_SHA:-}" ]; then
+            NOCTURNE=1
+            BASE_SHA=$(git rev-list -1 --before="24 hours ago" HEAD)
+            [ -n "$BASE_SHA" ] || BASE_SHA=$(git rev-list --max-parents=0 HEAD | tail -1)
+            PR_NUMBER=""
+            echo "Nocturne window: $(git rev-parse --short "$BASE_SHA")..HEAD (24 h of main)"
+          fi
           ADDED=$(git diff --name-only --diff-filter=A "$BASE_SHA"..HEAD -- '*.ipynb' || true)
           if [ -z "$ADDED" ]; then
-            echo "No notebooks added by this PR — advisory skips."
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "No notebooks added in the last-24h window — advisory skips."
+            else
+              echo "No notebooks added by this PR — advisory skips."
+            fi
             exit 0
           fi
           echo "Added notebooks:"; echo "$ADDED"
@@ -57,6 +76,10 @@ jobs:
           cat /tmp/scan.txt
           if grep -q "scan complete: 0 notebook" /tmp/scan.txt; then
             echo "No H1 hygiene defects in added notebooks."
+            exit 0
+          fi
+          if [ "$NOCTURNE" -eq 1 ]; then
+            echo "::warning::H1 hygiene defects in notebooks added by the last-24h window: see scan output above (#11840)"
             exit 0
           fi
           gh label create "h1-hygiene-advisory" \

--- a/.github/workflows/markdown-table-guard.yml
+++ b/.github/workflows/markdown-table-guard.yml
@@ -24,8 +24,9 @@ name: Markdown table syntax advisory
 # a repo-wide scan on every push (the canon scan_md_table_syntax.py consumes the
 # path list; the workflow does not re-implement detection).
 #
-# Hors scope (student-pr-reviews.md): forks (student PRs) are skipped -- a
-# benevolent review applies, no internal content criterion runs against them.
+# Tranche 2 #12817: the per-PR fork guard died with the pull_request trigger
+# (false under schedule -> job SKIPPED, organ extinguished). The nocturne
+# scans the last-24h window of main; labels are PR-only and noop'd at night.
 
 on:
   schedule:
@@ -47,9 +48,6 @@ jobs:
   md-table-syntax-advisory:
     name: "Markdown table syntax advisory (label, non-blocking)"
     runs-on: ubuntu-latest
-    # Same-repo PRs only (agents/staff). Fork PRs are student submissions
-    # under student-pr-reviews.md -- benevolent review, no content gate.
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR
@@ -67,12 +65,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
+          # '' under schedule/dispatch (no PR context) -> nocturne window below.
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          BASE: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD: ${{ github.event.pull_request.head.sha || '' }}
           LABEL_DEFECT: markdown-table-syntax
         run: |
           set -uo pipefail
+
+          # ---- Nocturne window (#12817 tranche 2) ----
+          # Under schedule/dispatch there is no PR: BASE is empty. Resolve the
+          # last 24 h of main so the sweep measures the day's merged apport.
+          # Labels are PR-only -- noop'd when there is no PR to label.
+          NOCTURNE=0
+          if [ -z "${BASE:-}" ]; then
+            NOCTURNE=1
+            BASE=$(git rev-list -1 --before="24 hours ago" HEAD)
+            [ -n "$BASE" ] || BASE=$(git rev-list --max-parents=0 HEAD | tail -1)
+            HEAD=$(git rev-parse HEAD)
+            PR_NUMBER=""
+            echo "Nocturne window: $(git rev-parse --short "$BASE")..$(git rev-parse --short "$HEAD") (24 h of main)"
+          fi
 
           # Added/modified *.ipynb + *.md + README* in the PR (deletions
           # excluded). Skip vendored / archived trees where we do not enforce
@@ -91,6 +104,12 @@ jobs:
           }
           set_label()   { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
           unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+          if [ "$NOCTURNE" -eq 1 ]; then
+            # No PR to label at night: the signal stays in the run output.
+            ensure_label() { true; }
+            set_label()   { true; }
+            unset_label() { true; }
+          fi
 
           ensure_label "$LABEL_DEFECT" "PR introduces a markdown table syntax defect (COL_MISMATCH / CODE_SPAN_PIPE / NO_SEP / NO_BLANK_BEFORE/AFTER). Advisory, non-blocking. See #10097." "d93f0b"
 
@@ -110,7 +129,11 @@ jobs:
 
           if [ "$TOTAL" -gt 0 ]; then
             set_label "$LABEL_DEFECT"
-            echo "::warning::Found $TOTAL markdown table syntax defect(s) in changed files (label '$LABEL_DEFECT' added). See scan_md_table_syntax.py --check locally."
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "::warning::Found $TOTAL markdown table syntax defect(s) in the last-24h window on main. See scan_md_table_syntax.py --check locally."
+            else
+              echo "::warning::Found $TOTAL markdown table syntax defect(s) in changed files (label '$LABEL_DEFECT' added). See scan_md_table_syntax.py --check locally."
+            fi
           else
             unset_label "$LABEL_DEFECT"
             echo "Clean."

--- a/.github/workflows/pedagogy-density-advisory.yml
+++ b/.github/workflows/pedagogy-density-advisory.yml
@@ -20,8 +20,9 @@ name: Pedagogy Density Advisory
 # count_exercises.py THROUGH pedagogy_density.py -- never re-implemented here,
 # so the label and the canonical tool cannot diverge.
 #
-# Hors scope (student-pr-reviews.md): forks (student PRs) are skipped -- a
-# benevolent review applies, no internal content criterion runs against them.
+# Tranche 2 #12817: the per-PR fork guard died with the pull_request trigger
+# (false under schedule -> job SKIPPED, organ extinguished). The nocturne
+# scans the last-24h window of main; labels are PR-only and noop'd at night.
 #
 # Promoting to a blocking gate is a separate decision, to revisit only once the
 # residual is at 0 and stable (issue #10479 "Hors scope").
@@ -46,9 +47,6 @@ jobs:
   pedagogy-density-advisory:
     name: "Pedagogy density >= 1200 c/cell advisory (label, non-blocking)"
     runs-on: ubuntu-latest
-    # Same-repo PRs only (agents/staff). Fork PRs are student submissions
-    # under student-pr-reviews.md -- benevolent review, no content gate.
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR
@@ -70,13 +68,29 @@ jobs:
           # cannot infer the target repo and fail silently (variation-tag-guard
           # documented this trap firsthand after #8765).
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
+          # '' under schedule/dispatch (no PR context) -> nocturne window below.
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          BASE: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD: ${{ github.event.pull_request.head.sha || '' }}
           LABEL_BELOW: pedagogy-density-below-threshold
           LABEL_UNMEASURED: pedagogy-density-unmeasured
         run: |
           set -uo pipefail
+
+          # ---- Nocturne window (#12817 tranche 2) ----
+          # Under schedule/dispatch there is no PR: BASE is empty. Resolve the
+          # last 24 h of main so the sweep measures the day's merged apport.
+          # Labels are PR-only -- noop'd when there is no PR to label; the
+          # nocturne payload is the annotations + RESULT line below.
+          NOCTURNE=0
+          if [ -z "${BASE:-}" ]; then
+            NOCTURNE=1
+            BASE=$(git rev-list -1 --before="24 hours ago" HEAD)
+            [ -n "$BASE" ] || BASE=$(git rev-list --max-parents=0 HEAD | tail -1)
+            HEAD=$(git rev-parse HEAD)
+            PR_NUMBER=""
+            echo "Nocturne window: $(git rev-parse --short "$BASE")..$(git rev-parse --short "$HEAD") (24 h of main)"
+          fi
 
           # Added/modified *.ipynb in the PR (deletions excluded -- a deleted
           # notebook has nothing to measure).
@@ -92,6 +106,12 @@ jobs:
           }
           set_label() { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
           unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+          if [ "$NOCTURNE" -eq 1 ]; then
+            # No PR to label at night: the signal stays in the run output.
+            ensure_label() { true; }
+            set_label()   { true; }
+            unset_label() { true; }
+          fi
 
           if [ "$COUNT" -eq 0 ]; then
             echo "No modified notebooks to check."
@@ -136,14 +156,22 @@ jobs:
           fi
 
           if [ "$SUB" -gt 0 ]; then
-            echo "::notice::$SUB modified notebook(s) below the 1200 chars-of-prose-per-code-cell floor (#10479). See the '$LABEL_BELOW' label."
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "::notice::$SUB notebook(s) below the 1200 chars-of-prose-per-code-cell floor merged in the last 24 h (#10479)."
+            else
+              echo "::notice::$SUB modified notebook(s) below the 1200 chars-of-prose-per-code-cell floor (#10479). See the '$LABEL_BELOW' label."
+            fi
             set_label "$LABEL_BELOW"
           else
             unset_label "$LABEL_BELOW"
           fi
 
           if [ "$UNM" -gt 0 ]; then
-            echo "::warning::$UNM modified notebook(s) could not be measured -- NOT verified by the density advisory (#8819). See the '$LABEL_UNMEASURED' label."
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "::warning::$UNM notebook(s) in the last-24h window could not be measured -- NOT verified by the density advisory (#8819)."
+            else
+              echo "::warning::$UNM modified notebook(s) could not be measured -- NOT verified by the density advisory (#8819). See the '$LABEL_UNMEASURED' label."
+            fi
             set_label "$LABEL_UNMEASURED"
           else
             unset_label "$LABEL_UNMEASURED"

--- a/.github/workflows/repo-size-advisory.yml
+++ b/.github/workflows/repo-size-advisory.yml
@@ -41,8 +41,18 @@ jobs:
         run: |
           set -uo pipefail
           # ADVISORY : on ne fail jamais, on collecte et on avertit.
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
+          BASE="${{ github.event.pull_request.base.sha || '' }}"
+          HEAD="${{ github.event.pull_request.head.sha || '' }}"
+          # ---- Nocturne window (#12817 tranche 2) ----
+          # Under schedule, BASE/HEAD were empty: `git diff --raw ""...""` failed
+          # into 2>/dev/null, the loop read nothing and the job printed "OK :
+          # aucun blob" every night -- a green no-op masquerading as a scan.
+          if [ -z "$BASE" ]; then
+            BASE=$(git rev-list -1 --before="24 hours ago" HEAD)
+            [ -n "$BASE" ] || BASE=$(git rev-list --max-parents=0 HEAD | tail -1)
+            HEAD=$(git rev-parse HEAD)
+            echo "Nocturne window (24 h of main)."
+          fi
           echo "Scanning added blobs between ${BASE:0:12}..${HEAD:0:12} (threshold ${THRESHOLD_BYTES} bytes)"
           found=0
           # git diff --raw : ':<oldmode> <newmode> <oldsha> <newsha> <status>\t<path>'

--- a/.github/workflows/slides-build-advisory.yml
+++ b/.github/workflows/slides-build-advisory.yml
@@ -43,8 +43,10 @@ name: Slides Build Advisory
 #      crossing `::right::`), reintroduced in the fix PR, MUST lift the label.
 #      That control is captured in the PR body, not asserted by the workflow.
 #
-# Hors scope (student-pr-reviews.md): forks (student PRs) are skipped -- a
-# benevolent review applies, no internal content gate runs against them.
+# Tranche 2 #12817: the per-PR fork guard died with the pull_request trigger
+# (false under schedule -> job SKIPPED, organ extinguished). The nocturne
+# builds the decks impacted by the last-24h window of main; the label side is
+# PR-only and skipped at night -- the nocturne payload is the build output.
 #
 # Promoting to a blocking gate is a separate decision, to revisit only once the
 # advisory has run green-and-stable across enough slide PRs to trust it.
@@ -69,9 +71,6 @@ jobs:
   slides-build-advisory:
     name: "Slidev build advisory (label, non-blocking)"
     runs-on: ubuntu-latest
-    # Same-repo PRs only (agents/staff). Fork PRs are student submissions
-    # under student-pr-reviews.md -- benevolent review, no content gate.
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR
@@ -143,12 +142,27 @@ jobs:
           # Without GH_REPO, `gh pr edit` / `gh label create` cannot infer the
           # target repo and fail silently (variation-tag-guard, post-#8765).
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
+          # '' under schedule/dispatch (no PR context) -> nocturne window below.
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          BASE: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD: ${{ github.event.pull_request.head.sha || '' }}
           LABEL: slides-build-failed
         run: |
           set -uo pipefail
+
+          # ---- Nocturne window (#12817 tranche 2) ----
+          # Under schedule/dispatch there is no PR: BASE is empty. Resolve the
+          # last 24 h of main so the sweep builds the decks impacted by the
+          # day's merged apport. Labels are PR-only and skipped at night.
+          NOCTURNE=0
+          if [ -z "${BASE:-}" ]; then
+            NOCTURNE=1
+            BASE=$(git rev-list -1 --before="24 hours ago" HEAD)
+            [ -n "$BASE" ] || BASE=$(git rev-list --max-parents=0 HEAD | tail -1)
+            HEAD=$(git rev-parse HEAD)
+            PR_NUMBER=""
+            echo "Nocturne window: $(git rev-parse --short "$BASE")..$(git rev-parse --short "$HEAD") (24 h of main)"
+          fi
 
           # ---- Trap 1: discover ALL deck targets, fail loudly on silent skip. ----
           # Deck dirs follow the NN-name / SN-name convention (01-introduction,
@@ -248,8 +262,12 @@ jobs:
           fi
 
           if [ "${#TOUCHED[@]}" -eq 0 ]; then
-            echo "No deck impacted by this PR (slides/ changes were in _tools/analysis/etc.). Discovery sanity above still validates the gate."
-            gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "No deck impacted by the last-24h window (slides/ changes were in _tools/analysis/etc.). Discovery sanity above still validates the gate."
+            else
+              echo "No deck impacted by this PR (slides/ changes were in _tools/analysis/etc.). Discovery sanity above still validates the gate."
+            fi
+            [ "$NOCTURNE" -eq 0 ] && gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
 
@@ -273,13 +291,17 @@ jobs:
 
           # ---- Label signaling (advisory: exit 0 regardless). ----
           if [ "$FAILURES" -gt 0 ]; then
-            echo "::notice::$FAILURES impacted deck(s) failed to build. See the '$LABEL' label. Failed:$FAILED_LIST"
+            if [ "$NOCTURNE" -eq 1 ]; then
+              echo "::warning::$FAILURES deck(s) impacted by the last-24h window failed to build. Failed:$FAILED_LIST"
+            else
+              echo "::notice::$FAILURES impacted deck(s) failed to build. See the '$LABEL' label. Failed:$FAILED_LIST"
+            fi
             gh label create "$LABEL" \
               --description "A Slidev deck impacted by this PR does not construct (#8807)" \
               --color "D93F0B" --force 2>/dev/null || true
-            gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
+            [ "$NOCTURNE" -eq 0 ] && gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
           else
             echo "All ${#TOUCHED[@]} impacted deck(s) build cleanly."
-            gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+            [ "$NOCTURNE" -eq 0 ] && gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
           fi
           exit 0

--- a/.github/workflows/slides-composition-advisory.yml
+++ b/.github/workflows/slides-composition-advisory.yml
@@ -50,9 +50,6 @@ jobs:
   slides-composition-advisory:
     name: "Slidev composition advisory (#11923, non-blocking)"
     runs-on: ubuntu-latest
-    # Same-repo PRs only : les forks étudiants suivent la review bienveillante
-    # (student-pr-reviews.md), pas de content gate.
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout (blobless, sparse slides)
@@ -100,8 +97,9 @@ jobs:
 
       - name: Measure composition of impacted decks (advisory)
         env:
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
+          # '' under schedule/dispatch (no PR context) -> nocturne window below.
+          BASE: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD: ${{ github.event.pull_request.head.sha || '' }}
         run: |
           set -uo pipefail
           # #12173 — neutralize errexit ajoutée par le shell wrapper GitHub
@@ -113,6 +111,19 @@ jobs:
           # annotations de #12151 viennent documenter. L'erreur n'est pas
           # supprimée : on l'annote explicitement, on en fait META_FAIL.
           set +e
+
+          # ---- Nocturne window (#12817 tranche 2) ----
+          # Under schedule/dispatch there is no PR: BASE is empty. Resolve the
+          # last 24 h of main so the sweep measures the decks impacted by the
+          # day's merged apport. Sans ce bloc, le diff ""..."" rendait CHANGED
+          # vide -> "Aucun deck impacté" vert chaque nuit (organe éteint).
+          if [ -z "${BASE:-}" ]; then
+            BASE=$(git rev-list -1 --before="24 hours ago" HEAD)
+            [ -n "$BASE" ] || BASE=$(git rev-list --max-parents=0 HEAD | tail -1)
+            HEAD=$(git rev-parse HEAD)
+            echo "Nocturne window: $(git rev-parse --short "$BASE")..$(git rev-parse --short "$HEAD") (24 h of main)"
+          fi
+
           echo "## Slides composition (advisory #11923)" >> "$GITHUB_STEP_SUMMARY"
           echo "Plancher mécanique — ne remplace pas le QA visuel humain." >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python #13008

## Summary

Tranche 2 de #12817 : après le débranchement `pull_request` (tranche 1, #12821), **9 des 16 advisory
nocturnes étaient des organes éteints** — mesuré sur les runs nocturnes réels :

| Défaut | Workflows | Symptôme nocturne |
|---|---|---|
| **Fork guard mort** — `if: github.event.pull_request.head.repo.full_name == github.repository` évalue **false** sous `schedule` (pas d'objet `pull_request` dans l'event) | cjk-residue, dotnet-nuget-block, exercises, markdown-table-guard, pedagogy-density, slides-build, slides-composition (7) | job `SKIPPED` chaque nuit — jamais un scan |
| **No-op vert silencieux** — `BASE` vide → `git diff ""..HEAD` échoue dans `|| true` / `2>/dev/null` → scan de rien → « No notebooks added » / « OK : aucun blob » chaque nuit | h1-hygiene, repo-size (2) | job `success` sans avoir rien mesuré |

C'est exactement l'organe à verdict constant que #12817 interdit : « Un advisory dont le verdict
devient constant est un organe éteint — le passage nocturne doit rester **vivant et rouge-capable** ».

## Le fix (par fichier, les 9)

1. **Fork guard supprimé** — son déclencheur (`pull_request`) n'existe plus depuis la tranche 1 ; sous
   schedule il est structurellement false.
2. **Contexte PR rendu optionnel** : `github.event.pull_request.* || ''` dans les env.
3. **Fenêtre nocturne 24 h** : quand `BASE` est vide, `BASE = git rev-list -1 --before="24 hours ago" HEAD`
   (fallback root-commit) — le sweep mesure l'apport mergé du jour (« attrape la dérive après merge »).
   `BASE` étant ancêtre de `HEAD`, le diff 3 points `BASE...HEAD` EST la fenêtre.
4. **Labels = PR-only** : noopés/escamotés en nocturne ; les constats nocturnes émettent `::warning`
   (cjk `::notice`→`::warning` sur findings window, messages nocturne-aware — jamais un message qui
   renvoie vers un label qui ne sera pas posé).
5. **dotnet-nuget-block** — le seul dont la détection exige un **body de PR** (indisponible post-merge) :
   replay **par commit** sur la fenêtre — chaque commit main étant un squash-merge dont le message
   porte le body de la PR, la sémantique par-PR survit au merge.
6. **slides-composition** : la fenêtre se résout AVANT la découverte des decks — ses exits rouges
   META_FAIL (deck découvert non mesuré, découverte vide) restent intacts.
7. **h1-hygiene / repo-size** : le commentaire de fix documente le no-op vert qu'ils étaient.

La structure duale PR/nocturne est conservée : le chemin PR est le dépôt de la sémantique de label
(reliquat de la tranche 1, inerte tant que `pull_request` n'est pas rebranché — rebranchable à
l'identique si la flotte remonte une voie rapide PR pour un sous-ensemble).

## Contrôle positif (acceptance #2 de #12817)

`workflow_dispatch` manuel sur **cette branche** — les deux transformations les plus lourdes,
**conclusions atterries** (file CI saturée ~40 min, cf le constat de l'issue) :

- **cjk-residue-advisory** run [32900931277](https://github.com/jsboige/CoursIA/actions/runs/32900931277) : `success` —
  fenêtre résolue **`b6d55f73d..d5922dcab` (24 h of main)**, scan window exécuté, verdict :
  ```
  CJK leak lines introduced/modified by THIS PR: 0
  No CJK residue in the last-24h window on main.
  ```
  (+ le fleet scan informatif a tourné dans le même run.)
- **dotnet-nuget-block-advisory** run [32900934132](https://github.com/jsboige/CoursIA/actions/runs/32900934132) : `success` —
  même fenêtre, **replay par commit** :
  ```
  Nocturne window: b6d55f73d..d5922dcab (24 h of main, per-commit replay)
  Commits replayed: 27
  RESULT: no .NET exec-block-without-nuget anti-pattern merged in the last 24 h (verified, per-commit replay).
  ```

Avant le fix, ces deux jobs rendaient `skipped` à chaque passage (guard fork mort) — ils rendent
désormais un **verdict window-scan daté et re-traçable** : fenêtre affichée, 27 commits rejoués,
scans exécutés. Un lot vert n'est plus indiscernable d'un moteur débranché.

## Validation

- Parse YAML 9/9 + `bash -n` sur **chaque** bloc `run` (script scratchpad, Git bash) : 0 erreur.
- Garanti par le même script : plus aucun `github.event.pull_request` non gardé (`|| ''` partout),
  plus aucun fork guard job-level, triggers inchangés (`schedule` + `workflow_dispatch` uniquement).
- `git diff --stat` : **9 fichiers**, +298/−76 — tous dans le scope du claim
  (`paths: .github/workflows/*advisory*.yml`, `markdown-table-guard.yml`) ; **aucun gate bloquant
  touché** (acceptance 4).
- Recompte (acceptance 3) : la forme **trigger** ancrée `grep -lE '^\s+pull_request:' | wc -l` rend
  **81** sur `origin/main` — mieux que le 86 demandé (d'autres workflows ont quitté le trigger
  depuis la rédaction de l'issue). La forme **non ancrée** littérale rend 102 et ne peut pas
  atteindre 86 sans retoucher les 16 fichiers : les occurrences restantes sont les expressions
  gardées `github.event.pull_request.* || ''` (chemin PR rebranchable, cf ci-dessus) et les
  **commentaires** de tranche 1 qui mentionnent le mot. Mesuré : les 7 organes sains ne matchent
  l'unanchored QUE sur leurs commentaires. L'intent de l'acceptance (aucun des 16 ne se déclenche
  sur `pull_request`) est prouvé par la forme ancrée ; la chasse au littéral dans les commentaires
  serait du number-chasing sans valeur.

See #12817 (tranche 2 ; l'acceptance #2 — contrôle positif — est satisfaite ci-dessus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
