### PR TITLE
ci(guards,#13246): retire paths-filter from perimeter-review-guard

### DIFF
--- a/.github/workflows/perimeter-review-guard.yml
+++ b/.github/workflows/perimeter-review-guard.yml
@@ -54,32 +54,19 @@ name: perimeter-review-guard
 # properties at once (#11648, point 2).
 
 on:
+  # #13246 : the #13193 paths-filter is REMOVED (measured, decision rule
+  # pre-registered on the issue): over the last 100 merged PRs, 44 carried
+  # perimeter assertions on files matching NONE of the filter patterns --
+  # the guard skipped exactly the assertions it exists to confront. The
+  # guard is metadata-dependent (PR body + reviews vs `gh pr view
+  # --json files`), so a diff-derived filter disarms it on every
+  # non-workflow PR.
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize, edited, reopened ]
-    # #12773 tranche 1a + amend. #13193 Hermes : paths-filter pour limiter les
-    # declenchements aux PR touchant la surface reelle du garde. Le script
-    # interroge l'API `gh pr view` uniquement (pas de lecture d'arbre), mais
-    # le filtre DOIT inclure les autres workflows CI : sans le glob
-    # `.github/workflows/**`, le garde ne tournerait plus que sur lui-meme
-    # (cf. incident fondateur #11268 : un workflow qui modifie le
-    # sorry-baseline passait inapercu parce que la porte se fermait sur la
-    # fonction du garde).
-    paths:
-      - '.github/workflows/perimeter-review-guard.yml'
-      - '.github/workflows/**'
-      - 'scripts/check_pr_perimeter.py'
-      - 'scripts/tests/test_check_pr_perimeter.py'
   pull_request_review:
     branches: [ main ]
     types: [ submitted, edited ]
-    # Meme filtre cote review : un commentaire de revue qui corrige le body doit
-    # aussi re-tourner le check, sur toute PR touchant la surface surveillee.
-    paths:
-      - '.github/workflows/perimeter-review-guard.yml'
-      - '.github/workflows/**'
-      - 'scripts/check_pr_perimeter.py'
-      - 'scripts/tests/test_check_pr_perimeter.py'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Retire le `paths:` filter que #13193 a pose sur les DEUX declencheurs de `perimeter-review-guard.yml`. Le garde est **metadata-dependent** : il confronte les assertions de perimetre (body PR + reviews via `--scan-thread`) avec `gh pr view --json files` — aucune lecture d'arbre. Un filtre derive du diff desarme donc le garde sur exactement les PR qu'il existe pour verifier.

## Mesure (1) — regle pre-enregistree

Script : parser du garde lui-meme (`extract_perimeter_assertions` de `scripts/check_pr_perimeter.py`) sur les bodies des 100 dernieres PRs mergees, croises avec l'ensemble de declenchement du filtre (prefixe `.github/workflows/` + les 2 chemins scripts exacts). 2026-08-27.

| Categorie | Count |
|---|---|
| PRs scannees | 100 |
| Sans assertion de perimetre (filtre sans effet) | 47 |
| Assertion + le filtre declencherait (armees) | 9 |
| **Assertion + le filtre SAUTE (desarmees)** | **44** |

44 PRs recentes portaient des assertions que le garde n'a jamais confrontees (notebooks, scripts, docs — ex. #13229, #13206, #13197, #13119, #12891...). Regle pre-enregistree sur l'issue : *un compte non nul condamne le filtre*.

## Controle positif (2) — les trois jambes

1. **Detecteur operationnel** : `python scripts/check_pr_perimeter.py 13154 --assert "Perimetre : 1 fichier uniquement, aucune autre modification"` → `VERDICT: FAIL` (la PR a 3 fichiers). Le detecteur attraperait l'assertion fausse.
2. **Le filtre saute l'evenement** : les 3 fichiers de #13154 (notebook + README + twin yaml) matchent **0 des 8 patterns** du YAML live (fnmatch, verifie). Semantique documentee `on.<event>.paths` : pas de match → workflow non declenche.
3. **Rollup** : la derniere run du garde sur #13154 date de 09:50:22Z (run 33060372609), **anterieure** au merge du filtre 16:54:23Z, meme head SHA — vestige pre-filtre, aucune run post-filtre ne peut exister sur une PR hors-workflows (le filtre est dans le dernier merge de main).

## Registre METADATA_DEPENDENT_GUARDS

Absent de main (`grep -rn METADATA_DEPENDENT scripts/` vide — #13234 non merge). Le retrait est donc documente inline dans le workflow (commentaire `# #13246` sur le bloc `on:`) ; l'inscription au registre se fera dans #13234 si/lorsqu'il merge — pas de test ad-hoc ici, conformement a l'acceptance.

Note : `scripts/tests/test_variation_tag_required.py` enforce deja le no-`paths:` pour `variation-tag-guard.yml` avec le rationale #10045 (« pending forever sur les PR hors filtre ») — meme classe d'argument.

## Test plan

- [x] YAML parse (`yaml.safe_load`) : `types` preserves sur les deux declencheurs, plus aucune cle `paths`
- [x] Regex no-`paths:` du style test_variation_tag_required (`^  paths:`) : plus de match
- [ ] CI : la presente PR touche `.github/workflows/**` → le garde tournera sur elle-meme (armed par definition)

Closes #13246