### PR TITLE
feat(ci,#13331): wire detect-dup live self-test into daily network sweep + blind-window negative control

### DIFF
--- a/.github/workflows/detect-dup-selftest.yml
+++ b/.github/workflows/detect-dup-selftest.yml
@@ -1,0 +1,98 @@
+name: Detect-Duplicate Self-Test
+
+# Organ for #13331: the live positive control of detect_duplicate_issues.py
+# (pair #13050/#13051, delta 1 s, #13208) was valid but DEBRANCHE -- gated
+# behind DETECT_DUP_NETWORK, posed nowhere. A control that never runs has
+# the same CI signature as a broken detector: green and silent.
+#
+# This daily sweep runs the control REALLY, on a network-enabled trigger
+# (schedule + workflow_dispatch -- NOT pull_request: it consumes
+# `gh issue list` quota and does not need per-PR execution).
+#
+# One step per acceptance criterion of #13331:
+#   4. Without the env var the live pytest test SKIPS (visible in the log)
+#      while unit tests still run -- the offline developer path is intact.
+#   1. With DETECT_DUP_NETWORK=1 the live test runs (not skipped) and the
+#      CLI scan prints the pair #13050/#13051 in its JSON output. Exit 1
+#      (real duplicates found -- the pair itself) is healthy; only exit 2
+#      (positive control missing) is broken.
+#   2. Negative control: a blind window (--window-seconds 0) must render
+#      ZERO pairs -- distinguishing "0 doublon" from "detecteur muet".
+#   3. Failure visibility: under the blind window the control MUST go
+#      missing and the CLI MUST exit 2 -- if blindness stops producing
+#      exit 2, the job goes red.
+
+on:
+  schedule:
+    # Daily, off-:00 minute (anti-stampede). 04:41 UTC.
+    - cron: '41 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: detect-dup-selftest
+  cancel-in-progress: false
+
+jobs:
+  self-test:
+    name: "Live positive control #13050/#13051 (detect-dup self-test)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      # Criterion 4: the skip path stays possible offline.
+      - name: Unit tests (live test SKIPS without DETECT_DUP_NETWORK)
+        run: python -m pytest scripts/tests/test_detect_duplicate_issues.py -v
+
+      # Criterion 1: the control executes via pytest too.
+      - name: Live self-test via pytest (positive control)
+        env:
+          DETECT_DUP_NETWORK: '1'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python -m pytest scripts/tests/test_detect_duplicate_issues.py -v -k SelfTestCLI
+
+      # Criterion 1 (pair visible): the CLI scan itself. #8894 lesson --
+      # capture the exit code with `&& RC=0 || RC=$?`, never `RC=$?` alone
+      # (bash -e kills the step before the capture on the non-zero path).
+      - name: Live CLI scan (pair #13050/#13051 must appear in output)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/detect_duplicate_issues.py --self-test --limit 600 --window-seconds 60 && RC=0 || RC=$?
+          echo "cli-exit=$RC"
+          if [ "$RC" -eq 2 ]; then
+            echo "SELF-TEST BROKEN: positive control #13050/#13051 missing"
+            exit 1
+          fi
+          if [ "$RC" -gt 1 ]; then
+            exit 1
+          fi
+
+      # Criteria 2 + 3: the blind window renders zero AND flips the CLI to
+      # exit 2. Two independent assertions.
+      - name: Negative control (window 0 renders zero pairs, exit 2)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/detect_duplicate_issues.py --self-test --limit 600 --window-seconds 0 > blind.json 2> blind.err && RC=0 || RC=$?
+          echo "cli-exit=$RC"
+          cat blind.err
+          N_PAIRS=$(python -c "import json;print(json.load(open('blind.json'))['n_pairs'])")
+          echo "n_pairs(window=0)=$N_PAIRS"
+          if [ "$N_PAIRS" -ne 0 ]; then
+            echo "NEGATIVE CONTROL BROKEN: window 0 must render zero pairs (a same-second burst would be a REAL finding -- triage it)"
+            exit 1
+          fi
+          if [ "$RC" -ne 2 ]; then
+            echo "FAILURE-VISIBILITY BROKEN: the blind window must flip the CLI to exit 2"
+            exit 1
+          fi

--- a/scripts/detect_duplicate_issues.py
+++ b/scripts/detect_duplicate_issues.py
@@ -45,6 +45,11 @@ Usage
     # Self-test (must include the #13050/#13051 pair, otherwise exit 2):
     python scripts/detect_duplicate_issues.py --self-test
 
+    # The live self-test is wired daily (network trigger) by
+    # .github/workflows/detect-dup-selftest.yml -- DETECT_DUP_NETWORK gates
+    # only the pytest live test, so offline `python -m pytest` still passes
+    # (#13331).
+
 Exit codes:
   0 -- no duplicates found, OR scan completed cleanly under --self-test.
   1 -- duplicates found (non-zero pair count).
@@ -146,7 +151,8 @@ def _gh_issue_list(limit: int, state: str = "all") -> list[dict]:
             "--state", state,
             "--json", "number,title,createdAt,state",
         ],
-        capture_output=True, text=True, timeout=120,
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        timeout=120,
     )
     if proc.returncode != 0:
         raise RuntimeError(

--- a/scripts/tests/test_detect_duplicate_issues.py
+++ b/scripts/tests/test_detect_duplicate_issues.py
@@ -190,13 +190,63 @@ class TestSelfTestCLI(unittest.TestCase):
                 sys.executable, str(_SCRIPT),
                 "--self-test", "--limit", "600", "--window-seconds", "60",
             ],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=120,
         )
         self.assertNotEqual(
             proc.returncode, 2,
             f"self-test FAILED: positive control #13050/#13051 missing.\n"
             f"stdout: {proc.stdout[-500:]}\nstderr: {proc.stderr[-500:]}",
         )
