### PR TITLE
fix(ci,#12704): explicit fork guard on the self-hosted job (acceptance B item 1)

### DIFF
--- a/.github/workflows/windows-self-hosted-tests.yml
+++ b/.github/workflows/windows-self-hosted-tests.yml
@@ -27,6 +27,12 @@ concurrency:
 jobs:
   windows-confinement-tests:
     name: Scripts Tests (Windows runner)
+    # Acceptance B item 1 (#12704) : garde fork EXPLICITE au niveau job.
+    # Le declencheur actuel est workflow_dispatch seul -- un fork ne peut pas
+    # l'emettre -- mais "pas de trigger" est un etat qu'une ligne de YAML
+    # defait : si un declencheur pull_request est ajoute un jour, un evenement
+    # fork est refuse ICI, defense-in-depth qui ne se defe pas d'un clic d'UI.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, coursia-ephemeral, coursia-fast-guards]
     timeout-minutes: 15
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/guard #13381

See #12704 (acceptance B item 1 — mission ai-01 DM 2026-08-28T14:33Z, ordre strict item 2)

## Summary

Acceptance B item 1 de #12704 : « Les workflows self-hosted refusent les PRs de fork. Garde explicite dans le YAML (`github.event.pull_request.head.repo.full_name == github.repository`), pas seulement un réglage d'UI qu'un clic défait. »

Le seul workflow self-hosted du dépôt (`windows-self-hosted-tests.yml`) est `workflow_dispatch`-seul — un fork **ne peut pas** émettre cet événement (mesuré : triggers = `['workflow_dispatch']` ; grep `pull_request_target` sur les 116 workflows = **0 fichier**, acceptance B item 2). Mais « pas de trigger » est un état qu'une ligne de YAML défait : si un déclencheur `pull_request` est ajouté un jour, un événement fork atteindrait le runner sans cette garde.

Le fix pose la garde **au niveau job** — defense-in-depth : elle survit à l'ajout d'un trigger, et ne se défait pas d'un clic d'UI.

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

Sémantique : les événements non-PR (dont workflow_dispatch) passent inchangés ; un `pull_request` dont la tête vient d'un autre dépôt est refusé.

## Validation

- YAML parse OK (job : garde + runs-on + steps inchangés — diff +6 lignes, rien d'autre touché)
- **Contrôle négatif par payload sur le runner** (acceptance D item 2, « sa simulation par payload » — l'issue le permet explicitement) : branche jetable `feature/runner-fork-sim-12704`, 3 sondes auto-tranchantes exécutées sur `myia-po-2024-fast-guards` — fork PR payload **REFUSED**, same-repo PR payload ALLOWED, workflow_dispatch ALLOWED. Run cité dans le commentaire sur #12704.
- Greps de contrôle (acceptance B item 2) : `pull_request_target` = **0 fichier** sur les 116 workflows ; triggers du workflow self-hosted = `workflow_dispatch` seul.

## À noter pour la lane #12704 (po-2025)

Le garde prédicat est l'ancre canonique pour les FUTURS workflows self-hosted du chantier — le contrôleur (item 3) doit la reproduire sur chaque workflow qu'il câble. Le réglage repo « Require approval for all outside collaborators » (acceptance B, dernier item) n'est **pas exposé par l'API** `/actions/permissions` vérifiée ce cycle (`default_workflow_permissions: read` confirmé, le flag outside-collaborator absent de la réponse) — capture d'état à faire côté admin (ai-01/user).
