### PR TITLE
fix(notebooks,#11112): PT_11 exec-sequence DIRTY -> CLEAN 1..13 (re-exec GPU + Stop&Repair hand-scrub cell 2)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen35_rlvr.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen35_rlvr.ipynb
@@ -57,7 +57,8 @@
     "print(f\"transformers={transformers.__version__}  (qwen3_5 requis: >=5.x)\")\n",
     "print(f\"trl={trl.__version__}  (GRPOTrainer sur transformers 5.x requis: >=1.0)\")\n",
     "print(f\"z3-solver={z3.get_version_string()}\")\n",
-    "print(f\"rewardspy @ {os.path.dirname(rewardspy.__file__)}\")\n",
+    "_rs_tail = os.sep.join(rewardspy.__file__.split(os.sep)[-3:])\n",
+    "print(f\"rewardspy @ ...{os.sep}{_rs_tail}\")\n",
     "\n",
     "# Reproductibilite\n",
     "SEED = 42\n",
@@ -68,9 +69,10 @@
     "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
     "print(f\"\\ndevice={device}\", \"|\", torch.cuda.get_device_name(0) if device==\"cuda\" else \"CPU only\")\n",
     "if device == \"cuda\":\n",
-    "    print(f\"VRAM totale: {torch.cuda.get_device_properties(0).total_memory/1e9:.1f} Go\")\n"
+    "    print(f\"VRAM totale: {torch.cuda.get_device_properties(0).total_memory/1e9:.1f} Go\")\n",
+    ""
    ],
-   "execution_count": 2,
+   "execution_count": 1,
    "outputs": [
     {
      "name": "stdout",
@@ -80,7 +82,13 @@
       "transformers=5.15.0  (qwen3_5 requis: >=5.x)\n",
       "trl=1.9.2  (GRPOTrainer sur transformers 5.x requis: >=1.0)\n",
       "z3-solver=5.0.0\n",
-      "rewardspy @ <USER_PATH>\\.conda\\envs\\coursia-ml-training\\Lib\\site-packages\\rewardspy\n",
+      "rewardspy @ ...\\site-packages\\rewardspy\\__init__.py\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "device=cuda | NVIDIA GeForce RTX 3070 Laptop GPU\n",
       "VRAM totale: 8.6 Go\n"
@@ -151,7 +159,7 @@
     "print(\"instance:\", _demo)\n",
     "print(\"prompt  :\", instance_prompt(_demo))\n"
    ],
-   "execution_count": 3,
+   "execution_count": 2,
    "outputs": [
     {
      "name": "stdout",
@@ -247,11 +255,11 @@
     "us = (time.perf_counter() - t0) / 10000 * 1e6\n",
     "print(f\"\\nlatence verify_z3: {us:.1f} us/appel (cible Tier-1 < 1000 us)\")\n"
    ],
-   "execution_count": 14,
+   "execution_count": 3,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "instance: {'n': 4, 'all_diff': True, 'extra': [(3, '+', 1, '<', 2), (3, '-', 1, '>', 0)]} \n",
       "\n",
@@ -265,7 +273,7 @@
       "----------------------------------------------------------------\n",
       "Le verificateur dit explicitement NON sur 3 des 5 cas : il est demontre.\n",
       "\n",
-      "latence verify_z3: 3.9 us/appel (cible Tier-1 < 1000 us)\n"
+      "latence verify_z3: 4.6 us/appel (cible Tier-1 < 1000 us)\n"
      ]
     }
    ]
@@ -305,7 +313,7 @@
     "print(f\"dataset: {len(ds)} rows; cols: {ds.column_names}\")\n",
     "print(\"ex prompt:\", ds[0][\"prompt\"][:90], \"...\")\n"
    ],
-   "execution_count": 5,
+   "execution_count": 4,
    "outputs": [
     {
      "name": "stdout",
@@ -353,7 +361,7 @@
     "print(\"reward instrumentee via rewardspy.watch_trl ->\", REWARD_LOG)\n",
     "print(\"type:\", type(reward_watched).__name__)\n"
    ],
-   "execution_count": 6,
+   "execution_count": 5,
    "outputs": [
     {
      "name": "stdout",
@@ -407,12 +415,12 @@
     "if device == \"cuda\":\n",
     "    print(f\"VRAM allouee: {torch.cuda.memory_allocated()/1e9:.2f} Go / reservee: {torch.cuda.memory_reserved()/1e9:.2f} Go\")\n"
    ],
-   "execution_count": 7,
+   "execution_count": 6,
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "287293d676824f36ab9112bd475eb576",
+       "model_id": "f3021655f15f4b86ac17f3b8dc51a879",
        "version_major": 2,
        "version_minor": 0
       },
@@ -479,20 +487,13 @@
     ")\n",
     "print(f\"GRPOConfig OK. {STEPS} steps prevus (~{STEPS*9//60} min a ~9 s/step).\")\n"
    ],
-   "execution_count": 8,
+   "execution_count": 7,
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GRPOConfig OK. 100 steps prevus (~15 min a ~9 s/step)."
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "GRPOConfig OK. 100 steps prevus (~15 min a ~9 s/step).\n"
      ]
     }
    ]
