### PR TITLE
fix(guard,#13440): qualifiers de resultat de controle + pluriel parenthetique fichier(s)

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -456,6 +456,17 @@ INCIDENTAL_QUALIFIERS = frozenset({
     "produites", "sources", "source",
     # #11985 formes 3-4: artifact kinds and scan inventories.
     "audio", "distinct", "distincts", "distinctes", "non-notebook",
+    # #13440: check-RESULT participles -- what a verification COVERED (a
+    # wider corpus than the diff), never what the diff touches. A perimeter
+    # claim writes with modification verbs, which stay authorial: restaures/
+    # restaurés (campagne accents #2876) et re-executes/re-exécutés (tranches
+    # MGS) sont DELIBEREMENT absents -- dans ce depot ces formes SONT des
+    # perimetres.
+    "verifies", "vérifiés", "verifie", "vérifié", "verifiés", "verifié",
+    "testes", "testés", "teste", "testé",
+    "conformes", "conforme",
+    "scannes", "scannés", "analyses", "analysés",
+    "audites", "audités", "examines", "examinés",
 })
 # A cited threshold ("< 15 fichiers", ">= 10 fichiers") quotes a rule, it does
 # not claim a perimeter.
@@ -639,23 +650,30 @@ def _count_is_exempt(line: str, m: re.Match, ante_context: str = "") -> bool:
     if LOCATIVE_PREP.search(line):
         return True
     after = line[m.end():]
-    if NEGATED_DIFF_TAIL.match(after):
+    # #13440: the parenthetical plural "fichier(s)" puts "(s)" between the
+    # noun and the tail -- the real-corpus form ("25 fichier(s) verifies").
+    # Strip EXACTLY that closed marker (s|es) for the tail readers; the
+    # paren-antecedent branch below keeps the raw tail (it inspects the
+    # count's own surrounding parens, a different shape).
+    plural_tail = re.match(r"\s*\((?:s|es)\)", after)
+    tail = after[plural_tail.end():] if plural_tail else after
+    if NEGATED_DIFF_TAIL.match(tail):
         return True
     if HIT_ANTECEDENT.search(line[: m.start()]):
         return True
     ante_scope = f"{ante_context}\n{line[: m.end()]}" if ante_context else line[: m.end()]
     if MEASUREMENT_ANTECEDENT.search(ante_scope):
         return True
-    if REFERENCE_VERB_TAIL.match(after):
+    if REFERENCE_VERB_TAIL.match(tail):
         return True
     if (before.endswith("(") and after.lstrip().startswith(")")
             and PAREN_ANTECEDENT_NUM.search(before[:-1])):
         return True
-    mw = re.match(r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)", after)
+    mw = re.match(r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)", tail)
     mw2 = re.match(
         r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)"
         r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)",
-        after,
+        tail,
     )
     if mw and mw.group(1).lower() in INCIDENTAL_QUALIFIERS:
         return True

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -2389,3 +2389,76 @@ def test_normalize_rest_files_keeps_full_page_count_13357():
     assert len(out) == 148
     assert out[0] == {"path": "file_000.py", "additions": 1, "deletions": 0}
     assert out[-1]["path"] == "file_147.py"
