### PR TITLE
fix(ict,#13396): corriger le decalage d'index de colonne dans l'unite bloc — sanity IDENTIQUE, verdict mealpy

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-29-GA-vs-Mealpy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-29-GA-vs-Mealpy.ipynb
@@ -5,10 +5,10 @@
    "id": "m29c00",
    "metadata": {
     "papermill": {
-     "duration": 0.003725,
-     "end_time": "2026-08-28T00:34:15.442910+00:00",
+     "duration": 0.001906,
+     "end_time": "2026-08-28T18:29:35.708594+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:15.439185+00:00",
+     "start_time": "2026-08-28T18:29:35.706688+00:00",
      "status": "completed"
     },
     "tags": []
@@ -37,10 +37,10 @@
    "id": "m29c01",
    "metadata": {
     "papermill": {
-     "duration": 0.002038,
-     "end_time": "2026-08-28T00:34:15.447154+00:00",
+     "duration": 0.001577,
+     "end_time": "2026-08-28T18:29:35.712043+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:15.445116+00:00",
+     "start_time": "2026-08-28T18:29:35.710466+00:00",
      "status": "completed"
     },
     "tags": []
@@ -69,16 +69,16 @@
    "id": "m29c02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:34:15.460268Z",
-     "iopub.status.busy": "2026-08-28T00:34:15.454568Z",
-     "iopub.status.idle": "2026-08-28T00:34:17.507930Z",
-     "shell.execute_reply": "2026-08-28T00:34:17.504886Z"
+     "iopub.execute_input": "2026-08-28T18:29:35.728499Z",
+     "iopub.status.busy": "2026-08-28T18:29:35.720583Z",
+     "iopub.status.idle": "2026-08-28T18:29:37.725141Z",
+     "shell.execute_reply": "2026-08-28T18:29:37.721569Z"
     },
     "papermill": {
-     "duration": 2.05894,
-     "end_time": "2026-08-28T00:34:17.508064+00:00",
+     "duration": 2.011538,
+     "end_time": "2026-08-28T18:29:37.725237+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:15.449124+00:00",
+     "start_time": "2026-08-28T18:29:35.713699+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,11 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-47216.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -102,7 +103,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -117,6 +121,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -128,11 +133,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '47216.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '2412.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -176,11 +183,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -265,10 +274,10 @@
    "id": "m29c03",
    "metadata": {
     "papermill": {
-     "duration": 0.002227,
-     "end_time": "2026-08-28T00:34:17.512944+00:00",
+     "duration": 0.001295,
+     "end_time": "2026-08-28T18:29:37.728184+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:17.510717+00:00",
+     "start_time": "2026-08-28T18:29:37.726889+00:00",
      "status": "completed"
     },
     "tags": []
@@ -290,16 +299,16 @@
    "id": "m29c04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:34:17.519070Z",
-     "iopub.status.busy": "2026-08-28T00:34:17.518837Z",
-     "iopub.status.idle": "2026-08-28T00:34:17.975773Z",
-     "shell.execute_reply": "2026-08-28T00:34:17.975371Z"
+     "iopub.execute_input": "2026-08-28T18:29:37.732301Z",
+     "iopub.status.busy": "2026-08-28T18:29:37.732099Z",
+     "iopub.status.idle": "2026-08-28T18:29:38.100606Z",
+     "shell.execute_reply": "2026-08-28T18:29:38.100451Z"
     },
     "papermill": {
-     "duration": 0.460585,
-     "end_time": "2026-08-28T00:34:17.975934+00:00",
+     "duration": 0.37108,
+     "end_time": "2026-08-28T18:29:38.100677+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:17.515349+00:00",
+     "start_time": "2026-08-28T18:29:37.729597+00:00",
      "status": "completed"
     },
     "tags": []
@@ -309,7 +318,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MGS GA Default (graine 7, temoin) : 15 conflits, 6026 evaluations, 238 ms.\r\n"
+      "MGS GA Default (graine 7, temoin) : 15 conflits, 6026 evaluations, 194 ms.\r\n"
      ]
     }
    ],
