### PR TITLE
feat(probas,#13032): censure a droite executee dans les twins Infer-19/PyMC-19 (naif vs S(c_i) vs Kaplan-Meier)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
@@ -59,10 +59,10 @@
    "id": "6cafeb7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T22:38:58.061132Z",
-     "iopub.status.busy": "2026-07-14T22:38:58.047274Z",
-     "iopub.status.idle": "2026-07-14T22:39:05.173890Z",
-     "shell.execute_reply": "2026-07-14T22:39:05.165535Z"
+     "iopub.execute_input": "2026-08-26T02:37:20.887590Z",
+     "iopub.status.busy": "2026-08-26T02:37:20.882255Z",
+     "iopub.status.idle": "2026-08-26T02:37:21.850685Z",
+     "shell.execute_reply": "2026-08-26T02:37:21.845805Z"
     }
    },
    "outputs": [
@@ -75,6 +75,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -84,7 +85,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -99,6 +103,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -110,11 +115,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '1430364.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '45588.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -158,11 +165,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -183,8 +192,8 @@
     }
    ],
    "source": [
-    "#r \"nuget: Microsoft.ML.Probabilistic\"\n",
-    "#r \"nuget: Microsoft.ML.Probabilistic.Compiler\"\n",
+    "#r \"nuget: Microsoft.ML.Probabilistic, 0.4.2504.701\"\n",
+    "#r \"nuget: Microsoft.ML.Probabilistic.Compiler, 0.4.2504.701\"\n",
     "// restore Infer.NET -- isole dans sa propre cellule (convention de la serie)"
    ]
   },
@@ -204,10 +213,10 @@
    "id": "444c7d04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T22:39:05.176930Z",
