### PR TITLE
fix(ci,#13238): allow runner-own checkout under _work in root-outside-repo invariant

### DIFF
--- a/scripts/ci/manage_self_hosted_runner.py
+++ b/scripts/ci/manage_self_hosted_runner.py
@@ -158,7 +158,11 @@ def _validate_profile(name: str, raw: Any) -> Profile:
     log_root = _canonical_absolute(raw["log_root"], "log_root")
     if not _is_within(work, root):
         raise Refused(f"profile {name!r} work directory must be below its runner root")
-    if _is_within(root, REPO_ROOT) or _is_within(REPO_ROOT, root):
+    if _is_within(root, REPO_ROOT):
+        raise Refused(f"profile {name!r} runner root must be outside the repository")
+    # Le checkout du runner lui-meme vit par construction sous <root>/_work :
+    # la clause REPO_ROOT-sous-root ne doit refuser que HORS de la zone work (#13238).
+    if _is_within(REPO_ROOT, root) and not _is_within(REPO_ROOT, work):
         raise Refused(f"profile {name!r} runner root must be outside the repository")
     sensitive = raw["sensitive_paths"]
     if (

--- a/scripts/tests/test_manage_self_hosted_runner.py
+++ b/scripts/tests/test_manage_self_hosted_runner.py
@@ -173,6 +173,7 @@ def test_committed_profiles_are_valid_and_distributed_across_pushers():
         assert loaded.archive_sha256 == "d59123a43003e357b0805b5d0f611d0bd2f65ab67d51bd070dd4e7a0f685c162"
 
 
+@requires_windows
 def test_profile_accepts_runner_own_checkout_under_work(tmp_path, monkeypatch):
     # #13238 : sur le runner lui-meme, le checkout vit sous <root>/_work —
     # l'invariant "root hors du repository" ne doit pas le refuser.
@@ -184,6 +185,7 @@ def test_profile_accepts_runner_own_checkout_under_work(tmp_path, monkeypatch):
     assert loaded.name == "test"
 
 
+@requires_windows
 def test_profile_refuses_repository_inside_runner_root_outside_work(tmp_path, monkeypatch):
     # Repo sous la racine runner mais HORS de la zone work : toujours refuse.
     registry = tmp_path / "profiles.json"

--- a/scripts/tests/test_manage_self_hosted_runner.py
+++ b/scripts/tests/test_manage_self_hosted_runner.py
@@ -173,6 +173,27 @@ def test_committed_profiles_are_valid_and_distributed_across_pushers():
         assert loaded.archive_sha256 == "d59123a43003e357b0805b5d0f611d0bd2f65ab67d51bd070dd4e7a0f685c162"
 
 
+def test_profile_accepts_runner_own_checkout_under_work(tmp_path, monkeypatch):
+    # #13238 : sur le runner lui-meme, le checkout vit sous <root>/_work —
+    # l'invariant "root hors du repository" ne doit pas le refuser.
+    registry = tmp_path / "profiles.json"
+    root = r"C:\CoursIA-Test\runner"
+    write_registry(registry, root)
+    monkeypatch.setattr(mod, "REPO_ROOT", Path(root) / "_work" / "CoursIA")
+    loaded = mod.load_profile("test", registry)
+    assert loaded.name == "test"
+
+
+def test_profile_refuses_repository_inside_runner_root_outside_work(tmp_path, monkeypatch):
+    # Repo sous la racine runner mais HORS de la zone work : toujours refuse.
+    registry = tmp_path / "profiles.json"
+    root = r"C:\CoursIA-Test\runner"
+    write_registry(registry, root)
+    monkeypatch.setattr(mod, "REPO_ROOT", Path(root) / "repo")
+    with pytest.raises(mod.Refused, match="outside the repository"):
+        mod.load_profile("test", registry)
+
+
 def test_profile_rejects_unknown_keys(tmp_path):
     registry = tmp_path / "profiles.json"
     root = r"C:\CoursIA-Test\runner"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-python #12653

## Summary

- `test_committed_profiles_are_valid_and_distributed_across_pushers` échoue **sur le runner Windows self-hosted lui-même** (premier run réel de la machinery, run 33092567324 : 39 passed / 1 failed) : la clause `_is_within(REPO_ROOT, root)` de la validation de profil est toujours vraie quand le checkout vit sous `<root>/_work` — par construction sur le runner.
- Fix : la clause ne refuse `REPO_ROOT` sous la racine runner que **hors de la zone `work`** (l'endroit désigné pour les checkouts). Le sens de l'anti-footgun est préservé : un repo sous la racine runner hors `_work` reste refusé.
- 2 tests ajoutés (monkeypatch `REPO_ROOT`) : checkout-own-runner sous `_work` accepté ; repo sous root hors work refusé.

## Validation

- Local (Windows, po-2024) : `pytest scripts/tests/test_manage_self_hosted_runner.py -q` → **42 passed in 5.37s** (40 précédents + 2 nouveaux).
- **Re-dispatch du workflow sur cette branche (preuve end-to-end sur le runner)** : résultat collé ci-dessous après exécution.

## Contexte

- Découvert pendant l'acceptance D de #12704 (one-shot green du runner ephemeral po-2024) — ce run prouve la machinery (pickup, checkout, setup-python cache-hit, pip, pytest) ; cette PR ferme le dernier rouge.
- Machine-side (po-2024, sans UAC supplémentaire) : tool-cache `_work/_tool/Python/3.11.9/x64` peuplé (python.org per-user install + robocopy as coursia-runner) + stamp `x64.complete` → `setup-python@v5` passe en cache local, zéro téléchargement. C'est la variante (a2) du playbook de #13217.

Closes #13238
