### PR TITLE
feat(iit,#13281): preuve exécutable d'identité argmax ICT-13 (gate 5)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb
@@ -820,13 +820,94 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e81a13201",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005093,
+     "end_time": "2026-08-28T00:43:56.547902",
+     "exception": false,
+     "start_time": "2026-08-28T00:43:56.542809",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Preuve d'identité du substrat argmax (gate 5)\n",
+    "\n",
+    "Le verdict ci-dessous (« la saturation du substrat est structurelle ») repose sur une\n",
+    "**exonération** : l'encodage `argmax` du substrat d'ICT-15d produirait la même séquence\n",
+    "avec ou sans mutation — régénérer ce substrat par ce levier ne peut donc pas créer de\n",
+    "relief (b1 > 0). Une exonération se prouve plus durement qu'un résultat positif,\n",
+    "précisément parce qu'elle justifie de *ne pas faire* le travail : la cellule suivante en\n",
+    "fait un **test exécutable**, pas une affirmation. Elle re-encode les deux trajectoires\n",
+    "ci-dessus (réplicateur pur et mu = 0,02) en alphabet discret (`argmax` sur les\n",
+    "6 stratégies), compte les positions différentes et **échoue** si les séquences\n",
+    "divergent — auquel cas l'exclusion d'ICT-15d serait réfutée, pas confirmée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e81a13202",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T00:43:56.556977Z",
+     "iopub.status.busy": "2026-08-28T00:43:56.556048Z",
+     "iopub.status.idle": "2026-08-28T00:43:56.560399Z",
+     "shell.execute_reply": "2026-08-28T00:43:56.560399Z"
+    },
+    "papermill": {
+     "duration": 0.010395,
+     "end_time": "2026-08-28T00:43:56.561405",
+     "exception": false,
+     "start_time": "2026-08-28T00:43:56.551010",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Substrat argmax : 401 pas (t = 0..400), alphabet = 6 stratégies.\n",
+      "États distincts visités : ['allc', 'tft'] (2/6 états).\n",
+      "Positions différentes (réplicateur pur vs mutation mu=0.02) : 0/401.\n",
+      "TEST PASSÉ : séquences argmax byte-identiques. La mutation maintient bien le\n",
+      "polymorphisme des fréquences (aucune extinction), mais l'encodage argmax ne lit\n",
+      "que le leader (allc à t=0 par égalité des fractions, puis tft seul) : régénérer\n",
+      "le substrat d'ICT-15d par ce levier serait vacuité — exclusion prouvée sur artefact.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Preuve (issue #13281) : identité byte-à-byte du substrat argmax, pur vs mutation.\n",
+    "seq_pure = np.argmax(pure, axis=1)   # alphabet = indices des n_strat stratégies\n",
+    "seq_mut = np.argmax(mut, axis=1)\n",
+    "n_diff = int((seq_pure != seq_mut).sum())\n",
+    "etats = sorted(set(seq_pure.tolist()))\n",
+    "print(f\"Substrat argmax : {len(seq_pure)} pas (t = 0..{len(seq_pure) - 1}), alphabet = {len(names)} stratégies.\")\n",
+    "print(f\"États distincts visités : {[names[i] for i in etats]} ({len(etats)}/{len(names)} états).\")\n",
+    "print(f\"Positions différentes (réplicateur pur vs mutation mu={mu}) : {n_diff}/{len(seq_pure)}.\")\n",
+    "assert n_diff == 0, (\n",
+    "    f\"Substrat NON identique ({n_diff} positions différentes) : l'exclusion d'ICT-15d \"\n",
+    "    \"serait réfutée — le verdict du gate 5 doit être réécrit, pas recopié.\"\n",
+    ")\n",
+    "print(\"TEST PASSÉ : séquences argmax byte-identiques. La mutation maintient bien le\")\n",
+    "print(\"polymorphisme des fréquences (aucune extinction), mais l'encodage argmax ne lit\")\n",
+    "print(\"que le leader (allc à t=0 par égalité des fractions, puis tft seul) : régénérer\")\n",
+    "print(\"le substrat d'ICT-15d par ce levier serait vacuité — exclusion prouvée sur artefact.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "243977d2",
    "metadata": {
     "papermill": {
-     "duration": 0.00416,
-     "end_time": "2026-08-24T18:32:21.574530",
+     "duration": 0.003987,
+     "end_time": "2026-08-28T00:43:56.569111",
      "exception": false,
-     "start_time": "2026-08-24T18:32:21.570370",
+     "start_time": "2026-08-28T00:43:56.565124",
      "status": "completed"
     },
     "tags": []
@@ -854,7 +935,7 @@
     "  (seuil 1,0). « Cooperateur » n'est pas un rôle uniforme : la morphologie\n",
     "  d'invasion discrimine les stratégies coopératrices.\n",
     "\n",
-    "- **Gate 5** : la population mixte **évolue** sous sélection-mutation, mais le jeu impose un ESS. La mutation (μ=0,02) maintient le polymorphisme (aucune stratégie ne s'éteint, entropie 1,60→1,70) sans créer de cycle : le paysage des fréquences converge. Le relief topologique recherché par ICT-15d (b1>0) **n'est pas atteint** par ce levier pour ce set de stratégies — la saturation du substrat est structurelle, pas un artefact d'échantillonnage.\n",
+    "- **Gate 5** : la population mixte **évolue** sous sélection-mutation, mais le jeu impose un ESS. La mutation (μ=0,02) maintient le polymorphisme (aucune stratégie ne s'éteint, entropie 1,60→1,70) sans créer de cycle : le paysage des fréquences converge. Le relief topologique recherché par ICT-15d (b1>0) **n'est pas atteint** par ce levier pour ce set de stratégies — la saturation du substrat est structurelle, pas un artefact d'échantillonnage (test d'identité exécutable ci-dessus : **0/401** positions différentes entre pur et mu = 0,02).\n",
     "**Conclusion** : une stratégie n'est stable que dans un **paysage donne**. TFT,\n",
     "gagnante sans bruit, devient fragile des que le régime devient incertain — et\n",
     "c'est exactement son atout sans bruit (la réciprocité) qui la perd sous bruit ;\n",
@@ -1125,7 +1206,7 @@
     "passer la théorie des jeux de la **stratégie** à la **morphodynamique** — la\n",
     "strate 3 de la série ICT.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Retour au sommaire** : [Index ICT-Series](ICT-0-Framing.md)\n"
    ]

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/strategic_morphodynamics.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/strategic_morphodynamics.py
@@ -281,7 +281,11 @@ def replicator_mutation_trajectory(
         x_i(t+1) = (1 - mu) * x_i(t) * f_i(t) / <f>(t) + mu / n,   f_i = (A x)_i.
 
     ``mu`` = taux de mutation uniforme (fraction de la population remplacee a chaque
-    generation par des mutants uniformement repartis). Contrairement au replicateur
+    generation par des mutants uniformement repartis). NB : le terme ``mu/n`` est
+    ajoute AVANT la renormalisation du simplex, donc le plancher effectif d'une
+    strategie contre-selectionnee n'est pas exactement ``mu/n`` (interaction
+    selection x normalisation) — p. ex. mu = 0,02, n = 6 : ``mu/n`` = 0,0033 mais
+    ``alld`` se stabilise vers ~0,0145 dans ICT-13. Contrairement au replicateur
     pur (qui converge vers une ESS et fige le nuage sur un point), la mutation
     maintient le polymorphisme : aucune frequence ne s'annule, la trajectoire balaie
     le simplex au lieu de s'ecraser sur un attracteur. Le nuage soumis au discriminant


