### PR TITLE
docs(rl,#13351): GAE attribution Schulman 2016 -> 2015 (rl_6c cell 23)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb
@@ -1051,7 +1051,7 @@
    "source": [
     "## 5. Generalized Advantage Estimation (GAE)\n",
     "\n",
-    "Jusqu'ici nous avons utilise un estimateur d'avantage simple : $A_t = R_t - V(s_t)$. GAE (Schulman 2016) offre un meilleur compromis biais-variance :\n",
+    "Jusqu'ici nous avons utilise un estimateur d'avantage simple : $A_t = R_t - V(s_t)$. GAE (Schulman 2015) offre un meilleur compromis biais-variance :\n",
     "\n",
     "$$\\hat{A}^{GAE(\\gamma, \\lambda)}_t = \\sum_{l=0}^{\\infty} (\\gamma \\lambda)^l \\delta_{t+l}$$\n",
     "\n",


### PR DESCRIPTION
Closes #13351

## Summary

Corrige la dérive substance signalée par le preflight po-2025 sur `origin/main` : la cellule 23 (prose pédagogique, ligne 1054) de `rl_6c_ppo_from_scratch.ipynb` portait encore `GAE (Schulman 2016)` après la passe #12838 (la cellule références corrigée avait été convertie en exercice TODO, la cellule prose a été manquée).

## Changement

- 1 cellule markdown : `GAE (Schulman 2016) offre` → `GAE (Schulman 2015) offre` — aligné sur la forme corrigée des « Ancres savantes » (cellule 1) et de la bibliographie (cellule 31) déjà sur main.
- Markdown-only → exception C.2 (outputs précédents valides, aucune re-exécution requise) ; aucune cellule code touchée.

## Vérification

- `git grep -c "Schulman 2016|2016.*High-Dimensional"` sur le notebook : **0** après fix (1 avant).
- Diff : 1 fichier, +1/−1 (chirurgical).
- Note : le body de #13351 mentionne un mot-cle de fermeture vers **#13365** — c'est une coquille pour **#13351** (cette PR ferme bien #13351 ; #13365 est la collision GT-06d, sans rapport).

## Grain

Grain: LIGHT/docs (attribution arXiv) — lane myia-po-2026:CoursIA — prev: DEEP/lean #13353 (PR #13356). Plafond LIGHT 1/lane/jour respecté (premier LIGHT du jour pour cette lane).

## Test plan

- [x] Grep résiduel 0 sur le notebook
- [x] Pre-commit H.3 + gitleaks Passed
- [ ] Merge ai-01 (file #13097)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

