### PR TITLE
feat(twin-parity,#12933): verdict NUMBERING-DRIFT + echappatoire numbering_exception

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -39,9 +39,13 @@ Pour chaque paire du registre, on :
      enregistrement d'audit** (`last_audit` legacy ou `audits[-1]`, #9399) ;
   3. **DRIFT** si l'un des deux a change depuis le dernier audit -> la paire
      doit etre re-auditee (un cote a evolue, la parite n'est plus garantie) ;
-  4. **MISSING** si le chemin n'existe pas dans git (typo, deplacement, jumeau
+  4. **NUMBERING-DRIFT** si les numeros de base des deux jumeaux declares
+     divergent (renommage unilateral d'un seul cote, classe #5361 -- EPIC
+     #12933 « parite des identifiants, liberte des contenus ») -> realigner
+     les numeros OU documenter `numbering_exception: <raison>` au cas par cas ;
+  5. **MISSING** si le chemin n'existe pas dans git (typo, deplacement, jumeau
      non cree) ;
-  5. **OK** sinon (les deux cotes sont au SHA audite, parite tenue).
+  6. **OK** sinon (les deux cotes sont au SHA audite, parite tenue).
 
 Le bouclage d'audit : apres avoir re-audite une paire firsthand, on rebaseline
 avec `--update --pair "<nom>" --by "<lane>"`, qui reecrit les SHAs courants
@@ -174,17 +178,18 @@ BRIDGE_VERDICTS = frozenset({
 def validate_pair_fields(pair: dict) -> list[str]:
     """Valide les champs structurels d'une paire. Retourne une liste d'erreurs
     (vide = OK). Fail-loud sur `bridge_verdict` hors enum, ou `bridge_verdict:
-    INTRINSIC` sans `bridge_verdict_reason` (#10439).
+    INTRINSIC` sans `bridge_verdict_reason` (#10439), ou `numbering_exception`
+    mal forme (#12933 -- doit etre une raison textuelle non vide).
 
     Les champs `bridge_verdict` et `bridge_verdict_reason` sont OPTIONNELS : la
     plupart des paires n'en portent pas (le verdict par defaut est "non-rompt",
     la paire reste actionnable). Un INTRINSIC sans reason est interdit car le
     verdict sans le raisonnement ne vaut rien (cf _schema.yaml + #10439).
 
-    Scope : ne valide QUE bridge_verdict (#10439). `parity_level` n'est pas
-    valide ici -- des fixtures de test utilisent des valeurs placeholders (ex.
-    'full') et l'enumeration reelle (surface/semantic/native-both) est deja
-    enforcee par revue + _schema.yaml.
+    Scope : ne valide QUE bridge_verdict (#10439) et numbering_exception
+    (#12933). `parity_level` n'est pas valide ici -- des fixtures de test
+    utilisent des valeurs placeholders (ex. 'full') et l'enumeration reelle
+    (surface/semantic/native-both) est deja enforcee par revue + _schema.yaml.
     """
     errs: list[str] = []
     name = pair.get("name", "?")
@@ -199,6 +204,18 @@ def validate_pair_fields(pair: dict) -> list[str]:
                 f"{name}: bridge_verdict=INTRINSIC requiert bridge_verdict_reason "
                 f"(le verdict sans le raisonnement ne vaut rien, #10439)"
             )
+    ne = pair.get("numbering_exception")
+    if ne is not None and (not isinstance(ne, str) or not ne.strip()):
+        # Un booleen (numbering_exception: true) ou un champ vide dirait QU'ON
+        # sort de la convention sans dire POURQUOI -- exactement le defaut que
+        # le pattern bridge_verdict_reason (#10439) interdit pour INTRINSIC.
+        # Cote check_pair, un non-string n'est PAS non plus accepte comme
+        # exception valide (isinstance str) : les deux organes sont coherents.
+        errs.append(
+            f"{name}: numbering_exception doit etre une raison textuelle NON VIDE "
+            f"(booleen/entier/champ vide refuses) -- documenter POURQUOI la paire "
+            f"sort de la convention de numerotation, ou supprimer le champ (#12933)"
+        )
     return errs
 
 
@@ -217,6 +234,26 @@ def _slug(name: str) -> str:
 def _pair_file(registry_dir: Path, name: str) -> Path:
     """Chemin du fichier d'une paire dans le registre file-per-entry."""
     return registry_dir / f"{_slug(name)}.yaml"
+
+
+def _twin_base_number(rel_path: str) -> str | None:
+    """Numero de base d'un jumeau depuis son chemin DECLARE (EPIC #12933).
+
+    Premier groupe de chiffres du basename. Convention du depot : deux jumeaux
+    d'une meme paire partagent ce numero (App-N / SW-N / <Prefixe>-N) ; le
+    suffixe lettre minuscule qui peut suivre (ex. App-10b) designe un compagnon
+    legitime (3e notebook de la serie) et N'EST PAS extrait -- seule la partie
+    numerique compte, un compagnon 10b cote C# face a un 10 cote Python n'est
+    donc PAS une derive de numerotation.
+
+    Retourne None si le basename n'a aucun chiffre (on ne compare pas ce qu'on
+    ne peut pas numeroter). Evalue le chemin tel que DECLARE dans le registre,
+    pas le disque : un renommage unilateral reste visible meme si les deux
+    fichiers existent par ailleurs.
+    """
+    base = str(rel_path).replace("\\", "/").rsplit("/", 1)[-1]
+    m = re.search(r"\d+", base)
+    return m.group(0) if m else None
 
 
 _CSHARP_TOKEN = re.compile(r"[-_][Cc][Ss]harp")
@@ -512,8 +549,9 @@ def load_registry(path: Path) -> list:
 def check_pair(repo_root: Path, pair: dict, git_ref: str = "HEAD") -> dict:
     """Verifie une paire. Retourne {name, python, csharp, status, details}.
 
-    status in {OK, DRIFT, MISSING}. details = liste de chaines explicatives.
-    `git_ref` permet de checker a un instant arbitraire (HEAD, origin/main, <sha>...).
+    status in {OK, DRIFT, NUMBERING-DRIFT, MISSING}. details = liste de chaines
+    explicatives. `git_ref` permet de checker a un instant arbitraire (HEAD,
+    origin/main, <sha>...).
     """
     name = pair.get("name", "?")
     py = pair["python"]
@@ -534,6 +572,33 @@ def check_pair(repo_root: Path, pair: dict, git_ref: str = "HEAD") -> dict:
     if cur_cs is None:
         details.append(f"C# MANQUANT dans git : {cs}")
         status = "MISSING"
+
+    # Verdict NUMBERING-DRIFT (EPIC #12933) : numeros de base distincts entre
+    # les jumeaux DECLARES. Evalue AVANT la comparaison de SHAs : si la
+    # numerotation a diverge, la paire est cassee a un niveau plus fondamental
+    # que l'empreinte de contenu -- realigner les numeros (rename) changera de
+    # toute facon les chemins et rendra la comparaison SHA courante caduque.
+    # MISSING garde la priorite (fichier absent = le cas le plus severe ; le
+    # detail de numerotation reste alors seulement informatif, non emis).
+    num_py = _twin_base_number(py)
+    num_cs = _twin_base_number(cs)
+    if status == "OK" and num_py is not None and num_cs is not None and num_py != num_cs:
+        ne_raw = pair.get("numbering_exception")
+        ne = ne_raw.strip() if isinstance(ne_raw, str) else ""
+        if ne:
+            details.append(
+                f"Numerotation divergente documentee : python base={num_py} vs "
+                f"csharp base={num_cs} -- exception : {ne}"
+            )
+        else:
+            details.append(
+                f"Numero de base divergent : python={num_py} ({py}) vs "
+                f"csharp={num_cs} ({cs}) -- renommage unilateral (classe #5361) ou "
+                f"declaration erronee. Realigner les numeros, OU documenter la "
+                f"divergence via `numbering_exception: <raison>` dans l'entree du "
+                f"registre (#12933)."
+            )
+            status = "NUMBERING-DRIFT"
 
     # content_*_sha (#9399 volet c) : metadata-immune. Calcules LAZILY -- UNIQUEMENT
     # quand l'audit les a enregistrees. Les paires legacy (aucune content_*_sha
@@ -1117,14 +1182,19 @@ def _classify_per_pair(base_status: str, head_status: str) -> str:
     DRIFT -> DRIFT_INTRODUCED. (Avant le fix, le 'else' classait MISSING+DRIFT en
     DRIFT_PRE_EXISTING, qui ne fail pas le gate -- contredisait le comment inline et
     laissait passer une paire ajoutee driftante. Forensic po-2026 c.709.)
+
+    NUMBERING-DRIFT (#12933) suit la meme semantique que DRIFT : introduit par la
+    PR (base OK -> head NUMBERING-DRIFT, ex. renommage unilateral dans cette PR) =
+    DRIFT_INTRODUCED, gate ROUGE ; resolu par la PR (renommage realigne, OU
+    divergence documentee via numbering_exception au HEAD) = DRIFT_RESOLVED.
     """
     if base_status == "MISSING":
         return "OK" if head_status == "OK" else "DRIFT_INTRODUCED"
     if base_status == "OK" and head_status == "OK":
         return "OK"
-    if base_status == "OK" and head_status in ("DRIFT", "MISSING"):
+    if base_status == "OK" and head_status in ("DRIFT", "MISSING", "NUMBERING-DRIFT"):
         return "DRIFT_INTRODUCED"
-    if base_status == "DRIFT" and head_status == "OK":
+    if base_status in ("DRIFT", "NUMBERING-DRIFT") and head_status == "OK":
         return "DRIFT_RESOLVED"
     return "DRIFT_PRE_EXISTING"
 
@@ -1140,7 +1210,7 @@ def main(argv=None) -> int:
     p.add_argument("--family", default=None,
                    help="Restreindre a une famille (ex. SMT/Z3-API)")
     p.add_argument("--check", action="store_true",
-                   help="Exit 1 si DRIFT/MISSING detecte (CI-ready)")
+                   help="Exit 1 si DRIFT/MISSING/NUMBERING-DRIFT detecte (CI-ready)")
     p.add_argument("--update", action="store_true",
                    help="Rebaseline : ecrit les SHAs courants comme nouveau last_audit "
                         "(a lancer APRES une audit firsthand d'une paire, ET EN DERNIER : "
@@ -1706,6 +1776,7 @@ def main(argv=None) -> int:
     n_ok = sum(1 for r in results if r["status"] == "OK")
     n_drift = sum(1 for r in results if r["status"] == "DRIFT")
     n_missing = sum(1 for r in results if r["status"] == "MISSING")
+    n_numbering = sum(1 for r in results if r["status"] == "NUMBERING-DRIFT")
 
     # --- Mode --ci-strict (#9399 volet b) ---
     # Verdict dur : pour chaque paire, on detaillé le verdict legacy vs content_sha.
@@ -1729,6 +1800,7 @@ def main(argv=None) -> int:
             "n_missing_python": 0,
             "n_missing_csharp": 0,
             "n_no_audit": 0,              # paire sans audits ni last_audit
+            "n_numbering_drift": 0,       # numeros de base distincts (#12933)
         }
         ci_results = []
         for pp, r in zip(pairs, results):
@@ -1750,6 +1822,17 @@ def main(argv=None) -> int:
                 "details": list(r["details"]),
                 "has_content_sha_audit": bool(rec_cpy and rec_ccs),
             }
+
+            # NUMBERING-DRIFT (#12933) : compte dans SA categorie, sans
+            # re-classer la paire dans les buckets SHA (blob/content) -- une
+            # paire renumerotee unilateralement est rouge pour une raison qui
+            # n'a rien a voir avec l'attestation d'empreinte, et la double
+            # comptabilisation (ex. no_audit en plus) fausserait chaque
+            # categorie.
+            if r["status"] == "NUMBERING-DRIFT":
+                cat["n_numbering_drift"] += 1
+                ci_results.append(entry_ci)
+                continue
 
             if not audit:
                 cat["n_no_audit"] += 1
@@ -1814,7 +1897,7 @@ def main(argv=None) -> int:
         # les anomalies, pour le reporting.
         n_blocking_drift = (cat["n_drift_blob"] + cat["n_drift_content"]
                             + cat["n_missing_python"] + cat["n_missing_csharp"]
-                            + cat["n_no_audit"])
+                            + cat["n_no_audit"] + cat["n_numbering_drift"])
         n_total_drift = n_blocking_drift + cat["n_drift_legacy_after_content"]
 
         if args.json:
@@ -1837,7 +1920,7 @@ def main(argv=None) -> int:
                   f"drift_blob={cat['n_drift_blob']} drift_content={cat['n_drift_content']} "
                   f"drift_legacy_after_content={cat['n_drift_legacy_after_content']} "
                   f"missing_py={cat['n_missing_python']} missing_cs={cat['n_missing_csharp']} "
-                  f"no_audit={cat['n_no_audit']}")
+                  f"no_audit={cat['n_no_audit']} numbering_drift={cat['n_numbering_drift']}")
             for r in ci_results:
                 if r["status"] != "OK":
                     print(f"  [{r['status']}] {r['name']} ({r['family']}, {r['parity_level']})")
@@ -1869,19 +1952,22 @@ def main(argv=None) -> int:
             "ok": n_ok,
             "drift": n_drift,
             "missing": n_missing,
+            "numbering_drift": n_numbering,
             "pairs": results,
         }
         print(json.dumps(out, ensure_ascii=False, indent=2))
     else:
         for r in results:
-            tag = {"OK": "OK", "DRIFT": "DRIFT", "MISSING": "MISSING"}[r["status"]]
+            tag = {"OK": "OK", "DRIFT": "DRIFT", "MISSING": "MISSING",
+                   "NUMBERING-DRIFT": "NUMBERING-DRIFT"}[r["status"]]
             print(f"[{tag}] {r['name']} ({r['family']}, {r['parity_level']})")
             if r["status"] != "OK":
                 for d in r["details"]:
                     print(f"       - {d}")
-        print(f"\nTotal : {len(results)} paire(s) | OK={n_ok} DRIFT={n_drift} MISSING={n_missing}")
+        print(f"\nTotal : {len(results)} paire(s) | OK={n_ok} DRIFT={n_drift} "
+              f"MISSING={n_missing} NUMBERING-DRIFT={n_numbering}")
 
-    if args.check and (n_drift > 0 or n_missing > 0):
+    if args.check and (n_drift > 0 or n_missing > 0 or n_numbering > 0):
         return 1
     return 0
 

--- a/scripts/notebook_tools/twin_pairs.d/_schema.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/_schema.yaml
@@ -76,6 +76,21 @@
 # manuelle. Validation fail-loud : une valeur hors enum fait sortir le check en
 # code 2 (jamais ignoree silencieusement).
 #
+# numbering_exception (OPTIONNEL, #12933) : echappatoire au verdict NUMBERING-DRIFT.
+# Principe de l'EPIC : « parite des identifiants, liberte des contenus » — deux
+# jumeaux declares d'une meme paire partagent leur NUMERO DE BASE (App-N / SW-N ;
+# le suffixe lettre minuscule type App-10b designe un compagnon legitime et n'est
+# pas une derive). Le verdict NUMBERING-DRIFT (check_twin_parity.py) rouge toute
+# paire dont les numeros divergent (renommage unilateral d'un seul cote, classe
+# #5361). QUAND une divergence est JUSTIFIEE au cas par cas (historique de
+# publication different, numero deja pris par un compagnon, etc.), on la documente :
+#   numbering_exception: "<raison courte, avec date de decision>"
+# Le champ DOIT etre une raison textuelle NON VIDE (pattern bridge_verdict_reason
+# #10439 : l'echappatoire sans le raisonnement ne vaut rien ; un booleen/vide est
+# refuse par la validation fail-loud). Une paire portant une exception valide
+# affiche son detail « Numerotation divergente documentee » et reste OK.
+#
+#
 # PILOTE (po-2024, 2026-07-23) : famille SMT/Z3-API (6 paires, NB-01..06).
 # Familles suivantes peuplees dans des PRs ulterieurs : Search/Part1-Part2 (c.802/#8079, 7 paires)
 # + ML.NET/Python (c.803, 8 paires ; ML-6 ONNX exclu = format d'echange, SKIP per #4956 CLOSED)

--- a/scripts/tests/test_check_twin_parity.py
+++ b/scripts/tests/test_check_twin_parity.py
@@ -1,0 +1,291 @@
+"""Tests for the NUMBERING-DRIFT verdict of check_twin_parity.py (EPIC #12933).
+
+EPIC #12933 (« renumerotation paritaire des series paralleles ») posse le
+principe « parite des identifiants, liberte des contenus » : deux jumeaux
+declares d'une meme paire partagent leur NUMERO DE BASE. The guard catches a
+unilateral renumber (one side renamed 10 -> 11, the class of defect #5361)
+that content-SHA comparison cannot see -- the paths themselves diverge.
+
+Scope of these tests (mirrors the claim on #12933):
+  1. _twin_base_number : base-number extraction, companion suffix `b` ignored;
+  2. validate_pair_fields : numbering_exception must be a non-empty string
+     (pattern bridge_verdict_reason, #10439);
+  3. check_pair : OK / NUMBERING-DRIFT / companion OK / documented exception OK;
+  4. _classify_per_pair : numbering drift introduced/resolved per-PR semantics;
+  5. fleet-wide --check : exit 1 + tallies when a pair numbering-diverges.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+CHECK_TWIN_PARITY = HERE.parent / "notebook_tools" / "check_twin_parity.py"
+
+
+def _load(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-c", "user.name=test", "-c", "user.email=test@example.com", *args],
+        capture_output=True, text=True, cwd=str(repo), check=True,
+    )
+
+
+def _make_repo(tmp_path: Path, files: dict[str, str]) -> Path:
+    """Mini git repo with the given files committed at HEAD."""
+    repo = tmp_path / "mini_repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    for rel, content in files.items():
+        f = repo / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(content, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "fixture")
+    return repo
+
+
+_MINIMAL_NB = '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}'
+
+
+def _pair(name: str, py: str, cs: str, **extra) -> dict:
+    return {"name": name, "family": "Fixture", "python": py, "csharp": cs,
+            "parity_level": "surface", **extra}
+
+
+def _audited_pair(mod, repo: Path, name: str, py: str, cs: str, **extra) -> dict:
+    """Pair whose legacy last_audit records the CURRENT blob SHAs (status OK)."""
+    pair = _pair(name, py, cs, **extra)
+    pair["last_audit"] = {
+        "date": "2026-08-26",
+        "by": "test-fixture",
+        "python_sha": mod._git_blob_sha(repo, py, "HEAD"),
+        "csharp_sha": mod._git_blob_sha(repo, cs, "HEAD"),
+    }
+    return pair
+
+
+# --- 1. _twin_base_number -----------------------------------------------------
+
+@pytest.mark.parametrize("rel_path, expected", [
+    ("MyIA.AI.Notebooks/ML/ML-3/ML-3.ipynb", "3"),
+    ("Some/App-10-CSharp.ipynb", "10"),
+    # Companion suffix (3rd notebook of the serie) : only the numeric part counts.
+    ("Some/App-10b-CSharp.ipynb", "10"),
+    ("Some/SW-10b-Python.ipynb", "10"),
+    # Multi-digit and number NOT in first position.
+    ("Probas/Infer-19-Classifier.ipynb", "19"),
+    ("x/Prefix-2b3-Toto.ipynb", "2"),
+    # Windows separators accepted.
+    ("MyIA.AI.Notebooks\\ML\\ML-3\\ML-3.ipynb", "3"),
+    # Unnumbered basename -> None (never compared).
+    ("Some/README.ipynb", None),
+])
+def test_twin_base_number(rel_path, expected):
+    mod = _load(CHECK_TWIN_PARITY)
+    assert mod._twin_base_number(rel_path) == expected
+
+
+def test_twin_base_number_companion_suffix_is_not_a_divergence():
+    """App-10 vs App-10b : same base number -- the sibling convention."""
+    mod = _load(CHECK_TWIN_PARITY)
+    assert mod._twin_base_number("Some/App-10-Python.ipynb") == \
+           mod._twin_base_number("Some/App-10b-CSharp.ipynb")
+
+
+# --- 2. validate_pair_fields --------------------------------------------------
+
+def test_validate_numbering_exception_absent_ok():
+    mod = _load(CHECK_TWIN_PARITY)
+    assert mod.validate_pair_fields(_pair("P", "a-1.py", "a-1.cs")) == []
+
+
+def test_validate_numbering_exception_string_ok():
+    mod = _load(CHECK_TWIN_PARITY)
+    errs = mod.validate_pair_fields(
+        _pair("P", "a-1.py", "a-2.cs", numbering_exception="justifie le 2026-08-26 (historique)")
+    )
+    assert errs == []
+
+
+@pytest.mark.parametrize("bad", [True, False, 1, "", "   "])
+def test_validate_numbering_exception_bad_values_fail(bad):
+    """Boolean / empty : says THAT we escape, not WHY -- refused (#10439 pattern)."""
+    mod = _load(CHECK_TWIN_PARITY)
+    errs = mod.validate_pair_fields(_pair("P", "a-1.py", "a-2.cs", numbering_exception=bad))
+    assert any("numbering_exception" in e for e in errs), errs
+
+
+def test_validate_bridge_verdict_regression_guard():
+    """The existing INTRINSIC-without-reason rule still holds (untouched by #12933)."""
+    mod = _load(CHECK_TWIN_PARITY)
+    errs = mod.validate_pair_fields(
+        _pair("P", "a-1.py", "a-1.cs", bridge_verdict="INTRINSIC")
+    )
+    assert any("bridge_verdict_reason" in e for e in errs), errs
+
+
+# --- 3. check_pair : the verdict itself ---------------------------------------
+
+def test_check_pair_aligned_numbers_ok(tmp_path):
+    mod = _load(CHECK_TWIN_PARITY)
+    repo = _make_repo(tmp_path, {
+        "nb/py-10.ipynb": _MINIMAL_NB,
+        "nb/cs-10.ipynb": _MINIMAL_NB,
+    })
+    r = mod.check_pair(repo, _audited_pair(mod, repo, "P-10", "nb/py-10.ipynb", "nb/cs-10.ipynb"))
+    assert r["status"] == "OK", r["details"]
+
+
+def test_check_pair_divergent_numbers_numbering_drift(tmp_path):
+    """The #5361-class defect : one side renamed unilaterally 10 -> 11."""
+    mod = _load(CHECK_TWIN_PARITY)
+    repo = _make_repo(tmp_path, {
+        "nb/py-10.ipynb": _MINIMAL_NB,
+        "nb/cs-11.ipynb": _MINIMAL_NB,
+    })
+    r = mod.check_pair(repo, _audited_pair(mod, repo, "P-10", "nb/py-10.ipynb", "nb/cs-11.ipynb"))
+    assert r["status"] == "NUMBERING-DRIFT", r["details"]
+    assert any("python=10" in d and "csharp=11" in d for d in r["details"]), r["details"]
+    assert any("numbering_exception" in d for d in r["details"]), r["details"]
+
+
+def test_check_pair_companion_suffix_ok(tmp_path):
+    """App-10 vs App-10b : companion suffix is NOT a numbering divergence."""
+    mod = _load(CHECK_TWIN_PARITY)
+    repo = _make_repo(tmp_path, {
+        "nb/py-10.ipynb": _MINIMAL_NB,
+        "nb/cs-10b.ipynb": _MINIMAL_NB,
+    })
+    r = mod.check_pair(repo, _audited_pair(mod, repo, "P-10b", "nb/py-10.ipynb", "nb/cs-10b.ipynb"))
+    assert r["status"] == "OK", r["details"]
+
+
+def test_check_pair_documented_exception_stays_ok(tmp_path):
+    """numbering_exception with a real reason : OK + detail, never red."""
+    mod = _load(CHECK_TWIN_PARITY)
+    repo = _make_repo(tmp_path, {
+        "nb/py-10.ipynb": _MINIMAL_NB,
+        "nb/cs-11.ipynb": _MINIMAL_NB,
+    })
+    r = mod.check_pair(repo, _audited_pair(
+        mod, repo, "P-doc", "nb/py-10.ipynb", "nb/cs-11.ipynb",
+        numbering_exception="publication decallee, numero 11 deja pris (2026-08-26)",
+    ))
+    assert r["status"] == "OK", r["details"]
+    assert any("documentee" in d for d in r["details"]), r["details"]
+
+
+def test_check_pair_bool_exception_is_not_an_escape(tmp_path):
+    """numbering_exception: true (non-string) must NOT silence the verdict --
+    check_pair does not run validate_pair_fields, so it guards on its own."""
+    mod = _load(CHECK_TWIN_PARITY)
+    repo = _make_repo(tmp_path, {
+        "nb/py-10.ipynb": _MINIMAL_NB,
+        "nb/cs-11.ipynb": _MINIMAL_NB,
+    })
+    r = mod.check_pair(repo, _audited_pair(
+        mod, repo, "P-bool", "nb/py-10.ipynb", "nb/cs-11.ipynb",
+        numbering_exception=True,
+    ))
+    assert r["status"] == "NUMBERING-DRIFT", r["details"]
+
+
+def test_check_pair_missing_wins_over_numbering(tmp_path):
+    """A missing twin is the more severe state : MISSING, not NUMBERING-DRIFT."""
+    mod = _load(CHECK_TWIN_PARITY)
+    repo = _make_repo(tmp_path, {"nb/py-10.ipynb": _MINIMAL_NB})
+    pair = _pair("P-miss", "nb/py-10.ipynb", "nb/cs-11.ipynb")
+    r = mod.check_pair(repo, pair)
+    assert r["status"] == "MISSING", r["details"]
+
+
+# --- 4. _classify_per_pair : per-PR semantics ---------------------------------
+
+@pytest.mark.parametrize("base, head, expected", [
+    ("OK", "NUMBERING-DRIFT", "DRIFT_INTRODUCED"),   # unilateral rename IN this PR
+    ("NUMBERING-DRIFT", "OK", "DRIFT_RESOLVED"),     # realigned, or exception added
+    ("NUMBERING-DRIFT", "NUMBERING-DRIFT", "DRIFT_PRE_EXISTING"),
+    ("MISSING", "NUMBERING-DRIFT", "DRIFT_INTRODUCED"),  # pair added by the PR, drifted
+    # Pre-existing semantics unchanged (regression guard).
+    ("OK", "DRIFT", "DRIFT_INTRODUCED"),
+    ("DRIFT", "OK", "DRIFT_RESOLVED"),
+    ("OK", "OK", "OK"),
+])
+def test_classify_per_pair(base, head, expected):
+    mod = _load(CHECK_TWIN_PARITY)
+    assert mod._classify_per_pair(base, head) == expected
+
+
+# --- 5. Fleet-wide --check gate ------------------------------------------------
+
+def _write_registry(tmp_path: Path, pairs: list[dict]) -> Path:
+    import yaml
+    reg = tmp_path / "twin_pairs.d"
+    reg.mkdir(exist_ok=True)
+    for pp in pairs:
+        slug = pp["name"].lower().replace(" ", "-")
+        (reg / f"{slug}.yaml").write_text(
+            yaml.safe_dump(pp, allow_unicode=True, sort_keys=False), encoding="utf-8"
+        )
+    return reg
+
+
+def test_fleet_check_green_when_aligned(tmp_path, capsys):
+    mod = _load(CHECK_TWIN_PARITY)
+    repo = _make_repo(tmp_path, {
+        "nb/py-10.ipynb": _MINIMAL_NB,
+        "nb/cs-10.ipynb": _MINIMAL_NB,
+    })
+    reg = _write_registry(tmp_path, [
+        _audited_pair(mod, repo, "Fixture-10", "nb/py-10.ipynb", "nb/cs-10.ipynb"),
+    ])
+    rc = mod.main(["--registry", str(reg), "--repo-root", str(repo), "--check"])
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    assert "NUMBERING-DRIFT=0" in out
+
+
+def test_fleet_check_red_on_numbering_drift(tmp_path, capsys):
+    mod = _load(CHECK_TWIN_PARITY)
+    repo = _make_repo(tmp_path, {
+        "nb/py-10.ipynb": _MINIMAL_NB,
+        "nb/cs-10.ipynb": _MINIMAL_NB,
+        "nb/py-21.ipynb": _MINIMAL_NB,
+        "nb/cs-22.ipynb": _MINIMAL_NB,
+    })
+    reg = _write_registry(tmp_path, [
+        _audited_pair(mod, repo, "Fixture-10", "nb/py-10.ipynb", "nb/cs-10.ipynb"),
+        _audited_pair(mod, repo, "Fixture-21", "nb/py-21.ipynb", "nb/cs-22.ipynb"),
+    ])
+    rc = mod.main(["--registry", str(reg), "--repo-root", str(repo), "--check"])
+    out = capsys.readouterr().out
+    assert rc == 1, out
+    assert "[NUMBERING-DRIFT] Fixture-21" in out
+    assert "NUMBERING-DRIFT=1" in out
+
+
+def test_fleet_json_carries_numbering_drift_count(tmp_path, capsys):
+    mod = _load(CHECK_TWIN_PARITY)
+    repo = _make_repo(tmp_path, {
+        "nb/py-3.ipynb": _MINIMAL_NB,
+        "nb/cs-4.ipynb": _MINIMAL_NB,
+    })
+    reg = _write_registry(tmp_path, [
+        _audited_pair(mod, repo, "Fixture-3", "nb/py-3.ipynb", "nb/cs-4.ipynb"),
+    ])
+    rc = mod.main(["--registry", str(reg), "--repo-root", str(repo), "--json"])
+    out = capsys.readouterr().out
+    import json
+    data = json.loads(out)
+    assert data["numbering_drift"] == 1, data.get("numbering_drift")
+    assert rc == 0  # --json alone does not gate ; only --check exits 1


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: DEEP/genai #13016

## Summary

Tranche « garde structurel » de l'EPIC #12933 (« Renumérotation paritaire des séries parallèles » — « Parité des identifiants, liberté des contenus »). Le principe devient un invariant **enforcé par le checker**, pas une convention que les READMEs espèrent.

1. **Verdict `NUMBERING-DRIFT`** dans `check_twin_parity.py --check` : numéro de base du jumeau python ≠ numéro de base du jumeau csharp (renommage unilatéral, classe #5361). Évalué sur les chemins **déclarés** dans le registre, avant la comparaison de SHAs (une paire renumérotée est cassée à un niveau plus fondamental que l'empreinte de contenu). `MISSING` garde la priorité. Le suffixe compagnon (`App-10b`) n'est **pas** une dérive — seule la partie numérique compte.
2. **Champ d'échappatoire `numbering_exception`** (pattern `bridge_verdict_reason` #10439) : raison textuelle NON VIDE obligatoire, fail-loud dans `validate_pair_fields` (exit 2 sur booléen/vide), gardé indépendamment dans `check_pair` (un booléen ne suffit pas à silencer le verdict hors mode fleet). Documenté dans `_schema.yaml`.
3. **Sémantique per-PR** : `_classify_per_pair` classe base OK → head NUMBERING-DRIFT comme `DRIFT_INTRODUCED` (gate per-PR rouge sur le renommage introduit par la PR — bullet 2 de l'EPIC) ; résolu par réalignement **ou** par ajout de l'exception.
4. **Bullets 1-2-3 du garde structurel EPIC** : (1) deux jumeaux déclarés à numéros incompatibles = NUMBERING-DRIFT ; (2) renumérotation unilatérale d'une paire enregistrée = DRIFT_INTRODUCED au gate per-PR ; (3) chemin mort après `git mv` = verdict MISSING existant (inchangé).
5. **33 cas pytest** (`scripts/tests/test_check_twin_parity.py`) : extraction du numéro (suffixe compagnon, séparateurs Windows, non numéroté), validation du champ (booléen/vide refusés, garde de régression INTRINSIC), verdict (égal / dérive / compagnon / exception documentée / booléen non-échappatoire / MISSING prioritaire), classification per-pair, gate fleet exit 1 + compteurs JSON.

## Mesures (calibration + gate vert)

- **Fleet-wide sur cette branche** : `python scripts/notebook_tools/check_twin_parity.py --json` → `total: 157 | ok: 157 | drift: 0 | missing: 0 | numbering_drift: 0` — le garde **shipe vert**, l'invariant tient déjà sur main (157/157 numéros de base égaux, 19 suffixes compagnons `b` comptés comme égaux, 0 non numéroté, mesuré sur origin/main avant l'implémentation).
- **P1 de l'EPIC vérifié mécaniquement** : l'alignement Probas/Infer.NET⇄PyMC 1–19 est couvert par la même passe (famille du registre).
- `--ci-strict` : nouvelle catégorie `numbering_drift` (bloquante) présente, sortie inchangée par ailleurs (`ok_legacy=9 ok_content=147 ... numbering_drift=0`).
- `--per-pair --base origin/main` : `OK=157 INTRO=0 FIXED=0 PRE=0` (aucun changement de registre dans cette PR — seuls checker + schéma + tests).
- Tests : `pytest scripts/tests/test_check_twin_parity.py` → **33 passed** ; consommateurs existants non cassés : `test_check_hooks_parity.py` 22 passed, `test_check_pr_perimeter.py` 119 passed.

## Scope

Aucun renommage de notebook dans cette PR (les P0 DecisionTheory de l'EPIC sont volontairement exclus : PRs actives #12914/#12918/#12920/#12924 sur cette famille — « ne pas renommer sous une lane active »). Aucune entrée de registre modifiée. Catalogue non touché.

See #12933 (tranche partielle de l'EPIC — garde structurel + invariant P1 ; les renommages P0 restent à suivre).

## Test plan

- [x] `pytest scripts/tests/test_check_twin_parity.py` (33 passed, preuve ci-dessus)
- [x] Fleet-wide `--json` sur la branche : 157/157 OK, 0 NUMBERING-DRIFT
- [x] `--ci-strict` et `--per-pair --base origin/main` fumés, sortie saine
- [x] Consommateurs (`test_check_hooks_parity.py`, `test_check_pr_perimeter.py`) re-passés verts

🤖 Generated with [Claude Code](https://claude.com/claude-code/)


Co-Authored-By: Claude-Code <noreply@anthropic.com>