### PR TITLE
fix(gametheory,#13326): GT-03d retypage cell[7] + restauration du code E2 perdu

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
@@ -1,6 +1,716 @@
 {
- "nbformat": 4,
- "nbformat_minor": 5,
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2433ddbd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002616,
+     "end_time": "2026-08-29T03:00:28.715478",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.712862",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-03d — Biens publics non-lineaires : plan de deformation\n",
+    "\n",
+    "**Navigation** : [<< 3-Topology2x2](GameTheory-03-Topology2x2.ipynb) | [<< 3b-Chambres-et-Murs](GameTheory-03b-Chambres-et-Murs.ipynb) | [<< 3c-Le-Joueur-LLM](GameTheory-03c-Le-Joueur-LLM.ipynb) | [Index](README.md) | [4-NashEquilibrium >>](GameTheory-04-NashEquilibrium.ipynb)\n",
+    "\n",
+    "## Du tableau periodique au plan de deformation\n",
+    "\n",
+    "Ce notebook etend la serie 3 (classification topologique des jeux 2x2 de Robinson & Goforth) au **cas N-personnes** grace a la revue d'Archetti & Scheuring (2012), *Game theory of public goods in one-shot social dilemmas without assortment*, *Journal of Theoretical Biology* 299 : 9-20.\n",
+    "\n",
+    "Le constat fondateur : aucun bien public **lineaire** n'a ete rapporte dans la nature — les fonctions de benefice biologiques sont saturantes ou sigmoides. Avec une fonction de benefice non-lineaire, un **equilibre polymorphe stable** (coexistence cooperateurs/defecteurs) emerge **sans aucun assortiment** (ni parentele, ni iteration).\n",
+    "\n",
+    "### Plan du notebook\n",
+    "\n",
+    "1. **E1 — La famille 2x2 dans le plan** : enumeration complete des 78 profils 2x2 distincts, classification par les 4 archetypes de Robinson-Goforth (PD, SH, SD, H) avec definition stricte, et verification que les 4 archetypes emergent avec leurs 4 profils canoniques.\n",
+    "2. **E2 — Le plan de deformation** : implementation de la fonction de benefice non-lineaire generalisee `b(i)` (eq. 13), balayage `(k, s, c/b)`, enumeration des regimes (defection pure / coexistence / bistabilite / cooperation pure), et verification de l'approximation `x+ ~ (k-1)/(N-1)` pour grand N.\n",
+    "3. **E3 — Le mur a memoire (hysteresis)** : diagramme de bifurcation de `c/b` avec deux trajectoires (montante puis descendante) qui peuvent diverger. La transformation du monde descriptif n'est pas inversee par sa contre-transformation.\n",
+    "4. **E4 — Le contre-claim execute** : MacLean et al. (2010) sur la levure — le Snowdrift 2-personnes predit mal l'optimum intermediaire, le **jeu N-personnes non-lineaire** le predit exactement. Une cellule qui montre que le modele echoue n'etait pas le bon modele.\n",
+    "\n",
+    "### Dette de derivation (HARD)\n",
+    "\n",
+    "- Les formules `eq. 7, 9, 13` et les `x+` associes sont **citees** d'Archetti-Scheuring 2012 (et la preuve formelle renvoyee a Archetti-Scheuring 2011 *Evolution* 65 : 1140-1148). **Pas re-derivees** par nous dans ce notebook — toute affirmation publique s'appuie sur la source, pas sur une reconstruction personnelle.\n",
+    "- La correspondance `convexe -> Stag-Hunt` / `concave -> Snowdrift` est **notre lecture** qualitative du papier, etablie dans E2.\n",
+    "- L'analogie `Robinson-Goforth 2x2 <-> plan de deformation N-personnes` est **notre construction**, pas un resultat de la source. Elle est utile pedagogiquement, mais doit rester explicitee comme telle.\n",
+    "\n",
+    "Ces trois points sont **non negociables** : confondre une dette de derivation avec un resultat acquis transforme une revue honnete en theatre anti-Hermes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "90f35ae5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T03:00:28.721394Z",
+     "iopub.status.busy": "2026-08-29T03:00:28.721394Z",
+     "iopub.status.idle": "2026-08-29T03:00:28.807925Z",
+     "shell.execute_reply": "2026-08-29T03:00:28.806895Z"
+    },
+    "papermill": {
+     "duration": 0.090926,
+     "end_time": "2026-08-29T03:00:28.808446",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.717520",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK. Numpy 2.2.6, RNG seed=20260822\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports et constantes\n",
+    "import numpy as np\n",
+    "\n",
+    "# Pas de scipy / sympy : notebook portable CPU-only\n",
+    "RNG = np.random.default_rng(20260822)  # graine fixee pour reproductibilite\n",
+    "print(f\"Imports OK. Numpy {np.__version__}, RNG seed=20260822\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ace19172",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001619,
+     "end_time": "2026-08-29T03:00:28.812651",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.811032",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Configuration de l'environnement\n",
+    "\n",
+    "Nous travaillons en numpy pur (pas de scipy, pas de sympy) — le notebook doit s'executer sur toute machine CPU avec un stack Python standard. La bibliotheque `matplotlib` n'est utilisee que pour les figures (non requises pour les assertions)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b947fe8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003071,
+     "end_time": "2026-08-29T03:00:28.817345",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.814274",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. La famille 2x2 dans le plan\n",
+    "\n",
+    "### Notation\n",
+    "\n",
+    "Pour classifier un jeu 2x2, Robinson & Goforth (2005) utilisent une representation **ordinale** (1=pire, 4=meilleur). Les 4 archetypes sont definis par leur profil d'incitation stricte :\n",
+    "\n",
+    "- **Prisoner's Dilemma (PD)** : T > R > P > S (defection strictement dominante, dilemme social).\n",
+    "- **Stag Hunt (SH)** : R > T et R > P (cooperation et defection sont NE, coordination).\n",
+    "- **Snowdrift / Hawk-Dove (SD)** : T > R > S > P (cooperation faiblement dominante, conflit).\n",
+    "- **Harmony (H)** : R > T et R > S > P (cooperation strictement dominante, pas de conflit).\n",
+    "\n",
+    "Archetti & Scheuring (2012, p. 10) invoquent Robinson-Goforth comme **validation independante** de la parente topologique de ces quatre jeux — et c'est une donnee pour la question d'attribution ouverte dans l'EPIC distillation #12208.\n",
+    "\n",
+    "### Verification\n",
+    "\n",
+    "Le code ci-dessous enumere les **78 profils 2x2 distincts en ordinaux** (4 issues placees sur 4 cases avec repetition possible mais avec 4 valeurs distinctes au total par ligne) et verifie que **les 4 archetypes** apparaissent comme profils canoniques. Le but est transformer la citation qualitative du papier en une **mesure verifiable** sur notre machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1a048d29",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T03:00:28.822922Z",
+     "iopub.status.busy": "2026-08-29T03:00:28.821413Z",
+     "iopub.status.idle": "2026-08-29T03:00:28.832197Z",
+     "shell.execute_reply": "2026-08-29T03:00:28.832197Z"
+    },
+    "papermill": {
+     "duration": 0.013999,
+     "end_time": "2026-08-29T03:00:28.833413",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.819414",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification des 4 archetypes canoniques :\n",
+      "  PD ((3, 0), (4, 1)) -> PD  [OK]\n",
+      "  SH ((3, 1), (2, 2)) -> SH  [OK]\n",
+      "  SD ((2, 1), (3, 0)) -> SD  [OK]\n",
+      "  H ((3, 2), (1, 0)) -> H  [OK]\n",
+      "\n",
+      "Enumeration complete (576 profils 2x2) :\n",
+      "     PD :   4 (  0.7%)\n",
+      "     SH :  28 (  4.9%)\n",
+      "     SD :   4 (  0.7%)\n",
+      "      H :  28 (  4.9%)\n",
+      "  Other : 512 ( 88.9%)\n",
+      "  TOTAL : 576\n"
+     ]
+    }
+   ],
+   "source": [
+    "# E1 — La famille 2x2 dans le plan\n",
+    "# Classification stricte des 4 archetypes Robinson-Goforth parmi les 78 profils distincts.\n",
+    "from itertools import permutations\n",
+    "\n",
+    "def rgs_class(profile):\n",
+    "    \"\"\"Classification Robinson-Goforth stricte : 4 archetypes par inequalities strictes.\n",
+    "    profile = ((J1_00, J1_01), (J1_10, J1_11)) en ordinaux 1..4.\n",
+    "    Renvoie : 'PD' | 'SH' | 'SD' | 'H' | 'Other'.\n",
+    "    T = J1_10 (defecter vs cooperateur)\n",
+    "    R = J1_00 (cooperer vs cooperateur)\n",
+    "    P = J1_11 (defecter vs defecter)\n",
+    "    S = J1_01 (cooperer vs defecter)\n",
+    "    \"\"\"\n",
+    "    T, R, P, S = profile[1][0], profile[0][0], profile[1][1], profile[0][1]\n",
+    "    if T > R > P > S:\n",
+    "        return 'PD'\n",
+    "    if R > T and R > P and P > S:\n",
+    "        return 'SH'  # cooperation ET defection sont NE\n",
+    "    if T > R > S > P:\n",
+    "        return 'SD'  # Snowdrift : cooperation faiblement dominante\n",
+    "    if R > T and R > S > P:\n",
+    "        return 'H'   # Harmony : cooperation strictement dominante\n",
+    "    return 'Other'\n",
+    "\n",
+    "# Les 4 archetypes canoniques (reference : Robinson-Goforth 2005, p. 47-52)\n",
+    "PD_canon = ((3, 0), (4, 1))   # R=3, P=1, S=0, T=4  -> PD (T=4>R=3>P=1>S=0)\n",
+    "SH_canon = ((3, 2), (2, 1))   # R=3, T=2, P=1, S=2  -> SH (R>T=2, R>P=1, P<S=2) Wait P=1 < S=2 fail\n",
+    "# Reordenancer pour verifier les 4 inequalities strictes de SH\n",
+    "SH_canon = ((3, 1), (2, 2))   # R=3, T=2, P=2, S=1 -> R>T=2 OK, R>P=2 OK, P=S=2 fail\n",
+    "SH_canon = ((3, 1), (2, 2))   # R=3 > T=2 OK, P=2 > S=1 OK -> SH authentique\n",
+    "SD_canon = ((2, 3), (4, 1))   # R=2, T=4, S=3, P=1 -> T=4>R=2 OK, R=2<S=3 fail -> SD?\n",
+    "# SD authentique : T > R > S > P. Reordenancer.\n",
+    "SD_canon = ((3, 1), (4, 2))   # R=3, T=4, S=1, P=2 -> T=4>R=3 OK, R=3>S=1 OK, S=1<P=2 fail\n",
+    "# Reordenancer pour S > P\n",
+    "SD_canon = ((2, 3), (3, 1))   # R=2, T=3, S=3, P=1 -> T=3>R=2 OK, R=2<S=3 fail\n",
+    "# SD authentique T>R>S>P : exemple canonique Hawk-Dove : T=3, R=2, S=1, P=0\n",
+    "SD_canon = ((2, 1), (3, 0))   # R=2, T=3, S=1, P=0 -> T=3>R=2>R ok wait R>S=1 ok S>P=0 ok -> SD\n",
+    "H_canon  = ((3, 2), (1, 0))   # R=3, T=1, S=2, P=0 -> R=3>T=1 OK, R=3>S=2 OK, S=2>P=0 OK -> H\n",
+    "\n",
+    "# Verification des 4 archetypes canoniques\n",
+    "print(\"Verification des 4 archetypes canoniques :\")\n",
+    "for name, prof in [('PD', PD_canon), ('SH', SH_canon), ('SD', SD_canon), ('H', H_canon)]:\n",
+    "    cls = rgs_class(prof)\n",
+    "    status = 'OK' if cls == name else f'BUG (classe comme {cls})'\n",
+    "    print(f\"  {name} {prof} -> {cls}  [{status}]\")\n",
+    "\n",
+    "# Enumere tous les profils admissibles : pour chaque ligne J1, choix d'une\n",
+    "# permutation stricte de 4 valeurs distinctes parmi {1,2,3,4}\n",
+    "# (chaque case recoit une valeur differente -> 4! = 24 profils par ligne)\n",
+    "# Pour le profil complet, J2 doit aussi etre une permutation stricte de 4 valeurs distinctes\n",
+    "# -> 24 x 24 = 576 profils complets. Mais les doublons (J1=J2 modulo label) -> 78 profils distincts\n",
+    "# (compte canonique Rapoport-Guyer 1966).\n",
+    "comptes = {'PD': 0, 'SH': 0, 'SD': 0, 'H': 0, 'Other': 0}\n",
+    "exemples_par_classe = {k: [] for k in comptes}\n",
+    "\n",
+    "# Enumeration exacte : pour chaque couple de permutations strictes de (1,2,3,4)\n",
+    "for J1_row in permutations([1, 2, 3, 4]):\n",
+    "    for J2_row in permutations([1, 2, 3, 4]):\n",
+    "        prof = (J1_row, J2_row)\n",
+    "        cls = rgs_class(prof)\n",
+    "        comptes[cls] += 1\n",
+    "        if len(exemples_par_classe[cls]) < 2:\n",
+    "            exemples_par_classe[cls].append(prof)\n",
+    "\n",
+    "print(f\"\\nEnumeration complete (576 profils 2x2) :\")\n",
+    "total = sum(comptes.values())\n",
+    "for cls in ['PD', 'SH', 'SD', 'H', 'Other']:\n",
+    "    n = comptes[cls]\n",
+    "    pct = 100 * n / total\n",
+    "    print(f\"  {cls:>5} : {n:>3} ({pct:>5.1f}%)\")\n",
+    "print(f\"  TOTAL : {total}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77d45634",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003257,
+     "end_time": "2026-08-29T03:00:28.838415",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.835158",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "L'enumeration produit **78 profils distincts** dont la distribution par classe Robinson-Goforth fait emerger les 4 archetypes canoniques (PD, SH, SD, H) avec leurs 4 profils canoniques specifies (T, R, P, S dans le bon ordre). Le reste des profils tombent dans **'Other'** — ces profils n'ont pas de structure d'incitation stricte et sont les **murs** au sens de #12213 (chambres-et-murs) : leur identite se voit dans la parente topologique plutot que dans la lecture des strategies dominantes.\n",
+    "\n",
+    "Archetti-Scheuring (2012, p. 10) affirment que **la parente des quatre jeux n'est pas evidente dans la taxonomie classique (Rapoport-Guyer 1966) mais claire dans une classification topologique** (Robinson-Goforth 2005). Notre verification ci-dessus donne chair a cette affirmation : les 4 archetypes canoniques se distinguent par leur signature topologique (les 4 inequalities strictes), pas par leur identite lexicale.\n",
+    "\n",
+    "**Verification croisee** : les 4 profils canoniques sont les **4 elements minimaux** de chaque classe au sens « un swap d'une case suffit a quitter la classe ». C'est la definition topologique de Robinson-Goforth."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b06f42d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002001,
+     "end_time": "2026-08-29T03:00:28.842428",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.840427",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Le plan de deformation (E2)\n",
+    "\n",
+    "### La fonction de benefice generalisee\n",
+    "\n",
+    "Le pivot du papier (Archetti & Scheuring 2012, eq. 13) est la **fonction de benefice non-lineaire generalisee** :\n",
+    "\n",
+    "```\n",
+    "b(i) = k^s / (k^s + i^s)   (eq. 13)\n",
+    "```\n",
+    "\n",
+    "avec `k` la position du seuil (cooperateurs au-dessus de k contribuent), `s` la raideur de la sigmoide, et `i` le nombre de cooperateurs. Cette fonction interpole continument tous les jeux N-personnes :\n",
+    "\n",
+    "- `s -> 0` : degenerescence, defection pure (N-personnes Prisoner's Dilemma classique).\n",
+    "- `s -> +inf`, `k = 1` : Volunteer's Dilemma pur, equilibre mixte `x+ = 1 - (c/b)^(1/(N-1))` (eq. 9).\n",
+    "- Pour grand N et autour de `k = 1`, l'approximation `x+ ~ (k-1)/(N-1)` (citee eq. 9 du papier, derivee dans Archetti-Scheuring 2011).\n",
+    "\n",
+    "### Notre implementation\n",
+    "\n",
+    "Le code ci-dessous implemente `b(i)`, balaye le plan `(k, s)` sur la plage `k in [1, 8]`, `s in [0.5, 8]`, pour differentes valeurs de `c/b`, et verifie que les 3 regimes emergent. **Pas de re-derivation** — `x+` est cite d'eq. 9."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "913fdebc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002015,
+     "end_time": "2026-08-29T03:00:28.846964",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.844949",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "L'enumeration produit **576 profils distincts en ordinaux stricts** dont la distribution par classe Robinson-Goforth fait emerger les 4 archetypes canoniques (4 PD, 28 SH, 4 SD, 28 H) sur 576 profils (les 88.9% restants sont des profils sans structure d'incitation stricte, les \"murs\" au sens de #12213 (chambres-et-murs)). La parente topologique de Robinson-Goforth (2005) tient : les 4 archetypes canoniques se distinguent par leur signature d'inegalites strictes, pas par leur identite lexicale.\n",
+    "\n",
+    "### Verdict E2 sur les regimes\n",
+    "\n",
+    "**Resultat observe** : sur la plage k in [0.5, 5.0], c/b in {0.1, 0.3, 0.5, 0.8} avec s grand (6.0), la formule x+ = 1 - (c/b)^(1/(N-1)) produit **100% coexistence** (aucune cellule en defection pure ni en cooperation pure). Cela reflete la nature de l'eq. 9 : pour c/b strictement entre 0 et 1, x+ est strictement entre 0 et 1, donc la coexistence est l'unique regime.\n",
+    "\n",
+    "**Pourquoi alors Archetti-Scheuring parlent de 3 regimes ?** L'eq. 9 est l'approximation Volunteer's Dilemma (s grand, k=1). Pour les regimes bistables (s moderee), il faut utiliser l'eq. 7 du papier (modele exact) qui peut donner defection pure ou cooperation pure pour certaines valeurs de (k, s). Notre implementation balaye l'eq. 9 seulement, d'ou la degeneration observee.\n",
+    "\n",
+    "**Verification eq. 9 vs approximation** : pour k=2, c/b=0.5, l'approximation x+ ~ (k-1)/(N-1) a une erreur relative de ~70% a N=3, ~50% a N=10, ~45% a N=100. L'approximation ne tient pas bien -- elle suppose N grand et (k-1) petit. Conclusion : l'eq. 9 est la reference, l'approximation est pedagogiquement interessante mais quantitativement grossiere.\n",
+    "\n",
+    "**Limite honnete** : le balayage sur les **3 regimes** (defection pure, coexistence, cooperation pure) necessite l'eq. 7 du papier, pas l'eq. 9. C'est une dette technique du notebook que nous assumons -- la classification des regimes selon l'eq. 7 ferait l'objet d'un E2bis ulterieur.\n",
+    "\n",
+    "Archetti-Scheuring (2012, p. 10) affirment que **la parente des quatre jeux n'est pas evidente dans la taxonomie classique (Rapoport-Guyer 1966) mais claire dans une classification topologique** (Robinson-Goforth 2005). Notre verification E1 ci-dessus donne chair a cette affirmation : les 4 archetypes canoniques se distinguent par leur signature topologique (les 4 inequalities strictes), pas par leur identite lexicale. La verification E2 confirme que l'eq. 9 (citee du papier) tient comme equilibre asymptotique, et demontre la degeneration du modele simplifie hors de son domaine de validite (s grand)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7254815b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00204,
+     "end_time": "2026-08-29T03:00:28.852001",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.849961",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "La carte des regimes montre la structure du plan `(k, s)` a `c/b` fixe :\n",
+    "\n",
+    "- **Bande cooperative pure** (k >> s, k eleve) : la cooperation est assez stable pour que l'equilibre unique soit cooperation totale.\n",
+    "- **Bande defectrice pure** (k << s, k bas) : la defection domine car le seuil n'est jamais atteignable.\n",
+    "- **Bande de coexistence** (k autour de 1, s moderee) : equilibre polymorphe stable, la population se partage entre cooperateurs et defecteurs — c'est le coeur du resultat d'Archetti-Scheuring.\n",
+    "\n",
+    "L'approximation `x+ ~ (k-1)/(N-1)` tient pour N >= 10 avec erreur relative < 20 %. Pour N = 3, l'approximation est grossiere (erreur ~ 30 %) — c'est attendu : la derivation de l'eq. 9 suppose N grand pour lineariser le terme `(1 - x+)^(N-1)`.\n",
+    "\n",
+    "Le **point pedagogique** : a un `c/b` fixe, le passage d'un regime a l'autre n'est pas un swap discret (comme dans le tableau 2x2 de Robinson-Goforth) mais une **deformation continue** dans `(k, s)`. C'est l'analogue N-personnes du tableau periodique — deux tranches de la meme geometrie.\n",
+    "\n",
+    "**Limite honnete** : le modele `x+ = 1 - (c/b)^(1/(N-1))` est une approximation Volunteer's Dilemma (s -> +inf). Pour les regimes bistables (s intermadiaire), il faudrait un modele different — voir eq. 7 du papier pour la formulation generale."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cba1a1c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002981,
+     "end_time": "2026-08-29T03:00:28.856986",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.854005",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Le mur a memoire (E3)\n",
+    "\n",
+    "### Hysteresis : la transformation n'est pas inversee par sa contre-transformation\n",
+    "\n",
+    "Pour un bien a seuil (Fig. 3A d'Archetti-Scheuring 2012), le diagramme de bifurcation de `c/b` presente un phenomene d'**hysteresis** quand la fonction de benefice est suffisamment non-lineaire :\n",
+    "\n",
+    "- **Trajet montante** (c/b croit depuis 0) : la population reste dans l'etat cooperation jusqu'a un seuil de bifurcation `c/b_up`, puis bascule en defection pure.\n",
+    "- **Trajet descendante** (c/b decroit depuis 1) : la population reste en defection pure jusqu'a un seuil `c/b_down < c/b_up`, puis bascule en cooperation.\n",
+    "\n",
+    "Les deux trajectoires **divergent** dans une fenetre intermediaire : pour `c/b_down < c/b < c/b_up`, l'etat de la population depend de **son histoire**. La contre-transformation (redescendre c/b) ne restaure pas l'etat anterieur (cooperation) — elle laisse la population en defection.\n",
+    "\n",
+    "### Notre implementation\n",
+    "\n",
+    "Le code ci-dessous simule un modele simplifie a hysteresis en utilisant un **potentiel bistable** : la dynamique de la population (proportion de cooperateurs `x`) suit `dx/dt = -dV/dx` avec un potentiel `V(x) = ...` qui depend de `c/b`. Quand `c/b` est dans la fenetre bistable, le potentiel a 2 minima locaux ; selon l'histoire, la population se trouve dans l'un ou l'autre.\n",
+    "\n",
+    "C'est une **simplification pedagogique** : le modele exact d'Archetti-Scheuring est multi-population, mais l'essence de l'hysteresis (bistabilite + path-dependence) est preservee."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "83312740",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T03:00:28.862986Z",
+     "iopub.status.busy": "2026-08-29T03:00:28.862986Z",
+     "iopub.status.idle": "2026-08-29T03:00:28.901661Z",
+     "shell.execute_reply": "2026-08-29T03:00:28.901661Z"
+    },
+    "papermill": {
+     "duration": 0.044227,
+     "end_time": "2026-08-29T03:00:28.903213",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.858986",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Diagramme de bifurcation avec bruit sigma=0.08 :\n",
+      "  Ecart max trajet montante vs descendante : -0.7381 a c/b = 0.600\n",
+      "  -> HYSTERESIS DETECTEE numerement (ecart > 5%)\n",
+      "\n",
+      "  c/b    Up    Down  Ecart\n",
+      "  0.000  0.885  0.929  -0.044\n",
+      "  0.250  0.074  0.793  -0.719\n",
+      "  0.500  0.682  1.000  -0.318\n",
+      "  0.750  0.725  0.627  +0.098\n",
+      "  1.000  0.809  0.403  +0.406\n",
+      "\n",
+      "Couplage ICT : hysteresis = dissociation-mesure (strate 7)\n",
+      "  Pour un meme c/b, l'etat final depend de l'histoire.\n",
+      "  Le parametre de controle n'est pas une fonction d'etat de la population.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# E3 — Mur a memoire : hysteresis\n",
+    "# Modele simplifie : dynamique de la proportion de cooperateurs avec bruit de Langevin.\n",
+    "# Potentiel V(x) bistable : la trajectoire est path-dependent quand V a 2 minima.\n",
+    "\n",
+    "def dynamique_coop(c_over_b, x_init, n_steps=200, sigma=0.05):\n",
+    "    \"\"\"Simule l'evolution de x (proportion de cooperateurs) selon une dynamique\n",
+    "    de type gradient + bruit : dx = f(x, c/b) dt + sigma dW.\n",
+    "    f(x, c/b) = x * (1 - x) * (b(i, k, s) - c) simplifie en 1D.\n",
+    "    \"\"\"\n",
+    "    x = x_init\n",
+    "    xs = [x]\n",
+    "    for _ in range(n_steps):\n",
+    "        # f(x) : pousse vers cooperation si benefice > cout, vers defection sinon\n",
+    "        f_x = x * (1 - x) * (1.0 - 2 * c_over_b)  # zero-crossing a c/b = 0.5\n",
+    "        # Bruit de Langevin\n",
+    "        bruit = sigma * RNG.normal()\n",
+    "        x = x + 0.05 * f_x + bruit\n",
+    "        x = max(0.0, min(1.0, x))\n",
+    "        xs.append(x)\n",
+    "    return np.array(xs)\n",
+    "\n",
+    "# Parametres\n",
+    "N = 10\n",
+    "n_steps = 500\n",
+    "sigma = 0.08  # bruit de Langevin\n",
+    "\n",
+    "# Balayage c/b dans [0, 1]\n",
+    "cb_vals = np.linspace(0.0, 1.0, 21)\n",
+    "\n",
+    "# Trajet montante : x_init = 1 (cooperation), c/b croit de 0 a 1\n",
+    "# Pour chaque valeur de c/b, on prend la valeur finale de la trajectoire precedente\n",
+    "coop_up = []\n",
+    "x = 1.0  # depart en cooperation totale\n",
+    "for c in cb_vals:\n",
+    "    traj = dynamique_coop(c, x_init=x, n_steps=n_steps, sigma=sigma)\n",
+    "    x = traj[-1]\n",
+    "    coop_up.append(x)\n",
+    "\n",
+    "# Trajet descendante : x_init = 0 (defection), c/b decroit de 1 a 0\n",
+    "coop_down = []\n",
+    "x = 0.0\n",
+    "for c in reversed(cb_vals):\n",
+    "    traj = dynamique_coop(c, x_init=x, n_steps=n_steps, sigma=sigma)\n",
+    "    x = traj[-1]\n",
+    "    coop_down.append(x)\n",
+    "coop_down = list(reversed(coop_down))\n",
+    "\n",
+    "# Detection de la fenetre d'hysteresis\n",
+    "diffs = np.array(coop_up) - np.array(coop_down)\n",
+    "max_diff_idx = np.argmax(np.abs(diffs))\n",
+    "max_diff = diffs[max_diff_idx]\n",
+    "\n",
+    "print(f\"Diagramme de bifurcation avec bruit sigma={sigma} :\")\n",
+    "print(f\"  Ecart max trajet montante vs descendante : {max_diff:.4f} a c/b = {cb_vals[max_diff_idx]:.3f}\")\n",
+    "if abs(max_diff) > 0.05:\n",
+    "    print(f\"  -> HYSTERESIS DETECTEE numerement (ecart > 5%)\")\n",
+    "else:\n",
+    "    print(f\"  -> Pas d'hysteresis distincte avec ce niveau de bruit\")\n",
+    "\n",
+    "# Affiche les valeurs pour 5 points intermediaires\n",
+    "print(f\"\\n  c/b    Up    Down  Ecart\")\n",
+    "for i in [0, 5, 10, 15, 20]:\n",
+    "    print(f\"  {cb_vals[i]:.3f}  {coop_up[i]:.3f}  {coop_down[i]:.3f}  {coop_up[i] - coop_down[i]:+.3f}\")\n",
+    "\n",
+    "# Couplage ICT : la transformation n'est pas inversee par sa contre-transformation\n",
+    "print(f\"\\nCouplage ICT : hysteresis = dissociation-mesure (strate 7)\")\n",
+    "print(f\"  Pour un meme c/b, l'etat final depend de l'histoire.\")\n",
+    "print(f\"  Le parametre de controle n'est pas une fonction d'etat de la population.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83332779",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002746,
+     "end_time": "2026-08-29T03:00:28.908196",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.905450",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "La simulation numerique exhibe une **fenetre d'hysteresis** dans le plan c/b : pour certaines plages de c/b, la trajectoire montante et la trajectoire descendante donnent des proportions de cooperation **tres distinctes** (jusqu'a 0.74 d'ecart, soit 74 points de pourcentage dans la fenetre centrale). Pour d'autres plages de c/b, les deux trajectoires convergent partiellement (cooperation stable en haut, defection stable en bas).\n",
+    "\n",
+    "**Ecart maximum observe : -0.7381 a c/b = 0.600** (la trajectoire descendante est plus haute que la trajectoire montante a ce point : x_down = 0.793, x_up = 0.074). C'est un cas typique d'hysteresis ou la memoire de l'etat initial persiste.\n",
+    "\n",
+    "**Couplage ICT** : la transformation du monde descriptif non inversee par sa contre-transformation = **strate 7 pure** (le parametre de controle n'est pas une fonction d'etat de la population). Cette dissociation-mesure est un candidat pour la matrice ICT.\n",
+    "\n",
+    "**Limite honnete** : le modele simplifie `dx = f(x) dt + sigma dW` avec `f(x) = x*(1-x)*(1 - 2*c/b)` n'est pas l'equation maitresse d'Archetti-Scheuring (qui est en temps continu multi-population). L'essence de l'hysteresis (bistabilite + path-dependence) est preservee, mais la forme exacte de la fenetre est un artefact du modele simplifie. Pour aller plus loin, voir eq. 7-9 du papier."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87ac3c30",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002007,
+     "end_time": "2026-08-29T03:00:28.913349",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.911342",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Le contre-claim execute (E4)\n",
+    "\n",
+    "### MacLean et al. (2010) : le Snowdrift 2-personnes predit mal, le N-personnes non-lineaire predit juste\n",
+    "\n",
+    "L'experience de MacLean,Fuentes Suarez et al. (2010) sur la levure mesure la frequence de cooperation dans un systeme biologique ou le benefice est non-lineaire. Resultat : la frequence optimale est **intermediaire**, pas totale.\n",
+    "\n",
+    "- **Le Snowdrift 2-personnes** predit l'optimum a cooperation totale (T > R > S > P : cooperation faiblement dominante). **Prediction ratee**.\n",
+    "- **Le jeu N-personnes lineaire** predit la defection totale (T > R : defection dominante en N-personnes lineaire). **Prediction ratee aussi**.\n",
+    "- **Le jeu N-personnes non-lineaire** (Archetti-Scheuring 2012) predit l'equilibre polymorphe, c'est-a-dire une frequence intermediaire. **Prediction reussie**.\n",
+    "\n",
+    "L'histoire est un cas classique d'**echec de modele mal identifie** : ce n'est pas la theorie des jeux qui echoue, c'est l'identification du jeu. Les auteurs du papier original (MacLean et al.) lisent leur resultat comme un **rejet de la theorie des jeux**. Archetti-Scheuring montrent qu'il s'agit d'un **rejet du mauvais modele**, pas de la theorie.\n",
+    "\n",
+    "### Notre implementation\n",
+    "\n",
+    "Le code ci-dessous implemente les trois modeles sur les parametres de l'experience (N=6 groupes typiques, c/b ajuste) et verifie les predictions. C'est une **contre-execution** : on ne derive pas les formules, on prend les predictions citees et on les confronte aux memes parametres.\n",
+    "\n",
+    "**Limite honnete** : MacLean et al. utilisent des populations finies, donc le resultat N-personnes non-lineaire est une **metastabilite** (section 3.11.1 d'Archetti-Scheuring) — l'equilibre theorique est polymorphe, mais une population finie peut deriver par fluctuation. Le notebook exhibe l'equilibre asymptotique, pas la dynamique de population finie."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "70916734",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T03:00:28.920348Z",
+     "iopub.status.busy": "2026-08-29T03:00:28.919352Z",
+     "iopub.status.idle": "2026-08-29T03:00:28.928189Z",
+     "shell.execute_reply": "2026-08-29T03:00:28.927183Z"
+    },
+    "papermill": {
+     "duration": 0.011838,
+     "end_time": "2026-08-29T03:00:28.928189",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.916351",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experience MacLean 2010 : N=6, c/b=0.5, freq_coop observee = 0.30\n",
+      "\n",
+      "Predictions des trois modeles :\n",
+      "  Snowdrift 2p           : 1.0000  -> erreur = 0.7000  [RATEE]\n",
+      "  NPD Np lineaire        : 0.0000  -> erreur = 0.3000  [RATEE]\n",
+      "  Np non-lineaire (eq.9) : 0.1294  -> erreur = 0.1706  [RATEE]\n",
+      "\n",
+      "Verdict :\n",
+      "  Les parametres ne reproduisent pas la dissociation documentee par Archetti-Scheuring\n",
+      "  -> Verifier N, c/b, freq observee sur la source primaire MacLean et al. 2010\n",
+      "\n",
+      "Limite (citee Archetti-Scheuring 2012 sec. 3.11.1) :\n",
+      "  En population finie, l'equilibre polymorphe est metastable -- la population peut\n",
+      "  deriver par fluctuation vers defection pure sur des temps longs. La prediction\n",
+      "  eq. 9 est un equilibre asymptotique, pas une trajectoire de population finie.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# E4 — Contre-claim execute : MacLean 2010 sur la levure\n",
+    "# Trois modeles sur les memes parametres : Snowdrift 2p, NPD Np lineaire, Np non-lineaire.\n",
+    "# Parametres ajustes pour discriminer les modeles (cite eq. 7 et 9 Archetti-Scheuring 2012).\n",
+    "\n",
+    "# Parametres Archetti-Scheuring 2012 (Table 1, scenario typique biens publics biologiques)\n",
+    "N = 6  # taille de groupe MacLean 2010 (cohorte levure)\n",
+    "c_over_b = 0.5  # ratio cout / benefice typique pour le benefice biologique\n",
+    "freq_coop_obs = 0.30  # frequence de cooperation observee MacLean 2010 (intermediaire, 30 %)\n",
+    "\n",
+    "# Modele 1 : Snowdrift 2-personnes (T > R > S > P)\n",
+    "# En 2p, l'equilibre est T > R > S > P : cooperation faiblement dominante\n",
+    "# -> prediction cooperation totale (1.0)\n",
+    "pred_sd = 1.0\n",
+    "\n",
+    "# Modele 2 : NPD N-personnes lineaire (T > R, defection dominante)\n",
+    "# En Np lineaire, defection domine -> prediction defection totale (0.0)\n",
+    "pred_npd = 0.0\n",
+    "\n",
+    "# Modele 3 : N-personnes non-lineaire (eq. 9 citee)\n",
+    "# Equilibre polymorphe : x+ = 1 - (c/b)^(1/(N-1))\n",
+    "def x_plus_archetti(N, c_over_b, k=1.0):\n",
+    "    if N == 1:\n",
+    "        return 1.0 if c_over_b < 1 else 0.0\n",
+    "    base = c_over_b ** (1.0 / (N - 1))\n",
+    "    return max(0.0, min(1.0, 1.0 - base))\n",
+    "\n",
+    "pred_npl = x_plus_archetti(N, c_over_b, k=1.0)\n",
+    "\n",
+    "print(f\"Experience MacLean 2010 : N={N}, c/b={c_over_b}, freq_coop observee = {freq_coop_obs:.2f}\")\n",
+    "print(f\"\\nPredictions des trois modeles :\")\n",
+    "print(f\"  Snowdrift 2p           : {pred_sd:.4f}  -> erreur = {abs(pred_sd - freq_coop_obs):.4f}  [{'CONFIRMEE' if abs(pred_sd - freq_coop_obs) < 0.1 else 'RATEE'}]\")\n",
+    "print(f\"  NPD Np lineaire        : {pred_npd:.4f}  -> erreur = {abs(pred_npd - freq_coop_obs):.4f}  [{'CONFIRMEE' if abs(pred_npd - freq_coop_obs) < 0.1 else 'RATEE'}]\")\n",
+    "print(f\"  Np non-lineaire (eq.9) : {pred_npl:.4f}  -> erreur = {abs(pred_npl - freq_coop_obs):.4f}  [{'CONFIRMEE' if abs(pred_npl - freq_coop_obs) < 0.1 else 'RATEE'}]\")\n",
+    "\n",
+    "# Verdict\n",
+    "sd_ok = abs(pred_sd - freq_coop_obs) < 0.1\n",
+    "npd_ok = abs(pred_npd - freq_coop_obs) < 0.1\n",
+    "npl_ok = abs(pred_npl - freq_coop_obs) < 0.1\n",
+    "\n",
+    "print(f\"\\nVerdict :\")\n",
+    "if npl_ok and not sd_ok and not npd_ok:\n",
+    "    print(f\"  Le modele N-personnes non-lineaire predit la freq observee (err = {abs(pred_npl - freq_coop_obs):.4f})\")\n",
+    "    print(f\"  Le Snowdrift 2p Echoue a predire (err = {abs(pred_sd - freq_coop_obs):.4f})\")\n",
+    "    print(f\"  Le NPD lineaire Echoue a predire (err = {abs(pred_npd - freq_coop_obs):.4f})\")\n",
+    "    print(f\"  -> Le 'rejet de la theorie des jeux' par MacLean 2010 etait un 'rejet du mauvais modele'\")\n",
+    "    print(f\"  -> La theorie des jeux N-personnes non-lineaire (Archetti-Scheuring 2012) reconcilie les observations\")\n",
+    "elif npl_ok and sd_ok and npd_ok:\n",
+    "    print(f\"  Les trois modeles predisent correctement sur ces parametres -- l'experience ne dissocie pas\")\n",
+    "elif npl_ok and sd_ok:\n",
+    "    print(f\"  Snowdrift et Np non-lineaire predisent -- l'experience ne dissocie pas Snowdrift vs Np non-lineaire\")\n",
+    "elif npl_ok and npd_ok:\n",
+    "    print(f\"  NPD lineaire et Np non-lineaire predisent -- l'experience ne dissocie pas lineaire vs non-lineaire\")\n",
+    "else:\n",
+    "    print(f\"  Les parametres ne reproduisent pas la dissociation documentee par Archetti-Scheuring\")\n",
+    "    print(f\"  -> Verifier N, c/b, freq observee sur la source primaire MacLean et al. 2010\")\n",
+    "\n",
+    "# Limite honnete : populations finies -> metastabilite\n",
+    "print(f\"\\nLimite (citee Archetti-Scheuring 2012 sec. 3.11.1) :\")\n",
+    "print(f\"  En population finie, l'equilibre polymorphe est metastable -- la population peut\")\n",
+    "print(f\"  deriver par fluctuation vers defection pure sur des temps longs. La prediction\")\n",
+    "print(f\"  eq. 9 est un equilibre asymptotique, pas une trajectoire de population finie.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02fb23f9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002717,
+     "end_time": "2026-08-29T03:00:28.933910",
+     "exception": false,
+     "start_time": "2026-08-29T03:00:28.931193",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "### Trois lectures\n",
+    "\n",
+    "1. **Serie 3 etendue** : le tableau periodique 2x2 (Robinson-Goforth, valide par biologie evolutive per Archetti-Scheuring 2012) a un analogue N-personnes ou l'on ne se deplace pas par swaps discrets mais par deformation continue de `(k, s, c/b)`. Les chambres/murs/swaps du tableau 2x2 deviennent des regimes/hysteresis/deformations dans le plan N-personnes.\n",
+    "2. **Hysteresis comme dissociation-mesure** : la transformation du monde descriptif non inversee par sa contre-transformation est un **mur a memoire**, candidat direct pour la matrice ICT en tant que dissociation-mesure (un meme `c/b` peut donner deux populations distinctes).\n",
+    "3. **Contre-claim execute** : MacLean 2010 sur la levure montre que le Snowdrift 2-personnes echoue, le NPD lineaire echoue, le N-personnes non-lineaire predit juste. La theorie des jeux n'est pas en defaut — c'est l'identification du jeu qui etait en defaut.\n",
+    "\n",
+    "### Dette de derivation asumee\n",
+    "\n",
+    "- Formules citees eq. 7, 9, 13 d'Archetti-Scheuring 2012, pas re-derivees.\n",
+    "- Preuve formelle renvoyee a Archetti-Scheuring 2011 *Evolution* 65 : 1140-1148.\n",
+    "- Analogie R-G <-> plan de deformation = notre construction.\n",
+    "- Resultats E4 (Snowdrift/NPD echouent, Np non-lineaire predit) pris comme **faits experimentaux rapportes** dans la litterature, pas re-verifies sur les donnees brutes de MacLean et al. 2010.\n",
+    "\n",
+    "### Suites possibles (hors scope ce notebook)\n",
+    "\n",
+    "- **Extension au joueur LLM #12254** : l'empreinte mixte `x+` au niveau population devrait etre observable chez un LLM joue en population simulee, et la prediction « plus rationnel qu'humain » devient mesurable.\n",
+    "- **Portage Lean** : la formalisation des regimes en `lake` — c.f. `cooperative_games_lean` deja en place pour le Shapley. Un submodule `nperson_public_goods_lean` portant la sigmoide et l'hysteresis serait la suite naturelle.\n",
+    "- **Infusion ICT** : le mur a memoire (hysteresis) est candidat strate 7 — voir la matrice de dissociations `docs/ict/dissociations-matrix.md` et le tracker #12257.\n",
+    "\n",
+    "Refs #12204 (EPIC distillation) · #12207 (EPIC lexique GT) · #12208 (table distillation) · #12213 (3b chambres/murs) · #12254 (3c joueur LLM) · #12256 (ce grain)."
+   ]
+  }
+ ],
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3",
@@ -8,140 +718,30 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.10+"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.730099,
+   "end_time": "2026-08-29T03:00:29.071316",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-03d-Plan-de-deformation.ipynb",
+   "output_path": "GameTheory-03d-Plan-de-deformation.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-29T03:00:27.341217",
+   "version": "2.6.0"
   }
  },
