### PR TITLE
feat(smartcontracts,#13049): SC-19 live XRPL Testnet via asyncio API, seed never exposed

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
@@ -5,10 +5,10 @@
    "id": "header",
    "metadata": {
     "papermill": {
-     "duration": 0.020793,
-     "end_time": "2026-06-03T08:33:27.579044",
+     "duration": 0.004498,
+     "end_time": "2026-08-26T12:42:56.310749",
      "exception": false,
-     "start_time": "2026-06-03T08:33:27.558251",
+     "start_time": "2026-08-26T12:42:56.306251",
      "status": "completed"
     },
     "tags": []
@@ -30,8 +30,10 @@
     "\n",
     "### Prerequis\n",
     "\n",
-    "- Python 3.10+ avec `xrpl-py`\n",
+    "- Python 3.10+ avec `xrpl-py` (kernel Jupyter `smartcontracts` : environnement ou `xrpl-py` est installe)\n",
     "- Connexion internet (acces au Testnet XRP)\n",
+    "\n",
+    "> **Environnement** : ce notebook utilise le kernel `smartcontracts` et l'API **asyncio** de `xrpl-py` (`AsyncJsonRpcClient`, `await`), seule compatible avec la boucle evenementielle de Jupyter. Le client synchrone `JsonRpcClient` declenche `asyncio.run() cannot be called from a running event loop` dans un notebook.\n",
     "\n",
     "### Duree estimee : 50 minutes"
    ]
@@ -41,10 +43,10 @@
    "id": "intro-concepts",
    "metadata": {
     "papermill": {
-     "duration": 0.011316,
-     "end_time": "2026-06-03T08:33:27.603373",
+     "duration": 0.00453,
+     "end_time": "2026-08-26T12:42:56.319585",
      "exception": false,
-     "start_time": "2026-06-03T08:33:27.592057",
+     "start_time": "2026-08-26T12:42:56.315055",
      "status": "completed"
     },
     "tags": []
@@ -94,16 +96,16 @@
    "id": "intro-comparison-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:27.628422Z",
-     "iopub.status.busy": "2026-06-03T08:33:27.627488Z",
-     "iopub.status.idle": "2026-06-03T08:33:27.654985Z",
-     "shell.execute_reply": "2026-06-03T08:33:27.654233Z"
+     "iopub.execute_input": "2026-08-26T12:42:56.328769Z",
+     "iopub.status.busy": "2026-08-26T12:42:56.328546Z",
+     "iopub.status.idle": "2026-08-26T12:42:56.334760Z",
+     "shell.execute_reply": "2026-08-26T12:42:56.334188Z"
     },
     "papermill": {
-     "duration": 0.045001,
-     "end_time": "2026-06-03T08:33:27.656853",
+     "duration": 0.012455,
+     "end_time": "2026-08-26T12:42:56.335723",
      "exception": false,
-     "start_time": "2026-06-03T08:33:27.611852",
+     "start_time": "2026-08-26T12:42:56.323268",
      "status": "completed"
     },
     "tags": []
@@ -176,10 +178,10 @@
    "id": "intro-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.011134,
-     "end_time": "2026-06-03T08:33:27.681661",
+     "duration": 0.003775,
+     "end_time": "2026-08-26T12:42:56.343241",
      "exception": false,
-     "start_time": "2026-06-03T08:33:27.670527",
+     "start_time": "2026-08-26T12:42:56.339466",
      "status": "completed"
     },
     "tags": []
@@ -201,10 +203,10 @@
    "id": "setup-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.043663,
-     "end_time": "2026-06-03T08:33:27.735782",
+     "duration": 0.002991,
+     "end_time": "2026-08-26T12:42:56.349220",
      "exception": false,
-     "start_time": "2026-06-03T08:33:27.692119",
+     "start_time": "2026-08-26T12:42:56.346229",
      "status": "completed"
     },
     "tags": []
@@ -225,16 +227,16 @@
    "id": "setup-check",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:27.846526Z",
-     "iopub.status.busy": "2026-06-03T08:33:27.844857Z",
-     "iopub.status.idle": "2026-06-03T08:33:28.424629Z",
-     "shell.execute_reply": "2026-06-03T08:33:28.424168Z"
+     "iopub.execute_input": "2026-08-26T12:42:56.358301Z",
+     "iopub.status.busy": "2026-08-26T12:42:56.358085Z",
+     "iopub.status.idle": "2026-08-26T12:42:56.766968Z",
+     "shell.execute_reply": "2026-08-26T12:42:56.766515Z"
     },
     "papermill": {
-     "duration": 0.645305,
-     "end_time": "2026-06-03T08:33:28.432960",
+     "duration": 0.415113,
+     "end_time": "2026-08-26T12:42:56.768281",
      "exception": false,
-     "start_time": "2026-06-03T08:33:27.787655",
+     "start_time": "2026-08-26T12:42:56.353168",
      "status": "completed"
     },
     "tags": []
@@ -245,7 +247,8 @@
      "output_type": "stream",
      "text": [
       "xrpl-py version : 4.5.0\n",
-      "Installation OK\n"
+      "Python         : 3.13.3\n",
+      "Installation OK - API asyncio chargee (compatible boucle Jupyter)\n"
      ]
     }
    ],
@@ -253,14 +256,17 @@
     "# Verification de l'installation de xrpl-py\n",
     "try:\n",
     "    import xrpl\n",
-    "    from xrpl.clients import JsonRpcClient\n",
-    "    from xrpl.wallet import generate_faucet_wallet\n",
-    "    from xrpl.models.requests import AccountInfo\n",
+    "    from xrpl.asyncio.clients import AsyncJsonRpcClient\n",
+    "    from xrpl.asyncio.wallet import generate_faucet_wallet\n",
+    "    from xrpl.asyncio.transaction import submit_and_wait\n",
+    "    from xrpl.models.requests import AccountInfo, Ledger\n",
     "    from importlib.metadata import version as pkg_version\n",
+    "    import sys\n",
     "    print(f\"xrpl-py version : {pkg_version('xrpl-py')}\")\n",
-    "    print(\"Installation OK\")\n",
+    "    print(f\"Python         : {sys.version.split()[0]}\")\n",
+    "    print(\"Installation OK - API asyncio chargee (compatible boucle Jupyter)\")\n",
     "except ImportError:\n",
-    "    print(\"xrpl-py n'est pas installe.\")\n",
+    "    print(\"xrpl-py n'est pas installe dans le kernel smartcontracts.\")\n",
     "    print(\"Installation : pip install xrpl-py\")\n",
     "    print(\"Les cellules suivantes ne fonctionneront pas sans cette bibliotheque.\")"
    ]
@@ -270,10 +276,10 @@
    "id": "kiyi7nubjkg",
    "metadata": {
     "papermill": {
-     "duration": 0.053332,
-     "end_time": "2026-06-03T08:33:28.496711",
+     "duration": 0.006714,
+     "end_time": "2026-08-26T12:42:56.783858",
      "exception": false,
-     "start_time": "2026-06-03T08:33:28.443379",
+     "start_time": "2026-08-26T12:42:56.777144",
      "status": "completed"
     },
     "tags": []
@@ -288,16 +294,16 @@
    "id": "setup-connect",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:28.609528Z",
-     "iopub.status.busy": "2026-06-03T08:33:28.607561Z",
-     "iopub.status.idle": "2026-06-03T08:33:28.663298Z",
-     "shell.execute_reply": "2026-06-03T08:33:28.656504Z"
+     "iopub.execute_input": "2026-08-26T12:42:56.793624Z",
+     "iopub.status.busy": "2026-08-26T12:42:56.793175Z",
+     "iopub.status.idle": "2026-08-26T12:42:57.931621Z",
+     "shell.execute_reply": "2026-08-26T12:42:57.931055Z"
     },
     "papermill": {
-     "duration": 0.109918,
-     "end_time": "2026-06-03T08:33:28.673846",
+     "duration": 1.143696,
+     "end_time": "2026-08-26T12:42:57.932561",
      "exception": false,
-     "start_time": "2026-06-03T08:33:28.563928",
+     "start_time": "2026-08-26T12:42:56.788865",
      "status": "completed"
     },
     "tags": []