+
+
+class TestSelfTestExitContract(unittest.TestCase):
+    """#13331: the --self-test exit contract, exercised WITHOUT network by
+    patching `_gh_issue_list`. Failure visibility (criterion 3) lives here:
+    a blind window MUST flip the CLI to exit 2, and a missing control MUST
+    take precedence over the duplicates-found exit 1."""
+
+    @staticmethod
+    def _gh_rows(*specs: tuple[int, str, str]) -> list[dict]:
+        return [
+            {"number": n, "title": t, "createdAt": iso, "state": "OPEN"}
+            for n, t, iso in specs
+        ]
+
+    def test_cli_exit_1_when_control_found(self):
+        """Healthy scan: the pair is a real duplicate -> exit 1, never 2."""
+        rows = self._gh_rows(
+            (13050, "[Lean-2] exemple", "2026-08-26T01:39:13Z"),
+            (13051, "[Lean-2] exemple", "2026-08-26T01:39:14Z"),
+        )
+        from unittest import mock
+        with mock.patch.object(_mod, "_gh_issue_list", return_value=rows):
+            rc = _mod._cli(["--self-test", "--limit", "10"])
+        self.assertEqual(rc, 1)
+
+    def test_cli_exit_2_when_control_missing(self):
+        """Control missing -> exit 2, even though other pairs exist
+        (exit 2 takes precedence over exit 1)."""
+        rows = self._gh_rows(
+            (1, "foo", "2026-08-26T01:00:00Z"),
+            (2, "foo", "2026-08-26T01:00:01Z"),
+        )
+        from unittest import mock
+        with mock.patch.object(_mod, "_gh_issue_list", return_value=rows):
+            rc = _mod._cli(["--self-test", "--limit", "10"])
+        self.assertEqual(rc, 2)
+
+    def test_blind_window_drops_control(self):
+        """Window 0 (blind): the known pair's delta (1 s) falls outside the
+        window -> zero pairs, control reported MISSING. This is the exact
+        shape the negative-control workflow step asserts on live data."""
+        rows = [
+            _row(13050, "foo", "2026-08-26T01:39:13Z"),
+            _row(13051, "foo", "2026-08-26T01:39:14Z"),
+        ]
+        result = detect_burst_pairs(rows, window_seconds=0)
+        self.assertEqual(result.n_pairs, 0)
+        self.assertIn((13050, 13051), result.positive_controls_missing)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The live positive control of `detect_duplicate_issues.py` (pair #13050/#13051, delta 1 s, #13208) was **valid but debranche**: gated behind `DETECT_DUP_NETWORK`, posed nowhere. A control that never runs has the same CI signature as a broken detector — green, silent. Hermes flagged it as non-blocking hygiene on #13210; this PR does the wiring.

### Workflow `.github/workflows/detect-dup-selftest.yml`

Daily 04:41 UTC (off-:00 minute) + `workflow_dispatch` — **not** `pull_request` (consumes `gh issue list` quota, no per-PR value). One step per acceptance criterion:

| Step | Criterion | Contract |
|---|---|---|
| Unit tests (no env var) | 4 | live test shows **SKIPPED** in the log — offline dev path intact |
| Live pytest (`DETECT_DUP_NETWORK=1`) | 1 | live test runs, `PASSED` line visible |
| Live CLI scan | 1 | pair **#13050/#13051 appears in the printed JSON**; exit 0/1 healthy, exit 2 = broken → red |
| Negative control | 2+3 | `--window-seconds 0` must render `n_pairs=0` **and** flip CLI to **exit 2**; either failing → job red |

Exit codes captured with `&& RC=0 || RC=$?` (#8894 `bash -e` lesson — `RC=$?` alone never runs on the failing path).

### Unit tests (network-free)

`TestSelfTestExitContract` (mock `_gh_issue_list`): exit 1 when control found · **exit 2 takes precedence** when control missing · blind window (0 s) drops the control (the exact shape the workflow's negative step asserts on live data).

Also: `encoding="utf-8"` added to the two pre-existing `subprocess` calls (pre-commit guard #12811 — cp1252 hosts crash on the French titles in `gh` output).

## Validation

- Offline suite: **16 passed + 1 skipped** (the live test, criterion 4 path).
- **Live pre-validation from a workstation** (same commands the workflow runs):
  - healthy: `cli-exit=1`, `\"a_number\": 13050` present in JSON;
  - blind: `cli-exit=2`, `n_pairs = 0`, stderr `WARNING: positive controls MISSING -- #13050/13051`.
- Workflow-count guards: `total_workflows >= 40` is a floor (raised, safe); job name unique (`check_unique_check_run_names`); `ubuntu-latest` (self-hosted policy compliant); no `paths:` filters involved.

## Acceptance vs #13331 — one residual

Criteria 2, 3, 4: **done and visible** (unit tests + workflow steps). Criterion 1: the script wiring is complete and pre-validated, but the **run link can only exist post-merge** — `workflow_dispatch` returns 404 for a workflow absent from the default branch (measured: `HTTP 404: workflow detect-dup-selftest.yml not found on the default branch`). Immediately after merge: dispatch + run-link comment on #13331. Hence `See` (not `Closes`).

Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13361

See #13331

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
