### PR TITLE
fix(ci,#13379): le sweep PR-gate draine les candidats du plus ancien au plus recent

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -263,8 +263,33 @@ jobs:
               print(f'{p["number"]} {p["sha"]} {str(p.get("fork", False)).lower()}')
           PY
 
+          # OLDEST FIRST, and the cap is the whole reason it matters.
+          #
+          # `GET /pulls` defaults to `sort=created&direction=desc`, and nothing
+          # downstream re-orders, so `candidates.txt` arrived NEWEST-first and
+          # MAX_POSTS took the newest 8. That is backwards for a capped queue:
+          # a young PR still receives `synchronize` / `reopened` events, and
+          # pr-gate.yml re-runs on each of them, so it has a second repair
+          # path. A quiet old PR emits no more events -- this sweep is its
+          # ONLY one. Newest-first therefore spends the cap on the population
+          # that needs it least and starves the one that has nothing else.
+          #
+          # Measured 2026-08-28T12:33Z (run 33169455408): 16 candidates, cap 8,
+          # served 13355 13347 13343 13332 13320 13286 13195 13191 -- eight
+          # consecutive descending numbers, i.e. exactly the newest eight. At
+          # 14:24Z the five left behind (12390 12534 12791 12995 13091) were
+          # still BLOCKED on stale gates dating from 07:42Z-10:35Z: 4 to 7
+          # hours, on PRs carrying no red constituent at all. The queue makes
+          # the effective cadence ~3 h (sweeps at 01:47, 04:53, 07:44, 12:02),
+          # so "the next sweep takes the next batch" holds only while arrivals
+          # stay under the cap; above it the tail is never reached.
+          #
+          # PR numbers are monotonic in creation time, so a numeric sort IS
+          # the age order -- no extra API call.
+          sort -n -o /tmp/candidates.txt /tmp/candidates.txt
+
           COUNT=$(wc -l < /tmp/candidates.txt | tr -d ' ')
-          echo "[stale-sweep] PRs whose only red is a stale \`PR gate\`: $COUNT"
+          echo "[stale-sweep] PRs whose only red is a stale \`PR gate\`: $COUNT (oldest first)"
           if [ "$COUNT" = "0" ]; then
             echo "[stale-sweep] nothing to do"
             exit 0
@@ -274,7 +299,7 @@ jobs:
           while read -r NUM SHA FORK; do
             [ -z "${NUM:-}" ] && continue
             if [ "$n" -ge "$MAX_POSTS" ]; then
-              echo "[stale-sweep] cap $MAX_POSTS reached -- remaining candidates wait for the next sweep"
+              echo "[stale-sweep] cap $MAX_POSTS reached -- $((COUNT - n)) newer candidate(s) wait for the next sweep"
               break
             fi
             # Re-run the ORIGINAL run rather than POSTing a fresh verdict.


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/docs #13373

## Le defaut

`pr-gate-stale-sweep.yml` sert ses candidats **du plus recent au plus ancien**, sous `MAX_POSTS=8`.
`GET /pulls` trie par `created` DESC, et rien en aval ne re-ordonne : `openprs.txt` -> `runs.jsonl`
-> `candidates.txt` preservent l'ordre, donc le cap consomme les **8 plus recents**.

C'est l'inverse de la priorite utile. Une PR jeune recoit encore des evenements `synchronize` /
`reopened`, et `pr-gate.yml` re-agrege a chacun : elle a un **second** chemin de reparation. Une
vieille PR silencieuse n'emet plus rien — ce sweep est son **seul** chemin.

## La mesure (firsthand, run 33169455408, sweep de 12:02Z)

```
[stale-sweep] PRs whose only red is a stale `PR gate`: 16
[stale-sweep] re-running gate for #13355 #13347 #13343 #13332 #13320 #13286 #13195 #13191
[stale-sweep] cap 8 reached -- remaining candidates wait for the next sweep
```

Huit numeros consecutifs decroissants : exactement les 8 plus recents. A **14:24Z**, les cinq
laisses derriere etaient toujours `BLOCKED`, **sans aucun rouge reel** :

| PR | `PR gate` FAIL a | attente |
|---|---|---|
| #12534 | 07:42:40Z | 6 h 42 |
| #12791 | 07:53:55Z | 6 h 31 |
| #13091 | 08:59:25Z | 5 h 25 |
| #12390 | 09:53:34Z | 4 h 31 |
| #12995 | 10:35:33Z | 3 h 49 |

Les logs `PR gate` lus firsthand disent `FAIL -- timed out waiting for: ... Static validation
(H.1/H.3/C.1)` : **famine de runners**, pas un defaut de la PR. Les constituants ont depuis
conclu au vert sur le meme SHA.

Le commentaire en tete promettait « the next sweep (20 min later) takes the next batch ». Les deux
moities sont fausses aujourd'hui : la cadence reelle est de **~3 h** (sweeps a 01:47, 04:53, 07:44,
12:02 — file de runners, #12728), et « the next batch » n'est le reste que si les arrivees restent
sous le cap.

## Le correctif

Une ligne avant la boucle d'emission :

```bash
sort -n -o /tmp/candidates.txt /tmp/candidates.txt
```

Les numeros de PR sont monotones dans le temps de creation : le tri numerique **est** l'ordre
d'age, sans appel d'API supplementaire. Le message de cap nomme desormais le nombre de differes
(`$((COUNT - n)) newer candidate(s)`), qui sont maintenant les plus **recents** — ceux qui ont un
autre chemin.

## Verification

- **Controle positif du tri** : `13355 12390 13091 12534` -> `sort -n` -> `12390 12534 13091 13355`. Ordre d'age, verifie sur une entree deliberement melangee (pas sur une entree deja triee, qui ne prouverait rien).
- **Arithmetique du cap** : `COUNT=16 n=8` -> `restants=8`.
- **Test seam du selecteur** : `pytest scripts/tests/test_pr_gate_sweep_select.py` -> **14 passed**. Le selecteur n'est pas touche — la selection etait juste, c'est l'**ordre de service** qui ne l'etait pas.
- **YAML** : `yaml.safe_load` du workflow OK ; CRLF preserve (`s.count("\r\n") == s.count("\n")`).

## Deblocage immediat, deja applique

Les cinq PRs du tableau ont recu un `gh run rerun` manuel de leur run `PR gate` a **14:25Z**
(`attempt=2` confirme sur les cinq) — le meme levier que le sweep, applique a la main faute d'ordre
correct. Ce PR fait en sorte que la prochaine fois, personne n'ait a le faire a la main.

## Portee — ce que ce PR NE fait PAS

- Il ne corrige pas la file de runners (#12728), cause de la cadence a ~3 h.
- Il ne change pas la valeur du cap : le probleme n'est pas 8, c'est **qui** 8 sacrifiait.
- Genre `tooling` = classe **META** : ce grain **ne tient pas** le plancher G-VAR-1 du cycle, et je
  ne pretends pas le contraire. Le plancher de contenu du cycle est porte par le merge de #13287
  (GT-06c, `partage_nash` + sensibilite kappa, execution Papermill 45/45).

See 13379
