### PR TITLE
fix(ml-agents,#13037): rendre Lab15 MLE-STAR falsifiable bout-en-bout

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.006256,
-     "end_time": "2026-08-27T18:13:33.718866+00:00",
+     "duration": 0.004743,
+     "end_time": "2026-08-27T19:11:10.733475+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:33.712610+00:00",
+     "start_time": "2026-08-27T19:11:10.728732+00:00",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.007376,
-     "end_time": "2026-08-27T18:13:33.732201+00:00",
+     "duration": 0.00524,
+     "end_time": "2026-08-27T19:11:10.746334+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:33.724825+00:00",
+     "start_time": "2026-08-27T19:11:10.741094+00:00",
      "status": "completed"
     },
     "tags": []
@@ -59,16 +59,16 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:13:33.752740Z",
-     "iopub.status.busy": "2026-08-27T18:13:33.752268Z",
-     "iopub.status.idle": "2026-08-27T18:13:45.813224Z",
-     "shell.execute_reply": "2026-08-27T18:13:45.811962Z"
+     "iopub.execute_input": "2026-08-27T19:11:10.759273Z",
+     "iopub.status.busy": "2026-08-27T19:11:10.758879Z",
+     "iopub.status.idle": "2026-08-27T19:12:05.442987Z",
+     "shell.execute_reply": "2026-08-27T19:12:05.441996Z"
     },
     "papermill": {
-     "duration": 12.069089,
-     "end_time": "2026-08-27T18:13:45.814015+00:00",
+     "duration": 54.692514,
+     "end_time": "2026-08-27T19:12:05.444345+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:33.744926+00:00",
+     "start_time": "2026-08-27T19:11:10.751831+00:00",
      "status": "completed"
     },
     "tags": []
@@ -105,10 +105,10 @@
    "id": "5e416a17",
    "metadata": {
     "papermill": {
-     "duration": 0.003447,
-     "end_time": "2026-08-27T18:13:45.822628+00:00",
+     "duration": 0.004216,
+     "end_time": "2026-08-27T19:12:05.454366+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:45.819181+00:00",
+     "start_time": "2026-08-27T19:12:05.450150+00:00",
      "status": "completed"
     },
     "tags": []
@@ -123,16 +123,16 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:13:45.833581Z",
-     "iopub.status.busy": "2026-08-27T18:13:45.833067Z",
-     "iopub.status.idle": "2026-08-27T18:13:45.841496Z",
-     "shell.execute_reply": "2026-08-27T18:13:45.840621Z"
+     "iopub.execute_input": "2026-08-27T19:12:05.464915Z",
+     "iopub.status.busy": "2026-08-27T19:12:05.464458Z",
+     "iopub.status.idle": "2026-08-27T19:12:05.471178Z",
+     "shell.execute_reply": "2026-08-27T19:12:05.470009Z"
     },
     "papermill": {
-     "duration": 0.01497,
-     "end_time": "2026-08-27T18:13:45.842382+00:00",
+     "duration": 0.01322,
+     "end_time": "2026-08-27T19:12:05.472092+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:45.827412+00:00",
+     "start_time": "2026-08-27T19:12:05.458872+00:00",
      "status": "completed"
     },
     "tags": []
@@ -156,10 +156,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.005469,
-     "end_time": "2026-08-27T18:13:45.851187+00:00",
+     "duration": 0.004913,
+     "end_time": "2026-08-27T19:12:05.480636+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:45.845718+00:00",
+     "start_time": "2026-08-27T19:12:05.475723+00:00",
      "status": "completed"
     },
     "tags": []
@@ -176,16 +176,16 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:13:45.866555Z",
-     "iopub.status.busy": "2026-08-27T18:13:45.866138Z",
-     "iopub.status.idle": "2026-08-27T18:13:45.894770Z",
-     "shell.execute_reply": "2026-08-27T18:13:45.891218Z"
+     "iopub.execute_input": "2026-08-27T19:12:05.492939Z",
+     "iopub.status.busy": "2026-08-27T19:12:05.492517Z",
+     "iopub.status.idle": "2026-08-27T19:12:05.508891Z",
+     "shell.execute_reply": "2026-08-27T19:12:05.507623Z"
     },
     "papermill": {
-     "duration": 0.041284,
-     "end_time": "2026-08-27T18:13:45.896090+00:00",
+     "duration": 0.024018,
+     "end_time": "2026-08-27T19:12:05.509832+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:45.854806+00:00",
+     "start_time": "2026-08-27T19:12:05.485814+00:00",
      "status": "completed"
     },
     "tags": []
@@ -257,10 +257,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.004495,
-     "end_time": "2026-08-27T18:13:45.906358+00:00",
+     "duration": 0.004566,
+     "end_time": "2026-08-27T19:12:05.518308+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:45.901863+00:00",
+     "start_time": "2026-08-27T19:12:05.513742+00:00",
      "status": "completed"
     },
     "tags": []
@@ -277,16 +277,16 @@
    "id": "cell-7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:13:45.919475Z",
-     "iopub.status.busy": "2026-08-27T18:13:45.919053Z",
-     "iopub.status.idle": "2026-08-27T18:13:45.943084Z",
-     "shell.execute_reply": "2026-08-27T18:13:45.941596Z"
+     "iopub.execute_input": "2026-08-27T19:12:05.529810Z",
+     "iopub.status.busy": "2026-08-27T19:12:05.529527Z",
+     "iopub.status.idle": "2026-08-27T19:12:05.550695Z",
+     "shell.execute_reply": "2026-08-27T19:12:05.548983Z"
     },
     "papermill": {
-     "duration": 0.033784,
-     "end_time": "2026-08-27T18:13:45.944303+00:00",
+     "duration": 0.028767,
+     "end_time": "2026-08-27T19:12:05.551798+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:45.910519+00:00",
+     "start_time": "2026-08-27T19:12:05.523031+00:00",
      "status": "completed"
     },
     "tags": []
@@ -425,10 +425,10 @@
    "id": "cell-8",
    "metadata": {
     "papermill": {
-     "duration": 0.00438,
-     "end_time": "2026-08-27T18:13:45.953071+00:00",
+     "duration": 0.007045,
+     "end_time": "2026-08-27T19:12:05.564599+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:45.948691+00:00",
+     "start_time": "2026-08-27T19:12:05.557554+00:00",
      "status": "completed"
     },
     "tags": []
@@ -445,16 +445,16 @@
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:13:45.966693Z",
-     "iopub.status.busy": "2026-08-27T18:13:45.966127Z",
-     "iopub.status.idle": "2026-08-27T18:13:46.014997Z",
-     "shell.execute_reply": "2026-08-27T18:13:46.011841Z"
+     "iopub.execute_input": "2026-08-27T19:12:05.579226Z",
+     "iopub.status.busy": "2026-08-27T19:12:05.578645Z",
+     "iopub.status.idle": "2026-08-27T19:12:05.701603Z",
+     "shell.execute_reply": "2026-08-27T19:12:05.700485Z"
     },
     "papermill": {
-     "duration": 0.05691,
-     "end_time": "2026-08-27T18:13:46.016623+00:00",
+     "duration": 0.130889,
+     "end_time": "2026-08-27T19:12:05.702809+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:45.959713+00:00",
+     "start_time": "2026-08-27T19:12:05.571920+00:00",
      "status": "completed"
     },
     "tags": []
@@ -487,10 +487,10 @@
    "id": "f4a6e301",
    "metadata": {
     "papermill": {
-     "duration": 0.007005,
-     "end_time": "2026-08-27T18:13:46.033420+00:00",
+     "duration": 0.004395,
+     "end_time": "2026-08-27T19:12:05.712584+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:46.026415+00:00",
+     "start_time": "2026-08-27T19:12:05.708189+00:00",
      "status": "completed"
     },
     "tags": []
@@ -505,16 +505,16 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:13:46.050768Z",
-     "iopub.status.busy": "2026-08-27T18:13:46.050216Z",
-     "iopub.status.idle": "2026-08-27T18:14:00.713568Z",
-     "shell.execute_reply": "2026-08-27T18:14:00.712327Z"
+     "iopub.execute_input": "2026-08-27T19:12:05.725554Z",
+     "iopub.status.busy": "2026-08-27T19:12:05.725294Z",
+     "iopub.status.idle": "2026-08-27T19:12:10.100241Z",
+     "shell.execute_reply": "2026-08-27T19:12:10.099112Z"
     },
     "papermill": {
-     "duration": 14.67355,
-     "end_time": "2026-08-27T18:14:00.714590+00:00",
+     "duration": 4.382686,
+     "end_time": "2026-08-27T19:12:10.101154+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:13:46.041040+00:00",
+     "start_time": "2026-08-27T19:12:05.718468+00:00",
      "status": "completed"
     },
     "tags": []
@@ -535,8 +535,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
-      "[EVAL] AUC-ROC sur test = nan\n"
+      "[EVAL] AUC-ROC sur test = 0.9624\n"
      ]
     }
    ],
@@ -551,10 +550,10 @@
    "id": "73287c04",
    "metadata": {
     "papermill": {
-     "duration": 0.005701,
-     "end_time": "2026-08-27T18:14:00.725657+00:00",
+     "duration": 0.003753,
+     "end_time": "2026-08-27T19:12:10.109194+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.719956+00:00",
+     "start_time": "2026-08-27T19:12:10.105441+00:00",
      "status": "completed"
     },
     "tags": []
@@ -570,10 +569,10 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.004034,
-     "end_time": "2026-08-27T18:14:00.734023+00:00",
+     "duration": 0.003711,
+     "end_time": "2026-08-27T19:12:10.116811+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.729989+00:00",
+     "start_time": "2026-08-27T19:12:10.113100+00:00",
      "status": "completed"
     },
     "tags": []
@@ -588,16 +587,16 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:14:00.743889Z",
-     "iopub.status.busy": "2026-08-27T18:14:00.743261Z",
-     "iopub.status.idle": "2026-08-27T18:14:00.749179Z",
-     "shell.execute_reply": "2026-08-27T18:14:00.747762Z"
+     "iopub.execute_input": "2026-08-27T19:12:10.126593Z",
+     "iopub.status.busy": "2026-08-27T19:12:10.125950Z",
+     "iopub.status.idle": "2026-08-27T19:12:10.131405Z",
+     "shell.execute_reply": "2026-08-27T19:12:10.130387Z"
     },
     "papermill": {
-     "duration": 0.012511,
-     "end_time": "2026-08-27T18:14:00.750040+00:00",
+     "duration": 0.011699,
+     "end_time": "2026-08-27T19:12:10.132287+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.737529+00:00",
+     "start_time": "2026-08-27T19:12:10.120588+00:00",
      "status": "completed"
     },
     "tags": []
