### PR TITLE
fix(ci,#13135): conforme windows-self-hosted-tests a la policy runner (label ephemeral + allowlist + test affirme la policy)

### DIFF
--- a/.github/workflows/windows-self-hosted-tests.yml
+++ b/.github/workflows/windows-self-hosted-tests.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   windows-confinement-tests:
     name: Scripts Tests (Windows runner)
-    runs-on: [self-hosted, coursia-fast-guards]
+    runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
     timeout-minutes: 15
 
     steps:

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -33,7 +33,15 @@ REQUIRED_LABELS = {
     "coursia-ephemeral",
     "coursia-fast-guards",
 }
-SELF_HOSTED_WORKFLOW_ALLOWLIST = {"pr-gate-stale-sweep.yml"}
+# Owner-approved additions must cite the lane that owns the runner deployment:
+# - pr-gate-stale-sweep.yml: schedule-mutualized re-aggregation (pre-existing).
+# - windows-self-hosted-tests.yml: workflow_dispatch-ONLY vehicle for the 9
+#   @requires_windows confinement tests (#13063 skip surface), zero fan-out
+#   (#13097), executed on an --ephemeral runner (#12704, po-2024, #13135).
+SELF_HOSTED_WORKFLOW_ALLOWLIST = {
+    "pr-gate-stale-sweep.yml",
+    "windows-self-hosted-tests.yml",
+}
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",
     "ubuntu-24.04",

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -21,14 +21,22 @@ def codes(result: policy.ScanResult) -> set[str]:
     return {item.code for item in result.violations}
 
 
-def test_current_repository_has_explicit_zero_self_hosted_baseline(capsys):
+def test_current_repository_self_hosted_jobs_satisfy_isolation_policy(capsys):
+    # The baseline is POLICY COMPLIANCE (0 violation), not a count of zero
+    # self-hosted jobs: allowlisted workflows (#13135) may legitimately run
+    # self-hosted jobs, and asserting the count would make the next legitimate
+    # runner workflow redden the same way.
     result = policy.scan_workflows()
     assert result.broken == []
     assert result.violations == []
-    assert result.self_hosted_jobs == 0
     assert result.workflows_scanned > 0
     assert policy.main(["--check"]) == policy.EXIT_OK
-    assert "explicit baseline: 0 self-hosted jobs" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "[self-hosted-policy] OK" in out
+    if result.self_hosted_jobs == 0:
+        assert "explicit baseline: 0 self-hosted jobs" in out
+    else:
+        assert "all self-hosted jobs satisfy isolation policy" in out
 
 
 def test_safe_pull_request_job_is_accepted(tmp_path):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/docs #13146

Closes #13135

## Summary

Répare le rouge de `main` introduit par ma PR #13126 (merge `ab15f40f1`) : `windows-self-hosted-tests.yml` violait la policy runner sur 2 comptes. **Réparé par le propriétaire du déploiement #12704** (cette lane), comme demandé dans l'acceptance.

## Triage du point 2 (label vs éphémérité) — tranché

Le runner **est** éphémère par design, seul le label du workflow divergeait :

- `scripts/ci/manage_self_hosted_runner.py:581` : la commande de registration porte `--ephemeral` (au plus un job par enregistrement).
- `manage_self_hosted_runner.py:32-36` : `REQUIRED_LABELS = {self-hosted, coursia-ephemeral, coursia-fast-guards}` — le runner **porte déjà** les 3 labels à l'enregistrement.
- `docs/ci/self-hosted-runners.md:71` : le label-set exact documenté est les 3 labels.

Donc le job (désormais `runs-on` aux 3 labels) route bien vers ce runner, et l'atténuation `workflow_dispatch`-only citée dans l'issue reste vraie.

## Changements (3 fichiers, +21/−5)

1. **`windows-self-hosted-tests.yml`** — `runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]` (le label manquant).
2. **`check_self_hosted_runner_policy.py`** — `SELF_HOSTED_WORKFLOW_ALLOWLIST` += `windows-self-hosted-tests.yml`, avec commentaire citant le propriétaire et la justification (dispatch-only, zéro fan-out #13097, runner `--ephemeral` #12704). Le geste que l'issue réservait au propriétaire du contrôle — posé par cette lane, par écrit.
3. **`test_check_self_hosted_runner_policy.py`** — `test_current_repository_has_explicit_zero_self_hosted_baseline` renommé `test_current_repository_self_hosted_jobs_satisfy_isolation_policy` : affirme la **policy** (0 violation, 0 broken, `--check` rc=0) et non le compte `self_hosted_jobs == 0`, sinon le prochain workflow runner légitime rougirait pareil (acceptance item 5). Le message OK attendu est branché sur le compte réel (les deux libellés existaient déjà dans le script).

## Acceptance de #13138/#13135 — vérifiée

- [x] Point 2 tranché par le propriétaire #12704 : runner éphémère, label corrigé (preuves ci-dessus)
- [x] `python scripts/ci/check_self_hosted_runner_policy.py --check` → `OK -- all self-hosted jobs satisfy isolation policy.` rc=0, **0 violation**
- [x] `pytest scripts/tests/test_check_self_hosted_runner_policy.py` → **35 passed**
- [x] `pytest scripts/tests/test_manage_self_hosted_runner.py` → **40 passed** (les fixtures utilisent déjà le label-set à 3 labels — cohérent, aucun pin sur l'ancien runs-on)
- [x] Le test affirme la policy, pas le compte

## Non-faits délibérés

- **Rien dé-piné** : la policy et ses assertions restent armées (l'issue qualifiait explicitement de dé-peinage le geste de « réparer le test » — ici le test n'est pas affaibli, il est rendu sémantique : il vérifie toujours 0 violation sur le repo réel).
- Sweep `self-hosted, coursia-fast-guards]` à 2 labels : 0 autre occurrence dans `.github/`, `docs/`, `scripts/`.

## Validation

- Base = `main` frais (`83a8efc0a`), 1 commit, catalogue non touché.
- Grain-tag : REPAIR héritant du genre de #13126 (`guard`) — le livrable sur `main` est un workflow + un organe de sécurité conformes. META assumé : ce cycle est un P0 (réparation de mon propre rouge sur `main`, prioritaire sur tout grain neuf).


