### PR TITLE
docs(quantconnect,#3973): resync QC READMEs — QC-Py-12b-Backtest-Validity invisible des comptages

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/README.md
@@ -52,6 +52,7 @@ Suite à l'audit du 5 mai 2026, voici l'état honnête de chaque notebook. **Auc
 | QC-Py-10-Risk-Portfolio-Management | NON EXÉCUTÉ | |
 | QC-Py-11-Technical-Indicators | NON EXÉCUTÉ | |
 | QC-Py-12-Backtesting-Analysis | NON EXÉCUTÉ | |
+| QC-Py-12b-Backtest-Validity | EXÉCUTÉ | |
 | QC-Py-13-Alpha-Models | NON EXÉCUTÉ | |
 | QC-Py-14-Portfolio-Construction-Execution | NON EXÉCUTÉ | |
 | QC-Py-15-Parameter-Optimization | NON EXÉCUTÉ | |
@@ -124,6 +125,8 @@ Chaque notebook de la série rend visible un geste quantitatif distinct, dans un
 
 **[12 — Le profil risque-rendement d'un backtest.](QC-Py-12-Backtesting-Analysis.ipynb)** La richesse d'un backtest ne tient pas dans un seul Sharpe : le scatter des rendements quotidiens de la stratégie contre son benchmark expose la dispersion, les queues et la fréquence des bons et mauvais jours. C'est la signature statistique complète du comportement de la stratégie.
 
+**[12b — Un Sharpe de 0,2 prouve-t-il quoi que ce soit ?](QC-Py-12b-Backtest-Validity.ipynb)** Non, si le backtest couvre moins de dix ans : l'erreur-type asymptotique du Sharpe annualisé vaut environ `1/sqrt(N_années)` (Lo, 2002) — sur 7 ans, ±0,38. Un Sharpe mesuré à 0,2 est statistiquement indistinguable d'une stratégie sans aucun bord. Le notebook construit la lecture honnête d'un backtest : intervalle de confiance du Sharpe, multiplication des tests et faux positifs, et ce qu'il faut pour qu'une performance soit significative.
+
 <p align="center"><a href="QC-Py-12-Backtesting-Analysis.ipynb"><img src="assets/readme/quantpy12-backtest-scatter.png" width="540" alt="Analyse de backtest : deux sous-graphiques côte-à-côte sur 2 ans (2022-01 → 2024-01). Gauche — scatter Strategy Returns (%) vs Benchmark Returns (%) avec droite de régression rouge en pointillés β = 0.44 (la stratégie amplifie modérément le benchmark), ~250 points bleus dispersés dans le quadrant [-3 %, +3 %]², axes croisés à (0, 0). Droite — equity curves comparées : Strategie (bleu marine) finit à 1.42, Benchmark (gris tirets) finit à 1.47, baseline noire horizontale à 1.00. La Strategie reste sous le Benchmark toute l'année 2022 (sous-performance), puis dépasse en 2023-07 → 2023-10 (pic ~1.50). Démontre la mesure du β (sensibilité au benchmark) et le profil risque/rendement : β=0.44 < 1 = stratégie défensive (moins volatile que le marché)."></a></p>
 
 **[19 — La validation walk-forward, ou l'honnêteté temporelle.](QC-Py-19-ML-Supervised-Classification.ipynb)** Un modèle entraîné une fois puis testé sur tout l'échantillon triche avec le temps. La validation walk-forward décale une fenêtre d'entraînement puis re-teste, fold après fold, en mimant le retrain périodique qu'exige un trading réel. L'accuracy par fold révèle la robustesse — ou l'effondrement — hors échantillon.
@@ -160,6 +163,7 @@ Chaque notebook de la série rend visible un geste quantitatif distinct, dans un
 |----------|---------|
 | [QC-Py-11-Technical-Indicators](QC-Py-11-Technical-Indicators.ipynb) | Indicateurs techniques, indicateurs custom |
 | [QC-Py-12-Backtesting-Analysis](QC-Py-12-Backtesting-Analysis.ipynb) | Mesures de performance, Sharpe, drawdown |
+| [QC-Py-12b-Backtest-Validity](QC-Py-12b-Backtest-Validity.ipynb) | Erreur-type du Sharpe (Lo 2002), signification statistique du backtest |
 | [QC-Py-13-Alpha-Models](QC-Py-13-Alpha-Models.ipynb) | Framework Alpha, signaux, combinaison |
 | [QC-Py-14-Portfolio-Construction-Execution](QC-Py-14-Portfolio-Construction-Execution.ipynb) | Construction portefeuille, exécution |
 | [QC-Py-15-Parameter-Optimization](QC-Py-15-Parameter-Optimization.ipynb) | Optimization, grid search, walk-forward |

--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -9,7 +9,7 @@ maturity: BETA=80, ALPHA=15, DRAFT=12, TEMPLATE=1
 
 > **Note éditoriale — counts kernels par sous-série** : Le marqueur CATALOG-STATUS agrégé ci-dessus reste **autoritatif** pour la décomposition par **sous-série** (Python / projects / ML-Training-Pipeline / kelly_lean). En revanche, pour les décomptes par **kernel** (Python vs Lean 4) **au sein** d'une sous-série — c'est-à-dire la répartition technique par interpréteur —, **ce README reste autoritatif** car la décomposition langagière par sous-série n'est pas dans le marqueur agrégé. Cette granularité est documentée ici par lecture directe des `metadata.kernelspec.language` des notebooks :
 >
-> - **`Python/` (parcours QC-Py-*)** : 53/53 = **Python** (mono-langage, QuantConnect Cloud + kernel local Jupyter) — *kernel Python majoritaire, aucun piège sémantique C#*. **Drift constaté c.744** (audit `git ls-files Python/`) : 55 .ipynb sur disque vs 53 déclarés hub → écart +2, attribué aux notebooks Cloud ajoutés 2026-05/06 (PCA-StatArb, TemporalCNN, ValueFactor-ZScore, OptionWheel). CATALOG-STATUS leaf ajouté en c.744.
+> - **`Python/` (parcours QC-Py-*)** : 54/54 = **Python** (mono-langage, QuantConnect Cloud + kernel local Jupyter) — *kernel Python majoritaire, aucun piège sémantique C#*. **Drift constaté c.744** (audit `git ls-files Python/`) : 55 .ipynb sur disque vs 53 déclarés hub → écart +2, attribué aux notebooks Cloud ajoutés 2026-05/06 (PCA-StatArb, TemporalCNN, ValueFactor-ZScore, OptionWheel). CATALOG-STATUS leaf ajouté en c.744. **Réconciliation §E c.S** (audit entier, `_output` exclus) : 54 exacts sur disque = 30 linéaires (QC-Py-01..28 + 12b + 23b) + 24 compléments ; le résiduel +1 du c.744 était `QC-Py-12b-Backtest-Validity`, jamais compté nulle part (corrigé dans les tables et décomptes ci-dessous).
 > - **`ML-Training-Pipeline/`** : 14/14 = **Python** (PyTorch / Stable-Baselines3 / Walk-Forward). **Drift constaté c.744** : 14 .ipynb sur disque vs 2 déclarés hub → écart +12, la sous-série a crû depuis la création du breakdown hub (ajouts RL/DL ladder). CATALOG-STATUS leaf ajouté en c.744.
 > - **`kelly_lean/`** : 7/7 = **Lean 4** (preuve formelle Kelly HMM-regime fee-aware) — *mono-paradigme Lean* : prouve les invariants algébriques du critère de Kelly pour le sizing position-aware des régimes HMM, complémentaire aux notebooks Python ML. **Note c.744** : « 7/7 » dans cette note désigne les **fichiers `.lean` du lake** (7 sources : `Kelly.lean` + lemmes), périmètre différent du marqueur hub (`kelly_lean=1` = 1 notebook Jupyter de référence). CATALOG-STATUS leaf (1 .ipynb) ajouté en c.744.
 > - **`research/`** : 17 .ipynb (standalone research, yfinance/sklearn, hors QC Cloud) — **non-référencé dans le breakdown hub** (4 sous-séries agrégées : Python/projects/ML-Training-Pipeline/kelly_lean). CATALOG-STATUS leaf ajouté en c.744.
@@ -50,7 +50,7 @@ Le matériel QuantConnect se répartit en **5 zones** — un visiteur y navigue 
 
 | Zone | Contenu | Entrée |
 |------|---------|--------|
-| **`Python/`** | 53 notebooks pédagogiques QC-Py-* (8 phases, ci-dessous) | [README Python](Python/README.md) |
+| **`Python/`** | 54 notebooks pédagogiques QC-Py-* (8 phases, ci-dessous) | [README Python](Python/README.md) |
 | **`projects/`** | 112 entrées brutes (101 stratégies déployables `main.py` + 11 autres : 5 recherches, 2 stubs, 2 templates, 2 BROKEN pédagogiques), statut best-guess inventorié | [docs/qc/qc-strategies-status.md](../../docs/qc/qc-strategies-status.md) · [README projects](projects/README.md) |
 | **`research/`** | Recherche autonome standalone (données locales, pas de QC Cloud requis) | [README research](research/README.md) |
 | **`partner-course-quant-trading/`** | Exemples de recherche avancée du cours partenaire | [README cours partenaire](partner-course-quant-trading/README.md) |
@@ -92,7 +92,7 @@ Sélection dynamique d'univers, comprendre les particularités de chaque classe 
 
 ---
 
-### Phase 3 : Trading Avancé et Risk Management (4 notebooks, ~5.5h)
+### Phase 3 : Trading Avancé et Risk Management (5 notebooks, ~6.5h)
 
 Gestion du risque professionnelle, types d'ordres avancés, analyse approfondie de backtests.
 
@@ -102,6 +102,7 @@ Gestion du risque professionnelle, types d'ordres avancés, analyse approfondie 
 | 10 | [QC-Py-10-Risk-Portfolio-Management](Python/QC-Py-10-Risk-Portfolio-Management.ipynb) | 90 min | Position sizing (Kelly, fixed fractional), stop-loss, take-profit |
 | 11 | [QC-Py-11-Technical-Indicators](Python/QC-Py-11-Technical-Indicators.ipynb) | 75 min | Indicateurs intégrés, custom indicators, signal generation |
 | 12 | [QC-Py-12-Backtesting-Analysis](Python/QC-Py-12-Backtesting-Analysis.ipynb) | 75 min | Performance metrics (Sharpe, Sortino, max drawdown), equity curve |
+| 12b | [QC-Py-12b-Backtest-Validity](Python/QC-Py-12b-Backtest-Validity.ipynb) | 60 min | Erreur-type du Sharpe (Lo 2002), signification statistique d'un backtest |
 
 **Objectifs** : Maîtriser gestion du risque, ordres avancés, analyse de backtests.
 
@@ -246,7 +247,7 @@ python -m ipykernel install --user --name=quantconnect --display-name "Python (Q
 
 ## Résumé de la Progression
 
-**Total cours linéaire** : **29 notebooks Python** (QC-Py-01 à QC-Py-28 + le 23b, ~33 heures de contenu) + **24 notebooks compléments** (Phase 4b-RL avancé QC-Py-33..35, paper trading QC-Py-40..41, **15** Cloud strategies QC-Py-Cloud-01..09, training QC-Py-30..32, dataset workflow), plus **17 notebooks de recherche** standalone (`research_*.ipynb`, détaillés dans [research/README.md](research/README.md)).
+**Total cours linéaire** : **30 notebooks Python** (QC-Py-01 à QC-Py-28 + les 12b et 23b, ~34 heures de contenu) + **24 notebooks compléments** (Phase 4b-RL avancé QC-Py-33..35, paper trading QC-Py-40..41, **15** Cloud strategies QC-Py-Cloud-01..09, training QC-Py-30..32, dataset workflow), plus **17 notebooks de recherche** standalone (`research_*.ipynb`, détaillés dans [research/README.md](research/README.md)).
 
 **Répartition cours linéaire (Phases 1-8)** :
 - **18 notebooks non-ML** (Fondations, Universe, Trading Avancé, Framework, Alternative Data) : ~18h


### PR DESCRIPTION
Grain: MED/readme — lane myia-po-2024:CoursIA — prev: DEEP/notebook-python #13190

See #3973 — tranche feuille QuantConnect (partition lane-alignée de l'Epic, règle « 1 PR atomique par famille »). Suite directe de la tranche #12809 (projects/README, doublon BTC-ML).

## Finding central

`QC-Py-12b-Backtest-Validity.ipynb` (24 cellules, 8 code, **exécuté 8/8, outputs présents**) existait sur disque mais était **compté nulle part** : absent de la table phase 3 du README hub, absent du statut et du résumé de `Python/README.md`, absent de la décomposition ligne « Total cours linéaire ». Le compte réel est **54** notebooks QC-Py (hors `_output`), le README en déclarait 53. C'est le résiduel +1 de la note de drift c.744 (qui avait attribué son écart +2 aux Cloud — l'écart réel était +1 Cloud résorbé + 1 = 12b jamais compté).

## Corrections (audit §E fichier-entier, disque = vérité)

**`QuantConnect/README.md`** (4 points) :
1. Note kernelspec : `53/53` → `54/54` + paragraphe de réconciliation §E (54 = 30 linéaires (01..28 + 12b + 23b) + 24 compléments) — la note c.744 historique est préservée telle quelle (elle cite le marqueur, byte-identique).
2. Table famille : « 53 notebooks pédagogiques » → 54.
3. Phase 3 : header 4 → 5 notebooks (~5.5h → ~6.5h) + row `12b` (erreur-type du Sharpe, Lo 2002).
4. Total cours linéaire : 29 → 30 (« + les 12b et 23b », ~33h → ~34h).

**`QuantConnect/Python/README.md`** (3 points) :
5. Table de statut : row `QC-Py-12b-Backtest-Validity | EXÉCUTÉ` (vérifié : exec counts 1-8, outputs non vides).
6. Table de résumé par notebook : row 12b.
7. Entrée prose `[12b — Un Sharpe de 0,2 prouve-t-il quoi que ce soit ?]` — fidèle au contenu (Lo 2002, `1/sqrt(N_années)` ≈ ±0,38 sur 7 ans), même format que les entrées existantes.

## Validation

- Somme des tables de phase vérifiée : 4+4+5+3+3+3+4+4 = **30** = le total linéaire annoncé. Cohérence interne 30 + 24 = 54 ✓.
- « 53 » restants audités un à un : citation du marqueur drift (byte-identique, documenté comme tel) + valeur Sharpe 53.3 dans une table de backtests — aucun n'est un comptage de notebooks.
- Marqueur `CATALOG-STATUS` **byte-identique** à main (aucun fichier catalogue touché, R1 catalog-pr-hygiene).
- Nouveau contenu en français (readme-french-first). Pré-commit H.3 : Passed.

## Périmètre (2 fichiers markdown)

Aucun notebook modifié. Pas de `Closes` (contribution partielle à l'Epic #3973, qui reste OPEN — la racine est réservée ai-01 en dernier).

## Note G-VAR-3

`readme` après `notebook-python` (DEEP #13190) : rotation de genre — META ce cycle, le plancher G-VAR-1 de l'intervalle étant porté par #13190 (DEEP/CONTENU) livré au cycle précédent du même intervalle.