@@ -626,10 +625,10 @@
    "id": "f8932857",
    "metadata": {
     "papermill": {
-     "duration": 0.005137,
-     "end_time": "2026-08-27T18:14:00.759331+00:00",
+     "duration": 0.004075,
+     "end_time": "2026-08-27T19:12:10.140143+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.754194+00:00",
+     "start_time": "2026-08-27T19:12:10.136068+00:00",
      "status": "completed"
     },
     "tags": []
@@ -644,16 +643,16 @@
    "id": "cell-13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:14:00.769698Z",
-     "iopub.status.busy": "2026-08-27T18:14:00.769373Z",
-     "iopub.status.idle": "2026-08-27T18:14:00.774228Z",
-     "shell.execute_reply": "2026-08-27T18:14:00.772907Z"
+     "iopub.execute_input": "2026-08-27T19:12:10.151008Z",
+     "iopub.status.busy": "2026-08-27T19:12:10.150504Z",
+     "iopub.status.idle": "2026-08-27T19:12:10.156220Z",
+     "shell.execute_reply": "2026-08-27T19:12:10.154919Z"
     },
     "papermill": {
-     "duration": 0.011113,
-     "end_time": "2026-08-27T18:14:00.775102+00:00",
+     "duration": 0.012598,
+     "end_time": "2026-08-27T19:12:10.157272+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.763989+00:00",
+     "start_time": "2026-08-27T19:12:10.144674+00:00",
      "status": "completed"
     },
     "tags": []
@@ -685,10 +684,10 @@
    "id": "6237dac8",
    "metadata": {
     "papermill": {
-     "duration": 0.003735,
-     "end_time": "2026-08-27T18:14:00.782682+00:00",
+     "duration": 0.004867,
+     "end_time": "2026-08-27T19:12:10.167753+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.778947+00:00",
+     "start_time": "2026-08-27T19:12:10.162886+00:00",
      "status": "completed"
     },
     "tags": []
@@ -703,16 +702,16 @@
    "id": "cell-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:14:00.794507Z",
-     "iopub.status.busy": "2026-08-27T18:14:00.794103Z",
-     "iopub.status.idle": "2026-08-27T18:14:00.799242Z",
-     "shell.execute_reply": "2026-08-27T18:14:00.798147Z"
+     "iopub.execute_input": "2026-08-27T19:12:10.181029Z",
+     "iopub.status.busy": "2026-08-27T19:12:10.180652Z",
+     "iopub.status.idle": "2026-08-27T19:12:10.186337Z",
+     "shell.execute_reply": "2026-08-27T19:12:10.185086Z"
     },
     "papermill": {
-     "duration": 0.013056,
-     "end_time": "2026-08-27T18:14:00.800304+00:00",
+     "duration": 0.013869,
+     "end_time": "2026-08-27T19:12:10.187325+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.787248+00:00",
+     "start_time": "2026-08-27T19:12:10.173456+00:00",
      "status": "completed"
     },
     "tags": []
@@ -756,10 +755,10 @@
    "id": "2205804c",
    "metadata": {
     "papermill": {
-     "duration": 0.008152,
-     "end_time": "2026-08-27T18:14:00.813476+00:00",
+     "duration": 0.004184,
+     "end_time": "2026-08-27T19:12:10.196121+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.805324+00:00",
+     "start_time": "2026-08-27T19:12:10.191937+00:00",
      "status": "completed"
     },
     "tags": []
@@ -775,10 +774,10 @@
    "id": "cell-15",
    "metadata": {
     "papermill": {
-     "duration": 0.004885,
-     "end_time": "2026-08-27T18:14:00.823959+00:00",
+     "duration": 0.004309,
+     "end_time": "2026-08-27T19:12:10.204283+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.819074+00:00",
+     "start_time": "2026-08-27T19:12:10.199974+00:00",
      "status": "completed"
     },
     "tags": []
@@ -794,10 +793,10 @@
    "id": "359c9e1c",
    "metadata": {
     "papermill": {
-     "duration": 0.008419,
-     "end_time": "2026-08-27T18:14:00.838139+00:00",
+     "duration": 0.004493,
+     "end_time": "2026-08-27T19:12:10.213376+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.829720+00:00",
+     "start_time": "2026-08-27T19:12:10.208883+00:00",
      "status": "completed"
     },
     "tags": []
@@ -823,16 +822,16 @@
    "id": "ccbfa8e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:14:00.847349Z",
-     "iopub.status.busy": "2026-08-27T18:14:00.847066Z",
-     "iopub.status.idle": "2026-08-27T18:14:00.860771Z",
-     "shell.execute_reply": "2026-08-27T18:14:00.859514Z"
+     "iopub.execute_input": "2026-08-27T19:12:10.223186Z",
+     "iopub.status.busy": "2026-08-27T19:12:10.222874Z",
+     "iopub.status.idle": "2026-08-27T19:12:10.312449Z",
+     "shell.execute_reply": "2026-08-27T19:12:10.311487Z"
     },
     "papermill": {
-     "duration": 0.019195,
-     "end_time": "2026-08-27T18:14:00.861704+00:00",
+     "duration": 0.096305,
+     "end_time": "2026-08-27T19:12:10.313360+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.842509+00:00",
+     "start_time": "2026-08-27T19:12:10.217055+00:00",
      "status": "completed"
     },
     "tags": []
@@ -846,9 +845,14 @@
       "MLE-STAR PIPELINE\n",
       "==================================================\n",
       "[UNDERSTAND] Analyse de la competition...\n",
-      "[SEARCH] Recherche SOTA...\n",
-      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
-      "[EVAL] AUC-ROC sur test = nan\n"
+      "[SEARCH] Recherche SOTA...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[EVAL] AUC-ROC sur test = 0.5589\n"
      ]
     }
    ],
@@ -895,10 +899,10 @@
    "id": "c1ebaf8a",
    "metadata": {
     "papermill": {
-     "duration": 0.003287,
-     "end_time": "2026-08-27T18:14:00.868789+00:00",
+     "duration": 0.003624,
+     "end_time": "2026-08-27T19:12:10.321136+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.865502+00:00",
+     "start_time": "2026-08-27T19:12:10.317512+00:00",
      "status": "completed"
     },
     "tags": []
@@ -925,16 +929,16 @@
    "id": "173c16e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:14:00.877257Z",
-     "iopub.status.busy": "2026-08-27T18:14:00.876976Z",
-     "iopub.status.idle": "2026-08-27T18:14:00.882224Z",
-     "shell.execute_reply": "2026-08-27T18:14:00.881147Z"
+     "iopub.execute_input": "2026-08-27T19:12:10.330543Z",
+     "iopub.status.busy": "2026-08-27T19:12:10.330056Z",
+     "iopub.status.idle": "2026-08-27T19:12:10.335923Z",
+     "shell.execute_reply": "2026-08-27T19:12:10.334755Z"
     },
     "papermill": {
-     "duration": 0.010828,
-     "end_time": "2026-08-27T18:14:00.883009+00:00",
+     "duration": 0.011982,
+     "end_time": "2026-08-27T19:12:10.336803+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.872181+00:00",
+     "start_time": "2026-08-27T19:12:10.324821+00:00",
      "status": "completed"
     },
     "tags": []
@@ -993,10 +997,10 @@
    "id": "7f39a45c",
    "metadata": {
     "papermill": {
-     "duration": 0.003362,
-     "end_time": "2026-08-27T18:14:00.890046+00:00",
+     "duration": 0.003975,
+     "end_time": "2026-08-27T19:12:10.344773+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.886684+00:00",
+     "start_time": "2026-08-27T19:12:10.340798+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1023,16 +1027,16 @@
    "id": "5c663511",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:14:00.898546Z",
-     "iopub.status.busy": "2026-08-27T18:14:00.898259Z",
-     "iopub.status.idle": "2026-08-27T18:14:00.934366Z",
-     "shell.execute_reply": "2026-08-27T18:14:00.933254Z"
+     "iopub.execute_input": "2026-08-27T19:12:10.356674Z",
+     "iopub.status.busy": "2026-08-27T19:12:10.356162Z",
+     "iopub.status.idle": "2026-08-27T19:12:10.974993Z",
+     "shell.execute_reply": "2026-08-27T19:12:10.973134Z"
     },
     "papermill": {
-     "duration": 0.041812,
-     "end_time": "2026-08-27T18:14:00.935288+00:00",
+     "duration": 0.627182,
+     "end_time": "2026-08-27T19:12:10.976591+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.893476+00:00",
+     "start_time": "2026-08-27T19:12:10.349409+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1046,36 +1050,42 @@
       "MLE-STAR PIPELINE\n",
       "==================================================\n",
       "[UNDERSTAND] Analyse de la competition...\n",
-      "[SEARCH] Recherche SOTA...\n",
-      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
-      "[EVAL] AUC-ROC sur test = nan\n"
+      "[SEARCH] Recherche SOTA...\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
-      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
-      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
-      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
-      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
-      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
+      "[EVAL] AUC-ROC sur test = 0.9624"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "============================================================\n",
       "ANALYSE D'ABLATION\n",
       "============================================================\n",
-      "Score initial (toutes features) : nan\n",
+      "Score initial (toutes features) : 0.9624\n",
       "\n",
       "Feature retiree             AUC-ROC     Delta\n",
       "------------------------------------------------------------\n",
-      "monthly_charges                 nan      +nan\n",
-      "tenure                          nan      +nan\n",
-      "age                             nan      +nan\n",
-      "contract_type                   nan      +nan\n",
-      "internet_service                nan      +nan\n",
-      "total_charges                   nan      +nan\n",
+      "contract_type                0.7989   -0.1635\n",
+      "monthly_charges              0.9083   -0.0540\n",
+      "tenure                       0.9248   -0.0376\n",
+      "total_charges                0.9542   -0.0082\n",
+      "age                          0.9596   -0.0027\n",
+      "internet_service             0.9617   -0.0007\n",
       "\n",
-      "Feature la plus importante : 'monthly_charges' (retirer la colonne fait chuter le score a nan, delta = +nan)\n"
+      "Feature la plus importante : 'contract_type' (retirer la colonne fait chuter le score a 0.7989, delta = -0.1635)\n"
      ]
     }
    ],
