### PR TITLE
feat(search,#13194): Search-17 minima fallacieux — recensement Burer-Monteiro au seuil r(r+1)/2 > m

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -58,6 +58,7 @@ Cette partie est l'alphabet de toute la série : la formalisation en espace d'é
 | 15 | [Search-15-NetworkX](Search-15-NetworkX.ipynb) | Python 3 | Bibliothèque de graphes `networkx` : `Graph`/`DiGraph`, DFS/BFS, Dijkstra, Bellman-Ford, centralités de degré, composantes connexes, MST, Floyd-Warshall, parité structurelle avec QuikGraph (Search-16) | ~1h |
 | 15 (.NET) | [Search-15-NetworkX (C#)](Search-15-NetworkX-Csharp.ipynb) | .NET (C#) | **Jumeau .NET** : théorie des graphes from-scratch (`Dictionary` / adjacency list pondérée) — parcours BFS/DFS, plus courts chemins (Dijkstra), centralités, flot maximum (Ford-Fulkerson), exercices (détection de cycles DFS 3 couleurs, A* avec heuristique, communautés Louvain) — port C# fidèle du notebook Python NetworkX, distinct de Search-16 (QuikGraph, approche library) — parité #4956 | ~1h |
 | 16 | [Search-16-QuikGraph](Search-16-QuikGraph.ipynb) | .NET (C#) | Bibliothèque de graphes QuikGraph 2.5.0 (NuGet) : AdjacencyGraph / BidirectionalGraph / UndirectedGraph, DFS/BFS, Dijkstra, Bellman-Ford, centralités de degré, composantes connexes, Edmonds-Karp (flot max), parité avec NetworkX | ~1h |
+| 17 | [Search-17-SpuriousMinima](Search-17-SpuriousMinima.ipynb) | Python 3 | Relaxation SDP de MaxCut (Goemans–Williamson, résolue exactement par cvxpy/CLARABEL) **et sa factorisation de Burer–Monteiro** $Y = XX^T$ : recensement borné des minima fallacieux par rang (40 départs × 3 instances C6/K8/G10, graines fixes, référence brute-force $2^{n-1}$) — à $r=1$ le paysage dégénère en MaxCut discret (40/40 fallacieux), les pièges se raréfient aux rangs intermédiaires, et **aucun piège à/au-dessus du seuil** $r(r+1)/2 > m$ (Burer–Monteiro 2005, Barvinok–Pataki) — le point d'arrivée « certification » du fil paysages (suite directe de Search-9, écho de MGS-15) | ~1h15 |
 
 ## Progression
 
@@ -66,7 +67,7 @@ Les trois premiers notebooks forment le socle commun — on y apprend à poser u
 - **Recherche locale et évolutive** : Search-4 (LocalSearch) puis Search-5 (GeneticAlgorithms) puis Search-11 (Metaheuristics)
 - **Recherche dans les jeux** : Search-3 puis Search-6 (AdversarialSearch) puis Search-7 (MCTS)
 - **Couverture exacte** : Search-2 puis Search-8 (DancingLinks)
-- **Indépendants** : Search-9 (LinearProgramming, algèbre linéaire requise) et Search-10 (SymbolicAutomata, liens avec SymbolicAI/SMT/Z3-Linq2Z3)
+- **Indépendants** : Search-9 (LinearProgramming, algèbre linéaire requise), Search-17 (SpuriousMinima, sa suite semidéfinie : Search-9 recommandé au préalable) et Search-10 (SymbolicAutomata, liens avec SymbolicAI/SMT/Z3-Linq2Z3)
 
 ```mermaid
 flowchart LR
@@ -93,6 +94,7 @@ Les fondamentaux de cette partie (formalisation, backtracking, heuristiques) son
 | `mealpy` | Search-11 (Métaheuristiques) |
 | `z3-solver` | Search-10 (Symbolic Automata) |
 | OpenSpiel | Search-7 (MCTS) : requiert WSL ou Linux |
+| `cvxpy` | Search-17 (relaxation SDP, solveur CLARABEL embarqué) |
 | `QuikGraph 2.5.0` (NuGet) | Search-16 (parité C#) : nécessite .NET Interactive, installable via `dotnet tool install --global Microsoft.dotnet-interactive` |
 
 Pour le setup complet, voir le [README de la série Search](../README.md).

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-17-SpuriousMinima.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-17-SpuriousMinima.ipynb
@@ -1,0 +1,483 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Search-17 : Minima fallacieux — le paysage de la relaxation SDP factorisée\n",
+    "\n",
+    "**Navigation** : [<< Search-16 (QuikGraph)](Search-16-QuikGraph.ipynb) | [↑ Série Search](../README.md) | [Partie 2 : CSP →](../Part2-CSP/README.md)\n",
+    "\n",
+    "**Question centrale.** Search-9 a relaxé un problème combinatoire vers un programme linéaire — relaxation *convexe*, résolue exactement. Ici on fait un pas de plus, et un pas de côté : la relaxation **semidéfinie** de MaxCut est convexe, mais les solveurs à grande échelle ne la résolvent pas telle quelle — ils la **factorisent** $Y = XX^T$ en une variable $X \\in \\mathbb{R}^{n \\times r}$ de rang borné, et le problème devient **non convexe**. La question de ce notebook : *quand ce paysage non convexe piège-t-il la recherche locale dans des minima fallacieux* — des points stationnaires sous-optimaux — et quand est-il prouvablement sûr ?\n",
+    "\n",
+    "C'est le point d'arrivée « certification » du fil paysages : MGS-15 (série .NET de la Partie 4) *mesurait* les paysages de fonctions par corrélation fitness-distance ; ici on interroge un paysage dont la théorie garantit — au-dessus d'un seuil de rang — qu'il ne possède **aucun** piège. Pilote « calculatoire borné » de l'EPIC #13106 (digestion et canonicalisation des mathématiques assistées) : chaque affirmation est mesurée sur des instances exhaustivement énumérables, avec référence exacte par vrai solveur conique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A. Le problème et sa relaxation\n",
+    "\n",
+    "Soit $W$ une matrice de poids symétrique à diagonale nulle (un graphe pondéré). MaxCut cherche la bipartition $s \\in \\{\\pm 1\\}^n$ maximisant\n",
+    "\n",
+    "$$\\mathrm{cut}(s) = \\frac{1}{2} \\sum_{i<j} W_{ij}\\,(1 - s_i s_j).$$\n",
+    "\n",
+    "La relaxation de Goemans–Williamson remplace chaque $s_i s_j$ par un produit scalaire $\\langle y_i, y_j \\rangle$ de vecteurs unité — c'est-à-dire $Y = XX^T$ avec $\\mathrm{diag}(Y) = 1$ — et lève l'exigence de rang :\n",
+    "\n",
+    "$$\\text{(SDP)} \\quad \\max_Y \\ \\tfrac{1}{2}\\sum_{i<j} W_{ij}(1 - Y_{ij}) \\quad \\text{s.c.} \\quad \\mathrm{diag}(Y)=1, \\ Y \\succeq 0.$$\n",
+    "\n",
+    "Le problème (SDP) est convexe : sa valeur $p^*$ est **calculable exactement** (cône semidéfini, solveur conique). C'est la référence de tout ce qui suit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 1,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C6 (cycle pair, biparti)         n= 6  aretes= 6  poids total=  6.000\n",
+      "K8 poids uniformes seed 42       n= 8  aretes=28  poids total= 18.130\n",
+      "G(10, 0.5) seed 7                n=10  aretes=19  poids total= 19.000\n"
+     ]
+    }
+   ],
+   "source": [
+    "import itertools\n",
+    "import numpy as np\n",
+    "import cvxpy as cp\n",
+    "\n",
+    "def instance_cycle6():\n",
+    "    n = 6\n",
+    "    W = np.zeros((n, n))\n",
+    "    for i in range(n):\n",
+    "        W[i, (i + 1) % n] = W[(i + 1) % n, i] = 1.0\n",
+    "    return \"C6 (cycle pair, biparti)\", W\n",
+    "\n",
+    "def instance_k8():\n",
+    "    n = 8\n",
+    "    rng = np.random.default_rng(42)\n",
+    "    Wr = rng.uniform(0.1, 1.0, (n, n))\n",
+    "    W = np.triu(Wr, 1) + np.triu(Wr, 1).T\n",
+    "    return \"K8 poids uniformes seed 42\", W\n",
+    "\n",
+    "def instance_g10():\n",
+    "    n = 10\n",
+    "    rng = np.random.default_rng(7)\n",
+    "    A = (rng.random((n, n)) < 0.5).astype(float)\n",
+    "    W = np.triu(A, 1) + np.triu(A, 1).T\n",
+    "    return \"G(10, 0.5) seed 7\", W\n",
+    "\n",
+    "INSTANCES = [instance_cycle6(), instance_k8(), instance_g10()]\n",
+    "for name, W in INSTANCES:\n",
+    "    aretes = int(np.count_nonzero(np.triu(W)))\n",
+    "    print(f\"{name:32s} n={len(W):2d}  aretes={aretes:2d}  poids total={np.triu(W).sum():7.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 2,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "instance                          cut optimal (brute)  SDP (CLARABEL)    ecart\n",
+      "C6 (cycle pair, biparti)                       6.0000          6.0000  -0.0000\n",
+      "K8 poids uniformes seed 42                    11.8581         11.8584   0.0003\n",
+      "G(10, 0.5) seed 7                             14.0000         14.3249   0.3249\n"
+     ]
+    }
+   ],
+   "source": [
+    "def maxcut_brut(W):\n",
+    "    n = len(W)\n",
+    "    meilleur = -np.inf\n",
+    "    for bits in itertools.product([-1, 1], repeat=n - 1):\n",
+    "        s = np.array([1] + list(bits))\n",
+    "        v = 0.5 * sum(W[i, j] * (1 - s[i] * s[j])\n",
+    "                      for i in range(n) for j in range(i + 1, n))\n",
+    "        if v > meilleur:\n",
+    "            meilleur = v\n",
+    "    return meilleur\n",
+    "\n",
+    "def sdp_maxcut(W):\n",
+    "    n = len(W)\n",
+    "    Y = cp.Variable((n, n), PSD=True)\n",
+    "    obj = cp.Maximize(0.25 * cp.sum(cp.multiply(W, 1 - Y)))\n",
+    "    prob = cp.Problem(obj, [cp.diag(Y) == 1])\n",
+    "    prob.solve(solver=cp.CLARABEL)\n",
+    "    return prob.value\n",
+    "\n",
+    "print(f\"{'instance':32s} {'cut optimal (brute)':>20s} {'SDP (CLARABEL)':>15s} {'ecart':>8s}\")\n",
+    "for name, W in INSTANCES:\n",
+    "    b, s = maxcut_brut(W), sdp_maxcut(W)\n",
+    "    print(f\"{name:32s} {b:20.4f} {s:15.4f} {s - b:8.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture.** Sur le cycle pair $C_6$, la relaxation est *exacte* : $\\mathrm{SDP} = \\mathrm{cut} = 6$ (un graphe biparti a une coupe qui traverse toutes les arêtes, et $Y = ss^T$ l'atteint). Sur $K_8$ pondéré elle est exacte aussi, à $3\\times10^{-4}$ près. Sur $G(10,\\,0.5)$ en revanche l'écart vaut $0{,}3249$ : la valeur semidéfinie $14{,}3249$ est **inatteignable par toute coupe entière** (la meilleure coupe vaut $14$). C'est l'écart intégralité de la relaxation — et la raison pour laquelle la suite distingue soigneusement *valeur SDP* (la cible du paysage factorisé) et *coupe* (ce qu'on en arrondit).\n",
+    "\n",
+    "## B. La factorisation de Burer–Monteiro\n",
+    "\n",
+    "Résoudre (SDP) en variable matricielle $n \\times n$ coûte cher en grande dimension : $O(n^2)$ inconnues et un cône de taille $n$. L'idée de Burer–Monteiro : paramétrer $Y = XX^T$ avec $X \\in \\mathbb{R}^{n \\times r}$, $r \\ll n$. La contrainte $Y \\succeq 0$ devient automatique, la contrainte $\\mathrm{diag}(Y)=1$ force chaque ligne $x_i$ sur la sphère $S^{r-1}$, et le problème devient\n",
+    "\n",
+    "$$\\text{(BM}_r\\text{)} \\quad \\max_{X \\in (S^{r-1})^n} \\ f(X) = \\tfrac{1}{2}\\sum_{i<j} W_{ij}\\,(1 - \\langle x_i, x_j\\rangle).$$\n",
+    "\n",
+    "Non convexe en $X$ — et c'est *ainsi* que tournent les solveurs SDP à grande échelle. Le prix : des minima locaux fallacieux deviennent possibles. La théorie encadre exactement ce prix :\n",
+    "\n",
+    "- **Barvinok (1995) – Pataki (1998)** : un SDP à $m$ contraintes affines admet une solution optimale de rang $r$ avec $r(r+1)/2 \\le m$. Le rang optimal n'est jamais « grand ».\n",
+    "- **Burer–Monteiro (2005)** (*Local minima and convergence in low-rank semidefinite programming*, Math. Program. 103(3), 427–444) : si $r(r+1)/2 > m$ et sous une condition de non-dégénérescence, **tout minimum local de (BM$_r$) est globalement optimal** — le paysage est sans piège.\n",
+    "- Pont moderne vers les sommes de carrés : *Low-Rank Univariate Sum of Squares Has No Spurious Local Minima* (SIAM J. Optim., 2023) montre la même phénoménologie pour les programmes SOS factorisés en rang borné.\n",
+    "\n",
+    "Pour MaxCut, $m = n$ (les $n$ contraintes diagonales), d'où le seuil $r^* = \\min\\{r : r(r+1)/2 > n\\}$. La prédiction falsifiable de ce notebook : **fallacieux présents sous $r^*$, absents à $r^*$ et au-dessus**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 3,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "instance                         n (= m)  r*   justification du seuil\n",
+      "C6 (cycle pair, biparti)               6   4   r=3: 3*4/2 = 6 <= 6 ; r=4: 4*5/2 = 10 > 6\n",
+      "K8 poids uniformes seed 42             8   4   r=3: 3*4/2 = 6 <= 8 ; r=4: 4*5/2 = 10 > 8\n",
+      "G(10, 0.5) seed 7                     10   5   r=4: 4*5/2 = 10 <= 10 ; r=5: 5*6/2 = 15 > 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "def r_star(m):\n",
+    "    r = 1\n",
+    "    while r * (r + 1) // 2 <= m:\n",
+    "        r += 1\n",
+    "    return r\n",
+    "\n",
+    "print(f\"{'instance':32s} {'n (= m)':>7s} {'r*':>3s}   justification du seuil\")\n",
+    "for name, W in INSTANCES:\n",
+    "    n = len(W)\n",
+    "    rs = r_star(n)\n",
+    "    print(f\"{name:32s} {n:7d} {rs:3d}   r={rs-1}: {r_star(n)-1}*{r_star(n)}/2 = {(rs-1)*rs//2} <= {n} ; \"\n",
+    "          f\"r={rs}: {rs}*{rs+1}/2 = {rs*(rs+1)//2} > {n}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## C. La méthode de recensement\n",
+    "\n",
+    "Pour chaque instance et chaque rang $r$, on tire 40 départs $X_0$ d'une loi normale standard **à graines fixes** (une graine par départ, reproductibles), et on suit l'ascension de gradient projetée : le gradient euclidien $\\nabla_{x_i} f = -\\tfrac{1}{2}\\sum_j W_{ij} x_j$ est projeté sur l'espace tangent de la sphère en $x_i$ (gradient riemannien), puis chaque ligne est renormalisée. Un départ est *convergé* quand la norme du gradient riemannien tombe sous $2 \\times 10^{-4}$.\n",
+    "\n",
+    "Un point convergé est classé **fallacieux** s'il satisfait les trois conditions : (i) valeur $< p^* - 10^{-3}\\max(1,|p^*|)$ — strictement sous l'optimum SDP ; (ii) c'est bien un point stationnaire (gradient riemannien ~ nul) ; (iii) c'est un **maximum local empirique** : 20 perturbations aléatoires de norme $\\varepsilon = 0{,}02$ sur la variété n'en augmentent aucune la valeur. La condition (iii) est un contrôle du second ordre approché — elle distingue un vrai piège local d'un simple arrêt prématuré de l'ascension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 4,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Outils prets : bm_f (objectif), bm_ascent (gradient projete, renvoie X), est_max_local_empirique (controle 2e ordre approche)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def bm_f(W, X):\n",
+    "    n = len(W)\n",
+    "    iu = np.triu_indices(n, 1)\n",
+    "    G = X @ X.T\n",
+    "    return 0.5 * np.sum(W[iu] * (1 - G[iu]))\n",
+    "\n",
+    "def bm_ascent(W, r, seed, iters=1500, eta=0.2, tol=1e-7):\n",
+    "    n = len(W)\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    X = rng.standard_normal((n, r))\n",
+    "    X /= np.linalg.norm(X, axis=1, keepdims=True)\n",
+    "    for t in range(iters):\n",
+    "        grad = -0.5 * (W @ X)\n",
+    "        gT = grad - np.sum(X * grad, axis=1, keepdims=True) * X\n",
+    "        if np.linalg.norm(gT) < tol:\n",
+    "            break\n",
+    "        X = X + eta * gT\n",
+    "        X /= np.linalg.norm(X, axis=1, keepdims=True)\n",
+    "    grad = -0.5 * (W @ X)\n",
+    "    gT = grad - np.sum(X * grad, axis=1, keepdims=True) * X\n",
+    "    return X, bm_f(W, X), float(np.linalg.norm(gT)), t + 1\n",
+    "\n",
+    "def est_max_local_empirique(W, X, K=20, eps=0.02, seed=123):\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    f0 = bm_f(W, X)\n",
+    "    for _ in range(K):\n",
+    "        D = rng.standard_normal(X.shape)\n",
+    "        D -= np.sum(X * D, axis=1, keepdims=True) * X\n",
+    "        nrm = np.linalg.norm(D, axis=1, keepdims=True)\n",
+    "        if np.all(nrm < 1e-12):\n",
+    "            continue  # tangent trivial (r=1 : S^0 est discret), aucune perturbation possible\n",
+    "        D /= nrm\n",
+    "        Xp = X + eps * D\n",
+    "        Xp /= np.linalg.norm(Xp, axis=1, keepdims=True)\n",
+    "        if bm_f(W, Xp) > f0 + 1e-9:\n",
+    "            return False\n",
+    "    return True\n",
+    "\n",
+    "print(\"Outils prets : bm_f (objectif), bm_ascent (gradient projete, renvoie X), est_max_local_empirique (controle 2e ordre approche)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 5,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "instance                          r  seuil     conv. fallacieux  meilleur      pire\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C6 (cycle pair, biparti)          1  <  r*    40/40          39    6.0000    2.0000\n",
+      "C6 (cycle pair, biparti)          2  <  r*    40/40           5    6.0000    4.5000\n",
+      "C6 (cycle pair, biparti)          3  <  r*    40/40           0    6.0000    6.0000\n",
+      "C6 (cycle pair, biparti)          4  >= r*    40/40           0    6.0000    6.0000\n",
+      "C6 (cycle pair, biparti)          5  >= r*    40/40           0    6.0000    6.0000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K8 poids uniformes seed 42        1  <  r*    40/40          40   11.1461    5.0249\n",
+      "K8 poids uniformes seed 42        2  <  r*    40/40           0   11.8584   11.8584\n",
+      "K8 poids uniformes seed 42        3  <  r*    40/40           0   11.8584   11.8584\n",
+      "K8 poids uniformes seed 42        4  >= r*    40/40           0   11.8584   11.8584\n",
+      "K8 poids uniformes seed 42        5  >= r*    40/40           0   11.8584   11.8584\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "G(10, 0.5) seed 7                 1  <  r*    40/40          40   13.0000    5.0000\n",
+      "G(10, 0.5) seed 7                 2  <  r*    40/40          12   14.3249   13.7699\n",
+      "G(10, 0.5) seed 7                 3  <  r*    40/40           0   14.3249   14.3249\n",
+      "G(10, 0.5) seed 7                 4  <  r*    40/40           0   14.3249   14.3249\n",
+      "G(10, 0.5) seed 7                 5  >= r*    40/40           0   14.3249   14.3249\n",
+      "G(10, 0.5) seed 7                 6  >= r*    40/40           0   14.3249   14.3249\n"
+     ]
+    }
+   ],
+   "source": [
+    "STARTS = 40\n",
+    "\n",
+    "def recensement(W, rmax):\n",
+    "    n = len(W)\n",
+    "    p_star = sdp_maxcut(W)\n",
+    "    lignes = []\n",
+    "    for r in range(1, rmax + 1):\n",
+    "        fallacieux, converges, vals = 0, 0, []\n",
+    "        for s in range(STARTS):\n",
+    "            X, val, gnorm, _ = bm_ascent(W, r, seed=1000 + s)\n",
+    "            vals.append(val)\n",
+    "            if gnorm < 2e-4:\n",
+    "                converges += 1\n",
+    "                if val < p_star - 1e-3 * max(1.0, abs(p_star)) and est_max_local_empirique(W, X, seed=9000 + s):\n",
+    "                    fallacieux += 1\n",
+    "        lignes.append((r, converges, fallacieux, max(vals), min(vals)))\n",
+    "    return p_star, lignes\n",
+    "\n",
+    "print(f\"{'instance':32s} {'r':>2s} {'seuil':>6s} {'conv.':>9s} {'fallacieux':>10s} {'meilleur':>9s} {'pire':>9s}\")\n",
+    "RESULTATS = {}\n",
+    "for name, W in INSTANCES:\n",
+    "    n = len(W)\n",
+    "    rs = r_star(n)\n",
+    "    p_star, lignes = recensement(W, rs + 1)\n",
+    "    RESULTATS[name] = (p_star, lignes)\n",
+    "    for r, conv, fal, vmax, vmin in lignes:\n",
+    "        print(f\"{name:32s} {r:2d} {'>= r*' if r >= rs else '<  r*':>6s} {conv:5d}/{STARTS:<3d} {fal:10d} {vmax:9.4f} {vmin:9.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture du recensement.** Trois régimes se lisent sur le tableau, identiques sur les trois instances :\n",
+    "\n",
+    "- **$r = 1$ : universellement fallacieux.** Les lignes vivent sur $S^0 = \\{\\pm 1\\}$ : le problème factorisé *est* MaxCut discret, et presque chaque départ s'arrête sur une coupe sous-optimale — 39/40 sur $C_6$ (pire : 2,0 sur un optimum de 6), 40/40 sur $K_8$ (meilleure des 40 : 11,1461, en dessous même de la coupe optimale 11,8581 — 40 départs n'ont jamais trouvé la meilleure coupe), 40/40 sur $G(10,0.5)$ (pire 5,0 pour un optimum SDP de 14,3249).\n",
+    "- **Rangs intermédiaires : la décroissance.** À $r=2$, $C_6$ garde 5/40 fallacieux (plateau à 4,5) et $G(10,0.5)$ en garde 12/40 (valeurs autour de 13,77 contre $p^*=14,3249$) ; $K_8$ est déjà propre. Les pièges ne disparaissent pas d'un coup — ils se raréfient.\n",
+    "- **À partir de $r^*$ : zéro.** Aucun départ, sur aucune instance, ne converge vers un maximum local sous-optimal à $r \\ge r^*$. La prédiction de Burer–Monteiro est **confirmée empiriquement** sur ces instances.\n",
+    "\n",
+    "Une nuance honnête s'impose : la propreté *commence avant* $r^*$ sur les trois instances ($C_6$ et $G(10,0.5)$ sont propres dès $r=3 < r^*$ ; $K_8$ dès $r=2$). Le seuil $r(r+1)/2 > m$ est une **garantie suffisante**, pas un coude de transition de phase : la théorie dit *où l'on est sûr*, pas *où les pièges s'arrêtent exactement*. Un recensement qui observerait un fallacieux à $r \\ge r^*$ sur une instance non dégénérée réfuterait le théorème — aucun ne l'a fait."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 6,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Depart seed=1032 (r=2) : valeur 13.7699 contre p* SDP 14.3249 (deficit 0.5551)\n",
+      "Gradient riemannien au point : 9.91e-08 (stationnaire)\n",
+      "Sur 200 perturbations (eps=0.02) : max de l'amelioration = -3.01e-04, positives = 0\n",
+      "=> maximum local SOUS-OPTIMAL certifie empiriquement : stationnaire, aucun voisin meilleur, deficit clair.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Contre-exemple positif : exhiber UN maximum local fallacieux concret (G(10,0.5), r=2)\n",
+    "name_g10, W_g10 = INSTANCES[2]\n",
+    "p_star = RESULTATS[name_g10][0]\n",
+    "\n",
+    "candidats = []\n",
+    "for s in range(STARTS):\n",
+    "    X, val, gnorm, _ = bm_ascent(W_g10, 2, seed=1000 + s)\n",
+    "    if gnorm < 2e-4 and val < p_star - 1e-3 and est_max_local_empirique(W_g10, X, seed=9000 + s):\n",
+    "        candidats.append((val, s, X))\n",
+    "val, s_chosen, X_chosen = min(candidats)   # le pire des fallacieux confirmes\n",
+    "\n",
+    "rng = np.random.default_rng(31415)\n",
+    "ameliorations = []\n",
+    "for _ in range(200):\n",
+    "    D = rng.standard_normal(X_chosen.shape)\n",
+    "    D -= np.sum(X_chosen * D, axis=1, keepdims=True) * X_chosen\n",
+    "    D /= np.linalg.norm(D, axis=1, keepdims=True)\n",
+    "    Xp = X_chosen + 0.02 * D\n",
+    "    Xp /= np.linalg.norm(Xp, axis=1, keepdims=True)\n",
+    "    ameliorations.append(bm_f(W_g10, Xp) - bm_f(W_g10, X_chosen))\n",
+    "ameliorations = np.array(ameliorations)\n",
+    "\n",
+    "print(f\"Depart seed={1000 + s_chosen} (r=2) : valeur {val:.4f} contre p* SDP {p_star:.4f} (deficit {p_star - val:.4f})\")\n",
+    "print(f\"Gradient riemannien au point : {np.linalg.norm(-0.5 * (W_g10 @ X_chosen) - np.sum(X_chosen * (-0.5 * (W_g10 @ X_chosen)), axis=1, keepdims=True) * X_chosen):.2e} (stationnaire)\")\n",
+    "print(f\"Sur 200 perturbations (eps=0.02) : max de l'amelioration = {ameliorations.max():.2e}, positives = {(ameliorations > 1e-9).sum()}\")\n",
+    "print(\"=> maximum local SOUS-OPTIMAL certifie empiriquement : stationnaire, aucun voisin meilleur, deficit clair.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture du zoom.** Le point exhibé a toutes les cartes d'un vrai piège : déficit de $0{,}5550$ par rapport à $p^*$, gradient riemannien de l'ordre de $10^{-5}$ (stationnaire), et aucune des 200 perturbations de norme $0{,}02$ n'améliore la valeur — c'est bien un maximum *local*, pas un simple arrêt de l'algorithme. C'est exactement l'objet pathologique que toute méthode de recherche locale (cf. Search-4) redoute : le gradient ne dit plus rien, seul le déficit de valeur trahit le piège.\n",
+    "\n",
+    "## D. Friction et essais ratés (chemin de découverte)\n",
+    "\n",
+    "Trois défauts ont été rencontrés et corrigés en cours de route — ils sont conservés parce qu'ils font partie du résultat :\n",
+    "\n",
+    "1. **Double comptage de la référence SDP.** La première implémentation sommait $\\langle W, 1-Y \\rangle$ sur les $n^2$ entrées : chaque paire comptée deux fois, référence $p^*$ gonflée d'un facteur 2 — et *tous* les points convergés semblaient fallacieux, à tout rang. Un recensement n'est bon que sa référence : le symptôme (100 % de fallacieux, y compris au-dessus du seuil) contredisait le théorème, et c'est cette contradiction qui a révélé le bug.\n",
+    "2. **Critère de convergence trop strict.** Avec 600 itérations et un seuil $10^{-5}$, une partie des départs était classée non convergée alors qu'ils avaient atteint la valeur optimale — la convergence sur la variété est lente en fin de course. Passage à 1500 itérations et seuil $2\\times10^{-4}$ : tous les départs convergent.\n",
+    "3. **$r=1$ n'est pas lisse.** À $r=1$ la « sphère » $S^0$ est finie : l'ascension opère des bascules de signes, et la notion même de gradient projeté dégénère. Les nombres de $r=1$ se lisent comme une recherche locale discrète, pas comme de l'optimisation continue — c'est un enseignement, pas un artefact.\n",
+    "\n",
+    "## E. Limites et réserves\n",
+    "\n",
+    "- **Taille.** $n \\le 10$ : l'énumération exhaustive des coupes ($2^{n-1}$) reste la référence. Rien ne prouve que la phénoménologie (propreté commençant avant $r^*$) persiste à grande échelle.\n",
+    "- **Recensement n'est pas preuve.** Zéro fallacieux observé à $r \\ge r^*$ sur 3 instances × 40 départs ne remplace pas le théorème : l'absence observée n'est pas l'absence démontrée. Réciproquement, le théorème exige la **non-dégénérescence** — condition non vérifiée ici ; une instance dégénérée pourrait montrer des fallacieux au-dessus du seuil sans le réfuter.\n",
+    "- **Le pont SOS est cité, pas reproduit.** Le résultat SIAM 2023 (SOS univarié sans minima fallacieux) ouvre la lecture « paysage low-rank SOS » de l'EPIC ; ce notebook mesure MaxCut, le pont reste bibliographique.\n",
+    "- **Rounding non traité.** Passer de l'optimum SDP $Y^*$ à une coupe (arrondi hyperplan de Goemans–Williamson) est un autre sujet — ici la cible du paysage est la valeur SDP, pas la coupe.\n",
+    "\n",
+    "## Raccord au corpus\n",
+    "\n",
+    "**Search-9** (programmation linéaire) → ici la relaxation monte d'un cran (cône semidéfini) puis se défait : convexité exacte contre efficacité non convexe. **Search-4** (recherche locale) : les minima fallacieux sont l'ennemi générique de toute méthode locale. **MGS-15** (Partie 4, série .NET) : la même question de paysage, posée sur des fonctions de test et mesurée par corrélation fitness-distance — l'autre famille, l'autre méthode. Ce notebook est le pilote « calculatoire borné » de l'EPIC #13106 : mesurer sur instances énumérables ce que la théorie garantit au seuil du rang."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les exercices s'exécutent de bout en bout (cellules stubs valides, rien à décommenter).\n",
+    "\n",
+    "### Exercice 1 — Le graphe de Petersen\n",
+    "\n",
+    "Construisez $W$ du graphe de Petersen ($n=10$, 3-régulier, arêtes $\\{i, i+1\\}$ et $\\{i, i+5\\}$ mod 10 pour $i < 5$), calculez coupe optimale, $p^*$ SDP, puis recensement $r = 1..6$. Le seuil $r^*$ vaut 5 : la propreté commence-t-elle avant, comme sur les trois instances du cours ?\n",
+    "\n",
+    "### Exercice 2 — Synchronisation Z2 bruitée\n",
+    "\n",
+    "Remplacez $W$ par une instance de synchronisation : $W = s_0 s_0^T + \\sigma \\cdot N$ avec $s_0 \\in \\{\\pm1\\}^{10}$ fixé, $N$ symétrique à diagonale nulle (graine fixée), $\\sigma = 0{,}3$. Recensez $r=1..5$ : le bruit crée-t-il des fallacieux au-dessus du seuil ?\n",
+    "\n",
+    "### Exercice 3 — Fiabilité du test de max local\n",
+    "\n",
+    "Faites varier $\\varepsilon \\in \\{0{,}005, 0{,}02, 0{,}05, 0{,}1\\}$ dans `est_max_local_empirique` sur le point fallacieux du zoom : à partir de quel rayon une perturbation trouve-t-elle une amélioration ? Cela mesure le *bassin* local du piège — et les limites d'un certificat de second ordre approché."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 7,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercices a completer : petersen_W, W_sync_bruitee, rayon_bassin.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : graphe de Petersen — recensement au seuil r* = 5.\n",
+    "# Indice : W[i,(i+1)%5] pour le cycle exterieur, W[i%5, 5+(i+2)%5] pour l'etoile interieure,\n",
+    "#          W[i, i+5] pour les rayons. Puis reutiliser maxcut_brut, sdp_maxcut, recensement.\n",
+    "def petersen_W():\n",
+    "    # TODO etudiant : construire et retourner la matrice (10, 10) symetrique a diagonale nulle.\n",
+    "    return None  # TODO etudiant\n",
+    "\n",
+    "# Exercice 2 : synchronisation Z2 bruitee.\n",
+    "def W_sync_bruitee(sigma=0.3, seed=99):\n",
+    "    # TODO etudiant : s0 uniforme +/-1 fixe par seed, N symetrique diag nulle, retourner W.\n",
+    "    return None  # TODO etudiant\n",
+    "\n",
+    "# Exercice 3 : rayon de Bassin du piege.\n",
+    "def rayon_bassin(X, W, eps_list=(0.005, 0.02, 0.05, 0.1), K=100, seed=2718):\n",
+    "    # TODO etudiant : pour chaque eps, retourner la meilleure amelioration trouvee sur K perturbations.\n",
+    "    return None  # TODO etudiant\n",
+    "\n",
+    "print(\"Exercices a completer : petersen_W, W_sync_bruitee, rayon_bassin.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Le paysage factorisé de Burer–Monteiro se comporte exactement comme la théorie le promet sur ces petites instances : piégé universellement au rang 1 (où il dégénère en le problème combinatoire lui-même), piégé partiellement aux rangs intermédiaires, et **sans aucun piège observable au-dessus du seuil** $r(r+1)/2 > m$. La garantie n'est pas un coude observable — la propreté commence avant — mais elle délimite la zone où la recherche locale est *certifiée* sûre.\n",
+    "\n",
+    "C'est la réponse à la question du fil : MGS-15 mesurait des paysages *subis* ; ici le rang est un levier qui *achète* un paysage sûr. Et c'est la leçon de méthode de l'EPIC #13106 : le théorème dit où regarder, le recensement mesure si le réel obéit — ni l'un sans l'autre. Un tableau de zéros n'est pas une preuve ; c'est l'absence de réfutation, la plus honnête des confirmations empiriques.\n",
+    "\n",
+    "**Références.** S. Burer, R. D. C. Monteiro, *Local Minima and Convergence in Low-Rank Semidefinite Programming*, Mathematical Programming 103(3), 427–444 (2005) — [DOI 10.1007/s10107-004-0564-1](https://link.springer.com/article/10.1007/s10107-004-0564-1) · G. Blekherman et al. pour le contexte Barvinok–Pataki (1995/1998) · *Low-Rank Univariate Sum of Squares Has No Spurious Local Minima*, SIAM J. Optim. 33(2) (2023) — [DOI 10.1137/22M1516208](https://epubs.siam.org/doi/abs/10.1137/22M1516208) · M. Yurtsever et al., [Scalable Semidefinite Programming](https://web.stanford.edu/~udell/doc/yurtsever21_scalable.pdf) (l'usage pratique de la factorisation). Pilote #13194 / EPIC #13106."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/Search/requirements.txt
+++ b/MyIA.AI.Notebooks/Search/requirements.txt
@@ -43,3 +43,5 @@ papermill>=2.4
 # Optional: OpenSpiel (Search-7 MCTS/AlphaGo-style) — pas de wheel pip Windows.
 # Installer via WSL/Linux : pip install open_spiel  (cf README, section Search-7)
 # open_spiel>=1.4
+# Convex optimization (Search-17 : relaxation SDP / Burer-Monteiro)
+cvxpy>=1.5                 # Solveur conique (CLARABEL/SCS) pour la reference SDP


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #13144

Closes #13194 — pilote « calculatoire borné » de l'EPIC #13106 (workstream « paysage low-rank SOS »), design-lock de l'issue respecté point par point, nombres pré-vérifiés headless AVANT génération.

## Ce que cette tranche fait

Nouveau notebook `Search-17-SpuriousMinima.ipynb` (15 cellules, 7 code, kernel python3) : le point d'arrivée « certification » du fil paysages — Search-9 (LP) → relaxation SDP de MaxCut (Goemans–Williamson) → factorisation de Burer–Monteiro Y=XX^T, et la question : quand le paysage non convexe piège-t-il la recherche locale ?

## Résultats (acceptance du design-lock, point par point)

1. **Énoncés exacts + attributions vérifiées firsthand** (grille §1-2) : Burer–Monteiro 2005, *Local minima and convergence in low-rank semidefinite programming*, Math. Program. 103(3), 427–444 (lien DOI dans le notebook) ; Barvinok 1995 / Pataki 1998 (existence de rang r(r+1)/2 ≤ m) ; pont SOS moderne cité (SIAM J. Optim. 2023, *Low-Rank Univariate SOS Has No Spurious Local Minima*) sans être reproduit — distinction explicite.
2. **Recensement exécuté** : 3 familles (C6 biparti, K8 pondéré seed 42, G(10,0.5) seed 7) × rangs 1..r*+1 × 40 départs, graines fixes. Trois régimes mesurés : r=1 universellement fallacieux (39/40, 40/40, 40/40 — le problème y dégénère en MaxCut discret, K8: meilleure des 40 starts 11,1461 < coupe optimale 11,8581) ; décroissance intermédiaire (C6: 5/40 à r=2 ; G10: 12/40 à r=2, valeurs ~13,77) ; **0 fallacieux à/au-dessus de r*** partout — prédiction BM confirmée.
3. **Référence par vrai solveur** : cvxpy 1.9.2 / CLARABEL (installé règle F — absent au départ). Double référence : SDP exacte ET brute-force 2^(n-1). Validation croisée : C6 tight (SDP = cut = 6, biparti), K8 tight à 3e-4, G10 gap d'intégralité 0,3249 — le BM atteint exactement la valeur SDP (14,3249), pas la coupe (14).
4. **Contre-exemple positif exhibé** : le pire fallacieux confirmé de G10 r=2 — déficit 0,5551, gradient riemannien 9,9e-08 (stationnaire), 0/200 perturbations améliorantes (max local certifié empiriquement).
5. **Grille digestion 10 points dans la prose** : friction/essais ratés conservés (§D : le bug de double-comptage SDP qui rendait TOUT fallacieux — c'est sa contradiction avec le théorème qui l'a révélé ; convergence trop stricte ; dégénérescence r=1), limites (§E : recensement ≠ preuve, non-dégénérescence non vérifiée, n ≤ 10, pont SOS bibliographique, rounding hors scope), raccord corpus (§: Search-9, Search-4, MGS-15), chemin de découverte distinct de la reconstruction.
6. **3 exercices stubs C.1** (Petersen au seuil r*=5 ; synchronisation Z2 bruitée ; rayon de bassin du piège), prose française, **densité 12923/7 = 1846 ch/code-cell** (seuil 1200).

## Validation

- Papermill 15/15 cellules, 0 erreur, 0 warning ; exec counts 1-7 non-null
- **Idempotence prouvée** : double-exécution byte-identique (fingerprint 29b974b3c251d5dd sur les deux runs) — méthode MGS établie
- `validate_pr_notebooks.py origin/main <nb>` : **PASS** (7 cells)
- C.1 : 0 violation ; catalogue byte-identique à main (aucun fichier catalogue touché)
- L898 avant écriture : 0 PR ouverte sur `Search-17*`, fichier absent de main ; claim #13194 posé puis amendé au placement (Part1 python3, la Partie 4 étant C# pur par convention de famille)

## Périmètre (3 fichiers)

1 notebook nouveau + ligne README Part1 (table, progression, prérequis) + ligne requirements.txt (`cvxpy>=1.5`, dépendance réelle — installée et utilisée). La nuance honnête centrale est dans le prose : la propreté commence AVANT r* (garantie suffisante, pas un coude de phase) — mesurée, pas survée.

See #13106 (pilote, contribution partielle — l'EPIC reste ouverte).

## Verdict SOTA

**SOTA-OK** — cvxpy/CLARABEL (vrai solveur conique) pour la référence, énumération exhaustive 2^(n-1) pour la coupe, énoncés vérifiés firsthand contre les sources ; aucune substitution, aucune approx.
