### PR TITLE
feat(genai,#12411): Texte 23 Inference Mechanics — KV-cache from scratch + mesures TTFT/ITL sur le vLLM

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/23_Inference_Mechanics.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/23_Inference_Mechanics.ipynb
@@ -1,0 +1,1295 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "011e71b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:30.058715Z",
+     "iopub.status.busy": "2026-08-25T21:47:30.058502Z",
+     "iopub.status.idle": "2026-08-25T21:47:30.061742Z",
+     "shell.execute_reply": "2026-08-25T21:47:30.061224Z"
+    },
+    "papermill": {
+     "duration": 0.007525,
+     "end_time": "2026-08-25T21:47:30.062673",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:30.055148",
+     "status": "completed"
+    },
+    "tags": [
+     "injected-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "BATCH_MODE = \"true\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66f64a9a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002276,
+     "end_time": "2026-08-25T21:47:30.068104",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:30.065828",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 23. Mécanique d'inférence LLM : le KV-cache, from scratch puis mesuré sur notre vLLM\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< Précédent](22_Evaluating_Generated_Text.ipynb) | [10_LocalLlama](10_LocalLlama.ipynb) · [11_Quantization](11_Quantization.ipynb)\n",
+    "\n",
+    "## Objectifs\n",
+    "\n",
+    "Les notebooks [10_LocalLlama](10_LocalLlama.ipynb) et [11_Quantization](11_Quantization.ipynb) couvrent le **déploiement** de notre stack self-hosted (vLLM, quantification). Ce notebook ouvre la cage : la **mécanique interne** de l'inférence autorégressive.\n",
+    "\n",
+    "1. **Le mur du recalcul** : pourquoi une génération naïve ralentit avec la longueur du contexte — mesuré, pas affirmé.\n",
+    "2. **Le KV-cache implémenté à la main** : incrémentalité, exactitude numérique vérifiée contre le passage naïf (écart affiché).\n",
+    "3. **Le speedup mesuré** : tokens/s naïf vs caché, à longueur de contexte croissante — la courbe de l'accélération.\n",
+    "4. **Le coût mémoire du cache** : la formule (couches × têtes × head_dim × seq × 2 × dtype) confrontée au mesuré.\n",
+    "5. **Le pont vers la production** : time-to-first-token et inter-token latency **mesurés sur notre vLLM** (qwen3.6-35b-a3b self-hosted), reliés aux mécaniques de la partie 1.\n",
+    "\n",
+    "**Prérequis** : PyTorch (CPU suffit pour la partie from scratch), notebook 10 (concepts de déploiement). La partie 5 interroge le vLLM du dépôt (service GPU distant) — si le service est éteint, le notebook affiche un verdict `[RECOVERABLE-MACHINE]` explicite et **aucune valeur de substitution**.\n",
+    "\n",
+    "**Durée estimée** : 60 minutes\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8c315dc8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:30.073131Z",
+     "iopub.status.busy": "2026-08-25T21:47:30.072826Z",
+     "iopub.status.idle": "2026-08-25T21:47:30.075448Z",
+     "shell.execute_reply": "2026-08-25T21:47:30.074977Z"
+    },
+    "papermill": {
+     "duration": 0.006233,
+     "end_time": "2026-08-25T21:47:30.076287",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:30.070054",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "BATCH_MODE = \"true\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8476f3e4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002621,
+     "end_time": "2026-08-25T21:47:30.081595",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:30.078974",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Un mini-GPT **écrit ici, en PyTorch pur** (CPU), sert de moteur d'étude. Poids aléatoires à seed fixe : ce notebook enseigne la **mécanique** (le coût et la forme des calculs), pas la qualité du texte — un modèle non entraîné produit du bruit, mais son attention coûte exactement ce que coûte celle d'un vrai modèle.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "32ddc0ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:30.092559Z",
+     "iopub.status.busy": "2026-08-25T21:47:30.092268Z",
+     "iopub.status.idle": "2026-08-25T21:47:32.326984Z",
+     "shell.execute_reply": "2026-08-25T21:47:32.325953Z"
+    },
+    "papermill": {
+     "duration": 2.24097,
+     "end_time": "2026-08-25T21:47:32.328130",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:30.087160",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch 2.8.0+cu126 | device: cpu\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import time\n",
+    "import math\n",
+    "import json\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "%matplotlib inline\n",
+    "\n",
+    "torch.manual_seed(20260825)\n",
+    "DEVICE = torch.device(\"cpu\")\n",
+    "print(\"torch\", torch.__version__, \"| device:\", DEVICE)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76da3aa3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002112,
+     "end_time": "2026-08-25T21:47:32.332616",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:32.330504",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le problème : la génération naïve recalcule tout le préfixe\n",
+    "\n",
+    "Une boucle de génération autorégressive produit le token t+1 à partir des logits de la position t. L'implémentation naïve la plus simple ré-exécute le modèle sur **toute la séquence** à chaque pas :\n",
+    "\n",
+    "- pas 1 : forward sur `n` tokens (le prompt)\n",
+    "- pas 2 : forward sur `n+1` tokens\n",
+    "- ...\n",
+    "- pas k : forward sur `n+k-1` tokens\n",
+    "\n",
+    "Or, dans l'attention, les projections **K** (clés) et **V** (valeurs) des tokens **passés ne changent jamais** : un token déjà encodé produit les mêmes K/V à chaque passage. Le recalcul est du travail **purement perdu**, et il croît avec le carré de la longueur générée.\n",
+    "\n",
+    "Construisons d'abord le moteur, puis mesurons ce mur.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "13598d53",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:32.338344Z",
+     "iopub.status.busy": "2026-08-25T21:47:32.337766Z",
+     "iopub.status.idle": "2026-08-25T21:47:32.360851Z",
+     "shell.execute_reply": "2026-08-25T21:47:32.359893Z"
+    },
+    "papermill": {
+     "duration": 0.027697,
+     "end_time": "2026-08-25T21:47:32.362378",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:32.334681",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MiniGPT : 4 couches, 4 têtes, d_model=128 (head_dim=32), bloc=1536 — 1.25 M paramètres\n"
+     ]
+    }
+   ],
+   "source": [
+    "class MiniGPTConfig:\n",
+    "    def __init__(self, vocab_size=1000, block_size=1536, n_layer=4, n_head=4, d_model=128):\n",
+    "        self.vocab_size = vocab_size\n",
+    "        self.block_size = block_size\n",
+    "        self.n_layer = n_layer\n",
+    "        self.n_head = n_head\n",
+    "        self.d_model = d_model\n",
+    "\n",
+    "CFG = MiniGPTConfig()\n",
+    "assert CFG.d_model % CFG.n_head == 0  # invariant de découpage des têtes\n",
+    "CFG.head_dim = CFG.d_model // CFG.n_head\n",
+    "\n",
+    "\n",
+    "class CausalSelfAttention(nn.Module):\n",
+    "    \"\"\"Attention causale avec support KV-cache explicite.\n",
+    "\n",
+    "    kv_cache=None  : passage complet (préfill ou mode naïf) — x peut faire (B, T, D).\n",
+    "    kv_cache=(k,v) : pas incrémental — x fait (B, 1, D), on ne calcule K/V que pour\n",
+    "                     CE token, puis on concatène aux K/V passés.\n",
+    "    Retourne (out, k, v) : le module ne cache rien lui-même, c'est l'appelant\n",
+    "    qui porte l'état — pédagogiquement volontaire (on veut VOIR le cache).\"\"\"\n",
+    "\n",
+    "    def __init__(self, cfg):\n",
+    "        super().__init__()\n",
+    "        self.n_head = cfg.n_head\n",
+    "        self.head_dim = cfg.head_dim\n",
+    "        self.qkv = nn.Linear(cfg.d_model, 3 * cfg.d_model)\n",
+    "        self.proj = nn.Linear(cfg.d_model, cfg.d_model)\n",
+    "\n",
+    "    def forward(self, x, kv_cache=None):\n",
+    "        B, T, D = x.shape\n",
+    "        qkv = self.qkv(x)\n",
+    "        q, k, v = qkv.split(D, dim=2)\n",
+    "        q = q.view(B, T, self.n_head, self.head_dim).transpose(1, 2)   # (B, nh, T, hd)\n",
+    "        k = k.view(B, T, self.n_head, self.head_dim).transpose(1, 2)\n",
+    "        v = v.view(B, T, self.n_head, self.head_dim).transpose(1, 2)\n",
+    "\n",
+    "        if kv_cache is not None:\n",
+    "            k_past, v_past = kv_cache\n",
+    "            k = torch.cat([k_past, k], dim=2)   # (B, nh, T_passé + 1, hd)\n",
+    "            v = torch.cat([v_past, v], dim=2)\n",
+    "\n",
+    "        T_total = k.shape[2]\n",
+    "        att = (q @ k.transpose(-2, -1)) / math.sqrt(self.head_dim)      # (B, nh, T, T_total)\n",
+    "        mask = torch.triu(torch.ones(T_total, T_total, dtype=torch.bool), diagonal=1)\n",
+    "        causal = mask[T_total - T:, :]   # les T nouvelles positions voient leur passé\n",
+    "        att = att.masked_fill(causal.view(1, 1, T, T_total), float(\"-inf\"))\n",
+    "        att = F.softmax(att, dim=-1)\n",
+    "        y = att @ v                                                     # (B, nh, T, hd)\n",
+    "        y = y.transpose(1, 2).contiguous().view(B, T, D)\n",
+    "        return self.proj(y), k, v\n",
+    "\n",
+    "\n",
+    "class Block(nn.Module):\n",
+    "    def __init__(self, cfg):\n",
+    "        super().__init__()\n",
+    "        self.ln1 = nn.LayerNorm(cfg.d_model)\n",
+    "        self.attn = CausalSelfAttention(cfg)\n",
+    "        self.ln2 = nn.LayerNorm(cfg.d_model)\n",
+    "        self.mlp = nn.Sequential(\n",
+    "            nn.Linear(cfg.d_model, 4 * cfg.d_model), nn.GELU(),\n",
+    "            nn.Linear(4 * cfg.d_model, cfg.d_model),\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, x, kv_cache=None):\n",
+    "        a, k, v = self.attn(self.ln1(x), kv_cache=kv_cache)\n",
+    "        x = x + a\n",
+    "        x = x + self.mlp(self.ln2(x))\n",
+    "        return x, k, v\n",
+    "\n",
+    "\n",
+    "class MiniGPT(nn.Module):\n",
+    "    \"\"\"Décodeur pur : embeddings + n blocs + LayerNorm final + tête de logits.\n",
+    "    forward renvoie (logits, cache) où cache = liste [(k_l, v_l)] par couche.\"\"\"\n",
+    "\n",
+    "    def __init__(self, cfg):\n",
+    "        super().__init__()\n",
+    "        self.cfg = cfg\n",
+    "        self.tok_emb = nn.Embedding(cfg.vocab_size, cfg.d_model)\n",
+    "        self.pos_emb = nn.Embedding(cfg.block_size, cfg.d_model)\n",
+    "        self.blocks = nn.ModuleList([Block(cfg) for _ in range(cfg.n_layer)])\n",
+    "        self.ln_f = nn.LayerNorm(cfg.d_model)\n",
+    "        self.head = nn.Linear(cfg.d_model, cfg.vocab_size, bias=False)\n",
+    "\n",
+    "    def forward(self, idx, kv_caches=None):\n",
+    "        B, T = idx.shape\n",
+    "        pos = torch.arange(T, device=idx.device)\n",
+    "        # en pas incrémental, la position du nouveau token = longueur du cache\n",
+    "        if kv_caches is not None and kv_caches[0] is not None:\n",
+    "            offset = kv_caches[0][0].shape[2]\n",
+    "            pos = pos + offset\n",
+    "        x = self.tok_emb(idx) + self.pos_emb(pos)\n",
+    "        new_caches = []\n",
+    "        for i, blk in enumerate(self.blocks):\n",
+    "            past = kv_caches[i] if kv_caches is not None else None\n",
+    "            x, k, v = blk(x, kv_cache=past)\n",
+    "            new_caches.append((k.detach(), v.detach()))\n",
+    "        logits = self.head(self.ln_f(x))\n",
+    "        return logits, new_caches\n",
+    "\n",
+    "\n",
+    "model = MiniGPT(CFG).to(DEVICE)\n",
+    "n_params = sum(p.numel() for p in model.parameters())\n",
+    "print(f\"MiniGPT : {CFG.n_layer} couches, {CFG.n_head} têtes, d_model={CFG.d_model} \"\n",
+    "      f\"(head_dim={CFG.head_dim}), bloc={CFG.block_size} — {n_params / 1e6:.2f} M paramètres\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e1573846",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:32.368202Z",
+     "iopub.status.busy": "2026-08-25T21:47:32.367675Z",
+     "iopub.status.idle": "2026-08-25T21:47:32.516395Z",
+     "shell.execute_reply": "2026-08-25T21:47:32.515351Z"
+    },
+    "papermill": {
+     "duration": 0.153294,
+     "end_time": "2026-08-25T21:47:32.517934",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:32.364640",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "naïf  :    83.1 ms pour 12 tokens | ids [793, 609, 916, 547, 898, 982]\n",
+      "cache :    55.4 ms pour 12 tokens | ids [793, 609, 916, 547, 898, 982]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def generate_naive(model, idx, n_new):\n",
+    "    \"\"\"Génération NAÏVE : à chaque pas, forward complet sur tout le préfixe.\n",
+    "\n",
+    "    Le modèle tourne en mode sans cache (kv_caches=None) : les K/V des tokens\n",
+    "    passés sont recalculés de zéro à chaque pas. Retourne (tokens, temps_total_s,\n",
+    "    liste des durées par pas).\"\"\"\n",
+    "    times = []\n",
+    "    out = idx.clone()\n",
+    "    for _ in range(n_new):\n",
+    "        t0 = time.perf_counter()\n",
+    "        with torch.no_grad():\n",
+    "            logits, _ = model(out)           # forward sur TOUT le préfixe\n",
+    "        nxt = logits[:, -1, :].argmax(dim=-1, keepdim=True)\n",
+    "        out = torch.cat([out, nxt], dim=1)\n",
+    "        times.append(time.perf_counter() - t0)\n",
+    "    return out, sum(times), times\n",
+    "\n",
+    "\n",
+    "def generate_cached(model, idx, n_new):\n",
+    "    \"\"\"Génération avec KV-cache porté par l'appelant : un préfill, puis des pas\n",
+    "    incrémentaux de 1 token. Retourne (tokens, temps_total_s, durées_par_pas).\"\"\"\n",
+    "    times = []\n",
+    "    t0 = time.perf_counter()\n",
+    "    with torch.no_grad():\n",
+    "        logits, caches = model(idx)          # préfill : K/V du prompt calculés une fois\n",
+    "    t_prefill = time.perf_counter() - t0\n",
+    "    out = idx.clone()\n",
+    "    nxt = logits[:, -1, :].argmax(dim=-1, keepdim=True)\n",
+    "    out = torch.cat([out, nxt], dim=1)\n",
+    "    times.append(t_prefill)\n",
+    "    for _ in range(n_new - 1):\n",
+    "        t0 = time.perf_counter()\n",
+    "        with torch.no_grad():\n",
+    "            logits, caches = model(nxt, kv_caches=caches)   # 1 seul token !\n",
+    "        nxt = logits[:, -1, :].argmax(dim=-1, keepdim=True)\n",
+    "        out = torch.cat([out, nxt], dim=1)\n",
+    "        times.append(time.perf_counter() - t0)\n",
+    "    return out, sum(times), times\n",
+    "\n",
+    "\n",
+    "# Démonstration rapide : 12 tokens générés chaque façon sur un prompt de 64 tokens\n",
+    "torch.manual_seed(7)\n",
+    "prompt = torch.randint(0, CFG.vocab_size, (1, 64))\n",
+    "tok_n, t_n, _ = generate_naive(model, prompt, 12)\n",
+    "tok_c, t_c, _ = generate_cached(model, prompt, 12)\n",
+    "print(f\"naïf  : {t_n * 1000:7.1f} ms pour 12 tokens | ids {tok_n[0, -6:].tolist()}\")\n",
+    "print(f\"cache : {t_c * 1000:7.1f} ms pour 12 tokens | ids {tok_c[0, -6:].tolist()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b00ce5f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002149,
+     "end_time": "2026-08-25T21:47:32.522482",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:32.520333",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Exactitude : le cache ne change PAS les logits (à l'epsilon près)\n",
+    "\n",
+    "Le KV-cache est une **optimisation strictement équivalente** : recalculer les K/V du préfixe ou les relire du cache doit produire les **mêmes logits**. Vérifions-le pas à pas — c'est la propriété qui justifie qu'un serveur de production puisse l'activer sans changer les sorties.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d9ffd6d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:32.528121Z",
+     "iopub.status.busy": "2026-08-25T21:47:32.527782Z",
+     "iopub.status.idle": "2026-08-25T21:47:32.933024Z",
+     "shell.execute_reply": "2026-08-25T21:47:32.932295Z"
+    },
+    "papermill": {
+     "duration": 0.409918,
+     "end_time": "2026-08-25T21:47:32.934634",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:32.524716",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pas vérifiés                          : 24\n",
+      "écart max  |logit_naïf − logit_cache| : 1.073e-06\n",
+      "écart moyen sur tous les pas          : 7.165e-07\n",
+      "argmax identiques (tokens générés)    : 24/24\n",
+      "\n",
+      "L'écart non nul est un artefact de l'ordre de sommation en float32\n",
+      "(choix de noyaux BLAS selon la taille des lots), pas une différence de\n",
+      "calcul : les tokens générés sont identiques.\n"
+     ]
+    }
+   ],
+   "source": [
+    "torch.manual_seed(11)\n",
+    "prompt = torch.randint(0, CFG.vocab_size, (1, 128))\n",
+    "n_steps = 24\n",
+    "\n",
+    "# --- passage naïf : on mémorise les logits du dernier token à chaque pas ---\n",
+    "with torch.no_grad():\n",
+    "    seq = prompt.clone()\n",
+    "    logits_naive = []\n",
+    "    for _ in range(n_steps):\n",
+    "        lg, _ = model(seq)\n",
+    "        logits_naive.append(lg[:, -1, :].clone())\n",
+    "        seq = torch.cat([seq, lg[:, -1, :].argmax(dim=-1, keepdim=True)], dim=1)\n",
+    "\n",
+    "# --- passage caché : mêmes logits, lus depuis les pas incrémentaux ---\n",
+    "with torch.no_grad():\n",
+    "    lg, caches = model(prompt)\n",
+    "    logits_cached = [lg[:, -1, :].clone()]\n",
+    "    nxt = lg[:, -1, :].argmax(dim=-1, keepdim=True)\n",
+    "    for _ in range(n_steps - 1):\n",
+    "        lg, caches = model(nxt, kv_caches=caches)\n",
+    "        logits_cached.append(lg[:, -1, :].clone())\n",
+    "        nxt = lg[:, -1, :].argmax(dim=-1, keepdim=True)\n",
+    "\n",
+    "# --- confrontation ---\n",
+    "diffs = [(a - b).abs().max().item() for a, b in zip(logits_naive, logits_cached)]\n",
+    "argmax_match = sum(int(torch.equal(a.argmax(-1), b.argmax(-1)))\n",
+    "                   for a, b in zip(logits_naive, logits_cached))\n",
+    "print(f\"pas vérifiés                          : {n_steps}\")\n",
+    "print(f\"écart max  |logit_naïf − logit_cache| : {max(diffs):.3e}\")\n",
+    "print(f\"écart moyen sur tous les pas          : {sum(diffs) / len(diffs):.3e}\")\n",
+    "print(f\"argmax identiques (tokens générés)    : {argmax_match}/{n_steps}\")\n",
+    "print()\n",
+    "print(\"L'écart non nul est un artefact de l'ordre de sommation en float32\")\n",
+    "print(\"(choix de noyaux BLAS selon la taille des lots), pas une différence de\")\n",
+    "print(\"calcul : les tokens générés sont identiques.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a654c1b6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003948,
+     "end_time": "2026-08-25T21:47:32.943403",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:32.939455",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Le mur, mesuré : tokens/s naïf vs caché à contexte croissant\n",
+    "\n",
+    "Maintenant le cœur du sujet : le **coût** du recalcul. À chaque pas, le naïf exécute l'attention sur un préfixe qui grandit — le coût par token croît linéairement, le coût total quadratiquement. Le pas caché, lui, traite **un** token contre un cache déjà constitué. Faisons générer 24 tokens aux deux implémentations pour des prompts de 128 à 1024 tokens.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7b47b052",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:32.952675Z",
+     "iopub.status.busy": "2026-08-25T21:47:32.952302Z",
+     "iopub.status.idle": "2026-08-25T21:47:36.665986Z",
+     "shell.execute_reply": "2026-08-25T21:47:36.665403Z"
+    },
+    "papermill": {
+     "duration": 3.719582,
+     "end_time": "2026-08-25T21:47:36.667006",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:32.947424",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ctx=  128 | naïf  106.5 tok/s | cache total  197.2 tok/s | décodage seul  205.0 tok/s | speedup ×1.9\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ctx=  256 | naïf   72.1 tok/s | cache total  194.6 tok/s | décodage seul  206.3 tok/s | speedup ×2.7\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ctx=  512 | naïf   36.5 tok/s | cache total  155.1 tok/s | décodage seul  177.2 tok/s | speedup ×4.3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ctx= 1024 | naïf   14.9 tok/s | cache total   83.5 tok/s | décodage seul  103.8 tok/s | speedup ×5.6\n",
+      "\n",
+      "   ctx  tok/s naïf  tok/s cache total  tok/s décodage seul\n",
+      "   128       106.5              197.2                205.0\n",
+      "   256        72.1              194.6                206.3\n",
+      "   512        36.5              155.1                177.2\n",
+      "  1024        14.9               83.5                103.8\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAuMAAAGZCAYAAAAjLD+eAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAxYdJREFUeJzsnQV4FNfXxt+4kBAjECQ4BIfiUlwLpdS9pe4GtX+Vuru3Xwt1pZQWKO5W3N2DxEhCQhISIvM97x1ms7vshk3IZiXn1+c27Mzs7J2ZMzPvnDnnXB9N0zQIgiAIgiAIglDl+Fb9TwqCIAiCIAiCQESMC4IgCIIgCIKLEDEuCIIgCIIgCC5CxLggCIIgCIIguAgR44IgCIIgCILgIkSMC4IgCIIgCIKLEDEuCIIgCIIgCC5CxLggCIIgCIIguAgR49WMwsJCvPHGG5g2bZqru+LWbN68GS+88AIOHz5caev8559/8Oabb6pjIAiCIAiCQESMVzP+97//4euvv0bPnj0tpn/77bfw8fHB2rVrz7mOAQMGqFbZUPyyD64mKysLl112GTIzMxEfH18p6+R+vfbaa9G8eXMEBASgqjCO68GDB+HONG7cGLfccguqMzxOPAe8FR5fHmdvt3Vnb6c3wWPFY/bOO+9Uye/RuRIcHIzly5ef97oWLVqk+s6/Fd1u2qzgGNu3b4e/vz+2bt0Kb0TEuAdh3GyMxotKvXr1MHz4cHz00Uc4efJkmd//+++/8eOPP2LWrFmIjY2ttH4dO3ZMiYiNGzfCG7j11ltxwQUX4P3336+U9Z04cQJXX321eiNxxRVXwBm89tprmDp1qlPWLQiC6zCcFMePHz9LWDZr1gzR0dFYtWoVatWqhQsvvNDuejRNU86Fzp07o7ry0ksvoUePHujTp4/FwxP3b82aNXHq1KmzvrNnzx7TPbcqHhr4Vpb3oCZNmqh7fFhYGDp16oQnnngC+/fvt1jW6LvRuA0dO3bEu+++i4KCApPod6Sd6yE2Pz9f3RO5/yIiIlTfWrZsiQceeAC7d+8+y16NFhoaijZt2uDZZ59Fdnb2Oe3aoF27dhZOP65j1KhReP755+GN+Lu6A0LFLig8URnukJycrJ7MH3nkEbz33nsqFKJDhw42v8eTbebMmco7ez7MmTPnLDH+4osvKm8QLxqeDPdR165dMX78ePj6Vs6zKh9SeCG67bbb4Cwoxq+88kpceumlFtNvuukm5ZEPCgpy2m8LglC1HD16FAMHDkRGRgbmzZuHLl264KqrrsKXX36JQ4cOoVGjRmd9Z8mSJThy5AjGjRuH6khaWhq+++471ayhxzUvL0+Fb9JxYs5PP/2khCfFqDn9+vVT4j0wMLDcfeHx4Xet35L+3//9H+699171YHXDDTegVatWKCoqUt7g77//Hh988IH6np+fn+k7vLbzbbfh+Pnzzz/x2GOPYc2aNfjmm2/www8/WPwGhTrtwNrZVJaDjoJ5xIgRWLduHS6++GJcf/316iFh165d+PXXX/HVV1/h9OnTFt/5/PPP1TI5OTlKM7z66qtYsGCBeitR0Tfg99xzD0aOHIl9+/apB1FvQsS4B3LRRRcpwWjw1FNPKSPnSXLJJZdgx44dCAkJOet7Dz/8cKX8fkUuPp4CHyiefvrpSl1necN6SkpK1IWNN4DzhRdt8wu34Hx48+QxdMfzhIKDnirBc6Hzg0I8PT0dc+fOVUKcULx98cUX+OWXX1Q4ojU///yzcjDw4bw6wrfCFN2jR48+ax4FLb3l3HfWYpz7jR5ZilxzuC8reo023mybs2LFCiXE2Y/p06cjPDz8LBFNQWsNt+nGG280fb7vvvuU9/q3335TDjrzeYTimSGY1tPLgh74DRs2YPLkyWe93X355ZfxzDPPnPUdOof4UGGIaH5vypQp+O+//9CrVy9UhCFDhiAqKko9UNEp6U1ImIqXMGjQIDz33HPKK8KLjjk7d+5UJwZfZ/ICQCFPD7q9m/Xdd9+NmJgY9crr5ptvVieuPXFJr3y3bt3Uv/lqzXg1da5YuGXLlqnvsT98wqVHxx7cHt5w+IDBbeDNxNHESvaP22v+O/Zi0x35HW43X58xfo03RAqb+vXr46233jprfXxNOGHCBPUmghd7viLmq0ZON4d94as+emDatm2rlmUoEeFr0d69e6vjwX6xf7wgWn8/NzdXXaCM/W/EX9uLo/3ss89Mv8VQp/vvv195VSq6rfa8KbQ92lRFYH/4xof7jf3kfmQCLIWuIw9VfDg1jj/3Xfv27U3xnbwp8DPtgvuUNxpHHqCs44HNY17ptaKNsa/cZ/bg8ad3kp4o3nD5AE1P1bl+q7y5FcbxozeLXjweP+NB01HbNM6L7t27q+/zRsh1mb8dY/gbxQrtiOviPuANuri4+Jx95LH88MMPTceC+4QeOCN3pazY2orE2PM48Xu8TlpDpwYfoIzrHcMTKCDi4uJU3xo0aKCuCcwpKS/cTtoHzzmuq06dOuo6a31tPRdJSUnqXExNTVXHwNwpQxFHe6F4tIZvUXnd4Hd5nM7ldb/99ttNx5NvYSkSDc8nvfH0vPKY0fPJ+wQdRJs2bTprXfQm8xgxnIHbXbduXVx++eXKs2kNvavG+cN7Az271pTnXmYNw/goUtlnW9DbyzfH5tdB9oF2wHmOxIw7es20Zdd8u8xpvA9YC3HC7eV5dS7nCh8SjGtXZeRPMARqxowZyiZshVnyeDkSvkONQg4cOFDhvgQEBKht4zXH2xAx7kUwJIGY3yi3bdumkjXpLae3hE/XNWrUUOEMf/3111nroCjksryAUojzwsBlGW9oi9atW5ueUO+66y71SoyNN2x7bNmyBcOGDVM3FP4ORTyFga3+0BPAfrRo0UI95VOczZ8/X63fWjxaQ4HFGzs9SLzQ8WLCvtqKrS7P7/AGyvUasXl8lfjkk0+qC7n5zZciixcpemI+/vhjtR/5avCaa6456/f5ZoMCjfMoTgwRxn8zfp39ZigKvSB8Hc2LowH3Ny+Iffv2Ne1/3ujtwX1O8c2bLfvPCywfUnhMrCu9OLKt9vjkk0+UfaxevRrlhQK+f//+SgjyuDAngmKDgokhRI6wd+9edRPl/n/99dfVtvDftGnua3qGaBcUBvSGOSLy7TFp0iR1jHkOcD9RLNjjjjvuUMKM+5t5BLzBUMw6A9o+hRLDx/ibFAjlsU3uH15X2EfaID9TuNNeDSgoKHB4XGivfLhhXKct76w1PCeNBy4+aPE7FB30njkDHmcKnt9///2seZzGY8IHDgpP5uKwHw8++CA+/fRTdWwZs3uu644teD4+/vjjyoa5j3jNox3yNxytrpSSkqIEDUMTZ8+ebXKCGHC7aO+8vvK6bw4f7imi6T0/l9edD170ntIWeN7x+C9evNj0UM19wGsoH3Z5reR28Td5vvL7BnwY4zK0GdoEzwu+neXDjHUSHh8g3n77bbWfXnnlFSUiKdrN901572XmcD0U1mXFy/P3uA/5oG7eL17zyhNnX5FrJvctzykKTT70nS/Gww6dOOeL8bBj6AtX96lLly7Kfszjz70CTfAYJk2aREWsrVmzxu4yERER2gUXXGD6PHjwYK19+/Zafn6+aVpJSYnWu3dvrUWLFmetu0uXLtrp06dN09966y01/e+//zZN69+/v2oG7A+X4Toc4dJLL9WCg4O1Q4cOmaZt375d8/PzU+sxOHjwoJr26quvWnx/y5Ytmr+//1nTrRk9erQWGhqqHT161DRtz5496rsV/R1uN7/7/fffm6YVFBRocXFx2hVXXGGa9sMPP2i+vr7a0qVLLdb5xRdfqO8vX77cNI2fuey2bdvO2oa8vDyLzzw27dq10wYNGmQxvUaNGtrYsWPP+r5xXA8cOKA+p6amaoGBgdqwYcO04uJi03KffPKJWm7ixInl3lZ7TJgwQX1/4cKF51y2UaNGFv1/+eWX1Tbt3r3bYrn//e9/6lglJiaec3387RUrVpimzZ49W00LCQmxsL0vv/zyrH5a27gB+8h1G3C/8rs1a9ZU+/ZcbNy4US1/3333WUy//vrr1XTuM3u/Zb1fz4Vx/Ghz5jhqmzxXuNxll11mYSvGNcSejZK7775bnXvm1x3r7VmwYIH6vYceeuis7xvrN/avrWuL9f6ytnV79OrVS13nzFm9erWFrW/YsEF9/uOPP7TyYr2d3M9c108//WSx3KxZs2xOt3e8uU7a2cqVK+0uy2sIl33qqacspl977bXqmpuVlVXmb918883qmNu6xxjHhMfU2h64z4OCgrSXXnrJNI3XEvblvffeO+fxjYmJ0TIyMkzzeb/h9GnTppX7XmaLvXv3qvV9/PHHNo8XrzXkyiuvVL9DuI281r344oumfr799tum7/F6Yeu64cg109quN23apD4/8sgjZ/UvPT1dS0tLMzWuz7rvxjxu52uvvab5+PhoHTp0sLkvRo0aZfO6Yg+e/+xbZmamQ8sb9rpr1y7VJ24rr7G0jzp16mi5ubkWy3EZW7Rt29bmNfjnn39W31u1apXmTYhn3Mugh8qoqkJPCJ+26Q3iNIYNsNFbRo8MX7/xlaQ59P6YJ5Xw9SS9sf/++2+l9I/eEnp16M1o2LChaTo9qOyTOfRQ0IvH/ht9Z+NrY3qwFy5cWObvMLGJv2P+Wpav5ekpPJ/f4T42j7fjq216k8wz3f/44w+1TfSKmK/TeFVnvU56lZgtbo157D89LvQq0QO+fv16VATuE3r96I00T1C988471etmc4+7o9talgeemqkiZTC5/7id9FKa7z/GDPLYMhntXHB/mscm8hU14TEwtz1juiPbZA++XXCkQpFxHj300EMW03k8nAHfmNALa46jtknvJ88Lermtk5nNw2TMbdS4zvDY0dvHsAJ7MAaX6+FbMWucWeKUHl+G7piHSjC+lvtqzJgx6jOrRRBeqyoaZmW+v7m+oUOHWuxvevh4fpV1HbP2jHN5hnqUZfN8k0bPtgFD2OjdpJea57g9eKx5zPm2xDz8xfqYcD8Z9sBzkfcT9ishIcHiusTjy5hhvlmwty7zY8Jz3YD2Y35OVuReZg6XI+a/YQu+WWDYCd8+8Pf411aISllU5JppeHlthdA0bdpUXVuMZh2Ww+NrzOP9jaFovO6d622Boxh9sxU6Uxa0B/aJYU5848G+8f5yvjkrUWeOob0qLJ6KJHB6Gcxcrl27tuk1PcUQY8nZbMFQEca0GVB8mmNc/Curdi8z2pkNbv07xslrLvp5gWX/bS1LyqrXze3i79iqHGM9rby/w9eI1jcTXiBYksp8nXydak+gsX/m8IJlCyby8LUtK7KYx/NWVKwYsbLc1+bwhsGLvnUsrSPb6gy4//gbju4/W5gLbnOBZV073phe3vhdR46fNdy/FDLWlQCsj0dlwXPbOpHUUdukWGVfbT0kmsPwAVYLonixfnVcVnw1188H5bJCepwBw7wYUkMBTuHCc5+CmQ/phljl8eQyDMNgOAnFIUN7KLIMe3EU7m/uB+O6XBFbJgzZ4u9T1DPnxt76GIrCmG4mBDLfhAKbDxRGiAoFNK/D5vAY0P55/Bjz7EicP/NOGP9rnhtgHoLA40u7pjOnvOeqIbiMc7Ii9zJb2Au3NGClDopO2gavuQwF4v2iPPe/ilwzDaHL+7c1jI9mmA1j8nlcrWFYlzGInxHjXxmhLgbGOcGHoMjISIe/x4cxfpf3T/anItVPfGzc54xj6A5jklQmIsa9CCaB8aJviE0jBpYnsLXX2eB8yxw6E/afJxxj7WwlrdhLxHH279hLoDG/0HOdTHDizdwW1oLQVvWbpUuXKgHAuHXe+PhQxAsb45NtJWk5A0e21Rlw/1F0MKnQFkwIq2jfHdkm2oOtbbSXlGjr+J0v9m42jiRGltWv8tpmWTB+mm91eNNlTDlvuBQH9JAyTvZ84vArax9YwwcAimvGiFOMMy48MTFRxaybw3hfJtFSDDEPh28zmHvA5csjdrgPKJwp6m3h6JgP3M/sM2ObeT2nB9fWg8F1112nzhteIyjG+ZdikEKTMCnd+uGR3nm+LXEE5q5QELNUKxMKKeT50Ma3OxU93uc6J8/3XmY8JJzrgZtilvuXyfD0ZFdkEK6KXDPZd3sD2vC4E3sPNfw9vjF0FnyDRpgXYLyxcATet4xqKrYwqsnYqu1O+ABpq1qNcQzLWrcnImLcizDqiRoXK3o6CQWcoycrvThM8jLgkzoz+I0LuS3K84TKGw8FAn/HGtYsNYc3dl7AeONwRHyZw5sfT2R6VKyxnnY+v2MPrpOejMGDB1f4CZ6eBW4DX5Wb1wmnGLfG0d8w6g9zXxv2QRi6Qi+XMy/q5d1/tD1X9YfixdZrZVtVOMoD9z+FheE1tGf7Rh9sJQuebx8ctU0ux76yMoS98QMoCBkCwFAv86RtRyomcP20bYYg2POOGx5S6/1wvvuAYREsAcf9Ti8oX53bKnnHhxY2ev7paWYCJssH8m2Vo3A7GR7G757vQxv7OHHiRIwdO1aFnfAhwXqdfNjgNZzefopmlj/kQ4XxhoThd5xmDpMNKez5UHWuEQ6NqiysYW0Oj5G5QOJ2sxIHvbrnO+pwRe5l1p537idH7JJhKdzHVVkGkomoDOdjoizDbc7l4a9KjAR4vpkpjxgvz70o3soBQCHOh0YmVFvDY8hjU1n3andBYsa9BL4ippeCgtJ4HUlByhOclTIoqK2xflVplJcyz2Bn4X7WTbaOs7a+kBBHqgzwKZ4PC3x1Sm+UAV+b88ZsDj0UXJ7Z+NZeBX424gDt/Q4v2vwd8wx/CnHrrPbz+R17MLaRF1UO4mANPQGM8zsX7BPFkrkXkK9LbVWD4TFwZP9zn/CmzCoJ5tvKGyvfqlRmVY/zKW3I/bdy5cqzbIJwO2mTzoRCgn03P0coYM93GG3jPOL+N4eVTmz1gcfE/PU2z+PzjQV11DaZb8GbHj3e1h5Pw3YML6C5LfHBjm9yHImz5/d43lljrI/ikALPOkfAkfWf67fZd9aVpmilsDWuY4ThGtY2RlHO/WGr/OO59jfPYV6freFvlLc6C6ta0F4YqsLtsFWNhfcAhm0wVpfzzauo8AGf1wHzxocebhuPOUMejNKS9o659XWS+9A6Zpt94zWAVZXsrctRKnIvM4cinnHwtrbLGj5o8Fix33xwqSqYm0E7YSiSrXAVZ7+NtAfjz1kdhgML2br38Hy3FT5zLugM4L2IGqPE6vpCHWJPdzDfgyVCyxsu5u6IZ9wDoZikUKCxMqmHQpyeDj5pMrnD/NUOS3JxiGTeSJikRw8Dv0Ohw7AW69qwPLF4kvAGwidW3vT4fYZL2IOigbFk9Bgx9o03NSbF2Yuj5c2Xpbb4lE3vFLeD5dV4gpkLD66XHiiWs6MI5Y2C6+eTMQUJk03LugjwFSM9R/RIMRGVFzpeYBkTyXjAyvodezdMvlLmYAd8Bcw+8Pd53DidItNWkpQ5FMYMJeCFkN4a3lx5PPlK0zr+kMlg9L5xeXrGuO+NxETrNxPcTh4DrpfH1TjOjI8sz0AQ54L7mr/D7S9vEifLpRlJZ/TqcfsoEvmqlJ45HidnvqbkK3juSz44svwe9z3tmzZ6PiW16GFmGAH3N4U2wwhYQtPWGxx65Rjqcdlll6kQCT7U8MZFj1BFE3jLY5u0Mw7mQWHCc5UPrXxDwxJxtDF6y9h/Cjl6atlHPjzyDZ0jwoGih33hgwnflNEeeVNmeBbnscyqUQqSJSD5l/2iMDcffrsiUNzxN3iMGQtrXdKR11T+PuPLub95jeJ2UYjaqrVcFgwzoCjm/uJ1h94+ikNuM0Us469ZO7s8cF/zjQLPL6MErXmSLfvIaytDbOh1LKvUrHUICq+Z7DOvewxdofhlPyn+eZ3nOckHNCYG8/jznOTvm79pI+wXR41k7D3Lm9KGeA7zOsW+GcmyjlLee5k1/D3aM8/fshJZuR/5JqSq4f7hNZMJr8xfMkbg5D2Z9s59TPFalQ8IBjyOtFteA+gpp0bgfZ42zGRh2ogjtcatz0E+gHBf9+vXT92L+IaKb6D4kMzfs35bxQdLvj2g/Xgdri7nIjiOUbrLaCxRx5JJQ4cO1T788EMtOzvb5vf27dunSlZx2YCAAK1+/fraxRdfrE2ePPmsdS9evFi76667tKioKC0sLEy74YYbVGklc2yVfWMpqjZt2pjKBp6rzCF/h+XFuA1NmzZVZdXslWz7888/tQsvvFCVcGJr1aqVdv/996vSSedi/vz5qtQjf6dZs2ba119/rT366KOqzFdFfofbzZJL1tgqQ8cyhG+++aZanmWduE+5zSyVZV5ijNvM37HFN998o8p28fvsD/errf20c+dOrV+/fqpsH+cZZQLtlXtjKUOuj/bAclP33nvvWaWryrOtlV3akJw8eVKVaGvevLk6frVq1VJlzN555x2L8pv21scSXtbY2te2ypaRH3/8Udkmf7tTp06qNKK90obW3y2LU6dOqXJ+LOdGO2MJzsOHD59Vqo/MmTNHlbJkHxISElSfylPa0NbxK49tGiXqeA4Zy3G9c+fONc1nKcSePXsq26tXr572xBNPmMpImh97W3ZTVFSk9h1tkdsYGxurXXTRRdq6dessSifefvvtqmxreHi4dvXVV6sykhUtbWjwf//3f2p5rpPHxJz9+/drt912m7pm8FoRHR2tDRw4UJs3b94512vv/Pjqq6/UPuZ+4m+yTB/31bFjx8pcX1kl4B588EE175577jlr3lVXXaXm8TfKA8t+8n7BY8FjznOA54xRUo+lBXkNrVu3rtqWPn36qHKLtu4LPHbPPPOM1qRJE3Wt4T2I5QN5TzrX+WPrfHDkXmaPlJQUdX9iaU97pQ3tUZ7Sho5cM8sq2cmymtzGhg0bqnOCfWOZQu5zli4sb9/Pt7Sh+bHktbdbt25KG7BvvDfRBs37da6ShdbwmtazZ0+1HcZ9jtch8xKWBjNnzlTrZtlVb8OH/3P1A4EgVCX0fLMChK24dUEQBME74Vsuepn59kXwzHu3j49PpZVtdCckZlzwaqwztSnAWT6xIrWvBUEQBM+FNe0ZZnW+uR9C1bNjxw5V6tdW7oU3IJ5xwathOUDGHBs1tBlzywSsDRs22K0rLgiCIAiCUFVIAqfg1TApjMkgHEmNyWfMDGeSkghxQRAEQRDcAfGMC4IgCIIgCIKLkJhxQRAEQRAEQXARIsYFQRAEQRAEwUVIzDigBprgKI0c6KWiQ5cLgiAIgiAIggEjwTmwGAdKMx+YyxoR44AS4hylTBAEQRAEQRAqk8OHD6NBgwZ254sYB5RH3NhZZQ2TK5z9RiEtLU0NsV7WE59Q/RDbEOwhtiHYQ2xD8DbbyM7OVs5eQ2faQ8Q4S8qcCU2hEBcxXr6TIz8/X+0zTzo5BOcjtiHYQ2xDsIfYhuCttnGuEGjP2yJBEARBEARB8BJEjAuCIAiCIAiCixAxLgiCIAiCIAguQmLGBUEQBLeiuLgYhYWFru6G4IK4YB53xgZ7YlywUP1sIyAgAH5+fue9HhHjgiAIgtvU5E1OTsaJEydc3RXBRcefoot1mWXMD8FTbCMyMhJxcXHn1S8R44IgCIJbYAjx2rVrIzQ01O1uuoLzBVdRURH8/f3l2AtubxvsU15eHlJTU9XnunXrVnhdIsYFQRAEtwhNMYR4TEyMq7sjuAB3FFyCe6C5qW2EhISovxTkvHZVNGTFfQJvBEEQhGqLESNOj7ggCIKnYFyzzifPRcS44HWsPLYSY6aOUX8FQfAs3MnrJQiCUBXXLBHjglfBV1kfrv8Q+7P2q7/8LAiCIAiC4K6IGHch4sEtJb8oHydPn0RGfgZSclNw5OQRHMg6gN2Zu9Vfc/5L+g/zE+dj1sFZmLZvGv7a8xd+3/U7ftrxE95b9x62pW9Ty/HvimMrXLRFgiC4iuISDSv3pePvjUfVX352ZwYMGIBHHnlExczTy7Zo0SI1/YUXXkCdOnXUtKlTp9r9/nPPPYe77roLrob97dSpU6Wtj/uB2+6J1XUqa1/873//w4MPPlgpfRLcF0ngdBMPbs+6PSvt9axKdCgpQmFJYWkrLv13jYAaiKsRp5blcquSVtlcjq1BWAP0bdBXLVuilai+mpYrLsTJvJPwD/RHoVaIVtGtcFeH0hvC2JljcarolM11d4rthI8Hf2xadtAfg5QYt0WHWh3w06ifTJ+fXfYsUvJSbC4b5BcEXx9f1Vf+fWLJE+hdrzd61euF7nHd0SC8QaXsY0EQ3JNZW5Pw4rTtSMrKN02rGxGMCaPbYES7ilc7cCZTpkxR9YrDwsKQlJSE6Oho7NixAy+++CL++usv9OzZE1FRUXYr0Hz44YfYsmVLlfdbqDwOHjyIJk2aYMOGDRYi/rHHHkPTpk0xbtw49VfwTkSMuwh6bM09uI8sfASxobEWorVfg34Y3Wy0WiYtLw3jF423K7DHNBuD8V3Hq2XpXR7w+wC7v31Js0vw6oWvqn+fLj6Ne+bdY3fZoY2GmsS4D3wwcetEu8vmFeVZfN6RsUOJcVtkn862+BzgG2D6t7+vv/pstJpBNS2WbRPTBnVr1EWAnz7fWP5EwQmsS1lnWo6CnL9DDzobqR9WHz3q9lDCnI37XBAE7xHi9/64HtZ+8OSsfDX98xs7u6Ugp/g2YL1ism/fPvV3zJgxZTpqvv76a/Tu3RuNGjWyu8zp06cRGBhYqX0WqoZatWph+PDh+Pzzz/H222+7ujuCkxAx7gLouf54w8fwhS9KUKKmLTi84KzlaoXUMonxYq0YG9M22l2nubilSLUm0DfQJF5D/EMslqVH21z8+vuViuGOsR1Ny/KGcEvbW5THWS3n44+CUwWIDI9EoH+gErrmvNv/XdOyxm8bLTTAsmLCzMtnmoT1ud4QfDToI5v79LoZ15m84qY+w0ftR/Zt6/GtOJpzFFP2TFFtYPxAi3VxH9YMtBT+giC4Dp7XpwqLHVqWoSgT/tl2lhBX61HXAuCFf7ajT/Na8PM991vIkAA/h99WMsykQ4cOCA4OVuKYwveee+5RoQoG7733HiZNmoT9+/cr8T169Gi89dZbyhtOvv32W1OoCr9HrzgxRhu0l//y66+/4t577z2rP+3atVNl4H788Ue0b98eCxcuxNatW/H4449j6dKlqFGjBoYNG4b3339fCT7CQVXeeecdfPXVVzh8+LAKkbn77rvxzDPPqPlPPvmk8tQfOXJEPTTccMMNeP7555VX3x4TJ07Eu+++i71796rtvuKKK/DJJ5/Y9ARz27nMggULMHDgQIf2Pb/DfjGMJysrC82bN8cbb7yBiy++WM3/888/VR/5+6wDzZCPRx991PT9xo0b44477sDu3bvVGwqW1fz444/Rq1cvNX3+/PnKI83t6Nq1q8Wx4l/uT+6r/v37q2MfHx9vt6+cz31x4MAB9bsPPfQQ7rvvPjWP+4JccMEF6i/XZ4Qr0VZ4DESMey8ixl3sFTfn4iYXo2lkU5N4pUg2iAqOwgcDPygVzIb3+IzIjQyKNC0bHhCOFdetMC3j52P/psL5f4z+w+G+P9q19CLGC7dRW9PW8LSGR90RrMV5Ze1TDRrSTqXh5T4v44LaF2B96noVlsPG0CADxqiPnDISrWNao0dcD+U95/Ln2y9BECoOhXib52dXyrooZZOz89H+hTkOLb/9peEIDXT8Fvndd99h/PjxWLVqFVauXIlbbrkFffr0wdChQ9V8XiM/+ugjJbooyCnCnnjiCXz22WdnrYuhCRRrt956qwpbsUdGRga2b99uEonW/aFIX758uUm0Dho0SAlMCvBTp04pEXv11Vcr8Uueeuop/N///Z+af+GFF6rf3rlzp2md4eHhSoDWq1dPhcXceeedahq3wxb05nKfUBxfdNFFSiwb/akMeA/iejkqIx86mjVrpvaHUet53bp1avv4cHPNNddgxYoVar9TcPP4GHB7X3vtNRV7z3/fdNNN6m3DbbfdpgQw99PNN9+Mbdu2me6lHOzl1Vdfxffff68evrjea6+91u72/fTTT+qhgA8iFNx8COH+40PR2LFjsXr1anTv3h3z5s1D27ZtLd5kcDofgPgAQ7sQvA8R467yilt5cPn5QPYBvNb3NZvCmbHQgxsOdug3+P3wwHBUt31KLzjFtzWczvm/jPoFF9a/UDXjewZbjm9R392evl21SdsmqYcZxqtTmI9sMhKNI+QiKAiCbegZnzBhgvp3ixYtlOiiV9UQ4/SkGlBQvfLKK8p7bkuM01vOIbbNw1ZskZiYqK5jFMfWsA/0vBvw9ygCKToN6O2lJ5deYXqNGXvOflMcEopbinKDZ5991mIb+NBAz7w9Mc7fpBf64YcfNk3r1q0bKgsKV4pYxte3bNlSTTOPq+bbiMGDByuRTbgMxToFtrkYHzlypHoDQCiY+RDBfl511VVqGsU4PeUpKSmm48Ga0txXPXr0MD38tG7d2iSqraFt0Ct++eWXq898KGNfvvzyS7W/Y2P1kEk+KFgfc+P4Hjp0SMS4lyJivIqx58GlMDeqf/Sp38clffNUGDOfnJtsU4gTTud8LhfoV+ptMH/ouajJRehcuzNWJ69WjZ7zpNwk5UlnS4hKMInxYznHkJmfqd5c+PlWbLQtQRDgUKgIPdSOsPpABm6ZtOacy317azd0bxLt0G+XV4ybQ3FrDJNtCMfXX39deZqzs7PVaIL5+fnKw1rRgY7o3SYMj7GmS5cuFp83bdqkQlWMsBhzGJ9Oz3lBQYESr/b47bfflHefy+fk5KhtqFnTdmgft/3YsWNlru982bhxIxo0aGAS4tZQpDPm3hy+rfjggw/UiK+GB9382DE0hzC0x3oat8kQygwBMn+waNWqlXqA4m9ai/Hc3Fy1z26//XblDTfg/ouIiHB4lEfaiuCdiBh3Qw8uq3/IwBeOQ4H968W/qsRVe0QHR1sIcVvUqVFHxeiz8VgxdGVVsh7S0jWu9DXw1L1T8fmmz9Xbh251uinPOVvTiKZy3AShEuH55GioSN8WsapqCpM1bT2W88yMiwhWyzkSM15erOOm2XeGURCGFzCGmWEjDG1gXPSyZcuUOGNyZUXFuBHrnZmZafKsGjD8wRyKZ8Yev/nmm2ethw8ODJ0pC4beMEacsexMKKSIpFec3t6yBKQ9bMXCl3cEw3P9RkWOnXENtzXNOJ7lhfueMATI8KQbODJ8OsORiPUxFrwHl9YZp5eAT5aMOWPc8aWXXopdu3ZZLEPPwf33369e3fCJnskffFVk/apu1KhR6oLG9TChgk+cnuzBFcoHSzWyyoq9ZpRydBRefONrxuPKllfi7f5vIyKo1HvBcpBhAWGqFCMTb19f/Tou/ftSVZ7xySVPIqsgywlbKAhCWVBgs3whsZbaxmfOd4YQPxeMXaaQo3BlmUJ6cuk1Pl8YRkLPNMMdzkXnzp1VzDPDHJjkaN4o3BnWQnHL0BpbMN6aFVuYSMgYdS7PsAl78L7O37K3PkNYmsfE09NdHujRZiw1w2xswbAR6xhufub+d0QElwU1xtq1a02fqV34doG/aQ096ww14QOP9b43EjeNGHF67K1h4i0fDhhLLngnLvWML168WAltCnIa9tNPP62yu3lhMZ7qWVtzxowZ+OOPP9ST+AMPPKBirowTjIZLIc5XR7xY8MRmogUN1zw2zps8uIJreajzQ7iv033Ykb7D5DnfkLoBx08dx9KjS5VQN/h7798qSbZ73e6qqosgCM6DZQtZvtC6znici+uMU3TR68sqHfRO8/71xRdfnPd66V0eMmSI8rLTmVUWvNfSM3vdddepGG9651lhhN5tVvlgqAtjozmPwpDhHGlpaUrA04NP8U3HF5fnPZv3ZVZWKQsmTjIunk4yI9GS286KJhT+fDBhcicFKUNAjNhuR2HFkX79+iknHePDuZ8ZBkRnyogRI1S8Ovv68ssvqwROevcZ520rTr+8UGNwOxi2w5AVahNuj614ccI3CqyeQh3DvjEkiGKebzWY5Mp9xH0ya9YsFXrD42GEsLD6Td++fSvtTYDghmhuRGpqKl3G2uLFi9XnEydOaAEBAdoff/xhWmbHjh1qmZUrV6rP//77r+br66slJyeblvn888+1mjVragUFBTZ/Jz8/X8vKyjK1w4cPq3VmZmZqxcXF0hxshYWF2rFjx9RfV/fF1e3U6VPaf0f/0/7Z849pWlFRkTbsj2Fau2/bqTbmrzHaqytf1eYemKtlnvJuWxPbkFZe28jNzdW2bdum5eXlaSUlJefVCouKtRV707Sp64+ov/x8vussq/Xv31976KGHLKaNGTNGGzt2rOnzu+++q9WtW1cLCQnRhg8frn333XfqvpORkaHmT5w4UYuIiDAtP2XKFDX/XL89Y8YMrX79+up6U1Z/2Hbt2qVddtllWmRkpOpHq1attIcffljtf87nOl5++WWtUaNG6t7bsGFD7dVXXzV9/7HHHtNiYmK0sLAw7ZprrtHee+89iz4///zzWseOHS1+k/fjhIQEtT5u/wMPPGCax+Pdq1cv1ZdOnTpps2fPVtu8YMECNZ9/zfeRrXb8+HHtlltuUf0KDg7W2rVrp02bNs00n/qhTZs2pu156623LL7PbeV2mE/jb3L/G5/379+vpq1fv97iWE2ePFlr2rSpFhQUpA0ZMkQ7ePBgmfvixx9/VNsZGBioRUVFaf369dP+/PNP0/yvvvpKi4+PV5qGx9CYzv33888/O9WGPaEVFBS4vA+2Gq9ZtGVew6yvd9SVtB1qzbLw4f/gJvApnU/fLJnEGqkst8TkDz45GpnlhK/KmJlOrzkzn//55x+L11us4cmM6vXr15tqdppjXsPVHL7q4qs1Z+J78hh88zPtzi8JjkJJ+NmZ8e4IX7uyVBWf3m2VNqzuMNxo4p6J2Ji+EftO7rMIT2KN+X5x/fBMR71+r7chtiGU1zboOeZ0Xt9tJSQKtuEtnF5sel1ZWs/Tt8VIrHTn/BuWM6TXnW8OnA095XxbQT1DD3x1RXNj22A4NUO2eE2zzh3h2yCGRfHaZi/Zmfi70wWaApsXFQpxY5hfvi4zF+JG/BXnGcsYmc7m8415tmAtVb4WMmBmO8s7MYatrJ113mQdhs/XI+BTVGB3Ec0/CNr9a4AI+wMHuNMx40nB/SaCyzbPxemvXTk66NrktSqshdVaDmYfRFxEnHo1aYyE+uDCB1Vtc44M2j6mvc3BmzwFsQ2hvLbBGxpvXBQc1Vl0VAQO0kMnlrfst7IGEXIHDLutiv3N84KDRckDqvvaBu2ANsHcRuvj5Ohxc5szl/FsTFJg7JuzCQoKUs0a7kynCodTmUAZQpxQqPtwuSj7Qxu7E7ypOn2/eQHRIdEY1mSYakQl8mqaab9tSd2C/5L+U42VWjhKauc6nU0DELG0oqeVURTbEMpjG/w3pxtNcBy+Abb1FtjT4DXROPbubANV2Uej1nl1R3Nj2zCuWbbud47e/9xCjDPxYfr06ViyZIlKXDBgUibLPjFD2dw7bl54n39ZZN8co9pKWYMluDWp2wEmcQbWAALDgMBQwD+YR9zVPXNfThwG8tLtzw+NASLd522DdXWXJhFN8Hyv51Uy6Oqk1cgsyMTyo8tVI491fQxj2441VXMpa1RVQRAEwXlwwCDzQYME4Xzxd/WTDrORmZG9aNEiU4kf80EL+EqCpZGYLW2UD2JGN0fDIvzLuq3GsOxk7ty5KtykTRu9zJXHMfXes6f5+OrCnMOzK5Fu1tS0sDOfzf7tyHT/IM8X+RTin3Qp+60Dt/OBdW4lyM1hpZWrWl6lGgeA2pO5Rx+AKGk11qastahzPuvgLLy39j1VocXwnNcL84w8A0EQBEEQ3EiMMzTl559/xt9//60SJ40YbwbBs4QP/7KkEuO7WYaJApvinQKcJYQISyFSdN90001q6F+ug0P2ct22QlE8grA4gLXGT+cBRfoIa9BKgIJsvVUmZYl8Jdxr2J8eEILAPPazPhAc7jqRT4/4OcJ/1Hwu56Zi3BxfH18kRCeodlObm5QnnNMM1iSvQdqpNMzYP0M10iCsgWnwof4N+iOUx0IQBEEQBLfHpWL8888/V38HDBhgMZ3JCsYroPfff1/F3NAzzrqcHPnLvEYoM2sZ4sKRzSjSWZ987NixeOmll+CxXP8bUK+T/u+SYuB0LlCYp/89naOLdOPftqYX8rONZj69KP+8RT7lYfS5RL7JE28WcmP829b0ssS/t3jyy4m/r+Vp+nSPpzGqySgVX07v+dbjW3Ek5wiO7DmCP/f8iYVXLzSJ8cTsREQGR6JmoBMTkwVBEARB8NwwlXPBTNRPP/1UNXuwFNa///4Lr4RJe8E19VaZGCLfJPQdEPlW07XTeSjKy4J/ST58jOmVIPLLxMfv7BCdakaQX5AKUWEjuYW5WJeyTsWbJ+UmWQwu9Mp/r6gKLm2i2yivOb/Dii1MEBUEQRAEwfW4RQKn4JkiXyspQfqZWH0fI2PYpsjnZ7N/25puU/ybefNNIr/YOSLfg6kRUAP9GvRTzfphl4mgjEHfmr5VtW+2fqNGBO0Y21GFs9zSTpKQBEEQBMGViBivSljRg2EW50o05HKeSlV48i1CbvKAlK3AvAnnXse/jwPdbgdajQKCnDu4kzvAait/jP5DlVFkOAs952wpeSkqKZQednMxPnn3ZLSNaati1c1j1AVBEARBcB4ixqsSJg+yoocHleDzCJFfozQso0yOrNYbQzQSLgLaXwU0HwL4B8KbYRnFS5pdohq95YknE5Uojw2JNS2TkpuCF1fqo9JGBEWgW51uprCWJjWbSBlFQRCE84AV43bs2KHy27wJjpD+0Ucf4a677kLdunVd3R2PRdxfVQ2FNpMz7TUR4s6jy61ATHO9Qs22KcCv1wHvtACmPQwcXMahAeHtUFQ3qtkIVydcjYENB5qm5xblqrAVhrxkFWRhXuI8vLrqVYyZOgZD/hiCKXumuLTfguBwmdNjG+03zhcsBCKvCRzLw9t54YUX0KnTmcIIZfDcc88pYVmZ7N+/HzfeeCO6detmMT0vL08Vp2ClOOM4NG7cGB988IFpGU6fOnWq+vfBgwfV540bN6Iqse6TAZ07LJhx6tQppwvxb7/9Vo3aW9V88cUXGD16tNN/RzzjQvUJ/+n7KHDx+0DSRmDLZL3lJAPrvtVbzfpAu8uB9lcDce2rVdWWphFN8cngT1QZxW3p21R9c3rPN6RuQOqpVAT7lQ7puytjF37Z+YvuOY/rjpgQDw6rErwHF443wOpfFFKGaCKTJ09WAozjYFD0FhYWYtasWWd9d+nSpejXrx82bdqEDh06oLpga58583uOwNLIH374IbZs2VJp62QVuGuvvRb/93//h65dS8eLIN999506/itWrECtWrVUOec1a9aoqnCewNtvv60eJF5//XV4K7fddhtefvlldZz69u3rtN8RMS5Uv/CfehfobehLukd8yx/A9n+A7KPAio/1VitBD2NpfyUQbTkYlbeXUWRyJ9udHe5EQXEBNqVuUnHkBkuPLlUlFNlI88jm6Fm3pxLmHJwoPND74/EFN8SNxhv4+uuv1VgX9KrdeuutaNasmfKAHjlyxGKUaaOUL0VadRLi7gqPW+/evVWFtvOBI4cHBurhjxzvxHqUcIN9+/ahdevWaNeunWlaZXt/6dWmV9m6hHRl8MQTT8DbCQwMxPXXX69CcZwpxiVMRai+4T+MQ2/aHxjzCfD4HuCaH4E2YwC/IOD4LmDhK8BHnYCvhwCrvgRyUlFdyygyjtygW1w3NRhRQpQu0Pee2Isfd/yIhxY+hAt/vRDb07e7sMeCV8Hyt7bGTLDVjAHSzgWXc2R9DpTetQUHn+PgdL/++qsS4uTiiy9WIouiyJycnBz88ccfanA7e1DAX3fddWrgO3pMKdxXrVplEnNjxoxBnTp1EBYWpsIg5s2bd5Zn9sknn0R8fLwShs2bN8c333xjscy6devUekNDQ5UY5UjX5nBgvs6dO6tSw02bNsWLL76IoqIinE/ICL3CXC/DLtj49oDQKz148GA18F9MTIwKGeF+Otf3uI0tW7ZU28A+MtyEbyPKA4+ZdUgCRewDDzygGj3X9GBz3ealmSl46T29+eablafYCHNZtmyZEnDcFu7/hx56CLm5uab1vvvuu1iyZInaDkMs2wsJqSo4mjn3AfvMUdF/+umns5bhm4k77rhD2TS3d9CgQerNjjnTpk1T9kib4T677LLLLOLMua+ioqLU8brooouwZ88ei+/zXGnYsKGaz++mp1s62xyx/aSkJIwaNcq0LRxk0nr/OrIt3B///POPCsdxFuIZFwTj9XXr0XrLzwJ2TNc95gcWA0fW6G3WU0DTAbrHnBVZKrtijIdgeM5JRn6GGhFUhbUkr0JqXipaRLYwLfvO2newI2OHaXTQdrXaqdKKguAQLHn6Wr3KXefEEY4t9/QxfSyDckBByEHpOBAdBaWBv7+/Eh8UGM8884wpIZpCvLi4WIltW1CE9u/fH/Xr11diIC4uDuvXr0fJmfwWzh85cqQKhaHQ/v7775VwoJimkCH83ZUrVyrPXseOHXHgwAEcP37c4nfYJwpDCpJ77rlHvZpfvny5msfX81yH4RmkCDLE5oQJtqtYUSAPHDhQ/RbFjzWPPfaYSmbMzs5WbwYIHzYoVPngwgH8GK5BYUihRCHMfWfve4SjeHOZevXqKUF/5513qmmOem8zMjKwffv2s0JJCB8A+MBED/fatWvV9nP/8jcM3nnnHTz//POmfcL9NGLECLzyyiuYOHEi0tLSTKKefZ8yZQr+97//YevWrerfhifd1TAM6NixY1i4cCECAgLUAwSPgzlXXXWVErgzZ85UDyhffvmlsvfdu3er4zFjxgwloGlXtEm+KTAfC4a/QfFNm6YAfvLJJ5Udc//zN/mwyf3N8JdLL71UhXdZ25qjtk9bpz1yvRzNvbzbQmgTfPhkv5zxhkGhCVpWVhYfcdVfwXGKi4u1pKQk9ddryU7WtJWfa9pXAzVtQs3S9nJtTfvtZk3bMV3TCvNd3Uu3IfNUpoVtjJ4yWmv3bTtT6/ZjN+2eufdo3279Vtt+fLtWUlLi6i4LbnLdOHXqlLZ9+3b110RBjuV5V5WNv+0gY8eO1QIDA9V9ZP78+TaX2bFjh5q/cOFC07S+fftqN954o931fvnll1p4eLiWnp7ucF/atm2rffzxx+rfu3btUr85d+5cm8uyL5w/b94807QZM2aoacZxGDx4sPbaa69ZfO+HH37Q6tata7cPq1at0hISErQjR46Uuc/GjBlz1vZGRUVpJ0+etOiPr6+vlpycbPd7tnj77be1Ll26mD5PmDBB69ixo93lN2zYoLY7MTHRYnr//v211q1bW1yrnnzySTXNoFGjRtqll15q8b3bb79du+uuuyymLV26VG2LsW8ffvhhtX5zuK7333/f9Jl9+uuvv9S/Dxw4oD6zr47C9ZnbXFkY9rJ69eqz7NboE7ehZs2aWn6+5X2vWbNm6viRXr16aTfccIPN39i9e7da3/Lly03Tjh8/roWEhGi///67+nzddddpI0eOtPjeNddco0VERJR5zzC3faPfa9asMc3fs2dPubfFgHb57bff2vxdm9eucupL8YwLQlmE1wF63qO39H3A1j+Bzb8D6XuA7VP1Fhyhh7cw8bNRH8AYAKkaEhkcafH5w4EfYk3KGpUMylrnJwpOYNnRZarVD6uPWVeUJrTRq85yi1JGUTDBEXbpoXaE5M2Oeb1vmwXEORCfXc7RfRnzTS8cPXjdu3dXr87NadWqlQoBoZeU3rW9e/cqr/NLL72k5tMj/eOPP1p4/lg144ILLjB56KzhMgzdoCeSr+TpveOr9MTERDWf3/fz81Pe9XP13cCoikEPIj2MfGVPLzk9kAb05ufn56tqIAwjsIbbv3PnTpQXer3ZF/MExj59+qg3AfR4MiTBHr/99pvy3tMjzf3CfUGvq6MYIQgMq7CmZ8+eFtcleu75JoH7gfuXWHvUud82b95sEeZBbc1t4RsDxoo7A2s74jFiGIjRT2KE/dja/3yL06VLFwu7jYyMtNgufp8hRNb7j/vesDvztwa2fqNHjx6maTExMUhISFDzjGXMw1qMY2CeAH0u26e98HcYXmXAEC2GxpRnWwzoPee+dBYixgXBUWKaAf2fAPo9DiRt0sNYKM5PJgHrv9dbeL0zFVmuAup2rFYVWWzBMopNIpuoUoocCXRP5h78l/SfEuYNw/VXiYRVXFhGMdQ/VMWoq7CWuB6oGyZ1a6s1PH8cDRXh+AGOLlfO8BNHYCgJK6gwPIPhCXztzTAJc/jqnfHkn376qQpVYGKnIZQpyhmGYS0AyoLLz507V4VIUGhw+SuvvFKFBTjyfQO+wjcwRKd5KAxjxC+//PKzvmdLuLoChuHccMMNqp/Dhw9X4QaM/6ZgdhTGNRvxzBVJorSugML9dvfdd6swD2uMMApnYG1HfPB78803LcTv+cDt4gObEatvjiHaHbW78+Gxc9h+ZW2LeRiTM0srihgXhPLCm5WRGMqKLIeWn6nI8jdw8hiw8hO91Wqpi/J2V+hCvprDUT1ZlYVtbNuxFvMSsxNxuvg0cgpzMH3/dNUIBTvF+UWNL1J/BcGdYRWOxYsXmwQ5PXnmgvzqq6/Gww8/rBLJGOPKAWAM8Vu7dm3VzKGXmBU+KARsecfpsWb8reFFpLhgLWqD9u3bK1HNPg0ZMqRC20TPIr2MFDyVCWOk6Vk2h95ixmczdtx4s8Bt9PX1VZ5Te99jaUDue8YoGxw6dKhc/eGDET3pjFtmIqg5RsKswX///YcWLVpYeJtt7Teuq7L327mwtiN6h/mg6Eg/6AWnh5kJvUZNdB578zr03C6WgOR6beUDGHY7f/58UwKz9TE24q/5poikp6er32nTpo1pGet9bv35XLZPe+HvbNiwweTp59soPmyVZ1sIveR8E8S3VM6i+r5PF4TKgBVZmvQDLvkYeGwPcO3PQJtLAf9g4PhuYOGrwMedgf8bBPz3BXAyxdU9dkuaRjbF8uuW4+thX+PO9neiQ2wH+Pn4qdFCJ++ejHUp60zLnjx9EosOL0LOaduvWoVqPt5AWXA+l3MirJpBTxvDPOilZbKhAQXmNddcg6eeekq9WqeYKAsmdjJpk0lsFB8cPObPP/9UnmBCQcjkP4YF8JU7S7AZHm1CgcFBWZiQybrcDI9g337//XeHt4dJiXxwoNd527ZtKoSAXudnn33W7neY6Ehhd/ToUbvLsG8M46AIY3gPK5/Qu01vO/cLExuZRMg3CTfddJMpRMXW97gfGJ7AflE4MVzlr7/+Qnmg4OcDCyugWMN1M/mPv/nLL7/g448/Vg9VZcGkRD4kMGGTx4cJi6wCw8/uCgUsHyLp0af4pShnAq25p5v7iGE6tMk5c+YoAczt5IMQk1sJQ7W4n/iX9sKEWnrnCY8Vq6AwjIX7mnZ74403qgcGTid8m8AHWXq9ud8++eSTs2r0n8v2aX/sK5NtaY8U5fw3t8V4AHZkWwjDyVihhw9sTqPMiPJqgiRwVoxqkcBZUU5ladqGnzXt+8s07YXI0qQw/vu7MZq24Sd9GS+lMmwjuyBbW5S4SHtj1RvatuPbTNPnHJyjkkE7ftdRu3769dqH6z7UVh5bqZ0qPDt5RvDwBM7ykpmoaUc32G+c7wRsJRUyebFFixZaz549Le4tK1asUPcb6wQ1exw8eFC74oorVKJZaGio1rVrV5UgaST0DRw4UCW/xcfHa5988olKCGRioAH357hx41TCJZNMmzdvrk2cONEigTMzU0+8Nk9k5LoNZs2apfXu3Vv9DvvRvXt37auvvrLbZ2O95uuwJjU1VRs6dKgWFhZmSmxlct66devUNgUHB2vR0dHanXfeaZHQaet75PHHH9diYmLUdCb7MUmPCX+OJnCSf//9V6tfv76FbXJ/3nfffdo999yjtp2JfE8//bRFIqF10qUBEyGNvtaoUUPr0KGD9uqrr5rmu1sCJ+G5OWrUKC0oKEhr2LCh9v3335/Vp+zsbO3BBx/U6tWrpwUEBCjbY8KmefLrn3/+qXXq1EnZXK1atbTLL7/cNC8jI0O76aab1PGhTQ0fPlwldprzzTffaA0aNFDzR48erRJyzRM4HbH9Y8eOaRdddJHaFm7Dzz//rNWuXVv74osvyrUtw4YN015//XW7+6wyEjh9+D9Uc+i5YIxZVlZWuRI+qjt8CqX3h6/E6FUQ7MD65Nv+0kNZWCLRgPXME0booSwthp3bq+dBONM2/t3/Lz7d+KnympsT6BuITrU74YluT1gMUiR4hm3wNTA9t6wH7C6xyELVQjnC0AKGDbgikZu/z9jqcePGmcpNMua6U6dOLq39LaBSbIM1+/nmivXIzUuPlgXfBrH2OEsdUifaoqxrl6P6UmLGBcHZhNUGetytt4z9wJY/gS2/62EsjDNn46A6bS7RhXnjC/XwF8EmI5uOVC0pJ0klgrJSC1vqqVT12XwE0IWJC5VoZ0Joy6iWKm5dEATBFhR5X331lQqrEDyfBQsWqFhy5k4wLIw15xnm1K9fP4fXwe8xTMueEK8sRIwLQlUS3RTo/zjQ7zEgeYsuyinOmfi54Qe9hdfVkz7bXwnU7VTtK7LYg5VWxjQfoxq9JoeyD2FT2ibUCysdJGbKnilYdETPlI8MilSjh7JKC8U5K71IGUVBEMyhF5xN8HwKCwvx9NNPq1wLJlIzYZSlJs2rB52LiiY+lxcJU5EwlQojYSqVBJNOElfoYSzbpgL5pZnriGmue8vZPKgii7vYxu+7flfJnkwAzSuyrBEbHx6PaZdOg5+8hahSJExFcNcwFcF90dzYNiRMRRC8AQoShqawXfQWsHe+Lsx3zQTS9wKLXtdbvc5nSiVeDoTHubrXHgHrm7MVlhRi2/FtekhL8ipsTN2IOqF1LIT4uIXjEBUcpbzm9KBHB9seaEUQBEEQKhMR44LgTjCJs9VIvRWcBHbO0IX5voXAsfV6m/OMXk6Rwrz1aH0EUKFMAnwDVHIn290d70Z+UT7S89NN80/kn8D8xPnQoOGP3X+oaQlRCfoARHE90KVOF4QFWo6oKAiCIAiVgYhxQXBXgsKBjtfqLSfNrCLLamD/Ir1NHw+0HF5akSVAXu87QrB/MOqH1Td9DgkIwUeDPjJ5zjlS6K7MXar9sP0HjGo6Cm/0fcP0uvR0yWkEsRqOIAiCIJwnIsYFwRMIiwV63KW3jAPAVlZk+QNI2wns+EdvQTWB1pcAHViRpa9UZCkHFNYD4geoRtJPpWNN8holzCnQ6R032J25G9fPuB4X1L5Aec67x3VHu1rt4O8rl1NBEASh/MjdQxA8jegmejWWvo8CKVt1Uc6KLNlHgI0/6i2szpmKLFcB9S6QiizlJCYkBiOajFCNlGilI7sx3pyecSXUk/UhmmsE1FChLBTmwxsPR1wNiekXBEEQHENKYAiCp0KBHdceGPoS8MgW4JZ/gS63AiFRQE4K8N9nwP8NBD7uAix8HTi+19U99ljM65MzIfTvS//GMz2ewZCGQ1AzsCZyC3Ox5MgSvLP2HezP2m9a9ljOMVVy8VxFq1YeW4kxU8eov4Ig2ObDDz/EypVyjgjeh4hxQfCaiix9gNEfAI/uBq77VfeM+4cAGfuAxW8An3QBvhoArPwUyE5ydY89FpbVahrRFNe2uhbvD3wfS69dit8u/g2PdnkU/Rr0U+ErBj/t+AkX/3Uxhv05DM8sewb/7PsHybnJFuujUP9w/YdKxPOvVJsVqopFixYpez5xwqycqgu59dZbccUVV9ic9+6772LKlCno3LmzU/tw8OBBtU82btwIb+eFF16QmupugohxQfA2/AOBhIuAKycCj+8FLv8/oPlQwMcPOLYBmP008F5r4LvRwPofgFPucSP2ZK95m5g2uKXdLfh08KcI4QPQGVjbnJVcKMApxCnIh04eitF/jcbLK1/GqaJTWHFsBbalb1PL8y8/C+dPVb5tuOWWW3DppZdaTJs8ebKqOUwROXr0aIwYoYc8WbN06VIl/jZv3uz0fnoqy5cvxw8//IC///4bQUGSOC14HyLGBcGbCQoDOlwN3DgZeGw3MPIdIL4n/bHAgSXAPw8A77QEfrsR2P43UJjv6h57FRN6TcDy65bjy6Ff4vZ2t6N9rfZKvB/MPqgGIwryDcLHGz42hcH4wld9Fu/4+eHqtw1ff/01brjhBnz++ed49NFHcfvtt2Pu3Lk4cuTIWctOmjQJXbt2RYcOHaq0j55Enz59lKc6MjLS1V0RBO8T40uWLFEeg3r16inPwNSpUy3mc5qt9vbbb5uWady48Vnz33hDL0EmCIIZNWoB3e8Ebp8NPLwJGPw8ENsaKC4AdkwDfr8ZeKcFMPU+va55SbGre+wV0FPeu15vPNLlEfw86mcV1vLRwI/U55VJK5U33EgQLUGJ+vzY4sew9fhWEeVnyCvMs9sKaL9Wyy5MXGjxtoGfOZ315R1Z7/nw1ltv4cEHH8Svv/6qwi7IxRdfjNjYWHz77bcWy+bk5OCPP/5QYt0eFPDXXXcdoqOjUaNGDSXcV63SE4f37duHMWPGoE6dOggLC0O3bt0wb948i+8XFBTgySefRHx8vPIqN2/eHN98843FMuvWrVPrDQ0NVUOG79q1y2I+PdIMD6Gnv2nTpnjxxRfVaIjnQ3FxMcaPH68EdkxMDJ544omz7J2jtb7++utqZMOQkBB07NhRvXEwZ9u2bWr/cnRDDnnet29ftV+M77/00kto0KCB2naGZMyaNcvi+6tXr8YFF1ygto37YMOGDWf1k8fH6ENCQoKKXTeH++Khhx4ybQv399ixYy3eljiyLdZ89tlnaNGiheobj/GVV17p8Ppoa9YPL9RY7jZ6peAG1VRyc3OVAd122224/PLLz5qflGQZ1zpz5kx1UljHlPFku/POO02feUIKglAGUY31aiyqIss2YPPvernErMPAxp/0xoosbS/XK7LU7ywVWSoJJnwObDhQCY/rZlynvOLm1VrInENzVKtboy6GNBqi6py3jWmL6kqPn0tLS1rTt35ffDbkM9Pn/r/1R36xpeh+eNHD6m/XOl0xacQk0/QRf45AZkHmWevcMnZLhfpJEUYBNX36dAwePNg0nUN433zzzUogPfPMMyZBRCFOsUexbQuK9f79+6N+/fr4559/EBcXh/Xr1yshZswfOXIkXn31VSU2v//+e+Xgophu2LChWoa/y6THjz76SN1vOWz38ePHLX6HfWI4DR8Y7rnnHnVPZmiIEUbDdfD7htC966671LwJEybYjUUfOHCg+i06zGzB3+P+mDhxIlq3bq0+//XXXxgwQC8vSig2f/zxR3zxxRdKlNKBd+ONN6p+cr8cPXoU/fr1U99ZsGCBEuTst/GgQNHM9X755ZdKcPO3LrnkEiXguT7uPwr5oUOHqt9hfx9+WLcVA+5rinkeKwrtFStWqO2vW7curr76arXMm2++iZ9++km95eC28HcpfLkPHN0Wa9auXasEPsNz+ICUkZGhjkVF1ye4OZqbwK789ddfZS4zZswYbdCgQRbTGjVqpL3//vvn9dtZWVnq9/lXcJzi4mItKSlJ/RW8AB7Hgys0bdojmvZGI02bULO0fdhJ0xa8qmlpux1cldjGuVh2ZJnW7tt2dlvn7zub/v3u2ndN3ysqLlLNU7FnG6dOndK2b9+u/lpT1n66d+69Fsua7zfrdsvMWyyW7ftLX5vLlZexY8dqgYGB6j4yf/58m8vs2LFDzV+4cGHp7/ftq91444121/vll19q4eHhWnp6usN9adu2rfbxxx+rf+/atUv95ty5c20uy75w/rx580zTZsyYoaYZx2Hw4MHaa6+9ZvG9H374Qatbt67dPqxatUpLSEjQjhw5YncZfv+tt94yfS4sLNQaNGigjR49WispKdHy8/O10NBQbcWKFRbfu/3227XrrrtO/fupp57SmjRpop0+fdrmb9SrV0979dVXLaZ169ZNu++++0z7NyYmxsLmPv/8c7X9GzZssNv3+++/X7viiitMn+vUqaO9/fbbps9FRUVaw4YNlWYhjmyLNX/++adWs2ZNLTs7+6x5jqxv0qRJWkREhMV8aixz2TdhwgStY8eOmidQUlKijjP/uhtlXbsc1ZceU2c8JSUFM2bMwHfffXfWPIalvPzyy8oTcP3112PcuHHKE2EPvrZjM8jOzjY9ARseB+HccF/xOUr2mRcR30Nvw19XoSo+WycDu/6FT8Z+YPGbqml1O0FrdyXQ9jKgZj2bqxHbKBvuG8aG+8AHGuP3reD0ZpHNcGe7OzHv8DwMbzjctC+XHV2G51c8j0HxgzC00VBV35xJop6CPdswphvNnP+u+8/u+vx8/UzL8y/3G0dONX/bwLcPCVEJ+HTQpxbrnnn5TJvrrEh4EGO+6XGmt5jhIgwbMYfhDfRw0jtLz+XevXuVp5MhH/w9eqTpXTU4efKkCpmgRzcqKspmn+jZZUWMf//9V71Jpkf41KlTOHRIL6fJ7/v5+Snvsa3vG9Pat29v+je978Y9l/fUTZs2KW8zve8G9Obn5+ert9sMbbGG279jxw67+zIrK0v1t3v37qb57CfDRLhusmfPHuTl5SmvtTmnT59W+4TfYxw5vfW831v/Du/rx44dU/vcfB4/M1mW07Zv366OG98qGMv07NnT1G9j2qeffqq83omJiWr/sg8MeeF8bgv3FbfZWN7X1xddunQx2bQj22LNkCFD0KhRIxUWxOTf4cOH47LLLlP725H1mZ8T1sfb3l93R3PT/hr725aGdPQe6DFinCKc4SfW4Sx8jcNYNsbT8fXRU089pU7y9957z+66+HqHF0Br0tLS1AVGcAwaGS9ENEJefAQvI/IC4MIL4NPjaQQdXIDgPdMRdGQZfJI2qqbNfQ6n63VHfovRyG86DFpQhOmrYhtlw0GDjp08ZlOIE05PzklGQlAC2rdsDxQDqampat7sPbORkZ+ByXsmqxYeEI4+tfugb52+uCDmArcX5vZso7CwUM2joLSORw70CbS/Qk2P2SWsRLMjY8fZv6mVqOlrktao+P1zrbe88dDsN8MWfvnlFwwbNkyJp2nTpp0VMsmqK4888gg++OADFbfdrFkzlZzI33v++efVPPM+MFaY+8lef5gcOn/+fOWQ4roYO3zttdcqZxO/Exiobx//bStW2BC+nGf8hjGNwo7TKPjZN+tqMYQiuCKx4+a/Zf59Q7zSFmgjRrw688rMoXjm9/jXsBlHf8MQTpxm/m/r7xl2+Ntvv+Hxxx9XuQA9evRQx5T6grHm5rZqa1uMvjmyLdbwWDI3YPHixSr5lw951C3UOY6sz9a2GfrGmGbs7/ON/68KNE2zsFd3gvuP+zI9PR0BAZbXXz5Ue5UYpzeB2em8OJnDBBADPuHy4nP33XcrwW2vBBIFu/n3+ATN5BbGWjHmTHAMGh9PCu43EVxeTv3bgT63Q8tLh7Z9Kny2TIbP4f8QdGyVajWXvaTKJ2rtrwRaDEeJX5DYxjn49eJfkZl/dryyQXRwNOrUqHPW9Am1JmBk8kjMOzQPCw4vUDHPs47OUo3CfMolU1A7tDY87bpBocAbFwVeWW82y7pZf77l8zLfNnB+3/i+lX4z53awURAzXnrQoEEqdpt5TuaCnEKZ957ff/9decHpDTdu3hRV1sKKMd689/EeRYeTNYwFZ6KgkdhH4UyvOLeP+5DeW+5verbpabWG3mhivs/N/7LR2UVPbKtWrSptfzH2mg8vjIs24qopaOjJZ5+5T+it5z2cceHcn7bg/mGcPI+9tQji/uL+/O+//yy+z31GLza3rU2bNuo4GA8+hH0y335+n970Bx54wLQOxpYb+5jbwuRKxvIb20LRSK89t4XLOLIttuB36RFnoxDnGxLGhtMjfq718Q0Hzyc+mDHxl2zZssXiGNNmje3wFAKsjrM7wP3HfUlbsNao1p/trgMeAF/lMSGFT6jngk+uPLFYuJ+vBW1BI7Yl1I0LquA4PJFlv1UjwmL1iixsJxKBLZNV80ndBuyaAZ9dM4DAcPi0vhhBDYbAN/YS+Pp6xGWmyqkXXk+18sJyiBc2uFC1Z0uexfqU9SrZc37ifIQFhCkBb4jNX3b+gtiQWPSp38ei/rk7XjcMYWC08lJYUqjquZf5tiE3GUVaEQJ9y/C0nwfsN0M7jARGeshZvcNw8lCYX3PNNXj66aeVwGa1lbK2lWGXdCwxPIF/KWApWCkye/XqpRL3mPTIpESu57nnnjM97LCx0gbFOgsfGAmcFOt8y8LkQ+O3zfe59TR6xZnkyJAJin4eJ4aubN26Fa+88orNftNrzKRPeu2ZfGoLJkoy8bFly5ZK6NPbbD74EPfZY489ph5eKLYvvPBC5RHmgwXncbtYteaTTz5RCbB0skVERCjxzPAX3v/p0aZHmRVkKIwZakKRTAHObaOD79lnn1UJmfw+dQMTPs23n/1jEuWcOXPU/uS/16xZo/5t7Cv2g28neDy4LR9//DEyMzNN63BkW6xhEvD+/ftViBFFOEOReGy5fkfWx3AbhrQwOZcRBPSyG2G+to61u6Npmtv21zjOtrSQw9pI84AETibHdOnSxaH1/Pjjj5qvr6+WkZHh8G9LAmfFkCQ9wUTyVk2b+4KmvdfOIvGz5K3mmvbvE5p2eA0zcFzdS6+GSZ1JOUmmz/lF+Vr3H7urhMRuP3bTxi0cp83cP1PLOZ3jcQmcjsLt33Z8m91mvn8qE96jjGQ9AyYvtmjRQuvZs6fFvYVJd7zfjBw50qF1Hzx4UCULMpmPSXtdu3ZVCZLkwIED2sCBA7WQkBAtPj5e++STT7T+/ftrDz/8sOn73J/jxo1TCZNMMm3evLk2ceJEiwTOzMxM0/JMXOQ0rttg1qxZWu/evdXvsB/du3fXvvrqK7t9NtZrvg5rmLDJfnJ9kZGR2vjx47Wbb77ZlMBJ+PeDDz5QyaABAQFabGysNnz4cG3x4sWm9WzatEkbNmyY2jdMdmVS7L59+9Q82tgLL7yg1a9fX32fyYozZ8606MfKlSvVdO6bTp06qcRJ8wROJkvecsstKhmS/bz33nu1//3vfxaJj9yWBx54QG1LVFSU9uSTT2pXXXWVdu2115qWcWRbzFm6dKk6llwf93uHDh203377rVzro6bi8eb3L774YnXMJIHTPRM4ffg/uAi+UmMSC2HSAZ+M6U3g6yWjLBO9B/QG8GmVr/TM4esmPu3xO/Q48DOTNy+66CKbiZ724G/wiZpPlhKm4jh8SqeHpXbt2uIZF3SYrHJkNbTNv0PbOgW+5mEYUU30MolssS1d2ctqQVZBFr7e8jXmHpqLozlHTdPpFaan/KqWV6Fvg75uc91gmApf/9Pj6OirXcG7MOKX+drf3byf5bVxljjk2wcWlxC82zbyy7h2OaovXfr+2DxejBhx3HzFYgyOwIETVD1eG3VYGWrC+cwmZ1wUdwTFuHk8uCAIVQjFVcOe0Bp0R+oF41A7Zxt8Wb985wwg8wCw5C29xXXQRXm7K4AI26+xhfMjIigCj3Z9FOO7jMf2jO2Ye3CuEuaJJxOx8PBCtKvVziTGORgOB8/hdwRBKB8M/WEYC6vkUIswdIbijGFGguAILvWMuwviGa8Y4hkXHLaN07nArpnAlj+AvfOAEiN73wdofCHAxM/WlwChZyepCZUHL/e7M3djXuI8jG46Gg1r6m8gZx6YiaeXPo1ucd0wtPFQVTYxJiTGKX0Qz7jgid7Psjh8+LBKzmUcPbehXbt2Koac8d6C99tGvqd7xgVBqCYE1tAFN1teBrB9KrD5DyBxBXBwqd5mPAa0GKYv03IEEHh2/WLh/OBNLCE6QTVzth7fqhIbVyatVO2V/15R9ctZx3xww8FuXZ1FEFwNq7EZI5YKQkUQz7h4xiuMeMaF87aNE4cBhrGwKkuK2RDkgWFA69G6MG8yAPATv4GzOZR9SIWxsGTitvRtFgPmzL9qPmqF1KqU3xHPuOCJ3k/BtWhubBviGRcEwbOJjAcufERvqTv0MBY2lk3c9IveasTqo322vxpo0JXuXVf32itpVLMR7mh/h2pM+KQopzjnTdBciL+79l3EBMdgSKMhaBDeoNL7If4hQRA8icq4ZolnXDzjFUY844JTbIOXpCNrgM2/A9umAHnppfMiG5VWZKldeYOQCPZhYmeQnz4uQ/bpbPT/rT+KzsT8t45urUJZ2BpHND4v2+BAKbt371bTOXiGUP1wZ++n4Fo0N7YNjrzJaxpr0hsDaZVXX4oYFzFeYUSMC063jeJCYP9iYMvvwI7pQGFu6by49mYVWSrfQyucTW5hLqbvm6485mtS1qhh5g1aRLXArW1vxehmoytsG0lJSWrgF87jgCXudtMVqq/gElyL5oa2wT7l5eWp61lkZKQqw22NhKkIguD5+AUALYbo7XQesJsVWSYDe+YCyVv0NncC0KiPHl/eZoxUZHEiNQJq4JpW16iWkZ+BBYkLVDjLqqRV2JO5R3nOzeucJ+UmISEqweGbJ4fwJry5CdUPihs+rBmjsQqCJ9gGhbhx7aoo4hkXz3iFEc+44DLbUBVZ/taF+aFlpdN9A4DmQ4AOVwEtL5KKLFUEhfeiw4vQu15vxIbGqml/7P4DL618CfHh8SqMZVijYWgT00bdVM9lGwxZKSwsrOKtENzhusFX/gxTknuK4Am2ERAQcFZoijniGRcEwXuh97vrrXrLOnKmIssfuqec3nO2gBpA64v1UJamrMgS4Opeey0cLGhM8zEW09JPpatY88MnD2Pi1omq1atRT5VK7FqzK2rF1oIvbN9UeXMr6wYneK/gorhhRQp3ElyC6ynxctsQz7h4xiuMeMYFt7ON1J1mFVkOlU4PrXWmIstVQHx3qchSReQV5mHp0aUqxnzJkSU4VXTKVC5xwZULEBMqiZpCKXJPEbzNNsQzLghC9YMVVgY/Bwx6FjiyVhflrMiSmwas+T+9RTY0q8jS2tU99mpCA0IxvPFw1fKL8rH82HLMOTgH2bnZiAqOMi03ftF4RAdHq3KJXet0hb+v3JoEQag+iGdcPOPV7klVqGa2UVwEHFikx5fvmAaczimdV6ddaUUW1jwXqtw20vLSMPiPwdCg34oigyJVKAuFeY+4HgiQ8KJqg1tdNwS3osRDbUNKG5YDEePV6+QQqrFtqIoss85UZJkDlJglCTbsrVdkYTiLVGSpMtsoLCnE6qTVKpRlfuJ8nCg4YVo2PDAc93e6Hze0vsGlfRaq+XVDcDklHmobEqYiCIJgDaurtLtcb6cyge3/6KEsB5cBiSv0NvMJvSILPeYJrMhSw9W99moCfAPQp34f1Z7t+SzWpaxTwpwlE9Pz05UgN0jJTcGW41vUsiH+IS7ttyAIQmUhYlwQhOpJSBTQZazeso7qseUc9TN5s+49Z2NFllajdGHebKBUZHEyjBXvUbeHak91fwob0zaiZVRL0/yZB2bi3XXvKiHet35fDG08FP3q91Ox6YIgCJ6KiHFBEISI+kDvB/WWtksPY6HHPPOAPvonGyt/GBVZGnQHPOhVqSfi5+uHLnW6WEwL8g9S5RGP5R7DnENzVGP5xD71+ihhznrm/CwIguBJSMy4xIxXuxguwfl4hW3w0nh0nS7KWcecFVkMIliR5Qqg/dVAnTau7GW1sw3esranb1ehLBTjrGNOKMKXXLPE5CUvKimSqiwehldcNwSnUOKhtiEx44IgCOcDa5E36Kq3Ya8CBxaXVmTJSgSWva+32m31xE82lk0UnAqHwm5bq61qD3d+GLszdytRzhrm5uEqN/x7g6rMQm/5oIaDVOlEQRAEd0Q84+IZr3ZPqoLz8WrbKDxlWZGl+HTpvIa9dFHe5jKghgxo4yrbOJpzFCP+HGH6zEGGWL+cwpxlE2NDY53yu8L54dXXDaFa2ka2lDZ0HBHj1evkEJxPtbENVmShp5yJn6zIcqZWNhge0WxwaUWWoLCzv3viMJCXbn/djFH3wtrnVWUbB7MOYl7iPBXOwrAWAx/44N5O9+Lejvc67beFilFtrhtCtbGNbAlTEQRBqIKKLJ1v1lv2MWDrFD3ZM2kTsGe23hg6kTAS6HA10GyQXpGFQvyTLkBRgf11+wcBD6zzSkFeFTSOaIw72t+h2pGTR1SpxLmJc7E5bTNaRpZWaNmftR9LDi9Rgww1CG/g0j4LglA9ETEuCIJQGdSsB/R+QG9pu4Gtk3WPOSuy8N9sIdFA20uBuheULcQJ59NzLmL8vKHIvqXdLaol5yYjKjjKNO/f/f/iy81fqpKJbWLaqFAWtkY1G7m0z4IgVB9EjAuCIFQ2sS2BgU8DA54Cjq43q8iSCqyd6OreVWviasRZfG4R1QI94npgTcoaFc7C9uH6D1V9c4rym9rchBqsNy8IguAkRIwLgiA4tSJLF70NewU4uPSMMP8LKMpzde8EAMMbD1ctIz8DCxIXqBjzVUmrVJUWetFvb3+7adn0U+mqKgsrugiCIFQWIsYFQRCqAj8mdQ7UW+exwMRh5/6O5NdXGRTZV7a8UrUT+Sew8PBC5BbmIsBXH3WVtQ5YLtHPx08PZWk8FG2i24gwFwThvBExLgiCUNUwOdMRfroSaHc50Ho00LC3LugFpxMZHInLWlxmMe1IzhGk5aXhdMlpfLP1G9Xqh9XHkIZDVPJnh9gOqoSiIAhCeZErhyAIgruSdxxY/RXw3WjgnRbA1PuBXbOAwnxX96zaER8ejyXXLsHb/d7GsEbDEOIfouqZf7f9O9w08yZ8sO4DV3dREAQPRdwsgiAI7sqIN4CUrcDOf4FTGcDGH/UWGAa0GKp7zFsMA4LCXd3TagETOUc0GaEaR/xcfnS5ijFffGQx+tTvY1puS9oW/L3vbxXO0qVOF/iz7rwgCIId5AohCIJQ1XBAH4aqnKvOeKuLgZ73AhcXAYkr9QGGdk4Hso8C2/7Sm1+QHofOZVnPXEb+rBLoGWd4CltBcQH8fUpvp/8e+Be/7fpNtaigKAxqOEgJ8+51u5ti0AVBENxCjC9ZsgRvv/021q1bh6SkJPz111+49NJLTfNvueUWfPfddxbfGT58OGbNmmX6nJGRgQcffBDTpk1TozJdccUV+PDDDxEWZmPEO0EQBHeAtcM5oI+jI3AyVrxJX71d9CZwbL0uzNnS9wK7Z+mNMcuN+uge81ajgAgZxKYqCOIDkRmDGw5WnvP5ifORWZCJP/f8qVrNwJoYGD8Q/+v+P4Tx7YYgCIKrxXhubi46duyI2267DZdffrnNZUaMGIFJkyaZPgcFWV70brjhBiXk586di8LCQtx6662466678PPPPzu9/4IgCBWGQrsiA/qwekf9LnobPAFI23VGmP8DJG/WyyeyzXxCX4Ye89aXALWaO2MrBBt0jeuq2rM9n8XalLWYe3Au5iXOU+UTVyatRChHZT3DzoydaFyzMYL9g13aZ0EQXIePxnpNbgDLQ9nyjJ84cQJTp061+Z0dO3agTZs2WLNmDbp27aqm0Ws+cuRIHDlyBPXq1bP5vYKCAtUMsrOzER8fj8zMTNSsWbPSt81bKSkpQVpaGmJjY9VbCUEwENtwEZmHgF0z4ENxfngVfFB6eddiWylhrrUaDcS110W9C6iutlFcUoyNaRuVIGfICikqKcKQyUOQX5yPvvX7qsos/Gsu1qsT1dU2BO+1DerLqKgoZGVllakv3T5mfNGiRahdu7bamEGDBuGVV15BTIweE7ly5UpERkaahDgZMmSIOlCrVq3CZZdZlqYyeP311/Hiiy+eNZ0HOj9fqhSU5+SggfF5zpNODsH5iG24ihCg6ZWq+ealIejgAgQfmIPAo//BJ20nkLYTPkvfQVF4fRQ0GYb8JkNQWOcCwNevynpYnW0j3ice8SHxSE1NVZ+T8pIQ4BOAzKJMzDk0R7VA30B0q9UNfev0Rc/YntVq9M/qbBuCd9rGyZMnHVrOrcU4Q1QYvtKkSRPs27cPTz/9NC666CIlwv38/JCcnKyEujn+/v6Ijo5W8+zx1FNPYfz48Wd5xvnEJZ7x8p0cfKPhaU+qgvMR23AHagON2wIDHoSWnwVt9yz47JwB7J0H/5NH4b95EmpsngStRm2g1UhoCRfrMel+gU7tldhGKbVRG3MazcG29G0qjIXt8MnDWJ66XLVb296KRzo/guqC2IbgbbYRHBzs+WL82muvNf27ffv26NChA5o1a6a85YMHD67wehl3bh17TniAPekguwM8OWS/CbYQ23AjQqOATtfp7XQesG8+sGM6sGsmfHJTgXXfwmfdt0BQBJAwQk8AbTYYCHROuITYhiUdandQbVyXcdiVuUuVS5xzcA6GNx5u2kcso/jDjh8wtOFQVZ0lKjgK3ojYhuBNtuFoX91ajFvTtGlT1KpVC3v37lViPC4uzvS6z6CoqEhVWOE8QRAEwQoKbIpttqLTerKnKpk4A6Aw3/yb3vxDgOaD9eTPlsOBkEhX97xaiI1W0a1Ue6DTAxbzZh2cpQQ528v/vawSRCnMBzcajFohtVzWZ0EQzp8Ki3EmVk6ePFmFjzz++OMqNGT9+vWoU6cO6tevD2fApMz09HTUrVtXfe7Vq5fqB0sjdunSRU1bsGCBep3Ro0cPp/RBEATBa/AP1AU326h3gSNrSiuznEjUa5qzcdCaJv10AZ8wCgiv4+qeVwthbs4d7e9Ao5qNlMd8R8YOrEpapdqrq15F5zqd8cmgT6RcoiBUp2oqmzdvVomSEREROHjwIHbt2qW81s8++ywSExPx/fffO7SenJwc5eUmF1xwAd577z0MHDhQCXs2Jlmybji93BT9TzzxhAqG37JliynMhDHkKSkp+OKLL0ylDZnQWZ7ShowZ57acK9tVsIQPPXwzwbh9T3ptJDgfsQ0Ph7eF5C2ltczTdpjN9AHie5zxrl8MRDUu16rFNs4fxpXPOzRPhbNsOb4FTSKa4O8xf5sE/OLDi9E8qjnqhznHMeYsxDYEb7MNR/VlhcQ4hXjnzp3x1ltvITw8HJs2bVJifMWKFbj++uuVQHcExn5TfFszduxYfP7556rM4YYNG5T3m2UKhw0bhpdffll53w0YkvLAAw9YDPrz0UcflWvQHxHj1evkEJyP2IaXcXwvsPOMMD+6znIeyyQylIXinOUTz1EyUWyjcknKSUJKXgo61e6kPucX5aP/b/2RV5SHtjFt1QihwxoNQ8OaDeHuiG0I3mYbThXjXDFDUphMaS7GDx06hISEBI8rDyhivHqdHILzEdvwYrKO6vHlDGU5tBzQSkrnxTQvHWSofmebwlxsw7kczTmK55Y/h3Up61BidmwSohKUML+oyUUq3MUdEdsQvM02HNWXFYoZZ4gIf8Ca3bt3q7IzgiAIgpcSUR/ocZfectOB3TN1j/m+BUD6XmD5B3qrWR9oNUr3mDfsDfh5VL0Aj4WhKROHT0T6qXQsOLxAjf65Onm1qtLC5ufjhzs73KmWpVj34X8uGgBKEASdCl0dL7nkErz00kv4/fff1WeeyIwVf/LJJ1WYiCAIglANqBEDXHCj3gpOAnvm6sJ8zxwg+yiw+iu9hUSrWubg6J9MBBWcTkxIDK5qeZVqJ/JPYOHhhSrGnN5xg1kHZuHzTZ+raRwVtHV0axHmguACKhSmQnf7lVdeibVr16qESsZzc5AdVjf5999/UaOGZ40YJmEq1eu1keB8xDaqOYX5wP5Fepz5zn+BUxmmWVpgGPLj+yGo0xXwZcnEoHCXdrU689jixzD74GwLrzpFOVv7Wu2rXJjLdUPwNttwasy4wbJly1RlFVZFYUInEzs9ERHj1evkEJyP2IZgorgISFyhDzJEr/nJY6Xz/IKAZgP1UJaWF+medqHKyC3MxZIjS5THfOmRpcgvLs33iqsRh6ljpqJGQNU51+S6IXibbVSJGPcWRIxXr5NDcD5iG4JNSkpQcnQd8tb9hhqJC+CTsa90no8v0KiPnvzJWHPGpgtVRl5hHpYfW65izBcfWYxmkc3w86jSEsG/7PwFzSKaqZrm/qw77wTkuiF4m21UuhhnuUBHeeihh+BJiBivXieH4HzENoRz2kZsLHzTd5fWMk/ebLlg/S66x5xx5rWau6q71ZKC4gKk5qYivma8+px9OluVSywqKUJ0cDQGxg9U5RK71e2GAN+ASvtduW4I3mYblS7GmzRpYvE5LS0NeXl5iIzUh0hmLfDQ0FC1o/bv3w9PQsR49To5BOcjtiGU2zYyD5aGshxexejy0nmxrc8MMjRar2suSYZVSkpuCj7d+KmqzpJVkGWaXjOwphLmV7a80lTn/HyQ64bgbbZR6aUNDxw4YPo3R7f87LPP8M0336i64oSjcN555524++67z7fvgiAIQnWDI3n2fkBvJ1OAXaxlPg04sEQfAZRtyVtAZKNSYd6gO+BBN2ZPpU6NOnipz0t4ruQ5rE1eq2LM5yfOR0Z+Bv7e9zfaxLQxifFTRadUucRg/2BXd1sQPIYKxYxzsJ/JkyerIezNWbdunaqyYi7cPQHxjFevJ1XB+YhtCJVmG6cygd1z9EGG9s4Hik6VzgurAySM1IV5476Af6BT+y6UUlxSjPWp65Uwv6P9HagdWltN/2P3H3hnzTvo16CfqspyYf0LERoQ6tA65boheJttOHXQn6SkJBQVFZ01vbi4GCkpKRVZpSAIgiCcTUgU0PEavZ3OA/bN1z3mu2YBOSnAukl6C47QK7K0vhhoNhgIdEwAChXDz9cP3eK6qWYOPed5RXmYdXCWasF+wUqQU5hToIcFhrmsz4LgVZ7x0aNH4+jRo/j6669VSUPDK37XXXehfv36+Oeff+BJiGe8ej2pCs5HbENwum0UnQYOLtHjzHfOAHJTS+f5hwAthujJn6xlHqLnNgnOh5Ji6/GtymPOdiTniGleiH8IFl29yK6nXK4bgj081Tac6hmfOHEixo4di65duyIgQM+kpqd8+PDhSqALgiAIglNhSErzIXob9S5weDWwkwmg/wAnEkurtLAMX5P+ZyqzjALC9HAKwTlwoKD2se1VG9dlHHZm7DQJc9YuNxfiDGdpGtlUJYFGBUe5tN+C4ErOq8747t27sXPnTvXvVq1aoWXLlvBExDNevZ5UBecjtiG4zDZ4S2OZRCXGp+uJnyZ8gIY9zwjzi4GoRpX/+4JNKDU4yJARppKal4rBfwxW//bz0UNeBjccjI4hHZEQnyDXDcEr7iky6E85EDFevU4OwfmIbQhuYxvH9+jCnF7zo+ss58V10AcZojiPTZCSiVVIZn4mJu+erDzmOzJKH5hYiaVLnS64td2tKsZcEDz5nuJUMc5EzW+//Rbz589XO4c7yZwFCxbAkxAxXr1ODsH5iG0IbmkbWUf0+HKK80PLAc3s3hXTvLRkYr3OIsyrkMPZhzE3ca4a/XNr+lY17bULX8PoZqPVv0/kn1BJofXC6rm4p4KrKPHQe4pTY8YffvhhJcZHjRqFdu3aqRgxQRAEQXBrIhoAPe7WW+5xYNdMXZjvXwik7wWWva+3mvX1MBYK84a9AD/nDP8u6HCkz9va3YZb2tyCLYe2YGPuRvSP72+a/9fev/DeuvfQLqYdhjYeiqENh5pGBxUEb6BCnvFatWrh+++/x8iRI+ENiGe8ej2pCs5HbEPwKNvIzwb2ztWFOWuaF+aWzguJBlqxlvkleiJogAxmU9W28ep/r+K3Xb9BMxuVtVV0K1UucUijIWga0dRFPRaq9XXD1WEq9erVw6JFizw2YdMaEePV6+QQnI/YhuCxtlGYD+xfdKaW+Qx90CEDJh+2GKZ7zFsMBYLCXdnTamUbx08dx4LEBSrGfE3yGhRrxWo665gvuXaJKpsoeC8l7n7dcEWYyqOPPooPP/wQn3zyiYSoCIIgCN4DPd8JI/RW/CGQuKK0MsvJY8C2KXrzCwKaDdSFOQcbqhHj6p57NbVCauHqhKtVY/LnwsMLlTAPDwi3EOKPLHxEecrpNaf3XDSK4AlUyDN+2WWXYeHChYiOjkbbtm1NtcYNpkyZAk9CPOPV60lVcD5iG4LX2QYLFRxbf0aY/wNk7C+d5+MHNOqth7KwlnlEfVf2tFrZBiWMIbgPZh3E6Kl60iepH1YfwxoNU8K8XS3Jb/NkSjz0uuHUMJVbb721zPmTJk2CJyFivHqdHILzEdsQvNo2eNtM3VE6yFDyFsv59bsCrZkAegkQ08xVvax2tpFXmIfFRxYrj/nSI0uRX5xvmle3Rl083PlhjGo6qpJ7LVQFJR563XBqmIqniW1BEARBqDToYa3TRm/9nwAyDpwR5tOBw6uAo2v1Nu8FoHab0sosce2lZKIT4eieFzW5SDUK82VHlylhToGelJuEYP/S5NujOUdxLOcYOtfuDD9fP5f2WxDOq15TWloadu3apf6dkJCA2NjYyuqXIAiCIHgG0U2A3g/q7WSyXsuc4vzAEiB1u96WvAVENiqtZd6gO+BBHj5PFObDGg9TLb8oH8uPLUefen1M86fsmYKvNn+F6OBoNfInq7JwFNAAX8uwW0FwWzGem5uLBx98UJU3NAb88fPzw80334yPP/4YoaGhld1PQRAEQXB/wuOAbrfrjZVYds/W48z3zgdOHAJWfqK3sDp6fDm95k36AX4iAp0FPeIU3Ob4+fihZmBNZORn4I/df6gWERSBQfGDlDDvXa83/H2lvrxQNVQoZvzuu+/GvHnzVDWVPn30J81ly5bhoYcewtChQ/H555/Dk5CY8eoVwyU4H7ENwR7V1jZO5+qCXNUynw0UZJXOC47QK7LQY95sEBBYPR1aVW0bhSWFqkwiQ1lYNpHCnFCkL7pmkclLbp4kKriGEg+9bjg1gZOD/kyePBkDBgywmM4KK1dffbUKX/EkRIxXr5NDcD5iG4I9xDYAFJ0GDi7RhTlDWnLN7pks09diiJ78yZrmIZGoLrjSNopKirAhdQPmHJyDkIAQjO8yXk2nRLr8n8vRIrKFGv2ToS4MgRGqlhIPvW44NYEzLy8PderUOWs6dxLnCYIgCIJgB/9AoPkQvY16Dzi8+kzJxGlAVmLpv+mZZQgLPeYMaQmr7eqeey0MSWHMOJs5OzJ2YO+JvarNPDhTDTLUt0FfVS6xX4N+qBFQw2V9FryHCj1e9OrVCxMmTEB+fmnZoFOnTuHFF19U8xxlyZIlGD16tBrRk6+Apk6dappXWFiIJ598Eu3bt0eNGjXUMoxJP3bsmMU6GjdurL5r3t54442KbJYgCIIgVC2s5NGoFzDiNeCRzcDdS4B+jwOxrYCSQmDffGD6I8A7LYGJI4CVnwKZh1zd62oDBw76aeRPuLXtrapuOcslMqzliSVPoN+v/fD7rt9d3UXBC6iQZ5yjbw4fPhwNGjRAx44d1bRNmzYhODgYs2fPLlciKL9/22234fLLL7eYRw/7+vXr8dxzz6llMjMz8fDDD+OSSy7B2rVrLZZ96aWXcOedd5o+h4fLEMWCIAiCh8G45Lod9TboWeD4nlIvOQccSlypt9lPA3Ed9FAWes1jE6RkopPw9fFFh9gOqo3rMk55yucdmoc5h+bgUPYhNKrZyLTsroxd2J6+HQPjByIyuPqEFwnnT4Vixg2x/NNPP2Hnzp3qc+vWrXHDDTcgJCSkYh3x8cFff/2FSy+91O4ya9asQffu3XHo0CE0bNjQ5Bl/5JFHVKsoEjNevWK4BOcjtiHYQ2yjgmQd0ePLKcwPLQc0vZKZIqbFmUGGRgP1OnusMPck26B02p25G80im5mqrryx+g38tOMnVamF4S4MZRnUcBBqhdRydXc9nhIPso0qS+B0Bo6IcVZwGTZsGE6cOGHaKIpxhsswrIUC/frrr8e4cePg72/f6V9QUKCa+c6Kj49X3ncR4+U7OZisy/rynnRyCM5HbEOwh9hGJZB7HNg9Ez6sZb5/EXyKT5tmaTXrq/hyrdVooGFPwIPK83m6bTBkZfKeydiVqY+/YnjWObDQkIZDcGWLKxEgJSyrlW1kZ2cjKirKOQmcr7/+ukrgZHiJORMnTlQ7i7HelQ0FN9d73XXXWWwQyyl27twZ0dHRWLFiBZ566ikkJSXhvffeK7P/jG+3hn03j4MXzn1y0MD4POdJJ4fgfMQ2BHuIbVQS9Yer5tM3B0GJixF0YC6CDi2Gb/ZRYPVX8Fn9FUqCo5DfeDAKmgxFQYPegF8g3BlPt40BUQMwoPsAHM09iqUpS7EsZRl2Ze/C2pS1OJR1CAOjBipxTnILcyX5sxrYxsmTJx1arkKecXqjf/75Z/Tu3dti+qpVq3DttdfiwIEDleoZp9f7iiuuwJEjR7Bo0aIyny74QMA66Dk5OQgKCrK5jHjGq/eTquB8xDYEe4htOJHCU7qnnB5zes456NAZtMBwoMVQaBxkiFVcgtwvt8obbeNozlHMT5yvQlmub3W9qYzikMlDUC+sngplodc8Pjze1V11a0o81Dac6hlPTk5G3bp1z5rOnUSvdGVCIc7a5YwTX7BgwTnFco8ePVBUVISDBw8iISHB5jIU6baEOg+wJx1kd4APUbLfBFuIbQj2ENtwEkE1gNaj9FZcpMeWq1rm0+FzMgnYNgU+26YAfkH64EKMMU+4CAiNhrvgbbYRXzMet7S7xWLansw9OFFwApkFmdiWvg0frP8AraNbK2HO1jiiscv66874eKBtONrXColxepGXL1+OJk2aWEznNJYgrGwhvmfPHjWgUExMzDm/s3HjRrXxDPIXBEEQhGqJnz/QtL/eLnpLr8ay4x9dnGfsV55z1Xz8gMZ99MosrGVes/Lu4YJt2sa0xYKrF6hRP1mVZW3yWlWlhe2jDR/hsa6PYWzbsa7uplCFVEiMs4wgq5dQLA8aNEhNmz9/Pp544gk8+uijDq+HoSR79+41fWZ4C8U047/peb/yyitVecPp06ejuLhYeeQJ5wcGBmLlypUqNGbgwIGqnCE/M3nzxhtvVK8FBEEQBKHaQ+9cg656G/IikLqjtGRiyhbgwBK9/fsYUL+r7jFni2nm6p57LaywcnXC1apl5mdi4eGFSpivOrYKXeO6mpajUF9xbAWGNR6GhKgE5R0WvI8KxYzzK//73//w0Ucf4fRpPYubNcaZYPn88887vB7Gf1NIWzN27Fi88MILZ3neDeglHzBggBLq9913nyqvyBhwLn/TTTdh/PjxduPFbSGlDatXqSHB+YhtCPYQ23AzMg6oMBYlzA+vspxXu02pMK/TzuklE8U2gKyCLNQMrGkS3c8uexZ/7/tb/btBWAMMbTwUwxoNU9716iTMSzzUNqqktCE92zt27FC1xVu0aFEuAexOiBivXieH4HzENgR7iG24MSeTS2uZH1wKlBSVzotsdEaYXwI06KZ72ysZsY2zYfLn9H3TsfToUhQUlxaeqFujLoY0GoJxncdVi3KJJR5qG1Uixhlism/fPvTr108Jcq7KE5/URIxXr5NDcD5iG4I9xDY8hLwMYPds3Wu+dx5QZFb2N6yOHl9Ocd64L1BJYlBswz55hXlKkM89NBdLjizBqaJTaBrRFH9fqnvNyf6s/WgU3gh+vn7wNko81DYc1ZcVihlPT09XiZUMF6H4ZoJl06ZNcfvtt6tY7Xffffd8+i4IgiAIgithhZVO1+ntdK4uyOkxp0DPSQHWTtRbcATQ8iJdmLNCS2Coq3vulYQGhGJ44+Gq5RflY/mx5SgxG4WV066dfi1C/ENUqUSGs3St09U0Oqjg3lToKDFJMiAgAImJiWjdurVp+jXXXKPitUWMC4IgCIKXEFgDaDNGb0Wn9WRPVmZhSEvecWDzr3oLCNVrmFOYtxgGhES6uudeSbB/MAY3HGwx7UDWAQT4BiAjPwO/7/5dtcigSAxqOEiVS+wR16NahLN4KhUKU4mLi8Ps2bPRsWNHVcVk06ZNyjO+f/9+dOjQQcWSexISplK9XhsJzkdsQ7CH2IYXUVKsJ30alVmyDpfO8w3QyypykCGGtISdu9yw2Mb5UVhSiDVJa1RVFpZNZB1zg3FdxuG2dpajpnsSJR5qG04NU8nNzUVo6NmvojIyMjw2iVMQBEEQhHLA2ORGvfU2/DUgaVOpMD++Sw9tYZs+DmjY60wC6MVAZENX99wroWe8d/3eqj3b81msT1mvhDmTQAfF62WoyfxD8zH70GzlMb+w/oUqtEXwQM/4yJEj0aVLF7z88svKM75582Y0atQI1157rXp6mTx5MjwJ8YxXrydVwfmIbQj2ENuoJqTtBnaeEebHNljOq9tRF+atRgOxCaaSiWIbzoGx5b4+pftz/KLxKhGUUIhTkFOY92vQDzUCasAdKfFQ23BqNZWtW7di8ODB6Ny5sxqi/pJLLsG2bduUZ5yjcDZr5lkDBYgYr14nh+B8xDYEe4htVENOHC4tmZi4AjBLPERMC5PHvCSuE1LT0sQ2nMzW41sx++BsJciP5hw1TQ/0DVTC/J0B7ygvuztR4qHXDaeXNuSKP/nkExUvzhhxCvP7779fjZzpaYgYr14nh+B8xDYEe4htVHNy0oBd/+olE/ctBEoKTbO0mvWR13AQQjpfDV+GvvhJJRBnQvm3PWM75h2ahzkH5yDxZCI61OqAn0b9ZFpm+dHlaFerHSKCIlza1xIPvW5USZ1xb0HEePU6OQTnI7Yh2ENsQzCRnwXsmat7zPm3MLd0XmgMkDBSH2SIiaD+ko/mTCgFd2fuRl5RHi6ofYFpNNABvw8ANKB73e5qkCHGnseExFR5/0o89LrhVDE+a9YshIWF4cILL1SfP/30U/zf//0f2rRpo/7NWuOehIjx6nVyCM5HbEOwh9iGYJPCUyjZOx8FGyYjOHEhfPJPlM4LDAdaDtPDWZoPBYLCXNnTasOujF14etnTSqQbMPac9cspzBlnXiukVpX0pcRDrxuO6ssKbdHjjz+ufoBs2bJF1RZnUueBAwfUvwVBEARBEBwmIER5wrMGvQHt0d3AzX8D3e4AwusCp08CW/8E/rgFeKsp8PO1wIaf9FFCBaeREJ2APy/5E9Mvm46HOz+MNjFtVDLo6uTVeG3Va6YkUCJBFudHhQKyKLrpBSd//vknRo8ejddeew3r169XolwQBEEQBKFCcHCapgP0dtHbwNF1+iBDDGfJPADsnqk3Hz+gcR89lIW1zGvWc3XPvZJGNRvhjvZ3qHbk5BFVKpElE80HHpq8ZzKm7pmqPOZs8eHxLu1ztRDjgYGByMvLU/+eN28ebr75ZvXv6Ohok8dcEARBEAThvGBIQnw3vQ19CUjdXlrLPGWrPhoo27+PAfW7nqnMMhqI8ayqbp5Cg/AGGNt2rGrmzD04F5uPb1btvXXvoXV0axXGwtY4orHL+uspVChmnKUMT58+jT59+qha4/SU169fH3PmzMEDDzyA3btL44s8AYkZr14xXILzEdsQ7CG2IVSabWTsB3ZM14X5kdWW82q31QcYojCv085Uy1xwDsdPHVeDCTF0ZU3KGhXOYkBh/vOon+Hv61/trhvZzhyBkyUN77vvPjW4z+eff66EOJk5cyZGjBhR8V4LgiAIgiA4QnRToM9DestOAnadqWV+YCmQuk1vi98EohqXDjLUoJvubRcqFSZyXtPqGtUy8jOwMHGhEuarklYhMijSQoj/vut3dIztiJZRLeEjD0kKKW0onvFq96QqOB+xDcEeYhuC022DiZ27Z+vCfN98oCi/dF5YnB5fTq954756fLrgNFgeMTM/0xSqkpqXisF/6LHmDcMbqvjyYY2GqeTQsoS5p143nOoZF86f4hINqw9kIPVkPmqHB6N7k2j4+coToiAIgiCcF6HRQKfr9FaQA+ydpw8yRIGekwys/UZvwZFAwkW617zZIL2ii1CpcLAg8wGDcgtzVa3y5ceWq0GGJm6dqFq9GvWUML+s+WVoHtUc1Q0R4y5g1tYkvDhtO5KySp/W60YEY8LoNhjRzvNGMBUEQRAEt4Q1ydteqreiAj3Zkx7znTOAvOPApl/0FhAKNB+iV2ZhTfNg14446a00iWiCDwd9iLzCPCw5ukQlfi49uhTHco/h++3fo1V0K5MYzy/KR4BvAPx8/eDtSJhKFYepUIjf++N6DmhlgeET//zGzh4jyD31tZHgfMQ2BHuIbQhuYRslxUDif2eE+XQg63DpPF+WVuyve8wTRgFhsc7tSzXnVNEprDi6AnMT5+LpHk+jZqCuw+gx/37b96qE4pCGQ9DQpyHqxtX1qOuGU0fg9DaqSowzNOXCNxdYeMStBXlcRDCWPTnII0JW5KYq2ENsQ7CH2IbgdrZBGZS08UzJxOnA8V1mM32Ahr3OlEy8GIhsWHX9qubcMecOlQBqUDOgph5j3ngYutftrrzm1VKMN2zYUJU1ZBs0aBD8/b0jyqWqxPjKfem47v/+O+dyv9zZE72axcDdkZuqYA+xDcEeYhuC29tG2q7SWuYU6ebU7XhGmF8CxCa4qofVgsLiQjXaJ6uyLEhcgMyCTNO82qG1MfuK2edVLtGd9GW5rP2HH35AUFAQ7r//ftSqVQvXXHMNfvrpJ5w4caIy+uz1MFmzMpcTBEEQBKGSocju9xhw92LgkS3AiDeARn0AH18gaROw4BXg0+7AJ92AeS8CR9fr3nWhUgnwC0Cf+n3wQu8XMO/KeXir61u4uuXViAmOUaURzYU4BxpinXOGvNhi5bGVGDN1jPrrjlQ4TGXbtm34559/8Pfff2Pjxo3o3bu3yWvetGlTeBLu5hn/+Y4e6N28Ftwdt/FiCG6H2IZgD7ENwWNtIycN2PWv7jHfvwgoKSydV7NB6SBDDGupBkmHrrINDRpOnj6JSFbDAXAg6wAumXqJ+neIfwj61u+LoY2Hol/9fggNCAVl7nUzrsO29G1oG9MWv4z6pcrqm1dpzHhycjKmTZumxPn8+fOVGH/zzTcxatQoeAJVHTOenJV/VgKnOV0bReLVyzogIS4c7ozbXzgFlyG2IdhDbEPwCtvIzwL2zAV2/KP/LcwrnRdaC2g1Uh9kiImg/kGu7KnX20ZSThJ+3PEj5h2ap6qyGAT5BaFPvT7oXKcz3ln7jmn6F0O+UB53r07gzMvLw+zZsxEeHo4hQ4bAE3BFNRVivuN9znwO9PPF6eIS+Pv64PYLm+DhIS0QGuieMVEedeEUqhSxDcEeYhuC19lG4Slg30LdY07Peb5Z6G5gONByuO41bz5UL7UoOMU2NE3D9vTtmHNojoozP3xSr5ATHx6PozlHUaKVwNfHF62jW1eZd1yqqbjxCJxl1Rlv3yASL/6zDXO2p6jp9SKC8cIlbTGsbRzcDY+9cApOR2xDsIfYhuDVtlFcCBxcppdLZGUWDjJk4BcENB+sh7K0HKEPTiQ4xTYobXdn7sakrZMw48CMs+ZXlXdcxLgbi3FHRuCcvyMFz/+9DUdP6MkIQ1rXxoTRbREfHQp3wSsunIJTENsQ7CG2IVQb2ygpAY6uPVOZ5R8g82DpPB8/oPGFujBvdTFQ0zPGF/Ek29DOxIrvyNihvOIGVekdFzHu5mLcEU6dLsbHC/bgqyX7UVSiITjAFw8NboE7LmyKQH/XX6i87sIpVBpiG4I9xDaEamkblFop20oHGUrZajm/QbdSYR7TzFW99CrbWH50Oe6Zd4/d+VXhHXdKacPKZsmSJRg9ejTq1aunnk6mTp1qMZ/PCc8//zzq1q2LkJAQFYO+Z88ei2UyMjJwww03qI2MjIzE7bffjpycHHgDIYF+eGJEK8x8uC96NIlGfmEJ3pq1C6M+Wor/9qe7unuCIAiCIDgCPbBx7YCBTwH3LgceXA8MfUkX4eTIGmDu88DHnYHPegMLXweSt0rJxApC/fjxho/hYxrf3BJO53x38Uf7Vpbyp5DesWNHub6Xm5uLjh074tNPP7U5/6233sJHH32EL774AqtWrUKNGjUwfPhw5OeXxlpTiLPM4ty5czF9+nQl8O+66y54Ey3qhOPXu3ri3as6IqZGIPak5uDar/7D+N834nhOgau7JwiCIAhCeaD3u8/DwB3zgPE7gJHvAE366+ErqduAxW8AX/QBPuoEzHkWOLxaD3sRHKKwpBDJucmqDKItOJ3zuZw7UKEwlauvvhr9+vXDAw88gFOnTilBffDgQfWE8euvv+KKK64of0d8fPDXX3/h0ksvVZ+5LnrMH330UTz22GNqGt38derUwbfffotrr71Wif82bdpgzZo16Nq1q1pm1qxZGDlyJI4cOaK+b4uCggLVzB8m4uPjkZmZ6VZhKrY4kXcab8/ZjV/XHFYPzBEhAXhieEtc0zUevmYx51X12igtLQ2xsbHe90pROC/ENgR7iG0I9hDbYEm6DGDPbPgwnGXfAvgUl2oVLSxOlUzUWDKRgxD5uf9w8K60jeTcZGTml47aaU10cDTq1KgDZ0J9GRUVdc4wlQrVzKP3+ZlnnlH/poCmcOYonN999x1eeeWVColxaw4cOKDql5uXR2TcTY8ePbBy5UolxvmXoSmGECdcngeKnvTLLrvM5rpff/11vPjii2dN54E297q7Kw/3ro3BTULx1oJE7E47hWembsMv/x3EE4MaomXt0Co9OWhgPP7V9sIp2ERsQ7CH2IZgD7GNM9QdrJpP31wEJi5F8IG5CDq0EL6szLJ2InzWTkRJUAQKGg1EfpOhKIi/EPAPhjdTUgHb8IUvYhBjf4FcIDU3Fc7k5MmTDi1XITHOHRIdHW3yRFN8h4aGqkF+Hn/8cVQGFOKEnnBz+NmYx78M5jfH399f9c1YxhZPPfUUxo8ff5ZnnE9c7u4ZNxhUuzb6tWuMH/5LxPvzdmNrci5u+WUHxvZujHFDWiAsyL9KTg6+0ajWXgzBJmIbgj3ENgR7iG3YoH4ToNfNQFEBSg4sgQ+TP3fNgG9eOkJ2T1VNCwgFmg+BxuTPFsOA4Ah4GyUeahvBwY49JFVIsVG40itN0UsxztAUwjAPR3/YlQQFBalmDQ+wJx3kQF9f3N63KUZ1qIeXZ2zHjM1JmLT8IP7dkoTnL26Lke3jnF62h+v3tP0mVA1iG4I9xDYEe4ht2CEwBEgYrreSD4DElXod8x3T4JN9RJVO9GH5RN8AfdRPVmZJGAWExcJb8PFA23Dci18BHnnkEZU42aBBAxWXPWDAAFP4Svv27VEZxMXpg9ykpOiD3xjwszGPf1nqxpyioiJVYcVYpjoQFxGMT6/vjO9u645GMaFIyS7A/T+vx9hJa3AoPdfV3RMEQRAEobLwPVOj/KI3gHFbgTsXAn0fBWJaAExI3DsPmPYw8G5LYNJIYOVnwIlEV/daqGwxft999ynP+MSJE7Fs2TKT8m/atKmKGa8MmjRpogT1/PnzLcJJGAveq1cv9Zl/Gau+bt060zILFixQrzMYW17d6N8yFrMf6adqkQf6+WLJ7jQMfX8JPpy3BwVFxa7uniAIgiAIlQnfftfvDAx+HnhwLXD/amDQs0DdTgAHujm0HJj9FPBBe+DL/sCSt4G0Xa7uteBOg/6wHvjevXvVvy+44AK89957GDhwoAp/adiwId5880288cYbKjGU4vy5557D5s2bsX37dlM4zEUXXaS85Sx/WFhYiFtvvVUldP78888eP+jP+bA/LUeN4Lls73H1uWmtGnj50nbo07xWpf2GVw/QIJwXYhuCPcQ2BHuIbVQy9IYzlIVx5odWqIJ+Jmq1LB1kqN4Fuqh3Y0o81DacOgJncXGxKi9IrzV3DneSOfROO8KiRYuU+LZm7Nixav3s2oQJE/DVV18pD/iFF16Izz77DC1btjQty5AUllicNm2aOkBMJmVt8rCwsGotxgn337TNSXh5+nakndTLI13SsR6evbg1aocHV9uTQ3A+YhuCPcQ2BHuIbTiRnFRg17/6CKD7F+vhLAYR8boob30x0LCXHgbjZpR4qG04VYxT/FIss3oKR8e0ThJ8//334Ul4qxg3yM4vxLuzd+GH/w6hRAPCg/zx2PAE3NizEfzOoza5p54cgvMR2xDsIbYh2ENso4rIzwJ2z1FJnyq+vDCvdF5oLVXLHK0vAZr0A/zPLnbhCko81DacKsZr1aqF77//Xg2u4w14uxg32HIkC89M3YLNR7LU5/b1I/DqZe3QoUFktTo5BOcjtiHYQ2xDsIfYhgsoPKUGF1Iec3rOKdQNAsOBlsP1cJbmQ4AgxyMOKpsSD7UNR/VlhUobBgYGonnz5ufTP8EFtG8Qgb/u64OfVx3CW7N3YcvRLIz5dDlu6tkIjw5LUKN5CoIgCIJQTQgIAVqN0ltxIXBwmS7MGWeekwJsnaw3DirUbJAuzFuOAEL1sWaEyqFCnvF3330X+/fvxyeffOL0OtZVQXXxjJuTejIfr83Ygakbj6nPtcKC8NzFrVVMuaPH1FOfVAXnI7Yh2ENsQ7CH2IYbwVzAo2v1UBaK88yDpfN8zpRWNBJAa9atgu6UeKRtODVMhcPML1y4UFU9adu2LQICLD2qU6ZMgSdRHcW4wYq9x/Hs31uxP02vR96neQxeGtMOzWLDvPbkEJyP2IZgD7ENwR5iG24KZWLKVtMgQ0jdZjm/QbdSYR7TzCldKPFQ23CqGGf5wLKYNGkSPInqLMYJa5D/35L9+HjBXhQUlaga5ff0b4r7BjZHcICf150cgvMR2xDsIbYh2ENsw0NI36eHsVCYH1ljOa9OuzOVWUYDddpWWsnEEg+1DaeKcW+juotxg8T0PDz/z1Ys2pWmPjeMDsVLY9piQEJtrzo5BOcjtiHYQ2xDsIfYhgeSfQzYOUMX5ow318wGGIxqopdLZGWW+l05Nny1s41sZ4txDjvPOuH79u3D9ddfj/DwcBw7dkz9WHlqfLsDIsZLoTnM2pqMF6dtR3J2vpo2sn0cnr+4LeIigr3i5BCcj9iGYA+xDcEeYhseTl4GsGum7jXfOx8o1sc3UYTF6cKcXnPGm/sFVAvbyHamGD906BBGjBiBxMREFBQUYPfu3WjatCkefvhh9ZmjYXoSIsbPJqegCB/M3Y1JKw6iuERDjUA/jBvaErf0bgx/P1+PPjkE5yO2IdhDbEOwh9iGF1GQA+ydq3vMWdP89MnSecGRQAJrmV+sV2gJCPFa23BUX1Zoiyi6OeR8ZmYmQkJCLBI7OSqn4PmEBfnj2YvbYNoDF6Jzw0jkni7GKzN2YPQny7E+MdPV3RMEQRAEwV1hTfK2lwFXTgSe2Adc/wdwwU1AaAyQfwLY9DPw6/XAW82A328Gtky2rHFezahQnfGlS5dixYoVqt64OY0bN8bRo0crq2+CG9CmXk1Mvqc3flt7GG/M3IkdSdm44vMVuLZbQzw+rIWruycIgiAIgjvDUTxbDtNbcRFw+D/dY86WfRTY/rfefAOApgP05E96zsNiUV2okGecrwuKi82C9M9w5MgRFTsueBe+vj64rntDLHi0P67s0kBVOfpldSKGvLcEM7anqzhzQRAEQRCEMvHz12PGL3oTGLcNuHMhcOF4IKYFUFKoh7ZMewh4tyUwaSTw3+fAicPwdioUM37NNdeoGJivvvpKie/NmzcjNjYWY8aMQcOGDaW0oZez+kAGnp26BbtTctTn7o2j8Mpl7dGyjjyICZ4d3yc4H7ENwR5iG9WctF2lgwwlbbKYpdXthJz4gajR9Vr41m4FT8GpCZz0gA8fPlx5RPfs2aPix/m3Vq1aWLJkiTqRPAkR4+WnsLgEXy/djw/n7UF+UQn8fX1wR9+meGhwc4QGVij6SfAi5KYq2ENsQ7CH2IZgIvNQacnExJWU46XzarXUQ1nY6naqtFrmHlva8LfffsOmTZuQk5ODzp0744YbbrBI6PQURIxX/MK5ae9hfLYyFXN3pKpp9SND8MIlbTG0TR1Xd09wIXJTFewhtiHYQ2xDsElOKkp2zkDhpj8RePQ/+DCcxSAivnSQoYY9AV+zgQoZ3pKXDrswmTQyHh4rxn/55Rdcd911Nuc9/vjjePvtt+FJiBg//wvngp1pmPDPNhw9cUrNoxinKKc4F6ofclMV7CG2IdhDbEM4p23UDIKvUTJx7zygMK90odBaQKtRujCPbgp83gsoMqt1biux9IF1ThXkTi1teO+992LmzJlnTR83bhx+/PHHiqxS8HCGtKmDueP74Z7+zVTIytztKRjy7mJ8sXifCmkRBEEQBEE4L4IjgA5XA9f8ADy+D7jmJ6Djdfr0vOPA+u+An64EvuhbthAnnF+W57wKqZAY/+mnn5RnfNmyZaZpDz74IH7//XcsXLiwMvsneBCMFf/fRa3w78N90b1JNE4VFqtyiKM+WqqSPgVBEARBECqFwFB94KDLvtCF+U1/AV1vA8LqAIW58CQqJMZHjRqFzz77DJdccgnWrVuH++67D1OmTFFCvFUrz8lyFZwDq6r8dldPvHNVR0TXCFRVV67+ciUe+2MT0nPO8aQqCIIgCIJQHvwC9NE8L34fGL8TuORTeBIVLntx/fXX48SJE+jTp48qa7h48WI0b968cnsneCw+Pj6qJvmQ1rXx5qxdqi755HVHMG9HCv43ohWu7hqv6pcLgiAIgiBUGsw3iGsHrxTj48ePtzmdQpyVVOgpN3jvvfcqp3eCxxMZGojXL2+vhPmzU7eqETz/N2ULfl97GK9e1h6t60rCrCAIgiAI1ReHxfiGDRtsTqc3nNmixnx6RAXBmi6NojDtgT74dsVBvD93N9YnnsDFHy/Drb0b45GhLREWJLXJBUEQBEGofjisgCQxUzhf/P181cBAozrUxcvTt+PfLcn4etkBTN+chAmj22BEuzh5mBMEQRAEoVpx3oU8ORonmyA4St2IEHx2QxdMurUbGkaHIjk7H/f+tB63fbsGielmNUMFQRAEQRDKCwf0YR3xsuB8LucG+Fe0+Porr7yCd999V42+ScLDw/Hoo4/imWeekWL9gkMMTKiNXuNi8NnCvfhi8X4s3JWGFe8vxoODmuPOfk0R5G82kpYgCIIgCIIjcCAfDujj4hE4nSrGKbi/+eYbvPHGG6qaCmHN8RdeeAH5+fl49dVXK7ufgpcSHOCH8cMSMOaC+nj+761Yvjcd78zZjSkbjuKVMe3Qu3ktV3dREARBEARPIzLebcS2U8T4d999h6+//lrVGTfo0KED6tevr2qOixgXykuz2DD8eHsP/LPpGF6evgP703Jx/dercGmnenhmVBvEhp/jdZMgCIIgCIIHUqF4koyMDJuD+3Aa5wlCRWDy5phO9TH/0f64uVcjMJdz6sZjGPTuIvyw8iCKSzRXd1EQBEEQBMH1Yrxjx4745JNPzprOaZxXmTRu3FiJNOt2//33q/kDBgw4a94999xTqX0QqpaIkAC8NKYd/r6/D9rXj8DJ/CI89/c2XP7Zcmw5kuXq7gmCIAiCILg2TOWtt97CqFGjMG/ePPTq1UtNW7lyJQ4fPox///238noHYM2aNSguLjZ93rp1K4YOHYqrrrrKNO3OO+/ESy+9ZPocGhpaqX0QXEOHBpGYen8f/LTqEN6etQubjmRhzKfLcHOvxhg/rCVqBge4uouCIAiCIAhV7xnv378/du/ejcsuuwwnTpxQ7fLLL8euXbvQt29fVCYc4TMuLs7Upk+fjmbNmqk+mItv82Vq1pRRHb0FP18fJb4ZunJJx3pgpAoHDhr87mIVX65pEroiCIIgCILn4qNVQM0kJiYiPj7e5gAtnNewYUM4g9OnT6NevXoYP348nn76aVOYyrZt25QooxAfPXo0nnvuuTK94wUFBaoZcARRbk9mZqYI+XKWuExLS1MPTFVVznLZ3uOY8M92HDieqz73aR6Dly5piya1aqjPjCtfczADqScLUDs8CN0aRytBL3i/bQiegdiGYA+xDcHbbIP6MioqCllZWWXqywqJcT8/PyQlJaF27doW09PT09U087CSyuT333/H9ddfrwQ/RTn56quv0KhRI/V58+bNePLJJ9G9e3dMmTLF7npYgvHFF188azq9/ayXLjh+ctDAIiIiqvTkOF1Ugh/XpeDb1Uk4XawhwM8HN3eNQ+PoYHy89AhScwpNy9YOC8C4AfEY2DyqyvonuM42BPdHbEOwh9iG4G22cfLkSbRs2dI5Ypw7IiUlRT2hmHPo0CG0adMGubm617KyGT58OAIDAzFt2jS7yyxYsACDBw/G3r17VTiLLcQz7h1PqofSc/HCtO1YvPu43WUMn/in11+AEe3iqqxv1R1X24bgvohtCPYQ2xCqq2e8XAmcDA8hDE+xDgWhN3zVqlXo1KkTnAGFPhNGy/J4kx49eqi/ZYnxoKAg1azhAfakg+wO0BZctd+axIbj21u7Y8bmJDz06wYVT26NdkaQvzxjB4a3qyshK9XENgT3RmxDsIfYhuBNtuFoX8slxjds2KD+0pm+ZcsW5aU24L9Z1vCxxx6DM5g0aZIKgWEVl7LYuHGj+lu3bl2n9ENwv5MzJizIphA34KykrHysPpCBXs1iqrJ7giAIgiAIlSfGFy5cqP7eeuut+PDDD6sspIOvJyjGx44dC3//0i7v27cPP//8M0aOHImYmBgVMz5u3Dj069dPjQgqVA9ST+Y7tNzvaw8jPjoEDaKk9KUgCIIgCB5cZ5zCuCpheAqTNm+77TaL6fTGc94HH3yg4tQZ933FFVfg2WefrdL+Ca6ldniwQ8v9teGoau3q18TwNnEqhrx57TCbVYEEQRAEQRDcVoxXNcOGDbNZT5rie/HixS7pk+A+dG8SjboRwUjOylchKbaoGeyPVnHhWHsoE1uPZqv27tzdaFqrBoa1jcPwtnXQsUEkfCWmXBAEQRCEKsQjxLgglAWTMieMboN7f1yvkjXNBbkhrd+6sgNGtKuL9JwCzNuRgtnbUrBsz3HsP56LLxbvUy2uZjCGta2DEW3jlMD39/OcJBFBEARBEDwTEeOCV0Ch/fmNnfHitO0qWdMgLiJYCXXOJ0z2vKZbQ9VO5hdi0a40zN6WjIU7U5GcnY/vVx5SLTI0AENa18HwtnHo26IWggP8XLh1giAIgiB4KyLGBa+BgntomzhVNYVJnYwlp4fbXjnD8OAAjO5YT7X8wmKs2Hccs7emYO6OFGTknsbkdUdUCw30w4CEWCXMB7aqjZrBAVW+bYIgCIIgeCcixgWvgsK7IuUL6fke1KqOaq8Wl6jYcnrMZ29NxrGsfPy7JVk1jvbZu1ktJcyHtqmD2PCz69ULgiAIgiA4iohxQbCCseI9m8ao9vzFbVSy56xtSSrOfG9qDhbvTlPtmalb0LVRlBLmbPHRUjJREARBEITyIWJcEMqAZQ/bN4hQ7fHhrZQYp8d8zrZkbDqShTUHM1V7ZcYOtKlbU5VLpDBvWUdKJgqCIAiCcG5EjAtCOWBd8ua1m+P+gc1x7MQpJcrpMV91IB3bk7JVe2/ubjSOCcXwM8K8k5RMFARBEATBDiLGBaGC1IsMwS19mqjGhE9VMnFrMpbuPY6D6Xn4cvF+1erUDMKwNrow79E0GgFSMlEQBEEQhDOIGBeESiC6RiCu7hqvWk5BERbvSsOsMyUTU7IL8MN/h1SLCAnA4Na1lTDv1yIWIYFSMlEQBEEQqjMixgWhkgkL8seoDnVVKygqxoq96SrOfO72FKTnnsaU9UdVCwnwQ/+WsSrOnCUTKdQFQRAEQaheiBgXBCcS5O+nhDbbq5dpWHcoE7O2Ms48GUdPnFLeczb/MyUZKcxZMpE10gVBEARB8H5EjAtCFdZA5yBEbM9d3BrbjmUrUU5xvic1B0v3HFft2alb0blhFEacKZnYMEZKJgqCIAiCtyJiXBBcAMsetqsfodqjwxKwP40lE1OUl3zT4RPKg8726r870LpuTQxvW0cJ81Zx4VIyURAEQRC8CBHjguAGNI0Nw70D2JohKYslE1OU13zVgQzsSMpW7YN5e9CIJROVx7wOLoiPkpKJgiAIguDhiBgXBDejbkQIxvZurFqmUTJxWwqW7knDofQ8fLVkv2q1w4NUfDnjzDlaqJRMFARBEATPQ8S4ILgxUTUCcVXXeNVyWTJxd5rymC/YkYrUkwX4aVWiajWD/TG4tR7KwgotUjJREARBEDwDEeOC4CHUCPLHyPZ1VTtdVIIV+44rj/nc7ck4nnMaf204qlpwgK8S5BTmg1vVQUSolEwUBEEQBHdFxLggeCCB/r4YkFBbtVcubYf1iaUlE49knlIinc0omTiMceYsmVhTSiYKgiAIgjshYlwQvKBkYrfG0ao9O6o1tidlY7YS5inYlXLSVDLxOVUyMfJMAmgcGteq4equC4IgCEK1R8S4IHgRLHvYtl6EauOHJeDA8VzlLWfbkHgC68+012fuVGUS6TFnPfPWdaVkoiAIgiC4AhHjguDFNKlVA/f0b6Zacla+ii+nx3zl/nTsTD6p2kfz9yA+OsQ0yBAHHJKSiYIgCIJQNYgYF4RqQlxEMG7q1Vi1E3mnMX9HqhpkaMnuNBzOOIX/W3pAtVphQRh2ZpChXk1jVHy6IAiCIAjOQcS4IFRDIkMDcUWXBqrlnS5SgpwJoPN3puJ4TgF+XpWoWjhLJraqrZdMTIhFaKBcMgRBEAShMpE7qyBUcyiwR7SrqxpLJv63P115zDkKKIX51I3HVAvy90W/MyUTh7SurQS9IAiCIAjnh4hxQRBMBJ4R3Gwvj2mHDYmZZxJAU5CYkYe521nXPEVVcOnZNFoJ82Ft4lQIjCAIgiAI5UfEuCAINqHg7to4WrWnR7bGjqSTpsosTPxcvjddtef/3oZO8ZEY0U5PAGXSqCAIgiAIjiFiXBCEc8Kyh23q1VRt3NCWOHg8F3O2J6s4c5ZK3HhYb2/M3ImWdcLUAENd6wYiNlZzddcFQRAEwa1x6zIJL7zwghIB5q1Vq1am+fn5+bj//vsRExODsLAwXHHFFUhJSXFpnwWhOsABg+7q1wxT7uuD1U8PVqOA9m1RS434uTslBx8v3IexP+9A/3cW4+Xp27H6QAaKS0SYC4IgCILHecbbtm2LefPmmT77+5d2edy4cZgxYwb++OMPRERE4IEHHsDll1+O5cuXu6i3glD9qF0zGDf2bKRaVl4h5u9MUR7zxbtTcSTzFL5ZdkC1WmGBGNqmjhpoqHezGAT5+7m664IgCILgctxejFN8x8XFnTU9KysL33zzDX7++WcMGjRITZs0aRJat26N//77Dz179nRBbwWhehMRGoDLOzfApZ3qIfFoMnacAOZuT8W8HazMchq/rD6sWniQPwa2qq3izPu3jEWNILe/FAmCIAiCU3D7O+CePXtQr149BAcHo1evXnj99dfRsGFDrFu3DoWFhRgyZIhpWYawcN7KlSvLFOMFBQWqGWRnZ6u/JSUlqgmOwX2laZrsM+EsaBNB/j4Y2lovhVhYzJKJGZizPUW1tJMF+GfTMdVYwaVv81oY3rYOBreujSgpmejVyHVDsIfYhuBttuFof91ajPfo0QPffvstEhISkJSUhBdffBF9+/bF1q1bkZycjMDAQERGRlp8p06dOmpeWVDQc13WpKWlqTh0wXEj4xsKniC+vm6dfiC4gW0kRAAJvWJxf89a2JaUi0X7TmDx3hM4klWgBhti8/MBLmgQjv7NIlWrHS7C3NuQ64ZgD7ENwdts4+TJkw4t56NxyzyEEydOoFGjRnjvvfcQEhKCW2+91cLDTbp3746BAwfizTffLJdnPD4+HpmZmahZs6ZTt8HbTg4+wMTGxnrUySG4j23w8rMrJUeVS6THnOUTzenYIALD2tZR1VmaxoZVQc8FZyPXDcEeYhuCt9kG9WVUVJR6kChLX7q1Z9waesFbtmyJvXv3YujQoTh9+rQS6ObecVZTsRVjbk5QUJBq1vAAe9JBdgdY4Ub2m3A+ttGmXoRq44YmIDE9z1TLfF1iJjYdyVLt7dm70aJ2mAp5YZx523o11foFz0SuG4I9xDYEb7INR/vqUWI8JycH+/btw0033YQuXbogICAA8+fPVyUNya5du5CYmKhiywVB8DwaxoTizn5NVUs9ma9G++Tonyv2Hsee1BzsSd2LTxbuRf3IEOUxH9E2Tg1KxAGKBEEQBMETcWsx/thjj2H06NEqNOXYsWOYMGEC/Pz8cN1116lShrfffjvGjx+P6Oho5f5/8MEHlRCXSiqC4PnUDg/GDT0aqZZ1qhALd6Yqj/miXWk4euIUJi0/qFpMjUAMaV1Hecx7N5eSiYIgCIJn4dZi/MiRI0p4p6enqzihCy+8UJUt5L/J+++/r14B0DPOGPDhw4fjs88+c3W3BUGoZCJCAnDpBfVVO3W6GEv3pGHWtmTM35GK9NzT+G3tYdXCzpRMZGWWAQm11WdBEARBcGc8KoHTmQH29LSfK8BeODuhIjU1FbVr1/aoGC7Be2yDJRNX7c84kwCajJTs0sTs0pKJcRjSpg6ia0hlFndArhuCPcQ2BG+zDUf1pbiNBEHwWAL8fHFhi1qqvXhJW2w8ckJPAN2ajIPpeaaSib5TgO5NopUwZ6sXGeLqrguCIAiCQsS4IAhega+vDzo3jFLtfyNaYfeZkomztiZje1K2GnSI7cVp29GhQYRJmDevLSUTBUEQBNchYlwQBK8sgZUQF67aQ4Nb4HBGacnEtYcysflIlmpvz96FZrE1VPInhXn7+hFSMlEQBEGoUkSMC4Lg9cRHh+KOvk1VSztZcKZkYjJW7DuOfWm5+HThPtXqRQRj2BmPebfGUfD385zYREEQBMEzETEuCEK1IjY8CNf3aKhadr5lycRjWfn4dsVB1ZjwOaQ1K7PEoU/zWggOkJKJgiAIQuUjYlwQhGpLzeAAjOlUX7X8QpZMPK6E+bwdKcjIPY3f1x5RrUagHwaokolxGJgQi/DgAFd3XRAEQfASRIwLgiAAyvM9tE0d1YqKS7D6gF4ykSOAJmfnY8bmJNUC/XzRp3mMijPnYEMxYUGu7rogCILgwYgYFwRBsIKx4r2b11Jtwui22Hw0S1VlmbMtGfuP52LhrjTVfH22oGvjaIxgnHm7ONSXkomCIAhCORExLgiCcI6SiZ3iI1V7ckQC9qbmKGE+e3syth7NVh50tpemb1fVWDj6p1EyUSqzCIIgCOdCxLggCIKDUFy3qBOu2oNnSibOOVOZZc3BDGw5mqXaO3N2o2lsDVMt844N7JdMLC7RlJhPPZmP2uHBanAiP18R8YIgCNUFEeOCIAjnUTLx9gubqHY8pwDzzgjz5XvTsT8tF58v2qdaXZZMbFNHhbJ0bxxtKpk4a2uSGoQoKSvftE4uO2F0G4xoV9eFWyYIgiBUFSLGBUEQKoFaYUG4tntD1U6yZOKuNMzemoyFu1KV2P5u5SHVokIDMLh1HcSGBeGLxfugWa0nOSsf9/64Hp/f2FkEuSAIQjVAxLggCEIlw9KHl3SspxpLJi7fe1zFmbNkYmZeISavO2L3uxTnDFKhx3xomzgJWREEQfByRIwLgiA4uWQiPeFsqmTiwQx8t+KgKplYliCnN/2aL1eiVd1wxIYFo3bNINQOD1KDFjG2vFZYoIwQKgiC4AWIGBcEQajKkonNaiHtZEGZYtxg7aFM1WzBfNDo0EAlzg2BTsHO8BdduAefmR6EGkFyqRcEQXBX5AotCIJQxVAoO8JtfRojLMgfqScLlIDnX1ZdOZ5zWlVhSc89rdrO5JNlric00E+JckOglwp4Cvdgk4CnuGcpR0EQBKHqEDEuCIJQxbB8IaumMFnTOoGTUA7HRQTjmVFtbMaMl5RoyMg7XSrQs/ORlsO/umjXp+erv7mni5F3uhgH0/NUKwv+FsNfzL3qRmhMrJnnnZ8ZfiMIgiCcPyLGBUEQqhiKXpYvZNUUSm1zQW5Ib863l7xJ7zWrt7C1PkfBldyCIjPPer4u2A3hrv7qop0ednrbU7ILVDsXNYP9lVe9NI7dMjTGCJ2pGeIvgx8JgiCUgYhxQRAEF8CyhSxfaF1nPK6S64wzXrwJW60aZS5XWFyC9JzTJo+6XQF/sgCni0uQnV+E7PwcNSJpWQT6+5rFsesPEDV8i9A4rgB1lJjXBbwkpAqCUF0RMS4IguAiKLhZvtAdRuAM8PNVDwJsZaFpGrJPFVmI9rMFvO5xp2A/XVSCoydOqWbJMbsJqeZx7OZedklIFQTBG5ErmiAIgguh8O7VLAaeAkNOIkIDVGtRJ7zMZVlj3Vykpykvez4OpWXhZKGPSkStSEJqjUC/UoFuVkFG/1saOiMJqYIgeAIixgVBEASnwCTP+OhQ1QxKSkqQmpqK2rVrw9dXD0uhEM/MO20Rx14q4C0970xGZVJqbjkTUs1j22PNPO+SkCoIgqsRMS4IgiC4FF006/Hk58JISDWvIGMe324I+PImpEaEBJxVQcaiqowS7pKQKghC5SNiXBAEQfAYzichVfe86wmp5p53JqRmnSpUzZGEVAsvuzHgktXgSzE1JCFVEATHEDEuCIIgeB3lSUilCC+zgkyOZULqkcxTqpUFnecU5PT2W5eAtBbwkpAqCNUbuQIIgiAI1RaGnESGBqpWvoRUGxVkzkwzElL5l82RhFSjgox5Qqr14EtRkpAqCF6JiHFBEARBqGBCqi0oxDNyjRFSLUW7yfN+JmzmVKGekHrgeK5qZeF/JrbeMo5dT0i19rwH+UtCqiB4CiLGBUEQBKGSE1IpiNnaoGaZy+YUFOkC3ayCjLmX3TwhtahEQ3J2vmqOJKRajI5qVUFG/eUIqcGSkCoIrsatxfjrr7+OKVOmYOfOnQgJCUHv3r3x5ptvIiEhwbTMgAEDsHjxYovv3X333fjiiy9c0GNBEARBcJywIH/VHElIPZ5zRqybxbPb8rybJ6TuOUdCahBHSDUX7TYqyEhCqiBUYzFOkX3//fejW7duKCoqwtNPP41hw4Zh+/btqFGj9MJ155134qWXXjJ9Dg0t+xWiIAiCIHhaQmrdiBDVypOQahLrNkpAMiG1oJwJqfSmn6sEZGigW0sLQXA73PqMmTVrlsXnb7/9Vg0UsW7dOvTr189CfMfFxTm83oKCAtUMsrOzTYNRsAmOwX3FC7/sM8EasQ3BHmIbzoehJ2zNYms4lJBqXq+d3nfL+HZ9WokGU0LqjiQ4OEKqLtYtPe96PXlbCaliG4I9PNU2HO2vW4txa7KystTf6Ohoi+k//fQTfvzxRyXIR48ejeeee65M7zjDX1588cWzpqelpSE//9yxeEKpkfGY8AQxRtITBCK2IdhDbMO94DBLDYLZfIHa9LqH2ExIPXGqCOm5hUjPK9T/5hbiuOnf+rzjuYXILyopxwipQHRoAGrVCFB/Y0L9EeZfjHpRqSquPaaGP2JqcHqAqu8uVF9KPPS6cfJk2ZWUDHw0bpmHHIhLLrkEJ06cwLJly0zTv/rqKzRq1Aj16tXD5s2b8eSTT6J79+4q1rw8nvH4+HhkZmaiZs2yk20Ey2PCB5jY2FiPOjkE5yO2IdhDbMO7YUKq8qZbhMmcLvXA8292PjLyCsu1XvOEVJPX3ayyjPE3XBJSvZISD71uUF9GRUWpB4my9KXHeMYZO75161YLIU7uuusu07/bt2+PunXrYvDgwdi3bx+aNWtmc11BQUGqWcMD7EkH2R3gRU/2m2ALsQ3BHmIb3kvNkEDVmtcOdyghVSWjmkZIPYVDqSeQU+SLtJzT55WQanN0VLPa7ZKQ6nn4eOB1w9G+eoQYf+CBBzB9+nQsWbIEDRo0KHPZHj16qL979+61K8YFQRAEQXCvhFR6P1NTU1VumCFijITUs0ZHtU5QPVmAkxVMSLUoAan+HWxRAlISUgVn49YWxpPwwQcfxF9//YVFixahSZMm5/zOxo0b1V96yAVBEARB8I4RUls6PEKq1eioRgnIM5748iaksvTk2Ymo1iUgZYRUwUvFOENTfv75Z/z9998IDw9HcnKymh4REaHqjjMUhfNHjhyJmJgYFTM+btw4VWmlQ4cOru6+IAiCIAhuOkKq3dFRzeq4c4RUxsGzOTpCqh4OY4j3s0dHlRFSBY8S459//rlpYB9zJk2ahFtuuQWBgYGYN28ePvjgA+Tm5qokzCuuuALPPvusi3osCIIgCIKnjJB6rrfzrAxzrtFROS2jnCOkRoYGmMJgzL3spd53fZqMkFo9cGsxfq5CLxTf1qNvCoIgCIIgnC8UwWqE1NgwNI0NK3PZ00UlSM+1PbiSLuD1CjNGQuqJvELVHElINcWvW4fGmIl2SUj1bNxajAuCIAiCILg7rINenhFS9eoxDIfRw2IsElTP/NtISD2ccUq1cyekWieiWiakGtMkIdX9kCMiCIIgCILgZgmpp04XnxkR1TKO3Vq0lyak6v92JCFVjYR6jhKQkSEBkpBaRYgYFwRBEARBcDNCAh1PSGWIzFnJqNmlFWSMWPf8whJTQup+BxJSLQZZMg+TMQn3YNQKC5SE1PNExLggCIIgCIIHJ6Tqnu1gtD1HiAxFuHkcuym23dzznlOakJqUla+aIwmp5l52Wwmp9LiHB1V9QmpxiYbVBzLUdrIf3ZtEq33mTogYFwRBEARB8HIogsODA1RzJCGVIS+2Blcy/T3jeS8s1kwJqbtTypeQaj64Um0zER9dSQmps7Ym4cVp2y0eKOpGBGPC6DYY0c59xqMRMS4IgiAIgiBYJKTWiwxRDefwtlOEl4bDWFaQSatgQqqvDxBdw9y7HogavsVoXCcPdSJCLAZfYjiPPSF+74/rYV2XLzkrX03//MbObiPIRYwLgiAIgiAIFfK2R9UIVM2RhFQVz26jgkyamYBPt0pIhUVCqj74o62EVPOQmJiwQHy1ZP9ZQpxwGoNU6DEf2ibOLUJWRIwLgiAIgiAIToUe7IYxoao5kpCaeiZ+nfHsKf/f3n1AR1FFfQB/CQGSCAk9BEIChE4ooUgHjyBVBPSAVAMqHgUkFGkioHIogoigUlUsoIhKaFKlg0hvAQwgLYeWQw0cWkLed/73+2a+nbipRmY3+f/OWbK7M8y+mX3J3nlz3907D9T5qzfV3URPde3uo0xNSE0ekCN1BbnkDUILK7sxGCciIiIil5uQakhKSlJxcXGqWLFiytPT0zIh1fLtqP+Xx37g3E219/xNlRYE9K6AwTgRERERue2E1NBkE1J3/X1ddZv/Z5rbcAz47cTvTiUiIiKibOPpMoWkakpK2eB4HsuxnitgME5ERERE2SrVZVz7KnI/eUBuPMZyV5i8CQzGiYiIiChbaR0WKOULi/tbU1Hw2JXKGgJzxomIiIgo22kdFijlC/kNnERERERENsjl6eES5QtTwzQVIiIiIiKbMBgnIiIiIrIJg3EiIiIiIpswGCciIiIisgmDcSIiIiIimzAYJyIiIiKyCYNxIiIiIiKbsM64UkprLT/j4+PtbopbSUpKUnfu3FHe3t7K05PndfT/2DcoJewblBL2DcpufcOIK404MyUMxpWSNxhKlSpld1OIiIiIKJvFmf7+/iku99Bphes55Izr0qVLKn/+/MrDw7W+ItXVz/hwAhMbG6v8/Pzsbg65EPYNSgn7BqWEfYOyW99AiI1AvESJEqmO6HNkHInznp4qKCjI7ma4LfxiuNMvBz057BuUEvYNSgn7BmWnvpHaiLjBfRJviIiIiIiyGQbjREREREQ2YTBOmZY3b141btw4+UnkiH2DUsK+QSlh36Cc2jc4gZOIiIiIyCYcGSciIiIisgmDcSIiIiIimzAYJyIiIiKyCYNxIiIiIiKbMBgni0mTJqm6devKt5EWK1ZMdezYUcXExFjWefDggerfv78qXLiwypcvn3rppZfU1atXLetcuHBBtWvXTvn6+sp2hg0bphITE5/w3tB/afLkyfKNtYMGDTKfY9/IuS5evKh69uwp772Pj4+qVq2a2rdvn7kctQLGjh2rAgMDZXmLFi3UqVOnLNu4ceOG6tGjh3ypR4ECBdRrr72m7t69a8PeUFZ5/PixGjNmjCpTpoy876GhoWr8+PHSHwzsGznDtm3bVPv27eXbKPHZsWzZMstynUX94MiRI6pJkybK29tbvrVzypQpyuWhmgqRoVWrVnrBggU6OjpaHzp0SLdt21YHBwfru3fvmuu8+eabulSpUnrjxo163759un79+rphw4bm8sTERB0WFqZbtGihDx48qFevXq2LFCmiR40aZdNeUVbbs2ePLl26tK5evbqOjIw0n2ffyJlu3LihQ0JCdO/evfXu3bv1mTNn9Lp16/Tp06fNdSZPnqz9/f31smXL9OHDh/ULL7ygy5Qpo+/fv2+u07p1a12jRg39559/6u3bt+ty5crpbt262bRXlBUmTJigCxcurFetWqXPnj2rf/75Z50vXz49Y8YMcx32jZwBf+9Hjx6tly5dijMxHRUVZVk+OQv6we3bt3VAQIDu0aOHxDE//vij9vHx0XPnztWujME4pSouLk5+abZu3SqPb926pXPnzi1/UA0nTpyQdXbt2mX+wnl6euorV66Y68yePVv7+fnphw8f2rAXlJXu3Lmjy5cvrzds2KCbNWtmBuPsGznXiBEjdOPGjVNcnpSUpIsXL66nTp1qPof+kjdvXvmwhOPHj0tf2bt3r7nOmjVrtIeHh7548eJ/vAf0X2nXrp1+9dVXLc+9+OKLEiwB+0bOlDwYT8qifjBr1ixdsGBBy+cJ/j5VrFhRuzKmqVCqbt++LT8LFSokP/fv368SEhLk8pGhUqVKKjg4WO3atUse4ycuUQcEBJjrtGrVSsXHx6tjx4498X2grIU0FKSZOPYBYN/IuVasWKHq1KmjOnfuLKlH4eHhav78+ebys2fPqitXrlj6hr+/v6pXr56lb+CyM7ZjwPqenp5q9+7dT3iPKKs0bNhQbdy4UZ08eVIeHz58WO3YsUO1adNGHrNvUFb2A6zTtGlTlSdPHstnDNJtb968qVyVl90NINeVlJQk+cCNGjVSYWFh8hx+WdDJ8QvhCMEVlhnrOAZbxnJjGbmvxYsXqwMHDqi9e/f+Yxn7Rs515swZNXv2bDVkyBD17rvvSv8YOHCg9IeIiAjzvXX23jv2DQTyjry8vGQggH3DfY0cOVJOtnFinitXLskhnzBhguT9AvsGZWU/wE/MT0i+DWNZwYIFlStiME6pjoBGR0fLKAZRbGysioyMVBs2bJCJMUSOJ+4YrZo4caI8xsg4/nbMmTNHgnHKuZYsWaIWLVqkfvjhB1W1alV16NAhGeTBJD72DaL/xTQVcmrAgAFq1apVavPmzSooKMh8vnjx4urRo0fq1q1blvVRMQPLjHWSV9AwHhvrkPtBGkpcXJyqVauWjEbgtnXrVjVz5ky5j9EH9o2cCdUPqlSpYnmucuXKUjnH8b119t479g30L0eosoPqCewb7gvVkjA63rVrV0lR69Wrlxo8eLBU7gL2DcrKfuCunzEMxskC8yoQiEdFRalNmzb943JP7dq1Ve7cuSUH0IBcLHzoNmjQQB7j59GjRy2/NBhNRSmi5B/Y5D6aN28u7ytGtowbRkNxudm4z76RMyGVLXkJVOQIh4SEyH38HcEHoWPfQOoC8jwd+wZO5HDSZ8DfIIy6I2+U3NO9e/ckp9cR0lXwvgL7BmVlP8A6KKGI+UuOnzEVK1Z02RQVYfcMUnItb731lpQW2rJli758+bJ5u3fvnqV8Hcodbtq0ScrXNWjQQG7Jy9e1bNlSyiOuXbtWFy1alOXrsiHHairAvpFzS116eXlJGbtTp07pRYsWaV9fX71w4UJL2bICBQro5cuX6yNHjugOHTo4LVsWHh4u5RF37NghVXtYvs69RURE6JIlS5qlDVHWDuVMhw8fbq7DvpFzKnGhpC1uCD8/+eQTuX/+/Pks6weowILShr169ZLShosXL5a/RSxtSG4FvyDObqg9bsAvRr9+/aR8EDp5p06dJGB3dO7cOd2mTRup74k/vEOHDtUJCQk27BE9yWCcfSPnWrlypZxooRRZpUqV9Lx58yzLUbpszJgx8kGJdZo3b65jYmIs61y/fl0+WFGHGuUu+/TpIx/g5L7i4+PlbwRO0r29vXXZsmWl1rRj6Tn2jZxh8+bNTuOLiIiILO0HqFGOUqvYBk4EEeS7Og/8Y/foPBERERFRTsSccSIiIiIimzAYJyIiIiKyCYNxIiIiIiKbMBgnIiIiIrIJg3EiIiIiIpswGCciIiIisgmDcSIiIiIimzAYJyIiIiKyCYNxInI5zzzzjBo0aJDdzXBJvXv3Vh07drS7GdlGr1691MSJE//1dkqXLq0+/fRTZZf69eurX3/91bbXJ6LMYzBORERuc0KVlds9fPiwWr16tRo4cKDLBNWZ9d5776mRI0eqpKQku5tCRBnEYJyIyGaPHj2yuwk50meffaY6d+6s8uXLp9xdmzZt1J07d9SaNWvsbgoRZRCDcSJyeTdv3lSvvPKKKliwoPL19ZXA49SpU+byb775RhUoUECtW7dOVa5cWYKr1q1bq8uXL5vrJCYmyggo1itcuLAaMWKEioiIsKR8OBsVrVmzpnr//ffNx7du3VKvv/66Klq0qPLz81PPPvusjLCmlkaCkVyM6Bpwf8CAAfJ8kSJFVKtWrZzu9+PHj9WQIUPMNg8fPlxprS3rpKfNznz99deqatWqKm/evCowMFDaY7hw4YLq0KGDHEfsY5cuXdTVq1fN5dg2XuP777+X1/f391ddu3aVYNA4Blu3blUzZsxQHh4ecjt37pwsi46OlvcP2w4ICJA0kWvXrsmyLVu2qDx58qjt27ebrzVlyhRVrFgxef3MbjelY/vLL7+o9u3bW96X8+fPq8GDB5vbNyAFxDhe2Odp06aleny//PJLed82btyYrvbhtdE/8R4XKlRIFS9e3PIe4n3H4+DgYGlDiRIlLCP6uXLlUm3btlWLFy9OtV1E5HoYjBORy0MQtm/fPrVixQq1a9cuCUwQeCQkJJjr3Lt3T3388ccSIG7btk0Cynfeecdc/tFHH6lFixapBQsWqJ07d6r4+Hi1bNmyDLcFI6lxcXEyArl//35Vq1Yt1bx5c3Xjxo0Mbefbb7+VwBNtmTNnjtN1EPDhRAOB844dO+Q1oqKi1L81e/Zs1b9/f/XGG2+oo0ePynEtV66cLEOaAwJxvBYC3w0bNqgzZ86ol19+2bKNv//+W47fqlWr5IZ1J0+eLMsQLDdo0ED17dtXTohwK1WqlJzI4OQlPDxc3s+1a9dKkI1g3zEFBYHq7du31cGDB9WYMWMksEUAm9ntOnPkyBF5jTp16pjPLV26VAUFBakPP/zQ3D7gfca2cMKB44WgGO3Ce+MMTiCQMrJ+/XrpG+ltH/rEU089pXbv3i3bQDtw/I2TgenTp6u5c+fKiSiOfbVq1Sz//+mnn7acyBCRm9BERC6mWbNmOjIyUu6fPHkSQ8F6586d5vJr165pHx8fvWTJEnm8YMECWef06dPmOl988YUOCAgwH+P+1KlTzceJiYk6ODhYd+jQwXwuJCRET58+3dKWGjVq6HHjxsn97du3az8/P/3gwQPLOqGhoXru3LlyPyIiwrJNwL5gnxz3Lzw8PM3jEBgYqKdMmWI+TkhI0EFBQRlqszMlSpTQo0ePdrps/fr1OleuXPrChQvmc8eOHZPju2fPHnmMbfv6+ur4+HhznWHDhul69eo5fQ8N48eP1y1btrQ8FxsbK9uOiYmRxw8fPtQ1a9bUXbp00VWqVNF9+/a1rJ/Z7SYXFRUl+5mUlGR53tnx7N69u37uuecsz2F/0b7k/2/48OHyvkVHR2eofdivxo0bW9apW7euHjFihNyfNm2arlChgn706JFOyfLly7Wnp6d+/PhxiusQkevhyDgRubQTJ04oLy8vVa9ePfM5pGxUrFhRlhmQvhIaGmo+RuoFRrABI6AYicTIoeNl/dq1a2eoLUhHuXv3rrw+0g2M29mzZ2WkOCPSem20GSOzjvuN4+A4kpsZOCaXLl2SEVtncEwx2oyboUqVKpJy4Xi8kaqRP39+p8c7teO3efNmy7GrVKmSLDOOH64W4AoGRoIfPHggo8FpSc92k7t//76kezimoqQE+92oUSPLc3iMEWqkuzheyZg/f75cxUBKS0bbV716dctrOB5TXJFBm8uWLStXBnCFBKlXjnx8fOTKxsOHD9PcJyJyHV52N4CIKCvkzp3b8hhBVvL86rR4enr+4/84psIgEEeAhNzm5BCspmcbBqQjZIX0vp5jwPZfHe+0Knng+CFHGylDyeG4Gv744w/5iVQZ3NI6VundriPk6iO1CZNncQKQFZo0aaJ+++03tWTJEklTyWj7UjumODmKiYlRv//+u6Su9OvXT02dOlXSg4z/ZxyrrHqPiejJ4Mg4Ebk0TMjECCDyaA3Xr1+XwAQjtumBCYbIOd67d6/5HEY0Dxw4YFkPkzIdJ30irxyj3gbkh1+5ckVGqJFj7XhDcOdsG3Do0KEM7zfajEDNcb9xHJC/nJE2J4fRbIxqGxMLnR3v2NhYuRmOHz8uec/pPd6AANdx1Ng4fseOHZPXT378jIAbI8WYQIkRZlwVwCRbxyA/s9tNDhNQjX1Lq904Jsjtd4THFSpUkCssBlx5wVwC1C3H/IV/0z5nEGQjqJ85c6acEGL+BHLYDZgkirx0InIvDMaJyKWVL19eJhTi0jwu/+OSf8+ePVXJkiXl+fR6++231aRJk9Ty5cslkI+MjJQqLY5pCphkhwmgmASHIAeBoGOw1aJFC5lAiGopmJyHSh4YxR09erRMzDO2gfvfffedpDGMGzdOgqTMQBsxKRKT9f766y8ZDUVQ7CitNjuDCYhIqUBQhzbipARl/ox9xMTAHj16yPN79uyRSjbNmjXLUIoMAk+cSOAYoWoIAmpMGsXobbdu3eTECIE3KuD06dNHAmDc8N6iugyew2RbTLR0rFySme06g5MYBMnoU8nbjQnAFy9eNKudDB06VE5exo8fr06ePCkTLT///HPLBGFDw4YNpXb5Bx98YFa5yUz7ksNk0a+++kr6EibULly4UILzkJAQcx30gZYtW6bzHSIiV8FgnIhcHoIy5Fg///zzEgwjLQMBT/LL+qlBKUMEQwgssQ3k7SLo8/b2NtcZNWqUBJ14nXbt2knQ7ZiHjsAdr9u0aVMJpDAyigobKIeHkXfANlFpAyXq6tatK+X+8JqZgSAQlUUQYKPNGNXu1KmTZZ202uwMtodAcdasWZLbjP9rlIrEPuKEBWUksZ8IzpGn/NNPP2Wo7QhUcVKA0XQEvqhug3J8GFFGAIqgEUE/qqcgxQfpNhMmTJBjiYohgCsD8+bNky+0McpHZma7KUGJSuSnO0IFEwT6OIbYPiBoR+oJygaGhYWpsWPHynqo8uNM48aNJV0F7cZJTmbb5wjr4moBctWRW450lZUrV8r8BcDJA04M0S+JyL14YBan3Y0gInrSMKKK9AOUl8OIJ+U8mBCJicA40cDJjjvDySau9ODkhYjcCydwElGOgBFXpJZgFBnVJpBmgNzq7t272900sgnSPJBOlNqXA7kLfDESviCKiNwPR8aJKEfAhESklCDnFn/2kG6AfGykYhAREdmFwTgRERERkU04gZOIiIiIyCYMxomIiIiIbMJgnIiIiIjIJgzGiYiIiIhswmCciIiIiMgmDMaJiIiIiGzCYJyIiIiIyCYMxomIiIiIlD3+B9W8m4sxpljGAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 750x420 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "CTX_LENGTHS = [128, 256, 512, 1024]\n",
+    "N_NEW = 24\n",
+    "\n",
+    "rows = []\n",
+    "for ctx_len in CTX_LENGTHS:\n",
+    "    torch.manual_seed(100 + ctx_len)\n",
+    "    prompt = torch.randint(0, CFG.vocab_size, (1, ctx_len))\n",
+    "    _, t_naive, _ = generate_naive(model, prompt, N_NEW)\n",
+    "    _, t_cached, per_step = generate_cached(model, prompt, N_NEW)\n",
+    "    tps_naive = N_NEW / t_naive\n",
+    "    tps_cached = N_NEW / t_cached                       # total : préfill + décodage\n",
+    "    t_decode = sum(per_step[1:])                        # décodage seul (préfill exclu)\n",
+    "    tps_decode = (N_NEW - 1) / t_decode\n",
+    "    rows.append((ctx_len, tps_naive, tps_cached, tps_decode))\n",
+    "    print(f\"ctx={ctx_len:5d} | naïf {tps_naive:6.1f} tok/s\"\n",
+    "          f\" | cache total {tps_cached:6.1f} tok/s\"\n",
+    "          f\" | décodage seul {tps_decode:6.1f} tok/s\"\n",
+    "          f\" | speedup ×{tps_cached / tps_naive:.1f}\")\n",
+    "\n",
+    "print()\n",
+    "print(f\"{'ctx':>6}{'tok/s naïf':>12}{'tok/s cache total':>19}{'tok/s décodage seul':>21}\")\n",
+    "for r in rows:\n",
+    "    print(f\"{r[0]:>6}{r[1]:>12.1f}{r[2]:>19.1f}{r[3]:>21.1f}\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7.5, 4.2))\n",
+    "xs = [r[0] for r in rows]\n",
+    "ax.plot(xs, [r[1] for r in rows], \"o-\", label=\"naïf (recalcul complet)\")\n",
+    "ax.plot(xs, [r[2] for r in rows], \"s-\", label=\"KV-cache : total (préfill + décodage)\")\n",
+    "ax.plot(xs, [r[3] for r in rows], \"^--\", label=\"KV-cache : décodage seul\")\n",
+    "ax.set_xlabel(\"longueur du contexte (tokens)\")\n",
+    "ax.set_ylabel(\"tokens / seconde\")\n",
+    "ax.set_title(\"Débit de génération : le mur du recalcul vs le KV-cache (MiniGPT CPU)\")\n",
+    "ax.legend()\n",
+    "ax.grid(alpha=0.3)\n",
+    "fig.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e0f5b55",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002821,
+     "end_time": "2026-08-25T21:47:36.672887",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:36.670066",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** Trois régimes bien distincts :\n",
+    "- le débit naïf **s'effondre** quand le contexte croît : chaque pas paie un forward sur tout le préfixe, et ce préfixe grandit — coût total quadratique ;\n",
+    "- le débit caché **total** décroît doucement : il inclut le **préfill** (proportionnel au prompt), pesé de plus en plus lourd à génération courte ;\n",
+    "- le débit caché **en décodage seul** (préfill exclu) reste **stable** : chaque pas ne traite qu'un token, et consulter le cache (une concaténation et un produit ligne × cache) coûte peu — c'est la signature mécanique du cache.\n",
+    "\n",
+    "Sur ce MiniGPT 4 couches en CPU, le speedup est modeste en valeur absolue — c'est la **forme** des courbes qui transporte la leçon : l'écart **croît avec le contexte**. Sur un vrai modèle (des dizaines de couches, des milliers de dimensions, GPU saturé), le même rapport devient le facteur qui décide si un service est utilisable ou pas. C'est ce que la partie 5 mesure sur notre vLLM.\n",
+    "\n",
+    "## 4. Le prix du cache : la mémoire\n",
+    "\n",
+    "Le cache n'est pas gratuit — il échange du calcul contre de la **mémoire vive**. Pour chaque couche, on conserve K **et** V pour chaque tête, chaque dimension de tête, chaque position :\n",
+    "\n",
+    "`octets = n_couches × 2 (K,V) × n_têtes_kv × head_dim × seq_len × octets_par_élément`\n",
+    "\n",
+    "Deux remarques de production :\n",
+    "- **GQA** (*grouped-query attention*) : les modèles récents gardent moins de têtes K/V que de têtes de requête (Llama-3.1-8B : 32 têtes Q, mais 8 têtes K/V) — le cache ne paie que les têtes KV.\n",
+    "- À **seq_len = 131 072** (contexte long), le cache peut dominer l'empreinte mémoire des poids eux-mêmes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "128e1b8f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:36.679621Z",
+     "iopub.status.busy": "2026-08-25T21:47:36.679291Z",
+     "iopub.status.idle": "2026-08-25T21:47:36.751219Z",
+     "shell.execute_reply": "2026-08-25T21:47:36.750307Z"
+    },
+    "papermill": {
+     "duration": 0.076207,
+     "end_time": "2026-08-25T21:47:36.752016",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:36.675809",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "modèle                      fp16 @ 8k  fp16 @ 32k  fp16 @ 131k   remarque\n",
+      "GPT-2 small (MHA)              0.30 GB      1.21 GB       4.83 GB   12 têtes K/V = 12 têtes Q\n",
+      "Llama-3.1-8B (GQA)             1.07 GB      4.29 GB      17.18 GB   32 têtes Q mais 8 têtes K/V seulement\n",
+      "MiniGPT (ce notebook)          0.02 GB      0.07 GB       0.27 GB   notre moteur d'étude\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "MiniGPT, seq=1024, dtype=torch.float32 :\n",
+      "  formule : 4.19 MB\n",
+      "  mesuré  : 4.19 MB  (somme des tenseurs K/V réellement alloués)\n",
+      "  écart   : 0.0000 %\n"
+     ]
+    }
+   ],
+   "source": [
+    "def cache_bytes_theoretical(n_layers, n_kv_heads, head_dim, seq_len, bytes_per_elem):\n",
+    "    \"\"\"Octets du KV-cache complet pour une séquence de seq_len tokens.\"\"\"\n",
+    "    return n_layers * 2 * n_kv_heads * head_dim * seq_len * bytes_per_elem\n",
+    "\n",
+    "\n",
+    "# --- configurations RÉELLES, chiffres publics des fiches modèles ---\n",
+    "configs = [\n",
+    "    # (nom, n_layers, n_kv_heads, head_dim, notes)\n",
+    "    (\"GPT-2 small (MHA)\",      12, 12,  64, \"12 têtes K/V = 12 têtes Q\"),\n",
+    "    (\"Llama-3.1-8B (GQA)\",     32,  8, 128, \"32 têtes Q mais 8 têtes K/V seulement\"),\n",
+    "    (\"MiniGPT (ce notebook)\",  CFG.n_layer, CFG.n_head, CFG.head_dim, \"notre moteur d'étude\"),\n",
+    "]\n",
+    "\n",
+    "print(f\"{'modèle':<26}{'fp16 @ 8k':>11}{'fp16 @ 32k':>12}{'fp16 @ 131k':>13}   remarque\")\n",
+    "for name, L, H, hd, note in configs:\n",
+    "    b8 = cache_bytes_theoretical(L, H, hd, 8192, 2)\n",
+    "    b32 = cache_bytes_theoretical(L, H, hd, 32768, 2)\n",
+    "    b131 = cache_bytes_theoretical(L, H, hd, 131072, 2)\n",
+    "    print(f\"{name:<26}{b8 / 1e9:>9.2f} GB{b32 / 1e9:>10.2f} GB{b131 / 1e9:>11.2f} GB   {note}\")\n",
+    "\n",
+    "# --- confrontation au MESURÉ sur notre MiniGPT : le cache réellement produit ---\n",
+    "torch.manual_seed(3)\n",
+    "probe = torch.randint(0, CFG.vocab_size, (1, 1024))\n",
+    "with torch.no_grad():\n",
+    "    _, caches = model(probe)\n",
+    "measured = sum((k.element_size() * k.nelement() + v.element_size() * v.nelement())\n",
+    "               for k, v in caches)\n",
+    "theoretical = cache_bytes_theoretical(CFG.n_layer, CFG.n_head, CFG.head_dim, 1024,\n",
+    "                                      caches[0][0].element_size())\n",
+    "print()\n",
+    "print(f\"MiniGPT, seq=1024, dtype={caches[0][0].dtype} :\")\n",
+    "print(f\"  formule : {theoretical / 1e6:.2f} MB\")\n",
+    "print(f\"  mesuré  : {measured / 1e6:.2f} MB  (somme des tenseurs K/V réellement alloués)\")\n",
+    "print(f\"  écart   : {abs(measured - theoretical) / theoretical * 100:.4f} %\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "830fcc57",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00266,
+     "end_time": "2026-08-25T21:47:36.757616",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:36.754956",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture.** La formule colle au mesuré (l'écart est nul : le cache EST exactement ces tenseurs). La ligne Llama-3.1-8B montre l'enjeu : plus de 2 Go de cache rien que pour 131 072 tokens en fp16 — avant même de compter les poids. C'est ce coût qui motive les optimisations de service (PagedAttention de vLLM, quantification du cache, fenêtres glissantes).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Exercice 1 — le cache d'un modèle inconnu\n",
+    "\n",
+    "**Contexte.** On vous donne la fiche d'un modèle : 40 couches, 64 têtes de requête, **8 têtes K/V** (GQA), `head_dim = 128`, service en **bf16** (2 octets).\n",
+    "\n",
+    "**Objectif.** Écrire `cache_bytes(n_layers, n_kv_heads, head_dim, seq_len, bytes_per_elem)` qui renvoie les octets du KV-cache — puis vérifier sur la fiche ci-dessus à `seq_len = 16 384`.\n",
+    "\n",
+    "**Indices.** Ne pas confondre têtes Q et têtes K/V (c'est toute la différence GQA). Le facteur 2 compte K **et** V.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a395de49",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:36.769129Z",
+     "iopub.status.busy": "2026-08-25T21:47:36.768768Z",
+     "iopub.status.idle": "2026-08-25T21:47:36.774219Z",
+     "shell.execute_reply": "2026-08-25T21:47:36.773399Z"
+    },
+    "papermill": {
+     "duration": 0.013865,
+     "end_time": "2026-08-25T21:47:36.775706",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:36.761841",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 à compléter (cache_bytes renvoie None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def cache_bytes(n_layers, n_kv_heads, head_dim, seq_len, bytes_per_elem):\n",
+    "    \"\"\"Renvoie les octets du KV-cache complet.\n",
+    "\n",
+    "    # Étape 1 : chaque couche conserve K et V -> facteur 2\n",
+    "    # Étape 2 : chaque tête K/V porte head_dim valeurs par position\n",
+    "    # Étape 3 : une position par token -> seq_len\n",
+    "    # Étape 4 : multiplier par la taille d'un élément (fp16/bf16 = 2 octets)\n",
+    "    \"\"\"\n",
+    "    return None  # TODO étudiant\n",
+    "\n",
+    "\n",
+    "# --- auto-vérification (s'affiche seulement si l'exercice est complété) ---\n",
+    "result = cache_bytes(40, 8, 128, 16384, 2)\n",
+    "if result is None:\n",
+    "    print(\"Exercice 1 à compléter (cache_bytes renvoie None)\")\n",
+    "else:\n",
+    "    attendu = 40 * 2 * 8 * 128 * 16384 * 2\n",
+    "    print(f\"calculé : {result / 1e9:.2f} GB | attendu : {attendu / 1e9:.2f} GB | \"\n",
+    "          f\"{'OK' if result == attendu else 'ÉCART'}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bf33e96",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0031,
+     "end_time": "2026-08-25T21:47:36.783076",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:36.779976",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Le pont vers la production : TTFT et ITL sur notre vLLM\n",
+    "\n",
+    "La boucle est bouclée : les mécaniques ci-dessus sont **exactement** ce qu'un serveur d'inférence exécute pour chaque requête. Deux métriques de service en découlent directement :\n",
+    "\n",
+    "- **TTFT** (*time-to-first-token*) : le temps du **préfill** — exécuter le prompt entier une fois (forward complet, comme notre premier pas naïf sur le prompt).\n",
+    "- **ITL** (*inter-token latency*) : le temps de chaque token suivant — un pas de **décodage incrémental avec KV-cache**.\n",
+    "\n",
+    "La prédiction de la partie 1 devient une prédiction de service : **le TTFT croît avec la longueur du prompt** (préfill proportionnel au prompt), **l'ITL reste à peu près constante** (chaque pas décode 1 token contre le cache — indépendant de la longueur du prompt).\n",
+    "\n",
+    "Mesurons-le sur **notre** vLLM self-hosted (qwen3.6-35b-a3b), en streaming : on chronomètre l'arrivée de chaque fragment SSE.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d55f3ac0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:36.791237Z",
+     "iopub.status.busy": "2026-08-25T21:47:36.790879Z",
+     "iopub.status.idle": "2026-08-25T21:47:36.927063Z",
+     "shell.execute_reply": "2026-08-25T21:47:36.926032Z"
+    },
+    "papermill": {
+     "duration": 0.142303,
+     "end_time": "2026-08-25T21:47:36.928365",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:36.786062",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "vLLM joignable, modèle servi : qwen3.6-35b-a3b\n"
+     ]
+    }
+   ],
+   "source": [
+    "import requests as _rq\n",
+    "\n",
+    "load_dotenv(dotenv_path=\"../.env\")\n",
+    "VLLM_KEY = os.getenv(\"VLLM_API_KEY\")\n",
+    "VLLM_BASE = os.getenv(\"VLLM_BASE_URL\", \"http://192.168.0.47:5002/v1\")  # adresse LAN du vLLM du dépôt (cf 10_LocalLlama)\n",
+    "\n",
+    "\n",
+    "def vllm_alive():\n",
+    "    try:\n",
+    "        r = _rq.get(f\"{VLLM_BASE}/models\", headers={\"Authorization\": f\"Bearer {VLLM_KEY}\"},\n",
+    "                    timeout=8)\n",
+    "        if r.status_code == 200:\n",
+    "            return r.json()[\"data\"][0][\"id\"]\n",
+    "        return None   # vivant mais clé refusée (401)\n",
+    "    except Exception:\n",
+    "        return None   # injoignable\n",
+    "\n",
+    "MODEL_ID = vllm_alive()\n",
+    "if MODEL_ID is None:\n",
+    "    print(\"[RECOVERABLE-MACHINE] vLLM self-hosted injoignable ou clé refusée sur\", VLLM_BASE)\n",
+    "    print(\"  -> la mesure RÉELLE exige la lane GenAI (po-2023) avec le vLLM du dépôt actif.\")\n",
+    "    print(\"  -> AUCUNE valeur de substitution affichée (Stop & Repair, cf sota-not-workaround).\")\n",
+    "else:\n",
+    "    print(\"vLLM joignable, modèle servi :\", MODEL_ID)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "91533bcc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:36.937325Z",
+     "iopub.status.busy": "2026-08-25T21:47:36.936858Z",
+     "iopub.status.idle": "2026-08-25T21:47:47.606801Z",
+     "shell.execute_reply": "2026-08-25T21:47:47.606144Z"
+    },
+    "papermill": {
+     "duration": 10.676209,
+     "end_time": "2026-08-25T21:47:47.608074",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:36.931865",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "prompt ~  250 tok | TTFT médiane   0.09 s (min 0.08 / max 0.09, 3 requêtes) | ITL moyenne   8.0 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "prompt ~ 8000 tok | TTFT médiane   0.28 s (min 0.27 / max 0.28, 3 requêtes) | ITL moyenne   8.8 ms\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "prompt ~32000 tok | TTFT médiane   0.37 s (min 0.36 / max 2.61, 3 requêtes) | ITL moyenne  11.6 ms\n",
+      "\n",
+      "Mesures RÉELLES en streaming sur le vLLM self-hosted du dépôt.\n",
+      "TTFT = premier jeton servi (médiane de 3 requêtes) ; ITL = cadence\n",
+      "inter-jetons moyenne (robuste aux salves réseau).\n"
+     ]
+    }
+   ],
+   "source": [
+    "FILLER = (\"Le système d'information d'une assurance s'appuie sur des modèles de \"\n",
+    "          \"tarification qui segmentent le portefeuille par classes de risque observées. \")\n",
+    "QUESTION = \"\\n\\nQuestion : résume ce texte en une seule phrase technique, sans liste.\"\n",
+    "\n",
+    "\n",
+    "def build_prompt(n_tokens_target):\n",
+    "    n_words = max(30, int(n_tokens_target / 1.45))   # ~1.45 mot/token en français\n",
+    "    reps = max(1, n_words // len(FILLER.split()))\n",
+    "    return FILLER * reps + QUESTION\n",
+    "\n",
+    "\n",
+    "def measure_ttft_itl(n_tokens_target, max_tokens=64):\n",
+    "    \"\"\"Une requête STREAMING : renvoie (ttft_s, itl_moyenne_s, itl_mediane_s, n_fragments).\n",
+    "\n",
+    "    On ne comptabilise que les fragments SSE qui PORTENT un jeton (delta non vide,\n",
+    "    contenu ou raisonnement) : les fragments de rôle/fin ne mesurent rien.\n",
+    "    TTFT = arrivée du premier jeton servi. ITL moyenne = (t_dernier - t_premier) /\n",
+    "    (n - 1), robuste aux salves réseau (plusieurs fragments arrivant dans le même\n",
+    "    paquet TCP, qui écraseraient une médiane d'intervalles vers 0).\"\"\"\n",
+    "    payload = {\n",
+    "        \"model\": MODEL_ID,\n",
+    "        \"messages\": [{\"role\": \"user\", \"content\": build_prompt(n_tokens_target)}],\n",
+    "        \"max_tokens\": max_tokens,\n",
+    "        \"temperature\": 0.0,\n",
+    "        \"stream\": True,\n",
+    "    }\n",
+    "    t_start = time.perf_counter()\n",
+    "    stamps = []\n",
+    "    with _rq.post(f\"{VLLM_BASE}/chat/completions\", json=payload, stream=True, timeout=180,\n",
+    "                  headers={\"Authorization\": f\"Bearer {VLLM_KEY}\"}) as r:\n",
+    "        r.raise_for_status()\n",
+    "        for line in r.iter_lines(decode_unicode=True):\n",
+    "            if not (line and line.startswith(\"data:\")) or \"[DONE]\" in line:\n",
+    "                continue\n",
+    "            try:\n",
+    "                obj = json.loads(line[5:].strip())\n",
+    "            except Exception:\n",
+    "                continue\n",
+    "            delta = obj.get(\"choices\", [{}])[0].get(\"delta\", {})\n",
+    "            # ce vLLM emet le raisonnement sous delta.reasoning ; d'autres builds\n",
+    "            # OpenAI-compatibles utilisent delta.reasoning_content — on prend les deux\n",
+    "            if delta.get(\"content\") or delta.get(\"reasoning\") or delta.get(\"reasoning_content\"):\n",
+    "                stamps.append(time.perf_counter() - t_start)\n",
+    "    ttft = stamps[0]\n",
+    "    itls = [b - a for a, b in zip(stamps, stamps[1:])]\n",
+    "    itl_mean = (stamps[-1] - stamps[0]) / (len(stamps) - 1)\n",
+    "    itl_med = sorted(itls)[len(itls) // 2] if itls else float(\"nan\")\n",
+    "    return ttft, itl_mean, itl_med, len(stamps)\n",
+    "\n",
+    "\n",
+    "if MODEL_ID is not None:\n",
+    "    measure_ttft_itl(64)   # échauffement : première requête jetée (chemin froid)\n",
+    "    PROMPT_TOKENS = [250, 8000, 32000]\n",
+    "    N_REPEATS = 3\n",
+    "    vllm_rows = []\n",
+    "    for pt in PROMPT_TOKENS:\n",
+    "        runs = [measure_ttft_itl(pt) for _ in range(N_REPEATS)]\n",
+    "        ttfts = sorted(r[0] for r in runs)\n",
+    "        ttft_med = ttfts[N_REPEATS // 2]                       # médiane : robuste au bruit\n",
+    "        itl_mean = sum(r[1] for r in runs) / N_REPEATS\n",
+    "        vllm_rows.append((pt, ttft_med, itl_mean))\n",
+    "        print(f\"prompt ~{pt:5d} tok | TTFT médiane {ttft_med:6.2f} s \"\n",
+    "              f\"(min {ttfts[0]:.2f} / max {ttfts[-1]:.2f}, {N_REPEATS} requêtes) \"\n",
+    "              f\"| ITL moyenne {itl_mean * 1000:5.1f} ms\")\n",
+    "\n",
+    "    print()\n",
+    "    print(\"Mesures RÉELLES en streaming sur le vLLM self-hosted du dépôt.\")\n",
+    "    print(\"TTFT = premier jeton servi (médiane de 3 requêtes) ; ITL = cadence\")\n",
+    "    print(\"inter-jetons moyenne (robuste aux salves réseau).\")\n",
+    "else:\n",
+    "    vllm_rows = []\n",
+    "    print(\"(passe : service injoignable, verdict [RECOVERABLE-MACHINE] affiché plus haut)\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "bd4a1412",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:47.614643Z",
+     "iopub.status.busy": "2026-08-25T21:47:47.614469Z",
+     "iopub.status.idle": "2026-08-25T21:47:47.767866Z",
+     "shell.execute_reply": "2026-08-25T21:47:47.767228Z"
+    },
+    "papermill": {
+     "duration": 0.157654,
+     "end_time": "2026-08-25T21:47:47.768723",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:47.611069",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABA8AAAGxCAYAAAANuJ95AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAxhpJREFUeJzs3Qd4U1UbB/C3e1Jmy957770FwS2CAg5AUByILAVB9lBAkSEyHB/DgYKKuHGg7D1l7z3asrp38z3/gzemIUnTNu1tkv/veQK9GTfn3CT3nvve95zjYTAYDEJEREREREREZIWntQeIiIiIiIiIiIDBAyIiIiIiIiKyicEDIiIiIiIiIrKJwQMiIiIiIiIisonBAyIiIiIiIiKyicEDIiIiIiIiIrKJwQMiIiIiIiIisonBAyIiIiIiIiKyicEDIiIiIqJ8aP78+fLZZ5/pXQwiIoXBAyJyWcuWLRMPDw85d+5chvvfffddqVSpknh5eUmDBg2svh6vHTx4sLiKChUqyLPPPqt3MUhn+fF7je/mQw89lKN1XLx4Ufz9/WXLli0OKxe5rg4dOqhbfg8cTJkyRVq0aOGw/f769evVPgD/54bevXtLz549c2XdRKQ/Bg+I3NSkSZNUA+L69etWn6M1Mr755hub68JzcHv++ectPj527Fjjc2y9X174/fffZdSoUdK6dWtZunSpvP3225Kf/PLLL+qzIf1duXJFnnnmGalevboUKFBAChUqJM2aNZPly5eLwWCwez179+6VRx55RIoUKSKBgYFSp04def/99+167fDhw6VRo0bG19asWVN9P2JjYy3+Vi3dtm/fLno4fPiwPPHEEypQh7IXK1ZM2rVrJz/++GOuvB9Ospo3b65+25R7tm7dqr6Dt2/f1rsoLm3Xrl0yYcIE9XupWrWqOIs33nhDvv32Wzlw4IDeRSGiXOCdGyslIveDK35oMCxcuFB8fX0zPPbll1+qxxMTE0Vvf/31l3h6esr//ve/u8qZX4IHCxYsYAAhH0Cg69KlS/L4449LuXLlJCUlRf744w91Fe/48eN2BZ4QrHr44YelYcOGMn78eAkODpbTp0+r9dp7AtG2bVvp37+/+g3t27dPZsyYIX/++ads3LhRfZdNDRkyRJo2bZrhvipVqogezp8/LzExMdKvXz8pVaqUxMfHq30EAikffvihvPDCCw57r8jISBXUwY1yP3gwefJk9TtAQM1Z4beZnyH4ht9LTrIO9IB9XZMmTeS9996TTz/9VO/iEJGDMXhARA5x3333yQ8//CC//vqrPProoxkammfPnpUePXqohpDeIiIiJCAgIF8GDih/qVev3l2pvUj3RzAAmQNTp05VXV+siY6Olr59+8qDDz6osnfMT/TtsXnz5rvuq1y5srz++uuyc+fOu04sEGhAsCM/eOCBB9TNfPs1btxYZs+e7dDgweeffy7e3t7qs3FF6enpkpycrAJIziQ/lzs/HQMsbSdn7mKGbgsTJ05UFxMQMCUi18FuC0QuBCcoSFPesGHDXY/hSh8eO3ToUK68d+nSpVVK8ooVKzLc/8UXX0jdunVVqrY9cKVy2LBhqp+mn5+fhIWFyb333qtSv03t2LFDBSwKFiyoUqLbt2+faV9n1B9dFeLi4owp3RgXITNr1qxR5Ud5ateuLWvXrr3rObgifP/990tISIhqLHXq1OmudHFcucYVO6SgopFYtGhRadOmjbqarTUWkXWglVW7mTYw586dq8qA1xcvXlxefPFFuXXrVob3QUr9tGnTpEyZMmrbdOzYUV3F0huutnfr1k2CgoLU54qU/N9++y1D/1uclOOE3DQlGlew8JwRI0YY70tLS1NdCZAim9Xto/Wvx4k5uiHguUitt/cqGV6Pq+ho7NuC30J4eLi89dZbKnCA7x3KmFN4f7CWNo7fUGpqaqbrwW8TXTJQf5zQI5PBHv/884/6rmKb4bUlSpSQAQMGyI0bNzJ9LT7bsmXLWi07rgZjHBKst1atWrJ69Wq7yoTfKLosmJ+ooE87frsoM/YR+D0gE0PrioV9JV6HgCK2BTI6zF2+fFnVD98nbR+wZMkSi/3T8Rjeo3Dhwurqq+n+ENtM++wsdSGzNC4FPiOsE++r7XccVR5rbL0OZR05cqT6u2LFisZ9lDauTE7Ljd8UUvXxfcS+HfsKBMT+/vvvDM/D++G9Zs2apfaZWteYLl26qLEvsA9EcA/7QHy2CGjfvHnT5pgHWtefVatWqd8sXovvIfblp06dums7ae+L9WM/smnTJrvHUXDE55uUlKRO0PF9xvPwu0KXPNyfHfYcU+09PuM+7O+0YxsRuQ5mHhC5EFzhROMZjR8c+E2tXLlSNULsPYnPjqeeekqGDh2q+mOjHDiB+frrr9VJn71dFl566SXVsEfDCicPOCHBSd7Ro0dV32+t6wFO1NHAROMJJ2YICtxzzz2qAYeGnCUYsfqjjz5SV2w/+eQTdV+rVq1slgfvjROYQYMGqZNVnNwii+LChQvq5B9wYo4GLgIHaLz5+PioYA0akdrJidbwnj59uhobAmXElendu3erhhcaWzjRRT97NLgsja6NxxHsQAo70tOR0fHBBx+owAUaeXhfQOMbwQPtyi/Wj0Z1Zie7uSkhIUE1wrHdUHaksaOO+CxNYTviBBvbXRtAD58pPmP8r0Gd8T1DwCqr2wdwMoAr9M8995xKq0fjHCd3+E7hd2JedjSE8X74PPFda9mypTppsAUnovhO4GQAQZMTJ06ok6E+ffrInDlz7L4ai98RTrbx+SH4N27cOPVdtPQ9R91RTpykY1ticFCc/JlDPbBPwHbCSQCuEOLEAb+NzPYR+H6eOXNGvRcCB/j+43eF/xEwMz8RxrbDNoyKijJmJ/Xq1euu9Z48eVLdj30APhNsZ4yZgJMq/D6sQVAO3Ttefvlli48jeITvEgZyw/oWLVqk/saJG06E8H7Yd2Fb4TuBk09sX0DwB9kd2sleaGioKj++N/j94vXw8ccfq22J12MfiP0dAhY4IcO6swO/DezL8b4YLwInbLldnsxe1717d/U9Rlc0fIdRLkA5HFFu/I1985NPPikDBw5UJ6voYta1a1f13TQf4BafIX4Xr776qgoOvPPOO+qqN44FCAYguIjfOgIiyNaxdBJuDt2CsL/B8/GdxTqffvpptQ00+A6hHviNIQiKYAZ+4wi2IOiQ258v9pHo/oP9JDJ4MBbKwYMH1WeCzwfBtKyw95hqz/EZ8Bj2j9jvPvbYY1kqCxHlcwYicilPPvmkISwszJCammq87+rVqwZPT0/DlClTjPdNnDgRI74ZIiMjra7r77//Vs/5+uuvbb4nnvPKK68Ybt68afD19TV89tln6v6ff/7Z4OHhYTh37pxd7wcFCxZU67ImPT3dULVqVUPXrl3V35r4+HhDxYoVDffee6/xvqVLl6r3PHv2rPG+fv36GYKCgmyWwbReqM+pU6eM9x04cEDdP3/+fON93bp1U887ffq08b4rV64YChQoYGjXrp3xvvr16xsefPBBm++JulvaNW/atEnd/8UXX2S4f+3atRnuj4iIUGXB+5hunzfffFM9D/XXw9y5c9X7r1q1ynhfXFycoUqVKup+fNcgLS3NEBISYhg1apRaRh2KFi1qeOKJJwxeXl6GmJgYdf/s2bPVd/rWrVtZ2j5Qvnx5dd/GjRuN92G7+fn5GV577bW7yj59+nT1fO3WqVMnw4ULFzKtc7169QyBgYHq9uqrrxq+/fZb9T/W0bt3b7u33bZt2zK8f/Xq1Y3bS7NlyxZDjx49DP/73/8M33//vSoztpu/v79h7969GZ6rrWf37t3G+86fP6+e+9hjj2VaHvzWzH355Zd3bVPNiy++aHxPfGaPP/642leY0j4TbCNNVFSUoWTJkoaGDRvaLA9+n+a/SU379u3VYytWrDDed+zYMWNZtm/fbrz/t99+U/djv6F57rnnVBmuX7+eYb34/LCv0rbFo48+aqhdu7bNcuK3h3qa0/aNprTyHT58OMP9jiyPJfa87t13371rv+qocuO4lZSUlOE5+I0XL17cMGDAAON9eG+8V2hoqOH27dvG+8eMGaPux742JSUlw3ER+8XExMQM3w3czI93NWvWzFCGefPmqfsPHjyolvEYfltNmzbN8B7Lli1TzzNdpzU53U44xuL12O+ZWrx4sVo39gcafOdM9/taPbV9SFaOqZkdn01Vq1bNcP/999v1XCJyHuy2QORicOUO/fpN+2rjSgGuVFi62udIuOqCq5e4KgVIdcWV/fLly9u9DgzAhSs8uAJvyf79+9UVSlwFw1UPDGqHG65u4so2Uq8dkRqu6dy5s+pjbtoPHleTceVVS59HqjWuOiGFVVOyZElVRlyVwRUjrW64OovyZxUyOJBOiiuwWp1xw5UiZHloab242q1diTO9AqxdsdJzIEhsE9P++EiNNe/3jite+M5oKfS4ooXPefTo0SoVedu2bep+XA3DFXJtwDZ7t4/plTFcNdTgCh/S1rXP1RSuguJqO77P2lVbXEnPDDIA0L0B4x4gYwVXbfE/MiS++uoru78HKCveH1cTkdmC7AXz2RawzfA7R7ozrkhie2lZAGPGjLlrncicwLbRYEBIpHajGwm+07aYZlzgyjS2szb2gnn6svbdQ/kxmCGubmL9lrJgkI1iepUSvzNsO2SOXLt2zWp5tO4S2P9Ygs8fmQYafM743uBqrZYVBNrf2ncA3zeM04JxFPC36fcKV8JxVVqrL9aHbjnIgHAUZI/hs9fkRXkcUY+clBsZM9pYBNiPI5sAmTfInrH03UImCX735p8hZknBGBim9+M7hyygzCCjxnQ8BG0/oX0vkC2G7xwyI0zfA9kJ1r6Djt5O2N/h+1ujRo0Mz0OmAJjv72zJyjE1s+OzKWwLvWdXIiLHY7cFIhej9VlESjIO/IC/ke5ZrVq1XH9/NECQlo30dJzsIOUzK/B8pCyj/yZObpB2jxMI7cRcO+HCc6xBI8veRhyea3oiiEYjpsUzPakyh3Vr/egxyjtOEHFCYg6NOzS6kAaNVHhMJYcTNHwOOPHFZ4VthYBEZlBvlBV9TC1BwEgb4R7Mp/bCybE92wT1yezk0Rq8h7UBBFEu9M01T2m3tN3QWEcXD3wuCBIg6ICU2Pr166tlBAgQlDGdS9ze7WPv52oKwS8tAIZAAgIeCCphxgVbXRe0x/Aa898IurUgEILPCSdIpifTeJ3pCRFOovF+gO8Pghj4HycS2CbWYHvjeeh2g8/U9LOxNPUbvpf4LuM7gN+AeR9x7fPF/Ri7AwEQ8+2Kz8AcTnBwA/yW0YUGJ0g4CTH9Plj6fmj7LKSFo4uELdamz0Qaufl6sX2xjzG/D0x/2+gugi4ZuFmi1R/p8QjcIb0b9UAd8TnnZNpIjClgKi/K44h65KTcgCATxjk5duyY6pJibb2WfsfaZ5jZZ2uL+Tq1/ab2Wm0faz6LCQIJlsa0yI3thP0dAqum3UUsPc8eWTmmZnZ8Nv89mv/uiMj5MXhA5GLQfxlXwb/77jvVjxl9KNHv0J5p5RwBVz1RBjQwMHCT6QmePfB8nDyi/Liij37IM2fOVCdAuGqpXQHB/eb9XzVZGd0Z/XpNp3fD1SDTrA1rJ8PWTlRsQf98TNP3/fffq7qhby/6qC5evFiNg2AL6o0TY/TxtcRaIzKrMM2f1jjOKowxkJXGszUYRBInDTi5RrBAu/KH/7GMkwo0tE0zB7K6fXLyuSJ7An3DcUUOVwStwZV0ZJpg4DNTWoBDOxlBRoLpIKf47dgayBPPR9AJJ++2ggeARj4CE7iKiCCEvTBLCgbatPT54jeKxzFwHn6D+L1h+yMYZk/WD7Yfsi/QN9tS8CirtLFHrJ0YWvusM/sOaHXBVWxrJ1Za4A+BQgSTfvrpJzVGgzZtLcYfQaAFrJ1IWQvWmQemHF0eS7L7OkeVG7NmYOwRHMPw/cJvBZ8TxorBvtNRn60tjtzn59Z2wnMxEDFmLbHEPHhiS1aOqZkdn03h92gpSElEzo3BAyIXhO4JOCFet26dujqBRk9ud1kwbRCh4YdGIBoT2oBaWYErzRigEDdcQcFVZ4x+jfVpXQhMr8bmBNLA0VjTZCXtVDspRfo9GtzmcJKLNHzThhyu6CItVhvYDgEFXGXXggfWTjBQb1wRxBVAW1e7tSvkuJpkejUIJ9v2XHXDybc9KfmW2LoyjHJhsD/zq1GWthuueiIDBIEC3LTR3bGtcNKO77W2nNXt4wja9rF0ld0UrswhXR+p0qYnyVrKrxbQwFVW088GQQdbEJRDgz+z99dSrTEwo3lAzVKXCZzM47uMciEAaD5SOj5flBPbHyeSOKG0tb6sbj8MbGf+/UCZwFZQCleK8ZkjuOFI2A4YOBEn9/bsa9CdBPtZ3BCwQZAH+y10G8FngH2LpVkm7A3WObo82X1dVq8mZ6Xc6HqD/RZORk3fB4P45RfaPhbfV9MAG7pXIEPGnkyynG4n7O8OHDigsgtzenU/q8dUW8dn022BjDtcTCAi18IxD4hcEBoAOElFdwXccDJmKeUzt2CUajT2xo8fn6XXodFkfkKBK084mdKmn8IJGRo7mKLLvN+3dpKcFehziu2l3Uz7gdsDV6mQ2otsAm26MkDGB9LLcRVdu+JrPpUdTuiQ+mo6tRYa7mB+koErPtg+mH7M2mj8gDpgVgGMLm56pQxTGNoDJ9+m2yMrN1snJEhvxUmzNkUeIEXeUnou1oMMCIydge4vppkHOPHEuAH4DqARm9XtkxXWvksY/R0NdtPRxdG3F8Ei1Mm0TNrzTSHjBCnO2pRu+M6ZbketHzTKbJq2bfp6MJ1FwVJZcXKB2Q3w/UQQyxSyOkz7kKOhj+8wnovvNE50LX2+2lVZ86uwlr5fllKnUR9MiYmTfdP+3oDvB65oajBWCJ6Lq6G2AlP4vmNboC+6I6GumFkFV98tTXFrus3Nf9sIfqF+2E7aZ4jvLPZvmL1Ac/Xq1Qx1zsvyWGLP66ztoxxRbkvfL3Rv0cY6yQ/wXUO2CwKZplOiIvBqT4DWEdsJ+xYEJVEGc9rsMPay95hqz/FZc+TIETUeSmazGRGR82HmAZELQmMaV4uQ1oxGBBoF1iDtEVcbTeFE48033zQuozGDEyNzWt9Hc0ilziyd2hJMy4X+yUhrxutxco2ryRi8C1dntbLh5AlXOTCOAK7gly5dWjWkMEgUTtR//PFHyUuYFhFXaREowNUYnBiiTzsaVKZjPqARjhNGNNYQ3MHJjjbtlUYLXmC6NKTEo0GJwd7QnQKp3kjfxQBXOMnD54wrvhg8a968eWq74eoVgjd4Hqanw0k7BpzDdF/ZyQJxFAwuhmkT0T92z5496sQfUzWaf/c0CBRgyjT0VUZ6rtZQxRV8ZCsgtdmUvdsnK3A1DV1+kI6Pq9vo64/fAr6PGJDStM8z6oar8fgOakGBhg0bqgEMMT0cTjK0LjEoD67iZpZhgOdq0+Yh/RdXgZGJgauyOIExzZjBVWKckKOxju2ExjsCM9i+2I7mMOYGvl+mUzVCZqnp+H0h4wPfa5xM4reH9GVLV/3xeSAAgOfjeRj0ECdY2Jfg92yeDYHxDTAlHbYvunpguyEIhynjMoOxHcaOHaveLyvdMzKDbYfPFAPu4TuM3zC+Bwi8YN+kjQuB7xsCHAi+oezI+MJ3AtPnatM+4neMMQUwKCS2OwJNmPIP9bY0GGBul8cSe16n7aOwvVEn/M4whoUWVMhJubHPwvcb2wjvie8VunXh+ZZObPWAgAqyxbAPwACFOJFH4BhdjXASnpNMAHu3E7otYZpHTJ2I5+Pzwsk9flu4HwOfWpqi1RJ7j6n2HJ81OB5i32NrilUiclJ6T/dARLnjjz/+UNMxYarEixcvWp0ezNINU+KZTulk7aZNE6VN1WiLPVM1YgqskSNHqmm2MM0hplTE3wsXLrzrufv27TN0795dTZmFKfYwHVXPnj0N69atc+hUjZbqZT71FWA6PEx1FRwcrKbm69ixo2Hr1q0ZnjNt2jRDs2bNDIUKFTIEBAQYatSoYXjrrbcMycnJxudgqjJM54cpyPDZme+mP/roI0Pjxo3V67GN6tatq6Y1xNSQGkx3OHnyZDXlF57XoUMHw6FDhyyWOy9hOsBHHnlEbZ9ixYoZhg4dapxK0XzqQUzzifvNp/p6/vnn1f2YktASe7YPtoOlKTPNp277/fffDQ899JChVKlSBh8fH7W+1q1bq++V6ZRmpt9v83rgs500aZJ6T6wDU1POmTPHru2FKQj79u1rqFSpkqoPplLENHp4r9jY2AzPxXRy+G4VKVLE4O3trT77Z555xnDy5Emr3+vPP/9cTdGG3w+mQzQvuzWXLl1SUzrie4yp2zCNJrYv1ouymU7f2LlzZzXNHspUuHBhtYypJM1pnwmmS8QUlygTfh+ZTROrCQ8PV++hTROrwedpaepBa98BS795rBv3lS1bVn2GJUqUUNN14rum+fDDD9W0rNr+qHLlympfhukmTeE7VadOHTVtIKbcxGdgbapGa/tUR5bHnL2vmzp1qqF06dJqukDTfWxOy43f1dtvv60+H+17+dNPP901zaU2VSOmjbRnemHtWLBr165Mp2o0f632XqZTeML7779vLCd+e5geEfue++67z+Y2dsR20vYtM2fOVN9vlAG/L7w/9v2mn1dmUzXae0zNyvG5efPmav9DRK7HA//oHcAgIiL3hKvr6DdsesWeKDuQtYAxEpCdQZTXMA4JMr+Q9WepO4G7QOYXunQhW8LaAIxE5Lw45gERERE5PYyzghRqdDUhyk3oz29+7Q3jc6BbgbsHQdH1Al0bGDggck0c84CIiIicHsalwEkdUW7bvn27DB8+XJ544gk1eCKusmNgVIwlgvvcGcZaIiLXxeABEREREZGdMHUoBgvGzC/INsAAuBgMFlfdMaAiEZGr4pgHRERERERERGQTxzwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiIiIiIiIimxg8ICIiIiIiIiKbGDwgIiIiIiIiIpsYPCAiojyVlJQkb7/9tmzdulXvohARkZP4+++/5d1335XU1FS9i0Lkthg8ICKiPDV48GD566+/pHHjxnoXhYiInMDRo0fl8ccflzp16oi3t7fexSFyWwweEBHlgnXr1slbb70lKSkpehclX7ly5YqUL19e1qxZI35+fnoXh4iInMC+ffvk888/l/vvv1/vohC5NQYPKEueffZZqVChgrgLpMaNGjVKypYtK56entKtWzd1v4eHh0yaNEmcGT7Hhx56SJyNM3wHw8PDpVevXrJ8+XKZOnVqrr3PuXPn1Hdx2bJl4ixKlSol48aNk+DgYL2LQkS5CPsmZBnlBx06dFA3sh/aOPgM84unnnqKgQNyWcuWLVO/t927d0t+x+ABqS+rPbf169dLfrRixQqZO3durqx7yZIlqn8dUuVwIjh8+PBceZ+FCxdm6QQQfcVxYL99+3aulIdy5uWXX5bnn39eZR989NFH6opJTj/zvIIGtunvvkiRItK0aVP1W0hPT88QxDF9HrIIqlWrJhMmTJDExMS71mtr3/LSSy9ZXa/pbe3atRmCJrNmzTK+Dvsn3PfNN984zQkNuY+cNAzj4+PV/j4vj8G//PKL0wfIHUGPbe/qvwHt5u/vr4LJXbt2lffff19iYmKsBjCs3a5du5bh+dHR0TJ58mSpX7++ClAHBASobg5vvPGGynoz99NPP8l9990nRYsWVeXBMez111+XGzdu3PVc82MT1l+pUiXVPvz2228zHB/Noa2G9eN16H5hDdbx6aefyr333ivFihUTHx8fCQsLky5duqi2BMYLys5x1VWgfYLP0xzaWoGBgdKoUSPZu3evqj8uUlhz8uRJ9ZwRI0bkcoldEzsNkXz22WcZlrHj+uOPP+66v2bNmvLxxx/b3EHqFTw4dOiQDBs2zOHrRr/s0qVLy5w5czLcn5CQ4NA+dziRxIECByd7gwc4QOL5hQoVclg5yDFZB82bN5fXXntNfUdWrVqlDlQNGzbM0Weel8qUKSPTp09Xf0dGRqp9wnPPPScnTpyQGTNmGJ+HgMEnn3yi/o6KipLvv/9eZVqcPn1avvjii7vWiwZR375977ofDTZTpus1hQYhkTuewGJ/D3l19RzBgwULFrh9AEGPbe/qpkyZIhUrVlRd+nDyj8AM2m+zZ8+WH374QerVq3fXaxYtWmQxW820/XPmzBnp3LmzXLhwQZ544gl54YUXxNfXV/755x/53//+J9999506hmkQJHjvvffUcQXBBQTKceL5wQcfyFdffaVOSKtXr2712IR24Pnz5+XHH39UAQR8P3AMDAkJuaucX3/9tTpZLVGihDo2Tps27a7nYH2PPfaY/Pbbb9KqVStVvuLFi8vNmzdlw4YNMmjQINmxY4eqS3aOq64K7fSHH35YfVZ//vmn+hxr1KghX375pcXtrJ03wDPPPJPHpXUNDB7QXT+e7du3q+ABf1QiERERFk/OEUHOTFxcnAQFBeVSySi/wsEeDRFNu3btxNkULFgww+//xRdfVAdmNKoQHMDVEEBwxPR5aNyg0YODNhqC2BbmjRl79ivm6yUix+MxivSArgdNmjQxLo8ZM0adAKIb5SOPPKKuzCNjwBROzhFst9XFtHv37ip4j2BEmzZtMjyO8YdmzpxpXMYxCoEDdC/EybyXl5fxMQT0O3bsqAIQCCaYXiiydGzCCSqC6qjHwIEDZeXKlXeVD2M1PPDAA2q8H5y4WjqpRWYrAgfIpB06dGiGx3AxAhch0DY3Z+9x1RUhqILAAbaBFjiAp59+WsaPH6/OZ1q0aHHX6/D5I8CATAXKOnZboBz1NzdNH8ZVCqRwIXUIKVYXL14Ug8GgTjZwJRMHg0cffVRFUc39+uuv0rZtW9WQKVCggDz44INy+PDhTMuDSO/PP/+sor9aqpZp+XDyjyumOInBCT8izOh+kBmtXpgWCOUw77phPuaBllp35MgR1S+vcOHCxoMXIuv9+/dX2wBR65IlS6rtgPcAlBfvgZ2g9j62rnDgvUaOHKn+RvRee422PhxEsc0rV66s3g/rf/PNN+9Kd7ME2wYHR239gEg30vpwQonPtn379rJly5a7yoQynDp1ypgNgeej3rhykxk859ixY3L9+nXJDmTD4IBbu3Zt9Tnj88YJ761bt+x6Pd67Z8+eEhoaqr6nOFEeO3Zshueg6wEaPbiqgCsgnTp1Ugcme/qIauma2f3MtbRHbFtsV2zffv36Wey2Yq1vb07GisDnjgMwTjaQiWAN6oHvPX73uApERNbhN4l9yeXLl9V4Ovgb+yBccUxLS1PPwT4D9wGugGv7C9PjD/ZfOLlCwxn7P5yY4QqupX2QdgUTqdA4JlkrF47nYJoGrcF+ACczGAsIxxjsL9EGwO8+MzhpwvhB8+fPz9Lx355tlRXJycmqixVmfME+Fe+NMuCYr3H0tsdxE2nSWCfeD1eZLe1PsT1wnMW2wPEG3ca0K6UTJ05UwVtLr8OVdhwbLHUb0+BqP8p89epVyS6cCGO74ViJevfu3Vu193LinnvuUSd7aMth/VmFbgMHDhxQx23zwAFgOyKAoMHniXYaugKYBg6gWbNm6gLAwYMHM+0Gpxk9erRq9yLDwDS7AZAJsWnTJrWdcDt79uxd0xRj+yGjAW0t88CBpmrVquq36yjY1lgffr/4LNF1AwETrZ0C6GaF766ldjMCHXgMXT80+H0OGDBAtcGwb0CbDF0ezeE7it8RTvrxu0G7GMEfZC3aC9sU+4oqVaqowAHKr0HwALTfjak9e/bI8ePHjc+xBe1fBH3wXcFvFlkx8+bNMz6OrBbsm3Dug3ogswT1t9TtBdsG5yPoqoNtg/Y7urhiX2QKbXV79xPZOW9yBGYekEMgcosfwKuvvqqCA++88446GcMBASfc2BHjxBINBhzsTXcm6B6BEyH0e0NkGCeSSFHDAQAnbLZOeHCgQLr0pUuXjF0LtNQ2pIDhJArviz7O+KFix44fOk66rO2gAT9alAsHm9jYWGMKN7pu2IIdL3bwmMNea0j16NFD/aCxbVAXBDQQPcYBBcs46cVjKLd2wmp+xdYUdrA4OCFyijpr0XitkYO+9tjRo0GDBh52fig/ovlI27MGB1H0kUOgQYuK42oATpjRUECjBY2+pUuXqs8VO24cZE3hM8d2xvshYo+DIRqpphF/S3bu3Kki/XiP7KTJIlCABhqCFUOGDFEHZ1wlx/cHDTbtSrkl2PljB4znoPGFzwQHMKQiao0NfH54DhogGEATz/3www/V9wuNcXRTyIqsfub4LiHgtHnzZvUZ4XuIzxK/m7yCYAAaWZl1k9EaHjjYWmowWAoQYbsivdSU+fOwzdHIJ3IlOPHFsQ/7EJyAoxGMK6II/qJhif06jof4G41I7P9BS+3Gvql169aqex1OYNCQRFcpnGDjhAqvMYWTBawTJ84IAljbn6J/uKXui9gX4eowTrLREG7QoIE6iUDAGY1j8y5+ptAHGcdG7DtxhTarx//MtlVWoG88jk9PPvmkKgv62yMdHOvH8Qj1cvS2xz4f+0Uc57CfxHEAbRPTK9U4juHkAydduJKN/S22A8Z7wYWJPn36qLR/vMZ07Ba0v3Cii/aGrcxIfEY4fmCbZ2fMHRwTcZKPYz3aGjipQbsOGXYoZ066UaJuaH/8/vvvxu+HxtJFJ1zo0N5PC9hgHZnBFXycPKItaKmLAaAbAD4nnBjjhN/e8qPs+N2YdhlAWw3fDWRW4CQd31e0mZGlZ3oiiO93djIIsnJcNbVr1y4VxED9EEjEdxLfd7RrcCEMFw0QDMOJMb7X5u0NfAfxfcZvBpD1gYsM2rhC+P2gXthP4PemdS1GPbEt0C0E7422OH5/2G7ogoztkxm063BSj/Ym1mOelYL7sX1RbuyTTANEWkABvydbUB6UE4ENlBGBAbSjf/rpJ+P5A56DthHanngc+wS0pfE/Li5pQVfsT9FexrkH2pnIesBvEb9Z7PNMPyd79hM5OW9yCAORmVdeeQVnvRYf69evn6F8+fLG5bNnz6rnhoaGGm7fvm28f8yYMer++vXrG1JSUoz3P/nkkwZfX19DYmKiWo6JiTEUKlTIMHDgwAzvc+3aNUPBggXvut+SBx98MEOZNHPnzlVl+Pzzz433JScnG1q2bGkIDg42REdHZ7ru9u3bG2rXrn3X/VjvxIkTjcv4G/ehfqZu3bql7n/33Xdtvg/eA+9lL6wP68X2N7V//351//PPP5/h/tdff13d/9dffxnvwzbDtoN58+YZPDw8DFOnTjU+np6ebqhataqha9eu6m9NfHy8oWLFioZ77733rvoPGDAgw/s+9thjhqJFi2Zan7///vuubWqN+Xdw06ZN6rVffPFFhuetXbvW4v3m2rVrZyhQoIDh/PnzGe43rXO3bt3U9/b06dPG+65cuaJeh9ebbwdzS5cuvevzyspnvmbNGvX6d955x3hfamqqoW3btup+rF+DdVpar/l2swavrVGjhiEyMlLdjh49ahgyZIh6n4cffjjD+oKCgozPO3XqlGHWrFnqe1SnTp0M2w/wemu3L7/8MsN6LT3HtE7afsf0d6V9h77++mub9cNzsI8jykvaPmDXrl13fdenTJmS4bkNGzY0NG7c2LiM35e1/WOnTp0MdevWNR5TAb+9Vq1aqf23+fu3adNG7Tuy2w7Q9kXTpk3LcP/jjz+ufvvYD1j6rb322msGT09Pw7Jly4yPZ+X4b++2ssZ8v4htkJSUdNfxunjx4hmOY47c9p07d86wXxw+fLjBy8vL2HbC/zimNG/e3JCQkJDhvUxfhzYMnmNq9erV6j2wH7RF23die2bG/Hh27tw5Vd633norw/MOHjxo8Pb2vut+e34D5vC54zM1L4OlW/Xq1Y3Pw2vwWnto3+E5c+bYfF5ISIihUaNGdx3zrNm3b59aLz5XU/iOPP3008blN99801CsWLEMbWO8Bq9FG84UvqPaMRa369evZ+u4agnacua2bdumXvvpp59maM/7+PgYbt68maFc+O2a/laee+45Q8mSJe8qY+/evdVno73fkiVL1HvMnj37rvc3bzeYw2+4SJEi6neCNlRERITV5y5YsEC9z2+//Wa8Ly0tzVC6dGn1G7IF+we0c9Fmwn7BWhnjLWxDbHe878aNG4339e3bV+3/LH33tfXZu59wxHlTTrHbAjkErribXhXUrsQiimraXwz3I0KOiJsWtUMkDtF/RE61G6KEeK5pCmF2BnxCJBDrNr16iSvTyCbAFWNHMx/dFlFmRBSRfWFvCn1OoM5gPoIsMhAAXTzMIUsEUVREL01Hp92/f7+K0CM6ixQs7bPB1Sqk7G/cuPGuwTPN64+r9Xgtos62INKN42B2sg6QTYLvHgYNMv0OIVsCV/ZtfYdw1QT1wJWecuXKZXhMixgjSo6rCbiahAi8BtFobBtkA2RWP0d8rvgdmV5dw28EEercgLRWXDXADVepcGUJKXHm6Yf4LmjPQ+ogsopwJQ6DRlnqvoHsCfzmzW/IOjGFK2fmz8EVRiJXZGm/aU+3H1yNRXYYrgLjyp2278M+F1eksP/WjrUaXNE1T9PO6r4Ir8dx1PwYg304rjSawn24aoZUX6Sjm169zM7xP7vbyhzeQ7vah+MYtiW6/OFKK7LmcmPb44qj6X4RZcfxBenj2vbAupDFYJ49YPo6XBVHRqFpijeuZKMbCbo72IIrkvhMspN1sHr1arWtUGfTzwvtLGRc5qS9psEx29KsC8jkMD8mIAtSg2MwUrftoa0/s+fj8awc27WsV9PyI7MR3R9M26Ha9x0ZO6blN12H6e9NO8bihjETsntcNWc6rgS6s+C7i+M4sjlMfwMYFwKP4/PXoE2E3y4eA3yn8Blh/AH8bfr9wO8BGcLaOvE8ZApYar/YMzUo2h3YxsjWtJY5opUbbX7Trgto9+N3mVmXBVy9RwYrsiXMs2k8TMpoug21DBBtjAWtvvjNrFmzRm0b07E+rNXZnv1Ebp032YvdFsghzE+8tEACDmaW7tdOpHGABaTBW6LtGNAFATsfUzhg2YIfGg5oSLU3pXU90H6IWC/Wr0GDQht0JauQKmUK/ZpwUo6GFXZ02KkgDQoH/8zKj52FeT8nlMtWGhrqhPriAGAK74UdoFZn0x0pAgroVmI6zoHpZ2MrNR7bzjQ93fx7oD2Gz9vWTj4nUE6UA90jLEE3EWu0RqelqX80+AyQEmY+6rL2XcKBAf0VkWaaW/C5IVhh3rCwVCZHQAMTM6to02nhd2Rp++IxdO8AdB1CIArb23ywKw1SIzEadmZwELTneUTODr8hrcuZ6X7TnmAzuuShoY40ctwswe8RafWWjlEI5Jung6MstoIL2Behz675iZf5cVWDmVoQrEdKrekJVFaO/47YVpagex+CkgiW4uTI2nHcUdve1vERtGCAreORdlKEkxoEDND9BMc/pFJjwD17Tr6yC58X6ozjgSW2ugfaC98VS8cadIuwNWAiviv2BpG0766lIIUpPG6tXWGt7KbrBwTM0GUBFx7wndG+xzjG4vNDUN70Ndo6NAjGa4MkYtpw8/GmsnJcNYd2L7qYIgiDE2rTMUtM29sYKwxp9kibRxcEwN/4PLTfLtpJOKFFyj5uttpi+J6j7ZLdGcvQvkUbGu1W7FNwAcnSPgtjICBwgS6eixcvVtsdgQS8LwJgts4t7P0t3rx5U42fgdk5zNua2nqxbRAcymxd9u4nsrrfzA0MHpBDWGtsWLtf20lpV67Rf8fSybS2c8GOCn2KLK0jp3DV3XQwGETuszuns6WTJhzkEXFE5BGRZjQ0sMPGVQvz6ftM4YTUvBGDiKI900XZ24DACS92+Nj+6Odq+n7aZ4MDFvp/WmJ+MpvZ550bUE4c4C1NDQjmjc3cZG27Z2dAr5yUwdL2zkoZ0NjJzkk+DtRoZOC7ZD5oGBHdLSdZANo+Ghk/Wr9jc+aBZNNjFPo7m1+dxNU2R/aXxckPstgwBg0a7KaBeXuP/47YVuZwUoc+78goQ+AcxxCsH8dmewZty862d9TxEScTuAihBQ/QbxqDrOX2iPuoM44vyC6xVBdLUylmBQLQOOEy3272wHEHV4vRbjK/aGVOC3QhK8AaBMFwwlerVi27y4D++qCVH58rxjvAlXJL68HJJoIF2G4ov7YO0ymJ0X7RjrHZGUjSFlz5R+AAbdSWLVuqi3v4fDEOgXlWKQJWGO8CV7gR6MDxHSfu2m9Uez6+g9YuOFmagjO7MPYUMiVwwQLZVBivxFL7C+VBYA03jNWCrAcMbKm1C3N6btGzZ0+1H8U+BO1kfJbYFhj4MrvT2jvqvCk3MXhAutIGRsGB29bJCg7OlqaosXXChvQuHBzwQzPNPsBVBu1xbSdketC1NNCbI+qJ7ANtuh3sZHDFQzsYWKoDdgrmddYOKrbqjPriPUwHd8RANggSmKe8IXKMhgcGWUFXBKTg46qSVmYtipmfrwKjnBg4C41Ua1e8rdG6IWgHfUtwkMHAQRhgyRy+S/huaY0V7buDbW2a6mZ+NQ6ycoUInxsGBdIaGhpLZUIZLF2BsVQGR0N2BK5+IRJvbYokIsoaa/sKbf+FK77Z2UfjeGJ+jNEao7aOMdjf4qqs6RVW8+OqBidSaOAj6I0GNfZj2uvsPf7nBhz3sP2Qim1aVwxSlhfb3hJte+B4lNkJNK68Il0dg94hiIALEbmZ/aaVDycwuMhgOiCgo2iDc1oLxtiCCzQ4UUebCgNN2oKy44YLOuhOY6n7AjJmAEGarJQf3xd0odQyOxEQwQCX5oNt4yoy0tNRBrQ/MTA1ThrxWdozC4CjfgM40TftEojUe0uzOCF4gOM6Tr6RRYvAiulAkmgnYTviIkVmvwd8j9DtBtk+OclWQVYvrvxj4FO0eyx1bUTAAOVCxgHeC9vddPtaO7cw/S1aq8+tW7fU/gzbBUE8jZYZYLpt0I621c7MCj33mxqOeUC6wg8XPyqMwGyaNqjR0vZxUoIfienN9CqpedoRYCRWTJNoOkIp+jSi/zZOwLS+gYgIm64XfeUdBenu5tMm4YePnZnp1Imog/kOGylW5nXWTk61ubnNX4M6A0ZnNTV79mz1v5YiZ57yhsYg0rdw0NOmmMF2QFkxqrV5Kh3YmrIvq3IyVSMivzhgYXpKc/i8LR0ITXfqSIdEX37MfmEpyosDOiLV6MdvOoURAjI4ICHwoqWJaTt1jKOgwVUHS9McWfrMrcHnirog9VeDOptOd6ZBGbAtTT8fTGFlKd0xN+BqBoItmPeaiHIOvycw31+g8YiTcsxeYGnqvcz20TiemB9jtL72to4x2Pcgk8AURjTHiRNOgixdcUTfbYxUjpM8rZugvcf/3KBd3TO9yogTmm3btuXJtrcExxm0DZD9YN5uML8aiu2M4D9OoHCSam/WQU6masRsE9huOFkyLw+WLU1PZy9kYuIYjsBEdk6eMbtU3bp11dVx888QEOwynX4ZJ3s4+cMYGuZZeZjKD9sVaeaYvcIeON5hHACcZGvdOrQuC7gqjfKZ3nC1HM/TMiaRqo6xl5DVYf7byq0MTnyW5utEm8JSliKCH9i+aE/jhjY52k6m68K2QnDB0kmy6e8Bz0Nbz1I9s1pH/P6wPdHG1WYJM4ULSpj1BPsftJ/weSDoprF2btGoUSP1XURb2vy3bzBpG1oqs3n7GxeYkOGELp6Y+jKnddZzv6lh5gHpCj8A/KAxxQ1+rIhk4oQOJ3Loi4+rydZ2pBqc5GJnhkECMR8yAgNooCCqix0LUhNxMEAqJiKtOInCj9vewXVyAlMq4oo+TnARpEA6Efpf4cTTNGqLOmA7YOeHKw5omFjrz6Q9H3AwxHoQUUWdcSUJkWT0OcMODwESTDuFk1fsvKwNoIP3xIEPjSHsmHAgx2eDiC4aKbiigdQu9N9E3zh0n8DjWn/3nMrJVI2oI9Lk0eBCeiwaYNgeiP6iLxyuLODgYs3777+vAgD4/uE7gwMGggT4/mF9gM8F0Wk8D1Od4XPEdwsBIFxV0+C90QhAv0A0GHBwQWBC+06byspnjs8WvwUMpIWy4buEK2aWgmZogOBAis8R5UBqJPr74TPM7YEdtX6G+K4sXLhQnSyYXnHB78FS6iWuZGhXa3IKjRftKqgp/C60DBEcwC01NPD9tzRHOJGe0ADGbx7HOVwxReo/TmxwW7BggfrOomGPExJcEcfxBSdQuOqJwGF2aMcYDIyIfQn2ZTjWYF+EfTWOPdgX4ZiDYweCq0h/tjbNGrKQ8BwEH7A/xhVXRxz/swtXlLEPxYkFguroroH9JLazabA8L7c9tgeCMJgCEW0ZDMiLAA/WgwC7aRAaxzhsL2wffDbm40nkxlSN+Gyx38SVfXz2aFOgHYVth3YNjp/oxpEZnCBjH42AOLYX2hs4viJrBenwlqaaRNvNUrcIHDdw/MD2wOeJkz+c1KLNhe8P7se0eQj0Y1tq0y8jQIGsDbQPMC0hlvE4BrnDMRvHMbyn+ZVxlFk7hiHAg4w+lBlZrvhdaP390TbAsQjlszZ1Jq6K4/1xjMbxH+1SbEsE4NGHHr813I8TbbRb0d6yNM5Rdo+r+A0gWwLdFfAdx/cWF5JQd0sQGEHQBfVB28J8PDEEUNA2xKB9+D1gncgMwDbFerXxVZA1g8wOtNnR9sOAgLjIguegfWV6cp8ZlAEBGLSF0CUYv0+swxQCa3g/dBvG56wFRjNbL/ZN+AyQKYw2DQIN+N4ePnxYrQu/V3zX0AbESTzax9gX4jM0hxN9PIb2Kn4n+A0igIc2KjJ+szLFqZ77TaNcn8+B3GKqRvOpCK1Nm2Ztqh48H1MCYpoRf39/Q+XKlQ3PPvusYffu3ZmWNzY21vDUU0+pqUuwbtPyhYeHG/r376+mxcFUe5gyx3RaO0dP1YipdExhyhpsT0x9hyl+UD9MsbRq1aq7pljBtImYfsZ8WjprMK0ippzB9C+m0wBi+p/JkyeraWYwvU7ZsmXVVDum00mZT9Wo2bFjh3H6QW0KGkw/1L17dzXlop+fn3pdz549DevWrcu0/pamKHT0VI2ajz76SE3ZFRAQoOqAz3rUqFFqSsXMHDp0SE0rie8Qvn+YAmr8+PEZnrN37171HcU0n4GBgYaOHTsatm7dete69uzZoz5jfN/KlSunpiOytB2y+pnfuHHD0KdPHzV9FL5H+FubGsr8O43pSStVqqTK0KBBAzVVUVamarT0nTdna9oqTGmJqYVMpwOzNaWUad0zmw4rs6kard0wpWdm5TCdqpQoL6ZqtPRdtzTlK/Y12L/hN22+r8TvDVOBlShRQu3zcVx46KGHDN98843N989sqrJXX31VTcOMKRhNy4OpwjB9WKlSpdT7YVpC/BYtTc9qPi3q999/r6b169Wrl5o2zd7jf1a2lT1TNaKsb7/9tton4riGqf5++ukni/vJ3Nr22j7LfHrFH374QU33iGMZ9vfNmjWzOO3ezp071eu7dOlisFdOpmrUfPvtt2rKT3weuKF9g8/5+PHjNtenbQfthu2J7YZpnzFdtKXps21N1Whp22FavQkTJqjjP47T+D5h6mC0ga5evWpx2ka8f+HChdX3oEqVKmpaUfO2jKVphLH+ChUqGHr06KE+b+37rG0jPOd///uf1e2xfv169RzU3fR3h+10zz33qCkJ8VtB+xXTgi5evPiuKTztPa5agm2ltY/RrsFv8NixY+r7b+n7cfLkSeO6N2/ebHGdaHPju4B2J34P+HxRdrTPTKF9OXbsWGM7Fc/DdK+m02FnpX2C84AWLVqo9rD59NzYpphCEuX+5ZdfDFmBeuL7gXYavuv16tUzzJ8/3/j4pUuXjG1H7L+eeOIJ1ea01J7FdODYV2Cfiu8a2mjYVtqUsVndT+TkvCmnPPBP7oYniIiIiIjIUZCRgKuiuKqKq5BERHmBYx4QERERETkRTKeLVH6MRUBElFc45gERERERkRNA33f000f/+sGDB9vVh5uIyFHYbYGIiIiIyAlg8GcMNIiBLDHgXV4M/kxEpGHwgIiIiIiIiIhs4pgHRERERERERGQTgwdEREREREREZBMHTLQgPT1drly5ovqReXh46F0cIiIih0KPxZiYGClVqpR4evI6QmbYLiAiIldmb7uAwQML0EAoW7as3sUgIiLKVRcvXpQyZcroXYx8j+0CIiJyB5m1Cxg8sEAbuRYbLyQkJNtXKSIjIyU0NNTtruq4c93dvf6su3vW3d3r74x1j46OVifDHKndPmwX5Azr7p51d/f6s+7uWXdXbxcweGCBlpKIBkJOGgmJiYnq9c7ypXEUd667u9efdXfPurt7/Z257kzBtw/bBTnDurtn3d29/qy7e9bd1dsFzlUbIiIiIiIiIspzDB4QERERERERkU0MHhARERERERGRTQweEBEREREREZFNDB4QERERERERkU2cbYGIiCgfM6SlSfzuPZIaGSneoaES2KSxeHh56V0sIiIiykNXY6/KraRbVh8v7FdYSgaXzNUyMHhARESUT0X//ruEvz1dUq9dM97nXaKEFH9zjIR06aJr2YiIiCjvAgcPrXlIktOSrT7H18tXfur2U64GENhtgYiIKJ8GDi4PHZYhcACp4eHqfjxOREREru9W0i2bgQPA47YyExyBwQMiIqJ82FUBGQdiMFh48M59eBzPIyIiIsoLDB4QERHlM2qMA7OMgwwMBvU4nkdERESUFxg8ICIiykcMqakSv3OHXc/FIIpEREREeYHBAyIiIp2l3rolUT/8IJdHvCYnWreR6wsW2vU6zL7gSjZu3CgPP/ywlCpVSjw8PGTNmjUZHl+9erV06dJFihYtqh7fv39/putctmyZeq7pzd/fPxdrQURE5FhJaUmSH3C2BSIiojxmMBgk6dgxid2wQWLXb5CEf/4RSU83Pu4REiKSnCyGxETLK/DwEO/ixdW0ja4kLi5O6tevLwMGDJDu3btbfLxNmzbSs2dPGThwoN3rDQkJkePHjxuXEUAgIiJyBruv7ZbRm0ZLfsDgARERUR5Ij4uTuO3bVbAgduNGNWuCKb/q1SW4fXsJ7tBeAurVk5i//lKzKiimAyf+e+KL6Ro9vLzEldx///3qZk2fPn3U/+fOncvSehEsKFGiRI7LR0RElFfiU+Jl3t55suLYCskvGDwgIiLKJcnnzxuzC+J37RJDSorxMY+AAAlq0eJOwKB9O/EpmXFe5pAuXUTmzVWzKpgOnoiMAwQO1ONkl9jYWClfvrykp6dLo0aN5O2335batWtbfX5SUpK6aaKjo9X/eD1u2YHXIeMku693Zqy7e9bd3evPurtn3R1V/93hu2Xi1olyKfaSWr6v/H3y18W/JDnd+nSNvp6+UtC3YLbe197XMHhARETkIIbkZInfs+dOdsGGDZJsdoXcp0wZY3ZBYLNm4unnZ3N9CBAU6NTpzuwLkZFqjAN0VXC1jIPcVL16dVmyZInUq1dPoqKiZNasWdKqVSs5fPiwlClTxuJrpk+fLpMnT77r/sjISEm01pXEjoYZ3h8NSk9P9xpyinV3z7q7e/1Zd/ese07rn5CaIJ+c+ER+uPiDWg71D5XhtYdL02JNpU/5PhKVEmX1tQV9CopXnJdExEVIVsXExNj1PAYPiIiIcgAn9Um//CKX9+2T+K3bVPcEI29vCWzc2Bgw8K1YMcv97REoCGrezPEFdxMtW7ZUNw0CBzVr1pQPP/xQpk6davE1Y8aMkREjRmTIPChbtqyEhoaq8ROy25jEZ491uFtjmnV3z7q7e/1Zd/ese07qv/PaTpm0Y5Jcjr2slntU7SEjGo2QYN9gtRwmYZJb7B1ImMEDIiKiLDCkp0viwYPG7giJR45keNyraFEJbtdOBQyCWrcSrwIFdCsr3c3Hx0caNmwop06dsvocPz8/dTOHRmBOGsJoTOZ0Hc6KdXfPurt7/Vl396x7VuuPsQ1m75ktK4+vVMslg0rKpFaTpFWpVpJX7P2cGDwgIiLKRFp0tMRt2XKnO8KmTZJ282aGx72qV5dCnTpJgY4dxL92bfFw08aSM0hLS5ODBw/KAw88oHdRiIjIzW2/ul0mbf0v26BntZ4yvPFwY7ZBfsPgARERkRn0U0w+ffq/wQ737sVZp/Fxz+BgCWrdWmUXBLZuJTcNBikWFua2V1gcObChaUbA2bNnZf/+/VKkSBEpV66c3Lx5Uy5cuCBXrlxRj2vTL2ImBW02hb59+0rp0qXVuAUwZcoUadGihVSpUkVu374t7777rpw/f16ef/55XepIREQUlxIn7+1+T74+8bVaLhVUSia3niwtSraQ/IzBAyIiIvRRTEyU+B07JHbDRhU0SLl85yqAxrdSpX9nRmgvgY0aioev738jFEdkfXAiutvu3bulY8eOxmVt3IF+/frJsmXL5IcffpD+/fsbH+/du7f6f+LEiTJp0iT1N4ILpkGcW7duycCBA+XatWtSuHBhady4sWzdulVq1aqVhzUjIiK6Y9uVbWomhatxV9Vyr+q9VLZBkE+Q5HcMHhARkdtKuXLFmF0Qt2OHGExG0kdwADMiGAc7LFtW17K6gw4dOqisD2ueffZZdbNl/fr1GZbnzJmjbkRERHqKTY6VWbtnybcnv1XLpYNLy5RWU6RZSecZFJnBAyIichuG1FRJ2L/fGDBIOnkyw+PeJUoYswuCWjQXz8BA3cpKRERErmHr5a0ycdtEuRZ3TS33rt5bZRsE+jhXO4PBAyIicmmpt25J3EZ0RdgosVu2SHqUyRzJnp4S0KCBMbvAr1q1LE+lSERERGRJTHKMyjZYfXK1Wi4TXEamtJ4iTUs0FWfE4AEREbkUpL0nHT1qzC5I+Ocf3Gl83KtgQQlq2/ZOdkGb1uJduLCu5SUiIiLXs+XyFpm8fbKEx4er5adqPCVDGw11umwDUwweEBGR00uPi5O4bdvuBAw2bJRUswEM/apXN2YXBNSvLx5eXrqVlYiIiFxXdHK0zDo0S367/JtaLlugrBrboEmJJuLsGDwgIiKnlHz+/H9TKe7aJYaUFONjHgEBEtSy5b/jF7QTn3+n8SMiIiLKLRsvbZTJ2yZLRHyEeIiHPF3zaXm14atOnW1gisEDIiJyCobkZInfvduYXZB87lyGx33Klv1vKsVmTcXTz0+3shIREZH7iEqKknd2vSM/nP5BLZcKLCVvtX3LJbINTP03EbKOFixYIBUqVBB/f39p3ry57Ny50+pzV69eLU2aNJFChQpJUFCQNGjQQD777LMMz8E0ThjwyvR233335UFNiIjIkVIiIuT2N9/IpVdflRMtWsqFAc/JzeWf3gkceHtLYPPmEjZqlFT65Wep/PtvUmLcWAlu24aBAyIiIsoTGy5ukO7fd1eBA2QbPFPzGfmw1YfSKKyRuBrdMw9WrlwpI0aMkMWLF6vAwdy5c6Vr165y/PhxCQsLu+v5RYoUkbFjx0qNGjXE19dXfvrpJ+nfv796Ll6nQbBg6dKlxmU/NiSJiPI9Q3q6JB48aOyOkHjkSIbHvYoVk+B27e4Mdti6lXgFB+tWViIiInLvbIOZO2fKj2d+VMsVQirI1NZTpV6xehJhNvaSq9A9eDB79mwZOHCgCgAAggg///yzLFmyREaPHn3X8zt06JBheejQobJ8+XLZvHlzhuABggUl2MeViCjfS4uOlrjNm+8EDDZtlrSbNzM87l+3rrE7gn/tWuLhmS+S5oiIiMhN/X3hb5m6fapEJkSqbIO+tfrK4IaDxd/bX9LT08VV6Ro8SE5Olj179siYMWOM93l6ekrnzp1l27Ztdk3H9ddff6kshZkzZ2Z4bP369SoboXDhwnLPPffItGnTpGjRohbXk5SUpG6a6Oho9T8++Ox++HgdyufKXx5r3Lnu7l5/1t09657V+uN5yadOS+zGDRK3YaMk7NsnkpZmfNwzOFgCW7VSAx1iSkXvYsX+e+2/2Qn5iTN+9s5UViIiovyUbTB953T5+czPGbINGoQ1EHega/Dg+vXrkpaWJsWLF89wP5aPHTtm9XVRUVFSunRpdcLv5eUlCxculHvvvTdDl4Xu3btLxYoV5fTp0/Lmm2/K/fffrwISeL656dOny+TJk++6PzIyUhITE7PdMEM50aBEQMSduHPd3b3+rLt71t2e+huSkiR13z5J2b5dUrZtl/TwO3MeazzLlxef5s3Fp2UL8a5bVzy8vQUh3SSc5Obz1D9n/OxjYmL0LgIREZFTWXdhnUzdNlVuJN4QTw9P6VernwxqMEhlG7gL3bstZEeBAgVk//79EhsbK+vWrVNjJlSqVMnYpaF3797G59atW1fq1asnlStXVtkInTp1umt9yHzAOkwzD8qWLSuhoaESEhKS7cYkBmrEOpylMeko7lx3d68/6+6edbdW/5QrVyR240aVXRC/Y4cYTIKxHr6+EtismQQhu6BdO/EtW1aclTN+9higmIiIiDJ3O/G2vL3zbfn17K9quWLBijKt9TSpF1pP3I2uwYNixYqpTIBwsytQWLY1XgEaZ1WqVFF/Y7aFo0ePquwB8/EQNAgs4L1OnTplMXiA8REsDaiI98lJQxCNyZyuw1m5c93dvf6su3vWXUlLl8S9eyV+40Y1fkHSyVMZHvYuUcI4dkFQi+biGegacx4742fvLOUkIiLS05/n/1RjG9xMvKmyDZ6t/azKNvDzcs/B+HUNHmC2hMaNG6vsgW7duhmv4GB58ODBdq8HrzEds8DcpUuX5MaNG1KyZEmHlJuIiO5IvXlT4jZtkpj1GOxwk9yOjf3vQU9PCWjY8N+AQTvxq1ZNnWQTERER5We3Em/J2zvelrXn1qrlygUrq7EN6obWFXeme7cFdBfo16+fNGnSRJo1a6amaoyLizPOvtC3b181vgEyCwD/47nohoCAwS+//CKfffaZLFq0SD2OrgwYv6BHjx4qewFjHowaNUplKpjOxkBERFmHfv2YPjEO2QXrN0jCP//gTuPjngULGqdSDG7TWrwKFdK1vERERERZ8fu53+WtHW+pbAMvDy/pX6e/vFT/JbfNNshXwYNevXqpgQknTJgg165dU90Q1q5daxxE8cKFCxnSKxFYGDRokMomCAgIkBo1asjnn3+u1gPoBvHPP/+o6Rtv374tpUqVki5dusjUqVMtdk0gIiLb0mLjJG7bVtUVAeMXpEZGZnjcr0YNNW5BSr26UrJ9e/Hy8dGtrERERETZgWDBW9vfkt/P/66WqxSqosY2qF2stt5Fyzd0Dx4AuihY66aAQQ5NYcpF3KxBQOG3335zeBmJiNxJ8rlzKligAga7doukpBgf8wgIkKCWLY3dEXxKlFDdxyIiIsTDwow2RERERPnZb+d+U4GDW0m3VLbBgDoDVLaBr5ev3kXLV/JF8ICIiPRlSE6W+N277wQM1m+Q5PPnMzzuU66ccbDDwKZNxJOZXEREROTkbiTcUF0U/jj/h1quWriqGtugdlFmG1jC4AERkZtKCY+Q2I0b1PgFcVu2Snp8/H8PentLYJMmxoCBb8UKHOyQiIiIXGYMJ5VtsOMtuZ10W7w9vOW5us/Ji/VeFB8vdr+0hsEDIiI3YUhLk8SDByXm3+4ISUeOZnjcq1gx42CHQa1biVdwsG5lJSIiIsoN1xOuqy4Kf174Uy1XK1xNjW1Qs2hNvYuW7zF4QETkwtKioyVu8+Y73RE2bpK0W7f+e9DDQ/zr1lXjFgS37yD+tWqKh8kAtURERESulG3w69lf5e2db0tUUpTKNhhYb6AMrDuQ2QZ2YvCAiMjFDoxJJ08aZ0aI37dPJC3N+LhncLAEtWlzpztCu7biXbSoruUlIiIiyotsg6nbpspfF/9Sy9ULV5dpbaZJjSI19C6aU2HwgIjIyaUnJEjcjh3GgEHKlSsZHvetXPm/wQ4bNRQPTqVIREREbnJR5eezP8v0HdMlOjlavD295YV6L8jzdZ8XH0+2h7KKwQMiIieUcvmyceyC+O07xJCUZHzMw9dXAps3vxMw6NBefMuU0bWsRERERHktMj5SpmyfIusvrlfLNYvUVDMpVC9SXe+iOS0GD4iInIAhJUV1QcDMCGqww5OnMjzuXbLkv2MXtJegFi3EMyBAt7ISERER6Zlt8NOZn2T6zukSkxyjsg1eqveSDKg7gNkGOcTgARFRPpV686bE/hssiNu8RdJjYv570NNTAho2NHZH8KtWlVMpEhERkVuLiI+QKdumyIZLG4zZBhjbADMqUM5xWG0ionwUKU84fFgiFy6Us716ycnWbeTq6DES8+taFTjwKlRIQh55WErNmiXVtm6RCl98LsVeGCj+1asxcEAuYePGjfLwww9LqVKl1Hd6zZo1GR5fvXq1dOnSRYoWLaoe379/v13r/frrr6VGjRri7+8vdevWlV9++SWXakBERHq1ob4/9b10+76bChwgw2BIwyHyxYNfMHDgQMw8ICLSUVpsnMRt22oc7DA1MjLD4341axq7IwTUqyceXl66lZUot8XFxUn9+vVlwIAB0r17d4uPt2nTRnr27CkDBw60a51bt26VJ598UqZPny4PPfSQrFixQrp16yZ79+6VOnXq5EItiIgoL4XHhcvkbZNl0+VNarl20dpqbIOqhavqXTSXw+ABEVEeSzp7VgUL1GCHu/eIpKQYH/MIDJSgli2NAQOf4sV1LStRXrr//vvVzZo+ffqo/8+dO2f3OufNmyf33XefjBw5Ui1PnTpV/vjjD/nggw9k8eLFDig1ERHplW2w5tQaeXfXuxKTEqOyDQY1GCTP1n5WjXNAjsetSkSUy9KTkyV+1y5jwCDl/IUMj/uUK/ffVIrNmoqnr69uZSVyNdu2bZMRI0ZkuK9r1653dYkwlZSUpG6a6Oho9X96erq6ZQdeh4Zudl/vzFh396y7u9efdc/dul+Lu6ZmUthyZYtarlO0jkxpNUUqF6psLINe0p3ws7e3rAweEBHlgpTw8P8GO9y6TQzx8f896OMjgU0a3wkYtGsvvhUrcMwColxy7do1KW6WwYNl3G8NujhMnjz5rvsjIyMlMTEx2w2zqKgo1aD09HSvIadYd/esu7vXn3XPnbpjnWsvr5XFxxdLfGq8yjboV6WfPF7+cfFK9pKIiAjRW7oTfvYxpoNy28DgARGRAxjS0iQVgx1++aXEbdwkSUePZnjcK7SYBLf7dyrFVq3EKzhYt7ISkW1jxozJkK2AzIOyZctKaGiohISEZLsxiSAh1uEsjUlHYd3ds+7uXn/W3fF1vxp3VY1tsO3qNrVct1hdlW1QqWAlyU/SnfCzx4DC9mDwgIgom9KioiR28+Y72QWbNkvarVv/PejhIf516/47dkEH8a9VUzyc5ABC5EpKlCgh4eHhGe7DMu63xs/PT93MoRGYk4YgGpM5XYezYt3ds+7uXn/W3TF1xxX8b09+K7N2z5K4lDjx8/KTwQ0GS59afcTLM38OJO3hZJ+9veVk8ICIKAsHr6STJ41jFyTs2y+SlmZ83CMoSILbtpXgDu3V/95Fi+paXiISadmypaxbt06GDRtmvA8DJuJ+IiLK367EXpGJWyfK9qvb1XL90PpqJoWKBSvqXTS3xOABEZEN6QkJErd9u3H8gtQrVzM87lul8p2uCO3aSUzp0lK8VCmniTIT5TexsbFy6tQp4/LZs2dl//79UqRIESlXrpzcvHlTLly4IFeuXFGPHz9+XP2PLAItk6Bv375SunRpNW4BDB06VNq3by/vvfeePPjgg/LVV1/J7t275aOPPtKljkREZN8Fm69PfC3v7X5PjW2AbINXG74qz9R8Jt9mG7gDBg+IiMwkX7ossRvW35lKccdOMZiMuu7h5yeBzZv9OztCB/EtU9rYvy02HwzSQ+TMcFLfsWNH47I27kC/fv1k2bJl8sMPP0j//v2Nj/fu3Vv9P3HiRJk0aZL6G8EF0wBeq1atZMWKFTJu3Dh58803pWrVqmqmhTp16uRhzYiIyF6XYy/LxC0TZce1HWq5YVhDNbZBhYIV9C6a22PwgIjcniElReL37TN2R0g+dTrD494lS/47dkF7CWrRQjwDAnQrK5Er69Chg7raZM2zzz6rbrasX7/+rvueeOIJdSMiovwr3ZAuXx//Wt7b854kpCaIv5e/DGk0RJ6q8RSzDfIJBg+IyC2l3rghsRs3SezGDRK3eYukm05R4+UlAQ0b/Jtd0F78qlblVIpEREREueRSzCU1tsHOazvVcqOwRjKl9RQpH1Je76KRCQYPiMgtGNLTJfHI0X+7I2yUxIMH0aHO+LhXoUIS1K7tnYBBmzbiVbCgruUlIiIicodsg5XHV8qcPXNUtkGAd4AMbTRUnqzxpHh6cAyp/IbBAyJyWWmxcRK3dcud7ggbN0pa5PUMj/vVrGnsjhBQr554eDEljoiIiCgvXIy+KBO2TpDd4bvVcuPijWVqq6lSNqSs3kUjKxg8ICKXknT2rHHsgvjde0RSUoyPeQQGSlCrlneyC9q1E5/ixXUtKxEREZE7Zht8eexLmbd3njHbYFijYdK7Rm9mG+RzDB4QkVNLT06W+J27/s0u2CAp5y9keNynfDnj2AWBTZuKp6+vbmUlIiIicmcXoi/I+C3jZW/EXrXctERTmdxqspQtwGwDZ8DgARE5nZTw8H+zCzZK3LZtYoiP/+9BHx8JbNL4v8EOK1bUs6hEREREbg/ZBiuOrlDZBolpiSrbYETjEdKzek9mGzgRBg+IKN8zpKVJwj//GAMGSUePZnjcOzRUgjB2Qbt2EtSqtXgFB+lWViIiIiL6z/no8zJhywRjtkGzEs1UtkGZAmX0LhplEYMHRJQvpd2+LbGb7wx2GLdpk1o28vAQ/3p1jdkF/jVriocno9ZERERE+UVaepp8fvRzeX/f+5KUliSB3oHyWpPX5PFqjzPbwEkxeEBE+YLBYJCkEyeNgx0m7Nsnkp5ufNyzQAEJatP6TsCgbVvxLlpU1/ISERERkWUX4y7KyL0jZX/kfrXcvGRzlW1QOri03kWjHGDwgIh0k56QIHHbtxu7I6RevZrhcb+qVVSwIKhdOwls2FA8fHx0KysRERERZZ5t8OmRT+WDfR9IcnqyBPkE3ck2qPq4eHh46F08yiEGD4goTyVfuvTfVIo7doohKcn4mIefnwS2aP7vVIrtxbcMo9NEREREzuBM1Bk1k8I/kf+o5RYlW8iUVlOkZHBJvYtGDsLgARHlKkNKisTv3WcMGCSfPp3hce9SJY1jFwQ1by6eAQG6lZWIiIiIcp5t8EK1F6Rfw37i5eWld/HIgRg8ICKHS71xQ+K1wQ63bJH0mJj/HvTykoCGDf6bSrFqVaaxERERETmhM7f/zTa4fifboHWp1jKhxQTxjPNk+84FMXhARDlmSE+XxMNHJGbDeolet05uHTuOERCNj3sVLizB7dreyS5o3Vq8ChbUtbxERERElH2p6amy/PByWbh/oco2CPYJllFNR0m3Kt3UINgRcRF6F5FyQb6YI2PBggVSoUIF8ff3l+bNm8vOnTutPnf16tXSpEkTKVSokAQFBUmDBg3ks88+y/AcfGEnTJggJUuWlICAAOncubOcPHkyD2pC5D7SYmMl+rff5cqbY+Vk+/Zy7okn5MYHCyTt6DEVOPCrVVOKvvySVPjqS6m6eZOUmjlTQh54gIEDIiIiIid26tYp6fNLH5m7d64KHLQp3Ua+e/Q7eazqY8w2cHG6Zx6sXLlSRowYIYsXL1aBg7lz50rXrl3l+PHjEhYWdtfzixQpImPHjpUaNWqIr6+v/PTTT9K/f3/1XLwO3nnnHXn//fdl+fLlUrFiRRk/frx67MiRIypAQURZh6Bc8tlz/w12uGePSEqK8XGPwEAJatlS0hs2lJIPPSi+JUroWl4iIiIicmy2wbLDy1S2QUp6ihTwKSCjmo2SRys/yqCBm9A9eDB79mwZOHCgCgAAggg///yzLFmyREaPHn3X8zt06JBheejQoSpIsHnzZhUgwAkOAhDjxo2TRx99VD3n008/leLFi8uaNWukd+/eeVQzIueXnpQk8Tt3SezGjSpgkHLhQobHfcuXl+AOd8YuCGjSRMTbWyIiIsTbQuCPiIiIiJzTyVsn1dgGh28cVsvtyrRTYxsUDyqud9HIXYIHycnJsmfPHhkzZozxPk9PT9XNYNu2bZm+HoGCv/76S2UpzJw5U9139uxZuXbtmlqHpmDBgiqrAetk8IDItpTwcIldfye7IG7bNjEkJPz3oI+PBDVtYhzs0LdChQyvTU9Pz/sCExEREVGuQIbB0kNLZdGBRSrzoIBvARndbLQ8XOlhZhu4IV2DB9evX5e0tDSVFWAKy8eOHbP6uqioKCldurQkJSWp6T8WLlwo9957r3oMgQNtHebr1B4zh/XgpomOjjaeCGX3ZAivQ3DDHU+m3Lnuzlh/Q1qaJP7zj8Ru2ChxGzZI0vHjGR73Cg2V4HbtJKh9O9UtwTMoyPiYeR2dre6O5M51d/f6O2PdnamsRESkj+M3j6tsg6M3j6rl9mXay4SWEyQskBmm7kr3bgvZUaBAAdm/f7/ExsbKunXr1JgJlSpVuqtLg72mT58ukydPvuv+yMhISUxMzHbDDEEONCiRTeFO3LnuzlL/9OhoSd21S1K2bZeUnTvF8G/ATPHwEK+aNcWnRXPxadFCvP6dShH5BwlxcSK4OXHdc4s7193d6++MdY8xnT6ViIjILNvgfwf/Jx/+86HKNgjxDVHZBg9VeojZBm5O1+BBsWLFVOZAeHh4hvuxXMLGYGtonFWpUkX9jdkWjh49qgIACB5or8M6MNuC6TrxXEvQbQIBCNPMg7Jly0poaKiEhIRkuzGJHxfW4SyNSUdx57rn1/rjpCbpxAmJQ3bBxg2SsP8ACmp83DMkRE2hqLIL2rQR7yJFXKbuecWd6+7u9XfGunPwYCIisifboEPZDmpsg9DAUL2LRu4ePMBsCY0bN1bZA926dTM2wrA8ePBgu9eD12jdDjC7AgIIWIcWLEAwYMeOHfLyyy9bfL2fn5+6mUMjMCcNQTQmc7oOZ+XOdc8v9U+Pj5e47TvuzI6wcaOkXr2a4XG/qlWMYxcENGwoHt7eLlN3vbhz3d29/s5Wd2cpJxER5Y2UtBT55OAn8tE/H0mqIVUK+hWUMc3GyAMVH2C2AeWfbgu44t+vXz9p0qSJNGvWTM2UEBcXZ5x9oW/fvmp8A2QWAP7HcytXrqwCBr/88ot89tlnsmjRIvU4vtzDhg2TadOmSdWqVY1TNZYqVcoYoCByVcmXLhkHO4zfsUMMycnGxzz8/CSoRQuVXVCgfXvxKV1a17ISkWvBMdlSIJ6IiPK3YzePybjN4+T4rTvjXt1T9h4Z33K8FAsopnfRKJ/RPXjQq1cvNbbAhAkT1ICGyBZYu3atccDDCxcuZLhCgsDCoEGD5NKlSxIQECA1atSQzz//XK1HM2rUKPW8F154QW7fvi1t2rRR62SaJrkaQ0qKxO/Zeye7YMMGST5zJsPjPqVKGadSDGzeXDz5GyAiB/n111/lq6++kk2bNsnFixdVFmBQUJA0bNhQunTpoi4CIHBPRET5N9vgo4MfySf/fKKyDQr5FZI3m78p91W4j9kGZJGHAZ2hKQN0c8D0jhgAKydjHmC++7CwMLdLD3XnuudF/VOvX5fYjZvuTKW4ZYukx8b+96CXlwQ2bGgMGPhWqZKnO393/uzdue7uXn9nrHtOjnPfffedvPHGG2rQxQceeEBlDSJIgID+zZs35dChQyqggOmRn332WZk6daoaD8KZsV2QM6y7e9bd3euf3+t+5MYRNbbBiVsn1HLncp1lbIuxDsk2yO91z23pTlh/e49zumceEJFthvR0STx8xJhdkHjwYIbHvQoXluB2bVWwAIMeehUsqFtZicj1vfPOOzJnzhy5//77LTaKevbsqf6/fPmyzJ8/X2UHDh8+XIeSEhGRueS0ZDWLAmZTSDOkSWG/wvJmizela/muzDagTDF4QJQPpcXGStyWrcbBDtOuX8/wuH+tWneyC9q1E/+6dcXDy0u3shKRe0FGgT0wXtGMGTOytO6NGzfKu+++K3v27JGrV6+qLAfT8YqQLDlx4kT5+OOPVbfE1q1bqzGPMMaRNZMmTbprOubq1avLsWPHslQ2IiJnd/j6YRm3ZZycun1KLXcp30V1UygaUFTvopGTYPCAKB9Agzj57Nn/Bjvcs0ckNdX4uGdgoAS1bnUnu6BtO/EpHqZreYmILElLS5ODBw9K+fLlpXDhwll+PcYrql+/vgwYMEC6d+9uMevh/fffl+XLlxsHRO7atascOXLE5rhGtWvXlj///NO47O2g2WWIiJwl22DxgcWy5NASlW1QxL+IChp0rdBV76KRk+HRk0gn6UlJEr9zl7E7QsrFixke9y1f3jh2QUCTJuLp66tbWYmILMHsRnXr1pXnnntOBQ7at28vW7dulcDAQPnpp5+kQ4cOWVofukLgZi3IihmZxo0bJ48++qi679NPP1UDLK9Zs0Z69+5tdb0IFmAaZyIid3Po+iE1toGWbYDBEMc0H6MCCERZxeABUR5KuXZNYjdsvDPY4bZtYkhIMD7m4eMjgU2bGrsj+FaooGtZiYgy880338gzzzyj/v7xxx/l7NmzqjsAplAeO3asbNmyxWHvhXVjVqbOnTsb78PgTs2bN1ddKWwFD06ePKkGdUR2QsuWLdW0z+XKlbM57SRupgNJaYNg4ZYdeB0CINl9vTNj3d2z7u5ef73rnpSWpLINlh1ZJumGdBUsGNtsrHQuf2cfmpvl0rvuekt3wvrbW1YGD4hykSEtTRIOHDB2R0g6fmf+XI13WJgEt293pztCy5biGRSkW1mJiLLq+vXrxiv6v/zyizzxxBNSrVo11e1g3rx5Dn0vBA5Am8pZg2XtMUsQXFi2bJka5wDjKGD8g7Zt26pZIQoUKGDxNQgumI+TAJhaOjExMdsNM4xijQals4y+7Sisu3vW3d3rr2fdj94+KrMOzZILcRfUcscSHeWVmq9IQd+CahaA3ObOn7uz1h8zKNmDwQMiB0u7fVuS//xTruzbL/GbN0taVNR/D3p4SEC9esbuCH41a3JkWyJyWjhxx3gDJUuWlLVr16rBCyE+Pl688slArqbdIOrVq6eCCRiTYdWqVaq7hSVjxoyRESNGZMg8KFu2rJpyMidTNWJ/j3U4S2PSUVh396y7u9dfj7oj22DhgYXy6ZFPVbZBUf+iMrb5WOlUrpPkJXf+3J21/rbGDTLF4AFRDiGqmHTihDG7IGH/fuw1jI97hoRIcJvW/w522Fa8i7CPGRG5hv79+6upGRE8QENJ61KwY8cOqVGjhkPfS8twCA8PV++nwXKDBg3sXk+hQoVUdsSpU3f6/1ri5+enbubQCMxJQxDbKKfrcFasu3vW3d3rn5d1PxB5QI1tcDbqrFp+sNKDMrrpaCnkX0j04M6fuzPW395yMnhAlA3p8fESt337nYDBxo2SapYy61mxohTqdI8U6NBBAho0EA+O7E1ELgjTINapU0cuXryouixoJ9zIOhg9erRD3wuzKyCAsG7dOmOwABkBCFS8/PLLdq8nNjZWTp8+LX369HFo+YiI9JCYmigL9i8wZhsUCygm41uMl3vK3aN30cgF8YyGyE7JFy/+N5Xizp1iSE42Pubh7y9BzZur7giBbdrKLR9vCQ0Lc5poIxFRdj3++ON33devX79srQsn9qYZARgkcf/+/VKkSBE1wCFmd5g2bZpUrVrVOFUjBkLs1q2b8TWdOnWSxx57TAYPHqyWX3/9dXn44YdVV4UrV67IxIkTVXDjySefzFYZiYjyi/0R+1W2wbnoc2r54UoPyxvN3pCCfgX1Lhq5KAYPyG0GLozfvUdSIyPFOzRUAps0Fo9M+uMaUlIkfs9e41SKyWfOZHjcp1Qp49gFgc2bi+e/fYXUaKV5MBgNEVF+sGvXLvn777/VIFzmozXPnj07S+vavXu3dOzY0bisjTuAYAQGPRw1apTExcXJCy+8ILdv35Y2bdqosRZM+2oiqwADOWouXbqkAgU3btxQ/U/xmu3bt6u/iYicUUJqgnyw7wP57MhnYhCDhAaEyoSWE6RD2axNj0uUVQwekMuL/v13CX97eoauBd4lSkjxN8dISJcuGZ6bev36f1Mpbt0q6bGx/z3o5SWBjRoZAwa+lStzsEMicmtvv/22jBs3Ts1kgMETTfeJ2dk/dujQQY0jYw3WOWXKFHWz5ty5O1fgNF999VWWy0FElF/tDd8rE7ZOkPPR59XyI5UfkVFNRzHbgPIEgwfk8oGDy0OHYVTDDPenhoffuX/uHJVBoHVHSDx0KMPzvIoUkeC2bVXAIKh1a/HK5ijbRESuCNMxLlmyRJ599lm9i0JE5PLZBu/vfV++OPqFyjYICwiTia0mSrsy7fQuGrkRBg/IpbsqIOPAPHBw58E7910ePiLDzAjgX6uWMbvAv25d8eC4BUREFmFcl9atW+tdDCIil7YnfI9M2DJBLsRcUMvdqnSTkU1HSogvL2pR3mLwgFyWGuPAbBaEu2AeVj8/CW7XToLbt5Ogdu3EJywsr4pIROTUhg8fLgsWLJC5c+fqXRQiIpcTnxIv7+97X1YcXXEn2yAwTCa1nCRty7TVu2jkphg8IJeFwRHtUXLyZCnY7dFcLw8RkavBTAYPPvigVK5cWWrVqiU+Pj4ZHl+9erVuZSMicma7ru1S2QaXYi+p5e5Vu8vrTV6XAr4F9C4auTEGD8hlYVYFu55XsmSul4WIyBUNGTJEzbSAGRKKFi3KQWSJiByQbTB371z58tiXarl4YHGZ3GqytC7NLmKkPwYPyGVhOkbMqmC164KHh3gXL66eR0REWbd8+XL59ttvVfYBERHlzM6rO9VMCpdjL6vlHlV7yGtNXmO2AeUbDB6Qy/Lw8lLTMV4eMtTCg3eujuFxPI+IiLKuSJEiqssCERHlLNtg9p7ZsvL4SrVcIqiETG45WVqVbqV30Ygy4DDy5NKsDX6IjIPS8+ZKSJcueV4mIiJXMWnSJJk4caLEx8frXRQiIqe04+oO6f5Dd2Pg4IlqT8h3j3zHwAHlS8w8IJdlMBgkfPoM9XfIY49JoW7d1CCKGAsBXRWYcUBElDPvv/++nD59WooXLy4VKlS4a8DEvXv36lY2IqL8LC4lTmbvni2rTqxSy6WCSsmkVpOkZamWeheNyCoGD8hlRf/8iyQcOCAegYESNnwYp2AkInKwbt266V0EIiKns+3KNpm0dZJcibuilntV7yXDGw+XIJ8gvYtGZBODB+SS0hMTJeK999TfxQY+z8ABEVEuQJcFIiKyT2xyrLy35z355sQ3arl0cGk1k0Lzks31LhqRXRg8IJd0c9kySb16VU3DWKR/f72LQ0TkUl3COCUjEVHWbL28VSZumyjX4u7MAta7em+VbRDoE6h30YjsxgETyeWkRETI9Y8+Vn+HjRghnv7+eheJiMhl1K5dW7766itJTk62+byTJ0/Kyy+/LDNm3Bl7hojIHcUkx6guCi/++aIKHCDbYEnXJTK2xVgGDsjpMPOAXE7kvHliiI8X//r1JOQhzj1ORORI8+fPlzfeeEMGDRok9957rzRp0kRKlSol/v7+cuvWLTly5Ihs3rxZDh8+LIMHD1YBBCIid7QrcpfM2zRPwuPD1fJTNZ6SoY2GMmhATovBA3IpiUeOSNTq79TfxUePZmotEZGDderUSXbv3q0CBCtXrpQvvvhCzp8/LwkJCVKsWDFp2LCh9O3bV55++mkpXLiw3sUlIspz0cnR8u7Od2XN6TVquUxwGZnSeoo0LdFU76IR5QiDB+R6UzMaDBLywAMS2LCh3kUiInJZbdq0UTciIvrPxksbZfK2yRIRHyEe4qGyDYY0GsJsA3IJDB6Qy4j580+J37VLPPz8JOy1EXoXh4iIiIjcKNvgnZ3vyPenv1fL5QqUk2E1h0mn6p3E05PDzJFrYPCAXEJ6crJEvDtL/V3k2WfFp3RpvYtERERERO6SbbB1skQk3Mk2eKbWM/JK/Vck5maM3kUjcigGD8gl3Pr8C0m5cEG8QotJ0YED9S4OEREREbm4qKQoeWfXO/LD6R/UcvmQ8jK19VRpGNZQ0tPTJUYYPCDXwuABOb3Umzfl+qJF6u+wYcPEKzhI7yIRERERkQtbf3G9TNk2RSITIlW2Qd9afeWVhq9IgHeA3kUjyn/Bg5SUFLl27ZrEx8dLaGioFClSxLElI7LT9Q8+kPSYGPGrWVMKduumd3GIiIiIyIWzDWbsnCE/nflJLVcIqaCyDRqENdC7aES5Lkujd8TExMiiRYukffv2EhISIhUqVJCaNWuq4EH58uVl4MCBsmvXrtwrLZGZpFOn5NbKVf9NzejlpXeRiIjcyunTp2XcuHHy5JNPSkREhLrv119/lcOHD+tdNCIih/rrwl/S7ftuKnDg6eEp/Wv3l68f/pqBA3IbdgcPZs+erYIFS5culc6dO8uaNWtk//79cuLECdm2bZtMnDhRUlNTpUuXLnLffffJyZMnc7fkRCISPvMdkbQ0Ce7cSYKaN9O7OEREbmXDhg1St25d2bFjh6xevVpiY2PV/QcOHFDtAiIiV3A78ba8sfENGfr3ULmecF0qFqwon97/qYxoMkL8vf31Lh5R/gseIKNg48aNsnPnThk/frx07dpVNRiqVKkizZo1kwEDBqjAAroydOvWTTZt2mR3IRYsWKACE/7+/tK8eXP1HtZ8/PHH0rZtWylcuLC6IZBh/vxnn31WPDw8MtwQ0CDXErtpk8The+bjI8VHjtS7OEREbmf06NEybdo0+eOPP8TX19d4/z333CPbt2/XtWxERI6w7vw6lW3wy9lfVLbBgDoDVLZB/dD6eheNKP+OefDll1/a9Tw/Pz956aWX7C7AypUrZcSIEbJ48WIVOJg7d64KTBw/flzCwsLuev769etVamSrVq1UsGHmzJkq2wHpkaVNpudDsADBDNNykeswpKZK+MyZ6u8iTz8tvuXL610kIiK3c/DgQVmxYsVd9+P4ff36dV3KRETkCLcSb8n0HdPl13O/quVKBSvJtNbTpG5oXb2LRuQcYx5YEx0drboxHD16NMuvRXcIjJXQv39/qVWrlgoiBAYGypIlSyw+/4svvpBBgwZJgwYNpEaNGvLJJ5+oqVDWrVuX4XkIFpQoUcJ4Q5YCuY5bq1ZJ8qnT4lWokBQb9LLexSEickuFChWSq1ev3nX/vn37MgT0iYicyR/n/1DZBggcINvg+brPy6qHVzFwQG4vW7Mt9OzZU9q1ayeDBw+WhIQEadKkiZw7d04MBoN89dVX0qNHD7vWk5ycLHv27JExY8YY7/P09FRdETCOgj0w2wNmfjCf7QEZCrjygaAB0ieRVlm0aFGL60hKSlI302AIICiBW3bgddge2X29M8vtuqdFR8v19+erv4sOfkU8goPz1XbmZ8+6uyN3rr8z1t1RZe3du7e88cYb8vXXX6sugljvli1b5PXXX5e+fftmeX3oHvnuu++qtgGCEt99953qCqnBdsZYCujCePv2bWndurUayLlq1aqZdo/EetG1sn79+jJ//nzV5ZKIyNTNxJvy9o635bdzv6nlKoWqqJkU6hSro3fRiJw3eICD+9ixY9XfOLDjYI6D+PLly9VJur3BA6Q0pqWlSfHixTPcj+Vjx47ZtQ40WkqVKqUCDqZdFrp37y4VK1ZUo0C/+eabcv/996uAhJeF0finT58ukydPvuv+yMhISUxMlOxAAyoqKkptGwRE3Elu1z1+4UJJu31bPMuXl+QOHY2je+cX/OxZd3eru7vX3xnrjtmTHOHtt9+WV155RcqWLauO58ggxP9PPfWUmoEhq+Li4tTJPcZRwnHc3DvvvCPvv/++am/gGK+NwXTkyBHVldER3SOJyD0hYIDAAQIIXh5eamyDl+q/JL5e/43nQuTushU8QCNJu9K/du1aFSxAV4MHH3xQRubhwHUzZsxQmQ7IMjBtNOBKiAaDOtarV08qV66sntepU6e71oPMBzQsTDMP0BDCFJSYkjK7jUlchcE6nKUx6Si5Wffkc+fl1urv1N8lx4yR4FIlJb/hZ8+6u1vd3b3+zlh3ayfaWYVBEpEFgJP4Q4cOqdkWGjZsmGkmgDUI9ONmCYIzOPFHUOLRRx9V93366afqggO6Tpoe+611jwQEEX7++WfVPRIDPhKRe7uRcEPe2vGW6qqgZRtMazNNahetrXfRiFwjeIATa1zFRwABwQOcwMOtW7ey1CApVqyYygQIDw/PcD+WMU6BLbNmzVLBgz///FMFB2ypVKmSeq9Tp05ZDB5gfARLAyqiEZiThiAakzldh7PKrbpHzn5PJDVVgtq2lZAO7SW/4mfPursjd66/s9Xd0eUsV66cuuWms2fPqm4HppmGBQsWVNkEaJNYCh5kt3skuzM6FuvunnXP7/VHuX47/5vM2DlDbiXdUtkGz9V5TgbWHaiyDXJa5vxc99zmznV31vrbW9ZsBQ+GDRsmTz/9tAQHB0v58uWlQ4cOxu4MuNKflSsWjRs3VoMdan0atcEPMZ6CNUhbfOutt+S3335T4y1k5tKlS3Ljxg0pWTL/XaUm+8Vt3yGxf64T8fKS4m+M0rs4RERuD10Uli1bpo7b6EJm3vj466+/HPZeCByApa6O2mOO6h7J7oyOxbq7Z93zc/0RLHj/yPuyOWKzWq4UXEler/u6VA2pKrdv3HbpuucFd667q3dnzFbwALMdINJ/4cIFuffee40bBVf4MeZBVqC7QL9+/VQQAIMXISURfR619EIMuIQRm3EgB0zNOGHCBDU1VIUKFYwNBgQycEPKJA746EqB7AWMeTBq1CipUqWK6uNIzsmQlmacmrFwr57iV6WK3kUiInJ7Q4cOVcEDdFusU6eOysBwBezO6Fisu3vWPT/WHydza8+tlRm7ZsjtpNvi7eGtZlJ4vs7z4uPl49J1z0vuXHdnrb+9vQeyFTwAZAzgZgqNh6zq1auXiuQjIIBAAKZgRFcI7SoBAhSmGx2jKiMN8fHHH8+wHoy+PGnSJNUN4p9//lGDKWEQRwym2KVLF5k6darFrgnkHKLWrJGko0fFs0ABKfbqq3oXh4iIRFS3xVWrVskDDzyQ6++ldWdE10bTTEIso+3gyO6R7M7oeKy7e9Y9P9X/esJ1mbptqvx18U5GVPXC1dXYBjWK1HD5uuvBnevujPW3t5x2Bw8wvgCuMAQEBGT63B07dqhUQXuDCeiiYK2bAgY5NIUpIW1B+dCdgVxHWmycRMydq/4u9vLL4l24sN5FIiKif7sfIrMvL2B2BZzwo4uEFixARgDaHC+//LJDu0cSketAtsEvZ3+R6TunS1RSlMo2eKH+C7mSbUDk6uwOhWAaJAyGhC4Lv/76q8oW0KSmpqqr/QsXLpRWrVqpbIICBQrkVpnJzdz45GNJi7wuPuXKSeFnnta7OERE9K/XXntN5s2bpxrnjoCuh/v371c3bZBE/I0sRFzFwZhL6B75ww8/yMGDB1XXRmQYaoEBwMDIH3zwgXEZ3Q8wIwQyEo8ePaoCDabdI4nIdUXGR8rQv4fK6E2jVeCgZpGa8tVDX8nL9V9m4IAoG+zOPMB0SAcOHFAHZMzfjGg/UgGR1hcfH6+eg+mZnn/+eXn22WcdNg0UubeUK1fk5tJl6u+wka+Lpy/n2iUiyi82b94sf//9t7qoULt2bfHxydgYX716dZbWt3v3bunYsaNxWRt3AGMjYWwFjGGEE/8XXnhBdU1s06aN6upo2ubAWEfIfrS3eyQRuR4ENH8685OaSSE6OVq8Pb3lpXovyYC6A8THk0EDouzK0pgH9evXV9H7Dz/8UGUanD9/XhISElSfQhyM8T+RI0W8N1sMSUkS2LSpFDCZnouIiPRXqFAheeyxxxy2PszeZCuLAdkHU6ZMUTdrLHVvtNU9kohcS0R8hBrbYP2lO12fkW2AsQ2qFa6md9GInJ53dgdUQLDA2gBFRI4Qv2+fRP/8M1qLUnzMaJcZxZuIyFUsXbpU7yIQESkIPP545keVbRCTHKOyDQbVHyTP1nmW2QZEDpLt2RaIcpMhPV3CZ8xQfxd87DHxr1VL7yIRERERUT4UHhcuU7ZPkY2XNqrl2kVry9TWU6Vq4ap6F43IpTjH3BHkdqJ//kUSD/wjHoGBEjpsqN7FISIiCzDlYZ8+fdSghd7e3mosJNMbEVFuZxusObVGHvv+MRU4QIbB0EZD5fMHPmfggCgXMPOA8p30hASJmD1b/V3shYHiExamd5GIiMgCDJCMmRDGjx8vJUuWZPcyIsoz1+KuyeRtk2Xz5c1quU7ROmpsg8qFKutdNCKXxeAB5Ts3ly2T1KtXxbtUSSny7LN6F4eIiGzMtrBp0yaOgUREeZ5t8M6udyQ2JVZ8PX3llYavSN9afdU4B0SUe7L0C0MK4tWrVyWMV4Ipl6SER8j1jz9Rf4eNeE08OeUnEVG+VbZsWZuzIxAROTrbYNLWSbLlyha1XK9YPTW2QaVClfQuGpFbyNKYB2wgUG6LnDdPDPHxElC/voQ8+IDexSEiIhvmzp0ro0ePtjg9IhGRo+Ac5NsT30q377upwAGyDV5r/Jp8ev+nDBwQ5SHm9lC+kXD4sER99536m1MzEhHlf7169ZL4+HipXLmyBAYGio9PxunQbt68qVvZiMg1XI29KhO3TpRtV7ep5fqh9WVK6ylSqSCDBkT5PnjwySefSHBwsM3nDBkyJCdlIjeNKEfMmIk/JOTBByWA/WeJiJwi84CIKLfaht+c/Ebe2/2exKXEiZ+Xn7za8FV5puYz4uXJ2VyInCJ4sHjxYpvTL+FqMYMHlFUxf/4p8bt2iYefn4S9NkLv4hARkR369eundxGIyAVdjr2sxjbYfnW7Wm4Q2kCNbVChYAW9i0bk1rIcPNi9ezcHTCSHSk9Oloh3Z6m/i/R/VnxKldK7SEREZKfTp0/L0qVL1f/z5s1TbYRff/1VypUrJ7Vr19a7eETkRNIN6fLNiTvZBvGp8eLv5S9DGg2Rp2o8xWwDImcbMJF90Ck33Prsc0m5cEG8QotJsYED9S4OERHZacOGDVK3bl3ZsWOHrF69WmJjY9X9Bw4ckIkTJ+pdPCJyIpdiLskLv78gU7dPVYGDRmGN5JtHvpE+tfowcECUT3C2BdJV6s2bcn3RIvV32LBh4hkUpHeRiIjITphpYdq0afLHH3+Ir6+v8f577rlHtm+/k25MRJRZtsFXx76S7j90lx3Xdqhsg9HNRsvS+5ZK+ZDyehePiLLbbQFXETIbLJEoKyLnz5f02Fjxq1VTCnbrpndxiIgoCw4ePCgrVqy46350Xbh+/bouZSIi53Ex5qKaSWHXtV1quXHxxjKl1RQpF1JO76IRUU4zD/73v/9JQkKCcfmDDz6Q6OjorKyCyCjp5Em5vXKV+rv46NHiYWMgTiIiyn8KFSokV69evev+ffv2SenSpXUpExE5R7bBiqMrpMcPPVTgIMA7QMY0GyNLui5h4IDIVYIHly5dkrS0NOPym2++ySsLlG3hM98RSU+XAvd2lqBmzfQuDhERZVHv3r3ljTfekGvXrqlxkdLT02XLli3y+uuvS9++ffUuHhHlQxejL8qA3wbI9J3TJSE1QZoUbyLfPvKtPFXzKfH0yNKpCRHl99kWTHEMBMqu2I0bJW7zZhEfHwl7/XW9i0NERNnw9ttvyyuvvCJly5ZVFxdq1aql/n/qqadk3LhxehePiPJZtsGXx76UuXvmSmJaoso2GNF4hPSs3pNBAyJ3CB4QZYchJeVO1gGmZnzmGfEtz8FwiIicEQZJ/Pjjj2X8+PFy6NAhNdtCw4YNpWrVqnoXjYjykfPR52XStkmyN2KvWm5WoplMbjVZyhQoo3fRiCg3gweffPKJcdDE1NRUWbZsmRQrVizDc4YMGZLV1ZIbubVqlSSfPi1ehQtLsZdf0rs4RESUTX///bd07NhRypUrp25ERKbS0tNk9bnVsvTUUpVtEOgdKK81eU0er/Y4sw2IXD14gIYBrjBoSpQoIZ999lmG56DPI4MHZE1aVJRcn/+B+rvYq4PFKyRE7yIREVE23XfffVKmTBnp37+/9OvXT3VfICKCc1HnZPyW8bI/cr9abl6yuco2KB3MwVSJ3CJ4cO7cudwrCbmF64sWS9rt2+JbpbIU7tlT7+IQEVEOXL58WV1EWL58uUyePFnuueceee6556Rbt26qSwMRuWe2wedHP5f5++ZLUlqSBHgFyOtNXpcnqj+hLjISkfPKUr4QGgW3b9/OvdKQS0s+d05ufvGF+rv4G2+IhzeH3CAicmbotjh8+HDZv3+/7NixQ6pVqyaDBg2SUqVKqSzEAwcO6F1EIspDZ6POSr+1/WTW7lkqcNCiZAv5uPXHqpsCAwdEbhY8WL9+vSQnJ+deacilhb87SyQlRYLatpXgtm31Lg4RETlQo0aNZMyYMTJ48GA1cOKSJUukcePG0rZtWzl8+LDexSOiXM42WHZomTz+w+NyIPKABPkEyaSWk2Rxp8VSPKC43sUjIgfhSCWUJ+K275DYdetEvLyk+Buj9C4OERE5SEpKinzzzTfywAMPSPny5eW3336TDz74QMLDw+XUqVPqvieeeELvYhJRLjlz+4z0XdtX3tvzniSnJ0vrUq3lu0e+kx7VejDbgMjFZDlv/MiRI3Lt2jWbz6lXr15OykQuxpCWJuEzZqi/C/fqJX5VquhdJCIicoBXX31VvvzySzEYDNKnTx955513pE6dOsbHg4KCZNasWaobAxG5ltT0VPn0yKeyYN8CFTQI9gmWUU1HSbcq3Rg0IHJRWQ4edOrUSTUSzGEngfvxf1pamqPKRy4g6rvvJOnYMfEsUEDNsEBERK4BFxTmz58v3bt3Fz8/P6vjImBKR0eJiYmR8ePHy3fffScRERHSsGFDmTdvnjRt2tRql0tMJ2nu6tWratYoIsq607dPq5kUDl4/qJZbl26tuimUCOJvisiVZTl4gAGRQkNDc6c05HLSYuMkYu489XexQYPEu3BhvYtEREQOsg7d0TLh7e0t7du3d9h7Pv/883Lo0CE1ywMyGj7//HPp3LmzCmSULm19Crjjx49LiMn0wGFhYQ4rE5E7ZRssO7xMFu5fKCnpKVLAp4CMbDqS2QZEbiLLwYNy5crxgEt2u/Hxx5J2/br4lC8nRZ5+Su/iEBGRg50+fVrmzp0rR48eVcu1atWSoUOHSuXKlR3+XgkJCfLtt9/K999/L+3atVP3TZo0SX788UdZtGiRTJs2zepr0XYpVKiQw8tE5C5O3jqpsg0O37gzAGrb0m1lQssJzDYgciMcMJFyTcrlK3Jz6VL1d/GRI8WDc34TEbkUDI6IYMHOnTvVeEe4IUOxdu3a8scffzj8/VJTU1XXSH9//wz3BwQEyObNm22+tkGDBlKyZEm59957ZcuWLQ4vG5ErZxt8/M/H0uunXipwgGyDaa2nyYJOCxg4IHIzWco8QNohp2oke0XOmS2G5GQJbNZMgjt10rs4RETkYKNHj5bhw4fLjH8HxTW9/4033lAn6o5UoEABadmypUydOlVq1qwpxYsXVwM2btu2TapYGYwXAYPFixdLkyZNJCkpST755BPp0KGDCnJgeklL8DzcNNHR0er/9PR0dcsOvA5jQ2X39c6MdXfeuiPbYMLWCXLk5hG13K50OxnXYpwUDyyu6mVpHDRXqn9OsO7uWXdnrb+9Zc1S8GDjxo3iy6vHZIfUw4cl5pdfMZKmFB8zmv3giIhcELoqrFq16q77BwwYoLoy5AaMdYD1Y3wDLy8vFQB48sknZc+ePRafX716dXXTtGrVSnW1mDNnjlqXJdOnT5fJkyffdX9kZKQkJiZmu2EWFRWlGpSenu6V+Mm6O1/dkW2w8uxK+fz055JqSJVg72AZVHOQdC7ZWTxiPSQiNsKl6+8IrLt71t1Z64/BiB0ePMgsuphdCxYskHfffVdNAVm/fn01cnOzZs0sPvfjjz+WTz/9VA2WBI0bN5a33347w/NRzokTJ6rn3r59W1q3bq36QlatWjVXyk8ZGdLTJf6DBervgt0fE/+aNfUuEhER5QIMoLx///67jq+4L7fGR8JYChs2bJC4uDiVEYDMgl69ekmlSpXsXgfaDLa6OYwZM0ZGjBhhXMb7lC1bVtXXdNDFrDYmEUjHOpylMekorLtz1f3ErRMyfut4OXbzmFruUKaDjGs+TkIDQ92i/o7Curtn3Z21/ubdAR02YKKjryCvXLlSHaCRUti8eXN1paJr165qVGRLDQ9MuYQrDLhygErOnDlTunTpIocPHzaOsox5pt9//31Zvny5VKxYUU3phHViJGZ7NwxlX8wvv0ja0aPiERAgoUOH6l0cIiLKJQMHDpQXXnhBzpw5o47LgPEEcGw2PfnODUFBQep269YtNfYCjv32QnADQQdrMO2kpakn0QjMSUMQbaicrsNZse75v+6YPeGTg5/IRwc+UtkGIb4hMqb5GHmw4oM5av87S/1zA+vunnV3xvrbW84sBw+qVauW6Q7k5s2bdq9v9uzZqvHRv39/tYwgws8//yxLlixRfSbNffHFFxmW0XcRIy9juqi+ffuqrAMEIMaNGyePPvqoeg4yFdAvcs2aNdK7d2+7y0ZZl56QIJGz56i/iw4cKD6cmYOIyGUhOI9xCN577z11tR4wfSJmQBgyZEiuvCcCBTjWoyvCqVOnZOTIkVKjRg1jOwLluHz5sjr2A9oEuJCAQRzR5QDthr/++kt+//33XCkfkTNClgFmUtCyDe4pe4+MbzleigUU07toRJSPZDl4gD6ABQsWdMibY/BF9FHUGhxa1APzNWPwI3vEx8dLSkqKFClSRC2fPXtWdX/AOjQoL7IasE5LwQMOjOQ415cskdRr18SjeJgU7NvH7ervzp89sO7uWXd3r78z1t1RZcXFBAyYiJvWXxLBhNyEfqRoN1y6dEkd+3v06CFvvfWW+Pj4qMevXr0qFy5cyNDWeO2111RAITAwUM0I8eeff0rHjh1ztZxEziAlLUU+Pvixmk0B2QYF/QrKm83elPsr3s/xqogo58EDnHw7qh/j9evX1ZRLyAowheVjx+5EPjOD0ZxxlUMLFiBwoK3DfJ3aY+Y4MJJjpF+/LlEff6L+Njz9jFyPjhbP2FhxN+742WtYd/esu7vX35UHRsqK3A4aaHr27Klu1ixbtizD8qhRo9SNiDI6euOojNsyTo1xAJ3LdZaxLcYy24CIHBM8yG8RSEwN9dVXX6lxEHIylgEHRnKMq3PniSQmin/9+uL30IMqyOQudXf3z17Durtn3d29/s5Yd0eN/3Pjxg2ZMGGC/P333xIREXFXRkNWujESUd5lG3z4z4dqfIM0Q5oU8iskY5uPla4Vuua7tj4R5S+6zrZQrFgxNc1SeHh4hvuxXKJECZuvnTVrlgoeIPUQKYga7XVYh+lgSFhu0KCBxXVxYKScSzh8WKK//179HTZ6tMT8W293qLu7f/bmWHf3rLu719/Z6u6ocvbp00eNO/Dcc8+pDD+eeBDlb4dvHFZjG5y8dVIt31v+XhU4KBpQVO+iEZGrBQ8c3Z/T19dXTbWIwQ67detmfA8sDx482OrrMKIy+jdi0KQmTZpkeAyDIiGAgHVowQJkEuzYsUNefvllh5af/gsqRUyfgT8k5KGHJKB+PYmJsG/+XyIicl6bNm1SUx5immUiyr+S05Jl8YHFsuTQEpVtUNivsOqigGwDIqJcG/PA0dBdoF+/fioIgHmXMSoy5m7WRk3GDAqYghHjEgCmf0KK5IoVK6RChQrGcQyCg4PVDVc9hg0bJtOmTVPzTmtTNWJcBC1AQY4V88cfEr97t3j4+UnYiOF6F4eIiPIIZjlISEjQuxhEZMPh64fV2Aanbp9SywgYvNn8TSnif2ewcSIipwke9OrVSw1MiIAAAgHIFli7dq1xwEOMmGyaXrlo0SI1cvLjjz+eYT0TJ05UU0MBBkZCAAJzT9++fVvatGmj1umoPp70n/TkZIl4d5b6u8iA/uJTqpRTjThORETZt3DhQjWtMo7hderUMc54oMnuuEFE5Jhsg0UHFsnSQ0tVtgGCBeii0KVCF72LRkROSvfgAaCLgrVuChgM0dS5c+cyXR+yD6ZMmaJulLtuffa5pFy8KN6hoVLs+ef1Lg4REeWhQoUKqa6B99xzz13d2XAsxoxKRJT3DkYeVGMbnI46rZbvr3C/jGk+Rgr7F9a7aETkxPJF8ICcU+rNm3J90SL1d+iwYeIZFKR3kYiIKA89/fTTKtsAXQk5YCKR/pLSkmTh/oWy7PAySTekq2yD8S3GS+fyd6Y0JyLKCQYPKNsi58+X9NhY8atVUwo+xvEkiIjczaFDh2Tfvn1SvXp1vYtC5PYORB5Q2QZno86q5QcqPiBjmo2RQv6F9C4aEbkIBg8oWxJPnJDbK1epv4uPHi0eTjI9GREROQ4GO7548SKDB0Q6SkxNVNkGy48sV9kGRf2LyviW46VTuU56F42IXAyDB5S9qRlnvoN5NaXAvfdKULNmeheJiIh08Oqrr8rQoUNl5MiRUrdu3bsGTKxXr55uZSNyB/sj9qtsg3PRd8YEe6jSQzK62Wgp6FdQ76IRkQti8ICyLG7jRonbskU8fHwkbOTreheHiIh0nDEJBgwYYLwP4x5wwESi3M82+GDfB/LpkU/FIAYpFlBMJrSYIB3LddS7aETkwhg8oCwxpKRIOLIORKRwnz7iW66c3kUiIiKdnD17p281EeWdfRH7ZMKWCcZsg0cqPyKjmo5itgER5ToGDyhLbq1cJclnzohX4cJS7OWX9C4OERHpqHz58noXgchtJKQmyPx98+XzI5+rbIOwgDCZ0HKCtC/bXu+iEZGbYPCA7JYWFSXX589Xf4cOeVW8ChTQu0hERERELm9P+B6VbXAh5oJafrTyozKy6UhmGxBRnmLwgOx2feEiFUDwq1pFCj3xhN7FISIiInJp8SnxKtvgi6Nf3Mk2CAyTiS0nSrsy7fQuGhG5IQYPyC7J587JzRUr1N9ho94QD29+dYiIiIhyy+5ru2XC1glyMeaiWn6symPyetPXJcQ3RO+iEZGb4hkg2SX83VkiKSkS1K6tBLdto3dxiIgoH8MsC+Hh4VKqVCm9i0LklNkG8/bOkxXH7ly0KR5YXCa1miRtSrP9RUT6YvCAMhW3fYfErlsn4uUlxd94Q+/iEBFRPnfo0CFp1KgRp2okyqJd13apsQ0uxV5Syz2q9pDXmrwmBXw5zhQR6Y/BA7LJgKtHM2aovwv36iV+lSvrXSQiIiIil8s2mLNnjnx1/Cu1XCKohExuOVlalW6ld9GIiIwYPCCbbq9eLUnHjolngQJS7NXBeheHiIiIyKXsuLpDJm6dKJdjL6vlx6s9Lq81fk2CfYP1LhoRUQYMHpBVabFxEjnvffV3sVcGiXfhwnoXiYiIiMglxKXEqWyDlcdXquWSQSVlcqvJ0rJUS72LRkRkEYMHZNWNjz6StOvXxbd8eSny1FN6F4eIiPKJf/75x+bjx48fz7OyEDmj7Ve3y8QtE+VK3BW13LNaTxnRZIQE+QTpXTQiIqsYPCCLki9dlpvLlqm/w0aNFA9fX72LRERE+USDBg3Ew8NDDAbDXY9p9+N/IsooNjlWZu+ZLV+f+FotlwoqJZNbT5YWJVvoXTQiokwxeEAWRc5+TwzJyRLYvLkE33OP3sUhIqJ85OzZs3oXgcjpbL2yVSZtnSRX466q5V7Ve8nwxsOZbUBEToPBA7pL/N59Ev3Lr7h8JMVHv8GrR0RElMHy5cvl9ddfl8DAQL2LQpTvxaXGyZRtU+TbU9+q5dLBpWVKqynSrGQzvYtGRJQlnll7Ork6Q3q6cWrGgj26i3/NmnoXiYiI8pnJkydLbGys3sUgyve2XNkiA7cMNAYOnqzxpKx+ZDUDB0TklBg8oAyif/5ZEv/5RzwDAyVs6FC9i0NERPmQpbEO8kpMTIwMGzZMypcvLwEBAdKqVSvZtWuXzdesX79eGjVqJH5+flKlShVZ9u+YPkS5JSY5Rk2/OGjdIIlMjJQywWVkSdcl8mbzNyXQhxk7ROScGDwgo/SEBIl4b7b6u+gLL4h3aKjeRSIionxKry5tzz//vPzxxx/y2WefycGDB6VLly7SuXNnuXz5stXxGR588EHp2LGj7N+/XwUesI7ffvstz8tO7mHTpU3y2PePyeqTq9Vyt3Ld5OuHvpamJZrqXTQiohzhmAdkdGPpUkm9dk28S5WUIs/207s4RESUj1WrVi3TAMLNmzcd+p4JCQny7bffyvfffy/t2rVT902aNEl+/PFHWbRokUybNu2u1yxevFgqVqwo7733nlquWbOmbN68WebMmSNdu3Z1aPnIvUUnR8u7u96VNafWqOWyBcrK5JaTpaxHWWYbEJFLYPCAlJTwCLnx8Sfq77DXXhNPf3+9i0RERPl83IOCBQvm6XumpqZKWlqa+Jsdo9B9AQEBS7Zt26YyE0whaIAMBGuSkpLUTRMdHa3+T09PV7fswOvQ3SO7r3dm7lD3TZc3yeRtkyUyIVI8xEOervG0DG44WPw8/SQyMtKl6+7un701rLt71t1Z629vWRk8ICVyzhwxJCRIQIMGEvLAA3oXh4iI8rnevXtLWFhYnr5ngQIFpGXLljJ16lSVQVC8eHH58ssvVYAAYxlYcu3aNfU8U1hGQACZDAg8mJs+fboKjpjDSWBiYmK2G2ZRUVGqQenp6V69Rl257jEpMbLo2CL548ofarl0YGl5vc7rUqdwHYm5GSNR6VEuW3d3/+wzw7q7Z92dtf4YT8geDB6QJBw6LFFr7qTYFR8zmlMzEhGRTXoeJzDWwYABA6R06dLi5eWlBkJ88sknZc+ePQ57jzFjxsiIESOMywg0lC1bVkJDQyUkJCTbjUlsN6zDWRqTjuKqdd9waYNM3T7VmG3wTM1n5JUGr0iAd4DL191e7lx/1t096+6s9TfP6LOGwQM3h4hY+Izp6u+Qhx+WgPr19S4SERHlc3rOtlC5cmXZsGGDxMXFqZP6kiVLSq9evaRSpUoWn1+iRAkJDw/PcB+WEQSwlHUAmJUBN3NoBOakIYjGZE7X4axcqe5RSVEyc+dM+fHMj2q5QkgFmdp6qjQIa+Dydc8Od64/6+6edXfG+ttbTgYP3FzM739Iwu494uHvL2EjhutdHCIicgL5oR9nUFCQut26dUvNnPDOO+9YfB66Ofzyyy8Z7sNsDbifKKv+vvC3TNk+Ra4nXBdPD0/pW6uvyjbw9+ZYUUTk+hg8cGPpyckSMWuW+rvogP7iU7Kk3kUiIiIn0L17d7uet3r1nanqHAmBAmQ+VK9eXU6dOiUjR46UGjVqSP/+/Y1dDjBt46effqqWX3rpJfnggw9k1KhRqrvDX3/9JatWrZKff/7Z4WUj13U78bbM2DVDfj7zs13ZBkRErojBAzd267PPJOXiRfEODZWizz2nd3GIiMhJ5PUsC6YwCBUCBJcuXZIiRYpIjx495K233hIfHx/1+NWrV+XChQvG52OaRgQKhg8fLvPmzZMyZcrIJ598wmkayW7rLqyTqdumyo3EGyrboF/tfjKo/iBmGxCR22HwwE2l3rgh1xctVn+HDh8unkFBeheJiIicxNKlS3V77549e6qbNcuWLbvrvg4dOsi+fftyuWTkam4l3pLpO6fLr2d/VcuVClZS2Qb1QuvpXTQiIl0weOCmIufPl/TYWPGvVUsKdntU7+IQERER5Rt/nv9TzaRwM/GmyjboX7u/vNzgZfHzunsgTSIid8HggRtKPHFCbq/6+r+pGZ1kFFAiIiKinLgae1VuJd2y+jimXFxyaImsPbdWLVcuWFmmtZkmdYrVycNSEhHlTwweuBkMMhUx8x0MlS0F7r1XAps21btIRERERHkSOHhozUOSnJac6XO9PLxkQJ0B8lL9l8TXyzdPykdElN8xeOBm4jZulLgtW8TDx0fCRr6ud3GIiIiI8gQyDuwJHJQJLiOz2s+S2sVq50m5iIiche756gsWLJAKFSqIv7+/NG/eXHbu3Gn1uYcPH1ajKuP5Hh4eMnfu3LueM2nSJPWY6Q1TOJGIISVFwmfMVH8X7ttHfMuV07tIRERERPnKjLYzGDggIspvwYOVK1fKiBEjZOLEibJ3716pX7++mjopIiLC4vPj4+OlUqVKMmPGDClRooTV9dauXVtN1aTdNm/enIu1cB63vlopyWfPileRIlLspZf0Lg4RERFRvuPjdWfaTyIiykfBg9mzZ8vAgQOlf//+UqtWLVm8eLEEBgbKkiVLLD6/adOm8u6770rv3r3Fz8/6aLfe3t4quKDdihUrJu4uLSpKrn/wgfo7dMir4lWggN5FIiIiIiIiIieh25gHycnJsmfPHhkzZozxPk9PT+ncubNs27YtR+s+efKklCpVSnWFaNmypUyfPl3K2UjRT0pKUjdNdHS0+j89PV3dsgOvw+CE2X29o0UuWKACCL5VqkhI9+65Wq78Vve85s71Z93ds+7uXn9nrLszlZXIUU7eOql3EYiInJpuwYPr169LWlqaFC9ePMP9WD527Fi214txE5YtWybVq1dXXRYmT54sbdu2lUOHDkkBK1fbEVzA88xFRkZKYmJithtmUVFRqkGJoIie0i5elOgvVqi/fV98QSJv3szV98tPddeDO9efdXfPurt7/Z2x7jExMXoXgSjPRCVFyby98+TrE3emqSYiouxxudkW7r//fuPf9erVU8GE8uXLy6pVq+S5556z+BpkP2DsBdPMg7Jly0poaKiEhIRkuzGJwRqxDr0bk5cnTxFJS5Ogdu2k9IMP5vr75ae668Gd68+6u2fd3b3+zlh3ZOYRuToE9H4886O8t/s9uZmYuxdOiIjcgW7BA4xD4OXlJeHh4Rnux7KtwRCzqlChQlKtWjU5deqU1edg/ARLYyigEZiThiAakzldR07Fbd8usX//LeLlJcXfGJVnZckPddeTO9efdXfPurt7/Z2t7s5STqLsOnP7jEzbMU12XdullisVrCQv139Zxm4Za3O6Rl8vXynsVzgPS0pE5Dx0Cx74+vpK48aNZd26ddKtWzfj1RssDx482GHvExsbK6dPn5Y+ffqIuzGkpUn49Bnq78IYZLJyZb2LRERERJRrElIT5KN/PpJlh5dJanqq+Hv5y4v1X5R+tfqpWRTqh9aXW0m3rL4egYOSwSXztMxERM5C124L6CrQr18/adKkiTRr1kzmzp0rcXFxavYF6Nu3r5QuXVqNSaANsnjkyBHj35cvX5b9+/dLcHCwVKlSRd3/+uuvy8MPP6y6Kly5ckVNA4kMhyeffFLcze3VqyXp+HHxDAmRYoNf0bs4RERERLlmw8UNMn3ndLkce1ktty/TXsY0HyOlg0sbn4PAAIMDREROGDzo1auXGpRwwoQJcu3aNWnQoIGsXbvWOIjihQsXMqRWIhjQsGFD4/KsWbPUrX379rJ+/Xp136VLl1Sg4MaNG6r/aZs2bWT79u3qb3eSFhsnkfPeV38XG/SyeBdmCh4RERG5nquxV2XGzhny18W/1HKJoBIyutlouafsPapLERERuciAieiiYK2bghYQ0FSoUEENfmPLV1995dDyOasbH30kadevi2/58lLkqaf0Lg4RERGRQ6Wkp8gXR76QhQcWqu4K3h7e0qdWH3mp/ksS6BOod/GIiFyO7sEDcrzkS5fl5rJl6u+wN0aJh6+v3kUiIiIicph9Eftk6vapcvLWSbXcMKyhjGsxTqoVrqZ30YiIXBaDBy4o4r1ZYkhOlsAWLSS4Y0e9i0NERETkELcTb8ucvXNk9cnVarmQXyEZ0XiEPFrlUfH04CwiRES5icEDFxO/d6/E/LoW84ZJ8dFvsK8fEREROb10Q7p8f+p7mb1nttxOuq3u6161uwxrNEwK+3NcJyKivMDggQsxpKcbp2Ys9HgP8a9RQ+8iEREREeXIiVsnZNr2aaqrAlQpVEUmtJyguioQEVHeYfDAhUT/9JMkHjwonoGBEjpkiN7FISIiIsq2+JR4WXxgsXx65FNJM6RJgHeADKo/SJ6u9bT4eProXTwiIrfD4IGLSE9IkIjZc9TfRV98UbzdbGpKIiIicg2YWQvTLmL6xWtx19R9ncp1UtMvYhpGIiLSB4MHLuLGkiWSeu2a+JQqJUWe7ad3cYiIiIiy7HLsZZm+Y7psuLRBLZcOLi1jmo2R9mXb6100IiK3x+CBC0gJD5cbn/xP/R32+mvi6eend5GIiIiI7JaSliLLjyyXDw98KIlpieLt6S3P1n5WXqj3guquQERE+mPwwAVEzpkrhoQECWjYUArcf7/exSEiIiKy265ru9SAiGeizqjlJsWbyPgW46VSoUp6F42IiEwweODkEg4dlqg1a9TfxceM5tSMRERE5BRuJNxQUy/+cPoHtVzEv4i83uR1eajSQ2zPEBHlQwweOPmAQuHTp6u/Qx5+WALq1dO7SEREREQ2pRvS5ZsT38i8vfMkOjlaPMRDHq/2uAxtNFQK+hXUu3hERGSFp7UHKP+L+e13SdizRzz8/SVsxHC9i0NERJSr0tLSZPz48VKxYkUJCAiQypUry9SpU1Uw3Zr169erq9jmt2vX7oziT3nr2M1j0ueXPjJ1+1QVOKhRpIZ8/sDnMqHlBAYOiIjyOWYeOKn0pCSJmDVL/V10wADxKVlS7yIRERHlqpkzZ8qiRYtk+fLlUrt2bdm9e7f0799fChYsKEOGDLH52uPHj0tISIhxOSwsLA9KTJr41Hh5d9e7suL4CpV5EOQTJIMbDJbeNXqrwRGJiCj/497aSd367DNJuXRJvMPCpOjzz+ldHCIioly3detWefTRR+XBBx9UyxUqVJAvv/xSdu7cmelrESwoVKhQHpSSTCEr5Pfzv8uMHTPkRtINdV/XCl1lZJORUjyouN7FIyKiLGDwwAml3rgh1xctVn+HDh8unoGBeheJiIgo17Vq1Uo++ugjOXHihFSrVk0OHDggmzdvltmzZ2f62gYNGkhSUpLUqVNHJk2aJK1bt7b6XDwPN010dLT6Pz09Xd2yA6/DiXR2X++MLsZclLd3vi1br2xVy2WDy8qY5mOkdak7294dtoU7fu6m3Ln+rLt71t1Z629vWRk8cEKR78+X9Lg48a9dWwo++ojexSEiIsoTo0ePVifyNWrUEC8vLzUGwltvvSVPP/201deULFlSFi9eLE2aNFEBgU8++UQ6dOggO3bskEaNGll8zfTp02Xy5Ml33R8ZGSmJiYnZbphFRUWpBqWnp2sPOZWcniwrz6yUL89+KSnpKeLj4SOPlnxU+tboKwHeARIRESHuwp0+d0vcuf6su3vW3VnrHxMTY9fzGDxwMonHT8jtr7/+b2pGJ/lCEhER5dSqVavkiy++kBUrVqgxD/bv3y/Dhg2TUqVKSb9+/Sy+pnr16upmmr1w+vRpmTNnjnz22WcWXzNmzBgZMWKEcRkBi7Jly0poaGiGcROy2pjEQI1Yh7M0JrNjx9Ud8tbOt+R89Hm13KJECxnddLQEJgW6fN3d+XO3xp3rz7q7Z92dtf7+/v52PY/BAyeC6FXEzJn4RkqBLl0ksEkTvYtERESUZ0aOHKmyD3r37q2W69atK+fPn1eZAtaCB5Y0a9ZMdXewxs/PT93MoRGYk4YgGpM5XUd+dT3huryz6x359eyvarlYQDEZ1XSU3Ffhvjvtl4gIl627O3/u9nDn+rPu7ll3Z6y/veVk8MCJxG7YIHFbt4qHj4+EjXxd7+IQERHlqfj4+LsaOOi+kNV+pchYQHcGyrm09DRZeXylzN83X2JTYsXTw1N6Ve8lrzZ8VQr4FlDPsTWVJhEROQ8GD5yEISVFIma+o/4u3LeP+JYtq3eRiIiI8tTDDz+sxjgoV66c6rawb98+NVjigAEDMnQ5uHz5snz66adqee7cuVKxYkX1fIxXgDEP/vrrL/n99991rIlrOHz9sEzZPkWO3DiilmsXrS3jW45X/xMRketh8MBJ3PpqpSSfPSteRYpIsZde0rs4REREeW7+/Pkyfvx4GTRokEqDx1gHL774okyYMMH4nKtXr8qFCxeMy8nJyfLaa6+pgEJgYKDUq1dP/vzzT+nYsaNOtXB+0cnRMn/vfJVxYBCDFPApIEMaDZEnqj0hXp5eehePiIhyCYMHTiDt9m2J/OAD9XfokFfFq8CdNEAiIiJ3UqBAAZVJgJs1y5Yty7A8atQodaOcQ/cDjGmAsQ1uJN5Q9z1Q8QEZ2XSkGuOAiIhcG4MHTiBy4UJJj4oSv6pVpdDjj+tdHCIiInIz56LOybQd09RsClAhpIKMbTFWWpRsoXfRiIgojzB4kM8lnTkrt1Z8qf4OG/2GeHjzIyMiIqK8kZiaKJ8c/ESWHFoiKekp4uvpKwPrDZQBdQaIr5ev3sUjIqI8xDPRfC7i3XdFUlMluH17CW7dWu/iEBERkZvYfHmzvL3jbbkYc1Etty7dWsY2GytlQzhoMxGRO2LwIB+L27ZNYv/+W8TbW8LeYH9NIiIiyn3hceFqXIPfz9+ZkSIsIEzeaPaG3Fv+XjV3ORERuScGD/IpQ1qahM+Yqf4u3Lu3+FWqpHeRiIiIyIWlpqfKl8e+lA/2fSDxqfHi6eEpT9d8Wl5p8IoE+QTpXTwiItIZgwf51O1vv5Wk48fFs2BBKfbKIL2LQ0RERC7sQOQBmbZ9mhy7eUwt1wutJ+NbjJcaRWroXTQiIsonGDzIh9JiYyVy3vvq79BBL4t34cJ6F4mIiIhcUFRSlMzdO1e+PfGtGMQgIb4hMqzxMOlRtYfKPCAiItIweJAP3fjwI0m7cUN8y5eXwk8+qXdxiIiIyMUYDAb58cyP8t7u9+Rm4k113yOVH5ERjUdI0YCiehePiIjyIQYP8pnkS5fl5vLl6m8Mkujhy2mQiIiIyHFO3z6tuijsDt+tlisXrCzjWoyTJiWa6F00IiLKxxg8yGci3pslhuRkCWzRQoI7dtS7OEREROQiElIT5MMDH8ryw8sl1ZAq/l7+8mL9F6VfrX7i4+Wjd/GIiCifY/AgH4nfs0difl0r4ukpxceM5nRIRERE5BAbLm6Qt3e8LVfirqjlDmU6yOjmo6V0cGm9i0ZERE6CwYN8wpCeLuHTZ6i/C/XoIf7Vq+tdJCIiInJyV2OvyoydM+Svi3+p5RJBJWRMszFyT7l79C4aERE5Gd2H0V2wYIFUqFBB/P39pXnz5rJz506rzz18+LD06NFDPR9X5efOnZvjdeYX0T/+KImHDolnUJCEDh2id3GIiIjIiaWkp8jSQ0vl0e8fVYEDbw9v6V+nv3z/6PcMHBARkfMFD1auXCkjRoyQiRMnyt69e6V+/frStWtXiYiIsPj8+Ph4qVSpksyYMUNKlCjhkHXmB+nx8RIxe476u+iLL4p3sWJ6F4mIiIic1N7wvdLzx54ye89sNc5Bo7BGsurhVWomhUCfQL2LR0RETkrX4MHs2bNl4MCB0r9/f6lVq5YsXrxYAgMDZcmSJRaf37RpU3n33Xeld+/e4ufn55B15gc3liyV1PBw8SldWor066t3cYiIiMgJ3Uq8JRO2TJB+a/vJqdunpJBfIZnSaoosvW+pVC1cVe/iERGRk9NtzIPk5GTZs2ePjBkzxnifp6endO7cWbZt25an60xKSlI3TXR0tPo/PT1d3bIDr8Mcypm9PiU8XG7873/q72IjRoj4+GT7PfMLe+vuqty5/qy7e9bd3evvjHV3prJS5tIN6bLm1BqVaRCVFKXu61G1hwxrNEwK+RfSu3hEROQidAseXL9+XdLS0qR48eIZ7sfysWPH8nSd06dPl8mTJ991f2RkpCQmJma7YRYVFaUalAhgWBM3Y4YYEhLEq04dSWjUUBLzcfcKR9fdVblz/Vl396y7u9ffGeseExOjdxHIQU7cOiFTt02V/ZH71TIyDMa3GC8NwxrqXTQiInIxnG1BRGUqYJwE08yDsmXLSmhoqISEhGS7MYlBHbEOa41JDJB467ff1d+lx4+TALOgh7Oyp+6uzJ3rz7q7Z93dvf7OWHcMKEzOLT4lXhbuXyifH/1c0gxpEuAdIK80eEWeqvmU+Hj66F08IiJyQboFD4oVKyZeXl4SHh6e4X4sWxsMMbfWifETLI2hgEZgThqCaExaWweuUEXMfEf9HfLIwxJUv764Elt1dwfuXH/W3T3r7u71d7a6O0s5SSy2H/668JdM3zldwuPvtHc6l+ssbzR7Q03DSERElFt0az34+vpK48aNZd26dRmu3mC5ZcuW+WaduSXmt98lYc8e8fD3lzCTrAciIiIiSy7FXJLBfw2WYeuHqcBB6eDSsqDTApnTcQ4DB0RE5NrdFtBVoF+/ftKkSRNp1qyZzJ07V+Li4tRMCdC3b18pXbq0GpNAGxDxyJEjxr8vX74s+/fvl+DgYKlSpYpd68wP0pOSJGLWLPV30QEDxCebmRZERETk+lLSUmT5keXy4YEPJTEtUbw9vaV/7f4ysN5A1V2BiIjI5YMHvXr1UoMSTpgwQa5duyYNGjSQtWvXGgc8vHDhQobUyitXrkjDhv8NADRr1ix1a9++vaxfv96udeYHNz/9VFIuXRLvsDAp+vxzeheHiIiI8qld13bJtO3T5EzUGbXctERTGdd8nFQqVEnvohERkZvRfcDEwYMHq5slWkBAU6FCBdXXLyfr1Fvq9etyY/GH6u/QEcPFMzBQ7yIRERFRPnMj4Ya8t/s9+fHMj2q5iH8Reb3J6/JQpYfUGBtERERuFzxwN5Hvz5f0uDjxr1NHCj7yiN7FISIionwk3ZAu35z4RubunSsxyTHiIR7yRLUnZEijIVLQr6DexSMiIjfG4EEeSjx+Qm5/8436u/joN8SDo10TERHRv47eOKq6KPxz/R+1XLNITRnXYpzUC62nd9GIiIgYPMhthrQ0idu1W1IjI+Tm0qWY/kEKdO0qgU2a6F00IiIiyiNX467KmegzcsPrhnh4Zux2kJCSIN+f/l7dkHkQ5BMkrzZ8VXpV76UGRyQiIsoPeETKRckbN8qZBQslNfzOPMyawObNdSsTERGRs0pLS5NJkybJ559/rgZFLlWqlDz77LMybtw4m+MAYAwlzMZ0+PBhKVu2rHo+XpdXrsZelUfWPCLJ6cmZPrdrha4yqukoCQsMy5OyERER2YvBg1wS88cfEjdhosXHwqdOFe9iRSWkS5c8LxcREZGzmjlzpixatEiWL18utWvXlt27d6upmAsWLChDhgyx+JqzZ8/Kgw8+KC+99JJ88cUXsm7dOnn++eelZMmS0rVr1zwp962kW3YFDsY2Gyu9a/bOkzIRERFlFYMHudRVIeLt6TafE/72dCnQqZN4eHnlWbmIiIic2datW+XRRx9VwQBtFqYvv/xSdu7cafU1ixcvlooVK8p7772nlmvWrCmbN2+WOXPm5FnwwF71wji2ARER5V8MHuSC+N177uqqkIHBIKnXrqnnBTVvlpdFIyIiclqtWrWSjz76SE6cOCHVqlWTAwcOqEDA7Nmzrb5m27Zt0rlz5wz3IWgwbNgwq69JSkpSN010dLT6Pz09Xd2yypBusPt52Vl/foc6YaptV6xbZty57u5ef9bdPevurPW3t6wMHuSC1MhIhz6PiIiIREaPHq1O5GvUqCFeXl5qDIS33npLnn76aauvwdgIxYsXz3AflrGehIQECQgIuOs106dPl8mTJ991f2RkpCQmJma53Dejb9r3vFs3JSItQlwNGqVRUVGqMe3pZjNNuXPd3b3+rLt71t1Z6x8TE2PX8xg8yAXeoaEOfR4RERGJrFq1So1bsGLFCjXmwf79+1UGAQZO7Nevn8PeZ8yYMWqARQ0CDRhoMTQ0VEJCQrK8PsywYI8ihYtIWNEwl2xIY0BLbD9naUg7ijvX3d3rz7q7Z92dtf7+/v52PY/Bg1wQ2KSxeBcvbr3rgoeHehzPIyIiIvuMHDlSZR/07n1nUMG6devK+fPnVaaAteBBiRIlJNzseIxlBAEsZR2An5+fuplDIzA7DUHzqRltPc9ZGppZhYZ0drefs3Pnurt7/Vl396y7M9bf3nI6R22cDAZBDHtzzL8LZg2Gf5eLvzmGgyUSERFlQXx8/F0NHHRfsNVXs2XLlmqGBVN//PGHup+IiIjsx+BBLilw770SNGWyeIdlTD9ExkHpeXM5TSMREVEWPfzww2qMg59//lnOnTsn3333nRos8bHHHsvQ5aBv377GZUzReObMGRk1apQcO3ZMFi5cqLo/DB8+PM/KXdivsPh6+tp8jq+Xr3oeERFRfsVuC7nIt107Kf3YY5K4d58aHBFjHKCrAjMOiIiIsm7+/Pkyfvx4GTRokERERKixDl588UWZMGGC8TlXr16VCxcuGJcxTSOCDQgWzJs3T8qUKSOffPJJnk7TWDK4pPzQ7Qc5c/WMGtfAUjcGBA7wPCIiovyKwYNchkABp2MkIiLKuQIFCsjcuXPVzZply5bddV+HDh1k3759oqeSQSXFK8RLDYjoLH1giYiITPHoRUREREREREQ2MXhARERERERERDYxeEBERERERERENjF4QEREREREREQ2MXhARERERERERDZxtgULDAaD+j86Ojrb60hPT5eYmBjx9/d3u1GV3bnu7l5/1t096+7u9XfGumvHN+14R7axXZAzrLt71t3d68+6u2fdXb1dwOCBBfiwoWzZsnoXhYiIKFePdwULFtS7GPke2wVEROQOMmsXeBh42cFitOjKlStqPmkPD4//t3cewE0cbRhewHQwvRkwYMCE3nsNzZShhVBCMyWAaaGa+oeWAgFCQggQCAFChtBrAiSEYlrovfc+9GLAdNh/3s3c5SRLsuzYsqR7nxlhnW7vtN/uavdl79tvYzx7A5Fx7do14evrK8yEmW03u/203Zy2m91+T7QdQz8Egp+fn8c8FYlPqAv+G7TdnLab3X7abk7bvV0X0PPABiiwHDlyxMq90GA8pdHENma23ez203Zz2m52+z3NdnocOA91QexA281pu9ntp+3mtN1bdQEfNxBCCCGEEEIIIcQhnDwghBBCCCGEEEKIQzh5EEckTZpUjBo1Sv01G2a23ez203Zz2m52+81sO3EeM7cT2m5O281uP203p+3ebj8DJhJCCCGEEEIIIcQh9DwghBBCCCGEEEKIQzh5QAghhBBCCCGEEIdw8oAQQgghhBBCCCEO4eQBIYQQQgghhBBCHMLJgzhg2rRpInfu3CJZsmSifPnyYu/evcLTGD16tEiQIIHF67333tPPv3jxQvTq1UtkyJBBpEqVSjRv3lzcvn3b4h5Xr14VDRs2FClSpBCZM2cWoaGh4s2bNxZpwsLCRKlSpVQ00nz58ol58+YJV7Nt2zbRqFEj4efnp+xctWqVxXnEFB05cqTIli2bSJ48uahdu7Y4d+6cRZoHDx6Itm3bCl9fX5E2bVrRpUsX8fTpU4s0R48eFVWrVlXtImfOnGLChAmR8rJ06VJVzkhTtGhRsW7dOhHf9nfs2DFSW6hXr57H2z9u3DhRtmxZkTp1atU+mzZtKs6cOWORxpXt3NX9hjP216hRI1Ldh4SEeLz9M2bMEMWKFVPtFa+KFSuK9evXm6LeSfzg6fVsJk1gdl1gVk1gdl1gZk0AqAuiAXZbILHHokWLZJIkSeScOXPkiRMnZNeuXWXatGnl7du3pScxatQoWbhwYXnz5k39dffuXf18SEiIzJkzp9y0aZPcv3+/rFChgqxUqZJ+/s2bN7JIkSKydu3a8tChQ3LdunUyY8aMctiwYXqaixcvyhQpUsgBAwbIkydPyqlTp8pEiRLJP/74w6W2Im8jRoyQK1aswM4jcuXKlRbnx48fL9OkSSNXrVoljxw5Ihs3bizz5Mkjnz9/rqepV6+eLF68uNy9e7fcvn27zJcvn/zoo4/08+Hh4TJLliyybdu28vjx43LhwoUyefLkcubMmXqanTt3KvsnTJigyuN///ufTJw4sTx27Fi82h8cHKzsM7aFBw8eWKTxRPuDgoLk3LlzVX4OHz4sGzRoIP39/eXTp09d3s7jo99wxv7q1aurvBjrHnXp6favWbNGrl27Vp49e1aeOXNGDh8+XLU1lIW31ztxPd5Qz2bSBGbXBWbVBGbXBWbWBIC6wHk4eRDLlCtXTvbq1Us/fvv2rfTz85Pjxo2TngSEAjp+Wzx69Ej9oJYuXap/durUKTXI7Nq1Sx3jR5MwYUJ569YtPc2MGTOkr6+vfPnypToePHiwEiNGWrVqpTqw+MJ6oHz37p3MmjWrnDhxooX9SZMmVYMdQAeA6/bt26enWb9+vUyQIIG8ceOGOp4+fbpMly6dbjsYMmSILFCggH7csmVL2bBhQ4v8lC9fXnbv3l26CntCoUmTJnav8Rb779y5o+zYunWry9u5O/Qb1vZrQqFv3752r/Em+9E+Z8+ebbp6J3GPN9SzWTWB2XWBmTWB2XWB2TUBoC6wDZctxCKvXr0SBw4cUO5rGgkTJlTHu3btEp4GXPDgthYQEKDcz+COA2Dj69evLeyEW5m/v79uJ/7CxSxLlix6mqCgIPH48WNx4sQJPY3xHloadyqrS5cuiVu3blnkM02aNMqNyGgr3PLKlCmjp0F61P2ePXv0NNWqVRNJkiSxsBUuYQ8fPnT78oCbFVywChQoIHr06CHu37+vn/MW+8PDw9Xf9OnTu7Sdu0u/YW2/xoIFC0TGjBlFkSJFxLBhw8SzZ8/0c95g/9u3b8WiRYtERESEclM0W72TuMWb6pma4B+oC8yhCcyuC8yqCQB1gWN8ojhPosG9e/dUgzM2HIDj06dPC08CgyDW4WBguHnzphgzZoxam3b8+HE1aKLDx+BgbSfOAfy1VQ7aOUdp8EN7/vy5WkcY32h5tZVPox0YRI34+PioDteYJk+ePJHuoZ1Lly6d3fLQ7hFfYC3jBx98oPJ/4cIFMXz4cFG/fn3VkSVKlMgr7H/37p3o16+fqFy5shoQtXy5op1DKMV3v2HLftCmTRuRK1cu9R8GrE8dMmSIEncrVqxwaJt2zp3tP3bsmBIFWMeI9YsrV64UhQoVEocPHzZNvZO4x1t0ATXBv5hdF5hBE5hdF5hREwDqAufg5AGxCQYCDQQQgXBAh7FkyRK3GcCJa2jdurX+HrOqaA958+ZVTx5q1aolvAEEwYEI3rFjhzAj9uzv1q2bRd0jOBjqHIIRbcCTwX+CIAjwdGXZsmUiODhYbN26Nb6zRYhbQk1AzKQJzK4LzKgJAHWBc3DZQiwCNx7MulpH38Rx1qxZhSeD2bbAwEBx/vx5ZQtcax49emTXTvy1VQ7aOUdpEOXUXcSIlldHdYq/d+7csTiP6KqINhwb5eFubQcuq2jraAveYH/v3r3F77//LrZs2SJy5Mihf+6qdh7f/YY9+22B/zAAY917qv14ioBIx6VLl1ZRposXLy6mTJlimnonrsFb69msmgBQF3i3JjC7LjCrJgDUBc7ByYNYbnRocJs2bbJw/cEx3GA8GWyxg5lFzDLCxsSJE1vYCbclrH/U7MRfuP8YB5C//vpL/UDgAqSlMd5DS+NOZQW3OvxgjfmEexHW7RltRYeCdUoamzdvVnWvdaxIg+2PsGbKaCtmOeGe5ynlAa5fv67WN6IteLL9iAWFQRJuacivtQulq9p5fPUbUdlvC8zIA2Pde6r91uA7X7586fX1TlyLt9azWTUBoC7wTk1gdl1ATRAZ6gI72AmkSGIItthAxN158+apiLPdunVTW2wYo296AgMHDpRhYWHy0qVLarscbD2CLUcQfVXbsgRbuGzevFltWVKxYkX1st6ypG7dumrLF2xDkilTJptbloSGhqqopdOmTYuXbZmePHmitlXBCz+JyZMnq/dXrlzRt2RCHa5evVoePXpURRm2tSVTyZIl5Z49e+SOHTtk/vz5LbYlQqRWbEvUvn17te0L2glst96WyMfHR06aNEmVB6Jbu2KrRkf249ygQYNUNFm0hY0bN8pSpUop+168eOHR9vfo0UNttYV2btx26NmzZ3oaV7Xz+Og3orL//PnzcuzYscpu1D3af0BAgKxWrZrH2z906FAVQRp24TeNY0QC37Bhg9fXO3E93lDPZtIEZtcFZtUEZtcFZtYEgLrAeTh5EAdg3040MOzTiS03sM+tp4GtQ7Jly6ZsyJ49uzpGx6GBAbJnz55qGxP8EJo1a6Y6GSOXL1+W9evXV3v3QmRAfLx+/doizZYtW2SJEiXU96ATwh6zrgZ5wABp/cJ2RNq2TJ9++qka6PCDrlWrltoD1sj9+/fVwJgqVSq1LUunTp3UIGsEe0FXqVJF3QNlCvFhzZIlS2RgYKAqD2zngj1n49N+DBroCNEBYtDOlSuX2nPWuhPzRPtt2YyXsQ26sp27ut+Iyv6rV68qUZA+fXpVZ9inGwOecU9nT7W/c+fOqi3ju9C28ZvWBIK31zuJHzy9ns2kCcyuC8yqCcyuC8ysCQB1gfMkwD/2vBIIIYQQQgghhBBCGPOAEEIIIYQQQgghDuHkASGEEEIIIYQQQhzCyQNCCCGEEEIIIYQ4hJMHhBBCCCGEEEIIcQgnDwghhBBCCCGEEOIQTh4QQgghhBBCCCHEIZw8IIQQQgghhBBCiEM4eUDinRo1aoh+/frFdzbcko4dO4qmTZvGdzbcnmrVqolff/31P98nQYIEYtWqVbGSJ+IcQ4cOFX369InvbBBC3AjqAvtQFzgHdYHnQl3g3nDygBDidsybN0+kTZvWqbRr1qwRt2/fFq1bt9Y/42DvOQwaNEj8/PPP4uLFi/GdFUIIIW4KdYF5oC5wbzh5QIiLefXqlXB3PCGPGt99953o1KmTSJiQ3ZkntomMGTOKoKAgMWPGjDi5PyGEuDueMOZ6Qh41qAtcA3WBOeGvirgdDx8+FB06dBDp0qUTKVKkEPXr1xfnzp2LNPv8559/ioIFC4pUqVKJevXqiZs3b+pp3rx5Iz755BOVLkOGDGLIkCEiODjYwtUvd+7c4ttvv7X47hIlSojRo0frx48ePRIff/yxyJQpk/D19RU1a9YUR44cceg+CFdLuFxq4H3v3r3V51qHaIu3b9+KAQMG6HkePHiwkFJapHEmz9ZoeRwzZoxuR0hIiEWnby+PW7duFeXKlRNJkyYV2bJlU65kKFvjdXAtw3WoryxZsogff/xRREREqIE7derUIl++fGL9+vX6NWFhYeoJwNq1a0WxYsVEsmTJRIUKFcTx48f187g2PDxcpcPLnn13794VmzdvFo0aNbIoI9CsWTN1rXYMMBDlzZtXJEmSRBQoUED88ssvwhGjRo1Sdh89elQd79ixQ1StWlUkT55c5MyZU7Ux2Gr87i+//FJ07txZ2e7v7y9mzZqln0eZo5xxT9idK1cuMW7cOOEsaCNdunQRefLkUXmADVOmTIlxfeOVJk0aVeeffvqpRXuDLZ999pn6LeIe3bp1U58vX75cFC5cWLUJpPn666/1a8aOHSv8/PzE/fv39c8aNmwo3n//ffHu3Tu7dqH+Fi1a5HQ5EELMBXUBdQF1gW2oC4ir4eQBcTvQye3fv1+5ne3atUt1XA0aNBCvX7/W0zx79kxMmjRJdfLbtm0TV69eVW5OGl999ZVYsGCBmDt3rti5c6d4/PhxjNzVWrRoIe7cuaMGuQMHDohSpUqJWrVqiQcPHkTrPnC/wsCEvPzwww8206CzhQCaM2eOGozwHStXrhSxwaZNm8SpU6fUALxw4UKxYsUKNYg4yuONGzdUuZctW1YJIwywP/30k/j8888jXYdBZu/evUow9OjRQ5VbpUqVxMGDB0XdunVF+/btVZ0ZCQ0NVTbv27dPDWYYKFDHuA5CCAMThB9exro1gnKCkIRY1MD9AOoe12rHKMu+ffuKgQMHKkHSvXt3JUa2bNkS6b5oc7Bl/vz5Yvv27UrMXLhwQYnR5s2bK9GwePFi9f0YaI3ApjJlyohDhw6Jnj17qvI4c+aM/jQE7XrJkiXqM7RRo4iJCgy0OXLkEEuXLhUnT54UI0eOFMOHD1f3i0l9+/j4qHqD0Jg8ebKYPXu2RRr8xooXL65sgYjAb6Bly5bKFfTYsWNKvOFztFswYsQIZQ+ENZg2bZr4+++/1Xc5egIEIXr9+nVx+fJlp8uCEGIeqAuoC6gLbENdQFyOJCSeqV69uuzbt696f/bsWUxxyp07d+rn7927J5MnTy6XLFmijufOnavSnD9/Xk8zbdo0mSVLFv0Y7ydOnKgfv3nzRvr7+8smTZron+XKlUt+8803FnkpXry4HDVqlHq/fft26evrK1+8eGGRJm/evHLmzJnqfXBwsMU9AWyBTUb7SpYsGWU5ZMuWTU6YMEE/fv36tcyRI0e08mwL5DF9+vQyIiJC/2zGjBkyVapU8u3bt3bzOHz4cFmgQAH57t07i3K2vq5KlSoW5ZwyZUrZvn17/bObN2+q+tq1a5c63rJlizpetGiRnub+/fuqjhcvXqzXcZo0aaIsM5RFQEBApM9x/5UrV1p8VqlSJdm1a1eLz1q0aCEbNGhgcd3SpUtlmzZtZMGCBeX169f1c126dJHdunWzuB5tJGHChPL58+d6/bRr104/j7LLnDmzKm/Qp08fWbNmTYsy/a/06tVLNm/ePNr1DfuM+RgyZIj6TAO2NG3a1OK7UC516tSx+Cw0NFQWKlRIP75w4YJMnTq1uh/qdMGCBVHaEB4erso+LCws2vYTQrwP6oJ/oC6gLogJ1AUkLqHnAXErMCuKWc/y5cvrn8FVD25YOKeBWWW4mWnA3QtPAgDc2hAoB7OWGokSJRKlS5eOVl4wq/706VP1/XCB1F6XLl1Ss83RIarvRp4xG260G+WAmerYALPEKDONihUrKtuuXbtmN48ob6SDi59G5cqV1XWYDdbA7LuxnFFeRYsW1T+DyyLQ6seYB4306dNHqmNneP78uXLzcwbcG/k3gmPr7+zfv7/Ys2ePenKVPXt2i/aAmXRjW4AbJ2b90SZslQfKLmvWrLrteHp2+PBhZStcGzds2CCiC2btUVd4KoM8wP0RT9iiW99wCTXWLdLADRgukBrW7c9eGRqvCwgIUE8m8JSvcePGok2bNlHaBFdLYP0UihBCqAuoC6IDdQF1AYlbfOL4/oTECYkTJ7Y4RmdnvQ4wKuAuZX2N0QUSnSrEB1y8rNEi/kZ1D42UKVNGK28xzfN/IaZ5tFUXxs+0gcjR2raYArdIrIWNTerUqaNc+rB2tm3bthbtAS6NGNytwRpGR+Wh2Q73VggKuLtu3LhRufrVrl1bLFu2zKm8Yf0fXDXhAolBHesnJ06cqERNXBDTNgGBBcEId0OshYXgdYTm7gvhQwghMYG6wPH3xQTqgn+gLvgX6gJCzwPiVmCNGjoVY6eHICtYB1aoUCGn7oFAL5jV1ta0Acx+Yp2dEXRIxmBKWP9onClGh37r1i3VwSG4j/GFwcnWPQBmkKML8gxBYrQb5YC1ZNHJsz0wO47ZeI3du3er2WkE93FUF9raUg2se8TAhPV1/xXkQQMD/dmzZ/U1ilhjaZzptkfJkiVVHVkLBQzU1tfj3si/ERxbtyvMimNvaKzPMwbrQXvAekLrtoAX8ussWLPZqlUrFUAK6yMRaMjZtbLIL9Z+Ys0kbMd323ra5Ux9WwsLpMmfP78a3O1hrwwDAwP162AT1lJCXOPJB4IrRQXWmqLOEHCJEEKMUBdQFwDqAttQFxBXw8kD4lagk2rSpIno2rWrCjqDzq5du3bKTQyfOwuC2iBa7erVq5XAQEAcDCRGdyxESEZgJQS+QZAXRF02dpCY+cUsLiLUwo0Ms6UI8oLgLwjcpN0D7xFABy5aiMKrRQeOLsjj+PHjVQCn06dPq4EAUZ2NRJVneyCiLqLxYpBbt26dyicC+jgKVoPvhzsbyhL5QVniOkR+jo3tjxCBFwF8UF5w24Pw0iJUI7gOZvRx/t69e3bd1jBQ4jrrgQvX41qjgEAgJrgXIsAT6gqBgDCY2Qq6hIjMKGcETtJm/xGZG/WPcoMQxD1QJtaBkRyB78TTC5QnRBECHMF90dm9q/H7QHvD0w9cj6BERjEcnfrGAI66xO8DeZo6dapqg45AUCmUKwZ+fD8CHn3//fd6GcJtFYGg4JpYpUoVFZwKUaaNghBRmocNG2ZxX7RnLVo1IYQYoS6gLgDUBbahLiAuJ04jKhASzcBI4MGDByqwDgLjILBKUFCQCpikYStoDoLgGJszggr17t1bBTZKly6dCtKCIDitW7e2CMbSqlUrlSZnzpxy3rx5kYIMPX78WAWz8fPzk4kTJ1bp2rZtK69evaqnGTlypArEhDz1799ffa91YCSjffZAnpEO+UmbNq0cMGCA7NChg0VgJGfybI0WvAn5zJAhgwqQgwBBxoBP9vKIQDVly5aVSZIkkVmzZlXliHw6us5W8CZjoCItMNJvv/0mCxcurO5drlw5eeTIEYtrQkJCVH6R1pF9gwcPtqhXsGbNGpkvXz7p4+Oj8qMxffp0FUgJdRkYGCjnz59vN58AgZqSJUsmly9fro737t2rAgOhDBEAqlixYvKLL75waLuxfmbNmiVLlCihrkUd1qpVSx48eNCiroxtxxrUWceOHVVbQxvp0aOHHDp0qPqO6NZ3z549VRlrvxEEwjIGSrJlC1i2bJkKhIQyRLAxLQAZroU9+L0a74PfD4KJPXnyRP9u5NEIAnAtXLjQrt2EEHNBXfBvnqkL/oW6IDLUBcTVJMA/rp+yIMS1YG0ZXKuwlswZdylvArP3eFIRky2p4gK4rWF/X8z8Ozuz7gg8RYBbG9xPsT+yJ1O9enVVNo72546N+sZ+ztgH3Hpv8PgA6zzx5ALbXEW1BpIQQmIL6gLqAk+AuoC6wN1gjRCv5MqVK8qlEJ3uy5cvlQsV1gA6E+GVeBZw78M+03C382SRgMjaWKe4du1aYSYiIiKUGyMFAiEkLqEuMA/UBZ4NdYF7w1ohXgnWcGEdG9ZcwbmmSJEiKoqtFniHeBfamkhPBsGxjFtdmYUPP/wwvrNACDEB1AXmgrrAc6EucG+4bIEQQgghhBBCCCEO4W4LhBBCCCGEEEIIcQgnDwghhBBCCCGEEOIQTh4QQgghhBBCCCHEIZw8IIQQQgghhBBCiEM4eUAIIYQQQgghhBCHcPKAEEIIIYQQQgghDuHkASGEEEIIIYQQQhzCyQNCCCGEEEIIIYQ4hJMHhBBCCCGEEEIIEY74PwHs5bUdgyqOAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1050x420 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if vllm_rows:\n",
+    "    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10.5, 4.2))\n",
+    "    xs = [r[0] for r in vllm_rows]\n",
+    "    ax1.plot(xs, [r[1] for r in vllm_rows], \"o-\", color=\"tab:red\")\n",
+    "    ax1.set_xlabel(\"longueur du prompt (tokens, approx.)\")\n",
+    "    ax1.set_ylabel(\"TTFT (s)\")\n",
+    "    ax1.set_title(\"Time-to-first-token : le coût du PRÉFILL\")\n",
+    "    ax1.grid(alpha=0.3)\n",
+    "\n",
+    "    ax2.plot(xs, [r[2] * 1000 for r in vllm_rows], \"s-\", color=\"tab:green\")\n",
+    "    ax2.set_xlabel(\"longueur du prompt (tokens, approx.)\")\n",
+    "    ax2.set_ylabel(\"ITL moyenne (ms)\")\n",
+    "    ax2.set_title(\"Inter-token latency : le DÉCODAGE avec KV-cache\")\n",
+    "    ax2.grid(alpha=0.3)\n",
+    "    fig.suptitle(f\"vLLM self-hosted — {MODEL_ID} (mesures streaming réelles)\", y=1.02)\n",
+    "    fig.tight_layout()\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b143f6b8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003542,
+     "end_time": "2026-08-25T21:47:47.776107",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:47.772565",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture — le pont.** À gauche, le TTFT grimpe quand le prompt s'allonge : c'est le **préfill**, la même montée du mur que notre courbe naïf×contexte de la partie 3. À droite, l'ITL reste **à peu près constante** : chaque jeton supplémentaire ne paie qu'un pas de décodage incrémental contre le cache — indépendant de la longueur du prompt, exactement la branche « décodage seul » de notre courbe de débit. Quand vous lirez les métriques d'un serveur vLLM en charge, vous saurez désormais **quoi** elles mesurent : un TTFT qui dérive attaque la capacité de préfill ; une ITL qui dérive attaque le décodage (ou la mémoire du cache).\n",
+    "\n",
+    "## 6. Ouverture : le décodage spéculatif, en cinq lignes\n",
+    "\n",
+    "Un petit modèle *draft* propose k tokens à la suite (rapides) ; le gros modèle les **vérifie en un seul forward** sur les k positions à la fois (le préfill sait traiter plusieurs positions d'un coup, le décodage incrémental non) ; on accepte le plus long préfixe que le gros modèle confirme, on rejette le reste et on repart de là. Espoir : payer k pas de décodage au prix d'un forward groupé — rentable tant que le petit modèle devine assez bien.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Exercice 2 — tronquer le cache (fenêtre glissante)\n",
+    "\n",
+    "**Contexte.** Un service doit borner la mémoire : on ne garde que les `max_len` **dernières** positions du cache (fenêtre glissante). Le modèle continue de générer contre cette fenêtre.\n",
+    "\n",
+    "**Objectif.** Écrire `trim_cache(caches, max_len)` qui renvoie un nouveau cache où chaque tenseur K/V ne conserve que les dernières `max_len` positions (dimension 2 : `(B, nh, T, hd)`).\n",
+    "\n",
+    "**Indices.** Le cache est une liste de tuples `(k, v)` par couche. Le slicing torch sur la dimension 2 fait l'affaire ; ne pas modifier les tenseurs en place (le cache est partagé entre les pas).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "929363d4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:47.783677Z",
+     "iopub.status.busy": "2026-08-25T21:47:47.783374Z",
+     "iopub.status.idle": "2026-08-25T21:47:47.800788Z",
+     "shell.execute_reply": "2026-08-25T21:47:47.799751Z"
+    },
+    "papermill": {
+     "duration": 0.022467,
+     "end_time": "2026-08-25T21:47:47.801833",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:47.779366",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 à compléter (trim_cache renvoie None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def trim_cache(caches, max_len):\n",
+    "    \"\"\"Renvoie un nouveau cache ne gardant que les max_len dernières positions.\n",
+    "\n",
+    "    caches : liste de tuples (k, v) par couche, chacun (B, n_head, T, head_dim).\n",
+    "    # Indice : k[:, :, -max_len:, :] garde les max_len dernières positions.\n",
+    "    \"\"\"\n",
+    "    return None  # TODO étudiant\n",
+    "\n",
+    "\n",
+    "# --- auto-vérification ---\n",
+    "torch.manual_seed(5)\n",
+    "_, demo_caches = model(torch.randint(0, CFG.vocab_size, (1, 300)))\n",
+    "trimmed = trim_cache(demo_caches, 128)\n",
+    "if trimmed is None:\n",
+    "    print(\"Exercice 2 à compléter (trim_cache renvoie None)\")\n",
+    "else:\n",
+    "    ok_shapes = all(k.shape[2] == 128 and v.shape[2] == 128 for k, v in trimmed)\n",
+    "    ok_contenu = torch.equal(trimmed[0][0], demo_caches[0][0][:, :, -128:, :])\n",
+    "    print(f\"formes : {'OK' if ok_shapes else 'KO'} | contenu = dernières positions : \"\n",
+    "          f\"{'OK' if ok_contenu else 'KO'}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74b8c3fa",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003215,
+     "end_time": "2026-08-25T21:47:47.808680",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:47.805465",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "### Exercice 3 — accepter ou rejeter (le cœur du spéculatif)\n",
+    "\n",
+    "**Contexte.** Le petit modèle a proposé les tokens `[t1, t2, t3]`. Le gros modèle, consulté en un seul forward groupé, produit les logits `L1, L2, L3` pour ces trois positions. Règle d'acceptation gloutonne : on accepte `t1` si `argmax(L1) == t1` ; puis `t2` si `argmax(L2) == t2` ; etc. Au premier désaccord on s'arrête (le token correct est déjà connu : l'argmax du désaccord).\n",
+    "\n",
+    "**Objectif.** Écrire `accepted_prefix(draft_tokens, logits_per_pos)` qui renvoie le nombre de tokens acceptés avant le premier rejet.\n",
+    "\n",
+    "**Indices.** `torch.equal` sur des tenseurs 0-d fait l'affaire ; une boucle avec `break` est parfaitement lisible ici.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c1cddaf3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-25T21:47:47.816072Z",
+     "iopub.status.busy": "2026-08-25T21:47:47.815712Z",
+     "iopub.status.idle": "2026-08-25T21:47:47.820184Z",
+     "shell.execute_reply": "2026-08-25T21:47:47.819714Z"
+    },
+    "papermill": {
+     "duration": 0.009152,
+     "end_time": "2026-08-25T21:47:47.820958",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:47.811806",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 à compléter (accepted_prefix renvoie None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def accepted_prefix(draft_tokens, logits_per_pos):\n",
+    "    \"\"\"Nombre de tokens du draft acceptés avant le premier désaccord glouton.\n",
+    "\n",
+    "    draft_tokens   : LongTensor (k) — la proposition du petit modèle\n",
+    "    logits_per_pos : FloatTensor (k, vocab) — les logits du gros modèle\n",
+    "    # Étape 1 : pour chaque position, l'argmax du gros modèle est sa confirmation\n",
+    "    # Étape 2 : accepter tant que les deux coïncident, s'arrêter au premier écart\n",
+    "    \"\"\"\n",
+    "    return None  # TODO étudiant\n",
+    "\n",
+    "\n",
+    "# --- auto-vérification ---\n",
+    "draft = torch.tensor([17, 4, 92, 55])\n",
+    "logits = torch.zeros(4, CFG.vocab_size)\n",
+    "logits[0, 17] = 5.0   # confirme t1\n",
+    "logits[1, 4] = 5.0    # confirme t2\n",
+    "logits[2, 31] = 5.0   # REFUTE t3 (le gros modèle veut 31, pas 92)\n",
+    "logits[3, 55] = 5.0   # (jamais atteint)\n",
+    "res = accepted_prefix(draft, logits)\n",
+    "if res is None:\n",
+    "    print(\"Exercice 3 à compléter (accepted_prefix renvoie None)\")\n",
+    "else:\n",
+    "    print(f\"attendu : 2 (t1, t2 acceptés ; t3 refusé) | obtenu : {res} \"\n",
+    "          f\"-> {'OK' if res == 2 else 'ÉCART'}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4588b1b0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003434,
+     "end_time": "2026-08-25T21:47:47.827842",
+     "exception": false,
+     "start_time": "2026-08-25T21:47:47.824408",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "| Notion | Ce notebook l'a montré par |\n",
+    "|---|---|\n",
+    "| Le mur du recalcul | débit naïf qui s'effondre à contexte croissant (partie 3, courbe) |\n",
+    "| Le KV-cache | implémenté à la main, porté par l'appelant, pas à pas (partie 1) |\n",
+    "| Son exactitude | logits naïfs vs cachés : écart d'epsilon float32, argmax identiques (partie 2) |\n",
+    "| Son coût mémoire | formule confrontée au mesuré — écart nul ; GQA divise la facture (partie 4) |\n",
+    "| Le lien au service | TTFT (préfill) qui croît, ITL (décodage + cache) qui reste plate — mesuré sur notre vLLM (partie 5) |\n",
+    "\n",
+    "**Ce qu'on retient pour la production** : lire `TTFT` et `ITL` dans les métriques d'un serveur, c'est relire la partie 3 de ce notebook en production. Un vLLM qui tient son débit est un serveur dont le cache est bien géré (PagedAttention) — et le jour où l'ITL dérive, la première question est celle de la partie 4 : combien de mémoire reste-t-il pour le cache ?\n",
+    "\n",
+    "**Pour aller plus loin** : [10_LocalLlama](10_LocalLlama.ipynb) (le déploiement), [11_Quantization](11_Quantization.ipynb) (compresser les poids — le cache, lui, se gère autrement), [22_Evaluating_Generated_Text](22_Evaluating_Generated_Text.ipynb) (évaluer ce que génère le service).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 20.242554,
+   "end_time": "2026-08-25T21:47:48.495953",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "23_Inference_Mechanics.ipynb",
+   "output_path": "23_Inference_Mechanics_output.ipynb",
+   "parameters": {
+    "BATCH_MODE": "true"
+   },
+   "start_time": "2026-08-25T21:47:28.253399",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -21,6 +21,7 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 - **Production enterprise** : gestion de sessions, retry, batch processing
 - **Déploiement local** : vLLM, quantification, optimisation des coûts
 - **Test-time scaling (ICR)** : routeur agentique, mémoire persistante, Tree-of-Thoughts sur CSP, courbes de scaling, raisonnement natif, plugins Semantic Kernel (notebooks 13 à 18, arc approfondi au-delà de NB-12)
+- **Sous le capot** : mécanique d'inférence — KV-cache from scratch, TTFT/ITL mesurés sur le vLLM self-hosted (23) ; évaluation des sorties générées, BLEU/ROUGE/perplexité/juge LLM (22)
 
 ## Contenu détaillé
 
@@ -54,6 +55,7 @@ La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Géné
 | 9 | `9_Production_Patterns.ipynb` | Conversations API, background mode, retry, batch processing | 70 min |
 | 9b | `09b_Prompt_Security_RedTeam.ipynb` | Versant **adversarial** du 9 : taxonomie de l'injection (directe / indirecte RAG / jailbreak / exfiltration), 3 attaques mesurées sur le routeur DeepSeek self-hosted (≥1 réussie avant défense), défenses testées + tableau attaque × défense, suite de tests rejouable (propriété « PWNED jamais délivré »), 3 exercices stubs C.1 | 70 min |
 | 10 | `10_LocalLlama.ipynb` | vLLM, Qwen3.5-35B-A3B, ZwZ-8B, multi-endpoints, benchmarking | 60 min |
+| 10c | `10c_Long_Context_Strategies.ipynb` | Stratégies pour contextes longs : budget de tokens, biais de position, map-reduce, prefix caching | 50 min |
 | 11 | `11_Quantization.ipynb` | AWQ, GPTQ, llmcompressor, modèles vision, déploiement vLLM | 60 min |
 | 12 | `12_Test_Time_Scaling.ipynb` | Best-of-N, Tree-of-Thoughts (BFS/DFS), Reflexion, routeur adaptatif (cf ICR) | 60 min |
 
@@ -64,6 +66,7 @@ Le notebook 12 introduit en Python pur les quatre moteurs d'inférence au moment
 | # | Notebook | Description | Durée |
 |---|----------|-------------|-------|
 | 13 | `13_Agentic_Orchestration.ipynb` | Routeur agentique : function calling (pont NB-04) pour laisser un LLM choisir le moteur par sous-tâche (mode "Agentic" d'ICR) | 60 min |
+| 13b | `13b_Agent_Evaluation.ipynb` | Frère *sides-first* du 13 : mesurer ce que valent les agents — taux de succès sur une suite de tâches, coût par trajectoire, ablation, sûreté | 60 min |
 | 14 | `14_Persistent_Memory.ipynb` | Mémoire vectorielle persistante (baseline BoW + cosine, pont NB-05 RAG) qui rétrocède les leçons aux runs suivants (agent "Memory" d'ICR) | 55 min |
 | 15 | `15_Tree_of_Thoughts_Search.ipynb` | Tree-of-Thoughts sur cryptarithmes (SEND+MORE=MONEY) : recherche DFS colonne par colonne avec propagation de retenue (pont séries Search/Sudoku) | 60 min |
 | 16 | `16_Scaling_Test_Time_Compute.ipynb` | Courbes de scaling Snell 2024 : estimateur pass@k, BoN vs Reflexion, frontière compute-optimale selon la difficulté | 65 min |
@@ -108,6 +111,15 @@ Le fil rouge est volontairement discriminant : enseigner au modèle un **format 
 | 21 | `21_LoRA_FineTuning.ipynb` | **QLoRA** (NF4 4-bit + double quant, bf16) sur Qwen2.5-0.5B-Instruct : fil rouge = format balisé `[T]/[D]/[E]` que le base échoue à produire ; adaptateurs LoRA via `peft` + `bitsandbytes` + `trl` + `datasets`, GPU CUDA requis (pont PostTraining / #10247) | 75 min |
 | 22 | `22_TensorSharp_DotNet_Inference.ipynb` | Pilote diagnostique .NET : TensorSharp CUDA charge Gemma 4 E4B et répond en OpenAI-compatible, mais le contrôle qualitatif détecte une répétition de `<pad>` (`RECOVERABLE-LOCAL`, adoption différée) | 55 min |
 
+### Tier 7 : Sous le capot — mécanique d'inférence et évaluation (Avancé)
+
+Les tiers précédents utilisent, déploient et adaptent le LLM **tel quel**. Ce tier ouvre la cage avec deux regards complémentaires : **mesurer les sorties** (22 — métriques d'évaluation classiques et juge LLM) et **comprendre la mécanique interne** de l'inférence (23 — pourquoi la génération ralentit, ce que le KV-cache achète et ce qu'il coûte). Le 23 relie les deux mondes : un mini-GPT écrit from scratch en PyTorch CPU exhibe le mur du recalcul, le cache qui le lève et son exactitude numérique ; puis le vLLM self-hosted du dépôt est interrogé en streaming pour relier TTFT (préfill) et inter-token latency (décodage caché) aux mécaniques démontrées.
+
+| # | Notebook | Description | Durée |
+|---|----------|-------------|-------|
+| 22 | `22_Evaluating_Generated_Text.ipynb` | Évaluer les sorties générées : BLEU, ROUGE, perplexité et juge LLM — la boucle qualité que les notebooks d'application appellent sans la démontrer | 55 min |
+| 23 | `23_Inference_Mechanics.ipynb` | **KV-cache from scratch** (mini-GPT PyTorch CPU : naïf vs caché, exactitude argmax 24/24, décodage seul stable, formule mémoire collant au mesuré) puis **mesuré sur le vLLM du dépôt** en streaming (TTFT croissant vs ITL plate ; verdict `RECOVERABLE-MACHINE` si service éteint, aucune valeur de substitution) ; ouverture décodage spéculatif, 3 exercices | 60 min |
+
 ## Prérequis
 
 ### Configuration API
@@ -142,6 +154,7 @@ Le fil rouge est volontairement discriminant : enseigner au modèle un **format 
 │                                                                 │
 │  10_LocalLlama (indépendant, prérequis: 1)                     │
 │        └──────► 11_Quantization (prérequis: 10)                │
+│        └──────► 23_Inference_Mechanics (prérequis: 10)         │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -199,7 +212,9 @@ Le fil rouge de cette série est la progression de l'interaction basique avec un
 
 5. **Tier 5** (test-time scaling approfondi) : partant de [12_Test_Time_Scaling](12_Test_Time_Scaling.ipynb) (les quatre moteurs en Python pur), l'arc NB-13..18 décompose chaque facette de l'inférence au moment du test — orchestration agentique via function calling ([13](13_Agentic_Orchestration.ipynb)), mémoire persistante par similarité ([14](14_Persistent_Memory.ipynb)), Tree-of-Thoughts sur des problèmes de recherche ([15](15_Tree_of_Thoughts_Search.ipynb)), courbes de scaling de Snell ([16](16_Scaling_Test_Time_Compute.ipynb)), raisonnement natif vs scaling hand-rolled ([17](17_Native_Reasoning_vs_Scaling.ipynb)), puis intégration Semantic Kernel ([18](18_Semantic_Kernel_Plugins.ipynb)).
 
-Le schéma ci-dessous résume comment les cinq tiers s'enchaînent pour maîtriser les LLMs : du prompt one-shot (tier 1) aux patterns de production puis à l'arc test-time scaling approfondi (tiers 4-5), en passant par les sorties structurées (tier 2) et l'augmentation RAG/code interpreter (tier 3).
+6. **Tiers 6-7** (adaptation et sous le capot) : [21_LoRA_FineTuning](21_LoRA_FineTuning.ipynb) adapte le modèle lui-même (QLoRA), [22_TensorSharp_DotNet_Inference](22_TensorSharp_DotNet_Inference.ipynb) sonde l'inférence .NET, et le tier 7 ouvre la cage : [22_Evaluating_Generated_Text](22_Evaluating_Generated_Text.ipynb) mesure la qualité des sorties, [23_Inference_Mechanics](23_Inference_Mechanics.ipynb) démontre la mécanique interne (KV-cache, TTFT/ITL sur le vLLM du dépôt).
+
+Le schéma ci-dessous résume comment les sept tiers s'enchaînent pour maîtriser les LLMs : du prompt one-shot (tier 1) aux patterns de production puis à l'arc test-time scaling approfondi (tiers 4-5), en passant par les sorties structurées (tier 2), l'augmentation RAG/code interpreter (tier 3), l'adaptation LoRA (tier 6) et la mécanique d'inférence sous le capot (tier 7).
 
 ```mermaid
 flowchart TD
@@ -226,7 +241,13 @@ flowchart TD
         E2["15-17 : ToT, Scaling, Native"]
         E3["18 : Plugins Semantic Kernel"]
     end
-    T1 --> T2 --> T3 --> T4 --> T5
+    subgraph T6["Tier 6 · Fine-tuning"]
+        F1["21 : LoRA/QLoRA · 22 : TensorSharp .NET"]
+    end
+    subgraph T7["Tier 7 · Mécanique & évaluation"]
+        G1["22 : Évaluation des sorties · 23 : Mécanique d'inférence"]
+    end
+    T1 --> T2 --> T3 --> T4 --> T5 --> T6 --> T7
 ```
 
 ## FAQ


### PR DESCRIPTION
Grain: DEEP/genai — lane myia-po-2023:CoursIA-2 — prev: DEEP/genai #13015

## Summary

Création du notebook `GenAI/Texte/23_Inference_Mechanics.ipynb` (renuméroté depuis le « 21 » de l'issue : 21 = LoRA, 22 déjà doublement utilisé) + réconciliation README (audit fichier entier §E).

**Partie 1 — from scratch (PyTorch pur CPU, mini-GPT 4 couches écrit dans le notebook)** :
- génération naïve (recalcul complet du préfixe à chaque token) vs KV-cache **implémenté à la main**, porté par l'appelant (on VOIT les tenseurs K/V) ;
- **exactitude numérique vérifiée pas à pas** : écart max de logits 1.07e-06 (artefact d'ordre de sommation float32), argmax identiques 24/24 ;
- **speedup mesuré** ctx 128→1024 : naïf 97.8→14.9 tok/s (effondrement), décodage seul ~127-243 tok/s stable, speedup ×2.0→×6.8 croissant (courbe + tableau C.2) ;
- **mémoire du cache** : formule `couches × 2 × têtes_kv × head_dim × seq × dtype` sur configs réelles (GPT-2 MHA, Llama-3.1-8B GQA 17.18 GB @131k fp16) confrontée au mesuré sur le mini-GPT : **écart 0.0000 %** ;
- rider décodage spéculatif (prose + exercice d'acceptation).

**Partie 6 — mesures RÉELLES sur le vLLM self-hosted du dépôt** (streaming SSE, fragments porteurs de contenu seulement, médiane de 3 requêtes, échauffement jeté) :

| prompt | TTFT médiane | ITL moyenne |
|---|---|---|
| ~250 tok | 0.09 s | 8.0 ms |
| ~8 000 tok | 0.28 s | 8.8 ms |
| ~32 000 tok | 0.37 s | 11.6 ms |

TTFT croît avec le prompt (préfill = le mur de la partie 1), ITL quasi plate (décodage incrémental caché) — le pont mécanique est démontré, pas affirmé. Verdict `[RECOVERABLE-MACHINE]` explicite si le service est éteint, aucune valeur de substitution.

## Critères d'acceptation #12411

- [x] Cache KV from scratch + vérification d'exactitude (écart 1.07e-06 affiché)
- [x] Courbe speedup + tableau mémoire théorique vs mesurée dans les outputs
- [x] Mesures réelles vLLM (token latencies) — pas un toy-only
- [x] ≥ 3 exercices stubs C.1 (cache_bytes GQA, trim_cache glissante, accepted_prefix spéculatif) ; partie 6 exécutable via le vLLM LAN (pas d'exception F nécessaire), fallback documenté
- [x] README GenAI/Texte mis à jour — **audit fichier entier** : réconciliation disque↔README (4 notebooks manquants ajoutés : `10c_Long_Context_Strategies`, `13b_Agent_Evaluation`, `22_Evaluating_Generated_Text`, + le nouveau 23), section Tier 7, bullet d'apprentissage, parcours ASCII, recette (« cinq tiers » → sept, drift préexistant), mermaid T6/T7. `ls` disque = 27 notebooks ↔ README désormais 27.

## Preuves d'exécution (C.2)

- `notebook_tools.py execute --kernel python3 --batch-mode` : SUCCESS, **14/14 cellules code exécutées, 0 erreur**, 2 figures matplotlib rendues dans les outputs.
- `validate` : OK, 0 warning, 0 erreur. C.1 : `grep -cE "raise NotImplementedError|assert False|1/0"` = 0.
- Prérequis ex. 1 : attendu 1.34 GB (40×2×8×128×16384×2).

## Verdict SOTA (EPIC #3801)

**SOTA-OK** — la partie 6 interroge le **vrai service vLLM du dépôt** (qwen3.6-35b-a3b, `192.168.0.47:5002`, clé via `.env` gitignored) ; la partie 1 exécute du **vrai PyTorch** (torch 2.8.0) avec le moteur écrit from scratch — aucun substitut, aucune sortie fabriquée. Piège rencontré et corrigé en cours de route : ce build vLLM émet le raisonnement sous `delta.reasoning` (pas `reasoning_content`) — le filtre couvre les deux.

## Note catalogue

`CATALOG-STATUS` du README **byte-identique à main** (règle catalogue). Son `pedagogical_count: 21` est toutefois **stale** vs les 27 notebooks disque — champ automation-owned, laissé au cron/catalog-drift (signalé, pas contourné).

Closes #12411

🤖 Generated with [Claude Code](https://claude.com/claude-code)