### PR TITLE
feat(ci,#12728): measure stale sweep queue separately

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -88,9 +88,9 @@ on:
     # them. Matching the cadence to the observed service time is what stops the
     # sweeps killing each other.
     #
-    # This does NOT fix the 99 % queue wait -- see #12728 T2, which routes this
-    # workflow to the self-hosted runners of #12704. Repair still arrives late;
-    # it just stops failing to arrive at all.
+    # This does NOT fix the queue wait. The final timing step below measures the
+    # run-created -> job-started queue separately from observed execution time;
+    # #12728 requires that evidence before any further cadence or runner change.
     - cron: '7 * * * *'
   workflow_dispatch:
     inputs:
@@ -322,3 +322,86 @@ jobs:
 
           # Advisory organ: it acts, it never blocks.
           exit 0
+
+      - name: Measure queue and observed execution separately
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          JOB_NAME: Re-aggregate stale PR gate verdicts
+        run: |
+          set -uo pipefail
+
+          RUN=$(gh api "repos/$REPO/actions/runs/$RUN_ID" 2>/dev/null) || {
+            echo "::warning::stale-sweep timing unavailable: run API failed"
+            exit 0
+          }
+          # The endpoint defaults to filter=latest. Keep it that way: filter=all
+          # includes prior attempts after a re-run and makes the current job name
+          # ambiguous, exactly when this workflow is measuring repeated service.
+          JOBS=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?filter=latest&per_page=100" 2>/dev/null) || {
+            echo "::warning::stale-sweep timing unavailable: jobs API failed"
+            exit 0
+          }
+
+          RUN_JSON="$RUN" JOBS_JSON="$JOBS" python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          def parse_timestamp(value, label):
+              if not value:
+                  raise ValueError(f"missing {label}")
+              text = value[:-1] + "+00:00" if value.endswith("Z") else value
+              parsed = datetime.fromisoformat(text)
+              if parsed.tzinfo is None:
+                  raise ValueError(f"timezone missing from {label}")
+              return parsed.astimezone(timezone.utc)
+
+          try:
+              run = json.loads(os.environ["RUN_JSON"])
+              jobs_payload = json.loads(os.environ["JOBS_JSON"])
+              jobs = [
+                  job for job in jobs_payload.get("jobs", [])
+                  if job.get("name") == os.environ["JOB_NAME"]
+              ]
+              if len(jobs) != 1:
+                  raise ValueError(
+                      f"expected one current job named {os.environ['JOB_NAME']!r}, "
+                      f"found {len(jobs)}"
+                  )
+
+              job = jobs[0]
+              created = parse_timestamp(run.get("created_at"), "run.created_at")
+              started = parse_timestamp(job.get("started_at"), "job.started_at")
+              measured = datetime.now(timezone.utc)
+              queue_seconds = (started - created).total_seconds()
+              execution_seconds = (measured - started).total_seconds()
+              if queue_seconds < 0 or execution_seconds < 0:
+                  raise ValueError(
+                      "negative duration: "
+                      f"queue={queue_seconds}, execution={execution_seconds}"
+                  )
+
+              lines = [
+                  "## Stale-sweep timing (#12728)",
+                  "",
+                  "Measured from job-level timestamps; `run_started_at` is not used.",
+                  "",
+                  f"- Run created: `{run['created_at']}`",
+                  f"- Job started: `{job['started_at']}`",
+                  f"- Measured at: `{measured.isoformat().replace('+00:00', 'Z')}`",
+                  f"- Queue: **{queue_seconds:.0f} s**",
+                  f"- Observed execution: **{execution_seconds:.0f} s**",
+              ]
+              with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+                  summary.write("\n".join(lines) + "\n")
+              print(
+                  "[stale-sweep] timing: "
+                  f"queue_seconds={queue_seconds:.0f} "
+                  f"observed_execution_seconds={execution_seconds:.0f}"
+              )
+          except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+              print(f"::warning::stale-sweep timing unavailable: {exc}")
+          PY

