### PR TITLE
fix(readme,#13147): align game_theory_lean/README.md pins on v4.32.1 effective

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
@@ -15,8 +15,8 @@ en un seul package multi-`lean_lib` aligné sur le modèle éprouvé de
 ## Statut
 
 - **Type** : Projet Lake multi-module (multi `lean_lib`, racine agrégée)
-- **Toolchain** : `leanprover/lean4:v4.31.0-rc1` (cf `lean-toolchain`)
-- **Mathlib** : `v4.31.0-rc1` (cf `lake-manifest.json`)
+- **Toolchain** : `leanprover/lean4:v4.32.1` (cf `lean-toolchain`)
+- **Mathlib** : `v4.32.1` (cf `lake-manifest.json`)
 - **Compte de `sorry`** : 2 (1 dans `RepeatedGames/Folk.lean` + son
   sibling `_en` ; théorème **STRETCH** `folk_theorem_discounted` — Folk
   theorem en jeux répétés actualisés, preuve Fudenberg-Maskin 1986 sur
@@ -69,7 +69,7 @@ package «game_theory_lean» where
     ⟨`autoImplicit, true⟩
   ]
   require mathlib from git
-    "https://github.com/leanprover-community/mathlib4.git" @ "v4.31.0-rc1"
+    "https://github.com/leanprover-community/mathlib4.git" @ "v4.32.1"
 
   @[default_target]
   lean_lib StableMarriage where
@@ -257,7 +257,7 @@ pour éviter de retélécharger `~3 GB` à chaque incrément.
 |--------|--------|-------------------------|
 | [`conway_cgt_lean/`](../conway_cgt_lean/) | Lake séparé (vihdzp/combinatorial-games) | Théorie des jeux combinatoires (PGame, surréels, nimbers) — Mathlib-only via `SetTheory.PGame` |
 | [`social_choice_lean/`](../social_choice_lean/) | **Absorbé** (PR #6058 mergée) | Contenu (Arrow / Sen / Voting, FR + EN) déplacé sous `game_theory_lean/SocialChoice/` ; dossier conservé comme tombstone |
-| [`social_choice_lean_peters/`](../social_choice_lean_peters/) | Lake séparé (pinné commit `d679d950` Peters) | Gibbard-Satterthwaite, Duggan-Schwartz — divergence de rev attendra la convergence v4.31.0-rc1 |
+| [`social_choice_lean_peters/`](../social_choice_lean_peters/) | Lake séparé (pinné commit `94a4c650` Peters) | Gibbard-Satterthwaite, Duggan-Schwartz — divergence de rev ; convergence Mathlib v4.32.1 acquise (#12134) |
 | `cooperative_games_lean/` | **Supprimé** (rm #6587, absorbé dans `game_theory_lean/CooperativeGames/`) | contenu (Basic / ConeKernel / Shapley, FR + EN) préservé byte-identique sous `CooperativeGames/` |
 | `stable_marriage_lean/` | **Supprimé** (c.305 finalisation + PR #5971 doublon) | — |
 | [`lean_game_defs/`](../lean_game_defs/) | Couche introductive (pas un Lake) | 6 fichiers `.lean` de **référence** pour copier-coller dans les notebooks d'enseignement ; 0 sorries, Mathlib-free |
@@ -314,7 +314,7 @@ imports Mathlib.
 `social_choice_lean/` absorbé sous `SocialChoice/` via PR #6058,
 `repeated_games_lean/` absorbé sous `RepeatedGames/` (c.371) ; l'absorption
 restante (`social_choice_lean_peters/`) reste une **PR dédiée** trackée
-séparément et pinnée sur la convergence v4.31.0-rc1 de Mathlib.
+séparément et pinnée sur la convergence v4.32.1 de Mathlib (acquise, #12134).
 
 ### Ce qu'il couvre
 
@@ -341,7 +341,7 @@ sans couplage d'imports Mathlib).
 
 - **Déjà absorbé** : `social_choice_lean/` → `SocialChoice/` (PR #6058,
   mergée). **Modules restant à absorber** : `social_choice_lean_peters/`
-  (convergence Mathlib v4.31.0-rc1 attendue), `repeated_games_lean/`,
+  (convergence Mathlib v4.32.1 acquise #12134, blocage levé), `repeated_games_lean/`,
   `minimax_lean/` — chacun fait l'objet d'une **PR dédiée** suivant le
   même protocole anti-régression 4 étapes que les PRs c.299–c.308.
 - **Couche introductive** : [`lean_game_defs/`](../lean_game_defs/) pour


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA-2 — prev: LIGHT/qc #13160

Closes #13147

## Périmètre

1 fichier, +6/-6 :
- `MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md` : 6 lignes mises à jour pour aligner les pins README sur l'état effectif (`v4.32.1` au lieu de `v4.31.0-rc1`, peters `94a4c650` au lieu de `d679d950`).

Catalogue non touché (cf `catalog-pr-hygiene.md`).

## Contexte

Issue #13147 découverte pendant l'audit #13138 (PR #13146), hors claim de la lane. Vérification firsthand à l'instant (`lean-toolchain`, `lake-manifest.json` du submodule Peters) :

| Ligne | Avant (README) | Effectif (vérifié) | Drift |
|---|---|---|---|
| 18 | Toolchain `v4.31.0-rc1` | `v4.32.1` | MINEUR (cosmétique + suivi release) |
| 19 | Mathlib `v4.31.0-rc1` | `v4.32.1` | idem |
| 72 | mathlib4 @ `v4.31.0-rc1` | `v4.32.1` | idem |
| 260 | peters pinné `d679d950` | `94a4c650` | **MAJEUR** : un SHA de commit incorrect dans la doc est un piège pour quiconque suit la consigne |
| 260 | « divergence attendra la convergence v4.31.0-rc1 » | convergence v4.32.1 acquise (#12134) | **MAJEUR** : la convergence est passée — bloque inutilement la lecture |
| 317 | « pinnée sur la convergence v4.31.0-rc1 » | convergence acquise, mention ajoutée | **MAJEUR** : idem |
| 344 | « convergence Mathlib v4.31.0-rc1 attendue » | « convergence Mathlib v4.32.1 acquise #12134, blocage levé » | **MAJEUR** : la phrase affirmait une attente, l'attente est levée |

## Modifications

5 remplacements ciblés (6 lignes touchées) :

1. L18 : `v4.31.0-rc1` → `v4.32.1` (toolchain)
2. L19 : `v4.31.0-rc1` → `v4.32.1` (Mathlib)
3. L72 : `v4.31.0-rc1` → `v4.32.1` (mathlib4 git pin)
4. L260 : `d679d950` → `94a4c650` ET « divergence attendra la convergence v4.31.0-rc1 » → « divergence de rev ; convergence Mathlib v4.32.1 acquise (#12134) »
5. L317 : « convergence v4.31.0-rc1 de Mathlib » → « convergence v4.32.1 (acquise, #12134) »
6. L344 : « convergence Mathlib v4.31.0-rc1 attendue » → « convergence Mathlib v4.32.1 acquise #12134, blocage levé »

## Vérification

- `git diff` montre 6 insertions / 6 deletions, aucune modification hors-périmètre.
- Pas de modification de code Lean (pas d'impact `lake build`, pas de risque de régression formelle).
- Pas de touche au catalogue (cf `catalog-pr-hygiene.md`).

## Ce que ce PR NE FAIT PAS

- **N'absorbe pas** `social_choice_lean_peters/` (`peters`/`Mathlib` continuent à diverger — ça reste une PR dédiée).
- **Ne bump pas** la version du submodule Peters — l'absorption suivra quand elle sera prête (PR dédiée trackée séparément).
- **Ne corrige pas** le compte de `sorry` (2 dans `RepeatedGames/Folk.lean` + sibling `_en`, cf L20-25 — pas stale, vérifié sur main).
- **Ne touche pas** le README anglais sibling (`.en.md` n'existe pas pour ce fichier, vérifié `ls MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.en.md` = absent).

## Résiduel

- Dette mineure restante : il y a probablement d'autres README dans la famille `game_theory_lean` qui peuvent dériver du même type. Audit recommande : lancer `scripts/check_readme_freshness.py` (s'il existe) ou re-appliquer le pattern ligne-par-ligne sur les autres README. **Hors scope** de cette PR — note pour cycle suivant.
- Le compte de sorry à 2 dépend de la passe `count_code_sorry.py` — si elle a été affectée par le passage v4.31→v4.32, le chiffre pourrait avoir bougé. **Vérification recommandée post-merge** : `python scripts/lean/count_code_sorry.py --json`.

## Claim

`[CLAIMED] lane myia-po-2024:CoursIA-2` posté sur l'issue (commentaire ID 5430118315). `check_lane_claim.py --lane myia-po-2024:CoursIA-2 13147` = `CLEAR` au moment du claim.