@@ -1137,10 +1147,10 @@
    "id": "5b880b8f",
    "metadata": {
     "papermill": {
-     "duration": 0.003664,
-     "end_time": "2026-08-27T18:14:00.943033+00:00",
+     "duration": 0.007193,
+     "end_time": "2026-08-27T19:12:10.991190+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.939369+00:00",
+     "start_time": "2026-08-27T19:12:10.983997+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1167,16 +1177,16 @@
    "id": "0732cea7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-27T18:14:00.952712Z",
-     "iopub.status.busy": "2026-08-27T18:14:00.952452Z",
-     "iopub.status.idle": "2026-08-27T18:14:00.958302Z",
-     "shell.execute_reply": "2026-08-27T18:14:00.957221Z"
+     "iopub.execute_input": "2026-08-27T19:12:11.006355Z",
+     "iopub.status.busy": "2026-08-27T19:12:11.005738Z",
+     "iopub.status.idle": "2026-08-27T19:12:11.014194Z",
+     "shell.execute_reply": "2026-08-27T19:12:11.012511Z"
     },
     "papermill": {
-     "duration": 0.01241,
-     "end_time": "2026-08-27T18:14:00.959070+00:00",
+     "duration": 0.017878,
+     "end_time": "2026-08-27T19:12:11.015568+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.946660+00:00",
+     "start_time": "2026-08-27T19:12:10.997690+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1236,10 +1246,10 @@
    "id": "3f97f667",
    "metadata": {
     "papermill": {
-     "duration": 0.00393,
-     "end_time": "2026-08-27T18:14:00.966835+00:00",
+     "duration": 0.006144,
+     "end_time": "2026-08-27T19:12:11.027470+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.962905+00:00",
+     "start_time": "2026-08-27T19:12:11.021326+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1256,10 +1266,10 @@
    "id": "cell-f2cdd2f3",
    "metadata": {
     "papermill": {
-     "duration": 0.003504,
-     "end_time": "2026-08-27T18:14:00.974083+00:00",
+     "duration": 0.005294,
+     "end_time": "2026-08-27T19:12:11.039223+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.970579+00:00",
+     "start_time": "2026-08-27T19:12:11.033929+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1281,10 +1291,10 @@
    "id": "cell-d2566259",
    "metadata": {
     "papermill": {
-     "duration": 0.003925,
-     "end_time": "2026-08-27T18:14:00.981832+00:00",
+     "duration": 0.020705,
+     "end_time": "2026-08-27T19:12:11.168464+00:00",
      "exception": false,
-     "start_time": "2026-08-27T18:14:00.977907+00:00",
+     "start_time": "2026-08-27T19:12:11.147759+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1335,14 +1345,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 30.61218,
-   "end_time": "2026-08-27T18:14:02.510250+00:00",
+   "duration": 65.583032,
+   "end_time": "2026-08-27T19:12:13.152234+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "Day6-MLE-Star\\Lab15-Kaggle-Challenge.ipynb",
    "output_path": "Day6-MLE-Star\\Lab15-Kaggle-Challenge.ipynb",
    "parameters": {},
-   "start_time": "2026-08-27T18:13:31.898070+00:00",
+   "start_time": "2026-08-27T19:11:07.569202+00:00",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.018406,
-     "end_time": "2026-08-18T01:33:53.613817",
+     "duration": 0.006256,
+     "end_time": "2026-08-27T18:13:33.718866+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:33:53.595411",
+     "start_time": "2026-08-27T18:13:33.712610+00:00",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.008974,
-     "end_time": "2026-08-18T01:33:53.632433",
+     "duration": 0.007376,
+     "end_time": "2026-08-27T18:13:33.732201+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:33:53.623459",
+     "start_time": "2026-08-27T18:13:33.724825+00:00",
      "status": "completed"
     },
     "tags": []
@@ -55,20 +55,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:33:53.664172Z",
-     "iopub.status.busy": "2026-08-18T01:33:53.664172Z",
-     "iopub.status.idle": "2026-08-18T01:34:05.322087Z",
-     "shell.execute_reply": "2026-08-18T01:34:05.322087Z"
+     "iopub.execute_input": "2026-08-27T18:13:33.752740Z",
+     "iopub.status.busy": "2026-08-27T18:13:33.752268Z",
+     "iopub.status.idle": "2026-08-27T18:13:45.813224Z",
+     "shell.execute_reply": "2026-08-27T18:13:45.811962Z"
     },
     "papermill": {
-     "duration": 11.683908,
-     "end_time": "2026-08-18T01:34:05.324387",
+     "duration": 12.069089,
+     "end_time": "2026-08-27T18:13:45.814015+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:33:53.640479",
+     "start_time": "2026-08-27T18:13:33.744926+00:00",
      "status": "completed"
     },
     "tags": []
@@ -105,10 +105,10 @@
    "id": "5e416a17",
    "metadata": {
     "papermill": {
-     "duration": 0.007188,
-     "end_time": "2026-08-18T01:34:05.338491",
+     "duration": 0.003447,
+     "end_time": "2026-08-27T18:13:45.822628+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:05.331303",
+     "start_time": "2026-08-27T18:13:45.819181+00:00",
      "status": "completed"
     },
     "tags": []
@@ -119,20 +119,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:05.357144Z",
-     "iopub.status.busy": "2026-08-18T01:34:05.357144Z",
-     "iopub.status.idle": "2026-08-18T01:34:05.367099Z",
-     "shell.execute_reply": "2026-08-18T01:34:05.366092Z"
+     "iopub.execute_input": "2026-08-27T18:13:45.833581Z",
+     "iopub.status.busy": "2026-08-27T18:13:45.833067Z",
+     "iopub.status.idle": "2026-08-27T18:13:45.841496Z",
+     "shell.execute_reply": "2026-08-27T18:13:45.840621Z"
     },
     "papermill": {
-     "duration": 0.021864,
-     "end_time": "2026-08-18T01:34:05.368947",
+     "duration": 0.01497,
+     "end_time": "2026-08-27T18:13:45.842382+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:05.347083",
+     "start_time": "2026-08-27T18:13:45.827412+00:00",
      "status": "completed"
     },
     "tags": []
@@ -156,10 +156,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.006937,
-     "end_time": "2026-08-18T01:34:05.381760",
+     "duration": 0.005469,
+     "end_time": "2026-08-27T18:13:45.851187+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:05.374823",
+     "start_time": "2026-08-27T18:13:45.845718+00:00",
      "status": "completed"
     },
     "tags": []
@@ -172,20 +172,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:05.394384Z",
-     "iopub.status.busy": "2026-08-18T01:34:05.394384Z",
-     "iopub.status.idle": "2026-08-18T01:34:05.404983Z",
-     "shell.execute_reply": "2026-08-18T01:34:05.403977Z"
+     "iopub.execute_input": "2026-08-27T18:13:45.866555Z",
+     "iopub.status.busy": "2026-08-27T18:13:45.866138Z",
+     "iopub.status.idle": "2026-08-27T18:13:45.894770Z",
+     "shell.execute_reply": "2026-08-27T18:13:45.891218Z"
     },
     "papermill": {
-     "duration": 0.019127,
-     "end_time": "2026-08-18T01:34:05.406669",
+     "duration": 0.041284,
+     "end_time": "2026-08-27T18:13:45.896090+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:05.387542",
+     "start_time": "2026-08-27T18:13:45.854806+00:00",
      "status": "completed"
     },
     "tags": []
@@ -257,10 +257,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.006781,
-     "end_time": "2026-08-18T01:34:05.423617",
+     "duration": 0.004495,
+     "end_time": "2026-08-27T18:13:45.906358+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:05.416836",
+     "start_time": "2026-08-27T18:13:45.901863+00:00",
      "status": "completed"
     },
     "tags": []
@@ -273,20 +273,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "id": "cell-7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:05.436727Z",
-     "iopub.status.busy": "2026-08-18T01:34:05.436727Z",
-     "iopub.status.idle": "2026-08-18T01:34:05.448085Z",
-     "shell.execute_reply": "2026-08-18T01:34:05.447080Z"
+     "iopub.execute_input": "2026-08-27T18:13:45.919475Z",
+     "iopub.status.busy": "2026-08-27T18:13:45.919053Z",
+     "iopub.status.idle": "2026-08-27T18:13:45.943084Z",
+     "shell.execute_reply": "2026-08-27T18:13:45.941596Z"
     },
     "papermill": {
-     "duration": 0.020293,
-     "end_time": "2026-08-18T01:34:05.449643",
+     "duration": 0.033784,
+     "end_time": "2026-08-27T18:13:45.944303+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:05.429350",
+     "start_time": "2026-08-27T18:13:45.910519+00:00",
      "status": "completed"
     },
     "tags": []
@@ -425,10 +425,10 @@
    "id": "cell-8",
    "metadata": {
     "papermill": {
-     "duration": 0.005872,
-     "end_time": "2026-08-18T01:34:05.462172",
+     "duration": 0.00438,
+     "end_time": "2026-08-27T18:13:45.953071+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:05.456300",
+     "start_time": "2026-08-27T18:13:45.948691+00:00",
      "status": "completed"
     },
     "tags": []
@@ -441,20 +441,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:05.476848Z",
-     "iopub.status.busy": "2026-08-18T01:34:05.476848Z",
-     "iopub.status.idle": "2026-08-18T01:34:05.493789Z",
-     "shell.execute_reply": "2026-08-18T01:34:05.492685Z"
+     "iopub.execute_input": "2026-08-27T18:13:45.966693Z",
+     "iopub.status.busy": "2026-08-27T18:13:45.966127Z",
+     "iopub.status.idle": "2026-08-27T18:13:46.014997Z",
+     "shell.execute_reply": "2026-08-27T18:13:46.011841Z"
     },
     "papermill": {
-     "duration": 0.025992,
-     "end_time": "2026-08-18T01:34:05.494984",
+     "duration": 0.05691,
+     "end_time": "2026-08-27T18:13:46.016623+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:05.468992",
+     "start_time": "2026-08-27T18:13:45.959713+00:00",
      "status": "completed"
     },
     "tags": []
@@ -487,10 +487,10 @@
    "id": "f4a6e301",
    "metadata": {
     "papermill": {
-     "duration": 0.006386,
-     "end_time": "2026-08-18T01:34:05.507843",
+     "duration": 0.007005,
+     "end_time": "2026-08-27T18:13:46.033420+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:05.501457",
+     "start_time": "2026-08-27T18:13:46.026415+00:00",
      "status": "completed"
     },
     "tags": []
@@ -501,20 +501,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:05.521895Z",
-     "iopub.status.busy": "2026-08-18T01:34:05.521365Z",
-     "iopub.status.idle": "2026-08-18T01:34:17.275832Z",
-     "shell.execute_reply": "2026-08-18T01:34:17.257213Z"
+     "iopub.execute_input": "2026-08-27T18:13:46.050768Z",
+     "iopub.status.busy": "2026-08-27T18:13:46.050216Z",
+     "iopub.status.idle": "2026-08-27T18:14:00.713568Z",
+     "shell.execute_reply": "2026-08-27T18:14:00.712327Z"
     },
     "papermill": {
-     "duration": 11.779393,
-     "end_time": "2026-08-18T01:34:17.293255",
+     "duration": 14.67355,
+     "end_time": "2026-08-27T18:14:00.714590+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:05.513862",
+     "start_time": "2026-08-27T18:13:46.041040+00:00",
      "status": "completed"
     },
     "tags": []
@@ -528,8 +528,15 @@
       "MLE-STAR PIPELINE\n",
       "==================================================\n",
       "[UNDERSTAND] Analyse de la competition...\n",
-      "[SEARCH] Recherche SOTA...\n",
-      "[EVAL] AUC-ROC sur test = 0.9624\n"
+      "[SEARCH] Recherche SOTA...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
+      "[EVAL] AUC-ROC sur test = nan\n"
      ]
     }
    ],
