### PR TITLE
fix(search,#13178): MGS-11 IslandSynergy re-exec sur moteur deterministe — verdict et GIF byte-reproduits, pins realignes

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb
@@ -41,10 +41,9 @@
    "source": [
     "## Cablage : MetaGeneticSharp (fork) + paysage + encodeur GIF\n",
     "\n",
-    "On charge les DLLs du fork (self-contained via `CopyLocalLockFileAssemblies` : il embarque `System.Drawing.Common.dll`, `SkiaSharp.dll` + son binaire natif `runtimes/<rid>/native/libSkiaSharp.dll`). On precharge ce binaire natif (le `#r` manage ne cable pas le probing natif de SkiaSharp). Le sous-module est epingle sur le fork (pointeur `c8bbd99`), qui porte les composes geometriques (WOA/EO/FBI/**DE**/**BBPSO**), l'archipel heterogene (`IslandCompoundMetaheuristic`), le de-biais (`ShiftedFitness` / `ShiftVectors.Seeded`), l'overlay iles colorees (`RenderHeatmapPng(..., individualColors)`) et l'encodeur GIF anime (`EncodeAnimatedGif`).\n",
+    "On charge les DLLs du fork (self-contained via `CopyLocalLockFileAssemblies` : il embarque `System.Drawing.Common.dll`, `SkiaSharp.dll` + son binaire natif `runtimes/<rid>/native/libSkiaSharp.dll`). On precharge ce binaire natif (le `#r` manage ne cable pas le probing natif de SkiaSharp). Le sous-module est epingle sur le fork (pointeur `607cf7a`), qui porte les composes geometriques (WOA/EO/FBI/**DE**/**BBPSO**), l'archipel heterogene (`IslandCompoundMetaheuristic`), le de-biais (`ShiftedFitness` / `ShiftVectors.Seeded`), l'overlay iles colorees (`RenderHeatmapPng(..., individualColors)`) et l'encodeur GIF anime (`EncodeAnimatedGif`).\n",
     "\n",
-    "> **Prerequis build.** `dotnet build ..\\MetaGeneticSharp\\src\\MetaGeneticSharp.Extensions\\MetaGeneticSharp.Extensions.csproj -c Debug` (sous-module epingle sur le fork `c8bbd99`).\n",
-    ""
+    "> **Prerequis build.** `dotnet build ..\\MetaGeneticSharp\\src\\MetaGeneticSharp.Extensions\\MetaGeneticSharp.Extensions.csproj -c Debug` (sous-module epingle sur le fork `607cf7a`, rendu deterministe par pixel -- PR MetaGeneticSharp #49).\n"
    ]
   },
   {
@@ -70,115 +69,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       
-       
-       "\r\n",
-       
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       
-       
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '15132.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": []
      },
      "metadata": {},
      "output_type": "display_data"
@@ -338,7 +229,7 @@
     "| **BBPSO** | 4 iles Bare-Bones PSO homogenes | exploitation |\n",
     "| **DE+BBPSO** | 2 iles DE + 2 iles BBPSO | heterogene -- l'hypothese de synergie |\n",
     "\n",
-    "Chaque archipel est lance sur deux fonctions **multimodales de-biaisees** en **dimension 5** (Rastrigin, Ackley -- toutes deux a optimum a l'origine, relocalise hors centre via `ShiftedFitness` + `ShiftVectors.Seeded`), a budget d'evaluations identique. La **dimension 5** (et non 2) est choisie pour que le problème soit assez dur pour que les opérateurs *differentient* : en dimension 2 a ce budget, tous solveent Rastrigin (objectif 0), ce qui rend une synergie indiscernable. La graine globale est fixee (`FastRandomRandomization.ResetSeed(42)`) au demarrage pour un depart reproductible.\n",
+    "Chaque archipel est lance sur deux fonctions **multimodales de-biaisees** en **dimension 5** (Rastrigin, Ackley -- toutes deux a optimum a l'origine, relocalise hors centre via `ShiftedFitness` + `ShiftVectors.Seeded`), a budget d'evaluations identique. La **dimension 5** (et non 2) est choisie pour que le problème soit assez dur pour que les opérateurs *differentient* : en dimension 2 a ce budget, tous solveent Rastrigin (objectif 0), ce qui rend une synergie indiscernable. La graine globale est fixee (`FastRandomRandomization.ResetSeed(42)`) au demarrage pour un depart reproductible -- verifiee : double execution sur le moteur deterministe (MetaGeneticSharp #49) **byte-identique sur les 7 cellules**, le tableau ci-dessous et le GIF de la section Lecture reproduisent a l'octet pres.\n",
     "\n",
     "> **Pourquoi de-biaiser ?** Rastrigin et Ackley ont leur optimum a l'origine ; un opérateur « recentre » y serait flate. `ShiftedFitness` translate l'optimum d'un vecteur non nul (magnitude 0.15 de la plage, assez petite pour garder l'optimum dans les bornes) : la recherche doit le *suivre*, pas tomber dessus par biais de centre.\n",
     ">\n",
