### PR TITLE
feat(ci,#12704): A1 mesure runner-demand — 3178 min-runner/h, 53 equivalents, provenance 327/327 same-repo

### DIFF
--- a/scripts/ci/measure_runner_demand.py
+++ b/scripts/ci/measure_runner_demand.py
@@ -29,8 +29,6 @@ EXIT_BROKEN = 2
 PER_PAGE = 100
 SEARCH_CAP = 1000
 MIN_SLICE = timedelta(seconds=1)
-TIMESTAMP_SKEW_TOLERANCE = timedelta(seconds=1)
-TIMESTAMP_SKEW_TOLERANCE = timedelta(seconds=1)
 
 
 class MeasurementError(RuntimeError):
@@ -241,12 +239,12 @@ def collect_snapshot(
 def _duration_minutes(start: str, end: str, label: str) -> float | None:
     a, b = parse_time(start), parse_time(end)
     if b < a:
-        # GitHub timestamps have one-second precision and occasionally invert
-        # adjacent events by exactly one second. Exclude and count this datum;
-        # never turn it into a clean zero. Larger inversions remain fatal.
-        if a - b <= TIMESTAMP_SKEW_TOLERANCE:
-            return None
-        raise MeasurementError(f"negative duration for {label}: {start} -> {end}")
+        # GitHub timestamps occasionally invert adjacent events -- observed in
+        # the wild up to several seconds (job 98968836743, 2026-08-28: started
+        # 6 s after completed). An inverted duration is unmeasurable, not
+        # negative: exclude the datum and let the caller count it in the
+        # timestamp_skew denominator. Never fatal, never a clean zero.
+        return None
     return (b - a).total_seconds() / 60.0
 
 

--- a/scripts/ci/runner-demand-20260828T2000Z.json
+++ b/scripts/ci/runner-demand-20260828T2000Z.json
@@ -1,0 +1,14729 @@
+{
+  "snapshot": {
+    "schema_version": 1,
+    "repo": "jsboige/CoursIA",
+    "since": "2026-08-28T20:00:00Z",
+    "until": "2026-08-28T21:00:00Z",
+    "runs": [
+      {
+        "id": 33206506371,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:02:39Z",
+        "run_started_at": "2026-08-28T20:02:39Z",
+        "updated_at": "2026-08-28T20:02:41Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98968813307,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:40Z",
+            "started_at": "2026-08-28T20:02:40Z",
+            "completed_at": "2026-08-28T20:02:40Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968813797,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:40Z",
+            "started_at": "2026-08-28T20:02:40Z",
+            "completed_at": "2026-08-28T20:02:40Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968813845,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:40Z",
+            "started_at": "2026-08-28T20:02:40Z",
+            "completed_at": "2026-08-28T20:02:40Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968836743,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:46Z",
+            "started_at": "2026-08-28T20:02:46Z",
+            "completed_at": "2026-08-28T20:02:40Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968842043,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:47Z",
+            "started_at": "2026-08-28T20:02:47Z",
+            "completed_at": "2026-08-28T20:02:40Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968852042,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:49Z",
+            "started_at": "2026-08-28T20:02:49Z",
+            "completed_at": "2026-08-28T20:02:40Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968855289,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:50Z",
+            "started_at": "2026-08-28T20:02:50Z",
+            "completed_at": "2026-08-28T20:02:40Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206508975,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:02:41Z",
+        "run_started_at": "2026-08-28T20:02:41Z",
+        "updated_at": "2026-08-28T20:02:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98968821973,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:42Z",
+            "started_at": "2026-08-28T20:02:42Z",
+            "completed_at": "2026-08-28T20:02:42Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968822269,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:42Z",
+            "started_at": "2026-08-28T20:02:42Z",
+            "completed_at": "2026-08-28T20:02:42Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968847302,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:48Z",
+            "started_at": "2026-08-28T20:02:48Z",
+            "completed_at": "2026-08-28T20:02:42Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968848217,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:48Z",
+            "started_at": "2026-08-28T20:02:48Z",
+            "completed_at": "2026-08-28T20:02:42Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968857260,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:50Z",
+            "started_at": "2026-08-28T20:02:50Z",
+            "completed_at": "2026-08-28T20:02:42Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968859225,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:51Z",
+            "started_at": "2026-08-28T20:02:51Z",
+            "completed_at": "2026-08-28T20:02:42Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968861732,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:52Z",
+            "started_at": "2026-08-28T20:02:52Z",
+            "completed_at": "2026-08-28T20:02:42Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206511102,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:02:43Z",
+        "run_started_at": "2026-08-28T20:02:43Z",
+        "updated_at": "2026-08-28T20:02:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98968828764,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:44Z",
+            "started_at": "2026-08-28T20:02:44Z",
+            "completed_at": "2026-08-28T20:02:44Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968829249,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:44Z",
+            "started_at": "2026-08-28T20:02:44Z",
+            "completed_at": "2026-08-28T20:02:44Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968855573,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:50Z",
+            "started_at": "2026-08-28T20:02:50Z",
+            "completed_at": "2026-08-28T20:02:44Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968855740,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:50Z",
+            "started_at": "2026-08-28T20:02:50Z",
+            "completed_at": "2026-08-28T20:02:44Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968860610,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:51Z",
+            "started_at": "2026-08-28T20:02:51Z",
+            "completed_at": "2026-08-28T20:02:44Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968861677,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:52Z",
+            "started_at": "2026-08-28T20:02:52Z",
+            "completed_at": "2026-08-28T20:02:44Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968867325,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:53Z",
+            "started_at": "2026-08-28T20:02:53Z",
+            "completed_at": "2026-08-28T20:02:44Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206512531,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:02:44Z",
+        "run_started_at": "2026-08-28T20:02:44Z",
+        "updated_at": "2026-08-28T20:02:46Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98968834026,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:45Z",
+            "started_at": "2026-08-28T20:02:45Z",
+            "completed_at": "2026-08-28T20:02:45Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968834440,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:45Z",
+            "started_at": "2026-08-28T20:02:45Z",
+            "completed_at": "2026-08-28T20:02:45Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968834587,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:45Z",
+            "started_at": "2026-08-28T20:02:45Z",
+            "completed_at": "2026-08-28T20:02:45Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968834771,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:45Z",
+            "started_at": "2026-08-28T20:02:45Z",
+            "completed_at": "2026-08-28T20:02:45Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968862291,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:52Z",
+            "started_at": "2026-08-28T20:02:52Z",
+            "completed_at": "2026-08-28T20:02:45Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968870041,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:54Z",
+            "started_at": "2026-08-28T20:02:54Z",
+            "completed_at": "2026-08-28T20:02:45Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98968876136,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:02:55Z",
+            "started_at": "2026-08-28T20:02:55Z",
+            "completed_at": "2026-08-28T20:02:45Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206925955,
+        "name": "PR #13414",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:16Z",
+        "run_started_at": "2026-08-28T20:08:16Z",
+        "updated_at": "2026-08-28T21:26:32Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970226360,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:17Z",
+            "started_at": "2026-08-28T21:14:02Z",
+            "completed_at": "2026-08-28T21:15:47Z",
+            "runner_name": "GitHub Actions 1000426988",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970226467,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:17Z",
+            "started_at": "2026-08-28T21:14:02Z",
+            "completed_at": "2026-08-28T21:17:56Z",
+            "runner_name": "GitHub Actions 1000426989",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970226508,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:17Z",
+            "started_at": "2026-08-28T20:56:57Z",
+            "completed_at": "2026-08-28T21:02:47Z",
+            "runner_name": "GitHub Actions 1000426880",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970226545,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:17Z",
+            "started_at": "2026-08-28T21:25:02Z",
+            "completed_at": "2026-08-28T21:26:32Z",
+            "runner_name": "GitHub Actions 1000427059",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98987661932,
+            "name": "fast-lane (ombre): banner-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:20:59Z",
+            "started_at": "2026-08-28T21:20:59Z",
+            "completed_at": "2026-08-28T21:20:59Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987663988,
+            "name": "fast-lane (ombre): pip-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:20:59Z",
+            "started_at": "2026-08-28T21:20:59Z",
+            "completed_at": "2026-08-28T21:20:59Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987665811,
+            "name": "fast-lane (ombre): solution-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:00Z",
+            "started_at": "2026-08-28T21:21:00Z",
+            "completed_at": "2026-08-28T21:21:00Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987667608,
+            "name": "fast-lane (ombre): prose-counts-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:00Z",
+            "started_at": "2026-08-28T21:21:00Z",
+            "completed_at": "2026-08-28T21:21:00Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987669280,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:01Z",
+            "started_at": "2026-08-28T21:21:01Z",
+            "completed_at": "2026-08-28T21:21:01Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987671174,
+            "name": "fast-lane (ombre): bare-cross-dir-load-gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:01Z",
+            "started_at": "2026-08-28T21:21:01Z",
+            "completed_at": "2026-08-28T21:21:01Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987673292,
+            "name": "fast-lane (ombre): notebook-navlink-check",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:02Z",
+            "started_at": "2026-08-28T21:21:02Z",
+            "completed_at": "2026-08-28T21:21:02Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987675474,
+            "name": "fast-lane (ombre): notebook-interp-positioning-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:02Z",
+            "started_at": "2026-08-28T21:21:02Z",
+            "completed_at": "2026-08-28T21:21:02Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987677292,
+            "name": "fast-lane (ombre): markdown-rendering-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:03Z",
+            "started_at": "2026-08-28T21:21:03Z",
+            "completed_at": "2026-08-28T21:21:03Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987678944,
+            "name": "Exercice-solution HIGH delta guard (#8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:03Z",
+            "started_at": "2026-08-28T21:21:03Z",
+            "completed_at": "2026-08-28T21:21:03Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987680593,
+            "name": "Output-failure ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:04Z",
+            "started_at": "2026-08-28T21:21:04Z",
+            "completed_at": "2026-08-28T21:21:04Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987682202,
+            "name": "No fabricated text output in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:04Z",
+            "started_at": "2026-08-28T21:21:04Z",
+            "completed_at": "2026-08-28T21:21:04Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987683870,
+            "name": "No degenerate figure in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:05Z",
+            "started_at": "2026-08-28T21:21:05Z",
+            "completed_at": "2026-08-28T21:21:05Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987685764,
+            "name": "No SVG broken-geometry (negative-dim) defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:05Z",
+            "started_at": "2026-08-28T21:21:05Z",
+            "completed_at": "2026-08-28T21:21:05Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987687839,
+            "name": "No SVG decimal-comma defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:06Z",
+            "started_at": "2026-08-28T21:21:06Z",
+            "completed_at": "2026-08-28T21:21:06Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987690288,
+            "name": "No SVG empty-display defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:06Z",
+            "started_at": "2026-08-28T21:21:06Z",
+            "completed_at": "2026-08-28T21:21:06Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987692458,
+            "name": "No offscreen-flat SVG in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:07Z",
+            "started_at": "2026-08-28T21:21:07Z",
+            "completed_at": "2026-08-28T21:21:07Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987694173,
+            "name": "No markdown content loss in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:07Z",
+            "started_at": "2026-08-28T21:21:07Z",
+            "completed_at": "2026-08-28T21:21:07Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33206928766,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:04:53Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233097,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:04:41Z",
+            "completed_at": "2026-08-28T21:04:52Z",
+            "runner_name": "GitHub Actions 1000426916",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928791,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T20:08:27Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970234402,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:08:19Z",
+            "completed_at": "2026-08-28T20:08:19Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928792,
+        "name": "Consecutive Code Cells Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T20:57:04Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233357,
+            "name": "Consecutive code cells >= 2 advisory (label, non-blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:55:51Z",
+            "completed_at": "2026-08-28T20:57:03Z",
+            "runner_name": "GitHub Actions 1000426872",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928801,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T21:50:29Z",
+        "updated_at": "2026-08-28T22:19:28Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233348,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:05:06Z",
+            "completed_at": "2026-08-28T21:34:04Z",
+            "runner_name": "GitHub Actions 1000426920",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98994336495,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:50:33Z",
+            "started_at": "2026-08-28T22:18:06Z",
+            "completed_at": "2026-08-28T22:19:27Z",
+            "runner_name": "GitHub Actions 1000427441",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928807,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:10:09Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233635,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:10:00Z",
+            "completed_at": "2026-08-28T21:10:09Z",
+            "runner_name": "GitHub Actions 1000426955",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928820,
+        "name": "MD Hierarchy Drift Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T20:51:50Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233069,
+            "name": "scan_md_hierarchy drift (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:50:41Z",
+            "completed_at": "2026-08-28T20:51:49Z",
+            "runner_name": "GitHub Actions 1000426837",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928843,
+        "name": "Notebook Papermill Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:06:54Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233552,
+            "name": "Papermill ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:06:01Z",
+            "completed_at": "2026-08-28T21:06:53Z",
+            "runner_name": "GitHub Actions 1000426927",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928844,
+        "name": "Validation Matrix",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T20:56:36Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233558,
+            "name": "validate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:55:44Z",
+            "completed_at": "2026-08-28T20:56:35Z",
+            "runner_name": "GitHub Actions 1000426870",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928864,
+        "name": "Notebook Navlink Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:18:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233917,
+            "name": "check-navlinks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:17:45Z",
+            "completed_at": "2026-08-28T21:18:30Z",
+            "runner_name": "GitHub Actions 1000427020",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928874,
+        "name": "markdown-rendering-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T20:58:15Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233388,
+            "name": "markdown-rendering guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:57:10Z",
+            "completed_at": "2026-08-28T20:58:15Z",
+            "runner_name": "GitHub Actions 1000426883",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928878,
+        "name": "Markdown claims anchored to previous output (advisory)",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:14:16Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233639,
+            "name": "Markdown claims anchored to previous output (#11435 advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:13:26Z",
+            "completed_at": "2026-08-28T21:14:15Z",
+            "runner_name": "GitHub Actions 1000426982",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928881,
+        "name": "Cell-order gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:10:50Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233786,
+            "name": "No cell-ordering regression in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:10:00Z",
+            "completed_at": "2026-08-28T21:10:49Z",
+            "runner_name": "GitHub Actions 1000426956",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928890,
+        "name": "Notebook Cell Source Parses",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:03:06Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233714,
+            "name": "cell-source-parses",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:01:52Z",
+            "completed_at": "2026-08-28T21:03:06Z",
+            "runner_name": "GitHub Actions 1000426908",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928904,
+        "name": "Notebook Execution Required",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:46:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233679,
+            "name": "Golden-set execution (H.7 P3)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:56:15Z",
+            "completed_at": "2026-08-28T20:58:38Z",
+            "runner_name": "GitHub Actions 1000426875",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970233885,
+            "name": "Detect notebook changes",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:58:46Z",
+            "completed_at": "2026-08-28T20:59:29Z",
+            "runner_name": "GitHub Actions 1000426894",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98982594356,
+            "name": "Static validation (H.1/H.3/C.1)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:59:30Z",
+            "started_at": "2026-08-28T21:45:50Z",
+            "completed_at": "2026-08-28T21:46:42Z",
+            "runner_name": "GitHub Actions 1000427207",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928906,
+        "name": "pip-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:09:17Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233854,
+            "name": "!pip install HIGH delta guard (#6314)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:08:19Z",
+            "completed_at": "2026-08-28T21:09:16Z",
+            "runner_name": "GitHub Actions 1000426948",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928913,
+        "name": "Quarto Pages Deploy",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:28:45Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233703,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:09:54Z",
+            "completed_at": "2026-08-28T21:28:44Z",
+            "runner_name": "GitHub Actions 1000426954",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970234853,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:08:19Z",
+            "completed_at": "2026-08-28T20:08:19Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970235531,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:08:19Z",
+            "completed_at": "2026-08-28T20:08:19Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928914,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:05:39Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233667,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:51:29Z",
+            "completed_at": "2026-08-28T20:59:10Z",
+            "runner_name": "GitHub Actions 1000426841",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970233839,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:04:47Z",
+            "completed_at": "2026-08-28T21:05:38Z",
+            "runner_name": "GitHub Actions 1000426917",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928917,
+        "name": "Notebook Exec Sequence Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T20:53:08Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233791,
+            "name": "Exec-sequence ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:52:19Z",
+            "completed_at": "2026-08-28T20:53:07Z",
+            "runner_name": "GitHub Actions 1000426847",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928921,
+        "name": "Catalog Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T20:54:47Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233775,
+            "name": "Notebook catalog drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:52:16Z",
+            "completed_at": "2026-08-28T20:54:46Z",
+            "runner_name": "GitHub Actions 1000426846",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928923,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T20:55:49Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233894,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:55:11Z",
+            "completed_at": "2026-08-28T20:55:48Z",
+            "runner_name": "GitHub Actions 1000426866",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928927,
+        "name": "banner-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:12:34Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233666,
+            "name": "probeAddresses banner guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:11:48Z",
+            "completed_at": "2026-08-28T21:12:33Z",
+            "runner_name": "GitHub Actions 1000426969",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928928,
+        "name": "Translation Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:00:08Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233773,
+            "name": "Translation drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:59:13Z",
+            "completed_at": "2026-08-28T21:00:06Z",
+            "runner_name": "GitHub Actions 1000426895",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928932,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:21:13Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970234124,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:18:52Z",
+            "completed_at": "2026-08-28T21:21:12Z",
+            "runner_name": "GitHub Actions 1000427033",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928936,
+        "name": "notebook-interp-positioning-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T20:55:42Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233784,
+            "name": "check_interp_positioning.py",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:54:49Z",
+            "completed_at": "2026-08-28T20:55:41Z",
+            "runner_name": "GitHub Actions 1000426864",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928943,
+        "name": "Twin Parity Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:14:21Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970233943,
+            "name": "Twin parity SHA mismatch (#9399 volet b, advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:10:52Z",
+            "completed_at": "2026-08-28T21:11:46Z",
+            "runner_name": "GitHub Actions 1000426961",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970234223,
+            "name": "Twin parity audit (#8057)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:13:26Z",
+            "completed_at": "2026-08-28T21:14:20Z",
+            "runner_name": "GitHub Actions 1000426983",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928952,
+        "name": "prose-counts-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:10:54Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970234119,
+            "name": "prose-counts",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:10:11Z",
+            "completed_at": "2026-08-28T21:10:53Z",
+            "runner_name": "GitHub Actions 1000426957",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928962,
+        "name": "Notebook Validation",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T21:11:39Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970234031,
+            "name": "validate-notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:07:06Z",
+            "completed_at": "2026-08-28T21:11:38Z",
+            "runner_name": "GitHub Actions 1000426940",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206928968,
+        "name": "solution-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:18Z",
+        "run_started_at": "2026-08-28T20:08:18Z",
+        "updated_at": "2026-08-28T20:55:59Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970234002,
+            "name": "Solution-leak HIGH delta (WARN phase, #8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T20:55:09Z",
+            "completed_at": "2026-08-28T20:55:58Z",
+            "runner_name": "GitHub Actions 1000426865",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33206929563,
+        "name": "Bare cross-dir",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:08:19Z",
+        "run_started_at": "2026-08-28T20:08:19Z",
+        "updated_at": "2026-08-28T21:12:00Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970235336,
+            "name": "No bare cross-dir #load in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:08:19Z",
+            "started_at": "2026-08-28T21:11:11Z",
+            "completed_at": "2026-08-28T21:11:59Z",
+            "runner_name": "GitHub Actions 1000426963",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207117648,
+        "name": "PR #13374",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:56Z",
+        "run_started_at": "2026-08-28T20:10:56Z",
+        "updated_at": "2026-08-28T21:34:24Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970880912,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:57Z",
+            "started_at": "2026-08-28T20:59:55Z",
+            "completed_at": "2026-08-28T21:06:09Z",
+            "runner_name": "GitHub Actions 1000426899",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970881116,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:57Z",
+            "started_at": "2026-08-28T20:59:55Z",
+            "completed_at": "2026-08-28T21:01:34Z",
+            "runner_name": "GitHub Actions 1000426900",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970881128,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:57Z",
+            "started_at": "2026-08-28T21:26:12Z",
+            "completed_at": "2026-08-28T21:27:48Z",
+            "runner_name": "GitHub Actions 1000427065",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970881207,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:57Z",
+            "started_at": "2026-08-28T21:30:17Z",
+            "completed_at": "2026-08-28T21:34:23Z",
+            "runner_name": "GitHub Actions 1000427091",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98983889506,
+            "name": "fast-lane (ombre): banner-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:53Z",
+            "started_at": "2026-08-28T21:04:53Z",
+            "completed_at": "2026-08-28T21:04:53Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983891077,
+            "name": "fast-lane (ombre): pip-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:54Z",
+            "started_at": "2026-08-28T21:04:54Z",
+            "completed_at": "2026-08-28T21:04:54Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983892874,
+            "name": "fast-lane (ombre): solution-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:54Z",
+            "started_at": "2026-08-28T21:04:54Z",
+            "completed_at": "2026-08-28T21:04:54Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983894275,
+            "name": "fast-lane (ombre): prose-counts-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:54Z",
+            "started_at": "2026-08-28T21:04:54Z",
+            "completed_at": "2026-08-28T21:04:54Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983895730,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:55Z",
+            "started_at": "2026-08-28T21:04:55Z",
+            "completed_at": "2026-08-28T21:04:55Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983897554,
+            "name": "fast-lane (ombre): bare-cross-dir-load-gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:55Z",
+            "started_at": "2026-08-28T21:04:55Z",
+            "completed_at": "2026-08-28T21:04:55Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983899185,
+            "name": "fast-lane (ombre): notebook-navlink-check",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:56Z",
+            "started_at": "2026-08-28T21:04:56Z",
+            "completed_at": "2026-08-28T21:04:56Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983900448,
+            "name": "fast-lane (ombre): notebook-interp-positioning-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:56Z",
+            "started_at": "2026-08-28T21:04:56Z",
+            "completed_at": "2026-08-28T21:04:56Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983901806,
+            "name": "fast-lane (ombre): markdown-rendering-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:56Z",
+            "started_at": "2026-08-28T21:04:56Z",
+            "completed_at": "2026-08-28T21:04:56Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983903338,
+            "name": "zero-pad guard (GameTheory serie)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:57Z",
+            "started_at": "2026-08-28T21:04:57Z",
+            "completed_at": "2026-08-28T21:04:57Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983904816,
+            "name": "Exercice-solution HIGH delta guard (#8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:57Z",
+            "started_at": "2026-08-28T21:04:57Z",
+            "completed_at": "2026-08-28T21:04:57Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983906429,
+            "name": "Output-failure ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:58Z",
+            "started_at": "2026-08-28T21:04:58Z",
+            "completed_at": "2026-08-28T21:04:58Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983908071,
+            "name": "No fabricated text output in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:58Z",
+            "started_at": "2026-08-28T21:04:58Z",
+            "completed_at": "2026-08-28T21:04:58Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983909282,
+            "name": "No degenerate figure in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:58Z",
+            "started_at": "2026-08-28T21:04:58Z",
+            "completed_at": "2026-08-28T21:04:58Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983910875,
+            "name": "No SVG broken-geometry (negative-dim) defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:59Z",
+            "started_at": "2026-08-28T21:04:59Z",
+            "completed_at": "2026-08-28T21:04:59Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983912438,
+            "name": "No SVG decimal-comma defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:04:59Z",
+            "started_at": "2026-08-28T21:04:59Z",
+            "completed_at": "2026-08-28T21:04:59Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983913923,
+            "name": "No SVG empty-display defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:05:00Z",
+            "started_at": "2026-08-28T21:05:00Z",
+            "completed_at": "2026-08-28T21:05:00Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983915308,
+            "name": "No offscreen-flat SVG in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:05:00Z",
+            "started_at": "2026-08-28T21:05:00Z",
+            "completed_at": "2026-08-28T21:05:00Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98983916677,
+            "name": "No markdown content loss in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:05:00Z",
+            "started_at": "2026-08-28T21:05:00Z",
+            "completed_at": "2026-08-28T21:05:00Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33207117988,
+        "name": "hooks-parity",
+        "event": "push",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:56Z",
+        "run_started_at": "2026-08-28T20:10:56Z",
+        "updated_at": "2026-08-28T21:17:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970879137,
+            "name": "parity gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:57Z",
+            "started_at": "2026-08-28T21:17:07Z",
+            "completed_at": "2026-08-28T21:17:50Z",
+            "runner_name": "GitHub Actions 1000427015",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120362,
+        "name": "Translation Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:11:08Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886717,
+            "name": "Translation drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:10:18Z",
+            "completed_at": "2026-08-28T21:11:08Z",
+            "runner_name": "GitHub Actions 1000426958",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120367,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:05:03Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886684,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:03:09Z",
+            "completed_at": "2026-08-28T21:05:02Z",
+            "runner_name": "GitHub Actions 1000426913",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120369,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:18:34Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886567,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:17:47Z",
+            "completed_at": "2026-08-28T21:18:33Z",
+            "runner_name": "GitHub Actions 1000427021",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120371,
+        "name": "Bare cross-dir",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:35:38Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886632,
+            "name": "No bare cross-dir #load in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:34:50Z",
+            "completed_at": "2026-08-28T21:35:37Z",
+            "runner_name": "GitHub Actions 1000427121",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120375,
+        "name": "Notebook Exec Sequence Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:07:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886825,
+            "name": "Exec-sequence ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:06:52Z",
+            "completed_at": "2026-08-28T21:07:43Z",
+            "runner_name": "GitHub Actions 1000426937",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120376,
+        "name": "Notebook Papermill Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:16:28Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886529,
+            "name": "Papermill ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:15:29Z",
+            "completed_at": "2026-08-28T21:16:27Z",
+            "runner_name": "GitHub Actions 1000427001",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120385,
+        "name": "pip-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:06:29Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886528,
+            "name": "!pip install HIGH delta guard (#6314)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:05:35Z",
+            "completed_at": "2026-08-28T21:06:28Z",
+            "runner_name": "GitHub Actions 1000426925",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120387,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T20:11:07Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970888098,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T20:10:59Z",
+            "completed_at": "2026-08-28T20:10:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120389,
+        "name": "Markdown claims anchored to previous output (advisory)",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:14:24Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886584,
+            "name": "Markdown claims anchored to previous output (#11435 advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:13:36Z",
+            "completed_at": "2026-08-28T21:14:23Z",
+            "runner_name": "GitHub Actions 1000426985",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120390,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:16:37Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886750,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:16:29Z",
+            "completed_at": "2026-08-28T21:16:37Z",
+            "runner_name": "GitHub Actions 1000427009",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120391,
+        "name": "Validation Matrix",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:20:47Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886928,
+            "name": "validate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:19:51Z",
+            "completed_at": "2026-08-28T21:20:47Z",
+            "runner_name": "GitHub Actions 1000427038",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120394,
+        "name": "notebook-interp-positioning-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:15:16Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886640,
+            "name": "check_interp_positioning.py",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:14:26Z",
+            "completed_at": "2026-08-28T21:15:15Z",
+            "runner_name": "GitHub Actions 1000426992",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120399,
+        "name": "Twin Parity Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:17:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886681,
+            "name": "Twin parity SHA mismatch (#9399 volet b, advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:12:41Z",
+            "completed_at": "2026-08-28T21:13:33Z",
+            "runner_name": "GitHub Actions 1000426977",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970886907,
+            "name": "Twin parity audit (#8057)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:16:52Z",
+            "completed_at": "2026-08-28T21:17:43Z",
+            "runner_name": "GitHub Actions 1000427014",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120400,
+        "name": "Consecutive Code Cells Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:10:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886833,
+            "name": "Consecutive code cells >= 2 advisory (label, non-blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:09:18Z",
+            "completed_at": "2026-08-28T21:10:30Z",
+            "runner_name": "GitHub Actions 1000426952",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120405,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T22:10:14Z",
+        "updated_at": "2026-08-28T22:21:36Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886946,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:22:22Z",
+            "completed_at": "2026-08-28T21:51:28Z",
+            "runner_name": "GitHub Actions 1000427047",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98998699481,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T22:10:16Z",
+            "started_at": "2026-08-28T22:20:17Z",
+            "completed_at": "2026-08-28T22:21:35Z",
+            "runner_name": "GitHub Actions 1000427462",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120407,
+        "name": "prose-counts-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T20:58:08Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970887003,
+            "name": "prose-counts",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T20:57:24Z",
+            "completed_at": "2026-08-28T20:58:07Z",
+            "runner_name": "GitHub Actions 1000426885",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120410,
+        "name": "Cell-order gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:27:08Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886847,
+            "name": "No cell-ordering regression in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:26:21Z",
+            "completed_at": "2026-08-28T21:27:08Z",
+            "runner_name": "GitHub Actions 1000427066",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120411,
+        "name": "Notebook Cell Source Parses",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:24:07Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970887049,
+            "name": "cell-source-parses",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:23:03Z",
+            "completed_at": "2026-08-28T21:24:06Z",
+            "runner_name": "GitHub Actions 1000427052",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120416,
+        "name": "Notebook Navlink Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:26:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970887165,
+            "name": "check-navlinks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:26:07Z",
+            "completed_at": "2026-08-28T21:26:50Z",
+            "runner_name": "GitHub Actions 1000427064",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120418,
+        "name": "solution-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:15:15Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886579,
+            "name": "Solution-leak HIGH delta (WARN phase, #8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:14:19Z",
+            "completed_at": "2026-08-28T21:15:14Z",
+            "runner_name": "GitHub Actions 1000426990",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120424,
+        "name": "MD Hierarchy Drift Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:26:19Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886656,
+            "name": "scan_md_hierarchy drift (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:24:50Z",
+            "completed_at": "2026-08-28T21:26:18Z",
+            "runner_name": "GitHub Actions 1000427058",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120426,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:21:34Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886957,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:21:22Z",
+            "completed_at": "2026-08-28T21:21:33Z",
+            "runner_name": "GitHub Actions 1000427044",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120428,
+        "name": "banner-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:27:22Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970887098,
+            "name": "probeAddresses banner guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:26:36Z",
+            "completed_at": "2026-08-28T21:27:21Z",
+            "runner_name": "GitHub Actions 1000427070",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120442,
+        "name": "Notebook Execution Required",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T22:00:40Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886954,
+            "name": "Detect notebook changes",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:09:48Z",
+            "completed_at": "2026-08-28T21:10:37Z",
+            "runner_name": "GitHub Actions 1000426953",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970887111,
+            "name": "Golden-set execution (H.7 P3)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:18:38Z",
+            "completed_at": "2026-08-28T21:20:55Z",
+            "runner_name": "GitHub Actions 1000427030",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98985244422,
+            "name": "Static validation (H.1/H.3/C.1)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:10:37Z",
+            "started_at": "2026-08-28T21:59:46Z",
+            "completed_at": "2026-08-28T22:00:39Z",
+            "runner_name": "GitHub Actions 1000427314",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120446,
+        "name": "markdown-rendering-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:05:22Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886737,
+            "name": "markdown-rendering guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:04:13Z",
+            "completed_at": "2026-08-28T21:05:21Z",
+            "runner_name": "GitHub Actions 1000426915",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120449,
+        "name": "Catalog Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:14:28Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970887190,
+            "name": "Notebook catalog drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:11:38Z",
+            "completed_at": "2026-08-28T21:14:27Z",
+            "runner_name": "GitHub Actions 1000426966",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120452,
+        "name": "Scripts & Notebook-Tools Tests",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:34:48Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886930,
+            "name": "Scripts Tests (CPU)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:28:04Z",
+            "completed_at": "2026-08-28T21:34:47Z",
+            "runner_name": "GitHub Actions 1000427081",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120463,
+        "name": "Bash Syntax Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:15:00Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970887036,
+            "name": "bash -n every scripts .sh (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:07:37Z",
+            "completed_at": "2026-08-28T21:08:19Z",
+            "runner_name": "GitHub Actions 1000426943",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970887270,
+            "name": "Shebang + dry-run advisory (non-blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:14:35Z",
+            "completed_at": "2026-08-28T21:14:59Z",
+            "runner_name": "GitHub Actions 1000426994",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120469,
+        "name": "Quarto Pages Deploy",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:32:21Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886895,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:13:02Z",
+            "completed_at": "2026-08-28T21:32:20Z",
+            "runner_name": "GitHub Actions 1000426980",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970887883,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T20:10:59Z",
+            "completed_at": "2026-08-28T20:10:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970888543,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T20:10:59Z",
+            "completed_at": "2026-08-28T20:10:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120477,
+        "name": "Notebook Validation",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:16:50Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970887160,
+            "name": "validate-notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:13:29Z",
+            "completed_at": "2026-08-28T21:16:49Z",
+            "runner_name": "GitHub Actions 1000426984",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207120488,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:10:58Z",
+        "run_started_at": "2026-08-28T20:10:58Z",
+        "updated_at": "2026-08-28T21:13:59Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98970886904,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:06:12Z",
+            "completed_at": "2026-08-28T21:06:59Z",
+            "runner_name": "GitHub Actions 1000426930",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98970887065,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:10:59Z",
+            "started_at": "2026-08-28T21:06:12Z",
+            "completed_at": "2026-08-28T21:13:58Z",
+            "runner_name": "GitHub Actions 1000426931",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207535904,
+        "name": "PR #13392",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:40Z",
+        "run_started_at": "2026-08-28T20:16:40Z",
+        "updated_at": "2026-08-28T20:52:38Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972308290,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:42Z",
+            "started_at": "2026-08-28T20:16:42Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972308485,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:42Z",
+            "started_at": "2026-08-28T20:16:42Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972308505,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:42Z",
+            "started_at": "2026-08-28T20:16:42Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972308531,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:42Z",
+            "started_at": "2026-08-28T20:16:42Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538450,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:16:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972315980,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:16:44Z",
+            "started_at": "2026-08-28T20:16:44Z",
+            "completed_at": "2026-08-28T20:16:43Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538466,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:52:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972314715,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:43Z",
+            "started_at": "2026-08-28T20:16:43Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538507,
+        "name": "prose-counts-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:52:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972319539,
+            "name": "prose-counts",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:44Z",
+            "started_at": "2026-08-28T20:16:44Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538510,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:52:32Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972315153,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:43Z",
+            "started_at": "2026-08-28T20:16:43Z",
+            "completed_at": "2026-08-28T20:52:31Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538519,
+        "name": "Quarto Pages Deploy",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:52:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972378666,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:59Z",
+            "started_at": "2026-08-28T20:16:59Z",
+            "completed_at": "2026-08-28T20:52:31Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972379908,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:16:59Z",
+            "started_at": "2026-08-28T20:16:59Z",
+            "completed_at": "2026-08-28T20:16:58Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972380383,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:16:59Z",
+            "started_at": "2026-08-28T20:16:59Z",
+            "completed_at": "2026-08-28T20:16:58Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538603,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:52:32Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972315345,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:43Z",
+            "started_at": "2026-08-28T20:16:43Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538654,
+        "name": "Bash Syntax Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:52:32Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972317928,
+            "name": "bash -n every scripts .sh (advisory)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:44Z",
+            "started_at": "2026-08-28T20:16:44Z",
+            "completed_at": "2026-08-28T20:52:31Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972318220,
+            "name": "Shebang + dry-run advisory (non-blocking)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:44Z",
+            "started_at": "2026-08-28T20:16:44Z",
+            "completed_at": "2026-08-28T20:52:31Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538729,
+        "name": "Scripts & Notebook-Tools Tests",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:52:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972318489,
+            "name": "Scripts Tests (CPU)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:44Z",
+            "started_at": "2026-08-28T20:16:44Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538744,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:52:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972315916,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:44Z",
+            "started_at": "2026-08-28T20:16:44Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538785,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:52:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972315617,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:44Z",
+            "started_at": "2026-08-28T20:16:44Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972315823,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:44Z",
+            "started_at": "2026-08-28T20:16:44Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207538839,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T20:52:32Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972367783,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:16:56Z",
+            "started_at": "2026-08-28T20:16:56Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207539100,
+        "name": "PR #13415",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:16:43Z",
+        "run_started_at": "2026-08-28T20:16:43Z",
+        "updated_at": "2026-08-28T21:34:37Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972320713,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:45Z",
+            "started_at": "2026-08-28T21:20:22Z",
+            "completed_at": "2026-08-28T21:26:33Z",
+            "runner_name": "GitHub Actions 1000427039",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972320823,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:45Z",
+            "started_at": "2026-08-28T21:26:34Z",
+            "completed_at": "2026-08-28T21:28:01Z",
+            "runner_name": "GitHub Actions 1000427069",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972320892,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:45Z",
+            "started_at": "2026-08-28T21:30:28Z",
+            "completed_at": "2026-08-28T21:34:36Z",
+            "runner_name": "GitHub Actions 1000427093",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972320928,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:45Z",
+            "started_at": "2026-08-28T21:13:02Z",
+            "completed_at": "2026-08-28T21:14:36Z",
+            "runner_name": "GitHub Actions 1000426981",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98984267723,
+            "name": "fast-lane (ombre): prose-counts-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:06:28Z",
+            "started_at": "2026-08-28T21:06:28Z",
+            "completed_at": "2026-08-28T21:06:28Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98984269382,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "neutral",
+            "created_at": "2026-08-28T21:06:29Z",
+            "started_at": "2026-08-28T21:06:29Z",
+            "completed_at": "2026-08-28T21:06:29Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98984271214,
+            "name": "check-links",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:06:29Z",
+            "started_at": "2026-08-28T21:06:29Z",
+            "completed_at": "2026-08-28T21:06:29Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98995118486,
+            "name": "fast-lane (ombre): prose-counts-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:54:03Z",
+            "started_at": "2026-08-28T21:54:03Z",
+            "completed_at": "2026-08-28T21:54:03Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98995120283,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:54:03Z",
+            "started_at": "2026-08-28T21:54:03Z",
+            "completed_at": "2026-08-28T21:54:03Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98995122196,
+            "name": "check-links",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:54:04Z",
+            "started_at": "2026-08-28T21:54:04Z",
+            "completed_at": "2026-08-28T21:54:04Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33207541677,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "failure",
+        "created_at": "2026-08-28T20:16:45Z",
+        "run_started_at": "2026-08-28T20:16:45Z",
+        "updated_at": "2026-08-28T21:06:33Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972326077,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T21:05:04Z",
+            "completed_at": "2026-08-28T21:06:32Z",
+            "runner_name": "GitHub Actions 1000426919",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207541678,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:16:45Z",
+        "run_started_at": "2026-08-28T20:16:45Z",
+        "updated_at": "2026-08-28T21:18:57Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972326300,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T21:10:57Z",
+            "completed_at": "2026-08-28T21:18:56Z",
+            "runner_name": "GitHub Actions 1000426962",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972326521,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T21:11:28Z",
+            "completed_at": "2026-08-28T21:12:21Z",
+            "runner_name": "GitHub Actions 1000426965",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207541679,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:16:45Z",
+        "run_started_at": "2026-08-28T20:16:45Z",
+        "updated_at": "2026-08-28T21:16:41Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972326404,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T21:16:03Z",
+            "completed_at": "2026-08-28T21:16:40Z",
+            "runner_name": "GitHub Actions 1000427005",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207541682,
+        "name": "Catalog Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:16:45Z",
+        "run_started_at": "2026-08-28T20:16:45Z",
+        "updated_at": "2026-08-28T21:12:09Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972326337,
+            "name": "Notebook catalog drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T21:09:14Z",
+            "completed_at": "2026-08-28T21:12:09Z",
+            "runner_name": "GitHub Actions 1000426951",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207541694,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:16:45Z",
+        "run_started_at": "2026-08-28T20:16:45Z",
+        "updated_at": "2026-08-28T21:15:26Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972326290,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T21:15:17Z",
+            "completed_at": "2026-08-28T21:15:26Z",
+            "runner_name": "GitHub Actions 1000426999",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207541699,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:16:45Z",
+        "run_started_at": "2026-08-28T20:16:45Z",
+        "updated_at": "2026-08-28T21:18:37Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972326422,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T21:18:25Z",
+            "completed_at": "2026-08-28T21:18:36Z",
+            "runner_name": "GitHub Actions 1000427027",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207541706,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:16:45Z",
+        "run_started_at": "2026-08-28T22:13:21Z",
+        "updated_at": "2026-08-28T22:18:06Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972326378,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T21:07:16Z",
+            "completed_at": "2026-08-28T21:08:04Z",
+            "runner_name": "GitHub Actions 1000426941",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98999363008,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T22:13:22Z",
+            "started_at": "2026-08-28T22:16:45Z",
+            "completed_at": "2026-08-28T22:18:06Z",
+            "runner_name": "GitHub Actions 1000427430",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207541714,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:16:45Z",
+        "run_started_at": "2026-08-28T20:16:45Z",
+        "updated_at": "2026-08-28T20:16:57Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972328112,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T20:16:46Z",
+            "completed_at": "2026-08-28T20:16:46Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207541763,
+        "name": "prose-counts-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:16:45Z",
+        "run_started_at": "2026-08-28T20:16:45Z",
+        "updated_at": "2026-08-28T21:19:01Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972326638,
+            "name": "prose-counts",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T21:18:17Z",
+            "completed_at": "2026-08-28T21:19:00Z",
+            "runner_name": "GitHub Actions 1000427026",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207541774,
+        "name": "Quarto Pages Deploy",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:16:46Z",
+        "run_started_at": "2026-08-28T20:16:46Z",
+        "updated_at": "2026-08-28T21:26:09Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972326779,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T21:07:46Z",
+            "completed_at": "2026-08-28T21:26:08Z",
+            "runner_name": "GitHub Actions 1000426944",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972327818,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:16:46Z",
+            "started_at": "2026-08-28T20:16:46Z",
+            "completed_at": "2026-08-28T20:16:46Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972328147,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:16:47Z",
+            "started_at": "2026-08-28T20:16:47Z",
+            "completed_at": "2026-08-28T20:16:46Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207572281,
+        "name": "PR #13416",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:11Z",
+        "run_started_at": "2026-08-28T20:17:11Z",
+        "updated_at": "2026-08-28T21:25:08Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972438484,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:13Z",
+            "started_at": "2026-08-28T21:12:21Z",
+            "completed_at": "2026-08-28T21:16:34Z",
+            "runner_name": "GitHub Actions 1000426973",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972438623,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:13Z",
+            "started_at": "2026-08-28T21:14:30Z",
+            "completed_at": "2026-08-28T21:16:06Z",
+            "runner_name": "GitHub Actions 1000426993",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972438676,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:13Z",
+            "started_at": "2026-08-28T21:16:40Z",
+            "completed_at": "2026-08-28T21:18:12Z",
+            "runner_name": "GitHub Actions 1000427011",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972438760,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:13Z",
+            "started_at": "2026-08-28T21:18:40Z",
+            "completed_at": "2026-08-28T21:25:07Z",
+            "runner_name": "GitHub Actions 1000427031",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98991222729,
+            "name": "fast-lane (ombre): banner-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:25Z",
+            "started_at": "2026-08-28T21:36:25Z",
+            "completed_at": "2026-08-28T21:36:25Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991224102,
+            "name": "fast-lane (ombre): pip-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:26Z",
+            "started_at": "2026-08-28T21:36:26Z",
+            "completed_at": "2026-08-28T21:36:26Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991225542,
+            "name": "fast-lane (ombre): solution-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:26Z",
+            "started_at": "2026-08-28T21:36:26Z",
+            "completed_at": "2026-08-28T21:36:26Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991226968,
+            "name": "fast-lane (ombre): prose-counts-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:26Z",
+            "started_at": "2026-08-28T21:36:26Z",
+            "completed_at": "2026-08-28T21:36:26Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991228250,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:27Z",
+            "started_at": "2026-08-28T21:36:27Z",
+            "completed_at": "2026-08-28T21:36:27Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991229359,
+            "name": "fast-lane (ombre): bare-cross-dir-load-gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:27Z",
+            "started_at": "2026-08-28T21:36:27Z",
+            "completed_at": "2026-08-28T21:36:27Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991230604,
+            "name": "fast-lane (ombre): notebook-navlink-check",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:28Z",
+            "started_at": "2026-08-28T21:36:28Z",
+            "completed_at": "2026-08-28T21:36:28Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991231918,
+            "name": "fast-lane (ombre): notebook-interp-positioning-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:28Z",
+            "started_at": "2026-08-28T21:36:28Z",
+            "completed_at": "2026-08-28T21:36:28Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991233139,
+            "name": "fast-lane (ombre): markdown-rendering-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:28Z",
+            "started_at": "2026-08-28T21:36:28Z",
+            "completed_at": "2026-08-28T21:36:28Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991234453,
+            "name": "Exercice-solution HIGH delta guard (#8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:29Z",
+            "started_at": "2026-08-28T21:36:29Z",
+            "completed_at": "2026-08-28T21:36:29Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991236050,
+            "name": "Output-failure ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:29Z",
+            "started_at": "2026-08-28T21:36:29Z",
+            "completed_at": "2026-08-28T21:36:29Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991237596,
+            "name": "No fabricated text output in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:29Z",
+            "started_at": "2026-08-28T21:36:29Z",
+            "completed_at": "2026-08-28T21:36:29Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991239172,
+            "name": "No degenerate figure in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:30Z",
+            "started_at": "2026-08-28T21:36:30Z",
+            "completed_at": "2026-08-28T21:36:30Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991240576,
+            "name": "No SVG broken-geometry (negative-dim) defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:30Z",
+            "started_at": "2026-08-28T21:36:30Z",
+            "completed_at": "2026-08-28T21:36:30Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991241904,
+            "name": "No SVG decimal-comma defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:31Z",
+            "started_at": "2026-08-28T21:36:31Z",
+            "completed_at": "2026-08-28T21:36:31Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991243399,
+            "name": "No SVG empty-display defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:31Z",
+            "started_at": "2026-08-28T21:36:31Z",
+            "completed_at": "2026-08-28T21:36:31Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991244756,
+            "name": "No offscreen-flat SVG in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:32Z",
+            "started_at": "2026-08-28T21:36:32Z",
+            "completed_at": "2026-08-28T21:36:32Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991246068,
+            "name": "No markdown content loss in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:32Z",
+            "started_at": "2026-08-28T21:36:32Z",
+            "completed_at": "2026-08-28T21:36:32Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33207573922,
+        "name": "Validation Matrix",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:15:38Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972441919,
+            "name": "validate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:14:42Z",
+            "completed_at": "2026-08-28T21:15:37Z",
+            "runner_name": "GitHub Actions 1000426996",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207573958,
+        "name": "solution-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:11:26Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442395,
+            "name": "Solution-leak HIGH delta (WARN phase, #8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:10:33Z",
+            "completed_at": "2026-08-28T21:11:25Z",
+            "runner_name": "GitHub Actions 1000426959",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207573959,
+        "name": "Notebook Navlink Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:07:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972441584,
+            "name": "check-navlinks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:07:02Z",
+            "completed_at": "2026-08-28T21:07:50Z",
+            "runner_name": "GitHub Actions 1000426939",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207573980,
+        "name": "notebook-interp-positioning-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:23:25Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442474,
+            "name": "check_interp_positioning.py",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:22:34Z",
+            "completed_at": "2026-08-28T21:23:25Z",
+            "runner_name": "GitHub Actions 1000427049",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207573988,
+        "name": "markdown-rendering-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:22:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972441955,
+            "name": "markdown-rendering guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:21:45Z",
+            "completed_at": "2026-08-28T21:22:50Z",
+            "runner_name": "GitHub Actions 1000427046",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574001,
+        "name": "Notebook Cell Source Parses",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:27:16Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972441915,
+            "name": "cell-source-parses",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:26:05Z",
+            "completed_at": "2026-08-28T21:27:15Z",
+            "runner_name": "GitHub Actions 1000427063",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574011,
+        "name": "prose-counts-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:27:37Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972441982,
+            "name": "prose-counts",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:26:53Z",
+            "completed_at": "2026-08-28T21:27:36Z",
+            "runner_name": "GitHub Actions 1000427072",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574012,
+        "name": "Bare cross-dir",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:18:15Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972441510,
+            "name": "No bare cross-dir #load in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:17:28Z",
+            "completed_at": "2026-08-28T21:18:14Z",
+            "runner_name": "GitHub Actions 1000427018",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574018,
+        "name": "Translation Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:17:26Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972441872,
+            "name": "Translation drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:16:36Z",
+            "completed_at": "2026-08-28T21:17:25Z",
+            "runner_name": "GitHub Actions 1000427010",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574024,
+        "name": "Quarto Pages Deploy",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:26:03Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442152,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:06:31Z",
+            "completed_at": "2026-08-28T21:26:02Z",
+            "runner_name": "GitHub Actions 1000426933",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972443054,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T20:17:14Z",
+            "completed_at": "2026-08-28T20:17:13Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972443877,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T20:17:14Z",
+            "completed_at": "2026-08-28T20:17:14Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574031,
+        "name": "Notebook Validation",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:28:35Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442094,
+            "name": "validate-notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:24:13Z",
+            "completed_at": "2026-08-28T21:28:34Z",
+            "runner_name": "GitHub Actions 1000427057",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574060,
+        "name": "banner-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:15:11Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442332,
+            "name": "probeAddresses banner guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:14:23Z",
+            "completed_at": "2026-08-28T21:15:10Z",
+            "runner_name": "GitHub Actions 1000426991",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574064,
+        "name": "Cell-order gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:07:28Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442136,
+            "name": "No cell-ordering regression in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:06:38Z",
+            "completed_at": "2026-08-28T21:07:27Z",
+            "runner_name": "GitHub Actions 1000426935",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574072,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:36:35Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972441984,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:34:38Z",
+            "completed_at": "2026-08-28T21:36:34Z",
+            "runner_name": "GitHub Actions 1000427119",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574073,
+        "name": "MD Hierarchy Drift Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:13:37Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972441829,
+            "name": "scan_md_hierarchy drift (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:12:24Z",
+            "completed_at": "2026-08-28T21:13:36Z",
+            "runner_name": "GitHub Actions 1000426974",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574079,
+        "name": "Markdown claims anchored to previous output (advisory)",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:13:24Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442497,
+            "name": "Markdown claims anchored to previous output (#11435 advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:12:37Z",
+            "completed_at": "2026-08-28T21:13:23Z",
+            "runner_name": "GitHub Actions 1000426976",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574088,
+        "name": "Catalog Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:18:57Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442260,
+            "name": "Notebook catalog drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:15:51Z",
+            "completed_at": "2026-08-28T21:18:56Z",
+            "runner_name": "GitHub Actions 1000427004",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574090,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:46:57Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442326,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:17:24Z",
+            "completed_at": "2026-08-28T21:25:29Z",
+            "runner_name": "GitHub Actions 1000427017",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972442621,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:46:07Z",
+            "completed_at": "2026-08-28T21:46:56Z",
+            "runner_name": "GitHub Actions 1000427208",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574103,
+        "name": "Twin Parity Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:18:50Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442569,
+            "name": "Twin parity audit (#8057)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:15:18Z",
+            "completed_at": "2026-08-28T21:16:14Z",
+            "runner_name": "GitHub Actions 1000427000",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972442852,
+            "name": "Twin parity SHA mismatch (#9399 volet b, advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:17:59Z",
+            "completed_at": "2026-08-28T21:18:49Z",
+            "runner_name": "GitHub Actions 1000427023",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574110,
+        "name": "Notebook Exec Sequence Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:16:41Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442565,
+            "name": "Exec-sequence ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:15:48Z",
+            "completed_at": "2026-08-28T21:16:41Z",
+            "runner_name": "GitHub Actions 1000427003",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574112,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T22:20:57Z",
+        "updated_at": "2026-08-28T22:29:46Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442338,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:12:02Z",
+            "completed_at": "2026-08-28T21:40:49Z",
+            "runner_name": "GitHub Actions 1000426970",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 99000982408,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T22:20:58Z",
+            "started_at": "2026-08-28T22:28:22Z",
+            "completed_at": "2026-08-28T22:29:46Z",
+            "runner_name": "GitHub Actions 1000427502",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574120,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:45:27Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442403,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:44:47Z",
+            "completed_at": "2026-08-28T21:45:26Z",
+            "runner_name": "GitHub Actions 1000427198",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574132,
+        "name": "Notebook Execution Required",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T22:01:59Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972443173,
+            "name": "Golden-set execution (H.7 P3)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:20:50Z",
+            "completed_at": "2026-08-28T21:23:19Z",
+            "runner_name": "GitHub Actions 1000427040",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98972443263,
+            "name": "Detect notebook changes",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:37:40Z",
+            "completed_at": "2026-08-28T21:38:25Z",
+            "runner_name": "GitHub Actions 1000427143",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98991661742,
+            "name": "Static validation (H.1/H.3/C.1)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:38:25Z",
+            "started_at": "2026-08-28T22:01:08Z",
+            "completed_at": "2026-08-28T22:01:58Z",
+            "runner_name": "GitHub Actions 1000427324",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574133,
+        "name": "Notebook Papermill Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:14:00Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442343,
+            "name": "Papermill ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:13:00Z",
+            "completed_at": "2026-08-28T21:13:59Z",
+            "runner_name": "GitHub Actions 1000426979",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574140,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T20:17:15Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972445529,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T20:17:14Z",
+            "completed_at": "2026-08-28T20:17:14Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574154,
+        "name": "Consecutive Code Cells Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:17:41Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442489,
+            "name": "Consecutive code cells >= 2 advisory (label, non-blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:15:42Z",
+            "completed_at": "2026-08-28T21:17:40Z",
+            "runner_name": "GitHub Actions 1000427002",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574168,
+        "name": "pip-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:36:13Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972442789,
+            "name": "!pip install HIGH delta guard (#6314)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:35:23Z",
+            "completed_at": "2026-08-28T21:36:12Z",
+            "runner_name": "GitHub Actions 1000427126",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574178,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:45:18Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972443192,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:45:04Z",
+            "completed_at": "2026-08-28T21:45:17Z",
+            "runner_name": "GitHub Actions 1000427202",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33207574404,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:17:13Z",
+        "run_started_at": "2026-08-28T20:17:13Z",
+        "updated_at": "2026-08-28T21:41:59Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98972443776,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:17:14Z",
+            "started_at": "2026-08-28T21:41:47Z",
+            "completed_at": "2026-08-28T21:41:58Z",
+            "runner_name": "GitHub Actions 1000427177",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208024519,
+        "name": "PR #13417",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:31Z",
+        "run_started_at": "2026-08-28T20:23:31Z",
+        "updated_at": "2026-08-28T21:10:41Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98973993153,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:40Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98973993360,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:40Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98973993375,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:40Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98973993441,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:40Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025843,
+        "name": "Quarto Pages Deploy",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994093,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98973995338,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T20:23:32Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98973995934,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:23:33Z",
+            "started_at": "2026-08-28T20:23:33Z",
+            "completed_at": "2026-08-28T20:23:32Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025846,
+        "name": "banner-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973993659,
+            "name": "probeAddresses banner guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:42Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025848,
+        "name": "MD Hierarchy Drift Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:16:00Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973993577,
+            "name": "scan_md_hierarchy drift (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T21:14:40Z",
+            "completed_at": "2026-08-28T21:16:00Z",
+            "runner_name": "GitHub Actions 1000426995",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025858,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973993796,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025869,
+        "name": "Catalog Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994158,
+            "name": "Notebook catalog drift (read-only)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025871,
+        "name": "Notebook Navlink Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994130,
+            "name": "check-navlinks",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025877,
+        "name": "Notebook Papermill Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994409,
+            "name": "Papermill ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025887,
+        "name": "Markdown claims anchored to previous output (advisory)",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994671,
+            "name": "Markdown claims anchored to previous output (#11435 advisory)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025890,
+        "name": "Notebook Cell Source Parses",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994507,
+            "name": "cell-source-parses",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025891,
+        "name": "Twin Parity Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994389,
+            "name": "Twin parity audit (#8057)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98973994601,
+            "name": "Twin parity SHA mismatch (#9399 volet b, advisory)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025895,
+        "name": "markdown-rendering-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994193,
+            "name": "markdown-rendering guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025898,
+        "name": "Notebook Exec Sequence Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994609,
+            "name": "Exec-sequence ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025899,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994405,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025900,
+        "name": "pip-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994373,
+            "name": "!pip install HIGH delta guard (#6314)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025905,
+        "name": "prose-counts-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994261,
+            "name": "prose-counts",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025912,
+        "name": "Translation Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994050,
+            "name": "Translation drift (read-only)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025920,
+        "name": "solution-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994519,
+            "name": "Solution-leak HIGH delta (WARN phase, #8053)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025921,
+        "name": "notebook-interp-positioning-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994340,
+            "name": "check_interp_positioning.py",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025922,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994382,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:42Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025929,
+        "name": "Bare cross-dir",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994520,
+            "name": "No bare cross-dir #load in changed notebooks",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025933,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994226,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98973994487,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025938,
+        "name": "Notebook Execution Required",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994538,
+            "name": "Detect notebook changes",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98973994803,
+            "name": "Golden-set execution (H.7 P3)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98985270708,
+            "name": "Static validation (H.1/H.3/C.1)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T21:10:43Z",
+            "started_at": "2026-08-28T21:10:43Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025940,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:09:39Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973995269,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:09:38Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025943,
+        "name": "Cell-order gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994684,
+            "name": "No cell-ordering regression in changed notebooks",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025944,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T20:23:33Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973995233,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T20:23:32Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025949,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994249,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025951,
+        "name": "Validation Matrix",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994647,
+            "name": "validate",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025964,
+        "name": "Notebook Validation",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994234,
+            "name": "validate-notebooks",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:42Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208025982,
+        "name": "Consecutive Code Cells Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:23:32Z",
+        "run_started_at": "2026-08-28T20:23:32Z",
+        "updated_at": "2026-08-28T21:10:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98973994841,
+            "name": "Consecutive code cells >= 2 advisory (label, non-blocking)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:23:32Z",
+            "started_at": "2026-08-28T20:23:32Z",
+            "completed_at": "2026-08-28T21:10:43Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208049695,
+        "name": "PR #13418",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:52Z",
+        "run_started_at": "2026-08-28T20:23:52Z",
+        "updated_at": "2026-08-28T21:33:56Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974079389,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:53Z",
+            "started_at": "2026-08-28T21:27:39Z",
+            "completed_at": "2026-08-28T21:31:00Z",
+            "runner_name": "GitHub Actions 1000427077",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974079522,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:53Z",
+            "started_at": "2026-08-28T21:27:40Z",
+            "completed_at": "2026-08-28T21:33:36Z",
+            "runner_name": "GitHub Actions 1000427078",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974079573,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:53Z",
+            "started_at": "2026-08-28T21:32:23Z",
+            "completed_at": "2026-08-28T21:33:49Z",
+            "runner_name": "GitHub Actions 1000427102",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974079720,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:53Z",
+            "started_at": "2026-08-28T21:32:24Z",
+            "completed_at": "2026-08-28T21:33:55Z",
+            "runner_name": "GitHub Actions 1000427103",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98987693146,
+            "name": "fast-lane (ombre): banner-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:07Z",
+            "started_at": "2026-08-28T21:21:07Z",
+            "completed_at": "2026-08-28T21:21:07Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987695014,
+            "name": "fast-lane (ombre): pip-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:08Z",
+            "started_at": "2026-08-28T21:21:08Z",
+            "completed_at": "2026-08-28T21:21:08Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987696845,
+            "name": "fast-lane (ombre): solution-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:08Z",
+            "started_at": "2026-08-28T21:21:08Z",
+            "completed_at": "2026-08-28T21:21:08Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987698389,
+            "name": "fast-lane (ombre): prose-counts-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:08Z",
+            "started_at": "2026-08-28T21:21:08Z",
+            "completed_at": "2026-08-28T21:21:08Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987699900,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:09Z",
+            "started_at": "2026-08-28T21:21:09Z",
+            "completed_at": "2026-08-28T21:21:09Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987701781,
+            "name": "fast-lane (ombre): bare-cross-dir-load-gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:09Z",
+            "started_at": "2026-08-28T21:21:09Z",
+            "completed_at": "2026-08-28T21:21:09Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987703479,
+            "name": "fast-lane (ombre): notebook-navlink-check",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:10Z",
+            "started_at": "2026-08-28T21:21:10Z",
+            "completed_at": "2026-08-28T21:21:10Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987705665,
+            "name": "fast-lane (ombre): notebook-interp-positioning-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:10Z",
+            "started_at": "2026-08-28T21:21:10Z",
+            "completed_at": "2026-08-28T21:21:10Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987707344,
+            "name": "fast-lane (ombre): markdown-rendering-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:11Z",
+            "started_at": "2026-08-28T21:21:11Z",
+            "completed_at": "2026-08-28T21:21:11Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987709168,
+            "name": "Exercice-solution HIGH delta guard (#8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:11Z",
+            "started_at": "2026-08-28T21:21:11Z",
+            "completed_at": "2026-08-28T21:21:11Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987711008,
+            "name": "Output-failure ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:12Z",
+            "started_at": "2026-08-28T21:21:12Z",
+            "completed_at": "2026-08-28T21:21:12Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987712547,
+            "name": "No fabricated text output in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:12Z",
+            "started_at": "2026-08-28T21:21:12Z",
+            "completed_at": "2026-08-28T21:21:12Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987714353,
+            "name": "No degenerate figure in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:12Z",
+            "started_at": "2026-08-28T21:21:12Z",
+            "completed_at": "2026-08-28T21:21:12Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987715756,
+            "name": "No SVG broken-geometry (negative-dim) defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:13Z",
+            "started_at": "2026-08-28T21:21:13Z",
+            "completed_at": "2026-08-28T21:21:13Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987717392,
+            "name": "No SVG decimal-comma defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:13Z",
+            "started_at": "2026-08-28T21:21:13Z",
+            "completed_at": "2026-08-28T21:21:13Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987718863,
+            "name": "No SVG empty-display defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:14Z",
+            "started_at": "2026-08-28T21:21:14Z",
+            "completed_at": "2026-08-28T21:21:14Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987720392,
+            "name": "No offscreen-flat SVG in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:14Z",
+            "started_at": "2026-08-28T21:21:14Z",
+            "completed_at": "2026-08-28T21:21:14Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98987722027,
+            "name": "No markdown content loss in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:21:15Z",
+            "started_at": "2026-08-28T21:21:15Z",
+            "completed_at": "2026-08-28T21:21:15Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33208056788,
+        "name": "Cell-order gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:13:00Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101060,
+            "name": "No cell-ordering regression in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:12:09Z",
+            "completed_at": "2026-08-28T21:13:00Z",
+            "runner_name": "GitHub Actions 1000426971",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056795,
+        "name": "Markdown claims anchored to previous output (advisory)",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:26:32Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101255,
+            "name": "Markdown claims anchored to previous output (#11435 advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:25:44Z",
+            "completed_at": "2026-08-28T21:26:31Z",
+            "runner_name": "GitHub Actions 1000427062",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056821,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:21:20Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102813,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:19:26Z",
+            "completed_at": "2026-08-28T21:21:19Z",
+            "runner_name": "GitHub Actions 1000427037",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056823,
+        "name": "Consecutive Code Cells Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:40:09Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101493,
+            "name": "Consecutive code cells >= 2 advisory (label, non-blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:38:58Z",
+            "completed_at": "2026-08-28T21:40:08Z",
+            "runner_name": "GitHub Actions 1000427156",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056849,
+        "name": "MD Hierarchy Drift Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:15:46Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974100800,
+            "name": "scan_md_hierarchy drift (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:13:41Z",
+            "completed_at": "2026-08-28T21:15:45Z",
+            "runner_name": "GitHub Actions 1000426987",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056864,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T20:24:00Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974103456,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T20:23:59Z",
+            "completed_at": "2026-08-28T20:23:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056867,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:31:14Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101439,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:23:28Z",
+            "completed_at": "2026-08-28T21:31:13Z",
+            "runner_name": "GitHub Actions 1000427054",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974101725,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:25:32Z",
+            "completed_at": "2026-08-28T21:26:22Z",
+            "runner_name": "GitHub Actions 1000427061",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056873,
+        "name": "pip-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:13:38Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101313,
+            "name": "!pip install HIGH delta guard (#6314)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:12:48Z",
+            "completed_at": "2026-08-28T21:13:37Z",
+            "runner_name": "GitHub Actions 1000426978",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056878,
+        "name": "banner-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:37:01Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101395,
+            "name": "probeAddresses banner guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:36:16Z",
+            "completed_at": "2026-08-28T21:37:00Z",
+            "runner_name": "GitHub Actions 1000427133",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056879,
+        "name": "markdown-rendering-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:38:14Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102708,
+            "name": "markdown-rendering guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:37:12Z",
+            "completed_at": "2026-08-28T21:38:13Z",
+            "runner_name": "GitHub Actions 1000427139",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056891,
+        "name": "Notebook Execution Required",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T22:08:40Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101773,
+            "name": "Detect notebook changes",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:17:53Z",
+            "completed_at": "2026-08-28T21:18:35Z",
+            "runner_name": "GitHub Actions 1000427022",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974102154,
+            "name": "Golden-set execution (H.7 P3)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:34:53Z",
+            "completed_at": "2026-08-28T21:37:09Z",
+            "runner_name": "GitHub Actions 1000427122",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98987098795,
+            "name": "Static validation (H.1/H.3/C.1)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:18:35Z",
+            "started_at": "2026-08-28T22:07:48Z",
+            "completed_at": "2026-08-28T22:08:39Z",
+            "runner_name": "GitHub Actions 1000427370",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056898,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:34:06Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102065,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:33:27Z",
+            "completed_at": "2026-08-28T21:34:05Z",
+            "runner_name": "GitHub Actions 1000427107",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056906,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T22:20:59Z",
+        "updated_at": "2026-08-28T22:26:28Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102082,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:28:01Z",
+            "completed_at": "2026-08-28T21:56:54Z",
+            "runner_name": "GitHub Actions 1000427080",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 99000989226,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T22:21:00Z",
+            "started_at": "2026-08-28T22:25:10Z",
+            "completed_at": "2026-08-28T22:26:28Z",
+            "runner_name": "GitHub Actions 1000427486",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056907,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:35:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101744,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:35:20Z",
+            "completed_at": "2026-08-28T21:35:30Z",
+            "runner_name": "GitHub Actions 1000427125",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056917,
+        "name": "Notebook Navlink Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:13:24Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101676,
+            "name": "check-navlinks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:12:37Z",
+            "completed_at": "2026-08-28T21:13:24Z",
+            "runner_name": "GitHub Actions 1000426975",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056918,
+        "name": "Catalog Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:37:05Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102324,
+            "name": "Notebook catalog drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:34:13Z",
+            "completed_at": "2026-08-28T21:37:04Z",
+            "runner_name": "GitHub Actions 1000427116",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056929,
+        "name": "Notebook Papermill Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:32:05Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101692,
+            "name": "Papermill ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:31:12Z",
+            "completed_at": "2026-08-28T21:32:05Z",
+            "runner_name": "GitHub Actions 1000427097",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056931,
+        "name": "Validation Matrix",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:16:08Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974103042,
+            "name": "validate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:15:13Z",
+            "completed_at": "2026-08-28T21:16:07Z",
+            "runner_name": "GitHub Actions 1000426998",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056945,
+        "name": "Bare cross-dir",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:24:09Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974101788,
+            "name": "No bare cross-dir #load in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:23:22Z",
+            "completed_at": "2026-08-28T21:24:08Z",
+            "runner_name": "GitHub Actions 1000427053",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056954,
+        "name": "solution-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:44:48Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102607,
+            "name": "Solution-leak HIGH delta (WARN phase, #8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:43:50Z",
+            "completed_at": "2026-08-28T21:44:47Z",
+            "runner_name": "GitHub Actions 1000427191",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056960,
+        "name": "Notebook Validation",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:40:46Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102764,
+            "name": "validate-notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:36:14Z",
+            "completed_at": "2026-08-28T21:40:45Z",
+            "runner_name": "GitHub Actions 1000427132",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056985,
+        "name": "Notebook Exec Sequence Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:18:09Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102692,
+            "name": "Exec-sequence ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:17:20Z",
+            "completed_at": "2026-08-28T21:18:08Z",
+            "runner_name": "GitHub Actions 1000427016",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208056994,
+        "name": "Quarto Pages Deploy",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:37:39Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974103158,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:18:33Z",
+            "completed_at": "2026-08-28T21:37:38Z",
+            "runner_name": "GitHub Actions 1000427028",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974104334,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:24:00Z",
+            "started_at": "2026-08-28T20:24:00Z",
+            "completed_at": "2026-08-28T20:23:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974104737,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:24:00Z",
+            "started_at": "2026-08-28T20:24:00Z",
+            "completed_at": "2026-08-28T20:23:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208057000,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:18:22Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102642,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:18:11Z",
+            "completed_at": "2026-08-28T21:18:21Z",
+            "runner_name": "GitHub Actions 1000427024",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208057005,
+        "name": "notebook-interp-positioning-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:36:09Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102879,
+            "name": "check_interp_positioning.py",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:35:15Z",
+            "completed_at": "2026-08-28T21:36:08Z",
+            "runner_name": "GitHub Actions 1000427124",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208057035,
+        "name": "Notebook Cell Source Parses",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:17:18Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102957,
+            "name": "cell-source-parses",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:16:11Z",
+            "completed_at": "2026-08-28T21:17:17Z",
+            "runner_name": "GitHub Actions 1000427007",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208057047,
+        "name": "prose-counts-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:31:10Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102827,
+            "name": "prose-counts",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:30:21Z",
+            "completed_at": "2026-08-28T21:31:09Z",
+            "runner_name": "GitHub Actions 1000427092",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208057048,
+        "name": "Translation Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:29:35Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102842,
+            "name": "Translation drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:28:47Z",
+            "completed_at": "2026-08-28T21:29:34Z",
+            "runner_name": "GitHub Actions 1000427085",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208057054,
+        "name": "Twin Parity Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:23:58Z",
+        "run_started_at": "2026-08-28T20:23:58Z",
+        "updated_at": "2026-08-28T21:38:41Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974102570,
+            "name": "Twin parity audit (#8057)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:29:36Z",
+            "completed_at": "2026-08-28T21:30:33Z",
+            "runner_name": "GitHub Actions 1000427087",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974102706,
+            "name": "Twin parity SHA mismatch (#9399 volet b, advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:23:59Z",
+            "started_at": "2026-08-28T21:37:40Z",
+            "completed_at": "2026-08-28T21:38:40Z",
+            "runner_name": "GitHub Actions 1000427142",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208090373,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:24:25Z",
+        "run_started_at": "2026-08-28T20:24:25Z",
+        "updated_at": "2026-08-28T20:24:27Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974213949,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:24:26Z",
+            "started_at": "2026-08-28T20:24:26Z",
+            "completed_at": "2026-08-28T20:24:26Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974214481,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:24:26Z",
+            "started_at": "2026-08-28T20:24:26Z",
+            "completed_at": "2026-08-28T20:24:26Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974214854,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:24:26Z",
+            "started_at": "2026-08-28T20:24:26Z",
+            "completed_at": "2026-08-28T20:24:26Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974242820,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:24:33Z",
+            "started_at": "2026-08-28T20:24:33Z",
+            "completed_at": "2026-08-28T20:24:26Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974243157,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:24:33Z",
+            "started_at": "2026-08-28T20:24:33Z",
+            "completed_at": "2026-08-28T20:24:26Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974244660,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:24:33Z",
+            "started_at": "2026-08-28T20:24:33Z",
+            "completed_at": "2026-08-28T20:24:26Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974253030,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:24:36Z",
+            "started_at": "2026-08-28T20:24:36Z",
+            "completed_at": "2026-08-28T20:24:26Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208104302,
+        "name": "PR #13196",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:24:37Z",
+        "run_started_at": "2026-08-28T20:24:37Z",
+        "updated_at": "2026-08-28T21:46:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974264725,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:39Z",
+            "started_at": "2026-08-28T21:35:42Z",
+            "completed_at": "2026-08-28T21:41:44Z",
+            "runner_name": "GitHub Actions 1000427129",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974264972,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:39Z",
+            "started_at": "2026-08-28T21:35:41Z",
+            "completed_at": "2026-08-28T21:39:09Z",
+            "runner_name": "GitHub Actions 1000427130",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974265005,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:39Z",
+            "started_at": "2026-08-28T21:36:11Z",
+            "completed_at": "2026-08-28T21:37:39Z",
+            "runner_name": "GitHub Actions 1000427131",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974265060,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:39Z",
+            "started_at": "2026-08-28T21:45:00Z",
+            "completed_at": "2026-08-28T21:46:30Z",
+            "runner_name": "GitHub Actions 1000427200",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98986873268,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:17:37Z",
+            "started_at": "2026-08-28T21:17:37Z",
+            "completed_at": "2026-08-28T21:17:37Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98986874655,
+            "name": "fast-lane (ombre): self-hosted-runner-policy",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:17:37Z",
+            "started_at": "2026-08-28T21:17:37Z",
+            "completed_at": "2026-08-28T21:17:37Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33208106895,
+        "name": "Scripts & Notebook-Tools Tests",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T21:35:17Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974270274,
+            "name": "Scripts Tests (CPU)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:15:02Z",
+            "completed_at": "2026-08-28T21:35:17Z",
+            "runner_name": "GitHub Actions 1000426997",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208106903,
+        "name": "Unique Check-Run Names Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T21:35:18Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974269989,
+            "name": "Require unique rendered check-run names across PR workflows (#11869)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:35:10Z",
+            "completed_at": "2026-08-28T21:35:17Z",
+            "runner_name": "GitHub Actions 1000427123",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208106905,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "failure",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T21:35:39Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974270346,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:18:58Z",
+            "completed_at": "2026-08-28T21:35:38Z",
+            "runner_name": "GitHub Actions 1000427034",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208106909,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T20:24:41Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974271986,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T20:24:40Z",
+            "completed_at": "2026-08-28T20:24:40Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208106911,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T21:23:02Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974270732,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:22:53Z",
+            "completed_at": "2026-08-28T21:23:01Z",
+            "runner_name": "GitHub Actions 1000427050",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208106925,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T21:58:09Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974270377,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:50:11Z",
+            "completed_at": "2026-08-28T21:58:08Z",
+            "runner_name": "GitHub Actions 1000427239",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974270589,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:52:25Z",
+            "completed_at": "2026-08-28T21:53:16Z",
+            "runner_name": "GitHub Actions 1000427258",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208106929,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T21:37:24Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974270669,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:37:13Z",
+            "completed_at": "2026-08-28T21:37:23Z",
+            "runner_name": "GitHub Actions 1000427140",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208106930,
+        "name": "Workflow Label-Paths Coverage Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T21:17:05Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974270541,
+            "name": "Label-poser workflows self-cover (blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:16:17Z",
+            "completed_at": "2026-08-28T21:17:04Z",
+            "runner_name": "GitHub Actions 1000427008",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208106967,
+        "name": "Bash Syntax Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T21:38:15Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974270824,
+            "name": "bash -n every scripts .sh (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:32:07Z",
+            "completed_at": "2026-08-28T21:32:48Z",
+            "runner_name": "GitHub Actions 1000427099",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974270975,
+            "name": "Shebang + dry-run advisory (non-blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:37:25Z",
+            "completed_at": "2026-08-28T21:38:14Z",
+            "runner_name": "GitHub Actions 1000427141",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208106979,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T21:17:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974270738,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:16:10Z",
+            "completed_at": "2026-08-28T21:17:42Z",
+            "runner_name": "GitHub Actions 1000427006",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208107029,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:24:39Z",
+        "run_started_at": "2026-08-28T20:24:39Z",
+        "updated_at": "2026-08-28T21:34:19Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13196
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974271458,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:24:40Z",
+            "started_at": "2026-08-28T21:33:39Z",
+            "completed_at": "2026-08-28T21:34:19Z",
+            "runner_name": "GitHub Actions 1000427108",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208129833,
+        "name": "PR #13008",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:24:58Z",
+        "run_started_at": "2026-08-28T20:24:58Z",
+        "updated_at": "2026-08-28T21:50:59Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98974351390,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:00Z",
+            "started_at": "2026-08-28T21:42:08Z",
+            "completed_at": "2026-08-28T21:46:13Z",
+            "runner_name": "GitHub Actions 1000427180",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974351624,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:00Z",
+            "started_at": "2026-08-28T21:43:56Z",
+            "completed_at": "2026-08-28T21:50:10Z",
+            "runner_name": "GitHub Actions 1000427192",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974351685,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:00Z",
+            "started_at": "2026-08-28T21:47:23Z",
+            "completed_at": "2026-08-28T21:48:48Z",
+            "runner_name": "GitHub Actions 1000427217",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974351731,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:00Z",
+            "started_at": "2026-08-28T21:49:21Z",
+            "completed_at": "2026-08-28T21:50:58Z",
+            "runner_name": "GitHub Actions 1000427235",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98992067308,
+            "name": "fast-lane (ombre): banner-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:17Z",
+            "started_at": "2026-08-28T21:40:17Z",
+            "completed_at": "2026-08-28T21:40:17Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992069202,
+            "name": "fast-lane (ombre): pip-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:17Z",
+            "started_at": "2026-08-28T21:40:17Z",
+            "completed_at": "2026-08-28T21:40:17Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992071306,
+            "name": "fast-lane (ombre): solution-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:18Z",
+            "started_at": "2026-08-28T21:40:18Z",
+            "completed_at": "2026-08-28T21:40:18Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992073417,
+            "name": "fast-lane (ombre): prose-counts-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:18Z",
+            "started_at": "2026-08-28T21:40:18Z",
+            "completed_at": "2026-08-28T21:40:18Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992075632,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:19Z",
+            "started_at": "2026-08-28T21:40:19Z",
+            "completed_at": "2026-08-28T21:40:19Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992077720,
+            "name": "fast-lane (ombre): bare-cross-dir-load-gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:19Z",
+            "started_at": "2026-08-28T21:40:19Z",
+            "completed_at": "2026-08-28T21:40:19Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992079454,
+            "name": "fast-lane (ombre): notebook-navlink-check",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:20Z",
+            "started_at": "2026-08-28T21:40:20Z",
+            "completed_at": "2026-08-28T21:40:20Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992081266,
+            "name": "fast-lane (ombre): notebook-interp-positioning-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:20Z",
+            "started_at": "2026-08-28T21:40:20Z",
+            "completed_at": "2026-08-28T21:40:20Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992082812,
+            "name": "fast-lane (ombre): markdown-rendering-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:21Z",
+            "started_at": "2026-08-28T21:40:21Z",
+            "completed_at": "2026-08-28T21:40:21Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992084444,
+            "name": "check-links",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:21Z",
+            "started_at": "2026-08-28T21:40:21Z",
+            "completed_at": "2026-08-28T21:40:21Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992086135,
+            "name": "Exercice-solution HIGH delta guard (#8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:22Z",
+            "started_at": "2026-08-28T21:40:22Z",
+            "completed_at": "2026-08-28T21:40:22Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992087672,
+            "name": "Output-failure ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:22Z",
+            "started_at": "2026-08-28T21:40:22Z",
+            "completed_at": "2026-08-28T21:40:22Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992089201,
+            "name": "No fabricated text output in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:23Z",
+            "started_at": "2026-08-28T21:40:23Z",
+            "completed_at": "2026-08-28T21:40:23Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992090914,
+            "name": "No degenerate figure in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:23Z",
+            "started_at": "2026-08-28T21:40:23Z",
+            "completed_at": "2026-08-28T21:40:23Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992092989,
+            "name": "No SVG broken-geometry (negative-dim) defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:24Z",
+            "started_at": "2026-08-28T21:40:24Z",
+            "completed_at": "2026-08-28T21:40:24Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992094946,
+            "name": "No SVG decimal-comma defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:24Z",
+            "started_at": "2026-08-28T21:40:24Z",
+            "completed_at": "2026-08-28T21:40:24Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992096727,
+            "name": "No SVG empty-display defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:25Z",
+            "started_at": "2026-08-28T21:40:25Z",
+            "completed_at": "2026-08-28T21:40:25Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992098775,
+            "name": "No offscreen-flat SVG in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:25Z",
+            "started_at": "2026-08-28T21:40:25Z",
+            "completed_at": "2026-08-28T21:40:25Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98992101157,
+            "name": "No markdown content loss in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:40:26Z",
+            "started_at": "2026-08-28T21:40:26Z",
+            "completed_at": "2026-08-28T21:40:26Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33208133314,
+        "name": "Markdown claims anchored to previous output (advisory)",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:37:54Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360182,
+            "name": "Markdown claims anchored to previous output (#11435 advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:37:04Z",
+            "completed_at": "2026-08-28T21:37:53Z",
+            "runner_name": "GitHub Actions 1000427136",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133316,
+        "name": "Notebook Validation",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:25:41Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360356,
+            "name": "validate-notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:21:15Z",
+            "completed_at": "2026-08-28T21:25:40Z",
+            "runner_name": "GitHub Actions 1000427043",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133340,
+        "name": "pip-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:28:50Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360034,
+            "name": "!pip install HIGH delta guard (#6314)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:27:51Z",
+            "completed_at": "2026-08-28T21:28:49Z",
+            "runner_name": "GitHub Actions 1000427079",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133341,
+        "name": "Quarto Pages Deploy",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:53:52Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360471,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:37:43Z",
+            "completed_at": "2026-08-28T21:53:51Z",
+            "runner_name": "GitHub Actions 1000427144",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974361490,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T20:25:02Z",
+            "completed_at": "2026-08-28T20:25:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974362249,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T20:25:02Z",
+            "completed_at": "2026-08-28T20:25:02Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133350,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:29:33Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360121,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:21:36Z",
+            "completed_at": "2026-08-28T21:29:32Z",
+            "runner_name": "GitHub Actions 1000427045",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974360310,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:24:09Z",
+            "completed_at": "2026-08-28T21:24:59Z",
+            "runner_name": "GitHub Actions 1000427056",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133352,
+        "name": "Notebook Cell Source Parses",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:22:19Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360396,
+            "name": "cell-source-parses",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:20:55Z",
+            "completed_at": "2026-08-28T21:22:18Z",
+            "runner_name": "GitHub Actions 1000427041",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133375,
+        "name": "Notebook Execution Required",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T22:16:16Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360554,
+            "name": "Detect notebook changes",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:48:15Z",
+            "completed_at": "2026-08-28T21:49:05Z",
+            "runner_name": "GitHub Actions 1000427225",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974360763,
+            "name": "Golden-set execution (H.7 P3)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:54:58Z",
+            "completed_at": "2026-08-28T21:57:21Z",
+            "runner_name": "GitHub Actions 1000427281",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98994020552,
+            "name": "Static validation (H.1/H.3/C.1)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:49:05Z",
+            "started_at": "2026-08-28T22:15:19Z",
+            "completed_at": "2026-08-28T22:16:15Z",
+            "runner_name": "GitHub Actions 1000427422",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133385,
+        "name": "notebook-interp-positioning-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:51:23Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360252,
+            "name": "check_interp_positioning.py",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:50:27Z",
+            "completed_at": "2026-08-28T21:51:22Z",
+            "runner_name": "GitHub Actions 1000427241",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133387,
+        "name": "MD Hierarchy Drift Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:35:13Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360198,
+            "name": "scan_md_hierarchy drift (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:34:08Z",
+            "completed_at": "2026-08-28T21:35:12Z",
+            "runner_name": "GitHub Actions 1000427114",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133388,
+        "name": "Catalog Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:41:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360616,
+            "name": "Notebook catalog drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:38:27Z",
+            "completed_at": "2026-08-28T21:41:30Z",
+            "runner_name": "GitHub Actions 1000427152",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133399,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:34:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974361005,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:34:09Z",
+            "completed_at": "2026-08-28T21:34:51Z",
+            "runner_name": "GitHub Actions 1000427115",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133405,
+        "name": "Notebook Navlink Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:40:56Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360750,
+            "name": "check-navlinks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:40:09Z",
+            "completed_at": "2026-08-28T21:40:55Z",
+            "runner_name": "GitHub Actions 1000427164",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133409,
+        "name": "solution-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:27:12Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360726,
+            "name": "Solution-leak HIGH delta (WARN phase, #8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:26:25Z",
+            "completed_at": "2026-08-28T21:27:11Z",
+            "runner_name": "GitHub Actions 1000427067",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133414,
+        "name": "banner-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:19:49Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360401,
+            "name": "probeAddresses banner guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:18:59Z",
+            "completed_at": "2026-08-28T21:19:48Z",
+            "runner_name": "GitHub Actions 1000427035",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133416,
+        "name": "Cell-order gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:19:23Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360159,
+            "name": "No cell-ordering regression in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:18:36Z",
+            "completed_at": "2026-08-28T21:19:22Z",
+            "runner_name": "GitHub Actions 1000427029",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133417,
+        "name": "Translation Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:33:24Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360418,
+            "name": "Translation drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:32:27Z",
+            "completed_at": "2026-08-28T21:33:24Z",
+            "runner_name": "GitHub Actions 1000427104",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133428,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T20:25:10Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974362338,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T20:25:02Z",
+            "completed_at": "2026-08-28T20:25:02Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133452,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:26:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974361973,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:26:35Z",
+            "completed_at": "2026-08-28T21:26:43Z",
+            "runner_name": "GitHub Actions 1000427068",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133468,
+        "name": "Consecutive Code Cells Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:39:19Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360778,
+            "name": "Consecutive code cells >= 2 advisory (label, non-blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:38:16Z",
+            "completed_at": "2026-08-28T21:39:18Z",
+            "runner_name": "GitHub Actions 1000427149",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133469,
+        "name": "Twin Parity Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:28:25Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360905,
+            "name": "Twin parity SHA mismatch (#9399 volet b, advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:22:56Z",
+            "completed_at": "2026-08-28T21:23:51Z",
+            "runner_name": "GitHub Actions 1000427051",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98974361240,
+            "name": "Twin parity audit (#8057)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:27:19Z",
+            "completed_at": "2026-08-28T21:28:24Z",
+            "runner_name": "GitHub Actions 1000427075",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133474,
+        "name": "Bare cross-dir",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:37:50Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360981,
+            "name": "No bare cross-dir #load in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:37:05Z",
+            "completed_at": "2026-08-28T21:37:50Z",
+            "runner_name": "GitHub Actions 1000427138",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133501,
+        "name": "Notebook Papermill Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:44:59Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974360745,
+            "name": "Papermill ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:44:07Z",
+            "completed_at": "2026-08-28T21:44:58Z",
+            "runner_name": "GitHub Actions 1000427193",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133506,
+        "name": "Notebook Exec Sequence Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:37:10Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974361066,
+            "name": "Exec-sequence ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:36:23Z",
+            "completed_at": "2026-08-28T21:37:09Z",
+            "runner_name": "GitHub Actions 1000427134",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133566,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:41:09Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974361278,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:40:57Z",
+            "completed_at": "2026-08-28T21:41:08Z",
+            "runner_name": "GitHub Actions 1000427170",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133575,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:40:32Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974361345,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:38:21Z",
+            "completed_at": "2026-08-28T21:40:30Z",
+            "runner_name": "GitHub Actions 1000427151",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133581,
+        "name": "Validation Matrix",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:26:04Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974361488,
+            "name": "validate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:25:10Z",
+            "completed_at": "2026-08-28T21:26:03Z",
+            "runner_name": "GitHub Actions 1000427060",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133616,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T22:20:48Z",
+        "updated_at": "2026-08-28T22:22:52Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974361498,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:19:03Z",
+            "completed_at": "2026-08-28T21:48:09Z",
+            "runner_name": "GitHub Actions 1000427036",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 99000951995,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T22:20:49Z",
+            "started_at": "2026-08-28T22:21:34Z",
+            "completed_at": "2026-08-28T22:22:51Z",
+            "runner_name": "GitHub Actions 1000427468",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133619,
+        "name": "prose-counts-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:30:26Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974361917,
+            "name": "prose-counts",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:29:38Z",
+            "completed_at": "2026-08-28T21:30:25Z",
+            "runner_name": "GitHub Actions 1000427088",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208133661,
+        "name": "markdown-rendering-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:25:01Z",
+        "run_started_at": "2026-08-28T20:25:01Z",
+        "updated_at": "2026-08-28T21:32:23Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13008
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98974361567,
+            "name": "markdown-rendering guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:25:02Z",
+            "started_at": "2026-08-28T21:31:16Z",
+            "completed_at": "2026-08-28T21:32:22Z",
+            "runner_name": "GitHub Actions 1000427098",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208450630,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:29:30Z",
+        "run_started_at": "2026-08-28T20:29:30Z",
+        "updated_at": "2026-08-28T20:29:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98975445969,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:31Z",
+            "started_at": "2026-08-28T20:29:31Z",
+            "completed_at": "2026-08-28T20:29:30Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975446423,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:31Z",
+            "started_at": "2026-08-28T20:29:31Z",
+            "completed_at": "2026-08-28T20:29:30Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975471318,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:37Z",
+            "started_at": "2026-08-28T20:29:37Z",
+            "completed_at": "2026-08-28T20:29:30Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975476324,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:38Z",
+            "started_at": "2026-08-28T20:29:38Z",
+            "completed_at": "2026-08-28T20:29:30Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975476987,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:39Z",
+            "started_at": "2026-08-28T20:29:39Z",
+            "completed_at": "2026-08-28T20:29:30Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975477191,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:39Z",
+            "started_at": "2026-08-28T20:29:39Z",
+            "completed_at": "2026-08-28T20:29:30Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975482754,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:40Z",
+            "started_at": "2026-08-28T20:29:40Z",
+            "completed_at": "2026-08-28T20:29:30Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208453591,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:29:32Z",
+        "run_started_at": "2026-08-28T20:29:32Z",
+        "updated_at": "2026-08-28T20:29:41Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98975455876,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:33Z",
+            "started_at": "2026-08-28T20:29:33Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975456031,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:33Z",
+            "started_at": "2026-08-28T20:29:33Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975456282,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:33Z",
+            "started_at": "2026-08-28T20:29:33Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975456500,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:33Z",
+            "started_at": "2026-08-28T20:29:33Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975488392,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:41Z",
+            "started_at": "2026-08-28T20:29:41Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975494758,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:43Z",
+            "started_at": "2026-08-28T20:29:43Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975494818,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:43Z",
+            "started_at": "2026-08-28T20:29:43Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208453899,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:29:33Z",
+        "run_started_at": "2026-08-28T20:29:33Z",
+        "updated_at": "2026-08-28T20:29:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98975456743,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:33Z",
+            "started_at": "2026-08-28T20:29:33Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975456926,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:33Z",
+            "started_at": "2026-08-28T20:29:33Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975457461,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:34Z",
+            "started_at": "2026-08-28T20:29:34Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975478443,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:39Z",
+            "started_at": "2026-08-28T20:29:39Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975482435,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:40Z",
+            "started_at": "2026-08-28T20:29:40Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975487729,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:41Z",
+            "started_at": "2026-08-28T20:29:41Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975487841,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:41Z",
+            "started_at": "2026-08-28T20:29:41Z",
+            "completed_at": "2026-08-28T20:29:33Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208456261,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:29:35Z",
+        "run_started_at": "2026-08-28T20:29:35Z",
+        "updated_at": "2026-08-28T20:29:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98975465683,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:36Z",
+            "started_at": "2026-08-28T20:29:36Z",
+            "completed_at": "2026-08-28T20:29:35Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975466016,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:36Z",
+            "started_at": "2026-08-28T20:29:36Z",
+            "completed_at": "2026-08-28T20:29:35Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975466382,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:36Z",
+            "started_at": "2026-08-28T20:29:36Z",
+            "completed_at": "2026-08-28T20:29:35Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975494364,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:43Z",
+            "started_at": "2026-08-28T20:29:43Z",
+            "completed_at": "2026-08-28T20:29:35Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975503135,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:45Z",
+            "started_at": "2026-08-28T20:29:45Z",
+            "completed_at": "2026-08-28T20:29:35Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975503209,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:45Z",
+            "started_at": "2026-08-28T20:29:45Z",
+            "completed_at": "2026-08-28T20:29:35Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975504747,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:46Z",
+            "started_at": "2026-08-28T20:29:46Z",
+            "completed_at": "2026-08-28T20:29:35Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208456813,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:29:35Z",
+        "run_started_at": "2026-08-28T20:29:35Z",
+        "updated_at": "2026-08-28T20:29:37Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98975466676,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:36Z",
+            "started_at": "2026-08-28T20:29:36Z",
+            "completed_at": "2026-08-28T20:29:36Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975466985,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:36Z",
+            "started_at": "2026-08-28T20:29:36Z",
+            "completed_at": "2026-08-28T20:29:36Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975467342,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:36Z",
+            "started_at": "2026-08-28T20:29:36Z",
+            "completed_at": "2026-08-28T20:29:36Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975487983,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:41Z",
+            "started_at": "2026-08-28T20:29:41Z",
+            "completed_at": "2026-08-28T20:29:36Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975495425,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:43Z",
+            "started_at": "2026-08-28T20:29:43Z",
+            "completed_at": "2026-08-28T20:29:36Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975496134,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:43Z",
+            "started_at": "2026-08-28T20:29:43Z",
+            "completed_at": "2026-08-28T20:29:36Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98975503972,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:29:45Z",
+            "started_at": "2026-08-28T20:29:45Z",
+            "completed_at": "2026-08-28T20:29:36Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208727027,
+        "name": "Always-on guards",
+        "event": "pull_request_review",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:33:16Z",
+        "run_started_at": "2026-08-28T20:33:16Z",
+        "updated_at": "2026-08-28T21:24:47Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13417
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98976362363,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:33:17Z",
+            "started_at": "2026-08-28T21:23:54Z",
+            "completed_at": "2026-08-28T21:24:46Z",
+            "runner_name": "GitHub Actions 1000427055",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33208834285,
+        "name": "PR gate sweep health advisory",
+        "event": "schedule",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:34:47Z",
+        "run_started_at": "2026-08-28T20:34:47Z",
+        "updated_at": "2026-08-28T21:22:32Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98976723086,
+            "name": "PR gate sweep health advisory",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:34:48Z",
+            "started_at": "2026-08-28T21:22:27Z",
+            "completed_at": "2026-08-28T21:22:32Z",
+            "runner_name": "GitHub Actions 1000427048",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209386672,
+        "name": "Always-on guards",
+        "event": "pull_request_review",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:42:36Z",
+        "run_started_at": "2026-08-28T20:42:36Z",
+        "updated_at": "2026-08-28T21:51:25Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98978567541,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:42:36Z",
+            "started_at": "2026-08-28T21:50:33Z",
+            "completed_at": "2026-08-28T21:51:24Z",
+            "runner_name": "GitHub Actions 1000427243",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209450588,
+        "name": "Always-on guards",
+        "event": "pull_request_review",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:43:31Z",
+        "run_started_at": "2026-08-28T20:43:31Z",
+        "updated_at": "2026-08-28T21:43:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13413
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98978781699,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:43:31Z",
+            "started_at": "2026-08-28T21:42:56Z",
+            "completed_at": "2026-08-28T21:43:43Z",
+            "runner_name": "GitHub Actions 1000427185",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209470674,
+        "name": "PR #13419",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:43:48Z",
+        "run_started_at": "2026-08-28T20:43:48Z",
+        "updated_at": "2026-08-28T21:43:53Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98978852069,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:43:49Z",
+            "started_at": "2026-08-28T21:28:37Z",
+            "completed_at": "2026-08-28T21:30:13Z",
+            "runner_name": "GitHub Actions 1000427083",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98978852241,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:43:49Z",
+            "started_at": "2026-08-28T21:32:11Z",
+            "completed_at": "2026-08-28T21:38:17Z",
+            "runner_name": "GitHub Actions 1000427101",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98978852299,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:43:49Z",
+            "started_at": "2026-08-28T21:39:04Z",
+            "completed_at": "2026-08-28T21:43:17Z",
+            "runner_name": "GitHub Actions 1000427157",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98978852314,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:43:49Z",
+            "started_at": "2026-08-28T21:42:28Z",
+            "completed_at": "2026-08-28T21:43:53Z",
+            "runner_name": "GitHub Actions 1000427183",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209472365,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:43:49Z",
+        "run_started_at": "2026-08-28T20:43:49Z",
+        "updated_at": "2026-08-28T20:44:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98978855267,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:44:50Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209472370,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:43:49Z",
+        "run_started_at": "2026-08-28T20:43:49Z",
+        "updated_at": "2026-08-28T20:44:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98978854979,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:44:50Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209472419,
+        "name": "Scripts & Notebook-Tools Tests",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:43:49Z",
+        "run_started_at": "2026-08-28T20:43:49Z",
+        "updated_at": "2026-08-28T20:44:58Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98978855249,
+            "name": "Scripts Tests (CPU)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:44:50Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209472432,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:43:49Z",
+        "run_started_at": "2026-08-28T20:43:49Z",
+        "updated_at": "2026-08-28T20:43:50Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98978857057,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:43:50Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209472447,
+        "name": "Bash Syntax Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:43:49Z",
+        "run_started_at": "2026-08-28T20:43:49Z",
+        "updated_at": "2026-08-28T20:44:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98978855607,
+            "name": "Shebang + dry-run advisory (non-blocking)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:44:50Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98978855880,
+            "name": "bash -n every scripts .sh (advisory)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:44:50Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209472460,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:43:49Z",
+        "run_started_at": "2026-08-28T20:43:49Z",
+        "updated_at": "2026-08-28T20:44:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98978855699,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:44:50Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98978855962,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:44:50Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209472467,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:43:49Z",
+        "run_started_at": "2026-08-28T20:43:49Z",
+        "updated_at": "2026-08-28T20:44:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98978855466,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:44:50Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209472477,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:43:49Z",
+        "run_started_at": "2026-08-28T20:43:49Z",
+        "updated_at": "2026-08-28T20:44:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98978855629,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:44:50Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209472606,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:43:49Z",
+        "run_started_at": "2026-08-28T20:43:49Z",
+        "updated_at": "2026-08-28T20:44:52Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98978856254,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:43:50Z",
+            "started_at": "2026-08-28T20:43:50Z",
+            "completed_at": "2026-08-28T20:44:51Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209542030,
+        "name": "PR #13419",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:44:47Z",
+        "run_started_at": "2026-08-28T20:44:47Z",
+        "updated_at": "2026-08-28T22:18:36Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98979083989,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:48Z",
+            "started_at": "2026-08-28T21:43:18Z",
+            "completed_at": "2026-08-28T21:44:39Z",
+            "runner_name": "GitHub Actions 1000427188",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98979084148,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:48Z",
+            "started_at": "2026-08-28T21:52:52Z",
+            "completed_at": "2026-08-28T21:56:51Z",
+            "runner_name": "GitHub Actions 1000427264",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98979084153,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:48Z",
+            "started_at": "2026-08-28T22:11:56Z",
+            "completed_at": "2026-08-28T22:18:35Z",
+            "runner_name": "GitHub Actions 1000427391",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98979084163,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:48Z",
+            "started_at": "2026-08-28T21:50:26Z",
+            "completed_at": "2026-08-28T21:52:03Z",
+            "runner_name": "GitHub Actions 1000427240",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98989429279,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:28:33Z",
+            "started_at": "2026-08-28T21:28:33Z",
+            "completed_at": "2026-08-28T21:28:33Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33209545185,
+        "name": "Bash Syntax Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:44:50Z",
+        "run_started_at": "2026-08-28T20:44:50Z",
+        "updated_at": "2026-08-28T21:37:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979095462,
+            "name": "bash -n every scripts .sh (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T21:28:52Z",
+            "completed_at": "2026-08-28T21:29:36Z",
+            "runner_name": "GitHub Actions 1000427086",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98979095675,
+            "name": "Shebang + dry-run advisory (non-blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T21:37:02Z",
+            "completed_at": "2026-08-28T21:37:43Z",
+            "runner_name": "GitHub Actions 1000427137",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209545234,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:44:50Z",
+        "run_started_at": "2026-08-28T20:44:50Z",
+        "updated_at": "2026-08-28T20:45:01Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979094138,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T20:44:51Z",
+            "completed_at": "2026-08-28T20:44:54Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209545261,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:44:50Z",
+        "run_started_at": "2026-08-28T20:44:50Z",
+        "updated_at": "2026-08-28T21:37:42Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979095386,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T21:28:41Z",
+            "completed_at": "2026-08-28T21:37:41Z",
+            "runner_name": "GitHub Actions 1000427084",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98979095528,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T21:27:11Z",
+            "completed_at": "2026-08-28T21:27:58Z",
+            "runner_name": "GitHub Actions 1000427073",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209545273,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:44:50Z",
+        "run_started_at": "2026-08-28T20:44:50Z",
+        "updated_at": "2026-08-28T20:44:52Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979096285,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T20:44:51Z",
+            "completed_at": "2026-08-28T20:44:51Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209545293,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:44:50Z",
+        "run_started_at": "2026-08-28T20:44:50Z",
+        "updated_at": "2026-08-28T21:47:53Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979096397,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T21:47:13Z",
+            "completed_at": "2026-08-28T21:47:52Z",
+            "runner_name": "GitHub Actions 1000427216",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209545299,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "failure",
+        "created_at": "2026-08-28T20:44:50Z",
+        "run_started_at": "2026-08-28T20:44:50Z",
+        "updated_at": "2026-08-28T22:10:56Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979095156,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T21:42:00Z",
+            "completed_at": "2026-08-28T22:10:55Z",
+            "runner_name": "GitHub Actions 1000427179",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209545321,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:44:50Z",
+        "run_started_at": "2026-08-28T20:44:50Z",
+        "updated_at": "2026-08-28T21:32:21Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979095705,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T21:32:09Z",
+            "completed_at": "2026-08-28T21:32:20Z",
+            "runner_name": "GitHub Actions 1000427100",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209545347,
+        "name": "Scripts & Notebook-Tools Tests",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:44:50Z",
+        "run_started_at": "2026-08-28T20:44:50Z",
+        "updated_at": "2026-08-28T21:50:27Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979094930,
+            "name": "Scripts Tests (CPU)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T21:44:49Z",
+            "completed_at": "2026-08-28T21:50:27Z",
+            "runner_name": "GitHub Actions 1000427199",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209545360,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:44:50Z",
+        "run_started_at": "2026-08-28T20:44:50Z",
+        "updated_at": "2026-08-28T21:33:50Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979096154,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:44:51Z",
+            "started_at": "2026-08-28T21:33:40Z",
+            "completed_at": "2026-08-28T21:33:49Z",
+            "runner_name": "GitHub Actions 1000427109",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209549678,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:44:54Z",
+        "run_started_at": "2026-08-28T20:44:54Z",
+        "updated_at": "2026-08-28T20:45:03Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979109535,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:44:55Z",
+            "started_at": "2026-08-28T20:44:55Z",
+            "completed_at": "2026-08-28T20:44:54Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209549721,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:44:54Z",
+        "run_started_at": "2026-08-28T20:44:54Z",
+        "updated_at": "2026-08-28T20:46:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979110931,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:44:55Z",
+            "started_at": "2026-08-28T20:44:55Z",
+            "completed_at": "2026-08-28T20:46:30Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209667136,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:46:30Z",
+        "run_started_at": "2026-08-28T20:46:30Z",
+        "updated_at": "2026-08-28T20:46:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979496232,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:46:31Z",
+            "started_at": "2026-08-28T20:46:31Z",
+            "completed_at": "2026-08-28T20:46:30Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209667182,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:46:30Z",
+        "run_started_at": "2026-08-28T20:46:30Z",
+        "updated_at": "2026-08-28T21:28:36Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [
+          {
+            "number": 13419
+          }
+        ],
+        "jobs": [
+          {
+            "id": 98979498325,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:46:31Z",
+            "started_at": "2026-08-28T21:27:24Z",
+            "completed_at": "2026-08-28T21:28:36Z",
+            "runner_name": "GitHub Actions 1000427076",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209699814,
+        "name": "Always-on guards",
+        "event": "pull_request_review",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:46:57Z",
+        "run_started_at": "2026-08-28T20:46:57Z",
+        "updated_at": "2026-08-28T21:39:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98979608099,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:46:58Z",
+            "started_at": "2026-08-28T21:38:45Z",
+            "completed_at": "2026-08-28T21:39:50Z",
+            "runner_name": "GitHub Actions 1000427154",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209741597,
+        "name": "Push on main",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:47:33Z",
+        "run_started_at": "2026-08-28T20:47:33Z",
+        "updated_at": "2026-08-28T21:47:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98979754952,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:47:35Z",
+            "started_at": "2026-08-28T21:39:11Z",
+            "completed_at": "2026-08-28T21:43:22Z",
+            "runner_name": "GitHub Actions 1000427158",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98979755190,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:47:35Z",
+            "started_at": "2026-08-28T21:39:52Z",
+            "completed_at": "2026-08-28T21:41:24Z",
+            "runner_name": "GitHub Actions 1000427162",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98979755191,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:47:35Z",
+            "started_at": "2026-08-28T21:41:26Z",
+            "completed_at": "2026-08-28T21:47:43Z",
+            "runner_name": "GitHub Actions 1000427175",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98979755207,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:47:35Z",
+            "started_at": "2026-08-28T21:41:54Z",
+            "completed_at": "2026-08-28T21:44:05Z",
+            "runner_name": "GitHub Actions 1000427178",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209741748,
+        "name": "Orphaned delivery scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:47:33Z",
+        "run_started_at": "2026-08-28T20:47:33Z",
+        "updated_at": "2026-08-28T21:41:20Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98982045271,
+            "name": "Verify merged PRs' mergeCommit reached main (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:10Z",
+            "started_at": "2026-08-28T21:40:47Z",
+            "completed_at": "2026-08-28T21:41:19Z",
+            "runner_name": "GitHub Actions 1000427168",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209741918,
+        "name": "Quarto Pages Deploy",
+        "event": "push",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:47:33Z",
+        "run_started_at": "2026-08-28T20:47:33Z",
+        "updated_at": "2026-08-28T22:13:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98979755306,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:47:35Z",
+            "started_at": "2026-08-28T21:35:38Z",
+            "completed_at": "2026-08-28T21:50:41Z",
+            "runner_name": "GitHub Actions 1000427128",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98979756275,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:47:35Z",
+            "started_at": "2026-08-28T20:47:35Z",
+            "completed_at": "2026-08-28T20:47:35Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98994368404,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:50:41Z",
+            "started_at": "2026-08-28T22:13:31Z",
+            "completed_at": "2026-08-28T22:13:50Z",
+            "runner_name": "GitHub Actions 1000427408",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209741938,
+        "name": "Secret Scan",
+        "event": "push",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:47:33Z",
+        "run_started_at": "2026-08-28T20:47:33Z",
+        "updated_at": "2026-08-28T22:01:57Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98986184332,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:14:39Z",
+            "started_at": "2026-08-28T21:54:10Z",
+            "completed_at": "2026-08-28T22:01:56Z",
+            "runner_name": "GitHub Actions 1000427275",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98986184496,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:14:40Z",
+            "started_at": "2026-08-28T21:51:51Z",
+            "completed_at": "2026-08-28T21:52:39Z",
+            "runner_name": "GitHub Actions 1000427251",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209743263,
+        "name": "Always-on guards",
+        "event": "pull_request_review",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:47:35Z",
+        "run_started_at": "2026-08-28T20:47:35Z",
+        "updated_at": "2026-08-28T21:48:46Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98979757194,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:47:35Z",
+            "started_at": "2026-08-28T21:47:54Z",
+            "completed_at": "2026-08-28T21:48:46Z",
+            "runner_name": "GitHub Actions 1000427223",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209846570,
+        "name": "PR #13422",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:03Z",
+        "run_started_at": "2026-08-28T20:49:03Z",
+        "updated_at": "2026-08-28T22:13:59Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980107237,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:27:14Z",
+            "completed_at": "2026-08-28T21:33:19Z",
+            "runner_name": "GitHub Actions 1000427074",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980107366,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:48:35Z",
+            "completed_at": "2026-08-28T21:52:43Z",
+            "runner_name": "GitHub Actions 1000427228",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980107403,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T22:01:57Z",
+            "completed_at": "2026-08-28T22:03:31Z",
+            "runner_name": "GitHub Actions 1000427329",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980107469,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T22:12:27Z",
+            "completed_at": "2026-08-28T22:13:58Z",
+            "runner_name": "GitHub Actions 1000427397",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98991137234,
+            "name": "fast-lane (ombre): banner-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:02Z",
+            "started_at": "2026-08-28T21:36:02Z",
+            "completed_at": "2026-08-28T21:36:02Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991138965,
+            "name": "fast-lane (ombre): pip-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:03Z",
+            "started_at": "2026-08-28T21:36:03Z",
+            "completed_at": "2026-08-28T21:36:03Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991140326,
+            "name": "fast-lane (ombre): solution-leak-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:03Z",
+            "started_at": "2026-08-28T21:36:03Z",
+            "completed_at": "2026-08-28T21:36:03Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991141846,
+            "name": "fast-lane (ombre): prose-counts-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:04Z",
+            "started_at": "2026-08-28T21:36:04Z",
+            "completed_at": "2026-08-28T21:36:04Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991143487,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:04Z",
+            "started_at": "2026-08-28T21:36:04Z",
+            "completed_at": "2026-08-28T21:36:04Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991144961,
+            "name": "fast-lane (ombre): bare-cross-dir-load-gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:04Z",
+            "started_at": "2026-08-28T21:36:04Z",
+            "completed_at": "2026-08-28T21:36:04Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991146499,
+            "name": "fast-lane (ombre): notebook-navlink-check",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:05Z",
+            "started_at": "2026-08-28T21:36:05Z",
+            "completed_at": "2026-08-28T21:36:05Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991148001,
+            "name": "fast-lane (ombre): notebook-interp-positioning-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:05Z",
+            "started_at": "2026-08-28T21:36:05Z",
+            "completed_at": "2026-08-28T21:36:05Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991149507,
+            "name": "fast-lane (ombre): markdown-rendering-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:06Z",
+            "started_at": "2026-08-28T21:36:06Z",
+            "completed_at": "2026-08-28T21:36:06Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991151316,
+            "name": "Exercice-solution HIGH delta guard (#8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:06Z",
+            "started_at": "2026-08-28T21:36:06Z",
+            "completed_at": "2026-08-28T21:36:06Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991153286,
+            "name": "Output-failure ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:07Z",
+            "started_at": "2026-08-28T21:36:07Z",
+            "completed_at": "2026-08-28T21:36:07Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991154815,
+            "name": "No fabricated text output in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:07Z",
+            "started_at": "2026-08-28T21:36:07Z",
+            "completed_at": "2026-08-28T21:36:07Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991156318,
+            "name": "No degenerate figure in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:07Z",
+            "started_at": "2026-08-28T21:36:07Z",
+            "completed_at": "2026-08-28T21:36:07Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991157537,
+            "name": "No SVG broken-geometry (negative-dim) defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:08Z",
+            "started_at": "2026-08-28T21:36:08Z",
+            "completed_at": "2026-08-28T21:36:08Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991159088,
+            "name": "No SVG decimal-comma defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:08Z",
+            "started_at": "2026-08-28T21:36:08Z",
+            "completed_at": "2026-08-28T21:36:08Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991161208,
+            "name": "No SVG empty-display defect in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:09Z",
+            "started_at": "2026-08-28T21:36:09Z",
+            "completed_at": "2026-08-28T21:36:09Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991163102,
+            "name": "No offscreen-flat SVG in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:09Z",
+            "started_at": "2026-08-28T21:36:09Z",
+            "completed_at": "2026-08-28T21:36:09Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98991164501,
+            "name": "No markdown content loss in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:36:10Z",
+            "started_at": "2026-08-28T21:36:10Z",
+            "completed_at": "2026-08-28T21:36:10Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33209848476,
+        "name": "Notebook Validation",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:48:14Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109809,
+            "name": "validate-notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:44:27Z",
+            "completed_at": "2026-08-28T21:48:13Z",
+            "runner_name": "GitHub Actions 1000427195",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848482,
+        "name": "MD Hierarchy Drift Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:41:53Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980108786,
+            "name": "scan_md_hierarchy drift (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:40:43Z",
+            "completed_at": "2026-08-28T21:41:52Z",
+            "runner_name": "GitHub Actions 1000427167",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848485,
+        "name": "ICT-Series Tests",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T22:05:37Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109387,
+            "name": "ICT tests/ (55)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:57:23Z",
+            "completed_at": "2026-08-28T22:05:36Z",
+            "runner_name": "GitHub Actions 1000427297",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980109500,
+            "name": "ICT ict/tests/ (42 package)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:53:52Z",
+            "completed_at": "2026-08-28T21:55:25Z",
+            "runner_name": "GitHub Actions 1000427272",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848495,
+        "name": "Consecutive Code Cells Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:40:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109529,
+            "name": "Consecutive code cells >= 2 advisory (label, non-blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:39:31Z",
+            "completed_at": "2026-08-28T21:40:42Z",
+            "runner_name": "GitHub Actions 1000427161",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848509,
+        "name": "notebook-interp-positioning-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:38:44Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109382,
+            "name": "check_interp_positioning.py",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:37:51Z",
+            "completed_at": "2026-08-28T21:38:43Z",
+            "runner_name": "GitHub Actions 1000427146",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848518,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:36:12Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109460,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:34:26Z",
+            "completed_at": "2026-08-28T21:36:11Z",
+            "runner_name": "GitHub Actions 1000427118",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848523,
+        "name": "markdown-rendering-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:48:45Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109208,
+            "name": "markdown-rendering guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:47:33Z",
+            "completed_at": "2026-08-28T21:48:44Z",
+            "runner_name": "GitHub Actions 1000427219",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848524,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:34:02Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109359,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:33:52Z",
+            "completed_at": "2026-08-28T21:34:02Z",
+            "runner_name": "GitHub Actions 1000427111",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848529,
+        "name": "Notebook Execution Required",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T22:05:10Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109709,
+            "name": "Golden-set execution (H.7 P3)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:49:25Z",
+            "completed_at": "2026-08-28T21:51:50Z",
+            "runner_name": "GitHub Actions 1000427236",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980109907,
+            "name": "Detect notebook changes",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:49:32Z",
+            "completed_at": "2026-08-28T21:50:25Z",
+            "runner_name": "GitHub Actions 1000427237",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98994311094,
+            "name": "Static validation (H.1/H.3/C.1)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:50:25Z",
+            "started_at": "2026-08-28T22:04:06Z",
+            "completed_at": "2026-08-28T22:05:09Z",
+            "runner_name": "GitHub Actions 1000427347",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848530,
+        "name": "Notebook Cell Source Parses",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:32:04Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109252,
+            "name": "cell-source-parses",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:30:54Z",
+            "completed_at": "2026-08-28T21:32:03Z",
+            "runner_name": "GitHub Actions 1000427095",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848531,
+        "name": "Bare cross-dir",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:46:15Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109604,
+            "name": "No bare cross-dir #load in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:45:28Z",
+            "completed_at": "2026-08-28T21:46:14Z",
+            "runner_name": "GitHub Actions 1000427204",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848532,
+        "name": "banner-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:35:07Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109594,
+            "name": "probeAddresses banner guard (main-repo notebooks)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:34:22Z",
+            "completed_at": "2026-08-28T21:35:06Z",
+            "runner_name": "GitHub Actions 1000427117",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848535,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T20:49:12Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980110622,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:49:06Z",
+            "started_at": "2026-08-28T20:49:06Z",
+            "completed_at": "2026-08-28T20:49:05Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848537,
+        "name": "pip-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:45:29Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109330,
+            "name": "!pip install HIGH delta guard (#6314)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:44:35Z",
+            "completed_at": "2026-08-28T21:45:29Z",
+            "runner_name": "GitHub Actions 1000427196",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848548,
+        "name": "Quarto Pages Deploy",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:52:35Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980110039,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:34:05Z",
+            "completed_at": "2026-08-28T21:52:34Z",
+            "runner_name": "GitHub Actions 1000427113",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980111083,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:49:06Z",
+            "started_at": "2026-08-28T20:49:06Z",
+            "completed_at": "2026-08-28T20:49:05Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980111154,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:49:06Z",
+            "started_at": "2026-08-28T20:49:06Z",
+            "completed_at": "2026-08-28T20:49:05Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848552,
+        "name": "Catalog Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:59:13Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109541,
+            "name": "Notebook catalog drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:57:40Z",
+            "completed_at": "2026-08-28T21:59:12Z",
+            "runner_name": "GitHub Actions 1000427299",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848553,
+        "name": "Validation Matrix",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:35:36Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109572,
+            "name": "validate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:34:43Z",
+            "completed_at": "2026-08-28T21:35:35Z",
+            "runner_name": "GitHub Actions 1000427120",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848556,
+        "name": "Markdown claims anchored to previous output (advisory)",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:30:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109450,
+            "name": "Markdown claims anchored to previous output (#11435 advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:29:40Z",
+            "completed_at": "2026-08-28T21:30:51Z",
+            "runner_name": "GitHub Actions 1000427090",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848568,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:45:43Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109549,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:45:31Z",
+            "completed_at": "2026-08-28T21:45:42Z",
+            "runner_name": "GitHub Actions 1000427205",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848572,
+        "name": "Notebook Papermill Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:42:05Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109623,
+            "name": "Papermill ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:41:18Z",
+            "completed_at": "2026-08-28T21:42:05Z",
+            "runner_name": "GitHub Actions 1000427173",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848574,
+        "name": "prose-counts-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:39:02Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109192,
+            "name": "prose-counts",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:38:15Z",
+            "completed_at": "2026-08-28T21:39:01Z",
+            "runner_name": "GitHub Actions 1000427148",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848578,
+        "name": "Twin Parity Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T22:01:07Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109532,
+            "name": "Twin parity SHA mismatch (#9399 volet b, advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:54:35Z",
+            "completed_at": "2026-08-28T21:55:32Z",
+            "runner_name": "GitHub Actions 1000427276",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980109771,
+            "name": "Twin parity audit (#8057)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T22:00:11Z",
+            "completed_at": "2026-08-28T22:01:06Z",
+            "runner_name": "GitHub Actions 1000427316",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848582,
+        "name": "Cell-order gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:43:01Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109770,
+            "name": "No cell-ordering regression in changed notebooks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:42:15Z",
+            "completed_at": "2026-08-28T21:42:59Z",
+            "runner_name": "GitHub Actions 1000427181",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848601,
+        "name": "Notebook Navlink Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:33:36Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109664,
+            "name": "check-navlinks",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:32:51Z",
+            "completed_at": "2026-08-28T21:33:36Z",
+            "runner_name": "GitHub Actions 1000427105",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848611,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:30:18Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109508,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:29:39Z",
+            "completed_at": "2026-08-28T21:30:17Z",
+            "runner_name": "GitHub Actions 1000427089",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848614,
+        "name": "solution-leak-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:34:11Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109751,
+            "name": "Solution-leak HIGH delta (WARN phase, #8053)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:33:22Z",
+            "completed_at": "2026-08-28T21:34:10Z",
+            "runner_name": "GitHub Actions 1000427106",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848618,
+        "name": "Translation Drift Check",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:53:05Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980109528,
+            "name": "Translation drift (read-only)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:52:13Z",
+            "completed_at": "2026-08-28T21:53:04Z",
+            "runner_name": "GitHub Actions 1000427254",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209848647,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T22:01:47Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980110068,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:40:10Z",
+            "completed_at": "2026-08-28T21:40:59Z",
+            "runner_name": "GitHub Actions 1000427165",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980110219,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:05Z",
+            "started_at": "2026-08-28T21:55:38Z",
+            "completed_at": "2026-08-28T22:01:47Z",
+            "runner_name": "GitHub Actions 1000427286",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209849227,
+        "name": "Notebook Exec Sequence Ratchet",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T20:49:05Z",
+        "updated_at": "2026-08-28T21:43:12Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980111917,
+            "name": "Exec-sequence ratchet (base vs PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:49:06Z",
+            "started_at": "2026-08-28T21:42:20Z",
+            "completed_at": "2026-08-28T21:43:11Z",
+            "runner_name": "GitHub Actions 1000427182",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209849231,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:49:05Z",
+        "run_started_at": "2026-08-28T22:21:00Z",
+        "updated_at": "2026-08-28T22:25:58Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980111656,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "failure",
+            "created_at": "2026-08-28T20:49:06Z",
+            "started_at": "2026-08-28T21:45:02Z",
+            "completed_at": "2026-08-28T22:13:52Z",
+            "runner_name": "GitHub Actions 1000427201",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 99000997233,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T22:21:03Z",
+            "started_at": "2026-08-28T22:24:35Z",
+            "completed_at": "2026-08-28T22:25:57Z",
+            "runner_name": "GitHub Actions 1000427484",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209932107,
+        "name": "Always-on guards",
+        "event": "pull_request_review",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:50:14Z",
+        "run_started_at": "2026-08-28T20:50:14Z",
+        "updated_at": "2026-08-28T21:36:22Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980386559,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:50:15Z",
+            "started_at": "2026-08-28T21:35:33Z",
+            "completed_at": "2026-08-28T21:36:21Z",
+            "runner_name": "GitHub Actions 1000427127",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33209981375,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:50:56Z",
+        "run_started_at": "2026-08-28T20:50:56Z",
+        "updated_at": "2026-08-28T20:51:03Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980555907,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:50:57Z",
+            "started_at": "2026-08-28T20:50:57Z",
+            "completed_at": "2026-08-28T20:50:56Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980556218,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:50:57Z",
+            "started_at": "2026-08-28T20:50:57Z",
+            "completed_at": "2026-08-28T20:50:56Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980556749,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:50:57Z",
+            "started_at": "2026-08-28T20:50:57Z",
+            "completed_at": "2026-08-28T20:50:56Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980577057,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:51:02Z",
+            "started_at": "2026-08-28T20:51:02Z",
+            "completed_at": "2026-08-28T20:50:56Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980580431,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:51:03Z",
+            "started_at": "2026-08-28T20:51:03Z",
+            "completed_at": "2026-08-28T20:50:56Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980587784,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:51:05Z",
+            "started_at": "2026-08-28T20:51:05Z",
+            "completed_at": "2026-08-28T20:50:56Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980591780,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:51:06Z",
+            "started_at": "2026-08-28T20:51:06Z",
+            "completed_at": "2026-08-28T20:50:56Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210090432,
+        "name": "hooks-parity",
+        "event": "push",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:29Z",
+        "run_started_at": "2026-08-28T20:52:29Z",
+        "updated_at": "2026-08-28T21:47:22Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980920392,
+            "name": "parity gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:30Z",
+            "started_at": "2026-08-28T21:46:38Z",
+            "completed_at": "2026-08-28T21:47:21Z",
+            "runner_name": "GitHub Actions 1000427212",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98993101187,
+            "name": "fast-lane (ombre): prose-counts-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:44:54Z",
+            "started_at": "2026-08-28T21:44:54Z",
+            "completed_at": "2026-08-28T21:44:54Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98993102889,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:44:54Z",
+            "started_at": "2026-08-28T21:44:54Z",
+            "completed_at": "2026-08-28T21:44:54Z",
+            "runner_name": null,
+            "labels": []
+          },
+          {
+            "id": 98993104341,
+            "name": "check-links",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:44:55Z",
+            "started_at": "2026-08-28T21:44:55Z",
+            "completed_at": "2026-08-28T21:44:55Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33210090470,
+        "name": "PR #13392",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:29Z",
+        "run_started_at": "2026-08-28T20:52:29Z",
+        "updated_at": "2026-08-28T22:12:22Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980925818,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T22:06:13Z",
+            "completed_at": "2026-08-28T22:12:21Z",
+            "runner_name": "GitHub Actions 1000427360",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980925919,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:34:00Z",
+            "completed_at": "2026-08-28T21:38:19Z",
+            "runner_name": "GitHub Actions 1000427112",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980926016,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:51:00Z",
+            "completed_at": "2026-08-28T21:52:31Z",
+            "runner_name": "GitHub Actions 1000427245",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980926021,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:59:25Z",
+            "completed_at": "2026-08-28T22:00:50Z",
+            "runner_name": "GitHub Actions 1000427313",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091507,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T21:47:32Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980926933,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:37:46Z",
+            "completed_at": "2026-08-28T21:42:42Z",
+            "runner_name": "GitHub Actions 1000427145",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980927072,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:46:43Z",
+            "completed_at": "2026-08-28T21:47:31Z",
+            "runner_name": "GitHub Actions 1000427213",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091510,
+        "name": "Scripts & Notebook-Tools Tests",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T21:44:46Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980927579,
+            "name": "Scripts Tests (CPU)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:37:56Z",
+            "completed_at": "2026-08-28T21:44:45Z",
+            "runner_name": "GitHub Actions 1000427147",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091541,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T20:52:31Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980925252,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T20:52:31Z",
+            "completed_at": "2026-08-28T20:52:30Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091544,
+        "name": "Bash Syntax Advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T21:57:39Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980928131,
+            "name": "bash -n every scripts .sh (advisory)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:50:29Z",
+            "completed_at": "2026-08-28T21:51:11Z",
+            "runner_name": "GitHub Actions 1000427242",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980928341,
+            "name": "Shebang + dry-run advisory (non-blocking)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:56:56Z",
+            "completed_at": "2026-08-28T21:57:38Z",
+            "runner_name": "GitHub Actions 1000427294",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091550,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T21:45:00Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980928591,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:32Z",
+            "started_at": "2026-08-28T21:43:13Z",
+            "completed_at": "2026-08-28T21:44:59Z",
+            "runner_name": "GitHub Actions 1000427187",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091555,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T21:38:57Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980927738,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:38:47Z",
+            "completed_at": "2026-08-28T21:38:57Z",
+            "runner_name": "GitHub Actions 1000427155",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091560,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T22:13:20Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980927197,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:47:25Z",
+            "completed_at": "2026-08-28T22:13:20Z",
+            "runner_name": "GitHub Actions 1000427218",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091572,
+        "name": "prose-counts-guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T21:41:17Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980927093,
+            "name": "prose-counts",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:40:33Z",
+            "completed_at": "2026-08-28T21:41:17Z",
+            "runner_name": "GitHub Actions 1000427166",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091586,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T21:48:51Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980927155,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:48:11Z",
+            "completed_at": "2026-08-28T21:48:50Z",
+            "runner_name": "GitHub Actions 1000427224",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091597,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T21:36:46Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980926005,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:36:37Z",
+            "completed_at": "2026-08-28T21:36:45Z",
+            "runner_name": "GitHub Actions 1000427135",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210091598,
+        "name": "Quarto Pages Deploy",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:52:30Z",
+        "run_started_at": "2026-08-28T20:52:30Z",
+        "updated_at": "2026-08-28T22:11:17Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98980927500,
+            "name": "Validate Quarto build (PR)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T21:52:19Z",
+            "completed_at": "2026-08-28T22:11:08Z",
+            "runner_name": "GitHub Actions 1000427257",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980928396,
+            "name": "Build Quarto site",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:52:31Z",
+            "started_at": "2026-08-28T20:52:31Z",
+            "completed_at": "2026-08-28T20:52:31Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98980928750,
+            "name": "Deploy to GitHub Pages",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:52:32Z",
+            "started_at": "2026-08-28T20:52:32Z",
+            "completed_at": "2026-08-28T20:52:31Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210125368,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:52:59Z",
+        "run_started_at": "2026-08-28T20:52:59Z",
+        "updated_at": "2026-08-28T20:53:08Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98981041488,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:00Z",
+            "started_at": "2026-08-28T20:53:00Z",
+            "completed_at": "2026-08-28T20:52:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981041850,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:00Z",
+            "started_at": "2026-08-28T20:53:00Z",
+            "completed_at": "2026-08-28T20:52:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981063293,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:05Z",
+            "started_at": "2026-08-28T20:53:05Z",
+            "completed_at": "2026-08-28T20:52:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981064284,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:06Z",
+            "started_at": "2026-08-28T20:53:06Z",
+            "completed_at": "2026-08-28T20:52:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981069618,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:07Z",
+            "started_at": "2026-08-28T20:53:07Z",
+            "completed_at": "2026-08-28T20:52:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981075677,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:08Z",
+            "started_at": "2026-08-28T20:53:08Z",
+            "completed_at": "2026-08-28T20:52:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981078633,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:09Z",
+            "started_at": "2026-08-28T20:53:09Z",
+            "completed_at": "2026-08-28T20:52:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210126967,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:53:00Z",
+        "run_started_at": "2026-08-28T20:53:00Z",
+        "updated_at": "2026-08-28T20:53:02Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98981048506,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:02Z",
+            "started_at": "2026-08-28T20:53:02Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981049071,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:02Z",
+            "started_at": "2026-08-28T20:53:02Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981049197,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:02Z",
+            "started_at": "2026-08-28T20:53:02Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981049326,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:02Z",
+            "started_at": "2026-08-28T20:53:02Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981071509,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:07Z",
+            "started_at": "2026-08-28T20:53:07Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981076203,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:08Z",
+            "started_at": "2026-08-28T20:53:08Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981088648,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:12Z",
+            "started_at": "2026-08-28T20:53:12Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210127646,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:53:01Z",
+        "run_started_at": "2026-08-28T20:53:01Z",
+        "updated_at": "2026-08-28T20:53:02Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98981049695,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:02Z",
+            "started_at": "2026-08-28T20:53:02Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981049944,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:02Z",
+            "started_at": "2026-08-28T20:53:02Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981071062,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:07Z",
+            "started_at": "2026-08-28T20:53:07Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981076481,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:09Z",
+            "started_at": "2026-08-28T20:53:09Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981079574,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:09Z",
+            "started_at": "2026-08-28T20:53:09Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981083415,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:10Z",
+            "started_at": "2026-08-28T20:53:10Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981084166,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:10Z",
+            "started_at": "2026-08-28T20:53:10Z",
+            "completed_at": "2026-08-28T20:53:01Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210129018,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:53:02Z",
+        "run_started_at": "2026-08-28T20:53:02Z",
+        "updated_at": "2026-08-28T20:53:09Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98981053977,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:03Z",
+            "started_at": "2026-08-28T20:53:03Z",
+            "completed_at": "2026-08-28T20:53:02Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981054517,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:03Z",
+            "started_at": "2026-08-28T20:53:03Z",
+            "completed_at": "2026-08-28T20:53:02Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981077407,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:09Z",
+            "started_at": "2026-08-28T20:53:09Z",
+            "completed_at": "2026-08-28T20:53:02Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981078444,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:09Z",
+            "started_at": "2026-08-28T20:53:09Z",
+            "completed_at": "2026-08-28T20:53:02Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981086065,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:11Z",
+            "started_at": "2026-08-28T20:53:11Z",
+            "completed_at": "2026-08-28T20:53:02Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981093422,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:13Z",
+            "started_at": "2026-08-28T20:53:13Z",
+            "completed_at": "2026-08-28T20:53:02Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981093486,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:13Z",
+            "started_at": "2026-08-28T20:53:13Z",
+            "completed_at": "2026-08-28T20:53:02Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210130355,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:53:03Z",
+        "run_started_at": "2026-08-28T20:53:03Z",
+        "updated_at": "2026-08-28T20:53:04Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98981058704,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:04Z",
+            "started_at": "2026-08-28T20:53:04Z",
+            "completed_at": "2026-08-28T20:53:04Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981058985,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:04Z",
+            "started_at": "2026-08-28T20:53:04Z",
+            "completed_at": "2026-08-28T20:53:04Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981079417,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:09Z",
+            "started_at": "2026-08-28T20:53:09Z",
+            "completed_at": "2026-08-28T20:53:04Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981082833,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:10Z",
+            "started_at": "2026-08-28T20:53:10Z",
+            "completed_at": "2026-08-28T20:53:04Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981084265,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:11Z",
+            "started_at": "2026-08-28T20:53:11Z",
+            "completed_at": "2026-08-28T20:53:04Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981084699,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:11Z",
+            "started_at": "2026-08-28T20:53:11Z",
+            "completed_at": "2026-08-28T20:53:04Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981090833,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:53:12Z",
+            "started_at": "2026-08-28T20:53:12Z",
+            "completed_at": "2026-08-28T20:53:04Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210203895,
+        "name": "Variation Tag Guard",
+        "event": "issue_comment",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:54:05Z",
+        "run_started_at": "2026-08-28T20:54:05Z",
+        "updated_at": "2026-08-28T20:54:06Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98981305137,
+            "name": "G-VAR-2 light cap (cross-PR)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:54:06Z",
+            "started_at": "2026-08-28T20:54:06Z",
+            "completed_at": "2026-08-28T20:54:06Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981329402,
+            "name": "Require no close-keyword + PR-number (block on auto-close of a PR, #10101)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:54:12Z",
+            "started_at": "2026-08-28T20:54:12Z",
+            "completed_at": "2026-08-28T20:54:06Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981331713,
+            "name": "Check Grain tag conformity",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:54:12Z",
+            "started_at": "2026-08-28T20:54:12Z",
+            "completed_at": "2026-08-28T20:54:06Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981333361,
+            "name": "Require genre diversity vs prev (comment, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:54:13Z",
+            "started_at": "2026-08-28T20:54:13Z",
+            "completed_at": "2026-08-28T20:54:06Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981341989,
+            "name": "Require Grain tag (block on absent,",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:54:15Z",
+            "started_at": "2026-08-28T20:54:15Z",
+            "completed_at": "2026-08-28T20:54:06Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981343250,
+            "name": "Require genre diversity vs prev (required, block on LIGHT adjacency, #11170)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:54:15Z",
+            "started_at": "2026-08-28T20:54:15Z",
+            "completed_at": "2026-08-28T20:54:06Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98981344128,
+            "name": "Require prev: non-closing (block on close-keyword genre, #10093)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:54:16Z",
+            "started_at": "2026-08-28T20:54:16Z",
+            "completed_at": "2026-08-28T20:54:06Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210254843,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-08-28T20:54:48Z",
+        "run_started_at": "2026-08-28T20:54:48Z",
+        "updated_at": "2026-08-28T20:55:00Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98981478354,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "created_at": "2026-08-28T20:54:48Z",
+            "started_at": "2026-08-28T20:54:48Z",
+            "completed_at": "2026-08-28T20:54:59Z",
+            "runner_name": "",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210254850,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:54:48Z",
+        "run_started_at": "2026-08-28T20:54:48Z",
+        "updated_at": "2026-08-28T20:54:49Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98981514069,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:54:57Z",
+            "started_at": "2026-08-28T20:54:57Z",
+            "completed_at": "2026-08-28T20:54:48Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210267858,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:54:59Z",
+        "run_started_at": "2026-08-28T20:54:59Z",
+        "updated_at": "2026-08-28T20:55:00Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98981524910,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:55:00Z",
+            "started_at": "2026-08-28T20:55:00Z",
+            "completed_at": "2026-08-28T20:54:59Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210267946,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:54:59Z",
+        "run_started_at": "2026-08-28T20:54:59Z",
+        "updated_at": "2026-08-28T21:42:56Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98981526913,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:55:00Z",
+            "started_at": "2026-08-28T21:40:52Z",
+            "completed_at": "2026-08-28T21:42:54Z",
+            "runner_name": "GitHub Actions 1000427169",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210413335,
+        "name": "PR #13423",
+        "event": "dynamic",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:57:01Z",
+        "run_started_at": "2026-08-28T20:57:01Z",
+        "updated_at": "2026-08-28T22:06:55Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98982013301,
+            "name": "Analyze (javascript-typescript)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:02Z",
+            "started_at": "2026-08-28T21:42:44Z",
+            "completed_at": "2026-08-28T21:44:25Z",
+            "runner_name": "GitHub Actions 1000427184",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98982013570,
+            "name": "Analyze (csharp)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:02Z",
+            "started_at": "2026-08-28T21:55:27Z",
+            "completed_at": "2026-08-28T22:01:49Z",
+            "runner_name": "GitHub Actions 1000427283",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98982013644,
+            "name": "Analyze (actions)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:02Z",
+            "started_at": "2026-08-28T21:55:46Z",
+            "completed_at": "2026-08-28T21:57:08Z",
+            "runner_name": "GitHub Actions 1000427287",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98982013654,
+            "name": "Analyze (python)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:02Z",
+            "started_at": "2026-08-28T22:02:43Z",
+            "completed_at": "2026-08-28T22:06:54Z",
+            "runner_name": "GitHub Actions 1000427338",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98994696500,
+            "name": "fast-lane (ombre): perimeter-review-guard",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T21:52:08Z",
+            "started_at": "2026-08-28T21:52:08Z",
+            "completed_at": "2026-08-28T21:52:08Z",
+            "runner_name": null,
+            "labels": []
+          }
+        ]
+      },
+      {
+        "id": 33210416022,
+        "name": "Secret Scan",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:57:03Z",
+        "run_started_at": "2026-08-28T20:57:03Z",
+        "updated_at": "2026-08-28T22:21:36Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98982018790,
+            "name": "Gitleaks positive controls (#10143)",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:03Z",
+            "started_at": "2026-08-28T22:06:09Z",
+            "completed_at": "2026-08-28T22:07:01Z",
+            "runner_name": "GitHub Actions 1000427359",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          },
+          {
+            "id": 98982018919,
+            "name": "Gitleaks secret scanner",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:03Z",
+            "started_at": "2026-08-28T22:13:44Z",
+            "completed_at": "2026-08-28T22:21:35Z",
+            "runner_name": "GitHub Actions 1000427410",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210416029,
+        "name": "Translation Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:57:03Z",
+        "run_started_at": "2026-08-28T20:57:03Z",
+        "updated_at": "2026-08-28T21:39:29Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98982018517,
+            "name": "No hand-edited translation files on feature branch",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:03Z",
+            "started_at": "2026-08-28T21:39:19Z",
+            "completed_at": "2026-08-28T21:39:28Z",
+            "runner_name": "GitHub Actions 1000427160",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210416037,
+        "name": "Stale Base Branch Warning",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:57:03Z",
+        "run_started_at": "2026-08-28T20:57:03Z",
+        "updated_at": "2026-08-28T21:46:42Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98982018557,
+            "name": "Check base branch staleness",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:03Z",
+            "started_at": "2026-08-28T21:46:32Z",
+            "completed_at": "2026-08-28T21:46:41Z",
+            "runner_name": "GitHub Actions 1000427211",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210416043,
+        "name": "Regression Guard",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:57:03Z",
+        "run_started_at": "2026-08-28T20:57:03Z",
+        "updated_at": "2026-08-28T21:42:19Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98982018459,
+            "name": "No notebook health regression",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:03Z",
+            "started_at": "2026-08-28T21:41:32Z",
+            "completed_at": "2026-08-28T21:42:18Z",
+            "runner_name": "GitHub Actions 1000427176",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210416063,
+        "name": "Base-not-main advisory",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-08-28T20:57:03Z",
+        "run_started_at": "2026-08-28T20:57:03Z",
+        "updated_at": "2026-08-28T20:57:04Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98982020120,
+            "name": "Flag PR targeting a non-main base (advisory)",
+            "status": "completed",
+            "conclusion": "skipped",
+            "created_at": "2026-08-28T20:57:04Z",
+            "started_at": "2026-08-28T20:57:04Z",
+            "completed_at": "2026-08-28T20:57:03Z",
+            "runner_name": null,
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210416065,
+        "name": "PR gate",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:57:03Z",
+        "run_started_at": "2026-08-28T20:57:03Z",
+        "updated_at": "2026-08-28T22:22:16Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98982018685,
+            "name": "PR gate",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:03Z",
+            "started_at": "2026-08-28T21:56:53Z",
+            "completed_at": "2026-08-28T22:22:15Z",
+            "runner_name": "GitHub Actions 1000427292",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210416100,
+        "name": "Always-on guards",
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:57:03Z",
+        "run_started_at": "2026-08-28T20:57:03Z",
+        "updated_at": "2026-08-28T21:52:13Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98982018997,
+            "name": "Always-on guards -- 12 organes, 1 checkout",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:57:03Z",
+            "started_at": "2026-08-28T21:50:43Z",
+            "completed_at": "2026-08-28T21:52:12Z",
+            "runner_name": "GitHub Actions 1000427244",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      },
+      {
+        "id": 33210496315,
+        "name": "PR gate stale-verdict sweep",
+        "event": "schedule",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-08-28T20:58:10Z",
+        "run_started_at": "2026-08-28T20:58:10Z",
+        "updated_at": "2026-08-28T21:50:32Z",
+        "head_repository": {
+          "full_name": "jsboige/CoursIA"
+        },
+        "pull_requests": [],
+        "jobs": [
+          {
+            "id": 98982283190,
+            "name": "Re-aggregate stale PR gate verdicts",
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-08-28T20:58:10Z",
+            "started_at": "2026-08-28T21:48:51Z",
+            "completed_at": "2026-08-28T21:50:31Z",
+            "runner_name": "GitHub Actions 1000427232",
+            "labels": [
+              "ubuntu-latest"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "analysis": {
+    "window": {
+      "since": "2026-08-28T20:00:00Z",
+      "until": "2026-08-28T21:00:00Z",
+      "hours": 1.0
+    },
+    "denominators": {
+      "runs": 327,
+      "jobs": 669,
+      "timed_jobs": 557,
+      "incomplete_or_untimed_jobs": 0,
+      "timestamp_skew_jobs": 112,
+      "skipped_without_start": 0,
+      "timing_coverage": 0.832586
+    },
+    "runner": {
+      "runner_minutes": 3178.117,
+      "runner_minutes_per_wall_hour": 3178.117,
+      "average_runner_equivalents": 52.968611,
+      "queue_minutes_for_timed_jobs": 18969.583
+    },
+    "provenance": {
+      "same_repo": 327,
+      "fork": 0,
+      "unknown": 0
+    },
+    "run_conclusions": {
+      "cancelled": 51,
+      "failure": 3,
+      "skipped": 35,
+      "success": 238
+    },
+    "runs_created_per_minute": {
+      "2026-08-28T20:02Z": 4,
+      "2026-08-28T20:08Z": 30,
+      "2026-08-28T20:10Z": 33,
+      "2026-08-28T20:16Z": 23,
+      "2026-08-28T20:17Z": 30,
+      "2026-08-28T20:23Z": 60,
+      "2026-08-28T20:24Z": 14,
+      "2026-08-28T20:25Z": 29,
+      "2026-08-28T20:29Z": 5,
+      "2026-08-28T20:33Z": 1,
+      "2026-08-28T20:34Z": 1,
+      "2026-08-28T20:42Z": 1,
+      "2026-08-28T20:43Z": 11,
+      "2026-08-28T20:44Z": 12,
+      "2026-08-28T20:46Z": 3,
+      "2026-08-28T20:47Z": 5,
+      "2026-08-28T20:49Z": 31,
+      "2026-08-28T20:50Z": 2,
+      "2026-08-28T20:52Z": 14,
+      "2026-08-28T20:53Z": 4,
+      "2026-08-28T20:54Z": 5,
+      "2026-08-28T20:57Z": 8,
+      "2026-08-28T20:58Z": 1
+    },
+    "by_workflow": [
+      {
+        "workflow": "PR gate",
+        "runs": 14,
+        "jobs": 21,
+        "timed_jobs": 21,
+        "runner_minutes": 364.433,
+        "queue_minutes": 690.433,
+        "run_conclusions": {
+          "cancelled": 3,
+          "failure": 2,
+          "success": 9
+        }
+      },
+      {
+        "workflow": "Secret Scan",
+        "runs": 15,
+        "jobs": 30,
+        "timed_jobs": 30,
+        "runner_minutes": 268.667,
+        "queue_minutes": 1403.717,
+        "run_conclusions": {
+          "cancelled": 3,
+          "success": 12
+        }
+      },
+      {
+        "workflow": "Quarto Pages Deploy",
+        "runs": 11,
+        "jobs": 33,
+        "timed_jobs": 22,
+        "runner_minutes": 246.617,
+        "queue_minutes": 526.85,
+        "run_conclusions": {
+          "cancelled": 2,
+          "success": 9
+        }
+      },
+      {
+        "workflow": "PR #13417",
+        "runs": 1,
+        "jobs": 4,
+        "timed_jobs": 4,
+        "runner_minutes": 188.533,
+        "queue_minutes": 0.0,
+        "run_conclusions": {
+          "cancelled": 1
+        }
+      },
+      {
+        "workflow": "PR #13392",
+        "runs": 2,
+        "jobs": 8,
+        "timed_jobs": 8,
+        "runner_minutes": 156.583,
+        "queue_minutes": 240.567,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 1
+        }
+      },
+      {
+        "workflow": "Notebook Execution Required",
+        "runs": 7,
+        "jobs": 21,
+        "timed_jobs": 21,
+        "runner_minutes": 118.7,
+        "queue_minutes": 994.95,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Always-on guards",
+        "runs": 24,
+        "jobs": 24,
+        "timed_jobs": 24,
+        "runner_minutes": 111.383,
+        "queue_minutes": 1000.517,
+        "run_conclusions": {
+          "cancelled": 6,
+          "failure": 1,
+          "success": 17
+        }
+      },
+      {
+        "workflow": "Twin Parity Check",
+        "runs": 7,
+        "jobs": 14,
+        "timed_jobs": 14,
+        "runner_minutes": 105.467,
+        "queue_minutes": 770.15,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Regression Guard",
+        "runs": 14,
+        "jobs": 14,
+        "timed_jobs": 14,
+        "runner_minutes": 91.317,
+        "queue_minutes": 671.15,
+        "run_conclusions": {
+          "cancelled": 3,
+          "success": 11
+        }
+      },
+      {
+        "workflow": "prose-counts-guard",
+        "runs": 10,
+        "jobs": 10,
+        "timed_jobs": 10,
+        "runner_minutes": 88.883,
+        "queue_minutes": 467.617,
+        "run_conclusions": {
+          "cancelled": 2,
+          "success": 8
+        }
+      },
+      {
+        "workflow": "Stale Base Branch Warning",
+        "runs": 14,
+        "jobs": 14,
+        "timed_jobs": 14,
+        "runner_minutes": 85.8,
+        "queue_minutes": 662.8,
+        "run_conclusions": {
+          "cancelled": 3,
+          "success": 11
+        }
+      },
+      {
+        "workflow": "Translation Guard",
+        "runs": 14,
+        "jobs": 14,
+        "timed_jobs": 14,
+        "runner_minutes": 85.733,
+        "queue_minutes": 656.917,
+        "run_conclusions": {
+          "cancelled": 3,
+          "success": 11
+        }
+      },
+      {
+        "workflow": "Bash Syntax Advisory",
+        "runs": 6,
+        "jobs": 12,
+        "timed_jobs": 12,
+        "runner_minutes": 78.983,
+        "queue_minutes": 479.017,
+        "run_conclusions": {
+          "cancelled": 2,
+          "success": 4
+        }
+      },
+      {
+        "workflow": "Scripts & Notebook-Tools Tests",
+        "runs": 6,
+        "jobs": 6,
+        "timed_jobs": 6,
+        "runner_minutes": 76.183,
+        "queue_minutes": 232.833,
+        "run_conclusions": {
+          "cancelled": 3,
+          "success": 3
+        }
+      },
+      {
+        "workflow": "Notebook Validation",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 72.083,
+        "queue_minutes": 372.1,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Catalog Drift Check",
+        "runs": 8,
+        "jobs": 8,
+        "timed_jobs": 8,
+        "runner_minutes": 65.933,
+        "queue_minutes": 427.917,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 7
+        }
+      },
+      {
+        "workflow": "Consecutive Code Cells Advisory",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 54.933,
+        "queue_minutes": 362.967,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Notebook Cell Source Parses",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 54.267,
+        "queue_minutes": 344.367,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "markdown-rendering-guard",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 53.783,
+        "queue_minutes": 364.517,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Validation Matrix",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 52.533,
+        "queue_minutes": 330.75,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Notebook Papermill Ratchet",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 52.517,
+        "queue_minutes": 376.483,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "pip-leak-guard",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 52.517,
+        "queue_minutes": 359.883,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "notebook-interp-positioning-guard",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 52.383,
+        "queue_minutes": 380.733,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Markdown claims anchored to previous output (advisory)",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 52.333,
+        "queue_minutes": 357.483,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Translation Drift Check",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 52.3,
+        "queue_minutes": 364.933,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "solution-leak-guard",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 52.3,
+        "queue_minutes": 349.0,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Notebook Exec Sequence Ratchet",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 52.133,
+        "queue_minutes": 336.383,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Cell-order gate",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 51.95,
+        "queue_minutes": 341.35,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Bare cross-dir",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 51.817,
+        "queue_minutes": 394.767,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "Notebook Navlink Check",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 51.75,
+        "queue_minutes": 361.883,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "banner-guard",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 51.733,
+        "queue_minutes": 367.767,
+        "run_conclusions": {
+          "cancelled": 1,
+          "success": 6
+        }
+      },
+      {
+        "workflow": "PR #13419",
+        "runs": 2,
+        "jobs": 9,
+        "timed_jobs": 9,
+        "runner_minutes": 26.933,
+        "queue_minutes": 486.4,
+        "run_conclusions": {
+          "success": 2
+        }
+      },
+      {
+        "workflow": "Push on main",
+        "runs": 1,
+        "jobs": 4,
+        "timed_jobs": 4,
+        "runner_minutes": 14.183,
+        "queue_minutes": 212.05,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "PR #13416",
+        "runs": 1,
+        "jobs": 22,
+        "timed_jobs": 22,
+        "runner_minutes": 13.8,
+        "queue_minutes": 233.317,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "PR #13423",
+        "runs": 1,
+        "jobs": 5,
+        "timed_jobs": 5,
+        "runner_minutes": 13.6,
+        "queue_minutes": 228.533,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "PR #13374",
+        "runs": 1,
+        "jobs": 23,
+        "timed_jobs": 23,
+        "runner_minutes": 13.583,
+        "queue_minutes": 252.517,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "PR #13008",
+        "runs": 1,
+        "jobs": 23,
+        "timed_jobs": 23,
+        "runner_minutes": 13.35,
+        "queue_minutes": 322.8,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "PR #13415",
+        "runs": 1,
+        "jobs": 10,
+        "timed_jobs": 10,
+        "runner_minutes": 13.333,
+        "queue_minutes": 263.433,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "PR #13422",
+        "runs": 1,
+        "jobs": 22,
+        "timed_jobs": 22,
+        "runner_minutes": 13.3,
+        "queue_minutes": 253.883,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "PR #13414",
+        "runs": 1,
+        "jobs": 22,
+        "timed_jobs": 22,
+        "runner_minutes": 12.983,
+        "queue_minutes": 256.917,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "PR #13196",
+        "runs": 1,
+        "jobs": 6,
+        "timed_jobs": 6,
+        "runner_minutes": 12.467,
+        "queue_minutes": 293.967,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "PR #13418",
+        "runs": 1,
+        "jobs": 22,
+        "timed_jobs": 22,
+        "runner_minutes": 12.233,
+        "queue_minutes": 264.567,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "ICT-Series Tests",
+        "runs": 1,
+        "jobs": 2,
+        "timed_jobs": 2,
+        "runner_minutes": 9.767,
+        "queue_minutes": 133.083,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "MD Hierarchy Drift Advisory",
+        "runs": 7,
+        "jobs": 7,
+        "timed_jobs": 7,
+        "runner_minutes": 9.417,
+        "queue_minutes": 392.95,
+        "run_conclusions": {
+          "success": 7
+        }
+      },
+      {
+        "workflow": "PR gate stale-verdict sweep",
+        "runs": 1,
+        "jobs": 1,
+        "timed_jobs": 1,
+        "runner_minutes": 1.667,
+        "queue_minutes": 50.683,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "hooks-parity",
+        "runs": 2,
+        "jobs": 5,
+        "timed_jobs": 5,
+        "runner_minutes": 1.433,
+        "queue_minutes": 120.3,
+        "run_conclusions": {
+          "success": 2
+        }
+      },
+      {
+        "workflow": "Workflow Label-Paths Coverage Guard",
+        "runs": 1,
+        "jobs": 1,
+        "timed_jobs": 1,
+        "runner_minutes": 0.783,
+        "queue_minutes": 51.617,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "Orphaned delivery scan",
+        "runs": 1,
+        "jobs": 1,
+        "timed_jobs": 1,
+        "runner_minutes": 0.533,
+        "queue_minutes": 43.617,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "Unique Check-Run Names Guard",
+        "runs": 1,
+        "jobs": 1,
+        "timed_jobs": 1,
+        "runner_minutes": 0.117,
+        "queue_minutes": 70.5,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "PR gate sweep health advisory",
+        "runs": 1,
+        "jobs": 1,
+        "timed_jobs": 1,
+        "runner_minutes": 0.083,
+        "queue_minutes": 47.65,
+        "run_conclusions": {
+          "success": 1
+        }
+      },
+      {
+        "workflow": "Base-not-main advisory",
+        "runs": 18,
+        "jobs": 18,
+        "timed_jobs": 10,
+        "runner_minutes": 0.0,
+        "queue_minutes": 0.0,
+        "run_conclusions": {
+          "skipped": 18
+        }
+      },
+      {
+        "workflow": "Variation Tag Guard",
+        "runs": 17,
+        "jobs": 119,
+        "timed_jobs": 26,
+        "runner_minutes": 0.0,
+        "queue_minutes": 0.0,
+        "run_conclusions": {
+          "skipped": 17
+        }
+      }
+    ]
+  }
+}

--- a/scripts/tests/test_measure_runner_demand.py
+++ b/scripts/tests/test_measure_runner_demand.py
@@ -162,10 +162,15 @@ def test_one_second_github_timestamp_skew_is_counted_not_zeroed():
     assert result["denominators"]["timestamp_skew_jobs"] == 1
 
 
-def test_larger_negative_timestamp_is_broken_not_zero():
-    bad = job(1, dt(), dt(0, 10), dt(0, 9))
-    with pytest.raises(mod.MeasurementError, match="negative duration"):
-        mod.analyze(snapshot([with_jobs(run(1, dt()), [bad])]))
+def test_larger_negative_timestamp_is_skew_not_fatal():
+    # Real-world datum (job 98968836743, 2026-08-28): GitHub inverted runtime
+    # by 6 s. The duration is unmeasurable -- count it as skew, never fatal
+    # (a datum-level anomaly must not kill a 1400-run measurement).
+    bad = job(1, dt(), dt(0, 10), dt(0, 9, 54))
+    result = mod.analyze(snapshot([with_jobs(run(1, dt()), [bad])]))
+    assert result["runner"]["runner_minutes"] == 0.0
+    assert result["denominators"]["timed_jobs"] == 0
+    assert result["denominators"]["timestamp_skew_jobs"] == 1
 
 
 def test_started_job_without_created_at_is_broken():


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #13427

See #12704 (livraison partielle : A1 cases 1+2 = débit mesuré + provenance re-confirmée ; la recommandation runners/machine avec contraintes GPU et la part non absorbée restent au coordinateur — le mandat est PRÉPARER)

## Summary

Mesure A1 exécutée sur la fenêtre saturée **2026-08-28T20:00-21:00Z** (l'heure où ai-01 a mesuré 370 runs en file), collecte live **non plafonnée** (pagination jusqu'à épuisement, zéro troncature silencieuse). La sortie est déposée à côté du script, rejouable hors ligne (`--input`).

### Instrument réparé au passage (découvert par les données réelles)

Le premier run est mort en exit 2 (comportement correct = bruyant) : GitHub inverse parfois des timestamps au-delà de la tolérance d'1 s — job `98968836743` : started `20:02:46Z`, completed `20:02:40Z` (**6 s d'inversion**). Fix : une durée inversée est **inmesurable, pas négative** — le datum est exclu et compté dans `timestamp_skew_jobs` ; le fatal reste réservé aux casses de collecte (pagination, snapshot malformé). Un datum ne doit pas tuer une mesure de population entière. 15/15 tests verts.

### Chiffres (dénominateurs compris)

| Grandeur | Valeur | Fenêtre |
|---|---|---|
| Runs / jobs collectés | **327 / 669** | 1 h, pagination exhaustive |
| **Minutes-runner / heure** | **3 178** | somme des exécutions réelles |
| **Équivalents-runners moyens** | **52,97** | 3178 min ÷ 60 |
| File d'attente (jobs timés) | **18 970 min** | ratio attente:exécution **6:1** = la saturation |
| Couverture temporelle | 83,3 % | 557 timés, 112 skew comptés (16,7 %), 0 incomplet |
| Provenance | **327/327 same_repo, 0 fork** | A1 case 2 re-confirmé sur cette population |
| Conclusions runs | 238 success / 51 cancelled / 35 skipped / 3 failure | — |

Note de méthode : le taux de création sur l'heure pleine est **327/h**, pas les 1 406/h extrapolés de l'échantillon burst de 0,3 h (400 runs) cité dans l'issue — la dénomination du burst surestimait ~4x.

### Lecture dimensionnement (entrée, pas décision)

Servir 53 équivalents-runners exige ~53 slots concurrents ; la file de 19k minutes est la demande non servie. Top consommateurs : PR gate (364 min/h), Secret Scan (269), Quarto Pages (247). La recommandation par machine (contrainte : rien ne touche GPU 0/1 d'ai-01 ni les entraînements GPU 2) reste à ai-01/user — mandat « préparer, pas activer ».

## Obligations

- Tests : `pytest scripts/tests/test_measure_runner_demand.py` = 15 passed (test fatal→skew mis à jour avec le datum réel)
- Replay vérifié : `python scripts/ci/measure_runner_demand.py --input scripts/ci/runner-demand-20260828T2000Z.json` régénère l'analyse depuis le seul snapshot
- Aucun notebook touché, aucun catalogue touché
