### PR TITLE
fix(gametheory): make grim punishment absorbing

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06b-Lean-RepeatedGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06b-Lean-RepeatedGames.ipynb
@@ -5,10 +5,10 @@
    "id": "b4daaeab",
    "metadata": {
     "papermill": {
-     "duration": 0.004381,
-     "end_time": "2026-08-20T20:33:55.153268+00:00",
+     "duration": 0.005264,
+     "end_time": "2026-08-27T18:53:58.433313+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.148887+00:00",
+     "start_time": "2026-08-27T18:53:58.428049+00:00",
      "status": "completed"
     },
     "tags": []
@@ -19,10 +19,10 @@
     "**Compagnon formel de [GameTheory-06c-RepeatedGames-FolkTheorem](GameTheory-06c-RepeatedGames-FolkTheorem.ipynb).**\n",
     "Le 6c dérive à la main, en Python, l'effondrement par induction arrière, la condition de\n",
     "crédibilité du grim trigger $\\delta \\geq (T-R)/(T-P)$ et le Folk Theorem. Ce notebook\n",
-    "**6b** montre la contrepartie formelle : le lake\n",
-    "[`game_theory_lean`](game_theory_lean/), dont les modules `RepeatedGames/` (Stage,\n",
-    "Discounting, GrimTrigger, Folk) portent ces résultats **prouvés en Lean 4**, module par\n",
-    "module, fichier réel à l'appui.\n",
+    "**6b** montre les briques formelles disponibles dans le lake\n",
+    "[`game_theory_lean`](game_theory_lean/) : jeu de stage, flux actualisés, transition\n",
+    "grim irréversible et condition d'incitation en une déviation. Le lake ne formalise pas\n",
+    "encore une sémantique complète des historiques et profils de stratégies/SPNE.\n",
     "\n",
     "Pourquoi ce compagnon existe : la mesure de visibilité de l'EPIC #11703\n",
     "(`scripts/lean/scan_lake_notebook_visibility.py`) montrait **7 modules noirs sur 19**\n",
@@ -36,7 +36,7 @@
     "|---|---|---|\n",
     "| `RepeatedGames/Stage.lean` | Le jeu de stage : le Dilemme du Prisonnier paramétré `T, R, P, S` | 0 sorry |\n",
     "| `RepeatedGames/Discounting.lean` | Sommes géométriques, seuil critique $\\delta^* = (T-R)/(T-P)$ | 0 sorry |\n",
-    "| `RepeatedGames/GrimTrigger.lean` | Le théorème-phare `grim_trigger_sustains_iff` (#4880) | 0 sorry |\n",
+    "| `RepeatedGames/GrimTrigger.lean` | Transition grim absorbante + condition d'incitation `grim_trigger_sustains_iff` | 0 sorry |\n",
     "| `RepeatedGames/Folk.lean` | Folk Theorem actualisé (Fudenberg-Maskin) | 1 sorry STRETCH assumé |\n",
     "| `CooperativeGames/ConeKernel.lean` | Noyau cône-fermé pour Bondareva-Farkas (#2959) | 0 sorry |\n",
     "| `SocialChoice/SortedListCounting.lean` | Helpers de comptage trié pour le median voter | 0 sorry |\n",
@@ -46,7 +46,7 @@
     "déclarations du fichier réel (parsing léger du source), affiche la première ligne de\n",
     "docstring — le texte que le lecteur verrait en ouvrant le fichier — et croise avec la\n",
     "théorie du 6c. Aucune cellule ne « recopie » une preuve : le fichier Lean **est** la\n",
-    "preuve ; ici on apprend où elle vit et ce qu'elle dit.\n",
+    "source formelle ; ici on apprend où elle vit et ce qu'elle dit exactement.\n",
     "\n",
     "**Repère d'orientation** : si vous explorez le disque, le répertoire `repeated_games_lean/` du dossier GameTheory est une **coquille archive** — depuis la PR #6146 (EPIC #4365 Phase-4), les quatre modules sources (`Stage`, `Discounting`, `GrimTrigger`, `Folk`) sont absorbés byte-identique dans `game_theory_lean/RepeatedGames/`, home canonique (`@[default_target]` du lakefile de `game_theory_lean`). C'est ce home canonique que ce notebook lit."
    ]
@@ -57,16 +57,16 @@
    "id": "f8a86cf9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.165620Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.165386Z",
-     "iopub.status.idle": "2026-08-20T20:33:55.237736Z",
-     "shell.execute_reply": "2026-08-20T20:33:55.237221Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.443771Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.443486Z",
+     "iopub.status.idle": "2026-08-27T18:53:58.465759Z",
+     "shell.execute_reply": "2026-08-27T18:53:58.464555Z"
     },
     "papermill": {
-     "duration": 0.08137,
-     "end_time": "2026-08-20T20:33:55.238561+00:00",
+     "duration": 0.028824,
+     "end_time": "2026-08-27T18:53:58.466798+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.157191+00:00",
+     "start_time": "2026-08-27T18:53:58.437974+00:00",
      "status": "completed"
     },
     "tags": []
@@ -79,7 +79,7 @@
       "Lake: MyIA.AI.Notebooks\\GameTheory\\game_theory_lean\n",
       "  RepeatedGames\\Stage.lean: 7 declarations, 0 sorry (code)\n",
       "  RepeatedGames\\Discounting.lean: 4 declarations, 0 sorry (code)\n",
-      "  RepeatedGames\\GrimTrigger.lean: 2 declarations, 0 sorry (code)\n",
+      "  RepeatedGames\\GrimTrigger.lean: 7 declarations, 0 sorry (code)\n",
       "  RepeatedGames\\Folk.lean: 5 declarations, 1 sorry (code)\n",
       "  CooperativeGames\\ConeKernel.lean: 16 declarations, 0 sorry (code)\n",
       "  SocialChoice\\SortedListCounting.lean: 5 declarations, 0 sorry (code)\n",
