### PR TITLE
feat(search): App-20 CP-SAT native-both

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
@@ -1238,27 +1238,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation — ce que révèle le moteur de production\n",
-    "\n",
-    "**Sortie obtenue** : CP-SAT retourne `OPTIMAL` sur les trois grilles dans les deux configurations, avec des solutions **vérifiées valides indépendamment** (indices préservés, lignes/colonnes/carrés tous différents).\n",
-    "\n",
-    "| Aspect | Valeur observée | Signification |\n",
-    "|--------|-----------------|---------------|\n",
-    "| Branches (presolve=on) | 0 sur les 3 grilles | la phase de presolve + la propagation de racine fixent toutes les cases **sans aucune décision de recherche** |\n",
-    "| Branches (presolve=off) | 0 (Easy/Medium), quelques unités (Hard) | sans presolve, le noyau SAT n'a besoin que de très peu de décisions — la propagation fait tout le reste |\n",
-    "| Contraste from-scratch | près de 900 000 appels (naïf, Hard — cf. tableau §7) | le backtracking naïf paie au prix fort ce que CP-SAT obtient par propagation de contraintes globales |\n",
-    "| Validité | True partout | invariant structurel, vérifié hors du moteur |\n",
-    "\n",
-    "**Points clés** :\n",
-    "\n",
-    "1. **La propagation est la vraie héroïne.** Avec `AddAllDifferent`, CP-SAT dispose d'un filtrage bien plus puissant que l'AC-3 binaire de la section 5 : le raisonnement au niveau racine suffit à fixer toutes les cases — le compteur de branches reste à zéro même sur la grille Hard. C'est la leçon à retenir : ce n'est pas la recherche qui est industrielle, c'est la **propagation**.\n",
-    "2. **`branches`/`conflicts` ne sont PAS les « appels récursifs » des solveurs from-scratch.** Ce sont des événements internes du moteur SAT (décisions de branchement, conflits appris) : ils se comparent en ordre de grandeur, pas unité pour unité. Le contraste des ordres de grandeur reste néanmoins écrasant.\n",
-    "3. **Déterminisme par construction** : `num_search_workers=1` + `random_seed=42` rendent chaque compteur reproductible exécution après exécution — ce sont des **invariants structurels**, au même titre que le nombre d'appels des solveurs from-scratch. Le twin C# exécute le **même moteur, même version** (portage .NET officiel du même code C++) : les compteurs sont directement comparables entre les deux notebooks.\n",
-    "4. **Ce que la boîte noire industrialise** : précisément le contenu des sections 3 à 6 — choix de variable (MRV), filtrage (AC-3), encodage structurel (exact-cover) — assemblés et poussés au niveau production. La tranche 1 rend la mécanique visible ; la tranche 2 montre où elle mène une fois combinée.\n",
-    "\n",
-    "> **Note technique** : le temps wall de CP-SAT (durée de l'ordre de la milliseconde, *machine-dep*) inclut la traduction du modèle vers le noyau SAT ; il se compare aux solveurs from-scratch à titre informatif seulement, comme tout au long de ce notebook."
-   ]
+   "source": "### Interprétation — ce que révèle le moteur de production\n\n**Sortie obtenue** : CP-SAT retourne `OPTIMAL` sur les trois grilles dans les deux configurations, avec des solutions **vérifiées valides indépendamment** (indices préservés, lignes/colonnes/carrés tous différents).\n\n| Aspect | Valeur observée | Signification |\n|--------|-----------------|---------------|\n| Branches (presolve=on) | 0 sur les 3 grilles | la phase de presolve + la propagation de racine fixent toutes les cases **sans aucune décision de recherche** |\n| Branches (presolve=off) | 0 (Easy/Medium), quelques unités (Hard) | sans presolve, le noyau SAT n'a besoin que de très peu de décisions — la propagation fait tout le reste |\n| Contraste from-scratch | près de 900 000 appels (naïf, Hard — cf. tableau §7) | le backtracking naïf paie au prix fort ce que CP-SAT obtient par propagation de contraintes globales |\n| Validité | True partout | invariant structurel, vérifié hors du moteur |\n\n**Points clés** :\n\n1. **La propagation est la vraie héroïne.** Avec `AddAllDifferent`, CP-SAT dispose d'un filtrage bien plus puissant que l'AC-3 binaire de la section 5 : le raisonnement au niveau racine suffit à fixer toutes les cases — le compteur de branches reste à zéro même sur la grille Hard. C'est la leçon à retenir : ce n'est pas la recherche qui est industrielle, c'est la **propagation**.\n2. **`branches`/`conflicts` ne sont PAS les « appels récursifs » des solveurs from-scratch.** Ce sont des événements internes du moteur SAT (décisions de branchement, conflits appris) : ils se comparent en ordre de grandeur, pas unité pour unité. Le contraste des ordres de grandeur reste néanmoins écrasant.\n3. **Déterminisme conditionné par la version épinglée** : `num_search_workers=1` + `random_seed=42` rendent chaque compteur reproductible pour OR-Tools `9.15.6755`, version imposée par l'assertion runtime. Le twin C# exécute le **même moteur, même version** (portage .NET officiel du même code C++) : les compteurs sont directement comparables entre les deux notebooks. Une autre version du moteur pourrait produire des compteurs différents.\n4. **Ce que la boîte noire industrialise** : précisément le contenu des sections 3 à 6 — choix de variable (MRV), filtrage (AC-3), encodage structurel (exact-cover) — assemblés et poussés au niveau production. La tranche 1 rend la mécanique visible ; la tranche 2 montre où elle mène une fois combinée.\n\n> **Note technique** : le temps wall de CP-SAT (durée de l'ordre de la milliseconde, *machine-dep*) inclut la traduction du modèle vers le noyau SAT ; il se compare aux solveurs from-scratch à titre informatif seulement, comme tout au long de ce notebook."
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "ee885a95",
    "metadata": {
     "papermill": {
-     "duration": 0.011857,
-     "end_time": "2026-07-03T03:00:24.146245",
+     "duration": 0.016634,
+     "end_time": "2026-08-29T05:24:51.038118+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.134388",
+     "start_time": "2026-08-29T05:24:51.021484+00:00",
      "status": "completed"
     },
     "tags": []
@@ -65,10 +65,10 @@
    "id": "144a39c7",
    "metadata": {
     "papermill": {
-     "duration": 0.010395,
-     "end_time": "2026-07-03T03:00:24.166941",
+     "duration": 0.011844,
+     "end_time": "2026-08-29T05:24:51.058707+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.156546",
+     "start_time": "2026-08-29T05:24:51.046863+00:00",
      "status": "completed"
     },
     "tags": []
@@ -91,19 +91,19 @@
    "id": "2e0405bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T03:00:24.191020Z",
-     "iopub.status.busy": "2026-07-03T03:00:24.189826Z",
-     "iopub.status.idle": "2026-07-03T03:00:24.210169Z",
-     "shell.execute_reply": "2026-07-03T03:00:24.208306Z"
+     "iopub.execute_input": "2026-08-29T05:24:51.068839Z",
+     "iopub.status.busy": "2026-08-29T05:24:51.068532Z",
+     "iopub.status.idle": "2026-08-29T05:24:51.077054Z",
+     "shell.execute_reply": "2026-08-29T05:24:51.076447Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.035461,
-     "end_time": "2026-07-03T03:00:24.213187",
+     "duration": 0.013093,
+     "end_time": "2026-08-29T05:24:51.077823+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.177726",
+     "start_time": "2026-08-29T05:24:51.064730+00:00",
      "status": "completed"
     },
     "tags": []
@@ -139,10 +139,10 @@
    "id": "02601abc",
    "metadata": {
     "papermill": {
-     "duration": 0.00906,
-     "end_time": "2026-07-03T03:00:24.231209",
+     "duration": 0.002822,
+     "end_time": "2026-08-29T05:24:51.084614+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.222149",
+     "start_time": "2026-08-29T05:24:51.081792+00:00",
      "status": "completed"
     },
     "tags": []
@@ -167,19 +167,19 @@
    "id": "2b598995",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T03:00:24.255313Z",
-     "iopub.status.busy": "2026-07-03T03:00:24.254237Z",
-     "iopub.status.idle": "2026-07-03T03:00:24.271836Z",
-     "shell.execute_reply": "2026-07-03T03:00:24.270136Z"
+     "iopub.execute_input": "2026-08-29T05:24:51.091126Z",
+     "iopub.status.busy": "2026-08-29T05:24:51.090932Z",
+     "iopub.status.idle": "2026-08-29T05:24:51.097207Z",
+     "shell.execute_reply": "2026-08-29T05:24:51.096589Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.03209,
-     "end_time": "2026-07-03T03:00:24.274631",
+     "duration": 0.010507,
+     "end_time": "2026-08-29T05:24:51.097688+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.242541",
+     "start_time": "2026-08-29T05:24:51.087181+00:00",
      "status": "completed"
     },
     "tags": []
@@ -251,10 +251,10 @@
    "id": "76090f5d",
    "metadata": {
     "papermill": {
-     "duration": 0.008771,
-     "end_time": "2026-07-03T03:00:24.293487",
+     "duration": 0.002753,
+     "end_time": "2026-08-29T05:24:51.103151+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.284716",
+     "start_time": "2026-08-29T05:24:51.100398+00:00",
      "status": "completed"
     },
     "tags": []
@@ -275,19 +275,19 @@
    "id": "b17f4bdf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T03:00:24.313912Z",
-     "iopub.status.busy": "2026-07-03T03:00:24.313101Z",
-     "iopub.status.idle": "2026-07-03T03:00:24.396908Z",
-     "shell.execute_reply": "2026-07-03T03:00:24.394668Z"
+     "iopub.execute_input": "2026-08-29T05:24:51.111202Z",
+     "iopub.status.busy": "2026-08-29T05:24:51.111031Z",
+     "iopub.status.idle": "2026-08-29T05:24:51.131332Z",
+     "shell.execute_reply": "2026-08-29T05:24:51.130756Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.09855,
-     "end_time": "2026-07-03T03:00:24.401044",
+     "duration": 0.025472,
+     "end_time": "2026-08-29T05:24:51.132171+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.302494",
+     "start_time": "2026-08-29T05:24:51.106699+00:00",
      "status": "completed"
     },
     "tags": []
@@ -297,7 +297,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Backtracking simple — Easy : succes=True, temps=64.41 ms, appels=4209\n"
+      "Backtracking simple — Easy : succes=True, temps=13.05 ms, appels=4209\n"
      ]
     }
    ],
@@ -364,10 +364,10 @@
    "id": "7930e964",
    "metadata": {
     "papermill": {
-     "duration": 0.012543,
-     "end_time": "2026-07-03T03:00:24.426701",
+     "duration": 0.002232,
+     "end_time": "2026-08-29T05:24:51.136889+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.414158",
+     "start_time": "2026-08-29T05:24:51.134657+00:00",
      "status": "completed"
     },
     "tags": []
@@ -391,19 +391,19 @@
    "id": "bd7a4df3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T03:00:24.460605Z",
-     "iopub.status.busy": "2026-07-03T03:00:24.459758Z",
-     "iopub.status.idle": "2026-07-03T03:00:24.493956Z",
-     "shell.execute_reply": "2026-07-03T03:00:24.491027Z"
+     "iopub.execute_input": "2026-08-29T05:24:51.142112Z",
+     "iopub.status.busy": "2026-08-29T05:24:51.141976Z",
+     "iopub.status.idle": "2026-08-29T05:24:51.149424Z",
+     "shell.execute_reply": "2026-08-29T05:24:51.148848Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.054672,
-     "end_time": "2026-07-03T03:00:24.498753",
+     "duration": 0.010751,
+     "end_time": "2026-08-29T05:24:51.149899+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.444081",
+     "start_time": "2026-08-29T05:24:51.139148+00:00",
      "status": "completed"
     },
     "tags": []
@@ -413,7 +413,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Backtracking+MRV — Easy : succes=True, temps=8.41 ms, appels=52\n"
+      "Backtracking+MRV — Easy : succes=True, temps=1.89 ms, appels=52\n"
      ]
     }
    ],
@@ -474,10 +474,10 @@
    "id": "59244654",
    "metadata": {
     "papermill": {
-     "duration": 0.010727,
-     "end_time": "2026-07-03T03:00:24.520849",
+     "duration": 0.002215,
+     "end_time": "2026-08-29T05:24:51.154545+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.510122",
+     "start_time": "2026-08-29T05:24:51.152330+00:00",
      "status": "completed"
     },
     "tags": []
@@ -500,19 +500,19 @@
    "id": "2e5d8e15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T03:00:24.547781Z",
-     "iopub.status.busy": "2026-07-03T03:00:24.546883Z",
-     "iopub.status.idle": "2026-07-03T03:00:24.658667Z",
-     "shell.execute_reply": "2026-07-03T03:00:24.656171Z"
+     "iopub.execute_input": "2026-08-29T05:24:51.159800Z",
+     "iopub.status.busy": "2026-08-29T05:24:51.159673Z",
+     "iopub.status.idle": "2026-08-29T05:24:51.177178Z",
+     "shell.execute_reply": "2026-08-29T05:24:51.176731Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.129017,
-     "end_time": "2026-07-03T03:00:24.662173",
+     "duration": 0.02109,
+     "end_time": "2026-08-29T05:24:51.177886+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.533156",
+     "start_time": "2026-08-29T05:24:51.156796+00:00",
      "status": "completed"
     },
     "tags": []
@@ -522,7 +522,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "AC-3 — Easy : succes=True, temps=78.84 ms, appels=82\n"
+      "AC-3 — Easy : succes=True, temps=10.46 ms, appels=82\n"
      ]
     }
    ],
@@ -638,10 +638,10 @@
    "id": "5243766f",
    "metadata": {
     "papermill": {
-     "duration": 0.010267,
-     "end_time": "2026-07-03T03:00:24.681983",
+     "duration": 0.002315,
+     "end_time": "2026-08-29T05:24:51.182717+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.671716",
+     "start_time": "2026-08-29T05:24:51.180402+00:00",
      "status": "completed"
     },
     "tags": []
@@ -665,19 +665,19 @@
    "id": "3e2d1985",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T03:00:24.708654Z",
-     "iopub.status.busy": "2026-07-03T03:00:24.707385Z",
-     "iopub.status.idle": "2026-07-03T03:00:24.752154Z",
-     "shell.execute_reply": "2026-07-03T03:00:24.749628Z"
+     "iopub.execute_input": "2026-08-29T05:24:51.188083Z",
+     "iopub.status.busy": "2026-08-29T05:24:51.187946Z",
+     "iopub.status.idle": "2026-08-29T05:24:51.197094Z",
+     "shell.execute_reply": "2026-08-29T05:24:51.196571Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.063088,
-     "end_time": "2026-07-03T03:00:24.755429",
+     "duration": 0.012518,
+     "end_time": "2026-08-29T05:24:51.197546+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.692341",
+     "start_time": "2026-08-29T05:24:51.185028+00:00",
      "status": "completed"
     },
     "tags": []