- "cells": [
-  {
-   "id": "2433ddbd",
-   "cell_type": "markdown",
-   "source": "# GameTheory-03d — Biens publics non-lineaires : plan de deformation\n\n**Navigation** : [<< 3-Topology2x2](GameTheory-03-Topology2x2.ipynb) | [<< 3b-Chambres-et-Murs](GameTheory-03b-Chambres-et-Murs.ipynb) | [<< 3c-Le-Joueur-LLM](GameTheory-03c-Le-Joueur-LLM.ipynb) | [Index](README.md) | [4-NashEquilibrium >>](GameTheory-04-NashEquilibrium.ipynb)\n\n## Du tableau periodique au plan de deformation\n\nCe notebook etend la serie 3 (classification topologique des jeux 2x2 de Robinson & Goforth) au **cas N-personnes** grace a la revue d'Archetti & Scheuring (2012), *Game theory of public goods in one-shot social dilemmas without assortment*, *Journal of Theoretical Biology* 299 : 9-20.\n\nLe constat fondateur : aucun bien public **lineaire** n'a ete rapporte dans la nature — les fonctions de benefice biologiques sont saturantes ou sigmoides. Avec une fonction de benefice non-lineaire, un **equilibre polymorphe stable** (coexistence cooperateurs/defecteurs) emerge **sans aucun assortiment** (ni parentele, ni iteration).\n\n### Plan du notebook\n\n1. **E1 — La famille 2x2 dans le plan** : enumeration complete des 78 profils 2x2 distincts, classification par les 4 archetypes de Robinson-Goforth (PD, SH, SD, H) avec definition stricte, et verification que les 4 archetypes emergent avec leurs 4 profils canoniques.\n2. **E2 — Le plan de deformation** : implementation de la fonction de benefice non-lineaire generalisee `b(i)` (eq. 13), balayage `(k, s, c/b)`, enumeration des regimes (defection pure / coexistence / bistabilite / cooperation pure), et verification de l'approximation `x+ ~ (k-1)/(N-1)` pour grand N.\n3. **E3 — Le mur a memoire (hysteresis)** : diagramme de bifurcation de `c/b` avec deux trajectoires (montante puis descendante) qui peuvent diverger. La transformation du monde descriptif n'est pas inversee par sa contre-transformation.\n4. **E4 — Le contre-claim execute** : MacLean et al. (2010) sur la levure — le Snowdrift 2-personnes predit mal l'optimum intermediaire, le **jeu N-personnes non-lineaire** le predit exactement. Une cellule qui montre que le modele echoue n'etait pas le bon modele.\n\n### Dette de derivation (HARD)\n\n- Les formules `eq. 7, 9, 13` et les `x+` associes sont **citees** d'Archetti-Scheuring 2012 (et la preuve formelle renvoyee a Archetti-Scheuring 2011 *Evolution* 65 : 1140-1148). **Pas re-derivees** par nous dans ce notebook — toute affirmation publique s'appuie sur la source, pas sur une reconstruction personnelle.\n- La correspondance `convexe -> Stag-Hunt` / `concave -> Snowdrift` est **notre lecture** qualitative du papier, etablie dans E2.\n- L'analogie `Robinson-Goforth 2x2 <-> plan de deformation N-personnes` est **notre construction**, pas un resultat de la source. Elle est utile pedagogiquement, mais doit rester explicitee comme telle.\n\nCes trois points sont **non negociables** : confondre une dette de derivation avec un resultat acquis transforme une revue honnete en theatre anti-Hermes.",
-   "metadata": {}
-  },
-  {
-   "id": "90f35ae5",
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": 1,
-   "source": "# Imports et constantes\nimport numpy as np\n\n# Pas de scipy / sympy : notebook portable CPU-only\nRNG = np.random.default_rng(20260822)  # graine fixee pour reproductibilite\nprint(f\"Imports OK. Numpy {np.__version__}, RNG seed=20260822\")",
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Imports OK. Numpy 2.4.4, RNG seed=20260822\n"
-    }
-   ]
-  },
-  {
-   "id": "ace19172",
-   "cell_type": "markdown",
-   "source": "### Configuration de l'environnement\n\nNous travaillons en numpy pur (pas de scipy, pas de sympy) — le notebook doit s'executer sur toute machine CPU avec un stack Python standard. La bibliotheque `matplotlib` n'est utilisee que pour les figures (non requises pour les assertions).",
-   "metadata": {}
-  },
-  {
-   "id": "9b947fe8",
-   "cell_type": "markdown",
-   "source": "## 1. La famille 2x2 dans le plan\n\n### Notation\n\nPour classifier un jeu 2x2, Robinson & Goforth (2005) utilisent une representation **ordinale** (1=pire, 4=meilleur). Les 4 archetypes sont definis par leur profil d'incitation stricte :\n\n- **Prisoner's Dilemma (PD)** : T > R > P > S (defection strictement dominante, dilemme social).\n- **Stag Hunt (SH)** : R > T et R > P (cooperation et defection sont NE, coordination).\n- **Snowdrift / Hawk-Dove (SD)** : T > R > S > P (cooperation faiblement dominante, conflit).\n- **Harmony (H)** : R > T et R > S > P (cooperation strictement dominante, pas de conflit).\n\nArchetti & Scheuring (2012, p. 10) invoquent Robinson-Goforth comme **validation independante** de la parente topologique de ces quatre jeux — et c'est une donnee pour la question d'attribution ouverte dans l'EPIC distillation #12208.\n\n### Verification\n\nLe code ci-dessous enumere les **78 profils 2x2 distincts en ordinaux** (4 issues placees sur 4 cases avec repetition possible mais avec 4 valeurs distinctes au total par ligne) et verifie que **les 4 archetypes** apparaissent comme profils canoniques. Le but est transformer la citation qualitative du papier en une **mesure verifiable** sur notre machine.",
-   "metadata": {}
-  },
-  {
-   "id": "1a048d29",
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": 2,
-   "source": "# E1 — La famille 2x2 dans le plan\n# Classification stricte des 4 archetypes Robinson-Goforth parmi les 78 profils distincts.\nfrom itertools import permutations\n\ndef rgs_class(profile):\n    \"\"\"Classification Robinson-Goforth stricte : 4 archetypes par inequalities strictes.\n    profile = ((J1_00, J1_01), (J1_10, J1_11)) en ordinaux 1..4.\n    Renvoie : 'PD' | 'SH' | 'SD' | 'H' | 'Other'.\n    T = J1_10 (defecter vs cooperateur)\n    R = J1_00 (cooperer vs cooperateur)\n    P = J1_11 (defecter vs defecter)\n    S = J1_01 (cooperer vs defecter)\n    \"\"\"\n    T, R, P, S = profile[1][0], profile[0][0], profile[1][1], profile[0][1]\n    if T > R > P > S:\n        return 'PD'\n    if R > T and R > P and P > S:\n        return 'SH'  # cooperation ET defection sont NE\n    if T > R > S > P:\n        return 'SD'  # Snowdrift : cooperation faiblement dominante\n    if R > T and R > S > P:\n        return 'H'   # Harmony : cooperation strictement dominante\n    return 'Other'\n\n# Les 4 archetypes canoniques (reference : Robinson-Goforth 2005, p. 47-52)\nPD_canon = ((3, 0), (4, 1))   # R=3, P=1, S=0, T=4  -> PD (T=4>R=3>P=1>S=0)\nSH_canon = ((3, 2), (2, 1))   # R=3, T=2, P=1, S=2  -> SH (R>T=2, R>P=1, P<S=2) Wait P=1 < S=2 fail\n# Reordenancer pour verifier les 4 inequalities strictes de SH\nSH_canon = ((3, 1), (2, 2))   # R=3, T=2, P=2, S=1 -> R>T=2 OK, R>P=2 OK, P=S=2 fail\nSH_canon = ((3, 1), (2, 2))   # R=3 > T=2 OK, P=2 > S=1 OK -> SH authentique\nSD_canon = ((2, 3), (4, 1))   # R=2, T=4, S=3, P=1 -> T=4>R=2 OK, R=2<S=3 fail -> SD?\n# SD authentique : T > R > S > P. Reordenancer.\nSD_canon = ((3, 1), (4, 2))   # R=3, T=4, S=1, P=2 -> T=4>R=3 OK, R=3>S=1 OK, S=1<P=2 fail\n# Reordenancer pour S > P\nSD_canon = ((2, 3), (3, 1))   # R=2, T=3, S=3, P=1 -> T=3>R=2 OK, R=2<S=3 fail\n# SD authentique T>R>S>P : exemple canonique Hawk-Dove : T=3, R=2, S=1, P=0\nSD_canon = ((2, 1), (3, 0))   # R=2, T=3, S=1, P=0 -> T=3>R=2>R ok wait R>S=1 ok S>P=0 ok -> SD\nH_canon  = ((3, 2), (1, 0))   # R=3, T=1, S=2, P=0 -> R=3>T=1 OK, R=3>S=2 OK, S=2>P=0 OK -> H\n\n# Verification des 4 archetypes canoniques\nprint(\"Verification des 4 archetypes canoniques :\")\nfor name, prof in [('PD', PD_canon), ('SH', SH_canon), ('SD', SD_canon), ('H', H_canon)]:\n    cls = rgs_class(prof)\n    status = 'OK' if cls == name else f'BUG (classe comme {cls})'\n    print(f\"  {name} {prof} -> {cls}  [{status}]\")\n\n# Enumere tous les profils admissibles : pour chaque ligne J1, choix d'une\n# permutation stricte de 4 valeurs distinctes parmi {1,2,3,4}\n# (chaque case recoit une valeur differente -> 4! = 24 profils par ligne)\n# Pour le profil complet, J2 doit aussi etre une permutation stricte de 4 valeurs distinctes\n# -> 24 x 24 = 576 profils complets. Mais les doublons (J1=J2 modulo label) -> 78 profils distincts\n# (compte canonique Rapoport-Guyer 1966).\ncomptes = {'PD': 0, 'SH': 0, 'SD': 0, 'H': 0, 'Other': 0}\nexemples_par_classe = {k: [] for k in comptes}\n\n# Enumeration exacte : pour chaque couple de permutations strictes de (1,2,3,4)\nfor J1_row in permutations([1, 2, 3, 4]):\n    for J2_row in permutations([1, 2, 3, 4]):\n        prof = (J1_row, J2_row)\n        cls = rgs_class(prof)\n        comptes[cls] += 1\n        if len(exemples_par_classe[cls]) < 2:\n            exemples_par_classe[cls].append(prof)\n\nprint(f\"\\nEnumeration complete (576 profils 2x2) :\")\ntotal = sum(comptes.values())\nfor cls in ['PD', 'SH', 'SD', 'H', 'Other']:\n    n = comptes[cls]\n    pct = 100 * n / total\n    print(f\"  {cls:>5} : {n:>3} ({pct:>5.1f}%)\")\nprint(f\"  TOTAL : {total}\")",
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Verification des 4 archetypes canoniques :\n  PD ((3, 0), (4, 1)) -> PD  [OK]\n  SH ((3, 1), (2, 2)) -> SH  [OK]\n  SD ((2, 1), (3, 0)) -> SD  [OK]\n  H ((3, 2), (1, 0)) -> H  [OK]\n\nEnumeration complete (576 profils 2x2) :\n     PD :   4 (  0.7%)\n     SH :  28 (  4.9%)\n     SD :   4 (  0.7%)\n      H :  28 (  4.9%)\n  Other : 512 ( 88.9%)\n  TOTAL : 576\n"
-    }
-   ]
-  },
-  {
-   "id": "77d45634",
-   "cell_type": "markdown",
-   "source": "### Lecture du resultat\n\nL'enumeration produit **78 profils distincts** dont la distribution par classe Robinson-Goforth fait emerger les 4 archetypes canoniques (PD, SH, SD, H) avec leurs 4 profils canoniques specifies (T, R, P, S dans le bon ordre). Le reste des profils tombent dans **'Other'** — ces profils n'ont pas de structure d'incitation stricte et sont les **murs** au sens de #12213 (chambres-et-murs) : leur identite se voit dans la parente topologique plutot que dans la lecture des strategies dominantes.\n\nArchetti-Scheuring (2012, p. 10) affirment que **la parente des quatre jeux n'est pas evidente dans la taxonomie classique (Rapoport-Guyer 1966) mais claire dans une classification topologique** (Robinson-Goforth 2005). Notre verification ci-dessus donne chair a cette affirmation : les 4 archetypes canoniques se distinguent par leur signature topologique (les 4 inequalities strictes), pas par leur identite lexicale.\n\n**Verification croisee** : les 4 profils canoniques sont les **4 elements minimaux** de chaque classe au sens « un swap d'une case suffit a quitter la classe ». C'est la definition topologique de Robinson-Goforth.",
-   "metadata": {}
-  },
-  {
-   "id": "6b06f42d",
-   "cell_type": "markdown",
-   "source": "## 2. Le plan de deformation (E2)\n\n### La fonction de benefice generalisee\n\nLe pivot du papier (Archetti & Scheuring 2012, eq. 13) est la **fonction de benefice non-lineaire generalisee** :\n\n```\nb(i) = k^s / (k^s + i^s)   (eq. 13)\n```\n\navec `k` la position du seuil (cooperateurs au-dessus de k contribuent), `s` la raideur de la sigmoide, et `i` le nombre de cooperateurs. Cette fonction interpole continument tous les jeux N-personnes :\n\n- `s -> 0` : degenerescence, defection pure (N-personnes Prisoner's Dilemma classique).\n- `s -> +inf`, `k = 1` : Volunteer's Dilemma pur, equilibre mixte `x+ = 1 - (c/b)^(1/(N-1))` (eq. 9).\n- Pour grand N et autour de `k = 1`, l'approximation `x+ ~ (k-1)/(N-1)` (citee eq. 9 du papier, derivee dans Archetti-Scheuring 2011).\n\n### Notre implementation\n\nLe code ci-dessous implemente `b(i)`, balaye le plan `(k, s)` sur la plage `k in [1, 8]`, `s in [0.5, 8]`, pour differentes valeurs de `c/b`, et verifie que les 3 regimes emergent. **Pas de re-derivation** — `x+` est cite d'eq. 9.",
-   "metadata": {}
-  },
-  {
-   "id": "913fdebc",
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": 3,
-   "source": "### Lecture du resultat\n\nL'enumeration produit **576 profils distincts en ordinaux stricts** dont la distribution par classe Robinson-Goforth fait emerger les 4 archetypes canoniques (4 PD, 28 SH, 4 SD, 28 H) sur 576 profils (les 88.9% restants sont des profils sans structure d'incitation stricte, les \"murs\" au sens de #12213 (chambres-et-murs)). La parente topologique de Robinson-Goforth (2005) tient : les 4 archetypes canoniques se distinguent par leur signature d'inegalites strictes, pas par leur identite lexicale.\n\n### Verdict E2 sur les regimes\n\n**Resultat observe** : sur la plage k in [0.5, 5.0], c/b in {0.1, 0.3, 0.5, 0.8} avec s grand (6.0), la formule x+ = 1 - (c/b)^(1/(N-1)) produit **100% coexistence** (aucune cellule en defection pure ni en cooperation pure). Cela reflete la nature de l'eq. 9 : pour c/b strictement entre 0 et 1, x+ est strictement entre 0 et 1, donc la coexistence est l'unique regime.\n\n**Pourquoi alors Archetti-Scheuring parlent de 3 regimes ?** L'eq. 9 est l'approximation Volunteer's Dilemma (s grand, k=1). Pour les regimes bistables (s moderee), il faut utiliser l'eq. 7 du papier (modele exact) qui peut donner defection pure ou cooperation pure pour certaines valeurs de (k, s). Notre implementation balaye l'eq. 9 seulement, d'ou la degeneration observee.\n\n**Verification eq. 9 vs approximation** : pour k=2, c/b=0.5, l'approximation x+ ~ (k-1)/(N-1) a une erreur relative de ~70% a N=3, ~50% a N=10, ~45% a N=100. L'approximation ne tient pas bien -- elle suppose N grand et (k-1) petit. Conclusion : l'eq. 9 est la reference, l'approximation est pedagogiquement interessante mais quantitativement grossiere.\n\n**Limite honnete** : le balayage sur les **3 regimes** (defection pure, coexistence, cooperation pure) necessite l'eq. 7 du papier, pas l'eq. 9. C'est une dette technique du notebook que nous assumons -- la classification des regimes selon l'eq. 7 ferait l'objet d'un E2bis ulterieur.\n\nArchetti-Scheuring (2012, p. 10) affirment que **la parente des quatre jeux n'est pas evidente dans la taxonomie classique (Rapoport-Guyer 1966) mais claire dans une classification topologique** (Robinson-Goforth 2005). Notre verification E1 ci-dessus donne chair a cette affirmation : les 4 archetypes canoniques se distinguent par leur signature topologique (les 4 inequalities strictes), pas par leur identite lexicale. La verification E2 confirme que l'eq. 9 (citee du papier) tient comme equilibre asymptotique, et demontre la degeneration du modele simplifie hors de son domaine de validite (s grand).",
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "c/b = 0.1 : 0 defection, 19 coexistence, 0 coop_pure (sur 19 valeurs de k)\nc/b = 0.3 : 0 defection, 19 coexistence, 0 coop_pure (sur 19 valeurs de k)\nc/b = 0.5 : 0 defection, 19 coexistence, 0 coop_pure (sur 19 valeurs de k)\nc/b = 0.8 : 0 defection, 19 coexistence, 0 coop_pure (sur 19 valeurs de k)\n\nVerification eq. 9 : x+ = 1 - (c/b)^(1/(N-1)) vs approximation (k-1)/(N-1)\n  Cas : k=2, c/b=0.5\n  N=  3  x+=0.2929  approx=0.5000  err_rel=0.7071\n  N= 10  x+=0.0741  approx=0.1111  err_rel=0.4990\n  N=100  x+=0.0070  approx=0.0101  err_rel=0.4478\n"
-    }
-   ]
-  },
-  {
-   "id": "7254815b",
-   "cell_type": "markdown",
-   "source": "### Lecture du resultat\n\nLa carte des regimes montre la structure du plan `(k, s)` a `c/b` fixe :\n\n- **Bande cooperative pure** (k >> s, k eleve) : la cooperation est assez stable pour que l'equilibre unique soit cooperation totale.\n- **Bande defectrice pure** (k << s, k bas) : la defection domine car le seuil n'est jamais atteignable.\n- **Bande de coexistence** (k autour de 1, s moderee) : equilibre polymorphe stable, la population se partage entre cooperateurs et defecteurs — c'est le coeur du resultat d'Archetti-Scheuring.\n\nL'approximation `x+ ~ (k-1)/(N-1)` tient pour N >= 10 avec erreur relative < 20 %. Pour N = 3, l'approximation est grossiere (erreur ~ 30 %) — c'est attendu : la derivation de l'eq. 9 suppose N grand pour lineariser le terme `(1 - x+)^(N-1)`.\n\nLe **point pedagogique** : a un `c/b` fixe, le passage d'un regime a l'autre n'est pas un swap discret (comme dans le tableau 2x2 de Robinson-Goforth) mais une **deformation continue** dans `(k, s)`. C'est l'analogue N-personnes du tableau periodique — deux tranches de la meme geometrie.\n\n**Limite honnete** : le modele `x+ = 1 - (c/b)^(1/(N-1))` est une approximation Volunteer's Dilemma (s -> +inf). Pour les regimes bistables (s intermadiaire), il faudrait un modele different — voir eq. 7 du papier pour la formulation generale.",
-   "metadata": {}
-  },
-  {
-   "id": "4cba1a1c",
-   "cell_type": "markdown",
-   "source": "## 3. Le mur a memoire (E3)\n\n### Hysteresis : la transformation n'est pas inversee par sa contre-transformation\n\nPour un bien a seuil (Fig. 3A d'Archetti-Scheuring 2012), le diagramme de bifurcation de `c/b` presente un phenomene d'**hysteresis** quand la fonction de benefice est suffisamment non-lineaire :\n\n- **Trajet montante** (c/b croit depuis 0) : la population reste dans l'etat cooperation jusqu'a un seuil de bifurcation `c/b_up`, puis bascule en defection pure.\n- **Trajet descendante** (c/b decroit depuis 1) : la population reste en defection pure jusqu'a un seuil `c/b_down < c/b_up`, puis bascule en cooperation.\n\nLes deux trajectoires **divergent** dans une fenetre intermediaire : pour `c/b_down < c/b < c/b_up`, l'etat de la population depend de **son histoire**. La contre-transformation (redescendre c/b) ne restaure pas l'etat anterieur (cooperation) — elle laisse la population en defection.\n\n### Notre implementation\n\nLe code ci-dessous simule un modele simplifie a hysteresis en utilisant un **potentiel bistable** : la dynamique de la population (proportion de cooperateurs `x`) suit `dx/dt = -dV/dx` avec un potentiel `V(x) = ...` qui depend de `c/b`. Quand `c/b` est dans la fenetre bistable, le potentiel a 2 minima locaux ; selon l'histoire, la population se trouve dans l'un ou l'autre.\n\nC'est une **simplification pedagogique** : le modele exact d'Archetti-Scheuring est multi-population, mais l'essence de l'hysteresis (bistabilite + path-dependence) est preservee.",
-   "metadata": {}
-  },
-  {
-   "id": "83312740",
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": 4,
-   "source": "# E3 — Mur a memoire : hysteresis\n# Modele simplifie : dynamique de la proportion de cooperateurs avec bruit de Langevin.\n# Potentiel V(x) bistable : la trajectoire est path-dependent quand V a 2 minima.\n\ndef dynamique_coop(c_over_b, x_init, n_steps=200, sigma=0.05):\n    \"\"\"Simule l'evolution de x (proportion de cooperateurs) selon une dynamique\n    de type gradient + bruit : dx = f(x, c/b) dt + sigma dW.\n    f(x, c/b) = x * (1 - x) * (b(i, k, s) - c) simplifie en 1D.\n    \"\"\"\n    x = x_init\n    xs = [x]\n    for _ in range(n_steps):\n        # f(x) : pousse vers cooperation si benefice > cout, vers defection sinon\n        f_x = x * (1 - x) * (1.0 - 2 * c_over_b)  # zero-crossing a c/b = 0.5\n        # Bruit de Langevin\n        bruit = sigma * RNG.normal()\n        x = x + 0.05 * f_x + bruit\n        x = max(0.0, min(1.0, x))\n        xs.append(x)\n    return np.array(xs)\n\n# Parametres\nN = 10\nn_steps = 500\nsigma = 0.08  # bruit de Langevin\n\n# Balayage c/b dans [0, 1]\ncb_vals = np.linspace(0.0, 1.0, 21)\n\n# Trajet montante : x_init = 1 (cooperation), c/b croit de 0 a 1\n# Pour chaque valeur de c/b, on prend la valeur finale de la trajectoire precedente\ncoop_up = []\nx = 1.0  # depart en cooperation totale\nfor c in cb_vals:\n    traj = dynamique_coop(c, x_init=x, n_steps=n_steps, sigma=sigma)\n    x = traj[-1]\n    coop_up.append(x)\n\n# Trajet descendante : x_init = 0 (defection), c/b decroit de 1 a 0\ncoop_down = []\nx = 0.0\nfor c in reversed(cb_vals):\n    traj = dynamique_coop(c, x_init=x, n_steps=n_steps, sigma=sigma)\n    x = traj[-1]\n    coop_down.append(x)\ncoop_down = list(reversed(coop_down))\n\n# Detection de la fenetre d'hysteresis\ndiffs = np.array(coop_up) - np.array(coop_down)\nmax_diff_idx = np.argmax(np.abs(diffs))\nmax_diff = diffs[max_diff_idx]\n\nprint(f\"Diagramme de bifurcation avec bruit sigma={sigma} :\")\nprint(f\"  Ecart max trajet montante vs descendante : {max_diff:.4f} a c/b = {cb_vals[max_diff_idx]:.3f}\")\nif abs(max_diff) > 0.05:\n    print(f\"  -> HYSTERESIS DETECTEE numerement (ecart > 5%)\")\nelse:\n    print(f\"  -> Pas d'hysteresis distincte avec ce niveau de bruit\")\n\n# Affiche les valeurs pour 5 points intermediaires\nprint(f\"\\n  c/b    Up    Down  Ecart\")\nfor i in [0, 5, 10, 15, 20]:\n    print(f\"  {cb_vals[i]:.3f}  {coop_up[i]:.3f}  {coop_down[i]:.3f}  {coop_up[i] - coop_down[i]:+.3f}\")\n\n# Couplage ICT : la transformation n'est pas inversee par sa contre-transformation\nprint(f\"\\nCouplage ICT : hysteresis = dissociation-mesure (strate 7)\")\nprint(f\"  Pour un meme c/b, l'etat final depend de l'histoire.\")\nprint(f\"  Le parametre de controle n'est pas une fonction d'etat de la population.\")",
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Diagramme de bifurcation avec bruit sigma=0.08 :\n  Ecart max trajet montante vs descendante : -0.7381 a c/b = 0.600\n  -> HYSTERESIS DETECTEE numerement (ecart > 5%)\n\n  c/b    Up    Down  Ecart\n  0.000  0.885  0.929  -0.044\n  0.250  0.074  0.793  -0.719\n  0.500  0.682  1.000  -0.318\n  0.750  0.725  0.627  +0.098\n  1.000  0.809  0.403  +0.406\n\nCouplage ICT : hysteresis = dissociation-mesure (strate 7)\n  Pour un meme c/b, l'etat final depend de l'histoire.\n  Le parametre de controle n'est pas une fonction d'etat de la population.\n"
-    }
-   ]
-  },
-  {
-   "id": "83332779",
-   "cell_type": "markdown",
-   "source": "### Lecture du resultat\n\nLa simulation numerique exhibe une **fenetre d'hysteresis** dans le plan c/b : pour certaines plages de c/b, la trajectoire montante et la trajectoire descendante donnent des proportions de cooperation **tres distinctes** (jusqu'a 0.74 d'ecart, soit 74 points de pourcentage dans la fenetre centrale). Pour d'autres plages de c/b, les deux trajectoires convergent partiellement (cooperation stable en haut, defection stable en bas).\n\n**Ecart maximum observe : -0.7381 a c/b = 0.600** (la trajectoire descendante est plus haute que la trajectoire montante a ce point : x_down = 0.793, x_up = 0.074). C'est un cas typique d'hysteresis ou la memoire de l'etat initial persiste.\n\n**Couplage ICT** : la transformation du monde descriptif non inversee par sa contre-transformation = **strate 7 pure** (le parametre de controle n'est pas une fonction d'etat de la population). Cette dissociation-mesure est un candidat pour la matrice ICT.\n\n**Limite honnete** : le modele simplifie `dx = f(x) dt + sigma dW` avec `f(x) = x*(1-x)*(1 - 2*c/b)` n'est pas l'equation maitresse d'Archetti-Scheuring (qui est en temps continu multi-population). L'essence de l'hysteresis (bistabilite + path-dependence) est preservee, mais la forme exacte de la fenetre est un artefact du modele simplifie. Pour aller plus loin, voir eq. 7-9 du papier.",
-   "metadata": {}
-  },
-  {
-   "id": "87ac3c30",
-   "cell_type": "markdown",
-   "source": "## 4. Le contre-claim execute (E4)\n\n### MacLean et al. (2010) : le Snowdrift 2-personnes predit mal, le N-personnes non-lineaire predit juste\n\nL'experience de MacLean,Fuentes Suarez et al. (2010) sur la levure mesure la frequence de cooperation dans un systeme biologique ou le benefice est non-lineaire. Resultat : la frequence optimale est **intermediaire**, pas totale.\n\n- **Le Snowdrift 2-personnes** predit l'optimum a cooperation totale (T > R > S > P : cooperation faiblement dominante). **Prediction ratee**.\n- **Le jeu N-personnes lineaire** predit la defection totale (T > R : defection dominante en N-personnes lineaire). **Prediction ratee aussi**.\n- **Le jeu N-personnes non-lineaire** (Archetti-Scheuring 2012) predit l'equilibre polymorphe, c'est-a-dire une frequence intermediaire. **Prediction reussie**.\n\nL'histoire est un cas classique d'**echec de modele mal identifie** : ce n'est pas la theorie des jeux qui echoue, c'est l'identification du jeu. Les auteurs du papier original (MacLean et al.) lisent leur resultat comme un **rejet de la theorie des jeux**. Archetti-Scheuring montrent qu'il s'agit d'un **rejet du mauvais modele**, pas de la theorie.\n\n### Notre implementation\n\nLe code ci-dessous implemente les trois modeles sur les parametres de l'experience (N=6 groupes typiques, c/b ajuste) et verifie les predictions. C'est une **contre-execution** : on ne derive pas les formules, on prend les predictions citees et on les confronte aux memes parametres.\n\n**Limite honnete** : MacLean et al. utilisent des populations finies, donc le resultat N-personnes non-lineaire est une **metastabilite** (section 3.11.1 d'Archetti-Scheuring) — l'equilibre theorique est polymorphe, mais une population finie peut deriver par fluctuation. Le notebook exhibe l'equilibre asymptotique, pas la dynamique de population finie.",
-   "metadata": {}
-  },
-  {
-   "id": "70916734",
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": 5,
-   "source": "# E4 — Contre-claim execute : MacLean 2010 sur la levure\n# Trois modeles sur les memes parametres : Snowdrift 2p, NPD Np lineaire, Np non-lineaire.\n# Parametres ajustes pour discriminer les modeles (cite eq. 7 et 9 Archetti-Scheuring 2012).\n\n# Parametres Archetti-Scheuring 2012 (Table 1, scenario typique biens publics biologiques)\nN = 6  # taille de groupe MacLean 2010 (cohorte levure)\nc_over_b = 0.5  # ratio cout / benefice typique pour le benefice biologique\nfreq_coop_obs = 0.30  # frequence de cooperation observee MacLean 2010 (intermediaire, 30 %)\n\n# Modele 1 : Snowdrift 2-personnes (T > R > S > P)\n# En 2p, l'equilibre est T > R > S > P : cooperation faiblement dominante\n# -> prediction cooperation totale (1.0)\npred_sd = 1.0\n\n# Modele 2 : NPD N-personnes lineaire (T > R, defection dominante)\n# En Np lineaire, defection domine -> prediction defection totale (0.0)\npred_npd = 0.0\n\n# Modele 3 : N-personnes non-lineaire (eq. 9 citee)\n# Equilibre polymorphe : x+ = 1 - (c/b)^(1/(N-1))\ndef x_plus_archetti(N, c_over_b, k=1.0):\n    if N == 1:\n        return 1.0 if c_over_b < 1 else 0.0\n    base = c_over_b ** (1.0 / (N - 1))\n    return max(0.0, min(1.0, 1.0 - base))\n\npred_npl = x_plus_archetti(N, c_over_b, k=1.0)\n\nprint(f\"Experience MacLean 2010 : N={N}, c/b={c_over_b}, freq_coop observee = {freq_coop_obs:.2f}\")\nprint(f\"\\nPredictions des trois modeles :\")\nprint(f\"  Snowdrift 2p           : {pred_sd:.4f}  -> erreur = {abs(pred_sd - freq_coop_obs):.4f}  [{'CONFIRMEE' if abs(pred_sd - freq_coop_obs) < 0.1 else 'RATEE'}]\")\nprint(f\"  NPD Np lineaire        : {pred_npd:.4f}  -> erreur = {abs(pred_npd - freq_coop_obs):.4f}  [{'CONFIRMEE' if abs(pred_npd - freq_coop_obs) < 0.1 else 'RATEE'}]\")\nprint(f\"  Np non-lineaire (eq.9) : {pred_npl:.4f}  -> erreur = {abs(pred_npl - freq_coop_obs):.4f}  [{'CONFIRMEE' if abs(pred_npl - freq_coop_obs) < 0.1 else 'RATEE'}]\")\n\n# Verdict\nsd_ok = abs(pred_sd - freq_coop_obs) < 0.1\nnpd_ok = abs(pred_npd - freq_coop_obs) < 0.1\nnpl_ok = abs(pred_npl - freq_coop_obs) < 0.1\n\nprint(f\"\\nVerdict :\")\nif npl_ok and not sd_ok and not npd_ok:\n    print(f\"  Le modele N-personnes non-lineaire predit la freq observee (err = {abs(pred_npl - freq_coop_obs):.4f})\")\n    print(f\"  Le Snowdrift 2p Echoue a predire (err = {abs(pred_sd - freq_coop_obs):.4f})\")\n    print(f\"  Le NPD lineaire Echoue a predire (err = {abs(pred_npd - freq_coop_obs):.4f})\")\n    print(f\"  -> Le 'rejet de la theorie des jeux' par MacLean 2010 etait un 'rejet du mauvais modele'\")\n    print(f\"  -> La theorie des jeux N-personnes non-lineaire (Archetti-Scheuring 2012) reconcilie les observations\")\nelif npl_ok and sd_ok and npd_ok:\n    print(f\"  Les trois modeles predisent correctement sur ces parametres -- l'experience ne dissocie pas\")\nelif npl_ok and sd_ok:\n    print(f\"  Snowdrift et Np non-lineaire predisent -- l'experience ne dissocie pas Snowdrift vs Np non-lineaire\")\nelif npl_ok and npd_ok:\n    print(f\"  NPD lineaire et Np non-lineaire predisent -- l'experience ne dissocie pas lineaire vs non-lineaire\")\nelse:\n    print(f\"  Les parametres ne reproduisent pas la dissociation documentee par Archetti-Scheuring\")\n    print(f\"  -> Verifier N, c/b, freq observee sur la source primaire MacLean et al. 2010\")\n\n# Limite honnete : populations finies -> metastabilite\nprint(f\"\\nLimite (citee Archetti-Scheuring 2012 sec. 3.11.1) :\")\nprint(f\"  En population finie, l'equilibre polymorphe est metastable -- la population peut\")\nprint(f\"  deriver par fluctuation vers defection pure sur des temps longs. La prediction\")\nprint(f\"  eq. 9 est un equilibre asymptotique, pas une trajectoire de population finie.\")",
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Experience MacLean 2010 : N=6, c/b=0.5, freq_coop observee = 0.30\n\nPredictions des trois modeles :\n  Snowdrift 2p           : 1.0000  -> erreur = 0.7000  [RATEE]\n  NPD Np lineaire        : 0.0000  -> erreur = 0.3000  [RATEE]\n  Np non-lineaire (eq.9) : 0.1294  -> erreur = 0.1706  [RATEE]\n\nVerdict :\n  Les parametres ne reproduisent pas la dissociation documentee par Archetti-Scheuring\n  -> Verifier N, c/b, freq observee sur la source primaire MacLean et al. 2010\n\nLimite (citee Archetti-Scheuring 2012 sec. 3.11.1) :\n  En population finie, l'equilibre polymorphe est metastable -- la population peut\n  deriver par fluctuation vers defection pure sur des temps longs. La prediction\n  eq. 9 est un equilibre asymptotique, pas une trajectoire de population finie.\n"
-    }
-   ]
-  },
-  {
-   "id": "02fb23f9",
-   "cell_type": "markdown",
-   "source": "## Conclusion\n\n### Trois lectures\n\n1. **Serie 3 etendue** : le tableau periodique 2x2 (Robinson-Goforth, valide par biologie evolutive per Archetti-Scheuring 2012) a un analogue N-personnes ou l'on ne se deplace pas par swaps discrets mais par deformation continue de `(k, s, c/b)`. Les chambres/murs/swaps du tableau 2x2 deviennent des regimes/hysteresis/deformations dans le plan N-personnes.\n2. **Hysteresis comme dissociation-mesure** : la transformation du monde descriptif non inversee par sa contre-transformation est un **mur a memoire**, candidat direct pour la matrice ICT en tant que dissociation-mesure (un meme `c/b` peut donner deux populations distinctes).\n3. **Contre-claim execute** : MacLean 2010 sur la levure montre que le Snowdrift 2-personnes echoue, le NPD lineaire echoue, le N-personnes non-lineaire predit juste. La theorie des jeux n'est pas en defaut — c'est l'identification du jeu qui etait en defaut.\n\n### Dette de derivation asumee\n\n- Formules citees eq. 7, 9, 13 d'Archetti-Scheuring 2012, pas re-derivees.\n- Preuve formelle renvoyee a Archetti-Scheuring 2011 *Evolution* 65 : 1140-1148.\n- Analogie R-G <-> plan de deformation = notre construction.\n- Resultats E4 (Snowdrift/NPD echouent, Np non-lineaire predit) pris comme **faits experimentaux rapportes** dans la litterature, pas re-verifies sur les donnees brutes de MacLean et al. 2010.\n\n### Suites possibles (hors scope ce notebook)\n\n- **Extension au joueur LLM #12254** : l'empreinte mixte `x+` au niveau population devrait etre observable chez un LLM joue en population simulee, et la prediction « plus rationnel qu'humain » devient mesurable.\n- **Portage Lean** : la formalisation des regimes en `lake` — c.f. `cooperative_games_lean` deja en place pour le Shapley. Un submodule `nperson_public_goods_lean` portant la sigmoide et l'hysteresis serait la suite naturelle.\n- **Infusion ICT** : le mur a memoire (hysteresis) est candidat strate 7 — voir la matrice de dissociations `docs/ict/dissociations-matrix.md` et le tracker #12257.\n\nRefs #12204 (EPIC distillation) · #12207 (EPIC lexique GT) · #12208 (table distillation) · #12213 (3b chambres/murs) · #12254 (3c joueur LLM) · #12256 (ce grain).",
-   "metadata": {}
-  }
- ]
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
@@ -5,10 +5,10 @@
    "id": "2433ddbd",
    "metadata": {
     "papermill": {
-     "duration": 0.002616,
-     "end_time": "2026-08-29T03:00:28.715478",
+     "duration": 0.003336,
+     "end_time": "2026-08-29T03:28:45.296095",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.712862",
+     "start_time": "2026-08-29T03:28:45.292759",
      "status": "completed"
     },
     "tags": []
@@ -46,16 +46,16 @@
    "id": "90f35ae5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:00:28.721394Z",
-     "iopub.status.busy": "2026-08-29T03:00:28.721394Z",
-     "iopub.status.idle": "2026-08-29T03:00:28.807925Z",
-     "shell.execute_reply": "2026-08-29T03:00:28.806895Z"
+     "iopub.execute_input": "2026-08-29T03:28:45.303076Z",
+     "iopub.status.busy": "2026-08-29T03:28:45.303076Z",
+     "iopub.status.idle": "2026-08-29T03:28:45.392896Z",
+     "shell.execute_reply": "2026-08-29T03:28:45.392347Z"
     },
     "papermill": {
-     "duration": 0.090926,
-     "end_time": "2026-08-29T03:00:28.808446",
+     "duration": 0.095025,
+     "end_time": "2026-08-29T03:28:45.394098",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.717520",
+     "start_time": "2026-08-29T03:28:45.299073",
      "status": "completed"
     },
     "tags": []
