### PR TITLE
ci(fast-lane): TRANCHE4 absorbe 5 gates + controle positif identite (#12396)

### DIFF
--- a/.github/workflows/fast-lane-shadow.yml
+++ b/.github/workflows/fast-lane-shadow.yml
@@ -41,6 +41,22 @@ name: Fast lane (ombre)
 # fabricated-text, degenerate-figure), memes regles -- nom canonique,
 # conclusion reelle, workflow d'origine retire de `pull_request`. Le
 # compteur du job suit le registre : 16 gardes, toujours 1 checkout.
+#
+# TRANCHE 4 (#12396) : le noyau du grain -- le gate MARKDOWN
+# md-content-loss (iter par notebook change + --base {base_ref}, son
+# anti-auto-desarmement AGREGE porte par le flag `fail_on_all_warn`) -- et
+# les 4 gates SVG de la serie #6959/#6971/#7008 (broken-geometry,
+# decimal-comma, empty-display, offscreen-flat) avec la meme forme que
+# degenerate-figure (rc=1 defaut / rc=2 illisible). La nouveaute de cette
+# tranche : le CONTROLE POSITIF d'identite byte-a-byte
+# (`check_absorbed_check_run_identity.py`, step ci-dessous) -- absent des
+# tranches 1/2/3 -- qui cimente chaque `guard.name` absorbe au nom de
+# check-run que rendait son workflow source (contrainte #12175 : un rename
+# casse la protection de branche).
+#
+# Compteur : PILOT 10 + TRANCHE1 3 + TRANCHE2 3 + TRANCHE4 5 = 21 gardes.
+# NB collision #13203 : ce depot en parallele ouvre TRANCHE3 (1 garde) sur
+# les memes fichiers -- le merge des deux ajuste le compteur a 22.
 
 on:
   pull_request:
@@ -59,7 +75,7 @@ concurrency:
 
 jobs:
   fast-lane:
-    name: "Fast lane (ombre) -- 16 gardes, 1 checkout"
+    name: "Fast lane (ombre) -- 21 gardes, 1 checkout"
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -95,3 +111,14 @@ jobs:
         run: |
           git fetch origin "${{ github.base_ref }}" -q
           python scripts/ci/fast_lane.py --shadow
+
+      # #12396 : controle POSITIF d'identite byte-a-byte. Sans lui, un renom
+      # du registre (guard.name != nom du job rendu par le workflow source)
+      # passerait : le check-run est emis sous le nouveau nom, mais la
+      # protection de branche requiert l'ANCien nom -- ni satisfaite ni
+      # rougie, echec silencieux de la branche (incident #12175). Ce step
+      # rougit la lane si un nom absorbe diverge de sa source. `if: always()`
+      # : diagnostique meme quand un verdict de garde a deja rougi le job.
+      - name: "Controle positif : identite byte-a-byte des gardes absorbes"
+        if: always()
+        run: python scripts/ci/check_absorbed_check_run_identity.py --check

--- a/.github/workflows/md-content-loss-gate.yml
+++ b/.github/workflows/md-content-loss-gate.yml
@@ -1,5 +1,14 @@
 name: Markdown content-loss gate
 
+# ABSORBE PAR LA VOIE RAPIDE (#12396, tranche 4) : sur `pull_request`, ce
+# garde est desormais rendu par `fast-lane-shadow.yml` (check-run nomme
+# `No markdown content loss in changed notebooks`, meme nom que ce job, meme
+# verdict -- rc=1 defaut / rc=2 illisible, anti-auto-desarmement AGREGE
+# porte par le flag `fail_on_all_warn` du moteur --, un seul checkout pour
+# toute la lane). Ce fichier garde `workflow_dispatch` pour le re-run manuel
+# sur `main` apres une panne CI (#9858). Les `paths:` et l'argv d'origine
+# vivent dans `scripts/ci/fast_lane_registry.py` (TRANCHE4).
+
 # Purpose
 # -------
 # Per-PR gate that catches markdown CONTENT LOSS a cellule tronquee : une PR
@@ -34,12 +43,6 @@ name: Markdown content-loss gate
 # detecteur base-vs-head).
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'MyIA.AI.Notebooks/**/*.ipynb'
-      - 'scripts/notebook_tools/detect_md_content_loss.py'
-      - '.github/workflows/md-content-loss-gate.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/svg-broken-geometry-gate.yml
+++ b/.github/workflows/svg-broken-geometry-gate.yml
@@ -1,5 +1,13 @@
 name: SVG broken-geometry gate
 
+# ABSORBE PAR LA VOIE RAPIDE (#12396, tranche 4) : sur `pull_request`, ce
+# garde est desormais rendu par `fast-lane-shadow.yml` (check-run nomme
+# `No SVG broken-geometry (negative-dim) defect in changed notebooks`, meme
+# nom que ce job, meme verdict -- rc=1 defaut / rc=2 illisible --, un seul
+# checkout pour toute la lane). Ce fichier garde `workflow_dispatch` pour le
+# re-run manuel sur `main` apres une panne CI (#9858). Les `paths:` et
+# l'argv d'origine vivent dans `scripts/ci/fast_lane_registry.py` (TRANCHE4).
+
 # Purpose
 # -------
 # Per-PR gate for inline SVG outputs whose GEOMETRY is broken: any element with
@@ -47,12 +55,6 @@ name: SVG broken-geometry gate
 # svg-6927-canon (detectors necessary-but-not-sufficient).
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'MyIA.AI.Notebooks/**/*.ipynb'
-      - 'scripts/notebook_tools/detect_svg_broken_geometry.py'
-      - '.github/workflows/svg-broken-geometry-gate.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/svg-decimal-comma-gate.yml
+++ b/.github/workflows/svg-decimal-comma-gate.yml
@@ -1,5 +1,13 @@
 name: SVG decimal-comma gate
 
+# ABSORBE PAR LA VOIE RAPIDE (#12396, tranche 4) : sur `pull_request`, ce
+# garde est desormais rendu par `fast-lane-shadow.yml` (check-run nomme
+# `No SVG decimal-comma defect in changed notebooks`, meme nom que ce job,
+# meme verdict -- rc=1 defaut / rc=2 illisible --, un seul checkout pour
+# toute la lane). Ce fichier garde `workflow_dispatch` pour le re-run manuel
+# sur `main` apres une panne CI (#9858). Les `paths:` et l'argv d'origine
+# vivent dans `scripts/ci/fast_lane_registry.py` (TRANCHE4).
+
 # Purpose
 # -------
 # Per-PR gate for inline SVG outputs that carry French decimal commas in
@@ -42,12 +50,6 @@ name: SVG decimal-comma gate
 # See EPIC #3801, rollout #6927 (SVG inline fleet-wide).
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'MyIA.AI.Notebooks/**/*.ipynb'
-      - 'scripts/notebook_tools/detect_svg_decimal_commas.py'
-      - '.github/workflows/svg-decimal-comma-gate.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/svg-empty-display-gate.yml
+++ b/.github/workflows/svg-empty-display-gate.yml
@@ -1,5 +1,13 @@
 name: SVG empty-display gate
 
+# ABSORBE PAR LA VOIE RAPIDE (#12396, tranche 4) : sur `pull_request`, ce
+# garde est desormais rendu par `fast-lane-shadow.yml` (check-run nomme
+# `No SVG empty-display defect in changed notebooks`, meme nom que ce job,
+# meme verdict -- rc=1 defaut / rc=2 illisible --, un seul checkout pour
+# toute la lane). Ce fichier garde `workflow_dispatch` pour le re-run manuel
+# sur `main` apres une panne CI (#9858). Les `paths:` et l'argv d'origine
+# vivent dans `scripts/ci/fast_lane_registry.py` (TRANCHE4).
+
 # Purpose
 # -------
 # Per-PR gate for .NET Interactive cells that `display()` an SVG chart but
@@ -97,12 +105,6 @@ name: SVG empty-display gate
 # rollout #6927 (SVG inline fleet-wide), canon ai-01 `svg-6927-canon.md`.
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'MyIA.AI.Notebooks/**/*.ipynb'
-      - 'scripts/notebook_tools/detect_svg_empty_display.py'
-      - '.github/workflows/svg-empty-display-gate.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/svg-offscreen-flat-gate.yml
+++ b/.github/workflows/svg-offscreen-flat-gate.yml
@@ -1,5 +1,13 @@
 name: SVG offscreen-flat gate
 
+# ABSORBE PAR LA VOIE RAPIDE (#12396, tranche 4) : sur `pull_request`, ce
+# garde est desormais rendu par `fast-lane-shadow.yml` (check-run nomme
+# `No offscreen-flat SVG in changed notebooks`, meme nom que ce job,
+# meme verdict -- rc=1 defaut / rc=2 illisible --, un seul checkout pour
+# toute la lane). Ce fichier garde `workflow_dispatch` pour le re-run manuel
+# sur `main` apres une panne CI (#9858). Les `paths:` et l'argv d'origine
+# vivent dans `scripts/ci/fast_lane_registry.py` (TRANCHE4).
+
 # Purpose
 # -------
 # Per-PR gate for the §5b residual of the SVG render-suite: a FLAT inline `<svg>`
@@ -38,12 +46,6 @@ name: SVG offscreen-flat gate
 # rollout), PR #7007 (founding logY layout/projection-mismatch incident).
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'MyIA.AI.Notebooks/**/*.ipynb'
-      - 'scripts/notebook_tools/detect_svg_offscreen_flat.py'
-      - '.github/workflows/svg-offscreen-flat-gate.yml'
   workflow_dispatch:
 
 permissions:

--- a/scripts/ci/check_absorbed_check_run_identity.py
+++ b/scripts/ci/check_absorbed_check_run_identity.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Positif-control d'identite byte-a-byte des gardes absorbes (#12396).
+
+Le moteur fast lane emet un check-run nomme `guard.name`. Un garde absorbe
+porte donc un nom qui DOIT etre byte-identique au nom de check-run que son
+workflow source rendait. Le nom rendu suit la MEME convention que
+`check_unique_check_run_names.py` (defect #11869) : `job.name` si declare,
+sinon la cle du job. Sans cette identite, le rename casse la protection de
+branche : le check requis porte l'ancien nom, et l'emission sous un nom
+different ne le satisfait pas plus qu'elle ne le rougit (incident #12175).
+
+Les tranches 1/2/3 ont absorbe des gardes par DECLARATION ; aucune emission
+ni aucun test n'a cimente l'identite nom-du-garde == nom-rendu. Ce module
+ferme ce trou : pour chaque garde absorbe du registre, il parse le workflow
+source et exige que `guard.name` figure byte-identique parmi les noms de job
+rendus.
+
+Modes:
+  --check  exit 0 si tous identiques ; 1 si un nom diverge ou un workflow
+           source est introuvable ; 2 si l'instrument est casse (PyYAML
+           indisponible, workflow illisible).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+CI_DIR = Path(__file__).resolve().parent
+ROOT = CI_DIR.parents[1]
+sys.path.insert(0, str(CI_DIR))
+
+import fast_lane_registry as reg  # noqa: E402
+from check_unique_check_run_names import _parse_workflow, _load_yaml  # noqa: E402
+
+EXIT_OK, EXIT_MISMATCH, EXIT_BROKEN = 0, 1, 2
+WORKFLOWS_DIR = ROOT / ".github" / "workflows"
+
+
+def absorbed_guards():
+    """Tous les gardes absorbes du registre, tranches 1/2/4 + 3 si merge."""
+    for tranche_name in ("TRANCHE1", "TRANCHE2", "TRANCHE3", "TRANCHE4"):
+        yield from getattr(reg, tranche_name, [])
+
+
+def rendered_job_names(workflow_file: Path, yaml) -> list[str] | None:
+    """Noms de check-run que le workflow rendait (None = illisible).
+
+    Meme logique que collect_rendered_names de check_unique_check_run_names :
+    `job.name` si declare, sinon la cle du job. Les jobs reutilisables
+    (`uses:`) sont sautes -- leur nom depend du callee apres templating.
+    """
+    try:
+        text = workflow_file.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    data = _parse_workflow(text, yaml)
+    if data is None:
+        return None
+    names: list[str] = []
+    for job_key, job_def in (data.get("jobs") or {}).items():
+        if not isinstance(job_def, dict) or "uses" in job_def:
+            continue
+        names.append(str(job_def.get("name") or job_key))
+    return names
+
+
+def mismatches() -> list[str]:
+    """Descriptions des gardes absorbes dont le nom diverge de la source."""
+    yaml = _load_yaml()
+    if yaml is None:
+        return ["PyYAML indisponible"]  # instrument casse
+    out: list[str] = []
+    for guard in absorbed_guards():
+        source = WORKFLOWS_DIR / guard.source
+        if not source.is_file():
+            out.append(f"{guard.name!r}: workflow source introuvable "
+                       f"({guard.source})")
+            continue
+        names = rendered_job_names(source, yaml)
+        if names is None:
+            out.append(f"{guard.name!r}: source illisible ({guard.source})")
+        elif guard.name not in names:
+            out.append(f"{guard.name!r} != noms rendus par "
+                       f"{guard.source} {sorted(names)}")
+    return out
+
+
+def _main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Byte-identity des gardes fast-lane absorbes."
+    )
+    parser.add_argument("--check", action="store_true",
+                        help="exit 0/1/2 par identite")
+    args = parser.parse_args(argv[1:])
+
+    problems = mismatches()
+    if not problems:
+        print(f"[absorbed-identity] OK -- {len(list(absorbed_guards()))} "
+              "gardes absorbes byte-identiques a leur source.")
+        return EXIT_OK
+    for problem in problems:
+        print(f"[absorbed-identity] MISMATCH: {problem}")
+    if not args.check:
+        return EXIT_OK
+    # Une liste peuplant "PyYAML indisponible" = instrument casse, pas une
+    # divergence de nom.
+    if problems == ["PyYAML indisponible"]:
+        print("[absorbed-identity] BROKEN INSTRUMENT: PyYAML absent. "
+              "Verdict nul.", file=sys.stderr)
+        return EXIT_BROKEN
+    return EXIT_MISMATCH
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv))

