### PR TITLE
docs(ai-engine,#12127): tranche 4 — dossier 01-Architecture/

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/01-Architecture/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/01-Architecture/README.md
@@ -1,0 +1,59 @@
+# Architecture et surface fonctionnelle
+
+[← README AI-Engine-WordPress](../README.md)
+
+Ce dossier regroupe ce qui relève de la structure d'AI-Engine : la
+surface fonctionnelle vue de haut niveau (sections 1 à 3 ci-dessous,
+déplacées du README parent lors de la réorganisation #12127) et le
+découpage en modules du tableau de bord. Les sections RAG, MCP server
+et intégration WordPress restent présentées dans le
+[README parent](../README.md) tant que leurs dossiers ne sont pas
+créés.
+
+## Sommaire
+
+1. [Vue d'ensemble](#vue-densemble)
+2. [Fonctionnalités GenAI cœur](#fonctionnalités-genai-cœur)
+3. [Multi-provider et self-hosting](#multi-provider-et-self-hosting)
+4. [L'architecture en modules](architecture-en-modules.md)
+
+## Vue d'ensemble
+
+AI-Engine en deux pages : ce que c'est, qui l'utilise, pourquoi on en
+parle à côté d'Open WebUI. Statistiques publiques (100K+ installations
+actives, 4.9/5 étoiles, version 3.7.0 août 2026, license GPL).
+
+→ le développement chiffré vit dans le
+[comparatif](../02-Comparatif/comparatif-owui-vs-ai-engine.md), au
+niveau catégorie.
+
+## Fonctionnalités GenAI cœur
+
+Chatbots, Workspace (plein écran dans wp-admin), Copilot pour l'éditeur
+WordPress, AI Forms (text/image/audio/file avec logique conditionnelle),
+génération d'image et de vision. Comparaison avec les surfaces
+équivalentes d'Open WebUI (chat, canaux, prompts).
+
+→ détail et mesures dans la
+[section dédiée du comparatif](../02-Comparatif/comparatif-owui-vs-ai-engine.md#fonctionnalités-cœur).
+
+## Multi-provider et self-hosting
+
+AI-Engine supporte **neuf providers distants** (OpenAI, Anthropic,
+Google, Mistral, xAI/Grok, Perplexity, OpenRouter, Replicate, Azure)
+plus un connecteur **Custom OpenAI-compatible** pour les moteurs
+auto-hébergés (Ollama, LM Studio, vLLM, llama.cpp, LocalAI). Côté
+Open WebUI, c'est la même philosophie avec OpenAI-compatible + Ollama
+natif ; la différence est qu'AI-Engine ne fournit pas son propre
+moteur local — il s'appuie sur l'écosystème WordPress existant.
+
+→ [section correspondante du comparatif](../02-Comparatif/comparatif-owui-vs-ai-engine.md#multi-provider-et-self-hosting).
+
+## L'architecture en modules
+
+Le plugin ne s'installe pas d'un bloc : son tableau de bord expose
+trois familles de modules activables indépendamment (Client, Server,
+Admin), et le protocole MCP s'y configure dans les deux sens à des
+endroits distincts. Voir
+[`architecture-en-modules.md`](architecture-en-modules.md), extrait du
+[cas d'usage éditorial](../04-Cas-Usage-livresagites/livresagites-parcours.md).

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/01-Architecture/architecture-en-modules.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/01-Architecture/architecture-en-modules.md
@@ -1,0 +1,121 @@
+# L'architecture en modules
+
+[← README Architecture](README.md) | [← README AI-Engine-WordPress](../README.md)
+
+> Extrait du [cas d'usage éditorial](../04-Cas-Usage-livresagites/livresagites-parcours.md)
+> dont il constituait le « Parcours 0 », relogé ici (réorganisation #12127)
+> avec les parcours fonctionnels restés en place.
+
+Avant les parcours fonctionnels, un point de structure qui n'est
+documenté nulle part clairement et qui conditionne la lecture du
+reste : **AI-Engine n'est pas un bloc**. Son tableau de bord
+présente trois familles de modules activables indépendamment.
+
+| Famille | Modules | Ce qu'elle décide |
+|---------|---------|-------------------|
+| **Client** | Chatbot, Forms, Search | Ce que voit le **visiteur** du site |
+| **Server** | Insights, Knowledge, Orchestration, Finetunes, Moderation, Assistants | Ce que le **serveur** sait faire (RAG, MCP sortant, logs, modération) |
+| **Admin** | Advisor, AI Assistant, Generators (texte / image / vidéo), Playground, Utilities, Transcription | Ce que voit l'**administrateur** dans `wp-admin` |
+
+Deux conséquences pratiques :
+
+1. Un déploiement minimal (chatbot public seul) n'active qu'un
+   module Client — l'empreinte du plugin est modulable, contrairement
+   à ce que suggère la longue liste de fonctionnalités commerciales.
+2. Le module **Orchestration** est la face *cliente* de MCP :
+   c'est lui qui permet à AI-Engine de **consommer** des serveurs MCP
+   externes. Le serveur MCP *exposé* par WordPress est une mécanique
+   distincte (voir le [Parcours 3 — WordPress comme serveur MCP métier](../04-Cas-Usage-livresagites/livresagites-parcours.md)). Les deux sens du protocole ne se
+   configurent pas au même endroit — confusion fréquente.
+
+> **Notebook compagnon.** [`consommer-vs-exposer-le-mcp.ipynb`](../consommer-vs-exposer-le-mcp.ipynb)
+> rend exécutable cette distinction : il monte les **deux côtés du fil** sur un
+> même fixture synthétique (Maison Valmont) — un mini-serveur MCP exposé et un
+> mini-client MCP consommé — et mesure le chevauchement fonctionnel
+> cross-catalogue. La question opérationnelle qu'il formalise : *faut-il
+> brancher ce serveur MCP externe, ou ses outils sont-ils déjà couverts par le
+> catalogue interne ?* Indice de Jaccard sur les signatures `(verbe, cible)`,
+> avec un accent sur le sous-ensemble écriture (le double-écrit, risque réel
+> même sous un chevauchement global faible).
+
+> **Notebook compagnon (module Client).**
+> [`configurer-chatbots-par-l-api.ipynb`](../configurer-chatbots-par-l-api.ipynb)
+> ouvre la face exécutable du module Chatbot : dans AI-Engine, un chatbot
+> est un **document JSON** (54 champs — identité, instructions, modèle,
+> présentation) que l'API REST lit et réécrit. Le `POST
+> /mwai/v1/settings/chatbots` **remplace toute la liste**, d'où le
+> pattern read-modify-write pour créer ou modifier un bot. Le notebook
+> duplique le chatbot d'accueil d'une maison synthétique (Maison Valmont)
+> en comité de lecture, vérifie la persistance par relecture, puis pose la
+> même question aux deux personas et **mesure** leur recouvrement
+> lexical : les instructions orientent la réponse, elles ne la garantissent
+> pas. Exécuté contre l'instance jetable locale (`instance-jetable/`),
+> corpus 100 % synthétique, aucun contenu privé.
+
+> **Notebook compagnon (module Client, face visiteur).**
+> [`parler-au-chatbot-en-visiteur-par-l-api.ipynb`](../parler-au-chatbot-en-visiteur-par-l-api.ipynb)
+> ouvre la troisième face du plugin — celle du **navigateur d'un visiteur
+> anonyme**, dans un namespace propre (`mwai-ui/v1`). Le cycle démontré :
+> la page publique du chatbot n'embarque **aucun jeton** (`restNonce` et
+> `sessionId` explicitement `null` dans le conteneur — un design
+> anti-cache : un nonce figé dans du HTML caché expirerait, un sessionId
+> figé fusionnerait les limites de tous les visiteurs) ; le navigateur
+> amorce par `POST /mwai/v1/start_session` (le seul endpoint à
+> permission `__return_true`), qui délivre nonce frais et cookie de
+> session ; puis la conversation passe par `chats/submit` au header
+> `X-WP-Nonce`. Frontière mesurée : **401 sans le nonce** — mais un nonce
+> n'est pas une authentification, c'est un anti-CSRF délivré à quiconque
+> charge le site ; le contrôle d'accès réel de cette face vit aux
+> limites de débit.
+
+> **Notebook compagnon (module Client, face pièces jointes).**
+> [`donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb`](../donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb)
+> ouvre la cinquième surface de la série — la famille
+> `mwai-ui/v1/files/*`, celle qui donne au chatbot ses pièces
+> jointes : un manuscrit à relire, un extrait audio, une image. Le
+> trait le plus caractéristique y est **mesuré par calcul** : la
+> fiche du fichier porte `created` et `expires`, et la soustraction
+> rend exactement **une heure** — la mémoire fichiers est éphémère
+> par architecture, pas par configuration, un choix lisible dans la
+> réponse même de l'API. Autour : le contrat d'upload découvert par
+> refus (400 « Purpose is required. » nomme le champ obligatoire),
+> l'URL publique servie par la médiathèque WordPress (contenu vérifié
+> octet pour octet), la partition par utilisateur — table
+> `mwai_files`, deux auteurs ne voient ni n'effacent les pièces
+> jointes de l'autre, jusqu'aux sessions anonymes qui ont chacune la
+> leur —, le delete par refus (400 « No valid files to delete » pour
+> `{id}` : le contrat veut `{"files": [refId]}`), et le miroir admin
+> `mwai/v1/openai/files/*` où les mêmes fichiers reviennent, augmentés
+> de `download` et `finetune`. Le fichier téléversé est synthétique
+> et détruit en fin de parcours — cleanup mesuré, total 0 → 1 → 0.
+
+> **Notebook compagnon (module Client, consommation des pièces jointes).**
+> [`joindre-un-fichier-au-chatbot-par-l-api.ipynb`](../joindre-un-fichier-au-chatbot-par-l-api.ipynb)
+> pose la question qui suit le stockage : **comment un fichier
+> téléversé entre-t-il dans une completion ?** La réponse mesurée
+> donne à une pièce jointe trois destins possibles, aucun lisible sur
+> le code de statut. *Ignorée* : la route `chats/submit` lit
+> `newFileId`, et un `fileId` à sa place rend un 200 silencieux — le
+> fichier n'est même pas regardé. *Annotée puis jetée* : avec le bon
+> nom, le plugin traite le fichier (`purpose` → `analysis`,
+> métadonnées de session) mais le contenu d'un fichier texte n'entre
+> jamais dans le prompt — compte de tokens identique à un tour sans
+> fichier, canary absent, le modèle le dit honnêtement. *Vraiment
+> vue* : une image, elle, traverse — encodée `image_url` base64, le
+> format de fil standard — et un PNG bicolore construit par le
+> notebook (stdlib `struct` + `zlib`, couleurs connues par
+> construction) est correctement décrit sur l'endpoint auto-hébergé :
+> **la frontière du multimodal est le format, pas le provider**. Le
+> contrôle négatif (même question sans image → aucune couleur citée)
+> ferme la porte à la devinette.
+
+---
+
+## Voir aussi
+
+- [`README.md`](README.md) — vue d'ensemble, fonctionnalités cœur,
+  multi-provider : la surface fonctionnelle du plugin
+- [`../04-Cas-Usage-livresagites/livresagites-parcours.md`](../04-Cas-Usage-livresagites/livresagites-parcours.md)
+  — le cas d'usage complet dont cette page est issue
+- [`../02-Comparatif/comparatif-owui-vs-ai-engine.md`](../02-Comparatif/comparatif-owui-vs-ai-engine.md)
+  — le même plugin vu par le tableau comparatif

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/04-Cas-Usage-livresagites/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/04-Cas-Usage-livresagites/livresagites-parcours.md
@@ -51,108 +51,12 @@ d'embeddings** coexistants, ~1600 vecteurs indexés.
 
 ## Parcours 0 — L'architecture en modules
 
-Avant les parcours fonctionnels, un point de structure qui n'est
-documenté nulle part clairement et qui conditionne la lecture du
-reste : **AI-Engine n'est pas un bloc**. Son tableau de bord
-présente trois familles de modules activables indépendamment.
-
-| Famille | Modules | Ce qu'elle décide |
-|---------|---------|-------------------|
-| **Client** | Chatbot, Forms, Search | Ce que voit le **visiteur** du site |
-| **Server** | Insights, Knowledge, Orchestration, Finetunes, Moderation, Assistants | Ce que le **serveur** sait faire (RAG, MCP sortant, logs, modération) |
-| **Admin** | Advisor, AI Assistant, Generators (texte / image / vidéo), Playground, Utilities, Transcription | Ce que voit l'**administrateur** dans `wp-admin` |
-
-Deux conséquences pratiques :
-
-1. Un déploiement minimal (chatbot public seul) n'active qu'un
-   module Client — l'empreinte du plugin est modulable, contrairement
-   à ce que suggère la longue liste de fonctionnalités commerciales.
-2. Le module **Orchestration** est la face *cliente* de MCP :
-   c'est lui qui permet à AI-Engine de **consommer** des serveurs MCP
-   externes. Le serveur MCP *exposé* par WordPress est une mécanique
-   distincte (voir Parcours 3). Les deux sens du protocole ne se
-   configurent pas au même endroit — confusion fréquente.
-
-> **Notebook compagnon.** [`consommer-vs-exposer-le-mcp.ipynb`](../consommer-vs-exposer-le-mcp.ipynb)
-> rend exécutable cette distinction : il monte les **deux côtés du fil** sur un
-> même fixture synthétique (Maison Valmont) — un mini-serveur MCP exposé et un
-> mini-client MCP consommé — et mesure le chevauchement fonctionnel
-> cross-catalogue. La question opérationnelle qu'il formalise : *faut-il
-> brancher ce serveur MCP externe, ou ses outils sont-ils déjà couverts par le
-> catalogue interne ?* Indice de Jaccard sur les signatures `(verbe, cible)`,
-> avec un accent sur le sous-ensemble écriture (le double-écrit, risque réel
-> même sous un chevauchement global faible).
-
-> **Notebook compagnon (module Client).**
-> [`configurer-chatbots-par-l-api.ipynb`](../configurer-chatbots-par-l-api.ipynb)
-> ouvre la face exécutable du module Chatbot : dans AI-Engine, un chatbot
-> est un **document JSON** (54 champs — identité, instructions, modèle,
-> présentation) que l'API REST lit et réécrit. Le `POST
-> /mwai/v1/settings/chatbots` **remplace toute la liste**, d'où le
-> pattern read-modify-write pour créer ou modifier un bot. Le notebook
-> duplique le chatbot d'accueil d'une maison synthétique (Maison Valmont)
-> en comité de lecture, vérifie la persistance par relecture, puis pose la
-> même question aux deux personas et **mesure** leur recouvrement
-> lexical : les instructions orientent la réponse, elles ne la garantissent
-> pas. Exécuté contre l'instance jetable locale (`instance-jetable/`),
-> corpus 100 % synthétique, aucun contenu privé.
-
-> **Notebook compagnon (module Client, face visiteur).**
-> [`parler-au-chatbot-en-visiteur-par-l-api.ipynb`](../parler-au-chatbot-en-visiteur-par-l-api.ipynb)
-> ouvre la troisième face du plugin — celle du **navigateur d'un visiteur
-> anonyme**, dans un namespace propre (`mwai-ui/v1`). Le cycle démontré :
-> la page publique du chatbot n'embarque **aucun jeton** (`restNonce` et
-> `sessionId` explicitement `null` dans le conteneur — un design
-> anti-cache : un nonce figé dans du HTML caché expirerait, un sessionId
-> figé fusionnerait les limites de tous les visiteurs) ; le navigateur
-> amorce par `POST /mwai/v1/start_session` (le seul endpoint à
-> permission `__return_true`), qui délivre nonce frais et cookie de
-> session ; puis la conversation passe par `chats/submit` au header
-> `X-WP-Nonce`. Frontière mesurée : **401 sans le nonce** — mais un nonce
-> n'est pas une authentification, c'est un anti-CSRF délivré à quiconque
-> charge le site ; le contrôle d'accès réel de cette face vit aux
-> limites de débit.
-
-> **Notebook compagnon (module Client, face pièces jointes).**
-> [`donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb`](../donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb)
-> ouvre la cinquième surface de la série — la famille
-> `mwai-ui/v1/files/*`, celle qui donne au chatbot ses pièces
-> jointes : un manuscrit à relire, un extrait audio, une image. Le
-> trait le plus caractéristique y est **mesuré par calcul** : la
-> fiche du fichier porte `created` et `expires`, et la soustraction
-> rend exactement **une heure** — la mémoire fichiers est éphémère
-> par architecture, pas par configuration, un choix lisible dans la
-> réponse même de l'API. Autour : le contrat d'upload découvert par
-> refus (400 « Purpose is required. » nomme le champ obligatoire),
-> l'URL publique servie par la médiathèque WordPress (contenu vérifié
-> octet pour octet), la partition par utilisateur — table
-> `mwai_files`, deux auteurs ne voient ni n'effacent les pièces
-> jointes de l'autre, jusqu'aux sessions anonymes qui ont chacune la
-> leur —, le delete par refus (400 « No valid files to delete » pour
-> `{id}` : le contrat veut `{"files": [refId]}`), et le miroir admin
-> `mwai/v1/openai/files/*` où les mêmes fichiers reviennent, augmentés
-> de `download` et `finetune`. Le fichier téléversé est synthétique
-> et détruit en fin de parcours — cleanup mesuré, total 0 → 1 → 0.
-
-> **Notebook compagnon (module Client, consommation des pièces jointes).**
-> [`joindre-un-fichier-au-chatbot-par-l-api.ipynb`](../joindre-un-fichier-au-chatbot-par-l-api.ipynb)
-> pose la question qui suit le stockage : **comment un fichier
-> téléversé entre-t-il dans une completion ?** La réponse mesurée
-> donne à une pièce jointe trois destins possibles, aucun lisible sur
-> le code de statut. *Ignorée* : la route `chats/submit` lit
-> `newFileId`, et un `fileId` à sa place rend un 200 silencieux — le
-> fichier n'est même pas regardé. *Annotée puis jetée* : avec le bon
-> nom, le plugin traite le fichier (`purpose` → `analysis`,
-> métadonnées de session) mais le contenu d'un fichier texte n'entre
-> jamais dans le prompt — compte de tokens identique à un tour sans
-> fichier, canary absent, le modèle le dit honnêtement. *Vraiment
-> vue* : une image, elle, traverse — encodée `image_url` base64, le
-> format de fil standard — et un PNG bicolore construit par le
-> notebook (stdlib `struct` + `zlib`, couleurs connues par
-> construction) est correctement décrit sur l'endpoint auto-hébergé :
-> **la frontière du multimodal est le format, pas le provider**. Le
-> contrôle négatif (même question sans image → aucune couleur citée)
-> ferme la porte à la devinette.
+> Cette section a déménagé vers le dossier
+> [`01-Architecture/`](../01-Architecture/) — voir
+> [`architecture-en-modules.md`](../01-Architecture/architecture-en-modules.md) :
+> trois familles de modules (Client / Server / Admin), l'empreinte modulable
+> d'un déploiement minimal, et les deux sens du protocole MCP qui ne se
+> configurent pas au même endroit.
 
 ---
 
@@ -452,7 +356,7 @@ la distance entre ses outils et le schéma de persistance.
 C'est ici qu'AI-Engine se distingue le plus franchement. Open WebUI
 peut *consommer* des outils MCP ; il n'en *expose* pas. AI-Engine
 joue **dans les deux sens** : il consomme des serveurs MCP externes
-(module Orchestration, Parcours 0) et expose WordPress comme serveur
+(module Orchestration, voir [l'architecture en modules](../01-Architecture/architecture-en-modules.md)) et expose WordPress comme serveur
 MCP. C'est un terrain pédagogique de choix pour comprendre le
 protocole des deux côtés du fil, sur une seule installation.
 

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -276,28 +276,22 @@ question sans image ne produit aucune couleur.
 
 ## Sections
 
-### 1. [Vue d'ensemble](02-Comparatif/comparatif-owui-vs-ai-engine.md)
+### 1. [Vue d'ensemble](01-Architecture/README.md#vue-densemble)
 
-AI-Engine en deux pages : ce que c'est, qui l'utilise, pourquoi on en
-parle à côté d'Open WebUI. Statistiques publiques (100K+ installations
-actives, 4.9/5 étoiles, version 3.7.0 août 2026, license GPL).
+Ce que c'est, qui l'utilise, pourquoi on en parle à côté d'Open
+WebUI — regroupé dans
+[`01-Architecture/`](01-Architecture/README.md#vue-densemble).
 
-### 2. [Fonctionnalités GenAI cœur](02-Comparatif/comparatif-owui-vs-ai-engine.md#fonctionnalités-cœur)
+### 2. [Fonctionnalités GenAI cœur](01-Architecture/README.md#fonctionnalités-genai-cœur)
 
-Chatbots, Workspace (plein écran dans wp-admin), Copilot pour l'éditeur
-WordPress, AI Forms (text/image/audio/file avec logique conditionnelle),
-génération d'image et de vision. Comparaison avec les surfaces
-équivalentes d'Open WebUI (chat, canaux, prompts).
+Chatbots, Workspace, Copilot, AI Forms, génération d'image —
+regroupé dans
+[`01-Architecture/`](01-Architecture/README.md#fonctionnalités-genai-cœur).
 
-### 3. [Multi-provider et self-hosting](02-Comparatif/comparatif-owui-vs-ai-engine.md#multi-provider-et-self-hosting)
+### 3. [Multi-provider et self-hosting](01-Architecture/README.md#multi-provider-et-self-hosting)
 
-AI-Engine supporte **neuf providers distants** (OpenAI, Anthropic,
-Google, Mistral, xAI/Grok, Perplexity, OpenRouter, Replicate, Azure)
-plus un connecteur **Custom OpenAI-compatible** pour les moteurs
-auto-hébergés (Ollama, LM Studio, vLLM, llama.cpp, LocalAI). Côté
-Open WebUI, c'est la même philosophie avec OpenAI-compatible + Ollama
-natif ; la différence est qu'AI-Engine ne fournit pas son propre
-moteur local — il s'appuie sur l'écosystème WordPress existant.
+Neuf providers distants + connecteur auto-hébergé — regroupé dans
+[`01-Architecture/`](01-Architecture/README.md#multi-provider-et-self-hosting).
 
 ### 4. [RAG et embeddings](02-Comparatif/comparatif-owui-vs-ai-engine.md#rag-et-embeddings)
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:LivresAgités — prev: LIGHT/tooling #13286

## Quoi

Tranche 4 de la réorganisation #12127 : création du dossier `01-Architecture/`.

- `01-Architecture/README.md` (nouveau) — reçoit les sections 1-3 du README AI-Engine-WordPress (Vue d'ensemble, Fonctionnalités GenAI cœur, Multi-provider et self-hosting), déplacées verbatim avec renvois vers les ancres du comparatif, + une section pointant vers le découpage en modules.
- `01-Architecture/architecture-en-modules.md` (nouveau) — le Parcours 0 du cas d'usage (familles de modules Client/Server/Admin, empreinte modulable, les deux sens de MCP), extrait et re-titré.
- `livresagites-parcours.md` — le titre `## Parcours 0` reste en place avec un pointeur vers le nouveau dossier (**les ancres `#parcours-0` existantes restent valides**) ; la référence interne « module Orchestration, Parcours 0 » (l.455) devient un lien croisé.
- README parent — les entrées 1-3 de « Sections » pointent vers `01-Architecture/` (6 entrées conservées, pas de renumérotation ; sections 4-6 intouchées, attendent leurs tranches).

## Preuve

```
python scripts/check_docs_links.py
  -> Scanned 634 files, 5199 links -- No broken links found.

python scripts/notebook_tools/check_notebook_navlinks.py
  -> OK: 0 lien casse (1161 notebook(s) scanne(s)).
```

Scan sécurité : aucun emoji, homoglyphe, ni secret dans les lignes ajoutées ; « Maison Valmont » = corpus synthétique préexistant déplacé depuis main. CRLF préservé partout (fichiers du dépôt en CRLF au checkout).

## Périmètre

4 fichiers :

1. `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/01-Architecture/README.md` (nouveau, 59 lignes)
2. `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/01-Architecture/architecture-en-modules.md` (nouveau, 121 lignes)
3. `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/04-Cas-Usage-livresagites/livresagites-parcours.md` (Parcours 0 remplacé par un pointeur, +7/−103)
4. `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md` (sections 1-3 → renvois compacts, +11/−17)

Claim c.5457084678 sur #12127 (précision de périmètre en 3 points) : sections 1-3 du README → 01-Architecture/README.md ; Parcours 0 → architecture-en-modules.md ; Parcours 1-4 intouchés. Aucun workflow CI touché. HEAD testé : `3bbb41fb7`.