### PR TITLE
fix(guards,#13030): OVERRIDE marker must be POSED (line-anchored), not CITED — close silent merge-gate disarm

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -123,7 +123,26 @@ AGENT_PREFIXES = (
 # temporelles restent entieres : un override POST-merge ne peut pas avoir
 # eteint une reserve avant la decision de merge (borne #10761).
 COORDINATOR_LOGINS = {"myia-ai-01", "jsboige"}
-OVERRIDE_LANE = re.compile(r"\[OVERRIDE\]\s+lane\s+\S+")
+# #13030 -- le marqueur doit etre POSE, pas CITE. L'ancien pattern sans
+# ancre matchait n'importe quelle mention dans le corps : le commentaire de
+# la lane #12872 qui DOCUMENTAIT l'option « (b) `[OVERRIDE] lane x` par
+# ai-01 » a eteint deux reserves BOT-CONCERN jamais levees (regex matchee
+# dans le backtick, nom de lane capture avec le backtick parasite), et le
+# gate est passe rc=0 sans que rien ne le signale. Un override fantome
+# SOUS-bloque : la porte s'ouvre silencieusement -- inverse exact du
+# [CLAIMED] fantome qui sur-bloque. Trois proprietes :
+#   1. ancrage ^ (re.M) : le marqueur doit ouvrir la ligne (un tiret de
+#      liste ou une phrase qui le precede = citation) ;
+#   2. rejet de la forme encadree de backticks -- la citation canonique ;
+#   3. lane capturee sans backtick parasite ( `\S+` avalait `CoursIA-2`` `).
+# Decoration de debut de ligne toleree (même famille que _DECOR de
+# check_lane_claim #10906 : `>`, `#`, `-` ne doivent pas voider un vrai
+# override) -- mais le backtick AVANT le crochet reste une citation, seul
+# le decor ASCII #>*+- l'est.
+_OVERRIDE_LANE = re.compile(
+    r"(?m)^[#>*+\-\s]*\[\s*OVERRIDE\s*\]\s+lane\s+([^\s`]+)",
+)
+OVERRIDE_LANE = _OVERRIDE_LANE
 
 # #13083 — le symetrique de #11639 : un coordinateur BLOQUE aussi, et l'organe
 # ne le modelisait pas. Même contrainte de pose stricte que le durcissement de
@@ -997,8 +1016,12 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         # s'ajoute. Un OVERRIDE sans phrase de levee n'entre meme pas ici :
         # can_lift l'a ecarte (tag de protocole nu), et explicit_lifts exige
         # un LIFT_MARKER.
+        # #13030 -- search sur le corps ENTIER retire : une citation du
+        # marqueur (documentation, dispatch, post-mortem, DM recopie)
+        # posait l'override. Seule la forme POSEE en tete de ligne compte.
+        m = OVERRIDE_LANE.search(lift_body or "")
         return (lift_author in COORDINATOR_LOGINS
-                and bool(OVERRIDE_LANE.search(lift_body or "")))
+                and m is not None)
 
     # Fenetre 2026-08-16 (#11222) : les temps plats ne suffisent pas pour un
     # CHANGES_REQUESTED. Une PHRASE explicite de levee (LIFT_MARKER non

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -1108,6 +1108,58 @@ def test_coord_override_leve_aussi_le_state_changes_requested():
     assert mod.analyse(data, [], MERGED)["blocked"] is False
 
 
+# --- #13030 : OVERRIDE POSE vs CITE -------------------------------------------
+# L'incident #12872 : le rapport de la lane qui DOCUMENTAIT l'option
+# « (b) `[OVERRIDE] lane x` par ai-01 » a eteint deux reserves BOT-CONCERN
+# jamais levees -- la regex ancre-less matchait dans le backtick, le gate
+# passait rc=0 sans que rien ne le signale. Un override fantome SOUS-bloque
+# (inverse exact du [CLAIMED] fantome qui sur-bloque). Le marqueur doit
+# desormais etre POSE en tete de ligne, hors backticks.
+
+def test_override_pose_canonique_leve():
+    """Controle positif : le marqueur seul en tete de ligne POSE l'override."""
+    lift = {"author": {"login": "myia-ai-01"},
+            "createdAt": "2026-08-18T13:06:34Z",
+            "body": "[OVERRIDE] lane myia-po-2026:CoursIA\n"
+                    "Levée de la réserve Hermes du 2026-08-17, points "
+                    "reportés sur #11058."}
+    assert run_coord([lift])["blocked"] is False
+
+
+def test_override_cite_dans_backtick_ne_leve_pas():
+    """Le cas EXACT de #12872 : une option documentee entre backticks dans
+    une puce ne pose PAS l'override -- le rapport qui explique que la
+    decision revient a ai-01 ne doit pas l'exercer."""
+    cited = {"author": {"login": "jsboige"},
+             "createdAt": "2026-08-25T17:38:05Z",
+             "body": "Options :\n"
+                     "- **(a)** attendre la re-review ;\n"
+                     "- **(b)** `[OVERRIDE] lane myia-po-2024:CoursIA-2` "
+                     "par ai-01 (commentaire sur cette PR) ;\n"
+                     "La lane ne peut pas lever ces 2 nits elle-meme."}
+    assert run_coord([cited])["blocked"] is True
+
+
+def test_override_cite_milieu_de_phrase_ne_leve_pas():
+    """« Le marqueur [OVERRIDE] lane x sert a ... » = documentation, pas acte."""
+    doc = {"author": {"login": "jsboige"},
+           "createdAt": "2026-08-26T00:00:00Z",
+           "body": "Le marqueur [OVERRIDE] lane x sert a arbitrer une "
+                   "reserve ; il doit etre pose en tete de ligne."}
+    assert run_coord([doc])["blocked"] is True
+
+
+def test_override_pose_apres_decor_leve():
+    """Non-regression #10906 (famille _DECOR de check_lane_claim) : un
+    override dans un blockquote / puce / heading reste POSE -- la tolerance
+    de decoration ne doit pas voider les formes legitimes de la flotte."""
+    quoted = {"author": {"login": "myia-ai-01"},
+              "createdAt": "2026-08-18T13:06:34Z",
+              "body": "> [OVERRIDE] lane myia-po-2026:CoursIA\n"
+                      "> Levée de la réserve Hermes, reportée sur #11058."}
+    assert run_coord([quoted])["blocked"] is False
+
+
 # --- #11677 : check_unaddressed_nits classe une review APPROVED en BOT-CONCERN
 # L'etat natif GitHub n'etait pas cable pour les reviews APPROVED (la branche
 # CHANGES_REQUESTED etait la seule symetrique documentee). 4 changes minimaux :


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/tooling #13027

## Summary

Le gate `check_unaddressed_nits.py` (garde B.0 `_lift_eligible`) laissait un override se poser via une **citation** du marqueur, pas une pose réelle.

**Incident fondateur (#12872, option (b))** : le commentaire de lane qui *documentait* l'option « (b) `[OVERRIDE] lane myia-po-2024:CoursIA-2` par ai-01 » a matché l'ancienne regex *à l'intérieur des backticks* (nom de lane capturé avec backtick parasite) et a éteint deux réserves `BOT_CONCERN` jamais levées → `rc=0`, merge silencieux, rien ne l'a signalé.

Un override fantôme **sous-bloque** (la porte s'ouvre en silence) — inverse exact du `[CLAIMED]` fantôme qui sur-bloque.

## Fix — 3 propriétés de l'acceptance

`_OVERRIDE_LANE` devient ancré ligne :

```python
re.compile(r"(?m)^[#>*+\-\s]*\[\s*OVERRIDE\s*\]\s+lane\s+([^\s`]+)")
```

| # | Propriété | Mécanisme |
|---|-----------|-----------|
| 1 | Ancrage `^` (re.M) | Le marqueur doit **ouvrir la ligne** — un tiret de liste ou une phrase qui le précède = citation |
| 2 | Rejet backticks | `[^\s`]+` + position de l'ancre : la forme `` `[OVERRIDE] lane x` `` canoniquement citée ne matche pas |
| 3 | Lane propre | Capture sans backtick parasite (`\S+` avalait `CoursIA-2`` `) |

Décor ASCII de début de ligne toléré (`>`, `#`, `-`, `*`, `+`) — même famille que `_DECOR` de `check_lane_claim` #10906 : un vrai override blockquoté ou en liste reste valide. Le backtick **avant** le crochet reste une citation.

`_lift_eligible` passe du search flou au match ancré ; bornes temporelles #10761 inchangées.

## Tests — 4 nouveaux (146 passed)

| Test | Cas | Attendu |
|------|-----|---------|
| `test_override_pose_canonique_leve` | `[OVERRIDE] lane x` en tête de ligne, coordo, pré-merge | lève |
| `test_override_cite_dans_backtick_ne_leve_pas` | body **exact** du commentaire #12872 | ne lève pas |
| `test_override_cite_milieu_de_phrase_ne_leve_pas` | mention en milieu de phrase | ne lève pas |
| `test_override_pose_apres_decor_leve` | `> [OVERRIDE] lane x` (blockquote) | lève |

```
python -m pytest -q scripts/tests/test_check_unaddressed_nits.py
146 passed in 0.28s
```

## Audit rétrospectif (livrable de l'acceptance)

Merged PRs matchées par la recherche GitHub `"[OVERRIDE] lane" in:comments is:merged` (64 candidates), classées par nouvelle regex sur le corps réel de chaque PR :

- **POSED (override réel, gate légitime)** : 13 PRs — comportement inchangé par ce fix
- **CITED-ONLY (l'ancienne regex matchait une citation)** : **51 PRs** dont le `rc=0` a pu reposer sur un override fantôme :

12810, 11886, 12099, 11963, 12281, 11729, 11841, 12170, 12394, 12352, 11997, 12884, 11965, 11727, 12890, 11974, 11951, 12180, 11776, 11767, 12602, 11861, 12107, 12543, 11529, 12612, 11733, 12927, 11777, 11978, 12176, 11916, 10236, 11452, 12056, 10468, 12314, 11758, 11680, 11845, 11507, 12054, 12316, 10358, 11671, 10499, 10452, 10304, 10307, 12343, 11134

⚠️ La plupart de ces 51 n'avaient probablement **aucun nit en attente** au moment du merge (le gate passait à `rc=0` indépendamment de l'override — un corps qui mentionne le marqueur ne crée pas de nit). La liste est un **portefeuille de candidats à re-vérifier** pour le coordinateur (ai-01), pas un constat de 51 merges fautifs. Audit script + artefacts : scratch local, non committés.

Closes #13030

## Validation

- [x] `python -m pytest -q scripts/tests/test_check_unaddressed_nits.py` → **146 passed** (142 pré-existants + 4 nouveaux, 0 régression)
- [x] Diff = 2 fichiers uniquement (`scripts/check_unaddressed_nits.py` + tests) — pas de scratch committé
- [x] Audit rétrospectif complet (64 candidates search API → classification per-PR sur corps réel)