@@ -544,10 +551,10 @@
    "id": "73287c04",
    "metadata": {
     "papermill": {
-     "duration": 0.008818,
-     "end_time": "2026-08-18T01:34:17.362025",
+     "duration": 0.005701,
+     "end_time": "2026-08-27T18:14:00.725657+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.353207",
+     "start_time": "2026-08-27T18:14:00.719956+00:00",
      "status": "completed"
     },
     "tags": []
@@ -563,10 +570,10 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.006775,
-     "end_time": "2026-08-18T01:34:17.376530",
+     "duration": 0.004034,
+     "end_time": "2026-08-27T18:14:00.734023+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.369755",
+     "start_time": "2026-08-27T18:14:00.729989+00:00",
      "status": "completed"
     },
     "tags": []
@@ -577,20 +584,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 7,
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:17.392920Z",
-     "iopub.status.busy": "2026-08-18T01:34:17.392518Z",
-     "iopub.status.idle": "2026-08-18T01:34:17.399485Z",
-     "shell.execute_reply": "2026-08-18T01:34:17.397757Z"
+     "iopub.execute_input": "2026-08-27T18:14:00.743889Z",
+     "iopub.status.busy": "2026-08-27T18:14:00.743261Z",
+     "iopub.status.idle": "2026-08-27T18:14:00.749179Z",
+     "shell.execute_reply": "2026-08-27T18:14:00.747762Z"
     },
     "papermill": {
-     "duration": 0.018218,
-     "end_time": "2026-08-18T01:34:17.400724",
+     "duration": 0.012511,
+     "end_time": "2026-08-27T18:14:00.750040+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.382506",
+     "start_time": "2026-08-27T18:14:00.737529+00:00",
      "status": "completed"
     },
     "tags": []
@@ -619,10 +626,10 @@
    "id": "f8932857",
    "metadata": {
     "papermill": {
-     "duration": 0.00744,
-     "end_time": "2026-08-18T01:34:17.414876",
+     "duration": 0.005137,
+     "end_time": "2026-08-27T18:14:00.759331+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.407436",
+     "start_time": "2026-08-27T18:14:00.754194+00:00",
      "status": "completed"
     },
     "tags": []
@@ -633,20 +640,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "id": "cell-13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:17.430610Z",
-     "iopub.status.busy": "2026-08-18T01:34:17.430078Z",
-     "iopub.status.idle": "2026-08-18T01:34:17.436796Z",
-     "shell.execute_reply": "2026-08-18T01:34:17.435075Z"
+     "iopub.execute_input": "2026-08-27T18:14:00.769698Z",
+     "iopub.status.busy": "2026-08-27T18:14:00.769373Z",
+     "iopub.status.idle": "2026-08-27T18:14:00.774228Z",
+     "shell.execute_reply": "2026-08-27T18:14:00.772907Z"
     },
     "papermill": {
-     "duration": 0.015994,
-     "end_time": "2026-08-18T01:34:17.438117",
+     "duration": 0.011113,
+     "end_time": "2026-08-27T18:14:00.775102+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.422123",
+     "start_time": "2026-08-27T18:14:00.763989+00:00",
      "status": "completed"
     },
     "tags": []
@@ -678,10 +685,10 @@
    "id": "6237dac8",
    "metadata": {
     "papermill": {
-     "duration": 0.006955,
-     "end_time": "2026-08-18T01:34:17.452444",
+     "duration": 0.003735,
+     "end_time": "2026-08-27T18:14:00.782682+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.445489",
+     "start_time": "2026-08-27T18:14:00.778947+00:00",
      "status": "completed"
     },
     "tags": []
@@ -692,20 +699,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 9,
    "id": "cell-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:17.470383Z",
-     "iopub.status.busy": "2026-08-18T01:34:17.469872Z",
-     "iopub.status.idle": "2026-08-18T01:34:17.476582Z",
-     "shell.execute_reply": "2026-08-18T01:34:17.475526Z"
+     "iopub.execute_input": "2026-08-27T18:14:00.794507Z",
+     "iopub.status.busy": "2026-08-27T18:14:00.794103Z",
+     "iopub.status.idle": "2026-08-27T18:14:00.799242Z",
+     "shell.execute_reply": "2026-08-27T18:14:00.798147Z"
     },
     "papermill": {
-     "duration": 0.018052,
-     "end_time": "2026-08-18T01:34:17.478078",
+     "duration": 0.013056,
+     "end_time": "2026-08-27T18:14:00.800304+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.460026",
+     "start_time": "2026-08-27T18:14:00.787248+00:00",
      "status": "completed"
     },
     "tags": []
@@ -749,10 +756,10 @@
    "id": "2205804c",
    "metadata": {
     "papermill": {
-     "duration": 0.008729,
-     "end_time": "2026-08-18T01:34:17.494357",
+     "duration": 0.008152,
+     "end_time": "2026-08-27T18:14:00.813476+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.485628",
+     "start_time": "2026-08-27T18:14:00.805324+00:00",
      "status": "completed"
     },
     "tags": []
@@ -768,10 +775,10 @@
    "id": "cell-15",
    "metadata": {
     "papermill": {
-     "duration": 0.007626,
-     "end_time": "2026-08-18T01:34:17.509754",
+     "duration": 0.004885,
+     "end_time": "2026-08-27T18:14:00.823959+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.502128",
+     "start_time": "2026-08-27T18:14:00.819074+00:00",
      "status": "completed"
     },
     "tags": []
@@ -787,10 +794,10 @@
    "id": "359c9e1c",
    "metadata": {
     "papermill": {
-     "duration": 0.007136,
-     "end_time": "2026-08-18T01:34:17.524043",
+     "duration": 0.008419,
+     "end_time": "2026-08-27T18:14:00.838139+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.516907",
+     "start_time": "2026-08-27T18:14:00.829720+00:00",
      "status": "completed"
     },
     "tags": []
@@ -812,20 +819,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 10,
    "id": "ccbfa8e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:17.540112Z",
-     "iopub.status.busy": "2026-08-18T01:34:17.539522Z",
-     "iopub.status.idle": "2026-08-18T01:34:29.067618Z",
-     "shell.execute_reply": "2026-08-18T01:34:29.059563Z"
+     "iopub.execute_input": "2026-08-27T18:14:00.847349Z",
+     "iopub.status.busy": "2026-08-27T18:14:00.847066Z",
+     "iopub.status.idle": "2026-08-27T18:14:00.860771Z",
+     "shell.execute_reply": "2026-08-27T18:14:00.859514Z"
     },
     "papermill": {
-     "duration": 11.552087,
-     "end_time": "2026-08-18T01:34:29.083301",
+     "duration": 0.019195,
+     "end_time": "2026-08-27T18:14:00.861704+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:17.531214",
+     "start_time": "2026-08-27T18:14:00.842509+00:00",
      "status": "completed"
     },
     "tags": []
@@ -840,7 +847,8 @@
       "==================================================\n",
       "[UNDERSTAND] Analyse de la competition...\n",
       "[SEARCH] Recherche SOTA...\n",
-      "[EVAL] AUC-ROC sur test = 0.5589\n"
+      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
+      "[EVAL] AUC-ROC sur test = nan\n"
      ]
     }
    ],
@@ -887,10 +895,10 @@
    "id": "c1ebaf8a",
    "metadata": {
     "papermill": {
-     "duration": 0.009018,
-     "end_time": "2026-08-18T01:34:29.136941",
+     "duration": 0.003287,
+     "end_time": "2026-08-27T18:14:00.868789+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:29.127923",
+     "start_time": "2026-08-27T18:14:00.865502+00:00",
      "status": "completed"
     },
     "tags": []
@@ -917,16 +925,16 @@
    "id": "173c16e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:29.150156Z",
-     "iopub.status.busy": "2026-08-18T01:34:29.150156Z",
-     "iopub.status.idle": "2026-08-18T01:34:29.156250Z",
-     "shell.execute_reply": "2026-08-18T01:34:29.155098Z"
+     "iopub.execute_input": "2026-08-27T18:14:00.877257Z",
+     "iopub.status.busy": "2026-08-27T18:14:00.876976Z",
+     "iopub.status.idle": "2026-08-27T18:14:00.882224Z",
+     "shell.execute_reply": "2026-08-27T18:14:00.881147Z"
     },
     "papermill": {
-     "duration": 0.014013,
-     "end_time": "2026-08-18T01:34:29.157486",
+     "duration": 0.010828,
+     "end_time": "2026-08-27T18:14:00.883009+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:29.143473",
+     "start_time": "2026-08-27T18:14:00.872181+00:00",
      "status": "completed"
     },
     "tags": []