@@ -687,7 +687,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DLX — Easy : succes=True, temps=6.04 ms, appels=82\n"
+      "DLX — Easy : succes=True, temps=0.99 ms, appels=82\n"
      ]
     }
    ],
@@ -859,10 +859,10 @@
    "id": "cf7a2250",
    "metadata": {
     "papermill": {
-     "duration": 0.008771,
-     "end_time": "2026-07-03T03:00:24.773986",
+     "duration": 0.002227,
+     "end_time": "2026-08-29T05:24:51.202196+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.765215",
+     "start_time": "2026-08-29T05:24:51.199969+00:00",
      "status": "completed"
     },
     "tags": []
@@ -882,19 +882,19 @@
    "id": "482ab0ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T03:00:24.793463Z",
-     "iopub.status.busy": "2026-07-03T03:00:24.792759Z",
-     "iopub.status.idle": "2026-07-03T03:01:52.949044Z",
-     "shell.execute_reply": "2026-07-03T03:01:52.946944Z"
+     "iopub.execute_input": "2026-08-29T05:24:51.207773Z",
+     "iopub.status.busy": "2026-08-29T05:24:51.207628Z",
+     "iopub.status.idle": "2026-08-29T05:25:12.093333Z",
+     "shell.execute_reply": "2026-08-29T05:25:12.092802Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 88.172695,
-     "end_time": "2026-07-03T03:01:52.955213",
+     "duration": 20.889458,
+     "end_time": "2026-08-29T05:25:12.093949+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:00:24.782518",
+     "start_time": "2026-08-29T05:24:51.204491+00:00",
      "status": "completed"
     },
     "tags": []
@@ -904,49 +904,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Easy   | Backtracking simple      | succes=True | temps=   59.16 ms | appels=    4209"
+      "Easy   | Backtracking simple      | succes=True | temps=   12.14 ms | appels=    4209\n",
+      "Easy   | Backtracking + MRV       | succes=True | temps=    1.79 ms | appels=      52\n",
+      "Easy   | AC-3 + backtracking      | succes=True | temps=   11.54 ms | appels=      82\n",
+      "Easy   | DLX (Knuth)              | succes=True | temps=    1.10 ms | appels=      82\n",
+      "Medium | Backtracking simple      | succes=True | temps=    0.16 ms | appels=      55\n",
+      "Medium | Backtracking + MRV       | succes=True | temps=    1.49 ms | appels=      46\n",
+      "Medium | AC-3 + backtracking      | succes=True | temps=    8.71 ms | appels=      82\n",
+      "Medium | DLX (Knuth)              | succes=True | temps=    0.94 ms | appels=      82\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Easy   | Backtracking + MRV       | succes=True | temps=    7.76 ms | appels=      52\n",
-      "Easy   | AC-3 + backtracking      | succes=True | temps=   46.85 ms | appels=      82\n",
-      "Easy   | DLX (Knuth)              | succes=True | temps=    3.94 ms | appels=      82\n",
-      "Medium | Backtracking simple      | succes=True | temps=    0.71 ms | appels=      55\n",
-      "Medium | Backtracking + MRV       | succes=True | temps=    5.79 ms | appels=      46\n"
+      "Hard   | Backtracking simple      | succes=True | temps= 3890.87 ms | appels=  879418\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Medium | AC-3 + backtracking      | succes=True | temps=   41.40 ms | appels=      82\n",
-      "Medium | DLX (Knuth)              | succes=True | temps=    4.71 ms | appels=      82\n"
+      "Hard   | Backtracking + MRV       | succes=True | temps=  268.95 ms | appels=    5565\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hard   | Backtracking simple      | succes=True | temps=11811.15 ms | appels=  879418\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hard   | Backtracking + MRV       | succes=True | temps=  949.08 ms | appels=    5565\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hard   | AC-3 + backtracking      | succes=False | temps=75199.77 ms | appels=  981113 [TIMEOUT]\n",
-      "Hard   | DLX (Knuth)              | succes=True | temps=    7.08 ms | appels=     103\n"
+      "Hard   | AC-3 + backtracking      | succes=True | temps=16679.55 ms | appels=  981113\n",
+      "Hard   | DLX (Knuth)              | succes=True | temps=    2.38 ms | appels=     103\n"
      ]
     }
    ],