### PR DESCRIPTION
## Summary

L'exclusion de l'acceptance 2/3 de #12673 (régénérer le substrat d'ICT-15d via la mutation serait vacuité) reposait sur une **affirmation** : le body de #12803 prétendait la vérification argmax byte-identique « incluse dans le commit », aucun artefact ne la contenait. Cette PR la transforme en **test exécutable** dans le livrable — exactement l'attendu (~5 lignes) spécifié dans #13281.

Stacked sur `feature/12673-ict13-axelrod-evolve` (#12803) : merger **#12803 PUIS celle-ci**.

## Livrable

- **Nouvelle cellule code** après la figure du gate 5 : re-encode les **deux** trajectoires (réplicateur pur et mu=0,02) en alphabet discret (`argmax` sur les 6 stratégies), affiche le nombre de positions différentes, **`assert n_diff == 0`** — si les séquences divergent un jour, la cellule échoue et l'exclusion est réfutée (le message d'assert le dit explicitement).
- **Markdown d'escorte** : pourquoi une exonération se prouve plus durement qu'un résultat positif.
- **Verdict gate 5 ancré sur la preuve** : « structurelle, pas un artefact d'échantillonnage **(test d'identité exécutable ci-dessus : 0/401 positions différentes)** ».
- **Docstring nuancée** (`replicator_mutation_trajectory`, observation reportée de la review) : `mu/n` est ajouté AVANT renormalisation du simplex → le plancher effectif d'une stratégie contre-sélectionnée n'est pas exactement `mu/n` (mu=0,02, n=6 : 0,0033 vs `alld` stabilisé à ~0,0145 dans ICT-13).
- Auto-fix pre-commit : `---` décoratif de la cellule Bilan → `***` (imposé par le hook fix-hr-separator).

