### PR TITLE
fix(genai,#11112): rebind forge-turbo sur RTX 3080 Ti — fin de la contention TTS (3 leviers)

### DIFF
--- a/docker-configurations/services/forge-turbo/docker-compose.yml
+++ b/docker-configurations/services/forge-turbo/docker-compose.yml
@@ -10,7 +10,9 @@ services:
       - "127.0.0.1:${FORGE_PORT:-17861}:17860"
       - "127.0.0.1:1111:1111"
     environment:
-      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_VISIBLE_DEVICES=0
+      - CUDA_DEVICE_ORDER=PCI_BUS_ID
+      - CUDA_VISIBLE_DEVICES=0
       - WEB_USER=${FORGE_USER:-admin}
       - WEB_PASSWORD=${FORGE_PASSWORD:-changeme}
       - FORGE_ARGS=--ui-settings-file config-turbo.json --api --api-log --listen --gradio-auth ${FORGE_USER:-admin}:${FORGE_PASSWORD:-changeme} --gpu-device-id 0 --xformers --skip-install
@@ -28,6 +30,6 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              device_ids: ['1']
+              device_ids: ['0']
               capabilities: [gpu]
     restart: unless-stopped


### PR DESCRIPTION
Grain: MED/infra-docker — lane myia-po-2023:CoursIA — prev: MED/notebook-dotnet #13418

See #11112 (rebind structurel demandé par po-2025, blocker RECOVERABLE-MACHINE)

## Summary

Rebind structurel de `forge-turbo` du RTX 3090 (GPU1, contendant avec la stack tts-multi) vers le RTX 3080 Ti libre (GPU0, 16 Go). Demande po-2025 20:16:45Z (HIGH) : PR infra séparée ou changement runtime réversible — les deux sont faits (runtime appliqué et vérifié sur po-2023, cette PR rend le changement durable).

**Le rebind exige 3 leviers — le `device_ids` seul ne suffit PAS :**

| Levier | Avant | Après | Pourquoi |
|---|---|---|---|
| `deploy...device_ids` | `['1']` | `['0']` | Réservation compose (seul, sans effet — voir ci-dessous) |
| `NVIDIA_VISIBLE_DEVICES` (env) | `all` | `0` | L'env legacy **primait** sur device_ids : le conteneur voyait les 2 GPU |
| `CUDA_DEVICE_ORDER` + `CUDA_VISIBLE_DEVICES` | (absents) | `PCI_BUS_ID` + `0` | **Racine** : CUDA ordonne les devices par vitesse (FASTEST_FIRST par défaut) → `cuda:0` = 3090 quel que soit l'ordre nvidia-smi. Sans ce levier, boot loggue `Device: cuda:0 = RTX 3090` même avec device_ids=['0'] |

## Preuves (runtime déjà appliqué sur po-2023, mesuré firsthand)

- Boot log : `Device: cuda:0 NVIDIA GeForce RTX 3080 Ti Laptop GPU : native` ;
- Modèle résident GPU0 : nvidia-smi 7 695 MiB / 16 384 — GPU1 (14,5 Go) rendu à la stack tts uniquement ;
- txt2img réels (sdxl_lightning_4step, 512×512, steps=4) : cold **200 en 20,8 s** (incl. chargement), warm **200 en 4,07 s** — parité de vitesse avec la 3090 (5,1 s), sans contention TTS ;
- `tts-gateway:8196/health`, `tts-api:8191/health`, `whisper-api:8190/health` = **200** intacts après recréation ;
- `options` 200 (port direct host `127.0.0.1:17861`).

Note opérationnelle : après recréation, le checkpoint par défaut était `None` (fallback LTX → KeyError UNet) — re-sélectionné `sdxl_lightning_4step.safetensors` (vérifié dans options). Les notebooks qui POSTent leur checkpoint ne sont pas affectés.

## Test plan

- [x] Conteneur recréé sur po-2023 avec la config de cette PR (diff identique)
- [x] Device boot = 3080 Ti (log)
- [x] txt2img cold + warm 200 avec vraies images
- [x] tts/whisper 200 intacts
- [ ] Review coordinateur (ai-01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
