### PR TITLE
fix(lean): aligner la descente omega de Lean-21b

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-21b-PFR-Primitives-Transportables.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-21b-PFR-Primitives-Transportables.ipynb
@@ -2,7 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "3fd55e7c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014223,
+     "end_time": "2026-08-27T16:51:12.363517+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.349294+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Lean-21b : Trois primitives de PFR, et l'endroit exact où elles cessent de valoir\n",
     "\n",
@@ -53,7 +63,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e44d9187",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00523,
+     "end_time": "2026-08-27T16:51:12.375421+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.370191+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Primitive 1 — Distance entropique de Ruzsa\n",
     "\n",
@@ -77,66 +97,92 @@
     "\n",
     "### 1.2 Calcul sur son terrain — un groupe additif fini\n",
     "\n",
-    "On prend `G = ℤ/nℤ` et on compare deux variables `X`, `Y` à distributions connues.\n",
-    ""
+    "On prend `G = ℤ/nℤ` et on compare deux variables `X`, `Y` à distributions connues.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "id": "8b72f4f5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T16:51:12.385158Z",
+     "iopub.status.busy": "2026-08-27T16:51:12.384881Z",
+     "iopub.status.idle": "2026-08-27T16:51:12.401139Z",
+     "shell.execute_reply": "2026-08-27T16:51:12.400097Z"
+    },
+    "papermill": {
+     "duration": 0.02188,
+     "end_time": "2026-08-27T16:51:12.402118+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.380238+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Test 1 : X = Y uniformes i.i.d. sur ℤ/8ℤ\n  d[X;Y] = 0.0000  (attendu ~ 0)\nTest 2 : Y = X + 1 (translation)\n  d[X;Y] = 0.0000  (attendu 0)\nTest 3 : X uniforme, Y concentré en 0\n  d[X;Y] = 1.5000  (H(Y)=0, formule dégénère)\n"
+     "output_type": "stream",
+     "text": [
+      "Test 1 : X = Y uniformes i.i.d. sur ℤ/8ℤ\n",
+      "  d[X;Y] = 0.0000  (attendu ~ 0)\n",
+      "Test 2 : Y = X + 1 (translation)\n",
+      "  d[X;Y] = 0.0000  (attendu 0)\n",
+      "Test 3 : X uniforme, Y concentré en 0\n",
+      "  d[X;Y] = 1.5000  (H(Y)=0, formule dégénère)\n"
+     ]
     }
    ],
    "source": [
-    "import math",
-    "from collections import Counter",
-    "",
-    "def entropy_bits(dist):",
-    "    \"\"\"Entropie de Shannon en bits à partir d'un dict {symbol: proba}.\"\"\"",
-    "    return -sum(p * math.log2(p) for p in dist.values() if p > 0)",
-    "",
-    "def d_ruzsa(X_dist, Y_dist, n):",
-    "    \"\"\"Distance de Ruzsa sur ℤ/nℤ entre deux distributions.",
-    "    Suppose X_dist et Y_dist sont des dicts {k: proba} sur 0..n-1.",
-    "    \"\"\"",
-    "    # X' - Y' : convolution signée modulo n",
-    "    XY_minus = Counter()",
-    "    for x, px in X_dist.items():",
-    "        for y, py in Y_dist.items():",
-    "            XY_minus[(x - y) % n] += px * py",
-    "    H_XY_minus = entropy_bits(XY_minus)",
-    "    H_X = entropy_bits(X_dist)",
-    "    H_Y = entropy_bits(Y_dist)",
-    "    return H_XY_minus - 0.5 * H_X - 0.5 * H_Y",
-    "",
-    "# Test 1 : X et Y uniformes indépendants sur ℤ/8ℤ",
-    "n = 8",
-    "uniform = {k: 1/n for k in range(n)}",
-    "print(f\"Test 1 : X = Y uniformes i.i.d. sur ℤ/{n}ℤ\")",
-    "print(f\"  d[X;Y] = {d_ruzsa(uniform, uniform, n):.4f}  (attendu ~ 0)\")",
-    "",
-    "# Test 2 : Y = X + 1 (translation)",
-    "shifted = {k: uniform[(k - 1) % n] for k in range(n)}",
-    "print(f\"Test 2 : Y = X + 1 (translation)\")",
-    "print(f\"  d[X;Y] = {d_ruzsa(uniform, shifted, n):.4f}  (attendu 0)\")",
-    "",
-    "# Test 3 : X = Y même variable (couplage parfait)",
-    "# Si X et Y ont la même distribution, d[X;Y] ≈ 0 si indépendants,",
-    "# ou peut être < 0 si corrélés (en théorie >= 0 mais bruit numérique).",
-    "print(f\"Test 3 : X uniforme, Y concentré en 0\")",
-    "Y_degen = {0: 1.0, **{k: 0.0 for k in range(1, n)}}",
-    "print(f\"  d[X;Y] = {d_ruzsa(uniform, Y_degen, n):.4f}  (H(Y)=0, formule dégénère)\")",
-    ""
+    "import math\n",
+    "from collections import Counter\n",
+    "def entropy_bits(dist):\n",
+    "    \"\"\"Entropie de Shannon en bits à partir d'un dict {symbol: proba}.\"\"\"\n",
+    "    return -sum(p * math.log2(p) for p in dist.values() if p > 0)\n",
+    "def d_ruzsa(X_dist, Y_dist, n):\n",
+    "    \"\"\"Distance de Ruzsa sur ℤ/nℤ entre deux distributions.\n",
+    "    Suppose X_dist et Y_dist sont des dicts {k: proba} sur 0..n-1.\n",
+    "    \"\"\"\n",
+    "    # X' - Y' : convolution signée modulo n\n",
+    "    XY_minus = Counter()\n",
+    "    for x, px in X_dist.items():\n",
+    "        for y, py in Y_dist.items():\n",
+    "            XY_minus[(x - y) % n] += px * py\n",
+    "    H_XY_minus = entropy_bits(XY_minus)\n",
+    "    H_X = entropy_bits(X_dist)\n",
+    "    H_Y = entropy_bits(Y_dist)\n",
+    "    return H_XY_minus - 0.5 * H_X - 0.5 * H_Y\n",
+    "# Test 1 : X et Y uniformes indépendants sur ℤ/8ℤ\n",
+    "n = 8\n",
+    "uniform = {k: 1/n for k in range(n)}\n",
+    "print(f\"Test 1 : X = Y uniformes i.i.d. sur ℤ/{n}ℤ\")\n",
+    "print(f\"  d[X;Y] = {d_ruzsa(uniform, uniform, n):.4f}  (attendu ~ 0)\")\n",
+    "# Test 2 : Y = X + 1 (translation)\n",
+    "shifted = {k: uniform[(k - 1) % n] for k in range(n)}\n",
+    "print(f\"Test 2 : Y = X + 1 (translation)\")\n",
+    "print(f\"  d[X;Y] = {d_ruzsa(uniform, shifted, n):.4f}  (attendu 0)\")\n",
+    "# Test 3 : X = Y même variable (couplage parfait)\n",
+    "# Si X et Y ont la même distribution, d[X;Y] ≈ 0 si indépendants,\n",
+    "# ou peut être < 0 si corrélés (en théorie >= 0 mais bruit numérique).\n",
+    "print(f\"Test 3 : X uniforme, Y concentré en 0\")\n",
+    "Y_degen = {0: 1.0, **{k: 0.0 for k in range(1, n)}}\n",
+    "print(f\"  d[X;Y] = {d_ruzsa(uniform, Y_degen, n):.4f}  (H(Y)=0, formule dégénère)\")\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c69d894c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001856,
+     "end_time": "2026-08-27T16:51:12.406526+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.404670+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du résultat\n",
     "\n",
@@ -149,60 +195,83 @@
     "\n",
     "### 1.3 Test de limite — quand la primitive ne transporte plus\n",
     "\n",
-    "On essaie la formule sur un objet **sans structure de groupe** : un arbre binaire.\n",
-    ""
+    "On essaie la formule sur un objet **sans structure de groupe** : un arbre binaire.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "id": "feb6d5f4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T16:51:12.410666Z",
+     "iopub.status.busy": "2026-08-27T16:51:12.410513Z",
+     "iopub.status.idle": "2026-08-27T16:51:12.414096Z",
+     "shell.execute_reply": "2026-08-27T16:51:12.413686Z"
+    },
+    "papermill": {
+     "duration": 0.006431,
+     "end_time": "2026-08-27T16:51:12.414675+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.408244+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Verdict Primitive 1 :\n  d_ruzsa exige STRUCTURE DE GROUPE ADDITIF.\n  Transportable SOUS CONDITION (laquelle ? groupe abélien).\n"
+     "output_type": "stream",
+     "text": [
+      "Verdict Primitive 1 :\n",
+      "  d_ruzsa exige STRUCTURE DE GROUPE ADDITIF.\n",
+      "  Transportable SOUS CONDITION (laquelle ? groupe abélien).\n"
+     ]
     }
    ],
    "source": [
-    "# Test de limite : la formule de Ruzsa appliquée à un objet SANS structure de groupe",
-    "# On simule X, Y comme distributions sur les nœuds d'un arbre binaire de profondeur 4",
-    "# (16 feuilles) et on essaie de définir un « X - Y » via le XOR des codes (proxy additif ℤ/2⁴ℤ).",
-    "",
-    "# Distribution uniforme sur les 16 nœuds",
-    "def uniform_binary_tree(d):",
-    "    leaves = list(range(2 ** d))",
-    "    return {k: 1.0 / len(leaves) for k in leaves}",
-    "",
-    "# Mais « l'arbre » lui-même n'a pas d'opération de groupe canonique.",
-    "# Le XOR des codes binaires EST une structure de groupe (ℤ/2⁴ℤ), donc ce test",
-    "# ne disqualifie pas la primitive — il montre que « l'objet » peut être ré-interprété.",
-    "#",
-    "# Test plus radical : objet sans représentation additive canonique.",
-    "# Par exemple : distances sur une sphère (métrique non-associative).",
-    "# d[X;Y] = H(distance entre X' et Y') - 0.5 H(X') - 0.5 H(Y')",
-    "# Cette définition est mathématiquement valide MAIS :",
-    "#   1. \"X' - Y'\" n'a plus de sens canonique (quelle est la \"différence\" de deux points sur une sphère ?)",
-    "#   2. Sans structure de groupe, \"X' - Y'\" dépend du choix de représentation.",
-    "#   3. La symétrie d[X;Y] = d[Y;X] peut être violée.",
-    "",
-    "# Conclusion : la primitive N'est PAS inconditionnellement transportable.",
-    "# Elle exige une structure de groupe additif (Z/nZ, F₂ⁿ, G quelconque).",
-    "# Coller la formule sur un objet sans groupe, c'est de l'over-fitting de formalisme.",
-    "",
-    "print(\"Verdict Primitive 1 :\")",
-    "print(\"  d_ruzsa exige STRUCTURE DE GROUPE ADDITIF.\")",
-    "print(\"  Transportable SOUS CONDITION (laquelle ? groupe abélien).\")",
-    "",
-    "# Distance de Ruzsa formelle dans Lean (cf Lean-21 cell#6 si besoin) :",
-    "#  def d_ruzsa_lean (G : Type*) [AddGroup G] (X Y : Distribution G) : ℝ :=",
-    "#    H(X' - Y') - ½ * H(X) - ½ * H(Y)",
-    ""
+    "# Test de limite : la formule de Ruzsa appliquée à un objet SANS structure de groupe\n",
+    "# On simule X, Y comme distributions sur les nœuds d'un arbre binaire de profondeur 4\n",
+    "# (16 feuilles) et on essaie de définir un « X - Y » via le XOR des codes (proxy additif ℤ/2⁴ℤ).\n",
+    "# Distribution uniforme sur les 16 nœuds\n",
+    "def uniform_binary_tree(d):\n",
+    "    leaves = list(range(2 ** d))\n",
+    "    return {k: 1.0 / len(leaves) for k in leaves}\n",
+    "# Mais « l'arbre » lui-même n'a pas d'opération de groupe canonique.\n",
+    "# Le XOR des codes binaires EST une structure de groupe (ℤ/2⁴ℤ), donc ce test\n",
+    "# ne disqualifie pas la primitive — il montre que « l'objet » peut être ré-interprété.\n",
+    "#\n",
+    "# Test plus radical : objet sans représentation additive canonique.\n",
+    "# Par exemple : distances sur une sphère (métrique non-associative).\n",
+    "# d[X;Y] = H(distance entre X' et Y') - 0.5 H(X') - 0.5 H(Y')\n",
+    "# Cette définition est mathématiquement valide MAIS :\n",
+    "#   1. \"X' - Y'\" n'a plus de sens canonique (quelle est la \"différence\" de deux points sur une sphère ?)\n",
+    "#   2. Sans structure de groupe, \"X' - Y'\" dépend du choix de représentation.\n",
+    "#   3. La symétrie d[X;Y] = d[Y;X] peut être violée.\n",
+    "# Conclusion : la primitive N'est PAS inconditionnellement transportable.\n",
+    "# Elle exige une structure de groupe additif (Z/nZ, F₂ⁿ, G quelconque).\n",
+    "# Coller la formule sur un objet sans groupe, c'est de l'over-fitting de formalisme.\n",
+    "print(\"Verdict Primitive 1 :\")\n",
+    "print(\"  d_ruzsa exige STRUCTURE DE GROUPE ADDITIF.\")\n",
+    "print(\"  Transportable SOUS CONDITION (laquelle ? groupe abélien).\")\n",
+    "# Distance de Ruzsa formelle dans Lean (cf Lean-21 cell#6 si besoin) :\n",
+    "#  def d_ruzsa_lean (G : Type*) [AddGroup G] (X Y : Distribution G) : ℝ :=\n",
+    "#    H(X' - Y') - ½ * H(X) - ½ * H(Y)\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "2e37b0be",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001393,
+     "end_time": "2026-08-27T16:51:12.417601+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.416208+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Verdict Primitive 1\n",
     "\n",
@@ -234,72 +303,97 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "id": "2c16f4f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T16:51:12.421472Z",
+     "iopub.status.busy": "2026-08-27T16:51:12.421279Z",
+     "iopub.status.idle": "2026-08-27T16:51:12.426803Z",
+     "shell.execute_reply": "2026-08-27T16:51:12.426414Z"
+    },
+    "papermill": {
+     "duration": 0.008245,
+     "end_time": "2026-08-27T16:51:12.427335+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.419090+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "H(X) = entropie sur les notes = 3.433 bits\nH(X | Y) = entropie intra-cours = 2.322 bits\nH(Y) = entropie sur les cours = 2.322 bits\nI(X;Y) = H(X) - H(X|Y) = 1.111 bits\nH(Y) - I(X;Y) = 1.211 bits (≠ H(Y), pas d'égalité directe)\nRègle de chaîne vérifiée : H(X) = 3.433 ≈ H(X|Y) + I(X;Y) = 3.433\n"
+     "output_type": "stream",
+     "text": [
+      "H(X) = entropie sur les notes = 3.433 bits\n",
+      "H(X | Y) = entropie intra-cours = 2.322 bits\n",
+      "H(Y) = entropie sur les cours = 2.322 bits\n",
+      "I(X;Y) = H(X) - H(X|Y) = 1.111 bits\n",
+      "H(Y) - I(X;Y) = 1.211 bits (≠ H(Y), pas d'égalité directe)\n",
+      "Règle de chaîne vérifiée : H(X) = 3.433 ≈ H(X|Y) + I(X;Y) = 3.433\n"
+     ]
     }
    ],
    "source": [
-    "# Primitive 2 — Décomposition projection / fibres sur un cas concret",
-    "# On prend un dataset de notes d'étudiants (X) et on projette sur le cours (Y).",
-    "# H(X) = entropie totale des notes, H(X|Y) = entropie intra-cours.",
-    "",
-    "import math",
-    "from collections import Counter, defaultdict",
-    "",
-    "def normalize(counts):",
-    "    total = sum(counts.values())",
-    "    return {k: v / total for k, v in counts.items()}",
-    "",
-    "# Notes de 100 étudiants sur 5 cours",
-    "notes_brutes = [",
-    "    ('Math', 14), ('Math', 16), ('Math', 12), ('Math', 18), ('Math', 15),",
-    "    ('Phys', 11), ('Phys', 13), ('Phys', 9),  ('Phys', 12), ('Phys', 14),",
-    "    ('Info', 17), ('Info', 19), ('Info', 16), ('Info', 18), ('Info', 20),",
-    "    ('Bio',  10), ('Bio',  12), ('Bio',  11), ('Bio',  13), ('Bio',  9),",
-    "    ('Chim', 13), ('Chim', 15), ('Chim', 14), ('Chim', 16), ('Chim', 12),",
-    "]",
-    "",
-    "# H(X) sur les notes",
-    "X_dist = normalize(Counter(n for _, n in notes_brutes))",
-    "H_X = -sum(p * math.log2(p) for p in X_dist.values() if p > 0)",
-    "print(f\"H(X) = entropie sur les notes = {H_X:.3f} bits\")",
-    "",
-    "# H(X | Y) par cours",
-    "H_X_given_Y = 0",
-    "n_total = len(notes_brutes)",
-    "for cours, ns in defaultdict(list, {c: [] for c, _ in notes_brutes}).items():",
-    "    pass  # syntax workaround",
-    "by_cours = defaultdict(list)",
-    "for c, n in notes_brutes:",
-    "    by_cours[c].append(n)",
-    "H_X_given_Y = 0",
-    "for cours, ns in by_cours.items():",
-    "    p_y = len(ns) / n_total",
-    "    dist_ns = normalize(Counter(ns))",
-    "    H_n_given_c = -sum(p * math.log2(p) for p in dist_ns.values() if p > 0)",
-    "    H_X_given_Y += p_y * H_n_given_c",
-    "print(f\"H(X | Y) = entropie intra-cours = {H_X_given_Y:.3f} bits\")",
-    "",
-    "# H(Y) sur les cours",
-    "Y_dist = normalize(Counter(c for c, _ in notes_brutes))",
-    "H_Y = -sum(p * math.log2(p) for p in Y_dist.values() if p > 0)",
-    "print(f\"H(Y) = entropie sur les cours = {H_Y:.3f} bits\")",
-    "",
-    "# Vérification règle de chaîne : H(X) = I(X;Y) + H(X|Y)",
-    "I_XY = H_X - H_X_given_Y",
-    "print(f\"I(X;Y) = H(X) - H(X|Y) = {I_XY:.3f} bits\")",
-    "print(f\"H(Y) - I(X;Y) = {H_Y - I_XY:.3f} bits (≠ H(Y), pas d'égalité directe)\")",
-    "print(f\"Règle de chaîne vérifiée : H(X) = {H_X:.3f} ≈ H(X|Y) + I(X;Y) = {H_X_given_Y + I_XY:.3f}\")",
-    ""
+    "# Primitive 2 — Décomposition projection / fibres sur un cas concret\n",
+    "# On prend un dataset de notes d'étudiants (X) et on projette sur le cours (Y).\n",
+    "# H(X) = entropie totale des notes, H(X|Y) = entropie intra-cours.\n",
+    "import math\n",
+    "from collections import Counter, defaultdict\n",
+    "def normalize(counts):\n",
+    "    total = sum(counts.values())\n",
+    "    return {k: v / total for k, v in counts.items()}\n",
+    "# Notes de 100 étudiants sur 5 cours\n",
+    "notes_brutes = [\n",
+    "    ('Math', 14), ('Math', 16), ('Math', 12), ('Math', 18), ('Math', 15),\n",
+    "    ('Phys', 11), ('Phys', 13), ('Phys', 9),  ('Phys', 12), ('Phys', 14),\n",
+    "    ('Info', 17), ('Info', 19), ('Info', 16), ('Info', 18), ('Info', 20),\n",
+    "    ('Bio',  10), ('Bio',  12), ('Bio',  11), ('Bio',  13), ('Bio',  9),\n",
+    "    ('Chim', 13), ('Chim', 15), ('Chim', 14), ('Chim', 16), ('Chim', 12),\n",
+    "]\n",
+    "# H(X) sur les notes\n",
+    "X_dist = normalize(Counter(n for _, n in notes_brutes))\n",
+    "H_X = -sum(p * math.log2(p) for p in X_dist.values() if p > 0)\n",
+    "print(f\"H(X) = entropie sur les notes = {H_X:.3f} bits\")\n",
+    "# H(X | Y) par cours\n",
+    "H_X_given_Y = 0\n",
+    "n_total = len(notes_brutes)\n",
+    "for cours, ns in defaultdict(list, {c: [] for c, _ in notes_brutes}).items():\n",
+    "    pass  # syntax workaround\n",
+    "by_cours = defaultdict(list)\n",
+    "for c, n in notes_brutes:\n",
+    "    by_cours[c].append(n)\n",
+    "H_X_given_Y = 0\n",
+    "for cours, ns in by_cours.items():\n",
+    "    p_y = len(ns) / n_total\n",
+    "    dist_ns = normalize(Counter(ns))\n",
+    "    H_n_given_c = -sum(p * math.log2(p) for p in dist_ns.values() if p > 0)\n",
+    "    H_X_given_Y += p_y * H_n_given_c\n",
+    "print(f\"H(X | Y) = entropie intra-cours = {H_X_given_Y:.3f} bits\")\n",
+    "# H(Y) sur les cours\n",
+    "Y_dist = normalize(Counter(c for c, _ in notes_brutes))\n",
+    "H_Y = -sum(p * math.log2(p) for p in Y_dist.values() if p > 0)\n",
+    "print(f\"H(Y) = entropie sur les cours = {H_Y:.3f} bits\")\n",
+    "# Vérification règle de chaîne : H(X) = I(X;Y) + H(X|Y)\n",
+    "I_XY = H_X - H_X_given_Y\n",
+    "print(f\"I(X;Y) = H(X) - H(X|Y) = {I_XY:.3f} bits\")\n",
+    "print(f\"H(Y) - I(X;Y) = {H_Y - I_XY:.3f} bits (≠ H(Y), pas d'égalité directe)\")\n",
+    "print(f\"Règle de chaîne vérifiée : H(X) = {H_X:.3f} ≈ H(X|Y) + I(X;Y) = {H_X_given_Y + I_XY:.3f}\")\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c909ff99",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001604,
+     "end_time": "2026-08-27T16:51:12.430701+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.429097+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du résultat\n",
     "\n",
@@ -311,61 +405,94 @@
     "\n",
     "### 2.3 Test de limite — quand la primitive ne transporte plus\n",
     "\n",
-    "La règle de chaîne **H(X) = H(X|Y) + I(X;Y)** est-elle valide pour **n'importe quelle** « projection » `Y` ?\n",
-    ""
+    "La règle de chaîne **H(X) = H(X|Y) + I(X;Y)** est-elle valide pour **n'importe quelle** « projection » `Y` ?\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "id": "979c328f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T16:51:12.434985Z",
+     "iopub.status.busy": "2026-08-27T16:51:12.434749Z",
+     "iopub.status.idle": "2026-08-27T16:51:12.439013Z",
+     "shell.execute_reply": "2026-08-27T16:51:12.438599Z"
+    },
+    "papermill": {
+     "duration": 0.007627,
+     "end_time": "2026-08-27T16:51:12.439980+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.432353+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Texte : 'le chat mange le poisson le chien mange la viande'\nMots uniques : 7, Mots totaux : 10\nDistribution normalisée → H(text) = 2.646 bits\nUne fois normalisée, l'entropie a un sens. Mais :\n  - Pas de σ-algèbre canonique sur 'mots'\n  - 'Y' = 'premier mot de la phrase' ? — Y est-il une v.a. légitime ?\n  - Sans mesure de probabilité, 'projection' n'a pas de sens formel\n\nVerdict Primitive 2 :\n  Décomposition X = π(X) + (X|π(X)) exige DISTRIBUTION DE PROBABILITÉ.\n  Transportable LARGE (la règle de chaîne est universelle en théorie de l'information).\n  Mais 'projection' et 'fibres' doivent être formalisées en proba —\n  sinon la décomposition est un formalisme vide.\n"
+     "output_type": "stream",
+     "text": [
+      "Texte : 'le chat mange le poisson le chien mange la viande'\n",
+      "Mots uniques : 7, Mots totaux : 10\n",
+      "Distribution normalisée → H(text) = 2.646 bits\n",
+      "Une fois normalisée, l'entropie a un sens. Mais :\n",
+      "  - Pas de σ-algèbre canonique sur 'mots'\n",
+      "  - 'Y' = 'premier mot de la phrase' ? — Y est-il une v.a. légitime ?\n",
+      "  - Sans mesure de probabilité, 'projection' n'a pas de sens formel\n",
+      "\n",
+      "Verdict Primitive 2 :\n",
+      "  Décomposition X = π(X) + (X|π(X)) exige DISTRIBUTION DE PROBABILITÉ.\n",
+      "  Transportable LARGE (la règle de chaîne est universelle en théorie de l'information).\n",
+      "  Mais 'projection' et 'fibres' doivent être formalisées en proba —\n",
+      "  sinon la décomposition est un formalisme vide.\n"
+     ]
     }
    ],
    "source": [
-    "import math",
-    "from collections import Counter",
-    "",
-    "# Test de limite : projection arbitraire sur un objet non-probabiliste",
-    "# On prend un texte brut et on essaie de définir H(X) comme nombre de mots uniques.",
-    "# Mais sans distribution de probabilité, ce n'est PAS de l'entropie de Shannon.",
-    "",
-    "texte = \"le chat mange le poisson le chien mange la viande\"",
-    "mots = texte.split()",
-    "print(f\"Texte : {texte!r}\")",
-    "print(f\"Mots uniques : {len(set(mots))}, Mots totaux : {len(mots)}\")",
-    "",
-    "# H_naive = -sum(1/N * log2(1/N)) sur N = nb total mots ? NON : ce n'est pas une distribution.",
-    "# La primitive EXIGE une distribution de probabilité sur X et Y.",
-    "# Sur du texte brut, on a un COMPTAGE, pas une distribution : il faut normaliser.",
-    "",
-    "# Construire une distribution : P(mot) = count / total",
-    "dist = Counter(mots)",
-    "N = len(mots)",
-    "probas = {m: c / N for m, c in dist.items()}",
-    "H_text = -sum(p * math.log2(p) for p in probas.values() if p > 0)",
-    "print(f\"Distribution normalisée → H(text) = {H_text:.3f} bits\")",
-    "print(\"Une fois normalisée, l'entropie a un sens. Mais :\")",
-    "print(\"  - Pas de σ-algèbre canonique sur 'mots'\")",
-    "print(\"  - 'Y' = 'premier mot de la phrase' ? — Y est-il une v.a. légitime ?\")",
-    "print(\"  - Sans mesure de probabilité, 'projection' n'a pas de sens formel\")",
-    "",
-    "print()",
-    "print(\"Verdict Primitive 2 :\")",
-    "print(\"  Décomposition X = π(X) + (X|π(X)) exige DISTRIBUTION DE PROBABILITÉ.\")",
-    "print(\"  Transportable LARGE (la règle de chaîne est universelle en théorie de l'information).\")",
-    "print(\"  Mais 'projection' et 'fibres' doivent être formalisées en proba —\")",
-    "print(\"  sinon la décomposition est un formalisme vide.\")",
-    ""
+    "import math\n",
+    "from collections import Counter\n",
+    "# Test de limite : projection arbitraire sur un objet non-probabiliste\n",
+    "# On prend un texte brut et on essaie de définir H(X) comme nombre de mots uniques.\n",
+    "# Mais sans distribution de probabilité, ce n'est PAS de l'entropie de Shannon.\n",
+    "texte = \"le chat mange le poisson le chien mange la viande\"\n",
+    "mots = texte.split()\n",
+    "print(f\"Texte : {texte!r}\")\n",
+    "print(f\"Mots uniques : {len(set(mots))}, Mots totaux : {len(mots)}\")\n",
+    "# H_naive = -sum(1/N * log2(1/N)) sur N = nb total mots ? NON : ce n'est pas une distribution.\n",
+    "# La primitive EXIGE une distribution de probabilité sur X et Y.\n",
+    "# Sur du texte brut, on a un COMPTAGE, pas une distribution : il faut normaliser.\n",
+    "# Construire une distribution : P(mot) = count / total\n",
+    "dist = Counter(mots)\n",
+    "N = len(mots)\n",
+    "probas = {m: c / N for m, c in dist.items()}\n",
+    "H_text = -sum(p * math.log2(p) for p in probas.values() if p > 0)\n",
+    "print(f\"Distribution normalisée → H(text) = {H_text:.3f} bits\")\n",
+    "print(\"Une fois normalisée, l'entropie a un sens. Mais :\")\n",
+    "print(\"  - Pas de σ-algèbre canonique sur 'mots'\")\n",
+    "print(\"  - 'Y' = 'premier mot de la phrase' ? — Y est-il une v.a. légitime ?\")\n",
+    "print(\"  - Sans mesure de probabilité, 'projection' n'a pas de sens formel\")\n",
+    "print()\n",
+    "print(\"Verdict Primitive 2 :\")\n",
+    "print(\"  Décomposition X = π(X) + (X|π(X)) exige DISTRIBUTION DE PROBABILITÉ.\")\n",
+    "print(\"  Transportable LARGE (la règle de chaîne est universelle en théorie de l'information).\")\n",
+    "print(\"  Mais 'projection' et 'fibres' doivent être formalisées en proba —\")\n",
+    "print(\"  sinon la décomposition est un formalisme vide.\")\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "99ebe05e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001706,
+     "end_time": "2026-08-27T16:51:12.443364+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.441658+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Verdict Primitive 2\n",
     "\n",
@@ -399,60 +526,103 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "id": "4355c4ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T16:51:12.448557Z",
+     "iopub.status.busy": "2026-08-27T16:51:12.448351Z",
+     "iopub.status.idle": "2026-08-27T16:51:12.455344Z",
+     "shell.execute_reply": "2026-08-27T16:51:12.454756Z"
+    },
+    "papermill": {
+     "duration": 0.01077,
+     "end_time": "2026-08-27T16:51:12.456148+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.445378+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "ω(60) = 3 (2×2×3×5 → facteurs premiers 2, 3, 5, soit ω = 3, pas 2 — correction)\nVérif manuelle : 60 = 2^2 × 3 × 5 → ω = 3\nSéquence de raffinement : [60, 30, 15, 5]\nω à chaque étape : [3, 3, 2, 1]\nω décroît-elle strictement ? [False, True, True]\n"
+     "output_type": "stream",
+     "text": [
+      "ω(60) = 3 (2×2×3×5 → facteurs premiers distincts 2, 3 et 5)\n",
+      "Vérif manuelle : 60 = 2² × 3 × 5 → ω = 3\n",
+      "Séquence de raffinement : [60, 15, 5, 1]\n",
+      "ω à chaque étape : [3, 2, 1, 0]\n",
+      "ω décroît-elle strictement ? [True, True, True]\n"
+     ]
     }
    ],
    "source": [
-    "# Primitive 3 — τ = nombre de diviseurs premiers distincts (omega(N)), sur N = 60.",
-    "# Procédure : division Euclidienne séquentielle par 2, 3, 5, 7, 11.",
-    "",
-    "def omega(N):",
-    "    \"\"\"Nombre de diviseurs premiers distincts de N.\"\"\"",
-    "    n, count, p = N, 0, 2",
-    "    while p * p <= n:",
-    "        if n % p == 0:",
-    "            count += 1",
-    "            while n % p == 0:",
-    "                n //= p",
-    "        p += 1",
-    "    if n > 1:",
-    "        count += 1",
-    "    return count",
-    "",
-    "# Trace : N₀ = 60, on divise par 2 → 30 → 15, puis par 3 → 5, puis 5 → 1.",
-    "# τ décroît à chaque factorisation : ω(60)=2 (2,3), ω(30)=2, ω(15)=2 (3,5), ω(5)=1, ω(1)=0.",
-    "N = 60",
-    "print(f\"ω({N}) = {omega(N)} (2×2×3×5 → facteurs premiers 2, 3, 5, soit ω = 3, pas 2 — correction)\")",
-    "# Re-vérification : 60 = 2^2 × 3 × 5 → 3 facteurs premiers distincts.",
-    "N = 60",
-    "expected = len({2, 3, 5})  # {2, 3, 5}",
-    "print(f\"Vérif manuelle : 60 = 2^2 × 3 × 5 → ω = {expected}\")",
-    "",
-    "# La procédure de raffinement : τ_i = ω(N_i), on s'arrête quand ω = 0 (N=1).",
-    "N = 60",
-    "steps = [N]",
-    "while N > 1:",
-    "    for p in range(2, int(N**0.5) + 1):",
-    "        if N % p == 0:",
-    "            N //= p",
-    "            steps.append(N)",
-    "            break",
-    "    else:",
-    "        break  # Plus de facteur",
-    "print(f\"Séquence de raffinement : {steps}\")",
-    "print(f\"ω à chaque étape : {[omega(s) for s in steps]}\")",
-    "print(f\"ω décroît-elle strictement ? {[omega(steps[i]) < omega(steps[i-1]) for i in range(1, len(steps))]}\")",
-    ""
+    "# Primitive 3 — τ = nombre de diviseurs premiers distincts (omega(N)), sur N = 60.\n",
+    "# Procédure : à chaque étape, retirer toute la valuation du plus petit facteur premier.\n",
+    "def omega(N):\n",
+    "    \"\"\"Nombre de diviseurs premiers distincts de N.\"\"\"\n",
+    "    n, count, p = N, 0, 2\n",
+    "    while p * p <= n:\n",
+    "        if n % p == 0:\n",
+    "            count += 1\n",
+    "            while n % p == 0:\n",
+    "                n //= p\n",
+    "        p += 1\n",
+    "    if n > 1:\n",
+    "        count += 1\n",
+    "    return count\n",
+    "\n",
+    "# Trace : N₀ = 60, on retire 2² → 15, puis 3 → 5, puis 5 → 1.\n",
+    "# Chaque étape élimine un facteur premier distinct :\n",
+    "# ω(60)=3, ω(15)=2, ω(5)=1, ω(1)=0.\n",
+    "N = 60\n",
+    "print(\n",
+    "    f\"ω({N}) = {omega(N)} \"\n",
+    "    \"(2×2×3×5 → facteurs premiers distincts 2, 3 et 5)\"\n",
+    ")\n",
+    "\n",
+    "# Re-vérification : 60 = 2² × 3 × 5 → 3 facteurs premiers distincts.\n",
+    "expected = len({2, 3, 5})\n",
+    "print(f\"Vérif manuelle : 60 = 2² × 3 × 5 → ω = {expected}\")\n",
+    "\n",
+    "# La procédure de raffinement s'arrête à N=1, où ω=0.\n",
+    "N = 60\n",
+    "steps = [N]\n",
+    "while N > 1:\n",
+    "    for p in range(2, int(N**0.5) + 1):\n",
+    "        if N % p == 0:\n",
+    "            while N % p == 0:\n",
+    "                N //= p\n",
+    "            steps.append(N)\n",
+    "            break\n",
+    "    else:\n",
+    "        # N est premier : retirer son unique facteur premier restant.\n",
+    "        N = 1\n",
+    "        steps.append(N)\n",
+    "\n",
+    "omega_steps = [omega(step) for step in steps]\n",
+    "strict_decrease = [\n",
+    "    omega_steps[i] < omega_steps[i - 1]\n",
+    "    for i in range(1, len(omega_steps))\n",
+    "]\n",
+    "print(f\"Séquence de raffinement : {steps}\")\n",
+    "print(f\"ω à chaque étape : {omega_steps}\")\n",
+    "print(f\"ω décroît-elle strictement ? {strict_decrease}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7d7c3a2c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002129,
+     "end_time": "2026-08-27T16:51:12.460760+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.458631+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture du résultat\n",
     "\n",
@@ -462,51 +632,77 @@
     "\n",
     "### 3.3 Test de limite — quand τ ne transporte plus\n",
     "\n",
-    "On essaie de définir une τ analogue sur un problème **sans ordre partiel naturel**.\n",
-    ""
+    "On essaie de définir une τ analogue sur un problème **sans ordre partiel naturel**.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "id": "ec5c9125",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-27T16:51:12.465284Z",
+     "iopub.status.busy": "2026-08-27T16:51:12.465097Z",
+     "iopub.status.idle": "2026-08-27T16:51:12.468323Z",
+     "shell.execute_reply": "2026-08-27T16:51:12.467935Z"
+    },
+    "papermill": {
+     "duration": 0.006041,
+     "end_time": "2026-08-27T16:51:12.468774+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.462733+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Verdict Primitive 3 :\n  τ exige une STRUCTURE ORDONNÉE sous-jacente (entier strictement décroissant).\n  Transportable SOUS CONDITION (laquelle ? ordre partiel bien-fondé).\n  Pour les problèmes sans ordre canonique (SAT général), τ n'existe pas.\n"
+     "output_type": "stream",
+     "text": [
+      "Verdict Primitive 3 :\n",
+      "  τ exige une STRUCTURE ORDONNÉE sous-jacente (entier strictement décroissant).\n",
+      "  Transportable SOUS CONDITION (laquelle ? ordre partiel bien-fondé).\n",
+      "  Pour les problèmes sans ordre canonique (SAT général), τ n'existe pas.\n"
+     ]
     }
    ],
    "source": [
-    "# Test de limite : τ sur un problème SAT (booléen, sans ordre canonique)",
-    "# Problème : (x1 ∨ ¬x2) ∧ (¬x1 ∨ x2) ∧ (x1 ∨ x2)",
-    "# C'est satisfiable : x1=x2=True. Mais quelle τ ?",
-    "#",
-    "# Candidate 1 : τ = nombre de clauses non satisfaites. Mais elle dépend de l'affectation,",
-    "# pas de la structure du problème — donc elle NE décroît PAS sous raffinement structurel.",
-    "#",
-    "# Candidate 2 : τ = nombre de variables. Décroît si on fixe une variable, mais pas strictement",
-    "# (on peut fixer une variable sans changer la satisfaisabilité — ex. si x1 = True est forcé).",
-    "#",
-    "# Candidate 3 : τ = une mesure de « complexité de la formule ». Mais SAT n'a pas de τ canonique.",
-    "",
-    "# Conclusion : pour SAT, il n'y a PAS de τ naturelle au sens où PFR en a une.",
-    "# La descente monotone n'est pas universelle ; elle exige une STRUCTURE ORDONNÉE",
-    "# sous-jacente au problème.",
-    "",
-    "# Mais : pour des SOUS-classes de SAT (2-SAT, Horn-SAT), il existe des τ naturelles",
-    "# (ex. pour 2-SAT : τ = nombre de composantes fortement connexes dans le graphe d'implication).",
-    "",
-    "print(\"Verdict Primitive 3 :\")",
-    "print(\"  τ exige une STRUCTURE ORDONNÉE sous-jacente (entier strictement décroissant).\")",
-    "print(\"  Transportable SOUS CONDITION (laquelle ? ordre partiel bien-fondé).\")",
-    "print(\"  Pour les problèmes sans ordre canonique (SAT général), τ n'existe pas.\")",
-    ""
+    "# Test de limite : τ sur un problème SAT (booléen, sans ordre canonique)\n",
+    "# Problème : (x1 ∨ ¬x2) ∧ (¬x1 ∨ x2) ∧ (x1 ∨ x2)\n",
+    "# C'est satisfiable : x1=x2=True. Mais quelle τ ?\n",
+    "#\n",
+    "# Candidate 1 : τ = nombre de clauses non satisfaites. Mais elle dépend de l'affectation,\n",
+    "# pas de la structure du problème — donc elle NE décroît PAS sous raffinement structurel.\n",
+    "#\n",
+    "# Candidate 2 : τ = nombre de variables. Décroît si on fixe une variable, mais pas strictement\n",
+    "# (on peut fixer une variable sans changer la satisfaisabilité — ex. si x1 = True est forcé).\n",
+    "#\n",
+    "# Candidate 3 : τ = une mesure de « complexité de la formule ». Mais SAT n'a pas de τ canonique.\n",
+    "# Conclusion : pour SAT, il n'y a PAS de τ naturelle au sens où PFR en a une.\n",
+    "# La descente monotone n'est pas universelle ; elle exige une STRUCTURE ORDONNÉE\n",
+    "# sous-jacente au problème.\n",
+    "# Mais : pour des SOUS-classes de SAT (2-SAT, Horn-SAT), il existe des τ naturelles\n",
+    "# (ex. pour 2-SAT : τ = nombre de composantes fortement connexes dans le graphe d'implication).\n",
+    "print(\"Verdict Primitive 3 :\")\n",
+    "print(\"  τ exige une STRUCTURE ORDONNÉE sous-jacente (entier strictement décroissant).\")\n",
+    "print(\"  Transportable SOUS CONDITION (laquelle ? ordre partiel bien-fondé).\")\n",
+    "print(\"  Pour les problèmes sans ordre canonique (SAT général), τ n'existe pas.\")\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "6be6ac45",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001442,
+     "end_time": "2026-08-27T16:51:12.471877+00:00",
+     "exception": false,
+     "start_time": "2026-08-27T16:51:12.470435+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Verdict Primitive 3\n",
     "\n",
@@ -549,26 +745,34 @@
   }
  ],
  "metadata": {
+  "authors": [
+   {
+    "name": "myia-po-2025:CoursIA-2"
+   }
+  ],
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
   },
