### PR TITLE
docs(plateformes,#9890): comparatif emojis->verdicts texte + breadcrumb niveau categorie

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/comparatif-owui-vs-ai-engine.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/comparatif-owui-vs-ai-engine.md
@@ -1,6 +1,6 @@
 # Comparatif OWUI vs AI-Engine — tableau structuré
 
-[← README AI-Engine-WordPress](AI-Engine-WordPress/README.md)
+[← README Plateformes conversationnelles](README.md)
 
 > Ce comparatif **ne cherche pas à classer** un produit au-dessus de
 > l'autre : OWUI et AI-Engine ciblent des usages différents et
@@ -46,26 +46,26 @@ version 3.7.0), de son code source GPL (distribué via le dépôt SVN
 
 | Fonctionnalité | Open WebUI | AI-Engine |
 |----------------|------------|-----------|
-| **Chat LLM multi-provider** | ✅ Cœur du produit | ✅ Cœur du produit |
+| **Chat LLM multi-provider** | Oui — Cœur du produit | Oui — Cœur du produit |
 | **Providers supportés** | OpenAI, Anthropic, Google, Mistral, Ollama (natif), OpenRouter, et tout endpoint OpenAI-compatible (Azure, Groq, xAI, etc.) | OpenAI, Anthropic, Google, Mistral, **xAI (Grok)**, Perplexity, OpenRouter, Replicate, Azure + Custom OpenAI-compatible (Ollama, LM Studio, vLLM, llama.cpp, LocalAI) |
-| **Streaming** | ✅ natif (SSE) | ✅ natif (Server-Sent Events) |
-| **Mémoire de conversation** | ✅ par utilisateur, multi-turn, dossiers d'équipe (v0.10+) | ✅ par chatbot, discussion history |
-| **Personas / System prompts** | ✅ avancés (modèles communautaires, custom) | ✅ par chatbot (customizable themes, system instructions/prompts) |
-| **Multi-utilisateur / RBAC** | ✅ Cœur du produit (groups, permissions, channels) | Limité (rôles WP natifs : admin, editor, author, subscriber) |
-| **Multi-tenant** | ✅ natif (groups + canaux) | ❌ pas nativement ; Pro tier ajoute « cross-site chatbots » |
-| **Canaux collaboratifs** | ✅ (channels multi-user, partage de conversations) | ❌ pas de canaux ; Workspace = chat individuel wp-admin |
-| **Copilot pour éditeur** | ❌ hors scope (pas de CMS intégré) | ✅ éditeur WordPress (grammaire, enhancement, traduction, rewriting, génération d'images) |
-| **AI Forms** | ❌ hors scope | ✅ text/image/audio/file inputs, conditional logic, multi-step workflows, CSV/JSON export |
-| **Application mobile** | ❌ (web responsive) | ✅ iOS app gratuite (Workspace en mobilité) |
-| **Vision (analyse d'images)** | ✅ upload + vision models | ✅ intégré |
-| **Génération d'images** | ✅ via tools / API externe | ✅ natif (multi-provider image gen) |
-| **Voix (TTS/STT)** | ✅ natif (multi-provider, realtime audio) | ⚠️ Pro tier uniquement (realtime audio) |
-| **Web search intégré** | ✅ via tools / web search natif | ✅ intégré |
-| **Outils MCP (consommation)** | ✅ natif (Tools section, MCP-compatible) | ✅ connectable à des serveurs MCP externes |
-| **Serveur MCP (exposition)** | ❌ (Open WebUI n'expose pas, il consomme) | ✅ **spécificité AI-Engine** — WordPress devient serveur MCP pour agents externes |
-| **Cross-site embedding** | ❌ (URL unique) | ✅ Pro tier (chatbots intégrables sur d'autres domaines) |
-| **GDPR tools** | Basique (auth + audit) | ✅ natif (IP banning, word filtering, content moderation, GDPR tools) |
-| **Statistiques d'usage** | ✅ natif (admin dashboard) | ⚠️ Pro tier |
+| **Streaming** | Oui — natif (SSE) | Oui — natif (Server-Sent Events) |
+| **Mémoire de conversation** | Oui — par utilisateur, multi-turn, dossiers d'équipe (v0.10+) | Oui — par chatbot, discussion history |
+| **Personas / System prompts** | Oui — avancés (modèles communautaires, custom) | Oui — par chatbot (customizable themes, system instructions/prompts) |
+| **Multi-utilisateur / RBAC** | Oui — Cœur du produit (groups, permissions, channels) | Limité (rôles WP natifs : admin, editor, author, subscriber) |
+| **Multi-tenant** | Oui — natif (groups + canaux) | Non — pas nativement ; Pro tier ajoute « cross-site chatbots » |
+| **Canaux collaboratifs** | Oui (channels multi-user, partage de conversations) | Non — pas de canaux ; Workspace = chat individuel wp-admin |
+| **Copilot pour éditeur** | Non — hors scope (pas de CMS intégré) | Oui — éditeur WordPress (grammaire, enhancement, traduction, rewriting, génération d'images) |
+| **AI Forms** | Non — hors scope | Oui — text/image/audio/file inputs, conditional logic, multi-step workflows, CSV/JSON export |
+| **Application mobile** | Non (web responsive) | Oui — iOS app gratuite (Workspace en mobilité) |
+| **Vision (analyse d'images)** | Oui — upload + vision models | Oui — intégré |
+| **Génération d'images** | Oui — via tools / API externe | Oui — natif (multi-provider image gen) |
+| **Voix (TTS/STT)** | Oui — natif (multi-provider, realtime audio) | Partiel — Pro tier uniquement (realtime audio) |
+| **Web search intégré** | Oui — via tools / web search natif | Oui — intégré |
+| **Outils MCP (consommation)** | Oui — natif (Tools section, MCP-compatible) | Oui — connectable à des serveurs MCP externes |
+| **Serveur MCP (exposition)** | Non (Open WebUI n'expose pas, il consomme) | Oui — **spécificité AI-Engine** — WordPress devient serveur MCP pour agents externes |
+| **Cross-site embedding** | Non (URL unique) | Oui — Pro tier (chatbots intégrables sur d'autres domaines) |
+| **GDPR tools** | Basique (auth + audit) | Oui — natif (IP banning, word filtering, content moderation, GDPR tools) |
+| **Statistiques d'usage** | Oui — natif (admin dashboard) | Partiel — Pro tier |
 
 ---
 
@@ -76,8 +76,8 @@ version 3.7.0), de son code source GPL (distribué via le dépôt SVN
 | **Sources de documents** | Upload direct, URL, integration sources (GitHub, etc.) | PDF import avec chunking automatique, sync filters (catégories, langues, Polylang) |
 | **Vector stores supportés** | Natif (chroma-like interne, postgres pgvector option) | **5 vector stores** : Chroma, Qdrant, Pinecone, OpenAI Vector Store, **Internal WordPress DB** |
 | **Modes de recherche** | Hybride (BM25 + embedding) | 3 modes : Simple, Context-Aware, Smart |
-| **Recommandations personnalisées** | Limité (par user history) | ✅ content classification + personalized recommendations |
-| **Fine-tuning** | ❌ (pas d'UI dédiée) | ⚠️ Interface OpenAI finetuning encore là mais deprecated (OpenAI sunset self-serve) |
+| **Recommandations personnalisées** | Limité (par user history) | Oui — content classification + personalized recommendations |
+| **Fine-tuning** | Non (pas d'UI dédiée) | Partiel — Interface OpenAI finetuning encore là mais deprecated (OpenAI sunset self-serve) |
 
 ---
 
@@ -88,12 +88,12 @@ où les deux produits divergent le plus :
 
 | Critère | Open WebUI | AI-Engine |
 |---------|------------|-----------|
-| **Consomme des outils MCP** | ✅ Oui (Tools + MCP-compatible) | ✅ Oui (peut se connecter à des serveurs MCP externes) |
-| **Expose des outils MCP** | ❌ Non | ✅ **Oui — AI-Engine transforme WordPress en serveur MCP** |
+| **Consomme des outils MCP** | Oui (Tools + MCP-compatible) | Oui (peut se connecter à des serveurs MCP externes) |
+| **Expose des outils MCP** | Non | **Oui — AI-Engine transforme WordPress en serveur MCP** |
 | **Outils MCP natifs (côté serveur)** | n/a | Post, comment, media, theme, plugin, WooCommerce, Polylang, requêtes SQL, SEO — tous permission-aware |
-| **Authentification MCP** | n/a | ✅ OAuth supporté pour clients desktop |
+| **Authentification MCP** | n/a | Oui — OAuth supporté pour clients desktop |
 | **Clients MCP compatibles** | Clients qui consomment (Claude Code, Cursor, etc.) | **Claude, Claude Code, ChatGPT, OpenClaw** (et autres agents MCP-compatibles) |
-| **Mode YOLO / unrestricted** | n/a | ⚠️ Plugin compagnon `ai-engine-yolo` sur GitHub — exécution PHP sans restriction, **uniquement dev sites** |
+| **Mode YOLO / unrestricted** | n/a | Partiel — Plugin compagnon `ai-engine-yolo` sur GitHub — exécution PHP sans restriction, **uniquement dev sites** |
 
 L'exposition MCP d'AI-Engine est **sa spécificité majeure** côté
 intégration agentique : un site WordPress peut devenir un *tool
@@ -134,11 +134,11 @@ workflow agentique plutôt qu'ils ne s'excluent.
 | Critère | Open WebUI | AI-Engine |
 |---------|------------|-----------|
 | **Authentification** | Cœur du produit (LDAP, OAuth, OIDC, local) | Rôles WordPress natifs (admin, editor, author, subscriber) |
-| **RBAC granulaire** | ✅ (groups, permissions par workspace, channel) | Limité (rôles WP) ; Pro tier ajoute contrôle fin |
-| **IP banning / word filtering** | ❌ hors scope | ✅ natif |
-| **Audit log** | ✅ admin | Basique (logs WP) ; Pro tier ajoute statistics/usage control |
-| **Conflits connus** | Peu (Docker = isolation naturelle) | ⚠️ SiteGround Optimizer, Ninja Firewall (compat frontend) |
-| **Multi-tenant isolation** | ✅ natif (groups, RBAC) | ❌ pas natif ; un site WP = un tenant |
+| **RBAC granulaire** | Oui (groups, permissions par workspace, channel) | Limité (rôles WP) ; Pro tier ajoute contrôle fin |
+| **IP banning / word filtering** | Non — hors scope | Oui — natif |
+| **Audit log** | Oui — admin | Basique (logs WP) ; Pro tier ajoute statistics/usage control |
+| **Conflits connus** | Peu (Docker = isolation naturelle) | Partiel — SiteGround Optimizer, Ninja Firewall (compat frontend) |
+| **Multi-tenant isolation** | Oui — natif (groups, RBAC) | Non — pas natif ; un site WP = un tenant |
 | **Scalabilité** | Horizontale (multi-instances Docker + LB) | Verticale (WordPress scale) |
 
 ---


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #13010

## Summary

Passe doc sur `comparatif-owui-vs-ai-engine.md` (audit fichier-entier), conformément à l'acceptance de #9890 qui exigeait un porteur MED et interdisait la PR isolée « 30 lignes d'emojis ».

**Ce que la PR fait (31 insertions / 31 deletions, 1 fichier) :**

1. **52 marqueurs de verdict convertis en texte** — 36 ✅ → `Oui`, 11 ❌ → `Non`, 5 ⚠️ → `Partiel`, avec le complément de chaque cellule conservé. Règles de fidélité appliquées : cellule déjà verbeuse (`✅ Oui (…)`) dédoublonnée ; parenthèse (`❌ (web responsive)`) collée directe (`Non (web responsive)`) ; gras préservé (`**Oui — AI-Engine transforme WordPress…**`) ; tiret cadratin pour le reste (`Oui — natif (SSE)`). Substance et mise en page inchangées : 242 lignes avant/après, aucune ligne supprimée.
2. **Breadcrumb racine réparé** (drift du renommage #9736) : le fichier vit au **niveau catégorie** depuis son déménagement hors de `Open-WebUI/01-AI-Engine-WordPress/`, mais son lien retour pointait encore `AI-Engine-WordPress/README.md`. Le README de catégorie ([§ Pourquoi une catégorie plutôt qu'un produit](MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/README.md)) dit explicitement qu'un comparatif ne se range pas dans l'un des deux objets qu'il compare — le parent est le README catégorie.

**Audit fichier-entier (règle E §Feuille README)** : tous les liens du fichier vérifiés au disque — Tour OWUI (`Open-WebUI/00-Tour-Plateforme/README.md`), série QA (`Open-WebUI/Playwright-OWUI/README.md`), `AI-Engine-WordPress/README.md`, `livresagites-parcours.md`, ancres internes `#coût` ×2 valides. Aucun autre défaut trouvé.

**Périmètre tenu** : les 2 autres fichiers md du niveau catégorie (`README.md`, `cadrer-les-agents.md`) mesurés **0 occurrence** dans les plages de l'acceptance (leurs flèches typographiques ← → sont hors plages 1F300-1FAFF / 2600-27BF, conformes). Les `.ipynb` du dossier intouchables : leurs emojis vivent dans des **outputs d'exécution réels** (jamais hand-éditer, règle 6). Les sous-dossiers Open-WebUI / AI-Engine-WordPress hors scope (leurs propres grains, #12874 en cours sur playwright-owui).

## Acceptance #9890 — case par case

- [x] regex plages 1F300-1FAFF / 2600-27BF renvoie **0** sur le fichier (mesuré post-conv : 0 ; pré-conv : 52 = 36×U+2705 + 11×U+274C + 5×U+26A0)
- [x] substance inchangée — marqueurs remplacés par du texte, 0 ligne supprimée
- [x] grain porteur **MED** (audit fichier-entier + correction d'un drift structurel de renommage), le nettoyage est un à-côté du breadcrumb fix

## Rouge attendu (justification --ignore-red pré-écrite)

`PR gate` timeout ~28 min sans verdict = signature de la famine CI #13097 (389 runs créés/h vs 49 terminés, 0 avec verdict). Cette PR n'est pas en cause (markdown-only, pas de re-exec due, pas de conflit). Conformément au steer ai-01 2026-08-26T11:25Z : un seul push, pas de rebase en boucle, à merger dès que la file rend des verdicts.

Closes #9890
