### PR TITLE
fix(runner,#12704): SSH isolation probe targets directory enumeration, not a machine-specific key file

### DIFF
--- a/scripts/ci/manage_self_hosted_runner.py
+++ b/scripts/ci/manage_self_hosted_runner.py
@@ -599,7 +599,16 @@ $c = ConvertFrom-Json @'
 '@
 $results = @()
 foreach ($path in $c.sensitive) {{
-  try {{ Get-Content -LiteralPath $path -TotalCount 1 -ErrorAction Stop | Out-Null; $status = 'READABLE' }}
+  try {{
+    $item = Get-Item -LiteralPath $path -Force -ErrorAction Stop
+    if ($item.PSIsContainer) {{
+      # Directory probe: enumeration of the directory itself must be denied.
+      $null = @(Get-ChildItem -LiteralPath $path -Force -ErrorAction Stop)
+    }} else {{
+      Get-Content -LiteralPath $path -TotalCount 1 -ErrorAction Stop | Out-Null
+    }}
+    $status = 'READABLE'
+  }}
   catch [System.UnauthorizedAccessException] {{ $status = 'ACCESS_DENIED' }}
   catch {{ $status = 'OTHER_ERROR' }}
   $results += $status

--- a/scripts/ci/self_hosted_runner_profiles.json
+++ b/scripts/ci/self_hosted_runner_profiles.json
@@ -17,7 +17,7 @@
       },
       "sensitive_paths": [
         {"deny": "{repo_root}\\.secrets", "probe": "{repo_root}\\.secrets\\master.env"},
-        {"deny": "{user_profile}\\.ssh", "probe": "{user_profile}\\.ssh\\jsboige_key"},
+        {"deny": "{user_profile}\\.ssh", "probe": "{user_profile}\\.ssh"},
         {"deny": "{appdata}\\GitHub CLI\\hosts.yml", "probe": "{appdata}\\GitHub CLI\\hosts.yml"}
       ]
     },
@@ -37,7 +37,7 @@
       },
       "sensitive_paths": [
         {"deny": "{repo_root}\\.secrets", "probe": "{repo_root}\\.secrets\\master.env"},
-        {"deny": "{user_profile}\\.ssh", "probe": "{user_profile}\\.ssh\\jsboige_key"},
+        {"deny": "{user_profile}\\.ssh", "probe": "{user_profile}\\.ssh"},
         {"deny": "{appdata}\\GitHub CLI\\hosts.yml", "probe": "{appdata}\\GitHub CLI\\hosts.yml"}
       ]
     },
@@ -57,7 +57,7 @@
       },
       "sensitive_paths": [
         {"deny": "{repo_root}\\.secrets", "probe": "{repo_root}\\.secrets\\master.env"},
-        {"deny": "{user_profile}\\.ssh", "probe": "{user_profile}\\.ssh\\jsboige_key"},
+        {"deny": "{user_profile}\\.ssh", "probe": "{user_profile}\\.ssh"},
         {"deny": "{appdata}\\GitHub CLI\\hosts.yml", "probe": "{appdata}\\GitHub CLI\\hosts.yml"}
       ]
     },
@@ -77,7 +77,7 @@
       },
       "sensitive_paths": [
         {"deny": "{repo_root}\\.secrets", "probe": "{repo_root}\\.secrets\\master.env"},
-        {"deny": "{user_profile}\\.ssh", "probe": "{user_profile}\\.ssh\\jsboige_key"},
+        {"deny": "{user_profile}\\.ssh", "probe": "{user_profile}\\.ssh"},
         {"deny": "{appdata}\\GitHub CLI\\hosts.yml", "probe": "{appdata}\\GitHub CLI\\hosts.yml"}
       ]
     }

--- a/scripts/tests/test_manage_self_hosted_runner.py
+++ b/scripts/tests/test_manage_self_hosted_runner.py
@@ -51,7 +51,7 @@ def profile(root: Path, *, digest: str = "a" * 64) -> mod.Profile:
         archive_sha256=digest,
         sensitive_templates=(
             (r"{repo_root}\.secrets", r"{repo_root}\.secrets\master.env"),
-            (r"{user_profile}\.ssh", r"{user_profile}\.ssh\jsboige_key"),
+            (r"{user_profile}\.ssh", r"{user_profile}\.ssh"),
             (r"{appdata}\GitHub CLI\hosts.yml", r"{appdata}\GitHub CLI\hosts.yml"),
         ),
     )


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/slides #13096

See #12704 (runner self-hosted, tranche durété du probe d'isolation).

## Problème

Le profil partagé (`self_hosted_runner_profiles.json`, 4 machines po-2023/2024/2025/2026) épinglait le probe SSH sur `{user_profile}\.ssh\jsboige_key` — un nom de fichier propre à UNE machine. Sur toute machine dont les clés portent d'autres noms :

- le deny ACL est bien posé sur le répertoire `.ssh` (`(OI)(CI)R`) ;
- mais `Get-Content jsboige_key` lève `ItemNotFoundException` → la sonde rend `OTHER_ERROR` (pas `ACCESS_DENIED`) ;
- `verify --apply` refuse → **`register --apply` est bloqué** au moment exact de l'activation UAC.

## Correctif

Le probe cible désormais le répertoire `.ssh` lui-même, et le script de sonde ([manage_self_hosted_runner.py](scripts/ci/manage_self_hosted_runner.py)) branche sur `PSIsContainer` :

- **répertoire** → `Get-ChildItem -Force` : l'énumération du répertoire nié doit être refusée (même invariant, indépendant des noms de fichiers) ;
- **fichier** → `Get-Content -TotalCount 1` (inchangé).

`{repo_root}\.secrets` et `hosts.yml` restent des probes fichiers (cibles garanties par le dépôt/l'outil).

## Validation

- `python -m pytest scripts/tests/test_manage_self_hosted_runner.py -q` → **40 passed** (fixture profil alignée sur le nouveau template).
- Mesuré sur la machine po-2024 : `jsboige_key` existe ici, mais le fix rend le profil utilisable sur les 3 autres machines de la flotte sans connaître leurs noms de clés — c'est la condition pour que la commande d'activation one-shot du coordinateur soit portable.

## Notes pour le review

- Les 9 tests `@requires_windows` ne tournent aujourd'hui nulle part en CI (skippés par #13063, aucun workflow `runs-on: windows|self-hosted`) — dette à recouvrir dès que le runner est actif (#13097).
- Ce fix est un prérequis direct de la commande UAC one-shot de #12704 : le register du runner passe par `verify --apply`.
