### PR TITLE
fix(gametheory,#13452): GT-03d E1 denombre reellement les 78 jeux canoniques Rapoport-Guyer (prose 78 vs output 576)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
@@ -5,10 +5,10 @@
    "id": "2433ddbd",
    "metadata": {
     "papermill": {
-     "duration": 0.002809,
-     "end_time": "2026-08-29T05:23:22.795751",
+     "duration": 0.003073,
+     "end_time": "2026-08-29T11:53:54.525777",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.792942",
+     "start_time": "2026-08-29T11:53:54.522704",
      "status": "completed"
     },
     "tags": []
@@ -46,16 +46,16 @@
    "id": "90f35ae5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:23:22.800954Z",
-     "iopub.status.busy": "2026-08-29T05:23:22.800434Z",
-     "iopub.status.idle": "2026-08-29T05:23:22.868457Z",
-     "shell.execute_reply": "2026-08-29T05:23:22.867916Z"
+     "iopub.execute_input": "2026-08-29T11:53:54.533430Z",
+     "iopub.status.busy": "2026-08-29T11:53:54.532785Z",
+     "iopub.status.idle": "2026-08-29T11:53:54.634984Z",
+     "shell.execute_reply": "2026-08-29T11:53:54.634469Z"
     },
     "papermill": {
-     "duration": 0.070504,
-     "end_time": "2026-08-29T05:23:22.868457",
+     "duration": 0.108434,
+     "end_time": "2026-08-29T11:53:54.636147",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.797953",
+     "start_time": "2026-08-29T11:53:54.527713",
      "status": "completed"
     },
     "tags": []
@@ -83,10 +83,10 @@
    "id": "ace19172",
    "metadata": {
     "papermill": {
-     "duration": 0.002013,
-     "end_time": "2026-08-29T05:23:22.873464",
+     "duration": 0.005002,
+     "end_time": "2026-08-29T11:53:54.646681",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.871451",
+     "start_time": "2026-08-29T11:53:54.641679",
      "status": "completed"
     },
     "tags": []
@@ -102,10 +102,10 @@
    "id": "9b947fe8",
    "metadata": {
     "papermill": {
-     "duration": 0.001523,
-     "end_time": "2026-08-29T05:23:22.876973",
+     "duration": 0.002875,
+     "end_time": "2026-08-29T11:53:54.654538",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.875450",
+     "start_time": "2026-08-29T11:53:54.651663",
      "status": "completed"
     },
     "tags": []
@@ -135,16 +135,16 @@
    "id": "1a048d29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:23:22.881986Z",
-     "iopub.status.busy": "2026-08-29T05:23:22.881986Z",
-     "iopub.status.idle": "2026-08-29T05:23:22.897148Z",
-     "shell.execute_reply": "2026-08-29T05:23:22.897148Z"
+     "iopub.execute_input": "2026-08-29T11:53:54.665305Z",
+     "iopub.status.busy": "2026-08-29T11:53:54.665305Z",
+     "iopub.status.idle": "2026-08-29T11:53:54.686750Z",
+     "shell.execute_reply": "2026-08-29T11:53:54.686135Z"
     },
     "papermill": {
-     "duration": 0.019165,
-     "end_time": "2026-08-29T05:23:22.898152",
+     "duration": 0.028084,
+     "end_time": "2026-08-29T11:53:54.687836",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.878987",
+     "start_time": "2026-08-29T11:53:54.659752",
      "status": "completed"
     },
     "tags": []
@@ -156,7 +156,7 @@
      "text": [
       "Verification des 4 archetypes canoniques :\n",
       "  PD ((3, 0), (4, 1)) -> PD  [OK]\n",
-      "  SH ((3, 1), (2, 2)) -> SH  [OK]\n",
+      "  SH ((4, 1), (3, 2)) -> SH  [OK]\n",
       "  SD ((2, 1), (3, 0)) -> SD  [OK]\n",
       "  H ((3, 2), (1, 0)) -> H  [OK]\n",
       "Enumeration brute : 576 jeux ordinaux (24 x 24 rangements stricts)\n",
@@ -197,19 +197,10 @@
     "    return 'Other'\n",
     "\n",
     "# Les 4 archetypes canoniques (reference : Robinson-Goforth 2005, p. 47-52)\n",
-    "PD_canon = ((3, 0), (4, 1))   # R=3, P=1, S=0, T=4  -> PD (T=4>R=3>P=1>S=0)\n",
-    "SH_canon = ((3, 2), (2, 1))   # R=3, T=2, P=1, S=2  -> SH (R>T=2, R>P=1, P<S=2) Wait P=1 < S=2 fail\n",
-    "# Reordenancer pour verifier les 4 inequalities strictes de SH\n",
-    "SH_canon = ((3, 1), (2, 2))   # R=3, T=2, P=2, S=1 -> R>T=2 OK, R>P=2 OK, P=S=2 fail\n",
-    "SH_canon = ((3, 1), (2, 2))   # R=3 > T=2 OK, P=2 > S=1 OK -> SH authentique\n",
-    "SD_canon = ((2, 3), (4, 1))   # R=2, T=4, S=3, P=1 -> T=4>R=2 OK, R=2<S=3 fail -> SD?\n",
-    "# SD authentique : T > R > S > P. Reordenancer.\n",
-    "SD_canon = ((3, 1), (4, 2))   # R=3, T=4, S=1, P=2 -> T=4>R=3 OK, R=3>S=1 OK, S=1<P=2 fail\n",
-    "# Reordenancer pour S > P\n",
-    "SD_canon = ((2, 3), (3, 1))   # R=2, T=3, S=3, P=1 -> T=3>R=2 OK, R=2<S=3 fail\n",
-    "# SD authentique T>R>S>P : exemple canonique Hawk-Dove : T=3, R=2, S=1, P=0\n",
-    "SD_canon = ((2, 1), (3, 0))   # R=2, T=3, S=1, P=0 -> T=3>R=2>R ok wait R>S=1 ok S>P=0 ok -> SD\n",
-    "H_canon  = ((3, 2), (1, 0))   # R=3, T=1, S=2, P=0 -> R=3>T=1 OK, R=3>S=2 OK, S=2>P=0 OK -> H\n",
+    "PD_canon = ((3, 0), (4, 1))   # R=3, S=0, T=4, P=1 -> T=4>R=3>P=1>S=0 (strict)\n",
+    "SH_canon = ((4, 1), (3, 2))   # R=4, S=1, T=3, P=2 -> R=4>T=3>P=2>S=1 (strict, 4 valeurs distinctes)\n",
+    "SD_canon = ((2, 1), (3, 0))   # R=2, S=1, T=3, P=0 -> T=3>R=2>S=1>P=0 (Hawk-Dove)\n",
+    "H_canon  = ((3, 2), (1, 0))   # R=3, S=2, T=1, P=0 -> R=3>T=1, R=3>S=2>P=0 (strict)\n",
     "\n",
     "# Verification des 4 archetypes canoniques\n",
     "print(\"Verification des 4 archetypes canoniques :\")\n",
@@ -277,6 +268,10 @@
     "    else:\n",
     "        comptes[\"Other\"] += 1\n",
     "\n",
+    "# Invariant : au plus UN archetype existentiel strict par orbite — si une\n",
+    "# orbite en realisait deux, le total depasserait len(orbites) sans erreur.\n",
+    "assert sum(comptes.values()) == len(orbites)\n",
+    "\n",
     "print(f\"Enumeration brute : {bruts} jeux ordinaux (24 x 24 rangements stricts)\")\n",
     "print(f\"Formes normales distinctes : {len(orbites)} jeux \"\n",
     "      f\"— compte canonique Rapoport-Guyer (1966)\")\n",
@@ -293,10 +288,10 @@
    "id": "77d45634",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-08-29T05:23:22.903152",
+     "duration": 0.002002,
+     "end_time": "2026-08-29T11:53:54.692812",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.900152",
+     "start_time": "2026-08-29T11:53:54.690810",
      "status": "completed"
     },
     "tags": []
@@ -304,7 +299,7 @@
    "source": [
     "### Lecture du resultat\n",
     "\n",
-    "L'enumeration brute produit **576 jeux ordinaux** (24 rangements stricts par joueur, croises) ; reduits a leurs formes normales — renommer une strategie ou echanger les roles ne change pas un jeu — ils donnent **78 jeux distincts**, le compte canonique de Rapoport-Guyer (1966). Sur ces 78, la classification Robinson-Goforth fait emerger les 4 archetypes canoniques avec leurs 4 profils canoniques specifies (T, R, P, S dans le bon ordre) : **1 PD, 6 SH, 1 SD, 6 H**. Les **64 jeux restants (82.1%)** tombent dans **'Other'** : ces profils n'ont pas de structure d'incitation stricte et sont les **murs** au sens de #12213 (chambres-et-murs) — leur identite se voit dans la parente topologique plutot que dans la lecture des strategies dominantes.\n",
+    "L'enumeration brute produit **576 jeux ordinaux** (24 rangements stricts par joueur, croises) ; reduits a leurs formes normales — renommer une strategie ou echanger les roles ne change pas un jeu — ils donnent **78 jeux distincts**, le compte canonique de Rapoport-Guyer (1966). Sur ces 78, **notre lecture stricte de Robinson-Goforth** fait emerger les 4 archetypes canoniques avec leurs 4 profils canoniques specifies (T, R, P, S dans le bon ordre) : **1 PD, 6 SH, 1 SD, 6 H**. Ces comptes existentiels stricts (les DEUX joueurs vivant simultanement la signature) sont une construction de ce notebook, pas un chiffre publie de Robinson-Goforth 2005. Les **64 jeux restants (82.1%)** tombent dans **'Other'** : ces profils n'ont pas de structure d'incitation stricte et sont les **murs** au sens de #12213 (chambres-et-murs) — leur identite se voit dans la parente topologique plutot que dans la lecture des strategies dominantes.\n",
     "\n",
     "Archetti-Scheuring (2012, p. 10) affirment que **la parente des quatre jeux n'est pas evidente dans la taxonomie classique (Rapoport-Guyer 1966) mais claire dans une classification topologique** (Robinson-Goforth 2005). Notre verification ci-dessus donne chair a cette affirmation : les 4 archetypes canoniques se distinguent par leur signature topologique (les 4 inequalities strictes), pas par leur identite lexicale.\n",
     "\n",
@@ -316,10 +311,10 @@
    "id": "6b06f42d",
    "metadata": {
     "papermill": {
-     "duration": 0.001552,
-     "end_time": "2026-08-29T05:23:22.906503",
+     "duration": 0.002999,
+     "end_time": "2026-08-29T11:53:54.699837",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.904951",
+     "start_time": "2026-08-29T11:53:54.696838",
      "status": "completed"
     },
     "tags": []
@@ -352,16 +347,16 @@
    "id": "ae2a353e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:23:22.912344Z",
-     "iopub.status.busy": "2026-08-29T05:23:22.912344Z",
-     "iopub.status.idle": "2026-08-29T05:23:22.917870Z",
-     "shell.execute_reply": "2026-08-29T05:23:22.917870Z"
+     "iopub.execute_input": "2026-08-29T11:53:54.707145Z",
+     "iopub.status.busy": "2026-08-29T11:53:54.706558Z",
+     "iopub.status.idle": "2026-08-29T11:53:54.713664Z",
+     "shell.execute_reply": "2026-08-29T11:53:54.713090Z"
     },
     "papermill": {
-     "duration": 0.010173,
-     "end_time": "2026-08-29T05:23:22.918885",
+     "duration": 0.011885,
+     "end_time": "2026-08-29T11:53:54.714726",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.908712",
+     "start_time": "2026-08-29T11:53:54.702841",
      "status": "completed"
     },
     "tags": []
@@ -430,10 +425,10 @@
    "id": "913fdebc",
    "metadata": {
     "papermill": {
-     "duration": 0.002285,
-     "end_time": "2026-08-29T05:23:22.923170",
+     "duration": 0.003013,
+     "end_time": "2026-08-29T11:53:54.720730",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.920885",
+     "start_time": "2026-08-29T11:53:54.717717",
      "status": "completed"
     },
     "tags": []
@@ -461,10 +456,10 @@
    "id": "7254815b",
    "metadata": {
     "papermill": {
-     "duration": 0.001668,
-     "end_time": "2026-08-29T05:23:22.927349",
+     "duration": 0.003689,
+     "end_time": "2026-08-29T11:53:54.727039",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.925681",
+     "start_time": "2026-08-29T11:53:54.723350",
      "status": "completed"
     },
     "tags": []
@@ -490,10 +485,10 @@
    "id": "4cba1a1c",
    "metadata": {
     "papermill": {
-     "duration": 0.002015,
-     "end_time": "2026-08-29T05:23:22.931369",
+     "duration": 0.002981,
+     "end_time": "2026-08-29T11:53:54.732042",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.929354",
+     "start_time": "2026-08-29T11:53:54.729061",
      "status": "completed"
     },
     "tags": []
@@ -523,16 +518,16 @@
    "id": "83312740",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:23:22.936859Z",
-     "iopub.status.busy": "2026-08-29T05:23:22.936859Z",
-     "iopub.status.idle": "2026-08-29T05:23:22.964609Z",
-     "shell.execute_reply": "2026-08-29T05:23:22.964060Z"
+     "iopub.execute_input": "2026-08-29T11:53:54.739608Z",
+     "iopub.status.busy": "2026-08-29T11:53:54.738463Z",
+     "iopub.status.idle": "2026-08-29T11:53:54.778414Z",
+     "shell.execute_reply": "2026-08-29T11:53:54.778414Z"
     },
     "papermill": {
-     "duration": 0.032299,
-     "end_time": "2026-08-29T05:23:22.965654",
+     "duration": 0.0448,
+     "end_time": "2026-08-29T11:53:54.779487",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.933355",
+     "start_time": "2026-08-29T11:53:54.734687",
      "status": "completed"
     },
     "tags": []
@@ -635,10 +630,10 @@
    "id": "83332779",
    "metadata": {
     "papermill": {
-     "duration": 0.00208,
-     "end_time": "2026-08-29T05:23:22.969871",
+     "duration": 0.004064,
+     "end_time": "2026-08-29T11:53:54.787542",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.967791",
+     "start_time": "2026-08-29T11:53:54.783478",
      "status": "completed"
     },
     "tags": []
@@ -660,10 +655,10 @@
    "id": "87ac3c30",
    "metadata": {
     "papermill": {
-     "duration": 0.002128,
-     "end_time": "2026-08-29T05:23:22.974152",
+     "duration": 0.002795,
+     "end_time": "2026-08-29T11:53:54.793201",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.972024",
+     "start_time": "2026-08-29T11:53:54.790406",
      "status": "completed"
     },
     "tags": []
@@ -694,16 +689,16 @@
    "id": "70916734",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:23:22.979415Z",
-     "iopub.status.busy": "2026-08-29T05:23:22.979415Z",
-     "iopub.status.idle": "2026-08-29T05:23:22.985928Z",
-     "shell.execute_reply": "2026-08-29T05:23:22.985417Z"
+     "iopub.execute_input": "2026-08-29T11:53:54.800434Z",
+     "iopub.status.busy": "2026-08-29T11:53:54.800434Z",
+     "iopub.status.idle": "2026-08-29T11:53:54.808477Z",
+     "shell.execute_reply": "2026-08-29T11:53:54.808477Z"
     },
     "papermill": {
-     "duration": 0.010196,
-     "end_time": "2026-08-29T05:23:22.986447",
+     "duration": 0.01275,
+     "end_time": "2026-08-29T11:53:54.809538",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.976251",
+     "start_time": "2026-08-29T11:53:54.796788",
      "status": "completed"
     },
     "tags": []
@@ -800,10 +795,10 @@
    "id": "02fb23f9",
    "metadata": {
     "papermill": {
-     "duration": 0.002144,
-     "end_time": "2026-08-29T05:23:22.991355",
+     "duration": 0.003263,
+     "end_time": "2026-08-29T11:53:54.815980",
      "exception": false,
-     "start_time": "2026-08-29T05:23:22.989211",
+     "start_time": "2026-08-29T11:53:54.812717",
      "status": "completed"
     },
     "tags": []
@@ -854,14 +849,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.644416,
-   "end_time": "2026-08-29T05:23:23.121156",
+   "duration": 1.933858,
+   "end_time": "2026-08-29T11:53:55.067096",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb",
    "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb",
    "parameters": {},
-   "start_time": "2026-08-29T05:23:21.476740",
+   "start_time": "2026-08-29T11:53:53.133238",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
@@ -5,10 +5,10 @@
    "id": "2433ddbd",
    "metadata": {
     "papermill": {
-     "duration": 0.003336,
-     "end_time": "2026-08-29T03:28:45.296095",
+     "duration": 0.002809,
+     "end_time": "2026-08-29T05:23:22.795751",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.292759",
+     "start_time": "2026-08-29T05:23:22.792942",
      "status": "completed"
     },
     "tags": []
@@ -46,16 +46,16 @@
    "id": "90f35ae5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:00:52.436117Z",
-     "iopub.status.busy": "2026-08-29T05:00:52.436117Z",
-     "iopub.status.idle": "2026-08-29T05:00:52.518870Z",
-     "shell.execute_reply": "2026-08-29T05:00:52.517863Z"
+     "iopub.execute_input": "2026-08-29T05:23:22.800954Z",
+     "iopub.status.busy": "2026-08-29T05:23:22.800434Z",
+     "iopub.status.idle": "2026-08-29T05:23:22.868457Z",
+     "shell.execute_reply": "2026-08-29T05:23:22.867916Z"
     },
     "papermill": {
-     "duration": 0.095025,
-     "end_time": "2026-08-29T03:28:45.394098",
+     "duration": 0.070504,
+     "end_time": "2026-08-29T05:23:22.868457",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.299073",
+     "start_time": "2026-08-29T05:23:22.797953",
      "status": "completed"
     },
     "tags": []
@@ -83,10 +83,10 @@
    "id": "ace19172",
    "metadata": {
     "papermill": {
-     "duration": 0.002992,
-     "end_time": "2026-08-29T03:28:45.400113",
+     "duration": 0.002013,
+     "end_time": "2026-08-29T05:23:22.873464",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.397121",
+     "start_time": "2026-08-29T05:23:22.871451",
      "status": "completed"
     },
     "tags": []
@@ -102,10 +102,10 @@
    "id": "9b947fe8",
    "metadata": {
     "papermill": {
-     "duration": 0.003379,
-     "end_time": "2026-08-29T03:28:45.406617",
+     "duration": 0.001523,
+     "end_time": "2026-08-29T05:23:22.876973",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.403238",
+     "start_time": "2026-08-29T05:23:22.875450",
      "status": "completed"
     },
     "tags": []
@@ -135,16 +135,16 @@
    "id": "1a048d29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:00:52.520722Z",
-     "iopub.status.busy": "2026-08-29T05:00:52.520722Z",
-     "iopub.status.idle": "2026-08-29T05:00:52.542340Z",
-     "shell.execute_reply": "2026-08-29T05:00:52.541225Z"
+     "iopub.execute_input": "2026-08-29T05:23:22.881986Z",
+     "iopub.status.busy": "2026-08-29T05:23:22.881986Z",
+     "iopub.status.idle": "2026-08-29T05:23:22.897148Z",
+     "shell.execute_reply": "2026-08-29T05:23:22.897148Z"
     },
     "papermill": {
-     "duration": 0.015438,
-     "end_time": "2026-08-29T03:28:45.424461",
+     "duration": 0.019165,
+     "end_time": "2026-08-29T05:23:22.898152",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.409023",
+     "start_time": "2026-08-29T05:23:22.878987",
      "status": "completed"
     },
     "tags": []
@@ -293,10 +293,10 @@
    "id": "77d45634",
    "metadata": {
     "papermill": {
-     "duration": 0.00298,
-     "end_time": "2026-08-29T03:28:45.430447",
+     "duration": 0.003,
+     "end_time": "2026-08-29T05:23:22.903152",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.427467",
+     "start_time": "2026-08-29T05:23:22.900152",
      "status": "completed"
     },
     "tags": []
@@ -316,10 +316,10 @@
    "id": "6b06f42d",
    "metadata": {
     "papermill": {
-     "duration": 0.002995,
-     "end_time": "2026-08-29T03:28:45.436455",
+     "duration": 0.001552,
+     "end_time": "2026-08-29T05:23:22.906503",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.433460",
+     "start_time": "2026-08-29T05:23:22.904951",
      "status": "completed"
     },
     "tags": []
@@ -352,16 +352,16 @@
    "id": "ae2a353e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:00:52.544523Z",
-     "iopub.status.busy": "2026-08-29T05:00:52.543990Z",
-     "iopub.status.idle": "2026-08-29T05:00:52.550573Z",
-     "shell.execute_reply": "2026-08-29T05:00:52.549992Z"
+     "iopub.execute_input": "2026-08-29T05:23:22.912344Z",
+     "iopub.status.busy": "2026-08-29T05:23:22.912344Z",
+     "iopub.status.idle": "2026-08-29T05:23:22.917870Z",
+     "shell.execute_reply": "2026-08-29T05:23:22.917870Z"
     },
     "papermill": {
-     "duration": 0.011912,
-     "end_time": "2026-08-29T03:28:45.451379",
+     "duration": 0.010173,
+     "end_time": "2026-08-29T05:23:22.918885",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.439467",
+     "start_time": "2026-08-29T05:23:22.908712",
      "status": "completed"
     },
     "tags": []
@@ -430,10 +430,10 @@
    "id": "913fdebc",
    "metadata": {
     "papermill": {
-     "duration": 0.002651,
-     "end_time": "2026-08-29T03:28:45.457016",
+     "duration": 0.002285,
+     "end_time": "2026-08-29T05:23:22.923170",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.454365",
+     "start_time": "2026-08-29T05:23:22.920885",
      "status": "completed"
     },
     "tags": []
@@ -461,10 +461,10 @@
    "id": "7254815b",
    "metadata": {
     "papermill": {
-     "duration": 0.002906,
-     "end_time": "2026-08-29T03:28:45.461793",
+     "duration": 0.001668,
+     "end_time": "2026-08-29T05:23:22.927349",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.458887",
+     "start_time": "2026-08-29T05:23:22.925681",
      "status": "completed"
     },
     "tags": []
@@ -490,10 +490,10 @@
    "id": "4cba1a1c",
    "metadata": {
     "papermill": {
-     "duration": 0.002996,
-     "end_time": "2026-08-29T03:28:45.466789",
+     "duration": 0.002015,
+     "end_time": "2026-08-29T05:23:22.931369",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.463793",
+     "start_time": "2026-08-29T05:23:22.929354",
      "status": "completed"
     },
     "tags": []
@@ -523,16 +523,16 @@
    "id": "83312740",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:00:52.552423Z",
-     "iopub.status.busy": "2026-08-29T05:00:52.552423Z",
-     "iopub.status.idle": "2026-08-29T05:00:52.586017Z",
-     "shell.execute_reply": "2026-08-29T05:00:52.585291Z"
+     "iopub.execute_input": "2026-08-29T05:23:22.936859Z",
+     "iopub.status.busy": "2026-08-29T05:23:22.936859Z",
+     "iopub.status.idle": "2026-08-29T05:23:22.964609Z",
+     "shell.execute_reply": "2026-08-29T05:23:22.964060Z"
     },
     "papermill": {
-     "duration": 0.041293,
-     "end_time": "2026-08-29T03:28:45.510712",
+     "duration": 0.032299,
+     "end_time": "2026-08-29T05:23:22.965654",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.469419",
+     "start_time": "2026-08-29T05:23:22.933355",
      "status": "completed"
     },
     "tags": []
@@ -635,10 +635,10 @@
    "id": "83332779",
    "metadata": {
     "papermill": {
-     "duration": 0.002034,
-     "end_time": "2026-08-29T03:28:45.517600",
+     "duration": 0.00208,
+     "end_time": "2026-08-29T05:23:22.969871",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.515566",
+     "start_time": "2026-08-29T05:23:22.967791",
      "status": "completed"
     },
     "tags": []
@@ -660,10 +660,10 @@
    "id": "87ac3c30",
    "metadata": {
     "papermill": {
-     "duration": 0.002702,
-     "end_time": "2026-08-29T03:28:45.523892",
+     "duration": 0.002128,
+     "end_time": "2026-08-29T05:23:22.974152",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.521190",
+     "start_time": "2026-08-29T05:23:22.972024",
      "status": "completed"
     },
     "tags": []
@@ -694,16 +694,16 @@
    "id": "70916734",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:00:52.588381Z",
-     "iopub.status.busy": "2026-08-29T05:00:52.588381Z",
-     "iopub.status.idle": "2026-08-29T05:00:52.595238Z",
-     "shell.execute_reply": "2026-08-29T05:00:52.595238Z"
+     "iopub.execute_input": "2026-08-29T05:23:22.979415Z",
+     "iopub.status.busy": "2026-08-29T05:23:22.979415Z",
+     "iopub.status.idle": "2026-08-29T05:23:22.985928Z",
+     "shell.execute_reply": "2026-08-29T05:23:22.985417Z"
     },
     "papermill": {
-     "duration": 0.014195,
-     "end_time": "2026-08-29T03:28:45.542427",
+     "duration": 0.010196,
+     "end_time": "2026-08-29T05:23:22.986447",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.528232",
+     "start_time": "2026-08-29T05:23:22.976251",
      "status": "completed"
     },
     "tags": []
@@ -800,10 +800,10 @@
    "id": "02fb23f9",
    "metadata": {
     "papermill": {
-     "duration": 0.003349,
-     "end_time": "2026-08-29T03:28:45.550797",
+     "duration": 0.002144,
+     "end_time": "2026-08-29T05:23:22.991355",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.547448",
+     "start_time": "2026-08-29T05:23:22.989211",
      "status": "completed"
     },
     "tags": []
@@ -854,14 +854,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.808627,
-   "end_time": "2026-08-29T03:28:45.697315",
+   "duration": 1.644416,
+   "end_time": "2026-08-29T05:23:23.121156",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb",
    "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb",
    "parameters": {},
-   "start_time": "2026-08-29T03:28:43.888688",
+   "start_time": "2026-08-29T05:23:21.476740",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
@@ -46,10 +46,10 @@
    "id": "90f35ae5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:28:45.303076Z",
-     "iopub.status.busy": "2026-08-29T03:28:45.303076Z",
-     "iopub.status.idle": "2026-08-29T03:28:45.392896Z",
-     "shell.execute_reply": "2026-08-29T03:28:45.392347Z"
+     "iopub.execute_input": "2026-08-29T05:00:52.436117Z",
+     "iopub.status.busy": "2026-08-29T05:00:52.436117Z",
+     "iopub.status.idle": "2026-08-29T05:00:52.518870Z",
+     "shell.execute_reply": "2026-08-29T05:00:52.517863Z"
     },
     "papermill": {
      "duration": 0.095025,
@@ -135,10 +135,10 @@
    "id": "1a048d29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:28:45.413141Z",
-     "iopub.status.busy": "2026-08-29T03:28:45.412021Z",
-     "iopub.status.idle": "2026-08-29T03:28:45.423320Z",
-     "shell.execute_reply": "2026-08-29T03:28:45.423320Z"
+     "iopub.execute_input": "2026-08-29T05:00:52.520722Z",
+     "iopub.status.busy": "2026-08-29T05:00:52.520722Z",
+     "iopub.status.idle": "2026-08-29T05:00:52.542340Z",
+     "shell.execute_reply": "2026-08-29T05:00:52.541225Z"
     },
     "papermill": {
      "duration": 0.015438,
@@ -159,14 +159,15 @@
       "  SH ((3, 1), (2, 2)) -> SH  [OK]\n",
       "  SD ((2, 1), (3, 0)) -> SD  [OK]\n",
       "  H ((3, 2), (1, 0)) -> H  [OK]\n",
+      "Enumeration brute : 576 jeux ordinaux (24 x 24 rangements stricts)\n",
+      "Formes normales distinctes : 78 jeux — compte canonique Rapoport-Guyer (1966)\n",
       "\n",
-      "Enumeration complete (576 profils 2x2) :\n",
-      "     PD :   4 (  0.7%)\n",
-      "     SH :  28 (  4.9%)\n",
-      "     SD :   4 (  0.7%)\n",
-      "      H :  28 (  4.9%)\n",
-      "  Other : 512 ( 88.9%)\n",
-      "  TOTAL : 576\n"
+      "Distribution par archétype sur les 78 jeux canoniques :\n",
+      "     PD :   1 (  1.3%)\n",
+      "     SH :   6 (  7.7%)\n",
+      "     SD :   1 (  1.3%)\n",
+      "      H :   6 (  7.7%)\n",
+      "  Other :  64 ( 82.1%)\n"
      ]
     }
    ],
@@ -217,31 +218,74 @@
     "    status = 'OK' if cls == name else f'BUG (classe comme {cls})'\n",
     "    print(f\"  {name} {prof} -> {cls}  [{status}]\")\n",
     "\n",
-    "# Enumere tous les profils admissibles : pour chaque ligne J1, choix d'une\n",
-    "# permutation stricte de 4 valeurs distinctes parmi {1,2,3,4}\n",
-    "# (chaque case recoit une valeur differente -> 4! = 24 profils par ligne)\n",
-    "# Pour le profil complet, J2 doit aussi etre une permutation stricte de 4 valeurs distinctes\n",
-    "# -> 24 x 24 = 576 profils complets. Mais les doublons (J1=J2 modulo label) -> 78 profils distincts\n",
-    "# (compte canonique Rapoport-Guyer 1966).\n",
-    "comptes = {'PD': 0, 'SH': 0, 'SD': 0, 'H': 0, 'Other': 0}\n",
-    "exemples_par_classe = {k: [] for k in comptes}\n",
+    "# Enumere tous les jeux ordinaux stricts : chaque joueur range strictement\n",
+    "# les 4 cases -> 4! = 24 rangements par joueur -> 24 x 24 = 576 jeux bruts.\n",
+    "# Renommer une strategie ou echanger les roles ne change pas le jeu : on\n",
+    "# reduit chaque jeu a sa forme normale (representant minimal de son orbite\n",
+    "# sous ces symetries) -> le compte canonique Rapoport-Guyer (1966).\n",
     "\n",
-    "# Enumeration exacte : pour chaque couple de permutations strictes de (1,2,3,4)\n",
+    "def _swap_rows(m):\n",
+    "    return (m[2], m[3], m[0], m[1])  # renomme les strategies du joueur ligne\n",
+    "\n",
+    "def _swap_cols(m):\n",
+    "    return (m[1], m[0], m[3], m[2])  # renomme les strategies du joueur colonne\n",
+    "\n",
+    "def _transpose(m):\n",
+    "    return (m[0], m[2], m[1], m[3])\n",
+    "\n",
+    "def orbite(jeu):\n",
+    "    \"\"\"Fermeture du jeu sous les renommages et l'echange des roles.\"\"\"\n",
+    "    vus, pile = {jeu}, [jeu]\n",
+    "    while pile:\n",
+    "        a, b = pile.pop()\n",
+    "        for voisin in ((_swap_rows(a), _swap_rows(b)),\n",
+    "                       (_swap_cols(a), _swap_cols(b)),\n",
+    "                       (_transpose(b), _transpose(a))):\n",
+    "            if voisin not in vus:\n",
+    "                vus.add(voisin)\n",
+    "                pile.append(voisin)\n",
+    "    return vus\n",
+    "\n",
+    "def archetypes_de_l_orbite(orb):\n",
+    "    \"\"\"Archeotypes existentiels : un archeotype appartient a l'orbite s'il\n",
+    "    existe un etiquetage du jeu ou les DEUX joueurs vivent sa signature\n",
+    "    (T, R, P, S dans le bon ordre). La lecture du joueur colonne se fait\n",
+    "    sur la transposee de sa matrice : son T est la case ou lui-meme defectionne.\"\"\"\n",
+    "    trouves = set()\n",
+    "    for (a, b) in orb:\n",
+    "        c_ligne = rgs_class((a[:2], a[2:]))\n",
+    "        t = _transpose(b)\n",
+    "        c_colonne = rgs_class((t[:2], t[2:]))\n",
+    "        if c_ligne == c_colonne and c_ligne != \"Other\":\n",
+    "            trouves.add(c_ligne)\n",
+    "    return trouves\n",
+    "\n",
+    "bruts = 0\n",
+    "orbites = {}\n",
     "for J1_row in permutations([1, 2, 3, 4]):\n",
     "    for J2_row in permutations([1, 2, 3, 4]):\n",
-    "        prof = (J1_row, J2_row)\n",
-    "        cls = rgs_class(prof)\n",
-    "        comptes[cls] += 1\n",
-    "        if len(exemples_par_classe[cls]) < 2:\n",
-    "            exemples_par_classe[cls].append(prof)\n",
+    "        bruts += 1\n",
+    "        o = orbite((J1_row, J2_row))\n",
+    "        orbites[min(o)] = o\n",
     "\n",
-    "print(f\"\\nEnumeration complete (576 profils 2x2) :\")\n",
+    "comptes = {\"PD\": 0, \"SH\": 0, \"SD\": 0, \"H\": 0, \"Other\": 0}\n",
+    "for norme, o in orbites.items():\n",
+    "    trouves = archetypes_de_l_orbite(o)\n",
+    "    if trouves:\n",
+    "        for cls in trouves:\n",
+    "            comptes[cls] += 1\n",
+    "    else:\n",
+    "        comptes[\"Other\"] += 1\n",
+    "\n",
+    "print(f\"Enumeration brute : {bruts} jeux ordinaux (24 x 24 rangements stricts)\")\n",
+    "print(f\"Formes normales distinctes : {len(orbites)} jeux \"\n",
+    "      f\"— compte canonique Rapoport-Guyer (1966)\")\n",
     "total = sum(comptes.values())\n",
-    "for cls in ['PD', 'SH', 'SD', 'H', 'Other']:\n",
+    "print(f\"\\nDistribution par archétype sur les {total} jeux canoniques :\")\n",
+    "for cls in [\"PD\", \"SH\", \"SD\", \"H\", \"Other\"]:\n",
     "    n = comptes[cls]\n",
     "    pct = 100 * n / total\n",
-    "    print(f\"  {cls:>5} : {n:>3} ({pct:>5.1f}%)\")\n",
-    "print(f\"  TOTAL : {total}\")"
+    "    print(f\"  {cls:>5} : {n:>3} ({pct:>5.1f}%)\")\n"
    ]
   },
   {
@@ -260,11 +304,11 @@
    "source": [
     "### Lecture du resultat\n",
     "\n",
-    "L'enumeration produit **78 profils distincts** dont la distribution par classe Robinson-Goforth fait emerger les 4 archetypes canoniques (PD, SH, SD, H) avec leurs 4 profils canoniques specifies (T, R, P, S dans le bon ordre). Le reste des profils tombent dans **'Other'** — ces profils n'ont pas de structure d'incitation stricte et sont les **murs** au sens de #12213 (chambres-et-murs) : leur identite se voit dans la parente topologique plutot que dans la lecture des strategies dominantes.\n",
+    "L'enumeration brute produit **576 jeux ordinaux** (24 rangements stricts par joueur, croises) ; reduits a leurs formes normales — renommer une strategie ou echanger les roles ne change pas un jeu — ils donnent **78 jeux distincts**, le compte canonique de Rapoport-Guyer (1966). Sur ces 78, la classification Robinson-Goforth fait emerger les 4 archetypes canoniques avec leurs 4 profils canoniques specifies (T, R, P, S dans le bon ordre) : **1 PD, 6 SH, 1 SD, 6 H**. Les **64 jeux restants (82.1%)** tombent dans **'Other'** : ces profils n'ont pas de structure d'incitation stricte et sont les **murs** au sens de #12213 (chambres-et-murs) — leur identite se voit dans la parente topologique plutot que dans la lecture des strategies dominantes.\n",
     "\n",
     "Archetti-Scheuring (2012, p. 10) affirment que **la parente des quatre jeux n'est pas evidente dans la taxonomie classique (Rapoport-Guyer 1966) mais claire dans une classification topologique** (Robinson-Goforth 2005). Notre verification ci-dessus donne chair a cette affirmation : les 4 archetypes canoniques se distinguent par leur signature topologique (les 4 inequalities strictes), pas par leur identite lexicale.\n",
     "\n",
-    "**Verification croisee** : les 4 profils canoniques sont les **4 elements minimaux** de chaque classe au sens « un swap d'une case suffit a quitter la classe ». C'est la definition topologique de Robinson-Goforth."
+    "**Verification croisee** : les 4 profils canoniques sont les **4 elements minimaux** de chaque classe au sens « un swap d'une case suffit a quitter la classe ». C'est la definition topologique de Robinson-Goforth.\n"
    ]
   },
   {
@@ -308,10 +352,10 @@
    "id": "ae2a353e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:28:45.444428Z",
-     "iopub.status.busy": "2026-08-29T03:28:45.443427Z",
-     "iopub.status.idle": "2026-08-29T03:28:45.450219Z",
-     "shell.execute_reply": "2026-08-29T03:28:45.450219Z"
+     "iopub.execute_input": "2026-08-29T05:00:52.544523Z",
+     "iopub.status.busy": "2026-08-29T05:00:52.543990Z",
+     "iopub.status.idle": "2026-08-29T05:00:52.550573Z",
+     "shell.execute_reply": "2026-08-29T05:00:52.549992Z"
     },
     "papermill": {
      "duration": 0.011912,
@@ -397,7 +441,7 @@
    "source": [
     "### Lecture du resultat\n",
     "\n",
-    "L'enumeration produit **576 profils distincts en ordinaux stricts** dont la distribution par classe Robinson-Goforth fait emerger les 4 archetypes canoniques (4 PD, 28 SH, 4 SD, 28 H) sur 576 profils (les 88.9% restants sont des profils sans structure d'incitation stricte, les \"murs\" au sens de #12213 (chambres-et-murs)). La parente topologique de Robinson-Goforth (2005) tient : les 4 archetypes canoniques se distinguent par leur signature d'inegalites strictes, pas par leur identite lexicale.\n",
+    "L'enumeration de E1 produit **78 jeux canoniques distincts en ordinaux stricts** (les 576 bruts dedoublonnes par renommage des strategies et echange des roles) dont la distribution par archétype Robinson-Goforth fait emerger les 4 archetypes canoniques (1 PD, 6 SH, 1 SD, 6 H) — les 82.1% restants sont des jeux sans structure d'incitation stricte, les \"murs\" au sens de #12213 (chambres-et-murs). La parente topologique de Robinson-Goforth (2005) tient : les 4 archetypes canoniques se distinguent par leur signature d'inegalites strictes, pas par leur identite lexicale.\n",
     "\n",
     "### Verdict E2 sur les regimes\n",
     "\n",
@@ -479,10 +523,10 @@
    "id": "83312740",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:28:45.472550Z",
-     "iopub.status.busy": "2026-08-29T03:28:45.472550Z",
-     "iopub.status.idle": "2026-08-29T03:28:45.509559Z",
-     "shell.execute_reply": "2026-08-29T03:28:45.508928Z"
+     "iopub.execute_input": "2026-08-29T05:00:52.552423Z",
+     "iopub.status.busy": "2026-08-29T05:00:52.552423Z",
+     "iopub.status.idle": "2026-08-29T05:00:52.586017Z",
+     "shell.execute_reply": "2026-08-29T05:00:52.585291Z"
     },
     "papermill": {
      "duration": 0.041293,
@@ -650,10 +694,10 @@
    "id": "70916734",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:28:45.532250Z",
-     "iopub.status.busy": "2026-08-29T03:28:45.532250Z",
-     "iopub.status.idle": "2026-08-29T03:28:45.541263Z",
-     "shell.execute_reply": "2026-08-29T03:28:45.540036Z"
+     "iopub.execute_input": "2026-08-29T05:00:52.588381Z",
+     "iopub.status.busy": "2026-08-29T05:00:52.588381Z",
+     "iopub.status.idle": "2026-08-29T05:00:52.595238Z",
+     "shell.execute_reply": "2026-08-29T05:00:52.595238Z"
     },
     "papermill": {
      "duration": 0.014195,


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13451

Closes #13452.

## Le defaut (Hermes, review #13446 point 2)

La prose E1 (cell 5) annonce **78 profils distincts** ; l'output de la cellule
E1 (cell 4) en denombre **576**. Le code enumerait le brut 24x24 sans faire le
dedoublonnage que son propre commentaire promettait (« les doublons (J1=J2
modulo label) -> 78 profils distincts »).

## Tranchement par mesure (pas par arbitrage texte)

La forme normale canonique — orbite de chaque jeu sous (renommage des
strategies du joueur ligne, renommage du joueur colonne, echange des roles) —
donne **exactement 78 orbites** sur les 576 bruts (66 orbites de taille 8 +
12 de taille 4 = 576). Le compte canonique Rapoport-Guyer (1966) est confirme
par la mesure : **la prose etait juste, le code devait tenir sa promesse.**

## Deuxieme defaut decouvert en route (cause de l'artefact 88.9% Other)

`rgs_class` etait appelee sur le **couple** `(J1_row, J2_row)` au lieu du profil
d'un seul joueur : la classification melangeait les deux joueurs (T pris dans
J2, R dans J1, ...) — d'ou la distribution brute 4 PD / 28 SH / 4 SD / 28 H /
512 Other, artefact du melange. Correct : lecture J1 sur A, lecture J2 sur la
**transposee** de B (le T du joueur colonne est la case ou lui-meme defectionne).

## Classification invariante

Un archeotype appartient a une orbite s'il existe un etiquetage du jeu ou les
**DEUX joueurs** vivent sa signature (T, R, P, S dans le bon ordre) — invariant
par renommage. Mesure : **0 orbite multi-archetype** (les signatures sont
exclusives). Distribution sur les 78 : **1 PD, 6 SH, 1 SD, 6 H, 64 Other (82.1%)**.

## Preuves d'execution (H.1, C.2)

- Re-exec complete nbclient kernel python3 : **5/5 counts [1..5], 0 erreur, 2.1s**.
- Output E1 committe : « Enumeration brute : 576 jeux ordinaux... Formes normales
  distinctes : 78 jeux — compte canonique Rapoport-Guyer (1966) » + distribution
  1/6/1/6/64.
- Diff perimetre verifie cellule par cellule : **exactement 3 cellules touchees**
  (4 source+outputs, 5 prose E1, 8 prose E2 1er §) ; outputs des cellules
  non modifiees reproduits **byte-identiques** ; metadata intacte.
- La prose E2 (1er §, cell 8) rapportait le brut 576 (4/28/4/28, 88.9%) comme
  livrable — meme incohérence dans le jumeau, alignee dans la meme PR (corriger
  un seul cote laissait le defaut entier).

## Jeux de tests

Scratchpad (mesures reproduites 2x) : `orbits78.py` (78 orbites, tailles
66x8 + 12x4), `dist78b.py` (distribution 1/6/1/6/64, 0 multi-archetype).
Vérification deposee dans le notebook lui-meme (autonome, CPU-only).

See #13446 (PR origine de la dette), #12213 (chambres-et-murs), #13326.