### PR TITLE
fix(gt,#13299): navlinks cellule 0 GT-21-Stackelberg — préfixes ../ corrigés en ./

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-21-Stackelberg-SecurityGame.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-21-Stackelberg-SecurityGame.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# GameTheory-21 : Stackelberg Security Game — patrouille, capteur imparfait, signaling\n",
     "\n",
-    "**Navigation** : [GameTheory-20-Commitment-Stackelberg](../GameTheory-20-Commitment-Stackelberg.ipynb) — engagement crédible · [Sommaire GameTheory](../README.md)\n",
+    "**Navigation** : [GameTheory-20-Commitment-Stackelberg](./GameTheory-20-Commitment-Stackelberg.ipynb) — engagement crédible · [Sommaire GameTheory](./README.md)\n",
     "\n",
     "## Pourquoi ce notebook\n",
     "\n",


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2023:CoursIA — prev: DEEP/notebook-python #13299

fix(gt,#13299): navlinks cellule 0 GT-21-Stackelberg — `../` retiré pour siblings

La cellule 0 du notebook `GameTheory-21-Stackelberg-SecurityGame.ipynb` (ajouté dans la PR #13299 = feat #13295) référençait deux fichiers **siblings** (même dossier `MyIA.AI.Notebooks/GameTheory/`) avec un préfixe `../` erroné :

1. `../GameTheory-20-Commitment-Stackelberg.ipynb` — devrait être `./GameTheory-20-Commitment-Stackelberg.ipynb` (sibling, pas parent)
2. `../README.md` — devrait être `./README.md` (README du dossier `GameTheory/`, sibling)

Le contrôle `check_notebook_navlinks.py` cassait sur les deux (`FAIL: 1 NEW broken navlink(s) vs baseline`). Convention déjà appliquée dans GT-22 et GT-23 : sibling = `./`, parent dir = `../`.

**Fix chirurgical** : remplacement des deux préfixes `../` par `./` sur la ligne 2 du `source` (liste de 40 strings — préservée intégralement, cf c.532-L2 ★★). Diff : `+2/-2`, structure de cellule inchangée, navlink check OK.

**Validation** :
- `python scripts/notebook_tools/check_notebook_navlinks.py` → `OK: 0 lien casse`
- Round-trip `json.dumps(nb, indent=1)` + LF-only (c.420-L1)
- 0 modification des autres cellules, 0 modification du papermill metadata, 0 modification des outputs

**Référence convention** : GT-22-Deux-Especes-de-Fleches navlink `[<< 21-Deux-Especes-de-Fleches](GameTheory-21-Deux-Especes-de-Fleches.ipynb) | [Index](README.md)` (siblings sans préfixe) — même pattern.

Push sur branche `fix/13299-navlink` (forkée depuis `origin/feature/13295-security-game`).

Cc: myia-po-2023:CoursIA 2026-08-28.