### PR TITLE
fix(slides,#13224): S3 tranche 2 - 11 img-grid slides en vraies grilles Tailwind

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -706,10 +706,10 @@ layout: default
 - Solveurs SAT
   - Problèmes NP-complets
 
-<div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_038.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Table de vérité en français des connecteurs logiques P, Q (négation, conjonction, disjonction, implication)" />
-<img src="./images/img_039.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Diagrammes de Venn des connecteurs logiques : (P ∨ Q), (P ∧ Q), (P ⇒ Q), (P ⇔ Q)" />
-<img src="./images/img_040.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Réseau sémantique : Mammals, Persons, Mary, John reliés par liens d'héritage et propriétés" />
+<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_038.png" class="max-h-[190px] w-full object-contain" alt="Table de vérité en français des connecteurs logiques P, Q (négation, conjonction, disjonction, implication)" />
+<img src="./images/img_039.png" class="max-h-[190px] w-full object-contain" alt="Diagrammes de Venn des connecteurs logiques : (P ∨ Q), (P ∧ Q), (P ⇒ Q), (P ⇔ Q)" />
+<img src="./images/img_040.png" class="max-h-[190px] w-full object-contain" alt="Réseau sémantique : Mammals, Persons, Mary, John reliés par liens d'héritage et propriétés" />
 </div>
 ---
 
@@ -858,11 +858,11 @@ layout: default
 - Planification à Ordre partiel
 - Décomposition hiérarchique
 
-<div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_043.png" class="max-h-[300px] max-w-full object-contain" alt="Graphe de planification : Start, Go(HWS), Go(SM), Buy(Drill/Milk/Bananas), Finish avec états At/Have" />
-<img src="./images/img_044.png" class="max-h-[300px] max-w-full object-contain" alt="Décomposition HTN « Build House » : Obtain Permit, Construction et sous-tâches" />
-<img src="./images/img_045.png" class="max-h-[300px] max-w-full object-contain" alt="Plan de transport aérien en logique : Init, Goal, actions Load/Unload/Fly avec préconditions et effets" />
-<img src="./images/img_046.png" class="max-h-[300px] max-w-full object-contain" alt="Plan d'actions logiques : Load(C1,P1,SFO), Fly(P1,SFO,JFK), Unload (transport aérien)" />
+<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_043.png" class="max-h-[190px] w-full object-contain" alt="Graphe de planification : Start, Go(HWS), Go(SM), Buy(Drill/Milk/Bananas), Finish avec états At/Have" />
+<img src="./images/img_044.png" class="max-h-[190px] w-full object-contain" alt="Décomposition HTN « Build House » : Obtain Permit, Construction et sous-tâches" />
+<img src="./images/img_045.png" class="max-h-[190px] w-full object-contain" alt="Plan de transport aérien en logique : Init, Goal, actions Load/Unload/Fly avec préconditions et effets" />
+<img src="./images/img_046.png" class="max-h-[190px] w-full object-contain" alt="Plan d'actions logiques : Load(C1,P1,SFO), Fly(P1,SFO,JFK), Unload (transport aérien)" />
 </div>
 ---
 
@@ -1084,11 +1084,11 @@ layout: section
 
 </div>
 
-<div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_061.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Courbe d'utilité concave : utilité U en fonction du montant en dollars" />
-<img src="./images/img_062.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Diagramme d'influence : décision AirportSite, conséquences Deaths/Noise/Cost, utilité U" />
-<img src="./images/img_063.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Processus de décision markovien : états S0-S2, actions a0-a1, récompenses +5/-1, probabilités de transition" />
-<img src="./images/img_064.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Grille 3x3 de navigation avec flèches de politique, cases +1/-1, piège, et inégalité sur R(s)" />
+<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_061.png" class="max-h-[190px] w-full object-contain" alt="Courbe d'utilité concave : utilité U en fonction du montant en dollars" />
+<img src="./images/img_062.png" class="max-h-[190px] w-full object-contain" alt="Diagramme d'influence : décision AirportSite, conséquences Deaths/Noise/Cost, utilité U" />
+<img src="./images/img_063.png" class="max-h-[190px] w-full object-contain" alt="Processus de décision markovien : états S0-S2, actions a0-a1, récompenses +5/-1, probabilités de transition" />
+<img src="./images/img_064.png" class="max-h-[190px] w-full object-contain" alt="Grille 3x3 de navigation avec flèches de politique, cases +1/-1, piège, et inégalité sur R(s)" />
 </div>
 ---
 
@@ -1463,11 +1463,11 @@ layout: section
 - Random forest
 - Ensemble
 
-<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_085.png" class="max-h-[300px] max-w-full object-contain" alt="Arbre de décision « Faut-il attendre ? » (exemple restaurant)" />
-<img src="./images/img_086.png" class="max-h-[300px] max-w-full object-contain" alt="Table d'exemples d'entraînement : Autre, Bar, Vendredi, Faim, Clients, Prix, Pluie, Réservation, Type, Estimation — 12 exemples" />
-<img src="./images/img_087.png" class="max-h-[300px] max-w-full object-contain" alt="Partitions d'attributs Clients? et Type? : ronds verts et rouges séparés en sous-ensembles" />
-<img src="./images/img_088.png" class="max-h-[300px] max-w-full object-contain" alt="Forêt aléatoire : nœud X, arbres tree1-treeB, vote (classification) ou moyenne (régression)" />
+<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_085.png" class="max-h-[190px] w-full object-contain" alt="Arbre de décision « Faut-il attendre ? » (exemple restaurant)" />
+<img src="./images/img_086.png" class="max-h-[190px] w-full object-contain" alt="Table d'exemples d'entraînement : Autre, Bar, Vendredi, Faim, Clients, Prix, Pluie, Réservation, Type, Estimation — 12 exemples" />
+<img src="./images/img_087.png" class="max-h-[190px] w-full object-contain" alt="Partitions d'attributs Clients? et Type? : ronds verts et rouges séparés en sous-ensembles" />
+<img src="./images/img_088.png" class="max-h-[190px] w-full object-contain" alt="Forêt aléatoire : nœud X, arbres tree1-treeB, vote (classification) ou moyenne (régression)" />
 </div>
 ---
 
@@ -1493,11 +1493,11 @@ layout: section
 - Multi-couches
   - Expressivité croissante
 
-<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_090.png" class="max-h-[300px] max-w-full object-contain" alt="Neurone biologique : dendrites, soma, axone — l'inspiration des réseaux artificiels" />
-<img src="./images/img_091.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_092.png" class="max-h-[300px] max-w-full object-contain" alt="Réseau de neurones fully-connected : une entrée, quatre neurones cachés, dix sorties" />
-<img src="./images/img_093.png" class="max-h-[300px] max-w-full object-contain" alt="Fonctions d'activation : sigmoïde, tanh, ReLU, Leaky ReLU, Maxout, ELU — formules et courbes" />
+<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_090.png" class="max-h-[190px] w-full object-contain" alt="Neurone biologique : dendrites, soma, axone — l'inspiration des réseaux artificiels" />
+<img src="./images/img_091.png" class="max-h-[190px] w-full object-contain" />
+<img src="./images/img_092.png" class="max-h-[190px] w-full object-contain" alt="Réseau de neurones fully-connected : une entrée, quatre neurones cachés, dix sorties" />
+<img src="./images/img_093.png" class="max-h-[190px] w-full object-contain" alt="Fonctions d'activation : sigmoïde, tanh, ReLU, Leaky ReLU, Maxout, ELU — formules et courbes" />
 </div>
 ---
 
@@ -1517,11 +1517,11 @@ layout: section
   - Noyaux de convolution
   - Sous-échantillonnage
 
-<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_094.png" class="max-h-[300px] max-w-full object-contain" alt="Opération de convolution : volume d'entrée 7x7x3 et noyau 3x3x3 glissant sur la matrice" />
-<img src="./images/img_095.png" class="max-h-[300px] max-w-full object-contain" alt="Architecture CNN historique : couches « Simple cells » (convolutions multiples) et « Complex cells » (sous-échantillonnage par pooling)" />
-<img src="./images/img_096.png" class="max-h-[300px] max-w-full object-contain" alt="Transfert learning : photo de voiture, extracteur de caractéristiques, caractéristiques de haut niveau, classifieur entraînable" />
-<img src="./images/img_097.png" class="max-h-[300px] max-w-full object-contain" alt="RNN déroulé : cellule A récurrente, entrées x0 à xt, sorties h0 à ht" />
+<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_094.png" class="max-h-[190px] w-full object-contain" alt="Opération de convolution : volume d'entrée 7x7x3 et noyau 3x3x3 glissant sur la matrice" />
+<img src="./images/img_095.png" class="max-h-[190px] w-full object-contain" alt="Architecture CNN historique : couches « Simple cells » (convolutions multiples) et « Complex cells » (sous-échantillonnage par pooling)" />
+<img src="./images/img_096.png" class="max-h-[190px] w-full object-contain" alt="Transfert learning : photo de voiture, extracteur de caractéristiques, caractéristiques de haut niveau, classifieur entraînable" />
+<img src="./images/img_097.png" class="max-h-[190px] w-full object-contain" alt="RNN déroulé : cellule A récurrente, entrées x0 à xt, sorties h0 à ht" />
 </div>
 ---
 
@@ -1539,13 +1539,13 @@ layout: section
 - GANs (2014)
   - Réseaux adversériaux
 
-<div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_098.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="RNN déroulé : cellule récurrente A, entrées x0 à xt, sorties h0 à ht" />
-<img src="./images/img_099.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Cellule récurrente LSTM : portes sigmoïdes σ, tanh, états cachés h entre les pas de temps" />
-<img src="./images/img_100.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="RNN à cinq cellules A alignées : entrées x0-x4, sorties h0-h4" />
-<img src="./images/img_101.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Porte sigmoïde σ de cellule LSTM — rendu dégradé, figure à régénérer (voir issue dédiée)" />
-<img src="./images/img_102.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="GAN : bruit aléatoire, générateur produisant une image forgée, discriminateur classant réel/factice" />
-<img src="./images/img_103.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Bloc résiduel ResNet : deux couches, connexion identité, H(x)=F(x)+x" />
+<div class="grid grid-cols-3 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_098.png" class="max-h-[150px] w-full object-contain" alt="RNN déroulé : cellule récurrente A, entrées x0 à xt, sorties h0 à ht" />
+<img src="./images/img_099.png" class="max-h-[150px] w-full object-contain" alt="Cellule récurrente LSTM : portes sigmoïdes σ, tanh, états cachés h entre les pas de temps" />
+<img src="./images/img_100.png" class="max-h-[150px] w-full object-contain" alt="RNN à cinq cellules A alignées : entrées x0-x4, sorties h0-h4" />
+<img src="./images/img_101.png" class="max-h-[150px] w-full object-contain" alt="Porte sigmoïde σ de cellule LSTM — rendu dégradé, figure à régénérer (voir issue dédiée)" />
+<img src="./images/img_102.png" class="max-h-[150px] w-full object-contain" alt="GAN : bruit aléatoire, générateur produisant une image forgée, discriminateur classant réel/factice" />
+<img src="./images/img_103.png" class="max-h-[150px] w-full object-contain" alt="Bloc résiduel ResNet : deux couches, connexion identité, H(x)=F(x)+x" />
 </div>
 
 <!-- GANs : générateur vs discriminateur, portraits StyleGAN, deepfakes -->
@@ -1569,13 +1569,13 @@ layout: section
 - Semi-supervisé, Transfert
 - LLMs : BERT (2018), GPT
 
-<div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_104.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Deux photos d'une femme lançant un frisbee dans un parc, légendées en anglais" />
-<img src="./images/img_105.jpg" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Attention mot à mot : traduction de « How was your day » avec poids d'importance colorés" />
-<img src="./images/img_106.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Autoencodeur variationnel : encodeur, mu/sigma, échantillonnage, décodeur, perte reconstruction + KL" />
-<img src="./images/img_107.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Graphe irrégulier versus grille de texte séquentielle — deux structures de données" />
-<img src="./images/img_108.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Pipeline GNN : graphe d'entrée, blocs GNN, graphe transformé, couche de classification, prédiction" />
-<img src="./images/img_109.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Architecture Transformer encodeur-décodeur avec auto-attention, exemple de traduction du tchèque" />
+<div class="grid grid-cols-3 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_104.png" class="max-h-[150px] w-full object-contain" alt="Deux photos d'une femme lançant un frisbee dans un parc, légendées en anglais" />
+<img src="./images/img_105.jpg" class="max-h-[150px] w-full object-contain" alt="Attention mot à mot : traduction de « How was your day » avec poids d'importance colorés" />
+<img src="./images/img_106.png" class="max-h-[150px] w-full object-contain" alt="Autoencodeur variationnel : encodeur, mu/sigma, échantillonnage, décodeur, perte reconstruction + KL" />
+<img src="./images/img_107.png" class="max-h-[150px] w-full object-contain" alt="Graphe irrégulier versus grille de texte séquentielle — deux structures de données" />
+<img src="./images/img_108.png" class="max-h-[150px] w-full object-contain" alt="Pipeline GNN : graphe d'entrée, blocs GNN, graphe transformé, couche de classification, prédiction" />
+<img src="./images/img_109.png" class="max-h-[150px] w-full object-contain" alt="Architecture Transformer encodeur-décodeur avec auto-attention, exemple de traduction du tchèque" />
 </div>
 
 <!-- Transformer : encodeur-decodeur, self-attention multi-tetes, positional encoding -->
@@ -1600,11 +1600,11 @@ layout: section
 - Conditionnement multimodal
 - Mécanisme attentionnel
 
-<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_110.png" class="max-h-[300px] max-w-full object-contain" alt="Trois paires image-légende : rue de Kyoto, aigle en vol, paysage montagneux" />
-<img src="./images/img_111.png" class="max-h-[300px] max-w-full object-contain" alt="CLIP : plongements image et texte comparés, mise à jour des modèles, verdict similaire ou non" />
-<img src="./images/img_112.png" class="max-h-[300px] max-w-full object-contain" alt="Chaîne de Markov de diffusion : bruitage progressif de xT vers x0 puis débruitage inverse" />
-<img src="./images/img_113.png" class="max-h-[300px] max-w-full object-contain" alt="U-Net de débruitage latent : encodeur, décodeur, attention croisée Q/K/V, conditionnements et pas de temps" />
+<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_110.png" class="max-h-[190px] w-full object-contain" alt="Trois paires image-légende : rue de Kyoto, aigle en vol, paysage montagneux" />
+<img src="./images/img_111.png" class="max-h-[190px] w-full object-contain" alt="CLIP : plongements image et texte comparés, mise à jour des modèles, verdict similaire ou non" />
+<img src="./images/img_112.png" class="max-h-[190px] w-full object-contain" alt="Chaîne de Markov de diffusion : bruitage progressif de xT vers x0 puis débruitage inverse" />
+<img src="./images/img_113.png" class="max-h-[190px] w-full object-contain" alt="U-Net de débruitage latent : encodeur, décodeur, attention croisée Q/K/V, conditionnements et pas de temps" />
 </div>
 
 <!-- Diffusion : bruit gaussien progressif → apprentissage du debruitage inverse -->
@@ -1629,11 +1629,11 @@ layout: section
 - Séparateurs à marge maximale
 - Astuce du noyau
 
-<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_114.png" class="max-h-[300px] max-w-full object-contain" alt="Courbe en cloche gaussienne centrée en zéro, densité de probabilité" />
-<img src="./images/img_115.png" class="max-h-[300px] max-w-full object-contain" alt="Diagramme de Voronoi bicolore : points rouges et bleus, classification par cellules" />
-<img src="./images/img_116.png" class="max-h-[300px] max-w-full object-contain" alt="SVM : deux classes (étoiles rouges, triangles verts), hyperplan, marge, vecteurs de support" />
-<img src="./images/img_117.png" class="max-h-[300px] max-w-full object-contain" alt="Astuce du noyau : nuage 2D non séparable projeté en 3D où un plan sépare les classes" />
+<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_114.png" class="max-h-[190px] w-full object-contain" alt="Courbe en cloche gaussienne centrée en zéro, densité de probabilité" />
+<img src="./images/img_115.png" class="max-h-[190px] w-full object-contain" alt="Diagramme de Voronoi bicolore : points rouges et bleus, classification par cellules" />
+<img src="./images/img_116.png" class="max-h-[190px] w-full object-contain" alt="SVM : deux classes (étoiles rouges, triangles verts), hyperplan, marge, vecteurs de support" />
+<img src="./images/img_117.png" class="max-h-[190px] w-full object-contain" alt="Astuce du noyau : nuage 2D non séparable projeté en 3D où un plan sépare les classes" />
 </div>
 ---
 
@@ -1817,11 +1817,11 @@ layout: section
   - Résumé, analyse syntaxique
   - Modèles sémantiques profonds
 
-<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_127.png" class="max-h-[300px] max-w-full object-contain" alt="Seq2seq avec attention : encodeur « hello how are you », décodeur allemand « hallo wie geht es dir »" />
-<img src="./images/img_128.png" class="max-h-[300px] max-w-full object-contain" alt="Résultats de recherche d'un modèle CLSM : requêtes et titres de documents retournés" />
-<img src="./images/img_129.png" class="max-h-[300px] max-w-full object-contain" alt="Signal audio analogique, version échantillonnée, et découpage en trames avec caractéristiques" />
-<img src="./images/img_130.png" class="max-h-[300px] max-w-full object-contain" alt="Traduction par interlingua : sémantique commune puis syntaxe et mots anglais/français (John loves Mary / Jean aime Marie)" />
+<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
+<img src="./images/img_127.png" class="max-h-[190px] w-full object-contain" alt="Seq2seq avec attention : encodeur « hello how are you », décodeur allemand « hallo wie geht es dir »" />
+<img src="./images/img_128.png" class="max-h-[190px] w-full object-contain" alt="Résultats de recherche d'un modèle CLSM : requêtes et titres de documents retournés" />
+<img src="./images/img_129.png" class="max-h-[190px] w-full object-contain" alt="Signal audio analogique, version échantillonnée, et découpage en trames avec caractéristiques" />
+<img src="./images/img_130.png" class="max-h-[190px] w-full object-contain" alt="Traduction par interlingua : sémantique commune puis syntaxe et mots anglais/français (John loves Mary / Jean aime Marie)" />
 </div>
 ---
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA — prev: MED/tooling #13392

See #13224 (tranche 2 — les 11 slides au signature identique ; tranches 3+ restantes = rendues 7/5/21/42/23/18/2, non touchées)

## Summary

Tranche 2 de l'Epic slides S3 : les 11 blocs `img-grid` restants au même signature dans `slides/S3-acculturation/slides.md` (rendues **28/32/40/52/54/55/56/57/58/59/66**) empilaient leurs images **verticalement** dans un div `w-[400px]` ancré à droite — les classes `img-grid` de style.css n'ont pas de `grid-template-columns`, d'où ~57 % de vide à gauche et severity **high** au scan de composition.

Chaque bloc est remplacé par une vraie grille Tailwind :

```html
<div class="grid grid-cols-2 gap-2 absolute top-[130px] right-[20px] w-[600px]">
  <img src="..." class="max-h-[190px] w-full object-contain" />
```

- `grid-cols-3` pour les deux slides à 6 images (rendues 54bis/55bis « Extensions 2010+/2015+ »), `grid-cols-2` ailleurs ;
- hauteurs calibrées `max-h-[150px]`/`max-h-[190px]` : top-130 + 2×190 + gap ≈ 518 < 552 px de canvas, zéro débordement vertical ;
- largeur 600 + right-20 → gap gauche 36,7 % < borne 40 %.

Édité par ancrage H1 (numérotation source vs rendu dérive de 1) ; 10 marqueurs `img-grid` restent dans le fichier = tranches 3+, intentionnellement non touchées.

## Validation (scan de composition, deck servi depuis le worktree)

| Métrique | Avant | Après |
|---|---|---|
| Slides severity **high** | 18 | **7** (= exactement les tranches 3+ : 7/5/21/42/23/18/2) |
| Les 11 cibles | high (~57 %) | **low**, gap_max **36,7 %**, gap_right ~2 % |
| HORS_CANVAS | — | **0** / 99 slides |
| Chevauchements | — | **0** / 99 slides |

Pipeline : `scan_slidev_composition.py --url http://localhost:4174` (Playwright headless, serveur dev sur le worktree) → `scan_slidev_gap_report.py`. Artefacts de scan hors repo (session).

**QA visuel Playwright** sur 3 des 11 cibles (une par variante de grille) :
- rendue 28 « Logique propositionnelle » : 3 images en vraie grille à droite, texte intact, pas de chevauchement ;
- rendue 56 « Extensions 2010+ » : 6 images en grille 3 colonnes, pas de débordement ;
- rendue 54 « Réseaux de neurones artificiels » : 4 images en grille 2×2, pas de chevauchement texte/image.

**Note d'honnêteté** : la console du deck en mode SPA affiche ~25 erreurs préexistantes « slide failed to load SyntaxError … export named 'default' » (lazy-load dynamique des slides non courantes) — observées identiques avant et après le patch, le diff ne touche que du markup div/img. Le scanner mesure les 99 slides normalement.

## G-VAR (déclaré)

MED/**slides** (CONTENU) — grain de contenu prioritaire après 3 cycles META consécutifs sur la mission #12704 (dette G-VAR-1 assumée et déclarée à chaque [DONE]) : **plancher G-VAR-1 tenu ce cycle**.
