### PR TITLE
fix(slides,#13216): 49 lignes vides apres chaque balise ouvrante HTML sur 3 decks

### DIFF
--- a/docs/reference/slides-layout-pattern.md
+++ b/docs/reference/slides-layout-pattern.md
@@ -52,6 +52,28 @@ Le remede n'est donc pas d'abandonner la grille : c'est une ligne vide.
 
 Contre-exemple deja present dans le depot avant que le diagnostic « impossible » soit pose : [`slides/S3-acculturation/deck-executif.md:39-41`](../../slides/S3-acculturation/deck-executif.md#L39-L41) — un `grid grid-cols-3` qui construit, et qui porte la ligne vide.
 
+## Generalisation : tout wrapper HTML sur sa ligne ouvre un bloc
+
+La regle precedent, portee sur le diagnostic « les grilles sont impossibles », cache une regle plus large : **tout** tag ouvrant HTML seul sur sa ligne ouvre un bloc HTML, et tout markdown de bloc place sur la ligne suivante est avale. Les coupables recurrents sur les decks du depot :
+
+- **`<div class="grid grid-cols-N ...">`** : layout en grille (cf regle 2).
+- **`<div v-click="N">`** : wrapper d'animation incremental Slidev, omnipresent
+  dans `slides/06-apprentissage` (~30 occurrences sur ce seul deck).
+- **`<div class="dense-list">`**, `<div class="columns">`, `<div class="...">`
+  utilitaires de mise en page.
+
+**Compte rendu main, 2026-08-27 (avant fix #13216) : 49 emplacements sur 36 decks, repartis :**
+
+| Deck | markdown avale |
+|---|---|
+| `slides/01-introduction/slides.md` | 1 |
+| `slides/06-apprentissage/slides.md` | 39 |
+| `slides/S8-semantic-web/slides.md` | 9 |
+
+**Le defaut est invisible aux scanners de composition** : `scan_slidev_composition.py` mesure debordement de canvas, chevauchement de glyphes et occupation -- des asterisques litteraux et une liste aplatie sont du texte A L'INTERIEUR du canvas. Le detecteur dedie `scan_slides_html_block_markdown.py` (PR #13218) a ete pose pour le rendu honnete de cette grandeur.
+
+**Regle praticienne a toute nouvelle tranche : apres avoir pose un `<div>` ouvrant seul sur sa ligne, poser systematiquement une ligne vide avant la premiere ligne markdown suivante.** La grille, le wrapper `v-click` ou la classe dense-list n'echappent pas a la regle.
+
 ## Geometrie du canvas — 980 x 552, et le facteur d'echelle
 
 Sans `canvasWidth` / `aspectRatio` / `canvasHeight` dans le headmatter, Slidev applique son defaut : **980 x 552**. Verifier le headmatter avant d'ecrire le moindre `top-[Npx]` — un deck calcule contre une autre constante produit des positions fausses **partout**, et l'erreur se propage a chaque reparation suivante.

--- a/scripts/notebook_tools/fix_slides_html_block_markdown.py
+++ b/scripts/notebook_tools/fix_slides_html_block_markdown.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""fix_slides_html_block_markdown.py -- insere une ligne vide avant chaque
+bloc markdown avale par un bloc HTML (cf #13216).
+
+Trois regles :
+  1. Run dry-run par defaut (imprime la liste des insertions prevues, exit 0
+     si au moins un fix serait applique, exit 1 sinon -- lecture seule).
+  2. --apply : modifie les fichiers EN PLACE.
+  3. --root-dir : par defaut, balaie slides/ (recursive=False, conforme aux
+     conventions scan_slides_image_refs / scan_slides_html_block_markdown).
+
+Le scanner source (scan_slides_html_block_markdown.py, #13218) detecte les
+lignes de markdown de bloc situees IMMEDIATEMENT apres une balise ouvrante
+HTML (sans ligne vide). Le fix : inserer une ligne vide juste avant la
+ligne signalee.
+
+Cas fondateur (slides/06-apprentissage/slides.md, L286) :
+    <div v-click="2">
+  - **Tri des symboles selon**      <-- scanner hit (L286)
+      - la frequence
+
+apres fix :
+    <div v-click="2">
+
+  - **Tri des symboles selon**
+      - la frequence
+
+Le scanner utilise des index 1-based sortants. On reproduit fidelement son
+`split('\n')` (pas splitlines : collapse les \\v, etc. et decalerait les
+index -- c.574 lesson).
+
+Les hits sont traites en ordre DECROISSANT (le plus haut d'abord) pour
+que l'insertion precedente ne decale pas les index suivants.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, NamedTuple
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_SCANNER = REPO / "scripts/notebook_tools/scan_slides_html_block_markdown.py"
+
+
+class Hit(NamedTuple):
+    file: Path
+    line: int  # 1-based line in file
+
+
+def parse_scanner_output(text: str) -> list[Hit]:
+    """Parse the output of scan_slides_html_block_markdown.py.
+
+    Format attendu :
+        scanned 36 markdown file(s) under slides
+
+        slides/01-introduction/slides.md  (1)
+          L595    - Intelligence animale
+
+        slides/06-apprentissage/slides.md  (39)
+          L286    - **Tri des symboles selon**
+
+        total: 49 line(s) of block markdown swallowed
+    """
+    hits: list[Hit] = []
+    cur_file: Path | None = None
+    for line in text.splitlines():
+        m = re.match(r"^\s*(\S+\.md)\s+\(\d+\)\s*$", line)
+        if m:
+            cur_file = Path(m.group(1))
+            continue
+        m = re.match(r"^\s*L(\d+)\s+", line)
+        if m and cur_file is not None:
+            hits.append(Hit(cur_file, int(m.group(1))))
+    return hits
+
+
+def would_insert_blank(lines: list[str], hit_line: int) -> bool:
+    """Verifie que la ligne hit_line est PRECEDEE d'une balise ouvrante HTML
+    SANS ligne vide entre les deux. Si une ligne vide est deja la, retourne
+    False (le scanner a sur-acuse ou le fichier a deja ete repare).
+    Convention 1-based pour hit_line (aligne avec le scanner).
+
+    Note : le scanner source utilise une regex stricte (_OPENING_TAG seule
+    sur sa ligne, pas d'auto-fermeture), donc faire confiance a son verdict
+    ici -- limiterait le scope de re-verification.
+    """
+    if hit_line <= 1:
+        return False
+    prev_idx = hit_line - 2  # 0-based index de la ligne juste avant
+    if prev_idx >= len(lines):
+        return False
+    prev_line = lines[prev_idx].rstrip()
+    if not prev_line:
+        return False  # ligne vide deja presente -- deja reparee
+    return True
+
+
+def apply_fix(file: Path, hits: Iterable[int], dry_run: bool) -> list[str]:
+    """Insere une ligne vide avant chaque hit. Retourne les chemins Lignes
+    dans le fichier ORIGINAL (1-based, avant insertion) pour logging.
+    """
+    if not hits:
+        return []
+    # newline='' preserve les LF d'origine (c.574 lesson : en mode texte
+    # Windows, open() sans newline='' convertit \n en \r\n et le diff explose
+    # inutilement).
+    with file.open("r", encoding="utf-8", newline="") as f:
+        text = f.read()
+    # split('\n') comme le scanner source (cf docstring)
+    lines = text.split("\n")
+    # DECROISSANT : insertion haute d'abord, pour eviter que l'insertion
+    # precedente ne decale les index.
+    sorted_hits = sorted(set(hits), reverse=True)
+    insertions: list[str] = []
+    for hit_line in sorted_hits:
+        if not would_insert_blank(lines, hit_line):
+            continue
+        idx = hit_line - 2  # 0-based de la ligne precedant L hit_line (1-based)
+        lines.insert(idx + 1, "")
+        insertions.append(f"{file}:L{hit_line}")
+    if not dry_run and insertions:
+        out = "\n".join(lines)
+        if text.endswith("\n") and not out.endswith("\n"):
+            out += "\n"
+        elif not text.endswith("\n") and out.endswith("\n"):
+            out = out.rstrip("\n")
+        # newline='' pour ne pas re-transformer les LF en CRLF.
+        with file.open("w", encoding="utf-8", newline="") as f:
+            f.write(out)
+    return insertions
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--scanner-output", type=Path, default=None,
+                    help="Sortie capturee de scan_slides_html_block_markdown.py (defaut : lancer le scanner)")
+    ap.add_argument("--apply", action="store_true", help="Modifie les fichiers EN PLACE (defaut : dry-run)")
+    ap.add_argument("--root-dir", type=Path, default=REPO / "slides")
+    args = ap.parse_args()
+
+    if args.scanner_output is not None:
+        scanner_text = args.scanner_output.read_text(encoding="utf-8")
+    else:
+        proc = subprocess.run(
+            [sys.executable, str(DEFAULT_SCANNER)],
+            capture_output=True, text=True, cwd=str(REPO)
+        )
+        if proc.returncode not in (0, 1) and not proc.stdout:
+            print(f"scanner echec (rc={proc.returncode}): {proc.stderr}", file=sys.stderr)
+            return 2
+        scanner_text = proc.stdout
+
+    hits = parse_scanner_output(scanner_text)
+    if not hits:
+        print("Aucun hit scanne -- rien a fixer.")
+        return 1
+
+    by_file: dict[Path, list[int]] = {}
+    for h in hits:
+        by_file.setdefault(h.file, []).append(h.line)
+
+    total_insertions: list[str] = []
+    for file, line_nums in sorted(by_file.items()):
+        insertions = apply_fix(file, line_nums, dry_run=not args.apply)
+        total_insertions.extend(insertions)
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"[{mode}] {len(total_insertions)} insertion(s) prevue(s) :")
+    for ins in total_insertions:
+        print(f"  - {ins}")
+    if not args.apply:
+        print("Relancer avec --apply pour modifier.")
+    return 0 if total_insertions else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_fix_slides_html_block_markdown.py
+++ b/scripts/notebook_tools/tests/test_fix_slides_html_block_markdown.py
@@ -1,0 +1,158 @@
+"""Tests unitaires de fix_slides_html_block_markdown.
+
+Le scanner source (scan_slides_html_block_markdown.py, #13218) reste couvert
+par son propre test ; ici on teste le script de fix : parser la sortie du
+scanner + inserer les lignes vides sans introduire de modifications
+parasites."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fix_slides_html_block_markdown import (  # noqa: E402
+    parse_scanner_output,
+    would_insert_blank,
+    apply_fix,
+)
+
+
+SAMPLE_SCANNER_OUTPUT = """\
+scanned 36 markdown file(s) under slides
+
+slides/01-introduction/slides.md  (1)
+  L595    - Intelligence animale
+
+slides/06-apprentissage/slides.md  (39)
+  L286    - **Tri des symboles selon**
+  L1878   - **Step 2: New Mean: 5.25**
+  L2297   - **Comportements problematiques observes** :
+
+slides/S8-semantic-web/slides.md  (9)
+  L189    ## Types de requetes SPARQL
+  L303    ## OWL 2 : au-dela de RDFS
+
+total: 11 line(s) of block markdown swallowed by an HTML block
+fix: insert a blank line after the opening tag preceding each line above
+"""
+
+
+def test_parse_scanner_output_extracts_files_and_lines():
+    hits = parse_scanner_output(SAMPLE_SCANNER_OUTPUT)
+    # SAMPLE_SCANNER_OUTPUT declare 11 hits en total mais n'en liste
+    # qu'un par deck : 1 + 3 + 2 = 6.
+    assert len(hits) == 6
+    files = {h.file for h in hits}
+    assert Path("slides/01-introduction/slides.md") in files
+    assert Path("slides/06-apprentissage/slides.md") in files
+    assert Path("slides/S8-semantic-web/slides.md") in files
+    lines_by_file = {h.file: [] for h in hits}
+    for h in hits:
+        lines_by_file[h.file].append(h.line)
+    assert lines_by_file[Path("slides/06-apprentissage/slides.md")] == [286, 1878, 2297]
+    assert lines_by_file[Path("slides/S8-semantic-web/slides.md")] == [189, 303]
+
+
+def test_would_insert_blank_on_opening_tag():
+    """La ligne precedent doit etre non-vide et contenir <+> (sanity check)."""
+    lines = ["", '<div class="grid">', "- **item**", ""]
+    assert would_insert_blank(lines, 3) is True
+
+
+def test_would_insert_blank_false_on_blank_line():
+    """Si la ligne d'avant est deja vide, ne pas re-inserer."""
+    lines = ["", "", "- **item**", ""]
+    assert would_insert_blank(lines, 3) is False
+
+
+def test_would_insert_blank_false_on_line_1():
+    """Pas de hit a la ligne 1 (rien a inserer avant)."""
+    lines = ["- **item**"]
+    assert would_insert_blank(lines, 1) is False
+
+
+def test_apply_fix_inserts_blank_lines(tmp_path):
+    """Le script doit inserer une ligne vide AVANT chaque hit signale,
+    en ordre decroissant pour eviter les decalages d'index."""
+    src = tmp_path / "deck.md"
+    src.write_text(
+        '<div v-click="2">\n'
+        '- **Item 1**\n'
+        '- Suite item 1\n'
+        '\n'
+        '<div v-click="3">\n'
+        '- **Item 2**\n'
+        '- Suite item 2\n'
+        '',
+        encoding='utf-8',
+    )
+    # Hit sur les lignes 2 et 6 (1-based) : les markdown Items 1 et 2.
+    insertions = apply_fix(src, [6, 2], dry_run=False)
+    assert len(insertions) == 2
+    text = src.read_text(encoding='utf-8')
+    # Attendu : ligne vide inseree entre <div v-click="2"> et "- **Item 1**"
+    #           ligne vide inseree entre <div v-click="3"> et "- **Item 2**"
+    expected = (
+        '<div v-click="2">\n'
+        '\n'
+        '- **Item 1**\n'
+        '- Suite item 1\n'
+        '\n'
+        '<div v-click="3">\n'
+        '\n'
+        '- **Item 2**\n'
+        '- Suite item 2\n'
+    )
+    assert text == expected, f"got:\n{text!r}\nexpected:\n{expected!r}"
+
+
+def test_apply_fix_dry_run_does_not_modify(tmp_path):
+    src = tmp_path / "deck.md"
+    original = (
+        '<div class="dense-list">\n'
+        '- **Item**\n'
+    )
+    src.write_text(original, encoding='utf-8')
+    insertions = apply_fix(src, [2], dry_run=True)
+    assert len(insertions) == 1
+    assert src.read_text(encoding='utf-8') == original, "dry-run modified file"
+
+
+def test_apply_fix_idempotent_on_already_repaired(tmp_path):
+    """Si une ligne vide est deja la, le script la signale mais ne la duplique pas."""
+    src = tmp_path / "deck.md"
+    src.write_text(
+        '<div class="dense-list">\n'
+        '\n'
+        '- **Deja repare**\n',
+        encoding='utf-8',
+    )
+    # Hit 3, mais ligne 2 deja vide -> would_insert_blank False
+    insertions = apply_fix(src, [3], dry_run=False)
+    assert len(insertions) == 0
+    # Fichier inchange
+    assert src.read_text(encoding='utf-8') == (
+        '<div class="dense-list">\n'
+        '\n'
+        '- **Deja repare**\n'
+    )
+
+
+def test_apply_fix_handles_trailing_blank_line(tmp_path):
+    """Le fichier termine par un newline : split('\n') ajoute un '' final.
+    Le script ne doit pas se laisser perturber."""
+    src = tmp_path / "deck.md"
+    src.write_text(
+        '<div v-click="1">\n'
+        '- **Final item**\n',
+        encoding='utf-8',
+    )
+    insertions = apply_fix(src, [2], dry_run=False)
+    assert len(insertions) == 1
+    assert src.read_text(encoding='utf-8') == (
+        '<div v-click="1">\n'
+        '\n'
+        '- **Final item**\n'
+    )

--- a/slides/01-introduction/slides.md
+++ b/slides/01-introduction/slides.md
@@ -592,6 +592,7 @@ Un agent naif pourrait stocker une table "percepts → action" :<br>la table ser
 **Intelligence animale**
 
 <div v-click="2">
+
 - Intelligence animale
 </div>
 - Behaviourism

--- a/slides/06-apprentissage/slides.md
+++ b/slides/06-apprentissage/slides.md
@@ -283,17 +283,20 @@ layout: dense
 - Construction du code:
 
 <div v-click="2">
+
 - **Tri des symboles selon**
   - la fréquence
 </div>
 
 <div v-click="3">
+
 - **Combinaison de symboles**
   - les moins fréquents
 - Tracé d’un chemin
 </div>
 
 <div v-click="4">
+
 - ** Arbre de décision**
   - optimal
 - encodage robuste
@@ -423,6 +426,7 @@ layout: dense
 - **Points forts** : rapide, simple, comprehensible, empiriquement valide, robuste au bruit
 
 <div v-click="2">
+
 - **Points faibles** :
   - Decoupe a un seul attribut : limite les types de problemes supportes
   - Les arbres de grande taille deviennent difficiles a interpreter
@@ -460,16 +464,19 @@ layout: two-cols
 - Et parfois double-descente
 
 <div v-click="2">
+
 - **Attention au dévoilement**
   - de l’ensemble de test:
 </div>
 
 <div v-click="3">
+
 - **Si on change d’hypothèse,**
   - il faut régénérer l’ensemble de test
 </div>
 
 <div v-click="4">
+
 - **Sinon l’ensemble de test a « fuité »**
   - dans l’apprentissage.
 </div>
@@ -489,6 +496,7 @@ layout: two-cols
 
 
 <div class="dense-list xl-dense">
+
 - Toute sorte de « bruits » peuvent apparaitre dans les exemples
   - 2 exemples ont les mêmes attributs mais pas la même classe
   - valeurs incorrectes du fait d’erreur d’acquisition ou de traitement
@@ -593,6 +601,7 @@ layout: dense
 # Méthodes d'ensemble
 
 <div class="dense-list">
+
 - Jusqu’à présent: 1 seule hypothèse
 - Apprentissage d’ensemble = ensemble d’hypothèses
 - Si indépendantes  probabilité faible de mauvaise prédiction
@@ -665,6 +674,7 @@ layout: two-cols
 
 
 <div class="dense-list">
+
 - Unité de McCulloch-Pitts
 - Inspiration biologique
 - Simplification élémentaire
@@ -723,6 +733,7 @@ layout: two-cols
 - 2 seuils  1 crète
 
 <div v-click="2">
+
 - **Toute fonction avec**
   - 3 couche
 - 2 crètes  1 bosse
@@ -732,6 +743,7 @@ layout: two-cols
 </div>
 
 <div v-click="3">
+
 - **Similaire à une classification**
   - par hyperplan dans l’espace cible
 
@@ -792,11 +804,13 @@ layout: two-cols
   - partie, objet
 
 <div v-click="2">
+
 - **Caractère, mot, groupe,**
   - clause, phrase, histoire
 </div>
 
 <div v-click="3">
+
 - ** fonctionne bien car**
   - le monde est hiérarchique
 - Librairies de Deep learning
@@ -858,6 +872,7 @@ layout: two-cols
 # Réseaux résiduels (ResNets)
 
 <div class="dense-list">
+
 - Problème:
 - Augmentation de la profondeur
 -  Dégradation des performances
@@ -895,6 +910,7 @@ layout: two-cols
 # Réseaux antagonistes génératifs (GANs)
 
 <div class="dense-list">
+
 - Principe
 - Apprentissage non-supervisé
 - Jeu à somme nulle
@@ -924,6 +940,7 @@ layout: two-cols
 # Réseaux récurrents - RNNs
 
 <div class="dense-list">
+
 - Réseaux récurrents
 - Pensées persistantes  Connexions réentrantes
 - Peuvent être vus « dépliés »
@@ -1045,6 +1062,7 @@ layout: two-cols
 # Graphs Neural Networks (GNNs)
 
 <div class="dense-list">
+
 - Graphes G = (V,E)
 - GNN opère sur la structure de G
 - Ex: Classification des noeuds: Xv  Tv
@@ -1319,10 +1337,12 @@ $$y_i(w \cdot x_i + b) \geq 1 \quad \forall i$$
 - **Astuce 1** : Identifier les points les plus proches du plan de separation optimal (les "vecteurs supports") et travailler directement a partir de ces instances.
 
 <div v-click="2">
+
 - **Astuce 2** : Formuler comme un problème d'optimisation quadratique et utiliser les techniques de programmation quadratique.
 </div>
 
 <div v-click="3">
+
 - **Astuce 3** (le "kernel trick") :
   - Au lieu d'utiliser directement les caractéristiques, representer les données dans un espace de grande dimension construit a partir de fonctions de base (combinaisons polynomiales et gaussiennes des caractéristiques d'origine).
   - Trouver un hyperplan separateur / SVM dans cet espace de grande dimension.
@@ -1358,6 +1378,7 @@ Le calcul dans l'espace projeté se fait **sans projeter explicitement** (astuce
 - **Excellents résultats** jusqu'aux années 2010 (texte, bioinformatique, vision, finance)
 
 <div v-click="2">
+
 - **Avantages** :
   - Optimum global garanti (problème convexe, pas de minimum local)
   - Bonne généralisation en haute dimension
@@ -1365,6 +1386,7 @@ Le calcul dans l'espace projeté se fait **sans projeter explicitement** (astuce
 </div>
 
 <div v-click="3">
+
 - **Limites et contexte actuel** :
   - Coût O(n²) à O(n³) — difficile sur grands datasets
   - Supplanté par le Deep Learning depuis 2012 (AlexNet, ImageNet)
@@ -1443,6 +1465,7 @@ layout: dense
 # Apprentissage et connaissance
 
 <div class="dense-list">
+
 - Relation en hypothèses et exemples:
 - Hypothèses ∧ Descriptions |= Classifications
 - Rasoir d’Occam  écarter l’énumération
@@ -1530,6 +1553,7 @@ layout: dense
 - Algorithme FOIL (1990): clauses de but/horn
 
 <div v-click="2">
+
 - **Ex: Père(x,y)GrandPère(x,y) a des contre-exemples,**
   - Père(x,z) ∧ Père(z,y) GrandPère(x,y) fonctionne
 - Couverture de tous les exemples positifs:+ Père(x,z) ∧ Mère(z,y) GrandPère(x,y)
@@ -1540,6 +1564,7 @@ layout: dense
 </div>
 
 <div v-click="3">
+
 - **b très grand mais restrictions de types + utilisation du gain**
   - informationnel  + heuristique d’Occam (ex: longueur de la clause)
 
@@ -1560,6 +1585,7 @@ layout: dense
 # Résumé apprentissage et connaissances
 
 <div class="dense-list">
+
 - Utilisation des connaissances
 - Modèles plus expressifs qu’attributs simple
 - Apprentissage cumulatif: utilisation de la KB
@@ -1621,11 +1647,13 @@ layout: section
   - = α p(C) p(F1, ..., Fn | C)
 
 <div v-click="2">
+
 - **Assume that each feature Fi is conditionally independent of the other features given the class C.  Then:**
   - p(C | F1, ..., Fn)  = α p(C) Πi p(Fi | C)
 </div>
 
 <div v-click="3">
+
 - **We can estimate each of these conditional probabilities from the observed counts in the training data:**
   - p(Fi | C)  = N(Fi ∧ C) / N(C)
 - Dealing with zeros
@@ -1635,6 +1663,7 @@ layout: section
 </div>
 
 <div v-click="4">
+
 - **p(Wait | Cuisine, Patrons, Rainy?)  =**
   - α p(Wait) p(Cuisine | Wait) p(Patrons | Wait)
   - p(Rainy? | Wait)
@@ -1845,6 +1874,7 @@ layout: section
 - Should we throw that data away??
 
 <div v-click="2">
+
 - **Idea: Guess the missing values**
   - based on the other data
 - Earthquake
@@ -1875,21 +1905,25 @@ layout: section
   - New Data:[4, 10, 3.5, 3.5]
 
 <div v-click="2">
+
 - **Step 2: New Mean: 5.25**
   - New Data: [4, 10, 5.25, 5.25]
 </div>
 
 <div v-click="3">
+
 - **Step 3: New Mean: 6.125**
   - New Data: [4, 10, 6.125, 6.125]
 </div>
 
 <div v-click="4">
+
 - **Step 4: New Mean: 6.5625**
   - New Data: [4, 10, 6.5625, 6.5625]
 </div>
 
 <div v-click="5">
+
 - **Step 5: New Mean: 6.7825**
   - New Data: [4, 10, 6.7825, 6.7825]
 - Result: New Mean: 6.890625
@@ -2211,6 +2245,7 @@ layout: dense
 # Minimisation de regret hypothétique
 
 <div class="dense-list">
+
 - Jeux à information imparfaite:
 - Etats de croyance probabilistes
 - Évaluation du regret:
@@ -2294,6 +2329,7 @@ layout: dense
 - **Problème** : les LLMs entraînés sur du texte brut ne suivent pas forcément les instructions ni les valeurs humaines
 
 <div v-click="2">
+
 - **Comportements problématiques observés** :
   - Réponses toxiques, biaisées ou dangereuses
   - Hallucinations présentées avec confiance
@@ -2301,6 +2337,7 @@ layout: dense
 </div>
 
 <div v-click="3">
+
 - **Solution** : Reinforcement Learning from Human Feedback (RLHF)
   - Apprendre un **modèle de récompense** à partir des préférences humaines
   - Optimiser le LLM via RL pour maximiser cette récompense
@@ -2358,6 +2395,7 @@ layout: dense
   - β · KL : pénalité pour rester proche du modèle SFT (β ≈ 0.02–0.5)
 
 <div v-click="2">
+
 - **InstructGPT** (Ouyang et al., 2022) : première démonstration à grande échelle
   - GPT-3 fine-tuné par RLHF → suivi d'instructions radicalement amélioré
   - Base de ChatGPT (déployé Nov. 2022) puis GPT-4
@@ -2398,6 +2436,7 @@ layout: section
 # Projets de groupe
 
 <div class="dense-list">
+
 - Moteur de recherche augmenté par le raisonnement et le langage naturel
 - Grammaire et sémantique des contenus et des requêtes. Lucene.Net, OpenNLP, SharpRDF, FOL
 - Conception de bots de services sur réseaux sociaux

--- a/slides/S8-semantic-web/slides.md
+++ b/slides/S8-semantic-web/slides.md
@@ -186,6 +186,7 @@ layout: section
 # SW-4 — SPARQL : Le SQL du Web Sémantique
 
 <div class="dense-list">
+
 ## Types de requêtes SPARQL
 
 | Requête | Usage |
@@ -223,6 +224,7 @@ foreach (var result in results)
 # SW-5 — Linked Data : DBpedia et Wikidata
 
 <div class="dense-list">
+
 ## Les 5 etoiles du Linked Data (Berners-Lee, 2010)
 
 | Etoiles | Critere |
@@ -300,6 +302,7 @@ Console.WriteLine($"Apres inference : {dataGraph.Triples.Count} triplets");
 # SW-7 — OWL 2 : Ontologies et Logiques de Description
 
 <div class="dense-list">
+
 ## OWL 2 : au-dela de RDFS
 
 | Feature | RDFS | OWL 2 |
@@ -342,6 +345,7 @@ layout: section
 # SW-8 — SHACL : Validation des Données RDF
 
 <div class="dense-list">
+
 ## SHACL vs OWL : deux philosophies
 
 | | OWL | SHACL |
@@ -381,6 +385,7 @@ print(results[2])  # rapport Turtle
 # SW-9 — JSON-LD : Le Web Sémantique rencontre JSON
 
 <div class="dense-list">
+
 ## JSON-LD : bridge entre JSON et Linked Data
 
 ```python
@@ -421,6 +426,7 @@ compacted = jsonld.compact(doc, {"foaf": "http://xmlns.com/foaf/0.1/"})
 # SW-10 — RDF 1.2 (RDF-Star) : Assertions sur des Assertions
 
 <div class="dense-list">
+
 ## Le problème de la reification classique
 
 **But** : annoter un triplet (confiance, source, date...)
@@ -466,6 +472,7 @@ layout: section
 # SW-11 — Knowledge Graphs : Construction et Exploration
 
 <div class="dense-list">
+
 ## Qu'est-ce qu'un Knowledge Graph ?
 
 Un **graphe de connaissances** = graphe RDF a grande echelle, oriente metier
@@ -504,6 +511,7 @@ results = g.query("SELECT ?p WHERE { <http://mykg.../Turing> ?rel ?p }")
 # SW-12 — GraphRAG : Graphes et LLMs
 
 <div class="dense-list">
+
 ## RAG classique vs GraphRAG
 
 | | RAG classique | GraphRAG |
@@ -541,6 +549,7 @@ for s, p, o in extract_triples(document):
 # SW-13 — Comparaison des Raisonneurs OWL
 
 <div class="dense-list">
+
 ## Raisonneurs OWL : panorama
 
 | Raisonneur | Langage | Points forts |


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA-2 — prev: MED/slides #13226 (c.573)

fix(slides,#13216): 49 lignes vides inserees apres chaque balise ouvrante HTML sur 3 decks

See #13216. See #13218 (detecteur source -- livre separement par une autre lane).

## Origine

Le scanner `scan_slides_html_block_markdown.py` (PR #13218, **OPEN**, livre separement) a detecte **49 emplacements** sur main (commit `2f4bdd2be7`, HEAD avant ce fix) ou une balise ouvrante HTML precede **sans ligne vide** une ligne de markdown de bloc. markdown-it applique alors la regle CommonMark HTML block : la ligne de markdown est **avalee** dans le HTML brut et rendue en littéral a l'ecran. Le defaut est strictement visuel (pas de crash, pas d'erreur Vue).

**Repartition mesuree main :**

| Deck | markdown avale |
|---|---|
| `slides/01-introduction/slides.md` | 1 |
| `slides/06-apprentissage/slides.md` | 39 (dont wrappers `<div v-click="N">`) |
| `slides/S8-semantic-web/slides.md` | 9 (titres `##` apres `<div>`) |

## Fix : une ligne vide par hit

Pour chaque ligne signalee par le scanner, j'insere une ligne vide **avant** la ligne (donc apres la balise ouvrante). Aucun autre changement de contenu. Cas fondateur (slides/06-apprentissage/slides.md:286) :

**Avant :**
```
<div v-click="2">
- **Tri des symboles selon**
  - la frequence
```

**Apres :**
```
<div v-click="2">

- **Tri des symboles selon**
  - la frequence
```

49 insertions `--` 1 ligne / hit :
- `slides/01-introduction/slides.md` : +1 ligne
- `slides/06-apprentissage/slides.md` : +39 lignes
- `slides/S8-semantic-web/slides.md` : +9 lignes

Apres le fix, le scanner source re-render en main signale : **`total: 0 line(s)`**. Acceptation substance verifiee firsthand.

## Outillage : `fix_slides_html_block_markdown.py`

Cette PR inclut un script de fix qui **consomme la sortie du scanner source** et applique les insertions en place :

- `--scanner-output <path>` : lit la sortie deja capturee (permet de brancher un CI gate).
- Par defaut : innonque le scanner source en sous-process, lit `slides/`.
- `--apply` : modifie les fichiers EN PLACE. **Defaut : dry-run.**
- Le split utilise `split('\n')` (aligne sur le scanner source) et non `splitlines()` : un `\v` dans le fichier decale les index de 1 sinon (leçon c.574).
- L'open/write utilisent `newline=''` : preservent les LF du repo (cf leçon c.452 eol-lf, sans quoi le diff explose a 8000+ lignes en re-line-ending sur Windows).
- Les hits sont traites **en ordre DECROISSANT** : l'insertion haute ne decale pas les index suivants.
- Sortie : chemin + ligne 1-based du fichier ORIGINAL pour logging.

### Tests (8 nouveaux, pytest verts)

`scripts/notebook_tools/tests/test_fix_slides_html_block_markdown.py` couvre : parser de la sortie scanner, sanity check `would_insert_blank` (opening_tag sans ligne vide, ligne deja vide, ligne 1), `apply_fix` (insertion correcte + ordre decroissant + dry-run n'ecrit pas + idempotence sur fichier deja repare + trailing newline).

Aucune regression sur le scanner source : `scan_slides_html_block_markdown` + son `test_scan_slides_html_block_markdown` (15 tests) toujours verts. **23 tests au total, tous verts.**

## Document de reference elargi

`docs/reference/slides-layout-pattern.md` (doc deja existant, ajoute la section "Generalisation : tout wrapper HTML sur sa ligne ouvre un bloc"). Cite les **trois coupables recurrents** :

- `<div class="grid grid-cols-N ...">` (layout grille, deja connu).
- **`<div v-click="N">`** (wrapper d'animation incremental Slidev, nouveau coupable principal).
- `<div class="dense-list">`, `<div class="columns">` et autres utilitaires de mise en page.

Donne le **compte rendu main** au 2026-08-27 (49 sur 36 decks), marque la regle **praticienne** (apres tout `<div>` ouvrant seul sur sa ligne, poser systematiquement une ligne vide avant la premiere ligne markdown suivante), et pointe le detecteur dedie qui evite le piege « invisible aux scanners de composition ».

## Acceptance #13216

- [x] 0 markdown avalé sur les trois decks, mesuré et cité : 49 → 0 (verifié firsthand par re-run du scanner source post-fix).
- [x] Les 7 occurrences saines de `S3-acculturation` non touchées (le scanner source les exclut de son rapport ; le fix script ne touche que les lignes rapportées par le scanner).
- [ ] Trois slides réparées rendues et regardées, une par deck : **reporté** (cette lane ne voit pas ; routage vision requis, MiniMax/ai-01). Verifiable après le merge par un deck-build de chacun des trois decks touchés.
- [x] La règle de ligne vide écrite dans `slides-layout-pattern.md` (section « Generalisation »).

## Diff

```diff
 docs/reference/slides-layout-pattern.md                       |  22 ++
 scripts/notebook_tools/fix_slides_html_block_markdown.py      | 181 +++++++++
 scripts/notebook_tools/tests/test_fix_slides_html_block_markdown.py | 158 +++++++
 slides/01-introduction/slides.md                              |   1 +
 slides/06-apprentissage/slides.md                             |  39 ++
 slides/S8-semantic-web/slides.md                              |   9 +
 6 paths changed, 410 insertions(+)
```

**Substance uniquement : 49 lignes ajoutees sur 3 decks.** L'outillage (fix script + tests) et la doc forment **un seul bundle coherent** (le script est le seul consommateur de la sortie du scanner sur ce depot, et la doc est la regle praticienne que le script materialise).

## Hors scope

- **Le scanner source** (`scan_slides_html_block_markdown.py` + ses tests, +306 lignes) est **livre separement par PR #13218** par une autre lane. Ma PR **consomme** cette sortie sans la dupliquer : le script `fix_*` parse la sortie texte, pas le scanner lui-même. Si #13218 merge avant ma PR, aucun conflit (scope disjoint). Si ma PR merge avant #13218, ma PR reste valide -- le scanner source s'ajoutera par-dessus.
- **Substance des 10 occurrences de #13096 sustained** : PR #13096 tranche 10 a deja re-integre la ligne vide sur ses 10 homologues (cf commentaire dans #13216). Ma PR traite les 49 restants.
- **Pas d'integration CI** : ce script est un outil de substance ponctuel, pas un gate de merge. Le scanner source (PR #13218) est ce qui peut servir de gate future.

## Tests

```
$ python -m pytest scripts/notebook_tools/tests/test_fix_slides_html_block_markdown.py scripts/notebook_tools/tests/test_scan_slides_html_block_markdown.py -v
============================= 23 passed in 0.24s ==============================
```

Aucune régression sur l'ensemble `scripts/notebook_tools/tests/` : **5055 passed, 2 skipped** (run complet 3min32).

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com)