@@ -375,10 +384,10 @@
    "id": "m29c05",
    "metadata": {
     "papermill": {
-     "duration": 0.002574,
-     "end_time": "2026-08-28T00:34:17.982868+00:00",
+     "duration": 0.001513,
+     "end_time": "2026-08-28T18:29:38.104013+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:17.980294+00:00",
+     "start_time": "2026-08-28T18:29:38.102500+00:00",
      "status": "completed"
     },
     "tags": []
@@ -400,16 +409,16 @@
    "id": "m29c06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:34:17.990186Z",
-     "iopub.status.busy": "2026-08-28T00:34:17.989924Z",
-     "iopub.status.idle": "2026-08-28T00:34:22.717791Z",
-     "shell.execute_reply": "2026-08-28T00:34:22.717601Z"
+     "iopub.execute_input": "2026-08-28T18:29:38.108253Z",
+     "iopub.status.busy": "2026-08-28T18:29:38.108053Z",
+     "iopub.status.idle": "2026-08-28T18:29:43.265938Z",
+     "shell.execute_reply": "2026-08-28T18:29:43.265796Z"
     },
     "papermill": {
-     "duration": 4.731787,
-     "end_time": "2026-08-28T00:34:22.717875+00:00",
+     "duration": 5.160536,
+     "end_time": "2026-08-28T18:29:43.266005+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:17.986088+00:00",
+     "start_time": "2026-08-28T18:29:38.105469+00:00",
      "status": "completed"
     },
     "tags": []
@@ -428,35 +437,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pont PythonNet actif : mealpy 3.0.2 sur Python 3.13.7\r\n"
+      "Pont PythonNet actif : mealpy 3.0.2 sur Python 3.13.15\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  vecteur temoin 1 : cout C# = 67, cout Python = 100 -> DIFFERENT\r\n"
+      "  vecteur temoin 1 : cout C# = 67, cout Python = 67 -> IDENTIQUE\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  vecteur temoin 2 : cout C# = 71, cout Python = 105 -> DIFFERENT\r\n"
+      "  vecteur temoin 2 : cout C# = 71, cout Python = 71 -> IDENTIQUE\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  vecteur temoin 3 : cout C# = 60, cout Python = 96 -> DIFFERENT\r\n"
+      "  vecteur temoin 3 : cout C# = 60, cout Python = 60 -> IDENTIQUE\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sanity check ECHOUE : les fonctions de cout different -- le bench serait invalide.\r\n"
+      "Sanity check PASSE : la fonction de cout est identique des deux cotes -- le bench est valide.\r\n"
      ]
     }
    ],
@@ -566,7 +575,7 @@
     "    for i in range(9):\n",
     "        units = ([g[i][j] for j in range(9)],\n",
     "                 [g[j][i] for j in range(9)],\n",
-    "                 [g[3 * (i // 3) + j // 3][3 * (i % 3) + j // 3] for j in range(9)])\n",
+    "                 [g[3 * (i // 3) + j // 3][3 * (i % 3) + j % 3] for j in range(9)])\n",
     "        for unit in units:\n",
     "            seen = set()\n",
     "            for v in unit:\n",
@@ -653,10 +662,10 @@
    "id": "m29c07",
    "metadata": {
     "papermill": {
-     "duration": 0.002468,
-     "end_time": "2026-08-28T00:34:22.722960+00:00",
+     "duration": 0.002706,
+     "end_time": "2026-08-28T18:29:43.271294+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:22.720492+00:00",
+     "start_time": "2026-08-28T18:29:43.268588+00:00",
      "status": "completed"
     },
     "tags": []
@@ -678,16 +687,16 @@
    "id": "m29c08",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:34:22.729079Z",
-     "iopub.status.busy": "2026-08-28T00:34:22.728862Z",
-     "iopub.status.idle": "2026-08-28T00:34:24.357181Z",
-     "shell.execute_reply": "2026-08-28T00:34:24.356993Z"
+     "iopub.execute_input": "2026-08-28T18:29:43.276559Z",
+     "iopub.status.busy": "2026-08-28T18:29:43.276226Z",
+     "iopub.status.idle": "2026-08-28T18:29:44.452243Z",
+     "shell.execute_reply": "2026-08-28T18:29:44.452095Z"
     },
     "papermill": {
-     "duration": 1.632009,
-     "end_time": "2026-08-28T00:34:24.357269+00:00",
+     "duration": 1.178981,
+     "end_time": "2026-08-28T18:29:44.452312+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:22.725260+00:00",
+     "start_time": "2026-08-28T18:29:43.273331+00:00",
      "status": "completed"
     },
     "tags": []
@@ -697,14 +706,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mealpy BaseGA (graine 7, temoin) : 62 conflits, 8050 evaluations, 1422 ms.\r\n"
+      "mealpy BaseGA (graine 7, temoin) : 16 conflits, 8050 evaluations, 985 ms.\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Contre-verif croisee : cout C# du meilleur mealpy = 19 (Python rapporte 62) -> DIFFERENT\r\n"
+      "Contre-verif croisee : cout C# du meilleur mealpy = 16 (Python rapporte 16) -> IDENTIQUE\r\n"
      ]
     }
    ],
@@ -736,16 +745,16 @@
    "id": "m29c09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-28T00:34:24.364903Z",
