### PR TITLE
fix(tooling,#13435): _DECL_RE ne rattache plus sur un renvoi de contexte seul

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -107,6 +107,7 @@ from series_saturation import (  # noqa: E402
     CONSOLIDATION,
     EXPANSION,
     SERIES_SCALE_DEFAULT,
+    cited_issues,
     fetch_series_visits,
     zone_balance,
     parent_issue,
@@ -170,31 +171,13 @@ GENRE_RULES: list[tuple[str, str]] = [
 #
 # Mesure du 2026-08-23 sur 10 issues (verite = `gh pr list --search "N
 # in:title,body"` restreint a la fenetre) : le premier-`#N` rappelle 59 %, le
-# schema ci-dessous 76 %. Cas d'ecole : #12591 s'intitule `fix(notebooks,#11947)`
+# schema d'attribution 76 %. Cas d'ecole : #12591 s'intitule `fix(notebooks,#11947)`
 # et porte `See #11947`, mais son premier `#N` de corps est #11949 (la tranche
 # soeur) -- la veine y est juste pour le cap, et fausse pour l'affluence.
-_REF_RE = re.compile(r"#(\d{4,6})\b")
-_PREV_RE = re.compile(r"prev:\s*[^\n]*?#(\d{4,6})\b")
-# Verbes de rattachement de ce depot (`Closes/See/Part of` -- catalog-pr-hygiene)
-# plus les tournures maison. `See #N` porte l'essentiel du travail d'ombrelle :
-# la convention reserve `Closes` a la resolution complete.
-_DECL_RE = re.compile(
-    r"(?:closes|fixes|resolves|see|refs?|part of|voir|ombrelle|epic)"
-    r"\s+#(\d{4,6})\b",
-    re.I)
-
-
-def cited_issues(pr: dict) -> set[int]:
-    """Issues qu'une PR DECLARE servir : refs du titre + clauses de rattachement.
-
-    La clause `prev:` du tag `Grain:` est masquee -- elle documente le grain
-    PRECEDENT de la lane (adjacence G-VAR-3), jamais le sujet de la PR. Sans ce
-    masque, chaque PR voterait pour le sujet de la precedente.
-    """
-    body = _PREV_RE.sub("prev: <adjacence>", pr.get("body") or "")
-    found = {int(m.group(1)) for m in _DECL_RE.finditer(body)}
-    found |= {int(m.group(1)) for m in _REF_RE.finditer(pr.get("title") or "")}
-    return found - {pr.get("number")}
+#
+# `cited_issues` vit dans series_saturation.py (source unique depuis #13435 :
+# declaration de travail vs renvoi de contexte -- un `voir #N` en prose
+# n'amortit plus l'issue citee dans le compteur de visites).
 
 
 NOW = dt.datetime.now(dt.timezone.utc)

--- a/scripts/series_saturation.py
+++ b/scripts/series_saturation.py
@@ -64,9 +64,14 @@ _EPIC_PARENT_RE = re.compile(r"(?:EPIC|Epic|epic|ombrelle)\s*#(\d{4,6})\b")
 
 _REF_RE = re.compile(r"#(\d{4,6})\b")
 _PREV_RE = re.compile(r"prev:\s*[^\n]*?#(\d{4,6})\b")
+# Declaration de travail uniquement (#13435) : le vocabulaire qui DIT servir
+# l'issue. Les renvois de contexte (voir, cf, bare "EPIC #N") sont exclus --
+# mesure fenetre 14 j du 2026-08-29 : 19 rattachements sur 459 (4,1 %, 18
+# PRs) venaient d'un renvoi seul et amortissaient une zone que la PR ne
+# touchait pas. Les formes structurelles restent couvertes via `_PARENT_RE`.
 _DECL_RE = re.compile(
-    r"(?:closes|fixes|resolves|see|refs?|part of|voir|ombrelle|epic)"
-    r"\s+#(\d{4,6})\b",
+    r"(?:closes|fixes|resolves|see|refs?|part of)"
+    r"\s*:?\s*#(\d{4,6})\b",
     re.I,
 )
 
@@ -96,9 +101,20 @@ def cited_issues(pr: dict) -> set[int]:
 
     La clause `prev:` du tag `Grain:` est masquee -- elle documente le grain
     PRECEDENT de la lane (adjacence G-VAR-3), jamais le sujet de la PR.
+
+    Declaration != renvoi de contexte (#13435). Seuls rattaches :
+    (a) le vocabulaire de declaration (`closes|fixes|resolves|see|refs|part
+    of`), (b) les formes structurelles (`Enfant de l'Epic #N`, `Paire 3/9 de
+    l'EPIC #N` -- `_PARENT_RE`), (c) les refs du titre. Un `voir #N` ou un
+    bare `EPIC #N` en prose raconte le contexte historique sans declarer
+    travailler la zone : sur la fenetre 14 j du 2026-08-29 (400 PRs mergees),
+    19 rattachements sur 459 venaient d'un renvoi seul -- chacun amortissait
+    le poids d'une issue neutre et gonflait l'expansion apparente d'une zone
+    deja saturee.
     """
     body = _PREV_RE.sub("prev: <adjacence>", pr.get("body") or "")
     found = {int(m.group(1)) for m in _DECL_RE.finditer(body)}
+    found |= {int(m.group(1)) for m in _PARENT_RE.finditer(body)}
     found |= {int(m.group(1)) for m in _REF_RE.finditer(pr.get("title") or "")}
     return found - {pr.get("number")}
 

--- a/scripts/tests/test_series_saturation.py
+++ b/scripts/tests/test_series_saturation.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Tests de rattachement de `series_saturation.py` (#13435).
+
+Le defaut vise : `_DECL_RE` comptait un renvoi purement referentiel
+(`voir #N`, bare `EPIC #N`) comme une declaration de travail -- la PR se
+voyait rattachee a la zone dominante de l'issue citee, ce qui amortissait le
+poids d'une issue neutre et gonflait l'expansion apparente d'une zone deja
+saturee (reserve Hermes sur #13419, mesure : 19/459 rattachements sur la
+fenetre 14 j du 2026-08-29).
+
+Un detecteur se valide par ses faux negatifs (anti-regression.md) : les
+controles ci-dessous epinglent les DEUX sens -- le renvoi de contexte NE
+rattache PAS, la declaration (et la forme structurelle) rattache.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import series_saturation as ss  # noqa: E402
+
+
+def _pr(body: str = "", title: str = "", number: int = 9999) -> dict:
+    return {"body": body, "title": title, "number": number}
+
+
+def test_context_ref_voir_does_not_attach():
+    """Controle positif du fix : `voir #N` seul ne rattache pas (#13435)."""
+    cited = ss.cited_issues(_pr(body="Contexte historique : voir #12373 pour le recit."))
+    assert 12373 not in cited, f"`voir #N` ne doit pas rattacher, cite={cited}"
+
+
+def test_context_bare_epic_does_not_attach():
+    """Un bare `EPIC #N` en prose ne declare pas servir la zone."""
+    cited = ss.cited_issues(_pr(body="Pourquoi ce bump etait attendu. L'EPIC #4960 suit son cours ailleurs."))
+    assert 4960 not in cited, f"bare `EPIC #N` ne doit pas rattacher, cite={cited}"
+
+
+def test_context_ombrelle_does_not_attach():
+    cited = ss.cited_issues(_pr(body="Cadre general (ombrelle #11268), hors perimetre de cette PR."))
+    assert 11268 not in cited, f"`ombrelle #N` ne doit pas rattacher, cite={cited}"
+
+
+def test_declaration_see_attaches():
+    """La classe declaration rattache toujours (regression guard du split)."""
+    cited = ss.cited_issues(_pr(body="Contribution partielle. See #12373."))
+    assert 12373 in cited, f"`See #N` doit rattacher, cite={cited}"
+
+
+def test_declaration_closes_attaches():
+    cited = ss.cited_issues(_pr(body="Closes #11168."))
+    assert 11168 in cited
+
+
+def test_declaration_refs_attaches():
+    cited = ss.cited_issues(_pr(body="Refs : #12373 (epic)."))
+    assert 12373 in cited, "`Refs :` doit rattacher meme suivi de `(epic)` en parenthese"
+
+
+def test_structural_enfant_de_attaches():
+    """Les formes structurelles restent des declarations (via _PARENT_RE)."""
+    cited = ss.cited_issues(_pr(body="Enfant de l'Epic #12373, paire 4/9."))
+    assert 12373 in cited, f"`Enfant de l'Epic #N` doit rattacher, cite={cited}"
+
+
+def test_structural_paire_de_attaches():
+    cited = ss.cited_issues(_pr(body="Paire 3/9 de l'EPIC #12373."))
+    assert 12373 in cited, f"`Paire N/N de l'EPIC #N` doit rattacher, cite={cited}"
+
+
+def test_title_ref_still_attaches():
+    """Les refs du titre ne dependent pas du split (_REF_RE inchange)."""
+    cited = ss.cited_issues(_pr(body="Rien de special.", title="fix(mgs,#12373): livraison"))
+    assert 12373 in cited
+
+
+def test_prev_grain_line_masked():
+    """La clause `prev:` du tag Grain reste masquee (adjacence != sujet)."""
+    cited = ss.cited_issues(_pr(body="Grain: MED/lean -- lane x:y -- prev: MED/lean #10999\n\nCloses #12373."))
+    assert 10999 not in cited, "prev: ne doit jamais rattacher"
+    assert 12373 in cited
+
+
+def test_saturation_does_not_map_zone_from_context_ref():
+    """Integration : une PR `voir #N` seule ne cree pas d'entree issue->zone."""
+    prs = [{
+        "number": 4242,
+        "title": "feat(x): unrelated work",
+        "body": "Incidemment, voir #12373 pour le contexte.",
+        "files": [{"path": "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/Foo.ipynb",
+                   "additions": 10, "deletions": 0}],
+    }]
+    zones, i2f = ss.saturation(prs)
+    assert 12373 not in i2f, f"renvoi contexte ne doit pas mapper l'issue a une zone, i2f={i2f}"
+    assert "MyIA.AI.Notebooks/Search/Part4-Metaheuristics" in zones
+
+
+def test_saturation_maps_zone_from_declaration():
+    """Integration miroir : `See #N` + depot dans la zone rattache #N."""
+    prs = [{
+        "number": 4243,
+        "title": "feat(x): work",
+        "body": "See #12373.",
+        "files": [{"path": "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/Foo.ipynb",
+                   "additions": 10, "deletions": 0}],
+    }]
+    zones, i2f = ss.saturation(prs)
+    assert i2f.get(12373) == "MyIA.AI.Notebooks/Search/Part4-Metaheuristics"
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #13446

## Summary

`series_saturation.py` rattachait une PR à la zone dominante d'une issue citée sur **n'importe quel** mot du motif `_DECL_RE` — y compris `voir`/`epic`/`ombrelle` en prose de contexte. Une PR qui écrit « voir #12373 » pour du contexte historique se voyait comptée dans `zone_balance` de la zone #12373 : l'issue neutre était amortie et l'expansion apparente d'une zone déjà saturée gonflée (réserve Hermes sur #13419, issue #13435).

## Mesure d'abord (le plan de l'issue, exécuté à la lettre)

Fenêtre 14 j, **400 PRs mergées** (fetch serveur `merged:>=` de `fetch_merged`) : **19 rattachements sur 459 (4,1 %, 18 PRs)** venaient d'un renvoi seul. Tous les échantillons inspectés sont du vrai faux positif (« L'EPIC #4960… », « Voir #8057 », « voir #13138 »).

## Fix

- **Classe declaration seule** : `closes|fixes|resolves|see|refs|part of` (+ deux-points optionnel : la convention FR vivante `Refs : #N` ne matchait **déjà pas** l'ancien motif — trou préexistant comblé) + formes structurelles via `_PARENT_RE` (`Enfant de l'Epic #N`, `Paire 3/9 de l'EPIC #N`).
- **Renvois de contexte exclus** : `voir`, `cf`, bare `epic/ombrelle` en prose.
- **Net post-fix** (re-mesure même fenêtre) : **−15 faux positifs, +2 déclarations réellement ratées** par l'ancien motif.
- **Déduplication** : `pick_idle_grain.py` portait une **copie** du même regex defectueux (compteur d'affluence par issue — même blast radius : un `voir #N` amortissait l'issue dans le picker). Il importe désormais `cited_issues` depuis `series_saturation.py` (source unique). Ses **66 tests passent inchangés**.

## Controles positifs (12 tests, `scripts/tests/test_series_saturation.py`)

Un détecteur se valide par ses faux négatifs — les deux sens épinglés :
- `voir #N` / bare `EPIC #N` / `ombrelle #N` **ne rattachent pas** (3 tests) ;
- `See/Closes/Refs :` **rattachent** (3) ; `Enfant de l'Epic #N` / `Paire N/N de` **rattachent** (2) ; refs titre (1) ; masquage `prev:` (1) ;
- intégration `saturation()` dans les deux sens : renvoi contexte → pas d'entrée issue→zone ; `See #N` + dépôt → zone mappée (2).

## Preuves

- `python -m pytest scripts/tests/test_series_saturation.py scripts/tests/test_pick_idle_grain.py -q` → **78 passed** (12 nouveaux + 66 picker).
- Import vérifié : `pick_idle_grain.cited_issues.__module__ == 'series_saturation'`.
- Mesures avant/après reproduites en local sur la même fenêtre (400 PRs).

## Perimetre

3 fichiers : `scripts/series_saturation.py`, `scripts/pick_idle_grain.py`, `scripts/tests/test_series_saturation.py` (nouveau).

Closes #13435

Co-Authored-By: Claude-Code <noreply@anthropic.com>