### PR TITLE
docs(gametheory,#13341): GT-06 miroir ESS relatif au pool de mutants

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust.ipynb
@@ -1723,32 +1723,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation : ESS, NSS et la subtilité que la note initiale masquait\n",
-    "\n",
-    "Appliqué à la matrice committée, le critère rend un verdict **inattendu** et **honnête** :\n",
-    "\n",
-    "| Stratégie | ESS ? | Pourquoi |\n",
-    "|-----------|-------|----------|\n",
-    "| TitForTat | **NON** | Mutant neutre AlwaysCooperate : `u(TFT,TFT) = u(AC,TFT) = 3.00` et `u(TFT,AC) = u(AC,AC) = 3.00`. C'est une **NSS**, pas une ESS. |\n",
-    "| AlwaysCooperate | **NON** | Neutre contre TitForTat, et exploitable par AlwaysDefect (`u(AC,AD) = 0.00`). |\n",
-    "| AlwaysDefect | **OUI** (au sens pair-à-pair) | `u(AD,AD) = 1.00 > u(TFT,AD) = 0.99` et `u(AD,AD) = 1.00 > u(AC,AD) = 0.00` : il gagne le face-à-face contre les deux. |\n",
-    "\n",
-    "Le point délicat : **AlwaysDefect est une ESS *stricte* au sens de Maynard Smith, pourtant la dynamique du\n",
-    "réplicateur l'élimine** (0,0 % à l'état final). Ce n'est pas une contradiction de la théorie, c'en est la portée\n",
-    "exacte : une ESS garantit la stabilité **locale** (une population presque toute-AD résiste à une petite invasion),\n",
-    "**pas** la convergence **globale** depuis n'importe quelle composition. Ici AD ne prospère qu'en présence de sa\n",
-    "« proie » (AlwaysCooperate, qui lui rapporte 5.00) ; dès qu'il l'élimine, sa propre fitness s'effondre et\n",
-    "TitForTat reprend l'avantage. La dynamique emmène donc la population vers la **face neutre TFT-AC** — un\n",
-    "continuum de points de repos — et non vers l'ESS locale AD.\n",
-    "\n",
-    "Ce que cela enseigne — et corrige — la note de la section 5 : **« TitForTat est une ESS » était faux**, et la\n",
-    "version « la coopération évolue » mérite d'être nuancée. TitForTat est **neutrement stable**, et l'équilibre\n",
-    "observé (77,5 % / 22,5 %) est un **point de repos** choisi par la condition initiale, pas un attracteur que la\n",
-    "dynamique aurait imposé. Une autre `x_0` (cellule 26) donne un autre couple tout aussi « final » : l'ESS est le\n",
-    "bon outil pour poser la question, et le seul moyen de ne pas attribuer au hasard de la condition initiale une\n",
-    "vertu stabilisatrice qu'il n'a pas."
-   ]
+   "source": "### Interprétation : ESS, NSS et la subtilité que la note initiale masquait\n\nAppliqué à la matrice committée, le critère rend un verdict **inattendu** et **honnête** :\n\n| Stratégie | ESS ? | Pourquoi |\n|-----------|-------|----------|\n| TitForTat | **NON** | Mutant neutre AlwaysCooperate : `u(TFT,TFT) = u(AC,TFT) = 3.00` et `u(TFT,AC) = u(AC,AC) = 3.00`. C'est une **NSS**, pas une ESS. |\n| AlwaysCooperate | **NON** | Neutre contre TitForTat, et exploitable par AlwaysDefect (`u(AC,AD) = 0.00`). |\n| AlwaysDefect | **OUI** (au sens pair-à-pair) | `u(AD,AD) = 1.00 > u(TFT,AD) = 0.99` et `u(AD,AD) = 1.00 > u(AC,AD) = 0.00` : il gagne le face-à-face contre les deux. |\n\nMiroir dans le jumeau C# (`GameTheory-06-EvolutionTrust-Csharp.ipynb`, pool de **7** stratégies) : là-bas, le verdict d'`AlwaysDefect` tombe à **NSS**. La raison tient en une stratégie absente de ce pool : `SuspiciousTFT` (TFT méfiant, qui déserte la première rencontre puis rend coup pour coup) tire exactement 1.00 contre une population `AlwaysDefect` — `u(STFT,AD) = u(AD,AD) = 1.00`, égalité parfaite — et le face-à-face ne départage pas. Les deux verdicts sont vrais simultanément : **le statut ESS est relatif à l'ensemble des mutants disponibles, il n'est pas une propriété intrinsèque de la stratégie.** Les conclusions ESS de ce notebook (pool de 3 stratégies) ne se transportent donc pas telles quelles dans un pool plus riche.\n\nLe point délicat : **AlwaysDefect est une ESS *stricte* au sens de Maynard Smith, pourtant la dynamique du\nréplicateur l'élimine** (0,0 % à l'état final). Ce n'est pas une contradiction de la théorie, c'en est la portée\nexacte : une ESS garantit la stabilité **locale** (une population presque toute-AD résiste à une petite invasion),\n**pas** la convergence **globale** depuis n'importe quelle composition. Ici AD ne prospère qu'en présence de sa\n« proie » (AlwaysCooperate, qui lui rapporte 5.00) ; dès qu'il l'élimine, sa propre fitness s'effondre et\nTitForTat reprend l'avantage. La dynamique emmène donc la population vers la **face neutre TFT-AC** — un\ncontinuum de points de repos — et non vers l'ESS locale AD.\n\nCe que cela enseigne — et corrige — la note de la section 5 : **« TitForTat est une ESS » était faux**, et la\nversion « la coopération évolue » mérite d'être nuancée. TitForTat est **neutrement stable**, et l'équilibre\nobservé (77,5 % / 22,5 %) est un **point de repos** choisi par la condition initiale, pas un attracteur que la\ndynamique aurait imposé. Une autre `x_0` (cellule 26) donne un autre couple tout aussi « final » : l'ESS est le\nbon outil pour poser la question, et le seul moyen de ne pas attribuer au hasard de la condition initiale une\nvertu stabilisatrice qu'il n'a pas."
   },
   {
    "cell_type": "code",
@@ -2570,7 +2545,7 @@
  "metadata": {
   "cost": {
    "api_provider": "none",
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "cpu_min": 5,
    "external_account": "none",
    "free_alternative": "self",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
@@ -64,6 +64,12 @@
       csharp_sha: d465d4c9c186893032969564dc6cdbe675d1a050
       content_python_sha: 0b4beabc96fb3b3411cfd15c8ac27c31773e974420b2f57734c9d9202f43f812
       content_csharp_sha: 01e5645cc9f961328cdd8b4f145378847b26dfac812d2d99323a8ced083d67be
+    - date: "2026-08-28"
+      by: myia-po-2026:CoursIA
+      python_sha: d6f0bbd99e8818650dd0de46188992867e475a15
+      csharp_sha: d465d4c9c186893032969564dc6cdbe675d1a050
+      content_python_sha: 0088f1f81d7da2b8348c9776765df56268c318c93ba7291df3f3e2ef6effdf0f
+      content_csharp_sha: 01e5645cc9f961328cdd8b4f145378847b26dfac812d2d99323a8ced083d67be
   known_differences:
     - "Socle pedagogique commun : Dilemme du Prisonnier Itere (IPD), tournoi d'Axelrod, strategies classiques (TitForTat, Pavlov, Generous TitForTat), dynamique evolutive (processus de Moran), emergence de la cooperation."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `matplotlib.animation` (viz dynamique du tournoi round-robin + courbes de Moran). C# = pur `System.*` (Collections.Generic, Linq) + moteur IPD from-scratch (T=5/R=3/P=1/S=0 convention Axelrod) ; 0 NuGet tiers."


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/docs #13373

## Summary

Miroir Python de la clarification ESS-relative-au-pool de #13341. L'issue demandait que la subtilité ESS/NSS (le statut ESS dépend du pool de mutants disponibles, il n'est pas une propriété intrinsèque) soit reflétée des DEUX côtés des jumeaux GT-06.

**État à l'ouverture de l'issue** (contre head b662ae4ee) : le côté C# portait la clarification mais pas le côté Python. Vérification sur main actuel : le côté C# est déjà complet (livré dans #12755 même, commit 48cae3f8f — la cellule 20 du jumeau C# contient la subtilité SuspiciousTFT + l'énoncé de relativité). Cette PR couvre donc le miroir Python manquant + le rebaseline du registre twin.

## Livrables (2 commits)

1. `fdc688f5d` — `GameTheory-06-EvolutionTrust.ipynb` (jumeau Python) : paragraphe miroir inséré dans la cellule markdown `c2f12c34` (après la table de verdicts ESS) — explique que le jumeau C# (pool de 7 stratégies) conclut NSS pour `AlwaysDefect` car `u(STFT,AD) = u(AD,AD) = 1.00` (SuspiciousTFT absent du pool Python de 3), et que les deux verdicts sont vrais simultanément : **le statut ESS est relatif à l'ensemble des mutants disponibles**.
2. `8ea1628e5` — registre twin `gametheory-6-evolutiontrust.yaml` : entrée d'audit append-only (python_sha `0b4beabc` → `0088f1f8`, csharp_sha inchangé).

## Critères d'acceptation #13341

| # | Critère | Statut |
|---|---------|--------|
| 1 | Côté C# explique pourquoi AD = NSS (égalité STFT) | Déjà vrai sur main (#12755, commit 48cae3f8f, cellule 20) — grep evidence : « 3 stratégies » count=1, `SuspiciousTFT` présent, énoncé de relativité présent |
| 2 | Côté Python renvoie au jumeau C# pour la divergence de verdict | **Cette PR** (paragraphe miroir cellule `c2f12c34`) |
| 3 | Édition markdown-only | Diff = 0 hunk `execution_count`/`outputs`/`id` ; 23/23 cellules code avec `execution_count` intacts (re-exec non requise, modif markdown seule) |
| 4 | Registre twin rebaseliné, parité OK | `check_twin_parity.py --pair "GameTheory-6 EvolutionTrust" --per-pair --base origin/main` → `[OK] base=OK head=OK` ; total 157/157 OK, INTRO=0 |

## Preuves

- Parité post-rebaseline : `Total : 157 paire(s) | OK=157 INTRO=0 FIXED=0 PRE=0`
- Notebook : 53 cellules, nbformat validate OK, seul le tableau source de `c2f12c34` modifié (resérialisation bénigne du array source : +3/−28)
- Catalogue : byte-identique à main (non touché)

Closes #13341