@@ -524,7 +525,7 @@
     "print(f\"\\nTRAIN_DONE en {elapsed/60:.1f} min. global_step={int(res.global_step)}\")\n",
     "print(\"reward finale (moyenne mobile):\", round(float(res.metrics.get(\"rewards/reward_fn/mean\", 0)), 4))\n"
    ],
-   "execution_count": 9,
+   "execution_count": 8,
    "outputs": [
     {
      "name": "stdout",
@@ -537,143 +538,143 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.009512', 'grad_norm': '0.7695', 'learning_rate': '4.8e-06', 'num_tokens': '2782', 'completions/mean_length': '47.5', 'completions/min_length': '46', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '17.2', 'completions/min_terminated_length': '17.2', 'completions/max_terminated_length': '17.2', 'rewards/reward_fn/mean': '0.1', 'rewards/reward_fn/std': '0.1718', 'reward': '0.1', 'reward_std': '0.1718', 'frac_reward_zero_std': '0.2', 'entropy': '1.699', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.753', 'epoch': '0.2083'}\n"
+      "{'loss': '0.009512', 'grad_norm': '0.8984', 'learning_rate': '4.8e-06', 'num_tokens': '2782', 'completions/mean_length': '47.5', 'completions/min_length': '46', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '17.2', 'completions/min_terminated_length': '17.2', 'completions/max_terminated_length': '17.2', 'rewards/reward_fn/mean': '0.1', 'rewards/reward_fn/std': '0.1718', 'reward': '0.1', 'reward_std': '0.1718', 'frac_reward_zero_std': '0.2', 'entropy': '1.714', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.697', 'epoch': '0.2083'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.02046', 'grad_norm': '0', 'learning_rate': '4.55e-06', 'num_tokens': '5529', 'completions/mean_length': '46.95', 'completions/min_length': '43.8', 'completions/max_length': '48', 'completions/clipped_ratio': '0.95', 'completions/mean_terminated_length': '5.4', 'completions/min_terminated_length': '5.4', 'completions/max_terminated_length': '5.4', 'rewards/reward_fn/mean': '0.25', 'rewards/reward_fn/std': '0.3023', 'reward': '0.25', 'reward_std': '0.3023', 'frac_reward_zero_std': '0.2', 'entropy': '1.686', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.712', 'epoch': '0.4167'}\n"
+      "{'loss': '0.02046', 'grad_norm': '0', 'learning_rate': '4.55e-06', 'num_tokens': '5529', 'completions/mean_length': '46.95', 'completions/min_length': '43.8', 'completions/max_length': '48', 'completions/clipped_ratio': '0.95', 'completions/mean_terminated_length': '5.4', 'completions/min_terminated_length': '5.4', 'completions/max_terminated_length': '5.4', 'rewards/reward_fn/mean': '0.25', 'rewards/reward_fn/std': '0.3023', 'reward': '0.25', 'reward_std': '0.3023', 'frac_reward_zero_std': '0.2', 'entropy': '1.689', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.425', 'epoch': '0.4167'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.06075', 'grad_norm': '0', 'learning_rate': '4.3e-06', 'num_tokens': '8253', 'completions/mean_length': '45.2', 'completions/min_length': '42', 'completions/max_length': '48', 'completions/clipped_ratio': '0.85', 'completions/mean_terminated_length': '13.2', 'completions/min_terminated_length': '13.2', 'completions/max_terminated_length': '13.2', 'rewards/reward_fn/mean': '0.1667', 'rewards/reward_fn/std': '0.2103', 'reward': '0.1667', 'reward_std': '0.2103', 'frac_reward_zero_std': '0.2', 'entropy': '1.517', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.83', 'epoch': '0.625'}\n"
+      "{'loss': '0.0643', 'grad_norm': '0', 'learning_rate': '4.3e-06', 'num_tokens': '8257', 'completions/mean_length': '45.4', 'completions/min_length': '42.8', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '4.4', 'completions/min_terminated_length': '4.4', 'completions/max_terminated_length': '4.4', 'rewards/reward_fn/mean': '0.1667', 'rewards/reward_fn/std': '0.2103', 'reward': '0.1667', 'reward_std': '0.2103', 'frac_reward_zero_std': '0.2', 'entropy': '1.396', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.61', 'epoch': '0.625'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.01999', 'grad_norm': '0.7695', 'learning_rate': '4.05e-06', 'num_tokens': '1.099e+04', 'completions/mean_length': '46.1', 'completions/min_length': '40.4', 'completions/max_length': '48', 'completions/clipped_ratio': '0.85', 'completions/mean_terminated_length': '21.2', 'completions/min_terminated_length': '21.2', 'completions/max_terminated_length': '21.2', 'rewards/reward_fn/mean': '0.1333', 'rewards/reward_fn/std': '0.1741', 'reward': '0.1333', 'reward_std': '0.1741', 'frac_reward_zero_std': '0.2', 'entropy': '1.525', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '8.721', 'epoch': '0.8333'}\n"
+      "{'loss': '0.01999', 'grad_norm': '0.707', 'learning_rate': '4.05e-06', 'num_tokens': '1.099e+04', 'completions/mean_length': '46.1', 'completions/min_length': '40.4', 'completions/max_length': '48', 'completions/clipped_ratio': '0.85', 'completions/mean_terminated_length': '21.2', 'completions/min_terminated_length': '21.2', 'completions/max_terminated_length': '21.2', 'rewards/reward_fn/mean': '0.15', 'rewards/reward_fn/std': '0.1995', 'reward': '0.15', 'reward_std': '0.1995', 'frac_reward_zero_std': '0.2', 'entropy': '1.538', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.398', 'epoch': '0.8333'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '-0.05077', 'grad_norm': '0.9336', 'learning_rate': '3.8e-06', 'num_tokens': '1.369e+04', 'completions/mean_length': '44.35', 'completions/min_length': '33.4', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '4.6', 'completions/min_terminated_length': '4.6', 'completions/max_terminated_length': '4.6', 'rewards/reward_fn/mean': '0.3', 'rewards/reward_fn/std': '0.3355', 'reward': '0.3', 'reward_std': '0.3355', 'frac_reward_zero_std': '0', 'entropy': '1.557', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '9.298', 'epoch': '1.042'}\n"
+      "{'loss': '-0.03063', 'grad_norm': '0.9141', 'learning_rate': '3.8e-06', 'num_tokens': '1.367e+04', 'completions/mean_length': '43.35', 'completions/min_length': '29.4', 'completions/max_length': '48', 'completions/clipped_ratio': '0.85', 'completions/mean_terminated_length': '10.2', 'completions/min_terminated_length': '10.2', 'completions/max_terminated_length': '10.2', 'rewards/reward_fn/mean': '0.3333', 'rewards/reward_fn/std': '0.3458', 'reward': '0.3333', 'reward_std': '0.3458', 'frac_reward_zero_std': '0', 'entropy': '1.615', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.466', 'epoch': '1.042'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '3.55e-06', 'num_tokens': '1.642e+04', 'completions/mean_length': '45.65', 'completions/min_length': '38.6', 'completions/max_length': '48', 'completions/clipped_ratio': '0.95', 'completions/mean_terminated_length': '0.2', 'completions/min_terminated_length': '0.2', 'completions/max_terminated_length': '0.2', 'rewards/reward_fn/mean': '0.06667', 'rewards/reward_fn/std': '0.05443', 'reward': '0.06667', 'reward_std': '0.05443', 'frac_reward_zero_std': '0.8', 'entropy': '1.98', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '8.397', 'epoch': '1.25'}\n"
+      "{'loss': '-3.974e-09', 'grad_norm': '0', 'learning_rate': '3.55e-06', 'num_tokens': '1.64e+04', 'completions/mean_length': '45.25', 'completions/min_length': '38.6', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '4.1', 'completions/min_terminated_length': '0.2', 'completions/max_terminated_length': '8', 'rewards/reward_fn/mean': '0.05', 'rewards/reward_fn/std': '0.06383', 'reward': '0.05', 'reward_std': '0.06383', 'frac_reward_zero_std': '0.8', 'entropy': '1.955', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.533', 'epoch': '1.25'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '-0.006433', 'grad_norm': '0', 'learning_rate': '3.3e-06', 'num_tokens': '1.917e+04', 'completions/mean_length': '46.2', 'completions/min_length': '40.8', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '12', 'completions/min_terminated_length': '12', 'completions/max_terminated_length': '12', 'rewards/reward_fn/mean': '0.1', 'rewards/reward_fn/std': '0.2', 'reward': '0.1', 'reward_std': '0.2', 'frac_reward_zero_std': '0.2', 'entropy': '1.61', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '10.07', 'epoch': '1.458'}\n"
+      "{'loss': '1.192e-08', 'grad_norm': '0', 'learning_rate': '3.3e-06', 'num_tokens': '1.918e+04', 'completions/mean_length': '48', 'completions/min_length': '48', 'completions/max_length': '48', 'completions/clipped_ratio': '1', 'completions/mean_terminated_length': '0', 'completions/min_terminated_length': '0', 'completions/max_terminated_length': '0', 'rewards/reward_fn/mean': '0.08333', 'rewards/reward_fn/std': '0.1667', 'reward': '0.08333', 'reward_std': '0.1667', 'frac_reward_zero_std': '0.4', 'entropy': '1.488', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.948', 'epoch': '1.458'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '-0.000444', 'grad_norm': '0', 'learning_rate': '3.05e-06', 'num_tokens': '2.184e+04', 'completions/mean_length': '43.3', 'completions/min_length': '29.2', 'completions/max_length': '48', 'completions/clipped_ratio': '0.85', 'completions/mean_terminated_length': '10', 'completions/min_terminated_length': '10', 'completions/max_terminated_length': '10', 'rewards/reward_fn/mean': '0.1167', 'rewards/reward_fn/std': '0.2333', 'reward': '0.1167', 'reward_std': '0.2333', 'frac_reward_zero_std': '0.2', 'entropy': '1.733', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '10.8', 'epoch': '1.667'}\n"
+      "{'loss': '-0.02082', 'grad_norm': '0', 'learning_rate': '3.05e-06', 'num_tokens': '2.183e+04', 'completions/mean_length': '42', 'completions/min_length': '28.4', 'completions/max_length': '48', 'completions/clipped_ratio': '0.8', 'completions/mean_terminated_length': '9.6', 'completions/min_terminated_length': '9.2', 'completions/max_terminated_length': '10', 'rewards/reward_fn/mean': '0.1167', 'rewards/reward_fn/std': '0.2333', 'reward': '0.1167', 'reward_std': '0.2333', 'frac_reward_zero_std': '0.2', 'entropy': '1.411', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.854', 'epoch': '1.667'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '-0.05877', 'grad_norm': '0.8086', 'learning_rate': '2.8e-06', 'num_tokens': '2.455e+04', 'completions/mean_length': '44.35', 'completions/min_length': '33.4', 'completions/max_length': '48', 'completions/clipped_ratio': '0.8', 'completions/mean_terminated_length': '23.8', 'completions/min_terminated_length': '23.8', 'completions/max_terminated_length': '23.8', 'rewards/reward_fn/mean': '0.1667', 'rewards/reward_fn/std': '0.277', 'reward': '0.1667', 'reward_std': '0.277', 'frac_reward_zero_std': '0.2', 'entropy': '1.697', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '10.03', 'epoch': '1.875'}\n"
+      "{'loss': '-0.05771', 'grad_norm': '0.875', 'learning_rate': '2.8e-06', 'num_tokens': '2.454e+04', 'completions/mean_length': '44.45', 'completions/min_length': '33.8', 'completions/max_length': '48', 'completions/clipped_ratio': '0.85', 'completions/mean_terminated_length': '14.6', 'completions/min_terminated_length': '14.6', 'completions/max_terminated_length': '14.6', 'rewards/reward_fn/mean': '0.1667', 'rewards/reward_fn/std': '0.277', 'reward': '0.1667', 'reward_std': '0.277', 'frac_reward_zero_std': '0.2', 'entropy': '1.728', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.69', 'epoch': '1.875'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '-0.09467', 'grad_norm': '0.9414', 'learning_rate': '2.55e-06', 'num_tokens': '2.725e+04', 'completions/mean_length': '44.15', 'completions/min_length': '38.6', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '1.9', 'completions/min_terminated_length': '0.2', 'completions/max_terminated_length': '3.6', 'rewards/reward_fn/mean': '0.25', 'rewards/reward_fn/std': '0.3018', 'reward': '0.25', 'reward_std': '0.3018', 'frac_reward_zero_std': '0', 'entropy': '1.49', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '9.303', 'epoch': '2.083'}\n"
+      "{'loss': '-0.09467', 'grad_norm': '0.918', 'learning_rate': '2.55e-06', 'num_tokens': '2.724e+04', 'completions/mean_length': '44.15', 'completions/min_length': '38.6', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '1.9', 'completions/min_terminated_length': '0.2', 'completions/max_terminated_length': '3.6', 'rewards/reward_fn/mean': '0.25', 'rewards/reward_fn/std': '0.3018', 'reward': '0.25', 'reward_std': '0.3018', 'frac_reward_zero_std': '0', 'entropy': '1.449', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.846', 'epoch': '2.083'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '-0.007461', 'grad_norm': '0.5977', 'learning_rate': '2.3e-06', 'num_tokens': '2.997e+04', 'completions/mean_length': '45.2', 'completions/min_length': '36.8', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '8', 'completions/min_terminated_length': '8', 'completions/max_terminated_length': '8', 'rewards/reward_fn/mean': '0.1333', 'rewards/reward_fn/std': '0.2305', 'reward': '0.1333', 'reward_std': '0.2305', 'frac_reward_zero_std': '0.2', 'entropy': '1.568', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '9.396', 'epoch': '2.292'}\n"
+      "{'loss': '-0.007452', 'grad_norm': '0.6406', 'learning_rate': '2.3e-06', 'num_tokens': '2.996e+04', 'completions/mean_length': '45.2', 'completions/min_length': '36.8', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '8', 'completions/min_terminated_length': '8', 'completions/max_terminated_length': '8', 'rewards/reward_fn/mean': '0.1167', 'rewards/reward_fn/std': '0.1972', 'reward': '0.1167', 'reward_std': '0.1972', 'frac_reward_zero_std': '0.2', 'entropy': '1.582', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.716', 'epoch': '2.292'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '5.96e-09', 'grad_norm': '0.7227', 'learning_rate': '2.05e-06', 'num_tokens': '3.274e+04', 'completions/mean_length': '48', 'completions/min_length': '48', 'completions/max_length': '48', 'completions/clipped_ratio': '1', 'completions/mean_terminated_length': '0', 'completions/min_terminated_length': '0', 'completions/max_terminated_length': '0', 'rewards/reward_fn/mean': '0.2333', 'rewards/reward_fn/std': '0.3557', 'reward': '0.2333', 'reward_std': '0.3557', 'frac_reward_zero_std': '0', 'entropy': '1.696', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '9.434', 'epoch': '2.5'}\n"
+      "{'loss': '-5.96e-09', 'grad_norm': '0.6523', 'learning_rate': '2.05e-06', 'num_tokens': '3.273e+04', 'completions/mean_length': '48', 'completions/min_length': '48', 'completions/max_length': '48', 'completions/clipped_ratio': '1', 'completions/mean_terminated_length': '0', 'completions/min_terminated_length': '0', 'completions/max_terminated_length': '0', 'rewards/reward_fn/mean': '0.25', 'rewards/reward_fn/std': '0.3144', 'reward': '0.25', 'reward_std': '0.3144', 'frac_reward_zero_std': '0', 'entropy': '1.661', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.773', 'epoch': '2.5'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '3.974e-09', 'grad_norm': '0.75', 'learning_rate': '1.8e-06', 'num_tokens': '3.549e+04', 'completions/mean_length': '46.75', 'completions/min_length': '43', 'completions/max_length': '48', 'completions/clipped_ratio': '0.95', 'completions/mean_terminated_length': '4.6', 'completions/min_terminated_length': '4.6', 'completions/max_terminated_length': '4.6', 'rewards/reward_fn/mean': '0.1667', 'rewards/reward_fn/std': '0.1638', 'reward': '0.1667', 'reward_std': '0.1638', 'frac_reward_zero_std': '0.4', 'entropy': '1.399', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '9.024', 'epoch': '2.708'}\n"
+      "{'loss': '1.192e-08', 'grad_norm': '0.7891', 'learning_rate': '1.8e-06', 'num_tokens': '3.547e+04', 'completions/mean_length': '46.75', 'completions/min_length': '43', 'completions/max_length': '48', 'completions/clipped_ratio': '0.95', 'completions/mean_terminated_length': '4.6', 'completions/min_terminated_length': '4.6', 'completions/max_terminated_length': '4.6', 'rewards/reward_fn/mean': '0.1333', 'rewards/reward_fn/std': '0.1052', 'reward': '0.1333', 'reward_std': '0.1052', 'frac_reward_zero_std': '0.4', 'entropy': '1.426', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.655', 'epoch': '2.708'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.01192', 'grad_norm': '0.6953', 'learning_rate': '1.55e-06', 'num_tokens': '3.819e+04', 'completions/mean_length': '43.85', 'completions/min_length': '43', 'completions/max_length': '45', 'completions/clipped_ratio': '0.8', 'completions/mean_terminated_length': '5.45', 'completions/min_terminated_length': '4.6', 'completions/max_terminated_length': '6.6', 'rewards/reward_fn/mean': '0.1', 'rewards/reward_fn/std': '0.1436', 'reward': '0.1', 'reward_std': '0.1436', 'frac_reward_zero_std': '0.2', 'entropy': '1.517', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '8.255', 'epoch': '2.917'}\n"
+      "{'loss': '0.02499', 'grad_norm': '0', 'learning_rate': '1.55e-06', 'num_tokens': '3.818e+04', 'completions/mean_length': '43.95', 'completions/min_length': '40.2', 'completions/max_length': '48', 'completions/clipped_ratio': '0.75', 'completions/mean_terminated_length': '13.23', 'completions/min_terminated_length': '11.4', 'completions/max_terminated_length': '15.6', 'rewards/reward_fn/mean': '0.1', 'rewards/reward_fn/std': '0.1638', 'reward': '0.1', 'reward_std': '0.1638', 'frac_reward_zero_std': '0.2', 'entropy': '1.596', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.516', 'epoch': '2.917'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.03232', 'grad_norm': '1.062', 'learning_rate': '1.3e-06', 'num_tokens': '4.088e+04', 'completions/mean_length': '43.7', 'completions/min_length': '30.8', 'completions/max_length': '48', 'completions/clipped_ratio': '0.8', 'completions/mean_terminated_length': '21.2', 'completions/min_terminated_length': '21.2', 'completions/max_terminated_length': '21.2', 'rewards/reward_fn/mean': '0.15', 'rewards/reward_fn/std': '0.1647', 'reward': '0.15', 'reward_std': '0.1647', 'frac_reward_zero_std': '0.2', 'entropy': '1.504', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '9.134', 'epoch': '3.125'}\n"
+      "{'loss': '-0.02385', 'grad_norm': '0.8047', 'learning_rate': '1.3e-06', 'num_tokens': '4.092e+04', 'completions/mean_length': '45.85', 'completions/min_length': '39.4', 'completions/max_length': '48', 'completions/clipped_ratio': '0.85', 'completions/mean_terminated_length': '20.2', 'completions/min_terminated_length': '20.2', 'completions/max_terminated_length': '20.2', 'rewards/reward_fn/mean': '0.2', 'rewards/reward_fn/std': '0.2972', 'reward': '0.2', 'reward_std': '0.2972', 'frac_reward_zero_std': '0', 'entropy': '1.672', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.343', 'epoch': '3.125'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.01982', 'grad_norm': '0.6406', 'learning_rate': '1.05e-06', 'num_tokens': '4.359e+04', 'completions/mean_length': '44.65', 'completions/min_length': '34.6', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '5.8', 'completions/min_terminated_length': '5.8', 'completions/max_terminated_length': '5.8', 'rewards/reward_fn/mean': '0.25', 'rewards/reward_fn/std': '0.2839', 'reward': '0.25', 'reward_std': '0.2839', 'frac_reward_zero_std': '0.2', 'entropy': '1.748', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '8.772', 'epoch': '3.333'}\n"
+      "{'loss': '0', 'grad_norm': '0', 'learning_rate': '1.05e-06', 'num_tokens': '4.367e+04', 'completions/mean_length': '47', 'completions/min_length': '44', 'completions/max_length': '48', 'completions/clipped_ratio': '0.95', 'completions/mean_terminated_length': '5.6', 'completions/min_terminated_length': '5.6', 'completions/max_terminated_length': '5.6', 'rewards/reward_fn/mean': '0.1333', 'rewards/reward_fn/std': '0.1277', 'reward': '0.1333', 'reward_std': '0.1277', 'frac_reward_zero_std': '0.6', 'entropy': '1.593', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.59', 'epoch': '3.333'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '0.02177', 'grad_norm': '0', 'learning_rate': '8e-07', 'num_tokens': '4.635e+04', 'completions/mean_length': '47.35', 'completions/min_length': '45.4', 'completions/max_length': '48', 'completions/clipped_ratio': '0.95', 'completions/mean_terminated_length': '7', 'completions/min_terminated_length': '7', 'completions/max_terminated_length': '7', 'rewards/reward_fn/mean': '0.15', 'rewards/reward_fn/std': '0.161', 'reward': '0.15', 'reward_std': '0.161', 'frac_reward_zero_std': '0.4', 'entropy': '1.508', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '8.189', 'epoch': '3.542'}\n"
+      "{'loss': '-0.0224', 'grad_norm': '0.7812', 'learning_rate': '8e-07', 'num_tokens': '4.642e+04', 'completions/mean_length': '46.9', 'completions/min_length': '43.6', 'completions/max_length': '48', 'completions/clipped_ratio': '0.95', 'completions/mean_terminated_length': '5.2', 'completions/min_terminated_length': '5.2', 'completions/max_terminated_length': '5.2', 'rewards/reward_fn/mean': '0.15', 'rewards/reward_fn/std': '0.2718', 'reward': '0.15', 'reward_std': '0.2718', 'frac_reward_zero_std': '0', 'entropy': '1.479', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.759', 'epoch': '3.542'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '-1.391e-08', 'grad_norm': '0', 'learning_rate': '5.5e-07', 'num_tokens': '4.91e+04', 'completions/mean_length': '46.7', 'completions/min_length': '42.8', 'completions/max_length': '48', 'completions/clipped_ratio': '0.95', 'completions/mean_terminated_length': '4.4', 'completions/min_terminated_length': '4.4', 'completions/max_terminated_length': '4.4', 'rewards/reward_fn/mean': '0.1667', 'rewards/reward_fn/std': '0.2103', 'reward': '0.1667', 'reward_std': '0.2103', 'frac_reward_zero_std': '0.4', 'entropy': '1.643', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.972', 'epoch': '3.75'}\n"
+      "{'loss': '0.002748', 'grad_norm': '0', 'learning_rate': '5.5e-07', 'num_tokens': '4.917e+04', 'completions/mean_length': '46.8', 'completions/min_length': '43.2', 'completions/max_length': '48', 'completions/clipped_ratio': '0.9', 'completions/mean_terminated_length': '14.4', 'completions/min_terminated_length': '14.4', 'completions/max_terminated_length': '14.4', 'rewards/reward_fn/mean': '0.03333', 'rewards/reward_fn/std': '0.03849', 'reward': '0.03333', 'reward_std': '0.03849', 'frac_reward_zero_std': '0.8', 'entropy': '1.679', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.681', 'epoch': '3.75'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '2.384e-08', 'grad_norm': '0', 'learning_rate': '3e-07', 'num_tokens': '5.189e+04', 'completions/mean_length': '48', 'completions/min_length': '48', 'completions/max_length': '48', 'completions/clipped_ratio': '1', 'completions/mean_terminated_length': '0', 'completions/min_terminated_length': '0', 'completions/max_terminated_length': '0', 'rewards/reward_fn/mean': '0.06667', 'rewards/reward_fn/std': '0.1333', 'reward': '0.06667', 'reward_std': '0.1333', 'frac_reward_zero_std': '0.2', 'entropy': '1.709', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '8.768', 'epoch': '3.958'}\n"
+      "{'loss': '0.03102', 'grad_norm': '0.543', 'learning_rate': '3e-07', 'num_tokens': '5.195e+04', 'completions/mean_length': '47.1', 'completions/min_length': '44.4', 'completions/max_length': '48', 'completions/clipped_ratio': '0.95', 'completions/mean_terminated_length': '6', 'completions/min_terminated_length': '6', 'completions/max_terminated_length': '6', 'rewards/reward_fn/mean': '0.1333', 'rewards/reward_fn/std': '0.2', 'reward': '0.1333', 'reward_std': '0.2', 'frac_reward_zero_std': '0', 'entropy': '1.478', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.588', 'epoch': '3.958'}\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'loss': '-0.04273', 'grad_norm': '0.7148', 'learning_rate': '5e-08', 'num_tokens': '5.461e+04', 'completions/mean_length': '44.55', 'completions/min_length': '34.2', 'completions/max_length': '48', 'completions/clipped_ratio': '0.85', 'completions/mean_terminated_length': '15', 'completions/min_terminated_length': '15', 'completions/max_terminated_length': '15', 'rewards/reward_fn/mean': '0.08333', 'rewards/reward_fn/std': '0.1667', 'reward': '0.08333', 'reward_std': '0.1667', 'frac_reward_zero_std': '0.2', 'entropy': '1.684', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '8.084', 'epoch': '4.167'}\n",
-      "{'train_runtime': '885.7', 'train_samples_per_second': '0.452', 'train_steps_per_second': '0.113', 'train_loss': '-0.003236', 'epoch': '4.167'}\n",
+      "{'loss': '1.391e-08', 'grad_norm': '0', 'learning_rate': '5e-08', 'num_tokens': '5.473e+04', 'completions/mean_length': '48', 'completions/min_length': '48', 'completions/max_length': '48', 'completions/clipped_ratio': '1', 'completions/mean_terminated_length': '0', 'completions/min_terminated_length': '0', 'completions/max_terminated_length': '0', 'rewards/reward_fn/mean': '0.1333', 'rewards/reward_fn/std': '0.1638', 'reward': '0.1333', 'reward_std': '0.1638', 'frac_reward_zero_std': '0.4', 'entropy': '1.61', 'clip_ratio/low_mean': '0', 'clip_ratio/high_mean': '0', 'clip_ratio/region_mean': '0', 'clip_ratio/low_min': '0', 'clip_ratio/high_max': '0', 'step_time': '7.507', 'epoch': '4.167'}\n",
+      "{'train_runtime': '763.8', 'train_samples_per_second': '0.524', 'train_steps_per_second': '0.131', 'train_loss': '-0.004227', 'epoch': '4.167'}\n",
       "\n",
-      "TRAIN_DONE en 14.8 min. global_step=100\n",
+      "TRAIN_DONE en 12.7 min. global_step=100\n",
       "reward finale (moyenne mobile): 0.0\n"
      ]
     }
