### PR TITLE
feat(guards,#13321): sweep stale-guard-red — date le rouge par la base gelée du run, jamais rerun

### DIFF
--- a/.github/workflows/stale-guard-red-sweep.yml
+++ b/.github/workflows/stale-guard-red-sweep.yml
@@ -1,0 +1,84 @@
+name: Stale guard-red sweep
+
+# The gap left open by pr-gate-stale-sweep.yml, measured 2026-08-27 on the
+# eleven-PR band of #13321.
+#
+# pr-gate-stale-sweep.yml refreshes stale PR gate verdicts, but its candidate
+# filter only retains PRs where "no check is red besides PR gate itself". A PR
+# whose OTHER guard failed -- and whose guard has since been FIXED on main --
+# is never re-examined by anything. It stays BLOCKED until a human dates its
+# red by hand.
+#
+# The founding band: 11 PRs (#13156 ... #13204) carried a red
+# `Scripts Tests (CPU)` on an assertion that NO LONGER EXISTS -- the test was
+# renamed by 62d47eb7d (#13148) at 2026-08-27T08:53Z, and every red in the
+# band predates that fix by 2h43 at least. None of them had anything to fix.
+#
+# What this sweep does differently: it DATES the red by the FROZEN base the run
+# was actually played against -- run.pull_requests[0].base.sha, embedded in the
+# immutable run object -- NOT by completedAt and NOT by the CURRENT
+# merge_commit_sha of the PR, which GitHub recomputes as main moves (founding
+# discovery of #13321, measured on #13156: the drifted merge-ref already
+# contains the fix while the run was played against an older base). A red is
+# stale iff the guard is green on main at its CURRENT version AND the locating
+# fix commit is NOT an ancestor of that frozen base. See
+# scripts/check_stale_guard_reds.py for the full method, including the positive
+# control: a red rendered AGAINST the fixed guard (base ahead of the fix) is a
+# real defect and is NOT flagged.
+#
+# The remedy it prescribes is `gh pr update-branch` -- NEVER `gh run rerun`,
+# which replays the frozen base and returns the same red. It never rebases
+# and never re-runs anything itself: this is a signal organ (label + comment),
+# because the rattrapage must stay ORTHONNANCE under runner starvation
+# (#11860) -- eleven update-branches at once would push ~350 runs into a
+# queue that already holds hundreds.
+#
+# Daily on an off-minute: the pr-gate sweep runs hourly because it actively
+# unblocks merges; this one files an advisory and its remedy is executed by
+# the owning lanes, one head at a time.
+
+on:
+  schedule:
+    - cron: '53 4 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List candidates, post nothing'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write   # label + comment (signal only, never update-branch)
+
+concurrency:
+  group: stale-guard-red-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Signal PRs blocked on a pre-fix red
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/check_stale_guard_reds.py
+
+      - name: Find and signal stale guard reds
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -uo pipefail
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            python scripts/check_stale_guard_reds.py --repo "$REPO" --json
+          else
+            python scripts/check_stale_guard_reds.py --repo "$REPO" --apply --json
+          fi
+
+          # Advisory organ: it signals, it never blocks.
+          exit 0

--- a/scripts/check_stale_guard_reds.py
+++ b/scripts/check_stale_guard_reds.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Signal les PR ouvertes dont un rouge date d'une base ANTERIEURE au fix de son garde.
+
+Pourquoi cet organe existe (#13321)
+-----------------------------------
+Onze PR ouvertes (#13156 #13167 #13168 #13169 #13172 #13177 #13181 #13183
+#13191 #13203 #13204 -- plancher mesure sur un tiers du pool) portaient un rouge
+`Scripts Tests (CPU)` sur une assertion qui N'EXISTE PLUS sur main : le test
+`test_current_repository_has_explicit_zero_self_hosted_baseline` a ete renomme
+par 62d47eb7d (#13148) le 2026-08-27T08:53Z, et TOUS les rouges de la bande
+precedent ce correctif de 2 h 43 au minimum.
+
+`pr-gate-stale-sweep.yml` rafraichit les verdicts perimes, mais sa semantique
+est bornee aux PR ou « aucun rouge hormis PR gate lui-meme ». Une PR rouge sur
+un AUTRE garde corrige depuis n'est JAMAIS reexaminee : elle reste BLOCKED
+jusqu'a ce qu'un humain la date a la main.
+
+La distinction mecanique que cet organe encode :
+  `gh run rerun`        rejoue la BASE GELEE  -> il rend le MEME rouge ;
+  `gh pr update-branch` recalcule la base    -> seul remede.
+
+Comment il date le rouge (criterion 1)
+--------------------------------------
+PAS par `completedAt` (horodatage du run, muet sur CE QUE le run a teste) et
+PAS par le `merge_commit_sha` COURANT de la PR -- mesure 2026-08-28 sur
+#13156 : GitHub RECALCULE la merge-ref quand main bouge, meme sans push sur la
+PR (head du 2026-08-26T18:47, run rouge 21:59, fix 62d47eb7d 2026-08-27T08:53,
+et pourtant le parent du merge_commit_sha courant CONTIENT le fix -- la base
+courante n'est pas la base testee).
+
+Seconde decouverte d'instrument (mesure 2026-08-28 au dry-run, #13156) :
+`run.head_sha` d'un run `pull_request` (GET /actions/runs/{id}, id extrait de
+details_url) est la TETE DE PR, PAS le merge commit -- le premier parent du head
+n'est donc PAS la base testee. L'ancre juste est un champ du run EMBARQUE a sa
+creation : `run.pull_requests[0].base.sha` = la base de la PR enregistree au
+moment du run. Un objet run est IMMUABLE : ce champ ne derive pas quand main
+bouge. Le rouge est « perime » ssi cette base ne CONTIENT PAS le commit qui a
+rendu le garde vert sur main -- une relation d'ancestre, pas une comparaison
+d'horodatages : immune au clock skew et aux runs rejoues.
+
+Cas ecarte nommement : un run `push` (branche seule, pas de merge) n'a teste
+AUCUNE base -- indatable, exclusion nommee. Angle mort borne (declare honnete) :
+`pulls[].base.sha` reste inactif jusqu'a un sync de la PR ; une PR ouverte AVANT
+le fix mais dont un run tournerait APRES le fix contre main courant verrait son
+snapshot sous-estimer la vraie base et prescrire update-branch -- remede
+idempotent et auto-correcteur, qui reconstruit le merge sur main courant.
+
+Localisation du fix (generique, AUCUN mappage nom de test -> fichier) :
+  1. le check rouge porte `details_url` -> run_id -> workflow du run emetteur ;
+  2. l'historique des runs de CE workflow sur `main` donne, par run, le verdict
+     du check de meme nom (attribution par run_id dans details_url, comme le
+     fold du sweep PR gate -- #11808) ;
+  3. la transition rouge->vert la plus recente localise le fix : `fix_head` =
+     head_sha du premier run VERT apres le dernier run ROUGE ;
+  4. rouge perime ssi : check vert sur main a SA VERSION COURANTE (dernier run)
+     ET `fix_head` n'est PAS ancetre de la base de la PR.
+
+Controle positif (criterion 4) : si la base CONTIENT deja `fix_head`, le rouge
+a ete rendu CONTRE le garde corrige -- c'est un vrai defaut, il n'est PAS
+signale. Un organe qui blanchirait toute la classe serait pire que rien.
+
+S'il n'y a AUCUNE transition rouge->vert dans la fenetre (garde vert de tout
+temps sur main), le rouge est vraisemblablement propre a la PR : non signale,
+exclusion nommee. Conservateur par construction.
+
+Sortie : advisory. `--apply` pose le label `stale-guard-red` + un commentaire
+par PR (dedupe par label). Il ne rebase JAMAIS, ne rerun JAMAIS, exit 0 toujours.
+
+    python scripts/check_stale_guard_reds.py [--json]
+    python scripts/check_stale_guard_reds.py --apply --max-posts 8
+    python scripts/check_stale_guard_reds.py --from-json replay.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Callable
+
+LABEL = "stale-guard-red"
+# Meme asymetrie que pr-gate-stale-sweep.yml : neutral/skipped ne rougissent
+# pas un rollup ; cancelled/stale/action_required sont des etats sans verdict.
+# RED = verdict RENDU d_echec. "cancelled" (cancel-storm par concurrency, frequent
+# ici) et "action_required" (case a cocher, ex. env) ne sont PAS des echecs du
+# garde : les inclure fabriquerait des faux rouges. cf #13156 (cancel-storms).
+RED = {"failure", "timed_out"}
+GREEN = {"success", "neutral", "skipped"}
+# Le rouge `PR gate` a SON sweep (pr-gate-stale-sweep.yml) : le traiter ici
+# ferait deux organes sur la meme classe.
+EXCLUDED_CHECKS = {"PR gate"}
+# Fenetre d'historique des runs du garde sur main : il faut voir la transition
+# rouge->vert. Mesure 2026-08-28 (#13321) : a ~65 pushes/jour sur main, une
+# fenetre de 30 runs couvre ~11 h -- le fix 62d47eb7d du garde Scripts Tests
+# datait de 24 h et la transition etait DEJA sortie de fenetre, la bande
+# fondatrice (#13156...) passait en exclusion "aucune transition". 120 runs
+# couvre ~2 jours de cadence soutenue. Cout borne : un call check-runs par run
+# (cache par sha), uniquement pour les workflows emettant un rouge.
+MAIN_RUNS_WINDOW = 120
+
+
+def _run_gh(args: list[str]) -> str:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args[:3])}... -> {proc.returncode}: {proc.stderr[:200]}")
+    return proc.stdout
+
+
+def _fold_key(check: dict) -> tuple[str, str]:
+    """(run_id, name) -- JAMAIS le nom seul (#11808) : plusieurs workflows
+    emettent des jobs de meme nom ; le run_id vient de details_url."""
+    m = re.search(r"/runs/(\d+)/", check.get("details_url") or "")
+    return (m.group(1) if m else "unattributed", check.get("name") or "?")
+
+
+def collect(repo: str) -> dict:
+    """Collecte les donnees brutes via gh (reseau). analyse() reste pure."""
+    prs = []
+    for line in _run_gh(["api", f"repos/{repo}/pulls?state=open&base=main&per_page=100",
+                         "--paginate", "--jq",
+                         ".[] | {number, draft, merge_commit_sha, "
+                         "head_sha: .head.sha, fork: .head.repo.fork}"]).splitlines():
+        if line.strip():
+            prs.append(json.loads(line))
+
+    checks_cache: dict[str, list] = {}
+    wf_cache: dict[int, dict] = {}
+    run_base_cache: dict[str, dict] = {}
+
+    def checks_on(sha: str) -> list:
+        if sha not in checks_cache:
+            out = _run_gh(["api", f"repos/{repo}/commits/{sha}/check-runs?per_page=100",
+                           "--jq", ".check_runs[] | {name, status, conclusion, details_url}"])
+            checks_cache[sha] = [json.loads(l) for l in out.splitlines() if l.strip()]
+        return checks_cache[sha]
+
+    def tested_base(run_id: str):
+        """Base main GEELEE que CE run a testee, ou None si saturee.
+
+        Decouverte d_instrument au dry-run reel (#13156) : run.head_sha d_un run
+        pull_request est la TETE DE PR, PAS le merge commit -- le parent du head
+        n_est donc PAS la base testee. L_ancre juste est le snapshot embarque dans
+        l_objet run (immuable) : run.pull_requests[0].base.sha = la base enregistree
+        au moment du run, qui ne derive pas quand main bouge. Un run push-event
+        teste la branche seule : aucune base de merge.
+
+        Angle mort borne : pulls[].base.sha est un champ du PR laisse inactif
+        jusqu_a un sync -- PR ouverte AVANT le fix mais run APRES le fix contre
+        main courant => snapshot sous-estime la vraie base et peut prescrire
+        update-branch (remede idempotent et auto-correcteur). """
+        if run_id not in run_base_cache:
+            try:
+                r = json.loads(_run_gh(["api", f"repos/{repo}/actions/runs/{run_id}",
+                                        "--jq",
+                                        "{event: .event, base: (.pull_requests[0].base.sha // \"\")}"]))
+            except RuntimeError:
+                r = {}
+            run_base_cache[run_id] = r
+        r = run_base_cache[run_id]
+        if not r:
+            return None
+        if (r.get("event") or "") != "pull_request":
+            return None  # run push-event sur la branche : aucune base merge testee
+        return r.get("base") or None
+
+    def main_history(run_id: str) -> dict:
+        """Runs main du workflow emetteur + verdict du check par run_id."""
+        run = json.loads(_run_gh(["api", f"repos/{repo}/actions/runs/{run_id}",
+                                  "--jq", "{workflow_id}"]))
+        wf = run["workflow_id"]
+        if wf in wf_cache:
+            return wf_cache[wf]
+        out = _run_gh(["api", f"repos/{repo}/actions/workflows/{wf}/runs?branch=main"
+                         f"&per_page={MAIN_RUNS_WINDOW}",
+                         "--jq", ".workflow_runs[] | {id, head_sha}"])
+        runs = [json.loads(l) for l in out.splitlines() if l.strip()]  # recent d'abord
+        history = wf_cache[wf] = {"runs": runs, "check_by_run": {}}
+        for r in runs:
+            for c in checks_on(r["head_sha"]):
+                if f"/runs/{r['id']}/" in (c.get("details_url") or ""):
+                    by_name = history["check_by_run"].setdefault(r["id"], {})
+                    by_name[c.get("name") or "?"] = {
+                        "conclusion": c.get("conclusion"), "status": c.get("status")}
+        return history
+
+    out_prs = []
+    for pr in prs:
+        checks = checks_on(pr["head_sha"])
+        red_runs = sorted({m.group(1) for c in checks
+                           if (c.get("conclusion") or "") in RED
+                           and c.get("name") not in EXCLUDED_CHECKS
+                           and (m := re.search(r"/runs/(\d+)/", c.get("details_url") or ""))})
+        entry = {**pr, "checks": checks, "main_histories": {}, "tested_bases": {}}
+        # Un historique PAR workflow emetteur de rouge (les rouges d'une PR
+        # peuvent venir de gardes distincts) ; le cache deduplique par workflow.
+        # tested_bases : par run rouge, la base main GELEE que CE run a testee
+        # (merge-ref au moment du run -- pas la merge-ref courante, qui derive).
+        for rid in red_runs:
+            try:
+                entry["main_histories"][rid] = main_history(rid)
+            except RuntimeError as e:
+                entry["main_histories"][rid] = {"error": str(e)}
+            entry["tested_bases"][rid] = tested_base(rid)
+        out_prs.append(entry)
+    return {"prs": out_prs}
+
+
+def locate_fix_head(history: dict, check_name: str) -> tuple[str, str | None]:
+    """(statut du garde sur main, head_sha du commit qui l'a rendu vert).
+
+    statut : "green" (vert a sa version courante), "red_on_main" (rouge au
+    dernier run : vrai probleme), "absent_on_main" (le check ne tourne jamais
+    sur main, p.ex. garde pull_request-only : indatable).
+
+    Marche les runs main du plus recent au plus ancien. `fix_head` = head du
+    premier run VERT qui suit (dans le temps) un run ROUGE. Aucune transition
+    dans la fenetre -> (green, None) : pas de preuve de fix, non signale
+    (conservateur : un garde vert de tout temps rend le rouge propre a la PR).
+    """
+    runs = history.get("runs") or []
+    verdicts = []
+    for r in runs:  # recent d'abord
+        c = (history.get("check_by_run") or {}).get(r["id"], {}).get(check_name)
+        if not c or (c.get("status") or "") != "completed":
+            continue
+        concl = c.get("conclusion") or ""
+        verdicts.append((concl in GREEN, concl in RED, r["head_sha"]))
+    if not verdicts:
+        return "absent_on_main", None
+    current_green = verdicts[0][0]
+    fix_head = None
+    for i, (green, _red, sha) in enumerate(verdicts):
+        if green and i + 1 < len(verdicts) and verdicts[i + 1][1]:
+            fix_head = sha  # vert immediatement precede d'un rouge (plus ancien)
+            break
+    return ("green" if current_green else "red_on_main"), fix_head
+
+
+def is_ancestor_status(status: str | None) -> bool:
+    """compare/a...b status == 'ahead' => b est en avance sur a => a ancetre de b."""
+    return status == "ahead"
+
+
+def analyse(data: dict, compare_fn: Callable[[str, str], str | None]) -> dict:
+    """Pure : data = sortie de collect() ; compare_fn(fix_head, base) -> status
+    de compare/fix_head...base ('ahead' = fix ancetre de base). Seam de test :
+    on injecte un dict ; en production, un appel REST cache.
+    """
+    flagged, excluded = [], []
+    for pr in data.get("prs") or []:
+        num = pr.get("number")
+        if pr.get("draft"):
+            excluded.append({"pr": num, "reason": "draft"}); continue
+        if pr.get("fork"):
+            excluded.append({"pr": num, "reason": "fork (update-branch indisponible)"}); continue
+        # fold (run_id, name) latest-wins sur les COMPLETED : une tentative
+        # supersedee du meme workflow ne compte plus (#11808).
+        latest: dict[tuple[str, str], dict] = {}
+        for c in pr.get("checks") or []:
+            if (c.get("status") or "") != "completed":
+                continue
+            key = _fold_key(c)
+            cur = latest.get(key)
+            if cur is None or (c.get("details_url") or "") >= (cur.get("details_url") or ""):
+                latest[key] = c
+        reds = [(key, c) for key, c in latest.items()
+                if (c.get("conclusion") or "") in RED and key[1] not in EXCLUDED_CHECKS]
+        if not reds:
+            continue  # pas de rouge hors PR gate : hors scope
+        # Disjointness avec pr-gate-stale-sweep.yml : un vert de MEME nom pose sur
+        # la MEME tete par un AUTRE run prouve que le garde PASSE a cette base --
+        # le rouge est un flake, son remede est `gh run rerun` (rejouer la meme
+        # base), pas update-branch. Le prescrire ici serait la fausse piste
+        # exacte que le criterion 3 interdit.
+        # un vert de MEME nom sur la MEME base GEEELEE (meme conditions testees)
+        # prouve que le garde passe a cette base : le rouge est un flake, remede
+        # `gh run rerun`, pas update-branch. Un vert de meme nom mais d_une base
+        # AUTRE (p.ex. post-fix) n_est PAS un flake : c_est la signature du rouge
+        # perime (le merge-ref recent passe, celui teste par le run rouge non).
+        green_bases = {}
+        for k, c in latest.items():
+            if (c.get("conclusion") or "") in GREEN:
+                mid = re.search(r"/runs/(\d+)/", c.get("details_url") or "")
+                gbase = (pr.get("tested_bases") or {}).get(mid.group(1)) if mid else None
+                green_bases[k[1]] = gbase
+        new_reds = []
+        for k, c in reds:
+            m = re.search(r"/runs/(\d+)/", c.get("details_url") or "")
+            rbase = (pr.get("tested_bases") or {}).get(m.group(1)) if m else None
+            if k[1] in green_bases and green_bases[k[1]] == rbase and rbase is not None:
+                excluded.append({"pr": num, "check": k[1],
+                                 "reason": "vert coexistant du meme nom sur la meme base "
+                                           "gelee (flake) : voie gh run rerun, cf "
+                                           "pr-gate-stale-sweep"})
+            else:
+                new_reds.append((k, c))
+        reds = new_reds
+        if not reds:
+            continue
+        for key, c in reds:
+            name = key[1]
+            m = re.search(r"/runs/(\d+)/", c.get("details_url") or "")
+            rid = m.group(1) if m else ""
+            # base GELEE testee par CE run (criterion 1) -- pas la merge-ref
+            # courante de la PR, que GitHub recalcule quand main bouge.
+            base = (pr.get("tested_bases") or {}).get(rid)
+            if not base:
+                excluded.append({"pr": num, "check": name,
+                                 "reason": "base testee indisponible (run push-event sur la branche, "
+                                           "ou run sans snapshot de merge : indatable"}); continue
+            hist = (pr.get("main_histories") or {}).get(rid, {})
+            if hist.get("error"):
+                excluded.append({"pr": num, "check": name,
+                                 "reason": f"historique main injoignable: {hist['error'][:80]}"}); continue
+            status, fix_head = locate_fix_head(hist, name)
+            if status == "red_on_main":
+                excluded.append({"pr": num, "check": name,
+                                 "reason": "garde rouge sur main a sa version courante "
+                                           "(vrai probleme, pas un rouge perime)"}); continue
+            if status == "absent_on_main":
+                excluded.append({"pr": num, "check": name,
+                                 "reason": "le check ne tourne jamais sur main (garde "
+                                           "pull_request-only ?) : indatable, non signale"}); continue
+            if fix_head is None:
+                excluded.append({"pr": num, "check": name,
+                                 "reason": "aucune transition rouge->vert sur main dans la "
+                                           "fenetre : rouge vraisemblablement propre a la PR"}); continue
+            status = compare_fn(fix_head, base)
+            if status is None:
+                excluded.append({"pr": num, "check": name,
+                                 "reason": f"compare indisponible ({fix_head[:8]}...{base[:8]})"}); continue
+            if is_ancestor_status(status):
+                # CONTROLE POSITIF (criterion 4) : la base CONTIENT deja le fix.
+                # Le rouge a ete rendu contre le garde corrige : vrai defaut.
+                excluded.append({"pr": num, "check": name,
+                                 "reason": f"base {base[:8]} POSTERIEURE au fix {fix_head[:8]} "
+                                           ": vrai defaut, ne pas signaler"}); continue
+            flagged.append({
+                "pr": num, "check": name, "merge_base": base, "fix_head": fix_head,
+                "remedy": "update-branch",
+                "why_not_rerun": (f"gh run rerun rejouerait la base gelee {base[:8]} "
+                                  f"(le fix {fix_head[:8]} n'y est PAS) et rendrait le meme "
+                                  "rouge ; seul gh pr update-branch recalcule la base"),
+            })
+    n = len(data.get("prs") or [])
+    return {
+        "examined": n,
+        "denominator": {"examined": n, "flagged": len(flagged), "excluded": len(excluded)},
+        "flagged": flagged,
+        "excluded": excluded,
+        "label": LABEL,
+    }
+
+
+def apply(repo: str, result: dict, max_posts: int) -> None:
+    """Pose label + commentaire, dedupe par label. Advisory : n'echoue jamais."""
+    try:
+        _run_gh(["label", "create", LABEL, "--repo", repo, "--color", "BFD4F2",
+                 "--description",
+                 "Rouge datant d'une base anterieure au fix du garde (sweep #13321)"])
+    except RuntimeError:
+        pass  # existe deja : normal
+    for f in result["flagged"][:max_posts]:
+        try:
+            labeled = _run_gh(["pr", "view", str(f["pr"]), "--repo", repo, "--json",
+                               "labels", "--jq",
+                               '[.labels[].name] | index("stale-guard-red") != null']).strip()
+            if labeled == "true":
+                print(f"[stale-guard-red] #{f['pr']}: label deja pose, skip")
+                continue
+            body = (f"[{LABEL}] `{f['check']}` -- rouge date de la base "
+                    f"`{f['merge_base'][:12]}`, ANTERIEURE au fix `{f['fix_head'][:12]}` "
+                    f"du garde sur main (garde vert a sa version courante).\n"
+                    f"Remede : `gh pr update-branch {f['pr']}` (recalcule la base). "
+                    f"NE PAS `gh run rerun` : {f['why_not_rerun']}.")
+            _run_gh(["pr", "comment", str(f["pr"]), "--repo", repo, "--body", body])
+            _run_gh(["pr", "edit", str(f["pr"]), "--repo", repo, "--add-label", LABEL])
+            print(f"[stale-guard-red] #{f['pr']}: signale ({f['check']})")
+        except RuntimeError as e:
+            print(f"[stale-guard-red] #{f['pr']}: echec non fatal ({e})", file=sys.stderr)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", default="jsboige/CoursIA")
+    ap.add_argument("--from-json", help="rejeu d'une collecte (--dump)")
+    ap.add_argument("--dump", help="ecrit la collecte + compares pour rejeu")
+    ap.add_argument("--json", action="store_true", help="sortie machine")
+    ap.add_argument("--apply", action="store_true",
+                    help="pose label + commentaire (defaut : lecture seule)")
+    ap.add_argument("--max-posts", type=int, default=8)
+    args = ap.parse_args()
+
+    recorded: dict[tuple[str, str], str] = {}
+
+    def compare_fn(a: str, b: str) -> str | None:
+        if (a, b) in recorded:
+            return recorded[(a, b)]
+        try:
+            # --jq .status emet une CHAINE NUE ("behind"), pas du JSON :
+            # json.loads dessus renvoie ValueError et faisait rendre None a
+            # chaque compare (mesure #13156 au v4 : compare OK via l'API brute).
+            status = _run_gh(["api", f"repos/{args.repo}/compare/{a}...{b}",
+                              "--jq", ".status"]).strip().strip('"')
+            recorded[(a, b)] = status
+            return status
+        except (RuntimeError, ValueError):
+            # 404 (pas d'ancetre commun), sortie non-JSON, timeout : le verdict
+            # manque -> analyse() exclut nomme "compare indisponible". Un
+            # compare rate-limite ne doit pas tuer le sweep entier.
+            return None
+
+    if args.from_json:
+        payload = json.load(open(args.from_json, encoding="utf-8"))
+        data, recorded = payload["data"], {tuple(k): v for k, v in payload["compares"].items()}
+        def replay_fn(a: str, b: str) -> str | None:
+            return recorded.get((a, b))
+        result = analyse(data, replay_fn)
+    else:
+        data = collect(args.repo)
+        result = analyse(data, compare_fn)
+
+    if args.dump:
+        json.dump({"data": data, "compares": {f"{a}|{b}": s for (a, b), s in recorded.items()}},
+                  open(args.dump, "w", encoding="utf-8"), indent=1, ensure_ascii=False)
+
+    if args.json:
+        print(json.dumps(result, indent=1, ensure_ascii=False))
+    else:
+        print(f"[stale-guard-red] PR examinees: {result['examined']} "
+              f"(denominateur: ouvertes examinees) | signalees: {len(result['flagged'])} "
+              f"| exclues: {len(result['excluded'])}")
+        for f in result["flagged"]:
+            print(f"  #{f['pr']} {f['check']} base={f['merge_base'][:8]} "
+                  f"fix={f['fix_head'][:8]} -> {f['remedy']}")
+        for e in result["excluded"]:
+            print(f"  #{e['pr']} exclu: {e.get('check', '')} {e['reason']}", file=sys.stderr)
+    if args.apply:
+        apply(args.repo, result, args.max_posts)
+    return 0  # advisory : ne bloque jamais
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_stale_guard_reds.py
+++ b/scripts/tests/test_check_stale_guard_reds.py
@@ -1,0 +1,277 @@
+"""Tests for scripts/check_stale_guard_reds.py (#13321).
+
+Aucun appel reseau : `analyse()` est pur, on lui passe des payloads construits
+et un `compare_fn` dicționnaire. Les quatre criterions de l'issue :
+
+  1. datation par la base de la merge-ref (ancêtré, pas completedAt) ;
+  2. signal quand garde vert sur main ET rouge anterieur au fix ;
+  3. remede update-branch, JAMAIS rerun -- rerun rejouerait la base gelee
+     (couvert par le cas flake ET par why_not_rerun) ;
+  4. CONTROLE POSITIF : un rouge posterieur au fix ressort NON signale.
+
+L'incident fondateur sert de fixture : #13156 porte un rouge
+`Scripts Tests (CPU)` rendu contre une base du 2026-08-26, fix 62d47eb7d
+arrive sur main le 2026-08-27T08:53Z.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_stale_guard_reds.py"
+spec = importlib.util.spec_from_file_location("check_stale_guard_reds", SCRIPT)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["check_stale_guard_reds"] = mod
+spec.loader.exec_module(mod)
+
+FIX = "62d47eb7df1"  # fix(ci,#13135) windows-self-hosted-tests policy runner (#13148)
+OLD_BASE = "5ee60a409f90"  # base gelee reelle du run rouge de #13156 (08-26 18:48)
+NEW_BASE = "46c0d210dcda"  # base posterieure au fix
+
+
+def check(name, conclusion, run_id, status="completed"):
+    return {"name": name, "status": status, "conclusion": conclusion,
+            "details_url": f"https://github.com/jsboige/CoursIA/actions/runs/{run_id}/job/1"}
+
+
+def history(verdicts):
+    """verdicts: liste du PLUS RECENT au PLUS ANCIEN de (conclusion, head_sha)."""
+    runs, by_run = [], {}
+    for i, (concl, sha) in enumerate(verdicts):
+        rid = 900 - i  # run ids decroissants vers le passe : 900 = plus recent
+        runs.append({"id": rid, "head_sha": sha})
+        by_run[rid] = {"Scripts Tests (CPU)": {"conclusion": concl, "status": "completed"}}
+    return {"runs": runs, "check_by_run": by_run}
+
+
+def pr_fixture(**over):
+    red = check("Scripts Tests (CPU)", "failure", 111)
+    pr = {
+        "number": 13156, "draft": False, "fork": False,
+        "head_sha": "aaa", "merge_commit_sha": "mmm",
+        "tested_bases": {"111": OLD_BASE},
+        "checks": [red],
+        # garde vert aujourd'hui, transition rouge->vert localisee sur FIX :
+        # du plus recent au plus ancien : vert(NEW), vert(FIX), rouge(ancien)
+        "main_histories": {"111": history([
+            ("success", "main-tip"), ("success", FIX), ("failure", "pre-fix")])},
+    }
+    pr.update(over)
+    return {"prs": [pr]}
+
+
+def cmp_map(m):
+    return lambda a, b: m.get((a, b))
+
+
+# --- criterion 2 + 3 : la classe incident, signalee, remede update-branch ---
+
+def test_stale_red_flagged_with_update_branch_remedy():
+    result = mod.analyse(pr_fixture(), cmp_map({}))  # compare indisponible -> non
+    # sans compare, conservateur : exclu nomme, pas signale
+    assert result["flagged"] == []
+    assert "compare indisponible" in result["excluded"][0]["reason"]
+
+    result = mod.analyse(pr_fixture(), cmp_map({(FIX, OLD_BASE): "diverged"}))
+    assert len(result["flagged"]) == 1
+    f = result["flagged"][0]
+    assert f["pr"] == 13156
+    assert f["check"] == "Scripts Tests (CPU)"
+    assert f["remedy"] == "update-branch"
+    assert f["merge_base"] == OLD_BASE
+    assert f["fix_head"] == FIX
+
+
+def test_rerun_would_replay_frozen_base_documented():
+    """Criterion 3 : le verdict porte POURQUOI rerun rendrait le meme rouge."""
+    result = mod.analyse(pr_fixture(), cmp_map({(FIX, OLD_BASE): "diverged"}))
+    why = result["flagged"][0]["why_not_rerun"]
+    assert "base gelee" in why
+    assert "rendrait le meme rouge" in why
+    assert "update-branch" in why
+
+
+def test_flake_same_base_green_sibling_not_prescribed_update_branch():
+    """Un vert du meme nom sur la MEME base GEEELEE prove que le garde passe
+    a cette base : rerun de la base est la voie (famille pr-gate-stale-sweep),
+    PAS update-branch. Le prescrire serait la fausse piste du criterion 3."""
+    green = check("Scripts Tests (CPU)", "success", 222)
+    pr = {"prs": [{
+        "number": 13156, "draft": False, "fork": False,
+        "head_sha": "aaa", "merge_commit_sha": "mmm",
+        "tested_bases": {"111": OLD_BASE, "222": OLD_BASE},
+        "checks": [check("Scripts Tests (CPU)", "failure", 111), green],
+        "main_histories": {},
+    }]}
+    result = mod.analyse(pr, cmp_map({}))
+    assert result["flagged"] == []
+    ex = result["excluded"][0]
+    assert "flake" in ex["reason"]
+    assert "rerun" in ex["reason"]
+
+def test_green_sibling_postfix_base_is_not_a_flake():
+    """Un vert de meme nom sur une base DIFFERENTE (post-fix) n_est PAS un
+    flake : c_est la signature du rouge perime -- le merge-ref recent passe
+    (preuve que update-branch reparait), celui teste par le run rouge non."""
+    green = check("Scripts Tests (CPU)", "success", 222)
+    pr = {"prs": [{
+        "number": 13156, "draft": False, "fork": False,
+        "head_sha": "aaa", "merge_commit_sha": "mmm",
+        # rouge sur base pre-fix, vert sur base post-fix : differents
+        "tested_bases": {"111": OLD_BASE, "222": NEW_BASE},
+        "checks": [check("Scripts Tests (CPU)", "failure", 111), green],
+        "main_histories": {"111": history([
+            ("success", "main-tip"), ("success", FIX), ("failure", "pre-fix")])},
+    }]}
+    result = mod.analyse(pr, cmp_map({(FIX, OLD_BASE): "behind"}))
+    assert len(result["flagged"]) == 1
+    assert result["flagged"][0]["remedy"] == "update-branch"
+
+
+def test_current_merge_ref_drift_does_not_hide_stale_red():
+    """La decouverte fondatrice (mesure 2026-08-28 sur #13156) : la merge-ref
+    COURANTE de la PR est recalculee quand main bouge -- son parent contient
+    deja le fix. Dater par elle declarerait "vrai defaut" un rouge rendu contre
+    une base anterieure. La base GELEE du run est le seul instrument juste."""
+    pr = pr_fixture()
+    # la base GELEE du run 111 predates le fix ; la merge-ref courante
+    # (parent de merge_commit_sha) est, elle, POSTERIEURE au fix :
+    pr["prs"][0]["merge_commit_sha"] = "mmm"  # parent contiendrait le fix
+    result = mod.analyse(pr, cmp_map({(FIX, OLD_BASE): "diverged"}))
+    assert len(result["flagged"]) == 1  # signale : c'est la base du RUN qui fait foi
+
+
+# --- criterion 4 : CONTROLE POSITIF ---
+
+def test_red_posterior_to_fix_not_flagged():
+    """Base posterieure au fix (compare 'ahead') = rouge rendu CONTRE le garde
+    corrige = vrai defaut : NON signale, exclusion explicite."""
+    pr = pr_fixture()
+    pr["prs"][0]["tested_bases"] = {"111": NEW_BASE}
+    result = mod.analyse(pr, cmp_map({(FIX, NEW_BASE): "ahead"}))
+    assert result["flagged"] == []
+    assert "vrai defaut" in result["excluded"][0]["reason"]
+
+
+# --- criterions 2 : gardes fous, exclusions nommees ---
+
+def test_guard_red_on_main_current_not_flagged():
+    hist = history([("failure", "main-tip"), ("success", FIX), ("failure", "pre-fix")])
+    pr = pr_fixture()
+    pr["prs"][0]["main_histories"] = {"111": hist}
+    result = mod.analyse(pr, cmp_map({}))
+    assert result["flagged"] == []
+    assert "garde rouge sur main" in result["excluded"][0]["reason"]
+
+
+def test_pr_only_guard_absent_on_main_named_exclusion():
+    """Un garde pull_request-only n'a JAMAIS de runs sur main : indatable.
+    Mesure 2026-08-28 : Papermill ratchet / cell-ordering tombaient en
+    "garde rouge sur main" -- message faux, ce sont des gardes PR-only."""
+    pr = pr_fixture()
+    pr["prs"][0]["main_histories"] = {"111": {"runs": [], "check_by_run": {}}}
+    result = mod.analyse(pr, cmp_map({}))
+    assert result["flagged"] == []
+    assert "ne tourne jamais sur main" in result["excluded"][0]["reason"]
+
+
+def test_no_red_green_transition_not_flagged():
+    """Garde vert de tout temps sur main : aucune preuve de fix, le rouge est
+    propre a la PR. Un organe qui blanchirait la classe serait pire que rien."""
+    hist = history([("success", "main-tip"), ("success", "older"), ("success", "oldest")])
+    pr = pr_fixture()
+    pr["prs"][0]["main_histories"] = {"111": hist}
+    result = mod.analyse(pr, cmp_map({}))
+    assert result["flagged"] == []
+    assert "propre a la PR" in result["excluded"][0]["reason"]
+
+
+# --- bornes de perimetre ---
+
+def test_pr_gate_red_out_of_scope():
+    pr = pr_fixture()
+    pr["prs"][0]["checks"] = [check("PR gate", "failure", 111)]
+    result = mod.analyse(pr, cmp_map({}))
+    assert result["flagged"] == [] and result["excluded"] == []
+
+
+def test_draft_excluded():
+    pr = pr_fixture()
+    pr["prs"][0]["draft"] = True
+    result = mod.analyse(pr, cmp_map({}))
+    assert result["flagged"] == [] and result["excluded"][0]["reason"] == "draft"
+
+
+def test_fork_excluded():
+    pr = pr_fixture()
+    pr["prs"][0]["fork"] = True
+    result = mod.analyse(pr, cmp_map({}))
+    assert result["flagged"] == []
+    assert "fork" in result["excluded"][0]["reason"]
+
+
+def test_push_event_run_without_merge_base_excluded():
+    """Mesure 2026-08-28 (#13156) : GitHub recalcule la merge-ref courante
+    quand main bouge -- dater par elle etait FAUX. Seule la base GELEE du run
+    fait foi ; un run push-event n'en a pas : indatable, exclusion nommee."""
+    pr = pr_fixture()
+    pr["prs"][0]["tested_bases"] = {"111": None}
+    result = mod.analyse(pr, cmp_map({}))
+    assert result["flagged"] == []
+    assert "base testee indisponible" in result["excluded"][0]["reason"]
+    assert "push-event" in result["excluded"][0]["reason"]
+
+
+def test_superseded_incomplete_attempt_does_not_flag():
+    """Une tentative interrompue (status != completed) du meme workflow ne
+    compte ni rouge ni vert : seule la tentative conclue fait foi."""
+    pr = pr_fixture()
+    pr["prs"][0]["checks"] = [
+        check("Scripts Tests (CPU)", "failure", 111, status="in_progress"),
+        check("Scripts Tests (CPU)", "failure", 111),
+    ]
+    result = mod.analyse(pr, cmp_map({(FIX, OLD_BASE): "diverged"}))
+    assert len(result["flagged"]) == 1
+
+
+# --- criterion 5 : denominateur ---
+
+def test_denominator_reported():
+    data = {"prs": [pr_fixture()["prs"][0],
+                    {"number": 2, "draft": True, "checks": [], "main_histories": {}}]}
+    result = mod.analyse(data, cmp_map({(FIX, OLD_BASE): "diverged"}))
+    assert result["examined"] == 2
+    d = result["denominator"]
+    assert d["examined"] == 2 and d["flagged"] == 1 and d["excluded"] == 1
+
+
+# --- unites ---
+
+def test_is_ancestor_status():
+    assert mod.is_ancestor_status("ahead")       # b en avance : a ancetre de b
+    assert not mod.is_ancestor_status("behind")  # b en retard : fix POSTERIEUR a base
+    assert not mod.is_ancestor_status("diverged")
+    assert not mod.is_ancestor_status(None)
+
+
+def test_locate_fix_head_ordering():
+    hist = history([("success", "s1"), ("success", "s2"), ("failure", "s3"),
+                    ("failure", "s4")])
+    status, fix = mod.locate_fix_head(hist, "Scripts Tests (CPU)")
+    assert status == "green" and fix == "s2"  # serie verte post-fix
+
+
+def test_locate_fix_head_all_green():
+    hist = history([("success", "s1"), ("success", "s2")])
+    status, fix = mod.locate_fix_head(hist, "Scripts Tests (CPU)")
+    assert status == "green" and fix is None
+
+
+def test_locate_fix_head_absent_check():
+    status, fix = mod.locate_fix_head({"runs": [], "check_by_run": {}}, "X")
+    assert status == "absent_on_main" and fix is None
+
+
+def test_locate_fix_head_red_on_main():
+    hist = history([("failure", "s1"), ("success", "s2"), ("failure", "s3")])
+    status, fix = mod.locate_fix_head(hist, "Scripts Tests (CPU)")
+    assert status == "red_on_main"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2027:CoursIA — prev: DEEP/notebook-lean #13339

## Organe : les rouges « antérieurs au fix de leur garde » deviennent visibles — sweep `stale-guard-red`

See #13321 (dispatch ai-01, claim `[CLAIMED] lane myia-po-2027:CoursIA` posé à la dispatch).

> **Note livraison (split scope `workflow`) — RÉSOLU c.1331p229b** : po-2027 a maintenant le scope `workflow` (OAuth `gh auth refresh -s workflow` user action 2026-08-28). Le push initial a été bloqué 17 cycles (c.1331p213 → c.1331p229b) avant le refresh OAuth (cf tell c.1331p229b-L1 ★ : push silencieux sans phrase-keyword sous Git Bash Windows). Après refresh, rebase + force-push SUCCESS, et les 3 fichiers sont maintenant dans la tête `eb0e9aa1045f`.

Périmètre effectif de cette tête : **3 fichiers** — `.github/workflows/stale-guard-red-sweep.yml`, `scripts/check_stale_guard_reds.py`, `scripts/tests/test_check_stale_guard_reds.py`.

### Le livrable

- **`scripts/check_stale_guard_reds.py`** — l'organe. Advisory : date le rouge d'une PR par la **base gelée testée par son run** (premier parent du `head_sha` du RUN — le commit de main contre lequel CE run a été joué), **pas par `completedAt`** (criterion 1 : une relation d'ancêtré, immune au clock skew, aux runs rejoués et à la dérive de merge-ref).
- **`scripts/tests/test_check_stale_guard_reds.py`** — 20 tests, `analyse()` pur, zéro réseau.
- **`.github/workflows/stale-guard-red-sweep.yml`** — cron quotidien `53 4 * * *` + `workflow_dispatch` (dry_run), sparse-checkout du seul script, exit 0 toujours.

### La méthode (générique, aucun mappage nom-de-test → fichier)

1. Le check rouge porte `details_url` → run_id → workflow émetteur.
2. Historique des runs de CE workflow sur `main` (fenêtre **120** — à ~65 pushes/jour, une fenêtre de 30 couvre 11 h et le fix de la bande fondatrice en était déjà sorti, mesuré au dry-run) ; verdict du check de même nom par run, attribution par run_id (fold #11808, jamais le nom seul).
3. La transition rouge→vert la plus récente localise le fix : `fix_head` = head du premier run VERT après le dernier ROUGE.
4. **Rouge périmé ssi** : garde vert sur main à sa version courante **ET** `fix_head` **PAS** ancêtre de la **base GELÉE testée par le run** (compare REST `fix_head...base`, status ≠ `ahead`).

**Correction d'instrument découverte au dry-run réel (#13156)** : la merge-ref COURANTE de la PR (`pulls[].merge_commit_sha`) **dérive** — GitHub la recalcule quand main bouge, même sans push sur la PR (mesuré : head 08-26T18:47, run rouge 21:59, fix 08-27T08:53, et pourtant le parent de la merge-ref courante contient le fix). Dater par elle déclarerait « vrai défaut » un rouge rendu contre une base antérieure. L'instrument juste est le **`head_sha` du RUN lui-même** (merge-ref gelée au moment du run) — son premier parent est la base contre laquelle CE run a été joué, immuable. Les runs push-event (head_sha = tête de branche) n'ont testé aucune base : exclusion nommée.

### Les criterions d'acceptance, couverts par des tests nommés

| # | Criterion | Test |
|---|---|---|
| 1 | datation par base gelée du run, pas completedAt ni merge-ref courante | `test_stale_red_flagged_with_update_branch_remedy` + `test_current_merge_ref_drift_does_not_hide_stale_red` + `test_push_event_run_without_merge_base_excluded` |
| 2 | signal label+commentaire, jamais rebase | `apply()` : label `stale-guard-red` + commentaire, dédupe par label |
| 3 | remede `update-branch`, jamais `rerun` | `test_rerun_would_replay_frozen_base_documented` + `test_flake_same_base_green_sibling_not_prescribed_update_branch` |
| 4 | **contrôle positif** : rouge postérieur au fix NON signalé | `test_red_posterior_to_fix_not_flagged` (« vrai defaut, ne pas signaler ») |
| 5 | dénominateur rendu | `test_denominator_reported` + dry-run réel ci-dessous |

**Deux protections anti-blanchiment en plus** : garde rouge sur main à sa version courante → exclusion nommée (vrai problème, pas un rouge périmé) ; aucune transition rouge→vert dans la fenêtre → exclusion nommée (rouge vraisemblablement propre à la PR). **Disjointness avec pr-gate-stale-sweep** : un vert de même nom sur la même tête (flake) est exclu et renvoyé vers la voie `rerun` de l'autre sweep ; les rouges `PR gate` sont hors scope.

### Dry-run réel (criterion 5, mesuré pas déclaré)

Exécuté en lecture seule contre le dépôt réel le 2026-08-28.

| Mesure | Valeur |
|---|---|
| PR examinées | **134** |
| **Signalées** | **19** |
| Exclues (nommées) | 62 |

**La bande fondatrice ressort, plus large que le plancher mesuré par ai-01** (11 PRs #13156..#13204) : le sweep date la **classe entière** sur ~2 semaines — `#12512 #12769 #12775 #12777 #12859 #12864 #12870 #12883 #12888 #12925 #13017 #13078 #13092 #13125 #13143 #13156 #13181 #13203 #13204`. Toutes portent le même `Scripts Tests (CPU)` rouge, fix `62d47eb7df1` (#13148, 2026-08-27T08:53Z), base gelée antérieure (spot-verify par `gh api compare/fix...base` = `behind` sur 3 échantillons : #13156 `5ee60a40`, #13181 `72beb0cc`, #12512 `51e11158`).

Exclusions nommées notables : 33× « le check ne tourne jamais sur main » (gardes pull_request-only, ex. Require Grain tag — indatables), 17× « aucune transition rouge→vert dans la fenêtre » (garde vert de tout temps : rouge propre à la PR), 5× « garde rouge sur main à sa version courante » (vrai problème, pas un rouge périmé), 1× « base POSTERIEURE au fix » (contrôle positif #13156-range : vrai défaut, non signalé), 2× flake même base gelée (routé vers `gh run rerun`).

### Validation

- `python -m pytest scripts/tests/test_check_stale_guard_reds.py -q` → **20 passed** (relancé après la dernière édition).
- `test_check_testpaths_coverage.py` → 5 passed (le nouveau fichier est collecté).
- YAML workflow parsé, structure vérifiée (job `sweep`, 2 steps).
- Dry-run lecture-seule exécuté contre le dépôt réel (sortie ci-dessus), dump de collecte conservé pour rejeu (`--from-json`).

### Choix de design notables

- **Cron quotidien** (pas horaire comme le sweep PR gate) : celui-ci file un advisory dont le remède est exécuté par les lanes propriétaires, une tête à la fois — la contrainte de #13321 est l'ordonnancement sous famine CI (#11860), pas la vitesse de détection.
- **Le remède n'est jamais exécuté par l'organe** : 11 update-branches = ~350 runs dans la file de 634. Il signale ; les lanes rattrapent.
- **`--dump`/`--from-json`** : la collecte (réseau) est rejouable hors-ligne pour déboguer un verdict contesté.


