### PR TITLE
fix(ci,#13384): fusion des 5 gardes always-on en un workflow unique (37% de la file CI, ~94 slots/vague)

### DIFF
--- a/.github/workflows/always-on-guards.yml
+++ b/.github/workflows/always-on-guards.yml
@@ -1,0 +1,952 @@
+name: Always-on guards
+
+# FUSION DES CINQ GARDES ALWAYS-ON (#13384) -- un seul workflow, un seul
+# checkout, un seul slot de runner par PR.
+#
+# Constat fondateur (issue #13384, mesure 2026-08-28T14:45Z) : la file CI
+# tenait 319 runs en attente, dont 117 (37 %) pour cinq gardes always-on
+# dont le travail reel additionne ~178 s de runner. Chacun paiait son propre
+# `actions/checkout` + `setup-python` et surtout OCCUPAIT UN SLOT -- c'est
+# le slot, pas la minute-CPU, qui est la ressource rare a 14 runners
+# heberges. Ce workflow paie un checkout et enchaine les douze organes.
+#
+# Sources absorbees (les fichiers RESTENT, dormants -- declencheurs
+# pull_request retires, jobs conserves verbatim pour la tracabilite et les
+# identites du registre fast-lane ; cf chaque en-tete) :
+#
+#   variation-tag-guard.yml    -> 6 jobs pull_request (le chemin commentaire
+#                                 [G-VAR-3 OVERRIDE] y reste LIVE, il n'a
+#                                 jamais fait partie des 117 runs)
+#   perimeter-review-guard.yml -> 1 job (porte aussi sur pull_request_review)
+#   fast-lane-shadow.yml       -> 1 job (moteur des 21 gardes diff-dependants)
+#   variation-light-genre.yml  -> 1 job advisory
+#   lane-claim-guard.yml       -> 2 jobs (1 bloquant + 1 advisory)
+#
+# ~117 runs deviennent ~23 par vague, a cout de calcul inchange.
+#
+# PIEGE NOMME PAR L'ISSUE : `scripts/pr_gate.py::derive_always_on_jobs` (la
+# canary de livraison, regle 8) derive l'ensemble des jobs tournant sur
+# CHAQUE pull_request depuis ce repertoire. La fusion change cet ensemble :
+# les 11 anciens noms de job disparaissent, le nom du job umbrella ci-dessous
+# les remplace. La canary reste armee tant que ce workflow garde un
+# declencheur pull_request SANS filtre `paths:` -- ne jamais en ajouter
+# (regle 2 d'#10045 : un check filtre par chemins rapporte `pending` a vie
+# sur les PR hors scope).
+#
+# CANARY PR GATE (invariant documente en tete de pr-gate.yml) : ce workflow
+# doit rendre un verdict sur toute PR, y compris celles qui ne declenchent
+# aucun autre CI. C'est pourquoi il n'a PAS de `paths:` -- sa surface
+# nominale est TOUTES les PR (les organes metadata lisent le body, pas le
+# diff ; cf #13232 : filtrer par chemins un garde METADONNEE-dependant le
+# desarme).
+#
+# SEMANTIQUE DE BLOCAGE : les organes bloquants portent
+# `continue-on-error: true` et un `id:` ; l'etape finale AGREGAT fait
+# rougir le job si l'un d'eux a echoue. Sans cela, un echec premature
+# empecherait les organes suivants de tourner -- aujourd'hui les jobs
+# tournent en parallele et un rouge n'arrete pas les labels advisory. Les
+# advisories tournent EN PREMIER (elles ne peuvent pas rougir) pour que les
+# labels restent poses meme quand un bloquant echoue.
+#
+# Le nom du job ne porte ni "advisory" ni "optional" : il agrege des
+# verdicts bloquants, `is_advisory()` de pr_gate.py ne doit pas le taire.
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, edited, reopened ]
+    # PAS de `paths:` ici -- cf en-tete + regle 2 d'#10045 + #13232.
+  pull_request_review:
+    branches: [ main ]
+    types: [ submitted, edited ]
+    # Porte le perimeter review guard : une review qui affirme un perimetre
+    # doit etre confrontee (fondateur #11268). Les autres organes sont
+    # `if:`-gates hors de cet evenement.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  checks: write         # fast-lane : un check-run nomme par garde absorbe
+
+# #11649 : pull_request et pull_request_review tirent sur la MEME paire
+# (PR, head SHA) -- un groupe partage avec cancel-in-progress laisserait un
+# run review ANNULER un run push encore en file. event_name dans la cle :
+# les pushes supplantent les pushes, les reviews supplantent les reviews,
+# les deux triggers ne s'annulent jamais entre eux.
+concurrency:
+  group: always-on-guards-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  always-on-guards:
+    name: "Always-on guards -- 12 organes, 1 checkout"
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    # Env partage par les organes metadata (portes depuis leurs jobs
+    # d'origine ; perimeter utilisait github.token, meme valeur que
+    # secrets.GITHUB_TOKEN).
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+
+    steps:
+      # fetch-depth: 0 + blob:none : requis par le fast-lane (les gardes
+      # delta comparent HEAD a la base) et SUFFISANT pour les organes
+      # metadata (leur sparse-checkout d'origine est un sous-ensemble de
+      # l'arbre complet). Paye UNE fois pour les douze.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # Dependances des detecteurs du fast-lane (pyyaml pour le scan de
+      # closure markdown-rendering, Pillow pour scan_md_hierarchy) --
+      # #11850 : sans install, un ImportError etait reporte a tort comme
+      # un _quarto.yml invalide.
+      - name: "Installer dependances detecteurs (pyyaml, Pillow)"
+        run: pip install --quiet pyyaml Pillow
+
+      # -----------------------------------------------------------------
+      # ORGANES ADVISORY (sortent toujours en 0 ; labels et commentaires
+      # seulement). En premier : ils doivent tourner meme si un bloquant
+      # echoue.
+      # -----------------------------------------------------------------
+
+      # Porte de variation-tag-guard.yml :: check-variation-tag.
+      - name: "Grain tag advisory (labels, non bloquant)"
+        if: github.event_name == 'pull_request'
+        run: |
+          set -uo pipefail
+
+          # ATTENTION au shell reel : GitHub invoque ce bloc avec
+          # `/usr/bin/bash -e {0}` -- l'errexit est ACTIF, et `set -uo
+          # pipefail` ne l'annule pas. Ce qui garde ce job non bloquant
+          # n'est pas l'absence de `-e`, c'est que chaque commande faillible
+          # est dans une condition ou suffixee `|| true`. Jamais `|| true`
+          # sur la capture d'un code de retour.
+
+          # Hors scope : bots (catalogue auto-regenere) et forks (PRs
+          # etudiantes, cf student-pr-reviews.md).
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          # Extraction via l'extracteur PARTAGE scripts/grain_tag.py
+          # (#9485 : source unique de lecture du tag, tolerate les formes
+          # Grain:, ## Grain, **Grain** :, sans tolerer l'absence de
+          # substance).
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+          python3 scripts/grain_tag.py --body-file /tmp/pr_body.txt > /tmp/tag.json 2>/dev/null || true
+
+          _field() { python3 -c "import json; print(json.load(open('/tmp/tag.json')).get('$1'))" 2>/dev/null || echo "None"; }
+          PRESENT=$(_field present)
+          TIER=$(_field tier)
+          GENRE=$(_field genre)
+          LANE=$(_field lane)
+          TIER_VALID=$(_field tier_valid)
+          GENRE_VALID=$(_field genre_valid)
+
+          DEFECTS=""
+          note_defect() { DEFECTS="$DEFECTS $1"; }
+
+          if [ "$PRESENT" = "True" ]; then
+            echo "Tag lu : TIER=$TIER GENRE=$GENRE lane=$LANE"
+
+            if [ "$TIER_VALID" != "True" ]; then
+              echo "::warning::TIER non reconnu ('${TIER:-vide}'). Attendu DEEP, MED ou LIGHT -- le TIER se decide par le litmus de variation-protocol.md, pas par auto-evaluation de valeur."
+              note_defect variation-tag-malformed
+            fi
+            if [ "$GENRE_VALID" != "True" ]; then
+              echo "::warning::GENRE '${GENRE:-vide}' hors enumeration §1 (lean, qc, training, genai, notebook-python, notebook-dotnet, notebook-lean, slides, docs, guard, refactor, ledger, readme, test, tooling, research-code). G-VAR-3 compare des genres consecutifs : un genre inedit rend l'adjacence invisible. Mappe-le sur le genre qui decrit le TYPE DE TRAVAIL, pas le repertoire traverse."
+              note_defect variation-tag-genre-offlist
+            fi
+            if [ -z "$LANE" ] || [ "$LANE" = "None" ]; then
+              echo "::warning::Aucune 'lane <machine:workspace>' declaree. G-VAR-2 est un cap PAR LANE et PAR JOUR : un grain sans lane est structurellement incomptable, et le cap devient inapplicable sans que personne ne l'ait contourne (§3)."
+              note_defect variation-tag-lane-missing
+            fi
+
+            # `prev:` -- rend G-VAR-3 EVALUABLE. Forme canonique :
+            # `prev: <TIER>/<GENRE> #<PR>` ; exemption premier grain :
+            # `prev: none (premier grain)`.
+            PREV_PRESENT=$(_field prev_present)
+            PREV_EXEMPT=$(_field prev_exempt)
+            if [ "$PREV_PRESENT" = "False" ] && [ "$PREV_EXEMPT" != "True" ]; then
+              echo "::warning::Champ 'prev:' absent du tag. variation-protocol §1 le rend obligatoire (support mecanique de G-VAR-3 : pas deux fois le meme GENRE LIGHT consecutif). Forme : prev: <TIER>/<GENRE> #<PR>. Premier grain d'une lane : prev: none (premier grain)."
+              note_defect variation-tag-prev-absent
+            fi
+          else
+            echo "::warning::Aucun tag 'Grain: <TIER>/<GENRE>' lisible dans le body (formes lues : Grain:, ## Grain, **Grain** :). variation-protocol.md exige 'Grain: <TIER>/<GENRE> -- lane <machine:workspace> -- prev: <TIER>/<GENRE> #<PR>'."
+            note_defect variation-tag-missing
+          fi
+
+          # Labels : un label colle par un push anterieur ne doit pas
+          # survivre a la correction. stderr LAISSE PASSER sur les
+          # create/add (#8786 : masquer l'erreur rend la panne invisible) ;
+          # 2>/dev/null justifie sur les remove (label absent = nominal).
+          for LABEL in variation-tag-missing variation-tag-malformed variation-tag-genre-offlist variation-tag-lane-missing variation-tag-prev-absent; do
+            case "$LABEL" in
+              variation-tag-missing)          COLOR="FBCA04"; DESC="PR sans tag Grain: <TIER>/<GENRE> (variation-protocol)" ;;
+              variation-tag-malformed)       COLOR="FEF2C0"; DESC="Tag Grain present mais TIER != DEEP|MED|LIGHT" ;;
+              variation-tag-genre-offlist)   COLOR="FEF2C0"; DESC="GENRE hors de l'enumeration variation-protocol §1" ;;
+              variation-tag-lane-missing)    COLOR="FEF2C0"; DESC="Tag Grain sans 'lane <machine:workspace>' (cap G-VAR-2 incomptable)" ;;
+              variation-tag-prev-absent)     COLOR="FEF2C0"; DESC="Tag Grain sans 'prev: <TIER>/<GENRE> #<PR>' (adjacence G-VAR-3 inevaluable)" ;;
+            esac
+            case " $DEFECTS " in
+              *" $LABEL "*)
+                gh label create "$LABEL" --description "$DESC" --color "$COLOR" --force || true
+                gh pr edit "$PR_NUMBER" --add-label "$LABEL" || true
+                ;;
+              *)
+                gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+                ;;
+            esac
+          done
+
+          if [ -z "$DEFECTS" ]; then
+            echo "Tag conforme : TIER + GENRE dans la liste §1 + lane declaree + prev: (ou exemption premier grain)."
+          else
+            echo "Defauts signales (advisory, non bloquant) :$DEFECTS"
+          fi
+          exit 0
+
+      # Porte de variation-tag-guard.yml :: check-light-cap.
+      - name: "G-VAR-2 light cap (cross-PR, advisory)"
+        if: github.event_name == 'pull_request'
+        run: |
+          set -uo pipefail
+
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          # Jour UTC : G-VAR-2 se compte par jour UTC (reset 00:00Z).
+          TODAY=$(date -u +%Y-%m-%d)
+
+          # --limit 500 OBLIGATOIRE : la page par defaut de `gh pr list`
+          # est 30, silencieusement. Le set tronque attaque le
+          # DENOMINATEUR du ratio G-VAR-2 (#10328 : 60 mergees pour 30
+          # vues -> faux positif contre les lanes productives).
+          gh pr list --state merged --search "merged:$TODAY" --limit 500 \
+            --json number,body,mergedAt,labels > /tmp/merged.json 2>/dev/null || true
+
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Labels de la PR courante : requalification #8970
+          # (grain-requalified:<TIER>) pre-appliquable sur la PR ouverte.
+          gh pr view "$PR_NUMBER" --json labels > /tmp/pr_labels.json 2>/dev/null || \
+            printf '[]' > /tmp/pr_labels.json
+
+          # ADVISORY : cap_reached consomme les DEUX axes du cap G-VAR-2
+          # (#10480) -- le TIER (LIGHT declare/effectif) ET le GENRE
+          # (light-genre : readme/docs/guard/ledger/test, quel que soit le
+          # tier declare).
+          python3 scripts/variation_light_cap.py \
+            --replay /tmp/merged.json \
+            --check-pr "$PR_NUMBER" \
+            --body-file /tmp/pr_body.txt \
+            --labels-file /tmp/pr_labels.json > /tmp/status.json 2>/tmp/cap.err || true
+
+          echo "--- detector output ---"
+          cat /tmp/status.json 2>/dev/null || true
+          [ -s /tmp/cap.err ] && { echo "--- detector stderr ---"; cat /tmp/cap.err; } || true
+
+          CAP=$(python3 -c "import json; print(json.load(open('/tmp/status.json')).get('cap_reached'))" 2>/dev/null || echo "False")
+
+          gh label create variation-light-cap-reached \
+            --description "Lane ayant deja merge une LIGHT aujourd'hui (cap G-VAR-2 atteint)" \
+            --color B60205 --force 2>/dev/null || true
+
+          if [ "$CAP" = "True" ]; then
+            gh pr edit "$PR_NUMBER" --add-label variation-light-cap-reached 2>/dev/null || true
+            LANE=$(python3 -c "import json; print(json.load(open('/tmp/status.json')).get('lane','?'))" 2>/dev/null || echo "?")
+            CB=$(python3 -c "import json; c=(json.load(open('/tmp/status.json')).get('consumed_by') or {}); print(f\"#{c.get('number','?')} (merge a {c.get('mergedAt','?')})\")" 2>/dev/null || echo "une LIGHT anterieure de cette lane")
+            # Commentaire idempotent (marqueur HTML invisible anti-spam).
+            MARK="<!-- gvar2-light-cap -->"
+            if ! gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' 2>/dev/null | grep -qF "$MARK"; then
+              BODY="${MARK}
+          **G-VAR-2 light cap reached** (advisory, non bloquant).
+          La lane \`${LANE}\` a deja consomme son budget LIGHT du jour (${CB}).
+          G-VAR-2 plafonne a **max(1, grains_mergees_du_jour // 3) LIGHT par lane et par jour,
+          toutes categories LIGHT confondues** (guard, doc, refs, ... partagent un seul budget) :
+          c'est un RATIO, pas un plafond plat. La decision de merge reste au coordinateur."
+              gh pr comment "$PR_NUMBER" --body "$BODY" 2>/dev/null || true
+            fi
+            echo "::notice::G-VAR-2 cap reached pour la lane ${LANE} (consomme par ${CB})."
+          else
+            gh pr edit "$PR_NUMBER" --remove-label variation-light-cap-reached 2>/dev/null || true
+          fi
+          exit 0
+
+      # Porte de variation-light-genre.yml :: check-light-genre-signals.
+      - name: "G-VAR-2/3 GENRE signals (advisory, #10020)"
+        if: github.event_name == 'pull_request'
+        run: |
+          set -uo pipefail
+
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          TODAY=$(date -u +%Y-%m-%d)
+          # --limit 500 : cf light-cap ci-dessus (#10328).
+          gh pr list --state merged --search "merged:$TODAY" --limit 500 \
+            --json number,body,mergedAt,labels > /tmp/merged.json 2>/dev/null || \
+            printf '[]' > /tmp/merged.json
+
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Lane : extraite du tag Grain: via l'extracteur partage. Absente
+          # = rien a calculer (le tag guard l'a deja signalee).
+          LANE=$(python3 scripts/grain_tag.py --body-file /tmp/pr_body.txt 2>/dev/null \
+            | python3 -c "import json,sys; print(json.load(sys.stdin).get('lane') or '')" 2>/dev/null || echo "")
+          if [ -z "$LANE" ]; then
+            echo "Lane absente du tag Grain: de la PR. variation-tag-guard l'a surement deja signalee ; ce job n'a rien a calculer sur G-VAR-2/3-by-GENRE."
+            exit 0
+          fi
+          echo "Lane ciblee : ${LANE}"
+
+          gh pr view "$PR_NUMBER" --json labels > /tmp/pr_labels.json 2>/dev/null || \
+            printf '[]' > /tmp/pr_labels.json
+
+          # Fichiers du diff : pour GENRE-MISMATCH (declared vs
+          # _genre_from_paths). PR sans fichiers -> --files "" (missing
+          # input is a missing signal, never a false positive).
+          gh pr view "$PR_NUMBER" --json files > /tmp/pr_files.json 2>/dev/null || \
+            printf '[]' > /tmp/pr_files.json
+          FILES_CSV=$(python3 -c "
+          import json
+          try:
+              data = json.load(open('/tmp/pr_files.json'))
+              files = data if isinstance(data, list) else data.get('files', [])
+              paths = [f.get('path','') for f in files if isinstance(f, dict)]
+              paths = [p for p in paths if p]
+              print(','.join(paths))
+          except Exception:
+              print('')
+          " 2>/dev/null || echo "")
+
+          python3 scripts/variation_light_cap.py \
+            --replay /tmp/merged.json \
+            --genre-signals \
+            --lane "${LANE}" \
+            --body-file /tmp/pr_body.txt \
+            --labels-file /tmp/pr_labels.json \
+            --files "${FILES_CSV}" > /tmp/signals.json 2>/tmp/cap.err || true
+
+          echo "--- detector output ---"
+          cat /tmp/signals.json 2>/dev/null || true
+          [ -s /tmp/cap.err ] && { echo "--- detector stderr ---"; cat /tmp/cap.err; } || true
+
+          SIG_INFLATION=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('TIER-INFLATION'))" 2>/dev/null || echo "False")
+          SIG_RUN=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('GENRE-RUN'))" 2>/dev/null || echo "False")
+          SIG_CAPEXC=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('CAP-EXCEEDED-BY-GENRE'))" 2>/dev/null || echo "False")
+          SIG_MISMATCH=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('GENRE-MISMATCH'))" 2>/dev/null || echo "False")
+          SIG_UNKNOWN=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('GENRE-UNKNOWN'))" 2>/dev/null || echo "False")
+          UNKNOWN_WORD=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('candidate_genre_unknown_word') or '')" 2>/dev/null || echo "")
+          TALLY=$(python3 -c "import json; t=json.load(open('/tmp/signals.json')).get('tally',{}); print(f\"declared={t.get('light_declared',0)} genre={t.get('light_genre',0)} cap={t.get('cap',1)}\")" 2>/dev/null || echo "inconnu")
+          # #10341 : les signaux agreges (TIER-INFLATION, GENRE-RUN,
+          # CAP-EXCEEDED-BY-GENRE) mesurent le LANE-JOUR, pas la candidate.
+          # Une PR CONTENU ne contribue pas au motif -- le label ne doit pas
+          # etre pose dessus. GENRE-MISMATCH est exempt (son sujet EST la
+          # candidate par construction).
+          CAND_LIGHT=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('candidate_is_light_genre'))" 2>/dev/null || echo "False")
+
+          for LABEL_PAIR in \
+            "variation-tier-inflation:FEF2C0:TIER-INFLATION:declared LIGHT << effective LIGHT-genre (#10020, advisory)" \
+            "variation-genre-run:FEF2C0:GENRE-RUN:>= 2 grains consecutifs du meme genre LIGHT pour la lane (#10020, advisory)" \
+            "variation-genre-cap-exceeded:FBCA04:CAP-EXCEEDED-BY-GENRE:light_genre > cap partage G-VAR-2 (#10020, advisory)" \
+            "variation-genre-mismatch:FEF2C0:GENRE-MISMATCH:declared genre != genre infere depuis les chemins du diff (#10020, advisory)" \
+            "variation-genre-unknown:FBCA04:GENRE-UNKNOWN:genre canonise hors enumeration close -- trou d'adjacence G-VAR-3, requalifier dans le body (#12158, advisory)"
+          do
+            LABEL=$(echo "$LABEL_PAIR" | cut -d: -f1)
+            COLOR=$(echo "$LABEL_PAIR" | cut -d: -f2)
+            SIGNAL=$(echo "$LABEL_PAIR" | cut -d: -f3)
+            DESC=$(echo "$LABEL_PAIR" | cut -d: -f4)
+            # Mapping explicite SIGNAL -> variable (pas d'eval dynamique,
+            # qui ne survit pas a set -u ; cf source d'origine).
+            case "$SIGNAL" in
+              TIER-INFLATION)        SIGVAR="SIG_INFLATION"; MAY_LABEL_INNOCENT="no" ;;
+              GENRE-RUN)             SIGVAR="SIG_RUN"; MAY_LABEL_INNOCENT="no" ;;
+              CAP-EXCEEDED-BY-GENRE) SIGVAR="SIG_CAPEXC"; MAY_LABEL_INNOCENT="no" ;;
+              GENRE-MISMATCH)        SIGVAR="SIG_MISMATCH"; MAY_LABEL_INNOCENT="yes" ;;
+              GENRE-UNKNOWN)         SIGVAR="SIG_UNKNOWN"; MAY_LABEL_INNOCENT="yes" ;;
+              *)
+                echo "Signal non reconnnu : ${SIGNAL} (PR ${PR_NUMBER})"
+                SIGVAR="__UNDEFINED__"
+                MAY_LABEL_INNOCENT="yes"
+                ;;
+            esac
+            if [ "$SIGVAR" = "__UNDEFINED__" ]; then
+              SIGVAL="False"
+            else
+              SIGVAL="${!SIGVAR:-False}"
+            fi
+            gh label create "$LABEL" --description "$DESC" --color "$COLOR" --force 2>/dev/null || true
+            # #10341 : les signaux agreges ne labelisent pas une candidate
+            # innocente ; la branche else retire aussi un label pose avant
+            # que la lane ne croise le cap (idempotence symetrique).
+            if [ "$SIGVAL" = "True" ] && { [ "$MAY_LABEL_INNOCENT" = "yes" ] || [ "$CAND_LIGHT" = "True" ]; }; then
+              gh pr edit "$PR_NUMBER" --add-label "$LABEL" 2>/dev/null || true
+            else
+              gh pr edit "$PR_NUMBER" --remove-label "$LABEL" 2>/dev/null || true
+            fi
+          done
+
+          # Commentaire diagnostique idempotent : RE-EDIT du commentaire
+          # existant (PATCH) plutot qu'un nouveau a chaque synchronize.
+          MARK="<!-- variation-genre-signals -->"
+          ACTIVE_LINES=""
+          [ "$SIG_INFLATION" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
+          - **TIER-INFLATION** : declared LIGHT << effective LIGHT-genre (tally : ${TALLY})"
+          [ "$SIG_RUN" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
+          - **GENRE-RUN** : run consecutif d'un genre LIGHT (voir \`signals.runs\` dans le log du job)"
+          [ "$SIG_CAPEXC" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
+          - **CAP-EXCEEDED-BY-GENRE** : light_genre > cap partage G-VAR-2 (tally : ${TALLY})"
+          [ "$SIG_MISMATCH" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
+          - **GENRE-MISMATCH** : declared genre != genre infere depuis les chemins du diff"
+          [ "$SIG_UNKNOWN" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
+          - **GENRE-UNKNOWN** : le genre canonise \\\`${UNKNOWN_WORD:-?}\\\` est hors enumeration close -- trou d'adjacence G-VAR-3, requalifier le genre dans le body (#12158)"
+
+          # #10341 nuance : la PR courante CONTENU ne contribue pas au
+          # motif -- le dire explicitement dans le commentaire.
+          if [ "$CAND_LIGHT" != "True" ]; then
+            if [ "$SIG_INFLATION" = "True" ] || [ "$SIG_RUN" = "True" ] || [ "$SIG_CAPEXC" = "True" ]; then
+              ACTIVE_LINES="${ACTIVE_LINES}
+          - **NOTE (#10341)** : la PR courante est de classe CONTENU (non LIGHT-genre) et ne contribue pas au motif ci-dessus -- les labels agregees ne sont PAS poses sur cette PR (le merge-gate ne doit pas la HOLD pour ce motif ; le coupable est parmi les grains META de la lane)."
+            fi
+          fi
+
+          if [ -n "$ACTIVE_LINES" ]; then
+            BODY="${MARK}
+          **G-VAR-2/3 GENRE signals** (advisory, non bloquant, #10020).
+          La lane \\\`${LANE}\\\` voit ces signaux actifs sur les mergees du jour (UTC ${TODAY}) :${ACTIVE_LINES}
+
+          G-VAR-2 plafonne a **max(1, grains_mergees_du_jour // 3) LIGHT par lane et par jour, toutes categories LIGHT confondues** -- un RATIO, pas un plafond plat ; le cap calcule du jour est dans le tally ci-dessus. G-VAR-3 interdit deux genres LIGHT consecutifs. Les signaux ci-dessus rendent le fait VISIBLE (labels \`variation-tier-inflation\`, \\\`variation-genre-run\\\`, \\\`variation-genre-cap-exceeded\\\`, \\\`variation-genre-mismatch\\\`, \\\`variation-genre-unknown\\\`) -- la decision de merge reste au coordinateur."
+            EXISTING_ID=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.body | startswith("'"$MARK"'")) | .id' 2>/dev/null | head -1 || echo "")
+            if [ -n "$EXISTING_ID" ]; then
+              gh api -X PATCH "repos/${GH_REPO}/issues/comments/${EXISTING_ID}" \
+                -f body="$BODY" 2>/dev/null || true
+            else
+              gh pr comment "$PR_NUMBER" --body "$BODY" 2>/dev/null || true
+            fi
+            echo "::notice::G-VAR-2/3-by-GENRE signale sur ${LANE} (tally ${TALLY})."
+          else
+            EXISTING_ID=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.body | startswith("'"$MARK"'")) | .id' 2>/dev/null | head -1 || echo "")
+            if [ -n "$EXISTING_ID" ]; then
+              gh api -X DELETE "repos/${GH_REPO}/issues/comments/${EXISTING_ID}" 2>/dev/null || true
+            fi
+            echo "Aucun signal actif pour ${LANE} aujourd'hui (tally ${TALLY})."
+          fi
+          exit 0
+
+      # Porte de lane-claim-guard.yml :: check-lane-claim-advisory.
+      - name: "Advisory lane-claim labels (adoption telemetry, non-blocking, #10223)"
+        if: github.event_name == 'pull_request'
+        run: |
+          set -uo pipefail
+
+          case "$PR_AUTHOR" in
+            *"[bot]") exit 0 ;;
+          esac
+          [ "$IS_FORK" = "true" ] && exit 0
+
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # #10323: cross-check closingIssuesReferences (GitHub-authoritaire)
+          # pour ne pas se declencher sur un mot-cle fermant dans un code
+          # span/negation que GitHub ignore.
+          if PR_CLOSING_REFS=$(gh pr view "$PR_NUMBER" \
+              --json closingIssuesReferences \
+              --jq '[.closingIssuesReferences[].number] | join(",")' 2>/dev/null); then
+            PR_CREFS_ARG=(--pr-closing-refs "$PR_CLOSING_REFS")
+          else
+            PR_CREFS_ARG=()
+          fi
+
+          # Advisory : on ignore le code et on ne lit que advisory_labels.
+          python3 scripts/ci/lane_claim_required.py \
+            --body-file /tmp/pr_body.txt "${PR_CREFS_ARG[@]}" \
+            > /tmp/verdict.json 2>/tmp/verdict.err || true
+
+          # #13129 -- annotations ::warning des globs morts du scope,
+          # deleguees au helper (le GitHub Actions bash n'accepte pas un
+          # python3 -c multi-lignes dans un scalaire YAML). Non bloquant.
+          PYTHONPATH=scripts python3 scripts/ci/emit_dead_scope_warnings.py \
+            --body-file /tmp/pr_body.txt \
+            > /tmp/lc_annotations.txt 2>/dev/null || true
+          if [ -s /tmp/lc_annotations.txt ]; then
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "$line"
+            done < /tmp/lc_annotations.txt
+          fi
+
+          mk_label() {
+            gh label create "$1" --description "$2" --color "$3" --force 2>/dev/null || true
+          }
+          mk_label "lane-claim-absent" "Closing issue carries no claim at all (#10223)" "fbca04"
+
+          set_label()   { gh pr edit "$PR_NUMBER" --add-label "$1" || true; }
+          unset_label() { gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true; }
+
+          # Fail-safe : verdict illisible -> aucun label dans la liste ->
+          # on retire lane-claim-absent.
+          has() { python3 -c "import json,sys; sys.exit(0 if '$1' in json.load(open('/tmp/verdict.json')).get('advisory_labels',[]) else 1)" 2>/dev/null; }
+
+          if has "lane-claim-absent"; then set_label "lane-claim-absent"; else unset_label "lane-claim-absent"; fi
+
+          # Nettoyage a la volee des anciens labels lane-claim-conflict
+          # poses par les versions precedentes du job.
+          unset_label "lane-claim-conflict"
+
+          echo "advisory labels applied."
+          exit 0
+
+      # -----------------------------------------------------------------
+      # ORGANES BLOQUANTS (continue-on-error + id ; l'agregat final fait
+      # rougir le job si l'un d'eux echoue -- cf en-tete).
+      # -----------------------------------------------------------------
+
+      # Porte de variation-tag-guard.yml :: check-variation-tag-required.
+      - name: 'Require Grain tag (block on absent, #10045)'
+        id: tag_required
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante, cf student-pr-reviews.md)."
+            exit 0
+          fi
+
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Capturer le RC via &&/|| (exempt d'errexit) -- jamais une
+          # commande suivie d'un RC=$? en ligne separee : sous bash -e elle
+          # meurt au block path meme, avant l'affectation.
+          python3 scripts/ci/variation_tag_required.py \
+            --body-file /tmp/pr_body.txt > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+
+          if [ -s /tmp/verdict.err ]; then
+            echo "--- helper stderr ---"
+            cat /tmp/verdict.err
+          fi
+          echo "--- verdict ---"
+          cat /tmp/verdict.json
+
+          OVERRIDDEN=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('overridden'))" 2>/dev/null || echo "None")
+          if [ "$OVERRIDDEN" = "True" ]; then
+            echo "::notice::Adjacence G-VAR-3 REELLE, levee par le coordinateur (clause 24h, section 3). Le grain suivant de la lane change de genre."
+          fi
+
+          if [ "$RC" -eq 0 ]; then
+            echo "Grain tag + lane present -- job passes."
+            exit 0
+          fi
+
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error::Grain tag ou lane manquant : $REASON"
+
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          <!-- vtr-required-block -->
+          **Grain tag obligatoire (#10045, bloquant).**
+
+          \`${REASON}\`.
+
+          Pour passer ce gate, le body doit porter en tete une ligne de la forme :
+
+          \`\`\`
+          Grain: <DEEP|MED|LIGHT>/<genre> -- lane <machine:workspace> -- prev: <TIER>/<GENRE> #<PR>
+          \`\`\`
+
+          Le \`<genre>\` doit figurer dans l'enumeration §1 de \`variation-protocol.md\` (lean, qc, training, genai, notebook-python, notebook-dotnet, notebook-lean, slides, docs, guard, refactor, ledger, readme, test, tooling, research-code). Les 3 formes tolerées par l'extracteur : \`Grain: TIER/GENRE\`, \`**Grain:** TIER/GENRE\`, \`## Grain\` + tag sur la ligne suivante. La lane doit suivre le format \`<machine>:<workspace>\` (cf. \`lane-claim-protocol.md\`).
+          EOF
+          )" 2>/dev/null || true
+
+          exit 1
+
+      # Porte de variation-tag-guard.yml :: check-prev-close-keyword-required.
+      - name: 'Require prev: non-closing (block on close-keyword genre, #10093)'
+        id: prev_guard
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante, cf student-pr-reviews.md)."
+            exit 0
+          fi
+
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Commit messages : messageBody = ce que GitHub parse pour
+          # l'auto-close. Echec de fetch LOGGE, non masque (#10953).
+          if ! gh pr view "$PR_NUMBER" --json commits --jq '[.commits[].messageBody]' \
+              > /tmp/commits.json; then
+            echo "::warning::gh pr view --json commits a echoue — scan des commits vide, body seul couvert (#10953)"
+            printf '[]' > /tmp/commits.json
+          fi
+
+          python3 scripts/ci/variation_prev_guard.py \
+            --body-file /tmp/pr_body.txt \
+            --commits-file /tmp/commits.json > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+
+          if [ -s /tmp/verdict.err ]; then
+            echo "--- helper stderr ---"
+            cat /tmp/verdict.err
+          fi
+          echo "--- verdict ---"
+          cat /tmp/verdict.json
+
+          if [ "$RC" -eq 0 ]; then
+            echo "No \`prev:\` close-keyword genre in body or commits -- job passes."
+            exit 0
+          fi
+
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error::prev: close-keyword genre detected: $REASON"
+
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          <!-- vtr-prev-close-keyword -->
+          **\`prev:\` genre mots-clé fermant -- bloquant (#10093).**
+
+          ${REASON}
+
+          Une \`prev:\` dont le genre est \`fix\`/\`close\`/\`resolve\` (ou une inflexion) fait que GitHub interprète \`<genre> #N\` comme un ordre de fermeture automatique dès que le texte atterrit dans un message de commit -- c'est exactement ce qui a fermé #10067 (sans la merger) au squash-merge de #10063. Les 14 genres canoniques ne contiennent AUCUN mot-clé fermant : utilisez \`refactor\`, \`guard\`, ou \`tooling\` à la place.
+
+          Pour passer ce gate, réécrivez le champ \`prev:\` (dans le body ET dans chaque commit concerné) avec un genre non-fermant :
+
+          \`\`\`
+          Grain: <TIER>/<genre> -- lane <machine:workspace> -- prev: <TIER>/<refactor|guard|tooling|...> #<PR>
+          \`\`\`
+          EOF
+          )" 2>/dev/null || true
+
+          exit 1
+
+      # Porte de variation-tag-guard.yml :: check-close-keyword-pr-ref-required.
+      - name: 'Require no close-keyword + PR-number (block on auto-close of a PR, #10101)'
+        id: close_keyword
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante, cf student-pr-reviews.md)."
+            exit 0
+          fi
+
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          if ! gh pr view "$PR_NUMBER" --json commits --jq '[.commits[].messageBody]' \
+              > /tmp/commits.json; then
+            echo "::warning::gh pr view --json commits a echoue — scan des commits vide, body seul couvert (#10953)"
+            printf '[]' > /tmp/commits.json
+          fi
+
+          python3 scripts/ci/pr_close_keyword_guard.py \
+            --body-file /tmp/pr_body.txt \
+            --commits-file /tmp/commits.json > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+
+          if [ -s /tmp/verdict.err ]; then
+            echo "--- helper stderr ---"
+            cat /tmp/verdict.err
+          fi
+          echo "--- verdict ---"
+          cat /tmp/verdict.json
+
+          # Warnings fail-open (refs perimees, blips) surfaces meme en pass.
+          python3 -c "import json; [print('::warning::'+w) for w in json.load(open('/tmp/verdict.json')).get('warnings',[])]" 2>/dev/null || true
+
+          if [ "$RC" -eq 0 ]; then
+            echo "No closing-keyword + PR-number reference in body or commits -- job passes."
+            exit 0
+          fi
+
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error::closing-keyword + PR-number reference detected: $REASON"
+
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          <!-- vtr-close-keyword-pr-ref -->
+          **\`<mot-clé fermant> #N\` où N est une PR -- bloquant (#10101).**
+
+          ${REASON}
+
+          GitHub interprète \`close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved #N\` comme un ordre de fermeture automatique dès que le texte atterrit dans le message de squash -- et fermer une **PR** par mot-clé n'est jamais intentionnel (une PR se merge ou se ferme explicitement, elle ne se « résout » pas). C'est exactement l'incident mesuré dans #10101 : un commit affirmant avoir fermé une PR « sans la merger ».
+
+          Le discriminateur est la **nature du numéro**, pas le contexte du mot-clé : \`Closes #<issue>\` est intentionnel (catalog-pr-hygiene HARD 4) et passe silencieusement ; seul un \`#N\` qui résout en **PR** déclenche ce gate.
+
+          Pour passer ce gate :
+          - **retirez le mot-clé fermant** devant le numéro, ou
+          - **écrivez le numéro SANS le \`#\`** (un nombre nu n'est pas un auto-close).
+          EOF
+          )" 2>/dev/null || true
+
+          exit 1
+
+      # Porte de variation-tag-guard.yml :: check-variation-adjacency-required.
+      - name: 'Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)'
+        id: adjacency
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante, cf student-pr-reviews.md)."
+            exit 0
+          fi
+
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # Comments, pour le marqueur [G-VAR-3 OVERRIDE] (#11708).
+          gh pr view "$PR_NUMBER" --json comments \
+            --jq '[.comments[] | {author: .author.login, body: .body}]' \
+            > /tmp/pr_comments.json 2>/dev/null || rm -f /tmp/pr_comments.json
+
+          COMMENTS_ARG=""
+          if [ -s /tmp/pr_comments.json ]; then
+            COMMENTS_ARG="--comments-file /tmp/pr_comments.json"
+          fi
+
+          # Merged PRs pour le VRAI predecesseur de la lane (#12095) :
+          # fenetre merge-time pagee via fetch_merged_prs_since.py
+          # (#12636 : --limit 100 est creation-capped).
+          python3 scripts/ci/fetch_merged_prs_since.py --days 21 \
+            > /tmp/merged_prs.json 2>/dev/null || rm -f /tmp/merged_prs.json
+
+          MERGED_ARG=""
+          if [ -s /tmp/merged_prs.json ]; then
+            MERGED_ARG="--merged-prs-file /tmp/merged_prs.json"
+          fi
+
+          # shellcheck disable=SC2086  # COMMENTS_ARG/MERGED_ARG are deliberate 0-or-2 token splits
+          python3 scripts/ci/variation_adjacency_guard.py \
+            --body-file /tmp/pr_body.txt $COMMENTS_ARG $MERGED_ARG \
+            > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+
+          if [ -s /tmp/verdict.err ]; then
+            echo "--- helper stderr ---"
+            cat /tmp/verdict.err
+          fi
+          echo "--- verdict ---"
+          cat /tmp/verdict.json
+
+          ADJACENT=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('adjacent'))" 2>/dev/null || echo "False")
+
+          # Label advisory pour l'adjacence DEEP/MED (jugement coord).
+          gh label create variation-adjacency-deep-med \
+            --description "Adjacence de genre DEEP/MED (hors liste LIGHT) : §2 l'autorise si substance distincte -- jugement au coordinateur" \
+            --color FEF2C0 --force 2>/dev/null || true
+          if [ "$ADJACENT" = "True" ]; then
+            gh pr edit "$PR_NUMBER" --add-label variation-adjacency-deep-med 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --remove-label variation-adjacency-deep-med 2>/dev/null || true
+          fi
+
+          if [ "$RC" -eq 0 ]; then
+            echo "No LIGHT-genre adjacency vs prev: -- job passes."
+            exit 0
+          fi
+
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error::G-VAR-3 LIGHT-genre adjacency: $REASON"
+
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          <!-- vtr-adjacency-block -->
+          **G-VAR-3 : deux grains LIGHT du meme genre consecutifs -- bloquant (#11170).**
+
+          ${REASON}
+
+          variation-protocol.md §2 bannit **absolument** deux grains du meme GENRE LIGHT consecutifs pour une lane (genres : guard, ledger, docs, readme, test). Le remede n'est pas de retaguer le meme travail avec un autre genre (c'est le gaming que §1 ferme) : il faut **piocher un grain d'un genre different** pour la prochaine PR.
+
+          Pour passer ce gate, remplacez la \`prev:\` par un grain precedent d'un genre different (ou changez le genre du grain courant pour un genre de substance differente) :
+
+          \`\`\`
+          Grain: <TIER>/<genre> -- lane <machine:workspace> -- prev: <TIER>/<genre-different> #<PR>
+          \`\`\`
+          EOF
+          )" 2>/dev/null || true
+
+          exit 1
+
+      # Porte de lane-claim-guard.yml :: check-lane-claim-required.
+      - name: 'Require no closing-ref against another lane active claim (block on lane collision, #10223)'
+        id: lane_claim
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante, cf student-pr-reviews.md)."
+            exit 0
+          fi
+
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # #10323: GitHub-authoritative closing refs.
+          if PR_CLOSING_REFS=$(gh pr view "$PR_NUMBER" \
+              --json closingIssuesReferences \
+              --jq '[.closingIssuesReferences[].number] | join(",")' 2>/dev/null); then
+            PR_CREFS_ARG=(--pr-closing-refs "$PR_CLOSING_REFS")
+          else
+            PR_CREFS_ARG=()
+            echo "::warning::closingIssuesReferences fetch failed; falling back to regex finder (#10323)."
+          fi
+
+          python3 scripts/ci/lane_claim_required.py \
+            --body-file /tmp/pr_body.txt "${PR_CREFS_ARG[@]}" \
+            > /tmp/verdict.json 2>/tmp/verdict.err
+          RC=$?
+
+          if [ -s /tmp/verdict.err ]; then
+            echo "--- helper stderr ---"
+            cat /tmp/verdict.err
+          fi
+          echo "--- verdict ---"
+          cat /tmp/verdict.json
+
+          python3 -c "import json; [print('::warning::'+w) for w in json.load(open('/tmp/verdict.json')).get('warnings',[])]" 2>/dev/null || true
+
+          if [ "$RC" -eq 0 ]; then
+            echo "Aucun claim frais d'une autre lane sur un renvoi fermant -- job passes."
+            exit 0
+          fi
+
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error::collision de lane sur une reference fermante: $REASON"
+
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          <!-- lane-claim-conflict -->
+          **Collision de lane sur une reference fermante (#10223).**
+
+          ${REASON}
+
+          Une autre lane detient un claim actif sur une issue que cette PR ferme par mot-cle (\`Closes\`/\`Fixes\`/\`Resolves #N\`). Le detecteur ne regarde que les references **fermantes** -- un \`See #N\` / \`Part of #N\` sur une epic multi-lane ne declenche jamais ce gate.
+
+          Les **trois sorties** pour passer ce gate :
+          - la lane detenrice **relache** son claim (\`[RELEASED] lane <machine:workspace>\` sur l'issue concernee), ou
+          - le **coordinateur ecrit** un arbitrage (\`[OVERRIDE] lane <cette lane>\` -- c'est la trace qui rend l'override mecaniquement traçable, #10223 Tache 2), ou
+          - le claim atteint **48 h** de peremption (le protocole re-arbitre les claims d'une lane inactive).
+
+          Voir #10223 et \`lane-claim-protocol.md\`.
+          EOF
+          )" 2>/dev/null || true
+
+          exit 1
+
+      # Porte de perimeter-review-guard.yml :: perimeter. Tourne AUSSI sur
+      # pull_request_review (submitted/edited) : une review qui affirme un
+      # perimetre doit etre confrontee (#11268). Les autres organes sont
+      # if:-gates hors de cet evenement.
+      - name: "perimeter review guard (#11268)"
+        id: perimeter
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
+        continue-on-error: true
+        run: |
+          PR="${{ github.event.pull_request.number }}"
+          python scripts/check_pr_perimeter.py "$PR" --scan-thread || {
+            echo "::error::A perimeter assertion on this PR (body or review) contradicts the effective file list, or an exclusivity claim does not name a touched .github/workflows/** file. Truth source: gh pr view $PR --json files (#11268). Fix the assertion to enumerate the real files."
+            exit 1
+          }
+
+      # Porte de fast-lane-shadow.yml :: fast-lane. Le moteur emet un
+      # check-run nomme par garde absorbe (API Checks) : la granularite
+      # visible sur la PR est preservee, seule l'infrastructure etait
+      # mutualisee -- et l'est desormais pour les cinq workflows.
+      - name: "Fast lane (verdicts par garde absorbe)"
+        id: fastlane
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          FAST_LANE_BASE: origin/${{ github.base_ref }}
+          FAST_LANE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FAST_LANE_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FAST_LANE_PR: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch origin "${{ github.base_ref }}" -q
+          python scripts/ci/fast_lane.py --shadow
+
+      # #12396 : controle positif d'identite byte-a-byte des gardes
+      # absorbes -- un renom du registre casserait la protection de branche
+      # (incident #12175). if: always() : diagnostique meme quand un
+      # verdict de garde a deja echoue.
+      - name: "Controle positif : identite byte-a-byte des gardes absorbes"
+        id: identity
+        if: always()
+        continue-on-error: true
+        run: python scripts/ci/check_absorbed_check_run_identity.py --check
+
+      # -----------------------------------------------------------------
+      # AGREGAT : la couleur du job. Un organe bloquant echoue -> rouge.
+      # Les organes advisory ne figurent pas ici (ils sortent toujours 0 ;
+      # si l'un crashe, le step lui-meme rougit le job -- meme posture que
+      # les jobs d'origine).
+      # -----------------------------------------------------------------
+      - name: "Agregat des verdicts bloquants"
+        if: always()
+        run: |
+          FAILED=""
+          check() {
+            # check <step-id> <outcome> -- les outcomes sont injectes par
+            # l'expression actions (steps.<id>.outcome) au templating du
+            # workflow, PAS au runtime shell : pas de reference dynamique de
+            # step possible, chaque organe est enumere explicitement.
+            if [ "$2" = "failure" ]; then
+              FAILED="$FAILED $1"
+            fi
+          }
+          check tag_required  "${{ steps.tag_required.outcome }}"
+          check prev_guard   "${{ steps.prev_guard.outcome }}"
+          check close_keyword "${{ steps.close_keyword.outcome }}"
+          check adjacency    "${{ steps.adjacency.outcome }}"
+          check lane_claim   "${{ steps.lane_claim.outcome }}"
+          check perimeter    "${{ steps.perimeter.outcome }}"
+          check fastlane     "${{ steps.fastlane.outcome }}"
+          check identity     "${{ steps.identity.outcome }}"
+          if [ -n "$FAILED" ]; then
+            echo "::error::Organes bloquants en echec :$FAILED (le detail est dans les steps correspondants ci-dessus)."
+            exit 1
+          fi
+          echo "Tous les organes always-on sont verts (ou skips d'evenement)."

--- a/.github/workflows/fast-lane-shadow.yml
+++ b/.github/workflows/fast-lane-shadow.yml
@@ -58,10 +58,17 @@ name: Fast lane (ombre)
 # NB collision #13203 : ce depot en parallele ouvre TRANCHE3 (1 garde) sur
 # les memes fichiers -- le merge des deux ajuste le compteur a 22.
 
+# DORMANT depuis #13384 : le job fast-lane est absorbe (checkout full +
+# setup-python + dependances + `fast_lane.py --shadow` + controle d'identite,
+# portes verbatim) par always-on-guards.yml -- un seul workflow, un seul
+# checkout, un seul slot de runner par PR (37 % de la file CI etait les cinq
+# gardes always-on pour ~3 min de travail reel, mesure #13384). Le job reste
+# ICI en copie de reference pour la tracabilite ET pour le controle positif
+# d'identite byte-a-byte (check_absorbed_check_run_identity.py lit ce
+# fichier : le nom du job doit rester inchanger). NE PAS reinscrire
+# pull_request ici sans retirer l'organe fastlane d'always-on-guards.
+
 on:
-  pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened, edited ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lane-claim-guard.yml
+++ b/.github/workflows/lane-claim-guard.yml
@@ -29,10 +29,15 @@ name: Lane Claim Guard
 # le reseau), YAML reduit a la plomberie, suffixe `-required` sur le nom du job
 # pour que `is_advisory()` de scripts/pr_gate.py ne le neutralise pas.
 
+# DORMANT depuis #13384 : les DEUX jobs (required + advisory) sont absorbes
+# (run blocks portes verbatim) par always-on-guards.yml -- un seul workflow,
+# un seul checkout, un seul slot de runner par PR (37 % de la file CI etait
+# les cinq gardes always-on pour ~3 min de travail reel, mesure #13384). Les
+# jobs restent ICI en copie de reference pour la tracabilite. NE PAS
+# reinscrire pull_request ici sans retirer les organes lane-claim
+# d'always-on-guards.
+
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/perimeter-review-guard.yml
+++ b/.github/workflows/perimeter-review-guard.yml
@@ -53,50 +53,19 @@ name: perimeter-review-guard
 # "fix" a future false-positive by narrowing the detection -- that loses both
 # properties at once (#11648, point 2).
 
+# DORMANT depuis #13384 : le job perimeter est absorbe (run block porte
+# verbatim, declencheurs pull_request + pull_request_review repris) par
+# always-on-guards.yml -- un seul workflow, un seul checkout, un seul slot
+# de runner par PR (37 % de la file CI etait les cinq gardes always-on pour
+# ~3 min de travail reel, mesure #13384). Le job reste ICI en copie de
+# reference pour la tracabilite (et l'identite du registre fast-lane, qui
+# lit ce fichier comme source du garde pilot). NE PAS reinscrire
+# pull_request/pull_request_review ici sans retirer l'organe perimeter
+# d'always-on-guards -- les deux surfaces executeraient le meme verdict en
+# double.
+
 on:
-  pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, edited, reopened ]
-    # PAS de `paths:` ici -- #13246 (classe #13232). Le verdict de ce garde
-    # depend d'une METADONNEE de la PR (l'assertion de perimetre dans le body
-    # ou une review) confrontee a `gh pr view --json files` (derivee du diff).
-    # Sa surface nominale est donc *toutes* les PR : toute PR dont le body
-    # affirme quelque chose sur son perimetre. Un paths-filter le reduirait
-    # aux PR touchant `.github/workflows/**` ou le script du garde -- soit
-    # ~58 % des PR merged recentes exclues de la verification, dont 21/50
-    # (42 %) portent une vraie assertion authoriale (cf. mesure #13246,
-    # 2026-08-27). Le critere #13232 : filtrer par chemins un garde
-    # METADONNEE-dependant le desarme. L'incident fondateur #11268 (la
-    # review Hermes « 2 fichiers twins uniquement » sur une PR 3-fichiers
-    # incluant un workflow) reste couvert par la surface nominale (toute
-    # PR), pas par un filtre : la PR #11227 elle-meme ne touchait pas
-    # uniquement un workflow, et le verdict a eu lieu parce que le garde
-    # n'avait PAS de paths: a l'epoque (cf. tranche 1c d'#12773, 71a36ae8b,
-    # revertede ici). Reduire le fan-out passe ici par `types:` ou
-    # `concurrency`, jamais par `paths:`.
-  pull_request_review:
-    branches: [ main ]
-    types: [ submitted, edited ]
-    # Meme raisonnement cote review : une review qui affirme un perimetre
-    # sur une PR hors `.github/workflows/**` doit aussi etre confrontee
-    # (cf. #11268 fondateur : la review elle-meme etait la source du defaut,
-    # pas le diff).
-
-permissions:
-  contents: read
-  pull-requests: read
-
-# The concurrency group carries github.event_name: the two triggers fire on
-# the SAME (PR, head SHA) pair, and a shared group with cancel-in-progress
-# lets a review-event run CANCEL a still-QUEUED pull_request run (measured on
-# #11649: pull_request run queued 14:26Z under the CI queue backlog, review
-# run started 14:57Z in the same group, the queued run died CANCELLED and
-# left a cancelled check-run on the head SHA). With event_name in the key,
-# pushes supersede pushes and reviews supersede reviews, but the two
-# triggers never cancel each other.
-concurrency:
-  group: perimeter-review-guard-${{ github.event_name }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
-  cancel-in-progress: true
+  workflow_dispatch:
 
 jobs:
   perimeter:

--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -28,18 +28,14 @@ name: Variation Light Genre Signals
 # la meme source de verite (variation_light_cap.py) et ajoute les 4
 # signaux GENRE que le cap TIER ne sait pas voir.
 
+# DORMANT depuis #13384 : le job check-light-genre-signals est absorbe (run
+# block porte verbatim) par always-on-guards.yml -- un seul workflow, un
+# seul checkout, un seul slot de runner par PR (37 % de la file CI etait les
+# cinq gardes always-on pour ~3 min de travail reel, mesure #13384). Le job
+# reste ICI en copie de reference pour la tracabilite. NE PAS reinscrire
+# pull_request ici sans retirer l'organe GENRE-signals d'always-on-guards.
+
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
-    branches: [main]
-    # PAS de `paths:` ici -- #13232. Le verdict de ce garde depend du BODY de
-    # la PR (tag `Grain:`), pas de son diff : sa surface nominale est donc
-    # *toutes* les PR. Un paths-filter le reduirait aux PR qui modifient le
-    # garde lui-meme, c'est-a-dire a presque aucune (tranche 1c d'#12773,
-    # 71a36ae8b, revertee ici). Le critere d'#12773 s'enonce ainsi : filtrer
-    # par chemins un garde DIFF-dependant (regression-guard, translation-guard)
-    # est correct ; filtrer un garde METADONNEE-dependant le desarme. Reduire
-    # le fan-out passe ici par `types:` ou `concurrency`, jamais par `paths:`.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -39,18 +39,18 @@ name: Variation Tag Guard
 # la nature du manquement lisible dans `gh pr list --json labels`, sans avoir a
 # ouvrir les logs du job.
 
+# DORMANT depuis #13384 : les SIX jobs pull_request ci-dessous sont absorbes
+# (run blocks portes verbatim) par always-on-guards.yml -- un seul workflow,
+# un seul checkout, un seul slot de runner par PR (37 % de la file CI etait
+# les cinq gardes always-on pour ~3 min de travail reel, mesure #13384).
+# Les jobs restent ICI en copie de reference (noms + logique inchanges) pour
+# la tracabilite ; leur `if: github.event_name != 'issue_comment'` les rend
+# inertes sur les runs issue_comment, et le declencheur pull_request est
+# retire : rien ne les execute plus sur une PR. NE PAS reinscrire
+# pull_request ici sans retirer les organes correspondants d'always-on-guards
+# -- les deux surfaces executeraient le meme verdict en double.
+
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
-    branches: [main]
-    # PAS de `paths:` ici -- #13232. Le verdict de ce garde depend du BODY de
-    # la PR (tag `Grain:`), pas de son diff : sa surface nominale est donc
-    # *toutes* les PR. Un paths-filter le reduirait aux PR qui modifient le
-    # garde lui-meme, c'est-a-dire a presque aucune (tranche 1c d'#12773,
-    # 71a36ae8b, revertee ici). Le critere d'#12773 s'enonce ainsi : filtrer
-    # par chemins un garde DIFF-dependant (regression-guard, translation-guard)
-    # est correct ; filtrer un garde METADONNEE-dependant le desarme. Reduire
-    # le fan-out passe ici par `types:` ou `concurrency`, jamais par `paths:`.
   # #11718 : le marqueur [G-VAR-3 OVERRIDE] vit en COMMENTAIRE de PR, mais
   # issue_comment etait absent -- poster le marqueur ne relancait rien. Un run
   # issue_comment checkout la branche par defaut (main), donc execute le gate

--- a/scripts/notebook_tools/audit_workflow_path_filters.py
+++ b/scripts/notebook_tools/audit_workflow_path_filters.py
@@ -40,10 +40,15 @@ import yaml
 REQUIRED_UNFILTERED_WORKFLOWS: set[str] = {
     # Gates PR (protection de branche)
     "pr-gate.yml",
-    "lane-claim-guard.yml",
-    "variation-tag-guard.yml",
-    "variation-light-genre.yml",
+    # #13384 : fusion des cinq gardes always-on (variation-tag-guard,
+    # perimeter-review-guard, fast-lane-shadow, variation-light-genre,
+    # lane-claim-guard -- tous dormant) en un seul workflow non filtre qui
+    # porte leurs organes metadata + le moteur fast-lane.
+    "always-on-guards.yml",
     "translation-guard.yml",
+    # Les quatre gardes fusionnes ci-dessus sont DORMANTS depuis #13384
+    # (declencheurs pull_request retires, jobs conserves en reference) :
+    # retires de cette liste, ils ne declenchent plus sur les PR.
     # catalog-pr-guard.yml retire par #11012 : le workflow n'a jamais tourne sur
     # une PR (0 run pull_request), c'est catalog-drift.yml qui tient la ligne.
     # Secret scan (doit voir chaque PR)

--- a/scripts/tests/test_audit_workflow_paths_filters.py
+++ b/scripts/tests/test_audit_workflow_paths_filters.py
@@ -37,8 +37,12 @@ def test_inventory_size():
     assert data["workflows_total"] >= 80, (
         f"expected >=80 workflows, got {data['workflows_total']}"
     )
-    assert data["workflows_pull_request"] >= 70, (
-        f"expected >=70 pull_request workflows, got {data['workflows_pull_request']}"
+    # #13384 : la fusion des 5 gardes always-on en l'umbrella always-on-guards.yml
+    # a rendu leurs workflows sources dormants (workflow_dispatch seul) —
+    # 74 -> 69 workflows a trigger pull_request. Plancher recalibre de 70 a 65
+    # (marge 4, identique a la marge d'origine), cf precedent absorption fast-lane.
+    assert data["workflows_pull_request"] >= 65, (
+        f"expected >=65 pull_request workflows, got {data['workflows_pull_request']}"
     )
 
 

--- a/scripts/tests/test_bash_e_rc_capture.py
+++ b/scripts/tests/test_bash_e_rc_capture.py
@@ -32,11 +32,12 @@ WORKFLOW = (
     Path(__file__).resolve().parents[2]
     / ".github"
     / "workflows"
-    / "variation-tag-guard.yml"
+    / "always-on-guards.yml"
 )
 
-# The three BLOCKING jobs of variation-tag-guard.yml that capture a helper
-# exit code. Each must pair its invocation with `&& RC=0 || RC=$?`.
+# The three BLOCKING helpers formerly of variation-tag-guard.yml, now steps
+# of always-on-guards.yml (#13384). Each must pair its invocation with
+# `&& RC=0 || RC=$?`.
 BLOCKING_HELPERS = [
     "python3 scripts/ci/variation_tag_required.py",
     "python3 scripts/ci/variation_prev_guard.py",

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -670,14 +670,20 @@ import pathlib
 
 
 def _read_perimeter_workflow() -> str:
-    """Locate and read the perimeter-review-guard.yml from repo root.
+    """Locate and read the LIVE perimeter surface from repo root.
+
+    #13384 : le declencheur pull_request du perimeter review guard vit
+    desormais dans always-on-guards.yml (fusion des cinq gardes always-on) ;
+    perimeter-review-guard.yml est dormant (copie de reference). Le pin de
+    trigger cible donc l'umbrella -- c'est la que `edited` doit rester
+    declare pour qu'une correction de body re-evalue le gate.
 
     Resolves from this test file's location so the test is independent of cwd.
     """
     here = pathlib.Path(__file__).resolve()
     # scripts/tests/test_check_pr_perimeter.py → repo root = parents[2]
     repo_root = here.parents[2]
-    wf = repo_root / ".github" / "workflows" / "perimeter-review-guard.yml"
+    wf = repo_root / ".github" / "workflows" / "always-on-guards.yml"
     return wf.read_text(encoding="utf-8")
 
 
@@ -1880,21 +1886,27 @@ def test_perimeter_workflow_file_exists_on_main():
 
 
 def test_perimeter_workflow_invokes_scan_thread():
-    """The cable's second leg: the workflow MUST call
+    """The cable's second leg: the LIVE gate MUST call
     `scripts/check_pr_perimeter.py --scan-thread`. A copy-paste that drops
     the flag would leave the gate never confront any review (silent green).
+
+    #13384 : la surface live est le step perimeter d'always-on-guards.yml
+    (fusion des cinq gardes always-on) ; perimeter-review-guard.yml est
+    dormant mais reste verifie -- sa copie de reference ne doit pas
+    diverger de ce qu'elle documente.
     """
     import re
-    wf = _repo_root() / ".github" / "workflows" / "perimeter-review-guard.yml"
-    text = wf.read_text(encoding="utf-8")
-    # The flag may be on the same line or split across continuation lines.
-    # Loose match: the file mentions the script and the flag.
-    assert "check_pr_perimeter.py" in text, (
-        "perimeter-review-guard.yml no longer invokes check_pr_perimeter.py"
-    )
-    assert "--scan-thread" in text, (
-        "perimeter-review-guard.yml invocation lost the --scan-thread flag"
-    )
+    for wf_name in ("always-on-guards.yml", "perimeter-review-guard.yml"):
+        wf = _repo_root() / ".github" / "workflows" / wf_name
+        text = wf.read_text(encoding="utf-8")
+        # The flag may be on the same line or split across continuation lines.
+        # Loose match: the file mentions the script and the flag.
+        assert "check_pr_perimeter.py" in text, (
+            f"{wf_name} no longer invokes check_pr_perimeter.py"
+        )
+        assert "--scan-thread" in text, (
+            f"{wf_name} invocation lost the --scan-thread flag"
+        )
 
 
 def test_perimeter_workflow_rescued_by_universal_sweep():
@@ -2169,7 +2181,13 @@ def test_13246_paths_filter_excludes_pr_with_perimeter_assertion_off_workflow():
 
 def test_13246_metadata_dependent_guard_has_no_paths_filter():
     """Verrou mecanique : apres le fix de #13246, le bloc `paths:` est absent
-    du declencheur `pull_request` de `perimeter-review-guard.yml`.
+    du declencheur `pull_request` de la surface LIVE du perimeter guard.
+
+    #13384 : la surface live est le declencheur `pull_request`/
+    `pull_request_review` d'always-on-guards.yml (fusion des cinq gardes
+    always-on ; perimeter-review-guard.yml est dormant). Le verrou suit la
+    surface qui s'execute : c'est le `paths:` de l'umbrella qui desarmerait
+    les SIX organes metadata qu'il porte.
 
     Meme contrat que `test_13232_metadata_dependent_guard_has_no_paths_filter`
     dans `test_variation_tag_required.py` (cf. #13234 tranche 1c), cible
@@ -2186,28 +2204,24 @@ def test_13246_metadata_dependent_guard_has_no_paths_filter():
 
     wf_path = (
         Path(__file__).resolve().parent.parent.parent
-        / ".github" / "workflows" / "perimeter-review-guard.yml"
+        / ".github" / "workflows" / "always-on-guards.yml"
     )
     text = wf_path.read_text(encoding="utf-8")
 
-    # Approche simple : verifier directement qu'AUCUN bloc `paths:` n'est
-    # indente sous `on:.pull_request:` ou `on:.pull_request_review:`. Le
-    # pattern cherche `paths:` a 4 espaces (sous pull_request_*) precedant un
-    # `- '` (debut d'item de liste YAML).
     # Sanity check #1 : le fichier existe et contient le declencheur.
     assert "pull_request:" in text, "Workflow doit declarer pull_request."
 
-    # Recherche : `paths:` a exactement 4 espaces en debut de ligne.
-    # Ancre le caractere apres `paths:` pour eviter les faux positifs
-    # (commentaires contenant le mot).
+    # Recherche : `paths:` a exactement 4 espaces en debut de ligne (= sous
+    # `pull_request:` ou `pull_request_review:`). Ancre la fin de ligne pour
+    # eviter les faux positifs (commentaires contenant le mot).
     paths_blocks = re.findall(r"^    paths:\s*$", text, flags=re.MULTILINE)
     assert len(paths_blocks) == 0, (
-        f"perimeter-review-guard.yml porte {len(paths_blocks)} bloc(s) `paths:` "
+        f"always-on-guards.yml porte {len(paths_blocks)} bloc(s) `paths:` "
         "a 4 espaces (= sous `pull_request:` ou `pull_request_review:`). "
-        "C'est le defaut que #13246 tranche : le verdict du garde depend d'une "
-        "METADONNEE (assertion dans le body / une review), pas du diff. Un "
-        "paths-filter le reduirait aux PR touchant `.github/workflows/**` ou "
-        "`scripts/check_pr_perimeter.py`, excluant 21/50 PR merged recentes "
-        "(42 %) qui portent une vraie assertion authoriale hors de cette "
-        "surface. Cf #13232."
+        "C'est le defaut que #13246 tranche : le verdict du garde perimeter "
+        "depend d'une METADONNEE (assertion dans le body / une review), pas "
+        "du diff. Un paths-filter sur l'umbrella desarmerait en bloc les "
+        "organes metadata qu'elle porte (tag, light-cap, genre-signals, "
+        "lane-claim) : un workflow saute par `paths:` ne poste AUCUN "
+        "check-run. Cf #13232."
     )

--- a/scripts/tests/test_emit_dead_scope_warnings.py
+++ b/scripts/tests/test_emit_dead_scope_warnings.py
@@ -144,16 +144,36 @@ def test_lane_claim_guard_workflow_yaml_remains_valid():
     """Regression pin -- the YAML literal must parse cleanly after the
     helper is wired in. The c.579 first attempt broke the YAML by putting
     a multi-line `python3 -c "..."` in a YAML scalar; the helper extraction
-    avoids that trap. Pin stays green for the foreseeable future."""
+    avoids that trap. Pin stays green for the foreseeable future.
+
+    #13384 : la surface live est le step advisory lane-claim
+    d'always-on-guards.yml (fusion des cinq gardes always-on) ;
+    lane-claim-guard.yml est dormant mais reste verifie -- sa copie de
+    reference ne doit pas diverger.
+    """
     import yaml  # type: ignore
 
-    wf = ROOT / ".github" / "workflows" / "lane-claim-guard.yml"
-    data = yaml.safe_load(wf.read_text(encoding="utf-8"))
-    assert "jobs" in data
-    assert "check-lane-claim-advisory" in data["jobs"]
-    # The advisory job's `run:` block must mention the helper by path.
-    advisory_run = "\n".join(
-        step.get("run", "") for step in
-        data["jobs"]["check-lane-claim-advisory"]["steps"]
-    )
-    assert "emit_dead_scope_warnings.py" in advisory_run
+    for wf_name in ("always-on-guards.yml", "lane-claim-guard.yml"):
+        wf = ROOT / ".github" / "workflows" / wf_name
+        data = yaml.safe_load(wf.read_text(encoding="utf-8"))
+        assert "jobs" in data, wf_name
+        if wf_name == "lane-claim-guard.yml":
+            assert "check-lane-claim-advisory" in data["jobs"]
+            # The advisory job's `run:` block must mention the helper by path.
+            advisory_run = "\n".join(
+                step.get("run", "") for step in
+                data["jobs"]["check-lane-claim-advisory"]["steps"]
+            )
+            assert "emit_dead_scope_warnings.py" in advisory_run
+        else:
+            # L'umbrella porte le run block porte verbatim : le helper doit
+            # y figurer dans le step advisory lane-claim.
+            umbrella_run = "\n".join(
+                step.get("run", "") for job in data["jobs"].values()
+                for step in job.get("steps", [])
+            )
+            assert "emit_dead_scope_warnings.py" in umbrella_run, (
+                "always-on-guards.yml ne mentionne plus "
+                "emit_dead_scope_warnings.py : le wiring #13129 des globs "
+                "morts a ete perdu dans la fusion #13384"
+            )

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -680,8 +680,10 @@ def test_aggregate_signals_real_but_candidate_innocent_10341():
     # ...but the OPEN candidate is CONTENT and does not carry the motif.
     assert sig["candidate_is_light_genre"] is False
     # The workflow's suppression gate keys off this flag (see the
-    # MAY_LABEL_INNOCENT branch in variation-light-genre.yml, #10341): the
-    # aggregate LABEL is NOT posed on this PR even though the signal is True.
+    # MAY_LABEL_INNOCENT branch in the GENRE-signals organe -- porte depuis
+    # #13384 dans always-on-guards.yml depuis variation-light-genre.yml,
+    # #10341): the aggregate LABEL is NOT posed on this PR even though the
+    # signal is True.
 
 
 def test_candidate_light_genre_true_for_guilty_meta_candidate():

--- a/scripts/tests/test_variation_tag_required.py
+++ b/scripts/tests/test_variation_tag_required.py
@@ -309,6 +309,11 @@ def test_check_name_is_not_advisory_friendly():
 # pourtant deja l'interdit par ecrit (variation-tag-guard.yml regle 2 des
 # acceptances d'#10045, et pr-gate.yml). Ce test le rend mecanique.
 METADATA_DEPENDENT_GUARDS = {
+    # #13384 : l'umbrella porte les organes metadata des cinq gardes
+    # always-on fusionnes -- c'est SA surface pull_request qui doit rester
+    # non-filtree (un `paths:` desermerait tag, light-cap, genre-signals et
+    # lane-claim d'un seul geste).
+    ".github/workflows/always-on-guards.yml": "porte les organes metadata des cinq gardes fusionnes (#13384)",
     ".github/workflows/variation-tag-guard.yml": "lit le tag Grain: du body",
     ".github/workflows/variation-light-genre.yml": "lit le tag Grain: du body",
     ".github/workflows/base-not-main-advisory.yml": "lit baseRefName (metadonnee)",


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/docs #13376

Closes #13384

## Summary

Fusion des 5 gardes always-on en **un seul workflow** `always-on-guards.yml` : 1 job, 12 organes séquentiels, **1 seul checkout** (~117 runs/vague → ~23, ~94 slots libérés, 37 % de la file).

Architecture de l'umbrella :

- **Organes advisory en premier** (toujours exit 0 : les labels atterrissent même si un organe bloquant échoue) : grain-tag labels, light-cap, GENRE-signals, lane-claim adoption telemetry.
- **Organes bloquants** : `continue-on-error: true` + `id:` (tag_required, prev_guard, close_keyword, adjacency, lane_claim, perimeter, fastlane) — le **step agrégat final** échoue le job si un seul `steps.<id>.outcome == "failure"` (les refs dynamiques de steps sont impossibles en `${{ }}` : chaque outcome est énuméré littéralement).
- **concurrency** `always-on-guards-${{ github.event_name }}-${{ pr.number || ref }}` : les runs push et review ne s'annulent pas mutuellement (piège #11649), les pushes se supplantent entre eux.
- **Contrôle d'identité** intégré (step `identity`, `if: always()`) : `check_absorbed_check_run_identity.py --check` valide à chaque run que les noms fast-lane restent byte-identiques aux workflows sources.

Les 5 workflows sources deviennent **dormants** : triggers retirés (en-tête DORMANT + avertissement « NE PAS réinscrire pull_request ici sans retirer les organes correspondants »), jobs gardés **verbatim** — ils restent la source d'identité du registre fast-lane (`guard.source` lit les fichiers ; PILOT perimeter-review-guard.yml, TRANCHE fast-lane-shadow.yml) et la copie de référence des mirror tests.

Exception live : variation-tag-guard.yml **conserve** son trigger `issue_comment` (le chemin commentaire [G-VAR-3 OVERRIDE] reste actif dans son fichier d'origine, comme avant).

## Obligation 1 — `derive_always_on_jobs` avant/après

```
BEFORE (20): Check Grain tag conformity, Flag PR targeting a non-main base (advisory),
  Check base branch staleness, G-VAR-2 light cap (cross-PR),
  Fast lane (ombre) -- 21 gardes, 1 checkout, perimeter review guard (#11268),
  No notebook health regression, Gitleaks secret scanner,
  Require genre diversity vs prev (comment, ...), Gitleaks positive controls (#10143),
  Require no closing-ref against another lane active claim (...),
  Require Grain tag (block on absent, ..., Require no close-keyword + PR-number (...),
  Require prev: non-closing (...), Require genre diversity vs prev (required, ...),
  PR gate, Verify merged PRs' mergeCommit reached main (advisory),
  G-VAR-2/3 GENRE signals (advisory, ..., No hand-edited translation files on feature branch,
  Advisory lane-claim labels (adoption telemetry, ...)

AFTER (9): Flag PR targeting a non-main base (advisory), Check base branch staleness,
  Always-on guards -- 12 organes, 1 checkout, PR gate,
  Verify merged PRs' mergeCommit reached main (advisory),
  No notebook health regression, Gitleaks secret scanner,
  Gitleaks positive controls (#10143), No hand-edited translation files on feature branch

GONE (12): les noms des jobs des 5 workflows fusionnés
NEW (1): "Always-on guards -- 12 organes, 1 checkout"
```

L'ensemble reste **non vide** → le canari `platform_delivered` de pr_gate.py reste armé.

## Obligation 2 — invariante « PR gate rend un verdict sur toute PR »

L'umbrella porte un trigger `pull_request` (branches: [main], types: opened/synchronize/edited/reopened) **sans `paths:`** (#13232, règle 2 #10045, verrou mécanique `test_13232_metadata_dependent_guard_has_no_paths_filter` retargeté). Une PR qui ne déclenche AUCUNE autre CI déclenche quand même l'umbrella → le canary voit `Always-on guards -- 12 organes, 1 checkout` → `platform_delivered` = true → verdict rendu.

## Obligation 3 — noms de check-runs

- **12 noms disparaissent, 1 apparaît** (sortie ci-dessus).
- **Branch protection vérifiée via API** : seul `PR gate` est required — **aucun** des 12 noms disparus n'est référencé dans une règle de branch protection → aucun required-check pend pour toujours.
- `check_unique_check_run_names.py` sur l'arbre fusionné : `54 jobs across 45 workflows, OK -- no duplicate rendered names` (le nouveau nom ne collisionne avec rien).
- L'agrégat échoue **avec un message listant les organes défaillants** (`::error::Organes bloquants en echec : ...`), le détail reste dans les steps individuels visibles.

## Validation (tout relancé après le dernier commit, commit c35a8fcf8 ; premier commit 1deb35e31)

| Vérification | Résultat |
|---|---|
| test_audit_workflow_paths_filters.py (plancher recalibré, cf Fichiers) | 5 passed |
| Parse YAML 6/6 workflows | OK |
| Fidélité run-blocks portés vs sources (command skeletons stricts, prose whitlistée) | 10/10 OK — a attrapé 1 vrai bug (niveau de quoting jq `startswith("'"$MARK"'")` perdu au portage) |
| `check_unique_check_run_names.py` | OK (54 jobs, 0 doublon) |
| `check_absorbed_check_run_identity.py --check` | OK (11 gardes byte-identiques) |
| `audit_workflow_path_filters.py` | rc=0 (positive control OK, 0 violation) |
| test_pr_gate.py | 57 passed |
| test_check_pr_perimeter.py | 123 passed |
| test_bash_e_rc_capture.py | 4 passed (retargeté sur l'umbrella) |
| test_variation_light_cap.py + test_check_unique_check_run_names.py | 112 passed |
| batch emit_dead_scope + tag_required + comment_trigger + fast_lane | 101 passed |

## Fichiers

- **Nouveau** : `.github/workflows/always-on-guards.yml` (l'umbrella, 12 organes).
- **Dormant-ifiés** (triggers retirés, jobs verbatim) : variation-tag-guard.yml, perimeter-review-guard.yml, fast-lane-shadow.yml, variation-light-genre.yml, lane-claim-guard.yml.
- **Mirror tests retargetés** ([mirror] : chaque édition de workflow YAML inverse son test miroir) : test_bash_e_rc_capture.py, test_check_pr_perimeter.py (3 retargetings), test_emit_dead_scope_warnings.py (boucle sur lane-claim-guard.yml + always-on-guards.yml), test_variation_tag_required.py (METADATA_DEPENDENT_GUARDS + always-on-guards.yml), test_variation_light_cap.py (commentaire).
- **Audit allowlist** : audit_workflow_path_filters.py (3 retraits, 1 ajout always-on-guards.yml).
- **Plancher d'inventaire recalibré** (commit c35a8fcf8) : test_audit_workflow_paths_filters.py — `workflows_pull_request` 74→69 par la dormance des 5 sources, plancher `>=70`→`>=65` (marge 4 conservée, précédent absorption fast-lane).

`docs/ci/slow-lane.md` mentionne fast-lane-shadow.yml en contexte historique — laissé tel quel (pas une dépendance fonctionnelle).