@@ -580,9 +471,7 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'System.Drawing.Primitives, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'MetaGeneticSharp.Extensions' correspond à l'identité 'System.Drawing.Primitives, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Drawing.Primitives', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
       "\r\n"
      ]
     }
@@ -886,18 +775,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 9.713432,
-   "end_time": "2026-06-23T16:29:53.433021+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "MGS-11-IslandSynergy.ipynb",
-   "output_path": "MGS-11_out.ipynb",
-   "parameters": {},
-   "start_time": "2026-06-23T16:29:43.719589+00:00",
-   "version": "2.7.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #13175

See #13178 (sous-grain umbrella #1203) — s'exécute contre le gitlink `607cf7a` porté par #13162/#13166/#13170/#13173/#13175 (MetaGeneticSharp #49).

## Ce que cette tranche fait

Re-exécution de `MGS-11-IslandSynergy.ipynb` (7 cellules code) contre le moteur **déterministe par pixel**. Verdict : comme MGS-9, le notebook est **déterministe de bout en bout** (`FastRandomRandomization.ResetSeed(42)` avant tout accès + `ShiftVectors.Seeded`) — la double exécution est **byte-identique sur les 7 cellules**, et le verdict quantitatif committé (« **pas de synergie** — un résultat négatif honnête ») **reproduit à l'octet près** : le tableau de taux de réussite (cellule protocole) et le GIF multicolore de l'archipel DE+BBPSO sont byte-identiques au committé.

## Résultats

- **Exécution** : 7/7 cellules, 0 erreur, passes A et B ; kernel .net-csharp.
- **Idempotence intégrale** : A==B cellule-par-cellule sans exception (2ᵉ notebook de la famille après MGS-9, 1ᵉʳ avec GIF animé byte-stable).
- **Verdict VALIDÉ** : aucune lecture à réécrire — les nombres du protocole (grille DE / BBPSO / DE+BBPSO sur Rastrigin/Ackley dé-biaisées dim 5) et le GIF reproduisent exactement. Note de reproductibilité étendue dans la prose du protocole (double exec byte-identique documentée).
- **Pins réalignés** : les deux mentions `c8bbd99` (pointeur du sous-module) → `607cf7a`, avec mention de la fix déterministe #49 sur l'instruction de build.
- **Diff minimal** : 4 cellules changées — 2 prose éditée (cellule câblage + protocole), 1 scaffolding kernel (capture honnête → vide, classe #13173), 1 warning CS1701 différent (l'ancien citait `System.Drawing.Primitives 9.0.0.0`, le nouveau `AspNetCore.Html.Abstractions 2.2.0.0` — émission par unité de compilation du build fork courant). Les 12 autres cellules **byte-identiques au committé**.

## Diagnostic dérive (C.4)

**Classe e (stochasticité non maîtrisée) → CAUSE_FIXED** (cause réparée au source en #13162/MetaGeneticSharp #49). Comme #13175, cette tranche **vérifie** plutôt qu'elle ne répare : la prose committée était déjà fidèle aux sorties (graine globale fixée documentée dans le protocole), et la re-exécution le prouve — la dérive potentielle de la famille (rendus RNG-partagé) ne touchait pas ce notebook, dont les rendus passent par l'overlay îles colorées seedé.

## Périmètre (2 fichiers)

1 notebook (outputs + 2 cellules prose), gitlink submodule `961a058→607cf7a` (**même cible que #13162/#13166/#13170/#13173/#13175** — no-op si l'une merge en premier).

## Validation

- `dotnet_executor` passes A/B : 7/7, 0 erreur ; symbole `PixelSeed` vérifié dans la DLL fraîche du build local (net9.0)
- Idempotence : A==B intégral (hash par cellule, 7/7 identiques) ; tableau protocole + GIF byte-identiques au committé
- `validate_pr_notebooks.py origin/main <nb>` : **PASS** (7 cells .net-csharp)
- C.1 : 0 violation ; exec counts non-null ; pre-commit H.3 Passed
- Catalogue byte-identique à main

## Verdict SOTA

**SOTA-OK** — vrai fork exécuté via DLLs fraîches du build local (net9.0), moteur déterministe, verdict quantitatif vérifié byte-à-byte contre le committé.

## Note G-VAR-3

`notebook-dotnet` consécutif (prev #13175) : substance distincte — verdict « reproduit à l'octet » avec GIF animé byte-stable (vs lecture validée au marqueur près sur MGS-9), notebook différent (archipels hétérogènes DE+BBPSO vs DEM Everest + Schwefel N-D), pins propres. Domaine-cœur de la lane.