@@ -987,10 +974,10 @@
    "id": "e2091bc6",
    "metadata": {
     "papermill": {
-     "duration": 0.006677,
-     "end_time": "2026-07-03T03:01:52.968781",
+     "duration": 0.002661,
+     "end_time": "2026-08-29T05:25:12.099871+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:01:52.962104",
+     "start_time": "2026-08-29T05:25:12.097210+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1014,13 +1001,270 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3ea0c082",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002529,
+     "end_time": "2026-08-29T05:25:12.105062+00:00",
+     "exception": false,
+     "start_time": "2026-08-29T05:25:12.102533+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Tranche 2 — moteur de production : OR-Tools CP-SAT (native-both, #10382)\n",
+    "\n",
+    "Les quatre solveurs ci-dessus sont **from-scratch** : chaque ligne de leur mécanique interne est visible — c'est le socle pédagogique (Tranche 1), **préservé intégralement**. Cette section ajoute une **tranche clairement séparée** : confronter ces implémentations au **moteur de production** Google **OR-Tools CP-SAT** (Perron & Furnon ; noyau SAT + *Lazy Clause Generation*), le même moteur des deux côtés de la paire jumelle Python ↔ C# — parité de moteur *lib-vs-lib*.\n",
+    "\n",
+    "**Modélisation CP-SAT** (miroir exact du twin [`App-20b`](App-20b-SudokuBenchmark-CSharp.ipynb)) :\n",
+    "\n",
+    "- une variable entière `c_{r,c} ∈ {1..9}` par case (domaine réduit au singleton pour chaque indice donné) ;\n",
+    "- 27 contraintes globales `AddAllDifferent` : 9 lignes, 9 colonnes, 9 carrés 3×3.\n",
+    "\n",
+    "**Métriques invariantes** — le fil rouge du notebook s'applique aussi au moteur industriel :\n",
+    "\n",
+    "- `num_search_workers = 1` + `random_seed = 42` → recherche **mono-thread déterministe** : `branches`, `conflicts` et les compteurs de propagation sont des **invariants structurels**, reproductibles exécution après exécution ;\n",
+    "- chaque solution est **vérifiée indépendamment du moteur** (indices préservés + lignes/colonnes/carrés tous différents) : la validité est un invariant ;\n",
+    "- le **temps** reste *machine-dep* (informatif uniquement), comme pour les solveurs from-scratch.\n",
+    "\n",
+    "Deux configurations sont mesurées sur les **mêmes trois grilles** :\n",
+    "\n",
+    "1. **Par défaut** (`cp_model_presolve = true`) — le mode production ;\n",
+    "2. **`cp_model_presolve = false`** — pour **exposer le moteur de recherche SAT sous-jacent**, que le presolve court-circuite dans le mode par défaut.\n",
+    "\n",
+    "> **Note** : la version du moteur est imprimée par la cellule suivante. Le twin C# exécute le **même numéro de version** (portage .NET officiel du même code C++), condition de comparabilité des compteurs `branches`/`conflicts` entre les deux langages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d358ea2b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T05:25:12.111271Z",
+     "iopub.status.busy": "2026-08-29T05:25:12.111082Z",
+     "iopub.status.idle": "2026-08-29T05:25:12.946766Z",
+     "shell.execute_reply": "2026-08-29T05:25:12.945735Z"
+    },
+    "papermill": {
+     "duration": 0.839968,
+     "end_time": "2026-08-29T05:25:12.947668+00:00",
+     "exception": false,
+     "start_time": "2026-08-29T05:25:12.107700+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OR-Tools version : 9.15.6755\n",
+      "CP-SAT — Easy (presolve on) : statut=OPTIMAL, branches=0, conflicts=0, temps=38.7 ms, solution valide=True\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ortools.sat.python import cp_model\n",
+    "import ortools\n",
+    "\n",
+    "\n",
+    "def build_cpsat_model(grid):\n",
+    "    \"\"\"Construit le modele CP-SAT du Sudoku (miroir exact du twin C# App-20b).\"\"\"\n",
+    "    model = cp_model.CpModel()\n",
+    "    cells = {}\n",
+    "    for r in range(9):\n",
+    "        for c in range(9):\n",
+    "            v = grid[r][c]\n",
+    "            # Domaine {1..9} pour une case vide, singleton pour un indice donne\n",
+    "            cells[(r, c)] = model.NewIntVar(v if v else 1, v if v else 9, f\"c_{r}_{c}\")\n",
+    "    for i in range(9):\n",
+    "        model.AddAllDifferent([cells[(i, j)] for j in range(9)])          # lignes\n",
+    "        model.AddAllDifferent([cells[(j, i)] for j in range(9)])          # colonnes\n",
+    "    for br in range(0, 9, 3):\n",
+    "        for bc in range(0, 9, 3):\n",
+    "            model.AddAllDifferent([cells[(br + r, bc + c)] for r in range(3) for c in range(3)])  # carres\n",
+    "    return model, cells\n",
+    "\n",
+    "\n",
+    "def run_cpsat(grid, use_presolve=True):\n",
+    "    \"\"\"Execute OR-Tools CP-SAT. Retourne le dictionnaire d'invariants + la solution.\n",
+    "\n",
+    "    Metriques invariantes : statut, branches, conflicts, propagations --\n",
+    "    la recherche est mono-thread (num_search_workers=1) et seedee (random_seed=42),\n",
+    "    donc deterministe d une execution a l autre. Le temps wall reste machine-dep\n",
+    "    (informatif), comme pour les solveurs from-scratch.\n",
+    "    \"\"\"\n",
+    "    model, cells = build_cpsat_model(grid)\n",
+    "    solver = cp_model.CpSolver()\n",
+    "    solver.parameters.num_search_workers = 1   # determinisme : mono-thread\n",
+    "    solver.parameters.random_seed = 42         # graine fixee, miroir du twin C#\n",
+    "    solver.parameters.max_time_in_seconds = TIMEOUT_S\n",
+    "    solver.parameters.cp_model_presolve = use_presolve\n",
+    "    t0 = time.perf_counter()\n",
+    "    status = solver.Solve(model)\n",
+    "    elapsed_ms = (time.perf_counter() - t0) * 1000.0\n",
+    "    ok = status in (cp_model.OPTIMAL, cp_model.FEASIBLE)\n",
+    "    solved = None\n",
+    "    if ok:\n",
+    "        solved = [[int(solver.Value(cells[(r, c)])) for c in range(9)] for r in range(9)]\n",
+    "    resp = solver.ResponseProto()\n",
+    "    return {\n",
+    "        \"statut\": solver.StatusName(status),\n",
+    "        \"succes\": ok,\n",
+    "        \"branches\": int(solver.NumBranches()),\n",
+    "        \"conflicts\": int(solver.NumConflicts()),\n",
+    "        \"prop_binaires\": int(resp.num_binary_propagations),\n",
+    "        \"prop_entieres\": int(resp.num_integer_propagations),\n",
+    "        \"temps_ms\": elapsed_ms,  # machine-dep, informatif\n",
+    "        \"solution\": solved,\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def check_sudoku_solution(grid, solution):\n",
+    "    \"\"\"Verification independante du moteur : indices preserves + alldiff lignes/colonnes/carres.\"\"\"\n",
+    "    if solution is None:\n",
+    "        return False\n",
+    "    if any(solution[r][c] != grid[r][c] for r in range(9) for c in range(9) if grid[r][c] != 0):\n",
+    "        return False\n",
+    "    full = set(range(1, 10))\n",
+    "    if any(set(solution[r]) != full for r in range(9)):\n",
+    "        return False\n",
+    "    if any({solution[r][c] for r in range(9)} != full for c in range(9)):\n",
+    "        return False\n",
+    "    for br in range(0, 9, 3):\n",
+    "        for bc in range(0, 9, 3):\n",
+    "            if {solution[br + r][bc + c] for r in range(3) for c in range(3)} != full:\n",
+    "                return False\n",
+    "    return True\n",
+    "\n",
+    "\n",
+    "print(f\"OR-Tools version : {ortools.__version__}\")\n",
+    "\n",
+    "# Smoke test sur Easy (configuration par defaut)\n",
+    "res_demo = run_cpsat(EASY_GRID)\n",
+    "valide_demo = check_sudoku_solution(EASY_GRID, res_demo[\"solution\"])\n",
+    "print(f\"CP-SAT — Easy (presolve on) : statut={res_demo['statut']}, \"\n",
+    "      f\"branches={res_demo['branches']}, conflicts={res_demo['conflicts']}, \"\n",
+    "      f\"temps={res_demo['temps_ms']:.1f} ms, solution valide={valide_demo}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "024df40d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003262,
+     "end_time": "2026-08-29T05:25:12.955754+00:00",
+     "exception": false,
+     "start_time": "2026-08-29T05:25:12.952492+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Avec le moteur défini, déroulons le même protocole que le socle : les **trois grilles** (Easy / Medium / Hard) dans **deux configurations** (`presolve=on` puis `presolve=off`). Pour chaque combinaison : statut, validité de la grille produite, branches, conflicts, propagations -- et le temps, informatif."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6c70fc72",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T05:25:12.964702Z",
+     "iopub.status.busy": "2026-08-29T05:25:12.964486Z",
+     "iopub.status.idle": "2026-08-29T05:25:13.051502Z",
+     "shell.execute_reply": "2026-08-29T05:25:13.050472Z"
+    },
+    "papermill": {
+     "duration": 0.092261,
+     "end_time": "2026-08-29T05:25:13.052818+00:00",
+     "exception": false,
+     "start_time": "2026-08-29T05:25:12.960557+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Grille  | Config       | Statut   | Valide | Branches | Conflicts | Prop.bin  | Prop.int  | Temps(ms)\n",
+      "----------------------------------------------------------------------------------------------------\n",
+      "Easy    | presolve=on  | OPTIMAL  | True   |        0 |         0 |         0 |         0 |       1.2\n",
+      "Easy    | presolve=off | OPTIMAL  | True   |        0 |         0 |       340 |       111 |      19.2\n",
+      "Medium  | presolve=on  | OPTIMAL  | True   |        0 |         0 |         0 |         0 |       3.4\n",
+      "Medium  | presolve=off | OPTIMAL  | True   |        0 |         0 |       251 |        49 |       4.5\n",
+      "Hard    | presolve=on  | OPTIMAL  | True   |        0 |         0 |         0 |         0 |      22.5\n",
+      "Hard    | presolve=off | OPTIMAL  | True   |        5 |         2 |       790 |       213 |      13.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Benchmark CP-SAT : les 3 grilles x 2 configurations (presolve on/off).\n",
+    "# Invariants : statut, validite, branches, conflicts, propagations (mono-thread deterministe).\n",
+    "# Temps = machine-dep (informatif uniquement).\n",
+    "print(f\"{'Grille':7s} | {'Config':12s} | {'Statut':8s} | {'Valide':6s} | {'Branches':8s} | \"\n",
+    "      f\"{'Conflicts':9s} | {'Prop.bin':9s} | {'Prop.int':9s} | {'Temps(ms)':9s}\")\n",
+    "print(\"-\" * 100)\n",
+    "for diff_name in DIFFICULTIES:\n",
+    "    grid = GRIDS[diff_name]\n",
+    "    for config_name, use_presolve in [(\"presolve=on\", True), (\"presolve=off\", False)]:\n",
+    "        res = run_cpsat(grid, use_presolve=use_presolve)\n",
+    "        valide = check_sudoku_solution(grid, res[\"solution\"])\n",
+    "        print(f\"{diff_name:7s} | {config_name:12s} | {res['statut']:8s} | {str(valide):6s} | \"\n",
+    "              f\"{res['branches']:8d} | {res['conflicts']:9d} | {res['prop_binaires']:9d} | \"\n",
+    "              f\"{res['prop_entieres']:9d} | {res['temps_ms']:9.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c675165c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003409,
+     "end_time": "2026-08-29T05:25:13.061114+00:00",
+     "exception": false,
+     "start_time": "2026-08-29T05:25:13.057705+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation — ce que révèle le moteur de production\n",
+    "\n",
+    "**Sortie obtenue** : CP-SAT retourne `OPTIMAL` sur les trois grilles dans les deux configurations, avec des solutions **vérifiées valides indépendamment** (indices préservés, lignes/colonnes/carrés tous différents).\n",
+    "\n",
+    "| Aspect | Valeur observée | Signification |\n",
+    "|--------|-----------------|---------------|\n",
+    "| Branches (presolve=on) | 0 sur les 3 grilles | la phase de presolve + la propagation de racine fixent toutes les cases **sans aucune décision de recherche** |\n",
+    "| Branches (presolve=off) | 0 (Easy/Medium), quelques unités (Hard) | sans presolve, le noyau SAT n'a besoin que de très peu de décisions — la propagation fait tout le reste |\n",
+    "| Contraste from-scratch | près de 900 000 appels (naïf, Hard — cf. tableau §7) | le backtracking naïf paie au prix fort ce que CP-SAT obtient par propagation de contraintes globales |\n",
+    "| Validité | True partout | invariant structurel, vérifié hors du moteur |\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "1. **La propagation est la vraie héroïne.** Avec `AddAllDifferent`, CP-SAT dispose d'un filtrage bien plus puissant que l'AC-3 binaire de la section 5 : le raisonnement au niveau racine suffit à fixer toutes les cases — le compteur de branches reste à zéro même sur la grille Hard. C'est la leçon à retenir : ce n'est pas la recherche qui est industrielle, c'est la **propagation**.\n",
+    "2. **`branches`/`conflicts` ne sont PAS les « appels récursifs » des solveurs from-scratch.** Ce sont des événements internes du moteur SAT (décisions de branchement, conflits appris) : ils se comparent en ordre de grandeur, pas unité pour unité. Le contraste des ordres de grandeur reste néanmoins écrasant.\n",
+    "3. **Déterminisme par construction** : `num_search_workers=1` + `random_seed=42` rendent chaque compteur reproductible exécution après exécution — ce sont des **invariants structurels**, au même titre que le nombre d'appels des solveurs from-scratch. Le twin C# exécute le **même moteur, même version** (portage .NET officiel du même code C++) : les compteurs sont directement comparables entre les deux notebooks.\n",
+    "4. **Ce que la boîte noire industrialise** : précisément le contenu des sections 3 à 6 — choix de variable (MRV), filtrage (AC-3), encodage structurel (exact-cover) — assemblés et poussés au niveau production. La tranche 1 rend la mécanique visible ; la tranche 2 montre où elle mène une fois combinée.\n",
+    "\n",
+    "> **Note technique** : le temps wall de CP-SAT (durée de l'ordre de la milliseconde, *machine-dep*) inclut la traduction du modèle vers le noyau SAT ; il se compare aux solveurs from-scratch à titre informatif seulement, comme tout au long de ce notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "01256f6a",
    "metadata": {
     "papermill": {
-     "duration": 0.0097,
-     "end_time": "2026-07-03T03:01:52.985922",
+     "duration": 0.002385,
+     "end_time": "2026-08-29T05:25:13.066162+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:01:52.976222",
+     "start_time": "2026-08-29T05:25:13.063777+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1037,23 +1281,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "4f5d00cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T03:01:53.008903Z",
-     "iopub.status.busy": "2026-07-03T03:01:53.007752Z",
-     "iopub.status.idle": "2026-07-03T03:01:53.020662Z",
-     "shell.execute_reply": "2026-07-03T03:01:53.018774Z"
+     "iopub.execute_input": "2026-08-29T05:25:13.071927Z",
+     "iopub.status.busy": "2026-08-29T05:25:13.071784Z",
+     "iopub.status.idle": "2026-08-29T05:25:13.075669Z",
+     "shell.execute_reply": "2026-08-29T05:25:13.075253Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.027517,
-     "end_time": "2026-07-03T03:01:53.023362",
+     "duration": 0.007616,
+     "end_time": "2026-08-29T05:25:13.076206+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:01:52.995845",
+     "start_time": "2026-08-29T05:25:13.068590+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1109,10 +1353,10 @@
    "id": "95c40832",
    "metadata": {
     "papermill": {
-     "duration": 0.009006,
-     "end_time": "2026-07-03T03:01:53.042294",
+     "duration": 0.002605,
+     "end_time": "2026-08-29T05:25:13.081538+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:01:53.033288",
+     "start_time": "2026-08-29T05:25:13.078933+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1129,23 +1373,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "49a26fd9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T03:01:53.064662Z",
-     "iopub.status.busy": "2026-07-03T03:01:53.063764Z",
-     "iopub.status.idle": "2026-07-03T03:01:53.083347Z",
-     "shell.execute_reply": "2026-07-03T03:01:53.081729Z"
+     "iopub.execute_input": "2026-08-29T05:25:13.087753Z",
+     "iopub.status.busy": "2026-08-29T05:25:13.087594Z",
+     "iopub.status.idle": "2026-08-29T05:25:13.090610Z",
+     "shell.execute_reply": "2026-08-29T05:25:13.090197Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.033677,
-     "end_time": "2026-07-03T03:01:53.086059",
+     "duration": 0.007232,
+     "end_time": "2026-08-29T05:25:13.091264+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:01:53.052382",
+     "start_time": "2026-08-29T05:25:13.084032+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1172,10 +1416,10 @@
    "id": "e11fff19",
    "metadata": {
     "papermill": {
-     "duration": 0.009332,
-     "end_time": "2026-07-03T03:01:53.103875",
+     "duration": 0.002422,
+     "end_time": "2026-08-29T05:25:13.096390+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:01:53.094543",
+     "start_time": "2026-08-29T05:25:13.093968+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1195,23 +1439,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "3f083a4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T03:01:53.125740Z",
-     "iopub.status.busy": "2026-07-03T03:01:53.125098Z",
-     "iopub.status.idle": "2026-07-03T03:01:53.136741Z",
-     "shell.execute_reply": "2026-07-03T03:01:53.134424Z"
+     "iopub.execute_input": "2026-08-29T05:25:13.102273Z",
+     "iopub.status.busy": "2026-08-29T05:25:13.102116Z",
+     "iopub.status.idle": "2026-08-29T05:25:13.105837Z",
+     "shell.execute_reply": "2026-08-29T05:25:13.105458Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.02619,
-     "end_time": "2026-07-03T03:01:53.139597",
+     "duration": 0.007591,
+     "end_time": "2026-08-29T05:25:13.106451+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:01:53.113407",
+     "start_time": "2026-08-29T05:25:13.098860+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1262,10 +1506,10 @@
    "id": "cd405af3",
    "metadata": {
     "papermill": {
-     "duration": 0.00917,
-     "end_time": "2026-07-03T03:01:53.158060",
+     "duration": 0.002766,
+     "end_time": "2026-08-29T05:25:13.112033+00:00",
      "exception": false,
-     "start_time": "2026-07-03T03:01:53.148890",
+     "start_time": "2026-08-29T05:25:13.109267+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1277,35 +1521,38 @@
     "\n",
     "**Le fil rouge du notebook** : passer d'un solveur naif (backtracking simple) a un solveur structure (DLX) montre que la richesse algorithmique d'un solveur de CSP ne reside pas dans la complexite asymptotique d'un seul algorithme, mais dans **l'interaction entre l'heuristique de sélection de variable** (MRV), **le filtrage des domaines** (AC-3), et **la structure de données** (DLX). Les solveurs industriels (Choco, OR-Tools, Gecode) combinent toutes ces techniques en un même moteur.\n",
     "\n",
-    "**Pour aller plus loin** : la serie *Search/Applications/CSP* presente d'autres problemes (N-Queens, Job Shop, Picross, Wordle) ou les mêmes compromis se posent avec des dominantes différentes.\n",
+    "**Tranche 2 (section 8)** : la confrontation au moteur de production OR-Tools CP-SAT confirme expérimentalement cette thèse — sur les mêmes grilles, sa propagation de contraintes globales fixe toutes les cases **sans aucune décision de recherche** (0 branche, même sur la grille Hard), là où le backtracking naïf déploie des centaines de milliers d'appels récursifs. Les deux tranches sont complémentaires : la première rend la mécanique visible, la seconde montre l'état de l'art une fois ces techniques industrialisées.\n",
+    "\n",
+    "**Pour aller plus loin** : la serie *Search/Applications/CSP* presente d'autres problemes (N-queens, Job Shop, Picross, Wordle) ou les mêmes compromis se posent avec des dominantes différentes.\n",
     "\n",
     "**References completes** :\n",
     "- Russell & Norvig, *AIMA* 4e ed. chap. 6 (CSP) — la reference pedagogique pour backtracking, MRV, AC-3.\n",
     "- Knuth, D. E. (2000). « Dancing Links ». *Millennial Perspectives in Computer Science*. — l'article fondateur de DLX.\n",
     "- Gent, I., et al. (2011). « Algorithms for the Constraint Satisfaction Problem ». — panorama des solveurs modernes.\n",
+    "- Perron, L., & Furnon, V. — *Google OR-Tools CP-SAT* (documentation officielle), moteur de la tranche 2.\n",
     "\n",
-    "*Notebook concu pour la serie Search/Applications/CSP (Prong B EPIC #3801 : problème non-trivial qui met les solveurs en valeur, pas le cas degenere).*\n"
+    "*Notebook concu pour la serie Search/Applications/CSP (Prong B EPIC #3801 : problème non-trivial qui met les solveurs en valeur, pas le cas degenere). Tranche 2 native-both EPIC #10382.*"
    ]
   }
  ],
  "metadata": {
   "cost": {
-   "api_usd_est": 0.0,
    "api_provider": "none",
-   "qcc_tokens_est": 0,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "none",
-   "network": true,
+   "api_usd_est": 0,
+   "cpu_min": 1,
    "external_account": false,
    "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-03",
+   "network": true,
+   "notes": "Sudoku solver benchmark (DLX/Norvig backtracking, stdlib copy/random/time/typing). random.Random seeded for puzzle generation. Deterministic solvers. CPU-only. cell19 = student exercise stub (# TODO, no output by design, C.1 conforming).",
+   "qcc_tokens_est": 0,
    "reduced_pedagogical": false,
    "reproducibility": "HIGH",
-   "metadata_written": "2026-08-03",
    "validator": "check_cost_metadata.py",
-   "cpu_min": 1,
-   "notes": "Sudoku solver benchmark (DLX/Norvig backtracking, stdlib copy/random/time/typing). random.Random seeded for puzzle generation. Deterministic solvers. CPU-only. cell19 = student exercise stub (# TODO, no output by design, C.1 conforming)."
+   "vram_gb": 0,
+   "vram_tier": "none"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -1322,18 +1569,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.14"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 94.419504,
-   "end_time": "2026-07-03T03:01:53.513636",
+   "duration": 25.546529,
+   "end_time": "2026-08-29T05:25:13.352869+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb",
    "output_path": "MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb",
    "parameters": {},
-   "start_time": "2026-07-03T03:00:19.094132",
+   "start_time": "2026-08-29T05:24:47.806340+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
@@ -1238,7 +1238,27 @@
     },
     "tags": []
    },
-   "source": "### Interprétation — ce que révèle le moteur de production\n\n**Sortie obtenue** : CP-SAT retourne `OPTIMAL` sur les trois grilles dans les deux configurations, avec des solutions **vérifiées valides indépendamment** (indices préservés, lignes/colonnes/carrés tous différents).\n\n| Aspect | Valeur observée | Signification |\n|--------|-----------------|---------------|\n| Branches (presolve=on) | 0 sur les 3 grilles | la phase de presolve + la propagation de racine fixent toutes les cases **sans aucune décision de recherche** |\n| Branches (presolve=off) | 0 (Easy/Medium), quelques unités (Hard) | sans presolve, le noyau SAT n'a besoin que de très peu de décisions — la propagation fait tout le reste |\n| Contraste from-scratch | près de 900 000 appels (naïf, Hard — cf. tableau §7) | le backtracking naïf paie au prix fort ce que CP-SAT obtient par propagation de contraintes globales |\n| Validité | True partout | invariant structurel, vérifié hors du moteur |\n\n**Points clés** :\n\n1. **La propagation est la vraie héroïne.** Avec `AddAllDifferent`, CP-SAT dispose d'un filtrage bien plus puissant que l'AC-3 binaire de la section 5 : le raisonnement au niveau racine suffit à fixer toutes les cases — le compteur de branches reste à zéro même sur la grille Hard. C'est la leçon à retenir : ce n'est pas la recherche qui est industrielle, c'est la **propagation**.\n2. **`branches`/`conflicts` ne sont PAS les « appels récursifs » des solveurs from-scratch.** Ce sont des événements internes du moteur SAT (décisions de branchement, conflits appris) : ils se comparent en ordre de grandeur, pas unité pour unité. Le contraste des ordres de grandeur reste néanmoins écrasant.\n3. **Déterminisme conditionné par la version épinglée** : `num_search_workers=1` + `random_seed=42` rendent chaque compteur reproductible pour OR-Tools `9.15.6755`, version imposée par l'assertion runtime. Le twin C# exécute le **même moteur, même version** (portage .NET officiel du même code C++) : les compteurs sont directement comparables entre les deux notebooks. Une autre version du moteur pourrait produire des compteurs différents.\n4. **Ce que la boîte noire industrialise** : précisément le contenu des sections 3 à 6 — choix de variable (MRV), filtrage (AC-3), encodage structurel (exact-cover) — assemblés et poussés au niveau production. La tranche 1 rend la mécanique visible ; la tranche 2 montre où elle mène une fois combinée.\n\n> **Note technique** : le temps wall de CP-SAT (durée de l'ordre de la milliseconde, *machine-dep*) inclut la traduction du modèle vers le noyau SAT ; il se compare aux solveurs from-scratch à titre informatif seulement, comme tout au long de ce notebook."
+   "source": [
+    "### Interprétation — ce que révèle le moteur de production\n",
+    "\n",
+    "**Sortie obtenue** : CP-SAT retourne `OPTIMAL` sur les trois grilles dans les deux configurations, avec des solutions **vérifiées valides indépendamment** (indices préservés, lignes/colonnes/carrés tous différents).\n",
+    "\n",
+    "| Aspect | Valeur observée | Signification |\n",
+    "|--------|-----------------|---------------|\n",
+    "| Branches (presolve=on) | 0 sur les 3 grilles | la phase de presolve + la propagation de racine fixent toutes les cases **sans aucune décision de recherche** |\n",
+    "| Branches (presolve=off) | 0 (Easy/Medium), quelques unités (Hard) | sans presolve, le noyau SAT n'a besoin que de très peu de décisions — la propagation fait tout le reste |\n",
+    "| Contraste from-scratch | près de 900 000 appels (naïf, Hard — cf. tableau §7) | le backtracking naïf paie au prix fort ce que CP-SAT obtient par propagation de contraintes globales |\n",
+    "| Validité | True partout | invariant structurel, vérifié hors du moteur |\n",
+    "\n",
+    "**Points clés** :\n",
+    "\n",
+    "1. **La propagation est la vraie héroïne.** Avec `AddAllDifferent`, CP-SAT dispose d'un filtrage bien plus puissant que l'AC-3 binaire de la section 5 : le raisonnement au niveau racine suffit à fixer toutes les cases — le compteur de branches reste à zéro même sur la grille Hard. C'est la leçon à retenir : ce n'est pas la recherche qui est industrielle, c'est la **propagation**.\n",
+    "2. **`branches`/`conflicts` ne sont PAS les « appels récursifs » des solveurs from-scratch.** Ce sont des événements internes du moteur SAT (décisions de branchement, conflits appris) : ils se comparent en ordre de grandeur, pas unité pour unité. Le contraste des ordres de grandeur reste néanmoins écrasant.\n",
+    "3. **Déterminisme conditionné par la version épinglée** : `num_search_workers=1` + `random_seed=42` rendent chaque compteur reproductible pour OR-Tools `9.15.6755`, version imposée par l'assertion runtime. Le twin C# exécute le **même moteur, même version** (portage .NET officiel du même code C++) : les compteurs sont directement comparables entre les deux notebooks. Une autre version du moteur pourrait produire des compteurs différents.\n",
+    "4. **Ce que la boîte noire industrialise** : précisément le contenu des sections 3 à 6 — choix de variable (MRV), filtrage (AC-3), encodage structurel (exact-cover) — assemblés et poussés au niveau production. La tranche 1 rend la mécanique visible ; la tranche 2 montre où elle mène une fois combinée.\n",
+    "\n",
+    "> **Note technique** : le temps wall de CP-SAT (durée de l'ordre de la milliseconde, *machine-dep*) inclut la traduction du modèle vers le noyau SAT ; il se compare aux solveurs from-scratch à titre informatif seulement, comme tout au long de ce notebook."
+   ]
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "ee885a95",
    "metadata": {
     "papermill": {
-     "duration": 0.016634,
-     "end_time": "2026-08-29T05:24:51.038118+00:00",
+     "duration": 0.009311,
+     "end_time": "2026-08-29T07:01:48.778928+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.021484+00:00",
+     "start_time": "2026-08-29T07:01:48.769617+00:00",
      "status": "completed"
     },
     "tags": []
@@ -65,10 +65,10 @@
    "id": "144a39c7",
    "metadata": {
     "papermill": {
-     "duration": 0.011844,
-     "end_time": "2026-08-29T05:24:51.058707+00:00",
+     "duration": 0.003886,
+     "end_time": "2026-08-29T07:01:48.788243+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.046863+00:00",
+     "start_time": "2026-08-29T07:01:48.784357+00:00",
      "status": "completed"
     },
     "tags": []
@@ -91,19 +91,19 @@
    "id": "2e0405bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:24:51.068839Z",
-     "iopub.status.busy": "2026-08-29T05:24:51.068532Z",
-     "iopub.status.idle": "2026-08-29T05:24:51.077054Z",
-     "shell.execute_reply": "2026-08-29T05:24:51.076447Z"
+     "iopub.execute_input": "2026-08-29T07:01:48.796557Z",
+     "iopub.status.busy": "2026-08-29T07:01:48.796397Z",
+     "iopub.status.idle": "2026-08-29T07:01:48.803347Z",
+     "shell.execute_reply": "2026-08-29T07:01:48.802317Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.013093,
-     "end_time": "2026-08-29T05:24:51.077823+00:00",
+     "duration": 0.012033,
+     "end_time": "2026-08-29T07:01:48.804966+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.064730+00:00",
+     "start_time": "2026-08-29T07:01:48.792933+00:00",
      "status": "completed"
     },
     "tags": []
@@ -139,10 +139,10 @@
    "id": "02601abc",
    "metadata": {
     "papermill": {
-     "duration": 0.002822,
-     "end_time": "2026-08-29T05:24:51.084614+00:00",
+     "duration": 0.003233,
+     "end_time": "2026-08-29T07:01:48.813791+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.081792+00:00",
+     "start_time": "2026-08-29T07:01:48.810558+00:00",
      "status": "completed"
     },
     "tags": []
@@ -167,19 +167,19 @@
    "id": "2b598995",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:24:51.091126Z",
-     "iopub.status.busy": "2026-08-29T05:24:51.090932Z",
-     "iopub.status.idle": "2026-08-29T05:24:51.097207Z",
-     "shell.execute_reply": "2026-08-29T05:24:51.096589Z"
+     "iopub.execute_input": "2026-08-29T07:01:48.819497Z",
+     "iopub.status.busy": "2026-08-29T07:01:48.819335Z",
+     "iopub.status.idle": "2026-08-29T07:01:48.824839Z",
+     "shell.execute_reply": "2026-08-29T07:01:48.824292Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.010507,
-     "end_time": "2026-08-29T05:24:51.097688+00:00",
+     "duration": 0.009372,
+     "end_time": "2026-08-29T07:01:48.825614+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.087181+00:00",
+     "start_time": "2026-08-29T07:01:48.816242+00:00",
      "status": "completed"
     },
     "tags": []
@@ -251,10 +251,10 @@
    "id": "76090f5d",
    "metadata": {
     "papermill": {
-     "duration": 0.002753,
-     "end_time": "2026-08-29T05:24:51.103151+00:00",
+     "duration": 0.002783,
+     "end_time": "2026-08-29T07:01:48.833246+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.100398+00:00",
+     "start_time": "2026-08-29T07:01:48.830463+00:00",
      "status": "completed"
     },
     "tags": []
@@ -275,19 +275,19 @@
    "id": "b17f4bdf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:24:51.111202Z",
-     "iopub.status.busy": "2026-08-29T05:24:51.111031Z",
-     "iopub.status.idle": "2026-08-29T05:24:51.131332Z",
-     "shell.execute_reply": "2026-08-29T05:24:51.130756Z"
+     "iopub.execute_input": "2026-08-29T07:01:48.839023Z",
+     "iopub.status.busy": "2026-08-29T07:01:48.838849Z",
+     "iopub.status.idle": "2026-08-29T07:01:48.857778Z",
+     "shell.execute_reply": "2026-08-29T07:01:48.857191Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.025472,
-     "end_time": "2026-08-29T05:24:51.132171+00:00",
+     "duration": 0.022865,
+     "end_time": "2026-08-29T07:01:48.858347+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.106699+00:00",
+     "start_time": "2026-08-29T07:01:48.835482+00:00",
      "status": "completed"
     },
     "tags": []
@@ -297,7 +297,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Backtracking simple — Easy : succes=True, temps=13.05 ms, appels=4209\n"
+      "Backtracking simple — Easy : succes=True, temps=13.04 ms, appels=4209\n"
      ]
     }
    ],
@@ -364,10 +364,10 @@
    "id": "7930e964",
    "metadata": {
     "papermill": {
-     "duration": 0.002232,
-     "end_time": "2026-08-29T05:24:51.136889+00:00",
+     "duration": 0.002708,
+     "end_time": "2026-08-29T07:01:48.863473+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.134657+00:00",
+     "start_time": "2026-08-29T07:01:48.860765+00:00",
      "status": "completed"
     },
     "tags": []
@@ -391,19 +391,19 @@
    "id": "bd7a4df3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:24:51.142112Z",
-     "iopub.status.busy": "2026-08-29T05:24:51.141976Z",
-     "iopub.status.idle": "2026-08-29T05:24:51.149424Z",
-     "shell.execute_reply": "2026-08-29T05:24:51.148848Z"
+     "iopub.execute_input": "2026-08-29T07:01:48.869405Z",
+     "iopub.status.busy": "2026-08-29T07:01:48.869246Z",
+     "iopub.status.idle": "2026-08-29T07:01:48.876194Z",
+     "shell.execute_reply": "2026-08-29T07:01:48.875619Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.010751,
-     "end_time": "2026-08-29T05:24:51.149899+00:00",
+     "duration": 0.010762,
+     "end_time": "2026-08-29T07:01:48.876667+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.139148+00:00",
+     "start_time": "2026-08-29T07:01:48.865905+00:00",
      "status": "completed"
     },
     "tags": []
@@ -413,7 +413,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Backtracking+MRV — Easy : succes=True, temps=1.89 ms, appels=52\n"
+      "Backtracking+MRV — Easy : succes=True, temps=1.72 ms, appels=52\n"
      ]
     }
    ],
@@ -474,10 +474,10 @@
    "id": "59244654",
    "metadata": {
     "papermill": {
-     "duration": 0.002215,
-     "end_time": "2026-08-29T05:24:51.154545+00:00",
+     "duration": 0.00231,
+     "end_time": "2026-08-29T07:01:48.881579+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.152330+00:00",
+     "start_time": "2026-08-29T07:01:48.879269+00:00",
      "status": "completed"
     },
     "tags": []
@@ -500,19 +500,19 @@
    "id": "2e5d8e15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:24:51.159800Z",
-     "iopub.status.busy": "2026-08-29T05:24:51.159673Z",
-     "iopub.status.idle": "2026-08-29T05:24:51.177178Z",
-     "shell.execute_reply": "2026-08-29T05:24:51.176731Z"
+     "iopub.execute_input": "2026-08-29T07:01:48.887200Z",
+     "iopub.status.busy": "2026-08-29T07:01:48.887036Z",
+     "iopub.status.idle": "2026-08-29T07:01:48.905489Z",
+     "shell.execute_reply": "2026-08-29T07:01:48.905093Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.02109,
-     "end_time": "2026-08-29T05:24:51.177886+00:00",
+     "duration": 0.022447,
+     "end_time": "2026-08-29T07:01:48.906253+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.156796+00:00",
+     "start_time": "2026-08-29T07:01:48.883806+00:00",
      "status": "completed"
     },
     "tags": []
@@ -522,7 +522,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "AC-3 — Easy : succes=True, temps=10.46 ms, appels=82\n"
+      "AC-3 — Easy : succes=True, temps=10.72 ms, appels=82\n"
      ]
     }
    ],
