### PR TITLE
docs(lean,#13366): LEAN_INVENTORY — 3 racines sans inventaire (kelly, planning, argumentation)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/LEAN_INVENTORY.md
@@ -1,0 +1,40 @@
+# Lean 4 Projects Inventory — QuantConnect
+
+Cross-directory inventory of all Lean 4 formalization projects under `QuantConnect/`.
+
+Réconcilié le 2026-08-28 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
+module-set réel du disque (issue #13366, matrice #13121 tranche 3). Comptes `sorry` mesurés avec
+l'instrument canonique `scripts/lean/count_code_sorry.py --lake <root> --json` (champ
+`distinct_code_sorry`), jamais `grep -c sorry`.
+
+## Summary
+
+**Lakes actifs (1)** :
+
+| Directory | Toolchain | Production sorry | Modules | Status |
+|-----------|-----------|-----------------|---------|--------|
+| `kelly_lean` | v4.32.1 | 0 | `Kelly/{Kelly, Bet, Growth}` (3 FR + 3 `_en`) | COMPLETE |
+
+---
+
+## Directories
+
+### 1. kelly_lean
+
+**Objective**: optimalité du critère de Kelly — fraction optimale de mise, croissance log-optimale
+du capital (`growthGrad_kelly_zero` : dérivée du growth nulle au point Kelly), faisabilité de la
+fraction (`kellyFrac_feasible`), et formalisation du pari équivalent (`q`, `pq_add_eq_one`).
+
+**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+
+| Module group | sorry | Content |
+|--------------|-------|---------|
+| `Kelly/Kelly` (FR + `_en`) | 0 | critère de Kelly : `kellyFrac_feasible`, richesses win/lose au point Kelly, `growthGrad_kelly_zero`, `growth_diff_le` |
+| `Kelly/Bet` (FR + `_en`) | 0 | pari équivalent : `q`, `q_pos`, `q_lt_one`, `pq_add_eq_one`, `winWealth` |
+| `Kelly/Growth` (FR + `_en`) | 0 | croissance : `growth_zero`, `growthGrad_zero` |
+
+**CI wiring**: caller workflow [`lean-kelly.yml`](../../.github/workflows/lean-kelly.yml)
+(push `main`, paths `MyIA.AI.Notebooks/QuantConnect/kelly_lean/**.lean` + `lakefile.*`), pipeline `standalone-tactic`.
+
+**Notebooks in-lake (2, C.2 OK)** : `Kelly_companion.ipynb` (Python) et
+`Kelly_companion_lean.ipynb` (Lean) à la racine du lake.

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/LEAN_INVENTORY.md
@@ -1,0 +1,43 @@
+# Lean 4 Projects Inventory — SymbolicAI/Planners
+
+Cross-directory inventory of all Lean 4 formalization projects under `SymbolicAI/Planners/`.
+
+Réconcilié le 2026-08-28 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
+module-set réel du disque (issue #13366, matrice #13121 tranche 3). Comptes `sorry` mesurés avec
+l'instrument canonique `scripts/lean/count_code_sorry.py --lake <root> --json` (champ
+`distinct_code_sorry`), jamais `grep -c sorry`.
+
+## Summary
+
+**Lakes actifs (1)** :
+
+| Directory | Toolchain | Production sorry | Modules | Status |
+|-----------|-----------|-----------------|---------|--------|
+| `planning_lean` | v4.32.1 | 0 | `Planning/{Strips, Relaxation, Admissibility}` (3 FR + 3 `_en`) | COMPLETE |
+
+Note de cheminement : la matrice #13121 tranche 3 référençait `MyIA.AI.Notebooks/Planners/planning_lean` ;
+le chemin effectif au disque est `MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean` (inventaire aligné
+sur le disque).
+
+---
+
+## Directories
+
+### 1. planning_lean
+
+**Objective**: admissibilité de la relaxation sans-delete en planification STRIPS — le coût du plan
+relaxé optimal `h⁺` n'excède jamais le coût du plan réel optimal `h*`
+(`relaxed_plan_admissible` + `relaxed_plan_witness`), sur les sémantiques `step` (réelle) et
+`stepR` (relaxée) avec `step_subset_stepR` et `run_mono`.
+
+**Toolchain**: v4.32.1 (pin effectif mesuré `lean-toolchain` ; la prose du README annonce encore
+`v4.31.0-rc1` — périmée, à corriger séparément) | **Dependencies**: Mathlib4
+
+| Module group | sorry | Content |
+|--------------|-------|---------|
+| `Planning/Strips` (FR + `_en`) | 0 | domaine STRIPS : `applicable`, `step`, `stepR`, `goalSatisfied`, `step_subset_stepR` |
+| `Planning/Relaxation` (FR + `_en`) | 0 | exécution relaxée : `run`, `runR`, `reaches`, `reachesR`, `run_mono` |
+| `Planning/Admissibility` (FR + `_en`) | 0 | théorème-phare : `relaxed_plan_admissible`, `relaxed_plan_witness` |
+
+**CI wiring**: caller workflow [`lean-planning.yml`](../../../.github/workflows/lean-planning.yml)
+(push `main`, paths `MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/**.lean` + `lakefile.*`), pipeline `standalone-tactic`.

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/LEAN_INVENTORY.md
@@ -1,0 +1,40 @@
+# Lean 4 Projects Inventory — SymbolicAI/Tweety
+
+Cross-directory inventory of all Lean 4 formalization projects under `SymbolicAI/Tweety/`.
+
+Réconcilié le 2026-08-28 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
+module-set réel du disque (issue #13366, matrice #13121 tranche 3). Comptes `sorry` mesurés avec
+l'instrument canonique `scripts/lean/count_code_sorry.py --lake <root> --json` (champ
+`distinct_code_sorry`), jamais `grep -c sorry`.
+
+## Summary
+
+**Lakes actifs (1)** :
+
+| Directory | Toolchain | Production sorry | Modules | Status |
+|-----------|-----------|-----------------|---------|--------|
+| `argumentation_lean` | v4.32.1 | 0 | `Argumentation/{Basic, Fundamental, Grounded, Characteristic, Extensions}` (5 FR + 5 `_en`) + umbrella `Argumentation.lean` | COMPLETE |
+
+---
+
+## Directories
+
+### 1. argumentation_lean
+
+**Objective**: théorie de l'argumentation abstraite de Dung (1995) — cadres d'argumentation (AF),
+les extensions canoniques (admissible, complète, grounded, preferred, stable), lemme fondamental
+et fonction caractéristique, au-dessus de Mathlib.
+
+**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+
+| Module group | sorry | Content |
+|--------------|-------|---------|
+| `Argumentation/Basic` (FR + `_en`) | 0 | conflit et défense : `conflictFree`, `defends`, `defendedBy`, `conflictFree_empty` |
+| `Argumentation/Fundamental` (FR + `_en`) | 0 | lemme fondamental : `fundamental_lemma` (+ variantes `defends`/`defends_self`) |
+| `Argumentation/Grounded` (FR + `_en`) | 0 | sémantique grounded : `grounded_fixed`, `grounded_defends_iff_mem`, `grounded_least_complete`, `F_preserves_conflictFree` |
+| `Argumentation/Characteristic` (FR + `_en`) | 0 | fonction caractéristique : `characteristic`, `mem_characteristic_iff`, `characteristic_eq_defendedBy` |
+| `Argumentation/Extensions` (FR + `_en`) | 0 | hiérarchie des extensions : `Admissible`, `Complete`, `grounded`, `Preferred` |
+| `Argumentation.lean` (umbrella) | 0 | imports agrégés du lake |
+
+**CI wiring**: caller workflow [`lean-argumentation.yml`](../../../.github/workflows/lean-argumentation.yml)
+(push `main`, paths `MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/**.lean` + `lakefile.*`), pipeline `standalone-tactic`.


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2023:CoursIA — prev: DEEP/notebook-python #13391

## Summary

Crée les 3 `LEAN_INVENTORY.md` pour les racines auditées sans aucune entrée (matrice #13121 tranche 3) :

| Racine | Fichier créé | Modules (re-mesuré @99dfb8d271) | Toolchain | distinct_code_sorry | CI caller |
|---|---|---|---|---|---|
| `kelly_lean` | `QuantConnect/LEAN_INVENTORY.md` | `Kelly/{Kelly,Bet,Growth}` 3 FR + 3 `_en` (6) | v4.32.1 | **0** | `lean-kelly.yml` |
| `planning_lean` | `SymbolicAI/Planners/LEAN_INVENTORY.md` | `Planning/{Strips,Relaxation,Admissibility}` 3 FR + 3 `_en` (6) | v4.32.1 | **0** | `lean-planning.yml` |
| `argumentation_lean` | `SymbolicAI/Tweety/LEAN_INVENTORY.md` | `Argumentation/{Basic,Fundamental,Grounded,Characteristic,Extensions}` 5 FR + 5 `_en` + umbrella (11) | v4.32.1 | **0** | `lean-argumentation.yml` |

Format = modèle GameTheory/ML : header « réconcilié contre les pins effectifs » + Summary table + section par lake (objective, toolchain/deps, table modules/sorry/content avec théorèmes réels extraits, wiring CI avec les paths triggers effectifs).

## Critères d'acceptance (#13366)

- [x] 3 entrées présentes avec toolchain + modules + sorry + wiring CI
- [x] Comptes **re-mesurés au moment du fix** : `count_code_sorry.py --lake <root> --json` (champ `distinct_code_sorry` = 0 ×3, naïfs = prose/lakefile uniquement) ; toolchain lus dans `lean-toolchain` ; triggers lus dans les workflows
- [x] Diff atomique : 3 nouveaux fichiers, aucun autre fichier modifié

## Écarts mesurés vs la matrice (base a avancé)

1. **Chemin** : la matrice dit `Planners/planning_lean` — le chemin effectif est `SymbolicAI/Planners/planning_lean` (noté dans l'inventaire créé).
2. **kelly_lean** : 3 paires FR/`_en` + 2 notebooks in-lake (`Kelly_companion.ipynb`, `Kelly_companion_lean.ipynb`) documentés.

## Signalements hors scope (principe 3)

- README `planning_lean` annonce encore toolchain `v4.31.0-rc1` alors que le pin effectif mesuré est `v4.32.1` (prose périmée, notée dans l'entrée ; correction à faire séparément pour garder ce diff atomique).
- check-links : 1 lien cassé préexistant sur main (`SymbolicAI/Lean/README.md:150`, correctif PR 13388 en attente) — cette PR n'en ajoute **aucun** (`check_docs_links.py` : 1 cassé avant/après, identique).

Closes #13366 (résolution complète du sous-grain 1/3 de la tranche 3) — See #13121