@@ -83,10 +83,10 @@
    "id": "ace19172",
    "metadata": {
     "papermill": {
-     "duration": 0.001619,
-     "end_time": "2026-08-29T03:00:28.812651",
+     "duration": 0.002992,
+     "end_time": "2026-08-29T03:28:45.400113",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.811032",
+     "start_time": "2026-08-29T03:28:45.397121",
      "status": "completed"
     },
     "tags": []
@@ -102,10 +102,10 @@
    "id": "9b947fe8",
    "metadata": {
     "papermill": {
-     "duration": 0.003071,
-     "end_time": "2026-08-29T03:00:28.817345",
+     "duration": 0.003379,
+     "end_time": "2026-08-29T03:28:45.406617",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.814274",
+     "start_time": "2026-08-29T03:28:45.403238",
      "status": "completed"
     },
     "tags": []
@@ -135,16 +135,16 @@
    "id": "1a048d29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:00:28.822922Z",
-     "iopub.status.busy": "2026-08-29T03:00:28.821413Z",
-     "iopub.status.idle": "2026-08-29T03:00:28.832197Z",
-     "shell.execute_reply": "2026-08-29T03:00:28.832197Z"
+     "iopub.execute_input": "2026-08-29T03:28:45.413141Z",
+     "iopub.status.busy": "2026-08-29T03:28:45.412021Z",
+     "iopub.status.idle": "2026-08-29T03:28:45.423320Z",
+     "shell.execute_reply": "2026-08-29T03:28:45.423320Z"
     },
     "papermill": {
-     "duration": 0.013999,
-     "end_time": "2026-08-29T03:00:28.833413",
+     "duration": 0.015438,
+     "end_time": "2026-08-29T03:28:45.424461",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.819414",
+     "start_time": "2026-08-29T03:28:45.409023",
      "status": "completed"
     },
     "tags": []
@@ -249,10 +249,10 @@
    "id": "77d45634",
    "metadata": {
     "papermill": {
-     "duration": 0.003257,
-     "end_time": "2026-08-29T03:00:28.838415",
+     "duration": 0.00298,
+     "end_time": "2026-08-29T03:28:45.430447",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.835158",
+     "start_time": "2026-08-29T03:28:45.427467",
      "status": "completed"
     },
     "tags": []
@@ -272,10 +272,10 @@
    "id": "6b06f42d",
    "metadata": {
     "papermill": {
-     "duration": 0.002001,
-     "end_time": "2026-08-29T03:00:28.842428",
+     "duration": 0.002995,
+     "end_time": "2026-08-29T03:28:45.436455",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.840427",
+     "start_time": "2026-08-29T03:28:45.433460",
      "status": "completed"
     },
     "tags": []
@@ -303,14 +303,93 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ae2a353e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T03:28:45.444428Z",
+     "iopub.status.busy": "2026-08-29T03:28:45.443427Z",
+     "iopub.status.idle": "2026-08-29T03:28:45.450219Z",
+     "shell.execute_reply": "2026-08-29T03:28:45.450219Z"
+    },
+    "papermill": {
+     "duration": 0.011912,
+     "end_time": "2026-08-29T03:28:45.451379",
+     "exception": false,
+     "start_time": "2026-08-29T03:28:45.439467",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c/b = 0.1 : 0 defection, 19 coexistence, 0 coop_pure (sur 19 valeurs de k)\n",
+      "c/b = 0.3 : 0 defection, 19 coexistence, 0 coop_pure (sur 19 valeurs de k)\n",
+      "c/b = 0.5 : 0 defection, 19 coexistence, 0 coop_pure (sur 19 valeurs de k)\n",
+      "c/b = 0.8 : 0 defection, 19 coexistence, 0 coop_pure (sur 19 valeurs de k)\n",
+      "\n",
+      "Verification eq. 9 : x+ = 1 - (c/b)^(1/(N-1)) vs approximation (k-1)/(N-1)\n",
+      "  Cas : k=2, c/b=0.5\n",
+      "  N=  3  x+=0.2929  approx=0.5000  err_rel=0.7071\n",
+      "  N= 10  x+=0.0741  approx=0.1111  err_rel=0.4990\n",
+      "  N=100  x+=0.0070  approx=0.0101  err_rel=0.4478\n"
+     ]
+    }
+   ],
+   "source": [
+    "# E2 — Balayage du plan de deformation selon l'eq. 9 (Volunteer's Dilemma)\n",
+    "# eq. 9 : x+ = 1 - (c/b)^(1/(N-1)) — approximation s grand, k = 1.\n",
+    "# Remarque cle : x+ ne depend NI de k NI de s. Le balayage eq. 9 produit donc\n",
+    "# mecaniquement 100% coexistence sur 0 < c/b < 1 — la degeneration documentee\n",
+    "# ci-dessous (les 3 regimes d'Archetti-Scheuring demandent l'eq. 7, modele exact).\n",
+    "\n",
+    "N = 10\n",
+    "s = 6.0                                   # s grand : domaine de validite de l'eq. 9\n",
+    "k_vals = np.linspace(0.5, 5.0, 19)        # 19 valeurs de k\n",
+    "cb_vals = [0.1, 0.3, 0.5, 0.8]\n",
+    "\n",
+    "def x_plus_eq9(cb, N):\n",
+    "    \"\"\"Equilibre asymptotique x+ de l'eq. 9 (Archetti-Scheuring 2012).\"\"\"\n",
+    "    return 1.0 - cb ** (1.0 / (N - 1))\n",
+    "\n",
+    "def regime_asymptotique(x_plus):\n",
+    "    \"\"\"Classe le regime : defection pure, coexistence, cooperation pure.\"\"\"\n",
+    "    if x_plus <= 0.0:\n",
+    "        return 'defection'\n",
+    "    if x_plus >= 1.0:\n",
+    "        return 'coop_pure'\n",
+    "    return 'coexistence'\n",
+    "\n",
+    "for cb in cb_vals:\n",
+    "    regimes = [regime_asymptotique(x_plus_eq9(cb, N)) for _ in k_vals]\n",
+    "    print(f\"c/b = {cb} : {regimes.count('defection')} defection, \"\n",
+    "          f\"{regimes.count('coexistence')} coexistence, \"\n",
+    "          f\"{regimes.count('coop_pure')} coop_pure (sur {len(k_vals)} valeurs de k)\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Verification eq. 9 : x+ = 1 - (c/b)^(1/(N-1)) vs approximation (k-1)/(N-1)\")\n",
+    "k0, cb0 = 2, 0.5\n",
+    "print(f\"  Cas : k={k0}, c/b={cb0}\")\n",
+    "for N_test in (3, 10, 100):\n",
+    "    x9 = x_plus_eq9(cb0, N_test)\n",
+    "    approx = (k0 - 1) / (N_test - 1)\n",
+    "    err_rel = abs(x9 - approx) / x9\n",
+    "    print(f\"  N={N_test:3d}  x+={x9:.4f}  approx={approx:.4f}  err_rel={err_rel:.4f}\")\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "913fdebc",
    "metadata": {
     "papermill": {
-     "duration": 0.002015,
-     "end_time": "2026-08-29T03:00:28.846964",
+     "duration": 0.002651,
+     "end_time": "2026-08-29T03:28:45.457016",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.844949",
+     "start_time": "2026-08-29T03:28:45.454365",
      "status": "completed"
     },
     "tags": []
@@ -338,10 +417,10 @@
    "id": "7254815b",
    "metadata": {
     "papermill": {
-     "duration": 0.00204,
-     "end_time": "2026-08-29T03:00:28.852001",
+     "duration": 0.002906,
+     "end_time": "2026-08-29T03:28:45.461793",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.849961",
+     "start_time": "2026-08-29T03:28:45.458887",
      "status": "completed"
     },
     "tags": []
@@ -367,10 +446,10 @@
    "id": "4cba1a1c",
    "metadata": {
     "papermill": {
-     "duration": 0.002981,
-     "end_time": "2026-08-29T03:00:28.856986",
+     "duration": 0.002996,
+     "end_time": "2026-08-29T03:28:45.466789",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.854005",
+     "start_time": "2026-08-29T03:28:45.463793",
      "status": "completed"
     },
     "tags": []
@@ -396,20 +475,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "83312740",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:00:28.862986Z",
-     "iopub.status.busy": "2026-08-29T03:00:28.862986Z",
-     "iopub.status.idle": "2026-08-29T03:00:28.901661Z",
-     "shell.execute_reply": "2026-08-29T03:00:28.901661Z"
+     "iopub.execute_input": "2026-08-29T03:28:45.472550Z",
+     "iopub.status.busy": "2026-08-29T03:28:45.472550Z",
+     "iopub.status.idle": "2026-08-29T03:28:45.509559Z",
+     "shell.execute_reply": "2026-08-29T03:28:45.508928Z"
     },
     "papermill": {
-     "duration": 0.044227,
-     "end_time": "2026-08-29T03:00:28.903213",
+     "duration": 0.041293,
+     "end_time": "2026-08-29T03:28:45.510712",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.858986",
+     "start_time": "2026-08-29T03:28:45.469419",
      "status": "completed"
     },
     "tags": []
@@ -512,10 +591,10 @@
    "id": "83332779",
    "metadata": {
     "papermill": {
-     "duration": 0.002746,
-     "end_time": "2026-08-29T03:00:28.908196",
+     "duration": 0.002034,
+     "end_time": "2026-08-29T03:28:45.517600",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.905450",
+     "start_time": "2026-08-29T03:28:45.515566",
      "status": "completed"
     },
     "tags": []
@@ -537,10 +616,10 @@
    "id": "87ac3c30",
    "metadata": {
     "papermill": {
-     "duration": 0.002007,
-     "end_time": "2026-08-29T03:00:28.913349",
+     "duration": 0.002702,
+     "end_time": "2026-08-29T03:28:45.523892",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.911342",
+     "start_time": "2026-08-29T03:28:45.521190",
      "status": "completed"
     },
     "tags": []
@@ -567,20 +646,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "70916734",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:00:28.920348Z",
-     "iopub.status.busy": "2026-08-29T03:00:28.919352Z",
-     "iopub.status.idle": "2026-08-29T03:00:28.928189Z",
-     "shell.execute_reply": "2026-08-29T03:00:28.927183Z"
+     "iopub.execute_input": "2026-08-29T03:28:45.532250Z",
+     "iopub.status.busy": "2026-08-29T03:28:45.532250Z",
+     "iopub.status.idle": "2026-08-29T03:28:45.541263Z",
+     "shell.execute_reply": "2026-08-29T03:28:45.540036Z"
     },
     "papermill": {
-     "duration": 0.011838,
-     "end_time": "2026-08-29T03:00:28.928189",
+     "duration": 0.014195,
+     "end_time": "2026-08-29T03:28:45.542427",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.916351",
+     "start_time": "2026-08-29T03:28:45.528232",
      "status": "completed"
     },
     "tags": []
@@ -677,10 +756,10 @@
    "id": "02fb23f9",
    "metadata": {
     "papermill": {
-     "duration": 0.002717,
-     "end_time": "2026-08-29T03:00:28.933910",
+     "duration": 0.003349,
+     "end_time": "2026-08-29T03:28:45.550797",
      "exception": false,
-     "start_time": "2026-08-29T03:00:28.931193",
+     "start_time": "2026-08-29T03:28:45.547448",
      "status": "completed"
     },
     "tags": []
@@ -731,14 +810,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.730099,
-   "end_time": "2026-08-29T03:00:29.071316",
+   "duration": 1.808627,
+   "end_time": "2026-08-29T03:28:45.697315",
    "environment_variables": {},
    "exception": null,
-   "input_path": "GameTheory-03d-Plan-de-deformation.ipynb",
-   "output_path": "GameTheory-03d-Plan-de-deformation.ipynb",
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb",
    "parameters": {},
-   "start_time": "2026-08-29T03:00:27.341217",
+   "start_time": "2026-08-29T03:28:43.888688",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #13442

## Summary

`GameTheory-03d-Plan-de-deformation.ipynb` cell[7] : typée **code** avec une source **markdown** (`### Lecture du résultat…`) et un **output orphelin**. `compile()` échouait sur la source : la cellule ne pouvait pas avoir produit la sortie qu'elle portait (classe C.2/H.4). C'est l'instance (b) de l'acceptance #13326, dernier vrai défaut dépôt-wide du scanner.

**Commit 1 (e1fd17066)** : retype `markdown`, output orphelin supprimé, re-exec 4/4.

**Commit 2 (03a4f4671) — la réparation complète** : le garde `check_interp_positioning` a alors FAILé x2 (`misplaced_before_section` cells 7-8), et c'est lui qui avait raison : l'output orphelin n'était **PAS un duplicata** (correction de mon claim initial — le sweep eq. 9 est unique au notebook) mais la **seule trace d'un code E2 jamais commis** : le notebook est né avec ce défaut (#12284), la section 2 n'avait **aucune cellule code**. Réparation honnête : cellule code E2 **reconstruite** et insérée après le header de section. L'output orphelin détermine le code exactement (sweep 19 k × 4 c/b + vérification eq. 9) — l'exécution réelle **reproduit l'ancien output byte-for-byte** (y compris err_rel 0.7071/0.4990/0.4478).

## Perimetre

1 fichier : `MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb`

## Preuves

- Re-exec papermill complète après restauration : **5/5 cellules code séquentielles [1..5], 0 erreur, exception null**.
- Output E2 re-produit byte-for-byte par le code reconstruit (vérifié standalone + dans le notebook).
- Gardes locaux : `check_interp_positioning.py --check --baseline` **OK 0 finding** (avant : 2), `check_cell_source_parses.py` **0 finding**.
- Trajectoire scanner dépôt-wide : 7 findings → 3 (repair scanner via #13433) → 1 (FP PEP 701 diagnostiqués) → **0** (sous runtime 3.13 ; FP runtime-documentés côté hook restent un wiring gap signalé à ai-01).

## Dettes preexistantes signalees (hors scope, a traiter separement)

- cell[5] (interp E1) annonce « 78 profils distincts » alors que l'output de cell[4] en dénombre **576** (le premier paragraphe de l'interp E2, déplacé en section 2, porte la version correcte 576).
- cell[9] (ex-8) décrit une carte des régimes à bandes coopératives/défectrices que le notebook ne produit pas — la prose documente elle-même la dégénerérescence eq. 9 et diffère l'eq. 7 (« E2bis »).

See #13326 (instance b brûlée ; l'issue garde son scope garde/CI).

Co-Authored-By: Claude-Code <noreply@anthropic.com>