@@ -152,10 +152,10 @@
    "id": "149ec537",
    "metadata": {
     "papermill": {
-     "duration": 0.003576,
-     "end_time": "2026-08-20T20:33:55.245684+00:00",
+     "duration": 0.004261,
+     "end_time": "2026-08-27T18:53:58.475464+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.242108+00:00",
+     "start_time": "2026-08-27T18:53:58.471203+00:00",
      "status": "completed"
     },
     "tags": []
@@ -175,10 +175,10 @@
    "id": "db0793f0",
    "metadata": {
     "papermill": {
-     "duration": 0.003539,
-     "end_time": "2026-08-20T20:33:55.252588+00:00",
+     "duration": 0.004417,
+     "end_time": "2026-08-27T18:53:58.484158+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.249049+00:00",
+     "start_time": "2026-08-27T18:53:58.479741+00:00",
      "status": "completed"
     },
     "tags": []
@@ -202,16 +202,16 @@
    "id": "670b1be1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.263379Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.262744Z",
-     "iopub.status.idle": "2026-08-20T20:33:55.267330Z",
-     "shell.execute_reply": "2026-08-20T20:33:55.266858Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.494602Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.494328Z",
+     "iopub.status.idle": "2026-08-27T18:53:58.501616Z",
+     "shell.execute_reply": "2026-08-27T18:53:58.500550Z"
     },
     "papermill": {
-     "duration": 0.011861,
-     "end_time": "2026-08-20T20:33:55.268284+00:00",
+     "duration": 0.013932,
+     "end_time": "2026-08-27T18:53:58.502565+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.256423+00:00",
+     "start_time": "2026-08-27T18:53:58.488633+00:00",
      "status": "completed"
     },
     "tags": []
@@ -246,10 +246,10 @@
    "id": "d93b1c2e",
    "metadata": {
     "papermill": {
-     "duration": 0.003953,
-     "end_time": "2026-08-20T20:33:55.276372+00:00",
+     "duration": 0.004521,
+     "end_time": "2026-08-27T18:53:58.511804+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.272419+00:00",
+     "start_time": "2026-08-27T18:53:58.507283+00:00",
      "status": "completed"
     },
     "tags": []
@@ -269,10 +269,10 @@
    "id": "02bfa3aa",
    "metadata": {
     "papermill": {
-     "duration": 0.005092,
-     "end_time": "2026-08-20T20:33:55.285571+00:00",
+     "duration": 0.004401,
+     "end_time": "2026-08-27T18:53:58.520640+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.280479+00:00",
+     "start_time": "2026-08-27T18:53:58.516239+00:00",
      "status": "completed"
     },
     "tags": []
@@ -295,16 +295,16 @@
    "id": "cfa6c8fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.297299Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.296931Z",
-     "iopub.status.idle": "2026-08-20T20:33:55.305985Z",
-     "shell.execute_reply": "2026-08-20T20:33:55.304976Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.534848Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.534570Z",
+     "iopub.status.idle": "2026-08-27T18:53:58.543968Z",
+     "shell.execute_reply": "2026-08-27T18:53:58.542725Z"
     },
     "papermill": {
-     "duration": 0.016393,
-     "end_time": "2026-08-20T20:33:55.306927+00:00",
+     "duration": 0.016171,
+     "end_time": "2026-08-27T18:53:58.544943+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.290534+00:00",
+     "start_time": "2026-08-27T18:53:58.528772+00:00",
      "status": "completed"
     },
     "tags": []
@@ -350,10 +350,10 @@
    "id": "42acd790",
    "metadata": {
     "papermill": {
-     "duration": 0.003584,
-     "end_time": "2026-08-20T20:33:55.314329+00:00",
+     "duration": 0.004738,
+     "end_time": "2026-08-27T18:53:58.559842+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.310745+00:00",
+     "start_time": "2026-08-27T18:53:58.555104+00:00",
      "status": "completed"
     },
     "tags": []
@@ -373,10 +373,10 @@
    "id": "ed46141a",
    "metadata": {
     "papermill": {
-     "duration": 0.00418,
-     "end_time": "2026-08-20T20:33:55.322343+00:00",
+     "duration": 0.004489,
+     "end_time": "2026-08-27T18:53:58.568850+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.318163+00:00",
+     "start_time": "2026-08-27T18:53:58.564361+00:00",
      "status": "completed"
     },
     "tags": []
@@ -402,16 +402,16 @@
    "id": "01868e2a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.333659Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.333107Z",
-     "iopub.status.idle": "2026-08-20T20:33:55.343533Z",
-     "shell.execute_reply": "2026-08-20T20:33:55.342139Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.581217Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.580750Z",
+     "iopub.status.idle": "2026-08-27T18:53:58.587585Z",
+     "shell.execute_reply": "2026-08-27T18:53:58.586372Z"
     },
     "papermill": {
-     "duration": 0.017597,
-     "end_time": "2026-08-20T20:33:55.344247+00:00",
+     "duration": 0.014026,
+     "end_time": "2026-08-27T18:53:58.588598+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.326650+00:00",
+     "start_time": "2026-08-27T18:53:58.574572+00:00",
      "status": "completed"
     },
     "tags": []
@@ -445,25 +445,29 @@
    "id": "b61b081b",
    "metadata": {
     "papermill": {
-     "duration": 0.003914,
-     "end_time": "2026-08-20T20:33:55.352274+00:00",
+     "duration": 0.004377,
+     "end_time": "2026-08-27T18:53:58.597426+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.348360+00:00",
+     "start_time": "2026-08-27T18:53:58.593049+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 3. `GrimTrigger.lean` — le théorème-phare, 0 sorry (#4880)\n",
+    "## 3. `GrimTrigger.lean` — transition grim et condition d'incitation, 0 sorry\n",
     "\n",
-    "La stratégie `grimNext` (coopérer tant que l'adversaire coopère, dévier pour toujours\n",
-    "dès la première défection), puis le résultat central :\n",
-    "**`grim_trigger_sustains_iff`** — la coopération est soutenable contre déviation en un\n",
-    "coup *si et seulement si* $\\delta \\geq (T-R)/(T-P)$. Ce théorème est le\n",
-    "théorème-phare de l'issue #4880, livré **0 sorry** : sa preuve est une réduction nette\n",
-    "au seuil de `Discounting` (`exact coop_ge_deviate_iff g h0 h1`). Le one-shot deviation\n",
-    "principle fait le reste : pour une stratégie stationnaire, vérifier toutes les\n",
-    "déviation équivaut à vérifier celles d'un seul coup."
+    "La transition `grimNext` encode désormais explicitement les deux états du grim trigger :\n",
+    "coopération tant qu'aucune défection n'a été observée, puis punition irréversible. Les\n",
+    "lemmes de transition vérifient notamment que `defect` est un état absorbant.\n",
+    "\n",
+    "**`grim_trigger_sustains_iff`** établit ensuite la condition d'incitation en une\n",
+    "déviation : le flux coopératif domine une déviation suivie de la punition *si et\n",
+    "seulement si* $\\delta \\geq (T-R)/(T-P)$. La preuve Lean, sans `sorry`, réduit cette\n",
+    "comparaison au seuil de `Discounting` (`exact coop_ge_deviate_iff g h0 h1`).\n",
+    "\n",
+    "Cette équivalence est une brique de la preuve classique par déviation en un coup, pas\n",
+    "encore une formalisation complète d'un SPNE : le module ne définit ni historiques ni\n",
+    "profils de stratégies."
    ]
   },
   {
@@ -472,16 +476,16 @@
    "id": "be62cf10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.361240Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.361002Z",
-     "iopub.status.idle": "2026-08-20T20:33:55.367844Z",
-     "shell.execute_reply": "2026-08-20T20:33:55.366805Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.608356Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.607912Z",
+     "iopub.status.idle": "2026-08-27T18:53:58.615340Z",
+     "shell.execute_reply": "2026-08-27T18:53:58.614228Z"
     },
     "papermill": {
-     "duration": 0.012709,
-     "end_time": "2026-08-20T20:33:55.368855+00:00",
+     "duration": 0.01444,
+     "end_time": "2026-08-27T18:53:58.616383+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.356146+00:00",
+     "start_time": "2026-08-27T18:53:58.601943+00:00",
      "status": "completed"
     },
     "tags": []
@@ -492,8 +496,13 @@
      "output_type": "stream",
      "text": [
       "--- RepeatedGames\\GrimTrigger.lean ---\n",
-      "  def          grimNext                               recopier le coup adverse de la période précédente (coopérer s'il a coopé\n",
-      "  theorem      grim_trigger_sustains_iff              Une déviation unilatérale en un coup n'est pas profitable (i.e. grim tri\n",
+      "  def          grimNext                               `defect` signifie que la phase de punition a déjà commencé. Cet état est\n",
+      "  theorem      grimNext_cooperate_cooperate           \n",
+      "  theorem      grimNext_cooperate_defect              \n",
+      "  theorem      grimNext_defect_cooperate              \n",
+      "  theorem      grimNext_defect_defect                 \n",
+      "  theorem      grimPunishment_absorbing               \n",
+      "  theorem      grim_trigger_sustains_iff              `δ ≥ (T − R) / (T − P)`.**\n",
       "sorry (code): 0\n"
      ]
     }
@@ -511,21 +520,22 @@
    "id": "50bab853",
    "metadata": {
     "papermill": {
-     "duration": 0.00386,
-     "end_time": "2026-08-20T20:33:55.376861+00:00",
+     "duration": 0.004717,
+     "end_time": "2026-08-27T18:53:58.625752+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.373001+00:00",
+     "start_time": "2026-08-27T18:53:58.621035+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : un théorème-phare qui tient en une ligne\n",
+    "### Lecture du résultat : la frontière formelle est maintenant explicite\n",
     "\n",
-    "Deux déclarations : la stratégie, le théorème. Et `sorry (code): 0` — la dette du\n",
-    "sprint #4880 est soldée sur le phare ; l'énoncé `iff` est la forme la plus forte\n",
-    "(caractérisation exacte du seuil, pas une implication partielle). C'est le socle que\n",
-    "le Folk Theorem généralise."
+    "Le module expose la transition grim, ses lemmes de cas et l'état de punition absorbant,\n",
+    "puis une équivalence `iff` exacte pour la condition d'incitation. Le compte\n",
+    "`sorry (code): 0` certifie ces briques. Il ne certifie pas une sémantique complète\n",
+    "d'équilibre : cette extension demanderait de formaliser les historiques, les profils de\n",
+    "stratégies et les déviations admissibles."
    ]
   },
   {
@@ -533,10 +543,10 @@
    "id": "f30cb0d9",
    "metadata": {
     "papermill": {
-     "duration": 0.004672,
-     "end_time": "2026-08-20T20:33:55.385748+00:00",
+     "duration": 0.004518,
+     "end_time": "2026-08-27T18:53:58.634891+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.381076+00:00",
+     "start_time": "2026-08-27T18:53:58.630373+00:00",
      "status": "completed"
     },
     "tags": []
@@ -570,16 +580,16 @@
    "id": "3a3cc72f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.395885Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.395503Z",
-     "iopub.status.idle": "2026-08-20T20:33:55.402987Z",
-     "shell.execute_reply": "2026-08-20T20:33:55.401862Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.648164Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.647709Z",
+     "iopub.status.idle": "2026-08-27T18:53:58.655388Z",
+     "shell.execute_reply": "2026-08-27T18:53:58.654411Z"
     },
     "papermill": {
-     "duration": 0.013731,
-     "end_time": "2026-08-20T20:33:55.403841+00:00",
+     "duration": 0.015795,
+     "end_time": "2026-08-27T18:53:58.656787+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.390110+00:00",
+     "start_time": "2026-08-27T18:53:58.640992+00:00",
      "status": "completed"
     },
     "tags": []
@@ -612,10 +622,10 @@
    "id": "8a4b5d58",
    "metadata": {
     "papermill": {
-     "duration": 0.004078,
-     "end_time": "2026-08-20T20:33:55.411904+00:00",
+     "duration": 0.004691,
+     "end_time": "2026-08-27T18:53:58.666212+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.407826+00:00",
+     "start_time": "2026-08-27T18:53:58.661521+00:00",
      "status": "completed"
     },
     "tags": []
@@ -634,10 +644,10 @@
    "id": "da25db9f",
    "metadata": {
     "papermill": {
-     "duration": 0.00414,
-     "end_time": "2026-08-20T20:33:55.420444+00:00",
+     "duration": 0.004696,
+     "end_time": "2026-08-27T18:53:58.675563+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.416304+00:00",
+     "start_time": "2026-08-27T18:53:58.670867+00:00",
      "status": "completed"
     },
     "tags": []
@@ -664,16 +674,16 @@
    "id": "6640d0e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.429678Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.429437Z",
-     "iopub.status.idle": "2026-08-20T20:33:55.436108Z",
-     "shell.execute_reply": "2026-08-20T20:33:55.434987Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.693432Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.693138Z",
+     "iopub.status.idle": "2026-08-27T18:53:58.699801Z",
+     "shell.execute_reply": "2026-08-27T18:53:58.698616Z"
     },
     "papermill": {
-     "duration": 0.012562,
-     "end_time": "2026-08-20T20:33:55.436936+00:00",
+     "duration": 0.013808,
+     "end_time": "2026-08-27T18:53:58.700852+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.424374+00:00",
+     "start_time": "2026-08-27T18:53:58.687044+00:00",
      "status": "completed"
     },
     "tags": []
@@ -706,10 +716,10 @@
    "id": "6c25ad89",
    "metadata": {
     "papermill": {
-     "duration": 0.00409,
-     "end_time": "2026-08-20T20:33:55.445249+00:00",
+     "duration": 0.004931,
+     "end_time": "2026-08-27T18:53:58.710535+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.441159+00:00",
+     "start_time": "2026-08-27T18:53:58.705604+00:00",
      "status": "completed"
     },
     "tags": []
@@ -736,16 +746,16 @@
    "id": "484c1177",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.457843Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.457492Z",
-     "iopub.status.idle": "2026-08-20T20:33:55.467505Z",
-     "shell.execute_reply": "2026-08-20T20:33:55.466534Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.721828Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.721388Z",
+     "iopub.status.idle": "2026-08-27T18:53:58.731487Z",
+     "shell.execute_reply": "2026-08-27T18:53:58.730594Z"
     },
     "papermill": {
-     "duration": 0.018268,
-     "end_time": "2026-08-20T20:33:55.468377+00:00",
+     "duration": 0.017228,
+     "end_time": "2026-08-27T18:53:58.732645+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.450109+00:00",
+     "start_time": "2026-08-27T18:53:58.715417+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,10 +800,10 @@
    "id": "452b18ca",
    "metadata": {
     "papermill": {
-     "duration": 0.0041,
-     "end_time": "2026-08-20T20:33:55.476712+00:00",
+     "duration": 0.004633,
+     "end_time": "2026-08-27T18:53:58.742027+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.472612+00:00",
+     "start_time": "2026-08-27T18:53:58.737394+00:00",
      "status": "completed"
     },
     "tags": []
@@ -811,10 +821,10 @@
    "id": "7c721a67",
    "metadata": {
     "papermill": {
-     "duration": 0.004217,
-     "end_time": "2026-08-20T20:33:55.485475+00:00",
+     "duration": 0.009241,
+     "end_time": "2026-08-27T18:53:58.755971+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.481258+00:00",
+     "start_time": "2026-08-27T18:53:58.746730+00:00",
      "status": "completed"
     },
     "tags": []
@@ -837,16 +847,16 @@
    "id": "3172db35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.495569Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.495197Z",
-     "iopub.status.idle": "2026-08-20T20:33:55.503718Z",
-     "shell.execute_reply": "2026-08-20T20:33:55.502613Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.769359Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.769051Z",
+     "iopub.status.idle": "2026-08-27T18:53:58.777491Z",
+     "shell.execute_reply": "2026-08-27T18:53:58.776329Z"
     },
     "papermill": {
-     "duration": 0.014749,
-     "end_time": "2026-08-20T20:33:55.504452+00:00",
+     "duration": 0.016072,
+     "end_time": "2026-08-27T18:53:58.778595+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.489703+00:00",
+     "start_time": "2026-08-27T18:53:58.762523+00:00",
      "status": "completed"
     },
     "tags": []
@@ -884,10 +894,10 @@
    "id": "da65d8b1",
    "metadata": {
     "papermill": {
-     "duration": 0.004505,
-     "end_time": "2026-08-20T20:33:55.513162+00:00",
+     "duration": 0.004848,
+     "end_time": "2026-08-27T18:53:58.788421+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.508657+00:00",
+     "start_time": "2026-08-27T18:53:58.783573+00:00",
      "status": "completed"
     },
     "tags": []
@@ -906,10 +916,10 @@
    "id": "f503783b",
    "metadata": {
     "papermill": {
-     "duration": 0.004188,
-     "end_time": "2026-08-20T20:33:55.521634+00:00",
+     "duration": 0.004596,
+     "end_time": "2026-08-27T18:53:58.797751+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.517446+00:00",
+     "start_time": "2026-08-27T18:53:58.793155+00:00",
      "status": "completed"
     },
     "tags": []
@@ -936,16 +946,16 @@
    "id": "f66877fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.531639Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.531286Z",
-     "iopub.status.idle": "2026-08-20T20:33:55.537696Z",
-     "shell.execute_reply": "2026-08-20T20:33:55.536633Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.808980Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.808500Z",
+     "iopub.status.idle": "2026-08-27T18:53:58.815219Z",
+     "shell.execute_reply": "2026-08-27T18:53:58.813812Z"
     },
     "papermill": {
-     "duration": 0.012594,
-     "end_time": "2026-08-20T20:33:55.538575+00:00",
+     "duration": 0.013887,
+     "end_time": "2026-08-27T18:53:58.816314+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.525981+00:00",
+     "start_time": "2026-08-27T18:53:58.802427+00:00",
      "status": "completed"
     },
     "tags": []
@@ -955,7 +965,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : plan_pont (4 etapes)\n"
+      "Exercice a completer : plan_pont (4 etapes)"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -979,10 +996,10 @@
    "id": "94b1cc96",
    "metadata": {
     "papermill": {
-     "duration": 0.00419,
-     "end_time": "2026-08-20T20:33:55.547213+00:00",
+     "duration": 0.004908,
+     "end_time": "2026-08-27T18:53:58.826249+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.543023+00:00",
+     "start_time": "2026-08-27T18:53:58.821341+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1002,16 +1019,16 @@
    "id": "8b721ea2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T20:33:55.557101Z",
-     "iopub.status.busy": "2026-08-20T20:33:55.556830Z",
-     "iopub.status.idle": "2026-08-20T20:34:57.461206Z",
-     "shell.execute_reply": "2026-08-20T20:34:57.460351Z"
+     "iopub.execute_input": "2026-08-27T18:53:58.838168Z",
+     "iopub.status.busy": "2026-08-27T18:53:58.837679Z",
+     "iopub.status.idle": "2026-08-27T18:55:19.721519Z",
+     "shell.execute_reply": "2026-08-27T18:55:19.720272Z"
     },
     "papermill": {
-     "duration": 61.913948,
-     "end_time": "2026-08-20T20:34:57.465106+00:00",
+     "duration": 80.894784,
+     "end_time": "2026-08-27T18:55:19.726150+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:33:55.551158+00:00",
+     "start_time": "2026-08-27T18:53:58.831366+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1021,12 +1038,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1045 notebooks lus, 19 lakes, 2812 declarations\n",
+      "1135 notebooks lus, 21 lakes, 3003 declarations\n",
       "\n",
       "lake                      decl  large  strict  noirs  compagnon principal\n",
-      "game_theory_lean           445    133      87   0/19  GameTheory/GameTheory-6b-Lean-RepeatedGames.ipynb\n",
+      "game_theory_lean           499    181     116   0/20  GameTheory/GameTheory-06b-Lean-RepeatedGames.ipynb\n",
       "\n",
-      "TOTAL 766/2835 (borne haute)  558/2835 (borne basse)  modules invisibles: 35/182\n"
+      "TOTAL 930/3027 (borne haute)  683/3027 (borne basse)  modules invisibles: 34/197\n"
      ]
     }
    ],
@@ -1046,10 +1063,10 @@
    "id": "bdcbadd1",
    "metadata": {
     "papermill": {
-     "duration": 0.004151,
-     "end_time": "2026-08-20T20:34:57.473462+00:00",
+     "duration": 0.004756,
+     "end_time": "2026-08-27T18:55:19.735997+00:00",
      "exception": false,
-     "start_time": "2026-08-20T20:34:57.469311+00:00",
+     "start_time": "2026-08-27T18:55:19.731241+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1057,16 +1074,16 @@
    "source": [
     "### Lecture du résultat : 7 modules noirs → 0\n",
     "\n",
-    "La ligne `game_theory_lean` du scanner confirme : plus aucun module noir. Les 445\n",
+    "La ligne `game_theory_lean` du scanner confirme : plus aucun module noir. Les 499\n",
     "déclarations du lake restent loin d'être toutes citées (la visibilité *large* n'est pas\n",
     "l'objectif — l'EPIC vise l'absence de modules *totalement* invisibles), mais chaque\n",
-    "fichier a maintenant sa vitrine : le stage game et sa dominance stricte, le seuil\n",
-    "critique du grim trigger avec son pont numérique 6c, le théorème-phare 0-sorry #4880,\n",
-    "le Folk STRETCH au bord réparé, le noyau Bondareva-Farkas, et l'infra SocialChoice.\n",
+    "fichier a maintenant sa vitrine : le stage game et sa dominance stricte, la transition\n",
+    "grim absorbante et sa condition d'incitation 0-sorry, le Folk STRETCH au bord réparé,\n",
+    "le noyau Bondareva-Farkas, et l'infra SocialChoice.\n",
     "\n",
     "**Ce que ce notebook ajoute au dépôt** : le chemin du lecteur entre la théorie dérivée\n",
-    "à la main (6c) et sa contrepartie formelle (lake) — là où il n'existait rien. See\n",
-    "#11703."
+    "à la main (6c) et les briques réellement formalisées dans le lake — là où il n'existait\n",
+    "rien. See #11703."
    ]
   }
  ],
@@ -1090,14 +1107,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 74.475682,
-   "end_time": "2026-08-20T20:34:57.732859+00:00",
+   "duration": 85.382881,
+   "end_time": "2026-08-27T18:55:20.086645+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-6b-Lean-RepeatedGames.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-6b-Lean-RepeatedGames.ipynb",
+   "input_path": "GameTheory-06b-Lean-RepeatedGames.ipynb",
+   "output_path": "GameTheory-06b-Lean-RepeatedGames.ipynb",
    "parameters": {},
-   "start_time": "2026-08-20T20:33:43.257177+00:00",
+   "start_time": "2026-08-27T18:53:54.703764+00:00",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames.lean
@@ -8,15 +8,14 @@
 
   ## Théorème-phare
 
-  `grim_trigger_sustains_iff` : la stratégie grim-trigger soutient la
-  coopération ssi le facteur d'actualisation vérifie δ ≥ (T−R)/(T−P).
+  `grim_trigger_sustains_iff` : la coopération procure au moins autant de
+  valeur qu'une déviation en un coup suivie de la punition grim ssi le facteur
+  d'actualisation vérifie δ ≥ (T−R)/(T−P).
 
-  Cette inégalité caractérise le seuil en-dessous duquel un joueur préfère
-  dévier (gagner T aujourd'hui puis endurer P forever) plutôt que coopérer
-  perpétuellement (R forever). Le mécanisme est le one-shot deviation
-  principle (Lemke–Tarski) : aucune déviation sur deux périodes ou plus
-  ne bat la déviation en une seule période, donc regarder uniquement le
-  trade-off one-shot suffit.
+  Cette équivalence formalise la condition d'incitation algébrique du grim
+  trigger. Le module prouve aussi que son état de punition est absorbant. Il
+  ne formalise pas encore les historiques et profils de stratégies requis
+  pour conclure à un équilibre de Nash parfait en sous-jeux.
 
   ## Structure
 
@@ -25,9 +24,9 @@
   - `RepeatedGames.Discounting` — factor d'actualisation, sommes géométriques
     pour les flux R, T + δ·P actualisés. Lemme de réécriture du seuil
     (cible prover BG).
-  - `RepeatedGames.GrimTrigger` — stratégie grim (coopère → si déviation
-    détectée, défaut éternel), théorème-phare `grim_trigger_sustains_iff`,
-    corollaire NE. Ces deux sorries sont les cibles primaires du prover BG.
+  - `RepeatedGames.GrimTrigger` — transition grim (la punition est absorbante)
+    et condition d'incitation `grim_trigger_sustains_iff` sur les deux flux
+    actualisés. Une sémantique complète des stratégies/SPNE reste hors module.
   - `RepeatedGames.Folk` (STRETCH) — théorème de Folk actualisé (Fudenberg–
     Maskin 1986), `sorry` accepté dans le scope stretch du companion.
 

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/GrimTrigger.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/GrimTrigger.lean
@@ -3,22 +3,23 @@ import RepeatedGames.Stage
 import RepeatedGames.Discounting
 
 /-!
-# Grim Trigger — théorème-phare
+# Grim Trigger — transition et condition d'incitation
 
-Résultat central de la théorie des jeux répétés : la stratégie *grim trigger*
-(coopérer tant que l'adversaire coopère, dévier pour toujours dès la première
-défection) soutient la coopération comme équilibre de Nash parfait en
-sous-jeux du Dilemme du Prisonnier infiniment répété **si et seulement si**
-le facteur d'escompte `δ` dépasse le seuil critique `(T − R) / (T − P)`.
+Ce module formalise deux briques du *grim trigger* dans le Dilemme du
+Prisonnier infiniment répété :
 
-La preuve repose sur le **principe de déviation en un coup** (one-shot
-deviation principle) : pour une stratégie stationaire comme grim trigger,
-vérifier toutes les déviations possibles équivaut à vérifier les déviations
-d'un seul coup.
+1. la transition irréversible vers la punition après la première défection ;
+2. l'équivalence algébrique entre l'absence de gain pour une déviation en un
+   coup et le seuil `δ ≥ (T − R) / (T − P)`.
+
+La seconde brique est la condition d'incitation utilisée dans la preuve
+classique par déviation en un coup. Elle ne constitue pas à elle seule une
+formalisation d'équilibre de Nash parfait en sous-jeux : une telle preuve
+demanderait une sémantique des historiques et des profils de stratégies.
 
 **Companion notebook** : `GameTheory-6c` (jeux répétés) dérive ce seuil à la
-main. Le présent module en donne la preuve formelle. Pont `ICT-13` (#4879) :
-la vérification numérique du seuil δ y est un gate.
+main. Pont `ICT-13` (#4879) : la vérification numérique du seuil δ y est un
+gate.
 -/
 
 namespace RepeatedGames
@@ -27,32 +28,53 @@ open PDAction
 
 /-! ## Stratégie grim trigger -/
 
-/-- Une stratégie grim trigger : coopérer à la première période, puis
-recopier le coup adverse de la période précédente (coopérer s'il a coopéré,
-dévier pour toujours dès qu'il dévie une fois). -/
+/-- Transition du grim trigger. `prevSelf` encode l'état courant :
+`defect` signifie que la phase de punition a déjà commencé. Cet état est
+absorbant ; sinon, une première défection adverse déclenche la punition. -/
 def grimNext (prevSelf prevFoe : PDAction) : PDAction :=
-  match prevFoe with
-  | cooperate => cooperate
-  | defect    => defect
+  match prevSelf, prevFoe with
+  | defect, _ => defect
+  | cooperate, cooperate => cooperate
+  | cooperate, defect => defect
 
-/-! ## Théorème-phare (scaffold — preuve en tranche 2) -/
+@[simp]
+theorem grimNext_cooperate_cooperate :
+    grimNext cooperate cooperate = cooperate := rfl
 
-/-- **Grim trigger soutient la coopération ssi `δ ≥ (T − R) / (T − P)`.**
+@[simp]
+theorem grimNext_cooperate_defect :
+    grimNext cooperate defect = defect := rfl
 
-Une déviation unilatérale en un coup n'est pas profitable (i.e. grim trigger
-est stable) exactement lorsque le facteur d'escompte est assez grand pour que
-la perte de coopération future (`R → P` à toutes les périodes post-déviation)
-compense le gain immédiat (`R → T` à la période de déviation).
+@[simp]
+theorem grimNext_defect_cooperate :
+    grimNext defect cooperate = defect := rfl
 
-Par `coop_ge_deviate_iff`, ce résultat se réduit à un seuil explicite sur `δ`.
+@[simp]
+theorem grimNext_defect_defect :
+    grimNext defect defect = defect := rfl
 
-TODO tranche 2 : assembler la preuve via le one-shot deviation principle
-(`coop_ge_deviate_iff` + `geom_sum` + `defect_strictly_dominates`). -/
+/-- Une fois la punition déclenchée, elle reste active quel que soit le
+prochain coup adverse. -/
+theorem grimPunishment_absorbing (prevFoe : PDAction) :
+    grimNext defect prevFoe = defect := by
+  cases prevFoe <;> rfl
+
+/-! ## Condition d'incitation en une déviation -/
+
+/-- **La coopération domine une déviation en un coup ssi
+`δ ≥ (T − R) / (T − P)`.**
+
+Cette équivalence compare les deux flux actualisés associés au chemin
+coopératif et à une déviation suivie de la punition grim. Elle établit la
+condition d'incitation algébrique utilisée par le principe de déviation en un
+coup ; elle ne quantifie pas encore sur les historiques ou les profils de
+stratégies nécessaires à un énoncé formel de SPNE.
+
+Par `coop_ge_deviate_iff`, le résultat se réduit au seuil explicite sur `δ`. -/
 theorem grim_trigger_sustains_iff (g : PrisonersDilemma) {δ : ℝ}
     (h0 : 0 ≤ δ) (h1 : δ < 1) :
     (coopValue g.R δ ≥ deviateValue g.T g.P δ) ↔
       δ ≥ (g.T - g.R) / (g.T - g.P) := by
-  -- Par réduction au seuil (algèbre réelle pure).
   exact coop_ge_deviate_iff g h0 h1
 
 end RepeatedGames

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/GrimTrigger_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/GrimTrigger_en.lean
@@ -15,20 +15,21 @@ import RepeatedGames.Discounting_en
   Note méthodologique : traduction manuelle du FR canonique (pas de source
   EN historique pré-Option A à recover, fichier FR-first depuis origin).
 
-  Central result of repeated game theory: the *grim trigger* strategy
-  (cooperate as long as the foe cooperates, defect forever as soon as
-  the foe defects once) sustains cooperation as a subgame-perfect
-  Nash equilibrium of the infinitely repeated Prisoner's Dilemma **if
-  and only if** the discount factor `δ` exceeds the critical threshold
-  `(T − R) / (T − P)`.
+  This module formalizes two building blocks of grim trigger in the
+  infinitely repeated Prisoner's Dilemma:
 
-  The proof rests on the **one-shot deviation principle**: for a stationary
-  strategy like grim trigger, checking all possible deviations reduces to
-  checking one-shot deviations.
+  1. the irreversible transition to punishment after the first defection;
+  2. the algebraic equivalence between no gain from a one-shot deviation and
+     the threshold `δ ≥ (T − R) / (T − P)`.
+
+  The second building block is the incentive condition used by the classical
+  one-shot deviation argument. By itself, it is not a formalization of a
+  subgame-perfect Nash equilibrium: that requires semantics for histories
+  and strategy profiles.
 
   **Companion notebook**: `GameTheory-6c` (repeated games) derives this
-  threshold by hand. The present module gives the formal proof. Bridge
-  `ICT-13` (#4879): the numerical verification of threshold δ is a gate.
+  threshold by hand. Bridge `ICT-13` (#4879): the numerical verification of
+  threshold δ is a gate.
 -/
 
 namespace RepeatedGames_en
@@ -38,33 +39,54 @@ open PDAction
 
 /-! ## Grim trigger strategy -/
 
-/-- A grim trigger strategy: cooperate in the first period, then copy
-the foe's previous move (cooperate if they cooperated, defect forever
-as soon as they defect once). -/
+/-- Grim-trigger transition. `prevSelf` encodes the current state:
+`defect` means that punishment has already started. That state is absorbing;
+otherwise, the foe's first defection triggers punishment. -/
 def grimNext (prevSelf prevFoe : PDAction) : PDAction :=
-  match prevFoe with
-  | cooperate => cooperate
-  | defect    => defect
+  match prevSelf, prevFoe with
+  | defect, _ => defect
+  | cooperate, cooperate => cooperate
+  | cooperate, defect => defect
 
-/-! ## Flagship theorem (scaffold — proof in tranche 2) -/
+@[simp]
+theorem grimNext_cooperate_cooperate :
+    grimNext cooperate cooperate = cooperate := rfl
 
-/-- **Grim trigger sustains cooperation iff `δ ≥ (T − R) / (T − P)`.**
+@[simp]
+theorem grimNext_cooperate_defect :
+    grimNext cooperate defect = defect := rfl
 
-A unilateral one-shot deviation is not profitable (i.e. grim trigger is
-stable) exactly when the discount factor is large enough that the loss of
-future cooperation (`R → P` in all post-deviation periods) outweighs the
-immediate gain (`R → T` in the deviation period).
+@[simp]
+theorem grimNext_defect_cooperate :
+    grimNext defect cooperate = defect := rfl
 
-By `coop_ge_deviate_iff`, this result reduces to an explicit threshold
-on `δ`.
+@[simp]
+theorem grimNext_defect_defect :
+    grimNext defect defect = defect := rfl
 
-TODO tranche 2: assemble the proof via the one-shot deviation principle
-(`coop_ge_deviate_iff` + `geom_sum` + `defect_strictly_dominates`). -/
+/-- Once punishment has been triggered, it remains active regardless of the
+foe's next move. -/
+theorem grimPunishment_absorbing (prevFoe : PDAction) :
+    grimNext defect prevFoe = defect := by
+  cases prevFoe <;> rfl
+
+/-! ## One-shot deviation incentive condition -/
+
+/-- **Cooperation dominates a one-shot deviation iff
+`δ ≥ (T − R) / (T − P)`.**
+
+This equivalence compares the two discounted streams associated with the
+cooperative path and a deviation followed by grim punishment. It establishes
+the algebraic incentive condition used by the one-shot deviation principle;
+it does not yet quantify over the histories or strategy profiles required by
+a formal SPNE statement.
+
+By `coop_ge_deviate_iff`, this result reduces to the explicit threshold on
+`δ`. -/
 theorem grim_trigger_sustains_iff (g : PrisonersDilemma) {δ : ℝ}
     (h0 : 0 ≤ δ) (h1 : δ < 1) :
     (coopValue g.R δ ≥ deviateValue g.T g.P δ) ↔
       δ ≥ (g.T - g.R) / (g.T - g.P) := by
-  -- By reduction to the threshold (pure real algebra).
   exact coop_ge_deviate_iff g h0 h1
 
 end RepeatedGames_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames_en.lean
@@ -8,15 +8,14 @@
 
   ## Headline theorem
 
-  `grim_trigger_sustains_iff`: the grim-trigger strategy sustains
-  cooperation iff the discount factor satisfies δ ≥ (T−R)/(T−P).
+  `grim_trigger_sustains_iff`: cooperation yields at least as much value as a
+  one-shot deviation followed by grim punishment iff the discount factor
+  satisfies δ ≥ (T−R)/(T−P).
 
-  This inequality characterizes the threshold below which a player prefers
-  to deviate (gain T today then endure P forever) rather than cooperate
-  perpetually (R forever). The mechanism is the one-shot deviation
-  principle (Lemke–Tarski): no deviation over two periods or more beats
-  the deviation in a single period, so looking at the one-shot trade-off
-  is sufficient.
+  This equivalence formalizes grim trigger's algebraic incentive condition.
+  The module also proves that the punishment state is absorbing. It does not
+  yet formalize the histories and strategy profiles required for a
+  subgame-perfect Nash equilibrium.
 
   ## Structure
 
@@ -25,9 +24,9 @@
   - `RepeatedGames.Discounting_en` — discount factor, geometric sums for
     the R, T + δ·P discounted flows. Threshold rewrite lemma (prover BG
     target).
-  - `RepeatedGames.GrimTrigger_en` — grim strategy (cooperate → if deviation
-    detected, eternal defection), headline theorem `grim_trigger_sustains_iff`,
-    NE corollary. These two sorries are the prover BG primary targets.
+  - `RepeatedGames.GrimTrigger_en` — grim transition (punishment is absorbing)
+    and the discounted-stream incentive condition `grim_trigger_sustains_iff`.
+    Complete strategy/SPNE semantics remain outside this module.
   - `RepeatedGames.Folk_en` (STRETCH) — discounted Folk theorem (Fudenberg–
     Maskin 1986), `sorry` accepted within the companion's stretch scope.
 


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2025:CoursIA — prev: MED/guard #13249

## Résumé

- corrige `grimNext`, qui copiait seulement le dernier coup adverse (tit-for-tat), afin que l'état de punition soit absorbant ;
- ajoute les quatre transitions calculatoires et le lemme générique `grimPunishment_absorbing` dans les siblings FR/EN ;
- requalifie honnêtement `grim_trigger_sustains_iff` comme condition d'incitation algébrique en une déviation, sans prétendre formaliser à lui seul les historiques, profils de stratégies ou un SPNE ;
- réexécute le notebook compagnon et aligne sa prose et ses sorties sur les déclarations Lean réelles.

## Reassessment

Reassessed by myia-po-2025:CoursIA: **CONFIRMED pedagogy/formal-model bug**.

L'ancienne transition ne consultait pas `prevSelf` et pardonnait après une coopération adverse suivant une défection. Elle implémentait donc une mémoire-1 de type tit-for-tat, contrairement à la punition irréversible annoncée par la prose. Le notebook compagnon 6c distingue explicitement ces deux stratégies.

La seconde divergence était un sur-claim : le théorème existant compare deux flux actualisés et prouve une équivalence de seuil, mais ne quantifie ni historiques, ni profils, ni déviations. Le symbole public et sa preuve sont préservés ; seule leur portée documentée est corrigée.

## Validation Lean

- Toolchain : `leanprover/lean4:v4.32.1` (pin du lake).
- Commande : `elan run leanprover/lean4:v4.32.1 lake -d MyIA.AI.Notebooks/GameTheory/game_theory_lean build RepeatedGames`
- Résultat : **SUCCESS**, 3007 jobs ; `RepeatedGames.GrimTrigger_en` construit. Les avertissements restants sont l'unique `sorry` STRETCH préexistant de `Folk` et `h0` inutilisé dans `Discounting`.
- `python scripts/lean/check_i18n_siblings.py <4 paths>` : **2/2 pairs byte-identical**, 0 drift, 0 orphan, 0 unbuilt.
- `python scripts/lean/count_code_sorry.py --json` : `game_theory_lean distinct_code_sorry` **1 → 1** (dette inchangée, dans `Folk`).
- Proof integrity B.3 : **NON APPLICABLE** — ni `.github/workflows/lean-game-theory.yml` ni son reusable `.github/workflows/lean-build.yml` ne câblent `proof-integrity`, `LeanVerifier` ou des `target-modules` couvrant RepeatedGames.

## Validation notebook

- `batch_reexecute.py` : **SUCCESS**, 1/1 notebook, 94 s.
- Papermill : version 2.7.0, 11/11 cellules code exécutées, séquence `1..11`, zéro erreur.
- `validate_pr_notebooks.py` : **1/1 passed**, 11 cellules code.
- `check_exec_sequence.py` : **CLEAN**, `[1..11]`.
- `check_null_exec.py` : **OK**.
- `detect_papermill_path_leak.py --outputs --nonpii --check` : **0 finding**.
- `check_papermill_ratchet.py origin/main` : **0 regression**.
- Inspection nbformat : format 4.5 valide, 30 cellules, 11 cellules avec sorties, zéro erreur et zéro avertissement.
- Scan C.1 : aucune erreur volontaire (`raise NotImplementedError`, `assert False`, `1/0`).

Closes #13253
See #13121