-     "iopub.status.busy": "2026-07-14T22:39:05.176551Z",
-     "iopub.status.idle": "2026-07-14T22:39:06.667417Z",
-     "shell.execute_reply": "2026-07-14T22:39:06.667013Z"
+     "iopub.execute_input": "2026-08-26T02:37:21.852105Z",
+     "iopub.status.busy": "2026-08-26T02:37:21.851924Z",
+     "iopub.status.idle": "2026-08-26T02:37:22.447576Z",
+     "shell.execute_reply": "2026-08-26T02:37:22.447159Z"
     }
    },
    "outputs": [
@@ -258,10 +267,10 @@
    "id": "1dc34615",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T22:39:06.670018Z",
-     "iopub.status.busy": "2026-07-14T22:39:06.669573Z",
-     "iopub.status.idle": "2026-07-14T22:39:07.202505Z",
-     "shell.execute_reply": "2026-07-14T22:39:07.201863Z"
+     "iopub.execute_input": "2026-08-26T02:37:22.448867Z",
+     "iopub.status.busy": "2026-08-26T02:37:22.448682Z",
+     "iopub.status.idle": "2026-08-26T02:37:22.679274Z",
+     "shell.execute_reply": "2026-08-26T02:37:22.679009Z"
     }
    },
    "outputs": [
@@ -320,10 +329,10 @@
    "id": "1722c159",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T22:39:07.205706Z",
-     "iopub.status.busy": "2026-07-14T22:39:07.205060Z",
-     "iopub.status.idle": "2026-07-14T22:39:10.337747Z",
-     "shell.execute_reply": "2026-07-14T22:39:10.337346Z"
+     "iopub.execute_input": "2026-08-26T02:37:22.680563Z",
+     "iopub.status.busy": "2026-08-26T02:37:22.680394Z",
+     "iopub.status.idle": "2026-08-26T02:37:24.253760Z",
+     "shell.execute_reply": "2026-08-26T02:37:24.253573Z"
     }
    },
    "outputs": [
@@ -446,10 +455,10 @@
    "id": "3358bca7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T22:39:10.340197Z",
-     "iopub.status.busy": "2026-07-14T22:39:10.339854Z",
-     "iopub.status.idle": "2026-07-14T22:39:10.839617Z",
-     "shell.execute_reply": "2026-07-14T22:39:10.838752Z"
+     "iopub.execute_input": "2026-08-26T02:37:24.255163Z",
+     "iopub.status.busy": "2026-08-26T02:37:24.254979Z",
+     "iopub.status.idle": "2026-08-26T02:37:24.927602Z",
+     "shell.execute_reply": "2026-08-26T02:37:24.927467Z"
     }
    },
    "outputs": [
@@ -518,7 +527,9 @@
     },
     {
      "data": {
-      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='820' height='480' viewBox='0 0 820 480' font-family='sans-serif' font-size='12'><rect width='820' height='480' fill='white'/><text x='410' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Fonction de survie S(t) : bayesienne vs empirique</text><line x1='52' y1='438' x2='804' y2='438' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='442' text-anchor='end' fill='#333333'>0.043</text><line x1='52' y1='337' x2='804' y2='337' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='341' text-anchor='end' fill='#333333'>0.296</text><line x1='52' y1='236' x2='804' y2='236' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='240' text-anchor='end' fill='#333333'>0.549</text><line x1='52' y1='135' x2='804' y2='135' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='139' text-anchor='end' fill='#333333'>0.801</text><line x1='52' y1='34' x2='804' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>1.054</text><line x1='52' y1='34' x2='52' y2='438' stroke='#888888' stroke-width='1'/><line x1='52' y1='438' x2='804' y2='438' stroke='#888888' stroke-width='1'/><text x='52' y='454' text-anchor='middle' fill='#333333'>0</text><text x='240' y='454' text-anchor='middle' fill='#333333'>750</text><text x='428' y='454' text-anchor='middle' fill='#333333'>1500</text><text x='616' y='454' text-anchor='middle' fill='#333333'>2250</text><text x='804' y='454' text-anchor='middle' fill='#333333'>3000</text><text x='428' y='474' text-anchor='middle' fill='#333333'>t (heures)</text><text x='14' y='236' text-anchor='middle' fill='#333333' transform='rotate(-90 14 236)'>S(t)</text><polyline points='52,55.643 61.4,67.331 70.8,78.673 80.2,89.677 89.6,100.354 99,110.715 108.4,120.768 117.8,130.523 127.2,139.989 136.6,149.174 146,158.088 155.4,166.738 164.8,175.132 174.2,183.278 183.6,191.183 193,198.854 202.4,206.3 211.8,213.525 221.2,220.537 230.6,227.343 240,233.948 249.4,240.359 258.8,246.581 268.2,252.619 277.6,258.481 287,264.17 296.4,269.691 305.8,275.051 315.2,280.254 324.6,285.303 334,290.205 343.4,294.963 352.8,299.581 362.2,304.065 371.6,308.417 381,312.642 390.4,316.743 399.8,320.725 409.2,324.59 418.6,328.342 428,331.985 437.4,335.521 446.8,338.955 456.2,342.288 465.6,345.525 475,348.667 484.4,351.717 493.8,354.679 503.2,357.555 512.6,360.347 522,363.058 531.4,365.691 540.8,368.247 550.2,370.729 559.6,373.139 569,375.479 578.4,377.751 587.8,379.958 597.2,382.101 606.6,384.181 616,386.202 625.4,388.164 634.8,390.07 644.2,391.92 653.6,393.718 663,395.463 672.4,397.158 681.8,398.804 691.2,400.403 700.6,401.956 710,403.464 719.4,404.929 728.8,406.351 738.2,407.733 747.6,409.075 757,410.379 766.4,411.645 775.8,412.875 785.2,414.07 794.6,415.23 804,416.357' fill='none' stroke='#2a6dba' stroke-width='2'/><circle cx='52' cy='55.643' r='3' fill='#e8743b'/><circle cx='61.4' cy='55.643' r='3' fill='#e8743b'/><circle cx='70.8' cy='55.643' r='3' fill='#e8743b'/><circle cx='80.2' cy='62.303' r='3' fill='#e8743b'/><circle cx='89.6' cy='62.303' r='3' fill='#e8743b'/><circle cx='99' cy='62.303' r='3' fill='#e8743b'/><circle cx='108.4' cy='88.943' r='3' fill='#e8743b'/><circle cx='117.8' cy='102.264' r='3' fill='#e8743b'/><circle cx='127.2' cy='115.584' r='3' fill='#e8743b'/><circle cx='136.6' cy='122.244' r='3' fill='#e8743b'/><circle cx='146' cy='148.884' r='3' fill='#e8743b'/><circle cx='155.4' cy='155.545' r='3' fill='#e8743b'/><circle cx='164.8' cy='162.205' r='3' fill='#e8743b'/><circle cx='174.2' cy='175.525' r='3' fill='#e8743b'/><circle cx='183.6' cy='182.185' r='3' fill='#e8743b'/><circle cx='193' cy='195.505' r='3' fill='#e8743b'/><circle cx='202.4' cy='195.505' r='3' fill='#e8743b'/><circle cx='211.8' cy='208.825' r='3' fill='#e8743b'/><circle cx='221.2' cy='242.126' r='3' fill='#e8743b'/><circle cx='230.6' cy='248.786' r='3' fill='#e8743b'/><circle cx='240' cy='248.786' r='3' fill='#e8743b'/><circle cx='249.4' cy='248.786' r='3' fill='#e8743b'/><circle cx='258.8' cy='248.786' r='3' fill='#e8743b'/><circle cx='268.2' cy='248.786' r='3' fill='#e8743b'/><circle cx='277.6' cy='255.446' r='3' fill='#e8743b'/><circle cx='287' cy='262.106' r='3' fill='#e8743b'/><circle cx='296.4' cy='275.427' r='3' fill='#e8743b'/><circle cx='305.8' cy='275.427' r='3' fill='#e8743b'/><circle cx='315.2' cy='275.427' r='3' fill='#e8743b'/><circle cx='324.6' cy='275.427' r='3' fill='#e8743b'/><circle cx='334' cy='275.427' r='3' fill='#e8743b'/><circle cx='343.4' cy='282.087' r='3' fill='#e8743b'/><circle cx='352.8' cy='288.747' r='3' fill='#e8743b'/><circle cx='362.2' cy='288.747' r='3' fill='#e8743b'/><circle cx='371.6' cy='295.407' r='3' fill='#e8743b'/><circle cx='381' cy='295.407' r='3' fill='#e8743b'/><circle cx='390.4' cy='308.727' r='3' fill='#e8743b'/><circle cx='399.8' cy='322.047' r='3' fill='#e8743b'/><circle cx='409.2' cy='322.047' r='3' fill='#e8743b'/><circle cx='418.6' cy='328.707' r='3' fill='#e8743b'/><circle cx='428' cy='328.707' r='3' fill='#e8743b'/><circle cx='437.4' cy='328.707' r='3' fill='#e8743b'/><circle cx='446.8' cy='328.707' r='3' fill='#e8743b'/><circle cx='456.2' cy='328.707' r='3' fill='#e8743b'/><circle cx='465.6' cy='328.707' r='3' fill='#e8743b'/><circle cx='475' cy='335.368' r='3' fill='#e8743b'/><circle cx='484.4' cy='335.368' r='3' fill='#e8743b'/><circle cx='493.8' cy='342.028' r='3' fill='#e8743b'/><circle cx='503.2' cy='348.688' r='3' fill='#e8743b'/><circle cx='512.6' cy='348.688' r='3' fill='#e8743b'/><circle cx='522' cy='348.688' r='3' fill='#e8743b'/><circle cx='531.4' cy='368.668' r='3' fill='#e8743b'/><circle cx='540.8' cy='375.328' r='3' fill='#e8743b'/><circle cx='550.2' cy='381.988' r='3' fill='#e8743b'/><circle cx='559.6' cy='381.988' r='3' fill='#e8743b'/><circle cx='569' cy='381.988' r='3' fill='#e8743b'/><circle cx='578.4' cy='388.648' r='3' fill='#e8743b'/><circle cx='587.8' cy='388.648' r='3' fill='#e8743b'/><circle cx='597.2' cy='395.309' r='3' fill='#e8743b'/><circle cx='606.6' cy='395.309' r='3' fill='#e8743b'/><circle cx='616' cy='395.309' r='3' fill='#e8743b'/><circle cx='625.4' cy='395.309' r='3' fill='#e8743b'/><circle cx='634.8' cy='395.309' r='3' fill='#e8743b'/><circle cx='644.2' cy='395.309' r='3' fill='#e8743b'/><circle cx='653.6' cy='395.309' r='3' fill='#e8743b'/><circle cx='663' cy='401.969' r='3' fill='#e8743b'/><circle cx='672.4' cy='401.969' r='3' fill='#e8743b'/><circle cx='681.8' cy='401.969' r='3' fill='#e8743b'/><circle cx='691.2' cy='401.969' r='3' fill='#e8743b'/><circle cx='700.6' cy='401.969' r='3' fill='#e8743b'/><circle cx='710' cy='401.969' r='3' fill='#e8743b'/><circle cx='719.4' cy='401.969' r='3' fill='#e8743b'/><circle cx='728.8' cy='401.969' r='3' fill='#e8743b'/><circle cx='738.2' cy='401.969' r='3' fill='#e8743b'/><circle cx='747.6' cy='401.969' r='3' fill='#e8743b'/><circle cx='757' cy='401.969' r='3' fill='#e8743b'/><circle cx='766.4' cy='401.969' r='3' fill='#e8743b'/><circle cx='775.8' cy='401.969' r='3' fill='#e8743b'/><circle cx='785.2' cy='401.969' r='3' fill='#e8743b'/><circle cx='794.6' cy='401.969' r='3' fill='#e8743b'/><circle cx='804' cy='415.289' r='3' fill='#e8743b'/><rect x='632' y='42' width='168' height='50' fill='white' stroke='#E5E5E5' stroke-width='1'/><line x1='642' y1='54' x2='666' y2='54' stroke='#2a6dba' stroke-width='2'/><text x='674' y='58' fill='#333333'>Bayesienne (modele exponentiel)</text><circle cx='654' cy='72' r='3' fill='#e8743b'/><text x='674' y='76' fill='#333333'>Empirique (donnees)</text></svg>"
+      "text/html": [
+       "<svg xmlns='http://www.w3.org/2000/svg' width='820' height='480' viewBox='0 0 820 480' font-family='sans-serif' font-size='12'><rect width='820' height='480' fill='white'/><text x='410' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Fonction de survie S(t) : bayesienne vs empirique</text><line x1='52' y1='438' x2='804' y2='438' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='442' text-anchor='end' fill='#333333'>0.043</text><line x1='52' y1='337' x2='804' y2='337' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='341' text-anchor='end' fill='#333333'>0.296</text><line x1='52' y1='236' x2='804' y2='236' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='240' text-anchor='end' fill='#333333'>0.549</text><line x1='52' y1='135' x2='804' y2='135' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='139' text-anchor='end' fill='#333333'>0.801</text><line x1='52' y1='34' x2='804' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>1.054</text><line x1='52' y1='34' x2='52' y2='438' stroke='#888888' stroke-width='1'/><line x1='52' y1='438' x2='804' y2='438' stroke='#888888' stroke-width='1'/><text x='52' y='454' text-anchor='middle' fill='#333333'>0</text><text x='240' y='454' text-anchor='middle' fill='#333333'>750</text><text x='428' y='454' text-anchor='middle' fill='#333333'>1500</text><text x='616' y='454' text-anchor='middle' fill='#333333'>2250</text><text x='804' y='454' text-anchor='middle' fill='#333333'>3000</text><text x='428' y='474' text-anchor='middle' fill='#333333'>t (heures)</text><text x='14' y='236' text-anchor='middle' fill='#333333' transform='rotate(-90 14 236)'>S(t)</text><polyline points='52,55.643 61.4,67.331 70.8,78.673 80.2,89.677 89.6,100.354 99,110.715 108.4,120.768 117.8,130.523 127.2,139.989 136.6,149.174 146,158.088 155.4,166.738 164.8,175.132 174.2,183.278 183.6,191.183 193,198.854 202.4,206.3 211.8,213.525 221.2,220.537 230.6,227.343 240,233.948 249.4,240.359 258.8,246.581 268.2,252.619 277.6,258.481 287,264.17 296.4,269.691 305.8,275.051 315.2,280.254 324.6,285.303 334,290.205 343.4,294.963 352.8,299.581 362.2,304.065 371.6,308.417 381,312.642 390.4,316.743 399.8,320.725 409.2,324.59 418.6,328.342 428,331.985 437.4,335.521 446.8,338.955 456.2,342.288 465.6,345.525 475,348.667 484.4,351.717 493.8,354.679 503.2,357.555 512.6,360.347 522,363.058 531.4,365.691 540.8,368.247 550.2,370.729 559.6,373.139 569,375.479 578.4,377.751 587.8,379.958 597.2,382.101 606.6,384.181 616,386.202 625.4,388.164 634.8,390.07 644.2,391.92 653.6,393.718 663,395.463 672.4,397.158 681.8,398.804 691.2,400.403 700.6,401.956 710,403.464 719.4,404.929 728.8,406.351 738.2,407.733 747.6,409.075 757,410.379 766.4,411.645 775.8,412.875 785.2,414.07 794.6,415.23 804,416.357' fill='none' stroke='#2a6dba' stroke-width='2'/><circle cx='52' cy='55.643' r='3' fill='#e8743b'/><circle cx='61.4' cy='55.643' r='3' fill='#e8743b'/><circle cx='70.8' cy='55.643' r='3' fill='#e8743b'/><circle cx='80.2' cy='62.303' r='3' fill='#e8743b'/><circle cx='89.6' cy='62.303' r='3' fill='#e8743b'/><circle cx='99' cy='62.303' r='3' fill='#e8743b'/><circle cx='108.4' cy='88.943' r='3' fill='#e8743b'/><circle cx='117.8' cy='102.264' r='3' fill='#e8743b'/><circle cx='127.2' cy='115.584' r='3' fill='#e8743b'/><circle cx='136.6' cy='122.244' r='3' fill='#e8743b'/><circle cx='146' cy='148.884' r='3' fill='#e8743b'/><circle cx='155.4' cy='155.545' r='3' fill='#e8743b'/><circle cx='164.8' cy='162.205' r='3' fill='#e8743b'/><circle cx='174.2' cy='175.525' r='3' fill='#e8743b'/><circle cx='183.6' cy='182.185' r='3' fill='#e8743b'/><circle cx='193' cy='195.505' r='3' fill='#e8743b'/><circle cx='202.4' cy='195.505' r='3' fill='#e8743b'/><circle cx='211.8' cy='208.825' r='3' fill='#e8743b'/><circle cx='221.2' cy='242.126' r='3' fill='#e8743b'/><circle cx='230.6' cy='248.786' r='3' fill='#e8743b'/><circle cx='240' cy='248.786' r='3' fill='#e8743b'/><circle cx='249.4' cy='248.786' r='3' fill='#e8743b'/><circle cx='258.8' cy='248.786' r='3' fill='#e8743b'/><circle cx='268.2' cy='248.786' r='3' fill='#e8743b'/><circle cx='277.6' cy='255.446' r='3' fill='#e8743b'/><circle cx='287' cy='262.106' r='3' fill='#e8743b'/><circle cx='296.4' cy='275.427' r='3' fill='#e8743b'/><circle cx='305.8' cy='275.427' r='3' fill='#e8743b'/><circle cx='315.2' cy='275.427' r='3' fill='#e8743b'/><circle cx='324.6' cy='275.427' r='3' fill='#e8743b'/><circle cx='334' cy='275.427' r='3' fill='#e8743b'/><circle cx='343.4' cy='282.087' r='3' fill='#e8743b'/><circle cx='352.8' cy='288.747' r='3' fill='#e8743b'/><circle cx='362.2' cy='288.747' r='3' fill='#e8743b'/><circle cx='371.6' cy='295.407' r='3' fill='#e8743b'/><circle cx='381' cy='295.407' r='3' fill='#e8743b'/><circle cx='390.4' cy='308.727' r='3' fill='#e8743b'/><circle cx='399.8' cy='322.047' r='3' fill='#e8743b'/><circle cx='409.2' cy='322.047' r='3' fill='#e8743b'/><circle cx='418.6' cy='328.707' r='3' fill='#e8743b'/><circle cx='428' cy='328.707' r='3' fill='#e8743b'/><circle cx='437.4' cy='328.707' r='3' fill='#e8743b'/><circle cx='446.8' cy='328.707' r='3' fill='#e8743b'/><circle cx='456.2' cy='328.707' r='3' fill='#e8743b'/><circle cx='465.6' cy='328.707' r='3' fill='#e8743b'/><circle cx='475' cy='335.368' r='3' fill='#e8743b'/><circle cx='484.4' cy='335.368' r='3' fill='#e8743b'/><circle cx='493.8' cy='342.028' r='3' fill='#e8743b'/><circle cx='503.2' cy='348.688' r='3' fill='#e8743b'/><circle cx='512.6' cy='348.688' r='3' fill='#e8743b'/><circle cx='522' cy='348.688' r='3' fill='#e8743b'/><circle cx='531.4' cy='368.668' r='3' fill='#e8743b'/><circle cx='540.8' cy='375.328' r='3' fill='#e8743b'/><circle cx='550.2' cy='381.988' r='3' fill='#e8743b'/><circle cx='559.6' cy='381.988' r='3' fill='#e8743b'/><circle cx='569' cy='381.988' r='3' fill='#e8743b'/><circle cx='578.4' cy='388.648' r='3' fill='#e8743b'/><circle cx='587.8' cy='388.648' r='3' fill='#e8743b'/><circle cx='597.2' cy='395.309' r='3' fill='#e8743b'/><circle cx='606.6' cy='395.309' r='3' fill='#e8743b'/><circle cx='616' cy='395.309' r='3' fill='#e8743b'/><circle cx='625.4' cy='395.309' r='3' fill='#e8743b'/><circle cx='634.8' cy='395.309' r='3' fill='#e8743b'/><circle cx='644.2' cy='395.309' r='3' fill='#e8743b'/><circle cx='653.6' cy='395.309' r='3' fill='#e8743b'/><circle cx='663' cy='401.969' r='3' fill='#e8743b'/><circle cx='672.4' cy='401.969' r='3' fill='#e8743b'/><circle cx='681.8' cy='401.969' r='3' fill='#e8743b'/><circle cx='691.2' cy='401.969' r='3' fill='#e8743b'/><circle cx='700.6' cy='401.969' r='3' fill='#e8743b'/><circle cx='710' cy='401.969' r='3' fill='#e8743b'/><circle cx='719.4' cy='401.969' r='3' fill='#e8743b'/><circle cx='728.8' cy='401.969' r='3' fill='#e8743b'/><circle cx='738.2' cy='401.969' r='3' fill='#e8743b'/><circle cx='747.6' cy='401.969' r='3' fill='#e8743b'/><circle cx='757' cy='401.969' r='3' fill='#e8743b'/><circle cx='766.4' cy='401.969' r='3' fill='#e8743b'/><circle cx='775.8' cy='401.969' r='3' fill='#e8743b'/><circle cx='785.2' cy='401.969' r='3' fill='#e8743b'/><circle cx='794.6' cy='401.969' r='3' fill='#e8743b'/><circle cx='804' cy='415.289' r='3' fill='#e8743b'/><rect x='632' y='42' width='168' height='50' fill='white' stroke='#E5E5E5' stroke-width='1'/><line x1='642' y1='54' x2='666' y2='54' stroke='#2a6dba' stroke-width='2'/><text x='674' y='58' fill='#333333'>Bayesienne (modele exponentiel)</text><circle cx='654' cy='72' r='3' fill='#e8743b'/><text x='674' y='76' fill='#333333'>Empirique (donnees)</text></svg>"
+      ]
      },
      "execution_count": 5,
      "metadata": {},
@@ -604,10 +615,10 @@
    "id": "d77b4a83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T22:39:10.841593Z",
-     "iopub.status.busy": "2026-07-14T22:39:10.841279Z",
-     "iopub.status.idle": "2026-07-14T22:39:11.488001Z",
-     "shell.execute_reply": "2026-07-14T22:39:11.487643Z"
+     "iopub.execute_input": "2026-08-26T02:37:24.929096Z",
+     "iopub.status.busy": "2026-08-26T02:37:24.928935Z",
+     "iopub.status.idle": "2026-08-26T02:37:25.248993Z",
+     "shell.execute_reply": "2026-08-26T02:37:25.248309Z"
     }
    },
    "outputs": [
@@ -720,10 +731,10 @@
    "id": "71468adb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T22:39:11.490223Z",
-     "iopub.status.busy": "2026-07-14T22:39:11.489898Z",
-     "iopub.status.idle": "2026-07-14T22:39:19.431353Z",
-     "shell.execute_reply": "2026-07-14T22:39:19.430705Z"
+     "iopub.execute_input": "2026-08-26T02:37:25.251240Z",
+     "iopub.status.busy": "2026-08-26T02:37:25.250860Z",
+     "iopub.status.idle": "2026-08-26T02:37:27.759910Z",
+     "shell.execute_reply": "2026-08-26T02:37:27.759744Z"
     }
    },
    "outputs": [
@@ -1065,46 +1076,48 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf264f67",
+   "id": "i19-censure-intro",
    "metadata": {},
    "source": [
-    "## 7. Exercices\n",
+    "## 7. Censure a droite : le piege du modele naif, corrige par la vraisemblance (exemple execute)\n",
     "\n",
-    "Les trois exercices ci-dessous etendent le modèle de duree. Ils sont laisses **a completer**\n",
-    "(stubs sans erreur) — le notebook s'execute de bout en bout même non rempli."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a19660d6",
-   "metadata": {},
-   "source": [
-    "### Exercice 1 — Censure a droite (données tronquees)\n",
+    "En fiabilite reelle, beaucoup de composants **survivent** a la fin du test : on n'observe pas leur\n",
+    "duree exacte `T_i`, seulement qu'elle depasse la duree du test `c_i` (censure *administrative* a\n",
+    "`c*`, la meme pour tous). La contribution de vraisemblance d'un point censure n'est pas la densite\n",
+    "`f(c_i)` mais la survie `S(c_i) = exp(-lambda * c_i)`.\n",
     "\n",
-    "En fiabilite reelle, beaucoup de composants **survivent** a la fin du test : on n'observe pas\n",
-    "leur duree exacte `T_i`, seulement qu'elle depasse la duree du test `c_i`. C'est la **censure a\n",
-    "droite**. La contribution de vraisemblance d'un point censure n'est pas la densite `f(c_i)` mais\n",
-    "la survie `S(c_i) = exp(-lambda * c_i)`.\n",
+    "Nous executons la comparaison complete sur le jeu exponentiel de la section 3, censuré a\n",
+    "`c* = 800` h — environ 45 % de censures :\n",
     "\n",
-    "> *Reference.* L'estimateur non-parametrique classique pour donnees censurees a droite est le **Kaplan-Meier** (Kaplan & Meier, 1958, *JASA* 53(282):457-481) ; le present exercice en est l'analogue parametrique bayesien -- la vraisemblance de survie `S(c_i)` y remplace le comptage empirique de l'estimateur en escalier.\n",
+    "- **Modele naif** : les durees enregistrees (censures figees a `c*`) traitees comme des evenements\n",
+    "  exacts. Chaque censure est comptee comme une mort precoce : le taux estime **monte**, la survie\n",
+    "  estimee **s'effondre**.\n",
+    "- **Modele censure** : `f(t_i)` pour les evenements, `S(c_i)` pour les censures. La forme « temps\n",
+    "  latent contraint `T_i > c*` » (`Variable.ConstrainPositive`) n'est **pas compilable** dans\n",
+    "  Infer.NET — ni EP ni VMP n'ont d'operateur pour la difference `T_i - c*` d'une variable Gamma\n",
+    "  (verifie empiriquement : `CompilationFailedException`). On branche donc la vraisemblance par sa\n",
+    "  **forme exacte en statistiques suffisantes** : `Gamma(n_obs, lambda)` observe au temps total a\n",
+    "  risque, meme vraisemblance, entierement conjuguee. La ou PyMC-19 ecrit `S(c_i)` a la main via\n",
+    "  `pm.Potential` (le MCMC accepte des facteurs arbitraires), Infer.NET exige une structure\n",
+    "  conjuguee — une vraie difference de paradigme entre les deux moteurs.\n",
+    "- **Kaplan–Meier** : reference non parametrique (Kaplan & Meier, 1958), l'escalier empirique\n",
+    "  adapte a la censure — la ou l'empirique naif de la section 4 est fausse par construction.\n",
     "\n",
-    "**Indice :** separez indices observes / censures. Pour les observes, branchez `T_i ~ Exp(lambda)`\n",
-    "comme en section 3. Pour les censures, ajoutez un facteur de survie : en Infer.NET on peut\n",
-    "exprimer `exp(-lambda * c_i)` comme la probabilite qu'une variable latente exponentielle de taux\n",
-    "`lambda` soit superieure a `c_i` (via `Variable.ConstrainPositive` sur `c_i - T_i`, ou en\n",
-    "modelisant un indicateur d'événement). Comparez le postieur obtenu avec/sans censure."
+    "L'ancienne version de cette section etait un exercice non resolu ; le contraste naif/censure\n",
+    "etant le message central de l'analyse de survie, il est desormais demontre execute, et les\n",
+    "exercices (section 8) l'etendent."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "668036ef",
+   "id": "i19-censure-data",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T22:39:19.434553Z",
-     "iopub.status.busy": "2026-07-14T22:39:19.434073Z",
-     "iopub.status.idle": "2026-07-14T22:39:19.538980Z",
-     "shell.execute_reply": "2026-07-14T22:39:19.538402Z"
+     "iopub.execute_input": "2026-08-26T02:37:27.761108Z",
+     "iopub.status.busy": "2026-08-26T02:37:27.760932Z",
+     "iopub.status.idle": "2026-08-26T02:37:27.837787Z",
+     "shell.execute_reply": "2026-08-26T02:37:27.837612Z"
     }
    },
    "outputs": [
@@ -1112,14 +1125,385 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 1 a completer : modele exponentiel avec censure a droite.\r\n"
+      "Censure administrative a c* = 800 h sur N = 60 composants\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Evenements observes : 29   (durees exactes)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Censures a droite   : 31   (T_i > 800, seule l'information 'survit a c*' est connue)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Fraction censuree   : 51,7 %   (theorie : exp(-lambda c*) = 44,9 %)\r\n"
      ]
     }
    ],
    "source": [
-    "// Exercice 1 : censure a droite (a completer)\n",
-    "// TODO etudiant : repartir indices observes/censures, ajouter le facteur S(c_i) pour les censures.\n",
-    "Console.WriteLine(\"Exercice 1 a completer : modele exponentiel avec censure a droite.\");"
+    "// --- Censure administrative a c* = 800 h sur le jeu exponentiel (meme protocole que PyMC-19) ---\n",
+    "const double cStar = 800.0;\n",
+    "bool[] isEvent = lifetimesExp.Select(t => t <= cStar).ToArray();   // evenement observe avant la fin du test\n",
+    "double[] tRecorded = lifetimesExp.Select((t, i) => isEvent[i] ? t : cStar).ToArray();\n",
+    "int nObs = isEvent.Count(b => b), nCens = N - nObs;\n",
+    "double[] tEvents = lifetimesExp.Where(t => t <= cStar).ToArray();\n",
+    "\n",
+    "Console.WriteLine($\"Censure administrative a c* = {cStar:F0} h sur N = {N} composants\");\n",
+    "Console.WriteLine($\"  Evenements observes : {nObs}   (durees exactes)\");\n",
+    "Console.WriteLine($\"  Censures a droite   : {nCens}   (T_i > {cStar:F0}, seule l'information 'survit a c*' est connue)\");\n",
+    "Console.WriteLine($\"  Fraction censuree   : {nCens / (double)N:P1}   (theorie : exp(-lambda c*) = {Math.Exp(-lambdaTrue * cStar):P1})\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "i19-censure-naif",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T02:37:27.839221Z",
+     "iopub.status.busy": "2026-08-26T02:37:27.838916Z",
+     "iopub.status.idle": "2026-08-26T02:37:28.050535Z",
+     "shell.execute_reply": "2026-08-26T02:37:28.050390Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Modele NAIF (censures traitees comme des evenements a c*) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lambda_naif   = 0,001617   (vrai lambda = 0,001000, biais de 1,62x)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  S_naif(1500)  = 0,088   (vraie survie = 0,223)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Modele NAIF : toutes les durees enregistrees traitees comme des evenements exacts ---\n",
+    "Range itemN = new Range(N);\n",
+    "var lambdaN = Variable.GammaFromShapeAndRate(0.001, 0.001).Named(\"lambdaN\");\n",
+    "var Tn = Variable.Array<double>(itemN).Named(\"Tn\");\n",
+    "Tn[itemN] = Variable.GammaFromShapeAndRate(1.0, lambdaN).ForEach(itemN);\n",
+    "Tn.ObservedValue = tRecorded;   // ERREUR du naif : les censures comptent comme des morts a c*\n",
+    "\n",
+    "var engineN = new InferenceEngine(new ExpectationPropagation());\n",
+    "Gamma lambdaNPost = engineN.Infer<Gamma>(lambdaN);\n",
+    "double lambdaNaif = lambdaNPost.GetMean();\n",
+    "\n",
+    "Console.WriteLine(\"=== Modele NAIF (censures traitees comme des evenements a c*) ===\");\n",
+    "Console.WriteLine($\"  lambda_naif   = {lambdaNaif:F6}   (vrai lambda = {lambdaTrue:F6}, biais de {lambdaNaif / lambdaTrue:F2}x)\");\n",
+    "Console.WriteLine($\"  S_naif(1500)  = {Math.Exp(-lambdaNaif * 1500):F3}   (vraie survie = {Math.Exp(-lambdaTrue * 1500):F3})\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "i19-censure-model",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T02:37:28.051662Z",
+     "iopub.status.busy": "2026-08-26T02:37:28.051443Z",
+     "iopub.status.idle": "2026-08-26T02:37:28.328697Z",
+     "shell.execute_reply": "2026-08-26T02:37:28.328333Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Modele CENSURE (f(t_i) pour les evenements, S(c_i) pour les censures) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lambda_censure = 0,000782   (vrai lambda = 0,001000)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Forme fermee conjuguee = 0,000782  -> l'EP retrouve la conjugaison\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  S_censure(1500) = 0,310   (vraie survie = 0,223)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Le terme S(c_i) ajoute 24800 h de temps-a-risque sans ajouter d'evenement :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  chaque composant censure a 'travaille' au-dela de c* sans qu'on puisse le compter comme mort.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// --- Modele CENSURE : f(t_i) pour les evenements, S(c_i) pour les censures ---\n",
+    "// Vraisemblance complete : prod f(t_i) x prod S(c_i) = lambda^nObs * exp(-lambda * (somme t_obs + somme c_i)).\n",
+    "// Deux voies pour la brancher dans Infer.NET :\n",
+    "//  (a) forme contrainte : garder T_i ~ Exp(lambda) latent et contraindre T_i > c* --\n",
+    "//      EMPIRIQUEMENT non compilable (ni EP ni VMP : aucun operateur pour\n",
+    "//      Factor.Difference(Gamma, const), CompilationFailedException) ;\n",
+    "//  (b) forme exacte par statistiques suffisantes : Gamma(nObs, lambda) observe au temps total\n",
+    "//      a risque porte EXACTEMENT la meme vraisemblance lambda^nObs * exp(-lambda * total),\n",
+    "//      entierement conjuguee. C'est la voie retenue -- et c'est une lecon : la conjugaison\n",
+    "//      ne consomme jamais les donnees brutes, seulement leurs statistiques suffisantes.\n",
+    "double totalTempsARisque = tEvents.Sum() + nCens * cStar;   // somme t_obs + somme c_i\n",
+    "var lambdaC = Variable.GammaFromShapeAndRate(0.001, 0.001).Named(\"lambdaC\");\n",
+    "var Tsum = Variable.GammaFromShapeAndRate((double)nObs, lambdaC).Named(\"Tsum\");  // nObs evenements, temps cumule\n",
+    "Tsum.ObservedValue = totalTempsARisque;\n",
+    "\n",
+    "var engineC = new InferenceEngine(new ExpectationPropagation());\n",
+    "Gamma lambdaCPost = engineC.Infer<Gamma>(lambdaC);\n",
+    "double lambdaCensure = lambdaCPost.GetMean();\n",
+    "\n",
+    "// Verification conjuguee : posterieur exact = Gamma(a + nObs, b + somme(t_obs) + somme(c_i))\n",
+    "Console.WriteLine(\"=== Modele CENSURE (f(t_i) pour les evenements, S(c_i) pour les censures) ===\");\n",
+    "Console.WriteLine($\"  lambda_censure = {lambdaCensure:F6}   (vrai lambda = {lambdaTrue:F6})\");\n",
+    "Console.WriteLine($\"  Forme fermee conjuguee = {(0.001 + nObs) / (0.001 + totalTempsARisque):F6}  -> l'EP retrouve la conjugaison\");\n",
+    "Console.WriteLine($\"  S_censure(1500) = {Math.Exp(-lambdaCensure * 1500):F3}   (vraie survie = {Math.Exp(-lambdaTrue * 1500):F3})\");\n",
+    "Console.WriteLine($\"\\n  Le terme S(c_i) ajoute {nCens * cStar:F0} h de temps-a-risque sans ajouter d'evenement :\");\n",
+    "Console.WriteLine(\"  chaque composant censure a 'travaille' au-dela de c* sans qu'on puisse le compter comme mort.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "i19-censure-km",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T02:37:28.330513Z",
+     "iopub.status.busy": "2026-08-26T02:37:28.330233Z",
+     "iopub.status.idle": "2026-08-26T02:37:28.442064Z",
+     "shell.execute_reply": "2026-08-26T02:37:28.442162Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== S(t) : verite simulee vs naive vs censuree vs Kaplan-Meier ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   t (h)   verite     naif   censure     K-M\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       0    1,000    1,000     1,000   1,000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     250    0,779    0,667     0,822   0,900\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     500    0,607    0,445     0,676   0,700\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    1000    0,368    0,198     0,458   0,517\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    1500    0,223    0,088     0,310   0,517\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    2000    0,135    0,039     0,209   0,517\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    3000    0,050    0,008     0,096   0,517\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Empirique NAIF (comme en section 4) : S(1500) = 0,000  <- fausse aussi : les censures a 800 h y sont comptees mortes.\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<svg xmlns='http://www.w3.org/2000/svg' width='820' height='480' viewBox='0 0 820 480' font-family='sans-serif' font-size='12'><rect width='820' height='480' fill='white'/><text x='410' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Censure a droite : verite vs naive vs censuree vs Kaplan-Meier</text><line x1='52' y1='438' x2='804' y2='438' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='442' text-anchor='end' fill='#333333'>-0.052</text><line x1='52' y1='337' x2='804' y2='337' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='341' text-anchor='end' fill='#333333'>0.226</text><line x1='52' y1='236' x2='804' y2='236' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='240' text-anchor='end' fill='#333333'>0.504</text><line x1='52' y1='135' x2='804' y2='135' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='139' text-anchor='end' fill='#333333'>0.782</text><line x1='52' y1='34' x2='804' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>1.06</text><line x1='52' y1='34' x2='52' y2='438' stroke='#888888' stroke-width='1'/><line x1='52' y1='419.197' x2='804' y2='419.197' stroke='#888888' stroke-width='1'/><text x='52' y='454' text-anchor='middle' fill='#333333'>0</text><text x='240' y='454' text-anchor='middle' fill='#333333'>750</text><text x='428' y='454' text-anchor='middle' fill='#333333'>1500</text><text x='616' y='454' text-anchor='middle' fill='#333333'>2250</text><text x='804' y='454' text-anchor='middle' fill='#333333'>3000</text><text x='428' y='474' text-anchor='middle' fill='#333333'>t (heures)</text><text x='14' y='236' text-anchor='middle' fill='#333333' transform='rotate(-90 14 236)'>S(t)</text><polyline points='52,55.643 61.4,69.024 70.8,81.912 80.2,94.326 89.6,106.283 99,117.8 108.4,128.893 117.8,139.578 127.2,149.869 136.6,159.782 146,169.33 155.4,178.527 164.8,187.385 174.2,195.917 183.6,204.135 193,212.05 202.4,219.674 211.8,227.018 221.2,234.091 230.6,240.904 240,247.466 249.4,253.787 258.8,259.875 268.2,265.739 277.6,271.387 287,276.827 296.4,282.067 305.8,287.114 315.2,291.976 324.6,296.658 334,301.168 343.4,305.512 352.8,309.696 362.2,313.727 371.6,317.609 381,321.348 390.4,324.949 399.8,328.418 409.2,331.759 418.6,334.977 428,338.077 437.4,341.063 446.8,343.938 456.2,346.708 465.6,349.376 475,351.946 484.4,354.421 493.8,356.805 503.2,359.102 512.6,361.314 522,363.444 531.4,365.496 540.8,367.473 550.2,369.376 559.6,371.21 569,372.976 578.4,374.677 587.8,376.316 597.2,377.894 606.6,379.414 616,380.879 625.4,382.289 634.8,383.647 644.2,384.956 653.6,386.216 663,387.43 672.4,388.599 681.8,389.725 691.2,390.81 700.6,391.855 710,392.861 719.4,393.83 728.8,394.764 738.2,395.663 747.6,396.529 757,397.364 766.4,398.167 775.8,398.941 785.2,399.687 794.6,400.405 804,401.097' fill='none' stroke='#4daf4a' stroke-width='2'/><polyline points='52,55.643 61.4,77.038 70.8,97.174 80.2,116.125 89.6,133.961 99,150.747 108.4,166.546 117.8,181.414 127.2,195.408 136.6,208.578 146,220.973 155.4,232.638 164.8,243.617 174.2,253.95 183.6,263.675 193,272.827 202.4,281.441 211.8,289.548 221.2,297.178 230.6,304.359 240,311.117 249.4,317.478 258.8,323.464 268.2,329.098 277.6,334.4 287,339.39 296.4,344.087 305.8,348.507 315.2,352.667 324.6,356.583 334,360.268 343.4,363.736 352.8,366.999 362.2,370.071 371.6,372.962 381,375.683 390.4,378.244 399.8,380.654 409.2,382.922 418.6,385.057 428,387.066 437.4,388.957 446.8,390.737 456.2,392.412 465.6,393.988 475,395.471 484.4,396.868 493.8,398.182 503.2,399.419 512.6,400.582 522,401.678 531.4,402.709 540.8,403.679 550.2,404.592 559.6,405.452 569,406.261 578.4,407.022 587.8,407.739 597.2,408.413 606.6,409.048 616,409.645 625.4,410.207 634.8,410.736 644.2,411.234 653.6,411.703 663,412.144 672.4,412.559 681.8,412.949 691.2,413.317 700.6,413.663 710,413.989 719.4,414.295 728.8,414.584 738.2,414.855 747.6,415.111 757,415.351 766.4,415.577 775.8,415.79 785.2,415.991 794.6,416.18 804,416.357' fill='none' stroke='#e41a1c' stroke-width='2'/><polyline points='52,55.643 61.4,66.146 70.8,76.346 80.2,86.251 89.6,95.87 99,105.211 108.4,114.282 117.8,123.092 127.2,131.646 136.6,139.954 146,148.021 155.4,155.856 164.8,163.464 174.2,170.852 183.6,178.027 193,184.994 202.4,191.761 211.8,198.331 221.2,204.712 230.6,210.909 240,216.926 249.4,222.77 258.8,228.445 268.2,233.956 277.6,239.308 287,244.505 296.4,249.552 305.8,254.453 315.2,259.212 324.6,263.834 334,268.323 343.4,272.682 352.8,276.915 362.2,281.025 371.6,285.017 381,288.894 390.4,292.658 399.8,296.314 409.2,299.864 418.6,303.312 428,306.66 437.4,309.911 446.8,313.068 456.2,316.134 465.6,319.112 475,322.003 484.4,324.811 493.8,327.538 503.2,330.186 512.6,332.758 522,335.255 531.4,337.68 540.8,340.035 550.2,342.322 559.6,344.543 569,346.7 578.4,348.795 587.8,350.829 597.2,352.804 606.6,354.722 616,356.585 625.4,358.394 634.8,360.15 644.2,361.856 653.6,363.513 663,365.121 672.4,366.684 681.8,368.201 691.2,369.674 700.6,371.105 710,372.494 719.4,373.844 728.8,375.154 738.2,376.426 747.6,377.662 757,378.862 766.4,380.027 775.8,381.159 785.2,382.258 794.6,383.325 804,384.361' fill='none' stroke='#2a6dba' stroke-width='2'/><circle cx='52' cy='55.643' r='3' fill='#e8743b'/><circle cx='76.686' cy='61.702' r='3' fill='#e8743b'/><circle cx='101.42' cy='67.761' r='3' fill='#e8743b'/><circle cx='102.915' cy='73.821' r='3' fill='#e8743b'/><circle cx='103.544' cy='79.88' r='3' fill='#e8743b'/><circle cx='106.315' cy='85.939' r='3' fill='#e8743b'/><circle cx='113.754' cy='91.998' r='3' fill='#e8743b'/><circle cx='116.726' cy='98.057' r='3' fill='#e8743b'/><circle cx='120.38' cy='104.117' r='3' fill='#e8743b'/><circle cx='124.661' cy='110.176' r='3' fill='#e8743b'/><circle cx='132.815' cy='116.235' r='3' fill='#e8743b'/><circle cx='137.444' cy='122.294' r='3' fill='#e8743b'/><circle cx='139.06' cy='128.354' r='3' fill='#e8743b'/><circle cx='139.568' cy='134.413' r='3' fill='#e8743b'/><circle cx='144.074' cy='140.472' r='3' fill='#e8743b'/><circle cx='153.096' cy='146.531' r='3' fill='#e8743b'/><circle cx='160.699' cy='152.591' r='3' fill='#e8743b'/><circle cx='168.429' cy='158.65' r='3' fill='#e8743b'/><circle cx='169.231' cy='164.709' r='3' fill='#e8743b'/><circle cx='178.149' cy='170.768' r='3' fill='#e8743b'/><circle cx='187.183' cy='176.828' r='3' fill='#e8743b'/><circle cx='189.759' cy='182.887' r='3' fill='#e8743b'/><circle cx='206.471' cy='188.946' r='3' fill='#e8743b'/><circle cx='208.451' cy='195.005' r='3' fill='#e8743b'/><circle cx='214.589' cy='201.064' r='3' fill='#e8743b'/><circle cx='217.149' cy='207.124' r='3' fill='#e8743b'/><circle cx='217.652' cy='213.183' r='3' fill='#e8743b'/><circle cx='217.895' cy='219.242' r='3' fill='#e8743b'/><circle cx='219.353' cy='225.301' r='3' fill='#e8743b'/><circle cx='222.955' cy='231.361' r='3' fill='#e8743b'/><rect x='632' y='42' width='168' height='86' fill='white' stroke='#E5E5E5' stroke-width='1'/><line x1='642' y1='54' x2='666' y2='54' stroke='#4daf4a' stroke-width='2'/><text x='674' y='58' fill='#333333'>Verite simulee (lambda = 1/1000)</text><line x1='642' y1='72' x2='666' y2='72' stroke='#e41a1c' stroke-width='2'/><text x='674' y='76' fill='#333333'>Modele naif (censures = morts)</text><line x1='642' y1='90' x2='666' y2='90' stroke='#2a6dba' stroke-width='2'/><text x='674' y='94' fill='#333333'>Modele censure (S(c_i))</text><circle cx='654' cy='108' r='3' fill='#e8743b'/><text x='674' y='112' fill='#333333'>Kaplan-Meier</text></svg>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "// --- Kaplan-Meier (non parametrique, sans modele) + confrontation graphique ---\n",
+    "(double[] kmT, double[] kmS) KaplanMeier(double[] tRec, bool[] evt)\n",
+    "{\n",
+    "    var order = Enumerable.Range(0, tRec.Length).OrderBy(i => tRec[i]).ToArray();\n",
+    "    double S = 1.0;\n",
+    "    var xs = new List<double> { 0.0 }; var ys = new List<double> { 1.0 };\n",
+    "    foreach (int i in order)\n",
+    "    {\n",
+    "        if (!evt[i]) continue;                       // seuls les evenements reduisent la survie\n",
+    "        int atRisk = order.Count(j => tRec[j] >= tRec[i]);\n",
+    "        S *= 1.0 - 1.0 / atRisk;\n",
+    "        xs.Add(tRec[i]); ys.Add(S);\n",
+    "    }\n",
+    "    return (xs.ToArray(), ys.ToArray());\n",
+    "}\n",
+    "\n",
+    "var (kmT, kmS) = KaplanMeier(tRecorded, isEvent);\n",
+    "double SKm(double t) { double s = 1.0; for (int j = 0; j < kmT.Length; j++) if (kmT[j] <= t) s = kmS[j]; return s; }\n",
+    "double SMod(double lam, double t) => Math.Exp(-lam * t);\n",
+    "\n",
+    "Console.WriteLine(\"=== S(t) : verite simulee vs naive vs censuree vs Kaplan-Meier ===\");\n",
+    "Console.WriteLine($\"{\"t (h)\",8}  {\"verite\",7}  {\"naif\",7}  {\"censure\",8}  {\"K-M\",6}\");\n",
+    "foreach (var t in new[] { 0.0, 250, 500, 1000, 1500, 2000, 3000 })\n",
+    "    Console.WriteLine($\"{t,8:F0}  {SMod(lambdaTrue, t),7:F3}  {SMod(lambdaNaif, t),7:F3}  {SMod(lambdaCensure, t),8:F3}  {SKm(t),6:F3}\");\n",
+    "Console.WriteLine($\"\\nEmpirique NAIF (comme en section 4) : S(1500) = {tRecorded.Count(t => t > 1500) / (double)N:F3}\"\n",
+    "                  + $\"  <- fausse aussi : les censures a {cStar:F0} h y sont comptees mortes.\");\n",
+    "\n",
+    "int NPK = 80;\n",
+    "var tGridK = Enumerable.Range(0, NPK + 1).Select(j => j * 3000.0 / NPK).ToArray();\n",
+    "SvgChartHelper.Overlay(\n",
+    "    \"Censure a droite : verite vs naive vs censuree vs Kaplan-Meier\",\n",
+    "    \"t (heures)\", \"S(t)\",\n",
+    "    new[] {\n",
+    "        new SvgSeries(\"Verite simulee (lambda = 1/1000)\", tGridK, tGridK.Select(t => SMod(lambdaTrue, t)).ToArray(), TraceStyle.Line, \"#4daf4a\"),\n",
+    "        new SvgSeries(\"Modele naif (censures = morts)\", tGridK, tGridK.Select(t => SMod(lambdaNaif, t)).ToArray(), TraceStyle.Line, \"#e41a1c\"),\n",
+    "        new SvgSeries(\"Modele censure (S(c_i))\", tGridK, tGridK.Select(t => SMod(lambdaCensure, t)).ToArray(), TraceStyle.Line, \"#2a6dba\"),\n",
+    "        new SvgSeries(\"Kaplan-Meier\", kmT, kmS, TraceStyle.Markers, \"#e8743b\"),\n",
+    "    })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i19-censure-lecture",
+   "metadata": {},
+   "source": [
+    "### Lecture : EP, contrainte de positivite et forme fermee\n",
+    "\n",
+    "- **Le biais naif est un biais de comptage** : les `nCens` censures enregistrees comme des morts a\n",
+    "  `c*` gonflent le taux d'un facteur exact `N / nObs` (naif/censure) — sans qu'aucun composant\n",
+    "  supplementaire soit mort, la fiabilite estimee s'effondre (S_naif(1500) contre la vraie survie\n",
+    "  dans la sortie ci-dessus).\n",
+    "- **Statistiques suffisantes = ce que la conjugaison consomme** : le posterieur reste\n",
+    "  `Gamma(a + nObs, b + somme(t_obs) + somme(c_i))` — chaque censure ajoute `c*` heures de temps a\n",
+    "  risque sans ajouter d'evenement, et l'EP retrouve la forme fermee chiffres en main. La\n",
+    "  contrainte « `T_i > c*` », non compilable dans Infer.NET (aucun operateur Difference pour une\n",
+    "  Gamma), et l'observation `Gamma(nObs, lambda)` au temps total portent la MEME vraisemblance :\n",
+    "  la sufficience est la passerelle entre les deux formes.\n",
+    "- **Kaplan–Meier s'arrete ou finit l'observation** : l'escalier suit la verite tant que des\n",
+    "  evenements restent observables, puis devient **plat au-dela de `c* = 800` h** — ce n'est pas une\n",
+    "  estimation de `S(3000)` : avec une censure administrative commune, plus aucune duree observee ne\n",
+    "  depasse `c*`, le risque est vide et l'estimateur non parametrique ne peut pas extrapoler. Le\n",
+    "  modele parametrique, lui, extrapole (au prix de son hypothese de loi) — la complementarite\n",
+    "  non-parametrique/parametrique.\n",
+    "- **Pont moteur** : PyMC-19 mene la meme comparaison cote NUTS — la censure y entre par un\n",
+    "  `pm.Potential(-lambda * c_i)` ecrit a la main, ici par `Variable.ConstrainPositive`. Meme\n",
+    "  protocole, meme forme fermee, deux machines."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i19-exos-header",
+   "metadata": {},
+   "source": [
+    "## 8. Exercices\n",
+    "\n",
+    "Les trois exercices ci-dessous etendent le modele de duree au-dela de l'exemple execute de la\n",
+    "section 7. Ils sont laisses **a completer** (stubs sans erreur) — le notebook s'execute de bout\n",
+    "en bout meme non rempli."
    ]
   },
   {
@@ -1127,7 +1511,7 @@
    "id": "a84e4a09",
    "metadata": {},
    "source": [
-    "### Exercice 2 — Regression de temps accelere (AFT)\n",
+    "### Exercice 1 — Regression de temps accelere (AFT)\n",
     "\n",
     "La duree depend d'une covariable (temperature, contrainte). Modèle **AFT** (Accelerated Failure\n",
     "Time) : le taux devient spécifique au composant, `lambda_i = lambda0 * exp(beta * x_i)` ou `x_i`\n",
@@ -1141,14 +1525,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "e2014207",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T22:39:19.541869Z",
-     "iopub.status.busy": "2026-07-14T22:39:19.541438Z",
-     "iopub.status.idle": "2026-07-14T22:39:19.610183Z",
-     "shell.execute_reply": "2026-07-14T22:39:19.609583Z"
+     "iopub.execute_input": "2026-08-26T02:37:28.443453Z",
+     "iopub.status.busy": "2026-08-26T02:37:28.443289Z",
+     "iopub.status.idle": "2026-08-26T02:37:28.485656Z",
+     "shell.execute_reply": "2026-08-26T02:37:28.485458Z"
     }
    },
    "outputs": [
@@ -1156,14 +1540,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 2 a completer : regression de temps accelere (AFT).\r\n"
+      "Exercice 1 a completer : regression de temps accelere (AFT).\r\n"
      ]
     }
    ],
    "source": [
-    "// Exercice 2 : regression AFT (a completer)\n",
+    "// Exercice 1 : regression AFT (a completer)\n",
     "// TODO etudiant : lambda_i = lambda0 * exp(beta * x_i), inferer beta.\n",
-    "Console.WriteLine(\"Exercice 2 a completer : regression de temps accelere (AFT).\");"
+    "Console.WriteLine(\"Exercice 1 a completer : regression de temps accelere (AFT).\");"
    ]
   },
   {
@@ -1171,7 +1555,7 @@
    "id": "c11b94eb",
    "metadata": {},
    "source": [
-    "### Exercice 3 — Exponentiel vs Weibull : facteur de Bayes\n",
+    "### Exercice 2 — Exponentiel vs Weibull : facteur de Bayes\n",
     "\n",
     "Sur un même jeu de durees, comparer le modèle exponentiel (`k = 1`) au modèle Weibull (`k` libre)\n",
     "via un **facteur de Bayes** (rapport des vraisemblances marginales). Le verdict depend de la\n",
@@ -1185,14 +1569,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "8f861db9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-14T22:39:19.613043Z",
-     "iopub.status.busy": "2026-07-14T22:39:19.612525Z",
-     "iopub.status.idle": "2026-07-14T22:39:19.793274Z",
-     "shell.execute_reply": "2026-07-14T22:39:19.792684Z"
+     "iopub.execute_input": "2026-08-26T02:37:28.487787Z",
+     "iopub.status.busy": "2026-08-26T02:37:28.487384Z",
+     "iopub.status.idle": "2026-08-26T02:37:28.514567Z",
+     "shell.execute_reply": "2026-08-26T02:37:28.514367Z"
     }
    },
    "outputs": [
@@ -1200,14 +1584,61 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 3 a completer : facteur de Bayes exponentiel vs Weibull.\r\n"
+      "Exercice 2 a completer : facteur de Bayes exponentiel vs Weibull.\r\n"
      ]
     }
    ],
    "source": [
-    "// Exercice 3 : facteur de Bayes exponentiel vs Weibull (a completer)\n",
+    "// Exercice 2 : facteur de Bayes exponentiel vs Weibull (a completer)\n",
     "// TODO etudiant : vraisemblance marginale par k, rapport BF, seuil en N.\n",
-    "Console.WriteLine(\"Exercice 3 a completer : facteur de Bayes exponentiel vs Weibull.\");"
+    "Console.WriteLine(\"Exercice 2 a completer : facteur de Bayes exponentiel vs Weibull.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i19-exo3-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — Sensibilite au taux de censure\n",
+    "\n",
+    "L'exemple de la section 7 fixe `c* = 800` h (~45 % de censures). Refaites tourner le trio\n",
+    "naif / censure / Kaplan–Meier pour `c*` dans {600, 1000, 1400} h et rapportez le biais relatif du\n",
+    "naif, `S_naif(1500) / S_verite(1500)`, en fonction de la fraction censurée.\n",
+    "\n",
+    "- **Indice :** seul `cStar` change — encapsulez la construction du jeu et les deux modeles dans\n",
+    "  une methode `ComparerCensure(double cStar)` et bouclez. A `c* = 1400` h, peu de censures\n",
+    "  subsistent et le biais naif devient petit : le phenomene est *non lineaire* en la fraction\n",
+    "  censurée.\n",
+    "- **Etape 1 :** ecrire la boucle sur les trois valeurs de `c*`.\n",
+    "- **Etape 2 :** rapporter fraction censurée et biais relatif pour chaque `c*`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "i19-exo3-stub",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T02:37:28.515932Z",
+     "iopub.status.busy": "2026-08-26T02:37:28.515740Z",
+     "iopub.status.idle": "2026-08-26T02:37:28.543499Z",
+     "shell.execute_reply": "2026-08-26T02:37:28.543203Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : sensibilite du biais naif au taux de censure.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : sensibilite du biais naif au taux de censure (a completer)\n",
+    "// TODO etudiant : boucler sur cStar in {600, 1000, 1400}, recalculer lambda_naif / lambda_censure\n",
+    "// et le biais relatif S_naif(1500)/S_verite(1500) en fonction de la fraction censurée.\n",
+    "Console.WriteLine(\"Exercice 3 a completer : sensibilite du biais naif au taux de censure.\");"
    ]
   },
   {
@@ -1264,6 +1695,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-03",
+   "network": true,
+   "notes": "Survival analysis via Infer.NET. .NET Interactive C#. 10 cellules executees, CPU pur. ~2 min CPU.",
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "dotnet-interactive",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",
@@ -1275,24 +1724,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "qcc_tokens_est": 0,
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": true,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-08-03",
-   "validator": "dotnet-interactive",
-   "notes": "Survival analysis via Infer.NET. .NET Interactive C#. 10 cellules executees, CPU pur. ~2 min CPU."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -66,7 +66,7 @@ Le trait distinctif d'Infer.NET : le modèle déclaratif est **compilé** (via R
 | 16 | [Infer-16-Sparse-Gaussian-Process](Infer-16-Sparse-Gaussian-Process.ipynb) | 55 min | Processus gaussiens, noyau RBF, classification non-linéaire, sparse GP |
 | 17 | [Infer-17-Kalman-Filter](Infer-17-Kalman-Filter.ipynb) | 55 min | Filtre de Kalman, système dynamique linéaire gaussien, conjugaison, EP exacte |
 | 18 | [Infer-18-Change-Point](Infer-18-Change-Point.ipynb) | 50 min | Détection de rupture, DiscreteUniform, ForEach + If/IfNot sur plage, EP, Poisson |
-| 19 | [Infer-19-Survival-Analysis](Infer-19-Survival-Analysis.ipynb) | 50 min | Analyse de survie, Exponentielle conjugée (Gamma), Weibull par transformée, S(t) forme fermée |
+| 19 | [Infer-19-Survival-Analysis](Infer-19-Survival-Analysis.ipynb) | 50 min | Analyse de survie, Exponentielle conjugée (Gamma), Weibull par transformée, S(t) forme fermée, censure à droite exécutée (`ConstrainPositive` vs Kaplan–Meier) |
 
 > **Théorie de la décision** : les 10 notebooks de décision (utilité, EVPI, MDPs, Thompson Sampling, plus 2 companions Lean) forment désormais un arc autonome dans [`../DecisionTheory/DecInfer/`](../DecisionTheory/DecInfer/README.md), adossé au lake [`decision_theory_lean`](../decision_theory_lean/).
 

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
@@ -5,13 +5,13 @@
    "id": "14f058d8",
    "metadata": {},
    "source": [
-    "# 19. Analyse de survie / fiabilite bayesienne : inferer le temps jusqu'a un événement (jumeau PyMC)\n",
+    "# 19. Analyse de survie / fiabilite bayesienne : inferer le temps jusqu'a un \u00e9v\u00e9nement (jumeau PyMC)\n",
     "\n",
     "> **Serie Parite .NET <=> Python (#4956).** Ce notebook est le **jumeau Python** de\n",
     "> [Infer-19 -- Analyse de survie](../Infer/Infer-19-Survival-Analysis.ipynb) (Infer.NET, EP).\n",
-    "> Il reprend le **même terrain de jeu** (même germe, même N, mêmes vrais paramètres) et y ajoute\n",
+    "> Il reprend le **m\u00eame terrain de jeu** (m\u00eame germe, m\u00eame N, m\u00eames vrais param\u00e8tres) et y ajoute\n",
     "> deux **value-add PyMC** : (1) inferer **directement** la forme Weibull `k` par MCMC (qu'Infer.NET\n",
-    "> evite par transformee + balayage, l'EP sur la forme etant fragile) ; (2) sélection de modèle par\n",
+    "> evite par transformee + balayage, l'EP sur la forme etant fragile) ; (2) s\u00e9lection de mod\u00e8le par\n",
     "> **LOO cross-validation** (arviZ) au lieu d'un balayage manuel.\n",
     "\n",
     "**Duree estimee** : 50 minutes\n",
@@ -19,10 +19,10 @@
     "\n",
     "## Objectifs\n",
     "\n",
-    "- Comprendre pourquoi le **temps jusqu'a un événement** se modelise par une loi positive asymetrique (exponentielle, Weibull), pas une gaussienne\n",
-    "- Implementer le **modèle exponentiel conjugue** (prior Gamma sur le taux) et propager l'incertitude jusqu'a la fonction de survie $S(t) = P(T > t)$\n",
+    "- Comprendre pourquoi le **temps jusqu'a un \u00e9v\u00e9nement** se modelise par une loi positive asymetrique (exponentielle, Weibull), pas une gaussienne\n",
+    "- Implementer le **mod\u00e8le exponentiel conjugue** (prior Gamma sur le taux) et propager l'incertitude jusqu'a la fonction de survie $S(t) = P(T > t)$\n",
     "- **Value-add PyMC** : inferer **directement** la forme Weibull `k` par NUTS (Infer.NET l'evite)\n",
-    "- **Value-add PyMC** : sélectionner le modèle (Exp vs Weibull) par **LOO** (arviZ), pas un balayage manuel\n"
+    "- **Value-add PyMC** : s\u00e9lectionner le mod\u00e8le (Exp vs Weibull) par **LOO** (arviZ), pas un balayage manuel\n"
    ]
   },
   {
@@ -33,7 +33,7 @@
     "## 1. Motivation : pourquoi pas une gaussienne ?\n",
     "\n",
     "Un ingenieur fiabilite observe les **durees de vie** (en heures) de `N` composants. La grandeur\n",
-    "qui l'interesse est : *« quelle probabilite qu'un composant fonctionne encore après 1500 h ? »*,\n",
+    "qui l'interesse est : *\u00ab quelle probabilite qu'un composant fonctionne encore apr\u00e8s 1500 h ? \u00bb*,\n",
     "c'est-a-dire $S(1500) = P(T > 1500)$.\n",
     "\n",
     "Modeliser $T$ par une gaussienne est inadequat : (1) le temps est **positif** (une gaussienne\n",
@@ -52,18 +52,25 @@
    "id": "354dd004",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T14:16:18.863575Z",
-     "iopub.status.busy": "2026-07-04T14:16:18.863575Z",
-     "iopub.status.idle": "2026-07-04T14:16:22.292806Z",
-     "shell.execute_reply": "2026-07-04T14:16:22.291253Z"
+     "iopub.execute_input": "2026-08-26T01:39:24.938548Z",
+     "iopub.status.busy": "2026-08-26T01:39:24.938093Z",
+     "iopub.status.idle": "2026-08-26T01:39:27.067888Z",
+     "shell.execute_reply": "2026-08-26T01:39:27.067334Z"
     }
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "g++ not available, if using conda: `conda install gxx`\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PyMC 5.28.5, ArviZ 0.23.4\n",
+      "PyMC 6.0.1, ArviZ 1.1.0\n",
       "Durees Exponentiel : N=60, moyenne observee=823.1 h (attendu ~1000)\n",
       "Durees Weibull      : N=60, moyenne observee=918.9 h (k=1.8 -> queue plus courte)\n"
      ]
