### PR TITLE
fix(guard,#13326): %-continuation lines are operators, not IPython magics

### DIFF
--- a/scripts/notebook_tools/check_cell_source_parses.py
+++ b/scripts/notebook_tools/check_cell_source_parses.py
@@ -62,16 +62,80 @@ def _is_python_kernel(metadata: dict) -> bool:
     return name.startswith("python") or language == "python"
 
 
+def _scan_line(line: str, depth: int, in_triple: Optional[str]) -> Tuple[int, Optional[str]]:
+    """Fold ONE physical line into the bracket/string state.
+
+    Returns (depth, in_triple) after the line. Bracket changes count only
+    outside strings and comments; a comment ends the scan for the line; a
+    triple-quoted string may open and/or close across the line; the escape
+    ``\\\\`` at end of line inside a single-quote string is irrelevant here
+    because splitlines() already made each line a physical unit (a string
+    never spans lines unless triple-quoted).
+    """
+    i, n = 0, len(line)
+    while i < n:
+        ch = line[i]
+        if in_triple is not None:
+            if line.startswith(in_triple, i):
+                in_triple = None
+                i += 3
+                continue
+            i += 1
+            continue
+        if ch == "#":
+            break  # comment: rest of the line is inert
+        if ch in "\"'":
+            triple = ch * 3
+            if line.startswith(triple, i):
+                # Enter (or pass through) a triple-quoted string.
+                j = line.find(triple, i + 3)
+                if j == -1:
+                    return depth, triple
+                i = j + 3
+                continue
+            # Single-quoted string: scan to the closing quote, honouring \".
+            j = i + 1
+            while j < n:
+                if line[j] == "\\":
+                    j += 2
+                    continue
+                if line[j] == ch:
+                    break
+                j += 1
+            i = j + 1
+            continue
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth = max(0, depth - 1)
+        i += 1
+    return depth, in_triple
+
+
 def _strip_ipython_magics(src: str) -> str:
     """Drop lines starting with `!` (shell) or `%` (magics incl. `%%`). The
     cell source may legitimately contain `!pip install` or `%%time` -- those
     are IPython, not Python. Naive `compile()` on the raw source would fail
-    on the magic prefix and produce a false positive."""
+    on the magic prefix and produce a false positive.
+
+    A magic is a LINE-level construct of IPython: it can only start a
+    LOGICAL line, never continue one. A line whose first non-space
+    character is `%` while brackets are still open (or a triple-quoted
+    string is active) is the ordinary string-formatting operator in
+    continuation position -- dropping it corrupts the source (PR #13328:
+    ``print("..."\\n      % (a, b))`` lost its argument line and the cell
+    was flagged "'(' was never closed"). The stripper therefore tracks
+    bracket depth and triple-quote state and only drops a magic line at
+    logical-line start."""
     out_lines = []
+    depth = 0
+    in_triple: Optional[str] = None
     for line in src.splitlines():
-        stripped = line.lstrip()
-        if stripped.startswith("!") or stripped.startswith("%"):
-            continue
+        if depth == 0 and in_triple is None:
+            stripped = line.lstrip()
+            if stripped.startswith("!") or stripped.startswith("%"):
+                continue
+        depth, in_triple = _scan_line(line, depth, in_triple)
         out_lines.append(line)
     return "\n".join(out_lines)
 

--- a/scripts/tests/test_check_cell_source_parses.py
+++ b/scripts/tests/test_check_cell_source_parses.py
@@ -128,6 +128,66 @@ class TestStripMagics(unittest.TestCase):
         self.assertIn("for i in range(3):", cleaned)
 
 
+class TestStripMagicsContinuation(unittest.TestCase):
+    """PR #13328: a `%` at the start of a CONTINUATION line is the ordinary
+    string-formatting operator, not an IPython magic. Dropping it corrupts
+    the cell (the reported symptom was "'(' was never closed" on the
+    previous line). The stripper must track bracket/string state."""
+
+    def test_percent_operator_continuation_kept(self):
+        src = (
+            'print("  BR1(K2*) - K1* = %.1e ; BR2(K1*) - K2* = %.1e"\n'
+            "      % (float(x.max()), float(y.max())))"
+        )
+        cleaned = _strip_ipython_magics(src)
+        self.assertEqual(cleaned, src)
+        err, _ = _mod._compile_cell(src)
+        self.assertIsNone(err)
+
+    def test_percent_continuation_after_else_print_kept(self):
+        # cell[22] motif: else-branch print, continuation, then closes.
+        src = (
+            'if p > 0.3:\n'
+            '    print("periode ~ %.0f iterations"\n'
+            '          % (1 / f, 100 * p))\n'
+            'else:\n'
+            '    print("aucune periode dominante"\n'
+            '          % (100 * p))'
+        )
+        cleaned = _strip_ipython_magics(src)
+        self.assertEqual(cleaned, src)
+        err, _ = _mod._compile_cell(src)
+        self.assertIsNone(err)
+
+    def test_percent_leading_line_inside_triple_quoted_string_kept(self):
+        src = (
+            'doc = """mise en forme\n'
+            '     %d pourcents\n'
+            '"""\n'
+            "y = 1\n"
+        )
+        cleaned = _strip_ipython_magics(src)
+        self.assertIn("%d pourcents", cleaned)
+        self.assertIn("y = 1", cleaned)
+
+    def test_magic_still_dropped_after_closed_bracket(self):
+        # Depth tracking must RESET after the bracket closes: this %%time
+        # is a real magic at logical-line start, not a continuation.
+        src = 'z = f(a)\n%%time\nfor i in range(3):\n    pass\n'
+        cleaned = _strip_ipython_magics(src)
+        self.assertNotIn("%%time", cleaned)
+        self.assertIn("z = f(a)", cleaned)
+
+    def test_magic_dropped_inside_closed_string_only_context(self):
+        # A line starting with `%` after a COMPLETE statement (no open
+        # bracket, no open string) is a magic even if it looks like an
+        # operator: IPython semantics win at logical-line start.
+        src = 'x = "valeur"\n%matplotlib inline\nprint(x)\n'
+        cleaned = _strip_ipython_magics(src)
+        self.assertNotIn("%matplotlib", cleaned)
+        self.assertIn('x = "valeur"', cleaned)
+
+
 class TestMarkdownHeuristic(unittest.TestCase):
     """`_looks_like_markdown_typed_code` must catch markdown-as-code without
     false-positiving on legitimate code that happens to start with `#`."""


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13430