-  "title": "Lean-21b : Trois primitives de PFR, et l'endroit exact où elles cessent de valoir",
-  "authors": [
-   {
-    "name": "myia-po-2025:CoursIA-2"
-   }
-  ],
   "references": [
    "Lean-21-PFR-Entropy-Method.ipynb (companion upstream)",
    "Gowers, Green, Manners, Tao (novembre 2023) — On a conjecture of Marton",
    "https://github.com/teorth/pfr — formalisation collaborative Lean 4"
-  ]
+  ],
+  "title": "Lean-21b : Trois primitives de PFR, et l'endroit exact où elles cessent de valoir"
  },
  "nbformat": 4,
  "nbformat_minor": 5


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/tooling #13027

## Résumé

- corrige la procédure de raffinement de `ω(N)` pour retirer toute la valuation du plus petit facteur premier à chaque étape ;
- aligne ainsi la trace exécutée sur la descente stricte annoncée : `60 → 15 → 5 → 1` et `ω = 3 → 2 → 1 → 0` ;
- restaure les séparateurs de lignes manquants dans les six cellules Python, défaut préexistant révélé par l'exécution réelle ;
- réexécute intégralement le notebook avec le kernel `python3` et committe les sorties fraîches.

Closes #13244
See #13121

## Diagnostic dérive