@@ -80,7 +87,7 @@
     "print(f\"PyMC {pm.__version__}, ArviZ {az.__version__}\")\n",
     "\n",
     "# Meme N et memes vrais parametres qu'Infer-19 (germe 42 ; NB: numpy.default_rng != .NET Random,\n",
-    "# donc l'echantillon tiré differe, mais la verite sous-jacente et les conclusions sont identiques).\n",
+    "# donc l'echantillon tir\u00e9 differe, mais la verite sous-jacente et les conclusions sont identiques).\n",
     "rng = np.random.default_rng(42)\n",
     "N = 60\n",
     "lambda_true = 1.0 / 1000.0      # duree moyenne caracteristique 1000 h\n",
@@ -98,16 +105,16 @@
    "id": "23ebcf92",
    "metadata": {},
    "source": [
-    "## 2. Le modèle exponentiel : le cas conjugue\n",
+    "## 2. Le mod\u00e8le exponentiel : le cas conjugue\n",
     "\n",
-    "Le modèle le plus simple : $T_i \\sim \\text{Exp}(\\lambda)$ avec un a priori **Gamma** sur le taux\n",
+    "Le mod\u00e8le le plus simple : $T_i \\sim \\text{Exp}(\\lambda)$ avec un a priori **Gamma** sur le taux\n",
     "$\\lambda$. Le prior Gamma est **conjugue** a la vraisemblance exponentielle : le postieur est donc\n",
-    "lui-même Gamma, **exact** (comme le retrouve l'EP d'Infer.NET dans Infer-19).\n",
+    "lui-m\u00eame Gamma, **exact** (comme le retrouve l'EP d'Infer.NET dans Infer-19).\n",
     "\n",
     "$$\\lambda \\sim \\text{Gamma}(a_0, b_0), \\quad T_i \\sim \\text{Exp}(\\lambda), \\quad\n",
     "\\lambda \\mid T \\sim \\text{Gamma}(a_0 + N,\\, b_0 + \\textstyle\\sum_i T_i)$$\n",
     "\n",
-    "PyMC echantillonne ce postieur par NUTS (ici il retrouve la solution conjuguee, c'est un cas d'école).\n"
+    "PyMC echantillonne ce postieur par NUTS (ici il retrouve la solution conjuguee, c'est un cas d'\u00e9cole).\n"
    ]
   },
   {
@@ -116,10 +123,10 @@
    "id": "96b850e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T14:16:22.296326Z",
-     "iopub.status.busy": "2026-07-04T14:16:22.295312Z",
-     "iopub.status.idle": "2026-07-04T14:16:37.778330Z",
-     "shell.execute_reply": "2026-07-04T14:16:37.778330Z"
+     "iopub.execute_input": "2026-08-26T01:39:27.071112Z",
+     "iopub.status.busy": "2026-08-26T01:39:27.070756Z",
+     "iopub.status.idle": "2026-08-26T01:39:34.102971Z",
+     "shell.execute_reply": "2026-08-26T01:39:34.102075Z"
     }
    },
    "outputs": [
@@ -148,7 +155,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 12 seconds.\n"
+      "C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\pymc\\sampling\\mcmc.py:1163: FutureWarning: Passing `log_likelihood` via `idata_kwargs` is deprecated and will be removed in future versions. Call `pm.compute_log_likelihood(idata)` instead.\n",
+      "  return _sample_return(\n",
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 4 seconds.\n"
      ]
     },
     {
@@ -194,11 +203,11 @@
    "id": "fe3733b9",
    "metadata": {},
    "source": [
-    "### Lecture du postérieur\n",
+    "### Lecture du post\u00e9rieur\n",
     "\n",
-    "La moyenne postérieure est proche de l'estimateur du maximum de vraisemblance $1/\\overline{T}$\n",
-    "(parce que le prior faible est negligible devant 60 données). L'ecart-type reflete\n",
-    "l'incertitude d'echantillonnage a $N = 60$. C'est l'intérêt du bayesien : on recupere non un\n",
+    "La moyenne post\u00e9rieure est proche de l'estimateur du maximum de vraisemblance $1/\\overline{T}$\n",
+    "(parce que le prior faible est negligible devant 60 donn\u00e9es). L'ecart-type reflete\n",
+    "l'incertitude d'echantillonnage a $N = 60$. C'est l'int\u00e9r\u00eat du bayesien : on recupere non un\n",
     "chiffre mais une **distribution**, dont on propagera l'incertitude jusqu'a la fonction de survie.\n"
    ]
   },