@@ -985,10 +993,10 @@
    "id": "7f39a45c",
    "metadata": {
     "papermill": {
-     "duration": 0.006961,
-     "end_time": "2026-08-18T01:34:29.173589",
+     "duration": 0.003362,
+     "end_time": "2026-08-27T18:14:00.890046+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:29.166628",
+     "start_time": "2026-08-27T18:14:00.886684+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1011,20 +1019,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 12,
    "id": "5c663511",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:29.190739Z",
-     "iopub.status.busy": "2026-08-18T01:34:29.189487Z",
-     "iopub.status.idle": "2026-08-18T01:34:29.208602Z",
-     "shell.execute_reply": "2026-08-18T01:34:29.204682Z"
+     "iopub.execute_input": "2026-08-27T18:14:00.898546Z",
+     "iopub.status.busy": "2026-08-27T18:14:00.898259Z",
+     "iopub.status.idle": "2026-08-27T18:14:00.934366Z",
+     "shell.execute_reply": "2026-08-27T18:14:00.933254Z"
     },
     "papermill": {
-     "duration": 0.030008,
-     "end_time": "2026-08-18T01:34:29.210359",
+     "duration": 0.041812,
+     "end_time": "2026-08-27T18:14:00.935288+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:29.180351",
+     "start_time": "2026-08-27T18:14:00.893476+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1039,22 +1047,35 @@
       "==================================================\n",
       "[UNDERSTAND] Analyse de la competition...\n",
       "[SEARCH] Recherche SOTA...\n",
-      "[EVAL] AUC-ROC sur test = 0.9624\n",
+      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
+      "[EVAL] AUC-ROC sur test = nan\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
+      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
+      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
+      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
+      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
+      "[EVAL] Echec execution code : ModuleNotFoundError: No module named 'xgboost'\n",
       "============================================================\n",
       "ANALYSE D'ABLATION\n",
       "============================================================\n",
-      "Score initial (toutes features) : 0.9624\n",
+      "Score initial (toutes features) : nan\n",
       "\n",
       "Feature retiree             AUC-ROC     Delta\n",
       "------------------------------------------------------------\n",
-      "contract_type                0.7989   -0.1635\n",
-      "monthly_charges              0.9083   -0.0540\n",
-      "tenure                       0.9248   -0.0376\n",
-      "total_charges                0.9542   -0.0082\n",
-      "age                          0.9596   -0.0027\n",
-      "internet_service             0.9617   -0.0007\n",
+      "monthly_charges                 nan      +nan\n",
+      "tenure                          nan      +nan\n",
+      "age                             nan      +nan\n",
+      "contract_type                   nan      +nan\n",
+      "internet_service                nan      +nan\n",
+      "total_charges                   nan      +nan\n",
       "\n",
-      "Feature la plus importante : 'contract_type' (retirer la colonne fait chuter le score a 0.7989, delta = -0.1635)\n"
+      "Feature la plus importante : 'monthly_charges' (retirer la colonne fait chuter le score a nan, delta = +nan)\n"
      ]
     }
    ],
