### PR TITLE
fix(guards,#13399): le merge-gate B.0 lisait comments[] seul — une levee par review etait invisible

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -1105,6 +1105,21 @@ def review_threads(pr: int) -> list[dict]:
     return out
 
 
+def _names_author(body: str, author: str) -> bool:
+    """``body`` mentionne-t-il ``author`` comme identite, pas par hasard ?
+
+    #13399 : un reviewer tiers n'approuve la reserve d'une lane que s'il NOMME
+    cette lane — sinon un APPROVED generique eteindrait toutes les reserves de
+    la PR. La frontiere de mot est posee par non-caractere d'identite (un login
+    contient `-` et `.`, donc `\\b` est fragile autour d'eux : `clusterManager-Myia`
+    n'a pas de frontiere au tiret). On exige un mot-de-login complet delimitere.
+    """
+    if not body or not author:
+        return False
+    return re.search(r"(?<![A-Za-z0-9_.-])" + re.escape(author) + r"(?![A-Za-z0-9_.-])",
+                     body) is not None
+
+
 def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     """cutoff = mergedAt (audit retro) ou now (gate pre-merge)."""
     commits = [ts(c.get("committedDate")) for c in (pr_data.get("commits") or [])]
@@ -1129,12 +1144,47 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     # d'exclusion can_lift ne s'applique pas — un state APPROVED n'est pas du
     # bruit de protocole, meme depuis un reviewer bot.
     approved_rereviews = [
-        (ts(r.get("submittedAt")), (r.get("author") or {}).get("login", ""), "")
+        (ts(r.get("submittedAt")), (r.get("author") or {}).get("login", ""),
+         r.get("body", ""))
         for r in (pr_data.get("reviews") or [])
         if r.get("state") == "APPROVED"
         and (r.get("author") or {}).get("login", "") not in BOT_LOGINS
     ]
     approved_rereviews = [x for x in approved_rereviews if x[0] is not None]
+
+    def _approved_lifts_reserve(reserve_author: str, reserve_when: datetime,
+                                pr_author: str) -> bool:
+        """Une re-review APPROVED leve-t-elle la reserve de ``reserve_author`` ?
+
+        #13399 — le defaut constate sur #13299 n'etait pas l'absence de re-review,
+        mais le fait que ``approved_rereviews`` ne levait que la reserve dont
+        l'auteur de l'APPROVED etait l'auteur (auto-approbation). Un reviewer
+        TIERS (ai-01) qui approuve en nommant la reserve d'une lane la leve
+        aussi. Le garde-fou #12798 reste : seule l'identite de l'auteur tranche,
+        jamais un commit ni un SAR. Deux voies, toutes posterieures a la reserve :
+
+        1. **Re-review de l'auteur** (``auteur_approved == reserve_author``) :
+           legitime uniquement si l'auteur de la reserve n'est pas l'auteur de la
+           PR. Sous le self-review cap (#12319) l'auteur de la reserve == l'auteur
+           de la PR == jsboige, et une APPROVED de ce compte est une
+           auto-approbation qui demontre rien — refuse.
+        2. **Approbation d'un tiers nommant la reserve** (auteur different de la
+           reserve ET de l'auteur de la PR, corps mentionnant le login de la
+           reserve) : le coordinateur confirme par ecrit que le point de la lane
+           est traite. Un APPROVED completement generique (qui n'identifie pas
+           la reserve) ne leve rien — sinon tout approval d'un coordinateur
+           eteindrait toutes les reserves de la PR.
+        """
+        for (t, app_author, app_body) in approved_rereviews:
+            if t is None or t <= reserve_when:
+                continue
+            if app_author == reserve_author:
+                if reserve_author != pr_author:
+                    return True
+                continue  # auto-approbation self-review : refusee, voir ci-dessous
+            if app_author != pr_author and _names_author(app_body, reserve_author):
+                return True
+        return False
 
     def _lift_eligible(lift_author: str, nit_author: str,
                        lift_body: str = "") -> bool:
@@ -1182,6 +1232,22 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         # une reserve, pas un evenement de levee du signal precedent.
         and classify((c.get("author") or {}).get("login", ""),
                      c.get("body", "")) is None
+    ] + [
+        # #13399 point 2 — symetrie de la levee : une PHRASE de levee portee
+        # par le corps d'une review COMMENTED (et pas un commentaire) devait
+        # aussi compter. Aujourd'hui la pose acceptait commentaire et review,
+        # la levee un seul. Une review APPROVED est deja traitee par
+        # approved_rereviews (etat natif) ; une review COMMENTED qui ecrit
+        # « je leve ma CHANGES_REQUESTED » est une levee comme un commentaire.
+        (ts(r.get("submittedAt")), (r.get("author") or {}).get("login", ""),
+         r.get("body", ""))
+        for r in (pr_data.get("reviews") or [])
+        if r.get("state") == "COMMENTED"
+        and can_lift(r)
+        and has_live_lift(r.get("body", ""))
+        and not _lift_cancelled(_strip_quoted(r.get("body", "")))
+        and classify((r.get("author") or {}).get("login", ""),
+                     r.get("body", "")) is None
     ]
     explicit_lifts = [x for x in explicit_lifts if x[0] is not None]
 
