### PR TITLE
docs(lean,#13212): arbitrage calibrations Epic 1453 — verdict GARDER AUTONOME, frontière documentée

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.md
@@ -67,6 +67,7 @@ flowchart LR
 
 - Ce module benchmark la capacité du prouveur Lean multi-agents à clore des preuves de type manuel
 - Toutes les cibles sont désormais fermées ; le module est conservé comme suite de régression permanente pour les changements du prouveur
+- **Frontière avec `grothendieck_lean/Grothendieck/Calibration.lean`** (arbitrage #13212 : **GARDER AUTONOME**) — ce lake est le consommable effectif du harnais (paths codés dans `agent_tests/prover/config.py`, cibles C-F sur la taxonomie P1-P5). Le module Grothendieck (Partie 5 de l'hommage, `trivial_le_discrete`/`pullback_top`/`zariski_eq_pretopology`/`isSheaf_trivial`) porte 4 cibles de micro-preuve dans le même esprit mais sur la topologie catégorique, consommées uniquement par `Lean-15b` : zéro déclaration partagée, zéro import partagé, consommateurs disjoints. Consolider ferait porter `CategoryTheory.Sites` + `BigZariski` au lake de calibration (god-lake, coût build/cache #4362).
 - Vérification : comptage code-level (docstrings `/-- ... -/` et commentaires `-- ...` strippés) = **0** `sorry` en production (cf [README Lean](../Lean-1-Setup.ipynb)). NB : le `grep -nE '^[^/]*\bsorry\b' Calibration/Nash.lean` naïf retourne **3** correspondances sur main — toutes en prose dans la docstring de la cible F (L90/96/97), pas des termes de preuve
 
 ## Conclusion

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -71,7 +71,9 @@ is its measuring instrument.
 3) tie the tour back to the original algebraic geometry, with the bridge
 theorem `zariski_topology_eq`. On the library side, the Mathlib map (Part 4,
 a `#check` index) states honestly what exists and what is missing, and
-`Calibration.lean` (Part 5) feeds the prover harness (Epic #1453).
+`Calibration.lean` (Part 5) reuses the prover harness calibration taxonomy
+(Epic #1453, P1-P4) without being consumed by it: the harness's live targets
+live in `calibration_lean/` (HARNESS class, boundary arbitrated in #13212).
 
 **The categorical foundations** (Parts 24-32). Yoneda, adjunctions, monads,
 comma categories, (co)limits, equivalences, Kan extensions, monoidal
@@ -100,7 +102,7 @@ sub-modules are Parts 20, 22, and 23 of the table.
 | 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 196 |
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 139 |
 | 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | `#check` index of Grothendieck-related Mathlib definitions | 124 |
-| 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 95 |
+| 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 micro-proof targets in the spirit of the prover harness (Epic #1453, not consumed by it — cf `calibration_lean/`, boundary #13212) | 95 |
 | 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities (7): `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 253 |
 | 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 231 |
 | 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Topology ordering, covering closure, sieve composition | 208 |

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -73,7 +73,10 @@ Mayer-Vietoris et Čech — en est l'instrument de mesure.
 (Parties 2, 3) relient la visite à la géométrie algébrique d'origine, avec le
 théorème-pont `zariski_topology_eq`. Côté bibliothèque, la carte Mathlib
 (Partie 4, index `#check`) dit honnêtement ce qui existe et ce qui manque, et
-`Calibration.lean` (Partie 5) alimente le harnais du prouveur (Epic #1453).
+`Calibration.lean` (Partie 5) reprend la taxonomie d'étalonnage du harnais
+prouveur (Epic #1453, P1-P4) sans être consommée par lui : les cibles
+effectives du harnais vivent dans `calibration_lean/` (classe HARNESS,
+frontière arbitrée #13212).
 
 **Les fondations catégorielles** (Parties 24-32). Yoneda, adjonctions,
 monades, catégories comma, (co)limites, équivalences, extensions de Kan,
@@ -103,7 +106,7 @@ La formalisation couvre **55 modules leaf** + **1 umbrella** `Grothendieck.lean`
 | 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 196 |
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 139 |
 | 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 124 |
-| 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 cibles de micro-preuve pour le harnais du prouveur (Epic #1453) | 95 |
+| 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 cibles de micro-preuve dans l'esprit du harnais prouveur (Epic #1453, non consommées par lui — cf `calibration_lean/`, frontière #13212) | 95 |
 | 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles (7) : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 253 |
 | 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 231 |
 | 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 208 |


### PR DESCRIPTION
## Summary

Arbitrage de consolidation (au sens strict — ANALYSER/DÉCIDER, merge seulement si justifié) des deux ensembles de calibration du harnais prover Epic #1453. **Verdict : GARDER AUTONOME** — zéro chevauchement, consommateurs disjoints, consolidation = god-lake. Frontière documentée dans les READMEs des deux lakes, et le claim « alimente/feeds the harness » du README grothendieck corrigé en « reprend la taxonomie, non consommée par lui » (grep : 0 référence des 4 noms de théorèmes dans `agent_tests/`, `scripts/`, `.github/`).

## Tableau déclaration-par-déclaration (acceptance #1)

**`calibration_lean/`** (classe HARNESS, toolchain v4.32.1, 0 sorry) — 3 feuilles + racine agrégateur, 33 déclarations, deps légères :

| Module | Déclarations | Finalité |
|--------|--------------|----------|
| `Calibration/Doomsday.lean` (135 l., 16 decls) | `DayOfWeek`, `toFin/ofFin/add/sub`, `isLeapYear`, `centuryAnchor`, `doomsday`, `dayOfWeek` + theorems (`conway_death_day`, `sep11_day`, `dayOfWeek_add_seven`…) | Calendrier Conway — support des cibles + hommage |
| `Calibration/Nash.lean` (103 l., 10 decls) | `Game2x2`, `strictlyDominates1`, `isPureNashEquilibrium`, `prisonersDilemma`, `Cooperer/Trahir` + **cibles C/D/E/F** : `strictly_domin_defect_pd` (P3), `pd_defect_is_pure_ne` (P2), `pd_cooperate_not_ne` (P1+P2), `pd_defect_is_ne_decomposable` (P4) | Cibles effectives du harnais, taxonomie P1-P5, suite de régression |
| `Calibration/Nim.lean` (67 l., 7 decls) | `nimSum`, `isWinningNim` + theorems (`nim_winning_345`, `nimSum_self_cancel`…) | Théorie combinatoire, support calibration |

**`grothendieck_lean/Grothendieck/Calibration.lean`** (Partie 5 de l'hommage, 95 l., 4 decls, REF) — `trivial_le_discrete`, `pullback_top`, `zariski_eq_pretopology`, `isSheaf_trivial` : topologie catégorique, imports lourds (`Mathlib.CategoryTheory.Sites.Grothendieck` + `AlgebraicGeometry.Sites.BigZariski`).

**Correspondance : 0 déclaration partagée, 0 import partagé.**

## Consommateurs (mesurés, pas supposés)

- `calibration_lean` : harnais prover (`agent_tests/prover/config.py` l.206-220, paths codés) + `Lean-26-Calibration-Native-Companion.ipynb` (`import Calibration.*`).
- `Grothendieck.Calibration` : **uniquement** `Lean-15b-Lean-Grothendieck.ipynb` (`import Grothendieck.Calibration`). 15c/15/25/23 : mentions prose uniquement. Harnais : 0 référence (grep cibles + `Grothendieck` dans `agent_tests/prover/` = vide).

## Verdict : GARDER AUTONOME (acceptance #2)

1. Rien à merger (0 chevauchement) — la « proximité de finalité » est réelle (les deux citent Epic #1453 et la taxonomie P) mais le contenu est disjoint.
2. Déplacer `Grothendieck/Calibration.lean` vers `calibration_lean` ferait porter `CategoryTheory.Sites` + `BigZariski` à chaque build de calibration du harnais (coût build/cache, god-lake interdit par #4362) et orphelinerait la Partie 5 du récit d'hommage (tableau 55 modules).
3. Déplacer `calibration_lean` vers grothendieck : absurde (cibles génériques, harnais câblé dessus).
4. La calibration Grothendieck spécifique n'est **pas aplatie** (acceptance #4) — son statut de micro-preuves topologiques est documenté tel quel.

## Acceptance

- [x] Tableau déclaration-par-déclaration (ci-dessus).
- [x] Verdict explicite : **GARDER AUTONOME**.
- [x] Aucun déplacement/suppression (0 move) → builds N/A ; les deux lakes restent à leur statut documenté (LEAN_INVENTORY : groth 0 sorry/23 modules REF ; calibration 0 sorry/3 modules HARNESS).
- [x] Calibration Grothendieck préservée spécifique.
- [x] Companions inchangés et fonctionnels (Lean-26 → calibration_lean, Lean-15b → Grothendieck.Calibration — chacun pointe déjà sa source canonique ; diff = 3 READMEs, 0 notebook).
- [x] Gain réel documenté : éviter le god-lake (deps lourdes dans le lake de calibration) + frontière explicite contre la re-question (cette issue ne reviendra pas).

## Audit §E fichier entier

- groth README FR/EN : « 55 modules leaf + 1 umbrella » — disque = 55 `.lean` hors `_en` ✓ ; table des Parties intacte (seule la ligne 5 modifiée) ; l.202/196 (« relie la formalisation à l'effort de preuve plus large ») laissées — lien narratif honnête.
- calibration README : 4 modules (racine + 3 feuilles) = disque ✓ ; cibles C-F = déclarations Nash.lean ✓ ; toolchain v4.32.1 vs LEAN_INVENTORY l.21 « v4.31.0-rc1 » — **inventaire stale sur cette ligne** (le README documente la bump #11307/#11325), signalé ici, correction hors scope de cette PR docs.
- Pas de bloc CATALOG-STATUS dans ces READMEs ; catalogue repo-root non touché.

See #13212
Closes #13212
See #13121 (audit passe 1), See #4362 (anti-prolifération)

Grain: DEEP/lean-analysis — lane myia-po-2026:CoursIA — prev: LIGHT/docs-lean #13229

🤖 Generated with [Claude Code](https://claude.com/claude-code)