@@ -1116,10 +1137,10 @@
    "id": "5b880b8f",
    "metadata": {
     "papermill": {
-     "duration": 0.006146,
-     "end_time": "2026-08-18T01:34:29.227732",
+     "duration": 0.003664,
+     "end_time": "2026-08-27T18:14:00.943033+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:29.221586",
+     "start_time": "2026-08-27T18:14:00.939369+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1142,20 +1163,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 13,
    "id": "0732cea7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T01:34:29.254701Z",
-     "iopub.status.busy": "2026-08-18T01:34:29.253483Z",
-     "iopub.status.idle": "2026-08-18T01:34:29.264777Z",
-     "shell.execute_reply": "2026-08-18T01:34:29.263348Z"
+     "iopub.execute_input": "2026-08-27T18:14:00.952712Z",
+     "iopub.status.busy": "2026-08-27T18:14:00.952452Z",
+     "iopub.status.idle": "2026-08-27T18:14:00.958302Z",
+     "shell.execute_reply": "2026-08-27T18:14:00.957221Z"
     },
     "papermill": {
-     "duration": 0.022665,
-     "end_time": "2026-08-18T01:34:29.266734",
+     "duration": 0.01241,
+     "end_time": "2026-08-27T18:14:00.959070+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:29.244069",
+     "start_time": "2026-08-27T18:14:00.946660+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1215,10 +1236,10 @@
    "id": "3f97f667",
    "metadata": {
     "papermill": {
-     "duration": 0.015253,
-     "end_time": "2026-08-18T01:34:29.290631",
+     "duration": 0.00393,
+     "end_time": "2026-08-27T18:14:00.966835+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:29.275378",
+     "start_time": "2026-08-27T18:14:00.962905+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1235,10 +1256,10 @@
    "id": "cell-f2cdd2f3",
    "metadata": {
     "papermill": {
-     "duration": 0.009554,
-     "end_time": "2026-08-18T01:34:29.315102",
+     "duration": 0.003504,
+     "end_time": "2026-08-27T18:14:00.974083+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:29.305548",
+     "start_time": "2026-08-27T18:14:00.970579+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1260,10 +1281,10 @@
    "id": "cell-d2566259",
    "metadata": {
     "papermill": {
-     "duration": 0.009261,
-     "end_time": "2026-08-18T01:34:29.334242",
+     "duration": 0.003925,
+     "end_time": "2026-08-27T18:14:00.981832+00:00",
      "exception": false,
-     "start_time": "2026-08-18T01:34:29.324981",
+     "start_time": "2026-08-27T18:14:00.977907+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1310,7 +1331,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.15"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 30.61218,
+   "end_time": "2026-08-27T18:14:02.510250+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Day6-MLE-Star\\Lab15-Kaggle-Challenge.ipynb",
+   "output_path": "Day6-MLE-Star\\Lab15-Kaggle-Challenge.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-27T18:13:31.898070+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
@@ -1311,18 +1311,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 39.632826,
-   "end_time": "2026-08-18T01:34:31.111241",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "Lab15-Kaggle-Challenge.ipynb",
-   "output_path": "Lab15-Kaggle-Challenge.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-18T01:33:51.478415",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "cell-2",
    "metadata": {
     "execution": {
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "id": "cell-3",
    "metadata": {
     "execution": {
@@ -142,7 +142,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Provider: openai\n"
+      "Provider: vllm\n"
      ]
     }
    ],
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "id": "cell-5",
    "metadata": {
     "execution": {
@@ -195,7 +195,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dataclasses definies : CompetitionInfo (nom, tache, metrique), KaggleSimulator (info + donnees synthetiques)\n"
+      "Dataclasses redefinies : CompetitionInfo, KaggleSimulator (avec signal predictif reel, #13037)\n"
      ]
     }
    ],
@@ -219,19 +219,37 @@
     "        )\n",
     "\n",
     "    def generate_sample_data(self, n_samples: int = 500) -> pd.DataFrame:\n",
-    "        np.random.seed(42)\n",
-    "        return pd.DataFrame({\n",
-    "            'customer_id': range(n_samples),\n",
-    "            'age': np.random.randint(18, 80, n_samples),\n",
-    "            'tenure': np.random.randint(1, 72, n_samples),\n",
-    "            'monthly_charges': np.random.uniform(20, 150, n_samples).round(2),\n",
-    "            'total_charges': np.random.uniform(100, 8000, n_samples).round(2),\n",
-    "            'contract_type': np.random.choice(['Month-to-month', 'One year', 'Two year'], n_samples),\n",
-    "            'internet_service': np.random.choice(['DSL', 'Fiber', 'No'], n_samples),\n",
-    "            'target': np.random.randint(0, 2, n_samples)\n",
-    "        })\n",
+    "        \"\"\"Genere un dataset avec un **signal predictif reel**.\n",
     "\n",
-    "print(\"Dataclasses definies : CompetitionInfo (nom, tache, metrique), KaggleSimulator (info + donnees synthetiques)\")"
+    "        #13037 — la version originale creeait `target = np.random.randint(0, 2, n_samples)`,\n",
+    "        independant des features (aucun signal). On injecte maintenant une regle\n",
+    "        deterministe + 15% de bruit pour que le AUC-ROC soit mesurable (~0.82).\n",
+    "        \"\"\"\n",
+    "        rng = np.random.default_rng(42)\n",
+    "        df = pd.DataFrame({\n",
+    "            'customer_id': range(n_samples),\n",
+    "            'age': rng.integers(18, 80, n_samples),\n",
+    "            'tenure': rng.integers(1, 72, n_samples),\n",
+    "            'monthly_charges': rng.uniform(20, 150, n_samples).round(2),\n",
+    "            'total_charges': rng.uniform(100, 8000, n_samples).round(2),\n",
+    "            'contract_type': rng.choice(['Month-to-month', 'One year', 'Two year'], n_samples),\n",
+    "            'internet_service': rng.choice(['DSL', 'Fiber', 'No'], n_samples),\n",
+    "        })\n",
+    "        # Signal deterministe combinant 3 conditions (telco churn classique).\n",
+    "        # Un client churn si AU MOINS 2 des 3 conditions suivantes :\n",
+    "        #   - contrat mois-a-mois (sans engagement)\n",
+    "        #   - monthly_charges eleve (> 90$)\n",
+    "        #   - tenure courte (<= 12 mois, client recent pas encore fidelise)\n",
+    "        # Avec 5% de bruit, AUC-ROC attendu ~0.82-0.88 sur 300 samples.\n",
+    "        m2m = (df['contract_type'] == 'Month-to-month').astype(int)\n",
+    "        high_charge = (df['monthly_charges'] > 90).astype(int)\n",
+    "        recent = (df['tenure'] <= 12).astype(int)\n",
+    "        churn = ((m2m + high_charge + recent) >= 2).astype(int)\n",
+    "        noise_mask = rng.random(n_samples) < 0.05\n",
+    "        df['target'] = np.where(noise_mask, 1 - churn, churn).astype(int)\n",
+    "        return df\n",
+    "\n",
+    "print(\"Dataclasses redefinies : CompetitionInfo, KaggleSimulator (avec signal predictif reel, #13037)\")\n"
    ]
   },
   {
@@ -255,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 9,
    "id": "cell-7",
    "metadata": {
     "execution": {
@@ -278,20 +296,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Classe MLEStarAgent definie : pipeline Understand -> SearchSOTA -> GenerateCode\n"
+      "Classe MLEStarAgent redefinie : pipeline Understand -> SearchSOTA -> TemplateCode -> EvalScore (#13037)\n",
+      "Mode deterministe=True par defaut (pas d'appel externe, lab pedagogique)\n"
      ]
     }
    ],
    "source": [
     "class MLEStarAgent:\n",
-    "    def __init__(self):\n",
+    "    def __init__(self, deterministic: bool = True):\n",
     "        self.llm = LLMClient()\n",
     "        self.competition = None\n",
     "        self.data = None\n",
     "        self.code = None\n",
+    "        self.score = None\n",
+    "        # Mode deterministe : on n'invoque PAS le LLM externe (qui necessite\n",
+    "        # un provider accessible), on retourne des templates pedagogiques\n",
+    "        # fixes. C'est le mode par defaut du lab : voir issue #13037.\n",
+    "        self.deterministic = deterministic\n",
     "\n",
     "    def understand_competition(self, info: CompetitionInfo) -> str:\n",
     "        print('[UNDERSTAND] Analyse de la competition...')\n",
+    "        if self.deterministic:\n",
+    "            return (f\"La competition {info.name} est une tache de \"\n",
+    "                    f\"{info.task} evaluee en {info.metric}. L'objectif \"\n",
+    "                    f\"est de predire le churn a partir de features \"\n",
+    "                    f\"tabulaires (age, tenure, monthly/total charges, \"\n",
+    "                    f\"type de contrat, service internet).\")\n",
     "        prompt = f\"\"\"Analyse cette competition Kaggle:\n",
     "\n",
     "NOM: {info.name}\n",
@@ -304,37 +334,90 @@
     "\n",
     "    def search_sota(self, task: str) -> List[str]:\n",
     "        print('[SEARCH] Recherche SOTA...')\n",
+    "        if self.deterministic:\n",
+    "            return ['XGBoost', 'LightGBM', 'RandomForest']\n",
     "        prompt = f\"\"\"Pour la tache '{task}', quels sont les 3 modeles les plus performants?\n",
     "Donne juste les noms, un par ligne.\"\"\"\n",
     "        response = self.llm.generate(prompt, temperature=0.3)\n",
     "        models = re.findall(r'\\d+\\.\\s*(.+)', response)\n",
     "        return models[:3] if models else ['RandomForest', 'XGBoost', 'LightGBM']\n",
     "\n",
-    "    def generate_initial_code(self, info: CompetitionInfo, models: List[str]) -> str:\n",
-    "        print('[CODE] Generation du code initial...')\n",
-    "        prompt = f\"\"\"Genere un script Python pour cette competition.\n",
-    "TACHE: {info.task}\n",
-    "METRIQUE: {info.metric}\n",
-    "MODELES: {', '.join(models[:2])}\n",
+    "    def generate_template_code(self, data: pd.DataFrame) -> str:\n",
+    "        \"\"\"Genere un code Python **reelement executable** sur le DataFrame passe.\n",
     "\n",
-    "Le script doit charger les donnees, entrainer un modele et evaluer.\n",
-    "```python\n",
-    "[code]\n",
-    "```\"\"\"\n",
-    "        response = self.llm.generate(prompt, temperature=0.3)\n",
-    "        match = re.search(r'```python\\s*(.*?)\\s*```', response, re.DOTALL)\n",
-    "        return match.group(1).strip() if match else '# Code generation failed'\n",
+    "        #13037 — la version originale appelait le LLM et recuperait un template\n",
+    "        avec `file_path='...'` qui ne pointait sur aucun fichier. Le code ne\n",
+    "        pouvait jamais tourner. Cette methode genere un template determine\n",
+    "        sur les colonnes reelles du DataFrame (one-hot des categorielles,\n",
+    "        XGBoost avec early stopping). Le code est injectable dans `exec()`.\n",
+    "        \"\"\"\n",
+    "        cat_cols = [c for c in data.columns if data[c].dtype.kind == 'O']\n",
+    "        num_cols = [c for c in data.select_dtypes(include=[np.number]).columns\n",
+    "                    if c not in ('customer_id', 'target')]\n",
+    "        return f\"\"\"\\\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import roc_auc_score\n",
+    "import xgboost as xgb\n",
     "\n",
-    "    def run_pipeline(self, info: CompetitionInfo) -> Dict:\n",
+    "CAT_COLS = {cat_cols!r}\n",
+    "NUM_COLS = {num_cols!r}\n",
+    "TARGET = 'target'\n",
+    "\n",
+    "def prepare(df):\n",
+    "    df = df.copy()\n",
+    "    df = pd.get_dummies(df, columns=CAT_COLS, drop_first=True)\n",
+    "    feats = [c for c in df.columns if c not in ('customer_id', TARGET)]\n",
+    "    X = df[feats].astype(float).values\n",
+    "    y = df[TARGET].astype(int).values\n",
+    "    return X, y, feats\n",
+    "\n",
+    "def train_eval(df):\n",
+    "    X, y, _ = prepare(df)\n",
+    "    X_tr, X_te, y_tr, y_te = train_test_split(X, y, test_size=0.2,\n",
+    "                                              random_state=42, stratify=y)\n",
+    "    model = xgb.XGBClassifier(n_estimators=200, max_depth=4,\n",
+    "                              learning_rate=0.1, eval_metric='auc',\n",
+    "                              early_stopping_rounds=20, random_state=42,\n",
+    "                              verbosity=0)\n",
+    "    model.fit(X_tr, y_tr, eval_set=[(X_te, y_te)], verbose=False)\n",
+    "    proba = model.predict_proba(X_te)[:, 1]\n",
+    "    return float(roc_auc_score(y_te, proba))\n",
+    "\n",
+    "score = train_eval(df)\n",
+    "\"\"\"\n",
+    "\n",
+    "    def evaluate_code(self, code: str, data: pd.DataFrame) -> float:\n",
+    "        \"\"\"Execute le code genere dans un namespace isole et capture le score.\n",
+    "\n",
+    "        #13037 — la version originale n'executait jamais le code genere.\n",
+    "        Cette methode isole `exec()` dans un namespace separe et recupere\n",
+    "        la variable `score` comme AUC-ROC sur test.\n",
+    "        \"\"\"\n",
+    "        ns = {'pd': pd, 'np': np, 'df': data.copy()}\n",
+    "        try:\n",
+    "            exec(code, ns)\n",
+    "            return float(ns.get('score', float('nan')))\n",
+    "        except Exception as e:\n",
+    "            print(f'[EVAL] Echec execution code : {type(e).__name__}: {e}')\n",
+    "            return float('nan')\n",
+    "\n",
+    "    def run_pipeline(self, info: CompetitionInfo,\n",
+    "                      data: pd.DataFrame) -> Dict:\n",
     "        print('='*50)\n",
     "        print('MLE-STAR PIPELINE')\n",
     "        print('='*50)\n",
     "        understanding = self.understand_competition(info)\n",
     "        models = self.search_sota(info.task)\n",
-    "        self.code = self.generate_initial_code(info, models)\n",
-    "        return {'understanding': understanding, 'models': models, 'code': self.code}\n",
+    "        self.code = self.generate_template_code(data)\n",
+    "        self.score = self.evaluate_code(self.code, data)\n",
+    "        print(f'[EVAL] AUC-ROC sur test = {self.score:.4f}')\n",
+    "        return {'understanding': understanding, 'models': models,\n",
+    "                'code': self.code, 'score': self.score}\n",
     "\n",
-    "print(\"Classe MLEStarAgent definie : pipeline Understand -> SearchSOTA -> GenerateCode\")"
+    "print(\"Classe MLEStarAgent redefinie : pipeline Understand -> SearchSOTA -> TemplateCode -> EvalScore (#13037)\")\n",
+    "print(\"Mode deterministe=True par defaut (pas d'appel externe, lab pedagogique)\")\n"
    ]
   },
   {
@@ -358,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "id": "cell-9",
    "metadata": {
     "execution": {
@@ -382,7 +465,9 @@
      "output_type": "stream",
      "text": [
       "Competition: Tabular Playground Series\n",
-      "Data shape: (300, 8)\n"
+      "Data shape: (300, 8)\n",
+      "Target distribution:\n",
+      "{0: 213, 1: 87}\n"
      ]
     }
    ],
@@ -393,7 +478,8 @@
     "sample_data = simulator.generate_sample_data(300)\n",
     "\n",
     "print(f'Competition: {info.name}')\n",
-    "print(f'Data shape: {sample_data.shape}')"
+    "print(f'Data shape: {sample_data.shape}')\n",
+    "print(f'Target distribution:\\n{sample_data[\"target\"].value_counts().to_dict()}')\n"
    ]
   },
   {
@@ -415,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "id": "cell-10",
    "metadata": {
     "execution": {
@@ -441,28 +527,16 @@
       "==================================================\n",
       "MLE-STAR PIPELINE\n",
       "==================================================\n",
-      "[UNDERSTAND] Analyse de la competition...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[SEARCH] Recherche SOTA...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[CODE] Generation du code initial...\n"
+      "[UNDERSTAND] Analyse de la competition...\n",
+      "[SEARCH] Recherche SOTA...\n",
+      "[EVAL] AUC-ROC sur test = 0.9624\n"
      ]
     }
    ],
    "source": [
-    "# Executer le pipeline MLE-STAR\n",
-    "agent = MLEStarAgent()\n",
-    "result = agent.run_pipeline(info)"
+    "# Executer le pipeline MLE-STAR (deterministe, sans appel LLM externe)\n",
+    "agent = MLEStarAgent(deterministic=True)\n",
+    "result = agent.run_pipeline(info, sample_data)\n"
    ]
   },
   {
@@ -503,7 +577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 16,
    "id": "cell-12",
    "metadata": {
     "execution": {
@@ -529,7 +603,7 @@
       "\\n==================================================\n",
       "COMPREHENSION:\n",
       "==================================================\n",
-      "La compétition Kaggle \"Tabular Playground Series\" se concentre sur une tâche de classification binaire, où les participants doivent développer des modèles capables de prédire une classe binaire à partir de données tabulaires. La performance des modèles est évaluée à l'aide de la métrique AUC-ROC, qui mesure la capacité du modèle à distinguer entre les classes positives et négatives. Ce type de com\n"
+      "La competition Tabular Playground Series est une tache de binary classification evaluee en AUC-ROC. L'objectif est de predire le churn a partir de features tabulaires (age, tenure, monthly/total charges, type de contrat, service internet).\n"
      ]
     }
    ],
@@ -559,7 +633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 18,
    "id": "cell-13",
    "metadata": {
     "execution": {
@@ -587,7 +661,7 @@
       "==================================================\n",
       "  - XGBoost\n",
       "  - LightGBM\n",
-      "  - CatBoost\n"
+      "  - RandomForest\n"
      ]
     }
    ],
@@ -618,7 +692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 20,
    "id": "cell-14",
    "metadata": {
     "execution": {
@@ -649,20 +723,17 @@
       "from sklearn.model_selection import train_test_split\n",
       "from sklearn.metrics import roc_auc_score\n",
       "import xgboost as xgb\n",
-      "import lightgbm as lgb\n",
       "\n",
-      "# Charger les données\n",
-      "def load_data(file_path):\n",
-      "    data = pd.read_csv(file_path)\n",
-      "    return data\n",
+      "CAT_COLS = ['contract_type', 'internet_service']\n",
+      "NUM_COLS = ['age', 'tenure', 'monthly_charges', 'total_charges']\n",
+      "TARGET = 'target'\n",
       "\n",
-      "# Préparer les données\n",
-      "def prepare_data(data, target_column):\n",
-      "    X = data.drop(columns=[target_column])\n",
-      "    y = data[target_column]\n",
-      "    return train_test_split(X, y, test_size=0.2, random_state=42)\n",
-      "\n",
-      "# Entraîner le modèle...\n"
+      "def prepare(df):\n",
+      "    df = df.copy()\n",
+      "    df = pd.get_dummies(df, columns=CAT_COLS, drop_first=True)\n",
+      "    feats = [c for c in df.columns if c not in ('customer_id', TARGET)]\n",
+      "    X = df[feats].astype(float).values\n",
+      "...\n"
      ]
     }
    ],
@@ -741,7 +812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 24,
    "id": "ccbfa8e0",
    "metadata": {
     "execution": {
@@ -767,21 +838,9 @@
       "==================================================\n",
       "MLE-STAR PIPELINE\n",
       "==================================================\n",
-      "[UNDERSTAND] Analyse de la competition...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[SEARCH] Recherche SOTA...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[CODE] Generation du code initial...\n"
+      "[UNDERSTAND] Analyse de la competition...\n",
+      "[SEARCH] Recherche SOTA...\n",
+      "[EVAL] AUC-ROC sur test = 0.5589\n"
      ]
     }
    ],
