### PR TITLE
fix(ci,#13315): md-drift guard juge le diff contre la base de fusion re-scannee, pas la baseline stockee

### DIFF
--- a/.github/workflows/scan-md-hierarchy-drift.yml
+++ b/.github/workflows/scan-md-hierarchy-drift.yml
@@ -45,11 +45,18 @@ jobs:
           # une baseline burndown. On restreint le scan aux notebooks que la PR
           # a reels changes (git -M resout les renommages) ; a defaut (dispatch,
           # BASE_SHA vide) on retombe sur un drift whole-corpus.
+          # #13315: la reference "avant" est la BASE DE FUSION re-scannee
+          # (--reference-base), pas la baseline stockee -- une PR basee sur un
+          # main ancien ne doit pas voir imputer la derive de la baseline. Le
+          # mode fallback (sans BASE_SHA) garde la baseline stockee, et la
+          # phrase du commentaire est alors attenuee.
           EXTRA=""
+          SCOPED=0
           if [ -n "$BASE_SHA" ]; then
             git diff -M --name-status "$BASE_SHA...$HEAD_SHA" \
               -- 'MyIA.AI.Notebooks/' > name_status.txt
-            EXTRA="--name-status name_status.txt"
+            EXTRA="--name-status name_status.txt --reference-base $BASE_SHA"
+            SCOPED=1
           fi
           set +e
           python scripts/notebook_tools/scan_md_hierarchy.py MyIA.AI.Notebooks/ \
@@ -60,16 +67,26 @@ jobs:
             {
               echo "## MD hierarchy drift -- ${HEAD_SHA:0:9}"
               echo ""
-              echo "Cette PR augmente le compte de defauts de rendu markdown"
-              echo "(baseline = burndown, ne pas croitre). Nouveaux defauts :"
+              if [ "$SCOPED" -eq 1 ]; then
+                echo "Cette PR augmente le compte de defauts de rendu markdown"
+                echo "par rapport a la base de fusion ${BASE_SHA:0:9} re-scannee."
+                echo "Nouveaux defauts imputables au diff :"
+              else
+                echo "Drift vs la baseline stockee (mode dispatch, sans base de"
+                echo "fusion) -- derive du corpus, pas d'imputation stricte a ce"
+                echo "diff. Details :"
+              fi
               echo ""
               echo '```'
               cat drift_report.txt
               echo '```'
               echo ""
-              echo "Corriger (ex. \`- # Indice : ...\` -> \`- **Indice :** ...\`) ou,"
-              echo "si la regle scanner change dans CETTE PR, re-seeder la baseline"
-              echo "dans le meme commit : \`--update-baseline\`. See #11831."
+              if [ "$SCOPED" -eq 1 ]; then
+                echo "Corriger (ex. \`- # Indice : ...\` -> \`- **Indice :** ...\`). See #11831."
+              else
+                echo "Si la regle scanner change dans CETTE PR, re-seeder la baseline"
+                echo "dans le meme commit : \`--update-baseline\`. See #11831."
+              fi
             } > comment_body.md
             gh pr comment "$PR_NUMBER" --body-file comment_body.md
             echo "::warning file=scripts/notebook_tools/md_hierarchy_baseline.json::MD hierarchy drift detected (advisory, #11831) -- see PR comment"
@@ -79,4 +96,8 @@ jobs:
             cat drift_err.txt
             exit 1
           fi
-          echo "No drift: every per-notebook delta <= 0."
+          if [ "$SCOPED" -eq 1 ]; then
+            echo "No drift imputable au diff de la PR (reference = base de fusion ${BASE_SHA:0:9} re-scannee)."
+          else
+            echo "No drift: every per-notebook delta <= 0."
+          fi

--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -350,6 +350,56 @@ def _resolve_against(p, root):
     return q if q.is_absolute() else (root / q)
 
 
+def reference_counts_from(items):
+    """{key: {kind: count}} from explicit (key, materialized-file) pairs.
+
+    ``--reference-base`` (#13315): the reference "before this PR" is the
+    BASE-OF-FUSION tree itself, re-scanned -- not the stored baseline (which
+    main re-seeds and can drift under a stale PR base). Keys are EXPLICIT (the
+    pre-rename path for a renamed notebook), never derived from the
+    materialization path, so ``diff_against_baseline`` resolves them through
+    ``renames`` exactly like a stored-baseline entry.
+    """
+    out: dict[str, dict[str, int]] = {}
+    for key, path in items:
+        kinds: dict[str, int] = {}
+        for f in scan_notebook(pathlib.Path(path)):
+            kinds[f['kind']] = kinds.get(f['kind'], 0) + 1
+        if kinds:
+            out[key] = kinds
+    return out
+
+
+def materialize_reference_base(base_sha, heads, renames, repo_root=None):
+    """[(old-or-current key, tmp file)] -- `git show base:<path>` per changed nb.
+
+    For a rename NEW->OLD the blob is read at (and keyed by) the OLD path: same
+    content, old key -- a pure rename nets to 0 through the existing renames
+    resolution (#13315 criterion 3). A notebook absent at the base tree (added
+    by the PR) yields no entry: all its findings are new, which is the correct
+    attribution. Unreadable blob -> skipped entry (treated as added).
+    """
+    import subprocess
+    import tempfile
+    root = pathlib.Path(repo_root) if repo_root is not None else _repo_root()
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix='md_hierarchy_ref_'))
+    items = []
+    for new_path in sorted(heads):
+        ref_path = renames.get(new_path, new_path)
+        dest = tmp / ref_path.replace('/', '__')
+        try:
+            proc = subprocess.run(
+                ['git', '-C', str(root), 'show', f'{base_sha}:{ref_path}'],
+                capture_output=True, timeout=30)
+        except OSError:
+            continue
+        if proc.returncode != 0 or not dest.parent.exists():
+            continue
+        dest.write_bytes(proc.stdout)
+        items.append((ref_path, dest))
+    return items
+
+
 def diff_against_baseline(current, baseline, renames=None, only=None):
     """(regressions, improvements, stable) -- per-notebook NET deltas.
 
@@ -476,6 +526,13 @@ def main(argv=None):
                              '"new defect of this PR"), and a legit rename is '
                              'resolved to its pre-rename baseline path so it '
                              'does not count +1/-1 as two notebooks')
+    parser.add_argument('--reference-base', default=None, metavar='SHA',
+                        help='reference tree (#13315): re-scan the BASE-OF-FUSION '
+                             'versions of the changed notebooks (git show SHA:path) '
+                             'instead of the stored baseline. Kills the stale-base '
+                             'poison: the "before" is the exact tree the PR merges '
+                             'into, so drift is always imputable to the diff. '
+                             'Requires --name-status')
     args = parser.parse_args(argv)
 
     try:
@@ -485,6 +542,9 @@ def main(argv=None):
 
     if args.baseline is not None and not (args.diff or args.update_baseline):
         parser.error('--baseline requires --diff or --update-baseline')
+    if args.reference_base and not args.name_status:
+        parser.error('--reference-base requires --name-status (the reference is '
+                     'scoped to the notebooks the diff changed)')
     drift = args.diff or args.update_baseline
 
     if drift:
@@ -532,18 +592,35 @@ def main(argv=None):
                       'was scanned, this is NOT an all-clear.', file=sys.stderr)
                 return 1
             counts = compute_counts(args.paths)
-        try:
-            baseline = load_baseline(baseline_path)
-        except (OSError, ValueError, json.JSONDecodeError) as e:
-            print(f'ERROR: unreadable baseline {baseline_path}: {e}',
-                  file=sys.stderr)
-            return 1
+        if args.reference_base:
+            # Reference = the exact tree this PR merges into, re-scanned
+            # (#13315): the stored baseline can predate a rebase, and drift
+            # measured against it is not imputable to THIS diff.
+            try:
+                ref_items = materialize_reference_base(
+                    args.reference_base, ipynb_heads, renames)
+            except OSError as e:
+                print(f'ERROR: unreadable reference base '
+                      f'{args.reference_base}: {e}', file=sys.stderr)
+                return 1
+            baseline = reference_counts_from(ref_items)
+            print(f'reference: merge base {args.reference_base} re-scanned '
+                  f'({len(ref_items)} of {len(ipynb_heads)} changed '
+                  f'notebook(s) existed at base; others are additions; '
+                  f'{len(baseline)} had findings at base)')
+        else:
+            try:
+                baseline = load_baseline(baseline_path)
+            except (OSError, ValueError, json.JSONDecodeError) as e:
+                print(f'ERROR: unreadable baseline {baseline_path}: {e}',
+                      file=sys.stderr)
+                return 1
+            # Baseline used as the reference "before this PR": date it so the
+            # report cannot be read as a live state (#12735).
+            print(f'baseline: {baseline_path} '
+                  f'(generated {baseline_generated_at(baseline_path) or "unknown"})')
         regressions, improvements, stable = diff_against_baseline(
             counts, baseline, renames=renames, only=only_set)
-        # Baseline used as the reference "before this PR": date it so the report
-        # cannot be read as a live state (#12735).
-        print(f'baseline: {baseline_path} '
-              f'(generated {baseline_generated_at(baseline_path) or "unknown"})')
         for e in regressions:
             print(f'  +{e["net"]}  {e["path"]}')
             for kind, delta in e['kinds']:

--- a/scripts/notebook_tools/tests/test_scan_md_hierarchy_drift.py
+++ b/scripts/notebook_tools/tests/test_scan_md_hierarchy_drift.py
@@ -313,3 +313,156 @@ def test_baseline_date_in_report(tmp_path, capsys):
     _diff(root, bl)
     out = capsys.readouterr().out
     assert "generated 2026-08-24T00:00:00Z" in out
+
+
+# --- 7. #13315 : reference = base de fusion re-scannee (--reference-base) ------
+#
+# Defaut #13315 : la reference "avant la PR" etait la BASELINE STOCKEE, re-seedee
+# sur main a chaque regle scanner. Une PR basee sur un main ancien (stale base)
+# comparait ses notebooks a une baseline qui a bouge SOUS elle -> drift non
+# imputable au diff, voire +1 fantome. Le fix : re-scanner les versions de la
+# BASE DE FUSION (git show SHA:path) comme reference, cles explicites (ancien
+# chemin pour un renommage).
+
+def _fake_materializer(items_spec):
+    """Remplace la couche git : items_spec = [(key, cellules de la version base)]."""
+    def fake(base_sha, heads, renames, repo_root=None):
+        out = []
+        for key, cells in items_spec:
+            dest = None
+            # un fichier SANS version a la base (Added) n'a pas d'entree
+            if cells is not None:
+                import tempfile
+                dest = Path(tempfile.mkdtemp()) / "base.ipynb"
+                dest.write_text(json.dumps(_nb(cells), ensure_ascii=False),
+                                encoding="utf-8")
+                out.append((key, dest))
+        return out
+    return fake
+
+
+def test_reference_base_kills_stale_baseline_phantom(tmp_path, capsys, monkeypatch):
+    """Criterium 1 : la PR ne change PAS le compte, mais la baseline stockee est
+    stale (pas d'entree pour ce notebook). Vs baseline stockee : +1 fantome.
+    Vs base de fusion re-scannee : delta 0, rc 0."""
+    root = _corpus(tmp_path)
+    _mutate(root, "touched.ipynb", FLAGGED_CELLS)  # 1 HINT a la base ET au head
+    # baseline stockee POISONNEE : aucune entree pour touched.ipynb
+    bl = tmp_path / "poison_baseline.json"
+    smh.write_baseline(bl, {})  # corpus vide -> rien
+    ns = _ns(tmp_path, f"M\t{_key(root, 'touched.ipynb')}")
+    # ancien comportement (sans --reference-base) : +1 fantome
+    assert smh.main([str(root), "--baseline", str(bl), "--diff",
+                     "--name-status", ns]) == 2
+    # nouveau : la reference est la version de touched.ipynb A LA BASE
+    monkeypatch.setattr(smh, "materialize_reference_base",
+                        _fake_materializer([(_key(root, "touched.ipynb"),
+                                             FLAGGED_CELLS)]))
+    assert smh.main([str(root), "--baseline", str(bl), "--diff",
+                     "--name-status", ns, "--reference-base", "deadbeef"]) == 0
+    out = capsys.readouterr().out
+    assert "drift: +0" in out
+
+
+def test_reference_base_flags_real_regression(tmp_path, capsys, monkeypatch):
+    """Controle positif : la PR EMPIRE reellement un notebook vs sa version de
+    base -> rc 2, notebook nomme (le garde ne devient pas permissif)."""
+    root = _corpus(tmp_path)
+    _mutate(root, "touched.ipynb", WORSE)  # 4 findings au head
+    ns = _ns(tmp_path, f"M\t{_key(root, 'touched.ipynb')}")
+    monkeypatch.setattr(smh, "materialize_reference_base",
+                        _fake_materializer([(_key(root, "touched.ipynb"),
+                                             FLAGGED_CELLS)]))  # 2 a la base
+    assert smh.main([str(root), "--diff", "--name-status", ns,
+                     "--reference-base", "deadbeef"]) == 2
+    out = capsys.readouterr().out
+    assert "touched.ipynb" in out
+    assert "+2" in out
+
+
+def test_reference_base_added_notebook_finding_is_regression(tmp_path, capsys, monkeypatch):
+    """Fichier AJOUTE par la PR (pas de version a la base) : tout finding est
+    nouveau -> imputation correcte (rc 2), pas un faux zero."""
+    root = _corpus(tmp_path)
+    _mutate(root, "added.ipynb", FLAGGED_CELLS)
+    ns = _ns(tmp_path, f"A\t{_key(root, 'added.ipynb')}")
+    monkeypatch.setattr(smh, "materialize_reference_base",
+                        _fake_materializer([(_key(root, "added.ipynb"), None)]))
+    assert smh.main([str(root), "--diff", "--name-status", ns,
+                     "--reference-base", "deadbeef"]) == 2
+    out = capsys.readouterr().out
+    assert "added.ipynb" in out
+
+
+def test_reference_base_rename_no_phantom(tmp_path, capsys, monkeypatch):
+    """Criterium 3 : R100 old->new, meme contenu. La version de base est lue ET
+    clee a l'ANCIEN chemin -> resolution par renames -> delta 0, pas de +1."""
+    root = _corpus(tmp_path)
+    _mutate(root, "new.ipynb", ["# Titre", "# Indice"])  # 1 HINT (au head)
+    old_key, new_key = _key(root, "old.ipynb"), _key(root, "new.ipynb")
+    ns = _ns(tmp_path, f"R100\t{old_key}\t{new_key}")
+    monkeypatch.setattr(smh, "materialize_reference_base",
+                        _fake_materializer([(old_key, ["# Titre", "# Indice"])]))
+    assert smh.main([str(root), "--diff", "--name-status", ns,
+                     "--reference-base", "deadbeef"]) == 0
+    out = capsys.readouterr().out
+    assert "drift: +0" in out
+    assert "+1" not in out
+
+
+def test_reference_report_names_base_sha(tmp_path, capsys, monkeypatch):
+    """Criterium 5 : le rapport NOMME la reference (base de fusion re-scannee),
+    comme la baseline stockee est datee (#12735) -- sinon le verdict se lit
+    comme un etat live."""
+    root = _corpus(tmp_path)
+    _mutate(root, "touched.ipynb", CLEAN_CELLS)
+    ns = _ns(tmp_path, f"M\t{_key(root, 'touched.ipynb')}")
+    monkeypatch.setattr(smh, "materialize_reference_base",
+                        _fake_materializer([(_key(root, "touched.ipynb"),
+                                             CLEAN_CELLS)]))
+    assert smh.main([str(root), "--diff", "--name-status", ns,
+                     "--reference-base", "abc123def456"]) == 0
+    out = capsys.readouterr().out
+    assert "reference: merge base abc123def456 re-scanned" in out
+
+
+def test_reference_base_requires_name_status(tmp_path):
+    """--reference-base sans --name-status : refus explicite (la reference est
+    scopee au diff), pas un whole-corpus silencieux."""
+    root = _corpus(tmp_path)
+    with pytest.raises(SystemExit):
+        smh.main([str(root), "--diff", "--reference-base", "deadbeef"])
+
+
+def test_materialize_reference_base_real_git(tmp_path):
+    """Couche git end-to-end : mini-repo, base commit avec old.ipynb (1 HINT).
+    Le materialiseur lit le blob a l'ANCIEN chemin et le CLE a l'ancien chemin ;
+    un fichier absent a la base (added) n'a pas d'entree."""
+    import subprocess
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    def _git(*a):
+        subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                        "-C", str(repo), *a], check=True, capture_output=True)
+    try:
+        _git("init", "-q")
+    except Exception:
+        pytest.skip("git indisponible")
+    (repo / "old.ipynb").write_text(
+        json.dumps(_nb(["# Titre", "# Indice"]), ensure_ascii=False),
+        encoding="utf-8")
+    _git("add", "-A")
+    _git("commit", "-q", "-m", "base")
+    base_sha = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True, text=True).stdout.strip()
+    items = smh.materialize_reference_base(
+        base_sha, {"new.ipynb", "added.ipynb"},
+        {"new.ipynb": "old.ipynb"}, repo_root=repo)
+    keys = [k for k, _ in items]
+    assert keys == ["old.ipynb"]  # added.ipynb : pas de version a la base
+    counts = smh.reference_counts_from(items)
+    # ["# Titre", "# Indice"] = 1 HINT + (H1-DEEP, MULTI-H1) selon les regles ;
+    # l'assertion cle : le blob de l'ANCIEN chemin, clee a l'ancien chemin.
+    assert "old.ipynb" in counts
+    assert counts["old.ipynb"]["HINT-AS-HEADING"] == 1


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: DEEP/notebook-python #13328