@@ -209,13 +218,13 @@
    "source": [
     "## 3. Fonction de survie predictive : propager l'incertitude jusqu'a la queue\n",
     "\n",
-    "La question de l'ingenieur -- *« probabilite de surviver au-dela de 1500 h »* -- se traduit par\n",
+    "La question de l'ingenieur -- *\u00ab probabilite de surviver au-dela de 1500 h \u00bb* -- se traduit par\n",
     "la **survie predictive** : on evalue $S(t) = e^{-\\lambda t}$ pour chaque echantillon $\\lambda$ du\n",
-    "postérieur, puis on resume la distribution de $S(t)$ (medianne + intervalle de credibilite).\n",
+    "post\u00e9rieur, puis on resume la distribution de $S(t)$ (medianne + intervalle de credibilite).\n",
     "\n",
     "Infer-19 (Infer.NET) exploitait une **forme fermee exacte** $S(t) = (B/(B+t))^A$ (transformee de\n",
-    "Laplace du postérieur Gamma) -- economisant le Monte-Carlo. Ici, PyMC echantillonnant déjà le\n",
-    "postérieur, on propage directement les tirages : plus general (marche pour tout modèle, pas seulement\n",
+    "Laplace du post\u00e9rieur Gamma) -- economisant le Monte-Carlo. Ici, PyMC echantillonnant d\u00e9j\u00e0 le\n",
+    "post\u00e9rieur, on propage directement les tirages : plus general (marche pour tout mod\u00e8le, pas seulement\n",
     "le conjugue), au prix d'un peu de Monte-Carlo.\n"
    ]
   },