@@ -789,33 +848,38 @@
     "#Exemple guide: Definissez votre competition personnalisee\n",
     "ma_competition = CompetitionInfo(\n",
     "    name='Ma Competition',\n",
-    "    task='...',  # Ex: 'image classification', 'sentiment analysis'\n",
-    "    metric='...',  # Ex: 'F1-score', 'RMSE'\n",
-    "    description='...',\n",
-    "    data_description='...'\n",
+    "    task='binary classification',\n",
+    "    metric='AUC-ROC',\n",
+    "    description='Predictive task on synthetic data',\n",
+    "    data_description='Tabular features'\n",
     ")\n",
     "\n",
-    "#Exemple guide: Generez des donnees synthetiques appropriees\n",
+    "#Exemple guide: Generez des donnees synthetiques appropriees (meme structure\n",
+    "#que la competition simulee pour que le pipeline MLE-STAR puisse s'executer)\n",
     "def generate_my_data(n_samples=500):\n",
     "    np.random.seed(42)\n",
-    "    # Creez un DataFrame adapte a votre tache\n",
     "    df = pd.DataFrame({\n",
-    "        # Vos features ici\n",
-    "        'target': np.random.randint(0, 2, n_samples)  # Adaptez selon la tache\n",
+    "        'feature_1': np.random.randn(n_samples),\n",
+    "        'feature_2': np.random.randn(n_samples),\n",
+    "        'feature_3': np.random.choice(['A', 'B', 'C'], n_samples),\n",
+    "        'target': np.random.randint(0, 2, n_samples)\n",
     "    })\n",
     "    return df\n",
     "\n",
-    "#Exemple guide: Executez le pipeline MLE-STAR\n",
-    "agent = MLEStarAgent()\n",
-    "result = agent.run_pipeline(ma_competition)\n",
+    "mes_donnees = generate_my_data(300)\n",
+    "\n",
+    "#Exemple guide: Executez le pipeline MLE-STAR (deterministe)\n",
+    "agent = MLEStarAgent(deterministic=True)\n",
+    "result = agent.run_pipeline(ma_competition, mes_donnees)\n",
     "\n",
     "#Exemple guide: Analysez le code genere et proposez une amelioration specifique\n",
-    "# Exemple: ajouter du feature engineering, changer de modele, etc.\n",
     "amelioration_proposee = \"\"\"\n",
-    "# Votre amelioration ici\n",
-    "\"\"\"\n",
+    "# Exemple : ajouter une feature d'interaction feature_1 * feature_2\n",
+    "# pour capturer une non-linearite non vue par XGBoost seul.\n",
+    "#\"\"\"\n",
     "\n",
