### PR TITLE
fix(guard,#12704): runner pwsh scripts via -File -- stdin here-strings were silent no-ops

### DIFF
--- a/scripts/ci/manage_self_hosted_runner.py
+++ b/scripts/ci/manage_self_hosted_runner.py
@@ -338,11 +338,23 @@ def _minimal_env(extra: Mapping[str, str] | None = None) -> dict[str, str]:
 
 
 def _run_powershell(script: str, env: Mapping[str, str], run: CommandRunner) -> None:
-    completed = run(
-        ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "-"],
-        input=script, capture_output=True, text=True, encoding="utf-8",
-        env=_minimal_env(env), check=False,
-    )
+    # Delivery via temp file + -File, never `-Command -` over stdin: pwsh
+    # silently stops executing a stdin command block at a PowerShell
+    # here-string (@'...'@) and still exits 0, which turned every apply
+    # script below into a silent no-op reported as success.
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".ps1", delete=False, encoding="utf-8"
+    ) as handle:
+        handle.write(script)
+        script_path = handle.name
+    try:
+        completed = run(
+            ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-File", script_path],
+            capture_output=True, text=True, encoding="utf-8",
+            env=_minimal_env(env), check=False,
+        )
+    finally:
+        Path(script_path).unlink(missing_ok=True)
     if completed.returncode != 0:
         detail = (completed.stderr or completed.stdout or "PowerShell failed").strip()
         raise Refused(detail.replace(os.environ.get(ACCOUNT_PASSWORD_ENV, "\0"), "[REDACTED]"))

--- a/scripts/tests/test_manage_self_hosted_runner.py
+++ b/scripts/tests/test_manage_self_hosted_runner.py
@@ -102,6 +102,36 @@ def PureWindows(path: Path) -> str:
     return "C:\\" + "\\".join(path.parts[-3:])
 
 
