### PR TITLE
fix(genai): comfyui-idle-monitor — tri-state UNKNOWN, jamais de /free sur serveur d'etat indetermine

### DIFF
--- a/docker-configurations/services/shared/comfyui_idle_monitor.py
+++ b/docker-configurations/services/shared/comfyui_idle_monitor.py
@@ -32,6 +32,13 @@ except ImportError:
 
 logger = logging.getLogger("comfyui-idle-monitor")
 
+# Sentinel d'etat INDETERMINABLE du serveur (API injoignable / auth echouee),
+# distinct de None (= determine : aucune activite, queue ET historique verses
+# et vides). Confondre les deux faisait deviner un serveur "inactif"
+# pendant qu'il generait : /free tire a l'aveugle, crash serveur exit 0,
+# reboot 7-8 min (incident 2026-08-25, 3 restarts en ~30 min).
+UNKNOWN = object()
+
 
 class ComfyUIIdleMonitor:
     """
@@ -147,11 +154,19 @@ class ComfyUIIdleMonitor:
             headers["Authorization"] = f"Bearer {self.auth_token}"
         return headers
 
-    def get_running_prompts(self) -> list:
-        """Get list of currently running prompt IDs."""
+    def get_running_prompts(self):
+        """Get list of currently running prompt IDs.
+
+        Tri-state: UNKNOWN (API injoignable / auth echouee -- etat
+        INDETERMINABLE), [] (queue verifiee vide), liste non vide (occupations
+        en cours). Ne jamais confondre UNKNOWN avec [] : l'ancien `return []`
+        sur echec faisait deviner au caller un serveur "inactif" alors qu'il
+        etait en pleine generation (incident 2026-08-25 : /free tire a
+        l'aveugle, 3 crashes serveur).
+        """
         if not self._ensure_authenticated():
-            logger.warning("Not authenticated, skipping queue check")
-            return []
+            logger.warning("Not authenticated, queue state indeterminate")
+            return UNKNOWN
 
         try:
             resp = self.session.get(
@@ -168,13 +183,17 @@ class ComfyUIIdleMonitor:
             # If 401, reset logged_in state to force re-auth next time
             if hasattr(e, 'response') and e.response.status_code == 401:
                 self._logged_in = False
-            return []
+            return UNKNOWN
 
-    def get_recent_history(self, max_items: int = 10) -> dict:
-        """Get recent prompt execution history."""
+    def get_recent_history(self, max_items: int = 10):
+        """Get recent prompt execution history.
+
+        Tri-state : UNKNOWN (echec de la requete) vs {} (historique verifie
+        vide, ex. boot frais) -- cf get_running_prompts.
+        """
         if not self._ensure_authenticated():
-            logger.warning("Not authenticated, skipping history check")
-            return {}
+            logger.warning("Not authenticated, history state indeterminate")
+            return UNKNOWN
 
         try:
             resp = self.session.get(
@@ -188,23 +207,34 @@ class ComfyUIIdleMonitor:
             logger.warning(f"Failed to get history: {e}")
             if hasattr(e, 'response') and e.response.status_code == 401:
                 self._logged_in = False
-            return {}
+            return UNKNOWN
 
-    def get_last_activity_time(self) -> Optional[float]:
+    def get_last_activity_time(self):
         """
         Get timestamp of last activity from ComfyUI.
 
-        Returns the most recent prompt execution time, or None if unable to determine.
+        Tri-state :
+          - float   : instant de la derniere activite (maintenant si une
+                      generation tourne, sinon le end_time le plus recent) ;
+          - None    : determine SANS activite (queue verifiee vide + historique
+                      verifie vide -- boot frais) ;
+          - UNKNOWN : etat serveur INDETERMINABLE (API injoignable / auth
+                      echouee). Le caller doit SKIPPER le check, jamais
+                      deviner un idle (incident 2026-08-25).
         """
         try:
             # Check if something is running right now
             running = self.get_running_prompts()
+            if running is UNKNOWN:
+                return UNKNOWN
             if running:
                 logger.debug(f"Found {len(running)} running prompts")
                 return time.time()  # Active right now
 
             # Check recent history for last execution
             history = self.get_recent_history(max_items=5)
+            if history is UNKNOWN:
+                return UNKNOWN
             if not history:
                 return None
 
@@ -275,6 +305,19 @@ class ComfyUIIdleMonitor:
         # to prevent re-unloading on stale history timestamps.
         if self._monitor_start_time:
             last_real_activity = self.get_last_activity_time()
+            if last_real_activity is UNKNOWN:
+                # Etat serveur indeterminable : NE PAS deviner l'idle depuis
+                # le start du monitor. L'ancien fallback tirait /free toutes
+                # les CHECK_INTERVAL secondes des que l'API devenait
+                # injoignable (auth stale post-restart, serveur sature en
+                # generation), y compris DANS un serveur occupe -> crash
+                # (exit 0, reboot 7-8 min). Fail-safe : on skippe.
+                logger.warning(
+                    "Server state indeterminate (API unreachable or auth "
+                    "failed) -- skipping idle check (fail-safe, no blind /free)"
+                )
+                self._error_count += 1
+                return False
             # Use the most recent of: last real activity, or last unload time
             if last_real_activity is not None:
                 last_activity = max(last_real_activity, self._monitor_start_time)
@@ -282,6 +325,13 @@ class ComfyUIIdleMonitor:
                 last_activity = self._monitor_start_time
         else:
             last_activity = self.get_last_activity_time()
+            if last_activity is UNKNOWN:
+                logger.warning(
+                    "Server state indeterminate (API unreachable or auth "
+                    "failed) -- skipping idle check (fail-safe, no blind /free)"
+                )
+                self._error_count += 1
+                return False
 
         if last_activity is None:
             logger.debug("No activity recorded and no start time, skipping check")
@@ -294,6 +344,22 @@ class ComfyUIIdleMonitor:
         logger.info(f"Idle: {idle_time:.0f}s / {self.idle_timeout}s ({source}, {self.comfyui_url})")
 
         if idle_time >= self.idle_timeout:
+            # Derniere ligne de defense avant /free : re-verifier la queue a
+            # l'instant present. Une generation peut avoir demarre entre la
+            # lecture d'historique et maintenant ; et /free dans un serveur
+            # en train d'executer/charger un modele le fait crasher.
+            running = self.get_running_prompts()
+            if running is UNKNOWN:
+                logger.warning(
+                    "Aborting /free: queue state indeterminate at fire time"
+                )
+                self._error_count += 1
+                return False
+            if running:
+                logger.info(
+                    f"Aborting /free: {len(running)} prompt(s) running at fire time"
+                )
+                return False
             logger.info(f"Idle timeout reached ({idle_time:.0f}s >= {self.idle_timeout}s)")
             unloaded = self.unload_models()
             if unloaded:

--- a/docker-configurations/services/shared/test_comfyui_idle_monitor.py
+++ b/docker-configurations/services/shared/test_comfyui_idle_monitor.py
@@ -1,0 +1,181 @@
+"""Tests unitaires pour comfyui_idle_monitor.py (incident 2026-08-25).
+
+Déterministes : mockent les primitives HTTP du monitor (pas de ComfyUI réel,
+pas de réseau). Le incident fondateur : quand l'API devient injoignable
+(auth stale post-restart, serveur saturé en génération), l'ancien code
+confondait « échec de la requête » et « queue vide vérifiée », devinait un
+idle depuis le démarrage du monitor, et tirait /free EN BOUCLE — y compris
+dans un serveur en pleine génération, le faisant crasher (exit 0, reboot
+7-8 min, 3 restarts en ~30 min ; logs : « no history » + idle croissant
+2673→3273s + unload 18→27 toutes les ~67s).
+
+Les tests verrouillent le fail-safe tri-états :
+  UNKNOWN (indéterminable)  -> skip, jamais de /free à l'aveugle ;
+  None (vide vérifié)        -> fallback monitor_start (boot frais) ;
+  garde pré-/free            -> queue relue à l'instant du tir.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+MONITOR = HERE / "comfyui_idle_monitor.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("comfyui_idle_monitor", MONITOR)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _monitor(mod, idle_timeout: int = 1200):
+    return mod.ComfyUIIdleMonitor(
+        comfyui_url="http://comfyui-test:8188",
+        idle_timeout=idle_timeout,
+        check_interval=60,
+        auth_token="test-token",
+    )
+
+
+# --- Tri-state des primitives -------------------------------------------------
+
+
+def test_queue_failure_returns_unknown_not_empty():
+    mod = _load()
+    m = _monitor(mod)
+    with patch.object(m, "session") as sess:
+        sess.get.side_effect = ConnectionError("refused")
+        r = m.get_running_prompts()
+    assert r is mod.UNKNOWN, "un échec de requête n'est PAS une queue vide"
+
+
+def test_history_failure_returns_unknown_not_empty():
+    mod = _load()
+    m = _monitor(mod)
+    with patch.object(m, "session") as sess:
+        sess.get.side_effect = ConnectionError("refused")
+        r = m.get_recent_history()
+    assert r is mod.UNKNOWN
+
+
+def test_auth_failure_returns_unknown_not_empty():
+    """Le déclencheur réel de l'incident : token stale après restart du serveur."""
+    mod = _load()
+    m = _monitor(mod)
+    m.auth_token = None
+    m.username = "admin"
+    m.password = "secret"
+    m._logged_in = False
+    with patch.object(m, "login", return_value=False):
+        assert m.get_running_prompts() is mod.UNKNOWN
+        assert m.get_recent_history() is mod.UNKNOWN
+
+
+# --- check_and_unload : fail-safe UNKNOWN -> skip, pas de /free aveugle -------
+
+
+def test_indeterminate_api_skips_check_no_free():
+    """Le cœur du fix : API injoignable -> SKIP, même si l'idle « deviné »
+    depuis le start du monitor dépasse largement le timeout."""
+    mod = _load()
+    m = _monitor(mod)
+    m._monitor_start_time = time.time() - 99999  # « idle » astronomique
+    with patch.object(m, "get_last_activity_time", return_value=mod.UNKNOWN), \
+         patch.object(m, "unload_models") as unload:
+        assert m.check_and_unload() is False
+        unload.assert_not_called()
+    assert m._error_count == 1
+
+
+def test_indeterminate_api_without_start_time_also_skips():
+    mod = _load()
+    m = _monitor(mod)
+    m._monitor_start_time = None
+    with patch.object(m, "get_last_activity_time", return_value=mod.UNKNOWN), \
+         patch.object(m, "unload_models") as unload:
+        assert m.check_and_unload() is False
+        unload.assert_not_called()
+
+
+# --- Chemins légitimes (non-régression) ----------------------------------------
+
+
+def test_verified_idle_triggers_free_and_resets_baseline():
+    mod = _load()
+    m = _monitor(mod)
+    old_start = time.time() - 99999
+    m._monitor_start_time = old_start
+    with patch.object(m, "get_last_activity_time", return_value=time.time() - 99999), \
+         patch.object(m, "get_running_prompts", return_value=[]), \
+         patch.object(m, "unload_models", return_value=True) as unload:
+        assert m.check_and_unload() is True
+        unload.assert_called_once()
+    assert m._monitor_start_time > old_start, "le reset post-unload doit tenir"
+
+
+def test_running_prompt_counts_as_active():
+    mod = _load()
+    m = _monitor(mod)
+    m._monitor_start_time = time.time() - 99999
+    with patch.object(m, "get_last_activity_time", return_value=time.time()), \
+         patch.object(m, "unload_models") as unload:
+        assert m.check_and_unload() is False
+        unload.assert_not_called()
+
+
+def test_empty_verified_history_after_boot_falls_back_to_monitor_start():
+    """None (vide VÉRIFIÉ, pas UNKNOWN) reste éligible au fallback boot frais."""
+    mod = _load()
+    m = _monitor(mod, idle_timeout=100)
+    m._monitor_start_time = time.time() - 200  # boot il y a 200s, timeout 100s
+    with patch.object(m, "get_last_activity_time", return_value=None), \
+         patch.object(m, "get_running_prompts", return_value=[]), \
+         patch.object(m, "unload_models", return_value=True) as unload:
+        assert m.check_and_unload() is True
+        unload.assert_called_once()
+
+
+# --- Garde pré-/free -----------------------------------------------------------
+
+
+def test_free_aborts_when_queue_started_between_measure_and_fire():
+    """Une génération démarre entre la lecture d'historique et le /free :
+    le re-check à l'instant du tir doit l'annuler."""
+    mod = _load()
+    m = _monitor(mod)
+    m._monitor_start_time = time.time() - 99999
+    with patch.object(m, "get_last_activity_time", return_value=time.time() - 99999), \
+         patch.object(m, "get_running_prompts", return_value=["prompt-abc"]), \
+         patch.object(m, "unload_models") as unload:
+        assert m.check_and_unload() is False
+        unload.assert_not_called()
+
+
+def test_free_aborts_when_precheck_indeterminate():
+    mod = _load()
+    m = _monitor(mod)
+    m._monitor_start_time = time.time() - 99999
+    with patch.object(m, "get_last_activity_time", return_value=time.time() - 99999), \
+         patch.object(m, "get_running_prompts", return_value=mod.UNKNOWN), \
+         patch.object(m, "unload_models") as unload:
+        assert m.check_and_unload() is False
+        unload.assert_not_called()
+
+
+def test_free_fires_when_precheck_confirms_empty_queue():
+    """Queue relue VIDE à l'instant du tir : le /free légitime passe."""
+    mod = _load()
+    m = _monitor(mod)
+    m._monitor_start_time = time.time() - 99999
+    # get_last_activity_time appelle get_running_prompts en interne (première
+    # lecture : vide), puis la garde pré-/free relit (deuxième lecture : vide).
+    with patch.object(m, "get_last_activity_time", return_value=time.time() - 99999), \
+         patch.object(m, "get_running_prompts", return_value=[]), \
+         patch.object(m, "unload_models", return_value=True) as unload:
+        assert m.check_and_unload() is True
+        unload.assert_called_once()

--- a/docs/genai/genai-services.md
+++ b/docs/genai/genai-services.md
@@ -272,7 +272,7 @@ BATCH_MODE=false
 - `whisper-api`, `musicgen-api`, `demucs-api`, `qwen-asr-api` — use `shared/lazy_model.py` with `IDLE_TIMEOUT=300`
 
 **External idle monitor sidecars:**
-- `comfyui-qwen`, `comfyui-video` — `comfyui_idle_monitor.py` (calls `/free` to unload models)
+- `comfyui-qwen`, `comfyui-video` — `comfyui_idle_monitor.py` (calls `/free` to unload models). Fail-safe tri-state : si l'état du serveur est indéterminable (API injoignable / auth échouée), le check est **sauté** — jamais de `/free` à l'aveugle ; et la queue est relue à l'instant du tir (un prompt démarré entre la mesure et le `/free` l'annule). Avant ce garde-fou, un token stale post-restart déclenchait `/free` en boucle toutes les ~67 s, y compris pendant une génération active → crash serveur (exit 0, reboot 7-8 min, incident 2026-08-25).
 - `vllm-zimage`, `tts-fishaudio` — `service_idle_monitor.py` (stops container)
 - `sd-forge-main` — `service_idle_monitor.py` with HTTP Basic Auth (Caddy reverse proxy)
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/guard #13017