--- a/scripts/tests/test_pr_gate_sweep_timing.py
+++ b/scripts/tests/test_pr_gate_sweep_timing.py
@@ -1,0 +1,112 @@
+"""Execute the stale-sweep timing heredoc verbatim (#12728).
+
+The instrument must separate run creation -> job start (queue) from job start
+-> measurement time (observed execution). It deliberately ignores
+``run_started_at``, which GitHub can set equal to ``created_at`` while the job
+is still waiting for a runner.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr-gate-stale-sweep.yml"
+JOB_NAME = "Re-aggregate stale PR gate verdicts"
+
+
+def _extract_instrument() -> str:
+    with WORKFLOW.open(encoding="utf-8") as stream:
+        document = yaml.safe_load(stream)
+    step = document["jobs"]["sweep"]["steps"][1]
+    assert step["if"] == "always()"
+    run = step["run"]
+    assert "jobs?filter=latest&per_page=100" in run
+    assert "jobs?filter=all" not in run
+    match = re.search(r"python - <<'PY'\n(.*?)\nPY\n?$", run, re.S)
+    assert match, "timing heredoc missing from pr-gate-stale-sweep.yml"
+    return match.group(1)
+
+
+INSTRUMENT = _extract_instrument()
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _run_instrument(tmp_path: Path, run: dict, jobs: list[dict]):
+    summary = tmp_path / "summary.md"
+    env = dict(
+        os.environ,
+        RUN_JSON=json.dumps(run),
+        JOBS_JSON=json.dumps({"jobs": jobs}),
+        JOB_NAME=JOB_NAME,
+        GITHUB_STEP_SUMMARY=str(summary),
+    )
+    completed = subprocess.run(
+        ["python", "-c", INSTRUMENT],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=env,
+        check=False,
+    )
+    return completed, summary
+
+
+def test_job_start_measures_queue_and_ignores_run_started_at(tmp_path):
+    now = datetime.now(timezone.utc)
+    created = now - timedelta(minutes=12)
+    started = now - timedelta(minutes=2)
+    run = {
+        "created_at": _iso(created),
+        # This misleading run-level timestamp is intentionally equal to creation.
+        "run_started_at": _iso(created),
+    }
+    jobs = [{"name": JOB_NAME, "started_at": _iso(started)}]
+
+    completed, summary = _run_instrument(tmp_path, run, jobs)
+
+    assert completed.returncode == 0
+    assert "queue_seconds=600" in completed.stdout
+    assert "observed_execution_seconds=120" in completed.stdout
+    rendered = summary.read_text(encoding="utf-8")
+    assert "Queue: **600 s**" in rendered
+    assert "Observed execution: **120 s**" in rendered
+    assert "`run_started_at` is not used" in rendered
+
+
+def test_missing_job_timestamp_warns_without_fabricating_zero(tmp_path):
+    now = datetime.now(timezone.utc)
+    run = {"created_at": _iso(now), "run_started_at": _iso(now)}
+    jobs = [{"name": JOB_NAME, "started_at": None}]
+
+    completed, summary = _run_instrument(tmp_path, run, jobs)
+
+    assert completed.returncode == 0
+    assert "::warning::stale-sweep timing unavailable: missing job.started_at" in completed.stdout
+    assert "queue_seconds=0" not in completed.stdout
+    assert not summary.exists()
+
+
+def test_ambiguous_job_match_warns_instead_of_selecting_one(tmp_path):
+    now = datetime.now(timezone.utc)
+    run = {"created_at": _iso(now)}
+    jobs = [
+        {"name": JOB_NAME, "started_at": _iso(now)},
+        {"name": JOB_NAME, "started_at": _iso(now)},
+    ]
+
+    completed, summary = _run_instrument(tmp_path, run, jobs)
+
+    assert completed.returncode == 0
+    assert "expected one current job" in completed.stdout
+    assert not summary.exists()

--- a/scripts/tests/test_pr_gate_sweep_timing.py
+++ b/scripts/tests/test_pr_gate_sweep_timing.py
@@ -77,10 +77,15 @@ def test_job_start_measures_queue_and_ignores_run_started_at(tmp_path):
 
     assert completed.returncode == 0
     assert "queue_seconds=600" in completed.stdout
-    assert "observed_execution_seconds=120" in completed.stdout
+    execution_match = re.search(
+        r"\bobserved_execution_seconds=(\d+)\b", completed.stdout
+    )
+    assert execution_match
+    execution_seconds = int(execution_match.group(1))
+    assert 120 <= execution_seconds < 130
     rendered = summary.read_text(encoding="utf-8")
     assert "Queue: **600 s**" in rendered
-    assert "Observed execution: **120 s**" in rendered
+    assert f"Observed execution: **{execution_seconds} s**" in rendered
     assert "`run_started_at` is not used" in rendered
 
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA — prev: MED/notebook-lean #13247  ## Summary  - instrument the stale PR-gate sweep with job-level timing - report `run.created_at -> job.started_at` as queue time - report `job.started_at -> measurement` as observed execution time - keep the organ advisory: missing, ambiguous, or incoherent timestamps warn without fabricating a zero - retain `filter=latest` so prior rerun attempts cannot make the current job ambiguous  No cron, `runs-on`, self-hosted activation, or runner routing is changed.  ## Validation  - `python -m pytest scripts/tests/test_pr_gate_sweep_timing.py scripts/tests/test_pr_gate_sweep_select.py scripts/tests/test_check_self_hosted_runner_policy.py scripts/tests/test_check_pr_perimeter.py -q` — 172 passed - `python scripts/ci/check_self_hosted_runner_policy.py --check` — 115 workflows, 141 jobs, 1 self-hosted, 0 violation - workflow YAML parse — PASS - `git diff --check` — PASS  ## Acceptance scope  This is the instrumentation prerequisite requested by #12728 before any further cadence or runner decision. The first scheduled or manual run after merge will provide the live queue/execution split; this PR does not claim that measurement in advance.  See #12728 