@@ -1239,10 +1305,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
             # (B.0 : ce qui leve une remarque est une phrase). Les nits portes
             # par un COMMENTAIRE gardent le regime general ci-dessous — limite
             # NLP documentee dans can_lift.
-            lifted = any(
-                when < t < cutoff and author == login
-                for (t, author, _) in approved_rereviews
-            ) or any(
+            lifted = _approved_lifts_reserve(login, when, pr_author) or any(
                 when < t < cutoff and _lift_eligible(lifter, login, lift_body)
                 for (t, lifter, lift_body) in explicit_lifts
             )
@@ -1264,9 +1327,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
                     and (lift_author != pr_author
                          or bool(OVERRIDE_LANE.search(lift_body)))
                     for (t, lift_author, lift_body) in explicit_lifts)
-                    or any(
-                    when < t < cutoff and author == login
-                    for (t, author, _) in approved_rereviews)):
+                    or _approved_lifts_reserve(login, when, pr_author)):
                 continue
         # #12319 : meme regime pour un nit porte par un commentaire ou une
         # review COMMENTED (dont chaque reserve Hermes, self-review cap).
@@ -1280,10 +1341,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         elif (any(
                   when < t < cutoff and _lift_eligible(lift_author, login, lift_body)
                   for (t, lift_author, lift_body) in explicit_lifts
-              ) or any(
-                  when < t < cutoff and author == login
-                  for (t, author, _) in approved_rereviews
-              )):
+              ) or _approved_lifts_reserve(login, when, pr_author)):
             continue
         # Un commit poussé après le nit ne le lève PAS à lui seul : sur #10761,
         # le « traitement » était un rebase à 19:41 qui n'adressait aucun des
