### PR TITLE
fix(ci): skip Windows-confinement runner tests on non-Windows hosts (unblocks all PR gates)

### DIFF
--- a/scripts/tests/test_manage_self_hosted_runner.py
+++ b/scripts/tests/test_manage_self_hosted_runner.py
@@ -14,6 +14,16 @@ from pathlib import Path
 
 import pytest
 
+# The runner-manager is a Windows-confinement tool (#12704: isolated Windows
+# runners, Windows accounts, NTFS ACLs). The tests below that exercise apply
+# paths assume a Windows host: USERPROFILE/APPDATA probes, os.name == "nt"
+# Path() flavor (a monkeypatched os.name cannot make pathlib instantiate
+# WindowsPath on Linux). Linux CI runs the platform-neutral surface only;
+# the Windows-hosted surface runs on the Windows runners the tool manages.
+requires_windows = pytest.mark.skipif(
+    os.name != "nt", reason="Windows-confinement surface (see #12704)"
+)
+
 MODULE_PATH = Path(__file__).parents[1] / "ci" / "manage_self_hosted_runner.py"
 SPEC = importlib.util.spec_from_file_location("manage_self_hosted_runner", MODULE_PATH)
 mod = importlib.util.module_from_spec(SPEC)
@@ -124,6 +134,7 @@ def test_run_powershell_delivers_scripts_via_file_not_stdin():
     assert not Path(seen["argv"][-1]).exists()
 
 
+@requires_windows
 def test_generated_apply_scripts_embed_here_strings():
     # If these scripts ever stop embedding here-strings the regression test
     # above loses its teeth: anchor the property the delivery bug broke.
@@ -147,6 +158,7 @@ def test_manager_has_no_duplicate_top_level_definitions():
     assert duplicates == {}
 
 
+@requires_windows
 def test_committed_profiles_are_valid_and_distributed_across_pushers():
     payload = json.loads(mod.PROFILE_PATH.read_text(encoding="utf-8"))
     assert set(payload["profiles"]) == {
@@ -278,6 +290,7 @@ def completed(argv=None, **kwargs):
     return subprocess.CompletedProcess(argv or [], 0, "", "")
 
 
+@requires_windows
 def test_install_refuses_bad_checksum_before_extraction(tmp_path, monkeypatch):
     data = make_runner_archive()
     target = profile(tmp_path / "runner", digest="0" * 64)
@@ -298,6 +311,7 @@ def test_install_refuses_bad_checksum_before_extraction(tmp_path, monkeypatch):
     assert not target.root.exists()
 
 
+@requires_windows
 def test_install_extracts_atomically_and_never_logs_password(tmp_path, monkeypatch):
     data = make_runner_archive()
     target = profile(tmp_path / "runner", digest=hashlib.sha256(data).hexdigest())
@@ -391,6 +405,7 @@ def test_register_redacts_secrets_from_failure(tmp_path, monkeypatch):
     assert str(caught.value).count("[REDACTED]") == 2
 
 
+@requires_windows
 def test_probe_requires_three_denials_and_one_write(tmp_path, monkeypatch):
     target = profile(tmp_path / "runner")
     write_installed(target)
@@ -410,6 +425,7 @@ def test_probe_requires_three_denials_and_one_write(tmp_path, monkeypatch):
     assert not (target.root / ".isolation-probe.json").exists()
 
 
+@requires_windows
 def test_probe_rejects_missing_or_ambiguous_results(tmp_path, monkeypatch):
     target = profile(tmp_path / "runner")
     write_installed(target)
@@ -428,6 +444,7 @@ def test_probe_rejects_missing_or_ambiguous_results(tmp_path, monkeypatch):
         mod.apply_verify(target, run=run)
 
 
+@requires_windows
 def test_acl_scripts_use_sids_and_check_native_exit_codes(tmp_path, monkeypatch):
     target = profile(tmp_path / "runner")
     monkeypatch.setenv("USERPROFILE", str(tmp_path / "user"))
@@ -469,6 +486,7 @@ def test_teardown_requires_removal_token_for_registered_runner(tmp_path, monkeyp
     assert target.root.exists()
 
 
+@requires_windows
 def test_teardown_unregisters_without_secret_argv_and_archives_logs(tmp_path, monkeypatch):
     target = profile(tmp_path / "runner")
     write_installed(target, registered=True)
@@ -519,6 +537,7 @@ def test_apply_noop_does_not_call_mutator(tmp_path, capsys, monkeypatch):
     assert result["applied"] is False
 
 
+@requires_windows
 def test_dry_run_cli_is_deterministic_and_does_not_mutate(tmp_path, capsys):
     registry = tmp_path / "profiles.json"
     root = PureWindows(tmp_path / "runner")


### PR DESCRIPTION
Grain: LIGHT/test — lane myia-po-2027:CoursIA-2 — prev: LIGHT/guard c.1331p80

## Summary
- `Scripts Tests (CPU)` runs on ubuntu, but 9 tests of `scripts/tests/test_manage_self_hosted_runner.py` (added by #13020, suite from #12704) assume a Windows host and have been failing on main since #13020 landed (main run 32848415463, 2026-08-25T12:35):
  - `Refused: USERPROFILE and APPDATA are required to resolve isolation probes` (env vars absent on Linux),
  - `NotImplementedError: cannot instantiate 'WindowsPath' on your system` inside `apply_install -> staging.with_suffix` (a monkeypatched `os.name = "nt"` cannot make pathlib instantiate `WindowsPath` on Linux), plus the pytest failure-formatter INTERNALERROR that follows.
- This failure gates **every open PR** (PR gate fails on `Scripts Tests (CPU)`), including #12839 and the ~29-PR merge queue.
- Fix: module-level `requires_windows = pytest.mark.skipif(os.name != "nt", ...)` marker on exactly the 9 Windows-surface tests. The 31 platform-neutral tests (profile validation fails-closed, safe_extract traversal/ADS/symlink, plan idempotence, manifest ownership) keep running on Linux CI.

## Validation
- Linux (WSL, python3.12, pytest): `31 passed, 9 skipped in 0.11s` (was `9 failed, 31 passed`)
- Windows host (python 3.11): `40 passed in 0.97s` (markers inert on nt)
- Scope: 1 file, +19 lines, test-only.

See #12704 (epic), regression source #13020.

- [x] Verified on both Linux and Windows hosts before pushing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Tag Grain ajouté

Body-edit c.1331p81 par po-2027 — gate Variation Tag Guard rougissait sur PR #13063 (tag absent en 1ère ligne, défaut classe #10921). Tag ajouté selon variation-protocol.md §1 (`Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE> #<PR|cNUM>`).

- TIER : **LIGHT** — body-edit seul, aucun commit ajouté, aucune re-exécution.
- GENRE : **test** — variantes officielles de variation-protocol.md §1.
- `prev:` : cycle précédent c.1331p80 a posé 2 update-batch préemptifs (PR #13002 dead-scope, PR #12982 quasi-marker) — même registre META gate.

**Effet attendu** : Variation Tag Guard pass → PR gate peut compléter → débloque ~30 PRs sustained (#12839 + queue) du gate `Scripts Tests (CPU)` côté Linux. Drainage CI indirect : PR #13063 peut merger, ce qui éteint la gate failure.

**Périmètre respecté** : 0 merge · 0 close d'autrui · 0 collision (claim #12704 vérifiée, path `scripts/tests/` disjoint de `scripts/ci/**`).