See #13326 (le garde existe depuis #13329 ; cette PR corrige un faux positif du garde, l'issue reste ouverte pour les 3 vrais défauts résiduels ci-dessous)

## Perimetre

2 fichiers : `scripts/notebook_tools/check_cell_source_parses.py`, `scripts/tests/test_check_cell_source_parses.py`

## Defaut

`_strip_ipython_magics` supprimait TOUTE ligne dont le premier caractere non-espace est `%` ou `!`. Or une magie est une construction LINE-LEVEL d'IPython : elle demarre une ligne logique, elle ne peut jamais la CONTINUER. Une ligne de continuation telle que

    print("  BR1(K2*) - K1* = %.1e ; BR2(K1*) - K2* = %.1e"
          % (float(x.max()), float(y.max())))

est l'operateur de formatage ordinaire en position de continuation entre crochets ; la supprimer tronquait l'appel et le garde flaggait la cellule « '(' was never closed » — faux positif qui a reddi le check `cell-source-parses` de la PR #13328 sur 3 cellules valides, et qui toucherait 23 notebooks du depot utilisant le meme idiome.

## Fix

Le stripper suit maintenant la profondeur de crochets et l'etat triple-quote (`_scan_line`) et ne supprime une magie qu'en debut de ligne logique (profondeur 0, pas de string ouverte). Nouvelle classe de tests `TestStripMagicsContinuation` : operateur `%` garde en continuation (2 motifs reels de #13328), ligne `%`-initiale dans un triple-quoted string gardee, magie re-supprimee apres fermeture de crochets, magie supprimee apres un statement complet.

## Validation

- `pytest scripts/tests/test_check_cell_source_parses.py` : **20 passed** (14 avant + 6 nouveaux).
- Controle whole-repo : **7 findings avant -> 3 apres** ; les 4 supprimes sont tous des FP `%`-continuation (GT-14 x3 + Audio 04-10 cell[27]), les 3 conserves sont des vrais defauts pre-existants sur main (GameTheory-03d cell[7] markdown-typed-code, Audio 04-8 cell[19], DecPyMC-4 cell[17] f-strings) — hors perimetre de cette PR, signalés pour arbitrage.
