### PR TITLE
docs(lean,#13214): reconciler archi mimo_lean -- phases lakefile vs README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/README.md
@@ -148,7 +148,7 @@ combinent ces queues par union bound sur les `N` colonnes du canal.
 
 ## Companion canonique
 
-Le compagnon natif est **[Lean-22b-MIMO-Converse-Native.ipynb](../../../../Lean-22b-MIMO-Converse-Native.ipynb)**
+Le compagnon natif est **[Lean-22b-MIMO-Converse-Native.ipynb](../Lean-22b-MIMO-Converse-Native.ipynb)**
 (kernel `lean4-wsl`) — il visite les 35 déclarations de `NormTails` /
 `Converse` / `Bridge`, chacune interrogée par `#check` et sondée par
 `#print axioms` sur les théorèmes clés. Trois axiomes standards, zéro

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/README.md
@@ -2,19 +2,54 @@
 
 Port formel de l'algorithme de détection MIMO par flips de coordonnées
 (Papailiopoulos, 2026 — issue #10984). Le lake naît directement sur
-`v4.32.0` (migration #10986 terminée) et suit la convention i18n #4980
+`v4.32.1` (Mathlib résolu à `520045ab14e26149ee970e2e617ca04b09bde5d6`,
+fin de la migration #10986) et suit la convention i18n #4980
 (docstrings FR par défaut, sibling `_en` avec namespace `Mimo_en`).
 
-## Phases
+## Phases et libs compilées
 
-| Phase | Livrable | Statut |
-|-------|----------|--------|
-| 1 | `Descent.lean` — squelette abstrait de la Proposition 9.1, **sans dépendance** (cœur Lean) | livré |
-| 2 | `Objective.lean` — fonction objectif au carré avec Mathlib : Lemme 11.1 (coût d'un flip `4·(s·‖hᵢ‖² + √s·⟪hᵢ,w⟫)`) + boucle de contrôle `flip_accepted_iff` | livré |
-| 3a | `Lmmse.lean` — **Lemme 5.1** (erreur LMMSE) : `E‖b − x*‖² = tr(B_ρ)`, `B_ρ = (I + s·HᵀH)⁻¹` — formule de la trace gaussienne + transport de loi | livré |
-| 3b | `Converse.lean` — converse §11 : briques probabilistes via le lake externe [YuanheZ/lean-stat-learning-theory](https://github.com/YuanheZ/lean-stat-learning-theory) (v4.32.0, Apache 2.0) : intervalles gaussiens + union bound + Hanson–Wright + assemblage | livré |
+Six `lean_lib` déclarées dans `lakefile.lean`, chacune avec son sibling EN
+et associée à une phase du papier §11 :
 
-## Phase 1 — ce qui est prouvé
+| Phase | Lib              | Livrable                                                              | Statut |
+|-------|------------------|-----------------------------------------------------------------------|--------|
+| 1     | `Descent`        | Proposition 9.1 abstraite — descente à flips, sans dépendance         | livré  |
+| 2     | `Objective`      | Lemme 11.1 — forme fermée du coût d'un flip + boucle `flip_accepted_iff` | livré  |
+| 3a    | `Lmmse`          | Lemme 5.1 — erreur LMMSE `E‖b − x*‖² = tr B_ρ`                         | livré  |
+| 3b    | `Converse`       | Converse §11 — Hanson–Wright + union bound + gaussian PDF            | livré  |
+| 4     | `Bridge`         | Pont ML ↔ converse — identité de différence de coût (`cost_diff`)     | livré  |
+| 5     | `NormTails`      | Queues de normes `‖w‖`, `‖hᵢ‖` — concentration 1-Lipschitz gaussienne | livré  |
+
+Les Phases 4 et 5 sont les grains à grignoter de l'issue **#11148** (suite
+de #10984) — modules portant une **substance propre** mais hors-périmètre
+du premier découpage.
+
+## Build
+
+```bash
+cd MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean
+lake build   # 6 libs × 2 namespaces (Mimo + Mimo_en) — Descent (cœur,
+             # instantané) + Objective/Lmmse/Converse/Bridge/NormTails
+             # (Mathlib + SLT requis)
+```
+
+CI : `lean-mimo.yml` (baseline sorry = 0, filtre standalone-tactic — cf les
+autres lakes du dépôt).
+
+## Dépendances externes
+
+| Lake           | Source                                                                  | Pin                                       | Consommé par                       |
+|----------------|-------------------------------------------------------------------------|-------------------------------------------|------------------------------------|
+| **mathlib4**   | github.com/leanprover-community/mathlib4.git                            | `v4.32.1` (résolu `520045ab…`)            | Objective, Lmmse, Converse, Bridge, NormTails |
+| **slt**        | github.com/YuanheZ/lean-stat-learning-theory.git (Apache 2.0)           | `d0f506f0a695018265dccb33bcb05e2f5ca1c876` | Converse (Hanson–Wright), NormTails (Lipschitz) |
+
+Le pin SLT est **identique** à `lake-manifest.json` — la `require` ne dérive
+pas. Aucune mise à jour de SLT n'est prévue sans revue dédiée (sécurité de
+la frontière formelle).
+
+## Inventaire détaillé des phases
+
+### Phase 1 — `Descent.lean` (sans dépendance, instantané)
 
 Le théorème phare `Mimo.descent_target_before_ceiling` est la forme abstraite
 de la Proposition 9.1 : sous (i) stricte décroissance du coût à chaque flip
@@ -22,94 +57,114 @@ accepté, (ii) confinement du coût sous une barrière `B`, (iii) absence de
 point bloquant hors cible, tout run **terminal** atteint la cible en
 **strictement moins de `M_N` flips** (plafond).
 
-Quatre lemmes intermédiaires, chacun autonome :
+Quatre lemmes intermédiaires :
 
 1. `run_tail_cost_lt` — la décroissance stricte se propage à toute la queue ;
 2. `run_nodup` — un run ne revisite jamais un état ;
 3. `run_length_le_cost` — le nombre de flips est majoré par le coût initial
-   (le « budget de descente ») ;
+   (« budget de descente ») ;
 4. `descent_flips_le_barrier` — sous la barrière `B`, flips ≤ `B < M_N`.
 
-Le fichier est volontairement **sans `require`** : build en quelques secondes,
-sans téléchargement de Mathlib. Les hypothèses `accept` / `cost` / `target`
-sont abstraites ; la Phase 2 instancie `cost` par la fonction objectif du
-papier (où seuls les flips diminuant l'objectif sont acceptés, ce qui donne
-`hstrict`).
+Pas de `require` : build en quelques secondes, pas de téléchargement Mathlib.
+Les hypothèses `accept` / `cost` / `target` sont abstraites ; Phase 2 les
+instancie sur la fonction objectif du papier.
 
-## Phase 2 — ce qui est prouvé
+### Phase 2 — `Objective.lean` (Mathlib)
 
-`Objective.lean` (twin `Objective_en.lean`, code byte-identique hors
-docstrings) instancie la géométrie du détecteur sur Mathlib :
+Instancie la géométrie du détecteur :
 
-1. `norm_add_sq_two` — Pythagore réel `‖x + y‖² = ‖x‖² + 2⟪x,y⟫ + ‖y‖²`,
-   redérivé des lemmes fondamentaux ;
+1. `norm_add_sq_two` — Pythagore réel `‖x + y‖² = ‖x‖² + 2⟪x,y⟫ + ‖y‖²` ;
 2. `flip_cost` — cœur géométrique **générique** (tout Hilbert réel) :
    `‖w + 2√s•h‖² − ‖w‖² = 4·(s·‖h‖² + √s·⟪h,w⟫)` ;
 3. `mimoObj` / `flipAt` — l'objectif concret `‖w + √s•A u‖²` (canal :
-   application linéaire de l'espace signal `(Fin N → ℝ)` vers l'espace de
-   mesure `EuclideanSpace ℝ (Fin M)`) et le vecteur de déviation `2·eᵢ` ;
-4. `mimo_flip_cost` — **Lemme 11.1** (Papailiopoulos 2026) : forme fermée
-   exacte du coût d'un flip ;
+   application linéaire `Fin N → ℝ → EuclideanSpace ℝ (Fin M)`) ;
+4. `mimo_flip_cost` — **Lemme 11.1** : forme fermée exacte du coût d'un flip ;
 5. `flip_accepted_iff` — la boucle de contrôle : un flip est accepté ssi le
-   score `s·‖hᵢ‖² + √s·⟪hᵢ,w⟫` est strictement négatif — exactement
-   l'hypothèse `hstrict` que consomme la Proposition 9.1 (Phase 1).
+   score `s·‖hᵢ‖² + √s·⟪hᵢ,w⟫` est strictement négatif — l'hypothèse
+   `hstrict` que consomme la Proposition 9.1 (Phase 1).
 
-Axiomes : `propext`, `Classical.choice`, `Quot.sound` (les trois standards
-de Mathlib) — zéro sorry.
+### Phase 3a — `Lmmse.lean` (Mathlib)
 
-## Phase 3a — ce qui est prouvé
+Prouve le **Lemme 5.1** :
 
-`Lmmse.lean` (twin `Lmmse_en.lean`) prouve le **Lemme 5.1** sur Mathlib :
+1. `integral_norm_sq_eq_trace` — **formule de la trace gaussienne** :
+   `E‖x‖² = tr B` pour gaussienne centrée de covariance PSD `B` ;
+2. `B_ρ` / `B_ρ_posSemidef` — la matrice d'erreur LMMSE
+   `(I + s·HᴴH)⁻¹` est PSD dès `s ≥ 0` ;
+3. `lmmse_error_eq_trace` — **Lemme 5.1** : `E‖b − x*‖² = tr(B_ρ)`.
 
-1. `integral_norm_sq_eq_trace` — **formule de la trace gaussienne** : pour
-   une gaussienne centrée de covariance PSD `B`, `E‖x‖² = tr B` (chaque
-   coordonnée contribue sa variance `B i i`, via les marginales
-   `gaussianReal` et `variance_eq_integral`) ;
-2. `B_ρ` / `B_ρ_posSemidef` — la matrice d'erreur LMMSE `(I + s·HᴴH)⁻¹`
-   est PSD dès `s ≥ 0` (`posSemidef_conjTranspose_mul_self` + inverse) ;
-3. `lmmse_error_eq_trace` — **Lemme 5.1** : `E‖b − x*‖² = tr(B_ρ)` par
-   transport de la loi de l'erreur.
+### Phase 3b — `Converse.lean` (Mathlib + SLT)
 
-Axiomes : les trois standards de Mathlib — zéro sorry.
+Briques probabilistes du converse §11, sur le lake externe SLT pinned
+`d0f506f0a695018265dccb33bcb05e2f5ca1c876` :
 
-## Phase 3b — ce qui est prouvé
-
-`Converse.lean` (twin `Converse_en.lean`) pose les briques probabilistes du
-converse §11 (impossibilité sous `2 log N − log log N − s_N`), en s'appuyant
-sur le lake externe SLT (pinned `d0f506f0` — mêmes toolchain et Mathlib que
-mimo, zéro re-téléchargement) :
-
-1. `gaussianPDFReal_lower_two` / `gaussian_interval_mass_lower` — **Brique 1** :
-   la densité `φ ≥ e⁻²/√(2π)` sur `[−2,2]`, donc tout intervalle inclus dans
-   `[−2,2]` porte une masse `≥ largeur·φ(2)` (mécanisme des « intervalles de
-   largeur `1/√ρ₀` » du §11) — domination d'indicateurs + `lintegral_mono` ;
+1. `gaussianPDFReal_lower_two` / `gaussian_interval_mass_lower` —
+   **Brique 1** : densité `φ ≥ e⁻²/√(2π)` sur `[−2,2]`, donc tout
+   intervalle inclus porte une masse `≥ largeur·φ(2)` ;
 2. `one_sub_pow_le_exp_mul` — **Brique 2** : union bound complémentaire
-   `(1−p)^n ≤ e^{−np}` (instance de `one_sub_div_pow_le_exp_neg`) ;
-3. `hasSubgaussianMGF_eval_stdGaussianPi` / `hanson_wright_noise` — **Brique 3** :
-   les coordonnées de `stdGaussianPi n` sont sous-gaussiennes de paramètre `1`
-   (transport du certificat `N(0,1)` via `map_eval_stdGaussianPi`), puis
-   **Hanson–Wright** cas `K = 1` : queue de la forme quadratique centrée
-   `|XᵀAX − E XᵀAX|` (théorème du lake SLT) — la queue chi-square de `‖w‖²`
-   et des formes `hᵢᵀ w` du §11 ;
-4. `gaussian_coordinate_escape_bound` — **assemblage** : par indépendance des
-   coordonnées (`Measure.pi_pi`), `P(w échappe aux n intervalles) = ∏ᵢ(1−mᵢ)
-   ≤ (1−p)^n ≤ e^{−np}` avec `p = ε·φ(2)` — le squelette complet de l'argument
-   d'impossibilité du §11.
+   `(1−p)^n ≤ e^{−np}` ;
+3. `hasSubgaussianMGF_eval_stdGaussianPi` / `hanson_wright_noise` —
+   **Brique 3** : coordonnées de `stdGaussianPi n` sont sous-gaussiennes
+   de paramètre `1`, puis **Hanson–Wright** cas `K = 1` : queue de la forme
+   quadratique centrée `|XᵀAX − E XᵀAX|` (transport depuis le certificat SLT) ;
+4. `gaussian_coordinate_escape_bound` — **assemblage** : par indépendance,
+   `P(w échappe aux n intervalles) = ∏ᵢ(1−mᵢ) ≤ (1−p)^n ≤ e^{−np}` avec
+   `p = ε·φ(2)` — le squelette complet du §11.
 
-Axiomes : les trois standards de Mathlib — zéro sorry.
+### Phase 4 — `Bridge.lean` (Mathlib + Phase 2 + Phase 3b)
 
-## Build
+Pont entre `mimoObj` (Phase 2) et converse (Phase 3b). Résultats phares :
 
-```bash
-cd MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean
-lake build   # Descent (cœur, instantané) + Objective/Lmmse/Converse (Mathlib requis)
+1. `cost_diff` — forme **générique** : dans tout Hilbert réel,
+   `‖w + √s•z + √s•v‖² − ‖w + √s•z‖² = s·‖v‖² + 2√s·⟪w,v⟫ + 2s·⟪z,v⟫` ;
+2. (grain suivant, à livrer) : fragment de converse connecté au décodeur ML.
+
+### Phase 5 — `NormTails.lean` (Mathlib + SLT)
+
+Concentration de Lipschitz gaussienne (`gaussian_lipschitz_concentration`
+du lake SLT, transporté en dépendance pinnée) — pour tout `t > 0` :
+
+```
+P(|‖X‖ − E‖X‖| ≥ t) ≤ 2·exp(−t²/2)
 ```
 
-CI : `lean-mimo.yml` (baseline sorry = 0, filtre standalone-tactic — cf les
-autres lakes du dépôt).
+La norme euclidienne est 1-Lipschitz sur un vecteur gaussien standard.
+C'est la **queue de norme** du §11 : elle borne `‖w‖` et `‖hᵢ‖` qui
+apparaissent dans le score de flip de Phase 2 — les grains suivants
+combinent ces queues par union bound sur les `N` colonnes du canal.
+
+## Frontière formelle : prouvé localement vs emprunté
+
+- **Prouvé localement** (CoursIA) : tout ce qui vit dans les six fichiers
+  `.lean` — Descent, Objective, Lmmse, Converse, Bridge, NormTails —
+  axiomes : `propext`, `Classical.choice`, `Quot.sound` (les trois
+  standards de Mathlib) ;
+- **Emprunté** (SLT) :
+  - `gaussian_lipschitz_concentration` (lake SLT, NormTails) ;
+  - `hanson_wright` (lake SLT, transporté dans `Converse.lean`).
+- **Pas de claim axiomatique nouveau** — tout axiome hors ces deux
+  emprunts doit faire l'objet d'une PR dédiée avec `#print axioms` et
+  revue de la frontière.
+
+## Companion canonique
+
+Le compagnon natif est **[Lean-22b-MIMO-Converse-Native.ipynb](../../../../Lean-22b-MIMO-Converse-Native.ipynb)**
+(kernel `lean4-wsl`) — il visite les 35 déclarations de `NormTails` /
+`Converse` / `Bridge`, chacune interrogée par `#check` et sondée par
+`#print axioms` sur les théorèmes clés. Trois axiomes standards, zéro
+`sorry`, zéro axiome non standard.
+
+Lean-22b **distingue** le prouvé localement (les énoncés de ce lake) de
+l'emprunté (les deux théorèmes SLT rappelés explicitement) — la lecture
+est self-contained, sans confusion de frontière.
 
 ## Voir aussi
 
-- Issue #10984 — spécification et découpage en phases
-- Lakes frères : `learning_theory_lean` (v4.32.0), `kelly_lean`
-- Convention i18n #4980 — `Descent.lean`/`Descent_en.lean`, `Objective.lean`/`Objective_en.lean`, `Lmmse.lean`/`Lmmse_en.lean`, `Converse.lean`/`Converse_en.lean`
+- Issue #10984 — spécification initiale et découpage en phases 1–3
+- Issue #11148 — grains à grignoter 4–5 (Bridge, NormTails)
+- Issue #13121 — passe 1 d'audit CoursIA : `mimo_lean` est **PROPRE
+  COURSIA** (preuve propre, différent d'un portage amont) ;
+  Mathlib 4.32.1 résolu, SLT pinné, `distinct_code_sorry=0`.
+- Lakes frères : `learning_theory_lean` (v4.32.1), `kelly_lean`
+- Convention i18n #4980 — sibling `_en` par fichier,
+  namespace `Mimo_en` côté anglais, byte-identity hors docstrings

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean
@@ -6,22 +6,33 @@ open Lake DSL
 
 Port formel de l'algorithme de détection MIMO par flips de coordonnées
 (Papailiopoulos, 2026 — cf issue #10984). Le lake naît directement sur
-`v4.32.0` (fin de la migration #10986) :
+`v4.32.1` (fin de la migration #10986) — Mathlib résolu à
+`520045ab14e26149ee970e2e617ca04b09bde5d6` (cf `lake-manifest.json`).
 
-- **Phase 1** (`Descent.lean`) : squelette de la Proposition 9.1 — descente à
-  flips sur un espace d'états abstrait, **sans aucune dépendance** (cœur Lean
-  uniquement, build en quelques secondes) : coût strictement décroissant à
-  chaque flip accepté, barrière de confinement, plafond de flips `M_N` ⟹ la
-  cible est atteinte strictement avant le plafond.
-- **Phase 2** (`Objective.lean`, livré) : fonction objectif au carré avec
+Six libs compilées, deux phases utilitaires + quatre phases du papier §11 :
+
+- **Phase 1 / Descent** (`Descent.lean`) : squelette de la Proposition 9.1 —
+  descente à flips sur un espace d'états abstrait, **sans aucune dépendance**
+  (cœur Lean uniquement, build en quelques secondes) : coût strictement
+  décroissant à chaque flip accepté, barrière de confinement, plafond de
+  flips `M_N` ⟹ la cible est atteinte strictement avant le plafond.
+- **Phase 2 / Objective** (`Objective.lean`) : fonction objectif au carré avec
   Mathlib — Lemme 11.1 (coût d'un flip, forme fermée) + boucle de contrôle
   `flip_accepted_iff` (pont avec `hstrict` de la Phase 1).
-- **Phase 3a** (`Lmmse.lean`, livré) : Lemme 5.1 (erreur LMMSE
+- **Phase 3a / Lmmse** (`Lmmse.lean`) : Lemme 5.1 (erreur LMMSE
   `E‖b − x*‖² = tr B_ρ`) — formule de la trace gaussienne, `B_ρ` PSD,
   transport de loi.
-- **Phase 3b** (à venir) : converse §11 — concentration Hanson–Wright du
-  bruit (`‖w‖²` chi-square), union bound `(1−p)^n ≤ e^{−np}`, appui sur le
-  lake externe `YuanheZ/lean-stat-learning-theory` (v4.32.0, Apache 2.0).
+- **Phase 3b / Converse** (`Converse.lean`) : converse §11 — concentration
+  Hanson–Wright du bruit (`‖w‖²` chi-square), union bound
+  `(1−p)^n ≤ e^{−np}`, appui sur le lake externe
+  `YuanheZ/lean-stat-learning-theory` (SLT, pinned
+  `d0f506f0a695018265dccb33bcb05e2f5ca1c876`, Apache 2.0).
+- **Phase 4 / Bridge** (`Bridge.lean`, grignotage #11148) : pont entre
+  `mimoObj` (Phase 2) et converse (Phase 3b) — identité de différence de
+  coût `cost_diff`, fragment de converse connecté au ML.
+- **Phase 5 / NormTails** (`NormTails.lean`, grignotage #11148) : queues de
+  normes `‖w‖`, `‖hᵢ‖` via `gaussian_lipschitz_concentration` du lake SLT
+  — concentration 1-Lipschitz de la norme euclidienne.
 
 Convention i18n #4980 : docstrings FR par défaut, sibling `_en`
 (namespace `Mimo_en`, imports `_en`), énoncés et noms de lemmes en anglais.


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA-2 — prev: MED/guard #13236 (c.575)

docs(lean,#13214): reconciler archi mimo_lean -- phases lakefile vs README, table libs exhaustive, raccord Lean-22b

See #13214. See #13121 (passe 1 audit CoursIA ayant diagnostique le drift).

## Origine

`MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean` est l'un des 21 lakes `PROPRE
COURSIA` identifiés par la passe 1 d'audit (#13121, ROOT-5 distinct_code_sorry=0,
Mathlib 4.32.1, SLT pinné). Mais la passe révèle aussi que **la carte interne
ne suit plus le code compilé** :

1. `lakefile.lean` déclare **six `lean_lib`** : `Descent`, `Objective`, `Lmmse`,
   `Converse`, `Bridge`, `NormTails` (avec siblings EN via globs `Descent_en`,
   etc.).
2. `README.md` ne documente que **quatre phases** (1/2/3a/3b) — Phases 4
   (Bridge) et 5 (NormTails, grignotages #11148) sont présentes sur disque
   mais invisibles à la lecture.
3. Statut incohérent : lakefile dit Phase 3b "(à venir)" alors que README
   dit Phase 3b "livré" — la lecture est fausse sur les deux supports, le
   code compilé (`Converse.lean` de 426 lignes avec 16+ déclarations)
   tranche : livré.
4. Toolchain : lakefile exige `v4.32.1`, README dit `v4.32.0`, manifest
   résout `520045ab14e26149ee970e2e617ca04b09bde5d6` ; SLT pinné
   `d0f506f0a695018265dccb33bcb05e2f5ca1c876` non documenté.
5. Frontière formelle (prouvé localement vs emprunté à SLT) non explicitée
   dans le README.

## Reconciliations

### 1. README.md (195 → 162 lignes, refondu)

Refonte structurelle en cinq sections :

- **Phases et libs compilées** : table exhaustive Phase/Lib/Livrable/Statut
  couvrant les **six** libs avec leur sibling EN ;
- **Build** : `lake build` documenté pour les **six** libs ;
- **Dépendances externes** : table SLT + Mathlib avec leurs pins et
  **qui les consomme** ;
- **Inventaire détaillé des phases** : 6 sous-sections miroir du
  docstring du lakefile, chacune avec son résultat phare et ses lemmes ;
- **Frontière formelle** : prouvé localement (CoursIA) vs emprunté (SLT) ;
- **Companion canonique** : Lean-22b-MIMO-Converse-Native.ipynb avec sa
  garantie "#check + #print axioms, 3 axiomes standards, zéro sorry".

### 2. lakefile.lean (docstring du bloc `/-! ... -/` uniquement)

Modifications **purement documentaires** (commentaire de tête, pas de code
ni de `require`/`lean_lib` touchées) :

- v4.32.0 → **v4.32.1** (alignement lakefile ↔ manifest) ;
- Résolution Mathlib `520045ab14e26149ee970e2e617ca04b09bde5d6` (depuis
  `lake-manifest.json`) ;
- Phase 3b "(à venir)" → **Phase 3b / Converse livré** (alignement code) ;
- Phase 4 / Bridge et Phase 5 / NormTails **ajoutées** avec note
  "grignotage #11148".

Aucune modification de `package`, `require`, `lean_lib`, ou `globs` —
**le lakefile reste byte-identique côté code**.

## Garanties anti-régression (règle D)

- **Aucune preuve modifiée ni remplacée** : 6 modules `.lean` du lake
  (Descent, Objective, Lmmse, Converse, Bridge, NormTails) + leurs twins
  `_en` non touchés (`git diff -- '*.lean' !'lakefile.lean'` = 0 ligne) ;
- **Aucun axiome ajouté** : `#print axioms` reste sur les 3 standards
  Mathlib (`propext`, `Classical.choice`, `Quot.sound`) — vérifiable
  via Lean-22b compagnon canonique ;
- **Aucun `sorry` introduit** : `distinct_code_sorry` du lake reste à 0
  (mesure #13121) ;
- **Aucun notebook ré-exécuté** : le diff reste strictement documentaire
  (README + docstring du lakefile) ; aucune cellule code touchée.

## Acceptance #13214

| Critère                                                | Statut |
|--------------------------------------------------------|--------|
| Phases 1–6 statut cohérent entre README et lakefile    | OK     |
| Table exhaustive des 6 libs + siblings EN              | OK     |
| Pour chaque module : rôle, résultat phare, provenance | OK (lattice Phase×Lib) |
| Lean-22b distinction "prouvé localement vs SLT"        | OK (section dédiée) |
| Pins Mathlib + SLT vérifiés et documentés              | OK     |
| Aucun claim axiomatique nouveau                        | OK     |
| Pas de ré-exécution notebook                           | OK     |

## Diff

```
 MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/README.md    | 199 +++++++++++++--------
 MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean |  35 ++--
 2 files changed, 150 insertions(+), 84 deletions(-)
```

- `README.md` : refonte structurelle (table exhaustive, dépendances
  pinnées, frontière formelle, compagnon canonique).
- `lakefile.lean` : commentaire de tête uniquement. Aucun `package` /
  `require` / `lean_lib` / `globs` modifié.

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>