--- a/scripts/ci/fast_lane.py
+++ b/scripts/ci/fast_lane.py
@@ -39,7 +39,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from fast_lane_registry import PILOT, TRANCHE1, TRANCHE2, Guard  # noqa: E402
+from fast_lane_registry import PILOT, TRANCHE1, TRANCHE2, TRANCHE4, Guard  # noqa: E402
 
 SHADOW_PREFIX = "fast-lane (ombre): "
 GUARD_TIMEOUT_S = 600
@@ -153,7 +153,8 @@ def expand_paths_token(argv: list[str], paths: list[str]) -> list[str]:
 
 def run_iter(argv_template: list[str], paths: list[str],
              ctx: dict[str, str],
-             warn_rc: tuple[int, ...] = ()) -> tuple[int, str]:
+             warn_rc: tuple[int, ...] = (),
+             fail_on_all_warn: bool = False) -> tuple[int, str]:
     """Execute un garde Pattern 1 (boucle par chemin) en aggregeant un rc
     = max(rc_par_iteration) et une log concatenee. Si `paths` est vide,
     rend un rc=0 no-op (log explicite) -- un CI sans chemin est un vert
@@ -161,19 +162,33 @@ def run_iter(argv_template: list[str], paths: list[str],
     comptent comme succes : les detecteurs de la serie figure/texte rendent
     rc=2 sur fichier illisible, et leur workflow d'origine l'affiche en
     warning -- l'agreger en echec rendrait la lane plus stricte que ce
-    qu'elle absorbe."""
+    qu'elle absorbe.
+
+    `fail_on_all_warn` rend l'anti-auto-desarmement AGREGE des workflows qui
+    le portent (md-content-loss-gate, clause #8655/#8656) : si CHAQUE fichier
+    examine a rendu un rc de `warn_rc`, le garde n'a RIEN analyse et rend 1
+    (fail loud) au lieu d'un quitus vert -- un detecteur casse ne doit pas
+    produire la bonne conclusion par silence."""
     if not paths:
         return 0, "[fast-lane] iterates_paths vide : aucun fichier a examiner"
     rc_agg = 0
+    warned = 0
     chunks: list[str] = []
     for path in paths:
         local_ctx = dict(ctx, changed_paths=path)
         rc, log = run_argv(argv_template, local_ctx)
         if rc in warn_rc:
             rc = 0
+            warned += 1
         chunks.append(f"--- {path} ---\n{log}")
         if rc > rc_agg:
             rc_agg = rc
+    if fail_on_all_warn and warned > 0 and warned == len(paths):
+        return 1, (
+            "[fast-lane] TOUS les fichiers examines etaient illisibles "
+            f"(rc {warn_rc}) : le garde n'a rien analyse et ne peut pas "
+            "certifier -- fail loud (anti-auto-desarmement, #8655/#8656)\n\n"
+            + "\n\n".join(chunks))
     return rc_agg, "\n\n".join(chunks)
 
 
@@ -297,7 +312,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"[fast-lane] {len(changed)} fichier(s) modifie(s) "
           f"contre {args.base_ref}")
 
-    guards = [g for g in PILOT + TRANCHE1 + TRANCHE2
+    guards = [g for g in PILOT + TRANCHE1 + TRANCHE2 + TRANCHE4
               if not args.only or g.name == args.only]
     selected = [g for g in guards if guard_applies(g, changed)]
     for guard in guards:
@@ -340,7 +355,8 @@ def main(argv: list[str] | None = None) -> int:
                                 if path_matches(f, p)
                                 and (REPO_ROOT / f).is_file()})
             rc, log = run_iter(guard.argv, arg_paths, ctx,
-                               warn_rc=guard.warn_rc)
+                               warn_rc=guard.warn_rc,
+                               fail_on_all_warn=guard.fail_on_all_warn)
             results[guard.name] = (rc, log)
             print(f"[fast-lane] phase 1 {guard.name} (iter sur {len(arg_paths)} "
                   f"fichier(s)) : exit {rc}")

--- a/scripts/ci/fast_lane.py
+++ b/scripts/ci/fast_lane.py
@@ -350,8 +350,14 @@ def main(argv: list[str] | None = None) -> int:
             # continue`). Un chemin absent passe au detecteur rendrait son
             # code "illisible" (rc=2), qui sans ce filtre deviendrait un
             # faux verdict sur un fichier que l'original n'examinait pas.
+            # `iterate_paths` (si renseigne) restreint l'ITERATION au glob
+            # d'actifs, distinct du declencheur `paths` -- sans lui, le
+            # detecteur/workflow present dans `paths` serait passe au
+            # detecteur de notebooks -> rc=2 -> faux echec (incident
+            # #13220 : la PR qui ajoute la garde echouait dessus).
+            iter_patterns = guard.iterate_paths or guard.paths
             arg_paths = sorted({f for f in changed
-                                for p in guard.paths
+                                for p in iter_patterns
                                 if path_matches(f, p)
                                 and (REPO_ROOT / f).is_file()})
             rc, log = run_iter(guard.argv, arg_paths, ctx,

--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -89,6 +89,13 @@ class Guard:
     # chemin echappe au filtre (checkout partiel). Sans lui, la lane serait
     # PLUS stricte que le workflow qu'elle absorbe.
     warn_rc: tuple[int, ...] = ()
+    # Anti-auto-desarmement AGREGE (clause #8655/#8656) : si CHAQUE fichier
+    # examine rend un rc de `warn_rc`, le garde n'a RIEN analyse et ne peut
+    # pas certifier -- on fail loud (rc=1) au lieu de produire un quitus
+    # aveugle. Sans ce flag, `warn_rc` lisserait la panne en succes. Reserved
+    # a `iterates_paths` ; par defaut desarme (un garde sans clause d'origine
+    # ne devient jamais plus strict).
+    fail_on_all_warn: bool = False
     # Commande de PRE-CONTROLE executee avant `argv` (phase 1). Un rc non
     # nul devient le verdict du garde et `argv` n'est PAS execute. Cas
     # d'usage : le self-test du ratchet output-failure, qui dans son
@@ -412,5 +419,131 @@ TRANCHE2: list[Guard] = [
         iterates_paths=True,
         absorbed=True,
         warn_rc=(2,),
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# TRANCHE 4 d'absorption (#12396) -- meme contrat que les tranches 1/2 (nom
+# canonique, conclusion reelle, workflow source retire de pull_request),
+# avec la nouveaute demandee par l'issue : un CONTROLE POSITIF d'identite
+# byte-a-byte (scripts/ci/check_absorbed_check_run_identity.py + tests) qui
+# cimente `guard.name` == nom de check-run rendu par le workflow source --
+# la contrainte #12175 que les tranches 1/2/3 n'ont jamais verifiee.
+#
+# Forme moteur : iter_paths + warn_rc, IDENTIQUE a la forme 3 de la tranche 2
+# (degenerate-figure) -- pour le gate markdown en plus : `needs_base` (son
+# argv porte `--base {base_ref}`) et le nouveau flag `fail_on_all_warn`.
+#
+# Contenu de la tranche :
+#   - le NOYAU du grain #12396 : md-content-loss-gate.yml (le gate markdown
+#     "petite taille" a verdict check-run qui tournait encore dedie). Sa
+#     clause anti-auto-desarmement AGREGEE (#8655/#8656 : "tous les
+#     notebooks lus sont illisibles -> exit 1") est portee par le flag
+#     `fail_on_all_warn` -- sans lui, `warn_rc` lisserait la panne en succes
+#     et absorber muterait la propriete.
+#   - les 4 gates SVG de la serie #6959/#6971/#7008 (#12384) : derniers
+#     petits gates d'ABSENCE a verdict check-run en workflow dedie, meme
+#     squelette (boucle par notebook change, rc=1 defaut / rc=2 illisible,
+#     aucun besoin d'ecriture PR).
+#
+# Exclusion documentee (cf #13097 pour la tranche 3) :
+#   - markdown-claims-output-advisory.yml / scan-md-hierarchy-drift.yml :
+#     verdict = COMMENTAIRE PR, pas check-run -> exigent `pull-requests:
+#     write`, refuse par le registre.
+# ---------------------------------------------------------------------------
+TRANCHE4: list[Guard] = [
+    Guard(
+        name="No SVG broken-geometry (negative-dim) defect in changed notebooks",
+        source="svg-broken-geometry-gate.yml",
+        paths=[
+            "MyIA.AI.Notebooks/**/*.ipynb",
+            "scripts/notebook_tools/detect_svg_broken_geometry.py",
+            ".github/workflows/svg-broken-geometry-gate.yml",
+        ],
+        argv=[
+            "python", "scripts/notebook_tools/detect_svg_broken_geometry.py",
+            "{changed_paths}", "--check",
+        ],
+        blocking=True,
+        iterates_paths=True,
+        absorbed=True,
+        warn_rc=(2,),
+    ),
+    Guard(
+        name="No SVG decimal-comma defect in changed notebooks",
+        source="svg-decimal-comma-gate.yml",
+        paths=[
+            "MyIA.AI.Notebooks/**/*.ipynb",
+            "scripts/notebook_tools/detect_svg_decimal_commas.py",
+            ".github/workflows/svg-decimal-comma-gate.yml",
+        ],
+        argv=[
+            "python", "scripts/notebook_tools/detect_svg_decimal_commas.py",
+            "{changed_paths}", "--check",
+        ],
+        blocking=True,
+        iterates_paths=True,
+        absorbed=True,
+        warn_rc=(2,),
+    ),
+    Guard(
+        name="No SVG empty-display defect in changed notebooks",
+        source="svg-empty-display-gate.yml",
+        paths=[
+            "MyIA.AI.Notebooks/**/*.ipynb",
+            "scripts/notebook_tools/detect_svg_empty_display.py",
+            ".github/workflows/svg-empty-display-gate.yml",
+        ],
+        argv=[
+            "python", "scripts/notebook_tools/detect_svg_empty_display.py",
+            "{changed_paths}", "--check",
+        ],
+        blocking=True,
+        iterates_paths=True,
+        absorbed=True,
+        warn_rc=(2,),
+    ),
+    Guard(
+        name="No offscreen-flat SVG in changed notebooks",
+        source="svg-offscreen-flat-gate.yml",
+        paths=[
+            "MyIA.AI.Notebooks/**/*.ipynb",
+            "scripts/notebook_tools/detect_svg_offscreen_flat.py",
+            ".github/workflows/svg-offscreen-flat-gate.yml",
+        ],
+        argv=[
+            "python", "scripts/notebook_tools/detect_svg_offscreen_flat.py",
+            "--check", "{changed_paths}",
+        ],
+        blocking=True,
+        iterates_paths=True,
+        absorbed=True,
+        warn_rc=(2,),
+    ),
+    # Noyau du grain #12396 : le gate MARKDOWN a verdict check-run. Compare
+    # chaque notebook change a sa base git (--base {base_ref}) ; rc=1 perte de
+    # contenu, rc=2 illisible. Anti-auto-desarmement AGREGE portee par
+    # `fail_on_all_warn` (cf commentaire du champ et clause #8655/#8656 du
+    # workflow d'origine) : un detecteur casse ou une ref git manquante ne
+    # doit pas produire un quitus vert par silence.
+    Guard(
+        name="No markdown content loss in changed notebooks",
+        source="md-content-loss-gate.yml",
+        paths=[
+            "MyIA.AI.Notebooks/**/*.ipynb",
+            "scripts/notebook_tools/detect_md_content_loss.py",
+            ".github/workflows/md-content-loss-gate.yml",
+        ],
+        argv=[
+            "python", "scripts/notebook_tools/detect_md_content_loss.py",
+            "--base", "{base_ref}", "--check", "{changed_paths}",
+        ],
+        blocking=True,
+        needs_base=True,
+        iterates_paths=True,
+        absorbed=True,
+        warn_rc=(2,),
+        fail_on_all_warn=True,
     ),
 ]

--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -96,6 +96,18 @@ class Guard:
     # a `iterates_paths` ; par defaut desarme (un garde sans clause d'origine
     # ne devient jamais plus strict).
     fail_on_all_warn: bool = False
+    # Globs EXCLUSIFS d'iteration quand `iterates_paths=True` : seuls les
+    # fichiers qui matchent sont passes au detecteur. Distinct de `paths` (le
+    # declencheur via `guard_applies`), parce que le workflow d'origine SEPARE
+    # les deux : `on.pull_request.paths` inclut le detecteur + le workflow
+    # (pour que la garde reparte quand ils changent), mais sa boucle interne
+    # itere UNIQUEMENT le glob d'actifs (`MyIA.AI.Notebooks/**/*.ipynb`).
+    # Mettre le detecteur/workflow dans le meme sac que l'iter-set ferait
+    # passer un `.yml`/`.py` au detecteur de notebooks -> rc=2 -> faux echec
+    # (incident #13220 : la PR qui ajoute la garde echouait dessus). Vide =
+    # fallback sur `paths` (comportement pre-change pour les gardes sans
+    # distinction trigger/iter).
+    iterate_paths: list[str] = field(default_factory=list)
     # Commande de PRE-CONTROLE executee avant `argv` (phase 1). Un rc non
     # nul devient le verdict du garde et `argv` n'est PAS execute. Cas
     # d'usage : le self-test du ratchet output-failure, qui dans son
@@ -461,6 +473,7 @@ TRANCHE4: list[Guard] = [
             "scripts/notebook_tools/detect_svg_broken_geometry.py",
             ".github/workflows/svg-broken-geometry-gate.yml",
         ],
+        iterate_paths=["MyIA.AI.Notebooks/**/*.ipynb"],
         argv=[
             "python", "scripts/notebook_tools/detect_svg_broken_geometry.py",
             "{changed_paths}", "--check",
@@ -478,6 +491,7 @@ TRANCHE4: list[Guard] = [
             "scripts/notebook_tools/detect_svg_decimal_commas.py",
             ".github/workflows/svg-decimal-comma-gate.yml",
         ],
+        iterate_paths=["MyIA.AI.Notebooks/**/*.ipynb"],
         argv=[
             "python", "scripts/notebook_tools/detect_svg_decimal_commas.py",
             "{changed_paths}", "--check",
@@ -495,6 +509,7 @@ TRANCHE4: list[Guard] = [
             "scripts/notebook_tools/detect_svg_empty_display.py",
             ".github/workflows/svg-empty-display-gate.yml",
         ],
+        iterate_paths=["MyIA.AI.Notebooks/**/*.ipynb"],
         argv=[
             "python", "scripts/notebook_tools/detect_svg_empty_display.py",
             "{changed_paths}", "--check",
@@ -512,6 +527,7 @@ TRANCHE4: list[Guard] = [
             "scripts/notebook_tools/detect_svg_offscreen_flat.py",
             ".github/workflows/svg-offscreen-flat-gate.yml",
         ],
+        iterate_paths=["MyIA.AI.Notebooks/**/*.ipynb"],
         argv=[
             "python", "scripts/notebook_tools/detect_svg_offscreen_flat.py",
             "--check", "{changed_paths}",
@@ -535,6 +551,7 @@ TRANCHE4: list[Guard] = [
             "scripts/notebook_tools/detect_md_content_loss.py",
             ".github/workflows/md-content-loss-gate.yml",
         ],
+        iterate_paths=["MyIA.AI.Notebooks/**/*.ipynb"],
         argv=[
             "python", "scripts/notebook_tools/detect_md_content_loss.py",
             "--base", "{base_ref}", "--check", "{changed_paths}",

--- a/scripts/tests/test_check_unique_check_run_names.py
+++ b/scripts/tests/test_check_unique_check_run_names.py
@@ -77,12 +77,13 @@ def test_branch_state_json_lists_no_duplicates(capsys):
     assert payload["ok"] is True, payload
     assert payload["duplicates"] == [], payload
     assert payload["total_jobs"] >= 7
-    # Floor pinned at 59 - margin: #12821 (tranche 1/2 #12817) moved 16 heavy
+    # Floor pinned with margin: #12821 (tranche 1/2 #12817) moved 16 heavy
     # advisories out of the pull_request trigger into the nightly schedule,
-    # dropping PR-triggered workflows from ~75 to 59. The floor's purpose is
-    # to catch an instrument that stops reading files (collapses to 0), not
-    # to freeze the corpus size.
-    assert payload["total_workflows"] >= 50
+    # dropping PR-triggered workflows from ~75 to 59; #13220 (TRANCHE4
+    # fast-lane) de-PR'd 5 more (md-content-loss + 4 gates SVG), 53 -> 48.
+    # The floor's purpose is to catch an instrument that stops reading files
+    # (collapses to 0), not to freeze the corpus size.
+    assert payload["total_workflows"] >= 40
 
 
 def test_branch_state_no_legacy_ratchet_dupes():
@@ -375,6 +376,7 @@ def test_main_state_quoted_on_works():
     parses correctly."""
     dupes, total_jobs, total_wfs = u.find_duplicates(DEFAULT_WF_DIR)
     # If the workaround didn't fire, the parse would silently skip workflows
-    # (treating `True` as the trigger key). Total workflow count > 50 is the
-    # smoke test that the parser actually sees the trigger.
-    assert total_wfs >= 50, total_wfs
+    # (treating `True` as the trigger key). Total workflow count > 40 is the
+    # smoke test that the parser actually sees the trigger (48 post-#13220
+    # TRANCHE4 de-PR).
+    assert total_wfs >= 40, total_wfs

--- a/scripts/tests/test_fast_lane.py
+++ b/scripts/tests/test_fast_lane.py
@@ -865,6 +865,36 @@ def test_absorbed_workflows_of_tranche4_no_longer_trigger_on_pull_request():
             f"{guard.name} est absorbe : double execution + zero run sauve")
 
 
