### PR TITLE
fix(search,#13407): MGS-27 probe PythonNet canonical order + re-exec (tranche 6/6, finale)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-27-ForensicBasedInvestigation-vs-Mealpy.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-27-ForensicBasedInvestigation-vs-Mealpy.ipynb
@@ -82,16 +82,11 @@
    "execution_count": 1,
    "outputs": [
     {
-     "output_type": "display_data",
-     "data": {
-      "text/html": ""
-     },
-     "metadata": {}
-    },
-    {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Grille de référence : 36 cellules vides, 45 indices fixes, 36 gènes R1.\r\n"
+     "text": [
+      "Grille de référence : 36 cellules vides, 45 indices fixes, 36 gènes R1.\r\n"
+     ]
     }
    ],
    "source": [
@@ -178,7 +173,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS FBI (graine 7, témoin) : 39 conflits, 7962 évaluations, 322 ms.\r\n"
+     "text": [
+      "MGS FBI (graine 7, témoin) : 39 conflits, 7962 évaluations, 461 ms.\r\n"
+     ]
     }
    ],
    "source": [
@@ -244,16 +241,7 @@
    "cell_type": "markdown",
    "id": "mgs27-mgs-lecture",
    "metadata": {},
-   "source": [
-    "**Lecture.** Le composé MGS `ForensicBasedInvestigation` est branché sur le même harnais que\n",
-    "les paires précédentes : chromosome R1, fitness comptée, seeding avant création de population.\n",
-    "La course témoin graine 7 donne le premier chiffre — 39 conflits pour 7 962 évaluations en\n",
-    "322 ms — et surtout la **mesure structurelle du budget** : ~40 évaluations par génération de 50\n",
-    "(la réinsertion pairwise de FBI ne soumet au duel que les enfants effectivement candidats), donc\n",
-    "200 générations ≈ 8 000 évaluations pour répondre aux 8 050 de mealpy (50 individus initiaux +\n",
-    "40 epochs × 4 phases × 50). L'échauffement JIT la précède pour que la course mesurée ne paie pas\n",
-    "la compilation."
-   ]
+   "source": "**Lecture.** Le composé MGS `ForensicBasedInvestigation` est branché sur le même harnais que\nles paires précédentes : chromosome R1, fitness comptée, seeding avant création de population.\nLa course témoin graine 7 donne le premier chiffre — 39 conflits pour 7 962 évaluations en\n461 ms (run original : 322 ms) — et surtout la **mesure structurelle du budget** : ~40\névaluations par génération de 50\n(la réinsertion pairwise de FBI ne soumet au duel que les enfants effectivement candidats), donc\n200 générations ≈ 8 000 évaluations pour répondre aux 8 050 de mealpy (50 individus initiaux +\n40 epochs × 4 phases × 50). L'échauffement JIT la précède pour que la course mesurée ne paie pas\nla compilation."
   },
   {
    "cell_type": "code",
@@ -263,25 +251,33 @@
    "outputs": [
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
-      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>pythonnet</span></li></ul></div><div></div></div>"
-     },
-     "metadata": {}
+      "text/html": [
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>pythonnet</span></li></ul></div><div></div></div>"
+      ]
+     }
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Pont PythonNet actif : mealpy 3.0.2 sur Python 3.13.12\r\n"
+     "text": [
+      "Pont PythonNet actif : mealpy 3.0.2 sur Python 3.13.3\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Parametres defaut mealpy : mealpy OriginalFBIO defaults: signature (self, epoch: int = 10000, pop_size: int = 100, **kwargs: object) -> None (aucun parametre scalaire transportable)\r\n"
+     "text": [
+      "Parametres defaut mealpy : mealpy OriginalFBIO defaults: signature (self, epoch: int = 10000, pop_size: int = 100, **kwargs: object) -> None (aucun parametre scalaire transportable)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Sanity check cout : C# 67,71,60 | Python 67,71,60 -> IDENTIQUE\r\n"
+     "text": [
+      "Sanity check cout : C# 67,71,60 | Python 67,71,60 -> IDENTIQUE\r\n"
+     ]
     }
    ],
    "source": [
@@ -298,6 +294,11 @@
     "    if (!string.IsNullOrEmpty(env) && System.IO.File.Exists(env)) return env;\n",
     "    if (OperatingSystem.IsWindows())\n",
     "    {\n",
+    "        // Installs CPython.org standards d'abord (les plus récentes portent les packages récents\n",
+    "        // comme mealpy), ensuite le scan LOCALAPPDATA — un Python périmé qui n'a pas mealpy\n",
+    "        // ne doit pas masquer une install plus récente (pb 2026-08-25 : Python310 2023 devant Python313).\n",
+    "        foreach (var c in new[] { @\"C:\\Python313\\python313.dll\", @\"C:\\Python312\\python312.dll\" })\n",
+    "            if (System.IO.File.Exists(c)) return c;\n",
     "        var local = Environment.GetEnvironmentVariable(\"LOCALAPPDATA\");\n",
     "        if (!string.IsNullOrEmpty(local))\n",
     "        {\n",
@@ -318,8 +319,6 @@
     "                }\n",
     "            }\n",
     "        }\n",
-    "        foreach (var c in new[] { @\"C:\\Python313\\python313.dll\", @\"C:\\Python312\\python312.dll\" })\n",
-    "            if (System.IO.File.Exists(c)) return c;\n",
     "        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);\n",
     "        foreach (var root in new[] {\n",
     "                     System.IO.Path.Combine(home, \"miniconda3\"),\n",
@@ -514,12 +513,16 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy OriginalFBIO (graine 7, témoin) : 45 conflits, 8050 évaluations, 1086 ms.\r\n"
+     "text": [
+      "mealpy OriginalFBIO (graine 7, témoin) : 45 conflits, 8050 évaluations, 1537 ms.\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Contre-vérif croisée : coût C# du meilleur mealpy = 45 (Python rapporte 45) -> IDENTIQUE\r\n"
+     "text": [
+      "Contre-vérif croisée : coût C# du meilleur mealpy = 45 (Python rapporte 45) -> IDENTIQUE\r\n"
+     ]
     }
    ],
    "source": [
@@ -569,72 +572,100 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "moteur    graine  conflits   evals       ms  ms/eval\r\n"
+     "text": [
+      "moteur    graine  conflits   evals       ms  ms/eval\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS            0        37    7988      265    0,033\r\n"
+     "text": [
+      "MGS            0        37    7988      390    0,049\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS            1        37    8138      260    0,032\r\n"
+     "text": [
+      "MGS            1        37    8138      381    0,047\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS            7        39    7962      244    0,031\r\n"
+     "text": [
+      "MGS            7        39    7962      390    0,049\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS           42        25    8172      230    0,028\r\n"
+     "text": [
+      "MGS           42        25    8172      423    0,052\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy         0        43    8050     1051    0,131\r\n"
+     "text": [
+      "mealpy         0        43    8050     1266    0,157\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy         1        44    8050     1001    0,124\r\n"
+     "text": [
+      "mealpy         1        44    8050     1199    0,149\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy         7        45    8050     1028    0,128\r\n"
+     "text": [
+      "mealpy         7        45    8050     1161    0,144\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy        42        43    8050     1021    0,127\r\n"
+     "text": [
+      "mealpy        42        43    8050     1208    0,150\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "MGS    : médiane conflits 37,0 (min 25, max 39), ms/éval moyen 0,031\r\n"
+     "text": [
+      "MGS    : médiane conflits 37,0 (min 25, max 39), ms/éval moyen 0,049\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "mealpy : médiane conflits 43,5 (min 43, max 45), ms/éval moyen 0,127\r\n"
+     "text": [
+      "mealpy : médiane conflits 43,5 (min 43, max 45), ms/éval moyen 0,150\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Rapport ms/éval mealpy/MGS : 4,11x\r\n"
+     "text": [
+      "Rapport ms/éval mealpy/MGS : 3,06x\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Déterminisme : conflits identiques sur les 3 répétitions pour 8/8 paires graine-moteur.\r\n"
+     "text": [
+      "Déterminisme : conflits identiques sur les 3 répétitions pour 8/8 paires graine-moteur.\r\n"
+     ]
     }
    ],
    "source": [
@@ -711,22 +742,30 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Fitness seule, 500 vecteurs identiques (médiane de 5 répétitions par côté) :\r\n"
+     "text": [
+      "Fitness seule, 500 vecteurs identiques (médiane de 5 répétitions par côté) :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  C#     : 2,7 ms total -> 0,005 ms/éval\r\n"
+     "text": [
+      "  C#     : 3,4 ms total -> 0,007 ms/éval\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Python : 17,0 ms total -> 0,034 ms/éval\r\n"
+     "text": [
+      "  Python : 16,4 ms total -> 0,033 ms/éval\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  rapport Python/C# : 6,36x\r\n"
+     "text": [
+      "  rapport Python/C# : 4,83x\r\n"
+     ]
     }
    ],
    "source": [
@@ -766,40 +805,7 @@
    "cell_type": "markdown",
    "id": "mgs27-croisement-lecture",
    "metadata": {},
-   "source": [
-    "**Lecture du croisement.** MGS passe devant — et pour la deuxième fois de l'Epic après le\n",
-    "recuit (MGS-24), sur les deux axes à la fois, cette fois avec **séparation totale** :\n",
-    "\n",
-    "- **qualité** : médiane 37,0 contre 43,5 conflits, étendues [25-39] contre [43-45] — le meilleur\n",
-    "  mealpy (43) reste au-dessus du pire MGS (39). Aux graines : MGS gagne 4/4 (37 contre 43,\n",
-    "  37 contre 44, 39 contre 45, 25 contre 43), la graine 42 offrant le meilleur run de la paire ;\n",
-    "- **vitesse** : l'évaluation MGS est 4,11× moins chère (0,031 contre 0,127 ms/éval) — le plus\n",
-    "  grand écart moteur de l'Epic (0,99× sur PSO, 1,69× sur WOA, 3,04× sur SA, 3,45× sur DE) ;\n",
-    "- **le protocole est tenu** : 7 962 à 8 172 évaluations MGS contre 8 050 mealpy (±1,5 %),\n",
-    "  déterminisme 8/8, contre-vérification croisée du coût IDENTIQUE (45 = 45, cellule témoin\n",
-    "  ci-dessus).\n",
-    "\n",
-    "Deux signatures à lire ensemble : mealpy est **régulier mais médiocre** (43-45 sur quatre\n",
-    "graines), MGS **dispersé mais gagnant partout** (25-39). C'est l'inverse exact du WOA (MGS-25),\n",
-    "où les deux colonnes MGS étaient ex æquo et mealpy derrière — ici l'écart entre les deux\n",
-    "implémentations dépasse l'écart typique entre algorithmes différents de l'Epic.\n",
-    "\n",
-    "**Lecture du coût par évaluation.** La fitness C# isolée reste 6,36× plus rapide (0,005 contre\n",
-    "0,034 ms/éval — même ordre que les 5,72× du PSO, 6,70× du DE, 4,20× du SA). L'écart moteur\n",
-    "(4,11×) reste sous l'écart fitness, comme sur DE et SA : le composé MGS paie de la mécanique\n",
-    "géométrique par évaluation, mais l'objet mealpy (quatre phases NumPy par epoch, génération\n",
-    "d'agents intermédiaires) paie plus encore.\n",
-    "\n",
-    "**Verdict de la paire.** Deuxième doublé de l'Epic — le plus net : séparation totale de qualité\n",
-    "et record d'écart de vitesse, sur la paire qui prétendait être un miroir. La divergence déclarée\n",
-    "au §1 en est la lecture la plus économique : le bruit A1 du port MGS, N(0,1) par Box-Muller, a\n",
-    "des queues plus lourdes que l'uniforme (−1, 1) de mealpy 3.0.2 — une perturbation du gène\n",
-    "investigé parfois bien plus ample, cohérente avec une médiane plus basse ET une variance plus\n",
-    "grande côté MGS. C'est une hypothèse déclarée, pas une preuve (aucun paramètre ne permet de\n",
-    "l'isoler d'une exécution à l'autre) ; mais la paire démontre au moins ceci : deux\n",
-    "implémentations qui se réclament de la même source ont ici plus divergé que des paires conçues\n",
-    "différentes."
-   ]
+   "source": "**Lecture du croisement.** MGS passe devant — et pour la deuxième fois de l'Epic après le\nrecuit (MGS-24), sur les deux axes à la fois, cette fois avec **séparation totale** :\n\n- **qualité** : médiane 37,0 contre 43,5 conflits, étendues [25-39] contre [43-45] — le meilleur\n  mealpy (43) reste au-dessus du pire MGS (39). Aux graines : MGS gagne 4/4 (37 contre 43,\n  37 contre 44, 39 contre 45, 25 contre 43), la graine 42 offrant le meilleur run de la paire ;\n- **vitesse** : l'évaluation MGS est 3,06× moins chère (0,049 contre 0,150 ms/éval ; run\n  original : 4,11×) — le deuxième plus grand écart moteur de l'Epic, derrière le recuit\n  (SA 3,26×, DE 2,37×, WOA 1,78×, EO 1,41×, PSO 0,8×-1,3× coude-à-coude — re-exécutions #13407) ;\n- **le protocole est tenu** : 7 962 à 8 172 évaluations MGS contre 8 050 mealpy (±1,5 %),\n  déterminisme 8/8, contre-vérification croisée du coût IDENTIQUE (45 = 45, cellule témoin\n  ci-dessus).\n\nDeux signatures à lire ensemble : mealpy est **régulier mais médiocre** (43-45 sur quatre\ngraines), MGS **dispersé mais gagnant partout** (25-39). C'est l'inverse exact du WOA (MGS-25),\noù les deux colonnes MGS étaient ex æquo et mealpy derrière — ici l'écart entre les deux\nimplémentations dépasse l'écart typique entre algorithmes différents de l'Epic.\n\n**Lecture du coût par évaluation.** La fitness C# isolée reste 4,83× plus rapide (0,007 contre\n0,033 ms/éval ; run original : 6,36× — l'amplitude du ratio fitness est sensible à la machine,\nl'ordre ne l'est pas ; même ordre que les 5,13× du PSO, 5,33× du SA, 5,56× de l'EO, 3,71× du\nDE — re-exécutions #13407). L'écart moteur\n(3,06×) reste sous l'écart fitness, comme sur DE et SA : le composé MGS paie de la mécanique\ngéométrique par évaluation, mais l'objet mealpy (quatre phases NumPy par epoch, génération\nd'agents intermédiaires) paie plus encore.\n\n**Verdict de la paire.** Deuxième doublé de l'Epic — le plus net : séparation totale de qualité\net l'un des plus grands écarts de vitesse de l'Epic (3,06×, juste sous les 3,26× du recuit\nre-exécuté), sur la paire qui prétendait être un miroir. La divergence déclarée\nau §1 en est la lecture la plus économique : le bruit A1 du port MGS, N(0,1) par Box-Muller, a\ndes queues plus lourdes que l'uniforme (−1, 1) de mealpy 3.0.2 — une perturbation du gène\ninvestigé parfois bien plus ample, cohérente avec une médiane plus basse ET une variance plus\ngrande côté MGS. C'est une hypothèse déclarée, pas une preuve (aucun paramètre ne permet de\nl'isoler d'une exécution à l'autre) ; mais la paire démontre au moins ceci : deux\nimplémentations qui se réclament de la même source ont ici plus divergé que des paires conçues\ndifférentes."
   },
   {
    "cell_type": "markdown",
@@ -832,7 +838,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer (decommentez le bloc ci-dessus).\r\n"
+     "text": [
+      "Exercice a completer (decommentez le bloc ci-dessus).\r\n"
+     ]
     }
    ],
    "source": [
@@ -882,7 +890,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer (decommentez le bloc ci-dessus).\r\n"
+     "text": [
+      "Exercice a completer (decommentez le bloc ci-dessus).\r\n"
+     ]
     }
    ],
    "source": [
@@ -933,7 +943,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer (decommentez le bloc ci-dessus).\r\n"
+     "text": [
+      "Exercice a completer (decommentez le bloc ci-dessus).\r\n"
+     ]
     }
    ],
    "source": [


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2023:CoursIA — prev: MED/notebook-dotnet #13416

Closes #13407 (tranche 6/6 — dernière : MGS-22..27 toutes livrées)

## Summary

Tranche FINALE MGS-27 du retro-fit #13407 : probe PythonNet canonical order + re-execution complète + ré-ancrage narratif. Avec cette PR, les 6 notebooks de l'Epic (MGS-22 PSO, MGS-23 DE, MGS-24 SA, MGS-25 WOA, MGS-26 EO, MGS-27 FBI) portent tous le probe corrigé et des outputs re-exécutées sur l'interpréteur résolu canoniquement (C:\Python313, mealpy 3.0.2).

- **Probe `ResolvePythonDll27`** : installs CPython.org standards AVANT le scan LOCALAPPDATA ; `PYTHONNET_PYDLL` reste premier.
- **Re-exec complète** (`exec_dotnet_persist.py`, kernel .net-csharp, 9 cellules, 0 erreur) — Python 3.13.3, mealpy 3.0.2.

## Preuves

**Non-régression (line-diff avant/après des outputs stream, hors whitespace) — déterministe identique :**

| Grandeur | HEAD (avant) | Cette PR | Verdict |
|---|---|---|---|
| Conflits MGS FBI graines {0,1,7,42} | 37/37/39/25 | 37/37/39/25 | identique |
| Conflits mealpy graines {0,1,7,42} | 43/44/45/43 | 43/44/45/43 | identique |
| Médianes conflits | 37,0 [25-39] / 43,5 [43-45] | idem | identique |
| Évals (compteurs) | 7988/8138/7962/8172 vs 8050 | idem | identique |
| Déterminisme | 8/8 | 8/8 | identique |
| Contre-vérif croisée | 45 = 45 IDENTIQUE | 45 = 45 IDENTIQUE | identique |
| Sanity check LCG | 67,71,60 IDENTIQUE | 67,71,60 IDENTIQUE | identique |

**Drift attendu (timings, ré-ancrés) + correction honnête d'un claim :**
- moteur : 4,11× → 3,06× (ms/éval 0,031/0,127 → 0,049/0,150) ; fitness : 6,36× → 4,83× (0,005/0,034 → 0,007/0,033) ; témoin 322 → 461 ms — run original conservé comme historique ;
- **claim corrigé** : « le plus grand écart moteur de l'Epic » ne tient plus avec les valeurs re-exécutées → « deuxième, derrière SA 3,26× » (verdict de paire ajusté en conséquence) ;
- cross-refs siblings rafraîchies vers les re-exécutions #13407 : PSO 0,8×-1,3×, EO 1,41×, WOA 1,78×, DE 2,37×, SA 3,26× ; fitness PSO 5,13× / SA 5,33× / EO 5,56× / DE 3,71×.

**Gates :**
- C.1 : 0 pattern interdit ;
- H.3 : 9/9 cellules code `execution_count != null` + outputs ;
- `validate_pr_notebooks.py HEAD <relpath>` : **1/1 PASS** (9 cells, .net-csharp) ;
- composition : 19 cellules, source code modifiée = probe seulement, markdown modifiées = `mgs27-mgs-lecture` + `mgs27-croisement-lecture` seulement.

Diff : 97 insertions, 85 deletions.

## Bilan Epic #13407 (6/6 tranches livrées par cette lane)

| Tranche | Notebook | PR |
|---|---|---|
| 1 | MGS-22 PSO | #13408 |
| 2 | MGS-23 DE | #13409 |
| 3 | MGS-24 SA | #13411 |
| 4 | MGS-25 WOA | #13414 |
| 5 | MGS-26 EO | #13416 |
| 6 | MGS-27 FBI | cette PR |

Chaque tranche : probe canonical + re-exec complète 0 erreur + non-régression déterministe prouvée line-diff + timings ré-ancrés avec run original conservé + cross-refs siblings rafraîchies. Le critère d'acceptation de l'issue (tous les notebooks MGS-vs-mealpy re-exécutés sur l'interpréteur probe corrigé, valeurs déterministes inchangées) est rempli.

## Test plan

- [x] Re-exec complète 0 erreur
- [x] Line-diff déterministe identique
- [x] Validator PASS
- [ ] Review coordinateur (ai-01) — 6 PRs #13408/#13409/#13411/#13414/#13416 + celle-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)
