### PR TITLE
docs(lean,#13402): franciser les 3 LEAN_INVENTORY du 2026-08-28 (QuantConnect, Planners, Tweety)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/LEAN_INVENTORY.md
@@ -1,40 +1,40 @@
-# Lean 4 Projects Inventory — QuantConnect
+# Inventaire des projets Lean 4 — `QuantConnect`
 
-Cross-directory inventory of all Lean 4 formalization projects under `QuantConnect/`.
+Inventaire transverse de tous les projets de formalisation Lean 4 sous `QuantConnect/`.
 
 Réconcilié le 2026-08-28 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
 module-set réel du disque (issue #13366, matrice #13121 tranche 3). Comptes `sorry` mesurés avec
 l'instrument canonique `scripts/lean/count_code_sorry.py --lake <root> --json` (champ
 `distinct_code_sorry`), jamais `grep -c sorry`.
 
-## Summary
+## Résumé
 
 **Lakes actifs (1)** :
 
-| Directory | Toolchain | Production sorry | Modules | Status |
-|-----------|-----------|-----------------|---------|--------|
-| `kelly_lean` | v4.32.1 | 0 | `Kelly/{Kelly, Bet, Growth}` (3 FR + 3 `_en`) | COMPLETE |
+| Répertoire | Toolchain | sorry (production) | Modules | Statut |
+|-----------|-----------|--------------------|---------|--------|
+| `kelly_lean` | v4.32.1 | 0 | `Kelly/{Kelly, Bet, Growth}` (3 FR + 3 `_en`) | COMPLET |
 
 ---
 
-## Directories
+## Par lake
 
 ### 1. kelly_lean
 
-**Objective**: optimalité du critère de Kelly — fraction optimale de mise, croissance log-optimale
+**Objectif** : optimalité du critère de Kelly — fraction optimale de mise, croissance log-optimale
 du capital (`growthGrad_kelly_zero` : dérivée du growth nulle au point Kelly), faisabilité de la
 fraction (`kellyFrac_feasible`), et formalisation du pari équivalent (`q`, `pq_add_eq_one`).
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4
 
-| Module group | sorry | Content |
+| Groupe de modules | sorry | Contenu |
 |--------------|-------|---------|
 | `Kelly/Kelly` (FR + `_en`) | 0 | critère de Kelly : `kellyFrac_feasible`, richesses win/lose au point Kelly, `growthGrad_kelly_zero`, `growth_diff_le` |
 | `Kelly/Bet` (FR + `_en`) | 0 | pari équivalent : `q`, `q_pos`, `q_lt_one`, `pq_add_eq_one`, `winWealth` |
 | `Kelly/Growth` (FR + `_en`) | 0 | croissance : `growth_zero`, `growthGrad_zero` |
 
-**CI wiring**: caller workflow [`lean-kelly.yml`](../../.github/workflows/lean-kelly.yml)
+**Câblage CI** : caller workflow [`lean-kelly.yml`](../../.github/workflows/lean-kelly.yml)
 (push `main`, paths `MyIA.AI.Notebooks/QuantConnect/kelly_lean/**.lean` + `lakefile.*`), pipeline `standalone-tactic`.
 
-**Notebooks in-lake (2, C.2 OK)** : `Kelly_companion.ipynb` (Python) et
+**Notebooks dans le lake (2, C.2 OK)** : `Kelly_companion.ipynb` (Python) et
 `Kelly_companion_lean.ipynb` (Lean) à la racine du lake.

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/LEAN_INVENTORY.md
@@ -1,19 +1,19 @@
-# Lean 4 Projects Inventory — SymbolicAI/Planners
+# Inventaire des projets Lean 4 — `SymbolicAI/Planners`
 
-Cross-directory inventory of all Lean 4 formalization projects under `SymbolicAI/Planners/`.
+Inventaire transverse de tous les projets de formalisation Lean 4 sous `SymbolicAI/Planners/`.
 
 Réconcilié le 2026-08-28 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
 module-set réel du disque (issue #13366, matrice #13121 tranche 3). Comptes `sorry` mesurés avec
 l'instrument canonique `scripts/lean/count_code_sorry.py --lake <root> --json` (champ
 `distinct_code_sorry`), jamais `grep -c sorry`.
 
-## Summary
+## Résumé
 
 **Lakes actifs (1)** :
 
-| Directory | Toolchain | Production sorry | Modules | Status |
-|-----------|-----------|-----------------|---------|--------|
-| `planning_lean` | v4.32.1 | 0 | `Planning/{Strips, Relaxation, Admissibility}` (3 FR + 3 `_en`) | COMPLETE |
+| Répertoire | Toolchain | sorry (production) | Modules | Statut |
+|-----------|-----------|--------------------|---------|--------|
+| `planning_lean` | v4.32.1 | 0 | `Planning/{Strips, Relaxation, Admissibility}` (3 FR + 3 `_en`) | COMPLET |
 
 Note de cheminement : la matrice #13121 tranche 3 référençait `MyIA.AI.Notebooks/Planners/planning_lean` ;
 le chemin effectif au disque est `MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean` (inventaire aligné
@@ -21,23 +21,23 @@ sur le disque).
 
 ---
 
-## Directories
+## Par lake
 
 ### 1. planning_lean
 
-**Objective**: admissibilité de la relaxation sans-delete en planification STRIPS — le coût du plan
+**Objectif** : admissibilité de la relaxation sans-delete en planification STRIPS — le coût du plan
 relaxé optimal `h⁺` n'excède jamais le coût du plan réel optimal `h*`
 (`relaxed_plan_admissible` + `relaxed_plan_witness`), sur les sémantiques `step` (réelle) et
 `stepR` (relaxée) avec `step_subset_stepR` et `run_mono`.
 
-**Toolchain**: v4.32.1 (pin effectif mesuré `lean-toolchain` ; la prose du README annonce encore
-`v4.31.0-rc1` — périmée, à corriger séparément) | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 (pin effectif mesuré `lean-toolchain` ; la prose du README annonce encore
+`v4.31.0-rc1` — périmée, à corriger séparément) | **Dépendances** : Mathlib4
 
-| Module group | sorry | Content |
+| Groupe de modules | sorry | Contenu |
 |--------------|-------|---------|
 | `Planning/Strips` (FR + `_en`) | 0 | domaine STRIPS : `applicable`, `step`, `stepR`, `goalSatisfied`, `step_subset_stepR` |
 | `Planning/Relaxation` (FR + `_en`) | 0 | exécution relaxée : `run`, `runR`, `reaches`, `reachesR`, `run_mono` |
 | `Planning/Admissibility` (FR + `_en`) | 0 | théorème-phare : `relaxed_plan_admissible`, `relaxed_plan_witness` |
 
-**CI wiring**: caller workflow [`lean-planning.yml`](../../../.github/workflows/lean-planning.yml)
+**Câblage CI** : caller workflow [`lean-planning.yml`](../../../.github/workflows/lean-planning.yml)
 (push `main`, paths `MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/**.lean` + `lakefile.*`), pipeline `standalone-tactic`.

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/LEAN_INVENTORY.md
@@ -1,33 +1,33 @@
-# Lean 4 Projects Inventory — SymbolicAI/Tweety
+# Inventaire des projets Lean 4 — `SymbolicAI/Tweety`
 
-Cross-directory inventory of all Lean 4 formalization projects under `SymbolicAI/Tweety/`.
+Inventaire transverse de tous les projets de formalisation Lean 4 sous `SymbolicAI/Tweety/`.
 
 Réconcilié le 2026-08-28 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
 module-set réel du disque (issue #13366, matrice #13121 tranche 3). Comptes `sorry` mesurés avec
 l'instrument canonique `scripts/lean/count_code_sorry.py --lake <root> --json` (champ
 `distinct_code_sorry`), jamais `grep -c sorry`.
 
-## Summary
+## Résumé
 
 **Lakes actifs (1)** :
 
-| Directory | Toolchain | Production sorry | Modules | Status |
-|-----------|-----------|-----------------|---------|--------|
-| `argumentation_lean` | v4.32.1 | 0 | `Argumentation/{Basic, Fundamental, Grounded, Characteristic, Extensions}` (5 FR + 5 `_en`) + umbrella `Argumentation.lean` | COMPLETE |
+| Répertoire | Toolchain | sorry (production) | Modules | Statut |
+|-----------|-----------|--------------------|---------|--------|
+| `argumentation_lean` | v4.32.1 | 0 | `Argumentation/{Basic, Fundamental, Grounded, Characteristic, Extensions}` (5 FR + 5 `_en`) + umbrella `Argumentation.lean` | COMPLET |
 
 ---
 
-## Directories
+## Par lake
 
 ### 1. argumentation_lean
 
-**Objective**: théorie de l'argumentation abstraite de Dung (1995) — cadres d'argumentation (AF),
+**Objectif** : théorie de l'argumentation abstraite de Dung (1995) — cadres d'argumentation (AF),
 les extensions canoniques (admissible, complète, grounded, preferred, stable), lemme fondamental
 et fonction caractéristique, au-dessus de Mathlib.
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4
 
-| Module group | sorry | Content |
+| Groupe de modules | sorry | Contenu |
 |--------------|-------|---------|
 | `Argumentation/Basic` (FR + `_en`) | 0 | conflit et défense : `conflictFree`, `defends`, `defendedBy`, `conflictFree_empty` |
 | `Argumentation/Fundamental` (FR + `_en`) | 0 | lemme fondamental : `fundamental_lemma` (+ variantes `defends`/`defends_self`) |
@@ -36,5 +36,11 @@ et fonction caractéristique, au-dessus de Mathlib.
 | `Argumentation/Extensions` (FR + `_en`) | 0 | hiérarchie des extensions : `Admissible`, `Complete`, `grounded`, `Preferred` |
 | `Argumentation.lean` (umbrella) | 0 | imports agrégés du lake |
 
-**CI wiring**: caller workflow [`lean-argumentation.yml`](../../../.github/workflows/lean-argumentation.yml)
+**Câblage CI** : caller workflow [`lean-argumentation.yml`](../../../.github/workflows/lean-argumentation.yml)
 (push `main`, paths `MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/**.lean` + `lakefile.*`), pipeline `standalone-tactic`.
+
+**Notebook câblé** : `Tweety-5b-Lean-Argumentation.ipynb` (kernel `lean4-wsl`, importe
+`Argumentation.*`) — companion conceptuel Tweety-5.
+
+**Suivi** : Epic [#4038](https://github.com/jsboige/CoursIA/issues/4038) /
+[#4046](https://github.com/jsboige/CoursIA/issues/4046) (roadmap Lean série Tweety).


### PR DESCRIPTION
Grain: MED/docs-translation — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-dotnet #13447

## Problem

See #13402. Les 3 LEAN_INVENTORY.md crees le 2026-08-28 par #13395 ont ete rediges en anglais, en violation de `readme-french-first.md` regle 1 (contenu neuf = francais, meme si le voisin GameTheory est anglais). Le francais est deja le modele majoritaire (6/10 inventaires FR, convention unanime : `# Inventaire des projets Lean 4 — \`X\``, `## Résumé`, `## Par lake`).

## Livrable (tranche 3 fichiers)

Francisation des elements structurels uniquement — la prose etait deja FR :

- Titre, ligne d'intro, `## Summary`/`## Directories`, en-tetes de tableaux (`Directory`/`Production sorry`/`Status` -> `Répertoire`/`sorry (production)`/`Statut`), labels `**Objective**`/`**Dependencies**`/`**CI wiring**` -> `**Objectif**`/`**Dépendances**`/`**Câblage CI**`, statut `COMPLETE` -> `COMPLET`.
- **Rien** de technique traduit : lakes, chemins, modules, toolchains, noms de lemmes, `distinct_code_sorry`, refs Mathlib.

## Tweety — reprise #13373 selon l'issue

- **Reinjectes** (verifies firsthand) : renvois Epic **#4038 / #4046** (bloc `**Suivi**`) + note de cablage `Tweety-5b-Lean-Argumentation.ipynb` (kernel `lean4-wsl`, importe `Argumentation.*` — fichier present au disque, import confirme par grep).
- **Exclus** : son compte "6 modules" (faux — le disque porte 5 FR + 5 `_en` + umbrella, version mergee gardee) et sa description d'instrument faite main (formulation mergee `count_code_sorry.py` / `distinct_code_sorry` gardee).

## Acceptance (issue verifiee point par point)

- [x] Titre, en-tetes de section et prose FR sur les 3 fichiers
- [x] Aucun nom technique traduit
- [x] Structure/ancres/colonnes identiques — diff lisible comme traduction (41+/35-, aucune ligne technique touchee)
- [x] `git grep -n "LEAN_INVENTORY" -- '*.md'` avant/apres : **identiques** (aucun lien d'ancre n'existe vers ces fichiers)
- [x] Tweety : 2 apports reinjectes, 2 erreurs exclues
- [x] Comptes sorry re-mesures avec l'instrument canonique : kelly **0**, planning **0**, argumentation **0** (`distinct_code_sorry` ; les comptes naive 1/5/18 = prose seulement — exactement pourquoi `grep -c sorry` est interdit)

## Scope

Tranche 3/4 fichiers. `GameTheory/LEAN_INVENTORY.md` (313 lignes, le plus ancien) = tranche separee comme le permet explicitement l'issue (« le traiter en dernier, ou dans une tranche a part si son volume le justifie »). Pas de `Closes` — contribution partielle.