@@ -638,10 +638,10 @@
    "id": "5243766f",
    "metadata": {
     "papermill": {
-     "duration": 0.002315,
-     "end_time": "2026-08-29T05:24:51.182717+00:00",
+     "duration": 0.003148,
+     "end_time": "2026-08-29T07:01:48.912209+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.180402+00:00",
+     "start_time": "2026-08-29T07:01:48.909061+00:00",
      "status": "completed"
     },
     "tags": []
@@ -665,19 +665,19 @@
    "id": "3e2d1985",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:24:51.188083Z",
-     "iopub.status.busy": "2026-08-29T05:24:51.187946Z",
-     "iopub.status.idle": "2026-08-29T05:24:51.197094Z",
-     "shell.execute_reply": "2026-08-29T05:24:51.196571Z"
+     "iopub.execute_input": "2026-08-29T07:01:48.918187Z",
+     "iopub.status.busy": "2026-08-29T07:01:48.918023Z",
+     "iopub.status.idle": "2026-08-29T07:01:48.928248Z",
+     "shell.execute_reply": "2026-08-29T07:01:48.927631Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.012518,
-     "end_time": "2026-08-29T05:24:51.197546+00:00",
+     "duration": 0.014044,
+     "end_time": "2026-08-29T07:01:48.928845+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.185028+00:00",
+     "start_time": "2026-08-29T07:01:48.914801+00:00",
      "status": "completed"
     },
     "tags": []
@@ -687,7 +687,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DLX — Easy : succes=True, temps=0.99 ms, appels=82\n"
+      "DLX — Easy : succes=True, temps=1.02 ms, appels=82\n"
      ]
     }
    ],
@@ -859,10 +859,10 @@
    "id": "cf7a2250",
    "metadata": {
     "papermill": {
-     "duration": 0.002227,
-     "end_time": "2026-08-29T05:24:51.202196+00:00",
+     "duration": 0.002385,
+     "end_time": "2026-08-29T07:01:48.933955+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.199969+00:00",
+     "start_time": "2026-08-29T07:01:48.931570+00:00",
      "status": "completed"
     },
     "tags": []
@@ -882,19 +882,19 @@
    "id": "482ab0ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:24:51.207773Z",
-     "iopub.status.busy": "2026-08-29T05:24:51.207628Z",
-     "iopub.status.idle": "2026-08-29T05:25:12.093333Z",
-     "shell.execute_reply": "2026-08-29T05:25:12.092802Z"
+     "iopub.execute_input": "2026-08-29T07:01:48.939706Z",
+     "iopub.status.busy": "2026-08-29T07:01:48.939417Z",
+     "iopub.status.idle": "2026-08-29T07:02:11.481216Z",
+     "shell.execute_reply": "2026-08-29T07:02:11.480223Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 20.889458,
-     "end_time": "2026-08-29T05:25:12.093949+00:00",
+     "duration": 22.545859,
+     "end_time": "2026-08-29T07:02:11.482103+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:24:51.204491+00:00",
+     "start_time": "2026-08-29T07:01:48.936244+00:00",
      "status": "completed"
     },
     "tags": []
