### PR TITLE
fix(ci,#13217): drop setup-python from windows-self-hosted-tests, use machine Python

### DIFF
--- a/.github/workflows/windows-self-hosted-tests.yml
+++ b/.github/workflows/windows-self-hosted-tests.yml
@@ -33,10 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
+      # #13217 : pas de actions/setup-python ici — il deroule un setup.ps1
+      # que l'ExecutionPolicy du compte service runner refuse (UnauthorizedAccess)
+      # et telecharge un interpreteur ~50 s que la machine a deja. Le Python du
+      # PATH du compte service est utilise tel quel ; pip install pytest est
+      # idempotent (no-op si deja present).
       - name: Install test dependencies
         run: python -m pip install pytest
 


### PR DESCRIPTION
## Summary

Option **(b)** de #13217 : suppression du step `actions/setup-python@v5` de `windows-self-hosted-tests.yml`. Le Python du PATH du compte service runner est utilisé tel quel ; `python -m pip install pytest` reste (idempotent — no-op si déjà présent).

**Pourquoi** : le step mourait dans son `setup.ps1` sous l'ExecutionPolicy du compte service (`UnauthorizedAccess`, runs 10:22Z **et** 14:55Z — re-vérifié firsthand : même step, même `setup.ps1`), en consommant ~50 s des 59 s du job pour télécharger un interpréteur.

## Validation — mesure obtenue, dépendance machine identifiée

- `workflow_dispatch` sur cette branche : **run 33087876304** pris par un runner ré-enregistré à 16:00:59Z (job 16 s). **FAIL à `Install test dependencies` : `python` n'est pas dans le PATH du compte service** (`The term 'python' is not recognized`). 
- Lecture : (b) repo-side seul ne suffit pas — le compte dédié (profil distinct, `manage_self_hosted_runner.py install`) n'a aucun Python accessible. Provisioning flotte : python/py.exe = installs per-user sous AppData (vérifié sur po-2026), hors PATH système et hors ACL du compte service.
- **Cette PR est la branche (a1) du playbook posté sur #13217 (issuecomment-5441828759)** : elle devient verte dès que po-2024 installe un Python all-users visible du compte service (UAC, 1 passe batchée — règles dispatch 27/08). Si po-2024 préfère la variante (a2) — seed du tool-cache runner, sans UAC — alors **cette PR doit être fermée** (setup-python reste, cache hit ~1-3 s) : la décision appartient au owner machine, les deux chemins documentés.
- Acceptance (run vert + 9 tests `@requires_windows` + <30 s) : à coller dès (a1) posé. Issue ouverte jusqu'à preuve verte.

## Preuves

- Run 14:55Z `--log-failed` : `setup.ps1:127 Throw "Error happened during Python installation"`, exit powershell.exe 1.
- Run 33087876304 (cette branche) : `python` introuvable compte service — 2ᵉ mesure, déplacement propre de l'échec au step attendu.
- Diff : 1 workflow, +5/−4 (un step supprimé, commentaire why).

See #13217, See #12704, See #13097

Grain: MED/ci-infra — lane myia-po-2026:CoursIA — prev: DEEP/lean-analysis #13231

🤖 Generated with [Claude Code](https://claude.com/claude-code)