### PR TITLE
fix(guard,#13440): participes de resultat de controle en incidental + fenetre (s) reparee

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -96,6 +96,11 @@ GENERIC_KNOB = re.compile(r"(?i)(baseline|threshold|ratchet|_cap\b|\bcap\b)")
 
 # Assertion vocabulary: file-count claims and exclusivity markers.
 COUNT_CLAIM = re.compile(r"\b(\d+)\s*(?:fichiers?|files?)\b", re.IGNORECASE)
+# #13440: the boundary `\b` stops the match at "fichier" when the body writes
+# the plural parenthetically ("25 fichier(s) verifies") -- without skipping
+# the "(s)" hump, every downstream tail window (incidental qualifier,
+# negated-diff tail, reference verb) is blind on this form.
+PLURAL_PAREN = re.compile(r"^\s*\(s\)\s*")
 # #11985 rule 1 extension (CLOSED LIST -- never expand to unknown vocabulary):
 # a body can declare its perimeter in words ("trois fichiers", "five files").
 # The authorial declaration is the same shape; we just spell-check the
@@ -456,6 +461,22 @@ INCIDENTAL_QUALIFIERS = frozenset({
     "produites", "sources", "source",
     # #11985 formes 3-4: artifact kinds and scan inventories.
     "audio", "distinct", "distincts", "distinctes", "non-notebook",
+    # #13440 -- participes de RESULTAT DE CONTROLE : ce qu'un controle a
+    # couvert, jamais ce que le diff touche (un claim de perimetre s'ecrit
+    # avec des verbes de modification, qui restent bloquants via
+    # _has_strong_scope et hors liste). Formes mesurees sur main :
+    # "25 fichier(s) verifies sans BOM", "18 fichiers testes sans erreur",
+    # "Controle encodage : 25 fichier(s) conformes".
+    # FN DELIBERE : "restaures"/"restaurés" (campagne accents #2876) et
+    # "re-executes"/"re-exécutés" (tranches MGS) restent HORS liste -- dans
+    # ce depot ces formes SONT des perimetres.
+    "verifies", "vérifiés", "verifie", "vérifié",
+    "testes", "testés", "teste", "testé",
+    "conformes", "conforme",
+    "scannes", "scannés", "scanne", "scanné",
+    "analyses", "analysés", "analyse", "analysé",
+    "audites", "audités", "audite", "audité",
+    "examines", "examinés", "examine", "examiné",
 })
 # A cited threshold ("< 15 fichiers", ">= 10 fichiers") quotes a rule, it does
 # not claim a perimeter.
@@ -638,7 +659,7 @@ def _count_is_exempt(line: str, m: re.Match, ante_context: str = "") -> bool:
         return True
     if LOCATIVE_PREP.search(line):
         return True
-    after = line[m.end():]
+    after = PLURAL_PAREN.sub(" ", line[m.end():], count=1)
     if NEGATED_DIFF_TAIL.match(after):
         return True
     if HIT_ANTECEDENT.search(line[: m.start()]):

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -18,6 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from check_pr_perimeter import (  # noqa: E402
     BaselineMove,
     Candidate,
+    COUNT_CLAIM,
     check_assertion,
     extract_baseline_moves,
     extract_perimeter_assertions,
@@ -27,6 +28,7 @@ from check_pr_perimeter import (  # noqa: E402
     select_candidates,
     _additive_line_sum,
     _check_unterminated_fence,
+    _count_is_exempt,
     _count_is_incidental,
     _fence_line_indices,
     _is_incidental_assertion,
@@ -2389,3 +2391,81 @@ def test_normalize_rest_files_keeps_full_page_count_13357():
     assert len(out) == 148
     assert out[0] == {"path": "file_000.py", "additions": 1, "deletions": 0}
     assert out[-1]["path"] == "file_147.py"
+
+
+# ---------------------------------------------------------------------------
+# #13440 — comptes de résultat de vérification sans antécédent d'outil.
+# Une PR qui documente ses contrôles qualité sur un corpus plus large que son
+# diff (« 25 fichier(s) vérifiés sans BOM ») ne fait AUCUNE assertion de
+# périmètre : la confrontation d'égalité ne peut jamais VALIDER ces formes,
+# donc les bloquer ne protège rien (asymétrie fondatrice #11712/#11985).
+# FN délibéré : « restaurés » (#2876) et « re-exécutés » (tranches MGS) sont
+# des périmètres dans ce dépôt et restent hors liste.
+# ---------------------------------------------------------------------------
+VERIFICATION_COUNT_BODIES_13440 = [
+    "## Vérifications\n"
+    "- 25 fichier(s) vérifiés sans BOM\n"
+    "- 18 fichiers testés sans erreur",
+    "## Résultats\n"
+    "- Contrôle encodage : 25 fichier(s) conformes",
+    "- 40 fichiers scannés par le garde hygiène\n",
+]
+
+PERIMETER_COUNT_BODIES_13440 = [
+    # Campagne accents #2876 : forme identifiée comme périmètre.
+    "- 18 fichiers avec accents restaurés",
+    # Tranches MGS : les re-exécutions SONT le livrable.
+    "- 13 fichiers re-exécutés",
+    "- 13 fichiers re-exécutés avec Papermill",
+    # Verbe de modification : périmètre authentique (contrôle FN de l'issue).
+    "- 13 fichiers touchés uniquement, aucune autre modification.",
+]
+
+
+def test_13440_verification_counts_are_incidental():
+    """Les formes résiduelles mesurées de l'issue deviennent incidental."""
+    for body in VERIFICATION_COUNT_BODIES_13440:
+        pairs = extract_perimeter_assertions_with_context(body)
+        assert pairs, f"aucune ligne candidate pour {body!r}"
+        for line, ctx in pairs:
+            assert _is_incidental_assertion(line, ctx) is True, (
+                f"compte de vérification doit être incidental : {line!r}"
+            )
+
+
+def test_13440_fn_perimeter_forms_stay_blocking():
+    """restaurés / re-exécutés / touchés restent des assertions bloquantes."""
+    for body in PERIMETER_COUNT_BODIES_13440:
+        pairs = extract_perimeter_assertions_with_context(body)
+        assert pairs, f"aucune ligne candidate pour {body!r}"
+        for line, ctx in pairs:
+            assert _is_incidental_assertion(line, ctx) is False, (
+                f"forme périmètre ne doit pas être incidental : {line!r}"
+            )
+
+
+def test_13440_plural_paren_window_no_longer_blind():
+    """Le pluriel parenthétique « fichier(s) » ne doit plus aveugler la fenêtre
+    de qualificatif : CountClaim s'arrête à « fichier » (\b), le « (s) » doit
+    être sauté pour lire le mot qui suit."""
+    # Négated-diff après (s) : l'exemption préexistante doit fonctionner.
+    assert _count_is_incidental("- 25 fichier(s) inchanges apres rebase") is True
+    # Qualificatif incidental après (s) : la nouvelle classe s'applique.
+    assert _count_is_incidental("- 25 fichier(s) vérifiés sans BOM") is True
+    # Un (s) seul ne qualifie rien : la ligne sans qualificatif reste auteur.
+    assert _count_is_incidental("- 25 fichier(s)") is False
+
+
+def test_13440_founder_negated_diff_still_exempt():
+    """Contrôle non-régression : le fondateur #11775 (« 91 fichiers inchanges
+    sur 2 touches ») — la ligne porte « scope » (strong scope word) donc
+    n'est PAS incidental au niveau ligne ; sa protection réelle est
+    l'exemption PAR-COMPTE (negated-diff pour 91, locative pour 2), que la
+    normalisation (s) ne doit pas altérer."""
+    line = "- 91 fichiers inchanges sur 2 touches -- scope delta confirme"
+    matches = list(COUNT_CLAIM.finditer(line))
+    assert matches, "le fondateur doit porter des comptes"
+    for m in matches:
+        assert _count_is_exempt(line, m) is True, (
+            f"le compte fondateur doit rester exempt : {m.group(0)!r}"
+        )


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2023:CoursIA-2 -- prev: LIGHT/docs #13461

## Summary

Résout #13440 (classe résiduelle du perimeter-review-guard, directive ai-01 « à porter en issue plutôt qu'en contournement répété ») : les comptes de **résultat de vérification** sans antécédent d'outil restaient bloquants alors qu'ils n'émettent AUCUNE assertion de périmètre — la confrontation d'égalité ne peut jamais les VALIDER (asymétrie fondatrice #11712/#11985), donc les bloquer ne protège rien.

## Deux corrections (fichier : `scripts/check_pr_perimeter.py`, 2 fichiers modifiés)

**1. `INCIDENTAL_QUALIFIERS` étendu** par les participes de résultat de contrôle : `verifies/vérifiés, testes/testés, conformes, scannes/scannés, analyses/analysés, audites/audités, examines/examinés` (+ singuliers). Ils dénotent ce qu'un CONTRÔLE a couvert, jamais ce que le diff touche — un claim de périmètre s'écrit avec des verbes de modification, qui restent bloquants via `_has_strong_scope` et hors liste.

**FN délibéré (doctrine du fichier : unknown qualifiers stay authorial, fail loud)** :
- `restaurés` (campagne accents #2876) et `re-exécutés` (tranches MGS) restent **hors liste** — dans ce dépôt ces formes SONT des périmètres ;
- extension de `MEASUREMENT_ANTECEDENT` par noms de section (`## Vérifications`, `## Résultats`) **rejetée** : un vrai claim « 13 fichiers touchés uniquement » sous un titre de section deviendrait incidental (FN sur un claim authentique).

**2. `PLURAL_PAREN` (défaut découvert en reproduisant)** : la frontière `\b` de `COUNT_CLAIM` arrête le match à « fichier » quand le pluriel est parenthétique — « 25 fichier(s) vérifiés » laissait le « (s) » aveugler TOUTES les fenêtres aval (qualificatif incidental, negated-diff, verbe de référence). La normalisation saute le « (s) » et rend un espace. Bonus : l'exemption negated-diff préexistante fonctionne à nouveau sur cette forme (« 25 fichier(s) inchangés »).

## Reproduction (avant correction, sur `origin/main` 9e03b82e3c)

Via le chemin réel du garde (`extract_perimeter_assertions_with_context` + `_is_incidental_assertion`), celui du diagnostic de l'issue :

| ligne | avant | après |
|---|---|---|
| `- 25 fichier(s) vérifiés sans BOM` | incidental=**False** (BLOQUE) | incidental=**True** |
| `- 18 fichiers testés sans erreur` | False (BLOQUE) | **True** |
| `- Contrôle encodage : 25 fichier(s) conformes` | False (BLOQUE) | **True** |
| `- 18 fichiers avec accents restaurés` | False (bloquant) | **False** (inchangé, FN gardé) |
| `- 13 fichiers re-exécutés` | False (bloquant) | **False** (inchangé, FN gardé) |
| `- 13 fichiers touchés uniquement` | False (bloquant) | **False** (inchangé, FN gardé) |

## Preuves

- 19/19 cas de la table de vérification OK (positifs + gardes FN + fondateur #11775 « 91 fichiers inchangés sur 2 touches » dont l'exemption par-compte est préservée) ;
- `pytest scripts/tests/test_check_pr_perimeter.py` → **136 passed** (132 existants + 4 nouveaux : positifs issue, gardes FN, fenêtre `(s)`, non-régression fondateur) ;
- diff : 2 fichiers, +102/−1, aucun test existant modifié (imports étendus uniquement).

Closes #13440 — See #13404 (diagnostic initial), #11268 (garde fondateur), #11712/#11985 (architecture incidentals).
