### PR TITLE
fix(ci,#13401): override G-VAR-3 deverrouille reellement les checks requis (rerun, jamais POST duplique)

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -948,8 +948,17 @@ jobs:
   # le fantome workflow_run deja mesure : un SHA qui porte un check sans dire
   # de quoi le check parle).
   #
-  # Le check-run porte le MEME nom que le job pull_request ; le verdict le plus
-  # recent par nom supplante le rouge gele de la vieille run dans la vue PR.
+  # #13401 : le check-run POSTe sous un nom DISTINCT (celui de ce job, avec
+  # deux-points) -- c'est un temoin d'information, il ne deverrouille RIEN :
+  # le check REQUIS (le nom du job pull_request) et l'agregat PR gate gardent
+  # leur rouge gele. Renommer ce POST au nom requis est mort ne : GitHub
+  # exige que TOUT check-run portant le nom d'un check requis soit vert (un
+  # ET, pas un latest-wins, #11519) -- un POST vert pose a cote du rouge gele
+  # de la run originale laisse la PR bloquee. Le mecanisme valide est la
+  # RE-RUN des runs ORIGINAUX pour le SHA de tete (le run pull_request de ce
+  # garde + l'agregat PR gate), dans la branche verdict vert ci-dessous : la
+  # re-run produit son check-run dans la MEME suite, ou le latest-wins tient
+  # (recette pr-gate-rerun.yml, #11519).
   #
   # Anti-boucle : ce job NE POSTE PAS de commentaire en retour (le chemin
   # bloquant s'exprime dans l'output du check-run), et il s'ignore lui-meme :
@@ -979,6 +988,10 @@ jobs:
       contents: read
       pull-requests: write
       checks: write
+      # #13401 : re-runner le run pull_request ORIGINAL de ce garde et
+      # l'agregat PR gate quand l'OVERRIDE est accepte -- le mecanisme
+      # valide est re-run, jamais POST duplique (#11519).
+      actions: write
     steps:
       - name: Checkout the adjacency helper (sparse, branche par defaut = gate COURANT)
         uses: actions/checkout@v4
@@ -1070,7 +1083,46 @@ jobs:
           SUMMARY=$(cat /tmp/verdict.json 2>/dev/null || echo '{}')
           if [ "$RC" -eq 0 ]; then
             echo "Adjacence OK (comment path)."
-            post_check success "Verdict du gate COURANT (main), declenche par commentaire :$SUMMARY"
+
+            # --- Re-run des runs ORIGINAUX, jamais un POST duplique ------
+            # #13401 : l'OVERRIDE accepte rend vert le temoin de CE job
+            # mais ni le check requis (job pull_request de ce garde) ni
+            # l'agregat PR gate ne bougent -- un POST vert sous leur nom
+            # ne les deverrouillerait pas (ET, pas latest-wins, #11519).
+            # On RE-RUN les runs originaux du meme SHA de tete : la re-run
+            # produit son check-run dans la MEME suite, ou le latest-wins
+            # tient (recette pr-gate-rerun.yml). Echec => ::warning::
+            # loud, jamais silencieux.
+
+            # (a) run pull_request de CE workflow pour le SHA de tete (le
+            # filtre --event exclut ce job commentaire, en issue_comment) :
+            # c'est le porte-nom du check requis.
+            GUARD_RUN_ID=$(gh run list --workflow variation-tag-guard.yml --event pull_request \
+              --limit 30 --json databaseId,headSha,status \
+              | python3 -c "import json,os,sys; print(next((r['databaseId'] for r in json.load(sys.stdin) if r['headSha']==os.environ.get('HEAD_SHA','') and r['status']=='completed'), ''))" 2>/dev/null \
+              || true)
+            if [ -n "$GUARD_RUN_ID" ] && gh run rerun "$GUARD_RUN_ID"; then
+              RERUN_NOTES="run pull_request du garde ${GUARD_RUN_ID} re-declenche"
+            else
+              echo "::warning::[G-VAR-3] aucun run pull_request variation-tag-guard termine pour ${HEAD_SHA} -- rerun MANUEL requis (gh run rerun, #13401)."
+              RERUN_NOTES="rerun du garde NON emis -- rerun manuel requis"
+            fi
+
+            # (b) agregat PR gate pour le meme SHA (recette #11519 : run le
+            # plus recent de ce nom pour le SHA ; on ne re-run que les runs
+            # termines -- l'API rejette la re-run d'un run en cours).
+            GATE_RUN_JSON=$(gh api "repos/${GH_REPO}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" \
+              --jq '[.workflow_runs[] | select(.name == "PR gate")] | sort_by(.created_at) | last')
+            GATE_RUN_ID=$(printf '%s' "$GATE_RUN_JSON" | jq -r '.id // empty' 2>/dev/null || true)
+            GATE_STATUS=$(printf '%s' "$GATE_RUN_JSON" | jq -r '.status // empty' 2>/dev/null || true)
+            if [ -n "$GATE_RUN_ID" ] && [ "$GATE_STATUS" = "completed" ] && gh run rerun "$GATE_RUN_ID"; then
+              RERUN_NOTES="${RERUN_NOTES}; run PR gate ${GATE_RUN_ID} re-declenche"
+            else
+              echo "::warning::[G-VAR-3] aucun run PR gate termine pour ${HEAD_SHA} -- rerun MANUEL requis (gh run rerun, #13401)."
+              RERUN_NOTES="${RERUN_NOTES}; rerun PR gate NON emis -- rerun manuel requis"
+            fi
+
+            post_check success "Verdict du gate COURANT (main), declenche par commentaire :$SUMMARY -- deverrouillage : $RERUN_NOTES"
             exit 0
           fi
           REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo unknown)

