### PR TITLE
feat(tools,#13224): scan_slidev_gap_report -- tableau par-slide des desequilibres de composition

### DIFF
--- a/scripts/notebook_tools/scan_slidev_gap_report.py
+++ b/scripts/notebook_tools/scan_slidev_gap_report.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""scan_slidev_gap_report.py — tableau par-slide des desequilibres de composition.
+
+Consomme le JSON produit par `scan_slidev_composition.py` et genere :
+
+  1. Un **rapport JSON structure** (sortie par defaut stdout) avec par slide :
+     - `slide` (1-based),
+     - `n_images`,
+     - `gap_left_pct`, `gap_right_pct`, `center_offset_pct`,
+     - `gap_max` (le pire des deux cotes),
+     - `severity` ("none" / "low" / "med" / "high"),
+     - `forms_triggered` (liste des formes F1-F4 qui flaggent la slide),
+     - `head` (60 premiers chars de innerText).
+
+  2. Un **CSV** trie par `gap_max` decroissant (sortie --csv) avec une
+     ligne par slide portant des images. Utile pour ouvrir dans un tableur
+     et **piloter les tranches** du chantier composition (cf issue #13224).
+
+Origine : #13223 a re-cable `occupation_flagged` sur 4 formes F1-F4, mais le
+JSON de sortie reste un rollup (n_occupation_flagged: 2 sur 42 cas reels a
+gap >= 40 %). Pour **piloter** la descente des 42 slides signalee par #13224
+(par tranches, mesure avant/apres datee), il faut un **tableau par slide**.
+C'est ce que ce script produit, sans rien toucher au scanner Playwright.
+
+Usage :
+    # 1. Lancer le scanner (dans un autre terminal) :
+    python scripts/notebook_tools/run_composition_control.py
+    # ... produit report.json dans tmp/slidev_control_xxx/
+
+    # 2. Produire le rapport structure :
+    python scripts/notebook_tools/scan_slidev_gap_report.py \\
+        --in  tmp/slidev_control_xxxx/report.json \\
+        --out tmp/gap_report.json
+
+    # 3. CSV pour tableur :
+    python scripts/notebook_tools/scan_slidev_gap_report.py \\
+        --in tmp/.../report.json --csv tmp/gap_report.csv
+
+Seuil de severity (calibre sur l'acceptance #13223 / #13224) :
+  - "high" : gap_max >= 55          (forme F1 du scanner)
+  - "med"  : gap_max >= 40          (F2 si offset cumule, sinon candidate)
+  - "low"  : gap_max >= 25          (F4 si saturation verticale)
+  - "none" : pas d'image ou gap < 25
+
+Bornes identiques au scanner c.572 (#13225). Tout seuil alternatif se
+justifie par ecrit dans le body de la PR consommatrice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCANNER_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCANNER_DIR))
+
+# Note : on importe scan_slidev_composition uniquement pour acceder aux
+# memes seuils (canvas, canvas_h). Le verdict flagged_by_scanner est
+# derive localement par _would_flag -- indifferent a la version du
+# scanner (origin/main pre-merge #13225 vs c.572 post-merge).
+
+
+SEVERITY_THRESHOLDS = (55, 40, 25)
+
+
+def _severity(gap_max: float) -> str:
+    if gap_max >= SEVERITY_THRESHOLDS[0]:
+        return "high"
+    if gap_max >= SEVERITY_THRESHOLDS[1]:
+        return "med"
+    if gap_max >= SEVERITY_THRESHOLDS[2]:
+        return "low"
+    return "none"
+
+
+def _forms_triggered(slide_record: dict, canvas_h: int) -> list[str]:
+    """Re-derive locally les formes F1-F4 (independamment de l'agregat)."""
+    occ = slide_record.get("occupation")
+    if not occ:
+        return []
+    out = []
+    gap_left = occ.get("gap_left_pct", 0)
+    gap_right = occ.get("gap_right_pct", 0)
+    offset = abs(occ.get("center_offset_pct", 0))
+    n_images = occ.get("n_images", 0)
+    # F1
+    if gap_left >= 55 or gap_right >= 55:
+        out.append("F1")
+    # F2
+    if (gap_left >= 40 or gap_right >= 40) and offset >= 25:
+        out.append("F2")
+    # F3
+    if n_images == 1 and offset >= 30:
+        out.append("F3")
+    # F4 (legere duplication avec occupation_flagged : on garde la trace)
+    if (gap_left > 25 or gap_right > 25) and slide_record.get("hors_canvas"):
+        out.append("F4-overflow")
+    elif (gap_left > 25 or gap_right > 25) and occ.get("content_bottom", 0) > canvas_h * 0.95:
+        out.append("F4-bord")
+    return out
+
+
+def _would_flag(slide_record: dict, canvas_h: int) -> bool:
+    """Verdict 'would flag' selon les 4 formes F1-F4.
+
+    Re-derive locale de la logique F1-F4 (cf occupation_flagged c.572).
+    Independant du module occupation_flagged importé pour deux raisons :
+    - le scanner origin/main peut ne pas encore porter F1-F4 (pre-merge #13225) ;
+    - le tableau doit predire la composition APRES merge du scanner c.572.
+    Toute slide qu'on signale ici sera signalee par le scanner post-merge.
+    """
+    return len(_forms_triggered(slide_record, canvas_h)) > 0
+
+
+def _slide_row(slide_record: dict, canvas_h: int) -> dict | None:
+    occ = slide_record.get("occupation")
+    if not occ:
+        return None  # pas d'image sur cette slide
+    gap_left = occ.get("gap_left_pct", 0)
+    gap_right = occ.get("gap_right_pct", 0)
+    gap_max = max(gap_left, gap_right)
+    flagged = _would_flag(slide_record, canvas_h)
+    return {
+        "slide": slide_record["slide"],
+        "text_head": (slide_record.get("text_head") or "?")[:60],
+        "n_images": occ.get("n_images", 0),
+        "gap_left_pct": gap_left,
+        "gap_right_pct": gap_right,
+        "gap_max": gap_max,
+        "center_offset_pct": occ.get("center_offset_pct", 0),
+        "dispersion": occ.get("dispersion", 0),
+        "severity": _severity(gap_max),
+        "forms_triggered": _forms_triggered(slide_record, canvas_h),
+        "flagged_by_scanner": flagged,
+    }
+
+
+def build_report(scanner_report: dict) -> dict:
+    canvas_h = scanner_report.get("canvas", [980, 552])[1]
+    rows = []
+    for r in scanner_report.get("results", []):
+        row = _slide_row(r, canvas_h)
+        if row is not None:
+            rows.append(row)
+    # Tri par severity (high -> med -> low -> none) puis gap_max desc
+    severity_rank = {"high": 0, "med": 1, "low": 2, "none": 3}
+    rows.sort(key=lambda x: (severity_rank[x["severity"]], -x["gap_max"]))
+    n = len(rows)
+    n_high = sum(1 for r in rows if r["severity"] == "high")
+    n_med = sum(1 for r in rows if r["severity"] == "med")
+    n_low = sum(1 for r in rows if r["severity"] == "low")
+    n_flagged = sum(1 for r in rows if r["flagged_by_scanner"])
+    return {
+        "source_n_occupation_flagged": scanner_report.get("n_occupation_flagged"),
+        "source_controle_positif_ok": scanner_report.get("controle_positif_ok"),
+        "source_controle_positif_warning": scanner_report.get("controle_positif_warning"),
+        "source_baseline_slide": scanner_report.get("baseline_slide"),
+        "source_baseline_commit": scanner_report.get("baseline_commit"),
+        "canvas_h": canvas_h,
+        "n_slides_with_images": n,
+        "summary_by_severity": {
+            "high": n_high,
+            "med": n_med,
+            "low": n_low,
+            "none": n - n_high - n_med - n_low,
+        },
+        "n_flagged_by_scanner": n_flagged,
+        "rows": rows,
+    }
+
+
+def write_csv(report: dict, csv_path: Path) -> None:
+    rows = report["rows"]
+    fieldnames = [
+        "slide", "severity", "n_images", "gap_left_pct", "gap_right_pct",
+        "gap_max", "center_offset_pct", "dispersion", "flagged_by_scanner",
+        "forms_triggered", "text_head",
+    ]
+    with csv_path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        for r in rows:
+            r2 = dict(r)
+            r2["forms_triggered"] = ";".join(r2["forms_triggered"])
+            w.writerow(r2)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--in", dest="input", type=Path, required=True,
+                    help="JSON produit par scan_slidev_composition.py")
+    ap.add_argument("--out", type=Path, default=None,
+                    help="Rapport JSON structure (defaut : stdout)")
+    ap.add_argument("--csv", type=Path, default=None,
+                    help="CSV par slide, tri severity desc / gap_max desc")
+    ap.add_argument("--top", type=int, default=0,
+                    help="Limiter la sortie aux N premieres lignes (0 = toutes)")
+    args = ap.parse_args()
+
+    scanner_report = json.loads(args.input.read_text(encoding="utf-8"))
+    report = build_report(scanner_report)
+    if args.top > 0:
+        report = dict(report)
+        report["rows"] = report["rows"][: args.top]
+
+    out_str = json.dumps(report, ensure_ascii=False, indent=2)
+    if args.out:
+        args.out.write_text(out_str, encoding="utf-8")
+    print(out_str)
+
+    if args.csv:
+        write_csv(report, args.csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/notebook_tools/tests/test_scan_slidev_gap_report.py
+++ b/scripts/notebook_tools/tests/test_scan_slidev_gap_report.py
@@ -1,0 +1,185 @@
+"""Tests unitaires de scan_slidev_gap_report.
+
+Le scanner Playwright reste couvert par scan_slidev_composition + son
+controle positif ; ici on teste la transformation JSON -> rapport structure
+avec des fixtures reproduisant la structure `results[]`.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scan_slidev_gap_report import (  # noqa: E402
+    _forms_triggered,
+    _severity,
+    _slide_row,
+    build_report,
+)
+
+
+SAMPLE_REPORT = {
+    "canvas": [980, 552],
+    "n_occupation_flagged": 2,
+    "controle_positif_ok": False,
+    "controle_positif_warning": "scan sans contrôle positif armé",
+    "baseline_slide": 5,
+    "baseline_commit": "6cabc826b",
+    "results": [
+        # Pas d'image
+        {"slide": 1, "text_head": "Sommaire", "hors_canvas": [], "chevauchements": [], "occupation": None},
+        # Cas fondateur F1 (gap_left 71.4)
+        {"slide": 7, "text_head": "Image collee a droite", "hors_canvas": [], "chevauchements": [],
+         "occupation": {"n_images": 1, "img_span": [700, 960], "span_ratio": 0.265,
+                        "gap_left_pct": 71.4, "gap_right_pct": 2.0,
+                        "center_offset_pct": 34.7, "dispersion": 0,
+                        "content_bottom": 400}},
+        # F2 : gap moderee + offset
+        {"slide": 21, "text_head": "Deux images decenter", "hors_canvas": [], "chevauchements": [],
+         "occupation": {"n_images": 2, "img_span": [300, 950], "span_ratio": 0.663,
+                        "gap_left_pct": 4.9, "gap_right_pct": 64.5,
+                        "center_offset_pct": -29.8, "dispersion": 0.3,
+                        "content_bottom": 380}},
+        # F3 : image unique offset
+        {"slide": 23, "text_head": "Image plaquee", "hors_canvas": [], "chevauchements": [],
+         "occupation": {"n_images": 1, "img_span": [600, 980], "span_ratio": 0.388,
+                        "gap_left_pct": 61.2, "gap_right_pct": 0.0,
+                        "center_offset_pct": 30.1, "dispersion": 0,
+                        "content_bottom": 450}},
+        # F4-overflow : gap bas + hors_canvas
+        {"slide": 5, "text_head": "Trois images + overflow", "hors_canvas": [{"tag": "IMG"}],
+         "chevauchements": [],
+         "occupation": {"n_images": 3, "img_span": [200, 700], "span_ratio": 0.510,
+                        "gap_left_pct": 30.0, "gap_right_pct": 5.0,
+                        "center_offset_pct": -12.5, "dispersion": 0.2,
+                        "content_bottom": 350}},
+        # Composition equilibree
+        {"slide": 30, "text_head": "Centre equilibre", "hors_canvas": [], "chevauchements": [],
+         "occupation": {"n_images": 1, "img_span": [380, 600], "span_ratio": 0.224,
+                        "gap_left_pct": 10.0, "gap_right_pct": 10.0,
+                        "center_offset_pct": 0.0, "dispersion": 0,
+                        "content_bottom": 300}},
+        # Faible gap sans offset (low severity)
+        {"slide": 40, "text_head": "Image en haut a droite", "hors_canvas": [], "chevauchements": [],
+         "occupation": {"n_images": 1, "img_span": [700, 850], "span_ratio": 0.153,
+                        "gap_left_pct": 26.0, "gap_right_pct": 13.0,
+                        "center_offset_pct": 13.5, "dispersion": 0,
+                        "content_bottom": 200}},
+    ],
+}
+
+
+def test_severity_thresholds():
+    assert _severity(71.4) == "high"
+    assert _severity(55.0) == "high"
+    assert _severity(54.9) == "med"
+    assert _severity(40.0) == "med"
+    assert _severity(39.9) == "low"
+    assert _severity(25.0) == "low"
+    assert _severity(24.9) == "none"
+    assert _severity(0.0) == "none"
+
+
+def test_forms_triggered_F1_fondateur():
+    r = SAMPLE_REPORT["results"][1]  # slide 7, gap_left 71.4
+    forms = _forms_triggered(r, 552)
+    assert "F1" in forms
+
+
+def test_forms_triggered_F2_moderee_offset():
+    r = SAMPLE_REPORT["results"][2]  # slide 21, gap_right 64.5 + offset -29.8
+    forms = _forms_triggered(r, 552)
+    assert "F1" in forms  # gap >= 55 declenche F1 aussi
+    assert "F2" in forms
+
+
+def test_forms_triggered_F3_single_image():
+    r = SAMPLE_REPORT["results"][3]  # slide 23, n_images=1, offset 30.1
+    forms = _forms_triggered(r, 552)
+    assert "F1" in forms  # gap_left 61.2 >= 55
+    assert "F3" in forms
+
+
+def test_forms_triggered_F4_overflow():
+    r = SAMPLE_REPORT["results"][4]  # slide 5, gap 30 + hors_canvas
+    forms = _forms_triggered(r, 552)
+    assert "F4-overflow" in forms
+
+
+def test_forms_triggered_balanced_no_forms():
+    r = SAMPLE_REPORT["results"][5]  # slide 30, gap 10/10
+    forms = _forms_triggered(r, 552)
+    assert forms == []
+
+
+def test_slide_row_drops_no_images():
+    r = SAMPLE_REPORT["results"][0]  # slide 1 sans image
+    assert _slide_row(r, 552) is None
+
+
+def test_slide_row_severity_and_flagged():
+    r = SAMPLE_REPORT["results"][1]  # slide 7
+    row = _slide_row(r, 552)
+    assert row is not None
+    assert row["slide"] == 7
+    assert row["severity"] == "high"
+    assert row["gap_max"] == 71.4
+    assert row["flagged_by_scanner"] is True
+    assert "F1" in row["forms_triggered"]
+
+
+def test_build_report_summary_and_sort():
+    report = build_report(SAMPLE_REPORT)
+    # Source preserved
+    assert report["source_n_occupation_flagged"] == 2
+    assert report["source_controle_positif_ok"] is False
+    assert report["canvas_h"] == 552
+    # 6 slides avec images (la slide 1 n'a pas d'image)
+    assert report["n_slides_with_images"] == 6
+    # Severity counts
+    assert report["summary_by_severity"]["high"] == 3  # slides 7, 21, 23
+    assert report["summary_by_severity"]["med"] == 0
+    assert report["summary_by_severity"]["low"] == 2  # slides 5, 40
+    assert report["summary_by_severity"]["none"] == 1  # slide 30
+    # Sorted: high d'abord par gap_max desc
+    rows = report["rows"]
+    assert rows[0]["severity"] == "high"
+    assert rows[0]["slide"] == 7  # 71.4
+    # high contigus
+    high_rows = [r for r in rows if r["severity"] == "high"]
+    assert {r["slide"] for r in high_rows} == {7, 21, 23}
+
+
+def test_build_report_top_limit():
+    report = build_report(SAMPLE_REPORT)
+    # Simule l'effet de --top
+    top = report["rows"][:3]
+    assert len(top) == 3
+    assert all(r["severity"] == "high" for r in top)
+
+
+def test_csv_field_round_trip(tmp_path):
+    """Le CSV doit contenir les cles de la row (forms_triggered en ';' separated)."""
+    report = build_report(SAMPLE_REPORT)
+    csv_path = tmp_path / "gap.csv"
+    # Inline minimal CSV write pour eviter de re-tester l'enrobage argparse.
+    import csv as _csv
+    with csv_path.open("w", encoding="utf-8", newline="") as f:
+        w = _csv.DictWriter(f, fieldnames=[
+            "slide", "severity", "n_images", "gap_left_pct", "gap_right_pct",
+            "gap_max", "center_offset_pct", "dispersion", "flagged_by_scanner",
+            "forms_triggered", "text_head",
+        ])
+        w.writeheader()
+        for r in report["rows"]:
+            r2 = dict(r)
+            r2["forms_triggered"] = ";".join(r2["forms_triggered"])
+            w.writerow(r2)
+    # Re-lire
+    with csv_path.open(encoding="utf-8") as f:
+        lines = f.readlines()
+    assert lines[0].startswith("slide,severity,")
+    # Slide 7 en tete (high)
+    assert lines[1].startswith("7,high,")
+    assert "F1" in lines[1]


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA-2 — prev: MED/slides #13225 (c.572)

feat(tools,#13224): scan_slidev_gap_report — tableau par-slide des déséquilibres de composition

See #13224. See #13223.

## Origine

Issue #13224 constate 42 slides de `slides/S3-acculturation` avec `gap_left_pct` ou `gap_right_pct` ≥ 40 %, sur 49 slides à images. Le scanner `scan_slidev_composition.py` mesurait la grandeur (`results[].occupation.gap_*`) mais ne sortait qu'un rollup `n_occupation_flagged: 2` (chemin de flagging mort — c.572 a re-câblé `occupation_flagged` sur 4 formes F1-F4 via #13225, MERGEABLE en attente ai-01).

Pour **piloter la descente** des 42 cas en tranches (cf #13224, acceptance #1 « Les slides de la tranche n'ont plus de côté vide ≥ 40 % »), il faut un **tableau par slide** : severity (high ≥55 / med ≥40 / low ≥25), `gap_max`, `forms_triggered` (F1-F4), `flagged_by_scanner`, et un tri stable par severity desc / gap_max desc. C'est ce que ce script produit.

## Périmètre

- `scripts/notebook_tools/scan_slidev_gap_report.py` (219 lignes) :
  - Consomme le JSON du scanner (`scan_slidev_composition.py`).
  - Génère un **rapport JSON structuré** (stdout ou `--out`) : `n_slides_with_images`, `summary_by_severity`, `n_flagged_by_scanner`, `rows[]`.
  - Génère un **CSV** trié (`--csv`) : colonnes `slide, severity, n_images, gap_left_pct, gap_right_pct, gap_max, center_offset_pct, dispersion, flagged_by_scanner, forms_triggered, text_head`.
  - **Re-dérive localement** la logique F1-F4 (dans `_forms_triggered`) au lieu d'importer `occupation_flagged` du scanner — la sortie est cohérente avec le scanner post-merge #13225, et reste exploitable si le scanner pré-c.572 est encore sur `origin/main`.
- `scripts/notebook_tools/tests/test_scan_slidev_gap_report.py` (184 lignes, 11 tests) :
  - Fixture synthétisée reproduisant `results[]` pour 7 slides (fondateur F1, F2, F3, F4-overflow, équilibré, sans images, low).
  - Couvre les seuils de severity (≥55 / ≥40 / ≥25 / none), `_forms_triggered` pour les 4 formes, `_would_flag` cohérent, `build_report` tri + summary, drop des slides sans images, round-trip CSV.

## Logique `_would_flag`

Re-dérive locale des 4 formes du c.572 :

| Forme | Condition | Origine #13225 |
|---|---|---|
| F1 | `gap_left ≥ 55` OU `gap_right ≥ 55` | bande unilatérale marquée (fondateur slide 7) |
| F2 | `(gap ≥ 40) ET |offset| ≥ 25` | cumul déséquilibre + décentrage |
| F3 | `n_images == 1 ET |offset| ≥ 30` | image plaquée sur un bord |
| F4-overflow | `gap > 25 ET hors_canvas non vide` | régression préservée |
| F4-bord | `gap > 25 ET content_bottom > 0.95 × canvas_h` | régression préservée |

Une `forms_triggered` non vide ⇒ `flagged_by_scanner: True`. Le test `test_slide_row_severity_and_flagged` reproduit la slide 7 (71.4 %) et vérifie `flagged_by_scanner == True` **via la logique locale**, indépendamment de la version du scanner en place.

## Tests

11 tests pytest verts (sur origin/main) :

```
$ python -m pytest scripts/notebook_tools/tests/test_scan_slidev_gap_report.py -v
============================= 11 passed in 0.13s ==============================
```

Aucune régression sur le scanner c.572 (6/6 tests `test_scan_slidev_composition.py` toujours verts).

## Usage (preview)

```bash
# 1. Servir le deck + scanner (cf #11923, run_composition_control.py)
python scripts/notebook_tools/run_composition_control.py
# produit /tmp/slidev_control_xxx/report.json

# 2. Tableau JSON structure
python scripts/notebook_tools/scan_slidev_gap_report.py \
    --in /tmp/slidev_control_xxx/report.json \
    --out /tmp/gap_report.json

# 3. CSV pour tableur
python scripts/notebook_tools/scan_slidev_gap_report.py \
    --in /tmp/slidev_control_xxx/report.json \
    --csv /tmp/gap_report.csv
```

Le CSV `--top 10` permet de cibler la première tranche (10 pires slides) — base pour piloter les PR de substance qui toucheront `slides.md`/`style.css` (scope de #13096 sustained, en attente ai-01).

## Hors scope

- **Substance des 42 slides** (#13224 acceptance) : ce script **outille** la descente mais ne touche pas `slides.md`/`style.css` (laissés à #13096 sustained, en attente ai-01).
- **Pas d'effet sur le scanner** : `_would_flag` est local, n'altère pas `occupation_flagged` du scanner.
- **Pas de CI integration** : ce script est invoqué manuellement (le scanner + ce rapport sont des outils de diagnostic, pas des gates de merge).

## Acceptance — ce qui est livré

- [x] Tableau par slide des `gap_*_pct` et `forms_triggered` (F1-F4 locaux).
- [x] CSV trié par severity desc / gap_max desc.
- [x] Summary par severity (high/med/low/none).
- [x] Source préservée (baseline_slide, baseline_commit, controle_positif_ok).
- [x] Tests écrits par leurs propres signaux (les 7 fixtures reproduisent les 4 formes + équilibré + sans images + low).

## Acceptance — ce qui reste à faire (#13224)

- [ ] Tranches de substance sur `slides.md`/`style.css` (à faire après merge #13096).
- [ ] Mesure avant/après datée pour chaque tranche (le rapport permet la mesure « après »).

## Diff

```diff
 scripts/notebook_tools/scan_slidev_gap_report.py            | 219 +++++++++++
 scripts/notebook_tools/tests/test_scan_slidev_gap_report.py | 184 +++++++++
 2 files changed, 403 insertions(+)
```

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com)