## Preuves (H.1, règle D)

**Exécution réelle** — notebook re-exécuté end-to-end, kernel `python3`, chirurgicalement (seules la nouvelle cellule + le verdict portent des timestamps frais ; les 29 cellules inchangées restaurées byte-identiques de la base, zéro churn de re-sérialisation) :

```
Substrat argmax : 401 pas (t = 0..400), alphabet = 6 stratégies.
États distincts visités : ['allc', 'tft'] (2/6 états).
Positions différentes (réplicateur pur vs mutation mu=0.02) : 0/401.
TEST PASSÉ : séquences argmax byte-identiques. La mutation maintient bien le
polymorphisme des fréquences (aucune extinction), mais l'encodage argmax ne lit
que le leader (allc à t=0 par égalité des fractions, puis tft seul) : régénérer
le substrat d'ICT-15d par ce levier serait vacuité — exclusion prouvée sur artefact.
```

- `execution_count` : 13 pour la cellule de preuve (séquentiel 1..16 sur les 16 cellules code), 0 erreur dans tout le notebook → verdict **EXEC_PROVED**.
- `validate_pr_notebooks.py` : **1/1 PASS** (16 cellules code).
- Tests module : `pytest test_strategic_morphodynamics.py` → **26 passed** (docstring seule, aucun comportement touché).
- C.1 : aucun `raise NotImplementedError`/`assert False`/`1/0` — le seul `assert` est un **test qui passe** (0/401 mesuré, cf. sortie).
- Lecture qualitative : la séquence ne visite que **2/6 états** (`allc` à t=0 par égalité des fractions 1/6, puis `tft` seul pendant 400 pas) — l'encodage argmax écrase le polymorphisme que la mutation maintient en fréquences (entropie 1,60→1,70) : c'est la démonstration, dans l'artefact, du mécanisme invoqué par le verdict.

## Portée (réponse aux 3 points de #13281)

1. Cellule 1-2-3 de l'attendu : re-encode les deux trajectoires ✓ / affiche le nombre de positions différentes ✓ / `assert` qui échoue si divergence ✓.
2. La ligne `## Preuves` de #12803 n'est plus la seule référence : la preuve vit dans le notebook.
3. Docstring `replicator_mutation_trajectory` nuancée ✓.

Après merge de #12803 + celle-ci, l'acceptance 2/3 de #12673 est fermable **sur preuve reproductible**.

Closes #13281
See #12673 · PR #12803

🤖 Generated with [Claude Code](https://claude.com/claude-code)