--- a/scripts/tests/test_variation_tag_override_rerun.py
+++ b/scripts/tests/test_variation_tag_override_rerun.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Wiring tests for the OVERRIDE unblock path of variation-tag-guard (#13401).
+
+The defect #13401 pins: the `[G-VAR-3 OVERRIDE]` marker made the comment job
+post a SUCCESS check-run under a DISTINCT name (`Require genre diversity vs
+prev: (...)`, colon form) -- an informational breadcrumb -- while the
+REQUIRED check (the pull_request job's name) and the `PR gate` aggregate
+(the only check required by branch protection) kept their stale red. A human
+had to `gh run rerun` by hand (measured live on PR #13387 head 2202fcb864).
+
+Renaming the POST to the required name is dead on arrival (#11519): GitHub
+requires EVERY check-run bearing a required check's name to be green -- an
+AND, not latest-wins -- so a green POST beside the old red run unblocks
+nothing. The validated mechanism is RE-RUN, NEVER POST: re-running the
+original run produces a check-run in the SAME suite, where latest-wins
+holds. These tests pin that wiring:
+
+  1. the comment job carries `actions: write` (job-level permissions
+     REPLACE workflow-level ones -- without it, `gh run rerun` fails);
+  2. the verdict-green branch re-runs this workflow's own pull_request run
+     (filtered by `--event pull_request`, so the comment run itself is
+     never the target) AND the latest "PR gate" run for the same head SHA;
+  3. the reruns sit ONLY in the RC=0 branch -- the failure path (RC != 0)
+     exits 1 before reaching them, and the out-of-scope early exits
+     (bot author / fork PR) live before the RC=0 marker;
+  4. the re-run degrades LOUDLY (`::warning::` + breadcrumb summary) when
+     no completed target run exists -- never silently.
+
+Run:
+    python -m pytest scripts/tests/test_variation_tag_override_rerun.py
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "variation-tag-guard.yml"
+COMMENT_JOB = "check-variation-adjacency-comment"
+
+
+def _load() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _comment_job_run_script() -> str:
+    """Concatenated `run:` bodies of the comment job (single big step today;
+    the concatenation keeps the assertions robust to a later step split)."""
+    job = _load()["jobs"][COMMENT_JOB]
+    return "\n".join(step.get("run", "") for step in job["steps"])
+
+
+def test_comment_job_has_actions_write_permission():
+    """`gh run rerun` exige actions:write ; les permissions job-level
+    REMPLACENT (ne fusionnent pas) celles du workflow -- il faut la
+    redeclarer sur CE job, pas seulement au niveau workflow."""
+    perms = _load()["jobs"][COMMENT_JOB].get("permissions") or {}
+    assert perms.get("actions") == "write", (
+        "actions:write absente du job commentaire : le `gh run rerun` du run "
+        "original echouerait et l'OVERRIDE #13401 ne deverrouillerait toujours rien"
+    )
+
+
+def test_verdict_green_branch_re_runs_original_guard_pull_request_run():
+    run = _comment_job_run_script()
+    assert "gh run rerun" in run, (
+        "recette de re-run absente : le POST sous nom distinct ne deverrouille rien (#13401)"
+    )
+    assert "--workflow variation-tag-guard.yml" in run, (
+        "le rerun du garde doit cibler CE workflow (variation-tag-guard.yml)"
+    )
+    assert "--event pull_request" in run, (
+        "le rerun du garde doit filtrer --event pull_request : le run issue_comment "
+        "de ce job ne porte pas le nom du check requis"
+    )
+
+
+def test_verdict_green_branch_re_runs_pr_gate_aggregate():
+    run = _comment_job_run_script()
+    assert 'select(.name == "PR gate")' in run, (
+        "le rerun doit AUSSI cibler l'agregat PR gate (le seul check requis par la "
+        "branch protection) pour le meme SHA -- recette pr-gate-rerun.yml (#11519)"
+    )
+    assert "head_sha=${HEAD_SHA}" in run, (
+        "le ciblage des runs doit etre le SHA de tete resolu de la PR, pas le SHA de l'evenement"
+    )
+
+
+def test_rerun_is_gated_to_the_verdict_green_branch():
+    """Le rerun doit sieger dans la branche RC=0 (verdict vert : OVERRIDE
+    accepte ou adjacence reellement OK) -- le chemin bloquant (RC != 0)
+    sort en exit 1 AVANT de l'atteindre, et les sorties anticipees
+    hors-scope (bot / fork) sont avant le marqueur RC=0."""
+    run = _comment_job_run_script()
+    rc0 = run.find('"$RC" -eq 0')
+    assert rc0 != -1, "marqueur RC=0 introuvable dans le script du job commentaire"
+    rerun = run.find("gh run rerun")
+    assert rerun > rc0, (
+        "gh run rerun doit etre APRES le marqueur RC=0 (branche verdict vert) : un "
+        "rerun place avant executerait aussi sur le chemin bloquant et les cas hors-scope"
+    )
+    # La sortie verte de la branche RC=0 est APRES le rerun : le chemin
+    # echec (fall-through, exit 1) ne peut pas l'avoir traverse.
+    green_exit = run.find("exit 0", rc0)
+    assert -1 < rerun < green_exit, "le rerun doit etre contenu dans la branche RC=0 (avant son exit 0)"
+    # Chemin echec : post_check failure ... exit 1, sans aucun rerun entre
+    # les deux (verdict rouge = on bloque, on ne re-run rien).
+    fail_post = run.find("post_check failure")
+    fail_exit = run.find("exit 1", fail_post)
+    assert fail_post != -1 and fail_exit != -1, "chemin bloquant (post_check failure / exit 1) introuvable"
+    assert "gh run rerun" not in run[fail_post:fail_exit], (
+        "le chemin bloquant ne doit PAS re-runner les gates (#13401 : le rerun est la "
+        "recompense du verdict vert, pas du rouge)"
+    )
+    # Hors-scope (bot, fork) : sorties anticipees AVANT le marqueur RC=0,
+    # donc hors de portee du rerun.
+    assert "gh run rerun" not in run[:rc0], (
+        "un rerun avant le marqueur RC=0 toucherait aussi les cas hors-scope (bot/fork) "
+        "qui sortent en succes sans verdict de garde"
+    )
+
+
+def test_rerun_degrades_loudly_not_silently():
+    """Pas de run cible termine (ou rerun rejete par l'API) => ::warning::
+    explicite demandant un rerun manuel -- un deverrouillage qui echoue en
+    silence laisse croire que l'OVERRIDE a marche (#13401)."""
+    run = _comment_job_run_script()
+    warnings = [ln for ln in run.splitlines() if "::warning::" in ln]
+    assert warnings and any("rerun" in ln.lower() for ln in warnings), (
+        "le fallback d'un rerun impossible doit se voir (::warning:: ... rerun MANUEL requis)"
+    )
+
+
+def test_success_breadcrumb_summary_mentions_the_rerun():
+    """Le temoin de succes (POST sous le nom distinct) doit signaler que les
+    runs requis ont ete re-declenches -- sinon le lecteur de la vue PR ne
+    fait pas le lien temoin vert <-> deverrouillage en cours."""
+    run = _comment_job_run_script()
+    rc0 = run.find('"$RC" -eq 0')
+    green = run[rc0 : run.find("exit 0", rc0)]
+    success_calls = [ln for ln in green.splitlines() if "post_check success" in ln]
+    assert success_calls, "post_check success absent de la branche RC=0"
+    assert "RERUN_NOTES" in success_calls[0], (
+        "le summary du temoin de succes doit mentionner l'etat du re-trigger des runs requis"
+    )


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: LIGHT/docs-lean #13431

## Problem

See #13401. Le chemin commentaire `[G-VAR-3 OVERRIDE]` du `variation-tag-guard` postait un check-run SUCCESS sous un nom DISTINCT (forme deux-points, lignes 1010/1018) : **temoin d'information, pas un deverrouillage**. Le check REQUIS (le nom du job `pull_request`, ligne 805) et l'agregat `PR gate` gardaient leur rouge gele -- l'OVERRIDE n'a jamais debloque une seule PR.

**Mesure live (premierhand, #13387 head 2202fcb864)** : 2 check-runs seulement sur le head -- comment=skipped 18:21, required=success **apres rerun manuel**. Le colon-variant est absent : c'est le rerun manuel qui a deverrouille, pas l'override.

## Design (pourquoi pas un renommage du POST)

Renommer le POST au nom du check requis est **mort ne** : GitHub exige que TOUT check-run portant le nom d'un check requis soit vert -- un **ET, pas latest-wins** (#11519, documente dans `pr-gate-rerun.yml`). Un POST vert pose a cote du rouge gele de la run originale laisse la PR bloquee. Le mecanisme valide = **RE-RUN de la run originale** (meme suite, latest-wins tient).

## Fix

Dans la branche verdict vert (RC=0, override accepte) du job `check-variation-adjacency-comment` :

1. **(a)** Re-run du run `pull_request` de CE workflow pour le SHA de tete resolu -- `gh run list --workflow variation-tag-guard.yml --event pull_request` (le filtre evenement exclut ce job commentaire lui-meme, en issue_comment), match `headSha`, statut `completed` requis.
2. **(b)** Re-run de la run **PR gate** la plus recente pour le meme SHA (recette `pr-gate-rerun.yml` : `gh api .../actions/runs?head_sha=...&event=pull_request`, `select(.name == "PR gate")`, la plus recente, `completed` seulement).
3. `actions: write` ajoutee aux permissions du job (les permissions job-level REMPLACENT celles du workflow -- sans elle, `gh run rerun` echoue).
4. **Degradation LOUD** : `::warning::` + breadcrumb `RERUN_NOTES` dans le summary si aucun run cible n'est trouve -- jamais silencieux.
5. Le temoin colon-name reste poste (breadcrumb d'information), maintenant enrichi du statut de deverrouillage.

Chemins hors-scope (bot, fork) et chemin RC!=0 **intacts** -- aucun rerun hors override accepte.

## Tests

- Nouveau `scripts/tests/test_variation_tag_override_rerun.py` : **6/6 passed** (permissions, cible (a) avec filtre evenement, cible (b) avec select PR gate, placement RC=0 seulement, degradation loud, breadcrumb summary).
- **Fail-on-main verifie par stash** : 6/6 FAILED sur l'etat `origin/main` du workflow (chaque assertion epingle le nouveau cablage).
- Regressions : suites adjacentes (`test_variation_tag_comment_trigger`, `test_pr_gate_rerun_noop_guard`) **10/10 passed** ; suite complete du sous-agent : 226 passed.
- `yaml.safe_load` OK ; script de job extrait : `bash -n` exit 0 ; one-liner python embarque : compile.

## Validation restante (coordinateur)

L'acceptance de #13401 exige la validation **live** d'un override sur une PR reellement bloquee -- un test sur un repo de production ne peut pas simuler la protection de branche. Procedure : bloquer une PR test avec G-VAR-3, poster `[G-VAR-3 OVERRIDE]`, observer les deux re-runs + le passage du PR gate. D'ou `See #13401` et non `Closes`.

## Checklist

- [x] 1 fichier workflow + 1 fichier test, rien d'autre (catalogue non touche)
- [x] Test structural echouant sur main (verifie par stash)
- [x] Aucune modification des chemins hors-scope / RC!=0
