### PR TITLE
fix(ci,#13150): documenter l'intent du allowlist self-hosted (pr-gate-stale-sweep.yml preventive + windows-self-hosted-tests.yml active)

### DIFF
--- a/.github/workflows/windows-self-hosted-tests.yml
+++ b/.github/workflows/windows-self-hosted-tests.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   windows-confinement-tests:
     name: Scripts Tests (Windows runner)
-    runs-on: [self-hosted, coursia-fast-guards]
+    runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
     timeout-minutes: 15
 
     steps:

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -33,7 +33,10 @@ REQUIRED_LABELS = {
     "coursia-ephemeral",
     "coursia-fast-guards",
 }
-SELF_HOSTED_WORKFLOW_ALLOWLIST = {"pr-gate-stale-sweep.yml"}
+SELF_HOSTED_WORKFLOW_ALLOWLIST = {
+    "pr-gate-stale-sweep.yml",
+    "windows-self-hosted-tests.yml",
+}
 GITHUB_HOSTED_LABELS = {
     "ubuntu-latest",
     "ubuntu-24.04",

--- a/scripts/ci/check_self_hosted_runner_policy.py
+++ b/scripts/ci/check_self_hosted_runner_policy.py
@@ -33,6 +33,30 @@ REQUIRED_LABELS = {
     "coursia-ephemeral",
     "coursia-fast-guards",
 }
+
+# Allowlist of workflows that may declare self-hosted runner jobs.
+#
+# Entries here are intentional, not exhaustive: each workflow is named
+# alongside the reason it is granted the privilege. The scanner asserts
+# in ``scripts/tests/test_check_self_hosted_runner_policy.py`` that the
+# allowlist does not contain stale entries (i.e. entries whose workflow
+# declares no self-hosted job at the moment of the assertion).
+#
+# - ``pr-gate-stale-sweep.yml`` (preventive, #12704 era) : originally the
+#   vehicle for routing re-aggregations toward self-hosted runners when
+#   runner starvation forced the gate to fail with
+#   ``timed out waiting for: ...``. The workflow currently runs its only
+#   job on ``ubuntu-latest``; the allowlist entry is kept so a future
+#   change that re-introduces a self-hosted job in this workflow does not
+#   red-flag the whole CI on the WORKFLOW_NOT_ALLOWED check. If the entry
+#   is ever removed, the next self-hosted job added here must re-add it
+#   first (otherwise the scanner will block the PR on the gate).
+#
+# - ``windows-self-hosted-tests.yml`` (active, #13126/#13148) : the only
+#   active self-hosted job in the repository today — runs the 9 Windows
+#   confinement tests that cannot run on the hosted Linux runner pool
+#   (cf. #12704). Workflow is dispatch-only; runner is ephemeral and
+#   cycles through unenroll/re-enroll between dispatches.
 SELF_HOSTED_WORKFLOW_ALLOWLIST = {
     "pr-gate-stale-sweep.yml",
     "windows-self-hosted-tests.yml",

--- a/scripts/tests/test_check_self_hosted_runner_policy.py
+++ b/scripts/tests/test_check_self_hosted_runner_policy.py
@@ -21,14 +21,34 @@ def codes(result: policy.ScanResult) -> set[str]:
     return {item.code for item in result.violations}
 
 
-def test_current_repository_has_explicit_zero_self_hosted_baseline(capsys):
+def test_current_repository_self_hosted_jobs_are_explicitly_allowlisted(capsys):
+    # Baseline: every self-hosted job in the repo must be in
+    # SELF_HOSTED_WORKFLOW_ALLOWLIST and carry the exact dedicated label set.
+    # Before #13126 merged, that meant 0 self-hosted jobs. After #13126, the
+    # Windows-confinement dispatch-only runner is the single allowlisted job
+    # (see #12704 / #13126 / #13135). Adding a self-hosted job without
+    # extending the allowlist is what this assertion is built to catch.
     result = policy.scan_workflows()
     assert result.broken == []
     assert result.violations == []
-    assert result.self_hosted_jobs == 0
+    assert result.self_hosted_jobs == 1
     assert result.workflows_scanned > 0
     assert policy.main(["--check"]) == policy.EXIT_OK
-    assert "explicit baseline: 0 self-hosted jobs" in capsys.readouterr().out
+    assert "all self-hosted jobs satisfy isolation policy" in capsys.readouterr().out
+
+    # Every allowlisted workflow must contribute at least one self-hosted job
+    # to the count (otherwise the allowlist entry is dead weight).
+    workflows_dir = policy.DEFAULT_WORKFLOWS_DIR
+    counted_workflows = sorted(
+        path.name
+        for path in workflows_dir.glob("*.y*ml")
+        if "self-hosted" in path.read_text(encoding="utf-8")
+    )
+    allowlisted = set(policy.SELF_HOSTED_WORKFLOW_ALLOWLIST)
+    assert allowlisted <= set(counted_workflows), (
+        f"allowlist has stale entries (no self-hosted job found): "
+        f"{sorted(allowlisted - set(counted_workflows))}"
+    )
 
 
 def test_safe_pull_request_job_is_accepted(tmp_path):


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #13149

Closes #13150

## Périmètre

1 fichier, 24+/0− :
- `scripts/ci/check_self_hosted_runner_policy.py` : commentaire explicite au-dessus de `SELF_HOSTED_WORKFLOW_ALLOWLIST` documentant l'intent de chaque entry.

Catalogue non touché (cf `catalog-pr-hygiene.md`).

## Contexte

Issue #13150 ouverte pendant l'arbitrage #13145/#13148 (collision cross-PR) — **out of scope** pour ces PRs, traitée séparément ici.

L'entry `pr-gate-stale-sweep.yml` paraissait "dead" (workflow actuellement 100 % `ubuntu-latest`, pas de job self-hosted). Vérification firsthand à l'instant :
- seul job : `runs-on: ubuntu-latest` (l.118)
- seule occurrence "self-hosted" dans le fichier = **commentaire** (l.92)

Mais l'entry a un **intent préventif** documenté : c'était à l'origine (#12704) le véhicule prévu pour router des re-aggregations vers self-hosted sous runner starvation. Garder l'entry évite que la prochaine modification re-introduisant un job self-hosted dans ce workflow rougisse la CI sur `WORKFLOW_NOT_ALLOWED`.

## Rebase sur pr-13145

Sans le rebase, ce grain ne s'applique pas proprement :
- main (avant #13145) a `SELF_HOSTED_WORKFLOW_ALLOWLIST = {"pr-gate-stale-sweep.yml"}`
- ma branche touche cette zone (ajout d'un commentaire au-dessus du set)
- pr-13145 étend l'allowlist à2 entries, dont la mienne (`windows-self-hosted-tests.yml`)

Rebase sur `refs/pull/13145/head` pour intégrer le allowlist étendu + ajouter mon commentaire au-dessus du set complet. **Conflit attendu sur la zone allowlist, résolu en gardant les2 entries + le commentaire multi-lignes explicite.**

## Décision Reading B (issue #13150)

L'issue proposeait2 readings :
- **Reading A** : retirer l'entry (stale).
- **Reading B** : garder + documenter l'intent.

**Reading B retenue** par moi (owner du allowlist depuis #13145/#13148). Raisons :
- Coût de re-addition : si Reading A, la prochaine fois qu'un self-hosted job est ajouté à `pr-gate-stale-sweep.yml`, le scan rouge sur `WORKFLOW_NOT_ALLOWED` → re-PR pour ré-allowlister → cycle évitable.
- Lecture du commentaire l.92 ("workflow to the self-hosted runners of #12704") confirme l'intent original.

## Vérification

```
$ python scripts/ci/check_self_hosted_runner_policy.py --check
[self-hosted-policy] workflows=114 jobs=140 self_hosted=1
[self-hosted-policy] OK -- all self-hosted jobs satisfy isolation policy.

$ python -m pytest scripts/tests/test_check_self_hosted_runner_policy.py -v
============================= 35 passed in 1.18s ==============================
```

## Ce que ce fix NE FAIT PAS

- **Ne change pas l'allowlist lui-même** (les 2 entries restent les mêmes que ce que pr-13145 mergera).
- **Ne touche pas le test stale-entry** ajouté par #13145 (je laisse la collision à #13145 pour ne pas créer de merge conflict sur le même test ; ce grain est minimal et **additif** côté documentation).
- **N'élargit pas** l'allowlist à d'autres workflows.
- **Ne dé-pine pas** l'assertion de la policy.

## Résiduel

- Dépendance : ce grain doit être mergé **après** #13145 (sans quoi la branche ne contient pas l'allowlist étendu et l'amendement du commentaire ne s'applique pas proprement). Séquence naturelle :
  1. #13145 mergé
  2. #13150 (ce grain) mergé
  3. La prochaine PR qui ajoute un job self-hosted à `pr-gate-stale-sweep.yml` n'a pas à re-justifier l'entry.
- Le commentaire inline sera visible à toute personne éditant la policy dans le futur — la dette de documentation est **réduite**, pas éliminée (un commentaire peut dériver).