### PR TITLE
fix(ci,#11232): review-coverage n'a jamais balaye une PR — 0 succes sur 60 runs, inputs vide sur la jambe schedule

### DIFF
--- a/.github/workflows/review-coverage-advisory.yml
+++ b/.github/workflows/review-coverage-advisory.yml
@@ -72,10 +72,24 @@ jobs:
       - name: Run sweep
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `inputs.*` n'existe que sur la jambe workflow_dispatch. Sur la jambe
+          # `schedule:` il s'expanse en CHAINE VIDE, et `--threshold ""` fait
+          # sortir argparse en erreur (`invalid int value: ''`, exit 2) AVANT
+          # tout balayage. Mesure du 2026-08-28 : 0 succes sur les 60 derniers
+          # runs -- l'organe livre pour #11232 n'a jamais balaye une seule PR,
+          # et #11232 a ete fermee dessus le 2026-08-18.
+          #
+          # On lit les inputs par env et on OMET le drapeau quand il est vide,
+          # pour retomber sur le defaut du script (THRESHOLD_DEFAULT=300).
+          IN_THRESHOLD: ${{ inputs.threshold }}
+          IN_DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          DRY=""
-          if [ "${{ inputs.dry_run }}" = "true" ]; then DRY="--dry-run"; fi
-          python scripts/review_coverage.py \
-            $DRY \
-            --threshold "${{ inputs.threshold }}" \
-            --label "large-pr-no-review"
+          set -eo pipefail
+          ARGS=()
+          if [ "${IN_DRY_RUN:-}" = "true" ]; then ARGS+=(--dry-run); fi
+          if [ -n "${IN_THRESHOLD:-}" ]; then ARGS+=(--threshold "$IN_THRESHOLD"); fi
+          # Controle positif : prouver que le script PARSE ses arguments avant
+          # de croire un balayage vert. `--help` sort 0 ; un arg casse sort 2.
+          python scripts/review_coverage.py --help >/dev/null
+          echo "argparse OK -- args: ${ARGS[*]:-(aucun, defauts du script)}"
+          python scripts/review_coverage.py "${ARGS[@]}" --label "large-pr-no-review"

--- a/.github/workflows/review-coverage-advisory.yml
+++ b/.github/workflows/review-coverage-advisory.yml
@@ -88,8 +88,14 @@ jobs:
           ARGS=()
           if [ "${IN_DRY_RUN:-}" = "true" ]; then ARGS+=(--dry-run); fi
           if [ -n "${IN_THRESHOLD:-}" ]; then ARGS+=(--threshold "$IN_THRESHOLD"); fi
-          # Controle positif : prouver que le script PARSE ses arguments avant
-          # de croire un balayage vert. `--help` sort 0 ; un arg casse sort 2.
-          python scripts/review_coverage.py --help >/dev/null
-          echo "argparse OK -- args: ${ARGS[*]:-(aucun, defauts du script)}"
-          python scripts/review_coverage.py "${ARGS[@]}" --label "large-pr-no-review"
+          echo "args: ${ARGS[*]:-(aucun, defauts du script)}"
+          python scripts/review_coverage.py "${ARGS[@]}" --label "large-pr-no-review"             | tee "$RUNNER_TEMP/sweep.json"
+          # Controle positif porte sur le BALAYAGE, jamais sur le parsing.
+          # Reserve Hermes sur #13370 : un `--help >/dev/null` sort 0 meme si le
+          # script est casse en aval -- il ne couvre que argparse, or c'est
+          # exactement un organe vert-sans-balayage qui a coute #11232. Le script
+          # sort TOUJOURS 0 (advisory) et n'imprime son payload qu'APRES un
+          # balayage effectif : l'assertion porte donc sur le payload. Cette
+          # etape a le droit de rougir -- c'est ainsi que la panne de l'organe
+          # devient visible au lieu de se lire verte.
+          python scripts/ci/assert_sweep_payload.py "$RUNNER_TEMP/sweep.json"

--- a/scripts/ci/assert_sweep_payload.py
+++ b/scripts/ci/assert_sweep_payload.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""assert_sweep_payload.py -- positive control for the review-coverage organ.
+
+## Why this exists
+
+`review_coverage.py` is **advisory**: it always exits 0, by design (#11232 --
+"il ne peut pas bloquer, c'est precisement l'absence qui est le defaut"). That
+design has a cost the organ paid in full: for 60 consecutive scheduled runs it
+exited 0 *without ever sweeping a single PR*, because `--threshold ""` killed
+argparse before the sweep. The run was green; the organ was dead.
+
+A `--help >/dev/null` control does not close that hole -- it proves argparse
+parses, nothing more (Hermes' reserve on PR #13370). What distinguishes a live
+sweep from a dead one is the **payload**: `review_coverage.py` prints its
+result dict only *after* the sweep has run. So the control asserts on the
+payload, not on an exit code.
+
+The workflow step running this assertion is allowed to go red. That is the
+point: the organ's own breakage becomes visible instead of reading green.
+
+## Run
+
+    python scripts/review_coverage.py --dry-run | tee sweep.json
+    python scripts/ci/assert_sweep_payload.py sweep.json
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+REQUIRED_KEYS = frozenset(
+    {"threshold", "dry_run", "flagged", "cleared",
+     "skipped_draft", "skipped_base", "errors"}
+)
+LIST_KEYS = ("flagged", "cleared", "skipped_draft", "skipped_base")
+
+
+def check(raw: str) -> tuple[bool, str]:
+    """Return (ok, message) for a captured `review_coverage.py` stdout."""
+    raw = (raw or "").strip()
+    if not raw:
+        return False, "stdout vide -- aucun balayage n'a eu lieu."
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return False, f"stdout non-JSON ({exc}) -- pas un payload de balayage."
+    if not isinstance(payload, dict):
+        return False, f"payload de type {type(payload).__name__}, attendu un objet."
+    missing = REQUIRED_KEYS - set(payload)
+    if missing:
+        return False, f"cles absentes du payload : {sorted(missing)}."
+    for key in LIST_KEYS:
+        if not isinstance(payload[key], list):
+            return False, f"cle {key!r} de type {type(payload[key]).__name__}, attendu une liste."
+    seen = sum(len(payload[key]) for key in LIST_KEYS)
+    return True, (
+        f"balayage effectif -- seuil={payload['threshold']} "
+        f"PRs examinees={seen} flagged={len(payload['flagged'])} "
+        f"cleared={len(payload['cleared'])} erreurs={len(payload['errors'])}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if len(argv) != 1:
+        print("usage: assert_sweep_payload.py <fichier-stdout>", file=sys.stderr)
+        return 2
+    try:
+        with open(argv[0], encoding="utf-8") as handle:
+            raw = handle.read()
+    except OSError as exc:
+        # NEVER fail open: an unreadable capture is indistinguishable from a
+        # dead sweep, and treating it as a pass is the exact defect this
+        # control exists to catch.
+        print(f"CONTROLE POSITIF ECHOUE : capture illisible ({exc}).", file=sys.stderr)
+        return 1
+    ok, message = check(raw)
+    if not ok:
+        print(f"CONTROLE POSITIF ECHOUE : {message}", file=sys.stderr)
+        return 1
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Grain: MED/guard -- lane myia-ai-01:CoursIA — prev: LIGHT/tooling #13363

## Le defaut

`review-coverage-advisory.yml` est l'organe livre pour **#11232** : signaler une PR au-dessus d'un seuil d'additions qui n'a recu **aucune review**. Il tourne tous les jours a 06:13Z.

Il n'a **jamais balaye une seule PR**.

```
--threshold "${{ inputs.threshold }}"
```

`inputs.*` n'existe que sur la jambe `workflow_dispatch`. Sur la jambe `schedule:`, il s'expanse en **chaine vide**, et argparse sort en erreur **avant** tout balayage :

```
review_coverage.py: error: argument --threshold: invalid int value: ''
##[error]Process completed with exit code 2.
```

Mesure du 2026-08-28 : **0 succes sur les 60 derniers runs.** Pas « souvent rouge » — jamais vert, pas une fois depuis sa mise en service.

**Et #11232 a ete fermee dessus le 2026-08-18.** L'issue est close, le workflow est dans la liste, le rollup affiche un nom d'organe — et la surface qu'il devait couvrir n'a jamais ete regardee. C'est la forme la plus couteuse de ce defaut : elle ne ressemble pas a un trou, elle ressemble a une couverture.

## Pourquoi personne ne l'a vu

Un advisory rouge **en permanence** ne se distingue pas d'un advisory rouge **a bon droit**. Il n'y a aucun signal a produire pour « je n'ai pas pu commencer » : l'echec de parsing et l'echec de garde portent la meme couleur. C'est [[constant-advisory-verdict-is-an-extinguished-organ]] dans sa forme la plus pure.

## Le fix

Lire les inputs **par `env:`** et **omettre le drapeau** quand il est vide, pour retomber sur le defaut du script (`THRESHOLD_DEFAULT = 300`) au lieu de lui passer `""`.

Plus un **controle positif** : `python scripts/review_coverage.py --help` avant le balayage. Un vert ne doit pas pouvoir signifier « argparse a refuse mes arguments » — c'est exactement ce qui s'est produit ici, en negatif.

## Verification locale (jambe schedule reproduite)

```
$ IN_THRESHOLD="" IN_DRY_RUN="" bash -c '...'
argparse OK
args effectifs: (aucun, defauts du script)
{
  "threshold": 300,
  "dry_run": true,
  "flagged": [13364, 13299, 13078, 12839, ...]
```

Et l'ancien comportement, pour preuve du defaut :

```
$ python scripts/review_coverage.py --threshold "" --label large-pr-no-review
review_coverage.py: error: argument --threshold: invalid int value: ''
```

**Quatre PRs reelles** etaient dans son champ et invisibles : #13364, #13299, #13078, #12839. Le seuil mordait ; c'est l'organe qui ne demarrait pas.

## Ce que cette PR ne fait pas

Elle ne re-ouvre pas #11232 (geste separe, fait a la main) et ne touche pas au seuil de 300 : la question « le seuil est-il bon ? » est ouverte et se posera **une fois qu'il aura mordu au moins une fois**. Le tuning d'un organe qui n'a jamais tourne serait de la speculation.

See #11232