@@ -904,36 +904,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Easy   | Backtracking simple      | succes=True | temps=   12.14 ms | appels=    4209\n",
-      "Easy   | Backtracking + MRV       | succes=True | temps=    1.79 ms | appels=      52\n",
-      "Easy   | AC-3 + backtracking      | succes=True | temps=   11.54 ms | appels=      82\n",
-      "Easy   | DLX (Knuth)              | succes=True | temps=    1.10 ms | appels=      82\n",
-      "Medium | Backtracking simple      | succes=True | temps=    0.16 ms | appels=      55\n",
-      "Medium | Backtracking + MRV       | succes=True | temps=    1.49 ms | appels=      46\n",
-      "Medium | AC-3 + backtracking      | succes=True | temps=    8.71 ms | appels=      82\n",
-      "Medium | DLX (Knuth)              | succes=True | temps=    0.94 ms | appels=      82\n"
+      "Easy   | Backtracking simple      | succes=True | temps=   12.31 ms | appels=    4209\n",
+      "Easy   | Backtracking + MRV       | succes=True | temps=    1.94 ms | appels=      52\n",
+      "Easy   | AC-3 + backtracking      | succes=True | temps=   11.14 ms | appels=      82\n",
+      "Easy   | DLX (Knuth)              | succes=True | temps=    1.01 ms | appels=      82\n",
+      "Medium | Backtracking simple      | succes=True | temps=    0.17 ms | appels=      55\n",
+      "Medium | Backtracking + MRV       | succes=True | temps=    1.36 ms | appels=      46\n",
+      "Medium | AC-3 + backtracking      | succes=True | temps=    9.22 ms | appels=      82\n",
+      "Medium | DLX (Knuth)              | succes=True | temps=    1.00 ms | appels=      82\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hard   | Backtracking simple      | succes=True | temps= 3890.87 ms | appels=  879418\n"
+      "Hard   | Backtracking simple      | succes=True | temps= 3414.19 ms | appels=  879418\n",
+      "Hard   | Backtracking + MRV       | succes=True | temps=  227.30 ms | appels=    5565\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hard   | Backtracking + MRV       | succes=True | temps=  268.95 ms | appels=    5565\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hard   | AC-3 + backtracking      | succes=True | temps=16679.55 ms | appels=  981113\n",
-      "Hard   | DLX (Knuth)              | succes=True | temps=    2.38 ms | appels=     103\n"
+      "Hard   | AC-3 + backtracking      | succes=True | temps=18852.22 ms | appels=  981113\n",
+      "Hard   | DLX (Knuth)              | succes=True | temps=    2.95 ms | appels=     103\n"
      ]
     }
    ],
@@ -974,10 +968,10 @@
    "id": "e2091bc6",
    "metadata": {
     "papermill": {
-     "duration": 0.002661,
-     "end_time": "2026-08-29T05:25:12.099871+00:00",
+     "duration": 0.002581,
+     "end_time": "2026-08-29T07:02:11.487754+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:12.097210+00:00",
+     "start_time": "2026-08-29T07:02:11.485173+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1004,10 +998,10 @@
    "id": "3ea0c082",
    "metadata": {
     "papermill": {
-     "duration": 0.002529,
-     "end_time": "2026-08-29T05:25:12.105062+00:00",
+     "duration": 0.002454,
+     "end_time": "2026-08-29T07:02:11.492786+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:12.102533+00:00",
+     "start_time": "2026-08-29T07:02:11.490332+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1024,7 +1018,7 @@
     "\n",
     "**Métriques invariantes** — le fil rouge du notebook s'applique aussi au moteur industriel :\n",
     "\n",
-    "- `num_search_workers = 1` + `random_seed = 42` → recherche **mono-thread déterministe** : `branches`, `conflicts` et les compteurs de propagation sont des **invariants structurels**, reproductibles exécution après exécution ;\n",
+    "- `num_search_workers = 1` + `random_seed = 42` + version du moteur **épinglée** (`EXPECTED_ORTOOLS_VERSION = \"9.15.6755\"`, assertion immédiatement après l'import) → recherche **mono-thread déterministe** : `branches`, `conflicts` et les compteurs de propagation sont des **invariants structurels**, reproductibles exécution après exécution — **pour cette version épinglée du moteur uniquement** ;\n",
     "- chaque solution est **vérifiée indépendamment du moteur** (indices préservés + lignes/colonnes/carrés tous différents) : la validité est un invariant ;\n",
     "- le **temps** reste *machine-dep* (informatif uniquement), comme pour les solveurs from-scratch.\n",
     "\n",
@@ -1033,7 +1027,7 @@
     "1. **Par défaut** (`cp_model_presolve = true`) — le mode production ;\n",
     "2. **`cp_model_presolve = false`** — pour **exposer le moteur de recherche SAT sous-jacent**, que le presolve court-circuite dans le mode par défaut.\n",
     "\n",
-    "> **Note** : la version du moteur est imprimée par la cellule suivante. Le twin C# exécute le **même numéro de version** (portage .NET officiel du même code C++), condition de comparabilité des compteurs `branches`/`conflicts` entre les deux langages."
+    "> **Note** : la version du moteur est **épinglée et vérifiée à l'exécution** par la cellule suivante (`EXPECTED_ORTOOLS_VERSION = \"9.15.6755\"`, assertion immédiatement après l'import) — miroir exact du `#r \"nuget: Google.OrTools, 9.15.6755\"` du twin C#. Les compteurs déterministes `branches`/`conflicts` ne sont reproductibles, et comparables entre les deux langages, **que pour cette version précisément épinglée du moteur** : le portage .NET officiel exécute le même code C++ des deux côtés, mais une autre version du moteur produirait des compteurs différents."
    ]
   },
   {
@@ -1042,16 +1036,16 @@
    "id": "d358ea2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:25:12.111271Z",
-     "iopub.status.busy": "2026-08-29T05:25:12.111082Z",
-     "iopub.status.idle": "2026-08-29T05:25:12.946766Z",
-     "shell.execute_reply": "2026-08-29T05:25:12.945735Z"
+     "iopub.execute_input": "2026-08-29T07:02:11.498814Z",
+     "iopub.status.busy": "2026-08-29T07:02:11.498651Z",
+     "iopub.status.idle": "2026-08-29T07:02:12.222420Z",
+     "shell.execute_reply": "2026-08-29T07:02:12.221637Z"
     },
     "papermill": {
-     "duration": 0.839968,
-     "end_time": "2026-08-29T05:25:12.947668+00:00",
+     "duration": 0.727762,
+     "end_time": "2026-08-29T07:02:12.223003+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:12.107700+00:00",
+     "start_time": "2026-08-29T07:02:11.495241+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1061,14 +1055,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "OR-Tools version : 9.15.6755\n",
-      "CP-SAT — Easy (presolve on) : statut=OPTIMAL, branches=0, conflicts=0, temps=38.7 ms, solution valide=True\n"
+      "OR-Tools version : 9.15.6755 (epinglee attendue 9.15.6755, assertion OK)\n",
+      "CP-SAT — Easy (presolve on) : statut=OPTIMAL, branches=0, conflicts=0, temps=45.3 ms, solution valide=True\n"
      ]
     }
    ],
    "source": [
     "from ortools.sat.python import cp_model\n",
     "import ortools\n",
+    "\n",
+    "# Version epinglee du moteur, miroir du #r \"nuget: Google.OrTools, 9.15.6755\" du twin C# :\n",
+    "# les compteurs deterministes (branches, conflicts, propagations) ne sont reproductibles\n",
+    "# que pour cette version precise du moteur C++ sous-jacent.\n",
+    "EXPECTED_ORTOOLS_VERSION = \"9.15.6755\"\n",
+    "assert ortools.__version__ == EXPECTED_ORTOOLS_VERSION, (\n",
+    "    f\"ortools {EXPECTED_ORTOOLS_VERSION} attendu (version epinglee, miroir du twin C#), \"\n",
+    "    f\"version importee : {ortools.__version__}\"\n",
+    ")\n",
     "\n",
     "\n",
     "def build_cpsat_model(grid):\n",
@@ -1141,7 +1144,8 @@
     "    return True\n",
     "\n",
     "\n",
-    "print(f\"OR-Tools version : {ortools.__version__}\")\n",
+    "print(f\"OR-Tools version : {ortools.__version__} \"\n",
+    "      f\"(epinglee attendue {EXPECTED_ORTOOLS_VERSION}, assertion OK)\")\n",
     "\n",
     "# Smoke test sur Easy (configuration par defaut)\n",
     "res_demo = run_cpsat(EASY_GRID)\n",
@@ -1156,10 +1160,10 @@
    "id": "024df40d",
    "metadata": {
     "papermill": {
-     "duration": 0.003262,
-     "end_time": "2026-08-29T05:25:12.955754+00:00",
+     "duration": 0.003285,
+     "end_time": "2026-08-29T07:02:12.230180+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:12.952492+00:00",
+     "start_time": "2026-08-29T07:02:12.226895+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1174,16 +1178,16 @@
    "id": "6c70fc72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:25:12.964702Z",
-     "iopub.status.busy": "2026-08-29T05:25:12.964486Z",
-     "iopub.status.idle": "2026-08-29T05:25:13.051502Z",
-     "shell.execute_reply": "2026-08-29T05:25:13.050472Z"
+     "iopub.execute_input": "2026-08-29T07:02:12.237440Z",
+     "iopub.status.busy": "2026-08-29T07:02:12.237209Z",
+     "iopub.status.idle": "2026-08-29T07:02:12.281264Z",
+     "shell.execute_reply": "2026-08-29T07:02:12.280409Z"
     },
     "papermill": {
-     "duration": 0.092261,
-     "end_time": "2026-08-29T05:25:13.052818+00:00",
+     "duration": 0.048971,
+     "end_time": "2026-08-29T07:02:12.282088+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:12.960557+00:00",
+     "start_time": "2026-08-29T07:02:12.233117+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1196,11 +1200,11 @@
       "Grille  | Config       | Statut   | Valide | Branches | Conflicts | Prop.bin  | Prop.int  | Temps(ms)\n",
       "----------------------------------------------------------------------------------------------------\n",
       "Easy    | presolve=on  | OPTIMAL  | True   |        0 |         0 |         0 |         0 |       1.2\n",
-      "Easy    | presolve=off | OPTIMAL  | True   |        0 |         0 |       340 |       111 |      19.2\n",
-      "Medium  | presolve=on  | OPTIMAL  | True   |        0 |         0 |         0 |         0 |       3.4\n",
-      "Medium  | presolve=off | OPTIMAL  | True   |        0 |         0 |       251 |        49 |       4.5\n",
-      "Hard    | presolve=on  | OPTIMAL  | True   |        0 |         0 |         0 |         0 |      22.5\n",
-      "Hard    | presolve=off | OPTIMAL  | True   |        5 |         2 |       790 |       213 |      13.5\n"
+      "Easy    | presolve=off | OPTIMAL  | True   |        0 |         0 |       340 |       111 |      11.5\n",
+      "Medium  | presolve=on  | OPTIMAL  | True   |        0 |         0 |         0 |         0 |       1.0\n",
+      "Medium  | presolve=off | OPTIMAL  | True   |        0 |         0 |       251 |        49 |       2.4\n",
+      "Hard    | presolve=on  | OPTIMAL  | True   |        0 |         0 |         0 |         0 |       9.4\n",
+      "Hard    | presolve=off | OPTIMAL  | True   |        5 |         2 |       790 |       213 |       4.7\n"
      ]
     }
    ],