@@ -307,42 +313,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Impossible de se connecter au Testnet : asyncio.run() cannot be called from a running event loop\n",
-      "Les cellules suivantes utiliseront des donnees simulees.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\421297247.py:21: RuntimeWarning: coroutine 'JsonRpcBase._request_impl' was never awaited\n",
-      "  client = None\n",
-      "RuntimeWarning: Enable tracemalloc to get the object allocation traceback\n"
+      "Connexion au Testnet XRP reussie\n",
+      "  URL           : https://s.altnet.rippletest.net:51234\n",
+      "  Ledger valide : #20235788\n",
+      "  Heure         : 2026-Aug-26 12:42:52.000000000 UTC\n"
      ]
     }
    ],
    "source": [
-    "# Connexion au Testnet XRP\n",
+    "# Connexion au Testnet XRP - API asyncio native\n",
     "import xrpl\n",
-    "from xrpl.clients import JsonRpcClient\n",
+    "from xrpl.asyncio.clients import AsyncJsonRpcClient\n",
+    "from xrpl.models.requests import Ledger\n",
     "\n",
     "TESTNET_URL = \"https://s.altnet.rippletest.net:51234\"\n",
     "\n",
-    "try:\n",
-    "    client = JsonRpcClient(TESTNET_URL)\n",
-    "    # Verifier la connexion en demandant le dernier ledger\n",
-    "    from xrpl.models.requests import Ledger\n",
-    "    response = client.request(Ledger(ledger_index=\"validated\"))\n",
-    "    ledger_index = response.result.get(\"ledger_index\", \"inconnu\")\n",
-    "    close_time = response.result.get(\"ledger\", {}).get(\"close_time_human\", \"inconnu\")\n",
-    "    print(f\"Connexion au Testnet XRP reussie\")\n",
-    "    print(f\"  URL           : {TESTNET_URL}\")\n",
-    "    print(f\"  Ledger valide : #{ledger_index}\")\n",
-    "    print(f\"  Heure         : {close_time}\")\n",
-    "except Exception as e:\n",
-    "    print(f\"Impossible de se connecter au Testnet : {e}\")\n",
-    "    print(\"Les cellules suivantes utiliseront des donnees simulees.\")\n",
-    "    client = None"
+    "# AsyncJsonRpcClient s'integre a la boucle evenementielle de Jupyter :\n",
+    "# chaque appel est un simple `await`, sans asyncio.run() interdit.\n",
+    "client = AsyncJsonRpcClient(TESTNET_URL)\n",
+    "\n",
+    "response = await client.request(Ledger(ledger_index=\"validated\"))\n",
+    "ledger_index = response.result.get(\"ledger_index\", \"inconnu\")\n",
+    "close_time = response.result.get(\"ledger\", {}).get(\"close_time_human\", \"inconnu\")\n",
+    "\n",
+    "print(\"Connexion au Testnet XRP reussie\")\n",
+    "print(f\"  URL           : {TESTNET_URL}\")\n",
+    "print(f\"  Ledger valide : #{ledger_index}\")\n",
+    "print(f\"  Heure         : {close_time}\")"
    ]
   },
   {
@@ -350,10 +347,10 @@
    "id": "90a8b643",
    "metadata": {
     "papermill": {
-     "duration": 0.052961,
-     "end_time": "2026-06-03T08:33:28.803816",
+     "duration": 0.00326,
+     "end_time": "2026-08-26T12:42:57.939182",
      "exception": false,
-     "start_time": "2026-06-03T08:33:28.750855",
+     "start_time": "2026-08-26T12:42:57.935922",
      "status": "completed"
     },
     "tags": []
@@ -361,15 +358,20 @@
    "source": [
     "### Interpretation : connexion au Testnet XRP\n",
     "\n",
-    "**Résultat obtenu** : La connexion via `JsonRpcClient` echoue ici a cause d'un conflit de boucle evenementielle asyncio dans l'environnement Jupyter. En exécution normale (script Python), elle retourne le numéro du dernier ledger valide et son horodatage.\n",
+    "**Resultat obtenu** : la lecture du dernier ledger valide reussit en direct - le numero de ledger et son horodatage ci-dessus viennent du reseau Testnet au moment de l'execution.\n",
+    "\n",
+    "**Le piege asyncio de `xrpl-py`** : le client synchrone `JsonRpcClient` encapsule chaque requete dans `asyncio.run()`, ce qui leve\n",
+    "`asyncio.run() cannot be called from a running event loop` sous Jupyter (le notebook possede deja sa boucle). Le notebook bascule\n",
+    "alors entierement en mode simule sans erreur visible - un defaut silencieux typique. La solution n'est pas de contourner (threads,\n",
+    "nest_asyncio) mais d'utiliser l'API officielle asynchrone : `AsyncJsonRpcClient` + `await client.request(...)`, native dans `xrpl-py`.\n",
     "\n",
     "| Information | Exemple | Source |\n",
     "|-------------|---------|--------|\n",
-    "| `ledger_index` | Numéro entier | Compteur séquentiel des ledgers |\n",
+    "| `ledger_index` | Numero entier | Compteur sequentiel des ledgers |\n",
     "| `close_time_human` | Date et heure | Horodatage de fermeture du ledger |\n",
     "| URL Testnet | `s.altnet.rippletest.net` | Point d'acces au reseau de test |\n",
     "\n",
-    "**Note technique** : Le XRPL utilise un modèle JSON-RPC (et WebSocket) plutot que REST. Chaque appel au client envoie une requête JSON structuree et recoit une reponse JSON. Les bibliotheques `xrpl-py` encapsulent cette communication."
+    "**Note technique** : Le XRPL utilise un modele JSON-RPC (et WebSocket) plutot que REST. Chaque appel au client envoie une requete JSON structuree et recoit une reponse JSON.\"\n"
    ]
   },
   {
@@ -377,10 +379,10 @@
    "id": "kq1o265ipl",
    "metadata": {
     "papermill": {
-     "duration": 0.073432,
-     "end_time": "2026-06-03T08:33:28.939112",
+     "duration": 0.00359,
+     "end_time": "2026-08-26T12:42:57.946599",
      "exception": false,
-     "start_time": "2026-06-03T08:33:28.865680",
+     "start_time": "2026-08-26T12:42:57.943009",
      "status": "completed"
     },
     "tags": []
@@ -395,16 +397,16 @@
    "id": "setup-wallets",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:29.047352Z",
-     "iopub.status.busy": "2026-06-03T08:33:29.044677Z",
-     "iopub.status.idle": "2026-06-03T08:33:29.090950Z",
-     "shell.execute_reply": "2026-06-03T08:33:29.083111Z"
+     "iopub.execute_input": "2026-08-26T12:42:57.955654Z",
+     "iopub.status.busy": "2026-08-26T12:42:57.955442Z",
+     "iopub.status.idle": "2026-08-26T12:43:20.295535Z",
+     "shell.execute_reply": "2026-08-26T12:43:20.295022Z"
     },
     "papermill": {
-     "duration": 0.110222,
-     "end_time": "2026-06-03T08:33:29.101119",
+     "duration": 22.346487,
+     "end_time": "2026-08-26T12:43:20.296712",
      "exception": false,
-     "start_time": "2026-06-03T08:33:28.990897",
+     "start_time": "2026-08-26T12:42:57.950225",
      "status": "completed"
     },
     "tags": []
@@ -414,56 +416,71 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur faucet : Pas de connexion au Testnet\n",
+      "Demande de XRP au faucet Testnet (10-20 s par wallet)...\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WALLET 1 (Alice)\n",
+      "  Adresse classique : rsV9uq1DVWrHWbx66jhkeyxa5jKfgmErg9\n",
+      "  Cle publique      : ED4BCB4D0E298410ECB3E4D6FC7A3EC5...\n",
+      "  Seed              : jamais affichee (secret de signature)\n",
       "\n",
-      "Simulation avec des donnees fictives :\n",
-      "  Alice : rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh (100 XRP)\n",
-      "  Bob   : rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe (100 XRP)\n"
+      "WALLET 2 (Bob)\n",
+      "  Adresse classique : rnAwyYV3R7CShvr4hVuBwHSurRbtWpzRSX\n",
+      "  Cle publique      : ED7DCA1B2D6E2A4DDABFF6E64524E308...\n",
+      "  Seed              : jamais affichee (secret de signature)\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solde Alice : 100.000000 XRP (100,000,000 drops)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solde Bob : 100.000000 XRP (100,000,000 drops)\n",
+      "  (1 XRP = 1,000,000 drops)\n"
      ]
     }
    ],
    "source": [
-    "# Creation d'un wallet de test via le faucet\n",
-    "from xrpl.wallet import generate_faucet_wallet\n",
+    "# Creation de wallets de test via le faucet - sans jamais exposer la seed\n",
+    "from xrpl.asyncio.wallet import generate_faucet_wallet\n",
+    "from xrpl.models.requests import AccountInfo\n",
     "\n",
-    "try:\n",
-    "    if client is None:\n",
-    "        raise ConnectionError(\"Pas de connexion au Testnet\")\n",
+    "print(\"Demande de XRP au faucet Testnet (10-20 s par wallet)...\\n\")\n",
     "\n",
-    "    print(\"Demande de XRP au faucet Testnet...\")\n",
-    "    print(\"(cette operation peut prendre 10-20 secondes)\\n\")\n",
+    "# debug=False est indispensable : debug=True imprimerait la seed dans les outputs.\n",
+    "wallet_1 = await generate_faucet_wallet(client, debug=False)\n",
+    "wallet_2 = await generate_faucet_wallet(client, debug=False)\n",
     "\n",
-    "    wallet_1 = generate_faucet_wallet(client, debug=False)\n",
-    "    wallet_2 = generate_faucet_wallet(client, debug=False)\n",
+    "print(\"WALLET 1 (Alice)\")\n",
+    "print(f\"  Adresse classique : {wallet_1.address}\")\n",
+    "print(f\"  Cle publique      : {wallet_1.public_key[:32]}...\")\n",
+    "print(\"  Seed              : jamais affichee (secret de signature)\")\n",
+    "print()\n",
+    "print(\"WALLET 2 (Bob)\")\n",
+    "print(f\"  Adresse classique : {wallet_2.address}\")\n",
+    "print(f\"  Cle publique      : {wallet_2.public_key[:32]}...\")\n",
+    "print(\"  Seed              : jamais affichee (secret de signature)\")\n",
+    "print()\n",
     "\n",
-    "    print(\"WALLET 1 (Alice)\")\n",
-    "    print(f\"  Adresse classique : {wallet_1.address}\")\n",
-    "    print(f\"  Cle publique      : {wallet_1.public_key[:32]}...\")\n",
-    "    print(f\"  Seed (secret)     : {wallet_1.seed}\")\n",
-    "    print()\n",
-    "    print(\"WALLET 2 (Bob)\")\n",
-    "    print(f\"  Adresse classique : {wallet_2.address}\")\n",
-    "    print(f\"  Cle publique      : {wallet_2.public_key[:32]}...\")\n",
-    "    print()\n",
-    "\n",
-    "    # Consulter le solde\n",
-    "    from xrpl.models.requests import AccountInfo\n",
-    "    acct_info = client.request(AccountInfo(\n",
-    "        account=wallet_1.address,\n",
-    "        ledger_index=\"validated\"\n",
-    "    ))\n",
+    "# Consulter les soldes reels\n",
+    "for label, w in ((\"Alice\", wallet_1), (\"Bob\", wallet_2)):\n",
+    "    acct_info = await client.request(AccountInfo(\n",
+    "        account=w.address, ledger_index=\"validated\"))\n",
     "    balance_drops = int(acct_info.result[\"account_data\"][\"Balance\"])\n",
-    "    balance_xrp = balance_drops / 1_000_000\n",
-    "    print(f\"Solde Alice : {balance_xrp:.6f} XRP ({balance_drops:,} drops)\")\n",
-    "    print(f\"  (1 XRP = 1,000,000 drops)\")\n",
-    "\n",
-    "except Exception as e:\n",
-    "    print(f\"Erreur faucet : {e}\")\n",
-    "    print(\"\\nSimulation avec des donnees fictives :\")\n",
-    "    print(\"  Alice : rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh (100 XRP)\")\n",
-    "    print(\"  Bob   : rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe (100 XRP)\")\n",
-    "    wallet_1 = None\n",
-    "    wallet_2 = None"
+    "    print(f\"Solde {label} : {balance_drops / 1_000_000:.6f} XRP ({balance_drops:,} drops)\")\n",
+    "print(\"  (1 XRP = 1,000,000 drops)\")"
    ]
   },
   {
@@ -471,10 +488,10 @@
    "id": "11977425",
    "metadata": {
     "papermill": {
-     "duration": 0.095884,
-     "end_time": "2026-06-03T08:33:29.264885",
+     "duration": 0.004076,
+     "end_time": "2026-08-26T12:43:20.305320",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.169001",
+     "start_time": "2026-08-26T12:43:20.301244",
      "status": "completed"
     },
     "tags": []
@@ -482,18 +499,18 @@
    "source": [
     "### Interpretation : creation de wallets et reserves\n",
     "\n",
-    "**Résultat obtenu** : En mode simule, Alice et Bob disposent chacun de 100 XRP fictifs. La creation d'un wallet via le faucet genere une adresse, une cle publique et une seed (cle privee).\n",
+    "**Resultat obtenu** : deux wallets finances par le faucet, avec soldes verifies en direct. La seed existe en memoire (elle signe les transactions des cellules suivantes) mais n'est **jamais imprimee ni persistee** : exposer la seed d'un wallet - meme de test - dans un output committe revient a publier sa cle privee.\n",
     "\n",
-    "| Élément | Format | Utilite |\n",
+    "| Element | Format | Utilite |\n",
     "|---------|--------|---------|\n",
-    "| Adresse | `r...` (25-35 caractères) | Identifiant public du compte |\n",
+    "| Adresse | `r...` (25-35 caracteres) | Identifiant public du compte |\n",
     "| Cle publique | Hex (64 octets) | Verification des signatures |\n",
-    "| Seed | `s...` (cle privee) | Signature des transactions |\n",
+    "| Seed | `s...` (cle privee) | Signature des transactions - **secret, jamais affichee** |\n",
     "\n",
     "**Points cles** :\n",
-    "- La reserve de base (10 XRP sur mainnet) est un mécanisme anti-spam : chaque objet supplementaire (trust line, offer, channel) consomme de la reserve\n",
-    "- 1 XRP = 1 000 000 drops. Le XRPL utilise les drops comme unite atomique dans toutes les opérations\n",
-    "- La seed (`s...`) doit etre gardee secrete. En production, elle n'est jamais affichée en clair et est stockee dans un wallet chiffre"
+    "- La reserve de base est un mecanisme anti-spam : chaque objet supplementaire (trust line, offer, channel) consomme de la reserve\n",
+    "- 1 XRP = 1 000 000 drops. Le XRPL utilise les drops comme unite atomique dans toutes les operations\n",
+    "- Regle de securite : la seed ne quitte jamais la memoire du process. En production, elle vit dans un wallet hardware ou un gestionnaire de secrets.\"\n"
    ]
   },
   {
@@ -501,10 +518,10 @@
    "id": "setup-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.014122,
-     "end_time": "2026-06-03T08:33:29.328277",
+     "duration": 0.003703,
+     "end_time": "2026-08-26T12:43:20.313704",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.314155",
+     "start_time": "2026-08-26T12:43:20.310001",
      "status": "completed"
     },
     "tags": []
@@ -529,10 +546,10 @@
    "id": "tx-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.008949,
-     "end_time": "2026-06-03T08:33:29.345765",
+     "duration": 0.003311,
+     "end_time": "2026-08-26T12:43:20.320451",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.336816",
+     "start_time": "2026-08-26T12:43:20.317140",
      "status": "completed"
     },
     "tags": []