-     "iopub.status.busy": "2026-08-28T00:34:24.364640Z",
-     "iopub.status.idle": "2026-08-28T00:34:44.591010Z",
-     "shell.execute_reply": "2026-08-28T00:34:44.590646Z"
+     "iopub.execute_input": "2026-08-28T18:29:44.458201Z",
+     "iopub.status.busy": "2026-08-28T18:29:44.457996Z",
+     "iopub.status.idle": "2026-08-28T18:29:56.200781Z",
+     "shell.execute_reply": "2026-08-28T18:29:56.200547Z"
     },
     "papermill": {
-     "duration": 20.230654,
-     "end_time": "2026-08-28T00:34:44.591157+00:00",
+     "duration": 11.746107,
+     "end_time": "2026-08-28T18:29:56.200837+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:24.360503+00:00",
+     "start_time": "2026-08-28T18:29:44.454730+00:00",
      "status": "completed"
     },
     "tags": []
@@ -762,56 +771,56 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MGS            0        12          -    6066      153    0,025\r\n"
+      "MGS            0        12          -    6066      151    0,025\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MGS            1        18          -    5942      141    0,024\r\n"
+      "MGS            1        18          -    5942       99    0,017\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MGS            7        15          -    6026      148    0,024\r\n"
+      "MGS            7        15          -    6026      105    0,017\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MGS           42        12          -    6082      130    0,021\r\n"
+      "MGS           42        12          -    6082      101    0,017\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mealpy         0        20         64    8050     1312    0,163\r\n"
+      "mealpy         0        10         10    8050      957    0,119\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mealpy         1         5         56    8050     1361    0,169\r\n"
+      "mealpy         1         9          9    8050      789    0,098\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mealpy         7        19         62    8050     1754    0,218\r\n"
+      "mealpy         7        16         16    8050      813    0,101\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mealpy        42         8         58    8050     1566    0,195\r\n"
+      "mealpy        42        15         15    8050      782    0,097\r\n"
      ]
     },
     {
@@ -825,21 +834,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MGS    : mediane conflits 13,5 (min 12, max 18), ms/eval moyen 0,024\r\n"
+      "MGS    : mediane conflits 13,5 (min 12, max 18), ms/eval moyen 0,019\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mealpy : mediane conflits 13,5 (min 5, max 20), ms/eval moyen 0,186\r\n"
+      "mealpy : mediane conflits 12,5 (min 9, max 16), ms/eval moyen 0,104\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rapport ms/eval mealpy/MGS : 7,85x\r\n"
+      "Rapport ms/eval mealpy/MGS : 5,49x\r\n"
      ]
     },
     {
@@ -933,10 +942,10 @@
    "id": "m29c10",
    "metadata": {
     "papermill": {
-     "duration": 0.00426,
-     "end_time": "2026-08-28T00:34:44.600902+00:00",
+     "duration": 0.001812,
+     "end_time": "2026-08-28T18:29:56.204524+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:44.596642+00:00",
+     "start_time": "2026-08-28T18:29:56.202712+00:00",
      "status": "completed"
     },
     "tags": []
@@ -958,10 +967,10 @@
    "id": "m29c11",
    "metadata": {
     "papermill": {
-     "duration": 0.005176,
-     "end_time": "2026-08-28T00:34:44.610076+00:00",
+     "duration": 0.001538,
+     "end_time": "2026-08-28T18:29:56.207647+00:00",
      "exception": false,
-     "start_time": "2026-08-28T00:34:44.604900+00:00",
+     "start_time": "2026-08-28T18:29:56.206109+00:00",
      "status": "completed"
     },
     "tags": []
@@ -996,14 +1005,15 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 34.57015,
-   "end_time": "2026-08-28T00:34:47.513819+00:00",
+   "duration": 26.710678,
+   "end_time": "2026-08-28T18:29:59.674037+00:00",
+   "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-29-GA-vs-Mealpy.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-29-GA-vs-Mealpy.ipynb",
+   "input_path": "MGS-29-GA-vs-Mealpy.ipynb",
+   "output_path": "MGS-29-GA-vs-Mealpy.ipynb",
    "parameters": {},
-   "start_time": "2026-08-28T00:34:12.943669+00:00",
-   "status": "completed"
+   "start_time": "2026-08-28T18:29:32.963359+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2027:CoursIA — prev: LIGHT/readme #13388

## Summary

MGS-29 (paire 8/9 de l'Epic **#12373**) avait un sanity check de coût qui échouait dans les outputs committés : C# 67/71/60 vs Python 100/105/96 → `DIFFERENT`, et la contre-vérif croisée rapportait 19 vs 62 → `DIFFERENT`. Ce PR **corrige la cause racine** et **re-exécute** le notebook complet.

## Diagnostic — décalage d'index de colonne dans l'unité bloc (1 caractère)

Le coût Python lisait l'offset de **colonne** du bloc 3×3 avec `j // 3` au lieu de `j % 3` :

```python
# AVANT (bug) : la ligne bloc utilise j//3 pour la colonne → lit la diagonale seule (3 cellules × 3 répétitions)
[g[3 * (i // 3) + j // 3][3 * (i % 3) + j // 3] for j in range(9)]
# APRÈS (correct) : colonne = j % 3, ligne = j // 3 → lit les 9 cellules du bloc
[g[3 * (i // 3) + j // 3][3 * (i % 3) + j % 3] for j in range(9)]
```

Le coût C# (`CountConflicts29`) utilisait déjà `bc = 3 * (i % 3) + j % 3`. Conséquence double :
1. Le sanity check de coût Python calculait une métrique **différente** (diagonale du bloc seulement) → mismatch avec C#.
2. La fonction objective mealpy (`obj_func = cost(decode(x))`) héritait du même bug → mealpy minimisait une **fausse** fonction, le faisant paraître **pire** qu'il n'est.

Vérification : la reproduction du coût exact (bug vs fix) sur les 3 témoins LCG redonne exactement `BUG=100/105/96` et `FIX=67/71/60` — soit les valeurs committées (bug) et le sanity C# (fix). La cause est confirmée, la divergence n'est pas un simple output périmé.

## Correction + re-exécution

- Correction : `j // 3` → `j % 3` (1 occurrence, cellule du pont PythonNet/coût Python).
- Re-exécution complète via **papermill**, kernel `.net-csharp`, cwd = `Part4-Metaheuristics/`, `DOTNET_ROOT="C:\Program Files\dotnet"` (le `#r "nuget: pythonnet,3.0.5"` échouait sous `C:\Users\Jesse\.dotnet` installé sans SDK — réparation, pas contournement, règle F).
- DLLs MGS du sous-module `MetaGeneticSharp` compilées en `bin/Debug/net9.0/` ; `mealpy==3.0.2` épinglé (cohérence Epic).
- Baader : `output_path` scrubbé au basename, banner probeAddresses strip (la re-exec .NET).

## Preuves de validation

**Sanity check coût — désormais IDENTIQUE** (3 témoins LCG) :
```
vecteur temoin 1 : cout C# = 67, cout Python = 67 -> IDENTIQUE
vecteur temoin 2 : cout C# = 71, cout Python = 71 -> IDENTIQUE
vecteur temoin 3 : cout C# = 60, cout Python = 60 -> IDENTIQUE
```
**Contre-vérification croisée — IDENTIQUE** (16 = 16).

**Verdict qualité — il CHANGE** (cellule 9 du notebook re-exécuté) :
```
MGS    : mediane conflits 13,5 (min 12, max 18), ms/eval moyen 0,019
mealpy : mediane conflits 12,5 (min 9, max 16), ms/eval moyen 0,104
Rapport ms/eval mealpy/MGS : 5,49x
Determinisme : 8/8
```
Avant correction le tableau annonçait 13,5 vs 13,5 (ex æquo) et 7,85× ; après correction mealpy **gagne la qualité** (12,5 < 13,5) et MGS domine la vitesse (5,49×). Le « verdict » du notebook change donc : la revanche du GA est à mealpy en qualité, pas un ex æquo.

## Notes de coordination

- **Le récit README MGS-29** (ligne 29 + paragraphe narratif, avec la `RÉSERVE #13396` et les chiffres 13,5/13,5 / 7,85×) vit dans le PR **#13397** (MGS-30), qui introduit la ligne 29. Il est **corrigé** dans #13397 au verdict post-fix (sanity IDENTIQUE, mealpy 12,5 vs MGS 13,5, 5,49×). Voir le commit `37390c8a65c` sur `feature/12373-mgs30-scattersearch`.
- **Ordre de merge conseillé : #13396 (ce PR, fix notebook MGS-29) avant #13397 (MGS-30 + récit README)** — les deux PRs touchent des fichiers disjoints (aucun conflit), mais le récit MGS-29 de #13397 décrit le notebook comme corrigé, donc doit arriver après.
- `See #13396` et `See #12373` (l'issue #13396 n'est entièrement close qu'une fois #13397 aussi mergé — le récit README y est corrigé).

## Test plan

- [x] Reproduction locale de la divergence (bug=100/105/96, fix=67/71/60)
- [x] Diagnostic de la cause (décalage d'index `j // 3` vs `j % 3`)
- [x] Correction + re-exécution complète du notebook
- [x] Sanity check IDENTIQUE sur 3 témoins + contre-vérif croisée IDENTIQUE
- [x] Verdict qualité mis à jour (mealpy 12,5 vs MGS 13,5, 5,49×)
- [x] Récit README MGS-29 corrigé dans #13397
