### PR TITLE
feat(notebooks,#13330): GameTheory-01-Setup aide-memoire multiplateforme

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-01-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-01-Setup.ipynb
@@ -2750,7 +2750,7 @@
     "### Aide-mémoire : installation selon votre plateforme\n",
     "\n",
     "La cellule suivante affiche la commande d'installation OpenSpiel adaptée à **votre**\n",
-    "machine détectée — miroir de l'aide-mémoire du [Lean-1-Setup](../../SymbolicAI/Lean/Lean-1-Setup.ipynb).\n",
+    "machine détectée — miroir de l'aide-mémoire du [Lean-1-Setup](../SymbolicAI/Lean/Lean-1-Setup.ipynb).\n",
     "Cellule informative : aucun changement de système, affichage uniquement.\n"
    ]
   },
@@ -2824,18 +2824,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 15.027438,
-   "end_time": "2026-05-14T19:28:05.998718+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "GameTheory-1-Setup.ipynb",
-   "output_path": "GameTheory-1-Setup.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-14T19:27:50.971280+00:00",
-   "version": "2.6.0"
   },
   "cost": {
    "api_usd_est": 0.0,

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-01-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-01-Setup.ipynb
@@ -2739,6 +2739,72 @@
     "\n",
     "**Suite** : [GT-2 - Forme normale](GameTheory-02-NormalForm.ipynb) | [Retour au sommaire](README.md)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt01-aide-memoire-md",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "\n",
+    "### Aide-mémoire : installation selon votre plateforme\n",
+    "\n",
+    "La cellule suivante affiche la commande d'installation OpenSpiel adaptée à **votre**\n",
+    "machine détectée — miroir de l'aide-mémoire du [Lean-1-Setup](../../SymbolicAI/Lean/Lean-1-Setup.ipynb).\n",
+    "Cellule informative : aucun changement de système, affichage uniquement.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "gt01-aide-memoire-code",
+   "metadata": {},
+   "execution_count": 22,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "================================================================\n    AIDE-MEMOIRE : installation OpenSpiel pour VOTRE machine\n================================================================\n\nOS detecte : Windows\n\nPlateforme : Windows\n\n  OpenSpiel n'a pas de wheel pip natif Windows. Deux voies :\n\n  1. WSL (recommande) : suivre la section Configuration WSL\n     de ce notebook (kernel gametheory-wsl configure automatiquement,\n     Windows uniquement).\n\n  2. Fallback Python pur : le notebook fonctionne sans OpenSpiel\n     via game_theory_utils.py (sections suivantes).\n"
+    }
+   ],
+   "source": [
+    "# Aide-memoire : commande d'installation OpenSpiel selon la plateforme detectee.\n",
+    "# Cellule informative : aucun changement de systeme, affichage uniquement.\n",
+    "\n",
+    "import platform\n",
+    "\n",
+    "system = platform.system()\n",
+    "print(\"=\" * 64)\n",
+    "print(\"    AIDE-MEMOIRE : installation OpenSpiel pour VOTRE machine\")\n",
+    "print(\"=\" * 64)\n",
+    "print()\n",
+    "print(f\"OS detecte : {system}\")\n",
+    "print()\n",
+    "\n",
+    "if system == \"Windows\":\n",
+    "    print(\"Plateforme : Windows\")\n",
+    "    print()\n",
+    "    print(\"  OpenSpiel n'a pas de wheel pip natif Windows. Deux voies :\")\n",
+    "    print()\n",
+    "    print(\"  1. WSL (recommande) : suivre la section Configuration WSL\")\n",
+    "    print(\"     de ce notebook (kernel gametheory-wsl configure automatiquement,\")\n",
+    "    print(\"     Windows uniquement).\")\n",
+    "    print()\n",
+    "    print(\"  2. Fallback Python pur : le notebook fonctionne sans OpenSpiel\")\n",
+    "    print(\"     via game_theory_utils.py (sections suivantes).\")\n",
+    "elif system in (\"Darwin\", \"Linux\"):\n",
+    "    nom = \"macOS\" if system == \"Darwin\" else \"Linux\"\n",
+    "    print(f\"Plateforme : {nom}\")\n",
+    "    print()\n",
+    "    print(\"  # Installation directe (elan/pip natifs, pas de WSL)\")\n",
+    "    print(\"  pip install open_spiel\")\n",
+    "    print()\n",
+    "    print(\"  Puis relancer ce notebook : la cellule de detection (section 1)\")\n",
+    "    print(\"  confirmera le nombre de jeux disponibles.\")\n",
+    "else:\n",
+    "    print(f\"Plateforme non reconnue : {system}\")\n",
+    "    print(\"  Consulter la table 'Plateformes supportees' en tete de notebook.\")\n",
+    ""
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: LIGHT/docs #13323

## Summary

Finalise le socle multiplateforme de **GameTheory-01-Setup** en ajoutant l'**aide-mémoire d'installation** qui manquait au miroir du standard Lean-1-Setup (#13271) — le dernier item d'acceptation de #13330 :

- **Cellule markdown** `### Aide-mémoire : installation selon votre plateforme` en fin de notebook, avec lien vers le miroir [Lean-1-Setup](../../SymbolicAI/Lean/Lean-1-Setup.ipynb).
- **Cellule code display-only** (aucune mutation de système) : détecte l'OS du lecteur via `platform.system()` et affiche la voie d'installation OpenSpiel correspondante :
  - **Windows** → WSL (section Configuration WSL du notebook) ou fallback Python pur `game_theory_utils.py` ;
  - **macOS / Linux** → `pip install open_spiel` natif puis relance ;
  - OS non reconnu → renvoi vers la table « Plateformes supportées » (cellule 3, livrée par #13271).

## Validation (H.1)

- **Exécution réelle** : cellule exécutée via `jupyter_client` (kernel `python3`) sur cette machine — output transplanted avec `execution_count: 22`, séquence ec monotone préservée (1..22 en ordre fichier, vérifiée avant l'append).
- **Sortie réelle commitée** (branche Windows, machine de build) :
```
================================================================
    AIDE-MEMOIRE : installation OpenSpiel pour VOTRE machine
================================================================

OS detecte : Windows

Plateforme : Windows
  OpenSpiel n'a pas de wheel pip natif Windows. Deux voies :
  1. WSL (recommande) : suivre la section Configuration WSL ...
  2. Fallback Python pur : le notebook fonctionne sans OpenSpiel ...
```
- `validate_pr_notebooks.py origin/main` : **PASS 1/1** (22 cellules code).
- Pre-commit H.3 : PASS (hook `fix-hr-separator` a converti le séparateur `---` → `***`, règle yaml_block_open_no_close — rendu identique).
- C.1 : conforme — cellule purement informative, aucune erreur volontaire, aucun side-effect.

Closes #13330 (sous-issue de #10643)
