### PR TITLE
fix(tooling,#13140): encoding=utf-8 on subprocess text=True — tranche 4/4 finale (34 sites)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/scripts/validate_lean_setup.py
+++ b/MyIA.AI.Notebooks/GameTheory/scripts/validate_lean_setup.py
@@ -65,7 +65,7 @@ def check_command(cmd, name, version_flag="--version"):
             result = subprocess.run(
                 ["bash", "-c", bash_cmd],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10
             )
             if result.returncode == 0:
@@ -82,7 +82,7 @@ def check_command(cmd, name, version_flag="--version"):
             result = subprocess.run(
                 [cmd, version_flag],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=5
             )
             version = result.stdout.strip().split('\n')[0]
@@ -117,7 +117,7 @@ def check_jupyter_kernel(kernel_name):
         result = subprocess.run(
             ["jupyter", "kernelspec", "list"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10
         )
         if kernel_name.lower() in result.stdout.lower():

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/forge_helper.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/forge_helper.py
@@ -44,7 +44,7 @@ def _run_forge(source_code: str, contract_name: str) -> dict:
             # Native: forge on PATH (Linux, Mac, or WSL kernel)
             cmd = ["forge", "build", "--force", "--silent"]
             result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=60,
+                cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=60,
                 cwd=foundry_path
             )
         elif platform.system() == "Windows":
@@ -57,7 +57,7 @@ def _run_forge(source_code: str, contract_name: str) -> dict:
                 f'export PATH="$HOME/.foundry/bin:$PATH" && '
                 f'cd "{wsl_path}" && forge build --force --silent 2>&1'
             ]
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+            result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=60)
         else:
             raise RuntimeError(
                 "forge not found on PATH. Install Foundry: "

--- a/docker-configurations/services/funasr-api/app.py
+++ b/docker-configurations/services/funasr-api/app.py
@@ -162,7 +162,7 @@ def _convert_audio_to_wav(input_path: str) -> str:
     result = subprocess.run(
         ["ffmpeg", "-y", "-i", input_path, "-ar", "16000", "-ac", "1",
          "-f", "wav", output_path],
-        capture_output=True, text=True
+        capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
     if result.returncode != 0:
         logger.warning(f"ffmpeg conversion warning: {result.stderr}")
@@ -184,7 +184,7 @@ async def health_check():
             import subprocess
             result = subprocess.run(
                 ["nvidia-smi", "--query-gpu=name,memory.used", "--format=csv,noheader,nounits"],
-                capture_output=True, text=True
+                capture_output=True, text=True, encoding="utf-8", errors="replace"
             )
             if result.returncode == 0:
                 parts = result.stdout.strip().split("\n")[0].split(",")

--- a/scripts/check_quantconnect_notebook_freshness.py
+++ b/scripts/check_quantconnect_notebook_freshness.py
@@ -69,7 +69,7 @@ def git_ls_tree_tracked(relpath: str, repo_root: pathlib.Path) -> bool:
             ["git", "ls-tree", "HEAD", "--", relpath],
             cwd=str(repo_root),
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=False,
         )
     except FileNotFoundError:
@@ -84,7 +84,7 @@ def git_check_ignore(relpath: str, repo_root: pathlib.Path) -> bool:
             ["git", "check-ignore", relpath],
             cwd=str(repo_root),
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=False,
         )
     except FileNotFoundError:

--- a/scripts/datasets/download_kaggle.py
+++ b/scripts/datasets/download_kaggle.py
@@ -24,7 +24,7 @@ DEFAULT_OUTPUT = Path(__file__).resolve().parent.parent.parent / "MyIA.AI.Notebo
 
 def _check_kaggle_cli():
     try:
