### PR TITLE
feat(gametheory,#13306): test de circularite du banc humour — 107 tenus-a-l'ecart, F1 deterministe par construction

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-28b-Humour-Banc-Dur.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-28b-Humour-Banc-Dur.ipynb
@@ -5,10 +5,10 @@
    "id": "8d6c2059",
    "metadata": {
     "papermill": {
-     "duration": 0.002948,
-     "end_time": "2026-08-24T16:11:24.078120",
+     "duration": 0.00293,
+     "end_time": "2026-08-28T02:55:30.136135",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.075172",
+     "start_time": "2026-08-28T02:55:30.133205",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +68,16 @@
    "id": "27ccb4b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:24.084326Z",
-     "iopub.status.busy": "2026-08-24T16:11:24.084326Z",
-     "iopub.status.idle": "2026-08-24T16:11:24.094113Z",
-     "shell.execute_reply": "2026-08-24T16:11:24.094113Z"
+     "iopub.execute_input": "2026-08-28T02:55:30.142612Z",
+     "iopub.status.busy": "2026-08-28T02:55:30.142262Z",
+     "iopub.status.idle": "2026-08-28T02:55:30.150166Z",
+     "shell.execute_reply": "2026-08-28T02:55:30.149558Z"
     },
     "papermill": {
-     "duration": 0.014792,
-     "end_time": "2026-08-24T16:11:24.095128",
+     "duration": 0.012148,
+     "end_time": "2026-08-28T02:55:30.151038",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.080336",
+     "start_time": "2026-08-28T02:55:30.138890",
      "status": "completed"
     },
     "tags": []
@@ -131,10 +131,10 @@
    "id": "79340466",
    "metadata": {
     "papermill": {
-     "duration": 0.003008,
-     "end_time": "2026-08-24T16:11:24.100134",
+     "duration": 0.002491,
+     "end_time": "2026-08-28T02:55:30.156132",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.097126",
+     "start_time": "2026-08-28T02:55:30.153641",
      "status": "completed"
     },
     "tags": []
@@ -163,16 +163,16 @@
    "id": "73d99644",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:24.105856Z",
-     "iopub.status.busy": "2026-08-24T16:11:24.105334Z",
-     "iopub.status.idle": "2026-08-24T16:11:24.772748Z",
-     "shell.execute_reply": "2026-08-24T16:11:24.772748Z"
+     "iopub.execute_input": "2026-08-28T02:55:30.162286Z",
+     "iopub.status.busy": "2026-08-28T02:55:30.161908Z",
+     "iopub.status.idle": "2026-08-28T02:55:30.553282Z",
+     "shell.execute_reply": "2026-08-28T02:55:30.552563Z"
     },
     "papermill": {
-     "duration": 0.672011,
-     "end_time": "2026-08-24T16:11:24.774051",
+     "duration": 0.395678,
+     "end_time": "2026-08-28T02:55:30.554293",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.102040",
+     "start_time": "2026-08-28T02:55:30.158615",
      "status": "completed"
     },
     "tags": []
@@ -189,7 +189,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[fetch] upstream master @4d3af131eb : fix(ontology): #946 migrate OwlAdapter to OWLSharp 5 — byte-exact OWL output (#1\n"
+      "[fetch] upstream master @0af0511c58 : test(rules): #1190 D1 assert the corpus premise of :has(h2 ~ h2 ~ h2 ~ h2) (#120\n"
      ]
     }
    ],
@@ -235,16 +235,16 @@
    "id": "7390cfad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:24.781644Z",
-     "iopub.status.busy": "2026-08-24T16:11:24.781644Z",
-     "iopub.status.idle": "2026-08-24T16:11:24.792246Z",
-     "shell.execute_reply": "2026-08-24T16:11:24.791731Z"
+     "iopub.execute_input": "2026-08-28T02:55:30.562725Z",
+     "iopub.status.busy": "2026-08-28T02:55:30.562129Z",
+     "iopub.status.idle": "2026-08-28T02:55:30.582134Z",
+     "shell.execute_reply": "2026-08-28T02:55:30.581383Z"
     },
     "papermill": {
-     "duration": 0.015665,
-     "end_time": "2026-08-24T16:11:24.792246",
+     "duration": 0.024855,
+     "end_time": "2026-08-28T02:55:30.583253",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.776581",
+     "start_time": "2026-08-28T02:55:30.558398",
      "status": "completed"
     },
     "tags": []
