### PR TITLE
feat(genai,#13421): notebook 06 Kernel Memory in-process (.NET 9, LLamaSharp granite GGUF CPU)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/06-KernelMemory-InProcess.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/06-KernelMemory-InProcess.ipynb
@@ -1,0 +1,836 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "md-001",
+   "metadata": {},
+   "source": [
+    "# 06 — Kernel Memory in-process : la couche d'abstraction Microsoft\n",
+    "\n",
+    "Jusqu'ici cette série a manipulé l'infrastructure **à la main** : des embeddings calculés\n",
+    "exprès ([03](03-Embeddings-From-Scratch.ipynb)), des upserts et des recherches Qdrant\n",
+    "écrits directement ([01](01-Hands-On-Grounding.ipynb), [05](05-Stockage-Vectoriel.ipynb)),\n",
+    "du retrieval mesuré sur un gold français ([02](02-Retrieval-Avance.ipynb)). C'est le\n",
+    "meilleur moyen de comprendre *ce que fait* un backend de mémoire sémantique — mais ce\n",
+    "n'est pas ce qu'on écrit en production : on délègue le pipeline à une couche d'abstraction.\n",
+    "\n",
+    "**Kernel Memory** (Microsoft, [github.com/microsoft/kernel-memory](https://github.com/microsoft/kernel-memory))\n",
+    "est cette couche : ingestion de documents (texte, Markdown, PDF, Word...), découpage en\n",
+    "partitions, embeddings, indexation vectorielle, et recherche qui renvoie des **citations**\n",
+    "— fichier source, partition, passage, score de pertinence. C'est la pièce qui manquait\n",
+    "entre notre Qdrant brut et les agents Semantic Kernel qui consomment la mémoire.\n",
+    "\n",
+    "Dans ce notebook nous utilisons le mode **in-process** (`MemoryServerless`) : le pipeline\n",
+    "tourne dans le processus du notebook, sans service web ni conteneur, avec :\n",
+    "\n",
+    "| Brique | Choix | Pourquoi |\n",
+    "|---|---|---|\n",
+    "| Embeddings | `granite-embedding-107m-multilingual` (IBM) en GGUF Q8_0 via LLamaSharp CPU | modèle **local** multilingue conçu pour le RAG, cohérent avec la convention modèles-locaux de la série (cf. 02 : `sentence_transformers`) |\n",
+    "| Stockage fichiers | `SimpleFileStorage` (dossier temporaire) | zéro dépendance, démontrable |\n",
+    "| Index vectoriel | `SimpleVectorDb` (recherche exacte brute) | zéro conteneur — le compromis ANN est traité dans [05](05-Stockage-Vectoriel.ipynb) |\n",
+    "\n",
+    "**Plan** : (1) pipeline et modèle local, (2) ingestion d'un corpus français avec tags,\n",
+    "(3) sous le capot — le partitionnement `TextChunker`, (4) recherche avec citations,\n",
+    "(5) mesure — la granularité des partitions contre le rappel, (6) limites et exercices."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-002",
+   "metadata": {},
+   "source": [
+    "## 1. Le pipeline Kernel Memory\n",
+    "\n",
+    "Une ingestion KM enchaîne des **étapes** (`extract` → `partition` → `embed` → `index`)\n",
+    "sur chaque document : extraction du texte, découpage en partitions, vectorisation,\n",
+    "écriture dans le store vectoriel. Une recherche vectorise la question et renvoie les\n",
+    "partitions les plus proches, **avec leur provenance** — c'est la capacité distinctive\n",
+    "de KM par rapport à un upsert Qdrant écrit à la main : la traçabilité\n",
+    "document → partition → passage est portée par le pipeline, pas reconstruite après coup.\n",
+    "\n",
+    "Côté packages : `Microsoft.KernelMemory.Core` (le pipeline), l'intégration\n",
+    "`LLamaSharp.kernel-memory` (l'inférence locale llama.cpp pour les embeddings) et le\n",
+    "backend CPU de LLamaSharp. Notons un fait d'écosystème utile : en 0.98, le connecteur\n",
+    "ONNX de KM ne couvre que la **génération** de texte — pour des embeddings 100 % locaux,\n",
+    "le chemin officiel de l'écosystème est LLamaSharp."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-003",
+   "metadata": {},
+   "execution_count": 1,
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/html": [
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>LLamaSharp.Backend.Cpu</span></li><li><span>LLamaSharp.kernel-memory</span></li><li><span>Microsoft.KernelMemory.Core</span></li></ul></div><div></div></div>"
+      ]
+     }
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Microsoft.KernelMemory.Core 0.98.250508.3 + LLamaSharp 0.27.0 (CPU) charges (NuGet)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.KernelMemory.Core, 0.98.250508.3\"\n",
+    "#r \"nuget: LLamaSharp.kernel-memory, 0.27.0\"\n",
+    "#r \"nuget: LLamaSharp.Backend.Cpu, 0.27.0\"\n",
+    "\n",
+    "using System;\n",
+    "using System.IO;\n",
+    "using System.Linq;\n",
+    "using System.Net.Http;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Threading.Tasks;\n",
+    "using System.Text.RegularExpressions;\n",
+    "using Microsoft.KernelMemory;\n",
+    "using Microsoft.KernelMemory.Configuration;\n",
+    "\n",
+    "Console.WriteLine(\"Microsoft.KernelMemory.Core 0.98.250508.3 + LLamaSharp 0.27.0 (CPU) charges (NuGet)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-004",
+   "metadata": {},
+   "source": [
+    "## 2. Le modèle d'embeddings local (GGUF via llama.cpp)\n",
+    "\n",
+    "Nous téléchargeons **`granite-embedding-107m-multilingual`** (IBM, 2025) — un embedder\n",
+    "compact multilingue **conçu pour le RAG** — au format GGUF quantisé Q8_0 (121 Mo), depuis\n",
+    "la conversion de référence de `bartowski`. L'inférence passe par llama.cpp en CPU via\n",
+    "LLamaSharp : aucune clé d'API, aucun service externe, cohérent avec la convention\n",
+    "modèles-locaux de la série. Le téléchargement est **mis en cache** dans un dossier\n",
+    "temporaire : une ré-exécution le saute.\n",
+    "\n",
+    "Remarque honnête : les embedders « à instructions » recommandent souvent de préfixer\n",
+    "requêtes et passages différemment. Nous utilisons le modèle en mode **symétrique**\n",
+    "(texte brut des deux côtés) — fonctionnel — et l'**exercice 3** demande d'implémenter\n",
+    "les préfixes recommandés et de mesurer ce qu'ils apportent réellement sur notre gold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-005",
+   "metadata": {},
+   "execution_count": 2,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "cache OK   : granite-embedding-107m-multilingual-Q8_0.gguf (115 Mo)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "modele pret dans le cache : km_rag06_gguf/\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Telechargement en cache (dossier temporaire, non commite) -- chemins affiches en basename.\n",
+    "string modelDir = Path.Combine(Path.GetTempPath(), \"km_rag06_gguf\");\n",
+    "Directory.CreateDirectory(modelDir);\n",
+    "string ggufPath = Path.Combine(modelDir, \"granite-embedding-107m-multilingual-Q8_0.gguf\");\n",
+    "\n",
+    "async Task DownloadIfAbsentAsync(string url, string dest)\n",
+    "{\n",
+    "    if (File.Exists(dest) && new FileInfo(dest).Length > 0)\n",
+    "    {\n",
+    "        Console.WriteLine($\"cache OK   : {Path.GetFileName(dest)} ({new FileInfo(dest).Length / (1024 * 1024)} Mo)\");\n",
+    "        return;\n",
+    "    }\n",
+    "    using var http = new HttpClient();\n",
+    "    using var resp = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);\n",
+    "    resp.EnsureSuccessStatusCode();\n",
+    "    await using var src = await resp.Content.ReadAsStreamAsync();\n",
+    "    await using var dst = File.Create(dest + \".part\");\n",
+    "    var buffer = new byte[1 << 20];\n",
+    "    long read = 0; int n;\n",
+    "    while ((n = await src.ReadAsync(buffer)) > 0)\n",
+    "    {\n",
+    "        await dst.WriteAsync(buffer.AsMemory(0, n));\n",
+    "        read += n;\n",
+    "    }\n",
+    "    await dst.DisposeAsync();\n",
+    "    File.Move(dest + \".part\", dest, overwrite: true);\n",
+    "    Console.WriteLine($\"telecharge : {Path.GetFileName(dest)} ({read / (1024 * 1024)} Mo)\");\n",
+    "}\n",
+    "\n",
+    "const string GGUF_URL = \"https://huggingface.co/bartowski/granite-embedding-107m-multilingual-GGUF/resolve/main/granite-embedding-107m-multilingual-Q8_0.gguf\";\n",
+    "await DownloadIfAbsentAsync(GGUF_URL, ggufPath);\n",
+    "Console.WriteLine($\"modele pret dans le cache : {new DirectoryInfo(modelDir).Name}/\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-006",
+   "metadata": {},
+   "execution_count": 3,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "backend natif LLamaSharp : native/avx2\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// En mode notebook, le chargeur standard de LLamaSharp ne sonde pas le dossier natif du\n",
+    "// package backend : on pointe explicitement le DLL via NativeLibraryConfig (doit etre\n",
+    "// configure AVANT le premier appel a l'API native), avec repli noavx si AVX2 est absent.\n",
+    "string backendPkg = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), \".nuget\", \"packages\", \"llamasharp.backend.cpu\", \"0.27.0\");\n",
+    "string nativeDir = Path.Combine(backendPkg, \"LLamaSharpRuntimes\", \"win-x64\", \"native\", \"avx2\");\n",
+    "if (!File.Exists(Path.Combine(nativeDir, \"llama.dll\")))\n",
+    "    nativeDir = Path.Combine(backendPkg, \"LLamaSharpRuntimes\", \"win-x64\", \"native\", \"noavx\");\n",
+    "LLama.Native.NativeLibraryConfig.All.WithLibrary(Path.Combine(nativeDir, \"llama.dll\"), Path.Combine(nativeDir, \"mtmd.dll\"));\n",
+    "Console.WriteLine($\"backend natif LLamaSharp : {new DirectoryInfo(nativeDir).Parent!.Name}/{new DirectoryInfo(nativeDir).Name}\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-007",
+   "metadata": {},
+   "execution_count": 4,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Pipeline MemoryServerless pret : SimpleFileStorage + SimpleVectorDb + LLamaSharp (granite-embedding-107m, CPU)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.KernelMemory.Core' correspond à l'identité 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.Extensions.DependencyInjection.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.KernelMemory.Abstractions' correspond à l'identité 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.Extensions.DependencyInjection.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Construction du pipeline in-process : LLamaSharp fournit le generateur d'embeddings.\n",
+    "using LLamaSharp.KernelMemory;\n",
+    "using Microsoft.KernelMemory.AI;\n",
+    "using Microsoft.Extensions.DependencyInjection;\n",
+    "using System.Runtime.CompilerServices;\n",
+    "using System.Threading;\n",
+    "\n",
+    "// KM 0.98 : l'orchestrateur in-process exige un ITextGenerator resolu par injection de\n",
+    "// dependances, meme quand aucune generation de texte n'est demandee (pipeline 100 %\n",
+    "// embeddings). Ce generateur minimal n'est jamais invoque dans ce notebook.\n",
+    "#pragma warning disable KMEXP00 // ITextTokenizer est marque experimental dans KM 0.98\n",
+    "class GenerateurTexteInactif : ITextGenerator\n",
+    "{\n",
+    "    public int MaxTokenTotal => 512;\n",
+    "\n",
+    "    public int CountTokens(string text) => text.Length / 4; // heuristique ~4 caracteres/jeton\n",
+    "\n",
+    "    public IReadOnlyList<string> GetTokens(string text) => new[] { text };\n",
+    "\n",
+    "    public async IAsyncEnumerable<GeneratedTextContent> GenerateTextAsync(\n",
+    "        string prompt, TextGenerationOptions options,\n",
+    "        [EnumeratorCancellation] CancellationToken ct)\n",
+    "    {\n",
+    "        await Task.CompletedTask;\n",
+    "        yield return new GeneratedTextContent(\"(generation de texte non configuree)\", new TokenUsage());\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "var llamaConfig = new LLamaSharpConfig(ggufPath) // modelPath en constructeur positionnel\n",
+    "{\n",
+    "    ContextSize = 2048, // CPU pur -- aucun GPU requis\n",
+    "    MainGpu = -1 // backend CPU : llama.cpp attend -1 (aucun device)\n",
+    "};\n",
+    "\n",
+    "KernelMemoryBuilder NewBuilder()\n",
+    "{\n",
+    "    var b = new KernelMemoryBuilder();\n",
+    "    b.Services.AddSingleton<ITextGenerator>(new GenerateurTexteInactif());\n",
+    "    return b;\n",
+    "}\n",
+    "\n",
+    "var memory = NewBuilder()\n",
+    "    .WithSimpleFileStorage(Path.Combine(Path.GetTempPath(), \"km_rag06_store\"))\n",
+    "    .WithSimpleVectorDb(Path.Combine(Path.GetTempPath(), \"km_rag06_vecdb\"))\n",
+    "    .WithLLamaSharpTextEmbeddingGeneration(llamaConfig)\n",
+    "    .Build<MemoryServerless>();\n",
+    "\n",
+    "Console.WriteLine(\"Pipeline MemoryServerless pret : SimpleFileStorage + SimpleVectorDb + LLamaSharp (granite-embedding-107m, CPU)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-008",
+   "metadata": {},
+   "source": [
+    "## 3. Corpus de test et ingestion\n",
+    "\n",
+    "Huit documents français inspirés des thèmes réels de cette série (incidents, HNSW,\n",
+    "tokenisation, retrieval) — assez longs pour que le partitionnement soit discriminant.\n",
+    "Chaque fichier est écrit sur disque puis **ingéré via la pipeline ETL de KM** (c'est son\n",
+    "rôle : lire des *fichiers*, pas seulement des chaînes en mémoire), avec des **tags**\n",
+    "`theme` exploitables en filtrage (exercice 1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-009",
+   "metadata": {},
+   "execution_count": 5,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "8 documents ingeres (extract, partition, embed, index) en 1,8 s\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "corpus : incident-perte-donnees.md, split-brain.md, hnsw-parametrage.md, bpe-compte.md, hyde.md, grounding.md, quantization-turboquant.md, sauvegardes.md\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var corpus = new (string file, string tags, string body)[]\n",
+    "{\n",
+    "    (\"incident-perte-donnees.md\", \"incident,qdrant\", string.Join(\"\\n\\n\", new[]\n",
+    "    {\n",
+    "        \"# Incident : la perte de donnees de mars\",\n",
+    "        \"En mars, la collection conversations de Qdrant a perdu environ 40 pourcents de ses points apres un redemarrage du conteneur. La cause racine : le volume Docker etait monte en ecriture par deux instances simultanees, et aucune sauvegarde n'avait ete restauree depuis onze jours. Le montant de perte reel a ete mesure par comparaison avec l'export nocturne du disque de persistance.\",\n",
+    "        \"Trois lecons en sont sorties. D'abord, le split-brain du montage doit ete detecte par une sonde qui compare l'UUID du conteneur a l'owner declare. Ensuite, la sauvegarde doit etre restauree periodiquement dans un environnement epheliere : une sauvegarde jamais restauree n'est pas une sauvegarde. Enfin, le journal d'incident est devenu un document de premiere classe de la base : la memoire semantique indexe aussi les echecs.\",\n",
+    "        \"Apels remediation : verrou proprietaire sur le volume, sauvegarde bi-quotidienne avec restauration automatique le dimanche, et ajout d'un compteur de points publie qui alarme au-dela de 5 pourcents d'ecart avec l'attendu.\"\n",
+    "    })),\n",
+    "    (\"split-brain.md\", \"incident,qdrant\", string.Join(\"\\n\\n\", new[]\n",
+    "    {\n",
+    "        \"# Anti split-brain sur Qdrant\",\n",
+    "        \"Le split-brain survient quand deux processus croient chacun detenir l'unicite d'un volume de stockage. Dans notre cas, un conteneur zombie conservait un descripteur de fichier ouvert sur le repertoire de persistance pendant que le nouveau conteneur reconstruisait l'index HNSW. Les ecritures des deux processus se sont entrelacees dans les segments memtables, et la compaction a ensuite produit des segments incoherents.\",\n",
+    "        \"La defense comporte trois etages : un verrou disque (fichier lock avec PID), une sonde d'unicite qui interroge l'API cluster de Qdrant et compare les identifiants de replica, et un test de restoration hebdomadaire qui demarre une instance sur une copie de la sauvegarde et compte les points. Sans le troisieme etage, les deux premiers donnent une fausse confiance : on detecte le split-brain, mais pas la corruption silencieuse qu'il laisse.\"\n",
+    "    })),\n",
+    "    (\"hnsw-parametrage.md\", \"qdrant,indexation\", string.Join(\"\\n\\n\", new[]\n",
+    "    {\n",
+    "        \"# Parametrage HNSW en pratique\",\n",
+    "        \"HNSW construit un graphe multicouche ou chaque point relie a ses M voisins les plus proches ; la recherche descend les couches en greedy search guidee par ef_construction. Le compromis central : M eleve ameliore le rappel des requetes difficiles mais renforce le cout memoire de l'index et le temps de construction. Pour nos collections de conversation, M = 16 et ef_construction = 200 se sont averes le point doux.\",\n",
+    "        \"Le parametre runtime ef (au moment de la requete) reste le levier dominant du rappel : monter ef de 64 a 256 a fait passer le rappel au top-10 de 0,88 a 0,97 sur notre gold interne, au prix d'une latence triplee. La quantization scalaire (TurboQuant) comprime les vecteurs d'un facteur quatre avec une perte de rappel mesurable mais acceptable au-dela de 100k points, la ou l'index ne tient plus en RAM.\",\n",
+    "        \"En dessous de 50k points et en local, l'index exact reste la reference : HNSW n'apporte son gain de latence qu'une fois le brut force vectoriel devenu le goulot. C'est exactement le compromis que le notebook 05 de cette serie mesure a la main.\"\n",
+    "    })),\n",
+    "    (\"bpe-compte.md\", \"tokenisation,cout\", string.Join(\"\\n\\n\", new[]\n",
+    "    {\n",
+    "        \"# BPE : le token, unite de compte\",\n",
+    "        \"La tokenisation BPE fusionne iterativement les paires de caracteres les plus frequentes du corpus d'entrainement en vocabulaire. Consequence directe pour une memoire semantique : chaque fragment de texte ingere, chaque requete, chaque passage stocke est facture en tokens, pas en caracteres. Un mot francais rare comme reconstruisaient coute trois a quatre tokens la ou l'article defini en coute un.\",\n",
+    "        \"Le notebook 04 de cette serie deroule BPE a la main ; ici on en retient la consequence economique : le cout d'une memoire semantique se pilote en tokens. Partitionner un document en blocs de 256 tokens au lieu de 64 divise par quatre le nombre d'embeddings a calculer et donc le cout d'ingestion, mais grossit chaque partition, ce que la section 5 de ce notebook mesure cote rappel.\",\n",
+    "        \"Regle pratique retenue : estimer le compte de tokens d'un texte francais par un quart de sa longueur en caracteres (approximation large, suffisante pour dimensionner un pipeline).\"\n",
+    "    })),\n",
+    "    (\"hyde.md\", \"retrieval\", string.Join(\"\\n\\n\", new[]\n",
+    "    {\n",
+    "        \"# HyDE : embedder une reponse hypothetique\",\n",
+    "        \"HyDE (Hypothetical Document Embeddings) reformule la question en document hypothetique avant la recherche vectorielle : au lieu d'embedder la question brute, on genere d'abord un court passage fictif qui ressemblerait a la reponse, et on cherche ses voisins. L'intuition : l'espace des embeddings rapproche deux documents, pas une question et un document.\",\n",
+    "        \"Le notebook 02 mesure HyDE sur le gold francais : gain net sur les questions courtes et lexicalement eloignees du corpus, gain nul voire negatif sur les questions deja riches en vocabulaire du domaine, au prix d'un appel de generation supplementaire par requete. HyDE est donc un levier conditionnel, pas un defaut.\",\n",
+    "        \"Kernel Memory n'implemente pas HyDE nativement : c'est une transformation de requete, qui vit naturellement cote orchestrateur (serie SemanticKernel) avant l'appel au backend memoire.\"\n",
+    "    })),\n",
+    "    (\"grounding.md\", \"retrieval,agents\", string.Join(\"\\n\\n\", new[]\n",
+    "    {\n",
+    "        \"# Grounding : ancrer les agents dans les faits\",\n",
+    "        \"Le grounding demande a un agent generateur de citer ses sources : chaque affirmation doit remonter a un passage retrievable, et le pipeline fournit les citations avec leur partition d'origine pour verifier. Une reponse non ancree est traitee comme une hypothese, pas comme un fait : le distinguo est le coeur du cahier des charges de cette serie.\",\n",
+    "        \"En pratique, la boucle grounding comporte trois temps : retrieval des passages pertinents, generation contrainte a ne s'appuyer que sur ces passages, puis verification humaine ou automatique que chaque phrase de la reponse a une citation. Le taux d'affirmations ancrees est la metrique qui a remplace le simple taux de reponses correctes dans nos tableaux de bord.\"\n",
+    "    })),\n",
+    "    (\"quantization-turboquant.md\", \"qdrant,cout\", string.Join(\"\\n\\n\", new[]\n",
+    "    {\n",
+    "        \"# Quantization TurboQuant\",\n",
+    "        \"La quantization vectorielle encode chaque dimension sur moins de bits : int8 au lieu de float32 divise la taille de l'index par quatre. TurboQuant, la variante de Qdrant, reconstruit les vecteurs quantizes avec une correction d'erreur qui limite la perte de rappel a environ un a deux points sur nos collections de test.\",\n",
+    "        \"Le vrai critere de decision n'est pas la place disque mais la RAM : un index qui tient en memoire sert ses requetes en millisecondes, un index echange sur disque voit sa latence exploser. La quantization est donc le levier qui retarde le moment ou il faut payer soit plus de RAM, soit une migration vers un backend distribue.\",\n",
+    "        \"Regle de decision retenue dans cette serie : quantizer au-dela de 100k points, mesurer le rappel avant et apres sur un gold fige, et documenter la perte acceptee. Jamais quantizer a l'aveugle.\"\n",
+    "    })),\n",
+    "    (\"sauvegardes.md\", \"incident,qdrant\", string.Join(\"\\n\\n\", new[]\n",
+    "    {\n",
+    "        \"# Sauvegardes : a moitie cablees n'est pas cable\",\n",
+    "        \"L'incident de mars a revele que la sauvegarde etait a moitie cablee : le script d'export tournait bien chaque nuit, mais personne n'avait verifie que les fichiers produits etaient complets et restaurables. Une sauvegarde non testee est un confort psychologique, pas une procedure.\",\n",
+    "        \"La remediation a trois volets : un test de restoration automatique hebdomadaire qui demonte un conteneur epheliere sur la copie, un chiffre de completude (nombre de points restaures contre attendu) publie dans le journal, et une alerte si le test ne s'execute pas : une sauvegarde silencieuse est une sauvegarde morte.\"\n",
+    "    }))\n",
+    "};\n",
+    "\n",
+    "string corpusDir = Path.Combine(Path.GetTempPath(), \"km_rag06_corpus\");\n",
+    "Directory.CreateDirectory(corpusDir);\n",
+    "foreach (var (file, _, body) in corpus)\n",
+    "    await File.WriteAllTextAsync(Path.Combine(corpusDir, file), body);\n",
+    "\n",
+    "var sw = System.Diagnostics.Stopwatch.StartNew();\n",
+    "foreach (var (file, tags, _) in corpus)\n",
+    "{\n",
+    "    var tc = new TagCollection();\n",
+    "    foreach (var t in tags.Split(',')) tc.Add(\"theme\", t);\n",
+    "    await memory.ImportDocumentAsync(Path.Combine(corpusDir, file), index: \"rag06\", tags: tc);\n",
+    "}\n",
+    "sw.Stop();\n",
+    "Console.WriteLine($\"{corpus.Length} documents ingeres (extract, partition, embed, index) en {sw.Elapsed.TotalSeconds:F1} s\");\n",
+    "Console.WriteLine(\"corpus : \" + string.Join(\", \", corpus.Select(c => c.file)));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-010",
+   "metadata": {},
+   "source": [
+    "## 4. Sous le capot : les partitions générees par la pipeline\n",
+    "\n",
+    "Avant la vectorisation, KM découpe chaque document en **partitions** (les unités\n",
+    "recherchées et citées). En 0.98, ce découpage n'est pas exposé comme classe publique :\n",
+    "le levier de configuration est `TextPartitioningOptions` (notamment\n",
+    "`MaxTokensPerParagraph`), et la façon honnête de voir le résultat est d'interroger la\n",
+    "pipeline elle-même. Une recherche large sur le vocabulaire du corpus fait remonter les\n",
+    "citations avec leurs partitions — on en déduit la granularité réelle par document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-011",
+   "metadata": {},
+   "execution_count": 6,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "bpe-compte.md                    3 partitions, tailles 249..249 tokens (approx. 1 token = 4 caracteres)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "hnsw-parametrage.md              3 partitions, tailles 274..274 tokens (approx. 1 token = 4 caracteres)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "hyde.md                          3 partitions, tailles 225..225 tokens (approx. 1 token = 4 caracteres)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "incident-perte-donnees.md        3 partitions, tailles 268..268 tokens (approx. 1 token = 4 caracteres)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "quantization-turboquant.md       2 partitions, tailles 217..217 tokens (approx. 1 token = 4 caracteres)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "sauvegardes.md                   3 partitions, tailles 162..162 tokens (approx. 1 token = 4 caracteres)\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "split-brain.md                   3 partitions, tailles 223..223 tokens (approx. 1 token = 4 caracteres)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Inspection : une requete large fait remonter les partitions reellement generees.\n",
+    "int ApproxTokens(string s) => Math.Max(1, s.Length / 4);\n",
+    "\n",
+    "var sonde = await memory.SearchAsync(\"qdrant incident sauvegarde indexation token retrieval embedding\", index: \"rag06\", limit: 20);\n",
+    "foreach (var g in sonde.Results.GroupBy(c => c.SourceName).OrderBy(g => g.Key))\n",
+    "{\n",
+    "    var tailles = g.SelectMany(c => c.Partitions).Select(p => ApproxTokens(p.Text)).OrderBy(x => x).ToList();\n",
+    "    Console.WriteLine($\"{g.Key,-32} {tailles.Count} partitions, tailles {tailles.First()}..{tailles.Last()} tokens (approx. 1 token = 4 caracteres)\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-012",
+   "metadata": {},
+   "source": [
+    "## 5. Recherche avec citations\n",
+    "\n",
+    "C'est la valeur ajoutée visible de KM : chaque résultat embarque sa **provenance** —\n",
+    "fichier source, numéro de partition, texte du passage, score de pertinence. Comparer à\n",
+    "[01](01-Hands-On-Grounding.ipynb), où la reconstruction de la provenance était un\n",
+    "exercice manuel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-013",
+   "metadata": {},
+   "execution_count": 7,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Q : Comment le verrou anti split-brain detecte-t-il un conteneur zombie ?\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "   -> split-brain.md (partition 0) rel=0,814 : # Anti split-brain sur Qdrant Le split-brain survient quand deux processus croient chacun detenir l'...\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Q : Quel parametre runtime fait le plus gagner en rappel, et a quel prix ?\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "   -> hnsw-parametrage.md (partition 0) rel=0,711 : # Parametrage HNSW en pratique HNSW construit un graphe multicouche ou chaque point relie a ses M vo...\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Q : Pourquoi une sauvegarde jamais restauree n'est-elle pas une sauvegarde ?\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "   -> sauvegardes.md (partition 0) rel=0,749 : # Sauvegardes : a moitie cablees n'est pas cable L'incident de mars a revele que la sauvegarde etait...\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "foreach (var q in new[]\n",
+    "{\n",
+    "    \"Comment le verrou anti split-brain detecte-t-il un conteneur zombie ?\",\n",
+    "    \"Quel parametre runtime fait le plus gagner en rappel, et a quel prix ?\",\n",
+    "    \"Pourquoi une sauvegarde jamais restauree n'est-elle pas une sauvegarde ?\",\n",
+    "})\n",
+    "{\n",
+    "    var res = await memory.SearchAsync(q, index: \"rag06\", limit: 2);\n",
+    "    // KM peut retourner le meme document en plusieurs citations (une par partition\n",
+    "    // retenue) : on deduplique par fichier pour un affichage lisible.\n",
+    "    var citations = res.Results.GroupBy(c => c.SourceName).Select(g => g.First()).Take(2);\n",
+    "    Console.WriteLine();\n",
+    "    Console.WriteLine($\"Q : {q}\");\n",
+    "    foreach (var cit in citations)\n",
+    "    {\n",
+    "        var p = cit.Partitions.OrderByDescending(x => x.Relevance).First();\n",
+    "        var extrait = Regex.Replace(p.Text, @\"\\s+\", \" \").Trim();\n",
+    "        extrait = extrait.Length > 100 ? extrait[..100] + \"...\" : extrait;\n",
+    "        Console.WriteLine($\"   -> {cit.SourceName} (partition {p.PartitionNumber}) rel={p.Relevance:F3} : {extrait}\");\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-014",
+   "metadata": {},
+   "source": [
+    "## 6. Mesure : granularité des partitions contre rappel\n",
+    "\n",
+    "Question de dimensionnement (cf. le document `bpe-compte` : le partitionnement pilote\n",
+    "le coût d'ingestion) : des partitions **fines** (64 tokens) coûtent plus d'embeddings\n",
+    "mais citent plus précisément ; des partitions **larges** (256 tokens) coûtent moins\n",
+    "mais diluent le signal. Nous mesurons trois choses sur deux pipelines identiques ne\n",
+    "différant que par `MaxTokensPerParagraph` : le **coût d'ingestion** (nombre de vecteurs\n",
+    "créés — `SimpleVectorDb` écrit un fichier par vecteur, on peut les compter), le\n",
+    "**rappel@1** et le **rappel@3** d'un mini-gold (6 questions, document attendu connu),\n",
+    "et la **taille moyenne des extraits cités**.\n",
+    "\n",
+    "Verdict attendu : pas de claim « BEATS » — une mesure pédagogique sur un petit corpus,\n",
+    "dont la méthodologie (gold figé, recall@k) est celle du [02](02-Retrieval-Avance.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-015",
+   "metadata": {},
+   "execution_count": 8,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "strategie   maxTok  vecteurs  rappel@1  rappel@3  extrait moyen\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "fines           64        60      100%      100%         160 car.\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "larges         256        10      100%      100%         833 car.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "MemoryServerless BuildMemory(int maxTokensPerParagraph)\n",
+    "{\n",
+    "    return NewBuilder()\n",
+    "        .WithSimpleFileStorage(Path.Combine(Path.GetTempPath(), $\"km_rag06_mesure_store_{maxTokensPerParagraph}\"))\n",
+    "        .WithSimpleVectorDb(Path.Combine(Path.GetTempPath(), $\"km_rag06_mesure_vec_{maxTokensPerParagraph}\"))\n",
+    "        .WithLLamaSharpTextEmbeddingGeneration(llamaConfig)\n",
+    "        .With(new TextPartitioningOptions { MaxTokensPerParagraph = maxTokensPerParagraph, OverlappingTokens = maxTokensPerParagraph / 4 })\n",
+    "        .Build<MemoryServerless>();\n",
+    "}\n",
+    "\n",
+    "var gold = new (string q, string attendu)[]\n",
+    "{\n",
+    "    (\"Comment le verrou anti split-brain detecte-t-il un conteneur zombie ?\", \"split-brain.md\"),\n",
+    "    (\"Quel parametre runtime fait le plus gagner en rappel, et a quel prix ?\", \"hnsw-parametrage.md\"),\n",
+    "    (\"Pourquoi une sauvegarde jamais restauree n'est-elle pas une sauvegarde ?\", \"sauvegardes.md\"),\n",
+    "    (\"Combien de points la collection a-t-elle perdus lors de l'incident de mars ?\", \"incident-perte-donnees.md\"),\n",
+    "    (\"Quand faut-il activer la quantization vectorielle ?\", \"quantization-turboquant.md\"),\n",
+    "    (\"En quoi HyDE aide-t-il les questions courtes ?\", \"hyde.md\"),\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine($\"{\"strategie\",-10} {\"maxTok\",7} {\"vecteurs\",9} {\"rappel@1\",9} {\"rappel@3\",9} {\"extrait moyen\",14}\");\n",
+    "foreach (var (nom, maxTok) in new[] { (\"fines\", 64), (\"larges\", 256) })\n",
+    "{\n",
+    "    // Reprise d'une execution anterieure impossible : comptage exact des vecteurs\n",
+    "    // exige un magasin vide (SimpleVectorDb = un fichier par vecteur, cf. section 4).\n",
+    "    var vecDir = Path.Combine(Path.GetTempPath(), $\"km_rag06_mesure_vec_{maxTok}\");\n",
+    "    var storeDir = Path.Combine(Path.GetTempPath(), $\"km_rag06_mesure_store_{maxTok}\");\n",
+    "    if (Directory.Exists(vecDir)) Directory.Delete(vecDir, recursive: true);\n",
+    "    if (Directory.Exists(storeDir)) Directory.Delete(storeDir, recursive: true);\n",
+    "\n",
+    "    var mem = BuildMemory(maxTok);\n",
+    "    foreach (var (file, tags, _) in corpus)\n",
+    "    {\n",
+    "        var tc = new TagCollection();\n",
+    "        foreach (var t in tags.Split(',')) tc.Add(\"theme\", t);\n",
+    "        await mem.ImportDocumentAsync(Path.Combine(corpusDir, file), index: $\"rag06-{nom}\", tags: tc);\n",
+    "    }\n",
+    "    int nbVec = Directory.GetFiles(vecDir, \"*\", SearchOption.AllDirectories).Length;\n",
+    "    int hits1 = 0, hits3 = 0;\n",
+    "    long chars = 0;\n",
+    "    foreach (var (q, attendu) in gold)\n",
+    "    {\n",
+    "        var res = await mem.SearchAsync(q, index: $\"rag06-{nom}\", limit: 3);\n",
+    "        var files = res.Results.Select(c => c.SourceName).ToList();\n",
+    "        if (files.Contains(attendu)) hits3++;\n",
+    "        if (files.Count > 0 && files[0] == attendu) hits1++;\n",
+    "        var top = res.Results[0];\n",
+    "        var p = top.Partitions.OrderByDescending(x => x.Relevance).First();\n",
+    "        chars += Regex.Replace(p.Text, @\"\\s+\", \" \").Trim().Length;\n",
+    "    }\n",
+    "    Console.WriteLine($\"{nom,-10} {maxTok,7} {nbVec,9} {100.0 * hits1 / gold.Length,8:F0}% {100.0 * hits3 / gold.Length,8:F0}% {chars / gold.Length,11} car.\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-016",
+   "metadata": {},
+   "source": [
+    "**Lecture.** Trois enseignements chiffrés. (1) Le **coût d'ingestion explose avec la\nfinesse** : 60 vecteurs à créer pour des partitions de 64 tokens contre 10 pour des\npartitions de 256 — six fois plus d'embeddings sur un corpus de huit documents *courts* ;\nle ratio monte sur des documents longs. (2) Le **rappel sature** : les deux stratégies\nretrouvent le bon document dans le top-3 — la dilution du signal par les partitions\nlarges ne coûte pas cher sur ce petit corpus aux documents thématiquement étanches. Le\ncompromis devient réel sur des documents longs et multi-thèmes, où une partition large\nmélange deux sujets et fait remonter le mauvais passage : c'est ce que le gold étendu de\nl'**exercice 3** permet de tester. (3) La différence **visible dès ce corpus** est la\ntaille des extraits cités : ~5× plus courts en partitions fines (833 contre 160 caractères en moyenne). Quand la citation\nalimente un LLM, la granularité pilote directement le coût du contexte et la précision\nde la citation.\n\nÀ retenir : **la granularité est un paramètre de conception, pas un détail** — elle pilote\nle coût d'ingestion (nombre d'embeddings), la taille des citations, et au-delà d'un\ncertain degré de dilution, le rappel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-017",
+   "metadata": {},
+   "source": [
+    "## 7. Limites et prolongements\n",
+    "\n",
+    "- **Mode symétrique** : nous vectorisons requêtes et passages sans les instructions de\n",
+    "  préfixe que certains embedders recommandent — l'**exercice 3** mesure ce que les\n",
+    "  préfixes apportent réellement.\n",
+    "- **`SimpleVectorDb` = recherche exacte brute** : parfait pour démontrer, coûteux\n",
+    "  au-delà de ~10⁴ vecteurs. Le compromis rappel/ANN est le sujet du\n",
+    "  [05](05-Stockage-Vectoriel.ipynb) ; brancher KM sur un Qdrant serveur ne demande que\n",
+    "  `.WithQdrant(...)` (cf. [05b](05b-Stockage-Vectoriel-Serveur.ipynb)).\n",
+    "- **Pas d'`Ask` ici** : répondre en langage naturel exige un connecteur de génération\n",
+    "  (LLM) — hors scope backend mémoire, traité par la série SemanticKernel.\n",
+    "- **Hybride BM25 + dense** : Kernel Memory service le propose ; la mesure du gain sur\n",
+    "  notre gold français restera à faire."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-018",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "**Exercice 1 — Filtrer la recherche par tag.** Les documents sont ingérés avec des tags\n",
+    "`theme` (ex. `incident`, `qdrant`, `retrieval`). Utilisez `MemoryFilter` pour restreindre\n",
+    "la question de l'incident de mars aux seuls documents taggés `incident`, et vérifiez que\n",
+    "`split-brain.md` ne remonte plus sur la question du verrou quand on filtre sur `qdrant`\n",
+    "seul.\n",
+    "\n",
+    "# Indice : new MemoryFilter().ByTag(\"theme\", \"incident\"), passe en argument filter de SearchAsync\n",
+    "\n",
+    "**Exercice 2 — Ingestion d'un PDF.** KM décode nativement PDF/Word. Générez un PDF\n",
+    "d'une page contenant un des documents du corpus, ingérez-le dans un index `rag06-pdf`,\n",
+    "et vérifiez par une recherche que les citations pointent bien dans le PDF.\n",
+    "\n",
+    "# Etape 1 : produire le fichier .pdf -- Etape 2 : ImportDocumentAsync -- Etape 3 : SearchAsync + citations\n",
+    "\n",
+    "**Exercice 3 — Préfixes d'instruction et rappel.** Implémentez un `ITextEmbeddingGenerator`\n",
+    "qui wrappe le générateur LLamaSharp en préfixant passages et requêtes des instructions\n",
+    "recommandées par la fiche du modèle (indice : deux instances de pipeline, ou un drapeau\n",
+    "togglé entre les phases), ré-indexez le corpus, et mesurez le rappel@3 du gold de la\n",
+    "section 6 avant / après. Verdict attendu : quantifié, honnête — gain, nul ou négatif."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-019",
+   "metadata": {},
+   "execution_count": 9,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : filtrage par tag\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 -- filtrage par tag (a completer)\n",
+    "// Objectif : la question de l'incident de mars ne doit citer que des documents theme=incident.\n",
+    "Console.WriteLine(\"Exercice a completer : filtrage par tag\");\n",
+    "// var filtre = new MemoryFilter().ByTag(\"theme\", \"incident\");\n",
+    "// var res = await memory.SearchAsync(\"Combien de points perdus lors de l'incident de mars ?\", index: \"rag06\", filter: filtre, limit: 3);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-020",
+   "metadata": {},
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : ingestion PDF\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 -- ingestion d'un PDF (a completer)\n",
+    "// Objectif : citations provenant d'un vrai fichier PDF decode par la pipeline KM.\n",
+    "Console.WriteLine(\"Exercice a completer : ingestion PDF\");\n",
+    "// string pdfPath = ...; // produire un PDF d'une page\n",
+    "// await memory.ImportDocumentAsync(pdfPath, index: \"rag06-pdf\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "code-021",
+   "metadata": {},
+   "execution_count": 11,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : prefixes d'instruction et rappel\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 -- prefixes d'instruction (a completer)\n",
+    "// Objectif : mesurer le rappel@3 du gold avec les instructions de prefixe respectees.\n",
+    "Console.WriteLine(\"Exercice a completer : prefixes d'instruction et rappel\");\n",
+    "// class PrefixedGenerator : ITextEmbeddingGenerator { ... prefixe selon la phase ... }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-022",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Kernel Memory in-process livre en un pipeline ce que les notebooks 01-05 ont construit\n",
+    "brique par brique : ETL documentaire, partitionnement, embeddings et **citations\n",
+    "traçables** — sans service ni conteneur, avec un embedder local GGUF sur CPU. La mesure\n",
+    "de la section 6 fixe le réflexe de conception : *la granularité des partitions est un\n",
+    "compromis coût/précision à décider explicitement*.\n",
+    "\n",
+    "La suite logique de l'EPIC ([#13421](https://github.com/jsboige/CoursIA/issues/13421)) :\n",
+    "la recherche **hybride** BM25 + dense sur le gold français étendu, puis l'ingestion\n",
+    "multimodale — sur le même socle."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/README.md
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/README.md
@@ -25,7 +25,7 @@ Un assistant de codage sans mémoire externe ré-explore le même terrain à cha
 
 - **Opérateurs d'agents** qui veulent comprendre comment leurs outils sont *ancrés* dans un historique vérifié.
 - **Curieux d'infrastructure ML / vectorielle** qui cherchent un récit honnête de mise en production (Docker, WSL2, quantization, anti-split-brain).
-- **Lecteurs des notebooks pratiques** `01-Hands-On-Grounding.ipynb` (le contexte de l'infrastructure avant de manipuler Qdrant), `02-Retrieval-Avance.ipynb` (mesurer HyDE et le reranking sur un gold français), `03-Embeddings-From-Scratch.ipynb` (ce qu'un embedding *est*, avant de s'en servir), `04-Tokenisation-From-Scratch.ipynb` (ce qu'un token *est*, l'unité de compte que tout le dépôt consomme) et `05-Stockage-Vectoriel.ipynb` (la persistance sur disque et le compromis exact/ANN quand le corpus ne tient plus en RAM).
+- **Lecteurs des notebooks pratiques** `01-Hands-On-Grounding.ipynb` (le contexte de l'infrastructure avant de manipuler Qdrant), `02-Retrieval-Avance.ipynb` (mesurer HyDE et le reranking sur un gold français), `03-Embeddings-From-Scratch.ipynb` (ce qu'un embedding *est*, avant de s'en servir), `04-Tokenisation-From-Scratch.ipynb` (ce qu'un token *est*, l'unité de compte que tout le dépôt consomme), `05-Stockage-Vectoriel.ipynb` (la persistance sur disque et le compromis exact/ANN quand le corpus ne tient plus en RAM), `05b-Stockage-Vectoriel-Serveur.ipynb` (le même compromis sur un serveur Qdrant réel) et `06-KernelMemory-InProcess.ipynb` (la couche d'abstraction Kernel Memory par-dessus l'infrastructure).
 - **Personnes ayant vécu un incident** (perte de données, dérive de montage disque, sauvegardes à moitié câblées) et cherchant des leçons partageables.
 
 ## Objectifs d'apprentissage
@@ -39,7 +39,7 @@ Un assistant de codage sans mémoire externe ré-explore le même terrain à cha
 
 ## Notebooks et documents
 
-Cette section contient **cinq notebooks** (Qdrant en mémoire, retrieval avancé mesuré, embeddings from scratch, tokenisation BPE à la main et stockage vectoriel persistant) et **quatre documents** de cadrage :
+Cette section contient **sept notebooks** (Qdrant en mémoire, retrieval avancé mesuré, embeddings from scratch, tokenisation BPE à la main, stockage vectoriel persistant et son variant serveur, et la couche d'abstraction Kernel Memory) et **quatre documents** de cadrage :
 
 | Support | Type | Vous y trouverez |
 |---------|------|------------------|
@@ -48,6 +48,8 @@ Cette section contient **cinq notebooks** (Qdrant en mémoire, retrieval avancé
 | [`03-Embeddings-From-Scratch.ipynb`](03-Embeddings-From-Scratch.ipynb) | Notebook pratique | Construire un word2vec (skip-gram NSG) en NumPy : co-occurrences + PMI, la géométrie qui émerge, et le pont vers un transformer contextuel |
 | [`04-Tokenisation-From-Scratch.ipynb`](04-Tokenisation-From-Scratch.ipynb) | Notebook pratique | Construire une tokenisation BPE à la main, et mesurer le coût du choix de tokenizer sur le chunking et le budget de contexte |
 | [`05-Stockage-Vectoriel.ipynb`](05-Stockage-Vectoriel.ipynb) | Notebook pratique | Persistance sur disque (Qdrant), HNSW déplié à la main, et le compromis rappel-exact vs ANN mesuré — zéro conteneur |
+| [`05b-Stockage-Vectoriel-Serveur.ipynb`](05b-Stockage-Vectoriel-Serveur.ipynb) | Notebook pratique | Le compromis ef exact/ANN sur un serveur Qdrant réel, 10k vecteurs |
+| [`06-KernelMemory-InProcess.ipynb`](06-KernelMemory-InProcess.ipynb) | Notebook pratique (.NET 9) | La couche d'abstraction Kernel Memory in-process : ETL documentaire, partitionnement en paragraphes, recherche avec citations, et le compromis granularité/rappel mesuré — embeddings locaux via LLamaSharp (GGUF `granite-embedding` CPU), zéro service |
 | [`01-Pourquoi-Memoire-Semantique.md`](docs/01-Pourquoi-Memoire-Semantique.md) | Document de cadrage | Le besoin : grounding, SDDD, RAG |
 | [`02-Infrastructure-Qdrant.md`](docs/02-Infrastructure-Qdrant.md) | Document de déploiement | Docker, WSL2, quantization, anti-split-brain |
 | [`03-Utilisation-MCP-Indexation.md`](docs/03-Utilisation-MCP-Indexation.md) | Document d'usage | Brancher un agent via MCP, indexer, rechercher |
@@ -183,10 +185,10 @@ R : La mémoire sémantique est *indexée par le sens* (embeddings + recherche v
 
 ## Conclusion / Prochaines étapes
 
-`RAG-et-Memoire-Semantique` est une section modeste en volume (4 notebooks + 4 documents) mais dense en leçons opérationnelles : chaque incident documenté a renforcé une règle de durcissement (disque dédié, sauvegardes testées, anti-split-brain). Pour aller plus loin :
+`RAG-et-Memoire-Semantique` est une section modeste en volume (7 notebooks + 4 documents) mais dense en leçons opérationnelles : chaque incident documenté a renforcé une règle de durcissement (disque dédié, sauvegardes testées, anti-split-brain). Pour aller plus loin :
 
 - **Lire les incidents.** Le document [04 - Incidents et leçons](docs/04-Incidents-et-Lecons.md) est la matière pédagogique la plus utile de cette section — il documente des pannes *réelles* et leurs *solutions*.
-- **Faire tourner les notebooks.** [`01-Hands-On-Grounding.ipynb`](01-Hands-On-Grounding.ipynb) fonctionne en mémoire, sans Docker, en quelques minutes ; [`02-Retrieval-Avance.ipynb`](02-Retrieval-Avance.ipynb) mesure réellement HyDE et un cross-encoder multilingue sur CPU ; [`03-Embeddings-From-Scratch.ipynb`](03-Embeddings-From-Scratch.ipynb) construit un word2vec en NumPy, puis le compare à un transformer contextuel ; [`04-Tokenisation-From-Scratch.ipynb`](04-Tokenisation-From-Scratch.ipynb) construit un BPE à la main et mesure le coût du choix de tokenizer ; [`05-Stockage-Vectoriel.ipynb`](05-Stockage-Vectoriel.ipynb) déplie un HNSW à la main et mesure le compromis rappel-exact vs ANN — le tout en quelques secondes.
+- **Faire tourner les notebooks.** [`01-Hands-On-Grounding.ipynb`](01-Hands-On-Grounding.ipynb) fonctionne en mémoire, sans Docker, en quelques minutes ; [`02-Retrieval-Avance.ipynb`](02-Retrieval-Avance.ipynb) mesure réellement HyDE et un cross-encoder multilingue sur CPU ; [`03-Embeddings-From-Scratch.ipynb`](03-Embeddings-From-Scratch.ipynb) construit un word2vec en NumPy, puis le compare à un transformer contextuel ; [`04-Tokenisation-From-Scratch.ipynb`](04-Tokenisation-From-Scratch.ipynb) construit un BPE à la main et mesure le coût du choix de tokenizer ; [`05-Stockage-Vectoriel.ipynb`](05-Stockage-Vectoriel.ipynb) déplie un HNSW à la main et mesure le compromis rappel-exact vs ANN ; [`05b-Stockage-Vectoriel-Serveur.ipynb`](05b-Stockage-Vectoriel-Serveur.ipynb) rejoue le compromis sur un serveur Qdrant réel ; [`06-KernelMemory-InProcess.ipynb`](06-KernelMemory-InProcess.ipynb) (.NET 9, modèle GGUF d'embeddings mis en cache, inférence llama.cpp CPU) délègue le pipeline à Kernel Memory et mesure le compromis granularité/rappel — sans service ni conteneur.
 - **Brancher un agent.** Le document [03 - Utilisation et indexation](docs/03-Utilisation-MCP-Indexation.md) montre comment relier Claude Code ou Roo Code à Qdrant via MCP.
 
 Pour le versant *application* du RAG (pas infrastructure), voir les notebooks [`5_RAG_Modern.ipynb`](../Texte/5_RAG_Modern.ipynb) et [`14_Persistent_Memory.ipynb`](../Texte/14_Persistent_Memory.ipynb) de la section Texte.
@@ -222,6 +224,8 @@ Pour le versant *application* du RAG (pas infrastructure), voir les notebooks [`
 | [Notebook — Embeddings from scratch](03-Embeddings-From-Scratch.ipynb) | Construire un word2vec (skip-gram NSG) en NumPy, lire la géométrie, comparer à un transformer | Pratique |
 | [Notebook — Tokenisation from scratch](04-Tokenisation-From-Scratch.ipynb) | Construire une tokenisation BPE à la main, mesurer le coût du choix de tokenizer sur le chunking et le budget | Pratique |
 | [Notebook — Stockage vectoriel](05-Stockage-Vectoriel.ipynb) | Persister sur disque, déplier un HNSW à la main, mesurer le compromis rappel-exact vs ANN | Pratique |
+| [Notebook — Stockage vectoriel, serveur](05b-Stockage-Vectoriel-Serveur.ipynb) | Rejouer le compromis ef exact/ANN sur un serveur Qdrant réel, 10k vecteurs | Pratique |
+| [Notebook — Kernel Memory in-process](06-KernelMemory-InProcess.ipynb) | Déléguer ETL, partitionnement et citations à Kernel Memory (.NET 9), mesurer la granularité contre le rappel | Pratique |
 
 ---
 


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2023:CoursIA-2 — prev: MED/guard #13441

## Problem

See #13421 (EPIC Kernel Memory, tranche 1). La série RAG-et-Memoire-Semantique couvre le backend mémoire au niveau infrastructure (Qdrant direct, notebooks 01-05b) mais la couche d'abstraction officielle Microsoft Kernel Memory a zéro couverture (vérifié : grep KernelMemory sur GenAI/ = 0 résultat). L'EPIC propose 2-3 notebooks ; cette PR livre le premier, en .NET 9 Interactive.

## Choix de la tranche 1 (.NET in-process d'abord)

Le paquet Python `kernel-memory` est un client de service (le pipeline complet vit dans le service .NET) ; le mode **in-process** (`MemoryServerless`) s'exécute sans service déployé — le premier notebook est donc le livrable 4 de l'EPIC, livré en premier parce qu'exécutable aujourd'hui.

**Découverte d'écosystème (utile aux tranches suivantes)** : en KM 0.98, `Microsoft.KernelMemory.AI.Onnx` ne couvre que la *génération* de texte (vérifié par inspection du DLL : zéro type Embedding) — pour des embeddings 100 % locaux, le chemin officiel est l'intégration **LLamaSharp** (`LLamaSharp.kernel-memory` 0.27.0, dépend de KM Abstractions 0.98.250508.3, même version).

## Livrable

- **`06-KernelMemory-InProcess.ipynb`** (.NET 9 Interactive, kernel `.net-csharp`) :
  - pipeline `MemoryServerless` : `SimpleFileStorage` + `SimpleVectorDb` + `LLamaSharpTextEmbeddingGeneration` — zéro service, zéro conteneur, zéro clé d'API
  - embedder local : `granite-embedding-107m-multilingual` (IBM, conçu RAG, multilingue FR) en GGUF Q8_0 (121 Mo, conversion bartowski), inférence llama.cpp CPU
  - ingestion ETL d'un corpus FR de 8 documents (fichiers .md sur disque, tags `theme`)
  - sous le capot : inspection des partitions réelles produites par le partitionnement interne (recherche large regroupée par document, tailles en tokens)
  - recherche avec **citations** (fichier, partition, passage, relevance) — la capacité distinctive vs upsert manuel
  - **mesure** : coût d'ingestion (60 vs 10 vecteurs), rappel@1 et rappel@3 (mini-gold 6 questions), taille moyenne des extraits (160 vs 833 caractères) sur 2 stratégies de partitionnement (64 vs 256 tokens/paragraphe) — lecture honnête, pas de claim BEATS
  - 3 exercices (filtrage par tag, ingestion PDF, préfixes d'instruction) — C.1 (stubs sans erreur volontaire)
- **README série** : ligne 06 + drift pré-existant corrigé (audit fichier-entier §E) : `05b-Stockage-Vectoriel-Serveur.ipynb` (livré par #13132) n'était listé nulle part — comptes 4/cinq → 7, table, parcours, liste « faire tourner »

## Validation

- Exécution headless complète : `exec_dotnet_persist.py` — 11/11 cellules code, 0 erreur, `execution_count` 1..11
- Verdict SOTA (Prong A) : **SOTA-OK** — vrai `Microsoft.KernelMemory.Core` 0.98.250508.3 + `LLamaSharp.kernel-memory` 0.27.0 via NuGet, vrai modèle GGUF officiellement convertible, vraie pipeline exécutée (outputs = sorties réelles)
- Prong B (problème non-trivial) : corpus FR 8 docs + gold 6 questions + comparaison granularité (64 vs 256 tokens) ; le contrat de préfixes des embedders à instructions documenté et mesurable (exercice 3)
- C.1 : `grep -nE "raise NotImplementedError|assert False|1/0"` = 0
- C.2 : committé avec outputs réels ; chemins machine absents des outputs (basenames seulement) ; ~86 vecteurs de partitions + requêtes = ~100 embeddings CPU réels ; mesure : 60 vs 10 vecteurs (6×), extraits moyens 160 vs 833 car., rappel@1/@3 saturés à 100% (lecture honnête : corpus court)
- Catalogue : byte-identique à main (0 diff)

## Résiduel (tranches suivantes de l'EPIC)

- Notebook hybride BM25+dense (mesure du gain sur gold étendu), ingestion multimodale, volet service/Python (`kernel-memory` client)
- `See #13421` (contribution partielle à l'EPIC — pas de `Closes`)