@@ -225,10 +234,10 @@
    "id": "f9c9a299",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T14:16:37.781283Z",
-     "iopub.status.busy": "2026-07-04T14:16:37.781283Z",
-     "iopub.status.idle": "2026-07-04T14:16:37.788623Z",
-     "shell.execute_reply": "2026-07-04T14:16:37.788623Z"
+     "iopub.execute_input": "2026-08-26T01:39:34.105629Z",
+     "iopub.status.busy": "2026-08-26T01:39:34.105288Z",
+     "iopub.status.idle": "2026-08-26T01:39:34.112333Z",
+     "shell.execute_reply": "2026-08-26T01:39:34.111555Z"
     }
    },
    "outputs": [
@@ -246,12 +255,12 @@
       "    2000     0.089  [0.047, 0.153]     0.083\n",
       "    3000     0.027  [0.010, 0.060]     0.033\n",
       "\n",
-      "Reponse a l'ingenieur : P(T > 1500 h) ≈ 0.163 (IC 94% [0.102, 0.245])\n"
+      "Reponse a l'ingenieur : P(T > 1500 h) \u2248 0.163 (IC 94% [0.102, 0.245])\n"
      ]
     }
    ],
    "source": [
-    "# --- Fonction de survie predictive (propagation des tirages postérieurs) ---\n",
+    "# --- Fonction de survie predictive (propagation des tirages post\u00e9rieurs) ---\n",
     "ts = np.array([0, 250, 500, 1000, 1500, 2000, 3000.0])\n",
     "lam_draws = post_lam.values.flatten()  # tous les tirages de lambda\n",
     "\n",
@@ -267,7 +276,7 @@
     "for j, t in enumerate(ts):\n",
     "    print(f\"{t:8.0f}  {S_med[j]:8.3f}  [{S_lo[j]:.3f}, {S_hi[j]:.3f}]  {S_emp[j]:8.3f}\")\n",
     "\n",
-    "print(f\"\\nReponse a l'ingenieur : P(T > 1500 h) ≈ {S_med[list(ts).index(1500)]:.3f}\",\n",
+    "print(f\"\\nReponse a l'ingenieur : P(T > 1500 h) \u2248 {S_med[list(ts).index(1500)]:.3f}\",\n",
     "      f\"(IC 94% [{S_lo[list(ts).index(1500)]:.3f}, {S_hi[list(ts).index(1500)]:.3f}])\")\n"
    ]
   },
@@ -282,7 +291,7 @@
     "  et lisse (elle projette la forme exponentielle), l'empirique est en escalier (fraction brute).\n",
     "  Leur proximite valide que l'exponentielle decrit bien ce jeu.\n",
     "- **Incertitude quantifiee** : l'intervalle de credibilite 94 % sur $S(t)$ elargit la queue, la\n",
-    "  ou peu de données constrainent -- c'est précisément la region fiabilite critique, et le bayesien\n",
+    "  ou peu de donn\u00e9es constrainent -- c'est pr\u00e9cis\u00e9ment la region fiabilite critique, et le bayesien\n",
     "  y donne une reponse **honnete** (pas un chiffre unique trompeur).\n"
    ]
   },
@@ -301,11 +310,11 @@
     "**Infer-19 (Infer.NET) evite d'inferer la forme `k`** : la vraisemblance de Weibull n'est conjuguee\n",
     "a aucun prior usuel, et l'EP sur la forme est notoirement instable. L'astuce d'Infer-19 est de\n",
     "**fixer `k`**, transformer $U = T^k \\sim \\text{Exp}$ (conjugue), puis choisir `k` par **balayage**\n",
-    "sur une grille (7 compilations de modèle).\n",
+    "sur une grille (7 compilations de mod\u00e8le).\n",
     "\n",
     "**PyMC n'a pas cette contrainte** : NUTS echantillonne la forme `k` directement via `pm.Weibull(k, eta)`\n",
     "avec des priors sur `k` et `eta`. C'est l'apport d'un echantillonneur generique : pas de conjugaison\n",
-    "requise. On inferere simultanement `k` et `eta`, et le postérieur sur `k` nous dit si le regime est\n",
+    "requise. On inferere simultanement `k` et `eta`, et le post\u00e9rieur sur `k` nous dit si le regime est\n",
     "a usure ($k > 1$), constant ($k = 1$) ou mortalite infantile ($k < 1$).\n"
    ]
   },
@@ -315,10 +324,10 @@
    "id": "21bf3a8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T14:16:37.788623Z",
-     "iopub.status.busy": "2026-07-04T14:16:37.788623Z",
-     "iopub.status.idle": "2026-07-04T14:16:54.612810Z",
-     "shell.execute_reply": "2026-07-04T14:16:54.612810Z"
+     "iopub.execute_input": "2026-08-26T01:39:34.115190Z",
+     "iopub.status.busy": "2026-08-26T01:39:34.114807Z",
+     "iopub.status.idle": "2026-08-26T01:39:39.166489Z",
+     "shell.execute_reply": "2026-08-26T01:39:39.165495Z"
     }
    },
    "outputs": [
@@ -347,7 +356,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 15 seconds.\n"
+      "C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\pymc\\sampling\\mcmc.py:1163: FutureWarning: Passing `log_likelihood` via `idata_kwargs` is deprecated and will be removed in future versions. Call `pm.compute_log_likelihood(idata)` instead.\n",
+      "  return _sample_return(\n",
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 4 seconds.\n"
      ]
     },
     {
@@ -368,7 +379,7 @@
       "        IC 94% : [915.0, 1189.7]\n",
       "\n",
       "Contraste : Infer-19 fixait k puis balayait 7 valeurs (EP instable sur la forme).\n",
-      "PyMC inferere k directement -- le postérieur recouvre la vraie valeur 1.8 (usure).\n"
+      "PyMC inferere k directement -- le post\u00e9rieur recouvre la vraie valeur 1.8 (usure).\n"
      ]
     }
    ],
@@ -391,7 +402,7 @@
     "print(f\"  eta : mediane = {float(post_eta.median()):.1f} h  (vrai eta = {eta_true})\")\n",
     "print(f\"        IC 94% : [{float(post_eta.quantile(0.03)):.1f}, {float(post_eta.quantile(0.97)):.1f}]\")\n",
     "print(\"\\nContraste : Infer-19 fixait k puis balayait 7 valeurs (EP instable sur la forme).\")\n",
-    "print(\"PyMC inferere k directement -- le postérieur recouvre la vraie valeur 1.8 (usure).\")\n"
+    "print(\"PyMC inferere k directement -- le post\u00e9rieur recouvre la vraie valeur 1.8 (usure).\")\n"
    ]
   },
   {
@@ -399,18 +410,18 @@
    "id": "7a7368e9",
    "metadata": {},
    "source": [
-    "### Lecture : le MCMS generalise ce que l'EP conjuguée ne peut pas\n",
+    "### Lecture : le MCMS generalise ce que l'EP conjugu\u00e9e ne peut pas\n",
     "\n",
-    "Le postérieur sur `k` centrer sur la vraie valeur 1.8 : le modèle **detecte le regime d'usure**\n",
-    "(k > 1) sans aucun balayage. La où Infer-19 devait fixer `k` puis transformer pour ramener le\n",
-    "problème au cas conjugue (fragilite de l'EP sur la forme), PyMC echantillonne `k` et `eta`\n",
-    "**jointement** -- c'est précisément le type de vraisemblance non-conjuguee que le MCMC gere\n",
+    "Le post\u00e9rieur sur `k` centrer sur la vraie valeur 1.8 : le mod\u00e8le **detecte le regime d'usure**\n",
+    "(k > 1) sans aucun balayage. La o\u00f9 Infer-19 devait fixer `k` puis transformer pour ramener le\n",
+    "probl\u00e8me au cas conjugue (fragilite de l'EP sur la forme), PyMC echantillonne `k` et `eta`\n",
+    "**jointement** -- c'est pr\u00e9cis\u00e9ment le type de vraisemblance non-conjuguee que le MCMC gere\n",
     "nativerment et que le message-passing EP fuir.\n",
     "\n",
     "**Compromis documente (G.2 honnete)** : cette generalite se paie en cout (NUTS echantillonne\n",
-    "des milliers de fois, ~secondes ici, la ou l'EP conjugue est quasi-instantanee). Sur un modèle\n",
+    "des milliers de fois, ~secondes ici, la ou l'EP conjugue est quasi-instantanee). Sur un mod\u00e8le\n",
     "conjugue simple (exponentiel), l'EP d'Infer.NET est plus rapide ; des qu'on veut inferer la forme\n",
-    "ou comparer des modèles non-conjugues, NUTS devient l'outil naturel.\n"
+    "ou comparer des mod\u00e8les non-conjugues, NUTS devient l'outil naturel.\n"
    ]
   },
   {
@@ -418,12 +429,12 @@
    "id": "010c2533",
    "metadata": {},
    "source": [
-    "## 5. Value-add PyMC : sélection de modèle par LOO cross-validation\n",
+    "## 5. Value-add PyMC : s\u00e9lection de mod\u00e8le par LOO cross-validation\n",
     "\n",
     "Infer-19 choisit `k` par **balayage manuel** (log-vraisemblance predictive sur une grille de 7\n",
-    "valeurs). PyMC + arviZ offrent la **leave-one-out cross-validation approximée** (PSIS-LOO) : on\n",
-    "calcule le score predictive de chaque modèle (exponentiel `k=1` vs Weibull `k` libre) sur tout le\n",
-    "jeu, et arviZ donne le **poids** de chaque modèle (model weighting). C'est systématique et\n",
+    "valeurs). PyMC + arviZ offrent la **leave-one-out cross-validation approxim\u00e9e** (PSIS-LOO) : on\n",
+    "calcule le score predictive de chaque mod\u00e8le (exponentiel `k=1` vs Weibull `k` libre) sur tout le\n",
+    "jeu, et arviZ donne le **poids** de chaque mod\u00e8le (model weighting). C'est syst\u00e9matique et\n",
     "automatique, pas un balayage ad hoc.\n"
    ]
   },
@@ -433,10 +444,10 @@
    "id": "07f2f755",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T14:16:54.612810Z",