@@ -295,16 +295,16 @@
    "id": "4161f8c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:24.801497Z",
-     "iopub.status.busy": "2026-08-24T16:11:24.800492Z",
-     "iopub.status.idle": "2026-08-24T16:11:24.805651Z",
-     "shell.execute_reply": "2026-08-24T16:11:24.805651Z"
+     "iopub.execute_input": "2026-08-28T02:55:30.591079Z",
+     "iopub.status.busy": "2026-08-28T02:55:30.590708Z",
+     "iopub.status.idle": "2026-08-28T02:55:30.596476Z",
+     "shell.execute_reply": "2026-08-28T02:55:30.595802Z"
     },
     "papermill": {
-     "duration": 0.009881,
-     "end_time": "2026-08-24T16:11:24.806659",
+     "duration": 0.010589,
+     "end_time": "2026-08-28T02:55:30.597466",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.796778",
+     "start_time": "2026-08-28T02:55:30.586877",
      "status": "completed"
     },
     "tags": []
@@ -371,10 +371,10 @@
    "id": "b2845630",
    "metadata": {
     "papermill": {
-     "duration": 0.002995,
-     "end_time": "2026-08-24T16:11:24.811660",
+     "duration": 0.002363,
+     "end_time": "2026-08-28T02:55:30.602287",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.808665",
+     "start_time": "2026-08-28T02:55:30.599924",
      "status": "completed"
     },
     "tags": []
@@ -404,16 +404,16 @@
    "id": "655305f9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:24.818175Z",
-     "iopub.status.busy": "2026-08-24T16:11:24.818175Z",
-     "iopub.status.idle": "2026-08-24T16:11:24.832108Z",
-     "shell.execute_reply": "2026-08-24T16:11:24.832108Z"
+     "iopub.execute_input": "2026-08-28T02:55:30.608439Z",
+     "iopub.status.busy": "2026-08-28T02:55:30.608190Z",
+     "iopub.status.idle": "2026-08-28T02:55:30.620880Z",
+     "shell.execute_reply": "2026-08-28T02:55:30.619937Z"
     },
     "papermill": {
-     "duration": 0.018944,
-     "end_time": "2026-08-24T16:11:24.833119",
+     "duration": 0.0172,
+     "end_time": "2026-08-28T02:55:30.621937",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.814175",
+     "start_time": "2026-08-28T02:55:30.604737",
      "status": "completed"
     },
     "tags": []
@@ -582,10 +582,10 @@
    "id": "4cc974f5",
    "metadata": {
     "papermill": {
-     "duration": 0.003063,
-     "end_time": "2026-08-24T16:11:24.838183",
+     "duration": 0.003243,
+     "end_time": "2026-08-28T02:55:30.627824",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.835120",
+     "start_time": "2026-08-28T02:55:30.624581",
      "status": "completed"
     },
     "tags": []
@@ -611,16 +611,16 @@
    "id": "bc3cafe6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:24.843717Z",
-     "iopub.status.busy": "2026-08-24T16:11:24.842718Z",
-     "iopub.status.idle": "2026-08-24T16:11:24.847755Z",
-     "shell.execute_reply": "2026-08-24T16:11:24.847755Z"
+     "iopub.execute_input": "2026-08-28T02:55:30.633477Z",
+     "iopub.status.busy": "2026-08-28T02:55:30.633249Z",
+     "iopub.status.idle": "2026-08-28T02:55:30.638962Z",
+     "shell.execute_reply": "2026-08-28T02:55:30.638136Z"
     },
     "papermill": {
-     "duration": 0.007554,
-     "end_time": "2026-08-24T16:11:24.847755",
+     "duration": 0.010459,
+     "end_time": "2026-08-28T02:55:30.640562",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.840201",
+     "start_time": "2026-08-28T02:55:30.630103",
      "status": "completed"
     },
     "tags": []
@@ -684,16 +684,16 @@
    "id": "d5841413",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:24.853976Z",
