### PR TITLE
feat(lean,#13292): prove product external regret additivity

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Regret.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Regret.lean
@@ -121,3 +121,121 @@ theorem externalRegret_playedOpt : externalRegret 3 1 payoffEx playedOpt = 0 := 
 /-- Un jeu sous-optimal a un regret externe strictement positif (certifié noyau). -/
 theorem externalRegret_playedBad : externalRegret 3 1 payoffEx playedBad = 1 := by
   decide
+
+/-!
+  ## Espaces d'actions produits et paiements séparables
+
+  Un jeu sur deux composantes choisit une paire `(a, b)` à chaque round. Quand
+  le paiement est additif, le meilleur comparateur fixe et le regret externe
+  se séparent exactement. C'est le circuit produit cartésien élémentaire de
+  Farina, Kroer et Sandholm, *Regret Circuits*.
+-/
+
+/-- Ajouter une constante à droite commute avec le maximum fini. -/
+theorem maxFin_add_const_right : ∀ {n : Nat} (f : Fin (n + 1) → Int) (c : Int),
+    maxFin n (fun a => f a + c) = maxFin n f + c
+  | 0, _, _ => rfl
+  | n + 1, f, c => by
+    simp only [maxFin_succ]
+    rw [maxFin_add_const_right (fun i => f i.succ) c]
+    omega
+
+/-- Ajouter une constante à gauche commute avec le maximum fini. -/
+theorem maxFin_const_add : ∀ {n : Nat} (c : Int) (f : Fin (n + 1) → Int),
+    maxFin n (fun a => c + f a) = c + maxFin n f
+  | 0, _, _ => rfl
+  | n + 1, c, f => by
+    simp only [maxFin_succ]
+    rw [maxFin_const_add c (fun i => f i.succ)]
+    omega
+
+/-- Le maximum d'une somme séparable sur un produit est la somme des maxima. -/
+theorem maxFin_add_separable {nA nB : Nat}
+    (f : Fin (nA + 1) → Int) (g : Fin (nB + 1) → Int) :
+    maxFin nA (fun a => maxFin nB (fun b => f a + g b))
+      = maxFin nA f + maxFin nB g := by
+  have hinner : (fun a => maxFin nB (fun b => f a + g b))
+      = (fun a => f a + maxFin nB g) := by
+    funext a
+    exact maxFin_const_add (f a) g
+  rw [hinner, maxFin_add_const_right f (maxFin nB g)]
+
+/-- Paiement réalisé sur l'espace produit sous paiement additif. -/
+def productRealizedTotal (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (playedA : Fin T → Fin (nA + 1)) (playedB : Fin T → Fin (nB + 1)) : Int :=
+  sumFin T (fun t => payoffA t (playedA t) + payoffB t (playedB t))
+
+/-- Paiement d'un comparateur fixe `(a, b)` sur l'espace produit. -/
+def productFixedTotal (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (a : Fin (nA + 1)) (b : Fin (nB + 1)) : Int :=
+  sumFin T (fun t => payoffA t a + payoffB t b)
+
+/-- Meilleur comparateur fixe sur l'espace produit. -/
+def productBestFixedTotal (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int) : Int :=
+  maxFin nA (fun a => maxFin nB (fun b =>
+    productFixedTotal T nA nB payoffA payoffB a b))
+
+/-- Regret externe du jeu produit sous paiement additif. -/
+def productExternalRegret (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (playedA : Fin T → Fin (nA + 1)) (playedB : Fin T → Fin (nB + 1)) : Int :=
+  productBestFixedTotal T nA nB payoffA payoffB
+    - productRealizedTotal T nA nB payoffA payoffB playedA playedB
+
+/-- Le paiement réalisé produit est la somme des paiements réalisés locaux. -/
+theorem productRealizedTotal_eq_add (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (playedA : Fin T → Fin (nA + 1)) (playedB : Fin T → Fin (nB + 1)) :
+    productRealizedTotal T nA nB payoffA payoffB playedA playedB
+      = realizedTotal T nA payoffA playedA + realizedTotal T nB payoffB playedB := by
+  unfold productRealizedTotal realizedTotal
+  exact sumFin_add _ _
+
+/-- Le paiement fixe produit est la somme des paiements fixes locaux. -/
+theorem productFixedTotal_eq_add (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (a : Fin (nA + 1)) (b : Fin (nB + 1)) :
+    productFixedTotal T nA nB payoffA payoffB a b
+      = fixedTotal T nA payoffA a + fixedTotal T nB payoffB b := by
+  unfold productFixedTotal fixedTotal
+  exact sumFin_add _ _
+
+/-- Le meilleur comparateur fixe produit se sépare en deux maxima locaux. -/
+theorem productBestFixedTotal_eq_add (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int) :
+    productBestFixedTotal T nA nB payoffA payoffB
+      = bestFixedTotal T nA payoffA + bestFixedTotal T nB payoffB := by
+  unfold productBestFixedTotal bestFixedTotal
+  simp only [productFixedTotal_eq_add]
+  exact maxFin_add_separable _ _
+
+/-- L'égalité compositionnelle : le regret du produit est la somme des regrets. -/
+theorem productExternalRegret_eq_add (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (playedA : Fin T → Fin (nA + 1)) (playedB : Fin T → Fin (nB + 1)) :
+    productExternalRegret T nA nB payoffA payoffB playedA playedB
+      = externalRegret T nA payoffA playedA + externalRegret T nB payoffB playedB := by
+  unfold productExternalRegret externalRegret
+  rw [productBestFixedTotal_eq_add, productRealizedTotal_eq_add]
+  omega
+
+/-- Deux composantes optimales donnent un regret produit nul. -/
+theorem productExternalRegret_playedOpt :
+    productExternalRegret 3 1 1 payoffEx payoffEx playedOpt playedOpt = 0 := by
+  decide
+
+/-- Deux composantes sous-optimales donnent un regret produit strictement positif. -/
+theorem productExternalRegret_playedBad :
+    productExternalRegret 3 1 1 payoffEx payoffEx playedBad playedBad = 2 := by
+  decide

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Regret_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Regret_en.lean
@@ -122,3 +122,121 @@ theorem externalRegret_playedOpt : externalRegret 3 1 payoffEx playedOpt = 0 := 
     (kernel-certified). -/
 theorem externalRegret_playedBad : externalRegret 3 1 payoffEx playedBad = 1 := by
   decide
+
+/-!
+  ## Product action spaces and separable payoffs
+
+  A two-component game chooses a pair `(a, b)` each round. When the payoff is
+  additive, the best fixed comparator and external regret separate exactly.
+  This is the elementary Cartesian-product circuit of Farina, Kroer and
+  Sandholm, *Regret Circuits*.
+-/
+
+/-- Adding a constant on the right commutes with the finite maximum. -/
+theorem maxFin_add_const_right : ∀ {n : Nat} (f : Fin (n + 1) → Int) (c : Int),
+    maxFin n (fun a => f a + c) = maxFin n f + c
+  | 0, _, _ => rfl
+  | n + 1, f, c => by
+    simp only [maxFin_succ]
+    rw [maxFin_add_const_right (fun i => f i.succ) c]
+    omega
+
+/-- Adding a constant on the left commutes with the finite maximum. -/
+theorem maxFin_const_add : ∀ {n : Nat} (c : Int) (f : Fin (n + 1) → Int),
+    maxFin n (fun a => c + f a) = c + maxFin n f
+  | 0, _, _ => rfl
+  | n + 1, c, f => by
+    simp only [maxFin_succ]
+    rw [maxFin_const_add c (fun i => f i.succ)]
+    omega
+
+/-- The maximum of a separable sum over a product is the sum of maxima. -/
+theorem maxFin_add_separable {nA nB : Nat}
+    (f : Fin (nA + 1) → Int) (g : Fin (nB + 1) → Int) :
+    maxFin nA (fun a => maxFin nB (fun b => f a + g b))
+      = maxFin nA f + maxFin nB g := by
+  have hinner : (fun a => maxFin nB (fun b => f a + g b))
+      = (fun a => f a + maxFin nB g) := by
+    funext a
+    exact maxFin_const_add (f a) g
+  rw [hinner, maxFin_add_const_right f (maxFin nB g)]
+
+/-- Realized payoff on the product space under additive payoffs. -/
+def productRealizedTotal (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (playedA : Fin T → Fin (nA + 1)) (playedB : Fin T → Fin (nB + 1)) : Int :=
+  sumFin T (fun t => payoffA t (playedA t) + payoffB t (playedB t))
+
+/-- Payoff of a fixed comparator `(a, b)` on the product space. -/
+def productFixedTotal (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (a : Fin (nA + 1)) (b : Fin (nB + 1)) : Int :=
+  sumFin T (fun t => payoffA t a + payoffB t b)
+
+/-- Best fixed comparator on the product space. -/
+def productBestFixedTotal (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int) : Int :=
+  maxFin nA (fun a => maxFin nB (fun b =>
+    productFixedTotal T nA nB payoffA payoffB a b))
+
+/-- External regret of the product game under additive payoffs. -/
+def productExternalRegret (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (playedA : Fin T → Fin (nA + 1)) (playedB : Fin T → Fin (nB + 1)) : Int :=
+  productBestFixedTotal T nA nB payoffA payoffB
+    - productRealizedTotal T nA nB payoffA payoffB playedA playedB
+
+/-- The realized product payoff is the sum of local realized payoffs. -/
+theorem productRealizedTotal_eq_add (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (playedA : Fin T → Fin (nA + 1)) (playedB : Fin T → Fin (nB + 1)) :
+    productRealizedTotal T nA nB payoffA payoffB playedA playedB
+      = realizedTotal T nA payoffA playedA + realizedTotal T nB payoffB playedB := by
+  unfold productRealizedTotal realizedTotal
+  exact sumFin_add _ _
+
+/-- The fixed product payoff is the sum of local fixed payoffs. -/
+theorem productFixedTotal_eq_add (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (a : Fin (nA + 1)) (b : Fin (nB + 1)) :
+    productFixedTotal T nA nB payoffA payoffB a b
+      = fixedTotal T nA payoffA a + fixedTotal T nB payoffB b := by
+  unfold productFixedTotal fixedTotal
+  exact sumFin_add _ _
+
+/-- The best fixed product comparator separates into two local maxima. -/
+theorem productBestFixedTotal_eq_add (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int) :
+    productBestFixedTotal T nA nB payoffA payoffB
+      = bestFixedTotal T nA payoffA + bestFixedTotal T nB payoffB := by
+  unfold productBestFixedTotal bestFixedTotal
+  simp only [productFixedTotal_eq_add]
+  exact maxFin_add_separable _ _
+
+/-- Compositional equality: product regret is the sum of component regrets. -/
+theorem productExternalRegret_eq_add (T nA nB : Nat)
+    (payoffA : Fin T → Fin (nA + 1) → Int)
+    (payoffB : Fin T → Fin (nB + 1) → Int)
+    (playedA : Fin T → Fin (nA + 1)) (playedB : Fin T → Fin (nB + 1)) :
+    productExternalRegret T nA nB payoffA payoffB playedA playedB
+      = externalRegret T nA payoffA playedA + externalRegret T nB payoffB playedB := by
+  unfold productExternalRegret externalRegret
+  rw [productBestFixedTotal_eq_add, productRealizedTotal_eq_add]
+  omega
+
+/-- Two optimal components yield zero product regret. -/
+theorem productExternalRegret_playedOpt :
+    productExternalRegret 3 1 1 payoffEx payoffEx playedOpt playedOpt = 0 := by
+  decide
+
+/-- Two suboptimal components yield strictly positive product regret. -/
+theorem productExternalRegret_playedBad :
+    productExternalRegret 3 1 1 payoffEx payoffEx playedBad playedBad = 2 := by
+  decide


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA — prev: MED/tooling #13274

## Résumé

- formalise le paiement réalisé et le comparateur fixe sur un espace d'actions produit sous paiements additifs ;
- prouve la séparation exacte du meilleur comparateur fixe en deux maxima locaux ;
- prouve `productExternalRegret = externalRegret A + externalRegret B` ;
- ajoute deux exemples noyau : regret produit nul (`0`) et strictement positif (`2`) ;
- maintient le sibling anglais byte-identique hors docstrings/commentaires.

Closes #13292

## Validation

- `elan run leanprover/lean4:v4.32.1 lake --dir MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext build` : **SUCCESS, 28/28 jobs** après le commit.
- `python scripts/lean/check_i18n_siblings.py .../Regret.lean .../Regret_en.lean` : **1/1 pair byte-identical, 0 drift**.
- `python scripts/lean/count_code_sorry.py --json` : `lean_game_defs_ext distinct_code_sorry = 0` avant et après.
- `#print axioms` sur les sept nouveaux théorèmes : seulement `propext` et `Quot.sound` pour les lemmes génériques ; seulement `propext` pour les deux exemples. Aucun `sorryAx`, `native_decide` ni `Classical.choice`.
- `git diff --check` : **SUCCESS**.

## Proof integrity

`B.3` est **non applicable** : `.github/workflows/lean-game-defs-ext.yml` appelle uniquement le build réutilisable `lean-build.yml`, pas `lean-axiom.yml`. L'intégrité a donc été contrôlée localement par `#print axioms` sur chaque nouveau théorème, avec les résultats détaillés ci-dessus.

## Périmètre

Deux fichiers uniquement :

- `Bayesian/Regret.lean` ;
- `Bayesian/Regret_en.lean`.

Le notebook Audio déjà modifié dans ce worktree par une autre session n'est ni staged ni inclus dans le commit/PR.