## Perimetre

3 fichiers : `.github/workflows/scan-md-hierarchy-drift.yml`, `scripts/notebook_tools/scan_md_hierarchy.py`, `scripts/notebook_tools/tests/test_scan_md_hierarchy_drift.py`

## Defaut (#13315)

Le guard `scan-md-hierarchy-drift` comparait les notebooks touches par la PR a la **baseline stockee** (`md_hierarchy_baseline.json`), re-seedee sur `main` a chaque changement de regle scanner. Une PR basee sur un `main` ancien (stale base) comparait donc son apport a un snapshot qui a bouge SOUS elle :

- drift **non imputable au diff** (la baseline avait evolue entre la base de la PR et maintenant) ;
- **+1 fantome** possible : un notebook dont le compte est IDENTIQUE a sa version de base, mais dont l'entree baseline est absente/stale, flagge comme regression ;
- le commentaire CI disait « Cette PR augmente le compte » **inconditionnellement**, meme en mode fallback dispatch ou l'imputation stricte n'a pas lieu d'etre ;
- le verdict ne nommait **ni la reference, ni sa date** quand le mode reference-base etait en jeu (contrairement a la baseline stockee, datee depuis #12735).

## Fix

1. **Scanner `--reference-base SHA`** : la reference « avant cette PR » devient la **base de fusion re-scannee**. Chaque notebook change (cote head) voit sa version a la base materialisee (`git show SHA:path`) puis re-scannee, avec **cles explicites** — l'ancien chemin pour un renommage (`R100 old new`), resolu par le mecanisme `renames` existant. Tout chemin absent a la base (Added) n'a pas d'entree : tous ses findings sont nouveaux (attribution correcte). Couche pure (`reference_counts_from`) separee de la couche git (`materialize_reference_base`) pour la testabilite.
2. **Workflow** : `--reference-base "$BASE_SHA"` quand la base existe ; phrase du commentaire **conditionnelle** (scope : « imputables au diff » / fallback : « derive du corpus, pas d'imputation stricte ») ; message de succes nommant le perimetre ; la ligne de rapport du scanner nomme la base de fusion re-scannee + combien de notebooks changes existaient a la base (extension du dating #12735).

## Critères d'acceptance (#13315)

- [x] **1. Imputation perimetre-diff.** Le drift est mesure contre la **version de base des notebooks du diff**, jamais contre un snapshot stocke qui aurait bouge. Test : `test_reference_base_kills_stale_baseline_phantom` (baseline poisonnee sans entree : ancien mode = +2 fantome rc 2 ; nouveau = +0 rc 0).
- [x] **2. Verdict parlant.** Succes = « No drift imputable au diff de la PR (reference = base de fusion <sha> re-scannee) » ; regression = commentaire nommant la base de fusion re-scannee. Test : `test_reference_report_names_base_sha`.
- [x] **3. Renommage A->B ne compte pas +1.** Le blob de base est lu ET cle a l'ANCIEN chemin, resolu par `renames` -> delta 0. Tests : `test_reference_base_rename_no_phantom` (compose) + `test_materialize_reference_base_real_git` (mini-repo git reel, R100 end-to-end).
- [x] **4. Phrase « Cette PR augmente le compte » conditionnelle.** Restreinte au mode scope (rc 2 avec BASE_SHA) ; le mode fallback (dispatch, sans base de fusion) dit « derive du corpus, pas d'imputation stricte ».
- [x] **5. Reference nommee et datee.** Rapport scanner : `reference: merge base <sha> re-scanned (n of m changed notebook(s) existed at base; ...)` ; baseline stockee conserve son dating #12735 en fallback.

## Validation

- `pytest scripts/notebook_tools/tests/test_scan_md_hierarchy_drift.py` : **26 passed** (19 existants + 7 nouveaux) ; freres (`test_scan_md_hierarchy.py`, `test_scan_md_hierarchy_list_item.py`) : **46 passed** — aucun changement de comportement hors reference-base.
- **Replay sur la tete reelle de #13004** (`M 2_PromptEngineering.ipynb`, base `72beb0c`) avec le nouveau scanner : `reference: merge base 72beb0c... re-scanned (1 of 1 existed at base; 0 had findings at base)` -> `+0 across 0`, **rc 0** — meme verdict que le replay pre-fix, mais desormais fonde sur la base de fusion elle-meme, pas sur la baseline stockee.
- **Controle positif end-to-end** : copie de la tete degradee (`- # Astuce de debug` ajoutee) -> `+1 HEADING-IN-LIST`, notebook nomme, **rc 2** (le garde ne devient pas permissif).
- Comportement conservé : `--update-baseline` (whole-corpus, jamais PR-scope), mode whole-corpus sans `--name-status`, messages d'erreur existants (`unreadable baseline`).

Closes #13315