-     "iopub.status.busy": "2026-08-24T16:11:24.853976Z",
-     "iopub.status.idle": "2026-08-24T16:11:25.164478Z",
-     "shell.execute_reply": "2026-08-24T16:11:25.163969Z"
+     "iopub.execute_input": "2026-08-28T02:55:30.648830Z",
+     "iopub.status.busy": "2026-08-28T02:55:30.648302Z",
+     "iopub.status.idle": "2026-08-28T02:55:30.818678Z",
+     "shell.execute_reply": "2026-08-28T02:55:30.817942Z"
     },
     "papermill": {
-     "duration": 0.313534,
-     "end_time": "2026-08-24T16:11:25.164478",
+     "duration": 0.175464,
+     "end_time": "2026-08-28T02:55:30.820027",
      "exception": false,
-     "start_time": "2026-08-24T16:11:24.850944",
+     "start_time": "2026-08-28T02:55:30.644563",
      "status": "completed"
     },
     "tags": []
@@ -706,7 +706,7 @@
       "[LLM test] arg-7.3.2 : truth=rire_sans_recadrage\n",
       "           pred='rien'\n",
       "           raw='rien'\n",
-      "           latency=304 ms\n"
+      "           latency=163 ms\n"
      ]
     }
    ],
@@ -800,10 +800,10 @@
    "id": "d7d46a28",
    "metadata": {
     "papermill": {
-     "duration": 0.006237,
-     "end_time": "2026-08-24T16:11:25.176634",
+     "duration": 0.007683,
+     "end_time": "2026-08-28T02:55:30.833108",
      "exception": false,
-     "start_time": "2026-08-24T16:11:25.170397",
+     "start_time": "2026-08-28T02:55:30.825425",
      "status": "completed"
     },
     "tags": []
@@ -830,16 +830,16 @@
    "id": "597cbf10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:25.182224Z",
-     "iopub.status.busy": "2026-08-24T16:11:25.182224Z",
-     "iopub.status.idle": "2026-08-24T16:11:29.149683Z",
-     "shell.execute_reply": "2026-08-24T16:11:29.148636Z"
+     "iopub.execute_input": "2026-08-28T02:55:30.841359Z",
+     "iopub.status.busy": "2026-08-28T02:55:30.841067Z",
+     "iopub.status.idle": "2026-08-28T02:55:35.350835Z",
+     "shell.execute_reply": "2026-08-28T02:55:35.350154Z"
     },
     "papermill": {
-     "duration": 3.971976,
-     "end_time": "2026-08-24T16:11:29.150646",
+     "duration": 4.514467,
+     "end_time": "2026-08-28T02:55:35.352105",
      "exception": false,
-     "start_time": "2026-08-24T16:11:25.178670",
+     "start_time": "2026-08-28T02:55:30.837638",
      "status": "completed"
     },
     "tags": []
@@ -894,7 +894,7 @@
      "text": [
       "[LLM batch] 30/30 traités — 0 échecs\n",
       "\n",
-      "[latence] min=106 ms, max=172 ms, mean=131 ms, n=30\n",
+      "[latence] min=118 ms, max=219 ms, mean=150 ms, n=30\n",
       "[latence] échecs : 0\n"
      ]
     }
@@ -949,10 +949,10 @@
    "id": "654ecae6",
    "metadata": {
     "papermill": {
-     "duration": 0.002525,
-     "end_time": "2026-08-24T16:11:29.158673",
+     "duration": 0.003058,
+     "end_time": "2026-08-28T02:55:35.358530",
      "exception": false,
-     "start_time": "2026-08-24T16:11:29.156148",
+     "start_time": "2026-08-28T02:55:35.355472",
      "status": "completed"
     },
     "tags": []
@@ -976,16 +976,16 @@
    "id": "751cceb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:29.175203Z",
-     "iopub.status.busy": "2026-08-24T16:11:29.174307Z",
-     "iopub.status.idle": "2026-08-24T16:11:29.181696Z",
-     "shell.execute_reply": "2026-08-24T16:11:29.181696Z"
+     "iopub.execute_input": "2026-08-28T02:55:35.365515Z",
+     "iopub.status.busy": "2026-08-28T02:55:35.365140Z",
+     "iopub.status.idle": "2026-08-28T02:55:35.371297Z",
+     "shell.execute_reply": "2026-08-28T02:55:35.370691Z"
     },
     "papermill": {
-     "duration": 0.02001,
-     "end_time": "2026-08-24T16:11:29.182702",
+     "duration": 0.010827,
+     "end_time": "2026-08-28T02:55:35.372252",
      "exception": false,
-     "start_time": "2026-08-24T16:11:29.162692",
+     "start_time": "2026-08-28T02:55:35.361425",
      "status": "completed"
     },
     "tags": []
