### PR TITLE
feat(train): --device flag on train_mamba + train_patchtst

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
@@ -661,6 +661,7 @@ def main():
         "--indicators", nargs="+", default=None,
         help="Specific indicators to use (overrides --advanced)",
     )
+    parser.add_argument("--device", default=None, help="Force device (cpu/cuda)")
     args = parser.parse_args()
 
     # Seeds
@@ -669,7 +670,10 @@ def main():
     torch.manual_seed(seeds[0])
 
     # Device
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if args.device:
+        device = args.device
+    else:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
 
     # Load data
     if args.dry_run:

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
@@ -386,6 +386,7 @@ def main():
         "--seeds", type=str, default=None,
         help="Comma-separated seeds for multi-seed evaluation (e.g. 0,1,7,42)",
     )
+    parser.add_argument("--device", default=None, help="Force device (cpu/cuda)")
 
     # Splitting
     parser.add_argument("--train-ratio", type=float, default=0.7)
@@ -415,6 +416,7 @@ def main():
         "--indicators", nargs="+", default=None,
         help="Specific indicators to use (overrides --advanced)",
     )
+    parser.add_argument("--device", default=None, help="Force device (cpu/cuda)")
     args = parser.parse_args()
 
     # Seeds
@@ -425,7 +427,10 @@ def main():
     try:
         import torch
         torch.manual_seed(seeds[0])
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        if args.device:
+            device = args.device
+        else:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
     except ImportError:
         print("ERROR: PyTorch not installed. Run: pip install torch", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2024:CoursIA-2 -- prev: MED/training #13462

Perimeter: 2 files — `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py`, `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py` (+11/−2).

## Summary
- Adds `--device` (cpu/cuda) argparse flag to both training scripts, overriding the `torch.cuda.is_available()` default when set.
- Use case: hosts where CUDA detection lies (WSL, broken drivers), or pinning CPU for reproducible benchmarks.
- Salvaged from stash `6f46b5df` (#3147 salvage campaign). Re-based over the multi-seed refactor: the stash's `torch.manual_seed(args.seed)` was stale — main now seeds with `seeds[0]`; only the device block is grafted.

## Test plan
- [x] `python -m py_compile` passes on both files
- [x] No conflict markers remain; diff scope = 2 files, +11/−2
- [ ] CI: ML Pipeline Tests (CPU) — scripts must import/parse cleanly

Companion to #13462 (m15 quarterly refit) — second pépite from the po-204 stash campaign, staged after observing m15's CI absorption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
