### PR TITLE
docs(gametheory,#13341): miroir Python de la relativite du statut ESS au pool de mutants

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06-EvolutionTrust.ipynb
@@ -1747,7 +1747,9 @@
     "observé (77,5 % / 22,5 %) est un **point de repos** choisi par la condition initiale, pas un attracteur que la\n",
     "dynamique aurait imposé. Une autre `x_0` (cellule 26) donne un autre couple tout aussi « final » : l'ESS est le\n",
     "bon outil pour poser la question, et le seul moyen de ne pas attribuer au hasard de la condition initiale une\n",
-    "vertu stabilisatrice qu'il n'a pas."
+    "vertu stabilisatrice qu'il n'a pas.\n",
+    "\n",
+    "**Miroir avec le jumeau C#.** Le jumeau C# de cette paire conclut `AlwaysDefect = NSS` — pas ESS — sur son pool de **7** stratégies : là-bas, `SuspiciousTFT` fait exactement 1.00 contre elle ($u(STFT,AD) = 1.00 = u(AD,AD)$, égalité parfaite sur les deux axes du critère), et le verdict d'`AlwaysDefect` tombe d'ESS stricte à NSS. Ici, sur **3** stratégies, `AlwaysDefect` **est** une ESS stricte ($u(AD,AD) = 1.00 > u(TFT,AD) = 0.99$). Les deux verdicts sont vrais simultanément : **le statut ESS est relatif à l'ensemble des mutants disponibles, pas une propriété intrinsèque de la stratégie**. Un étudiant qui compare les deux notebooks voit le même objet recevoir deux verdicts — c'est la leçon, pas une incohérence."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6-evolutiontrust.yaml
@@ -64,6 +64,12 @@
       csharp_sha: d465d4c9c186893032969564dc6cdbe675d1a050
       content_python_sha: 0b4beabc96fb3b3411cfd15c8ac27c31773e974420b2f57734c9d9202f43f812
       content_csharp_sha: 01e5645cc9f961328cdd8b4f145378847b26dfac812d2d99323a8ced083d67be
+    - date: "2026-08-29"
+      by: myia-po-2023:CoursIA-2 -- issue #13341 : phrase miroir Python (cellule 32) sur la relativite du statut ESS au pool de mutants (3 strat. ici = ESS stricte vs 7 strat. C# = NSS, SuspiciousTFT 1.00/1.00). Markdown-only, execution_counts inchanges (exception C.2).
+      python_sha: 15b83671f07996eccb6e99843648dbd0c21f265b
+      csharp_sha: d465d4c9c186893032969564dc6cdbe675d1a050
+      content_python_sha: d26598e7ba8e8c4dbe7f20cf02cd7060f621393a62312d4a1912e5aa6dd7af92
+      content_csharp_sha: 01e5645cc9f961328cdd8b4f145378847b26dfac812d2d99323a8ced083d67be
   known_differences:
     - "Socle pedagogique commun : Dilemme du Prisonnier Itere (IPD), tournoi d'Axelrod, strategies classiques (TitForTat, Pavlov, Generous TitForTat), dynamique evolutive (processus de Moran), emergence de la cooperation."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `matplotlib.animation` (viz dynamique du tournoi round-robin + courbes de Moran). C# = pur `System.*` (Collections.Generic, Linq) + moteur IPD from-scratch (T=5/R=3/P=1/S=0 convention Axelrod) ; 0 NuGet tiers."


### PR DESCRIPTION
Grain: LIGHT/pedagogy-prose — lane myia-po-2023:CoursIA-2 — prev: drainage #13209/#13203

## Summary

Lève la note Hermes (2026-08-24, non bloquante) sur la paire GT-06 : un étudiant qui compare les jumeaux lit `AlwaysDefect = ESS stricte` côté Python (3 stratégies) et `AlwaysDefect = NSS` côté C# (7 stratégies) sans que rien n'explique le contraste.

- **Côté C# : déjà livré** par le merge #12755 — la cellule 20 contient le contraste complet (« le twin Python (3 stratégies)... SuspiciousTFT fait exactement 1.00... Le statut ESS n'est pas une propriété intrinsèque »). Vérifié sur `origin/main` : critère 1 (grep « 3 stratégies » + SuspiciousTFT nommée) et critère 2 (relativité énoncée) déjà remplis.
- **Cette PR apporte le miroir Python** : paragraphe appendé à la cellule 32 (« Interprétation : ESS, NSS et la subtilité que la note initiale masquait ») — le jumeau C# conclut NSS sur 7 stratégies (SuspiciousTFT 1.00/1.00 exact contre AlwaysDefect), ici 3 stratégies la rendent ESS stricte, les deux verdicts sont vrais simultanément.

## Validation

- **Markdown-only** (exception C.2) : diff 3+/1−, 0 changement `execution_count`/`outputs` (grep du diff = 0). Pas de ré-exécution requise.
- `check_twin_parity.py --check --per-pair --base origin/main` : **157/157 OK** — entrée d'audit appendede (python_sha `15b83671`, content `d26598e7`, csharp inchangé `d465d4c9`), pas réécrite (critère 4).
- `validate_pr_notebooks.py origin/main` : 1/1 PASS (23 cellules code).
- Catalogue byte-identique à main (aucun fichier catalogue touché).

Closes #13341

Co-Authored-By: Claude-Code <noreply@anthropic.com>