@@ -1019,7 +1019,7 @@
       "humour_reussi                       2        0        0        0        4\n",
       "rire_sans_recadrage                 0        0        0        0        6\n",
       "recadrage_sans_rire                 2        0        0        0        4\n",
-      "offensif_compris_non_partage        0        1        1        0        4\n",
+      "offensif_compris_non_partage        0        1        0        0        5\n",
       "rien                                1        0        0        0        5\n"
      ]
     }
@@ -1054,16 +1054,16 @@
    "id": "2aeeaa32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:29.192317Z",
-     "iopub.status.busy": "2026-08-24T16:11:29.192317Z",
-     "iopub.status.idle": "2026-08-24T16:11:29.199380Z",
-     "shell.execute_reply": "2026-08-24T16:11:29.199380Z"
+     "iopub.execute_input": "2026-08-28T02:55:35.378848Z",
+     "iopub.status.busy": "2026-08-28T02:55:35.378647Z",
+     "iopub.status.idle": "2026-08-28T02:55:35.385806Z",
+     "shell.execute_reply": "2026-08-28T02:55:35.385216Z"
     },
     "papermill": {
-     "duration": 0.015178,
-     "end_time": "2026-08-24T16:11:29.200388",
+     "duration": 0.011707,
+     "end_time": "2026-08-28T02:55:35.386969",
      "exception": false,
-     "start_time": "2026-08-24T16:11:29.185210",
+     "start_time": "2026-08-28T02:55:35.375262",
      "status": "completed"
     },
     "tags": []
@@ -1115,16 +1115,16 @@
    "id": "7edaced2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-24T16:11:29.208489Z",
-     "iopub.status.busy": "2026-08-24T16:11:29.208489Z",
-     "iopub.status.idle": "2026-08-24T16:11:29.214320Z",
-     "shell.execute_reply": "2026-08-24T16:11:29.214320Z"
+     "iopub.execute_input": "2026-08-28T02:55:35.393443Z",
+     "iopub.status.busy": "2026-08-28T02:55:35.393249Z",
+     "iopub.status.idle": "2026-08-28T02:55:35.398667Z",
+     "shell.execute_reply": "2026-08-28T02:55:35.398108Z"
     },
     "papermill": {
-     "duration": 0.012004,
-     "end_time": "2026-08-24T16:11:29.215394",
+     "duration": 0.009962,
+     "end_time": "2026-08-28T02:55:35.399889",
      "exception": false,
-     "start_time": "2026-08-24T16:11:29.203390",
+     "start_time": "2026-08-28T02:55:35.389927",
      "status": "completed"
     },
     "tags": []
