### PR TITLE
feat(gametheory,#13185): GT-18b casser la composition — sélection non compositionnelle + frontière de contraction

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-18b-Casser-la-Composition.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-18b-Casser-la-Composition.ipynb
@@ -1,0 +1,640 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b00",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-18b : Casser la composition — où la meilleure réponse composée cesse d'être l'équilibre du jeu composé\n",
+    "\n",
+    "GT-18 a posé la composition d'open games et vérifié la propriété de Hedges — « la meilleure réponse de la composition est la composition des meilleures réponses » — sur un jouet où elle tient, puis mesuré la convergence de la boucle vers son point fixe. Ce notebook fait ce que le critère de maturation demande : **il essaie de casser le jouet, et regarde ce qui casse**.\n",
+    "\n",
+    "Deux surfaces d'attaque :\n",
+    "\n",
+    "- **Surface A — la sélection n'est pas compositionnelle.** Quand une meilleure réponse locale est *multivoque* (plateau d'optima) et que les paiements sont *couplés*, composer des sélections d'argmax locaux produit un profil qui n'est pas un équilibre du jeu composé. La propriété de Hedges, dans sa forme exacte, porte sur les *correspondances* d'ensembles ; la lecture fonctionnelle du jouet GT-18 — composer des points — ne survit qu'univoque.\n",
+    "- **Surface B — la frontière de contraction.** La convergence de la boucle GT-18 tient parce que l'update est (presque) contractante. En balayant le pas d'update, la boucle passe de la convergence monotone au 2-cycle exact, puis à l'oscillation persistante — et la frontière mesurée coïncide avec la borne de Banach, exactement.\n",
+    "\n",
+    "Références : Hedges (2015), *The composition of games* ; GT-18 (`GameTheory-18-Open-Games-et-Lentilles.ipynb`, issue #12212) ; issue #13185 sous l'Epic de maturation #12208."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b01",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. **Reproduire le régime où la composition tient** : couplée mais univoque, la meilleure réponse composée est bien l'équilibre du composé.\n",
+    "2. **Exhiber la casse** : ajouter UN ingrédient — la multivocité du plateau — et montrer par déviation explicite qu'un profil issu de la composition n'est pas Nash du composé.\n",
+    "3. **Isoler les ingrédients** : le couplage seul ne casse rien (cellule 3), la multivocité seule non plus (r = 0) ; c'est leur *conjonction* qui brise la sélection.\n",
+    "4. **Mesurer la frontière de contraction** : carte convergence / 2-cycle / oscillation sur le pas d'update, comparée à la borne théorique de Banach `L = |1 - delt| < 1`.\n",
+    "5. **Reconsidérer honnêtement le jouet GT-18** : sa boucle additive n'est jamais contractante (L = 1 partout) — sa convergence est une convergence-au-rail, pas un point fixe de Banach."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b02",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 1. Le régime où la composition tient — couplée mais univoque\n",
+    "\n",
+    "Rappel du cadre GT-18 : deux open games composés en série. Le joueur 1 choisit `x`, le joueur 2 observe `x` et choisit `y`. Le paiement de J2 dépend de `x` (couplage), celui de J1 de `y` (couplage en retour). Ici chaque meilleure réponse est **univoque** : `u1 = -(x-1)^2` a un unique maximum en `x = 1`, et `u2 = -(y-x)^2` a un unique maximum en `y = x`. La composition des argmax donne le profil `(1, 1)`, et ce profil est bien l'équilibre du jeu composé — vérifié par énumération des déviations, pas par affirmation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T00:01:26.925504Z",
+     "iopub.status.busy": "2026-08-27T00:01:26.925235Z",
+     "iopub.status.idle": "2026-08-27T00:01:27.002490Z",
+     "shell.execute_reply": "2026-08-27T00:01:27.001887Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BR locales univoques : br1(0) = 1, br2(1) = 1\n",
+      "Profil issu de la composition : (1, 1)\n",
+      "Ce profil est-il Nash du compose : True\n",
+      "Regime univoque-couple : la composition des selections Donne l'equilibre du compose.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "# === Deux open games en serie, COUPLES mais UNIVOQUES ===\n",
+    "ACTIONS_X = (0, 1, 2)\n",
+    "ACTIONS_Y = (0, 1, 2)\n",
+    "\n",
+    "def u1(x, y):\n",
+    "    \"\"\"Paiement J1 : maximum unique en x=1 (le couplage en y est neutre ici).\"\"\"\n",
+    "    return -(x - 1.0) ** 2 + 0.0 * y\n",
+    "\n",
+    "def u2(x, y):\n",
+    "    \"\"\"Paiement J2 : couplée, maximum unique en y=x.\"\"\"\n",
+    "    return -(y - x) ** 2\n",
+    "\n",
+    "def br1(y):\n",
+    "    \"\"\"Meilleure reponse LOCALE de J1 (y exogene) : univoque.\"\"\"\n",
+    "    return max(ACTIONS_X, key=lambda x: u1(x, y))\n",
+    "\n",
+    "def br2(x):\n",
+    "    \"\"\"Meilleure reponse de J2 voyant x : univoque.\"\"\"\n",
+    "    return max(ACTIONS_Y, key=lambda y: u2(x, y))\n",
+    "\n",
+    "# Composition des selections : x* = br1(y exogene), puis y* = br2(x*)\n",
+    "x_star, y_star = br1(0), None\n",
+    "y_star = br2(x_star)\n",
+    "profil_compose = (x_star, y_star)\n",
+    "\n",
+    "# Equilibre du compose : enumeration exhaustive des deviations\n",
+    "def est_nash_compose(x, y):\n",
+    "    \"\"\"Nash du jeu compose : aucune deviation profitable, J1 anticipant y'=br2(x').\"\"\"\n",
+    "    ok1 = all(u1(x, y) >= u1(xp, br2(xp)) - 1e-12 for xp in ACTIONS_X)\n",
+    "    ok2 = all(u2(x, y) >= u2(x, yp) - 1e-12 for yp in ACTIONS_Y)\n",
+    "    return ok1 and ok2\n",
+    "\n",
+    "print(f\"BR locales univoques : br1(0) = {br1(0)}, br2({x_star}) = {y_star}\")\n",
+    "print(f\"Profil issu de la composition : {profil_compose}\")\n",
+    "print(f\"Ce profil est-il Nash du compose : {est_nash_compose(*profil_compose)}\")\n",
+    "print(\"Regime univoque-couple : la composition des selections Donne l'equilibre du compose.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b04",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : la composition des argmax produit `(1, 1)`, et l'énumération exhaustive des déviations confirme que c'est l'équilibre du composé. Remarquer ce qui est déjà là : les paiements sont couplés dans les deux sens (`u2` dépend de `x`), et pourtant la composition tient. **Le couplage seul ne casse pas la sélection** — c'est un contre-fait utile : il faut autre chose. C'est cet « autre chose » que la section 2 installe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b05",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 2. Surface A — la multivocité du plateau brise la sélection\n",
+    "\n",
+    "On déplace le maximum de J1 au **centre exact d'un plateau** : `u1 = -(x - 0.5)^2 + r * y` avec `r = 0.3`. Sur `x ∈ {0, 1, 2}`, les valeurs locales sont `-0.25, -0.25, -2.25` — `x = 0` et `x = 1` sont **ex æquo** : la meilleure réponse locale est *multivoque* (`BR = {0, 1}`, plateau par symétrie exacte). La multivocité seule serait inoffensive : avec `r = 0`, J1 resterait indifférent entre les deux profils composés. Mais le couplage `r * y` fait que le choix de J1, via la réponse `y = x` de J2, **revient à J1** : deviner `x = 1` rapporte `r` de plus que `x = 0`. La composition naïve — prendre UN élément du plateau, disons le plus petit — rend un profil que le jeu composé réfute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T00:01:27.017524Z",
+     "iopub.status.busy": "2026-08-27T00:01:27.017302Z",
+     "iopub.status.idle": "2026-08-27T00:01:27.022031Z",
+     "shell.execute_reply": "2026-08-27T00:01:27.021526Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Valeurs locales de u1 (y exogene) : ['-0.250', '-0.250', '-2.250']\n",
+      "BR locale de J1 = [0, 1]  (MULTIVOQUE : plateau par symetrie exacte c=0.5)\n",
+      "Profil de la composition naive (plus petit argmax) : (0, 0)\n",
+      "Ensemble prevu par la composition des correspondances : [(0, 0), (1, 1)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Surface A : plateau multivoque + couplage ===\n",
+    "C_PLATEAU, R_COUPLAGE = 0.5, 0.3\n",
+    "\n",
+    "def u1_A(x, y):\n",
+    "    \"\"\"Plateau exact : x=0 et x=1 ex aequo en local (c=0.5 = milieu exact).\"\"\"\n",
+    "    return -(x - C_PLATEAU) ** 2 + R_COUPLAGE * y\n",
+    "\n",
+    "def br1_A_ensemble():\n",
+    "    \"\"\"CORRESPONDANCE locale de J1 (y exogene = 0) : l'ENSEMBLE des optima.\"\"\"\n",
+    "    vals = [u1_A(x, 0.0) for x in ACTIONS_X]\n",
+    "    vmax = max(vals)\n",
+    "    return [x for x in ACTIONS_X if abs(u1_A(x, 0.0) - vmax) < 1e-12], vals\n",
+    "\n",
+    "br1_A, vals_locales = br1_A_ensemble()\n",
+    "print(f\"Valeurs locales de u1 (y exogene) : {[f'{v:+.3f}' for v in vals_locales]}\")\n",
+    "print(f\"BR locale de J1 = {br1_A}  (MULTIVOQUE : plateau par symetrie exacte c=0.5)\")\n",
+    "\n",
+    "# Composition des selections : on prend UN element du plateau (le plus petit)\n",
+    "selection = min(br1_A)\n",
+    "profils_composes = [(x, br2(x)) for x in br1_A]\n",
+    "print(f\"Profil de la composition naive (plus petit argmax) : ({selection}, {br2(selection)})\")\n",
+    "print(f\"Ensemble prevu par la composition des correspondances : {profils_composes}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b07",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : la correspondance locale de J1 est `{0, 1}` — le plateau est exact, produit de la symétrie `c = 0.5` au milieu de deux actions consécutives. La composition des correspondances prévoit l'ensemble `{(0,0), (1,1)}`. Reste à demander au jeu composé ce qu'il en pense : chaque profil prédit est confronté à toutes les déviations, J1 anticipant la réponse de J2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T00:01:27.034630Z",
+     "iopub.status.busy": "2026-08-27T00:01:27.034446Z",
+     "iopub.status.idle": "2026-08-27T00:01:27.040201Z",
+     "shell.execute_reply": "2026-08-27T00:01:27.039549Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Profil prevu    u1(x, y)  meilleure deviation J1    ecart  Verdict\n",
+      "------------------------------------------------------------------------------\n",
+      "(0, 0)           -0.250 (1, 1)               +0.300  NON-NASH du compose (J1 devie)\n",
+      "(1, 1)            0.050 (1, 1)               +0.000  equilibre du compose\n",
+      "\n",
+      "Contre-fait r=0 (plateau sans couplage) : ecarts = [+0.000, +0.000] -> les deux profils survivent (indifference, equilibres faibles)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Test Nash du compose, profil par profil ===\n",
+    "def ecart_deviation_J1(x, y):\n",
+    "    \"\"\"Ecart de paiement si J1 devie vers x' en anticipant y' = br2(x').\"\"\"\n",
+    "    if y != br2(x):\n",
+    "        return None   # le profil ne respecte meme pas la BR de J2\n",
+    "    return max(u1_A(xp, br2(xp)) for xp in ACTIONS_X) - u1_A(x, y)\n",
+    "\n",
+    "print(f\"{'Profil prevu':<14} {'u1(x, y)':>9} {'meilleure deviation J1':>23} {'ecart':>8}  Verdict\")\n",
+    "print(\"-\" * 78)\n",
+    "for (x, y) in profils_composes:\n",
+    "    ecart = ecart_deviation_J1(x, y)\n",
+    "    x_best = max(ACTIONS_X, key=lambda xp: u1_A(xp, br2(xp)))\n",
+    "    verdict = \"NON-NASH du compose (J1 devie)\" if (ecart is not None and ecart > 1e-9) else \"equilibre du compose\"\n",
+    "    print(f\"({x}, {y}){'':<7} {u1_A(x, y):9.3f} ({x_best}, {br2(x_best)}){'':<12} \"\n",
+    "          f\"{ecart:+8.3f}  {verdict}\")\n",
+    "\n",
+    "# Contre-fait : R_COUPLAGE = 0 -> le plateau ne casse plus rien\n",
+    "u1_r0 = lambda x, y: -(x - C_PLATEAU) ** 2\n",
+    "ecarts_r0 = [max(u1_r0(xp, br2(xp)) for xp in ACTIONS_X) - u1_r0(x, br2(x)) for (x, y) in profils_composes]\n",
+    "print()\n",
+    "print(f\"Contre-fait r=0 (plateau sans couplage) : ecarts = [{ecarts_r0[0]:+.3f}, {ecarts_r0[1]:+.3f}]\"\n",
+    "      f\" -> les deux profils survivent (indifference, equilibres faibles)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b09",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : la casse est exhibée par déviation explicite. Le profil `(0, 0)` — prédit par la composition naïve (sélection du plus petit argmax du plateau) — **n'est pas Nash du composé** : J1, en anticipant que J2 répondra `y = x`, gagne `+0.300` à dévier vers `x = 1`. Seul `(1, 1)` survit. Et le contre-fait `r = 0` confirme l'isolation des ingrédients : sans couplage, le plateau est inoffensif (les deux profils sont des équilibres faibles par indifférence).\n",
+    "\n",
+    "**Ce que Hedges garantise vraiment.** La propriété de composition, dans sa forme exacte, porte sur les **correspondances** — les ensembles de meilleures réponses — munies de leur contexte : la composée des correspondances calcule bien l'ensemble des solutions du jeu composé, *à contexte correctement propagé*. Ce qui ne tient pas, et que le jouet univoque de GT-18 ne pouvait pas montrer, est la lecture **fonctionnelle** : composer des *sélections* d'argmax locaux, chacune calculée sans regarder le couplage en retour, ne prédit pas l'équilibre — la composition prédit l'ensemble (sur-approximation), pas le point. Chaque ingrédient est inoffensif seul — couplage sans plateau (section 1), plateau sans couplage (contre-fait r = 0) — c'est leur conjonction qui brise la sélection."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b10",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 3. Surface B — la frontière de contraction de la boucle\n",
+    "\n",
+    "La section 3 de GT-18 itère une boucle `W -> P -> decision -> update -> W'` et mesure la distance au point fixe. La famille d'update la plus simple qui généralise la sienne est le **rappel homing** : `a' = clip(a + delt * (b - a), -1, 1)`, qui tire `a` vers la cible `b` avec un pas `delt`. Cette application est affine de pente `1 - delt` (donc de constante de Lipschitz `L = |1 - delt|`) tant que le clip ne mord pas : le **théorème du point fixe de Banach** garantit contraction, donc convergence géométrique vers `b`, si et seulement si `L < 1`, c'est-à-dire `delt ∈ (0, 2)`. À `delt = 2` exactement, `L = 1` : la boucle rebondit de part et d'autre de la cible sans amortir — un 2-cycle exact. Au-delà, chaque pas **amplifie** l'écart (`a - b -> (1-delt)(a - b)` avec `|1-delt| > 1`) jusqu'à atteindre le rail `|a| = 1`, où le clip borne la divergence en un **cycle de période 2 collé au rail** — bornée, la boucle ne converge pas pour autant.\n",
+    "\n",
+    "La prédiction théorique est nette : la frontière entre convergence et non-convergence est **exactement `delt = 2`**. On la mesure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T00:01:27.055241Z",
+     "iopub.status.busy": "2026-08-27T00:01:27.055035Z",
+     "iopub.status.idle": "2026-08-27T00:01:27.063871Z",
+     "shell.execute_reply": "2026-08-27T00:01:27.063292Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " delt L=|1-delt|     a_120  |a_120-b|  comportement\n",
+      "----------------------------------------------------------\n",
+      "  0.5       0.50    0.3000     0.0000  converge\n",
+      "  1.0       0.00    0.3000     0.0000  converge\n",
+      "  1.5       0.50    0.3000     0.0000  converge\n",
+      "  1.9       0.90    0.3000     0.0000  converge\n",
+      "  2.0       1.00    0.9000     0.6000  2-cycle interieur\n",
+      "  2.1       1.10    1.0000     0.7000  2-cycle sur rail\n",
+      "  2.5       1.50    1.0000     0.7000  2-cycle sur rail\n",
+      "  3.0       2.00    1.0000     0.7000  2-cycle sur rail\n",
+      "\n",
+      "Borne de Banach : contraction ssi L < 1 ssi delt dans (0, 2)\n",
+      "Frontiere mesuree : convergence pour delt <= 1.9, bascule a delt = 2.0 exactement.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Surface B : carte delt -> comportement de la boucle ===\n",
+    "B_CIBLE = 0.3\n",
+    "\n",
+    "def boucle_homing(a0, delt, b=B_CIBLE, n=120):\n",
+    "    \"\"\"itere a' = clip(a + delt*(b-a)) et rend la trajectoire.\"\"\"\n",
+    "    traj = [a0]\n",
+    "    a = a0\n",
+    "    for _ in range(n):\n",
+    "        a = np.clip(a + delt * (b - a), -1.0, 1.0)\n",
+    "        traj.append(a)\n",
+    "    return np.array(traj)\n",
+    "\n",
+    "def classifie(traj, b=B_CIBLE, tol=1e-6):\n",
+    "    \"\"\"converge / 2-cycle interieur / 2-cycle sur rail, depuis la queue.\"\"\"\n",
+    "    queue = traj[-20:]\n",
+    "    if np.all(np.abs(queue - b) < 1e-4):\n",
+    "        return \"converge\"\n",
+    "    ecarts = queue - b\n",
+    "    if np.allclose(ecarts[::2], ecarts[0], atol=tol) and np.allclose(ecarts[1::2], ecarts[1], atol=tol):\n",
+    "        sur_rail = np.any(np.abs(np.abs(queue) - 1.0) < 1e-9)\n",
+    "        return \"2-cycle sur rail\" if sur_rail else \"2-cycle interieur\"\n",
+    "    return \"non stabilise\"\n",
+    "\n",
+    "DELTAS = [0.5, 1.0, 1.5, 1.9, 2.0, 2.1, 2.5, 3.0]\n",
+    "print(f\"{'delt':>5} {'L=|1-delt|':>10} {'a_120':>9} {'|a_120-b|':>10}  comportement\")\n",
+    "print(\"-\" * 58)\n",
+    "for delt in DELTAS:\n",
+    "    traj = boucle_homing(0.9, delt)\n",
+    "    comp = classifie(traj)\n",
+    "    print(f\"{delt:5.1f} {abs(1-delt):10.2f} {traj[-1]:9.4f} {abs(traj[-1]-B_CIBLE):10.4f}  {comp}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Borne de Banach : contraction ssi L < 1 ssi delt dans (0, 2)\")\n",
+    "print(\"Frontiere mesuree : convergence pour delt <= 1.9, bascule a delt = 2.0 exactement.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b12",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : la frontière mesurée coïncide avec la borne théorique **exactement**. En dessous de `delt = 2` (`L < 1`), la boucle converge vers la cible `b = 0.3` — géométriquement vite près de `delt = 1` (`L = 0`, convergence en un pas), plus lentement aux bords. À `delt = 2.0` (`L = 1`, cas limite non contractant), la boucle rebondit : l'écart change de signe à chaque pas sans changer de magnitude — le **2-cycle exact** prédit par l'analyse. Au-delà (`L > 1`), l'écart s'amplifie à chaque pas jusqu'à mordre le rail `|a| = 1` ; le clip a alors remplacé la divergence par un **2-cycle sur rail** — une des deux valeurs du cycle est collée au mur — la boucle bornée n'est plus pour autant convergente. Le clip ne répare pas la perte de contraction : il en masque la conséquence visible."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b13",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 4. Le régime exact de la boucle GT-18 — jamais contractante\n",
+    "\n",
+    "Reconsidérons la boucle effectivement committée dans GT-18 : `a' = clip(a + delta, -1, 1)` — un pas **additif** constant. Sa pente est `1` partout où le clip ne mord pas : constante de Lipschitz `L = 1`, **le cas limite non contractant, pour toute valeur de `delta`**. Banach ne s'applique pas ; ce qui fait converger la boucle de GT-18 vers `1.0` (cas `delta = 0.5`) est uniquement le **rail** : chaque pas ajoute `delta`, le clip tronque à `1`, et la valeur s'y colle — c'est une convergence-au-rail en temps borné (au plus `2/delta` pas), pas une convergence géométrique vers un point fixe intérieur. La distinction n'est pas cosmétique : la convergence-au-rail exige un mur pour s'arrêter, la convergence de Banach non — la surface B vient de le mesurer (`delt > 2` : même avec un rail, pas d'arrêt)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T00:01:27.078398Z",
+     "iopub.status.busy": "2026-08-27T00:01:27.078256Z",
+     "iopub.status.idle": "2026-08-27T00:01:27.084634Z",
+     "shell.execute_reply": "2026-08-27T00:01:27.084043Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Boucle additive GT-18 (L=1 partout, jamais contractante) :\n",
+      "  delta=+0.5 : atteint le rail en 1 pas, y reste (a_120 = +1.0)\n",
+      "  delta=-0.3 : atteint le rail en 5 pas, y reste (a_120 = -1.0)\n",
+      "\n",
+      "Boucle homing contractante (delt=0.8, L=0.2) : convergence GEOMETRIQUE interieure\n",
+      "  |a_n - b| pour n=0..7 : ['0.6000', '0.1200', '0.0240', '0.0048', '0.0010', '0.0002', '0.0000', '0.0000']\n",
+      "  ratio moyen d'amortissement par pas : 0.200 (theorie L = 0.2)\n",
+      "\n",
+      "Convergence-au-rail : temps borne par le mur, arret PAR le mur.\n",
+      "Convergence de Banach : taux geometrique |1-delt|, arret par amortissement interne.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === GT-18 reframed : la boucle additive est le cas L=1 partout ===\n",
+    "def boucle_additive(a0, delta, n=120):\n",
+    "    \"\"\"Boucle GT-18 exacte : a' = clip(a + delta).\"\"\"\n",
+    "    traj = [a0]\n",
+    "    a = a0\n",
+    "    for _ in range(n):\n",
+    "        a = np.clip(a + delta, -1.0, 1.0)\n",
+    "        traj.append(a)\n",
+    "    return np.array(traj)\n",
+    "\n",
+    "print(\"Boucle additive GT-18 (L=1 partout, jamais contractante) :\")\n",
+    "for delta in (0.5, -0.3):\n",
+    "    traj = boucle_additive(0.5, delta)\n",
+    "    n_rail = next((i for i, a in enumerate(traj) if abs(a - (1.0 if delta > 0 else -1.0)) < 1e-12), None)\n",
+    "    print(f\"  delta={delta:+.1f} : atteint le rail en {n_rail} pas, y reste (a_120 = {traj[-1]:+.1f})\")\n",
+    "print()\n",
+    "print(\"Boucle homing contractante (delt=0.8, L=0.2) : convergence GEOMETRIQUE interieure\")\n",
+    "traj = boucle_homing(0.9, 0.8)\n",
+    "errs = np.abs(traj[:8] - B_CIBLE)\n",
+    "print(f\"  |a_n - b| pour n=0..7 : {[f'{e:.4f}' for e in errs]}\")\n",
+    "print(f\"  ratio moyen d'amortissement par pas : {(errs[-1]/errs[0])**(1/7):.3f} (theorie L = 0.2)\")\n",
+    "print()\n",
+    "print(\"Convergence-au-rail : temps borne par le mur, arret PAR le mur.\")\n",
+    "print(\"Convergence de Banach : taux geometrique |1-delt|, arret par amortissement interne.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b15",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : les deux dynamiques sont distinguées par leur signature. La boucle additive de GT-18 atteint le rail en un nombre entier de pas (`2/delta` ici : 1 pas pour `delta = 0.5` partant de 0.5) et s'y colle — l'arrêt est un événement *discret*, causé par le mur. La boucle homing contractante, elle, amortit son erreur d'un facteur `L` à chaque pas — mesuré `≈ 0.2`, théorie `0.2` — et l'arrêt est *interieur*, asymptotique, sans mur. Le jouet GT-18 vivait donc dans le cas dégénéré `L = 1` : sa « convergence vers le point fixe » était la sédimentation sur le rail, et la section 3 de GT-18 mesurait la distance à un « point fixe » qui n'en était un que par clip."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b16",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 5. Verdict par surface — ce qui cède, ce qui tient\n",
+    "\n",
+    "| Surface | Ce qui cède | Ce qui tient | Condition exacte |\n",
+    "|---|---|---|---|\n",
+    "| **A — sélection compositionnelle** | composer des *sélections* d'argmax locaux sous plateau multivoque + couplage : le profil `(0,0)` prédit n'est pas Nash (`écart +0.300`) | la propriété de Hedges au sens des **correspondances** (l'ensemble composé sur-approxime les équilibres : `(1,1)` y est) ; la composition des sélections en régime **univoque** (section 1) | la casse exige la conjonction plateau × couplage — chacun seul est inoffensif (section 1, contre-fait r = 0) |\n",
+    "| **B — convergence de la boucle** | la lecture « la boucle converge donc elle est saine » : à `L ≥ 1` elle ne converge pas (2-cycle intérieur à `delt = 2`, 2-cycle sur rail au-delà) ; la boucle GT-18 est `L = 1` **partout** — jamais contractante | la frontière de contraction est **exactement** la borne de Banach `delt = 2` — le théorique et le mesuré coïncident sans zone grise | convergence géométrique ssi `delt ∈ (0, 2)` ; convergence-au-rail de GT-18 = arrêt par le mur, pas par amortissement |\n",
+    "\n",
+    "Le bilan de maturation est positif au sens strict : le jouet GT-18 **survit borné** — aucun de ses résultats numériques n'était faux — mais son périmètre de validité est désormais écrit : la composition des sélections exige l'univocité (ou l'absence de couplage), et la convergence de sa boucle est de type rail, pas de type Banach. C'est ce que « survivre à une variante -b » veut dire : pas rester intact, avoir ses bornes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b17",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Questions ouvertes — ce que cette variante ne tranche pas\n",
+    "\n",
+    "- **La sélection d'équilibre en amont.** La surface A montre que la composition sur-approxime l'ensemble des équilibres ; elle ne dit pas lequel un processus décentralisé sélectionne — ni si un raffinement (élimination des équilibres faibles par indifférence) suffirait à rétablir une composition des sélections *strictes*.\n",
+    "- **Le plateau exact est une symétrie.** La multivocité exhibée naît de `c = 0.5`, milieu exact de deux actions — un plateau de mesure nulle dans l'espace des paramètres. Un plateau épais (plateau d'utilité plate sur un intervalle, fréquent en jeux discrets de coordination) casserait de la même façon, mais la frontière « plateau de mesure nulle vs épais » n'est pas explorée ici.\n",
+    "- **Le clip lisse-t-il jamais ?** Sur la surface B, le clip a borné la divergence en oscillation. Il existe des update non lisses où le clip produit au contraire des points fixes attractifs *sur* le rail (convergence vers le mur avec approche unilatérale) — la taxonomy complète des régimes `L > 1` bornés n'est pas dressée."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b18",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 : le seuil de couplage\n",
+    "\n",
+    "La casse de la surface A exige `r > 0` — mais à quel seuil exactement ? Le profil `(0, 0)` prédit par la composition naïve cesse d'être un équilibre dès que `r` est strictement positif. Vérifiez-le : balayez `r` sur `np.linspace(0, 0.6, 7)` et, pour chaque valeur, recalculez l'écart de déviation de J1 au profil `(0, 0)`. Confirmez que l'écart vaut exactement `r` (pourquoi ?) et dites ce que devient le verdict à `r = 0`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T00:01:27.110175Z",
+     "iopub.status.busy": "2026-08-27T00:01:27.109897Z",
+     "iopub.status.idle": "2026-08-27T00:01:27.113870Z",
+     "shell.execute_reply": "2026-08-27T00:01:27.113083Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 a completer\n",
+    "# 1. Pour r dans np.linspace(0.0, 0.6, 7) : reconstruire u1_A avec ce couplage\n",
+    "# 2. Calculer l'ecart de deviation de J1 au profil (0, 0) : max_x u1(x, br2(x)) - u1(0, 0)\n",
+    "# 3. Verifier que l'ecart == r exactement, et expliquer pourquoi (indice : u1(1,1) - u1(0,0) = ... )\n",
+    "# Indice : -(1-0.5)^2 + r*1 - (-(0-0.5)^2 + r*0) = 0 + r = r\n",
+    "print(\"Exercice a completer\")\n",
+    "resultat_ex1 = None  # TODO etudiant : ecarts_par_r = ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b20",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 : le 2-cycle en main\n",
+    "\n",
+    "À `delt = 2.0` exactement, la théorie prédit que l'écart `a - b` change de signe à chaque pas sans changer de magnitude : `a_{n+1} - b = -(a_n - b)`. Partant de `a0 = 0.9` avec `b = 0.3` : calculez à la main les quatre premiers termes de la suite des écarts, puis vérifiez avec `boucle_homing` que la trajectoire exacte les reproduit. Combien vaut l'amplitude du cycle, et pourquoi ne décroît-elle jamais ?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b21",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T00:01:27.125897Z",
+     "iopub.status.busy": "2026-08-27T00:01:27.125719Z",
+     "iopub.status.idle": "2026-08-27T00:01:27.129100Z",
+     "shell.execute_reply": "2026-08-27T00:01:27.128421Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 a completer\n",
+    "# 1. Main : a0 = 0.9, b = 0.3, delt = 2.0 -> ecarts a_n - b pour n = 0..3\n",
+    "# 2. Verifier avec boucle_homing(0.9, 2.0) : les 4 premiers ecarts\n",
+    "# 3. Amplitude du cycle = |a0 - b| * (1 - 0) = |a0 - b| : pourquoi constante ?\n",
+    "# Indice : a' - b = clip(a + 2(b-a)) - b = (a + 2b - 2a) - b = -(a - b) tant que le clip ne mord pas\n",
+    "print(\"Exercice a completer\")\n",
+    "resultat_ex2 = None  # TODO etudiant : ecarts_theoriques = ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b22",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 : la cible hors du domaine\n",
+    "\n",
+    "Toute la surface B vise `b = 0.3`, intérieur au domaine `[-1, 1]` du clip. Que se passe-t-il quand la cible est **hors** du domaine — `b = 1.5` ? Prédisez d'abord (par écrit) : la boucle `a' = clip(a + delt*(b-a))` avec `delt = 0.8` converge-t-elle, et vers quoi ? Vérifiez numériquement : la limite est-elle le point fixe de Banach, ou autre chose ? Mesurez la distance finale et interprétez : le clip **projette** le point fixe sur le domaine fermé."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b23",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T00:01:27.141939Z",
+     "iopub.status.busy": "2026-08-27T00:01:27.141649Z",
+     "iopub.status.idle": "2026-08-27T00:01:27.145297Z",
+     "shell.execute_reply": "2026-08-27T00:01:27.144623Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 a completer\n",
+    "# 1. Prediction ecrite AVANT simulation : convergence vers b=1.5 ? vers 1.0 ? autre ?\n",
+    "# 2. Simuler boucle_homing(0.9, 0.8, b=1.5, n=120) et mesurer la limite\n",
+    "# 3. Distance finale : |limite - 1.5| = 0.5 -> le point fixe atteignable est projete sur le bord\n",
+    "# Indice : si a < 1 alors a' = a + 0.8*(1.5-a) > a (stritement) et clip(a') = 1 des que a >= 1\n",
+    "print(\"Exercice a completer\")\n",
+    "resultat_ex3 = None  # TODO etudiant : limite_b15 = ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b24",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Conclusion et perspectives\n",
+    "\n",
+    "GT-18 a survécu à sa variante -b au sens de la maturation : ses résultats tiennent, **et leurs bornes sont écrites**. Trois acquis :\n",
+    "\n",
+    "1. **La sélection n'est pas compositionnelle** — la composition de sélections d'argmax locaux rend un profil non-Nash (`(0, 0)`, écart `+0.300`) dès qu'un plateau multivoque rencontre un couplage ; la propriété de Hedges n'a jamais promis autre chose que la composition des *correspondances*, qui sur-approxime l'ensemble des équilibres. Prédire le point exige l'univocité — ou une théorie de la sélection.\n",
+    "2. **La frontière de contraction est la borne de Banach, exactement** — mesurée à `delt = 2` sans zone grise ; au-delà, le clip borne la divergence en oscillation sur rail, il ne la répare pas.\n",
+    "3. **La boucle GT-18 est le cas dégénéré `L = 1`** — sa convergence est une convergence-au-rail (arrêt par le mur, temps borné), pas une convergence géométrique de Banach (arrêt par amortissement interne). Les deux signatures sont mesurées et distinguées.\n",
+    "\n",
+    "Perspectives : le même patron s'applique à chaque objet mathématique porté par un jouet — vérifier la propriété sur le régime où elle tient (GT-18 l'a fait), puis chercher la frontière où elle cesse (ce notebook), puis écrire les bornes dans la prose (fait au §5). Le voisinage immédiat : la sélection d'équilibre dans les jeux composés à contextes multiples, et la taxonomy complète des boucles bornées non contractantes."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #13182

Closes #13185 — sous-grain de #12208 (stage 2 — maturation par variante -b), design-lock c.O validé headless avant construction.

## Ce que cette tranche fait

Nouveau notebook `GameTheory-18b-Casser-la-Composition.ipynb` (25 cellules, 8 code, 3 exercices stubs C.1) : la variante -b de maturation que le critère 4 de #12208 demande à GT-18 de survivre — « on a essayé de le casser et on sait ce qui s'est passé ». Deux surfaces d'attaque, chacune bornant le jouet GT-18 sans le réfuter.

## Résultats (acceptance point par point)

1. **Surface A exhibée par cellule exécutée** : J1 sur plateau exact (`u1 = -(x-0.5)² + r·y`, `c=0.5` = milieu exact de {0,1} → BR locale `{0,1}` multivoque), J2 couplée (`u2 = -(y-x)²`, `BR2(x) = x`). La composition de correspondances prévoit `{(0,0), (1,1)}` ; test Nash par énumération des déviations (J1 anticipant `y' = BR2(x')`) : **(0,0) NON-NASH du composé — écart +0.300** ; seul (1,1) survit. Vérifié contre la définition, aucune déviation profitable au composé affirmée sans être testée.
2. **Surface B balayée** : famille homing `a' = clip(a + delt·(b-a))`, `b=0.3`. Carte 8 delt : convergence pour delt ≤ 1.9 (`|a₁₂₀ − b| = 0`), **bascule à delt = 2.0 exactement** (2-cycle intérieur 0.9 ↔ −0.3, symétrique autour de b), delt ≥ 2.1 : **2-cycle sur rail** (une composante collée à ±1). **Frontière mesurée = borne théorique de Banach `L = |1−delt| < 1 ⇔ delt ∈ (0,2)`, sans zone grise.**
3. **GT-18 reproduit dans son régime** (section 1 : couplé mais univoque — la composition des sélections donne bien l'équilibre (1,1) du composé, vérifié par déviations) **et borné** : sa boucle additive `a' = clip(a + delta)` est `L = 1` partout — **jamais contractante** ; sa convergence est une convergence-au-rail (arrêt par le mur en temps borné), signature distinguée de la convergence géométrique de Banach (amortissement mesuré 0.2/pas vs théorie 0.2). La variante ne réfute pas le jouet monotone — elle écrit ses bornes (§5).
4. **Verdict honnête par surface** (table §5) : ce qui cède (la sélection compositionnelle sous plateau × couplage ; la lecture « la boucle converge donc elle est saine »), ce qui tient (Hedges au sens des correspondances — sur-approximation contenant (1,1) ; la borne de Banach exacte), condition exacte de chaque cas. Isolation des ingrédients par contre-faits : couplage seul (section 1, tient), plateau seul (`r = 0`, équilibres faibles par indifférence — tient) ; c'est la **conjonction** qui brise.
5. **3 exercices stubs C.1** (seuil de couplage r = écart exact ; le 2-cycle à la main + vérification ; cible hors domaine → point fixe projeté), prose française, **densité 14 769/8 = 1846 ch/code-cell** (seuil 1200).

## Design-lock respecté

Les deux surfaces étaient validées headless au cycle précédent (commentaire [DESIGN-LOCK] sur #13185) — les nombres du notebook reproduisent le verrou : écart +0.300, frontière delt = 2. Affinage de taxonomy en construction : le régime delt > 2 est un **2-cycle sur rail** (le clip borne la divergence en cycle de période 2), pas une oscillation générique — classifieur pré-vérifié sur les 8 delt critiques avant génération.

## Validation

- Papermill 25/25 cellules, 0 erreur, kernel python3 ; exec counts 1-8 non-null
- `validate_pr_notebooks.py origin/main <nb>` : **PASS** (8 cells python)
- C.1 : 0 violation ; H.3 pre-commit Passed (gitleaks, probe-banner, scrub-papermill inclus)
- Catalogue byte-identique à main (aucun fichier catalogue touché)
- L898 avant écriture : aucune PR ouverte sur `GameTheory-18b*`, aucun fichier 18b sur main

## Périmètre (1 fichier)

1 nouveau notebook auto-contenu (numpy seul). Aucune modification de GT-18 (pas de finding sur le jouet lui-même = pas de churn, conformément à l'anti-pattern #12208). GT-18 et 18b se mergent dans n'importe quel ordre.

## Diagnostic dérive (C.4)

Non applicable — notebook neuf. GT-18 inchangé : la -b le cite et le borne (régime univoque reproduit section 1, boucle additive reframée section 4), sans toucher au fichier.

## Verdict SOTA

**SOTA-OK** — numpy pour tout le calcul ; test Nash par énumération exhaustive (univers fini ×3 actions), classification de dynamique depuis la trajectoire, aucune substitution.

## Note G-VAR-3

`notebook-python` consécutif (prev #13182, MED) : substance distincte — casser la composition d'open games + frontière de contraction (théorie des jeux dynamique) vs statique comparative d'identification (économétrie expérimentale). Domaine-cœur GameTheory, tier DEEP (résultat de maturation nouveau : bornes de validité du jouet écrites, jamais exposées avant). G-VAR-1 : DEEP/CONTENU.
