### PR TITLE
fix(tooling,#13176): encoding=utf-8 on subprocess text=True — tranche 2b residuel

### DIFF
--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -254,7 +254,8 @@ def _repo_root():
     import subprocess
     try:
         out = subprocess.run(['git', 'rev-parse', '--show-toplevel'],
-                             capture_output=True, text=True, timeout=10)
+                             capture_output=True, text=True, timeout=10,
+                             encoding='utf-8', errors='replace')
         if out.returncode == 0:
             return pathlib.Path(out.stdout.strip())
     except Exception:

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -143,6 +143,7 @@ def get_changed_notebooks(base: str, paths: list[str] | None = None) -> list[Pat
         mb = subprocess.run(
             ["git", "merge-base", base, "HEAD"],
             capture_output=True, text=True, check=True,
+            encoding="utf-8", errors="replace",
             cwd=str(REPO_ROOT),
         ).stdout.strip()
         if mb:
@@ -154,6 +155,7 @@ def get_changed_notebooks(base: str, paths: list[str] | None = None) -> list[Pat
         result = subprocess.run(
             ["git", "diff", "--name-only", "--diff-filter=ACM", anchor],
             capture_output=True, text=True, check=True,
+            encoding="utf-8", errors="replace",
             cwd=str(REPO_ROOT),
         )
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: DEEP/notebook-python #12960

## Summary

Tranche 2b de #13176 (residuel 2a, famille notebook_tools) : 3 sites `text=True` sans `encoding` corriges sur 2 scripts, base frais `origin/main` @ 62d47eb7d (re-mesure convention de l'issue).

- `scripts/notebook_tools/scan_md_hierarchy.py` — `_repo_root()` : `git rev-parse --show-toplevel` (1 site)
- `scripts/notebook_tools/validate_pr_notebooks.py` — `git merge-base` + `git diff --name-only --diff-filter=ACM` (2 sites) : ces appels decodent des noms de fichiers de notebooks francais sur hotes cp1252, exactement la classe #12811/#12813

Pattern uniforme : `encoding="utf-8", errors="replace"`.

**Re-mesure firsthand** : `scan_d1_d3_d4_d5.py` (cite au ledger 2b) est DEJA propre sur main (`encoding="utf-8", errors="replace"` present ligne 260) — non touche. Le residuel reel 2b = 3 sites / 2 fichiers, pas 3 scripts.

## Validation

- `py_compile` 2/2 fichiers modifies
- AST scan complet des 3 scripts cites : 0 appel `run/Popen/check_output/check_call` avec `text=True` sans `encoding` restant
- Invocations reelles a travers les sites fixes : `validate_pr_notebooks.py origin/main` exit 0 (chemins merge-base + diff executes, "No notebooks changed in this PR."), `scan_md_hierarchy._repo_root()` resolu via le subprocess fixe
- `pytest scripts/tests/test_scan_d1_stream_text.py` : 4/4 passed (script adjacent du tri-packet)
- Disjonction queue verifiee : fichiers non touches par #13169 (x9) ni #13191 (x15) — pas de collision de merge
- Catalogue byte-identique a main (aucun fichier catalogue touche)

## Progression #13176

Tranche 1 (#13177, 23 sites) + tranche 4 (#13183, 15) + tranche 5 (#13184, 19) + 2a (#13191, 26) + **2b (3, cette PR)** = 86/304 sites post-merge attendus (~211). Residuel : tranches 2-residuel/tests (~88 sites) apres drainage de la queue.

See #13176