### PR TITLE
docs(lean,#13402): franciser GameTheory/LEAN_INVENTORY (tranche 4/4)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
@@ -1,69 +1,69 @@
-# Lean 4 Projects Inventory — GameTheory
+# Inventaire des projets Lean 4 — `GameTheory`
 
-Cross-directory inventory of all Lean 4 formalization projects under `GameTheory/`.
+Inventaire transverse de tous les projets de formalisation Lean 4 sous `GameTheory/`.
 
 Réconcilié le 2026-08-26 contre les pins effectifs (`lean-toolchain`, `lake-manifest.json`) et le
 module-set réel du disque (issue #13138). Comptes `sorry` mesurés avec l'instrument canonique
 `scripts/lean/count_code_sorry.py --json` (champ `distinct_code_sorry`), jamais `grep -c sorry`.
 
-## Summary
+## Résumé
 
 **Lakes actifs (8)** :
 
-| Directory | Toolchain | Production sorry | Modules | Status |
-|-----------|-----------|-----------------|---------|--------|
-| `game_theory_lean` | v4.32.1 | 1 (Folk stretch, #4880) | StableMarriage + CooperativeGames + SocialChoice + RepeatedGames + Swaps (49 `.lean` FR+EN) | COMPLETE (EPIC #4365) |
-| `lean_game_defs` | v4.32.1 | 0 | 12 (6 FR + 6 `_en`) | COMPLETE (shared defs) |
-| `lean_game_defs_ext` | v4.32.1 | 0 | Bayesian/* 24 (12 FR + 12 `_en`) + 2 umbrellas | COMPLETE |
-| `minimax_lean` | v4.32.1 | 0 | ZeroSum + Concavity + SionApplication (+ `_en`) | COMPLETE |
-| `assignment_lean` | v4.32.1 | 0 | Definitions / Duality / KuhnMunkres / Optimality (+ `_en`) | COMPLETE (#12598) |
-| `asymmetric_information_lean` | v4.32.1 | 0 | Lemons / Signaling / Screening / MiyazakiWilson / BayesianLink (+ `_en`) | COMPLETE (Epic #12844) |
-| `social_choice_lean_peters` | v4.32.1 | 0 | PetersTour (+ `_en`) | Reference only |
-| `conway_cgt_lean` | v4.31.0-rc2 | 0 | CGTTour (+ `_en`) | Reference tour |
+| Répertoire | Toolchain | sorry (production) | Modules | Statut |
+|-----------|-----------|--------------------|---------|--------|
+| `game_theory_lean` | v4.32.1 | 1 (stretch Folk, #4880) | StableMarriage + CooperativeGames + SocialChoice + RepeatedGames + Swaps (49 `.lean` FR+EN) | COMPLET (EPIC #4365) |
+| `lean_game_defs` | v4.32.1 | 0 | 12 (6 FR + 6 `_en`) | COMPLET (defs partagés) |
+| `lean_game_defs_ext` | v4.32.1 | 0 | Bayesian/* 24 (12 FR + 12 `_en`) + 2 umbrellas | COMPLET |
+| `minimax_lean` | v4.32.1 | 0 | ZeroSum + Concavity + SionApplication (+ `_en`) | COMPLET |
+| `assignment_lean` | v4.32.1 | 0 | Definitions / Duality / KuhnMunkres / Optimality (+ `_en`) | COMPLET (#12598) |
+| `asymmetric_information_lean` | v4.32.1 | 0 | Lemons / Signaling / Screening / MiyazakiWilson / BayesianLink (+ `_en`) | COMPLET (Epic #12844) |
+| `social_choice_lean_peters` | v4.32.1 | 0 | PetersTour (+ `_en`) | Référence seule |
+| `conway_cgt_lean` | v4.31.0-rc2 | 0 | CGTTour (+ `_en`) | Tour de référence |
 
 **Tombstones (absorbés, EPIC #4365)** :
 
-| Directory | Devenir |
+| Répertoire | Devenir |
 |-----------|---------|
 | ~~`cooperative_games_lean`~~ | **Supprimé** (rm #6587) → [`game_theory_lean/CooperativeGames/`](game_theory_lean/CooperativeGames/) |
 | ~~`social_choice_lean`~~ | Absorbé (#6058, 2026-07-11) → [`game_theory_lean/SocialChoice/`](game_theory_lean/SocialChoice/) — ne subsistent que 4 markdown tombstone |
 | ~~`repeated_games_lean`~~ | Absorbé (#6146) → [`game_theory_lean/RepeatedGames/`](game_theory_lean/RepeatedGames/) — coquille archive conservée (lakefile neutralisé, 0 module) |
 
-Note: `SymbolicAI/Lean/examples/llm_assisted_proof.lean` (2 sorry) is a pedagogical example, not production. `asymmetric_information_lean` carries 2 *naive* sorry (prose/docstrings) for 0 real code sorry.
+Note : `SymbolicAI/Lean/examples/llm_assisted_proof.lean` (2 sorry) est un exemple pédagogique, pas du code de production. `asymmetric_information_lean` porte 2 *naive* sorry (prose/docstrings) pour 0 vrai sorry de code.
 
-**Conway tribute series relocated**: `conway_lean/` (Conway hommage — Doomsday, FRACTRAN, Look-and-Say, Nim, Angel) was moved to [`SymbolicAI/Lean/conway_lean/`](../SymbolicAI/Lean/conway_lean/) since it formalizes lesser-known Conway results (not game-theoretic content per se). The prover calibration targets defined in `agent_tests/prover/config.py` follow the new path.
+**Série hommage Conway déplacée** : `conway_lean/` (hommage Conway — Doomsday, FRACTRAN, Look-and-Say, Nim, Angel) a été déplacé vers [`SymbolicAI/Lean/conway_lean/`](../SymbolicAI/Lean/conway_lean/) car il formalise des résultats Conway moins connus (pas du contenu game-théorique en soi). Les cibles de calibration du prover définies dans `agent_tests/prover/config.py` suivent le nouveau chemin.
 
-**Calibration relocated**: `calibration_lean/` was moved to [`SymbolicAI/Lean/calibration_lean/`](../SymbolicAI/Lean/calibration_lean/) (issue #1764) since it is a prover harness component, not game-theoretic content.
+**Calibration déplacée** : `calibration_lean/` a été déplacé vers [`SymbolicAI/Lean/calibration_lean/`](../SymbolicAI/Lean/calibration_lean/) (issue #1764) car c'est un composant de harnais prover, pas du contenu game-théorique.
 
 ---
 
-## Directories
+## Par lake
 
 ### 1. game_theory_lean
 
-**EPIC #4365 (phase 4)**: multi-module target lake, pôle d'absorption GT 6→2. A absorbé :
+**EPIC #4365 (phase 4)** : lake cible multi-module, pôle d'absorption GT 6→2. A absorbé :
 `stable_marriage_lean/` (supprimé, PRs #5904/#5905/#5910/#5911/#5913), `cooperative_games_lean/`
 (rm #6587), `social_choice_lean/` (#6058), `repeated_games_lean/` (#6146). Le lake porte
 également `Swaps` (grain #12222, compagnon du notebook GameTheory-03a).
 
-**Objective**: Formalize the GameTheory curriculum — cooperative games (Shapley, core), Gale-Shapley stable marriage, social choice (Arrow, Sen, median voter), repeated games (folk theorem), swap paths on 2×2 ordinal games.
+**Objectif** : formaliser le curriculum GameTheory — jeux coopératifs (Shapley, cœur), mariage stable de Gale-Shapley, choix social (Arrow, Sen, électeur médian), jeux répétés (théorème folk), chemins d'échange sur jeux ordinaux 2×2.
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4
 
-| Module group | sorry | Content |
+| Groupe de modules | sorry | Contenu |
 |--------------|-------|---------|
-| `StableMarriage/` (5 FR + 5 `_en`) | 0 | GS algorithm, termination, stability, `exists_isManOptimal`, woman_pessimal, Knuth lattice + refutations of former false statements |
-| `CooperativeGames/` (3 FR + 3 `_en`) | 0 | TU games, Core, `bondareva_shapley : Core.Nonempty ↔ Balanced`, Shapley value (Möbius decomposition), cone-separation machinery |
-| `SocialChoice/` (9 FR + 8 `_en`) | 0 | Arrow (Geanakoplos 2005), Sen's Liberal Paradox, median voter / Split Cycle / clones, Vickrey truthfulness, AMD, `PrefOrder`/`Profile`/SWF core |
+| `StableMarriage/` (5 FR + 5 `_en`) | 0 | algorithme GS, terminaison, stabilité, `exists_isManOptimal`, `woman_pessimal`, treillis de Knuth + réfutations d'anciens énoncés faux |
+| `CooperativeGames/` (3 FR + 3 `_en`) | 0 | jeux à transferts (TU), Core, `bondareva_shapley : Core.Nonempty ↔ Balanced`, valeur de Shapley (décomposition de Möbius), machinerie de séparation par cônes |
+| `SocialChoice/` (9 FR + 8 `_en`) | 0 | Arrow (Geanakoplos 2005), paradoxe libéral de Sen, électeur médian / Split Cycle / clones, véracité Vickrey, AMD, cœur `PrefOrder`/`Profile`/SWF |
 | `RepeatedGames/` (4 FR + 4 `_en`) | 1 (stretch) | `grim_trigger_sustains_iff` (théorème-phare, 0 sorry) ; `folk_theorem_discounted` / `folk_theorem_boundary` portent 1 sorry stretch (#4880) |
 | `Swaps/` (FR-only) | 0 | `Table`, générateurs adjacents, certificat de chemin, `distance_dilemme_chicken` |
 
-**Build**: `lake build` — SUCCESS. CI: `lean-game-theory.yml`, `lean-social-choice.yml`.
+**Compilation** : `lake build` — SUCCESS. CI : `lean-game-theory.yml`, `lean-social-choice.yml`.
 
-**Key proofs**:
-- `gale_shapley_stable` — PR #1194 ; `exists_isManOptimal` (honest, via minimal-weight on join semilattice) ; `woman_pessimal` — PR #1521 ; `meetSpouse_injective` / `joinSpouse_injective` — PR #1522
-- `no_cross_match_is_false` / `doctor_optimal_eq_top_is_false` — kernel-checked refutations of former false statements
-- `bondareva_shapley` (`Core.Nonempty ↔ Balanced`) — fully proved, no added axiom (compact-slice Weierstrass, #3954)
+**Preuves clés** :
+- `gale_shapley_stable` — PR #1194 ; `exists_isManOptimal` (honnête, via poids minimal sur le demi-treillis des jointures) ; `woman_pessimal` — PR #1521 ; `meetSpouse_injective` / `joinSpouse_injective` — PR #1522
+- `no_cross_match_is_false` / `doctor_optimal_eq_top_is_false` — réfutations vérifiées au kernel d'anciens énoncés faux
+- `bondareva_shapley` (`Core.Nonempty ↔ Balanced`) — prouvé intégralement, aucun axiome ajouté (tranches compactes + Weierstrass, #3954)
 - `grim_trigger_sustains_iff` — FORMAL-CERTIFIED, 0 sorry
 
 ---
@@ -76,221 +76,221 @@ Note: `SymbolicAI/Lean/examples/llm_assisted_proof.lean` (2 sorry) is a pedagogi
 > section ci-dessous est conservée comme trace d'audit du statut de preuve (0 sorry, préservé
 > dans la cible). Pour l'état courant, voir [§1. game_theory_lean](#1-game_theory_lean).
 
-**Status at removal**: COMPLETE (0 sorry). `bondareva_shapley` fully proved — the backward
-direction's attainment crux `hb_witness` closed by PR #3954 via a compact-slice Weierstrass
-argument, bypassing the missing Mathlib `ProperCone.hyperplane_separation` without any added
-axiom. Lineage: #3933 (cone kernel) → #3941 (bridge) → #3945 (decoding) → #3951 (`hb_strict`) →
-#3954 (attainment).
+**Statut à la suppression** : COMPLET (0 sorry). `bondareva_shapley` prouvé intégralement — le
+crux d'atteinte `hb_witness` de la direction retour a été clos par la PR #3954 via un argument
+tranches compactes + Weierstrass, contournant le `ProperCone.hyperplane_separation` manquant de
+Mathlib sans aucun axiome ajouté. Lignage : #3933 (cone kernel) → #3941 (bridge) → #3945
+(decoding) → #3951 (`hb_strict`) → #3954 (attainment).
 
 ---
 
 ### 3. ~~social_choice_lean~~ — Absorbé (#6058)
 
 > **⚑ Tombstone documentaire — home canonique déplacé.** Depuis la PR #6058 (EPIC #4365
-> Phase-4, 2026-07-11), les sept modules (Basic, Framework, Arrow, Sen, Voting,
-> MechanismDesign, SortedListCounting) ont été absorbés byte-identique dans
-> [`game_theory_lean/SocialChoice/`](game_theory_lean/SocialChoice/) (FR canonique + miroirs
-> `_en.lean` Pattern A #4980). **Ce répertoire n'est plus un lake** — la coquille technique
-> (`lakefile.lean`, `lean-toolchain`, `lake-manifest.json`) a été retirée ; ne subsistent que
-> 4 markdown (`README`, `STATUS`, `NOTICE`, `LEAN_PREREQUISITES`) conservés comme tombstone.
+Phase-4, 2026-07-11), les sept modules (Basic, Framework, Arrow, Sen, Voting,
+MechanismDesign, SortedListCounting) ont été absorbés byte-identique dans
+[`game_theory_lean/SocialChoice/`](game_theory_lean/SocialChoice/) (FR canonique + miroirs
+`_en.lean` Pattern A #4980). **Ce répertoire n'est plus un lake** — la coquille technique
+(`lakefile.lean`, `lean-toolchain`, `lake-manifest.json`) a été retirée ; ne subsistent que
+4 markdown (`README`, `STATUS`, `NOTICE`, `LEAN_PREREQUISITES`) conservés comme tombstone.
 
-**Status (historique, préservé dans le home canonique)**: COMPLETE, 0 sorry — Arrow's
-Impossibility (Geanakoplos 2005), Sen's Liberal Paradox, Median Voter / Split Cycle / clones,
-Vickrey truthfulness + first-price counter-example (#1469). Build repris par
+**Statut (historique, préservé dans le home canonique)** : COMPLET, 0 sorry — impossibilité
+d'Arrow (Geanakoplos 2005), paradoxe libéral de Sen, électeur médian / Split Cycle / clones,
+véracité Vickrey + contre-exemple au premier prix (#1469). Build repris par
 `.github/workflows/lean-social-choice.yml` sur `game_theory_lean`.
 
 ---
 
 ### 4. social_choice_lean_peters
 
-**Objective**: Reference project importing DominikPeters/SocialChoiceLean as a Lake dependency.
+**Objectif** : projet de référence important DominikPeters/SocialChoiceLean comme dépendance Lake.
 
-**Toolchain**: v4.32.1 (convergé avec le parc depuis #12134, 2026-08-21) | **Dependencies**: Mathlib4 (`520045ab`), SocialChoiceLean `94a4c650` (revs effectives du `lake-manifest.json`)
+**Toolchain** : v4.32.1 (convergé avec le parc depuis #12134, 2026-08-21) | **Dépendances** : Mathlib4 (`520045ab`), SocialChoiceLean `94a4c650` (revs effectives du `lake-manifest.json`)
 
-| File | sorry | Description |
+| Fichier | sorry | Description |
 |------|-------|-------------|
-| `PetersTour.lean` + `PetersTour_en.lean` | 0 | Curated tour of Peters' formalized results (i18n #4980) |
+| `PetersTour.lean` + `PetersTour_en.lean` | 0 | Tour curaté des résultats formalisés de Peters (i18n #4980) |
 
-**Build**: `lake build` — SUCCESS | **Reference only, not for proving**
+**Compilation** : `lake build` — SUCCESS | **Référence seule, pas une cible de preuve**
 
-**Content**: Imports Peters' library (Gibbard-Satterthwaite, Duggan-Schwartz, 4 Condorcet impossibilities, 15+ voting rules with axiom verification). Backend Lake for the (planned, not yet created) SocialChoiceLean tour companion notebook.
+**Contenu** : importe la bibliothèque de Peters (Gibbard-Satterthwaite, Duggan-Schwartz, 4 impossibilités de Condorcet, 15+ règles de vote avec vérification d'axiomes). Lake de support du notebook compagnon du tour SocialChoiceLean (prévu, pas encore créé).
 
-**Relationship to `social_choice_lean` (absorbé)**: Complementary, not duplicate. Notre cadre historique utilisait un `PrefOrder` custom (nos preuves, désormais dans `game_theory_lean/SocialChoice/`) ; ce lake expose le `LinearOrder` de Peters (référence externe). Both kept for pedagogical completeness.
+**Relation avec `social_choice_lean` (absorbé)** : complémentaire, pas un doublon. Notre cadre historique utilisait un `PrefOrder` custom (nos preuves, désormais dans `game_theory_lean/SocialChoice/`) ; ce lake expose le `LinearOrder` de Peters (référence externe). Les deux sont conservés par complétude pédagogique.
 
 ---
 
 ### 5. ~~repeated_games_lean~~ — Absorbé (#6146)
 
 > **⚑ Archive — home canonique déplacé.** Depuis la PR #6146 (EPIC #4365 Phase-4), les quatre
-> modules sources (`Stage`, `Discounting`, `GrimTrigger`, `Folk`) ont été absorbés
-> byte-identique dans [`game_theory_lean/RepeatedGames/`](game_theory_lean/RepeatedGames/).
-> Ce répertoire est conservé comme **coquille archive** : `package`, `require mathlib`,
-> manifest et documentation restent présents, mais la `lean_lib` est neutralisée dans le
-> `lakefile.lean` (ses globs matchaient 0 fichier depuis le déménagement). Certification et
-> build repris par `game_theory_lean` (`.github/workflows/lean-game-theory.yml`).
+modules sources (`Stage`, `Discounting`, `GrimTrigger`, `Folk`) ont été absorbés
+byte-identique dans [`game_theory_lean/RepeatedGames/`](game_theory_lean/RepeatedGames/).
+Ce répertoire est conservé comme **coquille archive** : `package`, `require mathlib`,
+manifest et documentation restent présents, mais la `lean_lib` est neutralisée dans le
+`lakefile.lean` (ses globs matchaient 0 fichier depuis le déménagement). Certification et
+build repris par `game_theory_lean` (`.github/workflows/lean-game-theory.yml`).
 
-**Status (historique, préservé dans le home canonique)**: `grim_trigger_sustains_iff`
-(sustains a subgame-perfect Nash iff δ ≥ threshold) fully proved, 0 sorry. The Folk theorem
-(`folk_theorem_discounted`) carries 1 stretch sorry, tolerated per #4880.
+**Statut (historique, préservé dans le home canonique)** : `grim_trigger_sustains_iff`
+(préserve un Nash parfait en sous-jeux ssi δ ≥ seuil) prouvé intégralement, 0 sorry. Le théorème
+Folk (`folk_theorem_discounted`) porte 1 sorry stretch, toléré au titre de #4880.
 
 ---
 
 ### 6. minimax_lean
 
-**Objective**: Formalize the two-player zero-sum game minimax setting — payoff bilinearity, concavity, and the Sion minimax application.
+**Objectif** : formaliser le cadre minimax des jeux à somme nulle à deux joueurs — bilinéarité des paiements, concavité, et application du minimax de Sion.
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4
 
-| File | sorry | Description |
+| Fichier | sorry | Description |
 |------|-------|-------------|
-| `Minimax/ZeroSum.lean` (+ `_en`) | 0 | Zero-sum payoff structure, bilinearity (`payoff_add_in_x`, `smul`), `continuous_payoff`; saddle-point existence derived from Mathlib's Sion minimax |
-| `Minimax/Concavity.lean` (+ `_en`) | 0 | Concavity lemmas feeding the Sion application |
-| `Minimax/SionApplication.lean` (+ `_en`) | 0 | Sion minimax application to the mixed-strategy saddle point |
+| `Minimax/ZeroSum.lean` (+ `_en`) | 0 | structure de paiement à somme nulle, bilinéarité (`payoff_add_in_x`, `smul`), `continuous_payoff` ; existence du point-selle dérivée du minimax de Sion de Mathlib |
+| `Minimax/Concavity.lean` (+ `_en`) | 0 | lemmes de concavité alimentant l'application de Sion |
+| `Minimax/SionApplication.lean` (+ `_en`) | 0 | application du minimax de Sion au point-selle en stratégies mixtes |
 
-**Build**: `lake build Minimax` — SUCCESS | **COMPLETE: 0 sorry**
+**Compilation** : `lake build Minimax` — SUCCESS | **COMPLET : 0 sorry**
 
-**Key facts**: payoff bilinearity and continuity proven 0 sorry; **saddle-point existence** (`∃ mixed strategies, max_x min_y = min_y max_x`) is *derived* from Mathlib's Sion minimax theorem — documented and proved, **not** left as a `sorry`.
+**Faits clés** : bilinéarité et continuité des paiements prouvées 0 sorry ; **l'existence du point-selle** (`∃ mixed strategies, max_x min_y = min_y max_x`) est *dérivée* du théorème minimax de Sion de Mathlib — documentée et prouvée, **pas** laissée en `sorry`.
 
 ---
 
 ### 7. lean_game_defs
 
-**Objective**: Shared game-theoretic type definitions (normal-form games, Bayesian games, combinatorial games, social choice, regret) — the foundational layer reused by the GT Lean notebooks. Self-contained (core Lean only, zero Mathlib dependency).
+**Objectif** : définitions de types partagées pour la théorie des jeux (jeux sous forme normale, jeux bayésiens, jeux combinatoires, choix social, regret) — la couche fondation réutilisée par les notebooks GT Lean. Autonome (Lean core seul, zéro dépendance Mathlib).
 
-**Toolchain**: v4.32.1 | **Dependencies**: Lean core (Mathlib-free)
+**Toolchain** : v4.32.1 | **Dépendances** : Lean core (sans Mathlib)
 
-| File (FR + `_en` sibling) | sorry | Description |
+| Fichier (FR + jumeau `_en`) | sorry | Description |
 |---------------------------|-------|-------------|
-| `LeanGameDefs/Basic.lean` | 0 | NormalFormGame / FiniteGame / Game2x2 core types |
-| `LeanGameDefs/Nash.lean` | 0 | Nash equilibrium, best response, strict dominance |
-| `LeanGameDefs/Bayesian.lean` | 0 | Bayesian game types |
-| `LeanGameDefs/Combinatorial.lean` | 0 | Combinatorial game types, minimax |
-| `LeanGameDefs/SocialChoice.lean` | 0 | Social choice primitives (`dictatorship_satisfies_pareto`, `dictatorship_satisfies_iia`) |
-| `LeanGameDefs/Regret.lean` | 0 | Regret / CFR definitions |
+| `LeanGameDefs/Basic.lean` | 0 | types fondamentaux NormalFormGame / FiniteGame / Game2x2 |
+| `LeanGameDefs/Nash.lean` | 0 | équilibre de Nash, meilleure réponse, dominance stricte |
+| `LeanGameDefs/Bayesian.lean` | 0 | types de jeux bayésiens |
+| `LeanGameDefs/Combinatorial.lean` | 0 | types de jeux combinatoires, minimax |
+| `LeanGameDefs/SocialChoice.lean` | 0 | primitives de choix social (`dictatorship_satisfies_pareto`, `dictatorship_satisfies_iia`) |
+| `LeanGameDefs/Regret.lean` | 0 | définitions regret / CFR |
 
-**Build**: `lake build LeanGameDefs` — SUCCESS (CI `lean-game-defs.yml` + `lean-game-defs-ext.yml`) | **COMPLETE: 0 sorry, Mathlib-free**
+**Compilation** : `lake build LeanGameDefs` — SUCCESS (CI `lean-game-defs.yml` + `lean-game-defs-ext.yml`) | **COMPLET : 0 sorry, sans Mathlib**
 
-**Status**: Lake autonome depuis #2752 (`lakefile.toml`, `lean-toolchain` pinné v4.32.1, `lake-manifest.json`, CI dédiée). Infrastructural definitions layer (2 theorems verifying dictatorship axioms), backend for the GT Lean notebooks. `lean_game_defs_ext` (next) extends it with Bayesian mechanism-design proofs.
+**Statut** : lake autonome depuis #2752 (`lakefile.toml`, `lean-toolchain` pinné v4.32.1, `lake-manifest.json`, CI dédiée). Couche de définitions infrastructurelle (2 théorèmes vérifiant les axiomes de dictature), support des notebooks GT Lean. `lean_game_defs_ext` (suivant) l'étend avec des preuves de design de mécanismes bayésiens.
 
 ---
 
 ### 8. lean_game_defs_ext
 
-**Objective**: Bayesian games & mechanism design — Vickrey truthfulness, Bayesian-Nash equilibrium, auctions, reputation, fictitious play, regret. Extension of `lean_game_defs` (shared definitions), Mathlib-free.
+**Objectif** : jeux bayésiens & design de mécanismes — véracité Vickrey, équilibre bayésien de Nash, enchères, réputation, jeu fictif, regret. Extension de `lean_game_defs` (définitions partagées), sans Mathlib.
 
-**Toolchain**: v4.32.1 | **Dependencies**: Lean core (Mathlib-free)
+**Toolchain** : v4.32.1 | **Dépendances** : Lean core (sans Mathlib)
 
-| File (FR + `_en` sibling) | sorry | Description |
+| Fichier (FR + jumeau `_en`) | sorry | Description |
 |---------------------------|-------|-------------|
-| `Bayesian/Types.lean` | 0 | Bayesian game type definitions |
-| `Bayesian/BNE.lean` | 0 | Bayesian-Nash equilibrium framework + refinement |
-| `Bayesian/Vickrey.lean` | 0 | Vickrey (second-price auction) truthfulness theorem |
-| `Bayesian/Auction.lean` | 0 | Auction mechanisms |
-| `Bayesian/Information.lean` + `InfoGames.lean` | 0 | Information structures, info games |
-| `Bayesian/Reputation.lean` | 0 | Reputation dynamics |
-| `Bayesian/FictitiousPlay.lean` + `Regret.lean` | 0 | Fictitious play, regret minimization |
-| `Bayesian/Max.lean` + `Sum.lean` | 0 | Max/sum helpers |
-| `Bayesian/Examples.lean` | 0 | Worked examples |
+| `Bayesian/Types.lean` | 0 | définitions de types de jeux bayésiens |
+| `Bayesian/BNE.lean` | 0 | cadre d'équilibre bayésien de Nash + raffinement |
+| `Bayesian/Vickrey.lean` | 0 | théorème de véracité de Vickrey (enchère au second prix) |
+| `Bayesian/Auction.lean` | 0 | mécanismes d'enchère |
+| `Bayesian/Information.lean` + `InfoGames.lean` | 0 | structures d'information, jeux d'information |
+| `Bayesian/Reputation.lean` | 0 | dynamique de réputation |
+| `Bayesian/FictitiousPlay.lean` + `Regret.lean` | 0 | jeu fictif, minimisation du regret |
+| `Bayesian/Max.lean` + `Sum.lean` | 0 | auxiliaires max/somme |
+| `Bayesian/Examples.lean` | 0 | exemples résolus |
 
-**Build**: `lake build` — SUCCESS | **COMPLETE: 0 sorry, no Mathlib**
+**Compilation** : `lake build` — SUCCESS | **COMPLET : 0 sorry, sans Mathlib**
 
-**Status**: Vickrey truthfulness (second-price auction dominant strategy = truthful bidding) proved 0 sorry, Mathlib-free. Backend for the Lean-11b BayesianGamesExt companion notebook.
+**Statut** : véracité Vickrey (stratégie dominante de l'enchère au second prix = enchérir sincèrement) prouvée 0 sorry, sans Mathlib. Support du notebook compagnon Lean-11b BayesianGamesExt.
 
 ---
 
 ### 9. conway_cgt_lean
 
-**Objective**: Reference tour of combinatorial game theory (surreal numbers, partizan games, nimbers) as formalized in [`vihdzp/combinatorial-games`](https://github.com/vihdzp/combinatorial-games), imported as a Lake dependency. Upstream is the current home of CGT in Lean after Mathlib's CGT modules (`SetTheory.Surreal`/`PGame`/`Game`/`Nimber`) were deprecated (#28063, Aug 2025) then removed (#35550, Feb 2026). Reference: Conway, *On Numbers and Games* (2001).
+**Objectif** : tour de référence de la théorie combinatoire des jeux (nombres surréels, jeux partisans, nimbers) telle que formalisée dans [`vihdzp/combinatorial-games`](https://github.com/vihdzp/combinatorial-games), importée comme dépendance Lake. L'amont est le home actuel de la CGT en Lean après que les modules CGT de Mathlib (`SetTheory.Surreal`/`PGame`/`Game`/`Nimber`) ont été dépréciés (#28063, août 2025) puis retirés (#35550, février 2026). Référence : Conway, *On Numbers and Games* (2001).
 
-**Toolchain**: v4.31.0-rc2 (tracks the upstream repo) | **Dependencies**: Mathlib4 + CombinatorialGames (Apache-2.0, `3c6dcdbc`)
+**Toolchain** : v4.31.0-rc2 (suit le dépôt amont) | **Dépendances** : Mathlib4 + CombinatorialGames (Apache-2.0, `3c6dcdbc`)
 
-| File | sorry | Description |
+| Fichier | sorry | Description |
 |------|-------|-------------|
-| `CGTTour.lean` + `CGTTour_en.lean` | 0 | Tour of `IGame`/`Game` (concrete pre-games + quotient), `Surreal` (simplicity theorem), `Nimber` (Sprague-Grundy), with a Mathlib-vs-upstream comparison table |
+| `CGTTour.lean` + `CGTTour_en.lean` | 0 | tour de `IGame`/`Game` (pré-jeux concrets + quotient), `Surreal` (théorème de simplicité), `Nimber` (Sprague-Grundy), avec tableau comparatif Mathlib-vs-amont |
 
-**Build**: `lake build CGTTour` — SUCCESS | **Reference tour, 0 sorry**
+**Compilation** : `lake build CGTTour` — SUCCESS | **Tour de référence, 0 sorry**
 
-**Status**: Reference / pedagogical tour, not a proving target. Exhibits the upstream API via `#check` + docstrings rather than proving new CGT theorems.
+**Statut** : tour de référence / pédagogique, pas une cible de preuve. Expose l'API amont via `#check` + docstrings plutôt que de prouver de nouveaux théorèmes CGT.
 
 ---
 
 ### 10. assignment_lean
 
-**Objective**: Correction skeleton of the Kuhn-Munkres (Hungarian) assignment algorithm — companion lake of the notebook GameTheory-27-Munkres-Assignment, hommage à James R. Munkres (1930-2026). Issue #12598 (1/3). The primal (cost matrix, perfect matching, value), the dual (potentials, feasibility, **weak duality**), the zero-gap optimality certificate, and the algorithm's structural invariants (equality graph, **output invariant**, **Hungarian tightening preserves dual feasibility**). Termination and O(n³) complexity deliberately out of scope.
+**Objectif** : squelette de correction de l'algorithme d'affectation de Kuhn-Munkres (hongrois) — lake compagnon du notebook GameTheory-27-Munkres-Assignment, hommage à James R. Munkres (1930-2026). Issue #12598 (1/3). Le primal (matrice de coûts, couplage parfait, valeur), le dual (potentiels, faisabilité, **dualité faible**), le certificat d'optimalité à écart nul, et les invariants structurels de l'algorithme (graphe d'égalité, **invariant de sortie**, **le serrage hongrois préserve la faisabilité duale**). Terminaison et complexité O(n³) volontairement hors scope.
 
-**Toolchain**: v4.32.1 | **Dependencies**: Mathlib4
+**Toolchain** : v4.32.1 | **Dépendances** : Mathlib4
 
-| File (FR + `_en` sibling) | sorry | Description |
+| Fichier (FR + jumeau `_en`) | sorry | Description |
 |---------------------------|-------|-------------|
-| `Assignment/Definitions.lean` | 0 | Cost matrix, perfect matching (permutation), value, optimality (`value`, `IsOptimal`) |
-| `Assignment/Duality.lean` | 0 | Dual potentials `u`/`v`, dual feasibility, **weak duality** (`DualFeasible`, `dualValue`, `weak_duality`) |
-| `Assignment/Optimality.lean` | 0 | Zero-gap optimality certificate + equality-edge lemma (`dualValue_eq_of_edges`, `optimality_of_zero_gap`) |
-| `Assignment/KuhnMunkres.lean` | 0 | Equality graph, **output invariant**, **Hungarian tightening** preserves dual feasibility (`EqEdge`, `kuhn_munkres_correct`, `dualFeasible_tighten`) |
-| `Assignment/*_en.lean` (×4) | 0 | i18n siblings (EPIC #4980) |
+| `Assignment/Definitions.lean` | 0 | matrice de coûts, couplage parfait (permutation), valeur, optimalité (`value`, `IsOptimal`) |
+| `Assignment/Duality.lean` | 0 | potentiels duaux `u`/`v`, faisabilité duale, **dualité faible** (`DualFeasible`, `dualValue`, `weak_duality`) |
+| `Assignment/Optimality.lean` | 0 | certificat d'optimalité à écart nul + lemme d'arête d'égalité (`dualValue_eq_of_edges`, `optimality_of_zero_gap`) |
+| `Assignment/KuhnMunkres.lean` | 0 | graphe d'égalité, **invariant de sortie**, le **serrage hongrois** préserve la faisabilité duale (`EqEdge`, `kuhn_munkres_correct`, `dualFeasible_tighten`) |
+| `Assignment/*_en.lean` (×4) | 0 | jumeaux i18n (EPIC #4980) |
 
-**Build**: `lake build Assignment Assignment_en` — SUCCESS (8665 jobs, cf PR #12614) | **COMPLETE: 0 sorry** (distinct_code_sorry = 0)
+**Compilation** : `lake build Assignment Assignment_en` — SUCCESS (8665 jobs, cf PR #12614) | **COMPLET : 0 sorry** (distinct_code_sorry = 0)
 
-**Key theorems**: `weak_duality`, `dualValue_eq_of_edges`, `optimality_of_zero_gap`, `kuhn_munkres_correct`, `dualFeasible_tighten`.
+**Théorèmes clés** : `weak_duality`, `dualValue_eq_of_edges`, `optimality_of_zero_gap`, `kuhn_munkres_correct`, `dualFeasible_tighten`.
 
-**Status**: COMPLETE. Companion notebooks: GT-27 (Python implementation + scipy SOTA) and GT-27b (native `lean4-wsl` companion — `#check` of all 10 declarations + kernel-proved `optimal_C3` certificate, EPIC #11703 visibility).
+**Statut** : COMPLET. Notebooks compagnons : GT-27 (implémentation Python + scipy SOTA) et GT-27b (compagnon natif `lean4-wsl` — `#check` des 10 déclarations + certificat `optimal_C3` prouvé au kernel, visibilité EPIC #11703).
 
 ---
 
 ### 11. asymmetric_information_lean
 
-**Objective**: Formalize the foundational models of information asymmetry — companion of the GT-17 notebooks. Epic #12844 (first delivery, portée bornée conforme à l'audit canonique c.475).
+**Objectif** : formaliser les modèles fondateurs de l'asymétrie d'information — compagnon des notebooks GT-17. Epic #12844 (première livraison, portée bornée conforme à l'audit canonique c.475).
 
-**Toolchain**: v4.32.1 | **Dependencies**: Lean core + `lean_game_defs_ext.Bayesian` (no Mathlib dependency)
+**Toolchain** : v4.32.1 | **Dépendances** : Lean core + `lean_game_defs_ext.Bayesian` (sans dépendance Mathlib)
 
-| File (FR + `_en` sibling) | sorry | Description |
+| Fichier (FR + jumeau `_en`) | sorry | Description |
 |---------------------------|-------|-------------|
-| `AsymmetricInformation/Lemons.lean` | 0 | Akerlof (1970) lemons market — participation-regions fixed point |
-| `AsymmetricInformation/Signaling.lean` | 0 | Spence (1973) education signal |
-| `AsymmetricInformation/Screening.lean` | 0 | Rothschild-Stiglitz (1976) adverse selection |
-| `AsymmetricInformation/MiyazakiWilson.lean` | 0 | Wilson (1977) / Miyazaki (1977) anticipatory cross-subsidy |
-| `AsymmetricInformation/BayesianLink.lean` | 0 | Non-trivial bridge to `lean_game_defs_ext.Bayesian` |
+| `AsymmetricInformation/Lemons.lean` | 0 | marché des lemons d'Akerlof (1970) — point fixe sur les régions de participation |
+| `AsymmetricInformation/Signaling.lean` | 0 | signal éducatif de Spence (1973) |
+| `AsymmetricInformation/Screening.lean` | 0 | sélection adverse Rothschild-Stiglitz (1976) |
+| `AsymmetricInformation/MiyazakiWilson.lean` | 0 | subvention croisée anticipatoire Wilson (1977) / Miyazaki (1977) |
+| `AsymmetricInformation/BayesianLink.lean` | 0 | pont non trivial vers `lean_game_defs_ext.Bayesian` |
 
-**Build**: `lake build` — SUCCESS | **COMPLETE: 0 code sorry** (2 naive hits = prose)
+**Compilation** : `lake build` — SUCCESS | **COMPLET : 0 code sorry** (2 touches naive = prose)
 
-**Bornes explicites** (per README): no general existence/uniformity theorem for the anticipatory equilibrium (Wilson-MWS); no auxiliary clause in κ (Lemons); no cross-subsidy in RS 1976; no Mathlib `sorry`-backed milestone — proofs on Lean 4 core + `decide`/`omega`.
+**Bornes explicites** (per README) : pas de théorème général d'existence/uniformité pour l'équilibre anticipatoire (Wilson-MWS) ; pas de clause auxiliaire en κ (Lemons) ; pas de subvention croisée en RS 1976 ; pas de jalon adossé à un `sorry` Mathlib — preuves sur Lean 4 core + `decide`/`omega`.
 
 ---
 
-## Remaining Proving Targets
+## Cibles de preuve restantes
 
-| Priority | Target | Dir | sorry | Feasibility |
+| Priorité | Cible | Rép. | sorry | Faisabilité |
 |----------|--------|-----|-------|-------------|
-| P3 | `folk_theorem_discounted` / `folk_theorem_boundary` (stretch toléré) | `game_theory_lean/RepeatedGames/Folk.lean` (+ `_en`) | 1 stretch (#4880) | Low — authentically hard direction (`… = u_col`), grim already covers the closure criterion |
+| P3 | `folk_theorem_discounted` / `folk_theorem_boundary` (stretch toléré) | `game_theory_lean/RepeatedGames/Folk.lean` (+ `_en`) | 1 stretch (#4880) | Faible — direction authentiquement difficile (`… = u_col`), grim couvre déjà le critère de fermeture |
 
-> **Note (G.9 correction, 2026-08-26):** l'ancienne ligne P1 « Basic.lean L309 hCore / Very Low
+> **Note (correction G.9, 2026-08-26) :** l'ancienne ligne P1 « Basic.lean L309 hCore / Very Low
 > (Hahn-Banach) » était stale (#3954 l'a close) ; l'ancien compte « 3 (Lattice) » pour
 > `game_theory_lean` était stale aussi — `StableMarriage/Lattice.lean` est à 0 sorry
 > (vérifié `count_code_sorry.py` : `distinct_code_sorry = 1`, localisé à `Folk.lean:127`).
-> Removing stale targets prevents a pointless BG-iter cycle on a sorry that no longer exists
+> Retirer les cibles stale évite un cycle BG-iter inutile sur un sorry qui n'existe plus
 > (cf. lean-merge-discipline §2).
 
-## GO/NO-GO per Project (for BG iter cycles)
+## GO/NO-GO par projet (pour les cycles BG iter)
 
-| Project | Decision | Reasoning |
+| Projet | Décision | Justification |
 |---------|----------|-----------|
-| game_theory_lean | COMPLETE | 1 sorry (Folk stretch, toléré #4880). StableMarriage: former false statements refuted, honest `exists_isManOptimal` proved; Lattice closed. Absorbed `stable_marriage_lean/` + `cooperative_games_lean/` + `social_choice_lean/` + `repeated_games_lean/` (EPIC #4365). |
-| ~~cooperative_games_lean~~ | **Supprimé** (rm #6587) | Absorbed byte-identique into `game_theory_lean/CooperativeGames/`. |
-| ~~social_choice_lean~~ | **Absorbé** (#6058) | 7 modules → `game_theory_lean/SocialChoice/` ; tombstone docs only. |
-| ~~repeated_games_lean~~ | **Absorbé** (#6146) | 4 modules → `game_theory_lean/RepeatedGames/` ; archive shell. |
-| lean_game_defs / _ext | COMPLETE | 0 sorry, Mathlib-free. |
-| minimax_lean | COMPLETE | 0 sorry ; Sion application proved. |
-| assignment_lean | COMPLETE | 0 sorry (#12598). |
-| asymmetric_information_lean | COMPLETE | 0 code sorry (Epic #12844). |
-| social_choice_lean_peters | N/A | Reference only (Peters `94a4c650`, Mathlib `520045ab`, v4.32.1). |
-| conway_cgt_lean | N/A | Reference tour (v4.31.0-rc2, tracks upstream). |
+| game_theory_lean | COMPLET | 1 sorry (stretch Folk, toléré #4880). StableMarriage : anciens énoncés faux réfutés, `exists_isManOptimal` honnête prouvé ; Lattice fermé. A absorbé `stable_marriage_lean/` + `cooperative_games_lean/` + `social_choice_lean/` + `repeated_games_lean/` (EPIC #4365). |
+| ~~cooperative_games_lean~~ | **Supprimé** (rm #6587) | Absorbé byte-identique dans `game_theory_lean/CooperativeGames/`. |
+| ~~social_choice_lean~~ | **Absorbé** (#6058) | 7 modules → `game_theory_lean/SocialChoice/` ; docs tombstone uniquement. |
+| ~~repeated_games_lean~~ | **Absorbé** (#6146) | 4 modules → `game_theory_lean/RepeatedGames/` ; coquille archive. |
+| lean_game_defs / _ext | COMPLET | 0 sorry, sans Mathlib. |
+| minimax_lean | COMPLET | 0 sorry ; application de Sion prouvée. |
+| assignment_lean | COMPLET | 0 sorry (#12598). |
+| asymmetric_information_lean | COMPLET | 0 code sorry (Epic #12844). |
+| social_choice_lean_peters | N/A | Référence seule (Peters `94a4c650`, Mathlib `520045ab`, v4.32.1). |
+| conway_cgt_lean | N/A | Tour de référence (v4.31.0-rc2, suit l'amont). |
 
-Conway calibration targets (Doomsday / FRACTRAN / Look-and-Say / Nim / Angel) live in `SymbolicAI/Lean/conway_lean/` and are still consumed by `agent_tests/prover/config.py` (#1453 prover harness co-evolution).
+Les cibles de calibration Conway (Doomsday / FRACTRAN / Look-and-Say / Nim / Angel) vivent dans `SymbolicAI/Lean/conway_lean/` et sont toujours consommées par `agent_tests/prover/config.py` (co-évolution du harnais prover #1453).
 
 ---
 
-## Related documentation
+## Documentation associée
 
-- [docs/lean/sota-2026-analysis.md](../../docs/lean/sota-2026-analysis.md) — SOTA in automated Lean 4 proving
-- [docs/lean/prover_iteration_history.md](../../docs/lean/prover_iteration_history.md) — Prover iterations F6-F11, B3
-- [docs/lean/llm-endpoints.md](../../docs/lean/llm-endpoints.md) — LLM providers for the prover
-- [docs/lean/coordinator-workflow.md](../../docs/lean/coordinator-workflow.md) — Coordinator build + BG iter workflow
+- [docs/lean/sota-2026-analysis.md](../../docs/lean/sota-2026-analysis.md) — SOTA du proving Lean 4 automatisé
+- [docs/lean/prover_iteration_history.md](../../docs/lean/prover_iteration_history.md) — Itérations prover F6-F11, B3
+- [docs/lean/llm-endpoints.md](../../docs/lean/llm-endpoints.md) — Fournisseurs LLM pour le prover
+- [docs/lean/coordinator-workflow.md](../../docs/lean/coordinator-workflow.md) — Workflow build coordinateur + BG iter


### PR DESCRIPTION
## Summary

Francisation de `MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md` — **tranche 4/4** de l'issue (le plus ancien et volumineux des 4 fichiers anglais, traité en tranche à part comme le prévoit l'issue). Avec #13448 (tranches 1-3 : QuantConnect, Planners, Tweety), ceci complète le périmètre.

- Prose, titre et en-têtes de section traduits en français (`## Summary` → `## Résumé`, `## Directories` → `## Par lake`, `**Objective**` → `**Objectif**`, `**Dependencies**` → `**Dépendances**`, etc.) — alignés sur la convention FR unanime des 10 inventaires.
- **Structure, ancres et colonnes inchangées** : diff 145 insertions / 145 délétions (traduction ligne-à-ligne) ; l'ancre interne `[§1. game_theory_lean](#1-game_theory_lean)` survit (les headings `### N. <lake>` ne changent pas) ; aucun lien entrant ne cible les ancres traduites (vérifié `git grep "LEAN_INVENTORY" -- '*.md'` avant/après : tous les liens entrants visent le chemin du fichier).
- **Aucun nom technique traduit** : lakes, chemins, modules, toolchains, noms de lemmes, `distinct_code_sorry`, workflows CI, revs Mathlib/SocialChoiceLean — tous inchangés.

## Chiffres re-mesurés (acceptance : jamais recopiés à l'aveugle)

Instrument canonique `scripts/lean/count_code_sorry.py --lake <root> --json` (champ `distinct_code_sorry`), exécuté sur les 8 lakes actifs du worktree frais :

| Lake | distinct_code_sorry | naive | Verdict vs inventaire |
|------|--------------------:|------:|----------------------|
| `game_theory_lean` | 1 | 32 | ✓ « 1 (Folk stretch, #4880) » confirmé |
| `lean_game_defs` | 0 | 0 | ✓ |
| `lean_game_defs_ext` | 0 | 0 | ✓ |
| `minimax_lean` | 0 | 17 | ✓ (naive = prose/docstrings) |
| `assignment_lean` | 0 | 0 | ✓ |
| `asymmetric_information_lean` | 0 | 2 | ✓ note « 2 naive sorry (prose) pour 0 code sorry » confirmée exactement |
| `social_choice_lean_peters` | 0 | 0 | ✓ |
| `conway_cgt_lean` | 0 | 0 | ✓ |

Comptage fichiers : instrument = 50 `.lean` sur `game_theory_lean`, dont `lakefile.lean` (config) → **49 modules**, conforme au tableau Résumé.

## Validation

- `git diff --stat` : 1 fichier, +145/−145 (traduction pure, pas de réécriture).
- Headings avant/après comparés ligne à ligne : même nombre de sections, même ordre (voir diff).
- Liens sortants vérifiés présents : `docs/lean/sota-2026-analysis.md`, `prover_iteration_history.md`, `llm-endpoints.md`, `coordinator-workflow.md` ; liens relatifs inter-inventaires inchangés.
- Docs-only : pas de notebook, pas d'exécution requise ; catalogue non touché.

Closes #13402

Grain: LIGHT/docs — lane myia-po-2023:CoursIA-2 — prev: LIGHT/notebook-python #13450

> **Tier re-qualifie par le coordinateur (merge-gate, variation-protocol.md §3).** Le tag declare disait `MED/docs-translation` ; le litmus LIGHT le refute : franciser un fichier markdown est generable-en-serie en scannant le suivant, et la jambe de verification (8 lakes re-mesures a l'instrument canonique) n'a rien change -- 8 verdicts « confirme », 0 ecart. Un audit qui trouve 0 ne vaut pas MED.
>
> **Exception ecrite au budget G-VAR-2** (precedent #11154 : exception + dette residuelle citee). La lane a merge 8 grains le 2026-08-29, donc un cap de `max(1, 8//3) = 2` LIGHT ; elle en a deja consomme **3** (#13429, #13431, #13450). Celle-ci est la **4e**, soit **2 au-dessus** du cap. Je la merge quand meme pour une raison bornee et non reconductible : c'est la **tranche 4/4 d'un ensemble ferme** dont les tranches 1-3 sont deja sur `main` (#13448), et la tenir laisserait #13402 a moitie livree sans rediriger la lane vers de la substance -- elle a tenu son plancher G-VAR-1 aujourd'hui (#13447 DEEP/notebook-dotnet, #13443 DEEP/notebook-python). L'exception porte sur **cette** PR ; le cap reste du, et la dette residuelle de 2 se solde en n'ouvrant plus de LIGHT sur cette lane aujourd'hui.