+
+
+# ---------------------------------------------------------------------------
+# #13440 -- comptes de verification sans antecedent d'outil. La classe
+# residuelle apres #13361 : un resultat de controle (« 25 fichier(s)
+# verifies sans BOM », « Controle encodage : 25 fichier(s) conformes ») dont
+# le paragraphe ne porte AUCUN antecedent de mesure reste confronte a
+# len(files) et echoue necessairement, sans qu'aucune assertion de perimetre
+# n'ait ete emise. Fermeture par qualifiers de resultat de controle (liste
+# fermee, pattern #11712/#11985) + lecture du marqueur pluriel
+# parenthetique « fichier(s) » (forme reelle du corpus, #12875).
+# ---------------------------------------------------------------------------
+
+
+def test_13440_check_result_qualifiers_are_incidental():
+    """Positifs de l'issue : les 4 formes residuelles deviennent
+    incidental (le controle a couvert un corpus plus large que le diff --
+    la confrontation d'egalite ne peut jamais les valider)."""
+    body = (
+        "## Verifications\n"
+        "- 25 fichier(s) verifies sans BOM\n"
+        "- 25 fichier(s) vérifiés sans BOM (formes accentuees incluses)\n"
+        "- Controle encodage : 25 fichier(s) conformes\n"
+        "- Controle encodage : 25 fichiers testes\n"
+    )
+    verdicts = dict(_classify(body))
+    assert len(verdicts) == 4, f"candidats attendus, got {verdicts}"
+    for line, incidental in verdicts.items():
+        assert incidental is True, f"doit etre incidental : {line!r}"
+
+
+def test_13440_paren_plural_marker_same_verdict_as_plain():
+    """Le marqueur « (s) » est de la notation, pas du sens : la forme
+    parenthetique doit avoir le MEME verdict que sa jumelle plaine (forme
+    fondatrice #11800 sans mot de scope, et sa variante AVEC mot de scope
+    qui reste bloquante)."""
+    pairs = [
+        ("91 fichier(s) inchanges sur 2 touches", True),
+        ("91 fichiers inchanges sur 2 touches", True),
+        ("91 fichier(s) inchanges sur 2 touches -- scope delta confirme", False),
+        ("91 fichiers inchanges sur 2 touches -- scope delta confirme", False),
+        ("25 fichier(s) verifies", True),
+        ("25 fichiers verifies", True),
+    ]
+    for line, want in pairs:
+        v = _is_incidental_assertion(line)
+        assert v is want, f"{line!r} -> {v}, attendu {want}"
+
+
+def test_13440_fn_controls_stay_blocking():
+    """FN controls : les verbes de modification et les formes perimetres de
+    ce depot restent authoriaux -- restaures (campagne accents #2876) et
+    re-executes (tranches MGS) sont DELIBEREMENT hors liste."""
+    body = (
+        "## Perimetre\n"
+        "13 fichiers touches uniquement, rien d autre.\n"
+        "11 fichiers re-executes : 0 erreur\n"
+        "18 fichiers avec accents restaures\n"
+        "12 fichiers modifies\n"
+    )
+    verdicts = dict(_classify(body))
+    assert len(verdicts) == 4, f"candidats attendus, got {verdicts}"
+    for line, incidental in verdicts.items():
+        assert incidental is False, f"doit rester bloquant : {line!r}"
+
+
+def test_13440_negated_diff_per_count_property_through_paren():
+    """La propriete par-compte de #11800 survit au marqueur (s) : SEUL le
+    compte negatif est exempt -- un compte de modification sur la meme
+    ligne garde la ligne bloquante."""
+    blocking = "5 fichier(s) modifies, 91 fichier(s) inchanges"
+    v = _is_incidental_assertion(blocking)
+    assert v is False, "le compte modifie doit garder la ligne bloquante"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: LIGHT/docs #13300

Closes #13440

## Summary

Suite directe de la directive ai-01 (dashboard 2026-08-29, diagnostic #13404 : « defaut du garde, pas du body -- a porter en issue plutot qu'en contournement repete »). Verifie G.1 prealable : la classe HISTORIQUE (#12875/#13404) est deja fermee sur main par #13361+#12201 (repro via chemin reel : incidental). Cette PR ferme la **classe residuelle mesuree sur main e43c01587d** : comptes de resultat de verification sans antecedent d'outil dans le paragraphe.

## Diagnostic (firsthand, chemin reel du garde)

Une PR documentant ses controles qualite sur un corpus plus large que son diff se fait bloquer sans avoir emis AUCUNE assertion de perimetre sur la PR elle-meme.

## Fix (2 extensions chirurgicales, patterns etablis)

1. **INCIDENTAL_QUALIFIERS += participes de resultat de controle** : verifies, testes, conformes, scannes, analyses, audites, examines (+ singuliers et formes accentuees). **restaures et re-executes DELIBEREMENT hors liste** (campagne accents #2876, tranches MGS : ces formes SONT des perimetres dans ce depot).
2. **Marqueur pluriel parenthetique « fichier(s) »** (forme reelle du corpus, #12875) : strip exact `(s)`/`(es)` pour les lecteurs de queue (NEGATED_DIFF_TAIL, REFERENCE_VERB_TAIL, fenetre qualifier). Sans lui, le marqueur pluriel neutralisait son qualifier (`after` commence par `(`). Le marqueur est de la notation, pas du sens.

**Rejet documente** (issue #13440 point 3) : extension de MEASUREMENT_ANTECEDENT par noms de section (verifications/controle/resultats) -- un vrai claim « 13 fichiers touches uniquement » sous un titre « ## Resultats » deviendrait incidental (FN sur claim authentique).

## Preuves

- Tests verts (existants + nouveaux ajoutes par cette PR).
- Fail-on-main verifie par stash : les 2 tests pinant le fix FAILED sur l'etat main du script ; les 2 controles FN verts sur main par construction (ils pinent des invariants, pas le changement).
- FN controls pinned (bloquants avant ET apres) sur des exemples de corpus main, hors perimetre PR.
- Coherence de notation pinned : verifiee par round-trip sur les memes chaines avec/sans `(s)`.
- Guard-self bootstrap (#12201) : cette PR modifiant le garde lui-meme, la confrontation d'egalite est ecartee sur son propre body par construction.

## Perimetre

2 fichiers : scripts/check_pr_perimeter.py (liste + strip + commentaires) + scripts/tests/test_check_pr_perimeter.py (+4 tests). Catalogue non touche.

## Grain

Grain: MED/guard -- lane myia-po-2023:CoursIA-2 -- prev: LIGHT/docs #13300 (dernier grain non-guard mergé de la lane = #13300 MERGED 2026-08-28T13:08:02Z, source vérifiée firsthand).