@@ -720,20 +721,14 @@
     "    plt.show()\n",
     "    print(\"courbe sauvee -> pt11_reward_curve.png\")\n"
    ],
-   "execution_count": 10,
+   "execution_count": 9,
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "400 recompenses enregistrees en ligne par rewardspy.\n",
-      "moyenne globale: 0.1575 | max: 1.0000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "moyenne globale: 0.1525 | max: 1.0000\n",
       "courbe sauvee -> pt11_reward_curve.png\n"
      ]
     }
@@ -788,20 +783,20 @@
     "else:\n",
     "    print(\"Lecture : au moins un detecteur a declenche -- voir les alertes ci-dessus.\")\n"
    ],
-   "execution_count": 14,
+   "execution_count": 10,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "=== Detection rewardspy en ligne (400 rollouts observes) ===\n",
       "\n",
       "Metriques anti-hacking (ce que les detecteurs scrutent) :\n",
       "  reward max observe      : 1.0000\n",
-      "  reward moyen (mobile)   : 0.1433\n",
-      "  variance mobile         : 0.069456\n",
-      "  variance de reference   : 0.268710\n",
-      "  taux au plafond (1.0)   : 0.0300   (proche de 1 = suspect)\n",
+      "  reward moyen (mobile)   : 0.1167\n",
+      "  variance mobile         : 0.049722\n",
+      "  variance de reference   : 0.273861\n",
+      "  taux au plafond (1.0)   : 0.0100   (proche de 1 = suspect)\n",
       "\n",
       "Verdict global rewardspy : OK\n",
       "Alertes declenchees      : 0\n",
