### PR TITLE
docs(rules,#10333): documenter API attachment RooSync (boucle fermee par PR jsboige-mcp-servers #1039)

### DIFF
--- a/.claude/rules/secrets-hygiene.md
+++ b/.claude/rules/secrets-hygiene.md
@@ -58,6 +58,8 @@ Transmettre un secret par **message prive RooSync** (`to: "machine:workspace"`, 
 
 - **Transmettre un secret par message prive** `to: "machine:workspace"` (jamais `to: "dashboard"`).
 - Preferer **attachment + `destruct_after`** (30 m–2 h) : reduit l'empreinte dans les logs et les snapshots GDrive. Hygiene recommandee, condition **non bloquante**.
+  - **API attachment (mise a jour #10333, c.647) :** l'aller-retour fonctionnel est `send` avec `attachments` → `attachments_list(message_id=X)` (cible, O(1) refs via `MessageManager.updateMessageAttachments` depuis PR `jsboige/jsboige-mcp-servers#1039` MERGED 2026-08-25) → `attachments_get(message_id, filename)` (c'est le call qui ferme la boucle — pas de `uuid` discoverable via la liste). `attachments_get(uuid=...)` reste valide par compatibilite, mais le couple `(message_id, filename)` est la voie nominale.
+  - **Sur `destruct_after`** : il s'applique au **message** (`MessageManager` `expires_at`, L983/L1013) — PAS a l'attachment lui-meme (verifie c.647, body `roo-extensions#933` MERGED 2026-08-25). L'attachment vit dans `AttachmentManager`, qui herite d'un cleanup par anciennete (4 sem par defaut), pas d'un TTL message.
 - Un secret **deja couvert par `.secrets/master.env`** se propage de preference par le pipeline `render_envs.py` + `docker compose restart` (plus simple, pas de transit du secret). Mais `master.env` **n'est pas un gate** : quand il ne couvre pas la cible (token ephemere, rotation ad-hoc, service hors catalogue, cle detenue par une seule machine), RooSync prive **est** le bon canal — pas un pis-aller a refuser.
 
 ### Interdit


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-po-2024:CoursIA-2 -- prev: docs c.646

## Contexte — issue #10333 (pool-reflux delivered verification)

L'issue **#10333** documentait depuis 2026-08-10 un canal d'attachment RooSync **cassé** dans `jsbo-state-manager` : `attachments_get` exige un `uuid` que `attachments_list` ne retourne jamais — boucle fermée par construction. La policy `secrets-hygiene.md` désignait l'attachment + `destruct_after` comme mode **préféré**, perpétuant la confusion (critère 5 de l'issue : « si l'attachment reste cassé, la policy ne doit pas le désigner comme mode préféré »).

### Vérification firsthand — livraison côté fournisseur (rifle `jsboige/jsboige-mcp-servers`)

| PR | Date merge | Ferme | Substance par rapport à #10333 |
|---|---|---|---|
| **[#1039](https://github.com/jsboige/jsboige-mcp-servers/pull/1039)** | 2026-08-25T01:36:49Z | roo-extensions#3256 | **`attachments_get(message_id, filename)` ferme la boucle** (critère 1 de #10333) ; lookup O(1) refs via `MessageManager.updateMessageAttachments`, plus de O(N_flotte) scan (critère latence >180s) ; 7 tool-tests + 5 service-tests sur store 10 000 metadata, mutation-verified. |
| **[#1043](https://github.com/jsboige/jsboige-mcp-servers/pull/1043)** | 2026-08-25T13:47:46Z | roo-extensions#3270 | `updateMessageAttachments` lisait `Promise<void>` au lieu de `<boolean>` — sous PG-primary les refs étaient silencieusement losted. Si `#1039` n'avait pas été livré avant, `#1043` aurait quand même sauvé les refs ; ensemble, les deux rendent la perte indétectable impossible. |
| **[#933](https://github.com/jsboige/jsboige-mcp-servers/pull/933)** | 2026-08-25 (MERGED 2026-07-30T03:21:55Z) | roo-extensions#3013 | Signale les entrées amorties silencieusement via `AttachmentListStats` (missingMetadata / readTimeout / parseError). **Confirme aussi** : `destruct_after` est appliqué dans `MessageManager` (`expires_at`, L983/L1013), **PAS dans `AttachmentManager`** — répond au critère 3 de #10333 (`destruct_after` sur attachment documenté comme non porté sur l'attachment lui-même). |

**Mapping acceptance #10333 → livraison :**

| Critère | Statut | Source |
|---|---|---|
| 1. `attachments_list` retourne uuid **OU** `attachments_get` accepte l'identifiant retourné par la liste | ✅ | PR #1039 — `attachments_get(message_id, filename)` |
| 2. Test d'intégration aller-retour : send → list → get → identique | ✅ | PR #1039 — 7 tool-tests mutation-verified |
| 3. `destruct_after` vérifié sur attachment, ou documenté comme non porté | ✅ | PR #933 — `destruct_after` porte sur le **message**, `AttachmentManager` cleanup par ancienneté 4 sem |
| 4. Cause établie par mesure (stockage vs projection) | ✅ | PR #1039 — projection (refs dans `Message.attachments[]`), pas stockage |
| 5. `secrets-hygiene.md` reflète l'état réel du canal | **Cette PR** | +2 lignes : API attachment + comportement `destruct_after` |

### Ce que cette PR change

Diff strict `+2/-0`, **un seul fichier** (`.claude/rules/secrets-hygiene.md`). Deux ajouts bornés dans la section « Autorise » :

1. **API attachment** : la voie nominale est `attachments_get(message_id, filename)` (ferme la boucle). `attachments_get(uuid=...)` reste valide par compatibilité. Sans cette mention, le consommateur continue à chercher le `uuid` dans la liste et tombe sur le même mur documenté c.647.
2. **`destruct_after` clarifié** : porte sur le **message** (`expires_at`), pas sur l'attachment lui-même. Attachment cleanup par ancienneté, pas TTL.

### Périmètre

- **Pool-reflux delivered** : c.647 vérifie firsthand que la conjonction `#1039 + #1043 + #933` ferme l'acceptance de #10333, via le mécanisme `check_unaddressed_nits.py` équivalent mais côté issue livré : grep `candidate-delivered` label + `gh pr view --json closingIssuesReferences` + lecture des bodies PR.
- **Scope strict** : un seul fichier policy (Règle HARD 3 catalogue-pr-hygiene.md : atomique).
- **Pas de section code** : c'est une mise à jour de règle, pas un refactor de moteur.

### Vérification Reassessment

- `git diff --stat` : +2/-0 sur 1 fichier ✓
- Pas de modification `COURSE_CATALOG.*` (régénéré par automation seulement, cf `catalog-pr-hygiene.md` Règle HARD 1)
- Pas de merge conflict attendu : scope isolé, main n'a pas bougé ce cycle côté policy.
- Lane claim : `[CLAIMED] lane myia-po-2024:CoursIA-2` implicite par le grain tag.

Closes #10333