@@ -1226,10 +1230,10 @@
    "id": "c675165c",
    "metadata": {
     "papermill": {
-     "duration": 0.003409,
-     "end_time": "2026-08-29T05:25:13.061114+00:00",
+     "duration": 0.003298,
+     "end_time": "2026-08-29T07:02:12.288710+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:13.057705+00:00",
+     "start_time": "2026-08-29T07:02:12.285412+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1261,10 +1265,10 @@
    "id": "01256f6a",
    "metadata": {
     "papermill": {
-     "duration": 0.002385,
-     "end_time": "2026-08-29T05:25:13.066162+00:00",
+     "duration": 0.003006,
+     "end_time": "2026-08-29T07:02:12.294505+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:13.063777+00:00",
+     "start_time": "2026-08-29T07:02:12.291499+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1285,19 +1289,19 @@
    "id": "4f5d00cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:25:13.071927Z",
-     "iopub.status.busy": "2026-08-29T05:25:13.071784Z",
-     "iopub.status.idle": "2026-08-29T05:25:13.075669Z",
-     "shell.execute_reply": "2026-08-29T05:25:13.075253Z"
+     "iopub.execute_input": "2026-08-29T07:02:12.301478Z",
+     "iopub.status.busy": "2026-08-29T07:02:12.301196Z",
+     "iopub.status.idle": "2026-08-29T07:02:12.308367Z",
+     "shell.execute_reply": "2026-08-29T07:02:12.307517Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.007616,
-     "end_time": "2026-08-29T05:25:13.076206+00:00",
+     "duration": 0.011633,
+     "end_time": "2026-08-29T07:02:12.309003+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:13.068590+00:00",
+     "start_time": "2026-08-29T07:02:12.297370+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1353,10 +1357,10 @@
    "id": "95c40832",
    "metadata": {
     "papermill": {
-     "duration": 0.002605,
-     "end_time": "2026-08-29T05:25:13.081538+00:00",
+     "duration": 0.002758,
+     "end_time": "2026-08-29T07:02:12.314749+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:13.078933+00:00",
+     "start_time": "2026-08-29T07:02:12.311991+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1377,19 +1381,19 @@
    "id": "49a26fd9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:25:13.087753Z",
-     "iopub.status.busy": "2026-08-29T05:25:13.087594Z",
-     "iopub.status.idle": "2026-08-29T05:25:13.090610Z",
-     "shell.execute_reply": "2026-08-29T05:25:13.090197Z"
+     "iopub.execute_input": "2026-08-29T07:02:12.321565Z",
+     "iopub.status.busy": "2026-08-29T07:02:12.321387Z",
+     "iopub.status.idle": "2026-08-29T07:02:12.325135Z",
+     "shell.execute_reply": "2026-08-29T07:02:12.324204Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.007232,
-     "end_time": "2026-08-29T05:25:13.091264+00:00",
+     "duration": 0.008352,
+     "end_time": "2026-08-29T07:02:12.325919+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:13.084032+00:00",
+     "start_time": "2026-08-29T07:02:12.317567+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1416,10 +1420,10 @@
    "id": "e11fff19",
    "metadata": {
     "papermill": {
-     "duration": 0.002422,
-     "end_time": "2026-08-29T05:25:13.096390+00:00",
+     "duration": 0.00288,
+     "end_time": "2026-08-29T07:02:12.332820+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:13.093968+00:00",
+     "start_time": "2026-08-29T07:02:12.329940+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1443,19 +1447,19 @@
    "id": "3f083a4d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T05:25:13.102273Z",
-     "iopub.status.busy": "2026-08-29T05:25:13.102116Z",
-     "iopub.status.idle": "2026-08-29T05:25:13.105837Z",
-     "shell.execute_reply": "2026-08-29T05:25:13.105458Z"
+     "iopub.execute_input": "2026-08-29T07:02:12.342686Z",
+     "iopub.status.busy": "2026-08-29T07:02:12.342360Z",
+     "iopub.status.idle": "2026-08-29T07:02:12.347653Z",
+     "shell.execute_reply": "2026-08-29T07:02:12.346750Z"
     },
     "jupyter": {
      "source_hidden": true
     },
     "papermill": {
-     "duration": 0.007591,
-     "end_time": "2026-08-29T05:25:13.106451+00:00",
+     "duration": 0.012628,
+     "end_time": "2026-08-29T07:02:12.348596+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:13.098860+00:00",
+     "start_time": "2026-08-29T07:02:12.335968+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1506,10 +1510,10 @@
    "id": "cd405af3",
    "metadata": {
     "papermill": {
-     "duration": 0.002766,
-     "end_time": "2026-08-29T05:25:13.112033+00:00",
+     "duration": 0.002805,
+     "end_time": "2026-08-29T07:02:12.356191+00:00",
      "exception": false,
-     "start_time": "2026-08-29T05:25:13.109267+00:00",
+     "start_time": "2026-08-29T07:02:12.353386+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1573,15 +1577,15 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 25.546529,
-   "end_time": "2026-08-29T05:25:13.352869+00:00",
+   "duration": 30.539272,
+   "end_time": "2026-08-29T07:02:12.696106+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb",
+   "input_path": "App-20-SudokuBenchmark-Python.ipynb",
+   "output_path": "App-20-SudokuBenchmark-Python.ipynb",
    "parameters": {},
-   "start_time": "2026-08-29T05:24:47.806340+00:00",
-   "version": "2.6.0"
+   "start_time": "2026-08-29T07:01:42.156834+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb
@@ -38,11 +38,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Setup OK. Seed=42, TIMEOUT=60s\r\n"
-     ]
+     "name": "stdout",
+     "text": "Setup OK. Seed=42, TIMEOUT=60s\r\n"
     }
    ],
    "source": [
@@ -83,25 +81,19 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Easy   : 30 indices donnes, 51 cases vides\r\n"
-     ]
+     "name": "stdout",
+     "text": "Easy   : 30 indices donnes, 51 cases vides\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Medium : 36 indices donnes, 45 cases vides\r\n"
-     ]
+     "name": "stdout",
+     "text": "Medium : 36 indices donnes, 45 cases vides\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Hard   : 23 indices donnes, 58 cases vides\r\n"
-     ]
+     "name": "stdout",
+     "text": "Hard   : 23 indices donnes, 58 cases vides\r\n"
     }
    ],
    "source": [
@@ -185,11 +177,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Backtracking simple -- Easy : succes=True, temps=1,68 ms, appels=4209\r\n"
-     ]
+     "name": "stdout",
+     "text": "Backtracking simple -- Easy : succes=True, temps=1,69 ms, appels=4209\r\n"
     }
    ],
    "source": [
@@ -265,11 +255,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Backtracking+MRV -- Easy : succes=True, temps=1,30 ms, appels=52\r\n"
-     ]
+     "name": "stdout",
+     "text": "Backtracking+MRV -- Easy : succes=True, temps=1,22 ms, appels=52\r\n"
     }
    ],
    "source": [
@@ -350,11 +338,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "AC-3 -- Easy : succes=True, temps=3,83 ms, appels=82\r\n"
-     ]
+     "name": "stdout",
+     "text": "AC-3 -- Easy : succes=True, temps=3,42 ms, appels=82\r\n"
     }
    ],
    "source": [
@@ -486,11 +472,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "DLX (Knuth) -- Easy : succes=True, temps=0,89 ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "DLX (Knuth) -- Easy : succes=True, temps=0,95 ms\r\n"
     }
    ],
    "source": [
@@ -620,102 +604,74 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Diff | Solveur                | Succes  |  Temps(ms) |     Appels\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Diff | Solveur                | Succes  |  Temps(ms) |     Appels\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "-----------------------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "-----------------------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Easy | Backtracking simple    | True    |       1,39 |       4209\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Easy | Backtracking simple    | True    |       1,35 |       4209\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Easy | Backtracking + MRV     | True    |       0,51 |         52\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Easy | Backtracking + MRV     | True    |       0,73 |         52\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Easy | AC-3 + backtracking    | True    |       1,22 |         82\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Easy | AC-3 + backtracking    | True    |       1,33 |         82\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Easy | DLX (Knuth)            | True    |       0,11 |          0\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Easy | DLX (Knuth)            | True    |       0,13 |          0\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Medium | Backtracking simple    | True    |       0,02 |         55\r\n"
-     ]
+     "name": "stdout",
+     "text": "Medium | Backtracking simple    | True    |       0,02 |         55\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Medium | Backtracking + MRV     | True    |       0,43 |         46\r\n"
-     ]
+     "name": "stdout",
+     "text": "Medium | Backtracking + MRV     | True    |       0,62 |         46\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Medium | AC-3 + backtracking    | True    |       1,09 |         82\r\n"
-     ]
+     "name": "stdout",
+     "text": "Medium | AC-3 + backtracking    | True    |       1,29 |         82\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Medium | DLX (Knuth)            | True    |       0,08 |          0\r\n"
-     ]
+     "name": "stdout",
+     "text": "Medium | DLX (Knuth)            | True    |       0,13 |          0\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Hard | Backtracking simple    | True    |     360,80 |     879418\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Hard | Backtracking simple    | True    |     346,21 |     879418\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Hard | Backtracking + MRV     | True    |     121,86 |       5565\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Hard | Backtracking + MRV     | True    |     140,87 |       5565\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Hard | AC-3 + backtracking    | True    |    1659,81 |     981113\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Hard | AC-3 + backtracking    | True    |    1884,22 |     981113\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Hard | DLX (Knuth)            | True    |       0,31 |          0\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Hard | DLX (Knuth)            | True    |       0,31 |          0\r\n"
     }
    ],
    "source": [
@@ -789,6 +745,99 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3c79bd13",
+   "source": "***\n## 4. Tranche 2 -- moteur de production : Google OR-Tools CP-SAT (native-both, #10382)\n\nLes quatre solveurs ci-dessus sont des réimplémentations **from-scratch** : leur rôle est pédagogique. Cette tranche confronte le socle au **moteur de production** utilisé par l'industrie : **CP-SAT**, le solveur de programmation par contraintes de **Google OR-Tools** (Perron & Furnon). C'est le même moteur des deux côtés de la parité -- le twin Python appelle `ortools` (pip) et ce jumeau C# appelle `Google.OrTools` (NuGet) : la parité passe de *semantic* à **native-both** (lib-vs-lib, EPIC #10382 / arbitrage #11200 Option A).\n\n**Modélisation miroir** (identique au twin Python) :\n\n- une variable entière `c_r_c` par case : domaine réduit au chiffre donné si la case est remplie, `[1, 9]` sinon ;\n- 27 contraintes `AddAllDifferent` : 9 lignes + 9 colonnes + 9 carrés 3x3.\n\n**Invariants comparables** (paramètres fixés pour le déterminisme) :\n\n| Invariant | Statut |\n|---|---|\n| Statut de résolution (`OPTIMAL`, ...) | déterministe |\n| Grille valide (indices préservés + règles du Sudoku) | déterministe |\n| `branches` / `conflicts` | déterministes (mono-worker, graine fixée) |\n| Propagations binaires / entières | déterministes |\n| Temps wall-clock | informatif, machine-dep |\n\nDeux configurations sont mesurées : `presolve=on` (défaut industriel) et `presolve=off` (recherche SAT exposée). Paramètres : `num_search_workers:1` (mono-thread -- condition du déterminisme), `random_seed:42` (miroir du `SEED` du socle), `max_time_in_seconds:60` (miroir du `TIMEOUT_S`). La version NuGet est **épinglée à 9.15.6755** -- exactement la version `ortools` du twin Python, pour garantir la comparaison des compteurs d'invariants entre les deux moteurs.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "04a1ad59",
+   "source": "#r \"nuget: Google.OrTools, 9.15.6755\"\nusing Google.OrTools.Sat;\n\n// --- Tranche 2 : moteur de production CP-SAT (Google OR-Tools) ---\n// Version epinglee 9.15.6755 = exactement la version 'ortools' du twin Python :\n// meme moteur C++ des deux cotes, condition de comparabilite des invariants.\nrecord CpsatResult(string Statut, bool Succes, bool Valide, long Branches, long Conflicts,\n                   long PropBinaires, long PropEntieres, double TempsMs, int[,] Solution);\n\n// Construit le modele miroir du twin Python : 81 variables + 27 AddAllDifferent.\nstatic (CpModel model, Google.OrTools.Sat.IntVar[,] cells) BuildCpsatModel(int[,] grid)\n{\n    var model = new CpModel();\n    var cells = new Google.OrTools.Sat.IntVar[9, 9];\n    for (int r = 0; r < 9; r++)\n        for (int c = 0; c < 9; c++)\n            cells[r, c] = model.NewIntVar(grid[r, c] == 0 ? 1 : grid[r, c],\n                                          grid[r, c] == 0 ? 9 : grid[r, c], $\"c_{r}_{c}\");\n    for (int i = 0; i < 9; i++)\n    {\n        var rowVars = new Google.OrTools.Sat.IntVar[9];\n        var colVars = new Google.OrTools.Sat.IntVar[9];\n        for (int j = 0; j < 9; j++) { rowVars[j] = cells[i, j]; colVars[j] = cells[j, i]; }\n        model.AddAllDifferent(rowVars);\n        model.AddAllDifferent(colVars);\n    }\n    for (int br = 0; br < 9; br += 3)\n        for (int bc = 0; bc < 9; bc += 3)\n        {\n            var boxVars = new Google.OrTools.Sat.IntVar[9];\n            for (int r = 0; r < 3; r++) for (int c = 0; c < 3; c++) boxVars[r * 3 + c] = cells[br + r, bc + c];\n            model.AddAllDifferent(boxVars);\n        }\n    return (model, cells);\n}\n\n// Valide une solution : indices donnes preserves + lignes/colonnes/carres = {1..9}.\nstatic bool CheckSudokuSolution(int[,] grid, int[,] solution)\n{\n    if (solution is null) return false;\n    for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++)\n        if (grid[r, c] != 0 && solution[r, c] != grid[r, c]) return false;\n    var full = Enumerable.Range(1, 9).ToArray();\n    for (int i = 0; i < 9; i++)\n    {\n        var row = Enumerable.Range(0, 9).Select(c => solution[i, c]).OrderBy(x => x);\n        var col = Enumerable.Range(0, 9).Select(r => solution[r, i]).OrderBy(x => x);\n        if (!row.SequenceEqual(full) || !col.SequenceEqual(full)) return false;\n    }\n    for (int br = 0; br < 9; br += 3) for (int bc = 0; bc < 9; bc += 3)\n    {\n        var box = Enumerable.Range(0, 3).SelectMany(r => Enumerable.Range(0, 3)\n            .Select(c => solution[br + r, bc + c])).OrderBy(x => x);\n        if (!box.SequenceEqual(full)) return false;\n    }\n    return true;\n}\n\n// Resout avec CP-SAT. workers=1 + seed=42 => invariants deterministes (miroir du twin Python).\nstatic CpsatResult RunCpsat(int[,] grid, bool usePresolve = true)\n{\n    var (model, cells) = BuildCpsatModel(grid);\n    var solver = new CpSolver();\n    solver.StringParameters = $\"num_search_workers:1,random_seed:42,max_time_in_seconds:60.0,cp_model_presolve:{(usePresolve ? \"true\" : \"false\")}\";\n    var sw = Stopwatch.StartNew();\n    var status = solver.Solve(model);\n    sw.Stop();\n    bool ok = status == CpSolverStatus.Optimal || status == CpSolverStatus.Feasible;\n    int[,] solved = null;\n    if (ok)\n    {\n        solved = new int[9, 9];\n        for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++) solved[r, c] = (int)solver.Value(cells[r, c]);\n    }\n    var resp = solver.Response;\n    return new CpsatResult(status.ToString(), ok, CheckSudokuSolution(grid, solved),\n        solver.NumBranches(), solver.NumConflicts(),\n        resp.NumBinaryPropagations, resp.NumIntegerPropagations,\n        sw.Elapsed.TotalMilliseconds, solved);\n}\n\nConsole.WriteLine(\"Google.OrTools 9.15.6755 charge (meme version de moteur que le twin Python).\");\nvar demo = RunCpsat(EASY_GRID);\nConsole.WriteLine($\"CP-SAT -- Easy (presolve on) : statut={demo.Statut}, branches={demo.Branches}, conflicts={demo.Conflicts}, temps={demo.TempsMs:F1} ms, solution valide={demo.Valide}\");\n",
+   "metadata": {},
+   "execution_count": 8,
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Google.OrTools</span></li></ul></div><div></div></div>"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Google.OrTools 9.15.6755 charge (meme version de moteur que le twin Python).\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "CP-SAT -- Easy (presolve on) : statut=Optimal, branches=0, conflicts=0, temps=2039,9 ms, solution valide=True\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0afa410",
+   "source": "Avec le moteur défini, déroulons le même protocole que le socle : les **trois grilles** (Easy / Medium / Hard) dans **deux configurations** (`presolve=on` puis `presolve=off`). Pour chaque combinaison : statut, validité de la grille produite, branches, conflicts, propagations -- et le temps, informatif.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "1b679338",
+   "source": "// Benchmark CP-SAT : 3 grilles x 2 configurations (presolve on/off), invariants deterministes.\nConsole.WriteLine($\"{\"Grille\",7} | {\"Config\",-12} | {\"Statut\",-8} | {\"Valide\",6} | {\"Branches\",9} | {\"Conflicts\",9} | {\"Prop.bin\",9} | {\"Prop.int\",9} | {\"Temps(ms)\",9}\");\nConsole.WriteLine(new string('-', 95));\nforeach (var diffName in DIFFICULTIES)\n{\n    var grid = GRIDS[diffName];\n    foreach (var (configName, usePresolve) in new[] { (\"presolve=on\", true), (\"presolve=off\", false) })\n    {\n        var res = RunCpsat(grid, usePresolve);\n        Console.WriteLine($\"{diffName,7} | {configName,-12} | {res.Statut,-8} | {res.Valide,6} | {res.Branches,9} | {res.Conflicts,9} | {res.PropBinaires,9} | {res.PropEntieres,9} | {res.TempsMs,9:F1}\");\n    }\n}\n",
+   "metadata": {},
+   "execution_count": 9,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": " Grille | Config       | Statut   | Valide |  Branches | Conflicts |  Prop.bin |  Prop.int | Temps(ms)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "-----------------------------------------------------------------------------------------------\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "   Easy | presolve=on  | Optimal  |   True |         0 |         0 |         0 |         0 |       2,5\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "   Easy | presolve=off | Optimal  |   True |         0 |         0 |       340 |       111 |      12,9\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": " Medium | presolve=on  | Optimal  |   True |         0 |         0 |         0 |         0 |       1,2\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": " Medium | presolve=off | Optimal  |   True |         0 |         0 |       251 |        49 |       2,5\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "   Hard | presolve=on  | Optimal  |   True |         0 |         0 |         0 |         0 |      10,7\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "   Hard | presolve=off | Optimal  |   True |         5 |         2 |       790 |       213 |       6,1\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6dccd3c2",
+   "source": "***\n### Interprétation -- ce que révèle le moteur de production\n\n| Config | Branches | Conflicts | Lecture |\n|---|---|---|---|\n| `presolve=on` | 0 sur les trois grilles | 0 | la grille est résolue **entièrement dans le présolve** -- propagation pure, aucun arbre de recherche |\n| `presolve=off` | 0 (Easy, Medium), quelques unités (Hard) | quelques unités sur Hard seulement | sans le présolve, la recherche SAT n'intervient quasiment pas : la propagation des 27 contraintes `AllDifferent` suffit déjà |\n\n- **L'héroïne, c'est la propagation** : le socle from-scratch montrait déjà que MRV coupait 879 418 appels à 5 565 et que DLX passait sous la milliseconde ; CP-SAT pousse la logique à son terme -- avec le présolve activé, **zéro branche, même sur la grille Hard**. Le travail est fait par les propagateurs : chaque `AddAllDifferent` embarque un filtrage par algorithme de flot (matching), bien plus fort que l'AC-3 du socle.\n- **Branches CP-SAT ≠ appels récursifs du socle** : les compteurs des deux tranches ne se comparent pas un à un -- ils mesurent des machines de recherche différentes. Ce qui est comparable, c'est le contraste qualitatif : chaque étage (naif -> MRV -> DLX -> CP-SAT) est séparé d'un ordre de grandeur.\n- **Déterminisme par construction** : `num_search_workers:1` + `random_seed:42` + version épinglée 9.15.6755 => les compteurs de cette table sont reproductibles à l'identique et **doivent concorder avec le twin Python** (même moteur C++ sous-jacent des deux côtés). C'est la parité *native-both* : lib contre lib.\n- **Ce que la boîte noire industrialise** : heuristiques de choix de variable/valeur calibrées sur des années de recherche, réduction de domaine par flot, clauses apprises, élimination de symétries. Le socle from-scratch reste indispensable pour comprendre *ce que* le moteur fait ; cette tranche montre *ce qu'un moteur de production fait de ces idées*.\n\n> Note technique : les **temps** (colonne `Temps(ms)`) restent informatifs et machine-dep -- JIT .NET, charge système. Seuls les compteurs d'invariants (statut, validité, branches, conflicts, propagations) sont déterministes et reproductibles.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "094af356784a",
    "metadata": {},
    "source": [
@@ -802,7 +851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "7d6acedcbc20",
    "metadata": {
     "execution": {
@@ -814,11 +863,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 1 : methode UnitPropagation definie (stub). A implementer.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 1 : methode UnitPropagation definie (stub). A implementer.\r\n"
     }
    ],
    "source": [
@@ -849,7 +896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "b213e70fa369",
    "metadata": {
     "execution": {
@@ -861,11 +908,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer -- instrumentation DLX (voir commentaire ci-dessus).\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer -- instrumentation DLX (voir commentaire ci-dessus).\r\n"
     }
    ],
    "source": [
@@ -889,7 +934,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "e7dcfa7ce515",
    "metadata": {
     "execution": {
@@ -901,11 +946,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 3 : methode GeneratePuzzle definie (stub). A implementer.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 3 : methode GeneratePuzzle definie (stub). A implementer.\r\n"
     }
    ],
    "source": [
@@ -928,45 +971,7 @@
    "cell_type": "markdown",
    "id": "2fc6ad9c5164",
    "metadata": {},
-   "source": [
-    "***\n",
-    "## Conclusion\n",
-    "\n",
-    "Ce twin C# a reconstruit depuis zero les quatre solveurs Sudoku du notebook Python :\n",
-    "\n",
-    "1. **Backtracking naif** -- baseline, explosion combinatoire ;\n",
-    "2. **Backtracking + MRV** -- heuristique de choix de variable, coupe massive ;\n",
-    "3. **AC-3 + backtracking** -- propagation de consistance d'arc avant recherche ;\n",
-    "4. **Dancing Links (Knuth 2000)** -- formulation exact-cover, asymptotiquement superieur.\n",
-    "\n",
-    "### Parite Python / C#\n",
-    "\n",
-    "- Les **trois grilles** (Easy/Medium/Hard) sont strictement identiques ;\n",
-    "- Le **nombre d'appels recursifs** (naif, MRV, AC-3) concorde exactement entre les deux langages (tableau §4) : c'est le critere de parite (algorithme déterministe) ;\n",
-    "- Le **temps** wall-clock depend du runtime (C# .NET JIT vs CPython, charge systeme), runtime *machine-dep* cote Python vs runtime *machine-dep* cote C#, ce n'est pas un critere de parite ;\n",
-    "- **Ecart runtime documente** : sur Hard+AC-3, le Python original timeout (runtime *machine-dep*, budget parametrable 60 s) alors que ce twin C# termine (runtime *machine-dep*) avec le meme nombre d'appels (981 113). La difference de succes apparente est un effet purement runtime, pas un bug.\n",
-    "\n",
-    "> **Note methodologique -- separation structurel / machine-dep** : tous les **nombres d'appels** et les **grilles** (Easy/Medium/Hard) sont des **invariants structurels** (resultats solveur sur instance specifique, deterministes sur la grainee SEED=42). En revanche, tous les **temps wall-clock** et les **ratios cross-runtime** cites dans cette conclusion sont **machine-dep** (JIT .NET vs CPython, charge systeme, version .NET) et **ne survivent pas** a une re-execution sur une autre machine. Le critere de parite reste le **nombre d'appels** (deterministe), pas le temps (runtime-dependent).\n",
-    "\n",
-    "### Ponts inter-series\n",
-    "\n",
-    "- **Dancing Links / couverture exacte** : cf. la formalisation DLX dans la serie Search et l'algorithme X de Knuth (cf. App-11 Picross pour une autre application de DLX) ;\n",
-    "- **AC-3 / propagation de contraintes** : cf. [Partie 2 (CSP)](../../Part2-CSP/README.md) pour la theorie de la consistance d'arc ;\n",
-    "- **App-20 Python** : la version originale avec la stdlib Python donne les memes nombres d'appels.\n",
-    "\n",
-    "### Prochaines etapes\n",
-    "\n",
-    "- Implementer les exercices (propagation unitaire, instrumentation DLX, generation de grilles) ;\n",
-    "- Comparer DLX au backtracking sur des grilles 16x16 ou 25x25 (ou l'ecart s'elargit) ;\n",
-    "- Revenir au [sommaire Search](../../README.md) pour replacer ce notebook dans le parcours global.\n",
-    "\n",
-    "## Navigation\n",
-    "\n",
-    "[<< App-20 Python](App-20-SudokuBenchmark-Python.ipynb) | [Index](../../README.md) | [App-7 Wordle >>](App-7-Wordle.ipynb)\n",
-    "\n",
-    "*Marathon #4956 -- parite .NET / Python, volet Search / Applications / CSP.*\n",
-    "\n"
-   ]
+   "source": "***\n## Conclusion\n\nCe twin C# a reconstruit depuis zero les quatre solveurs Sudoku du notebook Python :\n\n1. **Backtracking naif** -- baseline, explosion combinatoire ;\n2. **Backtracking + MRV** -- heuristique de choix de variable, coupe massive ;\n3. **AC-3 + backtracking** -- propagation de consistance d'arc avant recherche ;\n4. **Dancing Links (Knuth 2000)** -- formulation exact-cover, asymptotiquement superieur ;\n5. **OR-Tools CP-SAT (Tranche 2, section 4)** -- moteur de production Google (Perron & Furnon), appelé des deux côtés de la parité : `Google.OrTools` 9.15.6755 en C# et `ortools` 9.15.6755 en Python.\n\nLa **Tranche 2 (section 4)** confronte le socle from-scratch au moteur de production et confirme expérimentalement la thèse du socle -- avec le présolve activé, CP-SAT résout les trois grilles en **zéro branche**, même sur la grille Hard : tout le travail est fait par la propagation (filtrage par flot des 27 contraintes `AllDifferent`), pas par la recherche. C'est l'aboutissement de la progression naif -> MRV -> AC-3 -> DLX : chaque étage délègue davantage au raisonnement sur les domaines et moins à l'exploration aveugle.\n\n### Parite Python / C#\n\n- Les **trois grilles** (Easy/Medium/Hard) sont strictement identiques ;\n- Le **nombre d'appels recursifs** (naif, MRV, AC-3) concorde exactement entre les deux langages (tableau §4) : c'est le critere de parite (algorithme déterministe) ;\n- **Tranche 2 (native-both)** : CP-SAT est appelé via le **même moteur** des deux côtés (NuGet `Google.OrTools` vs pip `ortools`, même version 9.15.6755, `num_search_workers:1`, `random_seed:42`) -- les invariants (statut, validité, branches, conflicts, propagations) concordent exactement entre les deux jumeaux ;\n- Le **temps** wall-clock depend du runtime (C# .NET JIT vs CPython, charge systeme), runtime *machine-dep* cote Python vs runtime *machine-dep* cote C#, ce n'est pas un critere de parite ;\n- **Ecart runtime documente** : sur Hard+AC-3, le Python original timeout (runtime *machine-dep*, budget parametrable 60 s) alors que ce twin C# termine (runtime *machine-dep*) avec le meme nombre d'appels (981 113). La difference de succes apparente est un effet purement runtime, pas un bug.\n\n> **Note methodologique -- separation structurel / machine-dep** : tous les **nombres d'appels** et les **grilles** (Easy/Medium/Hard) sont des **invariants structurels** (resultats solveur sur instance specifique, deterministes sur la grainee SEED=42). En revanche, tous les **temps wall-clock** et les **ratios cross-runtime** cites dans cette conclusion sont **machine-dep** (JIT .NET vs CPython, charge systeme, version .NET) et **ne survivent pas** a une re-execution sur une autre machine. Le critere de parite reste le **nombre d'appels** (deterministe), pas le temps (runtime-dependent). Les compteurs CP-SAT de la Tranche 2 (branches, conflicts, propagations) sont deterministes eux aussi -- mono-worker, graine fixée -- et constituent le critere de parité *native-both*.\n\n### Ponts inter-series\n\n- **Dancing Links / couverture exacte** : cf. la formalisation DLX dans la serie Search et l'algorithme X de Knuth (cf. App-11 Picross pour une autre application de DLX) ;\n- **AC-3 / propagation de contraintes** : cf. [Partie 2 (CSP)](../../Part2-CSP/README.md) pour la theorie de la consistance d'arc ;\n- **CP-SAT / OR-Tools** : cf. la serie Sudoku (Sudoku-10 ORTools C#) pour une première prise en main du moteur, et la documentation Perron & Furnon, *CP-SAT in Google OR-Tools* ;\n- **App-20 Python** : la version originale avec la stdlib Python donne les memes nombres d'appels.\n\n### Prochaines etapes\n\n- Implementer les exercices (propagation unitaire, instrumentation DLX, generation de grilles) ;\n- Comparer DLX au backtracking sur des grilles 16x16 ou 25x25 (ou l'ecart s'elargit) ;\n- Revenir au [sommaire Search](../../README.md) pour replacer ce notebook dans le parcours global.\n\n## Navigation\n\n[<< App-20 Python](App-20-SudokuBenchmark-Python.ipynb) | [Index](../../README.md) | [App-7 Wordle >>](App-7-Wordle.ipynb)\n\n*Marathon #4956 -- parite .NET / Python, volet Search / Applications / CSP. Tranche 2 native-both EPIC #10382.*"
   }
  ],
  "metadata": {

--- a/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
@@ -35,7 +35,7 @@
       content_python_sha: 294a8b50ac5453295020f196dfcb59c25d51768788b5f64ab14427fcfecc54cf
       content_csharp_sha: f280d48767837420b685f9bc4d50fe6da8a6c59b6a648acbdb530269ab14ab2e
     - date: "2026-08-29"
-      by: myia-po-2024:CoursIA
+      by: myia-po-2025:CoursIA
       python_sha: 5dc1d80261b6d0ce9b05e329889c2add5ec130e7
       csharp_sha: 544fbc8be4cdb2ead8f7a4d2b6addbe97124ef3c
       content_python_sha: e41e1e2858796b7fbe07ddaa7f1fd8cf9e80ab5237db8662487251dd06fc3cc7

--- a/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
@@ -41,6 +41,13 @@
       content_python_sha: e41e1e2858796b7fbe07ddaa7f1fd8cf9e80ab5237db8662487251dd06fc3cc7
       content_csharp_sha: 69a7ebea7341c29420e702f78d873d8ad137c2d8ed9275319155f6cc75bcee4d
       reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib), implementation #10382 tranche CP-SAT : tranche 2 clairement separee ajoutee aux DEUX twins (socle from-scratch 4 solveurs preserve integralement), Python atteint OR-Tools CP-SAT (pip ortools 9.15.6755), C# atteint Google.OrTools (NuGet 9.15.6755 epingle, meme moteur, portage officiel .NET). Registre mis a jour APRES execution prouvant les deux moteurs reels : re-exec fraiche des deux notebooks (Papermill python3 cote Python, kernel .net-csharp cote C#), outputs + execution_count commites, 0 erreur, et concordance exacte des invariants branches/conflicts/propagations sur les 3 grilles x 2 configurations (presolve) — la comparabilite exige la meme version des deux cotes, d'ou l'epingle NuGet 9.15.6755 (repo precedent App-16 = 9.11.4210, different de l'ortools pip local)."
+    - date: "2026-08-29"
+      by: myia-po-2025:CoursIA
+      python_sha: f86d1c7fda26f57c5234c99dbf0cccd2ffd19af7
+      csharp_sha: 544fbc8be4cdb2ead8f7a4d2b6addbe97124ef3c
+      content_python_sha: 7140e5b56223b62bb6edde17a53cc7da79ab980f572cf194037663577043c34c
+      content_csharp_sha: 69a7ebea7341c29420e702f78d873d8ad137c2d8ed9275319155f6cc75bcee4d
+      reason: "review fix #13456 : le twin Python epinglait la version uniquement cote C# (NuGet) sans l'imposer a l'import — la cellule d'import definit desormais EXPECTED_ORTOOLS_VERSION = 9.15.6755 avec assertion runtime immediatement apres l'import (pas de %pip install), et le markdown amont precise que les compteurs deterministes CP-SAT ne sont reproductibles que pour cette version epinglee du moteur. Re-exec fraiche complete (kernel python3, 12/12 cellules, 0 erreur) apres le changement de source : invariants deterministes identiques a la baseline (Hard presolve=off : 5 branches / 2 conflicts / 790 prop.bin / 213 prop.int), seuls les temps machine-dep bougent ; twin C# inchange (memes SHA que l'audit precedent), d'ou rebaseline Python seul."
   known_differences:
     - "Socle pedagogique commun : Benchmark Sudoku (comparaison solveurs, timing) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = typing + random + time (from-scratch benchmark) ; C# = System.Diagnostics (Stopwatch) BCL pure."

--- a/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
@@ -48,6 +48,13 @@
       content_python_sha: 7140e5b56223b62bb6edde17a53cc7da79ab980f572cf194037663577043c34c
       content_csharp_sha: 69a7ebea7341c29420e702f78d873d8ad137c2d8ed9275319155f6cc75bcee4d
       reason: "review fix #13456 : le twin Python epinglait la version uniquement cote C# (NuGet) sans l'imposer a l'import — la cellule d'import definit desormais EXPECTED_ORTOOLS_VERSION = 9.15.6755 avec assertion runtime immediatement apres l'import (pas de %pip install), et le markdown amont precise que les compteurs deterministes CP-SAT ne sont reproductibles que pour cette version epinglee du moteur. Re-exec fraiche complete (kernel python3, 12/12 cellules, 0 erreur) apres le changement de source : invariants deterministes identiques a la baseline (Hard presolve=off : 5 branches / 2 conflicts / 790 prop.bin / 213 prop.int), seuls les temps machine-dep bougent ; twin C# inchange (memes SHA que l'audit precedent), d'ou rebaseline Python seul."
+    - date: "2026-08-29"
+      by: myia-po-2025:CoursIA
+      python_sha: c060aca55c56c0d3dfb32664558b49f9f156bf03
+      csharp_sha: 544fbc8be4cdb2ead8f7a4d2b6addbe97124ef3c
+      content_python_sha: 18ce484228a74b94f0cbfc5d8074e07460c793f70a6f8fc45e846eb33c3809f1
+      content_csharp_sha: 69a7ebea7341c29420e702f78d873d8ad137c2d8ed9275319155f6cc75bcee4d
+      reason: "review fix #13456 final : la condition de version est maintenant explicite dans la cellule d'import, le cadrage amont et l'interpretation aval ; le format source list et la newline finale du notebook sont preserves. Le twin C# reste byte-identique (memes SHA que l'audit initial)."
   known_differences:
     - "Socle pedagogique commun : Benchmark Sudoku (comparaison solveurs, timing) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = typing + random + time (from-scratch benchmark) ; C# = System.Diagnostics (Stopwatch) BCL pure."

--- a/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
@@ -2,10 +2,17 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
-  bridge_verdict_reason: "Python = stdlib pure (typing, copy, random, time) : solveurs Sudoku (backtracking, strategies) + benchmark from-scratch, aucun moteur de production externe (numpy/matplotlib = substrat generique viz uniquement). C# = BCL pure (0 NuGet) : meme benchmark from-scratch (backtracking, strategies). Verdict SOTA-OK : aucun des deux cotes n'importe un moteur de production — le benchmark compare des solveurs maison des deux cotes ; il n'y a rien a recuperer (pas de lib Python a bridger, pas d'equivalent .NET manquant). Le concept enseigne (benchmark de strategies Sudoku) est implemente from-scratch des deux cotes, parite sur les concepts cibles. parity_level: semantic preserve."
+  bridge_verdict_reason: "Tranche 1 (socle, preserve integralement) : Python = stdlib pure (typing, copy, random, time) et C# = BCL pure (0 NuGet), les 4 solveurs from-scratch (naif, MRV, AC-3, DLX) des deux cotes, parite sur le nombre d'appels recursifs. Tranche 2 (#10382) : les DEUX cotes appellent le moteur de production Google OR-Tools CP-SAT — Python = pip ortools 9.15.6755 (CpModel/AddAllDifferent/CpSolver), C# = NuGet Google.OrTools 9.15.6755 (#r nuget epingle + Google.OrTools.Sat). Verdict SOTA-OK lib-vs-lib : meme version de moteur des deux cotes (portage officiel .NET du meme code C++), num_search_workers=1 + random_seed=42 dans les deux, invariants (statut, validite, branches, conflicts, propagations) concordants a l'identique sur les 3 grilles x 2 configurations (presolve on : OPTIMAL/Optimal valide partout, 0 branche, 0 conflict ; presolve off : Easy/Medium 0/0, Hard 5 branches/2 conflicts/790 prop.bin/213 prop.int des deux cotes) — preuve d'execution fraiche commitee (outputs + execution_count) dans les deux notebooks. Le temps wall reste machine-dep (informatif)."
   audits:
+    - date: "2026-08-29"
+      by: myia-po-2024:CoursIA
+      python_sha: 5dc1d80261b6d0ce9b05e329889c2add5ec130e7
+      csharp_sha: 544fbc8be4cdb2ead8f7a4d2b6addbe97124ef3c
+      content_python_sha: e41e1e2858796b7fbe07ddaa7f1fd8cf9e80ab5237db8662487251dd06fc3cc7
+      content_csharp_sha: 69a7ebea7341c29420e702f78d873d8ad137c2d8ed9275319155f6cc75bcee4d
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib), implementation #10382 tranche CP-SAT : tranche 2 clairement separee ajoutee aux DEUX twins (socle from-scratch 4 solveurs preserve integralement), Python atteint OR-Tools CP-SAT (pip ortools 9.15.6755), C# atteint Google.OrTools (NuGet 9.15.6755 epingle, meme moteur, portage officiel .NET). Registre mis a jour APRES execution prouvant les deux moteurs reels : re-exec fraiche des deux notebooks (Papermill python3 cote Python, kernel .net-csharp cote C#), outputs + execution_count commites, 0 erreur, et concordance exacte des invariants branches/conflicts/propagations sur les 3 grilles x 2 configurations (presolve) — la comparabilite exige la meme version des deux cotes, d'ou l'epingle NuGet 9.15.6755 (repo precedent App-16 = 9.11.4210, different de l'ortools pip local)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 5a773fde57018c807f03804ac5c313172b9f9a19
@@ -37,4 +44,4 @@
   known_differences:
     - "Socle pedagogique commun : Benchmark Sudoku (comparaison solveurs, timing) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = typing + random + time (from-scratch benchmark) ; C# = System.Diagnostics (Stopwatch) BCL pure."
-    - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents."
+    - "Asymetrie pedagogique : la Tranche 1 (socle) reste from-scratch des deux cotes (stdlib Python vs BCL C#), presentation compacte cote C#. La Tranche 2 (#10382) est au contraire symetrique par construction : le meme moteur OR-Tools CP-SAT (version 9.15.6755 epinglee des deux cotes, num_search_workers=1, random_seed=42) resout les memes 3 grilles dans les memes 2 configurations presolve, et les invariants deterministes (statut, validite, branches, conflicts, propagations) concordent exactement entre les jumeaux — c'est le critere de parite native-both (lib-vs-lib), le temps wall restant machine-dep."

--- a/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-20-sudokubenchmark.yaml
@@ -6,13 +6,6 @@
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Tranche 1 (socle, preserve integralement) : Python = stdlib pure (typing, copy, random, time) et C# = BCL pure (0 NuGet), les 4 solveurs from-scratch (naif, MRV, AC-3, DLX) des deux cotes, parite sur le nombre d'appels recursifs. Tranche 2 (#10382) : les DEUX cotes appellent le moteur de production Google OR-Tools CP-SAT — Python = pip ortools 9.15.6755 (CpModel/AddAllDifferent/CpSolver), C# = NuGet Google.OrTools 9.15.6755 (#r nuget epingle + Google.OrTools.Sat). Verdict SOTA-OK lib-vs-lib : meme version de moteur des deux cotes (portage officiel .NET du meme code C++), num_search_workers=1 + random_seed=42 dans les deux, invariants (statut, validite, branches, conflicts, propagations) concordants a l'identique sur les 3 grilles x 2 configurations (presolve on : OPTIMAL/Optimal valide partout, 0 branche, 0 conflict ; presolve off : Easy/Medium 0/0, Hard 5 branches/2 conflicts/790 prop.bin/213 prop.int des deux cotes) — preuve d'execution fraiche commitee (outputs + execution_count) dans les deux notebooks. Le temps wall reste machine-dep (informatif)."
   audits:
-    - date: "2026-08-29"
-      by: myia-po-2024:CoursIA
-      python_sha: 5dc1d80261b6d0ce9b05e329889c2add5ec130e7
-      csharp_sha: 544fbc8be4cdb2ead8f7a4d2b6addbe97124ef3c
-      content_python_sha: e41e1e2858796b7fbe07ddaa7f1fd8cf9e80ab5237db8662487251dd06fc3cc7
-      content_csharp_sha: 69a7ebea7341c29420e702f78d873d8ad137c2d8ed9275319155f6cc75bcee4d
-      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib), implementation #10382 tranche CP-SAT : tranche 2 clairement separee ajoutee aux DEUX twins (socle from-scratch 4 solveurs preserve integralement), Python atteint OR-Tools CP-SAT (pip ortools 9.15.6755), C# atteint Google.OrTools (NuGet 9.15.6755 epingle, meme moteur, portage officiel .NET). Registre mis a jour APRES execution prouvant les deux moteurs reels : re-exec fraiche des deux notebooks (Papermill python3 cote Python, kernel .net-csharp cote C#), outputs + execution_count commites, 0 erreur, et concordance exacte des invariants branches/conflicts/propagations sur les 3 grilles x 2 configurations (presolve) — la comparabilite exige la meme version des deux cotes, d'ou l'epingle NuGet 9.15.6755 (repo precedent App-16 = 9.11.4210, different de l'ortools pip local)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 5a773fde57018c807f03804ac5c313172b9f9a19
@@ -41,6 +34,13 @@
       csharp_sha: 72f77838eafe5c5beafaf07df1a7d5c733390145
       content_python_sha: 294a8b50ac5453295020f196dfcb59c25d51768788b5f64ab14427fcfecc54cf
       content_csharp_sha: f280d48767837420b685f9bc4d50fe6da8a6c59b6a648acbdb530269ab14ab2e
+    - date: "2026-08-29"
+      by: myia-po-2024:CoursIA
+      python_sha: 5dc1d80261b6d0ce9b05e329889c2add5ec130e7
+      csharp_sha: 544fbc8be4cdb2ead8f7a4d2b6addbe97124ef3c
+      content_python_sha: e41e1e2858796b7fbe07ddaa7f1fd8cf9e80ab5237db8662487251dd06fc3cc7
+      content_csharp_sha: 69a7ebea7341c29420e702f78d873d8ad137c2d8ed9275319155f6cc75bcee4d
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib), implementation #10382 tranche CP-SAT : tranche 2 clairement separee ajoutee aux DEUX twins (socle from-scratch 4 solveurs preserve integralement), Python atteint OR-Tools CP-SAT (pip ortools 9.15.6755), C# atteint Google.OrTools (NuGet 9.15.6755 epingle, meme moteur, portage officiel .NET). Registre mis a jour APRES execution prouvant les deux moteurs reels : re-exec fraiche des deux notebooks (Papermill python3 cote Python, kernel .net-csharp cote C#), outputs + execution_count commites, 0 erreur, et concordance exacte des invariants branches/conflicts/propagations sur les 3 grilles x 2 configurations (presolve) — la comparabilite exige la meme version des deux cotes, d'ou l'epingle NuGet 9.15.6755 (repo precedent App-16 = 9.11.4210, different de l'ortools pip local)."
   known_differences:
     - "Socle pedagogique commun : Benchmark Sudoku (comparaison solveurs, timing) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = typing + random + time (from-scratch benchmark) ; C# = System.Diagnostics (Stopwatch) BCL pure."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/notebook-python #13445

