### PR TITLE
fix(tooling,#13100): veto no-op content-only refusait le rebaseline d'un orphelin par squash

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -896,6 +896,30 @@ def _shas_match(record: dict, new_entry: dict) -> bool:
     return str(rec_py) == str(new_py) and str(rec_cs) == str(new_cs)
 
 
+def _attestation_identical(record: dict, new_entry: dict) -> bool:
+    """True ssi une nouvelle entree serait STRICTEMENT identique a `record`.
+
+    Difference avec `_shas_match` (no-op, content-only) : on exige EN PLUS que
+    les git blob SHAs soient egaux. C'est la discrimination du cas orphelin par
+    squash (#11919 / #13100) : `update_pair` a deja tranche is_noop=False quand
+    le recorded blob n'est pas ancre de HEAD, puis recalcule une entree dont le
+    content_sha est PRESERVE (le squash a re-hashe le blob sans toucher au
+    contenu). Si la couche d'ecriture re-verifiait un `_shas_match` content-only,
+    elle REFUSERait cet ecrit legitime et `surgical_rebaseline` renvoyait
+    touched=0 -> message trompeur « aucun bloc d'audit reconnu » sur un bloc
+    2/4/6 parfaitement canonique. Seule une attestation identique au sens strict
+    (content ET blobs) est un faux audit a rejeter sans --force.
+    """
+    if not _shas_match(record, new_entry):
+        return False
+    for key in ("python_sha", "csharp_sha"):
+        rec_val = record.get(key)
+        new_val = new_entry.get(key)
+        if rec_val is not None and new_val is not None and rec_val != new_val:
+            return False
+    return True
+
+
 def _legacy_body_as_list_item(body_lines):
     """Convertit un body legacy (mapping plat indent 4) en 1er item de `audits:`.
 
@@ -970,7 +994,7 @@ def _transform_audit_block(form: str, block: list[str], new_entry: dict, force: 
     body = block[1:]
     if form == "audits":
         latest = _parse_latest_audit_entry(body)
-        if _shas_match(latest, new_entry) and not force:
+        if _attestation_identical(latest, new_entry) and not force:
             return block, False
         # force=True OU SHAs differents : APPEND une nouvelle entree
         # (avec --force c'est le faux audit designe par ai-01 -- averti sur stderr).

--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -34,7 +34,8 @@ yaml = pytest.importorskip("yaml")
 # la logique d'agregation du repertoire file-per-entry).
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from check_twin_parity import (
-    load_registry, _slug, _latest_audit, verify_recorded_sha, update_pair,
+    load_registry, _slug, _latest_audit, _content_sha, verify_recorded_sha,
+    update_pair, surgical_rebaseline,
 )  # noqa: E402
 
 REGISTRY_DIR = Path(__file__).resolve().parents[1] / "twin_pairs.d"
@@ -431,6 +432,26 @@ def _classify_attested_sha(
     return "renamed", f"sha apparu sous ancien(s) path(s) (renommage ?) : {sorted(others)}"
 
 
+def _content_matches_head(repo_root, latest: dict, sha_key: str, rel: str) -> bool:
+    """Reconciliation ``orphelin par squash`` (#13100) cote test.
+
+    Vrai si le `content_*_sha` enregistre dans le dernier audit est present ET
+    egal au content hash calcule a HEAD par `_content_sha` (qui exclut
+    ``nb["metadata"]``, papermill compris -- les normalisations sanctionnees).
+    Un sha (git blob) atteste sur une branche puis orpheline par squash-merge
+    n'est PAS une fabrication quand le contenu qu'il attestait est porteur de ce
+    que main porte aujourd'hui : le hash de contenu le prouve.
+    """
+    ckey = "content_" + sha_key
+    rec = latest.get(ckey)
+    if not isinstance(rec, str) or len(rec) != 64:
+        return False
+    try:
+        return _content_sha(repo_root, rel) == rec
+    except Exception:
+        return False
+
+
 def test_audit_shas_exist_in_file_history():
     """Ferme la faille #9399 (4e manifestation) : le sha du DERNIER audit d'une
     paire doit etre un blob que le carnet a REELLEMENT eu dans son historique git
@@ -473,7 +494,7 @@ def test_audit_shas_exist_in_file_history():
 
     path_blobs, blob_paths = _build_blob_history(repo_root)
     declared = _declared_paths()
-    fabricated, crossfile, renamed = [], [], []
+    fabricated, crossfile, renamed, orphaned = [], [], [], []
     for entry in _entries():
         latest = _latest_audit(entry)
         if not isinstance(latest, dict):
@@ -489,7 +510,21 @@ def test_audit_shas_exist_in_file_history():
             )
             label = f"{entry.get('name', '?')}.{sha_key} = {sha[:12]} ({detail})"
             if verdict == "fabricated":
-                fabricated.append(label)
+                # Reconciliation orphelin par squash (#13100) : un squash-merge
+                # re-hashe le blob sans toucher au contenu pedagogique. Le sha
+                # atteste etait le vrai blob du carnet sur la branche, mais
+                # l'historique de HEAD ne le contient plus -> faux « fabrique ».
+                # Un `content_*_sha` enregistre egal au content hash calcule a
+                # HEAD prouve que l'attestation correspond a un contenu
+                # reellement porte par main (modulo normalisations sanctionnees
+                # -- `_content_sha` exclut `nb["metadata"]`, papermill compris).
+                # Ce n'est PAS une fabrication : on signale (orpheline), on ne
+                # faille pas. Le vrai defaut (fabrication/typo/cross-file) n'a
+                # AUCUN content_sha concordant -> rougit toujours.
+                if _content_matches_head(repo_root, latest, sha_key, relf):
+                    orphaned.append(label)
+                else:
+                    fabricated.append(label)
             elif verdict == "crossfile":
                 crossfile.append(label)
             elif verdict == "renamed":
@@ -507,6 +542,16 @@ def test_audit_shas_exist_in_file_history():
         import warnings
         warnings.warn(
             "sha attestes sous un ancien path (carnet renomme ?) : " + "; ".join(renamed)
+        )
+    # ``orphaned`` est legitime (squash-merge a contenu preserve) -> warning,
+    # pas de FAIL : le `--update` de la prochaine PR re-rebaseline le blob. Ne
+    # pas le remonter en ''fabricated'' : ce serait rougir `main` pour une
+    # attestation veridique.
+    if orphaned:
+        import warnings
+        warnings.warn(
+            "blob(s) orphelins par squash mais contenu atteste identique a HEAD "
+            "(un --update re-baseline le git blob SHA) : " + "; ".join(orphaned)
         )
 
 
@@ -988,4 +1033,95 @@ def test_build_blob_history_sees_merge_introduced_blob(tmp_path):
         f"atteste dont la 1re apparition est une resolution de merge est classe "
         f"``fabricated`` a tort par ``test_audit_shas_exist_in_file_history``."
     )
