### PR TITLE
feat(slides,#13216): detecteur du markdown avale par un bloc HTML (ouvrante ET fermante)

### DIFF
--- a/scripts/notebook_tools/scan_slides_html_block_markdown.py
+++ b/scripts/notebook_tools/scan_slides_html_block_markdown.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Detect markdown swallowed by an HTML block in Slidev decks.
+
+Motivation
+----------
+markdown-it (which Slidev uses) applies the CommonMark **HTML block** rule: once a
+line opens an HTML block, every following line is passed through as *raw HTML* until
+a **blank line** closes the block. Content written on the line immediately after an
+opening tag, with no blank line, is therefore never parsed as markdown.
+
+The failure is silent and purely visual. This ships to a projected slide::
+
+    <div class="grid grid-cols-2 gap-5">
+    <div>
+    **Environnement multi-agents**        <-- two literal asterisks on screen
+
+while the *same construct* one blank line later renders correctly::
+
+    <div>
+
+    **Optimisation de strategies**        <-- bold, as intended
+
+Both forms coexisted in `slides/S3-acculturation/slides.md` (PR #13096): the left
+column of a two-column grid was broken and the right column was not. Same file, same
+commit, same tags -- the blank line was the only variable. That in-artifact positive
+control is what settled the diagnosis without a second dev server.
+
+Why the existing gates cannot see it
+------------------------------------
+`scan_slidev_composition.py` measures canvas overflow, glyph overlap and occupation.
+Literal asterisks and a flattened list are *text inside the canvas*: that scanner
+measures the right quantity honestly, it simply is not the quantity carrying this
+defect. No mechanical gate covered this class before this script.
+
+Scope of the rule -- and what it deliberately does NOT flag
+-----------------------------------------------------------
+Only **block-level** markdown is reported, because only block-level constructs are
+destroyed outright:
+
+    **bold**   - list   1. ordered   # heading   > quote   | table
+
+Inline markdown in an HTML block (``Some prose with *emphasis* inside``) is left
+alone: a naive detector that flags it over-accuses badly. Measured on
+`slides/S3-acculturation/slides.md` at `main`, the naive form reported 7 hits where
+the refined form reports 0 -- every one of the 7 was harmless inline prose. Under
+the refined rule, the 10 genuine regressions of PR #13096 stand out cleanly.
+
+Usage
+-----
+    python scripts/notebook_tools/scan_slides_html_block_markdown.py
+    python scripts/notebook_tools/scan_slides_html_block_markdown.py --check slides/S3-acculturation/slides.md
+    python scripts/notebook_tools/scan_slides_html_block_markdown.py --json
+
+Exit status is 1 when a violation is found outside the recorded baseline, 0 otherwise,
+so the script can serve as a ratchet while the known occurrences are burned down
+(issue #13216).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# An opening HTML tag alone on its line is what starts a block. Restricting to a
+# lone tag (rather than any line containing '<') keeps the rule narrow and
+# explainable: it is exactly the shape that swallows the NEXT line.
+_OPENING_TAG = re.compile(r"^\s*<(?P<tag>[a-zA-Z][a-zA-Z0-9-]*)\b[^>]*>\s*$")
+
+# Block-level markdown only -- see the module docstring for why inline is excluded.
+_BLOCK_MARKDOWN = re.compile(
+    r"^\s*("
+    r"\*\*"          # bold opener starting a line
+    r"|[-*+]\s"      # unordered list item
+    r"|\d+\.\s"      # ordered list item
+    r"|#{1,6}\s"     # ATX heading
+    r"|>\s"          # block quote
+    r"|\|"           # table row
+    r")"
+)
+
+# A self-closing or immediately-closed tag does not open a block that spans lines.
+_SELF_CONTAINED = re.compile(r"/>\s*$|</[a-zA-Z][a-zA-Z0-9-]*>\s*$")
+
+_DEFAULT_ROOT = "slides"
+
+
+def scan_text(text: str):
+    """Return [(line_number, offending_line)] for one deck's source.
+
+    ``line_number`` is 1-based and points at the swallowed markdown line, i.e. the
+    line the author must precede with a blank line.
+    """
+    lines = text.split("\n")
+    hits = []
+    for index, line in enumerate(lines):
+        match = _OPENING_TAG.match(line)
+        if not match or _SELF_CONTAINED.search(line):
+            continue
+        if index + 1 >= len(lines):
+            continue
+        nxt = lines[index + 1]
+        stripped = nxt.strip()
+        # A blank line closes the block: nothing is swallowed.
+        if not stripped:
+            continue
+        # Another tag keeps the block open but carries no markdown of its own; the
+        # line after it is examined on its own iteration.
+        if stripped.startswith("<"):
+            continue
+        if _BLOCK_MARKDOWN.match(nxt):
+            hits.append((index + 2, stripped))
+    return hits
+
+
+def scan_file(path: Path):
+    return scan_text(path.read_text(encoding="utf-8"))
+
+
+def iter_decks(root: Path):
+    """Yield rendered deck sources under ``root``.
+
+    The corpus is the ``.md`` files sitting at a deck's **top level**
+    (``slides/<deck>/*.md``), which is what Slidev and Marp actually render. It is
+    deliberately NOT recursive: ``analysis/``, ``extracted/`` and ``output/`` hold
+    prose and build artifacts that no renderer consumes, and flagging them
+    over-accuses -- a recursive scan reported 54 hits where the rendered corpus
+    holds 49, the 5 extra all living in ``01-introduction/analysis/``. Same
+    non-recursive convention as the sibling ``scan_slides_image_refs.py``.
+    """
+    if root.is_file():
+        yield root
+        return
+    # ``root`` is either slides/ (scan every deck) or one deck directory.
+    deck_dirs = [root] if any(root.glob("*.md")) else []
+    deck_dirs += [d for d in sorted(root.iterdir()) if d.is_dir()]
+    seen = set()
+    for deck in deck_dirs:
+        for md in sorted(deck.glob("*.md")):
+            if "RECAP" in md.name:
+                continue
+            if md not in seen:
+                seen.add(md)
+                yield md
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        metavar="PATH",
+        help="scan a single file or directory instead of the whole slides/ tree",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    root = Path(args.check) if args.check else Path(_DEFAULT_ROOT)
+    if not root.exists():
+        print("path not found: %s" % root, file=sys.stderr)
+        return 2
+
+    report = {}
+    total = 0
+    for deck in iter_decks(root):
+        hits = scan_file(deck)
+        if hits:
+            report[deck.as_posix()] = [
+                {"line": ln, "text": txt[:90]} for ln, txt in hits
+            ]
+            total += len(hits)
+
+    if args.json:
+        # The instrument names WHAT it measured next to the value: a bare 0 is
+        # indistinguishable from "scanned nothing".
+        print(
+            json.dumps(
+                {
+                    "root": root.as_posix(),
+                    "decks_scanned": sum(1 for _ in iter_decks(root)),
+                    "violations": total,
+                    "by_deck": report,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+    else:
+        scanned = sum(1 for _ in iter_decks(root))
+        print("scanned %d markdown file(s) under %s" % (scanned, root.as_posix()))
+        for deck, hits in report.items():
+            print("\n%s  (%d)" % (deck, len(hits)))
+            for hit in hits:
+                print("  L%-6d %s" % (hit["line"], hit["text"]))
+        print("\ntotal: %d line(s) of block markdown swallowed by an HTML block" % total)
+        if total:
+            print("fix: insert a blank line after the opening tag preceding each line above")
+
+    return 1 if total else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/notebook_tools/scan_slides_html_block_markdown.py
+++ b/scripts/notebook_tools/scan_slides_html_block_markdown.py
@@ -45,6 +45,19 @@ alone: a naive detector that flags it over-accuses badly. Measured on
 the refined form reports 0 -- every one of the 7 was harmless inline prose. Under
 the refined rule, the 10 genuine regressions of PR #13096 stand out cleanly.
 
+Two shapes are reported: a lone **opening** tag (`<div ...>`) and a lone
+**closing** tag (`</div>`). CommonMark HTML block type 6 opens on both, and
+the closing half was missing from the first version of this script -- caught
+by review on #13218 and confirmed at the engine. One real occurrence survives
+on main after the opening-tag burn-down of #13242: `slides/01-introduction`
+L597, where `</div>` swallows three bullets.
+
+What stays out of scope, deliberately: a tag with trailing content on its
+line (`<div>du texte`, `</div> et du texte`). markdown-it swallows those too,
+but the rule enforced here is a tag ALONE on its line -- narrow enough to
+explain in one sentence to an author. The tests name both forms so the gap
+is on the record rather than implicit.
+
 Usage
 -----
     python scripts/notebook_tools/scan_slides_html_block_markdown.py
@@ -64,10 +77,22 @@ import re
 import sys
 from pathlib import Path
 
-# An opening HTML tag alone on its line is what starts a block. Restricting to a
-# lone tag (rather than any line containing '<') keeps the rule narrow and
+# An HTML tag alone on its line is what starts a block. Restricting to a lone
+# tag (rather than any line containing '<') keeps the rule narrow and
 # explainable: it is exactly the shape that swallows the NEXT line.
-_OPENING_TAG = re.compile(r"^\s*<(?P<tag>[a-zA-Z][a-zA-Z0-9-]*)\b[^>]*>\s*$")
+#
+# The `/?` is load-bearing and was added after the detector shipped: CommonMark
+# HTML block type 6 opens on a CLOSING tag too, so a lone `</div>` swallows the
+# markdown that follows it exactly as `<div>` does. Verified at the engine
+# Slidev uses (markdown-it), against main:
+#
+#     md.render("</div>\n- Behaviourism\n")  ->  unchanged, the bullet
+#     comes back as literal text (no <li> in the output).
+#
+# Missing this form left the ratchet blind to a class it exists to catch
+# (found by review on #13218). One real occurrence on main: 01-introduction
+# L597, where three bullets are swallowed on a course slide.
+_OPENING_TAG = re.compile(r"^\s*</?(?P<tag>[a-zA-Z][a-zA-Z0-9-]*)\b[^>]*>\s*$")
 
 # Block-level markdown only -- see the module docstring for why inline is excluded.
 _BLOCK_MARKDOWN = re.compile(
@@ -84,6 +109,16 @@ _BLOCK_MARKDOWN = re.compile(
 # A self-closing or immediately-closed tag does not open a block that spans lines.
 _SELF_CONTAINED = re.compile(r"/>\s*$|</[a-zA-Z][a-zA-Z0-9-]*>\s*$")
 
+# ...but a line that is NOTHING BUT a closing tag is not self-contained: it
+# opens a block (see _OPENING_TAG above). Without this exception the `/?`
+# widening would be inert, since _SELF_CONTAINED matches any line ending in
+# `</tag>` -- `</div>` alone included. The two edits only work as a pair.
+#
+# Negative control that bounds the exception: `<span>x</span>` stays excluded,
+# because _OPENING_TAG never matches it (trailing text after the first `>`
+# breaks the end anchor). Asserted in the tests.
+_BARE_CLOSING_TAG = re.compile(r"^\s*</[a-zA-Z][a-zA-Z0-9-]*>\s*$")
+
 _DEFAULT_ROOT = "slides"
 
 
@@ -97,7 +132,9 @@ def scan_text(text: str):
     hits = []
     for index, line in enumerate(lines):
         match = _OPENING_TAG.match(line)
-        if not match or _SELF_CONTAINED.search(line):
+        if not match:
+            continue
+        if _SELF_CONTAINED.search(line) and not _BARE_CLOSING_TAG.match(line):
             continue
         if index + 1 >= len(lines):
             continue
@@ -195,7 +232,7 @@ def main(argv=None):
                 print("  L%-6d %s" % (hit["line"], hit["text"]))
         print("\ntotal: %d line(s) of block markdown swallowed by an HTML block" % total)
         if total:
-            print("fix: insert a blank line after the opening tag preceding each line above")
+            print("fix: insert a blank line after the lone HTML tag preceding each line above")
 
     return 1 if total else 0
 

--- a/scripts/notebook_tools/tests/test_scan_slides_html_block_markdown.py
+++ b/scripts/notebook_tools/tests/test_scan_slides_html_block_markdown.py
@@ -100,3 +100,71 @@ def test_opening_tag_on_the_last_line_does_not_crash():
 def test_several_defects_are_all_reported_in_order():
     text = "<div>\n**a**\n\n<div>\n- b\n"
     assert [line for line, _ in scan_text(text)] == [2, 5]
+
+
+# --- closing tags open a block too (found by review on #13218) ---------------
+#
+# CommonMark HTML block type 6 opens on `</tag>` exactly as it does on `<tag>`.
+# The detector shipped blind to that half, so the ratchet would have let the
+# whole class through forever. These tests are the faux-negatif controls: each
+# one names a shape the pattern MUST catch, so a future narrowing of the regex
+# fails here instead of silently rendering a smaller, cleaner-looking count.
+
+
+@pytest.mark.parametrize(
+    "markdown",
+    ["- Behaviourism", "**gras**", "## Titre", "1. premier", "> citation", "| a | b |"],
+)
+def test_bare_closing_tag_swallows_every_block_construct(markdown):
+    """The founder case: `</div>` alone, then block markdown.
+
+    Verified at the engine Slidev uses -- markdown_it.MarkdownIt("commonmark")
+    renders "</div>\n- Behaviourism\n" unchanged, with no <li>: the bullet comes
+    back as literal text on the slide.
+    """
+    assert scan_text("</div>\n" + markdown + "\n") == [(2, markdown)]
+
+
+def test_bare_closing_tag_followed_by_blank_line_is_clean():
+    """The positive control for the FIX itself: a blank line closes the block.
+
+    This is the exact edit the companion fixer applies, so if this test ever
+    fails the repair recipe is wrong, not just the detector.
+    """
+    assert scan_text("</div>\n\n- Behaviourism\n") == []
+
+
+def test_closing_tag_with_attributes_is_not_a_thing_but_does_not_crash():
+    assert scan_text("</div >\n- a\n") == [(2, "- a")]
+
+
+# --- the exception must NOT swallow genuinely self-contained lines -----------
+
+
+def test_inline_element_closed_on_its_line_still_opens_no_block():
+    """Negative control bounding _BARE_CLOSING_TAG.
+
+    `<span>x</span>` ends in `</span>` just like the bare closing tag does. It
+    must stay excluded -- markdown-it renders it as a paragraph and the next
+    line as a real list. Widening _SELF_CONTAINED carelessly would break this.
+    """
+    assert scan_text("<span>x</span>\n- Behaviourism\n") == []
+
+
+def test_self_closing_tag_still_opens_no_block_after_the_widening():
+    assert scan_text('<img src="x.png" />\n- a\n') == []
+
+
+def test_closing_tag_with_trailing_content_is_out_of_scope_not_harmless():
+    """A DECLARED scope limit, not a non-defect -- written out so the gap is
+    visible instead of implied by a passing test.
+
+    markdown-it DOES swallow here: `</div> et du texte` opens a block just as
+    the lone form does, so `- a` comes back literal. The detector still
+    ignores it, because the rule it enforces is "a tag ALONE on its line" --
+    the same narrowing the opening-tag side already applies (see
+    test_tag_with_trailing_content_is_not_a_lone_opening_tag). Widening both
+    sides is a separate decision with its own false-positive budget; what
+    must not happen is this test reading as though the engine were fine.
+    """
+    assert scan_text("</div> et du texte\n- a\n") == []

--- a/scripts/notebook_tools/tests/test_scan_slides_html_block_markdown.py
+++ b/scripts/notebook_tools/tests/test_scan_slides_html_block_markdown.py
@@ -1,0 +1,102 @@
+"""Tests for the HTML-block markdown detector (issue #13216).
+
+The suite is written around the failure mode the detector exists for -- a line of
+block markdown swallowed because it follows an opening tag with no blank line -- and
+around the OVER-accusation that a naive version of the same detector produced.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scan_slides_html_block_markdown import scan_text  # noqa: E402
+
+
+# --- the defect itself -------------------------------------------------------
+
+
+def test_bold_swallowed_by_an_html_block_is_reported():
+    """The canonical shape from PR #13096, verbatim."""
+    text = (
+        '<div class="grid grid-cols-2 gap-5 -mt-2">\n'
+        "<div>\n"
+        "**Environnement multi-agents**\n"
+    )
+    hits = scan_text(text)
+    assert len(hits) == 1
+    line, offending = hits[0]
+    assert line == 3, "the reported line must be the swallowed markdown, not the tag"
+    assert offending == "**Environnement multi-agents**"
+
+
+def test_blank_line_after_the_tag_is_clean():
+    """The in-artifact positive control: the SAME construct, one blank line later.
+
+    Both forms coexisted in `slides/S3-acculturation/slides.md`; the blank line was
+    the only variable between the broken left column and the working right one.
+    """
+    text = "<div>\n\n**Optimisation de strategies**\n"
+    assert scan_text(text) == []
+
+
+@pytest.mark.parametrize(
+    "markdown",
+    [
+        "- N-grams",
+        "1. Premier point",
+        "## Un titre",
+        "> une citation",
+        "| col | col |",
+        "**gras**",
+    ],
+)
+def test_every_block_level_construct_is_caught(markdown):
+    """A detector is validated by its FALSE NEGATIVES: name the shapes it must
+    catch and check it catches them, rather than trusting its hits."""
+    assert len(scan_text("<div>\n%s\n" % markdown)) == 1, markdown
+
+
+# --- and what it must NOT report ---------------------------------------------
+
+
+def test_inline_markdown_is_not_reported():
+    """The over-accusation that the first version of this detector produced.
+
+    Inline emphasis inside an HTML block renders acceptably; flagging it reported 7
+    hits on a file that holds 0 real defects. Only block-level constructs are
+    destroyed outright, so only those are reported.
+    """
+    text = "<div>\nDu texte courant avec de l'*emphase* et du `code`.\n"
+    assert scan_text(text) == []
+
+
+def test_nested_tag_on_the_next_line_is_not_reported():
+    """A tag keeps the block open but carries no markdown; the line after IT is
+    examined on its own iteration, so reporting here would double-count."""
+    text = "<div>\n<span>\n"
+    assert scan_text(text) == []
+
+
+def test_self_closing_tag_opens_no_block():
+    assert scan_text('<img src="x.png" />\n**gras**\n') == []
+
+
+def test_tag_closed_on_its_own_line_opens_no_block():
+    assert scan_text("<span>inline</span>\n**gras**\n") == []
+
+
+def test_tag_with_trailing_content_is_not_a_lone_opening_tag():
+    """Only a tag ALONE on its line starts the shape this rule is about."""
+    assert scan_text("<div>du texte\n**gras**\n") == []
+
+
+def test_opening_tag_on_the_last_line_does_not_crash():
+    assert scan_text("<div>") == []
+
+
+def test_several_defects_are_all_reported_in_order():
+    text = "<div>\n**a**\n\n<div>\n- b\n"
+    assert [line for line, _ in scan_text(text)] == [2, 5]


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #13148

Depose l'organe du defaut trouve au QA visuel de #13096, la ou il servira, plutot que de
le laisser dans un scratchpad jetable que la prochaine lane devra re-improviser.

## Le defaut

markdown-it applique la regle CommonMark du **bloc HTML** : une fois un bloc ouvert, tout
passe en HTML brut jusqu'a une **ligne vide**. Le contenu place sur la ligne suivant
immediatement une balise seule n'est donc jamais parse comme markdown.

```
<div class="grid grid-cols-2 gap-5">
<div>
**Environnement multi-agents**        <-- deux asterisques litteraux a l'ecran
```

Le controle positif est **dans le meme fichier** : la colonne de droite de la meme slide
porte une ligne vide apres `<div>` et rend correctement. Meme fichier, meme commit, memes
balises — la ligne vide est la seule variable.

## Une balise FERMANTE ouvre le bloc, elle aussi (correction post-review)

La premiere version ne voyait que les ouvrantes. Nit d'Hermes, et il a raison au moteur :
CommonMark type 6 ouvre sur `</div>` exactement comme sur `<div>`. Verifie a markdown-it
avec controle positif (ligne vide inseree, la construction rend) et negatif
(`<span>x</span>`, qui ne l'ouvre pas).

Sa suggestion d'une ligne — elargir `_OPENING_TAG` a `</?` — est **inerte seule** :
`_SELF_CONTAINED` matche toute ligne finissant par `</tag>`, donc une fermante seule
serait re-exclue aussitot. Les deux regex ne fonctionnent qu'en paire, d'ou
`_BARE_CLOSING_TAG` et son exception explicite dans `scan_text`.

## Ce que le detecteur ne signale PAS, et pourquoi

Seul le markdown de **bloc** (`**`, `- `, `1. `, `#`, `>`, `|`). Une premiere version qui
comptait aussi la prose inline **sur-accusait** : 7 hits sur `S3-acculturation/slides.md`
au niveau de `main`, dont **0 reel**. La forme affinee rend 0 au meme endroit, et les 10
vraies regressions de #13096 ressortent proprement.

Meme prudence sur le corpus : convention **non recursive** du scanner frere
`scan_slides_image_refs.py` (les `.md` au niveau du deck), parce qu'un scan recursif
remonte des fichiers sous `analysis/` que nul moteur de rendu ne consomme.

Reste hors portee, volontairement : une balise suivie de contenu sur sa ligne
(`<div>du texte`, `</div> et du texte`). Le moteur les avale aussi — la regle enforcee
ici est une balise **seule** sur sa ligne, symetriquement des deux cotes. Les tests
nomment la limite plutot que de la maquiller.

## Controles positifs, avec leur ordre de grandeur annonce d'avance

Un controle positif repond « ai-je mesure ? », jamais « assez ? » — l'ampleur attendue est
donc ecrite a cote :

| Cible | Attendu | Rendu |
|---|---|---|
| corpus rendu au 27/08, avant #13242 | ~49 (mesure a la main) | **49** — 06-apprentissage 39, S8-semantic-web 9, 01-introduction 1 |
| tete de la PR #13096 | 10 (constat manuel) | **10**, aux memes lignes |
| `S3-acculturation/slides.md` | 0 | **0** |

**Etat de `main` a l'instant** : #13242 a brule les ouvrantes. Le detecteur corrige rend
desormais **1** occurrence reelle — `slides/01-introduction/slides.md` L598, forme
**fermante**, trois puces avalees. Elle etait invisible a la version initiale : c'est le
premier defaut que la correction ci-dessus fait apparaitre, et non une regression.

## Tests — ecrits par leurs faux negatifs

26 tests (15 auparavant). Un jeu de motifs se valide par ce qu'il **rate**, pas par ses
hits : chaque construct de bloc que la regle doit attraper est nomme et verifie, cote
ouvrante comme cote fermante (parametrage sur `-`, `**`, `##`, `1.`, `>`, `|`), la recette
de reparation a son controle positif (ligne vide inseree, le scan rend vide), et la
sur-accusation inline garde son test de non-regression.

Un test affirmait a tort qu'une fermante suivie de texte est rendue. Le moteur l'avale. Le
test est renomme et son docstring dit la limite de portee, au lieu de laisser un test vert
suggerer que le moteur va bien la ou il ne va pas.

## Ce que cette PR ne fait pas

- **Elle ne cable rien en CI.** Le script sort en 1 sur violation, donc il *peut* servir
  de cliquet. Le cablage a 0 devient atteignable une fois l'occurrence residuelle reparee
  — c'est le grain de suite, pas celui-ci.
- **Elle ne corrige aucune slide.** Un seul sujet par PR.
- **Elle ne mesure pas le corpus notebooks.** La meme regle s'y applique et n'y est pas
  plus couverte, mais je n'ai pas mesure : le dire plutot que le supposer.

**Declaration de tier honnete** : `tooling` est un genre META. Cette PR ne tient donc
**pas** un plancher G-VAR-1 de contenu, et je ne la presente pas comme tel — le grain de
contenu correspondant est #13216, dispatche.

See #13216, #13096.
