### PR TITLE
fix(tooling,#13336): lane-claim guard queried dead gh field — every PR-state lookup failed, v2 silently inert

### DIFF
--- a/.github/workflows/lane-claim-guard.yml
+++ b/.github/workflows/lane-claim-guard.yml
@@ -64,6 +64,7 @@ jobs:
             scripts/ci/lane_claim_required.py
             scripts/check_lane_claim.py
             scripts/grain_tag.py
+            scripts/tests/test_check_lane_claim.py
       - name: 'Resolve closing-ref vs other lanes active claims (block on collision)'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,6 +165,24 @@ jobs:
           )" 2>/dev/null || true
 
           exit 1
+
+      # #13336 : controle positif LIVE du contrat de schema gh. Le guard ci-dessus
+      # depend de `gh pr view --json state,mergedAt` ; quand gh retire/deplace un
+      # champ, TOUT lookup echoue et le gate degenerate silencieusement (v2 -> v1,
+      # chaque [DELIVERED] relache son claim -- duplication mesuree sur #13216).
+      # Un self-test qui ne tourne jamais ne protege rien (#13331) : ce job a
+      # GH_TOKEN et tourne sur chaque PR, le controle vit donc ICI, pas dans
+      # scripts-tests.yml (push main, sans token). Le test ne tourne QUE ce
+      # controle (skipped hors CI sans LANE_CLAIM_LIVE, le reste de la suite
+      # reste hermetique).
+      - name: 'Live gh schema self-test (pr-state contract, #13336)'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LANE_CLAIM_LIVE: '1'
+        run: |
+          python3 -m pip install --quiet pytest
+          python3 -m pytest scripts/tests/test_check_lane_claim.py \
+            -k test_13336_live_control_real_pr -q
 
   # Advisory (#10223 Tache 4) : pose deux labels pour mesurer l'adoption du
   # protocole de claim SANS jamais bloquer. Nom portant "advisory" ->

--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -1044,9 +1044,37 @@ def _sort_events(payload: dict) -> list[ClaimEvent]:
 # failure -- an unreachable `gh` MUST NOT cause a `[DELIVERED]` to suddenly
 # start blocking. The failure is visible in `delivered_claims_failed` so an
 # operator can see which lookups were silently degraded.
+#
+# #13336 -- that fail-open is now scoped to TRANSIENT failures only. A gh
+# schema break (`Unknown JSON field`) is PERMANENT: while it lasts, every
+# lookup returns None and the v2 gate degenerates to v1 wholesale -- the
+# exact silence that let #13216 be written twice (both lanes passed their
+# guard, the signal was `null`). A permanent failure keeps the claim
+# BLOCKING (fail-CLOSED, the organ's default posture); a network/auth
+# hiccup keeps the documented fail-open.
 _PR_STATE_CACHE: dict[int, tuple[str | None, str | None]] = {}
 # value shape: (pr_state, error_message) where pr_state in
 # {"OPEN","MERGED","CLOSED",None} and error_message is None on success.
+
+# #13336 -- environmental failures (network, auth, gh binary absent) are
+# transient: retryable, orthogonal to the claim protocol, and the documented
+# fail-open applies. Everything else (schema break, non-JSON, unexpected
+# payload, PR not found) is permanent for the lifetime of the process.
+_TRANSIENT_ERROR_MARKERS = (
+    "timed out", "timeout", "could not resolve host", "connection",
+    "dial tcp", "temporary failure", "network", "rate limit",
+    "http 429", "http 5", "502", "503", "504",
+    "gh auth", "not logged in", "authentication required",
+    "gh exec failed",
+)
+
+
+def _is_transient_error(err: str | None) -> bool:
+    """#13336 -- True when a `_fetch_pr_state` error is environmental."""
+    if not err:
+        return False
+    e = err.lower()
+    return any(m in e for m in _TRANSIENT_ERROR_MARKERS)
 
 
 def _fetch_pr_state(pr_ref: int) -> tuple[str | None, str | None]:
@@ -1073,7 +1101,7 @@ def _fetch_pr_state(pr_ref: int) -> tuple[str | None, str | None]:
         proc = subprocess.run(
             [
                 "gh", "pr", "view", str(pr_ref),
-                "--json", "state,merged",
+                "--json", "state,mergedAt",
             ],
             capture_output=True, text=True, shell=False,
             encoding="utf-8", errors="replace",  # #12811
@@ -1092,14 +1120,15 @@ def _fetch_pr_state(pr_ref: int) -> tuple[str | None, str | None]:
         result = (None, f"gh pr view {pr_ref} non-JSON: {exc}")
         _PR_STATE_CACHE[pr_ref] = result
         return result
-    # GH field model: `state` in {OPEN, CLOSED, MERGED}, `merged` is a bool.
-    # When `state == "MERGED"`, the reducer should still treat the substance as
-    # locked -- the PR reached main. `merged=True` on its own is enough to lock
-    # even if `state` was raced (defence in depth: the bool was the canonical
-    # source until 2026).
-    if d.get("merged") is True:
-        result = ("MERGED", None)
-    elif d.get("state") == "MERGED":
+    # GH field model (#13336): `state` in {OPEN, CLOSED, MERGED}, `mergedAt`
+    # is an ISO timestamp (null until merged). The bool field `merged` was
+    # REMOVED from `gh pr view --json` (gh 2.83+): querying it exits 1 on the
+    # WHOLE request, which made every lookup fail and silently reverted the
+    # reducer to v1 (every [DELIVERED] released its claim, #13216 duplicated).
+    # When `state == "MERGED"`, the reducer treats the substance as locked --
+    # the PR reached main. A non-null `mergedAt` alone also locks, defence in
+    # depth against a raced `state`.
+    if d.get("mergedAt") is not None or d.get("state") == "MERGED":
         result = ("MERGED", None)
     elif d.get("state") == "CLOSED":
         result = ("CLOSED", None)
@@ -1146,8 +1175,9 @@ def _resolve_delivered_v2(
         return "close"  # legacy: a DELIVERED without a PR ref is a close
     if pr_states is not None:
         st = pr_states.get(pr_ref)
+        err = None
     else:
-        st, _err = _fetch_pr_state(pr_ref)
+        st, err = _fetch_pr_state(pr_ref)
     # Attach the resolved state to the event for the JSON summary. On a None
     # state (lookup failed) we still attach None so the consumer sees that we
     # TRIED -- the absence of the key would otherwise be indistinguishable from
@@ -1157,6 +1187,15 @@ def _resolve_delivered_v2(
         return "open"
     if st == "MERGED":
         return "open_locked"
+    if (st is None and pr_states is None
+            and err is not None and not _is_transient_error(err)):
+        # #13336 -- PERMANENT lookup failure (gh schema break, non-JSON
+        # payload, PR not found): fail-CLOSED. Releasing the claim here is
+        # what silently reverted v2 to v1 while the `merged` field was dead
+        # (#13216: the same 49 lines written twice, both guards CLEAR).
+        # The lane keeps its lock until a human or a working gh resolves it.
+        ev["pr_state_error"] = err
+        return "open"
     return "close"
 
 
@@ -2484,6 +2523,18 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             file=sys.stderr,
         )
 
+    # #13336 -- a DELIVERED whose PR state could not be resolved must be
+    # NAMED in the verdict, whatever the verdict. Before this, the JSON
+    # carried `delivered_claims_pr_states: {"N": null}` while the human line
+    # still said `CLEAR:` -- the second lane on #13216 read CLEAR and
+    # duplicated 49 lines that were already in an OPEN PR.
+    unresolved_delivered = [
+        (ev.get("lane") or "?", ev.get("pr_ref"), ev.get("pr_state_error"))
+        for ev in events
+        if ev.marker == "DELIVERED" and ev.get("pr_ref") is not None
+        and ev.get("pr_state") is None
+    ]
+
     # Human verdict after the JSON.
     if others:
         who = ", ".join(
@@ -2613,6 +2664,20 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
                 + "\n".join(lines),
                 file=sys.stderr,
             )
+        # #13336 -- fail-CLOSED witness: a lane blocked HERE because its
+        # DELIVERED could not be resolved (permanent gh/schema error) must
+        # see the CAUSE, not just the block. The exit code is unchanged (1
+        # is BLOCKED); the message explains why a visible [DELIVERED] did
+        # not release the lane.
+        for ln, pr, why in unresolved_delivered:
+            reason = f" ({why})" if why else ""
+            print(
+                f"WARN: le [DELIVERED] lane {ln} -- PR #{pr} n'a pas libere "
+                f"la voie : etat de PR NON RESOLU, echec non transitoire"
+                f"{reason}. Fail-CLOSED #13336 -- la lane garde son lock "
+                f"jusqu'a resolution (gh/schema) ou arbitrage coordinateur.",
+                file=sys.stderr,
+            )
         return 1
     # #12345 -- fail-CLOSED on an entirely-dead scope, EVEN with no
     # blockers. Without this branch, a caller who typo'd every glob in
@@ -2647,6 +2712,17 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
         parts.append(f"{len(stale_others)} stale claim(s) bypassed")
     note = f" ({'; '.join(parts)})" if parts else ""
     print(f"\nCLEAR: no other lane claims #{payload.get('number')}{note}.")
+    if unresolved_delivered:
+        # #13336 -- CLEAR is not an all-clear when a delivery's PR could not
+        # be resolved: the lane may still be holding an OPEN PR on this issue.
+        for ln, pr, why in unresolved_delivered:
+            reason = f" ({why})" if why else ""
+            print(
+                f"WARN: [DELIVERED] lane {ln} -- PR #{pr} non resolu{reason}: "
+                f"l'etat vivant de la PR n'a pas pu etre lu, verifiez-la "
+                f"avant de demarrer (#13336).",
+                file=sys.stderr,
+            )
     return 0
 
 

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -4580,6 +4580,15 @@ def test_delivered_close_drops_lane_from_active_claims(capsys):
     `state`. The summary shows `my_active_claim: false` for the
     delivering lane and `blocking_lanes: []` for any other lane that
     arrives after the close.
+
+    #13336 -- hermetic injection: this test ran WITHOUT `pr_states` and
+    passed only because the live lookup was dead (the `merged` field was
+    removed from gh; every fetch failed and v2 silently fell back to
+    `close`). Fixing the lookup made the REAL #12271 resolve OPEN ->
+    the delivering lane keeps its claim -> BLOCKED, flipping the
+    assertion machine-dependently (CI gh is authed, local dev may not
+    be). The legacy-close surface this test pins is now injected
+    explicitly: a CLOSED-without-merge PR.
     """
     p = payload(
         comment("[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: Lean-16g-*.ipynb",
@@ -4587,7 +4596,8 @@ def test_delivered_close_drops_lane_from_active_claims(capsys):
         comment("[DELIVERED] lane myia-po-2024:CoursIA-2 -- PR #12271 (substance shipped)",
                 "2026-08-22T04:14:00Z"),
     )
-    rc = clc._run_check(p, "myia-po-2025:CoursIA-2")
+    rc = clc._run_check(p, "myia-po-2025:CoursIA-2",
+                        pr_states=_pr_states(12271, "CLOSED"))
     assert rc == 0
     out = _json_out(capsys.readouterr())
     assert out["my_active_claim"] is False
@@ -4606,6 +4616,12 @@ def test_delivered_claims_in_json_summarises_history(capsys):
     PR state. The motivating use case is #12223: po-2024 reads CLEAR,
     the summary tells po-2024 "PR #12271 was delivered here, go check
     it before you start".
+
+    #13336 -- hermetic injection: same live-lookup disease as
+    test_delivered_close_drops_lane_from_active_claims -- the real
+    #12270/#12275 states decide the reduction machine-dependently. The
+    summary surface this test pins (delivered_claims list) is
+    state-independent, so pin both PRs CLOSED to keep it hermetic.
     """
     p = payload(
         comment("[CLAIMED] lane myia-po-2026:CoursIA-2 -- substance A",
@@ -4617,7 +4633,8 @@ def test_delivered_claims_in_json_summarises_history(capsys):
         comment("[DELIVERED] lane myia-po-2026:CoursIA-2 -- PR #12275",
                 "2026-08-22T05:00:00Z"),
     )
-    clc._run_check(p, "myia-po-2023:CoursIA-2")
+    clc._run_check(p, "myia-po-2023:CoursIA-2",
+                   pr_states={12270: "CLOSED", 12275: "CLOSED"})
     out = _json_out(capsys.readouterr())
     assert out["delivered_claims"] == [12270, 12275]
 

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -4636,6 +4636,15 @@ def test_delivered_does_not_block_subsequent_claim(capsys):
     the PR is MERGED) requires reading the PR state from `gh`, which
     is a side effect the reducer was deliberately built without.
     Coordinator sign-off gates the v2 release.
+
+    #13336 -- hermetic injection: this test ran WITHOUT `pr_states` and
+    passed only because the live lookup was dead (the `merged` field was
+    removed from gh; every fetch failed and v2 silently fell back to
+    `close`). Fixing the lookup made the REAL #12270 resolve MERGED ->
+    `open_locked` -> blocked, flipping the assertion machine-dependently.
+    The v1 surface this test pins is now injected explicitly: a
+    CLOSED-without-merge PR. The MERGED path has its own v2 test
+    (test_delivered_pr_merged_locks_lane).
     """
     p = payload(
         comment("[CLAIMED] lane myia-po-2026:CoursIA-2",
@@ -4643,7 +4652,8 @@ def test_delivered_does_not_block_subsequent_claim(capsys):
         comment("[DELIVERED] lane myia-po-2026:CoursIA-2 -- PR #12270",
                 "2026-08-22T02:00:00Z"),
     )
-    rc = clc._run_check(p, "myia-po-2023:CoursIA-2")
+    rc = clc._run_check(p, "myia-po-2023:CoursIA-2",
+                        pr_states=_pr_states(12270, "CLOSED"))
     assert rc == 0
     out = _json_out(capsys.readouterr())
     assert out["my_active_claim"] is False
@@ -4906,16 +4916,22 @@ def test_pr_states_signature_is_optional_no_behavioural_change(capsys):
     rc = clc._run_check(p, "myia-po-2023:CoursIA-2",
                        pr_states=None,
                        my_paths=["scripts/check_lane_claim.py"])
-    # Either CLEAR (legacy close when gh auth works) or NOT_SCOPED
-    # (when gh auth fails and we cannot introspect). Both are valid v1
-    # surfaces -- the test pins that v2 did not crash with a TypeError
-    # on the new kwarg.
-    assert rc in (0, 2)
+    # PR 99999 does not exist, so a live lookup FAILS. #13336 split the
+    # failure classes: on an authed machine the "not found" error is
+    # PERMANENT -> fail-CLOSED (rc 1, the claim stays blocking); in a
+    # sandbox without gh/network the error reads environmental -> legacy
+    # close (rc 0) or NOT_SCOPED (rc 2). All three are valid surfaces --
+    # the test pins that v2 accepted the None kwarg without TypeError and
+    # never crashed on the fetch path.
+    assert rc in (0, 1, 2)
     captured = capsys.readouterr()
     if rc == 0:
         out = _json_out(captured)
         # The forensic PR ref still surfaces.
         assert 99999 in out["delivered_claims"]
+    if rc == 1:
+        # fail-CLOSED (authed machine): the unresolved delivery is named.
+        assert "99999" in captured.err
     # On NOT_SCOPED the JSON output is replaced by the trailing
     # NOT_SCOPED banner; the kwarg was accepted without TypeError,
     # which is the only thing this test pins.
@@ -5664,3 +5680,148 @@ def test_gh_calls_pin_utf8_regression_12811(monkeypatch):
     assert issue_payload["title"].endswith(bad_char)
     prs = clc._gh_open_prs_with_files()
     assert prs[0]["title"].endswith(bad_char)
+
+
+# --- #13336 : gh a retire le champ `merged` -- le lookup mourait a chaque appel
+#
+# `_fetch_pr_state` interrogait `--json state,merged` ; gh 2.83+ refuse le champ
+# (`Unknown JSON field`), exit 1 sur la REQUETE entiere : (None, err) pour toute
+# PR. Le `None` tombait dans la branche `close` du reducteur -> TOUT [DELIVERED]
+# relachait son claim (v2 inerte, retour v1 silencieux). Duplication mesuree :
+# #13216 -- meme machine, deux lanes, 49 lignes ecrites deux fois (#13230 OPEN
+# vs #13242 MERGED) ; l'organe avait repondu CLEAR avec
+# `delivered_claims_pr_states: {"13230": null}`.
+
+import os as _os
+import subprocess as _subprocess  # noqa: F401  (monkeypatched via clc.subprocess)
+
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _fake_gh(monkeypatch, responses):
+    """Intercept clc.subprocess.run pour `gh pr view N --json ...`.
+
+    responses: {pr_number: _FakeProc}. Captured args are recorded on the
+    returned list for field-model assertions."""
+    calls = []
+
+    real_run = _subprocess.run
+
+    def fake_run(args, **kwargs):
+        if not (len(args) > 1 and args[0] == "gh"):
+            return real_run(args, **kwargs)  # git ls-files & co: pass-through
+        calls.append(list(args))
+        if args[1:3] == ["pr", "list"]:  # --paths collision probe
+            return _FakeProc(0, "[]", "")
+        pr = int(args[args.index("view") + 1])
+        return responses.get(pr, _FakeProc(1, "", "no pull requests found"))
+
+    monkeypatch.setattr(clc.subprocess, "run", fake_run)
+    monkeypatch.setattr(clc, "_PR_STATE_CACHE", {})
+    return calls
+
+
+def test_13336_fetch_queries_live_field_model(monkeypatch):
+    """Critere 1 : la requete interroge `state,mergedAt` (pas le `merged`
+    disparu), et `mergedAt` non-null verrouille meme si `state` est race."""
+    calls = _fake_gh(monkeypatch, {
+        13230: _FakeProc(0, '{"state":"OPEN","mergedAt":null}', ""),
+        13144: _FakeProc(0, '{"state":"OPEN","mergedAt":"2026-08-28T05:00:00Z"}', ""),
+        9977: _FakeProc(0, '{"state":"CLOSED","mergedAt":null}', ""),
+    })
+    assert clc._fetch_pr_state(13230) == ("OPEN", None)
+    assert clc._fetch_pr_state(13144) == ("MERGED", None)  # mergedAt seul verrouille
+    assert clc._fetch_pr_state(9977) == ("CLOSED", None)
+    fields = [c[c.index("--json") + 1] for c in calls]
+    assert all(f == "state,mergedAt" for f in fields)
+    assert "merged" not in fields  # le champ mort n'est plus interroge
+
+
+def test_13336_schema_break_blocks_delivered_claim(monkeypatch, capsys):
+    """Critere 3 : une erreur de schema (permanente) NE RELACHE PAS le claim.
+    Avant : le None tombait dans `close` -> CLEAR, la voie etait faussement
+    libre (mecanisme exact de la duplication #13216)."""
+    _fake_gh(monkeypatch, {
+        13230: _FakeProc(1, "", 'Unknown JSON field: "merged". Available fields:'),
+    })
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2024:CoursIA-2 -- decks S3",
+                "2026-08-28T01:00:00Z"),
+        comment("[DELIVERED] lane myia-po-2024:CoursIA-2 -- PR #13230",
+                "2026-08-28T02:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2024:CoursIA",
+                        pr_states=None,
+                        my_paths=["slides/**"])
+    assert rc == 1  # BLOCKED : la delivery non resolvable garde le lock
+    captured = capsys.readouterr()
+    out = _json_out(captured)
+    assert "myia-po-2024:CoursIA-2" in out["blocking_lanes"]
+    # Critere 4 (voix BLOCKED) : la CAUSE est nommee, pas seulement le bloc.
+    assert "WARN" in captured.err
+    assert "13230" in captured.err
+    assert "non transitoire" in captured.err
+
+
+def test_13336_transient_network_error_keeps_fail_open(monkeypatch, capsys):
+    """Miroir : une erreur RESEAU reste fail-open (posture documentee
+    #12386) -- mais le verdict porte le WARN (critere 4, voix CLEAR)."""
+    _fake_gh(monkeypatch, {
+        13230: _FakeProc(1, "", "dial tcp: could not resolve host"),
+    })
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2024:CoursIA-2 -- decks S3",
+                "2026-08-28T01:00:00Z"),
+        comment("[DELIVERED] lane myia-po-2024:CoursIA-2 -- PR #13230",
+                "2026-08-28T02:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2024:CoursIA",
+                        pr_states=None,
+                        my_paths=["slides/**"])
+    assert rc == 0  # fail-open preserve sur erreur transitoire
+    captured = capsys.readouterr()
+    out = _json_out(captured)
+    assert out["blocking_lanes"] == []
+    # ... mais PLUS silencieusement : le WARN nomme la PR non resolue.
+    assert "WARN" in captured.err
+    assert "13230" in captured.err
+
+
+def test_13336_replay_13216_open_pr_blocks_second_lane(capsys):
+    """Critere 5 (mecanisme, PR reelles) : tant que #13230 est OPEN, la lane
+    myia-po-2024:CoursIA-2 reste BLOQUANTE pour myia-po-2024:CoursIA -- c'est
+    exactement ce que l'organe cassat en repondant CLEAR le 28/08."""
+    p = payload(
+        comment("[CLAIMED] lane myia-po-2024:CoursIA-2 -- decks S3",
+                "2026-08-28T01:00:00Z"),
+        comment("[DELIVERED] lane myia-po-2024:CoursIA-2 -- PR #13230",
+                "2026-08-28T02:00:00Z"),
+    )
+    rc = clc._run_check(p, "myia-po-2024:CoursIA",
+                        pr_states=_pr_states(13230, "OPEN"),
+                        my_paths=["slides/**"])
+    assert rc == 1
+    out = _json_out(capsys.readouterr())
+    assert "myia-po-2024:CoursIA-2" in out["blocking_lanes"]
+
+
+def test_13336_live_control_real_pr():
+    """Critere 2 : controle positif END-TO-END (aucune injection) sur une PR
+    REELLE du depot -- rougit si gh change encore de schema. Ne tourne que
+    la ou le reseau et un token sont disponibles (le workflow
+    lane-claim-guard.yml pose LANE_CLAILM_LIVE=1 + GH_TOKEN) ; le skip local
+    reste possible (critere 4 de l'issue : `python -m pytest` hors CI passe).
+
+    PR epinglee : #13144, MERGEE le 2026-08-28 -- un etat fusionne est stable
+    a vie (une PR ouverte finit par merger, une fusionnee reste fusionnee)."""
+    if not (_os.environ.get("GH_TOKEN") and _os.environ.get("LANE_CLAIM_LIVE")):
+        import pytest
+        pytest.skip("live control: set GH_TOKEN + LANE_CLAIM_LIVE=1 (run by lane-claim-guard.yml)")
+    st, err = clc._fetch_pr_state(13144)
+    assert st == "MERGED", f"gh schema ou PR inattendus: state={st!r} err={err!r}"
+    assert err is None


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13337

## Défaut (#13336)

`check_lane_claim._fetch_pr_state` interrogait `gh pr view --json state,merged`. **gh 2.83+ a retiré le champ `merged`** : l'interroger fait échouer la REQUÊTE entière (exit 1, `Unknown JSON field`), donc `_fetch_pr_state` retournait `(None, err)` pour **toute PR**. Le `None` tombait dans la branche `close` de `_resolve_delivered_v2` : **chaque [DELIVERED] relâchait son claim — le protocole v2 était entièrement inert, un retour silencieux à v1**.

Vérifié firsthand (gh 2.90.0 local : `gh pr view 13230 --json merged` → `Unknown JSON field: "merged"`).

**Incident mesuré** : #13216 — même machine, deux lanes, les mêmes 49 lignes écrites deux fois (PR #13230 OPEN vs PR #13242 MERGED). Les DEUX lanes avaient passé leur garde ; l'organe avait répondu CLEAR avec `delivered_claims_pr_states: {"13230": null}` — le `null` était indistinguable d'un marqueur absent.

## Fix

1. **Requête `state,mergedAt`** — `mergedAt != null` verrouille MERGED même contre un `state` racé (défense en profondeur).
2. **Split des échecs de lookup** (`_is_transient_error`) : marqueurs transitoires (réseau, auth, `gh exec failed`) gardent le fail-open documenté ; une erreur **permanente** (casse de schéma, non-JSON, PR introuvable) est désormais **fail-CLOSED** — le claim reste bloquant tant que gh/schéma n'est pas résolu. Relâcher le claim sur une casse de schéma, c'est exactement la réversion silencieuse qui a produit #13216.
3. **WARN sur les DEUX sorties** : un [DELIVERED] avec état non résolu est nommé (PR# + cause) en BLOCKED **et** en CLEAR — plus de null silencieux.
4. **Self-test LIVE dans lane-claim-guard.yml** (le job required, le seul avec GH_TOKEN, tourne à chaque PR) : `test_13336_live_control_real_pr` épingle la PR réelle #13144 == MERGED. La prochaine suppression de champ par gh rougit ce job au lieu d'expédier un gate mort (#13331 : un self-test qui ne tourne jamais ne protège rien). `scripts-tests.yml` (push main, sans token) ne peut pas le porter.

## Critères d'acceptance (#13336)

- [x] **1.** `test_13336_fetch_queries_live_field_model` : la requête porte `state,mergedAt`, jamais le `merged` mort ; `mergedAt` non-null verrouille MERGED même si `state` dit OPEN.
- [x] **2.** `test_13336_live_control_real_pr` : contrôle positif END-TO-END sans injection sur PR réelle (#13144, mergée — stable à vie) ; skip propre hors CI (`GH_TOKEN` + `LANE_CLAIM_LIVE=1`), exécuté par le workflow.
- [x] **3.** `test_13336_schema_break_blocks_delivered_claim` : `Unknown JSON field` → rc=1, lane livreuse dans `blocking_lanes`, WARN nommant PR + « non transitoire ». Avant le fix : rc=0.
- [x] **4.** `test_13336_transient_network_error_keeps_fail_open` : `could not resolve host` → rc=0 (fail-open préservé) MAIS le WARN nomme la PR non résolue.
- [x] **5.** Replay du mécanisme réel : `test_13336_replay_13216_open_pr_blocks_second_lane` (PR #13230 injectée OPEN, vraies lanes) + **replay live** : `python scripts/check_lane_claim.py 13216 --lane myia-po-2024:CoursIA` → **BLOCKED rc=1**, `delivered_claims_pr_states: {"13230": "OPEN"}` — l'appel exact qui répondait CLEAR le 28/08.

## Validation

- `pytest scripts/tests/test_check_lane_claim.py` : **267 passed** + 1 live control (skip local sans token), zéro regression.
- `pytest scripts/tests/test_emit_dead_scope_warnings.py` (miroir workflow) : 10 passed.
- `audit_workflow_path_filters.py` : positive control OK, aucune non-conformité nouvelle.
- YAML validé (`yaml.safe_load`).

## Régularisation d'un test complice

`test_delivered_does_not_block_subsequent_claim` (v1) tournait SANS injection et ne passait **que grâce au lookup mort** — sa PR réelle #12270 résout MERGED → `open_locked` → bloquant. Épinglé hermétiquement à sa surface v1 documentée (injection `CLOSED` sans merge). Le chemin MERGED garde son propre test v2 (`test_delivered_pr_merged_locks_lane`).

Closes #13336