## Résumé

- préserve intégralement les quatre solveurs Sudoku from-scratch des twins App-20 ;
- ajoute une tranche lib-vs-lib Google OR-Tools CP-SAT dans les notebooks Python et C# ;
- exécute le même banc de trois grilles dans les deux écosystèmes et compare des invariants solveur plutôt que des temps machine ;
- bascule la paire `App-20 SudokuBenchmark` de `semantic` à `native-both` après exécution réelle des deux moteurs.

See #10382 — sous-grain atomique App-20 ; le rollout reste ouvert pour les autres paires.

## Résultats frais

Les deux twins utilisent Google OR-Tools `9.15.6755`, avec `num_search_workers=1`, `random_seed=42` et une limite de 60 s. Les invariants concordent sur les mêmes grilles :

| Grille | Presolve | Statut | Valide | Branches | Conflits | Prop. binaires | Prop. entières |
|---|---|---|---:|---:|---:|---:|---:|
| Easy | activé | OPTIMAL / Optimal | oui | 0 | 0 | 0 | 0 |
| Easy | désactivé | OPTIMAL / Optimal | oui | 0 | 0 | 340 | 111 |
| Medium | activé | OPTIMAL / Optimal | oui | 0 | 0 | 0 | 0 |
| Medium | désactivé | OPTIMAL / Optimal | oui | 0 | 0 | 251 | 49 |
| Hard | activé | OPTIMAL / Optimal | oui | 0 | 0 | 0 | 0 |
| Hard | désactivé | OPTIMAL / Optimal | oui | 5 | 2 | 790 | 213 |

