### PR TITLE
fix(search,#13407): MGS-22 probe PythonNet system-first + re-exec — deterministic substance identical, speed re-anchored

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-22-MGS-vs-Mealpy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-22-MGS-vs-Mealpy.ipynb
@@ -47,16 +47,11 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
-     "data": {
-      "text/html": ""
-     },
-     "metadata": {}
-    },
-    {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Grille de référence : 36 cellules vides, 45 indices fixes, 36 gènes R1.\r\n"
+     "text": [
+      "Grille de référence : 36 cellules vides, 45 indices fixes, 36 gènes R1.\r\n"
+     ]
     }
    ],
    "source": [
@@ -148,7 +143,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS PSO (graine 7, témoin) : 46 conflits, 8000 évaluations, 3733 ms.\r\n"
+     "text": [
+      "MGS PSO (graine 7, témoin) : 46 conflits, 8000 évaluations, 1288 ms.\r\n"
+     ]
     }
    ],
    "source": [
@@ -237,35 +234,47 @@
    "outputs": [
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
-      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>pythonnet</span></li></ul></div><div></div></div>"
-     },
-     "metadata": {}
+      "text/html": [
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>pythonnet</span></li></ul></div><div></div></div>"
+      ]
+     }
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Pont PythonNet actif : mealpy 3.0.2 sur Python 3.13.12\r\n"
+     "text": [
+      "Pont PythonNet actif : mealpy 3.0.2 sur Python 3.13.3\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  vecteur témoin 1 : coût C# = 67, coût Python = 67 -> IDENTIQUE\r\n"
+     "text": [
+      "  vecteur témoin 1 : coût C# = 67, coût Python = 67 -> IDENTIQUE\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  vecteur témoin 2 : coût C# = 71, coût Python = 71 -> IDENTIQUE\r\n"
+     "text": [
+      "  vecteur témoin 2 : coût C# = 71, coût Python = 71 -> IDENTIQUE\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  vecteur témoin 3 : coût C# = 60, coût Python = 60 -> IDENTIQUE\r\n"
+     "text": [
+      "  vecteur témoin 3 : coût C# = 60, coût Python = 60 -> IDENTIQUE\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Sanity check PASSE : la fonction de coût est identique des deux côtés -- le bench est valide.\r\n"
+     "text": [
+      "Sanity check PASSE : la fonction de coût est identique des deux côtés -- le bench est valide.\r\n"
+     ]
     }
    ],
    "source": [
@@ -288,6 +297,11 @@
     "    if (!string.IsNullOrEmpty(env) && System.IO.File.Exists(env)) return env;\n",
     "    if (OperatingSystem.IsWindows())\n",
     "    {\n",
+    "        // Installs CPython.org standards d'abord (les plus récentes portent les packages récents\n",
+    "        // comme mealpy), ensuite le scan LOCALAPPDATA — un Python périmé qui n'a pas mealpy\n",
+    "        // ne doit pas masquer une install plus récente (pb 2026-08-25 : Python310 2023 devant Python313).\n",
+    "        foreach (var c in new[] { @\"C:\\Python313\\python313.dll\", @\"C:\\Python312\\python312.dll\" })\n",
+    "            if (System.IO.File.Exists(c)) return c;\n",
     "        var local = Environment.GetEnvironmentVariable(\"LOCALAPPDATA\");\n",
     "        if (!string.IsNullOrEmpty(local))\n",
     "        {\n",
@@ -299,8 +313,6 @@
     "                    if (hit.Length > 0) return hit[0];\n",
     "                }\n",
     "        }\n",
-    "        foreach (var c in new[] { @\"C:\\Python313\\python313.dll\", @\"C:\\Python312\\python312.dll\" })\n",
-    "            if (System.IO.File.Exists(c)) return c;\n",
     "        // Racines conda (user puis systeme) : python313.dll versionne prefere au\n",
     "        // python3.dll stable-ABI (recommandation pythonnet).\n",
     "        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);\n",
@@ -510,12 +522,16 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy OriginalPSO (graine 7, témoin) : 26 conflits, 8050 évaluations, 2045 ms.\r\n"
+     "text": [
+      "mealpy OriginalPSO (graine 7, témoin) : 26 conflits, 8050 évaluations, 676 ms.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Contre-vérif croisée : coût C# du meilleur mealpy = 26 (Python rapporte 26) -> IDENTIQUE\r\n"
+     "text": [
+      "Contre-vérif croisée : coût C# du meilleur mealpy = 26 (Python rapporte 26) -> IDENTIQUE\r\n"
+     ]
     }
    ],
    "source": [
@@ -567,72 +583,100 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "moteur    graine  conflits   evals       ms  ms/eval\r\n"
+     "text": [
+      "moteur    graine  conflits   evals       ms  ms/eval\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS            0        39    8000     2133    0,267\r\n"
+     "text": [
+      "MGS            0        39    8000      787    0,098\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS            1        41    8000     1713    0,214\r\n"
+     "text": [
+      "MGS            1        41    8000      823    0,103\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS            7        46    8000     2392    0,299\r\n"
+     "text": [
+      "MGS            7        46    8000      852    0,106\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS           42        48    8000     1921    0,240\r\n"
+     "text": [
+      "MGS           42        48    8000      854    0,107\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy         0        30    8050     2597    0,323\r\n"
+     "text": [
+      "mealpy         0        30    8050      670    0,083\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy         1        27    8050     2656    0,330\r\n"
+     "text": [
+      "mealpy         1        27    8050      717    0,089\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy         7        26    8050     2375    0,295\r\n"
+     "text": [
+      "mealpy         7        26    8050      691    0,086\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy        42        31    8050     3115    0,387\r\n"
+     "text": [
+      "mealpy        42        31    8050      640    0,080\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS    : médiane conflits 43,5 (min 39, max 48), ms/éval moyen 0,255\r\n"
+     "text": [
+      "MGS    : médiane conflits 43,5 (min 39, max 48), ms/éval moyen 0,104\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy : médiane conflits 28,5 (min 26, max 31), ms/éval moyen 0,334\r\n"
+     "text": [
+      "mealpy : médiane conflits 28,5 (min 26, max 31), ms/éval moyen 0,084\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Rapport ms/éval mealpy/MGS : 1,31x\r\n"
+     "text": [
+      "Rapport ms/éval mealpy/MGS : 0,81x\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Déterminisme : conflits identiques sur les 3 répétitions pour 8/8 paires graine-moteur.\r\n"
+     "text": [
+      "Déterminisme : conflits identiques sur les 3 répétitions pour 8/8 paires graine-moteur.\r\n"
+     ]
     }
    ],
    "source": [
@@ -703,17 +747,7 @@
    "cell_type": "markdown",
    "id": "m22c11",
    "metadata": {},
-   "source": [
-    "### Lecture du croisement : ex æquo en vitesse, mealpy domine en qualité\n",
-    "\n",
-    "Les critères pré-enregistrés, appliqués aux médianes de 3 répétitions :\n",
-    "\n",
-    "- **Qualité** : mealpy médiane 28,5 contre 43,5 pour MGS — et **séparation totale des gammes** : le pire mealpy (31 conflits, graine 42) fait mieux que le meilleur MGS (39 conflits, graine 0). Le critère « médiane strictement inférieure ET max sous min » est satisfait dans les deux clauses : domination complète, sans chevauchement de distributions.\n",
-    "- **Vitesse** : rapport ms/éval de **0,99×** — ex æquo statistique. Les médianes par graine se tiennent dans une fourchette serrée côté mealpy (710-735 ms pour ~8 000 évaluations) ; côté MGS (680-692 ms, sauf la graine 0 à 857) la sensibilité GC survit partiellement à la médiane de 3 — deux des trois répétitions de la graine 0 ont pris le palier, preuve que trois répétitions bornent le bruit sans l'éliminer. Et l'amendement de protocole a été décisif ici : le run pilote en timing single-run concluant « 0,8×, mealpy 20 % plus vite » était un **artefact** — un pic de garbage collection .NET (1 132 ms mesurés pour une course qui en prend ~700 à chaud) avait gonflé la moyenne MGS. À médiane de répétitions, l'écart s'évanouit.\n",
-    "- **Déterminisme** : 8/8 paires graine-moteur avec conflits identiques sur les 3 répétitions — le seeding est prouvé *en direct*, et corollaire important : la différence de qualité entre moteurs (39-48 contre 26-31) **n'est pas du bruit**, chaque course seedée reproduit exactement son résultat.\n",
-    "\n",
-    "L'hypothèse de départ — *« possible que les perfs ne suivent pas mealpy sous NumPy optimisé »* — se lit donc en deux moitiés : **réfutée sur l'axe vitesse** (MGS tient le rythme de mealpy à budget égal), et **vérifiée en sens inverse sur l'axe qualité** (mealpy devant, nettement). La nuance honnête sur l'axe qualité : les deux « PSO canoniques » ne partagent pas leurs paramètres par défaut (coefficients d'inertie et d'attraction réglés différemment par chaque bibliothèque) — l'axe mesure *la bibliothèque telle qu'on la lance*, ce que mesure un utilisateur réel, pas une course de formules identiques. La section suivante explique pourquoi l'ex æquo vitesse est, malgré tout, le résultat le plus instructif du notebook."
-   ]
+   "source": "### Lecture du croisement : vitesse au coude-à-coude (sensible au matériel), mealpy domine en qualité\n\nLes critères pré-enregistrés, appliqués aux médianes de 3 répétitions :\n\n- **Qualité** : mealpy médiane 28,5 contre 43,5 pour MGS — et **séparation totale des gammes** : le pire mealpy (31 conflits, graine 42) fait mieux que le meilleur MGS (39 conflits, graine 0). Le critère « médiane strictement inférieure ET max sous min » est satisfait dans les deux clauses : domination complète, sans chevauchement de distributions. Ce verdict est **déterministe et reproductible à l'identique** (re-exécution #13407 : mêmes conflits 4/4 graines, mêmes médianes).\n- **Vitesse** : rapport ms/éval de **0,81×** sur cette exécution — mealpy ~19 % moins cher par évaluation. Les médianes par graine : mealpy 640-717 ms pour ~8 050 évaluations, MGS 787-854 ms pour 8 000. Le run original (outputs remplacés par la re-exécution #13407) donnait **0,99×** après amendement anti-pic GC (1,31× en moyenne brute) : la vitesse relative est **sensible au matériel** — l'écart observé traverse 1,0× d'une machine à l'autre. Le verdict robuste est la **parité d'ordre de grandeur** (0,8×-1,3× observé), pas le signe de l'écart. L'amendement de protocole reste décisif : le run pilote en timing single-run concluant « 0,8×, mealpy 20 % plus vite » était un **artefact** — un pic de garbage collection .NET (1 132 ms mesurés pour une course qui en prend ~660 à chaud) avait gonflé la moyenne MGS. Tout timing de cette série se lit en médiane de répétitions.\n- **Déterminisme** : 8/8 paires graine-moteur avec conflits identiques sur les 3 répétitions — le seeding est prouvé *en direct*, et corollaire important : la différence de qualité entre moteurs (39-48 contre 26-31) **n'est pas du bruit**, chaque course seedée reproduit exactement son résultat.\n\nL'hypothèse de départ — *« possible que les perfs ne suivent pas mealpy sous NumPy optimisé »* — se lit donc en deux moitiés : **réfutée sur l'axe vitesse** (MGS tient l'ordre de grandeur de mealpy à budget égal, l'écart restant dans la sensibilité matérielle), et **vérifiée en sens inverse sur l'axe qualité** (mealpy devant, nettement, de façon déterministe). La nuance honnête sur l'axe qualité : les deux « PSO canoniques » ne partagent pas leurs paramètres par défaut (coefficients d'inertie et d'attraction réglés différemment par chaque bibliothèque) — l'axe mesure *la bibliothèque telle qu'on la lance*, ce que mesure un utilisateur réel, pas une course de formules identiques. La section suivante explique pourquoi l'équilibre vitesse est, malgré tout, le résultat le plus instructif du notebook."
   },
   {
    "cell_type": "code",
@@ -728,22 +762,30 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Fitness seule, 500 vecteurs identiques (médiane de 5 répétitions par côté) :\r\n"
+     "text": [
+      "Fitness seule, 500 vecteurs identiques (médiane de 5 répétitions par côté) :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  C#     : 12,9 ms total -> 0,026 ms/éval\r\n"
+     "text": [
+      "  C#     : 3,5 ms total -> 0,007 ms/éval\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Python : 27,7 ms total -> 0,055 ms/éval\r\n"
+     "text": [
+      "  Python : 17,8 ms total -> 0,036 ms/éval\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  rapport Python/C# : 2,14x\r\n"
+     "text": [
+      "  rapport Python/C# : 5,13x\r\n"
+     ]
     }
    ],
    "source": [
@@ -783,22 +825,7 @@
    "cell_type": "markdown",
    "id": "m22c13",
    "metadata": {},
-   "source": [
-    "### Lecture du coût par évaluation : fitness C# 5,5× plus rapide — et un bench ex æquo quand même\n",
-    "\n",
-    "C'est la cellule qui explique le paradoxe apparent du croisement. Mesurée seule, hors moteur, sur les 500 mêmes vecteurs (médiane de 5 répétitions) :\n",
-    "\n",
-    "- **fitness C# : 0,007 ms/éval** (3,7 ms pour 500) — **fitness Python : 0,043 ms/éval** (21,3 ms) : rapport **5,72×** en faveur du C#. L'écart attendu entre code JIT .NET et code objet Python interprété est bien là, massif et stable (5,5-5,7× d'une exécution à l'autre).\n",
-    "\n",
-    "Pourtant le bench complet donne 0,091 ms/éval pour MGS contre 0,090 pour mealpy — l'ex æquo presque parfait. La décomposition arithmétique est la leçon du notebook :\n",
-    "\n",
-    "| | fitness (mesurée) | moteur (bench − fitness) | total |\n",
-    "|---|---|---|---|\n",
-    "| **MGS** | 0,007 ms/éval | **0,084 ms/éval** | 0,091 |\n",
-    "| **mealpy** | 0,043 ms/éval | **0,047 ms/éval** | 0,090 |\n",
-    "\n",
-    "Deux effets opposés s'annulent : la fitness C# est 5,5× plus rapide, mais la **mécanique de génération** de MetaGeneticSharp (sélection, croisement, mutation, structures de population) dépense ~0,084 ms par évaluation, soit **~1,8×** celle de mealpy (~0,047 ms) — et la fitness ne pèse que 8 % du coût total côté MGS. Trois moralités mesurées : *le coût par évaluation d'un moteur n'est pas le coût de sa fitness* ; *un avantage fitness spectaculaire (5,5×) peut être invisible dans le temps total* ; et *un timing single-run aurait conclu n'importe quoi* — 0,8× sur un run, 1,0× sur l'autre, pour le même code."
-   ]
+   "source": "### Lecture du coût par évaluation : fitness C# ~5× plus rapide — et un bench au coude-à-coule quand même\n\nC'est la cellule qui explique le paradoxe apparent du croisement. Mesurée seule, hors moteur, sur les 500 mêmes vecteurs (médiane de 5 répétitions) :\n\n- **fitness C# : 0,007 ms/éval** (3,5 ms pour 500) — **fitness Python : 0,036 ms/éval** (17,8 ms) : rapport **5,13×** en faveur du C# (run original : 5,72× — l'écart JIT .NET contre Python interprété est bien là, massif, de l'ordre de 5-6× d'une machine à l'autre).\n\nPourtant le bench complet donne 0,104 ms/éval pour MGS contre 0,084 pour mealpy — un écart de seulement ~20 %, là où la fitness seule en promettait 5×. La décomposition arithmétique est la leçon du notebook :\n\n| | fitness (mesurée) | moteur (bench − fitness) | total |\n|---|---|---|---|\n| **MGS** | 0,007 ms/éval | **0,097 ms/éval** | 0,104 |\n| **mealpy** | 0,036 ms/éval | **0,048 ms/éval** | 0,084 |\n\nDeux effets opposés se compensent : la fitness C# est ~5× plus rapide, mais la **mécanique de génération** de MetaGeneticSharp (sélection, croisement, mutation, structures de population) dépense ~0,097 ms par évaluation, soit **~2,0×** celle de mealpy (~0,048 ms ; run original : 1,8×) — et la fitness ne pèse que ~7 % du coût total côté MGS. Trois moralités mesurées : *le coût par évaluation d'un moteur n'est pas le coût de sa fitness* ; *un avantage fitness spectaculaire (~5×) peut être presque invisible dans le temps total* ; et *un timing single-run aurait conclu n'importe quoi* — le pilot a lu 0,8× sur un run, le run amendé 0,99×, cette exécution 0,81×, pour le même code (les deux derniers chiffres sur des machines différentes : le signe de l'écart vitesse n'est pas une propriété du code)."
   },
   {
    "cell_type": "markdown",
@@ -825,7 +852,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : bench croise GA mealpy vs GA MGS (4 graines, budget egal).\r\n"
+     "text": [
+      "Exercice a completer : bench croise GA mealpy vs GA MGS (4 graines, budget egal).\r\n"
+     ]
     }
    ],
    "source": [
@@ -863,7 +892,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : budget x4 des deux cotes, comparaison des medianes et du rapport ms/eval.\r\n"
+     "text": [
+      "Exercice a completer : budget x4 des deux cotes, comparaison des medianes et du rapport ms/eval.\r\n"
+     ]
     }
    ],
    "source": [
@@ -899,7 +930,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : profil decode/cost par cote, repartition fitness vs moteur.\r\n"
+     "text": [
+      "Exercice a completer : profil decode/cost par cote, repartition fitness vs moteur.\r\n"
+     ]
     }
    ],
    "source": [
@@ -917,17 +950,7 @@
    "cell_type": "markdown",
    "id": "m22c20",
    "metadata": {},
-   "source": [
-    "## Résumé et perspectives\n",
-    "\n",
-    "**Réponse à l'hypothèse de départ.** Sur ce plan (PSO canonique contre OriginalPSO, grille Easy[0], coût prouvé identique, ~8 000 évaluations, graines {0, 1, 7, 42}, médianes de répétitions) : **ex æquo en vitesse** (0,99× le coût par évaluation), **mealpy domine en qualité** (médiane 28,5 contre 43,5 conflits, séparation totale des gammes 26-31 contre 39-48). L'hypothèse « les perfs ne suivront pas mealpy » est réfutée sur l'axe vitesse — MetaGeneticSharp tient le rythme — et l'écart réel entre bibliothèques se joue sur les **défauts du solveur** (qualité à budget égal), pas sur la vitesse d'exécution.\n",
-    "\n",
-    "**Le mécanisme, mesuré.** La fitness C# est 5,72× plus rapide (0,007 contre 0,043 ms/éval), mais la mécanique MGS coûte ~1,8× plus par évaluation (0,084 contre 0,047 ms) — les deux effets se compensent presque exactement (0,091 contre 0,090 ms/éval au total). C'est la démonstration la plus utile du notebook pour la suite de la série : optimiser la fitness C# (déjà marginale à 8 % du total) ne rapprochera MGS de personne ; la cible est la mécanique de génération.\n",
-    "\n",
-    "**La méthode, réutilisable.** Sanity check sur vecteurs témoins LCG avant tout bench cross-langage ; seed explicite en `solve()` côté mealpy (le constructeur l'ignore silencieusement — piège documenté ici pour la série) ; `ResetSeed` avant création de population côté MGS ; **tout timing en médiane de répétitions** — l'amendement de ce notebook (un pic GC .NET peut fausser un single-run de ±60 %) vaut pour tous les bancs à venir.\n",
-    "\n",
-    "**Perspectives.** (1) Les exercices testent la robustesse du verdict : GA contre GA (Exercice 1 — mealpy a aussi `BaseGA`, MGS son composé `Default`), budget ×4 (Exercice 2). (2) Le point d'entrée pour dépasser mealpy en qualité n'est pas la vitesse brute mais les **composés spécialisés** de la série (seeding MGS-4/MGS-7, îles) : le composé PSO canonique, pris isolément, perd contre les défauts bien réglés de mealpy sur ce cas. (3) Le profiling de l'Exercice 3 dira où va la milliseconde moteur — les 0,084 ms/éval de mécanique MGS étant la cible évidente."
-   ]
+   "source": "## Résumé et perspectives\n\n**Réponse à l'hypothèse de départ.** Sur ce plan (PSO canonique contre OriginalPSO, grille Easy[0], coût prouvé identique, ~8 000 évaluations, graines {0, 1, 7, 42}, médianes de répétitions) : **vitesse au coude-à-coule** (0,81× le coût par éval sur cette exécution ; 0,99× sur le run original — l'écart traverse 1,0× selon la machine, le verdict robuste est la parité d'ordre de grandeur), **mealpy domine en qualité** (médiane 28,5 contre 43,5 conflits, séparation totale des gammes 26-31 contre 39-48 — reproductible à l'identique, la re-exécution #13407 retrouve chaque conflit par graine). L'hypothèse « les perfs ne suivront pas mealpy » est réfutée sur l'axe vitesse — MetaGeneticSharp tient l'ordre de grandeur — et l'écart réel entre bibliothèques se joue sur les **défauts du solveur** (qualité à budget égal), pas sur la vitesse d'exécution.\n\n**Le mécanisme, mesuré.** La fitness C# est 5,13× plus rapide (0,007 contre 0,036 ms/éval), mais la mécanique MGS coûte ~2,0× plus par évaluation (0,097 contre 0,048 ms) — les deux effets se compensent largement (0,104 contre 0,084 ms/éval au total). C'est la démonstration la plus utile du notebook pour la suite de la série : optimiser la fitness C# (déjà marginale à ~7 % du total) ne rapprochera MGS de personne ; la cible est la mécanique de génération.\n\n**La méthode, réutilisable.** Sanity check sur vecteurs témoins LCG avant tout bench cross-langage ; seed explicite en `solve()` côté mealpy (le constructeur l'ignore silencieusement — piège documenté ici pour la série) ; `ResetSeed` avant création de population côté MGS ; **tout timing en médiane de répétitions** — l'amendement de ce notebook (un pic GC .NET peut fausser un single-run de ±60 %) vaut pour tous les bancs à venir ; et, leçon de la re-exécution #13407 : les **grandeurs seedées (conflits, médianes) sont reproductibles à l'identique**, les **rapports de timing sont sensibles au matériel** — un verdict vitesse ne se lit jamais sur le seul signe d'un ratio observé une fois.\n\n**Perspectives.** (1) Les exercices testent la robustesse du verdict : GA contre GA (Exercice 1 — mealpy a aussi `BaseGA`, MGS son composé `Default`), budget ×4 (Exercice 2). (2) Le point d'entrée pour dépasser mealpy en qualité n'est pas la vitesse brute mais les **composés spécialisés** de la série (seeding MGS-4/MGS-7, îles) : le composé PSO canonique, pris isolément, perd contre les défauts bien réglés de mealpy sur ce cas. (3) Le profiling de l'Exercice 3 dira où va la milliseconde moteur — les 0,097 ms/éval de mécanique MGS étant la cible évidente."
   }
  ],
  "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2023:CoursIA — prev: MED/notebook-dotnet #13406

## #13407 tranche MGS-22 : probe PythonNet systeme-d'abord + re-exec complete + re-ancrage narratif

Premier grain du retro-fit #13407 (MGS-22 etait la source du protocole sanity de la famille). MGS-29 (#13406) avait montre le defaut : le scan LOCALAPPDATA servait un Python310 stale sans mealpy avant `C:\Python313`.

### Corrections apportees

1. **Probe reordonne** (m22c06, +5/-2) : installs CPython.org systeme (`C:\Python313`, `C:\Python312`) AVANT le scan LOCALAPPDATA — identique au canonical MGS-28 (#12943) / MGS-29 (#13406). Le fallback systeme arriere devenu mort est supprime.
2. **Re-execution complete** (C.2) : `exec_dotnet_persist.py`, kernel `.net-csharp`, 9/9 cellules vertes, 0 erreur. Pont actif : `mealpy 3.0.2 sur Python 3.13.3`.
3. **Narratives re-ancrees** (m22c11 lecture du croisement, m22c13 decomposition cout/eval, m22c20 resume) — chiffres de vitesse frais, run original garde explicitement comme historique etiquete.

### Preuves (outputs committes)

**Substance deterministe : IDENTIQUE avant/apres** (comparaison cellule par cellule) :

| grandeur seedee | avant (main) | apres (re-exec) |
|---|---|---|
| sanity check | 3/3 IDENTIQUE (67/71/60) | 3/3 IDENTIQUE (67/71/60) |
| MGS conflits 4 graines | 39/41/46/48 | 39/41/46/48 |
| mealpy conflits 4 graines | 30/27/26/31 | 30/27/26/31 |
| medianes | 43,5 vs 28,5 | 43,5 vs 28,5 |
| determinisme | 8/8 | 8/8 |
| contre-verif croisee | 26 = 26 | 26 = 26 |

Le verdict **qualite** (mealpy domine, separation totale des gammes) ne bouge pas — c'est le critere de non-regression du grain : toute divergence sur une grandeur seedee serait un signal.

**Timings : derives (attendu), re-ancres honnetement** :

| metrique | run original (remplace) | cette exec |
|---|---|---|
| rapport ms/eval bench | 0,99x (1,31x brut pre-amendement) | **0,81x** |
| fitness C# / Python | 0,007 / 0,043 (5,72x) | 0,007 / 0,036 (**5,13x**) |
| mecanique MGS vs mealpy | 0,084 vs 0,047 (~1,8x) | 0,097 vs 0,048 (**~2,0x**) |

Le re-ancrage ne maquille rien : les deux runs sont cites cote a cote, la conclusion robuste est la **parite d'ordre de grandeur** (0,8x-1,3x selon la machine), pas le signe d'un ratio observe une fois.

### Validation

- C.1 : 0 pattern interdit ; H.3 : 9/9 cellules code `execution_count` + outputs
- `validate_pr_notebooks.py HEAD <nb>` : PASS (9 cells)
- Diff 103+/80- : 21/21 cellules conservees, source 40 405 chars, outputs 4 108 chars — rien de stripp
- Catalogue : byte-identique a main (aucun fichier catalogue touche)

See #13407 (tranche 1/6 — MGS-23..27 restent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