+def test_run_powershell_delivers_scripts_via_file_not_stdin():
+    # Regression (measured on pwsh 7.5, 2026-08-25): `-Command -` fed over
+    # stdin silently stops executing at a PowerShell here-string (@'...'@)
+    # and still exits 0, turning every apply script embedding one into a
+    # no-op reported as success. Scripts must be delivered via -File.
+    seen = {}
+
+    def run(argv, **kwargs):
+        seen["argv"] = list(argv)
+        seen["env"] = kwargs["env"]
+        seen["script"] = Path(argv[-1]).read_text(encoding="utf-8")
+        assert "input" not in kwargs
+        return completed(argv)
+
+    script = "$c = ConvertFrom-Json @'\n{\"a\": 1}\n'@\nWrite-Output $c.a\n"
+    mod._run_powershell(script, {"MARKER": "x"}, run=run)
+    assert seen["argv"][1:5] == ["-NoLogo", "-NoProfile", "-NonInteractive", "-File"]
+    assert seen["script"] == script
+    assert seen["env"]["MARKER"] == "x"
+    assert not Path(seen["argv"][-1]).exists()
+
+
+def test_generated_apply_scripts_embed_here_strings():
+    # If these scripts ever stop embedding here-strings the regression test
+    # above loses its teeth: anchor the property the delivery bug broke.
+    target = profile(Path("unused"))
+    for generator in (mod._account_acl_script, mod._teardown_identity_script):
+        assert "@'" in generator(target)
+
+
 def test_manager_has_no_duplicate_top_level_definitions():
     tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
     names = [
@@ -282,7 +312,7 @@ def test_install_extracts_atomically_and_never_logs_password(tmp_path, monkeypat
     def run(*args, **kwargs):
         calls.append((args, kwargs))
         assert password not in " ".join(args[0])
-        assert password not in kwargs["input"]
+        assert password not in Path(args[0][-1]).read_text(encoding="utf-8")
         assert kwargs["env"][mod.ACCOUNT_PASSWORD_ENV] == password if len(calls) == 1 else True
         return completed(args[0])
 
@@ -449,8 +479,10 @@ def test_teardown_unregisters_without_secret_argv_and_archives_logs(tmp_path, mo
     calls = []
 
     def run(argv, **kwargs):
-        calls.append((argv, kwargs))
+        script = Path(argv[-1]).read_text(encoding="utf-8") if argv[0] == "pwsh" else ""
+        calls.append((argv, kwargs, script))
         assert token not in " ".join(argv)
+        assert token not in calls[-1][2]
         return completed(argv)
 
     mod.apply_teardown(target, run=run)
@@ -459,8 +491,8 @@ def test_teardown_unregisters_without_secret_argv_and_archives_logs(tmp_path, mo
     assert calls[0][0][1:] == ["remove", "--unattended"]
     assert calls[0][1]["env"]["ACTIONS_RUNNER_INPUT_TOKEN"] == token
     assert calls[1][0][0] == "pwsh"
-    assert "Get-CimInstance Win32_Service" in calls[1][1].get("input", "")
-    assert "Remove-LocalUser" in calls[2][1].get("input", "")
+    assert "Get-CimInstance Win32_Service" in calls[1][2]
+    assert "Remove-LocalUser" in calls[2][2]
 
 
 def test_teardown_refuses_if_archived_log_contains_supplied_secret(tmp_path, monkeypatch):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/tooling #12981

See #12704 (outillage runner self-hosted, #12784/#12833) — défaut de livraison découvert en exécutant la préparation pilote sur po-2024 (dispatch ai-01 2026-08-25T19:52Z)

## Summary

`manage_self_hosted_runner._run_powershell` livrait ses scripts par `pwsh -Command -` **sur stdin**. Or pwsh **s'arrête silencieusement d'exécuter** un bloc de commande stdin dès qu'il rencontre une **here-string PowerShell** (`@'...'@`) — et **sort quand même 0**.

Toutes les scripts apply en contiennent une (`ConvertFrom-Json @'...'@` pour injecter la config sérialisée : `_account_acl_script`, `_runner_root_acl_script`, `_teardown_identity_script`, `_teardown_service_script`, `_probe_script`) — **toute la surface `--apply` de l'outil était un no-op silencieux rapporté comme succès**.

**Mesuré firsthand sur po-2024 (pwsh 7.5)** pendant la préparation du runner pilote :

| Observation | Canal stdin (`-Command -`) | Canal fichier (`-File`) |
|---|---|---|
| repro minimale `@'{"a":41}'@` + Write-Output | **aucune sortie, exit 0** | `VAL:42` |
| script de compte exact via pwsh | **exit 0, rien exécuté** | `New-LocalUser: Accès refusé`, exit 1 |
| `install --apply` du manager | `applied: true` — **faux** : aucun compte, aucune ACE deny | (après fix) `Refused: New-LocalUser … Accès refusé` |

Le faux `applied: true` a masqué le vrai bloqueur (session non élevée → `New-LocalUser` refusé). Avec le fix, le garde parle : l'échec réel remonte en `Refused` comme conçu.

## Fix

`_run_powershell` écrit le script dans un `.ps1` temporaire (UTF-8 no-BOM) et invoque `pwsh -File`. Le secret ne transite ni par argv ni par le contenu du script (déjà le cas : le script lit `$env:`) ; le fichier est supprimé dans un `finally` ; la redaction Refused est inchangée.

## Validation

- Repro minimal avant/après (tableau ci-dessus), exécuté sur la vraie machine
- `pytest scripts/tests/test_manage_self_hosted_runner.py scripts/tests/test_check_self_hosted_runner_policy.py` : **75 passed** (les 3 tests instrumentant l'ancien canal stdin adaptés au canal fichier, avec les mêmes assertions de non-fuite de secret en argv ET en contenu de script)
- Nouveau test de régression `test_run_powershell_delivers_scripts_via_file_not_stdin` (livraison `-File`, contenu intégral, cleanup du temporaire, pas de kwarg `input`) + `test_generated_apply_scripts_embed_here_strings` (ancre la propriété que le bug cassait)
- Live : rejeu du script de compte via le `_run_powershell` corrigé → `Refused: New-LocalUser … Accès refusé` (le vrai échec non-élevé, enfin visible)

## Impact fleet

Tout agent ayant exécuté `install/register/teardown --apply` avec l'ancien code a potentiellement un état **partiel silencieux** (binaires posés, compte/ACLs non posés) rapporté comme succès. Après merge de ce fix, re-jouer `verify --apply` fait foi : il refusera proprement tant que le compte dédié n'existe pas.

## Note de genre

MED/guard (META) : correctif d'un garde qui rendait du faux-vert — il ne tient pas le plancher G-VAR-1 du cycle ; le plancher est tenu par la PR CONTENT J-lens #12981/en-vol (fits GPU). Grain découvert en exécutant la mission coordinator (préparation pilote), pas en scannant.