@@ -564,16 +581,16 @@
    "id": "tx-payment-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:29.363847Z",
-     "iopub.status.busy": "2026-06-03T08:33:29.363268Z",
-     "iopub.status.idle": "2026-06-03T08:33:29.372109Z",
-     "shell.execute_reply": "2026-06-03T08:33:29.371115Z"
+     "iopub.execute_input": "2026-08-26T12:43:20.329020Z",
+     "iopub.status.busy": "2026-08-26T12:43:20.328334Z",
+     "iopub.status.idle": "2026-08-26T12:43:34.524069Z",
+     "shell.execute_reply": "2026-08-26T12:43:34.523511Z"
     },
     "papermill": {
-     "duration": 0.019064,
-     "end_time": "2026-06-03T08:33:29.372982",
+     "duration": 14.201034,
+     "end_time": "2026-08-26T12:43:34.524926",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.353918",
+     "start_time": "2026-08-26T12:43:20.323892",
      "status": "completed"
     },
     "tags": []
@@ -583,65 +600,74 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur lors du paiement : Wallets non disponibles\n",
+      "ENVOI DE PAIEMENT XRP\n",
+      "============================================================\n",
+      "De      : rsV9uq1DVWrHWbx66jhkeyxa5jKfgmErg9\n",
+      "Vers    : rnAwyYV3R7CShvr4hVuBwHSurRbtWpzRSX\n",
+      "Montant : 25 XRP (25000000 drops)\n",
       "\n",
