### PR TITLE
feat(notebook): enrich RAG server pedagogy

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05b-Stockage-Vectoriel-Serveur.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/05b-Stockage-Vectoriel-Serveur.ipynb
@@ -26,6 +26,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "95fdc23c",
+   "metadata": {},
+   "source": [
+    "**Navigation** : [Index](README.md) | [<< Précédent](05-Stockage-Vectoriel.ipynb)\n",
+    "\n",
+    "## Objectifs et protocole de mesure\n",
+    "\n",
+    "**Objectifs d'apprentissage** — à la fin de ce notebook, vous saurez :\n",
+    "\n",
+    "1. Provisionner un serveur vectoriel Qdrant dans un conteneur Docker, de façon idempotente et dégradable ;\n",
+    "2. Charger une collection de vecteurs clusterisés munis d'un payload sémantique, puis l'ingérer par lots ;\n",
+    "3. Mesurer un compromis qualité/coût objectif — rappel@10 contre un ground truth exact, et latence — pour la recherche exacte et pour `hnsw_ef` croissant ;\n",
+    "4. Lire la courbe signature et situer le genou du compromis ;\n",
+    "5. Vérifier deux propriétés de production : la persistance au redémarrage du conteneur et le filtrage payload pendant la recherche ANN.\n",
+    "\n",
+    "**Protocole** : chaque mode de recherche est évalué sur les mêmes requêtes. Le rappel@10 d'une requête est la fraction du top-10 exact qu'elle retrouve ; la latence de chaque appel HTTP est chronométrée. Le ground truth est calculé hors du serveur, en NumPy — c'est cette indépendance qui rend la mesure honnête (juger Qdrant avec un ground truth calculé par Qdrant serait circulaire).\n",
+    "\n",
+    "**Pourquoi un serveur** : le notebook 05 code HNSW from-scratch pour exposer les mécanismes internes ; ici on interroge l'implémentation de production via son API REST, en HTTP brut — chaque requête (`/healthz`, `/collections/.../points/search`) reste lisible comme de la documentation vivante de l'API."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "d7e7ca7e",
@@ -124,6 +146,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7f2ce18c",
+   "metadata": {},
+   "source": [
+    "### Interprétation : les paramètres de l'expérience\n",
+    "\n",
+    "La sortie fixe le cadre : `QDRANT_URL=http://localhost:6333`, `N_VECTORS=10000`, `DIM=128`, `N_CLUSTERS=50`. Trois de ces nombres structurent toute la suite :\n",
+    "\n",
+    "| Paramètre | Valeur | Rôle |\n",
+    "|-----------|--------|------|\n",
+    "| `N_VECTORS` | 10000 | échelle de la démo |\n",
+    "| `DIM` | 128 | dimension des vecteurs — une dimension classique d'embedding |\n",
+    "| `N_CLUSTERS` | 50 | nombre de grappes du jeu synthétique |\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "1. **Graine posée** (`SEED = 42` sur `random` et `numpy`) : vecteurs, requêtes et payloads sont reproductibles d'une exécution à l'autre. Sans elle, aucune comparaison de rappel ne serait interprétable.\n",
+    "2. **Pas de SDK client** : les helpers `qdrant_get` / `qdrant_post` parlent l'API REST en `urllib` brut — chaque endpoint appelé reste visible dans le code au lieu d'être masqué par une librairie. La ligne `Helpers HTTP charges.` conclut ce chargement.\n",
+    "3. Le serveur n'est **pas encore interrogé** ici : cette cellule ne pose que le protocole, la sonde réelle vient ensuite.\n",
+    "\n",
+    "> **Note technique** : le balayage des six valeurs de `EF_VALUES` déclarées dans la cellule est le paramètre dont on mesurera l'effet — il fixe le nombre de candidats explorés dans le graphe HNSW à chaque recherche."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "fe4f5fb5",
@@ -211,6 +257,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "651b72d4",
+   "metadata": {},
+   "source": [
+    "### Interprétation : provisionnement idempotent\n",
+    "\n",
+    "La sortie se lit en trois temps : `Docker dispo : True`, puis la sonde `/healthz` qui renvoie exactement `healthz check passed`, et la confirmation `Qdrant operationnel`. Le provisioning suit un arbre de décision :\n",
+    "\n",
+    "1. **Qdrant déjà joignable** → on l'utilise tel quel. C'est la branche prise par cette exécution : un serveur répond déjà sur le port 6333, aucune action de lancement n'est engagée ;\n",
+    "2. **Port occupé par un autre conteneur** → on le réutilise au lieu de le remplacer : plusieurs notebooks peuvent partager le même serveur ;\n",
+    "3. **Port libre et Docker disponible** → `docker run` lance `qdrant/qdrant:latest` avec un volume dédié (`qdrant_rag05b_data`, défini dans le code de la cellule).\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "- **Idempotence** : relancer la cellule ne casse rien — chaque branche s'adapte à l'état trouvé plutôt que de le détruire.\n",
+    "- **Dégradation propre** : si aucune branche ne réussit, le notebook ne plante pas ; il bascule sur le mode dégradé de la dernière cellule, qui conserve la portée pédagogique en NumPy pur.\n",
+    "- `healthz` renvoie du texte brut, pas du JSON — d'où le helper qui vérifie le `Content-Type` avant de parser la réponse."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "6f8aec44",
@@ -274,6 +340,22 @@
     "print(f\"\\nDistribution sources : {dict(source_dist)}\")\n",
     "print(f\"Distribution severite : {dict(Counter(p['severite'] for p in payloads))}\")\n",
     "print(f\"Nombre clusters utilises : {len(set(cluster_ids))}/{N_CLUSTERS}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af451f0b",
+   "metadata": {},
+   "source": [
+    "### Interprétation : des grappes, pas du bruit uniforme\n",
+    "\n",
+    "La sortie donne `vectors.shape=(10000, 128)` et des normes `min=1.0000, max=1.0000` : chaque vecteur est **normalisé** (norme L2 égale à 1). C'est ce qui autorisera plus loin le produit scalaire comme similarité cosinus exacte — aucune renormalisation au moment de la recherche.\n",
+    "\n",
+    "Les distributions confirment le design du jeu de données : sources quasi uniformes (`incident` 2496, `faq` 2481, `documentation` 2478, `release_notes` 2545 — environ un quart chacune), sévérités équilibrées (2021, 2073, 1925, 2029, 1952 — environ un cinquième chacune), et `Nombre clusters utilises : 50/50` : chaque grappe a effectivement des points.\n",
+    "\n",
+    "**Pourquoi des grappes plutôt que des vecteurs uniformes** : dans un nuage uniforme en dimension 128, les plus proches voisins d'une requête sont presque tous à la même distance — le problème dégénère et ne met pas l'index en valeur. Cinquante centres tirés au hasard, chacun noyé dans un bruit faible, fabriquent des **quartiers** : la recherche a une structure à naviguer, comme les familles sémantiques d'un vrai corpus (les incidents forment des îlots distincts des FAQ).\n",
+    "\n",
+    "**Le payload ne sert pas encore** : `source`, `severite` et `cluster_id` accompagnent chaque point sans influencer la recherche vectorielle — ils deviendront le filtre métier de la section filtrage payload."
    ]
   },
   {
@@ -378,6 +460,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8867007f",
+   "metadata": {},
+   "source": [
+    "### Interprétation : création de collection et ingestion par lots\n",
+    "\n",
+    "Le `Delete (peut-etre 404 si nouveau) : status=ok` d'ouverture sert la **reproductibilité** : supprimer la collection si elle existe garantit que chaque exécution repart d'un index vierge. Le `Create collection : status=ok` enregistre la configuration HNSW demandée dans le code de la cellule :\n",
+    "\n",
+    "| Paramètre | Valeur | Signification |\n",
+    "|-----------|--------|---------------|\n",
+    "| `m` | 16 | nombre de liens par nœud du graphe |\n",
+    "| `ef_construct` | 100 | largeur de recherche lors de la construction des liens |\n",
+    "| `full_scan_threshold` | 10000 | seuil configuré pour l'arbitrage entre scan exact et HNSW |\n",
+    "| `indexing_threshold` | 0 | demander l'indexation sans seuil d'attente |\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "1. `Insertion 10000/10000 points` : tous les lots ont été acceptés ; le compteur serveur `points_count=10000` confirme la prise en compte — la source de vérité est la réponse du serveur, pas le compte local.\n",
+    "2. `vectors_count=None` est une absence de champ pour cette version de l'API, sans incidence sur la suite.\n",
+    "3. L'ingestion par lots successifs évite de pousser la base entière en une seule requête HTTP — le code découpe, le serveur confirme lot par lot."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "58b1033c",
@@ -428,6 +533,24 @@
     "print(f\"Ground truth : {t1-t0:.2f}s ({N_QUERIES/(t1-t0):.1f} queries/s)\")\n",
     "print(f\"Exemple query 0 : top-5 vrais = {sorted(list(ground_truth[0]))[:5]}\")\n",
     "print(f\"Stocke {len(ground_truth)} ground truths (K={K} chacun)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2387c89b",
+   "metadata": {},
+   "source": [
+    "### Interprétation : le ground truth exact, calculé hors du serveur\n",
+    "\n",
+    "Avant de juger une recherche approximative, il faut connaître la bonne réponse. Elle est calculée ici par **force brute en NumPy** : produit matriciel de la base entière contre chaque requête, extraction du top-k par `argpartition`, puis tri du top-k. La sortie confirme le stockage de 200 ground truths (K=10 chacun) et montre, pour la requête 0, le top-5 exact `[1519, 1720, 3065, 3128, 4136]`.\n",
+    "\n",
+    "**Pourquoi ce calcul est digne de confiance** :\n",
+    "\n",
+    "1. **Exhaustif** — chaque vecteur de la base est comparé à la requête, aucune heuristique n'intervient ;\n",
+    "2. **Indépendant du serveur** — mesurer Qdrant avec un ground truth calculé par Qdrant serait circulaire ;\n",
+    "3. **Reproductible** — les requêtes sont tirées avec la graine déjà posée en tête de notebook.\n",
+    "\n",
+    "**La métrique qui en découle** : le rappel@10 d'une requête est la taille de l'intersection entre le top-10 renvoyé et ce top-10 exact, divisée par 10. C'est un rappel **d'ensemble**, pas un classement : l'ordre des résultats n'entre pas dans la métrique, seuls les membres du top-10 comptent."
    ]
   },
   {
@@ -566,6 +689,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "58696280",
+   "metadata": {},
+   "source": [
+    "### Interprétation : rappel saturé — le signal est dans le coût\n",
+    "\n",
+    "C'est le résultat central du notebook, et il est contre-intuitif : le rappel@10 vaut **1.000 pour chaque mode**. La recherche exacte comme chaque `hnsw_ef` de 8 à 256 retrouve l'intégralité du top-10 exact sur les 200 requêtes. À cette échelle, sur des grappes aussi serrées, le graphe HNSW est suffisamment connecté pour que même le plus petit `ef` ne perde aucun voisin.\n",
+    "\n",
+    "Le signal discriminant est donc la **latence**, et la sortie en livre trois lectures :\n",
+    "\n",
+    "1. **La recherche exacte est la plus coûteuse** : plus de trois fois la latence médiane de `hnsw_ef=16` (les deux mesures proviennent de la même cellule) ;\n",
+    "2. **La latence médiane croît avec `ef`** : plus de deux fois plus élevée à `ef=256` qu'à `ef=16` — explorer plus de candidats coûte, même quand le rappel est déjà saturé ;\n",
+    "3. **Chaque p95 dépasse sa médiane** : la queue de latence (sérialisation JSON, ordonnanceur du conteneur) domine souvent l'écart entre modes.\n",
+    "\n",
+    "**Lecture honnête** : à l'échelle démo, le compromis est plat côté qualité — le choix rationnel est un petit `ef`. Le genou (le point où augmenter `ef` commence à acheter du rappel) n'apparaît qu'à plus grande échelle ou sur des données plus difficiles ; le paramétrage du notebook est précisément fait pour aller le mesurer en changeant une constante.\n",
+    "\n",
+    "> **Note technique** : un benchmark qui ne montre qu'un rappel de 1.000 partout ne dit rien tout seul — c'est son croisement avec la latence qui décide."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "de01bd37",
@@ -643,6 +786,24 @@
     "    print(f\"\\nCourbe sauvegardee : courbe_signature_rag05b.png\")\n",
     "else:\n",
     "    print(\"Pas de resultats : Qdrant indisponible.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "164c9d18",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : la courbe signature\n",
+    "\n",
+    "Le tableau récapitule sept lignes, toutes à `recall@10 = 1.000`. Sur le graphique, les points s'alignent sur un **plateau horizontal** en haut de l'axe vertical : les modes ne se distinguent plus que par leur position horizontale. La recherche exacte est le point le plus à droite (la plus coûteuse) ; les modes `hnsw_ef` s'étalent à sa gauche.\n",
+    "\n",
+    "**Comment lire cette courbe** :\n",
+    "\n",
+    "- l'axe horizontal porte le coût (latence médiane), l'axe vertical la qualité (rappel@10) ;\n",
+    "- un bon compromis est un point **le plus haut possible, le plus à gauche possible** ;\n",
+    "- ici tous les points sont à la même hauteur : le plateau dit « le rappel est saturé, prends le point le plus à gauche ».\n",
+    "\n",
+    "**Pourquoi le genou n'est pas visible** : la courbe signature canonique suppose une zone où le petit `ef` perd des voisins avant de saturer. Des données aussi bien clusterisées, à l'échelle démo, mettent HNSW d'emblée dans la partie saturée de la courbe. La figure reste l'outil juste : à plus grande échelle, la même cellule produirait le coude caractéristique, et le PNG sauvegardé (`courbe_signature_rag05b.png`) est l'artefact à comparer entre échelles."
    ]
   },
   {
@@ -749,6 +910,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3e9495fd",
+   "metadata": {},
+   "source": [
+    "### Interprétation : la collection survit au redémarrage\n",
+    "\n",
+    "La sortie raconte l'avant/après du `docker restart` : `points_count=10000` de part et d'autre, et la requête 0 renvoie exactement les mêmes ids — `[4136, 3065, 1519, 4529, 1720]` — avant et après. Le verdict `PERSISTANCE OK : count identique = True, resultats identiques = True` conclut : l'état de l'index vit dans le **stockage persistant du conteneur** (`/qdrant/storage`), pas dans la mémoire du processus.\n",
+    "\n",
+    "Deux lectures complémentaires :\n",
+    "\n",
+    "1. **Le conteneur détecté s'appelle `qdrant-rag05`**, pas `qdrant_rag05b`. C'est le cas nominal documenté en tête de notebook : le port 6333 était déjà servi par le conteneur du notebook 05, et le provisioning l'a réutilisé plutôt que d'en lancer un second. La collection `rag05b_demo` vit dans ce serveur partagé — et sa persistance est celle du conteneur qui l'héberge réellement.\n",
+    "2. **Les ids croisent le ground truth** : parmi les cinq premiers ids affichés figurent `1519`, `1720`, `3065` et `4136` — quatre des cinq voisins exacts du top-5 calculé à la section ground truth (référence explicite en amont). La recherche de cette cellule retrouve donc bien des voisins exacts, pas seulement des points vaguement proches.\n",
+    "\n",
+    "**Portée** : c'est la propriété qui distingue un serveur d'un index en mémoire de processus — redémarrer, upgrader ou réordonner les conteneurs ne détruit pas l'index."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "3f32334c",
@@ -834,6 +1012,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5a8b18f3",
+   "metadata": {},
+   "source": [
+    "### Interprétation : filtrer côté serveur plutôt qu'après la requête\n",
+    "\n",
+    "La comparaison est nette. **Sans filtre**, le top-10 mélange les sources : les cinq premiers ids affichés couvrent déjà `faq`, `release_notes` et `incident`. **Avec le filtre** `source='incident' AND severite>=3`, la même requête renvoie dix résultats dont chaque ligne vérifie la contrainte (`match=True` ligne à ligne, verdict global `True`).\n",
+    "\n",
+    "**Ce que le filtre change, concrètement** :\n",
+    "\n",
+    "1. Le résultat filtré (`4529`, `3291`, `6022`, ...) n'est **pas** le résultat sans filtre amputé : Qdrant reçoit le prédicat avec la requête et renvoie directement dix points qui le satisfont ;\n",
+    "2. Seuls `1470/10000 = 14.70%` des points matchent : la recherche porte sur les voisins admissibles dans ce sous-ensemble, sans post-filtrage dans le code client ;\n",
+    "3. Cette requête serveur évite le post-filtrage naïf qui demanderait arbitrairement cent voisins avant de jeter ceux qui ne matchent pas — méthode qui peut rendre trop peu de résultats admissibles.\n",
+    "\n",
+    "**Pourquoi c'est décisif pour le RAG** : une recherche de production n'est presque jamais « les voisins les plus proches, tous contenus confondus », mais « les plus proches **parmi** les documents autorisés » (source fiable, sévérité suffisante, fenêtre de temps). Le payload indexé rend cette contrainte exécutable par le serveur vectoriel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "69ca19c3",
    "metadata": {
     "papermill": {
@@ -851,16 +1047,28 @@
     "**Ce que ce notebook demontre** :\n",
     "\n",
     "1. **Conteneur Qdrant provisionne** : idempotent (peut etre lance par le notebook si Docker dispo), degradeable proprement (skip si Docker absent), ou utilise un conteneur deja tournant (cas nominal partage cross-lane).\n",
-    "2. **Mesure du compromis exact/ANN** : rappel@10 et latence mediane mesures sur 200 requetes pour `exact=True` vs `hnsw_ef ∈ {8,16,32,64,128,256}`.\n",
+    "2. **Mesure du compromis exact/ANN** : rappel@10 et latence mediane mesures sur 200 requetes pour `exact=True` et pour les six valeurs de `EF_VALUES`.\n",
     "3. **Courbe signature** : trade-off explicite entre qualite (recall@10) et cout (latence). Genou visible = valeur recommandee de `ef`.\n",
     "4. **Persistance** : `docker restart` preserve count + resultats de recherche (vs mode local `path=...` qui n'a pas cette propriete cross-deploiement).\n",
-    "5. **Filtrage payload** : `source='incident' AND severite>=3` restreint l'espace de recherche, demonstration que l'index HNSW filtrable est utilisable en production.\n",
+    "5. **Filtrage payload** : `source='incident' AND severite>=3` restreint l'espace de recherche, demonstration que la recherche vectorielle avec filtre est utilisable en production.\n",
     "\n",
     "**Passage a 100k+ vecteurs** : modifier `N_VECTORS = 10_000` en `N_VECTORS = 100_000` ; le reste du notebook est lineaire (plus de memoire conteneur + temps d'insertion). Les conclusions methodologiques sont identiques ; le genou du compromis peut se deplacer legerement.\n",
     "\n",
     "**Co-habitation avec #12552 (po-2024)** : #12552 livre le notebook 05 mode local avec HNSW from-scratch pedagogique ; ce 05b livre le mode serveur avec conteneur Docker reel. Les deux notebooks sont complementaires : 05 demontre les mecanismes internes (HNSW code from-scratch), 05b valide les memes compromis sur l'implementation de production (Qdrant conteneur).\n",
     "\n",
     "**Verdict SOTA** : RECOVERABLE-MACHINE (Qdrant conteneur Docker requis, non disponible sur machine CPU-only sans Docker). Le notebook degrade proprement si Docker absent (pas d'execution, mais structure pedagogique preservee)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f03ac1d4",
+   "metadata": {},
+   "source": [
+    "### Mode dégradé : le filet de sécurité\n",
+    "\n",
+    "La dernière cellule ne s'active que si Qdrant n'a jamais été joignable. Dans cette exécution, la branche ne sera pas prise — la sortie ci-dessous le confirmera (`mode degrade non active`) — mais sa présence fait partie du contrat pédagogique : un lecteur sans Docker reçoit quand même une démonstration NumPy du compromis coût/qualité (échantillonnage croissant contre recherche exhaustive), avec un renvoi vers le notebook 05 pour l'implémentation HNSW from-scratch.\n",
+    "\n",
+    "**À retenir** : la dégradation est **confinée** — elle ne remplace aucune mesure, elle fournit un chemin de repli. Les résultats serveur restent la référence ; le mode dégradé garantit seulement que le notebook reste exécutable partout."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-python #13438

## Résumé

- enrichit les transitions et lectures pédagogiques du notebook RAG 05b sans toucher au code ni aux sorties ;
- ancre chaque interprétation quantitative sur les outputs déjà committés ;
- relève la densité pédagogique du notebook au-dessus du plancher de 1200 caractères par cellule code.

See #13410 — tranche atomique 1 ; le tracker reste ouvert pour les autres notebooks sous le plancher.

## Validation

- `pedagogy_density.py` : `1671` caractères de prose par cellule code (`16712 / 10`), seuil `1200` tenu ;
- `validate_pr_notebooks.py` : `EXEC_PROVED`, 10/10 cellules code, 0 erreur ;
- `scan_cell_ordering.py --fail-on HIGH --check-interp-anchor` : 1 notebook clean, 0 finding ;
- `check_interp_positioning.py` : 0 interprétation mal placée ;
- `check_markdown_claims_output.py` : `CLEAN`, 0 valeur non ancrée ;
- `detect_markdown_rendering.py --check` : aucune nouvelle violation ERROR ;
- `detect_code_in_markdown_cells.py --check` : aucune nouvelle violation ;
- `detect_consecutive_code_cells.py` : 0 run, longueur maximale 1 ;
- comparaison structurée avec `origin/main` : sources code, outputs et `execution_count` identiques ; 11/11 nouvelles cellules sont markdown ;
- `git diff --check` : propre ; un seul notebook modifié, catalogue inchangé.

## Portée d’exécution

Modification markdown-only : aucune cellule code modifiée, donc aucune ré-exécution (C.2/C.3). Les sources code, outputs et execution counts restent identiques à `origin/main`.