@@ -815,9 +810,9 @@
       "  ProxyEvalDivergenceDetector      NOT_APPLICABLE\n",
       "\n",
       "Lecture honnete : aucun hacking detecte. Ce n'est PAS une absence de preuve :\n",
-      "  - le taux au plafond est bas (3.00%), donc le modele n'ecrase\n",
+      "  - le taux au plafond est bas (1.00%), donc le modele n'ecrase\n",
       "    pas le maximum (pas de 'reward inflation' typique du hacking).\n",
-      "  - la variance mobile (0.0695) reste non nulle : les completions\n",
+      "  - la variance mobile (0.0497) reste non nulle : les completions\n",
       "    d'un meme groupe different encore, le signal group-relative est vivant.\n",
       "  Un hacking aurait donne ceiling_rate ~ 1 + variance ~ 0 : ce n'est pas le cas.\n"
      ]
@@ -847,7 +842,7 @@
     "exercices 2 et 3 ci-dessous.\n",
     "\n",
     "**Lecture critique de la courbe (sur le run réel).** Sur 100 pas, la récompense moyenne par pas\n",
-    "(`rewards/reward_fn/mean`) **fluctue entre 0,07 et 0,30**, moyenne ~0,14, **sans tendance croissante\n",
+    "(`rewards/reward_fn/mean`) **fluctue entre 0,03 et 0,33**, moyenne ~0,15, **sans tendance croissante\n",
     "nette**. Le reward max observé atteint 1,0 (le modèle résout au moins une fois toutes les\n",
     "contraintes), mais en moyenne il n'apprend pas à résoudre le CSP en 100 pas. **C'est le résultat\n",
     "attendu et publiable d'un POC** : un 0,8 Md de paramètres n'apprend pas la résolution de CSP\n",
