### PR TITLE
fix(ict,#13322): payoff_matrix historique-indépendant — rng de match threadé aux stratégies

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/strategic_morphodynamics.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/strategic_morphodynamics.py
@@ -198,8 +198,8 @@ def play_match(
     g1 = g2 = 0.0
     for _ in range(n_rounds):
         h1, h2 = np.array(own1), np.array(own2)
-        a = int(s1(h1, h2, rng) if s1_rng else s1(h1, h2))
-        b = int(s2(h2, h1, rng) if s2_rng else s2(h2, h1))
+        a = int(s1(h1, h2, rng=rng) if s1_rng else s1(h1, h2))
+        b = int(s2(h2, h1, rng=rng) if s2_rng else s2(h2, h1))
         if noise > 0.0:
             if rng.random() < noise:
                 a = 1 - a

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/strategic_morphodynamics.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/strategic_morphodynamics.py
@@ -19,6 +19,7 @@ commitee. numpy CPU pur, gel GPU respecte.
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
@@ -113,22 +114,47 @@ def random_strategy(p_coop: float = 0.5):
     return _rand
 
 
-# Une strategie a etat (gtft, random) a besoin d'un generateur par match ;
-# on les construit via une factory qui injecte le rng.
+# Une strategie aleatoire (gtft, random) tire au hasard : le protocole etendu
+# (#13322) lui donne un 3e parametre nomme ``rng``, rempli par play_match avec
+# le generateur DU MATCH. Les strategies d'arite 2 restent deterministes.
 STRATEGY_NAMES = ["allc", "alld", "tft", "gtft", "pavlov", "grim"]
 
 
+def _accepts_rng(s: Strategy) -> bool:
+    """True si la strategie declare un 3e parametre nomme ``rng`` (protocole
+    etendu #13322) : play_match lui passera alors le generateur du match."""
+    try:
+        params = list(inspect.signature(s).parameters.values())
+    except (TypeError, ValueError):
+        return False
+    return (
+        len(params) >= 3
+        and params[2].name == "rng"
+        and params[2].kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    )
+
+
 def make_strategies(rng: Optional[np.random.Generator] = None) -> Dict[str, Strategy]:
-    """Construit le dictionnaire des strategies. Celles aleatoires (gtft, random)
-    partagent le ``rng`` fourni (reproductible)."""
+    """Construit le dictionnaire des strategies.
+
+    Le ``rng`` fourni n'est qu'un **fallback** pour les appels directs
+    ``strat["gtft"](own, opp)`` hors tournoi. Dans un tournoi
+    (:func:`play_match` et ses enveloppes), les tirages de gtft proviennent du
+    generateur passe AU TOURNOI : le resultat d'un tournoi ne depend que de ses
+    arguments, jamais de l'usage anterieur du dict (#13322 — les strategies ne
+    portent plus d'etat observable via les tournois)."""
     st = {"rng": rng or np.random.default_rng(0)}
 
-    def _gtft(own, opp):
+    def _gtft(own, opp, rng=None):
         if len(opp) == 0:
             return C
         if opp[-1] == C:
             return C
-        return C if st["rng"].random() < 1 / 3 else D
+        r = rng if rng is not None else st["rng"]
+        return C if r.random() < 1 / 3 else D
 
     return {
         "allc": allc,
@@ -157,15 +183,23 @@ def play_match(
     d'implementation : erreur, tremblement). Renvoie le gain moyen par coup de
     chacun (gain cumul / n_rounds).
 
+    Toutes les decisions aleatoires du match — bruit d'implementation ET tirages
+    des strategies aleatoires (protocole etendu : 3e parametre ``rng``) —
+    proviennent du meme ``rng`` : deux matches aux memes arguments rendent des
+    gains identiques, quel que soit l'usage anterieur des strategies (#13322).
+
     Le bruit n'est pas cosmetique : il discrimine TFT (effondrement par echo) de
     GTFT/Pavlov (résistent) — c'est le gate 3 du regime-dependance."""
     if rng is None:
         rng = np.random.default_rng(0)
+    s1_rng = _accepts_rng(s1)
+    s2_rng = _accepts_rng(s2)
     own1, own2 = [], []
     g1 = g2 = 0.0
     for _ in range(n_rounds):
-        a = int(s1(np.array(own1), np.array(own2)))
-        b = int(s2(np.array(own2), np.array(own1)))
+        h1, h2 = np.array(own1), np.array(own2)
+        a = int(s1(h1, h2, rng) if s1_rng else s1(h1, h2))
+        b = int(s2(h2, h1, rng) if s2_rng else s2(h2, h1))
         if noise > 0.0:
             if rng.random() < noise:
                 a = 1 - a
@@ -202,7 +236,8 @@ def round_robin(
     for i, ni in enumerate(names):
         for j, nj in enumerate(names):
             for _ in range(n_reps):
-                # reconstruire l'etat interne aleatoire a chaque match (gtft/random)
+                # les tirages aleatoires de chaque match proviennent du rng du
+                # tournoi (protocole #13322) : pas d'etat interne persistant
                 s_i = strategies[ni]
                 s_j = strategies[nj]
                 g_i, g_j = play_match(s_i, s_j, n_rounds=n_rounds, noise=noise, rng=rng)

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_strategic_morphodynamics.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_strategic_morphodynamics.py
@@ -28,9 +28,11 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from ict.strategic_morphodynamics import (  # noqa: E402
+    _accepts_rng,
     make_strategies,
     noise_collapse,
     payoff_matrix,
+    play_match,
     round_robin,
 )
 
@@ -95,3 +97,25 @@ def test_deterministic_strategies_unchanged():
     for name in ("allc", "alld", "tft", "pavlov", "grim"):
         s = strat[name]
         assert s(own, opp) == s(own, opp), name
+
+
+def test_keyword_only_rng_strategy_playable():
+    """(#13442) `_accepts_rng` accepte KEYWORD_ONLY mais play_match passait le
+    rng POSITIONNELLEMENT — une strategie `def s(own, opp, *, rng)` passait le
+    predicat puis plantait en TypeError au premier appel. play_match doit
+    passer rng par mot-cle : les deux kinds declares acceptables sont jouables.
+    CE TEST ECHOUE SI play_match REVENIR AU PASSAGE POSITIONNEL."""
+    def kw_only(own, opp, *, rng=None):
+        r = rng if rng is not None else np.random.default_rng(0)
+        return int(r.random() < 0.5)
+
+    def pos_or_kw(own, opp, rng=None):
+        r = rng if rng is not None else np.random.default_rng(0)
+        return int(r.random() < 0.5)
+
+    assert _accepts_rng(kw_only) and _accepts_rng(pos_or_kw)
+    strat = make_strategies(np.random.default_rng(0))
+    for s in (kw_only, pos_or_kw):
+        g1, g2 = play_match(s, strat["allc"], n_rounds=10,
+                            rng=np.random.default_rng(7))
+        assert -5.0 <= g1 <= 5.0  # gains IPD bornes par T..S sur 10 coups

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_strategic_morphodynamics.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_strategic_morphodynamics.py
@@ -1,0 +1,97 @@
+"""Tests du module :mod:`ict.strategic_morphodynamics` (ICT-13, #13322).
+
+Verrouillent le contrat de reproductibilite des tournois :
+
+  1. **Historique-independance** (#13322, criterium 1) : ``payoff_matrix`` avec
+     un ``rng`` fixe rend la MEME matrice quel que soit l'usage anterieur du
+     dict de strategies (round_robin / noise_collapse exercent le dict entre
+     les deux appels).
+  2. **Controle negatif** (#13322, criterium 3) : un seed different rend une
+     matrice differente — le fix ne gele pas les tirages. (L'ancien module
+     echouait ce controle dans l'autre sens : seeds 42 et 43 rendaient la meme
+     matrice car le rng appelant etait ignore a bruit nul.)
+  3. ``round_robin`` est historique-independant au meme titre.
+  4. Les strategies deterministes du module restent deterministes ; gtft reste
+     stochastique (ecart entre deux seeds > 0 sur une ligne gtft).
+
+Pattern herite de ``test_self_sorting.py`` : bootstrap ``sys.path``
+module-level, sans fixtures, tolerances commentees.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ict.strategic_morphodynamics import (  # noqa: E402
+    make_strategies,
+    noise_collapse,
+    payoff_matrix,
+    round_robin,
+)
+
+
+def test_payoff_matrix_history_independent():
+    """Criterium 1 : meme seed => meme matrice, quel que soit l'usage anterieur."""
+    def build_a(strat):
+        rng = np.random.default_rng(42)
+        return payoff_matrix(strat, n_rounds=150, noise=0.0, n_reps=2, rng=rng)
+
+    rng = np.random.default_rng(0)
+    a_fresh = build_a(make_strategies(rng))
+
+    rng = np.random.default_rng(0)
+    strat = make_strategies(rng)
+    r = np.random.default_rng(42)
+    round_robin(strat, n_rounds=200, noise=0.0, n_reps=1, rng=r)
+    r = np.random.default_rng(21)
+    noise_collapse(strat, np.linspace(0.0, 0.4, 9), n_rounds=150, n_reps=3, rng=r)
+
+    a_after = build_a(strat)
+    assert np.array_equal(a_fresh, a_after)
+
+
+def test_payoff_matrix_seed_changes_result():
+    """Controle negatif (criterium 3) : un seed different DOIT differer."""
+    a_mats = []
+    for seed in (42, 43):
+        rng = np.random.default_rng(0)
+        strat = make_strategies(rng)
+        a_mats.append(
+            payoff_matrix(strat, n_rounds=150, noise=0.0, n_reps=2,
+                          rng=np.random.default_rng(seed))
+        )
+    # tolerance nulle : les tirages gtft different des le premier match
+    assert not np.array_equal(a_mats[0], a_mats[1])
+
+
+def test_round_robin_history_independent():
+    """round_robin : meme seed => memes scores, quel que soit l'usage anterieur."""
+    def run(strat):
+        rng = np.random.default_rng(7)
+        return round_robin(strat, n_rounds=100, noise=0.0, n_reps=1, rng=rng)
+
+    rng = np.random.default_rng(0)
+    sc_fresh = run(make_strategies(rng))
+
+    rng = np.random.default_rng(0)
+    strat = make_strategies(rng)
+    payoff_matrix(strat, n_rounds=150, noise=0.0, n_reps=2,
+                  rng=np.random.default_rng(42))
+    sc_after = run(strat)
+
+    assert sc_fresh == sc_after
+
+
+def test_deterministic_strategies_unchanged():
+    """allc/alld/tft/pavlov/grim : sortie ne depend pas du rng (protocole arite 2)."""
+    strat = make_strategies(np.random.default_rng(0))
+    own = np.array([0, 1, 1])
+    opp = np.array([1, 0, 1])
+    for name in ("allc", "alld", "tft", "pavlov", "grim"):
+        s = strat[name]
+        assert s(own, opp) == s(own, opp), name


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/guard #13433

## Summary

`make_strategies()` fermait `_gtft` sur un générateur partagé : `payoff_matrix` ignorait le rng appelant (à bruit nul) et consultait une position de flux avancée par l'usage antérieur du dict — la matrice dépendait de l'historique malgré la signature qui promet la reproductibilité. Repro de l'issue vérifiée sur `main` tip (`ad159f48b`) : `False`, écart max `0.20`.

**Protocole étendu** : les stratégies stochastiques déclarent un 3e paramètre nommé `rng` (introspection `_accepts_rng`), `play_match` leur passe le générateur du match. Le résultat d'un tournoi ne dépend que de ses arguments.

Reprise **module-only** du commit `8bd89c13b` (PR #13324 fermée pour collision sur le notebook ICT-13 — non sur le fond ; la repro PASSAIT sur sa branche, mon verdict « fix non effectif » du drain 2026-08-29 était erroné, piège stale-cwd). Adapté au module dérivé par #13305 (`evolve_population`), dont les appels inline arity-2 gardent le fallback factory — comportement inchangé pour eux.

## Perimetre

2 fichiers : `MyIA.AI.Notebooks/IIT/ICT-Series/ict/strategic_morphodynamics.py`, `MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_strategic_morphodynamics.py`

## Acceptance vs issue #13322

| Critère | Preuve |
|---|---|
| 1. Matrice indépendante de l'usage antérieur | repro issue : `True` (exercice `round_robin` n_rounds=200) ; étendu : exercice via `noise_collapse` ET `evolve_population` → matrice inchangée |
| 2. Test verrou | 4 tests (`ict/tests/test_strategic_morphodynamics.py`) : historique-indépendance payoff_matrix/round_robin + stratégies déterministes intactes — **4 passed** |
| 3. Contrôle négatif | seed 42 vs 43 → matrices différentes (un fix qui gèle tout ne passe pas) |
| 4. ICT-13 end-to-end + verdict gate 5 | **DEFERRED à #12803** (PR ai-01 qui possède le notebook — les cells 5/12/15/19 dériveront à la re-exec sur ce module fixé ; séquencer : merger le module AVANT/AVEC la re-exec notebook) |
| 5. Consommateurs énumérés | mesure branche 8bd89c13b : ICT-15/22/Synthese/19-Raffinement **bit-identiques** (mêmes objets rng passés aux deux niveaux → séquence de tirages inchangée) ; ICT-13 seul à dériver ; `evolve_population`/`invasion_basin` (appels arity-2) : fallback factory, comportement inchangé |

## Validation

- Batterie acceptance 4/4 (round_robin + noise_collapse + evolve_population + négatif) sur arbre frais depuis `main ad159f48b`.
- Suite ict complète : **393 passed** (dont les tests #13305).
- Consumers : aucun notebook touché dans cette PR (collision notebook = zone #12803).

See #13322 (contribution module+tests, critère 4 = notebook, deferred).