### PR TITLE
fix(lane-claim,#13057): repeated --paths flags accumulate (CLI override fail-OPEN)

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -2637,7 +2637,10 @@ def main(argv: list[str] | None = None) -> int:
                         "age-filtered). The detected state is reported as "
                         "`stale_detection: \"disabled\"`.")
     p.add_argument("--paths", metavar="PATH", nargs="+", default=None,
+                   action="append",
                    help="path-mode (#9959): one or more file paths/globs. "
+                        "The flag may be repeated; every occurrence "
+                        "accumulates into the scope (#13057). "
                         "Exits 2 if any OPEN PR of a different lane (or with "
                         "an unreadable lane tag) has files[] intersecting. "
                         "Exits 0 if no collision, 1 on usage/`gh` failure. "
@@ -2666,6 +2669,17 @@ def main(argv: list[str] | None = None) -> int:
                         "blocked (#11064). Coordinator arbitration only -- "
                         "the reading side still honours [OVERRIDE] markers.")
     args = p.parse_args(argv)
+    # #13057 -- with plain nargs="+" a REPEATED --paths flag silently
+    # overrides the previous occurrences (argparse keeps only the last
+    # list), so `--paths P_in --paths P_out` scoped the check on [P_out]
+    # alone and rendered CLEAR against a claim intersecting P_in -- a
+    # fail-OPEN at the CLI surface while the verdict logic was correct.
+    # action="append" (declared above) yields a list of per-occurrence
+    # lists; flatten it back into a single flat list so every downstream
+    # consumer (path mode, bare-integer lint, --claim rendering, the
+    # issue check's my_paths) sees one accumulated scope.
+    if args.paths is not None:
+        args.paths = [entry for group in args.paths for entry in group]
     # #12751 -- default is 48 (measuring). `--no-stale`/threshold=None restores
     # the legacy behaviour (every claim blocks, nothing age-filtered); the
     # disabled state is reported honestly as `stale_detection: "disabled"`.

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -5049,3 +5049,84 @@ def test_run_check_disjoint_joker_caller_clear(capsys):
         f"disjoint joker scopes must not block each other (#10419): got rc={rc}"
     )
 
+
+
+# --- #13057: repeated --paths flags accumulate (CLI surface fail-OPEN) -------
+
+_P13057_IN = "scripts/notebook_tools/scan_md_hierarchy.py"
+_P13057_IN2 = "scripts/notebook_tools/md_hierarchy_baseline.json"
+_P13057_OUT = ".github/workflows/scan-md-hierarchy-drift.yml"
+
+
+def _payload_13057():
+    """The #12735 shape: one active path-scoped claim by another lane."""
+    return payload(
+        comment(
+            f"[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: "
+            f"{_P13057_IN}, {_P13057_IN2}",
+            "2026-08-25T04:00:23Z",
+        ),
+    )
+
+
+def _patch_13057_env(monkeypatch):
+    monkeypatch.setattr(clc, "_gh_issue_comments", lambda issue: _payload_13057())
+    monkeypatch.setattr(
+        clc, "_git_tracked_files",
+        lambda repo_root=None: [_P13057_IN, _P13057_IN2, _P13057_OUT],
+    )
+
+
+def test_main_repeated_paths_flags_accumulate(monkeypatch, capsys):
+    """The exact #13057 repro: `--paths P_dans --paths P_hors` used to
+    override (plain nargs="+" keeps only the last list), scoping the check
+    on [P_hors] alone -> CLEAR against a claim intersecting P_dans.
+    Acceptance 1: at least one intersecting path => BLOCKED, whatever the
+    number of out-of-scope paths passed alongside."""
+    _patch_13057_env(monkeypatch)
+    rc = clc.main(["12735", "--lane", "myia-ai-01:CoursIA", "--no-stale",
+                   "--paths", _P13057_IN, "--paths", _P13057_OUT])
+    assert rc == 1, (
+        f"repeated --paths must accumulate: the intersecting "
+        f"{_P13057_IN} was silently dropped pre-fix (#13057 fail-OPEN), "
+        f"got rc={rc}"
+    )
+    assert "BLOCKED" in capsys.readouterr().err
+
+
+def test_main_single_paths_in_claim_still_blocks(monkeypatch, capsys):
+    """Control from the issue: [P_dans] alone -> BLOCKED (was already
+    correct; pins the polarity against a future inversion of the fix)."""
+    _patch_13057_env(monkeypatch)
+    rc = clc.main(["12735", "--lane", "myia-ai-01:CoursIA", "--no-stale",
+                   "--paths", _P13057_IN])
+    assert rc == 1
+    assert "BLOCKED" in capsys.readouterr().err
+
+
+def test_main_repeated_paths_disjoint_still_clears(monkeypatch, capsys):
+    """Acceptance 3: real disjointness stays CLEAR -- the fix accumulates
+    scopes, it must not over-block. Both occurrences out of the claim's
+    scope."""
+    _patch_13057_env(monkeypatch)
+    rc = clc.main(["12735", "--lane", "myia-ai-01:CoursIA", "--no-stale",
+                   "--paths", _P13057_OUT, "--paths", "scripts/other.py"])
+    assert rc == 0
+    assert "CLEAR" in capsys.readouterr().out
+
+
+def test_main_repeated_paths_flat_list_reaches_check(monkeypatch):
+    """The flattened scope must reach the issue check as ONE flat list
+    (my_paths), not the nested [[a], [b]] shape action=append produces."""
+    seen = {}
+
+    def fake_run_check(payload_, my_lane, **kw):
+        seen.update(kw)
+        return 1
+
+    monkeypatch.setattr(clc, "_run_check", fake_run_check)
+    clc.main(["12735", "--lane", "x:y", "--no-stale",
+              "--paths", "a.py", "b.py", "--paths", "c.py"])
+    assert seen["my_paths"] == ["a.py", "b.py", "c.py"], (
+        f"flattened my_paths expected, got {seen['my_paths']!r}"
+    )


