### PR TITLE
docs(ci,#13217): le fichier temoin du cache d'outils, sans lequel l'amorcage est detruit au premier job

### DIFF
--- a/docs/ci/self-hosted-runners.md
+++ b/docs/ci/self-hosted-runners.md
@@ -139,6 +139,49 @@ Les logs conservés restent locaux et hors du dépôt. Le contrôle distant « z
 
 Un runner `--ephemeral` traite au plus un job puis doit être ré-enregistré. Le gestionnaire prépare une invocation unique ; il ne crée ni boucle permanente, ni broker de tokens. Le choix entre configuration JIT, contrôleur de ré-enregistrement ou preuve one-shot est une décision séparée avant activation durable. Un runner persistant n'est pas un raccourci acceptable.
 
+## Amorcer le cache d'outils, et pourquoi le fichier témoin porte tout
+
+Le compte de service dédié n'a **aucun Python accessible**. Ce n'est pas une supposition :
+le run `33087876304` (branche `fix/13217`, 2026-08-27T16:00Z) échoue en deux secondes sur
+`The term 'python' is not recognized`. Les interpréteurs de la flotte sont des installations
+*per-user* sous `AppData/Local/Programs/Python`, donc hors du `PATH` système **et** hors des
+ACL du compte de service, que l'installation retire de l'héritage.
+
+C'est la raison pour laquelle `actions/setup-python` est **conservé** dans
+`windows-self-hosted-tests.yml`, et pour laquelle la PR qui le retirait au profit du Python
+machine (#13233) est fermée : elle suppose un `PATH` que le compte de service n'a pas.
+
+L'amorçage se fait donc côté machine, en peuplant le cache d'outils du runner :
+
+```
+<workdir>/_work/_tool/Python/3.11.9/x64/        arbre Python complet
+<workdir>/_work/_tool/Python/3.11.9/x64.complete   fichier témoin
+```
+
+**Le fichier témoin n'est pas une formalité : sans lui, l'amorçage est détruit par le premier
+job.** `tc.find()` ne consulte que le témoin. S'il manque, l'arbre peuplé juste à côté est
+invisible : `setup-python` annonce `Version 3.11 was not found in the local cache`, télécharge
+l'archive, et son `install.ps1` trouve alors le répertoire existant, **le supprime**, puis y
+copie ce que l'archive contient réellement — l'installeur, pas un arbre, car les paquets
+`actions/python-versions` embarquent un exécutable. Il tente enfin de le jouer sous le compte
+de service et échoue en `0x80070005`. Un cache amorcé sans témoin est donc *pire* qu'un cache
+absent : il est effacé, et l'erreur qui en résulte ne nomme jamais la cause.
+
+Avec le témoin, le job touche le cache immédiatement : aucun `setup.ps1` exécuté, aucun
+téléchargement, et la dépendance à l'`ExecutionPolicy` du compte de service disparaît — c'est
+elle qui bloquait la lane (`UnauthorizedAccess` sur `setup.ps1`, #13217).
+
+Mesures d'acceptation sur po-2024, variante déployée :
+
+| Run | Branche | Résultat |
+|---|---|---|
+| `33092567324` | `main` | `setup-python` succès, 39 passés / 1 échec — l'échec est l'invariant #13238, côté dépôt |
+| `33093119578` | branche de correction | **42 passés**, conclusion `success` |
+
+L'amorçage est à refaire sur **chaque** machine qui porte un runner : il vit dans le workdir,
+que le teardown retire. Un runner ré-enregistré sur une machine non amorcée retombe dans la
+séquence destructrice ci-dessus.
+
 ## Tranches suivantes, non activées
 
 La préparation complète reste découpée :


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: MED/guard #13234

## Ce que cette PR ecrit, et pourquoi maintenant

Le playbook (a2) de #13217 est **deploye et prouve** sur po-2024 : cache d'outils amorce, `setup-python` en cache hit, `42 passed / success`. La PR concurrente #13233 (retirer `setup-python` au profit du Python machine) est **fermee**, parce qu'elle suppose un `PATH` que le compte de service n'a pas.

Mais le mecanisme qui fait tenir (a2) — le fichier temoin `x64.complete` — **n'etait ecrit nulle part** : `grep -niE 'x64.complete|tool-cache|_tool' docs/ci/self-hosted-runners.md` rendait 0 ligne. Il ne vivait que dans un commentaire d'issue.

C'est le genre de connaissance qui coute cher a re-decouvrir, parce que **son absence ne produit pas l'erreur qu'on chercherait** :

> `tc.find()` ne consulte que le temoin. S'il manque, l'arbre peuple juste a cote est invisible : `setup-python` annonce « was not found in the local cache », telecharge l'archive, et son `install.ps1` trouve alors le repertoire existant, **le supprime**, puis y copie ce que l'archive contient reellement — l'installeur, pas un arbre. Il tente de le jouer sous le compte de service et echoue en `0x80070005`.

Un cache amorce **sans** temoin est donc *pire* qu'un cache absent : il est efface au premier job, et l'erreur qui en resulte (`0x80070005`) ne nomme jamais la cause. La prochaine machine amorcee sans cette page rejouerait exactement cette sequence.

## Ce qui est ecrit

Une section dans [`docs/ci/self-hosted-runners.md`](../blob/docs/13217-tool-cache-stamp/docs/ci/self-hosted-runners.md), placee entre « Limite des runners ephemeres » et « Tranches suivantes » :

- **pourquoi `setup-python` est conserve** — le compte de service n'a aucun Python accessible, mesure par le run `33087876304` (`The term 'python' is not recognized`, 2 s) ; les interpreteurs de la flotte sont des installs *per-user* sous `AppData`, hors `PATH` systeme et hors ACL du compte, dont l'installation retire l'heritage ;
- **le layout d'amorcage** (arbre + temoin) ;
- **la sequence destructrice** ci-dessus, qui est la raison d'etre du temoin ;
- **les deux runs d'acceptation** : `33092567324` (main, 39 passes / 1 echec = invariant #13238, cote depot) et `33093119578` (branche de correction, **42 passes**, `success`) ;
- **la portee** : l'amorcage vit dans le workdir, que le teardown retire — il est donc a refaire sur *chaque* machine, et un runner re-enregistre sur une machine non amorcee retombe dans la sequence destructrice.

## Verification

- `grep -c 'x64.complete'` → 1 (le layout) ; les deux numeros de run et le chemin `AppData/Local/Programs/Python` presents dans le fichier ecrit.
- Encodage **UTF-8 sans BOM, LF** (verifie sur les octets apres ecriture).
- Diff : **1 fichier, +43 lignes, 0 suppression**. Aucun autre fichier touche — catalogue byte-identique a `main`.

## Portee — ce que cette PR n'est pas

Genre `docs` = **META**. Elle **ne tient pas** le plancher G-VAR-1 de ma lane, et je ne la presente pas comme tel. Elle est le prerequis ecrit de la seule voie qui augmente la **capacite** de runners, laquelle est la contrainte liante de la flotte a cette heure (**1190 runs en file pour 15 en vol**, mesure a 07:1xZ). Le plat principal de contenu reste du au cycle.

See #13217, #12704