Le temps wall est affiché mais reste informatif et machine-dépendant.

## Exécution réelle

- Python : Papermill, kernel `python3`, 28 cellules, 12 cellules code exécutées, 0 erreur ; output frais `OR-Tools version : 9.15.6755`.
- C# : kernel `.net-csharp`, 27 cellules, 12 cellules code exécutées, 0 erreur ; output frais `Google.OrTools 9.15.6755 charge`.
- comparaison structurée à `origin/main` : les 20 cellules code historiques et toutes les cellules d’exercice sont inchangées ; seules deux cellules code CP-SAT sont ajoutées dans chaque twin.

## Validation

- `validate_pr_notebooks.py` : 2/2 PASS, 24 cellules code, 0 erreur ;
- `check_exec_sequence.py` : CLEAN `1..12` sur les deux twins ; ratchet `CLEAN->CLEAN`, 0 régression ;
- `scan_cell_ordering.py --fail-on HIGH --check-interp-anchor` : 2 notebooks clean ;
- `check_interp_positioning.py --check` : aucune nouvelle interprétation mal placée ;
- `detect_consecutive_code_cells.py` : 0 run de cellules code consécutives ;
- `scan_machine_path_outputs.py` : 0 occurrence ; `strip_probe_banner.py --scan` : 0 bannière ;
- garde C.1 : 0 `raise NotImplementedError`, `assert False` ou `1/0` ;
- `check_twin_parity.py` ciblé : App-20 `native-both`, recorded SHA = current SHA, base=OK/head=OK ;
- `git diff --check` : propre ; exactement 3 fichiers dans la portée.

## SOTA

`SOTA-OK` — les deux twins invoquent le vrai moteur Google OR-Tools CP-SAT `9.15.6755` via le binding officiel de leur écosystème (`ortools` Python et NuGet `Google.OrTools` C#).

## Portée twin

Les deux notebooks sont modifiés et ré-exécutés sur le même banc. L’attestation append-only n’est mise à jour qu’après le dernier commit notebook.
