### PR TITLE
feat(m15): quarterly refit + 10y window for cross-asset LSTM (daily data)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_cross_asset_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_cross_asset_lstm.py
@@ -58,7 +58,7 @@ KELLY_CAP = 1.0
 MU_WINDOW = 60
 FEE_BPS = 5  # equity standard (not 50bps crypto)
 N_SPLITS = 5
-REFIT_EVERY = 22
+REFIT_EVERY = 66  # quarterly refit (daily data has more obs than crypto intraday)
 RESULTS_DIR = SCRIPT_DIR / "results" / "m15_cross_asset"
 
 # LSTM hyperparams (same as crypto M15)
@@ -78,10 +78,11 @@ def load_daily_asset(ticker: str) -> pd.Series:
     """Load daily log-returns for a traditional asset via yfinance.
 
     Returns a Series of daily log-returns indexed by Date.
+    Limited to last 10 years for computational feasibility.
     """
     import yfinance as yf
 
-    data = yf.download(ticker, period="max", auto_adjust=True, progress=False)
+    data = yf.download(ticker, period="10y", auto_adjust=True, progress=False)
     if data.empty:
         raise ValueError(f"No data for {ticker}")
     close = data["Close"]


### PR DESCRIPTION
Grain: MED/training -- lane myia-po-2024:CoursIA-2 -- prev: LIGHT/docs #13455

Perimeter: 1 file — `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_cross_asset_lstm.py` (+3/−2).

## What

Two tuning constants in `m15_cross_asset_lstm.py` — rescued from a stash (`recovery/stash-po204-m15-refit-tuning`, its base sat 6081 revisions behind main, redelivered clean off current main):

- **`REFIT_EVERY` 22 → 66** (quarterly): daily cross-asset bars carry far more observations per year than the crypto-intraday M15 the constant was tuned for; walk-forward refit resets to a quarterly cadence.
- yfinance `period="max"` → `"10y"`: bounds download/compute for feasibility without losing regime diversity.

## Scope discipline

The stash also captured workspace noise (notebook `execution_count`, local QuantConnect `organization-id`/`local-id` in `EMA-Cross-Alpha/config.json`) — **deliberately NOT delivered**; only the pipeline script ships. Verified against current main before applying: `REFIT_EVERY = 22` / `period="max"` still live (non-obsolete diff, file untouched since #12278).

## Provenance

Pépite #2 of the po-204 stash campaign (roo-extensions #3147, verdict LIVRER — ai-01 arbitration c.305, deferred during the CI fan-out famine per coordinator directive "pas avant drain"; famine measured drained this cycle: 72→18 pending with fresh starts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
