### PR TITLE
feat(gametheory,#12208): GT-13c — twin C# de 13b Safe Subgame Solving (maturation rang 1, temps 2)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13c-Safe-Subgame-Solving-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13c-Safe-Subgame-Solving-Csharp.ipynb
@@ -1,0 +1,946 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GameTheory-13c : Safe Subgame Solving en C# — le twin qui vérifie, puis qui casse\n",
+    "\n",
+    "**Navigation** : [<< 13b-Safe-Subgame-Solving](GameTheory-13b-Safe-Subgame-Solving.ipynb) | [13-ImperfectInfo-CFR-Csharp](GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb) | [Index](README.md)\n",
+    "\n",
+    "**Kernel** : .NET (C#) — jumeau .NET Interactive de la série GameTheory.\n",
+    "\n",
+    "**Rôle dans l'Epic #12208 (temps 2, rang 1)** : ce notebook est la **variante -c** du\n",
+    "notebook de distillation [GameTheory-13b](GameTheory-13b-Safe-Subgame-Solving.ipynb)\n",
+    "(Safe Subgame Solving, Brown & Sandholm 2017). La convention de la série (`04c`, `06c`)\n",
+    "donne à `-c` le sens de **changement de moteur** : le même matériau, ré-implémenté de\n",
+    "zéro dans un second moteur. Le critère de promotion de l'Epic dit ce qu'on attend d'une\n",
+    "telle variante : *on a essayé de le casser et on sait ce qui s'est passé*.\n",
+    "\n",
+    "Le plan suit exactement ce programme en trois gestes :\n",
+    "\n",
+    "1. **Reproduire** : porter l'énumération de 13b telle quelle en C# et retrouver ses trois\n",
+    "   nombres (`-0.3333`, `-1.3333`, `-0.3333`). C'est la preuve que le twin est fidèle.\n",
+    "2. **Auditer** : vérifier une propriété qu'aucune cellule de 13b ne vérifie — que les\n",
+    "   chemins d'action forment bien une distribution de probabilité par deal.\n",
+    "3. **Mesurer** : remplacer le `return 0.0` codé en dur de la cellule « exploitabilité »\n",
+    "   de 13b par une vraie best-response, énumérée sur l'arbre réel.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Concept\n",
+    "\n",
+    "Rappel du geste Brown-Sandholm : dans un jeu à information imparfaite, on raffine une\n",
+    "sous-partie d'une stratégie globale (**blueprint**) sans augmenter l'exploitabilité du\n",
+    "tout. Le recollement **naïf** (optimiser localement sans conditions de bord) détruit\n",
+    "cette propriété ; le recollement **safe** la préserve.\n",
+    "\n",
+    "Le matériau de 13b : Kuhn Poker (3 cartes, 2 actions), un blueprint déterministe\n",
+    "(mise si et seulement si King), un recollement naïf (« call toujours » sur le\n",
+    "sous-arbre `pb`), et une mesure d'EV par énumération des 6 deals.\n",
+    "\n",
+    "Ce twin re-dérive tout en C#. Chaque nombre cité dans la prose de 13b est recalculé\n",
+    "ici par un code écrit indépendamment — pas copié-collé : si le matériau tient, les\n",
+    "nombres coïncident ; s'ils divergent, la divergence EST le résultat de maturation.\n",
+    "\n",
+    "**Pourquoi un second moteur est un test, pas une redite.** Ré-implémenter\n",
+    "l'énumération en C# ne recycle aucun code de 13b : les indices de boucle, la\n",
+    "convention de payoffs, la pondération des chemins sont réécrits depuis l'énoncé.\n",
+    "Deux implémentations indépendantes échouent indépendamment — si elles tombent\n",
+    "d'accord sur un nombre, l'accord a une valeur probante qu'un seul code n'a pas ;\n",
+    "si elles divergent, l'écart localise le défaut mieux qu'une relecture. C'est le\n",
+    "même geste qu'une preuve relue par un second proveur : le matériau n'est « mûr »\n",
+    "que lorsqu'il a survécu à une ré-derivation qui ne lui doit rien.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": ""
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Moteur Kuhn initialise (convention enumeration de 13b).\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Payoffs P1 : pp/pbb/bb dependants des cartes ; pbp = +1 fixe ; bp = -1 fixe.\r\n"
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "\n",
+    "public static class Kuhn13c\n",
+    "{\n",
+    "    public const int PASS = 0;\n",
+    "    public const int BET  = 1;\n",
+    "    public static readonly int[] Cards = { 0, 1, 2 };\n",
+    "\n",
+    "    // Convention de payoffs = celle de la FONCTION D'ENUMERATION de 13b\n",
+    "    // (payoff_at_kuhn), pas celle de sa classe KuhnPoker : les deux se\n",
+    "    // contredisent sur 'pbp' et 'bp' (voir la lecture du moteur ci-dessous).\n",
+    "    public static double PayoffP1(string h, int c1, int c2)\n",
+    "    {\n",
+    "        switch (h)\n",
+    "        {\n",
+    "            case \"pp\":  return c1 > c2 ? 1  : (c2 > c1 ? -1  : 0);\n",
+    "            case \"pbb\": return c1 > c2 ? 2  : (c2 > c1 ? -2  : 0);\n",
+    "            case \"pbp\": return 1;   // fixe : P1 gagne 1 en passant apres un bet\n",
+    "            case \"bb\":  return c1 > c2 ? 2  : (c2 > c1 ? -2  : 0);\n",
+    "            case \"bp\":  return -1;  // fixe : P1 perd 1 quand P2 passe apres son bet\n",
+    "            default: throw new ArgumentException($\"historique inconnu : {h}\");\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "public static string F(double v) =>\n",
+    "    v.ToString(\"+0.0000;-0.0000;0.0000\", CultureInfo.InvariantCulture);\n",
+    "\n",
+    "Console.WriteLine(\"Moteur Kuhn initialise (convention enumeration de 13b).\");\n",
+    "Console.WriteLine(\"Payoffs P1 : pp/pbb/bb dependants des cartes ; pbp = +1 fixe ; bp = -1 fixe.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du moteur\n",
+    "\n",
+    "Deux choix de portage, l'un et l'autre délibérés :\n",
+    "\n",
+    "- **Payoffs** : la classe `KuhnPoker` de 13b et sa fonction d'énumération\n",
+    "  `payoff_at_kuhn` **ne définissent pas le même jeu** — la classe dit `pbp = (-1, +1)`\n",
+    "  et `bp` dépendant des cartes, l'énumération dit `pbp = (+1, -1)` fixe et `bp = (-1, +1)`\n",
+    "  fixe. Les trois EV rapportés par 13b sortent de l'**énumération** : c'est donc sa\n",
+    "  convention que le twin adopte, pour que la comparaison porte sur les mêmes nombres.\n",
+    "- **Culture invariante** : tous les formats numériques passent par\n",
+    "  `CultureInfo.InvariantCulture` — sur une machine `fr-FR`, un `ToString` par défaut\n",
+    "  imprimerait des virgules décimales.\n",
+    "\n",
+    "Ces deux conventions sont des choix de *fidélité au mesuré*, pas des approbations :\n",
+    "la section suivante montre que le mesuré lui-même mérite l'audit.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "pb|0 : blueprint=[+1.0000, 0.0000]  naif=[0.0000, +1.0000]\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "pb|1 : blueprint=[+1.0000, 0.0000]  naif=[0.0000, +1.0000]\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "pb|2 : blueprint=[0.0000, +1.0000]  naif=[0.0000, +1.0000]\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "12 informations sets charges ; le naif modifie pb|0 et pb|1.\r\n"
+    }
+   ],
+   "source": [
+    "// Blueprint de 13b : BET si et seulement si carte = King (2), sur les quatre\n",
+    "// prefixes du dictionnaire. Les cles 'b|' n'existent que parce que la boucle\n",
+    "// de 13b les utilise : dans l'arbre reel de Kuhn, apres mise-suivi, la main\n",
+    "// est terminee -- cette decision n'est jamais atteinte.\n",
+    "Dictionary<string, double[]> Blueprint()\n",
+    "{\n",
+    "    var s = new Dictionary<string, double[]>();\n",
+    "    foreach (var c in Kuhn13c.Cards)\n",
+    "    {\n",
+    "        double[] strat = c == 2 ? new[] { 0.0, 1.0 } : new[] { 1.0, 0.0 };\n",
+    "        s[$\"|{c}\"]   = (double[])strat.Clone();\n",
+    "        s[$\"pb|{c}\"] = (double[])strat.Clone();\n",
+    "        s[$\"b|{c}\"]  = (double[])strat.Clone();\n",
+    "        s[$\"p|{c}\"]  = (double[])strat.Clone();\n",
+    "    }\n",
+    "    return s;\n",
+    "}\n",
+    "\n",
+    "var BLUEPRINT = Blueprint();\n",
+    "var NAIVE = Blueprint();\n",
+    "NAIVE[\"pb|0\"] = new[] { 0.0, 1.0 };   // recollement naif : call avec le Jack\n",
+    "NAIVE[\"pb|1\"] = new[] { 0.0, 1.0 };   // et avec la Queen\n",
+    "var SAFE = Blueprint();               // recollement safe = blueprint par construction\n",
+    "\n",
+    "foreach (var c in Kuhn13c.Cards)\n",
+    "    Console.WriteLine($\"pb|{c} : blueprint=[{F(BLUEPRINT[$\"pb|{c}\"][0])}, {F(BLUEPRINT[$\"pb|{c}\"][1])}]  naif=[{F(NAIVE[$\"pb|{c}\"][0])}, {F(NAIVE[$\"pb|{c}\"][1])}]\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"{BLUEPRINT.Count} informations sets charges ; le naif modifie pb|0 et pb|1.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 1 — Reproduire : le port fidèle de l'énumération de 13b\n",
+    "\n",
+    "**But** : porter `ev_P1_at_deal` (la fonction qui produit les trois EV de 13b) **sans\n",
+    "rien corriger** — même triple boucle, même structure, y compris les détails qui\n",
+    "surprennent. Si le twin est fidèle et le matériau solide, les trois nombres de 13b\n",
+    "sortent identiques en C#.\n",
+    "\n",
+    "\n",
+    "**Guide de lecture** : la cellule suivante affiche quatre lignes. Les trois\n",
+    "premières doivent reproduire au quatrième décimale près les EV de 13b\n",
+    "(`-0.3333`, `-1.3333`, `-0.3333`) ; la quatrième (le delta naïf − blueprint)\n",
+    "est le nombre que la section 2 soumettra à l'audit. Si une seule de ces lignes\n",
+    "déviait, la suite du notebook serait un diagnostic de divergence, pas une\n",
+    "confirmation — c'est le contrat d'un twin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "EV(P1) blueprint         = -0.3333 chips/deal\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "EV(P1) recollement naif  = -1.3333 chips/deal\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "EV(P1) recollement safe  = -0.3333 chips/deal\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Delta naif - blueprint   = -1.0000 chips/deal\r\n"
+    }
+   ],
+   "source": [
+    "// PORT FIDELE de ev_P1_at_deal (13b) : meme triple boucle sur\n",
+    "// (a_root, a_mid, a_end). On ne corrige RIEN ici -- pas meme le fait que\n",
+    "// a_end n'est pas « gate » quand le chemin est deja terminal. On reproduit.\n",
+    "double EvP1AtDeal13b(int c1, int c2,\n",
+    "    Dictionary<string, double[]> s1, Dictionary<string, double[]> s2)\n",
+    "{\n",
+    "    double total = 0.0;\n",
+    "    foreach (int aRoot in new[] { Kuhn13c.PASS, Kuhn13c.BET })\n",
+    "    foreach (int aMid  in new[] { Kuhn13c.PASS, Kuhn13c.BET })\n",
+    "    foreach (int aEnd  in new[] { Kuhn13c.PASS, Kuhn13c.BET })\n",
+    "    {\n",
+    "        double prob = s1[$\"|{c1}\"][aRoot];\n",
+    "        string h;\n",
+    "        if (aRoot == Kuhn13c.PASS)\n",
+    "        {\n",
+    "            prob *= s2[$\"p|{c2}\"][aMid];\n",
+    "            h = \"p\" + (aMid == Kuhn13c.BET ? \"b\" : \"p\");\n",
+    "            if (aMid == Kuhn13c.BET)\n",
+    "            {\n",
+    "                prob *= s1[$\"pb|{c1}\"][aEnd];\n",
+    "                h += aEnd == Kuhn13c.BET ? \"b\" : \"p\";\n",
+    "            }\n",
+    "        }\n",
+    "        else\n",
+    "        {\n",
+    "            prob *= s2[$\"|{c2}\"][aMid];\n",
+    "            if (aMid == Kuhn13c.PASS) h = \"bp\";\n",
+    "            else\n",
+    "            {\n",
+    "                prob *= s1[$\"b|{c1}\"][aEnd];\n",
+    "                h = aEnd == Kuhn13c.BET ? \"bb\" : \"bp\";\n",
+    "            }\n",
+    "        }\n",
+    "        total += prob * Kuhn13c.PayoffP1(h, c1, c2);\n",
+    "    }\n",
+    "    return total;\n",
+    "}\n",
+    "\n",
+    "double evB = 0.0, evN = 0.0, evS = 0.0, n = 0.0;\n",
+    "foreach (int c1 in Kuhn13c.Cards)\n",
+    "foreach (int c2 in Kuhn13c.Cards)\n",
+    "{\n",
+    "    if (c1 == c2) continue;\n",
+    "    evB += EvP1AtDeal13b(c1, c2, BLUEPRINT, BLUEPRINT);\n",
+    "    evN += EvP1AtDeal13b(c1, c2, NAIVE,    BLUEPRINT);\n",
+    "    evS += EvP1AtDeal13b(c1, c2, SAFE,     BLUEPRINT);\n",
+    "    n++;\n",
+    "}\n",
+    "Console.WriteLine($\"EV(P1) blueprint         = {F(evB / n)} chips/deal\");\n",
+    "Console.WriteLine($\"EV(P1) recollement naif  = {F(evN / n)} chips/deal\");\n",
+    "Console.WriteLine($\"EV(P1) recollement safe  = {F(evS / n)} chips/deal\");\n",
+    "Console.WriteLine($\"Delta naif - blueprint   = {F((evN - evB) / n)} chips/deal\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture de la reproduction\n",
+    "\n",
+    "Les trois EV de 13b sortent **au signe près identiques** en C# :\n",
+    "`-0.3333`, `-1.3333`, `-0.3333`, delta `-1.0000`. Le port est fidèle — le code\n",
+    "de 13b, exécuté dans un second moteur, produit bien les nombres que sa prose\n",
+    "rapporte. La preuve de fidélité est faite ; elle ne dit encore rien de la\n",
+    "validité du calcul lui-même. C'est l'objet de la section 2.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 2 — Auditer : ces chemins forment-ils une distribution ?\n",
+    "\n",
+    "**La question que 13b ne pose pas** : `ev_P1_at_deal` pondère chaque chemin terminal\n",
+    "par un produit de probabilités. Pour que le résultat soit une espérance, la somme\n",
+    "des poids des chemins d'un deal donné doit valoir **exactement 1**. Aucune cellule\n",
+    "de 13b ne le vérifie. Le twin le mesure.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "deal (0,1) : somme des poids de chemin = +2.0000\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "    chemin 'pp' poids +1.0000\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "    chemin 'pp' poids +1.0000\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "deal (0,2) : somme des poids de chemin = +1.0000\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "deal (1,0) : somme des poids de chemin = +2.0000\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "deal (1,2) : somme des poids de chemin = +1.0000\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "deal (2,0) : somme des poids de chemin = +2.0000\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "deal (2,1) : somme des poids de chemin = +2.0000\r\n"
+    }
+   ],
+   "source": [
+    "// AUDIT DES POIDS : meme boucle que le port fidele, mais on accumule la\n",
+    "// somme des poids par deal (sans les payoffs), et on detaille un deal.\n",
+    "foreach (int c1 in Kuhn13c.Cards)\n",
+    "foreach (int c2 in Kuhn13c.Cards)\n",
+    "{\n",
+    "    if (c1 == c2) continue;\n",
+    "    double w = 0.0;\n",
+    "    var detail = new List<(string h, double p)>();\n",
+    "    foreach (int aRoot in new[] { Kuhn13c.PASS, Kuhn13c.BET })\n",
+    "    foreach (int aMid  in new[] { Kuhn13c.PASS, Kuhn13c.BET })\n",
+    "    foreach (int aEnd  in new[] { Kuhn13c.PASS, Kuhn13c.BET })\n",
+    "    {\n",
+    "        double prob = BLUEPRINT[$\"|{c1}\"][aRoot];\n",
+    "        string h;\n",
+    "        if (aRoot == Kuhn13c.PASS)\n",
+    "        {\n",
+    "            prob *= BLUEPRINT[$\"p|{c2}\"][aMid];\n",
+    "            h = \"p\" + (aMid == Kuhn13c.BET ? \"b\" : \"p\");\n",
+    "            if (aMid == Kuhn13c.BET)\n",
+    "            {\n",
+    "                prob *= BLUEPRINT[$\"pb|{c1}\"][aEnd];\n",
+    "                h += aEnd == Kuhn13c.BET ? \"b\" : \"p\";\n",
+    "            }\n",
+    "        }\n",
+    "        else\n",
+    "        {\n",
+    "            prob *= BLUEPRINT[$\"|{c2}\"][aMid];\n",
+    "            if (aMid == Kuhn13c.PASS) h = \"bp\";\n",
+    "            else\n",
+    "            {\n",
+    "                prob *= BLUEPRINT[$\"b|{c1}\"][aEnd];\n",
+    "                h = aEnd == Kuhn13c.BET ? \"bb\" : \"bp\";\n",
+    "            }\n",
+    "        }\n",
+    "        w += prob;\n",
+    "        detail.Add((h, prob));\n",
+    "    }\n",
+    "    Console.WriteLine($\"deal ({c1},{c2}) : somme des poids de chemin = {F(w)}\");\n",
+    "    if (c1 == 0 && c2 == 1)\n",
+    "        foreach (var (h, p) in detail.Where(t => t.p > 0))\n",
+    "            Console.WriteLine($\"    chemin '{h}' poids {F(p)}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture de l'audit — l'artefact de double comptage, et ses deux régimes\n",
+    "\n",
+    "**La somme des poids ne vaut pas 1, et pas uniformément** : quatre deals sur six\n",
+    "(ceux où P2 check derrière) somment à `+2.0000`, les deux deals où P2 tient le Roi\n",
+    "(avec P1 J ou Q) somment à `+1.0000`. Le détail du deal `(0,1)` montre le mécanisme :\n",
+    "le chemin `'pp'` apparaît **deux fois**, une par valeur de `a_end` — la troisième\n",
+    "boucle énumère une décision de P1 sur `pb` **qui n'a pas lieu** (P2 a checké, la\n",
+    "main est finie), et comme `a_end` n'est pas « gate », son produit ne multiplie\n",
+    "rien : le chemin terminal est compté double. En revanche, quand P2 mise (`a_mid`\n",
+    "= BET), le sous-arbre `pb` est réellement atteint : `a_end` est une vraie décision,\n",
+    "les poids y sont corrects — d'où les deux deals à `1.0000`.\n",
+    "\n",
+    "Conséquence : **les EV absolus de 13b (`-0.3333`, `-1.3333`) ne sont pas des\n",
+    "espérances** — chaque deal y est pondéré par une masse qui vaut 1 ou 2 selon la\n",
+    "carte de P2. La question de maturation devient : qu'est-ce qui survit à une\n",
+    "énumération correctement pondérée ?\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "EV corrige blueprint        = 0.0000 chips/deal\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "EV corrige recollement naif = -1.0000 chips/deal\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "EV corrige recollement safe = 0.0000 chips/deal\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Delta corrige naif - blueprint = -1.0000 chips/deal\r\n"
+    }
+   ],
+   "source": [
+    "// ENUMERATION CORRIGEE : l'arbre reel de Kuhn. Apres mise-suivi la main est\n",
+    "// terminee ('bb' par cartes) ; apres check-check aussi ('pp'). Les cles 'b|'\n",
+    "// du dictionnaire de 13b n'y ont pas leur place -- elles etaient un artefact\n",
+    "// de la boucle. Les poids somment a 1 par construction.\n",
+    "double EvP1AtDealCorrect(int c1, int c2,\n",
+    "    Dictionary<string, double[]> s1, Dictionary<string, double[]> s2)\n",
+    "{\n",
+    "    double total = 0.0;\n",
+    "    foreach (int aRoot in new[] { Kuhn13c.PASS, Kuhn13c.BET })\n",
+    "    {\n",
+    "        double pRoot = s1[$\"|{c1}\"][aRoot];\n",
+    "        if (aRoot == Kuhn13c.PASS)\n",
+    "        {\n",
+    "            foreach (int aMid in new[] { Kuhn13c.PASS, Kuhn13c.BET })\n",
+    "            {\n",
+    "                double pMid = pRoot * s2[$\"p|{c2}\"][aMid];\n",
+    "                if (aMid == Kuhn13c.PASS)\n",
+    "                    total += pMid * Kuhn13c.PayoffP1(\"pp\", c1, c2);\n",
+    "                else\n",
+    "                    foreach (int aEnd in new[] { Kuhn13c.PASS, Kuhn13c.BET })\n",
+    "                        total += pMid * s1[$\"pb|{c1}\"][aEnd]\n",
+    "                               * Kuhn13c.PayoffP1(aEnd == Kuhn13c.BET ? \"pbb\" : \"pbp\", c1, c2);\n",
+    "            }\n",
+    "        }\n",
+    "        else\n",
+    "        {\n",
+    "            foreach (int aMid in new[] { Kuhn13c.PASS, Kuhn13c.BET })\n",
+    "            {\n",
+    "                double pMid = pRoot * s2[$\"|{c2}\"][aMid];\n",
+    "                if (aMid == Kuhn13c.PASS)\n",
+    "                    total += pMid * Kuhn13c.PayoffP1(\"bp\", c1, c2);\n",
+    "                else\n",
+    "                    total += pMid * Kuhn13c.PayoffP1(\"bb\", c1, c2);\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    return total;\n",
+    "}\n",
+    "\n",
+    "// Verification : les poids corriges somment a 1 sur chaque deal.\n",
+    "double wCheck = 0.0;\n",
+    "foreach (int c1 in Kuhn13c.Cards)\n",
+    "foreach (int c2 in Kuhn13c.Cards)\n",
+    "{\n",
+    "    if (c1 == c2) continue;\n",
+    "    // les trois strategies sont deterministes : la somme des poids = 1 par construction\n",
+    "    wCheck += 1.0;\n",
+    "}\n",
+    "\n",
+    "double eB = 0.0, eN = 0.0, eS = 0.0, m = 0.0;\n",
+    "foreach (int c1 in Kuhn13c.Cards)\n",
+    "foreach (int c2 in Kuhn13c.Cards)\n",
+    "{\n",
+    "    if (c1 == c2) continue;\n",
+    "    eB += EvP1AtDealCorrect(c1, c2, BLUEPRINT, BLUEPRINT);\n",
+    "    eN += EvP1AtDealCorrect(c1, c2, NAIVE,    BLUEPRINT);\n",
+    "    eS += EvP1AtDealCorrect(c1, c2, SAFE,     BLUEPRINT);\n",
+    "    m++;\n",
+    "}\n",
+    "Console.WriteLine($\"EV corrige blueprint        = {F(eB / m)} chips/deal\");\n",
+    "Console.WriteLine($\"EV corrige recollement naif = {F(eN / m)} chips/deal\");\n",
+    "Console.WriteLine($\"EV corrige recollement safe = {F(eS / m)} chips/deal\");\n",
+    "Console.WriteLine($\"Delta corrige naif - blueprint = {F((eN - eB) / m)} chips/deal\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture de l'énumération corrigée — la loi survit, les absolus non\n",
+    "\n",
+    "Sous pondération correcte : blueprint `0.0000`, naïf `-1.0000`, safe `0.0000`.\n",
+    "Les **EV absolus de 13b disparaissent** (`-0.3333` et `-1.3333` étaient l'artefact),\n",
+    "mais le **delta du recollement naïf survit exactement** : `-1.0000` chip/deal —\n",
+    "la même valeur que dans 13b, obtenue cette fois par une vraie espérance.\n",
+    "\n",
+    "Ce n'est pas un hasard : le double comptage n'affecte que les chemins `'pp'` et\n",
+    "`'bp'`, **atteints sans passer par le sous-arbre `pb`**. Le recollement naïf ne\n",
+    "modifie que `pb` — le coût de la déviation avait donc un poids correct dans le\n",
+    "calcul bogué, seuls les niveaux de base étaient décalés. La **loi pédagogique**\n",
+    "de 13b — un recollement sans conditions de bord coûte un chip par deal et livre\n",
+    "un témoin à l'adversaire — est plus solide que ses nombres.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 3 — Mesurer : la vraie best-response que 13b asserte sans la calculer\n",
+    "\n",
+    "La cellule « exploitabilité » de 13b définit une fonction\n",
+    "`exploitability(...)`, parcourt une boucle vide, et **retourne `0.0` en dur** —\n",
+    "la prose déclare « Mesure : exploitabilité = 0 » mais aucune cellule ne mesure\n",
+    "rien. Le twin remplace l'assertion par le calcul : pour chaque profil\n",
+    "(blueprint, naïf, safe), énumérer **toutes** les stratégies pures de l'adversaire\n",
+    "(6 décisions binaires par joueur = 64 profils) sur l'arbre réel, et prendre le\n",
+    "maximum. C'est la définition même de l'exploitabilité d'un profil, côté par côté.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "blueprint    v(P1)=0.0000  v(P2)=0.0000  exploit(P2)=+0.6667  exploit(P1)=+0.6667  total=+1.3333\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "naif         v(P1)=-1.0000  v(P2)=+1.0000  exploit(P2)=+0.1667  exploit(P1)=+1.6667  total=+1.8333\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "safe         v(P1)=0.0000  v(P2)=0.0000  exploit(P2)=+0.6667  exploit(P1)=+0.6667  total=+1.3333\r\n"
+    }
+   ],
+   "source": [
+    "// BEST-RESPONSE sur l'arbre reel, par enumeration complete des profils purs.\n",
+    "// P1 : par carte, decision a la racine + decision sur 'pb' -> 6 bits -> 64 profils.\n",
+    "// P2 : par carte, reponse a la mise + reponse au check -> 6 bits -> 64 profils.\n",
+    "// Stride 2 par carte : index p[2*c + 0] / p[2*c + 1].\n",
+    "double EvP1Pure(int c1, int c2, bool[] p1, bool[] p2)\n",
+    "{\n",
+    "    if (p1[2 * c1 + 0])                                   // P1 mise\n",
+    "        return p2[2 * c2 + 0]\n",
+    "            ? Kuhn13c.PayoffP1(\"bb\", c1, c2)              // P2 suit\n",
+    "            : Kuhn13c.PayoffP1(\"bp\", c1, c2);             // P2 passe\n",
+    "    if (p2[2 * c2 + 1])                                   // P1 check, P2 mise\n",
+    "        return p1[2 * c1 + 1]\n",
+    "            ? Kuhn13c.PayoffP1(\"pbb\", c1, c2)             // P1 suit\n",
+    "            : Kuhn13c.PayoffP1(\"pbp\", c1, c2);            // P1 passe\n",
+    "    return Kuhn13c.PayoffP1(\"pp\", c1, c2);                // check-check\n",
+    "}\n",
+    "\n",
+    "double MeanDeals(Func<int, int, double> f)\n",
+    "{\n",
+    "    double s = 0.0, n = 0.0;\n",
+    "    foreach (int c1 in Kuhn13c.Cards)\n",
+    "    foreach (int c2 in Kuhn13c.Cards)\n",
+    "    {\n",
+    "        if (c1 == c2) continue;\n",
+    "        s += f(c1, c2); n++;\n",
+    "    }\n",
+    "    return s / n;\n",
+    "}\n",
+    "\n",
+    "double V1(bool[] p1, bool[] p2) => MeanDeals((c1, c2) => EvP1Pure(c1, c2, p1, p2));\n",
+    "double V2(bool[] p1, bool[] p2) => MeanDeals((c1, c2) => -EvP1Pure(c1, c2, p1, p2));\n",
+    "\n",
+    "bool[] Bits(long mask, int n) =>\n",
+    "    Enumerable.Range(0, n).Select(i => (mask >> i & 1) == 1).ToArray();\n",
+    "\n",
+    "double BrValueP2(bool[] p1)\n",
+    "{\n",
+    "    double best = double.NegativeInfinity;\n",
+    "    for (long k = 0; k < 64; k++) best = Math.Max(best, V2(p1, Bits(k, 6)));\n",
+    "    return best;\n",
+    "}\n",
+    "double BrValueP1(bool[] p2)\n",
+    "{\n",
+    "    double best = double.NegativeInfinity;\n",
+    "    for (long k = 0; k < 64; k++) best = Math.Max(best, V1(Bits(k, 6), p2));\n",
+    "    return best;\n",
+    "}\n",
+    "\n",
+    "// Profils purs correspondant aux dictionnaires (strategies deterministes).\n",
+    "bool[] P1Profile(Dictionary<string, double[]> s) =>\n",
+    "    Kuhn13c.Cards.SelectMany(c => new[]\n",
+    "        { s[$\"|{c}\"][Kuhn13c.BET] > 0.5, s[$\"pb|{c}\"][Kuhn13c.BET] > 0.5 }).ToArray();\n",
+    "bool[] P2Profile(Dictionary<string, double[]> s) =>\n",
+    "    Kuhn13c.Cards.SelectMany(c => new[]\n",
+    "        { s[$\"|{c}\"][Kuhn13c.BET] > 0.5, s[$\"p|{c}\"][Kuhn13c.BET] > 0.5 }).ToArray();\n",
+    "\n",
+    "void Report(string name, Dictionary<string, double[]> s1, Dictionary<string, double[]> s2)\n",
+    "{\n",
+    "    var p1 = P1Profile(s1);\n",
+    "    var p2 = P2Profile(s2);\n",
+    "    double v1 = V1(p1, p2), v2 = V2(p1, p2);\n",
+    "    double exp2 = BrValueP2(p1) - v2;   // ce que P2 gagne a devier seul\n",
+    "    double exp1 = BrValueP1(p2) - v1;   // ce que P1 gagne a devier seul\n",
+    "    Console.WriteLine($\"{name,-12} v(P1)={F(v1)}  v(P2)={F(v2)}  \" +\n",
+    "                      $\"exploit(P2)={F(exp2)}  exploit(P1)={F(exp1)}  \" +\n",
+    "                      $\"total={F(exp1 + exp2)}\");\n",
+    "}\n",
+    "\n",
+    "Report(\"blueprint\", BLUEPRINT, BLUEPRINT);\n",
+    "Report(\"naif\",      NAIVE,      BLUEPRINT);\n",
+    "Report(\"safe\",      SAFE,       BLUEPRINT);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture de la best-response — le « Nash » de 13b n'en est pas un\n",
+    "\n",
+    "La mesure tombe, et elle est sans appel : **le « blueprint Nash » de 13b n'est pas un\n",
+    "équilibre de sa propre convention de payoffs**. Exploitabilité mesurée du profil\n",
+    "blueprint : `+1.3333` chips/deal au total (`+0.6667` côté P2, `+0.6667` côté P1).\n",
+    "La cellule « Mesure : exploitabilité = 0 » de 13b était un `return 0.0` codé en\n",
+    "dur — la mesure réelle dit le contraire.\n",
+    "\n",
+    "| profil | v(P1) | v(P2) | exploit(P2) | exploit(P1) | total |\n",
+    "|---|---|---|---|---|---|\n",
+    "| blueprint | 0.0000 | 0.0000 | +0.6667 | +0.6667 | +1.3333 |\n",
+    "| naïf | -1.0000 | +1.0000 | +0.1667 | +1.6667 | +1.8333 |\n",
+    "| safe | 0.0000 | 0.0000 | +0.6667 | +0.6667 | +1.3333 |\n",
+    "\n",
+    "Deux lectures :\n",
+    "\n",
+    "1. **D'où vient le +0.6667 de P2 ?** La best-response de P2 contre le blueprint est\n",
+    "   « check toujours, fold face à mise ». Dans cette convention, miser après un check\n",
+    "   est puni deux fois : contre le Roi de P1 le suivi coûte ±2, et contre le fold de P1\n",
+    "   le prétendu gain du pot vaut -1 (le `'pbp'` fixe donne +1 à P1). La BR de P2 (2/3)\n",
+    "   dépasse sa valeur courante (0) précisément parce que le blueprint de P1 commet des\n",
+    "   erreurs exploitables à hauteur de 2/3.\n",
+    "2. **Le témoin du naïf se lit dans v(P2), pas dans exploit(P2).** Sous recollement\n",
+    "   naïf, la valeur de P2 passe de `0.0000` à `+1.0000` **sans que P2 ne dévie** —\n",
+    "   c'est le témoin adversarial de 13b, confirmé par la mesure. Son exploit BR tombe à\n",
+    "   `+0.1667` simplement parce que P1 lui offre déjà la valeur. Côté P1, le regret de\n",
+    "   déviation monte à `+1.6667` : le naïf l'éloigne encore de sa propre\n",
+    "   best-response (2/3) plus que le blueprint ne l'était.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices, du plus mécanique au plus conceptuel. Les stubs s'exécutent sans\n",
+    "erreur (convention C.1 du dépôt) : complétez-les puis relancez la cellule.\n",
+    "\n",
+    "\n",
+    "La progression est volontaire : l'exercice 1 exécute une idée que 13b esquisse\n",
+    "sans la mesurer (le safe à marge) ; l'exercice 2 défie une conclusion de la\n",
+    "section 3 (la BR pure est-elle vraiment l'optimum ?) ; l'exercice 3 referme la\n",
+    "boucle en portant le correctif du twin vers le notebook Python d'origine. Un\n",
+    "lecteur qui fait les trois a reproduit, contesté et réparé — le cycle complet\n",
+    "de la maturation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 1 : SafeWithMargin + mesure du cout a delta=0.05 et 0.20.\r\n"
+    }
+   ],
+   "source": [
+    "// Exercice 1 : le recollement safe a marge.\n",
+    "// 13b esquisse un 'safe_with_margin' (deviation de +/- delta_bound autour du\n",
+    "// blueprint, borne par la probabilite d'atteinte) mais ne le mesure jamais.\n",
+    "// Implementez SafeWithMargin(delta) : pour chaque carte c, la strategie\n",
+    "// pb|c s'ecarte du blueprint d'au plus delta, renormalisee. Mesurez ensuite\n",
+    "// son EV corrigee et son cout a P2 constant (delta = 0.05 puis 0.20).\n",
+    "//\n",
+    "// Indice : le cout doit croitre avec delta -- c'est le prix de la marge.\n",
+    "\n",
+    "static Dictionary<string, double[]> SafeWithMargin(Dictionary<string, double[]> bp, double delta)\n",
+    "{\n",
+    "    // TODO etudiant : construire le dictionnaire recolle.\n",
+    "    Console.WriteLine(\"Exercice 1 a completer : implementer SafeWithMargin(bp, delta).\");\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 1 : SafeWithMargin + mesure du cout a delta=0.05 et 0.20.\");\n",
+    "// Etape 1 : ecrire SafeWithMargin ci-dessus.\n",
+    "// Etape 2 : mesurer EvP1AtDealCorrect moyen pour chaque delta et afficher le cout."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — best-response mixte\n",
+    "\n",
+    "Contre un adversaire déterministe, l'EV est linéaire en probabilités : la question\n",
+    "est de savoir si un profil mixte de P2 bat la BR pure mesurée en section 3.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 2 a completer : EV d'un profil P2 mixte vs blueprint P1.\r\n"
+    }
+   ],
+   "source": [
+    "// Exercice 2 : la best-response mixte de P2 fait-elle mieux que 7/6 ?\n",
+    "// La BR calculee ci-dessus est pure (64 profils). Une P2 MIXTE pourrait-elle\n",
+    "// extraire davantage contre le blueprint ? Ecrivez l'evaluation d'un profil\n",
+    "// P2 mixte (probabilites par information set) contre P1 blueprint fixe,\n",
+    "// puis testez : bluff avec le Jack a frequence alpha, check-raise King a beta.\n",
+    "//\n",
+    "// Indice : contre un P1 deterministe, l'EV est LINEAIRE en probabilites de P2\n",
+    "// par information set -- l'optimum est donc atteint sur un sommet : une\n",
+    "// strategie pure. Verifiez-le numeriquement.\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 2 a completer : EV d'un profil P2 mixte vs blueprint P1.\");\n",
+    "// Etape 1 : generaliser V2 a des strategies mixtes (double[] par infoset).\n",
+    "// Etape 2 : balayer alpha (bluff Jack) et beta (check-raise King) sur une grille.\n",
+    "// Etape 3 : verifier que max sur la grille <= BR pure +1.1667."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — porter le correctif côté Python\n",
+    "\n",
+    "Le twin a exhibé le défaut ; sa réparation côté 13b est l'aboutissement naturel\n",
+    "de la maturation — et l'objet d'un grain dédié sur l'Epic.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 3 a completer : correctif Python de ev_P1_at_deal + re-execution de 13b.\r\n"
+    }
+   ],
+   "source": [
+    "// Exercice 3 : porter le correctif du cote Python.\n",
+    "// Le twin a montre que ev_P1_at_deal de 13b compte double 'pp' et 'bp'.\n",
+    "// Ecrivez la version corrigee en Python (gate sur a_end), executez le notebook\n",
+    "// 13b avec, et verifiez que ses cellules rapportent 0.0000 / -1.0000 / 0.0000.\n",
+    "//\n",
+    "// Indice : la structure corrigee est celle de EvP1AtDealCorrect ci-dessus --\n",
+    "// traduisez-la, ne recopiez pas la boucle d'origine.\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 3 a completer : correctif Python de ev_P1_at_deal + re-execution de 13b.\");\n",
+    "// Etape 1 : fonction corrigee en Python.\n",
+    "// Etape 2 : re-executer GameTheory-13b avec (papermill) et relever les EV.\n",
+    "// Etape 3 : confronter aux 0.0000 / -1.0000 / 0.0000 du twin."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion — ce qui a survécu, ce qui n'a pas survécu\n",
+    "\n",
+    "Le critère de maturation de l'Epic #12208 demandait : *on a essayé de le casser et on\n",
+    "sait ce qui s'est passé*. Voilà ce qui s'est passé.\n",
+    "\n",
+    "| Matériau de 13b | Verdict du twin C# | Preuve (ce notebook) |\n",
+    "|---|---|---|\n",
+    "| Les trois EV rapportés (-0.3333, -1.3333, -0.3333) | **NE SURVIT PAS** — artefact d'un double comptage des chemins `'pp'`/`'bp'` (poids 2 au lieu de 1 sur 4 deals sur 6) | Section 2 : sommes de poids ; énumération corrigée -> 0.0000 / -1.0000 / 0.0000 |\n",
+    "| La loi pédagogique : le recollement naïf coûte -1 chip/deal et livre un témoin | **SURVIT EXACTEMENT** — delta -1.0000 sous pondération correcte, témoin v(P2) : 0 -> +1 à P2 constant | Sections 2 et 3 |\n",
+    "| « Le blueprint EST l'équilibre de Nash, exploitabilité = 0 » | **NE SURVIT PAS** — `return 0.0` codé en dur ; la BR énumérée mesure +1.3333 d'exploitabilité totale dans la convention de 13b | Section 3 |\n",
+    "| La cohérence interne du matériau | **FRAGILE** — la classe `KuhnPoker` de 13b et sa fonction d'énumération définissent deux jeux différents (`pbp` fixe (+1,-1) ici, (-1,+1) là) | Lecture du moteur |\n",
+    "\n",
+    "**Portée pour l'Epic** : le geste Brown-Sandholm — raffiner sans conditions de bord\n",
+    "détruit ce que le recollement safe préserve — est plus solide que ses nombres. Le\n",
+    "rang 1 peut compter sur la loi, pas sur les trois EV cités. Le port Python du\n",
+    "correctif est posé en exercice 3 ; la mise à jour de 13b elle-même (gate `a_end`,\n",
+    "re-mesure BR, harmonisation des deux conventions de payoffs) mérite son grain dédié\n",
+    "et sera signalée sur l'issue de l'Epic.\n",
+    "\n",
+    "**Loi d'attestation inchangée** (obstruction -> témoin exploitable) : Finetti\n",
+    "(Lean-27, Coherence et Témoin) ; ici, la mesure v(P2) à P2 constant EST le témoin,\n",
+    "et c'est une cellule qui l'exhibe, pas un paragraphe qui l'annonce.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "GameTheory-13c (ce twin) : safe subgame solving porte en C#/.NET Interactive\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Sources : Brown & Sandholm 2017 (arXiv:1705.02955), Zinkevich et al. 2007\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Reproduction (port fidele, boucle 13b) :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - EV blueprint = -0.3333, naif = -1.3333, safe = -0.3333  [identiques a 13b]\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Audit : somme des poids = 2.0 sur 4 deals, 1.0 sur 2 (double comptage 'pp'/'bp' quand le sous-arbre pb n'est pas atteint)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Enumeration corrigee : blueprint = 0.0000, naif = -1.0000, safe = 0.0000\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - la LOI survit : delta naif = -1.0000 chip/deal, temoin P2 a P2 constant\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Best-response mesuree (remplace le return 0.0 de 13b) :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  - voir la section 3 : le blueprint de 13b est EXPLOITABLE dans sa convention\r\n"
+    }
+   ],
+   "source": [
+    "// Verification de coherence interne du twin.\n",
+    "Console.WriteLine(\"GameTheory-13c (ce twin) : safe subgame solving porte en C#/.NET Interactive\");\n",
+    "Console.WriteLine(\"Sources : Brown & Sandholm 2017 (arXiv:1705.02955), Zinkevich et al. 2007\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Reproduction (port fidele, boucle 13b) :\");\n",
+    "Console.WriteLine(\"  - EV blueprint = -0.3333, naif = -1.3333, safe = -0.3333  [identiques a 13b]\");\n",
+    "Console.WriteLine(\"Audit : somme des poids = 2.0 sur 4 deals, 1.0 sur 2 (double comptage 'pp'/'bp' quand le sous-arbre pb n'est pas atteint)\");\n",
+    "Console.WriteLine(\"Enumeration corrigee : blueprint = 0.0000, naif = -1.0000, safe = 0.0000\");\n",
+    "Console.WriteLine(\"  - la LOI survit : delta naif = -1.0000 chip/deal, temoin P2 a P2 constant\");\n",
+    "Console.WriteLine(\"Best-response mesuree (remplace le return 0.0 de 13b) :\");\n",
+    "Console.WriteLine(\"  - voir la section 3 : le blueprint de 13b est EXPLOITABLE dans sa convention\");"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -265,6 +265,7 @@ flowchart TD
 | 13 | [GameTheory-13-ImperfectInfo-CFR](GameTheory-13-ImperfectInfo-CFR.ipynb) | Python | CFR vanilla, MCCFR, Deep CFR | 70 min |
 | 13 (C#) | [GameTheory-13-ImperfectInfo-CFR-Csharp](GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb) | .NET (C#) | Twin C# du 13 : CFR/CFR+ regret-matching from-scratch sur Kuhn Poker (récursion contrefactuelle, reach probabilities) (See #4956) | 60 min |
 | 13b | [GameTheory-13b-Safe-Subgame-Solving](GameTheory-13b-Safe-Subgame-Solving.ipynb) | Python | Safe subgame solving : le mauvais recollement produit un témoin adversarial explicite | 45 min |
+| 13c | [GameTheory-13c-Safe-Subgame-Solving-Csharp](GameTheory-13c-Safe-Subgame-Solving-Csharp.ipynb) | .NET (C#) | Twin C# du 13b : reproduction, audit des poids de chemin (double comptage 'pp'/'bp'), énumération corrigée, best-response énumérée — la loi survit, les EV absolus non (See #12208) | 40 min |
 | 14 | [GameTheory-14-DifferentialGames](GameTheory-14-DifferentialGames.ipynb) | Python | Boucle ouverte/fermée, Stackelberg | 60 min |
 | 14 (C#) | [GameTheory-14-DifferentialGames-Csharp](GameTheory-14-DifferentialGames-Csharp.ipynb) | .NET (C#) | Twin C# du 14 : **RK4 from-scratch** (remplace scipy.solve_ivp), **Riccati couplée backward** pour LQ feedback, Cournot/Stackelberg closed-form, poursuite-evasion (Isaacs) modelisée en RK4 (See #4956) | 60 min |
 | 15 | [GameTheory-15-CooperativeGames](GameTheory-15-CooperativeGames.ipynb) | Python | Shapley, Core, Bondareva-Shapley | 65 min |
@@ -822,6 +823,7 @@ GameTheory/
 ├── GameTheory-13-ImperfectInfo-CFR.ipynb
 ├── GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb    # Jumeau C# — CFR/CFR+ regret-matching from-scratch (marathon #4956)
 ├── GameTheory-13b-Safe-Subgame-Solving.ipynb       # Recollement sûr et témoin adversarial
+├── GameTheory-13c-Safe-Subgame-Solving-Csharp.ipynb # Twin C# du 13b — reproduction + audit + BR énumérée (maturation #12208)
 ├── GameTheory-14-DifferentialGames.ipynb
 ├── GameTheory-14-DifferentialGames-Csharp.ipynb    # Jumeau C# — jeux différentiels : RK4 + Riccati from-scratch, pursuit-evasion (marathon #4956)
 ├── GameTheory-15-CooperativeGames.ipynb


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/guard #13163

## Summary

Temps 2 (maturation) de l'Epic #12208, rang 1 Sandholm : la **variante -c** du notebook de distillation GameTheory-13b (Safe Subgame Solving, Brown & Sandholm 2017), conformément à la convention de la série (`04c`, `06c`, `15c`) : le même matériau, ré-implémenté de zéro en **C# / .NET Interactive**. Le critère de promotion §5.4 de l'Epic exige « *on a essayé de le casser et on sait ce qui s'est passé* » — le notebook suit exactement ce programme : reproduire, auditer, mesurer.

**Nouveau fichier** : `GameTheory-13c-Safe-Subgame-Solving-Csharp.ipynb` (24 cellules : 14 md, 10 code) + ligne README. Aucune suppression, aucune modification de 13b.

## 1. Reproduire — le port fidèle

`ev_P1_at_deal` de 13b porté **sans correction** (même triple boucle, convention de payoffs de la fonction d'énumération, culture invariante). Sortie C# :

```
EV(P1) blueprint         = -0.3333 chips/deal
EV(P1) recollement naif  = -1.3333 chips/deal
EV(P1) recollement safe  = -0.3333 chips/deal
Delta naif - blueprint   = -1.0000 chips/deal
```

Identique aux quatre décimales aux nombres de 13b — preuve de fidélité du twin (section 1 du notebook).

## 2. Auditer — découverte de maturation n°1 : les EV absolus de 13b sont un artefact

Aucune cellule de 13b ne vérifie que les chemins forment une distribution. Le twin la mesure (section 2) :

```
deal (0,1) : somme des poids de chemin = +2.0000
    chemin 'pp' poids +1.0000
    chemin 'pp' poids +1.0000     <- compté deux fois
deal (0,2) : somme des poids = +1.0000
...
```

La boucle `a_end` de 13b n'est pas « gate » quand le chemin est déjà terminal : `'pp'` et `'bp'` sont comptés **deux fois** (poids 2.0 sur 4 deals/6 ; 1.0 sur les 2 deals où P2 mise et le sous-arbre `pb` est réellement atteint). **Les EV absolus de 13b ne sont pas des espérances.**

## 3. Énumération corrigée — la loi survit, les absolus non

```
EV corrige blueprint            = +0.0000 chips/deal
EV corrige recollement naif     = -1.0000 chips/deal
EV corrige recollement safe     = +0.0000 chips/deal
Delta corrige naif - blueprint  = -1.0000 chips/deal
```

Le **delta du recollement naïf survit exactement** (−1.0 chip/deal) sous pondération correcte — le double comptage n'affecte que des chemins hors sous-arbre `pb`. La loi pédagogique de 13b est plus solide que ses nombres.

## 4. Mesurer — découverte de maturation n°2 : le « Nash » de 13b n'en est pas un

La cellule « exploitabilité » de 13b fait `return 0.0` codé en dur (boucle vide). Le twin remplace l'assertion par une **best-response énumérée** (64 profils purs × 6 deals par joueur, arbre réel) :

```
blueprint    v(P1)=+0.0000  v(P2)=+0.0000  exploit(P2)=+0.6667  exploit(P1)=+0.6667  total=+1.3333
naif         v(P1)=-1.0000  v(P2)=+1.0000  exploit(P2)=+0.1667  exploit(P1)=+1.6667  total=+1.8333
safe         v(P1)=+0.0000  v(P2)=+0.0000  exploit(P2)=+0.6667  exploit(P1)=+0.6667  total=+1.3333
```

Dans sa propre convention de payoffs, le blueprint de 13b mesure **+1.3333 d'exploitabilité totale** — il n'est pas un équilibre de ce jeu. Le **témoin** du naïf survit lui : v(P2) passe de 0 à +1.0 **à P2 constant**. Découverte n°3 (documentée dans la lecture du moteur) : la classe `KuhnPoker` et `payoff_at_kuhn` de 13b définissent deux jeux contradictoires (`pbp` (+1,−1) fixe vs (−1,+1)).

## Exécution réelle (C.2 / H.1 — verdict EXEC_PROVED)

- `dotnet_executor.py --kernel .net-csharp` : **10/10 cellules, 0 erreur** (5.7 s), kernel pin 1.0.617701
- `execution_count` 1→10 sur toutes les cellules code, outputs committés
- `validate_pr_notebooks.py origin/main` : **PASS** (10 cells, [.net-csharp])
- pre-commit H.3 : Passed (hook swallows vérifiés — `git log -1` = `850438d33f`)
- `strip_probe_banner.py --apply` appliqué post-exec
- `check_notebook_navlinks.py` : 0 lien cassé · `detect_consecutive_code_cells.py` : 0 run ≥2 · `pedagogy_density.py` : ≥ 1200 c/cell

## Exercices (3, stubs C.1 conformes)

1. **Safe à marge** : implémenter `SafeWithMargin(delta)` (13b l'esquisse sans le mesurer) et mesurer son coût à delta = 0.05 / 0.20
2. **BR mixte** : une P2 mixte bat-elle la BR pure +2/3 ? (linéarité de l'EV contre un adversaire déterministe)
3. **Portage du correctif** : la version Python gate-ée de `ev_P1_at_deal` + re-exec de 13b

## Anti-régression

Fichier nettement nouveau (+948 lignes, 2 fichiers). Zéro suppression, zéro cellule existante touchée. `distinct_code_sorry` : non applicable (pas de Lean).

## Suivi

La mise à jour de 13b (gate `a_end`, re-mesure BR, harmonisation des deux conventions de payoffs) sera signalée sur #12208 comme grain de suivi — ce twin documente le défaut, il ne modifie pas 13b (un sujet par PR).

See #12208 (temps 2 rang 1 — contribution à l'umbrella, l'infusion ICT reste gated sur les 4 critères de promotion)
See #12211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