@@ -1292,6 +1350,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         pushed_after = last_commit is not None and last_commit > when
         blocking.append({
             "kind": kind, "author": login, "src": src,
+            "channel": "review" if src.startswith("review") else "comment",
             "at": when.isoformat(),
             "gap_hours": round((cutoff - when).total_seconds() / 3600.0, 1),
             "code_pushed_after": pushed_after,
@@ -1303,6 +1362,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
             continue
         blocking.append({
             "kind": "INLINE-UNRESOLVED", "author": t["author"], "src": "reviewThread",
+            "channel": "review",
             "at": t.get("createdAt") or "?",
             "where": f"{t.get('path')}:{t.get('line')}",
             "excerpt": _excerpt(t.get("body") or ""),

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -51,13 +51,13 @@ USER_NIT = {
 }
 
 
-def run(comments, commits=None, threads=None):
+def run(comments, commits=None, threads=None, reviews=None, pr_author="jsboige"):
     data = {
         "number": 0,
         "title": "t",
-        "author": {"login": "jsboige"},
+        "author": {"login": pr_author},
         "comments": comments,
-        "reviews": [],
+        "reviews": reviews if reviews is not None else [],
         "commits": commits if commits is not None else [{"committedDate": at(19)}],
     }
     return mod.analyse(data, threads or [], MERGED)
@@ -535,6 +535,125 @@ def test_approved_avant_la_concerne_ne_leve_pas():
         "submittedAt": at(9), "body": "",
     }
     assert run_reviews([early_ok, late_concern])["blocked"] is True
+
+
+# --- #13399 : une levee portee par une REVIEW est aussi visible qu'en
+# commentaire. Le defaut constate sur #13299 : ai-01 pose APPROVED par review
+# en nommant chaque reserve, mais l'organe n'etait capable de lever par re-review
+# que si l'auteur de l'APPROVED etait l'auteur de la reserve (auto-approbation).
+# Un reviewer TIERS qui approuve en nommant la reserve d'un autre la leve aussi.
+# Le garde-fou #12798 reste : c'est l'identite de l'auteur qui tranche.
+
+def test_approval_by_different_reviewer_naming_reserve_leves():
+    """Positif #13299 : reserve en commentaire (lane A), fix, APPROVED en review
+    par un auteur DIFFERENT qui nomme la reserve -> levee (rc=0)."""
+    reserve = {
+        "author": {"login": "po-2026"},
+        "createdAt": at(10),
+        "body": "Verdict : CHANGES_REQUESTED (substance) — sortie degeneree en cell 3.",
+    }
+    fix = {"author": {"login": "jsboige"}, "createdAt": at(12),
+           "body": "cell 3 corrigee, re-exec 5/5."}
+    approval_tierce = {
+        "author": {"login": "ai-01"},
+        "state": "APPROVED", "submittedAt": at(15),
+        "body": ("APPROVED — la reserve de po-2026 (sortie degeneree) est traitee "
+                 "(commit bb573c3819, re-exec 5/5)."),
+    }
+    res = run([reserve, fix], reviews=[approval_tierce])
+    assert res["blocked"] is False
+
+
+def test_approval_by_reserve_author_who_is_pr_author_refused():
+    """Negatif #13399 : si l'auteur de la reserve est l'auteur de la PR, une
+    APPROVED de CE meme compte est une auto-approbation (self-review cap #12319)
+    et ne leve pas. Seul un tiers legitime confirme."""
+    reserve = {
+        "author": {"login": "jsboige"},
+        "createdAt": at(10),
+        "body": "Verdict : CHANGES_REQUESTED (substance) — sortie degeneree en cell 3.",
+    }
+    fix = {"author": {"login": "jsboige"}, "createdAt": at(12),
+           "body": "cell 3 corrigee, re-exec 5/5."}
+    self_approval = {
+        "author": {"login": "jsboige"},
+        "state": "APPROVED", "submittedAt": at(15),
+        "body": "APPROVED.",
+    }
+    res = run([reserve, fix], reviews=[self_approval])
+    assert res["blocked"] is True
+
+
+def test_approval_by_different_reviewer_without_naming_does_not_leve():
+    """Garde-fou : une review APPROVED d'un tiers qui n'identifie pas la reserve
+    (pas de mention de son auteur) ne la leve pas — sinon tout APPROVED d'un
+    coordinateur eteindrait toutes les reserves de la PR."""
+    reserve = {
+        "author": {"login": "po-2026"},
+        "createdAt": at(10),
+        "body": "Verdict : CHANGES_REQUESTED (substance) — sortie degeneree en cell 3.",
+    }
+    fix = {"author": {"login": "jsboige"}, "createdAt": at(12),
+           "body": "cell 3 corrigee."}
+    approval_generique = {
+        "author": {"login": "ai-01"},
+        "state": "APPROVED", "submittedAt": at(15),
+        "body": "APPROVED — le livrable est bon a merger.",
+    }
+    res = run([reserve, fix], reviews=[approval_generique])
+    assert res["blocked"] is True
+
+
+def test_lift_phrase_in_review_commented_leves():
+    """#13399 point 2 : une PHRASE de levee portee par le corps d'une review
+    COMMENTED (et pas un commentaire) leve comme un commentaire — la levee
+    devient symetrique a la pose (qui acceptait deja commentaire et review).
+    La borne d'auteur #11145 reste : la phrase de l'auteur de la reserve leve
+    (ici clusterManager-Myia leve sa propre reserve par une review)."""
+    reserve = {
+        "author": {"login": "clusterManager-Myia"},
+        "state": "COMMENTED", "submittedAt": at(10),
+        "body": "[Hermes] — COMMENT_WITH_CONCERNS\nCI catalog-drift FAIL.",
+    }
+    lift_in_review = {
+        "author": {"login": "clusterManager-Myia"},
+        "state": "COMMENTED", "submittedAt": at(15),
+        "body": "Je leve la CHANGES_REQUESTED — drift corrige au commit c506d04b.",
+    }
+    res = run_reviews([reserve, lift_in_review])
+    assert res["blocked"] is False
+
+
+def test_reserve_in_review_lifted_by_third_party_naming():
+    """Symetrie pose/levee (#13399 point 2) : une reserve posee en REVIEW
+    (COMMENTED, meme surface qu'un __init__ par review) est levee par un tiers
+    APPROVED qui la nomme, comme celle d'un commentaire. La distinction est
+    l'identite de l'auteur, pas le canal."""
+    concern_in_review = {
+        "author": {"login": "po-2026"},
+        "state": "COMMENTED", "submittedAt": at(10),
+        "body": "Verdict : CHANGES_REQUESTED (substance) — sortie degeneree en cell 3.",
+    }
+    approval_tierce = {
+        "author": {"login": "ai-01"},
+        "state": "APPROVED", "submittedAt": at(15),
+        "body": "APPROVED — la reserve de po-2026 (sortie degeneree) est traitee.",
+    }
+    res = run_reviews([concern_in_review, approval_tierce])
+    assert res["blocked"] is False
+
+
+def test_channel_reflects_origin_surface():
+    """#13399 point 3 : le canal de chaque evenement bloqueur est expose
+    (comment vs review), pour qu'un desaccord entre l'organe et une lecture
+    humaine soit diagnosticable sans re-fouiller l'API."""
+    assert run([USER_NIT])["blocking"][0]["channel"] == "comment"
+    assert run_reviews([CONCERN_REVIEW])["blocking"][0]["channel"] == "review"
+    # un thread inline non resolu releve du canal review (surface GitHub review)
+    thread = {"author": "jsboige", "body": "ligne 3 a revoir",
+              "resolved": False, "outdated": False,
+              "createdAt": at(11), "path": "a/b.ipynb", "line": 3}
+    assert run([], threads=[thread])["blocking"][0]["channel"] == "review"
 
 
 # --- #11201 : le faux negatif « corrige X et je merge ». Le test LIFT_MARKERS


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13449

Closes #13399.

## Contexte

Le gate B.0 (`check_unaddressed_nits.py`) ne parcourait que `comments[]` pour les
**levees**. Une reserve levee par une **review** (`reviews[].state APPROVED`) ou une
phrase de levee portee par une review COMMENTED restait invisible : l'organe ne
levait la reserve que si l'auteur de l'APPROVED **etait** l'auteur de la reserve
(auto-approbation). Sequence reelle #13299 : ai-01 pose APPROVED par review en
nommant chaque reserve — le gate rendait quand meme rc=1 (seule la mention d'un
commit posterior pouvait lever), et il a ete franchi rouge. La levee a ete ecrite
apres le merge.

## Correction

1. **`+` levee par APPROVED d'un tiers nommant la reserve** — si le corps de la
   review APPROVED mentionne l'auteur de la reserve (et cet auteur n'est ni la
   reserve ni l'auteur de la PR), la reserve est levee.
2. **`+` garde-fou #12798 conserve** — une auto-approbation de l'auteur de la
   reserve **quand il est aussi l'auteur de la PR** (self-review cap #12319) ne
   leve pas : c'est l'identite de l'auteur qui tranche, pas le canal.
3. **`+` symetrie de levee** — une phrase de levee dans le corps d'une review
   COMMENTED compte comme un commentaire (la pose acceptait deja les deux canaux,
   la levee un seul).
4. **`+` champ `channel`** expose dans chaque `blocking[]` (`comment`/`review`),
   pour qu'un desaccord organe / lecture humaine soit diagnosticable sans
   re-fouiller l'API.

## Tests

- 217 (gate) + 386 (importeurs transitifs) **pass** ; 5 nouveaux.
- Nouveaux : positif #13299 (reserve commentaire + APPROVED tiers nommant) ;
  negatif (auto-approbation auteur PR) ; garde-fou (tiers APPROVED **sans**
  nommer → pas de levee) ; symetrie (phrase de levee en review COMMENTED) ;
  `channel`.
- Smoke CLI sur #13449 : le vrai nit residuel reste bloque (channel `review`) —
  aucun faux positif introduit.

## Note sur la rejoue #13216

Le point d'acceptation « rejouer sur #13216 » est devenu non-rejouable : la PR
#13230 (coin de la duplication) est **MERGED** — les deux lanes ne sont plus en
concurrence. Le **mecanisme** qui a produit la duplication (une levee par review
invisible, la lane ne voyant pas l'autre comme bloquante) est rejoue par le test
unitaire positif, qui est plus robuste qu'une rejouee sur un etat qui a evolue.

See #9774, #12319, #12386, #13299, #13336.