@@ -906,7 +901,7 @@
     "    return result\n",
     "print(\"Exercice 1 a completer: disjonction 'or'.\")\n"
    ],
-   "execution_count": 12,
+   "execution_count": 11,
    "outputs": [
     {
      "name": "stdout",
@@ -943,7 +938,7 @@
     "    return None\n",
     "print(\"Exercice 2 a completer: baseline SFT (solve_instance_z3 + SFTTrainer).\")\n"
    ],
-   "execution_count": 13,
+   "execution_count": 12,
    "outputs": [
     {
      "name": "stdout",
@@ -978,7 +973,7 @@
     "    return 0.0\n",
     "print(\"Exercice 3 a completer: run_grpo(seed) x4 + ecart 2-sigma.\")\n"
    ],
-   "execution_count": 14,
+   "execution_count": 13,
    "outputs": [
     {
      "name": "stdout",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/docs #13334

See #11112 (étage 3, tranche résiduelle PostTraining). Grain REPAIR (hérite du genre de la PR qu'il répare : notebook-python, CONTENU).

## Ce que répare cette PR

`GenAI/PostTraining/PT_11_grpo_qwen35_rlvr.ipynb` portait une séquence `execution_count` **DIRTY** (verdict `check_exec_sequence.py` : NOT_FROM_1 + UNORDERED) :

```
[2, 3, 14, 5, 6, 7, 8, 9, 10, 14, 12, 13, 14]   (committée sur main @ 46c0d210dc)
```

Cellules 6 (`def parse_answer`) et 19 (rapport rewardspy) avaient été re-lancées seules en fin de session interactive (les deux `14`) — les sorties committées ne décrivaient aucun run unique.

## Réparation 1 — re-exécution complète (pas un re-numérotage)

Re-exec end-to-end **papermill kernel `coursia-ml-training`** (RTX 3070 8GB libre, vérifié `nvidia-smi` avant lancement) : GRPO 100 steps sur Qwen3.5-0.8B 4-bit NF4 (snapshot local), `SEED=42` inchangé, reward Z3-CSP instrumentée rewardspy online (JSONL en scratch, hors repo). **TRAIN_DONE 12,6 min, global_step=100**, verdict rewardspy **OK / 0 alerte**.

## Réparation 2 — Stop & Repair d'un hand-scrub passé (découvert par la re-exec)

L'output **committé** de la cellule 2 portait `rewardspy @ <USER_PATH>\.conda\...` — un placeholder remplaçant le vrai chemin : trace d'un hand-scrub antérieur (règle 6). La source imprimant `os.path.dirname(rewardspy.__file__)`, ma première re-exec honnête a **fait resurger** `C:\Users\jsboi\...`. Cure appliquée (triage C, source-leak) : le print émet désormais un suffixe portable (`rewardspy @ ...\site-packages\rewardspy\__init__.py`), puis **deuxième re-exec complète** pour que l'output corresponde à la source patchée. Zéro placeholder réintroduit.

## Validation

- `check_exec_sequence.py` sur le notebook commité : verdict **CLEAN**, séquence **1..13** contiguë (relancé après la dernière écriture)
- `validate_pr_notebooks.py origin/main` : **PASS 1/1** (13 cellules code, kernel `coursia-ml-training`)
- 0 output `error` ; scan fuites (`jsboi`, `C:\Users`, chemins machine) : **NONE**
- Une seule source modifiée : le print cellule 2 (2 lignes). Exercices 1-3 stubs C.1 préservés.
- Citation markdown de la courbe réalignée sur **ce** run (chiffres dérivés des outputs frais par script, pas à la main) : « fluctue entre 0,03 et 0,33, moyenne ~0,15 » (min 0.033 / max 0.333 / moyenne 0.152 sur 20 logs). Timing « ~15 min » toujours vrai (12,6).

## Contexte mesure

Scan flotte sur `origin/main` @ `46c0d210dc` (ce cycle, instrument canonique, parse du document JSON complet) : **1103/1110 fully-executed CLEAN, 7 DIRTY résiduels** (tous GenAI ; 2 claimés po-2023:CoursIA-2). Cette PR réduit le résiduel à 6.