-      "Exemple de resultat attendu :\n",
-      "  Hash   : A1B2C3...  (64 caracteres hex)\n",
-      "  Statut : tesSUCCESS\n",
-      "  Frais  : 12 drops (0.000012 XRP)\n"
+      "Soumission en cours...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Resultat :\n",
+      "  Hash        : 4E1FF3141312183FC34E8C9284B109A6653705CD0CE9C4571A8E65DED4A0D4A9\n",
+      "  Statut      : tesSUCCESS\n",
+      "  Frais       : 10 drops (0.000010 XRP), mesures par solde avant/apres\n",
+      "  Solde Alice : 100.000000 -> 74.999990 XRP\n",
+      "  Ledger      : 20235798\n",
+      "\n",
+      "-> Transaction validee par le consensus Testnet en quelques secondes\n"
      ]
     }
    ],
    "source": [
-    "# Envoi d'un paiement XRP\n",
-    "import xrpl\n",
+    "# Envoi d'un paiement XRP - transaction Testnet reelle\n",
+    "from xrpl.asyncio.transaction import submit_and_wait as submit_and_wait_async\n",
     "from xrpl.models.transactions import Payment\n",
-    "from xrpl.transaction import submit_and_wait\n",
     "from xrpl.utils import xrp_to_drops\n",
     "\n",
-    "try:\n",
-    "    if wallet_1 is None or wallet_2 is None or client is None:\n",
-    "        raise ConnectionError(\"Wallets non disponibles\")\n",
+    "# Paiement de 25 XRP d'Alice vers Bob\n",
+    "payment_tx = Payment(\n",
+    "    account=wallet_1.address,\n",
+    "    destination=wallet_2.address,\n",
+    "    amount=xrp_to_drops(25),  # 25 XRP en drops\n",
+    ")\n",
     "\n",
-    "    # Preparer un paiement de 25 XRP d'Alice vers Bob\n",
-    "    payment_tx = Payment(\n",
-    "        account=wallet_1.address,\n",
-    "        destination=wallet_2.address,\n",
-    "        amount=xrp_to_drops(25),  # 25 XRP en drops\n",
-    "    )\n",
+    "print(\"ENVOI DE PAIEMENT XRP\")\n",
+    "print(\"=\" * 60)\n",
+    "print(f\"De      : {wallet_1.address}\")\n",
+    "print(f\"Vers    : {wallet_2.address}\")\n",
+    "print(f\"Montant : 25 XRP ({xrp_to_drops(25)} drops)\")\n",
+    "print(\"\\nSoumission en cours...\")\n",
     "\n",
-    "    print(\"ENVOI DE PAIEMENT XRP\")\n",
-    "    print(\"=\" * 60)\n",
-    "    print(f\"De      : {wallet_1.address}\")\n",
-    "    print(f\"Vers    : {wallet_2.address}\")\n",
-    "    print(f\"Montant : 25 XRP ({xrp_to_drops(25)} drops)\")\n",
-    "    print(f\"\\nSoumission en cours...\")\n",
+    "response = await submit_and_wait_async(payment_tx, client, wallet_1)\n",
+    "result = response.result\n",
     "\n",
-    "    # Soumettre et attendre la validation\n",
-    "    response = submit_and_wait(payment_tx, client, wallet_1)\n",
-    "    result = response.result\n",
+    "tx_hash = result.get(\"hash\", \"inconnu\")\n",
+    "status = result.get(\"meta\", {}).get(\"TransactionResult\", \"inconnu\")\n",
+    "# Frais reels, mesures par difference de solde avant/apres paiement :\n",
+    "# le solde d'Alice ne baisse que du montant envoye + des frais.\n",
+    "acct_after = await client.request(AccountInfo(\n",
+    "    account=wallet_1.address, ledger_index=\"validated\"))\n",
+    "balance_after = int(acct_after.result[\"account_data\"][\"Balance\"])\n",
+    "fee_drops = 100_000_000 - 25_000_000 - balance_after\n",
     "\n",
-    "    tx_hash = result.get(\"hash\", \"inconnu\")\n",
-    "    status = result.get(\"meta\", {}).get(\"TransactionResult\", \"inconnu\")\n",
-    "    fee_drops = int(result.get(\"Fee\", 0))\n",
+    "print(f\"\\nResultat :\")\n",
+    "print(f\"  Hash        : {tx_hash}\")\n",
+    "print(f\"  Statut      : {status}\")\n",
+    "print(f\"  Frais       : {fee_drops} drops ({fee_drops / 1_000_000:.6f} XRP), mesures par solde avant/apres\")\n",
+    "print(f\"  Solde Alice : 100.000000 -> {balance_after / 1_000_000:.6f} XRP\")\n",
+    "print(f\"  Ledger      : {result.get('ledger_index', 'inconnu')}\")\n",
     "\n",
-    "    print(f\"\\nResultat :\")\n",
-    "    print(f\"  Hash        : {tx_hash}\")\n",
-    "    print(f\"  Statut      : {status}\")\n",
-    "    print(f\"  Frais       : {fee_drops} drops ({fee_drops / 1_000_000:.6f} XRP)\")\n",
-    "    print(f\"  Ledger      : {result.get('ledger_index', 'inconnu')}\")\n",
-    "\n",
-    "    if status == \"tesSUCCESS\":\n",
-    "        print(\"\\n-> Transaction validee en quelques secondes !\")\n",
-    "    else:\n",
-    "        print(f\"\\n-> Resultat inattendu : {status}\")\n",
-    "\n",
-    "except Exception as e:\n",
-    "    print(f\"Erreur lors du paiement : {e}\")\n",
-    "    print(\"\\nExemple de resultat attendu :\")\n",
-    "    print(\"  Hash   : A1B2C3...  (64 caracteres hex)\")\n",
-    "    print(\"  Statut : tesSUCCESS\")\n",
-    "    print(\"  Frais  : 12 drops (0.000012 XRP)\")"
+    "if status == \"tesSUCCESS\":\n",
+    "    print(\"\\n-> Transaction validee par le consensus Testnet en quelques secondes\")\n",
+    "else:\n",
+    "    print(f\"\\n-> Resultat inattendu : {status}\")"
    ]
   },
   {
@@ -649,10 +675,10 @@
    "id": "a71592db",
    "metadata": {
     "papermill": {
-     "duration": 0.006261,
-     "end_time": "2026-06-03T08:33:29.386019",
+     "duration": 0.003134,
+     "end_time": "2026-08-26T12:43:34.531583",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.379758",
+     "start_time": "2026-08-26T12:43:34.528449",
      "status": "completed"
     },
     "tags": []
@@ -660,18 +686,19 @@
    "source": [
     "### Interpretation : transaction de paiement XRP\n",
     "\n",
-    "**Résultat obtenu** : En mode simule (sans connexion Testnet), le code affiche le résultat attendu d'un paiement de 25 XRP. En conditions reelles, la transaction serait validee en 3-5 secondes.\n",
+    "**Resultat obtenu** : transaction validee en direct sur le Testnet - le hash ci-dessus est verifiable dans l'explorateur (testnet.xrpl.org), le code `tesSUCCESS` et le numero de ledger sont ceux du reseau au moment de l'execution.\n",
     "\n",
     "| Champ | Valeur typique | Signification |\n",
     "|-------|---------------|---------------|\n",
-    "| `hash` | 64 caractères hex | Identifiant unique de la transaction |\n",
-    "| `TransactionResult` | `tesSUCCESS` | Code de résultat (tes = Transaction Engine Success) |\n",
-    "| `Fee` | 12 drops (~0.000012 XRP) | Frais de transaction fixes |\n",
-    "| `ledger_index` | Numéro du ledger | Bloc dans lequel la tx est incluse |\n",
+    "| `hash` | 64 caracteres hex | Identifiant unique de la transaction |\n",
+    "| `TransactionResult` | `tesSUCCESS` | Code de resultat (tes = Transaction Engine Success) |\n",
+    "| `Fee` | ~12 drops (~0.000012 XRP) | Frais de transaction |\n",
+    "| `ledger_index` | Numero du ledger | Bloc dans lequel la tx est incluse |\n",
     "\n",
     "**Points cles** :\n",
-    "- Le code `tesSUCCESS` signifie une validation reussie. Le prefixe `tes` est un des 4 prefixes de codes du XRPL (`tec`, `tef`, `tel`, `tem` pour les différents types d'echec)\n",
-    "- Les frais (12 drops) sont **fixes** et ne dependent pas de la congestion du reseau, contrairement au gas Ethereum"
+    "- Le code `tesSUCCESS` signifie une validation reussie. Le prefixe `tes` est un des prefixes de codes du XRPL (`tec`, `tef`, `tel`, `tem` pour les differents types d'echec)\n",
+    "- Les frais sont fixes et ne dependent pas de la congestion du reseau - a contraster avec le gas d'Ethereum\n",
+    "- La finalite est deterministe : 3-5 secondes, pas de reorganisation possible comme sur Ethereum\n"
    ]
   },
   {
@@ -679,10 +706,10 @@
    "id": "brjfwi7k7f4",
    "metadata": {
     "papermill": {
-     "duration": 0.008664,
-     "end_time": "2026-06-03T08:33:29.401289",
+     "duration": 0.003222,
+     "end_time": "2026-08-26T12:43:34.538621",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.392625",
+     "start_time": "2026-08-26T12:43:34.535399",
      "status": "completed"
     },
     "tags": []
@@ -697,16 +724,16 @@
    "id": "tx-trustline-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:29.418741Z",
-     "iopub.status.busy": "2026-06-03T08:33:29.417948Z",
-     "iopub.status.idle": "2026-06-03T08:33:29.437630Z",
-     "shell.execute_reply": "2026-06-03T08:33:29.435778Z"
+     "iopub.execute_input": "2026-08-26T12:43:34.546034Z",
+     "iopub.status.busy": "2026-08-26T12:43:34.545828Z",
+     "iopub.status.idle": "2026-08-26T12:43:44.677536Z",
+     "shell.execute_reply": "2026-08-26T12:43:44.676941Z"
     },
     "papermill": {
-     "duration": 0.032275,
-     "end_time": "2026-06-03T08:33:29.439245",
+     "duration": 10.136591,
+     "end_time": "2026-08-26T12:43:44.678372",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.406970",
+     "start_time": "2026-08-26T12:43:34.541781",
      "status": "completed"
     },
     "tags": []
@@ -716,60 +743,62 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur trust line : Wallets non disponibles\n",
+      "CREATION D'UNE TRUST LINE\n",
+      "============================================================\n",
+      "Bob autorise Alice a emettre jusqu'a 1000 EUR\n",
+      "  Compte      : rnAwyYV3R7CShvr4hVuBwHSurRbtWpzRSX (Bob)\n",
+      "  Emetteur    : rsV9uq1DVWrHWbx66jhkeyxa5jKfgmErg9 (Alice)\n",
+      "  Devise      : EUR\n",
+      "  Limite      : 1000\n",
       "\n",
-      "Principe d'une trust line :\n",
-      "  - Un compte CHOISIT de faire confiance a un emetteur\n",
-      "  - Limite maximale configurable\n",
-      "  - Permet les paiements en devises (IOU) sur le XRPL\n",
-      "  - Pas de trust line = impossible de recevoir cet IOU\n"
+      "Soumission en cours...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Hash   : 96C839AB3EF1CE83A25591F6DAEC7DCF601307EDAF3914414F39C467B4A62FEF\n",
+      "  Statut : tesSUCCESS\n",
+      "\n",
+      "-> Trust line creee sur le ledger. Bob peut maintenant recevoir des EUR d'Alice.\n",
+      "   Les trust lines sont la base du systeme de credit du XRPL.\n"
      ]
     }
    ],
    "source": [
-    "# Creation d'une Trust Line pour un IOU (devise personnalisee)\n",
+    "# Creation d'une Trust Line pour un IOU (devise personnalisee) - transaction reelle\n",
     "from xrpl.models.transactions import TrustSet\n",
     "from xrpl.models.amounts import IssuedCurrencyAmount\n",
     "\n",
-    "try:\n",
-    "    if wallet_1 is None or wallet_2 is None or client is None:\n",
-    "        raise ConnectionError(\"Wallets non disponibles\")\n",
+    "# Bob autorise Alice a emettre jusqu'a 1000 EUR (IOU)\n",
+    "trust_set_tx = TrustSet(\n",
+    "    account=wallet_2.address,\n",
+    "    limit_amount=IssuedCurrencyAmount(\n",
+    "        currency=\"EUR\",\n",
+    "        issuer=wallet_1.address,\n",
+    "        value=\"1000\",\n",
+    "    ),\n",
+    ")\n",
     "\n",
-    "    # Bob autorise Alice a emettre jusqu'a 1000 EUR (IOU)\n",
-    "    trust_set_tx = TrustSet(\n",
-    "        account=wallet_2.address,\n",
-    "        limit_amount=IssuedCurrencyAmount(\n",
-    "            currency=\"EUR\",\n",
-    "            issuer=wallet_1.address,\n",
-    "            value=\"1000\",\n",
-    "        ),\n",
-    "    )\n",
+    "print(\"CREATION D'UNE TRUST LINE\")\n",
+    "print(\"=\" * 60)\n",
+    "print(\"Bob autorise Alice a emettre jusqu'a 1000 EUR\")\n",
+    "print(f\"  Compte      : {wallet_2.address} (Bob)\")\n",
+    "print(f\"  Emetteur    : {wallet_1.address} (Alice)\")\n",
+    "print(f\"  Devise      : EUR\")\n",
+    "print(f\"  Limite      : 1000\")\n",
+    "print(\"\\nSoumission en cours...\")\n",
     "\n",
-    "    print(\"CREATION D'UNE TRUST LINE\")\n",
-    "    print(\"=\" * 60)\n",
-    "    print(f\"Bob autorise Alice a emettre jusqu'a 1000 EUR\")\n",
-    "    print(f\"  Compte      : {wallet_2.address} (Bob)\")\n",
-    "    print(f\"  Emetteur    : {wallet_1.address} (Alice)\")\n",
-    "    print(f\"  Devise      : EUR\")\n",
-    "    print(f\"  Limite      : 1000\")\n",
-    "    print(f\"\\nSoumission en cours...\")\n",
+    "response = await submit_and_wait_async(trust_set_tx, client, wallet_2)\n",
+    "status = response.result.get(\"meta\", {}).get(\"TransactionResult\", \"inconnu\")\n",
     "\n",
-    "    response = submit_and_wait(trust_set_tx, client, wallet_2)\n",
-    "    status = response.result.get(\"meta\", {}).get(\"TransactionResult\", \"inconnu\")\n",
+    "print(f\"  Hash   : {response.result.get('hash', 'inconnu')}\")\n",
+    "print(f\"  Statut : {status}\")\n",
     "\n",
-    "    print(f\"  Statut : {status}\")\n",
-    "\n",
-    "    if status == \"tesSUCCESS\":\n",
-    "        print(\"\\n-> Trust line creee. Bob peut maintenant recevoir des EUR d'Alice.\")\n",
-    "        print(\"   Les trust lines sont la base du systeme de credit du XRPL.\")\n",
-    "\n",
-    "except Exception as e:\n",
-    "    print(f\"Erreur trust line : {e}\")\n",
-    "    print(\"\\nPrincipe d'une trust line :\")\n",
-    "    print(\"  - Un compte CHOISIT de faire confiance a un emetteur\")\n",
-    "    print(\"  - Limite maximale configurable\")\n",
-    "    print(\"  - Permet les paiements en devises (IOU) sur le XRPL\")\n",
-    "    print(\"  - Pas de trust line = impossible de recevoir cet IOU\")"
+    "if status == \"tesSUCCESS\":\n",
+    "    print(\"\\n-> Trust line creee sur le ledger. Bob peut maintenant recevoir des EUR d'Alice.\")\n",
+    "    print(\"   Les trust lines sont la base du systeme de credit du XRPL.\")"
    ]
   },
   {
@@ -777,20 +806,20 @@
    "id": "7fa1f570",
    "metadata": {
     "papermill": {
-     "duration": 0.008541,
-     "end_time": "2026-06-03T08:33:29.457847",
+     "duration": 0.003431,
+     "end_time": "2026-08-26T12:43:44.685338",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.449306",
+     "start_time": "2026-08-26T12:43:44.681907",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Interpretation : Trust Lines et système de credit\n",
+    "### Interpretation : Trust Lines et systeme de credit\n",
     "\n",
-    "**Résultat obtenu** : La Trust Line créée par Bob envers Alice (limite 1000 EUR) etablit un lien bilateral de confiance, base du système IOU du XRPL.\n",
+    "**Resultat obtenu** : la Trust Line de Bob vers Alice (limite 1000 EUR) est **reellement inscrite au ledger** - le hash et le statut `tesSUCCESS` ci-dessus proviennent de la transaction Testnet validee.\n",
     "\n",
-    "| Propriete | Valeur | Rôle |\n",
+    "| Propriete | Valeur | Role |\n",
     "|-----------|--------|------|\n",
     "| Compte | Bob | Celui qui accorde sa confiance |\n",
     "| Emetteur | Alice | Celui qui peut emettre l'IOU |\n",
@@ -801,7 +830,7 @@
     "- Sans Trust Line, il est **impossible** de recevoir un IOU d'un emetteur donne\n",
     "- La limite protege Bob : Alice ne peut pas lui envoyer plus de 1000 EUR sans son consentement\n",
     "- Les Trust Lines sont bilaterales : Bob autorise Alice, mais Alice doit aussi autoriser Bob pour un flux bidirectionnel\n",
-    "- Ce mécanisme remplace les smart contracts ERC-20 d'Ethereum : pas de code a deployer pour créer un token"
+    "- Ce mecanisme remplace les smart contracts ERC-20 d'Ethereum : pas de code a deployer pour creer un token\n"
    ]
   },
   {
@@ -809,10 +838,10 @@
    "id": "fdsg6uhk6w",
    "metadata": {
     "papermill": {
-     "duration": 0.014874,
-     "end_time": "2026-06-03T08:33:29.486195",
+     "duration": 0.003291,
+     "end_time": "2026-08-26T12:43:44.692185",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.471321",
+     "start_time": "2026-08-26T12:43:44.688894",
      "status": "completed"
     },
     "tags": []
@@ -827,16 +856,16 @@
    "id": "tx-offer-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:29.525697Z",
-     "iopub.status.busy": "2026-06-03T08:33:29.525356Z",
-     "iopub.status.idle": "2026-06-03T08:33:29.537409Z",
-     "shell.execute_reply": "2026-06-03T08:33:29.535791Z"
+     "iopub.execute_input": "2026-08-26T12:43:44.700841Z",
+     "iopub.status.busy": "2026-08-26T12:43:44.700496Z",
+     "iopub.status.idle": "2026-08-26T12:43:54.734522Z",
+     "shell.execute_reply": "2026-08-26T12:43:54.734036Z"
     },
     "papermill": {
-     "duration": 0.027976,
-     "end_time": "2026-06-03T08:33:29.539316",
+     "duration": 10.039239,
+     "end_time": "2026-08-26T12:43:54.735281",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.511340",
+     "start_time": "2026-08-26T12:43:44.696042",
      "status": "completed"
     },
     "tags": []
@@ -846,62 +875,64 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur offer : Wallets non disponibles\n",
+      "CREATION D'UN OFFER (DEX INTEGRE)\n",
+      "============================================================\n",
+      "Le XRPL possede un DEX (Decentralized Exchange) natif.\n",
+      "Pas besoin de smart contract comme Uniswap sur Ethereum.\n",
       "\n",
-      "Architecture du DEX XRPL :\n",
-      "  - Carnet d'ordres on-chain (order book)\n",
-      "  - Matching automatique lors de la soumission\n",
-      "  - Auto-bridging via XRP (EUR->XRP->USD)\n",
-      "  - Pas de frais de gas supplementaires\n"
+      "Alice propose :\n",
+      "  Vend  : 45 EUR (IOU)\n",
+      "  Recoit: 50 XRP\n",
+      "  Taux  : 1 EUR = 1.11 XRP\n",
+      "\n",
+      "Soumission en cours...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Hash   : B5F36C3F9BC240F4D0DF063059CD91AD62C404A7AF84A58472CCC275A5E793B6\n",
+      "  Statut : tesSUCCESS\n",
+      "\n",
+      "-> Offer placee sur le carnet d'ordres du XRPL\n",
+      "   Elle sera executee automatiquement si un offer correspondant apparait.\n"
      ]
     }
    ],
    "source": [
-    "# Creation d'un Offer sur le DEX integre\n",
+    "# Creation d'un Offer sur le DEX integre - transaction reelle\n",
     "from xrpl.models.transactions import OfferCreate\n",
-    "from xrpl.models.amounts import IssuedCurrencyAmount\n",
-    "from xrpl.utils import xrp_to_drops\n",
     "\n",
-    "try:\n",
-    "    if wallet_1 is None or client is None:\n",
-    "        raise ConnectionError(\"Wallets non disponibles\")\n",
+    "# Alice propose de vendre 50 XRP contre 45 EUR\n",
+    "offer_tx = OfferCreate(\n",
+    "    account=wallet_1.address,\n",
+    "    taker_pays=xrp_to_drops(50),      # Ce que l'acheteur paie : 50 XRP\n",
+    "    taker_gets=IssuedCurrencyAmount(   # Ce que l'acheteur recoit : 45 EUR\n",
+    "        currency=\"EUR\",\n",
+    "        issuer=wallet_1.address,\n",
+    "        value=\"45\",\n",
+    "    ),\n",
+    ")\n",
     "\n",
-    "    # Alice propose de vendre 50 XRP contre 45 EUR\n",
-    "    offer_tx = OfferCreate(\n",
-    "        account=wallet_1.address,\n",
-    "        taker_pays=xrp_to_drops(50),      # Ce que l'acheteur paie : 50 XRP\n",
-    "        taker_gets=IssuedCurrencyAmount(   # Ce que l'acheteur recoit : 45 EUR\n",
-    "            currency=\"EUR\",\n",
-    "            issuer=wallet_1.address,\n",
-    "            value=\"45\",\n",
-    "        ),\n",
-    "    )\n",
+    "print(\"CREATION D'UN OFFER (DEX INTEGRE)\")\n",
+    "print(\"=\" * 60)\n",
+    "print(\"Le XRPL possede un DEX (Decentralized Exchange) natif.\")\n",
+    "print(\"Pas besoin de smart contract comme Uniswap sur Ethereum.\\n\")\n",
+    "print(\"Alice propose :\")\n",
+    "print(\"  Vend  : 45 EUR (IOU)\")\n",
+    "print(\"  Recoit: 50 XRP\")\n",
+    "print(\"  Taux  : 1 EUR = 1.11 XRP\\n\")\n",
+    "print(\"Soumission en cours...\")\n",
     "\n",
-    "    print(\"CREATION D'UN OFFER (DEX INTEGRE)\")\n",
-    "    print(\"=\" * 60)\n",
-    "    print(\"Le XRPL possede un DEX (Decentralized Exchange) natif.\")\n",
-    "    print(\"Pas besoin de smart contract comme Uniswap sur Ethereum.\\n\")\n",
-    "    print(f\"Alice propose :\")\n",
-    "    print(f\"  Vend  : 45 EUR (IOU)\")\n",
-    "    print(f\"  Recoit: 50 XRP\")\n",
-    "    print(f\"  Taux  : 1 EUR = 1.11 XRP\\n\")\n",
-    "    print(f\"Soumission en cours...\")\n",
+    "response = await submit_and_wait_async(offer_tx, client, wallet_1)\n",
+    "status = response.result.get(\"meta\", {}).get(\"TransactionResult\", \"inconnu\")\n",
+    "print(f\"  Hash   : {response.result.get('hash', 'inconnu')}\")\n",
+    "print(f\"  Statut : {status}\")\n",
     "\n",
-    "    response = submit_and_wait(offer_tx, client, wallet_1)\n",
-    "    status = response.result.get(\"meta\", {}).get(\"TransactionResult\", \"inconnu\")\n",
-    "    print(f\"  Statut : {status}\")\n",
-    "\n",
-    "    if status == \"tesSUCCESS\":\n",
-    "        print(\"\\n-> Offer placee sur le carnet d'ordres du XRPL\")\n",
-    "        print(\"   Elle sera executee automatiquement si un offer correspondant apparait.\")\n",
-    "\n",
-    "except Exception as e:\n",
-    "    print(f\"Erreur offer : {e}\")\n",
-    "    print(\"\\nArchitecture du DEX XRPL :\")\n",
-    "    print(\"  - Carnet d'ordres on-chain (order book)\")\n",
-    "    print(\"  - Matching automatique lors de la soumission\")\n",
-    "    print(\"  - Auto-bridging via XRP (EUR->XRP->USD)\")\n",
-    "    print(\"  - Pas de frais de gas supplementaires\")"
+    "if status == \"tesSUCCESS\":\n",
+    "    print(\"\\n-> Offer placee sur le carnet d'ordres du XRPL\")\n",
+    "    print(\"   Elle sera executee automatiquement si un offer correspondant apparait.\")"
    ]
   },
   {
@@ -909,10 +940,10 @@
    "id": "f223db30",
    "metadata": {
     "papermill": {
-     "duration": 0.012268,
-     "end_time": "2026-06-03T08:33:29.565908",
+     "duration": 0.003141,
+     "end_time": "2026-08-26T12:43:54.741753",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.553640",
+     "start_time": "2026-08-26T12:43:54.738612",
      "status": "completed"
     },
     "tags": []
@@ -920,16 +951,16 @@
    "source": [
     "### Interpretation : DEX integre au protocole\n",
     "\n",
-    "**Résultat obtenu** : L'offre de vente de 45 EUR contre 50 XRP illustre le fonctionnement du carnet d'ordres natif du XRPL.\n",
+    "**Resultat obtenu** : l'offre de vente de 45 EUR contre 50 XRP est **reellement placee sur le carnet d'ordres Testnet** (hash et `tesSUCCESS` ci-dessus). Comme aucun ordre correspondant n'existe, elle reste en attente - c'est le comportement attendu d'un carnet d'ordres.\n",
     "\n",
-    "| Élément | Valeur | Explication |\n",
+    "| Element | Valeur | Explication |\n",
     "|---------|--------|-------------|\n",
     "| `taker_pays` | 50 XRP | Ce que l'acheteur paie |\n",
     "| `taker_gets` | 45 EUR (IOU) | Ce que l'acheteur recoit |\n",
     "| Taux implicite | 1 EUR = 1.11 XRP | Ratio `taker_pays / taker_gets` |\n",
     "| Matching | Automatique | Le protocole execute si un offer inverse existe |\n",
     "\n",
-    "**Note technique** : L'**auto-bridging** est une fonctionnalite unique du XRPL. Si Alice veut vendre des EUR contre des USD et qu'un chemin optimal passe par XRP, le protocole effectue automatiquement la conversion EUR -> XRP -> USD sans intervention de l'utilisateur."
+    "**Note technique** : L'**auto-bridging** est une fonctionnalite unique du XRPL. Si Alice veut vendre des EUR contre des USD et qu'un chemin optimal passe par XRP, le protocole effectue automatiquement la conversion EUR -> XRP -> USD sans intervention de l'utilisateur.\"\n"
    ]
   },
   {
@@ -937,10 +968,10 @@
    "id": "tx-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.017038,
-     "end_time": "2026-06-03T08:33:29.602906",
+     "duration": 0.003051,
+     "end_time": "2026-08-26T12:43:54.747894",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.585868",
+     "start_time": "2026-08-26T12:43:54.744843",
      "status": "completed"
     },
     "tags": []
@@ -969,10 +1000,10 @@
    "id": "3e980446",
    "metadata": {
     "papermill": {
-     "duration": 0.009339,
-     "end_time": "2026-06-03T08:33:29.625571",
+     "duration": 0.003046,
+     "end_time": "2026-08-26T12:43:54.754127",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.616232",
+     "start_time": "2026-08-26T12:43:54.751081",
      "status": "completed"
     },
     "tags": []
@@ -1009,16 +1040,16 @@
    "id": "7a67ecd7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:29.640729Z",
-     "iopub.status.busy": "2026-06-03T08:33:29.640476Z",
-     "iopub.status.idle": "2026-06-03T08:33:29.646952Z",
-     "shell.execute_reply": "2026-06-03T08:33:29.646078Z"
+     "iopub.execute_input": "2026-08-26T12:43:54.761310Z",
+     "iopub.status.busy": "2026-08-26T12:43:54.761111Z",
+     "iopub.status.idle": "2026-08-26T12:43:54.765312Z",
+     "shell.execute_reply": "2026-08-26T12:43:54.764824Z"
     },
     "papermill": {
-     "duration": 0.014956,
-     "end_time": "2026-06-03T08:33:29.647815",
+     "duration": 0.009052,
+     "end_time": "2026-08-26T12:43:54.766288",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.632859",
+     "start_time": "2026-08-26T12:43:54.757236",
      "status": "completed"
     },
     "tags": []
@@ -1082,10 +1113,10 @@
    "id": "channel-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.006882,
-     "end_time": "2026-06-03T08:33:29.661323",
+     "duration": 0.00319,
+     "end_time": "2026-08-26T12:43:54.772813",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.654441",
+     "start_time": "2026-08-26T12:43:54.769623",
      "status": "completed"
     },
     "tags": []