@@ -1184,13 +1184,240 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c6ad3354",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003121,
+     "end_time": "2026-08-28T02:55:35.408454",
+     "exception": false,
+     "start_time": "2026-08-28T02:55:35.405333",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Test de circularité — scénarios Argumentum tenus à l'écart (#13306)\n",
+    "\n",
+    "Le F1 = 1,000 du détecteur maison n'est pas un résultat tant qu'une circularité n'est\n",
+    "pas écartée : un détecteur à règles qui sature sur le corpus où ses règles ont été\n",
+    "écrites mesure sa proximité à la procédure d'annotation, pas sa théorie.\n",
+    "\n",
+    "Protocole (#13306) : appliquer le détecteur **sans aucune modification** aux scénarios\n",
+    "Argumentum **non consommés** par la construction du corpus, et publier les deux F1\n",
+    "côte à côte avec leur intervalle de confiance bootstrap (leçon #12936 : c'est\n",
+    "l'incertitude d'échantillonnage qu'il faut afficher, pas une variance inter-seeds).\n",
+    "\n",
+    "Arithmétique corrigée au passage : l'issue #13306 annonce « 167 - 120 = 47 » scénarios\n",
+    "non consommés — ceci concatène le total du corpus de travail (120 instances, dont 60\n",
+    "manuelles hors Argumentum) avec la consommation Argumentum réelle (60 scénarios\n",
+    "échantillonnés). Le tenu-à-l'écart vrai est 167 - 60 = **107**, identifié ci-dessous\n",
+    "par un prédicat reproductible avec contrôle positif de disjonction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "682fbe54",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T02:55:35.415406Z",
+     "iopub.status.busy": "2026-08-28T02:55:35.415058Z",
+     "iopub.status.idle": "2026-08-28T02:55:35.421823Z",
+     "shell.execute_reply": "2026-08-28T02:55:35.421325Z"
+    },
+    "papermill": {
+     "duration": 0.011319,
+     "end_time": "2026-08-28T02:55:35.422581",
+     "exception": false,
+     "start_time": "2026-08-28T02:55:35.411262",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[circularité] Argumentum total : 167\n",
+      "[circularité] consommés par CORPUS_DUR (k=60, seed 42) : 60\n",
+      "[circularité] tenus à l'écart : 107\n",
+      "[disjonction] |consommés INTER tenu-à-l'écart| = 0 (attendu 0)\n",
+      "[disjonction] |consommés UNION tenu-à-l'écart| = 167 (attendu 167)\n",
+      "[disjonction] ids arg-* du CORPUS_DUR INTER tenu-à-l'écart = 0 (attendu 0)\n",
+      "[circularité] labels du tenu-à-l'écart : {'rien': 28, 'recadrage_sans_rire': 17, 'humour_reussi': 37, 'rire_sans_recadrage': 14, 'offensif_compris_non_partage': 11}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# -*- coding: utf-8 -*-\n",
+    "# Identification des scénarios NON consommés + contrôle POSITIF de disjonction (#13306).\n",
+    "# Prédicat reproductible : est consommé tout scénario de labeled_arg dont le path\n",
+    "# figure dans arg_sample (random.seed(42), k=60, cell[7]) ; tenu-à-l'écart = le reste.\n",
+    "consumed_paths = {r[\"path\"] for r in arg_sample}\n",
+    "heldout_arg = [r for r in labeled_arg if r[\"path\"] not in consumed_paths]\n",
+    "print(f\"[circularité] Argumentum total : {len(labeled_arg)}\")\n",
+    "print(f\"[circularité] consommés par CORPUS_DUR (k=60, seed 42) : {len(consumed_paths)}\")\n",
+    "print(f\"[circularité] tenus à l'écart : {len(heldout_arg)}\")\n",
+    "\n",
+    "# Contrôle positif de disjonction — montré, pas affirmé :\n",
+    "inter_paths = consumed_paths & {r[\"path\"] for r in heldout_arg}\n",
+    "union_paths = consumed_paths | {r[\"path\"] for r in heldout_arg}\n",
+    "corpus_arg_ids = {i[\"id\"] for i in CORPUS_DUR if i[\"id\"].startswith(\"arg-\")}\n",
+    "inter_ids = corpus_arg_ids & {\"arg-\" + r[\"path\"] for r in heldout_arg}\n",
+    "print(f\"[disjonction] |consommés INTER tenu-à-l'écart| = {len(inter_paths)} (attendu 0)\")\n",
+    "print(f\"[disjonction] |consommés UNION tenu-à-l'écart| = {len(union_paths)} (attendu {len(labeled_arg)})\")\n",
+    "print(f\"[disjonction] ids arg-* du CORPUS_DUR INTER tenu-à-l'écart = {len(inter_ids)} (attendu 0)\")\n",
+    "assert not inter_paths and len(union_paths) == len(labeled_arg) and not inter_ids\n",
+    "\n",
+    "# Construction des instances tenues à l'écart : IDENTIQUE à cell[7] — les features\n",
+    "# sont dérivées du label par la même fonction. Toute modification de cette\n",
+    "# construction invaliderait le test (acceptance #13306, critère 2).\n",
+    "def features_from_label(lab):\n",
+    "    return {\n",
+    "        \"laugh\":   lab == \"humour_reussi\" or lab == \"rire_sans_recadrage\",\n",
+    "        \"reframe\": lab == \"humour_reussi\" or lab == \"recadrage_sans_rire\",\n",
+    "        \"uptake\":  lab == \"humour_reussi\",\n",
+    "        \"refus\":   lab == \"offensif_compris_non_partage\",\n",
+    "    }\n",
+    "heldout_instances = [{\n",
+    "    \"id\": \"heldout-\" + r[\"path\"],\n",
+    "    \"texte\": \"[\" + r[\"catégorie\"] + \"/\" + r[\"sous-catégorie\"] + \"] \" + r[\"titre\"],\n",
+    "    \"features\": features_from_label(r[\"label\"]),\n",
+    "    \"label\": r[\"label\"],\n",
+    "    \"justification\": \"tenu à l'écart #13306 — construction identique à cell[7] (features dérivées du label)\",\n",
+    "    \"source\": \"ArgumentumGames/Argumentum\",\n",
+    "} for r in heldout_arg]\n",
+    "print(f\"[circularité] labels du tenu-à-l'écart : {dict(Counter(x['label'] for x in heldout_instances))}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "92f330cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T02:55:35.429583Z",
+     "iopub.status.busy": "2026-08-28T02:55:35.429212Z",
+     "iopub.status.idle": "2026-08-28T02:55:36.119167Z",
+     "shell.execute_reply": "2026-08-28T02:55:36.118598Z"
+    },
+    "papermill": {
+     "duration": 0.694919,
+     "end_time": "2026-08-28T02:55:36.120516",
+     "exception": false,
+     "start_time": "2026-08-28T02:55:35.425597",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CORPUS_DUR (120, dont 60 manuelles)    n= 120  TP= 48 FP= 0 FN= 0  P=1.000 R=1.000 F1=1.000  IC95=[1.000, 1.000]\n",
+      "Argumentum consommés (60)              n=  60  TP= 18 FP= 0 FN= 0  P=1.000 R=1.000 F1=1.000  IC95=[1.000, 1.000]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Argumentum tenus à l'écart (107)       n= 107  TP= 37 FP= 0 FN= 0  P=1.000 R=1.000 F1=1.000  IC95=[1.000, 1.000]\n",
+      "\n",
+      "=== Trace algébrique : label -> features (cell[7]) -> prédiction du détecteur (cell[9]) ===\n",
+      "  humour_reussi                  -> détecteur : humour_reussi\n",
+      "  rire_sans_recadrage            -> détecteur : rire_sans_recadrage\n",
+      "  recadrage_sans_rire            -> détecteur : rien\n",
+      "  offensif_compris_non_partage   -> détecteur : offensif_compris_non_partage\n",
+      "  rien                           -> détecteur : rien\n"
+     ]
+    }
+   ],
+   "source": [
+    "# -*- coding: utf-8 -*-\n",
+    "# F1 côte à côte (métrique identique à cell[15]) + IC bootstrap + trace algébrique.\n",
+    "def bootstrap_f1_ci(instances, detector, n_draws=5000, seed=13306):\n",
+    "    \"\"\"IC percentile 95% par bootstrap non paramétrique (rééchantillonnage des\n",
+    "    instances avec remise). Mesure l'incertitude d'échantillonnage du F1 —\n",
+    "    pas une variance inter-seeds (leçon #12936).\"\"\"\n",
+    "    rng = random.Random(seed)\n",
+    "    n = len(instances)\n",
+    "    f1s = []\n",
+    "    for _ in range(n_draws):\n",
+    "        sample = [instances[rng.randrange(n)] for _ in range(n)]\n",
+    "        f1s.append(precision_recall(sample, detector)[2])\n",
+    "    f1s.sort()\n",
+    "    return f1s[int(0.025 * n_draws)], f1s[int(0.975 * n_draws)]\n",
+    "\n",
+    "arg60 = [i for i in CORPUS_DUR if i[\"id\"].startswith(\"arg-\")]\n",
+    "for name, insts in [\n",
+    "    (\"CORPUS_DUR (120, dont 60 manuelles)\", CORPUS_DUR),\n",
+    "    (\"Argumentum consommés (60)\", arg60),\n",
+    "    (\"Argumentum tenus à l'écart (107)\", heldout_instances),\n",
+    "]:\n",
+    "    p, r, f1, tp, fp, fn, tn = precision_recall(insts, reframe_detector)\n",
+    "    lo, hi = bootstrap_f1_ci(insts, reframe_detector)\n",
+    "    print(f\"{name:<38} n={len(insts):>4}  TP={tp:>3} FP={fp:>2} FN={fn:>2}  \"\n",
+    "          f\"P={p:.3f} R={r:.3f} F1={f1:.3f}  IC95=[{lo:.3f}, {hi:.3f}]\")\n",
+    "\n",
+    "print()\n",
+    "print(\"=== Trace algébrique : label -> features (cell[7]) -> prédiction du détecteur (cell[9]) ===\")\n",
+    "for lab in CATEGORIES:\n",
+    "    inst = {\"features\": features_from_label(lab)}\n",
+    "    print(f\"  {lab:<30} -> détecteur : {reframe_detector(inst)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff219036",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003161,
+     "end_time": "2026-08-28T02:55:36.127195",
+     "exception": false,
+     "start_time": "2026-08-28T02:55:36.124034",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Verdict : `CIRCULARITE_GROSSIERE_ECARTEE` — avec réserve structurelle majeure\n",
+    "\n",
+    "Par la règle de décision de #13306, le F1 tient sur le tenu-à-l'écart → la\n",
+    "circularité **la plus grossière** (surapprentissage des instances spécifiques du\n",
+    "corpus) est écartée. Mais la trace algébrique ci-dessus montre **pourquoi il ne\n",
+    "pouvait pas en être autrement** : sur les instances Argumentum, les features sont\n",
+    "calculées À PARTIR du label annoté (cell[7]), et le détecteur inverse cette\n",
+    "fonction — seul `humour_reussi` produit `reframe + uptake`, donc précision =\n",
+    "rappel = 1 **par construction**, sur n'importe quel échantillon Argumentum,\n",
+    "tenu-à-l'écart compris. L'intervalle bootstrap dégénéré `[1.000, 1.000]` est la\n",
+    "signature d'un pipeline déterministe, pas celle d'une mesure confiante.\n",
+    "\n",
+    "Conséquence directe : le F1 = 1,000 du banc **ne mesure pas la théorie du partage\n",
+    "sur le corpus Argumentum** — il mesure l'identité de construction features ↔\n",
+    "label. Tant que les features ne sont pas annotées indépendamment du label,\n",
+    "l'écart avec Qwen (F1 ≈ 0,364) n'est pas un résultat : c'est l'écart entre un\n",
+    "détecteur évalué sur son terrain de construction et un modèle évalué hors du\n",
+    "sien.\n",
+    "\n",
+    "Suites (hors scope #13306, critère 5 — Qwen non re-testé ici) :\n",
+    "1. **#12756** (campagne multi-annotateurs) reste la voie de validation réelle ;\n",
+    "2. variante bas coût : annoter les features **depuis le texte**, sans voir le\n",
+    "   label, puis ré-appliquer ce détecteur inchangé — seule façon de donner un\n",
+    "   contenu au chiffre."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "07f174d8",
    "metadata": {
     "papermill": {
-     "duration": 0.002002,
-     "end_time": "2026-08-24T16:11:29.221331",
+     "duration": 0.002859,
+     "end_time": "2026-08-28T02:55:36.133247",
      "exception": false,
-     "start_time": "2026-08-24T16:11:29.219329",
+     "start_time": "2026-08-28T02:55:36.130388",
      "status": "completed"
     },
     "tags": []
@@ -1219,6 +1446,11 @@
     "- **Argumentum submodule non initialisé** sur la machine (c.539 mesure). Le\n",
     "  fetch HTTP direct contourne ; une PR séparée pourra faire `git submodule\n",
     "  update --init` proprement quand l'environnement le permettra.\n",
+    "- **Circularité (audit #13306)** : le F1 = 1,000 du détecteur maison est une\n",
+    "  identité de construction sur les instances Argumentum (features dérivées du\n",
+    "  label), pas une performance — verdict `CIRCULARITE_GROSSIERE_ECARTEE` avec\n",
+    "  réserve structurelle, cf section dédiée. Validation réelle : #12756 ou\n",
+    "  features annotées depuis le texte.\n",
     "- **Corpus annoté** = curation manuelle (avec justifications cell[7]).\n",
     "  Pas de corpus académique blagues publiquement annoté sur ce cycle. Si\n",
     "  dispo, intégrer par exemple le corpus `humour-classification` Kaggle\n",
@@ -1254,18 +1486,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.213282,
-   "end_time": "2026-08-24T16:11:29.457683",
+   "duration": 8.47635,
+   "end_time": "2026-08-28T02:55:36.370708",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-28b-Humour-Banc-Dur.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-28b-Humour-Banc-Dur_output.ipynb",
+   "input_path": "GameTheory-28b-Humour-Banc-Dur.ipynb",
+   "output_path": "gt28b_exec.ipynb",
    "parameters": {},
-   "start_time": "2026-08-24T16:11:23.244401",
+   "start_time": "2026-08-28T02:55:27.894358",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA-2 — prev: DEEP/genai #13080

## Summary

Exécution du test de circularité préalable demandé par #13306 : appliquer le détecteur maison **sans modification** aux scénarios Argumentum non consommés par la construction du corpus, publier les deux F1 côte à côte avec IC bootstrap, écrire le verdict en toutes lettres.

**Correction arithmétique firsthand** : l'issue annonce « 167 − 120 = 47 » non consommés — ceci concatène le total du corpus de travail (120 instances, dont 60 blagues manuelles **hors** Argumentum) avec la consommation Argumentum réelle (60 scénarios, `random.seed(42), k=60`, cell[7]). Le tenu-à-l'écart vrai est **167 − 60 = 107**.

## Résultats (re-exec papermill complète, 22/22 cellules, 0 erreur)

```
CORPUS_DUR (120, dont 60 manuelles)    n= 120  TP= 48 FP= 0 FN= 0  P=1.000 R=1.000 F1=1.000  IC95=[1.000, 1.000]
Argumentum consommés (60)              n=  60  TP= 18 FP= 0 FN= 0  P=1.000 R=1.000 F1=1.000  IC95=[1.000, 1.000]
Argumentum tenus à l'écart (107)       n= 107  TP= 37 FP= 0 FN= 0  P=1.000 R=1.000 F1=1.000  IC95=[1.000, 1.000]
```

**Verdict : `CIRCULARITE_GROSSIERE_ECARTEE`** (règle de décision de l'issue : le F1 tient) — **avec réserve structurelle majeure** : la trace algébrique ajoutée au notebook montre que le F1 sur instances Argumentum est 1 **par construction** — les features sont calculées à partir du label annoté (cell[7]), et le détecteur inverse cette fonction (seul `humour_reussi` produit `reframe + uptake`). Le test ne pouvait pas échouer ; l'IC dégénéré `[1.000, 1.000]` est la signature d'un pipeline déterministe, pas d'une mesure confiante. Le F1 = 1,000 du banc mesure l'identité features ↔ label, pas la théorie du partage — l'écart avec Qwen (0,364) n'est pas un résultat tant que les features ne sont pas annotées indépendamment du label.

## Acceptance #13306 (5/5)

- [x] **107 tenus à l'écart identifiés explicitement** : prédicat reproductible (`path not in arg_sample paths`, seed 42) + **contrôle positif de disjonction** (|consommés ∩ tenu-à-l'écart| = 0, union = 167, ids arg-* disjoints — montré en sortie, pas affirmé)
- [x] **Détecteur inchangé** : `reframe_detector` cell[9] réutilisé tel quel ; construction des instances tenues à l'écart identique à cell[7]
- [x] **F1 côte à côte avec IC** : bootstrap non paramétrique 5 000 tirages (incertitude d'échantillonnage, leçon #12936)
- [x] **Verdict en toutes lettres** : `CIRCULARITE_GROSSIERE_ECARTEE` (+ réserve structurelle documentée)
- [x] **Qwen non re-testé** : le ranking LLM existant (cell[12]) a seulement été ré-exécuté dans la passe complète — aucune nouvelle mesure comparative

## Validation

- Papermill end-to-end 22/22, 0 erreur, 0 `execution_count` null (C.2/H.3)
- LLM 30/30 appels réels au endpoint vLLM local (`qwen3.6-35b-a3b`, 0 échec, latence 118-219 ms) — pas de sortie fabriquée
- Diff source : exactement 4 nouvelles cellules (2 markdown + 2 code) + 1 bullet dans la conclusion ; 0 motif C.1 interdit
- Catalogue byte-identique à main (aucun fichier CATALOG touché)

Closes #13306
See #12756 (campagne multi-annotateurs — la suite logique), #13303

🤖 Generated with [Claude Code](https://claude.com/claude-code)
