### PR TITLE
feat(planners,#13104): notebook 14 -- LLM reducteur d'espace de recherche (position aicpp)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Planners-12: Learning to Plan avec LOOP\n",
     "\n",
-    "**Navigation** : [Index](../../README.md) | [<< Unified Planning](Planners-11-Unified-Planning.ipynb) | [Fin de serie >>]\n",
+    "**Navigation** : [Index](../../README.md) | [<< Unified Planning](Planners-11-Unified-Planning.ipynb) | [LLM Space Reducer >>](Planners-14-LLM-Space-Reducer.ipynb)\n",
     "\n",
     "## Neuro-Symbolic Planning\n",
     "\n",
@@ -89,7 +89,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Le paradigme Learning to Plan\n",
     "\n",
@@ -188,7 +188,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Setup et Imports"
    ]
@@ -314,7 +314,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Le Framework LOOP\n",
     "\n",
@@ -441,7 +441,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Implementation du reseau de neurones\n",
     "\n",
@@ -626,7 +626,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Representation des etats\n",
     "\n",
@@ -1027,7 +1027,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Entrainement et Evaluation\n",
     "\n",
@@ -1656,7 +1656,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. KRCL et méthodes apparentees\n",
     "\n",
@@ -1956,7 +1956,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Resume et Perspectives"
    ]
@@ -2061,7 +2061,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## References\n",
     "\n",
@@ -2079,7 +2079,7 @@
     "- [Fast Downward](https://www.fast-downward.org/)\n",
     "- [IPC Benchmarks](https://github.com/ipc2023-classical/domains)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Fin de la serie Planners** - Ce notebook conclude notre exploration des planificateurs, des fondements PDDL aux approches neuro-symboliques modernes.\n",
     "\n",