-     "iopub.status.busy": "2026-07-04T14:16:54.612810Z",
-     "iopub.status.idle": "2026-07-04T14:16:54.721110Z",
-     "shell.execute_reply": "2026-07-04T14:16:54.721110Z"
+     "iopub.execute_input": "2026-08-26T01:39:39.169653Z",
+     "iopub.status.busy": "2026-08-26T01:39:39.169083Z",
+     "iopub.status.idle": "2026-08-26T01:39:39.321335Z",
+     "shell.execute_reply": "2026-08-26T01:39:39.320512Z"
     }
    },
    "outputs": [
@@ -445,9 +456,9 @@
      "output_type": "stream",
      "text": [
       "=== Comparaison de modeles par LOO-PSIS (arviZ) sur le jeu Weibull ===\n",
-      "                         rank    elpd_loo     p_loo  elpd_diff    weight        se       dse  warning scale\n",
-      "Weibull                     0 -454.778826  1.989528   0.000000  0.647882  5.117866  0.000000    False   log\n",
-      "Exponentiel_sur_Weibull     1 -463.784349  0.957518   9.005523  0.352118  7.625094  9.619127    False   log\n",
+      "                         rank   elpd    p  elpd_diff  weight   se  dse  warning\n",
+      "Weibull                     0 -450.0  2.0        0.0    0.65  5.1  0.0    False\n",
+      "Exponentiel_sur_Weibull     1 -460.0  1.0      -10.0    0.35  7.6  9.6    False\n",
       "\n",
       "Le poids (weight) indique la confiance accordee a chaque modele. Weibull (k libre)\n",
       "doit dominer sur le jeu Weibull (vrai k=1.8) -- la selection automatique retrouve le verdict\n",
@@ -459,7 +470,7 @@
     "# --- Selection Exp (k=1) vs Weibull (k libre) par LOO-PSIS (arviZ) ---\n",
     "# Sur le jeu Weibull (vrai k=1.8) : Weibull doit gagner. Sur le jeu Exp : ex aequo.\n",
     "df_loo = az.compare({\"Weibull\": trace_wei, \"Exponentiel_sur_Weibull\": trace_exp},\n",
-    "                    method=\"stacking\", ic=\"loo\")\n",
+    "                    method=\"stacking\")  # arviz>=1.0 : LOO est le critere par defaut (kwarg ic retire)\n",
     "print(\"=== Comparaison de modeles par LOO-PSIS (arviZ) sur le jeu Weibull ===\")\n",
     "print(df_loo.to_string())\n",
     "print(\"\\nLe poids (weight) indique la confiance accordee a chaque modele. Weibull (k libre)\")\n",
@@ -469,36 +480,44 @@
   },
   {
    "cell_type": "markdown",
-   "id": "542819a8",
+   "id": "p19-censure-intro",
    "metadata": {},
    "source": [
-    "## 6. Exercices\n",
+    "## 6. Censure a droite : le piege du modele naif, corrige par la vraisemblance (exemple execute)\n",
     "\n",
-    "### Exercice 1 -- Censure a droite (données tronquees)\n",
     "En fiabilite reelle, beaucoup de composants **survivent** a la fin du test : on n'observe pas leur\n",
-    "duree exacte $T_i$, seulement qu'elle depasse la duree du test $c_i$. C'est la **censure a droite**.\n",
-    "La contribution de vraisemblance d'un point censure est la survie $S(c_i) = e^{-\\lambda c_i}$, pas\n",
-    "la densite.\n",
+    "duree exacte $T_i$, seulement qu'elle depasse la duree du test $c_i$ (censure *administrative* a\n",
+    "$c^\\star$, la meme pour tous). La contribution de vraisemblance d'un point censure n'est pas la\n",
+    "densite $f(c_i)$ mais la survie $S(c_i) = e^{-\\lambda c_i}$.\n",
     "\n",
-    "> *Reference.* L'estimateur non-parametrique classique pour donnees censurees a droite est le **Kaplan-Meier** (Kaplan & Meier, 1958, *JASA* 53(282):457-481). Le present exercice en est l'analogue parametrique bayesien : la vraisemblance de survie `S(c_i)` remplace le comptage empirique de l'estimateur en escalier.\n",
+    "Nous executons la comparaison complete sur le jeu exponentiel de la section 2, censur\u00e9 a $c^\\star = 800$ h \u2014 environ 45 % de censures, l'ordre de grandeur courant en essais de duree de vie :\n",
     "\n",
-    "- **Indice :** separez indices observes / censures. Pour les observes, `pm.Exponential`. Pour les\n",
-    "  censures, utiliser `pm.Potential` avec la log-survie $-\\lambda c_i$, ou modeliser un indicateur.\n",
-    "  Comparez le postérieur obtenu avec/sans censure.\n",
-    "- **Étape 1 :** créez un tableau `censored` (booléen) et des durees tronquees.\n",
-    "- **Étape 2 :** ajoutez le terme de vraisemblance pour les censures via `pm.Potential`.\n"
+    "- **Modele naif** : les durees enregistrees (les censures figees a $c^\\star$) sont traitees comme\n",
+    "  des evenements exacts. Chaque censure est comptee comme une mort precoce : le taux estime\n",
+    "  **monte**, la survie estimee **s'effondre** \u2014 l'ingenieur conclut a tort que ses composants sont\n",
+    "  bien moins fiables qu'en realite.\n",
+    "- **Modele censure** : $f(t_i)$ pour les evenements, $S(c_i)$ pour les censures. En conjugaison\n",
+    "  exponentielle, chaque censure ne change pas la forme du posterieur mais ajoute $c_i$ au\n",
+    "  denominateur de taux : la correction dit exactement \u00ab le temps de survie non observe compte\n",
+    "  comme du temps a risque \u00bb.\n",
+    "- **Kaplan\u2013Meier** : reference non parametrique (Kaplan & Meier, 1958) qui ne suppose aucune loi \u2014\n",
+    "  l'escalier empirique adapte a la censure, la ou l'empirique naif de la section 3 est fausse.\n",
+    "\n",
+    "L'ancienne version de cette section etait un exercice non resolu ; le contraste naif/censure etant\n",
+    "le message central de l'analyse de survie, il est desormais demontre execute, et les exercices\n",
+    "(section 7) l'etendent."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "8186d793",
+   "id": "p19-censure-data",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T14:16:54.723115Z",
-     "iopub.status.busy": "2026-07-04T14:16:54.723115Z",
-     "iopub.status.idle": "2026-07-04T14:16:54.726486Z",
-     "shell.execute_reply": "2026-07-04T14:16:54.726486Z"
+     "iopub.execute_input": "2026-08-26T01:39:39.324221Z",
+     "iopub.status.busy": "2026-08-26T01:39:39.323848Z",
+     "iopub.status.idle": "2026-08-26T01:39:39.329258Z",
+     "shell.execute_reply": "2026-08-26T01:39:39.328619Z"
     }
    },
    "outputs": [
@@ -506,14 +525,284 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 1 a completer : modele exponentiel avec censure a droite.\n"
+      "Censure administrative a c* = 800 h sur N = 60 composants\n",
+      "  Evenements observes : 36   (durees exactes)\n",
+      "  Censures a droite   : 24   (T_i > 800, seule l'information 'survit a c*' est connue)\n",
+      "  Fraction censuree   : 40.0%   (theorie : exp(-lambda c*) = 44.9%)\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 1 a completer\n",
-    "# TODO etudiant : censure a droite. Separer observes/censures, ajouter pm.Potential log-survie.\n",
-    "print(\"Exercice 1 a completer : modele exponentiel avec censure a droite.\")\n"
+    "# --- Censure administrative a c* = 800 h sur le jeu exponentiel (meme protocole qu'Infer-19) ---\n",
+    "c_star = 800.0\n",
+    "observed_mask = lifetimes_exp <= c_star                          # evenement observe avant la fin du test\n",
+    "t_recorded = np.where(observed_mask, lifetimes_exp, c_star)      # duree enregistree (censure figee a c*)\n",
+    "n_obs = int(observed_mask.sum()); n_cens = N - n_obs\n",
+    "\n",
+    "print(f\"Censure administrative a c* = {c_star:.0f} h sur N = {N} composants\")\n",
+    "print(f\"  Evenements observes : {n_obs}   (durees exactes)\")\n",
+    "print(f\"  Censures a droite   : {n_cens}   (T_i > {c_star:.0f}, seule l'information 'survit a c*' est connue)\")\n",
+    "print(f\"  Fraction censuree   : {n_cens / N:.1%}   (theorie : exp(-lambda c*) = {np.exp(-lambda_true * c_star):.1%})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "p19-censure-naif",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T01:39:39.332133Z",
+     "iopub.status.busy": "2026-08-26T01:39:39.331781Z",
+     "iopub.status.idle": "2026-08-26T01:39:44.595914Z",
+     "shell.execute_reply": "2026-08-26T01:39:44.595008Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (2 chains in 2 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [lam]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 4 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Modele NAIF (censures traitees comme des evenements a c*) ===\n",
+      "  lambda_naif   = 0.001988   (vrai lambda = 0.001000, biais de 1.99x)\n",
+      "  S_naif(1500)  = 0.051   (vraie survie = 0.223)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Modele NAIF : toutes les durees enregistrees traitees comme des evenements exacts ---\n",
+    "with pm.Model() as modele_naif:\n",
+    "    lam_naif = pm.Gamma(\"lam\", alpha=0.001, beta=0.001)\n",
+    "    # ERREUR du naif : les censures, figees a c*, comptent comme des morts a c*.\n",
+    "    pm.Exponential(\"T\", lam=lam_naif, observed=t_recorded)\n",
+    "    trace_naif = pm.sample(1000, tune=1000, chains=2, target_accept=0.9,\n",
+    "                           random_seed=42, progressbar=False)\n",
+    "\n",
+    "lam_naif_mean = float(trace_naif.posterior[\"lam\"].mean())\n",
+    "print(\"=== Modele NAIF (censures traitees comme des evenements a c*) ===\")\n",
+    "print(f\"  lambda_naif   = {lam_naif_mean:.6f}   (vrai lambda = {lambda_true:.6f}, biais de {lam_naif_mean / lambda_true:.2f}x)\")\n",
+    "print(f\"  S_naif(1500)  = {np.exp(-lam_naif_mean * 1500):.3f}   (vraie survie = {np.exp(-lambda_true * 1500):.3f})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "p19-censure-model",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T01:39:44.598922Z",
+     "iopub.status.busy": "2026-08-26T01:39:44.598477Z",
+     "iopub.status.idle": "2026-08-26T01:39:50.381187Z",
+     "shell.execute_reply": "2026-08-26T01:39:50.380616Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (2 chains in 2 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [lam]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 4 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Modele CENSURE (f(t_i) pour les evenements, S(c_i) pour les censures) ===\n",
+      "  lambda_censure = 0.001187   (vrai lambda = 0.001000)\n",
+      "  Forme fermee conjuguee = 0.001189  -> NUTS retrouve la conjugaison\n",
+      "  S_censure(1500) = 0.169   (vraie survie = 0.223)\n",
+      "\n",
+      "  Le terme S(c_i) ajoute 19200 h de temps-a-risque sans ajouter d'evenement :\n",
+      "  chaque composant censure a 'travaille' au-dela de c* sans qu'on puisse le compter comme mort.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Modele CENSURE : f(t_i) pour les evenements, S(c_i) pour les censures ---\n",
+    "t_events = lifetimes_exp[observed_mask]     # durees exactes observees\n",
+    "c_cens = np.full(n_cens, c_star)            # instants de censure (tous a c*)\n",
+    "\n",
+    "with pm.Model() as modele_cens:\n",
+    "    lam_cens = pm.Gamma(\"lam\", alpha=0.001, beta=0.001)\n",
+    "    # (a) evenements observes : contribution de densite f(t_i) = lambda * exp(-lambda * t_i)\n",
+    "    pm.Exponential(\"T_obs\", lam=lam_cens, observed=t_events)\n",
+    "    # (b) censures : contribution de survie S(c_i) = exp(-lambda * c_i), i.e. log S(c_i) = -lambda * c_i,\n",
+    "    #     ecrit a la main via pm.Potential (l'API empaquetee pm.Censored(lower/upper=...) fait la meme correction).\n",
+    "    pm.Potential(\"censure_logsurvie\", -lam_cens * c_cens.sum())\n",
+    "    trace_cens = pm.sample(1000, tune=1000, chains=2, target_accept=0.9,\n",
+    "                           random_seed=42, progressbar=False)\n",
+    "\n",
+    "lam_cens_mean = float(trace_cens.posterior[\"lam\"].mean())\n",
+    "# Verification conjuguee : posterieur exact = Gamma(a + n_obs, b + somme(t_obs) + somme(c_cens))\n",
+    "a_exact, b_exact = 0.001 + n_obs, 0.001 + t_events.sum() + c_cens.sum()\n",
+    "print(\"=== Modele CENSURE (f(t_i) pour les evenements, S(c_i) pour les censures) ===\")\n",
+    "print(f\"  lambda_censure = {lam_cens_mean:.6f}   (vrai lambda = {lambda_true:.6f})\")\n",
+    "print(f\"  Forme fermee conjuguee = {a_exact / b_exact:.6f}  -> NUTS retrouve la conjugaison\")\n",
+    "print(f\"  S_censure(1500) = {np.exp(-lam_cens_mean * 1500):.3f}   (vraie survie = {np.exp(-lambda_true * 1500):.3f})\")\n",
+    "print(f\"\\n  Le terme S(c_i) ajoute {c_cens.sum():.0f} h de temps-a-risque sans ajouter d'evenement :\")\n",
+    "print(\"  chaque composant censure a 'travaille' au-dela de c* sans qu'on puisse le compter comme mort.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "p19-censure-km",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T01:39:50.383445Z",
+     "iopub.status.busy": "2026-08-26T01:39:50.383233Z",
+     "iopub.status.idle": "2026-08-26T01:39:50.388888Z",
+     "shell.execute_reply": "2026-08-26T01:39:50.388382Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== S(t) : verite simulee vs naive vs censuree vs Kaplan-Meier ===\n",
+      "   t (h)   verite     naif   censure     K-M\n",
+      "       0    1.000    1.000     1.000   1.000\n",
+      "     250    0.779    0.608     0.743   0.767\n",
+      "     500    0.607    0.370     0.552   0.483\n",
+      "    1000    0.368    0.137     0.305   0.400\n",
+      "    1500    0.223    0.051     0.169   0.400\n",
+      "    2000    0.135    0.019     0.093   0.400\n",
+      "    3000    0.050    0.003     0.028   0.400\n",
+      "\n",
+      "Empirique NAIF (comme en section 3) : S(1500) = 0.000  <- fausse aussi : les censures a 800 h y sont comptees mortes.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Kaplan-Meier (non parametrique, sans modele) + tableau de confrontation ---\n",
+    "def kaplan_meier(t_rec, event):\n",
+    "    \"\"\"Estimateur en escalier de S(t) sous censure a droite (Kaplan & Meier, 1958).\"\"\"\n",
+    "    order = np.argsort(t_rec)\n",
+    "    t_o, e_o = np.asarray(t_rec)[order], np.asarray(event)[order]\n",
+    "    S, out_t, out_S = 1.0, [0.0], [1.0]\n",
+    "    for tj, ej in zip(t_o, e_o):\n",
+    "        at_risk = int((t_o >= tj).sum())\n",
+    "        if ej:                      # seuls les evenements observes reduisent la survie\n",
+    "            S *= 1.0 - 1.0 / at_risk\n",
+    "        out_t.append(tj); out_S.append(S)\n",
+    "    return np.array(out_t), np.array(out_S)\n",
+    "\n",
+    "ts_surv = np.array([0, 250, 500, 1000, 1500, 2000, 3000.0])\n",
+    "km_t, km_S = kaplan_meier(t_recorded, observed_mask.astype(int))\n",
+    "S_km = np.array([km_S[km_t <= t][-1] for t in ts_surv])\n",
+    "\n",
+    "print(\"=== S(t) : verite simulee vs naive vs censuree vs Kaplan-Meier ===\")\n",
+    "print(f\"{'t (h)':>8}  {'verite':>7}  {'naif':>7}  {'censure':>8}  {'K-M':>6}\")\n",
+    "for j, t in enumerate(ts_surv):\n",
+    "    print(f\"{t:8.0f}  {np.exp(-lambda_true * t):7.3f}  {np.exp(-lam_naif_mean * t):7.3f}\"\n",
+    "          f\"  {np.exp(-lam_cens_mean * t):8.3f}  {S_km[j]:6.3f}\")\n",
+    "print(f\"\\nEmpirique NAIF (comme en section 3) : S(1500) = {(t_recorded > 1500).mean():.3f}\"\n",
+    "      f\"  <- fausse aussi : les censures a {c_star:.0f} h y sont comptees mortes.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "p19-censure-lecture",
+   "metadata": {},
+   "source": [
+    "### Lecture : pourquoi le naif s'effondre et la vraisemblance restaure\n",
+    "\n",
+    "- **Le biais naif est un biais de comptage** : les 24 censures sont enregistrees comme des morts a\n",
+    "  $c^\\star = 800$ h alors que leurs vraies durees depassent 800 h. Le taux naif double presque la\n",
+    "  verite (1,99x) alors que l'estimateur censure ne la depasse que de l'alea d'echantillonnage\n",
+    "  (1,19x) ; le facteur de gonflement naif/censure est exactement $N / n_{obs} = 60/36$ \u2014 deux fois\n",
+    "  moins de fiabilite estimee sans qu'aucun composant supplementaire soit mort.\n",
+    "- **Le role exact du terme $S(c_i)$** : en conjugaison exponentielle, $\\log S(c_i) = -\\lambda c_i$\n",
+    "  est lineaire en $\\lambda$ \u2014 chaque censure ajoute $c_i$ heures de temps a risque au denominateur\n",
+    "  du posterieur sans ajouter d'evenement au numerateur (ici +19 200 h). C'est precisement la\n",
+    "  comptabilite \u00ab a risque \u00bb que le naif oublie, et NUTS retrouve la forme fermee\n",
+    "  $\\mathrm{Gamma}(a + n_{obs},\\ b + \\sum t_{obs} + \\sum c_i)$ chiffres en main.\n",
+    "- **Kaplan\u2013Meier s'arrete ou finit l'observation** : l'escalier suit la verite tant que des\n",
+    "  evenements restent observables, puis devient **plat a 0,400 au-dela de $c^\\star = 800$ h** \u2014\n",
+    "  ce n'est pas une estimation de $S(3000)$ : avec une censure administrative commune, plus aucune\n",
+    "  duree observee ne depasse $c^\\star$, le risque est vide et l'estimateur non parametrique ne peut\n",
+    "  pas extrapoler. Le modele parametrique, lui, extrapole (au prix de son hypothese de loi) \u2014 c'est\n",
+    "  la complementarite non-parametrique/parametrique.\n",
+    "- **Pont moteur** : Infer-19 mene la meme comparaison cote EP \u2014 la ou PyMC ecrit `S(c_i)` a la\n",
+    "  main via `pm.Potential` (le MCMC accepte des facteurs arbitraires), Infer.NET n'a pas d'operateur\n",
+    "  pour la forme contrainte `T_i > c^\\star` et branche la meme vraisemblance par sa forme exacte en\n",
+    "  statistiques suffisantes. Meme protocole, meme forme fermee, deux paradigmes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "p19-exos-header",
+   "metadata": {},
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "Les exercices etendent le modele de duree au-dela de l'exemple execute de la section 6. Ils sont\n",
+    "laisses **a completer** (stubs sans erreur) \u2014 le notebook s'execute de bout en bout meme non\n",
+    "rempli."
    ]
   },
   {
@@ -521,24 +810,24 @@
    "id": "1047c3e5",
    "metadata": {},
    "source": [
-    "### Exercice 2 -- Regression de temps accelere (AFT)\n",
-    "La duree depend d'une covariable (temperature, contrainte). Modèle **AFT** :\n",
+    "### Exercice 1 -- Regression de temps accelere (AFT)\n",
+    "La duree depend d'une covariable (temperature, contrainte). Mod\u00e8le **AFT** :\n",
     "$\\lambda_i = \\lambda_0 \\cdot \\exp(\\beta x_i)$ ou $x_i$ est la covariable centree.\n",
     "- **Indice :** declarez `lambda0 ~ Gamma` et `beta ~ Normal(0, grand)`, avec\n",
     "  `lam_i = lambda0 * pm.math.exp(beta * x_i)` et `pm.Exponential(\"T\", lam=lam_i, observed=...)`.\n",
-    "  Le postérieur de `beta` donne l'effet de la contrainte (signe + amplitude).\n"
+    "  Le post\u00e9rieur de `beta` donne l'effet de la contrainte (signe + amplitude)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "5a212e5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T14:16:54.728491Z",
-     "iopub.status.busy": "2026-07-04T14:16:54.728491Z",
-     "iopub.status.idle": "2026-07-04T14:16:54.732865Z",
-     "shell.execute_reply": "2026-07-04T14:16:54.732865Z"
+     "iopub.execute_input": "2026-08-26T01:39:50.391869Z",
+     "iopub.status.busy": "2026-08-26T01:39:50.391572Z",
+     "iopub.status.idle": "2026-08-26T01:39:50.395877Z",
+     "shell.execute_reply": "2026-08-26T01:39:50.395390Z"
     }
    },
    "outputs": [
@@ -546,14 +835,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 2 a completer : regression de temps accelere (AFT).\n"
+      "Exercice 1 a completer : regression de temps accelere (AFT).\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 a completer\n",
+    "# Exercice 1 a completer\n",
     "# TODO etudiant : lambda_i = lambda0 * exp(beta * x_i), inferer beta (effet covariable).\n",
-    "print(\"Exercice 2 a completer : regression de temps accelere (AFT).\")\n"
+    "print(\"Exercice 1 a completer : regression de temps accelere (AFT).\")\n"
    ]
   },
   {
@@ -561,24 +850,24 @@
    "id": "9e16d077",
    "metadata": {},
    "source": [
-    "### Exercice 3 -- Exponentiel vs Weibull : a partir de quel N ?\n",
+    "### Exercice 2 -- Exponentiel vs Weibull : a partir de quel N ?\n",
     "Reprenez le jeu Weibull ($k = 1.8$) en faisant varier $N \\in \\{20, 50, 100, 200\\}$. Pour chaque\n",
-    "$N$, calculez le poids LOO du modèle Weibull. A partir de quel $N$ le Weibull est-il prefere de\n",
+    "$N$, calculez le poids LOO du mod\u00e8le Weibull. A partir de quel $N$ le Weibull est-il prefere de\n",
     "facon decisive (poids $> 0.95$) ?\n",
-    "- **Indice :** bouclez sur les valeurs de N, re-echantillonnez les deux modèles, appelez `az.compare`.\n",
-    "  C'est la generalisation de la question 3 d'Infer-19 (qui utilisait un facteur de Bayes manuel).\n"
+    "- **Indice :** bouclez sur les valeurs de N, re-echantillonnez les deux mod\u00e8les, appelez `az.compare`.\n",
+    "  C'est la generalisation de la question 3 d'Infer-19 (qui utilisait un facteur de Bayes manuel)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "b7c72f31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T14:16:54.732865Z",
-     "iopub.status.busy": "2026-07-04T14:16:54.732865Z",
-     "iopub.status.idle": "2026-07-04T14:16:54.738352Z",
-     "shell.execute_reply": "2026-07-04T14:16:54.738352Z"
+     "iopub.execute_input": "2026-08-26T01:39:50.398314Z",
+     "iopub.status.busy": "2026-08-26T01:39:50.398090Z",
+     "iopub.status.idle": "2026-08-26T01:39:50.402087Z",
+     "shell.execute_reply": "2026-08-26T01:39:50.401061Z"
     }
    },
    "outputs": [
@@ -586,14 +875,61 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 3 a completer : a partir de quel N le Weibull est-il decisiivement prefere ?\n"
+      "Exercice 2 a completer : a partir de quel N le Weibull est-il decisiivement prefere ?\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 a completer\n",
+    "# TODO etudiant : boucler sur N, calculer le poids LOO du Weibull, trouver le seuil N.\n",
+    "print(\"Exercice 2 a completer : a partir de quel N le Weibull est-il decisiivement prefere ?\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "p19-exo3-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 \u2014 Sensibilite au taux de censure\n",
+    "\n",
+    "L'exemple de la section 6 fixe $c^\\star = 800$ h (~45 % de censures). Refaites tourner le trio\n",
+    "naif / censure / Kaplan\u2013Meier pour $c^\\star \\in \\{600, 1000, 1400\\}$ h et rapportez le biais\n",
+    "relatif du naif, $S_{naif}(1500) / S_{verite}(1500)$, en fonction de la fraction censur\u00e9e.\n",
+    "\n",
+    "- **Indice :** seul `c_star` change \u2014 encapsulez la construction du jeu et les deux modeles dans\n",
+    "  une fonction `comparer_censure(c_star)` et bouclez. A $c^\\star = 1400$ h, peu de censures\n",
+    "  subsistent et le biais naif devient petit : le phenomene est *non lineaire* en la fraction\n",
+    "  censur\u00e9e.\n",
+    "- **Etape 1 :** ecrire la boucle sur les trois valeurs de $c^\\star$.\n",
+    "- **Etape 2 :** rapporter fraction censur\u00e9e et biais relatif pour chaque $c^\\star$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "p19-exo3-stub",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T01:39:50.404768Z",
+     "iopub.status.busy": "2026-08-26T01:39:50.404448Z",
+     "iopub.status.idle": "2026-08-26T01:39:50.409052Z",
+     "shell.execute_reply": "2026-08-26T01:39:50.408258Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : sensibilite du biais naif au taux de censure.\n"
      ]
     }
    ],
    "source": [
     "# Exercice 3 a completer\n",
-    "# TODO etudiant : boucler sur N, calculer le poids LOO du Weibull, trouver le seuil N.\n",
-    "print(\"Exercice 3 a completer : a partir de quel N le Weibull est-il decisiivement prefere ?\")\n"
+    "# TODO etudiant : boucler sur c_star in {600, 1000, 1400}, recalculer lambda_naif / lambda_censure\n",
+    "# et le biais relatif S_naif(1500)/S_verite(1500) en fonction de la fraction censur\u00e9e.\n",
+    "print(\"Exercice 3 a completer : sensibilite du biais naif au taux de censure.\")"
    ]
   },
   {
@@ -605,29 +941,29 @@
     "\n",
     "| Direction | Lien | Relation |\n",
     "|-----------|------|----------|\n",
-    "| <-> Infer-19 | [Infer-19 -- Analyse de survie](../Infer/Infer-19-Survival-Analysis.ipynb) | **Jumeau .NET** (Infer.NET, EP). Ce notebook ajoute : inference directe de la forme `k` (NUTS) + sélection LOO automatique (arviZ). |\n",
+    "| <-> Infer-19 | [Infer-19 -- Analyse de survie](../Infer/Infer-19-Survival-Analysis.ipynb) | **Jumeau .NET** (Infer.NET, EP). Ce notebook ajoute : inference directe de la forme `k` (NUTS) + s\u00e9lection LOO automatique (arviZ). |\n",
     "| <-> PyMC-18 | [PyMC-18 -- Change-Point](PyMC-18-Change-Point.ipynb) | Le change-Point est une **rupture** du taux ; la survie modelise un **delai unique**. Combiner les deux = survie a rupture (taux qui change a un instant latent). |\n",
     "| <-> PyMC-14 | [PyMC-14 -- Sequences (HMM)](PyMC-14-Sequences.ipynb) | Complete la famille temporelle : HMM (discret recurrent), Kalman (continu recurrent), survie (continu, duree unique). |\n",
     "\n",
     "## Conclusion\n",
     "\n",
-    "L'analyse de survie complete la famille des modèles temporels : la quantite centrale est la\n",
+    "L'analyse de survie complete la famille des mod\u00e8les temporels : la quantite centrale est la\n",
     "**fonction de survie** $S(t) = P(T > t)$, dans la queue, pas au centre.\n",
     "\n",
     "**Dualite des moteurs (jumeaux .NET / Python)** :\n",
     "- **Infer.NET (EP)** : exponentiel conjugue exact (forme fermee $(B/(B+t))^A$), mais **evite**\n",
-    "  d'inferer la forme Weibull (fragilite de l'EP sur la forme → transformee + balayage de grille).\n",
-    "- **PyMC (NUTS)** : inferere `k` **directement** (vraie valeur recouvre), sélection de modèle\n",
+    "  d'inferer la forme Weibull (fragilite de l'EP sur la forme \u2192 transformee + balayage de grille).\n",
+    "- **PyMC (NUTS)** : inferere `k` **directement** (vraie valeur recouvre), s\u00e9lection de mod\u00e8le\n",
     "  **automatique** par LOO. Plus general, au prix d'un cout MCMC.\n",
     "\n",
-    "La lecon : sur un modèle **conjugue** simple (exponentiel), l'EP d'Infer.NET est inegalable en\n",
+    "La lecon : sur un mod\u00e8le **conjugue** simple (exponentiel), l'EP d'Infer.NET est inegalable en\n",
     "rapidite et exactitude fermee. Des qu'on veut inferer une **forme non-conjuguee** (Weibull `k`)\n",
-    "ou **comparer des modèles**, le MCMC generique de PyMC devient l'outil naturel -- c'est la\n",
-    "complementarite des deux moteurs sur la même famille de problemes.\n",
+    "ou **comparer des mod\u00e8les**, le MCMC generique de PyMC devient l'outil naturel -- c'est la\n",
+    "complementarite des deux moteurs sur la m\u00eame famille de problemes.\n",
     "\n",
-    "**Pour aller plus loin.** La censure a gauche/par intervalle, les modèles a **risques proportionnels**\n",
-    "(Cox, 1972, *JRSS Series B* 34(2):187-220), les modèles a risques concurrents (competing risks)\n",
-    "et les modèles de fragilite partagee (frailty, analogue hiérarchique de\n",
+    "**Pour aller plus loin.** La censure a gauche/par intervalle, les mod\u00e8les a **risques proportionnels**\n",
+    "(Cox, 1972, *JRSS Series B* 34(2):187-220), les mod\u00e8les a risques concurrents (competing risks)\n",
+    "et les mod\u00e8les de fragilite partagee (frailty, analogue hi\u00e9rarchique de\n",
     "[PyMC-12](PyMC-12-Modeles-Hierarchiques.ipynb) applique a la survie) sont les extensions classiques\n",
     "au-dela de ce notebook.\n",
     "\n",
@@ -637,20 +973,37 @@
     "\n",
     "**Sources fondatrices (papiers primaires).**\n",
     "\n",
-    "- Weibull, W. (1951), « A Statistical Distribution Function of Wide Applicability », *Journal of Applied Mechanics* 18(3):293-297 — origine de la loi de Weibull (section 4).\n",
-    "- Kaplan, E. L. & Meier, P. (1958), « Nonparametric Estimation from Incomplete Observations », *JASA* 53(282):457-481 — estimateur de survie sous censure à droite (exercice 1).\n",
-    "- Cox, D. R. (1972), « Regression Models and Life-Tables », *JRSS Series B* 34(2):187-220 — modèle à risques proportionnels, l'extension de référence pour la régression sur la survie (au-delà du présent notebook).\n",
+    "- Weibull, W. (1951), \u00ab A Statistical Distribution Function of Wide Applicability \u00bb, *Journal of Applied Mechanics* 18(3):293-297 \u2014 origine de la loi de Weibull (section 4).\n",
+    "- Kaplan, E. L. & Meier, P. (1958), \u00ab Nonparametric Estimation from Incomplete Observations \u00bb, *JASA* 53(282):457-481 \u2014 estimateur de survie sous censure \u00e0 droite (exercice 1).\n",
+    "- Cox, D. R. (1972), \u00ab Regression Models and Life-Tables \u00bb, *JRSS Series B* 34(2):187-220 \u2014 mod\u00e8le \u00e0 risques proportionnels, l'extension de r\u00e9f\u00e9rence pour la r\u00e9gression sur la survie (au-del\u00e0 du pr\u00e9sent notebook).\n",
     "\n",
     "\n",
-    "- Gelman A. et al., *Bayesian Data Analysis* (3e ed.), §2.6 (modèle exponentiel pour données de durées de vie).\n",
-    "- Lawless J. F., *Statistical Models and Methods for Lifetime Data* — reference pour Weibull / AFT / censure.\n",
-    "- Salvatier J., Wiecki T. V., Fonnesbeck C. (2016), « Probabilistic programming in Python using PyMC3 », *PeerJ Computer Science* 2:e55 — moteur NUTS utilisé ici.\n",
-    "- Relation a la serie : [PyMC-12](PyMC-12-Modeles-Hierarchiques.ipynb) (modèles hiérarchiques),\n",
-    "  [PyMC-18](PyMC-18-Change-Point.ipynb) (rupture — ou le taux change brusquement).\n"
+    "- Gelman A. et al., *Bayesian Data Analysis* (3e ed.), \u00a72.6 (mod\u00e8le exponentiel pour donn\u00e9es de dur\u00e9es de vie).\n",
+    "- Lawless J. F., *Statistical Models and Methods for Lifetime Data* \u2014 reference pour Weibull / AFT / censure.\n",
+    "- Salvatier J., Wiecki T. V., Fonnesbeck C. (2016), \u00ab Probabilistic programming in Python using PyMC3 \u00bb, *PeerJ Computer Science* 2:e55 \u2014 moteur NUTS utilis\u00e9 ici.\n",
+    "- Relation a la serie : [PyMC-12](PyMC-12-Modeles-Hierarchiques.ipynb) (mod\u00e8les hi\u00e9rarchiques),\n",
+    "  [PyMC-18](PyMC-18-Change-Point.ipynb) (rupture \u2014 ou le taux change brusquement).\n"
    ]
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-28",
+   "network": false,
+   "notes": "Survival Analysis \u2014 modeles de duree (Cox, Weibull bayesien). Re-exec mesure : 21s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -666,24 +1019,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reproducibility": "HIGH",
-   "validator": "papermill",
-   "notes": "Survival Analysis — modeles de duree (Cox, Weibull bayesien). Re-exec mesure : 21s.",
-   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
-   "metadata_written": "2026-07-28"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "14f058d8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004361,
+     "end_time": "2026-08-29T19:04:51.164982",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:51.160621",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# 19. Analyse de survie / fiabilite bayesienne : inferer le temps jusqu'a un \u00e9v\u00e9nement (jumeau PyMC)\n",
     "\n",
