### PR TITLE
fix(guards,#13273): align code stripping with GitHub rendering

### DIFF
--- a/scripts/ci/variation_adjacency_guard.py
+++ b/scripts/ci/variation_adjacency_guard.py
@@ -131,17 +131,34 @@ _GENRE_SHAPE_RE = re.compile(r"next\s*:\s*(?P<next>\S+)", re.IGNORECASE)
 # Fenced blocks and inline code spans are stripped before matching: a marker
 # inside code is discussion, not decision -- it grants nothing, rejects
 # nothing, and never masks a real override.
-_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
-_CODE_SPAN_RE = re.compile(r"`[^`\n]*`")
+#
+# #13273: the stripper's notion of code must coincide with what GitHub
+# RENDERS as code. Two deviations of opposite polarity, same root:
+#   * sous-match (fail-closed): OVERRIDE_EXPECTED_FORM displays the marker
+#     between backticks, so a coordinator recopying the recommended form
+#     posts a span-wrapped marker that stripping erased -- a silent None,
+#     the two-state collapse #12096 closed. A span whose ENTIRE content is
+#     a well-formed override is now UNWRAPPED instead of erased.
+#   * sur-match (fail-open): an UNCLOSED fence ran to the next ``` only, so
+#     a marker after a dangling ``` stayed live while GitHub renders it as
+#     code. An unclosed fence now extends to the end of the body.
+_CODE_FENCE_RE = re.compile(r"```.*?```|```.*", re.DOTALL)
+_CODE_SPAN_RE = re.compile(r"`([^`\n]*)`")
 
 
 def _strip_code_spans(body: str) -> str:
-    """Replace fenced blocks and inline code spans with a single space.
+    """Neutralize code surfaces the way GitHub renders them.
 
-    A space (not the empty string) so stripping never glues the tokens on
-    either side of the removed span into a new match.
+    Fenced blocks become a single space (a space, not the empty string, so
+    stripping never glues the tokens on either side into a new match); an
+    unclosed fence extends to the end of the body. An inline span whose
+    entire content is a well-formed override is unwrapped to that content --
+    everything else in a span is erased.
     """
-    return _CODE_SPAN_RE.sub(" ", _CODE_FENCE_RE.sub(" ", body))
+    def _span(m: re.Match[str]) -> str:
+        inner = m.group(1).strip()
+        return inner if _OVERRIDE_RE.fullmatch(inner) else " "
+    return _CODE_SPAN_RE.sub(_span, _CODE_FENCE_RE.sub(" ", body))
 
 OVERRIDE_EXPECTED_FORM = (
     "`[G-VAR-3 OVERRIDE] lane <machine:workspace> -- next: <genre>`, "

--- a/scripts/tests/test_variation_adjacency_guard.py
+++ b/scripts/tests/test_variation_adjacency_guard.py
@@ -453,6 +453,80 @@ def test_13261_malformed_fallback_is_the_MOST_RECENT_rejection():
     assert "n'est pas un genre" in ov["malformed"]  # the newer, not "manquant"
 
 
+# --- The stripper must follow GitHub's RENDERING of code (#13273) -----------
+#
+# Found in review of #13263 (which fixed #13261): two deviations of opposite
+# polarity, same root -- what the stripper calls "code" is not what GitHub
+# renders as code.
+#
+#   sous-match (fail-closed): OVERRIDE_EXPECTED_FORM DISPLAYS the marker
+#   between backticks, so a coordinator recopying the recommended form posts
+#   a span-wrapped marker that stripping erased -> silent None. Remedy taken:
+#   option 2 of the issue -- a span whose ENTIRE content is a well-formed
+#   override is UNWRAPPED, not erased (this also future-proofs copy-paste
+#   from any doc that puts the marker in code).
+#
+#   sur-match (fail-open): an UNCLOSED fence matched only up to the next ```
+#   (or never), so a marker after a dangling ``` stayed live text while
+#   GitHub renders it as code. Remedy: an unclosed fence extends to the end
+#   of the body.
+
+_SPAN_FULL_MARKER = ("`[G-VAR-3 OVERRIDE] lane myia-ai-01:CoursIA -- "
+                     "next: qc`")
+
+
+def test_13273_case_B_help_text_recopy_unwraps_full_marker_span():
+    # The exact entry the tool recommends, posted the way it displays it:
+    # the span's ENTIRE content is a well-formed override -> unwrapped and
+    # read as a live decision.
+    ov = vag.parse_override([
+        {"author": "myia-ai-01", "body": _SPAN_FULL_MARKER}])
+    assert ov is not None and "malformed" not in ov
+    assert ov["next_genre"] == "qc"
+
+
+def test_13273_partial_or_trailing_span_stays_inert():
+    # Only a span whose content is the marker AND NOTHING ELSE is unwrapped.
+    # Marker without next: (partial) and marker with trailing words inside
+    # the span both render as code on GitHub and stay inert.
+    ov_partial = vag.parse_override([
+        {"author": "myia-ai-01",
+         "body": "`[G-VAR-3 OVERRIDE] lane x:y`"}])
+    assert ov_partial is None
+    ov_trailing = vag.parse_override([
+        {"author": "myia-ai-01",
+         "body": "`[G-VAR-3 OVERRIDE] lane x:y -- next: lean voici pourquoi`"}])
+    assert ov_trailing is None
+
+
+def test_13273_marker_in_unclosed_fence_grants_nothing():
+    # Positive control from the issue: a fence never closed swallows the
+    # marker -- GitHub renders it as code, so it grants nothing.
+    body = ("voici la forme:\n```\n"
+            "[G-VAR-3 OVERRIDE] lane myia-ai-01:CoursIA -- next: lean\n")
+    ov = vag.parse_override([{"author": "myia-ai-01", "body": body}])
+    assert ov is None
+
+
+def test_13273_span_full_marker_inside_unclosed_fence_grants_nothing():
+    # The unwrap must not resurrect a span sitting INSIDE an unclosed fence:
+    # the fence pass runs first and erases to end of body.
+    body = "exemple :\n```\n" + _SPAN_FULL_MARKER + "\n"
+    ov = vag.parse_override([{"author": "myia-ai-01", "body": body}])
+    assert ov is None
+
+
+def test_13273_unwrapped_marker_is_a_full_fledged_newest_decision():
+    # An unwrapped marker is not merely tolerated: newest-first, it beats an
+    # older nude override -- the span-recopy is the coordinator's LAST word.
+    ov = vag.parse_override([
+        {"author": "myia-ai-01", "body": _OVERRIDE_13261_OK},
+        {"author": "myia-ai-01", "body": _SPAN_FULL_MARKER},
+    ])
+    assert ov is not None and "malformed" not in ov
+    assert ov["next_genre"] == "qc"
+
+
 # --- merged-sequence predecessor (#12095) ----------------------------------
 #
 # G-VAR-3 adjacency is a property of the MERGED sequence, which moves while a


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA — prev: DEEP/notebook-python #13265

fix(guards,#13273): align code stripping with GitHub rendering

Closes #13273. Continuité d'auteur : je suis l'auteur du stripper introduit par #13263 (fix #13261) ; l'issue d'ai-01 documente deux arêtes du même écart — ce que le stripper considère comme du code ne coïncide pas avec ce que GitHub rend comme du code.

## Les deux déviations et le remède choisi

| Déviation | Polarité | Remède livré |
|---|---|---|
| Marqueur ENTIER en span (recopie du help text, qui AFFICHE la forme canonique entre backticks) → effacé → `None` muet | sous-match (fail-closed) | **Option 2 de l'issue** : un span dont le contenu ENTIER est un override bien formé est DÉPLIÉ (contenu conservé), pas effacé. La recopie du help text devient une décision valide ; les mentions pédagogiques partielles restent inertes. Traite aussi le copier-coller depuis toute doc qui met le marqueur en code. |
| Fence NON clôturé : `_CODE_FENCE_RE` (```.*?``` DOTALL) ne matchait pas → marqueur après un ``` pendant restait texte vivant alors que GitHub le rend en code | sur-match (fail-open) | `_CODE_FENCE_RE = ```.*?```|```.*` (DOTALL) : l'alternative gauche ferme d'abord les paires, un fence ouvert s'étend jusqu'à la fin du corps — comme le rendu GitHub. |

L'option 1 seule (retirer les backticks de `OVERRIDE_EXPECTED_FORM`) n'aurait traité que la première ligne du tableau — l'addendum Hermes l'explicitait. `OVERRIDE_EXPECTED_FORM` reste tel quel : avec le dépliage, la forme recommandée telle qu'affichée FONCTIONNE.

## Tests (5 nouveaux, 47/47 au total)

- `case_B_help_text_recopy_unwraps_full_marker_span` — le cas B du tableau de l'issue, inversé : recopie span-wrapped → override VALIDE.
- `partial_or_trailing_span_stays_inert` — span sans `next:` ou avec mots en queue : toujours effacés (le dépliage est intégral ou rien).
- `marker_in_unclosed_fence_grants_nothing` — le contrôle positif demandé verbatim dans l'issue.
- `span_full_marker_inside_unclosed_fence_grants_nothing` — le fence pass tourne AVANT le span pass : un span-plein dans un fence ouvert reste inert (le dépliage ne ressuscite pas le code rendu).
- `unwrapped_marker_is_a_full_fledged_newest_decision` — newest-first, le marqueur déplié BEAT l'override nu plus ancien : c'est une décision à part entière, pas une tolérance.

Régressions : 47/47 `test_variation_adjacency_guard.py`, 388 passed + 1 skipped sur les suites sœurs (importeurs de `parse_override`, `-k "variation_adjacency or gvar or genre or lane_claim"`).

## Contrat trois états préservé

La matrice A/C/D/E de #13261 est ré-exécutée telle quelle (les 42 tests préexistants passent sans modification) : `None` ≠ `malformed` reste net sur toutes les entrées, y compris les nouvelles.