+def test_tranche4_iterate_paths_restricted_to_asset_glob():
+    """Regression #13220 : les gardes TRANCHE4 portent, comme le workflow
+    d'origine, le detecteur + le workflow dans `paths` (le declencheur, pour
+    que la garde reparte quand ils changent) -- mais leur boucle interne
+    itere UNIQUEMENT le glob d'actifs. Si `iteration` tombait sur `paths`
+    en entier, un `.yml`/`.py` change serait passe au detecteur de
+    notebooks -> rc=2 -> faux echec sur une PR qui ne touche AUCUN notebook
+    (incident : la PR qui ajoute la tranche echouait sur ses propres gardes).
+    `iterate_paths` doit donc restreindre a l'actif et exclure tout
+    non-notebook present dans `paths`."""
+    from fast_lane_registry import TRANCHE4
+    ASSET = "MyIA.AI.Notebooks/**/*.ipynb"
+    for guard in TRANCHE4:
+        assert guard.iterate_paths, (
+            f"{guard.name} doit restreindre l'iteration a l'actif"
+            " (`iterate_paths`) -- sinon une PR workflow/detecteur seule "
+            "echoue a tort (incident #13220)")
+        assert guard.iterate_paths == [ASSET], (
+            f"{guard.name} doit iterer UNIQUEMENT {ASSET}, got "
+            f"{guard.iterate_paths}")
+        extras = set(guard.paths) - set(guard.iterate_paths)
+        assert extras, (
+            f"{guard.name} : sans declencheur distinct de l'iteration, "
+            "le detecteur/workflow ne serait jamais dans `paths` et la garde "
+            "ne repartirait pas quand ils changent")
+        assert all("*" in e or e.endswith((".py", ".yml")) for e in extras), (
+            f"{guard.name} : les entrees de `paths` hors iteration devraient "
+            f"etre detecteur/workflow, got {extras}")
+
+
 def test_absorbed_names_are_byte_identical_to_source_job_names():
     """Le livrable propre de #12396 : le controle positif que les tranches
     1/2 n'ont jamais eu. `guard.name` doit etre byte-identique au nom de

--- a/scripts/tests/test_fast_lane.py
+++ b/scripts/tests/test_fast_lane.py
@@ -171,7 +171,7 @@ def _arm_unrestorable_tree(monkeypatch, published):
     monkeypatch.setattr(fast_lane, "guard_applies", lambda g, c: True)
     monkeypatch.setattr(fast_lane, "run_argv", lambda argv, ctx: (0, "{}"))
     monkeypatch.setattr(fast_lane, "run_iter",
-                        lambda argv, paths, ctx, warn_rc=(): (0, "{}"))
+                        lambda argv, paths, ctx, warn_rc=(), fail_on_all_warn=False: (0, "{}"))
     monkeypatch.setattr(fast_lane, "git",
                         lambda *a: subprocess.CompletedProcess(a, 0, "", ""))
     monkeypatch.setattr(fast_lane, "stale_added_paths", lambda _p: [])
@@ -579,13 +579,14 @@ def _drive_mixed_emission(monkeypatch, pilot_rc, tranche_rc):
     monkeypatch.setattr(fl, "PILOT", [pilot])
     monkeypatch.setattr(fl, "TRANCHE1", [tranche])
     monkeypatch.setattr(fl, "TRANCHE2", [])
+    monkeypatch.setattr(fl, "TRANCHE4", [])
     monkeypatch.setattr(fl, "changed_files", lambda _ref: ["x.ipynb"])
     monkeypatch.setattr(
         fl, "run_argv",
         lambda argv, ctx: (tranche_rc if argv == ["cmd-tranche"]
                            else pilot_rc, "sortie"))
     monkeypatch.setattr(fl, "run_iter",
-                        lambda a, p, c, warn_rc=(): (0, ""))
+                        lambda a, p, c, warn_rc=(), fail_on_all_warn=False: (0, ""))
     monkeypatch.setattr(
         fl, "git",
         lambda *a: subprocess.CompletedProcess(a, 0, "sha", ""))
@@ -669,6 +670,7 @@ def test_pre_argv_failure_short_circuits_the_guard(monkeypatch):
     monkeypatch.setattr(fl, "PILOT", [])
     monkeypatch.setattr(fl, "TRANCHE1", [guard])
     monkeypatch.setattr(fl, "TRANCHE2", [])
+    monkeypatch.setattr(fl, "TRANCHE4", [])
     monkeypatch.setattr(fl, "changed_files", lambda _ref: ["x.ipynb"])
 
     def fake_run_argv(argv, ctx):
@@ -698,6 +700,7 @@ def test_pre_argv_success_chains_into_the_scan(monkeypatch):
     monkeypatch.setattr(fl, "PILOT", [])
     monkeypatch.setattr(fl, "TRANCHE1", [guard])
     monkeypatch.setattr(fl, "TRANCHE2", [])
+    monkeypatch.setattr(fl, "TRANCHE4", [])
     monkeypatch.setattr(fl, "changed_files", lambda _ref: ["x.ipynb"])
 
     def fake_run_argv(argv, ctx):
@@ -740,6 +743,7 @@ def test_warn_rc_is_success_everywhere(monkeypatch):
     monkeypatch.setattr(fl, "PILOT", [])
     monkeypatch.setattr(fl, "TRANCHE1", [guard])
     monkeypatch.setattr(fl, "TRANCHE2", [])
+    monkeypatch.setattr(fl, "TRANCHE4", [])
     monkeypatch.setattr(fl, "changed_files", lambda _ref: ["x.ipynb"])
     monkeypatch.setattr(fl, "run_argv", lambda argv, ctx: (2, "illisible"))
     monkeypatch.setattr(
@@ -764,15 +768,17 @@ def test_iter_paths_skips_files_deleted_by_the_pr(monkeypatch):
     seen_paths: list[list[str]] = []
     real_iter = fl.run_iter
 
-    def spy_iter(argv, paths, ctx, warn_rc=()):
+    def spy_iter(argv, paths, ctx, warn_rc=(), fail_on_all_warn=False):
         seen_paths.append(list(paths))
-        return real_iter(argv, paths, ctx, warn_rc=warn_rc)
+        return real_iter(argv, paths, ctx, warn_rc=warn_rc,
+                         fail_on_all_warn=fail_on_all_warn)
 
     fig = next(g for g in TRANCHE2
                if g.name.startswith("No degenerate figure"))
     monkeypatch.setattr(fl, "PILOT", [])
     monkeypatch.setattr(fl, "TRANCHE1", [])
     monkeypatch.setattr(fl, "TRANCHE2", [fig])
+    monkeypatch.setattr(fl, "TRANCHE4", [])
 
     # Un notebook REEL (pour le cas here) + un chemin absent (gone) : le
     # filtre doit garder le premier et ecarter le second.
@@ -803,3 +809,140 @@ def test_iter_paths_skips_files_deleted_by_the_pr(monkeypatch):
         f"le notebook existant {real_nb} doit etre examine")
     assert gone not in examined, (
         "un fichier supprime par la PR ne doit pas atteindre le detecteur")
+
+
+# ---------------------------------------------------------------------------
+# 7. Tranche 4 (#12396) -- gates SVG absorbes + controle positif d'identite
+# ---------------------------------------------------------------------------
+
+def test_tranche4_guards_are_absorbed_svg_and_declare_warn_rc():
+    """Le noyau du grain #12396 -- le gate MARKDOWN md-content-loss (noyau de
+    la tranche, seul "advisory markdown" a verdict check-run encore en
+    workflow dedie) -- plus les 4 gates SVG de la serie #6959/#6971/#7008
+    (#12384), absorbes avec EXACTEMENT la forme eprouvee de degenerate-figure
+    (tranche 2) : iter par notebook change, rc=1 defaut / rc=2 illisible
+    declare en warn_rc, bloquant."""
+    from fast_lane_registry import TRANCHE4
+    assert len(TRANCHE4) == 5, (
+        "la tranche 4 documente 5 gates (1 markdown + 4 SVG) ; si le nombre "
+        "change, le commentaire du registre et ce test suivent")
+    for guard in TRANCHE4:
+        assert guard.absorbed, f"{guard.name} doit porter absorbed=True"
+        assert guard.blocking, (
+            f"{guard.name} remplace un gate qui rougit le job : il doit "
+            "rougir aussi")
+        assert guard.iterates_paths, (
+            f"{guard.name} remplace une boucle par notebook : il doit "
+            "iterer les chemins")
+        assert guard.warn_rc == (2,), (
+            f"{guard.name} doit declarer rc=2 illisible comme les sources")
+    svg = {g.name for g in TRANCHE4 if "SVG" in g.name}
+    assert svg == {
+        "No SVG broken-geometry (negative-dim) defect in changed notebooks",
+        "No SVG decimal-comma defect in changed notebooks",
+        "No SVG empty-display defect in changed notebooks",
+        "No offscreen-flat SVG in changed notebooks",
+    }, "les noms canoniques doivent etre ceux des jobs des workflows sources"
+    md = next(g for g in TRANCHE4 if "markdown" in g.name)
+    assert md.needs_base, (
+        "md-content-loss diffe contre la base git (`--base {base_ref}`) : "
+        "il doit declarer needs_base")
+    assert md.fail_on_all_warn, (
+        "md-content-loss porte l'anti-auto-desarmement AGREGE (#8655/#8656) : "
+        "il doit le declarer -- sinon un detecteur casse rendrait un quitus "
+        "vert par silence")
+
+
+def test_absorbed_workflows_of_tranche4_no_longer_trigger_on_pull_request():
+    import re as _re
+    from fast_lane_registry import TRANCHE4
+    for guard in TRANCHE4:
+        wf = WORKFLOWS / guard.source
+        assert wf.is_file(), f"{guard.source} absent du depot"
+        txt = wf.read_text(encoding="utf-8")
+        assert not _re.search(r"^\s+pull_request:", txt, _re.M), (
+            f"{guard.source} declenche encore sur pull_request alors que "
+            f"{guard.name} est absorbe : double execution + zero run sauve")
+
+
+def test_absorbed_names_are_byte_identical_to_source_job_names():
+    """Le livrable propre de #12396 : le controle positif que les tranches
+    1/2 n'ont jamais eu. `guard.name` doit etre byte-identique au nom de
+    check-run rendu par le workflow source (`job.name` ou la cle du job) --
+    sinon le rename casse la protection de branche : le check requis porte
+    l'ancien nom, l'emission sous un nom different ne le satisfait ni le
+    rougit (incident #12175)."""
+    import check_absorbed_check_run_identity as ident
+    problems = ident.mismatches()
+    assert problems == [], (
+        "identite byte-a-byte des gardes absorbes cassee :\n"
+        + "\n".join(problems))
+
+
+def test_absorbed_identity_control_detects_a_rename(monkeypatch):
+    """CONTROLE POSITIF DU CONTROLE : si `guard.name` diverge de la source,
+    le verificateur doit le voir -- sinon il mesurerait rien et le test
+    precedent deviendrait du theater."""
+    import dataclasses
+    import check_absorbed_check_run_identity as ident
+    premier = ident.reg.TRANCHE1[0]
+    renomme = dataclasses.replace(premier, name="renomme-oubli-canonique")
+    monkeypatch.setattr(ident.reg, "TRANCHE1", [renomme])
+    problems = ident.mismatches()
+    assert any("renomme-oubli-canonique" in p for p in problems), problems
+
+
+def test_absorbed_identity_control_detects_a_missing_source(monkeypatch):
+    import dataclasses
+    import check_absorbed_check_run_identity as ident
+    premier = ident.reg.TRANCHE1[0]
+    fantome = dataclasses.replace(premier, source="workflow-fantome.yml")
+    monkeypatch.setattr(ident.reg, "TRANCHE1", [fantome])
+    problems = ident.mismatches()
+    assert any("workflow-fantome.yml" in p for p in problems), problems
+
+
+def test_run_iter_fail_on_all_warn_returns_failure_when_every_file_warns(
+        monkeypatch):
+    """Anti-auto-desarmement AGREGE (#8655/#8656) : si CHAQUE fichier rend un
+    rc de `warn_rc`, run_iter doit rendre 1 (fail loud) -- un detecteur casse
+    ne produit pas la bonne conclusion par silence. Sans ce flag, le warn_rc
+    lisserait la panne en succes et absorber muterait la propriete du
+    workflow d'origine."""
+    import fast_lane as fl
+    monkeypatch.setattr(fl, "run_argv",
+                        lambda argv, ctx: (2, "illisible"))
+    rc, log = fl.run_iter(["python", "x.py", "{changed_paths}"],
+                          ["a.ipynb", "b.ipynb"], {},
+                          warn_rc=(2,), fail_on_all_warn=True)
+    assert rc == 1, (
+        "tous les fichiers a l'etat illisible doit rougir le garde")
+    assert "anti-auto-desarmement" in log
+
+
+def test_run_iter_fail_on_all_warn_does_not_fire_on_mixed_results(
+        monkeypatch):
+    """Le flag ne doit se declencher que si TOUS les fichiers ont ete
+    illisibles. Un seul illisible parmi des fichiers sains = la panne est
+    locale, le garde a bien travaille ailleurs -> agregat normal (le warn_rc
+    lisse l'illisible en succes, pas de fail loud)."""
+    import fast_lane as fl
+
+    def fake(argv, ctx):
+        return (2, "illisible") if ctx["changed_paths"] == "a.ipynb" else (0, "ok")
+    monkeypatch.setattr(fl, "run_argv", fake)
+    rc, log = fl.run_iter(["python", "x.py", "{changed_paths}"],
+                          ["a.ipynb", "b.ipynb"], {},
+                          warn_rc=(2,), fail_on_all_warn=True)
+    assert rc == 0, (
+        "un mixte (1 illisible + 1 sain) ne doit pas fail loud : le garde a "
+        "bien travaille ailleurs")
+
+
+def test_run_iter_fail_on_all_warn_ignores_empty_paths():
+    """Vide = aucun fichier a examiner, pas un detecteur casse : le no-op
+    reste 0, meme avec le flag arme (aucune iteration => aucun warn)."""
+    rc, log = fast_lane.run_iter(["python", "x.py", "{changed_paths}"],
+                                 [], {}, warn_rc=(2,), fail_on_all_warn=True)
+    assert rc == 0
+    assert "iterates_paths vide" in log


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: DEEP/notebook-python #13209

## Summary

Absorbe dans la voie rapide (`fast-lane-shadow.yml`, #11835) les 5 derniers petits gates a verdict check-run encore en workflow dedie — pour un PR qui touche un notebook, chacun clonait le depot (`fetch-depth: 0`, ~30-60 s de boot de runner) pour ~1 s d'analyse :

- **md-content-loss-gate.yml** (`No markdown content loss in changed notebooks`) — le noyau du grain #12396 : seul "advisory markdown/petite taille" a verdict check-run restant en workflow dedie.
- **4 gates SVG** de la serie #6959/#6971/#7008 (#12384) : `svg-broken-geometry`, `svg-decimal-comma`, `svg-empty-display`, `svg-offscreen-flat`.

**Le livrable propre de #12396, absent des tranches 1/2/3 : un CONTROLE POSITIF d'identite byte-a-byte** qui cimente chaque `guard.name` absorbe au nom de check-run rendu par le workflow source — la contrainte #12175 que les tranches ont affirmee sans jamais l'asservir. Ce step tourne aussi dans la lane (`if: always()`), donc un rename du registre rougit la lane au lieu de passer en silence.

## Mecanique

| Fichier | Changement |
|---|---|
| `scripts/ci/fast_lane_registry.py` | Champ `Guard.fail_on_all_warn` (anti-auto-desarmement AGREGE, clause #8655/#8656) + liste `TRANCHE4` (5 gardes) |
| `scripts/ci/fast_lane.py` | `run_iter` porte `fail_on_all_warn` ; composition `PILOT + TRANCHE1 + TRANCHE2 + TRANCHE4` |
| `scripts/ci/check_absorbed_check_run_identity.py` | **nouveau** : controle positif byte-identite (job.name ou cle de job, meme convention que `check_unique_check_run_names.py` #11869) |
| 5 workflows source | declenchement retire de `pull_request` (conservent `workflow_dispatch`) |
| `fast-lane-shadow.yml` | compteur 16 -> 21 gardes + step identite byte-a-byte |
| `scripts/tests/test_fast_lane.py` | tranche 4 + identite (positif/negatifs) + `fail_on_all_warn` (tout-warn->1, mixte->0, vide->0) |

## Pourquoi md-content-loss est absorbe (et pas exclude)

Il portait une clause anti-auto-desarmement AGREGE ("tous les notebooks lus illisibles -> exit 1") que le modele `warn_rc` aurait lisse en succes. Le nouveau champ `fail_on_all_warn` la porte a l'identique : si CHAQUE fichier examine rend rc=2, `run_iter` rend 1 (fail loud) — un detecteur casse ne produit pas la bonne conclusion par silence. Sans ce champ, absorber aurait mute la propriete.

## Pourquoi pas les comment-writers

`markdown-claims-output-advisory.yml` / `scan-md-hierarchy-drift.yml` : verdict = COMMENTAIRE PR, pas check-run -> exigent `pull-requests: write`, refuse par le registre (cf registre tranche #13097).

## Evidence

- `python -m pytest scripts/tests/test_fast_lane.py -q` : **62 passed**
- `python scripts/ci/check_absorbed_check_run_identity.py --check` : **exit 0** (11 gardes absorbes byte-identiques a leur source)
- YAML parse des 6 workflows via `_parse_workflow` (reutilise `check_unique_check_run_names`)

## Acceptance

- [x] Chaque `guard.name` absorbe est byte-identique au nom de check-run rendu par son workflow source (controle positif + step lane)
- [x] Les 5 workflows sources ne declenchent plus sur `pull_request`
- [x] `warn_rc` + `fail_on_all_warn` reproduisent les clauses des sources
- [x] Tests positifs ET negatifs (un rename / une source manquante sont detectes)

## NB collision #13203

`#13203` (`feature/13097-fastlane-tranche3`) ouvre `TRANCHE3` (garde regression-guard, ~1 check-run) sur ces memes fichiers. Les deux PRs sont compatibles a la re-baseline ; le merge des deux ajuste le compteur de lane a 22 (21 + 1). Ordre de merge indifferent.

See #12396