-        result = subprocess.run(["kaggle", "--version"], capture_output=True, text=True, timeout=10)
+        result = subprocess.run(["kaggle", "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10)
         if result.returncode != 0:
             raise FileNotFoundError
     except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -37,7 +37,7 @@ def search_datasets(query: str, max_results: int = 10):
     _check_kaggle_cli()
     result = subprocess.run(
         ["kaggle", "datasets", "list", "-s", query, "--max-size", str(max_results), "--csv"],
-        capture_output=True, text=True, timeout=30,
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30,
     )
     print(result.stdout)
     if result.stderr:
@@ -60,7 +60,7 @@ def download(dataset: str, output_dir: Path, unzip: bool = True) -> Path:
     print(f"Downloading Kaggle dataset: {dataset}")
     print(f"  Target: {target}")
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=300)
     if result.returncode != 0:
         print(f"ERROR: {result.stderr}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/datasets/download_qc_data.py
+++ b/scripts/datasets/download_qc_data.py
@@ -37,7 +37,7 @@ DEFAULT_OUTPUT = Path(__file__).resolve().parent.parent.parent / "MyIA.AI.Notebo
 
 def _check_lean_cli():
     try:
-        result = subprocess.run(["lean", "--version"], capture_output=True, text=True, timeout=10)
+        result = subprocess.run(["lean", "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10)
         if result.returncode != 0:
             raise FileNotFoundError
     except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -71,7 +71,7 @@ def download_lean_cli(
     print(f"Downloading QC data: {symbol} ({security_type}/{resolution}) [{start} -> {end}]")
     print(f"  Command: {' '.join(cmd)}")
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=300)
     if result.returncode != 0:
         print(f"ERROR: {result.stderr}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/execute_sudoku_python.py
+++ b/scripts/execute_sudoku_python.py
@@ -96,7 +96,7 @@ def execute_python_notebook(notebook_path: Path, timeout: int = 600):
          str(notebook_path),
          '--kernel', 'python3'],
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         timeout=timeout
     )
 

--- a/scripts/genai-stack/_archive/core/diagnose_comfyui_auth.py
+++ b/scripts/genai-stack/_archive/core/diagnose_comfyui_auth.py
@@ -42,7 +42,7 @@ class ComfyUIAuthDiagnostic:
         try:
             result = subprocess.run(
                 ["docker", "ps", "--filter", "name=comfyui-qwen", "--format", "json"],
-                capture_output=True, text=True
+                capture_output=True, text=True, encoding="utf-8", errors="replace"
             )
             
             if result.returncode == 0 and result.stdout.strip():
@@ -69,7 +69,7 @@ class ComfyUIAuthDiagnostic:
         try:
             # Vérification dans le conteneur
             cmd = "docker exec comfyui-qwen find /workspace/ComfyUI/custom_nodes -name '*login*' -type d"
-            result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+            result = subprocess.run(cmd, shell=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
             
             if result.returncode == 0 and result.stdout.strip():
                 print("✅ ComfyUI-Login trouvé dans custom_nodes")
@@ -97,7 +97,7 @@ class ComfyUIAuthDiagnostic:
         for dep in required_deps:
             try:
                 cmd = f"docker exec comfyui-qwen python -c \"import {dep.replace('-', '_')}\""
-                result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+                result = subprocess.run(cmd, shell=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
                 
                 if result.returncode == 0:
                     print(f"✅ {dep} - OK")
@@ -189,7 +189,7 @@ class ComfyUIAuthDiagnostic:
         try:
             result = subprocess.run(
                 ["docker", "logs", "comfyui-qwen", "--tail", str(lines)],
-                capture_output=True, text=True
+                capture_output=True, text=True, encoding="utf-8", errors="replace"
             )
             
             if result.returncode == 0:

--- a/scripts/genai-stack/commands/audio_apis.py
+++ b/scripts/genai-stack/commands/audio_apis.py
@@ -51,7 +51,7 @@ def get_container_status(container_name: str) -> str:
     """Retourne le statut d'un container Docker."""
     result = subprocess.run(
         ["docker", "inspect", container_name, "--format", "{{.State.Status}}"],
-        capture_output=True, text=True
+        capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
     if result.returncode != 0:
         return "not_found"
@@ -163,7 +163,7 @@ def stop_service(service_name: str) -> bool:
     result = subprocess.run(
         ["docker-compose", "down"],
         cwd=str(compose_dir),
-        capture_output=True, text=True
+        capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
 
     if result.returncode == 0:
@@ -198,7 +198,7 @@ def start_service(service_name: str, wait_health: bool = True) -> bool:
     result = subprocess.run(
         ["docker-compose", "up", "-d"],
         cwd=str(compose_dir),
-        capture_output=True, text=True
+        capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
 
     if result.returncode != 0:
@@ -265,7 +265,7 @@ def switch_to_service(service_name: str) -> bool:
     import subprocess
     result = subprocess.run(
         ["nvidia-smi", "--query-gpu=index,name,memory.used,memory.free", "--format=csv,noheader"],
-        capture_output=True, text=True
+        capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
     if result.returncode == 0:
         for line in result.stdout.strip().split("\n"):
@@ -539,7 +539,7 @@ def build_service(service_name: str) -> bool:
         ["docker-compose", "build", "--no-cache"],
         cwd=str(compose_dir),
         capture_output=False,  # Afficher la sortie en direct
-        text=True
+        text=True, encoding="utf-8", errors="replace"
     )
 
     if result.returncode == 0:

--- a/scripts/genai-stack/commands/gpu.py
+++ b/scripts/genai-stack/commands/gpu.py
@@ -42,7 +42,7 @@ def check_vram() -> List[Dict]:
             '--query-gpu=index,name,memory.total,memory.used,memory.free',
             '--format=csv,noheader,nounits'
         ]
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", check=True)
 
         gpus = []
         csv_reader = csv.reader(io.StringIO(result.stdout))
@@ -84,7 +84,7 @@ def print_gpu_table(gpus: List[Dict]):
 def _run_cmd(cmd: str):
     """Execute une commande shell et retourne (success, stdout, stderr)."""
     try:
-        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
         return result.returncode == 0, result.stdout, result.stderr
     except Exception as e:
         return False, "", str(e)
@@ -162,7 +162,7 @@ def _get_running_services() -> List[str]:
     for name, svc in SERVICES.items():
         result = subprocess.run(
             ["docker", "inspect", svc["container_name"], "--format", "{{.State.Running}}"],
-            capture_output=True, text=True
+            capture_output=True, text=True, encoding="utf-8", errors="replace"
         )
         if result.returncode == 0 and "true" in result.stdout.lower():
             running.append(name)

--- a/scripts/lean/setup_shared_mathlib_scan.py
+++ b/scripts/lean/setup_shared_mathlib_scan.py
@@ -36,7 +36,7 @@ def main() -> int:
     out = subprocess.run(
         ["git", "-C", repo_root, "ls-files", "--cached", "--others",
          "--exclude-standard", "--", "*lake-manifest.json"],
-        capture_output=True, text=True, check=False,
+        capture_output=True, text=True, encoding="utf-8", errors="replace", check=False,
     )
     if out.returncode != 0:
         print(f"WARN: git ls-files failed: {out.stderr[:200]}", file=sys.stderr)

--- a/scripts/regen_quarto_render.py
+++ b/scripts/regen_quarto_render.py
@@ -204,7 +204,7 @@ def git_tracked_notebooks() -> list[str]:
         patterns.append(tree + "**/*.ipynb")
     out = subprocess.run(
         ["git", "-C", str(REPO_ROOT), "-c", "core.quotePath=false", "ls-files", *patterns],
-        capture_output=True, text=True, check=True,
+        capture_output=True, text=True, encoding="utf-8", errors="replace", check=True,
     )
     paths = []
     for line in out.stdout.splitlines():
@@ -234,7 +234,7 @@ def git_tracked_readmes() -> list[str]:
     # single wrap below stays valid YAML on every machine (CI or local).
     out = subprocess.run(
         ["git", "-C", str(REPO_ROOT), "-c", "core.quotePath=false", "ls-files", "*README.md"],
-        capture_output=True, text=True, check=True,
+        capture_output=True, text=True, encoding="utf-8", errors="replace", check=True,
     )
     paths = []
     for line in out.stdout.splitlines():

--- a/scripts/translation/demo_t3_t4_acceptance.py
+++ b/scripts/translation/demo_t3_t4_acceptance.py
@@ -50,7 +50,7 @@ def _check_drift(csv_path: Path) -> list[dict]:
         ["python", "scripts/translation/check_translation_sync.py", str(csv_path), "--check"],
         cwd=REPO_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
     )
     m = re.search(r"(\{.*\})", proc.stdout, re.DOTALL)
     if not m:
@@ -82,7 +82,7 @@ def _t3_plan(csv_path: Path, lang: str = "en", max_cells: int = 100) -> tuple[in
         cwd=REPO_ROOT,
         env=env,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
     )
     plan_match = re.search(r"\[plan\] (\d+) traductions", proc.stderr)
     plan_count = int(plan_match.group(1)) if plan_match else -1
@@ -107,7 +107,7 @@ def _t4_render_dry(csv_path: Path, notebook: str, lang: str = "en") -> dict:
         ],
         cwd=REPO_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
     )
     out = proc.stdout
     stats = {}

--- a/slides/_tools/slide_tools.py
+++ b/slides/_tools/slide_tools.py
@@ -220,7 +220,7 @@ def render_marp(deck_path: str, scale: int = 2) -> list:
     print(f"Rendering Marp: {deck_path.name}")
     try:
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=120,
+            cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120,
             cwd=str(SLIDES_ROOT),
         )
         if result.returncode != 0:


### PR DESCRIPTION
## Summary

Tranche 4 (finale) du sweep #13140 : **34 sites** `subprocess` avec `text=True` **sans** `encoding=` corrigés sur 14 fichiers (le « reste » ~37 de la découpe de l'issue). Pattern #12813 : `encoding="utf-8", errors="replace"`. Suite des tranches 1-3 (PR #13167/#13168/#13169) + garde anti-régression (PR #13169).

| Fichier | Sites |
|---|---|
| `scripts/genai-stack/commands/audio_apis.py` | 5 |
| `scripts/genai-stack/_archive/core/diagnose_comfyui_auth.py` | 4 |
| `scripts/genai-stack/commands/gpu.py` | 3 |
| `scripts/translation/demo_t3_t4_acceptance.py` | 3 |
| `scripts/datasets/download_kaggle.py` | 3 |
| `scripts/datasets/download_qc_data.py` | 2 |
| `scripts/regen_quarto_render.py` | 2 |
| `scripts/check_quantconnect_notebook_freshness.py` | 2 |
| `scripts/lean/setup_shared_mathlib_scan.py` | 1 |
| `scripts/execute_sudoku_python.py` | 1 |
| `docker-configurations/services/funasr-api/app.py` | 2 |
| `MyIA.AI.Notebooks/GameTheory/scripts/validate_lean_setup.py` | 3 |
| `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/forge_helper.py` | 2 |
| `slides/_tools/slide_tools.py` | 1 |

## Écart de mesure documenté

La table de l'issue prévoyait ~37 sites (dont fix_sc9_foundry 2, setup_lean4_all 1, gradebook 2). Re-scan firsthand : ces 3 fichiers ont **0 site RÉEL** — leurs `text=True` appartiennent à des **docstrings / strings de code généré** (`fix_sc9_foundry.py` génère un script de correctif, pas un appel runtime ; `gradebook.py` ne matche que `Alignment(wrap_text=...)`). Non modifiés — aucun subprocess runtime à corriger.

## Validation

- Re-scan firsthand 34→0 (même parseur que l'issue et que la garde `check_subprocess_encoding.py`)
- `py_compile` 14/14 OK
- Tests dédiés : **167/167 passed** (check_quantconnect_notebook_freshness, execute_sudoku_python, genai_audio_apis, genai_commands_gpu, regen_quarto_render)
- Aucun site f-string dans cette tranche (variante simple-quote non requise)

## Découpage

Tranches 1-2 : PR #13167/#13168 ; tranche 3 + garde : PR #13169. **Avec celle-ci, le sweep listé par l'issue est terminé (compte total et répartition dans l'issue #13140).**

## Grain

Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/guard #13169

See #13140 (fin du sweep liste, contribution partielle sur l'epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

