### PR TITLE
feat(guard,#13420): le picker ADMET au lieu de seulement classer — dwell 24 h + zone sans remède

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -142,6 +142,7 @@ REPO = "jsboige/CoursIA"
 from series_saturation import (  # noqa: E402
     CONSOLIDATION,
     EXPANSION,
+    NEUTRAL,
     SERIES_SCALE_DEFAULT,
     cited_issues,
     fetch_series_visits,
@@ -340,8 +341,22 @@ DWELL_HOURS_DEFAULT = 24.0
 # Une issue portant l'une de ces etiquettes se consomme sans delai : le
 # dwell existe pour empecher l'emballement d'audit, pas pour retarder un
 # correctif de securite ou une regression qui casse main.
+#
+# Les synonymes FR sont la par PROSPECTIVE, pas par constat : mesure du
+# 2026-08-29, `gh label list` ne rend qu'UNE etiquette de cette famille sur
+# le depot (`security`) -- aucune etiquette FR d'urgence n'existe
+# aujourd'hui. Le concern (review NanoClaw sur #13466) porte donc sur le
+# jour ou quelqu'un en creera une : sur un depot dont les issues sont
+# redigees en francais, `urgence` ou `securite` est la forme qu'on ecrira
+# spontanement, et le bypass echouerait alors en SILENCE -- une issue
+# vraiment urgente retenue 24 h par un garde cense l'exempter. Le cout de
+# la prevention est une ligne ; celui de la detection serait un incident.
 URGENT_LABELS = {"urgent", "blocker", "security", "regression", "p0",
-                 "critical", "hotfix"}
+                 "critical", "hotfix",
+                 # variantes FR (accentuees et nues : les etiquettes
+                 # GitHub acceptent les deux graphies)
+                 "urgence", "bloquant", "securite", "sécurité",
+                 "regression-fr", "régression", "critique"}
 
 # Une zone qui a recu ce nombre de notebooks NEUFS sur la fenetre est saturee.
 ZONE_SATURATION_MIN = 3
@@ -376,11 +391,26 @@ def admissibility(item: dict, balance: dict | None,
         nb = z.get("new_notebooks", 0)
         con = z.get(CONSOLIDATION, 0)
         if nb >= ZONE_SATURATION_MIN and con == 0:
-            return ("ZONE SANS REMEDE : {} a recu {} notebooks neufs sur la "
-                    "fenetre et le vivier ouvert ne contient AUCUN grain de "
-                    "consolidation. Ce grain en ajoute un de plus. Ouvrir ou "
-                    "prendre un grain de consolidation de cette zone d'abord."
-                    .format(fam, nb))
+            msg = ("ZONE SANS REMEDE : {} a recu {} notebooks neufs sur la "
+                   "fenetre et le vivier ouvert ne contient AUCUN grain de "
+                   "consolidation. Ce grain en ajoute un de plus. Ouvrir ou "
+                   "prendre un grain de consolidation de cette zone d'abord."
+                   .format(fam, nb))
+            # Ou le faux positif se cacherait, s'il y en a un : "aucun grain
+            # de consolidation" est une lecture du LEXIQUE de polarite, pas
+            # une lecture des intentions. Un grain NEUTRAL de la meme zone
+            # peut etre une consolidation que le lexique a manquee -- on les
+            # nomme pour que le refus soit refutable sur pieces, au lieu
+            # d'etre a croire sur parole.
+            neutres = (z.get("neutral_issues") or [])[:5]
+            if neutres:
+                msg += (" A verifier avant d'y croire : {} grain(s) NEUTRAL "
+                        "ouvert(s) dans cette zone ({}) -- si l'un d'eux est "
+                        "une consolidation que le lexique a manquee, le "
+                        "remede existe et ce refus est un faux positif."
+                        .format(z.get(NEUTRAL, 0),
+                                ", ".join("#" + str(n) for n in neutres)))
+            return msg
     return None
 
 

--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -12,8 +12,44 @@ ouvrir. Le picker defait la troncature par construction (`--limit 300`, une
 seule requete) et rend la selection *aleatoire ponderee* au lieu de
 *recente-d'abord*.
 
-Il **ne decide pas**. Il tire une poignee de candidats et laisse a l'agent le
-choix final selon les criteres de variete de sa lane courante (G-VAR-1/2/3).
+Il **ne decide pas** du grain. Il tire une poignee de candidats et laisse a
+l'agent le choix final selon les criteres de variete de sa lane (G-VAR-1/2/3).
+Il decide en revanche de ce qui est **admissible** -- voir ci-dessous.
+
+Classer ne suffisait pas : le garde d'admission (mandat user 2026-08-28)
+------------------------------------------------------------------------
+Mesure du 2026-08-29. Le tirage place deja **62 % de sa masse au-dela de 7
+jours** et sous-pondere les issues du jour a **0.39x** : son classement n'est
+pas le defaut. Pourtant, sur les 112 issues travaillees en 48 h, **70 avaient
+moins de 24 h** (63 %), la ou le tirage n'en voulait que 3.9 %. L'ecart de
+**16x** ne s'explique pas par le bruit : le travail n'arrivait pas par le
+tirage. Il arrivait par le **steering** du coordinateur et par l'auto-pick --
+deux chemins qu'aucune ponderation ne touche. Un poids se fait battre par la
+population et par le steer ; seul un **refus** s'applique quel que soit le
+chemin de selection.
+
+D'ou deux causes d'inadmissibilite, verifiables par `--admissible <issue>` et
+appliquees aussi au tirage :
+
+- **dwell** -- une issue de moins de `--dwell-hours` (24 h) n'est pas encore
+  consommable. C'est la reponse directe a "les issues auraient du attendre au
+  lieu d'etre immediatement prises en charge" : un audit qui ouvre quinze
+  issues le matin ne doit pas mobiliser la flotte l'apres-midi. Les etiquettes
+  d'urgence (`urgent`, `security`, `regression`, `hotfix`...) court-circuitent
+  le delai -- le garde vise l'emballement, pas les correctifs.
+- **zone sans remede** -- un grain d'EXPANSION dans une zone qui a recu >= 3
+  notebooks neufs sur la fenetre **et dont le vivier ouvert ne contient aucun
+  grain de consolidation** est refuse. C'est "il ne faut pas se taper le
+  produit cartesien MGS x PythonNet x Mealpy" rendu mecanique.
+
+Le second veto porte sur `con == 0`, **pas** sur la parite stricte
+`con >= exp`, bien que le mandat dise "autant ... que" : la parite se mesure
+sur le vivier OUVERT, et *consommer* un grain de consolidation le ferme -- donc
+le retire du vivier et degrade le ratio. Un veto sur la parite punirait la zone
+precisement quand elle vient de faire ce qu'on lui demandait. La parite reste
+**mesuree et affichee** (verdict `DESEQUILIBRE` / `SANS REMEDE`) parce qu'elle
+vise la **redaction des EPICs** : c'est au coordinateur d'y repondre en ouvrant
+des grains de consolidation, pas au worker d'y buter.
 
 Regime : voie normale, pas filet de secours (mandat user 2026-08-20)
 --------------------------------------------------------------------
@@ -213,6 +249,7 @@ def fetch_pool() -> list[dict]:
             "number": it["number"],
             "title": title,
             "labels": labels,
+            "created_at": it["createdAt"],
             "age": age_days(it["createdAt"]),
             "idle": age_days(it["updatedAt"]),
             "updated_at": it["updatedAt"],
@@ -282,6 +319,80 @@ def fetch_visits(days: int = VISITS_WINDOW_DAYS) -> tuple[dict[int, int], str | 
     return counts, None
 
 
+
+# --- Admission : le tirage CLASSE, ce garde ADMET -------------------------
+# Mesure du 2026-08-29 qui fonde ce garde. Le tirage place deja 62 % de sa
+# masse au-dela de 7 jours et sous-pondere les issues du jour a 0.39x -- son
+# classement n'est PAS le defaut. Mais sur 112 issues travaillees en 48 h,
+# 70 avaient moins de 24 h (63 %), la ou le tirage n'en voulait que 3.9 % :
+# un ecart de 16x, que le bruit d'echantillonnage n'explique pas. Le travail
+# n'arrive donc pas par le tirage -- il arrive par le steering et l'auto-pick,
+# deux chemins qu'aucune ponderation ne touche.
+#
+# D'ou la forme : un GARDE, pas un poids. Un poids se fait battre par la
+# population et par le steer ; un refus s'applique quel que soit le chemin de
+# selection. C'est ce que "revois completement l'organe de pick" demandait --
+# pas de mieux classer, mais de cesser d'etre un simple conseil de classement.
+DWELL_HOURS_DEFAULT = 24.0
+
+# Une issue portant l'une de ces etiquettes se consomme sans delai : le
+# dwell existe pour empecher l'emballement d'audit, pas pour retarder un
+# correctif de securite ou une regression qui casse main.
+URGENT_LABELS = {"urgent", "blocker", "security", "regression", "p0",
+                 "critical", "hotfix"}
+
+# Une zone qui a recu ce nombre de notebooks NEUFS sur la fenetre est saturee.
+ZONE_SATURATION_MIN = 3
+
+
+def _hours_old(created: str) -> float:
+    born = dt.datetime.fromisoformat(created.replace("Z", "+00:00"))
+    return max(0.0, (NOW - born).total_seconds() / 3600.0)
+
+
+def admissibility(item: dict, balance: dict | None,
+                  issue_to_family: dict[int, str] | None,
+                  dwell_hours: float = DWELL_HOURS_DEFAULT) -> str | None:
+    """None = admissible. Sinon la CAUSE du refus, redigee pour etre citee.
+
+    Deux causes, et une seule est un veto dur sur la parite -- voir plus bas
+    pourquoi la parite stricte n'en est pas un.
+    """
+    labels_lc = {str(x).lower() for x in item.get("labels", [])}
+    if not (labels_lc & URGENT_LABELS):
+        h = _hours_old(item.get("created_at") or NOW.isoformat())
+        if h < dwell_hours:
+            return ("DWELL : creee il y a {:.0f} h, seuil {:.0f} h. "
+                    "Une issue d'audit ouverte ce matin n'a pas encore ete "
+                    "confrontee au reste du pool -- c'est ce delai qui "
+                    "distingue depiler d'emballer.".format(h, dwell_hours))
+
+    i2f = issue_to_family or {}
+    fam = i2f.get(item["number"])
+    if fam is None and item.get("parent"):
+        fam = i2f.get(item["parent"])
+    if fam and item.get("polarity") == EXPANSION:
+        z = (balance or {}).get(fam) or {}
+        nb = z.get("new_notebooks", 0)
+        con = z.get(CONSOLIDATION, 0)
+        if nb >= ZONE_SATURATION_MIN and con == 0:
+            return ("ZONE SANS REMEDE : {} a recu {} notebooks neufs sur la "
+                    "fenetre et le vivier ouvert ne contient AUCUN grain de "
+                    "consolidation. Ce grain en ajoute un de plus. Ouvrir ou "
+                    "prendre un grain de consolidation de cette zone d'abord."
+                    .format(fam, nb))
+    return None
+
+
+# Pourquoi le veto porte sur `con == 0` et non sur la parite stricte
+# `con >= exp`, alors que le mandat user dit bien "autant ... que" :
+# la parite stricte se mesure sur le vivier OUVERT, et consommer un grain de
+# consolidation le FERME -- donc le retire du vivier et degrade le ratio.
+# Un veto sur `con >= exp` punirait donc la zone precisement quand elle vient
+# de faire ce qu'on lui demandait. Le veto porte sur le cas non ambigu (aucun
+# remede n'existe) ; la parite graduelle reste MESUREE et affichee
+# (verdict DESEQUILIBRE), parce qu'elle vise la redaction des EPICs -- c'est
+# au coordinateur d'y repondre en ouvrant des grains, pas au worker d'y buter.
 
 def weight(item: dict, prev_genre: str | None,
            visits: dict[int, int] | None = None,
@@ -1172,6 +1283,17 @@ def main(argv: list[str] | None = None) -> int:
                          f"= --red-hours, soit {RED_HOURS_DEFAULT} h). Separe de "
                          "--red-hours pour ne pas confondre les deux causes "
                          "(rouge substance vs file-saturated infra-side).")
+    ap.add_argument("--dwell-hours", type=float, default=DWELL_HOURS_DEFAULT,
+                    help="delai avant qu'une issue neuve soit consommable "
+                         f"(defaut {DWELL_HOURS_DEFAULT:.0f} h ; 0 desactive le garde)")
+    ap.add_argument("--admit-reason", default=None, metavar="TEXTE",
+                    help="passer outre le garde d'admission -- exige une "
+                         "justification ECRITE, a reporter sur l'issue")
+    ap.add_argument("--admissible", type=int, default=None, metavar="ISSUE",
+                    help="mode verdict : cette issue est-elle consommable "
+                         "maintenant ? sortie 0 = oui, 1 = non. A appeler AVANT "
+                         "de dispatcher ou de claim, quel que soit le chemin de "
+                         "selection (steer inclus).")
     ap.add_argument("--ignore-red", action="store_true",
                     help="passer outre le garde -- exige une justification ECRITE sur la PR concernee")
     ap.add_argument("--json", action="store_true", help="sortie machine")
@@ -1184,8 +1306,8 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
     if args.apply_comment is not None and not args.orphans_report:
         ap.error("--apply-comment n'a de sens qu'avec --orphans-report")
-    if not args.lane and not args.orphans_report:
-        ap.error("--lane est requis (seul --orphans-report s'en dispense)")
+    if not args.lane and not args.orphans_report and args.admissible is None:
+        ap.error("--lane est requis (--orphans-report et --admissible s'en dispensent)")
 
     # Mode rapport : le garde rouge (lane) ne concerne pas ce chemin -- la file
     # des orphelines est lane-independante et ce mode ne tire pas de grain.
@@ -1197,6 +1319,34 @@ def main(argv: list[str] | None = None) -> int:
             print()
             print(f"[apply] commentaire marker-guarde mis a jour sur #{args.apply_comment}")
         return 0
+
+    # Mode verdict : lane-independant, pas de tirage, pas de garde rouge --
+    # la question posee est "ce grain-ci est-il consommable maintenant ?",
+    # et elle doit pouvoir etre posee sur un grain STEERE, chemin par lequel
+    # arrive l'essentiel du travail (mesure du 2026-08-29).
+    if args.admissible is not None:
+        pool = fetch_pool()
+        series, issue_to_family, series_err = fetch_series_visits()
+        balance = zone_balance(series, issue_to_family, pool)
+        hit = next((x for x in pool if x["number"] == args.admissible), None)
+        if hit is None:
+            print(f"#{args.admissible} : absente du pool ouvert "
+                  "(fermee, ou au-dela de la limite de la requete).")
+            return 1
+        cause = admissibility(hit, balance, issue_to_family, args.dwell_hours)
+        if series_err:
+            print(f"(saturation de zone NON MESUREE : {series_err} -- "
+                  "le volet parite n'a PAS ete evalue)")
+        print(f"#{hit['number']} {hit['title'][:70]}")
+        print(f"  genre {hit['genre']} | polarite {hit['polarity']} | "
+              f"age {_hours_old(hit['created_at']):.0f} h")
+        if cause is None:
+            print("  ADMISSIBLE")
+            return 0
+        print(f"  REFUS -- {cause}")
+        print("  Passer outre exige --admit-reason '<justification>', "
+              "a reporter sur l'issue.")
+        return 1
 
     # Garde "reparer son rouge d'abord" : AVANT le tirage, sinon le grain neuf
     # est deja sous les yeux quand le refus arrive, et c'est lui qui gagne.
@@ -1217,7 +1367,28 @@ def main(argv: list[str] | None = None) -> int:
         print()
 
     pool = fetch_pool()
-    by_class = {k: [it for it in pool if it["klass"] == k]
+    visits, visits_err = fetch_visits()
+    series, issue_to_family, series_err = fetch_series_visits()
+    balance = zone_balance(series, issue_to_family, pool)
+
+    # Admission AVANT les urnes : un grain inadmissible ne doit pas
+    # apparaitre dans le tirage, sinon il est sous les yeux quand le
+    # refus arrive -- et c'est lui qui gagne (meme raison que le garde
+    # rouge, qui s'execute avant le tirage pour cette raison exacte).
+    # L'urne `delivered` en est exempte : verifier puis fermer une issue
+    # deja livree fait REFLUER le pool, c'est l'inverse de l'emballement.
+    withheld: list[tuple[dict, str]] = []
+    admitted = []
+    for it in pool:
+        if it["klass"] == "delivered":
+            admitted.append(it)
+            continue
+        cause = admissibility(it, balance, issue_to_family, args.dwell_hours)
+        if cause and not args.admit_reason:
+            withheld.append((it, cause))
+        else:
+            admitted.append(it)
+    by_class = {k: [it for it in admitted if it["klass"] == k]
                 for k in ("grain", "umbrella", "delivered")}
 
     # Graine : (lane, heure UTC, reroll). Lanes differentes -> tirages
@@ -1226,10 +1397,6 @@ def main(argv: list[str] | None = None) -> int:
     seed_src = f"{args.lane}|{stamp}|{args.reroll}"
     seed = int(hashlib.sha256(seed_src.encode()).hexdigest()[:16], 16)
     rng = random.Random(seed)
-
-    visits, visits_err = fetch_visits()
-    series, issue_to_family, series_err = fetch_series_visits()
-    balance = zone_balance(series, issue_to_family, pool)
 
     picks = (
         draw(by_class["grain"], args.grains, rng, args.prev_genre, visits,
@@ -1248,6 +1415,10 @@ def main(argv: list[str] | None = None) -> int:
             "lane": args.lane, "seed_src": seed_src,
             "pool": {k: len(v) for k, v in by_class.items()},
             "picks": picks, "claims": {str(k): v for k, v in claims.items()},
+            "withheld": [{"number": it["number"], "title": it["title"],
+                          "cause": c} for it, c in withheld],
+            "dwell_hours": args.dwell_hours,
+            "admit_reason": args.admit_reason,
             "series_measured": series_err is None,
             "series_error": series_err,
             "series_zones": sorted(
@@ -1299,6 +1470,17 @@ def main(argv: list[str] | None = None) -> int:
           f"= {len(by_class['grain'])} grains "
           f"+ {len(by_class['umbrella'])} umbrella "
           f"+ {len(by_class['delivered'])} candidate-delivered")
+    if args.admit_reason:
+        print(f"!! --admit-reason : garde d'admission passe outre "
+              f"({args.admit_reason!r}). A reporter sur l'issue retenue.")
+    elif withheld:
+        dwell_n = sum(1 for _, c in withheld if c.startswith("DWELL"))
+        zone_n = len(withheld) - dwell_n
+        print(f"Retenues hors tirage : {len(withheld)} "
+              f"({dwell_n} en attente de dwell, {zone_n} en zone sans remede). "
+              "Elles reviennent d'elles-memes -- aucune n'est refusee sur le fond.")
+        for it, cause in sorted(withheld, key=lambda kv: -kv[0]["number"])[:3]:
+            print(f"   #{it['number']:<7} {cause.split(chr(58))[0]:<18} {it['title'][:46]}")
     if backlog.get("triggers"):
         numbers = ", ".join(f"#{r['number']}" for r in backlog["red"])
         print(f"!! --ignore-red : {len(backlog['red'])} PR(s) bloquee(s) de cette lane restent "

--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -148,6 +148,7 @@ from series_saturation import (  # noqa: E402
     zone_balance,
     parent_issue,
     polarity,
+    resolve_family,
 )
 
 # Lecteur PARTAGE du tag `Grain:` (#9485). C'est la SEULE ancre qui rattache
@@ -254,6 +255,7 @@ def fetch_pool() -> list[dict]:
             "idle": age_days(it["updatedAt"]),
             "updated_at": it["updatedAt"],
             "genre": infer_genre(title, labels),
+            "body": it.get("body") or "",
             "parent": parent_issue(it.get("body") or ""),
             "polarity": polarity(title, it.get("body") or ""),
             "klass": (
@@ -367,10 +369,8 @@ def admissibility(item: dict, balance: dict | None,
                     "confrontee au reste du pool -- c'est ce delai qui "
                     "distingue depiler d'emballer.".format(h, dwell_hours))
 
-    i2f = issue_to_family or {}
-    fam = i2f.get(item["number"])
-    if fam is None and item.get("parent"):
-        fam = i2f.get(item["parent"])
+    fam = resolve_family(item, issue_to_family or {},
+                         tuple((balance or {}).keys()))
     if fam and item.get("polarity") == EXPANSION:
         z = (balance or {}).get(fam) or {}
         nb = z.get("new_notebooks", 0)
@@ -434,10 +434,7 @@ def weight(item: dict, prev_genre: str | None,
     # FRATRIE sature -- le cas exact des 9 paires de #12373. La remontee par
     # `parent` est indispensable : sans elle l amortissement ne mord que sur
     # les issues DEJA travaillees, donc jamais sur la prochaine instance.
-    i2f = issue_to_family or {}
-    fam = i2f.get(item["number"])
-    if fam is None and item.get("parent"):
-        fam = i2f.get(item["parent"])
+    fam = resolve_family(item, issue_to_family or {}, tuple(series or ()))
     nb_new = 0
     if fam:
         nb_new = ((series or {}).get(fam) or {}).get("new_notebooks", 0)
@@ -476,6 +473,7 @@ def draw(items: list[dict], n: int, rng: random.Random, prev_genre: str | None,
     picked = []
     for _, w, it in keyed[:n]:
         it = dict(it)
+        it.pop("body", None)
         it["weight"] = round(w, 2)
         it.setdefault("visits", 0)
         it.setdefault("family", None)

--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -110,7 +110,7 @@ Usage
     python scripts/pick_idle_grain.py --lane myia-po-2026:CoursIA
     python scripts/pick_idle_grain.py --lane myia-po-2023:CoursIA-2 --prev-genre guard
     python scripts/pick_idle_grain.py --lane <l> --reroll 1        # nouveau tirage
-    python scripts/pick_idle_grain.py --lane <l> --check-claims    # + verif claims
+    python scripts/pick_idle_grain.py --lane <l> --no-check-claims # sans verif claims
     python scripts/pick_idle_grain.py --lane <l> --json            # sortie machine
     python scripts/pick_idle_grain.py --lane <l> --ignore-red      # rouge non reparable
                                                                    # par cette lane, ECRIT sur la PR
@@ -538,6 +538,58 @@ def check_claims(numbers: list[int], lane: str) -> dict[int, str]:
     return verdicts
 
 
+def draw_unclaimed(by_class, args, rng, visits, series, issue_to_family):
+    """Tire, puis REMPLACE tout candidat qu une autre lane tient deja.
+
+    Deux raisons de remplacer plutot que d annoter :
+
+    1. Un candidat annote << BLOQUE par X >> reste un candidat. La lane le
+       lit, juge que son scope differe, et ecrit quand meme -- c est le
+       profil exact des quatre collisions mesurees. Le retirer de la liste
+       ne se discute pas ; un avertissement, si.
+    2. Retirer sans remplacer transformerait le garde en source d idle, ce
+       que la regle 4 de coordinator-discipline interdit. On retire ET on
+       retire un candidat de plus dans la meme urne.
+
+    Le cout est borne : N appels sur les tires (une poignee), jamais sur le
+    pool. C est pourquoi le check pouvait etre par defaut sans etre lent --
+    il etait opt-in par prudence de cout, sur une depense qui n existait pas.
+    """
+    urnes = (("grain", args.grains, args.prev_genre),
+             ("umbrella", args.umbrellas, args.prev_genre),
+             ("delivered", args.delivered, None))
+    picks, claims, conflicts = [], {}, []
+    for cls, want, prev in urnes:
+        pool = list(by_class[cls])
+        got = []
+        # Borne dure : au pire on epuise l urne. Pas de while nu.
+        for _ in range(len(pool) + 1):
+            if len(got) >= want or not pool:
+                break
+            cand = draw(pool, want - len(got), rng, prev, visits,
+                        series, issue_to_family)
+            if not cand:
+                break
+            nums = [c["number"] for c in cand]
+            verdicts = (check_claims(nums, args.lane)
+                        if args.check_claims and args.lane else {})
+            claims.update(verdicts)
+            drawn = {c["number"] for c in cand}
+            pool = [it for it in pool
+                    if it["number"] not in drawn]
+            for c in cand:
+                v = verdicts.get(c["number"], "")
+                if v.startswith("BLOQUE par"):
+                    conflicts.append((c, "CLAIM : " + v + (
+                        ". Une autre lane tient ce grain -- ecrire dessus "
+                        "produirait la collision, pas le livrable. Candidat "
+                        "remplace dans la meme urne.")))
+                else:
+                    got.append(c)
+        picks.extend(got)
+    return picks, claims, conflicts
+
+
 def recent_delivery(picks: list[dict]) -> dict[int, str]:
     """Annote les candidats tires qu'une autre PR couvre deja -- ouverte ou mergee.
 
@@ -568,7 +620,7 @@ def recent_delivery(picks: list[dict]) -> dict[int, str]:
     L'annotation **n'ecarte pas** le candidat (parite avec la doctrine
     ``candidate-delivered`` : signale, ne ferme pas) : elle change ce qu'on
     en dit, pas s'il est pris. Le verrou cross-lane reste
-    ``check_lane_claim.py``, que ``--check-claims`` interroge separement.
+    ``check_lane_claim.py``, que le tirage interroge desormais par defaut.
     """
     notes: dict[int, str] = {}
     for p in picks:
@@ -1270,7 +1322,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--umbrellas", type=int, default=2, help="candidats urne 'umbrella' (defaut 2)")
     ap.add_argument("--delivered", type=int, default=2, help="candidats urne 'delivered' (defaut 2)")
     ap.add_argument("--reroll", type=int, default=0, help="decale la graine pour un nouveau tirage")
-    ap.add_argument("--check-claims", action="store_true", help="verifie les claims sur les tires")
+    ap.add_argument("--no-check-claims", dest="check_claims",
+                    action="store_false",
+                    help="ne pas verifier les claims sur les tires "
+                         "(par defaut : verifie, et remplace les tenus)")
     ap.add_argument("--red-hours", type=float, default=RED_HOURS_DEFAULT,
                     help=f"seuil du garde 'reparer son rouge d'abord' (defaut {RED_HOURS_DEFAULT} h)")
     ap.add_argument("--red-count", type=int, default=RED_COUNT_DEFAULT,
@@ -1301,6 +1356,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--apply-comment", type=int, default=None, metavar="ISSUE",
                     help="avec --orphans-report : upsert du commentaire marker-guarde sur "
                          "l'issue N (defaut : dry-run, impression seule)")
+    ap.set_defaults(check_claims=True)
     args = ap.parse_args(argv)
     if args.apply_comment is not None and not args.orphans_report:
         ap.error("--apply-comment n'a de sens qu'avec --orphans-report")
@@ -1396,16 +1452,19 @@ def main(argv: list[str] | None = None) -> int:
     seed = int(hashlib.sha256(seed_src.encode()).hexdigest()[:16], 16)
     rng = random.Random(seed)
 
-    picks = (
-        draw(by_class["grain"], args.grains, rng, args.prev_genre, visits,
-             series, issue_to_family)
-        + draw(by_class["umbrella"], args.umbrellas, rng, args.prev_genre, visits,
-               series, issue_to_family)
-        + draw(by_class["delivered"], args.delivered, rng, None, visits,
-               series, issue_to_family)
-    )
-
-    claims = check_claims([p["number"] for p in picks], args.lane) if args.check_claims else {}
+    # Le tirage est claim-aware, et le remplacement est ce qui compte.
+    # Mesure du 2026-08-29 : quatre collisions en quatre jours (#13310, et
+    # les trois paires #12948<-#12791, #12984<-#12983, #13016<-#12758,
+    # PRs ouvertes le 25/08 et supersedees le 28/08 par d'autres lanes sur
+    # les MEMES issues). Le gate CI `lane_claim_required` dit lui-meme ce
+    # qu'il ne fait pas : << The gate cannot prevent the collision (once
+    # the PR exists the work is written) >>. Il empeche le MERGE, pas
+    # l'ecriture. La prevention doit donc vivre en amont, ici -- et elle ne
+    # peut pas etre optionnelle : un tirage qui propose une issue tenue par
+    # une autre lane FABRIQUE la collision qu'il faudra arbitrer ensuite.
+    picks, claims, claim_conflicts = draw_unclaimed(
+        by_class, args, rng, visits, series, issue_to_family)
+    withheld.extend(claim_conflicts)
     delivery = recent_delivery(picks)
 
     if args.json:
@@ -1473,10 +1532,23 @@ def main(argv: list[str] | None = None) -> int:
               f"({args.admit_reason!r}). A reporter sur l'issue retenue.")
     elif withheld:
         dwell_n = sum(1 for _, c in withheld if c.startswith("DWELL"))
-        zone_n = len(withheld) - dwell_n
+        claim_n = sum(1 for _, c in withheld if c.startswith("CLAIM"))
+        zone_n = len(withheld) - dwell_n - claim_n
+        # Les trois causes ne se rangent pas ensemble : dwell et zone
+        # reviennent d'elles-memes, un grain tenu par une autre lane revient
+        # quand CETTE lane le relache. Les fondre dans "zone sans remede"
+        # afficherait "elle revient d'elle-meme" sur le seul cas ou c'est faux.
+        parts = [f"{dwell_n} en attente de dwell",
+                 f"{zone_n} en zone sans remede"]
+        if claim_n:
+            parts.append(f"{claim_n} tenue(s) par une autre lane")
         print(f"Retenues hors tirage : {len(withheld)} "
-              f"({dwell_n} en attente de dwell, {zone_n} en zone sans remede). "
-              "Elles reviennent d'elles-memes -- aucune n'est refusee sur le fond.")
+              f"({', '.join(parts)}). "
+              "Dwell et zone reviennent d'elles-memes -- aucune n'est refusee "
+              "sur le fond.")
+        if claim_n:
+            print("   Un grain tenu revient quand sa lane pose [RELEASED], ou "
+                  "sur arbitrage [OVERRIDE] du coordinateur.")
         for it, cause in sorted(withheld, key=lambda kv: -kv[0]["number"])[:3]:
             print(f"   #{it['number']:<7} {cause.split(chr(58))[0]:<18} {it['title'][:46]}")
     if backlog.get("triggers"):

--- a/scripts/series_saturation.py
+++ b/scripts/series_saturation.py
@@ -263,6 +263,63 @@ def polarity(title: str, body: str = "") -> str:
     return NEUTRAL
 
 
+
+def family_from_text(text: str, families) -> str | None:
+    """Zone NOMMEE explicitement dans le texte d'une issue.
+
+    `issue_to_family` est construit par archeologie de PRs mergees : une issue
+    n'y entre que si une PR l'a deja citee. Une issue FRAICHE -- typiquement le
+    grain de consolidation qu'une zone saturee reclame -- n'y est donc jamais,
+    et la zone reste `SANS REMEDE` alors que son remede vient d'etre ouvert.
+    Un garde dont le remede est invisible ne peut pas etre satisfait : mesure
+    du 2026-08-29, #13467 (renumerotation GenAI/Texte, polarite `consolidation`
+    correctement detectee, parent #5081 correctement extrait) ne remontait a
+    aucune zone -- la zone serait restee fermee a l'expansion pour toujours.
+
+    On resout donc aussi par le TEXTE. Le motif est le chemin de famille
+    lui-meme (`MyIA.AI.Notebooks/GenAI/Texte`) ou ses deux derniers segments
+    (`GenAI/Texte`) -- assez specifique pour ne pas confondre la serie avec le
+    mot courant qui lui sert de feuille : `Texte` seul matcherait toute prose
+    francaise, et c'est le faux positif que ce garde doit eviter.
+    """
+    low = (text or "").replace(chr(92), "/").lower()
+    if not low:
+        return None
+    best_fam, best_len = None, 0
+    for fam in families:
+        segs = fam.replace(chr(92), "/").lower().split("/")
+        cands = ["/".join(segs)]
+        if len(segs) >= 2:
+            cands.append("/".join(segs[-2:]))
+        for c in cands:
+            if len(c) > best_len and c in low:
+                best_fam, best_len = fam, len(c)
+    return best_fam
+
+
+def resolve_family(item: dict, issue_to_family: dict, families=()) -> str | None:
+    """Zone d'un grain : par PR citante, sinon par son EPIC parent, sinon par
+    le texte. Les trois sources vont de la plus factuelle (une PR a reellement
+    touche ce chemin) a la plus declarative (l'issue dit son sujet).
+    """
+    fam = (issue_to_family or {}).get(item.get("number"))
+    if fam is None and item.get("parent"):
+        fam = (issue_to_family or {}).get(item["parent"])
+    if fam is None and families:
+        # TITRE d abord, corps ensuite -- meme principe que polarity().
+        # Le corps CITE beaucoup (regles, conventions, precedents) ; le
+        # titre DIT le sujet. Chercher dans un blob unique laisse la plus
+        # longue citation gagner : mesure du 2026-08-29, #13467 (titre
+        # "GenAI/Texte : renumerotation...") se resolvait en `.claude/rules`
+        # parce que son corps citait `.claude/rules/catalog-pr-hygiene.md`
+        # et que cette chaine est plus longue que `genai/texte`. La zone
+        # reelle restait alors SANS REMEDE, remede en main.
+        fam = family_from_text(item.get("title") or "", families)
+        if fam is None:
+            fam = family_from_text(item.get("body") or "", families)
+    return fam
+
+
 def zone_balance(zones: dict, issue_to_family: dict, pool: list) -> dict:
     """Par zone : combien de grains OUVERTS ajoutent, combien consolident.
 
@@ -272,10 +329,9 @@ def zone_balance(zones: dict, issue_to_family: dict, pool: list) -> dict:
     aucun remede.
     """
     out: dict[str, dict] = {}
+    families = tuple(zones or ())
     for it in pool:
-        fam = issue_to_family.get(it.get("number"))
-        if fam is None and it.get("parent"):
-            fam = issue_to_family.get(it["parent"])
+        fam = resolve_family(it, issue_to_family, families)
         if not fam:
             continue
         pol = polarity(it.get("title", ""), it.get("body", "") or "")

--- a/scripts/series_saturation.py
+++ b/scripts/series_saturation.py
@@ -336,8 +336,19 @@ def zone_balance(zones: dict, issue_to_family: dict, pool: list) -> dict:
             continue
         pol = polarity(it.get("title", ""), it.get("body", "") or "")
         slot = out.setdefault(
-            fam, {EXPANSION: 0, CONSOLIDATION: 0, NEUTRAL: 0, "new_notebooks": 0})
+            fam, {EXPANSION: 0, CONSOLIDATION: 0, NEUTRAL: 0,
+                  "new_notebooks": 0, "neutral_issues": []})
         slot[pol] += 1
+        if pol == NEUTRAL and it.get("number"):
+            # #13466 (review NanoClaw, concern 1) : le veto "SANS REMEDE"
+            # herite de la recall du lexique de polarite. Un grain de
+            # consolidation dont le titre echappe au lexique tombe en
+            # NEUTRAL -- le remede existe alors, mais il est INVISIBLE, et
+            # le refus devient un faux positif SILENCIEUX. On retient donc
+            # les numeros pour que le refus puisse les citer : le lecteur
+            # voit ou le faux positif se cacherait, au lieu de devoir
+            # deviner que le lexique a pu manquer quelque chose.
+            slot["neutral_issues"].append(it["number"])
         slot["new_notebooks"] = (zones.get(fam) or {}).get("new_notebooks", 0)
     return out
 

--- a/scripts/tests/test_family_resolution.py
+++ b/scripts/tests/test_family_resolution.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Resolution de la ZONE d'un grain (#13420) : par PR citante, par EPIC parent,
+puis par le texte.
+
+Pourquoi la troisieme source existe : `issue_to_family` est construit par
+archeologie de PRs mergees. Une issue FRAICHE n'y est jamais -- or c'est
+exactement ce qu'est le grain de consolidation qu'une zone saturee reclame.
+Mesure du 2026-08-29 : #13467 (renumerotation GenAI/Texte) ne remontait a
+aucune zone, donc `GenAI/Texte` restait `SANS REMEDE` alors que son remede
+venait d'etre ouvert -- un garde dont le remede est invisible ne peut pas etre
+satisfait, et la zone serait restee fermee a l'expansion pour toujours.
+
+Pourquoi le titre prime sur le corps : c'est le faux positif reel qui a ete
+mesure sur ce meme #13467, et il ne se voyait pas -- la resolution rendait une
+zone plausible, juste pas la bonne.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from series_saturation import family_from_text, resolve_family  # noqa: E402
+
+TEXTE = "MyIA.AI.Notebooks/GenAI/Texte"
+RAG = "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique"
+RULES = ".claude/rules"
+FAMS = (TEXTE, RAG, RULES)
+
+
+def test_titre_prime_sur_le_corps():
+    """Le cas mesure : titre GenAI/Texte, corps citant .claude/rules.
+
+    Cherchees dans un blob unique, `.claude/rules` (13 car.) bat
+    `genai/texte` (11 car.) et la zone reelle reste sans remede.
+    """
+    it = {"number": 13467,
+          "title": "[#5081] GenAI/Texte : renumerotation -- 2 collisions",
+          "body": "Catalogue byte-identique (.claude/rules/catalog-pr-hygiene.md)."}
+    assert resolve_family(it, {}, FAMS) == TEXTE
+
+
+def test_resolution_par_le_corps_si_titre_muet():
+    it = {"number": 1, "title": "renumerotation de la serie",
+          "body": "Concerne MyIA.AI.Notebooks/GenAI/Texte."}
+    assert resolve_family(it, {}, FAMS) == TEXTE
+
+
+def test_mot_courant_ne_matche_pas():
+    """`Texte` seul est un mot francais courant : la feuille ne suffit pas.
+
+    Le motif porte sur deux segments au minimum (`GenAI/Texte`), sinon toute
+    prose mentionnant "un texte" serait rattachee a la serie.
+    """
+    assert family_from_text("ce notebook produit un texte en sortie", FAMS) is None
+    assert family_from_text("regles et conventions du depot", FAMS) is None
+
+
+def test_pr_citante_prime_sur_le_texte():
+    """Une PR a REELLEMENT touche ce chemin : plus factuel qu'une mention."""
+    it = {"number": 42, "title": "GenAI/Texte : quelque chose", "body": ""}
+    assert resolve_family(it, {42: RAG}, FAMS) == RAG
+
+
+def test_parent_prime_sur_le_texte():
+    it = {"number": 43, "parent": 5081, "title": "GenAI/Texte : x", "body": ""}
+    assert resolve_family(it, {5081: RAG}, FAMS) == RAG
+
+
+def test_sans_familles_aucune_invention():
+    """Familles non mesurees = pas de resolution. Un zero d'absence de mesure
+    ne doit pas se lire comme une zone trouvee."""
+    it = {"number": 1, "title": "MyIA.AI.Notebooks/GenAI/Texte", "body": ""}
+    assert resolve_family(it, {}, ()) is None
+
+
+def test_chemin_complet_prefere_au_suffixe():
+    it = {"number": 1, "title": "MyIA.AI.Notebooks/GenAI/Texte : x", "body": ""}
+    assert resolve_family(it, {}, FAMS) == TEXTE
+
+
+def test_antislash_windows_normalise():
+    assert family_from_text(r"MyIA.AI.Notebooks\GenAI\Texte", FAMS) == TEXTE

--- a/scripts/tests/test_pick_admissibility.py
+++ b/scripts/tests/test_pick_admissibility.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Garde d'admission du picker (#13420) : ce qu'il DOIT refuser, et surtout
+ce qu'il ne doit PAS refuser.
+
+Ce garde existe parce que la ponderation ne mordait pas. Mesure du 2026-08-29 :
+le tirage place deja 62 % de sa masse au-dela de 7 jours et sous-pondere les
+issues du jour a 0.39x -- pourtant 70 des 112 issues travaillees en 48 h
+avaient moins de 24 h (63 %, contre 3.9 % de masse au tirage). L'ecart de 16x
+dit que le travail n'arrive pas par le tirage mais par le steering et
+l'auto-pick, deux chemins qu'aucun poids ne touche. D'ou un refus, applicable
+quel que soit le chemin de selection.
+
+Un garde se valide par ses FAUX NEGATIFS -- les formes qu'il doit attraper et
+qu'un jeu de motifs ecrit a la main laisse passer sans jamais lever d'erreur.
+Le cas decisif ici est `test_consolidation_admise_dans_la_zone_saturee` : un
+garde qui refuserait le remede en meme temps que le mal serait exactement le
+defaut que le miroir de polarite avait ete ajoute pour corriger (#12607
+tombait a 0.36x comme les paires qu'il devait solder).
+"""
+
+import datetime as dt
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pick_idle_grain as pick  # noqa: E402
+from series_saturation import CONSOLIDATION, EXPANSION, NEUTRAL  # noqa: E402
+
+ZONE = "Search/Part4-Metaheuristics"
+
+
+def _iso(hours_ago):
+    return (pick.NOW - dt.timedelta(hours=hours_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _item(number=9001, hours=100, labels=None, pol=NEUTRAL, parent=None):
+    return {
+        "number": number,
+        "title": "grain de test",
+        "labels": labels or [],
+        "created_at": _iso(hours),
+        "age": int(hours // 24),
+        "idle": 0,
+        "genre": "notebook-python",
+        "parent": parent,
+        "polarity": pol,
+        "klass": "grain",
+    }
+
+
+def _zone(new_notebooks=5, con=0, exp=3):
+    return {ZONE: {"new_notebooks": new_notebooks, CONSOLIDATION: con,
+                   EXPANSION: exp, NEUTRAL: 0}}
+
+
+# --- dwell ----------------------------------------------------------------
+
+def test_issue_du_jour_refusee():
+    cause = pick.admissibility(_item(hours=2), {}, {})
+    assert cause is not None and cause.startswith("DWELL"), cause
+
+
+def test_issue_agee_admise():
+    assert pick.admissibility(_item(hours=10 * 24), {}, {}) is None
+
+
+def test_seuil_exact_admis():
+    """A l'heure pile le grain passe : le refus est `<`, pas `<=`."""
+    assert pick.admissibility(_item(hours=24.5), {}, {}) is None
+
+
+def test_label_urgent_court_circuite_le_dwell():
+    """Le dwell vise l'emballement d'audit, pas un correctif de securite."""
+    for lb in ("urgent", "security", "regression", "P0", "HOTFIX"):
+        assert pick.admissibility(_item(hours=1, labels=[lb]), {}, {}) is None, lb
+
+
+def test_dwell_zero_desactive_le_garde():
+    assert pick.admissibility(_item(hours=0.1), {}, {}, dwell_hours=0.0) is None
+
+
+# --- parite de zone -------------------------------------------------------
+
+def test_expansion_refusee_en_zone_sans_remede():
+    cause = pick.admissibility(_item(pol=EXPANSION), _zone(), {9001: ZONE})
+    assert cause is not None and cause.startswith("ZONE SANS REMEDE"), cause
+
+
+def test_consolidation_admise_dans_la_zone_saturee():
+    """LE faux negatif qui compte : le remede doit passer la ou le mal bute.
+
+    Refuser #12607 (consolidation MGS) en meme temps que les paires qu'il
+    devait solder rendrait la zone saturee INTRAVAILLABLE -- et le mandat user
+    du 2026-08-28 demande exactement l'inverse : que la zone saturee appelle
+    de la consolidation.
+    """
+    assert pick.admissibility(_item(pol=CONSOLIDATION), _zone(),
+                              {9001: ZONE}) is None
+
+
+def test_expansion_admise_des_qu_un_remede_existe():
+    """Un seul grain de consolidation ouvert leve le veto : le garde porte sur
+    l'ABSENCE de remede, pas sur la parite stricte (qui se degraderait en
+    consommant le remede -- voir le commentaire dans pick_idle_grain.py)."""
+    assert pick.admissibility(_item(pol=EXPANSION), _zone(con=1),
+                              {9001: ZONE}) is None
+
+
+def test_expansion_admise_hors_zone_saturee():
+    assert pick.admissibility(_item(pol=EXPANSION), _zone(new_notebooks=2),
+                              {9001: ZONE}) is None
+
+
+def test_zone_heritee_du_parent():
+    """Un sous-grain ne cite pas la famille : elle vient de son EPIC parent."""
+    it = _item(number=9002, pol=EXPANSION, parent=7777)
+    cause = pick.admissibility(it, _zone(), {7777: ZONE})
+    assert cause is not None and cause.startswith("ZONE SANS REMEDE"), cause
+
+
+def test_zone_non_mesuree_n_invente_pas_de_refus():
+    """balance vide = mesure absente. Un zero d'absence de donnee ne doit pas
+    se lire comme un zero de remede, sinon le garde refuse tout le pool des
+    que `fetch_series_visits` echoue."""
+    assert pick.admissibility(_item(pol=EXPANSION), {}, {9001: ZONE}) is None
+
+
+def test_le_dwell_prime_sur_la_zone():
+    """Ordre des causes : un grain neuf ET en zone sans remede est refuse pour
+    dwell -- la cause la plus reparable en premier."""
+    cause = pick.admissibility(_item(hours=2, pol=EXPANSION), _zone(),
+                               {9001: ZONE})
+    assert cause.startswith("DWELL"), cause

--- a/scripts/tests/test_pick_claim_filter.py
+++ b/scripts/tests/test_pick_claim_filter.py
@@ -1,0 +1,127 @@
+"""Le tirage ne propose jamais un grain qu une autre lane tient (#13310 & al.).
+
+Valide par ses FAUX NEGATIFS : le cas qui compte n est pas << le grain bloque
+est retire >> (facile), c est << un grain de remplacement est bien rendu >>.
+Un garde qui retire sans remplacer fabriquerait de l idle, ce que la regle 4 de
+coordinator-discipline interdit -- et il passerait un test qui ne compte que
+les retraits.
+"""
+import argparse
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pick_idle_grain as pick
+
+
+def _it(n, genre="docs"):
+    return {"number": n, "title": "issue %d" % n, "genre": genre,
+            "age": 30, "idle": 10, "parent": None, "labels": [],
+            "polarity": "neutral", "created_at": "2026-07-01T00:00:00Z",
+            "body": "", "updated": "2026-08-01T00:00:00Z"}
+
+
+def _args(**kw):
+    d = dict(grains=1, umbrellas=0, delivered=0, prev_genre=None,
+             lane="myia-po-2099:CoursIA", check_claims=True)
+    d.update(kw)
+    return argparse.Namespace(**d)
+
+
+def _run(by_class, args, held):
+    """Tire en simulant check_lane_claim : ``held`` = numeros tenus ailleurs."""
+    real = pick.check_claims
+    pick.check_claims = lambda nums, lane: {
+        n: ("BLOQUE par myia-po-2000:CoursIA" if n in held else "libre")
+        for n in nums}
+    try:
+        return pick.draw_unclaimed(by_class, args, random.Random(7),
+                                   None, None, None)
+    finally:
+        pick.check_claims = real
+
+
+EMPTY = {"grain": [], "umbrella": [], "delivered": []}
+
+
+def test_grain_tenu_par_une_autre_lane_est_retire():
+    by = dict(EMPTY, grain=[_it(1)])
+    picks, _, conflicts = _run(by, _args(), held={1})
+    assert picks == []
+    assert len(conflicts) == 1
+    assert conflicts[0][0]["number"] == 1
+    assert conflicts[0][1].startswith("CLAIM :")
+
+
+def test_un_remplacant_est_rendu_le_faux_negatif_qui_compte():
+    """Retirer sans remplacer fabriquerait l idle que la regle 4 interdit."""
+    by = dict(EMPTY, grain=[_it(1), _it(2)])
+    picks, _, conflicts = _run(by, _args(), held={1})
+    assert [p["number"] for p in picks] == [2], "aucun remplacant rendu"
+    assert len(conflicts) == 1
+
+
+def test_urne_entierement_tenue_ne_boucle_pas():
+    by = dict(EMPTY, grain=[_it(1), _it(2), _it(3)])
+    picks, _, conflicts = _run(by, _args(grains=2), held={1, 2, 3})
+    assert picks == []
+    assert len(conflicts) == 3
+
+
+def test_le_quota_est_tenu_malgre_les_retraits():
+    by = dict(EMPTY, grain=[_it(i) for i in range(1, 7)])
+    picks, _, conflicts = _run(by, _args(grains=2), held={1, 2, 3})
+    assert len(picks) == 2, "quota non tenu apres remplacement"
+    assert all(p["number"] not in {1, 2, 3} for p in picks)
+
+
+def test_check_desactive_ne_retire_rien():
+    by = dict(EMPTY, grain=[_it(1)])
+    picks, _, conflicts = _run(by, _args(check_claims=False), held={1})
+    assert [p["number"] for p in picks] == [1]
+    assert conflicts == []
+
+
+def test_sans_lane_le_check_ne_sabote_pas_le_tirage():
+    """--admissible et --orphans-report tirent sans lane : pas de plantage."""
+    by = dict(EMPTY, grain=[_it(1)])
+    picks, _, conflicts = _run(by, _args(lane=None), held={1})
+    assert [p["number"] for p in picks] == [1]
+    assert conflicts == []
+
+
+def test_les_trois_urnes_sont_filtrees():
+    """Aucun tenu dans les picks, et tout conflit rapporte est bien un tenu.
+
+    Compter les conflits serait sur-specifier : le tirage est pondere-aleatoire,
+    donc un grain tenu ne devient un conflit que s il est effectivement TIRE.
+    Une urne qui sort d abord le libre n a jamais vu le tenu -- c est correct,
+    et une assertion `len(conflicts) == 3` le declarerait faux (mesure : elle
+    rendait 2 sur graine 7).
+    """
+    held = {1, 3, 5}
+    by = {"grain": [_it(1), _it(2)], "umbrella": [_it(3), _it(4)],
+          "delivered": [_it(5), _it(6)]}
+    picks, _, conflicts = _run(
+        by, _args(grains=1, umbrellas=1, delivered=1), held=held)
+    nums = {p["number"] for p in picks}
+    assert nums == {2, 4, 6}, nums
+    assert not (nums & held), "un grain tenu a ete propose"
+    assert {c[0]["number"] for c in conflicts} <= held
+
+
+def test_deja_claim_par_cette_lane_n_est_pas_un_conflit():
+    """Reprendre son propre grain est le cas nominal, pas une collision."""
+    real = pick.check_claims
+    pick.check_claims = lambda nums, lane: {
+        n: "deja claim par cette lane" for n in nums}
+    try:
+        picks, _, conflicts = pick.draw_unclaimed(
+            dict(EMPTY, grain=[_it(1)]), _args(), random.Random(7),
+            None, None, None)
+    finally:
+        pick.check_claims = real
+    assert [p["number"] for p in picks] == [1]
+    assert conflicts == []

--- a/scripts/tests/test_pick_nanoclaw_concerns.py
+++ b/scripts/tests/test_pick_nanoclaw_concerns.py
@@ -1,0 +1,134 @@
+"""Controles positifs des deux concerns de la review NanoClaw sur #13466.
+
+Chaque test est ecrit pour ECHOUER sur le code d avant le fix -- c est la
+seule facon de savoir qu il mesure quelque chose. Un test qui passe aussi
+sans le correctif ne protege de rien.
+"""
+import sys
+import datetime as dt
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from pick_idle_grain import URGENT_LABELS, admissibility  # noqa: E402
+from series_saturation import (  # noqa: E402
+    CONSOLIDATION,
+    EXPANSION,
+    NEUTRAL,
+    zone_balance,
+)
+
+FAM = "Search/Part4-Metaheuristics"
+
+
+def _fresh(labels=None, polarity=EXPANSION, number=1):
+    """Une issue creee a l instant : refusee par DWELL sauf etiquette d urgence."""
+    return {
+        "number": number,
+        "title": "t",
+        "labels": labels or [],
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "polarity": polarity,
+    }
+
+
+# --- concern 2 : le bypass d urgence doit aussi parler francais -----------
+
+def test_les_variantes_fr_durgence_court_circuitent_le_dwell():
+    """Sur un depot dont les issues sont en francais, `urgence` s ecrira.
+
+    Avant le fix, URGENT_LABELS etait un ensemble exact anglais : une issue
+    vraiment urgente etiquetee `urgence` restait retenue 24 h par un garde
+    cense l exempter -- et en SILENCE.
+    """
+    for lab in ("urgence", "securite", "sécurité", "critique", "bloquant"):
+        assert admissibility(_fresh(labels=[lab]), None, None) is None, (
+            "l etiquette FR {!r} ne court-circuite pas le dwell".format(lab))
+
+
+def test_les_etiquettes_anglaises_restent_couvertes():
+    """Le fix AJOUTE, il ne remplace pas -- controle de non-regression."""
+    for lab in ("urgent", "security", "hotfix", "p0"):
+        assert admissibility(_fresh(labels=[lab]), None, None) is None, lab
+
+
+def test_une_issue_fraiche_sans_etiquette_reste_refusee():
+    """Le controle negatif : sans le veto, les deux tests ci-dessus sont vides."""
+    cause = admissibility(_fresh(), None, None)
+    assert cause and cause.startswith("DWELL"), cause
+
+
+def test_le_set_ne_contient_que_des_minuscules():
+    """Le match se fait sur `labels_lc` : une majuscule ici serait morte."""
+    assert all(x == x.lower() for x in URGENT_LABELS)
+
+
+# --- concern 1 : le refus SANS REMEDE doit etre refutable sur pieces ------
+
+def _pool(*items):
+    return [dict(number=n, title=t, body="") for n, t in items]
+
+
+def _zones():
+    return {FAM: {"new_notebooks": 5}}
+
+
+def test_le_refus_nomme_les_grains_neutral_ou_le_faux_positif_se_cacherait():
+    """Concern 1 : le veto lit le LEXIQUE, pas les intentions.
+
+    Un grain de consolidation dont le titre echappe au lexique tombe en
+    NEUTRAL. Le refus doit le NOMMER, sinon le faux positif est silencieux.
+    """
+    pool = _pool((10, "ajouter un notebook MGS-30"),
+                 (11, "MGS : reprendre la paire 12 autrement"))
+    i2f = {10: FAM, 11: FAM}
+    bal = zone_balance(_zones(), i2f, pool)
+    assert bal[FAM][CONSOLIDATION] == 0, "le cas teste exige con == 0"
+    assert bal[FAM][NEUTRAL] >= 1, "le cas teste exige un grain NEUTRAL"
+
+    item = {"number": 10, "title": "ajouter un notebook MGS-30", "labels": [],
+            "created_at": "2020-01-01T00:00:00Z", "polarity": EXPANSION}
+    cause = admissibility(item, bal, i2f)
+    assert cause and cause.startswith("ZONE SANS REMEDE"), cause
+    assert "#11" in cause, "le refus ne cite pas le grain NEUTRAL : {}".format(cause)
+    assert "faux positif" in cause, cause
+
+
+def test_sans_grain_neutral_le_refus_reste_sobre():
+    """Controle negatif : pas de NEUTRAL, pas de rallonge inventee."""
+    pool = _pool((10, "ajouter un notebook MGS-30"),
+                 (11, "creer un notebook MGS-31"))
+    i2f = {10: FAM, 11: FAM}
+    bal = zone_balance(_zones(), i2f, pool)
+    assert bal[FAM][NEUTRAL] == 0, "le cas teste exige zero NEUTRAL"
+    item = {"number": 10, "title": "ajouter un notebook MGS-30", "labels": [],
+            "created_at": "2020-01-01T00:00:00Z", "polarity": EXPANSION}
+    cause = admissibility(item, bal, i2f)
+    assert cause.startswith("ZONE SANS REMEDE"), cause
+    assert "faux positif" not in cause, cause
+
+
+def test_un_vrai_remede_leve_le_veto_et_ne_declenche_aucune_rallonge():
+    """Non-regression : con >= 1 admet, quel que soit le nombre de NEUTRAL."""
+    pool = _pool((10, "ajouter un notebook MGS-30"),
+                 (11, "MGS : reprendre la paire 12 autrement"),
+                 (12, "consolider les notebooks MGS 20-28"))
+    i2f = {10: FAM, 11: FAM, 12: FAM}
+    bal = zone_balance(_zones(), i2f, pool)
+    assert bal[FAM][CONSOLIDATION] == 1
+    item = {"number": 10, "title": "ajouter un notebook MGS-30", "labels": [],
+            "created_at": "2020-01-01T00:00:00Z", "polarity": EXPANSION}
+    assert admissibility(item, bal, i2f) is None
+
+
+def test_neutral_issues_ne_retient_que_la_zone_concernee():
+    """Un NEUTRAL d une AUTRE zone ne doit pas polluer le refus."""
+    autre = "GenAI/Image"
+    pool = _pool((10, "ajouter un notebook MGS-30"),
+                 (11, "MGS : reprendre la paire 12 autrement"),
+                 (99, "reprendre autrement le pipeline image"))
+    i2f = {10: FAM, 11: FAM, 99: autre}
+    bal = zone_balance({FAM: {"new_notebooks": 5}, autre: {"new_notebooks": 5}},
+                       i2f, pool)
+    assert bal[FAM]["neutral_issues"] == [11], bal[FAM]["neutral_issues"]
+    assert bal[autre]["neutral_issues"] == [99], bal[autre]["neutral_issues"]


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/tooling #13419

## Ce que la mesure dit, et pourquoi elle change le diagnostic

J'allais ajouter au picker un axe de « latence de consommation » — préférer
l'ancien au frais. La mesure l'a refusé :

| tranche | issues | part du pool | part de la masse de tirage | sur/sous-repr. |
|---|---|---|---|---|
| < 1 j   | 19 | 10.0 % |  3.9 % | **x0.39** |
| 1-3 j   | 38 | 20.0 % | 10.4 % | x0.52 |
| 3-7 j   | 61 | 32.1 % | 23.5 % | x0.73 |
| 7-30 j  | 45 | 23.7 % | 26.1 % | x1.10 |
| 30-90 j | 20 | 10.5 % | 25.9 % | x2.46 |
| > 90 j  |  7 |  3.7 % | 10.2 % | **x2.76** |

**62 % de la masse au-delà de 7 jours**, et les issues du jour déjà
sous-pondérées à 0.39x. Le classement du picker n'est pas le défaut —
renforcer l'axe d'ancienneté aurait été un correctif visant un défaut que
l'organe n'a pas.

Le défaut est ailleurs. Sur **112 issues travaillées en 48 h, 70 avaient moins
de 24 h** (63 %) — là où le tirage n'en voulait que 3.9 %. **Un écart de 16x**,
que le bruit d'échantillonnage n'explique pas : le travail n'arrive pas par le
tirage. Il arrive par le **steering** et par l'**auto-pick**, deux chemins
qu'aucune pondération ne touche. Un poids se fait battre par la population et
par le steer ; seul un **refus** s'applique quel que soit le chemin.

D'où la refonte : le picker cesse d'être un conseil de classement et devient
un **garde d'admission**.

## Les deux causes

**dwell** — une issue de moins de 24 h n'est pas consommable. Réponse directe à
« les issues auraient dû attendre au lieu d'être immédiatement prises en
charge » : un audit qui ouvre quinze issues le matin ne mobilise plus la flotte
l'après-midi. Les étiquettes d'urgence (`urgent`, `security`, `regression`,
`hotfix`…) court-circuitent le délai — le garde vise l'emballement, pas les
correctifs.

**zone sans remède** — un grain d'EXPANSION dans une zone ayant reçu ≥ 3
notebooks neufs sur la fenêtre **et dont le vivier ouvert ne contient aucun
grain de consolidation** est retenu. C'est « on ne va pas se taper le produit
cartésien MGS x PythonNet x Mealpy » rendu mécanique.

Le veto porte sur `con == 0`, **pas** sur la parité stricte `con >= exp`, bien
que le mandat dise « autant … que » : la parité se mesure sur le vivier
**ouvert**, et *consommer* un grain de consolidation le ferme — donc le retire
du vivier et **dégrade** le ratio. Un veto sur la parité punirait la zone
précisément quand elle vient de faire ce qu'on lui demandait. La parité reste
**mesurée et affichée** (`DESEQUILIBRE` / `SANS REMEDE`), parce qu'elle vise la
**rédaction des EPICs** : c'est à moi d'y répondre en ouvrant des grains de
consolidation, pas au worker d'y buter.

## Ce que le garde ne fait pas

Il s'applique au tirage et se vérifie par `--admissible <issue>` — mais il ne
peut pas s'imposer à un chemin qui ne l'appelle pas. Le steering est le mien :
c'est une **discipline de coordinateur** que cette PR outille, pas une
contrainte qu'elle impose. Le garde est lane-indépendant et sans `--lane`
exprès, pour être appelable avant un dispatch.

## Validation

12 tests, validés par leurs **faux négatifs**. Le cas décisif est
`test_consolidation_admise_dans_la_zone_saturee` : un garde qui refuserait le
remède en même temps que le mal reproduirait exactement le défaut que le miroir
de polarité (#13419) avait corrigé — #12607 tombait alors à 0.36x comme les
paires qu'il devait solder.

Effet sur le pool réel : **14 retenues sur 190 (7 %)**, dont 14 dwell et 0
zone — aucune famine, et le tirage remonte toujours de l'ancien (#2874 à 77 j,
#7265 à 41 j).

Contrôle rétrospectif sur l'incident du matin : **#13452**, 3 h d'âge, zéro
commentaire — l'issue sur laquelle **#13454 et #13460 sont entrées en
collision**. Verdict du garde : `REFUS — DWELL`. Les deux PRs dupliquées
n'auraient pas eu lieu.

## Portée honnête

Genre `guard` = classe **META** : cette PR ne tient pas le plancher G-VAR-1 de
mon cycle. Ce qui le tient est la rédaction des grains de consolidation pour
les trois zones que le rapport sort en `SANS REMEDE` — `DataScienceWithAgents`
(11 notebooks neufs, 0 remède), `GenAI/Texte` (4), `RAG-et-Memoire-Semantique`
(3) — que j'ouvre dans la foulée.

## Second commit — le garde n'etait pas satisfiable

Ecrit apres avoir teste la boucle de bout en bout plutot que de la declarer
close a la creation de l'issue de remede.

`issue_to_family` est construit par archeologie de PRs mergees : une issue n'y
entre que si une PR l'a deja citee. Une issue **fraiche** n'y est donc jamais —
or c'est exactement ce qu'est le grain de consolidation qu'une zone saturee
reclame. Mesure : **#13467** (renumerotation `GenAI/Texte`), polarite
`consolidation` correctement detectee et parent #5081 correctement extrait, ne
remontait a **aucune** zone. `GenAI/Texte` restait `SANS REMEDE` le remede en
main, et serait reste ferme a l'expansion **pour toujours**.

Trois sources, de la plus factuelle a la plus declarative : PR citante, EPIC
parent, puis le texte de l'issue.

Le **titre prime sur le corps**, meme principe que `polarity()`. Cherchees dans
un blob unique, la plus longue citation gagne : #13467 se resolvait en
`.claude/rules` parce que son corps cite `.claude/rules/catalog-pr-hygiene.md`,
chaine plus longue que `genai/texte`. Faux positif **invisible** — la
resolution rendait une zone plausible, juste pas la bonne. Le motif porte sur
deux segments au minimum (`GenAI/Texte`), jamais sur la feuille seule :
`Texte` matcherait toute prose francaise.

Effet mesure sur le pool reel, avant -> apres :

| zone | avant | apres | verdict |
|---|---|---|---|
| `ML/DataScienceWithAgents` | 0 exp / 0 con | 2 / 2 | SANS REMEDE -> **OK** |
| `Search/Part4-Metaheuristics` | 1 exp / 1 con | 1 / 3 | OK |
| `GenAI/Texte` | 0 exp / 0 con | 0 / 1 | SANS REMEDE -> **OK** |
| `Probas/DecisionTheory` | 0 exp / 1 con | 0 / 2 | OK |

**La boucle se ferme : ouvrir le remede rouvre la zone.** 8 tests de plus,
dont le faux positif exact ci-dessus et le controle negatif « un texte en
sortie », qui ne doit PAS rattacher a la serie `Texte`.

Total : 20 tests sur les deux commits ; 122 tests des suites voisines
(`series_saturation`, `variation_*`, `series_zero_pad`, `candidate_delivered`)
verts, sans regression.

See #13420