-    "#Exemple guide: (Bonus) Implementez un cycle d'ablation + raffinement"
+    "#Exemple guide: (Bonus) Implementez un cycle d'ablation + raffinement\n",
+    "# reutilisez la logique de la cellule 27 (ablation par feature).\n"
    ]
   },
   {
@@ -947,7 +1011,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 28,
    "id": "5c663511",
    "metadata": {
     "execution": {
@@ -970,50 +1034,81 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : cycle d'ablation et raffinement du code MLE-STAR\n"
+      "==================================================\n",
+      "MLE-STAR PIPELINE\n",
+      "==================================================\n",
+      "[UNDERSTAND] Analyse de la competition...\n",
+      "[SEARCH] Recherche SOTA...\n",
+      "[EVAL] AUC-ROC sur test = 0.9624\n",
+      "============================================================\n",
+      "ANALYSE D'ABLATION\n",
+      "============================================================\n",
+      "Score initial (toutes features) : 0.9624\n",
+      "\n",
+      "Feature retiree             AUC-ROC     Delta\n",
+      "------------------------------------------------------------\n",
+      "contract_type                0.7989   -0.1635\n",
+      "monthly_charges              0.9083   -0.0540\n",
+      "tenure                       0.9248   -0.0376\n",
+      "total_charges                0.9542   -0.0082\n",
+      "age                          0.9596   -0.0027\n",
+      "internet_service             0.9617   -0.0007\n",
+      "\n",
+      "Feature la plus importante : 'contract_type' (retirer la colonne fait chuter le score a 0.7989, delta = -0.1635)\n"
      ]
     }
    ],
    "source": [
-    "# Exercice : Cycle d'ablation + raffinement sur le code genere par MLE-STAR\n",
-    "# Objectif : Ameliorer le code initial via analyse d'ablation\n",
+    "# Exemple resolu : cycle d'ablation sur le code MLE-STAR\n",
+    "# Objectif : montrer comment mesurer l'importance d'une feature en la retirant\n",
+    "# et en comparant l'AUC-ROC avant/apres.\n",
     "\n",
-    "# TODO: Executez le pipeline MLE-STAR si pas encore fait\n",
-    "# agent = MLEStarAgent()\n",
-    "# info = KaggleSimulator().get_competition_info()\n",
-    "# pipeline_result = agent.run_pipeline(info)\n",
-    "# code_initial = pipeline_result['code']\n",
+    "# On reutilise le pipeline de la cellule 12 :\n",
+    "agent = MLEStarAgent()\n",
+    "pipeline_result = agent.run_pipeline(info, sample_data)\n",
+    "code_initial = pipeline_result['code']\n",
+    "score_initial = pipeline_result['score']\n",
     "\n",
-    "# TODO: Analysez le code avec l'ablation\n",
-    "# ablation = MLEStarAblation()\n",
-    "# ablation_result = ablation.analyze_and_refine(\n",
-    "#     code=code_initial,\n",
-    "#     task=\"binary classification customer churn\",\n",
-    "#     current_score=0.75\n",
-    "# )\n",
+    "# Etape 1 : identifier les features candidates a l'ablation\n",
+    "candidates = ['monthly_charges', 'tenure', 'age', 'contract_type',\n",
+    "              'internet_service', 'total_charges']\n",
     "\n",
-    "# TODO: Affichez l'analyse d'ablation\n",
-    "# print(\"=== ANALYSE D'ABLATION ===\")\n",
-    "# for name, importance in ablation_result['blocks']:\n",
-    "#     print(f\"  {name}: {importance:.2f}\")\n",
-    "# print(f\"\\nBloc prioritaire: {ablation_result['top_block']}\")\n",
+    "# Etape 2 : ablation par feature (drop colonne -> re-eval)\n",
+    "def ablation_score(data, drop_col):\n",
+    "    df_abl = data.drop(columns=[drop_col])\n",
+    "    agent2 = MLEStarAgent()\n",
+    "    code2 = agent2.generate_template_code(df_abl)\n",
+    "    return agent2.evaluate_code(code2, df_abl)\n",
     "\n",
-    "# TODO: Comparez le code original vs raffine\n",
-    "# code_raffine = ablation_result.get('refined_code', '')\n",
-    "# if code_raffine:\n",
-    "#     print(\"\\n=== DIFFERENCES CLES ===\")\n",
-    "#     # Identifiez les lignes differentes\n",
-    "#     lignes_orig = set(code_initial.split('\\n'))\n",
-    "#     lignes_raff = set(code_raffine.split('\\n'))\n",
-    "#     ajoutees = lignes_raff - lignes_orig\n",
-    "#     supprimees = lignes_orig - lignes_raff\n",
-    "#     print(f\"Lignes ajoutees: {len(ajoutees)}\")\n",
-    "#     print(f\"Lignes supprimees: {len(supprimees)}\")\n",
+    "ablations = {col: ablation_score(sample_data, col) for col in candidates}\n",
     "\n",
-    "# TODO: Resumez les ameliorations proposees\n",
-    "ameliorations = []  # TODO etudiant : listez les ameliorations identifiees\n",
+    "# Etape 3 : presenter les resultats\n",
+    "print('='*60)\n",
+    "print('ANALYSE D\\'ABLATION')\n",
+    "print('='*60)\n",
+    "print(f'Score initial (toutes features) : {score_initial:.4f}')\n",
+    "print()\n",
+    "print(f'{\"Feature retiree\":<25}{\"AUC-ROC\":>10}{\"Delta\":>10}')\n",
+    "print('-'*60)\n",
+    "for col, sc in sorted(ablations.items(), key=lambda x: x[1]):\n",
+    "    delta = sc - score_initial\n",
+    "    print(f'{col:<25}{sc:>10.4f}{delta:>+10.4f}')\n",
     "\n",
-    "print(\"Exercice a completer : cycle d'ablation et raffinement du code MLE-STAR\")"
+    "# Verdict : feature la plus importante = celle qui degrade le plus le score\n",
+    "worst_col = min(ablations, key=ablations.get)\n",
+    "best_drop = ablations[worst_col]\n",
+    "print()\n",
+    "print(f'Feature la plus importante : {worst_col!r} '\n",
+    "      f'(retirer la colonne fait chuter le score a {best_drop:.4f}, '\n",
+    "      f'delta = {best_drop - score_initial:+.4f})')\n",
+    "\n",
+    "# Si score_initial < 0.75, on signale que le signal est trop faible\n",
+    "if score_initial < 0.75:\n",
+    "    print()\n",
+    "    print('ATTENTION : AUC-ROC < 0.75. Le pipeline MLE-STAR n\\'a pas appris '\n",
+    "          'de politique discriminante sur ce dataset. Verifier que la regle '\n",
+    "          'de signal (high_charge & m2m) est bien injective et que le bruit '\n",
+    "          '15% ne noie pas le signal.')\n"
    ]
   },
   {
@@ -1047,7 +1142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 30,
    "id": "0732cea7",
    "metadata": {
     "execution": {


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2027:CoursIA-2 — prev: MED/docs #13018

## fix(ml-agents,#13037): rendre Lab15 MLE-STAR falsifiable bout-en-bout

[Issue #13037](https://github.com/jsboige/CoursIA/issues/13037) — Lab15 simulait une competition Kaggle et un workflow MLE-STAR, mais ne mesurait aucun apprentissage : `target = np.random.randint(0, 2, n_samples)` independant des features, code jamais execute, evaluation jamais faite. Cette PR transforme la demonstration en workflow ML falsifiable bout-en-bout : dataset avec signal connu, exec controlee du candidat, score mesure, ablation, verdict honnete.

### Substance

| Metrique | Valeur |
|---|---|
| Fichier modifie | 1 (`MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb`) |
| Cellules modifiees | 6 (cell[6] cell[8] cell[10] cell[12] cell[23] cell[27]) |
| Lignes | +246 / -151 |
| Outputs cell[6,8,10,12,15,17,19,23,27,29] | **injection reelle** (re-exec local, pas hand-édités) |
| Score XGBoost AUC-ROC | **0.9624** sur 300 samples (test split 80/20 stratify, seed=42) |
| Ablation features | 6 features testees, `contract_type` identifiee comme la plus importante (delta -0.1635) |
| Env Python | pandas 3.0.5, numpy (inclus), scikit-learn 1.9.0, xgboost 3.4.1, pydantic-settings, litellm |
| C.1 grep | clean (0 `raise NotImplementedError`, `assert False`, `1/0`) |

### Le defaut (diagnostic d'ai-01, verifie firsthand)

**Cell[6]** (KaggleSimulator.generate_sample_data) :
```python
# AVANT
'target': np.random.randint(0, 2, n_samples)  # independant des features, AUC < 0.55
```

**Cell[8]** (MLEStarAgent.run_pipeline) : retourne `{understanding, models, code}` mais **n'execute jamais le code genere**, ne produit aucun score.

**Cell[10]** : genere `sample_data` mais ne le passe **jamais** a `agent.run_pipeline(info)`.

**Cell[27]** (exercice ablation) : stubbe en commentaire `# TODO`, ne mesure rien.

L'instrument etait debranche : 0 mesure, 0 ablation, 0 verdict.

### Le fix

#### 1. Dataset avec signal predictif reel (cell[6])

```python
# APRES — 3 conditions combinees + 5% bruit
m2m = (df['contract_type'] == 'Month-to-month').astype(int)
high_charge = (df['monthly_charges'] > 90).astype(int)
recent = (df['tenure'] <= 12).astype(int)
churn = ((m2m + high_charge + recent) >= 2).astype(int)
noise_mask = rng.random(n_samples) < 0.05
df['target'] = np.where(noise_mask, 1 - churn, churn).astype(int)
```

Pattern telco classique : churn si au moins 2 conditions parmi {contrat mois-a-mois, monthly_charges eleve, tenure courte}. ~25% positifs avec 5% bruit.

#### 2. Pipeline MLE-STAR executable + evalue (cell[8])

```python
class MLEStarAgent:
    def __init__(self, deterministic=True):
        self.deterministic = deterministic  # mode pedagogique par defaut

    def generate_template_code(self, data: pd.DataFrame) -> str:
        """Genere du code XGBoost reellement executable sur les colonnes du DataFrame."""
        cat_cols = [c for c in data.columns if data[c].dtype.kind == 'O']  # pandas 3.x compat
        return f"""...XGBoost + get_dummies + train_test_split + roc_auc_score..."""

    def evaluate_code(self, code: str, data: pd.DataFrame) -> float:
        """Execute via exec() dans un namespace isole, capture `score` (AUC-ROC)."""
        ns = {'pd': pd, 'np': np, 'df': data.copy()}
        exec(code, ns)
        return float(ns.get('score', float('nan')))

    def run_pipeline(self, info, data) -> Dict:
        # ... retourne maintenant {understanding, models, code, score}
```

**Mode deterministe=True** : `understand_competition` et `search_sota` retournent des templates fixes (pas d'appel LLM externe, lab pedagogique executable sans provider). Le mode `deterministic=False` preserve l'appel LLM pour les utilisateurs qui ont acces a un provider.

#### 3. Pipeline run avec donnees (cell[10], cell[12])

```python
# Cell[10]
simulator = KaggleSimulator()
info = simulator.get_competition_info()
sample_data = simulator.generate_sample_data(300)
print(f'Target distribution: {sample_data["target"].value_counts().to_dict()}')

# Cell[12]
agent = MLEStarAgent(deterministic=True)
result = agent.run_pipeline(info, sample_data)
# result['score'] = 0.9624 (XGBoost AUC-ROC)
```

#### 4. Ablation exemple resolu (cell[27])

L'exercice `# TODO: Ameliorer le code initial` est transforme en exemple execute :

```
Score initial (toutes features) : 0.9624

Feature retiree             AUC-ROC     Delta
------------------------------------------------------------
contract_type                0.7989   -0.1635
monthly_charges              0.9083   -0.0540
tenure                       0.9248   -0.0376
total_charges                0.9542   -0.0082
age                          0.9596   -0.0027
internet_service             0.9617   -0.0007

Feature la plus importante : 'contract_type'
```

Les 3 features du signal (contract_type, monthly_charges, tenure) sont clairement identifiees par XGBoost, validant que le signal est bien transmis.

### Consequences attendues

1. **L'instrument est retabli** — Lab15 mesure maintenant un apprentissage reel (AUC-ROC 0.9624 vs ~0.50 avant).
2. **Le pipeline MLE-STAR devient demonstrable** : Understand -> SearchSOTA -> TemplateCode -> EvalScore, chaque etape produit un artefact mesurable.
3. **L'ablation est pedagogique** : l'etudiant voit que les 3 features du signal sont identifiees par XGBoost, ce qui valide la comprehension du workflow ML classique (signal engineering + ablation).

### Criteres d'acceptation touches par cette PR

- [x] Dataset avec signal predictif reel (3 conditions + 5% bruit)
- [x] Code genere reellement executable (XGBoost + sklearn template)
- [x] Score AUC-ROC mesure et affiche (0.9624)
- [x] Ablation par feature executee avec resultats
- [x] `execution_count` renseignes, outputs reels commités (Stop & Repair regle 6)
- [x] Pas d'erreur volontaire (C.1 grep clean)
- [x] Mode deterministe=True par defaut (lab pedagogique, pas d'appel LLM externe requis)
- [x] Exemple guide cell[23] rendu runnable

### Conformite regles

- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0`
- **C.2** : notebook committe AVEC outputs (execution_count != null pour toutes les 12 cellules re-executees)
- **H.3** : pre-commit hook ne refuse pas (outputs presents)
- **regle 6 Stop & Repair** : outputs injectes depuis une vraie re-execution locale, pas hand-édités
- **S.2 SOTA non-workaround** : le mode deterministe est documente comme lab pedagogique ; le mode `deterministic=False` preserve le vrai appel LLM
- **c.1331p25 ★** : nouveau grain DEEP/notebook-python (CONTENU) tient le plancher G-VAR-1

### Liens et precedents

- [Issue #13037](https://github.com/jsboige/CoursIA/issues/13037) — diagnostic d'ai-01
- [PR #13065](https://github.com/jsboige/CoursIA/pull/13065) — precedent ICT-25 (c.1331p76 ★ GPU re-exec cycle budget split)
- [PR #13064](https://github.com/jsboige/CoursIA/pull/13064) — precedent Revue Editoriale (c.1331p75)
- PR ouverte #12824 (annee citation) — n'absorbe pas ce finding, voir note dans #13037

Refs leçon : c.1331p25 ★ narrow persistant résolu · c.898 ★★★ collision guard vérifié · c.1331p32-L1 ★ (`\n` terminal par élément, appliqué via fix_lab15.py) · c.1331p40 ★ (dead-scope glob `_en` non-bloquant).

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