+
+
+# --- #13100 : le rebaseline d'un orphelin par squash ne doit pas etre veto --
+#
+# Criteres 1+2 de #13100 : un bloc d'audit en indentation CANONIQUE 2/4/6 dont
+# le git blob SHA a change (squash-merge) mais dont le content_sha est preserve
+# doit se rebaseliner via `surgical_rebaseline`. `update_pair` a deja tranche
+# is_noop=False (discrimination reachability #11919 : le recorded blob n'est pas
+# ancetre de HEAD) ; la couche d'ecriture ne doit pas RE-veto un _shas_match
+# content-only qui produisait le message trompeur « aucun bloc d'audit
+# reconnu ». Controle positif : ce test est ROUGE avant le fix (#13100 : la
+# cause exacte du refus), VERT apres.
+
+
+def test_surgical_rebaseline_orphan_blob_content_same_appends():
+    """Regression #13100 : entree 2/4/6 canonique, blob deplace (squash),
+    contenu preserve -> APPEND d'une nouvelle entree, touches=1.
+
+    Avant le fix, `_transform_audit_block` vetait via `_shas_match` (content
+    egal -> « rien ne change ») et `surgical_rebaseline` renvoyait touched=0,
+    lis par le caller comme « aucun bloc d'audit reconnu » alors que le header
+    2/4/6 est parfaitement reconnu.
+    """
+    raw = (
+        "- name: \"Search-11 Orphan\"\n"
+        "  family: Search\n"
+        "  python: X.ipynb\n"
+        "  csharp: Y.ipynb\n"
+        "  parity_level: native-both\n"
+        "  audits:\n"
+        "    - date: \"2026-08-24\"\n"
+        "      by: previous-auditor\n"
+        "      python_sha: e032816cc66591c490c447b6bf2bc440e428ce37\n"
+        "      csharp_sha: 8a882e759991dc7a0af2c82376334eaeaa884a74\n"
+        "      content_python_sha: f3921b23c094a8d16d6f990a4fb6bbae2d0375c5afd774b2626b344cda74acb2\n"
+        "      content_csharp_sha: 098a90cd675c7f17f5b3c5debca7305463f1abd7d4788b1ab3a34fa91ad15df4\n"
+    )
+    # Rebaseline sur la paire : le git blob SHA a bouge (squash) MAIS le
+    # content_sha est PRESERVE -- signature exacte de l'orphelin Search-11.
+    new_entry = {
+        "date": "2026-08-26",
+        "by": "myia-po-2026:CoursIA",
+        "python_sha": "3e30af4a17a0c88489539174e669b52619139133",
+        "csharp_sha": "8a882e759991dc7a0af2c82376334eaeaa884a74",
+        "content_python_sha": "f3921b23c094a8d16d6f990a4fb6bbae2d0375c5afd774b2626b344cda74acb2",
+        "content_csharp_sha": "098a90cd675c7f17f5b3c5debca7305463f1abd7d4788b1ab3a34fa91ad15df4",
+    }
+    new_raw, touched = surgical_rebaseline(raw, {"Search-11 Orphan": new_entry})
+    assert touched == 1, (
+        "le rebaseline d'un orphelin par squash (blob deplace, contenu preserve) "
+        "doit APPEND une nouvelle entree -- le bloc d'audit 2/4/6 est reconnu, "
+        "mais le veto content-only de la couche d'ecriture le refusait "
+        "(« aucun bloc d'audit reconnu » trompeur, #13100)."
+    )
+    assert "3e30af4a17a0c88489539174e669b52619139133" in new_raw, (
+        "le nouveau python_sha (blob HEAD) doit apparaitre dans la nouvelle entree"
+    )
+    assert raw.count("    - date:") == 1, "fixture : une seule entree au depart"
+    assert new_raw.count("    - date:") == 2, (
+        "un rebaseline reel APPEND une entree, il ne remplace pas l'historique"
+    )
+
+
+def test_surgical_rebaseline_truly_identical_still_noop():
+    """Garde anti-regression : une attestation STRICTEMENT identique (content
+    ET git blobs egaux) doit RESTER un no-op byte-identical (#9399 critere 2)."""
+    raw = (
+        "- name: \"Search-11 Noop\"\n"
+        "  family: Search\n"
+        "  python: X.ipynb\n"
+        "  csharp: Y.ipynb\n"
+        "  parity_level: native-both\n"
+        "  audits:\n"
+        "    - date: \"2026-08-24\"\n"
+        "      by: previous-auditor\n"
+        "      python_sha: 3e30af4a17a0c88489539174e669b52619139133\n"
+        "      csharp_sha: 8a882e759991dc7a0af2c82376334eaeaa884a74\n"
+        "      content_python_sha: f3921b23c094a8d16d6f990a4fb6bbae2d0375c5afd774b2626b344cda74acb2\n"
+        "      content_csharp_sha: 098a90cd675c7f17f5b3c5debca7305463f1abd7d4788b1ab3a34fa91ad15df4\n"
+    )
+    same = {
+        "date": "2026-08-26",
+        "by": "myia-po-2026:CoursIA",
+        "python_sha": "3e30af4a17a0c88489539174e669b52619139133",
+        "csharp_sha": "8a882e759991dc7a0af2c82376334eaeaa884a74",
+        "content_python_sha": "f3921b23c094a8d16d6f990a4fb6bbae2d0375c5afd774b2626b344cda74acb2",
+        "content_csharp_sha": "098a90cd675c7f17f5b3c5debca7305463f1abd7d4788b1ab3a34fa91ad15df4",
+    }
+    out, touched = surgical_rebaseline(raw, {"Search-11 Noop": same})
+    assert touched == 0
+    assert out == raw, "une attestation identique doit rester byte-identical (faux audit)"
 