**Cause :** `CAUSE_FIXED`

Deux causes source ont été corrigées, sans édition manuelle des sorties :

1. la procédure retirait une seule occurrence de `2` (`60 → 30`), ce qui conservait les mêmes trois facteurs premiers distincts et rendait faux le claim de décroissance stricte ;
2. les listes `source` des six cellules code avaient perdu leurs fins de ligne intermédiaires, de sorte que nbformat concaténait par exemple `import mathfrom collections ...` lors d'une exécution fraîche.

Le correctif retire toute la valuation du facteur choisi et restaure les frontières de lignes avant réexécution complète.

## Preuves post-fix

- Papermill : **SUCCESS**, 6 cellules code exécutées, 6 réussies, 0 échec ;
- trace fraîche : `Séquence de raffinement : [60, 15, 5, 1]` ;
- mesure fraîche : `ω à chaque étape : [3, 2, 1, 0]` ;
- assertion fraîche : `ω décroît-elle strictement ? [True, True, True]` ;
- `validate_pr_notebooks.py` : **1/1 passed** ;
- C.1 / C.3 : aucun finding ;
- C.2 : **1/1 compliant** ;
- séquence `execution_count` : **CLEAN (1..N)**, 6 cellules ;
- `nbformat.validate` : **PASS** ;
- sorties d'erreur : **0** ;
- chemins machine dans les outputs : **0** ;
- états Papermill failed/pending/cell-error : **0** ;
- code dans cellules markdown et erreurs de rendu markdown : aucune nouvelle violation.

## Périmètre

Un seul fichier modifié :

- `MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-21b-PFR-Primitives-Transportables.ipynb`

Les cinq cellules code hors primitive `ω` ne changent pas sémantiquement : seules leurs fins de ligne intermédiaires ont été restaurées, puis leurs sorties ont été régénérées par l'exécution complète.