## Summary

Fix durable du bug idle-detection du sidecar `comfyui-qwen-idle-monitor` (documente sur le dashboard depuis le 2026-08-25, blocage structurel « ComfyUI Monitor Bug »).

**Incident fondateur (2026-08-25, verifie firsthand dans les logs)** : quand l'API ComfyUI devenait injoignable (token stale apres restart, ou serveur sature en generation), `get_running_prompts()` / `get_recent_history()` avalaient l'exception et retournaient `[]` / `{}` — **indiscernables d'une queue/historique VERIFIES vides**. `check_and_unload` devinait alors l'idle depuis le start du monitor, depassait le timeout 1200s, et tirait `/free` a l'aveugle — y compris PENDANT une generation active, ce qui crashe ComfyUI (exit 0 propre, reboot Docker 7-8 min). 3 restarts en ~30 min. La boucle etait encore LIVE a la prise du grain : logs « no history », idle croissant 2673→3273s, `/free` toutes les ~67s (unload 18→27).

**Root-cause double** : (1) confusion echec-de-requete == vide-verify ; (2) le fallback « no history » devinait l'idle au lieu de skipper. La version deployee dans l'image etait en plus agee que main (pas de reset de baseline sur la branche no-history) — diff image vs origin/main fourni dans la session.

## Le fix (3 etages de defense)

