### PR TITLE
feat(lean,#11703): Lean-16j compagnon natif Hashlife/conway_lean — EXEC OK 15/15, modules noirs visitables in-kernel

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16j-Conway-Hashlife-Correctness-Native.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16j-Conway-Hashlife-Correctness-Native.ipynb
@@ -1165,7 +1165,7 @@
    "id": "4bc47952",
    "metadata": {},
    "source": [
-    "**Interprétation.** `hashlife_correct_margin` est le **théorème de correction de Hashlife sous hypothèse de marge** : si le support tient dans la marge, alors la fenêtre centrale prédite par l'algorithme coïncide avec l'évolution réelle. Les trois certificats `cexBlock1_supportInMargin_k*` montrent sur un bloc concret que l'hypothèse se vérifie pour des marges croissantes — la décenabilité (`Decidable`) de `supportInMargin` rend cette vérification mécanique."
+    "**Interprétation.** `hashlife_correct_margin` est le **théorème de correction de Hashlife sous hypothèse de marge** : si le support tient dans la marge, alors la fenêtre centrale prédite par l'algorithme coïncide avec l'évolution réelle. Les trois certificats `cexBlock1_supportInMargin_k*` montrent sur un bloc concret que l'hypothèse se vérifie pour des marges croissantes — la décenabilité (`Decidable`) de `supportInMargin` rend cette vérification mécanique. En l'état actuel du lake, la preuve de ce théorème repose encore sur un `sorry` résiduel — dette tracée par les `#print axioms` plus bas (epic #11703), pas cachée ; l'énoncé reste le contrat."
    ]
   },
   {
@@ -2086,7 +2086,7 @@
    "id": "59ed836a",
    "metadata": {},
    "source": [
-    "**Interprétation.** Les sorties `#print axioms` ne doivent faire apparaître que les axiomes standard de Lean (`propext`, `Classical.choice`, `Quot.sound`) — jamais `sorryAx`. La preuve de correction Hashlife est ainsi **transparente** : ce que le notebook affiche est exactement ce que le noyau a vérifié."
+    "**Interprétation.** Trois des quatre théorèmes sont axiomatiquement propres : `novelty_bound_of_period`, `lightCone_subset_of_le` et `chebDist_triangle` ne dépendent que des axiomes standard de Lean (`propext`, `Classical.choice`, `Quot.sound`). L'exception est visible dans la sortie ci-dessus : `hashlife_correct_margin`, le théorème-phare, dépend encore de `sorryAx` — le `sorry` résiduel du lake est **tracé comme une dette, pas caché** (epic #11703). Ce que le notebook affiche est exactement ce que le noyau a vérifié : la transparence est dans l'affichage honnête des axiomes, y compris lorsqu'ils révèlent une dette ouverte."
    ]
   },
   {
@@ -2561,7 +2561,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Sur le kernel Lean natif, ce compagnon a : (1) **exécuté** la machinerie de la preuve de correction Hashlife du lake `conway_lean` — cône de lumière, quadtree, murs, marge ; (2) **vérifié** la transparence axiomatique des théorèmes clés ; (3) croisé la discipline du lake sur ses modules satellite — batterie adverse, borne de nouveauté, lemmes FRACTRAN. Le lake reste la source de vérité ; ce notebook en est le banc d'essai exécutable, cellule par cellule."
+    "Sur le kernel Lean natif, ce compagnon a : (1) **exécuté** la machinerie de la preuve de correction Hashlife du lake `conway_lean` — cône de lumière, quadtree, murs, marge ; (2) **vérifié** les axiomes de chaque théorème clé — trois propres, `hashlife_correct_margin` encore sur `sorryAx` (dette tracée, epic #11703) ; (3) croisé la discipline du lake sur ses modules satellite — batterie adverse, borne de nouveauté, lemmes FRACTRAN. Le lake reste la source de vérité ; ce notebook en est le banc d'essai exécutable, cellule par cellule."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -153,7 +153,7 @@ Tous les notebooks incluent une **barre de navigation** en haut et en bas permet
 | 28 | [Lean-28-Munkres-Tribute](Lean-28-Munkres-Tribute.ipynb) | Hommage à James R. Munkres (1930-2026), le cours 18.901 dans Mathlib en kernel **natif** `lean4-wsl`, exécuté sur le lake `mathlib_examples` (environnement d'exécution Mathlib, cf. [`mathlib_examples/`](mathlib_examples/)) : les cinq chapitres du manuel *Topology* — axiomes (`IsOpen`), adhérence/intérieur (`nhds`, dualités §17 ex. 6), continuité (`continuous_def` = Munkres §18.1), T2/compacité, connexité — chaque notion interrogée par `#check`/`example`/`#print axioms` (0 axiome), 3 exercices `sorry` | 30 min |
 | 29 | [Lean-29-EdgeColoring-Tutte-Companion](Lean-29-EdgeColoring-Tutte-Companion.ipynb) | Compagnon **natif** (kernel `lean4-wsl`) du notebook [App-22](../../Search/Applications/CSP/App-22-EdgeColoring-Tutte.ipynb) (théorème apex arXiv 2608.22870, #13031) : définitions `IsCubic`/`Edge3Colorable`/`IsApexRelativeTo` posées sur `SimpleGraph` (absentes de Mathlib, vérifié), Petersen = Kneser KG(5,2) via `SimpleGraph.mk'` — 10 sommets, 15 arêtes, cubique prouvés par `decide`, backtracking `#eval` qui certifie l'absence de toute 3-coloration d'arêtes (`0`) avec contrôle positif K4 (`6`), ancrage `SimpleGraph.tutte` | 35 min |
 
-**Durée totale** : ~29h35min
+**Durée totale** : ~32h45min
 
 ## Acquis d'apprentissage
 


### PR DESCRIPTION
Grain: DEEP/notebook-lean — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #13079

## Lean-16j — compagnon natif des modules de correction Hashlife de `conway_lean`

See #11703 (contribution à l'epic visibilité : les modules noirs du lake deviennent visitables par leurs énoncés dans un kernel Lean réel).

### Le livrable

`Lean-16j-Conway-Hashlife-Correctness-Native.ipynb` — 43 cellules, kernel `lean4-wsl`. À la différence de Lean-16d (qui redéfinit le GoL in-notebook), 16j **importe** les modules du lake et les interroge in-kernel :

- **Cône de lumière** (`Conway.Life` / `ConeGeometry`) : `chebDist`, `chebDist_self/comm/triangle`, `lightCone_subset_of_le`, `lightCone_translate`, `isAlive_true_iff_mem`, `mem_lightCone_of_chebDist_le`
- **MacroCell** : `level`, `size`, `deadLeaf`, `emptyOfLevel`, `isEmpty`, `toCellsAux`
- **Les 4 murs** (`HashlifeCorrectness/Walls/{NE,NW,SW,SE}`) : `p4_*_membership_arm` + `#print axioms`
- **Théorème de marge** (`HashlifeMarginFragment`) : `supportInMargin`, `hashlife_correct_margin`, certificats `cexBlock1_supportInMargin_k0/k1/k2`
- **GridCanonical** : `lexLe` (+ `_total/_trans/_antisymm`), `Canonical`
- **Batterie adverse** (`AdversarialBattery` + `G2`) : témoins `cex*`, `central_window_j0_*`
- **DecideProbe** : `eater1_still_life_sanity`
- **Novelty** : `novelty_bound_of_period`, `nodesBound`, `depth`
- **FractranLemmas**, transparence axiomatique (`#print axioms` sur les théorèmes clés), 3 exercices (pattern 16d : corps trivial + `#eval` contre attendu).

### Validation (H.1/H.4, C.1/C.2)

- **Exécution réelle** : nbclient direct (NotebookClient, kernel `lean4-wsl`, cwd sur le lake, timeout 7200 s) — papermill 2.7 est mort rc=0 silencieusement 2× en pleine cellule d'import (cause racine non élucidée), nbclient est l'outil prouvé. Log final : `EXEC OK FULL` — 15/15 cellules code exécutées, **0 marqueur d'erreur lean** (scan ❌ des outputs display_data).
- Toutes cellules code : `execution_count` = 1..15 séquentiel CLEAN + outputs réels + **0 fuite de chemin machine** (scan `C:\`, `/mnt/c`, username : 0 hit).
- **Diagnostic de l'exécution** : run v3 (imports seuls en cellule 2) exécutait 15/15 mais 13 cellules en `Unknown identifier` — les imports chargeaient (slots env assignés) mais le notebook cite les symboles **nus** alors qu'ils vivent sous `Conway.Life` / `Conway.Life.MacroCell` / `Conway` (Fractran). Fix : 3 `open` dans la cellule d'imports ; v4 = 0 erreur.
- Valeurs de sortie vérifiées contre la prose AVANT exécution ET confirmées par le run : `chebDist (0,0) (3,4)` → **4**, `chebDist (2,-1) (-5,0)` → **7**, `size (emptyOfLevel 3)` → **8**, `nodesBound 2` → **21**.
- 0 pattern interdit (`raise NotImplementedError` / `assert False` / `1/0`) : grep 0 hit
- Imports en 1ʳᵉ cellule (contrainte kernel), miroir FS natif WSL
- Interprétations recalées sur les outputs réels (ex. `chebDist (0,0) (3,4)` → `4`, `size (emptyOfLevel 3)` → `8`, `nodesBound 2` → `21`, vérifiés contre les définitions du lake AVANT exécution)

### README série Lean — audit fichier entier (rule E)

- Ligne 16j (inventaire + arbre + maturité + mode « Avec hommages » ~18h05 → ~20h10)
- **Dérive préexistante corrigée** : `16h`, `16i`, `21b`, `25`, `28` absents des tables (notebooks présents sur main) — lignes ajoutées aux 3 tables ; réconciliation mécanique disque ↔ README : **48/48 liés, 0 fantôme** ; « Durée totale » ~29h → ~32h45min (somme mécanique de la colonne Durée sur l'arbre final, **1965 min** — l'audit initial avait mesuré 2110 min, corrigé à la résolution du conflit merge : main a ajouté Lean-29 +35 min entre-temps, somme re-dérivée de zéro, commit 430bf41b312)
- Signalement séparé (hors scope PR) : la 1ʳᵉ cellule de `Lean-16i` titre « Lean-16b » au lieu de « Lean-16i » (typo copy-paste, cellule markdown) → issue **#13255**

### Contexte build (règle F — réparer l'env)

Les murs `Walls/{SE,SW,NE}` culminent à ~7-9 GB RSS chacun et étaient tués en OOM **silencieux** sous le plafond WSL défaut (7,6 GB) — diagnostic par `dmesg` croisé avec les timestamps du log. Fix : `C:\Users\Jesse\.wslconfig` (`memory=10GB / swap=24GB`) + rebuild séquentiel par tiers (`lean -o` nu, `ELAN_TOOLCHAIN=v4.32.1` en env, LEAN_PATH sur lt_pkgs + OUT du lake).

### Sorry-count

Non applicable (notebook compagnon, aucun `*.lean` modifié — `count_code_sorry.py` inchangé par construction).