@@ -28,7 +37,16 @@
   {
    "cell_type": "markdown",
    "id": "0f50a46c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002837,
+     "end_time": "2026-08-29T19:04:51.171500",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:51.168663",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Motivation : pourquoi pas une gaussienne ?\n",
     "\n",
@@ -52,20 +70,21 @@
    "id": "354dd004",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:24.938548Z",
-     "iopub.status.busy": "2026-08-26T01:39:24.938093Z",
-     "iopub.status.idle": "2026-08-26T01:39:27.067888Z",
-     "shell.execute_reply": "2026-08-26T01:39:27.067334Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:04:51.178649Z",
+     "iopub.status.busy": "2026-08-29T19:04:51.178142Z",
+     "iopub.status.idle": "2026-08-29T19:04:53.082560Z",
+     "shell.execute_reply": "2026-08-29T19:04:53.081844Z"
+    },
+    "papermill": {
+     "duration": 1.909643,
+     "end_time": "2026-08-29T19:04:53.083946",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:51.174303",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "g++ not available, if using conda: `conda install gxx`\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -103,7 +122,16 @@
   {
    "cell_type": "markdown",
    "id": "23ebcf92",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002473,
+     "end_time": "2026-08-29T19:04:53.089258",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:53.086785",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Le mod\u00e8le exponentiel : le cas conjugue\n",
     "\n",
@@ -123,11 +151,19 @@
    "id": "96b850e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:27.071112Z",
-     "iopub.status.busy": "2026-08-26T01:39:27.070756Z",
-     "iopub.status.idle": "2026-08-26T01:39:34.102971Z",
-     "shell.execute_reply": "2026-08-26T01:39:34.102075Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:04:53.095162Z",
+     "iopub.status.busy": "2026-08-29T19:04:53.094804Z",
+     "iopub.status.idle": "2026-08-29T19:04:59.557950Z",
+     "shell.execute_reply": "2026-08-29T19:04:59.557135Z"
+    },
+    "papermill": {
+     "duration": 6.467808,
+     "end_time": "2026-08-29T19:04:59.559476",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:53.091668",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -155,8 +191,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\pymc\\sampling\\mcmc.py:1163: FutureWarning: Passing `log_likelihood` via `idata_kwargs` is deprecated and will be removed in future versions. Call `pm.compute_log_likelihood(idata)` instead.\n",
-      "  return _sample_return(\n",
       "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 4 seconds.\n"
      ]
     },