1. **Sentinel `UNKNOWN`** (module-level, distinct de `None`) : echec de requete ou echec d'auth => `UNKNOWN`, pas `[]`/`{}`. Propage a travers `get_running_prompts` → `get_recent_history` → `get_last_activity_time`. `None` garde son sens legitime : queue ET historique verses et vides (boot frais).
2. **`check_and_unload` fail-safe** : `UNKNOWN` => **skip** du check (jamais de /free a l'aveugle), error_count incremente. Les chemins legitimes (idle verifie, boot frais via fallback baseline, reset post-unload de main) sont inchanges.
3. **Garde pre-/free** : relecture de la queue a l'instant du tir — un prompt demarre entre la mesure d'historique et le `/free` annule le tir ; une queue indeterminable a l'instant du tir l'annule aussi.

## Validation (regle F : repare en production, pas contourne)

- **Tests** : `pytest docker-configurations/services/shared/test_comfyui_idle_monitor.py` → **11 passed** (tri-etats des primitives, skip UNKNOWN, aborts pre-/free, non-regression des chemins legitimes). Sibling `test_service_wake.py` → 16 passed (27 total, 0 regression).
- **Deploye et verifie LIVE sur cette machine** (po-2023, host du service) : image rebuild depuis la branche (`docker compose build idle-monitor`), sidecar recree `up -d --no-deps` (serveur ComfyUI non touche), script deploye verifie (`grep -c UNKNOWN /app/comfyui_idle_monitor.py` → 16). **Logs post-fix** : cadence saine `Idle: 0s → 67s / 1200s (since last unload)` depuis la baseline, **zero /free** — versus la boucle `/free` toutes les 67s avant.
- Doc : `docs/genai/genai-services.md` §Idle Management documente le fail-safe (une ligne, le comportement « calls /free » reste vrai).
- Bénéficiaires : `comfyui-qwen` ET `comfyui-video` (meme script via build context `shared/`).

## Scope

Aucun notebook touche. 3 fichiers : le script sidecar, son test, une ligne de doc. Catalogue non touche.

## Test plan

- [x] 11 tests pytest verts (preuve ci-dessus)
- [x] Deploiement live + verification logs post-fix (cadence 0→67s, 0 /free)
- [x] Non-regression sibling test_service_wake.py (16 passed)
- [ ] Surveillance a moyen terme : si l'API redevient injoignable (restart serveur), le monitor doit logger le WARNING skip au lieu de boucler — comportement observable dans `docker logs comfyui-qwen-idle-monitor`

🤖 Generated with [Claude Code](https://claude.com/claude-code/)


Co-Authored-By: Claude-Code <noreply@anthropic.com>