--- a/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
@@ -61,6 +61,12 @@
       csharp_sha: 8a882e759991dc7a0af2c82376334eaeaa884a74
       content_python_sha: f3921b23c094a8d16d6f990a4fb6bbae2d0375c5afd774b2626b344cda74acb2
       content_csharp_sha: 098a90cd675c7f17f5b3c5debca7305463f1abd7d4788b1ab3a34fa91ad15df4
+    - date: "2026-08-26"
+      by: myia-po-2026:CoursIA-2
+      python_sha: 3e30af4a17a0c88489539174e669b52619139133
+      csharp_sha: 8a882e759991dc7a0af2c82376334eaeaa884a74
+      content_python_sha: f3921b23c094a8d16d6f990a4fb6bbae2d0375c5afd774b2626b344cda74acb2
+      content_csharp_sha: 098a90cd675c7f17f5b3c5debca7305463f1abd7d4788b1ab3a34fa91ad15df4
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: |
     Python = MEALPy (librairie metaheuristique 40+ algos, MIT) -- vrai SOTA ecosysteme Python. C# = GeneticSharp (librairie .NET GA/evolutionnaire reference, LGPL) post Tranche 2 -- vrai SOTA ecosysteme .NET. Les DEUX cotes branchent une librairie native de leur ecosysteme (mealpy + geneticsharp). Tranche 1 C# from-scratch (PSO/SA/GA) preservee + Tranche 2 ajoute GeneticSharp sur 4 fonctions benchmark -- lib-vs-lib cote-a-cote avec from-scratch. Asymetrie de couverture (ABC + BRO cote Python, GA + TSP cote C#) asumee native-both parity_level. Verdict SOTA-OK.


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA-2

