### PR TITLE
fix(scripts,#12858): detect_code_in_markdown_cells --json stdout is now pure JSON, baseline identity on stderr

### DIFF
--- a/scripts/notebook_tools/detect_code_in_markdown_cells.py
+++ b/scripts/notebook_tools/detect_code_in_markdown_cells.py
@@ -465,7 +465,9 @@ def main(argv=None) -> int:
     baseline_path = args.baseline if args.baseline else DEFAULT_BASELINE
     baseline = load_baseline(baseline_path)
     if not args.update_baseline:
-        print(f"baseline: {baseline_path} ({len(baseline)} entries)")
+        # #12858 : la ligne d'identite part sur stderr -- stdout doit rester
+        # pur en mode --json (consommateurs : jq, scripts CI en pipe, etc.).
+        print(f"baseline: {baseline_path} ({len(baseline)} entries)", file=sys.stderr)
     new_findings = [f for f in findings
                     if _finding_hash(f) not in baseline] if baseline else findings
 

--- a/scripts/notebook_tools/tests/test_detect_code_in_markdown_cells.py
+++ b/scripts/notebook_tools/tests/test_detect_code_in_markdown_cells.py
@@ -194,7 +194,8 @@ def test_check_without_baseline_defaults_to_canonical_rc0():
     Avant le fix, l'invocation desarmee rendait un FAIL fantome sur un main
     vert -- toutes les violations acceptees ressortaient « new ». Le test
     existant passait le chemin explicitement, donc ne pouvait pas voir ce
-    defaut. Exige en outre la ligne d'identite qui nomme la reference."""
+    defaut. Exige en outre la ligne d'identite qui nomme la reference.
+    #12858 : la ligne d'identite part sur stderr (stdout reste pur)."""
     import subprocess
     proc = subprocess.run(
         [
@@ -210,9 +211,39 @@ def test_check_without_baseline_defaults_to_canonical_rc0():
         f"bare --check exited {proc.returncode}\n"
         f"stdout: {proc.stdout[:500]}\nstderr: {proc.stderr[:500]}"
     )
-    assert "baseline:" in proc.stdout and "entries)" in proc.stdout, (
-        "l'identite de la reference doit etre affichee "
-        f"(baseline: <path> (<n> entries)); stdout: {proc.stdout[:300]}"
+    assert "baseline:" in proc.stderr and "entries)" in proc.stderr, (
+        "l'identite de la reference doit etre affichee sur stderr "
+        f"(baseline: <path> (<n> entries)); stderr: {proc.stderr[:300]}"
+    )
+
+
+def test_json_mode_stdout_is_pure_json_baseline_on_stderr():
+    """#12858 : en mode ``--json``, stdout doit etre du JSON pur
+    (consommable par ``jq`` ou tout parser), tandis que la ligne d'identite
+    baseline va sur stderr. Avant ce fix, stdout etait pollue par la ligne
+    ``baseline: <path> (<n> entries)`` qui cassait le parse JSON."""
+    import subprocess
+    import json
+    proc = subprocess.run(
+        [
+            sys.executable, str(TOOL),
+            "MyIA.AI.Notebooks",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    # stdout doit etre du JSON valide de bout en bout (pas de ligne parasite)
+    assert proc.stdout, "stdout vide en mode --json"
+    parsed = json.loads(proc.stdout)  # leve json.JSONDecodeError si pollue
+    assert isinstance(parsed, dict), "le JSON doit etre un objet racine"
+    for key in ("total", "new", "baseline_size", "findings"):
+        assert key in parsed, f"cle {key!r} manquante dans le JSON: {parsed.keys()}"
+    # la ligne d'identite reste sur stderr (operateur humain)
+    assert "baseline:" in proc.stderr and "entries)" in proc.stderr, (
+        "l'identite de la reference doit etre affichee sur stderr ; "
+        f"stderr: {proc.stderr[:300]}"
     )
 
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/slides #13230 (c.574)

fix(scripts,#12858): detect_code_in_markdown_cells --json stdout is now pure JSON, baseline identity on stderr

See #12858.

## Origine

`detect_code_in_markdown_cells.py` imprime une ligne d'identité `baseline: <path> (<n> entries)` sur **stdout** avant le `json.dumps(...)` du mode `--json`. La sortie stdout n'est donc plus du JSON pur, ce qui casse tout consommateur en aval (`jq`, scripts CI en pipe, parse Python).

Hermes a releve ce concern en review de #12779 (declare non-bloquant et ouvert avant le merge conformement a CLAUDE.md §B.0). Le fix demande : "stderr-baseline-line au lieu de stdout".

## Fix

Deplace la ligne d'identite baseline de stdout vers stderr. stdout reste reserve a la sortie structuree (JSON en mode `--json`, format humain en mode `--report`). stderr reste le canal operateur humain, compatible avec `2>/dev/null` ou redirection separee.

Code (`scripts/notebook_tools/detect_code_in_markdown_cells.py:468`) :

```python
# #12858 : la ligne d'identite part sur stderr -- stdout doit rester
# pur en mode --json (consommateurs : jq, scripts CI en pipe, etc.).
print(f"baseline: {baseline_path} ({len(baseline)} entries)", file=sys.stderr)
```

## Tests

`scripts/notebook_tools/tests/test_detect_code_in_markdown_cells.py` :

1. **Nouveau** `test_json_mode_stdout_is_pure_json_baseline_on_stderr` : lance `--json MyIA.AI.Notebooks`, verifie que stdout est parsable par `json.loads()` (objet racine avec cles `total`, `new`, `baseline_size`, `findings`) et que stderr contient la ligne `baseline: ...`.

2. **Mise a jour** `test_check_without_baseline_defaults_to_canonical_rc0` : la ligne d'identite est maintenant attendue sur stderr (`assert "baseline:" in proc.stderr`) au lieu de stdout.

**12/12 tests passent** dans `test_detect_code_in_markdown_cells.py`. Suite `scripts/notebook_tools/tests/` complete : **5050 passed, 2 skipped** (run 3min30, aucune regression).

## Diff

```diff
 scripts/notebook_tools/detect_code_in_markdown_cells.py            |  4 ++-
 scripts/notebook_tools/tests/test_detect_code_in_markdown_cells.py | 39 +++++++++++++++++++---
 2 files changed, 38 insertions(+), 5 deletions(-)
```

## Hors scope

- **Aucun consommateur externe** de `detect_code_in_markdown_cells.py` n'a ete trouve dans le repo (`grep -rn` sur `scripts/` et `.github/`). Le seul caller est le test lui-meme, qui est mis a jour ici.
- **Le mode `--check`** continue d'ecrire ses messages `FAIL:` sur stderr (comportement pre-existant, inchange). Seule la ligne d'identite baseline a ete deplacee.

## Acceptance #12858

- [x] Sortie `--json` est du JSON pur sur stdout (verifie par `json.loads(stdout)`).
- [x] Ligne d'identite baseline deplacee sur stderr.
- [x] Test pytest couvre les deux flux (stdout JSON pur + stderr baseline line).
- [x] Aucune regression sur la suite notebook_tools (5050 tests verts).

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com)
