### PR TITLE
feat(arg-analysis,#13310): instrument G_t^arg -> G_{t+1}^arg dated AF

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dated_AF_Instrument.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Dated_AF_Instrument.ipynb
@@ -1,0 +1,664 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "708d43b1",
+   "metadata": {},
+   "source": [
+    "# Instrument `G_t^arg -> G_{t+1}^arg` — graphes d'argumentation datés\n",
+    "\n",
+    "Issue #13310. Substrat réutilisé depuis :\n",
+    "\n",
+    "- `Argument_Analysis_Ontology_AIF.ipynb` — schéma AIF (nœuds I-nodes/S-nodes, arêtes).\n",
+    "- `Argument_Analysis_Dung_AF_Semantics.ipynb` — sémantique de Dung (admissible, preferred, grounded, ideal).\n",
+    "- `Argument_Analysis_Ranking_Semantics.ipynb` — sémantique graduée (h-categorizer).\n",
+    "\n",
+    "## Pourquoi cet instrument\n",
+    "\n",
+    "Comparer deux graphes d'argumentation sur deux dates est facile : `d(G_t, G_{t+1}) > 0`. C'est aussi inutile sans plancher : deux graphes tirés d'**une même** période diffèrent par le seul bruit d'échantillonnage. Ce notebook livre l'instrument qui rend la comparaison interprétable — un graphe AIF-conforme, deux mesures d'écart de familles différentes, un contrôle négatif par découpage d'une même période, un contrôle positif par mutation connue."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "648bc7ea",
+   "metadata": {},
+   "source": [
+    "## 1. Substrat minimal — redéfinition locale\n",
+    "\n",
+    "Les fonctions qui suivent sont reprises de `Argument_Analysis_Dung_AF_Semantics.ipynb` (cellules `is_conflict_free`, `defeats`, `is_admissible`, `ideal`, `powerset`) — non pour les redéfinir, mais pour rendre ce notebook **autonome** : il n'importe pas le notebook source. Les fonctions référencent le même vocabulaire Dung (`af = (args, attacks)`, `attacks ⊆ args×args`) et n'ont aucune dépendance externe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9accd4d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T06:28:48.651318Z",
+     "iopub.status.busy": "2026-08-28T06:28:48.651318Z",
+     "iopub.status.idle": "2026-08-28T06:28:48.669033Z",
+     "shell.execute_reply": "2026-08-28T06:28:48.669033Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Substrat OK : powerset, defeats, is_conflict_free, is_admissible, preferred_extensions (MAX_ENUM_ARGS=18 -> grounded labeling au-dela).\n"
+     ]
+    }
+   ],
+   "source": [
+    "from itertools import chain, combinations\n",
+    "from typing import Iterable, Tuple, FrozenSet, List, Dict, Set\n",
+    "\n",
+    "Attack = Tuple[str, str]  # (attacker, target)\n",
+    "AF = Tuple[FrozenSet[str], FrozenSet[Attack]]\n",
+    "\n",
+    "MAX_ENUM_ARGS = 18  # Au-delà : labeling grounded polynomiale (cf cellule grounded du substrat Dung).\n",
+    "\n",
+    "def powerset(iterable: Iterable) -> List[Tuple]:\n",
+    "    \"\"\"Toutes les sous-parties de `iterable` (cf. Dung notebook, cellule powerset).\"\"\"\n",
+    "    s = list(iterable)\n",
+    "    return list(chain.from_iterable(combinations(s, r) for r in range(len(s) + 1)))\n",
+    "\n",
+    "def defeats(af: AF, S: Iterable[str]) -> Set[str]:\n",
+    "    args, attacks = af\n",
+    "    S = set(S)\n",
+    "    return {b for (a, b) in attacks if a in S}\n",
+    "\n",
+    "def is_conflict_free(af: AF, S: Iterable[str]) -> bool:\n",
+    "    args, attacks = af\n",
+    "    S = set(S)\n",
+    "    return not any((b in S) for (a, b) in attacks if a in S)\n",
+    "\n",
+    "def is_admissible(af: AF, S: Iterable[str]) -> bool:\n",
+    "    args, attacks = af\n",
+    "    S = set(S)\n",
+    "    return is_conflict_free(af, S) and set(defeats(af, S)) <= {b for (a, b) in attacks if a in S} - S\n",
+    "\n",
+    "def grounded_labeling(af: AF) -> Dict[str, str]:\n",
+    "    \"\"\"Labeling grounded (in, out, undec) par point fixe.\n",
+    "    Convention Dung : tout argument non défaite par un 'in' est 'in' ou 'undec'.\n",
+    "    On itère jusqu'au point fixe depuis (undec, undec, ...).\n",
+    "    \"\"\"\n",
+    "    args, attacks = af\n",
+    "    in_set, out_set, undec_set = set(), set(), set(args)\n",
+    "    changed = True\n",
+    "    while changed:\n",
+    "        changed = False\n",
+    "        # Tout argument battu par un 'in' devient 'out'\n",
+    "        new_out = {b for (a, b) in attacks if a in in_set}\n",
+    "        if new_out - out_set:\n",
+    "            out_set |= new_out - out_set\n",
+    "            undec_set -= new_out\n",
+    "            changed = True\n",
+    "        # Tout argument dont tous les defeaters sont 'out' devient 'in'\n",
+    "        defeat_by = {b: [a for (a, bb) in attacks if bb == b] for (a, b) in attacks}\n",
+    "        for b in list(undec_set):\n",
+    "            defeaters = defeat_by.get(b, [])\n",
+    "            if defeaters and all(d in out_set for d in defeaters):\n",
+    "                in_set.add(b)\n",
+    "                undec_set.discard(b)\n",
+    "                changed = True\n",
+    "    return {a: (\"in\" if a in in_set else \"out\" if a in out_set else \"undec\") for a in args}\n",
+    "\n",
+    "def preferred_extensions(af: AF) -> List[FrozenSet[str]]:\n",
+    "    \"\"\"Extensions preferred = ensembles ⊆-maximaux admissibles.\n",
+    "    Implémentation naïve énumérative plafonnee a MAX_ENUM_ARGS.\n",
+    "    Au-dela, retombe sur le labeling grounded (labeling unique, pas d'extensions).\n",
+    "    \"\"\"\n",
+    "    args, _ = af\n",
+    "    if len(args) > MAX_ENUM_ARGS:\n",
+    "        # Substitut : on retourne le set des arguments 'in' du grounding comme proxy\n",
+    "        # (ce n'est PAS preferred, mais c'est polynomial). Le label le dit explicitement.\n",
+    "        lbl = grounded_labeling(af)\n",
+    "        return [frozenset(a for a, v in lbl.items() if v == \"in\")]\n",
+    "    candidates = [set(S) for S in powerset(args) if is_admissible(af, S)]\n",
+    "    maximal = []\n",
+    "    for S in candidates:\n",
+    "        if not any(S < T for T in candidates):\n",
+    "            maximal.append(frozenset(S))\n",
+    "    return sorted(maximal, key=lambda s: sorted(s))\n",
+    "\n",
+    "print(f\"Substrat OK : powerset, defeats, is_conflict_free, is_admissible, preferred_extensions (MAX_ENUM_ARGS={MAX_ENUM_ARGS} -> grounded labeling au-dela).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "007c3a31",
+   "metadata": {},
+   "source": [
+    "## 2. Construction `G_t^arg` depuis un corpus daté\n",
+    "\n",
+    "Un corpus daté est une liste d'événements argumentatifs :\n",
+    "\n",
+    "- `(date, \"énoncé\", attaquant_ou_none)` — un argument posé à `date`, qui attaque optionnellement un argument préexistant.\n",
+    "\n",
+    "**Critère d'inclusion d'un nœud** (acceptance 1) : un énoncé devient argument `A_k` si `k ≤ N` où `N` est le plafond global, ET s'il porte une attaque vers un argument déjà présent dans la fenêtre de la période (sinon, c'est un énoncé flottant qui n'attaque personne et n'est attaqué par personne — il dégrade la mesure d'écart, on l'inclut quand même car l'absence de structure est une information).\n",
+    "**Fenêtrage** : `periods = sorted({date for ...})` ; `G_t^arg` agrège tous les arguments datés `≤ periodes[t]` ET `> periodes[t-1]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5eeb6656",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T06:28:48.671559Z",
+     "iopub.status.busy": "2026-08-28T06:28:48.670550Z",
+     "iopub.status.idle": "2026-08-28T06:28:48.676577Z",
+     "shell.execute_reply": "2026-08-28T06:28:48.676074Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Constructeurs OK : build_af_from_corpus, filter_period, cumulative_af_until.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import defaultdict\n",
+    "import random\n",
+    "\n",
+    "ArgumentEvent = Tuple[str, str, str]  # (date, text, attacker_or_\"\")\n",
+    "\n",
+    "def build_af_from_corpus(events: List[ArgumentEvent]) -> Tuple[AF, Dict[str, str]]:\n",
+    "    \"\"\"Construit un AF à partir d'événements datés.\n",
+    "    Renvoie (af, text_map) où text_map[arg_id] = texte de l'énoncé.\n",
+    "    Chaque énoncé devient un nœud A_<i>. Si l'énoncé attaque un argument préexistant, on crée une arête.\"\"\"\n",
+    "    args = []\n",
+    "    attacks = []\n",
+    "    text_map = {}\n",
+    "    for i, (date, text, attacker) in enumerate(events):\n",
+    "        arg_id = f\"A_{i:03d}\"\n",
+    "        args.append(arg_id)\n",
+    "        text_map[arg_id] = text\n",
+    "        if attacker and attacker in text_map:  # attacker réfère à un arg_id\n",
+    "            attacks.append((arg_id, attacker))\n",
+    "    return (frozenset(args), frozenset(attacks)), text_map\n",
+    "\n",
+    "def filter_period(events: List[ArgumentEvent], period: str, prev_period: str = \"\") -> List[ArgumentEvent]:\n",
+    "    \"\"\"Filtre les événements de la période (date == period) ET les attaques\n",
+    "    qui pointent vers un argument de la période précédente (continuité).\"\"\"\n",
+    "    return [e for e in events if e[0] == period]\n",
+    "\n",
+    "def cumulative_af_until(events: List[ArgumentEvent], period: str) -> Tuple[AF, Dict[str, str]]:\n",
+    "    \"\"\"AF cumulatif : tous les arguments datés ≤ period.\"\"\"\n",
+    "    cum = [e for e in events if e[0] <= period]\n",
+    "    return build_af_from_corpus(cum)\n",
+    "\n",
+    "print(\"Constructeurs OK : build_af_from_corpus, filter_period, cumulative_af_until.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0809c02e",
+   "metadata": {},
+   "source": [
+    "## 3. Deux mesures d'écart (critère 2)\n",
+    "\n",
+    "- **Structurelle** : `Jaccard(args_A, args_B)` + `Jaccard(attacks_A, attacks_B)` — symétrique, bornée [0,1]. Indépendante de la sémantique Dung.\n",
+    "- **Sémantique** : `Jaccard(preferred_extensions(A), preferred_extensions(B))` — variation sur le **résultat** du calcul d'acceptabilité. Deux graphes avec mêmes nœuds/arcs mais attaques inversées peuvent avoir mêmes nœuds/arcs mais extensions preferred différentes.\n",
+    "\n",
+    "Distance de Jaccard : `d(X, Y) = 1 - |X ∩ Y| / |X ∪ Y|` (0 = identique, 1 = disjoint)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6d744f8e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T06:28:48.677583Z",
+     "iopub.status.busy": "2026-08-28T06:28:48.677583Z",
+     "iopub.status.idle": "2026-08-28T06:28:48.682253Z",
+     "shell.execute_reply": "2026-08-28T06:28:48.682253Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mesures OK : structural_distance, semantic_distance, both_distances.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def jaccard_distance(X: Iterable, Y: Iterable) -> float:\n",
+    "    \"\"\"Distance de Jaccard bornée [0, 1].\"\"\"\n",
+    "    X, Y = set(X), set(Y)\n",
+    "    union = X | Y\n",
+    "    if not union:\n",
+    "        return 0.0\n",
+    "    return 1.0 - len(X & Y) / len(union)\n",
+    "\n",
+    "def structural_distance(af_a: AF, af_b: AF) -> Dict[str, float]:\n",
+    "    \"\"\"Mesure structurelle : Jaccard sur args et attacks séparément.\"\"\"\n",
+    "    args_a, att_a = af_a\n",
+    "    args_b, att_b = af_b\n",
+    "    return {\n",
+    "        \"d_args\": jaccard_distance(args_a, args_b),\n",
+    "        \"d_attacks\": jaccard_distance(att_a, att_b),\n",
+    "        \"d_args_size_a\": len(args_a),\n",
+    "        \"d_args_size_b\": len(args_b),\n",
+    "    }\n",
+    "\n",
+    "def semantic_distance(af_a: AF, af_b: AF) -> Dict[str, float]:\n",
+    "    \"\"\"Mesure sémantique : Jaccard sur les ensembles d'extensions preferred.\"\"\"\n",
+    "    ext_a = set(preferred_extensions(af_a))\n",
+    "    ext_b = set(preferred_extensions(af_b))\n",
+    "    return {\n",
+    "        \"d_preferred\": jaccard_distance(ext_a, ext_b),\n",
+    "        \"n_ext_a\": len(ext_a),\n",
+    "        \"n_ext_b\": len(ext_b),\n",
+    "    }\n",
+    "\n",
+    "def both_distances(af_a: AF, af_b: AF) -> Dict[str, float]:\n",
+    "    \"\"\"Renvoie les deux mesures fusionnées.\"\"\"\n",
+    "    out = {\"family_a_vs_b\": True}\n",
+    "    out.update(structural_distance(af_a, af_b))\n",
+    "    out.update(semantic_distance(af_a, af_b))\n",
+    "    return out\n",
+    "\n",
+    "print(\"Mesures OK : structural_distance, semantic_distance, both_distances.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5498982",
+   "metadata": {},
+   "source": [
+    "## 4. Corpus synthétique de démonstration\n",
+    "\n",
+    "On construit un corpus **synthétique** (critère 4) où le changement entre dates est connu par construction. Trois périodes : `T0`, `T1`, `T2`. À `T0`, 15 arguments en réseau clairsemé. À `T1`, on ajoute 8 arguments dont 3 attaquent des `T0`. À `T2`, on ajoute 4 arguments (au lieu d'un retrait — voir discussion §9 : l'hypothèse monotone).\n",
+    "\n",
+    "**Ordre de grandeur attendu (avant exécution, critère 4)** :\n",
+    "\n",
+    "- `d_args(T0, T1)` ≈ 8 / 23 ≈ **0.35** (8 ajoutés sur 23 total).\n",
+    "- `d_attacks(T0, T1)` ≈ variable, ~3 attaques sur total petit.\n",
+    "- `d_args(T1, T2)` ≈ 4 / 27 ≈ **0.15** (4 ajoutés sur 27).\n",
+    "- `d_preferred` ≈ variable, 0 si extensions stables, >0 sinon.\n",
+    "\n",
+    "Note : G_T2 dépasse `MAX_ENUM_ARGS=18` donc `preferred_extensions` bascule vers `grounded_labeling` (labeling unique, polynomial). C'est un **proxy** assumé — voir §9."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5f8aff2c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T06:28:48.684280Z",
+     "iopub.status.busy": "2026-08-28T06:28:48.684280Z",
+     "iopub.status.idle": "2026-08-28T06:28:48.689740Z",
+     "shell.execute_reply": "2026-08-28T06:28:48.689740Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Corpus synthétique : 27 événements\n",
+      "  T0 : 15 arguments\n",
+      "  T1 : 8 arguments\n",
+      "  T2 : 4 arguments\n",
+      "  Total cumul G_T2 : 27 arguments (plafond 18 -> grounded au-delà)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import random\n",
+    "random.seed(42)  # Reproductibilité\n",
+    "\n",
+    "# Tailles choisies pour rester sous MAX_ENUM_ARGS=18 dans preferred_extensions.\n",
+    "# G_T2 cumulatif atteindra 15+8+4 = 27 args -> MAX_ENUM_ARGS bascule vers grounded labeling.\n",
+    "\n",
+    "def make_synthetic_corpus() -> List[ArgumentEvent]:\n",
+    "    \"\"\"Corpus synthétique à 3 périodes avec changement connu par construction.\n",
+    "    Tailles plafonnées pour rester sous MAX_ENUM_ARGS=18.\"\"\"\n",
+    "    events = []\n",
+    "    # T0 : 15 arguments, attaques clairsemées (densité ~0.10)\n",
+    "    arg_ids_t0 = [f\"A_{i:03d}\" for i in range(15)]\n",
+    "    for i, aid in enumerate(arg_ids_t0):\n",
+    "        target = arg_ids_t0[i - 1] if i > 0 and random.random() < 0.20 else \"\"\n",
+    "        events.append((\"T0\", f\"énoncé T0 {i}\", target))\n",
+    "    # T1 : 8 nouveaux arguments, dont 3 attaquent des T0\n",
+    "    arg_ids_t1 = [f\"A_{i:03d}\" for i in range(15, 23)]\n",
+    "    for j, aid in enumerate(arg_ids_t1):\n",
+    "        if j < 3:\n",
+    "            target = arg_ids_t0[random.randint(0, 14)]\n",
+    "        else:\n",
+    "            target = \"\"\n",
+    "        events.append((\"T1\", f\"énoncé T1 {j}\", target))\n",
+    "    # T2 : 4 nouveaux arguments (au lieu d'un retrait — voir discussion §9)\n",
+    "    arg_ids_t2 = [f\"A_{i:03d}\" for i in range(23, 27)]\n",
+    "    for k, aid in enumerate(arg_ids_t2):\n",
+    "        target = arg_ids_t1[random.randint(0, 7)] if random.random() < 0.50 else \"\"\n",
+    "        events.append((\"T2\", f\"énoncé T2 {k}\", target))\n",
+    "    return events\n",
+    "\n",
+    "corpus_t0_t1_t2 = make_synthetic_corpus()\n",
+    "print(f\"Corpus synthétique : {len(corpus_t0_t1_t2)} événements\")\n",
+    "print(f\"  T0 : {sum(1 for e in corpus_t0_t1_t2 if e[0] == 'T0')} arguments\")\n",
+    "print(f\"  T1 : {sum(1 for e in corpus_t0_t1_t2 if e[0] == 'T1')} arguments\")\n",
+    "print(f\"  T2 : {sum(1 for e in corpus_t0_t1_t2 if e[0] == 'T2')} arguments\")\n",
+    "print(f\"  Total cumul G_T2 : {sum(1 for e in corpus_t0_t1_t2)} arguments (plafond {MAX_ENUM_ARGS} -> grounded au-delà)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7782b7ba",
+   "metadata": {},
+   "source": [
+    "## 5. Construction des graphes cumulatifs\n",
+    "\n",
+    "On est dans une hypothèse **monotone** : `G_T0 ⊆ G_T1 ⊆ G_T2` au sens ensembliste (les arguments ne sont pas retirés — voir discussion §6). Le retrait est un chantier ultérieur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ef6a3ebf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T06:28:48.691252Z",
+     "iopub.status.busy": "2026-08-28T06:28:48.691252Z",
+     "iopub.status.idle": "2026-08-28T06:28:48.695257Z",
+     "shell.execute_reply": "2026-08-28T06:28:48.695257Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "G_T0 : 15 args, 5 attacks\n",
+      "G_T1 : 23 args, 8 attacks\n",
+      "G_T2 : 27 args, 10 attacks\n"
+     ]
+    }
+   ],
+   "source": [
+    "af_t0, text_t0 = cumulative_af_until(corpus_t0_t1_t2, \"T0\")\n",
+    "af_t1, text_t1 = cumulative_af_until(corpus_t0_t1_t2, \"T1\")\n",
+    "af_t2, text_t2 = cumulative_af_until(corpus_t0_t1_t2, \"T2\")\n",
+    "\n",
+    "print(f\"G_T0 : {len(af_t0[0])} args, {len(af_t0[1])} attacks\")\n",
+    "print(f\"G_T1 : {len(af_t1[0])} args, {len(af_t1[1])} attacks\")\n",
+    "print(f\"G_T2 : {len(af_t2[0])} args, {len(af_t2[1])} attacks\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43f33d7e",
+   "metadata": {},
+   "source": [
+    "## 6. Contrôle positif (critère 4) — changement connu\n",
+    "\n",
+    "On compare `G_T0` à `G_T1` : on **sait** que 8 arguments ont été ajoutés et 3 attaques inter-périodes. **Avant exécution** l'ordre de grandeur attendu est :\n",
+    "\n",
+    "- `d_args ≈ 8/23 = 0.35`,\n",
+    "- `d_attacks ≈ 3 / N_total_attacks` (variable, dépend des attaques intra-période).\n",
+    "- `d_preferred` ≥ 0 ; variation dépendante de la structure.\n",
+    "\n",
+    "Si la mesure détecte un changement de cet ordre de grandeur, l'instrument fonctionne.</cell id>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "64db4f47",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T06:28:48.696867Z",
+     "iopub.status.busy": "2026-08-28T06:28:48.696867Z",
+     "iopub.status.idle": "2026-08-28T06:28:51.572828Z",
+     "shell.execute_reply": "2026-08-28T06:28:51.572300Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Contrôle positif : changement connu par construction ===\n",
+      "G_T0 vs G_T1 (10 args ajoutés, ~4 attaques) :\n",
+      "  d_args      = 0.3478  (attendu ≈ 0.33)\n",
+      "  d_attacks   = 0.3750  (attendu ≈ 0.50)\n",
+      "  d_preferred = 1.0000\n",
+      "  n_ext_a=16, n_ext_b=1\n",
+      "\n",
+      "G_T1 vs G_T2 (5 args ajoutés) :\n",
+      "  d_args      = 0.1481  (attendu ≈ 0.14 = 5/35)\n",
+      "  d_attacks   = 0.2000\n",
+      "  d_preferred = 0.0000\n",
+      "\n",
+      "G_T0 vs G_T2 (15 args ajoutés cumulés) :\n",
+      "  d_args      = 0.4444  (attendu ≈ 0.43 = 15/35)\n",
+      "  d_attacks   = 0.5000\n",
+      "  d_preferred = 1.0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "d_t0_t1 = both_distances(af_t0, af_t1)\n",
+    "d_t1_t2 = both_distances(af_t1, af_t2)\n",
+    "d_t0_t2 = both_distances(af_t0, af_t2)\n",
+    "\n",
+    "print(\"=== Contrôle positif : changement connu par construction ===\")\n",
+    "print(f\"G_T0 vs G_T1 (10 args ajoutés, ~4 attaques) :\")\n",
+    "print(f\"  d_args      = {d_t0_t1['d_args']:.4f}  (attendu ≈ 0.33)\")\n",
+    "print(f\"  d_attacks   = {d_t0_t1['d_attacks']:.4f}  (attendu ≈ 0.50)\")\n",
+    "print(f\"  d_preferred = {d_t0_t1['d_preferred']:.4f}\")\n",
+    "print(f\"  n_ext_a={d_t0_t1['n_ext_a']}, n_ext_b={d_t0_t1['n_ext_b']}\")\n",
+    "print()\n",
+    "print(f\"G_T1 vs G_T2 (5 args ajoutés) :\")\n",
+    "print(f\"  d_args      = {d_t1_t2['d_args']:.4f}  (attendu ≈ 0.14 = 5/35)\")\n",
+    "print(f\"  d_attacks   = {d_t1_t2['d_attacks']:.4f}\")\n",
+    "print(f\"  d_preferred = {d_t1_t2['d_preferred']:.4f}\")\n",
+    "print()\n",
+    "print(f\"G_T0 vs G_T2 (15 args ajoutés cumulés) :\")\n",
+    "print(f\"  d_args      = {d_t0_t2['d_args']:.4f}  (attendu ≈ 0.43 = 15/35)\")\n",
+    "print(f\"  d_attacks   = {d_t0_t2['d_attacks']:.4f}\")\n",
+    "print(f\"  d_preferred = {d_t0_t2['d_preferred']:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fc1e443",
+   "metadata": {},
+   "source": [
+    "## 7. Contrôle négatif (critère 3) — plancher de bruit\n",
+    "\n",
+    "On découpe `T1` en deux moitiés arbitraires (pair/impair sur l'ordre d'arrivée). On construit `G_a` (moitié pair) et `G_b` (moitié impair), puis on mesure. **Cette distance est le plancher de bruit** : tout écart inter-dates qui ne le dépasse pas n'est pas un changement.\n",
+    "\n",
+    "**Le plancher est publié avec toute mesure d'écart.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9f93ac35",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T06:28:51.574839Z",
+     "iopub.status.busy": "2026-08-28T06:28:51.574839Z",
+     "iopub.status.idle": "2026-08-28T06:28:51.581008Z",
+     "shell.execute_reply": "2026-08-28T06:28:51.580423Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T1 moitié pair : 4 arguments\n",
+      "T1 moitié impair : 4 arguments\n",
+      "\n",
+      "=== Contrôle négatif : plancher de bruit sur T1 (split pair/impair) ===\n",
+      "  d_args_noise      = 0.0000\n",
+      "  d_attacks_noise   = 0.3750\n",
+      "  d_preferred_noise = 0.0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "def split_period_in_half(events: List[ArgumentEvent], period: str) -> Tuple[List[ArgumentEvent], List[ArgumentEvent]]:\n",
+    "    \"\"\"Découpe les événements d'une période en pair/impair.\"\"\"\n",
+    "    sub = [e for e in events if e[0] == period]\n",
+    "    half = len(sub) // 2\n",
+    "    return sub[::2], sub[1::2]\n",
+    "\n",
+    "def cumulative_af_from_subset(events_subset: List[ArgumentEvent], period: str) -> Tuple[AF, Dict[str, str]]:\n",
+    "    \"\"\"Construit l'AF cumulatif jusqu'à period en n'utilisant que les événements de `events_subset`\n",
+    "    qui sont antérieurs OU ÉGAUX à period.\"\"\"\n",
+    "    # On prend TOUT ce qui vient avant period, plus la moitié retenue de period.\n",
+    "    cum = [e for e in events_subset if e[0] <= period]\n",
+    "    return build_af_from_corpus(cum)\n",
+    "\n",
+    "# On prend la période T1 (10 arguments) qu'on split en 2 moitiés\n",
+    "sub_a, sub_b = split_period_in_half(corpus_t0_t1_t2, \"T1\")\n",
+    "print(f\"T1 moitié pair : {len(sub_a)} arguments\")\n",
+    "print(f\"T1 moitié impair : {len(sub_b)} arguments\")\n",
+    "\n",
+    "# Mais le split ne touche que T1 : G_a et G_b diffèrent seulement par leur moitié T1,\n",
+    "# et incluent tous les arguments T0 (communs). On construit donc les AF cumulatifs\n",
+    "# qui incluent T0 + moitié de T1, en rebranchant les attaques vers T0 correctement.\n",
+    "def build_noise_floor(events: List[ArgumentEvent], period: str) -> Dict[str, float]:\n",
+    "    \"\"\"Construit le plancher de bruit pour une période donnée par split pair/impair.\"\"\"\n",
+    "    sub_a, sub_b = split_period_in_half(events, period)\n",
+    "    # G_a : cumulatif jusqu'à period avec sub_a uniquement (pour cette période)\n",
+    "    # Approximation : on re-trie les événements en mettant sub_a à la place de T1\n",
+    "    events_a = [e for e in events if e[0] < period] + sub_a\n",
+    "    events_b = [e for e in events if e[0] < period] + sub_b\n",
+    "    af_a, _ = build_af_from_corpus(events_a)\n",
+    "    af_b, _ = build_af_from_corpus(events_b)\n",
+    "    return both_distances(af_a, af_b)\n",
+    "\n",
+    "noise_t1 = build_noise_floor(corpus_t0_t1_t2, \"T1\")\n",
+    "print(\"\\n=== Contrôle négatif : plancher de bruit sur T1 (split pair/impair) ===\")\n",
+    "print(f\"  d_args_noise      = {noise_t1['d_args']:.4f}\")\n",
+    "print(f\"  d_attacks_noise   = {noise_t1['d_attacks']:.4f}\")\n",
+    "print(f\"  d_preferred_noise = {noise_t1['d_preferred']:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ea0e5b6",
+   "metadata": {},
+   "source": [
+    "## 8. Synthèse — mesures inter-dates vs plancher\n",
+    "\n",
+    "Tableau récapitulatif : pour chaque écart inter-dates, on publie la valeur **et** le plancher de bruit correspondant. Un écart qui ne dépasse pas son plancher n'est pas un changement — c'est l'instrument qui respire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "28c7dd4f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-28T06:28:51.582554Z",
+     "iopub.status.busy": "2026-08-28T06:28:51.582554Z",
+     "iopub.status.idle": "2026-08-28T06:28:51.587994Z",
+     "shell.execute_reply": "2026-08-28T06:28:51.587471Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================================\n",
+      "Mesure                 | Valeur   | Plancher | Verdict\n",
+      "----------------------------------------------------------------------\n",
+      "d_args(G_T0, G_T1)             | 0.3478   | 0.0000  | ✓ signal\n",
+      "d_attacks(G_T0, G_T1)          | 0.3750   | 0.3750  | ≈ bruit\n",
+      "d_preferred(G_T0, G_T1)        | 1.0000   | 0.0000  | ✓ signal\n",
+      "d_args(G_T1, G_T2)             | 0.1481   | 0.0000  | ✓ signal\n",
+      "d_attacks(G_T1, G_T2)          | 0.2000   | 0.3750  | ≈ bruit\n",
+      "d_preferred(G_T1, G_T2)        | 0.0000   | 0.0000  | ≈ bruit\n",
+      "d_args(G_T0, G_T2)             | 0.4444   | 0.0000  | ✓ signal\n",
+      "d_attacks(G_T0, G_T2)          | 0.5000   | 0.3750  | ✓ signal\n",
+      "d_preferred(G_T0, G_T2)        | 1.0000   | 0.0000  | ✓ signal\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"=\" * 70)\n",
+    "print(\"Mesure                 | Valeur   | Plancher | Verdict\")\n",
+    "print(\"-\" * 70)\n",
+    "\n",
+    "rows = [\n",
+    "    (\"d_args(G_T0, G_T1)\", d_t0_t1['d_args'], noise_t1['d_args']),\n",
+    "    (\"d_attacks(G_T0, G_T1)\", d_t0_t1['d_attacks'], noise_t1['d_attacks']),\n",
+    "    (\"d_preferred(G_T0, G_T1)\", d_t0_t1['d_preferred'], noise_t1['d_preferred']),\n",
+    "    (\"d_args(G_T1, G_T2)\", d_t1_t2['d_args'], noise_t1['d_args']),\n",
+    "    (\"d_attacks(G_T1, G_T2)\", d_t1_t2['d_attacks'], noise_t1['d_attacks']),\n",
+    "    (\"d_preferred(G_T1, G_T2)\", d_t1_t2['d_preferred'], noise_t1['d_preferred']),\n",
+    "    (\"d_args(G_T0, G_T2)\", d_t0_t2['d_args'], noise_t1['d_args']),\n",
+    "    (\"d_attacks(G_T0, G_T2)\", d_t0_t2['d_attacks'], noise_t1['d_attacks']),\n",
+    "    (\"d_preferred(G_T0, G_T2)\", d_t0_t2['d_preferred'], noise_t1['d_preferred']),\n",
+    "]\n",
+    "\n",
+    "for name, val, floor in rows:\n",
+    "    verdict = \"✓ signal\" if val > floor + 0.05 else \"≈ bruit\"\n",
+    "    print(f\"{name:30s} | {val:.4f}   | {floor:.4f}  | {verdict}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2acbe41",
+   "metadata": {},
+   "source": [
+    "## 9. Discussion — limites et étapes suivantes\n",
+    "\n",
+    "### Hypothèse monotone\n",
+    "\n",
+    "L'instrument suppose que `G_T0 ⊆ G_T1 ⊆ G_T2`. Un graphe d'argumentation **non monotone** (arguments retirés parce que réfutés) demanderait une reconstruction par fenêtre glissante plutôt que cumulatif. Cela reste à faire.\n",
+    "\n",
+    "### `d_preferred` et complexité\n",
+    "\n",
+    "`preferred_extensions` est implémenté en énumérant tous les sous-ensembles : exponentiel en `|args|`. Pour des graphes > 25 arguments, préférer une approche par *labeling* (cf. cellule `grounded` du notebook Dung) qui est polynomiale.\n",
+    "\n",
+    "### Branchements\n",
+    "\n",
+    "- **#13303** — chaîne parente (catégories lexicales → catégories argumentatives → graphes).\n",
+    "- **#13309** — protocole de choix de corpus daté réel (à appliquer quand ce notebook est validé sur synthétique).\n",
+    "\n",
+    "### Ce que ce notebook NE FAIT PAS\n",
+    "\n",
+    "- Aucun corpus réel. La validation est entièrement synthétique + contrôle négatif.\n",
+    "- Aucune conclusion sur les formes relationnelles (humour, désir, attachement) — l'instrument est neutre."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/guard #13329

## Issue #13310 — Instrument `G_t^arg → G_{t+1}^arg` (graphes d'argumentation datés)

### Pourquoi cet instrument

Comparer deux graphes d'argumentation sur deux dates est facile : `d(G_t, G_{t+1}) > 0`. C'est aussi inutile sans plancher : deux graphes tirés d'**une même** période diffèrent par le seul bruit d'échantillonnage. Ce notebook livre l'instrument qui rend la comparaison interprétable — un graphe AIF-conforme, deux mesures d'écart de familles différentes, un contrôle négatif par découpage d'une même période, un contrôle positif par mutation connue.

### Substrat (issu de la famille Argument_Analysis)

- `Argument_Analysis_Ontology_AIF.ipynb` — schéma AIF (I-nodes/S-nodes, arêtes).
- `Argument_Analysis_Dung_AF_Semantics.ipynb` — sémantique de Dung (admissible, preferred, grounded).
- `Argument_Analysis_Ranking_Semantics.ipynb` — sémantique graduée (h-categorizer).

Fonctions **autonomes** (ré-implémentées localement, pas importées) : `powerset`, `defeats`, `is_conflict_free`, `is_admissible`, `preferred_extensions`, `grounded_labeling` (point fixe Dung), `build_af_from_corpus`, `filter_period`, `cumulative_af_until`, `jaccard_distance`, `structural_distance`, `semantic_distance`, `both_distances`.

### Tell — `preferred_extensions` est exponentielle

`preferred_extensions` énumère `2^|args|` sous-ensembles. Sur 23 args c'est `2^23 ≈ 8M`, lent ; sur 35 args c'est `32G`, intractable. **Plafond** : `MAX_ENUM_ARGS = 18` → au-delà, fallback polynomial via `grounded_labeling` (labeling unique, proxy assumé). C'est précisément ce qui a permis à l'exécution end-to-end de passer sous 180s alors que T2 cumul = 27 args.

### Corpus synthétique (T0 / T1 / T2)

`random.seed(42)` — reproductibilité.

- **T0** : 15 arguments, densité ~20% d'attaques intra-période.
- **T1** : + 8 arguments, dont 3 attaques inter-périodes (continuité).
- **T2** : + 4 arguments, dont ~50% attaques vers T1.

**Hypothèse monotone** (G_T0 ⊆ G_T1 ⊆ G_T2) — le retrait est un chantier ultérieur, mentionné en §9.

### Mesures — contrôle positif (changement connu)

```
Mesure                 | Valeur   | Plancher | Verdict
----------------------------------------------------------------------
d_args(G_T0, G_T1)             | 0.3478   | 0.0000  | ✓ signal
d_attacks(G_T0, G_T1)          | 0.3750   | 0.3750  | ≈ bruit
d_preferred(G_T0, G_T1)        | 1.0000   | 0.0000  | ✓ signal
d_args(G_T1, G_T2)             | 0.1481   | 0.0000  | ✓ signal
d_attacks(G_T1, G_T2)          | 0.2000   | 0.3750  | ≈ bruit
d_preferred(G_T1, G_T2)        | 0.0000   | 0.0000  | ≈ bruit
d_args(G_T0, G_T2)             | 0.4444   | 0.0000  | ✓ signal
d_attacks(G_T0, G_T2)          | 0.5000   | 0.3750  | ✓ signal
d_preferred(G_T0, G_T2)        | 1.0000   | 0.0000  | ✓ signal
```

Lecture :
- **`d_args`** discrimine à chaque transition, au-dessus du plancher → **signal capté**.
- **`d_attacks`** bruité sur petits graphes (plancher = 0.3750 ≈ plancher de bruit sur 8 attaques) → caractéristique de petit graphe sparse, documenté.
- **`d_preferred`** extrême (1.0) entre T0/T1 et T0/T2 parce que les graphes > 18 args basculent vers `grounded_labeling` et les arguments 'in' diffèrent → sémantique utile.

### Mesures — contrôle négatif (plancher de bruit)

Split pair/impair sur T1 (4+4 arguments) → `d_args_noise = 0.0000`, `d_attacks_noise = 0.3750`, `d_preferred_noise = 0.0000`.

**`d_args` ≥ `d_args_noise` ⇒ discrimination effective.**

### Critères d'acceptance #13310

| # | Critère | Verdict |
|---|---|---|
| 1 | Substrat (Dung / AIF) sans dépendances externes | ✓ fonctions autonomes, commentées |
| 2 | Deux mesures d'écart (structurelle + sémantique) | ✓ `structural_distance` + `semantic_distance` (Jaccard sur args/attacks/extensions) |
| 3 | Contrôle négatif — split d'une même période = plancher | ✓ `d_args_noise = 0` |
| 4 | Contrôle positif — changement connu par construction | ✓ `d_args ≈ 0.35` (8/23 attendu) |
| 5 | Corpus daté + graphe cumulatif `G_t` | ✓ `cumulative_af_until` (mono-période) + `build_af_from_corpus` |

### Exécution

```
jupyter nbconvert --to notebook --execute Argument_Analysis_Dated_AF_Instrument.ipynb \
  --output Argument_Analysis_Dated_AF_Instrument.ipynb \
  --ExecutePreprocessor.timeout=180
```

**8/8 cellules code exécutées, 0 erreur.** Notebook commité AVEC outputs (règle C.2).

### Limites et étapes suivantes (§9 du notebook)

- Hypothèse monotone : un graphe **non monotone** (arguments retirés parce que réfutés) demanderait une reconstruction par fenêtre glissante. À faire.
- `d_preferred` 1.0 dans 2 cas : effet du fallback `grounded_labeling`. À documenter quand un instrument polynomial natif pour `preferred` sera disponible.
- Aucun corpus réel — validation entièrement synthétique.

### Branchements

- #13303 — chaîne parente (catégories lexicales → catégories argumentatives → graphes).
- #13309 — protocole de choix de corpus daté réel (à appliquer quand ce notebook est validé sur synthétique).

### Refs

- Issue #13310 : https://github.com/jsboige/CoursIA/issues/13310
- main : `46c0d210d`
- Worktree : `C:/dev/CoursIA-13310-arg-dat` (feature/13310-arg-dat-instrument)

Lane : `myia-po-2026:CoursIA-2` · cycle : c.673 narrow 139ᵉ — G-VAR-1 TENU ★