@@ -2123,7 +2123,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Exemple guide : Heuristique aprendie pour Blocks World 3-blocs\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-14-LLM-Space-Reducer.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-14-LLM-Space-Reducer.ipynb
@@ -1,0 +1,1339 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003007,
+     "end_time": "2026-08-26T20:04:44.337951",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:44.334944",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Planners-14: Le LLM comme reducteur d'espace de recherche\n",
+    "\n",
+    "**Navigation** : [Index](../../README.md) | [<< Learning to Plan (LOOP)](Planners-12-LOOP.ipynb) | [Fin de serie >>]\n",
+    "\n",
+    "## Neuro-Symbolic Planning, position inverse\n",
+    "\n",
+    "Les notebooks 10 et 12 ont regarde le LLM et le reseau comme **producteurs** de plans. Ce notebook teste le positionnement inverse, formule par le moteur de recherche symbolique [aicpp](https://github.com/Julien-Livet/aicpp) (Julien Livet, Apache 2.0) :\n",
+    "\n",
+    "> *Large Language Models are most effective not as solvers, but as structural search space reducers.*\n",
+    "\n",
+    "Le LLM **restreint l'espace** (quelles primitives, quelle profondeur de composition) ; le **solving reste deterministe, symbolique, inspectable**. Le programme produit est une suite explicite de primitives typees, verifiee par exemples — la correction ne depend jamais du LLM.\n",
+    "\n",
+    "Nous construisons un mini-DSL de 8 primitives sur des grilles colorees (format ARC-AGI), trois taches flip/color/mask, puis nous mesurons **trois bras** sur les memes taches :\n",
+    "\n",
+    "1. **Recherche exhaustive bornee** (le mur) ;\n",
+    "2. **LLM-direct** : le modele doit rendre le programme solution ;\n",
+    "3. **LLM-reducteur** : le modele ne rend que le sous-espace — le solveur deterministe fait le reste.\n",
+    "\n",
+    "*Echelle pedagogique assumee* : aicpp resout 69/120 taches ARC-AGI-2 training (57,5 %) avec une architecture Neuron/Connection/Brain en C++23. Ce notebook reproduit le **geste** (reduire puis resoudre) sur un espace de pres de 200 millions de programmes, dont seule une fraction minuscule est traversable en session."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002005,
+     "end_time": "2026-08-26T20:04:44.343460",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:44.341455",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "\n",
+    "1. **Distinguer** LLM-solver et LLM-reducteur, et ce que chaque position garantit (ou non)\n",
+    "2. **Construire** un mini-DSL de primitives typees sur des grilles ARC-like\n",
+    "3. **Mesurer** l'explosion combinatoire d'un espace de programmes et la borner honnetement\n",
+    "4. **Executer** une recherche exhaustive deterministe sous budget de noeuds\n",
+    "5. **Comparer** les trois bras (noeuds, temps, reussite) sur les memes taches\n",
+    "6. **Situer** la these reductrice face a Learning to Plan (notebook 12) et a la veille interpretable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003264,
+     "end_time": "2026-08-26T20:04:44.350724",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:44.347460",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Prerequis\n",
+    "\n",
+    "- Avoir suivi [Planners-10-LLM-Planning](Planners-10-LLM-Planning.ipynb) (prompting, limites des LLM)\n",
+    "- Connaissance de base de numpy (grilles = tableaux 2D d'entiers)\n",
+    "- Une cles d'API LLM (OpenRouter ou OpenAI) pour les bras 2 et 3 — les cellules verifient sa presence sans jamais l'afficher\n",
+    "\n",
+    "### Duree estimee : 40 minutes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-03",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003847,
+     "end_time": "2026-08-26T20:04:44.357110",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:44.353263",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le positionnement inverse : reduire, pas resoudre\n",
+    "\n",
+    "Le notebook 10 a montre un LLM **generateur** de plans : il produit la solution, avec les taux d'echec que l'on connait — plan invalide, etape inexistante, hallucination d'objet. Le notebook 12 a deplace l'apprentissage **dans** l'heuristique : le reseau ne rend plus un plan, il ordonne la recherche.\n",
+    "\n",
+    "La these reductrice pousse le meme geste jusqu'au bout :\n",
+    "\n",
+    "| Position | Ce que le modele rend | Qui garantit la correction |\n",
+    "|---|---|---|\n",
+    "| LLM-solver | le programme / plan final | personne (on espere) |\n",
+    "| L2P (notebook 12) | une heuristique apprise | le solveur, en explorant |\n",
+    "| **LLM-reducteur** | **un sous-espace (primitives, profondeur)** | **le solveur deterministe, par verification sur exemples** |\n",
+    "\n",
+    "Le contrat est asymetrique : si le reducteur se trompe, le solveur **echoue proprement** (la solution n'est pas dans le sous-espace) ; s'il a raison, la solution trouvee est **prouvee par exemples**, independamment du modele. Le LLM n'est jamais dans la boucle de correction.\n",
+    "\n",
+    "C'est exactement l'architecture d'aicpp : selection de primitives et parametrisation structurelle par LLM, puis recherche exhaustive bornee, ordonnee par cout, en C++ natif compile — 69/120 taches ARC-AGI-2 training resolues. La boucle generation-compilation-re-execution est une instance concrete du pattern plan-execute-compile discute au notebook 11."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:04:44.364652Z",
+     "iopub.status.busy": "2026-08-26T20:04:44.363647Z",
+     "iopub.status.idle": "2026-08-26T20:04:45.341791Z",
+     "shell.execute_reply": "2026-08-26T20:04:45.341791Z"
+    },
+    "papermill": {
+     "duration": 0.983679,
+     "end_time": "2026-08-26T20:04:45.343300",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:44.359621",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Client LLM pret (cles : variable d'environnement) | modele : openai/gpt-5\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports standards\n",
+    "import os\n",
+    "import json\n",
+    "import time\n",
+    "import itertools\n",
+    "import numpy as np\n",
+    "\n",
+    "# Client LLM (OpenRouter : agregateur compatible client OpenAI)\n",
+    "try:\n",
+    "    from openai import OpenAI\n",
+    "    HAS_OPENAI = True\n",
+    "except ImportError:\n",
+    "    HAS_OPENAI = False\n",
+    "    OpenAI = None\n",
+    "\n",
+    "\n",
+    "def load_llm_client():\n",
+    "    # Construit le client LLM sans jamais afficher la cles.\n",
+    "    # Sources essayees dans l'ordre : variable d'environnement OPENROUTER_API_KEY,\n",
+    "    # puis le fichier local .secrets/master.env (gitignore).\n",
+    "    # Retourne (client, source) ou (None, raison) si aucune cles n'est disponible.\n",
+    "    if not HAS_OPENAI:\n",
+    "        return None, \"bibliotheque openai absente\"\n",
+    "    key = os.environ.get(\"OPENROUTER_API_KEY\")\n",
+    "    source = \"variable d'environnement\"\n",
+    "    if not key:\n",
+    "        # candidats relatifs uniquement (racine du depot ou cwd), jamais de chemin machine\n",
+    "        for cand in [\".secrets/master.env\", \"../../../../.secrets/master.env\"]:\n",
+    "            if os.path.isfile(cand):\n",
+    "                with open(cand, encoding=\"utf-8\") as f:\n",
+    "                    for line in f:\n",
+    "                        if line.startswith(\"OPENROUTER_API_KEY=\"):\n",
+    "                            key = line.split(\"=\", 1)[1].strip()\n",
+    "                            # label generique : jamais de chemin machine dans les sorties\n",
+    "                            source = \"fichier local .secrets/master.env\"\n",
+    "                if key:\n",
+    "                    break\n",
+    "    if not key:\n",
+    "        return None, \"cles OPENROUTER_API_KEY introuvable\"\n",
+    "    return OpenAI(api_key=key, base_url=\"https://openrouter.ai/api/v1\"), source\n",
+    "\n",
+    "\n",
+    "LLM_MODEL = \"openai/gpt-5\"\n",
+    "llm_client, llm_source = load_llm_client()\n",
+    "if llm_client:\n",
+    "    print(f\"Client LLM pret (cles : {llm_source}) | modele : {LLM_MODEL}\")\n",
+    "else:\n",
+    "    print(f\"Client LLM INDISPONIBLE ({llm_source}) : bras 2 et 3 en mode constat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-05",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004615,
+     "end_time": "2026-08-26T20:04:45.354429",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.349814",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Le mini-DSL : huit primitives typees sur des grilles\n",
+    "\n",
+    "Une grille ARC est un tableau 2D d'entiers 0-9 (0 = fond, 1-9 = couleurs). Chaque primitive est une fonction totale `Grid -> Grid` :\n",
+    "\n",
+    "| Primitive | Instances | Effet |\n",
+    "|---|---|---|\n",
+    "| `flipud` | 1 | miroir vertical |\n",
+    "| `fliplr` | 1 | miroir horizontal |\n",
+    "| `rot90` | 1 | rotation d'un quart de tour (horaire) |\n",
+    "| `transpose` | 1 | transposition principale |\n",
+    "| `crop_content` | 1 | cadre sur les cases non nulles |\n",
+    "| `recolor(c1, c2)` | 90 (c1 != c2 dans 0-9) | remplace c1 par c2 |\n",
+    "| `mask_keep(c)` | 10 | garde uniquement c, le reste a 0 |\n",
+    "| `mask_drop(c)` | 10 | passe c a 0 |\n",
+    "\n",
+    "Un **programme** est une suite (eventuellement vide) d'instances appliquees en sequence. Compter l'espace est immediat : 115 instances par slot, profondeur au plus 4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:04:45.365461Z",
+     "iopub.status.busy": "2026-08-26T20:04:45.363950Z",
+     "iopub.status.idle": "2026-08-26T20:04:45.372492Z",
+     "shell.execute_reply": "2026-08-26T20:04:45.372492Z"
+    },
+    "papermill": {
+     "duration": 0.016646,
+     "end_time": "2026-08-26T20:04:45.374075",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.357429",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Primitives : 8 | Instances par slot : 115\n",
+      "Espace total (profondeur <= 4) : 115 + 115**2 + 115**3 + 115**4 = 176,434,840 programmes\n"
+     ]
+    }
+   ],
+   "source": [
+    "Grid = np.ndarray  # tableau 2D d'entiers 0-9\n",
+    "\n",
+    "\n",
+    "def flipud(g): return np.flipud(g)\n",
+    "def fliplr(g): return np.fliplr(g)\n",
+    "def rot90(g): return np.rot90(g, k=-1)          # quart de tour horaire\n",
+    "def transpose(g): return g.T\n",
+    "def crop_content(g):\n",
+    "    nz = np.argwhere(g != 0)\n",
+    "    if nz.size == 0:\n",
+    "        return g\n",
+    "    r0, c0 = nz.min(axis=0); r1, c1 = nz.max(axis=0)\n",
+    "    return g[r0:r1 + 1, c0:c1 + 1]\n",
+    "\n",
+    "\n",
+    "def make_recolor(c1, c2):\n",
+    "    def recolor(g):\n",
+    "        out = g.copy(); out[out == c1] = c2; return out\n",
+    "    return recolor\n",
+    "\n",
+    "\n",
+    "def make_mask_keep(c):\n",
+    "    def mask_keep(g):\n",
+    "        out = g.copy(); out[out != c] = 0; return out\n",
+    "    return mask_keep\n",
+    "\n",
+    "\n",
+    "def make_mask_drop(c):\n",
+    "    def mask_drop(g):\n",
+    "        out = g.copy(); out[out == c] = 0; return out\n",
+    "    return mask_drop\n",
+    "\n",
+    "\n",
+    "# Registre : nom canonique -> (arite d'arguments, factory)\n",
+    "DSL = {\n",
+    "    \"flipud\": (0, lambda: flipud),\n",
+    "    \"fliplr\": (0, lambda: fliplr),\n",
+    "    \"rot90\": (0, lambda: rot90),\n",
+    "    \"transpose\": (0, lambda: transpose),\n",
+    "    \"crop_content\": (0, lambda: crop_content),\n",
+    "    \"recolor\": (2, make_recolor),\n",
+    "    \"mask_keep\": (1, make_mask_keep),\n",
+    "    \"mask_drop\": (1, lambda c: make_mask_drop(c)),\n",
+    "}\n",
+    "\n",
+    "COLORS = range(10)\n",
+    "\n",
+    "\n",
+    "def all_instances():\n",
+    "    # Enumere toutes les instances du DSL sous forme (nom_lisible, fonction).\n",
+    "    inst = []\n",
+    "    for name, (arity, factory) in DSL.items():\n",
+    "        if arity == 0:\n",
+    "            inst.append((name, factory()))\n",
+    "        elif name == \"recolor\":\n",
+    "            for c1, c2 in itertools.permutations(COLORS, 2):\n",
+    "                inst.append((f\"recolor:{c1}:{c2}\", factory(c1, c2)))\n",
+    "        else:\n",
+    "            for c in COLORS:\n",
+    "                inst.append((f\"{name}:{c}\", factory(c)))\n",
+    "    return sorted(inst, key=lambda t: t[0])\n",
+    "\n",
+    "\n",
+    "INSTANCES = all_instances()\n",
+    "INSTANCE_LOOKUP = dict(INSTANCES)\n",
+    "print(f\"Primitives : {len(DSL)} | Instances par slot : {len(INSTANCES)}\")\n",
+    "n = len(INSTANCES)\n",
+    "MAX_DEPTH = 4\n",
+    "print(f\"Espace total (profondeur <= {MAX_DEPTH}) : \"\n",
+    "      f\"{n} + {n}**2 + {n}**3 + {n}**4 = \"\n",
+    "      f\"{sum(n ** d for d in range(1, MAX_DEPTH + 1)):,} programmes\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:04:45.385584Z",
+     "iopub.status.busy": "2026-08-26T20:04:45.385584Z",
+     "iopub.status.idle": "2026-08-26T20:04:45.389592Z",
+     "shell.execute_reply": "2026-08-26T20:04:45.389592Z"
+    },
+    "papermill": {
+     "duration": 0.011017,
+     "end_time": "2026-08-26T20:04:45.390096",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.379079",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OK   flipud x2 = id\n",
+      "OK   fliplr x2 = id\n",
+      "OK   rot90 x4 = id\n",
+      "OK   transpose x2 = id\n",
+      "OK   recolor sans effet si c absent\n",
+      "OK   mask_keep(c) ne garde que c\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Sanity du DSL : fonctions totales Grid -> Grid, involutivites connues\n",
+    "g = np.array([[1, 2, 0], [3, 0, 2], [0, 1, 5], [3, 3, 0]])\n",
+    "checks = {\n",
+    "    \"flipud x2 = id\": np.array_equal(flipud(flipud(g)), g),\n",
+    "    \"fliplr x2 = id\": np.array_equal(fliplr(fliplr(g)), g),\n",
+    "    \"rot90 x4 = id\": np.array_equal(rot90(rot90(rot90(rot90(g)))), g),\n",
+    "    \"transpose x2 = id\": np.array_equal(transpose(transpose(g)), g),\n",
+    "    \"recolor sans effet si c absent\": np.array_equal(make_recolor(8, 9)(g), g),\n",
+    "    \"mask_keep(c) ne garde que c\": set(np.unique(make_mask_keep(2)(g))) <= {0, 2},\n",
+    "}\n",
+    "for k, v in checks.items():\n",
+    "    print((\"OK  \" if v else \"FAIL\"), k)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-08",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003001,
+     "end_time": "2026-08-26T20:04:45.396101",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.393100",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Trois taches ARC-like : flip, isolation, composition\n",
+    "\n",
+    "Chaque tache fournit **deux exemples d'entrainement** (la solution doit reproduire les deux sorties) et **une grille de test** (generalisation). Les solutions attendues montent en profondeur :\n",
+    "\n",
+    "- **T1 Miroir teinte** : `flipud` puis `recolor(3, 5)` — profondeur 2, mais l'instance `recolor:3:5` est une aiguille dans 90 bottes de foin ;\n",
+    "- **T2 Isoler la forme** : `mask_keep(4)` puis `crop_content` — profondeur 2 ;\n",
+    "- **T3 Retourner, isoler, cadrer** : `flipud` puis `mask_keep(4)` puis `crop_content` — profondeur 3. Trois effets independants (geometrique, masque, cadrage) qu'aucune primitive ne combine : la solution la plus courte possible fait 3 etapes. C'est la tache du mur.\n",
+    "\n",
+    "Remarque de conception : les grilles sont **non carrees** — sur une grille carree, des compositions du groupe des symetries du carre se reduisent a un simple flip (par exemple transpose apres rot90 redonne flipud), et la tache \"profondeur 3\" n'en serait pas une. Les grilles rectangulaires ecartent ces equivalents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:04:45.403612Z",
+     "iopub.status.busy": "2026-08-26T20:04:45.403612Z",
+     "iopub.status.idle": "2026-08-26T20:04:45.412005Z",
+     "shell.execute_reply": "2026-08-26T20:04:45.412005Z"
+    },
+    "papermill": {
+     "duration": 0.013919,
+     "end_time": "2026-08-26T20:04:45.413019",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.399100",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- T1 miroir teinte | solution attendue : flipud >> recolor:3:5\n",
+      "--- T2 isoler la forme | solution attendue : mask_keep:4 >> crop_content\n",
+      "--- T3 retourner-isoler-cadrer | solution attendue : flipud >> mask_keep:4 >> crop_content\n"
+     ]
+    }
+   ],
+   "source": [
+    "def grid(*rows):\n",
+    "    return np.array(rows, dtype=int)\n",
+    "\n",
+    "\n",
+    "def show(g):\n",
+    "    return \"\\n\".join(\" \".join(str(v) for v in row) for row in g)\n",
+    "\n",
+    "\n",
+    "TASKS = {}\n",
+    "\n",
+    "# --- T1 : miroir vertical, puis la couleur 3 devient 5 -----------------------\n",
+    "t1a_in = grid([3, 0, 2], [1, 3, 0], [0, 2, 3], [3, 3, 1])\n",
+    "t1a_out = make_recolor(3, 5)(flipud(t1a_in))\n",
+    "t1b_in = grid([3, 2, 2, 0], [0, 3, 1, 3], [2, 0, 3, 0])\n",
+    "t1b_out = make_recolor(3, 5)(flipud(t1b_in))\n",
+    "t1_test = grid([3, 1, 0, 3], [2, 3, 3, 0], [0, 0, 3, 2], [1, 3, 2, 3], [3, 3, 0, 1])\n",
+    "TASKS[\"T1 miroir teinte\"] = {\n",
+    "    \"train\": [(t1a_in, t1a_out), (t1b_in, t1b_out)], \"test\": t1_test,\n",
+    "    \"solution\": [\"flipud\", \"recolor:3:5\"]}\n",
+    "\n",
+    "# --- T2 : garder la couleur 4, puis cadrer sur le contenu --------------------\n",
+    "# (les 4 strictement interieurs : le cadrage n'est pas un no-op,\n",
+    "#  et du contenu non-4 hors de la boite des 4 rend l'ordre masque->cadre obligatoire)\n",
+    "t2a_in = grid([1, 0, 7, 0], [0, 4, 0, 4], [0, 0, 4, 0], [2, 0, 0, 0])\n",
+    "t2a_out = crop_content(make_mask_keep(4)(t2a_in))\n",
+    "t2b_in = grid([9, 0, 0, 0, 8], [0, 4, 0, 0, 0], [0, 0, 4, 4, 0])\n",
+    "t2b_out = crop_content(make_mask_keep(4)(t2b_in))\n",
+    "t2_test = grid([5, 0, 0, 0], [0, 4, 0, 4], [0, 0, 4, 0], [6, 0, 0, 0])\n",
+    "TASKS[\"T2 isoler la forme\"] = {\n",
+    "    \"train\": [(t2a_in, t2a_out), (t2b_in, t2b_out)], \"test\": t2_test,\n",
+    "    \"solution\": [\"mask_keep:4\", \"crop_content\"]}\n",
+    "\n",
+    "# --- T3 : retourner, isoler les 4, cadrer (profondeur 3 exacte) --------------\n",
+    "t3a_in = grid([0, 4, 0, 2], [7, 0, 4, 0], [0, 4, 0, 0], [2, 0, 0, 4])\n",
+    "t3a_out = crop_content(make_mask_keep(4)(flipud(t3a_in)))\n",
+    "t3b_in = grid([4, 9, 0, 4, 0], [0, 0, 4, 0, 1], [6, 4, 0, 0, 0])\n",
+    "t3b_out = crop_content(make_mask_keep(4)(flipud(t3b_in)))\n",
+    "t3_test = grid([0, 4, 0, 8], [4, 0, 4, 0], [3, 0, 0, 0], [0, 4, 5, 4])\n",
+    "TASKS[\"T3 retourner-isoler-cadrer\"] = {\n",
+    "    \"train\": [(t3a_in, t3a_out), (t3b_in, t3b_out)], \"test\": t3_test,\n",
+    "    \"solution\": [\"flipud\", \"mask_keep:4\", \"crop_content\"]}\n",
+    "\n",
+    "for name, t in TASKS.items():\n",
+    "    print(f\"--- {name} | solution attendue : {' >> '.join(t['solution'])}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:04:45.420125Z",
+     "iopub.status.busy": "2026-08-26T20:04:45.420125Z",
+     "iopub.status.idle": "2026-08-26T20:04:45.424309Z",
+     "shell.execute_reply": "2026-08-26T20:04:45.424309Z"
+    },
+    "papermill": {
+     "duration": 0.009438,
+     "end_time": "2026-08-26T20:04:45.425557",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.416119",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OK   T1 miroir teinte -> flipud >> recolor:3:5\n",
+      "OK   T2 isoler la forme -> mask_keep:4 >> crop_content\n",
+      "OK   T3 retourner-isoler-cadrer -> flipud >> mask_keep:4 >> crop_content\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verification : chaque tache est bien resolue par sa solution attendue\n",
+    "import functools\n",
+    "\n",
+    "\n",
+    "def compose(prog, gin):\n",
+    "    return functools.reduce(lambda acc, f: f(acc),\n",
+    "                            [INSTANCE_LOOKUP[s] for s in prog], gin)\n",
+    "\n",
+    "\n",
+    "for name, t in TASKS.items():\n",
+    "    ok = all(np.array_equal(compose(t[\"solution\"], gin), gout)\n",
+    "             for gin, gout in t[\"train\"])\n",
+    "    print((\"OK  \" if ok else \"FAIL\"), name, \"->\", \" >> \".join(t[\"solution\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-11",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003999,
+     "end_time": "2026-08-26T20:04:45.433560",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.429561",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Bras 1 — la recherche exhaustive bornee (le mur)\n",
+    "\n",
+    "Le solveur enumere les programmes **par profondeur croissante, ordre lexicographique des instances** — completement deterministe. Il s'arrete au premier programme qui reproduit **tous** les exemples d'entrainement. Le **budget de 15 000 noeuds** (une fraction infime de l'espace) encode le mur : au-dela, echec mesure, pas attente opaque.\n",
+    "\n",
+    "Trois quantites separent honnetement ce qui est **mesure** de ce qui est **extrapole** :\n",
+    "\n",
+    "- noeuds explores, temps, verdict : **mesures** ;\n",
+    "- temps total de l'espace complet : **extrapolation** depuis le debit mesure (noeuds/seconde), jamais execute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:04:45.442558Z",
+     "iopub.status.busy": "2026-08-26T20:04:45.441557Z",
+     "iopub.status.idle": "2026-08-26T20:04:45.541172Z",
+     "shell.execute_reply": "2026-08-26T20:04:45.541172Z"
+    },
+    "papermill": {
+     "duration": 0.105617,
+     "end_time": "2026-08-26T20:04:45.542177",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.436560",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T1 miroir teinte           TROUVE           noeuds=    400 temps= 0.003s prog=['flipud', 'recolor:3:5']\n",
+      "T2 isoler la forme         TROUVE           noeuds=  2,071 temps= 0.009s prog=['mask_keep:4', 'crop_content']\n",
+      "T3 retourner-isoler-cadrer BUDGET_DEPASSE   noeuds= 15,001 temps= 0.080s prog=None\n"
+     ]
+    }
+   ],
+   "source": [
+    "BUDGET_NODES = 15_000\n",
+    "\n",
+    "\n",
+    "def apply_program(prog_names, g):\n",
+    "    for step in prog_names:\n",
+    "        g = INSTANCE_LOOKUP[step](g)\n",
+    "    return g\n",
+    "\n",
+    "\n",
+    "def solves(prog_names, task):\n",
+    "    return all(np.array_equal(apply_program(prog_names, gin), gout)\n",
+    "               for gin, gout in task[\"train\"])\n",
+    "\n",
+    "\n",
+    "def exhaustive_solve(task, instances=None, max_depth=MAX_DEPTH,\n",
+    "                     budget=BUDGET_NODES, time_budget_s=120):\n",
+    "    # DFS par profondeur croissante. Rend (verdict, programme, noeuds, secondes).\n",
+    "    if instances is None:\n",
+    "        instances = INSTANCES\n",
+    "    t0 = time.perf_counter()\n",
+    "    nodes = 0\n",
+    "    for depth in range(1, max_depth + 1):\n",
+    "        for combo in itertools.product(instances, repeat=depth):\n",
+    "            nodes += 1\n",
+    "            if nodes > budget or (time.perf_counter() - t0) > time_budget_s:\n",
+    "                return (\"BUDGET_DEPASSE\", None, nodes, time.perf_counter() - t0)\n",
+    "            names = [n_ for n_, _ in combo]\n",
+    "            if solves(names, task):\n",
+    "                return (\"TROUVE\", names, nodes, time.perf_counter() - t0)\n",
+    "    return (\"INTROUVABLE_DEPTH\", None, nodes, time.perf_counter() - t0)\n",
+    "\n",
+    "\n",
+    "results_b1 = {}\n",
+    "for name, task in TASKS.items():\n",
+    "    verdict, prog, nodes, secs = exhaustive_solve(task)\n",
+    "    results_b1[name] = (verdict, prog, nodes, secs)\n",
+    "    print(f\"{name:26s} {verdict:16s} noeuds={nodes:7,d} temps={secs:6.3f}s prog={prog}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:04:45.550245Z",
+     "iopub.status.busy": "2026-08-26T20:04:45.550245Z",
+     "iopub.status.idle": "2026-08-26T20:04:45.554297Z",
+     "shell.execute_reply": "2026-08-26T20:04:45.554297Z"
+    },
+    "papermill": {
+     "duration": 0.00906,
+     "end_time": "2026-08-26T20:04:45.555303",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.546243",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Debit mesure : 169,038 noeuds/seconde (moyenne des taches executees)\n",
+      "Espace complet : 176,434,840 programmes\n",
+      "Temps total extrapole : 1,044 s = 0.3 heures\n",
+      "\n",
+      "Le budget de 15,000 noeuds couvre ~0.0 % de l'espace.\n",
+      "Une solution situee apres le budget est INACCESSIBLE au bras 1 : c'est le mur a reduire.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Debit mesure -> extrapolation honnete du mur (jamais execute en entier)\n",
+    "rate = np.mean([results_b1[n_][3] / max(results_b1[n_][2], 1) for n_ in TASKS])\n",
+    "n = len(INSTANCES)\n",
+    "total_space = sum(n ** d for d in range(1, MAX_DEPTH + 1))\n",
+    "print(f\"Debit mesure : {1 / rate:,.0f} noeuds/seconde (moyenne des taches executees)\")\n",
+    "print(f\"Espace complet : {total_space:,} programmes\")\n",
+    "print(f\"Temps total extrapole : {total_space * rate:,.0f} s \"\n",
+    "      f\"= {total_space * rate / 3600:,.1f} heures\")\n",
+    "print()\n",
+    "print(f\"Le budget de {BUDGET_NODES:,} noeuds couvre ~{100 * BUDGET_NODES / total_space:.1f} % de l'espace.\")\n",
+    "print(\"Une solution situee apres le budget est INACCESSIBLE au bras 1 : c'est le mur a reduire.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-14",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003526,
+     "end_time": "2026-08-26T20:04:45.561339",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.557813",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Bras 2 — LLM-direct : solver ou illusion ?\n",
+    "\n",
+    "Le modele recoit la documentation du DSL et les exemples d'entrainement serialises, et doit rendre **le programme solution** en JSON strict. Rien ne guide sa reponse : soit il inferere la transformation, soit non. On mesure la reussite **verifiee sur les exemples** — une reponse qui ne matche pas les exemples compte echec, meme si elle ressemble a une solution. Une relance unique est accordee si la reponse est illisible (les modeles raisonneurs consomment parfois tout leur budget de tokens en raisonnement interne) ; elle est mesuree et rapportee dans les sorties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cell-15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:04:45.567523Z",
+     "iopub.status.busy": "2026-08-26T20:04:45.567523Z",
+     "iopub.status.idle": "2026-08-26T20:04:45.574364Z",
+     "shell.execute_reply": "2026-08-26T20:04:45.574364Z"
+    },
+    "papermill": {
+     "duration": 0.011529,
+     "end_time": "2026-08-26T20:04:45.575383",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.563854",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Helpers prets. Client : OK\n"
+     ]
+    }
+   ],
+   "source": [
+    "SYSTEM_PROMPT = (\n",
+    "    \"Tu es un solveur de puzzles de grilles. Tu disposes d'un DSL de primitives \"\n",
+    "    \"sur des grilles d'entiers 0-9 : flipud, fliplr, rot90 (quart de tour horaire), \"\n",
+    "    \"transpose, crop_content (cadre sur les cases non nulles), recolor:c1:c2 \"\n",
+    "    \"(c1 devient c2), mask_keep:c (garde uniquement c), mask_drop:c (passe c a 0). \"\n",
+    "    \"Un programme est une liste d'instances appliquees en sequence. \"\n",
+    "    \"Reponds UNIQUEMENT en JSON : {\\\"program\\\": [\\\"primitive(:args)\\\", ...]}. \"\n",
+    "    \"Le programme doit transformer chaque entree en sa sortie. Programmes courts d'abord.\"\n",
+    ")\n",
+    "\n",
+    "REDUCER_PROMPT = (\n",
+    "    \"Tu es un ANALYSTE d'espace de recherche, PAS un solveur. Observe les exemples \"\n",
+    "    \"et ne rends PAS la solution : rends UNIQUEMENT le sous-espace de recherche \"\n",
+    "    \"plausible. Reponds en JSON strict : \"\n",
+    "    \"{\\\"primitives\\\": [au plus 3 noms parmi flipud, fliplr, rot90, transpose, \"\n",
+    "    \"crop_content, recolor, mask_keep, mask_drop], \\\"max_depth\\\": 1, 2 ou 3}. \"\n",
+    "    \"recolor/mask_keep/mask_drop comptent pour UNE primitive (leurs arguments restent libres). \"\n",
+    "    \"Choisis le sous-espace MINIMAL dans lequel la solution semble vivre.\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def serialize_task(task):\n",
+    "    parts = []\n",
+    "    for i, (gin, gout) in enumerate(task[\"train\"]):\n",
+    "        parts.append(f\"exemple {i + 1} entree:\\n{show(gin)}\\n\"\n",
+    "                     f\"exemple {i + 1} sortie:\\n{show(gout)}\")\n",
+    "    return \"\\n\\n\".join(parts)\n",
+    "\n",
+    "\n",
+    "def call_llm(system, user, max_completion_tokens=8000):\n",
+    "    # Les modeles raisonneurs ne supportent ni temperature ni seed :\n",
+    "    # deux executions peuvent differer (le solveur, lui, reste deterministe).\n",
+    "    # Budget large : le raisonnement interne consomme les tokens avant la reponse.\n",
+    "    resp = llm_client.chat.completions.create(\n",
+    "        model=LLM_MODEL,\n",
+    "        messages=[{\"role\": \"system\", \"content\": system},\n",
+    "                  {\"role\": \"user\", \"content\": user}],\n",
+    "        max_completion_tokens=max_completion_tokens)\n",
+    "    return resp.choices[0].message.content or \"\"\n",
+    "\n",
+    "\n",
+    "def call_llm_json(system, user):\n",
+    "    # Un appel + AU PLUS une relance si la reponse est illisible.\n",
+    "    # Rend (parsed, essais). La relance est mesuree et rapportee.\n",
+    "    for attempt in (1, 2):\n",
+    "        raw = call_llm(system, user)\n",
+    "        parsed = parse_json_block(raw)\n",
+    "        if parsed is not None:\n",
+    "            return parsed, attempt\n",
+    "    return None, 2\n",
+    "\n",
+    "\n",
+    "def parse_json_block(text):\n",
+    "    # Extrait le premier objet JSON d'une reponse (tolere les fences markdown).\n",
+    "    text = text.strip()\n",
+    "    if \"```\" in text:\n",
+    "        for block in text.split(\"```\"):\n",
+    "            block = block.removeprefix(\"json\").strip()\n",
+    "            if block.startswith(\"{\"):\n",
+    "                text = block\n",
+    "                break\n",
+    "    start, end = text.find(\"{\"), text.rfind(\"}\")\n",
+    "    if start == -1 or end <= start:\n",
+    "        return None\n",
+    "    try:\n",
+    "        return json.loads(text[start:end + 1])\n",
+    "    except json.JSONDecodeError:\n",
+    "        return None\n",
+    "\n",
+    "\n",
+    "print(\"Helpers prets. Client :\", \"OK\" if llm_client else \"ABSENT\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cell-16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:04:45.581890Z",
+     "iopub.status.busy": "2026-08-26T20:04:45.581890Z",
+     "iopub.status.idle": "2026-08-26T20:05:45.127523Z",
+     "shell.execute_reply": "2026-08-26T20:05:45.127523Z"
+    },
+    "papermill": {
+     "duration": 59.553347,
+     "end_time": "2026-08-26T20:05:45.131230",
+     "exception": false,
+     "start_time": "2026-08-26T20:04:45.577883",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T1 miroir teinte           TROUVE         essais=1 prog=['recolor:3:5', 'flipud']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T2 isoler la forme         TROUVE         essais=1 prog=['mask_keep:4', 'crop_content']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T3 retourner-isoler-cadrer TROUVE         essais=1 prog=['mask_keep:4', 'crop_content', 'flipud']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Bras 2 : le LLM rend directement le programme — verdict VERIFIE sur les exemples\n",
+    "results_b2 = {}\n",
+    "if llm_client:\n",
+    "    for name, task in TASKS.items():\n",
+    "        try:\n",
+    "            parsed, essais = call_llm_json(SYSTEM_PROMPT, serialize_task(task))\n",
+    "            prog = parsed.get(\"program\") if isinstance(parsed, dict) else None\n",
+    "            if isinstance(prog, list) and prog and solves(prog, task):\n",
+    "                verdict, kept = \"TROUVE\", prog\n",
+    "            elif isinstance(prog, list) and prog:\n",
+    "                verdict, kept = \"NE_MATCH_PAS\", prog\n",
+    "            else:\n",
+    "                verdict, kept = \"PARSE_FAIL\", None\n",
+    "        except Exception as e:\n",
+    "            verdict, kept, essais = f\"ERREUR_API ({type(e).__name__})\", None, 1\n",
+    "        results_b2[name] = (verdict, kept)\n",
+    "        print(f\"{name:26s} {verdict:14s} essais={essais} prog={kept}\")\n",
+    "else:\n",
+    "    print(\"Client LLM absent : bras 2 non execute (constat affiche, pas de substitution).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-17",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003001,
+     "end_time": "2026-08-26T20:05:45.137228",
+     "exception": false,
+     "start_time": "2026-08-26T20:05:45.134227",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Bras 3 — le LLM comme reducteur d'espace\n",
+    "\n",
+    "Le meme modele, un prompt system different : il ne rend **ni programme ni solution**, seulement un sous-espace — au plus 3 primitives et une borne de profondeur. Le solveur deterministe du bras 1 tourne **a l'identique** dans ce sous-espace restreint : ce sont les instances candidates qui changent, pas l'algorithme ni la verification.\n",
+    "\n",
+    "Deux issues possibles, toutes deux informatives :\n",
+    "\n",
+    "- la solution vit dans le sous-espace : le solveur la trouve, **prouvee par exemples** ;\n",
+    "- elle n'y vit pas : echec propre du bras 3 — le reducteur s'est trompe, et personne n'a pretendu le contraire.\n",
+    "\n",
+    "C'est le contrat de la these : la reduction n'achete pas la correction, elle achete la **traversabilite**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cell-18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:05:45.145738Z",
+     "iopub.status.busy": "2026-08-26T20:05:45.144738Z",
+     "iopub.status.idle": "2026-08-26T20:07:00.743521Z",
+     "shell.execute_reply": "2026-08-26T20:07:00.743521Z"
+    },
+    "papermill": {
+     "duration": 75.603797,
+     "end_time": "2026-08-26T20:07:00.744534",
+     "exception": false,
+     "start_time": "2026-08-26T20:05:45.140737",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T1 miroir teinte           TROUVE           sous-espace= 8,372 noeuds=   124 temps=0.001s essais=1 sel=['flipud', 'recolor'] depth=2 prog=['flipud', 'recolor:3:5']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T2 isoler la forme         TROUVE           sous-espace=   132 noeuds=    67 temps=0.000s essais=1 sel=['mask_keep', 'crop_content'] depth=2 prog=['mask_keep:4', 'crop_content']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T3 retourner-isoler-cadrer TROUVE           sous-espace= 1,884 noeuds=   373 temps=0.003s essais=1 sel=['mask_keep', 'crop_content', 'flipud'] depth=3 prog=['flipud', 'mask_keep:4', 'crop_content']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Bras 3 : reduction LLM -> sous-espace -> MEME solveur deterministe\n",
+    "results_b3 = {}\n",
+    "if llm_client:\n",
+    "    for name, task in TASKS.items():\n",
+    "        try:\n",
+    "            parsed, essais = call_llm_json(REDUCER_PROMPT, serialize_task(task))\n",
+    "            prim_sel = parsed.get(\"primitives\") if isinstance(parsed, dict) else None\n",
+    "            depth = parsed.get(\"max_depth\") if isinstance(parsed, dict) else None\n",
+    "            if not (isinstance(prim_sel, list) and prim_sel\n",
+    "                    and isinstance(depth, int) and 1 <= depth <= 3):\n",
+    "                results_b3[name] = (\"PARSE_FAIL\", None, None, None, None)\n",
+    "                print(f\"{name:26s} PARSE_FAIL (essais={essais})\")\n",
+    "                continue\n",
+    "            base = lambda s: s.split(\":\")[0]\n",
+    "            sub = [(nm, f) for nm, f in INSTANCES if base(nm) in prim_sel]\n",
+    "            sub_size = sum(len(sub) ** d for d in range(1, depth + 1))\n",
+    "            verdict, prog, nodes, secs = exhaustive_solve(\n",
+    "                task, instances=sub, max_depth=depth, budget=BUDGET_NODES)\n",
+    "            results_b3[name] = (verdict, prog, nodes, secs,\n",
+    "                                (prim_sel, depth, sub_size))\n",
+    "            print(f\"{name:26s} {verdict:16s} sous-espace={sub_size:6,d} \"\n",
+    "                  f\"noeuds={nodes:6,d} temps={secs:5.3f}s essais={essais} \"\n",
+    "                  f\"sel={prim_sel} depth={depth} prog={prog}\")\n",
+    "        except Exception as e:\n",
+    "            results_b3[name] = (f\"ERREUR_API ({type(e).__name__})\", None, None, None, None)\n",
+    "            print(f\"{name:26s} ERREUR_API ({type(e).__name__})\")\n",
+    "else:\n",
+    "    print(\"Client LLM absent : bras 3 non execute (constat affiche, pas de substitution).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-19",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003411,
+     "end_time": "2026-08-26T20:07:00.750958",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.747547",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Comparaison honnete des trois bras\n",
+    "\n",
+    "Les trois bras ont affronte les memes taches. La table finale rassemble les mesures brutes : noeuds explores, temps, verdict verifie. Les echecs sont des **donnees** — un LLM-direct qui se trompe ou un reducteur trop etroit sont des resultats, pas des accidents a maquiller."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cell-20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:07:00.759517Z",
+     "iopub.status.busy": "2026-08-26T20:07:00.759517Z",
+     "iopub.status.idle": "2026-08-26T20:07:00.764282Z",
+     "shell.execute_reply": "2026-08-26T20:07:00.764282Z"
+    },
+    "papermill": {
+     "duration": 0.010339,
+     "end_time": "2026-08-26T20:07:00.765294",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.754955",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tache                      | Bras 1 exhaustif                     | Bras 2 LLM-direct              | Bras 3 LLM-reducteur                        \n",
+      "-------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "T1 miroir teinte           | TROUVE (400 nds, 0.0s)               | TROUVE recolor:3:5 flipud      | TROUVE (124/8,372 nds, 0.0s)                \n",
+      "T2 isoler la forme         | TROUVE (2,071 nds, 0.0s)             | TROUVE mask_keep:4 crop_conten | TROUVE (67/132 nds, 0.0s)                   \n",
+      "T3 retourner-isoler-cadrer | BUDGET_DEPASSE (15,001 nds, 0.1s)    | TROUVE mask_keep:4 crop_conten | TROUVE (373/1,884 nds, 0.0s)                \n",
+      "\n",
+      "T1 miroir teinte           reduction x21,074 (176,434,840 -> 8,372 programmes, profondeur <= 2)\n",
+      "T2 isoler la forme         reduction x1,336,628 (176,434,840 -> 132 programmes, profondeur <= 2)\n",
+      "T3 retourner-isoler-cadrer reduction x93,649 (176,434,840 -> 1,884 programmes, profondeur <= 3)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Table finale : 3 taches x 3 bras\n",
+    "header = (f\"{'Tache':26s} | {'Bras 1 exhaustif':36s} | \"\n",
+    "          f\"{'Bras 2 LLM-direct':30s} | {'Bras 3 LLM-reducteur':44s}\")\n",
+    "print(header)\n",
+    "print(\"-\" * len(header))\n",
+    "for name in TASKS:\n",
+    "    v1, p1, n1, s1 = results_b1[name]\n",
+    "    b1 = f\"{v1} ({n1:,} nds, {s1:.1f}s)\"\n",
+    "    if name in results_b2:\n",
+    "        v2, p2 = results_b2[name]\n",
+    "        b2 = f\"{v2} {' '.join(p2) if p2 else ''}\"[:30]\n",
+    "    else:\n",
+    "        b2 = \"non execute\"\n",
+    "    r3 = results_b3.get(name)\n",
+    "    if r3 and r3[4] is not None:\n",
+    "        v3, p3, n3, s3, (sel, d3, sub) = r3\n",
+    "        b3 = f\"{v3} ({n3:,}/{sub:,} nds, {s3:.1f}s)\"[:44]\n",
+    "    else:\n",
+    "        b3 = \"non execute\"\n",
+    "    print(f\"{name:26s} | {b1:36s} | {b2:30s} | {b3:44s}\")\n",
+    "\n",
+    "# Espace total vs sous-espaces : le rapport de reduction, mesure\n",
+    "n = len(INSTANCES)\n",
+    "total = sum(n ** d for d in range(1, MAX_DEPTH + 1))\n",
+    "reductions = [(nm, r[4]) for nm in TASKS\n",
+    "              if (r := results_b3.get(nm)) is not None and r[4] is not None]\n",
+    "if reductions:\n",
+    "    print()\n",
+    "    for name, (sel, d3, sub) in reductions:\n",
+    "        print(f\"{name:26s} reduction x{total / sub:,.0f} \"\n",
+    "              f\"({total:,} -> {sub:,} programmes, profondeur <= {d3})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-21",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004506,
+     "end_time": "2026-08-26T20:07:00.772798",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.768292",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture : ce que la these dit, et ce qu'elle ne dit pas\n",
+    "\n",
+    "Trois enseignements se lisent sur les chiffres ci-dessus :\n",
+    "\n",
+    "1. **Le mur est reel mais pas uniforme** : les taches de profondeur 2 tombent en centaines ou milliers de noeuds ; la profondeur 3 plonge la solution au coeur d'un espace de pres de 200 millions de programmes — hors budget. L'ordre lexicographique determine si elle tombe avant ou apres la coupe.\n",
+    "2. **LLM-direct est sans garantie** : meme reussi, le programme rendu n'est accepte qu'apres verification par exemples — c'est le solveur qui certifie, jamais le modele. Un echec de parse ou de match est un resultat normal de cette position, pas un bug.\n",
+    "3. **Le reducteur deplace le mur** : le sous-espace selectionne traverse en une fraction du budget. Si la selection rate une primitive necessaire, l'echec est **propre et diagnostique** (INTROUVABLE dans un petit espace, pas un timeout opaque). La correction reste entierement cote solveur.\n",
+    "\n",
+    "Deux precautions honnetes : les appels LLM ne fixent ni temperature ni seed (non supportes par les modeles raisonneurs) — deux executions du notebook peuvent differer sur les bras 2 et 3, jamais sur le bras 1 ; et chaque appel a un cout. En production de recherche, aicpp pousse ce contrat jusqu'a la boucle compilee C++ et aux 69/120 taches ARC-AGI-2 training ; ce notebook en reste au geste, volontairement inspectable ligne a ligne."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-22",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004377,
+     "end_time": "2026-08-26T20:07:00.780168",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.775791",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Ponts et precautions\n",
+    "\n",
+    "- **[Planners-10](Planners-10-LLM-Planning.ipynb)** : le LLM **generateur** de plans — la position que la these reductrice remet en cause, avec les memes symptomes (hallucination d'etapes, plans invalides).\n",
+    "- **[Planners-11](Planners-11-Unified-Planning.ipynb)** : la boucle plan-execute-compile d'aicpp (C++ genere, recompile, reexecute) est une instance concrete du pattern unifie.\n",
+    "- **[Planners-12](Planners-12-LOOP.ipynb)** : Learning to Plan apprend la **representation** ; le reducteur LLM la **demande**. Deux facons de ne pas laisser le modele resoudre.\n",
+    "- **Serie SymbolicLearning** : les primitives typees et la memoire structurelle d'aicpp resonnent avec le library learning interpretable (compressibilite par abstractions reutilisables).\n",
+    "- **ARC-AGI** : ce benchmark fait ici une apparition miniaturisee, sur le sous-ensemble flip/color/mask des transformations.\n",
+    "\n",
+    "**Precautions sur la source** : aicpp (Julien Livet, Apache 2.0) est un depot **jeune et actif** (cree janvier 2026) ; toute execution du moteur reel doit figer un commit precis. Les auteurs le presentent eux-memes comme **non-production ARC solver** — exploration de recherche, pas produit. Ce notebook cite et s'inspire du positionnement ; il ne porte pas leur code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-23",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003996,
+     "end_time": "2026-08-26T20:07:00.788188",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.784192",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Resume\n",
+    "\n",
+    "| Concept | En une phrase |\n",
+    "|---|---|\n",
+    "| LLM-solver | le modele rend la solution ; rien ne la garantit |\n",
+    "| LLM-reducteur | le modele restreint l'espace ; le solveur deterministe garantit la solution |\n",
+    "| Budget de noeuds | le mur rendu mesurable : echec propre au-dela, pas d'attente opaque |\n",
+    "| Verification par exemples | la seule source de correction, toujours cote solveur |\n",
+    "| Echec de reduction | une donnee diagnostiquee (INTROUVABLE en petit espace), pas une faute du solveur |\n",
+    "\n",
+    "**Fil conducteur de la serie** : du LLM prompte (10) a l'interface unifiee (11), du plan appris (12) a l'espace reduit (13) — l'agent qui cherche change, la structure symbolique persiste."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-24",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003568,
+     "end_time": "2026-08-26T20:07:00.795755",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.792187",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : etendre le DSL d'une primitive\n",
+    "\n",
+    "Ajoutez `swap_colors(c1, c2)` (echange deux couleurs) au registre, puis construisez une tache dont la solution est `swap_colors:2:7` suivi de `flipud`. Montrez — en executant le solveur du bras 1 sur votre tache — que **le solveur n'a pas change d'une ligne** : seule l'enumeration des instances s'est enrichie. C'est la propriete qui fait la valeur d'un DSL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cell-25",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:07:00.804633Z",
+     "iopub.status.busy": "2026-08-26T20:07:00.804633Z",
+     "iopub.status.idle": "2026-08-26T20:07:00.807553Z",
+     "shell.execute_reply": "2026-08-26T20:07:00.807553Z"
+    },
+    "papermill": {
+     "duration": 0.008814,
+     "end_time": "2026-08-26T20:07:00.808568",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.799754",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : TODO etudiant\n",
+    "# 1. Definissez make_swap_colors(c1, c2) sur le modele de make_recolor\n",
+    "# 2. Ajoutez \"swap_colors\" au registre DSL (arite 2)\n",
+    "# 3. Reconstruisez INSTANCES et verifiez le nouveau total\n",
+    "# 4. Construisez une tache a solution [\"swap_colors:2:7\", \"flipud\"]\n",
+    "# 5. Lancez exhaustive_solve dessus et rapportez noeuds/temps\n",
+    "def make_swap_colors(c1, c2):\n",
+    "    # TODO etudiant : renvoyer la grille avec c1 et c2 echanges\n",
+    "    return None\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-26",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004137,
+     "end_time": "2026-08-26T20:07:00.816718",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.812581",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : construire une tache qui resiste au reducteur\n",
+    "\n",
+    "Construisez une tache dont la solution exige `mask_drop` — une primitive que le reducteur LLM a peu de chances de placer dans son top-3 pour un puzzle de couleurs. Executez le bras 3 : attendez-vous a un INTROUVABLE propre dans le sous-espace. C'est le cout structurel de la reduction : un sous-espace faux est muet sur ce qui lui manque."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "cell-27",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:07:00.825559Z",
+     "iopub.status.busy": "2026-08-26T20:07:00.825559Z",
+     "iopub.status.idle": "2026-08-26T20:07:00.828807Z",
+     "shell.execute_reply": "2026-08-26T20:07:00.828807Z"
+    },
+    "papermill": {
+     "duration": 0.009096,
+     "end_time": "2026-08-26T20:07:00.829829",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.820733",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : TODO etudiant\n",
+    "# 1. Construisez une tache (2 exemples + test) a solution [\"mask_drop:9\", \"fliplr\"]\n",
+    "# 2. Verifiez que le bras 1 la trouve (profondeur 2)\n",
+    "# 3. Simulez un reducteur qui selectionne [\"flipud\", \"recolor\", \"crop_content\"]\n",
+    "#    et lancez exhaustive_solve dans ce sous-espace : constatez l'echec propre\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-28",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005066,
+     "end_time": "2026-08-26T20:07:00.838948",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.833882",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : reduire sans LLM — l'heuristique de longueur de description\n",
+    "\n",
+    "Implementez un reducteur **deterministe** MDL-lite : pour chaque primitive, mesurez si elle rapproche l'entree de la sortie (nombre de cellules differentes apres application, moyenne sur les exemples) et gardez les 3 meilleures. Comparez son sous-espace a celui du LLM sur les trois taches : les deux reductions selectionnent-elles les memes primitives ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "cell-29",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-26T20:07:00.848845Z",
+     "iopub.status.busy": "2026-08-26T20:07:00.848845Z",
+     "iopub.status.idle": "2026-08-26T20:07:00.852044Z",
+     "shell.execute_reply": "2026-08-26T20:07:00.852044Z"
+    },
+    "papermill": {
+     "duration": 0.010255,
+     "end_time": "2026-08-26T20:07:00.853058",
+     "exception": false,
+     "start_time": "2026-08-26T20:07:00.842803",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : TODO etudiant\n",
+    "# 1. Score(primitive) = nombre de cellules differentes entre entree et sortie,\n",
+    "#    moyenne sur les exemples (une primitive utile rapproche la sortie)\n",
+    "# 2. Gardez les 3 primitives au meilleur score, profondeur 2\n",
+    "# 3. Lancez le solveur dans ce sous-espace et comparez aux results_b3\n",
+    "print(\"Exercice a completer\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 138.197811,
+   "end_time": "2026-08-26T20:07:01.188891",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Planners-14-LLM-Space-Reducer.ipynb",
+   "output_path": "Planners-14-LLM-Space-Reducer.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-26T20:04:42.991080",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/README.md
@@ -2,7 +2,7 @@
 
 [← Partie 3 — Avancée](../03-Advanced/README.md) | [↑ Planification](../README.md)
 
-La dernière partie explore la **frontière entre IA symbolique et apprentissage profond**. Les parties précédentes ont construit des solveurs que l'on *conçoit* ; celle-ci regarde ce qui change quand on *apprend* à planifier. Trois angles : les LLM comme générateurs de plans (notebook 10), une interface unifiée qui rend le modèle PDDL portable entre tous les moteurs (notebook 11), et surtout *Learning to Plan* (notebook 12) — le point où l'apprentissage rencontre la planification, clôture naturelle de la série vers les foundation models.
+La dernière partie explore la **frontière entre IA symbolique et apprentissage profond**. Les parties précédentes ont construit des solveurs que l'on *conçoit* ; celle-ci regarde ce qui change quand on *apprend* à planifier. Quatre angles : les LLM comme générateurs de plans (notebook 10), une interface unifiée qui rend le modèle PDDL portable entre tous les moteurs (notebook 11), *Learning to Plan* (notebook 12) — le point où l'apprentissage rencontre la planification — et la position inverse (notebook 14) : le LLM non plus solveur mais **réducteur d'espace de recherche**, la correction restant au solveur déterministe, clôture de la série vers les foundation models.
 
 ## Position dans la série
 
@@ -12,7 +12,7 @@ La dernière partie explore la **frontière entre IA symbolique et apprentissage
 | **Partie 4 — Neuro-Symbolique** | **Comment *apprendre* à planifier plutôt que le coder à la main ?** |
 | Fin de la série → | Ponts vers RL, vérification formelle, théorie des jeux |
 
-Le fil conducteur : le geste de planifier — un état, un but, une séquence d'actions — reste identique ; ce qui change, c'est l'agent qui cherche. Du LLM prompté (notebook 10) au réseau qui apprend une heuristique (notebook 12), la structure symbolique persiste sous l'apprentissage. C'est elle, rappelle le fil rouge de la série, que l'on emporte au-delà.
+Le fil conducteur : le geste de planifier — un état, un but, une séquence d'actions — reste identique ; ce qui change, c'est l'agent qui cherche. Du LLM prompté (notebook 10) au réseau qui apprend une heuristique (notebook 12) jusqu'au LLM qui se borne à restreindre l'espace (notebook 14), la structure symbolique persiste sous l'apprentissage. C'est elle, rappelle le fil rouge de la série, que l'on emporte au-delà.
 
 ## Notebooks
 
@@ -21,12 +21,13 @@ Le fil conducteur : le geste de planifier — un état, un but, une séquence d'
 | 10 | [Planners-10-LLM-Planning](Planners-10-LLM-Planning.ipynb) | 50 min | Large Language Models pour la planification : prompting, génération de plans, plan repair ; limites et avantages |
 | 11 | [Planners-11-Unified-Planning](Planners-11-Unified-Planning.ipynb) | 40 min | Interface `unified-planning` : un modèle PDDL, plusieurs solveurs, comparaison croisée des performances |
 | 12 | [Planners-12-LOOP](Planners-12-LOOP.ipynb) | 45 min | Learning to Plan (framework LOOP) : state encoder, policy/value networks, encodage PDDL en tenseurs, 85,8 % de coverage IPC |
+| 14 | [Planners-14-LLM-Space-Reducer](Planners-14-LLM-Space-Reducer.ipynb) | 40 min | Le LLM comme réducteur d'espace de recherche (position aicpp) : mini-DSL sur grilles ARC, trois bras mesurés — exhaustif borné, LLM-direct, LLM-réducteur |
 
 ## Prérequis
 
 - **Parties 1 à 3** : toute la mécanique de la planification symbolique (notebooks 1-9)
 - **Machine learning** (notebooks 10, 12) : réseaux de neurones, fonction de perte, rétropropagation
-- **API LLM** (notebook 10) : clé OpenAI/Anthropic, prompting
+- **API LLM** (notebooks 10, 14) : clé OpenAI/Anthropic/OpenRouter, prompting
 - **PyTorch** (notebook 12) : tenseurs, modules, boucle d'entraînement
 
 ## À l'issue de cette partie
@@ -36,7 +37,8 @@ Vous saurez :
 1. **Utiliser** un LLM pour générer et réparer des plans, et en mesurer les limites
 2. **Abstraire** un problème de planification via unified-planning pour le porter d'un solveur à l'autre
 3. **Entraîner** un modèle à planifier (LOOP) : encoder un état PDDL, apprendre une politique ou une heuristique
-4. **Situer** la planification neuro-symbolique dans la trajectoire des foundation models
+4. **Comparer** LLM-solver et LLM-réducteur (notebook 14) : trois bras mesurés (nœuds, temps, réussite vérifiée) sur un mini-DSL ARC
+5. **Situer** la planification neuro-symbolique dans la trajectoire des foundation models
 
 ## Pour aller plus loin (fin de série)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -35,7 +35,7 @@ flowchart TD
     P1["<b>Phase 1 · Fondations</b><br/>triptyque État-Action-But, modèle STRIPS, langage PDDL"]
     P2["<b>Phase 2 · Classique</b><br/>recherche dans l'espace d'états : Fast Downward, heuristiques A* / h(FF) / LM-cut"]
     P3["<b>Phase 3 · Avancée</b><br/>au-delà de l'explosion d'états : CP-SAT (OR-Tools), temporel, HTN"]
-    P4["<b>Phase 4 · Neuro-symbolique</b><br/>frontière IA symbolique ↔ apprentissage : LLM planning, Learning to Plan"]
+    P4["<b>Phase 4 · Neuro-symbolique</b><br/>frontière IA symbolique ↔ apprentissage : LLM planning, Learning to Plan, LLM réducteur d'espace"]
     P1 -->|"modéliser un problème"| P2
     P2 -->|"l'explosion d'états bloque"| P3
     P3 -->|"doter le symbolique d'apprentissage"| P4
@@ -69,9 +69,9 @@ La planification classique épuise ses limites dès que les problèmes deviennen
 
 <p align="center"><a href="03-Advanced/Planners-8-Temporal.ipynb"><img src="assets/readme/planners8-temporal.png" width="560" alt="Planification temporelle : chronologie d'actions avec durées et contraintes de scheduling sur un réseau temporel."></a></p>
 
-### Phase 4 : Neuro-Symbolique (Notebooks 10-12, ~3h)
+### Phase 4 : Neuro-Symbolique (Notebooks 10, 11, 12, 14 ; ~3h)
 
-La dernière partie explore la frontière entre IA symbolique et apprentissage profond. Le notebook 10 (LLM-Planning) montre comment les Large Language Models peuvent générer des plans à partir de descriptions en langage naturel, le prompting pour la planification, et le plan repair. Le notebook 11 (Unified-Planning) détaille l'interface unifiée `unified-planning` : connexion à plusieurs solveurs en quelques lignes, comparaison croisée des performances, portabilité du modèle PDDL entre moteurs, **et le saut qualitatif satisfaction → optimisation** via `MinimizeActionCosts` (un moteur *optimal* comme `fast-downward-opt` certifie le plan de coût minimal là où un moteur *satisficing* comme `fast-downward` s'arrête au premier plan trouvé — voir [la section dédiée ci-dessous](#au-delà-de-la-satisfaction--optimisation-pddl-cout-minimal-planners-11)). Le notebook 12 (LOOP) introduit le paradigme **Learning to Plan** : architecture LOOP (state encoder, policy network, value network), encodage PDDL en tenseurs (one-hot, GNN), entraînement par imitation et renforcement, résultats sur benchmarks IPC (85.8% coverage), et comparaison avec KRCL. Ce notebook conclut la série avec les tendances futures : foundation models, meta-learning, inverse reinforcement learning.
+La dernière partie explore la frontière entre IA symbolique et apprentissage profond. Le notebook 10 (LLM-Planning) montre comment les Large Language Models peuvent générer des plans à partir de descriptions en langage naturel, le prompting pour la planification, et le plan repair. Le notebook 11 (Unified-Planning) détaille l'interface unifiée `unified-planning` : connexion à plusieurs solveurs en quelques lignes, comparaison croisée des performances, portabilité du modèle PDDL entre moteurs, **et le saut qualitatif satisfaction → optimisation** via `MinimizeActionCosts` (un moteur *optimal* comme `fast-downward-opt` certifie le plan de coût minimal là où un moteur *satisficing* comme `fast-downward` s'arrête au premier plan trouvé — voir [la section dédiée ci-dessous](#au-delà-de-la-satisfaction--optimisation-pddl-cout-minimal-planners-11)). Le notebook 12 (LOOP) introduit le paradigme **Learning to Plan** : architecture LOOP (state encoder, policy network, value network), encodage PDDL en tenseurs (one-hot, GNN), entraînement par imitation et renforcement, résultats sur benchmarks IPC (85.8% coverage), et comparaison avec KRCL. Le notebook 14 (LLM-Space-Reducer) teste la **position inverse** : le LLM non plus solveur mais réducteur d'espace de recherche (position du moteur [aicpp](https://github.com/Julien-Livet/aicpp)) — mini-DSL de primitives typées sur grilles ARC, trois bras mesurés (exhaustif borné, LLM-direct, LLM-réducteur), la correction restant toujours au solveur déterministe. C'est lui qui conclut la série sur les tendances : foundation models, meta-learning, inverse reinforcement learning.
 
 ### Au-delà de la satisfaction : optimisation PDDL (coût minimal, Planners-11)
 
@@ -116,10 +116,10 @@ Pour les applications de planification par contraintes et temporelles :
 1. `0-Setup` → `1-Introduction` → `2-PDDL-Basics`
 2. `7-OR-Tools` → `8-Temporal` → `9-HTN`
 
-#### Parcours neuro-symbolique (5h, recherche)
+#### Parcours neuro-symbolique (~6h, recherche)
 Pour les approches combinées apprentissage profond + symbolique :
 1. `0-Setup` → `1-Introduction` → `4-Fast-Downward`
-2. `10-LLM-Planning` → `11-Unified-Planning` → `12-LOOP`
+2. `10-LLM-Planning` → `11-Unified-Planning` → `12-LOOP` → `14-LLM-Space-Reducer`
 
 ## Quel parcours choisir ?
 
@@ -142,6 +142,7 @@ Pour les approches combinées apprentissage profond + symbolique :
 | Optimisation de scheduling | **Planners-7-OR-Tools** |
 | Planification hiérarchique | **Planners-9-HTN** (SHOP2, decomposition) |
 | Frontière LLM + IA | **Planners-10-LLM-Planning** |
+| LLM qui réduit l'espace de recherche | **Planners-14-LLM-Space-Reducer** |
 | Approche neuro-symbolique avancée | **Planners-12-LOOP** (85.8% IPC coverage) |
 | Comparer tous les solveurs (satisfaction) | **Planners-11-Unified-Planning** |
 | Comparer satisfaction **vs** optimisation (`MinimizeActionCosts`) | **Planners-11-Unified-Planning** ([#7592](https://github.com/jsboige/CoursIA/pull/7592)) |
@@ -196,7 +197,8 @@ SymbolicAI/Planners/
 ├── 04-NeuroSymbolic/
 │   ├── Planners-10-LLM-Planning.ipynb   # LLM + Planning
 │   ├── Planners-11-Unified-Planning.ipynb # Interface unifiée
-│   └── Planners-12-LOOP.ipynb           # Learning to Plan
+│   ├── Planners-12-LOOP.ipynb           # Learning to Plan
+│   └── Planners-14-LLM-Space-Reducer.ipynb # LLM reducteur d'espace (position aicpp)
 ├── planning_lean/                        # Projet Lake Lean 4 (preuve formelle 0-sorry de l'admissibilité de la relaxation h+ <= h*, cf Planners-5b)
 │   ├── README.md                          # Documentation du lake (FR)
 │   ├── Planning.en.md                     # Companion EN (i18n tranche 8, #5013)
@@ -232,6 +234,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 10 | LLM-Planning | Planification avec LLMs, prompting, plan repair, limites et avantages |
 | 11 | Unified-Planning | Interface multi-solveurs, comparaison croisée, portabilité du modèle — + optimisation `MinimizeActionCosts` (optimal bat satisficing de 7 unités) [#7592] |
 | 12 | LOOP | Learning to Plan : state encoder, policy network, value network, 85.8% IPC coverage |
+| 14 | LLM-Space-Reducer | Le LLM comme réducteur d'espace de recherche (position aicpp) : mini-DSL ARC, trois bras mesurés (exhaustif borné, LLM-direct, LLM-réducteur) |
 
 ---
 
@@ -284,6 +287,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 10 | [Planners-10-LLM-Planning](04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb) | Python | LLMs pour la planification, prompting, plan repair | 50 min |
 | 11 | [Planners-11-Unified-Planning](04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb) | Python | Interface unifiée, multi-solveurs, comparaisons | 40 min |
 | 12 | [Planners-12-LOOP](04-NeuroSymbolic/Planners-12-LOOP.ipynb) | Python | Learning to Plan, modèles neuronaux pour heuristiques | 45 min |
+| 14 | [Planners-14-LLM-Space-Reducer](04-NeuroSymbolic/Planners-14-LLM-Space-Reducer.ipynb) | Python | Le LLM comme réducteur d'espace de recherche : mini-DSL ARC, trois bras mesurés (exhaustif borné, LLM-direct, LLM-réducteur, position aicpp) | 40 min |
 
 ---
 
@@ -307,8 +311,8 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 
 ### Pour les notebooks avancés
 
-- **Bases en machine learning** (notebooks 10-12) : réseaux de neurones, loss, backpropagation
-- **API OpenAI/Anthropic** (notebook 10) : prompts LLM, génération de texte
+- **Bases en machine learning** (notebooks 10, 12) : réseaux de neurones, loss, backpropagation
+- **API OpenAI/Anthropic/OpenRouter** (notebooks 10, 14) : prompts LLM, génération de texte
 - **Connaissance de PDDL** (notebooks 8-9) : domaines, problèmes, types
 
 ### Pour les notebooks pratiques
@@ -734,7 +738,7 @@ La planification automatique est le versant **décisionnel** de l'IA — là où
 - **Les fondations classiques** (notebooks 1-4) : le triptyque État-Action-But, STRIPS, les heuristiques de recherche (A*, h-max, LM-cut). Vous avez vu qu'un plan n'est pas une prédiction — c'est une *séquence d'actions* justifiée par une structure de coût.
 - **Les standards et solveurs** (notebooks 5-7) : PDDL comme langage commun, Fast Downward, OR-Tools CP-SAT, le passage du « plan à la main » au « plan par solveur industriel ».
 - **La composition et la hiérarchie** (notebooks 8-9) : planification temporelle, réseaux de tâches hiérarchiques (HTN/SHOP2) — comment découper un but complexe en sous-but réutilisables.
-- **La synthèse neuro-symbolique** (notebooks 10-12) : plan repair par LLM, l'API unified-planning, et surtout *Learning to Plan* (notebook 12) — le point où l'apprentissage rencontre la planification, clôture naturelle de la série vers les foundation models.
+- **La synthèse neuro-symbolique** (notebooks 10, 11, 12, 14) : plan repair par LLM, l'API unified-planning, *Learning to Plan* (notebook 12) — le point où l'apprentissage rencontre la planification — et la position inverse (notebook 14) : le LLM réducteur d'espace de recherche, la correction restant au solveur déterministe, clôture de la série vers les foundation models.
 
 ### Prochaines étapes
 
@@ -760,8 +764,8 @@ Le décompte exact ci-dessous est synchronisé avec le bloc `<!-- CATALOG-STATUS
 | **01-Foundation** | 3 | PRODUCTION=3, BETA=0 | Triptyque État-Action-But, modèle STRIPS, syntaxe PDDL, explosion combinatoire $O(2^n)$ |
 | **02-Classical** | 5 | PRODUCTION=3, BETA=2 | Fast Downward (translator→preprocessor→search), heuristiques admissibles ($h^{add}$, $h^{max}$, $h^{FF}$, LM-cut), domaines IPC (Blocks World, Logistics, Gripper, Satellite), companion Lean `5b-Lean-Relaxation`, différentiel d'atteignabilité (`13-Differentiel-Atteignabilite`, strate 7) |
 | **03-Advanced** | 3 | PRODUCTION=3, BETA=0 | CP-SAT (OR-Tools), planification temporelle PDDL 2.1 (durées, parallélisme), HTN/SHOP2 (décomposition hiérarchique, HDDL) |
-| **04-NeuroSymbolic** | 3 | PRODUCTION=3, BETA=0 | LLM-Planning (génération plans depuis langage naturel, plan repair), `unified-planning` (portabilité cross-solveur), LOOP — *Learning to Plan* (state encoder + policy + value nets, 85.8% IPC coverage) |
-| **Total** | **15** | **PRODUCTION=13, BETA=2** | Python 3.9+, kernel Python 3, solveurs : Fast Downward (Docker) + OR-Tools 9.8+ + unified-planning 1.1+ |
+| **04-NeuroSymbolic** | 4 | PRODUCTION=4, BETA=0 | LLM-Planning (génération plans depuis langage naturel, plan repair), `unified-planning` (portabilité cross-solveur), LOOP — *Learning to Plan* (state encoder + policy + value nets, 85.8% IPC coverage), LLM-Space-Reducer (LLM réducteur d'espace, position aicpp, trois bras mesurés) |
+| **Total** | **16** | **PRODUCTION=14, BETA=2** | Python 3.9+, kernel Python 3, solveurs : Fast Downward (Docker) + OR-Tools 9.8+ + unified-planning 1.1+ |
 
 > **Note sur la maturité.** Les notebooks `BETA=2` correspondent à `Planners-5b-Lean-Relaxation.ipynb` (companion natif du lake `planning_lean/` : la **preuve formelle 0-sorry** de l'admissibilité $h^{+} \leq h^{*}$ y est certifiée par `lake build`) et à `Planners-13-Differentiel-Atteignabilite.ipynb` (nouveau, strate 7). Le statut `BETA` reflète la phase de relecture pédagogique (intégration au parcours d'apprentissage) plutôt qu'un défaut technique. Le déploiement industriel est validé.
 


### PR DESCRIPTION
## Summary

Grain: DEEP/notebook-python -- lane myia-po-2026:CoursIA — prev: MED/tooling #13159

Nouveau notebook **Planners-14-LLM-Space-Reducer.ipynb** (30 cellules, kernel python3) distillant le positionnement [aicpp](https://github.com/Julien-Livet/aicpp) : le LLM comme **reducteur d'espace de recherche** plutot que solveur — la correction reste au solveur deterministe, verifiee par exemples.

**Renumerotation** : le numero 13 etait pris (`Planners-13-Differentiel-Atteignabilite`, 02-Classical, strate 7) ; le notebook devient **14** (verifie sur disque + README parent).

### Contenu

- **Mini-DSL** : 8 primitives typees sur grilles ARC-like (flipud, fliplr, rot90, transpose, crop_content, recolor(c1,c2), mask_keep(c), mask_drop(c)) = 115 instances/slot, profondeur <= 4 = **176 434 840 programmes**.
- **3 taches** : T1 miroir teinte (prof. 2), T2 isoler la forme (prof. 2, cadrage non-trivial), T3 retourner-isoler-cadrer (prof. 3 exacte, grilles non carrees pour eviter les equivalences du groupe des symetries).
- **3 bras mesures** (resultats de l'execution commitee) :

| Tache | Bras 1 exhaustif (15 000 nds) | Bras 2 LLM-direct | Bras 3 LLM-reducteur |
|---|---|---|---|
| T1 | TROUVE (400 nds) | TROUVE (essais=1) | TROUVE (124/8 372 nds, reduction x21 074) |
| T2 | TROUVE (2 071 nds) | TROUVE (essais=1) | TROUVE (67/132 nds, reduction x1 336 628) |
| T3 | **BUDGET_DEPASSE** | TROUVE (essais=1) | **TROUVE (373/1 884 nds, reduction x93 649)** |

T3 est muree au bras 1 et sauvee au bras 3 : le LLM ne rend qu'un sous-espace (3 primitives + profondeur), le MEME solveur deterministe fait le reste — le geste exact de la these.

- **Prose** : tableau LLM-solver vs L2P vs LLM-reducteur, lecture honnete (mur non uniforme, LLM-direct sans garantie, echec de reduction = donnee diagnostiquee), non-determinisme LLM documente (modeles raisonneurs : ni temperature ni seed).
- **Citation aicpp** : 69/120 ARC-AGI-2 training (57,5 %), Apache 2.0, depot jeune (janvier 2026) a figer par commit si execution du reel, non-production — aucun de leur code embarque.
- **3 exercices** stubbes C.1 (extension DSL, tache resistante au reducteur, reducteur MDL-lite deterministe).

### Fichiers

- `Planners-14-LLM-Space-Reducer.ipynb` (nouveau) — 30 cellules, 3 exercices
- `04-NeuroSymbolic/README.md` — fichier-entier : 4 angles, ligne 14, prerequis, acquis (5)
- `Planners/README.md` (parent) — 10 points factuels : en-tete phase 4, prose, parcours neuro-symbolique, table recommandations, arbre, table contenus, table partie 4, prerequis, synthese finale, stats (04-NeuroSymbolic 3->4 notebooks, total 15->16, PRODUCTION 13->14), mermaid
- `Planners-12-LOOP.ipynb` — nav markdown seul : fin de serie -> lien vers 14 (C.2 exception markdown ; + separateurs normalises par hook pre-commit)

## Test plan

- [x] Papermill end-to-end **30/30 cellules** (log : `Executing: 100%|...| 30/30 [02:18]`), kernel python3
- [x] `execution_count` 14/14 cellules code, `outputs` non vides (script nbformat)
- [x] `grep -c "raise NotImplementedError|assert False|1/0"` = **0** (C.1)
- [x] 0 chemin machine dans source ET outputs (cles API : variable d'environnement uniquement, jamais affichee ; gitleaks Passed)
- [x] `check_notebook_navlinks.py` : 0 lien casse (14 + 12)
- [x] nbformat validate : VALID (ids string)
- [x] Verdict SOTA (Prong A) : **SOTA-OK** — vrai LLM frontier (openai/gpt-5 via OpenRouter) proprement invoque, sorties commitees = vraies sorties
- [x] Prong B (probleme non-trivial) : T3 exige une composition de profondeur 3 exacte dans un espace de 176M programmes — le bras exhaustif borne echoue dessus, le probleme discrimine

Closes #13104

🤖 Generated with [Claude Code](https://claude.com/claude-code)