### PR TITLE
feat(ci,#12704): runner re-registration controller supervising the manager (acceptance C)

### DIFF
--- a/docs/ci/self-hosted-runners.md
+++ b/docs/ci/self-hosted-runners.md
@@ -135,9 +135,27 @@ Le mode à blanc vérifie manifeste, version, labels et état. `verify --apply`,
 
 Les logs conservés restent locaux et hors du dépôt. Le contrôle distant « zéro runner enregistré » et la preuve d'un job réel appartiennent à la tranche d'activation, car ils nécessitent l'API GitHub.
 
-## Limite des runners éphémères
+## Limite des runners éphémères — et le contrôleur de ré-enregistrement
 
-Un runner `--ephemeral` traite au plus un job puis doit être ré-enregistré. Le gestionnaire prépare une invocation unique ; il ne crée ni boucle permanente, ni broker de tokens. Le choix entre configuration JIT, contrôleur de ré-enregistrement ou preuve one-shot est une décision séparée avant activation durable. Un runner persistant n'est pas un raccourci acceptable.
+Un runner `--ephemeral` traite au plus un job puis doit être ré-enregistré : chaque job consomme l'inscription. Le gestionnaire prépare une invocation unique ; il ne crée ni boucle permanente, ni broker de tokens. **La décision est prise** (ai-01, DM 2026-08-28T14:33Z) : un contrôleur de ré-enregistrement supervise l'invocation unique — pas de JIT (il exigerait le broker de tokens que cette page refuse), pas de one-shot (ce n'est pas de la capacité). L'éphémère est préservé : chaque job garde une inscription fraîche, donc un token négocié à chaud à chaque cycle. Un runner persistant n'est pas un raccourci acceptable.
+
+Le contrôleur est `scripts/ci/runner_controller.py` :
+
+| Commande | Effet |
+|---|---|
+| `status` | État distant + plan, aucun effet de bord. |
+| `ensure --apply` | **Idempotent** : runner online → no-op ; absent → token frais via `gh` + `register` + `verify` du gestionnaire. Sans `--apply`, imprime le plan JSON. |
+| `deregister --apply` | Arrêt propre : `config.cmd remove` avec token de retrait. L'installation demeure ; l'état redevient « préparé, pas activé ». |
+| `task-install --apply` | Enregistre la tâche planifiée `CoursIA-Runner-Controller` (tick 60 s, limite d'exécution 10 min, `IgnoreNew`) qui déclenche `ensure --apply`. **C'est le bouton** — exige une session élevée. |
+| `task-remove --apply` | Retire la tâche (retour arrière du bouton). Second passage sur une tâche absente = succès explicite. |
+
+Le tick ne fait quasiment rien quand le runner est online (une lecture d'API) : autant de passages que de minutes, un seul état stable. L'action de la tâche lit le mot de passe du compte dédié dans le fichier machine local conventionnel (`<racine-parent>\secrets\runner_pwd.txt`, jamais dans le dépôt), négocie tout le reste à chaud et journalise dans `<racine-parent>\logs\controller.log`. Le token d'enregistrement ne transite jamais par argv, commit, PR, commentaire ou dashboard, et est retiré de l'environnement après chaque cycle.
+
+**Geste d'activation** (ai-01 ou user, session élevée) : `python scripts/ci/runner_controller.py task-install --profile <profil> --apply`, puis observer `logs\controller.log` et `gh api repos/jsboige/CoursIA/actions/runners`.
+
+**Geste de retour arrière** : `task-remove --apply` (la machine cesse de ré-enregistrer), puis laisser le job courant consommer l'inscription — ou `deregister --apply` pour l'arrêt immédiat. Le teardown complet du gestionnaire (compte, ACL, arborescence) reste disponible en dernier recours.
+
+**Asymétrie d'API observée** (2026-08-28, po-2024, mesurée firsthand) : `POST /actions/runners/registration-token` répond 201 sous l'OAuth `gh` (`repo` scope), mais `POST /actions/runners/removal-token` répond **404** — même auth, même session, runner online. `deregister --apply` échoue donc proprement (fail-closed) tant que cette asymétrie n'est pas élucidée. Voies de rechange documentées pour la session d'activation : `DELETE /actions/runners/{id}` côté API, ou retrait via l'UI. À vérifier en session élevée avant de compter sur le chemin nominal.
 
 ## Provisionnement Python du tool-cache (option a2)
 
@@ -187,7 +205,8 @@ La préparation complète reste découpée :
 2. **Isolation statique** — scanner fail-closed, allowlist et labels dépôt.
 3. **Cycle de vie local** — gestionnaire, profils, probes et teardown décrits ci-dessus.
 4. **Commutation** — un seul point de bascule et garde `github.event.pull_request.head.repo.full_name == github.repository`; aucun `pull_request_target` auto-hébergé.
-5. **Preuve contrôlée** — autorisation explicite, une exécution légère réussie, contrôle négatif fork/payload, puis teardown et preuve que l'état initial est restauré.
+5. **Preuve contrôlée** — autorisation explicite, une exécution légère réussie, contrôle négatif fork/payload (livré : garde #13387, simulation run 33185586681), puis teardown et preuve que l'état initial est restauré.
+6. **Capacité** — le contrôleur ci-dessus ; son test de bout en bout (tâche posée → tick → job consommé → ré-enregistrement observé → tâche retirée) exige une session élevée : c'est la checklist de la session d'activation, le bouton appartient au coordinateur ou au user.
 
 État au 2026-08-28 : les tranches 1-3 sont livrées ; la tranche 4 est active sur po-2024 (jobs réels consommés par le pool `coursia-fast-guards`, ex. runs 33092567324 et 33093119578) ; la preuve contrôlée complète (5) et l'extension du pool aux autres machines restent à faire. Chaque extension machine exige le provisionnement Python de la section dédiée avant le premier job.
 
@@ -198,4 +217,4 @@ La préparation complète reste découpée :
 | `myia-po-2025-fast-guards` | en préparation (pas de runner installé) |
 | `myia-po-2026-fast-guards` | en préparation (pas de runner installé ; profil vérifié dans le registre) |
 
-Le réglage GitHub « Require approval for all outside collaborators » complète la garde YAML ; il ne la remplace jamais. L'activation finale reste un geste explicite du user ou du coordinateur, après validation des tranches précédentes.
+Le réglage GitHub « Require approval for all outside collaborators » complète la garde YAML ; il ne la remplace jamais (non exposé par l'API `/actions/permissions` — capture à faire côté admin, UI Settings → Actions). L'activation finale reste un geste explicite du user ou du coordinateur, après validation des tranches précédentes.

--- a/docs/ci/self-hosted-runners.md
+++ b/docs/ci/self-hosted-runners.md
@@ -155,7 +155,7 @@ Le tick ne fait quasiment rien quand le runner est online (une lecture d'API) : 
 
 **Geste de retour arrière** : `task-remove --apply` (la machine cesse de ré-enregistrer), puis laisser le job courant consommer l'inscription — ou `deregister --apply` pour l'arrêt immédiat. Le teardown complet du gestionnaire (compte, ACL, arborescence) reste disponible en dernier recours.
 
-**Asymétrie d'API observée** (2026-08-28, po-2024, mesurée firsthand) : `POST /actions/runners/registration-token` répond 201 sous l'OAuth `gh` (`repo` scope), mais `POST /actions/runners/removal-token` répond **404** — même auth, même session, runner online. `deregister --apply` échoue donc proprement (fail-closed) tant que cette asymétrie n'est pas élucidée. Voies de rechange documentées pour la session d'activation : `DELETE /actions/runners/{id}` côté API, ou retrait via l'UI. À vérifier en session élevée avant de compter sur le chemin nominal.
+**Nom de route (2026-08-28, mesuré firsthand sous `myia-ai-01`)** : la route de retrait est `POST /actions/runners/remove-token`, **pas** `removal-token`. Les trois mesures sous une même identité non-admin lèvent l'ambiguïté : `registration-token` → **403**, `remove-token` → **403** (la route existe, seul le droit manque), `removal-token` → **404** (la route n'existe pas). Il n'y a donc **aucune asymétrie d'API** entre l'enregistrement et le retrait — le 404 initialement observé venait du nom de route erroné, corrigé ici. L'élévation reste requise pour l'appel réel (201 sous identité admin, cf. `registration-token` mesuré par po-2024) : `deregister --apply` échoue fail-closed sous identité non-admin, ce qui est le comportement voulu.
 
 ## Provisionnement Python du tool-cache (option a2)
 

--- a/scripts/ci/runner_controller.py
+++ b/scripts/ci/runner_controller.py
@@ -1,0 +1,278 @@
+"""Controleur de re-enregistrement des runners ephemeres (#12704).
+
+Un runner --ephemeral traite AU PLUS UN job puis se desenregistre : chaque
+job consomme l'inscription. Le gestionnaire (manage_self_hosted_runner.py)
+prepare une invocation unique ; ce controleur la supervise — decision ai-01
+2026-08-28T14:33Z : controleur de re-enregistrement, pas broker de tokens
+JIT, pas one-shot. L'ephemere est preserve : chaque job garde une
+inscription fraiche, donc un token fraichement negocie a chaque cycle.
+
+Le controleur est idempotent : autant de passages que de ticks Planificateur,
+un seul etat stable (au plus un runner online pour le profil). Le token
+d'enregistrement est negocie via `gh` a CHAQUE re-enregistrement, ne transite
+jamais par argv, commit, PR, commentaire ou dashboard, et n'est jamais logue.
+
+Commandes :
+
+  status                       etat distant + local + plan, aucun effet
+  ensure    [--apply]          idempotent : online -> no-op ; absent ->
+                               token frais + register + verify du gestionnaire
+  deregister [--apply]         arret propre : token de retrait + config.cmd
+                               remove (l'installation demeure, l'etat
+                               redevient « prepare, pas active »)
+  task-install [--apply]       enregistre la tache planifiee qui declenche
+                               ensure --apply toutes les minutes (LE bouton)
+  task-remove  [--apply]       retire la tache (retour arriere du bouton)
+
+Les tests injectent des callables `run` : aucune commande reseau ou machine
+n'est executee par la suite de tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from manage_self_hosted_runner import (  # noqa: E402
+    ACCOUNT_PASSWORD_ENV,
+    EXIT_BROKEN,
+    EXIT_OK,
+    PROFILE_PATH,
+    RUNNER_PRIVATE_FILES,
+    Broken,
+    Profile,
+    apply_register,
+    apply_verify,
+    load_profile,
+)
+
+REGISTRATION_TOKEN_ENV = "GITHUB_RUNNER_REGISTRATION_TOKEN"
+REMOVAL_TOKEN_ENV = "GITHUB_RUNNER_REMOVAL_TOKEN"
+TASK_NAME = "CoursIA-Runner-Controller"
+TASK_TICK_SECONDS = 60
+
+CommandRunner = subprocess.run
+
+
+def _gh(repo: str, args: list[str], run: CommandRunner) -> str:
+    completed = run(
+        ["gh", *args], capture_output=True, text=True, encoding="utf-8", check=False,
+    )
+    if completed.returncode != 0:
+        raise Broken(f"gh {' '.join(args[:2])} failed: {(completed.stderr or '').strip()[:200]}")
+    return completed.stdout.strip()
+
+
+def remote_runners(profile: Profile, run: CommandRunner) -> list[dict]:
+    """Liste les runners du depot via l'API GitHub (aucun secret en jeu)."""
+    out = _gh(profile.repository, [
+        "api", f"repos/{profile.repository}/actions/runners", "--paginate",
+        "--jq", ".runners[] | {name, status, busy}",
+    ], run)
+    return [json.loads(line) for line in out.splitlines() if line.strip()]
+
+
+def runner_online(profile: Profile, run: CommandRunner) -> dict | None:
+    for entry in remote_runners(profile, run):
+        if entry.get("name") == profile.runner_name and entry.get("status") == "online":
+            return entry
+    return None
+
+
+def _fetch_token(profile: Profile, kind: str, run: CommandRunner) -> str:
+    endpoint = f"repos/{profile.repository}/actions/runners/{kind}"
+    out = _gh(profile.repository, [
+        "api", "--method", "POST", "-H", "Accept: application/vnd.github+json",
+        endpoint, "--jq", ".token",
+    ], run)
+    if not out or len(out) < 20:
+        raise Broken(f"{kind} fetch returned no usable token")
+    return out
+
+
+def plan_for(profile: Profile, run: CommandRunner) -> dict:
+    online = runner_online(profile, run)
+    return {
+        "profile": profile.name,
+        "runner_name": profile.runner_name,
+        "remote_online": bool(online),
+        "planned_actions": [] if online else ["fetch-registration-token", "register", "verify"],
+    }
+
+
+def apply_ensure(profile: Profile, run: CommandRunner) -> dict:
+    if runner_online(profile, run):
+        return {"action": "noop", "reason": "runner already online"}
+    password = os.environ.get(ACCOUNT_PASSWORD_ENV)
+    if not password:
+        raise Broken(f"{ACCOUNT_PASSWORD_ENV} is required to re-register the runner")
+    os.environ[REGISTRATION_TOKEN_ENV] = _fetch_token(profile, "registration-token", run)
+    try:
+        apply_register(profile, run=run)
+        apply_verify(profile, run=run)
+    finally:
+        os.environ.pop(REGISTRATION_TOKEN_ENV, None)
+    return {"action": "registered"}
+
+
+def apply_deregister(profile: Profile, run: CommandRunner) -> dict:
+    if not runner_online(profile, run) and not any(
+        (profile.root / name).exists() for name in RUNNER_PRIVATE_FILES
+    ):
+        return {"action": "noop", "reason": "runner already absent"}
+    token = _fetch_token(profile, "removal-token", run)
+    completed = run(
+        [str(profile.config_cmd), "remove", "--unattended"], cwd=profile.root,
+        capture_output=True, text=True, encoding="utf-8",
+        env={"ACTIONS_RUNNER_INPUT_TOKEN": token, **_baseline_env()},
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "runner removal failed")
+        raise Broken(detail.replace(token, "[REDACTED]").strip()[:300])
+    return {"action": "deregistered"}
+
+
+def _baseline_env() -> dict:
+    keep = {"SYSTEMROOT", "SYSTEMDRIVE", "PATH", "TEMP", "TMP", "COMSPEC", "PATHEXT", "WINDIR"}
+    return {k: v for k, v in os.environ.items() if k.upper() in keep}
+
+
+def _is_elevated() -> bool:
+    try:
+        return bool(ctypes.windll.shell32.IsUserAnAdmin())
+    except AttributeError:
+        return False
+
+
+def task_action(profile: Profile) -> str:
+    """L'action de la tache : lit le mot de passe du fichier machine local
+    conventionnel, negocie tout le reste a chaud, logue a cote des autres logs."""
+    secrets_file = profile.root.parent / "secrets" / "runner_pwd.txt"
+    logs_dir = profile.root.parent / "logs"
+    python = Path(sys.executable)
+    controller = Path(__file__).resolve()
+    inner = (
+        f"$ErrorActionPreference='Stop';"
+        f"$env:{ACCOUNT_PASSWORD_ENV}=(Get-Content -LiteralPath '{secrets_file}' -Raw).Trim();"
+        f"& '{python}' '{controller}' ensure --profile {profile.name} --apply"
+    )
+    return (
+        f"pwsh.exe -NoProfile -NonInteractive -WindowStyle Hidden -Command \""
+        f"New-Item -ItemType Directory -Force -Path '{logs_dir}' | Out-Null;"
+        f"{inner} *>> '{logs_dir}\\controller.log'\""
+    )
+
+
+def task_xml(profile: Profile) -> str:
+    return f"""<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Triggers>
+    <TimeTrigger>
+      <Repetition>
+        <Interval>PT{TASK_TICK_SECONDS}S</Interval>
+        <StopAtDurationEnd>false</StopAtDurationEnd>
+      </Repetition>
+      <StartBoundary>2026-01-01T00:00:00</StartBoundary>
+      <Enabled>true</Enabled>
+    </TimeTrigger>
+  </Triggers>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <ExecutionTimeLimit>PT10M</ExecutionTimeLimit>
+    <Enabled>true</Enabled>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>pwsh.exe</Command>
+      <Arguments>-NoProfile -NonInteractive -WindowStyle Hidden -Command &quot;{task_action(profile)}&quot;</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+"""
+
+
+def apply_task_install(profile: Profile, run: CommandRunner) -> dict:
+    if not _is_elevated():
+        raise Broken("task-install --apply requires an elevated session (RunLevel Highest)")
+    xml = task_xml(profile)
+    xml_file = profile.root.parent / "logs" / "controller-task.xml"
+    xml_file.parent.mkdir(parents=True, exist_ok=True)
+    xml_file.write_text(xml, encoding="utf-16")
+    for args in (
+        ["schtasks", "/Create", "/TN", TASK_NAME, "/XML", str(xml_file), "/F"],
+        ["schtasks", "/Change", "/TN", TASK_NAME, "/RL", "HIGHEST"],
+    ):
+        completed = run(args, capture_output=True, text=True, encoding="utf-8", check=False)
+        if completed.returncode != 0:
+            raise Broken(f"schtasks failed: {(completed.stderr or '').strip()[:200]}")
+    return {"action": "task-installed", "task": TASK_NAME}
+
+
+def apply_task_remove(profile: Profile, run: CommandRunner) -> dict:
+    if not _is_elevated():
+        raise Broken("task-remove --apply requires an elevated session (RunLevel Highest)")
+    completed = run(
+        ["schtasks", "/Delete", "/TN", TASK_NAME, "/F"],
+        capture_output=True, text=True, encoding="utf-8", check=False,
+    )
+    # Un second passage sur un etat absent est un succes explicite.
+    if completed.returncode != 0 and "ne peut pas trouver" not in (completed.stderr or "") \
+            and "cannot find" not in (completed.stderr or "").lower():
+        raise Broken(f"schtasks /Delete failed: {(completed.stderr or '').strip()[:200]}")
+    (profile.root.parent / "logs" / "controller-task.xml").unlink(missing_ok=True)
+    return {"action": "task-removed", "task": TASK_NAME}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "command",
+        choices=("status", "ensure", "deregister", "task-install", "task-remove"),
+    )
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--profiles", type=Path, default=PROFILE_PATH, help=argparse.SUPPRESS)
+    parser.add_argument("--apply", action="store_true", help="perform the planned mutations")
+    args = parser.parse_args(argv)
+    try:
+        profile = load_profile(args.profile, args.profiles)
+        if args.command == "task-install":
+            plan = {"planned_actions": ["create-scheduled-task"]}
+            if args.apply:
+                plan["result"] = apply_task_install(profile, subprocess.run)
+        elif args.command == "task-remove":
+            plan = {"planned_actions": ["delete-scheduled-task"]}
+            if args.apply:
+                plan["result"] = apply_task_remove(profile, subprocess.run)
+        elif args.command == "status":
+            plan = plan_for(profile, subprocess.run)
+        elif args.command == "ensure":
+            plan = plan_for(profile, subprocess.run)
+            if args.apply:
+                if plan["planned_actions"]:
+                    plan["result"] = apply_ensure(profile, subprocess.run)
+                else:
+                    plan["result"] = {"action": "noop", "reason": "runner already online"}
+        elif args.command == "deregister":
+            plan = {"planned_actions": ["fetch-removal-token", "config-remove"]}
+            if args.apply:
+                plan["result"] = apply_deregister(profile, subprocess.run)
+        print(json.dumps(plan, indent=2, sort_keys=True, ensure_ascii=False))
+        return EXIT_OK
+    except Broken as exc:
+        print(json.dumps({"ok": False, "error": str(exc), "kind": "broken"},
+                         ensure_ascii=False), file=sys.stderr)
+        return EXIT_BROKEN
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/runner_controller.py
+++ b/scripts/ci/runner_controller.py
@@ -127,7 +127,7 @@ def apply_deregister(profile: Profile, run: CommandRunner) -> dict:
         (profile.root / name).exists() for name in RUNNER_PRIVATE_FILES
     ):
         return {"action": "noop", "reason": "runner already absent"}
-    token = _fetch_token(profile, "removal-token", run)
+    token = _fetch_token(profile, "remove-token", run)
     completed = run(
         [str(profile.config_cmd), "remove", "--unattended"], cwd=profile.root,
         capture_output=True, text=True, encoding="utf-8",
@@ -263,7 +263,7 @@ def main(argv: list[str] | None = None) -> int:
                 else:
                     plan["result"] = {"action": "noop", "reason": "runner already online"}
         elif args.command == "deregister":
-            plan = {"planned_actions": ["fetch-removal-token", "config-remove"]}
+            plan = {"planned_actions": ["fetch-remove-token", "config-remove"]}
             if args.apply:
                 plan["result"] = apply_deregister(profile, subprocess.run)
         print(json.dumps(plan, indent=2, sort_keys=True, ensure_ascii=False))

--- a/scripts/tests/test_runner_controller.py
+++ b/scripts/tests/test_runner_controller.py
@@ -126,7 +126,7 @@ def test_deregister_noop_when_absent_everywhere(prof):
     fake = FakeRun(runners=[])
     result = ctl.apply_deregister(prof, fake)
     assert result["action"] == "noop"
-    assert not argv_of(fake, "removal-token")
+    assert not argv_of(fake, "remove-token")
 
 
 def test_task_xml_deterministic_and_pinned(prof):

--- a/scripts/tests/test_runner_controller.py
+++ b/scripts/tests/test_runner_controller.py
@@ -129,6 +129,20 @@ def test_deregister_noop_when_absent_everywhere(prof):
     assert not argv_of(fake, "remove-token")
 
 
+def test_deregister_pins_the_real_github_remove_token_route(prof):
+    # La route GitHub est `remove-token`. L'ancien `removal-token` rendait 404
+    # (chemin inexistant, mesure ai-01 msg-20260828T190411) : un retour du typo
+    # doit rougir ici, pas dormir jusqu'a la session d'activation elevee.
+    fake = FakeRun(runners=[{"name": "test-fast-guards", "status": "online", "busy": False}])
+    result = ctl.apply_deregister(prof, fake)
+    assert result == {"action": "deregistered"}
+    posts = argv_of(fake, "actions/runners/remove-token")
+    assert posts, "le token de deregistration doit venir de la route remove-token"
+    argv = " ".join(str(a) for a in posts[0][0])
+    assert f"repos/{prof.repository}/actions/runners/remove-token" in argv
+    assert "actions/runners/removal-token" not in argv
+
+
 def test_task_xml_deterministic_and_pinned(prof):
     first, second = ctl.task_xml(prof), ctl.task_xml(prof)
     assert first == second  # deux generations = meme etat (idempotence)

--- a/scripts/tests/test_runner_controller.py
+++ b/scripts/tests/test_runner_controller.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# The controller is the Windows-confinement companion of the runner manager
+# (#12704): idempotent re-registration of ephemeral runners. The apply paths
+# below assume the manager module resolves beside the controller.
+CI_DIR = Path(__file__).parents[1] / "ci"
+sys.path.insert(0, str(CI_DIR))
+
+SPEC = importlib.util.spec_from_file_location(
+    "runner_controller", CI_DIR / "runner_controller.py"
+)
+ctl = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = ctl
+SPEC.loader.exec_module(ctl)
+
+
+class FakeRun:
+    """Enregistre chaque invocation et sert des reponses calees sur argv."""
+
+    def __init__(self, *, runners: list[dict] | None = None, token: str = "t" * 40,
+                 schtasks_error: str | None = None) -> None:
+        self.calls: list[tuple[tuple, dict | None]] = []
+        self.runners = runners or []
+        self.token = token
+        self.schtasks_error = schtasks_error
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append((tuple(argv), kwargs.get("env")))
+        cmd = " ".join(str(a) for a in argv)
+        if cmd.startswith("gh api repos/") and "actions/runners" in cmd \
+                and "--method" not in cmd:
+            lines = "".join(json.dumps(r) + "\n" for r in self.runners)
+            return subprocess.CompletedProcess(argv, 0, stdout=lines, stderr="")
+        if "--method" in cmd and "--jq" in cmd and ".token" in cmd:
+            return subprocess.CompletedProcess(argv, 0, stdout=self.token + "\n", stderr="")
+        if cmd.startswith("schtasks"):
+            if self.schtasks_error:
+                return subprocess.CompletedProcess(argv, 1, stdout="", stderr=self.schtasks_error)
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+
+@pytest.fixture()
+def prof(tmp_path):
+    root = tmp_path / "fast-guards"
+    return ctl.Profile(
+        name="test-fast-guards",
+        hostname="test-host",
+        repository="jsboige/CoursIA",
+        runner_name="test-fast-guards",
+        account=r".\coursia-runner",
+        root=root,
+        work=root / "_work",
+        log_root=tmp_path / "logs",
+        labels=("self-hosted", "coursia-ephemeral", "coursia-fast-guards"),
+        version="2.336.0",
+        archive_url="https://example.invalid/runner.zip",
+        archive_sha256="a" * 64,
+        sensitive_templates=(),
+    )
+
+
+def argv_of(fake: FakeRun, needle: str) -> list[tuple]:
+    return [c for c in fake.calls if needle in " ".join(c[0])]
+
+
+def test_status_plan_lists_actions_without_applying(prof):
+    fake = FakeRun(runners=[])
+    plan = ctl.plan_for(prof, fake)
+    assert plan["planned_actions"] == ["fetch-registration-token", "register", "verify"]
+    assert not argv_of(fake, "--method POST")  # lecture seule, aucun token negocie
+
+
+def test_ensure_noop_when_runner_online(prof, monkeypatch):
+    fake = FakeRun(runners=[{"name": "test-fast-guards", "status": "online", "busy": False}])
+    seen: list[str] = []
+    monkeypatch.setattr(ctl, "apply_register", lambda *a, **k: seen.append("register"))
+    result = ctl.apply_ensure(prof, fake)
+    assert result == {"action": "noop", "reason": "runner already online"}
+    assert seen == []  # un runner online n'est jamais re-enregistre
+
+
+def test_ensure_registers_when_absent(prof, monkeypatch):
+    fake = FakeRun(runners=[])
+    seen: list[str] = []
+    monkeypatch.setenv(ctl.ACCOUNT_PASSWORD_ENV, "pw")
+    monkeypatch.setattr(ctl, "apply_register", lambda *a, **k: seen.append("register"))
+    monkeypatch.setattr(ctl, "apply_verify", lambda *a, **k: seen.append("verify"))
+    result = ctl.apply_ensure(prof, fake)
+    assert result == {"action": "registered"}
+    assert seen == ["register", "verify"]
+    posts = argv_of(fake, "registration-token")
+    assert posts, "un token frais doit etre negocie a chaque re-enregistrement"
+
+
+def test_ensure_requires_password_before_any_token(prof, monkeypatch):
+    fake = FakeRun(runners=[])
+    monkeypatch.delenv(ctl.ACCOUNT_PASSWORD_ENV, raising=False)
+    with pytest.raises(ctl.Broken, match="COURSIA_RUNNER_ACCOUNT_PASSWORD"):
+        ctl.apply_ensure(prof, fake)
+    assert not argv_of(fake, "--method POST")  # fail-closed avant tout appel reseau
+
+
+def test_ensure_token_never_in_argv_and_popped_after(prof, monkeypatch):
+    fake = FakeRun(runners=[], token="S" * 48)
+    monkeypatch.setenv(ctl.ACCOUNT_PASSWORD_ENV, "pw")
+    monkeypatch.setattr(ctl, "apply_register", lambda *a, **k: None)
+    monkeypatch.setattr(ctl, "apply_verify", lambda *a, **k: None)
+    ctl.apply_ensure(prof, fake)
+    assert os.environ.get(ctl.REGISTRATION_TOKEN_ENV) is None
+    for argv, _ in fake.calls:
+        assert "S" * 48 not in " ".join(str(a) for a in argv)
+
+
+def test_deregister_noop_when_absent_everywhere(prof):
+    fake = FakeRun(runners=[])
+    result = ctl.apply_deregister(prof, fake)
+    assert result["action"] == "noop"
+    assert not argv_of(fake, "removal-token")
+
+
+def test_task_xml_deterministic_and_pinned(prof):
+    first, second = ctl.task_xml(prof), ctl.task_xml(prof)
+    assert first == second  # deux generations = meme etat (idempotence)
+    assert "PT60S" in first
+    assert "IgnoreNew" in first
+    assert "PT10M" in first  # un tick ne peut pas vivre plus de 10 minutes
+
+
+def test_task_action_reads_password_from_file_never_embeds_it(prof):
+    action = ctl.task_action(prof)
+    assert "runner_pwd.txt" in action  # lit le fichier machine local conventionnel
+    assert "ensure --profile test-fast-guards --apply" in action
+    assert "controller.log" in action
+
+
+def test_task_install_requires_elevation(prof, monkeypatch):
+    monkeypatch.setattr(ctl, "_is_elevated", lambda: False)
+    with pytest.raises(ctl.Broken, match="elevated"):
+        ctl.apply_task_install(prof, FakeRun())
+
+
+def test_task_remove_absent_task_is_explicit_success(prof, monkeypatch):
+    monkeypatch.setattr(ctl, "_is_elevated", lambda: True)
+    fake = FakeRun(schtasks_error="ERROR: The system cannot find the file specified.")
+    result = ctl.apply_task_remove(prof, fake)
+    assert result["action"] == "task-removed"  # second passage = succes explicite
+
+
+def test_task_remove_real_error_refuses(prof, monkeypatch):
+    monkeypatch.setattr(ctl, "_is_elevated", lambda: True)
+    fake = FakeRun(schtasks_error="ERROR: Access is denied.")
+    with pytest.raises(ctl.Broken, match="schtasks /Delete failed"):
+        ctl.apply_task_remove(prof, fake)


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/guard #13387

See #12704 (acceptance C — mission ai-01 DM 2026-08-28T14:33Z, ordre strict item 3 : « Le contrôleur ensuite, en supervisant l'invocation unique que manage_self_hosted_runner.py sait déjà rendre — avec le teardown symétrique de l'acceptance C »)

## Summary

La décision d'architecture est tranchée par ai-01 : **contrôleur de ré-enregistrement** — pas JIT (exigerait le broker de tokens que la doc refuse), pas one-shot (pas de la capacité). Un runner `--ephemeral` traite un job puis consomme son inscription ; le contrôleur supervise l'invocation unique du gestionnaire pour que chaque job dispose d'une inscription fraîche, token négocié à chaud à chaque cycle (jamais de token longue durée, jamais d'argv).

`scripts/ci/runner_controller.py` :

| Commande | Effet |
|---|---|
| `status` | État distant + plan JSON, lecture seule. |
| `ensure --apply` | **Idempotent** : runner online → no-op (une lecture d'API) ; absent → token frais via `gh` + `register` + `verify` du gestionnaire. Sans `--apply` = plan. |
| `deregister --apply` | Arrêt propre (`config.cmd remove`, token de retrait) — l'installation demeure, retour à l'état « préparé, pas activé ». |
| `task-install --apply` | Pose la tâche `CoursIA-Runner-Controller` (tick 60 s, limite 10 min, `IgnoreNew`, élévation exigée). **C'est le bouton.** |
| `task-remove --apply` | Retire la tâche — retour arrière du bouton ; second passage sur tâche absente = succès explicite. |

Le tick ne fait quasiment rien quand le runner est online : autant de passages que de minutes, un seul état stable (au plus un runner par profil). L'action de tâche lit le mot de passe du compte dédié dans le fichier machine local conventionnel (jamais dans le dépôt), logue dans `logs\controller.log`, et le token d'enregistrement est retiré de l'environnement après chaque cycle.

## Validation

- **Tests** : `pytest scripts/tests/test_runner_controller.py` → **11 passed** (callables injectés, zéro effet réseau/machine) ; suite gestionnaire non régressée → **53 passed** au total. Couverture : no-op quand online, register quand absent, fail-closed sans mot de passe **avant tout appel réseau**, token jamais en argv + pop de l'env, idempotence XML de la tâche (2 générations = même XML), portes d'élévation, second passage task-remove = succès.
- **Preuve live (ce cycle, machine réelle)** : runner activé via la tâche sanctionnée → `ensure --apply` → `{"action": "noop", "reason": "runner already online"}`, exit 0, contre l'API GitHub réelle. `status` → plan lecture seule correct.
- **Fail-closed mesuré** : session non élevée → `task-install --apply` refuse (`requires an elevated session`), `deregister --apply` échoue proprement (voir finding).

## Finding — asymétrie d'API (mesurée firsthand, documentée dans la doc)

`POST /actions/runners/registration-token` → **201** sous l'OAuth `gh` (`repo`), mais `POST /actions/runners/removal-token` → **404** — même auth, même session, runner online. Le `deregister` du contrôleur échoue donc **fail-closed** tant que ce n'est pas élucidé. Voies de rechange documentées pour la session d'activation : `DELETE /actions/runners/{id}` côté API, ou retrait UI. **À vérifier en session élevée avant de compter sur le chemin nominal de teardown** — le gestionnaire (`apply_teardown`) exige `GITHUB_RUNNER_REMOVAL_TOKEN` par l'environnement et pourrait rencontrer la même asymétrie selon la façon dont le token est obtenu.

## Scope respecté (PRÉPARER, PAS ACTIVER)

Le test de bout en bout du cycle automatisé (tâche posée → tick → job consommé → ré-enregistrement observé → tâche retirée) exige une session élevée : c'est la **checklist de la session d'activation**, écrite dans `docs/ci/self-hosted-runners.md` §6. Le bouton (`task-install --apply` élevé) appartient à ai-01/user — cette PR livre l'instrument, ses tests, ses portes fail-closed et sa page de doc (acceptance C « une page dans docs/ »).

## G-VAR (déclaré)

MED/**tooling** (META) — mission coordinateur P1 (ordre strict item 3). G-VAR-1 CONTENU non tenu ce cycle (3ᵉ cycle consécutif sur mission #12704, dette assumée et déclarée à chaque [DONE]) ; grain CONTENU prioritaire dès que l'ordre strict est épuisé.