## Objectif

Closes #13100 — réparer le 2e rouge de `main` (`Scripts Tests (CPU` rouge depuis 2026-08-25T12:35Z) : `test_audit_shas_exist_in_file_history` échoue sur `Search-11 Metaheuristics.python_sha = e032816cc665 (jamais blob d'aucun fichier)`, et la voie de guérison honnête (`--update`) refuse d'appliquer le rebaseline.

## Cause exacte du refus (Défaut 2, NOMMÉE — pas contournée)

Le refus **n'est pas** un problème d'indentation : le bloc 2/4/6 de `search-11-metaheuristics.yaml` est parfaitement reconnu par le scanner (`m_hdr` matche, la coupure relative s'arrête proprement avant `bridge_verdict:`). La cause est un **veto incohérent entre deux couches du même outil** :

1. `update_pair` calcule `is_noop=False` avec la discrimination reachability (#11919) : le recorded blob `e032816c` n'est pas ancêtre de HEAD (orphelin par le squash de #12551) → rebaseline légitime à écrire. L'audit produit porte le blob HEAD `3e30af4a` et un `content_python_sha` **préservé** (`f3921b23` — le squash a re-hashé le blob sans toucher au contenu pédagogique).
2. `_transform_audit_block` re-vérifie ensuite un `_shas_match` **content-only** → `True` (contenu identique) → retourne `did=False` → `surgical_rebaseline` renvoie `touched=0` → le caller l'interprète comme « aucun bloc d'audit reconnu (indentation non reconnue) ».

**Fix** : nouveau `_attestation_identical` (content_sha **ET** git blob SHAs égaux) remplace `_shas_match` dans le veto de la branche append-only. Seule une attestation STRICTEMENT identique reste un faux audit rejeté sans `--force` ; l'orphelin par squash (blob déplacé, contenu préservé) est écrit. La branche legacy `last_audit:` (fallback blob par absence de content_sha) était déjà cohérente et est inchangée.

## Défaut 3 — tranché explicitement (criterion 4)

**Décision : le test TOLÈRE un blob orphelin dont le `content_*_sha` correspond à main modulo normalisations sanctionnées** — en `warnings.warn`, pas en FAIL. Justification :

- Le rôle de `test_audit_shas_exist_in_file_history` (#9399, 4e manifestation) est de rougir les sha **fabriqués** (typo / cross-file / invention) qui « ne correspondent JAMAIS au carnet ». Un orphelin par squash n'en est pas un : il fut le vrai blob du carnet sur la branche, et le contenu qu'il attestait est porté par main aujourd'hui (`_content_sha` exclut `nb["metadata"]` — les normalisations papermill sanctionnées sont donc hors hash, preuve firsthand : `f3921b23` enregistré sur branche == `f3921b23` calculé à HEAD).
- Le vrai défaut reste rouge : une fabrication/typo/cross-file n'a **aucun** `content_*_sha` concordant — la réconciliation ne peut pas l'absorber.
- Sans cette décision, la classe se représente à chaque paire auditée en branche puis squash-mergée, rougissant `main` pour une attestation véridique pendant tout l'intervalle avant rebaseline.

## Contenu livré

- `check_twin_parity.py` : `_attestation_identical` + veto de la couche d'écriture corrigé (branche append-only).
- `test_twin_registry_integrity.py` :
  - `test_surgical_rebaseline_orphan_blob_content_same_appends` (criterion 2, entrée indentation 2/4/6, blob déplacé + contenu préservé → APPEND) ;
  - `test_surgical_rebaseline_truly_identical_still_noop` (garde anti-regression : attestation strictement identique → byte-identical, design-gate #9399 critère 2 préservé) ;
  - réconciliation orphelin dans `test_audit_shas_exist_in_file_history` (`_content_matches_head`) avec warning visible.
- `twin_pairs.d/search-11-metaheuristics.yaml` : **rebaseline healing via l'outil réparé** (criterion 1) — audit 2026-08-26 `myia-po-2026:CoursIA-2`, `python_sha: 3e30af4a...` (blob HEAD), `content_python_sha: f3921b23...` préservé, historique 08-01→08-24 intact (append-only). Aucun sha édité à la main.

## Contrôle positif obligatoire (criterion 2) — test ROUGE avant le fix

```
$ git stash push -- scripts/notebook_tools/check_twin_parity.py   # code d'origine restauré
$ python -m pytest scripts/notebook_tools/tests/test_twin_registry_integrity.py::test_surgical_rebaseline_orphan_blob_content_same_appends -q
FAILED ... test_surgical_rebaseline_orphan_blob_content_same_appends
E   AssertionError: le rebaseline d'un orphelin par squash (blob deplace, contenu preserve)
    doit APPEND une nouvelle entree -- le bloc d'audit 2/4/6 est reconnu, mais le veto
    content-only de la couche d'ecriture le refusait (« aucun bloc d'audit reconnu » trompeur).
E   assert 0 == 1
=== 1 failed in 0.20s ===   # puis git stash pop -> fix restauré -> VERT
```

## Validation (criterion 3 + gates)

- `python -m pytest scripts/notebook_tools/tests/test_twin_registry_integrity.py -q` → **32 passed** (dont le test historique, qui passe par le chemin « ok » après healing ; le warning orphelin a disparu).
- Famille complète `test_check_twin_parity*.py` → **84 passed** (surgical #10430 indent-4, squash-orphan #11919, update-guard, ci-sha, content-sha, bridge-verdict : aucun comportement gardé ne régresse).
- Consommateurs adjacents `test_cron_helpers.py` + `test_check_pr_perimeter.py` → **130 passed**.
- `check_twin_parity.py --check --json` → **157 OK / 0 drift / 0 missing**.
- `check_twin_parity.py --verify-recorded-sha --check --json` → **exit 0, 157 OK / 0 MISMATCH** (Search-11 cohérent recorded vs HEAD après healing).
- Réexécution de la commande refusée avant fix, désormais appliquée :
  `check_twin_parity.py --update --pair "Search-11 Metaheuristics" --by "myia-po-2026:CoursIA-2"` → **`Registre rebaseline : 1 paire(s) mise(s) à jour`** (avant : `AVERTISSEMENT ... rebaseline IGNORE`).

## Note

DM `msg-20260826T112406-n2hy77` cité par le dispatch ai-01 : introuvable dans inbox/sent/archive (scopes CoursIA + CoursIA-2) — signalé sur le dashboard ; travail mené depuis le body #13100 + le post dashboard (qui porte l'essentiel : parité 2-lignes metadata vérifiée, normalisation basename autorisée). Un seul push (consigne famine CI #13097), pas de rebase en boucle ; `Scripts Tests (CPU)` mettra du temps à verdigrir et ce n'est pas la faute de cette PR.
