### PR TITLE
feat(runner,#12704): workflow_dispatch-only job recouvrant les 9 tests Windows-confinement sur le runner self-hosted

### DIFF
--- a/.github/workflows/windows-self-hosted-tests.yml
+++ b/.github/workflows/windows-self-hosted-tests.yml
@@ -1,0 +1,49 @@
+name: Windows Self-Hosted Tests
+
+# Dispatch-only : ZERO declencheur pull_request/push, donc zero fan-out CI
+# (#13097). La famine rend tout declencheur automatique contre-productif ;
+# ce workflow existe pour etre appele a la demande, au moment ou un runner
+# ephemeral myia-po-*-fast-guards est Idle (voir #12704 / #13097).
+#
+# Cycle de vie : un runner --ephemeral traite AU PLUS UN JOB puis se
+# desenregistre (docs/ci/self-hosted-runners.md, manage_self_hosted_runner.py).
+# Chaque dispatch consomme donc l'enregistrement courant : un dispatch,
+# un job, un runner. Ne pas dispatcher deux fois de suite sans avoir
+# re-enregistre un runner.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Un runner ephemeral ne peut prendre qu'un job a la fois : un second
+# dispatch resterait en file pour toujours (plus de runner apres le 1er job).
+# cancel-in-progress annule la file precedente au lieu de l'empiler.
+concurrency:
+  group: windows-self-hosted-tests
+  cancel-in-progress: true
+
+jobs:
+  windows-confinement-tests:
+    name: Scripts Tests (Windows runner)
+    runs-on: [self-hosted, coursia-fast-guards]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: python -m pip install pytest
+
+      # Les 9 tests @requires_windows (skippes par #13063 : aucun runner
+      # Windows en CI) couvrent la surface de confinement du gestionnaire
+      # de runners : rendu des scripts PowerShell (compte, ACL, teardown),
+      # probes d'isolation, allowlist d'environnement. Ils n'ecrivent rien
+      # sur l'hote : toutes les mutations passent par des callables injectes.
+      - name: Run Windows-confinement tests
+        run: python -m pytest scripts/tests/test_manage_self_hosted_runner.py -v


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/guard #13124

See #12704 (dette de câblage assignée par DM coordinateur, tranche « recouvrir les 9 tests @requires_windows dès que le runner tourne »).

## Résumé

Workflow `Windows Self-Hosted Tests` : un job `workflow_dispatch`-only sur `[self-hosted, coursia-fast-guards]` qui exécute `scripts/tests/test_manage_self_hosted_runner.py` — les 9 tests `@requires_windows` (skippés par #13063 : aucun runner Windows en CI) y tournent enfin. Ils couvrent la surface de confinement du gestionnaire : rendu des scripts PowerShell (compte dédié, ACL deny, teardown), probes d'isolation, allowlist d'environnement — plusieurs sont sécurité-critiques.

## Choix de design (chacun motivé par l'état mesuré du plateau)

| Choix | Pourquoi |
|---|---|
| **`workflow_dispatch` ONLY** (aucun trigger `pull_request`/`push`) | Famine CI #13097 : 389 runs créés/h pour 49 terminés. Ce workflow a un coût fan-out de **zéro** — il n'existe que pour être appelé à la demande, au moment où un runner est Idle. |
| **`runs-on: [self-hosted, coursia-fast-guards]`** | Labels exacts du profil `manage_self_hosted_runner.py` (REQUIRED_LABELS). |
| **`concurrency` + `cancel-in-progress: true`** | Un runner `--ephemeral` traite AU PLUS UN JOB puis se désenregistre (docs/ci/self-hosted-runners.md L140). Un second dispatch resterait en file pour toujours — cancel empile rien. |
| **`timeout-minutes: 15`** | Un job coincé monopoliserait le seul runner (one-shot) sans jamais rendre de verdict — même pathologie que #13097. |
| **setup-python 3.11** | Le compte runner `coursia-runner` n'a pas le python per-user de la session interactive ; setup-python installe dans le tool cache du root runner (ACL du profil : compte runner = full control). |

## Validation

- `yaml.safe_load` : OK (`on: [workflow_dispatch]`, 1 job).
- Commande exacte du workflow relancée localement sur Windows (où les 9 tests tournent) : `python -m pytest scripts/tests/test_manage_self_hosted_runner.py -v` → **40 passed** (9 Windows + 31 platform-neutral).
- Aucune mutation hôte : les tests passent par des callables injectés (`run`, `download`) — le job est sans danger pour le runner.

## Séquençage prévu (rappel DM ai-01)

1. Merge de cette PR (via la file, comme tout le monde — pas de fan-out ajouté).
2. Press UAC one-shot sur po-2024 (commande fournie par DM) → runner Idle.
3. `workflow_dispatch` de ce workflow → le runner consomme le job, prouve le pipeline de bout en bout, exécute les 9 tests, puis se désenregistre.

Le contrôleur de ré-enregistrement (JIT / token broker) reste une décision séparée per la doc — ce workflow n'en dépend pas.
