### PR TITLE
fix(guards,#13261): G-VAR-3 override survives prose mentions of the marker

### DIFF
--- a/scripts/ci/variation_adjacency_guard.py
+++ b/scripts/ci/variation_adjacency_guard.py
@@ -125,6 +125,24 @@ _MARKER_LINE_RE = re.compile(
 _NEXT_ANYWHERE_RE = re.compile(r"next\s*:", re.IGNORECASE)
 _GENRE_SHAPE_RE = re.compile(r"next\s*:\s*(?P<next>\S+)", re.IGNORECASE)
 
+# #13261: the comment-trigger job's entry gate matches any comment CONTAINING
+# the marker string, so quoting the marker between backticks to DISCUSS it
+# (e.g. explaining a check_unaddressed_nits false positive) arms the parse.
+# Fenced blocks and inline code spans are stripped before matching: a marker
+# inside code is discussion, not decision -- it grants nothing, rejects
+# nothing, and never masks a real override.
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_CODE_SPAN_RE = re.compile(r"`[^`\n]*`")
+
+
+def _strip_code_spans(body: str) -> str:
+    """Replace fenced blocks and inline code spans with a single space.
+
+    A space (not the empty string) so stripping never glues the tokens on
+    either side of the removed span into a new match.
+    """
+    return _CODE_SPAN_RE.sub(" ", _CODE_FENCE_RE.sub(" ", body))
+
 OVERRIDE_EXPECTED_FORM = (
     "`[G-VAR-3 OVERRIDE] lane <machine:workspace> -- next: <genre>`, "
     "sur une seule ligne"
@@ -147,19 +165,24 @@ def parse_override(comments: list[dict] | None) -> dict | None:
         its value not a genre shape. The gate stays down -- a malformed
         override never waives it -- but `check` announces the rejection in
         the verdict so the coordinator gets feedback instead of a mute
-        re-block (#11963).
+        re-block (#11963). Since #13261 this verdict is only reached when NO
+        well-formed marker exists anywhere in the thread: a later prose
+        mention by the same coordinator no longer revokes their earlier
+        valid override, and a marker quoted inside code spans is stripped
+        before matching (discussion is not decision).
       * well-formed dict -- ``author`` + ``lane`` + ``next_genre`` (kept
         verbatim when outside the enum, per the pass-through of section 1).
     """
     if not comments:
         return None
+    fallback: dict | None = None
     for c in reversed(comments):
         login = (c.get("author") or "")
         if isinstance(login, dict):
             login = login.get("login") or ""
         if login not in COORDINATOR_LOGINS:
             continue
-        body = c.get("body") or ""
+        body = _strip_code_spans(c.get("body") or "")
         m = _OVERRIDE_RE.search(body)
         if m:
             return {
@@ -180,8 +203,16 @@ def parse_override(comments: list[dict] | None) -> dict | None:
                 reason = "`next:` pas sur la meme ligne que le marqueur"
             else:
                 reason = "`next:` manquant (aucun remplacant nomme)"
-            return {"author": login, "lane": None, "malformed": reason}
-    return None
+            # #13261: do NOT abandon the search here. A later prose mention
+            # of the marker must not revoke a valid override posted earlier
+            # in the thread -- remember the first (most recent) rejection as
+            # the fallback and keep scanning older comments for a
+            # well-formed marker. "Malformed" is only the verdict when NO
+            # valid override exists anywhere in the thread.
+            if fallback is None:
+                fallback = {"author": login, "lane": None, "malformed": reason}
+            continue
+    return fallback
 
 
 def resolve_merged_prev_genre(merged_prs: list[dict] | None, lane: str | None) -> tuple:

--- a/scripts/tests/test_variation_adjacency_guard.py
+++ b/scripts/tests/test_variation_adjacency_guard.py
@@ -356,6 +356,103 @@ def test_parse_override_malformed_reasons_distinct():
     assert "n'est pas un genre" in r_shape["malformed"]
 
 
+# --- A prose MENTION must not revoke a valid earlier override (#13261) -------
+#
+# #13234, run 33111721678: the gate went red 62 s after a coordinator review
+# comment that merely QUOTED the marker between backticks to explain a
+# check_unaddressed_nits false positive. parse_override scanned the thread
+# newest-first and RETURNED on the malformed branch, so the later mention
+# masked the valid override posted 3h49 earlier. Two fixes, tested here
+# together and separately: (a) the malformed verdict becomes a FALLBACK --
+# the scan continues and only concludes "malformed" when no well-formed
+# marker exists; (b) code spans/blocks are stripped before matching, so
+# discussing the marker in backticks arms nothing.
+
+_OVERRIDE_13261_OK = ("[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- "
+                      "next: lean")
+_MENTION_BACKTICK = ("Le faux positif de check_unaddressed_nits : ce n'est "
+                     "pas un `[G-VAR-3 OVERRIDE]` manquant, la lane est "
+                     "conforme.")
+_MENTION_PLAIN = ("Pour rappel le marqueur [G-VAR-3 OVERRIDE] exige un "
+                  "remplacant nomme apres la mention next, sur la meme "
+                  "ligne que le marqueur.")
+
+
+def test_13261_case_C_backtick_mention_after_override_keeps_it():
+    # Route (b): the quoted marker is stripped, the mention comment carries
+    # no marker at all, the valid override below it survives.
+    ov = vag.parse_override([
+        {"author": "myia-ai-01", "body": _OVERRIDE_13261_OK},
+        {"author": "myia-ai-01", "body": _MENTION_BACKTICK},
+    ])
+    assert ov is not None and "malformed" not in ov
+    assert ov["next_genre"] == "lean"
+
+
+def test_13261_case_C_plain_mention_after_override_keeps_it():
+    # Route (a): a plain-text marker (no backticks, no next:) IS read as
+    # malformed -- but only as fallback: the scan continues to the older
+    # comment and finds the valid override.
+    ov = vag.parse_override([
+        {"author": "myia-ai-01", "body": _OVERRIDE_13261_OK},
+        {"author": "myia-ai-01", "body": _MENTION_PLAIN},
+    ])
+    assert ov is not None and "malformed" not in ov
+    assert ov["next_genre"] == "lean"
+
+
+def test_13261_case_D_controls_stay_held():
+    # NEGATIVE CONTROL, same invocation: D must stay rejected in BOTH forms.
+    # A fix that would let prose grant an override would be worse than the
+    # defect (auto-exemption by simply talking about the marker).
+    ov_plain = vag.parse_override([{"author": "myia-ai-01",
+                                    "body": _MENTION_PLAIN}])
+    assert ov_plain is not None and "malformed" in ov_plain
+    # backticked mention alone: stripped to nothing -> "absent", the
+    # nothing-granted-nothing-rejected contract of fix (b).
+    ov_code = vag.parse_override([{"author": "myia-ai-01",
+                                   "body": _MENTION_BACKTICK}])
+    assert ov_code is None
+
+
+def test_13261_case_B_third_party_comment_after_override_keeps_it():
+    # Control B of the issue matrix, unchanged by the fix.
+    ov = vag.parse_override([
+        {"author": "myia-ai-01", "body": _OVERRIDE_13261_OK},
+        {"author": "myia-po-2025", "body": _MENTION_PLAIN},
+    ])
+    assert ov is not None and ov["next_genre"] == "lean"
+
+
+def test_13261_marker_in_fenced_block_grants_and_rejects_nothing():
+    # Fix (b), fenced form: a marker fully inside a code block is
+    # discussion -- neither an override nor a malformed rejection.
+    ov = vag.parse_override([
+        {"author": "myia-ai-01",
+         "body": "```\n[G-VAR-3 OVERRIDE] lane x:y -- next: lean\n```"}])
+    assert ov is None
+    # and it must not MASK a real override posted later in the thread either
+    ov2 = vag.parse_override([
+        {"author": "myia-ai-01", "body": _OVERRIDE_13261_OK},
+        {"author": "myia-ai-01",
+         "body": "exemple : ```[G-VAR-3 OVERRIDE] next: qc```"},
+    ])
+    assert ov2 is not None and "malformed" not in ov2
+    assert ov2["next_genre"] == "lean"
+
+
+def test_13261_malformed_fallback_is_the_MOST_RECENT_rejection():
+    # When no valid override exists, the fallback keeps the pre-fix
+    # newest-first semantics: the MOST RECENT coordinator rejection is the
+    # announced one (its reason is the actionable one).
+    ov = vag.parse_override([
+        {"author": "jsboige", "body": "[G-VAR-3 OVERRIDE] lane x:y"},
+        {"author": "jsboige", "body": "[G-VAR-3 OVERRIDE] next: 7days"},
+    ])
+    assert ov is not None and "malformed" in ov
+    assert "n'est pas un genre" in ov["malformed"]  # the newer, not "manquant"
+
+
 # --- merged-sequence predecessor (#12095) ----------------------------------
 #
 # G-VAR-3 adjacency is a property of the MERGED sequence, which moves while a


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: DEEP/forensic-review #13254 (c.582)

fix(guards,#13261): G-VAR-3 override survives prose mentions of the marker

Closes #13261

## Fix (a) — le verdict malformé devient un fallback, pas un abandon

`parse_override` parcourait le fil du plus récent au plus ancien et **retournait** sur la branche malformée : une mention postérieure du marqueur **masquait** l'override valide posté avant (cas C de l'issue, mesuré sur #13234 run 33111721678 — rouge 62 s après un commentaire de review qui citait le marqueur pour expliquer un faux positif). Le rejet est maintenant mémorisé comme repli (le **plus récent**, sémantique inchangée) et la boucle continue ; « malformé » n'est rendu que si **aucun** marqueur bien formé n'existe dans le fil. Le contrat trois-états #12096 est préservé (« lu et malformé » ≠ « absent »).

## Fix (b) — spans de code neutralisés avant match

`_strip_code_spans()` remplace blocs clôturés ``` et spans inline `` ` `` par une espace **avant** l'application de `_OVERRIDE_RE`/`_MARKER_RE` : discuter du marqueur entre backticks n'arme plus rien — ni override, ni rejet. Une espace (pas la chaîne vide) pour ne jamais coller les tokens adjacents en un nouveau match.

## Tests — 7 nouveaux, la matrice A-D de l'issue en une invocation

| Test | Cas issue | Attendu | Mesuré |
|---|---|---|---|
| `case_C_backtick_mention_after_override_keeps_it` | C (backticks) | override conservé (route b) | PASS |
| `case_C_plain_mention_after_override_keeps_it` | C (prose nue) | override conservé (route a) | PASS |
| `case_D_controls_stay_held` | D (2 formes) | prose nue → malformé ; backtick → None | PASS |
| `case_B_third_party_comment_after_override_keeps_it` | B | inchangé | PASS |
| `marker_in_fenced_block_grants_and_rejects_nothing` | (b) | ni accorde ni rejette, ne masque pas | PASS |
| `malformed_fallback_is_the_MOST_RECENT_rejection` | ordre | sémantique newest-first préservée | PASS |
| (implicit: `case_A_override_seul` = tests existants 160/331) | A | inchangé | PASS |

**Suites** : `test_variation_adjacency_guard.py` **42/42** (0,1 s) ; suites sœurs importatrices de `parse_override` (`test_variation_tag_required.py`, `test_check_lane_claim.py`, `test_variation_tag_comment_trigger.py`) **275 passed**, 0 failed — les contrôles positifs (A/B) et négatif (D) tiennent dans la même invocation.

## Frontière documentée (découverte pendant les tests)

Une prose nue qui cite le marqueur **et** contient par hasard `next: <mot>` sur la même ligne satisfait la grammaire et parse comme un override bien formé (mon premier fixture l'a prouvé en échouant). Ce n'est pas un défaut du fix : la grammaire est ligne-based par design (#12096), et une ligne qui la satisfait littéralement EST un marker. Non traité ici — détection d'intention = hors scope.

## Portée respectée

`check_lane_claim.py` non touché (réducteur `createdAt`, sémantique open/close différente — exclue par l'issue).

## Test plan

- [x] 42/42 guard + 275 sibling tests locaux
- [ ] CI complète