### PR TITLE
fix(guard,#11947): fences blockquotees bornees verbatim par _inside_fence_lines -- dernier finding heading_in_list etait un FP

### DIFF
--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -230,6 +230,13 @@ _LIST_ITEM_RE = re.compile(r"^\s{0,3}(?:[-*+]|\d{1,9}[.)])\s+")
 # `setext_oversized` false positives (CSP cryptarithmes, Sudoku grids, Mermaid-ish
 # boxes). See PR follow-up to #8392 (same precision vein, different FP family).
 _FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")
+# blockquote prefix (up to 3 nestings, optional space after '>'): a fence can
+# live INSIDE a blockquote (`> ```bash` ... `> ````) and its content still
+# renders verbatim -- CommonMark keeps the fenced block within the quote.
+# _FENCE_RE alone is blind to the prefix, so `_inside_fence_lines` strips it
+# before matching (Search-10-SymbolicAutomata c23: `> # Windows` bash comments
+# inside a blockquoted fence were flagged heading_in_list, a scanner FP).
+_BQ_PREFIX_RE = re.compile(r"^\s{0,3}(?:>\s?){1,3}")
 _YAML_KV_RE = re.compile(r"^\s*[A-Za-z_][\w .\-]*:\s?(\S.*)?$")
 # exercise-hint keywords, word-boundary. Deliberately NOT "note"/"remarque"
 # (those are legitimate section headings, not the oversized-hint defect).
@@ -433,6 +440,35 @@ def _selfcheck() -> int:
         for f in failed:
             print(f"  !! {f}", file=sys.stderr)
         return 1
+    # fence fixtures (#11947 residual): validates the fence oracle itself on its
+    # false negatives. A detection pattern validates on what it must NOT flag:
+    # here, bash comments (`> # Windows`) inside a BLOCKQUOTED fenced block were
+    # the last heading_in_list corpus FP (Search-10-SymbolicAutomata c23) -- the
+    # prefix-blind _FENCE_RE let them reach the prose rules.
+    fence_fixtures: list[tuple[str, list[str], set[int]]] = [
+        # (name, lines, expected inside-set)
+        ("blockquote fence: bash comments are verbatim",
+         ["> ```bash", "> # Windows", "> choco install graphviz", "> ```"],
+         {1, 2}),
+        ("plain fence: content verbatim",
+         ["```bash", "# Windows", "choco install graphviz", "```"],
+         {1, 2}),
+        ("blockquote prose OUTSIDE any fence stays scannable",
+         ["> # Windows", "text"],
+         set()),
+        ("tilde fence inside blockquote",
+         ["> ~~~", "> # note", "> ~~~"],
+         {1}),
+    ]
+    for name, flines, expected in fence_fixtures:
+        got = _inside_fence_lines(flines)
+        if got != expected:
+            failed.append(f"{name}: inside={sorted(got)}, expected={sorted(expected)}")
+    if failed:
+        print("selfcheck FAIL:", file=sys.stderr)
+        for f in failed:
+            print(f"  !! {f}", file=sys.stderr)
+        return 1
     print("selfcheck OK: yaml_block_open_no_close fires on both observed forms "
           "(FallacyDetection/02 + SL-8), silent on bare divider / complete "
           "frontmatter / prose")
@@ -582,13 +618,16 @@ def _inside_fence_lines(lines) -> set[int]:
     setext underline. Backtick and tilde fences are independent: a tilde line never
     closes a backtick block (and vice-versa). An unclosed fence leaves every subsequent
     line inside (defensive: prefer a false-negative on setext over a false-positive).
+    Fence markers may carry a blockquote prefix (``> ```bash``): the prefix is
+    stripped before matching, so blockquoted fences bound their verbatim content
+    exactly like plain ones.
     """
     inside: set[int] = set()
     in_fence = False
     fence_char = None
     fence_len = 0
     for i, ln in enumerate(lines):
-        m = _FENCE_RE.match(ln)
+        m = _FENCE_RE.match(_BQ_PREFIX_RE.sub("", ln, count=1))
         if m:
             marker = m.group(1)
             ch, ln_len = marker[0], len(marker)


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: LIGHT/docs #13375

Closes #11947 (tranche finale : le dernier finding corpus heading_in_list était un FP scanner, pas un défaut de contenu)

## Summary

Vérification de l'urne `delivered` (#11947 labellisée candidate-delivered) : l'acceptance (114 notebooks / 302 cellules → 0) n'était **pas** remplie — re-scan corpus sur origin/main frais : **1 finding résiduel** (Search-10-SymbolicAutomata.ipynb c23), non couvert par les tranches mergées (#11949, #12066, #12087, #12744).

Première mesure (12 findings / 9 notebooks) faite sur l'arbre partagé **stale** — re-mesure sur origin/main frais : 11 des 12 étaient déjà réparés par les merges récents (leçon `scan-origin-main` enfreinte puis corrigée). Le seul vrai résiduel :

```
> ```bash
> # Windows
> choco install graphviz
> # macOS
> brew install graphviz
> # Linux
> sudo apt-get install graphviz
> ```
```

**C'est un faux positif scanner** : `# Windows` est un commentaire bash dans un bloc fence — CommonMark rend le contenu d'une fence **verbatim**, même préfixée de blockquote. GitHub rend ces lignes en code, pas en H1 géant. Le scanner ne les voyait pas comme fence : `_FENCE_RE` ne matche les marqueurs qu'à ≤3 espaces d'indentation, jamais derrière un préfixe `> ` — la fence blockquotée était invisible et son contenu tombait dans les règles de prose.

## Fix (scanner, pas de contenu édité)

- `_inside_fence_lines` strippe le préfixe blockquote (`_BQ_PREFIX_RE`, jusqu'à 3 niveaux) **avant** le match de marqueur — fences blockquotées et plain bornent leur contenu verbatim à l'identique. Le strip ne sert qu'au matching : prose blockquotée hors fence, fences plain et tout le reste inchangés.
- Selfcheck : +4 fixtures oracle-fence (fence blockquotée / fence plain / **prose blockquotée hors fence reste scannable** / tilde blockquoté) — un pattern de détection se valide par ses faux négatifs.

## Validation

- `detect_markdown_rendering.py --selfcheck` → **OK** (4 sections, dont la nouvelle) — le garde CI embarque ce selfcheck.
- `pytest scripts/tests/test_detect_markdown_rendering_repair.py` → **7 passed**
- Rescan corpus complet (le livrable) : `heading_in_list` **1 → 0**, autres règles byte-stables (total 692 → 691 findings ; yaml 539, oversized_hint 147, unclosed_bold 2, cjk 3 inchangés — aucune classe n'a bougé).
- Aucun notebook édité : le contenu était correct, l'outil avait tort.

## Pourquoi `Closes #11947`

L'acceptance de l'issue = remediation des 114 notebooks / 302 cellules. Toutes les tranches de contenu sont mergées ; le résiduel mesuré était ce FP ; après ce fix le scanner rend **0** corpus-wide — vérifié firsthand sur l'arbre complet au HEAD de cette branche.

## G-VAR (déclaré)

MED/**guard** (META) — le plancher G-VAR-1 CONTENU n'est pas tenu par ce grain ; dette déclarée, grain CONTENU visé au prochain cycle de la lane (umbrella QC #11698 en tête de liste).
