### PR TITLE
fix(slides,#13345): ligne vide après le </div> seul — corpus zéro, ratchet tenu par le test

### DIFF
--- a/scripts/notebook_tools/scan_slides_html_block_markdown.py
+++ b/scripts/notebook_tools/scan_slides_html_block_markdown.py
@@ -48,9 +48,9 @@ the refined rule, the 10 genuine regressions of PR #13096 stand out cleanly.
 Two shapes are reported: a lone **opening** tag (`<div ...>`) and a lone
 **closing** tag (`</div>`). CommonMark HTML block type 6 opens on both, and
 the closing half was missing from the first version of this script -- caught
-by review on #13218 and confirmed at the engine. One real occurrence survives
-on main after the opening-tag burn-down of #13242: `slides/01-introduction`,
-where `</div>` swallows three bullets (tracked by #13345).
+by review on #13218 and confirmed at the engine. One real occurrence survived
+on main after the opening-tag burn-down of #13242 (`slides/01-introduction`,
+`</div>` swallowing three bullets) -- burned down by #13345.
 
 What stays out of scope, deliberately: a tag with trailing content on its
 line (`<div>du texte`, `</div> et du texte`). markdown-it swallows those too,
@@ -65,10 +65,9 @@ Usage
     python scripts/notebook_tools/scan_slides_html_block_markdown.py --json
 
 Exit status is 1 when any violation is found, 0 otherwise. There is NO baseline
-mechanism: the corpus is expected at zero once the last known occurrence is
-burned down (#13345, the closing-tag form in `slides/01-introduction`), at
-which point the scan can be armed as a blocking gate (landing #13360 keeps it
-advisory-unwired until then).
+mechanism: the corpus sits at ZERO since #13345 burned down the last known
+occurrence (the closing-tag form in `slides/01-introduction`), and the corpus
+test in `tests/test_scan_slides_html_block_markdown.py` holds that line.
 """
 
 from __future__ import annotations

--- a/scripts/notebook_tools/tests/test_scan_slides_html_block_markdown.py
+++ b/scripts/notebook_tools/tests/test_scan_slides_html_block_markdown.py
@@ -98,43 +98,18 @@ def test_check_nonexistent_path_returns_2(capsys):
     assert main(["--check", "no/such/path"]) == 2
 
 
-def test_corpus_no_regression_on_decks_fixed_by_13230():
-    """Acceptance #13360 : la sortie ne REGRESSE pas les decks corriges par
-    #13230 (classe balise OUVRANTE). Subtilite mesuree : slides/01-introduction
-    est a la fois un deck #13230 ET le porteur de l'unique occurrence vivante
-    -- de la classe FERMANTE (#13345), pas une regression de #13230. On
-    verifie donc la CLASSE du finding (ligne precedente = `</tag>` seul), pas
-    son numero de ligne (il derive a chaque edition du deck)."""
+def test_corpus_is_zero_after_13345_burn_down():
+    """Corpus ZERO depuis le burn-down de #13345 (la forme fermante survivante
+    de slides/01-introduction). Ce test EST le ratchet : toute reapparition
+    de la classe -- ouvrante (#13230/#13242) ou fermante (#13345) -- sur
+    n'importe quel deck rougit ici, sans attendre un cablage workflow."""
     slides_root = _REPO_ROOT / "slides"
     findings = {}
     for deck in iter_decks(slides_root):
         hits = scan_file(deck)
         if hits:
             findings[deck.relative_to(_REPO_ROOT).as_posix()] = hits
-
-    # Les 2 decks non concernes par #13345 : zero finding.
-    for deck in DECKS_FIXED_BY_13230:
-        if deck == "slides/01-introduction/slides.md":
-            continue
-        assert deck not in findings, f"regression de #13230 sur {deck}"
-
-    # Corpus total connu : exactement 1 occurrence vivante.
-    assert list(findings) == ["slides/01-introduction/slides.md"], findings
-    hits = findings["slides/01-introduction/slides.md"]
-    assert len(hits) == 1, hits
-
-    # Et elle est de la classe FERMANTE (#13345), pas de la classe que
-    # #13230 a corrige (ouvrante) : la ligne precedente est un `</tag>` seul.
-    import re
-    lines = (slides_root / "01-introduction" / "slides.md").read_text(
-        encoding="utf-8"
-    ).split("\n")
-    hit_line = hits[0][0]
-    preceding = lines[hit_line - 2]
-    assert re.match(r"^\s*</[a-zA-Z][a-zA-Z0-9-]*>\s*$", preceding), (
-        f"l'occurrence vivante devait etre de classe fermante (#13345), "
-        f"ligne precedente = {preceding!r}"
-    )
+    assert findings == {}, findings
 
 
 def test_corpus_deck_discovery_is_non_recursive_and_finds_the_deck_dirs():

--- a/slides/01-introduction/slides.md
+++ b/slides/01-introduction/slides.md
@@ -595,6 +595,7 @@ Un agent naif pourrait stocker une table "percepts → action" :<br>la table ser
 
 - Intelligence animale
 </div>
+
 - Behaviourism
 - Artificial Life
 - Cellular Automata


### PR DESCRIPTION
## Summary

Burn-down de l'unique occurrence survivante de la classe « markdown avalé par un bloc HTML » : la forme **FERMANTE** (un `</div>` seul ouvre aussi un bloc HTML CommonMark type 6) que les fix #13242/#13230 — produits avec le détecteur ne modélisant que les ouvrantes — ne pouvaient pas voir.

**STACK sur #13364** (`feature/13216-land-html-block-detector`) : l'acceptance de #13345 dépend du détecteur (« Depend de #13218 pour que le detecteur voie le cas »), qui n'est pas encore sur `main`. **Merger #13364 d'abord.**

## Acceptance vs #13345 (3/3)

| # | Critère | Preuve |
|---|---|---|
| 1 | Ligne vide insérée après le `</div>` L597 de `slides/01-introduction/slides.md` | fait — diff **strictement additif, +1 ligne, 0 suppression** |
| 2 | Scanner rend `violations: 0` sur les 36 decks (il rend `1` aujourd'hui) | mesuré : `{"decks_scanned": 36, "violations": 0, "by_deck": {}}`, exit 0 |
| 3 | Contrôle négatif : aucun `<div ...>` déjà suivi d'une ligne vide modifié | le diff ne touche qu'une ligne du deck ; le `<div v-click="1">`/blanc des L590-591 est intact |

## Vérification au moteur (le défaut est visuel — preuve mécanique de la restauration)

markdown-it **14.1.1** (le moteur que Slidev utilise, install du repo) sur le snippet exact :

- **AVANT** : `- Behaviourism` rend en texte littéral — aucun `<li>` dans la sortie.
- **APRÈS** : `- Behaviourism` rend comme vrai `<li>` dans un `<ul>`.

La vérification du rendu à l'écran (slide réelle, `?clicks=99`) reste au merge-gate visuel (lane CoursIA-2/ai-01) conformément au capability-routing ; la restauration est prouvée au niveau du moteur ici.

## Le ratchet

Le test corpus passe de « exactement 1 occurrence vivante connue » à **`findings == {}`** : toute réapparition de la classe — ouvrante OU fermante — sur n'importe quel deck rougit en local, sans attendre un câblage workflow (le corpus test court avec la suite scripts). Le docstring du scanner est aligné sur l'état post-burn-down.

## Validation

- `python -m pytest scripts/notebook_tools/tests/test_scan_slides_html_block_markdown.py` → **12 passed** (sur branche stackée contenant le détecteur).
- Diff total : 3 fichiers, +13/−38 (le − vient du test qui simplifie + docstring, le deck lui-même +1/−0).

Grain: LIGHT/slides (fix 1 ligne + alignement test)

Closes #13345 · See #13216 (classe gardée) · stack sur #13364

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>