### PR TITLE
fix(guards,#13083): BLOCAGE coordinateur reconnu par le gate B.0 — symetrique de #11639, jamais rate par un adverbe

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -45,6 +45,14 @@ Ce qui leve un nit — et ce qui ne le leve PAS
     la borne tient pour tout autre tiers, et un override POST-merge ne peut
     pas avoir eteint une reserve avant la decision de merge.
 
+Le symetrique — #13083 : un coordinateur qui BLOQUE, direction que #11639 ne
+traitait pas. Un blocage (`[BLOCAGE] lane ...` pose en tete de ligne, ou le
+verdict `**BLOCAGE ...**` en tete de corps) ne se leve ni par l'auteur de la
+PR ni par un compte qui, sous le self-review cap, est a la fois emetteur et
+auteur : seuls l'arbitrage ecrit `[OVERRIDE] lane` ou l'emetteur reel (compte
+distinct de l'auteur PR) levent. Detection structurelle, jamais une
+sous-chaine — un adverbe intercale (« avant TOUT merge ») ne la rate pas.
+
 Ne levent RIEN :
   - **un commit pousse apres le nit** : un push muet est indiscernable d'un push
     qui repond (sur #10761, le « traitement » etait un rebase qui n'adressait
@@ -116,6 +124,14 @@ AGENT_PREFIXES = (
 # eteint une reserve avant la decision de merge (borne #10761).
 COORDINATOR_LOGINS = {"myia-ai-01", "jsboige"}
 OVERRIDE_LANE = re.compile(r"\[OVERRIDE\]\s+lane\s+\S+")
+
+# #13083 — le symetrique de #11639 : un coordinateur BLOQUE aussi, et l'organe
+# ne le modelisait pas. Même contrainte de pose stricte que le durcissement de
+# la citation (#13030) : le marqueur est POSE — ancre debut de ligne, hors
+# backticks ni liste a puces — il n'est jamais POSE par une citation en milieu
+# de phrase. La prose descriptive peut suivre sur la meme ligne. Alias anglais
+# `[BLOCK] lane` pour les reviews ecrites en anglais.
+BLOCAGE_LANE = re.compile(r"(?m)^[\s*_#]*\[(?:BLOCAGE|BLOCK)\]\s+lane\s+\S+")
 
 # Marqueurs de reserve d'un reviewer bot (le verdict est dans le body, pas l'etat).
 # #12311 — `REQUEST_CHANGES` (verbe, e.g. « [Hermes] Review — REQUEST_CHANGES »)
@@ -714,6 +730,51 @@ def has_live_marker(body: str, markers: tuple[str, ...]) -> bool:
     return False
 
 
+def _block_emitted(body: str) -> bool:
+    """Le coordinateur POSE-t-il un blocage (verdict, jamais une citation) ?
+
+    #13083 — le defaut mesure : la prose « il doit etre leve par une phrase
+    AVANT TOUT merge » ratait la sous-chaine « avant merge » a cause du mot
+    intercale — un marqueur de sous-chaine ne survit pas a un adverbe. Deux
+    formes STRUCTURELLES, aucune dependante d'un mot :
+
+      (a) le marqueur de protocole `[BLOCAGE] lane <machine:workspace>` /
+          `[BLOCK] lane ...`, pose en tete de ligne — ancre `^` re.M et rejet
+          des backticks, meme pose stricte que #13030 pour `[OVERRIDE] lane` :
+          citer le marqueur (en liste, en prose, en backticks) ne le POSE pas ;
+      (b) le verdict `**BLOCAGE ...**` en TETE du corps (60 premiers chars) —
+          la position du verdict, pas une substring de milieu. La narration
+          « pas un blocage » (fixture #11190) vit en section ; l'emission
+          aussi. Les negations immediates (« pas de blocage ») restent citees
+          via `_is_cited`.
+
+    La levée d'un blocage passe par les formes canoniques — LIFT_MARKER
+    reconnu (donc classify -> None dans la branche levee, cf `classify`) ou
+    `[OVERRIDE] lane` (arbitrage #11639 en `analyse`). Un corps qui commence
+    par BLOCAGE sans forme de levee reste un signal : sur-blocquer est le bon
+    defaut d'un gate de merge, le sous-blocage est la dechirure que #13083
+    ferme.
+    """
+    stripped = _strip_quoted(body)
+    normalised = _unaccent(stripped)
+    if BLOCAGE_LANE.search(normalised):
+        return True
+    head = normalised[:60]
+    uhead = head.upper()
+    for marker in ("BLOCAGE", "BLOCK"):
+        pos = 0
+        while (i := uhead.find(marker, pos)) != -1:
+            before = head[i - 1] if i > 0 else ""
+            after = head[i + len(marker)] if i + len(marker) < len(head) else ""
+            if before.isalnum() or before == "_" or after.isalnum() or after == "_":
+                pos = i + len(marker)
+                continue
+            if not _is_cited(normalised[max(0, i - 30):i]):
+                return True
+            pos = i + len(marker)
+    return False
+
+
 def ts(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -791,6 +852,15 @@ def classify(author: str, body: str) -> str | None:
     # (construction conditionnelle « et je merge » : voir _lift_cancelled —
     # l'annonce conditionnee n'est pas une levee, SAUF levee explicite d'auteur
     # en amont (#12074) ; le commentaire continue sinon)
+    # #13083 — un BLOCAGE coordinateur, le symetrique non traite de #11639 :
+    # l'organe modelisait un coordinateur qui LEVE (trappe [OVERRIDE] lane),
+    # pas un coordinateur qui BLOQUE. Traite a part de CONCERN_MARKERS : le
+    # blocage ne se leve PAS par les regles des nits ordinaires (cf `analyse`,
+    # lieu de la borne stricte) — le mettre dans la liste le downgraderait en
+    # reserve levable trop facilement. La detection est structurelle, pas une
+    # sous-chaine (cf `_block_emitted`).
+    if _block_emitted(body):
+        return "BLOCK"
     if has_live_marker(body, (VERDICT_POSITIVE,)):
         return None  # verdict structurel positif rendu : il decide, la prose ne compte plus
     # #11636 : la recherche porte le body nettoye de ses verdicts MENTIONNES —
@@ -861,6 +931,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     commits = [ts(c.get("committedDate")) for c in (pr_data.get("commits") or [])]
     commits = [c for c in commits if c]
     last_commit = max(commits) if commits else None
+    pr_author = (pr_data.get("author") or {}).get("login", "")
 
     # #11145 — borne d'auteur, durcie par #12836 : seule une levee de l'auteur
     # de la reserve compte. #12798 a montre pourquoi PR_AUTHOR n'est pas une
@@ -988,6 +1059,26 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
                 for (t, lifter, lift_body) in explicit_lifts
             )
             if lifted:
+                continue
+        # #13083 — les bornes strictes du blocage. Un blocage ne se leve ni
+        # par l'auteur de la PR, ni par une phrase de levee d'un compte qui est
+        # a la fois auteur de la PR et emetteur du blocage : sous le self-review
+        # cap (#12319) nit_author == pr_author == "jsboige" rendait la borne
+        # d'auteur #11145 vacue — la PR se debloquait elle-meme en repondant
+        # une phrase de levee. Seuls ouverts : l'arbitrage ECRIT `[OVERRIDE]
+        # lane` d'un coordinateur (mecanique #11639) et la re-review APPROVED
+        # de l'emetteur (etat natif), plus l'emetteur reel quand son compte est
+        # DISTINCT de l'auteur de la PR.
+        elif kind == "BLOCK":
+            if (any(
+                    when < t < cutoff
+                    and _lift_eligible(lift_author, login, lift_body)
+                    and (lift_author != pr_author
+                         or bool(OVERRIDE_LANE.search(lift_body)))
+                    for (t, lift_author, lift_body) in explicit_lifts)
+                    or any(
+                    when < t < cutoff and author == login
+                    for (t, author, _) in approved_rereviews)):
                 continue
         # #12319 : meme regime pour un nit porte par un commentaire ou une
         # review COMMENTED (dont chaque reserve Hermes, self-review cap).

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -757,6 +757,22 @@ def _block_emitted(body: str) -> bool:
     par BLOCAGE sans forme de levee reste un signal : sur-blocquer est le bon
     defaut d'un gate de merge, le sous-blocage est la dechirure que #13083
     ferme.
+
+    Reparation preflight ADJOINT (po-2025, 2026-08-26) : un override NATUREL
+    qui nomme le blocage qu'il leve (« [OVERRIDE] lane x — Blocage leve par
+    override ») etait reclasse BLOCK avant l'etage de levee — mesure : le post
+    d'arbitrage devenait lui-meme un signal BLOCK (et etait exclu
+    d'explicit_lifts par classify != None), la prose meme qui arbitrait
+    re-bloquait le gate. Deux bornes, toutes deux scopees a la forme verdict
+    en tete (b) ; le marqueur structurel (a) reste absolu — un arbitre qui
+    veut re-bloquer le pose delibereement :
+
+      A. un post d'ARBITRAGE (`[OVERRIDE]` pose en tete du corps) n'emet
+         jamais — l'override est l'etage superieur du protocole (#11639) ;
+      B. « BLOCAGE leve / levee / lifted ... » : l'occurrence immédiatement
+         suivie d'un participe de levée est le COMPLÉMENT d'une levée
+         (mention #11636), pas une émission — miroir post-fenêtre de
+         `_is_cited`.
     """
     stripped = _strip_quoted(body)
     normalised = _unaccent(stripped)
@@ -764,12 +780,23 @@ def _block_emitted(body: str) -> bool:
         return True
     head = normalised[:60]
     uhead = head.upper()
+    if head.lstrip(" \t*_").upper().startswith("[OVERRIDE]"):
+        return False
     for marker in ("BLOCAGE", "BLOCK"):
         pos = 0
         while (i := uhead.find(marker, pos)) != -1:
             before = head[i - 1] if i > 0 else ""
             after = head[i + len(marker)] if i + len(marker) < len(head) else ""
             if before.isalnum() or before == "_" or before == "[" or after.isalnum() or after == "_":
+                pos = i + len(marker)
+                continue
+            tail = head[i + len(marker):i + len(marker) + 10].lstrip(" \t:;,.)('\"-—*")
+            word = ""
+            for ch in tail:
+                if not ch.isalpha():
+                    break
+                word += ch
+            if word.lower() in ("leve", "levee", "lifted"):
                 pos = i + len(marker)
                 continue
             if not _is_cited(normalised[max(0, i - 30):i]):

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -127,11 +127,14 @@ OVERRIDE_LANE = re.compile(r"\[OVERRIDE\]\s+lane\s+\S+")
 
 # #13083 — le symetrique de #11639 : un coordinateur BLOQUE aussi, et l'organe
 # ne le modelisait pas. Même contrainte de pose stricte que le durcissement de
-# la citation (#13030) : le marqueur est POSE — ancre debut de ligne, hors
-# backticks ni liste a puces — il n'est jamais POSE par une citation en milieu
-# de phrase. La prose descriptive peut suivre sur la meme ligne. Alias anglais
-# `[BLOCK] lane` pour les reviews ecrites en anglais.
-BLOCAGE_LANE = re.compile(r"(?m)^[\s*_#]*\[(?:BLOCAGE|BLOCK)\]\s+lane\s+\S+")
+# la citation (#13030) : le marqueur est POSE — ancre debut de ligne (seule
+# indentation toleree), hors backticks, hors puces markdown (`* `, `- `), hors
+# blockquote (`>`), il n'est jamais POSE par une citation en milieu de phrase.
+# La forme verdict-gras (`**BLOCAGE ...**` en tete de corps) est couverte par
+# _block_emitted (2e branche), pas par ce pattern. La prose descriptive peut
+# suivre sur la meme ligne. Alias anglais `[BLOCK] lane` pour les reviews
+# ecrites en anglais.
+BLOCAGE_LANE = re.compile(r"(?m)^\s*\[(?:BLOCAGE|BLOCK)\]\s+lane\s+\S+")
 
 # Marqueurs de reserve d'un reviewer bot (le verdict est dans le body, pas l'etat).
 # #12311 — `REQUEST_CHANGES` (verbe, e.g. « [Hermes] Review — REQUEST_CHANGES »)
@@ -766,7 +769,7 @@ def _block_emitted(body: str) -> bool:
         while (i := uhead.find(marker, pos)) != -1:
             before = head[i - 1] if i > 0 else ""
             after = head[i + len(marker)] if i + len(marker) < len(head) else ""
-            if before.isalnum() or before == "_" or after.isalnum() or after == "_":
+            if before.isalnum() or before == "_" or before == "[" or after.isalnum() or after == "_":
                 pos = i + len(marker)
                 continue
             if not _is_cited(normalised[max(0, i - 30):i]):

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -2044,3 +2044,48 @@ def test_13083_blocage_dans_un_verdict_mention_ne_declenche_pas():
     body = ("APPROVE — le BLOCAGE leve par le commit 06956bd0a, chemin corrige. "
             "**Mergée.**")
     assert mod.classify("myia-ai-01", body) is None
+
+
+def test_13083_override_naturel_nommant_le_blocage_ne_rebloque_pas():
+    """#13083 correctif preflight ADJOINT (po-2025, 2026-08-26), borne A : un
+    override NATUREL « [OVERRIDE] lane x — Blocage leve par override » etait
+    reclasse BLOCK avant l'etage de levee — mesure pre-fix : classify='BLOCK',
+    le post d'arbitrage devenait lui-meme un signal bloquant. L'arbitrage est
+    l'etage superieur du protocole (#11639) : pose en tete, il n'emet jamais."""
+    body = ("[OVERRIDE] lane myia-ai-01:CoursIA — Blocage leve par override, "
+            "chemin corrige.")
+    assert mod._block_emitted(body) is False
+    assert mod.classify("myia-ai-01", body) is None
+
+
+def test_13083_mention_blocage_leve_en_tete_ne_pose_pas():
+    """#13083 correctif preflight ADJOINT, borne B : « Blocage leve par
+    override » SANS marqueur [OVERRIDE] — l'occurrence est le COMPLEMENT d'une
+    levee (mention #11636), pas une emission. Miroir post-fenetre de _is_cited
+    (qui ne regarde que les 30 chars AVANT l'occurrence)."""
+    assert mod.classify("myia-ai-01",
+                        "Blocage leve par override : chemin corrige.") is None
+    assert mod.classify("myia-ai-01", "Blocage levee.") is None
+    assert mod.classify("myia-ai-01",
+                        "BLOCK lifted by override, path fixed.") is None
+
+
+def test_13083_override_naturel_seul_ne_bloque_pas_la_pr():
+    """#13083 correctif preflight ADJOINT, niveau organe : sur une PR SANS
+    blocage prealable, l'override naturel d'un coordinateur (arbitrage d'un
+    nit ordinaire) ne doit pas BLOQUER la PR. Mesure pre-fix : blocked=True sur
+    le seul post d'arbitrage — le coordinateur bloquait la PR en la debloquant."""
+    override = {"author": {"login": "myia-ai-01"}, "createdAt": at(12),
+                "body": "[OVERRIDE] lane myia-ai-01:CoursIA — Blocage leve "
+                        "par override, chemin corrige."}
+    assert run([override])["blocked"] is False
+
+
+def test_13083_blocage_reel_conditionnel_a_un_override_reste_block():
+    """#13083 garde-fou du correctif preflight : un VRAI blocage dont la prose
+    nomme l'override ATTENDU (« tant que [OVERRIDE] lane n'est pas pose »)
+    reste un blocage — la borne A ne desarme que le post qui COMMENCE par
+    l'arbitrage, jamais celui qui commence par le verdict BLOCAGE."""
+    body = ("**BLOCAGE MERGE (ai-01)** — pas de merge tant que [OVERRIDE] lane "
+            "n'est pas pose par le coordinateur.")
+    assert mod.classify("myia-ai-01", body) == "BLOCK"

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -1905,3 +1905,132 @@ def test_12335_date_changerequested_reste_live():
         "L'agent n'a pas repondu depuis."
     )
     assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+# ---------------------------------------------------------------------------
+# #13083 — le BLOCAGE coordinateur, symetrique non traite de #11639. L'organe
+# modelisait un coordinateur qui LEVE (trappe [OVERRIDE] lane), pas un qui
+# BLOQUE. Mesure du 2026-08-26 : `**BLOCAGE MERGE (ai-01)**` sur #12942/#12946
+# -> classify None -> gate OK (controle de l'instrument). Le blur : « avant TOUT
+# merge » rate la sous-chaine « avant merge » — un marqueur structure ne se
+# rate pas par un adverbe. Le fix : marqueur `[BLOCAGE] lane` / `[BLOCK] lane`
+# pose en tete de ligne (forme stricte #13030) + verdict BLOCAGE/BLOCK en tete
+# de corps ; kind "BLOCK" distinct et levée strictement encadree (jamais par
+# l'auteur de la PR, jamais par un compte qui emet et est auteur de la PR —
+# self-review cap #12319 —, seulement par l'arbitrage ecrit [OVERRIDE] lane ou
+# l'emetteur reel hors self-cap, ou sa re-review APPROVED).
+# ---------------------------------------------------------------------------
+
+
+def test_13083_prose_blocage_reelle_est_vue():
+    """#13083 critere 1 (controle positif) : la prose REELLE du blocage
+    (commentaire 2026-08-26 sur #12942, non modifie) sort le gate du silence.
+    Avant le fix : classify -> None (« avant merge » rate par le « tout »
+    intercale dans « avant tout merge ») et le gate rendait OK. Apres : le
+    verdict BLOCAGE en tete du corps est un signal BLOCK a part entiere."""
+    body = ("**BLOCAGE MERGE (ai-01)** — defaut de **chemin**, pas de substance. "
+            "Le travail scientifique est bon et je ne demande rien dessus ; c'est "
+            "un `git mv` qui separe cette PR du merge. (Poste en commentaire : "
+            "GitHub refuse `--request-changes` sur une PR du compte actif — le "
+            "blocage vaut au titre de B.0, il doit etre leve par une phrase "
+            "avant tout merge.)")
+    assert mod.classify("myia-ai-01", body) == "BLOCK"
+
+
+def test_13083_marqueur_structurel_ne_se_rate_pas_par_un_adverbe():
+    """#13083 — le besoin STRUCTUREL de l'issue en toutes lettres : le marqueur
+    `[BLOCAGE] lane` ne depend d'aucune sous-chaine, donc d'aucun mot intercale.
+    Peu importe la phrase qui suit, le marqueur pose le signal."""
+    body = ("[BLOCAGE] lane myia-ai-01:CoursIA — il doit etre leve par une "
+            "phrase avant tout merge, n'importe quelle phrase.")
+    assert mod.classify("myia-ai-01", body) == "BLOCK"
+    body_en = ("[BLOCK] lane myia-ai-01:CoursIA — path defect, must be fixed "
+               "before any merge.")
+    assert mod.classify("myia-ai-01", body_en) == "BLOCK"
+
+
+def test_13083_blocage_lane_non_levable_par_l_auteur_pr():
+    """#13083 critere 2 : un `[BLOCAGE] lane` pose par un coordinateur ne se
+    leve pas par une phrase de levee de l'auteur de la PR — la borne d'auteur
+    #11145/#12836 tient mot pour mot pour un blocage (documenter un fix n'est
+    pas confirmer a la place de celui qui bloque)."""
+    blocage = {"author": {"login": "myia-ai-01"}, "createdAt": at(10),
+               "body": "[BLOCAGE] lane myia-ai-01:CoursIA — le chemin est mauvais, "
+                       "il doit etre leve par une phrase avant tout merge."}
+    author_lift = {"author": {"login": "jsboige"}, "createdAt": at(12),
+                   "body": "Les 2 points sont adresses : chemin corrige, commit abc."}
+    assert run([blocage, author_lift])["blocked"] is True
+
+
+def test_13083_blocage_lane_self_cap_non_levable_par_le_meme_compte():
+    """#13083 critere 2, cas severe : blocage POSE et PR AUTHOR sur le MEME
+    compte jsboige (self-review cap #12319). La borne d'auteur #11145 est alors
+    vacue (nit_author == pr_author == "jsboige") — sans le garde dedie, une
+    phrase de levee du compte pr leverait son PROPRE blocage. Seul l'arbitrage
+    ecrit le leve (cf test suivant)."""
+    blocage = {"author": {"login": "jsboige"}, "createdAt": at(10),
+               "body": "[BLOCAGE] lane myia-ai-01:CoursIA — chemin mauvais."}
+    self_lift = {"author": {"login": "jsboige"}, "createdAt": at(12),
+                 "body": "Les 2 points sont adresses : chemin corrige."}
+    assert run([blocage, self_lift])["blocked"] is True
+
+
+def test_13083_override_lane_leve_le_blocage():
+    """#13083 critere 3 : un `[OVERRIDE] lane` posterieur d'un coordinateur
+    leve le blocage qu'il arbitre — la mecanique #11639, coherence #13030.
+    Le blocage est pose par un worker (lane CoursIA-2), l'arbitrage par ai-01."""
+    blocage = {"author": {"login": "myia-po-2023"}, "createdAt": at(10),
+               "body": "[BLOCK] lane myia-po-2023:CoursIA-2 — l'arbre est sale, "
+                       "pas de merge tant que le drift n'est pas regle."}
+    override = {"author": {"login": "myia-ai-01"}, "createdAt": at(12),
+                "body": OVERRIDE_BODY}
+    assert run([blocage, override])["blocked"] is False
+
+
+def test_13083_emetteur_hors_self_cap_leve_son_blocage():
+    """#13083 — le pendant de l'issue (« seulement par son emetteur ») :
+    l'emetteur dont le compte est DISTINCT de l'auteur de la PR leve son propre
+    blocage par une phrase de levee — borne d'auteur standard, rien de plus."""
+    blocage = {"author": {"login": "myia-ai-01"}, "createdAt": at(10),
+               "body": "[BLOCAGE] lane myia-ai-01:CoursIA — chemin mauvais."}
+    emetter_lift = {"author": {"login": "myia-ai-01"}, "createdAt": at(12),
+                    "body": "Levee de mon blocage : chemin corrige, commit abc."}
+    assert run([blocage, emetter_lift])["blocked"] is False
+
+
+def test_13083_marqueur_cite_ne_pose_pas():
+    """#13083 garde-fou (forme #13030) : citer `[BLOCAGE] lane x` en liste ou
+    en backticks ne POSE pas le marqueur — un geste qui documente le mecanisme
+    ne bloque pas le merge (le miroir exacter du desarmement #13030, cote
+    sur-blocage cette fois)."""
+    body = ("- **(b)** `[BLOCAGE] lane myia-po-2023:CoursIA-2` serait le marqueur "
+            "(discussion de design).")
+    assert mod.classify("myia-ai-01", body) is None
+
+
+def test_13083_negation_immediate_ne_declenche_pas():
+    """#13083 garde-fou : « Pas de blocage de ma part » ne pose rien — le citer
+    « pas de » neutralise l'occurrence (meme hygiene `_is_cited` que les
+    CONCERN_MARKERS)."""
+    assert mod.classify("myia-ai-01", "Pas de blocage de ma part, LGTM.") is None
+    assert mod.classify("myia-ai-01", "No block from my side.") is None
+
+
+def test_13083_narration_pas_un_blocage_en_section_ne_declenche_pas():
+    """#13083 borne de la position : la narration « pas un blocage » vit en
+    SECTION (hors 60 premiers chars) — elle ne declare rien, et le registre du
+    nit (« a changer », en tete de corps) reste, lui, detecte (BOT-CONCERN,
+    fixture #11190 inchangee)."""
+    body = ("Une seule chose a changer — une ligne.\n\n"
+            "Contexte de la veille, paragraphe de remplissage de reserve.\n\n"
+            "## Ce qui reste — pas un blocage, c'est le grain suivant.")
+    assert mod.classify("myia-ai-01", body) == "BOT-CONCERN"
+
+
+def test_13083_blocage_dans_un_verdict_mention_ne_declenche_pas():
+    """#13083 garde-fou : un verdict positif (APPROVE) qui nomme le BLOCAGE
+    d'un autre cycle dans sa narration reste positif — la mention « leve par »
+    (pattern #11809, reference pointable) neutralise l'occurrence."""
+    body = ("APPROVE — le BLOCAGE leve par le commit 06956bd0a, chemin corrige. "
+            "**Mergée.**")
+    assert mod.classify("myia-ai-01", body) is None

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -2008,6 +2008,16 @@ def test_13083_marqueur_cite_ne_pose_pas():
     assert mod.classify("myia-ai-01", body) is None
 
 
+def test_13083_puce_etoile_ne_pose_pas():
+    """#13083 garde-fou (comment Hermes, PR #13093) : `* [BLOCAGE] lane x` en
+    liste a puces markdown ne POSE pas — l'etoile de deco n'est PAS dans
+    l'ancrage `^\\s*` (seule l'indentation est toleree). La forme verdict-gras
+    `**BLOCAGE ...**` reste couverte par la 2e branche de _block_emitted."""
+    body = ("* [BLOCAGE] lane myia-po-2023:CoursIA-2 — liste a puces, "
+            "documentation du mecanisme, pas un blocage.")
+    assert mod.classify("myia-ai-01", body) is None
+
+
 def test_13083_negation_immediate_ne_declenche_pas():
     """#13083 garde-fou : « Pas de blocage de ma part » ne pose rien — le citer
     « pas de » neutralise l'occurrence (meme hygiene `_is_cited` que les


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-python #13092

## Summary

`check_unaddressed_nits.py` — le gate B.0 — **ne reconnaissait pas un blocage ecrit par le coordinateur**. Le symetrique exact de #11639 : l'organe modelisait un coordinateur qui *leve* (trappe `[OVERRIDE] lane`), jamais un qui *bloque*. Mesure du 2026-08-26 : `**BLOCAGE MERGE (ai-01)**` sur #12942 et #12946 → `classify()` rend None, gate `rc=0` « OK » sur deux PR explicitement bloquees.

**La cause — a un mot pres.** Le commentaire disait « il doit etre leve par une phrase **avant tout merge** ». Le marqueur present dans `CONCERN_MARKERS` est `"avant merge"` — la sous-chaine ne matche pas a cause du mot intercale. Un blocage a echoue par un adverbe. Conformement a l'issue, **pas** d'ajout de `"BLOCAGE"` a `CONCERN_MARKERS` (le motif recurrent que ce fichier collectionne deja) : la detection est **structurelle**.

## Le correctif (3 changements)

1. **`[BLOCAGE] lane <machine:workspace>` / `[BLOCK] lane ...`** — marqueur symetrique de `[OVERRIDE] lane`, **pose** en tete de ligne et jamais par une citation (ancrage `^` re.M strict — seule l'indentation toleree ; puces `* `, backticks et blockquote ne posent pas). Meme forme stricte que le durcissement `[OVERRIDE]` de #13030 (PR #13035).
2. **Verdict `**BLOCAGE ...**` en tete de corps** (60 premiers chars) — la position du verdict, pas une substring de milieu. La narration « pas un blocage » (fixture #11190) vit en section et ne declare rien ; les negations immediates (« Pas de blocage ») restent neutralisees par `_is_cited`.
3. **`kind == "BLOCK"` distinct + levée strictement encadree** dans `analyse()` : un blocage ne se leve **ni par l'auteur de la PR** (borne d'auteur #11145/#12836), **ni par un compte a la fois emetteur et auteur de la PR** (self-review cap #12319 : `nit_author == pr_author == "jsboige"` rendait la borne vacue — la PR se debloquait elle-meme en repondant une phrase). Seuls ouverts : l'arbitrage ecrit `[OVERRIDE] lane` d'un coordinateur (mecanique #11639), l'emetteur reel quand son compte est distinct de l'auteur PR, ou la re-review APPROVED de l'emetteur.

## Correctif post-preflight ADJOINT (po-2025, commit `b14e68e383`)

Le preflight a mesure un defaut residuel : **un `[OVERRIDE]` naturel disant « Blocage leve par override » etait reclasse BLOCK avant l'etage de levee** — le post d'arbitrage devenait lui-meme un signal bloquant (mesure : `blocked=True` sur une PR dont le seul commentaire est l'override du coordinateur ; le coordinateur bloquait la PR en la debloquant), et `classify != None` l'excluait d'`explicit_lifts`. Deux bornes ajoutees dans `_block_emitted`, toutes deux scopees a la forme verdict en tete (le marqueur structurel `[BLOCAGE] lane` reste absolu) :

- **A.** un post d'ARBITRAGE (`[OVERRIDE]` pose en tete du corps) n'emet jamais — l'override est l'etage superieur du protocole (#11639) ;
- **B.** « BLOCAGE leve / levee / lifted ... » : l'occurrence immediatement suivie d'un participe de levee est le COMPLEMENT d'une levee (mention #11636), pas une emission — miroir post-fenetre de `_is_cited`.

Garde-fou inverse : un VRAI blocage dont la prose nomme l'override attendu (« tant que `[OVERRIDE] lane` n'est pas pose ») reste BLOCK (borne A = seulement le post qui COMMENCE par l'arbitrage).

## Critères d'acceptance de l'issue — verifies

- [x] `python scripts/check_unaddressed_nits.py 12942` → **rc=1** (verifie live AVANT et APRES le correctif post-preflight, commentaire existant non modifie). Idem #12946 → rc=1.
- [x] Un `[BLOCAGE] lane` n'est pas levable par l'auteur de la PR — `test_13083_blocage_lane_non_levable_par_l_auteur_pr` + `test_13083_blocage_lane_self_cap_non_levable_par_le_meme_compte` (le cas #12942 reel : blocage POSE et PR author sur le meme compte jsboige).
- [x] Un `[OVERRIDE] lane` posterieur le leve — `test_13083_override_lane_leve_le_blocage` + correctif preflight : `test_13083_override_naturel_nommant_le_blocage_ne_rebloque_pas`, `test_13083_mention_blocage_leve_en_tete_ne_pose_pas`, `test_13083_override_naturel_seul_ne_bloque_pas_la_pr` (niveau organe), garde-fou `test_13083_blocage_reel_conditionnel_a_un_override_reste_block`.
- [x] Corpus de non-regression : **157/157 passent** (base `main` 142 + 15 nouveaux — le compte anterieur « 176 (152+24) » du body etait FAUX, corrige). Non-regression croisee : `test_check_unaddressed_nits_mention` + `test_pick_idle_grain` = 70/70.

## Périmètre vs l'issue — contribution partielle (See, pas Closes)

L'issue #13083 a ete etendue dans ses commentaires a **4 instances** mesurees. Cette PR en traite **une** (l'instance fondatrice : blocage coordinateur invisible) + les 4 criteres d'acceptation du body. Restent ouverts sur l'issue :

- **instance 2** (asymetrie mention/emission de l'etage lift : `has_marker(body, LIFT_MARKERS)` brut vs citer-aware, PR #12896) ;
- **instance 3** (sur-accusation : locution temporelle « avant merge » dans `CONCERN_MARKERS`, PR #12627) ;
- **instance 4** (sous-accusation : reserve de gouvernance hors vocabulaire `CONCERN_MARKERS`, PR #13024).

Ces trois mecanismes touchent les etages CONCERN/LIFT generaux — un traitement separe, pour ne pas rejouer le motif « un marqueur de plus » que l'issue meme interdit. `See #13083` (l'issue reste le tracker du residuel).

## Twin parity / catalogue

Aucun notebook, aucun catalogue, aucun README touche — 2 fichiers : `scripts/check_unaddressed_nits.py` (+110 cumulés) et `scripts/tests/test_check_unaddressed_nits.py` (+184 cumulés). Byte-identique a main hors ces deux fichiers.

See #13083

🤖 Generated with [Claude Code](https://claude.com/claude-code)