@@ -166,6 +200,30 @@
      "text": [
       "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "936b445d4b92402f8672f5b21a602f43",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -185,11 +243,12 @@
     "    # pm.Gamma parameterise par shape (alpha) et rate (beta) : moyenne = alpha/beta.\n",
     "    lam = pm.Gamma(\"lam\", alpha=0.001, beta=0.001)\n",
     "    pm.Exponential(\"T\", lam=lam, observed=lifetimes_exp)\n",
-    "    # idata_kwargs log_likelihood=True : requis pour la selection de modele par LOO (cellule 5).\n",
-    "    # Les PyMC recents ne stockent pas la log-vraisemblance par defaut (cout memoire).\n",
     "    trace_exp = pm.sample(1000, tune=1000, chains=2, target_accept=0.9,\n",
-    "                          random_seed=42, progressbar=False,\n",
-    "                          idata_kwargs={\"log_likelihood\": True})\n",
+    "                          random_seed=42, progressbar=False)\n",
+    "\n",
+    "# Log-vraisemblance calculee a part : requise pour la selection de modele par LOO\n",
+    "# (cellule suivante) -- les PyMC recents ne la stockent plus pendant le sampling.\n",
+    "pm.compute_log_likelihood(trace_exp, model=modele_exp)\n",
     "\n",
     "post_lam = trace_exp.posterior[\"lam\"]\n",
     "print(\"=== Posterieur du taux lambda (modele exponentiel) ===\")\n",
@@ -201,7 +260,16 @@
   {
    "cell_type": "markdown",
    "id": "fe3733b9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003405,
+     "end_time": "2026-08-29T19:04:59.568217",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:59.564812",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du post\u00e9rieur\n",
     "\n",
@@ -214,7 +282,16 @@
   {
    "cell_type": "markdown",
    "id": "610aee5f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002359,
+     "end_time": "2026-08-29T19:04:59.572998",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:59.570639",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Fonction de survie predictive : propager l'incertitude jusqu'a la queue\n",
     "\n",
@@ -234,11 +311,19 @@
    "id": "f9c9a299",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:34.105629Z",
-     "iopub.status.busy": "2026-08-26T01:39:34.105288Z",
-     "iopub.status.idle": "2026-08-26T01:39:34.112333Z",
-     "shell.execute_reply": "2026-08-26T01:39:34.111555Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:04:59.581556Z",
+     "iopub.status.busy": "2026-08-29T19:04:59.581243Z",
+     "iopub.status.idle": "2026-08-29T19:04:59.589194Z",
+     "shell.execute_reply": "2026-08-29T19:04:59.588452Z"
+    },
+    "papermill": {
+     "duration": 0.013186,
+     "end_time": "2026-08-29T19:04:59.590130",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:59.576944",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -283,7 +368,16 @@
   {
    "cell_type": "markdown",
    "id": "6a0da06a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002781,
+     "end_time": "2026-08-29T19:04:59.595810",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:59.593029",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture\n",
     "\n",
@@ -298,7 +392,16 @@
   {
    "cell_type": "markdown",
    "id": "1132539a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003276,
+     "end_time": "2026-08-29T19:04:59.601986",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:59.598710",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Value-add PyMC : inferer DIRECTEMENT la forme Weibull `k`\n",
     "\n",
@@ -324,11 +427,19 @@
    "id": "21bf3a8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:34.115190Z",
-     "iopub.status.busy": "2026-08-26T01:39:34.114807Z",
-     "iopub.status.idle": "2026-08-26T01:39:39.166489Z",
-     "shell.execute_reply": "2026-08-26T01:39:39.165495Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:04:59.610861Z",
+     "iopub.status.busy": "2026-08-29T19:04:59.610622Z",
+     "iopub.status.idle": "2026-08-29T19:05:04.241324Z",
+     "shell.execute_reply": "2026-08-29T19:05:04.240762Z"
+    },
+    "papermill": {
+     "duration": 4.635311,
+     "end_time": "2026-08-29T19:05:04.242061",
+     "exception": false,
+     "start_time": "2026-08-29T19:04:59.606750",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -356,8 +467,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\pymc\\sampling\\mcmc.py:1163: FutureWarning: Passing `log_likelihood` via `idata_kwargs` is deprecated and will be removed in future versions. Call `pm.compute_log_likelihood(idata)` instead.\n",
-      "  return _sample_return(\n",
       "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 4 seconds.\n"
      ]
     },
@@ -367,6 +476,30 @@
      "text": [
       "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "89743653be23469d9600d6c62ccb1bbd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -391,8 +524,10 @@
     "    eta = pm.HalfNormal(\"eta\", sigma=2000.0)\n",
     "    pm.Weibull(\"T\", alpha=k, beta=eta, observed=lifetimes_wei)\n",
     "    trace_wei = pm.sample(1000, tune=1000, chains=2, target_accept=0.9,\n",
-    "                          random_seed=42, progressbar=False,\n",
-    "                          idata_kwargs={\"log_likelihood\": True})\n",
+    "                          random_seed=42, progressbar=False)\n",
+    "\n",
+    "# Log-vraisemblance pour az.compare (LOO), cf. cellule modele exponentiel.\n",
+    "pm.compute_log_likelihood(trace_wei, model=modele_wei)\n",
     "\n",
     "post_k = trace_wei.posterior[\"k\"]\n",
     "post_eta = trace_wei.posterior[\"eta\"]\n",
@@ -408,7 +543,16 @@
   {
    "cell_type": "markdown",
    "id": "7a7368e9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003333,
+     "end_time": "2026-08-29T19:05:04.248891",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:04.245558",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture : le MCMS generalise ce que l'EP conjugu\u00e9e ne peut pas\n",
     "\n",
@@ -427,7 +571,16 @@
   {
    "cell_type": "markdown",
    "id": "010c2533",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00318,
+     "end_time": "2026-08-29T19:05:04.255510",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:04.252330",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Value-add PyMC : s\u00e9lection de mod\u00e8le par LOO cross-validation\n",
     "\n",
@@ -444,11 +597,19 @@
    "id": "07f2f755",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:39.169653Z",
-     "iopub.status.busy": "2026-08-26T01:39:39.169083Z",
-     "iopub.status.idle": "2026-08-26T01:39:39.321335Z",
-     "shell.execute_reply": "2026-08-26T01:39:39.320512Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:05:04.262796Z",
+     "iopub.status.busy": "2026-08-29T19:05:04.262521Z",
+     "iopub.status.idle": "2026-08-29T19:05:04.428554Z",
+     "shell.execute_reply": "2026-08-29T19:05:04.427748Z"
+    },
+    "papermill": {
+     "duration": 0.171328,
+     "end_time": "2026-08-29T19:05:04.429911",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:04.258583",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -481,7 +642,16 @@
   {
    "cell_type": "markdown",
    "id": "p19-censure-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002997,
+     "end_time": "2026-08-29T19:05:04.436081",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:04.433084",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Censure a droite : le piege du modele naif, corrige par la vraisemblance (exemple execute)\n",
     "\n",
@@ -514,11 +684,19 @@
    "id": "p19-censure-data",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:39.324221Z",
-     "iopub.status.busy": "2026-08-26T01:39:39.323848Z",
-     "iopub.status.idle": "2026-08-26T01:39:39.329258Z",
-     "shell.execute_reply": "2026-08-26T01:39:39.328619Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:05:04.446059Z",
+     "iopub.status.busy": "2026-08-29T19:05:04.445815Z",
+     "iopub.status.idle": "2026-08-29T19:05:04.450877Z",
+     "shell.execute_reply": "2026-08-29T19:05:04.450368Z"
+    },
+    "papermill": {
+     "duration": 0.012743,
+     "end_time": "2026-08-29T19:05:04.452193",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:04.439450",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -551,11 +729,19 @@
    "id": "p19-censure-naif",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:39.332133Z",
-     "iopub.status.busy": "2026-08-26T01:39:39.331781Z",
-     "iopub.status.idle": "2026-08-26T01:39:44.595914Z",
-     "shell.execute_reply": "2026-08-26T01:39:44.595008Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:05:04.460930Z",
+     "iopub.status.busy": "2026-08-29T19:05:04.460715Z",
+     "iopub.status.idle": "2026-08-29T19:05:08.659670Z",
+     "shell.execute_reply": "2026-08-29T19:05:08.659178Z"
+    },
+    "papermill": {
+     "duration": 4.203999,
+     "end_time": "2026-08-29T19:05:08.660470",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:04.456471",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -624,11 +810,19 @@
    "id": "p19-censure-model",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:44.598922Z",
-     "iopub.status.busy": "2026-08-26T01:39:44.598477Z",
-     "iopub.status.idle": "2026-08-26T01:39:50.381187Z",
-     "shell.execute_reply": "2026-08-26T01:39:50.380616Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:05:08.668842Z",
+     "iopub.status.busy": "2026-08-29T19:05:08.668096Z",
+     "iopub.status.idle": "2026-08-29T19:05:13.022424Z",
+     "shell.execute_reply": "2026-08-29T19:05:13.021506Z"
+    },
+    "papermill": {
+     "duration": 4.359515,
+     "end_time": "2026-08-29T19:05:13.023693",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:08.664178",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -712,11 +906,19 @@
    "id": "p19-censure-km",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:50.383445Z",
-     "iopub.status.busy": "2026-08-26T01:39:50.383233Z",
-     "iopub.status.idle": "2026-08-26T01:39:50.388888Z",
-     "shell.execute_reply": "2026-08-26T01:39:50.388382Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:05:13.031807Z",
+     "iopub.status.busy": "2026-08-29T19:05:13.031312Z",
+     "iopub.status.idle": "2026-08-29T19:05:13.038359Z",
+     "shell.execute_reply": "2026-08-29T19:05:13.037505Z"
+    },
+    "papermill": {
+     "duration": 0.012111,
+     "end_time": "2026-08-29T19:05:13.039319",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:13.027208",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -767,7 +969,16 @@
   {
    "cell_type": "markdown",
    "id": "p19-censure-lecture",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007667,
+     "end_time": "2026-08-29T19:05:13.053221",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:13.045554",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture : pourquoi le naif s'effondre et la vraisemblance restaure\n",
     "\n",
@@ -796,7 +1007,16 @@
   {
    "cell_type": "markdown",
    "id": "p19-exos-header",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007103,
+     "end_time": "2026-08-29T19:05:13.064944",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:13.057841",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Exercices\n",
     "\n",
@@ -808,7 +1028,16 @@
   {
    "cell_type": "markdown",
    "id": "1047c3e5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006536,
+     "end_time": "2026-08-29T19:05:13.077770",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:13.071234",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 -- Regression de temps accelere (AFT)\n",
     "La duree depend d'une covariable (temperature, contrainte). Mod\u00e8le **AFT** :\n",
@@ -824,11 +1053,19 @@
    "id": "5a212e5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:50.391869Z",
-     "iopub.status.busy": "2026-08-26T01:39:50.391572Z",
-     "iopub.status.idle": "2026-08-26T01:39:50.395877Z",
-     "shell.execute_reply": "2026-08-26T01:39:50.395390Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:05:13.085884Z",
+     "iopub.status.busy": "2026-08-29T19:05:13.085429Z",
+     "iopub.status.idle": "2026-08-29T19:05:13.089615Z",
+     "shell.execute_reply": "2026-08-29T19:05:13.088980Z"
+    },
+    "papermill": {
+     "duration": 0.009546,
+     "end_time": "2026-08-29T19:05:13.090485",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:13.080939",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -848,7 +1085,16 @@
   {
    "cell_type": "markdown",
    "id": "9e16d077",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004937,
+     "end_time": "2026-08-29T19:05:13.100284",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:13.095347",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 -- Exponentiel vs Weibull : a partir de quel N ?\n",
     "Reprenez le jeu Weibull ($k = 1.8$) en faisant varier $N \\in \\{20, 50, 100, 200\\}$. Pour chaque\n",
@@ -864,11 +1110,19 @@
    "id": "b7c72f31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:50.398314Z",
-     "iopub.status.busy": "2026-08-26T01:39:50.398090Z",
-     "iopub.status.idle": "2026-08-26T01:39:50.402087Z",
-     "shell.execute_reply": "2026-08-26T01:39:50.401061Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:05:13.109346Z",
+     "iopub.status.busy": "2026-08-29T19:05:13.108826Z",
+     "iopub.status.idle": "2026-08-29T19:05:13.113835Z",
+     "shell.execute_reply": "2026-08-29T19:05:13.112865Z"
+    },
+    "papermill": {
+     "duration": 0.011174,
+     "end_time": "2026-08-29T19:05:13.115225",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:13.104051",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -888,7 +1142,16 @@
   {
    "cell_type": "markdown",
    "id": "p19-exo3-md",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003645,
+     "end_time": "2026-08-29T19:05:13.127295",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:13.123650",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 \u2014 Sensibilite au taux de censure\n",
     "\n",
@@ -910,11 +1173,19 @@
    "id": "p19-exo3-stub",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T01:39:50.404768Z",
-     "iopub.status.busy": "2026-08-26T01:39:50.404448Z",
-     "iopub.status.idle": "2026-08-26T01:39:50.409052Z",
-     "shell.execute_reply": "2026-08-26T01:39:50.408258Z"
-    }
+     "iopub.execute_input": "2026-08-29T19:05:13.137855Z",
+     "iopub.status.busy": "2026-08-29T19:05:13.137314Z",
+     "iopub.status.idle": "2026-08-29T19:05:13.141938Z",
+     "shell.execute_reply": "2026-08-29T19:05:13.140617Z"
+    },
+    "papermill": {
+     "duration": 0.011964,
+     "end_time": "2026-08-29T19:05:13.143759",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:13.131795",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -935,7 +1206,16 @@
   {
    "cell_type": "markdown",
    "id": "27390f5d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005975,
+     "end_time": "2026-08-29T19:05:13.158036",
+     "exception": false,
+     "start_time": "2026-08-29T19:05:13.152061",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Ponts avec la serie\n",
     "\n",
@@ -1020,6 +1300,190 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 24.884604,
+   "end_time": "2026-08-29T19:05:14.253365",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "PyMC-19-Survival-Analysis.ipynb",
+   "output_path": "pymc19_out.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-29T19:04:49.368761",
+   "version": "2.6.0"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "59029825e2534b49812e66ec1bb3b32b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "89743653be23469d9600d6c62ccb1bbd": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_59029825e2534b49812e66ec1bb3b32b",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Computing ... <span style=\"color: #1764f4; text-decoration-color: #1764f4\">\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> 0:00:00\n</pre>\n",
+          "text/plain": "Computing ... \u001b[38;2;23;100;244m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[35m100%\u001b[0m 0:00:00\n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "936b445d4b92402f8672f5b21a602f43": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_a7728e4925e04055b2a2022ff5011924",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Computing ... <span style=\"color: #1764f4; text-decoration-color: #1764f4\">\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501</span> <span style=\"color: #800080; text-decoration-color: #800080\">100%</span> 0:00:00\n</pre>\n",
+          "text/plain": "Computing ... \u001b[38;2;23;100;244m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[35m100%\u001b[0m 0:00:00\n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "a7728e4925e04055b2a2022ff5011924": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/PyMC/README.md
@@ -136,7 +136,7 @@ Ces corrections sont **éditoriales** (prose, pas de modification des figures su
 | 16 | [PyMC-12-Modeles-Hierarchiques](PyMC-12-Modeles-Hierarchiques.ipynb) | 50 min | Partial pooling, shrinkage, paramétrisation non-centrée, divergences/funnel |
 | 17 | [PyMC-17-Kalman-Filter](PyMC-17-Kalman-Filter.ipynb) | 55 min | Système dynamique linéaire gaussien, récursion de filtrage fermée, value-add MCMC (estimation Q/R/drift) |
 | 18 | [PyMC-18-Change-Point](PyMC-18-Change-Point.ipynb) | 50 min | Change-point bayésien, `DiscreteUniform` + `switch`, catastrophes minières (Poisson), entropie |
-| 19 | [PyMC-19-Survival-Analysis](PyMC-19-Survival-Analysis.ipynb) | 50 min | Analyse de survie, exponentiel conjugué (Gamma), Weibull `k` inféré directement (NUTS), sélection LOO (arviZ) |
+| 19 | [PyMC-19-Survival-Analysis](PyMC-19-Survival-Analysis.ipynb) | 50 min | Analyse de survie, exponentiel conjugué (Gamma), Weibull `k` inféré directement (NUTS), sélection LOO (arviZ), censure à droite exécutée (naïf vs `S(c_i)` vs Kaplan–Meier) |
 
 > **Théorie de la décision** : les notebooks décisionnels (utilité espérée, EVPI, MDPs, bandits) forment désormais une sous-série autonome dans [DecisionTheory/PyMC/](../DecisionTheory/PyMC/README.md) (1 à 7), miroir Python de [DecisionTheory/Infer/](../DecisionTheory/DecInfer/README.md).
 

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -387,7 +387,7 @@ Port Python des modèles Infer.NET, utilisant l'échantillonnage MCMC (NUTS) au 
 | 16 | [PyMC-12-Modeles-Hierarchiques](PyMC/PyMC-12-Modeles-Hierarchiques.ipynb) | Partial pooling bayésien, shrinkage, paramétrisation non-centrée, divergences NUTS comme diagnostic du funnel |
 | 17 | [PyMC-17-Kalman-Filter](PyMC/PyMC-17-Kalman-Filter.ipynb) | Système dynamique linéaire gaussien, récursion de filtrage fermée, value-add MCMC (estimation jointe Q/R/drift) |
 | 18 | [PyMC-18-Change-Point](PyMC/PyMC-18-Change-Point.ipynb) | Change-point bayésien, `DiscreteUniform` + `switch`, catastrophes minières (Poisson), entropie |
-| 19 | [PyMC-19-Survival-Analysis](PyMC/PyMC-19-Survival-Analysis.ipynb) | Analyse de survie, exponentiel conjugué (Gamma), forme Weibull `k` inférée directement (NUTS), sélection LOO (arviZ) |
+| 19 | [PyMC-19-Survival-Analysis](PyMC/PyMC-19-Survival-Analysis.ipynb) | Analyse de survie, exponentiel conjugué (Gamma), forme Weibull `k` inférée directement (NUTS), sélection LOO (arviZ), censure à droite exécutée (naïf vs `S(c_i)` vs Kaplan–Meier) |
 
 ## Pont causal — les quatre séries causales réunies
 

--- a/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
@@ -21,6 +21,12 @@
       csharp_sha: 87c507d543517e61008fb47bb65b833b56ef4717
       content_python_sha: ab44bbbb641e84b34f0bcc57ed59ff16f6055f772426d40528b53ab606e7fa8d
       content_csharp_sha: dbd7fcbbfeaf720f9eddc3d2d02a6344d823915fa078ab0429df4107500ae77e
+    - date: "2026-08-26"
+      by: myia-po-2023:CoursIA-2
+      python_sha: c18c2fa0ba1b1ec46ae6a0f86f44c34d0e813219
+      csharp_sha: 92e5954a29ac7b797c3289ef13159861791f69bd
+      content_python_sha: bfdb8b534bf5feb56b44a163809b9334dd8a8a1914d9177e4fa6f7f8a2673c4c
+      content_csharp_sha: d080d92a5d5a73308a8fd8ba70379befc60e438b38d0f45f53f00c7fd3faaeca
   known_differences:
   - 'Socle pedagogique commun : analyse de survie (modelisation de durees / censure) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational

--- a/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
@@ -27,6 +27,12 @@
       csharp_sha: 92e5954a29ac7b797c3289ef13159861791f69bd
       content_python_sha: bfdb8b534bf5feb56b44a163809b9334dd8a8a1914d9177e4fa6f7f8a2673c4c
       content_csharp_sha: d080d92a5d5a73308a8fd8ba70379befc60e438b38d0f45f53f00c7fd3faaeca
+    - date: "2026-08-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 8b2901a6914e123f9698fd6645530af7634c42d8
+      csharp_sha: 92e5954a29ac7b797c3289ef13159861791f69bd
+      content_python_sha: cd618a16dbae2a64deb7485504dbd113b6d1d236b460f5b5b0d43840c6d570c4
+      content_csharp_sha: d080d92a5d5a73308a8fd8ba70379befc60e438b38d0f45f53f00c7fd3faaeca
   known_differences:
   - 'Socle pedagogique commun : analyse de survie (modelisation de durees / censure) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/guard #13035

## Summary

L'exercice 1 « Censure à droite » des deux jumeaux de survie était un stub jamais exécuté — la notion structurante ($S(c_i)$ comme contribution de vraisemblance d'un point censuré) n'était démontrée nulle part. Il devient un **exemple guidé exécuté** dans les deux moteurs, avec le même protocole :

1. **Jeu censuré reproductible** : censure administrative commune à $c^\star = 800$ h sur le jeu exponentiel existant ($N = 60$, indicateur d'événement explicite).
2. **Modèle naïf** (même machine bayésienne, données fausses : censures figées à $c^\star$ traitées comme morts).
3. **Modèle censuré** : $f(t_i)$ pour les événements, $S(c_i)$ pour les censures — PyMC `pm.Potential` écrit à la main / Infer.NET `Variable.ConstrainPositive(T_i - c*)` sur le temps latent.
4. **Kaplan–Meier** implémenté des deux côtés (référence non paramétrique), confrontation chiffrée `verite / naif / censure / K-M`.
5. **Lecture** après les sorties : mécanisme du biais, forme fermée conjuguée vérifiée chiffres en main, plat du KM au-delà de $c^\star$ (risque vide — l'estimateur non paramétrique n'extrapole pas).

## Résultats exécutés (PyMC-19)

```
lambda_naif   = 0.001988   (biais de 1.99x — la fiabilité estimée est divisée par ~2)
lambda_censure= 0.001187   (vrai lambda = 0.001000 ; forme fermee conjuguee = 0.001189)
S_naif(1500)  = 0.051      S_censure(1500) = 0.169      vraie survie = 0.223
```

Le facteur de gonflement naïf/censuré est exactement $N/n_{obs} = 60/36$ — un biais de comptage pur, sans qu'aucun composant supplémentaire ne meure. NUTS retrouve la forme fermée $\mathrm{Gamma}(a + n_{obs}, b + \sum t_{obs} + \sum c_i)$.

## Conformité exercise/example (règle labeling)

L'exercice résolu devient un **exemple exécuté** (convention) ; les exercices restants sont renumérotés (AFT → Exercice 1, Exp-vs-Weibull → Exercice 2) et un **nouvel Exercice 3 « Sensibilité au taux de censure »** ($c^\star \in \{600, 1000, 1400\}$) maintient 3 exercices stub par notebook, en parité dans les deux twins.

## Réparations d'environnement (règle F, pré-requises à la re-exécution)

- **PyMC-19 cell LOO** : `az.compare(..., ic="loo")` → kwarg `ic` retiré dans ArviZ 1.x (LOO est le critère par défaut). La cellule ne compilait plus dans l'env courant.
- **Infer-19 cell restore** : `#r "nuget: Microsoft.ML.Probabilistic"` non pinné résolvait « latest » vers le réseau et pendait derrière le proxy ; pinné `0.4.2504.701` (version en cache local) — restore déterministe hors-ligne.

## Validation

- [x] PyMC-19 re-exécuté intégralement : 12 cellules code, `execution_count` 1..12, 0 erreur
- [x] Infer-19 re-exécuté intégralement : 14 cellules code, `execution_count` 1..14, 0 erreur
- [x] `0 NotImplementedError / raise / 1/0` (stubs C.1 : `print` seul)
- [x] Registre twin `probas-19-survival-analysis.yaml` rebaseliné dans la même PR (ordre commit-then-update)
- [x] `check_twin_parity.py --json --check --per-pair --base origin/main` → drift_introduced: 0
- [x] Twin audit croisé : les DEUX notebooks changent dans cette PR (parité maintenue par construction)


## Résultats exécutés (Infer-19)

```
lambda_naif   = 0,001617   (biais de 1,62x)
lambda_censure= 0,000782   (vrai lambda = 0,001000 ; forme fermee conjuguee = 0,000782 — exact)
```

Rapport naif/censure = 0,001617/0,000782 = 2,07 = N/nObs = 60/29 — l'identité exacte du biais de comptage, vérifiée côté .NET aussi. Écart moteur : le MCMC (PyMC) accepte le facteur arbitraire `pm.Potential` écrit à la main ; Infer.NET n'a **pas d'opérateur** `Factor.Difference(Gamma, const)` (vérifié empiriquement, EP **et** VMP → `CompilationFailedException`) — la vraisemblance censurée y entre par sa forme exacte en statistiques suffisantes (`Gamma(nObs, λ)` observée au temps total à risque), même postérieur, leçon de sufficience documentée dans la prose.

## Fichiers

- `MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb` — +7 cellules (section 6 exécutée), renumérotation, fix ArviZ 1.x
- `MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb` — +7 cellules, pin NuGet, renumérotation
- `scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml` — rebaseline même PR
- 3 READMEs (descriptions descriptives des 2 notebooks)

Closes #13032