### PR DESCRIPTION
## Root cause — pas la polarite du filtre, l'override argparse en amont

Le verdict est **correct a tous les niveaux testes** : `_filter_by_claim_scope` (semantique any-intersect, #10419), `_scopes_intersect`, et `_run_check` direct rendent BLOCKED pour `[P_in, P_out]` contre le claim po-2024 de #12735 — verifie sur les 5 dernieres revisions du fichier (c631b3389 → 87dffc2bd), aucune ne reproduit via `_run_check`.

Le defaut est a la **surface CLI** : `--paths` etait declare `nargs="+"` **sans** `action="append"`. Un flag repete **override** silencieusement les occurrences precedentes (argparse ne garde que la derniere liste) :

```
--paths scripts/notebook_tools/scan_md_hierarchy.py            -> my_paths = [P_in]    -> BLOCKED (correct)
--paths scripts/notebook_tools/scan_md_hierarchy.py \
--paths .github/workflows/scan-md-hierarchy-drift.yml          -> my_paths = [P_out]   -> CLEAR   (FAUX)
```

La bissection de l'issue (« n'importe quel chemin hors scope exonere ») est exactement ce que produit last-wins quand le caller liste son fichier intersectant en PREMIER et les fichiers additionnels ensuite : chaque occurrence suivante ecrase la precedente. C'est la forme naturelle d'une re-verification scopee qui passe la liste complete des fichiers de la PR (`--paths f1 --paths f2 --paths f3` → seul f3 survit).

### Reproduction end-to-end (payload reel #12735, 4 commentaires pre-OVERRIDE)

Via `main()` avec `_gh_issue_comments` monkeypathe sur les vrais bodies :

| Commande | pre-fix | post-fix |
|---|---|---|
| `--paths P_in` | rc=1 BLOCKED | rc=1 BLOCKED |
| `--paths P_in --paths P_out` | **rc=0 CLEAR (FAUX)** | **rc=1 BLOCKED** |
| `--paths P_out` seul | rc=0 CLEAR | rc=0 CLEAR |

Le JSON pre-fix matche byte-pour-byte le rapport de l'issue : `active_claims` liste po-2024 avec les chemins qui recoupent, `blocking_lanes: []`, `blocked: false`.

## Fix

`action="append"` sur `--paths` + aplatissement en une liste plate immediately apres `parse_args` — chaque consommateur aval (path-mode #9959, lint #10881, rendu `--claim` #11064, `my_paths` du check d'issue) voit le scope **accumule**. Au passage, ceci repare aussi une perte silencieuse de donnees : un `[CLAIMED] -- paths` poste avec des flags repetes n'enregistrait que la derniere liste.

## Acceptance (les 4 criteres de l'issue)

1. **Au moins un chemin recoupant → BLOCKED** quelque soit le nombre de chemins hors scope : oui (CMD2 ci-dessus).
2. **Test de non-regression explicite** portant `[P_dans]` → BLOCKED **et** `[P_dans, P_hors]` → BLOCKED : `test_main_repeated_paths_flags_accumulate` + `test_main_single_paths_in_claim_still_blocks`.
3. **CLEAR preserve pour disjonction reelle** : `test_main_repeated_paths_disjoint_still_clears` (+ CMD3 ci-dessus) — le fix accumule, il ne sur-bloque pas.
4. **Jumeau verifie** : `git grep _scopes_intersect|_filter_by_claim_scope` → aucun consommateur hors `check_lane_claim.py` (tests exclus) ; audit du parser : `--paths` est la seule option `nargs="+"` exposee au hazard.

## Tests

`python -m pytest scripts/tests/test_check_lane_claim.py -q` → **244 passed** (240 preexistants + 4 nouveaux : accumulate, controle positif single, disjonction reelle, liste plate atteignant `_run_check`).

Closes #13057

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>