### PR TITLE
fix(ci,#12867): le roster advisory epinglait le symptome, pas le contrat (1er des 2 rouges de main)

### DIFF
--- a/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
@@ -32,6 +32,7 @@ caught before the workflow advisory is shipped.
 """
 import json
 import sys
+import warnings
 from pathlib import Path
 
 import nbformat
@@ -509,8 +510,13 @@ class TestUnreadableNotebookSkipped:
 #                  des 3 n'etait dans les +9 du fix multi-colonnes). Le 20/15
 #                  de la branche originale etait mesure sur un main
 #                  pre-#12729 (23/18) : obsolete au moment du rebase.
-CORPUS_BASELINE_TOTAL = 29
-CORPUS_BASELINE_FILES_WITH = 21
+#   c.13099 : 15 findings / 15 files, re-mesure firsthand 2026-08-26 sur
+#                 main 0ceb30e7b. Le detecteur est INCHANGE depuis le pin
+#                 de #12637 (0 commit sur detect_ascii_flowchart.py entre
+#                 2a40b3b0b et HEAD) : la baisse 29 -> 15 mesure la
+#                 conversion de 20 notebooks, pas une perte de detection.
+CORPUS_BASELINE_TOTAL = 15
+CORPUS_BASELINE_FILES_WITH = 15
 
 
 class TestCorpusBaseline:
@@ -519,8 +525,8 @@ class TestCorpusBaseline:
         scripts/notebook_tools/detect_ascii_flowchart.py MyIA.AI.Notebooks/
         --json` and assert the totals match the baseline.
 
-        Skipped by default to keep the test fast. Run with:
-            pytest -k test_corpus_baseline_pinned --runslow
+        Le plancher est un CLIQUET : il ne doit jamais remonter. Le
+        resserrer apres une tranche de conversion (mesure firsthand).
         """
         import subprocess
         repo_root = Path(__file__).resolve().parents[3]
@@ -535,12 +541,28 @@ class TestCorpusBaseline:
         if proc.returncode != 0:
             pytest.skip(f"scan returned {proc.returncode}")
         result = json.loads(proc.stdout)
-        assert result["total_findings"] == CORPUS_BASELINE_TOTAL, (
-            f"Corpus baseline drift: expected {CORPUS_BASELINE_TOTAL}, "
-            f"got {result['total_findings']}. Re-measure firsthand, then "
-            f"update CORPUS_BASELINE_TOTAL."
+        total = result["total_findings"]
+        files_with = result["files_with_findings"]
+        # Cliquet, pas egalite. Une HAUSSE est la regression que ce garde
+        # existe pour attraper : un diagramme ASCII neuf entre dans le corpus.
+        # Une BAISSE est le rollout #11962 qui fait son travail. La faire
+        # rougir a mis `main` au rouge du 2026-08-25T12:35Z au 26/08 alors que
+        # 20 notebooks avaient ete convertis : le test accusait le succes, et
+        # bloquait au passage toutes les PR derriere le `PR gate`.
+        assert total <= CORPUS_BASELINE_TOTAL, (
+            f"Regression ASCII-flowchart : {total} findings > plancher "
+            f"{CORPUS_BASELINE_TOTAL}. Un flowchart ASCII a ete introduit ou "
+            f"reintroduit -- le convertir, ne PAS relever le plancher."
         )
-        assert result["files_with_findings"] == CORPUS_BASELINE_FILES_WITH, (
-            f"Files-with-findings drift: expected {CORPUS_BASELINE_FILES_WITH}, "
-            f"got {result['files_with_findings']}."
+        assert files_with <= CORPUS_BASELINE_FILES_WITH, (
+            f"Regression ASCII-flowchart : {files_with} fichiers > plancher "
+            f"{CORPUS_BASELINE_FILES_WITH}."
         )
+        if total < CORPUS_BASELINE_TOTAL or files_with < CORPUS_BASELINE_FILES_WITH:
+            warnings.warn(
+                f"Plancher ASCII-flowchart desserre : mesure {total}/{files_with} "
+                f"sous le plancher {CORPUS_BASELINE_TOTAL}/"
+                f"{CORPUS_BASELINE_FILES_WITH}. Resserrer CORPUS_BASELINE_* a la "
+                "mesure courante pour que le cliquet garde ses dents.",
+                stacklevel=2,
+            )

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -560,9 +560,51 @@ def test_advisory_jobs_roster_only_advisory_workflows():
     roster = pr_gate.derive_advisory_jobs()
     assert "PR gate" not in roster, "the gate itself must never be advisory"
     assert "Lean CI" not in roster, "non-advisory workflow jobs must not leak"
-    assert "machine-dep-timing" in roster, (
-        "the canonical fix from the 2026-08-25 incident must hold"
+    assert roster, "an empty roster would silently disable the workflow-name path"
+    # `machine-dep-timing` is the workflow the 2026-08-25 incident was about,
+    # so it must stay covered -- but NOT under a pinned spelling. #12860
+    # (a81c5842c) gave its job an explicit `name: machine-dep-timing
+    # (advisory)`, which fixed the incident AT THE SOURCE: the marker now
+    # lives in the job name, so `is_advisory` catches it by substring and the
+    # roster is merely a second line of defence. Pinning the bare job key
+    # asserted the SYMPTOM (a nameless job recovered via the roster), so
+    # repairing the cause read as a regression and turned `main` red for 3
+    # consecutive runs (2026-08-25T12:35Z, 2026-08-26T00:26Z, 05:02Z).
+    # Assert coverage; let the spelling drift.
+    assert any(j.startswith("machine-dep-timing") for j in roster), (
+        "the workflow behind the 2026-08-25 incident must stay covered"
     )
+
+
+ADVISORY_WORKFLOW_FIXTURE = "name: synthetic (advisory)\non:\n  pull_request:\njobs:\n  nameless-job:\n    runs-on: ubuntu-latest\n    steps:\n      - run: 'true'\n"
+
+BLOCKING_WORKFLOW_FIXTURE = "name: synthetic blocking\non:\n  pull_request:\njobs:\n  nameless-job-blocking:\n    runs-on: ubuntu-latest\n    steps:\n      - run: 'true'\n"
+
+
+def test_advisory_jobs_roster_recovers_a_nameless_job(tmp_path):
+    """The contract the 2026-08-25 incident actually exposed: a job whose
+    WORKFLOW name carries the marker but whose JOB name does not must still
+    be routed as advisory. Held on a synthetic fixture rather than on a live
+    workflow, so that repairing a real workflow's job name -- which is the
+    better fix, and what #12860 did -- can never read as a regression again.
+    """
+    (tmp_path / "synthetic-advisory.yml").write_text(
+        ADVISORY_WORKFLOW_FIXTURE, encoding="utf-8"
+    )
+    (tmp_path / "synthetic-blocking.yml").write_text(
+        BLOCKING_WORKFLOW_FIXTURE, encoding="utf-8"
+    )
+    roster = pr_gate.derive_advisory_jobs(workflows_dir=str(tmp_path))
+    assert "nameless-job" in roster, (
+        "a job with no `name:` must be recovered by its key"
+    )
+    assert "nameless-job-blocking" not in roster, (
+        "a non-advisory workflow must not leak its jobs into the roster"
+    )
+    # And the routing the roster exists to enable:
+    checks = [run("nameless-job", "failure")]
+    _pending, bad, _ok, advisory = pr_gate.classify(checks, "PR gate", roster)
+    assert bad == [] and len(advisory) == 1
 
 
 def test_advisory_jobs_roster_handles_missing_directory(tmp_path):


### PR DESCRIPTION
Grain: MED/test — lane myia-ai-01:CoursIA — prev: MED/guard #12799

## Pourquoi cette PR existe

`Scripts Tests (CPU)` est **rouge sur `main`** depuis trois runs consecutifs
(`2026-08-25T12:35Z`, `2026-08-26T00:26Z`, `2026-08-26T05:02Z`, entrecoupes de deux
`cancelled`). Un rouge sur `main` n'appartient a aucune lane, donc il est au
coordinateur (skill `/coordinate` Phase 3, « le rouge sans lane est a MOI »).

Il bloque **au moins** #12757, #12799 et #12807, qui n'y sont pour rien : leur seul
rouge non-advisory est ce test-la.

## La cause — un test qui epinglait le symptome, pas le contrat

`test_advisory_jobs_roster_only_advisory_workflows` assertait :

```python
assert "machine-dep-timing" in pr_gate.derive_advisory_jobs()
```

Le commit `a81c5842c` (#12860, 25/08) a donne a ce job un `name:` explicite :

```yaml
+        name: machine-dep-timing (advisory)
```

C'est **la bonne correction** de l'incident du 25/08, et elle le corrige **a la
source** : le marqueur vit desormais dans le nom du job, donc `is_advisory`
l'attrape par sous-chaine et le roster n'est plus qu'une deuxieme ligne de
defense. Mesure firsthand :

```
$ python -c "import sys; sys.path.insert(0,'scripts'); import pr_gate;
             print([x for x in sorted(pr_gate.derive_advisory_jobs()) if 'machine-dep' in x])"
['machine-dep-timing (advisory)']
```

Le roster rend la graphie **rendue**, plus la cle nue. L'assertion pinnait donc le
**symptome** de l'incident (un job sans `name:` recupere via le roster) : reparer
la cause s'est lu comme une regression, et a rougi `main`.

## Ce que fait la PR

1. **L'assertion vivante devient insensible a l'orthographe** —
   `any(j.startswith("machine-dep-timing") for j in roster)` : elle verifie la
   **couverture** du workflow concerne, plus sa graphie. Plus `assert roster`,
   parce qu'un roster vide desactiverait silencieusement le chemin workflow-name.
2. **Le contrat que l'assertion portait ne disparait pas avec elle.** Ce contrat --
   *un job dont le WORKFLOW porte le marqueur mais dont le JOB name ne le porte pas
   doit quand meme etre route en advisory* -- passe sur une fixture **synthetique**
   (`test_advisory_jobs_roster_recovers_a_nameless_job`), donc insensible au drift,
   avec son **controle negatif** (un workflow non-advisory ne doit pas fuiter ses
   jobs dans le roster) et l'assertion de routage que le roster existe pour rendre
   possible.

Affaiblir un test pour le rendre vert serait le red-flag exact d'`anti-regression.md`.
Ici la garantie est **conservee et rendue non-derivable** ; c'est l'orthographe qui
est relachee, pas la propriete.

## Preuve

**Controle positif, a l'ordre de grandeur attendu.** Regression injectee dans
`derive_advisory_jobs` (le roster ne retient que les jobs dont le NOM porte deja le
marqueur -- exactement le trou expose le 25/08) :

```
FAILED scripts/tests/test_pr_gate.py::test_advisory_jobs_roster_recovers_a_nameless_job
E   AssertionError: a job with no `name:` must be recovered by its key
E   assert 'nameless-job' in frozenset()
======================== 1 failed, 56 passed =========================
```

**Exactement un** echec, et c'est le nouveau test synthetique. Regression retiree :

```
============================= 57 passed in 4.47s =============================
```

## Ce que cette PR ne fait PAS

Elle **ne rend pas `main` vert a elle seule.** `Scripts Tests (CPU)` porte un
**second** rouge, independant :
`test_twin_registry_integrity.py::test_audit_shas_exist_in_file_history`. Diagnostic
etabli firsthand et suivi separement (issue liee) : le sha atteste
`e032816cc665...` pour `Search-11 Metaheuristics` vit dans `d82b575ab`, sur
`origin/feature/search-11-metaheuristic-baselines`, qui **n'est pas ancetre de
`main`** -- la branche a ete squash-mergee (#12551, `7574e98a0`) et le squash a
produit un autre blob. Le dire ici plutot que de laisser croire au vert complet.

See #12867


---

## Defaut 3 (ajoute c.13099) — le meme defaut de forme, sur un autre test

En reparant le defaut 1, j'ai decouvert que `Scripts Tests (CPU)` de `main` portait **trois** echecs, pas deux. Le troisieme est de la **meme classe** que celui qui donne son titre a cette PR : un test qui epingle un **symptome** (une valeur vivante) au lieu du **contrat**, si bien que reparer la cause se lit comme une regression.

`test_corpus_baseline_pinned` epinglait une **egalite** `total_findings == 29` sur un compte que chaque tranche du rollout ASCII-flowchart (#11962) fait **baisser**. Mesure firsthand a HEAD : **15/15**. Le test rougissait donc sur le rollout qui fait exactement son travail.

### La baisse est-elle une conversion, ou une perte de detection ?

C'est la seule question qui compte : un compteur qui tombe peut signifier « 14 flowcharts convertis » **ou** « le detecteur a cesse de voir ». Mesure, pas supposition :

```
$ git log --oneline 2a40b3b0b..HEAD -- scripts/notebook_tools/detect_ascii_flowchart.py | wc -l
0
```

**Zero commit** : le detecteur est byte-identique depuis le pin. Le code est le meme, seul le corpus a bouge. Deux corroborations : le pin lui-meme etait deja un decrement (`32/24 -> 29/21`, #12637), et 20 notebooks ont ete modifies depuis. La baisse mesure la conversion.

### Fix : cliquet, pas egalite

- Une **HAUSSE** reste la regression que ce garde existe pour attraper (un flowchart ASCII neuf entre dans le corpus) → `assert <=`.
- Une **BAISSE** passe, et emet un `warnings.warn` invitant a resserrer le plancher — visible sans mettre `main` au rouge.
- Plancher re-pique a la mesure firsthand **15/15**.

### Controle positif — dans les deux sens

Un cliquet qui ne rougit plus est pire qu'une egalite : il certifie sans tester. Les deux polarites :

```
(1) au plancher reel               -> 1 passed, 2 warnings in 16.88s
(2) plancher abaisse a 14 (hausse) -> 1 failed
    E   AssertionError: Regression ASCII-flowchart : 15 findings > plancher 14.
        Un flowchart ASCII a ete introduit ou reintroduit -- le convertir,
        ne PAS relever le plancher.
```

Fichiers affectes, suite complete : `test_detect_ascii_flowchart.py` + `test_pr_gate.py` → **78 passed**.

## Cascade de merge — pourquoi aucune des trois PR ne peut verdir seule

| # | Test en echec sur `main` | Repare par |
|---|---|---|
| 1 | `test_advisory_jobs_roster_only_advisory_workflows` | **cette PR** |
| 2 | `test_audit_shas_exist_in_file_history` | #13102 (po-2026), **mergee** `2f9798634` |
| 3 | `test_corpus_baseline_pinned` | **cette PR** |

Chaque branche restait rouge des defauts des autres — verifie firsthand : run `32963021873` de cette branche ne listait QUE les defauts 2 et 3 (le roster passait), run `32965072607` de #13102 ne listait QUE 1 et 3 (le registre passait). Le deadlock s'est casse en fusionnant #13102 sous override ecrit, puis en recalculant la base de celle-ci par `update-branch` (jamais `rerun`, qui rejouerait la base gelee).

See #11962
