### PR TITLE
fix(tooling,#11962): exclure les tables du détecteur de flowcharts ASCII

### DIFF
--- a/.claude/rules/sota-not-workaround.md
+++ b/.claude/rules/sota-not-workaround.md
@@ -20,6 +20,8 @@ Avant de committer une sortie degradee, repondre **par ecrit (body PR)** par 1 d
 
 Le defaut paresseux (« ASCII art / reimplementation jouet / 'Java absent' / 'kernel not available locally' ») committe **sans avoir verifie RECOVERABLE-*** = manquement grave.
 
+**Flowcharts : Mermaid est le moteur canonique.** Une architecture pipeline, un flux de données ou un organigramme dessiné en ASCII se remplace par un bloc `mermaid` (`flowchart LR`/`TD`), après vérification sémantique humaine ; `scripts/notebook_tools/detect_ascii_flowchart.py` détecte les candidats mais n'auto-convertit jamais. Les tables et grilles ASCII légitimes sont hors scope et restent des tables.
+
 ### Procedure d'etablissement INTRINSIC — checklist 6 axes obligatoire (NEW c.8243, #10459)
 
 `INTRINSIC` declare une impossibilite : il justifie une substitution durable, invisible pour les auditeurs suivants. Donc **chaque verdict `INTRINSIC` doit repondre nominativement les 6 axes** suivants, par « non applicable, parce que… » ou « oui, mais testé, résultat : ... » :

--- a/scripts/notebook_tools/detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/detect_ascii_flowchart.py
@@ -188,6 +188,64 @@ def _is_markdown_table_row(line: str) -> bool:
     return stripped.startswith("|") and stripped.endswith("|") and stripped.count("|") >= 2
 
 
+def _is_ascii_table_border(line: str) -> bool:
+    """Reconnaît une bordure multi-colonnes contiguë ASCII ou Unicode.
+
+    Une rangée de boîtes de flowchart contient des espaces entre les boîtes ;
+    une table utilise au contraire une bordure contiguë (`+---+---+` ou
+    `┌───┬───┐`). Le seuil de deux colonnes évite de classer une boîte simple
+    comme table.
+    """
+    stripped = line.strip()
+    if re.fullmatch(r"\+(?:[-=]+\+){2,}", stripped):
+        return True
+    return bool(re.fullmatch(
+        r"[┌├└](?:[─━]+[┬┼┴]){1,}[─━]+[┐┤┘]",
+        stripped,
+    ))
+
+
+def _is_ascii_table_content_row(line: str) -> bool:
+    """Reconnaît une rangée de contenu ayant au moins deux colonnes."""
+    stripped = line.strip()
+    if stripped.startswith("|") and stripped.endswith("|"):
+        return stripped.count("|") >= 3
+    if stripped.startswith("│") and stripped.endswith("│"):
+        return stripped.count("│") >= 3
+    return False
+
+
+def _ascii_table_line_indices(lines: list[str]) -> set[int]:
+    """Retourne les lignes appartenant à des tables encadrées complètes.
+
+    Le détecteur travaille par fenêtres de douze lignes. Sans marquage du bloc
+    complet, il peut démarrer sur la bordure basse d'une table puis emprunter
+    un connecteur au paragraphe suivant. On exige ici une bordure ouvrante, au
+    moins une rangée multi-colonnes et une bordure fermante contiguës.
+    """
+    table_indices: set[int] = set()
+    i = 0
+    while i < len(lines):
+        if not _is_ascii_table_border(lines[i]):
+            i += 1
+            continue
+        j = i + 1
+        has_content_row = False
+        while j < len(lines):
+            if _is_ascii_table_content_row(lines[j]):
+                has_content_row = True
+                j += 1
+                continue
+            if _is_ascii_table_border(lines[j]):
+                if has_content_row:
+                    table_indices.update(range(i, j + 1))
+                j += 1
+                continue
+            break
+        i = max(i + 1, j)
+    return table_indices
+
+
 def _is_inside_fence(lines: list[str], idx: int) -> bool:
     """Verifie si la ligne idx est a l'interieur d'un bloc ``` ... ```
     (mermaid ou autre langage — les fences code block sont l'encadrement
@@ -211,7 +269,7 @@ def _find_flowchart_blocks(cell_source: str) -> list[dict]:
     degrade), mais on flagge `fenced=True` pour que la remediation proposee
     inclue le remplacement de la fence ```` ``` ```` par ```` ```mermaid ````.
 
-    c.474 patch d'une ligne (issue #12324) : l'ancre `\s*$` du `_RE_BOX_ASCII`
+    c.474 patch d'une ligne (issue #12324) : l'ancre `\\s*$` du `_RE_BOX_ASCII`
     a ete retiree, ce qui rend visible la **disposition horizontale** (boites
     cote a cote sur la meme ligne) en plus de la disposition verticale
     traditionnelle. Les 3 branches du discriminant :
@@ -236,10 +294,14 @@ def _find_flowchart_blocks(cell_source: str) -> list[dict]:
     boxes_inline=1 (1 boite par ligne) -- d'ou le seuil 2.
     """
     lines = cell_source.split("\n")
+    table_line_indices = _ascii_table_line_indices(lines)
     blocks = []
     n = len(lines)
     i = 0
     while i < n:
+        if i in table_line_indices:
+            i += 1
+            continue
         if _is_markdown_table_separator(lines[i]):
             i += 1
             continue
@@ -253,9 +315,13 @@ def _find_flowchart_blocks(cell_source: str) -> list[dict]:
         if not (_line_is_box(lines[i]) or _line_has_connector(lines[i])):
             i += 1
             continue
-        # Fenetre 4-12 lignes autour de i
+        # Fenetre 4-12 lignes autour de i. Les lignes de table déjà classées
+        # sont neutralisées même lorsque la fenêtre démarre juste avant elles.
         window_end = min(i + 12, n)
-        window = lines[i:window_end]
+        window = [
+            "" if idx in table_line_indices else lines[idx]
+            for idx in range(i, window_end)
+        ]
         # Compter boites et connecteurs dans la fenetre
         boxes = sum(1 for ln in window if _line_is_box(ln))
         boxes_inline = max(_count_boxes_on_line(ln) for ln in window)

--- a/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
@@ -362,6 +362,51 @@ Some text after.
         # Single box is not enough — we require >= 2 boxes
         assert blocks == []
 
+    @pytest.mark.parametrize(
+        "src",
+        [
+            """
+┌────────┬───────────┬─────────────────────────────────┐
+│ Signe  │ Exponent  │ Mantissa                        │
+│ 1 bit  │ 8 bits    │ 23 bits                         │
+└────────┴───────────┴─────────────────────────────────┘
+""",
+            """
++-------------------+----------------------+---------------------+
+| Aspect            | Planification Class. | Planification HTN   |
++-------------------+----------------------+---------------------+
+| Objectif          | Etat but             | Tâche a accomplir   |
+| Recherche         | Etats                | Decompositions      |
++-------------------+----------------------+---------------------+
+""",
+            """
++----------+--------+--------------------+--------+---------------------+----------+
+| Version  | Nb In  | Inputs             | Nb Out | Outputs             | Locktime |
+| 4 bytes  | varint | (prev_tx + script) | varint | (amount + script)   | 4 bytes  |
++----------+--------+--------------------+--------+---------------------+----------+
+""",
+        ],
+        ids=["unicode-field-layout", "ascii-comparison", "ascii-record-layout"],
+    )
+    def test_bordered_ascii_tables_excluded(self, src):
+        """Les trois faux positifs corpus #11962 sont des tables encadrées."""
+        assert _find_flowchart_blocks(src) == []
+
+    def test_table_followed_by_flowchart_keeps_flowchart(self):
+        """Neutraliser une table ne doit pas masquer le diagramme suivant."""
+        src = """
++------+------+
+| A    | B    |
++------+------+
+
++--------+      +--------+
+| Input  | ---> | Output |
++--------+      +--------+
+"""
+        blocks = _find_flowchart_blocks(src)
+        assert len(blocks) == 1
+        assert "Input" in blocks[0]["verbatim"]
+
     def test_mermaid_fence_already_converted(self):
         """A cell already in ```mermaid ... ``` is NOT an ASCII flowchart
         (it's the canonical Mermaid rendering). The detector scans
@@ -410,7 +455,7 @@ class TestScanNotebook:
     def test_scan_sw12_founder(self, tmp_path):
         """The founder case is detected via the notebook entry-point.
 
-        c.474 patch d'une ligne (issue #12324) : le retrait de l'ancre `\s*$`
+        c.474 patch d'une ligne (issue #12324) : le retrait de l'ancre `\\s*$`
         du `_RE_BOX_ASCII` permet de detecter le bloc horizontal `+--+ +--+ +--+`
         (boites cote a cote) en plus du bloc vertical traditionnel. Le founder
         SW-12 contient les deux dispositions, donc on attend >= 2 findings
@@ -515,8 +560,12 @@ class TestUnreadableNotebookSkipped:
 #                 de #12637 (0 commit sur detect_ascii_flowchart.py entre
 #                 2a40b3b0b et HEAD) : la baisse 29 -> 15 mesure la
 #                 conversion de 20 notebooks, pas une perte de detection.
-CORPUS_BASELINE_TOTAL = 15
-CORPUS_BASELINE_FILES_WITH = 15
+#   #11962 finalisation : 12 findings / 12 files, re-mesure 2026-08-27 sur
+#                 origin/main 080d55256 + filtre des tables encadrees. La
+#                 baisse 15 -> 12 correspond exactement aux trois faux
+#                 positifs firsthand Lean-11 / Planners-9 / SC-20.
+CORPUS_BASELINE_TOTAL = 12
+CORPUS_BASELINE_FILES_WITH = 12
 
 
 class TestCorpusBaseline:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: DEEP/lean #13258

## Résumé

- exclut du détecteur de flowcharts les tables encadrées ASCII et Unicode multi-colonnes ;
- neutralise le bloc de table complet afin qu'une fenêtre adjacente ne le requalifie pas comme diagramme ;
- conserve la détection d'un vrai flowchart placé juste après une table ;
- documente Mermaid comme moteur canonique des architectures pipeline, flux de données et organigrammes ASCII.

## Vérification

- `python -m pytest scripts/notebook_tools/tests/test_detect_ascii_flowchart.py -q` : **24 passed, 1 skipped** ;
- scan complet `MyIA.AI.Notebooks` : **1135 fichiers**, **12 findings dans 12 fichiers**, **0 skipped** ;
- baisse contrôlée **15 → 12**, correspondant exactement aux trois faux positifs firsthand (table IEEE-754, comparaison HTN, structure de transaction Bitcoin) ;
- `git diff --check origin/main...origin/fix/11962-ascii-table-fp` : succès ;
- branche basée sur le `origin/main` courant.

## Portée

Le changement reste detection-only : aucune conversion automatique n'est ajoutée, car la traduction vers Mermaid requiert une vérification sémantique humaine. Les 12 candidats résiduels restent visibles.

See #11962
