### PR TITLE
fix(ci,#13135): windows-self-hosted-tests respecte la policy runner (label ephemere + allowlist + baseline test)

### DIFF
--- a/.github/workflows/windows-self-hosted-tests.yml
+++ b/.github/workflows/windows-self-hosted-tests.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   windows-confinement-tests:
     name: Scripts Tests (Windows runner)
-    runs-on: [self-hosted, coursia-fast-guards]
+    runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
     timeout-minutes: 15
 
     steps:

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -33,7 +33,10 @@ REQUIRED_LABELS = {
     "coursia-ephemeral",
     "coursia-fast-guards",
 }
-SELF_HOSTED_WORKFLOW_ALLOWLIST = {"pr-gate-stale-sweep.yml"}
+SELF_HOSTED_WORKFLOW_ALLOWLIST = {
+    "pr-gate-stale-sweep.yml",
+    "windows-self-hosted-tests.yml",
+}
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",
     "ubuntu-24.04",

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -21,14 +21,34 @@ def codes(result: policy.ScanResult) -> set[str]:
     return {item.code for item in result.violations}
 
 
-def test_current_repository_has_explicit_zero_self_hosted_baseline(capsys):
+def test_current_repository_self_hosted_jobs_are_explicitly_allowlisted(capsys):
+    # Baseline: every self-hosted job in the repo must be in
+    # SELF_HOSTED_WORKFLOW_ALLOWLIST and carry the exact dedicated label set.
+    # Before #13126 merged, that meant 0 self-hosted jobs. After #13126, the
+    # Windows-confinement dispatch-only runner is the single allowlisted job
+    # (see #12704 / #13126 / #13135). Adding a self-hosted job without
+    # extending the allowlist is what this assertion is built to catch.
     result = policy.scan_workflows()
     assert result.broken == []
     assert result.violations == []
-    assert result.self_hosted_jobs == 0
+    assert result.self_hosted_jobs == 1
     assert result.workflows_scanned > 0
     assert policy.main(["--check"]) == policy.EXIT_OK
-    assert "explicit baseline: 0 self-hosted jobs" in capsys.readouterr().out
+    assert "all self-hosted jobs satisfy isolation policy" in capsys.readouterr().out
+
+    # Every allowlisted workflow must contribute at least one self-hosted job
+    # to the count (otherwise the allowlist entry is dead weight).
+    workflows_dir = policy.DEFAULT_WORKFLOWS_DIR
+    counted_workflows = sorted(
+        path.name
+        for path in workflows_dir.glob("*.y*ml")
+        if "self-hosted" in path.read_text(encoding="utf-8")
+    )
+    allowlisted = set(policy.SELF_HOSTED_WORKFLOW_ALLOWLIST)
+    assert allowlisted <= set(counted_workflows), (
+        f"allowlist has stale entries (no self-hosted job found): "
+        f"{sorted(allowlisted - set(counted_workflows))}"
+    )
 
 
 def test_safe_pull_request_job_is_accepted(tmp_path):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/guard #13124

Closes #13135

## Périmètre

3 fichiers, 28+/5− :
- `.github/workflows/windows-self-hosted-tests.yml` (1+/1−) : `runs-on` ajoute `coursia-ephemeral`.
- `scripts/ci/check_self_hosted_runner_policy.py` (3+/1−) : allowlist étendue avec `windows-self-hosted-tests.yml`.
- `scripts/tests/test_check_self_hosted_runner_policy.py` (24+/3−) : baseline amendée de `self_hosted_jobs == 0` à `== 1` (post-#13126), plus assertion anti-entrée-morte sur l'allowlist.

Catalogue non touché (pas de régénération sur branche feature, cf `catalog-pr-hygiene.md`).

## Contexte

Issue #13135 ouverte par ai-01 : `main` est rouge sur `scripts/tests/test_check_self_hosted_runner_policy.py` depuis `ab15f40f1` (#13126 mergé 14:18Z). Chaque PR en héritait via `Scripts Tests (CPU)` (cf `scripts-tests.yml`). Deux violations mesurées firsthand à `83a8efc0a` :

```
VIOLATION WORKFLOW_NOT_ALLOWED: windows-self-hosted-tests.yml:windows-confinement-tests
VIOLATION RUNNER_LABELS: windows-self-hosted-tests.yml:windows-confinement-tests (missing: coursia-ephemeral)
```

ai-01 a explicitement refusé d'élargir l'allowlist sans le propriétaire du workflow (lui-même dans ce cas — #13126 est mon véhicule, `jsboige/jsboige`, `maintainerCanModify: true`). Le geste était mécanique, mais il fallait que je le fasse en tant que propriétaire.

## Diagnostic séparé (les 2 causes)

1. **`RUNNER_LABELS`** — le job déclarait `[self-hosted, coursia-fast-guards]` alors que `REQUIRED_LABELS = {self-hosted, coursia-ephemeral, coursia-fast-guards}` dans la policy. **Le runner ephemeral sous-jacent est déjà inscrit avec le triplet canonique** (vérifié dans `manage_self_hosted_runner.py` + `self_hosted_runner_profiles.json`) ; seul le workflow était mal déclaré. La correction est locale : ajouter le label manquant côté workflow.

2. **`WORKFLOW_NOT_ALLOWED`** — `SELF_HOSTED_WORKFLOW_ALLOWLIST = {"pr-gate-stale-sweep.yml"}` ne contenait pas le nouveau workflow. L'allowlist est un **contrôle de sécurité** : un repo public avec un job self-hosted doit prouver que chaque job a été audité individuellement. Élargir cette liste au nom de la flotte sans le propriétaire serait exactement le geste que l'organe existe pour empêcher. La bonne voie : le propriétaire du workflow l'ajoute après avoir vérifié son isolation.

## Cause n°3 (secondaire) — baseline test obsolète

La baseline historique du repo était `self_hosted_jobs == 0`, reflet de l'époque pré-#13126 où **aucun job self-hosted n'existait dans le repo**. Avec #13126 mergé, le repo a désormais 1 job self-hosted légitime. Le test a été écrit pour empêcher l'arrivée de jobs non-audités ; il doit désormais vérifier que **tout job self-hosted est dans l'allowlist + a le triplet canonique**, pas qu'il y en a 0.

L'amendement :
- `result.self_hosted_jobs == 0` → `== 1`
- stdout attendu : `"explicit baseline: 0 self-hosted jobs"` → `"all self-hosted jobs satisfy isolation policy"`
- ajout d'une assertion anti-entrée-morte : `allowlisted <= {workflows qui déclarent effectivement un job self-hosted}`. Empêche d'ajouter une entrée d'allowlist vide (zombie).

## Ce que ce fix NE FAIT PAS

- **Ne dé-pine pas l'assertion de la policy** — ce serait désarmer le contrôle de sécurité. C'est explicitement écrit dans le body de #13135 par ai-01.
- **Ne change pas le déploiement** du runner (le runner est déjà ephemeral, géré par `manage_self_hosted_runner.py` avec cycle de vie : un job → desenregistrement → ré-enregistrement).
- **N'élargit pas l'allowlist** à d'autres workflows (ils n'existent pas, et ne pas en ajouter reste la doctrine).

## Vérification

```
$ python scripts/ci/check_self_hosted_runner_policy.py --check
[self-hosted-policy] workflows=114 jobs=140 self_hosted=1
[self-hosted-policy] OK -- all self-hosted jobs satisfy isolation policy.

$ python -m pytest scripts/tests/test_check_self_hosted_runner_policy.py -v
============================= 35 passed in 1.36s ==============================
```

## Résiduel

- File CI #11860 toujours cyclique (cf p524 ★) — la mise au vert de `Scripts Tests (CPU)` sur `main` ne dépend pas que de cette PR ; d'autres PRs en attente draineront au fil de l'eau.
- #13073 (autre véhicule ai-01 sur le même dossier) : ai-01 l'a recalculé en local (delta 0, 15 échecs identiques, env local), décision de merge prise par ai-01 user-gated. Aucun geste de ma part.

See #12704 (dette de câblage, tranche « recouvrir les 9 tests @requires_windows »).
