### PR TITLE
docs(lean,#13402): franciser les 4 LEAN_INVENTORY.md EN->FR (Tweety, Planners, QuantConnect, GameTheory)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
@@ -1,69 +1,69 @@
-# Lean 4 Projects Inventory — GameTheory
+# Inventaire des projets Lean 4 — GameTheory
 
-Cross-directory inventory of all Lean 4 formalization projects under `GameTheory/`.
+Inventaire transverse de tous les projets de formalisation Lean 4 sous `GameTheory/`.
 
 Réconcilié le 2026-08-26 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
 module-set réel du disque (issue #13138). Comptes `sorry` mesurés avec l'instrument canonique
 `scripts/lean/count_code_sorry.py --json` (champ `distinct_code_sorry`), jamais `grep -c sorry`.
 
-## Summary
+## Résumé
 
 **Lakes actifs (8)** :
 
-| Directory | Toolchain | Production sorry | Modules | Status |
+| Répertoire | Toolchain | Sorry (production) | Modules | Statut |
 |-----------|-----------|-----------------|---------|--------|
-| `game_theory_lean` | v4.32.1 | 1 (Folk stretch, #4880) | StableMarriage + CooperativeGames + SocialChoice + RepeatedGames + Swaps (49 `.lean` FR+EN) | COMPLETE (EPIC #4365) |
-| `lean_game_defs` | v4.32.1 | 0 | 12 (6 FR + 6 `_en`) | COMPLETE (shared defs) |
-| `lean_game_defs_ext` | v4.32.1 | 0 | Bayesian/* 24 (12 FR + 12 `_en`) + 2 umbrellas | COMPLETE |
-| `minimax_lean` | v4.32.1 | 0 | ZeroSum + Concavity + SionApplication (+ `_en`) | COMPLETE |
-| `assignment_lean` | v4.32.1 | 0 | Definitions / Duality / KuhnMunkres / Optimality (+ `_en`) | COMPLETE (#12598) |
-| `asymmetric_information_lean` | v4.32.1 | 0 | Lemons / Signaling / Screening / MiyazakiWilson / BayesianLink (+ `_en`) | COMPLETE (Epic #12844) |
-| `social_choice_lean_peters` | v4.32.1 | 0 | PetersTour (+ `_en`) | Reference only |
-| `conway_cgt_lean` | v4.31.0-rc2 | 0 | CGTTour (+ `_en`) | Reference tour |
+| `game_theory_lean` | v4.32.1 | 1 (Folk stretch, #4880) | StableMarriage + CooperativeGames + SocialChoice + RepeatedGames + Swaps (49 `.lean` FR+EN) | COMPLET (EPIC #4365) |
+| `lean_game_defs` | v4.32.1 | 0 | 12 (6 FR + 6 `_en`) | COMPLET (définitions partagées) |
+| `lean_game_defs_ext` | v4.32.1 | 0 | Bayesian/* 24 (12 FR + 12 `_en`) + 2 umbrellas | COMPLET |
+| `minimax_lean` | v4.32.1 | 0 | ZeroSum + Concavity + SionApplication (+ `_en`) | COMPLET |
+| `assignment_lean` | v4.32.1 | 0 | Definitions / Duality / KuhnMunkres / Optimality (+ `_en`) | COMPLET (#12598) |
+| `asymmetric_information_lean` | v4.32.1 | 0 | Lemons / Signaling / Screening / MiyazakiWilson / BayesianLink (+ `_en`) | COMPLET (Epic #12844) |
+| `social_choice_lean_peters` | v4.32.1 | 0 | PetersTour (+ `_en`) | Référence seule |
+| `conway_cgt_lean` | v4.31.0-rc2 | 0 | CGTTour (+ `_en`) | Tour de référence |
 
 **Tombstones (absorbés, EPIC #4365)** :
 
-| Directory | Devenir |
+| Répertoire | Devenir |
 |-----------|---------|
 | ~~`cooperative_games_lean`~~ | **Supprimé** (rm #6587) → [`game_theory_lean/CooperativeGames/`](game_theory_lean/CooperativeGames/) |
 | ~~`social_choice_lean`~~ | Absorbé (#6058, 2026-07-11) → [`game_theory_lean/SocialChoice/`](game_theory_lean/SocialChoice/) — ne subsistent que 4 markdown tombstone |
 | ~~`repeated_games_lean`~~ | Absorbé (#6146) → [`game_theory_lean/RepeatedGames/`](game_theory_lean/RepeatedGames/) — coquille archive conservée (lakefile neutralisé, 0 module) |
 
-Note: `SymbolicAI/Lean/examples/llm_assisted_proof.lean` (2 sorry) is a pedagogical example, not production. `asymmetric_information_lean` carries 2 *naive* sorry (prose/docstrings) for 0 real code sorry.
+Note : `SymbolicAI/Lean/examples/llm_assisted_proof.lean` (2 sorry) est un exemple pédagogique, pas de la production. `asymmetric_information_lean` porte 2 *naive* sorry (prose/docstrings) pour 0 sorry de code réel.
 
-**Conway tribute series relocated**: `conway_lean/` (Conway hommage — Doomsday, FRACTRAN, Look-and-Say, Nim, Angel) was moved to [`SymbolicAI/Lean/conway_lean/`](../SymbolicAI/Lean/conway_lean/) since it formalizes lesser-known Conway results (not game-theoretic content per se). The prover calibration targets defined in `agent_tests/prover/config.py` follow the new path.
+**Série hommage Conway déplacée** : `conway_lean/` (hommage Conway — Doomsday, FRACTRAN, Look-and-Say, Nim, Angel) a été déplacée vers [`SymbolicAI/Lean/conway_lean/`](../SymbolicAI/Lean/conway_lean/) car elle formalise des résultats Conway moins connus (pas du contenu de théorie des jeux à proprement parler). Les cibles de calibration du prouveur définies dans `agent_tests/prover/config.py` suivent le nouveau chemin.
 
-**Calibration relocated**: `calibration_lean/` was moved to [`SymbolicAI/Lean/calibration_lean/`](../SymbolicAI/Lean/calibration_lean/) (issue #1764) since it is a prover harness component, not game-theoretic content.
+**Calibration déplacée** : `calibration_lean/` a été déplacée vers [`SymbolicAI/Lean/calibration_lean/`](../SymbolicAI/Lean/calibration_lean/) (issue #1764) car c'est un composant du harnais du prouveur, pas du contenu de théorie des jeux.
 
 ---
 
-## Directories
+## Répertoires
 
 ### 1. game_theory_lean
 
-**EPIC #4365 (phase 4)**: multi-module target lake, pôle d'absorption GT 6→2. A absorbé :
+**EPIC #4365 (phase 4)** : lake cible multi-modules, pôle d'absorption GT 6→2. A absorbé :
 `stable_marriage_lean/` (supprimé, PRs #5904/#5905/#5910/#5911/#5913), `cooperative_games_lean/`
 (rm #6587), `social_choice_lean/` (#6058), `repeated_games_lean/` (#6146). Le lake porte
 également `Swaps` (grain #12222, compagnon du notebook GameTheory-03a).
 
-**Objective**: Formalize the GameTheory curriculum — cooperative games (Shapley, core), Gale-Shapley stable marriage, social choice (Arrow, Sen, median voter), repeated games (folk theorem), swap paths on 2×2 ordinal games.
+**Objectif** : formaliser le curriculum GameTheory — jeux coopératifs (Shapley, cœur), mariage stable de Gale-Shapley, choix social (Arrow, Sen, électeur médian), jeux répétés (théorème folk), chemins d'échange sur jeux ordinaux 2×2.
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4
 
-| Module group | sorry | Content |
+| Groupe de modules | sorry | Contenu |
 |--------------|-------|---------|
-| `StableMarriage/` (5 FR + 5 `_en`) | 0 | GS algorithm, termination, stability, `exists_isManOptimal`, woman_pessimal, Knuth lattice + refutations of former false statements |
-| `CooperativeGames/` (3 FR + 3 `_en`) | 0 | TU games, Core, `bondareva_shapley : Core.Nonempty ↔ Balanced`, Shapley value (Möbius decomposition), cone-separation machinery |
-| `SocialChoice/` (9 FR + 8 `_en`) | 0 | Arrow (Geanakoplos 2005), Sen's Liberal Paradox, median voter / Split Cycle / clones, Vickrey truthfulness, AMD, `PrefOrder`/`Profile`/SWF core |
+| `StableMarriage/` (5 FR + 5 `_en`) | 0 | algorithme GS, terminaison, stabilité, `exists_isManOptimal`, woman_pessimal, treillis de Knuth + réfutations d'anciens énoncés faux |
+| `CooperativeGames/` (3 FR + 3 `_en`) | 0 | jeux à transferts (TU), Core, `bondareva_shapley : Core.Nonempty ↔ Balanced`, valeur de Shapley (décomposition de Möbius), machinerie de séparation par cônes |
+| `SocialChoice/` (9 FR + 8 `_en`) | 0 | Arrow (Geanakoplos 2005), paradoxe libéral de Sen, électeur médian / Split Cycle / clones, véracité de Vickrey, AMD, socle `PrefOrder`/`Profile`/SWF |
 | `RepeatedGames/` (4 FR + 4 `_en`) | 1 (stretch) | `grim_trigger_sustains_iff` (théorème-phare, 0 sorry) ; `folk_theorem_discounted` / `folk_theorem_boundary` portent 1 sorry stretch (#4880) |
 | `Swaps/` (FR-only) | 0 | `Table`, générateurs adjacents, certificat de chemin, `distance_dilemme_chicken` |
 
-**Build**: `lake build` — SUCCESS. CI: `lean-game-theory.yml`, `lean-social-choice.yml`.
+**Build** : `lake build` — SUCCESS. CI : `lean-game-theory.yml`, `lean-social-choice.yml`.
 
-**Key proofs**:
-- `gale_shapley_stable` — PR #1194 ; `exists_isManOptimal` (honest, via minimal-weight on join semilattice) ; `woman_pessimal` — PR #1521 ; `meetSpouse_injective` / `joinSpouse_injective` — PR #1522
-- `no_cross_match_is_false` / `doctor_optimal_eq_top_is_false` — kernel-checked refutations of former false statements
-- `bondareva_shapley` (`Core.Nonempty ↔ Balanced`) — fully proved, no added axiom (compact-slice Weierstrass, #3954)
+**Preuves clés** :
+- `gale_shapley_stable` — PR #1194 ; `exists_isManOptimal` (honnête, via poids minimal sur le demi-treillis supérieur) ; `woman_pessimal` — PR #1521 ; `meetSpouse_injective` / `joinSpouse_injective` — PR #1522
+- `no_cross_match_is_false` / `doctor_optimal_eq_top_is_false` — réfutations kernel-checkées d'anciens énoncés faux
+- `bondareva_shapley` (`Core.Nonempty ↔ Balanced`) — entièrement prouvé, aucun axiome ajouté (Weierstrass sur tranche compacte, #3954)
 - `grim_trigger_sustains_iff` — FORMAL-CERTIFIED, 0 sorry
 
 ---
@@ -76,11 +76,11 @@ Note: `SymbolicAI/Lean/examples/llm_assisted_proof.lean` (2 sorry) is a pedagogi
 > section ci-dessous est conservée comme trace d'audit du statut de preuve (0 sorry, préservé
 > dans la cible). Pour l'état courant, voir [§1. game_theory_lean](#1-game_theory_lean).
 
-**Status at removal**: COMPLETE (0 sorry). `bondareva_shapley` fully proved — the backward
-direction's attainment crux `hb_witness` closed by PR #3954 via a compact-slice Weierstrass
-argument, bypassing the missing Mathlib `ProperCone.hyperplane_separation` without any added
-axiom. Lineage: #3933 (cone kernel) → #3941 (bridge) → #3945 (decoding) → #3951 (`hb_strict`) →
-#3954 (attainment).
+**Statut à la suppression** : COMPLET (0 sorry). `bondareva_shapley` entièrement prouvé — le
+nœud d'atteinte de la direction réciproque `hb_witness` a été clos par la PR #3954 via un
+argument Weierstrass sur tranche compacte, en contournant le `ProperCone.hyperplane_separation`
+manquant de Mathlib sans aucun axiome ajouté. Lignage : #3933 (noyau cône) → #3941 (pont) →
+#3945 (décodage) → #3951 (`hb_strict`) → #3954 (atteinte).
 
 ---
 
@@ -94,28 +94,28 @@ axiom. Lineage: #3933 (cone kernel) → #3941 (bridge) → #3945 (decoding) → 
 > (`lakefile.lean`, `lean-toolchain`, `lake-manifest.json`) a été retirée ; ne subsistent que
 > 4 markdown (`README`, `STATUS`, `NOTICE`, `LEAN_PREREQUISITES`) conservés comme tombstone.
 
-**Status (historique, préservé dans le home canonique)**: COMPLETE, 0 sorry — Arrow's
-Impossibility (Geanakoplos 2005), Sen's Liberal Paradox, Median Voter / Split Cycle / clones,
-Vickrey truthfulness + first-price counter-example (#1469). Build repris par
+**Statut (historique, préservé dans le home canonique)** : COMPLET, 0 sorry — impossibilité
+d'Arrow (Geanakoplos 2005), paradoxe libéral de Sen, électeur médian / Split Cycle / clones,
+véracité de Vickrey + contre-exemple au premier prix (#1469). Build repris par
 `.github/workflows/lean-social-choice.yml` sur `game_theory_lean`.
 
 ---
 
 ### 4. social_choice_lean_peters
 
-**Objective**: Reference project importing DominikPeters/SocialChoiceLean as a Lake dependency.
+**Objectif** : projet de référence important DominikPeters/SocialChoiceLean comme dépendance Lake.
 
-**Toolchain**: v4.32.1 (convergé avec le parc depuis #12134, 2026-08-21) | **Dependencies**: Mathlib4 (`520045ab`), SocialChoiceLean `94a4c650` (revs effectives du `lake-manifest.json`)
+**Toolchain** : v4.32.1 (convergé avec le parc depuis #12134, 2026-08-21) | **Dépendances** : Mathlib4 (`520045ab`), SocialChoiceLean `94a4c650` (revs effectives du `lake-manifest.json`)
 
-| File | sorry | Description |
+| Fichier | sorry | Description |
 |------|-------|-------------|
-| `PetersTour.lean` + `PetersTour_en.lean` | 0 | Curated tour of Peters' formalized results (i18n #4980) |
+| `PetersTour.lean` + `PetersTour_en.lean` | 0 | tour curaté des résultats formalisés de Peters (i18n #4980) |
 
-**Build**: `lake build` — SUCCESS | **Reference only, not for proving**
+**Build** : `lake build` — SUCCESS | **Référence seule, pas une cible de preuve**
 
-**Content**: Imports Peters' library (Gibbard-Satterthwaite, Duggan-Schwartz, 4 Condorcet impossibilities, 15+ voting rules with axiom verification). Backend Lake for the (planned, not yet created) SocialChoiceLean tour companion notebook.
+**Contenu** : importe la bibliothèque de Peters (Gibbard-Satterthwaite, Duggan-Schwartz, 4 impossibilités de Condorcet, 15+ règles de vote avec vérification d'axiomes). Lake de backend pour le notebook compagnon du tour SocialChoiceLean (prévu, pas encore créé).
 
-**Relationship to `social_choice_lean` (absorbé)**: Complementary, not duplicate. Notre cadre historique utilisait un `PrefOrder` custom (nos preuves, désormais dans `game_theory_lean/SocialChoice/`) ; ce lake expose le `LinearOrder` de Peters (référence externe). Both kept for pedagogical completeness.
+**Relation à `social_choice_lean` (absorbé)** : complémentaire, pas un doublon. Notre cadre historique utilisait un `PrefOrder` custom (nos preuves, désormais dans `game_theory_lean/SocialChoice/`) ; ce lake expose le `LinearOrder` de Peters (référence externe). Les deux sont conservés par complétude pédagogique.
 
 ---
 
@@ -129,185 +129,185 @@ Vickrey truthfulness + first-price counter-example (#1469). Build repris par
 > `lakefile.lean` (ses globs matchaient 0 fichier depuis le déménagement). Certification et
 > build repris par `game_theory_lean` (`.github/workflows/lean-game-theory.yml`).
 
-**Status (historique, préservé dans le home canonique)**: `grim_trigger_sustains_iff`
-(sustains a subgame-perfect Nash iff δ ≥ threshold) fully proved, 0 sorry. The Folk theorem
-(`folk_theorem_discounted`) carries 1 stretch sorry, tolerated per #4880.
+**Statut (historique, préservé dans le home canonique)** : `grim_trigger_sustains_iff`
+(sustain un Nash parfait en sous-jeux ssi δ ≥ seuil) entièrement prouvé, 0 sorry. Le théorème
+Folk (`folk_theorem_discounted`) porte 1 sorry stretch, toléré selon #4880.
 
 ---
 
 ### 6. minimax_lean
 
-**Objective**: Formalize the two-player zero-sum game minimax setting — payoff bilinearity, concavity, and the Sion minimax application.
+**Objectif** : formaliser le cadre minimax des jeux à somme nulle à deux joueurs — bilinéarité des paiements, concavité, et application du minimax de Sion.
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4
 
-| File | sorry | Description |
+| Fichier | sorry | Description |
 |------|-------|-------------|
-| `Minimax/ZeroSum.lean` (+ `_en`) | 0 | Zero-sum payoff structure, bilinearity (`payoff_add_in_x`, `smul`), `continuous_payoff`; saddle-point existence derived from Mathlib's Sion minimax |
-| `Minimax/Concavity.lean` (+ `_en`) | 0 | Concavity lemmas feeding the Sion application |
-| `Minimax/SionApplication.lean` (+ `_en`) | 0 | Sion minimax application to the mixed-strategy saddle point |
+| `Minimax/ZeroSum.lean` (+ `_en`) | 0 | structure de paiement à somme nulle, bilinéarité (`payoff_add_in_x`, `smul`), `continuous_payoff` ; existence du point-selle dérivée du minimax de Sion de Mathlib |
+| `Minimax/Concavity.lean` (+ `_en`) | 0 | lemmes de concavité alimentant l'application de Sion |
+| `Minimax/SionApplication.lean` (+ `_en`) | 0 | application du minimax de Sion au point-selle en stratégies mixtes |
 
-**Build**: `lake build Minimax` — SUCCESS | **COMPLETE: 0 sorry**
+**Build** : `lake build Minimax` — SUCCESS | **COMPLET : 0 sorry**
 
-**Key facts**: payoff bilinearity and continuity proven 0 sorry; **saddle-point existence** (`∃ mixed strategies, max_x min_y = min_y max_x`) is *derived* from Mathlib's Sion minimax theorem — documented and proved, **not** left as a `sorry`.
+**Faits clés** : bilinéarité et continuité des paiements prouvées 0 sorry ; **l'existence du point-selle** (`∃ mixed strategies, max_x min_y = min_y max_x`) est *dérivée* du théorème minimax de Sion de Mathlib — documentée et prouvée, **pas** laissée en `sorry`.
 
 ---
 
 ### 7. lean_game_defs
 
-**Objective**: Shared game-theoretic type definitions (normal-form games, Bayesian games, combinatorial games, social choice, regret) — the foundational layer reused by the GT Lean notebooks. Self-contained (core Lean only, zero Mathlib dependency).
+**Objectif** : définitions de types partagées de théorie des jeux (formes normales, jeux bayésiens, jeux combinatoires, choix social, regret) — la couche fondation réutilisée par les notebooks GT Lean. Autonome (Lean core seul, zéro dépendance Mathlib).
 
-**Toolchain**: v4.32.1 | **Dependencies**: Lean core (Mathlib-free)
+**Toolchain** : v4.32.1 | **Dépendances** : Lean core (sans Mathlib)
 
-| File (FR + `_en` sibling) | sorry | Description |
+| Fichier (FR + jumeau `_en`) | sorry | Description |
 |---------------------------|-------|-------------|
-| `LeanGameDefs/Basic.lean` | 0 | NormalFormGame / FiniteGame / Game2x2 core types |
-| `LeanGameDefs/Nash.lean` | 0 | Nash equilibrium, best response, strict dominance |
-| `LeanGameDefs/Bayesian.lean` | 0 | Bayesian game types |
-| `LeanGameDefs/Combinatorial.lean` | 0 | Combinatorial game types, minimax |
-| `LeanGameDefs/SocialChoice.lean` | 0 | Social choice primitives (`dictatorship_satisfies_pareto`, `dictatorship_satisfies_iia`) |
-| `LeanGameDefs/Regret.lean` | 0 | Regret / CFR definitions |
+| `LeanGameDefs/Basic.lean` | 0 | types socle NormalFormGame / FiniteGame / Game2x2 |
+| `LeanGameDefs/Nash.lean` | 0 | équilibre de Nash, meilleure réponse, dominance stricte |
+| `LeanGameDefs/Bayesian.lean` | 0 | types de jeux bayésiens |
+| `LeanGameDefs/Combinatorial.lean` | 0 | types de jeux combinatoires, minimax |
+| `LeanGameDefs/SocialChoice.lean` | 0 | primitives de choix social (`dictatorship_satisfies_pareto`, `dictatorship_satisfies_iia`) |
+| `LeanGameDefs/Regret.lean` | 0 | définitions regret / CFR |
 
-**Build**: `lake build LeanGameDefs` — SUCCESS (CI `lean-game-defs.yml` + `lean-game-defs-ext.yml`) | **COMPLETE: 0 sorry, Mathlib-free**
+**Build** : `lake build LeanGameDefs` — SUCCESS (CI `lean-game-defs.yml` + `lean-game-defs-ext.yml`) | **COMPLET : 0 sorry, sans Mathlib**
 
-**Status**: Lake autonome depuis #2752 (`lakefile.toml`, `lean-toolchain` pinné v4.32.1, `lake-manifest.json`, CI dédiée). Infrastructural definitions layer (2 theorems verifying dictatorship axioms), backend for the GT Lean notebooks. `lean_game_defs_ext` (next) extends it with Bayesian mechanism-design proofs.
+**Statut** : lake autonome depuis #2752 (`lakefile.toml`, `lean-toolchain` pinné v4.32.1, `lake-manifest.json`, CI dédiée). Couche de définitions infrastructurelle (2 théorèmes vérifiant les axiomes de dictature), backend des notebooks GT Lean. `lean_game_defs_ext` (suivant) l'étend avec des preuves de design de mécanismes bayésiens.
 
 ---
 
 ### 8. lean_game_defs_ext
 
-**Objective**: Bayesian games & mechanism design — Vickrey truthfulness, Bayesian-Nash equilibrium, auctions, reputation, fictitious play, regret. Extension of `lean_game_defs` (shared definitions), Mathlib-free.
+**Objectif** : jeux bayésiens et design de mécanismes — véracité de Vickrey, équilibre bayésien de Nash, enchères, réputation, jeu fictif, regret. Extension de `lean_game_defs` (définitions partagées), sans Mathlib.
 
-**Toolchain**: v4.32.1 | **Dependencies**: Lean core (Mathlib-free)
+**Toolchain** : v4.32.1 | **Dépendances** : Lean core (sans Mathlib)
 
-| File (FR + `_en` sibling) | sorry | Description |
+| Fichier (FR + jumeau `_en`) | sorry | Description |
 |---------------------------|-------|-------------|
-| `Bayesian/Types.lean` | 0 | Bayesian game type definitions |
-| `Bayesian/BNE.lean` | 0 | Bayesian-Nash equilibrium framework + refinement |
-| `Bayesian/Vickrey.lean` | 0 | Vickrey (second-price auction) truthfulness theorem |
-| `Bayesian/Auction.lean` | 0 | Auction mechanisms |
-| `Bayesian/Information.lean` + `InfoGames.lean` | 0 | Information structures, info games |
-| `Bayesian/Reputation.lean` | 0 | Reputation dynamics |
-| `Bayesian/FictitiousPlay.lean` + `Regret.lean` | 0 | Fictitious play, regret minimization |
-| `Bayesian/Max.lean` + `Sum.lean` | 0 | Max/sum helpers |
-| `Bayesian/Examples.lean` | 0 | Worked examples |
+| `Bayesian/Types.lean` | 0 | définitions de types de jeux bayésiens |
+| `Bayesian/BNE.lean` | 0 | cadre d'équilibre bayésien de Nash + raffinement |
+| `Bayesian/Vickrey.lean` | 0 | théorème de véracité de Vickrey (enchère au second prix) |
+| `Bayesian/Auction.lean` | 0 | mécanismes d'enchère |
+| `Bayesian/Information.lean` + `InfoGames.lean` | 0 | structures d'information, jeux d'information |
+| `Bayesian/Reputation.lean` | 0 | dynamique de réputation |
+| `Bayesian/FictitiousPlay.lean` + `Regret.lean` | 0 | jeu fictif, minimisation du regret |
+| `Bayesian/Max.lean` + `Sum.lean` | 0 | assistants max/somme |
+| `Bayesian/Examples.lean` | 0 | exemples résolus |
 
-**Build**: `lake build` — SUCCESS | **COMPLETE: 0 sorry, no Mathlib**
+**Build** : `lake build` — SUCCESS | **COMPLET : 0 sorry, sans Mathlib**
 
-**Status**: Vickrey truthfulness (second-price auction dominant strategy = truthful bidding) proved 0 sorry, Mathlib-free. Backend for the Lean-11b BayesianGamesExt companion notebook.
+**Statut** : véracité de Vickrey (enchère au second prix : stratégie dominante = enchérir honnêtement) prouvée 0 sorry, sans Mathlib. Backend du notebook compagnon Lean-11b BayesianGamesExt.
 
 ---
 
 ### 9. conway_cgt_lean
 
-**Objective**: Reference tour of combinatorial game theory (surreal numbers, partizan games, nimbers) as formalized in [`vihdzp/combinatorial-games`](https://github.com/vihdzp/combinatorial-games), imported as a Lake dependency. Upstream is the current home of CGT in Lean after Mathlib's CGT modules (`SetTheory.Surreal`/`PGame`/`Game`/`Nimber`) were deprecated (#28063, Aug 2025) then removed (#35550, Feb 2026). Reference: Conway, *On Numbers and Games* (2001).
+**Objectif** : tour de référence de la théorie combinatoire des jeux (nombres surréels, jeux partisans, nimbers) telle que formalisée dans [`vihdzp/combinatorial-games`](https://github.com/vihdzp/combinatorial-games), importée comme dépendance Lake. L'upstream est le home actuel de la TCG en Lean après la dépréciation (#28063, août 2025) puis la suppression (#35550, février 2026) des modules TCG de Mathlib (`SetTheory.Surreal`/`PGame`/`Game`/`Nimber`). Référence : Conway, *On Numbers and Games* (2001).
 
-**Toolchain**: v4.31.0-rc2 (tracks the upstream repo) | **Dependencies**: Mathlib4 + CombinatorialGames (Apache-2.0, `3c6dcdbc`)
+**Toolchain** : v4.31.0-rc2 (suit le repo upstream) | **Dépendances** : Mathlib4 + CombinatorialGames (Apache-2.0, `3c6dcdbc`)
 
-| File | sorry | Description |
+| Fichier | sorry | Description |
 |------|-------|-------------|
-| `CGTTour.lean` + `CGTTour_en.lean` | 0 | Tour of `IGame`/`Game` (concrete pre-games + quotient), `Surreal` (simplicity theorem), `Nimber` (Sprague-Grundy), with a Mathlib-vs-upstream comparison table |
+| `CGTTour.lean` + `CGTTour_en.lean` | 0 | tour de `IGame`/`Game` (pré-jeux concrets + quotient), `Surreal` (théorème de simplicité), `Nimber` (Sprague-Grundy), avec une table comparative Mathlib-vs-upstream |
 
-**Build**: `lake build CGTTour` — SUCCESS | **Reference tour, 0 sorry**
+**Build** : `lake build CGTTour` — SUCCESS | **Tour de référence, 0 sorry**
 
-**Status**: Reference / pedagogical tour, not a proving target. Exhibits the upstream API via `#check` + docstrings rather than proving new CGT theorems.
+**Statut** : tour de référence / pédagogique, pas une cible de preuve. Exhibe l'API upstream via `#check` + docstrings plutôt que de prouver de nouveaux théorèmes TCG.
 
 ---
 
 ### 10. assignment_lean
 
-**Objective**: Formalize the correction skeleton of the Hungarian method (Kuhn 1955, Munkres 1957) — companion lake of the notebook GameTheory-27-Munkres-Assignment, hommage à James R. Munkres (1930-2026). Issue #12598 (1/3).
+**Objectif** : formaliser le squelette de correction de la méthode hongroise (Kuhn 1955, Munkres 1957) — lake compagnon du notebook GameTheory-27-Munkres-Assignment, hommage à James R. Munkres (1930-2026). Issue #12598 (1/3).
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4
 
-| File (FR + `_en` sibling) | sorry | Description |
+| Fichier (FR + jumeau `_en`) | sorry | Description |
 |---------------------------|-------|-------------|
-| `Assignment/Definitions.lean` | 0 | Cost matrix, perfect matching (permutation), value, optimality |
-| `Assignment/Duality.lean` | 0 | Dual potentials `u`/`v`, dual feasibility, **weak duality** |
-| `Assignment/Optimality.lean` | 0 | Zero-gap optimality certificate (+ equality-edge lemma) |
-| `Assignment/KuhnMunkres.lean` | 0 | Equality graph, **output invariant**, **Hungarian tightening** preserves dual feasibility |
+| `Assignment/Definitions.lean` | 0 | matrice de coûts, couplage parfait (permutation), valeur, optimalité |
+| `Assignment/Duality.lean` | 0 | potentiels duaux `u`/`v`, faisabilité duale, **dualité faible** |
+| `Assignment/Optimality.lean` | 0 | certificat d'optimalité à écart nul (+ lemme d'arêtes d'égalité) |
+| `Assignment/KuhnMunkres.lean` | 0 | graphe d'égalité, **invariant de sortie**, le **resserrage hongrois** préserve la faisabilité duale |
 
-**Build**: `lake build Assignment` — SUCCESS | **COMPLETE: 0 sorry**
+**Build** : `lake build Assignment` — SUCCESS | **COMPLET : 0 sorry**
 
-**Key theorems**: `weak_duality`, `dualValue_eq_of_edges`, `optimality_of_zero_gap`, `kuhn_munkres_correct`, `dualFeasible_tighten`. **Hors scope (délibéré)**: termination / O(n³) complexity (Edmonds-Karp/Tomizawa) — structural correction by duality suffices for the teaching purpose.
+**Théorèmes clés** : `weak_duality`, `dualValue_eq_of_edges`, `optimality_of_zero_gap`, `kuhn_munkres_correct`, `dualFeasible_tighten`. **Hors scope (délibéré)** : terminaison / complexité O(n³) (Edmonds-Karp/Tomizawa) — la correction structurelle par dualité suffit à l'objectif pédagogique.
 
 ---
 
 ### 11. asymmetric_information_lean
 
-**Objective**: Formalize the foundational models of information asymmetry — companion of the GT-17 notebooks. Epic #12844 (first delivery, portée bornée conforme à l'audit canonique c.475).
+**Objectif** : formaliser les modèles fondateurs d'asymétrie d'information — compagnon des notebooks GT-17. Epic #12844 (première livraison, portée bornée conforme à l'audit canonique c.475).
 
-**Toolchain**: v4.32.1 | **Dependencies**: Lean core + `lean_game_defs_ext.Bayesian` (no Mathlib dependency)
+**Toolchain** : v4.32.1 | **Dépendances** : Lean core + `lean_game_defs_ext.Bayesian` (sans dépendance Mathlib)
 
-| File (FR + `_en` sibling) | sorry | Description |
+| Fichier (FR + jumeau `_en`) | sorry | Description |
 |---------------------------|-------|-------------|
-| `AsymmetricInformation/Lemons.lean` | 0 | Akerlof (1970) lemons market — participation-regions fixed point |
-| `AsymmetricInformation/Signaling.lean` | 0 | Spence (1973) education signal |
-| `AsymmetricInformation/Screening.lean` | 0 | Rothschild-Stiglitz (1976) adverse selection |
-| `AsymmetricInformation/MiyazakiWilson.lean` | 0 | Wilson (1977) / Miyazaki (1977) anticipatory cross-subsidy |
-| `AsymmetricInformation/BayesianLink.lean` | 0 | Non-trivial bridge to `lean_game_defs_ext.Bayesian` |
+| `AsymmetricInformation/Lemons.lean` | 0 | marché des lemons d'Akerlof (1970) — point fixe sur régions de participation |
+| `AsymmetricInformation/Signaling.lean` | 0 | signal éducation de Spence (1973) |
+| `AsymmetricInformation/Screening.lean` | 0 | sélection adverse Rothschild-Stiglitz (1976) |
+| `AsymmetricInformation/MiyazakiWilson.lean` | 0 | subvention croisée anticipatrice Wilson (1977) / Miyazaki (1977) |
+| `AsymmetricInformation/BayesianLink.lean` | 0 | pont non trivial vers `lean_game_defs_ext.Bayesian` |
 
-**Build**: `lake build` — SUCCESS | **COMPLETE: 0 code sorry** (2 naive hits = prose)
+**Build** : `lake build` — SUCCESS | **COMPLET : 0 sorry de code** (2 hits naive = prose)
 
-**Bornes explicites** (per README): no general existence/uniformity theorem for the anticipatory equilibrium (Wilson-MWS); no auxiliary clause in κ (Lemons); no cross-subsidy in RS 1976; no Mathlib `sorry`-backed milestone — proofs on Lean 4 core + `decide`/`omega`.
+**Bornes explicites** (per README) : pas de théorème général d'existence/uniformité pour l'équilibre anticipateur (Wilson-MWS) ; pas de clause auxiliaire en κ (Lemons) ; pas de subvention croisée dans RS 1976 ; aucun jalon `sorry`-backed Mathlib — preuves sur Lean 4 core + `decide`/`omega`.
 
 ---
 
 ### 10. assignment_lean
 
-**Objective**: Correction skeleton of the Kuhn-Munkres (Hungarian) assignment algorithm (issue #12598, Munkres tribute 1930-2026): the primal (cost matrix, perfect matching, value), the dual (potentials, feasibility, **weak duality**), the zero-gap optimality certificate, and the algorithm's structural invariants (equality graph, **output invariant**, **Hungarian tightening preserves dual feasibility**). Termination and O(n³) complexity deliberately out of scope.
+**Objectif** : squelette de correction de l'algorithme d'affectation de Kuhn-Munkres (hongrois) (issue #12598, hommage Munkres 1930-2026) : le primal (matrice de coûts, couplage parfait, valeur), le dual (potentiels, faisabilité, **dualité faible**), le certificat d'optimalité à écart nul, et les invariants structurels de l'algorithme (graphe d'égalité, **invariant de sortie**, **le resserrage hongrois préserve la faisabilité duale**). Terminaison et complexité O(n³) délibérément hors scope.
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4 (v4.32.1)
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4 (v4.32.1)
 
-| File | sorry | Description |
+| Fichier | sorry | Description |
 |------|-------|-------------|
-| `Assignment/Definitions.lean` | 0 | `value`, `IsOptimal` (primal problem) |
+| `Assignment/Definitions.lean` | 0 | `value`, `IsOptimal` (problème primal) |
 | `Assignment/Duality.lean` | 0 | `DualFeasible`, `dualValue`, `weak_duality` |
 | `Assignment/Optimality.lean` | 0 | `dualValue_eq_of_edges`, `optimality_of_zero_gap` |
 | `Assignment/KuhnMunkres.lean` | 0 | `EqEdge`, `kuhn_munkres_correct`, `dualFeasible_tighten` |
-| `Assignment/*_en.lean` (×4) | 0 | i18n siblings (EPIC #4980) |
+| `Assignment/*_en.lean` (×4) | 0 | jumeaux i18n (EPIC #4980) |
 
-**Build**: `lake build Assignment Assignment_en` — SUCCESS (8665 jobs, cf PR #12614) | **0 sorry** (distinct_code_sorry = 0)
+**Build** : `lake build Assignment Assignment_en` — SUCCESS (8665 jobs, cf PR #12614) | **0 sorry** (distinct_code_sorry = 0)
 
-**Status**: COMPLETE. Companion notebooks: GT-27 (Python implementation + scipy SOTA) and GT-27b (native `lean4-wsl` companion — `#check` of all 10 declarations + kernel-proved `optimal_C3` certificate, EPIC #11703 visibility).
+**Statut** : COMPLET. Notebooks compagnons : GT-27 (implémentation Python + scipy SOTA) et GT-27b (compagnon natif `lean4-wsl` — `#check` des 10 déclarations + certificat `optimal_C3` prouvé au kernel, visibilité EPIC #11703).
 
 ---
 
-## Remaining Proving Targets
+## Cibles de preuve restantes
 
-| Priority | Target | Dir | sorry | Feasibility |
+| Priorité | Cible | Rép | sorry | Faisabilité |
 |----------|--------|-----|-------|-------------|
-| P3 | `folk_theorem_discounted` / `folk_theorem_boundary` (stretch toléré) | `game_theory_lean/RepeatedGames/Folk.lean` (+ `_en`) | 1 stretch (#4880) | Low — authentically hard direction (`… = u_col`), grim already covers the closure criterion |
+| P3 | `folk_theorem_discounted` / `folk_theorem_boundary` (stretch toléré) | `game_theory_lean/RepeatedGames/Folk.lean` (+ `_en`) | 1 stretch (#4880) | Basse — direction authentiquement difficile (`… = u_col`), grim couvre déjà le critère de clôture |
 
-> **Note (G.9 correction, 2026-08-26):** l'ancienne ligne P1 « Basic.lean L309 hCore / Very Low
+> **Note (correction G.9, 2026-08-26) :** l'ancienne ligne P1 « Basic.lean L309 hCore / Very Low
 > (Hahn-Banach) » était stale (#3954 l'a close) ; l'ancien compte « 3 (Lattice) » pour
 > `game_theory_lean` était stale aussi — `StableMarriage/Lattice.lean` est à 0 sorry
 > (vérifié `count_code_sorry.py` : `distinct_code_sorry = 1`, localisé à `Folk.lean:127`).
-> Removing stale targets prevents a pointless BG-iter cycle on a sorry that no longer exists
+> Retirer les cibles stale évite un cycle BG-iter inutile sur un sorry qui n'existe plus
 > (cf. lean-merge-discipline §2).
 
-## GO/NO-GO per Project (for BG iter cycles)
+## GO/NO-GO par projet (pour les cycles BG iter)
 
-| Project | Decision | Reasoning |
+| Projet | Décision | Justification |
 |---------|----------|-----------|
-| game_theory_lean | COMPLETE | 1 sorry (Folk stretch, toléré #4880). StableMarriage: former false statements refuted, honest `exists_isManOptimal` proved; Lattice closed. Absorbed `stable_marriage_lean/` + `cooperative_games_lean/` + `social_choice_lean/` + `repeated_games_lean/` (EPIC #4365). |
-| ~~cooperative_games_lean~~ | **Supprimé** (rm #6587) | Absorbed byte-identique into `game_theory_lean/CooperativeGames/`. |
-| ~~social_choice_lean~~ | **Absorbé** (#6058) | 7 modules → `game_theory_lean/SocialChoice/` ; tombstone docs only. |
-| ~~repeated_games_lean~~ | **Absorbé** (#6146) | 4 modules → `game_theory_lean/RepeatedGames/` ; archive shell. |
-| lean_game_defs / _ext | COMPLETE | 0 sorry, Mathlib-free. |
-| minimax_lean | COMPLETE | 0 sorry ; Sion application proved. |
-| assignment_lean | COMPLETE | 0 sorry (#12598). |
-| asymmetric_information_lean | COMPLETE | 0 code sorry (Epic #12844). |
-| social_choice_lean_peters | N/A | Reference only (Peters `94a4c650`, Mathlib `520045ab`, v4.32.1). |
-| conway_cgt_lean | N/A | Reference tour (v4.31.0-rc2, tracks upstream). |
+| game_theory_lean | COMPLET | 1 sorry (Folk stretch, toléré #4880). StableMarriage : anciens énoncés faux réfutés, `exists_isManOptimal` honnête prouvé ; Lattice clos. A absorbé `stable_marriage_lean/` + `cooperative_games_lean/` + `social_choice_lean/` + `repeated_games_lean/` (EPIC #4365). |
+| ~~cooperative_games_lean~~ | **Supprimé** (rm #6587) | Absorbé byte-identique dans `game_theory_lean/CooperativeGames/`. |
+| ~~social_choice_lean~~ | **Absorbé** (#6058) | 7 modules → `game_theory_lean/SocialChoice/` ; docs tombstone uniquement. |
+| ~~repeated_games_lean~~ | **Absorbé** (#6146) | 4 modules → `game_theory_lean/RepeatedGames/` ; coquille archive. |
+| lean_game_defs / _ext | COMPLET | 0 sorry, sans Mathlib. |
+| minimax_lean | COMPLET | 0 sorry ; application de Sion prouvée. |
+| assignment_lean | COMPLET | 0 sorry (#12598). |
+| asymmetric_information_lean | COMPLET | 0 sorry de code (Epic #12844). |
+| social_choice_lean_peters | N/A | Référence seule (Peters `94a4c650`, Mathlib `520045ab`, v4.32.1). |
+| conway_cgt_lean | N/A | Tour de référence (v4.31.0-rc2, suit l'upstream). |
 
-Conway calibration targets (Doomsday / FRACTRAN / Look-and-Say / Nim / Angel) live in `SymbolicAI/Lean/conway_lean/` and are still consumed by `agent_tests/prover/config.py` (#1453 prover harness co-evolution).
+Les cibles de calibration Conway (Doomsday / FRACTRAN / Look-and-Say / Nim / Angel) vivent dans `SymbolicAI/Lean/conway_lean/` et sont toujours consommées par `agent_tests/prover/config.py` (co-évolution du harnais prouveur #1453).
 
 ---
 
-## Related documentation
+## Documentation liée
 
-- [docs/lean/sota-2026-analysis.md](../../docs/lean/sota-2026-analysis.md) — SOTA in automated Lean 4 proving
-- [docs/lean/prover_iteration_history.md](../../docs/lean/prover_iteration_history.md) — Prover iterations F6-F11, B3
-- [docs/lean/llm-endpoints.md](../../docs/lean/llm-endpoints.md) — LLM providers for the prover
-- [docs/lean/coordinator-workflow.md](../../docs/lean/coordinator-workflow.md) — Coordinator build + BG iter workflow
+- [docs/lean/sota-2026-analysis.md](../../docs/lean/sota-2026-analysis.md) — SOTA de la preuve automatisée en Lean 4
+- [docs/lean/prover_iteration_history.md](../../docs/lean/prover_iteration_history.md) — itérations du prouveur F6-F11, B3
+- [docs/lean/llm-endpoints.md](../../docs/lean/llm-endpoints.md) — fournisseurs LLM pour le prouveur
+- [docs/lean/coordinator-workflow.md](../../docs/lean/coordinator-workflow.md) — workflow build coordinateur + BG iter

--- a/MyIA.AI.Notebooks/QuantConnect/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/LEAN_INVENTORY.md
@@ -1,40 +1,40 @@
-# Lean 4 Projects Inventory — QuantConnect
+# Inventaire des projets Lean 4 — QuantConnect
 
-Cross-directory inventory of all Lean 4 formalization projects under `QuantConnect/`.
+Inventaire transverse de tous les projets de formalisation Lean 4 sous `QuantConnect/`.
 
 Réconcilié le 2026-08-28 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
 module-set réel du disque (issue #13366, matrice #13121 tranche 3). Comptes `sorry` mesurés avec
 l'instrument canonique `scripts/lean/count_code_sorry.py --lake <root> --json` (champ
 `distinct_code_sorry`), jamais `grep -c sorry`.
 
-## Summary
+## Résumé
 
 **Lakes actifs (1)** :
 
-| Directory | Toolchain | Production sorry | Modules | Status |
+| Répertoire | Toolchain | Sorry (production) | Modules | Statut |
 |-----------|-----------|-----------------|---------|--------|
-| `kelly_lean` | v4.32.1 | 0 | `Kelly/{Kelly, Bet, Growth}` (3 FR + 3 `_en`) | COMPLETE |
+| `kelly_lean` | v4.32.1 | 0 | `Kelly/{Kelly, Bet, Growth}` (3 FR + 3 `_en`) | COMPLET |
 
 ---
 
-## Directories
+## Répertoires
 
 ### 1. kelly_lean
 
-**Objective**: optimalité du critère de Kelly — fraction optimale de mise, croissance log-optimale
+**Objectif** : optimalité du critère de Kelly — fraction optimale de mise, croissance log-optimale
 du capital (`growthGrad_kelly_zero` : dérivée du growth nulle au point Kelly), faisabilité de la
 fraction (`kellyFrac_feasible`), et formalisation du pari équivalent (`q`, `pq_add_eq_one`).
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4
 
-| Module group | sorry | Content |
+| Groupe de modules | sorry | Contenu |
 |--------------|-------|---------|
 | `Kelly/Kelly` (FR + `_en`) | 0 | critère de Kelly : `kellyFrac_feasible`, richesses win/lose au point Kelly, `growthGrad_kelly_zero`, `growth_diff_le` |
 | `Kelly/Bet` (FR + `_en`) | 0 | pari équivalent : `q`, `q_pos`, `q_lt_one`, `pq_add_eq_one`, `winWealth` |
 | `Kelly/Growth` (FR + `_en`) | 0 | croissance : `growth_zero`, `growthGrad_zero` |
 
-**CI wiring**: caller workflow [`lean-kelly.yml`](../../.github/workflows/lean-kelly.yml)
+**Câblage CI** : workflow caller [`lean-kelly.yml`](../../.github/workflows/lean-kelly.yml)
 (push `main`, paths `MyIA.AI.Notebooks/QuantConnect/kelly_lean/**.lean` + `lakefile.*`), pipeline `standalone-tactic`.
 
-**Notebooks in-lake (2, C.2 OK)** : `Kelly_companion.ipynb` (Python) et
+**Notebooks dans le lake (2, C.2 OK)** : `Kelly_companion.ipynb` (Python) et
 `Kelly_companion_lean.ipynb` (Lean) à la racine du lake.

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/LEAN_INVENTORY.md
@@ -1,19 +1,19 @@
-# Lean 4 Projects Inventory — SymbolicAI/Planners
+# Inventaire des projets Lean 4 — SymbolicAI/Planners
 
-Cross-directory inventory of all Lean 4 formalization projects under `SymbolicAI/Planners/`.
+Inventaire transverse de tous les projets de formalisation Lean 4 sous `SymbolicAI/Planners/`.
 
 Réconcilié le 2026-08-28 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
 module-set réel du disque (issue #13366, matrice #13121 tranche 3). Comptes `sorry` mesurés avec
 l'instrument canonique `scripts/lean/count_code_sorry.py --lake <root> --json` (champ
 `distinct_code_sorry`), jamais `grep -c sorry`.
 
-## Summary
+## Résumé
 
 **Lakes actifs (1)** :
 
-| Directory | Toolchain | Production sorry | Modules | Status |
+| Répertoire | Toolchain | Sorry (production) | Modules | Statut |
 |-----------|-----------|-----------------|---------|--------|
-| `planning_lean` | v4.32.1 | 0 | `Planning/{Strips, Relaxation, Admissibility}` (3 FR + 3 `_en`) | COMPLETE |
+| `planning_lean` | v4.32.1 | 0 | `Planning/{Strips, Relaxation, Admissibility}` (3 FR + 3 `_en`) | COMPLET |
 
 Note de cheminement : la matrice #13121 tranche 3 référençait `MyIA.AI.Notebooks/Planners/planning_lean` ;
 le chemin effectif au disque est `MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean` (inventaire aligné
@@ -21,23 +21,23 @@ sur le disque).
 
 ---
 
-## Directories
+## Répertoires
 
 ### 1. planning_lean
 
-**Objective**: admissibilité de la relaxation sans-delete en planification STRIPS — le coût du plan
+**Objectif** : admissibilité de la relaxation sans-delete en planification STRIPS — le coût du plan
 relaxé optimal `h⁺` n'excède jamais le coût du plan réel optimal `h*`
 (`relaxed_plan_admissible` + `relaxed_plan_witness`), sur les sémantiques `step` (réelle) et
 `stepR` (relaxée) avec `step_subset_stepR` et `run_mono`.
 
-**Toolchain**: v4.32.1 (pin effectif mesuré `lean-toolchain` ; la prose du README annonce encore
-`v4.31.0-rc1` — périmée, à corriger séparément) | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 (pin effectif mesuré `lean-toolchain` ; la prose du README annonce encore
+`v4.31.0-rc1` — périmée, à corriger séparément) | **Dépendances** : Mathlib4
 
-| Module group | sorry | Content |
+| Groupe de modules | sorry | Contenu |
 |--------------|-------|---------|
 | `Planning/Strips` (FR + `_en`) | 0 | domaine STRIPS : `applicable`, `step`, `stepR`, `goalSatisfied`, `step_subset_stepR` |
 | `Planning/Relaxation` (FR + `_en`) | 0 | exécution relaxée : `run`, `runR`, `reaches`, `reachesR`, `run_mono` |
 | `Planning/Admissibility` (FR + `_en`) | 0 | théorème-phare : `relaxed_plan_admissible`, `relaxed_plan_witness` |
 
-**CI wiring**: caller workflow [`lean-planning.yml`](../../../.github/workflows/lean-planning.yml)
+**Câblage CI** : workflow caller [`lean-planning.yml`](../../../.github/workflows/lean-planning.yml)
 (push `main`, paths `MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/**.lean` + `lakefile.*`), pipeline `standalone-tactic`.

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/LEAN_INVENTORY.md
@@ -1,33 +1,37 @@
-# Lean 4 Projects Inventory — SymbolicAI/Tweety
+# Inventaire des projets Lean 4 — SymbolicAI/Tweety
 
-Cross-directory inventory of all Lean 4 formalization projects under `SymbolicAI/Tweety/`.
+Inventaire transverse de tous les projets de formalisation Lean 4 sous `SymbolicAI/Tweety/`.
 
 Réconcilié le 2026-08-28 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
 module-set réel du disque (issue #13366, matrice #13121 tranche 3). Comptes `sorry` mesurés avec
 l'instrument canonique `scripts/lean/count_code_sorry.py --lake <root> --json` (champ
 `distinct_code_sorry`), jamais `grep -c sorry`.
 
-## Summary
+## Résumé
 
 **Lakes actifs (1)** :
 
-| Directory | Toolchain | Production sorry | Modules | Status |
+| Répertoire | Toolchain | Sorry (production) | Modules | Statut |
 |-----------|-----------|-----------------|---------|--------|
-| `argumentation_lean` | v4.32.1 | 0 | `Argumentation/{Basic, Fundamental, Grounded, Characteristic, Extensions}` (5 FR + 5 `_en`) + umbrella `Argumentation.lean` | COMPLETE |
+| `argumentation_lean` | v4.32.1 | 0 | `Argumentation/{Basic, Fundamental, Grounded, Characteristic, Extensions}` (5 FR + 5 `_en`) + umbrella `Argumentation.lean` | COMPLET |
 
 ---
 
-## Directories
+## Répertoires
 
 ### 1. argumentation_lean
 
-**Objective**: théorie de l'argumentation abstraite de Dung (1995) — cadres d'argumentation (AF),
+**Objectif** : théorie de l'argumentation abstraite de Dung (1995) — cadres d'argumentation (AF),
 les extensions canoniques (admissible, complète, grounded, preferred, stable), lemme fondamental
-et fonction caractéristique, au-dessus de Mathlib.
+et fonction caractéristique, au-dessus de Mathlib. Formalisation compagnon du notebook Tweety-5
+(roadmap Lean #4038, #4046).
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+**Notebook câblé** : `Tweety-5b-Lean-Argumentation.ipynb` (kernel `lean4-wsl`, importe
+`Argumentation.*`) ; companion conceptuel = le notebook **Tweety-5**.
 
-| Module group | sorry | Content |
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4
+
+| Groupe de modules | sorry | Contenu |
 |--------------|-------|---------|
 | `Argumentation/Basic` (FR + `_en`) | 0 | conflit et défense : `conflictFree`, `defends`, `defendedBy`, `conflictFree_empty` |
 | `Argumentation/Fundamental` (FR + `_en`) | 0 | lemme fondamental : `fundamental_lemma` (+ variantes `defends`/`defends_self`) |
@@ -36,5 +40,5 @@ et fonction caractéristique, au-dessus de Mathlib.
 | `Argumentation/Extensions` (FR + `_en`) | 0 | hiérarchie des extensions : `Admissible`, `Complete`, `grounded`, `Preferred` |
 | `Argumentation.lean` (umbrella) | 0 | imports agrégés du lake |
 
-**CI wiring**: caller workflow [`lean-argumentation.yml`](../../../.github/workflows/lean-argumentation.yml)
+**Câblage CI** : workflow caller [`lean-argumentation.yml`](../../../.github/workflows/lean-argumentation.yml)
 (push `main`, paths `MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/**.lean` + `lakefile.*`), pipeline `standalone-tactic`.


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: MED/lean #13395

## Summary

Francisation des **4 `LEAN_INVENTORY.md` anglais** — livraison complète 4/4 de #13402 : `SymbolicAI/Tweety` (43 l.), `SymbolicAI/Planners` (45 l.), `QuantConnect` (41 l.), `GameTheory` (313 l., traité en second dans la même PR car même sujet — règle one-subject-per-PR ; l'option « tranche à part » de l'issue ne s'imposait plus une fois la traduction produite).

Francisation de prose uniquement : titre (`# Lean 4 Projects Inventory —` → `# Inventaire des projets Lean 4 —`), ligne d'introduction, `## Summary` → `## Résumé`, `## Directories` → `## Répertoires`, en-têtes de colonnes (`Directory/Production sorry/Status/Module group/Content/File/Priority/Target/Dir/Feasibility/Project/Decision/Reasoning` → équivalents FR), libellés (`Objective/Dependencies/CI wiring/Key proofs/Key facts/Key theorems/Status/Build` → `Objectif/Dépendances/Câblage CI/Preuves clés/Faits clés/Théorèmes clés/Statut/Build`), `COMPLETE` → `COMPLET`, `Reference only/tour` → `Référence seule/Tour de référence`. Sections finales GameTheory : `Remaining Proving Targets` → `Cibles de preuve restantes`, `GO/NO-GO per Project` → `GO/NO-GO par projet`, `Related documentation` → `Documentation liée`.

**Non traduits** (règle de l'issue) : noms de lakes, chemins, noms de modules Lean, identifiants de toolchain, noms de lemmes/théorèmes, `distinct_code_sorry`, références Mathlib, statuts techniques (`SUCCESS`, `FORMAL-CERTIFIED`).

## Reprise de #13373 (Tweety uniquement) — 2 apports réinjectés, 2 erreurs exclues

Réinjectés (vérifiés firsthand sur le disque) :
1. Renvois Epic **#4038 / #4046** : « Formalisation compagnon du notebook Tweety-5 (roadmap Lean #4038, #4046) » ajouté à l'Objectif.
2. Note de câblage : « **Notebook câblé** : `Tweety-5b-Lean-Argumentation.ipynb` (kernel `lean4-wsl`, importe `Argumentation.*`) ; companion conceptuel = le notebook **Tweety-5** » — fichier vérifié existant sur disque.

Exclus (erreurs documentées par l'issue) : le compte erroné « 6 modules » (le disque porte en réalité des paires FR+`_en` plus un umbrella — re-vérifié par `ls` dans `Argumentation/`) et la description maison de l'instrument de comptage (la formulation mergée cite l'instrument canonique `count_code_sorry.py`/`distinct_code_sorry`, conservée).

## Preuves d'acceptance

- **Structure/ancres identiques** : GameTheory 18 sections avant/après (niveaux de titres identiques) ; `git diff` 136+/136− (fichier), lisible comme traduction.
- **Liens relatifs identiques** : diff des cibles de liens avant/après = vide sur les 4 fichiers ; workflows cibles (`lean-argumentation.yml`, `lean-planning.yml`, `lean-kelly.yml`) vérifiés existants.
- **Zéro lien ancré** vers ces fichiers : `git grep -E "LEAN_INVENTORY\.md#" -- '*.md'` → vide.
- **Chiffres non touchés** : aucun compte sorry/module modifié (traduction pure) ; module-sets re-vérifiés par `ls` sur chaque répertoire (FR + `_en` pairs, conformes aux tableaux).
- **Encodage** : UTF-8 sans BOM vérifié sur les 4 fichiers.
- **Pas de collision** : PR 13369 (tranche 3, OPEN) touche les fichiers FR (ML, Probas, Search, Sudoku, SmartContracts) — zéro recouvrement avec les EN de cette PR.

## Signalement hors scope (ne pas traiter ici)

`GameTheory/LEAN_INVENTORY.md` porte une **section dupliquée** `### 10. assignment_lean` (apparaît deux fois avec des contenus différents, défaut préexistant, numérotation 11→10). Non corrigé ici (francisation ≠ refonte) — signalé pour une issue dédiée.

Closes #13402

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>