### PR TITLE
chore(mgs,#1203): re-exec tranche MGS-7 TSP post-rebase — outputs byte-identiques, rafraîchissement kernel

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7-TSP.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-7-TSP.ipynb
@@ -48,145 +48,36 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '54184.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": ""
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "DLLs chargées (incluant GeneticSharp.Extensions = TSP).\r\n"
-     ]
+     "name": "stdout",
+     "text": "DLLs chargées (incluant GeneticSharp.Extensions = TSP).\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  TspFitness          : TspFitness\r\n"
-     ]
+     "name": "stdout",
+     "text": "  TspFitness          : TspFitness\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  TspChromosome       : TspChromosome\r\n"
-     ]
+     "name": "stdout",
+     "text": "  TspChromosome       : TspChromosome\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  IslandMetaHeuristic : IslandMetaHeuristic\r\n"
-     ]
+     "name": "stdout",
+     "text": "  IslandMetaHeuristic : IslandMetaHeuristic\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  MigrationMode       : MigrationMode\r\n"
-     ]
+     "name": "stdout",
+     "text": "  MigrationMode       : MigrationMode\r\n"
     }
    ],
    "source": [
@@ -256,11 +147,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "TSP : 20 villes chargées dans [0,100]².\r\n"
-     ]
+     "name": "stdout",
+     "text": "TSP : 20 villes chargées dans [0,100]².\r\n"
     }
    ],
    "source": [
@@ -317,11 +206,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Helper Run prêt.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Helper Run prêt.\r\n"
     }
    ],
    "source": [
@@ -402,11 +289,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Baseline (panmictic)       tour final = 455,3\r\n"
-     ]
+     "name": "stdout",
+     "text": "Baseline (panmictic)       tour final = 455,3\r\n"
     }
    ],
    "source": [
@@ -460,11 +345,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Islands (4 x 10, Static)   tour final = 512,1\r\n"
-     ]
+     "name": "stdout",
+     "text": "Islands (4 x 10, Static)   tour final = 512,1\r\n"
     }
    ],
    "source": [
@@ -530,11 +413,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Geometric (Moraglio)       tour final = 596,9\r\n"
-     ]
+     "name": "stdout",
+     "text": "Geometric (Moraglio)       tour final = 596,9\r\n"
     }
    ],
    "source": [
@@ -596,53 +477,39 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  parent             = [0, 1, 2, 3, 4]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  parent             = [0, 1, 2, 3, 4]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  cible (permutation)= [2, 0, 1, 3, 4]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  cible (permutation)= [2, 0, 1, 3, 4]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  1 pas swap (Cayley)    = [2, 1, 0, 3, 4]   (transposition)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  1 pas swap (Cayley)    = [2, 1, 0, 3, 4]   (transposition)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  1 pas insertion (Ulam) = [2, 0, 1, 3, 4]   (déplacement+décalage)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  1 pas insertion (Ulam) = [2, 0, 1, 3, 4]   (déplacement+décalage)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  -> distincts en un pas ? True\r\n"
-     ]
+     "name": "stdout",
+     "text": "  -> distincts en un pas ? True\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Geometric (insertion/Ulam) tour final = 614,3\r\n"
-     ]
+     "name": "stdout",
+     "text": "Geometric (insertion/Ulam) tour final = 614,3\r\n"
     }
    ],
    "source": [
@@ -749,60 +616,44 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  parent A = [0, 1, 2, 3, 4]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  parent A = [0, 1, 2, 3, 4]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  parent B = [0, 2, 1, 3, 4]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  parent B = [0, 2, 1, 3, 4]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  arêtes communes = {(1,2), (3,4), (0,4)}\r\n"
-     ]
+     "name": "stdout",
+     "text": "  arêtes communes = {(1,2), (3,4), (0,4)}\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  offspring edge = [0, 4, 3, 1, 2]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  offspring edge = [0, 4, 3, 1, 2]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  novel vs A ? True  novel vs B ? True\r\n"
-     ]
+     "name": "stdout",
+     "text": "  novel vs A ? True  novel vs B ? True\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  contient TOUTES les arêtes communes ? True\r\n"
-     ]
+     "name": "stdout",
+     "text": "  contient TOUTES les arêtes communes ? True\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Geometric (edge/TSP)       tour final = 580,5\r\n"
-     ]
+     "name": "stdout",
+     "text": "Geometric (edge/TSP)       tour final = 580,5\r\n"
     }
    ],
    "source": [
@@ -893,102 +744,74 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Config                     | Tour final |  vs baseline\r\n"
-     ]
+     "name": "stdout",
+     "text": "Config                     | Tour final |  vs baseline\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "------------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "------------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Baseline (panmictic)       |      455,3 |        0,0 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "Baseline (panmictic)       |      455,3 |        0,0 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Islands (4 x 10, Static)   |      512,1 |      -12,5 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "Islands (4 x 10, Static)   |      512,1 |      -12,5 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Geometric (Moraglio)       |      596,9 |      -31,1 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "Geometric (Moraglio)       |      596,9 |      -31,1 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Geometric (insertion/Ulam) |      614,3 |      -34,9 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "Geometric (insertion/Ulam) |      614,3 |      -34,9 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Geometric (edge/TSP)       |      580,5 |      -27,5 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "Geometric (edge/TSP)       |      580,5 |      -27,5 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Convergence (longueur du meilleur tour, échantillonnée) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Convergence (longueur du meilleur tour, échantillonnée) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Baseline (panmictic)    g1=1011  g26=633  g51=543  g76=491  g100=455\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Baseline (panmictic)    g1=1011  g26=633  g51=543  g76=491  g100=455\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Islands (4 x 10, Static)g1=1011  g26=672  g51=577  g76=577  g100=512\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Islands (4 x 10, Static)g1=1011  g26=672  g51=577  g76=577  g100=512\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Geometric (Moraglio)    g1=1011  g26=725  g51=665  g76=636  g100=597\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Geometric (Moraglio)    g1=1011  g26=725  g51=665  g76=636  g100=597\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Geometric (insertion/Ulam)g1=1011  g26=889  g51=767  g76=713  g100=614\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Geometric (insertion/Ulam)g1=1011  g26=889  g51=767  g76=713  g100=614\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Geometric (edge/TSP)    g1=1011  g26=843  g51=705  g76=594  g100=581\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Geometric (edge/TSP)    g1=1011  g26=843  g51=705  g76=594  g100=581\r\n"
     }
    ],
    "source": [
@@ -1086,11 +909,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[Exercice 1] À compléter. Référence : baseline-OX1 = 455,3.\r\n"
-     ]
+     "name": "stdout",
+     "text": "[Exercice 1] À compléter. Référence : baseline-OX1 = 455,3.\r\n"
     }
    ],
    "source": [
@@ -1146,11 +967,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[Exercice 2] À compléter. Référence : islands-Static = 512,1.\r\n"
-     ]
+     "name": "stdout",
+     "text": "[Exercice 2] À compléter. Référence : islands-Static = 512,1.\r\n"
     }
    ],
    "source": [
@@ -1204,11 +1023,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[Exercice 3] À compléter. Comparez les longueurs finales selon la granularité.\r\n"
-     ]
+     "name": "stdout",
+     "text": "[Exercice 3] À compléter. Comparez les longueurs finales selon la granularité.\r\n"
     }
    ],
    "source": [


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #13152

See #1203 (tranche re-exec post-rebase MGS-7, suite MGS-1/2/3 #11941/#11943/#12070, MGS-5 #12187, MGS-6 #12190, MGS-4 #13152, MGS-19 #12573, MGS-10 #12575 ; post-bump MGS-8..18 = #12935, périmètre disjoint vérifié ; famille 7b/7c/7d reste derrière)

## Ce que cette tranche fait

Re-exécution complète de `MGS-7-TSP.ipynb` (12/12 cellules, 0 erreur, 6-7 s) contre l'état actuel du submodule `MetaGeneticSharp` : gitlink `961a058` (celui du train post-rebase), GeneticSharp imbriqué `4406ad7`, solution rebuilt from scratch dans un worktree isolé (`dotnet build` 9,3 s, exit 0), kernel `.net-csharp` épinglé via `dotnet_executor.py`.

## Résultat : outputs byte-identiques

**Déterminisme prouvé** : double exécution → fichier byte-identique entre les deux passes. Le harness est seedé de bout en bout (vérifié AVANT l'exécution) : villes `ResetSeed(42)` (cell. 3), `ResetRng(7)` avant chaque config dans le helper `Run` (cell. 5), démonstrations géométriques (Ulam cell. 13, edge cell. 15) sur permutations **fixes** construites à la main — aucune cellule de calcul non-seedée.

**Les 12 sorties byte-identiques aux committées**, vérifié cellule par cellule (streams + text/plain). Chiffres porteurs reproduits exactement : baseline panmictic **455,3** / islands 4×10 Static **512,1** (−12,5 %) / geometric Moraglio **596,9** (−31,1 %) / insertion-Ulam **614,3** (−34,9 %) / edge-TSP **580,5** (−27,5 %), courbes de convergence échantillonnées (g1=1011 → g100=455) identiques.

**Le diff (+88/−271) est du format, pas du contenu** : retrait du boilerplate JS `dotnet-interactive-this-cell` (shim du kernel précédent, ~270 lignes mortes) + banner `probeAddresses` strippée (1 occurrence, outil standard). Aucune valeur, aucun graphique, aucune prose ne change.

## Audit prose-vs-chiffres : 0 infidélité

La Lecture [18] est qualitative (agnosticité de la grammaire de composition — aucun chiffre cité) ; le tableau comparatif (cell. 17) et les sorties par-config (cell. 7/9/11) reproduisent byte-à-byte. La fidélité de prose est préservée par construction (sorties identiques).

## Diagnostic dérive (C.4)

**Cause a — env/kernel** : sorties committées datant d'un kernel qui embossait le shim JS ; rafraîchissement aligné sur ce que le kernel épinglé produit (idempotence atteinte). Aucune valeur dérivée — pas de CAUSE_FIXED à poser.

## Validation

- `dotnet_executor.py` : 12/12 cellules, 0 erreur, exécuté 2× → fichier byte-identique
- `validate_pr_notebooks.py origin/main <nb>` : **1/1 PASS** (12 cellules .net-csharp)
- C.1 : 0 `raise NotImplementedError` / `assert False` / `1/0`
- exec counts 1-12 non-null, JSON valide, catalogue byte-identique à main
- périmètre : 1 fichier, outputs-only (0 cellule source modifiée, C.3 respecté)
- submodule gitlink inchangé (961a058 = byte-identique à main)

## Verdict SOTA

**SOTA-OK** — vrai fork exécuté via DLLs fraîches du build local (net9.0 self-contained), pas de substitution.

## Note G-VAR-3

Deuxième `notebook-dotnet` MED consécutif — autorisé par la clause domaine-cœur (substance genuinement distincte : embeddings géométriques de permutations sur TSP vs modèle insulaire sur fonctions continues), revendiqué dans le claim ([CLAIMED] issuecomment-5429452239) et l'override coordinateur `next: notebook-dotnet` (arbitrage #12932 du 2026-08-26).
