### PR TITLE
feat(pymc): expose strict diagnostics across PyMC-15 traces

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
@@ -3169,18 +3169,6 @@
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
   },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 87.052734,
-   "end_time": "2026-08-26T10:55:15.439935",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "PyMC-15-Recommenders.ipynb",
-   "output_path": "PyMC-15-Recommenders.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-26T10:53:48.387201",
-   "version": "2.6.0"
-  },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
@@ -32,10 +32,10 @@
    "id": "006afef1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:53:49.795593Z",
-     "iopub.status.busy": "2026-08-26T10:53:49.795593Z",
-     "iopub.status.idle": "2026-08-26T10:53:49.805833Z",
-     "shell.execute_reply": "2026-08-26T10:53:49.805833Z"
+     "iopub.execute_input": "2026-08-29T01:35:17.259263Z",
+     "iopub.status.busy": "2026-08-29T01:35:17.259263Z",
+     "iopub.status.idle": "2026-08-29T01:35:17.271750Z",
+     "shell.execute_reply": "2026-08-29T01:35:17.271750Z"
     },
     "papermill": {
      "duration": 0.029185,
@@ -93,10 +93,10 @@
    "id": "c7fbd5f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:53:49.871380Z",
-     "iopub.status.busy": "2026-08-26T10:53:49.871380Z",
-     "iopub.status.idle": "2026-08-26T10:53:52.568902Z",
-     "shell.execute_reply": "2026-08-26T10:53:52.568902Z"
+     "iopub.execute_input": "2026-08-29T01:35:17.274754Z",
+     "iopub.status.busy": "2026-08-29T01:35:17.273753Z",
+     "iopub.status.idle": "2026-08-29T01:35:20.215574Z",
+     "shell.execute_reply": "2026-08-29T01:35:20.215574Z"
     },
     "papermill": {
      "duration": 2.715823,
@@ -215,10 +215,10 @@
    "id": "21aaaf9e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:53:52.702050Z",
-     "iopub.status.busy": "2026-08-26T10:53:52.701532Z",
-     "iopub.status.idle": "2026-08-26T10:53:52.706114Z",
-     "shell.execute_reply": "2026-08-26T10:53:52.706114Z"
+     "iopub.execute_input": "2026-08-29T01:35:20.215574Z",
+     "iopub.status.busy": "2026-08-29T01:35:20.215574Z",
+     "iopub.status.idle": "2026-08-29T01:35:20.221718Z",
+     "shell.execute_reply": "2026-08-29T01:35:20.221718Z"
     },
     "papermill": {
      "duration": 0.023112,
@@ -316,10 +316,10 @@
    "id": "35dca21b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:53:52.809097Z",
-     "iopub.status.busy": "2026-08-26T10:53:52.809097Z",
-     "iopub.status.idle": "2026-08-26T10:53:52.835016Z",
-     "shell.execute_reply": "2026-08-26T10:53:52.834498Z"
+     "iopub.execute_input": "2026-08-29T01:35:20.221718Z",
+     "iopub.status.busy": "2026-08-29T01:35:20.221718Z",
+     "iopub.status.idle": "2026-08-29T01:35:20.268960Z",
+     "shell.execute_reply": "2026-08-29T01:35:20.268960Z"
     },
     "papermill": {
      "duration": 0.04337,
@@ -368,6 +368,72 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5ca8f5ff",
+   "metadata": {},
+   "source": [
+    "### Outil réutilisable : rapport de diagnostic strict MCMC\n",
+    "\n",
+    "Avant la première inference, nous définissons **une seule fois** l'instrument qui jugera **toutes** les traces de ce notebook. Le rapport applique quatre critères stricts — les seuils des warnings officiels de PyMC (cf [PyMC-6-Debugging](PyMC-6-Debugging.ipynb)) :\n",
+    "\n",
+    "| Critère | Seuil strict | Ce qu'il détecte |\n",
+    "|---------|--------------|------------------|\n",
+    "| Divergences | `= 0` | Trajectoires hamiltoniennes divergentes (postérieur mal conditionné) |\n",
+    "| `r_hat` | `< 1.01` | Des chaînes qui n'ont pas mélangé vers la même distribution |\n",
+    "| `ess_bulk` | `> 400` | Trop peu d'échantillons effectifs pour la moyenne / l'écart-type |\n",
+    "| `ess_tail` | `> 400` | Trop peu d'échantillons effectifs pour les quantiles extrêmes |\n",
+    "\n",
+    "Un critère non tenu **n'interrompt pas** le notebook : le rapport l'affiche `FAIL` et la « Lecture du résultat » qui suit l'explique. Plusieurs modèles de ce notebook sont volontairement sous-contraints à des fins pédagogiques — la leçon est de **quantifier** leurs défauts de convergence, pas de les cacher."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c068431b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T01:35:20.270473Z",
+     "iopub.status.busy": "2026-08-29T01:35:20.270473Z",
+     "iopub.status.idle": "2026-08-29T01:35:20.275581Z",
+     "shell.execute_reply": "2026-08-29T01:35:20.275581Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 fonction definie : rapport_diagnostic_strict(trace, nom_modele)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Rapport de diagnostic strict, reutilisable pour toutes les traces du notebook.\n",
+    "# Seuils stricts (meme regle que les warnings PyMC, cf PyMC-6-Debugging) :\n",
+    "# divergences = 0, r_hat < 1.01, ess_bulk > 400, ess_tail > 400.\n",
+    "# Un critere non tenu n'interrompt PAS le notebook : il s'affiche FAIL et la\n",
+    "# lecture du resultat qui suit l'explique (pedagogie honnete).\n",
+    "def rapport_diagnostic_strict(trace, nom_modele):\n",
+    "    diag = az.summary(trace, kind=\"diagnostics\")\n",
+    "    div = int(trace.sample_stats[\"diverging\"].sum())\n",
+    "    criteres = [\n",
+    "        (\"divergences = 0\", div == 0, f\"{div} divergences\"),\n",
+    "        (\"r_hat < 1.01\", float(diag[\"r_hat\"].max()) < 1.01,\n",
+    "         f\"max r_hat = {diag['r_hat'].max():.3f} (sur {diag['r_hat'].idxmax()})\"),\n",
+    "        (\"ess_bulk > 400\", int(diag[\"ess_bulk\"].min()) > 400,\n",
+    "         f\"min ess_bulk = {int(diag['ess_bulk'].min())} (sur {diag['ess_bulk'].idxmin()})\"),\n",
+    "        (\"ess_tail > 400\", int(diag[\"ess_tail\"].min()) > 400,\n",
+    "         f\"min ess_tail = {int(diag['ess_tail'].min())} (sur {diag['ess_tail'].idxmin()})\"),\n",
+    "    ]\n",
+    "    n_ok = sum(1 for _, ok, _ in criteres if ok)\n",
+    "    print(f\"Rapport strict ({nom_modele}) : {n_ok}/4 criteres tenus\")\n",
+    "    for critere, ok, valeur in criteres:\n",
+    "        print(f\"  [{'PASS' if ok else 'FAIL'}] {critere:<16} -> {valeur}\")\n",
+    "\n",
+    "print(\"1 fonction definie : rapport_diagnostic_strict(trace, nom_modele)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ef6d0d47",
    "metadata": {
     "papermill": {
@@ -387,14 +453,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "26039705",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:53:52.904586Z",
-     "iopub.status.busy": "2026-08-26T10:53:52.903040Z",
-     "iopub.status.idle": "2026-08-26T10:53:57.795420Z",
-     "shell.execute_reply": "2026-08-26T10:53:57.795420Z"
+     "iopub.execute_input": "2026-08-29T01:35:20.275581Z",
+     "iopub.status.busy": "2026-08-29T01:35:20.275581Z",
+     "iopub.status.idle": "2026-08-29T01:35:38.473976Z",
+     "shell.execute_reply": "2026-08-29T01:35:38.473976Z"
     },
     "papermill": {
      "duration": 4.909783,
@@ -430,7 +496,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8a8bd28f25e84ab7af1afd4efafd0a5f",
+       "model_id": "d607b5a22ec44fd9a0ad4107c885b064",
        "version_major": 2,
        "version_minor": 0
       },
@@ -462,7 +528,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "There were 7 divergences after tuning. Increase `target_accept` or reparameterize.\n"
+      "There were 163 divergences after tuning. Increase `target_accept` or reparameterize.\n"
      ]
     },
     {
@@ -473,10 +539,29 @@
      ]
     },
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Inference terminee.\n"
+      "Inference terminee.\n",
+      "Rapport strict (factorisation initiale) : 0/4 criteres tenus\n",
+      "  [FAIL] divergences = 0  -> 163 divergences\n",
+      "  [FAIL] r_hat < 1.01     -> max r_hat = 1.140 (sur sigma)\n",
+      "  [FAIL] ess_bulk > 400   -> min ess_bulk = 11 (sur sigma)\n",
+      "  [FAIL] ess_tail > 400   -> min ess_tail = 27 (sur sigma)\n"
      ]
     },
     {
@@ -514,15 +599,15 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>sigma</th>\n",
-       "      <td>2.238</td>\n",
-       "      <td>0.563</td>\n",
-       "      <td>1.06</td>\n",
-       "      <td>3.175</td>\n",
-       "      <td>0.023</td>\n",
-       "      <td>0.016</td>\n",
-       "      <td>615.086</td>\n",
-       "      <td>323.711</td>\n",
-       "      <td>1.001</td>\n",
+       "      <td>2.018</td>\n",
+       "      <td>0.752</td>\n",
+       "      <td>0.626</td>\n",
+       "      <td>3.056</td>\n",
+       "      <td>0.254</td>\n",
+       "      <td>0.155</td>\n",
+       "      <td>11.302</td>\n",
+       "      <td>27.28</td>\n",
+       "      <td>1.141</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -530,13 +615,13 @@
       ],
       "text/plain": [
        "        mean     sd  hdi_3%  hdi_97%  mcse_mean  mcse_sd  ess_bulk  ess_tail  \\\n",
-       "sigma  2.238  0.563    1.06    3.175      0.023    0.016   615.086   323.711   \n",
+       "sigma  2.018  0.752   0.626    3.056      0.254    0.155    11.302     27.28   \n",
        "\n",
        "       r_hat  \n",
-       "sigma  1.001  "
+       "sigma  1.141  "
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -549,6 +634,10 @@
     "                         return_inferencedata=True)\n",
     "\n",
     "print(\"Inference terminee.\")\n",
+    "\n",
+    "# Diagnostic strict sur TOUT le posteriori (U, V, sigma) -- pas seulement sigma\n",
+    "rapport_diagnostic_strict(trace_mf, \"factorisation initiale\")\n",
+    "\n",
     "az.summary(trace_mf, var_names=['sigma'], round_to=3)"
    ]
   },
@@ -565,15 +654,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du résultat : 163 divergences — diagnostic critique\n",
-    "\n",
-    "La sortie révèle **163 divergences** après tuning — c'est un **signal d'alarme**. Une divergence signifie que NUTS a détecté un problème numérique dans l'exploration (la trajectoire hamiltonienne diverge), indiquant un postérieur mal conditionné. Causes probables ici :\n",
-    "- **Modèle sous-contraint** : peu de données (8 obs) pour beaucoup de paramètres (U 4×2 + V 5×2 + sigma = 21 params), ratio ~0.4.\n",
-    "- **Priors trop larges** : les gaussiennes laissent les traits dériver vers des régions pathologiques.\n",
-    "\n",
-    "Le warning PyMC le dit explicitement : « Increase `target_accept` or reparameterize ». La section suivante (modèle corrigé avec biais) montrera comment réduire ces divergences — c'est la **leçon de diagnostic MCMC** centrale de ce notebook."
-   ]
+   "source": "### Lecture du résultat : 163 divergences — diagnostic critique (0/4 au rapport strict)\n\nLe rapport strict ci-dessus affiche **0/4 critères tenus** : **163 divergences** après tuning, `r_hat` max **1.140** (sur `sigma`), `ess_bulk` min **11** et `ess_tail` min **27** — les trois derniers mesurés sur `sigma` également. C'est un **signal d'alarme** complet : une divergence signifie que NUTS a détecté un problème numérique dans l'exploration (la trajectoire hamiltonienne diverge), indiquant un postérieur mal conditionné. Causes probables ici :\n- **Modèle sous-contraint** : peu de données (8 obs) pour beaucoup de paramètres (U 4×2 + V 5×2 + sigma = 21 params), ratio ~0.4.\n- **Priors trop larges** : les gaussiennes laissent les traits dériver vers des régions pathologiques.\n\nLe warning PyMC le dit explicitement : « Increase `target_accept` or reparameterize ». La section suivante (modèle corrigé avec biais) montrera comment réduire ces divergences — c'est la **leçon de diagnostic MCMC** centrale de ce notebook."
   },
   {
    "cell_type": "markdown",
@@ -596,14 +677,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "d603db24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:53:57.909551Z",
-     "iopub.status.busy": "2026-08-26T10:53:57.909551Z",
-     "iopub.status.idle": "2026-08-26T10:53:57.915926Z",
-     "shell.execute_reply": "2026-08-26T10:53:57.915926Z"
+     "iopub.execute_input": "2026-08-29T01:35:38.508340Z",
+     "iopub.status.busy": "2026-08-29T01:35:38.508340Z",
+     "iopub.status.idle": "2026-08-29T01:35:38.516070Z",
+     "shell.execute_reply": "2026-08-29T01:35:38.516070Z"
     },
     "papermill": {
      "duration": 0.028718,
@@ -620,24 +701,24 @@
      "output_type": "stream",
      "text": [
       "=== Traits utilisateurs (U) ===\n",
-      "  User 0: [0.018, 0.025]\n",
-      "  User 1: [0.088, -0.038]\n",
-      "  User 2: [0.047, 0.025]\n",
-      "  User 3: [0.078, -0.002]\n",
+      "  User 0: [0.310, -0.187]\n",
+      "  User 1: [-0.084, 0.298]\n",
+      "  User 2: [0.155, -0.235]\n",
+      "  User 3: [-0.235, 0.188]\n",
       "\n",
       "=== Traits items (V) ===\n",
-      "  Item 0: [0.060, 0.050]\n",
-      "  Item 1: [0.109, -0.028]\n",
-      "  Item 2: [0.002, 0.050]\n",
-      "  Item 3: [0.010, 0.007]\n",
-      "  Item 4: [0.013, 0.069]\n",
+      "  Item 0: [0.107, -0.293]\n",
+      "  Item 1: [-0.092, 0.282]\n",
+      "  Item 2: [0.083, -0.136]\n",
+      "  Item 3: [-0.139, 0.133]\n",
+      "  Item 4: [0.210, -0.288]\n",
       "\n",
       "=== Notes predites (moyenne posterior) ===\n",
       "        Item  0 Item  1 Item  2 Item  3 Item  4 \n",
-      "User  0   0.00*  0.00   0.00*  0.00   0.00  \n",
-      "User  1   0.00   0.01* -0.00   0.00* -0.00  \n",
-      "User  2   0.00*  0.00   0.00   0.00   0.00* \n",
-      "User  3   0.00   0.01*  0.00   0.00*  0.00  \n",
+      "User  0   0.09* -0.08   0.05* -0.07   0.12  \n",
+      "User  1  -0.10   0.09* -0.05   0.05* -0.10  \n",
+      "User  2   0.09* -0.08   0.04  -0.05   0.10* \n",
+      "User  3  -0.08   0.07* -0.05   0.06* -0.10  \n",
       "(* = observation, autres = prediction)\n"
      ]
     }
@@ -692,14 +773,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "d35364ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:53:57.992097Z",
-     "iopub.status.busy": "2026-08-26T10:53:57.992097Z",
-     "iopub.status.idle": "2026-08-26T10:53:58.124912Z",
-     "shell.execute_reply": "2026-08-26T10:53:58.123792Z"
+     "iopub.execute_input": "2026-08-29T01:35:38.516070Z",
+     "iopub.status.busy": "2026-08-29T01:35:38.516070Z",
+     "iopub.status.idle": "2026-08-29T01:35:38.689701Z",
+     "shell.execute_reply": "2026-08-29T01:35:38.688588Z"
     },
     "papermill": {
      "duration": 0.151366,
@@ -713,7 +794,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAJOCAYAAAAqFJGJAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYN1JREFUeJzt3Qm8TPX/+PH3XV3bvde+r0UoS24RKYpQCqVNJPJHi0rK90ubtElFKlnaf4ovXy0q9SUkKqKQshOyZd9d3G3+j/dHM83cO/femXtm7swcr2ePyZ2zzeeczzkz530+W5TD4XAIAAAAAFgQbWVlAAAAAFAEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAIImKipKnn766VAnwxb0OOrxdFezZk3p3bu36/13331nltF/kbvrrrtO+vXrJ+GkIHmXnp4u1apVk/Hjxwc1bee6l156SerVqydZWVliR7fffrvceuutoU4GbILAAgiSDz74wNwo5Pb66aefQp3EsLV27VpzI71t27agf1Zqaqr5rGDcjDvPgV9++cXr/Ouvv94EB4WRlkDQG1jdp0j2448/yjfffCP//ve/JdLFxcXJ4MGD5fnnn5fTp0+HTXD08ccfu6YtXrzYnNNHjhyRSHTs2DEZNWqUOV+io+15y6T79sknn8iqVatCnRTYgD2vEiCMPPPMM/Lhhx/meJ1//vmhTlpYBxYjRowotMBCPyscbubzSssTTzwhp06dynP9K6+80iyj/waDHQKLl19+Wdq2bWub669Pnz5y4MABmTp1qoQjDSz0nI7UwOK9996TjIwM6d69u9jVxRdfLJdccomMHj061EmBDcSGOgGA3V177bXmSxuwIjY21rzyok9UExISxK5OnjwpxYsXL/D6+/btk6+++komTpwY9M8qLMnJydK+fXsT8N19992hTo7tvP/++9K5c+dCva4cDocpgSpatGiOeTo9Pj4+4KUnWhVq+PDh5uFBiRIlArptnFsosQDCwLRp0yQlJUVKliwpiYmJ0rBhQ3nttddyVKlZtGiRDBgwQMqUKWOW69Wrlxw+fNhjW59//rl06tRJKleuLEWKFJHzzjtPnn32WcnMzMzxuUuXLjX1zUuVKmVuoho1auTxuWr9+vVy8803S+nSpc2PqwZJX3zxRYH2888//5T77rtPLrjgAvOjqftxyy23eJRM6L7qNHXVVVe5qo65P8X/3//+J1dccYVJsx4z3d81a9Z4fJa2PdAfyF27dknXrl3N3+XKlZNHH33UdSz0c3Wa0qeqzs/Kr13IH3/8YV6BlF9avLWx8KWe/qZNm6Rbt25SsWJFk39Vq1Y1daqPHj3qcfN09dVXS/ny5c0506BBA5kwYYLHtrXKlh7jhQsXutLWpk0b13x9Ij1o0CBT51+3oSUCWoXEvV56bu0IdN91untpiDP/9DjrOar53KNHD5/3yRsNKvTpc7t27TymO68v3Tc9P/U46Dad9GbrwgsvNPul19X999+f4wm8HouLLrrIlLbpeVusWDGpUqWKqZ+f3c6dO805qeevftbDDz8sZ86cybGcr/t5zTXXyA8//CCHDh3Kdd/37t1rAlM9t7LbsGGD2f9x48a52m7ocnXq1DGfq9dpq1atZO7cueIPPWeHDBli/q5Vq5brvHG/3j/66CPz3affB/odo/u3Y8cOr8f2t99+k9atW5tjq+eXs8qV5lvz5s3NNvS7Zd68eR7rHz9+3Jybeg5rHuox12O2YsWKPNO/detW85nZzxel57V+V+p3tR4jvXY7duzoUe3Rl+tKabq0WuScOXPM96vux6RJk1zXi/4+aImlnk+671o9y/n9rZ+ZlJRkpuux0ap+Bdl3nabBtL95DGRHiQUQZHoToFUV3OmPhf5YK/0i12J2rZ6hN2Jq3bp15gfioYce8lhv4MCB5gml/mDrzYD+SOnNuvMHyHmTpDdkWvda//3222/lqaeeMj9GWg3EST9Xf8wqVapkPkdvXvRzZ82a5fpcvZG8/PLLzQ/a0KFDzY3Qf//7X3NTpHVyb7zxRr+Oxc8//2yqRujNg94k6Q2G7oPeOOgNmf44ajWeBx98UF5//XV57LHHpH79+mZd579ajeyuu+6SDh06mOOl1Yd0G3rjs3LlSo82CxpA6HJ60/HKK6+YGw4t7tdg69577zU3A7qu/q37ctNNN5n1NMDKi+aVCmRVrYKmJS9paWlm//Wm9YEHHjB5rIGW5rHeGOsNidLP1RtnfTKrN59ffvmlucHWmye9iVZjx44129Bz6vHHHzfTKlSoYP7VPNCbGt22Br7Vq1c3+Txs2DD566+/zLoFoUGApl/zVvNPzw9f98kbTZNedzVq1PA6X/dZ80GvF73JUnqt6U223lxq3jivOz2X9RrVdg5OGuTrjZ7mnT4B1htfrb+uN59acqm0qpqeP9u3bzfnuQYqek7rdVqQvFN6Y65PuXX/9Jr2RvNK80ivX30y7W769OkSExPjCuh1n0eOHCn/7//9P2nWrJn57tAbZr0Z1RtQX+lx2Lhxo/znP/+RV199VcqWLWumOwNobRvy5JNPmmOln7V//3554403zHeAXsv6Xed+bHXf9LtD06l5oH9PmTLF3Djfc889cscdd5jvOH0QosGJBqNK52le6Pen3twfPHjQBGL6fde0adNc06/HU3lbpm/fvua7VvNV067n6vfff2/azjlLqH25rpz0vNLfAb1+tGMBDZCc9MGQllLoQxE9H/RvPV/0szXvNT+1BMMZyGg6NN/82XedpwGNntP+fq8DHhwAguL999936CXm7VWkSBHXcg899JAjMTHRkZGRke+2UlJSHGlpaa7pL730kpn++eefu6alpqbmWH/AgAGOYsWKOU6fPm3e62fVqlXLUaNGDcfhw4c9ls3KynL93bZtW0fDhg1d6znnt2zZ0lGnTp18j4Gmbfjw4XmmbcmSJWa5yZMnu6bNmDHDTFuwYIHHssePH3ckJyc7+vXr5zF9z549jqSkJI/pd911l9nGM88847HsxRdfbI6j0/79+3OkMz963PSVH2e+/fzzz17nd+rUyWM7eaVFp2X/ytZ1dT+d9Hi5H7eVK1ea93o88+ItXzp06OCoXbu2x7QLL7zQ0bp16xzLPvvss47ixYs7Nm7c6DF96NChjpiYGMf27du9ps9p69atZroer+z5p9tw5+s+edOqVSuPvM+eTzrf/Trct2+fIz4+3tG+fXtHZmama/q4cePM8u+9955rmh6X7OfxmTNnHBUrVnR069bNNW3s2LFmuf/+97+uaSdPnnScf/75Bco7tXv3brPsqFGj8lxu0qRJZrnff//dY3qDBg0cV199tet948aNzbnpL2f+uqf55ZdfNtM0j91t27bNnBvPP/+8x3RNW2xsrMd057GdOnWqa9r69evNtOjoaMdPP/3kmj5nzpwc55J+N9x///1+788TTzxhtqXfO+6+/fZbM/3BBx/MsY7796ev15Vex7q92bNnez2eurz7tvQz9PtXt5X98/R7/ZprrinQvtetW9dx7bXX+rQskBuqQgFB9uabb5rSAfeXVuVx0qdyvhZB9+/f3+MJqT5B1SdhX3/9tWuae71cLQbX0hKtNqRPlbVak9KngVrMr0/63J8KKmfJh1ar0Kdi+jTRuR196RMvfZKq1TT0Cao/3NOm1S10W1qlQdOQX7UEpcdIn9bqkz1nevSlT1u1VGLBggU51tEndu70WGzZskWs0JKKwmhYbpXzqbZWsdD89yVfnCVs+nRbj1N+1YvUjBkzzHHVKnXu+aJP+bXUSKvwFZSe4wXZJ2/0fNM05kafFOu55KQlXFpyoNeJe512XU6rImrVKndamtOzZ0/Xe32yrE+O3c83vVa1lFCfqjtpSYxe2wXdT+c+ZS8Z9VaCoN8XWkLhtHr1alNaeNttt7mm6fWopZV6jQfLp59+ap7c6/eL+zmjJTNaBSv7tazHVksonPSJvqZTSzL12ndy/u1+zHU5rTa0e/duv88XPV7Z2xxoaa1+T2Yv+VHu1RX9ua60qph+r3qjJbTu2/r1119N3mgJjabReez0d0RLw/R6c1ZB9GffndcvYAVVoYAg0xuLvBpva9G4Vk/QYm2tcqQNMfXHVqtUZKc/uO70B09vUtxvcvWGQOvjalDgrIvr5Pwxc7YP0HrLudm8ebOpXqFVFfSVW2NYTbOvtBqIVrHQInsNSs4WanimLS/OGx0t7vdGb/bcOes+Z//xzN4uJZTyazdhhd6saJW4MWPGmCojevOv1TL05te9Ko1Wf9CbpCVLluS4idV8yat6kTNftC569mPtfp4UhN7Uubd18GefcuN+zmWn23an1QyVe7UUZ8BQu3Zt13wnTWv2/NTzTY+N+zY1mM6+XPbP8Gc/nfuU37mkVZH0xlO/b7R6jdIgQ4+zs+qdsye7Ll26SN26dc13hH4X3XnnnZaq5Xk7ZzTd2b/TnNwfoOR2bPU4aJue7NOU+zWu7Vz05lyX1apD2mZH26dpHhaEfn9qFTZtE5IXf66r7Oeeu+zznN+Duk+50e3ruefPvmt+BPP7COcGAgsgxLQxnT6B0ieTWpKhL73x1i////u///NrW/o0X5+I6Q223hxoWwK9udbSAK3r7c8AT85ltV5vbk/S/O2yU+uK677pE+AWLVqYH1b9IdMnkb6kzbmM1knXJ5vZZe81yf3pcyg4e5LJrZtYvdkIdm8z2qZEG0Jro34dv0Hr9Wtwp3XB9WZNb5L0ZlMHANObWL0B0RtnfbKu9eJ9zRete/+vf/3L63y9QVW53bR461hAaWNTb73f5LdPudH2FXkFld564fFHbudbXsFMXnzdT+c+Odsw5EWvNe2iVr9zmjRpYoIMzX/3dbWNg54Xzs995513zLmgvWlpe4JA0HNGzwf9vvN23LKXEuR2bH055vqgRgOzzz77zOyPtsPQ9llaauJs+5Lb+aJtJ7TE1tlew1f+Xld5nXvZ5znX1f3QPPTGefz82Xc9j3IL9ABfEVgAYUB/cG644Qbz0h8NLcXQXkG0pMD95l2fVGmPM04nTpwwjWP1KZTSRtxaNK4/Gu5jGWi1J3cacDirQXjr8UQ5n2jpk8PclvGXNiLUp2fu/aVr94nZe9jJ7QbUmW4NxgKVpmA+oXM2EtaGmfrjnp02bHUvNQpWWrTxsL60JEsbpGqDfL1JfO6550yDUm0Qqj19aaNrJ2/VyvLKFz0X88sTZ5Wd7Pmd/cm/1X3Kjd7kaTWWguSf+xNerR6l11RBzkHdpl532Z8O62cUdD+d17ezg4O8aMcL2kDYWR1Kz0FtZJ+dPo3XAERfmrf6faKNuv0NLPI6Z/QY6NN4Z+AZTFqyq9+r+tISNG24rI3H8wos9HxxHl/30hpNuz4I0uqiuZVa+HNd+cv5PagPkHw5B33Zdw2gtMG7looBVtDGAggxDQTc6RNa549Y9i4o33rrLdM2wUl7HdEfBOcPhPPpnfvTOr0J0u4y3ekPi/6ga2892W/ynOvqzbv21qQBjgYv2WkPLv7S9GV/equ9wGR/Yu0cPyB72rTkRH9MX3jhBY/jYCVNWr/d22cFortZrXqgx1Gf+GbPy5kzZ5rqYO4/7gVJS160KpyeH+70JlXPMWd6vJ0zWo1CS5ay03zxljZ9KqrVPfRmKztd3pkGvanWz8ve5iL7+Wl1n3KjpWT6VNbXNjZ606ZBv/ZQ5n583n33XXOMtJtjf+lDAK3v7j46tZZc6bVd0P1cvny5uYHX/cuP1rnX60hLKrQbU90/DTby+k7Sp9/6gCO/4+tNbteyVr3Sc0F73Mr+naDvs6ehoPS7JXs1S70mtSqTL+eLcu9CVmkXwJpGb133OvfFn+vKX/q9osGF9pSmQV9u34P+7Lu2s9GHPC1btrScPpzbKLEAgkyL+p2Npt3pF7g+BdUngPrkS9sNaPUGfXqrN9taxJ39CaQGCVq8rjdy+oRTb8i0K07nUybdpj4V1lIBrTahNxtabSj7D7fenGhQoiUk+jn6VFKfamk6tY2G8wZRG57r9vWGRhusanq1P3y9idS++FetWuXXsdDuIjU9WgVKuzfU7WgDWWfXu06aJv1h1iJ7/WHUKjHO/uA13VrfW4Mjrdah9fq1605tSKtPc5198ftKqxloWvQJrj451SeQWoqQV/sTX7ub1Zs2/fHX/Lj00ktNA1ndV208ryP6agDp3mi3IGnJi7az0W4mtXtO3Z7eqOrx12OrN0dK2/Q4S8z0SbbeqLz99tvmWGcPKPWGRo+/Pi3XG01dRvNFxyrQJ7Oav1p1R5fThqS///67uYHW46RVbTTfNS16fuu5qTdH2n2qP20wfNmn3GggoNXl9JzL3ljaGz239Gm+3kBqOwO9zpzXneane0NtX+l1pOeoVnXUgECvO02/M6gsyH5qpwZ67me/jnKj56GmXfdDg4zsHTjoOagPFTQf9RzUG2tnl6X+0m0o7aJYr1ctAdVzTfNezyM9vnp+aHCj1Y20dECr7Wj+aDVMq7Qak36vamP5xo0bmyBJ81+7C85vpGn9vtNrT5d3H3xQS431O0gDTi1F1nNDS5q1m1edp8fJn+vKX/r9rQ8r9KGEdmer39/a1k0fVGiJiD580RITf/ZdzyE9B/3pThjwKtf+ogAErbtZ9+4QP/74Y9OdZfny5U3XltWrVzfdw/711185trVw4UJH//79HaVKlXKUKFHC0aNHD8fBgwc9PvfHH390XHbZZY6iRYs6Kleu7PjXv/7l6oIxezefP/zwg+masGTJkqa70EaNGjneeOMNj2X++OMPR69evUy3mXFxcY4qVao4rr/+epPu/GTvOlW7tu3Tp4+jbNmyJv3aXaJ2G5m921T19ttvm24WtUvK7GnXv3Vd7UoxISHBcd555zl69+7t+OWXX1zL6PZ0n3zptnXx4sWmG1I9/r50Petrd7NO//vf/xxXXXWV6VZYj6F2CTl48OAcXf3mlZaCdDe7ZcsWx913322Ojx6n0qVLm3TMmzfPYztffPGFyXtdpmbNmqbbUu1KNXs3odqtr3ZDqueLznPvela75Bw2bJjpNlXTrnms3RK/8sorHl0ka5e62v2qdn+s57Ge66tXr/ba3ay3/PN1n3LTuXNn042yP90Ca/ey9erVM3lXoUIFx7333psj7/RYaHe82el+ZD9X/vzzT5MOPQZ6nLTLae1qtCB5d+TIEXO833nnHYevjh07Zr4f9PM++uijHPOfe+45R7NmzUzXzrqc7rt2/+qej752N+vsjli/N7Rr2Ozn1CeffGK6+dW81pd+lnaPumHDhnyPrR5Xb93i6mc4u1jVLn+HDBliutB1fs/p3+PHj/fpWI0ZM8Z8V2XvOla7JdaudDW9evzLlStnumpdvny539dVbvuR2/F00i6Jb7rpJkeZMmVMF+a6nVtvvdUxf/58v/e9efPmjp49e/p0TIC8ROn/vIccAMKFDsSkT6X0SVNePUwByJs+Vdan8Vo6Z4eGqlqdUXv+0ap5VhufIyctMdWSCz3GOiieHWlDfi0B1k4+cmsMDviKNhYAgHOGNqLXaip6oxjptJ2R9jikDbsJKoJDq+9pb2fam5I/vepFkhdffNFUlyKoQCBQYgFEAEosAABAuKPEAgAAAIBllFgAAAAAsIwSCwAAAACWEVgAAAAAsIwB8gJAe4rQkVR1cB8d9AkAAACwA201oQMu6qjtOkBjXggsAkCDimrVqoU6GQAAAEBQ7Nixw4zmnhcCiwDQkgrnAU9MTLRc+rF//34pV65cvlEhIgt5a1/krX2Rt/ZF3toXeRtYx44dMw/Qnfe7eSGwCABn9ScNKgIRWJw+fdpsh4vBXshb+yJv7Yu8tS/y1r7I2+Dwpbo/RxsAAACAZQQWAAAAACyjKlSQZWZmSnp6ul/Fd7q8FuGdS8V3cXFxEhMTE+pkAAAAoIAILILoxIkTsnPnTtNNl690WQ0utFuvc6nrWt1X7WmgRIkSoU4KAAAACoDAIoglFRpUFCtWzPRK4GuQoIGFllicSHdIalqWFI+PkeRicbYOMnSftfcGPV516tSh5AIAACACEVgEiQYHesOsQUXRokV9WufoqXT5ZPkO+WDxNtl+6JRreo3SxeSuljWlW0pVSSoaJ3akx2nbtm3muBFYAAAARB4CiyDztaRh4cb9cu9Hy+VUWmaOedsPpcqzs9bKK99skAk9U6R13XJiN3YukQEAADgXnDutg8OYBhV93l8mp9IzRVtjZG+R4Zym83U5Xd7KDfyRI0c8ptWsWVN+/fVXCZalS5dK48aNpW7dunL11VfLrl27rG90dm+RmV29fNiLIqOjRBYMsv4ZAAAA8BmBRYhp9SctqTDBQz5tvHW+LqLL63rhKCMjw+O9NkTv0aOHjB07VjZu3CjXXXedDBoUpJv+PT+L/DZJpFyj4GwfAAAAuSKwCLFPlu801Z987ThKl9PlP12xM+Bp0SBg4MCBUr9+fVPCkJKSYrq9VXPmzJFWrVqZac2aNZMFCxaY6d99951ceOGF0rdvX2nSpIl89tlnHttcvny5xMbGylVXXWXeDxgwQL788kvXdgMm7YTI1z1E2r8tUqRUYLcNAACAfNHGIoS0cff/Ld5WoHU/+HGb9G5ZM6BtE1atWiXz58+XNWvWmDE0jh49KvHx8bJlyxZ5+umnTXCRmJgomzdvliuuuMI0tlbr1q2T8ePHy7vvvptjm9u3b5caNWq43pcsWdJsY/fu3VK7du2ApV3m3y9Sq5NIjXYiPz0XuO0CAADAJwQWIXQ4NV3+PJTq93pauKHrHUlNl1LF4wOSFg1QatWqZaoy3X333aaEoVOnTibAmD17tgkmrrzyStfyOl2DBqUBQuvWrSVk1k8T2bdCpMfPoUsDAADAOY7AIoROnvFsj+CvE2cy/A4stFvXgwcPSnJysmvagQMHpHz58pKUlCSrV6+WhQsXmqpOw4YNk0WLFpmSlWuuuUamTp2aY3vaEDuvQe2qV68uf/75p+u9DvynJSGVK1eWAjm2SSTjuEjGQZGs4yI7vhZZeJ9Iuwkix9aeXcZxXCR9n8ihFf+sF1tSJLFOwT4TAAAA+aKNRQgVL2ItritRgPU7dOggkyZNcr2fPHmyKXGoVKmSGaTu5MmT0r59e3nhhRdMb1Fr164168ybN09+++0313rLli3z6fO0TYaOTeFsk6GffcMNN0hCQkLBgopZdUVmp4gcmyVyeqHI951ESh4WWXr72en6ylohcuA//7zXl66n6wMAACAoKLEIoVLF4szgdzpOhY9ttw1tVVG9dDEzIre/tHcm7ZWpUaNGpjpTxYoVZcaMGWbejh07pF+/fiYQ0JHDL7/8crn22mslLi7OlFZow+vU1FRJS0uTiy++2GsJRnb6GR999JFZVxtsa0nFhx9+KAWiJRVWWF0fAAAAuSKwCCFt16Ajauvgd/7qfXnBGm6XKVMm1xv7pk2bml6cvGnXrp15ZdemTZt8x8Bo0aKFR2kHAAAA7IeqUCHWLaWqFI2PEV9jhOgoMcvf1LRqsJMGAAAA+IzAIsSSisbJhJ4ppnpTfsGFc/7EnilmPQAAACBcEFiEgdZ1y8n7fZpJ0biYswFGtvnOaTr/gz7N5Mq65UKUUgAAAMA72liEUXCxZFhbMxL3B4u3yvZDp1zztKG2tqnQalOJCZRUAAAAIPwQWIQRrd7U5/Ka0vPSynLy6EE5lXpcihVPlKQyFSQqmsIlAAAAhC8Ci3By6ojIr1MlbukkKXVkm5RyTi9VS6T5AJHG3UWK/jOwHQAAABAueAweLjbPExnTQGTOYyJH/hmp2ji8TWT2sLPzdTkAAAAgzBBYhAMNFqbcKpJ+SqLEYV6e9L3DzDfLWQgudOyLI0eOeEzTEbbzG4vCiptvvtkMjOftswEAAGAPBBbhUP1pei8RhwYPWfksnHV2OV1e1wtDGRkZOabdc889QQ1cAAAAEHoEFqG26j8i6ak+BBVOWWeXXzUt4EnJysqSgQMHSv369aVx48aSkpIip0+fNvPmzJkjrVq1MtOaNWsmCxYsMNO/++47ufDCC6Vv377SpEkT+eyzz3JsV0fsLl++fMDTCwAAgPBB4+1Q0tKHpZMKtu7SiWcbdPs6ZLcPVq1aJfPnz5c1a9ZIdHS0HD16VOLj42XLli3y9NNPm+AiMTFRNm/eLFdccYVs27bNrLdu3ToZP368vPvuuwFLCwAAACILgUUopR4SOby1ACs6zq536rBIsdIBSYq2f6hVq5apynT33XfLVVddJZ06dTIBxuzZs00wceWVV7qW1+nbt283f9euXVtat24tQRdbMrTrAwAAIFcEFqGUdsLa+meO+x1YlCtXTg4ePCjJyf90W3vgwAFTVSkpKUlWr14tCxcuNFWdhg0bJosWLRKHwyHXXHONTJ06Ncf2du3aJSVKlJBCkVhH5PqNIhnHCxZU6PoAAAAICgKLUIq3eENexP8n8B06dJBJkybJSy+9ZN5PnjzZlDhUqlRJ9u/fLzExMdK+fXsTSGiAsXbtWrPOiBEj5LfffpNGjRqZ9ZYtW2baWhQ6ggMAAICwRGARSlraoIPf6TgVObqYzUuUSKmaIkVdQ+j5bOzYsTJo0CATIGh1pooVK8qMGTPMvB07dki/fv0kPT1dMjMz5fLLL5drr71W4uLiTGnFgAEDJDU1VdLS0uTiiy/2WoLhjVap0vYbSht616lTxzT6BgAAgH0QWISSNrzWBtg6+J2/mt9ToIbbZcqUkQ8//NDrvKZNm8ry5cu9ztOenfSVXZs2bfLtSvarr77yO50AAACILHQ3G2qNu4vEFfM9K6Kizy7f+PZgpwwAAADwGYFFqBVNFrlt8t+lD/llh86PErntw7PrAQAAAGGCwCIcnN9OpMd/ReKKikOizMuTvo8y86XHDJHz24YooQAAAIB3tLEIp+Bi8NqzI3H/NFHkyNnB5wxtqK1tKpp0F0lICmUqAQAAAK8ILMKJVm9qfo+kX3y3nDi5U06dOijFipWV5KSaEhVN4RIAAADCF4FFGDmWdkw+3/y5TF03VXae2OmaXq1kNbmj3h3S+fzOkhifGNI0AgAAAN7wGDxM/LjrR2k3o528/PPLsuvELo95O4/vlJd+fsnM1+WsiIqKkiNHjnhMq1mzZr5dxhbU7t27zQB7F1xwgRk7o1u3bmYgPgAAANgLgUUY0GDhvvn3yemM0+L4+z93zmk6X5ezGlwEU0ZGhsd7Hcn7ySeflA0bNpiRu3WU7yFDhoQsfQAAAAgOAoswqP708HcPi8ORM6DIzizhcJjldb1Ay8rKkoEDB0r9+vWlcePGkpKSIqdPnzbz5syZI61atTLTmjVrJgsWLDDTdQRtHU27b9++0qRJE/nss888tlmhQgWznlPz5s1l2za3hukAAACwBdpYhNgXm79wlVT4wlly8eUfX0qP+j0CmpZVq1bJ/PnzZc2aNRIdHS1Hjx6V+Ph42bJlizz99NMmuEhMTJTNmzfLFVdc4QoQ1q1bJ+PHj5d33303z+1nZmbKuHHjpEuXLgFNNwAAAEKPwCKEtPRh6vqpBVp3yroppkG3tpkIBN1OrVq1TFWmu+++W6666irp1KmTCTBmz55tgokrr7zStbxO3759u/lbqze1bt0633297777pFSpUvLQQw8FJM0AAAAIH1SFCqEjZ47IjuM7fC6tcNLldb2jZ476/ZnlypWTgwcPekw7cOCAlC9fXpKSkmT16tVyxx13yPr1601jaw0oNCi45pprTANv52vXrl1Sp04ds36JEiXy/dwHH3xQduzYIdOnTzdBCQAAAOyFO7wQSs1ItbT+yYyTfq+jPTRNmjTJ9X7y5MmmxKFSpUqmt6aTJ09K+/bt5YUXXjC9Ra1du9asM2/ePNP42mnZsmU+f6YGFRqgaPsLrVoFAAAA+6EqVAgViy1maf3iscX9Xmfs2LEyaNAgUxqhJQcVK1aUGTNmmHlaotCvXz9JT0837SEuv/xyufbaayUuLk6mTp0qAwYMkNTUVElLS5OLL77YTMvPjz/+KG+88YbUq1fPNNxWWuUqeyNvAAAARDYCixBKLpJsBr/TcSr8qQ4VJVFStWRVSSqS5PdnlilTRj788EOv85o2bSrLly/3Oq9du3bmlV2bNm3yHANDgxOtSgUAAAB7oypUCGmDaW2AXRDaI1SgGm4DAAAAVhFYhFjn8ztLQmyCKYXwRbREm+VvOO+GoKcNAAAA8BWBRYglxifKq21eNaUP+QUXZn6UyNg2Y816AAAAQLggsAgDl1e5XMa3He8qucgeYDin6fwJbSdIyyotQ5ZWAAAAwBsab4dRcDHvlnlmJO4paz+So/t3SkKayOl4keTyVaVHg57S+bzOUjK+ZKiTCgAAAORAYBFGip8WufbnLGn+UaZk7Mh0TY+rliml78yUYlUcIgwDAQAAgDAUcVWh3nzzTTNwW0JCghkXIb+B2nSMBh1DQZdv2LChfP311zmWWbdunXTu3NmMPF28eHG59NJLZfv27VKYTnz/g2xq3Ub2vfiiZOzc5TEvfedO2TvyRTNflwMAAADCTUQFFtOnT5fBgwfL8OHDZcWKFdK4cWMzKvS+ffu8Lr948WLp3r279O3bV1auXCldu3Y1r9WrV7uW+eOPP6RVq1Ym+Pjuu+/M6NJPPvmkCUQKiwYLOwYMEMfp0yI65kP2cR/+nqbzdTkrwYU2Ej9y5IjHNA3U8hqLwgodyVsDQM0rfXXs2FG2bdsWlM8CAABA6EQ5Imj0Mr1B1dKEcePGmfdZWVlSrVo1eeCBB2To0KE5lr/tttvMje2sWbNc0y677DJp0qSJTJw40by//fbbzcjSuQ0a54tjx46Z0o6jR49KYuLZ3ppOnz4tW7duNaNM5xWkZB47ZkoiXEFFfrT3qIQEqbPwO4n5+7P8DSwOHz4sycnJHoHFzJkzzXGxKiMjQ2Jj/6lhp3mkeVCy5Nm2Ia+++qoJ4D7//HOP9Xw9XpFMj4UGweXLlzejnsM+yFv7Im/ti7y1L/I2sLzd50Z8G4u0tDQzKvSwYcNc0/Rk0dGglyxZ4nUdna4lHO60hENvop0n3ldffSX/+te/zHQt1dAbW/0MLdnIzZkzZ8zL/YA7t6cv598aszlfuTny2Uzfgwr1d8nFkZkzpfSdd/q2To5N5EyTvs/MzJQHH3xQvv32W4mPjzcBwg8//GBu9OfMmSPPPfecnDp1SmJiYuTFF1+Uq666ygQJAwcONEGfliI99thjcsstt3gEMiVKlHB9pp6UOs3b5+vL/RjajfOcsOv+ncvIW/sib+2LvLUv8jaw/DmOERNYHDhwwNz4VqhQwWO6vl+/fr3Xdfbs2eN1eZ2uNJo9ceKEuUnWm+ZRo0bJ7Nmz5aabbpIFCxZI69atvW535MiRMmLEiBzT9+/fb568q/T0dJMR+gRfX97oSX/oo4+kIA59+JGUvP32Ao2+7S1N+l4Dt/nz58uqVatM0KZBgP67ceNGefrpp00QppHq5s2b5eqrr5ZNmzaZPNE2Kq+//rpMmjTJta3stAqUVkErW7as2Y63z9fjdfDgQVOCZEe6f3pMNd95gmIv5K19kbf2Rd7aF3kbWMePH7dfYBHMCKxLly7y8MMPm7+1OpC2zdCqUrkFFlqi4V4SoiUWWiWrXLlyHlWhNCP0qb971SB3GYcPS8aOHf4n3OEw60WfOCkxpf6p0uQrb2nSm3mtEqWBwoABA6RNmzbSqVMnU3Ixb9480xalbdu2ruX1Qt29e7cpvahdu7YJNPKi29Dj/fzzz5sAbvz48TnSpNssU6aMratCaSCo5wlfdPZC3toXeWtf5K19kbeB5c99WcQEFvqkW29i9+7d6zFd31esWNHrOjo9r+V1m3pD26BBA49l6tevb6oA5aZIkSLmlZ2evM4TWP81o2n//fLGkXpKrMhKTZXY0qX8WkcvskOHDkmpUqU8SoO0JEfbXWipwsKFC02JjVZrWrRokVnmmmuukalTp+bYngYXWtXJl5ITzb/+/ftLnTp1ZMKECR7znMfJ/Rja0bmwj+cq8ta+yFv7Im/ti7wNHH+OYcQcbX1ynpKSYqrquEek+r5FixZe19Hp7suruXPnupbXbWpj8A0bNngso1V/atSoIcEWXbxYoa+vbUmcVZbU5MmTTYlDpUqVTFUubWjdvn17eeGFF0wJxtq1a806WuKgPWY55dfNr5NWO9PG4u49ezVq1MjvdAMAACC8RUyJhdLqR3fddZdccskl0qxZMxk7dqy5Ee7Tp4+Z36tXL6lSpYppA6EeeughU51p9OjRplrPtGnT5JdffpG33nrLtc0hQ4aY3qOuvPJK0xhZ21h8+eWXplFysMUkJ0tc9WqSvmOn7423VVSUxFWratb3lx6zQYMGmZt7jUC19EbH+lA7duyQfv36mfYhWiXq8ssvl2uvvdZUk9LSCq0ilZqaahrSX3zxxV5LMLLT8UB0Pd2e1nU877zz5KMCtisBAABA+IqowEIDAH2q/tRTT5kn4doeQgMBZwNtvYl1L65p2bKlufl94oknTLUerYKjPUJddNFFrmVuvPFG055CgxHtEemCCy6QTz75xIxtURjFdKV79jSD3/mrdM87C9RwW9sw5Na1btOmTU0Dbm+09y19ZadtMfIaA0MDQO1tCwAAAPYWUeNYhKtCHcdC224UKVLgcSzCFeNYIJKRt/ZF3toXeWtf5G3oxrHgaIeYBgdVX3/dVG8yr7z8Pb/qG2/YKqgAAABA5COwCAMlrmgl1SZNMiNqew0w/p6m86u99ZaUaHV5qJIKAAAARH4bi0jka00zDS60epOOqK2D37mPb6ENtbVNRdKNXSWmZEmxI2rkAQAARDYCiyDRnpS0cbU2NtexI3xqaB0fL8VuuUXiunaV6JMnzTgX2qVsdFKSWT9dR/T+e2RvuwUVepx0H+066jYAAIDdEVgEiQ4GV7VqVdm5c6ds27bNr5tsbXTkHGBP0s6IuI0DYVe6r3q89LgBAAAg8hBYBJGOSK1d3Oq4EL7SoOLgwYOmW9hzqScDLakgqAAAAIhcBBZBpjfL/twwa2ChN9na5eq5FFgAAAAgsnHnCgAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFgWa30TKFSze4ucPiLSdabI0pEimz4VObReJLaoSOWWIleOEil9QahTCQCR+92qVr4p8svLEnVyj5RObiDSfrxI5ctCnUoACGuUWESynQtFmtwvcsdPIjfPFclKF/m4vUj6yVCnDAAi1/rpIgsHi7QYLo4ev0hGqQYS9em1Iqn7Qp0yAAhrBBaRrNtskYt6i5S9UKR8Y5GOH4gc3y6yd3moUwYAkWv5GJGG/UQu6iNSpoEca/aSSGwxkd/fC3XKACCsEVjYyZmjZ/9NKB3qlABAZMpMO/twpnq7f6ZFRYtUbyvy15JQpgwAwh6BhV04skS+GyRS+XKRsheFOjUAEJlOHRBxZIoUr+A5vVgFkZN7QpUqAIgINN6OFMc2iWQcF8k4KJJ1XOTQCs/5S18QObRcpP17nvNiS4ok1in05AJARH63Hvn97C/j8Q0ih4qIZGVJ7PFDIml7ReTkP9+vfLcCQA4EFpHywzerrue02Sk5lysqIt9fl3P69Rv5AQQAX75bFy0UKaftLPq4ivXLOudFZfvu5bsVADxQFSoS6NO0UK4PAHbEdysABBSBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVhEgtiSoV0fAOyI71YACKjYwG4OQZFYR+T6jSIZxwv2w6frAwD8/m7NysqSQ4cPSelSpSU62u1ZHN+tAJADgUWk4AcMAAr/uzUrSzIy9omULi/iHlgAAHLgWxIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAgHMvsHjzzTelZs2akpCQIM2bN5dly5blufyMGTOkXr16ZvmGDRvK119/neuy99xzj0RFRcnYsWODkHIAAADAviIqsJg+fboMHjxYhg8fLitWrJDGjRtLhw4dZN++fV6XX7x4sXTv3l369u0rK1eulK5du5rX6tWrcyz72WefyU8//SSVK1cuhD0BAAAA7CWiAosxY8ZIv379pE+fPtKgQQOZOHGiFCtWTN577z2vy7/22mvSsWNHGTJkiNSvX1+effZZadq0qYwbN85juV27dskDDzwgU6ZMkbi4uELaGwAAAMA+IiawSEtLk+XLl0u7du1c06Kjo837JUuWeF1Hp7svr7SEw335rKwsufPOO03wceGFFwZxDwAAAAD7ipUIceDAAcnMzJQKFSp4TNf369ev97rOnj17vC6v051GjRolsbGx8uCDD/qcljNnzpiX07Fjx1xBir6s0PUdDofl7SD8kLf2Rd7aF3lrX+StfZG3geXPcYyYwCIYtAREq0tpew1ttO2rkSNHyogRI3JM379/v5w+fdpy5h09etRcEFoiA/sgb+2LvLUv8ta+yFv7Im8D6/jx4/YLLMqWLSsxMTGyd+9ej+n6vmLFil7X0el5Lf/999+bht/Vq1d3zddSkUceecT0DLVt2zav2x02bJhpRO5eYlGtWjUpV66cJCYmWr4YNMjRbXEx2At5a1/krX2Rt/ZF3toXeRtY2rOq7QKL+Ph4SUlJkfnz55uenZwnjr4fOHCg13VatGhh5g8aNMg1be7cuWa60rYV3tpg6HRtIJ6bIkWKmFd2evIG4gTWiyFQ20J4IW/ti7y1L/LWvshb+yJvA8efYxgxgYXSUoK77rpLLrnkEmnWrJkpVTh58qQrCOjVq5dUqVLFVFVSDz30kLRu3VpGjx4tnTp1kmnTpskvv/wib731lplfpkwZ83KnvUJpicYFF1wQgj0EAAAAIlNEBRa33Xabacfw1FNPmQbYTZo0kdmzZ7saaG/fvt0jqmrZsqVMnTpVnnjiCXnsscekTp06MnPmTLnoootCuBcAAACA/UQ5tGULLNE2FklJSaahUCDaWGi7j/Lly1N8ZzPkrX2Rt/ZF3toXeWtf5G3o7nM52gAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAHko02bNjJo0KAc0z/44ANJTk52vZ8xY4bUq1dPEhISpGHDhvL1118XckoBAABCh8ACCIDFixdL9+7dpW/fvrJy5Urp2rWrea1evTrUSQMAACgUBBZAALz22mvSsWNHGTJkiNSvX1+effZZadq0qYwbNy7USQMAACgUBBZAACxZskTatWvnMa1Dhw5mOhBuVffefvttueKKK6RUqVLmpefusmXLQpBaAICdEFgAAbBnzx6pUKGCxzR9r9OBcPPdd9+ZqnsLFiwwwW+1atWkffv2smvXrlAnDQAQwWJDnQAgUjkcIlEJJWTHoVSJTihp3gORYMqUKR7v33nnHfnkk09k/vz50qtXr5ClCwAQ2SixAPKRmJgoR48edb0/eipd3vthq4zdnCRJvSfJFS8tkIr3TZZRaxLMdJ2v9u7dKxUrVgxhygHfpKamSnp6upQuXTrUSQEARDBKLIB8XHDBBfLNN9+Yvxdu3C/3frRcTqVlisMRJxL1z3JHM2Ll2Vlr5ZVvNsiEnikyd+5cadGiRegSDvjo3//+t1SuXDlHOyEAAPxBYAHk49577zW9O90+aIQsK3qJqfJkaj1FuUUV5n20ma5BR+/3lsqB/Rny1sCBIUo14N3h04clNSNVisUWk+QiyTJq1CiZNm2aaXehY7AAAFBQBBZAPmrXri3/m/ed9Jm5W7IysyQqOu8ahCbocDik0i3Dpdp5FxRWMgGvVffUsbRj8sOpH6TyU5XlyulXuqaXzCwp25dsl5n/mymNGjUKQWoBAHZCGwvAB1sc5UVi4vMNKlyioiU9S+TTFTuDnTQgR9W9FStWuN7/uOtHaTejnSwtulRiSsd4LHss6piUuqmUPLr5UbMcAABWEFgA+XA4HPJ/i7cVaN0Pftxm1gcKs+rexo0b5cEHH5SPfvhI7pt3n5xKP3W2PVCO2ntnJ5zOOG2Wm7d5XmgSDQCwBQILIB+HU9Plz0OpZ6s4+UGX1/WOpJ7tJQoorKp7ixYtkrV/rJWRa0dKZlZmjoAiO4c4zHKPfv+oqTYFAEBBEFgA+Th5JsPS+icsrg/469JLL5XeL/eWmCIxrlKJ/OhyWdFZ8uUfXwY9fQAAeyKwAPJRvIi1Pg5KWFwf8JdWv5u6fmqB1p2ybgrV9wAABUJgAeSjVLE4qVG6WH61SXLQ5XW95GJxQUoZ4N2RM0dkx/EdpoqTP3R5Xe/oGc9epQAA8AWBBZCPqKgouatlzQKt2/vymmZ9oDDpOBVWnMw4GbC0AADOHQQWgA+6pVSVovExOcbEy41Wa9flb2paNdhJA3LQwe+sKB5bPGBpAQCcOwgsAB8kFY2TCT1TzvbYmU9w4Zw/sWeKWQ8obDqidrWS1STKzwp8uryul1QkKWhpAwDYF4EF4KPWdcvJ+32aSdG4GG9DArim6fwP+jSTK+uWC1FKca7T6nd31LujQOv2qN+D6nsAgAIhsAD8DC6WDGsrT93QQKqX9qxuou91+k+PtSWoQMh1Pr+zJMQm+FxqES3RZvkbzrsh6GkDANgT/WACftLqTX0uryW9W9Y0g9/pOBXapaz2/sSTXoSLxPhEebXNq3Lf/PvMaI159RBlgo8okbFtxpr1AAAoCEosgALSIKJU8XipVrqY+ZegAuHm8iqXy/i2410lF9lLL5zTdP6EthOkZZWWIUsrACDyUWIBADYPLubdMs+MqK2D3+k4FU5VS1Y1bSo6n9dZSsaXDGk6AQCRj8ACAGxOqzdpAKENunXwOx2nQruU1d6fKGkDAAQKgQUAnCM0iEhOSBb9DwCAQKONBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAADj3Aos333xTatasKQkJCdK8eXNZtmxZnsvPmDFD6tWrZ5Zv2LChfP3116556enp8u9//9tML168uFSuXFl69eolu3fvLoQ9AQAAAOwjogKL6dOny+DBg2X48OGyYsUKady4sXTo0EH27dvndfnFixdL9+7dpW/fvrJy5Urp2rWrea1evdrMT01NNdt58sknzb+ffvqpbNiwQTp37lzIewYAAABEtiiHw+GQCKElFJdeeqmMGzfOvM/KypJq1arJAw88IEOHDs2x/G233SYnT56UWbNmuaZddtll0qRJE5k4caLXz/j555+lWbNm8ueff0r16tV9StexY8ckKSlJjh49KomJiWKF7pMGSuXLl5fo6IiK+5AP8ta+yFv7Im/ti7y1L/I2sPy5z42YAfLS0tJk+fLlMmzYMNc0PVnatWsnS5Ys8bqOTtcSDndawjFz5sxcP0cPmhlEKjn3AaTOnDljXu4H3Hki68sKXV9jPavbQfghb+2LvLUv8ta+yFv7Im8Dy5/jGDGBxYEDByQzM1MqVKjgMV3fr1+/3us6e/bs8bq8Tvfm9OnTps2FVp/KKyIbOXKkjBgxIsf0/fv3m21YzTwNbvSCIMq2F/LWvshb+yJv7Yu8tS/yNrCOHz9uv8Ai2LQh96233mpOwgkTJuS5rJaauJeEaImFVskqV65cQKpCaYmJbouLwV7IW/sib+2LvLUv8ta+yNvA0g6QAh5Y6I33448/bho4ly5dWu655x65++67XfP37t1relXSUoVgKFu2rMTExJjPcafvK1as6HUdne7L8s6gQttVfPvtt/kGB0WKFDGv7PTkDcQJrBdDoLaF8ELe2hd5a1/krX2Rt/ZF3gaOP8fQ5yWff/55mTx5sgko2rdvb57YDxgwwGOZYLYDj4+Pl5SUFJk/f75HRKrvW7Ro4XUdne6+vJo7d67H8s6gYtOmTTJv3jwpU6ZM0PYBAAAAsCufSyymTJki77zzjlx//fXmfe/eveXaa6+VPn36yHvvveeKDoNJg5m77rpLLrnkEtNz09ixY02vT5oGpWNQVKlSxbSBUA899JC0bt1aRo8eLZ06dZJp06bJL7/8Im+99ZYrqLj55ptNV7Pac5SWtjjbX2ipjAYzAAAAAAIYWOzatUsuuugi1/vzzz9fvvvuO7n66qvlzjvvlJdeekmCTbuP1QbSTz31lAkAtNvY2bNnuxpob9++3aO4pmXLljJ16lR54okn5LHHHpM6deqYHqGc+6H79MUXX5i/dVvuFixYIG3atAn6PgEAAADn1DgWtWvXlrffflvatm3rMV1Hqb7qqqukRo0aptpRsNpYhDPGsYAvyFv7Im/ti7y1L/LWvsjb0N3n+ny0tWRCn/5npw22tcHz1q1bC5ZaAAAAAOdOVagnn3wy1/EitF3DwoULTcNoAAAAAOcenwMLreqkr9xoyYU2rAYAAABw7qHiGQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAhR9Y6HgWBw8ezDH9yJEjZh4AAACAc4/fgcW2bdu8DoJ35swZM5I1AAAAgHOPz93NfvHFF66/58yZY0bgc9JAQ0fdrlmzZuBTCAAAAMA+gUXXrl3Nv1FRUTnGq4iLizNBxejRowOfQgAAAAD2CSyysrLMv7Vq1ZKff/5ZypYtG8x0AQAAALBjYOG0devW4KQEAAAAgL0Di9dff1369+8vCQkJ5u+8PPjgg4FKGwAAAAA7BRavvvqq9OjRwwQW+ndutP0FgQUAAABw7on1t/oTVaEAAAAAZMfI2wAAAAAKv/G22rlzpxnXYvv27ZKWluYxb8yYMdZTBQAAAMDegYUOhNe5c2epXbu2rF+/Xi666CIzGrfD4ZCmTZsGJ5UAAAAA7FUVatiwYfLoo4/K77//bhpzf/LJJ7Jjxw5p3bq13HLLLcFJJQAAAAB7BRbr1q2TXr16mb9jY2Pl1KlTUqJECXnmmWdk1KhRwUgjAAAAALsFFsWLF3e1q6hUqZL88ccfrnkHDhwIbOoAAAAA2LONxWWXXSY//PCD1K9fX6677jp55JFHTLWoTz/91MwDAAAAcO7xO7DQXp9OnDhh/h4xYoT5e/r06VKnTh16hAIAAADOUX4FFpmZmaar2UaNGrmqRU2cODFYaQMAAABgxzYWMTEx0r59ezl8+HDwUgQAAADA/o23ddyKLVu2BCc1AAAAAM6NwOK5554z41jMmjVL/vrrLzl27JjHCwAAAMC5x+c2FjpOhfYApT1BKR19OyoqyjVfR97W99oOAwAAAMC5xefAQnuAuueee2TBggXBTREAAAAA+wYWWiKhWrduHcz0AAAAALB7Gwv3qk8AAAAAUKBxLOrWrZtvcHHo0CF/NgkAAADgXAsstJ1FUlJS8FIDAAAAwP6Bxe233y7ly5cPXmoAAAAA2DuwoH0FAmp2b5HTR0S6zhT5dYLIqgkix7adnVfmQpEWT4nUujbUqQQAAECweoUCAq5kVZErXhQpVUdPNJG1/ycys4vInStFyl4Y6tQBAAAgkIFFVlaWr4sC/jnvBs/3rZ4/W4Lx108EFgAAAHZsYwEEXVamyMYZIuknRSq3CHVqAAAA4CMCC4SH/b+L/KeFSMZpkfgSIp0/EynTINSpAgAAgI8ILFC4jm0SyTguknFQJOu4yKEVf89IF+k8RST9hMj2eSJze4i0f1skqfbZ2bElRRLrhDLlAAAAyAOBBQo3qJhV13Pa7BTvy5YUkSW3eE67fiPBBQAAQJiKDnUCcA7RkopQrg8AAICgIbAAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCxSe2JKhXR8AAABBExu8TQPZJNYRuX6jSMbxggUVuj4AAADCEoEFChfBAQAAgC1RFQoAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAwLkXWLz55ptSs2ZNSUhIkObNm8uyZcvyXH7GjBlSr149s3zDhg3l66+/9pjvcDjkqaeekkqVKknRokWlXbt2smnTpiDvBQAA8EWbNm1k0KBBOaZ/8MEHkpycbP7+9NNP5ZJLLjHvixcvLk2aNJEPP/wwBKkFzm0RFVhMnz5dBg8eLMOHD5cVK1ZI48aNpUOHDrJv3z6vyy9evFi6d+8uffv2lZUrV0rXrl3Na/Xq1a5lXnrpJXn99ddl4sSJsnTpUvOFpNs8ffp0Ie4ZAAAoqNKlS8vjjz8uS5Yskd9++0369OljXnPmzAl10oBzSkQFFmPGjJF+/fqZL4sGDRqYYKBYsWLy3nvveV3+tddek44dO8qQIUOkfv368uyzz0rTpk1l3LhxrtKKsWPHyhNPPCFdunSRRo0ayeTJk2X37t0yc+bMQt47AABQ0FKNG2+80fzWn3feefLQQw+Z3/Qffvgh1EkDzimxEiHS0tJk+fLlMmzYMNe06OhoU3VJn1B4o9O1hMOdlkY4g4atW7fKnj17zDackpKSTBUrXff222/3ut0zZ86Yl9OxY8fMv1lZWeZlha6vAY/V7SD8kLf2Rd7aF3kbHrzlgfN99um67LfffisbNmyQkSNH5pp35K19kbeB5c9xjJjA4sCBA5KZmSkVKlTwmK7v169f73UdDRq8La/TnfOd03Jbxhv9ohoxYkSO6fv377dchUoz7+jRo+aC0MAJ9kHe2hd5a1/kbXg8WExNTc1R7fn48eMmX5zT9SHfxRdfbJaPiYkxv9VaZTq36tLkrX2Rt4Gl15rtAotwoqUm7iUh+mVWrVo1KVeunCQmJlq+GKKiosy2uBjshby1L/LWvsjb0IuPjzfVnsuXL+8xvWSJEpIcHS2l0tMlqlgxKVOrlmlPeeLECVNioQ8ANbDQalLekLf2Rd4GlnaAZLvAomzZsuYJxN69ez2m6/uKFSt6XUen57W881+dpr1CuS+jPUrkpkiRIuaVnZ68gTiB9WII1LYQXshb+yJv7Yu8DS19YKcP8JzHP/PYMTk6c6Y0nvSWzK5QUbZc095Mj6teTcr27Cnnde1q2lNqbYZRo0bJ1Vdfneu2yVv7Im8Dx59jGB1JTyxSUlJk/vz5HhGpvm/RooXXdXS6+/Jq7ty5ruVr1aplggv3ZfTLS3uHym2bAACg8FxwwQWmJ0h14vsfZFPrNrJ35IuS8Hf7Rqf0HTvNdJ2vy+k9gnt7SADBFzElFkqrH911112mr+pmzZqZHp1OnjxpeolSvXr1kipVqph6lUp7hWjdurWMHj1aOnXqJNOmTZNffvlF3nrrLVc0q31jP/fcc1KnTh0TaDz55JNSuXJl0y0tAAAIrXvvvdf05vjyHXdIp19XSZTDoS20cz4Z1en6z+nTsr1/f/lj1y65c8zoUCQZOGdFVGBx2223mQbSOqCdNq7W6kqzZ892Nb7evn27R3FNy5YtZerUqaY72ccee8wED9oj1EUXXeRa5l//+pcJTvr37y9HjhyRVq1amW36U58MAAAER+3atWXR//4ncffeZ0ohYqKi8l7B4RANMd6sUUPq33prYSUTgD60d2iTeVii1ae0m1rtgSAQjbe1BwttpEa9QHshb+2LvLUv8jY8HJo82VRzcpZK+CQqSioMGyale93pdTZ5a1/kbejucznaAAAgbOnzz0MffVSgdQ999KFZH0DhILAAAABhK/PIEUnfvsO/0grlcJj1dH0AhYPAAgAAhK2sk6khXR+A7wgsAABA2IouXiyk6wPwHYEFAAAIWzHJyWbwO22M7ZeoKLOerg+gcBBYAACAsKVjTpXu2bNA65bueadZH0DhILAAAABhLalrV4nS8aV8DRKio83ySV27BDtpANwQWAAAgLAWk5goVV9//WxgkV9w8ff8qm+8YdYDUHgILAAAQNgrcUUrqTZp0j8lF9kDjL+n6fxqb70lJVpdHqqkAues2FAnAAAAwNfgos7C7+TozM/N4HdmfIu/xVWratpUJN3YVWJKlgxpOoFzFYEFAACIGFq9qXSvO6XUnT3N4Hc6ToV2Kau9P9FQGwgtAgsAABBxNIiILVVKRF8AwgJtLAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAADOncDi0KFD0qNHD0lMTJTk5GTp27evnDhxIs91Tp8+Lffff7+UKVNGSpQoId26dZO9e/e65q9atUq6d+8u1apVk6JFi0r9+vXltddeK4S9AQAAAOwlYgILDSrWrFkjc+fOlVmzZsmiRYukf//+ea7z8MMPy5dffikzZsyQhQsXyu7du+Wmm25yzV++fLmUL19ePvroI7Ptxx9/XIYNGybjxo0rhD0CAAAA7CPK4XA4JMytW7dOGjRoID///LNccsklZtrs2bPluuuuk507d0rlypVzrHP06FEpV66cTJ06VW6++WYzbf369aZUYsmSJXLZZZd5/Swt4dDP+/bbb31O37FjxyQpKcl8ppaoWJGVlSX79u0zAU90dMTEffABeWtf5K19kbf2Rd7aF3kbWP7c50bE0dZAQKs/OYMK1a5dO3OyLF261Os6WhqRnp5ulnOqV6+eVK9e3WwvN3rQSpcuHeA9AAAAAOwtViLAnj17TNTpLjY21gQAOi+3deLj401A4q5ChQq5rrN48WKZPn26fPXVV3mm58yZM+blHsk5I2R9WaHrayGS1e0g/JC39kXe2hd5a1/krX2Rt4Hlz3EMaWAxdOhQGTVqVJ7LaLWkwrB69Wrp0qWLDB8+XNq3b5/nsiNHjpQRI0bkmL5//37TYNxq5mmpiV4QFN/ZC3lrX+StfZG39kXe2hd5G1jHjx+PjMDikUcekd69e+e5TO3ataVixYqmrpy7jIwM01OUzvNGp6elpcmRI0c8Si20V6js66xdu1batm1rGoM/8cQT+aZbG3gPHjzYo8RCe5bSNh2BaGMRFRVltsXFYC/krX2Rt/ZF3toXeWtf5G1gJSQkREZgoRmur/y0aNHCBAjabiIlJcVM08bVeuI0b97c6zq6XFxcnMyfP990M6s2bNgg27dvN9tz0t6grr76arnrrrvk+eef9yndRYoUMa/s9OQNxAmsF0OgtoXwQt7aF3lrX+StfZG39kXeBo4/xzAijrb25NSxY0fp16+fLFu2TH788UcZOHCg3H777a4eoXbt2mUaZ+t8pa3XdawLLVlYsGCBCUr69Oljggpnj1Ba/emqq64yVZ90OW17oS+t0gQAAADAZo231ZQpU0wwoVWWNHLSUojXX3/dNV97gNISidTUVNe0V1991bWsNrbu0KGDjB8/3jX/448/NkGEjmOhL6caNWrItm3bCnHvAAAAgMgWEeNYhDvGsYAvyFv7Im/ti7y1L/LWvsjbwLLdOBYAAAAAwhuBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAAgXs3uLzOx69u+di0Q+u0FkYmWR0VEim2ZKOCOwAAAAAMJR+kmRco1F2r4pkSA21AkAAAAA4EWta8++IgQlFgAAAAAsI7AAAAAAYBlVoQAAAIBQO7ZJJOO4SMZBkazjIodW5LxrP/mHl+klRRLrSDggsAAAAABCHVTMqus5bXaK5/tyIrL2UZG1Xta/fmNYBBdUhQIAAABCKeN4aNcPEAILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABCKbZkaNcPkNhQJwAAAAA4pyXWEbl+o0jG8YIFFbp+GCCwAAAAAEItMTyCAyuoCgUAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAwkCbNm1k0KBBOaZ/8MEHkpycbP5es2aNdOvWTWrWrClRUVEyduzYEKQU8I7AAgAAIEKkpqZK7dq15cUXX5SKFSuGOjmAh1jPtwAAAAhXl156qXmpoUOHhjo5gAdKLAAAAABYRmABAAAAwDICCwAAgHDmcEjpBIfI4T9FTh4074FwRBsLAACAMJCYmChHjx79Z8KpIyKr/iNdd4yS3veIyGuNzk4vVUuk+QBJjM8KWVoBbwgsAAAAwsAFF1wg33zzzdk3m+eJTO8lkp4qiVpCEeW24OFtIrOHyZJbHPJN+uZQJRfIgapQAAAAYeDee++VjRs3yvhHuoljyi3iSE/VelAS7R5UGFoVyiEJMSJdTnwkf8x5SzZvJsBA6BFYAAAAhAEdn+LH+V9Ln2LfSlZmlkSZACJ3MdHa3CJLKix8VAbd07vQ0gnkhqpQAAAAYaJp9HqRGN8bZ8dER0mJ+CiZ9VzPoKYL8AUlFgAAAOFA21IsnVSwdZdOpLcohByBBQAAQDhIPSRyeOvfbSj8oV3RbhU5dThICQN8Q2ABAAAQDtJOWFv/zPFApQQoEAILAACAcBBfwtr6RUoGKiWAvQOLQ4cOSY8ePczgMcnJydK3b185cSLvyP706dNy//33S5kyZaREiRLSrVs32bt3r9dlDx48KFWrVpWoqCg5cuRIkPYCAAAgF8VKnx38zmPQCl9EnV2vaKkgJQywWWChQcWaNWtk7ty5MmvWLFm0aJH0798/z3Uefvhh+fLLL2XGjBmycOFC2b17t9x0001el9VApVGjv0e0BAAAKGxRUWZE7QJpfs/Z9YEQiojAYt26dTJ79mx55513pHnz5tKqVSt54403ZNq0aSZY8Obo0aPy7rvvypgxY+Tqq6+WlJQUef/992Xx4sXy008/eSw7YcIEU0rx6KOPFtIeAQAAeNG4u0hcMd9v0aKizy7f+PZgpwywxzgWS5YsMdWfLrnkEte0du3aSXR0tCxdulRuvPHGHOssX75c0tPTzXJO9erVk+rVq5vtXXbZZWba2rVr5ZlnnjHb2bJli0/pOXPmjHk5HTt2zPyblZVlXlbo+g6Hw/J2EH7IW/sib+2LvLWvsM3bIokit/yfRP3nNhFHtERJ7ulzmOAjShy3Tj67XrjtS4iEbd5GKH+OY0QEFnv27JHy5ct7TIuNjZXSpUubebmtEx8fbwISdxUqVHCto8FB9+7d5eWXXzYBh6+BxciRI2XEiBE5pu/fv9+067CaeVraoheEBk6wD/LWvshb+yJv7Sus8zaxocRfN0mS5zwoknHKTHIfhdvxdxsMR2yCHOnwhqSVvEhk376QJTfchHXeRqDjx49HRmAxdOhQGTVqVL7VoIJl2LBhUr9+fenZs6ff6w0ePNijxKJatWpSrlw507jc6sWgDch1W1wM9kLe2hd5a1/krX2Ffd6W7yZyYTtxrJomUcsm/T2+xd9K1RRHswGm+lNyQlIoUxmWwj5vI0xCQkJkBBaPPPKI9O7dO89lateuLRUrVpR92SLxjIwM01OUzvNGp6elpZm2E+6lFtorlHOdb7/9Vn7//Xf5+OOPzXuNbFXZsmXl8ccf91oqoYoUKWJe2enJG4gTWC+GQG0L4YW8tS/y1r7IW/sK+7wtVkqkxb0il91zdvA7HaeiSEmJKlrKpB0RnLcRxJ9jGNLAQiNJfeWnRYsWJkDQdhPaCNsZFGhEqo25vdHl4uLiZP78+aabWbVhwwbZvn272Z765JNP5NSps0WM6ueff5a7775bvv/+eznvvPMCtJcAAAAWaBChXdHqCwhjEdHGQqsrdezYUfr16ycTJ040jbIHDhwot99+u1SuXNkss2vXLmnbtq1MnjxZmjVrJklJSaYLWa2ypG0xtIrSAw88YIIKZ8Pt7MHDgQMHXJ+XvW0GAAAAgAgPLNSUKVNMMKHBgxbJaCnE66+/7pqvwYaWSKSmprqmvfrqq65ltaF2hw4dZPz48SHaAwAAAMC+ohzOhgUoMG28rSUk2gNBIBpva3sS7QWLeoH2Qt7aF3lrX+StfZG39kXehu4+l6MNAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAsljrm4Bz8HIdmTAQo0UeP35cEhISGC3SZshb+yJv7Yu8tS/y1r7I28By3t8673fzQmARAHryqmrVqoU6KQAAAEBQ7neTkpLyXCbK4Uv4gXwj4927d0vJkiUlKirKclSoAcqOHTskMTExYGlE6JG39kXe2hd5a1/krX2Rt4GloYIGFZUrV863BIgSiwDQg1y1atWAblMvBC4GeyJv7Yu8tS/y1r7IW/sibwMnv5IKJyqeAQAAALCMwAIAAACAZQQWYaZIkSIyfPhw8y/shby1L/LWvshb+yJv7Yu8DR0abwMAAACwjBILAAAAAJYRWAAAAACwjMACAAAAgGUEFoXgzTfflJo1a5qh5Zs3by7Lli3Lc/kZM2ZIvXr1zPINGzaUr7/+2mO+Not56qmnpFKlSlK0aFFp166dbNq0Kch7gWDnbXp6uvz73/8204sXL24GounVq5cZfBGRf926u+eee8xgmmPHjg1CylHY+bpu3Trp3Lmz6eddr91LL71Utm/fHsS9QGHk7YkTJ2TgwIFmnCr9rW3QoIFMnDgxyHsBq3m7Zs0a6datm1k+r+9Zf88X+EgbbyN4pk2b5oiPj3e89957jjVr1jj69evnSE5Oduzdu9fr8j/++KMjJibG8dJLLznWrl3reOKJJxxxcXGO33//3bXMiy++6EhKSnLMnDnTsWrVKkfnzp0dtWrVcpw6daoQ9wyBztsjR4442rVr55g+fbpj/fr1jiVLljiaNWvmSElJKeQ9QzCuW6dPP/3U0bhxY0flypUdr776aiHsDYKZr5s3b3aULl3aMWTIEMeKFSvM+88//zzXbSJy8la3cd555zkWLFjg2Lp1q2PSpElmHc1fhG/eLlu2zPHoo486/vOf/zgqVqzo9XvW323CdwQWQaY3hvfff7/rfWZmprmhGDlypNflb731VkenTp08pjVv3twxYMAA83dWVpa5UF5++WXXfL0hLVKkiLmIELl5m9sXpMb/f/75ZwBTjlDl7c6dOx1VqlRxrF692lGjRg0CCxvk62233ebo2bNnEFONUOXthRde6HjmmWc8lmnatKnj8ccfD3j6Ebi8dZfb96yVbSJvVIUKorS0NFm+fLmpquQUHR1t3i9ZssTrOjrdfXnVoUMH1/Jbt26VPXv2eCyjxe9ajJfbNhEZeevN0aNHTVFucnJyAFOPUORtVlaW3HnnnTJkyBC58MILg7gHKKx81Tz96quvpG7dumZ6+fLlzXfxzJkzg7w3KIxrtmXLlvLFF1/Irl27TBXkBQsWyMaNG6V9+/ZB3BtYzdtQbBP/ILAIogMHDkhmZqZUqFDBY7q+1+DAG52e1/LOf/3ZJiIjb7M7ffq0aXPRvXt3SUxMDGDqEYq8HTVqlMTGxsqDDz4YpJSjsPN13759ph7+iy++KB07dpRvvvlGbrzxRrnppptk4cKFQdwbFMY1+8Ybb5h2FdrGIj4+3uSx1su/8sorg7QnCETehmKb+Ees298AwoQ25L711lvNU7IJEyaEOjmwSJ+Ovfbaa7JixQpTAgV70BIL1aVLF3n44YfN302aNJHFixebRr6tW7cOcQphhQYWP/30kym1qFGjhixatEjuv/9+07FG9tIOAGdRYhFEZcuWlZiYGNm7d6/HdH1fsWJFr+vo9LyWd/7rzzYRGXmbPaj4888/Ze7cuZRW2CBvv//+e/N0u3r16qbUQl+av4888ojplQSRma+6Tc1Lfartrn79+vQKFeF5e+rUKXnsscdkzJgxcsMNN0ijRo1MD1G33XabvPLKK0HcG1jN21BsE/8gsAgiLTpNSUmR+fPnezzh0vctWrTwuo5Od19e6c2lc/latWqZE999mWPHjsnSpUtz3SYiI2/dgwrtPnjevHlSpkyZIO4FCitvtW3Fb7/9Jr/++qvrpU89tb3FnDlzgrxHCFa+6ja1a9kNGzZ4LKP18PUJNyI3b/W7WF9a996d3pA6S6oQnnkbim3CTT6Nu2GRdmmmPTZ98MEHpku7/v37my7N9uzZY+bfeeedjqFDh3p0gRcbG+t45ZVXHOvWrXMMHz7ca3ezug3t8u63335zdOnShe5mbZC3aWlppuvgqlWrOn799VfHX3/95XqdOXMmZPt5LgrGdZsdvULZI1+1+2Cd9tZbbzk2bdrkeOONN0yXpN9//31I9vFcFYy8bd26tekZSrub3bJli+P99993JCQkOMaPHx+SfTxX+Zu3+nu5cuVK86pUqZLpelb/1uvT122i4AgsCoH+0FSvXt30maxdnP30008eX1x33XWXx/L//e9/HXXr1jXL65faV1995TFfu5x98sknHRUqVDAXRtu2bR0bNmwotP1BcPJW+0nXWN/bS3/YENnXbXYEFvbJ13fffddx/vnnm5tOHaNExxhC5OetPtTp3bu36YZU8/aCCy5wjB492vwGI3zzNrffUl3O122i4KL0f+4lGAAAAADgL9pYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAACJOzZo1ZezYsaFOBgDADYEFACBooqKi8nw9/fTTBdruzz//LP379/f4nJkzZ+a73vPPPy8tW7aUYsWKSXJycoE+GwDgXWwu0wEAsOyvv/5y/T19+nR56qmnZMOGDa5pJUqUcP3tcDgkMzNTYmPz/2kqV65cgdKTlpYmt9xyi7Ro0ULefffdAm0DAOAdJRYAgKCpWLGi65WUlGRKFpzv169fLyVLlpT//e9/kpKSIkWKFJEffvhB/vjjD+nSpYtUqFDBBB6XXnqpzJs3L9eqUPq3uvHGG832ne+9GTFihDz88MPSsGHDIO85AJx7CCwAACE1dOhQefHFF2XdunXSqFEjOXHihFx33XUyf/58WblypXTs2FFuuOEG2b59e67VotT7779vSkic7wEAhYuqUACAkHrmmWfkmmuucb0vXbq0NG7c2PX+2Weflc8++0y++OILGThwYK7VorTNhJaEAABCgxILAEBIXXLJJR7vtcTi0Ucflfr165tgQatDaWlGbiUWAIDwQIkFACCkihcv7vFeg4q5c+fKK6+8Iueff74ULVpUbr75ZtPwGgAQvggsAABh5ccff5TevXubxtjOEoxt27bluU5cXJzpUQoAEDpUhQIAhJU6derIp59+Kr/++qusWrVK7rjjDsnKyspzHe0JSht779mzRw4fPpzrclqdSrer/2ogon/rS4MXAIA1BBYAgLAyZswYKVWqlBnITnuD6tChgzRt2jTPdUaPHm2qT1WrVk0uvvjiXJfTcTR0/vDhw00woX/r65dffgnCngDAuSXKoSMSAQAAAIAFlFgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAIFb9f7ui+InQg+xlAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAJOCAYAAAAqFJGJAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAXoJJREFUeJzt3Qd8FGX6wPEnjYSSAlIiEgQEadIMwiHVk6ZY8KyIIsgfUA+VQ0/hzgJnAZVDTiwoFkTh5DjFQ1QQEESKgCAoVWnSOykQgZT9f54XNu5u2iaTzWYmv6+flezszO47887svs+8LcTlcrkEAAAAACwItbIxAAAAABBYAAAAACgW1FgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAMUmJCRERo0axREtBnoc9Xh6qlOnjvTv3z/7+eLFi806+i/ydu2118qgQYNK1SEqSt6lp6dLQkKCvP766wFNW1n34osvSqNGjSQrK0uc6I477pDbbrst2MmAQxFYAMVkypQppqCQ1+O7777jWOdh06ZNpiC9a9eugB+jtLQ081mBKIy7z4Hvv/8+19evu+46ExyURFqKgxZgdZ/sbNmyZfLVV1/J448/LnYXEREhw4cPl+eee05Onz5daoKj//73v9nLli9fbs7ppKQksaOUlBR54YUXzPkSGurMIpLu28cffyzr168PdlLgQM68aoAg+sc//iEffPBBjkf9+vXJl3wCi9GjR5dYYKGfVRoK8/ml5YknnpDffvst3+07depk1tF/A8EJgcVLL70kV199tWOuvwEDBsjRo0dl+vTpUhppYKHntF0Di3fffVcyMjKkT58+4lStWrWS1q1byz//+c9gJwUOFB7sBABOc80115gvbcCK8PBw88iP3lGNiopy7IE+deqUVKxYscjbHz58WD7//HOZNGlSwD+rpMTFxUn37t1NwHfvvfcGOzmO895778kNN9xQoteVy+UyNVDly5fP8ZouL1euXLHXnmhTqKefftrcPKhUqVKxvjfKNmosgCD46KOPJDExUaKjoyUmJkaaNWsm//rXv3I0qVmyZIkMGTJELrjgArNev3795MSJE17v9b///U969eolNWvWlMjISLnkkkvkmWeekczMzByfu3LlStPevHLlyqYQ1bx5c6/PVVu2bJFbbrlFqlSpYn5cNUiaPXt2kfbz119/lQceeEAaNmxofjR1P2699VavmgndV12mrrrqquymY5538b/88kvp2LGjSbMeM93fjRs3en2W9j3QH8h9+/ZJ7969zd/VqlWTRx99NPtY6OfqMqV3Vd2fVVC/kO3bt5tHcSooLbn1sfCnnf4vv/wiN998s8THx5v8q1WrlmlTnZyc7FV4+uMf/yjVq1c350yTJk3kjTfe8HpvbbKlx/ibb77JTluXLl2yX9c70sOGDTNt/vU9tEZAm5B4tkvPqx+B7rsu96wNceefHmc9RzWf+/bt6/c+5UaDCr373LVrV6/l7utL903PTz0O+p5uWthq2rSp2S+9rv785z/nuAOvx+Kyyy4ztW163laoUEEuuugi0z7f1969e805qeevftZf/vIXOXPmTI71/N3Pbt26ydKlS+X48eN57vuhQ4dMYKrnlq+tW7ea/X/11Vez+27oeg0aNDCfq9dphw4dZP78+VIYes7+9a9/NX/XrVs3+7zxvN4//PBD892n3wf6HaP7t2fPnlyP7Y8//iidO3c2x1bPL3eTK823tm3bmvfQ75YFCxZ4bZ+ammrOTT2HNQ/1mOsxW7t2bb7p37lzp/lM3/NF6Xmt35X6Xa3HSK/dnj17ejV79Oe6UpoubRY5b9488/2q+/Hmm29mXy/6+6A1lno+6b5r8yz397d+ZmxsrFmux0ab+hVl33WZBtOFzWOgINRYAMVMCwHaVMGT/ljoj7XSL3KtZtfmGVoQU5s3bzY/EA8//LDXdkOHDjV3KPUHWwsD+iOlhXX3D5C7kKQFMm17rf9+/fXX8tRTT5kfI20G4qafqz9mF154ofkcLbzo586ZMyf7c7Ug2b59e/ODNmLECFMQ+s9//mMKRdom96abbirUsVi9erVpGqGFBy0kaQFD90ELDlog0x9Hbcbz0EMPySuvvCJ/+9vfpHHjxmZb97/ajOyee+6RHj16mOOlzYf0PbTg88MPP3j1WdAAQtfTQse4ceNMgUOr+zXYuv/++01hQLfVv3Vf/vSnP5ntNMDKj+aVKs6mWkVNS37Onj1r9l8LrQ8++KDJYw20NI+1YKwFEqWfqwVnvTOrhc/PPvvMFLC18KSFaDVhwgTzHnpO/f3vfzfLatSoYf7VPNBCjb63Br61a9c2+Txy5Eg5cOCA2bYoNAjQ9Gveav7p+eHvPuVG06TX3cUXX5zr67rPmg96vWghS+m1poVsLVxq3rivOz2X9RrVfg5uGuRrQU/zTu8Aa8FX269r4VNrLpU2VdPzZ/fu3eY810BFz2m9TouSd0oL5nqXW/dPr+ncaF5pHun1q3emPc2YMUPCwsKyA3rd5zFjxsj//d//SZs2bcx3hxaYtTCqBVB/6XH4+eef5d///re8/PLLUrVqVbPcHUBr35Ann3zSHCv9rCNHjsjEiRPNd4Bey/pd53lsdd/0u0PTqXmgf0+bNs0UnO+77z658847zXec3gjR4ESDUaWvaV7o96cW7o8dO2YCMf2+u/zyy/NMvx5Plds6AwcONN+1mq+adj1Xv/32W9N3zl1D7c915abnlf4O6PWjAwtogOSmN4a0lkJviuj5oH/r+aKfrXmv+ak1GO5ARtOh+VaYfdfXNKDRc7qw3+tAvlwAisV7773n0ksqt0dkZGT2eg8//LArJibGlZGRUeB7JSYmus6ePZu9/MUXXzTL//e//2UvS0tLy7H9kCFDXBUqVHCdPn3aPNfPqlu3ruviiy92nThxwmvdrKys7L+vvvpqV7NmzbK3c79+5ZVXuho0aFDgMdC0Pf300/mmbcWKFWa9qVOnZi+bOXOmWbZo0SKvdVNTU11xcXGuQYMGeS0/ePCgKzY21mv5PffcY97jH//4h9e6rVq1MsfR7ciRIznSWRA9bvooiDvfVq9enevrvXr18nqf/NKiy3y/onVb3U83PV6ex+2HH34wz/V45ie3fOnRo4erXr16XsuaNm3q6ty5c451n3nmGVfFihVdP//8s9fyESNGuMLCwly7d+/ONX1uO3fuNMv1ePnmn76HJ3/3KTcdOnTwynvffNLXPa/Dw4cPu8qVK+fq3r27KzMzM3v5q6++atZ/9913s5fpcfE9j8+cOeOKj4933XzzzdnLJkyYYNb7z3/+k73s1KlTrvr16xcp79T+/fvNui+88EK+67355ptmvZ9++slreZMmTVx//OMfs5+3aNHCnJuF5c5fzzS/9NJLZpnmsaddu3aZc+O5557zWq5pCw8P91ruPrbTp0/PXrZlyxazLDQ01PXdd99lL583b16Oc0m/G/785z8Xen+eeOIJ8176vePp66+/NssfeuihHNt4fn/6e13pdazvN3fu3FyPp67v+V76Gfr9q+/l+3n6vd6tW7ci7full17quuaaa/xaF/AXTaGAYvbaa6+Z2gHPhzblcdO7cv5WQQ8ePNjrDqneQdU7YV988UX2Ms92uVoNrrUl2mxI7yprsyaldwO1ml/v9HneFVTumg9tVqF3xfRuovt99KF3vPROqjbT0DuoheGZNm1uoe+lTRo0DQU1S1B6jPRurd7Zc6dHH3q3VWslFi1alGMbvWPnSY/Fjh07xAqtqSiJjuVWue9qaxMLzX9/8sVdw6Z3t/U4FdS8SM2cOdMcV21S55kvepdfa420CV9R6TlelH3KjZ5vmsa86J1iPZfctIZLaw70OvFs067raVNEbVrlSWtz7rrrruznemdZ7xx7nm96rWotod5Vd9OaGL22i7qf7n3yrRnNrQZBvy+0hsJtw4YNprbw9ttvz16m16PWVuo1HiiffPKJuXOv3y+e54zWzGgTLN9rWY+t1lC46R19TafWZOq17+b+2/OY63rabGj//v2FPl/0ePn2OdDaWv2e9K35UZ7NFQtzXWlTMf1ezY3W0Hq+17p160zeaA2NptF97PR3RGvD9HpzN0EszL67r1+gONEUCihmWrDIr/O2Vo1r8wSt1tYmR9oRU39stUmFL/3B9aQ/eFpI8SzkaoFA2+NqUOBui+vm/jFz9w/Qdst52bZtm2leoU0V9JFXZ1hNs7+0GYg2sdAqew1KzlVqeKctP+6Cjlb350YLe57cbZ99fzx9+6UEU0H9JqzQwoo2iRs/frxpMqKFf22WoYVfz6Y02vxBC0krVqzIUYjVfMmveZE7X7Qtuu+x9jxPikILdZ59HQqzT3nxPOd86Xt70maGyrNZijtgqFevXvbrbppW3/zU802Pjed7ajDtu57vZxRmP937VNC5pE2RtOCp3zfavEZpkKHH2d30zj2S3Y033iiXXnqp+Y7Q76K7777bUrO83M4ZTbfvd5qb5w2UvI6tHgft0+O7THle49rPRQvnuq42HdI+O9o/TfOwKPT7U5uwaZ+Q/BTmuvI99zz5vub+HtR9you+v557hdl3zY9Afh+hbCKwAEqYdqbTO1B6Z1JrMvShBW/98n///fcL9V56N1/viGkBWwsH2pdAC9daG6BtvQszwZN7XW3Xm9edtMIO2altxXXf9A5wu3btzA+r/pDpnUh/0uZeR9uk651NX76jJnnefQ4G90gyeQ0Tq4WNQI82o31KtCO0durX+Ru0Xb8Gd9oWXAtrWkjSwqZOAKaFWC2AaMFZ76xru3h/80Xb3j/22GO5vq4FVJVXoSW3gQWUdjbNbfSbgvYpL9q/Ir+gMrdReAojr/Mtv2AmP/7up3uf3H0Y8qPXmg5Rq985LVu2NEGG5r/nttrHQc8L9+e+/fbb5lzQ0bS0P0Fx0HNGzwf9vsvtuPnWEuR1bP055nqjRgOzWbNmmf3RfhjaP0trTdx9X/I6X7TvhNbYuvtr+Kuw11V+557va+5tdT80D3PjPn6F2Xc9j/IK9ICiIrAAgkB/cK6//nrz0B8NrcXQUUG0psCz8K53qnTEGbeTJ0+azrF6F0ppJ26tGtcfDc+5DLTZkycNONzNIHIb8US572jpncO81iks7USod888x0vX4RN9R9jJqwDqTrcGY8WVpkDeoXN3EtaOmfrj7ks7tnrWGgUqLdp5WB9ak6UdUrVDvhYSn332WdOhVDuE6khf2unaLbdmZfnli56LBeWJu8mOb3773vm3uk950UKeNmMpSv553uHV5lF6TRXlHNT31OvO9+6wfkZR99N9fbsHOMiPDrygHYTdzaH0HNRO9r70brwGIPrQvNXvE+3UXdjAIr9zRo+B3o13B56BpDW7+r2qD61B047L2nk8v8BCzxf38fWsrdG0640gbS6aV61FYa6rwnJ/D+oNJH/OQX/2XQMo7fCutWJAcaKPBVDCNBDwughDQ7N/xHyHoHzrrbdM3wQ3HXVEfxDcPxDuu3eed+u0EKTDZXrSHxb9QdfRenwLee5ttfCuozVpgKPBiy8dwaWwNH2+d291FBjfO9bu+QN806Y1J/pj+vzzz3sdBytp0vbtuX1WcQw3q00P9DjqHV/fvPz0009NczDPH/eipCU/2hROzw9PWkjVc8ydntzOGW1GoTVLvjRfckub3hXV5h5a2PKl67vToIVq/TzfPhe+56fVfcqL1pLpXVl/+9hooU2Dfh2hzPP4vPPOO+YY6TDHhaU3AbS9u+fs1Fpzpdd2UfdzzZo1pgCv+1cQbXOv15HWVOgwprp/Gmzk952kd7/1BkdBxzc3eV3L2vRKzwUdccv3O0Gf+6ahqPS7xbeZpV6T2pTJn/NFeQ4hq3QIYE1jbkP3uvelMNdVYen3igYXOlKaBn15fQ8WZt+1n43e5Lnyyistpw/wRI0FUMy0qt/dadqTfoHrXVC9A6h3vrTfgDZv0Lu3WtjWKm7fO5AaJGj1uhbk9A6nFsh0KE73XSZ9T70rrLUC2mxCCxvabMj3h1sLJxqUaA2Jfo7eldS7WppO7aPhLiBqx3N9fy3QaIdVTa+Oh6+FSB2Lf/369YU6FjpcpKZHm0Dp8Ib6PtpB1j30rpumSX+Ytcpefxi1SYx7PHhNt7b31uBIm3Vou34dulM70urdXPdY/P7SZgaaFr2Dq3dO9Q6k1iLk1//E3+FmtdCmP/6aH1dccYXpIKv7qp3ndUZfDSA9O+0WJS350X42OsykDs+p76cFVT3+emy1cKS0T4+7xkzvZGtBZfLkyeZY+waUWqDR4693y7WgqetovuhcBXpnVvNXm+7oetqR9KeffjIFaD1O2tRG813Toue3nptaONLhUwvTB8OffcqLBgLaXE7POd/O0rnRc0vv5msBUvsZ6HXmvu40Pz07avtLryM9R7WpowYEet1p+t1BZVH2Uwc10HPf9zrKi56HmnbdDw0yfAdw0HNQbypoPuo5qAVr95ClhaXvoXSIYr1etQZUzzXNez2P9Pjq+aHBjTY30toBbbaj+aPNMK3SZkz6vaqd5Vu0aGGCJM1/HS64oJmm9ftOrz1d33PyQa011u8gDTi1FlnPDa1p1mFe9TU9ToW5rgpLv7/1ZoXelNDhbPX7W/u66Y0KrRHRmy9aY1KYfddzSM/BwgwnDPjF7/GjABR5uFnP4RD/+9//muEsq1evboa2rF27thke9sCBAzne65tvvnENHjzYVblyZVelSpVcffv2dR07dszrc5ctW+b6wx/+4CpfvryrZs2arsceeyx7CEbfYT6XLl1qhiaMjo42w4U2b97cNXHiRK91tm/f7urXr58ZNjMiIsJ10UUXua677jqT7oL4Dp2qQ9sOGDDAVbVqVZN+HS5Rh430HTZVTZ482QyzqENS+qZd/9ZtdSjFqKgo1yWXXOLq37+/6/vvv89eR99P98mfYVuXL19uhiHV4+/P0LP+Djfr9uWXX7quuuoqM6ywHkMdEnL48OE5hvrNLy1FGW52x44drnvvvdccHz1OVapUMelYsGCB1/vMnj3b5L2uU6dOHTNsqQ6l6jtMqA7rq8OQ6vmir3kOPatDco4cOdIMm6pp1zzWYYnHjRvnNUSyDqmrw6/q8Md6Huu5vmHDhlyHm80t//zdp7zccMMNZhjlwgwLrMPLNmrUyORdjRo1XPfff3+OvNNjocPx+tL98D1Xfv31V5MOPQZ6nHTIaR1qtCh5l5SUZI7322+/7fJXSkqK+X7Qz/vwww9zvP7ss8+62rRpY4Z21vV033X4V8989He4WfdwxPq9oUPD+p5TH3/8sRnmV/NaH/pZOjzq1q1bCzy2elxzGxZXP8M9xKoO+fvXv/7VDKHr/p7Tv19//XW/jtX48ePNd5Xv0LE6LLEOpavp1eNfrVo1M1TrmjVrCn1d5bUfeR1PNx2S+E9/+pPrggsuMEOY6/vcdtttroULFxZ639u2beu66667/DomQGGE6P/8C0EAlBSdiEnvSumdpvxGmAKQP72rrHfjtXbOCR1VtTmjjvyjTfOsdj5HTlpjqjUXeox1Ujwn0o78WgOsg3zk1RkcKCr6WAAAHEs70WszFS0o2p32M9IRh7RjN0FFYGjzPR3tTEdTKsyoenYyduxY01yKoAKBQI0FUApRYwEAAOyGGgsAAAAAllFjAQAAAMAyaiwAAAAAWEZgAQAAAMAyJsgrgI4KobOm6kQ+OsETAAAAUFa4XC4zAaPO4q4TNuaHwKIAGlQkJCQUZ/4AAAAAtrJnzx4zu3t+CCwKoDUV7oMZExNTfLnjsFqdI0eOSLVq1QqMZGEf5Kszka/ORL46E/nqTFk2KzelpKSYm+zuMnF+CCwK4G7+pEEFgUXeF8jp06fN8bHDBQL/kK/ORL46E/nqTOSrM2XZtNzkT5cA++wNAAAAgFKLwAIAAACAZTSFsthLPiMjQzIzM6WsV+mlp6ebar3cqvQiIiIkLCwsKGkDAABAySCwKKKzZ8/KgQMHJC0tTco6DbA0uNChyHJrf6fLdBSBSpUqBSV9AAAACDwCiyLQQvTOnTvNXXgd07dcuXJ+z3GhhfCktHQ5dTZTKpYLk7gKEbafH8NdcxMeHp5jX/Q1Hflg79690qBBA2ouAAAAHIrAooi1FRpc6NBbFSpU8Gub5N/S5eM1e+X95bvk1+O/13JcXKWC3HNlHbk5sZbElo8QpwUWSodT27Vrl2kuRZMoAAAAZyKwsMDfIcK++fmI3P/hGvntbM6+GLuPp8kzczbJuK+2yht3JUrnS6uJ09i9RgYAAAAFY1SoANOgYsB7q+S39Exx6d19n9fdy/R1XU/Xt1KAT0pK8lpWp04dWbdunQTKypUrpWXLltKkSRO5+uqrZd++fQH7LJReXbp0kWHDhuVYPmXKFImLizN/b9y4UW6++WZzTuq5OmHChCCkFAAABAqBRQBp8yetqTDBg29E4UNf11V0fd2uNNLmTp60OVjfvn3l5Zdflk2bNsk111yTa+ESUDrQQb169WTs2LESHx/PQQEAwGEILAJI+1Ro86eCggo3XU/X/2Tt3mJPiwYBQ4cOlcaNG0uLFi0kMTHRDA+r5s2bJx06dDDL2rRpI4sWLTLLFy9eLE2bNpWBAweaWolZs2Z5veeaNWtMv4qrrrrKPB8yZIh89tln2e8LeLriiivkpZdekjvuuEMiIyM5OAAAOAx9LALYoVk7ahfFlGW7pP+V55qLFJf169fLwoULTXMU7RuSnJxsRrPasWOHjBo1ygQXOrX8tm3bpGPHjqaztdq8ebO8/vrr8s477+R4z927d8vFF1+c/Tw6Otq8x/79+82daQAAAJQdBBYBciIt3Wv0J39p5YZup0PSVq5YrljSogFK3bp1TVOme++919Qw9OrVywQYc+fONcFEp06dstfX5Ro0KA0QOnfuXCzpAAAAgHPRFCpATp3x7o9QWCeLsL0O63rs2DGvZUePHpXq1atLbGysbNiwQe68807ZsmWLNG/e3AQUWrPSrVs308Hb/dAO2DrnhMpvUrvatWvLr7/+mv1cJ8jTmhCd2wP4nUvk1DGRE7+e+9fftoEAAMBWCCwCpGKktcqgSkXYvkePHvLmm29mP586daqpcbjwwgvNJHWnTp2S7t27y/PPP29G5tEO17rNggUL5Mcff8zebtWqVX59nvbJ0Lkp3H0y9LOvv/56iYqKKnTaYW/aBE6DSi+/JUmdQ1/KuntDRV6qJ/Kv5uf+faWVDGh8WiKzfgtWcgEAQADYLrB47bXXTKFYC69t27bNtxD8ySefSOvWrc1wlxUrVjQdkD/44IMSSWflChFm8rvC9pLQ9XU7nZG7sHT4zgMHDpjaCN3X6dOny8yZM81re/bsMTUT+tpll11mHjqKU/369c162vFaO3Vr525/hwHVJlMffvihGQlKh5v9/PPPzQhRKHsaNmwoa9eu/X3BtgUi45tIp7S5Ujs6y3vlE7vkyTa/ycCUf55bDwAAOEKIS9vC2MSMGTOkX79+MmnSJBNUaAFYC85bt241zX186ahGJ06ckEaNGpmOynPmzJFHHnnEFID1Tr0/UlJSTDMivRurd2WVjnq0c+dO028hv7vz7y7daSa/cxUysHjq+iYyoH1dccrM2/4eL5QuOpLY4cOHzbVV0GSQOgiAjiA2aNAgGXZ9M6m7/DFxubLyvXOR5RIJCQ2VA1f9S2p26lfs6Yf1fIV9kK/ORL46U5bNvodzKwvnpfTvjYfx48ebgsuAAQPMHXINMCpUqCDvvvtunpN23XTTTeYu/CWXXCIPP/ywuWO/dOnSEknvzYm1pHy5MPF3cKfQEDHr/+nyWoFOGlCstMndkiVLZM8vG6TG4kclKzP/oMJ9vmdlZkrl+Q+bZlMAAMDebBNYnD171syb0LVr1+xlGuXp8xUrVvh1V12HW9XaDc8RkAIptnyEvHFXoqmFKCi4cL8+6a5Esx1gx3kqZj19q1SMCJEwP79ZwkJDpHyYS2T9R4FOHgAACDDbDDeroxtlZmZKjRo1vJbrcx3lKC9abXPRRRfJmTNnJCwszMzJoH0N8qLr6cOz+sddbaUP998aqLgf+enUoKq82/8KeWDaWjP5nfLcwh1vlI8Ikzf6Xi4dG1Qt8D1LI3eac0u7+zh5HkOUfu7z3O88c7kkZOW5wQMK07fInDErJ4nrikEFR+Ao+XyFLZCvzkS+OlOWzb6HC5NO2wQWRaWTtukQqidPnjQ1FsOHDzfNNrSZVG7GjBkjo0ePzrFcR1VyzyitIyHpQdZ+BfooSPt6leXbRzvJrHX7Zep3u2X38d9Hw0moUl76/aG2/KlVTYmOivDr/UobvTg06FO59bHQfdLjpUPhRkRQG2MXmmcamGv++tMGNOS341LjxM5Cf06IhhYndsrhPT+LK6pyEVOLQOUr7IF8dSby1ZmybPY9rNMJOC6wqFq1qqlxOHTokNdyfR4fH5/ndpphOvKR0pGSdCZpDR7yCixGjhxpgg/PGouEhAQzR4Rn5209yNpZWR/+qBIdLgM7XiL3tq8ryccOyW9pKVK+QozEXlDDdGB1gryCBj1Gmg8XXHABnbdt9sWngaKe++4vvpB5A0TOJInrhlkie5dIyPfjRA6vlZBTByTrqt+HOi6KajHlReJyDsKAwOcr7I98dSby1ZmybPY9XJiBd2wTWOioTjpvgtY69O7dOztj9PnQoUP9fh/dxrOpk6/IyEjz8KUZ7858/VdPCPfDL9o5df2/TVORyid2SvZ92cp1RdoOEWnRR6R8nNiRRtzu45Db8XAfJ89jCHvIkW8mf0POBcOZv4lUbynSbKDI7D9JaER5S58VGhWjF1fxJBz54np0JvLVmchXZwqxUbmoMGm0TWChtCbhnnvuMXNTtGnTxgw3q5O+6ShRSoei1f4UWiOh9F9dV0eE0mDiiy++MPNYvPHGGyWbcB2rf0Y/kfS0nK+d2CUyd6TIwmdEbp8qUv/3zulAqVb3mnMPt8hK5wJlPacLO8hy5Toi5WkGBQCAnZX+MMnD7bffLuPGjZOnnnrKNGvSvhNz587N7tC9e/duM0GcmwYdDzzwgBlfv3379vLxxx+bCd3+7//+r2SDimm3iaT/dr6w5VvgOr9MX9f1LEwYptFvUpL3sJ06maAep0C55ZZbTDCnNUq+n40yRmsztPatKNreR8dtAABszlY1FkqbPeXV9EknxPP07LPPmkfQaPMnrakwIyUV1KM+S8QVem794ZtKZbMo9yR4nu677z4zG3p+/VxQhmiTPq19M4G0H6NIhISKhJcXaXFHSaQOAAAEkK1qLGxn/b/PN3/yd5iurHPrB2BMf+1bogGZThbYokUL01/FPcrVvHnzpEOHDmaZNjFbtGhRdqCmtT0DBw40NUSzZs3K8b46j0hus57DgVJ+Eck4JpKVJHJ8rfdD481T20V+2yFy3ZMiUZkikVkikZkiEedGDMv96ydE5PYPSmUgDQAAHF5jYRtaS3F+TP9CWznpXJOSYhzTf/369aaj+8aNG00nHB3mTJsv7dixQ0aNGmWCCx31atu2bdKxY0fZtUvbyYsZRUvn/njnnXeKLS2waVAx59Lfn89N9H69mohselRk0/nntX2231lRJD3s/JPz57V29tagov7VgUs3AAAoMQQWgZJ23IzNX3jnxvSX306IVKhSLEnRvhd169Y1TZnuvfdeueqqq6RXr14mwNA+KhpMeM5Grsu1v4rSOT86d+5cLOmAjWX4P4Z1gXWj2lFb+1S07CMSFWs1ZQAAoJQgsAiUsyetbX8mtdCBhY6HrJPQxcXFec1Yrk2VYmNjZcOGDfLNN9+Ypk46X8eSJUvMULE6E/n06dNzvN++ffukUqVK1vYDUPd8JlK+nkhk9LnRn5hhGwAAx6GPRaCUs1gg1wJYIfXo0UPefPP35ldTp041NQ4XXnihmTlcR8nq3r27PP/882a0qE2bNpltFixYID/++GP2dqtWrbKWdsCX1kxUvvhcsExQAQCAI1FjEShagCrhMf11Xo9hw4ZJ8+bNTXMmHalp5syZ5rU9e/bIoEGDJD09XTIzM83wu9dcc42ZLVtrK4YMGSJpaWly9uxZadWqVa41GLnRJlXaf0Nddtll0qBBgxyjcwEAAMD5CCwCPaa/Tn5XQmP6X3DBBWYCwNxcfvnlsmbNmlxf05Gd9OGrS5cuBc6B8fnnn5vmVO6haP2eiRwAAACOQlOoQI/pH1HB/8OsY/rr+ozpDwAAAJshsAgkHZv/9qnnax8KOtSM6Q8AAAD7IrAItPpdRfr+59yY/Wb8ft+mQueX6et9ZzKmPwAAAGyJPhYlFVwM33RuRm2d/M5zfgvG9AcAAIADEFiUZLOoP9wnrjaDJSl5l6SlHZUKFapKXGwdCQml4ggAAAD2RmBRQlLOpsjsbbNl+pbpsid1T/byhOgEubPRnXJD/RskplxMSSUHAAAAKFbcKi8By/Ytk64zu8qLq1+Uval7vV7T57pcX9f1rNChXpOSkryW6UR4BQ0ZW1T79+83E+w1atTIDGd7yy23mIn4AAAAUPYQWASYBgsPLHxATmecFtf5/zy5l+nrup7V4CKQdK4KT2FhYfLkk0/Kli1bZO3atVK3bl3561//GrT0AQAAIHgILALc/Okvi/9iJpDzDSh8mTVcLrO+blfcsrKyZOjQodK4cWNp0aKFJCYmyunTp81r8+bNkw4dOphlbdq0kUWLFpnlOoN206ZNZeDAgdKyZUuZNWuW13vWqFHDbOfWtm1b2bVLZxqH44RHB3d7AABQ6tHHIoC0T4W7psIf7pqLz7Z/Jn0b9y3WtKxfv14WLlwoGzdulNDQUElOTpZy5crJjh07ZNSoUSa4iImJkW3btknHjh2zA4TNmzfL66+/Lu+8806+75+ZmSmvvfaa3HjjjcWabpQSMQ1ErvtZJCO1aEGFbg8AAByNwCJAtPZBO2oXxbTN00yHbu0zURz0fbSZkjZluvfee+Wqq66SXr16mQBj7ty5Jpjo1KlT9vq6fPfu3ebvevXqSefOnQvc1wcffFAqV64sDz/8cLGkGaUQwQEAAMgHTaECJOlMkhn9yd/aCjddX7dLPpNc6M+sVq2aHDt2zGvZ0aNHpXr16hIbGysbNmyQO++80/SJaN68uQkoNCjo1q2b6eDtfuzbt08aNDh3h7lSpUoFfu5DDz0ke/fulY8++sgEJQAAACh7KAUGSFpGmqXtT2WcKvQ2OkLTm2++mf186tSppsbhwgsvNKM1nTp1Srp37y7PP/+8GS1q06ZNZpsFCxbIjz/+mL3dqlWr/P5MDSq2b98uM2fONE2rAAAAUDbRFCpAKoRXsLR9xfCKhd5mwoQJMmzYMFMboTUH8fHxpsCv9uzZI4MGDZL09HTTH6J9+/ZyzTXXSEREhEyfPl2GDBkiaWlpcvbsWWnVqpVZVpBly5bJxIkTzXCz+n7uJle+nbwBAADgfAQWARIXGWcmv9N5KgrTHCpEQqRWdC2JjYwt9GdecMEF8sEHH+T6ms4zsWbNmlxf69q1q3n46tKlS75zYGgwYUa8crlM/43w8PBi6xcCAAAAe6EpVIBoAVs7YBeFjghFAR0AAAB2QmARQDfUv0GiwqNMLYR/mRFq1r/+kusDmSwAAACg2BFYBFBMuRh5ucvLpvahoODCvB4iMqHLBLMdAAAAYCcEFgHW/qL28vrVr2fXXPgGGO5l+vobV78hV150ZaCTBAAAABQ7Om+XUHCx4NYFZkbtaZs+lKTDeyTqrMjpciJx1WtJ3yZ3yQ2X3CDR5aJLIjkAAABAsSOwKCEVT4tcszpT2n6QKel7MrOXRyRkSpW7M6XCRS4RpoEAAACATdEUqgSc/Hap/NK5ixwaM1bS9+71ek2f63J9XdcDAAAA7IjAIsA0WNgzZIi4Tp8WcbnOPTydX6av63pWggvtJJ6UlOS1TGfYzm8uCit0Ju+2bdtKy5YtJTEx0Uy4t2vXroB8FgAAAEo3AosAykxJkb0PPZR7QOHr/Dq6vm5XGukkeJ7Kly8vCxYsMIGLTr7XvXt3efjhh4OWPgAAAAQPgUUAJX/66e81Ff44X3OR/On/ij0tWVlZMnToUGncuLG0aNHC1DCc1rSJyLx586RDhw5mWZs2bWTRokVm+eLFi6Vp06YycOBAUysxa9Ysr/cMDQ2V6OhzHc519u2UlBQm9gMAACij6LwdIFrQPv7hh0Xa9viHH0jlu+8q1kL6+vXrZeHChbJx40YTECQnJ0u5cuVkx44dMmrUKBNcxMTEyLZt26Rjx47ZTZo2b94sr7/+urzzzjt5vne3bt3kp59+kmrVqpn3AQAAQNlDjUWAZCYlSfruPf7XVri5XGY73b64aIBSr14905Tp3nvvlffff1/S09NNgDF37lwTTHTq1MnUStxyyy1m+e7du822ul3nzp3zff/58+eb9W+77TZ57rnnii3dAAAAsA8CiwDJOpVW4ttrjcGxY8e8lh09elSqV68usbGxsmHDBrnzzjtly5Yt0rx5cxNQaM2K1jhoPwn3Y9++fdKgQQOzfaVKlfz6bA1GBg0aJB988EGh0w0AAAD7I7AI1IGtWKHEt+/Ro4e8+eab2c+nTp1qahwuvPBCOXLkiBnFSTtYP//882a0qE2bNplttAP2jz/+mL3dqlWr/Pq8gwcPyokTJ7Kfz5gxwwQsAAAAKHvoYxEgYXFxElE7QdL37C1cc6iQEIlIqGW2L6wJEybIsGHDTOFeaxDi4+Nl5syZ5rU9e/aYGgVtApWZmSnt27c3w8NGRETI9OnTZciQIZKWliZnz56VVq1amWUF0eZPup2+n3YOr1+/vnxYxH4lAAAAsDcCiwDRfg1V7rrLTH5XWFXuurtIHbcvuOCCPJsiXX755WZI2Nx07drVPHx16dIl3zkwdASpH374wTSn0v4b4eHhjAoFAABQRtEUKoBie/eWkKgoUwvhX26EmvVje98YyGQBAAAAxY7AIoDCYmKk1iuvnAssCgouzr9ea+JEsx0AAABgJwQWAVapYwdJePPN32sufAOM88v09YS33pJKHdoHOkkAAABAsaOPhQXaYdnf4KLBN4vNjNo6+Z2Z3+I87aitfSpib+otYednsXYa7YMBAAAAZyOwKAKdsVpHXdq/f7+ZO0KfF9jZulw5qXDbrVL+1lskKznZzFOhQ8qGxsaabdNFJP30abGj/Dpv62s61K0u1xGoAAAA4EwEFkWgQUXdunXlwIEDJrgosrNnRDzmgbArDR609kaPS24Bli6rVauWhIWFBSV9AAAACDwCiyLSWoratWubO/U6j0NZpkGFzvitw91qcOFLayoIKgAAAJyNwMICd/Oest7ERwMLPQZRUVG5BhYAAABwPkqBAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAACBBQAAAIDgo8YCAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAgLIXWLz22mtSp04diYqKkrZt28qqVavyXHfy5MnSsWNHqVy5snl07do13/UBAAAAlIHAYsaMGTJ8+HB5+umnZe3atdKiRQvp0aOHHD58ONf1Fy9eLH369JFFixbJihUrJCEhQbp37y779u2T0qRLly4ybNiwHMunTJkicXFx5u9PPvlEWrdubZ5XrFhRWrZsKR988EEQUgsAAADYPLAYP368DBo0SAYMGCBNmjSRSZMmSYUKFeTdd9/Ndf1p06bJAw88YArhjRo1krfffluysrJk4cKFYjdVqlSRv//97yZA+vHHH80x0Me8efOCnTQAAABAwu1yDM6ePStr1qyRkSNHZi8LDQ01zZu0sO2PtLQ0SU9PN4X0vJw5c8Y83FJSUsy/GpDoI1BcLleO93c/1387derk9dqDDz4o77//vnz77bfSrVs3CSZNX27ph72Rr85EvjoT+epM5KszZdms3FSYdNomsDh69KhkZmZKjRo1vJbr8y1btvj1Ho8//rjUrFnTBCN5GTNmjIwePTrH8iNHjsjp06clUEGTBj2+TbpSU1PNiee7XJctXbrU7LfuU15NwUryhEtOTjbp0mAPzkC+OhP56kzkqzORr86UZbNyk5ZHHRdYWDV27Fj56KOPTL8L7fidF60R0X4cnjUW2jejWrVqEhMTE5C0lStXzjTpql69utfy6OhoCQkJyV6uJ6GmRWtUwsLC5NVXX5Vbb71VSsMFounUY2SHCwT+IV+diXx1JvLVmchXZ8qyWbkpv3KzbQOLqlWrmsL0oUOHvJbr8/j4+Hy3HTdunAksFixYIM2bN8933cjISPPwpRkfyMzXE8z3/UNDQiQ2JEQy9h+Q0IoVTGCzbt06OXnypOkn8uijj0r9+vVN5+9gc6ffDhcI/Ee+OhP56kzkqzORr84UYqNyU2HSWPr3xuOufmJiolfHa3dH7Hbt2uW53YsvvijPPPOMzJ0714yqVBppwKC1EW6ZKSlyfOpUafbGJJlbI162d+0qv7S7UnZec41UWb5cmtWrJ4888ojccsstpukWAAAAEGy2CSyUNlHSuSm00/LmzZvl/vvvl1OnTpnRkVS/fv28One/8MIL8uSTT5pRo3Tui4MHD5qH3vEvTRo2bGiGz1Unv10qv3TuIofGjJWo8x3H3dL37DXL9XVdTwMrz47mAAAAQLDYpimUuv32200n6qeeesoECDqMrNZEuDt0796926u65o033jAdo/XOviedB2PUqFFSWmiApP0lXrrzTum1br2EuFzaQztn1KfL9Z/Tp2X34MGyfd8+uXv8P4ORZAAAAMBLiEu7pCNP2nk7NjbWNFUKVOdttXrxYom4/wEJz8qSsJCQAtfXgb9cERHSeNlSCQtguvyhNSc6MpV2MrdDW0H4h3x1JvLVmchXZyJfnSnLZuWmwpSFS//elBGX7N4t2mXcn6DCnXFhGRmS/On/Ap42AAAAoCAEFqWAVhod//DDIm17/MMPzPYAAABAMBFYlAKZSUmSvntPdh8Kv7lcZjvdHgAAAAgmAotSIOtUWlC3BwAAAKwisCgFdPK7YG4PAAAAWEVgUQqExcVJRO0EnYaxcBuGhJjtdHsAAAAgmAgsSsm07lXuuqtI21a5626zPQAAABBMBBalRGzv3hISFeV/rUVoqFk/tveNgU4aAAAAUCACi1JCJ7mr9cor5wKLgoKL86/Xmjgx6JPjAQAAAIrAohSp1LGDJLz55u81F74Bxvll+nrCW29JpQ7tg5VUAAAAwEu491OUhuCiwTeLzYzaOvmdmd/ivIiEWqZPRexNvSUsOjqo6QQAAAA8EViUQtq8qUq/u6Xy3XeZye90ngodUlZHf6KjNgAAAEojAotSTIOI8MqVRfQBAAAAlGL0sQAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWBZu/S0AeJnbX+R0kkjvT0XWvSGy/g2RlF3nXrugqUi7p0TqXsNBAwAAjkJgAQRSdC2RjmNFKjcQcblENr0v8umNInf/IFK1KcceAAA4BoEFEEiXXO/9vMNz52owDnxHYAEAAByFwAIoKVmZIj/PFEk/JVKzHccdAAA4CoEFEGhHfhL5dzuRjNMi5SqJ3DBL5IImHHcAAOAoBBZAcUn5RSQjVSTjmEhWqsjxtedfSBe5YZpI+kmR3QtE5vcV6T5ZJLbe+aswWiSmAfkAAABsjcACKK6gYs6l3svmJua+brSIrLjVe9l1PxNcAAAAW2MeC6A4aE1FMLcHAAAIMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsACKQ3h0cLcHAAAIsvBgJwBwhJgGItf9LJKRWrSgQrcHAACwMQILoLgQHAAAgDKMplAAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAlL3A4rXXXpM6depIVFSUtG3bVlatWpXnuhs3bpSbb77ZrB8SEiITJkwo0bQCAAAAZYWtAosZM2bI8OHD5emnn5a1a9dKixYtpEePHnL48OFc109LS5N69erJ2LFjJT4+vsTTCwAAAJQVtgosxo8fL4MGDZIBAwZIkyZNZNKkSVKhQgV59913c13/iiuukJdeeknuuOMOiYyMLPH0AgAAAGVFuNjE2bNnZc2aNTJy5MjsZaGhodK1a1dZsWJFsX3OmTNnzMMtJSXF/JuVlWUeyEmPi8vl4vg4DPnqTOSrM5GvzkS+OlOWzcpNhUmnbQKLo0ePSmZmptSoUcNruT7fsmVLsX3OmDFjZPTo0TmWHzlyRE6fPl1sn+MkesIlJyebi0SDPTgD+epM5Kszka/ORL46U5bNyk2pqanOCyxKitaIaD8OzxqLhIQEqVatmsTExAQ1baX5AtHO8XqM7HCBwD/kqzORr85EvjoT+epMWTYrN+mASY4LLKpWrSphYWFy6NAhr+X6vDg7ZmtfjNz6Y2jG2yHzg0UvEI6R85CvzkS+OhP56kzkqzOF2KjcVJg0lv69Oa9cuXKSmJgoCxcu9Ir49Hm7du2CmjYAAACgrLNNjYXSJkr33HOPtG7dWtq0aWPmpTh16pQZJUr169dPLrroItNPwt3he9OmTdl/79u3T9atWyeVKlWS+vXrB3VfAAAAACexVWBx++23m07UTz31lBw8eFBatmwpc+fOze7QvXv3bq/qmv3790urVq2yn48bN848OnfuLIsXLw7KPgAAAABOZKvAQg0dOtQ8cuMbLOiM29rjHgAAAEBg2aaPBQAAAIDSi8ACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABAYAEAAAAg+KixAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAKDkAov09HR57LHHpH79+tKmTRt59913vV4/dOiQhIWFWU8RAAAAAOcGFs8995xMnTpV7rvvPunevbsMHz5chgwZ4rWOy+UKRBoBAAAAlHLh/q44bdo0efvtt+W6664zz/v37y/XXHONDBgwILv2IiQkJHApBQAAAGD/Got9+/bJZZddlv1cm0QtXrxYli9fLnfffbdkZmYGKo0AAAAAnBJYxMfHy/bt272WXXTRRbJo0SJZvXq1qcEAAAAAUDb5HVj88Y9/lOnTp+dYXrNmTfn6669l586dxZ02AAAAAE7rY/Hkk0/Kli1bcn1Nay6++eYbmT9/fnGmDQAAAIDTAouLL77YPPKiNRf33HNPcaULAAAAgI0wQR4AAAAAywgsAAAAAFhGYAEAAADAMgILAAAAACUfWNSrV0+OHTuWY3lSUpJ5DQAAAEDZU+jAYteuXbnOsn3mzBkzOzcAAACAssfv4WZnz56d/fe8efMkNjY2+7kGGgsXLpQ6deoUfwoBAAAAOCew6N27t/k3JCQkx3wVERERJqj45z//WfwpBAAAAOCcwCIrK8v8W7duXVm9erVUrVo1kOkCAAAA4OQ+Fjt37gxqUPHaa6+Z2pGoqChp27atrFq1Kt/1Z86cKY0aNTLrN2vWTL744osSSysAAABQVvhVY/HKK6/I4MGDTeFc/87PQw89JIEyY8YMGT58uEyaNMkEFRMmTJAePXrI1q1bpXr16jnWX758ufTp00fGjBkj1113nUyfPt006Vq7dq1cdtllAUsnAAAAUNaEuFwuV0ErafOn77//Xi644ALzd55vFhIiO3bskEDRYOKKK66QV199Nbt5VkJCgjz44IMyYsSIHOvffvvtcurUKZkzZ072sj/84Q/SsmVLE5z4IyUlxXRUT05OlpiYmGLcG+fQfDh8+LAJ7kJDmRrFKchXZyJfnYl8dSby1ZmybFZuKkxZONzf5k+5/V2Szp49K2vWrJGRI0dmL9PM6Nq1q6xYsSLXbXS51nB40hqOTz/9NODpBQAAAMoSvztvB9vRo0fNsLY1atTwWq7Pt2zZkus2Bw8ezHV9XZ4XnY9DH55Rmju6dHdghzc9LlrxxfFxFvLVmchXZyJfnYl8daYsm5WbCpPOIgUWe/fuNfNa7N6929QkeBo/frzYmfbHGD16dI7lR44ckdOnTwclTXY44bR6TC8SO1TpwT/kqzORr85EvjoT+epMWTYrN6WmpgYusNCJ8G644QapV6+eqSnQTtA6G7cenMsvv1wCRUeiCgsLk0OHDnkt1+fx8fG5bqPLC7O+0qZWns2ntMZC+3FUq1aNPhb5XCDav0aPkR0uEPiHfHUm8tWZyFdnIl+dKctm5SYdvClggYUWvB999FFzVz86Olo+/vhj0/mkb9++0rNnTwmUcuXKSWJiogls3JP1acbo86FDh+a6Tbt27czrw4YNy142f/58szwvkZGR5uFLM94OmR8seoFwjJyHfHUm8tWZyFdnIl+dKcRG5abCpLHQe7N582bp16+f+Ts8PFx+++03qVSpkvzjH/+QF154QQJJaxImT54s77//vknH/fffb0Z9GjBggHld0+XZufvhhx+WuXPnmhnBtXZl1KhRZnSrvAIRAAAAAEVT6BqLihUrZveruPDCC2X79u3StGnT7A7WgaTDx2pfh6eeesp0wNZhYzVwcHfQ1j4fnlHVlVdeaeaueOKJJ+Rvf/ubNGjQwIwIxRwWAAAAQJADC50HYunSpdK4cWO59tpr5ZFHHpGffvpJPvnkE/NaoGltQ141DosXL86x7NZbbzUPAAAAAKUosNBRn06ePGn+1n4W+rfOiK21AXYfEQoAAABACQQWOo+EDjXbvHnz7GZR/s5gDQAAAMC5CtV5W4d77d69u5w4cSJwKQIAAABgO4UeFUo7Pu/YsSMwqQEAAABQNgKLZ5991sxjMWfOHDlw4ICZQM7zAQAAAKDs8buPhc5ToSNA6UhQSmff1sk93HTmbX2u/TAAAAAAlC1+BxY6AtR9990nixYtCmyKAAAAADg3sNAaCdW5c+dApgcAAACA0/tYeDZ9AgAAAIAizWNx6aWXFhhcHD9+vDBvCQAAAKCsBRbazyI2NjZwqQEAAADg/MDijjvukOrVqwcuNQAAAACc3ceC/hUAAAAALAcW7lGhAAAAAKDITaGysrL8XRUAAABAGVOo4WYBAAAAIDcEFgAAAAAsI7AAAAAAQGABAAAAIPiosQAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAAMsILAAAAABYRmABAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAAMpOYHH8+HHp27evxMTESFxcnAwcOFBOnjyZ7zZvvfWWdOnSxWwTEhIiSUlJJZZeAAAAoCyxTWChQcXGjRtl/vz5MmfOHFmyZIkMHjw4323S0tKkZ8+e8re//a3E0gkAAACUReFiA5s3b5a5c+fK6tWrpXXr1mbZxIkT5dprr5Vx48ZJzZo1c91u2LBh5t/FixeXaHoBAACAssYWgcWKFStM8yd3UKG6du0qoaGhsnLlSrnpppuK7bPOnDljHm4pKSnm36ysLPNATnpcXC4Xx8dhyFdnIl+diXx1JvLVmbJsVm4qTDptEVgcPHhQqlev7rUsPDxcqlSpYl4rTmPGjJHRo0fnWH7kyBE5ffp0sX6WU+gJl5ycbC4SDfbgDOSrM5GvzkS+OhP56kxZNis3paam2iOwGDFihLzwwgsFNoMqSSNHjpThw4d71VgkJCRItWrVTCdw5H6BaOd4PUZ2uEDgH/LVmchXZyJfnYl8daYsm5WboqKi7BFYPPLII9K/f/9816lXr57Ex8fL4cOHvZZnZGSYkaL0teIUGRlpHr404+2Q+cGiFwjHyHnIV2ciX52JfHUm8tWZQmxUbipMGoMaWGikpo+CtGvXzgwVu2bNGklMTDTLvv76axPxtW3btgRSCgAAACA/pT9MEpHGjRubYWMHDRokq1atkmXLlsnQoUPljjvuyB4Rat++fdKoUSPzupv2v1i3bp1s27bNPP/pp5/Mc63pAAAAAFDGAgs1bdo0EzhcffXVZpjZDh06mAnw3NLT02Xr1q1m7gq3SZMmSatWrUxAojp16mSez549Oyj7AAAAADiVLUaFUjoC1PTp0/N8vU6dOqZ3vadRo0aZBwAAAIDAsk2NBQAAAIDSi8ACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAZWeCPAAAbGtuf5HTSSK9PxVZOUbkl09Ejm8RCS8vUvNKkU4viFRpGOxUAoAl1FgAAFCS9n4j0vLPInd+J3LLfJGsdJH/dhdJP0U+ALA1aiwAAChJN8/1ft5zisgb1UUOrRGp1Ym8AGBb1FgAABBMZ5LP/RtVhXwAYGsEFgAABIsrS2TxMJGa7UWqXkY+ALA1mkIBABAoKb+IZKSKZBwTyUoVOb7W+/WVz4scXyPS/V3v18KjRWIakC8AbIXAAgCAQAUVcy71XjY3Med65UXk22tzLr/uZ4ILALZCUygAAAJBayqCuT0AlDACCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAACAQwqODuz0AlLDwkv5AAADKhJgGItf9LJKRWrSgQrcHABshsAAAIFAIDgCUITSFAgAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAACAZQQWAAAAACwjsAAAAABgGYEFAAAAEERdunSRYcOG5Vg+ZcoUiYuLy34+c+ZMadSokURFRUmzZs3kiy++kNKEwAIAAAAo5ZYvXy59+vSRgQMHyg8//CC9e/c2jw0bNkhpQWABAAAAlHL/+te/pGfPnvLXv/5VGjduLM8884xcfvnl8uqrr0ppQWABAAAAlHIrVqyQrl27ei3r0aOHWV5aEFgAAAAApdzBgwelRo0aXsv0uS4vLQgsAAAAgFLI5RIJiaoke46nSWhUtHlemhFYAAAAAEEUExMjycnJ2c+Tf0uXd5fulAnbYiW2/5vS8cVFEv/AVHlhY5RZrq+rQ4cOSXx8vJQW4cFOAAAAAFCWNWzYUL766ivz9zc/H5H7P1wjv53NFJcrQiTk9/WSM8LlmTmbZNxXW+WNuxJl/vz50q5dOyktqLEAAAAAguj++++Xn3/+We4YNloGvLfqXFChL4R4RBXmeahZrq/3f3el/HQkQ4YOHSqlBYEFAAAAEET16tWTLxcslpURzSUzM+tcUJEPfd3lcsmFtz4tCZc0lNKCwAIAAAAIsh2u6iJh5SQk1M/ieUiopGeJfLJ2r5QWBBYAAABAELlcLnl/+a4ibTtl2S6zfWlAYAEAAAAE0Ym0dPn1eFqBTaB86fq6XVLauVGigo3AAgAAAAiiU2cyLG1/0uL2xYXAAgAAAAiiipHWZoCoZHH74kJgAQAAAARR5QoRcnGVCp5TVvhF19ft4ipESGlAYAEAAAAEUUhIiNxzZZ0ibdu/fR2zfWlAYAEAAAAE2c2JtaR8ubAcc+LlJTREzPp/uryWlBa2CSyOHz8uffv2lZiYGImLi5OBAwfKyZMn813/wQcfNFOkly9fXmrXri0PPfSQJCcnl2i6AQAAgILElo+QN+5KNM2bCgou3K9PuivRbFda2Caw0KBi48aNMn/+fJkzZ44sWbJEBg8enOf6+/fvN49x48bJhg0bZMqUKTJ37lwTkAAAAAClTedLq8l7A9pI+YiwcwGGz+vuZfr6lAFtpNOl1aQ0CXGVlhk18rF582Zp0qSJrF69Wlq3bm2WaZBw7bXXyt69e6VmzZp+vc/MmTPlrrvuklOnTkl4uH+951NSUiQ2NtbUdGhtCXLKysqSw4cPS/Xq1SXU39kiUeqRr85EvjoT+epM5GvZzdfk39LNjNo6+Z3OU+GmHbW1T4U2m4qJKpmaisKUhUvH2FQFWLFihWn+5A4qVNeuXU1mrFy5Um666Sa/3sd9QPwNKgAAAICSFls+Qga0ryv9r6xjJr/TeSp0SFkd/am0dNTOjS1K2AcPHjRRnScNDqpUqWJe88fRo0flmWeeybf5lDpz5ox5eEZp7uhSH8hJj4tWfHF8nIV8dSby1ZnIV2ciX50pq5Dlptjy4eahdLuSbmxUmPJdUAOLESNGyAsvvFBgMyirNDjo1auXaU41atSofNcdM2aMjB49OsfyI0eOyOnTpy2nxYn0hNPaID3RaQrlHOSrM5GvzkS+OhP56kxZNis3paam2iOweOSRR6R///75rlOvXj2Jj483bdE8ZWRkmJGf9LWCDkbPnj0lOjpaZs2aJRER+bdHGzlypAwfPtwrKElISJBq1arRxyKfC0Sr5fQY2eECgX/IV2ciX52JfHUm8tWZsmxWboqKirJHYKEHVB8FadeunSQlJcmaNWskMTHRLPv6669NxrRt2zbP7TQo6NGjh0RGRsrs2bP9OjC6rj58acbbIfODRS8QjpHzkK/ORL46E/nqTOSrM4XYqNxUmDSW/r0RkcaNG5tah0GDBsmqVatk2bJlMnToULnjjjuyR4Tat2+fNGrUyLzuDiq6d+9uRoB65513zHPtj6GPzMzMIO8RAAAA4Cy26Lytpk2bZoKJq6++2kRON998s7zyyivZr6enp8vWrVslLe3ckFxr1641I0ap+vXre73Xzp07pU6dok2bDgAAAMDGgYWOADV9+vQ8X9dAwbOXfJcuXUq81zwAAABQVtmiKRQAAACA0o3AAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAFvQyW+HDRuWY/mUKVMkLi7O/D158mTp2LGjVK5c2Ty6du0qq1atCkJqgbKHwAIAADjG4sWLpU+fPrJo0SJZsWKFJCQkSPfu3WXfvn3BThrgeOHBTgAAAEBxmTZtmtfzt99+Wz7++GNZuHCh9OvXjwMNBBA1FgAAwLHS0tIkPT1dqlSpEuykAI5HYAEAABzr8ccfl5o1a5q+FgACi6ZQAADA1lziktCKobLv5D6pEF5B4iLjJCQkRMaOHSsfffSR6XcRFRUV7GQCjkdgAQAAbCEmJkaSk5Ozn6ecTZHZ22bL5KzJctHzF0nPj3ua5QnRCRJ/IF5m/WuWzP9qvjRv3jyIqQbKDgILAABgCw0bNpSvvvrK/L1s3zL5y+K/yOmM0+IKdXmttydlj+yuuFsueeESOXPhmSClFih76GMBAABs4f7775eff/5Z+j7RVx5Y8MC5oEJcIiE+K4aIaQp11nXWrPfZhs/k5MmTQUo1UHYQWAAAAFuoV6+ezF00V36q85NkZmWeCyryoa/reo8ve1yeH/98iaUTKKtoCgUAAGxjT8wekQitlPCtpshdSGiIhEeFS9NbmwY8bUBZR40FAACwBZfLJdO3TC/SttM2TzPbAwgcAgsAAGALSWeSZE/qngKbQPnS9XW75DO/jygFoPgRWAAAAFtIy0iztP2pjFPFlhYAORFYAAAAW9DJ76yoGF6x2NICICcCCwAAYAs6o7ZOfudvx203XV+3i42MDVjaABBYAAAAm9C5Ke5sdGeRtu3buK/ZHkDgUGMBAABs44b6N0hUeJTftRahEmrWv/6S6wOeNqCsI7AAAAC2EVMuRl7u8rKpfSgouDCvh4hM6DLBbAcgsAgsAACArbS/qL28fvXr2TUXvgGGe5m+/sbVb8iVF10ZtLQCZQkzbwMAAFsGFwtuXSCfbf/MTH6n81S41YquZfpU3HDJDRJdLjqo6QTKEgILAABgS9q8SQMI7dCtk9/pPBU6pKyO/kRHbaDkEVgAAABb0yAiLipO9D8AwUMfCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMAyAgsAAAAAlhFYAAAAALCMwAIAAMCO5vYX+bR3zuUrx4r8M0Rk0bBgpAplGIEFAACAUxxcLfLjmyLVmgc7JSiDCCwAAACc4OxJkS/6inSfLBJZOdipQRlEYAEAAOAEC/8sUreXyMVdg50SlFEEFgAAOL3t/Q+viUyuIzIhSmRaW5EDq4KZOgTClo9EDq8V6TiG44ugCQ/eRwMAgIDbMkPkm+EiXSeJXNhWZM0EkY97iNy7VaRCdTLAjlJ+EclIFck4JpKVKrLnC5FvHhDp+oZIyqZz67hSRdIPixxf+/t24dEiMQ2Clmw4H4EFAABOtma8SLNBIpcNOPe82ySRnZ+L/PSuSNsRwU4dihJUzLnUe9m334hE62hQd3gvP7pWZO6/vZdd9zPBBQKGplAAADhV5lmRQ2tEanu0uQ8JPff8wIpgpgxFpTUVwdweyAeBBQAATvXbURFXpkjFGt7LK9QQOXUwWKkC4FA0hQIAwClSfxHJPPV72/ukn8790qduFTke+ft6Zw+JyKnf29/T9h5AMSCwAADAAcLSdkjo1+29Fy75RqSa9rM437/CU4iOHpX4+3Pa3gOwiKZQAAA4QEjmSWtvQNt7ABYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAlJ3A4vjx49K3b1+JiYmRuLg4GThwoJw8mf/QekOGDJFLLrlEypcvL9WqVZMbb7xRtmzZUmJpBgAAAMoK2wQWGlRs3LhR5s+fL3PmzJElS5bI4MGD890mMTFR3nvvPdm8ebPMmzdPXC6XdO/eXTIzM0ss3QAAAEBZYIuZtzUwmDt3rqxevVpat25tlk2cOFGuvfZaGTdunNSsWTPX7TwDjzp16sizzz4rLVq0kF27dpmaDAAAAFsJjw7u9oDdA4sVK1aY5k/uoEJ17dpVQkNDZeXKlXLTTTcV+B6nTp0ytRd169aVhISEPNc7c+aMebilpKSYf7OysswDOelx0dogjo+zkK/ORL46O1+tvofwO1f6r9dKl4j02iKSnlr4N4yIPrc9+RxUWTYrNxUmnbYILA4ePCjVq1f3WhYeHi5VqlQxr+Xn9ddfl8cee8wEFg0bNjRNqcqVK5fn+mPGjJHRo0fnWH7kyBE5ffq0hb1wLj3hkpOTzUWiwR6cgXx1JvLVufl6JvWkVLPwHsdPHJeMjMPFmCoE7nqNPf8opAwR+Y08DrYsm5WbUlNT7RFYjBgxQl544YUCm0FZ7ZvRrVs3OXDggGk2ddttt8myZcskKioq1/VHjhwpw4cP96qx0BoO7fytHceR+wUSEhJijpEdLhD4h3x1JvLVufl64mQlS+9RpXIVkSreN/EQXFyvzpRls3JTXmXmUhdYPPLII9K/f/9816lXr57Ex8fL4cPeEXZGRoYZKUpfy09sbKx5NGjQQP7whz9I5cqVZdasWdKnT59c14+MjDQPX5rxdsj8YNELhGPkPOSrM5GvDmWx7XxouVj9sSu25KB4cL06U4iNyk2FSWNQAwuN1PRRkHbt2klSUpKsWbPGjPSkvv76axPxtW3b1u/P0yonfXj2oQAAwAkyK9STrF5bJDTzVNGCkpgGgUgWgDLEFn0sGjduLD179pRBgwbJpEmTJD09XYYOHSp33HFH9ohQ+/btk6uvvlqmTp0qbdq0kR07dsiMGTPM8LIavOzdu1fGjh1r5rTQ0aQAAHCc6AbUOgAImtJf/3LetGnTpFGjRiZ40MCgQ4cO8tZbb2W/rsHG1q1bJS0tLbs92LfffmvWrV+/vtx+++0SHR0ty5cvz9ERHAAAAEAZqLFQOgLU9OnT83xd56nwHGpPazK++OKLEkodAAAAULbZpsYCAAAAQOlFYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQAAAADLCCwAAAAAWEZgAQAAAMCycOtv4Wwul8v8m5KSEuyklFpZWVmSmpoqUVFREhpKrOoU5Kszka/ORL46E/nqTFk2Kze5y8DuMnF+CCwKoBmvEhISiiNvAAAAAFuWiWNjY/NdJ8TlT/hRxqPK/fv3S3R0tISEhAQ7OaU2ktXAa8+ePRITExPs5KCYkK/ORL46E/nqTOSrM6XYrNykoYIGFTVr1iywhoUaiwLoAaxVq1Zx5o9j6cVhhwsEhUO+OhP56kzkqzORr84UY6NyU0E1FW6lv2EXAAAAgFKPwAIAAACAZQQWsCwyMlKefvpp8y+cg3x1JvLVmchXZyJfnSnSweUmOm8DAAAAsIwaCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYokuPHj0vfvn3N+MtxcXEycOBAOXnyZL7rP/jgg9KwYUMpX7681K5dWx566CFJTk4mB2ycr+qtt96SLl26mG10EsmkpKQSSy9y99prr0mdOnUkKipK2rZtK6tWrcr3UM2cOVMaNWpk1m/WrJl88cUXHFqb5+vGjRvl5ptvNuvrdTlhwoQSTSsCk6+TJ0+Wjh07SuXKlc2ja9euBV7fKP35+sknn0jr1q3N727FihWlZcuW8sEHH4gdEVigSLTwqT9c8+fPlzlz5siSJUtk8ODBea6vs5frY9y4cbJhwwaZMmWKzJ071xRcYd98VWlpadKzZ0/529/+VmLpRN5mzJghw4cPNyOOrF27Vlq0aCE9evSQw4cP57r+8uXLpU+fPuZa/OGHH6R3797modcp7Juvel3Wq1dPxo4dK/Hx8SWeXgQmXxcvXmyu10WLFsmKFSvM7M3du3eXffv2cchtnK9VqlSRv//97yZPf/zxRxkwYIB5zJs3T2zHBRTSpk2bXHrqrF69OnvZl19+6QoJCXHt27fP7/f5z3/+4ypXrpwrPT2dPHBAvi5atMhsf+LEiQCnFPlp06aN689//nP288zMTFfNmjVdY8aMyXX92267zdWrVy+vZW3btnUNGTKEA23jfPV08cUXu15++eUApxAlna8qIyPDFR0d7Xr//ffJAAflq2rVqpXriSeecNkNNRYoNI2otbpOq+3ctDo2NDRUVq5c6ff7aDMobT4THh5OLjgoXxE8Z8+elTVr1ph8c9P80+eav7nR5Z7rK72zltf6sEe+omzkq9ZMpaenmzvecEa+ulwuWbhwoWzdulU6deokdkNggUI7ePCgVK9e3WuZBgf6xaav+ePo0aPyzDPPFNjMBvbKVwSXXleZmZlSo0YNr+X6PK881OWFWR/2yFeUjXx9/PHHpWbNmjluDsB++ZqcnCyVKlWScuXKSa9evWTixInSrVs3sRsCC2QbMWKE6eSX32PLli2Wj1hKSoq5aJo0aSKjRo0iBxySrwCAkqP9Zz766COZNWuW6SAMe4uOjpZ169bJ6tWr5bnnnjN9NLRPjd3QBgXZHnnkEenfv3++R0Q7A2pHQN8OSBkZGWZEoYI6CaamppqOvnoB6ZdhREQEOeCAfEXpULVqVQkLC5NDhw55LdfneeWhLi/M+rBHvsLZ+aoDoWhgsWDBAmnevHmAU4qSyNfQ0FCpX7+++VtHhdq8ebOMGTPGjLpoJ9RYIFu1atXMkJP5PbSKrl27dmZIUW1D6Pb1119LVlaWGVItv5oKHb1C32P27NncYXFIvqL00HxMTEw07XPdNP/0ueZvbnS55/pKRwXLa33YI1/h3Hx98cUXTVNiHVnRs08cnHW9ZmVlyZkzZ8R2gt17HPbUs2dPM2LBypUrXUuXLnU1aNDA1adPn+zX9+7d62rYsKF5XSUnJ5uRZpo1a+batm2b68CBA9kPHdUC9sxXpXn4ww8/uCZPnmxGhVqyZIl5fuzYsSDtRdn20UcfuSIjI11TpkwxI30NHjzYFRcX5zp48KB5/e6773aNGDEie/1ly5a5wsPDXePGjXNt3rzZ9fTTT7siIiJcP/30UxD3Albz9cyZM+Y61MeFF17oevTRR83fv/zyCwfXxvk6duxYM5rif//7X6/f0dTU1CDuBazm6/PPP+/66quvXNu3bzfr6/exfi/r76rdEFigSLTQqAXOSpUquWJiYlwDBgzw+mLbuXOnKWTqEKSeQ5Hm9tB1Yc98VVoQzS1f33vvvSDtBSZOnOiqXbu2KYDosIffffdd9kHp3Lmz65577skx9POll15q1m/atKnr888/5yDaPF/d16rvQ9eDffNVhw7OLV/1exj2zde///3vrvr167uioqJclStXdrVr184EJ3YUov8Ldq0JAAAAAHujjwUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgGUEFgAAAAAsI7AAAAAAYBmBBQCg1KtTp45MmDAh2MkAAOSDwAIAUGxCQkLyfYwaNapI77t69WoZPHiw1+d8+umnBW733HPPyZVXXikVKlSQuLi4In02AMA/4X6uBwBAgQ4cOJD994wZM+Spp56SrVu3Zi+rVKlS9t8ul0syMzMlPLzgn6Jq1aoV6eifPXtWbr31VmnXrp288847RXoPAIB/qLEAABSb+Pj47EdsbKypWXA/37Jli0RHR8uXX34piYmJEhkZKUuXLpXt27fLjTfeKDVq1DCBxxVXXCELFizIsymU/q1uuukm8/7u57kZPXq0/OUvf5FmzZqRywAQYAQWAIASNWLECBk7dqxs3rxZmjdvLidPnpRrr71WFi5cKD/88IP07NlTrr/+etm9e3eezaLUe++9Z2pI3M8BAMFFUygAQIn6xz/+Id26dct+XqVKFWnRokX282eeeUZmzZols2fPlqFDh+bZLEr7TGhNCACgdKDGAgBQolq3bu31XGssHn30UWncuLEJFrQ5lNZm5FVjAQAonaixAACUqIoVK3o916Bi/vz5Mm7cOKlfv76UL19ebrnlFtPxGgBgHwQWAICgWrZsmfTv3990xnbXYOzatSvfbSIiIsyIUgCA0oOmUACAoGrQoIF88sknsm7dOlm/fr3ceeedkpWVle82OhKUdvY+ePCgnDhxIs/1tDmVvq/+q4GI/q0PDV4AAMWLwAIAEFTjx4+XypUrm4nsdDSoHj16yOWXX57vNv/85z9N86mEhARp1apVnuvpPBr6+tNPP22CCf1bH99//30A9gQAyrYQl85QBAAAAAAWUGMBAAAAwDICCwAAAACWEVgAAAAAsIzAAgAAAIBlBBYAAAAALCOwAAAAAGAZgQUAAAAAywgsAAAAAFhGYAEAAADAMgILAAAAAJYRWAAAAACwjMACAAAAgFj1/1wnCuSTBa5hAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 800x600 with 1 Axes>"
       ]
@@ -773,14 +854,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "1a7ade26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:53:58.201108Z",
-     "iopub.status.busy": "2026-08-26T10:53:58.201108Z",
-     "iopub.status.idle": "2026-08-26T10:53:58.206268Z",
-     "shell.execute_reply": "2026-08-26T10:53:58.206268Z"
+     "iopub.execute_input": "2026-08-29T01:35:38.692300Z",
+     "iopub.status.busy": "2026-08-29T01:35:38.691787Z",
+     "iopub.status.idle": "2026-08-29T01:35:38.698494Z",
+     "shell.execute_reply": "2026-08-29T01:35:38.697429Z"
     },
     "papermill": {
      "duration": 0.02554,
@@ -845,14 +926,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "909ef32d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:53:58.282779Z",
-     "iopub.status.busy": "2026-08-26T10:53:58.281846Z",
-     "iopub.status.idle": "2026-08-26T10:53:58.302853Z",
-     "shell.execute_reply": "2026-08-26T10:53:58.302853Z"
+     "iopub.execute_input": "2026-08-29T01:35:38.701301Z",
+     "iopub.status.busy": "2026-08-29T01:35:38.700719Z",
+     "iopub.status.idle": "2026-08-29T01:35:38.738932Z",
+     "shell.execute_reply": "2026-08-29T01:35:38.737893Z"
     },
     "papermill": {
      "duration": 0.041901,
@@ -908,16 +989,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du résultat : divergences 163 → 1, l'amélioration spectaculaire\n",
-    "\n",
-    "Le modèle corrigé (avec biais user/item) ne produit plus que **1 divergence** (mesurée à la re-exécution) (vs 163 précédemment) — une réduction d'un facteur >160. Trois leviers expliquent cette convergence :\n",
-    "- **Biais additifs** : capturer les tendances systématiques soulage les traits latents (ils n'ont plus à tout expliquer).\n",
-    "- **Plus de données** : 25 observations (ratio 1.2×) mieux conditionnent le postérieur.\n",
-    "- **Reparamétrisation** : l'ajout de structure réduit les corrélations pathologiques entre paramètres.\n",
-    "\n",
-    "C'est la leçon pratique du diagnostic MCMC : les divergences ne sont pas une fatalité, elles **orientent** l'amélioration du modèle. Le warning « reparameterize » du modèle naïf pointait exactement vers cette correction. Le diagnostic chiffré (r_hat 1.020, ess 139) est lu dans la cellule de lecture dédiée qui suit l'inference."
-   ]
+   "source": "### Lecture du résultat : divergences 163 → 5, l'amélioration spectaculaire\n\nLe modèle corrigé (avec biais user/item) ne produit plus que **5 divergences** (vs 163 précédemment) — une réduction d'un facteur ~33. Trois leviers expliquent cette amélioration :\n- **Biais additifs** : capturer les tendances systématiques soulage les traits latents (ils n'ont plus à tout expliquer).\n- **Plus de données** : 25 observations (ratio 1.2×) mieux conditionnent le postérieur.\n- **Reparamétrisation** : l'ajout de structure réduit les corrélations pathologiques entre paramètres.\n\nC'est la leçon pratique du diagnostic MCMC : les divergences ne sont pas une fatalité, elles **orientent** l'amélioration du modèle. Le warning « reparameterize » du modèle naïf pointait exactement vers cette correction. Le rapport strict chiffré (5 divergences, pire `r_hat` 1.020, `ess_tail` min 484) est lu dans la cellule de lecture dédiée qui suit l'inference."
   },
   {
    "cell_type": "markdown",
@@ -940,14 +1012,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "edb046fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:53:58.422927Z",
-     "iopub.status.busy": "2026-08-26T10:53:58.421288Z",
-     "iopub.status.idle": "2026-08-26T10:54:13.273482Z",
-     "shell.execute_reply": "2026-08-26T10:54:13.273482Z"
+     "iopub.execute_input": "2026-08-29T01:35:38.742148Z",
+     "iopub.status.busy": "2026-08-29T01:35:38.741632Z",
+     "iopub.status.idle": "2026-08-29T01:36:17.754152Z",
+     "shell.execute_reply": "2026-08-29T01:36:17.753141Z"
     },
     "papermill": {
      "duration": 14.873004,
@@ -983,7 +1055,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5e3c170f5edb48eba68a3c7cd733f828",
+       "model_id": "89859869c4e54a14a452214870f9e028",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1008,14 +1080,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_500 tune and 1_000 draw iterations (3_000 + 2_000 draws total) took 14 seconds.\n"
+      "Sampling 2 chains for 1_500 tune and 1_000 draw iterations (3_000 + 2_000 draws total) took 17 seconds.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "There was 1 divergence after tuning. Increase `target_accept` or reparameterize.\n"
+      "There were 5 divergences after tuning. Increase `target_accept` or reparameterize.\n"
      ]
     },
     {
@@ -1043,7 +1115,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Diagnostic MCMC (modele corrige) : divergences=1 ; pire r_hat=1.020 (sur U2[4, 0]) ; ess_bulk min=139\n",
+      "Rapport strict (modele corrige (biais user/item)) : 1/4 criteres tenus\n",
+      "  [FAIL] divergences = 0  -> 5 divergences\n",
+      "  [FAIL] r_hat < 1.01     -> max r_hat = 1.020 (sur U2[0, 1])\n",
+      "  [FAIL] ess_bulk > 400   -> min ess_bulk = 162 (sur V2[4, 1])\n",
+      "  [PASS] ess_tail > 400   -> min ess_tail = 484 (sur V2[3, 1])\n",
       "Inference terminee.\n"
      ]
     }
@@ -1055,11 +1131,7 @@
     "                          random_seed=42, cores=1,\n",
     "                          return_inferencedata=True)\n",
     "\n",
-    "# Lecture de diagnostic (honnete) : quantifier le warning rhat/ESS (voir PyMC-6-Debugging)\n",
-    "diag_mf2 = az.summary(trace_mf2, kind=\"diagnostics\")\n",
-    "wv_mf2 = diag_mf2[\"r_hat\"].idxmax()\n",
-    "div_mf2 = int(trace_mf2.sample_stats[\"diverging\"].sum())\n",
-    "print(f\"Diagnostic MCMC (modele corrige) : divergences={div_mf2} ; pire r_hat={diag_mf2['r_hat'].max():.3f} (sur {wv_mf2}) ; ess_bulk min={int(diag_mf2['ess_bulk'].min())}\")\n",
+    "rapport_diagnostic_strict(trace_mf2, \"modele corrige (biais user/item)\")\n",
     "\n",
     "print(\"Inference terminee.\")"
    ]
@@ -1077,11 +1149,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du diagnostic : modèle corrigé — convergence saine\n",
-    "\n",
-    "Le `az.summary(kind=\"diagnostics\")` fraîchement lu confirme la correction du modèle naïf (163 divergences) par l'ajout des biais additifs : **1 divergence**, `r_hat` max **1.020** (sur `U2[4,0]`), `ess_bulk` min **139** (> 100). Le modèle corrigé converge correctement — un `r_hat` marginalement > 1.01 sur un unique paramètre latent sans divergence ni ess sous le seuil est **interprétable**. C'est la leçon de diagnostic MCMC : la **reparamétrisation** (biais user/item) a résorbé les 163 divergences, ici au prix d'un déplacement des priors (`sigma2=0.5`) et de 25 observations. Voir [PyMC-6-Debugging](PyMC-6-Debugging.ipynb)."
-   ]
+   "source": "### Lecture du diagnostic : modèle corrigé — 1/4 au rapport strict, ess_tail tenu\n\nLe rapport strict fraîchement lu affiche **1/4** : **5 divergences** (vs 163 au modèle naïf, divisées par ~33), `r_hat` max **1.020** (sur `U2[0,1]`), `ess_bulk` min **162** (sur `V2[4,1]`) — deux critères encore rouges — mais `ess_tail` min **484** (sur `V2[3,1]`) **passe** le seuil strict de 400 : c'est le seul critère strict tenu de tout le notebook. Le modèle corrigé est **largement amélioré sans être encore au niveau strict** : la reparamétrisation (biais user/item, `sigma2=0.5`, 25 observations) a résorbé l'essentiel des divergences, mais l'échantillonnage effectif reste insuffisant pour la moyenne des paramètres latents (`ess_bulk` 162 < 400). Voir [PyMC-6-Debugging](PyMC-6-Debugging.ipynb)."
   },
   {
    "cell_type": "markdown",
@@ -1104,14 +1172,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "e04691b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:13.427354Z",
-     "iopub.status.busy": "2026-08-26T10:54:13.427354Z",
-     "iopub.status.idle": "2026-08-26T10:54:13.433876Z",
-     "shell.execute_reply": "2026-08-26T10:54:13.433876Z"
+     "iopub.execute_input": "2026-08-29T01:36:17.983283Z",
+     "iopub.status.busy": "2026-08-29T01:36:17.983283Z",
+     "iopub.status.idle": "2026-08-29T01:36:17.991068Z",
+     "shell.execute_reply": "2026-08-29T01:36:17.991068Z"
     },
     "papermill": {
      "duration": 0.073425,
@@ -1129,14 +1197,14 @@
      "text": [
       "=== Predictions Corrigees ===\n",
       "        Item   0 Item   1 Item   2 Item   3 Item   4 \n",
-      "User  0   1.01*  1.09*  0.87*  1.02*  1.23* \n",
-      "User  1   1.21*  1.29*  1.07*  1.22*  1.43* \n",
-      "User  2   1.07*  1.15*  0.93*  1.08*  1.29* \n",
-      "User  3   1.04*  1.13*  0.91*  1.06*  1.27* \n",
-      "User  4   0.96*  1.04*  0.83*  0.98*  1.19* \n",
+      "User  0   1.04*  1.18*  0.97*  1.01*  1.23* \n",
+      "User  1   1.22*  1.36*  1.14*  1.18*  1.41* \n",
+      "User  2   1.08*  1.22*  1.04*  1.08*  1.30* \n",
+      "User  3   1.03*  1.17*  0.99*  1.03*  1.25* \n",
+      "User  4   0.96*  1.09*  0.90*  0.95*  1.16* \n",
       "(* = observation, autres = prediction)\n",
       "\n",
-      "RMSE sur les observations : 2.480\n"
+      "RMSE sur les observations : 2.457\n"
      ]
     }
    ],
@@ -1201,14 +1269,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "cb2a9932",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:13.551091Z",
-     "iopub.status.busy": "2026-08-26T10:54:13.551091Z",
-     "iopub.status.idle": "2026-08-26T10:54:13.558128Z",
-     "shell.execute_reply": "2026-08-26T10:54:13.557607Z"
+     "iopub.execute_input": "2026-08-29T01:36:17.993120Z",
+     "iopub.status.busy": "2026-08-29T01:36:17.993120Z",
+     "iopub.status.idle": "2026-08-29T01:36:17.999906Z",
+     "shell.execute_reply": "2026-08-29T01:36:17.999265Z"
     },
     "papermill": {
      "duration": 0.031691,
@@ -1269,15 +1337,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6b1f56ac",
+   "source": "### Baselines OOS : le plancher a battre\n\nAvant le modele bayesien, deux baselines deterministes fixent la reference : la **moyenne globale** (GM) et la descente de coordonnees **UIBI** (biais utilisateur/item a somme nulle, meme algorithme que le jumeau C#). Leur `rmse_test` autour de 1.9-2.0 montre ce que predit un modele sans structure latente sur le masque : c'est le plancher que NUTS doit battre.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "45151e2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:13.602925Z",
-     "iopub.status.busy": "2026-08-26T10:54:13.602925Z",
-     "iopub.status.idle": "2026-08-26T10:54:13.612943Z",
-     "shell.execute_reply": "2026-08-26T10:54:13.612436Z"
+     "iopub.execute_input": "2026-08-29T01:36:18.001489Z",
+     "iopub.status.busy": "2026-08-29T01:36:17.999906Z",
+     "iopub.status.idle": "2026-08-29T01:36:18.014097Z",
+     "shell.execute_reply": "2026-08-29T01:36:18.013071Z"
     },
     "papermill": {
      "duration": 0.032608,
@@ -1327,15 +1401,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "06a17d05",
+   "source": "### Modele bayesien miroir des deux jumeaux\n\nLe modele NUTS reprend exactement la structure `note ~ g + bU[u] + bI[i] + U[u].V[i]` (rang latent 1) : biais additifs plus un facteur latent par paire. **Quatre chaines** avec `target_accept=0.9` — sur un posteriori multi-modal, multiplier les chaines augmente la probabilite d'explorer le mode a facteur actif (verifie sur le jumeau Infer/EP).",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "2d570db7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:13.655943Z",
-     "iopub.status.busy": "2026-08-26T10:54:13.654690Z",
-     "iopub.status.idle": "2026-08-26T10:54:46.566507Z",
-     "shell.execute_reply": "2026-08-26T10:54:46.566507Z"
+     "iopub.execute_input": "2026-08-29T01:36:18.016099Z",
+     "iopub.status.busy": "2026-08-29T01:36:18.016099Z",
+     "iopub.status.idle": "2026-08-29T01:37:25.997109Z",
+     "shell.execute_reply": "2026-08-29T01:37:25.996103Z"
     },
     "papermill": {
      "duration": 32.932834,
@@ -1372,14 +1452,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 1_000 draw iterations (4_000 + 4_000 draws total) took 32 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 1_000 draw iterations (4_000 + 4_000 draws total) took 44 seconds.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "There were 36 divergences after tuning. Increase `target_accept` or reparameterize.\n"
+      "There were 2 divergences after tuning. Increase `target_accept` or reparameterize.\n"
      ]
     },
     {
@@ -1401,7 +1481,11 @@
      "output_type": "stream",
      "text": [
       "NUTS : 1000 tirages x 4 chaines (4 chaines : robustesse vs multi-modalite)\n",
-      "Divergences : 36\n"
+      "Rapport strict (OOS miroir (4 chaines, target_accept=0.9)) : 0/4 criteres tenus\n",
+      "  [FAIL] divergences = 0  -> 2 divergences\n",
+      "  [FAIL] r_hat < 1.01     -> max r_hat = 1.530 (sur oos_U[0, 0])\n",
+      "  [FAIL] ess_bulk > 400   -> min ess_bulk = 7 (sur oos_U[0, 0])\n",
+      "  [FAIL] ess_tail > 400   -> min ess_tail = 27 (sur oos_U[2, 0])\n"
      ]
     }
    ],
@@ -1422,21 +1506,25 @@
     "                          target_accept=0.9, progressbar=False)\n",
     "print(f\"NUTS : {len(oos_trace.posterior.draw)} tirages x {len(oos_trace.posterior.chain)} chaines (4 chaines : robustesse vs multi-modalite)\")\n",
     "\n",
-    "divs = int(oos_trace.sample_stats[\"diverging\"].sum().item())\n",
-    "print(f\"Divergences : {divs}\")\n",
-    "\n"
+    "rapport_diagnostic_strict(oos_trace, \"OOS miroir (4 chaines, target_accept=0.9)\")\n"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "5beab0ec",
+   "source": "### Metriques OOS : erreur, classement, cold-start\n\nTrois lectures du masque : **rmse/mae test** (generalisation numerique), **precision pairwise** (l'item aime du test doit etre score au-dessus de chaque item non-aime — la metrique metier d'une recommandation), et le bras **cold-start** compare a la popularite d'entrainement. Le score evalue est le **score predictif bayesien** (moyenne des predictions tirage par tirage), pas `E[U].E[V]` qui ecraserait le facteur multi-modal.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "88f2a335",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:46.611885Z",
-     "iopub.status.busy": "2026-08-26T10:54:46.610883Z",
-     "iopub.status.idle": "2026-08-26T10:54:46.622920Z",
-     "shell.execute_reply": "2026-08-26T10:54:46.622400Z"
+     "iopub.execute_input": "2026-08-29T01:37:25.998111Z",
+     "iopub.status.busy": "2026-08-29T01:37:25.998111Z",
+     "iopub.status.idle": "2026-08-29T01:37:26.013455Z",
+     "shell.execute_reply": "2026-08-29T01:37:26.012573Z"
     },
     "papermill": {
      "duration": 0.036341,
@@ -1452,11 +1540,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MODEL : rmse_train=0.130  rmse_test=1.106  mae_test=0.967\n",
+      "MODEL : rmse_train=0.131  rmse_test=1.097  mae_test=0.969\n",
       "pairwise aime>non-aime : model=1.000  uibi=0.469  (hasard=0.500, n=32)\n",
-      "cold-start (pred = g + bI, U=0) : [3.107 2.783 3.224 3.089 2.524 3.362 2.898 3.369]\n",
+      "cold-start (pred = g + bI, U=0) : [3.104 2.798 3.193 3.119 2.513 3.342 2.889 3.355]\n",
       "popularite train               : [3.45  3.625 3.7   3.9   3.125 3.7   3.625 3.725]\n",
-      "corr(pred_cold, popularite)   = 0.696\n"
+      "corr(pred_cold, popularite)   = 0.726\n"
      ]
     }
    ],
@@ -1515,24 +1603,7 @@
     "tags": []
    },
    "outputs": [],
-   "source": [
-    "### Interpretation : NUTS apprend la structure, une fois le score evalue correctement\n",
-    "\n",
-    "| Metrique | GM | UIBI | Modele NUTS |\n",
-    "|----------|----|------|-------------|\n",
-    "| RMSE train | 0.985 | 0.938 | 0.130 |\n",
-    "| RMSE test | 1.947 | 2.012 | **1.106** |\n",
-    "| MAE test | 1.72 | 1.80 | **0.967** |\n",
-    "| Pairwise aime>non-aime | — | 0.469 | **1.000** |\n",
-    "\n",
-    "**Le pseudo-effondrement etait une illusion d'evaluation.** Sur ces 32 notes eparses, le posteriori du couple latent `(U, V)` est **multi-modal** : le produit `U[u].V[i]` porte du signal, mais chaque mode a une orientation isolee, et calculer `E[U].E[V]` moyen **annule le produit** (des modes opposes s'effacent) — on retombe alors sur un modele sans facteur (RMSE test ~1.9, pairwise = hasard). La bonne quantite bayesienne est le **score predictif** : la moyenne, sur les tirages posteriori, de `g + bU[u] + bI[i] + U[u].V[i]`. Avec lui, NUTS apprend la structure de facon robuste (reproductible sur plusieurs graines). Le protocole OOS sert ici exactement a cela : demasquer une evaluation naive.\n",
-    "\n",
-    "**Grain d'honnetete** : NUTS signale ~1% de divergences apres warm-up et un `rhat` > 1.01 sur quelques parametres — le modele est peu identifiable sur ce jeu epars, on le documente au lieu de le maquiller. L'ecart train (0.130) / test (1.106) reste raisonnable : le modele a appris la structure du train sans *gouffre* de sur-apprentissage.\n",
-    "\n",
-    "**Cold-start documente separement** : pour un nouvel utilisateur sans aucune note, la prediction retombe a `g + bI` (aucun rang latent appris pour lui) et corelle a 0.70 avec la popularite d'entrainement — c'est un **fallback**, pas une recommendation apprise. On ne le presente pas comme un apprentissage (cf. consigne OOS).\n",
-    "\n",
-    "**Asymetrie moteurs** : le jumeau C# Infer.NET (meme modele, meme grille) obtient, lui, avec l'inference EP variationnelle : RMSE test 1.989 (= la moyenne globale) et precision pairwise 0.500 (hasard), car EP ecrase les facteurs latents sur ce corpus sparse (la latente y est vraiment a 0 — c'est EP qui echoue, pas l'evaluation). Le contraste est le point pedagogique du `bridge_verdict` : MCMC (PyMC) explore la structure de la posteriori que l'approximation variationnelle locale (EP) aplatit."
-   ]
+   "source": "### Interpretation : NUTS apprend la structure, une fois le score evalue correctement\n\n| Metrique | GM | UIBI | Modele NUTS |\n|----------|----|------|-------------|\n| RMSE train | 0.985 | 0.938 | 0.131 |\n| RMSE test | 1.947 | 2.012 | **1.097** |\n| MAE test | 1.72 | 1.80 | **0.969** |\n| Pairwise aime>non-aime | — | 0.469 | **1.000** |\n\n**Le pseudo-effondrement etait une illusion d'evaluation.** Sur ces 32 notes eparses, le posteriori du couple latent `(U, V)` est **multi-modal** : le produit `U[u].V[i]` porte du signal, mais chaque mode a une orientation isolee, et calculer `E[U].E[V]` moyen **annule le produit** (des modes opposes s'effacent) — on retombe alors sur un modele sans facteur (RMSE test ~1.9, pairwise = hasard). La bonne quantite bayesienne est le **score predictif** : la moyenne, sur les tirages posteriori, de `g + bU[u] + bI[i] + U[u].V[i]`. Avec lui, NUTS apprend la structure de facon robuste (reproductible sur plusieurs graines). Le protocole OOS sert ici exactement a cela : demasquer une evaluation naive.\n\n**Grain d'honnetete (0/4 au rapport strict)** : le rapport ci-dessus affiche **2 divergences** (0,05 % des 4 000 tirages), un `r_hat` max **1.530** (sur `oos_U[0,0]`) et un `ess_bulk` min **7** — les 4 chaines ne s'accordent pas sur le mode du facteur latent (posteriori multi-modal), on le documente au lieu de le maquiller. L'ecart train (0.131) / test (1.097) reste raisonnable : le modele a appris la structure du train sans *gouffre* de sur-apprentissage.\n\n**Cold-start documente separement** : pour un nouvel utilisateur sans aucune note, la prediction retombe a `g + bI` (aucun rang latent appris pour lui) et corelle a 0.726 avec la popularite d'entrainement — c'est un **fallback**, pas une recommendation apprise. On ne le presente pas comme un apprentissage (cf. consigne OOS).\n\n**Asymetrie moteurs** : le jumeau C# Infer.NET (meme modele, meme grille) obtient, lui, avec l'inference EP variationnelle : RMSE test 1.989 (= la moyenne globale) et precision pairwise 0.500 (hasard), car EP ecrase les facteurs latents sur ce corpus sparse (la latente y est vraiment a 0 — c'est EP qui echoue, pas l'evaluation). Le contraste est le point pedagogique du `bridge_verdict` : MCMC (PyMC) explore la structure de la posteriori que l'approximation variationnelle locale (EP) aplatit."
   },
   {
    "cell_type": "markdown",
@@ -1566,14 +1637,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "2f65797c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:46.763278Z",
-     "iopub.status.busy": "2026-08-26T10:54:46.762743Z",
-     "iopub.status.idle": "2026-08-26T10:54:46.766448Z",
-     "shell.execute_reply": "2026-08-26T10:54:46.765920Z"
+     "iopub.execute_input": "2026-08-29T01:37:26.015479Z",
+     "iopub.status.busy": "2026-08-29T01:37:26.015479Z",
+     "iopub.status.idle": "2026-08-29T01:37:26.020245Z",
+     "shell.execute_reply": "2026-08-29T01:37:26.019731Z"
     },
     "papermill": {
      "duration": 0.030574,
@@ -1656,14 +1727,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "a3f65092",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:46.900777Z",
-     "iopub.status.busy": "2026-08-26T10:54:46.900777Z",
-     "iopub.status.idle": "2026-08-26T10:54:46.904844Z",
-     "shell.execute_reply": "2026-08-26T10:54:46.904313Z"
+     "iopub.execute_input": "2026-08-29T01:37:26.022255Z",
+     "iopub.status.busy": "2026-08-29T01:37:26.022255Z",
+     "iopub.status.idle": "2026-08-29T01:37:26.026756Z",
+     "shell.execute_reply": "2026-08-29T01:37:26.026756Z"
     },
     "papermill": {
      "duration": 0.028102,
@@ -1733,14 +1804,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "dcd879f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:47.000494Z",
-     "iopub.status.busy": "2026-08-26T10:54:46.999483Z",
-     "iopub.status.idle": "2026-08-26T10:54:47.021845Z",
-     "shell.execute_reply": "2026-08-26T10:54:47.021328Z"
+     "iopub.execute_input": "2026-08-29T01:37:26.029765Z",
+     "iopub.status.busy": "2026-08-29T01:37:26.028764Z",
+     "iopub.status.idle": "2026-08-29T01:37:26.066199Z",
+     "shell.execute_reply": "2026-08-29T01:37:26.064652Z"
     },
     "papermill": {
      "duration": 0.044098,
@@ -1807,14 +1878,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "65d3746c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:47.115884Z",
-     "iopub.status.busy": "2026-08-26T10:54:47.115376Z",
-     "iopub.status.idle": "2026-08-26T10:54:52.403999Z",
-     "shell.execute_reply": "2026-08-26T10:54:52.403490Z"
+     "iopub.execute_input": "2026-08-29T01:37:26.070213Z",
+     "iopub.status.busy": "2026-08-29T01:37:26.069230Z",
+     "iopub.status.idle": "2026-08-29T01:37:39.257061Z",
+     "shell.execute_reply": "2026-08-29T01:37:39.256465Z"
     },
     "papermill": {
      "duration": 5.312956,
@@ -1850,7 +1921,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "739a6baa6c0648d48569c7d14c4b6354",
+       "model_id": "251c38fcb411459fa2776ce32207063f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1875,14 +1946,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 4 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 5 seconds.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "There were 130 divergences after tuning. Increase `target_accept` or reparameterize.\n"
+      "There were 61 divergences after tuning. Increase `target_accept` or reparameterize.\n"
      ]
     },
     {
@@ -1900,21 +1971,18 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Diagnostic MCMC (cold-start) : divergences=130 ; pire r_hat=1.040 (sur V_cs[2, 0]) ; ess_bulk min=37\n",
+      "Rapport strict (cold-start hybride) : 0/4 criteres tenus\n",
+      "  [FAIL] divergences = 0  -> 61 divergences\n",
+      "  [FAIL] r_hat < 1.01     -> max r_hat = 1.020 (sur V_cs[0, 1])\n",
+      "  [FAIL] ess_bulk > 400   -> min ess_bulk = 246 (sur V_cs[4, 0])\n",
+      "  [FAIL] ess_tail > 400   -> min ess_tail = 66 (sur V_cs[0, 1])\n",
       "Inference terminee.\n",
       "\n",
-      "Poids features utilisateur : age=1.480, genre=0.785\n",
-      "Poids features item : action=1.915, comedie=0.979\n"
+      "Poids features utilisateur : age=1.554, genre=0.919\n",
+      "Poids features item : action=1.735, comedie=0.904\n"
      ]
     }
    ],
@@ -1925,11 +1993,7 @@
     "                         random_seed=42, cores=1,\n",
     "                         return_inferencedata=True)\n",
     "\n",
-    "# Lecture de diagnostic (honnete) : quantifier le warning rhat/ESS (voir PyMC-6-Debugging)\n",
-    "diag_cs = az.summary(trace_cs, kind=\"diagnostics\")\n",
-    "wv_cs = diag_cs[\"r_hat\"].idxmax()\n",
-    "div_cs = int(trace_cs.sample_stats[\"diverging\"].sum())\n",
-    "print(f\"Diagnostic MCMC (cold-start) : divergences={div_cs} ; pire r_hat={diag_cs['r_hat'].max():.3f} (sur {wv_cs}) ; ess_bulk min={int(diag_cs['ess_bulk'].min())}\")\n",
+    "rapport_diagnostic_strict(trace_cs, \"cold-start hybride\")\n",
     "\n",
     "print(\"Inference terminee.\")\n",
     "\n",
@@ -1954,11 +2018,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du diagnostic : cold-start — mauvais conditionnement de la régression hybride\n",
-    "\n",
-    "Le diagnostic quantifie un mise en garde sérieuse : **130 divergences**, `r_hat` max **1.040** (sur `V_cs[2,0]`), `ess_bulk` min **37** (< 100). Le modèle cold-start croise factorisation latente ET régression sur features (`U_cs`, `V_cs` + `w_user`, `w_item`) sur seulement **8 observations** — ratio données/paramètres ~0.4 (21 paramètres pour 8 notes). Les traits latents résiduels `U_cs`/`V_cs` sont **sous-contraints** par les 8 observations avec un prior `sigma=1` large ; NUTS peine à les identifier → divergences + ess bas. Les poids de régression `w_user`/`w_item` (le livrable pédagogique : age, genre, action, comedie) restent interprétables, mais les traits latents ne le sont pas. Remède : plus de données, prior plus informatif sur `U_cs`/`V_cs`, ou `target_accept` relevé. Voir [PyMC-6-Debugging](PyMC-6-Debugging.ipynb)."
-   ]
+   "source": "### Lecture du diagnostic : cold-start — mauvais conditionnement, 0/4 au rapport strict\n\nLe rapport strict affiche **0/4** : **61 divergences**, `r_hat` max **1.020** (sur `V_cs[0,1]`), `ess_bulk` min **246** (sur `V_cs[4,0]`), `ess_tail` min **66** (sur `V_cs[0,1]`). Le modèle cold-start croise factorisation latente ET régression sur features (`U_cs`, `V_cs` + `w_user`, `w_item`) sur seulement **8 observations** — ratio données/paramètres ~0.4 (21 paramètres pour 8 notes). Les traits latents résiduels `U_cs`/`V_cs` sont **sous-contraints** par les 8 observations avec un prior `sigma=1` large ; NUTS peine à les identifier → divergences + ess bas. Les poids de régression `w_user`/`w_item` (le livrable pédagogique : age, genre, action, comedie) restent interprétables, mais les traits latents ne le sont pas. Remède : plus de données, prior plus informatif sur `U_cs`/`V_cs`, ou `target_accept` relevé. Voir [PyMC-6-Debugging](PyMC-6-Debugging.ipynb)."
   },
   {
    "cell_type": "markdown",
@@ -1981,14 +2041,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "2ab9dcd4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:52.545322Z",
-     "iopub.status.busy": "2026-08-26T10:54:52.545322Z",
-     "iopub.status.idle": "2026-08-26T10:54:52.549865Z",
-     "shell.execute_reply": "2026-08-26T10:54:52.549355Z"
+     "iopub.execute_input": "2026-08-29T01:37:39.321846Z",
+     "iopub.status.busy": "2026-08-29T01:37:39.321846Z",
+     "iopub.status.idle": "2026-08-29T01:37:39.325969Z",
+     "shell.execute_reply": "2026-08-29T01:37:39.325969Z"
     },
     "papermill": {
      "duration": 0.043935,
@@ -2008,11 +2068,11 @@
       "Nouvel utilisateur : age=0.4, genre=F\n",
       "\n",
       "Scores predits (cold-start):\n",
-      "  Item 0 : 3.199\n",
-      "  Item 1 : 3.105\n",
-      "  Item 2 : 2.450\n",
-      "  Item 3 : 2.544\n",
-      "  Item 4 : 2.824\n",
+      "  Item 0 : 3.192\n",
+      "  Item 1 : 3.109\n",
+      "  Item 2 : 2.528\n",
+      "  Item 3 : 2.611\n",
+      "  Item 4 : 2.860\n",
       "\n",
       "Recommandation : Item 0\n"
      ]
@@ -2087,14 +2147,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "b59b509c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:52.711304Z",
-     "iopub.status.busy": "2026-08-26T10:54:52.711304Z",
-     "iopub.status.idle": "2026-08-26T10:54:52.714839Z",
-     "shell.execute_reply": "2026-08-26T10:54:52.714330Z"
+     "iopub.execute_input": "2026-08-29T01:37:39.329311Z",
+     "iopub.status.busy": "2026-08-29T01:37:39.329311Z",
+     "iopub.status.idle": "2026-08-29T01:37:39.333389Z",
+     "shell.execute_reply": "2026-08-29T01:37:39.333029Z"
     },
     "papermill": {
      "duration": 0.030332,
@@ -2175,14 +2235,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "de30873f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:52.868337Z",
-     "iopub.status.busy": "2026-08-26T10:54:52.868337Z",
-     "iopub.status.idle": "2026-08-26T10:54:52.872710Z",
-     "shell.execute_reply": "2026-08-26T10:54:52.872710Z"
+     "iopub.execute_input": "2026-08-29T01:37:39.336072Z",
+     "iopub.status.busy": "2026-08-29T01:37:39.336072Z",
+     "iopub.status.idle": "2026-08-29T01:37:39.340692Z",
+     "shell.execute_reply": "2026-08-29T01:37:39.340692Z"
     },
     "papermill": {
      "duration": 0.033932,
@@ -2238,14 +2298,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "ebe0ac0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:52.990574Z",
-     "iopub.status.busy": "2026-08-26T10:54:52.990053Z",
-     "iopub.status.idle": "2026-08-26T10:54:53.012956Z",
-     "shell.execute_reply": "2026-08-26T10:54:53.011909Z"
+     "iopub.execute_input": "2026-08-29T01:37:39.343615Z",
+     "iopub.status.busy": "2026-08-29T01:37:39.343615Z",
+     "iopub.status.idle": "2026-08-29T01:37:39.368812Z",
+     "shell.execute_reply": "2026-08-29T01:37:39.368197Z"
     },
     "papermill": {
      "duration": 0.061247,
@@ -2309,14 +2369,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "06abf169",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:53.116021Z",
-     "iopub.status.busy": "2026-08-26T10:54:53.115022Z",
-     "iopub.status.idle": "2026-08-26T10:54:56.593405Z",
-     "shell.execute_reply": "2026-08-26T10:54:56.593405Z"
+     "iopub.execute_input": "2026-08-29T01:37:39.370673Z",
+     "iopub.status.busy": "2026-08-29T01:37:39.370673Z",
+     "iopub.status.idle": "2026-08-29T01:37:49.617194Z",
+     "shell.execute_reply": "2026-08-29T01:37:49.617194Z"
     },
     "papermill": {
      "duration": 3.506119,
@@ -2352,7 +2412,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7cb521260d51416d94dafd27ff1180d0",
+       "model_id": "632083873284434993c5bdda720300ea",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2384,7 +2444,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "There were 198 divergences after tuning. Increase `target_accept` or reparameterize.\n"
+      "There were 51 divergences after tuning. Increase `target_accept` or reparameterize.\n"
      ]
     },
     {
@@ -2412,12 +2472,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Diagnostic MCMC (click model) : divergences=198 ; pire r_hat=1.170 (sur sigma_c) ; ess_bulk min=8\n",
+      "Rapport strict (click model (fusion multi-sources)) : 0/4 criteres tenus\n",
+      "  [FAIL] divergences = 0  -> 51 divergences\n",
+      "  [FAIL] r_hat < 1.01     -> max r_hat = 1.030 (sur sigma_c)\n",
+      "  [FAIL] ess_bulk > 400   -> min ess_bulk = 167 (sur sigma_c)\n",
+      "  [FAIL] ess_tail > 400   -> min ess_tail = 168 (sur sigma_c)\n",
       "Inference terminee.\n",
       "\n",
-      "alpha (echelle clics) : 0.1753\n",
-      "sigma_jugements : 0.319\n",
-      "sigma_clics : 0.062\n"
+      "alpha (echelle clics) : 0.1761\n",
+      "sigma_jugements : 0.335\n",
+      "sigma_clics : 0.070\n"
      ]
     }
    ],
@@ -2428,11 +2492,7 @@
     "                            random_seed=42, cores=1,\n",
     "                            return_inferencedata=True)\n",
     "\n",
-    "# Lecture de diagnostic (honnete) : quantifier le warning rhat/ESS (voir PyMC-6-Debugging)\n",
-    "diag_cl = az.summary(trace_click, kind=\"diagnostics\")\n",
-    "wv_cl = diag_cl[\"r_hat\"].idxmax()\n",
-    "div_cl = int(trace_click.sample_stats[\"diverging\"].sum())\n",
-    "print(f\"Diagnostic MCMC (click model) : divergences={div_cl} ; pire r_hat={diag_cl['r_hat'].max():.3f} (sur {wv_cl}) ; ess_bulk min={int(diag_cl['ess_bulk'].min())}\")\n",
+    "rapport_diagnostic_strict(trace_click, \"click model (fusion multi-sources)\")\n",
     "\n",
     "print(\"Inference terminee.\")\n",
     "\n",
@@ -2460,11 +2520,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du diagnostic : click model — non-identifiabilité du couple `alpha`/`sigma_c`\n",
-    "\n",
-    "Le diagnostic pointe une dégradation forte : **198 divergences**, `r_hat` max **1.170** (sur `sigma_c`), `ess_bulk` min **8** (< 100, critique). Cause **structurelle** : le modèle définit `scores ~ Normal(mu=3, sigma=1.5)` et `obs_c ~ Normal(scores * alpha, sigma_c)` avec `alpha ~ Normal(0.2, 0.05)`. Multiplier le score latent par `alpha` (petit, ~0.2) **réduit drastiquement l'échelle** observée des clics ([0.3, 0.9]) : `sigma_c` devient quasi non-identifiable (r_hat 1.170, ess 8) car l'échelle des clics est absorbée par le produit `scores * alpha`, dont les deux facteurs ne sont pas séparables l'un de l'autre. C'est un **problème d'échelle** (reparamétrisation), pas un manque de données. Remède : fixer `alpha` ou reparamétriser le score en échelle clics (sans multiplication), ou `target_accept` relevé. Le classement des documents (rang) reste robuste car il n'utilise que l'ordre relatif des `scores`. Voir [PyMC-6-Debugging](PyMC-6-Debugging.ipynb)."
-   ]
+   "source": "### Lecture du diagnostic : click model — non-identifiabilité du couple `alpha`/`sigma_c`, 0/4\n\nLe rapport strict affiche **0/4** : **51 divergences**, et `sigma_c` est le paramètre le plus faible sur **tous** les critères — `r_hat` max **1.030**, `ess_bulk` min **167**, `ess_tail` min **168**, les trois mesurés sur `sigma_c` (ess sous le seuil strict de 400). Cause **structurelle** : le modèle définit `scores ~ Normal(mu=3, sigma=1.5)` et `obs_c ~ Normal(scores * alpha, sigma_c)` avec `alpha ~ Normal(0.2, 0.05)`. Multiplier le score latent par `alpha` (petit, ~0.2) **réduit drastiquement l'échelle** observée des clics ([0.3, 0.9]) : `sigma_c` devient quasi non-identifiable car l'échelle des clics est absorbée par le produit `scores * alpha`, dont les deux facteurs ne sont pas séparables l'un de l'autre. C'est un **problème d'échelle** (reparamétrisation), pas un manque de données. Remède : fixer `alpha` ou reparamétriser le score en échelle clics (sans multiplication), ou `target_accept` relevé. Le classement des documents (rang) reste robuste car il n'utilise que l'ordre relatif des `scores`. Voir [PyMC-6-Debugging](PyMC-6-Debugging.ipynb)."
   },
   {
    "cell_type": "markdown",
@@ -2487,14 +2543,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "65ef7e87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:56.730956Z",
-     "iopub.status.busy": "2026-08-26T10:54:56.729916Z",
-     "iopub.status.idle": "2026-08-26T10:54:56.734059Z",
-     "shell.execute_reply": "2026-08-26T10:54:56.734059Z"
+     "iopub.execute_input": "2026-08-29T01:37:49.654136Z",
+     "iopub.status.busy": "2026-08-29T01:37:49.653525Z",
+     "iopub.status.idle": "2026-08-29T01:37:49.658197Z",
+     "shell.execute_reply": "2026-08-29T01:37:49.657512Z"
     },
     "papermill": {
      "duration": 0.033442,
@@ -2513,12 +2569,12 @@
       "=== Classement Final ===\n",
       " Rang   Doc    Score     Juge    Clics\n",
       "----------------------------------------\n",
-      "    1     4    5.035      5.0     0.90\n",
-      "    2     0    4.504      4.5     0.80\n",
-      "    3     2    3.985      4.0     0.70\n",
-      "    4     5    3.447      3.5     0.60\n",
-      "    5     1    2.937      3.0     0.50\n",
-      "    6     3    2.137      2.5     0.30\n"
+      "    1     4    4.988      5.0     0.90\n",
+      "    2     0    4.475      4.5     0.80\n",
+      "    3     2    3.958      4.0     0.70\n",
+      "    4     5    3.445      3.5     0.60\n",
+      "    5     1    2.917      3.0     0.50\n",
+      "    6     3    2.174      2.5     0.30\n"
      ]
     }
    ],
@@ -2574,14 +2630,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "d715c456",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:56.875173Z",
-     "iopub.status.busy": "2026-08-26T10:54:56.875173Z",
-     "iopub.status.idle": "2026-08-26T10:54:57.124820Z",
-     "shell.execute_reply": "2026-08-26T10:54:57.124293Z"
+     "iopub.execute_input": "2026-08-29T01:37:49.659322Z",
+     "iopub.status.busy": "2026-08-29T01:37:49.659322Z",
+     "iopub.status.idle": "2026-08-29T01:37:49.986610Z",
+     "shell.execute_reply": "2026-08-29T01:37:49.985076Z"
     },
     "papermill": {
      "duration": 0.272939,
@@ -2595,7 +2651,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHqCAYAAAB/bWzAAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAfMtJREFUeJzt3Qd4FFXXwPFD6L1X6dJrpHelF2mCGhQEFVEUkKYgr0jXWECqICoCFl56F+lFqjSRJiDNgFTpRULJfs+577P77YZNsgnZzCT5/55n3OzM7MydnZW9c/bMuUkcDodDAAAAAAAAAAC2EGB1AwAAAAAAAAAA/4+gLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtACBOPfXUU2YCAACJw5AhQyRJkiSW9DPWr19v9j137tw42f/LL78sBQsWjJN9QWTatGnm/J48eVISk8R63EBiQ9AWgM/27dsnzz77rBQoUEBSpUoljz32mDRs2FDGjx9vddMSvE2bNknTpk3Ne67vff78+aVFixYyY8YMSSxu375tLvr04isuTJw40XSIAQDAw8Ei56T9kjx58kjjxo1l3LhxcuPGjVjZz5kzZ8z3/p49e8Ru7Nw2u4nr/hsAJCQEbQH4ZMuWLVKpUiX5/fffpUuXLjJhwgR57bXXJCAgQMaOHWt18xK0OXPmSJ06deT8+fPSs2dPEyTv0KGDXLlyRb7++mtJTJ3+oUOHErQFAMAGhg0bJt9//71MmjRJevToYeb16tVLypYtK3v37vVYd+DAgfLvv/9GOzCq3/vRDYyuXLnSTP4UWdu0b3b48GG/7j8+8Xf/7aWXXjKfLU0qAYCEJpnVDQAQP3z44YeSMWNG2bFjh2TKlMlj2YULF+K8Pbdu3ZK0adNKYqDZCaVKlZJt27ZJihQpLHvvHQ6H3LlzR1KnTh1n+wQAAPakdwDpD/pOAwYMkLVr10rz5s2lZcuW8scff7j6DMmSJTOTv4ODadKkeaivFNeSJ09u6f4TC+e1QNKkSc0U1+7fvy9hYWGWf94Sm8R0DQgoMm0B+OTYsWNSunTphwK2KkeOHA91YoYPHy6PP/64pEyZ0tT1+s9//iOhoaEe6+ktdRqQDE/X13pg4W/D27Bhg7z11ltmf3nz5nUt//nnn+XJJ5+U9OnTS4YMGaRy5coPlQ349ddfpUmTJibwrB16XX/z5s0e6+jtfJohovvXdut+tPzD7t27I3xftD6as23hTZ482Szbv3+/eX7u3Dl55ZVXTNt1+7lz55ZWrVpFWYtK33s9Jm+dwvDvvXYeNfNZs1z0dsXs2bOb4965c2e0z4/O1wuvFStWmIsyvfDSY1JXr14171W+fPnMNooUKSKffPKJ2X903b17VwYNGiQVK1Y050c7YrVr15Z169a51tH3SI9FabaG85ZM98/PoUOHTPmOLFmymGPXNi9evNhjX87Pkp77Pn36mG3q/p555hm5ePGix7EfOHDAnFfnvqjDCwBA5OrVqycffPCB/PXXX/LDDz9EWtN21apVUqtWLdO3TJcunRQvXtz0R5RmZWrfR2nfyfld7LwDRr+Ty5QpI7t27TJ3I2nfzvnaiGrnP3jwwKyTK1cu892vgeVTp05F2gd1ct9mVG3zVtNWA019+/Z19Zv0WEeOHGl+EHen2+nevbssXLjQHJ+uq/3v5cuXP3Kf1f08aJ/p+eefN/3mrFmzmju59Id5d772F7WPqaUxsmXLZvqKhQoVkldffdUv/Tdv1wIR1XbV6wPtT+q51muEp59+2vTtIjqv7sKfQ9227kPP2ZgxY1zvycGDB30+hnv37pn3oGjRomYdfd/186//H0RF263/b+n7q8c9YsSICPvcvhx3TK9JfH2dL9dmeieh9v31mPSzo3cR/v333w+dB/23Qa+FmjVrZrbXvn17s0yPX8+F/v+h72fOnDnljTfeMHci+vr5BOIDMm0B+ERvOdq6dasJQGonMjJaNmH69Omm86IdVA2YBgcHm4yLBQsWxLgN2knTjp8G+LTz6+yo6RevfmFrhod2/H/77TfTuX3xxRfNOpr1odkg2jEYPHiwKekwdepU0/nZuHGjVKlSxazXtWtXE4TVzrJmtl66dMnUktV2V6hQwWubtCOknYnZs2ebzom7WbNmmXY536+2bduaTpPeQqgdQc2S1Y5aSEhIpANW6Hu/Zs0aOX36tEew2pvOnTub90SPV8+Ddrj1GDVL15kNE53zo7f3vfDCC6YTpGUx9CJDM1n0WLVjpfO1vq6Wz9D3/+zZs6YDFR3Xr1+Xb775xuxH96EXIlOmTDEdrO3bt0tgYKA573r75ZtvvmkCrG3atDGvLVeunHnU97VmzZqm5u97771nOqp6Tlq3bi3z5s0zr3Gn5yBz5szm86AdTW2znnc9Z0qf6zp6bt9//30zTzuDAAAg6tvVNbinJQr0e90b/d7WH4b1e1zLLGgA6OjRo64f1EuWLGnma5/v9ddfN0EoVaNGDdc2tJ+m/Z127dqZgE9U39N615gG3vr372/6YPpd36BBA1PiIDp3EfnSNncamNUAsf4Yrf007dfoD+Lvvvuu6UuNHj3aY33te86fP9/0ezVIpXWCtQ+p/UUN9MW0z+pOA7ba99T+n/YRdR8a7Pruu+9c6/jSX9T3sVGjRqafpv0v7Ydrv0rbr2K7/+btWsAbLdvRqVMn05fUpALtu2o7NEiq1wkxHShOrx80uK3nXT+zGqT19Rg0UK3vn76veu2h/V8NKGqgXQPukQVK69ata/r0zu1/9dVXXj+zvh53TK9JfHmdL9dmuo4GfzWYq++JloDTpBP9/1/XdU8S0uPW49Fj0KC5/kCj9BrEuZ23335bTpw4Ycr36et1O5rxHtXnE4gXHADgg5UrVzqSJk1qpurVqzv69evnWLFihePu3bse6+3Zs0dTBhyvvfaax/x33nnHzF+7dq1rnj4fPHjwQ/sqUKCAo1OnTq7nU6dONevWqlXLcf/+fdf8q1evOtKnT++oWrWq499///XYRlhYmOuxaNGijsaNG7vmqdu3bzsKFSrkaNiwoWtexowZHd26dYv2e/PCCy84cuTI4dG2s2fPOgICAhzDhg0zz69cuWKO4bPPPov29qdMmWJemyJFCkfdunUdH3zwgWPjxo2OBw8eeKyn762u9/bbbz+0DeexR+f86HnQecuXL/dYd/jw4Y60adM6jhw54jH/vffeM5+PkJCQSI/nySefNJOTvm+hoaEe6+j7lTNnTserr77qmnfx4sUIPzP169d3lC1b1nHnzh2PY65Ro4Y5/+E/Sw0aNPD4PPTu3du0XT9TTqVLl/ZoJwAA+P/v0h07dkS4jvapnnjiCddz/e52v/QcPXq0ea7f7RHR7es6ur/w9PtZl3355Zdel7l/f69bt86s+9hjjzmuX7/umj979mwzf+zYsRH2QSPaZmRt09frdpwWLlxo1h0xYoTHes8++6wjSZIkjqNHj7rmOft77vN+//13M3/8+PGP3Gd1noeWLVt6zH/rrbfMfN1XdPqLCxYsiPKzEJv9t/DXAu7LTpw4YZ7fuHHDkSlTJkeXLl081jt37px539znhz+vEZ1D3bbuI0OGDI4LFy7E6BjKly/vePrppx3R1atXL7PvX3/91TVP26DHEpPjjuk1iS+v8+XaTK8d9bqpTJkyHussXbrUbH/QoEEe50Hn6TWGO70O0vk//vijx3y9ZnGf78vnE7A7yiMA8In+AqyZtpopoIORffrpp+ZXT/1V2f32n2XLlplHvfXcnf5Cr3766acYt0GzNdxrVukvu5qVqb+c6m0x7py34Gn2xJ9//ml+2dUshH/++cdM+ut8/fr15ZdffnHdXqS/vmoWgQ4uER1BQUHml1z3ARY0+0G3q8uU/hqu5Q10nfC37URFf63WX6f19i3NotBb1TSrQ2+v0gxXJ/01X49bs0fDc74f0T0/eguRnufwtzPp/jVT1fl+6qTZKnrrob6n0aHn1Fn6Qd+zy5cvm1/VNTM4qtv8lK6v2dSaNaKfB2d79Hxr2/X8h7/dSjMk3G/T1OPRtuvtnAAA4NHonSr6nRwRZybdokWLYlRaSWmmo2bZ+apjx44mc9VJM0j19m5n38hfdPva19FswPB9L43T6q3k7rQ/pbffO2lWqt5ifvz4cde8mPZZnbp16+bx3DmQnPO98LW/6DyPS5cuNbf/R0dM+m/hrwW80esDLeOld3C591P1dVWrVvUovxVdmmnqLPcQ3WPQ90qzVHVedOi5qFatmuvOQKVtcJYJiO5xx/SaxJfX+XJtptnFet2kWdPu6+jdiyVKlPB6raiZ2uGvRbSkml6fuh+r3lWp//Y4j/VRPp+AXRC0BeAzvYVFbyfRL2q9bV1vedEvZu30Oms6adBLyw9ojVN3Wj9MvzgfJSimAUR3Wt9IRVauwdkx0luFtIPjPukt+VqX69q1a2YdDURr+QetN6YdI72Nyb2DHBFnrVznrfVK/9bb34oVK+a6sNDblLRjrrfvaf013Z/e8uQL7fjprXTaGdOgqHa29b3UWwudg5Hp+5EnTx5zq1ZEont+wr/nzvdUg8jh30+9yIjp4Gh6+51elDhrfOn2tNPmPDeR0dsp9aJHa+iFb5MzgB2+TVrSwZ0GoFV0A+oAAOBhN2/e9AiQhqc/aust5XqruPaLtMSB3lIenQCuJg5EZxAo/bE7fBBJ+0NR1fF8VNq30v5Z+PdDyyw4l0fWR3H2U9z7KDHts0b0XmiQWPuHzvfC1/6ilsvSQKbWatWaoVrfVEsIhK97G1v9N2/90oj6/loGLfx2tWTHowziG37/0TkGLamh/Xi9NtCxJ7Q8xt69e6Pcp77X4c+X0pJlMTnumF6T+PI6X67NnJ+d8O1XGrQN//+DDmAYvjycHqteI2ht4/DHqv/2OI/1UT6fgF1Q0xZAtGkHWQO4OmnHQ7Mc9BdP9wzP8INNRIdmPHoTnXpjTs7O/2effWaCqN7oL7JKfyXXjEut06WdG32Ndk40UK010yLrxGjdKn3dxIkTTV0mraX00UcfeaynA0a0aNHCDC6hAVjt4GkdJ/2F/oknnvDpeLSOk7ZRJ+18aCdEO08alI4OX8+Pt/dc31P9Zbtfv35eX+MMVPtKByrRgQb0PdQOrHbANCtA3xtn58+Xc/zOO+88lBXsFP6iI6IsjfADggAAgOjRGvwaUAn/3Ru+f6E/QmtGnP5Iqz8G6w/eGnDSPlhU2ZTObcS2iPpH2jf1pU2xwZc+Skz7rNE97qj6i7pc7y7TurhLliwx/Vu9Q2zUqFFmnrOPHVv9N1/OuXO7Wt9Vg8zhaRDQvf3e+n6+XotE5xg0yKn9Ws0u13OmySNaz/jLL780P148qugcd0yvSWLjWia69DpLf0AIf6x6vfDjjz96fY0zG/pRPp+AXRC0BfBInINb6QBUzkGz9ItUfwF1ZhAoDWTqr8u63D1rQOe5u3v3rmtbUXHeOqaZBhFdGDjX0dvKnJmgkdHb5PR2HZ30V1odzEEHroiqA6wZI5otqgOG6QAN2gF0lkYI3x69tUwnfY80kKwdB/cRlmP63uu2tTOit2pFlG0bnfMTEd2P/orty/vpC+1MFS5c2FxouF8chC/zENGFg75W6YADsdWmyPYHAAAipkEjFVEQy0kDMVqqSqfPP//c/Nitg39qIFe/z2P7ezj8benaV9NMSeegWBH1TZVm/zn7Gyo6bdO+1erVq83dae7ZtocOHXItj4mY9lmd74V71qi+D9o/dA4mFd3+ot6+r5Puf8aMGebW/ZkzZ5pgZFz335x9fw3qRbVdPd/eMpR9vTMwuseg/XNNdtFJ+9IayNUs6ciCtvpeeyupoIMFx/S4H+WaJLLX+XJt5vzsaPv1R5rwx+TrtYj+P6XZ+r4E8iP7fAJ2R3kEAD7RDrS3X6KdNa+ct7g0a9bMPOqIvO60M+6sV+T+hRu+/qmOhhrRr9vh6Wig2vnVX3h1JFd3zrZqbSPdj442qp2j8C5evGgedZ/hb8XXTo/ezubLLTTaOdKOmGaJ6KS3qrl3hnX01vBt1HZp+6PavgaCvQn/3uvtP3rcmn0bnvP9iM75iYhmd2h9Yw0Qh6cdea1HG5OMEvfPl9Zp0324c44WG/5iSs+T1vudPHmy14C/8xxHl47O6+3CDQAAeKcZd1p7X/tA4WtuutMfmMNz3hHl7Bfp97CKre/i7777zqPOrv5orP0G9yCn9s00A0+TCJy0HuapU6c8thWdtmnfS/uZOrK9O82y1IBmdDNjH7XPqr744guP5+PHjzePzrb42l/Ukg3hrw/Cn8e47r/pjwWarKE/AnirY+q+XT3fGjx3n6djd+gdc76IzjFonVt3muWpgc2ozpmeC/1Mamk69+2GzzL19bhjek3iy+t8uTbTpBN93zTD2H1/euegJr74ei2i/x/ovzXh6XWI87Pmy+cTsDsybQH4RAco0C/rZ555xtQb0s6sDoKlAUr9Vd45EET58uXNrfoafNUvTK0lpJ0MzULV29/r1q3r2qb+utm1a1cTbNTb7bWTpIFAve3fF9ox0Q6vbkdLNehgY/qLuW5H26r71CwOvf1IO6GlS5c27dQaaDoogAaidRt6u4x24rVektbn1WPQjpT+grtjxw7z63FU9Bf2Nm3amF9tdZAzDRK7O3LkiMkk0U5GqVKlzC1KekubZixoHbfIaP0lvfjR25G0c6Tb17Zpu/W4db7S9/all16ScePGmV++tdauZkls3LjRLOvevXu0zk9EtISBDj6n9XS1rIEGxrVN+/btMxdAWg/N13OodDuaZaufLe2onThxwnTk9H1yD7TrL+k6Tz9zWoJBg+RaM0snvfioVauWqRGmg1Ro5oO+txr41ds09TMRXXpckyZNkhEjRphOtXYww2cEAACQWGmQRQNeGiTR71wN2OpARJopp/2E8AMRudP6nvrDvX7v6/qaKaolprQvpt/nSvs8Wj9V+wQaCNJAqQ6o5EtdU2+036Db1r6gtlcDkvr9rv0GJ+1Tal9G+1DaZ9Pb2d0zCJ2i0zbtp2n/SrOItY+kfTG9PV5vk9fbzcNvOyqP2mdV2tfSwYX1OLWvpMeo/WjdnvK1v6jP9bxpH06PQ9v29ddfm/61M/Ab1/033bf237RPrNnH2s/W2+VDQkJMKQ7NznQG0PVWeQ1Ea8Czc+fO5nOo51SvGa5fv+7T/nw9Bn0PNMCr/Ut9D3RALv2saf88MlqOTLPX9Vz17NnTfNb0vOj/N+41cX097phek/jyOl+uzfSaSUt56P+H+rnSgdN0G2PHjjXXlL17947yPdfXvfHGGyY4rINOa7BYt6vXP1qyT7el/3/48vkEbM8BAD74+eefHa+++qqjRIkSjnTp0jlSpEjhKFKkiKNHjx6O8+fPe6x77949x9ChQx2FChVyJE+e3JEvXz7HgAEDHHfu3PFY78GDB47+/fs7smXL5kiTJo2jcePGjqNHjzoKFCjg6NSpk2u9qVOn6k+kjh07dnht2+LFix01atRwpE6d2pEhQwZHlSpVHP/973891vntt98cbdq0cWTNmtWRMmVKs4/nn3/esWbNGrM8NDTU8e677zrKly/vSJ8+vSNt2rTm74kTJ/r8Hq1atcq0M0mSJI5Tp055LPvnn38c3bp1M++fbjtjxoyOqlWrOmbPnh3ldvVY2rVr53j88cfNMaZKlcpRqlQpx/vvv++4fv26x7r37993fPbZZ2Y/eo6yZ8/uaNq0qWPXrl3RPj/6Hj399NNe23Tjxg3zGv0M6H70HOo5GDlypOPu3buRHs+TTz5pJqewsDDHRx99ZPan5+aJJ55wLF261HwGdJ67LVu2OCpWrGj2qe/14MGDXcuOHTvm6NixoyNXrlzmuB577DFH8+bNHXPnzo3ys7Ru3TozXx+dzp07Z45fPw+6zL3NAAAkVs7vUuek38n63duwYUPH2LFjH+qbKP2+dr/01P5Xq1atHHny5DGv18cXXnjBceTIEY/XLVq0yPR5kiVLZl6v+1b6nVy6dGmf+hnO73jtT2nfJUeOHKY/pd/xf/3110OvHzVqlOlDaJ+kZs2ajp07dz60zcja5q3/ov2m3r17m+PUPkrRokVNf037QO50O9pfDM+9b/wofVbneTh48KDj2WefNa/PnDmzo3v37o5///3XY11f+ou7d+825y1//vzm/dL3Vvte+p7FRf/NfdmJEyc85ut512sL7XNr31n70S+//PJDbfvhhx8chQsXNm0LDAx0rFix4qFzqNvWfeg588aXYxgxYoS5RsmUKZP5/Glf/cMPP4yy36z27t1rPn96HLrt4cOHO6ZMmRKj447pNUl0XufLtdmsWbNMn18/N1myZHG0b9/ecfr0aY919DzoviLy1Vdfmc+V7kc/y2XLlnX069fPcebMmWh9PgE7S6L/sTpwDAAAAAAA/Efrp2oZLb1VPjp3RQEArEFNWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEaoaQsAAAAAAAAANkKmLQAAAAAAAADYCEFbAAAAAAAAALCRZBKPhYWFyZkzZyR9+vSSJEkSq5sDAACAR6BVu27cuCF58uSRgAByC5zo8wIAACS+Pm+8Dtpq5zVfvnxWNwMAAACx6NSpU5I3b16rm2Eb9HkBAAASX583XgdtNdvAeZAZMmSwujkAAAB4BNevXzfBSWcfD/9DnxcAACDx9XnjddDWeXuYdl7pwAIAACQMlADwRJ8XAAAg8fV5KRYGAAAAAAAAADZC0BYAAAAAAAAAbCRel0cAAAAAAAAAYB2HwyH379+XBw8eWN0UW0mePLkkTZo0xq8naAvAEvqP+b1796xuBhKwR/2CBAAAAABE7u7du3L27Fm5ffu21U2xZc3avHnzSrp06WL0eoK2AOL8F7hz587J1atXrW4KEoFMmTJJrly5GNQIAAAAAGJZWFiYnDhxwiTL5MmTR1KkSMG1l1vs4+LFi3L69GkpWrRojBKKCNoCiFPOgG2OHDkkTZo0/IMOv31B6i+9Fy5cMM9z585tdZMAAAAAIMFl2WrgNl++fOb6Hp6yZ88uJ0+eNHcZE7QFYPuSCM6AbdasWa1uDhK41KlTm0cN3OpnjlIJAAAAABD7AgICrG6CLT1qkhrvKoA446xhyy9wiCvOzxr1kwEAAAAgcShYsKAUL15cypcvL0WKFJFWrVrJli1bYnUfv/76q9l+sWLFpF69evL3339LbCPTFkCcoyQC4gqfNQAAAACIW6NXHfHLdns3LObzurNmzZLAwEDz9/z586VZs2ayYsUKqVq16iO3Q0tCtG/fXr7++mupW7eujBw5Unr16iVz5syR2ESmLQAAAAAAAIAEqU2bNtK1a1cTXFU3b96UV199VcqUKWOmoUOHutbVjNlnn31WypYtK+XKlZMPPvjgoe3t2rVLkiVLZgK26o033pAlS5bInTt3YrXdZNoCAAAAAAAASLCqVq0qixcvNn8PHz5cQkNDZe/evfLvv/9KrVq1pESJEhIUFCQdOnSQRo0aydy5c826Fy9efGhbISEhUqBAAdfz9OnTS4YMGeTMmTNSuHDhWGszQVsAttBi/KY43d+SHrWitf7LL79sBlFbuHChJJYaQHp7h04AAAAAAMRnDofD9ffq1atl1KhRZgC1tGnTSseOHWXVqlXy9NNPy6ZNm0wZBafs2bNb1GLKIwAAAAAAAABIwHbs2GFKIcTGWCj58+eXv/76y/X8xo0bcu3aNcmTJ4/EJoK2ABCDLNQxY8Z4zNMC50OGDHE9P3TokLnFIlWqVFKqVCnzS55+Ebhn6p46dUqef/55yZQpk2TJksWMaHny5EmP7N7WrVvLRx99JDlz5jTrDRs2TO7fvy/vvvuueU3evHll6tSpHm3xdbtazyd37tySNWtW6datm9y7d88sf+qpp8wXUO/evU2bnV9gOq9FixaSOXNm82tk6dKlZdmyZX54hwEAAAAAiB2LFi2SSZMmSd++fc3zBg0ayJQpU0z27a1bt+T77783JRHSpUsnderUMVm4Tt7KI1SsWNFcP69bt848nzx5srlW1uv/2ETQFgBi2YMHD0xQNE2aNPLrr7/KV199Je+//77HOvoPfOPGjU3tm40bN8rmzZvNF0STJk3k7t27rvXWrl1r6uL88ssv8vnnn8vgwYOlefPmJnCq29Zi6lr0/PTp09Harn65HDt2zDxOnz5dpk2bZibnyJoaDNYA8dmzZ82kNLCrdX+0Lfv27ZNPPvnEbBsAAAAAADsJCgqS8uXLS5EiRUyAVhOOtK6t0sHFkidPbgYb03ktW7Y0iU9KA7g7d+40SUqanDVhwoSHtq1lFX744Qfp2bOnFCtWTJYuXSqjR4+O9WOgpi0AxDKthaMB0fXr10uuXLnMvA8//FAaNmzoWmfWrFkSFhYm33zzjSuTVTNmNTtWX6e/8inNlB03bpz5UihevLh8+umncvv2bfnPf/5jlg8YMEA+/vhjU3enXbt2Pm9Xg7765ZM0aVJTcF1r96xZs0a6dOli9qnzNfDrbL+z2Hrbtm3NF5uKzQLrAAAAAICEoXfDYpbu/6TbnabeaPLRt99+63WZljiYN29elPuoXr26GcjMnwjaAkAsO3z4sOTLl88j4FmlShWPdX7//Xc5evSoCYy6u3Pnjgn4OumvexqwddIyCe51eDS4quUNLly4EO3t6mudtEyCZs9G5u2335Y333xTVq5caW4n0QBuuXLlfHpPAAAAAACA7wjaAkA0aRDVfeRJ5awH66ubN2+aOjg//vjjQ8vcR6fUWzbcafast3maXfuo23VuIyKvvfaaKb3w008/mcBtcHCwqfXTo0ePKI8XCUPQ0iC/72NW81l+3wcAAIiftsx5uI8bkRrPtfdrWwDA3wjaAkA0afDTWedVXb9+XU6cOOF6rmUMdDCw8+fPm8xY50iV7ipUqGBKGeTIkUMyZMgQa22Lre2mSJHC1OYNTzOItY6uTlqa4euvvyZoCwAAAABALGMgMgCIpnr16pni5DrQl5YU6NSpk0epAa1d+/jjj5v5WuNGBwMbOHCgWeasM9u+fXvJli2btGrVymxHg75ac1ZLEDgHFYuJ2NpuwYIFzYBjf//9t/zzzz9mXq9evWTFihVmm7t37zaDmJUsWTLGbQUAAAAAAN4RtAUAH2jpgGTJ/ndzgmaYPvnkk9K8eXMzgFfr1q1NkNZJA7gLFy40pQoqV65sygq8//77ZlmqVKnMY5o0aUxQNH/+/NKmTRsT/OzcubOpPfsoGbKxtd1hw4aZ4u16XM6yCpp5261bN7PNJk2amFEyJ06cGOO2AgAAAAAA75I4whdmjEf0luSMGTPKtWvXYvX2YgD+oYFDzdIsVKiQK3gZX2iQskiRIjJhwoQYvV6zbWvVqmUGCXMP8MK/4vNnzo6oaQt/o2/nHe8LAPwPNW0Be+F6K2bvj699O0szbYcMGWJuFXafSpQoYWWTAMDDlStXZOnSpabEQIMGDXx+3YIFC2TVqlUmW3X16tXy+uuvS82aNQnYAgAAAAAA+w9EVrp0aRPQcHLefgwAdvDqq6+aQcT69u1r6sT66saNG9K/f38JCQkxNWY14Dtq1Ci/thUAAAAAAMutC/bPdusO8HmMlpQpU5rs1lu3bpnYo16f16hRI9aa8uyzz8qWLVvMIOWa7JUpUyaJbZZHSDVImytXLqubAQARZszGRMeOHc0ExKnJT/p3+4/xfQ0AAADA/mbNmiWBgYHm7/nz50uzZs3MwNpVq1aNle137drVjPGSM2dOSbADkf3555+SJ08eKVy4sBn1XLPSAAAAAAAAAOBR6SDdGmQdOXKkea6DhutdtWXKlDHT0KFDXev+/fffJou2bNmyUq5cOfnggw+8blPvps2RI4f4k6WZthrdnjZtmhQvXtykE+ubVLt2bdm/f7+kT5/+ofVDQ0PN5F64FwAAAAAAAAAii0EuXrzY/D18+HATX9y7d6/8+++/ZtBwHWMrKChIOnToII0aNZK5c+eadS9evChWsTRo27RpU9ffGr3WN7BAgQIye/Zs6dy580PrBwcHe0S/AQCIL1qM3+T3fSxJ4fddAAAAAEC843A4XH/r2Fo65kxAQICkTZvWlDbUgcSffvpp2bRpkymj4JQ9e3aLWmyD8gjutGhvsWLF5OjRo16XDxgwQK5du+aaTp06FedtBAAAAAAAABB/7Nixw5RC8CZJkiRiR7YK2mpNiWPHjknu3Lm9LteR3zJkyOAxAQAAAAAAAIA3ixYtkkmTJknfvn1d9WinTJlism9v3bol33//vSmJkC5dOqlTp47JwnWysjyCpUHbd955RzZs2CAnT56ULVu2yDPPPCNJkyaVF154wcpmAQAAAAAAAIingoKCpHz58lKkSBEToF22bJkpy6p0cLHkyZObwcZ0XsuWLeX55583yzSAu3PnTildurQEBgbKhAkTvG5fSynkzZvX/K3rPvXUUwmrpu3p06dNgPbSpUumRoQW/t22bZul9SIAIL4bMmSILFy4UPbs2WN1UwAAAAAAiU3dAZbu/uTJk5Eu14zab7/91uuyPHnyyLx586Lcx08//ST+ZmnQdubMmVbuHoCdTH4ybvf3xoZora63RAwaNMj8w3z+/HnJnDmz+dVO59WsWVPiO63hs2DBAmndunWsbnf9+vVSt25duXLliqlbDgAAAAAAbB60BYD4om3btnL37l2ZPn26FC5c2ARu16xZY+4U8BfdX4oUKfy2fQAAAAAAYE+2GogMAOzo6tWrsnHjRvnkk09M1miBAgWkSpUqMmDAAFP7xn29N954Q3LmzCmpUqUyI1MuXbrUtVxvsdBaNzqoYsGCBT2KmyudN3z4cOnYsaMZaPH111838zdt2iS1a9eW1KlTS758+eTtt982xdKjM0pmw4YNJVu2bJIxY0Z58sknZffu3R77VVpXXDNunc+dBdsrVKhgjkeD1UOHDpX79++7luv633zzjXltmjRppGjRorJ48WLXLSn6finNTNZ1X3755Wi99wAAAAAAJEYEbQEgClrvRietExsaGup1nbCwMGnatKls3rxZfvjhBzl48KB8/PHHZnBFtWvXLlPYvF27drJv3z5Td1aLn0+bNs1jOyNHjjRlF3777Tez/NixY9KkSROT6bt3716ZNWuWCeJ2797d5/bfuHFDOnXqZF6ndcM1sNqsWTMz3xnUVVOnTpWzZ8+6nmugWgPIPXv2NMczefJk094PP/zQY/sayNVj0/bpdtu3by+XL182AWZnLaDDhw+bbY8dOzZa7z0AAAAAAIkR5REAIArJkiUzwcouXbrIl19+aTJPNVtVA7DlypUz66xevVq2b98uf/zxhxQrVszM08xUp88//1zq169vArFK19FA6GeffeaRfVqvXj3p27ev6/lrr71mgqC9evUyzzXgOm7cOLP/SZMmmQzYqOg23X311VemvuyGDRukefPmrsEfdV6uXLk8grHvvfeeCfg6j0czgfv16yeDBw92raft10El1UcffWTap++FBpuzZMli5ufIkYOatgAAAAAA+IhMWwDwgWa6njlzxtz6r8FIHWBLg7fOTNk9e/ZI3rx5XQHb8DSYG37AMn3+559/yoMHD1zzKlWq5LHO77//bvbhzPbVqXHjxiaz98SJEz61XevvasBZA75aHkFLL9y8eVNCQkIifZ3ue9iwYR771u1oxuzt27dd6zkD1ypt2rRm+xcuXPCpbQAAAAAA4GFk2gKAjzSrVWvD6qQZs5oFqxmnmmmq9WZjgwY93WlwVevkah3b8PLnz+/TNjVTVgdM09IEWo9Xa+pWr17dDHQWGd23Ztu2adPmoWXuGb7Jkyf3WKa1azWoDAAAAABAXCtYsKC57tXrVh0PRseW6d+/v9SoUSNWtq8JXa+88ooZx0X3owlSeleu8y7W2ELQFgBiqFSpUqbOrTPb9PTp03LkyBGv2bYlS5Y09W7d6XNd11n31hvN5tUyCkWKFIlxO3U/EydONPVm1alTp+Sff/7xWEcDr+4Zv859ay3aR9l3ihQpzGP4bQMAAAAAEqaJeyb6ZbtvBb7l87o6HkxgYKD5e/78+eZ6eMWKFVK1atVHbodew2siV61atczzd99910zhx6x5VARtASAKmqX63HPPyauvvmqCs+nTp5edO3fKp59+Kq1atTLraI3ZOnXqmDIKWr9WA52HDh0yWadaTkHr1FauXNnUhA0KCpKtW7fKhAkTTDA1MvprYLVq1czAY5rZq5m4GsRdtWqVeb0v9Fe/77//3pReuH79uvkyCZ8ZrL9ErlmzxpRs0F8KM2fOLIMGDTI1bzWj99lnn5WAgABTMmH//v0yYsQIn/atmb36HixdutR8Sep+tcwCAAAA4si64KjXqTsgLloCAJZo06aNGXdFB/6eM2eOuatU72bVeUqv953jtvz9999mMG5NYNJrWb3m1+t4dzlz5jSTkwaCfb0+jw5q2gJAFDTIqP8Ijx492gRmy5QpY35V0/qu7v8wz5s3zwRmdVAuzcLVAbucGaaatTp79myZOXOmeb0GRLVerPsgZN5okFgHDNMM3tq1a8sTTzxhXpsnTx6f2z9lyhS5cuWKacNLL71kvpx0YDB3o0aNMoHgfPnymX0orZ2rwdaVK1ea49Lgsb4HGoj11WOPPeYa0Ey/1DT4DADxiXbcO3ToIFmzZjU/PJUtW9b8cOfkcDjMv8u5c+c2yxs0aGDqlbu7fPmyGVRSa37roIydO3c2FwsAAACIG1WrVpUDBw6YvzUIGxoaKnv37pVff/3V3EGrmblK+30VK1aUffv2meXeShW602t+jQs4E7piUxKH9jTjKc0Y00F1rl27ZjrBAOztzp07ZvCsQoUKedREBRLDZ67F+E1+38eSFO/7dftBj+USf5vV/H+dJSROduvb6Q9e+kNW3bp15c033zR1yjQg+/jjj5tJffLJJxIcHCzTp083/9boj3rayde7Ipz/7jRt2tQM4jh58mS5d++eqYGmP4bNmDEjXr4vAOKZBJRpu2XOjz6vW+O59n5tC4CIr7esLo9QsGBBE4h1lkdwlkgYOHCg6aNpUFYTl5566imzTJOTNKA7ZswYc9ep1sF1lvqLjIZUu3btagbi1iQuvTvVl/fH174d5REAAAAALzQgq3cgTJ061TVPO93uHXXt3OsFgDO74rvvvjN3FuiFQrt27eSPP/6Q5cuXy44dO0yZGjV+/HhTMkZv0YvOnRMAAACIGe2L6V2v3mgZhJjQLFwdM0b7feEDtrGB8ggAAACAF4sXLzaBVq1zpmVlNOv266+/di3XzIlz586ZkghOmjWht99p7XKlj1oSwRmwVbq+duz1djxv9HY9zcBwnwAAABAzixYtkkmTJpmxZpx9MS0jqD/Aa1atjgHTqFEjUxpRSyJqFq7TxYsXIwzYHj16VBYsWOBTVm5MELQFAAAAvDh+/Ljp4OuAjjrasJZI0A66lkJQGrBV7gNROJ87l+lj+DriyZIlkyxZsrjWCU/LLWjw1zlpti8AAAB8pwOAly9f3gwSrgHaZcuWmR/WlZazSp48uRmrQOe1bNlSnn/+ebNMA7g6fkHp0qVNeQVvA4xt3rzZ3Dl18uRJ83pd75lnnpHYRnkEAAAAwIuwsDCTIfvRRx+Z55ppu3//fvnyyy+lU6dOftvvgAEDpE+fPq7nmmlL4BYAAMQXvtae9ZeTJ09Gulwzar/99luvy7R0ldanjUzNmjVNlq6/kWkLAAAAeJE7d24pVaqUx7ySJUtKSEiI+TtXrv8Nznf+/HmPdfS5c5k+6uAU7u7fvy+XL192rRNeypQpzaAU7hMAAAASF4K2AAAAQARZFIcPH/aYd+TIESlQoIBrUDINvK5Zs8YjK1Zr1VavXt0818erV6/Krl27XOusXbvWZPE6b9EDAAAAwqM8AgAAAOBF7969pUaNGqY8gtY52759u3z11Vdmco403KtXLxkxYoSpe6tBXK2RprfVtW7d2pWZ26RJE+nSpYspq3Dv3j3p3r27tGvXzqwHAAAAeEPQFgAAAPCicuXKZkRgrTE7bNgwE5QdM2aMtG/f3rVOv379zKjDr7/+usmorVWrlixfvlxSpUrlWufHH380gdr69etLQECAtG3bVsaNG2fRUQEAACA+IGgLAAAARKB58+Zmiohm22pAV6eIZMmSRWbMmOGnFgIAACAhoqYtAMQivXhfuHCha8RKfb5nzx6/7W/KlCnSqFEjsbP169eb90Ez0B5FwYIFTYabunv3rnm+c+fOWGolAAAAAAD2QaYtAFsIWhoUp/ub1XxWtF9z7tw5+fDDD+Wnn36Sv//+W3LkyCGBgYGmnqHe8hpevnz55OzZs5ItWzbxhzt37pjaiXPmzJHEJkWKFPLOO+9I//79PQYAAgAAAAAgISBoCwA+0KxZHUU8U6ZM8tlnn0nZsmXNYDIrVqyQbt26yaFDhx56TdKkSc2o4v4yd+5cyZAhg2lXRDQjVQOcCZHWlOzbt68cOHBASpcubXVzAAAAAAAicnH8BL9sN3uP7j6tp3dlpkyZ0owxoGMP6PWiJvzoALOxQbdZr149k0ilcufObQac1f3GJsojAIAP3nrrLXOLv44crgPIFCtWzPzD36dPH9m2bZvX13grj6ABRq2NqMHW9OnTS+3ateXYsWOuMgJVqlSRtGnTmuCwBmP/+uuvCNs0c+ZMadGihce8l19+2YxYrhnBOip58eLFzfxTp06Zkc91u1pbsVWrVqZ9TlHte8mSJWZAHv3S08zhZ555xrXs+++/l0qVKpnj0SD1iy++KBcuXIj0/dy0aZM59tSpU5uM5Lffftt88Tnp6/XYdLkO/KOD+ISXOXNm0059HwAAAAAAcJo1a5b8/vvvcvToUenUqZM0a9ZMfv31V4kNep26evVqs32dGjduLD179pTYRtAWAKJw+fJlMxK4ZtRqUDM8DXL6Qksq1KlTx/zit3btWtm1a5e8+uqrcv/+fTNpsPXJJ5+UvXv3ytatW81I5Br0jSzwqcHS8LRcwOHDh2XVqlWydOlSkxGsXyIaVN24caNs3rxZ0qVLJ02aNDGZuFHtW8tBaJBWv+R+++03s30N8Drp9ocPH26+rLSerwaDNXgcEQ1S6741+K370y9TPRYdWd1JX6+B5nXr1pmM4okTJ3oNBGs79JgAAAAAAPCmTZs20rVrVxk5cqR5fvPmTXMtXqZMGTMNHTrU47r92WefNXfXlitXzpQkDC8gIMBcXyuHwyHXr1+P9No9piiPAABR0F/m9B/iEiVKPNJ2vvjiC8mYMaPJDE2ePLmZpxm7zsDwtWvXTBbu448/buaVLFkywm3poF66vmbThqeB5W+++cZVFuGHH36QsLAwM8/5RTJ16lQTbNYMWw38RrZvzdpt166dxxdZ+fLlXX/rl51T4cKFZdy4cSYrV78INTgcXnBwsCltoLWAVdGiRc1rNGg8adIkCQkJkZ9//tlkNet2nAOueXs/9Pgjy0YGAAAAAKBq1aqyePFi87cmHYWGhpokon///Vdq1aplrveDgoKkQ4cOZrBvTR5SFy9ejHCbDRo0kH379kn27NlN6cTYRqYtAERBA7axQcskaEkAZ8DWnZYs0OxSzYjVsgBjx441g5hFRL9YlJYrCE9/EXSvY+u8JUR/CdQgqk66P62/o1mvUe1b2+1toDUnzRjW1+XPn9/sQ4OvSoOv3mh7pk2b5mqLTrpvDSyfOHFC/vjjD0mWLJlUrFjR9Rr9AvWW0ay3pdy+fTvCtgEAAAAA4HC7rtfSBl26dDEZs5r01LFjR3OnqiYe6V2gOnaKkwZkI6Lb0WtnDfZqslNsI9M2EQtaGuT3fcxqPsvv+wD8TTNBNUPV22Bj0aEBxsho9qvWdtVSDFoyYODAgeaLo1q1ag+tmzVrVtOmK1euPLQsfAkH/eLRAKi3urDOL6DI9h1Zu7UOrQZcddLt6/Y0WKvPtfSCN9qeN954w+wvPA38HjlyRHylGcqRfYkCAAAAALBjxw5TCsGbRyltoIFfDQBr3EDL+sUmMm0BIAqaiapBSC1v4D5YlnupAl9oPRytv6o1YCPyxBNPyIABA2TLli3mC2XGjBle19NM2lKlSsnBgwej3G+FChXkzz//lBw5ckiRIkU8Ji3XENW+td1ax9YbDWRfunRJPv74Y5NFrBmxUQ1Cpu3Rdodvi056XLoNrbOrGbxOWqPX2/u8f/9+024AAAAAALxZtGiRKcXnzKDVsgZagk+zb/UaXwfX1pIIeheojkMzatQo12u9lUc4d+6cRwKVJj7pdXNsI2gLAD7QgO2DBw/MwFfz5s0zQVC9jV9rsVavXt2nbehAW1qgXOvD7ty502xDvxw0IKllATRgqoOAaY3WlStXmuWR1bXVQLLeuhEVrR+bLVs2adWqlQka6760lq1mup4+fTrKfQ8ePFj++9//mkc9Zq3Z88knn7gyYzXQOn78eDl+/LipEaT1gSLTv39/ExjW90NLL+i+9EvUORBZ8eLFzUBlmo2ro3tq8Pa1117zmvGrx6NfrgAAAAAAOGnJAh2LRZODNEC7bNkyU9dW6eBiWrZQSwvqvJYtW8rzzz9vluk1ul6vly5dWgIDA2XChAkSnt5dWq9ePROo1W3oANo6lkxsozwCAPhAB9javXu3qVOjv85p3Rq9LV/LDugvdr7QkgZr166Vd99919R9TZo0qfkSqFmzpqRJk8ZkrU6fPt1krubOnVu6detmApcR6dy5s2sQMfeM2fB027/88osJluqomTdu3JDHHnvM1KnNkCGDqY8b2b6feuopmTNnjgnGakatvkZ/fVT6Hmh92v/85z8mgK1ZtDoip37pRUS/2DZs2CDvv/++yc7VXzd1ADT9UnXScg0aqNX3KWfOnDJixIiHRu3UILMeu47sCQAAACBujV7le1mz3g3/NwAzEofsPf6XkGOVkydPRrpcM2q//fZbr8t0sGtN1IqMJnP99ttv4m9JHLE1wo4FNGNNAxV60a5BBEQPNW0R13TgK83qLFSokNcBtBB9zz33nAmUaqZsYv3lVAPG8eEz12J81FnRj2pJivf9uv2gx3KJv/G9kbjRt/OO9wXAI1kXHPU6deNHX3LLnIfHaIhIjefa+7UtIGgLe11vxaf3x9e+HZm2ifTC24iDi28A/vXZZ5/JkiVLJLHRQc70NpTevXtb3RQAAAAAAGIdQVsAiMcKFiwoPXr0kMRG6+gOHDjQ6mYAAAAAAOAXDEQGAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAHEuLCzM6iYgkeCzBgAAAACIjxiIDECcDh4VEBAgZ86ckezZs5vnSZIksbpZSIAcDofcvXtXLl68aD5z+lkDAAAAAPjf9iXH/bLdKi0K+zxgd8qUKSVVqlRy69YtKV26tPTv319q1KgR620aPHiwDBs2TH777TcJDAyM1W0TtAUQZzR4VqhQITl79qwJ3AL+liZNGsmfP7/57AEAAAAAEodZs2a5gqjz58+XZs2ayYoVK6Rq1aqxto/t27fLjh07pECBAuIPBG0BxCnNeNQg2v379+XBgwdWNwcJWNKkSSVZsmRkcwMAAABAItamTRsTYB05cqTMmTNHbt68KW+//baZp5577jmTMav+/vtv6dmzpxw+fNhcS7Zq1UqGDx/+0DZv374t3bt3l3nz5knt2rX90m6CtgDinP7Dlzx5cjMBAAAAAAD4U9WqVWXx4sXmbw3ChoaGyt69e+Xff/+VWrVqSYkSJSQoKEg6dOggjRo1krlz55p1teSeN/369ZM333xT8uXL57c2c78oAAAAAAAAgAQ97onT6tWrpUuXLqaMXtq0aaVjx46yatUqk4G7adMm6du3r2tdHY8nPF33r7/+kldeeUX8iaAtAAAAAAAAgARrx44dUqZMGa/LoltSb+3atbJ7924z4JlOp0+fNjVzlyxZIrGJoC0AAAAAAACABGnRokUyadIkVwZtgwYNZMqUKSb79tatW/L999+bkgjp0qWTOnXqyKhRo1yv9VYeITg42NS+PXnypJny5s0ry5YtkxYtWsRquwnaAgAAAAAAAEgwgoKCpHz58lKkSBEToNWgqta1VR988IEZY6ds2bJmXsuWLeX55583yzSAu3PnTildurQEBgbKhAkTLDsGBiIDAAAAAAAAECuqtChs6f5PnjwZ6XLNqP3222+9LsuTJ4/MmzcvVvcXU2TaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsJFkVjcAAAAAAAAAQMKwZc6Pftlujefa+7RewYIFJWXKlJIqVSq5deuWlC5dWvr37y81atSItbYkSZJEypQpI0mTJjXPx48fL7Vr15bYRNAWAAAAAAAAQIIxa9YsCQwMNH/Pnz9fmjVrJitWrJCqVavG2j42btwomTJlEn+hPAIAAAAAAACABKlNmzbStWtXGTlypHl+8+ZNefXVV02mrE5Dhw51rfv333/Ls88+K2XLlpVy5crJBx98YFm7ybQFAAAAAAAAkGBVrVpVFi9ebP4ePny4hIaGyt69e+Xff/+VWrVqSYkSJSQoKEg6dOggjRo1krlz55p1L168GOE269evL/fv3zePus20adPGapvJtAUAAAAAAACQYDkcDtffq1evli5dukhAQIAJtHbs2FFWrVplMnA3bdokffv2da2bPXt2r9v766+/ZNeuXbJlyxYT2H333Xdjvc0EbQEAAAAAAAAkWDt27DClECIaVCy68ufPbx416PvWW2+Z+raxjaAtAAAAAAAAgARp0aJFMmnSJFcGbYMGDWTKlCkm+/bWrVvy/fffm5II6dKlkzp16sioUaNcr/VWHuHKlSty+/Zt83dYWJgZ9OyJJ56I9XYTtAUAAAAAAACQYAQFBUn58uWlSJEiJkC7bNkyU9dW6eBiyZMnN4ON6byWLVvK888/b5ZpAHfnzp1SunRpCQwMlAkTJjy07UOHDkm1atXM9nUbly5dkjFjxsT6MTAQGQAAAAAAAIBYUeO59pbu/+TJk5Eu14zab7/91uuyPHnyyLx58yJ9ffXq1c0gZv5Gpi0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjtgnafvzxx5IkSRLp1auX1U0BAAAAAAAA4AOHw2F1ExLk+2KLoO2OHTtk8uTJUq5cOaubAgAAAAAAACAKyZMnN4+3b9+2uim2dPfuXfOYNGnSGL0+mVjs5s2b0r59e/n6669lxIgRVjcHAAAAAAAAQBQ0GJkpUya5cOGCeZ4mTRpzFz1EwsLC5OLFi+Y9SZYsWfwM2nbr1k2efvppadCgAUFbAAAA2MaQIUNk6NChHvOKFy8uhw4dMn/fuXNH+vbtKzNnzpTQ0FBp3LixTJw4UXLmzOlaPyQkRN58801Zt26dpEuXTjp16iTBwcEx7rwDAADYSa5cucyjM3CL/xcQECD58+ePcSDb0t6idnB3795tyiP4QjvDOjldv37dj60DAABAYle6dGlZvXq167l7sLV3797y008/yZw5cyRjxozSvXt3adOmjWzevNksf/DggUlO0IuZLVu2yNmzZ6Vjx47mVsKPPvrIkuMBAACITRqQzJ07t+TIkUPu3btndXNsJUWKFCZwG1OWBW1PnTolPXv2lFWrVkmqVKl8eo1mJYTPdgBgHy3Gb/L7Ppb0qOX3fQQtDfL7PmY1n+X3fQAAHp0GaZ0ZJO6uXbsmU6ZMkRkzZki9evXMvKlTp0rJkiVl27ZtUq1aNVm5cqUcPHjQBH01+zYwMFCGDx8u/fv3N1m82pEHAABIKKUSYlq7FTYL2u7atcukTleoUME1T7MRfvnlF5kwYYLJqA1/sgcMGCB9+vTxyLTNly9fnLYbgMUmP+n/fTz28MU5ACBx+vPPPyVPnjwmyaB69eomiUBvc9O+rGaTaIkvpxIlSphlW7duNUFbfSxbtqxHuQQtoaDlEg4cOCBPPPGERUcFAAAAu7MsaFu/fn3Zt2+fx7xXXnnFdHY1+8BbdD5lypRmAgAAAPytatWqMm3aNFPHVksb6B1ftWvXlv3798u5c+dMpqwOvuFOA7S6TOmje8DWudy5LCKUBAMAAIBlQdv06dNLmTJlPOalTZtWsmbN+tB8AAAAIK41bdrU9Xe5cuVMELdAgQIye/ZsSZ06td/2S0kwAAAAxLwaLgAAAJCIaFZtsWLF5OjRo6bO7d27d+Xq1ase65w/f95VA1cf9Xn45c5lEdGSYFoz1znpWBAAAABIXGwVtF2/fr2MGTPG6mYAAAAAD7l586YcO3bMjJBcsWJFSZ48uaxZs8a1/PDhwxISEmJq3yp91HJgOo6Dkw7CmyFDBilVqlSE+9FyYLqO+wQAAIDExbLyCAAAAICdvfPOO9KiRQtTEuHMmTMyePBgM+7CCy+8IBkzZpTOnTubQXKzZMliAqs9evQwgVodhEw1atTIBGdfeukl+fTTT00d24EDB0q3bt0YpwEAAACRImgLAAAAeHH69GkToL106ZJkz55datWqJdu2bTN/q9GjR0tAQIC0bdvWDBzWuHFjmThxouv1GuBdunSpvPnmmyaYq+M3dOrUSYYNG2bhUQEAACA+IGgLAAAAeDFz5sxIl6dKlUq++OILM0VEs3SXLVvmh9YBAAAgIbNVTVsAAAAAAAAASOwI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADaSzOoGAAAAxKUW4zf5fR9LetTy+z4AAAAAJFxk2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZCTVsAAIDYNvlJ/+/jjQ3+3wcAAAAAS5BpCwAAAAAAAAA2QqYtAABAPBS0NMjv+5jVfJbf9wEAAADgYWTaAgAAAAAAAICNkGkLAAAAAAAssWXOj1Y3AQBsiUxbAAAAAAAAALARgrYAAAAAAAAAYCOURwAAAAAAALDYxD0TI1z2VuBbcdoWeLd9yXGf163SorBf24KEj0xbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANhIMqsbAAAAAMQHH3/8sQwYMEB69uwpY8aMMfPu3Lkjffv2lZkzZ0poaKg0btxYJk6cKDlz5nS9LiQkRN58801Zt26dpEuXTjp16iTBwcGSLBldcQBITCbumWh1EwDEI2TaAgAAAFHYsWOHTJ48WcqVK+cxv3fv3rJkyRKZM2eObNiwQc6cOSNt2rRxLX/w4IE8/fTTcvfuXdmyZYtMnz5dpk2bJoMGDbLgKAAAABBfELQFAAAAInHz5k1p3769fP3115I5c2bX/GvXrsmUKVPk888/l3r16knFihVl6tSpJji7bds2s87KlSvl4MGD8sMPP0hgYKA0bdpUhg8fLl988YUJ5AIAAADeELQFAAAAItGtWzeTLdugQQOP+bt27ZJ79+55zC9RooTkz59ftm7dap7rY9myZT3KJWgJhevXr8uBAwfi8CgAAAAQn1BICwAAAIiA1qrdvXu3KY8Q3rlz5yRFihSSKVMmj/kaoNVlznXcA7bO5c5l3mhtXJ2cNMALAACAxIVMWwAAAMCLU6dOmUHHfvzxR0mVKlWc7VcHKcuYMaNrypcvX5ztGwAAAPZA0BYAAADwQssfXLhwQSpUqCDJkiUzkw42Nm7cOPO3ZsxqXdqrV696vO78+fOSK1cu87c+6vPwy53LvBkwYICpl+ucNHgMAACAxIWgLQAAAOBF/fr1Zd++fbJnzx7XVKlSJTMomfPv5MmTy5o1a1yvOXz4sISEhEj16tXNc33UbWjw12nVqlWSIUMGKVWqlNf9pkyZ0ix3nwAAAJC4UNMWAAAACdbRo0fl2LFjUqdOHUmdOrU4HA5JkiSJT69Nnz69lClTxmNe2rRpJWvWrK75nTt3lj59+kiWLFlMcLVHjx4mUFutWjWzvFGjRiY4+9JLL8mnn35q6tgOHDjQDG6mwVkAAADAG4K2AAAASHAuXbokQUFBsnbtWhOk/fPPP6Vw4cImyJo5c2YZNWpUrOxn9OjREhAQIG3btjWDhzVu3FgmTpzoWp40aVJZunSpvPnmmyaYq0HfTp06ybBhw2Jl/wASuXXBVrcAAOAnBG0BAACQ4PTu3dvUndVSBSVLlnTN10CuZsbGNGi7fv16j+c6QNkXX3xhpogUKFBAli1bFqP9AQAAIHEiaAsAAIAEZ+XKlbJixQrJmzevx/yiRYvKX3/9ZVm7AAAAAF8wEBkAAAASnFu3bkmaNGkemn/58mVqyQIAAMD2LM20nTRpkplOnjxpnpcuXVoGDRokTZs2tbJZAAAAiOdq164t3333nQwfPtw817q2YWFhZjCwunXrWt08AABgI9uXHLe6CYC9grZ6u9rHH39sblPTkXynT58urVq1kt9++80EcAEAAICY0OBs/fr1ZefOnXL37l3p16+fHDhwwGTabt682ermAQAAAPYtj9CiRQtp1qyZCdoWK1ZMPvzwQ0mXLp1s27bNymYBAAAgnitTpowcOXJEatWqZZICtFxCmzZtTHLA448/bnXzAAAAgPgxENmDBw9kzpw5pkNdvXp1q5sDAACAeC5jxozy/vvvW90MAAAAIP4Fbfft22eCtHfu3DFZtgsWLJBSpUp5XTc0NNRMTtevX4/DlgIAACC+mDp1qulbPvfccx7zNUng9u3b0qlTJ8vaBgAAANg+aFu8eHHZs2ePXLt2TebOnWs60Bs2bPAauA0ODpahQ4da0k7YV4vxm/y6/SU9avl1+wAAIPZpv3Hy5MkPzc+RI4e8/vrrBG0BAABga5YHbVOkSCFFihQxf1esWFF27NghY8eO9drJHjBggPTp08cj0zZfvnxx2l4AAADYX0hIiBQqVOih+QUKFDDLAODi+Ak+r5u9R3e/tgUAANsFbcMLCwvzKIHgLmXKlGYCAAAAIqMZtXv37pWCBQt6zP/9998la9aslrULAAAAsH3QVjNnmzZtKvnz55cbN27IjBkzZP369bJixQormwUAAIB47oUXXpC3335b0qdPL3Xq1DHztARXz549pV27dlY3DwAAALBv0PbChQvSsWNHOXv2rBndt1y5ciZg27BhQyubBXia/KT/9/HGBv/vAwCARGT48OFy8uRJqV+/viRLlsx1R5f2PT/66COrmwcAAAD4L2h79+5dOXHihDz++OOuznB0TJky5VF2DwAAAEQ4bsKsWbNM8FZLIqROnVrKli1ratoCAAAACTJoe/v2benRo4dMnz7dPD9y5IgULlzYzHvsscfkvffei+12AgAAANFWrFgxMwEAAAAJPmirtWg1Y0HrzzZp0sQ1v0GDBjJkyBCCtgAAALDUgwcPZNq0abJmzRpTkktLI7hbu3atZW0DAAAA/BK0XbhwobndrFq1apIkSRLX/NKlS8uxY8diskkAAAAg1uiAYxq0ffrpp6VMmTIefVYAAAAgQQZtL168KDly5Hho/q1bt+gQAwAAwHIzZ86U2bNnS7NmzaxuCgAAABBtAdF/iUilSpXkp59+cj13Bmq/+eYbqV69ekw2CQAAAMTqQGRFihSxuhkAAABA3GXafvTRR9K0aVM5ePCg3L9/X8aOHWv+3rJli2zYsCFmLQESsaClQX7fx6zms/y+DwAA7KJv376mjzphwgTuBAMAAEDiCNrWqlXLDEQWHBwsZcuWlZUrV0qFChVk69at5jkAAABgpU2bNsm6devk559/NuMuJE+e3GP5/PnzLWsbAAAAEOtB23v37skbb7whH3zwgXz99dfRfTkAAADgd5kyZZJnnnnG6mYAAAAAcRO01SyFefPmmaAtAAAAYEdTp061ugkAAABA3A5E1rp1a1m4cGHM9woAAAD4mY69sHr1apk8ebLcuHHDzDtz5ozcvHnT6qYBAAAAsV/TtmjRojJs2DDZvHmzVKxYUdKmTeux/O23347JZgEAAIBY8ddff0mTJk0kJCREQkNDpWHDhpI+fXr55JNPzPMvv/zS6iYCAAAAsRu0nTJliqkTtmvXLjO509F5CdoCAADASj179pRKlSqZwXOzZs3qmq91brt06WJp2wAAAAC/BG1PnDgRk5cBAAAAcWLjxo2yZcsWSZEihcf8ggULyt9//21ZuwAASIxGrzri03q9Gxbze1uABF3T1p3D4TATAAAAYBdhYWHy4MGDh+afPn3alEkAAAAAEmTQ9rvvvpOyZctK6tSpzVSuXDn5/vvvY7d1AAAAQAw0atRIxowZ41HCSwcgGzx4sDRr1szStgEAAAB+KY/w+eefywcffCDdu3eXmjVrmnmbNm2Srl27yj///CO9e/eOyWYBAACAWDFq1Chp3LixlCpVSu7cuSMvvvii/Pnnn5ItWzb573//a3XzAAAAgNgP2o4fP14mTZokHTt2dM1r2bKllC5dWoYMGULQFgAAAJbKmzevGYRs5syZsnfvXpNl27lzZ2nfvr25SwwAAABIcEHbs2fPSo0aNR6ar/N0GQAAAGC1ZMmSSYcOHaxuBgAAABA3QdsiRYrI7Nmz5T//+Y/H/FmzZknRokVjskkAAAAg1uj4C5Fxv2MMAAAASBBB26FDh0pQUJD88ssvrpq2mzdvljVr1phgLgAAAGClnj17ejy/d++e3L59W1KkSCFp0qQhaAsAAABbC4jJi9q2bSu//vqrGchh4cKFZtK/t2/fLs8880zstxIAAACIhitXrnhMWtP28OHDUqtWLQYiAwAAQMLMtFUVK1aUH374IXZbAwAAAPiJlvH6+OOPTZ3bQ4cOWd0cAAAAIHYzbZctWyYrVqx4aL7O+/nnn2OySQAAACBOBic7c+aM1c0AAAAAYj/T9r333jNZCuE5HA6zrGnTpjHZLAAAABArFi9e/FA/9ezZszJhwgTXmAwAAMBeRq864tN6vRsW83tbgHgZtP3zzz+lVKlSD80vUaKEHD16NDbaBQAAAMRY69atPZ4nSZJEsmfPLvXq1ZNRo0ZZ1i4AAADAb0HbjBkzyvHjx6VgwYIe8zVgmzZt2phsEgAAAIg1YWFhVjcBAAAAiNuatq1atZJevXrJsWPHPAK2ffv2lZYtW8a8NQAAAAAAAACQyMUo0/bTTz+VJk2amHIIefPmNfNOnTolderUkZEjR8Z2GwEAAIBo6dOnj8/rfv75535tCwAg7m2Z86PP69Z4rr1f2wIAcVoeYcuWLbJq1Sr5/fffJXXq1FK+fHmpXbt2jBoBAAAAxKbffvvNTPfu3ZPixYubeUeOHJGkSZNKhQoVPGrdAgAAAPE6aLt161a5dOmSNG/e3HRwGzVqZEbhHTx4sNy+fdsM+DB+/HhJmTKl/1oMAAAARKFFixaSPn16mT59umTOnNnMu3Llirzyyism0UDLegEAAAAJoqbtsGHD5MCBA67n+/btky5dukjDhg3lvffekyVLlkhwcLA/2gkAAAD4bNSoUaZf6gzYKv17xIgRZhkAAACQYDJt9+zZI8OHD3c9nzlzplSpUkW+/vpr8zxfvnwm63bIkCGx31IAQLS0GL/J7/tY0qOW3/cBADFx/fp1uXjx4kPzdd6NGzcsaRMAAADgl0xbvaUsZ86crucbNmyQpk2bup5XrlzZDEgGAAAAWOmZZ54xpRDmz58vp0+fNtO8efOkc+fO0qZNG6ubBwAAAMRe0FYDtidOnDB/3717V3bv3i3VqlVzLdesheTJk0dnkwAAAECs+/LLL01ywYsvvigFChQwk/7dpEkTmThxotXNAwAAAGKvPEKzZs1M7dpPPvlEFi5cKGnSpDEDOTjt3btXHn/88ehsEgAAAIh12k/V4Oxnn30mx44dM/O0n5o2bVqrmwYAABKB7UuO+7xulRaF/doWJIJMW61nmyxZMnnyySdNHVudUqRI4Vr+7bffSqNGjfzRTgAAACDazp49a6aiRYuagK3D4bC6SQAAAEDsBm2zZcsmv/zyi6ltq5PWCnM3Z84cMxAZAAAAYKVLly5J/fr1pVixYuZuMQ3cKq1p27dvX5+2MWnSJClXrpxkyJDBTNWrV5eff/7ZtfzOnTvSrVs3yZo1q6RLl07atm0r58+f99hGSEiIPP300ybzN0eOHPLuu+/K/fv3Y/loAQAAkKiDtk4ZM2aUpEmTPjQ/S5YsHpm3AAAAgBV69+5txlrQoKkGTJ2CgoJk+fLlPm0jb9688vHHH8uuXbtk586dUq9ePWnVqpUcOHDAtY8lS5aYxAUdoPfMmTMeg5w9ePDABGx1LIgtW7bI9OnTZdq0aTJo0CA/HDEAAAASbU1bAAAAID5YuXKlrFixwgRe3WmZhL/++sunbbRo0cLj+Ycffmiyb7dt22a2O2XKFJkxY4YJ5qqpU6dKyZIlzXIdrFfbcPDgQVm9erUZ0DcwMNCUG+vfv78MGTKEZAcAAADEbqYtAAAAYGe3bt3yyLB1unz5sqRMmTLa29Os2ZkzZ5rtapkEzb69d++eNGjQwLVOiRIlJH/+/LJ161bzXB/Lli1rArZOjRs3luvXr7uydb0JDQ0167hPAAAASFwI2gIAACDBqV27tnz33Xeu50mSJJGwsDD59NNPpW7duj5vZ9++faZerQZ6u3btKgsWLJBSpUrJuXPnTKZspkyZPNbXAK0uU/roHrB1Lncui0hwcLApR+ac8uXL53N7AQAAkDBQHgEAAAAJjgZndSAyrUWrNWX79etnsls103bz5s0+b6d48eKyZ88euXbtmsydO1c6depk6tf604ABA6RPnz6u55ppS+AWAAAgcSFoCwAAgASnTJkycuTIEZkwYYKkT59ebt68aQYJ69atm+TOndvn7Wg2bZEiRczfFStWlB07dsjYsWPNgGYaDL569apHtu358+clV65c5m993L59u8f2dLlzWUQ0qzcmJRwAAACQcBC0BQAAQIKitWabNGkiX375pbz//vuxum0tsaA1ZzWAmzx5clmzZo20bdvWLDt8+LCEhISYmrdKH3XwsgsXLkiOHDnMvFWrVkmGDBlMiQUAAAAgIgRtAQAAkKBoMHXv3r2xUqagadOmZnCxGzduyIwZM2T9+vWyYsUKU2u2c+fOpoxBlixZTCC2R48eJlBbrVo18/pGjRqZ4OxLL71kyjVoHduBAweabF8yaQEAABAZBiIDAABAgtOhQweZMmXKI21DM2Q7duxo6tpqfVwtjaAB24YNG5rlo0ePlubNm5tM2zp16piSB/Pnz3e9PmnSpLJ06VLzqMFcbZNub9iwYY98fAAAAEjYyLQFAABAgnP//n359ttvZfXq1aaUQdq0aT2Wf/7551FuI6qgb6pUqeSLL74wU0QKFCggy5Yti0bLgbhxcfwEn9fN3qO7X9sCAAAeRtAWAAAACcbx48elYMGCsn//fqlQoYKZpwOSuUuSJIlFrQMAAAB8Q9AWAAAACUbRokXl7Nmzsm7dOvM8KChIxo0bJzlz5rS6aQAAAIDPqGkLAACABMPhcHg8//nnn+XWrVuWtQcAAACICYK2AAAASDRBXAAAACA+IGgLAACABEPr1YavWUsNWwAAAMQ31LQFAABAgsqsffnllyVlypTm+Z07d6Rr166SNm1aj/Xmz59vUQsBAACAqBG0BQAAQILRqVMnj+cdOnSwrC0AAABATBG0BQAAQIIxdepUq5sAAAAAPDJq2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZCTVsAQMxNftL/+3hjg//3AQAAAACAjZBpCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjlgZtg4ODpXLlypI+fXrJkSOHtG7dWg4fPmxlkwAAAAAAAADAUpYGbTds2CDdunWTbdu2yapVq+TevXvSqFEjuXXrlpXNAgAAAAAAAADLJLNu1yLLly/3eD5t2jSTcbtr1y6pU6eOZe0CAAAAAAAAAKvYqqbttWvXzGOWLFmsbgoAAAAAAAAAJL5MW3dhYWHSq1cvqVmzppQpU8brOqGhoWZyun79ehy2EAAAAAAAAAASUaat1rbdv3+/zJw5M9KByzJmzOia8uXLF6dtBAAAAAAAAIBEEbTt3r27LF26VNatWyd58+aNcL0BAwaYEgrO6dSpU3HaTgAAAAAAAABI0OURHA6H9OjRQxYsWCDr16+XQoUKRbp+ypQpzQQAAAAAAAAACVUyq0sizJgxQxYtWiTp06eXc+fOmfla+iB16tRWNg0AAAAAgMRhXXDU69QdEBctAQDYoTzCpEmTTJmDp556SnLnzu2aZs2aZWWzAAAAAAAAACDxlkcAAAAAAAAAANhsIDIAAAAAAAAAgA0ybQEAAAAAAIDEbPuS4z6tV6VFYb+3BfZBpi0AAAAAAAAA2AhBWwAAAAAAAACwEcojAAAAAAAA2NjEPRMjXf5W4Ftx1hYAcYNMWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEaoaQsAAAAAAJBAa95S7xaIn8i0BQAAAAAAAAAbIdMWAAAAAAA7WRdsdQsAABYj0xYAAAAAAAAAbISgLQAAAAAAAADYCOURAAAAAACIxMXxE3xeN3uP7n5tCwAgcSDTFgAAAAAAAABshExbAICtBS0N8vs+ZjWf5fd9AAAAAADgKzJtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAA8CI4OFgqV64s6dOnlxw5ckjr1q3l8OHDHuvcuXNHunXrJlmzZpV06dJJ27Zt5fz58x7rhISEyNNPPy1p0qQx23n33Xfl/v37cXw0AAAAiE8I2gIAAABebNiwwQRkt23bJqtWrZJ79+5Jo0aN5NatW651evfuLUuWLJE5c+aY9c+cOSNt2rRxLX/w4IEJ2N69e1e2bNki06dPl2nTpsmgQYMsOioAAADEB8msbgAAAABgR8uXL/d4rsFWzZTdtWuX1KlTR65duyZTpkyRGTNmSL169cw6U6dOlZIlS5pAb7Vq1WTlypVy8OBBWb16teTMmVMCAwNl+PDh0r9/fxkyZIikSJHCoqMDACBh277kuNVNAB4JmbYAAACADzRIq7JkyWIeNXir2bcNGjRwrVOiRAnJnz+/bN261TzXx7Jly5qArVPjxo3l+vXrcuDAgTg/BgAAAMQPZNoCAAAAUQgLC5NevXpJzZo1pUyZMmbeuXPnTKZspkyZPNbVAK0uc67jHrB1Lncu8yY0NNRMThrgBQAAQOJCpi0AAAAQBa1tu3//fpk5c2acDICWMWNG15QvXz6/7xMAAAD2QtAWAAAAiET37t1l6dKlsm7dOsmbN69rfq5cucwAY1evXvVY//z582aZcx19Hn65c5k3AwYMMKUYnNOpU6f8cFQAAACwM4K2AAAAgBcOh8MEbBcsWCBr166VQoUKeSyvWLGiJE+eXNasWeOad/jwYQkJCZHq1aub5/q4b98+uXDhgmudVatWSYYMGaRUqVJe95syZUqz3H0CAABA4kJNWwAAACCCkggzZsyQRYsWSfr06V01aLVkQerUqc1j586dpU+fPmZwMg2u9ujRwwRqq1WrZtZt1KiRCc6+9NJL8umnn5ptDBw40Gxbg7MAAACANwRtAQAAAC8mTZpkHp966imP+VOnTpWXX37Z/D169GgJCAiQtm3bmsHDGjduLBMnTnStmzRpUlNa4c033zTB3LRp00qnTp1k2LBhcXw0AAAAiE8I2gIAAAARlEeISqpUqeSLL74wU0QKFCggy5Yti+XWAXHn4vgJPq+bvUd3v7YFAIDEgpq2AAAAAAAAAGAjZNoCAAAAAADAGL3qiNVNAECmLQAAAAAAAADYC5m2AAAAAJDIas8CAAB7I9MWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjDEQGAAAAAABizZY5P1rdBACI98i0BQAAAAAAAAAbIWgLAAAAAAAAADZCeQQAAAAAAADEG6NXHYlynaTHr5nHaoWzxkGLgNhHpi0AAAAAAAAA2AiZtgAAAACABOHi+AlWNwEAgFhBpi0AAAAAAAAA2AiZtgAAAAAAAI9o4p6JVjcBQAJCpi0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCPJrG4AAAAAAAARuTh+gtVNAAAgzpFpCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjyazc+S+//CKfffaZ7Nq1S86ePSsLFiyQ1q1bW9kkAAAAAICfXRw/weomAABga5Zm2t66dUvKly8vX3zxhZXNAAAAAAAAAADbsDTTtmnTpmYCAAAAAAAAAPwPNW0BAAAAAAAAwEYszbSNrtDQUDM5Xb9+3dL2AAAAAAAAAECizrQNDg6WjBkzuqZ8+fJZ3SQAAAAAAAAASLxB2wEDBsi1a9dc06lTp6xuEgAAAAAAAAAk3vIIKVOmNBMAAAAAAAAAJFSWBm1v3rwpR48edT0/ceKE7NmzR7JkySL58+e3smkAAAAAAAAeJu6ZaHUTACQSlgZtd+7cKXXr1nU979Onj3ns1KmTTJs2zcKWAQAAAAAAAPaxfclxn9et0qKwX9uCBB60feqpp8ThcFjZBAAAAAAAAACwlXg1EBkAAAAAAAAAJHQEbQEAAAAAAADARiwtjwAAAAAAAAD/G73qiNVNABANZNoCAAAAAAAAgI2QaQsAAAAAiBUXx0+wugkAACQIZNoCAAAAEfjll1+kRYsWkidPHkmSJIksXLjQY7nD4ZBBgwZJ7ty5JXXq1NKgQQP5888/Pda5fPmytG/fXjJkyCCZMmWSzp07y82bN+P4SAAAABCfkGkLAAAARODWrVtSvnx5efXVV6VNmzYPLf/0009l3LhxMn36dClUqJB88MEH0rhxYzl48KCkSpXKrKMB27Nnz8qqVavk3r178sorr8jrr78uM2bMsOCIAADhbZnzo+8rF/VnSwDg/xG0BQAAACLQtGlTM3mjWbZjxoyRgQMHSqtWrcy87777TnLmzGkyctu1ayd//PGHLF++XHbs2CGVKlUy64wfP16aNWsmI0eONBm8AJDgApsAgEdGeQQAAAAgBk6cOCHnzp0zJRGcMmbMKFWrVpWtW7ea5/qoJRGcAVul6wcEBMivv/7qdbuhoaFy/fp1jwkAAACJC5m2AAAAQAxowFZpZq07fe5cpo85cuTwWJ4sWTLJkiWLa53wgoODZejQoX5rNwCLrQu2ugUAgHiATFsAAADARgYMGCDXrl1zTadOnbK6SQAAAIhjBG0BAACAGMiVK5d5PH/+vMd8fe5cpo8XLlzwWH7//n25fPmya53wUqZMKRkyZPCYAAAAkLhQHgEAAACIgUKFCpnA65o1ayQwMNDM0/qzWqv2zTffNM+rV68uV69elV27dknFihXNvLVr10pYWJipfQsA8caJTb6tV6iWv1sCAIkCQVsAAAAgAjdv3pSjR496DD62Z88eU5M2f/780qtXLxkxYoQULVrUBHE/+OADyZMnj7Ru3dqsX7JkSWnSpIl06dJFvvzyS7l37550795d2rVrZ9YDAAAAvCFoCwAAAERg586dUrduXdfzPn36mMdOnTrJtGnTpF+/fnLr1i15/fXXTUZtrVq1ZPny5ZIqVSrXa3788UcTqK1fv74EBARI27ZtZdy4cZYcDwAAAOIHgrYAAABABJ566ilxOBwRLk+SJIkMGzbMTBHRrNwZM2b4qYUAbOXkRpF1N6xuBQAgASBoCwAAAAAAkEBN3DPRPO6+fsnr8goZguK4RQB8EeDTWgAAAAAAAACAOEGmLQAAAAAAAGwv6cFrVjcBiDNk2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNJLO6AQAAAAAAAHaw49yOSJcnL1osztoCIHEjaAsAAAAAAIAEadvxSz6tV61wVr+3BYgOyiMAAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEgcgAAAAAAEDsOLEp6nUK1YqLlgBAvEbQFgAAAACAWHJx6R6f183ePNCvbQEAxF+URwAAAAAAAAAAGyFoCwAAAAAAAAA2QnkEAAAAAACQKOw4t0MSkq3HLlndhEeW9OA1q5sA2BKZtgAAAAAAAABgI2TaAgAAAACQyGzZEWJ1EwAAkSDTFgAAAAAAAABshKAtAAAAAAAAANgI5REAAAAAAIjKyY1WtwA2cG/jEZ/XTV67mF/bAiBhI2gLAAAAADZ1cfwEq5sAIIHbfX1WpMsrZAiKs7YA+H+URwAAAAAAAAAAGyFoCwAAAAAAAAA2QnkEAAAAAAASgC07QiReOLEp6nUK1YqLlsCPkh68ZnUTErXtS477vG6VFoX92hbEDEFbAAAAAACQYOw4t8PqJgDAIyNoCwAAAAAAYCNbj12yugkALEZNWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEaoaQsAAAAAABDL7m08Eq31k9cuJna0+/qsCJdVyBAkCcW2477VEa5WOKvf2wIogrYAAAAAAABx4PTlfyNcdo7BxwC4IWgLAAAAAHHo4vgJVjcB7k5utLoFAGCp7UuO+7xulRaF/doW/D+CtgAAAAAAAIjV0gl5Q/NJ7pSl47Q9QEJC0BYAAAAAAJvasiPE6iYALnmP5bO6CUCiQdAWAAAAAAALXFy6J8p1bl27ax7TFssVBy1CbNepBYCYImgLAAAAAADs5cSmqNcpVCsuWgIAlgiwZrcAAAAAAAAAAG/ItAUAAAAAJEwnN1rdAvjBjjvn//fHuR1WNwUA/IagLQAAAAA8oovjJ1jdBCDhBWUR750NPRDp8twpS0t8s+34JZ/XrVY4q1/bgoSNoC0AAAAAIP5lyBasHRctgZ0Ds1dCfFsvc35bDxyW4UqG/z1uvB7lutcz/2+dc2XyRrpe3mP5fN7/6cdP+bwusH3JcZ/Wq9KisN/bktDZImj7xRdfyGeffSbnzp2T8uXLy/jx46VKlSpWNwsAAACINfR54x+yZ5HYA6eVU+WMs7bAOtEJ8AJIREHbWbNmSZ8+feTLL7+UqlWrypgxY6Rx48Zy+PBhyZEjh9XNAwAAAB4ZfV4g4der3XPtrtjFrSPnfFsxfxKxu+t37vm0XoZUyX3OyM0Q+vA2r6fMI/GB71m5/1+W4Hae+FeCAIANgraff/65dOnSRV555RXzXDuyP/30k3z77bfy3nvvWd08AAAA4JHR5wXsGWiNT3wOxMaT2rK+BmOt2l5sBVfxaDVv43s9XF/r3ybE2re+llFQlFKwYdD27t27smvXLhkwYIBrXkBAgDRo0EC2bt1qZdMAAACAWEGf114oeZAwa8xGJ8s1MGMKSUjO3L8V4bI8ydLGaVvsFjj1h/gYjE1zxvfAKFm5gH1YGrT9559/5MGDB5Izp2edHH1+6NChh9YPDQ01k9O1a9fM4/XrURfrjk33/o34SzG2XH9w3+/7uHfb/1+ocXFu/H0+OBe+4/8N33E+fMf5sM/54Fz4jv83Hm1/DodDEpL42uf958vJPq+bresbftkuIhGyVfZejyJQmfH/Byoql+9xnze999Sxh2de8/5vZ7kMbgHQw2sj325U7Y1ouz64ddf3fxNvhMa8JMDfVyMewOrcvTDX3+lTRnKrfvjX3b8tsSn0wf+346pE/p6nPBQg/zqirmf6IOx//y4nl8gH/nKGMy/kTSUpbzzmU3vTXLsX5XZj4lpG3z/z2obU4tvgZLczRv4dH5rUt0B5ygdR90d82ZYv2/GV7i/gxG6f1/83d0mx0sk7OyX12T8iXJ4uaXaP50nz1XL9fS704e9fd7lSlpC4tP7gTZ/Wq1Qwi8/b3Hnycqxv01/Wzvrd0v1XalrIln1ey8sjREdwcLAMHTr0ofn58iW8otkZJWFYIAskvuNc2Avnw144H/aSEM4H58JerDofN27ckIwZE8q7mEj6vP37Wd0CAAhng9UNAIBH6vNaGrTNli2bJE2aVM6f96yTo89z5cr10Pp6S5kO4OAUFhYmly9flqxZs0qSJPYvoO7PCL124k+dOiUZMsS/WzUSGs6HvXA+7INzYS+cD3vhfIgr20A7r3nyxI/BYHxFn9d/+H/Hvjg39sW5sTfOj31xbuzrejw7N772eS0N2qZIkUIqVqwoa9askdatW7s6pfq8e/fuD62fMmVKM7nLlClTnLXX7vSDGR8+nIkF58NeOB/2wbmwF86HvXA+JEFm2NLn9T/+37Evzo19cW7sjfNjX5wb+8oQj86NL31ey8sjaBZBp06dpFKlSlKlShUZM2aM3Lp1yzWyLgAAABDf0ecFAABAdFgetA0KCpKLFy/KoEGD5Ny5cxIYGCjLly9/aKAGAAAAIL6izwsAAIB4FbRVeluYt1vD4Bu9fW7w4MEP3UYHa3A+7IXzYR+cC3vhfNgL5yNxoM8b+/h/x744N/bFubE3zo99cW7sK2UCPTdJHFr9FgAAAAAAAABgCwFWNwAAAAAAAAAA8P8I2gIAAAAAAACAjRC0BQAAAAAAAAAbIWibAHzxxRdSsGBBSZUqlVStWlW2b99udZMSpV9++UVatGghefLkkSRJksjChQutblKiFRwcLJUrV5b06dNLjhw5pHXr1nL48GGrm5VoTZo0ScqVKycZMmQwU/Xq1eXnn3+2ulkQkY8//tj8e9WrVy+rm5IoDRkyxLz/7lOJEiWsbhYQL9Dvsi/6YfZFnyz+oI9mL/TZ7O3vv/+WDh06SNasWSV16tRStmxZ2blzpyQEBG3juVmzZkmfPn3MKHm7d++W8uXLS+PGjeXChQtWNy3RuXXrlnn/NYgOa23YsEG6desm27Ztk1WrVsm9e/ekUaNG5hwh7uXNm9d0PHft2mW+POvVqyetWrWSAwcOWN20RG3Hjh0yefJkc/EG65QuXVrOnj3rmjZt2mR1k4B4gX6XfdEPsy/6ZPEDfTR7os9mT1euXJGaNWtK8uTJzY9QBw8elFGjRknmzJklIUjicDgcVjcCMaeZtfpL9oQJE8zzsLAwyZcvn/To0UPee+89q5uXaOkvbwsWLDCZBbDexYsXTaaHXkTUqVPH6uZARLJkySKfffaZdO7c2eqmJEo3b96UChUqyMSJE2XEiBESGBgoY8aMsbpZiTJrQ7MD9+zZY3VTgHiNfpe90Q+zN/pk9kIfzZ7os9nXe++9J5s3b5aNGzdKQkSmbTx29+5d8ytpgwYNXPMCAgLM861bt1raNsBOrl275uqUwloPHjyQmTNnmmwbvSUP1tAMqKefftrj+wPW+PPPP83t3YULF5b27dtLSEiI1U0CgFhFP8ye6JPZE300+6LPZk+LFy+WSpUqyXPPPWd+IHziiSfk66+/loQimdUNQMz9888/5ss2Z86cHvP1+aFDhyxrF2Anmn2utaD0lokyZcpY3ZxEa9++feaC4M6dO5IuXTqTEVWqVCmrm5Uo6QWaltPRW+9g/d0y06ZNk+LFi5vb7IYOHSq1a9eW/fv3m1qQABDf0Q+zH/pk9kUfzb7os9nX8ePHTb1uLRv6n//8x/z/8/bbb0uKFCmkU6dOEt8RtAWQ4H+t1i9Tag5ZSzs4ejuRZtvMnTvXfIHqbZJcJMStU6dOSc+ePU2NQR28EtZq2rSp62+tW6cXBAUKFJDZs2dzmyqABIF+mP3QJ7Mn+mj2Rp/N3j8OVqpUST766CPzXDNt9Xvnyy+/TBBBW8ojxGPZsmWTpEmTyvnz5z3m6/NcuXJZ1i7ALrp37y5Lly6VdevWmYEXYB39pbNIkSJSsWJFM6q0Dh4zduxYq5uV6GhJHR2oUmulJUuWzEx6oTZu3Djzt969AetkypRJihUrJkePHrW6KQDwyOiH2RN9Mnuijxa/0Gezj9y5cz/0o1PJkiUTTPkKgrbx/AtXv2zXrFnj8SuDPqcuERIzHV9RLxT0dq+1a9dKoUKFrG4SwtF/q0JDQ61uRqJTv359c1ukZtg4J/1lWuty6d/6QyCsHXzk2LFjpvMJAPEV/bD4hT6ZPdBHi1/os9lHzZo15fDhwx7zjhw5YjKhEwLKI8RzWrdDU771H/QqVaqYkSW1mPwrr7xiddMS5T/c7r+0nThxwnzB6qAL+fPnt7RtifFWvBkzZsiiRYtMjaFz586Z+RkzZpTUqVNb3bxEZ8CAAeaWIv3/4MaNG+bcrF+/XlasWGF10xId/f8hfE3BtGnTStasWak1aIF33nlHWrRoYTqVZ86ckcGDB5uLshdeeMHqpgG2R7/LvuiH2Rd9Mvuij2Zv9Nnsq3fv3lKjRg1THuH555+X7du3y1dffWWmhICgbTwXFBQkFy9elEGDBpkOUWBgoCxfvvyhwcngfzt37pS6det6BNSVBtW1aDnijhYiV0899ZTH/KlTp8rLL79sUasSL73Vq2PHjqZov16waR0ovTho2LCh1U0DLHX69GnT2b906ZJkz55datWqJdu2bTN/A4gc/S77oh9mX/TJgJihz2ZflStXNnd26I9Sw4YNM3d3aDKjZqknBEkcev8KAAAAAAAAAMAWqGkLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAGxlyJAhEhgYaHUzAMAyBG0BIBIvv/yyJEmSxEzJkyeXnDlzSsOGDeXbb7+VsLAwSQymTZsmmTJlsroZAAAAeEQXL16UN998U/Lnzy8pU6aUXLlySePGjWXz5s2SEGiffeHChbG+3fXr15ttX716Nda3DQARSRbhEgCA0aRJE5k6dao8ePBAzp8/L8uXL5eePXvK3LlzZfHixZIsGf+UAgAAwP7atm0rd+/elenTp0vhwoVN33bNmjVy6dIlv+1T95ciRQq/bR8AEioybQEgCs4shMcee0wqVKgg//nPf2TRokXy888/myxUFRISIq1atZJ06dJJhgwZ5PnnnzedYHdLliyRypUrS6pUqSRbtmzyzDPPRJoVoNmtzu2fPHnSrDN79mypXbu2pE6d2mzryJEjsmPHDqlUqZLZd9OmTU0GhbtvvvlGSpYsafZbokQJmThxomuZc7vz58+XunXrSpo0aaR8+fKydetWV1bBK6+8IteuXXNlHOutagAAAIhfNEt048aN8sknn5h+X4ECBaRKlSoyYMAAadmypcd6b7zxhrnDTPuPZcqUkaVLl7qWz5s3T0qXLm36yAULFpRRo0Z57EfnDR8+XDp27Gj6xa+//rqZv2nTJlc/Nl++fPL222/LrVu3fG6/9nn1jjftR2fMmFGefPJJ2b17t8d+lfaxtc/qfK607679eD0eDVYPHTpU7t+/71qu62ufWV+r/eGiRYua5Axnf1nfL5U5c2azrt6NBwD+RtAWAGKgXr16JripwU4tk6AB28uXL8uGDRtk1apVcvz4cQkKCnKt/9NPP5lOYLNmzeS3334zGQ3aSY6uwYMHy8CBA00HVTN8X3zxRenXr5+MHTvWdMKPHj0qgwYNcq3/448/mucffvih/PHHH/LRRx/JBx98YLIr3L3//vvyzjvvyJ49e6RYsWLywgsvmI5sjRo1ZMyYMabDffbsWTPpegAAAIhf9Ad+nTRRIDQ01Os62q/VJAAtl/DDDz/IwYMH5eOPP5akSZOa5bt27TLJCe3atZN9+/aZH/O1b+lMNHAaOXKk6Strv1eXHzt2zNy9ppm+e/fulVmzZpkgbvfu3X1u/40bN6RTp07mddu2bTOBVe1b63xnUFfpHXLaZ3U+1z6yBpD1Tjk9nsmTJ5v2av/YnQZy9di0fbrd9u3bm/69Bpg1UK0OHz5stq19bwDwOwcAIEKdOnVytGrVyuuyoKAgR8mSJR0rV650JE2a1BESEuJaduDAAYf+E7t9+3bzvHr16o727dtHuB9dd8GCBR7zMmbM6Jg6dar5+8SJE2adb775xrX8v//9r5m3Zs0a17zg4GBH8eLFXc8ff/xxx4wZMzy2O3z4cNOeiLbrbPsff/xhnmsbtC0AAACI3+bOnevInDmzI1WqVI4aNWo4BgwY4Pj9999dy1esWOEICAhwHD582OvrX3zxRUfDhg095r377ruOUqVKuZ4XKFDA0bp1a491Onfu7Hj99dc95m3cuNHs699///W6r8GDBzvKly8f4bE8ePDAkT59eseSJUsi7VPXr1/f8dFHH3nM+/777x25c+f2eN3AgQNdz2/evGnm/fzzz+b5unXrzPMrV65E2B4AiG1k2gJADGn/Tm+P0gxW/QVeJ6dSpUqZ8ga6TGkGa/369R95n+XKlXP9rbesqbJly3rMu3DhgvlbbzfTrIbOnTu7Mit0GjFihJkf0XZz585tHp3bAQAAQMKgma5nzpwxt/5r5quWwtKyAc5MWe2z5s2b19x55Y32bWvWrOkxT5//+eefZvwHJy3d5e733383+3Dvk+oAaJrZe+LECZ/arqXHunTpYjJstTyC3gl28+ZNU6YsMrrvYcOGeexbt6MZs7dv3/baH06bNq3ZPv1hAFZi9BwAiCHttBYqVMindbV2V2Q0+Pu/H/n/37179x5aL3ny5B6v8TZPO79KO7Hq66+/lqpVq3psx3mLW2TbdW4HAAAACYfWddXasDpp6YLXXnvNlODSOq1R9Vl9pUFPd9ov1Tq5Wsc2vPz58/u0TS2NoAOmaWkCrcerNXWrV69uBjqLjO5bSx+0adPG63vhrT8cvl8NAFYgaAsAMbB27VpTx6t3794mG+HUqVNmcmbbar0sHcRBM26dv9xrHVsd1Mub7Nmzm1/7nTRbwf2X/5jQrNs8efKY+rpakyumdLRf98wJAAAAJBzaX3UOiKt91tOnT5vBbr1l2+rgtlrv1p0+13XDJwW402xe7R8XKVIkxu3U/eiAulpvVmnf+59//vFYRwOv4futum+tRfso+9b+sKJPDCAuEbQFgCjoQA3nzp0znTS9LWv58uUSHBwszZs3N4MaBAQEmBIFGhjVQbt0AK+33nrLjGjrvDVMsxe0PMLjjz9uBm7QdZYtWyb9+/d3DWw2YcIEky2g+9H54X/tjwnNKtCMBr2FTG+B02PZuXOnXLlyRfr06ePTNnTkXc1Q0KCzDiihI+rqBAAAgPhDs1Sfe+45efXVV01wNn369KZf+Omnn5pBdZX2X+vUqWPKKHz++ecm0Hno0CGTdap9yb59+0rlypVl+PDhZtDdrVu3mj6sBlMjo33batWqmYHHNLNXM3E1iKsD+OrrfaFlEb7//nvTv75+/bq8++67D2UGa79V+6xaskEzcTNnzmwG5dV+u2b0Pvvss6bvriUT9u/fb8qG+UIze/U9WLp0qQka6361zAIA+BM1bQEgChqk1Tqv2gnUzuq6detk3LhxsmjRIpNRoB04/Vs7hdrJbdCggRQuXNiMiuv01FNPyZw5c0z9sMDAQBOk3b59u2v5qFGjTJZu7dq15cUXX5R33nknVgKj2in+5ptvzCi6GljWjrjWE/O1rIOqUaOGdO3a1XTMNSNYO/YAAACIXzTIqCWzRo8ebfqsZcqUMeURtL6re+B03rx5JjD7wgsvmCzcfv36uTJMNWt19uzZMnPmTPN6DYhqvVgtrRAZDRJv2LDBZPBqf/eJJ54wr9W7wnw1ZcoUk3igbXjppZdMYkKOHDk81tE+tQaCtV+t+1BaO1eDrStXrjTHpcFjfQ80EOurxx57zCRDvPfee+ZuNg0+A4C/JdHRyPy+FwAAAAAAAACAT8i0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAAIh9/B9IAAXDF+PKEgAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHqCAYAAAB/bWzAAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAeg9JREFUeJzt3Qd4FFX3+PEDJITeu/TeiaB0UHovghIVBBWxAdJURFGqoAhSBXwVAVFeepdepUoTQZAOAlJFpJMA2f9z7u+/++6mbsJudrL5fp5nTHZmdubuTGTvnDlzbjKbzWYTAAAAAAAAAIAlJPd1AwAAAAAAAAAA/0PQFgAAAAAAAAAshKAtAAAAAAAAAFgIQVsAAAAAAAAAsBCCtgAAAAAAAABgIQRtAQAAAAAAAMBCCNoCAAAAAAAAgIUQtAUAAAAAAAAACyFoCwAAAAAAAAAWQtAWAJCgnn76aTMBAICkYeDAgZIsWTKf9DM2btxo9j1v3rwE2f/LL78sBQsWTJB9QWTatGnm/J4+fTpJHY6k+rmBpIagLQC3HThwQJ599lkpUKCApEqVSh577DFp0KCBjB8/nqPoZVu2bJEmTZqYY67HPn/+/NKiRQuZOXNmkjn2d+7cMRd9evGVECZOnGg6xAAAIHKwyD5pvyRPnjzSqFEjGTdunNy8edMjh+v8+fPme3/fvn2WO/xWbpvVJHT/DQD8CUFbAG7Ztm2bPPHEE/Lbb79Jly5dZMKECfLaa69J8uTJZezYsRxFL5o7d67Url1bLl26JD169DBB8g4dOsi1a9fkm2++SVKd/kGDBhG0BQDAAgYPHiwzZsyQSZMmSffu3c28nj17Srly5WT//v0u6/bv31/u3r0b58Cofu/HNTC6evVqM3lTTG3TvtmRI0e8uv/ExNv9t5deesn8bWlSCQD4mwBfNwBA4vDpp59KxowZZdeuXZIpUyaXZZcvX07w9ty+fVvSpk0rSYFmJ5QuXVp27NghKVOm9Nmxt9lscu/ePUmdOnWC7RMAAFiTPgGkN/Tt+vXrJ+vXr5fmzZtLy5Yt5Y8//nD0GQICAszk7eBgmjRpIvWVElpgYKBP959U2K8FUqRIYaaE9uDBAwkPD/f531tSk5SuAQFFpi0At5w4cULKlCkTKWCrcuTIEakTM2TIEClSpIgEBQWZul4ffvihhIaGuqynj9RpQDIiXV/rgUV8DG/Tpk3y9ttvm/3lzZvXsXzFihXy1FNPSfr06SVDhgzy5JNPRiob8Msvv0jjxo1N4Fk79Lr+1q1bXdbRx/k0Q0T3r+3W/Wj5h71790Z7XLQ+mr1tEX399ddm2e+//25eX7x4UV555RXTdt1+7ty5pVWrVrHWotJjr58pqk5hxGOvnUfNfNYsF31cMXv27OZz7969O87nR+frhdeqVavMRZleeOlnUv/++685Vvny5TPbKFq0qHz++edm/3EVFhYmn3zyiVSqVMmcH+2I1apVSzZs2OBYR4+Rfhal2Rr2RzKd/34OHz5syndkyZLFfHZt85IlS1z2Zf9b0nPfu3dvs03d3zPPPCNXrlxx+ewHDx4059W+L+rwAgAQs7p168rHH38sf/75p/zwww8x1rRds2aN1KxZ0/Qt06VLJyVKlDD9EaVZmdr3Udp3sn8X28sW6Xdy2bJlZc+ePeZpJO3b2d8bXe38hw8fmnVy5cplvvs1sHz27NkY+6B2ztuMrW1R1bTVQFOfPn0c/Sb9rCNHjjQ3xJ3pdrp16yaLFi0yn0/X1f73ypUrH7nP6nwetM/Url0702/OmjWreZJLb8w7c7e/qH1MLY2RLVs201csVKiQvPrqq17pv0V1LRBdbVe9PtD+pJ5rvUZo1qyZ6dtFd16dRTyHum3dh56zMWPGOI7JoUOH3P4M9+/fN8egWLFiZh097vr3r/8fxEbbrf9v6fHVzz106NBo+9zufO74XpO4+z53rs30SULt++tn0r8dfYrwr7/+inQe9N8GvRZq2rSp2V779u3NMv38ei70/w89njlz5pQ33njDPIno7t8nkBiQaQvALfrI0fbt200AUjuRMdGyCdOnTzedF+2gasB0+PDhJuNi4cKF8T7i2knTjp8G+LTza++o6RevfmFrhod2/H/99VfTuX3xxRfNOpr1odkg2jEYMGCAKekwdepU0/nZvHmzVK5c2az35ptvmiCsdpY1s/Xq1aumlqy2u2LFilG2STtC2pmYM2eO6Zw4mz17tmmX/Xi1bdvWdJr0EULtCGqWrHbUzpw5E+OAFXrs161bJ+fOnXMJVkelc+fO5pjo59XzoB1u/YyapWvPhonL+dHH+1544QXTCdKyGHqRoZks+lm1Y6Xztb6uls/Q43/hwgXTgYqLGzduyLfffmv2o/vQC5EpU6aYDtbOnTslODjYnHd9/PKtt94yAdY2bdqY95YvX9781ONao0YNU/P3gw8+MB1VPSetW7eW+fPnm/c403OQOXNm8/egHU1ts553PWdKX+s6em4/+ugjM087gwAAIPbH1TW4pyUK9Hs9Kvq9rTeG9XtcyyxoAOj48eOOG+qlSpUy87XP9/rrr5sglKpevbpjG9pP0/7O888/bwI+sX1P61NjGnjr27ev6YPpd339+vVNiYO4PEXkTtucaWBWA8R6M1r7adqv0Rvi7733nulLjR492mV97XsuWLDA9Hs1SKV1grUPqf1FDfTFt8/qTAO22vfU/p/2EXUfGuz6/vvvHeu401/U49iwYUPTT9P+l/bDtV+l7Vee7r9FdS0QFS3b0alTJ9OX1KQC7btqOzRIqtcJ8R0oTq8fNLit513/ZjVI6+5n0EC1Hj89rnrtof1fDShqoF0D7jEFSuvUqWP69Pbt/+c//4nyb9bdzx3faxJ33ufOtZmuo8FfDebqMdEScJp0ov//67rOSUL6ufXz6GfQoLneoFF6DWLfzjvvvCOnTp0y5fv0/bodzXiP7e8TSBRsAOCG1atX21KkSGGmatWq2d5//33bqlWrbGFhYS7r7du3T1MGbK+99prL/HfffdfMX79+vWOevh4wYECkfRUoUMDWqVMnx+upU6eadWvWrGl78OCBY/6///5rS58+va1KlSq2u3fvumwjPDzc8bNYsWK2Ro0aOeapO3fu2AoVKmRr0KCBY17GjBltXbt2jfPfwwsvvGDLkSOHS9suXLhgS548uW3w4MHm9bVr18xn+OKLL+K8/SlTppj3pkyZ0lanTh3bxx9/bNu8ebPt4cOHLuvpsdX13nnnnUjbsH/2uJwfPQ86b+XKlS7rDhkyxJY2bVrb0aNHXeZ/8MEH5u/jzJkzMX6ep556ykx2etxCQ0Nd1tHjlTNnTturr77qmHflypVo/2bq1atnK1eunO3evXsun7l69erm/Ef8W6pfv77L30OvXr1M2/Vvyq5MmTIu7QQAAP/7Lt21a1e0h0P7VI8//rjjtX53O196jh492rzW7/bo6PZ1Hd1fRPr9rMsmT54c5TLn7+8NGzaYdR977DHbjRs3HPPnzJlj5o8dOzbaPmh024ypbfp+3Y7dokWLzLpDhw51We/ZZ5+1JUuWzHb8+HHHPHt/z3neb7/9ZuaPHz/+kfus9vPQsmVLl/lvv/22ma/7ikt/ceHChbH+LXiy/xbxWsB52alTp8zrmzdv2jJlymTr0qWLy3oXL140x815fsTzGt051G3rPjJkyGC7fPlyvD5DhQoVbM2aNbPFVc+ePc2+f/nlF8c8bYN+lvh87vhek7jzPneuzfTaUa+bypYt67LOsmXLzPY/+eQTl/Og8/Qaw5leB+n8H3/80WW+XrM4z3fn7xOwOsojAHCL3gHWTFvNFNDByEaMGGHueupdZefHf5YvX25+6qPnzvQOvfrpp5/ifcQ1W8O5ZpXe2dWsTL1zqo/FOLM/gqfZE8eOHTN3djUL4e+//zaT3p2vV6+e/Pzzz47Hi/Tuq2YR6OAScRESEmLu5DoPsKDZD7pdXab0briWN9B1Ij62Exu9W613p/XxLc2i0EfVNKtDH6/SDFc7vZuvn1uzRyOyH4+4nh99hEjPc8THmXT/mqlqP546abaKPnqoxzQu9JzaSz/oMfvnn3/MXXXNDI7tMT+l62s2tWaN6N+DvT16vrXtev4jPm6lGRLOj2nq59G26+OcAADg0eiTKvqdHB17Jt3ixYvjVVpJaaajZtm5q2PHjiZz1U4zSPXxbnvfyFt0+9rX0WzAiH0vjdPqo+TOtD+lj9/baVaqPmJ+8uRJx7z49lntunbt6vLaPpCc/Vi421+0n8dly5aZx//jIj79t4jXAlHR6wMt46VPcDn3U/V9VapUcSm/FVeaaWov9xDXz6DHSrNUdV5c6LmoWrWq48lApW2wlwmI6+eO7zWJO+9z59pMs4v1ukmzpp3X0acXS5YsGeW1omZqR7wW0ZJqen3q/Fn1qUr9t8f+WR/l7xOwCoK2ANymj7Do4yT6Ra2PresjL/rFrJ1ee00nDXpp+QGtcepM64fpF+ejBMU0gOhM6xupmMo12DtG+qiQdnCcJ30kX+tyXb9+3ayjgWgt/6D1xrRjpI8xOXeQo2OvlWt/tF7p7/r4W/HixR0XFvqYknbM9fE9rb+m+9NHntyhHT99lE47YxoU1c62Hkt9tNA+GJkejzx58phHtaIT1/MT8Zjbj6kGkSMeT73IiO/gaPr4nV6U2Gt86fa002Y/NzHRxyn1okdr6EVskz2AHbFNWtLBmQagVVwD6gAAILJbt265BEgj0pva+ki5Piqu/SItcaCPlMclgKuJA3EZBEpvdkcMIml/KLY6no9K+1baP4t4PLTMgn15TH0Uez/FuY8S3z5rdMdCg8TaP7QfC3f7i1ouSwOZWqtVa4ZqfVMtIRCx7q2n+m9R9Uuj6/trGbSI29WSHY8yiG/E/cflM2hJDe3H67WBjj2h5TH2798f6z71WEc8X0pLlsXnc8f3msSd97lzbWb/24nYfqVB24j/P+gAhhHLw+ln1WsErW0c8bPqvz32z/oof5+AVVDTFkCcaQdZA7g6acdDsxz0jqdzhmfEwSbiQjMeoxKXemN29s7/F198YYKoUdE7skrvkmvGpdbp0s6Nvkc7Jxqo1pppMXVitG6Vvm/ixImmLpPWUho2bJjLejpgRIsWLczgEhqA1Q6e1nHSO/SPP/64W59H6zhpG3XSzod2QrTzpEHpuHD3/ER1zPWY6p3t999/P8r32APV7tKBSnSgAT2G2oHVDphmBeixsXf+3DnH7777bqSsYLuIFx3RZWlEHBAEAADEjdbg14BKxO/eiP0LvQmtGXF6k1ZvBusNbw04aR8stmxK+zY8Lbr+kfZN3WmTJ7jTR4lvnzWunzu2/qIu16fLtC7u0qVLTf9WnxAbNWqUmWfvY3uq/+bOObdvV+u7apA5Ig0COrc/qr6fu9cicfkMGuTUfq1ml+s50+QRrWc8efJkc/PiUcXlc8f3msQT1zJxpddZegMh4mfV64Uff/wxyvfYs6Ef5e8TsAqCtgAeiX1wKx2Ayj5oln6R6h1QewaB0kCm3l3W5c5ZAzrPWVhYmGNbsbE/OqaZBtFdGNjX0cfK7JmgMdHH5PRxHZ30Lq0O5qADV8TWAdaMEc0W1QHDdIAG7QDaSyNEbI8+WqaTHiMNJGvHwXmE5fgee922dkb0Ua3osm3jcn6io/vRu9juHE93aGeqcOHC5kLD+eIgYpmH6C4c9L1KBxzwVJti2h8AAIieBo1UdEEsOw3EaKkqnb788ktzs1sH/9RArn6fe/p7OOJj6dpX00xJ+6BY0fVNlWb/2fsbKi5t077V2rVrzdNpztm2hw8fdiyPj/j2We3HwjlrVI+D9g/tg0nFtb+oj+/rpPufOXOmeXR/1qxZJhiZ0P03e99fg3qxbVfPd1QZyu4+GRjXz6D9c0120Un70hrI1SzpmIK2eqyjKqmggwXH93M/yjVJTO9z59rM/rej7debNBE/k7vXIvr/lGbruxPIj+nvE7A6yiMAcIt2oKO6E22veWV/xKVp06bmp47I60w74/Z6Rc5fuBHrn+poqNHd3Y5IRwPVzq/e4dWRXJ3Z26q1jXQ/Otqodo4iunLlivmp+4z4KL52evRxNnceodHOkXbENEtEJ31UzbkzrKO3RmyjtkvbH9v2NRAclYjHXh//0c+t2bcR2Y9HXM5PdDS7Q+sba4A4Iu3Iaz3a+GSUOP99aZ023Ycz+2ixES+m9Dxpvd+vv/46yoC//RzHlY7OG9WFGwAAiJpm3Gntfe0DRay56UxvMEdkfyLK3i/S72Hlqe/i77//3qXOrt401n6Dc5BT+2aagadJBHZaD/Ps2bMu24pL27Tvpf1MHdnemWZZakAzrpmxj9pnVV999ZXL6/Hjx5uf9ra421/Ukg0Rrw8inseE7r/pzQJN1tCbAFHVMXXerp5vDZ47z9OxO/SJOXfE5TNonVtnmuWpgc3YzpmeC/2b1NJ0ztuNmGXq7ueO7zWJO+9z59pMk070uGmGsfP+9MlBTXxx91pE/z/Qf2si0usQ+9+aO3+fgNWRaQvALTpAgX5ZP/PMM6bekHZmdRAsDVDqXXn7QBAVKlQwj+pr8FW/MLWWkHYyNAtVH3+vU6eOY5t6d/PNN980wUZ93F47SRoI1Mf+3aEdE+3w6na0VIMONqZ3zHU72lbdp2Zx6ONH2gktU6aMaafWQNNBATQQrdvQx2W0E6/1krQ+r34G7UjpHdxdu3aZu8ex0Tvsbdq0MXdtdZAzDRI7O3r0qMkk0U5G6dKlzSNK+kibZixoHbeYaP0lvfjRx5G0c6Tb17Zpu/Vz63ylx/all16ScePGmTvfWmtXsyQ2b95slnXr1i1O5yc6WsJAB5/Terpa1kAD49qmAwcOmAsgrYfm7jlUuh3NstW/Le2onTp1ynTk9Dg5B9r1TrrO0785LcGgQXKtmaWTXnzUrFnT1AjTQSo080GPrQZ+9TFN/ZuIK/1ckyZNkqFDh5pOtXYwI2YEAACQVGmQRQNeGiTR71wN2OpARJopp/2EiAMROdP6nnrjXr/3dX3NFNUSU9oX0+9zpX0erZ+qfQINBGmgVAdUcqeuaVS036Db1r6gtlcDkvr9rv0GO+1Tal9G+1DaZ9PH2Z0zCO3i0jbtp2n/SrOItY+kfTF9PF4fk9fHzSNuOzaP2mdV2tfSwYX1c2pfST+j9qN1e8rd/qK+1vOmfTj9HNq2b775xvSv7YHfhO6/6b61/6Z9Ys0+1n62Pi5/5swZU4pDszPtAXR9VF4D0Rrw7Ny5s/k71HOq1ww3btxwa3/ufgY9Bhrg1f6lHgMdkEv/1rR/HhMtR6bZ63quevToYf7W9Lzo/zfONXHd/dzxvSZx533uXJvpNZOW8tD/D/XvSgdO022MHTvWXFP26tUr1mOu73vjjTdMcFgHndZgsW5Xr3+0ZJ9uS///cOfvE7A8GwC4YcWKFbZXX33VVrJkSVu6dOlsKVOmtBUtWtTWvXt326VLl1zWvX//vm3QoEG2QoUK2QIDA2358uWz9evXz3bv3j2X9R4+fGjr27evLVu2bLY0adLYGjVqZDt+/LitQIECtk6dOjnWmzp1qt4ite3atSvKti1ZssRWvXp1W+rUqW0ZMmSwVa5c2fbf//7XZZ1ff/3V1qZNG1vWrFltQUFBZh/t2rWzrVu3ziwPDQ21vffee7YKFSrY0qdPb0ubNq35feLEiW7/faxZs8a0M1myZLazZ8+6LPv7779tXbt2NcdPt50xY0ZblSpVbHPmzIl1u/pZnn/+eVuRIkXMZ0yVKpWtdOnSto8++sh248YNl3UfPHhg++KLL8x+9Bxlz57d1qRJE9uePXvifH70GDVr1izKNt28edO8R/8GdD96DvUcjBw50hYWFhbj53nqqafMZBceHm4bNmyY2Z+em8cff9y2bNky8zeg85xt27bNVqlSJbNPPdYDBgxwLDtx4oStY8eOtly5cpnP9dhjj9maN29umzdvXqx/Sxs2bDDz9afdxYsXzefXvwdd5txmAACSKvt3qX3S72T97m3QoIFt7NixkfomSr+vnS89tf/VqlUrW548ecz79ecLL7xgO3r0qMv7Fi9ebPo8AQEB5v26b6XfyWXKlHGrn2H/jtf+lPZdcuTIYfpT+h3/559/Rnr/qFGjTB9C+yQ1atSw7d69O9I2Y2pbVP0X7Tf16tXLfE7toxQrVsz017QP5Ey3o/3FiJz7xo/SZ7Wfh0OHDtmeffZZ8/7MmTPbunXrZrt7967Luu70F/fu3WvOW/78+c3x0mOrfS89ZgnRf3NedurUKZf5et712kL73Np31n70yy+/HKltP/zwg61w4cKmbcHBwbZVq1ZFOoe6bd2HnrOouPMZhg4daq5RMmXKZP7+tK/+6aefxtpvVvv37zd/f/o5dNtDhgyxTZkyJV6fO77XJHF5nzvXZrNnzzZ9fv27yZIli619+/a2c+fOuayj50H3FZ3//Oc/5u9K96N/y+XKlbO9//77tvPnz8fp7xOwsmT6H18HjgEAAAAAgPdo/VQto6WPysflqSgAgG9Q0xYAAAAAAAAALISgLQAAAAAAAABYCEFbAAAAAAAAALAQatoCAAAAAAAAgIWQaQsAAAAAAAAAFkLQFgAAAAAAAAAsJEASsfDwcDl//rykT59ekiVL5uvmAAAA4BHYbDa5efOm5MmTR5InJ7fAjj4vAABA0uvzJuqgrQZs8+XL5+tmAAAAwIPOnj0refPm5Zj+f/R5AQAAkl6fN1EHbTXD1v4hM2TI4OvmAAAA4BHcuHHD3JC39/F8beDAgTJo0CCXeSVKlJDDhw+b3+/duyd9+vSRWbNmSWhoqDRq1EgmTpwoOXPmdKx/5swZeeutt2TDhg2SLl066dSpkwwfPlwCAtzvhtPnBQAASHp93kQdtLWXRNCALUFbAAAA/2ClsldlypSRtWvXOl47B1t79eolP/30k8ydO1cyZswo3bp1kzZt2sjWrVvN8ocPH0qzZs0kV65csm3bNrlw4YJ07NhRAgMDZdiwYW63gT4vAABA0uvzJuqgLQAAAOBNGqTVoGtE169flylTpsjMmTOlbt26Zt7UqVOlVKlSsmPHDqlataqsXr1aDh06ZIK+mn0bHBwsQ4YMkb59+5os3pQpU3LyAAAAECVGeAAAAACicezYMTNIROHChaV9+/am3IHas2eP3L9/X+rXr+9Yt2TJkpI/f37Zvn27ea0/y5Ur51IuQUso6CNxBw8ejPaYa6kFXcd5AgAAQNJCpi0AAAAQhSpVqsi0adNMHVstbaD1bWvVqiW///67XLx40WTKZsqUyeU9GqDVZUp/Ogds7cvty6KjNW8j1tIFAACwKpvNJg8ePDClofA/WhIrRYoUEl8EbQH4hP5jrhlKgFW/IAGgSZMmjoNQvnx5E8QtUKCAzJkzR1KnTu21A9SvXz/p3bt3pMEqAAAArCYsLMzc3L5z546vm2LJmrV58+Y1g9HGB0FbAAl+B06zi/7991+OPLxOM+C0FqWVBjUCkLj/TSlevLgcP35cGjRoYC5S9PvMOdv20qVLjhq4+nPnzp0u29Dl9mXRCQoKMhMAAICVhYeHy6lTp0yyjJaT0qeQuPb6X+zjypUrcu7cOSlWrFi8EooI2gJIUPaAbY4cOSRNmjT8gw6vfUHqnd7Lly+b17lz5+ZIA3hkt27dkhMnTshLL70klSpVMhn969atk7Zt25rlR44cMTVvq1WrZl7rz08//dT8W6Tfe2rNmjWSIUMGKV26NGcEAAAkanoDWwO3+kSQXt/DVfbs2eX06dPmKWOCtgAsXxLBHrDNmjWrr5sDP2d/dNkeLKFUAoC4evfdd6VFixamJML58+dlwIAB5t+SF154QTJmzCidO3c2ZQyyZMliArHdu3c3gdqqVaua9zds2NAEZzXIO2LECHPjsn///tK1a1cyaQEAgN9Injy5r5tgSY+adUymLYAEY69hyx04JBT731p872wCSNr0cTYN0F69etVkStSsWVN27NhhflejR482FymaaRsaGiqNGjWSiRMnOt6v/+4sW7ZM3nrrLRPMTZs2rXTq1EkGDx7sw08FAADg3woWLGhukKdKlUpu374tZcqUkb59+0r16tU9to9ffvlFXn/9dbl7966pWztjxgx57LHHxJMI2gJIcNS4AX9rABKDWbNmxbhcLwS++uorM0VHs3SXL1/uhdYBAABY0+g1R72y3V4Niru97uzZsyU4ONj8vmDBAmnatKmsWrXKDCz7qLQkRPv27eWbb76ROnXqyMiRI6Vnz54yd+5c8STylwEAAAAAAAD4pTZt2sibb75pgqv2cQpeffVVKVu2rJkGDRrkWPevv/6SZ599VsqVKyfly5eXjz/+ONL29uzZIwEBASZgq9544w1ZunSp3Lt3z6PtJtMWAAAAAAAAgN+qUqWKLFmyxPw+ZMgQU9pq//79pryBlsAqWbKkhISESIcOHcy4BPPmzTPrXrlyJdK2dOBZfZrKLn369GZ8Ax0DoXDhwh5rM0FbAJbQYvyWBN3f0u4147T+yy+/bAZRW7RokSSVGkD6eIdOAAAAAAAkZjabzfH72rVrZdSoUWZsAh1zoGPHjrJmzRpp1qyZbNmyxZRRsLOPZeALlEcAAAAAAAAA4Ld27dplSiF4Ytyd/Pnzy59//ul4ffPmTbl+/brkyZNHPImgLQDEIwt1zJgxLvO0wPnAgQMdrw8fPmwesdBBakqXLm3u5OkXgXOm7tmzZ6Vdu3aSKVMmyZIli7Rq1UpOnz7tkt3bunVrGTZsmOTMmdOspyOOP3jwQN577z3zHh2lcurUqS5tcXe7Ws8nd+7ckjVrVunatavcv3/fLH/66afNF1CvXr1Mm+1fYDqvRYsWkjlzZnM3UkfgZHAdAAAAAICVLV68WCZNmiR9+vQxr+vXry9Tpkwx2be3b9+WGTNmmJII6dKlk9q1a5ssXLuoyiNUqlTJXD9v2LDBvP7666/NtbJe/3sSQVsA8LCHDx+aoGiaNGnkl19+kf/85z/y0Ucfuayj/8A3atTI1L7ZvHmzbN261XxBNG7cWMLCwhzrrV+/3tTF+fnnn+XLL7+UAQMGSPPmzU3gVLetxdS16Pm5c+fitF39cjlx4oT5OX36dJk2bZqZ7CNrajBYA8QXLlwwk9LArtb90bYcOHBAPv/8c7NtAAAAAACsJCQkRCpUqCBFixY1AVpNONK6tkoHFwsMDDSDjem8li1bmsQnpQHc3bt3myQlTc6aMGFCpG1rWYUffvhBevToIcWLF5dly5bJ6NGjPf4ZqGkLAB6mtXA0ILpx40bJlSuXmffpp59KgwYNHOvMnj1bwsPD5dtvv3VksmrGrGbH6vv0Lp/STNlx48aZL4USJUrIiBEj5M6dO/Lhhx+a5f369ZPPPvvM1N15/vnn3d6uBn31yydFihSm4LrW7lm3bp106dLF7FPna+DX3n57sfW2bduaLzblyQLrAAAAAAD/0KtBcZ/u/7TTk6ZR0eSj7777LsplWuJg/vz5se6jWrVqZiAzbyJoCwAeduTIEcmXL59LwLNy5cou6/z2229y/PhxExh1du/ePRPwtdO7exqwtdMyCc51eDS4quUNLl++HOft6nvttEyCZs/G5J133pG33npLVq9ebR4n0QBu+fLl3TomAAAAAADAfQRtASCONIjqPPKksteDddetW7dMHZwff/wx0jLn0Sn1kQ1nmj0b1TzNrn3U7dq3EZ3XXnvNlF746aefTOB2+PDhptZP9+7dY/288A8hy0K8vo/ZzWd7fR8AACDhbJsbuV/qjurPtfd4WwAgMSFoCwBxpMFPe51XdePGDTl16pTjtZYx0MHALl26ZDJj7SNVOqtYsaIpZZAjRw7JkCGDx86Bp7abMmVKU5s3Is0g1jq6Omlphm+++YagLQAAAAAAHsZAZAAQR3Xr1jXFyXWgLy0p0KlTJ5dSA1q7tkiRIma+1rjRwcD69+9vltnrzLZv316yZcsmrVq1MtvRoK/WnNUSBPZBxeLDU9stWLCgGXDsr7/+kr///tvM69mzp6xatcpsc+/evWYQs1KlSsW7rQAAAAAAwIJB24EDB5oAhvOkA+IAgNVo6YCAgP97OEEzTJ966ilp3ry5GcCrdevWJkhrpwHcRYsWmVIFTz75pCkr8NFHH5llqVKlMj/TpEljgqL58+eXNm3amOBn586dTe3ZR8mQ9dR2Bw8ebIq36+eyl1XQzNuuXbuabTZu3NiMkjlx4sR4txUAAAAAAFi0PIIOhrN27VrHa3tQBEDSsrR7TbEyHeiraNGi5ncNfs6aNctluWbVOtMbUFu2bHG81mxbZd+G0oHKpk+fHu0+p02bFmmeZs3GNjJmfLY7ZswYl9dVq1Y1g5o5Gz9+fLTbBAAAAAAAnuPzCKkGaZ1HWAcAK7l27ZoJuGqwVOu4umvhwoWSLl06KVasmBw/flx69OghNWrUcMnIBQAAAAAAsGTQ9tixY5InTx7zyHC1atXMaOT6WC8AWMGrr75qBhHr06ePqRPrrps3b0rfvn3lzJkzpsZs/fr1ZdSoUV5tKwAAAAAAPrdhuHe2W6ef22O0BAUFmVjj7du3zVP+en1evXp1jzXl2WeflW3btplByjXZK1OmTOJXQdsqVaqYx3R1pHX9kIMGDZJatWrJ77//LunTp4+0fmhoqJmcR2wHAG/SjNn46Nixo5kAAAAAAEDCmj17tgQHB5vfFyxYIE2bNjUDa2ss0hP0SVwd4yVnzpziLT4N2jZp0sTxe/ny5c2BK1CggMyZM8cMnBORZuFqYBcAgMSmxfj/1ThOqrWhAQAAACChtWnTRnbu3CkjR46UuXPnmkHD33nnHTNPPffcczJgwADz+19//WXKGx45ckSSJUtmnrgdMmRIpG3q07R+Xx7BmaYS62jkWv8xKjpie+/evV0ybfPly5eALQQAwMK+fsq723+MGvQAACBhbJv7Y7zeV/259h5vC4DEr0qVKrJkyRLzuwZh9Un+/fv3y927d6VmzZpmMPGQkBDp0KGDNGzYUObNm2fWvXLlis/anFwsRCPdJ06ckNy5c0e5XOtR6KjtzhMAAAAAAAAARMdmszl+X7t2rXTp0kWSJ08uadOmNaUN16xZY+KSW7ZsMWPa2GXPnl2SZND23XfflU2bNsnp06dN8d5nnnlGUqRIIS+88IIvmwUAAAAAAADAT+zatUvKli0b5TItg2BFPg3anjt3zgRodSCydu3aSdasWWXHjh0+jWIDAAAAAAAA8A+LFy+WSZMmOTJotR7tlClTTPbt7du3ZcaMGaYkQrp06aR27doyatQox3t9WR7BpzVtZ82a5cvdAwAAAAAAAPAzISEhkipVKhOULV26tCxfvtzUtVUff/yxGYisXLlyjoHINJlUaQC3e/fuUqZMGQkMDDQDkQ0aNCjS9ps1aya//fab+V3XLVasmGzcuNF/ByIDADy6gQMHyqJFi2Tfvn0cTgAAAABAwqrTz6dH/PTp0zEu14za7777LsplefLkkfnz58e6j59++km8jaAtgKQx6n1Eb2yK0+r6SMQnn3xi/mG+dOmSZM6cWSpUqGDm1ahRQxI7reGzcOFCad26tUe3q3ca69SpI9euXZNMmTJ5dNsAAAAAAPgrgrYA4Ia2bdtKWFiYTJ8+XQoXLmwCt+vWrZOrV6967fjp/lKmTMn5AQAAAAAgifHpQGQAkBj8+++/snnzZvn8889N1miBAgWkcuXK0q9fP2nZsqXLem+88YbkzJnT1M7RkSmXLVvmWK6PWGitm6CgIClYsKBLcXOl84YMGSIdO3aUDBkyyOuvv27mb9myRWrVqiWpU6eWfPnymdo7WpcnLqNkNmjQQLJlyyYZM2aUp556Svbu3euyX/XMM8+YjFv7a3vB9ooVK5rPo8FqreXz4MEDx3Jd/9tvvzXvTZMmjanjs2TJEscjKXq8lGYm67ovv/xynI49AAAAAABJEZm2ABALrXejk9aJrVq1qgm6RhQeHi5NmjSRmzdvyg8//CBFihSRQ4cOSYoUKczyPXv2mMLmWm9WC6Jv27ZN3n77bcmaNatLIHPkyJGm5MKAAQPM6xMnTkjjxo1l6NChpuaOlmno1q2bmaZOnerWudM2derUScaPH29Gx9RgcdOmTeXYsWOSPn16E9TNkSOH2Z7uy95mDVRrAHncuHEmaKxtsQeS7e1TGsgdMWKEfPHFF2Yf7du3lz///NMEmDVQrVnKR44cMYFoDTwDAAAA+J+J+ybG6XC8Hfw2hw9IAgjaAkBs/1AGBMi0adOkS5cuMnnyZJN5qtmqzz//vJQvX96ss3btWtm5c6f88ccfUrx4cTNPM1PtvvzyS6lXr54ZpVLpOhrU1UCnc9C2bt260qdPH8fr1157zQRBe/bsaV5rJqsGUXX/kyZNMhmwsdFtOvvPf/5j6stu2rRJmjdvLtmzZzfzdV6uXLlcgrEffPCBCfjaP49mAr///vsuQVtt/wsvvGB+HzZsmGmfHgsNAGfJksXM16AwNW0BAAAAAHAP5REAwA2aLXr+/Hnz6L8GI3WALQ3eajBX7du3T/LmzesI2EakwdyIA5bpa812ffjwoWPeE0884bLOb7/9ZvZhz/bVqVGjRiaz99SpU26dO62/qwFnDfhqeQTNeL1165acOXMmxvfpvgcPHuyyb93OhQsX5M6dO4717IFrlTZtWrP9y5cvu9U2AAAAAAAQGZm2AOAmzWrV2rA6acasZsFqxqlmmnrqsX8NejrT4KrWydU6thHlz5/frW1qpqwOmDZ27FhTj1fLO1SrVs0MdBYT3bdm27Zp0ybSMucM38DAQJdlWrtWg8oAAAAAACS0ggULmutevW7V8WB0bJm+fftK9erVPbJ9Teh65ZVXzDguuh9NkNKncu1PsXoKQVsAiKfSpUubOrf2bNNz587J0aNHo8y2LVWqlGzdutVlnr7Wde01ZKOi2bxaRqFo0aLxPk+6n4kTJ5o6turs2bPy999/u6yjgVfnjF/7vrUW7aPsO2XKlOZnxG0DAAAAAPxTXOs0e6Oe8+zZsyU4ONj8vmDBAnM9vGrVKqlSpcojt0Ov4TWRq2bNmub1e++9Zyb7k7ieQnkEAIiFZqlqXVgdYGz//v2mLMHcuXPN4FutWrUy62iN2dq1a5syCmvWrDHrrFixQlauXGmWa53adevWmZqwGtidPn26TJgwQd59990Y9613A3XQMh14TEswaDmFxYsXm9fu0rt+M2bMMCUafvnlF1MjN2JmsN6J1PZdvHhRrl27ZubpgGjff/+9ybY9ePCgef+sWbOkf//+bu9bM3s183bZsmVmEDXN3gUAAAAAIKG0adNG3nzzTTPwt9Lr0ldffVXKli1rJr3mtfvrr7/k2WeflXLlypnkLPu4NM5y5szpCNgqDQRr1q2nEbQFgFhoLVf9R3j06NEmMKv/qOs/3FrfVQOvdvPnz5cnn3zSDMqlWbg6YJc9w1SzVufMmWOCnvp+DYhqvVjnQciiol8SOmCYBnpr1aoljz/+uHlvnjx53D5vU6ZMMYFYbcNLL71kSi3owGDORo0aZYLN+fLlM/tQWjtXg62rV682n6tq1armGGgg1l2PPfaYY0Az/WKLS7AZAAAAAABP0Gt6TUZSmkwVGhpqkrI0sUmfoNXMXNWhQwepVKmSHDhwwCyPqlShM73m17iAPaHLk5LZbDabJFI3btwwg+pcv37dDHwDwNru3btnMlALFSrkUhMVSAp/cy3Gb/H6Ppam/Mir2w95LJd42+zm/9dZQtJE347jAsD/bJv7Y4Lur/pz7cXfHyWPyyPigC+ut3xdHqFgwYImEGsvj2AvkaBPjWr5QQ3KauLS008/bZZpcpIGdMeMGSOZM2c2dXDtpf5ioiFVzeDVgbg1iSt58uRuHR93+7zUtAUAAAAAAADgt3bt2mWeeo2KlvSLD83C1TFjNEAcMWDrCZRHAAAAAAAAAOCXFi9eLJMmTTJjzaj69eubMoKaKatZtToGTMOGDU1pRC2JqFm4djo2S3QB2+PHj8vChQvdysqND4K2AAAAAAAAAPxGSEiIVKhQQYoWLWoCtMuXLzd1bZWOURMYGGgGG9N5LVu2lHbt2pllGsDdvXu3lClTxpRXcB7Hxm7r1q0yfvx4M/iYvl/Xe+aZZzz+GSiPAAAAAAAAAMAjfF13+fTp0zEu14za7777LsplOui31qeNSY0aNUyWrreRaQsAAAAAAAAAFkLQFgAAAAAAAAAshKAtAAAAAAAAAFgIQVsAAAAAAAAAsBCCtgAAAAAAAABgIQRtAcCDkiVLJosWLXKMWKmv9+3b57VjPGXKFGnYsKFY2caNG81x+Pfffx9pOwULFpQxY8aY38PCwszr3bt3e6iVAAAAAABYR4CvGwAAKmRZSIIeiNnNZ8f5PRcvXpRPP/1UfvrpJ/nrr78kR44cEhwcLD179pR69epFWj9fvnxy4cIFyZYtm3jDvXv35OOPP5a5c+dKUpMyZUp59913pW/fvrJu3TpfNwcAAAAAAI8iaAsAbtCs2Ro1akimTJnkiy++kHLlysn9+/dl1apV0rVrVzl8+HCk96RIkUJy5crlteM7b948yZAhg2lXdDQjVQOc/qh9+/bSp08fOXjwoJQpU8bXzQEAAAAAiMiV8RO8chyyd+/m1nr6VGZQUJCkSpVKbt++ba4XNeGnevXqHmmHbrNu3bomkUrlzp1bJk+ebPbrSZRHAAA3vP322+YR/507d0rbtm2lePHi5h/+3r17y44dO6J8T1TlETTA2Lx5cxNsTZ8+vdSqVUtOnDjhKCNQuXJlSZs2rQkOazD2zz//jLZNs2bNkhYtWrjMe/nll6V169YmIzhPnjxSokQJM//s2bPSrl07s90sWbJIq1atTPvsYtv30qVL5cknnzRfepo5/MwzzziWzZgxQ5544gnzeTRI/eKLL8rly5djPJ5btmwxnz116tQmI/mdd94xX3x2+n79bLq8UKFC8uOPP0baRubMmU079TgAAAAAAGA3e/Zs+e233+T48ePSqVMnadq0qfzyyy/iCXqdunbtWrN9nRo1aiQ9evQQTyNoCwCx+Oeff2TlypUmo1aDmhFpkNMdWlKhdu3a5o7f+vXrZc+ePfLqq6/KgwcPzKTB1qeeekr2798v27dvl9dff90EfWMKfGqwNCItF3DkyBFZs2aNLFu2zGQE65eIBlU3b94sW7dulXTp0knjxo1NJm5s+9ZyEBqk1S+5X3/91WxfA7x2uv0hQ4aYLyut56vBYA0eR0eD1LpvDX7r/vTLVD9Lt27/u2uq79dA84YNG0xG8cSJE6MMBGs79DMBAAAAABCVNm3ayJtvvikjR440r2/dumWuxcuWLWumQYMGuVy3P/vss+bp2vLly5uShBElT57cXF8rm80mN27ciPHaPb4ojwAAsdA7c/oPccmSJR/pWH311VeSMWNGkxkaGBho5mnGrj0wfP36dZOFW6RIETOvVKlS0W5LB/XS9TWbNiINLH/77beOsgg//PCDhIeHm3n2L5KpU6eaYLNm2GrgN6Z9a9bu888/7/JFVqFCBcfv+mVnV7hwYRk3bpzJytUvQg0ORzR8+HBT2kBrAatixYqZ92jQeNKkSXLmzBlZsWKFyWrW7dgHXIvqeOjnjykbGQAAAACAKlWqyJIlS8yB0KSj0NBQk0R09+5dqVmzprneDwkJkQ4dOpjBvjV5SF25ciXag1e/fn05cOCAZM+e3ZRO9DQybQEgFhqw9QQtk6AlAewBW2daskCzSzUjVssCjB071gxiFh39YlFariAivSPoXMfW/kiI3gnUIKpOuj+tv6NZr7HtW9sd1UBrdpoxrO/Lnz+/2YcGX5UGX6Oi7Zk2bZqjLTrpvjWwfOrUKfnjjz8kICBAKlWq5HiPfoFGldGsj6XcuXMn2rYBAAAAAGBzuq7X0gZdunQxGbOa9NSxY0fzpKomHulToDp2ip0GZKOj29FrZw32arKTp5Fpm4SFLAvx+j5mN5/t9X0A3qaZoJqhGtVgY3GhAcaYaPar1nbVUgxaMqB///7mi6Nq1aqR1s2aNatp07Vr1yIti1jCQb94NAAaVV1Y+xdQTPuOqd1ah1YDrjrp9nV7GqzV11p6ISranjfeeMPsLyIN/B49elTcpRnKMX2JAgAAAACwa9cuUwohKo9S2kADvxoA1riBlvXzJDJtASAWmomqQUgtb+A8WJZzqQJ3aD0crb+qNWCj8/jjj0u/fv1k27Zt5gtl5syZUa6nmbSlS5eWQ4cOxbrfihUryrFjxyRHjhxStGhRl0nLNcS2b2231rGNigayr169Kp999pnJItaM2NgGIdP2aLsjtkUn/Vy6Da2zqxm8dlqjN6rj/Pvvv5t2AwAAAAAQlcWLF5tSfPYMWi1roCX4NPtWr/F1cG0tiaBPgeo4NKNGjXK8N6ryCBcvXnRJoNLEJ71u9jSCtgDgBg3YPnz40Ax8NX/+fBME1cf4tRZrtWrV3DqGOtCWFijX+rC7d+8229AvBw1IalkADZjqIGBao3X16tVmeUx1bTWQrI9uxEbrx2bLlk1atWplgsa6L61lq5mu586di3XfAwYMkP/+97/mp35mrdnz+eefOzJjNdA6fvx4OXnypKkRpPWBYtK3b18TGNbjoaUXdF/6JWofiKxEiRJmoDLNxtXRPTV4+9prr0WZ8aufR79cAQAAAACw05IFOhaLJgdpgHb58uWmrq3SwcW0bKGWFtR5LVu2lHbt2plleo2u1+tlypSR4OBgmTBhgkSkT5fWrVvXBGp1GzqAto4l42mURwAAN+gAW3v37jV1avTunNat0cfyteyA3rFzh5Y0WL9+vbz33num7muKFCnMl0CNGjUkTZo0Jmt1+vTpJnM1d+7c0rVrVxO4jE7nzp0dg4g5Z8xGpNv++eefTbBUR828efOmPPbYY6ZObYYMGUx93Jj2/fTTT8vcuXNNMFYzavU9evdR6THQ+rQffvihCWBrFq2OyKlfetHRL7ZNmzbJRx99ZLJz9e6mDoCmX6p2Wq5BA7V6nHLmzClDhw6NNGqnBpn1s+vIngAAAAAAa8je/f8Scnzl9OnTMS7XjNrvvvsuymU62LUmasVEk7l+/fVX8bZkNk+NsOMDmrGmgQq9aNcgQkJpMT72zLZHtbR7Ta/vg5q2SGg68JVmdRYqVCjKAbQQd88995wJlGqmbFK9c6oB48TwN5cg3x0pP/Lq9kMeyyXeRi30pM1XfTur47gASMy2zY08roI3VX+uvSQ2E/fFrQ7m28Fve60tQFxY6XorMR0fd/t2lEcAgETsiy++MHcJkxod5EwfQ+nVq5evmwIAAAAAgMdRHsGqvn7K+/tIgIwpAN5VsGBB6d69e5I7zFpHt3///r5uBgAAAAAAXkHQFgAAAAAAAB4xes1Rt9ft1aA4Rx2IBuURAAAAAAAAAMBCCNoCAAAAAAAAgIUQtAWQ4MLDwznq4G8NAAAAAIBoUNMWQIIOHpU8eXI5f/68ZM+e3bxOliwZZwAeZ7PZJCwsTK5cuWL+5vRvDQAAAADgfTuXnvTKdiu3KOz2gN1BQUGSKlUquX37tpQpU0b69u0r1atX93ibBgwYIIMHD5Zff/1VgoODPbptgrYAEowGzwoVKiQXLlwwgVvA29KkSSP58+c3f3sAAAAAgKRh9uzZjiDqggULpGnTprJq1SqpUqWKx/axc+dO2bVrlxQoUEC8gaAtgASlGY8aRHvw4IE8fPiQow+vSZEihQQEBJDNDQAAAABJWJs2bUyAdeTIkTJ37ly5deuWvPPOO2aeeu6550zGrPrrr7+kR48ecuTIEXMt2apVKxkyZEikbd65c0e6desm8+fPl1q1anml3QRtASQ4/YcvMDDQTAAAAAAAAN5UpUoVWbJkifldg7ChoaGyf/9+uXv3rtSsWVNKliwpISEh0qFDB2nYsKHMmzfPrKsl96Ly/vvvy1tvvSX58uXzWpt5XhQAAAAAAACAX497Yrd27Vrp0qWLKaOXNm1a6dixo6xZs8Zk4G7ZskX69OnjWFfH44lI1/3zzz/llVdeEW8iaAsAAAAAAADAb+3atUvKli0b5bK4DpC+fv162bt3rxnwTKdz586ZmrlLly4VTyJoCwAAAAAAAMAvLV68WCZNmuTIoK1fv75MmTLFZN/evn1bZsyYYUoipEuXTmrXri2jRo1yvDeq8gjDhw83tW9Pnz5tprx588ry5culRYsWHm03QVsAAAAAAAAAfiMkJEQqVKggRYsWNQFaDapqXVv18ccfmzF2ypUrZ+a1bNlS2rVrZ5ZpAHf37t1SpkwZCQ4OlgkTJvjsMzAQGQAAAOCGzz77TPr162dGFB4zZoyZd+/ePZO1MWvWLDOgRaNGjWTixImSM2dOx/vOnDljBqrYsGGDyeDo1KmTydAICKArDgAA/E/lFoV9uv/Tp0/HuFz7Y999912Uy/LkySPz58/36P7ii0xbAAAAwI06aF9//bWUL1/eZX6vXr1M/bK5c+fKpk2b5Pz589KmTRvH8ocPH0qzZs0kLCxMtm3bJtOnT5dp06bJJ598wjEHAABAtAjaAgAAADHQkYTbt28v33zzjWTOnNkx//r16+Zxuy+//FLq1q0rlSpVkqlTp5rg7I4dO8w6q1evlkOHDskPP/xgHrFr0qSJDBkyRL766isTyAUAAACiwjNZAAAAQAy6du1qsmV10IqhQ4c65u/Zs0fu379v5tuVLFlS8ufPL9u3b5eqVauan1ovzblcgpZQ0HIJBw8elMcffzzS/rTMgk52N27c4PwAQCIycd9EXzcBgB8gaAsAAABEQ2vV7t2715RHiOjixYuSMmVKyZQpk8t8DdDqMvs6zgFb+3L7sqhovdtBgwZxTgAAAJIwyiMAAAAAUTh79qwZdOzHH3+UVKlSJdgx0sHOtPSCfdJ2AAAAIGkhaAsAAABEQcsfXL58WSpWrCgBAQFm0sHGxo0bZ37XjFmtS/vvv/+6vO/SpUuSK1cu87v+1NcRl9uXRSUoKEgyZMjgMgEAACBpoTwCAAAAEIV69erJgQMHXOa98sorpm5t3759JV++fBIYGCjr1q2Ttm3bmuVHjhyRM2fOSLVq1cxr/fnpp5+a4G+OHDnMvDVr1phAbOnSpTnuAADA72yb+6NXtlv9ufZurVewYEFzE1yflLp9+7aUKVPG9N2qV6/usbYkS5ZMypYtKylSpDCvx48fL7Vq1RJPImgLAAAARCF9+vSmM+4sbdq0kjVrVsf8zp07S+/evSVLliwmENu9e3cTqNVByFTDhg1NcPall16SESNGmDq2/fv3N4Ob6cUEAAAAPG/27NkSHBxsfl+wYIE0bdpUVq1aJVWqVPHYPjZv3hxpbANPojwCAAAAEE+jR4+W5s2bm0zb2rVrm5IHemFgp9kXy5YtMz81mNuhQwfp2LGjDB48mGMOAACQANq0aSNvvvmmjBw50ry+deuWvPrqq+YmvE7OA8D+9ddf8uyzz0q5cuWkfPny8vHHH/vsHJFpCwAAALhp48aNLq/1sbuvvvrKTNEpUKCALF++nGMMAADgI1WqVJElS5aY34cMGSKhoaGyf/9+uXv3rtSsWdOUvwoJCTE32PVJqXnz5pl1r1y5EmMprQcPHpifuk19IsuTyLQFAAAAAAAA4LdsNpvj97Vr10qXLl0kefLkJtCqT0HpmAOagbtlyxbp06ePY93s2bNHub0///zTDFq7bds2E9h97733PN5mgrYAAAAAAAAA/NauXbsijVXgPKhYXOXPn9/81KDv22+/berbehpBWwAAAAAAAAB+afHixTJp0iRHBm39+vVlypQpJvv29u3bMmPGDFMSIV26dGaMglGjRjneG1V5hGvXrsmdO3fM7+Hh4WbQs8cff9zj7SZoCwAAAAAAAMBvhISESIUKFaRo0aImQKvjC2hdW6WDiwUGBprBxnRey5YtpV27dmaZBnB3794tZcqUkeDgYJkwYUKkbR8+fFiqVq1qtq/buHr1qowZM8bjn4GByAAAAAAAAAB4RPXn2vv0SJ4+fTrG5ZpR+91330W5LE+ePDJ//vwY31+tWjUziJm3kWkLAAAAAAAAABZC0BYAAAAAAAAALMQyQdvPPvvMjNbWs2dPXzcFAAAAAAAAAJJ20HbXrl3y9ddfS/ny5X3dFAAAAAAAAABustlsHCsvHBefB21v3bol7du3l2+++UYyZ87s6+YAAAAAAAAAiEVgYKD5eefOHY5VFMLCwszPFClSSHwEiI917dpVmjVrJvXr15ehQ4fGuG5oaKiZ7G7cuJEALQQAAAAAAADgTIORmTJlksuXL5vXadKkMaVPIRIeHi5XrlwxxyQgICDxBW1nzZole/fuNeUR3DF8+HAZNGiQ19sFIH5ajN/i9UO3tHtNr+8DAAAAAOB9o9ccdXvdXg2Ke7UtiJ9cuXKZn/bALf4nefLkkj9//ngHsn0WtD179qz06NFD1qxZI6lSpXLrPf369ZPevXu7ZNrmy5fPi60EAAAAAAAAEBUNSObOnVty5Mgh9+/f5yA5SZkypQncxpfPgrZ79uwxUfiKFSs65j18+FB+/vlnmTBhgimDELHmQ1BQkJkAwJtCloV4/QDPbj7b6/sAAAAAACAhaAwvvrVbYbGgbb169eTAgQMu81555RUpWbKk9O3blxMNIGpfP+X9I/PY/z3eAQAAAAAAkKSCtunTp5eyZcu6zEubNq1kzZo10nwAAAAAAAAASCriX1gBAAAAAAAAAOA/mbZR2bhxo6+bAAAAAAAAAAA+RaYtAAAAAAAAAFgIQVsAAAAAAAAAsBCCtgAAAAAAAABgIQRtAQAAAAAAAMBCLDUQGQAAAAAAiMWG4bEfojr9OIwAkIiRaQsAAAAAAAAAFkLQFgAAAAAAAAAshKAtAAAAAAAAAFgIQVsAAAAAAAAAsBCCtgAAAAAAAABgIQRtAQAAAAAAAMBCCNoCAAAAAAAAgIUQtAUAAAAAAAAACyFoCwAAAAAAAAAWQtAWAAAAAAAAACyEoC0AAAAAAAAAWAhBWwAAAAAAAACwEIK2AAAAAAAAAGAhBG0BAAAAAAAAwEII2gIAAAAAAACAhRC0BQAAAAAAAAALIWgLAAAAAAAAABZC0BYAAAAAAAAALISgLQAAAAAAAABYCEFbAAAAAAAAALAQgrYAAAAAAAAAYCEEbQEAAAAAAADAQgjaAgAAAAAAAICFELQFAAAAAAAAAAshaAsAAAAAAAAAFkLQFgAAAAAAAAAsJMDXDQAAAEhILcZv8fo+lnav6fV9AAAAAPBfZNoCAAAAAAAAgIUQtAUAAAAAAAAACyFoCwAAAAAAAAAWQk1bAAAAT/v6Ke8f0zc2eX8fAAAAAHyCTFsAAAAAAAAAsBCCtgAAAAAAAABgIZRHAAAASIRCloV4fR+zm8/2+j4AAAAAREamLQAAAAAAAABYCEFbAAAAAAAAALAQgrYAAAAAAAAAYCEEbQEAAAAAAADAQgjaAgAAAAAAAICFELQFAAAAAAAAAAshaAsAAAAAAAAAFkLQFgAAAAAAAAAshKAtAAAAAAAAAFgIQVsAAAAAAAAAsBCCtgAAAAAAAABgIQRtAQAAAAAAAMBCCNoCAAAAUZg0aZKUL19eMmTIYKZq1arJihUrHMvv3bsnXbt2laxZs0q6dOmkbdu2cunSJZdtnDlzRpo1ayZp0qSRHDlyyHvvvScPHjzgeAMAACBGBG0BAACAKOTNm1c+++wz2bNnj+zevVvq1q0rrVq1koMHD5rlvXr1kqVLl8rcuXNl06ZNcv78eWnTpo3j/Q8fPjQB27CwMNm2bZtMnz5dpk2bJp988gnHGwAAADEKiHkxAAAAkDS1aNHC5fWnn35qsm937NhhArpTpkyRmTNnmmCumjp1qpQqVcosr1q1qqxevVoOHToka9eulZw5c0pwcLAMGTJE+vbtKwMHDpSUKVP66JMBAADA6si0BQAAAGKhWbOzZs2S27dvmzIJmn17//59qV+/vmOdkiVLSv78+WX79u3mtf4sV66cCdjaNWrUSG7cuOHI1o1KaGioWcd5AgAAQNJC0BYAAACIxoEDB0y92qCgIHnzzTdl4cKFUrp0abl48aLJlM2UKZPL+hqg1WVKfzoHbO3L7cuiM3z4cMmYMaNjypcvH+cHAAAgiSFoCwAAAESjRIkSsm/fPvnll1/krbfekk6dOpmSB97Ur18/uX79umM6e/Ys5wcAACCJoaYtAAAAEA3Npi1atKj5vVKlSrJr1y4ZO3ashISEmAHG/v33X5ds20uXLkmuXLnM7/pz586dLtvT5fZl0dGsXp0AAACQdJFpCwAAALgpPDzc1JzVAG5gYKCsW7fOsezIkSNy5swZU/NW6U8tr3D58mXHOmvWrJEMGTKYEgsAAABAdMi0BQAAAKIpU9CkSRMzuNjNmzdl5syZsnHjRlm1apWpNdu5c2fp3bu3ZMmSxQRiu3fvbgK1VatWNe9v2LChCc6+9NJLMmLECFPHtn///tK1a1cyaQEAABAjgrYAAADwW8ePH5cTJ05I7dq1JXXq1GKz2SRZsmRuvVczZDt27CgXLlwwQdry5cubgG2DBg3M8tGjR0vy5Mmlbdu2Jvu2UaNGMnHiRMf7U6RIIcuWLTO1cDWYmzZtWlMTd/DgwV77vAAAAPAPBG0BAADgd65evWrqzq5fv94EaY8dOyaFCxc22bGZM2eWUaNGxbqNKVOmxLg8VapU8tVXX5kpOgUKFJDly5fH6zMAAAAg6aKmLQAAAPxOr169JCAgwNSYTZMmjWO+BnJXrlzp07YBAAAAsSHTFgAAAH5n9erVppRB3rx5XeYXK1ZM/vzzT5+1CwAAALB80HbSpElmOn36tHldpkwZ+eSTT8yADwAAAEB83b592yXD1u6ff/5hEDAA1rZhuK9bAABI6uURNPPhs88+kz179sju3bulbt260qpVKzl48KAvmwUAAIBErlatWvL99987Xmtd2/DwcBkxYoTUqVPHp20DAAAALJ1p26JFC5fXn376qcm83bFjh8m6BQAAAOJDg7P16tUziQFhYWHy/vvvm8QAzbTdunUrBxUAAACWZpmByB4+fCizZs0yj7JVq1bN180BAABAIla2bFk5evSo1KxZ0zzJpX3MNm3ayK+//ipFihTxdfMAAAAAaw9EduDAAROkvXfvnqRLl04WLlwopUuXjnLd0NBQM9nduHEjAVsKAACAxCRjxozy0Ucf+boZAAAAQOIL2pYoUUL27dsn169fl3nz5kmnTp1k06ZNUQZuhw8fLoMGDfJJO2FdLcZv8er2l3av6dXtAwAAz5s6dapJCHjuuedc5s+dO1fu3Llj+pwAAACAVfm8PELKlCmlaNGiUqlSJROUrVChgowdOzbKdfv162eCu/bp7NmzCd5eAAAAWJ/2K7NlyxZpfo4cOWTYsGE+aRMAAACQaDJtI9JRfZ1LIDgLCgoyEwAAABCTM2fOSKFChSLNL1CggFkGAPBP2+b+GO/3Vn+uvUfbAgCJNmirmbNNmjSR/Pnzy82bN2XmzJmyceNGWbVqlS+bBQAAgEROM2r3798vBQsWdJn/22+/SdasWX3WLgAAAMDyQdvLly9Lx44d5cKFC2agiPLly5uAbYMGDXzZLAAAACRyL7zwgrzzzjuSPn16qV27tpmn4yb06NFDnn/+eV83DwCSTPYqACARBm2nTJniy90DAADATw0ZMkROnz4t9erVk4CAAEcZLk0YoKYtAABICDuXnoxxeeUWhTkR8E7QNiwsTE6dOiVFihRxdIYBv/P1U97fxxubvL8PAACSEB3sdvbs2SZ4qyURUqdOLeXKlTM1bQEAAACri1ek9c6dO9K9e3eZPn26eX306FEpXLiwmffYY4/JBx984Ol2AgAAAHFWvHhxMwEAAAB+H7TVAcQ0Y0EHDWvcuLFjfv369WXgwIEEbQEAAOBTDx8+lGnTpsm6devMOApaGsHZ+vXrfdY2AAAAwCtB20WLFpnHzapWrSrJkiVzzC9TpoycOHEiPpsEAAAAPEYHHNOgbbNmzaRs2bIufVYAAADAL4O2V65ckRw5ckSaf/v2bTrEAAAA8LlZs2bJnDlzpGnTpr5uCgAAAJAwQdsnnnhCfvrpJ1PDVtkzF7799lupVq1afDYJAAAAeHQgsqJFi3JEAQCA1+xcepKjC2sFbYcNGyZNmjSRQ4cOyYMHD2Ts2LHm923btsmmTZs830rAz4UsC/H6PmY3n+31fQAAYBV9+vQxfdQJEybwJBgAAACSRtC2Zs2aZiCy4cOHS7ly5WT16tVSsWJF2b59u3kNAAAA+NKWLVtkw4YNsmLFCjPuQmBgoMvyBQsW+KxtAAAAgMeDtvfv35c33nhDPv74Y/nmm2/i+nYAAADA6zJlyiTPPPMMRxoAAABJI2irWQrz5883QVsAAADAiqZOnerrJgAA4BUT902M0/pvB7/NmQASoeTxeVPr1q1l0aJFnm8NAAAA4CE69sLatWvl66+/lps3b5p558+fl1u3bnGMAQAA4H81bYsVKyaDBw+WrVu3SqVKlSRt2rQuy9955x1PtQ8AAACIsz///FMaN24sZ86ckdDQUGnQoIGkT59ePv/8c/N68uTJHFUAAAD4V9B2ypQppk7Ynj17zOQsWbJkBG0BAADgUz169JAnnnjCDJ6bNWtWx3ytc9ulSxeftg0AAADwStD21KlT8XkbAAAAkCA2b94s27Ztk5QpU7rML1iwoPz111+cBQAAAPhfTVtnNpvNTAAAAIBVhIeHy8OHDyPNP3funCmTAAAAAPhl0Pb777+XcuXKSerUqc1Uvnx5mTFjhmdbBwAAAMRDw4YNZcyYMS4lvHQAsgEDBkjTpk05pgAAAPC/8ghffvmlfPzxx9KtWzepUaOGmbdlyxZ588035e+//5ZevXp5up0AAACA20aNGiWNGjWS0qVLy7179+TFF1+UY8eOSbZs2eS///0vRxIAAAD+F7QdP368TJo0STp27OiY17JlSylTpowMHDiQoC0AAAB8Km/evGYQslmzZsn+/ftNlm3nzp2lffv25ikxAAAAwO+CthcuXJDq1atHmq/zdBkAAADgawEBAdKhQwdfNwMAAABImKBt0aJFZc6cOfLhhx+6zJ89e7YUK1YsPpsEAAAAPEbHX4iJ8xNjAAAAgF8EbQcNGiQhISHy888/O2rabt26VdatW2eCuQAAAIAv9ejRw+X1/fv35c6dO5IyZUpJkyYNQVsAAABYWvL4vKlt27byyy+/mIEcFi1aZCb9fefOnfLMM894vpUAAABAHFy7ds1l0pq2R44ckZo1azIQGQAAAPwz01ZVqlRJfvjhB8+2BgAAAPASLeP12WefmTq3hw8f5jgDAADAvzJtly9fLqtWrYo0X+etWLHCE+0CAAAAvDI42fnz5zmyAAAA8L9M2w8++MBkKURks9nMsiZNmniibQAAAEC8LFmyJFI/9cKFCzJhwgTHmAwAAACAXwVtjx07JqVLl440v2TJknL8+HFPtAsAAACIt9atW7u8TpYsmWTPnl3q1q0ro0aN4sgCAADA/4K2GTNmlJMnT0rBggVd5mvANm3atJ5qGwAAABAv4eHhHDkAAAAkrZq2rVq1kp49e8qJEydcArZ9+vSRli1berJ9AAAAAAAAAJCkxCvTdsSIEdK4cWNTDiFv3rxm3tmzZ6V27doycuRIT7cRAAAAiJPevXu7ve6XX37J0QUAAIB/lEfYtm2brFmzRn777TdJnTq1VKhQQWrVquX5FgIAAABx9Ouvv5rp/v37UqJECTPv6NGjkiJFCqlYsaJLrVsAAKIzcd/EJH9wRq85muSPAWD5oO327dvl6tWr0rx5c9PBbdiwoRmFd8CAAXLnzh0z4MP48eMlKCjIey0GAAAAYtGiRQtJnz69TJ8+XTJnzmzmXbt2TV555RWTaKBlvQAAAAC/CNoOHjxYnn76aRO0VQcOHJAuXbpIp06dpFSpUvLFF19Injx5ZODAgd5qLwDATS3Gb/H6sVravabX9wEA8TFq1ChZvXq1I2Cr9PehQ4eaxAOCtgAAAPCbgcj27dsn9erVc7yeNWuWVK5cWb755htTN2zcuHEyZ84cb7QTAAAAcNuNGzfkypUrkebrvJs3b3IkAQAA4D9BW32kLGfOnI7XmzZtkiZNmjheP/nkk2ZAMgAAAMCXnnnmGVMKYcGCBXLu3DkzzZ8/Xzp37ixt2rTh5AAAAMB/yiNowPbUqVOSL18+CQsLk71798qgQYMcyzVrITAw0BvtBAAAANw2efJkeffdd+XFF180g5GpgIAAE7TVkl4AAMB/B0Tr1aC4V9sCWC5o27RpU/nggw/k888/l0WLFkmaNGnMQA52+/fvlyJFinijnQAAAIDbtJ86ceJEE6A9ceKEmaf91LRp03IUAQAA4F9B2yFDhpjHyZ566ilJly6dGY03ZcqUjuXfffedGdgBAAAAsIILFy6YqXbt2pI6dWqx2WySLFkyXzcLAABAdi49GetRqNyiMEcqiYpT0DZbtmzy888/y/Xr103QNkWKFC7L586da+YDAAAAvnT16lVp166dbNiwwQRpjx07JoULFzblETJnziyjRo3iBAEAAMA/grZ2GTNmjHJ+lixZHrU9AAAAwCPr1auXGWvhzJkzUqpUKcf8kJAQ6d27N0FbAP5vw/DY16nTLyFaAgBIqKAtAAAAYGWrV6+WVatWSd68eV3mFytWTP7880+ftQsAAABwR3K31gIAAAASkdu3b5vByCL6559/JCgoyCdtAgAAANxFpi0AAAD8Tq1ateT77783A+kqrWsbHh4uI0aMkDp16vi6eQDi4cr4CW6vm717N44xACBRI2gLAAAAv6PB2Xr16snu3bslLCxM3n//fTl48KDJtN26dauvmwcAAADEiPIIAAAA8Dtly5aVo0ePSs2aNaVVq1amXEKbNm3k119/lSJFivi6eQAAAECMyLQFAACAX7l//740btxYJk+eLB999JGvmwMAAADEGZm2AAAA8CuBgYGyf/9+XzcDAAAAiDcybQEAAOB3OnToIFOmTJHPPvvM100BAACJ1M6lJ33dBCRhBG0BAADgdx48eCDfffedrF27VipVqiRp06Z1Wf7ll1/6rG0AXF0ZPyFpHZINw33dAgBAIkDQFgAAAH7j5MmTUrBgQfn999+lYsWKZp4OSOYsWbJkPmodAAAA4B6CtgAAAPAbxYoVkwsXLsiGDRvM65CQEBk3bpzkzJnT100DAAAA3MZAZAAAAPAbNpvN5fWKFSvk9u3bPmsPAAAAEB8EbQEAAJBkgrgAAABAYkDQFgAAAH5D69VGrFlLDVsAAAAkNtS0BQAAgF9l1r788ssSFBRkXt+7d0/efPNNSZs2rct6CxYs8FELAQAAgNgRtAUAAIDf6NSpk8vrDh06+KwtAAAAQHwRtAUAAIDfmDp1qse2NXz4cJORe/jwYUmdOrVUr15dPv/8cylRooRjHc3k7dOnj8yaNUtCQ0OlUaNGMnHiRMmZM6djnTNnzshbb70lGzZskHTp0pnAsm47IICuOOAtV8ZPcHvd7N27cSIAAJZDTxEAEH9fP+X9o/fGJu/vAwCisGnTJunatas8+eST8uDBA/nwww+lYcOGcujQIUe5hV69eslPP/0kc+fOlYwZM0q3bt2kTZs2snXrVrP84cOH0qxZM8mVK5ds27ZNLly4IB07dpTAwEAZNmwYxx0AAABRImgLAAAARGHlypUur6dNmyY5cuSQPXv2SO3ateX69esyZcoUmTlzptStW9eR6VuqVCnZsWOHVK1aVVavXm2CvGvXrjXZt8HBwTJkyBDp27evDBw4UFKmTMmxBwAAQCQEbQEAAAA3aJBWZcmSxfzU4O39+/elfv36jnVKliwp+fPnl+3bt5ugrf4sV66cS7kELaGg5RIOHjwojz/+OMce8Ccbhvu6BQAAP0HQFgAAAIhFeHi49OzZU2rUqCFly5Y18y5evGgyZTNlyuSyrgZodZl9HeeArX25fVlUtDauTnY3btzg/AAAACQxyX3dAAAAAMDqtLbt77//bgYc8zYdpEzr49qnfPnyeX2fAAAAsBaCtgAAAEAMdHCxZcuWyYYNGyRv3ryO+Tq4WFhYmPz7778u61+6dMkss6+jryMuty+LSr9+/UwpBvt09uxZzg8AAEASQ9AWAAAAiILNZjMB24ULF8r69eulUKFCLssrVaokgYGBsm7dOse8I0eOyJkzZ6RatWrmtf48cOCAXL582bHOmjVrJEOGDFK6dOkoj3tQUJBZ7jwBAAAgaaGmLQAAABBNSYSZM2fK4sWLJX369I4atFqyIHXq1OZn586dpXfv3mZwMg2udu/e3QRqdRAy1bBhQxOcfemll2TEiBFmG/379zfb1uAsAAAAEBWCtgAAAEAUJk2aZH4+/fTTLvOnTp0qL7/8svl99OjRkjx5cmnbtq0ZPKxRo0YyceJEx7opUqQwpRXeeustE8xNmzatdOrUSQYPHswxBwAAgDWDtjrIwoIFC+Tw4cMmW6F69ery+eefS4kSJXzZLAAAAMCUR4hNqlSp5KuvvjJTdAoUKCDLly/niAIAAMBtPq1pu2nTJvNo2I4dO0xtr/v375tHyG7fvu3LZgEAAAAAAABA0sy0XblypcvradOmSY4cOWTPnj1Su3Ztn7ULAAAAAAAAAHzFUjVtr1+/bn7qQA5R0TphOtnduHEjwdoGAAAAAAAAAH5fHsFZeHi49OzZU2rUqCFly5aNtgaujtJrn/Lly5fg7QQAAAAAAACAJBG01dq2v//+u8yaNSvadfr162eyce3T2bNnE7SNAAAAAAAAAJAkyiN069ZNli1bJj///LPkzZs32vWCgoLMBAAAAAAAAAD+yqdBW5vNJt27d5eFCxfKxo0bpVChQr5sDgAAAAAAAAAk7aCtlkSYOXOmLF68WNKnTy8XL14087VeberUqX3ZNAAAAAAAAABIejVtJ02aZGrTPv3005I7d27HNHv2bF82CwAAAAAAAACSbnkEAAAAAAAAAIBFMm0BAAAAAAAAAK4I2gIAAAAAAACAhRC0BQAAAAAAAAALIWgLAAAAAAAAABZC0BYAAAAAAAAALISgLQAAAAAAAABYSICvGwAAAAAA8C9Xxk/wdRMAAEjUyLQFAAAAAAAAAAshaAsAAAAAAAAAFkJ5BAAAAAAAAMCCdi49GePyyi0KJ1hbkLAI2gIAAAAA3EKtWgAAEgblEQAAAAAAAADAQgjaAgAAAAAAAICFELQFAAAAAAAAAAshaAsAAAAAAAAAFsJAZAAASwtZFuL1fcxuPtvr+wAAAAAAwF0EbQEAAAAAAJKQ0WuO+roJAGJB0BYAAAAAAMBPTdw3MdK8vTeuRrt+xQzef9INQOyoaQsAAAAAAAAAFkLQFgAAAAAAAAAshKAtAAAAAAAAAFgINW0BAAAAAECSsOvirmiX7dt3PUHbAgAxIdMWAAAAAAAAACyEoC0AAAAAAAAAWAhBWwAAAAAAAACwEGraAgAAAACQBGzbdcZ1xt8/+qopAIBYkGkLAAAAAAAAABZCpi0AAAAAJGFXxk/wdRMAAEAEBG0BAAAAwM8QiAUAIHGjPAIAAAAAAAAAWAhBWwAAAAAAAACwEMojAAAAAAAAIMnZufSkr5sARItMWwAAAAAAAACwEIK2AAAAAAAAAGAhBG0BAAAAAAAAwEII2gIAAAAAAACAhRC0BQAAAAAAAAALIWgLAAAAAAAAABZC0BYAAAAAAAAALISgLQAAAAAAAABYSICvGwAAAAAAAAB4yug1R91aL8XJ6+Zn1cJZOfiwHDJtAQAAAAAAAMBCyLQFAAAAAB+6Mn6C2+tm797Nq21BDDYM97/Dc2pLzMsL1UyolgAAIiDTFgAAAAAAAAAshExbAAAAAPDDrFwAAJB4kWkLAAAAAAAAABZCpi0AAAAAAEjy7m8+Gq9jEFireJI/dgA8j6AtAAAAAAAAkAjtXHoyxuWVWxROsLbAsyiPAAAAAAAAAAAWQtAWAAAAAAAAACyEoC0AAAAAAAAAWAhBWwAAAAAAAACwEIK2AAAAAAAAAGAhBG0BAAAAAAAAwEII2gIAAAAAAACAhQT4ugEAAAAA4I+ujJ/g6yYAAIBEikxbAAAAAAAAALAQgrYAAAAAAAAAYCEEbQEAAAAAAADAQgjaAgAAANH4+eefpUWLFpInTx5JliyZLFq0yGW5zWaTTz75RHLnzi2pU6eW+vXry7Fjx1zW+eeff6R9+/aSIUMGyZQpk3Tu3Flu3brFMQcAAEC0CNoCAAAA0bh9+7ZUqFBBvvrqqyiXjxgxQsaNGyeTJ0+WX375RdKmTSuNGjWSe/fuOdbRgO3BgwdlzZo1smzZMhMIfv311znmAAAAiFZA9IsAAACApK1JkyZmiopm2Y4ZM0b69+8vrVq1MvO+//57yZkzp8nIff755+WPP/6QlStXyq5du+SJJ54w64wfP16aNm0qI0eONBm8AAAAQERk2gIAAADxcOrUKbl48aIpiWCXMWNGqVKlimzfvt281p9aEsEesFW6fvLkyU1mLgAAABAVMm0BAACAeNCArdLMWmf62r5Mf+bIkcO1Ax4QIFmyZHGsE1FoaKiZ7G7cuMH5AQAASGKSW3lgBwAAACCpGT58uMnYtU/58uXzdZMAAACQlIK2sQ3sAAAAAFhVrly5zM9Lly65zNfX9mX68/Llyy7LHzx4IP/8849jnYj69esn169fd0xnz5712mcAAACANQVYdWAHAAAAwMoKFSpkAq/r1q2T4OBgRykDrVX71ltvmdfVqlWTf//9V/bs2SOVKlUy89avXy/h4eGm9m1UgoKCzAQAAICkK1HVtKW+FwAAABLSrVu35Pjx4y6Dj+3bt8/UpM2fP7/07NlThg4dKsWKFTNB3I8//tiU/mrdurVZv1SpUtK4cWPp0qWLTJ48We7fvy/dunWT559/3qwHwPeujJ/g1nrZy3q9KQAAJM6grdb3GjRokK+bAQAAgCRi9+7dUqdOHcfr3r17m5+dOnWSadOmyfvvv29Kfr3++usmo7ZmzZqycuVKSZUqleM9P/74ownU1qtXT5InTy5t27aVcePG+eTzAACAyHacvOr2YalaOCuHEAkiUQVttb6XvaNsf/yMgRkAAADgLU8//bTYbLZol+tguoMHDzZTdDQrd+bMmV5qIQAA/2f7CfcDjwCsL1EFbanvBQAAAAAAAMDfJfd1AwAAAAAAAAAAFsm0jW1gBwAAAABIjINWAQAAJNqgbWwDOwAAAAAAAABAUhNg5YEdAAAAAAAAACCpoaYtAAAAAAAAAFgIQVsAAAAAAAAAsBCflkcAAAAAAAAAvCHFoescWCRaZNoCAAAAAAAAgIUQtAUAAAAAAAAAC6E8AgAAAAAApzfHfAzKBnOMAAAJhqAtAAAAACBpB2QBALAYyiMAAAAAAAAAgIUQtAUAAAAAAAAACyFoCwAAAAAAAAAWQtAWAAAAAAAAACyEoC0AAAAAAAAAWEiArxsAAAAAAADcs23XGQ4VACQBZNoCAAAAAAAAgIWQaQsAAAAAACI7tSX2o1Kopk+P3K6Lu3y6fwDwFoK2AAAAAAAASHRSHLru6yZY3s6lJ2NcXrlF4QRrC+KG8ggAAAAAAAAAYCFk2gIAAAAAAFjQ9hNXfd0EAD5C0BYAAAAAAADG3huz43QkKmYI4cglYpRPsC7KIwAAAAAAAACAhRC0BQAAAAAAAAALIWgLAAAAAAAAABZC0BYAAAAAAAAALISgLQAAAAAAAABYCEFbAAAAAAAAALAQgrYAAAAAAAAAYCEEbQEAAAAAAADAQgjaAgAAAAAAAICFELQFAAAAAAAAAAsJ8HUDAAAAAAAAAGcpDl3ngCBJI2gLAAAAAAAsYdfFXb5uAgBYAuURAAAAAAAAAMBCCNoCAAAAAAAAgIVQHgEAAAAAACCe7m8+Gu9jF1irOMcdQJQI2gIAAAAAgPg5tSX2dQrV5Og6OffPXcfvF09c5dgAiBJBWwAAAAAAAMTL3huz4/yeihlCJMWh6xxxIAbUtAUAAAAAAAAACyFoCwAAAAAAAAAWQnkEAAAAAAAAAJHsXHoyxqNSuUVhjpqXELQFAAAAAAAA3LDjpPuDx1UtnJVjingjaAsAAAAASLxOb/Z1CwAgyYotE1eRjRs/BG0BAAAA+KUr4ye4vW727t282hYAAIC4IGgLAAAAIMmLS4AXSdOVZfvcXjd782CvtgUA4P+S+7oBAAAAAAAAAID/IdMWAAAAAIAEtm3XmSRxzHfduyRycZevmwEAiQ6ZtgAAAAAAAABgIQRtAQAAAAAAAMBCCNoCAAAAAAAAgIUQtAUAAAAAAAAAC2EgMgAAAACANZ3e7OsWIKqBxQAAXkfQFgAAAADgGwRlAb+V90S+aJelCLqeoG0BEiOCtgAAAAAAAPF07p+7HDsAHkfQFgAAAAAAD7qybF+s69y+HiZpi+dKGsf92pnY18mcPyFaAgCJBkFbAAAAAAAAJJgLoQfjtH7uoDJeawtgVQRtAQAAAACeR71aIFa5fj8Xr6N0sWxeji7g5wjaAgAAAAAQD/uuh3HcAERrx8mrbh+dqoWzciThgqAtAAAAAACAEwYXi13eE/n4mwG8iKAtAAAAAACw9mBlDFSW4AjKAr5F0BYAAAAAACTuoK4isBsnBGUTbykFRTkF/5fc1w0AAAAAAAAAAPwPmbYAAAAAAABJRK7fz5mfaa7diNP77uQp46UWAYgKQVsAAAAAAAAAXrFz6ckYl1duUZgjHwWCtgAAAAB87sr4CW6tl717N6+3BUgot49e9Pg20xbP5fFtwr/q0cY1w9YKLoQejNP6uYP8Pys4LjVwqX+bOBG0BQAAAAAkafuuh/m6CUgA5/656zfHOc35uAUxgcRsZxLN1LVE0Parr76SL774Qi5evCgVKlSQ8ePHS+XKlX3dLAAAAMBjkmKf193sWV9vE0iq2bv+kJV74979//2eiIKyGa5liHH5jcyJLxsWgJ8FbWfPni29e/eWyZMnS5UqVWTMmDHSqFEjOXLkiOTIkcPXzQMAAAAeGX1e+J3Tm33dAsCvxRbUhWdRfsHambRJNRPX50HbL7/8Urp06SKvvPKKea3B259++km+++47+eCDD3zdPAAAAOCR0edFouPDoCylCuLv/IPbcXvDoRNur/pv4XTiiWxYb8oQej72tgTlSZC2wDPlHO7kKZMgQVj4t52JNKjr06BtWFiY7NmzR/r16+eYlzx5cqlfv75s377dl00DAAAAPII+LywXbC1YKyFaAnhMzjPulz24lD/1Iwd23RF0I2+My0MznIv5/Q+SS2hA/APhSaWO7qPsM74BX3/MzLXKoGVWaUdi4dOg7d9//y0PHz6UnDlzuszX14cPH460fmhoqJnsrl+/bn7euJGwtV7u343j3ct4uPHwgdf3cf+O9+92JsS58fb54Fy4j/83ktb/G4r/P5LW+eB7w338v/Fo/zbabDbxJ4m1z/vLwtnxfm+VZ0LMz5t3E099yUThjIcSW46sd2u1vaGX47TZikGeKW93OyxhsjK97Wao+58jfVCgR/Z594FrXyD0Ybh4zMF/3Frtct5Ubm8yx7l7bq0Xl39J7sXhuD9KO+9L1H27Oxn//7n8O+b/H+5JmIQ+/N+/9VEJehh7/zE0RdpY10mqQu9Z5zvonu1WnNa/GBq5fxCbXEElxRNu3Ukp3nLv3i1LtCMiq/Z5fV4eIS6GDx8ugwYNijQ/X7584m8yin9YKAslseNcWAvnw1o4H9biD+fDH743/OVc+PJ83Lx5UzJm9JejmET7vC+/7usWAAAAWFpsfV6fBm2zZcsmKVKkkEuXLrnM19e5ckUexVLLKOigZXbh4eHyzz//SNasWSVZsmSSVGmEXjvxZ8+elQwZKFbua5wPa+F8WAfnwlo4H9bC+RBHtoF2XvPk8a96g4m9z8vfp3/hfPofzql/4Xz6F86nf7nhofibu31enwZtU6ZMKZUqVZJ169ZJ69atHZ1Sfd2tW7dI6wcFBZnJWaZMmRKsvVanfzAEba2D82EtnA/r4FxYC+fDWjgf4pcZtv7S5+Xv079wPv0P59S/cD79C+fTv2TwQPzNnT6vz8sjaBZBp06d5IknnpDKlSvLmDFj5Pbt2/LKK6/4umkAAACAR9DnBQAAQFz4PGgbEhIiV65ckU8++UQuXrwowcHBsnLlykgDNQAAAACJFX1eAAAAJKqgrdLHwqJ6NAzu0cfnBgwYEOkxOvgG58NaOB/WwbmwFs6HtXA+kobE2ufl79O/cD79D+fUv3A+/Qvn078EJXD8LZlNq98CAAAAAAAAACwhua8bAAAAAAAAAAD4H4K2AAAAAAAAAGAhBG0BAAAAAAAAwEII2vqBr776SgoWLCipUqWSKlWqyM6dO33dpCTp559/lhYtWkiePHkkWbJksmjRIl83KckaPny4PPnkk5I+fXrJkSOHtG7dWo4cOeLrZiVZkyZNkvLly0uGDBnMVK1aNVmxYoWvmwUR+eyzz8y/Vz179uR4+MDAgQPN8XeeSpYsybmAZdC38S/0j/wL/Sv/Rh8t8aOf53/++usv6dChg2TNmlVSp04t5cqVk927d3t1nwRtE7nZs2dL7969zeh1e/fulQoVKkijRo3k8uXLvm5aknP79m1z/DWIDt/atGmTdO3aVXbs2CFr1qyR+/fvS8OGDc05QsLLmzev6Xju2bPHfKnVrVtXWrVqJQcPHuR0+NCuXbvk66+/NgF1+E6ZMmXkwoULjmnLli2cDlgGfRv/Qv/Iv9C/8l/00fwH/Tz/ce3aNalRo4YEBgaaBKRDhw7JqFGjJHPmzF7dbzKbzWbz6h7gVZpZqxmFEyZMMK/Dw8MlX7580r17d/nggw84+j6i2VILFy40GZ7wvStXrpiMW71YqV27tq+bAxHJkiWLfPHFF9K5c2eOhw/cunVLKlasKBMnTpShQ4dKcHCwjBkzhnPhgwwMfSpj3759HHtYHn0b/0P/yP/Qv0r86KP5D/p5/uWDDz6QrVu3yubNmxN0v2TaJmJhYWEmc61+/fqOecmTJzevt2/f7tO2AVZy/fp1R0cWvvXw4UOZNWuWyd7SMgnwDc1Eb9asmcv3B3zj2LFjpqxO4cKFpX379nLmzBlOBYAEQf/If9C/8h/00fwL/Tz/sWTJEnniiSfkueeeMwlhjz/+uHzzzTde32+A1/cAr/n777/NF3TOnDld5uvrw4cPc+SB/599rvU69VGGsmXLckx85MCBAyZIe+/ePUmXLp3JRC9dujTnwwc0aK7ldPTRO/j+aZlp06ZJiRIlTGmEQYMGSa1ateT33383NbkBwFvoH/kH+lf+hT6af6Gf519OnjxpaolredIPP/zQXEu98847kjJlSunUqZPX9kvQFoDf363WAAh1In1Lg1L6CLhm9cybN898sWm5CgK3Cevs2bPSo0cPU+tZB6+EbzVp0sTxu9YW1s59gQIFZM6cOZQOAeBV9I/8A/0r/0Efzf/Qz/O/m51PPPGEDBs2zLzWTFuNM0yePNmrQVvKIyRi2bJlkxQpUsilS5dc5uvrXLly+axdgFV069ZNli1bJhs2bDCDNcB39A5k0aJFpVKlSmb0ah20b+zYsZySBKYldXSgSq1nGxAQYCYNno8bN878rk9vwHcyZcokxYsXl+PHj3MaAHgN/SP/Qf/Kf9BH83/08xK33LlzR0o4KlWqlNdLmxG0TeRf0hoAWbdunUv0X19TKxJJmY6vqBck+gj++vXrpVChQr5uEiLQf6tCQ0M5LgmsXr165lFKzXq2T3rHWGup6u96IxC+HXzkxIkTplMIAJ5G/8j/0b9KvOij+T/6eYlbjRo15MiRIy7zjh49ap6S8ybKIyRyWk9DU7H1orty5cpm9G8d4OeVV17xddOS5D/CztlRp06dMkEQHfwqf/78Pm1bUnzkb+bMmbJ48WJTF/LixYtmfsaMGSV16tS+bl6S069fP/N4kP5/cPPmTXNuNm7cKKtWrfJ105Ic/f8hYm3ntGnTStasWan57APvvvuutGjRwnT2zp8/LwMGDDCB8xdeeMEXzQEioW/jX+gf+Rf6V/6FPpr/oZ/nX3r16iXVq1c35RHatWsnO3fulP/85z9m8iaCtolcSEiIXLlyRT755BMTmAoODpaVK1dGGpwM3rd7926pU6eOS0BdaVBdB5pBwtEC4erpp592mT916lR5+eWXORUJTB/H79ixoxloSQPnWrtTA7YNGjTgXCBJO3funAnQXr16VbJnzy41a9aUHTt2mN8BK6Bv41/oH/kX+leAtdHP8y9PPvmkeZJXb5gNHjzYPM2rSZP6xKI3JbPpczIAAAAAAAAAAEugpi0AAAAAAAAAWAhBWwAAAAAAAACwEIK2AAAAAAAAAGAhBG0BAAAAAAAAwEII2gIAAAAAAACAhRC0BQAAAAAAAAALIWgLAAAAAAAAABZC0BYAAAAAAAAALISgLQAAAAAAsJSBAwdKcHCwr5sBAD5D0BYAYvDyyy9LsmTJzBQYGCg5c+aUBg0ayHfffSfh4eFJ4thNmzZNMmXK5OtmAAAA4BFduXJF3nrrLcmfP78EBQVJrly5pFGjRrJ161a/OLbaZ1+0aJHHt7tx40az7X///dfj2waA6AREuwQAYDRu3FimTp0qDx8+lEuXLsnKlSulR48eMm/ePFmyZIkEBPBPKQAAAKyvbdu2EhYWJtOnT5fChQubvu26devk6tWrXtun7i9lypRe2z4A+CsybQEgFvYshMcee0wqVqwoH374oSxevFhWrFhhslDVmTNnpFWrVpIuXTrJkCGDtGvXznSCnS1dulSefPJJSZUqlWTLlk2eeeaZGLMCNLvVvv3Tp0+bdebMmSO1atWS1KlTm20dPXpUdu3aJU888YTZd5MmTUwGhbNvv/1WSpUqZfZbsmRJmThxomOZfbsLFiyQOnXqSJo0aaRChQqyfft2R1bBK6+8ItevX3dkHOujagAAAEhcNEt08+bN8vnnn5t+X4ECBaRy5crSr18/admypct6b7zxhnnCTPuPZcuWlWXLljmWz58/X8qUKWP6yAULFpRRo0a57EfnDRkyRDp27Gj6xa+//rqZv2XLFkc/Nl++fPLOO+/I7du33W6/9nn1iTftR2fMmFGeeuop2bt3r8t+lfaxtc9qf6207679eP08GqweNGiQPHjwwLFc19c+s75X+8PFihUzyRn2/rIeL5U5c2azrj6NBwDeRtAWAOKhbt26JripwU4tk6AB23/++Uc2bdoka9askZMnT0pISIhj/Z9++sl0Aps2bSq//vqryWjQTnJcDRgwQPr37286qJrh++KLL8r7778vY8eONZ3w48ePyyeffOJY/8cffzSvP/30U/njjz9k2LBh8vHHH5vsCmcfffSRvPvuu7Jv3z4pXry4vPDCC6YjW716dRkzZozpcF+4cMFMuh4AAAASF73Br5MmCoSGhka5jvZrNQlAyyX88MMPcujQIfnss88kRYoUZvmePXtMcsLzzz8vBw4cMDfztW9pTzSwGzlypOkra79Xl584ccI8vaaZvvv375fZs2ebIG63bt3cbv/NmzelU6dO5n07duwwgVXtW+t8e1BX6RNy2me1v9Y+sgaQ9Uk5/Txff/21aa/2j51pIFc/m7ZPt9u+fXvTv9cAswaq1ZEjR8y2te8NAF5nAwBEq1OnTrZWrVpFuSwkJMRWqlQp2+rVq20pUqSwnTlzxrHs4MGDNv0ndufOneZ1tWrVbO3bt492P7ruwoULXeZlzJjRNnXqVPP7qVOnzDrffvutY/l///tfM2/dunWOecOHD7eVKFHC8bpIkSK2mTNnumx3yJAhpj3Rbdfe9j/++MO81jZoWwAAAJC4zZs3z5Y5c2ZbqlSpbNWrV7f169fP9ttvvzmWr1q1ypY8eXLbkSNHonz/iy++aGvQoIHLvPfee89WunRpx+sCBQrYWrdu7bJO586dba+//rrLvM2bN5t93b17N8p9DRgwwFahQoVoP8vDhw9t6dOnty1dujTGPnW9evVsw4YNc5k3Y8YMW+7cuV3e179/f8frW7dumXkrVqwwrzds2GBeX7t2Ldr2AICnkWkLAPG/6WUej9IMVr0Dr5Nd6dKlTXkDXaY0g7VevXqPfKzLly/v+F0fWVPlypVzmXf58mXzuz5uplkNnTt3dmRW6DR06FAzP7rt5s6d2/y0bwcAAAD+QTNdz58/bx7918xXLYWlZQPsmbLaZ82bN6958ioq2retUaOGyzx9fezYMTP+g52W7nL222+/mX0490l1ADTN7D116pRbbdfSY126dDEZtloeQZ8Eu3XrlilTFhPd9+DBg132rdvRjNk7d+5E2R9Omzat2T79YQC+xOg5ABBP2mktVKiQW+tq7a6YaPD3/27y/8/9+/cjrRcYGOjynqjmaedXaSdWffPNN1KlShWX7dgfcYtpu/btAAAAwH9oXVetDauTli547bXXTAkurdMaW5/VXRr0dKb9Uq2Tq3VsI8qfP79b29TSCDpgmpYm0Hq8WlO3WrVqZqCzmOi+tfRBmzZtojwWUfWHI/arAcAXCNoCQDysX7/e1PHq1auXyUY4e/asmezZtlovSwdx0Ixb+517rWOrg3pFJXv27OZuv51mKzjf+Y8PzbrNkyePqa+rNbniS0f7dc6cAAAAgP/Q/qp9QFzts547d84MdhtVtq0Obqv1bp3pa103YlKAM83m1f5x0aJF491O3Y8OqKv1ZpX2vf/++2+XdTTwGrHfqvvWWrSPsm/tDyv6xAASEkFbAIiFDtRw8eJF00nTx7JWrlwpw4cPl+bNm5tBDZInT25KFGhgVAft0gG83n77bTOirf3RMM1e0PIIRYoUMQM36DrLly+Xvn37OgY2mzBhgskW0P3o/Ih3++NDswo0o0EfIdNH4PSz7N69W65duya9e/d2axs68q5mKGjQWQeU0BF1dQIAAEDioVmqzz33nLz66qsmOJs+fXrTLxwxYoQZVFdp/7V27dqmjMKXX35pAp2HDx82Wafal+zTp488+eSTMmTIEDPo7vbt200fVoOpMdG+bdWqVc3AY5rZq5m4GsTVAXz1/e7QsggzZsww/esbN27Ie++9FykzWPut2mfVkg2aiZs5c2YzKK/22zWj99lnnzV9dy2Z8Pvvv5uyYe7QzF49BsuWLTNBY92vllkAAG+ipi0AxEKDtFrnVTuB2lndsGGDjBs3ThYvXmwyCrQDp79rp1A7ufXr15fChQubUXHtnn76aZk7d66pHxYcHGyCtDt37nQsHzVqlMnSrVWrlrz44ovy7rvveiQwqp3ib7/91oyiq4Fl7YhrPTF3yzqo6tWry5tvvmk65poRrB17AAAAJC4aZNSSWaNHjzZ91rJly5ryCFrf1TlwOn/+fBOYfeGFF0wW7vvvv+/IMNWs1Tlz5sisWbPM+zUgqvVitbRCTDRIvGnTJpPBq/3dxx9/3LxXnwpz15QpU0zigbbhpZdeMokJOXLkcFlH+9QaCNZ+te5Dae1cDbauXr3afC4NHusx0ECsux577DGTDPHBBx+Yp9k0+AwA3pZMRyPz+l4AAAAAAAAAAG4h0xYAAAAAAAAALISgLQAAAAAAAABYCEFbAAAAAAAAALAQgrYAAAAAAAAAYCEEbQEAAAAAAADAQgjaAgAAAAAAAICFELQFAAAAAAAAAAshaAsAAAAAAAAAFkLQFgAAAAAAAAAshKAtAAAAAAAAAFgIQVsAAAAAAAAAsBCCtgAAAAAAAAAg1vH/AONh8z/udgCUAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 1400x500 with 2 Axes>"
       ]
@@ -2655,14 +2711,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "727b2f3d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:54:57.226647Z",
-     "iopub.status.busy": "2026-08-26T10:54:57.226647Z",
-     "iopub.status.idle": "2026-08-26T10:55:14.079881Z",
-     "shell.execute_reply": "2026-08-26T10:55:14.079881Z"
+     "iopub.execute_input": "2026-08-29T01:37:49.988621Z",
+     "iopub.status.busy": "2026-08-29T01:37:49.988621Z",
+     "iopub.status.idle": "2026-08-29T01:38:14.061978Z",
+     "shell.execute_reply": "2026-08-29T01:38:14.061978Z"
     },
     "papermill": {
      "duration": 16.88015,
@@ -2698,7 +2754,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "23b274d77d2e4222ba2d85e3fb790aaf",
+       "model_id": "5d4d2729ebaa499ea7bf647fcd48bf2d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2723,14 +2779,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 16 seconds.\n"
+      "Sampling 2 chains for 1_000 tune and 1_000 draw iterations (2_000 + 2_000 draws total) took 19 seconds.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "There were 100 divergences after tuning. Increase `target_accept` or reparameterize.\n"
+      "There were 98 divergences after tuning. Increase `target_accept` or reparameterize.\n"
      ]
     },
     {
@@ -2748,27 +2804,24 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Diagnostic MCMC (films) : divergences=100 ; pire r_hat=1.030 (sur U_f[0, 1]) ; ess_bulk min=139\n",
+      "Rapport strict (exemple guide films) : 0/4 criteres tenus\n",
+      "  [FAIL] divergences = 0  -> 98 divergences\n",
+      "  [FAIL] r_hat < 1.01     -> max r_hat = 1.030 (sur V_f[2, 0])\n",
+      "  [FAIL] ess_bulk > 400   -> min ess_bulk = 210 (sur U_f[0, 0])\n",
+      "  [FAIL] ess_tail > 400   -> min ess_tail = 252 (sur sigma_f)\n",
       "=== Recommandations de Films ===\n",
       "             Inception     Titanic      MatrixNotebookFilm  Terminator\n",
-      "     Alice        0.05       -0.04        0.04       -0.02        0.05\n",
-      "       Bob       -0.02        0.02       -0.02        0.01       -0.02\n",
-      "   Charlie        0.03       -0.02        0.02       -0.01        0.03\n",
+      "     Alice        0.08        0.01        0.06        0.02        0.08\n",
+      "       Bob        0.03        0.01        0.01        0.01        0.01\n",
+      "   Charlie        0.07        0.01        0.04        0.02        0.06\n",
       "\n",
       "Top recommandations :\n",
-      "  Alice : NotebookFilm (score: -0.02)\n",
-      "  Bob : Matrix (score: -0.02)\n",
-      "  Charlie : Terminator (score: 0.03)\n"
+      "  Alice : NotebookFilm (score: 0.02)\n",
+      "  Bob : Inception (score: 0.03)\n",
+      "  Charlie : Terminator (score: 0.06)\n"
      ]
     }
    ],
@@ -2799,11 +2852,7 @@
     "                           random_seed=42, cores=1,\n",
     "                           return_inferencedata=True)\n",
     "\n",
-    "# Lecture de diagnostic (honnete) : quantifier le warning rhat/ESS (voir PyMC-6-Debugging)\n",
-    "diag_film = az.summary(trace_film, kind=\"diagnostics\")\n",
-    "wv_film = diag_film[\"r_hat\"].idxmax()\n",
-    "div_film = int(trace_film.sample_stats[\"diverging\"].sum())\n",
-    "print(f\"Diagnostic MCMC (films) : divergences={div_film} ; pire r_hat={diag_film['r_hat'].max():.3f} (sur {wv_film}) ; ess_bulk min={int(diag_film['ess_bulk'].min())}\")\n",
+    "rapport_diagnostic_strict(trace_film, \"exemple guide films\")\n",
     "\n",
     "# Predictions\n",
     "U_f_post = trace_film.posterior['U_f'].mean(dim=['chain', 'draw']).values\n",
@@ -2845,11 +2894,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Lecture du diagnostic : films — modèle sous-contraint (7 notes, priors larges)\n",
-    "\n",
-    "Le `az.summary(kind=\"diagnostics\")` fraîchement lu quantifie le warning : **100 divergences**, `r_hat` max **1.030** (sur `U_f[0,1]`), `ess_bulk` min **139** (> 100). Une divergence élevée avec un `r_hat` et un ess acceptables indique un **postérieur mal conditionné** plutôt qu'une non-convergence totale. Le modèle de films n'a que **7 observations** (3 utilisateurs × 5 items = 15 paires, 7 notées) pour estimer **17 paramètres** (3×2 traits user + 5×2 traits item + 1 sigma) — ratio données/paramètres ~0.4. Avec des priors larges (`sigma=2` sur `U_f`/`V_f`), NUTS explore des régions pathologiques → trajectoires divergentes. Les scores prédits et le classement restent exploitables (ordre relatif), mais l'incertitude sur les traits latents est surestimée. Remède : prior plus informatif, plus de données, ou `target_accept` relevé. Voir [PyMC-6-Debugging](PyMC-6-Debugging.ipynb) pour la lecture systématique."
-   ]
+   "source": "### Lecture du diagnostic : films — modèle sous-contraint, 0/4 au rapport strict\n\nLe rapport strict fraîchement lu quantifie le warning : **0/4 critères tenus** — **98 divergences**, `r_hat` max **1.030** (sur `V_f[2,0]`), `ess_bulk` min **210** (sur `U_f[0,0]`), `ess_tail` min **252** (sur `sigma_f`) — mais des ess qui restent au-dessus du seuil de vigilance 100. Une divergence élevée avec un `r_hat` et un ess acceptables indique un **postérieur mal conditionné** plutôt qu'une non-convergence totale. Le modèle de films n'a que **7 observations** (3 utilisateurs × 5 items = 15 paires, 7 notées) pour estimer **17 paramètres** (3×2 traits user + 5×2 traits item + 1 sigma) — ratio données/paramètres ~0.4. Avec des priors larges (`sigma=2` sur `U_f`/`V_f`), NUTS explore des régions pathologiques → trajectoires divergentes. Les scores prédits et le classement restent exploitables (ordre relatif), mais l'incertitude sur les traits latents est surestimée. Remède : prior plus informatif, plus de données, ou `target_accept` relevé. Voir [PyMC-6-Debugging](PyMC-6-Debugging.ipynb) pour la lecture systématique."
   },
   {
    "cell_type": "markdown",
@@ -2949,14 +2994,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "465fd8c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-26T10:55:14.377512Z",
-     "iopub.status.busy": "2026-08-26T10:55:14.377512Z",
-     "iopub.status.idle": "2026-08-26T10:55:14.381377Z",
-     "shell.execute_reply": "2026-08-26T10:55:14.381377Z"
+     "iopub.execute_input": "2026-08-29T01:38:14.355665Z",
+     "iopub.status.busy": "2026-08-29T01:38:14.355078Z",
+     "iopub.status.idle": "2026-08-29T01:38:14.359561Z",
+     "shell.execute_reply": "2026-08-29T01:38:14.359561Z"
     },
     "papermill": {
      "duration": 0.079239,
@@ -3122,7 +3167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},
@@ -3139,7 +3184,7 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "17dc43fcb9f44e74a2e73d00bfed0f58": {
+     "244da5a4f4814fd3ab3493340cd8f560": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -3192,7 +3237,94 @@
        "width": null
       }
      },
-     "1f0a5c86f8ee486cae8886aca4b74236": {
+     "251c38fcb411459fa2776ce32207063f": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_e9ff757bde6643b38a4a5e4196b0a6dc",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   26            0.236       15           815.33 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   35            0.156       15           430.94 draws/s   0:00:04   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   26            0.236       15           815.33 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   35            0.156       15           430.94 draws/s   0:00:04   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "5d4d2729ebaa499ea7bf647fcd48bf2d": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_7fc07b0184a14b918c95b8931c15e518",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   48            0.047       63           191.61 draws/s   0:00:10   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   50            0.032       127          103.06 draws/s   0:00:19   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   48            0.047       63           191.61 draws/s   0:00:10   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   50            0.032       127          103.06 draws/s   0:00:19   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "632083873284434993c5bdda720300ea": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_244da5a4f4814fd3ab3493340cd8f560",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   9             0.227       7            1230.77 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   42            0.321       7            680.97 draws/s    0:00:02   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   9             0.227       7            1230.77 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   42            0.321       7            680.97 draws/s    0:00:02   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "7fc07b0184a14b918c95b8931c15e518": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -3245,7 +3377,7 @@
        "width": null
       }
      },
-     "23b274d77d2e4222ba2d85e3fb790aaf": {
+     "89859869c4e54a14a452214870f9e028": {
       "model_module": "@jupyter-widgets/output",
       "model_module_version": "1.0.0",
       "model_name": "OutputModel",
@@ -3258,13 +3390,13 @@
        "_view_module": "@jupyter-widgets/output",
        "_view_module_version": "1.0.0",
        "_view_name": "OutputView",
-       "layout": "IPY_MODEL_462d43d691994b428538c4fb663bd39a",
+       "layout": "IPY_MODEL_a945a9d5114c4ec5adee1e9237870f74",
        "msg_id": "",
        "outputs": [
         {
          "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   39            0.056       63           207.45 draws/s   0:00:09   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   61            0.029       63           123.91 draws/s   0:00:16   0:00:00    \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   39            0.056       63           207.45 draws/s   0:00:09   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   61            0.029       63           123.91 draws/s   0:00:16   0:00:00    \n                                                                                                                   \n"
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2500   2             0.076       63           284.67 draws/s   0:00:08   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2500   3             0.071       63           147.06 draws/s   0:00:17   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2500   2             0.076       63           284.67 draws/s   0:00:08   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2500   3             0.071       63           147.06 draws/s   0:00:17   0:00:00    \n                                                                                                                   \n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -3274,7 +3406,7 @@
        "tooltip": null
       }
      },
-     "3970035bcfb64f00b78080489eb88da3": {
+     "a945a9d5114c4ec5adee1e9237870f74": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -3327,7 +3459,36 @@
        "width": null
       }
      },
-     "462d43d691994b428538c4fb663bd39a": {
+     "d607b5a22ec44fd9a0ad4107c885b064": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/output",
+       "_model_module_version": "1.0.0",
+       "_model_name": "OutputModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/output",
+       "_view_module_version": "1.0.0",
+       "_view_name": "OutputView",
+       "layout": "IPY_MODEL_f98ef4fc8da1487ca2ff7cb888fe93c0",
+       "msg_id": "",
+       "outputs": [
+        {
+         "data": {
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   5             0.473       7            1254.71 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   158           0.361       7            627.35 draws/s    0:00:03   0:00:00    \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   5             0.473       7            1254.71 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   158           0.361       7            627.35 draws/s    0:00:03   0:00:00    \n                                                                                                                   \n"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ],
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "e9ff757bde6643b38a4a5e4196b0a6dc": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -3380,123 +3541,7 @@
        "width": null
       }
      },
-     "5e3c170f5edb48eba68a3c7cd733f828": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_1f0a5c86f8ee486cae8886aca4b74236",
-       "msg_id": "",
-       "outputs": [
-        {
-         "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2500   0             0.092       63           350.88 draws/s   0:00:07   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2500   1             0.117       63           177.97 draws/s   0:00:14   0:00:00    \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2500   0             0.092       63           350.88 draws/s   0:00:07   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2500   1             0.117       63           177.97 draws/s   0:00:14   0:00:00    \n                                                                                                                   \n"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        }
-       ],
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "739a6baa6c0648d48569c7d14c4b6354": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_bbbfafaaba0341b889171d7d30e8775c",
-       "msg_id": "",
-       "outputs": [
-        {
-         "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   50            0.281       15           895.26 draws/s   0:00:02   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   80            0.360       15           462.11 draws/s   0:00:04   0:00:00    \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   50            0.281       15           895.26 draws/s   0:00:02   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   80            0.360       15           462.11 draws/s   0:00:04   0:00:00    \n                                                                                                                   \n"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        }
-       ],
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "7cb521260d51416d94dafd27ff1180d0": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_17dc43fcb9f44e74a2e73d00bfed0f58",
-       "msg_id": "",
-       "outputs": [
-        {
-         "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   35            0.301       15           1421.46 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   163           0.224       31           735.56 draws/s    0:00:02   0:00:00    \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   35            0.301       15           1421.46 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   163           0.224       31           735.56 draws/s    0:00:02   0:00:00    \n                                                                                                                   \n"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        }
-       ],
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "8a8bd28f25e84ab7af1afd4efafd0a5f": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_3970035bcfb64f00b78080489eb88da3",
-       "msg_id": "",
-       "outputs": [
-        {
-         "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                  </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed           </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   2             0.412       7            1543.21 draws/s   0:00:01   0:00:00    \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━━━━━━</span>   2000   5             0.452       23           815.33 draws/s    0:00:02   0:00:00    \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                 \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed          \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   2             0.412       7            1543.21 draws/s   0:00:01   0:00:00    \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   2000   5             0.452       23           815.33 draws/s    0:00:02   0:00:00    \n                                                                                                                   \n"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        }
-       ],
-       "tabbable": null,
-       "tooltip": null
-      }
-     },
-     "bbbfafaaba0341b889171d7d30e8775c": {
+     "f98ef4fc8da1487ca2ff7cb888fe93c0": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",

--- a/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
@@ -70,6 +70,13 @@
       content_python_sha: c4031b237010ac4ce2e6a9e68068bdb1d740be06adcaab5a8651a4dd4692cb9e
       content_csharp_sha: 2a0c52e6a68d5c62eb5e186df559d66e3a10b8bde641bb7830cea166999ae79f
       reason: "PR #13130 : 3bis C# renommee 'Correction' -> 'Diagnostic' (la latente EP s'effondre a exactement zero, le titre enseignait l'inverse de l'output). Cause MESUREE dans le notebook, 3 configurations EP deterministes : (A) InitialiseTo asymetrique -> retour EXACT au point fixe symetrique (attracteur EP, l'initialisation ne suffit pas) ; (B) ConstrainPositive trait 0 -> s'echappe (max|U|=1.52, RMSE 0.95) mais structure INVERSEE (croisements entre clusters predits hauts, user 2 -> item 1 = 5.26). Explication 'ratio donnees insuffisant' retiree (refutee par NUTS, ratio ~1). Mouvement unilateral C# legitime (parity_level native-both) ; jumeau PyMC inchange au SHA atteste. Re-exec complet exec_dotnet_persist (32 cellules, 0 erreur, exec_counts 1..32, machine path 0)."
+    - date: "2026-08-29"
+      by: myia-po-2025:CoursIA
+      python_sha: 078ccae9bc00a64086ed54e0ebf06a6a72894229
+      csharp_sha: 5e4acf3dc0d5b5119a0c6e1cede03b74954c4dd2
+      content_python_sha: 526299f6b8dd18d0154947eab6d9a650b952d18bf992503980ffb853faaff836
+      content_csharp_sha: 2a0c52e6a68d5c62eb5e186df559d66e3a10b8bde641bb7830cea166999ae79f
+      reason: "#12476 : fonction reutilisable rapport_diagnostic_strict (divergences=0, r_hat<1.01, ess_bulk>400, ess_tail>400) appliquee aux 6 traces NUTS cote Python, remplacant les diagnostics partiels inline ; trace_mf passait de az.summary(sigma) seul au rapport complet. Re-exec complet (nbconvert in-place, kernel pymc18-jsboi, PyMC 5.28.5, seed 42 ; exec_counts 1..29, 0 erreur, machine path 0). Prose re-alignee sur les sorties fraiches (divergences corrige 1->5, RMSE test 1.097, corr cold-start 0.726) + 3 cellules de transition OOS (advisory consecutive-code-cells run 4 -> 0). Mouvement unilateral Python legitime (parity_level native-both) ; jumeau C# inchange au SHA atteste (5e4acf3d). Aucun strip outille en attente."
   known_differences:
   - 'Re-baseline 2026-08-14 (myia-po-2024:CoursIA-2, #10876) : SHA Python avance d34f279b -> dbda0bd8 (repositionnement 5 cellules d''interp markdown mal ancrees — tranche Probas, #10678). Markdown-only, aucun code touche, axe de parite semantic (Infer.NET EP + concepts de recommandation) inchange. Drift verifie parite-preserving.'
   - 'Socle pedagogique commun : systemes de recommandation (filtrage collaboratif) modelise dans les deux stacks.'


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-python #13432

## Résumé

- complète le dernier diagnostic partiel de PyMC-15 : `trace_mf` ne présentait que `az.summary(sigma)` ;
- affiche désormais `r_hat`, `ess_bulk`, `ess_tail`, divergences NUTS et un verdict dérivé de seuils stricts ;
- redérive la lecture pédagogique depuis la ré-exécution fraîche, sans masquer le mauvais conditionnement du modèle naïf ;
- ré-atteste la paire native-both PyMC/Infer.NET après le commit notebook.

See #12476 — tranche atomique PyMC-15 ; le tracker reste ouvert pour les autres notebooks.

## Résultats frais

| Trace | divergences | r_hat max | ess_bulk min | ess_tail min | Score strict |
|---|---:|---:|---:|---:|---:|
| `trace_mf` | 163 | 1.140 (`sigma`) | 11 (`sigma`) | 27 (`sigma`) | 0/4 |
| `trace_mf2` | 5 | 1.020 (`U2[0,1]`) | 162 (`V2[4,1]`) | 484 (`V2[3,1]`) | 1/4 |
| `oos_trace` | 2 | 1.530 (`oos_U[0,0]`) | 7 (`oos_U[0,0]`) | 27 (`oos_U[2,0]`) | 0/4 |
| `trace_cs` | 61 | 1.020 (`V_cs[0,1]`) | 246 (`V_cs[4,0]`) | 66 (`V_cs[0,1]`) | 0/4 |
| `trace_click` | 51 | 1.030 (`sigma_c`) | 167 (`sigma_c`) | 168 (`sigma_c`) | 0/4 |
| `trace_film` | 98 | 1.030 (`V_f[2,0]`) | 210 (`U_f[0,0]`) | 252 (`sigma_f`) | 0/4 |

Seuils enseignés : zéro divergence, `r_hat < 1.01`, `ess_bulk > 400`, `ess_tail > 400`. Le notebook ne masque aucun échec : seul `ess_tail` du modèle corrigé franchit son seuil ; aucun des six modèles ne satisfait le verdict strict complet.

## Diagnostic dérive

- **Cause** : `e — stochasticité MCMC malgré des seeds fixées`, amplifiée par un posteriori mal conditionné et multi-modal. Les outputs précédemment committés indiquaient notamment 7 divergences sur le modèle naïf ; la ré-exécution fraîche dans l'environnement PyMC canonique en mesure 163. La prose historique anticipait déjà cette fragilité mais ne dérivait pas systématiquement son verdict des outputs.
- **Verdict** : `CAUSE_INTRINSIC` pour la variabilité inter-exécution de ces modèles pédagogiques mal conditionnés ; la cause statistique n'est pas maquillée. Le livrable ajoute un rapport dérivé des mesures fraîches et conserve les verdicts insuffisants.

## Exécution réelle

```text
C:/Users/jsboi/miniconda3/envs/coursia-ml-training/python.exe -m nbconvert \
  --execute --to notebook --inplace \
  --ExecutePreprocessor.kernel_name=pymc18-jsboi \
  --ExecutePreprocessor.timeout=900 \
  MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb

exit 0 — PyMC 5.28.5, ArviZ 0.23.4
```

## Validation

- `validate_pr_notebooks.py`: `EXEC_PROVED`, 29/29 cellules code, 0 erreur ;
- `check_exec_sequence.py`: `CLEAN 1..29` ;
- `scan_cell_ordering.py --fail-on HIGH --check-interp-anchor`: aucun finding bloquant ; un `SECTION_GAP` LOW préexistant reste hors scope ;
- `detect_consecutive_code_cells.py`: 0 run de cellules code consécutives ;
- `strip_machine_paths.py --scan`: 0 fuite machine ;
- C.1 : aucun `raise NotImplementedError`, `assert False` ni `1/0` dans les cellules code ;
- parité twin ciblée : `Probas-15 Recommenders` `OK`, et mode PR `base=OK head=OK` ;
- garde fleet-wide `--verify-recorded-sha` : échec préexistant hors scope sur `Tweety-3 Advanced-Logics`; la paire touchée est conforme et la PR n'introduit aucun drift ;
- `git diff --check`: propre ; deux fichiers strictement dans le claim ; catalogue généré inchangé.

## SOTA

`SOTA-OK` — le notebook exécute le vrai moteur PyMC/NUTS ; aucun workaround, aucune sortie fabriquée ou retouchée.

## Portée twin

Mouvement unilatéral légitime pour une paire `native-both` : l'instrumentation MCMC est propre à PyMC. Le notebook Infer.NET reste inchangé et son SHA est conservé dans l'attestation append-only.
