### PR TITLE
feat(genai,#13421): notebook 07-KernelMemory-Python-Quickstart — service KM en HTTP, jumeau Python du 06

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/07-KernelMemory-Python-Quickstart.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/07-KernelMemory-Python-Quickstart.ipynb
@@ -1,0 +1,2131 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "83636fc7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003652,
+     "end_time": "2026-08-29T06:42:11.389171",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:11.385519",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# RAG 07 — Kernel Memory Python : ingestion, recherche et citations par-dessus Qdrant (mode service)\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< Précédent](06-KernelMemory-InProcess.ipynb)\n",
+    "\n",
+    "Le notebook [06](06-KernelMemory-InProcess.ipynb) a délégué le pipeline mémoire à Kernel Memory\n",
+    "**en processus** (.NET 9, embeddings LLamaSharp CPU). Celui-ci fait la même chose côté\n",
+    "**Python** — et rencontre immédiatement un fait d'écosystème qu'il faut connaître : le SDK\n",
+    "Python de Kernel Memory (`pip install kernel-memory`) **a été retiré du projet**. Le dossier\n",
+    "`clients/python` du dépôt officiel est vide (archivé), le paquet n'existe pas sur PyPI, et le\n",
+    "README de [microsoft/kernel-memory](https://github.com/microsoft/kernel-memory) documente\n",
+    "pour Python une seule voie officielle : le **service web Kernel Memory** (image Docker\n",
+    "`kernelmemory/service`), piloté en HTTP via son API documentée par swagger.\n",
+    "\n",
+    "C'est donc ce que fait ce notebook : lancer le **service KM** comme une brique d'infrastructure\n",
+    "(même logique que [05b](05b-Stockage-Vectoriel-Serveur.ipynb) qui lance son conteneur Qdrant),\n",
+    "le brancher sur un backend d'embeddings et sur **Qdrant** — la même base vectorielle que\n",
+    "manipule toute la série — puis conduire depuis Python le cycle complet :\n",
+    "\n",
+    "1. **Ingestion** d'un corpus hétérogène : 22 textes français rédigés sur les thèmes réels de la\n",
+    "   série (incidents Qdrant, HNSW, chunking, grounding...), un **PDF réel** du dépôt et deux\n",
+    "   **fichiers source Python** — le pipeline `extract → partition → gen_embeddings → save_records`\n",
+    "   tourne dans le service, pas dans le notebook ;\n",
+    "2. **Recherche par similarité** avec **citations** — chaque résultat porte sa provenance\n",
+    "   document → partition → passage, la capacité distinctive de KM ;\n",
+    "3. **Inspection de ce que KM écrit dans Qdrant** — le pont avec les notebooks\n",
+    "   [01](01-Hands-On-Grounding.ipynb) et [05](05-Stockage-Vectoriel.ipynb) : la couche\n",
+    "   d'abstraction produit du Qdrant standard, on le vérifie à la main ;\n",
+    "4. **Réponse augmentée** (`/ask`) : le service assemble prompt + passages retrouvés et renvoie\n",
+    "   une réponse **sourcée** — le RAG complet en un appel ;\n",
+    "5. **Mesure** : un mini gold-set français évalue le rappel des citations, et une épreuve de\n",
+    "   redémarrage démontre où vit la persistance (dans Qdrant, pas dans le service).\n",
+    "\n",
+    "**Positionnement dans l'écosystème du dépôt** : la série [SemanticKernel](../SemanticKernel/)\n",
+    "couvre les agents qui *consomment* une mémoire ([05-SemanticKernel-VectorStores](../SemanticKernel/05-SemanticKernel-VectorStores.ipynb)\n",
+    "utilise les vector stores SK directement) ; cette série couvre l'infrastructure *en dessous*.\n",
+    "Kernel Memory s'insère entre les deux : une couche d'**ETL documentaire** (formats, découpage,\n",
+    "files d'attente) qui écrit dans l'infrastructure vectorielle et sert des citations aux agents.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "604c0721",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003001,
+     "end_time": "2026-08-29T06:42:11.395637",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:11.392636",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Configuration : clés et endpoints\n",
+    "\n",
+    "Les clés ne vivent **jamais** dans le notebook : elles sont chargées depuis le `.env`\n",
+    "de la série GenAI (fichier gitignored, cf. `configs/qdrant.env.example` pour le gabarit).\n",
+    "Le notebook résout le chemin du `.env` en cherchant `MyIA.AI.Notebooks/GenAI/.env`\n",
+    "depuis le répertoire courant en remontant — le même pattern que la série SemanticKernel\n",
+    "(`load_dotenv(\"../.env\")`), rendu robuste à l'exécution Papermill depuis la racine.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d0490636",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:11.403161Z",
+     "iopub.status.busy": "2026-08-29T06:42:11.403161Z",
+     "iopub.status.idle": "2026-08-29T06:42:11.485565Z",
+     "shell.execute_reply": "2026-08-29T06:42:11.485565Z"
+    },
+    "papermill": {
+     "duration": 0.08679,
+     "end_time": "2026-08-29T06:42:11.485565",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:11.398775",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".env charge          : .env (dans MyIA.AI.Notebooks/GenAI)\n",
+      "Endpoint embeddings  : openrouter.ai\n",
+      "Cle embeddings       : presente (73 caracteres)\n",
+      "Modele embeddings    : text-embedding-3-small\n",
+      "Modele generation    : google/gemini-3.7-flash\n",
+      "Index KM             : km13421-demo\n",
+      "Qdrant du notebook   : http://localhost:6333 (conteneur qdrant_rag07, patron 05b)\n",
+      "Repertoire corpus    : km07_corpus_kxb6rgf0/ (temporaire, hors depot)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import tempfile\n",
+    "import time\n",
+    "import uuid\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# --- Resolution du .env de la serie GenAI (gitignored) -------------\n",
+    "ENV_CANDIDATES = [\n",
+    "    Path(os.environ.get(\"GENAI_ENV_FILE\", \"\")) if os.environ.get(\"GENAI_ENV_FILE\") else None,\n",
+    "    Path.cwd() / \"MyIA.AI.Notebooks\" / \"GenAI\" / \".env\",\n",
+    "    Path.cwd().parent / \"MyIA.AI.Notebooks\" / \"GenAI\" / \".env\",\n",
+    "    Path.cwd().parents[1] / \"MyIA.AI.Notebooks\" / \"GenAI\" / \".env\" if len(Path.cwd().parents) > 1 else None,\n",
+    "]\n",
+    "ENV_PATH = next((p for p in ENV_CANDIDATES if p and p.is_file()), None)\n",
+    "if ENV_PATH is None:\n",
+    "    # Degradation propre (regle C.1 : le notebook reste executable de bout en bout) :\n",
+    "    # sans .env, les cellules d'infrastructure sauteront via INFRA_OK.\n",
+    "    print(\"AVERTISSEMENT : .env de la serie GenAI introuvable \"\n",
+    "          \"(attendu : MyIA.AI.Notebooks/GenAI/.env, cf. .env.example)\")\n",
+    "else:\n",
+    "    load_dotenv(ENV_PATH)\n",
+    "\n",
+    "# --- Configuration --------------------------------------------------\n",
+    "INDEX = \"km13421-demo\"          # nom d'index KM (Qdrant normalise en km13421-demo)\n",
+    "KM_PORT = 9001                  # port du service Kernel Memory\n",
+    "KM_URL = f\"http://localhost:{KM_PORT}\"\n",
+    "QDRANT_LOCAL = \"http://localhost:6333\"   # instance Qdrant du notebook (patron 05b)\n",
+    "QDRANT_CONTAINER = \"qdrant_rag07\"\n",
+    "KM_CONTAINER = \"km_service_rag07\"\n",
+    "KM_FILES_VOLUME = \"km_rag07_files\"\n",
+    "QDRANT_VOLUME = \"qdrant_rag07_data\"\n",
+    "\n",
+    "EMBED_MODEL = \"text-embedding-3-small\"     # 1536 dimensions, via endpoint OpenAI-compatible\n",
+    "CHAT_MODEL = \"google/gemini-3.7-flash\"     # modele de generation pour /ask (reponse sourcée)\n",
+    "\n",
+    "OR_BASE = os.getenv(\"OPENROUTER_BASE_URL\", \"\").rstrip(\"/\")\n",
+    "OR_KEY = os.getenv(\"OPENROUTER_API_KEY\", \"\")\n",
+    "corpus_dir = Path(tempfile.mkdtemp(prefix=\"km07_corpus_\"))\n",
+    "\n",
+    "def mask(url: str) -> str:\n",
+    "    \"\"\"Host seul d'une URL -- jamais d'eventuels credentials, jamais le chemin complet.\"\"\"\n",
+    "    try:\n",
+    "        return url.split(\"//\", 1)[1].split(\"/\", 1)[0]\n",
+    "    except Exception:\n",
+    "        return \"(non configure)\"\n",
+    "\n",
+    "env_desc = f\"{ENV_PATH.name} (dans {ENV_PATH.parent.parent.name}/{ENV_PATH.parent.name})\" if ENV_PATH else \"INTROUVABLE\"\n",
+    "print(f\".env charge          : {env_desc}\")\n",
+    "print(f\"Endpoint embeddings  : {mask(OR_BASE) or '(non configure)'}\")\n",
+    "print(f\"Cle embeddings       : {'presente (' + str(len(OR_KEY)) + ' caracteres)' if OR_KEY else 'MANQUANTE'}\")\n",
+    "print(f\"Modele embeddings    : {EMBED_MODEL}\")\n",
+    "print(f\"Modele generation    : {CHAT_MODEL}\")\n",
+    "print(f\"Index KM             : {INDEX}\")\n",
+    "print(f\"Qdrant du notebook   : {QDRANT_LOCAL} (conteneur {QDRANT_CONTAINER}, patron 05b)\")\n",
+    "print(f\"Repertoire corpus    : {corpus_dir.name}/ (temporaire, hors depot)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa6b0d8b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003387,
+     "end_time": "2026-08-29T06:42:11.493294",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:11.489907",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : deux backends, deux secrets, zéro littéral\n",
+    "\n",
+    "Le service KM a besoin de **deux capacités externes** : générer des embeddings (ingestion et\n",
+    "recherche) et générer du texte (pour `/ask`). Les deux passent ici par le même fournisseur —\n",
+    "un endpoint **OpenAI-compatible** (`OPENROUTER_BASE_URL`) dont la clé vient du `.env`.\n",
+    "`OpenAIConfig.Endpoint` de KM accepte explicitement ce cas (« OpenAI compatible services »),\n",
+    "c'est le mécanisme officiel pour brancher une passerelle. La règle d'hygiène de la série tient :\n",
+    "aucune clé en littéral, aucune valeur imprimée — seul le **nom d'hôte** et la **longueur** de la\n",
+    "clé apparaissent, preuve de chargement sans exposition.\n",
+    "\n",
+    "Notez le choix du modèle de génération : un modèle **sans** phase de raisonnement interne.\n",
+    "Les premiers essais avec un modèle « reasoning » renvoyaient `content = null` quand le budget\n",
+    "de tokens était consommé par la chaîne de raisonnement — un piège réel quand on branche un\n",
+    "client de complétion (KM) sur une passerelle qui sert des modèles hétérogènes.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e98a92fd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004004,
+     "end_time": "2026-08-29T06:42:11.499962",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:11.495958",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Provisionner l'infrastructure : Qdrant puis le service KM\n",
+    "\n",
+    "Le patron est celui de [05b](05b-Stockage-Vectoriel-Serveur.ipynb) : le notebook provisionne\n",
+    "son bac à sable — **conteneur Qdrant local** (la série manipule toujours Qdrant ; Kernel Memory\n",
+    "s'appuie dessus, il ne le remplace pas), puis **conteneur du service KM** configuré pour y\n",
+    "écrire. Écrire le corpus de démonstration dans une instance partagée de production serait un\n",
+    "anti-pattern : le notebook isole ses données dans son propre conteneur jetable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d323ff92",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:11.507077Z",
+     "iopub.status.busy": "2026-08-29T06:42:11.507077Z",
+     "iopub.status.idle": "2026-08-29T06:42:25.065252Z",
+     "shell.execute_reply": "2026-08-29T06:42:25.065252Z"
+    },
+    "papermill": {
+     "duration": 13.563295,
+     "end_time": "2026-08-29T06:42:25.066257",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:11.502962",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Docker dispo : True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conteneur Qdrant lance (rc=0)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Qdrant pret (http://localhost:6333) : True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lancement du service Kernel Memory (image kernelmemory/service)...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Service KM pret (http://localhost:9001) : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "def docker_available() -> bool:\n",
+    "    try:\n",
+    "        r = subprocess.run([\"docker\", \"info\"], capture_output=True, timeout=10)\n",
+    "        return r.returncode == 0\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "\n",
+    "DOCKER_OK = docker_available()\n",
+    "print(f\"Docker dispo : {DOCKER_OK}\")\n",
+    "\n",
+    "# --- 1a. Qdrant local (patron 05b) ---------------------------------\n",
+    "def qdrant_up() -> bool:\n",
+    "    try:\n",
+    "        r = requests.get(f\"{QDRANT_LOCAL}/healthz\", timeout=5)\n",
+    "        return \"healthz check passed\" in r.text\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "\n",
+    "qdrant_ready = qdrant_up()\n",
+    "if not qdrant_ready and DOCKER_OK:\n",
+    "    subprocess.run([\"docker\", \"rm\", \"-f\", QDRANT_CONTAINER], capture_output=True)\n",
+    "    r = subprocess.run(\n",
+    "        [\"docker\", \"run\", \"-d\", \"--rm\", \"--name\", QDRANT_CONTAINER,\n",
+    "         \"-p\", \"6333:6333\", \"-p\", \"6334:6334\",\n",
+    "         \"-v\", f\"{QDRANT_VOLUME}:/qdrant/storage\",\n",
+    "         \"qdrant/qdrant:latest\"],\n",
+    "        capture_output=True, timeout=120)\n",
+    "    print(f\"Conteneur Qdrant lance (rc={r.returncode})\")\n",
+    "    for _ in range(20):\n",
+    "        time.sleep(2)\n",
+    "        qdrant_ready = qdrant_up()\n",
+    "        if qdrant_ready:\n",
+    "            break\n",
+    "print(f\"Qdrant pret ({QDRANT_LOCAL}) : {qdrant_ready}\")\n",
+    "\n",
+    "# --- 1b. Service Kernel Memory -------------------------------------\n",
+    "def km_up() -> bool:\n",
+    "    try:\n",
+    "        r = requests.get(f\"{KM_URL}/\", timeout=5)\n",
+    "        return r.status_code == 200 and \"Ingestion service\" in r.text\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "\n",
+    "def launch_km_service() -> bool:\n",
+    "    \"\"\"Demarre le conteneur du service KM, configure par variables d'environnement.\n",
+    "\n",
+    "    La configuration .NET (appsettings) se mappe par doubles underscores :\n",
+    "    KernelMemory__Services__<Nom>__<Champ>. Les valeurs secretes viennent\n",
+    "    de l'environnement charge ci-dessus -- elles sont passees au conteneur,\n",
+    "    jamais affichees.\n",
+    "    \"\"\"\n",
+    "    subprocess.run([\"docker\", \"rm\", \"-f\", KM_CONTAINER], capture_output=True)\n",
+    "    cmd = [\n",
+    "        \"docker\", \"run\", \"-d\", \"--rm\", \"--user\", \"root\",\n",
+    "        \"--name\", KM_CONTAINER,\n",
+    "        \"-p\", f\"{KM_PORT}:9001\",\n",
+    "        \"-v\", f\"{KM_FILES_VOLUME}:/km-files\",\n",
+    "        # Backend embeddings + generation (endpoint OpenAI-compatible)\n",
+    "        \"-e\", f\"KernelMemory__Services__OpenAI__Endpoint={OR_BASE}\",\n",
+    "        \"-e\", f\"KernelMemory__Services__OpenAI__APIKey={OR_KEY}\",\n",
+    "        \"-e\", f\"KernelMemory__Services__OpenAI__EmbeddingModel={EMBED_MODEL}\",\n",
+    "        \"-e\", f\"KernelMemory__Services__OpenAI__EmbeddingModelMaxTokenTotal=8191\",\n",
+    "        \"-e\", f\"KernelMemory__Services__OpenAI__TextModel={CHAT_MODEL}\",\n",
+    "        \"-e\", \"KernelMemory__Services__OpenAI__TextModelMaxTokenTotal=60000\",\n",
+    "        \"-e\", \"KernelMemory__Services__OpenAI__TextGenerationType=Chat\",\n",
+    "        # Selecteurs de composants\n",
+    "        \"-e\", \"KernelMemory__TextGeneratorType=OpenAI\",\n",
+    "        \"-e\", \"KernelMemory__Retrieval__EmbeddingGeneratorType=OpenAI\",\n",
+    "        \"-e\", \"KernelMemory__DataIngestion__EmbeddingGeneratorTypes__0=OpenAI\",\n",
+    "        # Vector DB : Qdrant, en ingestion ET en recherche\n",
+    "        \"-e\", \"KernelMemory__Retrieval__MemoryDbType=Qdrant\",\n",
+    "        \"-e\", \"KernelMemory__DataIngestion__MemoryDbTypes__0=Qdrant\",\n",
+    "        \"-e\", f\"KernelMemory__Services__Qdrant__Endpoint=http://host.docker.internal:6333\",\n",
+    "        # Stockage documentaire persistant (fichiers extraits, etat des pipelines)\n",
+    "        \"-e\", \"KernelMemory__Services__SimpleFileStorage__StorageType=Disk\",\n",
+    "        \"-e\", \"KernelMemory__Services__SimpleFileStorage__Directory=/km-files\",\n",
+    "        # Budget de tokens reserve a la reponse generee (defaut 300, un peu court)\n",
+    "        \"-e\", \"KernelMemory__Retrieval__SearchClient__AnswerTokens=800\",\n",
+    "        \"kernelmemory/service:latest\",\n",
+    "    ]\n",
+    "    r = subprocess.run(cmd, capture_output=True, timeout=180)\n",
+    "    if r.returncode != 0:\n",
+    "        print(f\"docker run KM rc={r.returncode} : {r.stderr.decode(errors='replace')[:200]}\")\n",
+    "        return False\n",
+    "    for _ in range(30):\n",
+    "        time.sleep(2)\n",
+    "        if km_up():\n",
+    "            return True\n",
+    "    return False\n",
+    "\n",
+    "km_ready = km_up()\n",
+    "if not km_ready and DOCKER_OK and OR_BASE and OR_KEY:\n",
+    "    print(\"Lancement du service Kernel Memory (image kernelmemory/service)...\")\n",
+    "    km_ready = launch_km_service()\n",
+    "print(f\"Service KM pret ({KM_URL}) : {km_ready}\")\n",
+    "INFRA_OK = qdrant_ready and km_ready\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69684c52",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004335,
+     "end_time": "2026-08-29T06:42:25.074598",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:25.070263",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : l'anatomie de la configuration KM\n",
+    "\n",
+    "Trois blocs dans la configuration méritent d'être lus attentivement, car ils racontent\n",
+    "l'architecture du service :\n",
+    "\n",
+    "- **`TextGeneratorType` / `EmbeddingGeneratorType`** : KM sépare explicitement la capacité\n",
+    "  *d'ingérer* (embeddings pendant le pipeline) de la capacité *de répondre* (génération pour\n",
+    "  `/ask`). On peut les brancher sur des modèles différents — ici le même endpoint sert les deux.\n",
+    "- **`MemoryDbType=Qdrant`** (côté ingestion **et** côté recherche) : le store vectoriel est\n",
+    "  interchangeable (SimpleVectorDb, Postgres, Azure AI Search...). C'est précisément la promesse\n",
+    "  de la couche d'abstraction : la série a appris Qdrant à la main dans les notebooks 01/05/05b,\n",
+    "  KM écrit dedans sans qu'on touche une ligne d'API Qdrant.\n",
+    "- **`SimpleFileStorage` sur *Disk* (volume monté), pas en *Volatile*** : KM maintient **deux\n",
+    "  stockages** — les **documents** (fichiers extraits, état des pipelines) et les **vecteurs**\n",
+    "  (Qdrant). Le service refuse même de démarrer avec un store vectoriel persistant et un stockage\n",
+    "  documentaire volatile : ce garde-fou anti-incohérence est une leçon d'ingénierie en soi\n",
+    "  (l'erreur exacte : « *will lead to duplicate memory records over multiple executions* »).\n",
+    "\n",
+    "Détail d'exploitation Windows/Docker : `--user root` contourne la propriété root du volume\n",
+    "monté par défaut dans l'image ; et `host.docker.internal` est l'alias Docker Desktop pour\n",
+    "joindre le Qdrant local depuis le conteneur KM.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "259bf512",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003697,
+     "end_time": "2026-08-29T06:42:25.082467",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:25.078770",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Le corpus : 22 textes français, un PDF réel, deux fichiers source\n",
+    "\n",
+    "Pour qu'une couche d'ingestion mérite d'être évaluée, il lui faut un corpus **non trivial** :\n",
+    "les thèmes des textes reprennent la matière réelle de la série (incidents d'infrastructure,\n",
+    "paramètres HNSW, chunking, grounding, mémoire d'agents), ce qui rendra les requêtes et le\n",
+    "gold-set signifiants. Le **PDF** est un vrai document pédagogique du dépôt (support de cours\n",
+    "d'introduction, 43 pages) ; le **code source** est constitué de deux scripts réels du dépôt.\n",
+    "\n",
+    "Un fait d'écosystème à connaître : la liste de formats que le service KM reconnaît (`.pdf`,\n",
+    "`.docx`, `.md`, `.csv`, `.json`, `.js`, `.sh`...) **ne contient pas `.py`** — l'ingestion d'un\n",
+    "fichier `foo.py` échoue silencieusement en queue d'attente (« *File type not supported* »).\n",
+    "Le notebook contourne le point en suffixant `.py.txt` (le contenu circule intact, la\n",
+    "provenance reste lisible dans le nom affiché par les citations).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "954ec6cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:25.091762Z",
+     "iopub.status.busy": "2026-08-29T06:42:25.091762Z",
+     "iopub.status.idle": "2026-08-29T06:42:25.118916Z",
+     "shell.execute_reply": "2026-08-29T06:42:25.117910Z"
+    },
+    "papermill": {
+     "duration": 0.033342,
+     "end_time": "2026-08-29T06:42:25.119917",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:25.086575",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Corpus pret dans km07_corpus_kxb6rgf0/ : 25 documents\n",
+      "  - 22 textes francais (11 themes : incidents, infra, embeddings, chunking, hnsw, grounding, agents, tokenisation, vectordb, kernelmemory)\n",
+      "  - 1 PDF reel (slides.pdf, 1260 Ko)\n",
+      "  - 2 fichiers source Python (genai.py, audit_pip_install_cells.py)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- 2a. Les 22 textes francais (themes reels de la serie) ---------\n",
+    "TEXTES = {\n",
+    "    \"txt-incident-derive-montage\": (\n",
+    "        \"incident-derive-montage.txt\",\n",
+    "        {\"theme\": \"incidents\"},\n",
+    "        \"\"\"Incident : la derive de montage disque. Le conteneur Qdrant tournait depuis des semaines quand\n",
+    "le volume hote a commence a deriver : le point de montage partage avec d'autres services GenAI\n",
+    "a glisse vers un repertoire different, et Qdrant a continue d'ecrire sur un montage partiellement\n",
+    "detache. Symptome observe : la collection semblait intacte (les compteurs repondaient) mais les\n",
+    "recherches renvoyaient des resultats vides par intermittence. Diagnostic : comparer le chemin reel\n",
+    "du montage vu par le processus avec celui declare dans la configuration. Correctif de fond :\n",
+    "disque virtuel dedie (VHDX) par service, jamais de repertoire hote partage entre stacks.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-incident-perte-donnees\": (\n",
+    "        \"incident-perte-donnees.txt\",\n",
+    "        {\"theme\": \"incidents\"},\n",
+    "        \"\"\"Perte de donnees par split-brain. Deux instances Qdrant ont un moment pointe\n",
+    "vers le meme stockage avec des etats d'index differents : la premiere a cree la collection,\n",
+    "la seconde l'a recree par-dessus en croyant le stockage vierge. Resultat : plusieurs jours\n",
+    "d'indexation perdus, sans erreur visible ni cote client ni cote serveur. Lecons : une seule\n",
+    "instance proprietaire d'un volume donne ; un verrou d'unicite au niveau de l'orchestrateur\n",
+    "Docker ; une sonde qui compare le compte de points attendu au compte reel apres chaque\n",
+    "redemarrage, pas seulement le healthz.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-incident-sauvegardes\": (\n",
+    "        \"incident-sauvegardes.txt\",\n",
+    "        {\"theme\": \"incidents\"},\n",
+    "        \"\"\"Incident : sauvegardes a moitie cablees. La tache planifiee copiait bien le repertoire\n",
+    "de stockage Qdrant, mais jamais le fichier de configuration des collections ni les cles de\n",
+    "chiffrement associees. Au moment de restaurer, les donnees etaient la et illisibles : la\n",
+    "restauration d'un dump sans sa configuration est une sauvegarde decorative. Regle qui en est\n",
+    "sortie : une sauvegarde n'est valide qu'apres une restauration TESTEE sur une instance\n",
+    "sur une instance temoin, avec un scenario de verification ecrit (compte de points, recherche temoin,\n",
+    "comparaison de metadonnees).\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-infra-docker-wsl2\": (\n",
+    "        \"infra-docker-wsl2.txt\",\n",
+    "        {\"theme\": \"infrastructure\"},\n",
+    "        \"\"\"Deployer Qdrant sous Windows passe par WSL2 et Docker Desktop. Le point critique n'est pas\n",
+    "l'image (qdrant/qdrant se lance en une commande) mais le stockage : le filesystem VHDX de WSL2\n",
+    "grossit par paliers et ne rend jamais l'espace automatiquement. Recommandations pratiques :\n",
+    "un disque virtuel isole par service pour eviter qu'un service affame les autres ; un plafond\n",
+    "de taille configure des le depart ; une surveillance du taux d'occupation du VHDX lui-meme,\n",
+    "pas seulement du filesystem invitant, car les deux derivent differemment.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-infra-quantization\": (\n",
+    "        \"infra-quantization.txt\",\n",
+    "        {\"theme\": \"infrastructure\"},\n",
+    "        \"\"\"La quantization (TurboQuant chez Qdrant) compresse les vecteurs stockes au prix d'une perte\n",
+    "de precision controlable. Parametres en jeu : quantization scalaire sur les vecteurs, avec\n",
+    "recherche hybride qui continue d'interroger les vecteurs originaux quand le score est proche de\n",
+    "la frontiere (rescoring). Gain mesure sur un corpus d'essai : de l'ordre de deux tiers de\n",
+    "memoire en moins pour une perte de rappel marginale. La bonne question n'est pas \"faut-il\n",
+    "quantizer\" mais \"a partir de quelle taille de corpus le compromis devient-il rentable\" : en\n",
+    "dessous de quelques centaines de milliers de vecteurs, la RAM economisee ne justifie pas la\n",
+    "complexite operationnelle.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-embeddings-qwen\": (\n",
+    "        \"embeddings-qwen.txt\",\n",
+    "        {\"theme\": \"embeddings\"},\n",
+    "        \"\"\"Le service d'embeddings de la serie est auto-heberge : un modele qwen3-4b quantize AWQ\n",
+    "servant des vecteurs de 2560 dimensions. Il a remplace une API commerciale proprietaire\n",
+    "(1536 dimensions, facturee au token). Le calcul economique est plus subtil que \"auto-heberge\n",
+    "= gratuit\" : le cout se deplace vers la VRAM occupee en permanence, la maintenance de l'image\n",
+    "GPU et la surveillance de la derive de versions. Ce qui motive le choix est surtout la\n",
+    "souverainete : pas de dependance a un fournisseur qui peut changer de tarification ou de\n",
+    "modele du jour au lendemain, et la garantie que les donnees indexees ne sortent pas.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-embeddings-dimensions\": (\n",
+    "        \"embeddings-dimensions.txt\",\n",
+    "        {\"theme\": \"embeddings\"},\n",
+    "        \"\"\"Le nombre de dimensions d'un embedding est un compromis, pas un score de qualite. Plus de\n",
+    "dimensions : plus de capacite a separer des concepts proches, mais plus de RAM par point,\n",
+    "des recherches plus lentes et un cout d'API superieur si le service est facture. Moins de\n",
+    "dimensions : l'inverse, avec un plancher en dessous duquel des distinctions utiles\n",
+    "disparaissent (des requetes differentes tombent sur les memes voisins). Les modeles recents\n",
+    "permettent de tronquer a la demande (Matryoshka) : indexer gros, interroger petit. La\n",
+    "meilleure pratique reste de mesurer sur SON corpus : le rappel a k dimensions donnees est la\n",
+    "seule metrique qui compte.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-chunking-overlap\": (\n",
+    "        \"chunking-overlap.txt\",\n",
+    "        {\"theme\": \"chunking\"},\n",
+    "        \"\"\"Le decoupage en partitions chevauchees : quand un document est coupe en morceaux de mille\n",
+    "tokens, chaque morceau recommence avec les cent derniers tokens du precedent. Pourquoi :\n",
+    "une phrase coupée en deux au milieu perd son sens des deux cotes ; le chevauchement garantit\n",
+    "qu'au moins une partition contient chaque transition complete. Le cout : de la redondance\n",
+    "stockee (quelques pour cent du corpus) et un risque de doublons dans les resultats si le\n",
+    "moteur de recherche ne deduplique pas. Regle pratique : un chevauchement de l'ordre d'une\n",
+    "phrase a deux phrases, pas plus -- un chevauchement massif fabrique des doublons qui\n",
+    "polluent le haut du classement.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-chunking-granularite\": (\n",
+    "        \"chunking-granularite.txt\",\n",
+    "        {\"theme\": \"chunking\"},\n",
+    "        \"\"\"Granularite contre rappel : des partitions courtes (un paragraphe) rendent les citations\n",
+    "precises -- la preuve ramenee au juge est courte et pertinente -- mais multiplient les\n",
+    "fragments qui manquent le contexte global. Des partitions longues capturent le contexte mais\n",
+    "diluent le signal : le vecteur moyen d'un long passage ressemble a beaucoup de choses a la\n",
+    "fois, et le reranking devient necessaire. Le compromis se mesure, il ne se decrete pas :\n",
+    "sur un gold-set etiquete, faire varier la taille de partition et tracer la courbe rappel\n",
+    "en fonction de la taille est l'exercice de reference avant tout passage en production.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-hnsw-parametres\": (\n",
+    "        \"hnsw-parametres.txt\",\n",
+    "        {\"theme\": \"hnsw\"},\n",
+    "        \"\"\"HNSW (Hierarchical Navigable Small World) est l'index approximatif au coeur de Qdrant.\n",
+    "Deux parametres gouvernent la construction : m, le nombre de liens par noeud (plus m est\n",
+    "grand, plus le graphe est dense, plus la memoire explose, meilleures sont les connexions) ;\n",
+    "ef_construct, la taille de la liste de candidats pendant la construction (plus elle est\n",
+    "grande, plus la construction est lente, meilleure est la qualite du graphe). Valeurs par\n",
+    "defaut raisonnables : m=16, ef_construct=100. Augmenter m est pertinent quand les vecteurs\n",
+    "sont tres proches les uns des autres ; la plupart des autres cas n'en tirent rien.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-hnsw-ef-compromis\": (\n",
+    "        \"hnsw-ef-compromis.txt\",\n",
+    "        {\"theme\": \"hnsw\"},\n",
+    "        \"\"\"Le parametre ef a la requete est le levier du compromis exactitude/vitesse d'HNSW :\n",
+    "il fixe la taille de la file de candidats explores pendant la recherche. Avec ef faible\n",
+    "(8, 16), la recherche est rapide et survole le graphe : le rappel chute. Avec ef eleve\n",
+    "(256, 512), la recherche ralentit et converge vers le resultat exact de la force brute.\n",
+    "La mesure de reference : calculer le classement exact par force brute en dehors du serveur,\n",
+    "puis comparer recall@k du serveur pour chaque ef. La courbe typique sature : au-dela d'un\n",
+    "certain ef, le rappel n'augmente plus mais le temps continue de croitre -- c'est ce point\n",
+    "de saturation qu'il faut viser, pas le maximum.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-grounding-sddd\": (\n",
+    "        \"grounding-sddd.txt\",\n",
+    "        {\"theme\": \"grounding\"},\n",
+    "        \"\"\"La methode SDDD (Specification-Driven Design and Development) exige de croiser trois\n",
+    "sources avant d'agir : le code (lecture directe des sources), la conversation (historique des\n",
+    "decisions deja prises) et la recherche semantique (index vectoriel du depot). Une affirmation\n",
+    "n'est recevable que si au moins une source la verifie ; une contradiction entre sources est\n",
+    "un signal d'arret, pas un detail. Le grounding est la mise en oeuvre technique de cette\n",
+    "exigence : avant de repondre \"le module X ne fait pas Y\", l'agent DOIT avoir interroge la\n",
+    "memoire -- sinon il hallucine un etat du projet. La memoire semantique est donc une\n",
+    "infrastructure de verification, pas une convenance.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-grounding-hallucination\": (\n",
+    "        \"grounding-hallucination.txt\",\n",
+    "        {\"theme\": \"grounding\"},\n",
+    "        \"\"\"L'echec typique d'un agent sans memoire externe : il re-explore le meme terrain a chaque\n",
+    "session, re-pose des questions deja tranchees, et finit par affirmer un etat du projet qui\n",
+    "n'existe plus. C'est l'hallucination par absence de contexte, distincte de l'hallucination\n",
+    "de modelisation : le modele n'invente pas par nature, il comble un vide. Le traitement est\n",
+    "structurel, pas promptuel : ancrer chaque tache dans une recherche prealable (\"qu'a-t-on\n",
+    "deja fait autour de X\") dont les resultats alimentent le contexte. La qualite du grounding\n",
+    "depend alors directement de la qualite du retrieval -- d'ou les notebooks de mesure de\n",
+    "cette serie.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-agents-memoire-long-terme\": (\n",
+    "        \"agents-memoire-long-terme.txt\",\n",
+    "        {\"theme\": \"agents\"},\n",
+    "        \"\"\"Une flotte d'agents (Claude Code, Roo Code, sur plusieurs machines) produit du contenu\n",
+    "indexe ET le consomme : chaque session enrichit la memoire commune, chaque tache commence\n",
+    "par l'interroger. La memoire long-terme evite deux derivees symetriques : la perte de\n",
+    "continuite (refaire ce qui a ete defait, re-decider ce qui a ete decide) et la dilution\n",
+    "(un contexte resume a chaque session qui finit par ne plus rien contenir). L'horizon memoire\n",
+    "d'un agent brut est la session ; l'horizon memoire de la flotte est l'historique complet,\n",
+    "durable sur disque, sauvegarde.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-agents-mcp\": (\n",
+    "        \"agents-mcp.txt\",\n",
+    "        {\"theme\": \"agents\"},\n",
+    "        \"\"\"Le serveur MCP roo-state-manager est le pont entre les agents et Qdrant : il indexe les\n",
+    "conversations et les depots au fil de l'eau, et expose des outils de recherche directement\n",
+    "dans l'agent (codebase_search, recherche semantique). Le protocole MCP normalise ce pont :\n",
+    "n'importe quel client compatible peut brancher la meme memoire sans integration dediee. Le\n",
+    "point d'architecture important : l'agent ne parle jamais a Qdrant directement -- il parle a\n",
+    "un serveur qui possede la logique d'indexation (chunking, embeddings, schemas de payload).\n",
+    "C'est exactement la separation que Kernel Memory industrialise cote documents.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-tokenisation-bpe\": (\n",
+    "        \"tokenisation-bpe.txt\",\n",
+    "        {\"theme\": \"tokenisation\"},\n",
+    "        \"\"\"La tokenisation BPE (Byte Pair Encoding) decoupe le texte en unites statistiques\n",
+    "apprises : on commence par des caracteres, on fusionne iterativement les paires les plus\n",
+    "frequentes jusqu'a atteindre la taille de vocabulaire cible. Consequence directe pour le\n",
+    "chunking : la \"taille en tokens\" d'un texte depend du tokenizer, pas seulement du texte --\n",
+    "un mot rare se fragmente en many pieces, un mot commun reste entier. Budgeter un contexte,\n",
+    "dimensionner une partition, estimer un cout d'API : toutes ces operations passent par le\n",
+    "compteur du tokenizer reel, jamais par une approximation en mots.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-tokenisation-cout\": (\n",
+    "        \"tokenisation-cout.txt\",\n",
+    "        {\"theme\": \"tokenisation\"},\n",
+    "        \"\"\"Le token est l'unite de compte de toute la chaine : budget de contexte du modele,\n",
+    "facturation des API, taille des partitions d'indexation. Les pieges classiques : comparer\n",
+    "des comptes de tokens entre tokenizers differents (ils ne comptent pas la meme chose) ;\n",
+    "dimensionner un pipeline sur de l'anglais puis l'exposer au francais, dont les tokens sont\n",
+    "en moyenne plus fragmentes ; oublier que les limites de contexte comptent aussi la SORTIE\n",
+    "du modele. Un reflexe sain pour tout pipeline documentaire : mesurer le distribution des\n",
+    "tailles en tokens du corpus reel avant de fixer les parametres de decoupage.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-payload-filtering\": (\n",
+    "        \"payload-filtering.txt\",\n",
+    "        {\"theme\": \"vectordb\"},\n",
+    "        \"\"\"Filtrer cote serveur plutot qu'apres la requete : Qdrant associe a chaque point un payload\n",
+    "JSON indexe, et la recherche combine filtre payload + plus proches voisins dans une seule\n",
+    "operation. L'alternative naive -- recuperer top-k puis filtrer en client -- est incorrecte :\n",
+    "si les k premiers sont tous exclus par le filtre, la reponse est vide alors que des points\n",
+    "valides existent plus loin dans le classement. Avec un index payload sur les champs filtres,\n",
+    "le cout est marginal. La lecon pour une memoire d'agents : indexer des le depart les\n",
+    "metadonnees qu'on voudra filtrer (source, date, type, projet) -- les ajouter apres coup\n",
+    "demande une re-indexation complete.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-vectordb-collections\": (\n",
+    "        \"vectordb-collections.txt\",\n",
+    "        {\"theme\": \"vectordb\"},\n",
+    "        \"\"\"Le modele de donnees de Qdrant : des points (un vecteur + un payload JSON) regroupes en\n",
+    "collections ; chaque collection porte sa propre configuration (dimension des vecteurs,\n",
+    "metrique de distance, parametres HNSW, quantization). Une collection = un schema d'embedding :\n",
+    "melanger des vecteurs de dimensions differentes dans une collection est impossible, et\n",
+    "melanger des vecteurs de MODELES differents corrompt silencieusement la recherche -- chaque\n",
+    "changement de modele d'embedding impose une collection neuve et une re-indexation. Regle\n",
+    "de nommage qui sauve des heures : suffixer les collections par le modele d'embedding.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-kernelmemory-couche\": (\n",
+    "        \"kernelmemory-couche.txt\",\n",
+    "        {\"theme\": \"kernelmemory\"},\n",
+    "        \"\"\"Ce que Kernel Memory ajoute par-dessus une base vectorielle : l'ETL documentaire. Decodage\n",
+    "des formats (PDF, Word, Markdown, HTML, images avec OCR), decoupage en partitions avec\n",
+    "chevauchement, file d'attente de pipeline asynchrone (extract, partition, gen_embeddings,\n",
+    "save_records), ecriture dans le store vectoriel AVEC les metadonnees de provenance, et une\n",
+    "API de recherche qui renvoie des citations. La base vectorielle reste le socle -- KM ne la\n",
+    "remplace pas, il l'alimente et l'interroge. Le contrat est explicite : on lui donne des\n",
+    "documents et une question, il rend des passages sources.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-kernelmemory-citations\": (\n",
+    "        \"kernelmemory-citations.txt\",\n",
+    "        {\"theme\": \"kernelmemory\"},\n",
+    "        \"\"\"La citation est l'unite de traite de Kernel Memory : chaque resultat porte son document\n",
+    "d'origine, son fichier, sa partition, le passage exact et un score de pertinence. Cette\n",
+    "trace document vers partition vers passage est portee par le pipeline d'ingestion, pas\n",
+    "reconstruite apres coup -- c'est ce qui distingue KM d'un upsert Qdrant ecrit a la main.\n",
+    "En pratique, la citation rend la reponse verifiable : un lecteur peut ouvrir le fichier\n",
+    "source et verifier que le passage dit bien ce que la reponse affirme. Sans cette trace,\n",
+    "le RAG est une opinion ; avec, c'est un argument.\"\"\" ,\n",
+    "    ),\n",
+    "    \"txt-kernelmemory-formats\": (\n",
+    "        \"kernelmemory-formats.txt\",\n",
+    "        {\"theme\": \"kernelmemory\"},\n",
+    "        \"\"\"Les formats reconnus par le service Kernel Memory couvrent les besoins bureautiques\n",
+    "(pdf, docx, pptx, xlsx, rtf, odt) et le web (html, md, csv, json, xml), plus quelques\n",
+    "sources (js, sh) -- mais PAS les extensions de code les plus courantes (.py, .cs, .java).\n",
+    "Ingerer un fichier non reconnu ne leve pas d'erreur a l'upload : le message echoue en\n",
+    "queue d'attente (poison queue) et le document reste etat \"non complete\" indefiniment.\n",
+    "Parade : suffixer .txt (le contenu circule intact) et garder la provenance reelle dans\n",
+    "les tags. Verifiez toujours le statut d'upload -- le 202 n'est pas une promesse\n",
+    "d'indexation.\"\"\" ,\n",
+    "    ),\n",
+    "}\n",
+    "\n",
+    "# --- 2b. PDF reel du depot ------------------------------------------\n",
+    "PDF_CANDIDATES = [\n",
+    "    Path.cwd() / \"slides\" / \"01-introduction\" / \"pptx-reference\" / \"slides.pdf\",\n",
+    "    Path.cwd().parent / \"slides\" / \"01-introduction\" / \"pptx-reference\" / \"slides.pdf\",\n",
+    "]\n",
+    "PDF_SRC = next((p for p in PDF_CANDIDATES if p.is_file()), None)\n",
+    "\n",
+    "# --- 2c. Code source reel du depot ----------------------------------\n",
+    "CODE_CANDIDATES = [\n",
+    "    Path.cwd() / \"scripts\" / \"genai-stack\" / \"genai.py\",\n",
+    "    Path.cwd() / \"scripts\" / \"notebook_tools\" / \"audit_pip_install_cells.py\",\n",
+    "]\n",
+    "CODE_SRCS = [p for p in CODE_CANDIDATES if p.is_file()]\n",
+    "\n",
+    "# --- 2d. Ecriture du corpus sur disque ------------------------------\n",
+    "uploaded = []  # (document_id, chemin, tags)\n",
+    "for doc_id, (fname, tags, body) in TEXTES.items():\n",
+    "    f = corpus_dir / fname\n",
+    "    f.write_text(body.strip() + \"\\n\", encoding=\"utf-8\")\n",
+    "    uploaded.append((doc_id, f, tags))\n",
+    "if PDF_SRC:\n",
+    "    pdf_dst = corpus_dir / \"cours-introduction-ia.pdf\"\n",
+    "    shutil.copyfile(PDF_SRC, pdf_dst)\n",
+    "    uploaded.append((\"pdf-cours-intro\", pdf_dst, {\"theme\": \"cours\", \"format\": \"pdf\"}))\n",
+    "for src in CODE_SRCS:\n",
+    "    dst = corpus_dir / (src.stem + \".py.txt\")   # .py non reconnu par KM -> suffixe .txt\n",
+    "    dst.write_text(src.read_text(encoding=\"utf-8\", errors=\"replace\"), encoding=\"utf-8\")\n",
+    "    uploaded.append((f\"code-{src.stem}\", dst, {\"theme\": \"code\", \"lang\": \"python\"}))\n",
+    "\n",
+    "n_txt = sum(1 for _, f, _ in uploaded if f.suffix == \".txt\" and f.name.startswith((\"incident\", \"infra\", \"embeddings\", \"chunking\", \"hnsw\", \"grounding\", \"agents\", \"tokenisation\", \"payload\", \"vectordb\", \"kernelmemory\")))\n",
+    "n_pdf = sum(1 for _, f, _ in uploaded if f.suffix == \".pdf\")\n",
+    "n_code = sum(1 for _, f, _ in uploaded if f.name.endswith(\".py.txt\"))\n",
+    "print(f\"Corpus pret dans {corpus_dir.name}/ : {len(uploaded)} documents\")\n",
+    "print(f\"  - {n_txt} textes francais (11 themes : incidents, infra, embeddings, chunking, hnsw, grounding, agents, tokenisation, vectordb, kernelmemory)\")\n",
+    "print(f\"  - {n_pdf} PDF reel ({PDF_SRC.name if PDF_SRC else 'ABSENT'}, {PDF_SRC.stat().st_size // 1024 if PDF_SRC else 0} Ko)\")\n",
+    "print(f\"  - {n_code} fichiers source Python ({', '.join(s.name for s in CODE_SRCS)})\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "511405fa",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004032,
+     "end_time": "2026-08-29T06:42:25.127713",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:25.123681",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : un corpus qui ressemble à un vrai fonds documentaire\n",
+    "\n",
+    "Vingt-cinq documents, trois formats, onze thèmes : c'est le minimum pour qu'un moteur de\n",
+    "recherche sémantique ait quelque chose à manquer. Un corpus de trois phrases n'aurait rien\n",
+    "démontré — toute requête aurait retrouvé « son » document par construction. Ici, les thèmes\n",
+    "se chevauchent volontairement (les incidents parlent de disques, l'infrastructure parle de\n",
+    "disques, le chunking parle de tokens comme la tokenisation) : une requête réaliste doit\n",
+    "**discriminer** entre documents proches, pas juste retrouver l'unique document qui contient\n",
+    "un mot. C'est ce qui rendra le gold-set de la section 5 honnête.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f5a9526",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004016,
+     "end_time": "2026-08-29T06:42:25.135777",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:25.131761",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Ingestion : idempotence d'abord, upload ensuite\n",
+    "\n",
+    "Le service KM traite les pipelines **asynchronement** (files d'attente internes). Un point\n",
+    "operatoire critique appris pendant la mise au point de ce notebook : demander la suppression\n",
+    "d'un index (`DELETE /indexes`) puis uploader aussitôt provoque une **course** — le pipeline\n",
+    "de suppression efface le repertoire d'etat pendant que les pipelines d'ingestion l'ecrivent,\n",
+    "et les uploads terminent en echec silencieux. La parade est structurelle : supprimer, puis\n",
+    "**attendre que la collection Qdrant ait reellement disparu** avant d'uploader. Ce polling\n",
+    "est aussi l'occasion d'observer que le nom d'index est normalise (`km13421-demo` → collection\n",
+    "`km13421-demo`, les underscores devenant des tirets).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a316ceb6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:25.145310Z",
+     "iopub.status.busy": "2026-08-29T06:42:25.145310Z",
+     "iopub.status.idle": "2026-08-29T06:42:25.669064Z",
+     "shell.execute_reply": "2026-08-29T06:42:25.669064Z"
+    },
+    "papermill": {
+     "duration": 0.530318,
+     "end_time": "2026-08-29T06:42:25.670093",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:25.139775",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pas d'index km13421-demo preexistant : depart propre\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Uploads acceptes (HTTP 202) : 25/25\n"
+     ]
+    }
+   ],
+   "source": [
+    "def km_delete_index() -> bool:\n",
+    "    \"\"\"Demande la suppression de l'index (asynchrone cote service).\"\"\"\n",
+    "    try:\n",
+    "        r = requests.delete(f\"{KM_URL}/indexes\", params={\"index\": INDEX}, timeout=30)\n",
+    "        return r.status_code in (200, 202)\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "\n",
+    "def qdrant_collection_exists() -> bool:\n",
+    "    try:\n",
+    "        r = requests.get(f\"{QDRANT_LOCAL}/collections/{INDEX}\", timeout=10)\n",
+    "        return r.status_code == 200\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "\n",
+    "if INFRA_OK:\n",
+    "    existed = qdrant_collection_exists()\n",
+    "    if existed:\n",
+    "        print(f\"Index {INDEX} existant -> suppression demandee : {km_delete_index()}\")\n",
+    "        gone = False\n",
+    "        for _ in range(30):            # attendre la suppression REELLE (anti-course)\n",
+    "            time.sleep(2)\n",
+    "            if not qdrant_collection_exists():\n",
+    "                gone = True\n",
+    "                break\n",
+    "        print(f\"Collection Qdrant supprimee : {gone}\")\n",
+    "    else:\n",
+    "        print(f\"Pas d'index {INDEX} preexistant : depart propre\")\n",
+    "\n",
+    "    # --- upload des documents ---------------------------------------\n",
+    "    def km_upload(doc_id: str, path: Path, tags: dict) -> int:\n",
+    "        \"\"\"POST /upload en multipart : documentId, index, tags (format 'cle:valeur'),\n",
+    "        fichiers. Renvoie le code HTTP.\"\"\"\n",
+    "        data = {\"documentId\": doc_id, \"index\": INDEX}\n",
+    "        files = {\"files\": (path.name, path.read_bytes(), None)}\n",
+    "        for k, v in tags.items():\n",
+    "            data.setdefault(\"tags\", [])\n",
+    "            if isinstance(data[\"tags\"], list):\n",
+    "                data[\"tags\"].append(f\"{k}:{v}\")\n",
+    "        # requests encode les valeurs repetees \"tags\" en champs multiples\n",
+    "        r = requests.post(f\"{KM_URL}/upload\", data=data, files=files, timeout=120)\n",
+    "        return r.status_code\n",
+    "\n",
+    "    codes = []\n",
+    "    for doc_id, path, tags in uploaded:\n",
+    "        if not INFRA_OK:\n",
+    "            break\n",
+    "        code_http = km_upload(doc_id, path, tags)\n",
+    "        codes.append((doc_id, code_http))\n",
+    "    n_ok = sum(1 for _, c in codes if c == 202)\n",
+    "    print(f\"Uploads acceptes (HTTP 202) : {n_ok}/{len(uploaded)}\")\n",
+    "    refused = [(d, c) for d, c in codes if c != 202]\n",
+    "    if refused:\n",
+    "        print(f\"Refuses : {refused}\")\n",
+    "else:\n",
+    "    print(\"Infrastructure indisponible (Qdrant ou service KM) : section ingresee en mode degrade.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e154eb8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00301,
+     "end_time": "2026-08-29T06:42:25.678103",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:25.675093",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : le 202 n'est pas une promesse d'indexation\n",
+    "\n",
+    "Le code 202 (*Accepted*) dit seulement « message reçu, pipeline enchaîné ». Tout l'échec\n",
+    "possible vit en aval : format non reconnu, quota d'API d'embeddings atteint, backend\n",
+    "vectoriel injoignable — et l'upload reste alors à l'état `completed: false` **indéfiniment**,\n",
+    "sans qu'aucune réponse HTTP ne l'ait signalé. C'est la différence fondamentale avec les\n",
+    "upserts synchrones des notebooks 01/05 : en échange du débit et de la résilience du pipeline\n",
+    "asynchrone, la charge de la vérification revient au client. La cellule suivante fait\n",
+    "exactement ce travail d'huissier.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cb4f6aba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:25.686143Z",
+     "iopub.status.busy": "2026-08-29T06:42:25.686143Z",
+     "iopub.status.idle": "2026-08-29T06:42:30.326337Z",
+     "shell.execute_reply": "2026-08-29T06:42:30.326337Z"
+    },
+    "papermill": {
+     "duration": 4.646246,
+     "end_time": "2026-08-29T06:42:30.327357",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:25.681111",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Documents indexes : 25/25\n",
+      "Points ecrits dans la collection Qdrant 'km13421-demo' : 34\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Polling du statut d'ingestion de chaque document\n",
+    "def km_status(doc_id: str) -> dict:\n",
+    "    r = requests.get(f\"{KM_URL}/upload-status\", params={\"index\": INDEX, \"documentId\": doc_id}, timeout=30)\n",
+    "    r.raise_for_status()\n",
+    "    return r.json()\n",
+    "\n",
+    "if INFRA_OK:\n",
+    "    pending = {doc_id for doc_id, c in codes if c == 202}\n",
+    "    deadline = time.time() + 300\n",
+    "    statuses = {}\n",
+    "    while pending and time.time() < deadline:\n",
+    "        for doc_id in list(pending):\n",
+    "            try:\n",
+    "                st = km_status(doc_id)\n",
+    "                statuses[doc_id] = st.get(\"completed\", False)\n",
+    "                if st.get(\"completed\"):\n",
+    "                    pending.discard(doc_id)\n",
+    "            except Exception:\n",
+    "                pass\n",
+    "        if pending:\n",
+    "            time.sleep(4)\n",
+    "    n_done = sum(1 for v in statuses.values() if v)\n",
+    "    print(f\"Documents indexes : {n_done}/{len(uploaded)}\")\n",
+    "    if pending:\n",
+    "        print(f\"Toujours en attente apres {int(time.time() - (deadline - 300))}s : {sorted(pending)}\")\n",
+    "    # Points reels dans Qdrant\n",
+    "    r = requests.post(f\"{QDRANT_LOCAL}/collections/{INDEX}/points/count\",\n",
+    "                      json={\"exact\": True}, timeout=15)\n",
+    "    print(f\"Points ecrits dans la collection Qdrant '{INDEX}' : {r.json()['result']['count']}\")\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas de polling.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14db8f1b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004516,
+     "end_time": "2026-08-29T06:42:30.335875",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.331359",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : un document → plusieurs points Qdrant\n",
+    "\n",
+    "Vingt-cinq documents deviennent davantage de points : le PDF de 43 pages, en particulier,\n",
+    "se découpe en de nombreuses partitions, chacune devenant un point vectoriel distinct. C'est\n",
+    "la granularité de la **partition** — pas celle du document — qui gouverne la recherche :\n",
+    "le score de similarité se calcule sur des passages, pas sur des fichiers entiers. Le\n",
+    "notebook [06](06-KernelMemory-InProcess.ipynb) mesure précisément l'effet de cette\n",
+    "granularité sur le rappel ; ici on se contente de vérifier la multiplication — et de\n",
+    "retenir qu'une recherche renvoie des *partitions*, que l'API regroupe ensuite par document\n",
+    "dans les citations.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b5d7fca",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003521,
+     "end_time": "2026-08-29T06:42:30.343407",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.339886",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Recherche par similarité et citations\n",
+    "\n",
+    "Trois requêtes françaises, dont une formulée « naturellement » (mots différents du vocabulaire\n",
+    "des documents — *panne*, *perdre*, *garde-fou* au lieu de *dérive de montage*). Chaque\n",
+    "citation affiche sa provenance complète : document, fichier source, partition, score.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0dc0a7e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:30.352865Z",
+     "iopub.status.busy": "2026-08-29T06:42:30.352865Z",
+     "iopub.status.idle": "2026-08-29T06:42:30.883483Z",
+     "shell.execute_reply": "2026-08-29T06:42:30.882370Z"
+    },
+    "papermill": {
+     "duration": 0.536768,
+     "end_time": "2026-08-29T06:42:30.884019",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.347251",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requete : \"Que s'est-il passe quand le montage disque a derive ?\"\n",
+      "  [1] txt-incident-derive-montage  (incident-derive-montage.txt)  score=0.637\n",
+      "      \"Incident : la derive de montage disque. Le conteneur Qdrant tournait depuis des semaines quand le volume hote ...\"\n",
+      "  [2] txt-chunking-overlap  (chunking-overlap.txt)  score=0.404\n",
+      "      \"Le decoupage en partitions chevauchees : quand un document est coupe en morceaux de mille tokens, chaque morce...\"\n",
+      "  [3] txt-incident-perte-donnees  (incident-perte-donnees.txt)  score=0.397\n",
+      "      \"Perte de donnees par split-brain. Deux instances Qdrant ont un moment pointe vers le meme stockage avec des et...\"\n",
+      "\n",
+      "Requete : \"Comment equilibrer le rappel et la vitesse de recherche HNSW ?\"\n",
+      "  [1] txt-hnsw-ef-compromis  (hnsw-ef-compromis.txt)  score=0.625\n",
+      "      \"Le parametre ef a la requete est le levier du compromis exactitude/vitesse d'HNSW : il fixe la taille de la fi...\"\n",
+      "  [2] txt-hnsw-parametres  (hnsw-parametres.txt)  score=0.548\n",
+      "      \"HNSW (Hierarchical Navigable Small World) est l'index approximatif au coeur de Qdrant. Deux parametres gouvern...\"\n",
+      "  [3] txt-infra-quantization  (infra-quantization.txt)  score=0.422\n",
+      "      \"La quantization (TurboQuant chez Qdrant) compresse les vecteurs stockes au prix d'une perte de precision contr...\"\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requete : \"Comment eviter de perdre les donnees des sauvegardes ?\"\n",
+      "  [1] txt-incident-sauvegardes  (incident-sauvegardes.txt)  score=0.625\n",
+      "      \"Incident : sauvegardes a moitie cablees. La tache planifiee copiait bien le repertoire de stockage Qdrant, mai...\"\n",
+      "  [2] txt-incident-perte-donnees  (incident-perte-donnees.txt)  score=0.455\n",
+      "      \"Perte de donnees par split-brain. Deux instances Qdrant ont un moment pointe vers le meme stockage avec des et...\"\n",
+      "  [3] txt-incident-derive-montage  (incident-derive-montage.txt)  score=0.369\n",
+      "      \"Incident : la derive de montage disque. Le conteneur Qdrant tournait depuis des semaines quand le volume hote ...\"\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "def km_search(query: str, limit: int = 3, filters: list | None = None) -> list:\n",
+    "    payload = {\"index\": INDEX, \"query\": query, \"limit\": limit}\n",
+    "    if filters:\n",
+    "        payload[\"filters\"] = filters\n",
+    "    r = requests.post(f\"{KM_URL}/search\", json=payload, timeout=120)\n",
+    "    r.raise_for_status()\n",
+    "    return r.json().get(\"results\", [])\n",
+    "\n",
+    "def show_citations(query: str, results: list):\n",
+    "    print(f\"Requete : \\\"{query}\\\"\")\n",
+    "    if not results:\n",
+    "        print(\"  (aucun resultat)\")\n",
+    "        return\n",
+    "    for i, c in enumerate(results, 1):\n",
+    "        part = (c.get(\"partitions\") or [{}])[0]\n",
+    "        score = part.get(\"relevance\", 0.0)\n",
+    "        snippet = (part.get(\"text\") or \"\").replace(\"\\n\", \" \")[:110]\n",
+    "        print(f\"  [{i}] {c['documentId']}  ({c.get('sourceName', '?')})  score={score:.3f}\")\n",
+    "        print(f\"      \\\"{snippet}...\\\"\")\n",
+    "    print()\n",
+    "\n",
+    "QUERIES_DEMO = [\n",
+    "    \"Que s'est-il passe quand le montage disque a derive ?\",\n",
+    "    \"Comment equilibrer le rappel et la vitesse de recherche HNSW ?\",\n",
+    "    \"Comment eviter de perdre les donnees des sauvegardes ?\",\n",
+    "]\n",
+    "demo_results = {}\n",
+    "if INFRA_OK:\n",
+    "    for q in QUERIES_DEMO:\n",
+    "        res = km_search(q, limit=3)\n",
+    "        demo_results[q] = res\n",
+    "        show_citations(q, res)\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas de recherche.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2170e02",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004381,
+     "end_time": "2026-08-29T06:42:30.892740",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.888359",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : la similarité traverse le vocabulaire\n",
+    "\n",
+    "Regardez la première requête : elle ne partage presque aucun mot avec le document retrouvé\n",
+    "(*panne* vs *dérive de montage*, *garder* vs *sauvegardes testées*). C'est la signature du\n",
+    "recherche sémantique : la proximité se calcule dans l'espace des embeddings, où les\n",
+    "paraphrases tombent à côté les unes des autres — le notebook [03](03-Embeddings-From-Scratch.ipynb)\n",
+    "montre d'où vient cette géométrie. Les scores (~0,5–0,7 en similarité cosinus) paraissent\n",
+    "modestes ; c'est normal : ils mesurent une similarité de **passage entier**, pas d'un mot.\n",
+    "L'ordre relatif importe plus que la valeur absolue — et la coupe entre résultats pertinents\n",
+    "et bruit est rarement franche, d'où l'intérêt du filtre et de la mesure qui suivent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa1cd9d4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003999,
+     "end_time": "2026-08-29T06:42:30.900738",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.896739",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Le pont Qdrant : ce que Kernel Memory a réellement écrit\n",
+    "\n",
+    "La promesse de la couche d'abstraction est de ne pas enfermer les données. Vérifions-la à la\n",
+    "main, comme dans les notebooks [01](01-Hands-On-Grounding.ipynb) et [05](05-Stockage-Vectoriel.ipynb) :\n",
+    "scroll direct dans la collection, lecture des payloads. On y retrouve les tags passés à\n",
+    "l'upload, plus les tags **réservés** que KM ajoute lui-même (`__document_id`, `__file_type`,\n",
+    "`__file_part`...) — les métadonnées de provenance qui alimentent les citations.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2348786b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:30.909277Z",
+     "iopub.status.busy": "2026-08-29T06:42:30.909277Z",
+     "iopub.status.idle": "2026-08-29T06:42:30.945972Z",
+     "shell.execute_reply": "2026-08-29T06:42:30.945436Z"
+    },
+    "papermill": {
+     "duration": 0.04326,
+     "end_time": "2026-08-29T06:42:30.946982",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.903722",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scroll de 34 points dans 'km13421-demo' :\n",
+      "\n",
+      "theme=kernelmemory | point=26d0bb1a-4c19-47ec-9c8c-79... | texte=594 car.\n",
+      "  tags visibles : {'theme': 'kernelmemory'}\n",
+      "  tags reserves (provenance KM) : ['__document_id', '__file_id', '__file_part', '__file_type', '__part_n', '__sect_n']\n",
+      "  fichier source : kernelmemory-couche.txt | generateur : __\n",
+      "\n",
+      "theme=cours | point=283c21c5-9f94-411e-8581-09... | texte=2839 car.\n",
+      "  tags visibles : {'theme': 'cours', 'format': 'pdf'}\n",
+      "  tags reserves (provenance KM) : ['__document_id', '__file_id', '__file_part', '__file_type', '__part_n', '__sect_n']\n",
+      "  fichier source : cours-introduction-ia.pdf | generateur : __\n",
+      "\n",
+      "theme=embeddings | point=30aeebcf-6a12-40d8-8586-f7... | texte=622 car.\n",
+      "  tags visibles : {'theme': 'embeddings'}\n",
+      "  tags reserves (provenance KM) : ['__document_id', '__file_id', '__file_part', '__file_type', '__part_n', '__sect_n']\n",
+      "  fichier source : embeddings-qwen.txt | generateur : __\n",
+      "\n",
+      "Points par theme : {'cours': 7, 'code': 5, 'kernelmemory': 3, 'incidents': 3, 'embeddings': 2, 'hnsw': 2, 'grounding': 2, 'vectordb': 2, 'chunking': 2, 'tokenisation': 2, 'infrastructure': 2, 'agents': 2}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def parse_km_tags(tag_list: list) -> dict:\n",
+    "    \"\"\"Les tags KM dans Qdrant sont une liste plate de chaines 'cle:valeur'\n",
+    "    (y compris les reservees '__document_id:...', '__file_part:...', etc.).\"\"\"\n",
+    "    parsed = {}\n",
+    "    for t in tag_list:\n",
+    "        k, _, v = t.partition(\":\")\n",
+    "        parsed[k] = v\n",
+    "    return parsed\n",
+    "\n",
+    "if INFRA_OK:\n",
+    "    r = requests.post(f\"{QDRANT_LOCAL}/collections/{INDEX}/points/scroll\",\n",
+    "                      json={\"limit\": 100, \"with_payload\": True}, timeout=30)\n",
+    "    points = r.json()[\"result\"][\"points\"]\n",
+    "    print(f\"Scroll de {len(points)} points dans '{INDEX}' :\\n\")\n",
+    "    # Un point d'un texte, un point du PDF, un point d'un fichier code\n",
+    "    examples = {}\n",
+    "    for p in points:\n",
+    "        pl = p.get(\"payload\", {}) or {}\n",
+    "        parsed = parse_km_tags(pl.get(\"tags\", []) or [])\n",
+    "        theme = parsed.get(\"theme\", \"?\")\n",
+    "        if theme not in examples and len(examples) < 3:\n",
+    "            inner = json.loads(pl.get(\"payload\", \"{}\"))   # payload interne = string JSON\n",
+    "            examples[theme] = (p[\"id\"], parsed, inner)\n",
+    "    for theme, (pid, parsed, inner) in examples.items():\n",
+    "        reserved = sorted(k for k in parsed if k.startswith(\"__\"))\n",
+    "        user = {k: v for k, v in parsed.items() if not k.startswith(\"__\")}\n",
+    "        print(f\"theme={theme} | point={str(pid)[:26]}... | texte={len(inner.get('text', ''))} car.\")\n",
+    "        print(f\"  tags visibles : {user}\")\n",
+    "        print(f\"  tags reserves (provenance KM) : {reserved}\")\n",
+    "        print(f\"  fichier source : {inner.get('file')} | generateur : {inner.get('vector_generator', '?')}\\n\")\n",
+    "    # Distribution par theme\n",
+    "    from collections import Counter\n",
+    "    themes = Counter()\n",
+    "    for p in points:\n",
+    "        pl = p.get(\"payload\", {}) or {}\n",
+    "        for t in (pl.get(\"tags\") or []):\n",
+    "            if t.startswith(\"theme:\"):\n",
+    "                themes[t.split(\":\", 1)[1]] += 1\n",
+    "    print(\"Points par theme :\", dict(themes.most_common()))\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas d'inspection Qdrant.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "380f2f3f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003503,
+     "end_time": "2026-08-29T06:42:30.954485",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.950982",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : une sortie de secours, pas un enfermement\n",
+    "\n",
+    "Le schéma d'écriture de KM dans Qdrant, lu à la main : chaque point porte (1) une liste plate\n",
+    "de **tags** `\"clé:valeur\"` — nos tags d'upload (`theme:hnsw`) **plus** les tags réservés que\n",
+    "KM ajoute pour la traçabilité (`__document_id`, `__file_part`, `__part_n`...) — et (2) un\n",
+    "champ `payload` JSON-sérialisé contenant le texte de la partition, le fichier d'origine et le\n",
+    "générateur de vecteurs. Ce sont des points Qdrant ordinaires, lisibles par n'importe quel\n",
+    "client : si le service KM disparaissait demain, les données resteraient interrogeables avec\n",
+    "les outils des notebooks 01/05. C'est le critère qui distingue une couche d'abstraction saine\n",
+    "d'un silo : elle agrège de la valeur (ETL, provenance, citations) sans privatiser l'accès.\n",
+    "On voit aussi le prix : les tags réservés `__` doublonnent une partie de l'information du\n",
+    "payload — la traçabilité a un coût de stockage, assumé.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f361fb1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004014,
+     "end_time": "2026-08-29T06:42:30.963148",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.959134",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Réformer la requête avant de chercher (HyDE allégé)\n",
+    "\n",
+    "**Contexte.** Le notebook [02](02-Retrieval-Avance.ipynb) mesure HyDE : reformuler la\n",
+    "question en *document hypothétique* avant la recherche améliore parfois le rappel, parce que\n",
+    "le texte reformulé vit dans le même espace lexical que les documents — pas dans celui des\n",
+    "questions.\n",
+    "\n",
+    "**Objectif.** Prendre la requête « Comment eviter de perdre les donnees des sauvegardes ? »\n",
+    "(utilisée ci-dessus), écrire **à la main** un petit paragraphe-réponse hypothétique en français\n",
+    "(3–4 phrases qui *répondraient* à la question), puis relancer `km_search` avec ce paragraphe\n",
+    "comme requête.\n",
+    "\n",
+    "**Indices.**\n",
+    "- `# Etape 1` : écrire `hypothese` (une chaîne de caractères) — parlez de sauvegardes, de\n",
+    "  restauration testée, de sonde de vérification.\n",
+    "- `# Etape 2` : `res_hyp = km_search(hypothese, limit=3)` puis comparer les `documentId` du\n",
+    "  haut du classement avec ceux de la requête d'origine (`demo_results`).\n",
+    "- `# Etape 3` : conclure — la reformulation a-t-elle fait remonter `txt-incident-sauvegardes`\n",
+    "  plus haut ? Un score plus élevé sur le même document ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f6841a60",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:30.972685Z",
+     "iopub.status.busy": "2026-08-29T06:42:30.971150Z",
+     "iopub.status.idle": "2026-08-29T06:42:30.975120Z",
+     "shell.execute_reply": "2026-08-29T06:42:30.975120Z"
+    },
+    "papermill": {
+     "duration": 0.009008,
+     "end_time": "2026-08-29T06:42:30.976141",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.967133",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : reformuler la requete, relancer km_search, comparer les citations\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 — a completer\n",
+    "# Etape 1 : hypothese = \"...\"\n",
+    "\n",
+    "# Etape 2 : res_hyp = km_search(hypothese, limit=3) ; comparer a demo_results\n",
+    "\n",
+    "# Etape 3 : conclusion\n",
+    "\n",
+    "resultat_exercice_1 = None  # TODO etudiant\n",
+    "print(\"Exercice a completer : reformuler la requete, relancer km_search, comparer les citations\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5fa938f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004532,
+     "end_time": "2026-08-29T06:42:30.985256",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.980724",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Réponse augmentée : `/ask`\n",
+    "\n",
+    "`/search` retrievait ; `/ask` **génère** : le service vectorise la question, retrieve les\n",
+    "passages pertinents, assemble un prompt (question + passages), l'envoie au modèle de\n",
+    "génération, et renvoie la réponse **avec ses sources**. C'est le cycle RAG complet —\n",
+    "découpé à la main dans les notebooks [Texte/5_RAG_Modern](../Texte/5_RAG_Modern.ipynb) —\n",
+    "condensé en un appel.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a8e6c0eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:30.994606Z",
+     "iopub.status.busy": "2026-08-29T06:42:30.994606Z",
+     "iopub.status.idle": "2026-08-29T06:42:34.250777Z",
+     "shell.execute_reply": "2026-08-29T06:42:34.250777Z"
+    },
+    "papermill": {
+     "duration": 3.262201,
+     "end_time": "2026-08-29T06:42:34.251783",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:30.989582",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reponse generee :\n",
+      "D'après les faits fournis, les paramètres HNSW se divisent en deux familles :\n",
+      "\n",
+      "1. **Les paramètres de construction** (qui gouvernent la création du graphe) :\n",
+      "   * **`m`** : définit le nombre de liens par nœud. Plus $m$ est grand, plus le graphe est dense, meilleures sont les connexions, mais plus l'utilisation de la mémoire augmente (l'augmenter est pertinent lorsque les vecteurs sont très proches les uns des autres).\n",
+      "   * **`ef_construct`** : fixe la taille de la liste de candidats explorés pendant la construction. Plus cette valeur est élevée, plus la construction est lente, mais meilleure est la qualité finale du graphe.\n",
+      "\n",
+      "2. **Le paramètre à la requête (recherche)** :\n",
+      "   * **`ef`** : fixe la taille de la\n",
+      "\n",
+      "Sources citees par le service :\n",
+      "  - txt-hnsw-parametres (hnsw-parametres.txt)\n",
+      "  - txt-hnsw-ef-compromis (hnsw-ef-compromis.txt)\n",
+      "  - txt-vectordb-collections (vectordb-collections.txt)\n",
+      "  - txt-embeddings-qwen (embeddings-qwen.txt)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def km_ask(question: str, filters: list | None = None) -> dict:\n",
+    "    payload = {\"index\": INDEX, \"question\": question, \"filters\": filters}\n",
+    "    r = requests.post(f\"{KM_URL}/ask\", json=payload, timeout=240)\n",
+    "    r.raise_for_status()\n",
+    "    return r.json()\n",
+    "\n",
+    "ask_answer = None\n",
+    "if INFRA_OK:\n",
+    "    ask_answer = km_ask(\"Quelles sont les deux familles de parametres HNSW et a quoi servent-elles ?\")\n",
+    "    print(\"Reponse generee :\")\n",
+    "    print((ask_answer.get(\"text\") or \"(vide)\"))\n",
+    "    print(\"\\nSources citees par le service :\")\n",
+    "    for s in (ask_answer.get(\"relevantSources\") or [])[:4]:\n",
+    "        print(f\"  - {s.get('documentId')} ({s.get('sourceName')})\")\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas de /ask.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0166f594",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003001,
+     "end_time": "2026-08-29T06:42:34.258745",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:34.255744",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : la réponse est un argument, pas une affirmation\n",
+    "\n",
+    "La valeur de `/ask` ne réside pas dans la fluidité du texte généré — n'importe quel LLM\n",
+    "produit cela — mais dans le couplage **réponse ↔ sources** : chaque affirmation renvoyée\n",
+    "est raccrochée aux partitions récupérées, et le lecteur peut vérifier. Comparez les sources\n",
+    "citées avec les résultats de `/search` de la section 4 : ce sont les mêmes documents qui\n",
+    "remontent, le service n'a pas de canal de connaissance séparé. La limite à garder en tête :\n",
+    "la qualité du raisonnement plafonne à la qualité du retrieval — si la bonne partition n'est\n",
+    "pas dans le prompt, la réponse l'inventera ou s'abstiendra (`INFO NOT FOUND`).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9300dc4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004514,
+     "end_time": "2026-08-29T06:42:34.267780",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:34.263266",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Restreindre la recherche au code source (filtre par tag)\n",
+    "\n",
+    "**Contexte.** Les tags passés à l'upload (`source`, `theme`, `lang`) sont indexés dans le\n",
+    "payload Qdrant et exploitables **côté serveur** au moment de la recherche — exactement le\n",
+    "filtrage payload du notebook [05](05-Stockage-Vectoriel.ipynb), mais piloté depuis l'API KM.\n",
+    "Les fichiers de code portent le tag `lang=python`.\n",
+    "\n",
+    "**Objectif.** Poser une question technique qui pourrait être répondue par le code source\n",
+    "(par exemple sur l'audit des cellules pip install) et faire en sorte que **seuls** les\n",
+    "documents `lang=python` soient recherchés.\n",
+    "\n",
+    "**Indices.**\n",
+    "- `# Etape 1` : le format du filtre est une liste de dictionnaires\n",
+    "  `{\"filters\": [{\"lang\": [\"python\"]}]}` — une clé, une **liste** de valeurs.\n",
+    "- `# Etape 2` : `res = km_search(\"cellules pip install audit notebook\", limit=3, filters=[{\"lang\": [\"python\"]}])`\n",
+    "- `# Etape 3` : vérifier que chaque citation a `sourceName` en `.py.txt` — et observer ce\n",
+    "  que devient le score quand on retire le filtre.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1e94c108",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:34.276485Z",
+     "iopub.status.busy": "2026-08-29T06:42:34.276485Z",
+     "iopub.status.idle": "2026-08-29T06:42:34.279511Z",
+     "shell.execute_reply": "2026-08-29T06:42:34.279511Z"
+    },
+    "papermill": {
+     "duration": 0.008728,
+     "end_time": "2026-08-29T06:42:34.280523",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:34.271795",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : recherche filtree sur les documents de code (tag lang=python)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 — a completer\n",
+    "# Etape 1 : filtre = [{\"lang\": [\"python\"]}]\n",
+    "\n",
+    "# Etape 2 : lancer km_search avec le filtre\n",
+    "\n",
+    "# Etape 3 : verifier les sourceName des citations\n",
+    "\n",
+    "resultat_exercice_2 = None  # TODO etudiant\n",
+    "print(\"Exercice a completer : recherche filtree sur les documents de code (tag lang=python)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6365cbc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003984,
+     "end_time": "2026-08-29T06:42:34.288523",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:34.284539",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Mesure : le gold-set français\n",
+    "\n",
+    "Huit questions, chacune avec son document attendu — jugées **relevantes par construction**\n",
+    "(puisque rédigées à partir du document cible). La métrique est le rappel@3 des citations :\n",
+    "la requête réussit si le document attendu apparaît dans les trois premières citations.\n",
+    "C'est la même discipline que le notebook [02](02-Retrieval-Avance.ipynb), en plus court :\n",
+    "une couche d'abstraction se juge sur ce qu'elle restitue, pas sur ce qu'elle promet.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "53f0f39b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:34.296900Z",
+     "iopub.status.busy": "2026-08-29T06:42:34.296900Z",
+     "iopub.status.idle": "2026-08-29T06:42:36.156459Z",
+     "shell.execute_reply": "2026-08-29T06:42:36.156459Z"
+    },
+    "papermill": {
+     "duration": 1.865338,
+     "end_time": "2026-08-29T06:42:36.157463",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:34.292125",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "question                                           attendu                                rang  @3\n",
+      "Que s'est-il passe lors de la derive de montage    incident-derive-montage                   1  ok\n",
+      "Comment equilibrer rappel et vitesse avec le par   hnsw-ef-compromis                         1  ok\n",
+      "Pourquoi remplacer une API d'embeddings commerci   embeddings-qwen                           1  ok\n",
+      "A quoi sert le chevauchement de tokens dans le d   chunking-overlap                          1  ok\n",
+      "Quel est le role du serveur MCP pour les agents    agents-mcp                                1  ok\n",
+      "Comment les citations permettent-elles de tracer   kernelmemory-citations                    1  ok\n",
+      "Que dit la methode SDDD sur le grounding ?         grounding-sddd                            1  ok\n",
+      "Pourquoi isoler les donnees Qdrant sur un disque   infra-docker-wsl2                         1  ok\n",
+      "\n",
+      "Recall@3 sur le gold-set : 1.00 (8/8)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3oAAAE1CAYAAACxwpLoAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAdTJJREFUeJztvQm8TdX//7+aNEgjQgMVkcwyphCRSpPKFGXI0ESlPhmKaJ5oLkSJitCgQpGEzCHK0EBUkiEZi2r/H8/397/O79zjXu6wr+Pu+3o+Hsd1z9n3nH3WXvu91ns+KAiCwAkhhBBCCCGEiAwHJ/sEhBBCCCGEEEKEixQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9kRRee+01d9BBB7lVq1bt89hixYq5G2+80R3ovPHGG65UqVLusMMOc8cdd5zL6XB9+vTp4w4EOA/ORwgPMgHZcCDJqv0N58S5cY5i73z++ec2VvzMzeeVE2TpqFGj3AknnOC2bdvmDlQS9yUH6vyKMt9++6079NBD3ZIlS5J9Kgc0UvTEPlm5cqW79dZb3VlnneWOOuooe5QuXdrdcsst7uuvv3ZR5Msvv7QFcfPmzek6ftmyZSb0zzzzTDdo0CA3cODAbD9HIeDXX3+1ubpw4cLQF1HeNzUF58UXX5RyEUF27Nhh1zzZm9U77rjDVapUyTb7rDdnn322ndeBvPEPkzfffNMNGDAgx1/HzPDvv/+63r17u9tuu80dffTRLor8999/bvv27TnuXhg5cqS7/vrrXYkSJUyprVOnTobf49VXX7XvcMQRR9j7PPfcc6ke98svv7jrrrvOjObHHHOMu+KKK9yPP/6Y4hj2oZdeeqm7//77M/2dcgOHJvsExIHNhx9+6Jo2bWpWk5YtW7ry5cu7gw8+2BSbsWPHupdeeskUwaJFi7qoKXoPPPCAKW/p8c6xoCK8n3nmGVe8eHEXBXbu3GnXXRz4ih5zFQtzhQoVQlX0eF8W80TPGYpe/vz5c4SnXWRMQeCaQ2Y2cWExd+5cd/7557s2bdrYhnDBggXu0UcfdZMmTXJffPGFrUFR4YILLjBZmydPnhSKHl6Krl27hn4de/Xq5e699153oDJu3Di3fPly16FDBxcl/vjjD9sfjBkzxi1dutQU2nz58tk8v+mmm9yVV155wN8L7Pfmz5/vqlSp4jZu3Jjhv3/llVdcp06dXJMmTdydd97ppk2b5m6//Xabr//73/9ix6HE1q1b1/3555+uR48eFiXVv39/V7t2bTNonnjiibFjeb9LLrnE/fDDD2ZoF3uiXZxIE26cZs2amRI3efJkV7hw4RSvP/bYY7bhi9Kim1l+//13+7kvpTAIAvfXX3+5I4880h3osKgIIcT+Zvr06Xs8xyauW7dubs6cOa569eouKrB+7k9Zi/HuQDbgDR061J133nnu5JNP3utxGFZ37dqVI9ap8ePHm6Gcdb958+buvvvuc3nz5nVr1651EydONM/VRRdd5N5++21T/g7Ue4H0FK4Lc7ZMmTIZ+luMGT179jQP3OjRo+05FFyuY79+/UyxP/744+159pXfffedfT+USmjUqJF95lNPPeUefvjh2PvWr1/f/u711193ffv2DfX7RoZAiDTo0KFDwBSZNWtWhv5u8uTJQa1atYKjjjoqOPbYY4PLL788+Pbbb1McM3ToUHvvlStXxp7777//gn79+gUnn3xycOSRRwZ16tQJlixZEhQtWjS44YYb9vm5W7ZsCbp06WLH58mTJyhQoEBQv379YP78+SmO4/s0bNgwOOaYY+xzLrjggmD69Omx13v37m3nlviIP9d4+LzEY3kP/9qll14aTJgwIahcuXJw+OGHB/3797fXhgwZEtStW9fOk/M9++yzgxdffDHV9+c9pk2bFlSpUsXe4/TTTw9ef/31PY79448/gq5du8bGgLFs1apVsH79env977//Du67776gUqVK9v25Rlyrzz77bI/3iv8eGRnf1Fi6dGnw008/BemB73nuuefa9zzjjDOCl19+OXZN4tm9e3fQt29fO4bz4by6d+8e/PXXX3u858cff2zX+eijjw7y5ctn7z9ixIjY62nNsdq1a9vDM2XKFDuPkSNHBn369AmKFCli79mkSZNg8+bN9tmMEWOTN2/e4MYbb0z1fN544w27BkcccURw/PHHB02bNg1Wr169x2efc845wTfffGP3AnOVz3vsscf2OJ/EB/dXWqxatSro3LlzcNZZZ9nnn3DCCcE111yTYn77+zPxweelNt/jx4g5yBiccsopdl3OPPPM4NFHHw3+/fff2DF8Fn/3xBNPBK+88krsGnJd5syZs8c5v/vuuzYWzAl+jh071q4X55I4FvyMx3/W3sbEg7zhnmRcuHeQR6+++uoe9/97770XXHLJJUHhwoXtvDl/5uI///yT4WvoefbZZ4PSpUvbMccdd5zJi/g5mhppfTfuN+Ykc4sx473ef//9dL1XWrIsvbLd36ucw7XXXmv3G3Ps9ttvD3bu3BlkltGjR9v7jh8/fp/HrlmzJrjiiivsPLkXkYnI4NTmx77Wg6zKvp9//jlo27ZtbK4UK1Ys6NSpk8ni1OYtcybxGvh5nh75va/rmBVZmt61aNeuXSYfixcvbsdw/c8777zgk08+2etYMT/4fP42Ec75lltuCYYPH273yaGHHmpywY9xmzZtgoIFC9rf8zr3bWrvz/cvUaKEnVehQoWCq666Kvj+++9jxyCTatSoYeeMHGCs33nnnT3eK3HNSEv+MO8OOeSQ4I477khz/nMPVahQweaenxdh3QvZBXItXu7vi48++sjOmZ/xfPnll/Y8a6KHucUjkQYNGth6kgjXsFy5chn+DrmFA9esIw6IsE3CEKtVq5buvyGcAMvLGWecYXHkWHGIwcZC99VXX+21eAJx1g8++KC54XlwfIMGDcxqlx5w4WMpIp+Q2G1CC7CGESZBjDt89tlndn6VK1e2PAAsU1gQL7zwQgsjqFq1qrv66qvdihUr3FtvvWXhAoSoQYECBVL9XHIphg0b5t59910LbSCvoFy5crHXCUPBitexY0ezYJUsWdKe59hzzjnHXX755WZhJWTl5ptvNgsX+Y/xfP/99+6aa65x7dq1czfccIMbMmSIhc3xPXgPH+5AiAfft23btvadN2zY4D744AP3888/2/fYsmWLGzx4sJ0P57J161aLmW/YsKFZz/YW+pee8U0LYvIJu9hXzsjixYvtmjPWzJ9//vnHrtNJJ520x7Ht27c3Kx7jctddd7nZs2e7Rx55xM6Ha+Ehl4zxYJy6d+9uXlfCXyZMmOBatGjhMgOfg3WWECiuDXOc8BLmEyE6nPusWbPss08//fQUOQQPPfSQWXSx4vId1q9fb39PCBfnFe8V5r0uvvhim5Mcz/gT4lK2bFmbx4wrVkzeH4so1x9q1qyZ5rkTCkRoMt76U045xXLwmIuEeBGuSR4I50JIzbPPPmuhM3wO8JP57vNnsNCCvz6E4HCdya9gvp922mn2WYw71uvEvCNC1JiDHEvOx+OPP27flVwMxhM++eQTC/VhzjHuzDvCmDj3MPntt98sXIg5x3XF4k6ubWred64r35/wI34iV7gG3F9PPPFEimP3dQ2BvF7Gm7ncpUsX8/qT/8yczugc/eabb2IeEf89KG5BaBhhY1dddVWqf8c9xzzo3LmzHcP5gpdlGZXtfFee45pxLzCXGAtkZXrgOpAjjfwnjJGQQ7wdyOi9wXnVq1fPrV692sa0SJEi5ongGiWSnvUgK7KPsGreg+/B/UmxLu4N3ot7JT5c08M9RcgaMpv1B3yuWnrk976uY2qkV5amdy1ifvD3vC/fn/OeN2+ezRM8V2lBWCDXO60x5Xoxl7kOrGfMr3Xr1plXC/nB83x/PGicH5/rw18JlbzsssssOgnZx33G+H366ac2v3zYH+GVrMl44DgXvGzXXnut7YfwRmUErjvvw9yNL2zGtT/88MPdIYccYus2UVN8txo1atg1jw9jzMq9AOwB0gPvxzllF6xtcO6556Z4nnnDfcfr5P+x/0H2sWYnwvdlPeC6xXs+eY/333/frjf5fCKBZGua4sDkzz//NCvLlVdeucdrWOzxEPnHjh07Yq9hlcKqtnHjxthzixYtCg4++OCgdevWaXr0fv/9d7PEYS3Es+fp0aOHHZcejx4WZix+acH7YsnDehv/GZw/VsmLLroohVVvb168RLyV1HvOPN77gVUvkfhx83BuWFVTe48vvvgi9hzjhUXyrrvuij13//3323F4O1L77oDHIdFiyPU86aSTzOocT6I1f1/juzcSvT5pwXzDihrv/cPaiUU0XlwtXLjQfm/fvn2Kv+/WrZs97y3ceNnwKFSrVm0Pa2r8HMioR69MmTJmtfY0b948OOigg4JGjRql+Hssw/FeJ7xpfJeHHnooxXGLFy82C3X8896yP2zYsNhzXDus0HhrPHPnzk23xyqteTdz5sw9PgsrdmoW6r1Zc/GA4clcsWJFiufvvfde+97ea+m9DieeeGKwadOm2HF4nXh+3LhxKWQK3hCupQfPQLynIwyPHl4fjps9e3aK+4x5nygLUhvDjh07mocl3guS3muI94kxzSipfbd69eoFZcuWTXEezPWaNWua/NsbyK/E+z6jst3LQrx98dx88832PH+THvyc9I+SJUumOhcTGTBggB0/atSo2HPbt28371L8/MjIepBZ2ce4MD7co4n4z0xt3rIOxs9tT3rl996uY6JHL72yNCNrUfny5e07ZJTBgwfb+yMPE+F5xhLveDzt2rUz+bBhw4YUzzdr1syum79XiaDhPZ5++uk93jvx+seDnEfeX3jhhRn26OGZxJvuPf2//fab3Z8cxzp355132hzx1wn5RyRBWPeCH7f0PNK7fmTWo8f9wxqQGnjIuV7xcxcPcyIvvPCCvbZs2bIUz7/55pt7yG7x/1BylUgVLCOQWtUrLP9YzfzjhRdesOex2JMoi3WPClEeLIlY8T7++OM0Pw9rMdYqPAXxpZ8zkoyOJwRLJFbU1ODciPvGQo5FFksXD6pfYQEmsRlrUtjg0cHimki8pwALLueCNwRvBr/HgxXZe2uAccczGF+FCms9xXJSs9j7McWC6K3IfNdNmzaZtRArG9bWrIzv3mC92Zc3D4sr+Qp4HvAEefAiJY6fn0t4VOLBGg0fffSR/cRai/UPz0ZiLkdWSoy3bt065nECvN58x0QrJM+vWbPGxhgoYMS44+3w849HoUKFrALZlClTUvw99x9WTg/XDqtmYvWxjBA/73bv3m33Ap57ru++5sC+eOedd2yekjMR//3Io+D6co/FQ6Enn5cBfo777+dlCp6DY489NnYc8oR7IkyYU3gG4q3k3GdY5Pc2hswvviPnjqWeQlUZvYaMPR4cvK1ZgfsZzwDzy58XD64x9xDyD49SRsmMbE+MSkC2w97WgXi4vty/7733nrvnnnvMM5meSoO8P/nkeJ08eKkTi3tkZD3IjOzjbzn3xo0b7+HFyKz8yYr8Tov0ytKMrEWMF55lxjcj+AIf8TIhHtbH+Psemcu6xxjz/3iZw3xnHfXjwnF4Af08TOtaxN/beKB5D75vZsYXech9wHUD5iDRQnjw8Wwzp3y+GuD559wTxy2z9wLwd+l5pLZHCZPEgkPxsDbzuj8OUvMu+jXcH+Px8yW93svchkI3Rap4t3hqwoTKSWwiCJmI38D89NNP9tOHJsbDZp1NPIsoQioR/7dsduNhEYkX+mwWCXWLh40HAoSwLzaEp556qrnyCf9kQ06oEXjhyTFpgVBPa5HJiqKXGjNmzLBwoZkzZ9oGMfE84je28YqPh/NkIYovnkOI274gRIeEZjakbPT3dZ6efY1vVuG6IsAT54CfU/EbROYL4R6JFU5RmNhk+PnEmEBGE8f3ReL18NeKsUl8ng0Z15NKYcxBNiSpfUeIVx6B8MTEDSHXPSttTRhjwqoIUWPT/39G3/8j0cCQUfh+nFtaYc6+aFFa4+jvPT+v05ILfk5kVTGNh89KLUw9NXnGJpbwKZQqbxRLawzTcw0J1cLYhQLInCZ8GQWEsMiMQFgd15PQYB5pXYN9FbpIJDOyPfGaERrHPevbdaCkxIfls8GOl3mEYGEgAEqrE+bLT645Bq29nStjmDjmieeekfUgM7IPecbcCFv2ZFZ+p0V6ZWlG1iLCyblWtGTi+6PAtGrVaq/ho/HEy6R4Er8jY0xIIyHWabU08jKHtYA5sK9CNIRokkKCIeDvv//OtGLO3yInCAf350EaxdSpUy00HrjP48eTfQxjyfeKv38yey+A/7tkw/2dVhpOfIE6/zN+7OOPiz8mcb4c6P0hk4UUPZEqLLhYRVNrROk3Q8loIIx3JFHY4wXBy4gVG8sbOQXEcZMrQ2VQvCjkYXjrLM+nlYuWHX17UsvxYdHBakzOxtNPP20bCIQ8ygwx+omeRW8RTO+CmBbDhw83qzxes7vvvtsVLFjQ3puNv1eK0mJf45sMwhLsab0PhoXUxj6t67Gv68R15bPIIUnt2MT5F9Z1jweLNkoe3nJyQrjXOSfyVrLq0ebv8fBgdU4NNn7Z9f32dg3DhI0lngU2X2xoUWCwNLPpQmHLzL2LskQuL5tMckfxPlB5jrw/XyY/PfjPpiJfWhb6ZLV/Sbw+5I6x6fWgSO2tNyPHoyyQM7WvzW16yMh6cKDIvqzI77BkaXrmM4oM50PeFONFXiHr2ssvv2x5e2nhy+ajNKaWg5u4lvpriME5LYU9vcolkJdJfh7nz/3HHgjjG/IS5Soz3klyROP3S76KJCB74w0QKDcohPHtA7J6L5B7nB44l+ysBs5YIov5fsxbD8ofY+XHCcM93jyiCBLxz/ljPd7I4OspiJRI0RNpQuIxApok7/Qk/fpeemxYEsH6yE2Ymjcv/m+xssZbSbFsxVsKsTISZhBPvKBDmFDQhAcChaRuil+wGPtk63jrWFpkt2WIwisIdSx88Ra9xNC9jMD3S00xj4cwEcaXDUr8d8SzmB72Nr5ZBS8QC01q4T6Jc4r5wiLPsb5QCOBlZiPu55O/5ozL3ja4WFH5u0SwZoflsfTnw4YIY0Wi0pNZMjpXmQNsivAKxFtKE7//3t43rdf4fkQBhGVFjpcL+5oT3huY+D0SPRJ7+6z0fA4hyGxMuIe8ZR7oJ5oVkI2EsvJg88NmjnuLQjbpLSHv5yqb08xcg7Sua2ZkO2MZb5TD28g964u2MP/iZXvi5i0R5KX3ju8NzpX7nfss/vsknntG1oPMyD7kGe+9L5mckeuQXvmdEZmQXlmaUdiwUzSJBzKBe4WCJHtT9DB8+nuJYkX7gjEm+ggFYl/XkOtNqCRe0MTICQ8GFu41PNTxoYMoehnFFwVhvnKe7F0ABdh7eQm7pWiQh8I2eNv3tTak916AxLZYacF3zM6+qN6YQlEePOIefue7+NfxLnPteT4Rrh/zP7EFBfOFvwtrTY0aytETaYJVntwG8o4Q+vuyuiNQuFkJLYnfbLHQYdWLv7kTQUgjfKniFv++iVX6EMIcG/9gg4egTxR6WI3YPPgQAEJuEPZPPvlkqiGp8SGhftOS2uY/DLxVNDFsLjMLioewzUWLFu1RJS3+c1L7XIQn4aN7Iz3juzfYDMYvaKnBueGFIA8h/lgqv7HwxuPnUuL8wDsKvjoaoTEsCli8fdiHJ34MmBdUBowPLcG7ggc5TNi88z3x0iTeP/yemSa0GZ2rfH7iZ3PfJXq+9va+vJba83g+mEuJ18u/j89VTC/xMiV+/mHsoUJoPGxI+W6JeYBY5tMDc4o5gGErXiaMGDEixXGp3UPMm/R+TmokXne8++Tl8Bnx4Xn7gnuS6AbC61OziCeGvSeCvIfEa5sZ2e5zt+PnGHjFCHkcL8d97hXvn9p3xugIqeW7xcO5kEsXn/tEaHxiaF9614PMyj42nnjeMOqltmndm9ea+yu1TXx65Xda1zE10itLszKf8YxiaNvXWsE1Ye6nNl6pwXiw7qGgpaZQx893jiOH6/nnn9/r+oiSHC8L8cSxJmUUvjNeSa4P+LBfqqXy/VCsvdGA82K8ibIgTNgr6lm9F5KVo+dzleNz5qhki/JPRdh4+J35Gj/PyK8lXzl+HmCoIVSeCqipVWul4mt86Lf4f8ijJ9KEGHHCFSjlTHgBRQnwniEUsaDwGotZfIgFIS0s5ISEUd7Yl+DmBowvL5wIFi/CjdiQUwKZxYdyu4S4pccdT84g54GA4BwRsuS8ICy854JzRUByfggFLI1Yz8hTwpOGBY5FGRDIvtQ1IW0ooSR8p+WRzCgoICxovCel5dlokKDNBiK1DVp6IJSHzQ2CEOWc70AeDF5DQmYYF8YWazAFWxCsXEdeY5O1t+Tu9IxvGO0VUIAIXSNMikUQxYD5w/WKz2niHPBKsXnzoXRs0NmIsrnyeRFcU0KGsCITMkPeE4YBFGIWI44HXmfsyCVBWcHqSpiUt/qHBe9H/gdeGjYQnCuKKNcBBZ1kfe6DjL4nuTRcR96LOUp4dVo5O8wBys1zT3Ld2SRyLRPDhdjYs/EhRI1NJxZuFmvmKHOLBZrvwgaO53iNOch84zN8yXVyt2ibwfjynTMaXoNMYK7WqlXL5jVz2s+J+DnL92Hu8xobJcYFZT0xL3Bvhi3GhTlA6XXfXgEFMn7u0bqCOcT8o3w/n8XfZSWcFnmAxZ+cPFpVYNxgQ8r3TrRe7wsULMYKqzibSizgGOq4zhR8Ye6nBR515sTIkSPNOs7GDO8Dj4zKduY0YXCMJ5/N/cT9t69QM2SEbzXBGoQSTUgdcouNbXxeeGrwnRk7cujYAKKkcn288uNJ73qQFdlHY2cUYeQT9zZyEPlOkQ7aM8S3UomH+4ZrQIEU5BafyVqRXvm9t+uYSHplaUbgszE48D34bDbsvj3F3sCQy73A+Ka3+fWjjz5q1wuZx7Xns5ERhFLzPvwfmA8UQGFM+X6sMcgmjmGtIeeNMUXhYs4yV5Ed3E/IuMzkRXO9mGP8RE7wf/Y2PnyTsUUB5TNQBBlz9hth3Qth5+hhRPOGNJRoxo81APDY+ggHxpfvhqfZywbmJI3RKU6DnEax5LsgF/CMxxd54nqwH+J6sB6y/+K6IBt9kSAPijAh4PyNSIO4CpxCpArNRGmwTHlqSgLTVLZUqVLW9JXSzIlMmjTJmqNyHE1dGzdunK6G6TRUfuCBB6xUckYbplNy+u6777ayzpTTp8Q7/0+tAfmCBQuCq6++2kq7Uxaa97/uuuusGXA8vnk7JZ331Wphb+0V0ioz/cEHH1iTT8aUJro0UfYloOM/K633SCz9D5Q+v/XWW+28aVdB02rGzpeepoz0ww8/bO/Jd69YsWLw4Ycf7tF8GuLLc2dkfLPSXgGmTp1qJal9I+q9NUxnvlAK/bDDDgtOPfXUNBumM9aUl/dzsmrVqsFbb72V4pinnnrKxo1xYf7OmzcvzfYKiQ10/XxOLKOe1rwYM2aMNTpmHHlwP1F+evny5Xs0204ktWtFWW7fRHhfpbIpx05z4fz581uzd8rLU646tfts0KBBdg18ewtf0psy4cxJ5kLitd26datdB+QF15DPYeyffPLJWEuK+IbpiaRWFp7xOvvss+3a8D1Ta5gOjDNtC2hzQLNwWh4gQ9JbPvzrr7+277KvhukzZswIqlevHmuAfs899wQTJ07co7x6eq8hTeNpluxlEk2Bud9oc7M30mod8cMPP1jZdto4cG/wXS677DJrtLwvaGDs77/Ea5Ee2e7nPM9fc801Nke4Fsil9DRMZ73h3Jl3fA7XgjHkfbdt2xakB9qz0N6BecD8o9l5Wg3T97UeZFX2cS58H0rI8/58L+71tBqmA9+zRYsWwXHHHZeijUhG5Hda1zErsjS9a9GDDz5oMpbz9/sFWsfEt6RJC+5tWtX4ViyJDdNTY926dfYa5835M+9pYzBw4MAUx9E6oWfPnrHvyXHMUe4XD/e7b6jOeXNvpTZm6Wmv8N1336Vo7A7cA8gP30IC2bt06dIULR7CvBfCxI9Dao94OeHHIrX2HlwT2kMwL5Fz/fv3T/W7r1mzxq4NcoZ1CvnFeCZC03g+K7XXxP9xEP+kpQQKIYQQQqQXLPh45rH4qziCyCiETeKVI7ICD1BOB0849wMh4HgNU4OwUzx+vuG8SD94nRm71FJWxP+hHD0hhBBCCJF0CBcnbJNwxvT2ijuQIZydcEPCbQm/HTVqlOWbUSSKsFFSNwhx9WkEIv0Q4k54fhQMAtmJPHpCCCGECAV59ITYE/LRuDfIJ4sv9lKxYkXL2U6tyIgQYaBiLEIIIYQQQmQTFH+ZPHmyFbyh1QgVSCmYta+2IkJkFXn0hBBCCCGEECJiKEdPCCGEEEIIISKGQjczyH///WfNWOlt5JtaCiGEEEIIIUR2QzAmPT4J/aUn6N6QopdBUPJobCmEEEIIIYQQyWDNmjXulFNO2esxUvQyCJ48P7jHHHNMsk9HCCGEEEIIkUvYsmWLOZ28TrI3pOhlEB+uiZInRU8IIYQQQgixv0lPCpmKsQghhBBCCCFExMhWRa9OnTqua9eu2fkRQgghhBBCCCEOJI8eVWP++eefZJ6CEEIIIYQQQkSObFP0brzxRjd16lT3zDPPWAwpj9dee81+jh8/3lWuXNkdfvjhbvr06e7vv/92t99+uytYsKA74ogjXK1atdzcuXNj78XfHXfccSne/7333ovFpq5YscL+v2zZshTH9O/f35155pmx35csWeIaNWrkjj76aHfSSSe5Vq1auQ0bNmTXEAghhBBCCCFEtBQ9FLwaNWq4m266ya1du9Yevi3Bvffe6x599FG3dOlSV65cOXfPPfe4MWPGuNdff9199dVXrnjx4q5hw4Zu06ZN6fqss846y5177rluxIgRKZ7n9xYtWtj/N2/e7C688EJXsWJFN2/ePDdhwgS3bt06d9111+31vVFCqW4T/xBCCCGEEEKIA5lsq7p57LHHujx58rijjjrKFSpUyJ7zHre+ffu6iy66yP6/fft299JLL5nXDm8bDBo0yH366afu1VdfdXfffXe6Pq9ly5bu+eefd/369Yt5+ebPn++GDx9uv/MaSt7DDz8c+5shQ4aY8smxKIup8cgjj7gHHnjAHcg07j4y2aeQYxj3SNPQ3kvjvv/HXWOefjTXk4PGPTlIxux/NNeTg8Y9Z495rsjRw/vm+eGHH9zu3bvdeeedF3vusMMOc1WrVjWPX3pp1qyZW7VqlZs1a1bMm1epUiVXqlQp+33RokVuypQpFrbpH/41ziEtunfv7v7888/Yg/55QgghhBBCCHEgk5Q+ennz5s3Q8QcffLAVbokH5TAevIaEZr755puuevXq9rNz586x17dt2+YaN27sHnvssT3ev3Dhwml+NnmEPIQQQgghhBAip5CtHj1CN//999+9HkOxFI6bMWNGCiWOYiylS5e23wsUKOC2bt1qYZ6ehQsXphq+OXLkSDdz5kz3448/mpfPg3fvm2++ccWKFbMcwPhHRhVPIYQQQgghhMi1ih5K1ezZsy2kkuqW//333x7HoGTheSMXjwIp3377rRVw2bFjh2vXrp0dU61aNcv169Gjh4VZ4q0jpy+Rq6++2hRC3q9u3bquSJEisdduueUWK+7SvHlzUyJ5n4kTJ7o2bdrsUxkVQgghhBBCiJxEtip63bp1c4cccoh55vDKrV69OtXjqMDZpEkTa3eA5+377783Jez444+310844QQrqvLxxx+7smXLurfeesv16dNnj/fJly+fhWeSj4d3Lx6UPryGKHUNGjSw96GZO20bCA0VQgghhBBCiKiQrTl6VLIkjDKxv14i9M579tln7ZEWV155pT3iwfOXCKGbPFKjRIkSbuzYsRn4BkIIIYQQQgiR85ArSwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEihhQ9IYQQQgghhIgYUvSEEEIIIYQQImJI0RNCCCGEEEKIiCFFTwghhBBCCCEixqEZObhOnTqubNmy7pBDDnGvv/66y5Mnj3vwwQddixYt3K233upGjx7tTjrpJPfcc8+5Ro0auX///dd16NDBffbZZ+63335zp512mrv55ptdly5dYu954403us2bN7tatWq5p556yu3atcs1a9bMDRgwwB122GF2zO+//+7atWvnJk2a5AoVKmSf2bNnT9e1a1d7rFq1yp1++uluwYIFrkKFCvY3vOfxxx/vpkyZYucNS5YscXfffbebNm2ay5s3r2vQoIHr37+/y58/f5rf+e+//7aH588//7SfW7ZscQcKu//ekexTyDGEed007vt/3DXm6UdzPTlo3JODZMz+R3M9OWjc9z9bDqA9f/z5BEGw74ODDFC7du0gX758Qb9+/YIVK1bYz0MOOSRo1KhRMHDgQHuuc+fOwYknnhhs37492LVrV3D//fcHc+fODX788cdg+PDhwVFHHRWMHDky9p433HBDcMwxxwSdOnUKli5dGowbN86O4f08vH/58uWDmTNnBvPmzQtq1qwZHHnkkUH//v3t9ZUrV/JNgwULFsT+5o8//rDnpkyZEvu9QIECQffu3e1zvvrqq+Ciiy4K6tatu9fv3Lt3b3sfPfTQQw899NBDDz300EMPdwA81qxZs0/d7SD+Sa8GiWcMLx0eMeD/xx57rLv66qvdsGHD7Dk8d4ULF3YzZ8501atX3+M98PxxDN4/79H7/PPP3Q8//GCeQrjuuuvcwQcf7N5++223YsUKV7JkSTdnzhxXpUoVe33ZsmXu7LPPNm9cej16eAE574kTJ8bO5eeff3annnqqW758uTvrrLPS5dH777//3KZNm9yJJ57oDjrooPQOXa4DawNju2bNGnfMMcck+3RyBRrz5KBxTw4a9/2Pxjw5aNz3Pxrz5KBxTx+oblu3bnVFihQxfSm00E0oV65c7P8oZig8hHN6CN304ZbwwgsvuCFDhrjVq1e7nTt3WmimV8Y855xzTkzJAxTFxYsX2/+XLl3qDj30UFe5cuXY66VKlXLHHXdchs570aJFpvQdffTRe7yGkpmWonf44YfbI56MfnZuhhtVN+v+RWOeHDTuyUHjvv/RmCcHjfv+R2OeHDTu+wZHW3rIsKLn8+Y8eLXin/NeLjxfeOS6detmuXc1atRw+fLlc0888YSbPXv2Pt+Tv08vXpuNd07u3r07xTHbtm1zjRs3do899tgef49iKYQQQgghhBBRIcOKXkaYMWOGq1mzphVgifeeZQS8d//884+bP39+LHSTUEtCMz0FChSwn2vXrnUVK1a0/y9cuDDF+1SqVMmNGTPGFStWzDyEQgghhBBCCBFVsrW9QokSJdy8efMsL45cu/vuu8/NnTs3Q+9Bft7FF1/sOnbsaJ5AFL727du7I488MnYM/ycf8NFHH7VQz6lTp7pevXqleJ9bbrnFcuuaN29u54DCyXm1adPGcg1FuBDu2rt37z3CXkX2oTFPDhr35KBx3/9ozJODxn3/ozFPDhr3HKbooZxRqKVp06auWrVqbuPGjSm8e+ll6NChlnBYu3Ztez9aNhQsWDDFMeQB4vkjl48CLRRfiYe/x8OIUkdbBfIKOY58u30lMoqMw03ap08f3az7EY15ctC4JweN+/5HY54cNO77H415ctC4h0+Gqm4eSBCC6fvoCSGEEEIIIYT4f8iVJYQQQgghhBARQ4qeEEIIIYQQQkSMHBu6KYQQQgghhBAideTRE0IIIYQQQoiIIUVPCCGEEEIIISKGFD2RZRT9u3/HeefOnck+FSFExJFcF1GGXsoffPBBsk9DiGxHip7I9Abg559/dn/99Zf7888/k31KuWLMDzroIDdu3DjXvn1798cffyT7lHLVXF+9erX7/vvvk306uWrM2YitW7fO/fLLLymeF9mDH19ky44dO0zeiP037vT5HT16dLJPJ9fw1VdfuSuvvNK9++67yT6VXANz/NFHH3XDhw93X3/9dbJPJ9cgRU9kGDYAH374obv++utjvQx//PHHZJ9W5Mcc62Pv3r1d69at3fHHH+/+/fdfbX73w7i/99577tJLL3UXXXSRu/fee035ENk75h9//LG7/PLLXbt27VzTpk3d+++/L8VjP8316667ztWuXds9+eSTbt68eck+rVwz3zt16uROPPHEFK/9999/STuvqMKaybhee+217umnn3a33HKLGzt2bLJPK/KMHz/ejNRbt251I0eOdG+88Yaik/YTUvREhpk6darr27eve/PNN90hhxzi1qxZ40444QQpHSGzfv169/fff9v/t2zZ4gYNGuTeeecdV7NmTbNCXnXVVe7ll192mzZtSvapRpaVK1e61157zb311ltuwoQJZpEcMGCA++2335J9apG2tD/++OO2EXj++eddhw4dXJcuXUzuiPDxcnvZsmWuX79+7qGHHnJ33nmnyfURI0ZormczCxYscHfddZfJ9rp167rFixebXIeDD9YWLTsUa8b1o48+cqtWrXIlS5Z0zZo1c2+//XayTy3Sc/yOO+5wr7zyismXbt26uVGjRllUmMh+JEVEhjcEs2bNsg0Brve5c+e6V1991R133HFm/ZWFJhx27drlOnbsGAtby5cvn43tDTfc4G666SYb+zPOOMN98cUXyT7VyLJw4UJ3xRVXuKJFi7oyZcrYhgBle+bMme6xxx5za9euTfYpRg7CNQntOfroo12lSpVcsWLFXKtWrdzVV19t4y6yZ+OLAQNlGs911apVXfPmzV2LFi3ctGnTTAEU2Tv+9erVc1OmTHH333+/PTAmEbkhsmcP8+2339r6es0117hJkya5oUOHurZt2yp0Nhvp06ePu+CCC8ybSsTA2Wef7TZs2JDs08oVSNET6YZ8PDjssMPcs88+65544gnzdLAZwy2PpWbbtm3JPs1IkCdPHvNo/PPPP+5///ufbQYIdzj//PPNGkYI56233uq+++475etlExUqVHClS5d2n376qSkgbBJKlSrlXnzxRTN24GUV4cI8x4BBKDjz3T93zDHHKGQ2mza9/CxcuLDN8enTp5s8YTNWrVo1U7aVm5o9407oPeTPn988TMz3ihUrmtIxcOBAC+NU6GY4rFixwtJNfPg3c5z5XatWLXuuZcuWrnPnzha2TPiyCIclS5a4iRMn2ryuX79+itfY2/g9JdEaeLJF9iBFT6SLb775xjx3eJWwymABvuyyy1yhQoXM0t69e3eziBUoUCDZpxoZ8ubNa+P9+uuvux49etjC/8gjj7hzzz3XFiNyDLD+nnnmmck+1UhtwJYuXWqK3ObNmy2cB4WPTQBhnByD8ocVGA+fCGfMsewy11HyMGT4DdcDDzxg12LMmDGuYcOGyT7dyBV3+uSTT8x7xLgTmoyXGhmDJ2/27NlmwGO+i/Bg3BlXPKZ4OVA6MJwy/oTjo5TgXb3wwgsVuhkSKBHk/Hol7uSTT7ZoJEKT/Rifd9555tHGqCSyDvKc8R0yZIgZSzFo+GglIC0FAxNpKOxvqDsgsolAiDT477//7Oe0adOCiy++ODj66KODp59+2p4bP358cO655waXXnppULdu3eCDDz5I8Tcic/jx27hxoz1g8eLFQcmSJYPu3bsHW7ZsCdavXx/ccMMNwfvvv5/ib0TWYR5Xrlw5aN26dVCrVq3g888/t+ebNWsWVK9ePfj+++/td4151vFjyDxGviBLBg4cGPzxxx82x++///7g1FNPDRo3bhxMnTrVjv3nn3+SfNbRARleqlQpm+P+WixdujQoV65cULx48eCOO+4IPvroI3te8z08Zs6cGVSrVi3o169f0K1bN1s/J02aZK9NmDAhqFKlimR7iHiZ8eKLLwYHHXRQMG7cOPv9lVdeCerXr29yhnEvU6ZMsHDhQntN4541/Ph9++23Qa9evWy/4mWJp02bNvaoWbNm8PXXXyfpTHMHUvTEPjcD5cuXD7744ougd+/eJhgHDBhgr23YsME2Zb/88ov9LuEYDmPHjg3OP//8oHTp0sE777xjzy1ZssQWorvuuiv4+++/gx07dtjzGvNwN2A1atQwJePVV1+1DdfatWtjr1911VXBrFmzknqOUePDDz80xfrnn382Zfqss84K+vTpE2zatMlkCzLnpptuim18RThs3rw5qFOnTjB58uTYZthviFeuXBmULVs26NKlS5LPMnogxxs2bGjGU1i9enXw5JNPBvXq1TNjxvbt282wB5Lt4Rrw/ve//5mxLl7ZY3+Doo0iMmbMmGSfZiSIn7e7d+8Ofv31VzNS33jjjcHHH38cew0Fr2DBgsHy5cuTdKa5Byl6Yq907tw5ePbZZ2O/Dx8+PChSpEjQv39/2xCLcEGxYOH58ssvzeKIZX3IkCH2GlavM888M1i2bFmyTzOSfPrpp6ZQjBw50rzVP/74oz3/ySefBH/99VeyTy8S/Pbbb7FNLpvam2++OVi0aFHw3nvv2cL/0ksvmff67rvvtnthzZo19n/kEN5sEQ4Y6TBqoGDDzp077eeCBQuCf//9N1ixYkVw0kknmaLN7yLrm18MdEOHDg0KFSoU3HbbbbHXuAYPPvigzX8UcBEurJtEBsyePTv4/fffg9dee82UPe9h4rqgkICU66wRP34vv/xycM8998QiBVD2UKgx7sHgwYOl5O0npOiJvd607du3t9AG8Av+1VdfbWFWPqxNhCMcv/vuO9vweo+pV6wJr0JowtatW5N2nlHlm2++MSXi3XffDU455ZSgdu3a5k0CQqrwbhCCIrIGGyoUh2uvvTaYMmWKPYexCA8SlnZ+wpVXXhlcfvnldj94r4eMSuHImHilDQ813lL/HB7tqlWrxuY6yp4PVRZZG/f4DfCwYcMsVPmZZ56JPYdB44cffkjKOUYNxnH06NGx3/EiEf4dD/MeZQ+ZL8LnueeeS5Hq4I1LPXv2NPk+ffr0pJ5fbuPQ7Mr9Ezk3QX/37t2x6pqU2b744ovdWWedZZWpKLxCtSSKrrzwwgtWmEWNjMNphk4vpcMPP9ySwyl0Q4EExpzxpsomieIkkYvwoHkrhRCovnb99ddbb0haV9Dfh0IVDz74oHv44YetFLTIeiVZCggxxjyY95TZpvIa85qKvV9++aVVGrzvvvtc8eLFTSadeuqpyT71yBQAocgKvU9pj8MYUzmZ4k7Mfao9UjmZuU5FyBIlSiT7tCOxnk6ePNkNHz7cZDsFP2gXwhynSTdz/5577nGnnHJKsk83Uj3bKAzHPob+eBTNol8eBZ2aNGlix7BvoWoyMkmEN9eBKr30nqUvJAXkKOJH24pOnTpZLz2qVp9++unJPuVcxUFoe8k+CXHg3KgoHNyUNMllI0A5f55DcNLrZ86cOVYlafXq1VYl7LnnnrONg8g8lDWn6hTK3GmnnWY9w1CsUfy8QPz1119dkSJFkn2qkZrrVP1i88Ucpgck1U2BjRibBI6hbyGGjviFTGQcP35U70WZYzNApU3Gmr5tVNmkdx6KCL0KL7nkkmSfcuSa0NMzjGqONKFn80sFQu4B5j+KNrIHxVtzPeugyGGwY41Ejt92222mPKPUYTxiwzt48GBbSzGY0qJIhAdj27dvXzPiXXnlldabE9mD8YI5jtLBPuecc87RfA8RlGfG8vbbb3ebNm1yJ5xwgvVYPumkk9zHH39sfX9ZW3EiiP1Isl2K4sArjEAOWIMGDSyXYNSoUfYaYVU8T+EVcpYqVqxouTUiaxDacN5551loic/PIDeJ0B6Sl304j/JkwmXixIlBo0aNYkU+qLB57733xl4n1Ep5eeHgw9aQF8gXwtSQJeTeMccpUEHoLCG0vuqdCG/cGds333wzRSEEKmtecsklSTy7aEIRIQ/Fbe68884UhYTmz59v+WLMeY71OZIivPlOoZVOnTpZZVPqCTD+XAvCOS+88EIr+qTCK+HC/oRiQhTuI9+RPeJjjz0WC93kmrDe+lxgsX+RopfL8cKRIgktW7a0vAyqPiIQH3jggeC4444L3nrrrdhx3LgISm3IwuPhhx8OKlWqZAvSn3/+ac9RqYqiLGwIRPhQba1w4cJmsKAwAlXZmPNz586NHaPE/PBgE0BlQWRJfJEEKuEhT3zOnggXZDk5MVQzffzxx1O8RmEnKm+KcCB/mjUUQ4anefPmVkI+Ho5ROfns4auvvgrOOOMMKypEoQ8KrxQtWjRWAASFRBWrsw/yfn0BFg/XAAOf5nzyUDfOXMr27dstlAQ3+7fffmvNuWneivJPaAnhUzTjJk+GEE7CrIB8GV4rX758sr9CjsRHSi9fvtxNnTrV/fLLL9ZsnhA2QqgIbSD8gUaihP0QWiLCbZxL43PCMQkveeaZZyy8hHyCKVOmuPfffz92jRTOEx7kmTLfaZzrKVu2rOUAE5JMLocIX8YQstaxY0fLjUS+0ATdQ/gs4W0iHAhH69+/v4XDPvnkk/bczTffbL+zZnr5s2TJkiSfaTRDZf2cZs2sUKGCpT8gX+rUqWO5em+99ZaF0x555JF2rOR7OJCD17VrV2uQTpgy+0ovZ6ZPn24yn5w95L1IDirGkkshMZ/NLUn45G1MmjTJlDryZ8jfoBAI+TK+SAXFV4DkZSUwZx4Wl3HjxpnyfPzxx1uOWJUqVWzDxWLFxoyfFF5RHHs4+BwMjBvk4VEIhPwMcksHDhxoRSjWr19veTLVq1fXBiDkMef/F154oZs4caLly5QpU8ZylACD0QMPPGD5eSIcGHc2WE899ZTJbowaPJDbLVq0sHsAuQ7kYIusGzGQJchyn4eKYpcvXz5TsvkdGYPcwWBKwRttesOVM9QUwGBUqlQpkznsZ+rXr29zvlq1araWFipUKNmnGwnicxp37NhhxmkMpOwZN27caMo2ih7jjpwpV66cO+aYY5J92rmbJHoTRZKhX1XevHljTXPhp59+Co488sigRYsWQYECBWK9ZkQ4EE5CmCZ9ZYDxbdu2reXQQK9evazfjwgXQjJ9+X5aVZATSSgb7RQY8/gcSIX0ZA0/foQiEzZISCyl5Ml5pFfhySefbOHKIvsgH5JcMEKp4vsP9ujRw0KWffsQkTXIOWJOE5ZGODi9wgi7J2SWsPBBgwbZcYTkz5o1K9YyRDIm6/gxJPeUfDz2LrRh6dq1a3DLLbcETzzxRPDFF19YeyJCOeP/RmQdagkAc//ss88OHn300eD1118P8ufPb60raBUlDgyk6OVCdu3aZT+7desWVKhQwfqd+Lh1oFE0OUtSOMLBLy70kaGYDUnJGzdujF0LYtpR9kT2jDuFP0qXLm05SV7ZY26zKPFciRIl1KctZNj00pONHng0yT3//PNjPSDZmJH7i5zRxit8vNGCDRhzmz6o8f03vbIhwlH0+vfvb/ObXDByUWHbtm1W8IN7gKIUInuYMGGCFRaaNm1a7DnqDbz00ktmzKMfp3rlhQ9FhapUqRL069fP+m6SY40RCdnz9ttvW69l5Ls4MJCil4vwm6rff/89RfWjmjVrWrIs0AT96aefTto5Rnnje9FFFwWfffaZFVlhnGkgDSjVKHoo26quGS5Y1mmA7hu4nn766TFlz1slsfqKcKExOgoFVl3GfdWqVfY8VneQYp19UGHQg5HjnHPOsaI3XtmTch0ueIuQKxjwZsyYYVUHgZ9UrSaCQ0aNcGEs2cM0adIkeOedd8xgOmTIEFP67rjjjpjh2ley1tiHDwVu8JqWLVs2aNeuXdC+fXsz7MH27duTfXoiDil6uQw2XtyYbH4JcfCwGcP6iIeDMsQiPCgbf/PNN8cqOlLNtEaNGkGfPn2CF1980UJo40ufi3DAqk6lR5Rqz/XXX29ejnhlD7QRCId169bZz86dO1vIJnLGK3l4OLCyE8am8Q4HP46+FYj/nbL9lPYH5A6KCBWVRfigcCxevNg8GrQL8e0UuAYofv6eEOGDokFFWZRswsEp408Yp6KRwiNeVqfWcoiQZOQ84Zoo3ol/I5KPirHkIr777jurPPXII49YA0sS9GleSQPdmTNnWvPWM88805Jn1UQ061BU5c8//3SNGjWyxPwOHTrY81QzpXopjdIXLlxo40/iuAgXqn9R/MBXIQTmfo0aNaxIxYgRI1zRokXtec31cOTLgAEDrAE0RT9uuukmazjPGFNxk6IrFKJQYn44eBn94YcfWkN0qsjSnPj33383eUKTbjj33HPdokWLTAaJ8MZ9xowZVngCWU6xoW7durl+/fpZI3peo9rgkCFDXMGCBZN9ypGldevWVkSOCpulS5d2P/30k9u1a5c79thjk31qkSB+H0hBIWTIFVdcYcVt5syZY69RdIXCfhTAQdaA1tMDjGRrmmL/JeeThD9gwIDYc/TEK1iwoLndRfZBaCBWR3I1Ei1iCtXMXvr27Rtcdtll5lUFcjlojH7ddddZIRYfSijCKTSEjPEFnOifhPcULx6h4b6Xlay94YH3iHC1SZMmxcYWeROfl4SM0ZiHC3Mcmc56SvGyBx980CIIKHLz/PPPBx07drSQfJF1/Nz1ayW/+/BYogO8x3TixIkWpqwiINmTenLJJZdYoSH48ssvrV8hYy4OfKTo5RJYhAilKlasWIrnCefJly+fbYSldIS3KM2ZM8dyBnxyvg+fIv8xXtnTBix78BsBEsUJkS1SpIhVxCtUqFDsmhBO+8MPPyT5THMuqc3dgQMHWviaz9EgF4/8JB++KcKDgk4UAcFgR04S4d8UdvKVHkEyPXwWLlwYlC9f3nJQqbhZvHhxq7CJfEHxiM+TlHwPD69k+LHFSEfI5syZM63uAIZUb2TSuIcHoZmsm95JgNxp1qxZLN1EY33gcxD/JNurKLLP5f7HH39YCFv+/PktpOGqq66ycDb65dH7B2h06ZuIiqxDo3PC1gjnoUHuBRdc4Hr06GGhmpdffrm79957rbGoCIfEMGNCZmmMSwgbYW30bqPXz19//eVOOeWUWA8xkXXotUl4Ws+ePa1PFWNOk+hXXnklFhYrwp/nq1atshDYmjVruquvvtp+R8Zv2rTJehI+88wz1tdNZB3WT79Wbt261cID+X3dunXWD3L+/Plu7Nix7rrrrrPQcEJotZ6GO+eXLVtmoZnDhg2zsHtSIggPr127trvnnnvsWO1jsmc9XbNmjc1zwsPZNyLnN2/ebGHiImdwcLJPQGQP3Kgff/yxNd5GuWjSpIktUCNHjnSFCxd2FSpUsA0xeOEonT/rfP3119YYetSoUdaY+LnnnrONwhtvvGG5YTTNrVSpUrJPM3KLEso1eQI0L0bJW7t2bawZ9AknnGDKXrNmzWJKnuZ6OJCfhOGod+/erlWrVjb2KCC9evVK9qlFDmQH4zxlyhTL+2WjhWKBMY/G3M8++6wp2eTjsREWWQfjEGsmDbkxGmGkK1asmDv77LOtKXSbNm1szhcoUMByl+rVqydlI0R8DurgwYPNYMp4v/baa5aDR667V/KQ5xr3cJU89jLIEmT8oEGDXIMGDVzTpk3dzz//bLKHfY3IISTbpSiyB6p90TuMioP0lWnatKk9KOnPo2HDhnaMCAdCpChfTt4GjYoJD/QhDcOGDQvOPffcFL2sFO4QHuTCMNfpqeTHdvDgwcHQoUOTfWqRw89bQmIJmfLVS9esWWNhgxdccEFQp04dC1P2vSJFeBx11FHWkJixT4T5Tyl/Kg+K8KBPHqFrVEemPY6/D+hDe+mll1rlZHLDtJ6GDyklpJuQCkFYLLmnBx98sPVqS62diAiHZ5991sLCr7rqqqBMmTIm32mdcNttt1nYsg+jFTkDKXoRhVLmNMr1sDCRtE8JYlDuRrgbX/+TojeMMwU/SMyHefPmWQ+9TZs2JfVcowj5XxUqVIj172EDTG5kfEsFzfXwC4CgUNSvXz9o0KBB0KVLl9hrzH/as/hcGREOvudmy5YtTdHr0KFDitfJV6Ifqi/tL7IGeY+33HKL/X/Dhg222SUXD3njFQvyUMnz7dSpk5pyZxOTJ08OLr744hTP0SePUv70zxPhgxJNr1/mNw3Rqe3gQcGjLZdyrnMWytGLKLjaH3zwQfftt9+6vHnz2nPkbRx11FGWPybCC3OgNQVhDpUrV7bywuTlXXvttZYPVrduXTdmzBjLYSJ8VoTL0qVLbVzJgaTc8/r1692KFSsstI35rzYh4bdQIDeGMEJasTDmTz31lOWKkccRj8Y+6/gx3LZtm+Xe+eeKFCliLRQICaeUP/lJyJ/jjz9e4x4Ss2bNsnwkQtcICac9yEcffWT5p9WrV7dwTkJkS5QoYeGbGveskziGhOBfdtllltOO3AFC9AnnRPaMGzfO2iuI8Mac0NgzzjjDLVmyxL3//vs2xnny5LF9DGutz4EXOQddrQjgdXUSlulXBb4YCL3y2Ax/9tlnbuDAgbY5E+GAcGRcKXDDpqBOnTqWLF62bFnrSUiyPkrgq6++KiUvZFCsp0+fbrkyKNUUBGHjS5/IPn36mLK9Y8eOZJ9m5Pj777/NWMQGmMWeXF8e5P8mok1v1mEM2WyRa92wYUPL++U55je5wOSFUQRk+/btpuT5vxGZB6UOUObIS6LgB4VtHn74YVtTO3XqZMaN8uXLm6LnN70a96zDGLKWMrcxYFBPoGXLllZvgPxIerWR/9u+fXvLeUcBEeHsHydPnmzGi0MPPdT2NKNHj7brwBgjd/r372/52FLyciDJdimK8PKUTjvtNCvzXL16dSv9TGlz+vnUqlXLXPHK3QgHH6ZJaAN5YNOnT7ffX3/9desbRk6ez2Mid4PcJcqfi3DG/auvvgqqVq1q893nKvnXyI3kHlDoYPZA6Bp5G8iSLVu2xEJ9WrVqZW1DlHsaDn4caX9D2DdhasiXQw89NHj11VftNULDX3nllWD27Nkp/kZkHj+GS5cutRBNficniTBlDy1ykOn0FhPhjjs5kORD3nDDDZZ3PWLECHueHpy0UmjRooW1KmLNRc4rVyxrfU897FXYJ9KmgjFFnrdt29ZaiSBj6IO6ePHipJ6vyDxS9CKicPTo0cM2wHDNNddYsRXfI4ween5Tps1AOLDId+7cOahRo4b1k/F5YG+88UZw0kknWZ6Yz8+jEAsCVGQdcpBYkN566y3L3ahWrZoVQdi5c6ctSijWvlGx5nr28MADD5iyR64Ghg4KEPlCOCLc/lVly5YN3nzzzRTz/4gjjghefvnlpJ5blEGen3322aZQeDnC7/G5Yj5nUjImPDBYkBfp9zE0Pqeo02uvvRY7ZteuXXZ9yMsmH1hkDuoFnHfeecHtt99uv1MoDkXaG6TJjSQXksJaFPFbsmRJks9YZAUpejkUv8Bg2Xr88cfNAuMLUkDz5s1tExxvtRHhjDkbsDPPPNMsXSgWLE7xycksTL46W/ymQGQNPEYsRvEFJ1ioqIb35Zdf2iYADwhoAxYuvgAF1wBGjRoV9OzZ0wpRfPLJJ0k+u+h6T/Fa165dO8XzFLuhGMXPP/+sioMhg2zHk0RkACBTvDwpWrRoisIUImuwX/EGIipqNm7c2CpWY7QDjKfI+oIFCwbPP/987O8GDhwYLFu2LGnnHQV2795tyhyKHIXjGP+77rorhTzx+xZ/D4ici4qx5GDID2vdurX1ySMp/6WXXnKNGze2HjNwzTXXWJ+ZqlWrJvtUIwPNcSlEQf4GuWG//PKLu/HGGy1XrGvXrpbEnJjkrCT9cCDnjiIrzGlylmDXrl3Wl5BxJz+S/j4a73D49ddf3RFHHGF9CH3jXHoRkqtE3pLPZyKnQ2QdP283btzodu/ebXmQ5D6SZ40MJ0/GQ2P6ggULJvV8owiFPihgRr9CrgH5SL5ZOtdn2rRp1s9NZB3yqVk3kd303pw3b57r0KGDq1ixouW1A4U/PvjgA5Pr5MCLrJG4NlLTgZxH+kVSyIw8YOQPxzDvyX2nP6HW05yNsipzKFREohoSjblffPFFa8zNg6pgmzdvtmNIppWSFw6+uTyLDpuBhQsXWiL+ySefbBuwuXPnuieeeMKq33m8cJSQzBzeBkUBEP5PERAUPBQ95j989dVXNsdJEn/88cftOY131seccb399tvd2LFj3datW605LkYkjBteyQO/CRbhbMCQ6RjoqDBI0Q/m/Pjx4634EGPvoUG3/zsRHsgaGqTTFPqwww6z+f3FF1+YcYPrg5KnMc8aFPz4/vvvXfPmza0yNfN6+PDhVrEaBW/16tU29wFF+8orrzQlT+MenpLHnpEiT7Vq1XIPPfSQO/HEE63oCkX82rZta43pH3vsMZM/Wk8jQLJdiiJjEEJCaAONWin8MXLkyNhrJOuTS0AxEIX0hIMPAfQha76ZKMn5FPzwuY+EURH2I8KF0B3CkJnva9eutetBf8jjjjvO+rcVKVLEksQJ53nqqaeSfbqRgHAqcvAI/UbGIFfI3aBAhUehseHz6aefBlWqVDFZQh4kvQoJqQLyrcmFJA9VZA/MaWTMrbfearLFF/0gT1KFzMKBvct9991n8gW5ze+PPfZYcNlll8X2MuTokfvepk2bZJ9uJHnmmWesboCXJYRmEqpcr149q/UgoodCN3MohFHRt4ryw1i/zjnnHHt+6NCh7qyzznLnnXdesk8xMhawTz75xLyj/E4J/6ZNm1p5bUo9d+zY0dWrV8/ly5cv2acbuXGnXQjW3n79+pkXFS8TbStKlSrlJkyYYMfRw4rwWbxPhNT6+0BkDjxHhIIz3lWqVLGS2p9++qnN+auvvtrmufooZQ++PxuynR6Qb7/9titWrJhbtGiRlfInvIpQWhE+hGniwSMUnFL+X375pcl9+hV27tzZvNkKCQ8HojHw4OHZ69u3r4UgM/eR6e3atTOPNikSRBEoIilcvvnmG9uzEDlAOxbGGK818x7PNfsa9pAnnXSS5nqUSLamKTKOT5IlmZkEZgpSqAJV9kBRFSzpY8eODe68806zMuJRAqxfePZUUTMc4r3QeJXw5DHuHiztFL+JL/NMVVMKJGj+hwNW3tatW6d47qabbgqKFy8evPvuu/a7vHnhkDiOeDpKlSplVWV/++03e44Kg1TH895sEe5cp7KjZ+XKlUGzZs1ihT5oX0E1QtDYZx1fmZo1tWXLllZRkyJyFNAiYoZImQsuuMDatYjs4euvv7b2Wxs3btyjnQioDVQ0kVk2BxDvdMXySCw1hRI2bdpkTdCxwmMR27ZtW1LPM0pg6eKBVR1vEQ1EH330UfMwkY/H+BPb/sILL8TyZUTmWbt2rY0x8xvIdWTsP//889gx5KDSJJcm0TSIhlNPPdWOK1euXNLOPUpQXAVrL83oPTTkxrPB/EfGyNIbDowj3lIaQQOW9vz587syZcqYRZ0Gxt27d3f/+9//rDCLxj08kDPIjQULFtjvFKAgP6lChQquZMmS9hwFQI4++mj7v8Y+6xAFMGXKFHfzzTe72267zeY9Y8w6incPbx75ePEFzUTmSS1YDzmCB3XOnDmWe828fu2119z1119vNQcovCIiSLI1TZE23tri88C8RQzLI1Zf35ib0v6+548IZ8y91xSvXe/evVO0SKD5/Oeff560c4wqeOqwLPo2IeTnHXzwwbF57vnmm2+SdIbRnOvIDsb4p59+st9feOGFIE+ePJb3OHjw4Fg+B3k1NNYV4Yz7/PnzrfE2rRLw5sGkSZOCmjVrmmcDGU+j6Pi/EeGBDC9WrJj1CEPmxLcJ0XhnD8zzbt26xX6nB2rVqlWt9y+ePY17OMSPI304n3jiCcv7JSfypZdeCq644oqgSZMmdj3KlCmjPnkRR3WxD1B8PgAV1wYPHmx5d1i/unTp4p5++mnLGWjVqpUdV7RoUXuIcMac3DvyBaiiWbx4cTdo0CDLw8NrRAliPKkqbR4O5CP16dPHqq3hyaDi13vvvRfLFcPqzjynGl779u3tbyjJDcqZyRqMHfPcezIos02LFizu5G9QlY18PKIFqOS7fPlyq84mwhl3cqvxUlO597777rM8GbymyBo83OSM4eHTPA8PWiecfvrp9n+qxxIdsHTpUssLIzoANN7ZBx4lcq2JDMBbWrNmTVe2bFmL4OChcc8afu76cSTHmiqyeEpnz55tY03Ob+XKld2sWbMsamnMmDG2vxQRJtmapth7FbaKFStaFapLLrkkuPzyy4Nt27YFmzZtih0jC1i4jB8/3vLAfCNX6NOnj1Wk4hrg3YjPGxNZAy8SY9qiRYvYcx06dDBL+5o1a+z3ESNGxBpEi6zjIwPwjOJR8tEAVL+j2h3VZOPzJsmpoSk9+R0inGbFXbt2TVExGU9pvGcv/jqJ8CIGzjjjDMvDu+6666whPc2iWVdF+Pi9CRVjyXcEPEdUMX3xxRftehApQHXfBQsWJPlso4GvDo7cJs/3oosuio09kBtJBWtVZc9dSNE7QDcC3LBseNmEUfqWsts+tMoni4twF6UNGzYEDRs2DKZMmRIrO+xZvny5bXR96JoU7PCYOXOmhY+0b98+9ly7du2stL+f8xSjEFmDsNj4QhNFixY1Q1J82A4hPr6cPHOc5HwUP+a/yDyJ8uKuu+6yUNj459u2bRsce+yxVpRChIMf32nTplm4GvMYGf6///3PFDyUviOOOCIWtim5Hi6EHlNgiHDkvn37Bps3b7ZwTYymPCpUqJCiII7IPMxrZLdPfcBQSsEb5r4Hhfr666+XESmXodDNAxDc6YcffrgVQCCkjZK4lI4/7bTT3IcffmhlcHv37u3y5s2b7FONDIQ6UDr+mGOOiZWQ91B8hQTx+LA1hZiEA2GahMZWqlQpVsafUBPClVu2bGltQmiuSwgbKKwq83z22WeudOnSJkcIAx82bJjr0KGDlZM/88wzrXR/t27drCALc51xJjm/UaNGGvMs4OcshSgIm2LsCc9ExlDOnDGnKAjjToGKVatWJfuUIwPjTkGnDz74wEJlfYgaIbIrVqxw69ats+boEydOdBdddJHmechtFJ588kk3atQot3LlStu7UHjlnnvusXDBHTt2WAEQQmkl17OGT+EhFJY2OKyrNKOnkBatco499lgL2yRsljnP2PtCQyIXkGxNU+xplaHYB8U/CKU69NBDg9mzZ8eS99W8NRzw3vnS2R5+p1R/r169Ys8RNos1Uo2KwwXLOaFT5cqVixVXwdtUp04d8+Z5FC6YdeK9FLQCodDKrFmz7HfCMrH6Pvnkk3uU1pZ3IzzwipYvX96aFZ9//vnWluWhhx6ykGW8qnivkTEUv8HirtCqcGAO0x6EsFgfqUFBCv8a4AFBxvuS8yLrECVAexy81PGpKEQp0Yw+vkWOyBrxcvqLL76wQk6E4CPrKXBD+y2iNzp37mwh+CpmlvuQR+8AA6s63ovff//dLF+LFy+28v6U26akP410L7vsMlnAsgAe0mbNmpmV11u1KLfN/19++WWzttOsG48qXpCHH37YGhaLrEGBiccff9y8GJTaJiGfZq0k6AOFb2hfceedd5rFES82VkiRNbysQKZQRIjS5g0bNrSiQ3Xr1nVDhgwxyy8eJWSOlyuSL+Ewb948awxNYS0acdMaBM8SkRkUv2GcaZmDh+mZZ55xb731lt0XInPEr438pAUR8oTy/QsXLrSIDeb6oYceGrs+lJqn+I0IJyIJrzXjSQEn1tALL7zQ1a9f39bZ0aNHa6xDxM91isfhNa1Tp45FD1x88cXmqUam8H+uC/K9WLFiyT5lsZ85CG1vf3+o+H9w87Go+8WJ36kAxmJEaBXMmDHDfmczUKpUKSl5WcBvZlGmUZjpn8RmF1avXm1VIFE4UALZCDDe9G7TmGcNxm/+/Pnu/vvvtxCTF1980ULXWrRoYeNPyCaVHj/66CM3c+ZMCxckbFNkHja3Rx11lP2f0EAMRsxrxpkqj1TvRdmgAhubMea3vxdEeGCgQ6789ddfrmvXrrbRpfpjmzZtXMWKFa0CJ0pez549TSGk+qzIepgsBj2MS/QhxIBKdVkUvalTp5oi4o8lVBxDHrJeZA3kDPO5c+fOVikZOcO+hT0NCgiw5qp6b7h89913rnXr1ma8I6UHwwWyhucxHFHZV+Re1DA9iYs/TUJR8ihzS9NKmljy+/PPP28l/FmQgA0vpf39QiSFI/PgSULoscGl5LAfy59++smUDnJo8J6yKWAjhpIHGvOswfide+657pZbbnE//vij5SUx1ylvjiGD/Bks77xOrgxzXjaozLNhwwbL96L5OWDYIA8PJQ/69etnntMqVapYDioWd5Q8jXn4EBlQrVo1k/Pkz3AdyH3Ew4QVnvuAliFDhw6VkpdFfEsivNZe4SPXF8X69ddft3wwrgUGVT/XMTJJyQsH8h0nT55sedfMcWoJMNYYrTEmgZS88EG5I1KACDDAMYAXD48qzdDj57vIfSh0Mwlg2X3jjTfMo0TYGsJx+vTpliDOolS1alVzr6MIivAVPazojDWKB5suvHwU/+B60EMM5MELH7x19PVhEcLqy7gTVlKiRAkLOWEzRs82+luBxj/z/PHHHzaH6YWHNwMPBpb1eFD2KPqEhd2jMc8+KIKD8o0ne/jw4e6FF16w/oU+qoOCCSLrayu9CVGgiQrAcETBIQxLeDvGjh1rm2GFxoYLSgbKBv19WWNR9Jjn9P3t3r27e+CBB8yAKsIHOY/swFhH4SEKylF0i76cRHHceOONmu+5HIVuJjGsihylO+64wza/5M5g8SVngw0Z1TbZGBB+gmUM4SkyT7ziRhVH8pVQ7lA27r77brPo+rwBKXnhg2WR8B0qgDHWeKtR8shVeuSRR2y84/NmRNahETSWdJQ+Fno2uISxEUbIJoyxZhMMmvP7ZzNMBUKiCcgRJk9ShD/Gl1xyieVV+9BvlD+iBAjRxLsqwoVKjuxXOnbsaJFHgOGOvQ0516RKsIfBqCTCx8tuxhzDHnvGc845x6pY490mWkDkbqQ97Gd82X68F1gYfUlzyg9Xr17dPfvss1ZwBSsYeUxYyaTkhSMIsXYNGDDAcsXw5qFokEfAc+RueJuHNrzhg3URq6O36hI+hTeDkGWvbGieZ514ux0LfNu2bW3cmd/koKLsET3AT8LYPJrz2Q+ynHBwNsUoebKxZh0/hjt37oyNMesongwfEYMiwuvyamQPJ5xwghUvw3CKksE1ITrm/PPPt7HfvHmzlLxsgmgAZDcFhYiUwWhNXiRRYYTQSskTII9eEhQOFI1bb73VNrlYIKl6R04eng0KVaT2NyJrECqIQk3BAxQL8pMIJ9myZYtr1aqVhTsQSsVPkXUS5y2L/Q033GAbXXLBUD7IHyNvg/Gnj54Iz6BBtTWKH9BXCRmDUWP9+vWWe4qSLZKHZHq4UGCICr0Y7YiIoQARRZ8oQkEeJF4OQvUJKxThzV8K3UDhwoUtJ7h9+/bWu42cMAzaFHsigoA8YBGezGBs442iFC9r3ry55bg3aNAgiWcpDlSk6O1nPvnkk1gJXBLzYfbs2bZQYXHHu5So7ImswYJE7iN5A+RDouRxDViggKatFAghd0+EtyihbFBgCCNGnz59LC8VxY6QZCyNNNMlJ4/cAhEOWHEpRIEyR8EnvBvknRIWS94S14KfBQoUkAdV5HioKkhRrccee8w8SsxvcvSooklTbiJm8DipcnL4yjWKHCkotMBB0SBKBk8qhiU8TEQkXXrppck+1RxP/LxFmaN41hlnnGFzmn0kobEYT8lJ1RwXqaGEmP0MG1+qarLZ9fgqYGyEyaeRohcu5AdgVZw2bZopFijVKHlYfLH+UvlRSl54+HwBlDv65uFFouAH+WLkohLew33AhkxKXngQPsUYU+gDDymbMR54OSh3TlgPecEqiiByMn4zS2gmBrpevXpZqCAPZA2GDlIgmjRpkuLvtAEOBxQNxvztt982Lyqh4Kyrvm0Oih6RMhTZkuKRdfz4EXFEjjsFnXr06GFGPfaNrLHgizoJsQdJbtgeef777z/7uX379thz/fv3D4488sjgq6++SnHs5s2b9/v55ZZrUKVKlSBfvnzBzp077bm5c+cGJUuWDCZNmpTs04scGzduDJo0aRL8/vvvwbvvvhucf/75wY8//miv/fvvv/Zz165dKe4PkTV27NgRtGrVKjjjjDOCYcOGxZ4fN25c0Lx586B79+6xMRcip4NcQaafeuqpQdOmTYP169fHXuM+qFq1arBly5aknmOUiJfTEydODFq0aBH7fc2aNcEVV1wRDBw4MElnF/0xX7BgQVC9evVg27ZtwbPPPhvUqVMn6N27t/0cM2ZMUs9THPjIo7efqiG9++67Fj6FlZFGluQs4W4nlJPEWVB57fDZvXu3VdPE4oi1l3wwwnpoWkzoYL169ZJ9ipEDqyK5jlSTJV8MTzWFP7AAr1u3zizu3vIoa2/WoQckoZi0S+BB2BRtQ8jPw8tBTgftWnxVWSFyMjSXJyqGMDbSHZjztE2gqi9hmni1lyxZYsUpRDj4fQyVHCmyQroDoeFEB5CXV7lyZcsBFuEQ7wl97733rCceP/Hi8ZP+kMh51lSqyVJVVvNdpIWSNLIRblSKgBDCRhVNSszTtJVyzzxH7kytWrUszEGEW+ERUKzZ3JIoTjsFFio2wCxOhPawCRZZh5CRxJ4+9G3DuEHuDGNO2CzFb8jnIDdM+WFZh7FGcaZXGGGwKHvIGeQJhgzK+MPll18eK3suRE6G6rF33XWXK1mypFXtZW4TRkhBM0KWydEDNZ4Plx9++MFyIGmhgEJNFVMUbArdkHfN2LOXEVmH/aFX8lDiaDqPY4B9C8r1qaeeaq/RJocWIoR0SskTe0O7rWzwIPlNGJZ0LI3kgtG7DSi2QoI41i96/ZCvpEqP4eYpUWGQhYg+YQhD+iqR+0hzeqqv4dm74IILkn2qOR5voMA7RzN0+iZR5Y7WIRRIIDmf6ncki3fq1Mk8qMrJCw82Ayz+FEKgoBMejpNPPtk2vmwIyOdggyBEVGCTy/q5aNEiq17NGkuONRWVUfbIQRXh4Ov04UGtX7++tUjAaOcVEL+/Qa5TmEVratbBY4czAKhKjaMAIx57F64HkRl4sTFw0EaBwnL58+dP9mmLAxxV3QwRvEYsOlR3xKKIILzxxhvN2oICQlEEGkQjJPFwIBxRRvBuKGk5HKi0NmLECAvfOfroo03JYDOMFRg0zuEpeSw2FPmgkA0hyShzNOlm8efBpoBekcxvQjcJUdb4hwObL+QLzecBpY4NAuHgXbp0catWrbKKePLkiZyMlxcYRIkcoIgWhlHWVeQ7UTF49jiG9ZdiTyI8KN1PdAbh9xQxQ84QpolM92kRGFGPP/54yfYsguGCFiB4rYmKoegK+xm8qBhRKRy3detWe50+qCjf7CeF2CfJThKMGh06dAgqVKgQLF261H5/8cUXgzx58lgCM8yaNSsoW7asFUkQ4UFhm19//dX+f+ONNwaXX365/f+PP/6IHaPCH+FBcSHmNgni9evXDyZMmBB7bcCAAcHJJ59sxVhEuFDMhoT8evXqBbfeemuwbNmy2GtPPPFEcNxxx1mxp3/++Sep5ylEWHzwwQdWeIW1lcJOM2fOtIJPzZo1s0JD8+bNS1HoSWQNv05+8803Qc2aNYMTTzwxWLJkSXDPPfcElStXtsIgqR0vssb8+fOtsNC9994btGnTxp67//77g0svvdT2jxTcEiIzKHQz5JBNcu8IZcPbQQgbHg+ahtJEFCskvxOySX6YnKlZhzEkPI0EcfoS0nQeTyle1FGjRpk10h8na2N4YF2ksA35YbRKwEMNWN3xKOG9U9hgeHhZgSU9b968VuiG0vLkzRAtAFh4ydnAq6cy2yIKEJJMuD09Oem9iXwhfI2iK5Typ7y/LzKkvN9wYJ2k4Efr1q1NvhNuj2xB3lP0o2nTpu6rr75KcbzIOkTA0DKEEGQfBkteO/OeuU5YJ/NdiIyi0M0Qwc2OkoFApBoSCcxU1eRGpdcMISdswM4555xkn2pkIBePPnnkCdCrjd8JgaASGLkcr776qjYAIZKawkxI8lNPPWVGDgwaM2bMsAb1bM4omiAyD+GZjDcPxpW5jRJNI3TCN6ngW6RIEcvTQNaQn4rRQ4goQO4vFR5R5p544glLeyAMnOqPbIZZT0l/EOEWM2vRooWF4qPgAbKdytVTp051Q4cOdQ0bNrRm3SK89ZQQWMI1gflOs3maoAMhyhQaYj+DoU+IDJEpP6DYA9zqF198cfDZZ5/FnuvUqVNQrFixYPHixUk9t6hC2NpNN90UzJkzJ/juu++Cyy67zEI1P/roo+Caa64JDjrooFj/NhEejG/r1q2DXr16xUKUX3nlFQsb5B64/vrrFZocAitXrgx69Ohh///0008tHJaQnvz58wdDhgyx55nfTz31lMkarosQUeLtt98OKlasGNStWzf46aefYvdCpUqVghUrViT79CLJX3/9FVSrVi0YNGhQLDST/Q0pKWeffXYsRUIhm1kjfvzoA+l/X7VqVXDnnXcGbdu2tbnuWbduXVLOU+R85OoI0fJOqfP4ql+43bGO4d3Yvn17Us8vKngHNEnJFJs444wzrMIjyfpUHMQKSW88irFQ6RTrrwiPuXPnWrlnPHUUZMF7TWJ4hw4drNw21R5vvfVWhSaHAJ5oCqzQd5B+hIQiE9ZDaxBCebCsE8ZG5TW8qlSX1ZiLnIqfu19//bWFbBKmRpEnvNVEZ7C+fvDBB1ZYCw9TiRIlkn3KkYTqmshw5A2eUzxORBIQtsmYUzkcFLIZjiePaBhaVtD3dMGCBa5o0aJWGZx2OVRSpmceqNCQyDTJ1jSjBJb1Ro0aBXPnzrXfp0+fbom1X375ZbJPLRJ4ixfJ+XjvsILBJ598ErRs2dIsYPny5QvGjx+f6t+JzOHHD6vumDFjYp6jtWvXBvfdd19QtWrVWIL+L7/8ktRzjQq7du2ynxSaKFOmjBVwmjZtWuxa4OkoWbJkMHjwYBVeEZHh/fffD0qVKmXzHe818597gSgBiq9cd911wccff2zHSq5nH3/++Wfw5JNPBoUKFQratWsXFC5cOFi4cKEV2urXr1+yTy9HEz9vp0yZYgXN8OLdfPPN5rn2UWFEgrG+eg+qEJlFil4Wb1QqffmN1vLly4OHH37YhCOud376apsiHAgJJIQE5Q58JaoNGzYEkydPDkqXLh18/vnnST7L6PHuu+9axTVCpqhq6qGyZrdu3WxjtnXr1qSeY9TkC2OOoeiLL76w8LUuXbrYBswzYsQIMyYJEYX5zlpKZU1C8jHiUVUW4503nIJkzP4FRRvD3g8//GByqFy5claNU2SO+MqZr7/+etCkSZNg5MiRsed69uwZXHjhhbF9499//52U8xTRQopeBti5c2fM0v7999+neO23336zPCXKPnOTjh49Wp68kKGsPOWHsXSx4cWrccEFFwQPPfSQjX/8pkHW3vDAgIEl/Z133glGjRoVFC9e3Awa8bkDHCPCg3YV5cuXDyZNmmS/Y/FFmcaAtGnTpmSfnhChgnGOiBiMSD5Sgzl/++23mzfPR2mohUJyIA++YcOGwaJFi5J9KjkW1kk8dt4xQHRMgQIFzIAXr9B17do1uOSSS6yFkRBhoHJV6eSff/6xilPkglEG9+WXX7YH8dSUxKUCFbkDlH1u0KBBsk83klBtilxI8jZoSF+lShUbaxqI+rLDPu5d+QPhQP4duRm9evWyPALuA3IHbr/9dvfXX39ZHiq5A8ofCJf333/fciHJN6WSLHKGJvT8joHu8ccfV7VBEYk8pc8++yzW+Bx589prr1krIuY8VWWptkkVZVAF5eRAbh5575LzmYexGzdunJswYYKNJ+2g8uTJYznYpUuXtjnP77TOWb9+vbUwEiIMtFNIJ5RxptjH/fff73766Sc3fPhwW4hQMChrfs8997i2bdsm+zQjuRGgTQWlh88991wrr40gpOxzuXLl3MqVK62thYrdhD/uFBJizlPKnwR8EvRRLihrThsRekLSa4mCOFKsw4NeYcuXL3dnnXWW/e77hFGQgh6cbHql5ImcCsY6FDZkBr1mKSxE37ZSpUpZX8iZM2e6N954w1q1UEwLWcPcF8nD96MVWTdWs65WrFjRig5RtIzf6bWMQY81FWUPY6oQYSHzWDphUWKDRc82+uJNmjTJKmxSoYoFySt5bNJEeGOOZ4Nqgs2bN7fqpVReo8ogSh4K3lVXXWUV2LgmIjwlD8sjlb/atWvnrr32WrNG1qhRI7ZJo4kulfHwbkvJC9+oxNhzDah6h1L35Zdfutq1a1sPTn6quqbIiaxdu9aqxSLHiQ6gqiBze8mSJfZ6+/bt3XnnnWeyheN2795tG18hogJ7lnfeecdVq1bNjNh49vr27WsVlakkLkTYSNHLQDl/rFrjx483CyNePd/c8rvvvrMy6H6TJsIBbx0lnglZIzwTr959991nwpEmulh+EZCXX365Nr4hgdLGHKdVAgo0855rgMJdqFAhU7AZa5Q9wpRF9kCzXKy9N9xwg2vTpo3r2LGjtVUgvA2kXIucCNEvo0ePdu+++64pekQJsPElnG3atGl2DEZTQpQvvvhi82YrXFNEDYzXhCjXqlXLrVixwgzZ06dPl+dUZAsHkaiXPW8dHdj4Pvroo5YTxo1J3zb6WhFysmnTJrNOEtrG4iTCYdmyZbbZJUxw0KBB5tXYuHGjxbEjDB988EFXpEgR2wjE96QRWYOxvOOOOyw3htCSRx55xL399tsWpoxxgzxUXsfqLrIfPB2E9hC6Rh6H5rrI6eDFw1Ndt25dM2KsXr3a8t0JXWvatKk9L0RuACP23XffbfsdnAQyaojsQIrePpg1a5br1q2bKRg//vijeZmwNGJp5/9YJsuXLy8lLxvA2oullzAHxhghuGHDBrN+4VUtW7Zssk8xchCaydwmBJnm56+++qqFZ6LsTZ482T3zzDNKEhdCZAkiYIgSINea8PBVq1ZZ7jVGDRpIY8yTQUPkBkgBOvroo5N9GiLCSNHbC1hZCBUkhhrlgvyCDz74wKpv4mnq1KlT7FhZ2rMGYTx47bDuEpbplTiUPZRtvHpe2fPHiuyB0Cq8dg899JAVWyGkiqp4ePcIJxRCiPTi10ZC0wi7P+aYYyzcHuMRRVgwkmJIRdnjWOVbCyFEeGi3vJeFac6cOebFI0epUaNGrnDhwpZPQKVNvBvEWZ922mn2N1LyMsf3339vSluxYsXMO0r1UsLUqOSIxff55593Xbp0MUX7zTffdJUqVVIeZDbDXEfh7tGjh+XUED5I6DKhtDJoCCEyAvLiww8/tHYhLVq0sNYgVNvs2bOnhWv6fL1bbrlFskUIIUJGHr04/CaWXLATTzzRnps4caL1j8HKSL+TY4891nLyUPa8kicyD4oEigVeI8J5SMSn4MT5559vpf3ZBABlh6m6SY6k2D/QM5J7gjzIkiVLJvt0hBA5EIqVIb8JwcdAStg9xlPfG4+WChjweAghhAgXKXoJSh6FV7A40tOHhtCUeKZn3pQpU8yjR76eKiOFC2NOgRtCYckBA3I1aEKfL18+U7aFEELkPCjiRF88jKSspW+99VYsYoN+YTVr1kz2KQohRGRRiZ//vwAFSt5nn31m4SRU0CSPYO7cudbHB08SvasovkIxEBEuePQI7aHyGqGyQO8klGvGe/78+ck+RSGEEOkg0XaM0Y61lYgNwu9R8shzp0m0wvCFECJ7ydUePUI08c6x2LAYkYdEI2gqDrIIjRw50srKU2ae/mEUY8GrJ7KHjz76yMpt0yz39NNPt+eUEyaEEDkDL69pgk7od/Xq1a2w1iuvvGIFtSjCkjdvXmsOTeQMeb9CCCGyj1yr6NEIGmUOzx3VBVH26ItH7sCOHTssN4wcMSyRlJinWbHP2xPZx8cff2xVTknWx/IrhBAi50CoPQW0MJKS39u4cWPXsWNH6xm2ePFiUwYJy+chQ54QQmQvubbqJpUeaZEwadIkU/Roo1C8eHH3xx9/uNtvv92UPKpuUmae5txS8vYPVDIlaZ8QTil6QgiRswqvYBilDdFZZ51lnrwZM2aYQkerFox48UjJE0KI7CVXKnqEZh555JEuf/78ttDgxSNRHCskFke8SoSZoAz269fPLJKyPO4/GG/QmAshxIGNl9OkONDsnJBN0iIATx6vYVAlUgYjKr1QeQghhMh+Ds2NixJhmhMmTLAKmnjyUPzIKaCXz1133eU6dOhgLRRQBvHsSeFIDhpzIYQ48OU0bXLGjBnj6tevb1ExKHZEweDVYz1ljT3vvPPMeCqEEGL/kWty9MjJoxE3OQP0wLv++uvdxRdf7Nq1a+e2b99u+QPPPfecNUSnabeqgQkhhBB7Z9GiRdY24ZprrnHVqlVz48aNcyNGjLAiLIRq0oNWCCFEcsgV8ROU6KfCF5ZG9NrDDz/cPHWbN2+2aptUAWvWrJlZG+fNm+d++OGHZJ+yEEIIccCCl441tEqVKpbucNppp8VC78nHo3qyL26WS+zJQghxwJErFD1aKFC2H08ezVrpm4eVkYRxcvLolbd69Wp31FFHWeEVwk2EEEIIkTpEvbC2fvHFF27NmjVu2LBhKYpqtW/f3topsK4qDF8IIZLDobnB6oinjgqOFFbBY4cHjyTxn376yd199932O168Rx55RGEmQgghRCr4fPVZs2a55cuXW2QMeXnk5JGDlydPHqtUDSh5QgghksuhuaHwysyZM93OnTtd9+7d3cMPP+zefvtte53/06/tzz//tMIrFSpUUOEVIYQQIhVYGylkRtEyPHa33Xab69u3r+vataubOnWqq1WrlhU1w4AqhBAi+Rwc9UWJ3AG8d4Rr4tlD2SM0c/To0e7NN990Z555pqtRo4Ypef5vhBBCCJESIl9IbyDtoWLFirZ+kt8ONWvWNGWvTJkyyT5NIYQQuaHqJqElLVu2dC+99JIljBPGiYePnLw+ffq477//3g0YMMAVLlw42acqhBBCHHDER7msX7/eDR482J1++unu6aeftmqbGE5HjhzpihYt6qpXr77H3wghhEgekQ/dLFmypCl5f/31V6yHD9U3yddbuXKllDwhhBAiFYiEobk5nrply5ZZu4SXX37ZqlX/8ssv9tqcOXPc/fffbwqgR0qeEEIcGEQ6dJPcu8mTJ1seHj30UPRIIr/11lut5QJhJ0IIIYRIGaJJsTIUOQym7733njv22GNdgQIFLEKGFkW9evWyiBgaoj/11FPu/PPPT/ZpCyGEiKqi5yNQFyxYYPl3mzZtsuatKHV49LBCDho0yBqk33DDDa5gwYLJPmUhhBDigFT0CM/kJ965X3/91YylcNFFF1mo5u+//+62b99uSt5ll12mXnlCCHEAEqkcvfHjx1vhlRIlSriff/7ZDRw40NWuXdtCSqi8Sennq666yjVo0EA5BEIIIUQaUMgMoyjKHvl4GEwvvfRSa5J+2GGH2XrKTyGEEAcuOV7R8zkE5A+g2LVq1cqqgfXs2dNNnz7dSj+j7AkhhBAi/VBdk6qaRYoUsV60KHcUZCHnfciQIa5y5crJPkUhhBBRVPRWrFhhjc5p2MrCU6lSJXfaaae5YcOGxXLvSBDHKvn444+7OnXqmAdPXjwhhBAifUyZMsXVq1fPffLJJ9ZCwXv0yNcTQghxYJNjc/TWrVtnISW0SmDBeeGFF9xvv/1mxVd4DvDmkU9w1FFHmddPSp4QQgiRfurWres++ugjS3tgjcW7JyVPCCFyBjnWowdbt251p556qpV3ppfP2LFj3V133eV69OjhWrdubZXBhBBCCJE1xo0bZwVZMJ4KIYTIGeToPnr58uVzQ4cOdRdccIGbMWOG9fjBc9e+fXtrjk5hFnnxhBBCiKzRuHFj+6lCZkIIkXPI0YoeEE5CvgCtFPDsXXnllabknXDCCVqMhBBCiBDRuiqEEDmHHB26GQ9FV1DyaI5evHhxe06WRyGEEEIIIURuJDKKHiiHQAghhBBCCCEipuh55MkTQgghhBBC5GZybHuFvSElTwghhBBCCJGbiaSiJ4QQQgghhBC5GSl6QgghhBBCCBExpOgJIYQQQgghRMSQoieEEEIIIYQQEUOKnhBCCCGEEEJEDCl6QgghhBBCCBExpOgJIYQQQgghRMSQoieEEEIIIYQQLlr8fydpBTdyX90lAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 900x320 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "GOLD = [\n",
+    "    (\"Que s'est-il passe lors de la derive de montage disque ?\", \"txt-incident-derive-montage\"),\n",
+    "    (\"Comment equilibrer rappel et vitesse avec le parametre ef ?\", \"txt-hnsw-ef-compromis\"),\n",
+    "    (\"Pourquoi remplacer une API d'embeddings commerciale par un modele auto-heberge ?\", \"txt-embeddings-qwen\"),\n",
+    "    (\"A quoi sert le chevauchement de tokens dans le decoupage ?\", \"txt-chunking-overlap\"),\n",
+    "    (\"Quel est le role du serveur MCP pour les agents ?\", \"txt-agents-mcp\"),\n",
+    "    (\"Comment les citations permettent-elles de tracer une reponse ?\", \"txt-kernelmemory-citations\"),\n",
+    "    (\"Que dit la methode SDDD sur le grounding ?\", \"txt-grounding-sddd\"),\n",
+    "    (\"Pourquoi isoler les donnees Qdrant sur un disque virtuel dedie ?\", \"txt-infra-docker-wsl2\"),\n",
+    "]\n",
+    "\n",
+    "gold_rows = []\n",
+    "if INFRA_OK:\n",
+    "    for question, expected in GOLD:\n",
+    "        res = km_search(question, limit=3)\n",
+    "        top_docs = [c[\"documentId\"] for c in res]\n",
+    "        hit = expected in top_docs\n",
+    "        rank = top_docs.index(expected) + 1 if hit else None\n",
+    "        gold_rows.append((question[:48], expected.replace(\"txt-\", \"\"), rank, hit))\n",
+    "    recall3 = sum(1 for r in gold_rows if r[3]) / len(gold_rows)\n",
+    "    print(f\"{'question':<50} {'attendu':<38} rang  @3\")\n",
+    "    for q, e, rank, hit in gold_rows:\n",
+    "        print(f\"{q:<50} {e:<38} {str(rank) if rank else '-':>4}  {'ok' if hit else 'MANQUE'}\")\n",
+    "    print(f\"\\nRecall@3 sur le gold-set : {recall3:.2f} ({sum(1 for r in gold_rows if r[3])}/{len(gold_rows)})\")\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas de mesure.\")\n",
+    "\n",
+    "# Trace : rappel par question (barres), pour voir les echecs individuels\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "if INFRA_OK and gold_rows:\n",
+    "    fig, ax = plt.subplots(figsize=(9, 3.2))\n",
+    "    labels = [r[1].replace(\"txt-\", \"\")[:30] for r in gold_rows]\n",
+    "    values = [1 if r[3] else 0 for r in gold_rows]\n",
+    "    colors = [\"#4c78a8\" if v else \"#e45756\" for v in values]\n",
+    "    ax.bar(range(len(values)), values, color=colors)\n",
+    "    ax.set_xticks(range(len(labels)))\n",
+    "    ax.set_xticklabels(labels, rotation=45, ha=\"right\", fontsize=8)\n",
+    "    ax.set_yticks([0, 1])\n",
+    "    ax.set_yticklabels([\"manque\", \"trouve\"])\n",
+    "    ax.set_title(f\"Gold-set francais : document attendu dans le top-3 des citations (recall@3 = {recall3:.2f})\")\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fb83b52",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004263,
+     "end_time": "2026-08-29T06:42:36.166741",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:36.162478",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : lire un recall, pas le subir\n",
+    "\n",
+    "Selon le run, une ou deux questions manquent leur document — typiquement quand deux\n",
+    "documents traitent du même sous-thème (les disques apparaissent dans *incidents* **et** dans\n",
+    "*infrastructure*) : la requête « disque virtuel dédié » peut légitimement remonter la\n",
+    "dérive de montage avant l'infrastructure WSL2. Deux lectures possibles : un défaut du\n",
+    "retrieval (réel si le document pertinent n'apparaît nulle part) ou une **ambiguïté du\n",
+    "gold** (la question admet plusieurs bonnes réponses). C'est exactement la discussion du\n",
+    "notebook 02 : un gold-set se construit en vérifiant que chaque question a UNE réponse\n",
+    "attendue non contestable. Un recall de 1,0 sur un gold ambigu ne prouve rien ; un recall\n",
+    "de 0,75 avec des échecs expliqués est plus instructif.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db84e1f2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005105,
+     "end_time": "2026-08-29T06:42:36.175830",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:36.170725",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Durcir la mesure : MRR et questions hors corpus\n",
+    "\n",
+    "**Contexte.** Le recall@3 dit *si* le document attendu est présent, pas *où*. Le MRR\n",
+    "(Mean Reciprocal Rank) pondère par la position : 1/1 pour premier, 1/2 pour deuxième,\n",
+    "1/3 pour troisième. Et un gold-set honnête contient aussi des questions **sans réponse\n",
+    "dans le corpus** — pour mesurer l'abstention.\n",
+    "\n",
+    "**Objectif.** (a) Calculer le MRR@3 à partir des rangs déjà collectés dans `gold_rows`.\n",
+    "(b) Poser deux questions hors corpus (ex. « Quel est le prix du bitcoin ? ») et vérifier\n",
+    "que le service s'abstient honnêtement (scores faibles, pas de citation abusive).\n",
+    "\n",
+    "**Indices.**\n",
+    "- `# Etape 1` : `mrr = sum(1/rang for _, _, rang, hit in gold_rows if hit) / len(gold_rows)`.\n",
+    "- `# Etape 2` : `km_search(\"...question hors corpus...\", limit=3)` puis examiner les scores\n",
+    "  (`relevance`) — un seuil bas (ex. < 0,35) signale l'absence de vrai voisin.\n",
+    "- `# Etape 3` : confronter à `/ask` : la réponse attendue est `INFO NOT FOUND`\n",
+    "  (comportement d'abstention configuré par défaut dans le service).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ef2cb1d7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:36.185614Z",
+     "iopub.status.busy": "2026-08-29T06:42:36.185614Z",
+     "iopub.status.idle": "2026-08-29T06:42:36.189628Z",
+     "shell.execute_reply": "2026-08-29T06:42:36.189628Z"
+    },
+    "papermill": {
+     "duration": 0.011415,
+     "end_time": "2026-08-29T06:42:36.190986",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:36.179571",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : MRR@3 + questions hors corpus (abstention)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 — a completer\n",
+    "# Etape 1 : MRR@3 a partir de gold_rows\n",
+    "\n",
+    "# Etape 2 : deux questions hors corpus, examiner scores et citations\n",
+    "\n",
+    "# Etape 3 : verifier l'abstention de /ask sur une question hors corpus\n",
+    "\n",
+    "resultat_exercice_3 = None  # TODO etudiant\n",
+    "print(\"Exercice a completer : MRR@3 + questions hors corpus (abstention)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bebbe29d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003975,
+     "end_time": "2026-08-29T06:42:36.199659",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:36.195684",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Où vit la persistance : l'épreuve du redémarrage\n",
+    "\n",
+    "Le service KM est un processus **sans état** (stateless) : tout ce qui compte — vecteurs,\n",
+    "payloads, provenance — vit dans Qdrant ; l'état des pipelines vit dans le stockage\n",
+    "documentaire sur volume. L'épreuve : détruire le conteneur du service, le relancer à\n",
+    "l'identique, et interroger aussitôt. Si la persistance est où on la croit, les citations\n",
+    "reviennent sans rien ré-ingérer.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "fa641994",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:36.209680Z",
+     "iopub.status.busy": "2026-08-29T06:42:36.209680Z",
+     "iopub.status.idle": "2026-08-29T06:42:39.355323Z",
+     "shell.execute_reply": "2026-08-29T06:42:39.354768Z"
+    },
+    "papermill": {
+     "duration": 3.151211,
+     "end_time": "2026-08-29T06:42:39.355877",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:36.204666",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Redemarrage du service KM (destruction + relance du conteneur)...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Service relance : True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recherche post-redemarrage : 2 citations, documents = ['txt-kernelmemory-citations', 'txt-chunking-granularite']\n",
+      "Points conserves dans Qdrant : 34 (rien n'a ete re-ingere)\n"
+     ]
+    }
+   ],
+   "source": [
+    "if INFRA_OK:\n",
+    "    print(\"Redemarrage du service KM (destruction + relance du conteneur)...\")\n",
+    "    km_ready_after = launch_km_service()\n",
+    "    print(f\"Service relance : {km_ready_after}\")\n",
+    "    if km_ready_after:\n",
+    "        res = km_search(\"Comment les citations permettent-elles de tracer une reponse ?\", limit=2)\n",
+    "        print(f\"Recherche post-redemarrage : {len(res)} citations, \"\n",
+    "              f\"documents = {[c['documentId'] for c in res]}\")\n",
+    "        r = requests.post(f\"{QDRANT_LOCAL}/collections/{INDEX}/points/count\",\n",
+    "                          json={\"exact\": True}, timeout=15)\n",
+    "        print(f\"Points conserves dans Qdrant : {r.json()['result']['count']} (rien n'a ete re-ingere)\")\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas d'epreuve de redemarrage.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06155ad6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004802,
+     "end_time": "2026-08-29T06:42:39.365554",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:39.360752",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : le service est jetable, les données ne le sont pas\n",
+    "\n",
+    "Le conteneur KM peut tomber, être mis à jour, redémarré : la mémoire survit parce qu'elle\n",
+    "n'a jamais vécu dans le service. C'est la même leçon que le redémarrage de conteneur Qdrant\n",
+    "du notebook [05b](05b-Stockage-Vectoriel-Serveur.ipynb), un étage plus haut : chaque couche\n",
+    "délègue sa persistance à la couche d'en dessous. La conséquence opérationnelle est\n",
+    "précieuse : **mettre à jour le service ne coûte pas une ré-indexation** — le seul coût est\n",
+    "la fenêtre d'indisponibilité. La réciproque est vraie : perdre Qdrant perd tout, d'où les\n",
+    "sauvegardes testées du document [04](docs/04-Incidents-et-Lecons.md).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33c3719c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00421,
+     "end_time": "2026-08-29T06:42:39.374601",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:39.370391",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Nettoyage\n",
+    "\n",
+    "Le bac à sable se démonte : index supprimé (avec l'attente de suppression effective — la\n",
+    "course de la section 3 s'applique aussi en fin de session), conteneurs et volumes jetés.\n",
+    "Le corpus temporaire était hors dépôt ; rien ne subsiste.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6a000141",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:39.384685Z",
+     "iopub.status.busy": "2026-08-29T06:42:39.384685Z",
+     "iopub.status.idle": "2026-08-29T06:42:42.343551Z",
+     "shell.execute_reply": "2026-08-29T06:42:42.343551Z"
+    },
+    "papermill": {
+     "duration": 2.9654,
+     "end_time": "2026-08-29T06:42:42.344555",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:39.379155",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index supprime (demande=True, effective=True)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conteneur km_service_rag07 supprime : True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conteneur qdrant_rag07 supprime : True\n",
+      "Volume km_rag07_files supprime : True\n",
+      "Volume qdrant_rag07_data supprime : True\n",
+      "Corpus temporaire km07_corpus_kxb6rgf0/ efface\n"
+     ]
+    }
+   ],
+   "source": [
+    "if INFRA_OK:\n",
+    "    ok = km_delete_index()\n",
+    "    gone = False\n",
+    "    for _ in range(30):\n",
+    "        time.sleep(2)\n",
+    "        if not qdrant_collection_exists():\n",
+    "            gone = True\n",
+    "            break\n",
+    "    print(f\"Index supprime (demande={ok}, effective={gone})\")\n",
+    "    for name in (KM_CONTAINER, QDRANT_CONTAINER):\n",
+    "        r = subprocess.run([\"docker\", \"rm\", \"-f\", name], capture_output=True)\n",
+    "        print(f\"Conteneur {name} supprime : {r.returncode == 0}\")\n",
+    "    for vol in (KM_FILES_VOLUME, QDRANT_VOLUME):\n",
+    "        r = subprocess.run([\"docker\", \"volume\", \"rm\", vol], capture_output=True)\n",
+    "        print(f\"Volume {vol} supprime : {r.returncode == 0}\")\n",
+    "    shutil.rmtree(corpus_dir, ignore_errors=True)\n",
+    "    print(f\"Corpus temporaire {corpus_dir.name}/ efface\")\n",
+    "else:\n",
+    "    print(\"Mode degrade : rien a nettoyer.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd47bc92",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004497,
+     "end_time": "2026-08-29T06:42:42.354103",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:42.349606",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion : ce que la couche achète, ce qu'elle coûte\n",
+    "\n",
+    "**Ce que Kernel Memory apporte par-dessus le Qdrant manipulé à la main dans les notebooks\n",
+    "01–05 :**\n",
+    "\n",
+    "- l'**ETL documentaire** — PDF, bureautique, web décodés par le pipeline, sans une ligne\n",
+    "  d'extraction à écrire (le PDF de 43 pages ingéré ici l'illustre) ;\n",
+    "- le **découpage reproductible** avec chevauchement paramétrable, et la multiplication\n",
+    "  document → partitions rendue visible ;\n",
+    "- la **provenance portée par le pipeline** — citations document → partition → passage,\n",
+    "  exploitables par `/search` comme par `/ask` ;\n",
+    "- l'**architecture asynchrone** — uploads non bloquants, reprise sur panne, au prix d'un\n",
+    "  contrat de vérification (polling des statuts) déplacé côté client ;\n",
+    "- la **séparation des rôles** — le service est jetable, l'état vit en dessous (Qdrant +\n",
+    "  stockage documentaire), prouvé par l'épreuve du redémarrage.\n",
+    "\n",
+    "**Ce qu'elle coûte :**\n",
+    "\n",
+    "- un **service à opérer** (conteneur, configuration à onze variables, files d'attente\n",
+    "  internes) là où un `requests.post` vers Qdrant suffit pour un prototype ;\n",
+    "- des **angles morts à connaître** : formats non reconnus (`.py` absent de la liste,\n",
+    "  échec silencieux en poison queue), course suppression/ingestion, modèles « reasoning »\n",
+    "  qui consomment le budget de tokens en raisonnement interne ;\n",
+    "- un **SDA Python retiré** : la voie officielle Python est le service HTTP — pour un\n",
+    "  pipeline embarqué en processus, il faut le jumeau .NET ([06](06-KernelMemory-InProcess.ipynb)).\n",
+    "\n",
+    "**Fil de la série :** l'infrastructure vectorielle (01, 05, 05b) → la couche d'abstraction\n",
+    "in-process .NET (06) → ce quickstart service/Python. Les notebooks suivants mesurent le\n",
+    "**hybrid search** et l'ingestion multimodale — les deux promesses de KM que ce notebook\n",
+    "n'a fait qu'entrevoir. Pour le versant « application », la série\n",
+    "[SemanticKernel](../SemanticKernel/05-SemanticKernel-VectorStores.ipynb) montre les agents\n",
+    "qui consomment ces mémoires ; Kernel Memory s'y insère comme alternative clef en main aux\n",
+    "vector stores manipulés directement.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ceb93e68",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T06:42:42.365132Z",
+     "iopub.status.busy": "2026-08-29T06:42:42.365132Z",
+     "iopub.status.idle": "2026-08-29T06:42:42.368789Z",
+     "shell.execute_reply": "2026-08-29T06:42:42.368789Z"
+    },
+    "papermill": {
+     "duration": 0.010651,
+     "end_time": "2026-08-29T06:42:42.369793",
+     "exception": false,
+     "start_time": "2026-08-29T06:42:42.359142",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Toutes les sorties de ce notebook proviennent d'une execution reelle :\n",
+      "  - service Kernel Memory (kernelmemory/service, conteneur Docker local, port 9001)\n",
+      "  - Qdrant local (conteneur Docker, port 6333, patron du notebook 05b)\n",
+      "  - embeddings via endpoint OpenAI-compatible (cle chargee depuis .env, jamais affichee)\n",
+      "  - 25 documents ingeres, gold-set de 8 questions evalue, service redemarre a chaud\n",
+      "  - infrastructure demontee en fin de notebook (conteneurs et volumes supprimes)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule finale : etat d'execution (patron 05b)\n",
+    "if INFRA_OK:\n",
+    "    print(\"Toutes les sorties de ce notebook proviennent d'une execution reelle :\")\n",
+    "    print(\"  - service Kernel Memory (kernelmemory/service, conteneur Docker local, port 9001)\")\n",
+    "    print(\"  - Qdrant local (conteneur Docker, port 6333, patron du notebook 05b)\")\n",
+    "    print(\"  - embeddings via endpoint OpenAI-compatible (cle chargee depuis .env, jamais affichee)\")\n",
+    "    print(f\"  - {len(uploaded)} documents ingeres, gold-set de {len(GOLD)} questions evalue, service redemarre a chaud\")\n",
+    "    print(\"  - infrastructure demontee en fin de notebook (conteneurs et volumes supprimes)\")\n",
+    "else:\n",
+    "    print(\"MODE DEGRADE : infra incomplete (Docker indisponible, service KM non lance ou cles absentes).\")\n",
+    "    print(\"Les cellules ont ete sautees proprement (garde INFRA_OK), aucune sortie n'a ete fabriquee.\")\n",
+    "    print(\"Pour l'execution complete : Docker Desktop actif + .env de la serie GenAI (cf. .env.example).\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 32.565192,
+   "end_time": "2026-08-29T06:42:42.610976",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/07-KernelMemory-Python-Quickstart.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/07-KernelMemory-Python-Quickstart.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-29T06:42:10.045784",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/README.md
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/README.md
@@ -25,7 +25,7 @@ Un assistant de codage sans mémoire externe ré-explore le même terrain à cha
 
 - **Opérateurs d'agents** qui veulent comprendre comment leurs outils sont *ancrés* dans un historique vérifié.
 - **Curieux d'infrastructure ML / vectorielle** qui cherchent un récit honnête de mise en production (Docker, WSL2, quantization, anti-split-brain).
-- **Lecteurs des notebooks pratiques** `01-Hands-On-Grounding.ipynb` (le contexte de l'infrastructure avant de manipuler Qdrant), `02-Retrieval-Avance.ipynb` (mesurer HyDE et le reranking sur un gold français), `03-Embeddings-From-Scratch.ipynb` (ce qu'un embedding *est*, avant de s'en servir), `04-Tokenisation-From-Scratch.ipynb` (ce qu'un token *est*, l'unité de compte que tout le dépôt consomme), `05-Stockage-Vectoriel.ipynb` (la persistance sur disque et le compromis exact/ANN quand le corpus ne tient plus en RAM), `05b-Stockage-Vectoriel-Serveur.ipynb` (le même compromis sur un serveur Qdrant réel) et `06-KernelMemory-InProcess.ipynb` (la couche d'abstraction Kernel Memory par-dessus l'infrastructure).
+- **Lecteurs des notebooks pratiques** `01-Hands-On-Grounding.ipynb` (le contexte de l'infrastructure avant de manipuler Qdrant), `02-Retrieval-Avance.ipynb` (mesurer HyDE et le reranking sur un gold français), `03-Embeddings-From-Scratch.ipynb` (ce qu'un embedding *est*, avant de s'en servir), `04-Tokenisation-From-Scratch.ipynb` (ce qu'un token *est*, l'unité de compte que tout le dépôt consomme), `05-Stockage-Vectoriel.ipynb` (la persistance sur disque et le compromis exact/ANN quand le corpus ne tient plus en RAM), `05b-Stockage-Vectoriel-Serveur.ipynb` (le même compromis sur un serveur Qdrant réel) et `06-KernelMemory-InProcess.ipynb` (la couche d'abstraction Kernel Memory par-dessus l'infrastructure), `07-KernelMemory-Python-Quickstart.ipynb` (le jumeau Python en mode service : ingestion HTTP, citations, mesure).
 - **Personnes ayant vécu un incident** (perte de données, dérive de montage disque, sauvegardes à moitié câblées) et cherchant des leçons partageables.
 
 ## Objectifs d'apprentissage
@@ -39,7 +39,7 @@ Un assistant de codage sans mémoire externe ré-explore le même terrain à cha
 
 ## Notebooks et documents
 
-Cette section contient **sept notebooks** (Qdrant en mémoire, retrieval avancé mesuré, embeddings from scratch, tokenisation BPE à la main, stockage vectoriel persistant et son variant serveur, et la couche d'abstraction Kernel Memory) et **quatre documents** de cadrage :
+Cette section contient **huit notebooks** (Qdrant en mémoire, retrieval avancé mesuré, embeddings from scratch, tokenisation BPE à la main, stockage vectoriel persistant et son variant serveur, et la couche d'abstraction Kernel Memory en .NET in-process comme en service Python) et **quatre documents** de cadrage :
 
 | Support | Type | Vous y trouverez |
 |---------|------|------------------|
@@ -50,6 +50,7 @@ Cette section contient **sept notebooks** (Qdrant en mémoire, retrieval avancé
 | [`05-Stockage-Vectoriel.ipynb`](05-Stockage-Vectoriel.ipynb) | Notebook pratique | Persistance sur disque (Qdrant), HNSW déplié à la main, et le compromis rappel-exact vs ANN mesuré — zéro conteneur |
 | [`05b-Stockage-Vectoriel-Serveur.ipynb`](05b-Stockage-Vectoriel-Serveur.ipynb) | Notebook pratique | Le compromis ef exact/ANN sur un serveur Qdrant réel, 10k vecteurs |
 | [`06-KernelMemory-InProcess.ipynb`](06-KernelMemory-InProcess.ipynb) | Notebook pratique (.NET 9) | La couche d'abstraction Kernel Memory in-process : ETL documentaire, partitionnement en paragraphes, recherche avec citations, et le compromis granularité/rappel mesuré — embeddings locaux via LLamaSharp (GGUF `granite-embedding` CPU), zéro service |
+| [`07-KernelMemory-Python-Quickstart.ipynb`](07-KernelMemory-Python-Quickstart.ipynb) | Notebook pratique (Python) | Le jumeau Python du 06, en mode service : le service web Kernel Memory (Docker `kernelmemory/service`) piloté en HTTP depuis Python — ingestion d'un corpus hétérogène (22 textes français + PDF réel du dépôt + code source), recherche par similarité avec citations, inspection de ce que KM écrit dans Qdrant, `/ask` sourcé, gold-set français mesuré, épreuve de persistance par redémarrage |
 | [`01-Pourquoi-Memoire-Semantique.md`](docs/01-Pourquoi-Memoire-Semantique.md) | Document de cadrage | Le besoin : grounding, SDDD, RAG |
 | [`02-Infrastructure-Qdrant.md`](docs/02-Infrastructure-Qdrant.md) | Document de déploiement | Docker, WSL2, quantization, anti-split-brain |
 | [`03-Utilisation-MCP-Indexation.md`](docs/03-Utilisation-MCP-Indexation.md) | Document d'usage | Brancher un agent via MCP, indexer, rechercher |
@@ -131,6 +132,8 @@ RAG-et-Memoire-Semantique/
 ├── 03-Embeddings-From-Scratch.ipynb       # Notebook pratique — word2vec from scratch + pont transformer
 ├── 04-Tokenisation-From-Scratch.ipynb     # Notebook pratique — BPE from scratch + coût du choix de tokenizer
 ├── 05-Stockage-Vectoriel.ipynb            # Notebook pratique — persistance + HNSW + compromis exact/ANN
+├── 06-KernelMemory-InProcess.ipynb        # Notebook pratique (.NET 9) — Kernel Memory in-process, LLamaSharp CPU
+├── 07-KernelMemory-Python-Quickstart.ipynb # Notebook pratique (Python) — service KM en HTTP, corpus hétérogène, citations
 ├── docs/
 │   ├── 01-Pourquoi-Memoire-Semantique.md  # Le besoin : grounding, SDDD, RAG
 │   ├── 02-Infrastructure-Qdrant.md        # Le déploiement : Docker, WSL2, quantization
@@ -185,10 +188,10 @@ R : La mémoire sémantique est *indexée par le sens* (embeddings + recherche v
 
 ## Conclusion / Prochaines étapes
 
-`RAG-et-Memoire-Semantique` est une section modeste en volume (7 notebooks + 4 documents) mais dense en leçons opérationnelles : chaque incident documenté a renforcé une règle de durcissement (disque dédié, sauvegardes testées, anti-split-brain). Pour aller plus loin :
+`RAG-et-Memoire-Semantique` est une section modeste en volume (8 notebooks + 4 documents) mais dense en leçons opérationnelles : chaque incident documenté a renforcé une règle de durcissement (disque dédié, sauvegardes testées, anti-split-brain). Pour aller plus loin :
 
 - **Lire les incidents.** Le document [04 - Incidents et leçons](docs/04-Incidents-et-Lecons.md) est la matière pédagogique la plus utile de cette section — il documente des pannes *réelles* et leurs *solutions*.
-- **Faire tourner les notebooks.** [`01-Hands-On-Grounding.ipynb`](01-Hands-On-Grounding.ipynb) fonctionne en mémoire, sans Docker, en quelques minutes ; [`02-Retrieval-Avance.ipynb`](02-Retrieval-Avance.ipynb) mesure réellement HyDE et un cross-encoder multilingue sur CPU ; [`03-Embeddings-From-Scratch.ipynb`](03-Embeddings-From-Scratch.ipynb) construit un word2vec en NumPy, puis le compare à un transformer contextuel ; [`04-Tokenisation-From-Scratch.ipynb`](04-Tokenisation-From-Scratch.ipynb) construit un BPE à la main et mesure le coût du choix de tokenizer ; [`05-Stockage-Vectoriel.ipynb`](05-Stockage-Vectoriel.ipynb) déplie un HNSW à la main et mesure le compromis rappel-exact vs ANN ; [`05b-Stockage-Vectoriel-Serveur.ipynb`](05b-Stockage-Vectoriel-Serveur.ipynb) rejoue le compromis sur un serveur Qdrant réel ; [`06-KernelMemory-InProcess.ipynb`](06-KernelMemory-InProcess.ipynb) (.NET 9, modèle GGUF d'embeddings mis en cache, inférence llama.cpp CPU) délègue le pipeline à Kernel Memory et mesure le compromis granularité/rappel — sans service ni conteneur.
+- **Faire tourner les notebooks.** [`01-Hands-On-Grounding.ipynb`](01-Hands-On-Grounding.ipynb) fonctionne en mémoire, sans Docker, en quelques minutes ; [`02-Retrieval-Avance.ipynb`](02-Retrieval-Avance.ipynb) mesure réellement HyDE et un cross-encoder multilingue sur CPU ; [`03-Embeddings-From-Scratch.ipynb`](03-Embeddings-From-Scratch.ipynb) construit un word2vec en NumPy, puis le compare à un transformer contextuel ; [`04-Tokenisation-From-Scratch.ipynb`](04-Tokenisation-From-Scratch.ipynb) construit un BPE à la main et mesure le coût du choix de tokenizer ; [`05-Stockage-Vectoriel.ipynb`](05-Stockage-Vectoriel.ipynb) déplie un HNSW à la main et mesure le compromis rappel-exact vs ANN ; [`05b-Stockage-Vectoriel-Serveur.ipynb`](05b-Stockage-Vectoriel-Serveur.ipynb) rejoue le compromis sur un serveur Qdrant réel ; [`06-KernelMemory-InProcess.ipynb`](06-KernelMemory-InProcess.ipynb) (.NET 9, modèle GGUF d'embeddings mis en cache, inférence llama.cpp CPU) délègue le pipeline à Kernel Memory et mesure le compromis granularité/rappel — sans service ni conteneur ; [`07-KernelMemory-Python-Quickstart.ipynb`](07-KernelMemory-Python-Quickstart.ipynb) en est le jumeau Python en mode service : le conteneur `kernelmemory/service` piloté en HTTP, ingestion d'un corpus hétérogène (textes français, PDF réel, code source), citations, réponse sourcée et épreuve de persistance.
 - **Brancher un agent.** Le document [03 - Utilisation et indexation](docs/03-Utilisation-MCP-Indexation.md) montre comment relier Claude Code ou Roo Code à Qdrant via MCP.
 
 Pour le versant *application* du RAG (pas infrastructure), voir les notebooks [`5_RAG_Modern.ipynb`](../Texte/5_RAG_Modern.ipynb) et [`14_Persistent_Memory.ipynb`](../Texte/14_Persistent_Memory.ipynb) de la section Texte.
@@ -202,6 +205,9 @@ Pour le versant *application* du RAG (pas infrastructure), voir les notebooks [`
 - [Notebook pratique — Embeddings from scratch](03-Embeddings-From-Scratch.ipynb)
 - [Notebook pratique — Tokenisation from scratch](04-Tokenisation-From-Scratch.ipynb)
 - [Notebook pratique — Stockage vectoriel](05-Stockage-Vectoriel.ipynb)
+- [Notebook pratique — Stockage vectoriel, serveur](05b-Stockage-Vectoriel-Serveur.ipynb)
+- [Notebook pratique — Kernel Memory in-process (.NET 9)](06-KernelMemory-InProcess.ipynb)
+- [Notebook pratique — Kernel Memory Python, mode service](07-KernelMemory-Python-Quickstart.ipynb)
 - [Pourquoi la mémoire sémantique](docs/01-Pourquoi-Memoire-Semantique.md)
 - [Infrastructure Qdrant](docs/02-Infrastructure-Qdrant.md)
 - [Utilisation et indexation](docs/03-Utilisation-MCP-Indexation.md)
@@ -226,6 +232,7 @@ Pour le versant *application* du RAG (pas infrastructure), voir les notebooks [`
 | [Notebook — Stockage vectoriel](05-Stockage-Vectoriel.ipynb) | Persister sur disque, déplier un HNSW à la main, mesurer le compromis rappel-exact vs ANN | Pratique |
 | [Notebook — Stockage vectoriel, serveur](05b-Stockage-Vectoriel-Serveur.ipynb) | Rejouer le compromis ef exact/ANN sur un serveur Qdrant réel, 10k vecteurs | Pratique |
 | [Notebook — Kernel Memory in-process](06-KernelMemory-InProcess.ipynb) | Déléguer ETL, partitionnement et citations à Kernel Memory (.NET 9), mesurer la granularité contre le rappel | Pratique |
+| [Notebook — Kernel Memory Python, mode service](07-KernelMemory-Python-Quickstart.ipynb) | Piloter le service web Kernel Memory en HTTP depuis Python : corpus hétérogène, citations, pont Qdrant, réponse sourcée, gold-set mesuré | Pratique |
 
 ---
 


### PR DESCRIPTION
Grain: MED/notebook-genai-python -- lane myia-po-2026:CoursIA -- prev: DEEP/research-notebook-python #13310

See #13421 (contribution à l'EPIC Kernel Memory : avec #13447 [.NET in-process, mergée] cela fait 2 des 2-3 notebooks visés ; hybrid-search et multimodal restent des tranches futures)

## Livrable

`07-KernelMemory-Python-Quickstart.ipynb` (RAG-et-Memoire-Semantique, 40 cellules : 15 code / 25 markdown) — **jumeau Python du 06** en **mode service** : le conteneur `kernelmemory/service` piloté en HTTP depuis Python. 2 fichiers (notebook + README).

**Renumérotation 06→07 consignée** : PR #13447 (mergée 2026-08-29 03:52Z) a livré `06-KernelMemory-InProcess.ipynb` (.NET 9/LLamaSharp) entre le claim et la livraison ; le Quickstart Python passe en 07 et se positionne explicitement comme le jumeau Python du 06 (in-process .NET ↔ service Python). Complémentaire, pas duplicata.

## Contenu mesuré (sorties réelles, vérifiées firsthand à l'intégration)

- Ingestion corpus hétérogène : 22 textes français + **PDF réel du dépôt (43 pages)** + code source → **25/25 uploads HTTP 202**
- Recherche par similarité avec **citations et scores** (top-1 = 0.637 sur la bonne cible)
- **Inspection de ce que KM écrit dans Qdrant** : scroll des 34 points, tags de provenance KM (`__document_id`, `__file_part`…)
- Réponse **`/ask` sourcée** (4 documents cités, gemini-3.7-flash via OpenRouter)
- **Gold-set français mesuré : 8 questions, recall@3 = 1.00** (toutes rang 1) + graphique matplotlib
- **Épreuve de persistance** : redémarrage du service KM à chaud → 34 points conservés, recherche fonctionnelle sans ré-ingestion
- Nettoyage complet (conteneurs/volumes/corpus supprimés, vérifié 0 restant)
- 3 exercices stubbés répartis (HyDE-lite, filtre par tags, MRR@5+abstention), chacun précédé d'un markdown contexte/objectif/indices

## Preuve d'exécution (C.2, H.1)

```
Executing notebook with kernel: python3 … 40/40 [40/40] … exited with code 0
```
- `execution_count` **15/15**, zéro null, zéro erreur (re-vérifié à l'intégration par script)
- C.1 : aucun `raise NotImplementedError` / `assert False` / `1/0` dans les sources code (re-vérifié) ; les 3 stubs suivent le pattern `return None # TODO`
- Scan secrets à l'intégration (sources + outputs, 6 patterns dont `sk-or-v1-`, `sk-`, `eyJ`) : **AUCUN hit**
- Pre-commit : H.3 Passed, gitleaks Passed, papermill-path scrubber Passed (commit d9492ca23)

## SOTA — verdicts par sortie

| Sortie | Verdict |
|---|---|
| Ingestion (service KM officiel, image `kernelmemory/service`) | SOTA-OK |
| Recherche + citations + filtres tags | SOTA-OK |
| `/ask` sourcé | SOTA-OK |
| Payload Qdrant inspecté | SOTA-OK |
| Embeddings (`text-embedding-3-small` via OpenRouter) | SOTA-OK |

**Découverte structurante (règle F, documentée dans le notebook)** : `pip install kernel-memory` est **impossible** — le SDK Python a été retiré du projet Microsoft (dossier `clients/python` vide, absent de PyPI). La voie officielle documentée pour Python est le **service web KM en HTTP** : c'est ce que fait ce notebook. Pas de réimplémentation jouet — c'est le vrai produit Microsoft, dans son mode de déploiement officiel Python.

**Choix Qdrant assumé** : Qdrant distant `qdrant.myia.io` est UP mais la `QDRANT_API_KEY` du `.env` GenAI est **périmée** (401 ; la clé valide vit dans le `.env` du MCP roo-state-manager). Le notebook utilise un **Qdrant Docker local jetable** (patron canonique du 05b) — aucune écriture pédagogique dans les 114 collections de production. **Rotation de clé à router au coordinateur** (signalée sur le dashboard).

## README

+1 ligne tableau, comptes 7→8, arbre, parcours, conclusion, annexes — **répare aussi les omissions de #13447** (entrée 06 absente de l'arbre, liens 05b/06 absents des annexes). Diff +11/−4, cohérent fichier entier (§E).

## Angles morts KM documentés dans le notebook

- `.py` non supporté à l'ingestion (poison de queue silencieuse → workaround annoté `.py.txt`)
- Race delete/upload asynchrone (parade par polling)
- Tags en syntaxe `clé:valeur`