@@ -1122,16 +1153,16 @@
    "id": "channel-simulation-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:29.677908Z",
-     "iopub.status.busy": "2026-06-03T08:33:29.677603Z",
-     "iopub.status.idle": "2026-06-03T08:33:29.687625Z",
-     "shell.execute_reply": "2026-06-03T08:33:29.686337Z"
+     "iopub.execute_input": "2026-08-26T12:43:54.779993Z",
+     "iopub.status.busy": "2026-08-26T12:43:54.779717Z",
+     "iopub.status.idle": "2026-08-26T12:43:54.785407Z",
+     "shell.execute_reply": "2026-08-26T12:43:54.784760Z"
     },
     "papermill": {
-     "duration": 0.018774,
-     "end_time": "2026-06-03T08:33:29.688440",
+     "duration": 0.010282,
+     "end_time": "2026-08-26T12:43:54.786136",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.669666",
+     "start_time": "2026-08-26T12:43:54.775854",
      "status": "completed"
     },
     "tags": []
@@ -1239,10 +1270,10 @@
    "id": "a3efb56d",
    "metadata": {
     "papermill": {
-     "duration": 0.00885,
-     "end_time": "2026-06-03T08:33:29.706277",
+     "duration": 0.00317,
+     "end_time": "2026-08-26T12:43:54.792621",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.697427",
+     "start_time": "2026-08-26T12:43:54.789451",
      "status": "completed"
     },
     "tags": []
@@ -1269,10 +1300,10 @@
    "id": "4j194fc48ue",
    "metadata": {
     "papermill": {
-     "duration": 0.00663,
-     "end_time": "2026-06-03T08:33:29.721543",
+     "duration": 0.003524,
+     "end_time": "2026-08-26T12:43:54.799195",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.714913",
+     "start_time": "2026-08-26T12:43:54.795671",
      "status": "completed"
     },
     "tags": []
@@ -1287,16 +1318,16 @@
    "id": "channel-real-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:29.740720Z",
-     "iopub.status.busy": "2026-06-03T08:33:29.740445Z",
-     "iopub.status.idle": "2026-06-03T08:33:29.749763Z",
-     "shell.execute_reply": "2026-06-03T08:33:29.748825Z"
+     "iopub.execute_input": "2026-08-26T12:43:54.806305Z",
+     "iopub.status.busy": "2026-08-26T12:43:54.806118Z",
+     "iopub.status.idle": "2026-08-26T12:44:01.982523Z",
+     "shell.execute_reply": "2026-08-26T12:44:01.981884Z"
     },
     "papermill": {
-     "duration": 0.02079,
-     "end_time": "2026-06-03T08:33:29.750503",
+     "duration": 7.180996,
+     "end_time": "2026-08-26T12:44:01.983306",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.729713",
+     "start_time": "2026-08-26T12:43:54.802310",
      "status": "completed"
     },
     "tags": []
@@ -1306,65 +1337,67 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur payment channel : Wallets non disponibles\n",
+      "OUVERTURE D'UN PAYMENT CHANNEL REEL\n",
+      "============================================================\n",
+      "  De      : rsV9uq1DVWrHWbx66jhkeyxa5jKfgmErg9\n",
+      "  Vers    : rnAwyYV3R7CShvr4hVuBwHSurRbtWpzRSX\n",
+      "  Reserve : 20 XRP\n",
+      "  Delai   : 3600 secondes\n",
       "\n",
-      "Le Payment Channel XRPL permet :\n",
-      "  - Micropaiements instantanes off-chain\n",
-      "  - Un seul cout de transaction pour ouvrir + fermer\n",
-      "  - Streaming de paiements (IoT, API, contenu)\n"
+      "Soumission en cours...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Hash   : 561A526FB4B1B0E5CCB956CB6E5F560B117A43D7776AD4D5F0AAA4528FD392F4\n",
+      "  Statut : tesSUCCESS\n",
+      "  Channel ID : 8F9AACFF78829EA1552E00458707AB983C85039027B27B16492CF573287A1419\n",
+      "\n",
+      "-> Canal ouvert sur le ledger. Les claims off-chain peuvent commencer.\n"
      ]
     }
    ],
    "source": [
-    "# Utilisation reelle via xrpl-py (ouverture de canal)\n",
+    "# Ouverture d'un Payment Channel reelle - transaction Testnet\n",
     "from xrpl.models.transactions import PaymentChannelCreate\n",
-    "from xrpl.utils import xrp_to_drops\n",
     "\n",
-    "try:\n",
-    "    if wallet_1 is None or wallet_2 is None or client is None:\n",
-    "        raise ConnectionError(\"Wallets non disponibles\")\n",
+    "# Ouverture d'un canal de 20 XRP\n",
+    "channel_tx = PaymentChannelCreate(\n",
+    "    account=wallet_1.address,\n",
+    "    destination=wallet_2.address,\n",
+    "    amount=xrp_to_drops(20),\n",
+    "    settle_delay=3600,           # 1 heure de delai de reglement\n",
+    "    public_key=wallet_1.public_key,\n",
+    ")\n",
     "\n",
-    "    # Ouverture d'un canal de 20 XRP\n",
-    "    channel_tx = PaymentChannelCreate(\n",
-    "        account=wallet_1.address,\n",
-    "        destination=wallet_2.address,\n",
-    "        amount=xrp_to_drops(20),\n",
-    "        settle_delay=3600,           # 1 heure de delai de reglement\n",
-    "        public_key=wallet_1.public_key,\n",
-    "    )\n",
+    "print(\"OUVERTURE D'UN PAYMENT CHANNEL REEL\")\n",
+    "print(\"=\" * 60)\n",
+    "print(f\"  De      : {wallet_1.address}\")\n",
+    "print(f\"  Vers    : {wallet_2.address}\")\n",
+    "print(f\"  Reserve : 20 XRP\")\n",
+    "print(f\"  Delai   : 3600 secondes\\n\")\n",
+    "print(\"Soumission en cours...\")\n",
     "\n",
-    "    print(\"OUVERTURE D'UN PAYMENT CHANNEL REEL\")\n",
-    "    print(\"=\" * 60)\n",
-    "    print(f\"  De      : {wallet_1.address}\")\n",
-    "    print(f\"  Vers    : {wallet_2.address}\")\n",
-    "    print(f\"  Reserve : 20 XRP\")\n",
-    "    print(f\"  Delai   : 3600 secondes\\n\")\n",
-    "    print(\"Soumission en cours...\")\n",
+    "response = await submit_and_wait_async(channel_tx, client, wallet_1)\n",
+    "status = response.result.get(\"meta\", {}).get(\"TransactionResult\", \"inconnu\")\n",
+    "print(f\"  Hash   : {response.result.get('hash', 'inconnu')}\")\n",
+    "print(f\"  Statut : {status}\")\n",
     "\n",
-    "    response = submit_and_wait(channel_tx, client, wallet_1)\n",
-    "    status = response.result.get(\"meta\", {}).get(\"TransactionResult\", \"inconnu\")\n",
-    "    print(f\"  Statut : {status}\")\n",
-    "\n",
-    "    if status == \"tesSUCCESS\":\n",
-    "        # Extraire le channel ID des metadonnees\n",
-    "        meta = response.result.get(\"meta\", {})\n",
-    "        affected = meta.get(\"AffectedNodes\", [])\n",
-    "        channel_id = None\n",
-    "        for node in affected:\n",
-    "            created = node.get(\"CreatedNode\", {})\n",
-    "            if created.get(\"LedgerEntryType\") == \"PayChannel\":\n",
-    "                channel_id = created.get(\"LedgerIndex\")\n",
-    "                break\n",
-    "        if channel_id:\n",
-    "            print(f\"  Channel ID : {channel_id}\")\n",
-    "        print(\"\\n-> Canal ouvert. Les claims off-chain peuvent commencer.\")\n",
-    "\n",
-    "except Exception as e:\n",
-    "    print(f\"Erreur payment channel : {e}\")\n",
-    "    print(\"\\nLe Payment Channel XRPL permet :\")\n",
-    "    print(\"  - Micropaiements instantanes off-chain\")\n",
-    "    print(\"  - Un seul cout de transaction pour ouvrir + fermer\")\n",
-    "    print(\"  - Streaming de paiements (IoT, API, contenu)\")"
+    "if status == \"tesSUCCESS\":\n",
+    "    # Extraire le channel ID des metadonnees\n",
+    "    meta = response.result.get(\"meta\", {})\n",
+    "    affected = meta.get(\"AffectedNodes\", [])\n",
+    "    channel_id = None\n",
+    "    for node in affected:\n",
+    "        created = node.get(\"CreatedNode\", {})\n",
+    "        if created.get(\"LedgerEntryType\") == \"PayChannel\":\n",
+    "            channel_id = created.get(\"LedgerIndex\")\n",
+    "            break\n",
+    "    if channel_id:\n",
+    "        print(f\"  Channel ID : {channel_id}\")\n",
+    "    print(\"\\n-> Canal ouvert sur le ledger. Les claims off-chain peuvent commencer.\")"
    ]
   },
   {
@@ -1372,10 +1405,10 @@
    "id": "8cc19a59",
    "metadata": {
     "papermill": {
-     "duration": 0.010267,
-     "end_time": "2026-06-03T08:33:29.770769",
+     "duration": 0.003401,
+     "end_time": "2026-08-26T12:44:01.990341",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.760502",
+     "start_time": "2026-08-26T12:44:01.986940",
      "status": "completed"
     },
     "tags": []
@@ -1383,15 +1416,15 @@
    "source": [
     "### Interpretation : ouverture d'un Payment Channel reel\n",
     "\n",
-    "**Résultat obtenu** : En mode simule (sans connexion Testnet), le code affiche les paramètres d'ouverture du canal. En production, on obtiendrait un `channel_id` unique.\n",
+    "**Resultat obtenu** : le canal est **reellement ouvert sur le Testnet** - le `channel_id` ci-dessus est l'identifiant du ledger entry `PayChannel` cree par la transaction (extrait des `AffectedNodes` de la reponse validee).\n",
     "\n",
-    "| Paramètre | Valeur | Signification |\n",
+    "| Parametre | Valeur | Signification |\n",
     "|-----------|--------|---------------|\n",
     "| `amount` | 20 XRP | Reserve bloquee on-chain |\n",
-    "| `settle_delay` | 3600s | Delai de contestation après fermeture |\n",
+    "| `settle_delay` | 3600s | Delai de contestation apres fermeture |\n",
     "| `public_key` | cle Alice | Authentification des claims |\n",
     "\n",
-    "**Note technique** : Le `settle_delay` est crucial pour la securite. Si Alice veut fermer le canal, elle doit attendre 3600 secondes pendant lesquelles Bob peut soumettre son dernier claim. Cela empeche Alice de fermer le canal brutalement avant que Bob n'ait recu ses fonds."
+    "**Note technique** : Le `settle_delay` est crucial pour la securite. Si Alice veut fermer le canal, elle doit attendre 3600 secondes pendant lesquelles Bob peut soumettre son dernier claim. Cela empeche Alice de fermer le canal brutalement avant que Bob n'ait recu ses fonds.\"\n"
    ]
   },
   {
@@ -1399,10 +1432,10 @@
    "id": "channel-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.010366,
-     "end_time": "2026-06-03T08:33:29.790838",
+     "duration": 0.003442,
+     "end_time": "2026-08-26T12:44:01.997270",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.780472",
+     "start_time": "2026-08-26T12:44:01.993828",
      "status": "completed"
     },
     "tags": []
@@ -1429,10 +1462,10 @@
    "id": "57b6889d",
    "metadata": {
     "papermill": {
-     "duration": 0.007752,
-     "end_time": "2026-06-03T08:33:29.815825",
+     "duration": 0.003838,
+     "end_time": "2026-08-26T12:44:02.004618",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.808073",
+     "start_time": "2026-08-26T12:44:02.000780",
      "status": "completed"
     },
     "tags": []
@@ -1469,16 +1502,16 @@
    "id": "84185969",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:29.837835Z",
-     "iopub.status.busy": "2026-06-03T08:33:29.837541Z",
-     "iopub.status.idle": "2026-06-03T08:33:29.846435Z",
-     "shell.execute_reply": "2026-06-03T08:33:29.845181Z"
+     "iopub.execute_input": "2026-08-26T12:44:02.012079Z",
+     "iopub.status.busy": "2026-08-26T12:44:02.011856Z",
+     "iopub.status.idle": "2026-08-26T12:44:02.016672Z",
+     "shell.execute_reply": "2026-08-26T12:44:02.016211Z"
     },
     "papermill": {
-     "duration": 0.02368,
-     "end_time": "2026-06-03T08:33:29.847368",
+     "duration": 0.009518,
+     "end_time": "2026-08-26T12:44:02.017421",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.823688",
+     "start_time": "2026-08-26T12:44:02.007903",
      "status": "completed"
     },
     "tags": []
@@ -1549,10 +1582,10 @@
    "id": "hooks-section",
    "metadata": {
     "papermill": {
-     "duration": 0.022956,
-     "end_time": "2026-06-03T08:33:29.881325",
+     "duration": 0.003607,
+     "end_time": "2026-08-26T12:44:02.024742",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.858369",
+     "start_time": "2026-08-26T12:44:02.021135",
      "status": "completed"
     },
     "tags": []
@@ -1635,16 +1668,16 @@
    "id": "hooks-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:29.976035Z",
-     "iopub.status.busy": "2026-06-03T08:33:29.975400Z",
-     "iopub.status.idle": "2026-06-03T08:33:29.992525Z",
-     "shell.execute_reply": "2026-06-03T08:33:29.989542Z"
+     "iopub.execute_input": "2026-08-26T12:44:02.032325Z",
+     "iopub.status.busy": "2026-08-26T12:44:02.032130Z",
+     "iopub.status.idle": "2026-08-26T12:44:02.037715Z",
+     "shell.execute_reply": "2026-08-26T12:44:02.036945Z"
     },
     "papermill": {
-     "duration": 0.068978,
-     "end_time": "2026-06-03T08:33:29.995704",
+     "duration": 0.01047,
+     "end_time": "2026-08-26T12:44:02.038653",
      "exception": false,
-     "start_time": "2026-06-03T08:33:29.926726",
+     "start_time": "2026-08-26T12:44:02.028183",
      "status": "completed"
     },
     "tags": []
@@ -1726,10 +1759,10 @@
    "id": "877bd928",
    "metadata": {
     "papermill": {
-     "duration": 0.024612,
-     "end_time": "2026-06-03T08:33:30.048256",
+     "duration": 0.003485,
+     "end_time": "2026-08-26T12:44:02.045582",
      "exception": false,
-     "start_time": "2026-06-03T08:33:30.023644",
+     "start_time": "2026-08-26T12:44:02.042097",
      "status": "completed"
     },
     "tags": []
@@ -1757,10 +1790,10 @@
    "id": "hooks-comparison",
    "metadata": {
     "papermill": {
-     "duration": 0.017171,
-     "end_time": "2026-06-03T08:33:30.085481",
+     "duration": 0.003277,
+     "end_time": "2026-08-26T12:44:02.052495",
      "exception": false,
-     "start_time": "2026-06-03T08:33:30.068310",
+     "start_time": "2026-08-26T12:44:02.049218",
      "status": "completed"
     },
     "tags": []
@@ -1786,10 +1819,10 @@
    "id": "exercise-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.012943,
-     "end_time": "2026-06-03T08:33:30.116482",
+     "duration": 0.003268,
+     "end_time": "2026-08-26T12:44:02.059066",
      "exception": false,
-     "start_time": "2026-06-03T08:33:30.103539",
+     "start_time": "2026-08-26T12:44:02.055798",
      "status": "completed"
     },
     "tags": []
@@ -1816,10 +1849,10 @@
    "id": "077a034e",
    "metadata": {
     "papermill": {
-     "duration": 0.02104,
-     "end_time": "2026-06-03T08:33:30.158792",
+     "duration": 0.003351,
+     "end_time": "2026-08-26T12:44:02.065753",
      "exception": false,
-     "start_time": "2026-06-03T08:33:30.137752",
+     "start_time": "2026-08-26T12:44:02.062402",
      "status": "completed"
     },
     "tags": []
@@ -1836,16 +1869,16 @@
    "id": "exercise-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T08:33:30.212453Z",
-     "iopub.status.busy": "2026-06-03T08:33:30.210624Z",
-     "iopub.status.idle": "2026-06-03T08:33:30.240817Z",
-     "shell.execute_reply": "2026-06-03T08:33:30.235835Z"
+     "iopub.execute_input": "2026-08-26T12:44:02.074266Z",
+     "iopub.status.busy": "2026-08-26T12:44:02.073882Z",
+     "iopub.status.idle": "2026-08-26T12:44:02.077798Z",
+     "shell.execute_reply": "2026-08-26T12:44:02.077350Z"
     },
     "papermill": {
-     "duration": 0.071186,
-     "end_time": "2026-06-03T08:33:30.247008",
+     "duration": 0.009178,
+     "end_time": "2026-08-26T12:44:02.078618",
      "exception": false,
-     "start_time": "2026-06-03T08:33:30.175822",
+     "start_time": "2026-08-26T12:44:02.069440",
      "status": "completed"
     },
     "tags": []
@@ -1863,12 +1896,13 @@
     "# Exercice : Paiement cross-currency via trust lines et DEX\n",
     "\n",
     "import xrpl\n",
-    "from xrpl.clients import JsonRpcClient\n",
-    "from xrpl.wallet import generate_faucet_wallet\n",
+    "from xrpl.asyncio.clients import AsyncJsonRpcClient\n",
+    "from xrpl.asyncio.wallet import generate_faucet_wallet\n",
+    "from xrpl.asyncio.transaction import submit_and_wait\n",
     "from xrpl.models.transactions import TrustSet, Payment, OfferCreate\n",
     "from xrpl.models.amounts import IssuedCurrencyAmount\n",
-    "from xrpl.transaction import submit_and_wait\n",
     "from xrpl.utils import xrp_to_drops\n",
+    "# API asyncio : dans ce kernel Jupyter, chaque appel reseau se fait avec `await`.\n",
     "\n",
     "\n",
     "def cross_currency_scenario(client):\n",
@@ -1899,10 +1933,10 @@
    "id": "8b8a1559",
    "metadata": {
     "papermill": {
-     "duration": 0.05729,
-     "end_time": "2026-06-03T08:33:30.346764",
+     "duration": 0.003401,
+     "end_time": "2026-08-26T12:44:02.086436",
      "exception": false,
-     "start_time": "2026-06-03T08:33:30.289474",
+     "start_time": "2026-08-26T12:44:02.083035",
      "status": "completed"
     },
     "tags": []
@@ -1926,10 +1960,10 @@
    "id": "summary",
    "metadata": {
     "papermill": {
-     "duration": 0.068086,
-     "end_time": "2026-06-03T08:33:30.477778",
+     "duration": 0.003411,
+     "end_time": "2026-08-26T12:44:02.093537",
      "exception": false,
-     "start_time": "2026-06-03T08:33:30.409692",
+     "start_time": "2026-08-26T12:44:02.090126",
      "status": "completed"
     },
     "tags": []
@@ -1975,10 +2009,10 @@
    "id": "a14c98ef",
    "metadata": {
     "papermill": {
-     "duration": 0.024914,
-     "end_time": "2026-06-03T08:33:30.536027",
+     "duration": 0.003528,
+     "end_time": "2026-08-26T12:44:02.100510",
      "exception": false,
-     "start_time": "2026-06-03T08:33:30.511113",
+     "start_time": "2026-08-26T12:44:02.096982",
      "status": "completed"
     },
     "tags": []
@@ -1998,10 +2032,10 @@
    "id": "135011b6",
    "metadata": {
     "papermill": {
-     "duration": 0.014255,
-     "end_time": "2026-06-03T08:33:30.564857",
+     "duration": 0.003452,
+     "end_time": "2026-08-26T12:44:02.107452",
      "exception": false,
-     "start_time": "2026-06-03T08:33:30.550602",
+     "start_time": "2026-08-26T12:44:02.104000",
      "status": "completed"
     },
     "tags": []
@@ -2015,9 +2049,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (smartcontracts)",
    "language": "python",
-   "name": "python3"
+   "name": "smartcontracts"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2029,18 +2063,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.22581,
-   "end_time": "2026-06-03T08:33:30.970500",
+   "duration": 67.808415,
+   "end_time": "2026-08-26T12:44:02.349994",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\05-Alternative-Chains\\SC-19-Ripple-XRP.ipynb",
-   "output_path": "MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\05-Alternative-Chains\\SC-19-Ripple-XRP.ipynb",
+   "input_path": "SC-19-Ripple-XRP.ipynb",
+   "output_path": "sc19_reexec.ipynb",
    "parameters": {},
-   "start_time": "2026-06-03T08:33:25.744690",
+   "start_time": "2026-08-26T12:42:54.541579",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-python #13116

## Summary

`SC-19-Ripple-XRP.ipynb` — toutes les interactions Testnet basculaient en **sorties simulées** : le client synchrone `JsonRpcClient` encapsule chaque requête dans `asyncio.run()`, interdit dans la boucle Jupyter (`asyncio.run() cannot be called from a running event loop` — visible dans les outputs committés), et la cascade try/except maquillait chaque échec en « données fictives » tout en imprimant `wallet_1.seed` au passage. Cette PR branche l'**API asyncio officielle** de `xrpl-py` et exécute **réellement** chaque interaction :

| Interaction | Preuve committée (run du 2026-08-26) |
|---|---|
| Lecture ledger validé | `#20235735`, horodatage Testnet |
| Faucet ×2 (Alice, Bob) | adresses `rngbWER5…`/`rweLS2…`, soldes 100 XRP vérifiés en direct |
| Paiement 25 XRP | hash `4E1FF314…`, `tesSUCCESS`, ledger `20235798`, frais **10 drops mesurés** (solde 100 → 74.999990 XRP) |
| Trust Line EUR 1000 | hash réel, `tesSUCCESS` |
| Offer DEX 45 EUR ↔ 50 XRP | hash réel, `tesSUCCESS` (ordre reposant sur le carnet, attendu) |
| Payment Channel 20 XRP | hash réel, `tesSUCCESS`, **channel ID extrait des AffectedNodes** |

## Points clés

1. **Sécurité d'abord** : `generate_faucet_wallet(client, debug=False)` — `debug=True` imprime la seed ; la cellule faucet affiche « jamais affichée (secret de signature) ». Scan post-exécution : **aucun pattern de seed** (`s[A-Za-z0-9]{20,}`) dans aucun output committé.
2. **Frais mesurés, pas décrétés** : le champ `Fee` de la réponse `submit_and_wait` ne se lit pas au niveau attendu (imprimait 0) ; le notebook mesure le frais réel par **différence de solde avant/après** (100 000 000 − 25 000 000 − solde = 10 drops) — un chiffre dérivé du réseau, vérifiable.
3. **Kernel reproductible** : kernelspec → `smartcontracts` (env documenté où `xrpl-py` est importable), prérequis mis à jour en tête de notebook avec l'avertissement sync/async.
4. **Interprétations réalignées sur les outputs réels** : plus aucun « En mode simule… » pour des transactions qui ont maintenant lieu ; leçon pédagogique conservée sur le piège asyncio (défaut silencieux typique : bascule simulation sans erreur visible).
5. **Stub d'exercice aligné** : imports de l'exercice cross-currency passés à l'API asyncio (le corps reste `TODO` étudiant, règle C.1 respectée — 0 `raise NotImplementedError`).

## Critères d'acceptance — vérifiés

- [x] Kernelspec `smartcontracts` + dépendance documentée (cellule 0 + cellule 5 imprime la version xrpl-py et la charge async).
- [x] Lecture Testnet réussie du ledger courant dans les outputs committés.
- [x] ≥1 transaction avec hash réel + `tesSUCCESS` + ledger index (5 transactions : payment, trustset, offer, channel + lecture).
- [x] Aucune seed/clé privée/préfixe de secret dans outputs ou source (scan regex post-exécution).
- [x] Branches simulées distinctes : la démonstration conceptuelle des claims (cellule 26) reste explicitement « SIMULATION CONCEPTUELLE » — qualifiée, jamais « résultat obtenu ».
- [x] Verdict SOTA : **SOTA-OK** — le vrai outil (xrpl-py 4.5.0, Testnet public) est invoqué ; les sorties committées sont ses vraies sorties.
- [x] Papermill 45/45 cellules, 0 erreur, `execution_count` renseigné partout, aucune sortie hand-editée.

## Exécution

Papermill `--kernel smartcontracts` end-to-end (45/45, ~67 s, 2 runs complets pour itérer sur la mesure des frais). Ratchets : `check_output_failure_text` **0 regressed** ; `check_papermill_ratchet` **BLOCK_MOVED, RC=0**. 1 fichier (+537/−503), catalogue byte-identique à main.

Closes #13049 (le doublon harness #13048 reste à disposition du coordinateur — même constat, non traité séparément)

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
