### PR TITLE
feat(probas,#13036): LDA K-selection (K=2..6) executed in both Probas-11 twins

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
@@ -90,126 +90,23 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-104724.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '104724.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": "\r\n<div>\r\n    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n    </div>\r\n    <script type='text/javascript'>\r\nasync function probeAddresses(probingAddresses) {\r\n    function timeout(ms, promise) {\r\n        return new Promise(function (resolve, reject) {\r\n            setTimeout(function () {\r\n                reject(new Error('timeout'))\r\n            }, ms)\r\n            promise.then(resolve, reject)\r\n        })\r\n    }\r\n\r\n    if (Array.isArray(probingAddresses)) {\r\n        for (let i = 0; i < probingAddresses.length; i++) {\r\n\r\n            let rootUrl = probingAddresses[i];\r\n\r\n            if (!rootUrl.endsWith('/')) {\r\n                rootUrl = `${rootUrl}/`;\r\n            }\r\n\r\n            try {\r\n                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n                    method: 'POST',\r\n                    cache: 'no-cache',\r\n                    mode: 'cors',\r\n                    timeout: 1000,\r\n                    headers: {\r\n                        'Content-Type': 'text/plain'\r\n                    },\r\n                    body: probingAddresses[i]\r\n                }));\r\n\r\n                if (response.status == 200) {\r\n                    return rootUrl;\r\n                }\r\n            }\r\n            catch (e) { }\r\n        }\r\n    }\r\n}\r\n\r\nfunction loadDotnetInteractiveApi() {\r\n    probeAddresses([\"http://2a01:cb14:11a:e100:1173:a4f3:3c59:d15d:2048/\",\"http://2a01:cb14:11a:e100:dde:6249:7639:2c2b:2048/\",\"http://2a01:cb14:11a:e100:740b:8d54:a65d:e322:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%13:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::4050:b6c1:81f8:3162%21:2048/\",\"http://172.22.112.1:2048/\",\"http://fe80::be5b:f4d4:aa3e:65e1%49:2048/\",\"http://172.26.208.1:2048/\"])\r\n        .then((root) => {\r\n        // use probing to find host url and api resources\r\n        // load interactive helpers and language services\r\n        let dotnetInteractiveRequire = require.config({\r\n        context: '26336.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n                paths:\r\n            {\r\n                'dotnet-interactive': `${root}resources`\r\n                }\r\n        }) || require;\r\n\r\n            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n\r\n            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n                let paths = {};\r\n                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n                \r\n                let internalRequire = require.config({\r\n                    context: extensionCacheBuster,\r\n                    paths: paths,\r\n                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n                    }) || require;\r\n\r\n                return internalRequire\r\n            };\r\n        \r\n            dotnetInteractiveRequire([\r\n                    'dotnet-interactive/dotnet-interactive'\r\n                ],\r\n                function (dotnet) {\r\n                    dotnet.init(window);\r\n                },\r\n                function (error) {\r\n                    console.log(error);\r\n                }\r\n            );\r\n        })\r\n        .catch(error => {console.log(error);});\r\n    }\r\n\r\n// ensure `require` is available globally\r\nif ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n    let require_script = document.createElement('script');\r\n    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n    require_script.setAttribute('type', 'text/javascript');\r\n    \r\n    \r\n    require_script.onload = function() {\r\n        loadDotnetInteractiveApi();\r\n    };\r\n\r\n    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n}\r\nelse {\r\n    loadDotnetInteractiveApi();\r\n}\r\n\r\n    </script>\r\n</div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.ML.Probabilistic, 0.4.2504.701</span></li><li><span>Microsoft.ML.Probabilistic.Compiler, 0.4.2504.701</span></li></ul></div></div>"
-      ]
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.ML.Probabilistic</span></li><li><span>Microsoft.ML.Probabilistic.Compiler</span></li></ul></div><div></div></div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Infer.NET pret !\r\n"
-     ]
+     "name": "stdout",
+     "text": "Infer.NET pret !\r\n"
     }
    ],
    "source": [
@@ -269,18 +166,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "FactorGraphHelper charge.\r\n"
-     ]
+     "name": "stdout",
+     "text": "FactorGraphHelper charge.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Graphviz disponible : True\r\n"
-     ]
+     "name": "stdout",
+     "text": "Graphviz disponible : False\r\n"
     }
    ],
    "source": [
@@ -572,60 +465,44 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Corpus ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Corpus ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 1 : sport, equipe, match, sport, match\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 1 : sport, equipe, match, sport, match\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 2 : politique, election, vote, election, politique\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 2 : politique, election, vote, election, politique\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 3 : musique, concert, artiste, concert, musique\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 3 : musique, concert, artiste, concert, musique\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 4 : sport, equipe, politique, election, sport\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 4 : sport, equipe, politique, election, sport\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 5 : musique, concert, sport, equipe, artiste\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 5 : musique, concert, sport, equipe, artiste\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 6 : match, match, equipe, sport, match\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 6 : match, match, equipe, sport, match\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 7 : match, match, vote, match, election\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 7 : match, match, vote, match, election\r\n"
     }
    ],
    "source": [
@@ -722,25 +599,19 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Variables LDA definies.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Variables LDA definies.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Nombre de topics : 3\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Nombre de topics : 3\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Taille vocabulaire : 9\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Taille vocabulaire : 9\r\n"
     }
    ],
    "source": [
@@ -828,426 +699,324 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compiling model..."
-     ]
+     "name": "stdout",
+     "text": "Problem with converting DOT to SVG\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "done.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Iterating: \r\n"
-     ]
+     "name": "stdout",
+     "text": "If \"dot\" program is not installed, install Graphviz\nand add a path to \"dot\" to the PATH\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "DOT file is saved to \"D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_08_29_26_10_14_10_12.gv\"\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "Compiling model..."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "done.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "Iterating: \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "|"
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "|"
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "|"
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "|"
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "|"
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " 50\r\n"
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Inference pour Doc 1 ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Mots : sport, equipe, match, sport, match\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Distribution de topics (theta) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic 1 : 0,333\r\n"
-     ]
+     "name": "stdout",
+     "text": " 50\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic 2 : 0,333\r\n"
-     ]
+     "name": "stdout",
+     "text": "\n=== Inference pour Doc 1 ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic 3 : 0,333\r\n"
-     ]
+     "name": "stdout",
+     "text": "Mots : sport, equipe, match, sport, match\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Distribution de topics (theta) :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Topic 1 : 0,333\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Topic 2 : 0,333\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Topic 3 : 0,333\r\n"
     }
    ],
    "source": [
@@ -1358,171 +1127,16 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_17_21_87.svg</div>\r\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
-       "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
-       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
-       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
-       " -->\r\n",
-       "<!-- Title: Model Pages: 1 -->\r\n",
-       "<svg width=\"204pt\" height=\"444pt\"\r\n",
-       " viewBox=\"0.00 0.00 204.00 444.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 440)\">\r\n",
-       "<title>Model</title>\r\n",
-       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-440 200.25,-440 200.25,4 -4,4\"/>\r\n",
-       "<!-- node0 -->\r\n",
-       "<g id=\"node1\" class=\"node\">\r\n",
-       "<title>node0</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M55.12,-436C55.12,-436 23.38,-436 23.38,-436 17.38,-436 11.38,-430 11.38,-424 11.38,-424 11.38,-412 11.38,-412 11.38,-406 17.38,-400 23.38,-400 23.38,-400 55.12,-400 55.12,-400 61.12,-400 67.12,-406 67.12,-412 67.12,-412 67.12,-424 67.12,-424 67.12,-430 61.12,-436 55.12,-436\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"39.25\" y=\"-414.7\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet1</text>\r\n",
-       "</g>\r\n",
-       "<!-- node1 -->\r\n",
-       "<g id=\"node2\" class=\"node\">\r\n",
-       "<title>node1</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M54.25,-354.25C54.25,-354.25 24.25,-354.25 24.25,-354.25 18.25,-354.25 12.25,-348.25 12.25,-342.25 12.25,-342.25 12.25,-330.25 12.25,-330.25 12.25,-324.25 18.25,-318.25 24.25,-318.25 24.25,-318.25 54.25,-318.25 54.25,-318.25 60.25,-318.25 66.25,-324.25 66.25,-330.25 66.25,-330.25 66.25,-342.25 66.25,-342.25 66.25,-348.25 60.25,-354.25 54.25,-354.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"39.25\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node0&#45;&gt;node1 -->\r\n",
-       "<g id=\"edge1\" class=\"edge\">\r\n",
-       "<title>node0&#45;&gt;node1</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M39.25,-400.09C39.25,-390.18 39.25,-377.4 39.25,-365.96\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"42.75,-366.2 39.25,-356.2 35.75,-366.2 42.75,-366.2\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"44.88\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node2 -->\r\n",
-       "<g id=\"node3\" class=\"node\">\r\n",
-       "<title>node2</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M54.25,-281.25C54.25,-281.25 24.25,-281.25 24.25,-281.25 18.25,-281.25 12.25,-275.25 12.25,-269.25 12.25,-269.25 12.25,-257.25 12.25,-257.25 12.25,-251.25 18.25,-245.25 24.25,-245.25 24.25,-245.25 54.25,-245.25 54.25,-245.25 60.25,-245.25 66.25,-251.25 66.25,-257.25 66.25,-257.25 66.25,-269.25 66.25,-269.25 66.25,-275.25 60.25,-281.25 54.25,-281.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"39.25\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">theta</text>\r\n",
-       "</g>\r\n",
-       "<!-- node1&#45;&gt;node2 -->\r\n",
-       "<g id=\"edge2\" class=\"edge\">\r\n",
-       "<title>node1&#45;&gt;node2</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M39.25,-318.06C39.25,-310.48 39.25,-301.35 39.25,-292.79\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"42.75,-292.79 39.25,-282.79 35.75,-292.79 42.75,-292.79\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node3 -->\r\n",
-       "<g id=\"node4\" class=\"node\">\r\n",
-       "<title>node3</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M54.25,-199.5C54.25,-199.5 24.25,-199.5 24.25,-199.5 18.25,-199.5 12.25,-193.5 12.25,-187.5 12.25,-187.5 12.25,-175.5 12.25,-175.5 12.25,-169.5 18.25,-163.5 24.25,-163.5 24.25,-163.5 54.25,-163.5 54.25,-163.5 60.25,-163.5 66.25,-169.5 66.25,-175.5 66.25,-175.5 66.25,-187.5 66.25,-187.5 66.25,-193.5 60.25,-199.5 54.25,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"39.25\" y=\"-178.78\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node2&#45;&gt;node3 -->\r\n",
-       "<g id=\"edge3\" class=\"edge\">\r\n",
-       "<title>node2&#45;&gt;node3</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M39.25,-244.95C39.25,-235.02 39.25,-222.31 39.25,-210.95\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"42.75,-211.28 39.25,-201.28 35.75,-211.28 42.75,-211.28\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"47.88\" y=\"-219.65\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node4 -->\r\n",
-       "<g id=\"node5\" class=\"node\">\r\n",
-       "<title>node4</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M80.5,-117.75C80.5,-117.75 12,-117.75 12,-117.75 6,-117.75 0,-111.75 0,-105.75 0,-105.75 0,-93.75 0,-93.75 0,-87.75 6,-81.75 12,-81.75 12,-81.75 80.5,-81.75 80.5,-81.75 86.5,-81.75 92.5,-87.75 92.5,-93.75 92.5,-93.75 92.5,-105.75 92.5,-105.75 92.5,-111.75 86.5,-117.75 80.5,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"46.25\" y=\"-95.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">topicAssign[word]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node3&#45;&gt;node4 -->\r\n",
-       "<g id=\"edge4\" class=\"edge\">\r\n",
-       "<title>node3&#45;&gt;node4</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M40.77,-163.2C41.64,-153.27 42.76,-140.56 43.75,-129.2\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"47.21,-129.8 44.6,-119.53 40.24,-129.18 47.21,-129.8\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node7 -->\r\n",
-       "<g id=\"node8\" class=\"node\">\r\n",
-       "<title>node7</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M119.5,-36C119.5,-36 63,-36 63,-36 57,-36 51,-30 51,-24 51,-24 51,-12 51,-12 51,-6 57,0 63,0 63,0 119.5,0 119.5,0 125.5,0 131.5,-6 131.5,-12 131.5,-12 131.5,-24 131.5,-24 131.5,-30 125.5,-36 119.5,-36\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"91.25\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">wordObs[word]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node4&#45;&gt;node7 -->\r\n",
-       "<g id=\"edge7\" class=\"edge\">\r\n",
-       "<title>node4&#45;&gt;node7</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M56.01,-81.45C61.89,-71.03 69.5,-57.55 76.14,-45.78\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"79.05,-47.74 80.92,-37.31 72.95,-44.3 79.05,-47.74\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"86.07\" y=\"-56.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">condition</text>\r\n",
-       "</g>\r\n",
-       "<!-- node5 -->\r\n",
-       "<g id=\"node6\" class=\"node\">\r\n",
-       "<title>node5</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M184.25,-199.5C184.25,-199.5 96.25,-199.5 96.25,-199.5 90.25,-199.5 84.25,-193.5 84.25,-187.5 84.25,-187.5 84.25,-175.5 84.25,-175.5 84.25,-169.5 90.25,-163.5 96.25,-163.5 96.25,-163.5 184.25,-163.5 184.25,-163.5 190.25,-163.5 196.25,-169.5 196.25,-175.5 196.25,-175.5 196.25,-187.5 196.25,-187.5 196.25,-193.5 190.25,-199.5 184.25,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"140.25\" y=\"-177.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">phi[topicAssign[word]]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node6 -->\r\n",
-       "<g id=\"node7\" class=\"node\">\r\n",
-       "<title>node6</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M153.25,-117.75C153.25,-117.75 123.25,-117.75 123.25,-117.75 117.25,-117.75 111.25,-111.75 111.25,-105.75 111.25,-105.75 111.25,-93.75 111.25,-93.75 111.25,-87.75 117.25,-81.75 123.25,-81.75 123.25,-81.75 153.25,-81.75 153.25,-81.75 159.25,-81.75 165.25,-87.75 165.25,-93.75 165.25,-93.75 165.25,-105.75 165.25,-105.75 165.25,-111.75 159.25,-117.75 153.25,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"138.25\" y=\"-97.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node5&#45;&gt;node6 -->\r\n",
-       "<g id=\"edge5\" class=\"edge\">\r\n",
-       "<title>node5&#45;&gt;node6</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M139.82,-163.2C139.57,-153.27 139.25,-140.56 138.96,-129.2\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"142.47,-129.44 138.72,-119.53 135.47,-129.62 142.47,-129.44\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"147.99\" y=\"-137.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node6&#45;&gt;node7 -->\r\n",
-       "<g id=\"edge6\" class=\"edge\">\r\n",
-       "<title>node6&#45;&gt;node7</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M128.05,-81.45C121.91,-71.03 113.97,-57.55 107.03,-45.78\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"110.13,-44.14 102.04,-37.3 104.1,-47.69 110.13,-44.14\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node8 -->\r\n",
-       "<g id=\"node9\" class=\"node\">\r\n",
-       "<title>node8</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M156.12,-436C156.12,-436 124.38,-436 124.38,-436 118.38,-436 112.38,-430 112.38,-424 112.38,-424 112.38,-412 112.38,-412 112.38,-406 118.38,-400 124.38,-400 124.38,-400 156.12,-400 156.12,-400 162.12,-400 168.12,-406 168.12,-412 168.12,-412 168.12,-424 168.12,-424 168.12,-430 162.12,-436 156.12,-436\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"140.25\" y=\"-414.7\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet0</text>\r\n",
-       "</g>\r\n",
-       "<!-- node9 -->\r\n",
-       "<g id=\"node10\" class=\"node\">\r\n",
-       "<title>node9</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M155.25,-354.25C155.25,-354.25 125.25,-354.25 125.25,-354.25 119.25,-354.25 113.25,-348.25 113.25,-342.25 113.25,-342.25 113.25,-330.25 113.25,-330.25 113.25,-324.25 119.25,-318.25 125.25,-318.25 125.25,-318.25 155.25,-318.25 155.25,-318.25 161.25,-318.25 167.25,-324.25 167.25,-330.25 167.25,-330.25 167.25,-342.25 167.25,-342.25 167.25,-348.25 161.25,-354.25 155.25,-354.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"140.25\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node8&#45;&gt;node9 -->\r\n",
-       "<g id=\"edge8\" class=\"edge\">\r\n",
-       "<title>node8&#45;&gt;node9</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M140.25,-400.09C140.25,-390.18 140.25,-377.4 140.25,-365.96\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"143.75,-366.2 140.25,-356.2 136.75,-366.2 143.75,-366.2\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"145.88\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node10 -->\r\n",
-       "<g id=\"node11\" class=\"node\">\r\n",
-       "<title>node10</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M156.5,-281.25C156.5,-281.25 124,-281.25 124,-281.25 118,-281.25 112,-275.25 112,-269.25 112,-269.25 112,-257.25 112,-257.25 112,-251.25 118,-245.25 124,-245.25 124,-245.25 156.5,-245.25 156.5,-245.25 162.5,-245.25 168.5,-251.25 168.5,-257.25 168.5,-257.25 168.5,-269.25 168.5,-269.25 168.5,-275.25 162.5,-281.25 156.5,-281.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"140.25\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">phi[topic]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node9&#45;&gt;node10 -->\r\n",
-       "<g id=\"edge9\" class=\"edge\">\r\n",
-       "<title>node9&#45;&gt;node10</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M140.25,-318.06C140.25,-310.48 140.25,-301.35 140.25,-292.79\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"143.75,-292.79 140.25,-282.79 136.75,-292.79 143.75,-292.79\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node10&#45;&gt;node5 -->\r\n",
-       "<g id=\"edge10\" class=\"edge\">\r\n",
-       "<title>node10&#45;&gt;node5</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M140.25,-244.95C140.25,-231.57 140.25,-213.14 140.25,-199.77\"/>\r\n",
-       "</g>\r\n",
-       "</g>\r\n",
-       "</svg>\r\n",
-       "\r\n",
-       "    </div>\r\n",
-       "</div>"
-      ]
+      "text/html": "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n                <strong>Graphviz non disponible.</strong><br/>\n                Copiez le contenu de <code>Model_08_29_26_10_14_10_12.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n            </div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
+     "name": "stderr",
+     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
     }
    ],
    "source": [
@@ -1651,47 +1265,34 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== LDA avec Priors Asymétriques ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== LDA avec Priors Asymétriques ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Priors sur phi (log-echelle relative) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nPriors sur phi (log-echelle relative) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic 0 : sport, equipe, match (beta=10)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Topic 0 : sport, equipe, match (beta=10)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic 1 : match, politique, election, vote (beta=10)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Topic 1 : match, politique, election, vote (beta=10)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic 2 : musique, concert, artiste (beta=10)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Topic 2 : musique, concert, artiste (beta=10)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     }
    ],
    "source": [
@@ -1786,180 +1387,249 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Inference LDA Corrigee ===\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Inference LDA Corrigee ===\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 1 : sport, equipe, match, sport, match\r\n"
-     ]
+     "name": "stdout",
+     "text": "Problem with converting DOT to SVG\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Theta : Sport=0,718, Politique=0,153, Musique=0,129\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic dominant : Sport (72 %)\r\n"
-     ]
+     "name": "stdout",
+     "text": "If \"dot\" program is not installed, install Graphviz\nand add a path to \"dot\" to the PATH\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "DOT file is saved to \"D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_08_29_26_10_14_13_33.gv\"\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 2 : politique, election, vote, election, politique\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 1 : sport, equipe, match, sport, match\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Theta : Sport=0,129, Politique=0,741, Musique=0,130\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Theta : Sport=0,718, Politique=0,153, Musique=0,129\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic dominant : Politique (74 %)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Topic dominant : Sport (72 %)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 3 : musique, concert, artiste, concert, musique\r\n"
-     ]
+     "name": "stdout",
+     "text": "Problem with converting DOT to SVG\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Theta : Sport=0,128, Politique=0,128, Musique=0,744\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic dominant : Musique (74 %)\r\n"
-     ]
+     "name": "stdout",
+     "text": "If \"dot\" program is not installed, install Graphviz\nand add a path to \"dot\" to the PATH\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "DOT file is saved to \"D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_08_29_26_10_14_14_04.gv\"\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 4 : sport, equipe, politique, election, sport\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 2 : politique, election, vote, election, politique\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Theta : Sport=0,508, Politique=0,360, Musique=0,131\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Theta : Sport=0,129, Politique=0,741, Musique=0,130\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic dominant : Sport (51 %)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Topic dominant : Politique (74 %)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 5 : musique, concert, sport, equipe, artiste\r\n"
-     ]
+     "name": "stdout",
+     "text": "Problem with converting DOT to SVG\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Theta : Sport=0,368, Politique=0,130, Musique=0,502\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic dominant : Musique (50 %)\r\n"
-     ]
+     "name": "stdout",
+     "text": "If \"dot\" program is not installed, install Graphviz\nand add a path to \"dot\" to the PATH\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "DOT file is saved to \"D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_08_29_26_10_14_15_06.gv\"\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 7 : match, match, vote, match, election\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 3 : musique, concert, artiste, concert, musique\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Theta : Sport=0,226, Politique=0,645, Musique=0,129\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Theta : Sport=0,128, Politique=0,128, Musique=0,744\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Topic dominant : Politique (65 %)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Topic dominant : Musique (74 %)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Problem with converting DOT to SVG\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "If \"dot\" program is not installed, install Graphviz\nand add a path to \"dot\" to the PATH\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "DOT file is saved to \"D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_08_29_26_10_14_16_34.gv\"\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Doc 4 : sport, equipe, politique, election, sport\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Theta : Sport=0,508, Politique=0,360, Musique=0,131\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Topic dominant : Sport (51 %)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Problem with converting DOT to SVG\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "If \"dot\" program is not installed, install Graphviz\nand add a path to \"dot\" to the PATH\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "DOT file is saved to \"D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_08_29_26_10_14_18_07.gv\"\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Doc 5 : musique, concert, sport, equipe, artiste\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Theta : Sport=0,368, Politique=0,130, Musique=0,502\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Topic dominant : Musique (50 %)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Problem with converting DOT to SVG\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "If \"dot\" program is not installed, install Graphviz\nand add a path to \"dot\" to the PATH\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "DOT file is saved to \"D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_08_29_26_10_14_20_53.gv\"\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Doc 7 : match, match, vote, match, election\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Theta : Sport=0,226, Politique=0,645, Musique=0,129\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Topic dominant : Politique (65 %)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\r\n"
     }
    ],
    "source": [
@@ -2086,709 +1756,16 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n",
-       "    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_06_22_26_21_17_28_65.svg</div>\r\n",
-       "    <div style=\"max-width: 800px; overflow: auto;\">\r\n",
-       "        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n",
-       "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n",
-       " \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n",
-       "<!-- Generated by graphviz version 14.1.2 (0)\r\n",
-       " -->\r\n",
-       "<!-- Title: Model Pages: 1 -->\r\n",
-       "<svg width=\"1104pt\" height=\"608pt\"\r\n",
-       " viewBox=\"0.00 0.00 1104.00 608.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n",
-       "<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 603.5)\">\r\n",
-       "<title>Model</title>\r\n",
-       "<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-603.5 1099.75,-603.5 1099.75,4 -4,4\"/>\r\n",
-       "<!-- node0 -->\r\n",
-       "<g id=\"node1\" class=\"node\">\r\n",
-       "<title>node0</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M117.75,-436C117.75,-436 86,-436 86,-436 80,-436 74,-430 74,-424 74,-424 74,-412 74,-412 74,-406 80,-400 86,-400 86,-400 117.75,-400 117.75,-400 123.75,-400 129.75,-406 129.75,-412 129.75,-412 129.75,-424 129.75,-424 129.75,-430 123.75,-436 117.75,-436\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"101.88\" y=\"-414.7\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet9</text>\r\n",
-       "</g>\r\n",
-       "<!-- node1 -->\r\n",
-       "<g id=\"node2\" class=\"node\">\r\n",
-       "<title>node1</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M116.88,-354.25C116.88,-354.25 86.88,-354.25 86.88,-354.25 80.88,-354.25 74.88,-348.25 74.88,-342.25 74.88,-342.25 74.88,-330.25 74.88,-330.25 74.88,-324.25 80.88,-318.25 86.88,-318.25 86.88,-318.25 116.88,-318.25 116.88,-318.25 122.88,-318.25 128.88,-324.25 128.88,-330.25 128.88,-330.25 128.88,-342.25 128.88,-342.25 128.88,-348.25 122.88,-354.25 116.88,-354.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"101.88\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node0&#45;&gt;node1 -->\r\n",
-       "<g id=\"edge1\" class=\"edge\">\r\n",
-       "<title>node0&#45;&gt;node1</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M101.88,-400.09C101.88,-390.18 101.88,-377.4 101.88,-365.96\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"105.38,-366.2 101.88,-356.2 98.38,-366.2 105.38,-366.2\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"107.5\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node2 -->\r\n",
-       "<g id=\"node3\" class=\"node\">\r\n",
-       "<title>node2</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M116.88,-281.25C116.88,-281.25 86.88,-281.25 86.88,-281.25 80.88,-281.25 74.88,-275.25 74.88,-269.25 74.88,-269.25 74.88,-257.25 74.88,-257.25 74.88,-251.25 80.88,-245.25 86.88,-245.25 86.88,-245.25 116.88,-245.25 116.88,-245.25 122.88,-245.25 128.88,-251.25 128.88,-257.25 128.88,-257.25 128.88,-269.25 128.88,-269.25 128.88,-275.25 122.88,-281.25 116.88,-281.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"101.88\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">theta_4</text>\r\n",
-       "</g>\r\n",
-       "<!-- node1&#45;&gt;node2 -->\r\n",
-       "<g id=\"edge2\" class=\"edge\">\r\n",
-       "<title>node1&#45;&gt;node2</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M101.88,-318.06C101.88,-310.48 101.88,-301.35 101.88,-292.79\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"105.38,-292.79 101.88,-282.79 98.38,-292.79 105.38,-292.79\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node3 -->\r\n",
-       "<g id=\"node4\" class=\"node\">\r\n",
-       "<title>node3</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M116.88,-199.5C116.88,-199.5 86.88,-199.5 86.88,-199.5 80.88,-199.5 74.88,-193.5 74.88,-187.5 74.88,-187.5 74.88,-175.5 74.88,-175.5 74.88,-169.5 80.88,-163.5 86.88,-163.5 86.88,-163.5 116.88,-163.5 116.88,-163.5 122.88,-163.5 128.88,-169.5 128.88,-175.5 128.88,-175.5 128.88,-187.5 128.88,-187.5 128.88,-193.5 122.88,-199.5 116.88,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"101.88\" y=\"-178.78\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node2&#45;&gt;node3 -->\r\n",
-       "<g id=\"edge3\" class=\"edge\">\r\n",
-       "<title>node2&#45;&gt;node3</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M101.88,-244.95C101.88,-235.02 101.88,-222.31 101.88,-210.95\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"105.38,-211.28 101.88,-201.28 98.38,-211.28 105.38,-211.28\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"110.5\" y=\"-219.65\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node4 -->\r\n",
-       "<g id=\"node5\" class=\"node\">\r\n",
-       "<title>node4</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M219.25,-117.75C219.25,-117.75 154.5,-117.75 154.5,-117.75 148.5,-117.75 142.5,-111.75 142.5,-105.75 142.5,-105.75 142.5,-93.75 142.5,-93.75 142.5,-87.75 148.5,-81.75 154.5,-81.75 154.5,-81.75 219.25,-81.75 219.25,-81.75 225.25,-81.75 231.25,-87.75 231.25,-93.75 231.25,-93.75 231.25,-105.75 231.25,-105.75 231.25,-111.75 225.25,-117.75 219.25,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"186.88\" y=\"-95.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">topics_4[word_4]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node3&#45;&gt;node4 -->\r\n",
-       "<g id=\"edge4\" class=\"edge\">\r\n",
-       "<title>node3&#45;&gt;node4</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M120.32,-163.2C132.01,-152.22 147.33,-137.85 160.33,-125.66\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"162.47,-128.45 167.36,-119.06 157.68,-123.35 162.47,-128.45\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node7 -->\r\n",
-       "<g id=\"node8\" class=\"node\">\r\n",
-       "<title>node7</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M244.25,-36C244.25,-36 179.5,-36 179.5,-36 173.5,-36 167.5,-30 167.5,-24 167.5,-24 167.5,-12 167.5,-12 167.5,-6 173.5,0 179.5,0 179.5,0 244.25,0 244.25,0 250.25,0 256.25,-6 256.25,-12 256.25,-12 256.25,-24 256.25,-24 256.25,-30 250.25,-36 244.25,-36\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"211.88\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">words_4[word_4]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node4&#45;&gt;node7 -->\r\n",
-       "<g id=\"edge7\" class=\"edge\">\r\n",
-       "<title>node4&#45;&gt;node7</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M192.3,-81.45C195.47,-71.34 199.54,-58.36 203.14,-46.85\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"206.44,-48.03 206.09,-37.44 199.76,-45.94 206.44,-48.03\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"215.5\" y=\"-56.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">condition</text>\r\n",
-       "</g>\r\n",
-       "<!-- node5 -->\r\n",
-       "<g id=\"node6\" class=\"node\">\r\n",
-       "<title>node5</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M489,-199.5C489,-199.5 380.75,-199.5 380.75,-199.5 374.75,-199.5 368.75,-193.5 368.75,-187.5 368.75,-187.5 368.75,-175.5 368.75,-175.5 368.75,-169.5 374.75,-163.5 380.75,-163.5 380.75,-163.5 489,-163.5 489,-163.5 495,-163.5 501,-169.5 501,-175.5 501,-175.5 501,-187.5 501,-187.5 501,-193.5 495,-199.5 489,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"434.88\" y=\"-177.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">phiAsym[topics_4[word_4]]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node6 -->\r\n",
-       "<g id=\"node7\" class=\"node\">\r\n",
-       "<title>node6</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M370.88,-117.75C370.88,-117.75 340.88,-117.75 340.88,-117.75 334.88,-117.75 328.88,-111.75 328.88,-105.75 328.88,-105.75 328.88,-93.75 328.88,-93.75 328.88,-87.75 334.88,-81.75 340.88,-81.75 340.88,-81.75 370.88,-81.75 370.88,-81.75 376.88,-81.75 382.88,-87.75 382.88,-93.75 382.88,-93.75 382.88,-105.75 382.88,-105.75 382.88,-111.75 376.88,-117.75 370.88,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"355.88\" y=\"-97.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node5&#45;&gt;node6 -->\r\n",
-       "<g id=\"edge5\" class=\"edge\">\r\n",
-       "<title>node5&#45;&gt;node6</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M417.73,-163.2C406.97,-152.33 392.9,-138.12 380.9,-126.01\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"383.57,-123.74 374.05,-119.1 378.6,-128.66 383.57,-123.74\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"408.73\" y=\"-137.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node6&#45;&gt;node7 -->\r\n",
-       "<g id=\"edge6\" class=\"edge\">\r\n",
-       "<title>node6&#45;&gt;node7</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M328.45,-83.56C306.96,-71.66 276.73,-54.92 252.44,-41.47\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"254.21,-38.44 243.76,-36.66 250.81,-44.57 254.21,-38.44\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node8 -->\r\n",
-       "<g id=\"node9\" class=\"node\">\r\n",
-       "<title>node8</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M789,-199.5C789,-199.5 680.75,-199.5 680.75,-199.5 674.75,-199.5 668.75,-193.5 668.75,-187.5 668.75,-187.5 668.75,-175.5 668.75,-175.5 668.75,-169.5 674.75,-163.5 680.75,-163.5 680.75,-163.5 789,-163.5 789,-163.5 795,-163.5 801,-169.5 801,-175.5 801,-175.5 801,-187.5 801,-187.5 801,-193.5 795,-199.5 789,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"734.88\" y=\"-177.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">phiAsym[topics_0[word_0]]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node9 -->\r\n",
-       "<g id=\"node10\" class=\"node\">\r\n",
-       "<title>node9</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M770.88,-117.75C770.88,-117.75 740.88,-117.75 740.88,-117.75 734.88,-117.75 728.88,-111.75 728.88,-105.75 728.88,-105.75 728.88,-93.75 728.88,-93.75 728.88,-87.75 734.88,-81.75 740.88,-81.75 740.88,-81.75 770.88,-81.75 770.88,-81.75 776.88,-81.75 782.88,-87.75 782.88,-93.75 782.88,-93.75 782.88,-105.75 782.88,-105.75 782.88,-111.75 776.88,-117.75 770.88,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"755.88\" y=\"-97.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node8&#45;&gt;node9 -->\r\n",
-       "<g id=\"edge8\" class=\"edge\">\r\n",
-       "<title>node8&#45;&gt;node9</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M739.43,-163.2C742.07,-153.16 745.46,-140.29 748.48,-128.84\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"751.78,-130.05 750.94,-119.48 745.01,-128.26 751.78,-130.05\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"755.26\" y=\"-137.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node10 -->\r\n",
-       "<g id=\"node11\" class=\"node\">\r\n",
-       "<title>node10</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M880.25,-36C880.25,-36 815.5,-36 815.5,-36 809.5,-36 803.5,-30 803.5,-24 803.5,-24 803.5,-12 803.5,-12 803.5,-6 809.5,0 815.5,0 815.5,0 880.25,0 880.25,0 886.25,0 892.25,-6 892.25,-12 892.25,-12 892.25,-24 892.25,-24 892.25,-30 886.25,-36 880.25,-36\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"847.88\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">words_0[word_0]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node9&#45;&gt;node10 -->\r\n",
-       "<g id=\"edge9\" class=\"edge\">\r\n",
-       "<title>node9&#45;&gt;node10</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M775.84,-81.45C788.7,-70.29 805.62,-55.63 819.83,-43.31\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"821.86,-46.18 827.12,-36.99 817.27,-40.89 821.86,-46.18\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node11 -->\r\n",
-       "<g id=\"node12\" class=\"node\">\r\n",
-       "<title>node11</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M886.25,-117.75C886.25,-117.75 821.5,-117.75 821.5,-117.75 815.5,-117.75 809.5,-111.75 809.5,-105.75 809.5,-105.75 809.5,-93.75 809.5,-93.75 809.5,-87.75 815.5,-81.75 821.5,-81.75 821.5,-81.75 886.25,-81.75 886.25,-81.75 892.25,-81.75 898.25,-87.75 898.25,-93.75 898.25,-93.75 898.25,-105.75 898.25,-105.75 898.25,-111.75 892.25,-117.75 886.25,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"853.88\" y=\"-95.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">topics_0[word_0]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node11&#45;&gt;node10 -->\r\n",
-       "<g id=\"edge10\" class=\"edge\">\r\n",
-       "<title>node11&#45;&gt;node10</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M852.57,-81.45C851.82,-71.45 850.86,-58.63 850,-47.21\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"853.51,-47.22 849.27,-37.51 846.53,-47.74 853.51,-47.22\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"865.86\" y=\"-56.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">condition</text>\r\n",
-       "</g>\r\n",
-       "<!-- node12 -->\r\n",
-       "<g id=\"node13\" class=\"node\">\r\n",
-       "<title>node12</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M339,-199.5C339,-199.5 230.75,-199.5 230.75,-199.5 224.75,-199.5 218.75,-193.5 218.75,-187.5 218.75,-187.5 218.75,-175.5 218.75,-175.5 218.75,-169.5 224.75,-163.5 230.75,-163.5 230.75,-163.5 339,-163.5 339,-163.5 345,-163.5 351,-169.5 351,-175.5 351,-175.5 351,-187.5 351,-187.5 351,-193.5 345,-199.5 339,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"284.88\" y=\"-177.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">phiAsym[topics_1[word_1]]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node13 -->\r\n",
-       "<g id=\"node14\" class=\"node\">\r\n",
-       "<title>node13</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M294.88,-117.75C294.88,-117.75 264.88,-117.75 264.88,-117.75 258.88,-117.75 252.88,-111.75 252.88,-105.75 252.88,-105.75 252.88,-93.75 252.88,-93.75 252.88,-87.75 258.88,-81.75 264.88,-81.75 264.88,-81.75 294.88,-81.75 294.88,-81.75 300.88,-81.75 306.88,-87.75 306.88,-93.75 306.88,-93.75 306.88,-105.75 306.88,-105.75 306.88,-111.75 300.88,-117.75 294.88,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"279.88\" y=\"-97.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node12&#45;&gt;node13 -->\r\n",
-       "<g id=\"edge11\" class=\"edge\">\r\n",
-       "<title>node12&#45;&gt;node13</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M283.79,-163.2C283.17,-153.27 282.37,-140.56 281.66,-129.2\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"285.17,-129.29 281.05,-119.53 278.19,-129.73 285.17,-129.29\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"291.3\" y=\"-137.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node14 -->\r\n",
-       "<g id=\"node15\" class=\"node\">\r\n",
-       "<title>node14</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M137.25,-36C137.25,-36 72.5,-36 72.5,-36 66.5,-36 60.5,-30 60.5,-24 60.5,-24 60.5,-12 60.5,-12 60.5,-6 66.5,0 72.5,0 72.5,0 137.25,0 137.25,0 143.25,0 149.25,-6 149.25,-12 149.25,-12 149.25,-24 149.25,-24 149.25,-30 143.25,-36 137.25,-36\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"104.88\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">words_1[word_1]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node13&#45;&gt;node14 -->\r\n",
-       "<g id=\"edge12\" class=\"edge\">\r\n",
-       "<title>node13&#45;&gt;node14</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M252.38,-86.94C248.2,-85.18 243.93,-83.4 239.88,-81.75 219.55,-73.46 213.93,-72.69 193.88,-63.75 178.22,-56.77 161.34,-48.48 146.54,-40.95\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"148.5,-38.03 138.01,-36.58 145.31,-44.25 148.5,-38.03\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node15 -->\r\n",
-       "<g id=\"node16\" class=\"node\">\r\n",
-       "<title>node15</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M103.25,-117.75C103.25,-117.75 38.5,-117.75 38.5,-117.75 32.5,-117.75 26.5,-111.75 26.5,-105.75 26.5,-105.75 26.5,-93.75 26.5,-93.75 26.5,-87.75 32.5,-81.75 38.5,-81.75 38.5,-81.75 103.25,-81.75 103.25,-81.75 109.25,-81.75 115.25,-87.75 115.25,-93.75 115.25,-93.75 115.25,-105.75 115.25,-105.75 115.25,-111.75 109.25,-117.75 103.25,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"70.88\" y=\"-95.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">topics_1[word_1]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node15&#45;&gt;node14 -->\r\n",
-       "<g id=\"edge13\" class=\"edge\">\r\n",
-       "<title>node15&#45;&gt;node14</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M78.25,-81.45C82.6,-71.24 88.21,-58.09 93.15,-46.49\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"96.33,-47.96 97.04,-37.39 89.89,-45.22 96.33,-47.96\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"104.54\" y=\"-56.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">condition</text>\r\n",
-       "</g>\r\n",
-       "<!-- node16 -->\r\n",
-       "<g id=\"node17\" class=\"node\">\r\n",
-       "<title>node16</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M639,-199.5C639,-199.5 530.75,-199.5 530.75,-199.5 524.75,-199.5 518.75,-193.5 518.75,-187.5 518.75,-187.5 518.75,-175.5 518.75,-175.5 518.75,-169.5 524.75,-163.5 530.75,-163.5 530.75,-163.5 639,-163.5 639,-163.5 645,-163.5 651,-169.5 651,-175.5 651,-175.5 651,-187.5 651,-187.5 651,-193.5 645,-199.5 639,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"584.88\" y=\"-177.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">phiAsym[topics_2[word_2]]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node17 -->\r\n",
-       "<g id=\"node18\" class=\"node\">\r\n",
-       "<title>node17</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M569.88,-117.75C569.88,-117.75 539.88,-117.75 539.88,-117.75 533.88,-117.75 527.88,-111.75 527.88,-105.75 527.88,-105.75 527.88,-93.75 527.88,-93.75 527.88,-87.75 533.88,-81.75 539.88,-81.75 539.88,-81.75 569.88,-81.75 569.88,-81.75 575.88,-81.75 581.88,-87.75 581.88,-93.75 581.88,-93.75 581.88,-105.75 581.88,-105.75 581.88,-111.75 575.88,-117.75 569.88,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"554.88\" y=\"-97.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node16&#45;&gt;node17 -->\r\n",
-       "<g id=\"edge14\" class=\"edge\">\r\n",
-       "<title>node16&#45;&gt;node17</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M578.37,-163.2C574.55,-153.06 569.65,-140.02 565.31,-128.48\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"568.7,-127.56 561.9,-119.44 562.15,-130.03 568.7,-127.56\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"580.3\" y=\"-137.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node18 -->\r\n",
-       "<g id=\"node19\" class=\"node\">\r\n",
-       "<title>node18</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M528.25,-36C528.25,-36 463.5,-36 463.5,-36 457.5,-36 451.5,-30 451.5,-24 451.5,-24 451.5,-12 451.5,-12 451.5,-6 457.5,0 463.5,0 463.5,0 528.25,0 528.25,0 534.25,0 540.25,-6 540.25,-12 540.25,-12 540.25,-24 540.25,-24 540.25,-30 534.25,-36 528.25,-36\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"495.88\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">words_2[word_2]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node17&#45;&gt;node18 -->\r\n",
-       "<g id=\"edge15\" class=\"edge\">\r\n",
-       "<title>node17&#45;&gt;node18</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M542.07,-81.45C534.21,-70.82 523.99,-57 515.16,-45.07\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"518.11,-43.17 509.35,-37.21 512.48,-47.33 518.11,-43.17\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node19 -->\r\n",
-       "<g id=\"node20\" class=\"node\">\r\n",
-       "<title>node19</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M491.25,-117.75C491.25,-117.75 426.5,-117.75 426.5,-117.75 420.5,-117.75 414.5,-111.75 414.5,-105.75 414.5,-105.75 414.5,-93.75 414.5,-93.75 414.5,-87.75 420.5,-81.75 426.5,-81.75 426.5,-81.75 491.25,-81.75 491.25,-81.75 497.25,-81.75 503.25,-87.75 503.25,-93.75 503.25,-93.75 503.25,-105.75 503.25,-105.75 503.25,-111.75 497.25,-117.75 491.25,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"458.88\" y=\"-95.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">topics_2[word_2]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node19&#45;&gt;node18 -->\r\n",
-       "<g id=\"edge16\" class=\"edge\">\r\n",
-       "<title>node19&#45;&gt;node18</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M466.9,-81.45C471.69,-71.13 477.86,-57.82 483.29,-46.14\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"486.32,-47.91 487.35,-37.37 479.97,-44.97 486.32,-47.91\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"494.22\" y=\"-56.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">condition</text>\r\n",
-       "</g>\r\n",
-       "<!-- node20 -->\r\n",
-       "<g id=\"node21\" class=\"node\">\r\n",
-       "<title>node20</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M939,-199.5C939,-199.5 830.75,-199.5 830.75,-199.5 824.75,-199.5 818.75,-193.5 818.75,-187.5 818.75,-187.5 818.75,-175.5 818.75,-175.5 818.75,-169.5 824.75,-163.5 830.75,-163.5 830.75,-163.5 939,-163.5 939,-163.5 945,-163.5 951,-169.5 951,-175.5 951,-175.5 951,-187.5 951,-187.5 951,-193.5 945,-199.5 939,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"884.88\" y=\"-177.62\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">phiAsym[topics_3[word_3]]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node21 -->\r\n",
-       "<g id=\"node22\" class=\"node\">\r\n",
-       "<title>node21</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M962.88,-117.75C962.88,-117.75 932.88,-117.75 932.88,-117.75 926.88,-117.75 920.88,-111.75 920.88,-105.75 920.88,-105.75 920.88,-93.75 920.88,-93.75 920.88,-87.75 926.88,-81.75 932.88,-81.75 932.88,-81.75 962.88,-81.75 962.88,-81.75 968.88,-81.75 974.88,-87.75 974.88,-93.75 974.88,-93.75 974.88,-105.75 974.88,-105.75 974.88,-111.75 968.88,-117.75 962.88,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"947.88\" y=\"-97.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node20&#45;&gt;node21 -->\r\n",
-       "<g id=\"edge17\" class=\"edge\">\r\n",
-       "<title>node20&#45;&gt;node21</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M898.55,-163.2C906.97,-152.54 917.92,-138.67 927.37,-126.71\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"929.84,-129.23 933.29,-119.21 924.35,-124.89 929.84,-129.23\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"928.77\" y=\"-137.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node22 -->\r\n",
-       "<g id=\"node23\" class=\"node\">\r\n",
-       "<title>node22</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M994.25,-36C994.25,-36 929.5,-36 929.5,-36 923.5,-36 917.5,-30 917.5,-24 917.5,-24 917.5,-12 917.5,-12 917.5,-6 923.5,0 929.5,0 929.5,0 994.25,0 994.25,0 1000.25,0 1006.25,-6 1006.25,-12 1006.25,-12 1006.25,-24 1006.25,-24 1006.25,-30 1000.25,-36 994.25,-36\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"961.88\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">words_3[word_3]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node21&#45;&gt;node22 -->\r\n",
-       "<g id=\"edge18\" class=\"edge\">\r\n",
-       "<title>node21&#45;&gt;node22</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M950.91,-81.45C952.67,-71.45 954.92,-58.63 956.92,-47.21\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"960.35,-47.94 958.63,-37.49 953.45,-46.73 960.35,-47.94\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node23 -->\r\n",
-       "<g id=\"node24\" class=\"node\">\r\n",
-       "<title>node23</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M1071.25,-117.75C1071.25,-117.75 1006.5,-117.75 1006.5,-117.75 1000.5,-117.75 994.5,-111.75 994.5,-105.75 994.5,-105.75 994.5,-93.75 994.5,-93.75 994.5,-87.75 1000.5,-81.75 1006.5,-81.75 1006.5,-81.75 1071.25,-81.75 1071.25,-81.75 1077.25,-81.75 1083.25,-87.75 1083.25,-93.75 1083.25,-93.75 1083.25,-105.75 1083.25,-105.75 1083.25,-111.75 1077.25,-117.75 1071.25,-117.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"1038.88\" y=\"-95.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">topics_3[word_3]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node23&#45;&gt;node22 -->\r\n",
-       "<g id=\"edge19\" class=\"edge\">\r\n",
-       "<title>node23&#45;&gt;node22</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M1022.17,-81.45C1011.6,-70.5 997.77,-56.18 986.02,-44.01\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"988.8,-41.85 979.34,-37.09 983.77,-46.71 988.8,-41.85\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"1019.61\" y=\"-56.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">condition</text>\r\n",
-       "</g>\r\n",
-       "<!-- node24 -->\r\n",
-       "<g id=\"node25\" class=\"node\">\r\n",
-       "<title>node24</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M1082.88,-281.25C1082.88,-281.25 1052.88,-281.25 1052.88,-281.25 1046.88,-281.25 1040.88,-275.25 1040.88,-269.25 1040.88,-269.25 1040.88,-257.25 1040.88,-257.25 1040.88,-251.25 1046.88,-245.25 1052.88,-245.25 1052.88,-245.25 1082.88,-245.25 1082.88,-245.25 1088.88,-245.25 1094.88,-251.25 1094.88,-257.25 1094.88,-257.25 1094.88,-269.25 1094.88,-269.25 1094.88,-275.25 1088.88,-281.25 1082.88,-281.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"1067.88\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">theta_3</text>\r\n",
-       "</g>\r\n",
-       "<!-- node25 -->\r\n",
-       "<g id=\"node26\" class=\"node\">\r\n",
-       "<title>node25</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M1082.88,-199.5C1082.88,-199.5 1052.88,-199.5 1052.88,-199.5 1046.88,-199.5 1040.88,-193.5 1040.88,-187.5 1040.88,-187.5 1040.88,-175.5 1040.88,-175.5 1040.88,-169.5 1046.88,-163.5 1052.88,-163.5 1052.88,-163.5 1082.88,-163.5 1082.88,-163.5 1088.88,-163.5 1094.88,-169.5 1094.88,-175.5 1094.88,-175.5 1094.88,-187.5 1094.88,-187.5 1094.88,-193.5 1088.88,-199.5 1082.88,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"1067.88\" y=\"-178.78\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node24&#45;&gt;node25 -->\r\n",
-       "<g id=\"edge20\" class=\"edge\">\r\n",
-       "<title>node24&#45;&gt;node25</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M1067.88,-244.95C1067.88,-235.02 1067.88,-222.31 1067.88,-210.95\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"1071.38,-211.28 1067.88,-201.28 1064.38,-211.28 1071.38,-211.28\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"1076.5\" y=\"-219.65\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node25&#45;&gt;node23 -->\r\n",
-       "<g id=\"edge21\" class=\"edge\">\r\n",
-       "<title>node25&#45;&gt;node23</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M1061.58,-163.2C1057.93,-153.16 1053.25,-140.29 1049.09,-128.84\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"1052.38,-127.65 1045.67,-119.44 1045.8,-130.04 1052.38,-127.65\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node26 -->\r\n",
-       "<g id=\"node27\" class=\"node\">\r\n",
-       "<title>node26</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M1083.75,-436C1083.75,-436 1052,-436 1052,-436 1046,-436 1040,-430 1040,-424 1040,-424 1040,-412 1040,-412 1040,-406 1046,-400 1052,-400 1052,-400 1083.75,-400 1083.75,-400 1089.75,-400 1095.75,-406 1095.75,-412 1095.75,-412 1095.75,-424 1095.75,-424 1095.75,-430 1089.75,-436 1083.75,-436\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"1067.88\" y=\"-414.7\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet8</text>\r\n",
-       "</g>\r\n",
-       "<!-- node27 -->\r\n",
-       "<g id=\"node28\" class=\"node\">\r\n",
-       "<title>node27</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M1082.88,-354.25C1082.88,-354.25 1052.88,-354.25 1052.88,-354.25 1046.88,-354.25 1040.88,-348.25 1040.88,-342.25 1040.88,-342.25 1040.88,-330.25 1040.88,-330.25 1040.88,-324.25 1046.88,-318.25 1052.88,-318.25 1052.88,-318.25 1082.88,-318.25 1082.88,-318.25 1088.88,-318.25 1094.88,-324.25 1094.88,-330.25 1094.88,-330.25 1094.88,-342.25 1094.88,-342.25 1094.88,-348.25 1088.88,-354.25 1082.88,-354.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"1067.88\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node26&#45;&gt;node27 -->\r\n",
-       "<g id=\"edge22\" class=\"edge\">\r\n",
-       "<title>node26&#45;&gt;node27</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M1067.88,-400.09C1067.88,-390.18 1067.88,-377.4 1067.88,-365.96\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"1071.38,-366.2 1067.88,-356.2 1064.38,-366.2 1071.38,-366.2\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"1073.5\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node27&#45;&gt;node24 -->\r\n",
-       "<g id=\"edge23\" class=\"edge\">\r\n",
-       "<title>node27&#45;&gt;node24</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M1067.88,-318.06C1067.88,-310.48 1067.88,-301.35 1067.88,-292.79\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"1071.38,-292.79 1067.88,-282.79 1064.38,-292.79 1071.38,-292.79\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node28 -->\r\n",
-       "<g id=\"node29\" class=\"node\">\r\n",
-       "<title>node28</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M189.88,-281.25C189.88,-281.25 159.88,-281.25 159.88,-281.25 153.88,-281.25 147.88,-275.25 147.88,-269.25 147.88,-269.25 147.88,-257.25 147.88,-257.25 147.88,-251.25 153.88,-245.25 159.88,-245.25 159.88,-245.25 189.88,-245.25 189.88,-245.25 195.88,-245.25 201.88,-251.25 201.88,-257.25 201.88,-257.25 201.88,-269.25 201.88,-269.25 201.88,-275.25 195.88,-281.25 189.88,-281.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"174.88\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">theta_2</text>\r\n",
-       "</g>\r\n",
-       "<!-- node29 -->\r\n",
-       "<g id=\"node30\" class=\"node\">\r\n",
-       "<title>node29</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M188.88,-199.5C188.88,-199.5 158.88,-199.5 158.88,-199.5 152.88,-199.5 146.88,-193.5 146.88,-187.5 146.88,-187.5 146.88,-175.5 146.88,-175.5 146.88,-169.5 152.88,-163.5 158.88,-163.5 158.88,-163.5 188.88,-163.5 188.88,-163.5 194.88,-163.5 200.88,-169.5 200.88,-175.5 200.88,-175.5 200.88,-187.5 200.88,-187.5 200.88,-193.5 194.88,-199.5 188.88,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"173.88\" y=\"-178.78\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node28&#45;&gt;node29 -->\r\n",
-       "<g id=\"edge24\" class=\"edge\">\r\n",
-       "<title>node28&#45;&gt;node29</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M174.66,-244.95C174.53,-235.02 174.37,-222.31 174.23,-210.95\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"177.74,-211.24 174.11,-201.28 170.74,-211.33 177.74,-211.24\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"183.06\" y=\"-219.65\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node29&#45;&gt;node19 -->\r\n",
-       "<g id=\"edge25\" class=\"edge\">\r\n",
-       "<title>node29&#45;&gt;node19</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M201.32,-167.35C204.2,-166.03 207.09,-164.72 209.88,-163.5 239.76,-150.36 246.43,-144.52 277.88,-135.75 327.28,-121.97 341.63,-128.07 391.88,-117.75 395.63,-116.98 399.5,-116.13 403.38,-115.25\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"403.92,-118.72 412.84,-113.01 402.31,-111.91 403.92,-118.72\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node30 -->\r\n",
-       "<g id=\"node31\" class=\"node\">\r\n",
-       "<title>node30</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M191.75,-436C191.75,-436 160,-436 160,-436 154,-436 148,-430 148,-424 148,-424 148,-412 148,-412 148,-406 154,-400 160,-400 160,-400 191.75,-400 191.75,-400 197.75,-400 203.75,-406 203.75,-412 203.75,-412 203.75,-424 203.75,-424 203.75,-430 197.75,-436 191.75,-436\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"175.88\" y=\"-414.7\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet7</text>\r\n",
-       "</g>\r\n",
-       "<!-- node31 -->\r\n",
-       "<g id=\"node32\" class=\"node\">\r\n",
-       "<title>node31</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M190.88,-354.25C190.88,-354.25 160.88,-354.25 160.88,-354.25 154.88,-354.25 148.88,-348.25 148.88,-342.25 148.88,-342.25 148.88,-330.25 148.88,-330.25 148.88,-324.25 154.88,-318.25 160.88,-318.25 160.88,-318.25 190.88,-318.25 190.88,-318.25 196.88,-318.25 202.88,-324.25 202.88,-330.25 202.88,-330.25 202.88,-342.25 202.88,-342.25 202.88,-348.25 196.88,-354.25 190.88,-354.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"175.88\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node30&#45;&gt;node31 -->\r\n",
-       "<g id=\"edge26\" class=\"edge\">\r\n",
-       "<title>node30&#45;&gt;node31</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M175.88,-400.09C175.88,-390.18 175.88,-377.4 175.88,-365.96\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"179.38,-366.2 175.88,-356.2 172.38,-366.2 179.38,-366.2\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"181.5\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node31&#45;&gt;node28 -->\r\n",
-       "<g id=\"edge27\" class=\"edge\">\r\n",
-       "<title>node31&#45;&gt;node28</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M175.63,-318.06C175.53,-310.48 175.4,-301.35 175.28,-292.79\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"178.78,-292.74 175.14,-282.79 171.78,-292.84 178.78,-292.74\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node32 -->\r\n",
-       "<g id=\"node33\" class=\"node\">\r\n",
-       "<title>node32</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M43.88,-281.25C43.88,-281.25 13.88,-281.25 13.88,-281.25 7.88,-281.25 1.88,-275.25 1.88,-269.25 1.88,-269.25 1.88,-257.25 1.88,-257.25 1.88,-251.25 7.88,-245.25 13.88,-245.25 13.88,-245.25 43.88,-245.25 43.88,-245.25 49.88,-245.25 55.88,-251.25 55.88,-257.25 55.88,-257.25 55.88,-269.25 55.88,-269.25 55.88,-275.25 49.88,-281.25 43.88,-281.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"28.88\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">theta_1</text>\r\n",
-       "</g>\r\n",
-       "<!-- node33 -->\r\n",
-       "<g id=\"node34\" class=\"node\">\r\n",
-       "<title>node33</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M43.88,-199.5C43.88,-199.5 13.88,-199.5 13.88,-199.5 7.88,-199.5 1.88,-193.5 1.88,-187.5 1.88,-187.5 1.88,-175.5 1.88,-175.5 1.88,-169.5 7.88,-163.5 13.88,-163.5 13.88,-163.5 43.88,-163.5 43.88,-163.5 49.88,-163.5 55.88,-169.5 55.88,-175.5 55.88,-175.5 55.88,-187.5 55.88,-187.5 55.88,-193.5 49.88,-199.5 43.88,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"28.88\" y=\"-178.78\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node32&#45;&gt;node33 -->\r\n",
-       "<g id=\"edge28\" class=\"edge\">\r\n",
-       "<title>node32&#45;&gt;node33</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M28.88,-244.95C28.88,-235.02 28.88,-222.31 28.88,-210.95\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"32.38,-211.28 28.88,-201.28 25.38,-211.28 32.38,-211.28\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"37.5\" y=\"-219.65\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node33&#45;&gt;node15 -->\r\n",
-       "<g id=\"edge29\" class=\"edge\">\r\n",
-       "<title>node33&#45;&gt;node15</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M37.99,-163.2C43.38,-152.95 50.34,-139.75 56.46,-128.12\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"59.51,-129.84 61.07,-119.36 53.32,-126.58 59.51,-129.84\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node34 -->\r\n",
-       "<g id=\"node35\" class=\"node\">\r\n",
-       "<title>node34</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M43.75,-436C43.75,-436 12,-436 12,-436 6,-436 0,-430 0,-424 0,-424 0,-412 0,-412 0,-406 6,-400 12,-400 12,-400 43.75,-400 43.75,-400 49.75,-400 55.75,-406 55.75,-412 55.75,-412 55.75,-424 55.75,-424 55.75,-430 49.75,-436 43.75,-436\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"27.88\" y=\"-414.7\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet6</text>\r\n",
-       "</g>\r\n",
-       "<!-- node35 -->\r\n",
-       "<g id=\"node36\" class=\"node\">\r\n",
-       "<title>node35</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M43.88,-354.25C43.88,-354.25 13.88,-354.25 13.88,-354.25 7.88,-354.25 1.88,-348.25 1.88,-342.25 1.88,-342.25 1.88,-330.25 1.88,-330.25 1.88,-324.25 7.88,-318.25 13.88,-318.25 13.88,-318.25 43.88,-318.25 43.88,-318.25 49.88,-318.25 55.88,-324.25 55.88,-330.25 55.88,-330.25 55.88,-342.25 55.88,-342.25 55.88,-348.25 49.88,-354.25 43.88,-354.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"28.88\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node34&#45;&gt;node35 -->\r\n",
-       "<g id=\"edge30\" class=\"edge\">\r\n",
-       "<title>node34&#45;&gt;node35</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M28.09,-400.09C28.21,-390.18 28.37,-377.4 28.52,-365.96\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"32.01,-366.25 28.64,-356.2 25.01,-366.16 32.01,-366.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"34.06\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node35&#45;&gt;node32 -->\r\n",
-       "<g id=\"edge31\" class=\"edge\">\r\n",
-       "<title>node35&#45;&gt;node32</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M28.88,-318.06C28.88,-310.48 28.88,-301.35 28.88,-292.79\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"32.38,-292.79 28.88,-282.79 25.38,-292.79 32.38,-292.79\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node36 -->\r\n",
-       "<g id=\"node37\" class=\"node\">\r\n",
-       "<title>node36</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M1009.88,-281.25C1009.88,-281.25 979.88,-281.25 979.88,-281.25 973.88,-281.25 967.88,-275.25 967.88,-269.25 967.88,-269.25 967.88,-257.25 967.88,-257.25 967.88,-251.25 973.88,-245.25 979.88,-245.25 979.88,-245.25 1009.88,-245.25 1009.88,-245.25 1015.88,-245.25 1021.88,-251.25 1021.88,-257.25 1021.88,-257.25 1021.88,-269.25 1021.88,-269.25 1021.88,-275.25 1015.88,-281.25 1009.88,-281.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"994.88\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">theta_0</text>\r\n",
-       "</g>\r\n",
-       "<!-- node37 -->\r\n",
-       "<g id=\"node38\" class=\"node\">\r\n",
-       "<title>node37</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M1010.88,-199.5C1010.88,-199.5 980.88,-199.5 980.88,-199.5 974.88,-199.5 968.88,-193.5 968.88,-187.5 968.88,-187.5 968.88,-175.5 968.88,-175.5 968.88,-169.5 974.88,-163.5 980.88,-163.5 980.88,-163.5 1010.88,-163.5 1010.88,-163.5 1016.88,-163.5 1022.88,-169.5 1022.88,-175.5 1022.88,-175.5 1022.88,-187.5 1022.88,-187.5 1022.88,-193.5 1016.88,-199.5 1010.88,-199.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"995.88\" y=\"-178.78\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n",
-       "</g>\r\n",
-       "<!-- node36&#45;&gt;node37 -->\r\n",
-       "<g id=\"edge32\" class=\"edge\">\r\n",
-       "<title>node36&#45;&gt;node37</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M995.09,-244.95C995.22,-235.02 995.38,-222.31 995.52,-210.95\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"999.01,-211.33 995.64,-201.28 992.01,-211.24 999.01,-211.33\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"1004.06\" y=\"-219.65\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n",
-       "</g>\r\n",
-       "<!-- node37&#45;&gt;node11 -->\r\n",
-       "<g id=\"edge33\" class=\"edge\">\r\n",
-       "<title>node37&#45;&gt;node11</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M977.97,-163.22C967.94,-154.19 954.86,-143.45 941.88,-135.75 931.69,-129.71 920.28,-124.3 909.13,-119.64\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"910.56,-116.45 899.98,-115.98 907.96,-122.95 910.56,-116.45\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node38 -->\r\n",
-       "<g id=\"node39\" class=\"node\">\r\n",
-       "<title>node38</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M1009.75,-436C1009.75,-436 978,-436 978,-436 972,-436 966,-430 966,-424 966,-424 966,-412 966,-412 966,-406 972,-400 978,-400 978,-400 1009.75,-400 1009.75,-400 1015.75,-400 1021.75,-406 1021.75,-412 1021.75,-412 1021.75,-424 1021.75,-424 1021.75,-430 1015.75,-436 1009.75,-436\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"993.88\" y=\"-414.7\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet5</text>\r\n",
-       "</g>\r\n",
-       "<!-- node39 -->\r\n",
-       "<g id=\"node40\" class=\"node\">\r\n",
-       "<title>node39</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M1009.88,-354.25C1009.88,-354.25 979.88,-354.25 979.88,-354.25 973.88,-354.25 967.88,-348.25 967.88,-342.25 967.88,-342.25 967.88,-330.25 967.88,-330.25 967.88,-324.25 973.88,-318.25 979.88,-318.25 979.88,-318.25 1009.88,-318.25 1009.88,-318.25 1015.88,-318.25 1021.88,-324.25 1021.88,-330.25 1021.88,-330.25 1021.88,-342.25 1021.88,-342.25 1021.88,-348.25 1015.88,-354.25 1009.88,-354.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"994.88\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node38&#45;&gt;node39 -->\r\n",
-       "<g id=\"edge34\" class=\"edge\">\r\n",
-       "<title>node38&#45;&gt;node39</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M994.09,-400.09C994.21,-390.18 994.37,-377.4 994.52,-365.96\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"998.01,-366.25 994.64,-356.2 991.01,-366.16 998.01,-366.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"1000.06\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node39&#45;&gt;node36 -->\r\n",
-       "<g id=\"edge35\" class=\"edge\">\r\n",
-       "<title>node39&#45;&gt;node36</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M994.88,-318.06C994.88,-310.48 994.88,-301.35 994.88,-292.79\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"998.38,-292.79 994.88,-282.79 991.38,-292.79 998.38,-292.79\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node40 -->\r\n",
-       "<g id=\"node41\" class=\"node\">\r\n",
-       "<title>node40</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M665.75,-599.5C665.75,-599.5 634,-599.5 634,-599.5 628,-599.5 622,-593.5 622,-587.5 622,-587.5 622,-575.5 622,-575.5 622,-569.5 628,-563.5 634,-563.5 634,-563.5 665.75,-563.5 665.75,-563.5 671.75,-563.5 677.75,-569.5 677.75,-575.5 677.75,-575.5 677.75,-587.5 677.75,-587.5 677.75,-593.5 671.75,-599.5 665.75,-599.5\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"649.88\" y=\"-578.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet4</text>\r\n",
-       "</g>\r\n",
-       "<!-- node41 -->\r\n",
-       "<g id=\"node42\" class=\"node\">\r\n",
-       "<title>node41</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M664.88,-517.75C664.88,-517.75 634.88,-517.75 634.88,-517.75 628.88,-517.75 622.88,-511.75 622.88,-505.75 622.88,-505.75 622.88,-493.75 622.88,-493.75 622.88,-487.75 628.88,-481.75 634.88,-481.75 634.88,-481.75 664.88,-481.75 664.88,-481.75 670.88,-481.75 676.88,-487.75 676.88,-493.75 676.88,-493.75 676.88,-505.75 676.88,-505.75 676.88,-511.75 670.88,-517.75 664.88,-517.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"649.88\" y=\"-497.02\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node40&#45;&gt;node41 -->\r\n",
-       "<g id=\"edge36\" class=\"edge\">\r\n",
-       "<title>node40&#45;&gt;node41</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M649.88,-563.59C649.88,-553.68 649.88,-540.9 649.88,-529.46\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"653.38,-529.7 649.88,-519.7 646.38,-529.7 653.38,-529.7\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"655.5\" y=\"-537.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node42 -->\r\n",
-       "<g id=\"node43\" class=\"node\">\r\n",
-       "<title>node42</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M681.12,-436C681.12,-436 618.62,-436 618.62,-436 612.62,-436 606.62,-430 606.62,-424 606.62,-424 606.62,-412 606.62,-412 606.62,-406 612.62,-400 618.62,-400 618.62,-400 681.12,-400 681.12,-400 687.12,-400 693.12,-406 693.12,-412 693.12,-412 693.12,-424 693.12,-424 693.12,-430 687.12,-436 681.12,-436\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"649.88\" y=\"-414.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">phiAsym[vint14]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node41&#45;&gt;node42 -->\r\n",
-       "<g id=\"edge37\" class=\"edge\">\r\n",
-       "<title>node41&#45;&gt;node42</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M649.88,-481.45C649.88,-471.52 649.88,-458.81 649.88,-447.45\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"653.38,-447.78 649.88,-437.78 646.38,-447.78 653.38,-447.78\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node42&#45;&gt;node5 -->\r\n",
-       "<g id=\"edge42\" class=\"edge\">\r\n",
-       "<title>node42&#45;&gt;node5</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M606.4,-405.14C577.69,-395.44 540.89,-379.19 515.88,-354.25 470.59,-309.09 447.42,-233.74 438.86,-199.9\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node42&#45;&gt;node8 -->\r\n",
-       "<g id=\"edge43\" class=\"edge\">\r\n",
-       "<title>node42&#45;&gt;node8</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M670.45,-399.87C696.76,-376.38 740.74,-331.34 755.88,-281.25 764.34,-253.23 752.83,-219.74 743.79,-199.85\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node42&#45;&gt;node12 -->\r\n",
-       "<g id=\"edge44\" class=\"edge\">\r\n",
-       "<title>node42&#45;&gt;node12</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M606.27,-405.98C584.46,-399.91 557.88,-391.64 534.88,-382 431.68,-338.75 336.05,-239.99 300.01,-199.9\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node42&#45;&gt;node16 -->\r\n",
-       "<g id=\"edge45\" class=\"edge\">\r\n",
-       "<title>node42&#45;&gt;node16</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M645.1,-399.76C633.07,-356.39 601.69,-243.16 589.66,-199.77\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node42&#45;&gt;node20 -->\r\n",
-       "<g id=\"edge46\" class=\"edge\">\r\n",
-       "<title>node42&#45;&gt;node20</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M693.49,-417.67C743.35,-415.86 823.53,-404.61 865.88,-354.25 903.43,-309.59 894.88,-233.65 888.61,-199.74\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node45 -->\r\n",
-       "<g id=\"node46\" class=\"node\">\r\n",
-       "<title>node45</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M599.12,-354.25C599.12,-354.25 536.62,-354.25 536.62,-354.25 530.62,-354.25 524.62,-348.25 524.62,-342.25 524.62,-342.25 524.62,-330.25 524.62,-330.25 524.62,-324.25 530.62,-318.25 536.62,-318.25 536.62,-318.25 599.12,-318.25 599.12,-318.25 605.12,-318.25 611.12,-324.25 611.12,-330.25 611.12,-330.25 611.12,-342.25 611.12,-342.25 611.12,-348.25 605.12,-354.25 599.12,-354.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"567.88\" y=\"-332.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">phiAsym[vint13]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node42&#45;&gt;node45 -->\r\n",
-       "<g id=\"edge47\" class=\"edge\">\r\n",
-       "<title>node42&#45;&gt;node45</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M626.4,-399.7C611.22,-386.32 592.27,-367.89 579.96,-354.52\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node48 -->\r\n",
-       "<g id=\"node49\" class=\"node\">\r\n",
-       "<title>node48</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M735.12,-281.25C735.12,-281.25 672.62,-281.25 672.62,-281.25 666.62,-281.25 660.62,-275.25 660.62,-269.25 660.62,-269.25 660.62,-257.25 660.62,-257.25 660.62,-251.25 666.62,-245.25 672.62,-245.25 672.62,-245.25 735.12,-245.25 735.12,-245.25 741.12,-245.25 747.12,-251.25 747.12,-257.25 747.12,-257.25 747.12,-269.25 747.12,-269.25 747.12,-275.25 741.12,-281.25 735.12,-281.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"703.88\" y=\"-259.38\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">phiAsym[vint12]</text>\r\n",
-       "</g>\r\n",
-       "<!-- node42&#45;&gt;node48 -->\r\n",
-       "<g id=\"edge48\" class=\"edge\">\r\n",
-       "<title>node42&#45;&gt;node48</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M648.48,-399.62C650.29,-394.02 652.74,-387.77 654.88,-382 667.97,-346.56 681.85,-304.55 692.2,-281.51\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node43 -->\r\n",
-       "<g id=\"node44\" class=\"node\">\r\n",
-       "<title>node43</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M422.75,-517.75C422.75,-517.75 391,-517.75 391,-517.75 385,-517.75 379,-511.75 379,-505.75 379,-505.75 379,-493.75 379,-493.75 379,-487.75 385,-481.75 391,-481.75 391,-481.75 422.75,-481.75 422.75,-481.75 428.75,-481.75 434.75,-487.75 434.75,-493.75 434.75,-493.75 434.75,-505.75 434.75,-505.75 434.75,-511.75 428.75,-517.75 422.75,-517.75\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"406.88\" y=\"-496.45\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet3</text>\r\n",
-       "</g>\r\n",
-       "<!-- node44 -->\r\n",
-       "<g id=\"node45\" class=\"node\">\r\n",
-       "<title>node44</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M421.88,-436C421.88,-436 391.88,-436 391.88,-436 385.88,-436 379.88,-430 379.88,-424 379.88,-424 379.88,-412 379.88,-412 379.88,-406 385.88,-400 391.88,-400 391.88,-400 421.88,-400 421.88,-400 427.88,-400 433.88,-406 433.88,-412 433.88,-412 433.88,-424 433.88,-424 433.88,-430 427.88,-436 421.88,-436\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"406.88\" y=\"-415.27\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node43&#45;&gt;node44 -->\r\n",
-       "<g id=\"edge38\" class=\"edge\">\r\n",
-       "<title>node43&#45;&gt;node44</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M406.88,-481.84C406.88,-471.93 406.88,-459.15 406.88,-447.71\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"410.38,-447.95 406.88,-437.95 403.38,-447.95 410.38,-447.95\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"412.5\" y=\"-456.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node44&#45;&gt;node45 -->\r\n",
-       "<g id=\"edge39\" class=\"edge\">\r\n",
-       "<title>node44&#45;&gt;node45</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M434.19,-403.47C458.4,-391.48 494.23,-373.73 522.7,-359.63\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"524.06,-362.86 531.46,-355.29 520.95,-356.59 524.06,-362.86\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node45&#45;&gt;node5 -->\r\n",
-       "<g id=\"edge49\" class=\"edge\">\r\n",
-       "<title>node45&#45;&gt;node5</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M552.88,-318.02C527.33,-288.69 475.67,-229.35 450.02,-199.9\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node45&#45;&gt;node8 -->\r\n",
-       "<g id=\"edge50\" class=\"edge\">\r\n",
-       "<title>node45&#45;&gt;node8</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M567.11,-317.86C567.41,-311.77 568.4,-305.01 570.88,-299.25 583.52,-269.74 594.97,-266.69 618.88,-245.25 640.18,-226.14 668.33,-210.73 691.57,-199.96\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node45&#45;&gt;node12 -->\r\n",
-       "<g id=\"edge51\" class=\"edge\">\r\n",
-       "<title>node45&#45;&gt;node12</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M535.69,-317.88C481.22,-288.48 371.48,-229.25 317.03,-199.86\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node45&#45;&gt;node16 -->\r\n",
-       "<g id=\"edge52\" class=\"edge\">\r\n",
-       "<title>node45&#45;&gt;node16</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M553.1,-318.06C549.18,-312.68 545.36,-306.5 542.88,-300.25 529.2,-265.82 515.47,-250.2 532.88,-217.5 536.61,-210.49 542.44,-204.63 548.87,-199.84\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node45&#45;&gt;node20 -->\r\n",
-       "<g id=\"edge53\" class=\"edge\">\r\n",
-       "<title>node45&#45;&gt;node20</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M583.15,-317.89C605.03,-293.16 643.59,-250.23 651.88,-245.25 666.32,-236.56 754.76,-213.98 818.4,-198.42\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node45&#45;&gt;node42 -->\r\n",
-       "<g id=\"edge54\" class=\"edge\">\r\n",
-       "<title>node45&#45;&gt;node42</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M591.31,-354.52C606.49,-367.89 625.44,-386.32 637.76,-399.7\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node45&#45;&gt;node48 -->\r\n",
-       "<g id=\"edge55\" class=\"edge\">\r\n",
-       "<title>node45&#45;&gt;node48</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M595.25,-317.88C615.19,-306.88 642.34,-292.7 664.57,-281.69\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node46 -->\r\n",
-       "<g id=\"node47\" class=\"node\">\r\n",
-       "<title>node46</title>\r\n",
-       "<path fill=\"none\" stroke=\"none\" d=\"M933.75,-436C933.75,-436 902,-436 902,-436 896,-436 890,-430 890,-424 890,-424 890,-412 890,-412 890,-406 896,-400 902,-400 902,-400 933.75,-400 933.75,-400 939.75,-400 945.75,-406 945.75,-412 945.75,-412 945.75,-424 945.75,-424 945.75,-430 939.75,-436 933.75,-436\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"917.88\" y=\"-414.7\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet2</text>\r\n",
-       "</g>\r\n",
-       "<!-- node47 -->\r\n",
-       "<g id=\"node48\" class=\"node\">\r\n",
-       "<title>node47</title>\r\n",
-       "<path fill=\"#000000\" stroke=\"black\" d=\"M844.88,-354.25C844.88,-354.25 814.88,-354.25 814.88,-354.25 808.88,-354.25 802.88,-348.25 802.88,-342.25 802.88,-342.25 802.88,-330.25 802.88,-330.25 802.88,-324.25 808.88,-318.25 814.88,-318.25 814.88,-318.25 844.88,-318.25 844.88,-318.25 850.88,-318.25 856.88,-324.25 856.88,-330.25 856.88,-330.25 856.88,-342.25 856.88,-342.25 856.88,-348.25 850.88,-354.25 844.88,-354.25\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"829.88\" y=\"-333.52\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n",
-       "</g>\r\n",
-       "<!-- node46&#45;&gt;node47 -->\r\n",
-       "<g id=\"edge40\" class=\"edge\">\r\n",
-       "<title>node46&#45;&gt;node47</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M899.21,-400.09C887.13,-389.14 871.17,-374.68 857.62,-362.39\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"860,-359.83 850.24,-355.71 855.3,-365.01 860,-359.83\"/>\r\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"884.77\" y=\"-374.4\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n",
-       "</g>\r\n",
-       "<!-- node47&#45;&gt;node48 -->\r\n",
-       "<g id=\"edge41\" class=\"edge\">\r\n",
-       "<title>node47&#45;&gt;node48</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M802.53,-319.84C785.6,-310.3 763.54,-297.87 744.58,-287.19\"/>\r\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"746.45,-284.22 736.02,-282.36 743.02,-290.32 746.45,-284.22\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node48&#45;&gt;node5 -->\r\n",
-       "<g id=\"edge56\" class=\"edge\">\r\n",
-       "<title>node48&#45;&gt;node5</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M660.36,-245.23C636.76,-236.33 606.95,-225.63 579.88,-217.5 564.93,-213.01 531.93,-205 501.18,-197.77\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node48&#45;&gt;node8 -->\r\n",
-       "<g id=\"edge57\" class=\"edge\">\r\n",
-       "<title>node48&#45;&gt;node8</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M710.6,-244.95C715.8,-231.57 722.97,-213.14 728.16,-199.77\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node48&#45;&gt;node12 -->\r\n",
-       "<g id=\"edge58\" class=\"edge\">\r\n",
-       "<title>node48&#45;&gt;node12</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M660.32,-254.92C594.92,-243.76 467.53,-221.51 359.88,-199.5 357.13,-198.94 354.33,-198.35 351.5,-197.76\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node48&#45;&gt;node16 -->\r\n",
-       "<g id=\"edge59\" class=\"edge\">\r\n",
-       "<title>node48&#45;&gt;node16</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M678.05,-244.95C658.09,-231.57 630.59,-213.14 610.65,-199.77\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node48&#45;&gt;node20 -->\r\n",
-       "<g id=\"edge60\" class=\"edge\">\r\n",
-       "<title>node48&#45;&gt;node20</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M743.15,-244.95C773.41,-231.61 815.05,-213.27 845.37,-199.91\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node48&#45;&gt;node42 -->\r\n",
-       "<g id=\"edge61\" class=\"edge\">\r\n",
-       "<title>node48&#45;&gt;node42</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M704.45,-281.51C699.85,-304.55 685.97,-346.56 672.88,-382 670.74,-387.77 668.29,-394.02 665.59,-399.62\"/>\r\n",
-       "</g>\r\n",
-       "<!-- node48&#45;&gt;node45 -->\r\n",
-       "<g id=\"edge62\" class=\"edge\">\r\n",
-       "<title>node48&#45;&gt;node45</title>\r\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M676.38,-281.69C656.41,-292.7 629.25,-306.88 607.04,-317.88\"/>\r\n",
-       "</g>\r\n",
-       "</g>\r\n",
-       "</svg>\r\n",
-       "\r\n",
-       "    </div>\r\n",
-       "</div>"
-      ]
+      "text/html": "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n                <strong>Graphviz non disponible.</strong><br/>\n                Copiez le contenu de <code>Model_08_29_26_10_14_20_53.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n            </div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
+     "name": "stderr",
+     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
     }
    ],
    "source": [
@@ -2895,75 +1872,54 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== LDA sur corpus complet ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== LDA sur corpus complet ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 1 : Sport=1,00, Politique=0,00, Musique=0,00\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 1 : Sport=1,00, Politique=0,00, Musique=0,00\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 2 : Sport=0,00, Politique=1,00, Musique=0,00\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 2 : Sport=0,00, Politique=1,00, Musique=0,00\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 3 : Sport=0,00, Politique=0,00, Musique=1,00\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 3 : Sport=0,00, Politique=0,00, Musique=1,00\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 4 : Sport=0,60, Politique=0,40, Musique=0,00\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 4 : Sport=0,60, Politique=0,40, Musique=0,00\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 5 : Sport=0,40, Politique=0,00, Musique=0,60\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 5 : Sport=0,40, Politique=0,00, Musique=0,60\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 6 : Sport=1,00, Politique=0,00, Musique=0,00\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 6 : Sport=1,00, Politique=0,00, Musique=0,00\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 7 : Sport=0,60, Politique=0,40, Musique=0,00\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 7 : Sport=0,60, Politique=0,40, Musique=0,00\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "(Proportions basees sur les mots observes)\r\n"
-     ]
+     "name": "stdout",
+     "text": "\n(Proportions basees sur les mots observes)\r\n"
     }
    ],
    "source": [
@@ -3034,6 +1990,339 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5bis. Exemple resolu : selectionner le nombre de topics (K)\n",
+    "\n",
+    "Jusqu'ici, `numTopics = 3` et les priors asymetriques `betaAsym` encodaient notre connaissance des trois themes (Sport, Politique, Musique). En pratique, on ne connait **ni K, ni les mots canoniques** des themes : il faut choisir K en comparant des modeles ajustes sur les donnees seules.\n",
+    "\n",
+    "Cette section ajuste une **vraie LDA corpus** : contrairement a la section precedente ou phi restait fixe a son prior, phi est ici **apris** sur l'ensemble des documents (tableaux jagged, pattern canonique Infer.NET), avec un prior neutre par mot. Trois mesures independantes, calculees sur les topics **effectivement appris** (jamais sur `betaAsym`, jamais sur les etiquettes cachees) :\n",
+    "\n",
+    "1. **Coherence UMass documentaire** (Mimno et al. 2011) : les mots dominants d'un topic doivent co-apparaitre dans les memes documents. Proche de 0 = interpretable.\n",
+    "2. **Redondance entre topics** : similarite cosinus maximale entre paires de topics appris. Un K trop grand fabrique des topics quasi identiques.\n",
+    "3. **Log-vraisemblance predictive held-out** : chaque document est coupe en deux (2 mots pour l'ajustement, 3 pour l'evaluation --- limite assumee, documentee a la fin) ; on evalue la probabilite moyenne des mots retenus.\n",
+    "\n",
+    "Chaque K fait donc l'objet de **deux ajustements separes** : un ajustement sur le **corpus complet** (35 mots) pour les mesures de qualite des topics --- coherence et redondance s'estiment sur les topics appris avec toutes les donnees --- et un ajustement sur la **moitie d'apprentissage** pour la mesure predictive, qui exige par construction des mots tenus a l'ecart.\n",
+    "\n",
+    "**Bris de symetrie sans fuite d'information** : VMP est deterministe et, parti d'un prior uniforme, convergerait vers un mode symetrique ou tous les topics sont identiques. On perturbe donc le prior neutre de chaque topic par un **bruit aleatoire reproductible** (`1.0 + 0.1 * Random`) : le bruit ne sait rien des themes, il choisit seulement un point de depart. C'est l'equivalent VMP de l'initialisation aleatoire de NUTS cote PyMC.\n",
+    "\n",
+    "La verite terrain (3 themes) sert **uniquement** de controle final."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 11,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Split-half : 14 mots ajustement / 21 mots held-out\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Coherence UMass et split-half prets.\r\n"
+    }
+   ],
+   "source": [
+    "// Protocole de selection de K : split-half deterministe + coherence UMass\n",
+    "\n",
+    "// Chaque document (5 mots) est coupe : 2 mots pour l'ajustement, 3 pour l'evaluation\n",
+    "int[][] docsFit = documents.Select(d => d.Take(d.Length / 2).ToArray()).ToArray();\n",
+    "int[][] docsHeld = documents.Select(d => d.Skip(d.Length / 2).ToArray()).ToArray();\n",
+    "\n",
+    "Console.WriteLine($\"Split-half : {docsFit.Sum(d => d.Length)} mots ajustement / {docsHeld.Sum(d => d.Length)} mots held-out\");\n",
+    "\n",
+    "// Ensembles de mots par document (pour la coherence UMass, calculee sur le corpus complet)\n",
+    "HashSet<int>[] ensemblesDocs = documents.Select(d => new HashSet<int>(d)).ToArray();\n",
+    "\n",
+    "double FreqDoc(int w) => ensemblesDocs.Count(s => s.Contains(w));\n",
+    "double CoFreq(int w1, int w2) => ensemblesDocs.Count(s => s.Contains(w1) && s.Contains(w2));\n",
+    "\n",
+    "double CoherenceUMass(double[][] phiEstime, int topN = 5)\n",
+    "{\n",
+    "    double total = 0.0;\n",
+    "    foreach (double[] ligne in phiEstime)\n",
+    "    {\n",
+    "        int[] dominants = ligne\n",
+    "            .Select((p, w) => (p, w))\n",
+    "            .OrderByDescending(x => x.p)\n",
+    "            .Take(topN)\n",
+    "            .Select(x => x.w)\n",
+    "            .ToArray();\n",
+    "        for (int i = 0; i < dominants.Length; i++)\n",
+    "            for (int j = 0; j < dominants.Length; j++)\n",
+    "                if (i != j)\n",
+    "                    total += Math.Log((CoFreq(dominants[i], dominants[j]) + 1) / (FreqDoc(dominants[i]) + 1));\n",
+    "    }\n",
+    "    return total / phiEstime.Length;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Coherence UMass et split-half prets.\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 12,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "K=2 : coherence UMass=-9,77, redondance=0,538, log-prob/mot held-out=-2,186\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "K=3 : coherence UMass=-11,20, redondance=0,614, log-prob/mot held-out=-2,161\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "K=4 : coherence UMass=-11,65, redondance=0,867, log-prob/mot held-out=-2,121\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "K=5 : coherence UMass=-13,18, redondance=0,882, log-prob/mot held-out=-2,126\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "K=6 : coherence UMass=-12,88, redondance=0,999, log-prob/mot held-out=-2,137\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nSynthese de la selection de K :\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  K    UMass  redondance  held-out/mot\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "----------------------------------------\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  2    -9,77       0,538        -2,186\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  3   -11,20       0,614        -2,161\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  4   -11,65       0,867        -2,121\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  5   -13,18       0,882        -2,126\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  6   -12,88       0,999        -2,137\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nK=2 : topic 0 = musique, concert, artiste, equipe | topic 1 = match, sport, election, equipe\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nK=3 : topic 0 = match, sport, equipe, vote | topic 1 = concert, musique, artiste, equipe | topic 2 = election, politique, sport, vote\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nK=4 : topic 0 = election, politique, vote, sport | topic 1 = concert, musique, artiste, equipe | topic 2 = sport, election, vote, equipe | topic 3 = match, sport, equipe, election\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nK=5 : topic 0 = election, politique, vote, sport | topic 1 = sport, equipe, politique, election | topic 2 = concert, musique, artiste, equipe | topic 3 = match, sport, equipe, concert | topic 4 = match, vote, election, sport\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nK=6 : topic 0 = match, sport, equipe, vote | topic 1 = election, equipe, match, sport | topic 2 = sport, equipe, politique, election | topic 3 = election, politique, vote, equipe | topic 4 = equipe, election, sport, match | topic 5 = concert, musique, artiste, equipe\r\n"
+    }
+   ],
+   "source": [
+    "// Ajustement reel des LDA concurrentes : K = 2..6, phi APPRIS, moteur VMP\n",
+    "// Deux ajustements par K : corpus complet (qualite des topics) + moitie 1 (predictif)\n",
+    "\n",
+    "(double[][] phi, double[][] theta) AjusterLDA(int K, int[][] docs, double[][] beta)\n",
+    "{\n",
+    "    Range topicR = new Range(K).Named($\"topic{K}_{docs.Length}\");\n",
+    "    Range docR = new Range(docs.Length).Named($\"doc{K}_{docs.Length}\");\n",
+    "    Range wordR = new Range(docs[0].Length).Named($\"word{K}_{docs.Length}\");\n",
+    "\n",
+    "    VariableArray<Vector> phiVar = Variable.Array<Vector>(topicR).Named($\"phiSel{K}_{docs.Length}\");\n",
+    "    for (int k = 0; k < K; k++)\n",
+    "        phiVar[k] = Variable.Dirichlet(beta[k]);\n",
+    "\n",
+    "    VariableArray<Vector> thetaVar = Variable.Array<Vector>(docR).Named($\"thetaSel{K}_{docs.Length}\");\n",
+    "    thetaVar[docR] = Variable.DirichletSymmetric(K, 0.5).ForEach(docR);\n",
+    "\n",
+    "    var zAssign = Variable.Array(Variable.Array<int>(wordR), docR).Named($\"zSel{K}_{docs.Length}\");\n",
+    "    var wObs = Variable.Array(Variable.Array<int>(wordR), docR).Named($\"wSel{K}_{docs.Length}\");\n",
+    "\n",
+    "    using (Variable.ForEach(docR))\n",
+    "    {\n",
+    "        zAssign[docR].SetValueRange(topicR);\n",
+    "        using (Variable.ForEach(wordR))\n",
+    "        {\n",
+    "            zAssign[docR][wordR] = Variable.Discrete(thetaVar[docR]);\n",
+    "            using (Variable.Switch(zAssign[docR][wordR]))\n",
+    "                wObs[docR][wordR] = Variable.Discrete(phiVar[zAssign[docR][wordR]]);\n",
+    "        }\n",
+    "    }\n",
+    "    wObs.ObservedValue = docs;\n",
+    "\n",
+    "    var moteur = new InferenceEngine(new VariationalMessagePassing());\n",
+    "    moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;\n",
+    "    moteur.NumberOfIterations = 50;\n",
+    "    moteur.ShowProgress = false;\n",
+    "\n",
+    "    Dirichlet[] phiPost = moteur.Infer<Dirichlet[]>(phiVar);\n",
+    "    Dirichlet[] thetaPost = moteur.Infer<Dirichlet[]>(thetaVar);\n",
+    "\n",
+    "    double[][] phiM = new double[K][];\n",
+    "    for (int k = 0; k < K; k++)\n",
+    "    {\n",
+    "        Vector m = phiPost[k].GetMean();\n",
+    "        phiM[k] = new double[vocabSize];\n",
+    "        for (int w = 0; w < vocabSize; w++) phiM[k][w] = m[w];\n",
+    "    }\n",
+    "    double[][] thetaM = new double[docs.Length][];\n",
+    "    for (int d = 0; d < docs.Length; d++)\n",
+    "    {\n",
+    "        Vector m = thetaPost[d].GetMean();\n",
+    "        thetaM[d] = new double[K];\n",
+    "        for (int k = 0; k < K; k++) thetaM[d][k] = m[k];\n",
+    "    }\n",
+    "    return (phiM, thetaM);\n",
+    "}\n",
+    "\n",
+    "int[] grilleK = { 2, 3, 4, 5, 6 };\n",
+    "var resultatsK = new List<(int K, double coherence, double redondance, double heldout)>();\n",
+    "var phiParK = new Dictionary<int, double[][]>();\n",
+    "\n",
+    "foreach (int K in grilleK)\n",
+    "{\n",
+    "    // Prior neutre + jitter aleatoire reproductible (bris de symetrie sans fuite)\n",
+    "    var rng = new Random(1000 + K);\n",
+    "    double[][] betaNeutre = new double[K][];\n",
+    "    for (int k = 0; k < K; k++)\n",
+    "    {\n",
+    "        betaNeutre[k] = new double[vocabSize];\n",
+    "        for (int w = 0; w < vocabSize; w++)\n",
+    "            betaNeutre[k][w] = 1.0 + 0.1 * rng.NextDouble();\n",
+    "    }\n",
+    "\n",
+    "    // Ajustement A : corpus complet -> topics appris pour coherence/redondance\n",
+    "    var (phiPlein, _) = AjusterLDA(K, documents, betaNeutre);\n",
+    "    phiParK[K] = phiPlein;\n",
+    "\n",
+    "    // Ajustement B : moitie 1 -> parametres pour la mesure predictive held-out\n",
+    "    var (phiDemi, thetaDemi) = AjusterLDA(K, docsFit, betaNeutre);\n",
+    "\n",
+    "    // Mesure 1 : coherence UMass sur les topics appris (corpus complet)\n",
+    "    double coherence = CoherenceUMass(phiPlein, topN: 5);\n",
+    "\n",
+    "    // Mesure 2 : redondance = similarite cosinus max entre paires de topics\n",
+    "    double redondance = 0.0;\n",
+    "    for (int a = 0; a < K; a++)\n",
+    "        for (int b = 0; b < K; b++)\n",
+    "        {\n",
+    "            if (a == b) continue;\n",
+    "            double ps = 0, na = 0, nb = 0;\n",
+    "            for (int w = 0; w < vocabSize; w++)\n",
+    "            {\n",
+    "                ps += phiPlein[a][w] * phiPlein[b][w];\n",
+    "                na += phiPlein[a][w] * phiPlein[a][w];\n",
+    "                nb += phiPlein[b][w] * phiPlein[b][w];\n",
+    "            }\n",
+    "            double cos = ps / (Math.Sqrt(na) * Math.Sqrt(nb) + 1e-12);\n",
+    "            if (cos > redondance) redondance = cos;\n",
+    "        }\n",
+    "\n",
+    "    // Mesure 3 : log-probabilite moyenne par mot held-out (ajustement B uniquement)\n",
+    "    double logLl = 0.0;\n",
+    "    int nMotsHeld = 0;\n",
+    "    for (int d = 0; d < numDocs; d++)\n",
+    "        foreach (int w in docsHeld[d])\n",
+    "        {\n",
+    "            double p = 0.0;\n",
+    "            for (int k = 0; k < K; k++) p += thetaDemi[d][k] * phiDemi[k][w];\n",
+    "            logLl += Math.Log(p + 1e-12);\n",
+    "            nMotsHeld++;\n",
+    "        }\n",
+    "    double heldoutParMot = logLl / nMotsHeld;\n",
+    "\n",
+    "    resultatsK.Add((K, coherence, redondance, heldoutParMot));\n",
+    "    Console.WriteLine($\"K={K} : coherence UMass={coherence:F2}, redondance={redondance:F3}, log-prob/mot held-out={heldoutParMot:F3}\");\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"\\nSynthese de la selection de K :\");\n",
+    "Console.WriteLine(\"  K    UMass  redondance  held-out/mot\");\n",
+    "Console.WriteLine(new string('-', 40));\n",
+    "foreach (var r in resultatsK)\n",
+    "    Console.WriteLine($\"{r.K,3} {r.coherence,8:F2} {r.redondance,11:F3} {r.heldout,13:F3}\");\n",
+    "\n",
+    "// Mots dominants par topic pour chaque K (les topics APPRIS)\n",
+    "foreach (int K in grilleK)\n",
+    "{\n",
+    "    var lignes = phiParK[K].Select(ligne =>\n",
+    "    {\n",
+    "        int[] dom = ligne.Select((p, w) => (p, w)).OrderByDescending(x => x.p).Take(4)\n",
+    "                         .Select(x => x.w).ToArray();\n",
+    "        return string.Join(\", \", dom.Select(w => vocabulaire[w]));\n",
+    "    }).ToArray();\n",
+    "    Console.WriteLine($\"\\nK={K} : \" + string.Join(\" | \", lignes.Select((t, k) => $\"topic {k} = {t}\")));\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpretation : des metriques qui divergent\n",
+    "\n",
+    "Aucun K ne domine sur les trois mesures a la fois --- et c'est precisement la lecon :\n",
+    "\n",
+    "| Mesure | Gagnant | Lecture |\n",
+    "|--------|---------|---------|\n",
+    "| Coherence UMass | **K=2** (-9,77) | Mais K=2 **fusionne Sport et Politique** en un seul topic (top-mots : match, sport, election) |\n",
+    "| Held-out | **K=4** (-2,121) | Ecarts de 0,016-0,065 nat/mot contre K=2..3 : **dans le bruit** pour 21 mots evalues |\n",
+    "| Redondance | condamne K=6 | 0,999 (topics clones) ; deja 0,867 des K=4 |\n",
+    "\n",
+    "Quatre enseignements :\n",
+    "\n",
+    "1. **Chaque metrique repond a une question differente.** La coherence prefere les topics larges et peu nombreux (les paires de mots dominants co-occurrent presque toujours) ; la prevision recompense la capacite predictive (plus de topics = plus de parametres = meilleur ajustement, jusqu'au sur-ajustement) ; la redondance detecte les topics clones fabriques par un K trop grand.\n",
+    "\n",
+    "2. **Le K=2 est structurant a lire** : les top-mots (match, sport, election) montrent que le modele fusionne Sport et Politique --- c'est le mot polysemique « match » (Doc 7) qui sert de pont entre les deux themes. La granularite K=2 ne raconte pas la meme histoire que K=3 : l'une des deux est un choix editorial, pas une erreur.\n",
+    "\n",
+    "3. **K=3 est le plus interpretable** : un pole musique (concert, musique, artiste), un pole politique (election, politique, vote), un pole sport (match, sport, equipe) --- exactement les trois themes generateurs. C'est aussi la que la lecture humaine et la verite terrain convergent, alors qu'aucune metrique seule ne le designe gagnant.\n",
+    "\n",
+    "4. **Limite documentee** : la mesure predictive n'a que 21 mots a evaluer et s'appuie sur des thetas appris sur 2 mots par document --- ses ecarts entre K=2..5 sont tous dans le bruit. Sur un corpus de demonstration, la selection de K combine donc redondance (qui elimine nettement K=6), coherence et lecture des top-mots ; un corpus reel utiliserait des held-out plus larges.\n",
+    "\n",
+    "**Ces topics viennent de l'inference** (phi appris par VMP, priors neutres + jitter aleatoire reproductible) : ni le comptage par categories connues de la section precedente (qui echouait sur « match »), ni les priors asymetriques `betaAsym` qui codaient les themes dans le prior. La structure emerge ici des seules co-occurrences."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1dc820f4",
    "metadata": {
     "papermill": {
@@ -3057,7 +2346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "0e5bd4a3",
    "metadata": {
     "dotnet_interactive": {
@@ -3086,171 +2375,125 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Distribution Mots par Topic (phi) ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Distribution Mots par Topic (phi) ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Topic 1 (Sport) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Topic 1 (Sport) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  sport        : 0,30\r\n"
-     ]
+     "name": "stdout",
+     "text": "  sport        : 0,30\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  equipe       : 0,30\r\n"
-     ]
+     "name": "stdout",
+     "text": "  equipe       : 0,30\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  match        : 0,30\r\n"
-     ]
+     "name": "stdout",
+     "text": "  match        : 0,30\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Topic 2 (Politique) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Topic 2 (Politique) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  politique    : 0,30\r\n"
-     ]
+     "name": "stdout",
+     "text": "  politique    : 0,30\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  election     : 0,30\r\n"
-     ]
+     "name": "stdout",
+     "text": "  election     : 0,30\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  vote         : 0,30\r\n"
-     ]
+     "name": "stdout",
+     "text": "  vote         : 0,30\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Topic 3 (Musique) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Topic 3 (Musique) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  musique      : 0,30\r\n"
-     ]
+     "name": "stdout",
+     "text": "  musique      : 0,30\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  concert      : 0,30\r\n"
-     ]
+     "name": "stdout",
+     "text": "  concert      : 0,30\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  artiste      : 0,30\r\n"
-     ]
+     "name": "stdout",
+     "text": "  artiste      : 0,30\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>P(mot | Topic=Sport) - 3 mots dominants a 0.30</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.081</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.162</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.243</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.324</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='62.387' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='79.333' y='294' text-anchor='middle' fill='#333333'>sport</text><rect x='117.053' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='134' y='294' text-anchor='middle' fill='#333333'>equipe</text><rect x='171.72' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='188.667' y='294' text-anchor='middle' fill='#333333'>match</text><rect x='226.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='243.333' y='294' text-anchor='middle' fill='#333333'>politique</text><rect x='281.053' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='298' y='294' text-anchor='middle' fill='#333333'>election</text><rect x='335.72' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='352.667' y='294' text-anchor='middle' fill='#333333'>vote</text><rect x='390.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='407.333' y='294' text-anchor='middle' fill='#333333'>musique</text><rect x='445.053' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='462' y='294' text-anchor='middle' fill='#333333'>concert</text><rect x='499.72' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='516.667' y='294' text-anchor='middle' fill='#333333'>artiste</text></svg>"
-      ]
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>P(mot | Topic=Sport) - 3 mots dominants a 0.30</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.081</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.162</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.243</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.324</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='62.387' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='79.333' y='294' text-anchor='middle' fill='#333333'>sport</text><rect x='117.053' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='134' y='294' text-anchor='middle' fill='#333333'>equipe</text><rect x='171.72' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='188.667' y='294' text-anchor='middle' fill='#333333'>match</text><rect x='226.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='243.333' y='294' text-anchor='middle' fill='#333333'>politique</text><rect x='281.053' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='298' y='294' text-anchor='middle' fill='#333333'>election</text><rect x='335.72' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='352.667' y='294' text-anchor='middle' fill='#333333'>vote</text><rect x='390.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='407.333' y='294' text-anchor='middle' fill='#333333'>musique</text><rect x='445.053' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='462' y='294' text-anchor='middle' fill='#333333'>concert</text><rect x='499.72' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='516.667' y='294' text-anchor='middle' fill='#333333'>artiste</text></svg>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  [Sport] pic sur les 3 premiers mots (0.30) puis plateau quasi-nul (0.01-0.02).\r\n"
-     ]
+     "name": "stdout",
+     "text": "  [Sport] pic sur les 3 premiers mots (0.30) puis plateau quasi-nul (0.01-0.02).\r\n"
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>P(mot | Topic=Politique) - 3 mots dominants a 0.30</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.081</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.162</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.243</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.324</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='62.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='79.333' y='294' text-anchor='middle' fill='#333333'>sport</text><rect x='117.053' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='134' y='294' text-anchor='middle' fill='#333333'>equipe</text><rect x='171.72' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='188.667' y='294' text-anchor='middle' fill='#333333'>match</text><rect x='226.387' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='243.333' y='294' text-anchor='middle' fill='#333333'>politique</text><rect x='281.053' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='298' y='294' text-anchor='middle' fill='#333333'>election</text><rect x='335.72' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='352.667' y='294' text-anchor='middle' fill='#333333'>vote</text><rect x='390.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='407.333' y='294' text-anchor='middle' fill='#333333'>musique</text><rect x='445.053' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='462' y='294' text-anchor='middle' fill='#333333'>concert</text><rect x='499.72' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='516.667' y='294' text-anchor='middle' fill='#333333'>artiste</text></svg>"
-      ]
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>P(mot | Topic=Politique) - 3 mots dominants a 0.30</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.081</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.162</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.243</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.324</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='62.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='79.333' y='294' text-anchor='middle' fill='#333333'>sport</text><rect x='117.053' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='134' y='294' text-anchor='middle' fill='#333333'>equipe</text><rect x='171.72' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='188.667' y='294' text-anchor='middle' fill='#333333'>match</text><rect x='226.387' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='243.333' y='294' text-anchor='middle' fill='#333333'>politique</text><rect x='281.053' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='298' y='294' text-anchor='middle' fill='#333333'>election</text><rect x='335.72' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='352.667' y='294' text-anchor='middle' fill='#333333'>vote</text><rect x='390.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='407.333' y='294' text-anchor='middle' fill='#333333'>musique</text><rect x='445.053' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='462' y='294' text-anchor='middle' fill='#333333'>concert</text><rect x='499.72' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='516.667' y='294' text-anchor='middle' fill='#333333'>artiste</text></svg>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  [Politique] bloc-diagonal decale : mots 4-6 (indices 3-5) a 0.30.\r\n"
-     ]
+     "name": "stdout",
+     "text": "  [Politique] bloc-diagonal decale : mots 4-6 (indices 3-5) a 0.30.\r\n"
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>P(mot | Topic=Musique) - 3 mots dominants a 0.30</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.081</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.162</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.243</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.324</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='62.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='79.333' y='294' text-anchor='middle' fill='#333333'>sport</text><rect x='117.053' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='134' y='294' text-anchor='middle' fill='#333333'>equipe</text><rect x='171.72' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='188.667' y='294' text-anchor='middle' fill='#333333'>match</text><rect x='226.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='243.333' y='294' text-anchor='middle' fill='#333333'>politique</text><rect x='281.053' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='298' y='294' text-anchor='middle' fill='#333333'>election</text><rect x='335.72' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='352.667' y='294' text-anchor='middle' fill='#333333'>vote</text><rect x='390.387' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='407.333' y='294' text-anchor='middle' fill='#333333'>musique</text><rect x='445.053' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='462' y='294' text-anchor='middle' fill='#333333'>concert</text><rect x='499.72' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='516.667' y='294' text-anchor='middle' fill='#333333'>artiste</text></svg>"
-      ]
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>P(mot | Topic=Musique) - 3 mots dominants a 0.30</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.081</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.162</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.243</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.324</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='62.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='79.333' y='294' text-anchor='middle' fill='#333333'>sport</text><rect x='117.053' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='134' y='294' text-anchor='middle' fill='#333333'>equipe</text><rect x='171.72' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='188.667' y='294' text-anchor='middle' fill='#333333'>match</text><rect x='226.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='243.333' y='294' text-anchor='middle' fill='#333333'>politique</text><rect x='281.053' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='298' y='294' text-anchor='middle' fill='#333333'>election</text><rect x='335.72' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='352.667' y='294' text-anchor='middle' fill='#333333'>vote</text><rect x='390.387' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='407.333' y='294' text-anchor='middle' fill='#333333'>musique</text><rect x='445.053' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='462' y='294' text-anchor='middle' fill='#333333'>concert</text><rect x='499.72' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='516.667' y='294' text-anchor='middle' fill='#333333'>artiste</text></svg>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  [Musique] bloc-diagonal en queue : mots 7-9 (indices 6-8) a 0.30.\r\n"
-     ]
+     "name": "stdout",
+     "text": "  [Musique] bloc-diagonal en queue : mots 7-9 (indices 6-8) a 0.30.\r\n"
     }
    ],
    "source": [
@@ -3390,7 +2633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "85050b23",
    "metadata": {
     "dotnet_interactive": {
@@ -3419,47 +2662,34 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Prediction Nouveau Document ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Prediction Nouveau Document ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Mots : sport, equipe, musique, concert, sport\r\n"
-     ]
+     "name": "stdout",
+     "text": "Mots : sport, equipe, musique, concert, sport\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Probabilites de topics :\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nProbabilites de topics :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Sport        : 0,937\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Sport        : 0,937\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Politique    : 0,000\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Politique    : 0,000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Musique      : 0,062\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Musique      : 0,062\r\n"
     }
    ],
    "source": [
@@ -3667,7 +2897,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "486b86a1",
    "metadata": {
     "dotnet_interactive": {
@@ -3696,67 +2926,49 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Corpus Etendu (4 topics) ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Corpus Etendu (4 topics) ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 1 [Sport   ] : football, basketball, tennis, competition, football\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 1 [Sport   ] : football, basketball, tennis, competition, football\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 2 [Tech    ] : ordinateur, logiciel, internet, application, logiciel\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 2 [Tech    ] : ordinateur, logiciel, internet, application, logiciel\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 3 [Cuisine ] : recette, ingredient, cuisson, gastronomie, ingredient\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 3 [Cuisine ] : recette, ingredient, cuisson, gastronomie, ingredient\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 4 [Voyage  ] : hotel, avion, destination, tourisme, avion\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 4 [Voyage  ] : hotel, avion, destination, tourisme, avion\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 5 [Tech    ] : football, ordinateur, logiciel, basketball, internet\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 5 [Tech    ] : football, ordinateur, logiciel, basketball, internet\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 6 [Voyage  ] : recette, hotel, avion, cuisson, destination\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 6 [Voyage  ] : recette, hotel, avion, cuisson, destination\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 7 [Sport   ] : tennis, competition, football, basketball, tennis\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 7 [Sport   ] : tennis, competition, football, basketball, tennis\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Doc 8 [Tech    ] : internet, application, ordinateur, logiciel, application\r\n"
-     ]
+     "name": "stdout",
+     "text": "Doc 8 [Tech    ] : internet, application, ordinateur, logiciel, application\r\n"
     }
    ],
    "source": [
@@ -3967,7 +3179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "39a2f788",
    "metadata": {
     "execution": {
@@ -3987,11 +3199,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\r\n"
     }
    ],
    "source": [
@@ -4073,7 +3283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "908106ac",
    "metadata": {
     "execution": {
@@ -4093,11 +3303,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : detection de theme emergent\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : detection de theme emergent\r\n"
     }
    ],
    "source": [
@@ -4184,7 +3392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "4a80aa15",
    "metadata": {
     "execution": {
@@ -4204,11 +3412,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : evaluation de coherence des topics\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : evaluation de coherence des topics\r\n"
     }
    ],
    "source": [
@@ -4303,7 +3509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "54e8a060",
    "metadata": {
     "execution": {
@@ -4323,11 +3529,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : nombre optimal de topics\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : nombre optimal de topics\r\n"
     }
    ],
    "source": [
@@ -4440,18 +3644,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 15.570591,
-   "end_time": "2026-06-22T19:17:31.951759",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "Infer-11-Topic-Models.ipynb",
-   "output_path": "Infer-11-Topic-Models.ipynb",
-   "parameters": {},
-   "start_time": "2026-06-22T19:17:16.381168",
-   "version": "2.6.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb
@@ -1,14 +1,42 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ac9058ae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:12:56.380293Z",
+     "iopub.status.busy": "2026-08-29T08:12:56.380084Z",
+     "iopub.status.idle": "2026-08-29T08:12:56.383782Z",
+     "shell.execute_reply": "2026-08-29T08:12:56.383293Z"
+    },
+    "papermill": {
+     "duration": 0.011526,
+     "end_time": "2026-08-29T08:12:56.385129",
+     "exception": false,
+     "start_time": "2026-08-29T08:12:56.373603",
+     "status": "completed"
+    },
+    "tags": [
+     "injected-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "BATCH_MODE = \"true\"\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "a1b2c3d0",
    "metadata": {
     "papermill": {
-     "duration": 0.039883,
-     "end_time": "2026-06-03T00:03:23.553353+00:00",
+     "duration": 0.00367,
+     "end_time": "2026-08-29T08:12:56.392974",
      "exception": false,
-     "start_time": "2026-06-03T00:03:23.513470+00:00",
+     "start_time": "2026-08-29T08:12:56.389304",
      "status": "completed"
     },
     "tags": []
@@ -34,20 +62,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "b2c3d4e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:51:06.133793Z",
-     "iopub.status.busy": "2026-07-03T15:51:06.132787Z",
-     "iopub.status.idle": "2026-07-03T15:51:08.938282Z",
-     "shell.execute_reply": "2026-07-03T15:51:08.938282Z"
+     "iopub.execute_input": "2026-08-29T08:12:56.402329Z",
+     "iopub.status.busy": "2026-08-29T08:12:56.401860Z",
+     "iopub.status.idle": "2026-08-29T08:12:58.319197Z",
+     "shell.execute_reply": "2026-08-29T08:12:58.318494Z"
     },
     "papermill": {
-     "duration": 7.85928,
-     "end_time": "2026-06-03T00:03:31.437590+00:00",
+     "duration": 1.924036,
+     "end_time": "2026-08-29T08:12:58.320518",
      "exception": false,
-     "start_time": "2026-06-03T00:03:23.578310+00:00",
+     "start_time": "2026-08-29T08:12:56.396482",
      "status": "completed"
     },
     "tags": []
@@ -57,7 +85,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PyMC version: 5.28.5\n"
+      "PyMC version: 6.0.1\n"
      ]
     }
    ],
@@ -111,10 +139,10 @@
    "id": "c3d4e5f2",
    "metadata": {
     "papermill": {
-     "duration": 0.005402,
-     "end_time": "2026-06-03T00:03:31.448722+00:00",
+     "duration": 0.003584,
+     "end_time": "2026-08-29T08:12:58.328401",
      "exception": false,
-     "start_time": "2026-06-03T00:03:31.443320+00:00",
+     "start_time": "2026-08-29T08:12:58.324817",
      "status": "completed"
     },
     "tags": []
@@ -144,10 +172,10 @@
    "id": "d4e5f6a3",
    "metadata": {
     "papermill": {
-     "duration": 0.005046,
-     "end_time": "2026-06-03T00:03:31.458732+00:00",
+     "duration": 0.003697,
+     "end_time": "2026-08-29T08:12:58.336573",
      "exception": false,
-     "start_time": "2026-06-03T00:03:31.453686+00:00",
+     "start_time": "2026-08-29T08:12:58.332876",
      "status": "completed"
     },
     "tags": []
@@ -200,20 +228,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "e5f6a7b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:51:08.940737Z",
-     "iopub.status.busy": "2026-07-03T15:51:08.940737Z",
-     "iopub.status.idle": "2026-07-03T15:51:08.948234Z",
-     "shell.execute_reply": "2026-07-03T15:51:08.948234Z"
+     "iopub.execute_input": "2026-08-29T08:12:58.344274Z",
+     "iopub.status.busy": "2026-08-29T08:12:58.343799Z",
+     "iopub.status.idle": "2026-08-29T08:12:58.352946Z",
+     "shell.execute_reply": "2026-08-29T08:12:58.352416Z"
     },
     "papermill": {
-     "duration": 0.027415,
-     "end_time": "2026-06-03T00:03:31.491655+00:00",
+     "duration": 0.014023,
+     "end_time": "2026-08-29T08:12:58.353774",
      "exception": false,
-     "start_time": "2026-06-03T00:03:31.464240+00:00",
+     "start_time": "2026-08-29T08:12:58.339751",
      "status": "completed"
     },
     "tags": []
@@ -286,10 +314,10 @@
    "id": "947a32cc",
    "metadata": {
     "papermill": {
-     "duration": 0.004968,
-     "end_time": "2026-06-03T00:03:31.502738+00:00",
+     "duration": 0.003165,
+     "end_time": "2026-08-29T08:12:58.360271",
      "exception": false,
-     "start_time": "2026-06-03T00:03:31.497770+00:00",
+     "start_time": "2026-08-29T08:12:58.357106",
      "status": "completed"
     },
     "tags": []
@@ -304,20 +332,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "f6a7b8c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:51:08.949241Z",
-     "iopub.status.busy": "2026-07-03T15:51:08.949241Z",
-     "iopub.status.idle": "2026-07-03T15:51:08.958246Z",
-     "shell.execute_reply": "2026-07-03T15:51:08.958246Z"
+     "iopub.execute_input": "2026-08-29T08:12:58.368606Z",
+     "iopub.status.busy": "2026-08-29T08:12:58.368261Z",
+     "iopub.status.idle": "2026-08-29T08:12:58.374000Z",
+     "shell.execute_reply": "2026-08-29T08:12:58.373118Z"
     },
     "papermill": {
-     "duration": 0.0164,
-     "end_time": "2026-06-03T00:03:31.524217+00:00",
+     "duration": 0.011148,
+     "end_time": "2026-08-29T08:12:58.374935",
      "exception": false,
-     "start_time": "2026-06-03T00:03:31.507817+00:00",
+     "start_time": "2026-08-29T08:12:58.363787",
      "status": "completed"
     },
     "tags": []
@@ -362,10 +390,10 @@
    "id": "a7b8c9d6",
    "metadata": {
     "papermill": {
-     "duration": 0.00539,
-     "end_time": "2026-06-03T00:03:31.535112+00:00",
+     "duration": 0.003586,
+     "end_time": "2026-08-29T08:12:58.382041",
      "exception": false,
-     "start_time": "2026-06-03T00:03:31.529722+00:00",
+     "start_time": "2026-08-29T08:12:58.378455",
      "status": "completed"
     },
     "tags": []
@@ -380,20 +408,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "b8c9d0e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:51:08.958246Z",
-     "iopub.status.busy": "2026-07-03T15:51:08.958246Z",
-     "iopub.status.idle": "2026-07-03T15:52:16.419727Z",
-     "shell.execute_reply": "2026-07-03T15:52:16.419727Z"
+     "iopub.execute_input": "2026-08-29T08:12:58.393126Z",
+     "iopub.status.busy": "2026-08-29T08:12:58.392748Z",
+     "iopub.status.idle": "2026-08-29T08:13:19.161786Z",
+     "shell.execute_reply": "2026-08-29T08:13:19.161020Z"
     },
     "papermill": {
-     "duration": 142.090709,
-     "end_time": "2026-06-03T00:05:53.631286+00:00",
+     "duration": 20.777186,
+     "end_time": "2026-08-29T08:13:19.163360",
      "exception": false,
-     "start_time": "2026-06-03T00:03:31.540577+00:00",
+     "start_time": "2026-08-29T08:12:58.386174",
      "status": "completed"
     },
     "tags": []
@@ -423,7 +451,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "78db0471937f42be8f0570875e6900e3",
+       "model_id": "7a04eb2190fa4d71a8085713b5a12d49",
        "version_major": 2,
        "version_minor": 0
       },
@@ -448,7 +476,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 30 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 2_000 draw iterations (4_000 + 8_000 draws total) took 17 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
      ]
     },
     {
@@ -490,10 +532,10 @@
    "id": "933dc3c8",
    "metadata": {
     "papermill": {
-     "duration": 0.005324,
-     "end_time": "2026-06-03T00:05:53.643230+00:00",
+     "duration": 0.004438,
+     "end_time": "2026-08-29T08:13:19.172772",
      "exception": false,
-     "start_time": "2026-06-03T00:05:53.637906+00:00",
+     "start_time": "2026-08-29T08:13:19.168334",
      "status": "completed"
     },
     "tags": []
@@ -508,20 +550,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "c9d0e1f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:52:16.612808Z",
-     "iopub.status.busy": "2026-07-03T15:52:16.612808Z",
-     "iopub.status.idle": "2026-07-03T15:52:16.618793Z",
-     "shell.execute_reply": "2026-07-03T15:52:16.618793Z"
+     "iopub.execute_input": "2026-08-29T08:13:19.386630Z",
+     "iopub.status.busy": "2026-08-29T08:13:19.386329Z",
+     "iopub.status.idle": "2026-08-29T08:13:19.393606Z",
+     "shell.execute_reply": "2026-08-29T08:13:19.392876Z"
     },
     "papermill": {
-     "duration": 0.021439,
-     "end_time": "2026-06-03T00:05:53.670396+00:00",
+     "duration": 0.217788,
+     "end_time": "2026-08-29T08:13:19.394621",
      "exception": false,
-     "start_time": "2026-06-03T00:05:53.648957+00:00",
+     "start_time": "2026-08-29T08:13:19.176833",
      "status": "completed"
     },
     "tags": []
@@ -534,16 +576,16 @@
       "Resultats LDA avec priors symetriques :\n",
       "(Attendu : distributions degenerees / uniformes)\n",
       "\n",
-      "  Sujet 0 : atome (0.151), recette (0.145), four (0.125), ingredient (0.109)\n",
-      "  Sujet 1 : recette (0.150), atome (0.144), four (0.126), ingredient (0.112)\n",
-      "  Sujet 2 : recette (0.150), atome (0.145), four (0.124), ingredient (0.113)\n",
+      "  Sujet 0 : atome (0.148), recette (0.146), four (0.124), ingredient (0.112)\n",
+      "  Sujet 1 : atome (0.148), recette (0.144), four (0.126), ballon (0.109)\n",
+      "  Sujet 2 : recette (0.151), atome (0.147), four (0.124), ingredient (0.114)\n",
       "\n",
       "Proportions theta (document-sujet) :\n",
-      "  Doc 0 : [0.346 0.327 0.327]\n",
-      "  Doc 1 : [0.335 0.336 0.329]\n",
-      "  Doc 2 : [0.327 0.334 0.339]\n",
-      "  Doc 3 : [0.333 0.335 0.332]\n",
-      "  Doc 4 : [0.329 0.338 0.332]\n",
+      "  Doc 0 : [0.338 0.331 0.331]\n",
+      "  Doc 1 : [0.331 0.346 0.322]\n",
+      "  Doc 2 : [0.335 0.322 0.343]\n",
+      "  Doc 3 : [0.333 0.334 0.334]\n",
+      "  Doc 4 : [0.334 0.33  0.336]\n",
       "\n",
       "Probleme : les sujets ne sont pas differencies (symetrie non brisee).\n",
       "C'est le meme probleme qu'en Infer.NET avec des priors symetriques.\n"
@@ -578,10 +620,10 @@
    "id": "5ed3ea4b",
    "metadata": {
     "papermill": {
-     "duration": 0.005146,
-     "end_time": "2026-06-03T00:05:53.681141+00:00",
+     "duration": 0.004177,
+     "end_time": "2026-08-29T08:13:19.402547",
      "exception": false,
-     "start_time": "2026-06-03T00:05:53.675995+00:00",
+     "start_time": "2026-08-29T08:13:19.398370",
      "status": "completed"
     },
     "tags": []
@@ -600,20 +642,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "adf10941",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:52:16.620796Z",
-     "iopub.status.busy": "2026-07-03T15:52:16.620796Z",
-     "iopub.status.idle": "2026-07-03T15:52:16.626987Z",
-     "shell.execute_reply": "2026-07-03T15:52:16.626987Z"
+     "iopub.execute_input": "2026-08-29T08:13:19.411148Z",
+     "iopub.status.busy": "2026-08-29T08:13:19.410834Z",
+     "iopub.status.idle": "2026-08-29T08:13:19.415280Z",
+     "shell.execute_reply": "2026-08-29T08:13:19.414522Z"
     },
     "papermill": {
-     "duration": 0.013703,
-     "end_time": "2026-06-03T00:05:53.701427+00:00",
+     "duration": 0.009712,
+     "end_time": "2026-08-29T08:13:19.416114",
      "exception": false,
-     "start_time": "2026-06-03T00:05:53.687724+00:00",
+     "start_time": "2026-08-29T08:13:19.406402",
      "status": "completed"
     },
     "tags": []
@@ -644,10 +686,10 @@
    "id": "d0e1f2a9",
    "metadata": {
     "papermill": {
-     "duration": 0.008252,
-     "end_time": "2026-06-03T00:05:53.715981+00:00",
+     "duration": 0.004222,
+     "end_time": "2026-08-29T08:13:19.425089",
      "exception": false,
-     "start_time": "2026-06-03T00:05:53.707729+00:00",
+     "start_time": "2026-08-29T08:13:19.420867",
      "status": "completed"
     },
     "tags": []
@@ -664,20 +706,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "e1f2a3b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:52:16.628991Z",
-     "iopub.status.busy": "2026-07-03T15:52:16.628991Z",
-     "iopub.status.idle": "2026-07-03T15:52:16.633993Z",
-     "shell.execute_reply": "2026-07-03T15:52:16.633993Z"
+     "iopub.execute_input": "2026-08-29T08:13:19.434798Z",
+     "iopub.status.busy": "2026-08-29T08:13:19.434228Z",
+     "iopub.status.idle": "2026-08-29T08:13:19.440121Z",
+     "shell.execute_reply": "2026-08-29T08:13:19.439349Z"
     },
     "papermill": {
-     "duration": 0.015826,
-     "end_time": "2026-06-03T00:05:53.737415+00:00",
+     "duration": 0.012151,
+     "end_time": "2026-08-29T08:13:19.441085",
      "exception": false,
-     "start_time": "2026-06-03T00:05:53.721589+00:00",
+     "start_time": "2026-08-29T08:13:19.428934",
      "status": "completed"
     },
     "tags": []
@@ -716,10 +758,10 @@
    "id": "7a8c62d1",
    "metadata": {
     "papermill": {
-     "duration": 0.00686,
-     "end_time": "2026-06-03T00:05:53.749883+00:00",
+     "duration": 0.004057,
+     "end_time": "2026-08-29T08:13:19.449332",
      "exception": false,
-     "start_time": "2026-06-03T00:05:53.743023+00:00",
+     "start_time": "2026-08-29T08:13:19.445275",
      "status": "completed"
     },
     "tags": []
@@ -732,20 +774,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "f2a3b4c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:52:16.636178Z",
-     "iopub.status.busy": "2026-07-03T15:52:16.636178Z",
-     "iopub.status.idle": "2026-07-03T15:53:12.119603Z",
-     "shell.execute_reply": "2026-07-03T15:53:12.119072Z"
+     "iopub.execute_input": "2026-08-29T08:13:19.459010Z",
+     "iopub.status.busy": "2026-08-29T08:13:19.458314Z",
+     "iopub.status.idle": "2026-08-29T08:13:48.299522Z",
+     "shell.execute_reply": "2026-08-29T08:13:48.298866Z"
     },
     "papermill": {
-     "duration": 107.673973,
-     "end_time": "2026-06-03T00:07:41.429697+00:00",
+     "duration": 28.847127,
+     "end_time": "2026-08-29T08:13:48.300346",
      "exception": false,
-     "start_time": "2026-06-03T00:05:53.755724+00:00",
+     "start_time": "2026-08-29T08:13:19.453219",
      "status": "completed"
     },
     "tags": []
@@ -775,7 +817,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "be473910c1ff421aabd93041c9f601b0",
+       "model_id": "ba139dab2320400badd1a6f1590735f8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -800,7 +842,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 44 seconds.\n"
+      "Sampling 4 chains for 1_000 tune and 3_000 draw iterations (4_000 + 12_000 draws total) took 27 seconds.\n"
      ]
     },
     {
@@ -837,10 +879,10 @@
    "id": "9c7e22ff",
    "metadata": {
     "papermill": {
-     "duration": 0.014559,
-     "end_time": "2026-06-03T00:07:41.454337+00:00",
+     "duration": 0.003787,
+     "end_time": "2026-08-29T08:13:48.308379",
      "exception": false,
-     "start_time": "2026-06-03T00:07:41.439778+00:00",
+     "start_time": "2026-08-29T08:13:48.304592",
      "status": "completed"
     },
     "tags": []
@@ -853,20 +895,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "a3b4c5d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:53:12.494204Z",
-     "iopub.status.busy": "2026-07-03T15:53:12.494204Z",
-     "iopub.status.idle": "2026-07-03T15:53:12.501497Z",
-     "shell.execute_reply": "2026-07-03T15:53:12.500961Z"
+     "iopub.execute_input": "2026-08-29T08:13:48.602411Z",
+     "iopub.status.busy": "2026-08-29T08:13:48.602129Z",
+     "iopub.status.idle": "2026-08-29T08:13:48.608485Z",
+     "shell.execute_reply": "2026-08-29T08:13:48.607971Z"
     },
     "papermill": {
-     "duration": 0.023681,
-     "end_time": "2026-06-03T00:07:41.490010+00:00",
+     "duration": 0.296826,
+     "end_time": "2026-08-29T08:13:48.609202",
      "exception": false,
-     "start_time": "2026-06-03T00:07:41.466329+00:00",
+     "start_time": "2026-08-29T08:13:48.312376",
      "status": "completed"
     },
     "tags": []
@@ -879,16 +921,16 @@
       "Resultats LDA avec priors asymetriques :\n",
       "(Attendu : sujets bien differencies)\n",
       "\n",
-      "  Sujet 0 (Science) : atome (0.411), experience (0.239), theorie (0.160), match (0.046)\n",
-      "  Sujet 1 (Sport) : ballon (0.328), equipe (0.248), match (0.169), four (0.114)\n",
-      "  Sujet 2 (Cuisine) : recette (0.358), ingredient (0.258), four (0.185), match (0.053)\n",
+      "  Sujet 0 (Science) : atome (0.412), experience (0.239), theorie (0.159), match (0.047)\n",
+      "  Sujet 1 (Sport) : ballon (0.327), equipe (0.249), match (0.168), four (0.114)\n",
+      "  Sujet 2 (Cuisine) : recette (0.359), ingredient (0.258), four (0.185), match (0.052)\n",
       "\n",
       "Proportions theta (document-sujet) :\n",
-      "  Doc 0 : [0.808 0.113 0.079] -> dominant : Science\n",
-      "  Doc 1 : [0.121 0.806 0.073] -> dominant : Sport\n",
-      "  Doc 2 : [0.093 0.087 0.82 ] -> dominant : Cuisine\n",
-      "  Doc 3 : [0.4   0.238 0.362] -> dominant : Science\n",
-      "  Doc 4 : [0.118 0.298 0.584] -> dominant : Cuisine\n"
+      "  Doc 0 : [0.811 0.11  0.079] -> dominant : Science\n",
+      "  Doc 1 : [0.12  0.808 0.072] -> dominant : Sport\n",
+      "  Doc 2 : [0.094 0.088 0.819] -> dominant : Cuisine\n",
+      "  Doc 3 : [0.395 0.24  0.365] -> dominant : Science\n",
+      "  Doc 4 : [0.118 0.299 0.583] -> dominant : Cuisine\n"
      ]
     }
    ],
@@ -918,10 +960,10 @@
    "id": "9eeb0b66",
    "metadata": {
     "papermill": {
-     "duration": 0.007564,
-     "end_time": "2026-06-03T00:07:41.504694+00:00",
+     "duration": 0.003631,
+     "end_time": "2026-08-29T08:13:48.616984",
      "exception": false,
-     "start_time": "2026-06-03T00:07:41.497130+00:00",
+     "start_time": "2026-08-29T08:13:48.613353",
      "status": "completed"
     },
     "tags": []
@@ -945,10 +987,10 @@
    "id": "0e23c2f5",
    "metadata": {
     "papermill": {
-     "duration": 0.008455,
-     "end_time": "2026-06-03T00:07:41.521509+00:00",
+     "duration": 0.00362,
+     "end_time": "2026-08-29T08:13:48.624280",
      "exception": false,
-     "start_time": "2026-06-03T00:07:41.513054+00:00",
+     "start_time": "2026-08-29T08:13:48.620660",
      "status": "completed"
     },
     "tags": []
@@ -968,20 +1010,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "4e2a0393",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:53:12.503344Z",
-     "iopub.status.busy": "2026-07-03T15:53:12.503344Z",
-     "iopub.status.idle": "2026-07-03T15:53:12.506804Z",
-     "shell.execute_reply": "2026-07-03T15:53:12.506804Z"
+     "iopub.execute_input": "2026-08-29T08:13:48.632624Z",
+     "iopub.status.busy": "2026-08-29T08:13:48.632421Z",
+     "iopub.status.idle": "2026-08-29T08:13:48.635149Z",
+     "shell.execute_reply": "2026-08-29T08:13:48.634774Z"
     },
     "papermill": {
-     "duration": 0.016334,
-     "end_time": "2026-06-03T00:07:41.545912+00:00",
+     "duration": 0.007718,
+     "end_time": "2026-08-29T08:13:48.635797",
      "exception": false,
-     "start_time": "2026-06-03T00:07:41.529578+00:00",
+     "start_time": "2026-08-29T08:13:48.628079",
      "status": "completed"
     },
     "tags": []
@@ -1008,20 +1050,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "b4c5d6e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:53:12.508860Z",
-     "iopub.status.busy": "2026-07-03T15:53:12.508860Z",
-     "iopub.status.idle": "2026-07-03T15:53:12.938999Z",
-     "shell.execute_reply": "2026-07-03T15:53:12.938999Z"
+     "iopub.execute_input": "2026-08-29T08:13:48.644400Z",
+     "iopub.status.busy": "2026-08-29T08:13:48.644192Z",
+     "iopub.status.idle": "2026-08-29T08:13:48.922676Z",
+     "shell.execute_reply": "2026-08-29T08:13:48.922000Z"
     },
     "papermill": {
-     "duration": 0.734997,
-     "end_time": "2026-06-03T00:07:42.288133+00:00",
+     "duration": 0.284051,
+     "end_time": "2026-08-29T08:13:48.923656",
      "exception": false,
-     "start_time": "2026-06-03T00:07:41.553136+00:00",
+     "start_time": "2026-08-29T08:13:48.639605",
      "status": "completed"
     },
     "tags": []
@@ -1029,7 +1071,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABjYAAAIDCAYAAACn2CepAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAq69JREFUeJzs3QucTfX+//HPDDEuuSXXnFxLCtMhInI6RE4nlApdMGnqKOeQSilMokTSlMRJEd3odvy6Ujl0uogiXSkchdwVQi6x/o/39/9Y++w9s4eZMTN7r5nX8/FYaa+99tprr7323p/5fr7fzzfB8zzPAAAAAAAAAAAAAiAx1gcAAAAAAAAAAACQXSQ2AAAAAAAAAABAYJDYAAAAAAAAAAAAgUFiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAADy2T333GMJCQkFcp7/9Kc/ucW3cOFC99wvv/xygTx/3759rXbt2hZkTz/9tDtnn332WY7Pd9DovfrrX/+aZ/vLyfUW7VrRY/V5yfhe/PDDDxavdGw6Rh0rip4gXKMAAACFEYkNAACAXDRi+UtSUpLVqFHDOnXqZI8++qj9+uuveXI+N27c6Bp4ly9fHnfvTzwfW07fu9NOO80GDBhgW7ZsifXhIZsef/xxkggF6P7777c5c+YU5FMWGW+99VZEIg8AAADZR2IDAAAgF+6991575plnbPLkyfb3v//drRs0aJA1btzYvvzyy4hthw0bZr/99luOkwcjR47McfLgnXfecUt+OtqxTZ061b777jsLwnv32GOPWevWrd172KpVK9u3b1+O91UQ57uwys61cu2117rPzqmnnhpaR2KjYJHYsBxfozlJbOi7FAAAADlXPBePAQAAKPI6d+5szZs3D52HoUOH2r///W9X1qdLly62YsUKK1Wq1P8PuIoXd0t+UqN86dKlrUSJEjF9b0444QQL0nt3/fXX20knnWQTJkyw//u//7NevXrlaF+xPt8Z7d2718qUKWNBkJ1rpVixYm4BcsLzPNu/f3/oOzg/cY0CAADEBiM2AAAA8sif//xnGz58uP3444/27LPPHnWOjXfffdfatGljFSpUsLJly9rpp59ud911V2iegnPOOcf9f0pKSqh0kl/DX3M6nHXWWbZ06VI7//zzXULDf2xWcz4cPnzYbVOtWjXX8K3ky/r16yO20XwHmvcgo/B9HuvYos2boMb2W2+91WrVqmUlS5Z0r3X8+PGu8TGc9qOyUCp7o9enbc8880ybO3duxHYq96XRMXoebVOlShW78MILbdmyZZbb903Wrl0bsf7AgQM2ePBgO/nkk905u/TSS23btm1Znpuj2b59u61cuTJbo0L88/Dcc8+5c6WSWc2aNbP//Oc/Edv519W3335rV111lVWsWNFdU/L777/bqFGjrF69eu4c6Vzp/ddrikajTpKTk91zNWrUyF599dWI+3/++We77bbb3IgkXa/lypVzCaIvvvgi6v6yc71lZz6WjPMXaPtvvvnG3n///dC1F37+d+7c6a4N/1qrX7++jR071o4cORKx31mzZrlzeuKJJ7rXotf1yCOPHPVY/P3ruMuXL+8+u3369HHrotH7ffnll1ulSpXceVUy7bXXXovY5tChQ67HfoMGDdw2SrLpPdT3Q3bOy4cffmj/+Mc/3DWq47nxxhvt4MGD7ph69+7trgktQ4YMyfR5y87nUs+h7WbMmBE63/53RG4/h/51q/Nz5ZVXuvOv1z1w4ECXjAg3ffp09/nUvvUcujY1wiqruWLmzZvnzrMSGv/85z+zPIZVq1ZZ9+7d3fWp837KKadYz549bdeuXcecNyW788C8/fbb1rZtW3f96zq7+OKL3bXr03mcNGlSaJ/+AgAAgOxhxAYAAEAelyVRg64ailNTU6Nuo8YtNcI1adLElUVSg93q1avto48+cvefccYZbv2IESPshhtucI1jorJJvh07driGZTXGXXPNNVa1atWjHtd9993nGs3uuOMO27p1q6Wnp1uHDh1cOamc9GrOzrGFUyOpGrUXLFhg/fr1c43nany8/fbb7aeffrKHH344Yns11KpR/aabbnKNgZq3RA2Q69atc42f8re//c1NTq3GfzV06lzocRol88c//tFyas2aNe5ff/8+lRhTo3BaWpprtNQ503POnj07x8+hsldqwNZ5yE4iRA33eh41Wuv6UPmliy66yJYsWeKSPuGuuOIK1zCukkF+o7RGoqgxWg3rarxevHixjRkzxp2jf/3rX5kaeXv06OHOqxrq1ZisfSqhpIZq+e9//+sSTlpfp04dNyeJGo7btWvnEiuaZyY/rreMtB+9L0qu3H333W6df+0raaTj0XWlBv4//OEP9vHHH7vRVJs2bXKPFSUNNDKnffv2LukhOi/6/KlxPSs6t127dnXXms6VPgs6lzpn0T7j5513ntWsWdPuvPNO17j94osvWrdu3eyVV15xSTJRA7neF71fLVq0sN27d7tJ65Uc8M/90ehcqHFe19Ynn3xiTzzxhEtw6HXr9euaULmjBx980F03Snbk5HOpkm3+senzLkqW5cXnUEkNJST0+nXs+qz/8ssvNnPmzNA2SmIoualj1ai3119/3X03KFF18803R+xPZc30vuq913evEjXRKPGjOZGU5PPPn17zG2+84RJCSlodL503XRd6Hl1jujb1WpS0+vzzz93r1nGqrJ+uR20PAACAHPIAAACQbdOnT1fLsffpp59muU358uW9s88+O3Q7LS3NPcb38MMPu9vbtm3Lch/av7bR82XUrl07d9+UKVOi3qfFt2DBArdtzZo1vd27d4fWv/jii279I488Elp36qmnen369DnmPo92bHq89uObM2eO23b06NER211++eVeQkKCt3r16tA6bVeiRImIdV988YVbP3HixIjze/PNN3u5fe/ee+89d+7Xr1/vzZo1yzvppJO8UqVKeRs2bIjYrkOHDt6RI0dCj7/lllu8YsWKeTt37szy3GTFvwb0fhyLttPy2Wefhdb9+OOPXlJSknfppZdm2mevXr0iHr98+XK3/vrrr49Yf9ttt7n1//73v0Pr9F5p3SuvvBJat2vXLq969eoR1/D+/fu9w4cPR+xv7dq1XsmSJb177703V9dbxmvFf+16XT7/vdBz+c4888yo53zUqFFemTJlvO+//z5i/Z133unet3Xr1rnbAwcO9MqVK+f9/vvvXk741/K4ceNC67SPtm3bZvo8tG/f3mvcuLE7bz5dS61bt/YaNGgQWte0aVPv4osv9nLKPy+dOnWKuEZbtWrlPld/+9vfIo7xlFNOiThnOflc6pxG+17I7efQv267dOkSsf6mm25y6/WZ9+3bty/T4/Wa69atG7HOv47nzp17zOf//PPP3bYvvfRSltvoesvqO+5Y1+ivv/7qVahQwUtNTY143ObNm905C1+v88ef5AAAALlDKSoAAIA8pt7kKtOSFfWoFs3pkLFETnapF79KQWWXemprBIRPPfmrV6/uenPnJ+1fNeg18iCcRhGojVDlWsKpV7/fI1w0qkWlajRiIPz8aQSCejvnhp5DpXtUgkcjXvR+qee9eteHUw/18NIwGp2iEksqNZZT6pmv15ud0RqiycxVKsmn3vcaLaBe9TqGcOo5H85/T1VGK+M5lzfffDNivUZb+CMIROdb14t6lm/evDl0vSUm/v8/HfT86p3vl1CLVnooFtfbSy+95N4jjbJR6S9/0futY/ZLeen6UXmlY5V7ykjHrlED/fv3D63Tta1e/xnLdmm+HY1I0PeAfxw6Z+rBrxEyGiHgH4tGd2hdbmi0Rfg12rJlS3edaX34Mao8U/hnKKefy2iO93OYccSFfx7Dr5Hw0T0qE6XzqFE5ei1+2SifRhLp/B6LPyJDn6XslIbLKV1XGvmh0SPh16HOt94fjZIBAADA8SOxAQAAkMf27NkT0aibkcr+qEyNSryojI4a11WmJidJDjXC52TiapUqCqfGUM0/kLEufF5TEkAN5xnPh8r4+PeHUwN+RmqoVoka37hx4+zrr792iQmVyFHSILzR9lhU116Nj2pgVBklPTZag2jGY9FxSPix5JeM75ecdtppriE24zwfatANp3OqJITe33AquaPG6IznXNtlrO2v5xL/+tC1qfJEOi4lOSpXruySQ19++WWmBuZYXW9KDqh8lo4rfFFiQ1QSS1TKSK9Ppdw0t8J1112XaR6XaHTelJxRQidcxpJHKiun5IDm28l4LCprFn4sKuumRnAdj+b5UCkondPsyniN+o32+mxkXB9+3eb0cxnN8X4OM14jSmjqug2/RlQeTO+fSnnp2tU59OcTipbYyA5tp6Tfk08+6a5jffb1nRDtOs4NP0mluUEyvv8qUei/9wAAADg+zLEBAACQhzZs2OAayDI2KodTL2T1HlfDunrPq1FV8ymoIUwNX+rZeyzHM09BVrKauFa93bNzTHkhq+cJn9BYPeHVM1+jLHS+NH+A6thrbg41Vh+LGmHVgz0vjiUeZHUt5OVExJqrQQ31SgJoUnJNiK1GaE0endtRR3lNx6F5KTRRdjR+skYTUWuuD/XY18gELZpXRKNMNC9JXhyHaLL1rEYQ+N8P559/vpvjRaO3dC2rsV0JpClTprjEZ26v0Wjr8/q6Pd7P4bGuV50XzYPSsGFDmzBhgkugKJmrER06Rxmvu5x8Jz700ENu8m7/vGvkij/Xh5JdR/suPBb/uDRvhpKJGWnUDwAAAI4fURUAAEAe8ieBPVZJFDUKq9FOixrt1HCsyZCV7FAP5bxslJaMpW7UyKme5Sr1FD4iQb3HM1Lv7bp164Zu5+TYTj31VHvvvfdcSZ7w3uErV64M3Z8b6jmvnvda1ANakxVrwurcNKjGo2ilib7//nsrXbq06/l9NDqnalzVPvwe+KIJv/X+Zjzn/giD8PdVzyWa5Fg0SfQFF1xgTz31VMRjtT/1es/N9ZZbWV1/6vGv0VL+CI2jUQP5JZdc4hadK11HmgxdyZuskpI6b/Pnz3fPET5qQ5NWh/M/KyeccEK2jkVJIpWV06J9K9mh0Q/ZSWzkVk4+l0f7vB/P51DXSPgoC10fei/8a04ThWuC79deey1iZEpelXLSCBktw4YNc5OtaxSdEkqjR48Ojc7K+H2YnZEsfik9JdCO9f7n9fc8AABAUUIpKgAAgDyiuvrqza7GuquvvjrL7VSDP6Pk5GT3rxryRKVXJFqiITdmzpwZMe+HGqo3bdoU0QCpBjn1WD548GBo3RtvvGHr16+P2FdOju0vf/mL6+X82GOPRaxXj2s16uU0EaF9ZSwZowZEldXxz108Uo19NRpnt6b/okWLIuau0Hug3uUdO3Y85ugZnXNJT0+PWK8Emlx88cUR6zVHgnrd+3bv3u2uF12Tfo9zPWfGHv+a08KfKyI311tu6fqLdu1pBIHOm0ZiZKTtf//9d/f/musiY5LRT7gc7RrSedU+Jk+eHHE9Tpw4MdP1qLlUlCjRa84ovJRYxmNRwkSJlfy+lnPyuYx2vvPic6jyT+H88+g/t3+dh193ek6Nrjkeur79a8GnBIeuA//YNc+MEnb+vCy+xx9//Jj7V1Jbj1ey+tChQ0d9//P6ex4AAKAoYcQGAABALqh8jRqq1UCmnvBKamjeBvV0Vg/jpKSkLB+ruvpqMFMDs7ZXT2c1mKkESps2bUJJBtWUVw9i9ahWA5gmns1uHflovcK1b/UK1/Gq0VsNqKmpqaFt1ENcDdAXXXSRayRWKZhnn302YjLvnB6besSrp79Go6h2ftOmTV3pFzXSq4xRxn0fixrLdZ40GbX2pYZg9Tz/9NNPXXmZeKUG5JEjR7re5tmZQPyss85yDaQqkaM5LfwGVe3jWHRe+vTpY0888YRrMNVky0uWLHFllrp16+bej4wlmjTZtM6h5nyZNm2au0bCG5D/+te/uutW10/r1q3tq6++sueeey5iJE9Or7fc0qTqSi6oZ732qQZ1lXHT/BT67OlYVWZI22mScB2rrmtdf2qs1nWu5KIeo2tJvfDVqK5ETvgIl2jXsnr133nnnW5fjRo1cmWXos3NoEZ7vX41mOs16zzpPCjxonJ1X3zxhdtO+9D1oGPVOfvss8/csQ4YMMDyU04+lzo2fcaUGFPiQp9zzStyvJ/DtWvXWpcuXdz3jc6Lvmuuuuoqtz9REs8fWXPjjTe60SxTp05173e0hFF26bta5/eKK65w176+wzXSTomU7t27h7bTdfLAAw+4f1W6Tt/Z/kimo1FSQ9fntdde60awaA4ljbJat26dKz2oa8hPKOncij7n+rzrGLQ9AAAAssEDAABAtk2fPl3dh0NLiRIlvGrVqnkXXnih98gjj3i7d+/O9Ji0tDS3rW/+/Ple165dvRo1arjH699evXp533//fcTj/u///s9r1KiRV7x4cfd4Pbe0a9fOO/PMM6Men+7T4luwYIF77AsvvOANHTrUq1KlileqVCnv4osv9n788cdMj3/ooYe8mjVreiVLlvTOO+8877PPPsu0z6MdW58+fbxTTz01Yttff/3Vu+WWW9zrPOGEE7wGDRp4Dz74oHfkyJGI7bSfm2++OdMxaX/arxw4cMC7/fbbvaZNm3onnniiV6ZMGff/jz/+uJfd9+7TTz/N1Xb+udS/vmjnJhr/Ggh/bFb88/Dss8+6c6X34uyzz870WH+f27Zty7SPQ4cOeSNHjvTq1KnjznmtWrXc+79///5M51bXwrx587wmTZq452rYsKH30ksvRWynx916661e9erV3fWja2PRokXHdb1Fu1b0WL2ujO/F2rVrQ+s2b97s9qf3X/eFP7+uNT1v/fr13WercuXKXuvWrb3x48d7Bw8edNu8/PLLXseOHd2xaZs//OEP3o033uht2rTpmO/Njh07vGuvvdYrV66cV758eff/n3/+ecRnwLdmzRqvd+/e7vtB74E+V3/961/d8/tGjx7ttWjRwqtQoYI7Tzr39913X+hYc3qNZnVN6Fzrs5Kbz+XKlSu9888/3x2f9q19Hc/n0D/Gb7/91rv88svd4ytWrOgNGDDA++233yK2fe2119x1mZSU5NWuXdsbO3asN23atEzXhH8dZ8d///tf77rrrvPq1avn9lupUiXvggsu8N57772I7fbt2+f169fPvc86xiuvvNLbunVrtq5R/7PQqVMn93g9j56vb9++7jvV9/vvv3t///vfvZNPPtlLSEiI+J0AAADA0SXoP9lJgAAAAADIfyoFdPPNN2cqEwQUBpo/RCOPVJIp2vwsQaN5ZzSqQ+XiNIoFAAAABYM5NgAAAAAAyAWVxVIyUqXEAAAAUHCYYwMAAAAAgBzQnCmaD0VzDbVq1cpKly7N+QMAAChAjNgAAAAAACAHVqxY4Sas1wT2Tz/9NOcOAACggDHHBgAAAAAAAAAACAxGbAAAAAAAAAAAgMAgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAACg8QGAAAAAAAAAAAIDBIbAAAAAAAAAAAgMEhsAAAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwSGwAAAAAAAAAAIDBIbAAAAAAAAAAAgMAgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAACg8QGAAAAAAAAAAAIDBIbAAAAAAAAAAAgMEhsAAAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwSGwAAAAAAAAAAIDBIbAAAAAAAAAAAgMAgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAACg8QGAAAAAAAAAAAIDBIbAAAAAAAAAAAgMEhsAAAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwSGwAAAAAAAAAAIDBIbAAAAAAAAAAAgMAgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhtAIff0009bQkKC/fDDDxYE69evt6SkJPvoo4/y7Tl0Pu655x4Lirlz51rZsmVt27ZtsT4UAAACHWfs2bPHqlSpYs8995wF1Y4dO6xMmTL21ltvxfpQAACIivgga2qLUOyUE4qz9Bid1/x07rnn2pAhQ/L1OYC8RGIDiDNfffWVXX755Xbqqae6Bv6aNWvahRdeaBMnTizwY9EfzDlNAKxYscIuuugi1xBfqVIlu/baa3PUIH/vvfday5Yt7bzzzotY//rrr1u7du1cY0Tp0qWtbt26duWVV7pG/8JO57N+/fo2ZsyYWB8KACDgghxnLFmyxG666SZr1qyZnXDCCTluFJBHHnnETjzxROvZs2fE+g8//NA6d+7szofOyx/+8Ae75JJL7Pnnn7dYyer8nHTSSXb99dfb8OHDY3JcAIDCJ6jxwZEjR1xjf5cuXaxWrVou8X/WWWfZ6NGjbf/+/ccdH8jy5cvtmmuucfsvWbKka+fo0KGDTZ8+3Q4fPmyFyR133GGTJk2yzZs3x/pQgGxJ8DzPy96mAPLbxx9/bBdccIH7Y7pPnz5WrVo1N4Lhk08+sTVr1tjq1atzvE/90B46dMj9AOe0AWDAgAHuRy27XxMbNmyws88+28qXL2//+Mc/XK/I8ePHu9ejxogSJUoc9fFKgCiAmjFjhvXq1Su0Xvu4/fbbXWKja9euLrGhc/Hee+9Z06ZNc9xrQQFO8eLF3RIUkydPtttuu80FGAq4AAAoanGGGjnuv/9+a9Kkif3666/2/fffZ/uxouNUnHHLLbfY0KFDQ+tfeukl69GjhyUnJ7sGjYoVK9ratWvtP//5j0ugLFiwwGLhaOdHHUkaNWpk8+fPtz//+c8xOT4AQOEQ5PhAbQ76+1gjDf7617+6jpCLFi1ybQrnn3++/fvf/z7m82cVH8iTTz5pf/vb36xq1aqu02aDBg1cDKLf3zfffNMlUO66664cvb7ff//dLUogZZfOxYEDB1xcUqxYMcsvShTpXKSmprpOp0C8C06rHlAE3HfffS4p8Omnn1qFChUi7tu6dWuu9qkfvfz84Qunxoa9e/fa0qVLXVAkLVq0cD09lHy44YYbjvr4Z5991iUb1EPSpx/8UaNGuX288847mR6Tm/OSkwAiXnTv3t3+/ve/u8aX6667LtaHAwAIoKDHGf3793c9CUuVKuUaPZTYyIk33njDdaLQiM+MCRMlCdSAk7ETRm7Py/FQLKUep0dzxhlnuB6piq9IbAAAimp8oN9tlbFu3bp1aJ0a5WvXrm1paWkuAaHRFbmJDxQXKKnRqlUrN4okvIPhoEGD7LPPPrOvv/46x8ecm06WSs4URDtGYmKiG7kzc+ZMGzlyZK5GxwIFiVJUQBxRb4gzzzwzUzAh6nmQnfqKGeePyKq25dtvv21t27Z1fzjrB/riiy+2b775JnR/3759XS8Jf5/+cjSvvPKK6yXhJzVEQcRpp51mL7744jFf/5w5c1wZKpWx8m3fvt12796dqTRVtPPij8bQ69dz6oe/evXqdtlll7lzm9U5kp9++sklDNQTQ71K9D5MmzYtYpuFCxe6x+q1KPg75ZRT3HO0b98+ai+WxYsX21/+8hfX81PnWT1MNcQ13MqVK13goOGs2lfz5s3ttddei/o69fj/+7//O+Z5BACgMMYZ+o1WUiO3FGeooaNevXqZzss555wTdWRptPOikaQPP/ywK9eh49GI0mgNG+ol6p8DnXONOtVIi2h1tr/99lu76qqrXMzQpk2bbJ0fdfpQqU4G4AMAimp8oN/u8KSG79JLL3X/ZvzdzUl84Dfsa16uaFUT9Le7jje8rUD/hot2zqLNsfHuu++633+9B2oPOf300yNGgkTbj55b26oto1u3bu7/Tz75ZFfpIWOJLI3ESE9Pd++z2h0UU9144432yy+/ZHpdii9+/PFHV4ILiHeM2ADiiP5A1rBJ/XGsXnj55ZlnnnFDTDt16mRjx461ffv2uVJH+iH9/PPP3Y+6fuQ2btzofmC1/bHox1S9OfTjnpFGbRxrgksN/1QPEfXGzBhIqdFAf7hrxIISAFnRj7cSK+qVoVISAwcOdMNE9Rp0TjMGKr4tW7a4oasKFNQDVMGAAq5+/fq5pIp6Y4R74IEHXE8GBQy7du2ycePG2dVXX+0SGT49p45FiRUdh4bzKqhSbxDdFgVwSthoqOedd97pgjslTRSUKEnkB2M+1RRX0AUAQFGLM/Kq1MYf//jHqOdFsYNKaqrTwrGoF6Pii5tvvtl1qFCnBY2aUH1yNRSIymVqzg7NCaYGjN9++83VKdfv/rJly9w5CHfFFVe48hYa/apEhUp7Huv8KC5QgkXxRH6+nwCAwq0wxgf+HBGVK1fOVXygY1NsoHJW4R0384N+x9V2oI6MKv+kjpbqOKmRKMeiNhCdT3UQVccLxR8PPfSQa/sIb1vReVVSJCUlxZUNV8nNxx57zJ13PY9KXIXHF6L1ikeAuKY5NgDEh3feeccrVqyYW1q1auUNGTLEmzdvnnfw4MGI7dauXatik9706dMz7UPr09LSQre1jdbpMfLrr796FSpU8FJTUyMet3nzZq98+fIR62+++Wb32Oz49NNP3bYzZ87MdN/tt9/u7tu/f3+Wj1+9erXbZuLEiZnuGzFihLuvTJkyXufOnb377rvPW7p0aabtpk2b5rabMGFCpvuOHDmS5Tnq16+fV716dW/79u0Rj+nZs6c7J/v27XO3FyxY4B57xhlneAcOHAht98gjj7j1X331lbv9+++/e3Xq1PFOPfVU75dffsnyONq3b+81btw44rzo/tatW3sNGjTI9Bruv/9+9zxbtmyJeg4BACiscUZGOX3soUOHvISEBO/WW2/NdN9TTz3l9lWiRAnvggsu8IYPH+598MEH3uHDh6Oel1KlSnkbNmwIrV+8eLFbf8stt4TWJScne1WqVPF27NgRWvfFF194iYmJXu/evUPrdC712F69euX4NX788cfu/tmzZ2f7PAAAUJjjA1+HDh28cuXKZfp7PLvxgX6zdQwDBw7M1vP5bQX691jnzP/t9z388MPu9rZt27Lcf7T99OnTx6279957I7Y9++yzvWbNmoVuK6bRds8991zEdnPnzo26XhQT9e/fP1uvHYglSlEBcURD/tRTokuXLvbFF1+4kQDKvqtHf7TyRLmhng87d+50k3OrzJO/qP6lsvy5nSBTPRFFvQsy8mtB+ttEs2PHDvevSjBkpCGgzz//vOstMG/ePLv77rtdLwL1qggfWqpRDuqRoZEdGWU1fFUxmB6neT30/+HnROdeIzLUszKcejmEl6vQUFr573//6/5Vrwf1gNBIj4zDef3j+Pnnn12JCtXxVK9P/zl1HvS8q1atcqNgwvnnRtsBAFCU4ozjpd9d/c5HizNUinLu3Ln2pz/9yT788EM3t5d+2zWCQr04M9LISp2z8JGpem3+6NRNmza58g0qERE+0lQ9MfUeRBvFqhreOUVcAADIC4UtPtDoR41cUKWFaOW1shMfqHKDRCtBldf8Y1TZaZWMyqmMMYRiGL9tQjRPp+ZQ0fscfu7VpqLyVdHOvc4H7Q4IAhIbQJxRjedXX33V1TpcsmSJDR061DV8ax4G1V8+XmowF5VMUMml8EWTc+d2cjC/5vWBAwcy3acyDeHbHE1WdaIVAH3wwQfuvOg4VYdaCQQlJPz9qzaoalHmZCIuTRKmAOuJJ57IdD6UwJCM5yTjUFQ/CPLrU/rzeRxtGK+Gluq1Dh8+PNPzapKzaM/rnxsm8AIAFLU4I69kFWeoAUedJxQT/Oc//3FlplRfWqUhMh6zEh4ZaW4vv464HieKSaJN+q2GAk0QHq5OnTq5fi3EBQCA41VY4oPZs2fbsGHDXFnpjGWucxIflCtXzv2rc5DfevTo4UpVXn/99a6kpcpqq0R1dpIc6kSqc5ixfSJ87gyde3XYVJnvjOd+z549Uc+9zgfxBYKAOTaAOKURAQoutOiPZTWyK9OuRu+sfmAyThAVjf/jqHqVmvcho5wkBcJpLgm/l2JGWqcei9FGc/hOOukk92+0yasyBhjqaaBFdSBnzJjh5rbQxJ254Z+Pa665xtX7jEY9LMOpV0k0OZm8039ezdOhxpRo6tevH3HbPzfZqRMKAEBhijOOl+IQva5jxRmlS5d2PR216PdWo0Y171ZWMUJeyc2k6MQFAIC8FuT4QKNCevfu7SYknzJlynHFB/pbXMek+bOy43jOjWIAdarQyIk333zTjSJVgkZJICV9smp/kKPdF37uldTQJOjRZEyMiDp60O6AICCxAQSAPyG3nzTwRwjoxyac30PwaPwJtPXD1qFDh6Num5MMvYap6gfxs88+y3SfenwkJycf9fEaBaEfdJVwysl5UWLDPy96bUpyaCLy8MmvjkbHrOGlCjiOdT6yyz/Hmnwtq31qMlHRcWb3eXVuFFxECzwAACjMccbxUuOEji2ncUa0Tht+r9Nw33//fWhCcE3CKt99912m7VauXOl+y8uUKXPM5z/W+fFfi0aBAABQlOMDtQNceuml7pg12iG7iZKs4gN1dFBiQeWj169fb7Vq1Trqfo7n3EhiYqK1b9/eLRMmTHDltFSCW8mO422n0OtTaS6NCslORwqVxD548CDxBQKBUlRAHNGPVrRe/34tZr+kgUYt6I9iZfXDPf7448d8Do0O0OP1Q6kEQLTSTD7/j+6MP85Z6d69u73xxhvuh983f/5898f+FVdccdTHqoFfQUjGxMi+fftcvc9o1IMy/Lzo+VXe4bHHHsv2aAr1cNDjNM+GEhFHOx/Zpbk/VFIiPT0907nzj0MBnWp5//Of/4w6yiXa8y5dutRatWqV4+MBAKAwxBnHS7+h0TpgKFaJJuN58c2ZMydiHix14FCDSufOnUOjWNWhQ50vwl+b4gz1vPzLX/6SreM91vlRXKCa2WeeeWa29gcAQGGMDzTvpkZpqIOB2iNyOgoyq/hAo1R0Xq699lpXsina77B+6/1ODWpbyM250TwfGfkdQ6OV+s4pzeupjpyaQyyj33//PdN51uuS1q1bH/dzA/mNERtAHNGk12rIV0+Dhg0buiy5Jq3UMET9SPtzPojqL2oyLP2rhIB+QJVAOBYFE5MnT3Y/zmqAV/1GjQBYt26dG/aoLL6fGNBkUvKPf/zDBSL6odb2WbnrrrvcMNULLrjABg4c6H78H3zwQWvcuHHEsWela9eurleCJurya1rqfOgH9dxzz7WLLrrI9ZTQD68aFTTnhibw1KTiomGnM2fOtMGDB7tGBpWRUA1r9U646aab3P6j0XlUMKdJy1JTU61Ro0YuuNCk4XpstEDjWL0tdI41/4cCEr12NXKol+Y333zjanjLpEmTrE2bNu786Hk1imPLli0ukbNhwwY3cZtPdS+//PJLV/MbAICiGGeo16NKWIjfADF69OhQg4Ke82gUB+jxeh0qrxG+Xh0S9LutXo1+7PD666+7Uhxan7E8hX6/VbtbDQ7qyKCSmkOGDAlto/hHiQ41lqjO92+//WYTJ050iYh77rnnmOcxO+dHJTd0bNTABgAU1fhAc2BoG5WSuv32292+wul3/VidA7OKD9QOob/Z1Zag86Jj1zxbes6FCxe6idX9OES/7+rMqd96/S7reZVkyc7cIffee687j0rOKJ7RY5QQOeWUU1y8cbxUtvvGG2+0MWPG2PLly61jx46uY6lGoKr95pFHHnFzqYTHF6qo4bezAHHNAxA33n77be+6667zGjZs6JUtW9YrUaKEV79+fe/vf/+7t2XLloht9+3b5/Xr188rX768d+KJJ3pXXnmlt3XrVnWz8NLS0kLbTZ8+3a1bu3ZtxOMXLFjgderUyT0+KSnJq1evnte3b1/vs88+C23z+++/u+c++eSTvYSEBLefY/n666+9jh07eqVLl/YqVKjgXX311d7mzZuz9fr1GosXL+4988wzoXWHDh3ypk6d6nXr1s079dRTvZIlS7p9n3322d6DDz7oHThwINN5ufvuu706dep4J5xwgletWjXv8ssv99asWRPaJuM58p/75ptv9mrVqhV6XPv27b0nnngi4pzpsS+99FLEY3VutV7nOtyHH37oXXjhhe79KVOmjNekSRNv4sSJEdvouHr37u2eT89bs2ZN769//av38ssvR2w3efJk97p3796drXMJAEBhizP83+FoS7t27Y75hitmqFy5sjdq1KiI9S+88ILXs2dPd4ylSpVyx9uoUSMXT4T/7vq/94o/HnroIRczKC5p27at98UXX2R6vvfee88777zz3D7LlSvnXXLJJd63334bsY3Opfa5bdu2TI8/2vlZsWKFu63nAACgqMYH/m9zVkufPn1yHR/4li5d6l111VVejRo13N/sFStWdG0FM2bM8A4fPhzaTr/l3bt3d3+3a5sbb7zRtY9kbCvwf/t98+fP97p27er2r3Ovf3v16uV9//33mV5n+H702tTOkFHG/fvUttGsWTMXl+i9a9y4sTdkyBBv48aNoW30eqpXr+4NGzbsmOcNiAcJ+k+skysA8s9TTz3lelOoPJQy/vFOvRrVU0KjMfA/6i2h0lUPP/wwpwUAEDeCFmeoDMP06dNdL8XsTLgZ7ocffnAjOzQa47bbbrNYGjRokOvdqXIRjNgAAMSbohQfFCaqjHHVVVfZmjVrXNUJIN4xxwZQyGn+Bv3BW6lSJQsC1bH89NNP7aOPPor1ocSNuXPnugBr6NChsT4UAAACHWfccsstrlTmrFmzLKh27NhhTz75pCt/QVIDABCPiA+CaezYsTZgwACSGggM5tgACinN1fDyyy/blClTXE3J0qVLWxColuP+/ftjfRhxRXOLRJusDACAWAlqnFG2bNls1buOZ5rPg7gAABCPiA+CTfN9AkHCiA2gkFqxYoWbPEsTXD799NOxPhwAAFCIEGcAAADiAwCxxBwbAAAAAAAAAAAgMBixAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwmD8/CkSNHbOPGjXbiiSdaQkJCwb4rAADECc/z7Ndff7UaNWpYYiL9IY6F+AEAAGKInCJ+AAAg520QJDayoKRGrVq1jnryAAAoKtavX2+nnHJKrA8j7hE/AAAQiRiC+AEAgPyIH0hsZEEjNfyTWK5cuRyffAAACoPdu3e7RL//u4ijI34AAIAYIqeIHwAAyHkbBImNLPjlp5TUILEBACjqKMuYs/NE/AAAADFETuMs4gcAALLfBkGxbAAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgkNgAAAAAAAAAAACBQWIDAAAAAAAAAAAEBokNAAAAAAAAAAAQGCQ2AAAAAAAAAABAYJDYAAAAAAAAAAAAgUFiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGAUj/UBFCWbL2lr8aja6x/E+hAAAABQiGNO4k0AAIDCIx7jTSHmLFoYsQEAAAAAAAAAAAKDxAYAAAAAACgyJk2aZLVr17akpCRr2bKlLVmyJMttX331VWvevLlVqFDBypQpY8nJyfbMM89EbNO3b19LSEiIWC666KICeCUAABRdlKICAAAAAABFwuzZs23w4ME2ZcoUl9RIT0+3Tp062XfffWdVqlTJtH2lSpXs7rvvtoYNG1qJEiXsjTfesJSUFLetHudTImP69Omh2yVLliyw1wQAQFGUGLTeEuFmzZrlekJ069YtYr3neTZixAirXr26lSpVyjp06GCrVq3Kp6MHAAAAAABBMGHCBEtNTXXJiUaNGrkER+nSpW3atGlRt//Tn/5kl156qZ1xxhlWr149GzhwoDVp0sQ+/PDDiO2UyKhWrVpoqVixYgG9IgAAiqbEeOktkZaWZsuWLbOmTZu6Xg9bt2496uN++OEHu+2226xt28yT1YwbN84effRRF6AsXrzYDRfVPvfv35+PrwQAAAAAAMSrgwcP2tKlS13nR19iYqK7vWjRomM+Xp0o58+f70Z3nH/++RH3LVy40I3iOP30061///62Y8eOfHkNAAAgThIbOe0tIYcPH7arr77aRo4caXXr1s0UaGgo6bBhw6xr166uJ8XMmTNt48aNNmfOnAJ4RQAAAAAAIN5s377dtSdUrVo1Yr1ub968OcvH7dq1y8qWLetKUV188cU2ceJEu/DCCyPKUKndQUmPsWPH2vvvv2+dO3d2zxXNgQMHbPfu3RELAAAIUGIjt70l7r33XtcTol+/fpnuW7t2rQtIwvdZvnx5V+LqaPsksAAAAAAAABmdeOKJtnz5cvv000/tvvvuc1UnNELD17NnT+vSpYs1btzYlcrWPBzaNnybcGPGjHHtFP5Sq1YtTjoAAEFKbOSmt4TqWD711FM2derUqPf7j8tpDwwCCwAAAAAACq/KlStbsWLFbMuWLRHrdVvzYmRFHTDr169vycnJduutt9rll1/u2hCyosoSeq7Vq1dHvX/o0KFuFIi/rF+//jheFQAARVPMS1HlxK+//mrXXnutS2ooSMhLBBYAAAAAABReKiXVrFkzVzLKd+TIEXe7VatW2d6PHqOqD1nZsGGDm2OjevXqUe/XROPlypWLWAAAQM4UtwD1llizZo2bNPySSy6JCCikePHibgIv/3HaR3gQodvqXZEVBRZaAAAAAABA4aQyUn369LHmzZtbixYt3Byde/fudfN+Su/eva1mzZqhERn6V9vWq1fPJTPeeuste+aZZ2zy5Mnu/j179rj5P7t37+7aI9RuMWTIEDfCo1OnTjF9rQAAFGbF46W3hOpQhveWGDBgQKbtGzZsaF999VXEOk0SrpEcjzzyiKtLecIJJ7hgQvvwExmaiGvx4sXWv3//AnplAAAAAAAg3vTo0cO2bdtmI0aMcOWq1W4wd+7cUDnrdevWudJTPiU9brrpJjcKo1SpUq5d4tlnn3X7EXXW/PLLL23GjBm2c+dOq1GjhnXs2NFGjRpF50kAAAprYiOnvSWSkpLsrLPOinh8hQoV3L/h6wcNGmSjR4+2Bg0aWJ06dWz48OEuuPCTJwAAAAAAoGhSR8ponSkl44TfalvQkhUlO+bNm5fnxwgAAOI8sZHT3hLZoWGfSo7ccMMNrsdEmzZt3D6VGAEAAAAAAAAAAMEV88RGTntLZPT0009nWpeQkGD33nuvWwAAAAAAAAAAQOGRs6EQAAAAAAAAAAAAMURiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgkNgAAACBNGnSJKtdu7YlJSVZy5YtbcmSJVlu++qrr1rz5s2tQoUKVqZMGUtOTrZnnnkmYhvP82zEiBFWvXp1K1WqlHXo0MFWrVpVAK8EAAAAAADkBIkNAAAQOLNnz7bBgwdbWlqaLVu2zJo2bWqdOnWyrVu3Rt2+UqVKdvfdd9uiRYvsyy+/tJSUFLfMmzcvtM24cePs0UcftSlTptjixYtdAkT73L9/fwG+MgAAAAAAcCwkNgAAQOBMmDDBUlNTXXKiUaNGLhlRunRpmzZtWtTt//SnP9mll15qZ5xxhtWrV88GDhxoTZo0sQ8//DA0WiM9Pd2GDRtmXbt2dffNnDnTNm7caHPmzCngVwcAAAAAAI6GxAYAAAiUgwcP2tKlS12pKF9iYqK7rREZx6Ikxvz58+27776z888/361bu3atbd68OWKf5cuXdyWujrbPAwcO2O7duyMWAAAAAACQv0hsAACAQNm+fbsdPnzYqlatGrFet5WcyMquXbusbNmyVqJECbv44ott4sSJduGFF7r7/MfldJ9jxoxxCRB/qVWr1nG+OgAAAAAAcCwkNgAAQJFw4okn2vLly+3TTz+1++67z83RsXDhwuPa59ChQ13CxF/Wr1+fZ8cLAAAAAACiK57FegAAgLhUuXJlK1asmG3ZsiVivW5Xq1Yty8epXFX9+vXd/ycnJ9uKFSvciAvNv+E/TvuoXr16xD61bVZKlizpFgAAAAAAUHAYsQEAAAJFpaSaNWvm5snwHTlyxN1u1apVtvejx2iODKlTp45LboTvU/NlLF68OEf7BAAAAAAA+Y8RGwAAIHBURqpPnz7WvHlza9GihaWnp9vevXstJSXF3d+7d2+rWbOmG5Eh+lfb1qtXzyUz3nrrLXvmmWds8uTJ7v6EhAQbNGiQjR492ho0aOASHcOHD7caNWpYt27dYvpaAQAAAABAJBIbAAAgcHr06GHbtm2zESNGuMm9VS5q7ty5ocm/161b50pP+ZT0uOmmm2zDhg1WqlQpa9iwoT377LNuP74hQ4a47W644QbbuXOntWnTxu0zKSkpJq8RAAAAAABEl+B5npfFfUWayk+UL1/eTQRarly5PNnn5kvaWjyq9voHsT4EAEAR+j0szDhfiAfxGHMSbwJFD7+JnCsAhVc8xptCzFm04gfm2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgkNgAAAAAAAAAAACBQWIDAAAAAAAAAAAEBokNAAAAAAAAAAAQGCQ2AAAAAAAAAABAYJDYAAAAAAAAAAAAgREXiY1JkyZZ7dq1LSkpyVq2bGlLlizJcttXX33VmjdvbhUqVLAyZcpYcnKyPfPMMxHb9O3b1xISEiKWiy66qABeCQAAAAAAAAAAyE/FLcZmz55tgwcPtilTprikRnp6unXq1Mm+++47q1KlSqbtK1WqZHfffbc1bNjQSpQoYW+88YalpKS4bfU4nxIZ06dPD90uWbJkgb0mAAAAAAAAAABQSEdsTJgwwVJTU11yolGjRi7BUbp0aZs2bVrU7f/0pz/ZpZdeameccYbVq1fPBg4caE2aNLEPP/wwYjslMqpVqxZaKlasWECvCAAAAAAAAAAAFMrExsGDB23p0qXWoUOH/x1QYqK7vWjRomM+3vM8mz9/vhvdcf7550fct3DhQjeK4/TTT7f+/fvbjh078uU1AAAAAAAAAACAIpLY2L59ux0+fNiqVq0asV63N2/enOXjdu3aZWXLlnWlqC6++GKbOHGiXXjhhRFlqGbOnOmSHmPHjrX333/fOnfu7J4rKwcOHLDdu3dHLAAAAAAAoHDJ63k+1elyxIgRVr16dStVqpTrrLlq1aoCeCUAABRdMS9FlRsnnniiLV++3D799FO777773BwdGqHh69mzp3Xp0sUaN25s3bp1c/NwaNvwbTIaM2aMlS9fPrTUqlWrgF4NAAAAAAAoyHk+09LSbNmyZda0aVM3X+fWrVujbu/P86mqEl9++aUro61l3rx5oW3GjRtnjz76qCutvXjxYpcA0T7379/PmwoAQGFMbFSuXNmKFStmW7ZsiViv25oXIysqV1W/fn3XU+LWW2+1yy+/3CUmslK3bl33XKtXr85ym6FDh7qRIP6yfv36XL4qAAAAAAAQj/J6nk+N1khPT7dhw4ZZ165d3X2qILFx40abM2dOAb86AACKjpgmNlRKqlmzZq5klO/IkSPudqtWrbK9Hz1GpaSysmHDBjfHhoaFZkWTjZcrVy5iAQAAAAAAhUN+zPO5du1aV0o7fJ+qAqESV9nZJwAAyJ3iFmMaAtqnTx9Xs7JFixaup8PevXtd7wnp3bu31axZMzQiQ/9qW/WUUDLjrbfecvUtJ0+e7O7fs2ePjRw50rp37+5GfaxZs8aGDBniRnhoKCgAAAAAACh6jjbP58qVK7N8nKo6qF1CbRCqOvH444+H5vn05wfNydyh2k9450zm+AQAIICJjR49eti2bdvcRFv60Vd5qblz54aCgnXr1rkeFD4lPW666SY3CkOTcjVs2NCeffZZtx9RkKG6lzNmzLCdO3dajRo1rGPHjjZq1Cg3KgMAAAAAACCn83yqI6VGbKiDpkpeq0xVbqjDpjpkAgCAACc2ZMCAAW6JJuOE36NHj3ZLVpTsCJ/ECwAAAAAA4Hjn+RR1xlyxYoVLTiix4T9O+wgvf63b2jarOT6VHAkfsVGrVi3eIAAAgjLHBgAAAAAAQFDn+axTp45LboTvU4mKxYsXZ7lP5vgEAKCQjNgAAAAAAAAI2jyfCQkJNmjQIFdZokGDBi7RMXz4cFcWu1u3bryhAADkExIbAAAAAACgSMjreT5lyJAhbrsbbrjBzfXZpk0bt8+kpKSYvEYAAIqCBM/zvFgfRDzS0NHy5cvbrl27rFy5cnmyz82XtLV4VO31D2J9CACAIvR7WJhxvhAP4jHmJN4Eih5+EzlXAAqveIw3hZizaMUPzLEBAAAAAAAAAAACg8QGAAAAAAAAAAAIDBIbAAAAAAAAAAAgMEhsAAAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwSGwAAAAAAAAAAIDBIbAAAAAAAAAAAgMAgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAACg8QGAAAAAAAAAAAIDBIbAAAgkCZNmmS1a9e2pKQka9mypS1ZsiTLbadOnWpt27a1ihUruqVDhw6Ztu/bt68lJCRELBdddFEBvBIAAAAAAJATJDYAAEDgzJ492wYPHmxpaWm2bNkya9q0qXXq1Mm2bt0adfuFCxdar169bMGCBbZo0SKrVauWdezY0X766aeI7ZTI2LRpU2h54YUXCugVAQAAAACA7CKxAQAAAmfChAmWmppqKSkp1qhRI5syZYqVLl3apk2bFnX75557zm666SZLTk62hg0b2pNPPmlHjhyx+fPnR2xXsmRJq1atWmjR6A4AAAAAABBfSGwAAIBAOXjwoC1dutSVk/IlJia62xqNkR379u2zQ4cOWaVKlTKN7KhSpYqdfvrp1r9/f9uxY0eeHz8AAAAAADg+xY/z8QAAAAVq+/btdvjwYatatWrEet1euXJltvZxxx13WI0aNSKSIypDddlll1mdOnVszZo1dtddd1nnzp1dsqRYsWJR93PgwAG3+Hbv3p3r1wUAAAAAALKHxAYAAChSHnjgAZs1a5YbnaGJx309e/YM/X/jxo2tSZMmVq9ePbdd+/bto+5rzJgxNnLkyAI5bgAAAAAA8P+R2AAAAIFSuXJlN4Jiy5YtEet1W/NiHM348eNdYuO9995ziYujqVu3rnuu1atXZ5nYGDp0qJvEPHzEhiYmB5A7my9pG3enrtrrH8T6EAAAAABkwBwbAAAgUEqUKGHNmjWLmPjbnwi8VatWWT5u3LhxNmrUKJs7d641b978mM+zYcMGN8dG9erVs9xGk42XK1cuYgEAAAAAAPmLxAYAAAgcjZKYOnWqzZgxw1asWOEm+t67d6+lpKS4+3v37u1GU/jGjh1rw4cPt2nTplnt2rVt8+bNbtmzZ4+7X//efvvt9sknn9gPP/zgkiRdu3a1+vXrW6dOnWL2OgEAAAAAQGaUogIAAIHTo0cP27Ztm40YMcIlKJKTk91IDH9C8XXr1lli4v/6b0yePNkOHjxol19+ecR+0tLS7J577nGlrb788kuXKNm5c6ebWLxjx45uhIdGZQAAAAAAgPhBYgMAAATSgAED3BKNJvwOp1EYR1OqVCmbN29enh4fAAAAAAAoxKWoJk2a5MpCJCUlWcuWLW3JkiVZbvvqq6+6utgVKlSwMmXKuB6azzzzTMQ2nue5Hpyqia2Gig4dOtiqVasK4JUAAAAAAAAAAIBCndiYPXu2q5OtUhDLli2zpk2bulrWW7dujbp9pUqV7O6777ZFixa5khGqpa0lvJelJgd99NFHbcqUKbZ48WKXANE+9+/fX4CvDAAAAAAAAAAAFLrExoQJEyw1NdUlJxo1auSSEaVLl3aTe0bzpz/9yS699FI744wzrF69ejZw4EBr0qSJffjhh6HRGunp6TZs2DA36afumzlzpm3cuNHmzJlTwK8OAAAAAAAAAAAUmsSGJvFcunSpKxUVOqDERHdbIzKORUmM+fPn23fffWfnn3++W7d27Vo3iWj4PsuXL+9KXB1tnwcOHLDdu3dHLAAAAAAAAAAAIL7ENLGxfft2O3z4sFWtWjVivW4rOZGVXbt2WdmyZa1EiRJ28cUX28SJE+3CCy909/mPy+k+x4wZ4xIg/lKrVq3jfHUAAAAAAAAAAKDQlaLKjRNPPNGWL19un376qd13331ujo6FCxce1z6HDh3qEib+sn79+jw7XgAAAAAAAAAAkDeKWwxVrlzZihUrZlu2bIlYr9vVqlXL8nEqV1W/fn33/8nJybZixQo34kLzb/iP0z6qV68esU9tm5WSJUu6BQAAAAAAAAAAxK+YJjZUSqpZs2Zunoxu3bq5dUeOHHG3BwwYkO396DGaI0Pq1Knjkhvah5/I0HwZixcvtv79++fTKwEAAAAAAAAAxLPNl7S1eFTt9Q9ifQiBE9PEhqiMVJ8+fax58+bWokULS09Pt71791pKSoq7v3fv3lazZk03IkP0r7atV6+eS2a89dZb9swzz9jkyZPd/QkJCTZo0CAbPXq0NWjQwCU6hg8fbjVq1AglTwAAAAAAAAAAQDDFPLHRo0cP27Ztm40YMcJN7q1RFnPnzg1N/r1u3TpXesqnpMdNN91kGzZssFKlSlnDhg3t2WefdfvxDRkyxG13ww032M6dO61NmzZun0lJSTF5jQAAAAAAAAAAoBBNHq6yUz/++KMbgaGSUS1btgzdp0nBn3766dBtjcRYtWqV/fbbb/bzzz/bxx9/HJHU8Edt3HvvvS5Rsn//fnvvvffstNNOK9DXBAAAAAAA4s+kSZOsdu3arvOj2h+WLFmS5bZTp061tm3bWsWKFd3SoUOHTNv37dvXtUOELxdddFEBvBIAAIquuEhsAAAAAAAA5LfZs2e7kthpaWm2bNkya9q0qXXq1Mm2bt0adXt1tuzVq5ctWLDAFi1aZLVq1bKOHTvaTz/9FLGdEhmbNm0KLS+88AJvJgAA+YjEBgAAAAAAKBImTJhgqampbl7PRo0a2ZQpU6x06dI2bdq0qNs/99xzrhy2ymarFPaTTz5pR44csfnz50dsV7JkSatWrVpo0egOAACQf0hsAAAAAACAQu/gwYO2dOlSV07Kpzk9dVujMbJj3759dujQIatUqVKmkR1VqlSx008/3fr37287duzIch8qw7179+6IBQAA5AyJDQAAAAAAUOht377dDh8+bFWrVo1Yr9uaozM77rjjDqtRo0ZEckRlqGbOnOlGcYwdO9bef/9969y5s3uuaMaMGWPly5cPLSpvBQAAcqZ4DrcHAAAAAAAoch544AGbNWuWG52hicd9PXv2DP1/48aNrUmTJlavXj23Xfv27TPtZ+jQoW6eD59GbJDcAAAgZxixAQAAAAAACr3KlStbsWLFbMuWLRHrdVvzYhzN+PHjXWLjnXfecYmLo6lbt657rtWrV0e9X/NxlCtXLmIBAAA5Q2IDAAAAAAAUeiVKlLBmzZpFTPztTwTeqlWrLB83btw4GzVqlM2dO9eaN29+zOfZsGGDm2OjevXqeXbsAAAgEokNAAAAAABQJKgE1NSpU23GjBm2YsUKN9H33r17LSUlxd3fu3dvVyrKpzkzhg8fbtOmTbPatWu7uTi07Nmzx92vf2+//Xb75JNP7IcffnBJkq5du1r9+vWtU6dOMXudAAAUdsyxAQAAAAAAioQePXrYtm3bbMSIES5BkZyc7EZi+BOKr1u3zhIT/9cHdPLkyXbw4EG7/PLLI/aTlpZm99xzjytt9eWXX7pEyc6dO93E4h07dnQjPFRyCgAA5A8SGwAAAAAAoMgYMGCAW6LRhN/hNArjaEqVKmXz5s3L0+MDAADHRikqAAAAAAAAAAAQGCQ2AAAAAAAAAABAYJDYAAAAAAAAAAAAgUFiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBjFc/qAnTt32r/+9S/74IMP7Mcff7R9+/bZySefbGeffbZ16tTJWrdunT9HCgAAAov4AQAAED8AAIACH7GxceNGu/7666169eo2evRo++233yw5Odnat29vp5xyii1YsMAuvPBCa9Sokc2ePTvPDhAAAAQX8QMAACB+AAAAMRuxoREZffr0saVLl7rkRTRKdsyZM8fS09Nt/fr1dtttt+XlsQIAgIAhfgAAAMQPAAAgZomNb7/91k466aSjblOqVCnr1auXW3bs2JEXxwcAAAKM+AEAABA/AACAmJWiCk9q/Oc//7Hff/890zZap/sybg8AAIom4gcAAED8AAAAYpbYCHfBBRfYzz//nGn9rl273H0AAADEDwAA4HjR/gAAAPIsseF5niUkJGRar/JTZcqUyc0uAQBAIUf8AAAAiB8AAECBzrEhl112mftXSY2+fftayZIlQ/cdPnzYvvzyS2vdunWeHBgAACgciB8AAADxAwAAiFlio3z58qEelyeeeKKbLNxXokQJO/fccy01NTVPDxAAAAQb8QMAACB+AAAAMUtsTJ8+3f1bu3Ztu+222yg7BQAAiB8AAECeo/0BAADk+RwbaWlprgzVe++9Z//85z/t119/des3btxoe/bsyc0uAQBAIUf8AAAAiB8AAECBj9jw/fjjj3bRRRfZunXr7MCBA3bhhRe60lRjx451t6dMmZInBwcAAAoP4gcAAED8AAAAYjZiY+DAgda8eXP75ZdfIubZuPTSS23+/Pl5cmAAAKBwIX4AAADEDwAAIGaJjQ8++MCGDRvmJgwPp7k3fvrppxzvb9KkSe6xSUlJ1rJlS1uyZEmW206dOtXatm1rFStWdEuHDh0ybd+3b19LSEiIWDTCBAAAxE68xw+e59mIESOsevXqruOGtlm1alWOjwsAAMRv/AAAAIpwYuPIkSN2+PDhTOs3bNjgSlLlxOzZs23w4MGu7vayZcusadOm1qlTJ9u6dWvU7RcuXGi9evWyBQsW2KJFi6xWrVrWsWPHTAGNEhmbNm0KLS+88EIOXyUAAMhL8R4/jBs3zh599FFXUnPx4sVWpkwZt8/9+/fn4tUCAIB4ix8AAEART2yoISA9PT10WyMiNGm4Ghf+8pe/5GhfEyZMsNTUVEtJSbFGjRq5xoTSpUvbtGnTom7/3HPP2U033WTJycnWsGFDe/LJJ12gk7EEliY3r1atWmhR70wAABA78Rw/aLSGjk09Qrt27WpNmjSxmTNn2saNG23OnDnH+coBAEA8xA8AAKCIJzYeeugh++ijj1xDgnoxXnXVVaFhoJpAPLsOHjxoS5cudaUeQgeUmOhuqzdlduzbt88OHTpklSpVytQzs0qVKnb66adb//79bceOHTl4hQAAIK/Fc/ywdu1a27x5c8Q+y5cv70pcHW2fBw4csN27d0csAAAg/uIHAABQuBTPzYNOOeUU++KLL2zWrFn25Zdfut4S/fr1s6uvvjpiMvFj2b59uxtSWrVq1Yj1ur1y5cps7eOOO+6wGjVqRDREqAzVZZddZnXq1LE1a9bYXXfdZZ07d3YNE8WKFcuyYUKLj4YJAADyVjzHD0pq+PvIuE//vmjGjBljI0eOzPaxAwCA2MQPAACgcCme6wcWL27XXHONxdIDDzzgghuNztDEob6ePXuG/r9x48aunES9evXcdu3bt4+6LxomAADIf/EcP+TG0KFD3Vwf4R0jNH8HAAAoXPEDAAAIaGLjtddec6MeTjjhBPf/R1O2bFlXv1o9IY+mcuXKbgTFli1bItbrtubFOJrx48e7hon33nvPJS6Opm7duu65Vq9enWVig4YJAADyXlDiB/9x2kf16tUj9ql5ObKiOb20AACA+I4fAABAEU1sdOvWzZVi0LwV+v9jUYPDuHHj7JZbbslymxIlSlizZs3cxJ3+Pv2JPAcMGJDl47Tf++67z+bNm2fNmzc/5rFs2LDBzbER3lCREQ0TAADkvaDEDypfqeSG9uEnMjT6YvHixW6uLgAAEOz4AQAAFNHJw9VgoKDC//+jLZrQa+rUqS6wOBaVb9C2M2bMsBUrVrjGg71791pKSoq7v3fv3m40hU+Tgw0fPtymTZvmJgxTsKNFdTZF/95+++32ySef2A8//OAaKLp27Wr169e3Tp065eYcAQCAXApK/JCQkGCDBg2y0aNHu56hX331lduHen9mp0EFAADEf/wAAAAKj1zPsXE06knZvXt3N7HXsfTo0cO2bdtmI0aMcA0M6iU5d+7c0OSd69ats8TE/+VfJk+ebAcPHrTLL788Yj9paWl2zz33uJ4ael41dOzcudM1SHTs2NFGjRpFqQgAAOJYLOMHGTJkiEuO3HDDDS6GaNOmjdvn8c7DAQAA4iN+AAAAhUeC53leTh80c+bMo96vHo5Bp/IT5cuXt127dlm5cuXyZJ+bL2lr8aja6x/E+hAAAEXg95D4ASgY8RhzZjfeDPKxA8ifGIL4AQDiTzzGbNmN24J87EXB7hzED7kasTFw4MCI24cOHbJ9+/a5nhKlS5cuFIkNAACQt4gfAAAA8QMAACjQOTbC/fLLLxGL6lN/9913rmTDCy+8kCcHBgAAChfiBwAAQPwAAABiltiIpkGDBvbAAw9k6o0JAABA/AAAAGh/AAAAcTl5ePHixW3jxo15uUvEiXisP0ftOQAoHIgfAAAA8QMAAMj3xMZrr70WcVvzj2/atMkee+wxO++883KzSwAAUMgRPwAAAOIHAAAQs8RGt27dIm4nJCTYySefbH/+85/toYceypMDAwAAhQvxAwAAiIf4YdKkSfbggw/a5s2brWnTpjZx4kRr0aJF1G2nTp1qM2fOtK+//trdbtasmd1///0R26uzZ1pamtt2586drsPn5MmTXcluAAAQR4mNI0eO5P2RAACAQo34AQAAxDp+mD17tg0ePNimTJliLVu2tPT0dOvUqZN99913VqVKlUzbL1y40Hr16mWtW7e2pKQkGzt2rHXs2NG++eYbq1mzpttm3Lhx9uijj9qMGTOsTp06Nnz4cLfPb7/91j0GAADE6eThhw8ftuXLl9svv/ySF7sDAABFAPEDAAAo6PhhwoQJlpqaaikpKdaoUSOX4ChdurRNmzYt6vbPPfec3XTTTZacnGwNGza0J5980iVb5s+fHxqtoeTIsGHDrGvXrtakSRM3wkPzj86ZM4c3GACAeEpsDBo0yJ566qlQUHH++efbH//4R6tVq5brzQAAAED8AAAAjldetj8cPHjQli5dah06dAitS0xMdLcXLVqUrX3s27fPDh06ZJUqVXK3165d60pahe+zfPnybjRIdvcJAAAKKLHx8ssvuzqU8vrrr9sPP/xgK1eutFtuucXuvvvu3OwSAAAUcsQPAAAglvHD9u3bXXKkatWqEet1W8mJ7LjjjjusRo0aoUSG/7ic7PPAgQO2e/fuiAUAABRAYkPBQLVq1dz/v/XWW3bFFVfYaaedZtddd5199dVXudklAAAo5IgfAABAkOOHBx54wGbNmmX/+te/jmvujDFjxrhRHf6i0ScAAKAAEhvqeaBJsNTTYe7cuXbhhReGhmQWK1YsN7sEAACFHPEDAACIZfxQuXJl95gtW7ZErNdtP3mSlfHjx7vExjvvvOPm0fD5j8vJPocOHWq7du0KLevXr8/R6wAAALlMbGiSrSuvvNLOOussS0hICA3BXLx4sZtMCwAAgPgBAAAcr7xsfyhRooQ1a9YsNPG3+BOBt2rVKsvHjRs3zkaNGuUSK82bN4+4r06dOi6BEb5PlZbS8WW1z5IlS1q5cuUiFgAAkDPFLRfuueceF1SoV4GGgepHWdTz4c4778zNLgEAQCFH/AAAAGIdPwwePNj69OnjEhQtWrSw9PR027t3r0ugSO/eva1mzZquXJSMHTvWRowYYc8//7zVrl07NG9G2bJl3aJkiyY4Hz16tDVo0MAlOoYPH+7m4ejWrRtvOAAA8ZTYkMsvvzzTOgUHAAAAxA8AACCv5GX7Q48ePWzbtm0uWaEkRXJyshuJ4U/+vW7dOktM/F9xi8mTJ9vBgwczHUNaWppLusiQIUNccuSGG26wnTt3Wps2bdw+j2ceDgAAkE+JDQAAAAAAgKAZMGCAW6JZuHBhxO0ffvjhmPvTqI17773XLQAAII7n2AAAAAAAAAAAAIgFEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAAK3+Th1113Xa6eoFu3btalS5dcPRYAAAQb8QMAACB+AAAAMUtsnHrqqbl6ggoVKuTqcQAAIPiIHwAAAPEDAACIWWIjLS0tz58cAAAUbsQPAACA+AEAAMQssQEAAAAAAAAAAAre5kvaxt1pr/b6BzF7bhIbAAAAAFDI/siM9R+aAAAAQH5KzNe9AwAAAAAAAAAA5CESGwAAAAAAAAAAIDBIbAAAAAAAAAAAgMKd2ChWrJht3bo10/odO3a4+wAAAIgfAADA8aL9AQAA5Fliw/O8qOsPHDhgJUqUyPH+Jk2aZLVr17akpCRr2bKlLVmyJMttp06dam3btrWKFSu6pUOHDpm21/GNGDHCqlevbqVKlXLbrFq1KsfHBQAA8k5exw8AAKDwI34AAADRFLccePTRR92/CQkJ9uSTT1rZsmVD9x0+fNj+85//WMOGDXOyS5s9e7YNHjzYpkyZ4pIa6enp1qlTJ/vuu++sSpUqmbZfuHCh9erVy1q3bu0SIWPHjrWOHTvaN998YzVr1nTbjBs3zh3rjBkzrE6dOjZ8+HC3z2+//dY9BgAAFJz8iB8AAEDhRvwAAADyLLHx8MMPh3pMKBERXnZKPS016kLrc2LChAmWmppqKSkp7rYe/+abb9q0adPszjvvzLT9c889F3FbDSSvvPKKzZ8/33r37u2OTcmRYcOGWdeuXd02M2fOtKpVq9qcOXOsZ8+eOTo+AABwfPIjfgAAAIUb8QMAAMizxMbatWvdvxdccIG9+uqrrhTU8Th48KAtXbrUhg4dGlqXmJjoSkctWrQoW/vYt2+fHTp0yCpVqhQ6xs2bN7t9+MqXL+9Gg2ifWSU2VAZDi2/37t3H8coAAEB+xQ8AAKDwI34AAAB5PsfGggULQo0S6n2ZVc3LY9m+fbsrQaHRFOF0W8mJ7LjjjjusRo0aoUSG/7ic7nPMmDEuAeIvtWrVysUrAgAA+R0/AACAooP4AQAA5Fliwy/v1LhxYzc5t5YmTZrYM888YwXpgQcesFmzZtm//vWv4547Q6NGdu3aFVrWr1+fZ8cJAADiJ34AAADBQvwAAACOqxRV+LwYmpB7wIABdt5557l1H374of3tb39zozBuueWWbO2ncuXKrs72li1bItbrdrVq1Y762PHjx7vExnvvvecaRXz+47SP6tWrR+wzOTk5y/2VLFnSLQAAIH/kVfwAAACKDuIHAACQZ4mNiRMn2uTJk91k3b4uXbrYmWeeaffcc0+2GyY0YWizZs3cxN/dunVz644cOeJuq9EjK+PGjbP77rvP5s2bZ82bN4+4r06dOi65oX34iQzNl7F48WLr379/bl4uAADIA3kVPwAAgKKD+AEAAORZYmPTpk3WunXrTOu1TvflxODBg61Pnz4uQdGiRQtLT0+3vXv3WkpKirtfjR81a9Z0c2DI2LFjbcSIEfb8889b7dq1Q/NmlC1b1i0JCQk2aNAgGz16tDVo0MAlOtQ7VPNw+MkTAABQ8PIyfgAAAEUD8QMAAMizOTbq169vL774Yqb1s2fPdsmEnOjRo4crK6VkhUZYLF++3ObOnRua/HvdunURjR3q6Xnw4EG7/PLLXakpf9E+fEOGDLG///3vdsMNN9g555xje/bscfs83nk4AABA7uVl/CCTJk1ynRz0+96yZUtbsmRJltt+88031r17d7e9OkGoI0VGGjWi+8KXhg0b5vi4AABA/MYPAACgCI/YGDlypEtI/Oc//wnVyP7oo49c+adoAcexqOxUVqWnFi5cGHH7hx9+OOb+1BBx7733ugUAAMSHvIwf1JihUZ9TpkxxSQ0lKjp16mTfffedValSJdP2+/bts7p169oVV1xx1JJXKoul+bt8xYvnKlQCAAB5JK/bHwAAQBEesaEej5qzQpN/z5kzxy36f/WUvPTSS/P+KAEAQODlZfygiURTU1Nd6cpGjRq5BEfp0qVt2rRpUbfXCM4HH3zQevbsaSVLlsxyv0pkaK4uf9HxAQCA2KH9AQAARJPrboia9PvZZ5/N7cMBAEARlBfxg0pSLl261IYOHRpal5iYaB06dLBFixYd175XrVrl5uVSeatWrVq5Ob7+8Ic/HNc+AQDA8aH9AQAAZHRc9RW2bt3qliNHjkSsb9KkyfHsFgAAFGLHGz9s377dDh8+HJqPy6fbK1euzPVxqaTV008/baeffrqb30ulL9q2bWtff/21nXjiiVEfc+DAAbf4du/enevnBwAAWaP9AQAAHHdiQ70k+/TpYytWrDDP8zLNb6HGBgAAgCDFD507d45IsijRceqpp7r63f369Yv6GI3oUAIEAAAUzfgBAAAEKLFx3XXX2WmnnWZPPfWU6x2pYAIAAKAg4gfNe1GsWDHbsmVLxHrd1rwYeaVChQrueFevXp3lNiqHpUnMw0ds1KpVK8+OAQCAoo72BwAAkGeJjf/+97/2yiuvWP369XPzcAAAUATlVfxQokQJV2t7/vz51q1bN7dOZa10e8CAAXl0tGZ79uyxNWvW2LXXXpvlNpqI/GiTkQMAgOND+wMAAIgm0XKhffv29sUXX+TmoQAAoIjKy/hBoySmTp1qM2bMcKUp+vfvb3v37rWUlBR3f+/evSMmF9eE48uXL3eL/v+nn35y/x8+GuO2226z999/33744Qf7+OOP7dJLL3UjQ3r16pUnxwwAAHKO9gcAAJBnIzaefPJJV+NSk2meddZZdsIJJ0Tc36VLl9zsFgAAFGJ5GT/06NHDtm3bZiNGjLDNmzdbcnKyzZ07NzSh+Lp16ywx8X/9NzZu3Ghnn3126Pb48ePd0q5dO1u4cKFbt2HDBpfE2LFjh5188snWpk0b++STT9z/AwCA2KD9AQAA5FliY9GiRfbRRx/Z22+/nek+Ju8CAAAFET+o7FRWpaf8ZIWvdu3amSYczWjWrFk5en4AAJD/aH8AAAB5Vorq73//u11zzTW2adMmV9M6fMlpowQAACgaiB8AAADxAwAAiFliQyUabrnlllC5BwAAAOIHAACQ1/Kj/WHSpEluNGdSUpK1bNnSlixZkuW233zzjXXv3t1trxGm6enpmba555573H3hS8OGDfPseAEAQB4lNi677DJbsGBBbh4KAACKKOIHAAAQ6/hh9uzZNnjwYEtLS7Nly5ZZ06ZNrVOnTrZ169ao2+/bt8/q1q1rDzzwgFWrVi3L/Z555pmuqoW/fPjhh3l2zAAAII/m2DjttNNs6NCh7oe6cePGmSb//Mc//pGb3QIAgEKM+AEAAMQ6fpgwYYKlpqZaSkqKuz1lyhR78803bdq0aXbnnXdm2v6cc85xi0S731e8ePGjJj4AAEAcJDaefPJJK1u2rL3//vtuCachlyQ2AAAA8QMAADheedn+cPDgQVu6dKlLlPgSExOtQ4cObpLy47Fq1SqrUaOGK2/VqlUrGzNmjP3hD384rn0CAIA8TmysXbs2Nw8DAABFGPEDAACIZfywfft2O3z4cKb5OnR75cqVud6v5ul4+umn7fTTT3dlqEaOHGlt27a1r7/+2k488cRM2x84cMAtvt27d+f6uQEAKKpyldgAAAAAAACAWefOnUOnoUmTJi7Rceqpp9qLL75o/fr1y3SKNJpDyQ8AAFAAk4droqzffvstW9suXrzY1agEAABFG/EDAACIl/ihcuXKVqxYMduyZUvEet3Oy/kxKlSo4OYGWb16ddT7VQpr165doWX9+vV59twAABQV2U5sfPvtt64+5E033WRvv/22bdu2LXTf77//bl9++aU9/vjj1rp1a+vRo0fU4ZYAAKBoIX4AAADxEj+UKFHCmjVrZvPnzw+tO3LkiLuteTHyyp49e2zNmjVWvXr1qPeXLFnSypUrF7EAAIB8KkU1c+ZM++KLL+yxxx6zq666ytWAVE8H/SDv27fPbXP22Wfb9ddfb3379nUTZgEAgKKN+AEAAMRT/DB48GDr06ePNW/e3Fq0aGHp6em2d+9eS0lJcff37t3batas6cpF+ROOK9Hi//9PP/1ky5cvdxOa169f362/7bbb7JJLLnHlpzZu3GhpaWnueHv16sWbDwBAPMyx0bRpU5s6dar985//dEHGunXr3PBQDedMTk52/wIAABA/AACA45Ff7Q8a4aERICNGjLDNmze7fc2dOzc0obieJzHxf8UtlKhQEsU3fvx4t7Rr184WLlzo1m3YsMElMXbs2GEnn3yytWnTxj755BP3/wAAII4mD9ePvH7Yw3/cAQAAiB8AAEBeyo/2hwEDBrglGj9Z4atdu7Z5nnfU/c2aNSvPjg0AAOTxHBty+PBhGzt2rJ133nl2zjnn2J133pntCb0AAEDRRPwAAACIHwAAQMwSG/fff7/dddddrpakak4+8sgjdvPNN+fpAQEAgMKF+AEAABA/AACAmCU2NIHX448/bvPmzbM5c+bY66+/bs8995wdOXIkTw8KAAAUHsQPAACA+AEAAMQssaFJtP7yl7+Ebnfo0MESEhLcZFoAAADEDwAAIC/Q/gAAAPJs8vDff//dkpKSItadcMIJdujQoZzsBihQmy9pG3dnvNrrH8T6EACgwBA/AAAA4gcAABCzxIbneda3b18rWbJkaN3+/fvtb3/7m5UpUya07tVXX83TgwQAAMFF/AAAAIgfAABAzBIbffr0ybTummuuycvjAQAAhQzxAwAAIH4AAAAxS2xMnz7d8sOkSZPswQcftM2bN1vTpk1t4sSJ1qJFi6jbfvPNNzZixAhbunSp/fjjj/bwww/boEGDIra55557bOTIkRHrTj/9dFu5cmW+HD8AACj4+AEAABRexA8AACDPJg/PD7Nnz7bBgwdbWlqaLVu2zCU2OnXqZFu3bo26/b59+6xu3br2wAMPWLVq1bLc75lnnmmbNm0KLR9++GE+vgoAAAAAAAAAAFAkEhsTJkyw1NRUS0lJsUaNGtmUKVOsdOnSNm3atKjbn3POOW50R8+ePSPm+sioePHiLvHhL5UrV87HVwEAAAAAAAAAAAp9YuPgwYOupFSHDh3+d0CJie72okWLjmvfq1atsho1arjRHVdffbWtW7cuD44YAAAAAAAAAAAU2cTG9u3b7fDhw1a1atWI9bqt+TZyq2XLlvb000/b3LlzbfLkybZ27Vpr27at/frrr1k+5sCBA7Z79+6IBQAAAAAAAAAABHjy8KDo3Llz6P+bNGniEh2nnnqqvfjii9avX7+ojxkzZkymCccBAAAAAAAAAEB8iemIDc17UaxYMduyZUvEet0+2sTgOVWhQgU77bTTbPXq1VluM3ToUNu1a1doWb9+fZ49PwAAAAAAAAAAKASJjRIlSlizZs1s/vz5oXVHjhxxt1u1apVnz7Nnzx5bs2aNVa9ePcttNBF5uXLlIhYAAAAAAAAAABBfYl6KavDgwdanTx9r3ry5tWjRwtLT023v3r2WkpLi7u/du7fVrFnTlYryJxz/9ttvQ///008/2fLly61s2bJWv359t/62226zSy65xJWf2rhxo6WlpbmRIb169YrhKwUAAAAAAAAAAIFPbPTo0cO2bdtmI0aMcBOGJycnu0m//QnF161bZ4mJ/xtYokTF2WefHbo9fvx4t7Rr184WLlzo1m3YsMElMXbs2GEnn3yytWnTxj755BP3/wAAAAAAAAAAILhintiQAQMGuCUaP1nhq127tnmed9T9zZo1K0+PDwAAAACAvLL5krZxdzKrvf5BrA8BAAAgGHNsAAAAAAAAAAAA5ASJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgkNgAAAAAAAAAAACBQWIDAAAAAAAAAAAEBokNAAAQSJMmTbLatWtbUlKStWzZ0pYsWZLltt988411797dbZ+QkGDp6enHvU8AAAAAABAbJDYAAEDgzJ492wYPHmxpaWm2bNkya9q0qXXq1Mm2bt0adft9+/ZZ3bp17YEHHrBq1arlyT4BAAAAAEBskNgAAACBM2HCBEtNTbWUlBRr1KiRTZkyxUqXLm3Tpk2Luv0555xjDz74oPXs2dNKliyZJ/sEAAAAAACxQWIDAAAEysGDB23p0qXWoUOH0LrExER3e9GiRQW6zwMHDtju3bsjFgAAAAAAkL9IbAAAgEDZvn27HT582KpWrRqxXrc3b95coPscM2aMlS9fPrTUqlUrV88PAAAAAACyj8QGAABALg0dOtR27doVWtavX8+5BAAAAAAgnxXP7ycAAADIS5UrV7ZixYrZli1bItbrdlYTg+fXPjVfR1ZzdgAAAAAAgPzBiA0AABAoJUqUsGbNmtn8+fND644cOeJut2rVKm72CQAAAAAA8geJDQAAEDiDBw+2qVOn2owZM2zFihXWv39/27t3r6WkpLj7e/fu7cpEhU8Ovnz5crfo/3/66Sf3/6tXr872PgEAQOEwadIkq127tiUlJVnLli1tyZIlWW77zTffWPfu3d32CQkJlp6eftz7BAAAx49SVAAAIHB69Ohh27ZtsxEjRrjJvZOTk23u3Lmhyb/XrVtniYn/67+xceNGO/vss0O3x48f75Z27drZwoULs7VPAAAQfLNnz3adGaZMmeISEEpUdOrUyb777jurUqVKpu337dtndevWtSuuuMJuueWWPNknAAA4fozYAAAAgTRgwAD78ccf7cCBA7Z48WLXkOBTsuLpp58O3VYPSs/zMi1+UiM7+wQAAME3YcIES01NdSMyGzVq5JIRpUuXtmnTpkXd/pxzzrEHH3zQevbsmeW8WjndJwAAOH4kNgAAAAAAQKGncpRLly61Dh06hNZphKduL1q0qMD2qQ4Uu3fvjlgAAEDOkNgAAAAAAACF3vbt2+3w4cOZykzqtspQFtQ+x4wZY+XLlw8ttWrVytVzAwBQlJHYAAAAAAAAKCBDhw61Xbt2hZb169dz7gEAyCEmDwcAAAAAAIVe5cqVrVixYrZly5aI9bpdrVq1Atun5urIar4OAACQPYzYAAAAAAAAhV6JEiWsWbNmNn/+/NC6I0eOuNutWrWKm30CAIBjY8QGAAAAAAAoEgYPHmx9+vSx5s2bW4sWLSw9Pd327t1rKSkp7v7evXtbzZo13TwY/uTg3377bej/f/rpJ1u+fLmVLVvW6tevn619AgCAvEdiAwAAAAAAFAk9evSwbdu22YgRI9zk3snJyTZ37tzQ5N/r1q2zxMT/FbfYuHGjnX322aHb48ePd0u7du1s4cKF2donAADIeyQ2AAAAAABAkTFgwAC3ROMnK3y1a9c2z/OOa58AACDvMccGAAAAAAAAAAAIjLhIbEyaNMn1gkhKSrKWLVvakiVLstz2m2++se7du7vtExISXO3K490nAAAAAAAAAAAIhpgnNmbPnu0m2kpLS7Nly5ZZ06ZNrVOnTrZ169ao2+/bt8/q1q1rDzzwgFWrVi1P9gkAAAAAAAAAAIIh5omNCRMmWGpqqqWkpFijRo1sypQpVrp0aZs2bVrU7c855xx78MEHrWfPnlayZMk82ScAAAAAAAAAAAiGmCY2Dh48aEuXLrUOHTr874ASE93tRYsWFeg+Dxw4YLt3745YAAAAAAAAAABAfIlpYmP79u12+PBhq1q1asR63d68eXOB7nPMmDFWvnz50FKrVq1cPT8AAAAAAAAAACjEpajixdChQ23Xrl2hZf369bE+JAAAAAAAAAAAkEFxi6HKlStbsWLFbMuWLRHrdTuricHza5+aryOrOTsAAAAAAAAAAEB8iOmIjRIlSlizZs1s/vz5oXVHjhxxt1u1ahU3+wQAAAAAAAAAAPEhpiM2ZPDgwdanTx9r3ry5tWjRwtLT023v3r2WkpLi7u/du7fVrFnTzYHhTw7+7bffhv7/p59+suXLl1vZsmWtfv362donAAAAAAAAAAAIppgnNnr06GHbtm2zESNGuMm9k5OTbe7cuaHJv9etW2eJif8bWLJx40Y7++yzQ7fHjx/vlnbt2tnChQuztU8AAAAAAAAAABBMMU9syIABA9wSjZ+s8NWuXds8zzuufQIAAAAAAAAAgGCK6RwbAAAAAAAAAAAAOUFiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgkNgAAAAAAAAAAACBQWIDAAAAAAAAAAAEBokNAAAAAAAAAAAQGCQ2AAAAAAAAAABAYJDYAAAAAAAAAAAAgUFiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AABBIkyZNstq1a1tSUpK1bNnSlixZctTtX3rpJWvYsKHbvnHjxvbWW29F3N+3b19LSEiIWC666KJ8fhUAAAAAACCnSGwAAIDAmT17tg0ePNjS0tJs2bJl1rRpU+vUqZNt3bo16vYff/yx9erVy/r162eff/65devWzS1ff/11xHZKZGzatCm0vPDCCwX0igAAAAAAQHaR2AAAAIEzYcIES01NtZSUFGvUqJFNmTLFSpcubdOmTYu6/SOPPOKSFrfffrudccYZNmrUKPvjH/9ojz32WMR2JUuWtGrVqoWWihUrFtArAgAAAAAA2UViAwAABMrBgwdt6dKl1qFDh9C6xMREd3vRokVRH6P14duLRnhk3H7hwoVWpUoVO/30061///62Y8eOfHoVAAAAAAAgt0hsAACAQNm+fbsdPnzYqlatGrFetzdv3hz1MVp/rO01omPmzJk2f/58Gzt2rL3//vvWuXNn91xZOXDggO3evTtiAQAA8Y15ugAACD4SGwAAAGbWs2dP69Kli5tYXPNvvPHGG/bpp5+6URxZGTNmjJUvXz601KpVi3MJAEAcY54uAAAKh+KxPgAAAICcqFy5shUrVsy2bNkSsV63NS9GNFqfk+2lbt267rlWr15t7du3j7rN0KFD3STmPo3YILkBAEAw5ukSzdP15ptvunm67rzzzqPO0yWap+vdd99183TpsRnn6QKAnPj3h5/E3Qn7c5tzY30IQLYwYgMAAARKiRIlrFmzZq5klO/IkSPudqtWraI+RuvDtxc1SmS1vWzYsMHNsVG9evUst1EjRrly5SIWAAAQn5inCwCAwoMRGwAAIHA0SqJPnz7WvHlza9GihaWnp9vevXtDvS979+5tNWvWdKWiZODAgdauXTt76KGH7OKLL7ZZs2bZZ599Zk888YS7f8+ePTZy5Ejr3r276225Zs0aGzJkiNWvX99NMh5L8diLS+jJBQAoTPN0rVy58rjm6brsssusTp06Loa466673DxdixYtcqNMo83RpcXHHF0AAOQciQ0AABA4PXr0sG3bttmIESNcw0JycrLNnTs31PCwbt06S0z838DU1q1b2/PPP2/Dhg1zjQ0NGjSwOXPm2FlnneXuV6PDl19+aTNmzLCdO3dajRo1rGPHjq7chEZlAAAAHG2eLp/m6mrSpInVq1fPzdMVrZylOl6oQwUAAAh4KapJkyZZ7dq1LSkpyVq2bGlLliw56vYvvfSSNWzY0G2voOGtt96KuL9v376WkJAQsagHBQAAKDwGDBhgP/74o+vxuHjxYhdD+NSQ8PTTT0dsf8UVV9h3333ntv/666/tL3/5S+i+UqVK2bx582zr1q2uTMUPP/zgRnNk7KEJAACCKxbzdGU1R9euXbtCy/r163P1egAAKMpintiYPXu2KyeRlpZmy5Yts6ZNm7qSD2pYiObjjz+2Xr16Wb9+/ezzzz+3bt26uUUNFOGUyNi0aVNoeeGFFwroFQEAAAAAgHgTL/N0MUcXAACFILExYcIES01NdTWxGzVqZFOmTLHSpUvbtGnTom7/yCOPuKTF7bffbmeccYYrEfHHP/7RHnvssUyBgnpQ+EvFihUL6BUBAAAAAIB4pI6VU6dOdeUnV6xYYf379880T5dGVPg0T5fKXWqeLs3Dcc8997h5ujRy1J+nS+0Tn3zyiRvxqSRI165d42KeLgAACrOYJjZU6mHp0qXWoUOH/x1QYqK7rUm2otH68O1FwULG7VWCokqVKnb66ae7QEW9JQAAAAAAQNGep2v8+PFuni7N0bV8+fJM83Sp6kPGebpUolIVJl5++eWo83R16dLFTjvtNFddQqNCPvjgA+bpAgCgsE4evn37djt8+HCm+tW6rZ4Q0WiC0Gjba71PIzouu+wyq1Onjq1Zs8ZNEtq5c2eX/FDQEY3qbWvx7d69+zhfHQAAAAAAiDcabeGPuMhInSQz0jxdWqLx5+kCAABFKLGRX3r27Bn6f00u3qRJE6tXr54LUNq3bx/1MWPGjLGRI0cW4FECAAAAAAAAAIBAlaKqXLmyG0GxZcuWiPW6rXkxotH6nGwvdevWdc+1evXqLLdRDc1du3aFlvXr1+f49QAAAAAAAAAAgEI8YqNEiRKu9qQm1+rWrZtbd+TIEXc7q2GhrVq1cvcPGjQotO7dd99167OyYcMGN8dG9erVs9xGk41rAQAAAAAAQOz8+8NP4u70/7nNubE+BABAPJWiGjx4sPXp08eaN29uLVq0sPT0dNu7d6+lpKS4+3v37m01a9Z0paJk4MCB1q5dO3vooYfs4osvtlmzZtlnn33mJvKSPXv2uJJS3bt3d6M4NMfGkCFDrH79+m6ScQA4GgJoAAAAAAAAIL7FPLHRo0cP27Ztm40YMcJNAJ6cnGxz584NTRC+bt06S0z8X8Ws1q1b2/PPP2/Dhg1zk4I3aNDA5syZY2eddZa7X6WtvvzyS5sxY4bt3LnTatSoYR07drRRo0YxIgMAAAAAAAAAgICLeWJDVHYqq9JTmvA7oyuuuMIt0ZQqVcrmzZuX58cIAAAAAAAAAACK+OThAAAAAAAAAAAAOUFiAwAAAAAAAAAABEZclKICAAAAAAAAguzfH35i8ejPbc6N9SEAQJ4jsQEAhUQ8BtEE0AAAAAAAAMhrJDYAAChEySQhoQQAAACgqIjHv8v4mwzIf8yxAQAAAAAAAAAAAoMRGwAAACgyveeEHnQAAAAAEGwkNoA4RWMQAAAAAAAAAGRGKSoAAAAAAAAAABAYjNgAAAAAgCKKUcIAAAAIIhIbAAAAQAAae5kbBAAAAAD+P0pRAQAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwSGwAAAAAAAAAAIDCYPBwAAAAAEDj//vATizd/bnNurA8BAArNd6rwvQogKyQ2AOQ5AiIAAAAAiK14/LuMRmoAQF6hFBUAAAAAAAAAAAgMEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAACg8nDAQAxx8SGAAAAAAAAyC5GbAAAAAAAAAAAgMAgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAACg8QGAAAAAAAAAAAIjLhIbEyaNMlq165tSUlJ1rJlS1uyZMlRt3/ppZesYcOGbvvGjRvbW2+9FXG/53k2YsQIq169upUqVco6dOhgq1atyudXAQAAChLxAwAAIIYAAKBoinliY/bs2TZ48GBLS0uzZcuWWdOmTa1Tp062devWqNt//PHH1qtXL+vXr599/vnn1q1bN7d8/fXXoW3GjRtnjz76qE2ZMsUWL15sZcqUcfvcv39/Ab4yAACQX4gfAAAAMQQAAEVXzBMbEyZMsNTUVEtJSbFGjRq5ZETp0qVt2rRpUbd/5JFH7KKLLrLbb7/dzjjjDBs1apT98Y9/tMceeyw0WiM9Pd2GDRtmXbt2tSZNmtjMmTNt48aNNmfOnAJ+dQAAID8QPwAAAGIIAACKruKxfPKDBw/a0qVLbejQoaF1iYmJrnTUokWLoj5G6zXCI5xGY/hJi7Vr19rmzZvdPnzly5d3Ja702J49e0bd74EDB9zi27Vrl/t39+7dlld+PfS7xaPS2XiN8Xjs2TnuIB/73r17LR5l5zPBsRf8OY/X817Yjz0ejzuvf7v8fanjQLwoavFDkK8zjr3gz3mQY58gH3s8HrcQcxa8ovA5zS5iiKxjiIKIH+L1d5i/D+L3vMfj9RLkYy/s13o8/o4VhbgtHo+9dAzjh5gmNrZv326HDx+2qlWrRqzX7ZUrV0Z9jBodom2v9f79/rqstolmzJgxNnLkyEzra9WqZYVe+fIWSEE97qAfO4Ai6ddff3UN/fGA+AEIoDj5/sgVjh1FRT5d68QQmRXp9gcAyE/EbUUqfohpYiOeqNdneE/OI0eO2M8//2wnnXSSJSQkWDxR5koBz/r1661cuXIWJEE99qAet3DsnHeul/gXz59T9ZJQQFGjRo1YH0pcIn4oGPH8GSmsxx7U4xaOnfNeVK6ZeD9uYoisET8UjHj/jBwNx85553qJf3xOYx8/xDSxUblyZStWrJht2bIlYr1uV6tWLepjtP5o2/v/al316tUjtklOTs7yWEqWLOmWcBUqVLB4ph/moP04B/3Yg3rcwrFz3rle4l+8fk7jZaSGj/ihcF5n2cGxc865XuIfn1POeThiiOhtELQ/FCy+l2KD884553qJf+Xi9G/D7MYPMZ08vESJEtasWTObP39+xEgJ3W7VqlXUx2h9+Pby7rvvhravU6eOS26Eb6MM2uLFi7PcJwAACA7iBwAAQAwBAEDRFvNSVCr/1KdPH2vevLm1aNHC0tPT3cQ5KSkp7v7evXtbzZo1XQ1KGThwoLVr184eeughu/jii23WrFn22Wef2RNPPOHuV9moQYMG2ejRo61BgwYu0TF8+HA3fKVbt24xfa0AACBvED8AAABiCAAAiq6YJzZ69Ohh27ZtsxEjRrjJvVUuau7cuaHJv9etW2eJif8bWNK6dWt7/vnnbdiwYXbXXXe55MWcOXPsrLPOCm0zZMgQlxy54YYbbOfOndamTRu3z6SkJCsMNGw1LS0tU+msIAjqsQf1uIVj57xzvcS/IH9OY4X4oWhdZxw755zrJf7xOeWcBwUxRM7w2Y4Nzjvnnesl/vE5jb0ETzNyAAAAAAAAAAAABEBM59gAAAAAAAAAAADICRIbAAAAAAAAAAAgMEhsAAAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAABeDIkSOcZwAAQAwBAABog8gDJDYAAHHN8zwL8nEvWrTI/ZuYyE8uAACx+C0OGmIIAABih/ghOGhlQb70QA7Cl0D4MdKTumBwnpEbCQkJ7t+9e/cG7rjfeecdO++88+zNN9+M9eEAcYX4AXl1zQBHQwwBFD5BjSFof4gN4gfkBvFDcCR48f7tXwToLdCH5ptvvrE1a9bYCSecYHXq1LGGDRtavP9A+D2Q1SP5999/t4MHD1r79u0tKOf83Xfftblz59rnn39u11xzjTVt2tSaNWtmQeO/nqBcLzrvmzdvtnLlylmTJk3c9Y6CF+/Xzdtvv23nnnuuVaxY0YYNG2aHDx+20aNHW7FixSwIfvzxR/vXv/5lxYsXtwEDBsT6cFAIET/E7pwXlvghCL8FQgwRX4JwzRBDAEdHDFGwiB9ig/ghvhA/5L8fi2AbBImNOPHKK6/YwIEDrWbNmq7RbseOHTZmzBi77LLLLN4NHTrU5syZ4/5///79rqF6+vTpVqlSJYtnOmY1RqSmprpzvmDBAitdurQ9++yzduqpp1q8/xhs2rTJ9u3bZ/Xq1bMgueOOO+z555+3Bg0auNdQpUoVGzRokF166aUWz5S404+Dko96D5SA9K+TeP+B9o9v3bp19vPPP1upUqWsVq1a7noPD/biya5du6xdu3bu306dOtkzzzxjn3zyiTVu3NiCYOXKlda9e3f79ddfLT093X2Xx+u5RrARPxS8oMYPQgxR8IgfCh4xBJA9xBAFi/ghdoLYBkH8UPCIHwJKIzYQW59++qlXqVIl7/HHH3e333nnHS8hIcG7++674/6tmTBhgnfSSSd5S5YscbcffPBBd+wffvihF8/Wr1/vJScne5MnT3a39+3b55144oneHXfc4QXBK6+84tWpU8erVauW16JFC3e+Dx486MW76dOnezVq1PAWLVrkbj/00ENeUlKS98Ybb3jxaMqUKd6TTz4Zuj179mx3zqtXr+6dd9553j//+c/QfUeOHPHikX9cumbOPPNMd920adPGu/DCC72tW7d68Wzbtm1exYoVvVKlSnkLFy506w4dOuTFq/Br4PPPP/euv/56r2zZst79998fdRvgeBE/FLygxw9CDJH/iB9ijxgCODpiiIJF/BA7QWqDIH6IPeKH4CGxEQfUcNqtWzf3/z/++KP3hz/8wbvpppsifgTj1XXXXRf6415/KJcvX959Gft/7McDHV/GH61169Z5Z511lrdjxw5v1apV3imnnOKlpqaG7v/ggw/irtHXbxD98ssvvVNPPdV74IEHvLfffts1sDdo0MB77bXXvAMHDnjx7JZbbgld2y+//LJXrly5iMYhXf/x9IN29dVXe/Xq1fNmzZrl7d2716tbt677vOpaHzRokPusjh8/Pu4brRcsWOCVKVPGmzRpknsdeg1KQD722GNePPvvf//r1a9f32vYsKF3xhlneFu2bHHrDx8+HLFdPJ13P2CWb775xrvxxhu9atWqRSTI4ul4EWzED/mrsMQPQgxRcIgf4gMxBHB0xBD5h/ghvgSlDYL4IT4QPwQPiY04oJEavXr18lavXu3+QL7hhhtCDXfz58/37rnnHu+XX36J9WFmaozTCAH9ca9e62o4Vc9k/wfi999/99LS0rwXX3wxpse7ceNG769//as7t+GUHGjUqJFrhFRjtXpW++f8iy++8FJSUrzPPvvMi8eeNTNnzszUM/Siiy6K6+SGrgdRI6+u948++ijT9TJ16lTvqaeeiquRJ1999ZULgnStDB061P2/f50o4ThixAivZs2acZvc0LFqGTZsmPePf/zDrdNnQqNOBgwYENpu//79XjzImLCQX3/91duwYYPXrFkz7/TTT8/UYLhz504vXuh7WiNilIQJv4Zuvvlml5yZNm1aXF4nCC7ih/xRGOMHIYYoOMQPBY8YAsgZYoi8R/wQX4LYBkH8UPCIH4KPxEYceOmll1zP7ypVqrgv3XD9+/f3evfu7e3Zs8eLlw+7eij+/PPP7v/vu+8+74ILLnClYp544omIbPNf/vIX7+GHH/Zi7bfffnP/Ll682PvXv/4VWt+lSxfXa12jTsLdeeedXvPmzV2jRrxRg6mOuWvXrpkaRpXcUGOLrqdY/zBH+3GQRx55xB1/8eLF3SgI365du7z27du7Bvh4EH78X3/9tfscKoGhaz2cn9yoXbu2N2rUKC9eqeFNiRkdr16Hkqf+9fN///d/LqDzA794OOevvvqqCz5Vli/8e0efS13jSnToePXdqO+geKHX8P7777vP6TnnnBPREKrkhkqB+SUHgbxA/JC/ClP8IMQQ+Y/4ITaIIYCcI4bIP8QPsRHkNgjih9ifd9oggovERozKAHz88cfe0qVLQ/f169fPfdmq5IGSAtu3b3e98k8++WRXziRePuz60lcD+pw5c9xtjdRQT+S2bdu6mvKixlMlNc4999yYNpb6vdVFx6FGaZVt8hsn1AuzXbt2rlFaDagvvPCCKy+kWtnqdRmPlLDQua5ataqbVyPjj3erVq1co4p6ucdK+DGpJIfO7bJly0LXvxrZS5cu7eZlUWmhNWvWeJ06dXLHHS/zJ/jH6icUv/vuO1dqRLU4NWImnBrZb731VtfgrtIkseyJv2nTptB7r9E7mgNHRo8e7f3pT39yCVS/ZIqOUyM1/KRHLEdthJ8zNQzq+jj77LPdd6JGmvjDg5XcaNmypfuMKnGgMmGxTOJFe691/euzqRJauqbDe9/06dPHHbdGmTBiA7m51ogfCkZhjB+EGCL/ET8UPGIIIHufEWKI/Ef8QBtEbhE/FDzih8KDxEYBU21+TYaryYvUc27IkCERPQA1akP36Q9ozaOgBuF4MXz4cK9y5cre66+/7pIvPv2hr5JUfh18Ndxp8RscY90T/Omnn3Ylsb7//nvXgK5Fjb6yYsUKN/pBpXnUm1r3xUujhP9Fq9JSOod+I4vOq45V51zJgYwNpLGsERl+LKplqUm2K1So4K4LTVatY//pp5+87t27eyVKlHDXuBqwdb3Hy/Xiv4Y333zTjQhQcsa/VjTSQdf5s88+G/EYvabwz0QsKAmjxIUaz2fMmOGSAn6PFCVKVcbppJNOcskB/7q666673AgOJW7igRr/zz//fNc7Wte7vmtUA1Xn/YcffnDbKAGjCd+UtPETYbG8ZjRCw58jKWNyQ9e3rm2fktRKPgG5QfxQ8IIaPwgxROzOOfFDbBBDAFkjhihYxA8FK+htEMQPsUX8EHwkNgrwy0pD3dTD75lnnnF1jtU4p0llwycK14gNNUpqUmj1BI8XK1eudD3S9cda+GvyG9vVA0SjODShtf71fxhi1QPf/3FQr0r1/r7//vvdbTU6aLihfuDUaOpTo4Xen927d3vxwD/+t956y7v22mvd6Je77747dP7VKK33Q8kNXUux7v0dfi2IerCqoUd1LHXtaFifjvWPf/xj6NrQNiqDtHDhwtBj42XEhpJ1um40T4war8LLUqlcnJIbzz//vBdvdH1rknAFbFOmTIk4p3od+r5JTk5281VccsklbkRYvCRP9Rnt2bOnu97DrwN9J5YvX94lNzLWuo+HIFSNnkoYXXHFFZnu1+TsSjA1bdo0JseHwoH4oeDPd5DjByGGiB3ih9gghgCiI4YoOMQPBa8wtUEQP8QG8UPhQGKjgH7gVGdR81Jcc8013ubNm906lSPRvBQaBfG3v/3Ni2dKXKj8kV9uKpwa2fVHfUax7nmvXt9jx471brvtNnc7fHJPNU6od2V4zexYy5ic0A+uGqgHDx7sJiNVCTD1LlDiS9S7QI3U6nEfy8ZplZMKp8RW3759IxJ2em06RiVjVPooJzUxC5pGvKh3x8SJE6Per+SGXptGV6lROx74506jMdSQfsIJJ7gEjF+Wyr+2VCpLIx10Tf3zn/+MmiiIFc09oWNv0KCBt27duky9V5Q8uPLKK12pu3iic6xecBotc9lll0Xcp6RMhw4dvNatW7uSa0BOED/ETtDiByGGiH0MQfwQO8QQQCRiiNggfig4hakNgvghdogfCgcSGwVADdQaqaFGr9NOO83bunVr6D4lBJTcUPkplZCJB9F6/y9fvtw1lmoEgZ/V9rf7z3/+4z333HOhSbLigUrvqDyMeluqF7ifaPGTLWqcUMOERkKEj0KJNf/4fvnlF1fTW3Mj+NTrQHM51KlTJzSpspIbsWw0VUJO5Yz8Y1fyrk2bNu68q1drtHJmmgdk7969XrzIeL2rLFPdunXdHDj+fRm3UUkhDXONdWJAjfzqkeJPAKg67xqZoRJlZcuWdcGdn9yIdaIxOwGkSnwpuaF5NpSECffyyy97HTt2jFnwqWvAvw5UFksJrv/+97+h+/3kxqWXXho63xrxM3DgwLj6bkSwED8UvKDGD0IMUbCIH2KDGALIHmKIgkX8UHCC3gZB/BAbxA+FF4mNfKY6636NeNXrV5kY9b4Pp+TGo48+6iab9UdzxMOH3S+r4H/xqkSMGnzVEyF8tIZ+PDTBb7xRb2lNYq7JPD/77DO3LnyuCjVcqz52LOekkPT0dO+qq66KWKcfZzWSPvLIIxHr1WithId6ksYDjVjw61JqBJKsXbvW1a9UbUuNCsjYcK3REBl7WBS0aMNO9dnT7U8++cQ1rvujk8K3UY8PJfL8az/Wc2poBIMmBR81apQ7Zn80j8yfP98lN/r16xdKbuha86+pWJUvC/+O0blU7xrVrPfPpxK9ei3Dhg1zn4Nj7SO/ZfweVAJDI6c0cbmSvUpI63ve/wNS9fY1j5KCZ51/1ewEcoP4IXaCEj8IMUTBIn6IXfwQfv6FGALIGjFEbBA/FIwgtkEQPxA/5ARtEDlDYiMfqRFak/eOGTMm1BCpOn9q7Mo4FE4Xrnrpx1L4HypqOFfCQr0W1ZCnHw410Kk3cqVKlbz77rvPu+eee1xJhsaNG8e8LmFWPev1R49eh+oq+uWawntexrJxWseqiZA1/E3ntH///qH7dK2o0UQJo4xlvjTy5+KLL/ZiKeN51gRpmrPB78GuwOKvf/2r6zmhuWT27dvnGoD+/Oc/u5JasZ4TRHQ8fkJOn0vNm6FJxXRNaGSASgj5I2H841XvEC2xTmr4VBtUE58pEaA5WDLWGv33v//tGuY0YqxXr15eqVKl4mZy2yFDhrgJzXXedZ2oBJV6Osm0adPcaxoxYkRoXSykpqZ61113Xej7Td8nSk6rTJm+3xVUK7HUuXPn0MgZJcjuvfdeb/z48W6UFZAbxA8FJ4jxgxBDxA7xQ+wRQwBZI4YoGMQPBS/obRDED7FH/FA4kdjIJ0pSKIGhxrnbb789tF4NZH5yI57m1Qj/klePbk3Wq17gLVq08M455xz3/zp2NdqpsVF1CpXUCG/0i/VE4SrPpN7TSsaoLvamTZtCjRP6gWvevHmoF77f8BvLHze/1I6uFf0oa84GjezxqQyV5jWZOXNmRHJDozvUIB/LepD+c/v/jhs3zpXl0KgkBRSipECXLl28pKQkNxpJSTH1gPXL8sS6nuWkSZNcUkBJDPW8f+aZZyJ6dajBWgkB9Xh677333OdYPfHjoQe+f93q86jrWp9HJbvef//90Db++dX8OHofrr766pglNTJ+zjSptuYWUsksv8exvis1csP35JNPunVTp071YkFlvTS5evi8QkroZhzerOTSeeed5+Y0AfIC8UPBCWr8IMQQsYshiB8KFjEEkH3EEAWD+CE2gt4GQfxQsIgfig4SG/nogw8+cOWElAAIrxev3n4qv6JGO9VfjycquaAJl+bOnRv6MtBEw0pujBw50mW9w4f8+WI9YkPns2TJkq5hQsmBatWquaSM39Crsjz6UVP5mHjosT579mz3/muuBv98Tp8+3SUyVDrIp1Ec/jqdfyXD1ANf9f3jwaeffhrxQ63eEWpA9wMLzUWghqKmTZu6XhM+jVSJBzqfeh+UxMjY+1YTw+qaUdJDc+MoCRLeyB0P9LnTd4uub9V8V5ImPLkR/p0Tq97F/jUeTt8xmsTcP8+6plWCSpTE879PXn/99Zh9tyhQ1mgS//vl4Ycf9u6//35XYkrnMjxQUgkwjYbxG0OB40X8UHCCFj8IMUTsYwjih4JBDAHkHDFEwSB+iJ0gt0EQPxQM4oeihcRGHsmq5556+2mOjWuuuSZUJ03UWKcajBoqGi80kuTMM89082j4NaVF2W1NWt2yZUs3WsOv1++Lda9FlapRqYjweSeUKNDxavGTSjrfKscTPuFvLIchqiFaNSC//fbbTMmN8HlYVNJGozSaNGnifqDjpWFlwYIFrieEGnx9KtGTMbBQrwn1ktDcICrNFg9UWk29NTS5s871+eef70YfRau7qXJCGzZsyDSZdSz4nzWVRVFCQPVD/c+jyk5piK3KIvkNciqJpNEQsfqMaqI2JY0y9o7RkGF9Xt966y03ek3l2PxtNN+QAtTwY45FckOjSVQqS0OXlfzSHy9qTCxevLgbpRHu448/dnVb161bV+DHieAjfoidIMYPQgwRO8QPBYcYAjg2YojYIH6InaC2QRA/FBzih6KHxEYeBhRqWNSEt/pC1bwUq1atcuvVyKjkhhqnw5Mb8UY/0Dp2HasSGH4daT+7rVI8SnqoREw80QTDaoB8+eWX3W2/Z7qG4qqUjBqvfXv37vXihRrL9WOrYzxWckOvScfuD6GMBwoWdE1knORcgUXbtm3dZPOrV6926xRgKCmjUQ+alyDePPjgg17r1q1dcmPr1q2h9Tr+WNdRz0jXuRJiCt503deuXduVzpK3337bJQ00X4XKp6hBXpPcxsr3338fSkpo/hI/eaHSdmo01HeNkhg+nXt9JjRaIh5oZInOoYY4+/Q9ftJJJ7le3P7INZWuOeuss+Ii+YVgIX6IraDGD0IMER+IH/IPMQRwdMQQsUP8EDuFpQ2C+CH/ED8UPSQ28ogSGcoc9+zZ05Uw0MgHlYXxRz5o5IYaw9TomHHEQyxkrC2oDLL/x7x+DFR6avLkyRHJDTWq6wcjfF089E5RY0OtWrW8oUOHhtb5jROXX355RGmneLN+/fqjJjfC59yIx95A6jV65513ejVr1nQjA3zqga8yPppg3r9eFITo86GhobF8DRrx8txzz7kyR+ElvTQyRnMlKKGk16UGLTVWx1MyUsNuda2o9JFs27bNNbz7ZZ380QMPPPCAS9JEG4JZEDSSJOP3o45Txybq9ax5QVTi65NPPnGfYZ1zjTZRwiPWpe1EZfc0WuP66693x6re2qLrWd+RKl2j60OlqSpVqhSaXBjIKeKHglVY4gchhigYxA8FixgCyD5iiIJD/FDwgt4GQfxQsIgfii4SG3n0h6UauDQhrk9lS1STWaVh/NIFGtFx6qmnhnoux0NSQ3Xtb775Zu+yyy4L9fpWjXv1SlaDXcbkhi9WyQ3/x0GNzToGv8e0zr0SAVOmTInYXr3WBw0a5MUz/TBHS26o8Vplb+Lp+HV+/eskY2CR8fwr0PavE//fWE8wr2NS/XSVHlHyUQ3XSnD41OtDiUkFSVrU6B5PVApJ14qojJ1Ga6jh3ReeNI3VxGhKXiiJMWDAgNA6zU3SvXt3N9JEk7H7Jb5Us75x48ZelSpV3PeNkhp+kjUeEqh+D+2nnnrK9epWSUHfSy+95MpmKZj2ewUBOUX8UHAKY/wgxBD5i/ihYBFDANlHDFEwiB9iL4htEMQPBYv4oWgjsZEH2WM1MKqx9J133sk0Z4Uyxu+++25onT/5djzQED413qoBUr3T1RipenT+yA0lN1TuRj3ZY9VIGu2cv/nmm25IoRpB9a8SRmoM1etRckATsuvHTa9LkxL7yYJ4OX7V4deiIXLhgal6q4cnNzTEVSMLvvvuu5gdc/j7vnnzZu/KK6/06tevHyrb4VPyTg3TOt/htcrjpYFadJ3o/Pqlj5R81PGqbJMSBr7ly5e7ayxWI0uORiWcNBJMo6c0/FYjevz3SMNrVULOTwzEip5fjf5lypRxk6P5NDqmR48e7j3wkxtK8up7U59XlXaKdQIsK0oYTZs2zSU3/JEbQG4RPxS8oMcPQgwRO8QPBYcYAjg6YoiCRfwQG4WlDYL4oeAQPxRtJDZyKLzRULXrNfeEGuc0YsMvDxP+RawJZf/xj3948UaNiBo9snjxYnf7o48+comNmTNnhrZRvXhNcH3jjTfGfIJw3//93/+5kl9jxozxnn/+eZd80XErUaD3wW98bN68uZsoSo3U8cA/fzp+9VDXMap3QfjQSdXLVnKjRo0a3ldffRXxuFjzj0Ol1VJTU13CTo3X4TRyQOdd5Tu0fbwcu+hzqvkSbrnlllAiSaMdNKpKo5U0d4wmh40n/vnTyAYtoiSXvlNUBslPGvjbqWexXo9GXMVK+HefJjc/4YQTIkq86Lr2kxv6zpGM10k8BKHR7Nmzx32/6LteJQWBnCJ+iK2gxg9CDBE7xA8FhxgCyBoxROwQP8ROkNsgiB8KDvEDSGzkgDLCF154oWt4U+/o8uXLe0uWLHH3XXHFFV6dOnVCDdKi7dS7Orz+fSzcddddmeb10A+Ckhai11K2bFlXdsofraF5CESNpP4XRax/JNSwqDI8mmhJ1BCh5Ex4KR6/PrZ+SOJtok/1FNV51jwlaqBWrwI1qoTXgFRyQ5NYq0eCXkesznn4j4PK8CgZ4wfUSuip7rjmHdBQT/+9UZmeWbNmhY451tdLRhpZ9cEHH7hrulmzZqHr5rXXXvNKlCjh5knQKKt4ED50VedZI6q2bNniRvEoUaDrQ/No+JOi6TOuOXxiNadG+DGLrm31eK5YsaK7xsOTu/qOVJ1TjXLT3ENBoutctVtVrizWJQURLMQPxA/Hixgidogf8h8xBJA1YojYxRBBb38Q4ofYIX7If8QPEBIbOaBe3ppkUrX51Vjnj9DwP1CaeFi9wFWvWcPkVNpAyY9YlhJSGYXzzz8/U2kXNZhqnoGnn37aK1eunGusC096qEfyxo0bQ+vioRSVGnV1fjXvwdatW10ZrfDJtTXaJLy8UzzREEqVvRg3bpy7rR6iGiWg96ZYsWKuYdqfsFTnXffHSvh7rVEMo0ePdte76o3715GSGxrJo2GfSt7pWjr77LNDCZpYJzX859f1r8Zzf54bmTdvnuvVobqcouupQ4cO3pAhQ9zkYvFCx1mqVCmXcFRSw6djVKJA81Vobork5GRXTiteJq8eOXKkV7lyZXftqIeTkjIaYaIRM+FlqZQkvvjii72g0R8sfm1+ILuIH2IryPGDEEMUHOKH2CKGADIjhogd4oeCE/Q2COKH2CJ+KNpIbOSQGhn1BauGRL/kS/iXsHqtqze4/oA+99xz3aS58UIjM/TjLGrobd++veuprh+N8DlAunTp4vXu3TvmjdMZ6QdLpSPUU13zC+hHzf8RU8Pvtdde68pLxNtx+2W9NDG1EhZqoFByzO/poQZ1XVNKhMVTGR4dj5Ivw4YN87p27ep632vOFT+w0GvRHCBXX321ew3++nhIgvmlkDRCRqMb1LCuuuk6v+q1omTeggUL3HYaAdG3b9+4aazW9aseP7qeb7311tA68c+xjlUJjieeeMIlbjTSJx7o+0NBpkq9hCcClARWAu+2224Lrdfxx8u1AhQE4ofYCXL8IMQQBYv4ITaIIYCsEUPEBvFDwQtyGwTxQ2wQP4DERg6pEVGlpVQe5pxzzgn1rA9vkFbCQ73BVdIplsK/3NVDsXjx4i5p4ZelUkOvGthVFkYT+KoMj8pTNWnSJKY/EDqXfuOCGnjDR5sMHjzYJQHU01v3+e68805Xc9HvhR9LOnb/eti+fbu3e/fuiPvVsPLnP//Z27Ztm7utURw6ds07EN4zP5ZUx1K97v2J7/V6NC+LEnYaZRJe5zX8GomHSZ91PGoE0giqf/7zn96qVau8+++/3103anBftGiR1717d++UU05xyUclP/zSa/FEJcn8OUGi9dyKRwoqlPTNOK+QhnGr7qneg5SUlIj74iEIBQoC8UP+C3r8IMQQsUP8EFvEEEDWiCHyF/EDbRDHg/ghtogfQGLjGPw/kFUfTyUM1OAr+gNYSQGVtAnvLf3WW29F/MEcD1QTUsP5dOyasFolkX777Td336RJk9wf+Rq5oYZUTaTsN1oX9OiB999/P+L266+/7hItOr7wHuCaz0RleNToe99993nXXXedK/kV69ExGgkQPtmoyn21bNnS9TjQOX/yySfdes1PoTI8PvViV0kwNf7GCyUx1DsivByZGojUC0ENQ0qQ+aWz4qVh2v+s6trWj5vKe/kjlEQTtScmJnqPPvqo9/bbb7vEnrbxJ+aOtfC5SZR81DWiHsYSPrxWSQ2NMol12ays3vdRo0a5YcGazyTc8OHD3WgOLfFyzQD5ifih4AQ9fhBiiNghfih4xBDA0RFDFAziB9ogjgfxQ8EjfkA0JDay8UWlxlz1VFePPtW8V9kafx6Es846y5WeUlkb9fpTr/tYzo8QbeLnGjVqhCY517+aZFjD+sITMOrVrob1jCVvCooSAmowV0Oz6HzqXKsGtspiqZRQnz59QtvrXGseEJ17NUyoZn8sqbyUJo9Xb3Q1OGsSZ9V+VJkvjdDQ/AJKHmkYsRp81cCubdWLvUKFCm4uiHj6cdCIh3r16nkPPfRQxHol8bRe74cSYX4SLF4aqufMmeMaszSiSp/XjCMxNNoqKSnJzfsQL8fsf+Y0ukcJDb8klpIv+kz4k9X5lNRQQjWWo3vCz52+UzQBuz7DOnYlitq1a+dGgi1cuNBto/X6vPrJvYz7AAob4oeCE/T4QYghYv97QPxQcIghgKMjhigYxA+0QeQF4oeCQ/yArJDYyMYEvmp4Vkkb9VDXiAz9Ad2jRw/Xc1p/jKp3shp7lfzQhEbxYvHixd7AgQNdciP8i8BPbmh0RrR5BWLR4Kgki+YLUKPzPffc4xpK/UZ1JVnmzp3r5kXQHCY+rdfj4mVeCr33anC++eabvbvvvjtiPgGVJ5s4caJLbkybNs179tlnvbZt27r3IJZlkMLf6+nTp3t33PH/2rv3YBvLNo7jVyH+0GT6Q3JIaUI5bTIONTkXKqYYlNDBIcxolENNUTJTFFGTdCChybEUpXGqdNLERHQQOTWJ0AFlKGq/87ve91mz9iYv2Ws993p8PzPC2ntrWZ797N++r/u+rnv9+WsmQu/evb0ANnPmzNT7qH2WFqzVokrXfLNmzQq0pYrTqlWr/Brp27evFx9LlCjh1/+2bdsKvJ927+pzOmoFFsI3LtpdrNZZupdoJoiuD31uTpgwwe83uk60QKdeovo7xjkoPL0Hva4XtZ7StdC4ceP85s2b5+/cudNb27Vp08aLqmrZp0JTrVq1UgXTUPvYA0WJ/JAdScgPQoaID/khe8gQwIkhQ2Qe+YE1iFNFfsge8gOOh8LGcWgxWjv+Hn744dTAbS3gaZe9Whdox58W8USL06HMRxC1ndIuRf3Q0OrCC9m6CZctW9YXIuNqgXSsAoraA2lxQidftLs+nRYndApCOyxDpYWJBg0a5FeuXNkLBOm0UK3nHrUX0u78UNqWaUiX2pSpB7nmT2gnq1ohqbChhWkVC6ZPn+6FDA3v0mKQFtfVrqpt27ZxP/38TZs25T/44IMFWo5MnDjR52hod27h4kZ6i6oQ2o9od7EW4tatW+fXjYoZmgUS9dTVgpzuN/p30GmgEKjoontI1HJKRQ4V7vR5Khs3bvSCjQp8Y8eOTRU1QlpIBDKF/JBZScwPQobIPvJDPMgQwD8jQ2QO+YE1iKJCfogH+QHHQmHjOHRCY86cOX7TUmueunXr+nwEmTFjhi8+ql984UXTuPvzR3RSQzvTtTitRcbC7/vxxx/7onScLWHUtkuvscyePdsX/fW8VTjq1avXUe+vneB63QsXDUKiIlfUuqxw3261yqhTp05qPkUI1PJIbbR0wif6d9BpBz2ufx8NN8/Ly/Nih3bhR89dC9T6+6mNWdzhXydlNOw8akWS/oWvQoUKfoJGhclI3CcG0v//3bt39/ZS0ewenYCIrv30IbhxD2eP7hP6Wc9Lz1s96kU7pLVoqF3TohknxyoehTBcHsgG8kPmJTE/CBkie8gP2UOGAE4cGSKzyA9hyOU1CPJD9pAfcCIobPwf0ZDtl19+2VutqP2UqD2Pdq9rZ74WI+OUXpjQ6YsDBw4U2MFYrly5/KFDh+Zv3br1mB9zrN9ng1oYqa2RZjUMHDjQFxzUDkmLplqc0Be2YcOGHXOwdSgDn/+Jdt6r9Y5aIqUPFNcJoFatWgU1KFyvdZMmTfzXc+fO9QVqnXaIrFixwq8PfQGPFtpDaT8V0ekRFQTUzumLL74o8DbNNdEuXp28CmlhXbN7VHhRUUYLbjrBo9ZNukai1/mZZ54pUDiNqyCT/v9dv369B0otIup6UfgsXbq0v86i11jX1KxZs4J6vYFsIz9kTpLzg5Ahsof8kHlkCODkkSEyg/zAGkRRIT9kHvkBJ4rCxgkaOXKkDwqPdiGrvY1mJsS9wJtekFArG1WztUitdllaKBUtOGrXulrFhHC6JN2vv/6a37BhQ1+U6NevX4Ewp0HDxYsXP+biRC7QFztdM1WqVPECx5133umzTQqf4oib5mlodoPmx6QvUMu8efPyBw0aVGAeRdynHY63y1W7OlQYKDwMVtdS+qmlEFrFnXvuuf76qjWKZvaobZaGzEf3FBUo27dv722c4nzN0//fAwYM8F0zarunGSwqxGh39KRJk1Lvo7e1bNnyqFYwwOmK/JAZSc4PQobIHvJD5pAhgFNDhih65IcwJGENgvyQOeQHnAwKGyfxDabmVWhHuBbtNIgyzqHPhamVjfrda4e3+tpr171mIaQXNy644ALv0R/NBQmBFnFbtGjhC9Ka6aChyRG1s9HihOYP3H333fm5SLsuNQy6UqVKPv8htMJStANfsxGiHa/pr3/r1q29/VqIQeKfPk81gFttSEKZRVGYjs1qHohOUYl2F+sa0WwWvebpn9N6fPPmzfkhUDs+FVree++91OKhiqg6taZihoq+ureouNqoUSNOawD/Q37IjKTnByFDZA/5IbPIEMC/Q4YoeuSHMCRlDYL8kFnkB5wIChsnQS15NMRX/ZkL7wiP04YNG/Jr166dv2zZstQwYhVe0qveMnr0aJ+3EdoXCM0P0ILodddd58PM1fYrnXZ+a7D17t2783ORdudr0SXk56+WQloA0mK7Fq7fffddf866rqJ2QqFdN8cLFyoSqE2JAlNIon6cGm6r9imitk7akaLZK1qk0yKcTlxpMHsop3v0OVitWjVvo5ZeGNWgWz2uwt3FF1/sBQ39/aJTJwwKB/6L/JAZSc8PQobIHvJDZpAhgFNDhih65IcwJGUNgvyQGeQHnCgKGycpGpwbWtjRaQzRaQ0d5dNsDdm/f3+BNjHHGjIeCu1M1+KETsRMnz7dH9PO9ltvvdUrtUnokxoqLUDPmDHDW5bph9oNtWvXLmcXqFeuXJnftGnT/B07duSHJurHqV3GKgyIgtvUqVO9ZZlOPKi4EWdRpvDMHc0AqVq1qg9o3759e4G36V6i5677zPz581PXCvM1gKM/r0L72kt+yA1kiOwhP5w6MgRQ9MgQmZHk9QchP2QP+eHUkR/wb52h/xhyhv65zjjjjAK//vnnn61Tp052xRVX2FNPPWVPPPGE9enTx99nzZo1dv/999uIESOsYcOG/jES/Rmh2bp1qw0aNMi+/fZbK1WqlP+8ePFif+7IvD179tjevXutZMmSVqlSJb9Ojhw5YsWLF8+5l//QoUN+DYVo3bp11r17d2vQoIENGDDAateubSHasmWLValSxf7++2/78MMPrWvXrpaXl2cLFy70tx8+fNhKlChx1Mf99ddfVqxYsRieMYB/Qn5ApiUlQ5AfigYZAkiOJGcI1h/iR37IvFxZfxDyA04WhY0cosXFM888M/X7KFTs27fPevbsaQsWLPCblEJF9I1Zx44dfeFx3rx5BT42ZD/88IMXM7Zv325dunSxatWqxf2UTluFrzkUHQX+Xr16Wb169WzgwIFWo0aNoP69ly5daq1bt/bPxauvvtofW758uX9ONm7c2N544w1/jCIGED7yA0K47pDc/CBkCCCZTocMwfpDWMgPmUF+QFJR2MjBXRLjxo2zzz//3H788UcPE+3atbOffvrJfy5TpoxXYStWrOgLj3p89erVHiz4AgGEFy769u3rpyIeeughq169emzPJf3+8MILL9iff/5pd911l1WoUMEmT57sRY6ouHHTTTf57ix9swIgbOQHIHlCyg9ChgCSiQwBJAv5AUkUfvkc/s1CVNQYNmyYPfLII95i5+yzz/ZvarT4eNZZZ/kiY/369W3JkiW+21rf5OjGpaKGWgHkwm4J4HRSt25dmzBhgu3cudPOOeecWJ9LdH944IEHbPjw4X5/GT16tNWqVcuPmS9atMjf3qxZM5s9e7YXTu+7775YnzOA4yM/AMkUUn4QMgSQPGQIIHnID0giTmzkEJ3QePTRR32R8aqrrvLHZs2aZaNGjfLf6xsctYVRCFE/46gYkov9jYHTSSj9vHfs2GHNmzf34kaPHj38sd9//9369+/vx8znzJlj11xzjT+uoqmKHtxbgPCRH4BkCiU/CBkCSCYyBJA85AckCVv4c8TMmTOtfPnyNn/+/ALDetUSZsiQIfbiiy/a2rVrfWCv3p4+3IuFRyBsoSxK/PHHH7Z7924777zz/PcqkpYuXdp75moQrHp6v/POO/62OnXq+L1FxVQA4SI/AMkVSn4QMgSQPGQIIJnID0gSChuB0oJiuiZNmljXrl3t+++/94VHOXz4sP/crVs3O//8823FihVH/TlRgQMAjnePkYsuusjy8vLs6aef9gUKtZZQcVSze6pWreoBqEOHDrZ169bU21RMBRAO8gOAbN9nhAwB5D4yBIBs3mOE/IBTRWEjUOlDfD/66CMf4KvZGu3bt7c77rjDh4dHJzc0IFwLjOqJDwAnM+RTRYpt27al3tanTx/bs2ePDR48uEBxVO8/ZcoUP6mhU2JqcUfhFAgP+QFAJpEhgOQiQwDIFPIDMoXBC4FSoWLfvn2+uDh58mR/rHLlyj5HQwPDW7Ro4UPD1TJm4cKFXtRQWyoAONFvWjT8+80337TvvvvOZ2r069fPunTp4r10p02bZjVr1vSZG5988okXMho1amSXXHKJnxqjxR0QJvIDgEwiQwDJRYYAkCnkB2QKJzYCPJalQKGd0Gr/Ur9+/VTrKalYsaI999xz1qpVKxs5cqQvON544422cuVKX2jU4iMAHEv6PIxZs2b5jxEjRtj48eNt2bJlNmzYMPvss89s4MCB9uyzz3ohQ8NAdR/69NNP/R5z8OBBb32ne43uVQDiR34AkGlkCCCZyBAAMon8gEw7I5+VqeBs2LDBqlWr5r++/fbb7bfffrO5c+cWaPui9jFDhw61Dz74wN5//32rXr2698QvWbJkjM8cQIhGjx5tnTt3tipVqvjvdc94++23fW5Gz549/TEVR/v372/ly5e3e++916688soCf8ahQ4e88DF16lRvj6d7DoCwkB8AFDUyBHB6IEMAKErkB2QLJzYC8/zzz/uCohYcGzdu7MPCf/nlF99Nrb73Bw4cSA3YmThxou+kbtmypX355ZcUNQAcZePGjT6TR63sRPeUa6+91saMGWM7d+5MvV+DBg38nqITGuPGjfPCR2Tz5s02fPhwW7x4sS1dupSiBhAg8gOAokaGAE4PZAgARYn8gGzixEZAA3Rky5YtfvJi9erVvmti1apVvpjYsGFD+/rrr32IuOZq9O7d27p27Wrbt2+3m2++2Xbt2mVfffVVaqA4AESi9nZvvfWWF0x14qtjx45eoHjssccsLy8v9b6653To0MG6detmo0aNSj2+du1aK1u2rLehAhA/8gOAbCBDAMlDhgCQaeQHZAuFjUAChdq7qHChokbbtm2tTZs2/rhavrRv3953SevEhob6aoHx8ccfTxUxtMNafesqVaoU518HQMB071CBVMPAdSJDhVMNCteJr3vuucdq1aqVet/169f7qbFixYod9Y0PgPiRHwBkExkCSA4yBIBsIT8gGyhsBECzMqZPn546gaHhvddff709+eSTPji8adOm9sorr9jll19e4OM0vFfDfAHgROgkWJ8+faxOnTo2duxYL6bqxJeKG4MGDbKaNWsWeH8VTFXcABAm8gOAbCFDAMlChgCQDeQHZBrbcGO2aNEie/XVV23BggW+i7pTp05+AkP97tU6Rm2nSpUqZUuWLEl9TDTvnaIGgJNRr149mzRpkoeLwYMH22WXXWYzZ8605cuX+2BwtcJLR1EDCBf5AUA2kSGA5CBDAMgW8gMyjcJGzFTEUAspFTJU4OjZs6eNHz/ebrnlFtu/f7+3oipTpoy3qIqo4AEA/0bdunVtypQpXtwYMmSI1ahRw3+vdlMXXnghLyqQI8gPALKNDAEkAxkCQDaRH5BJtKKKmVpQ6TSGChmdO3e2MWPGWN++ff1tr7/+um3atMkuvfRSn7nBCQ0ARWXNmjXWu3dvq1y5sk2bNs1Kly7tjzNTA8gN5AcAcSFDALmNDAEgDuQHZAKFjZh988033u/+8OHDvmv6tttu88cPHjxoN9xwg5UvX95eeuklf4x+9wCK0sqVK23ixImpExsAcgf5AUCcyBBA7iJDAIgL+QFFjcJGANSCqkePHjZgwABr27atz9AYNWqU7dq1yweJc1IDQKbofqP2dpzUAHIP+QFAnMgQQO4iQwCIC/kBRYnCRgB0EmPOnDne717KlSvnJzVee+01K1GiBCc1AGQlWADILeQHAHEjQwC5iQwBIE7kBxQVChsB2bNnj+3du9dKlizpA8W10HjkyBFObAAAAPIDAABgDQIAgP+hsBEwWsMAAADyAwAAYA0CAICCKGwAAAAAAAAAAICccWbcTwAAAAAAAAAAAOBEUdgAAAAAAAAAAAA5g8IGAAAAAAAAAADIGRQ2AAAAAAAAAABAzqCwAQAAAAAAAAAAcgaFDQAAAAAAAAAAkDMobAAAAAAAAAAAgJxBYQMAAAAAAAAAAOQMChsAAAAAAAAAACBnUNgAAAAAAAAAAAA5g8IGAAAAAAAAAACwXPEfFtpNwQC5vJMAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABjYAAAIDCAYAAACn2CepAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAq8dJREFUeJzs3Ql8VNX5//EnASEssomsUlkVUSAWhIIgKghSK6BgARcg2mhRWhAVRVlEUAQR44LQoqi4QV1KXcHKD6xWBAXRVkWBooDsVIiALML9v77n/7rTmWQCmZDMzE0+79frinPnzs2Zmztzn9znnOekeJ7nGQAAAAAAAAAAQACkJroBAAAAAAAAAAAA+UViAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgkNgAAAAAAAAAAACBQWIDAACgiN19992WkpISl591/vnnu8W3ePFi97NffvnluPz8QYMGWf369S3Inn76aXfMPvnkk5iPd9Dod/Wb3/ym0PYXy/kW7VzRa/V5yfm7+Pbbby1ZqW1qo9qKkicI5ygAAEBxRGIDAACgADex/CUtLc3q1Klj3bp1s0ceecR+/PHHQvk5mzZtcjd4V65cackmmdsW6+/utNNOsyFDhtjWrVsT3Tzk0+OPP04SIY7uu+8+mzdvXqKbUSy99dZbEYk8AAAA5B+JDQAAgAK455577Nlnn7Xp06fbH/7wB7du2LBh1rx5c/v8888jth01apT99NNPMScPxo0bF3Py4J133nFLUTpa22bOnGlff/21BeF399hjj1n79u3d77Bdu3a2b9++mPcVj+NdXOXnXLnmmmvcZ+fUU08NrSOxEV8kNizmczSWxIa+SwEAABC70gV4DQAAQInXvXt3a926dejxyJEj7f/+7/9cWZ8ePXrYV199ZeXKlXPPlS5d2i1FSTfly5cvb2XKlLFEOuGEEyxIv7vf/e53dtJJJ9nUqVPtb3/7m/Xv3z+mfSX6eOe0d+9eq1ChggVBfs6VUqVKuQWIhed5tn///tB3cFHiHAUAAEgMRmwAAAAUkgsvvNBGjx5t3333nT333HNHnWPj73//u3Xo0MGqVKliFStWtNNPP93uvPPO0DwF55xzjvv/jIyMUOkkv5e65nQ466yzbPny5Xbeeee5hIb/2rzmfDh8+LDbplatWu7Gt5IvGzZsiNhG8x1o3oOcwvd5rLZFmzdBN9tvueUWq1evnpUtW9a91ylTpribj+G0H5WFUu9wvT9te+aZZ9r8+fMjtlO5L42O0c/RNjVq1LCLLrrIVqxYYQX9vcm6desi1h84cMCGDx9uJ598sjtml112mW3fvj3PY3M0O3bssFWrVuVrVIh/HJ5//nl3rFQyq1WrVvaPf/wjYjv/vPryyy/tyiuvtKpVq7pzSn7++WcbP368NWrUyB0jHSv9/vWeotGok/T0dPezmjVrZq+++mrE8//973/t1ltvdSOSdL5WqlTJJYg+++yzqPvLz/mWn/lYcs5foO2/+OILe++990LnXvjx37Vrlzs3/HOtcePGNmnSJDty5EjEfufMmeOO6Yknnujei97Xww8/fNS2+PtXuytXruw+uwMHDnTrotHvu0+fPlatWjV3XJVMe+211yK2OXTokOux36RJE7eNkmz6Her7IT/H5YMPPrA//vGP7hxVe2644QY7ePCga9OAAQPcOaFlxIgRuT5v+flc6mdou2eeeSZ0vP3viIJ+Dv3zVsfnt7/9rTv+et9Dhw51yYhwTz31lPt8at/6GTo3NcIqr7liFixY4I6zEhp/+tOf8mzD6tWrrXfv3u781HE/5ZRTrF+/frZ79+5jzpuS33lg3n77bevYsaM7/3WeXXLJJe7c9ek4Tps2LbRPfwEAAED+MGIDAACgkMuS6IaubhRnZmZG3UY3t3QTrkWLFq4skm7YrVmzxv75z3+658844wy3fsyYMXb99de7m2Oiskm+nTt3uhvLuhl39dVXW82aNY/arnvvvdfdNLv99ttt27ZtlpWVZV26dHHlpGLp1ZyftoXTTVLd1F60aJFdd9117ua5bj7edttt9v3339tDDz0Usb1u1Oqm+o033uhuBmreEt2AXL9+vbv5Kb///e/d5NS6+a8bnToWep1Gyfzyl7+0WK1du9b96+/fpxJjuik8duxYd9NSx0w/c+7cuTH/DJW90g1sHYf8JEJ0414/RzetdX6o/NLFF19sy5Ytc0mfcFdccYW7Ma6SQf5NaY1E0c1o3VjXzeulS5faxIkT3TH661//musmb9++fd1x1Y163UzWPpVQ0o1q+c9//uMSTlrfoEEDNyeJbhx36tTJJVY0z0xRnG85aT/6vSi5ctddd7l1/rmvpJHao/NKN/h/8Ytf2IcffuhGU23evNm9VpQ00Miczp07u6SH6Ljo86eb63nRse3Zs6c713Ss9FnQsdQxi/YZP/fcc61u3bp2xx13uJvbf/nLX6xXr172yiuvuCSZ6Aa5fi/6fbVp08ays7PdpPVKDvjH/mh0LHRzXufWRx99ZH/+859dgkPvW+9f54TKHT3wwAPuvFGyI5bPpUq2+W3T512ULCuMz6GSGkpI6P2r7fqs//DDDzZ79uzQNkpiKLmptmrU2+uvv+6+G5SouummmyL2p7Jm+r3qd6/vXiVqolHiR3MiKcnnHz+95zfeeMMlhJS0Ol46bjov9HN0junc1HtR0urTTz9171vtVFk/nY/aHgAAADHyAAAAkG9PPfWU7hx7H3/8cZ7bVK5c2Tv77LNDj8eOHete43vooYfc4+3bt+e5D+1f2+jn5dSpUyf33IwZM6I+p8W3aNEit23dunW97Ozs0Pq//OUvbv3DDz8cWnfqqad6AwcOPOY+j9Y2vV778c2bN89tO2HChIjt+vTp46WkpHhr1qwJrdN2ZcqUiVj32WefufWPPvpoxPG96aabvIL+7t5991137Dds2ODNmTPHO+mkk7xy5cp5GzdujNiuS5cu3pEjR0Kvv/nmm71SpUp5u3btyvPY5MU/B/T7OBZtp+WTTz4Jrfvuu++8tLQ077LLLsu1z/79+0e8fuXKlW797373u4j1t956q1v/f//3f6F1+l1p3SuvvBJat3v3bq927doR5/D+/fu9w4cPR+xv3bp1XtmyZb177rmnQOdbznPFf+96Xz7/d6Gf5TvzzDOjHvPx48d7FSpU8L755puI9XfccYf7va1fv949Hjp0qFepUiXv559/9mLhn8uTJ08OrdM+OnbsmOvz0LlzZ6958+buuPl0LrVv395r0qRJaF3Lli29Sy65xIuVf1y6desWcY62a9fOfa5+//vfR7TxlFNOiThmsXwudUyjfS8U9HPon7c9evSIWH/jjTe69frM+/bt25fr9XrPDRs2jFjnn8fz588/5s//9NNP3bYvvfRSntvofMvrO+5Y5+iPP/7oValSxcvMzIx43ZYtW9wxC1+v48ef5AAAAAVDKSoAAIBCpt7kKtOSF/WoFs3pkLNETn6pF79KQeWXemprBIRPPflr167tenMXJe1f9ec18iCcRhHoHqHKtYRTr36/R7hoVItK1WjEQPjx0wgE9XYuCP0Mle5RCR6NeNHvSz3v1bs+nHqoh5eG0egUlVhSqbFYqWe+3m9+RmuIJjNXqSSfet9rtIB61asN4dRzPpz/O1UZrZzHXN58882I9Rpt4Y8gEB1vnS/qWb5ly5bQ+Zaa+v//dNDPV+98v4RatNJDiTjfXnrpJfc70igblf7yF/2+1Wa/lJfOH5VXOla5p5zUdo0aGDx4cGidzm31+s9Ztkvz7WhEgr4H/HbomKkHv0bIaISA3xaN7tC6gtBoi/BztG3btu480/rwNqo8U/hnKNbPZTTH+znMOeLCP47h50j46B6VidJx1KgcvRe/bJRPI4l0fI/FH5Ghz1J+SsPFSueVRn5o9Ej4eajjrd+PRskAAADg+JHYAAAAKGR79uyJuKmbk8r+qEyNSryojI5urqtMTSxJDt2Ej2XiapUqCqeboZp/IGdd+MKmJIBunOc8Hirj4z8fTjfwc9KNapWo8U2ePNn+/e9/u8SESuQoaRB+0/ZYVNdeNx91g1FllPTaaDdEc7ZF7ZDwthSVnL8vOe2009yN2JzzfOiGbjgdUyUh9PsNp5I7uhmd85hru5y1/fWzxD8/dG6qPJHapSRH9erVXXLo888/z3WDOVHnm5IDKp+ldoUvSmyISmKJShnp/amUm+ZWuPbaa3PN4xKNjpuSM0rohMtZ8khl5ZQc0Hw7OduismbhbVFZN90EV3s0z4dKQemY5lfOc9S/aa/PRs714edtrJ/LaI73c5jzHFFCU+dt+Dmi8mD6/amUl85dHUN/PqFoiY380HZK+j3xxBPuPNZnX98J0c7jgvCTVJobJOfvXyUK/d89AAAAjg9zbAAAABSijRs3uhtkOW8qh1MvZPUe14119Z7XTVXNp6AbYbrxpZ69x3I88xTkJa+Ja9XbPT9tKgx5/ZzwCY3VE1498zXKQsdL8weojr3m5tDN6mPRTVj1YC+MtiSDvM6FwpyIWHM16Ea9kgCalFwTYusmtCaPLuioo8KmdmheCk2UHY2frNFE1JrrQz32NTJBi+YV0SgTzUtSGO0QTbae1wgC//vhvPPOc3O8aPSWzmXdbFcCacaMGS7xWdBzNNr6wj5vj/dzeKzzVcdF86A0bdrUpk6d6hIoSuZqRIeOUc7zLpbvxAcffNBN3u0fd41c8ef6ULLraN+Fx+K3S/NmKJmYk0b9AAAA4PgRVQEAABQifxLYY5VE0U1h3bTTopt2unGsyZCV7FAP5cK8KS05S93oJqd6lqvUU/iIBPUez0m9txs2bBh6HEvbTj31VHv33XddSZ7w3uGrVq0KPV8Q6jmvnvda1ANakxVrwuqC3FBNRtFKE33zzTdWvnx51/P7aHRMdXNV+/B74Ism/NbvN+cx90cYhP9e9bNEkxyLJom+4IIL7Mknn4x4rfanXu8FOd8KKq/zTz3+NVrKH6FxNLpBfumll7pFx0rnkSZDV/Imr6SkjtvChQvdzwgftaFJq8P5n5UTTjghX21Rkkhl5bRo30p2aPRDfhIbBRXL5/Jon/fj+RzqHAkfZaHzQ78L/5zTROGa4Pu1116LGJlSWKWcNEJGy6hRo9xk6xpFp4TShAkTQqOzcn4f5mcki19KTwm0Y/3+C/t7HgAAoCShFBUAAEAhUV199WbXzbqrrroqz+1Ugz+n9PR0969u5IlKr0i0RENBzJ49O2LeD92o3rx5c8QNSN2QU4/lgwcPhta98cYbtmHDhoh9xdK2X//6166X82OPPRaxXj2udVMv1kSE9pWzZIxuIKqsjn/skpFq7OumcX5r+i9ZsiRi7gr9DtS7vGvXrsccPaNjLllZWRHrlUCTSy65JGK95khQr3tfdna2O190Tvo9zvUzc/b415wW/lwRBTnfCkrnX7RzTyMIdNw0EiMnbf/zzz+7/9dcFzmTjH7C5WjnkI6r9jF9+vSI8/HRRx/NdT5qLhUlSvSecwovJZazLUqYKLFS1OdyLJ/LaMe7MD6HKv8Uzj+O/s/2z/Pw804/U6NrjofOb/9c8CnBofPAb7vmmVHCzp+Xxff4448fc/9Kauv1SlYfOnToqL//wv6eBwAAKEkYsQEAAFAAKl+jG9W6Qaae8EpqaN4G9XRWD+O0tLQ8X6u6+rphphvM2l49nXXDTCVQOnToEEoyqKa8ehCrR7VugGni2fzWkY/WK1z7Vq9wtVc3vXUDNTMzM7SNeojrBvTFF1/sbhKrFMxzzz0XMZl3rG1Tj3j19NdoFNXOb9mypSv9opv0KmOUc9/HopvlOk6ajFr70o1g9Tz/+OOPXXmZZKUbyOPGjXO9zfMzgfhZZ53lbpCqRI7mtPBvqGofx6LjMnDgQPvzn//sbphqsuVly5a5Mku9evVyv4+cJZo02bSOoeZ8mTVrljtHwm8g/+Y3v3Hnrc6f9u3b27/+9S97/vnnI0byxHq+FZQmVVdyQT3rtU/dUFcZN81Poc+e2qoyQ9pOk4SrrTqvdf7pZrXOcyUX9RqdS+qFr5vqSuSEj3CJdi6rV/8dd9zh9tWsWTNXdina3Ay6aa/3rxvmes86TjoOSryoXN1nn33mttM+dD6orTpmn3zyiWvrkCFDrCjF8rlU2/QZU2JMiQt9zjWvyPF+DtetW2c9evRw3zc6LvquufLKK93+REk8f2TNDTfc4EazzJw50/2+oyWM8kvf1Tq+V1xxhTv39R2ukXZKpPTu3Tu0nc6T+++/3/2r0nX6zvZHMh2Nkho6P6+55ho3gkVzKGmU1fr1613pQZ1DfkJJx1b0OdfnXW3Q9gAAAMgHDwAAAPn21FNPqftwaClTpoxXq1Yt76KLLvIefvhhLzs7O9drxo4d67b1LVy40OvZs6dXp04d93r9279/f++bb76JeN3f/vY3r1mzZl7p0qXd6/WzpVOnTt6ZZ54ZtX16Totv0aJF7rUvvviiN3LkSK9GjRpeuXLlvEsuucT77rvvcr3+wQcf9OrWreuVLVvWO/fcc71PPvkk1z6P1raBAwd6p556asS2P/74o3fzzTe793nCCSd4TZo08R544AHvyJEjEdtpPzfddFOuNml/2q8cOHDAu+2227yWLVt6J554olehQgX3/48//riX39/dxx9/XKDt/GOpf33Rjk00/jkQ/tq8+Mfhueeec8dKv4uzzz4712v9fW7fvj3XPg4dOuSNGzfOa9CggTvm9erVc7///fv35zq2OhcWLFjgtWjRwv2spk2bei+99FLEdnrdLbfc4tWuXdudPzo3lixZclznW7RzRa/V+8r5u1i3bl1o3ZYtW9z+9PvXc+E/X+eafm7jxo3dZ6t69epe+/btvSlTpngHDx5027z88ste165dXdu0zS9+8Qvvhhtu8DZv3nzM383OnTu9a665xqtUqZJXuXJl9/+ffvppxGfAt3btWm/AgAHu+0G/A32ufvOb37if75swYYLXpk0br0qVKu446djfe++9obbGeo7mdU7oWOuzUpDP5apVq7zzzjvPtU/71r6O53Pot/HLL7/0+vTp415ftWpVb8iQId5PP/0Use1rr73mzsu0tDSvfv363qRJk7xZs2blOif88zg//vOf/3jXXnut16hRI7ffatWqeRdccIH37rvvRmy3b98+77rrrnO/Z7Xxt7/9rbdt27Z8naP+Z6Fbt27u9fo5+nmDBg1y36m+n3/+2fvDH/7gnXzyyV5KSkrEdQIAAABHl6L/5CcBAgAAAKDoqRTQTTfdlKtMEFAcaP4QjTxSSaZo87MEjead0agOlYvTKBYAAADEB3NsAAAAAABQACqLpWSkSokBAAAgfphjAwAAAACAGGjOFM2HormG2rVrZ+XLl090kwAAAEoURmwAAAAAABCDr776yk1Yrwnsn3766UQ3BwAAoMRhjg0AAAAAAAAAABAYjNgAAAAAAAAAAACBQWIDAAAAAAAAAAAEBokNAAAAAAAAAAAQGCQ2AAAAAAAAAABAYJDYAAAAAAAAAAAAgUFiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgkNgAAAAAAAAAAACBQWIDAAAAAAAAAAAEBokNAAAAAAAAAAAQGCQ2AAAAAAAAAABAYJDYAAAAAAAAAAAAgUFiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgkNgAAAAAAAAAAACBQWIDAAAAAAAAAAAEBokNAAAAAAAAAAAQGCQ2AAAAAAAAAABAYJDYAAAAAAAAAAAAgUFiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgkNgAAAAAAAAAAACBQWIDAAAAAAAAAAAEBokNAAAAAAAAAAAQGCQ2gGLu6aeftpSUFPv2228tCDZs2GBpaWn2z3/+s8h+ho7H3XffbUExf/58q1ixom3fvj3RTQEAINBxxp49e6xGjRr2/PPPW1Dt3LnTKlSoYG+99VaimwIAQFTEB3nTvQgdm1joOOo1Oq5F6Ve/+pWNGDGiSH8GUJhIbABJ5l//+pf16dPHTj31VHeDv27dunbRRRfZo48+Gve26A/mWBMAX331lV188cXuRny1atXsmmuuiemG/D333GNt27a1c889N2L966+/bp06dXLBRvny5a1hw4b229/+1t30L+50PBs3bmwTJ05MdFMAAAEX5Dhj2bJlduONN1qrVq3shBNOiPmmgDz88MN24oknWr9+/SLWf/DBB9a9e3d3PHRcfvGLX9ill15qL7zwgiVKXsfnpJNOst/97nc2evTohLQLAFD8BDU+OHLkiLvZ36NHD6tXr55L/J911lk2YcIE279//3HHB7Jy5Uq7+uqr3f7Lli3r7nN06dLFnnrqKTt8+LAVJ7fffrtNmzbNtmzZkuimAPmS4nmel79NARS1Dz/80C644AL3x/TAgQOtVq1abgTDRx99ZGvXrrU1a9bEvE9daA8dOuQuwLHeABgyZIi7qOX3a2Ljxo129tlnW+XKle2Pf/yj6/UwZcoU9350M6JMmTJHfb0SIAqgnnnmGevfv39ovfZx2223ucRGz549XWJDx+Ldd9+1li1bxtxrQQFO6dKl3RIU06dPt1tvvdUFGAq4AAAoaXGGbnLcd9991qJFC/vxxx/tm2++yfdrRe1UnHHzzTfbyJEjQ+tfeukl69u3r6Wnp7sbGlWrVrV169bZP/7xD5dAWbRokSXC0Y6POpI0a9bMFi5caBdeeGFC2gcAKB6CHB/onoP+PtZIg9/85jeuI+SSJUvcPYXzzjvP/u///u+YPz+v+ECeeOIJ+/3vf281a9Z0nTabNGniYhBdf998802XQLnzzjtjen8///yzW5RAyi8diwMHDri4pFSpUlZUlCjSscjMzHSdToFkF5y7ekAJcO+997qkwMcff2xVqlSJeG7btm0F2qcuekV54Qunmw179+615cuXu6BI2rRp43p6KPlw/fXXH/X1zz33nEs2qIekTxf88ePHu3288847uV5TkOMSSwCRLHr37m1/+MMf3M2Xa6+9NtHNAQAEUNDjjMGDB7uehOXKlXM3PZTYiMUbb7zhOlFoxGfOhImSBLqBk7MTRkGPy/FQLKUep0dzxhlnuB6piq9IbAAASmp8oOu2yli3b98+tE435evXr29jx451CQiNrihIfKC4QEmNdu3auVEk4R0Mhw0bZp988on9+9//jrnNBelkqeRMPO5jpKamupE7s2fPtnHjxhVodCwQT5SiApKIekOceeaZuYIJUc+D/NRXzDl/RF61Ld9++23r2LGj+8NZF+hLLrnEvvjii9DzgwYNcr0k/H36y9G88sorrpeEn9QQBRGnnXaa/eUvfznm+583b54rQ6UyVr4dO3ZYdnZ2rtJU0Y6LPxpD718/Uxf+2rVr2+WXX+6ObV7HSL7//nuXMFBPDPUq0e9h1qxZEdssXrzYvVbvRcHfKaec4n5G586do/ZiWbp0qf361792PT91nNXDVENcw61atcoFDhrOqn21bt3aXnvttajvU6//29/+dszjCABAcYwzdI1WUqOgFGfoRkejRo1yHZdzzjkn6sjSaMdFI0kfeughV65D7dGI0mg3NtRL1D8GOuYadaqRFtHqbH/55Zd25ZVXupihQ4cO+To+6vShUp0MwAcAlNT4QNfu8KSG77LLLnP/5rzuxhIf+Df2Ne9GtKoJ+ttd7Q2/V6B/w0U7ZtHm2Pj73//urv/6Heh+yOmnnx4xEiTafvSzta3uZfTq1cv9/8knn+wqPeQskaWRGFlZWe73rPsOiqluuOEG++GHH3K9L8UX3333nSvBBSQ7RmwASUR/IGvYpP44Vi+8ovLss8+6IabdunWzSZMm2b59+1ypI11IP/30U3dR10Vu06ZN7gKr7Y9FF1P15tDFPSeN2jjWBJca/qkeIuqNmTOQ0k0D/eGuEQtKAORFF28lVtQrQ6Ukhg4d6oaJ6j3omOYMVHxbt251Q1cVKKgHqIIBBVzXXXedS6qoN0a4+++/3/VkUMCwe/dumzx5sl111VUukeHTz1RblFhROzScV0GVeoPosSiAU8JGQz3vuOMOF9wpaaKgREkiPxjzqaa4gi4AAEpanFFYpTZ++ctfRj0uih1UUlOdFo5FvRgVX9x0002uQ4U6LWjUhOqT60aBqFym5uzQnGC6gfHTTz+5OuW67q9YscIdg3BXXHGFK2+h0a9KVKi057GOj+ICJVgUTxTl7xMAULwVx/jAnyOievXqBYoP1DbFBipnFd5xsyjoOq57B+rIqPJP6mipjpMaiXIsugei46kOoup4ofjjwQcfdPc+wu+t6LgqKZKRkeHKhqvk5mOPPeaOu36OSlyFxxei9YpHgKSmOTYAJId33nnHK1WqlFvatWvnjRgxwluwYIF38ODBiO3WrVunrnneU089lWsfWj927NjQY22jdXqN/Pjjj16VKlW8zMzMiNdt2bLFq1y5csT6m266yb02Pz7++GO37ezZs3M9d9ttt7nn9u/fn+fr16xZ47Z59NFHcz03ZswY91yFChW87t27e/fee6+3fPnyXNvNmjXLbTd16tRczx05ciTPY3Tdddd5tWvX9nbs2BHxmn79+rljsm/fPvd40aJF7rVnnHGGd+DAgdB2Dz/8sFv/r3/9yz3++eefvQYNGninnnqq98MPP+TZjs6dO3vNmzePOC56vn379l6TJk1yvYf77rvP/ZytW7dGPYYAABTXOCOnWF976NAhLyUlxbvllltyPffkk0+6fZUpU8a74IILvNGjR3vvv/++d/jw4ajHpVy5ct7GjRtD65cuXerW33zzzaF16enpXo0aNbydO3eG1n322WdeamqqN2DAgNA6HUu9tn///jG/xw8//NA9P3fu3HwfBwAAinN84OvSpYtXqVKlXH+P5zc+0DVbbRg6dGi+fp5/r0D/HuuY+dd+30MPPeQeb9++Pc/9R9vPwIED3bp77rknYtuzzz7ba9WqVeixYhpt9/zzz0dsN3/+/KjrRTHR4MGD8/XegUSiFBWQRDTkTz0levToYZ999pkbCaDsu3r0RytPVBDq+bBr1y43ObfKPPmL6l8qy1/QCTLVE1HUuyAnvxakv000O3fudP+qBENOGgL6wgsvuN4CCxYssLvuusv1IlCvivChpRrloB4ZGtmRU17DVxWD6XWa10P/H35MdOw1IkM9K8Opl0N4uQoNpZX//Oc/7l/1elAPCI30yDmc12/Hf//7X1eiQnU81evT/5k6Dvq5q1evdqNgwvnHRtsBAFCS4ozjpeuurvPR4gyVopw/f76df/759sEHH7i5vXRt1wgK9eLMSSMrdczCR6bqvfmjUzdv3uzKN6hERPhIU/XE1O8g2ihW1fCOFXEBAKAwFLf4QKMfNXJBlRaildfKT3ygyg0SrQRVYfPbqLLTKhkVq5wxhGIY/96EaJ5OzaGi33P4sdc9FZWvinbsdTyILxAEJDaAJKMaz6+++qqrdbhs2TIbOXKku/GteRhUf/l46Ya5qGSCSi6FL5qcu6CTg/k1rw8cOJDrOZVpCN/maPKqE60A6P3333fHRe1UHWolEJSQ8Pev2qCqRRnLRFyaJEwB1p///Odcx0MJDMl5THIORfWDIL8+pT+fx9GG8Wpoqd7r6NGjc/1cTXIW7ef6x4YJvAAAJS3OKCx5xRm6gaPOE4oJ/vGPf7gyU6ovrdIQOdushEdOmtvLryOu14likmiTfutGgSYID9egQYMCvxfiAgDA8Sou8cHcuXNt1KhRrqx0zjLXscQHlSpVcv/qGBS1vn37ulKVv/vd71xJS5XVVonq/CQ51IlUxzDn/YnwuTN07NVhU2W+cx77PXv2RD32Oh7EFwgC5tgAkpRGBCi40KI/lnWTXZl23fTO6wKTc4KoaPyLo+pVat6HnGJJCoTTXBJ+L8WctE49FqON5vCddNJJ7t9ok1flDDDU00CL6kA+88wzbm4LTdxZEP7xuPrqq129z2jUwzKcepVEE8vknf7P1TwdupkSTePGjSMe+8cmP3VCAQAoTnHG8VIcovd1rDijfPnyrqejFl1vNWpU827lFSMUloJMik5cAAAobEGODzQqZMCAAW5C8hkzZhxXfKC/xdUmzZ+VH8dzbBQDqFOFRk68+eabbhSpEjRKAinpk9f9Bznac+HHXkkNTYIeTc7EiKijB/EFgoDEBhAA/oTcftLAHyGgi004v4fg0fgTaOvC1qVLl6NuG0uGXsNUdUH85JNPcj2nHh/p6elHfb1GQeiCrhJOsRwXJTb846L3piSHJiIPn/zqaNRmDS9VwHGs45Ff/jHW5Gt57VOTiYramd+fq2Oj4CJa4AEAQHGOM46Xbk6obbHGGdE6bfi9TsN98803oQnBNQmrfP3117m2W7VqlbuWV6hQ4Zg//1jHx38vGgUCAEBJjg90H+Cyyy5zbdZoh/wmSvKKD9TRQYkFlY/esGGD1atX76j7OZ5jI6mpqda5c2e3TJ061ZXTUgluJTuO9z6F3p9Kc2lUSH46Uqgk9sGDB4kvEAiUogKSiC5a0Xr9+7WY/ZIGGrWgP4qV1Q/3+OOPH/NnaHSAXq8LpRIA0Uoz+fw/unNenPPSu3dve+ONN9yF37dw4UL3x/4VV1xx1NfqBr+CkJyJkX379rl6n9GoB2X4cdHPV3mHxx57LN+jKdTDQa/TPBtKRBzteOSX5v5QSYmsrKxcx85vhwI61fL+05/+FHWUS7Sfu3z5cmvXrl3M7QEAoDjEGcdL19BoHTAUq0ST87j45s2bFzEPljpw6IZK9+7dQ6NY1aFDnS/C35viDPW8/PWvf52v9h7r+CguUM3sM888M1/7AwCgOMYHmndTozTUwUD3I2IdBZlXfKBRKjou11xzjSvZFO06rGu936lB9xYKcmw0z0dOfsfQaKW+Y6V5PdWRU3OI5fTzzz/nOs56X9K+ffvj/tlAUWPEBpBENOm1buSrp0HTpk1dllyTVmoYoi7S/pwPovqLmgxL/yohoAuoEgjHomBi+vTp7uKsG/Cq36gRAOvXr3fDHpXF9xMDmkxK/vjHP7pARBdqbZ+XO++80w1TveCCC2zo0KHu4v/AAw9Y8+bNI9qel549e7peCZqoy69pqeOhC+qvfvUru/jii11PCV14dVNBc25oAk9NKi4adjp79mwbPny4u8mgMhKqYa3eCTfeeKPbfzQ6jgrmNGlZZmamNWvWzAUXmjRcr40WaByrt4WOseb/UECi966bHOql+cUXX7ga3jJt2jTr0KGDOz76uRrFsXXrVpfI2bhxo5u4zae6l59//rmr+Q0AQEmMM9TrUSUsxL8BMWHChNANBf3Mo1EcoNfrfai8Rvh6dUjQdVu9Gv3Y4fXXX3elOLQ+Z3kKXb9Vu1s3HNSRQSU1R4wYEdpG8Y8SHbpZojrfP/30kz366KMuEXH33Xcf8zjm5/io5IbaRg1sAEBJjQ80B4a2USmp2267ze0rnK7rx+ocmFd8oPsQ+ptd9xJ0XNR2zbOln7l48WI3sbofh+j6rs6cutbruqyfqyRLfuYOueeee9xxVHJG8Yxeo4TIKaec4uKN46Wy3TfccINNnDjRVq5caV27dnUdSzUCVfdvHn74YTeXSnh8oYoa/n0WIKl5AJLG22+/7V177bVe06ZNvYoVK3plypTxGjdu7P3hD3/wtm7dGrHtvn37vOuuu86rXLmyd+KJJ3q//e1vvW3btqmbhTd27NjQdk899ZRbt27duojXL1q0yOvWrZt7fVpamteoUSNv0KBB3ieffBLa5ueff3Y/++STT/ZSUlLcfo7l3//+t9e1a1evfPnyXpUqVbyrrrrK27JlS77ev95j6dKlvWeffTa07tChQ97MmTO9Xr16eaeeeqpXtmxZt++zzz7be+CBB7wDBw7kOi533XWX16BBA++EE07watWq5fXp08dbu3ZtaJucx8j/2TfddJNXr1690Os6d+7s/fnPf444ZnrtSy+9FPFaHVut17EO98EHH3gXXXSR+/1UqFDBa9Gihffoo49GbKN2DRgwwP08/dy6det6v/nNb7yXX345Yrvp06e7952dnZ2vYwkAQHGLM/zrcLSlU6dOx3z/ihmqV6/ujR8/PmL9iy++6PXr18+1sVy5cq69zZo1c/FE+HXXv94r/njwwQddzKC4pGPHjt5nn32W6+e9++673rnnnuv2WalSJe/SSy/1vvzyy4htdCy1z+3bt+d6/dGOz1dffeUe62cAAFBS4wP/2pzXMnDgwALHB77ly5d7V155pVenTh33N3vVqlXdvYJnnnnGO3z4cGg7Xct79+7t/m7XNjfccIO7P5LzXoF/7fctXLjQ69mzp9u/jr3+7d+/v/fNN9/kep/h+9F7032GnHLu36d7G61atXJxiX53zZs390aMGOFt2rQptI3eT+3atb1Ro0Yd87gBySBF/0l0cgVA0XnyySddbwqVh1LGP9mpV6N6Smg0Bv5HvSVUuuqhhx5KdFMAAAhsnKEyDE899ZTrpZifCTfDffvtt25kh0Zj3HrrrZZIw4YNc707VS6CERsAgGRTkuKD4kSVMa688kpbu3atqzoBJDvm2ACKOc3foD94q1WrZkGgOpYff/yx/fOf/0x0U5LG/PnzXYA1cuTIRDcFAIBAxxk333yzK5U5Z84cC6qdO3faE0884cpfkNQAACQj4oNgmjRpkg0ZMoSkBgKDOTaAYkpzNbz88ss2Y8YMV1OyfPnyFgSq5bh///5ENyOpaG6RaJOVAQCQKEGNMypWrJivetfJTPN5EBcAAJIR8UGwab5PIEgYsQEUU1999ZWbPEsTXD799NOJbg4AAChGiDMAAEBOxAcA4ok5NgAAAAAAAAAAQGAwYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYTB6ehyNHjtimTZvsxBNPtJSUlEQ3BwCAhFDFyh9//NHq1Kljqan0hzgW4gcAAP4/Yoj8I34AACD2+IHERh4UVNSrVy/RzQAAICls2LDBTjnllEQ3I+kRPwAAEIkY4tiIHwAAiD1+ILGRB/WU8A9ipUqVEt0cAAASIjs72/2h7V8XcXTEDwAA/H/EEPlH/AAAQOzxA4mNPPjDPxVUEFgAAEo6yiLkD/EDAACRiCGOjfgBAIDY4wcKXQIAAAAAAAAAgMAgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAACg8QGAAAAAAAAAAAIDBIbAAAAAAAAAAAgMEhsAAAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwSGwAAAAAAAAAAIDBIbAAAAAAAAAAAgMAgsQEAAAAAAAAAAAKjdKIbUJJsubSjJaNar7+f6CYAAACgGMecxJsAAADFRzLGm0LMWbIwYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAECJMW3aNKtfv76lpaVZ27ZtbdmyZXlu++qrr1rr1q2tSpUqVqFCBUtPT7dnn302YptBgwZZSkpKxHLxxRfH4Z0AAFByMccGAAAAAAAoEebOnWvDhw+3GTNmuKRGVlaWdevWzb7++murUaNGru2rVatmd911lzVt2tTKlCljb7zxhmVkZLht9TqfEhlPPfVU6HHZsmXj9p4AACiJUoPWWyLcnDlzXE+IXr16Raz3PM/GjBljtWvXtnLlylmXLl1s9erVRdR6AAAAAAAQBFOnTrXMzEyXnGjWrJlLcJQvX95mzZoVdfvzzz/fLrvsMjvjjDOsUaNGNnToUGvRooV98MEHEdspkVGrVq3QUrVq1Ti9IwAASqbUZOktMXbsWFuxYoW1bNnS9XrYtm3bUV/37bff2q233modO3bM9dzkyZPtkUcecQHK0qVL3XBR7XP//v1F+E4AAAAAAECyOnjwoC1fvtx1fvSlpqa6x0uWLDnm69WJcuHChW50x3nnnRfx3OLFi90ojtNPP90GDx5sO3fuLJL3AAAAkiSxEWtvCTl8+LBdddVVNm7cOGvYsGGuQENDSUeNGmU9e/Z0PSlmz55tmzZtsnnz5sXhHQEAAAAAgGSzY8cOdz+hZs2aEev1eMuWLXm+bvfu3VaxYkVXiuqSSy6xRx991C666KKIMlS676Ckx6RJk+y9996z7t27u58VzYEDByw7OztiAQAAAUpsFLS3xD333ON6Qlx33XW5nlu3bp0LSML3WblyZVfi6mj7JLAAAAAAAAA5nXjiibZy5Ur7+OOP7d5773VVJzRCw9evXz/r0aOHNW/e3JXK1jwc2jZ8m3ATJ0509yn8pV69enF8NwAAFA+pQestoTqWTz75pM2cOTPq8/7rYu2BQWABAAAAAEDxVb16dStVqpRt3bo1Yr0ea16MvKgDZuPGjS09Pd1uueUW69Onj7uHkBdVltDPWrNmTdTnR44c6UaB+MuGDRuO410BAFAyJbwUVSx+/PFHu+aaa1xSQ0FCYSKwAAAAAACg+FIpqVatWrmSUb4jR464x+3atcv3fvQaVX3Iy8aNG90cG7Vr1476vCYar1SpUsQCAABiU9oC1Fti7dq1btLwSy+9NCKgkNKlS7sJvPzXaR/hQYQeq3dFXhRYaAEAAAAAAMWTykgNHDjQWrdubW3atHFzdO7du9fN+ykDBgywunXrhkZk6F9t26hRI5fMeOutt+zZZ5+16dOnu+f37Nnj5v/s3bu3ux+h+xYjRoxwIzy6deuW0PcKAEBxVjpZekuoDmV4b4khQ4bk2r5p06b2r3/9K2KdJgnXSI6HH37YlY864YQTXDChffiJDM2XsXTpUhs8eHCc3hkAAAAAAEg2ffv2te3bt9uYMWNcuWrdN5g/f36onPX69etd6Smfkh433nijG4VRrlw5d1/iueeec/sRddb8/PPP7ZlnnrFdu3ZZnTp1rGvXrjZ+/Hg6TwIAUFwTG7H2lkhLS7Ozzjor4vVVqlRx/4avHzZsmE2YMMGaNGliDRo0sNGjR7vgwk+eAAAAAACAkkkdKaN1ppScE37r3oKWvCjZsWDBgkJvIwAASPLERqy9JfJDwz6VHLn++utdj4kOHTq4fSoxAgAAAAAAAAAAgivhiY1Ye0vk9PTTT+dal5KSYvfcc49bAAAAAAAAAABA8RHbUAgAAAAAAAAAAIAEIrEBAAAAAAAAAAACg8QGAAAAAAAAAAAIDBIbAAAAAAAAAAAgMEhsAAAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAACKRp06ZZ/fr1LS0tzdq2bWvLli3Lc9tXX33VWrdubVWqVLEKFSpYenq6PfvssxHbeJ5nY8aMsdq1a1u5cuWsS5cutnr16ji8EwAAAAAAEAsSGwAAIHDmzp1rw4cPt7Fjx9qKFSusZcuW1q1bN9u2bVvU7atVq2Z33XWXLVmyxD7//HPLyMhwy4IFC0LbTJ482R555BGbMWOGLV261CVAtM/9+/fH8Z0BAAAAAIBjIbEBAAACZ+rUqZaZmemSE82aNXPJiPLly9usWbOibn/++efbZZddZmeccYY1atTIhg4dai1atLAPPvggNFojKyvLRo0aZT179nTPzZ492zZt2mTz5s2L87sDAAAAAABHQ2IDAAAEysGDB2358uWuVJQvNTXVPdaIjGNREmPhwoX29ddf23nnnefWrVu3zrZs2RKxz8qVK7sSV/nZJwAAAAAAiJ/ScfxZAAAAx23Hjh12+PBhq1mzZsR6PV61alWer9u9e7fVrVvXDhw4YKVKlbLHH3/cLrroIveckhr+PnLu038uGu1Liy87O7vA7wsAAAAAAOQPiQ0AAFAinHjiibZy5Urbs2ePG7GhOToaNmzoylQV1MSJE23cuHGF2k4AAAAAAHB0lKICAACBUr16dTfiYuvWrRHr9bhWrVp5vk7lqho3bmzp6el2yy23WJ8+fVxiQvzXxbrPkSNHupEg/rJhw4bjfHcAAAAAAOBYSGwAAIBAKVOmjLVq1cqNuvAdOXLEPW7Xrl2+96PX+GWkGjRo4BIY4ftUWamlS5cedZ9ly5a1SpUqRSwAAAAAAKBoUYoKAAAEjspIDRw40Fq3bm1t2rSxrKws27t3r2VkZLjnBwwY4ObT8Edk6F9t26hRI5fMeOutt+zZZ5+16dOnu+dTUlJs2LBhNmHCBGvSpIlLdIwePdrq1KljvXr1Suh7BQAAAAAAkUhsAACAwOnbt69t377dxowZ4yb3Vnmp+fPnhyb/Xr9+vSs95VPS48Ybb7SNGzdauXLlrGnTpvbcc8+5/fhGjBjhtrv++utt165d1qFDB7fPtLS0hLxHAAAAAAAQXYrneV4ez5VoKj9RuXJlVy+7sMpKbLm0oyWjWq+/n+gmAABK0PWwOON4IRkkY8xJvAmUPFwT849jBSBokjHeFGLOknVNZI4NAAAAAAAAAAAQGCQ2AAAAAAAAAABAYJDYAAAAAAAAAAAAgUFiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgkNgAAAAAAAAAAACBkRSJjWnTpln9+vUtLS3N2rZta8uWLctz21dffdVat25tVapUsQoVKlh6ero9++yzEdsMGjTIUlJSIpaLL744Du8EAAAAAAAAAAAUpdKWYHPnzrXhw4fbjBkzXFIjKyvLunXrZl9//bXVqFEj1/bVqlWzu+66y5o2bWplypSxN954wzIyMty2ep1PiYynnnoq9Lhs2bJxe08AAAAAAAAAAKCYjtiYOnWqZWZmuuREs2bNXIKjfPnyNmvWrKjbn3/++XbZZZfZGWecYY0aNbKhQ4daixYt7IMPPojYTomMWrVqhZaqVavG6R0BAAAAAAAAAIBimdg4ePCgLV++3Lp06fK/BqWmusdLliw55us9z7OFCxe60R3nnXdexHOLFy92ozhOP/10Gzx4sO3cufOo+zpw4IBlZ2dHLAAAAAAAAAAAILkkNLGxY8cOO3z4sNWsWTNivR5v2bIlz9ft3r3bKlas6EpRXXLJJfboo4/aRRddFFGGavbs2S7pMWnSJHvvvfese/fu7mflZeLEiVa5cuXQUq9evUJ6lwAAAAAAIFkU9jyf6nQ5ZswYq127tpUrV8511ly9enUc3gkAACVXwktRFcSJJ55oK1eutI8//tjuvfdeN0eHRmj4+vXrZz169LDmzZtbr1693Dwc2jZ8m5xGjhzpEib+smHDhji9GwAAAAAAEM95PseOHWsrVqywli1buvk6t23bFnV7f55PVZX4/PPPXRltLQsWLAhtM3nyZHvkkUdcae2lS5e6BIj2uX///ji+MwAASpaEJjaqV69upUqVsq1bt0as12PNi5EXlatq3Lix6ylxyy23WJ8+fdyIi7w0bNjQ/aw1a9bkuY3m5KhUqVLEAgAAAAAAio/CnudTozWysrJs1KhR1rNnT/ecKkhs2rTJ5s2bF+d3BwBAyZHQxIZKSbVq1cqVjPIdOXLEPW7Xrl2+96PXaI6MvGzcuNHNsaFhoQAAAAAAoOQpink+161b50pph+9T5a1V4io/+wQAAAVT2hJMQ0AHDhzoala2adPG9XTYu3ev6z0hAwYMsLp164ZGZOhfbaueEkpmvPXWW66+5fTp093ze/bssXHjxlnv3r3dqI+1a9faiBEj3AgPDQUFAAAAAAAlz9Hm+Vy1alWer1O5at2X0D0IVZ14/PHHQ/N8+vODxjJ3qPYT3jkzOzv7uN4XAAAlUcITG3379rXt27e7ibZ00Vd5qfnz54eCgvXr17seFD4lPW688UY3CkOTcjVt2tSee+45tx9RkKG6l88884zt2rXL6tSpY127drXx48e7clMAAAAAAACxzvOpjpQasaEOmip5rTJVBaEOm+qQCQAAApzYkCFDhrglmpwTfk+YMMEteVGyI3wSLwAAAAAAgOOd51PUGfOrr75yyQklNvzXaR/h5a/1WNtGM3LkSJccCR+xUa9eveN+fwAAlCQJnWMDAAAAAAAgqPN8NmjQwCU3wvepRMXSpUvz3KeqSVSqVCliAQAAARyxAQAAAAAAELR5PlNSUmzYsGGuskSTJk1comP06NGuLHavXr0S+l4BACjOSGwAAAAAAIASobDn+ZQRI0a47a6//no312eHDh3cPtPS0hLyHgEAKAlSPM/zEt2IZKSho5UrV7bdu3cX2rDQLZd2tGRU6/X3E90EAEAJuh4WZxwvJINkjDmJN4GSh2ti/nGsAARNMsabQsxZsq6JzLEBAAAAAAAAAAACg8QGAAAAAAAAAAAIDBIbAAAAAAAAAAAgMEhsAAAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwSGwAAAAAAAAAAIDBIbAAAAAAAAAAAgMAgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAACg8QGAAAIpGnTpln9+vUtLS3N2rZta8uWLctz25kzZ1rHjh2tatWqbunSpUuu7QcNGmQpKSkRy8UXXxyHdwIAAAAAAGJBYgMAAATO3Llzbfjw4TZ27FhbsWKFtWzZ0rp162bbtm2Luv3ixYutf//+tmjRIluyZInVq1fPunbtat9//33EdkpkbN68ObS8+OKLcXpHAAAAAAAgv0hsAACAwJk6daplZmZaRkaGNWvWzGbMmGHly5e3WbNmRd3++eeftxtvvNHS09OtadOm9sQTT9iRI0ds4cKFEduVLVvWatWqFVo0ugMAAAAAACQXEhsAACBQDh48aMuXL3flpHypqanusUZj5Me+ffvs0KFDVq1atVwjO2rUqGGnn366DR482Hbu3HnU/Rw4cMCys7MjFgAAAAAAULRIbAAAgEDZsWOHHT582GrWrBmxXo+3bNmSr33cfvvtVqdOnYjkiMpQzZ49243imDRpkr333nvWvXt397PyMnHiRKtcuXJoUYkrAAAAAABQtEoX8f4BAACSyv33329z5sxxozM08bivX79+of9v3ry5tWjRwho1auS269y5c9R9jRw50s314dOIDZIbQMFtubSjJZtar7+f6CYAAAAAyIERGwAAIFCqV69upUqVsq1bt0as12PNi3E0U6ZMcYmNd955xyUujqZhw4buZ61ZsybPbTQnR6VKlSIWAAAAAABQtEhsAACAQClTpoy1atUqYuJvfyLwdu3a5fm6yZMn2/jx423+/PnWunXrY/6cjRs3ujk2ateuXWhtBwAAAAAAx4/EBgAACByVf5o5c6Y988wz9tVXX7mJvvfu3WsZGRnu+QEDBrgyUT7NmTF69GibNWuW1a9f383FoWXPnj3uef1722232UcffWTffvutS5L07NnTGjdubN26dUvY+wQAAAAAALkxxwYAAAicvn372vbt223MmDEuQZGenu5GYvgTiq9fv95SU//Xf2P69Ol28OBB69OnT8R+xo4da3fffbcrbfX555+7RMmuXbvcxOJdu3Z1IzxUbgoAAAAAACQPEhsAACCQhgwZ4pZoNOF3OI3COJpy5crZggULCrV9AAAAAACgGJeimjZtmisLkZaWZm3btrVly5blue2rr77q6mJXqVLFKlSo4HpoPvvssxHbeJ7nenCqJrZuVHTp0sVWr14dh3cCAAAAAAAAAACKdWJj7ty5rk62SkGsWLHCWrZs6WpZb9u2Ler21apVs7vuusuWLFniSkaolraW8F6Wmhz0kUcesRkzZtjSpUtdAkT73L9/fxzfGQAAAAAAAAAAKHaJjalTp1pmZqZLTjRr1swlI8qXL+8m94zm/PPPt8suu8zOOOMMa9SokQ0dOtRatGhhH3zwQWi0RlZWlo0aNcpN+qnnZs+ebZs2bbJ58+bF+d0BAAAAAAAAAIBik9jQJJ7Lly93paJCDUpNdY81IuNYlMRYuHChff3113beeee5devWrXOTiIbvs3Llyq7EVX72CQAAAAAAAAAAkldCJw/fsWOHHT582GrWrBmxXo9XrVqV5+t2795tdevWtQMHDlipUqXs8ccft4suusg9p6SGv4+c+/Sfi0b70uLLzs4u8PsCAAAAAAAAAADFMLFRUCeeeKKtXLnS9uzZ40ZsaI6Ohg0bujJVBTVx4kQbN25cobYTAAAAAAAAAAAUo1JU1atXdyMutm7dGrFej2vVqpXn61SuqnHjxpaenm633HKL9enTxyUmxH9drPscOXKkGwniLxs2bDjOdwcAAAAAAAAAAIpVYqNMmTLWqlUrN+rCd+TIEfe4Xbt2+d6PXuOXkWrQoIFLYITvU2Wlli5detR9li1b1ipVqhSxAAAAAAAAAACA5JLwUlQqIzVw4EBr3bq1tWnTxrKysmzv3r2WkZHhnh8wYICbT8MfkaF/tW2jRo1cMuOtt96yZ5991qZPn+6eT0lJsWHDhtmECROsSZMmLtExevRoq1OnjvXq1Suh7xUAAAAAAAAAkBhbLu1oyajW6+8nugmBk/DERt++fW379u02ZswYN7m3ykvNnz8/NPn3+vXrXekpn5IeN954o23cuNHKlStnTZs2teeee87txzdixAi33fXXX2+7du2yDh06uH2mpaUl5D0CAAAAAAAAAIBiktiQIUOGuCWaxYsXRzzWSAwtR6NRG/fcc49bAAAAAAAAAABA8ZHQOTYAAAAAAADiadq0aVa/fn1X1aFt27a2bNmyPLedOXOmdezY0apWreqWLl265Np+0KBBroNl+HLxxRfH4Z0AAFBykdgAAAAAAAAlwty5c91cn2PHjrUVK1ZYy5YtrVu3brZt27Y8q0j079/fFi1aZEuWLLF69epZ165d7fvvv4/YTomMzZs3h5YXX3wxTu8IAICSicQGAAAAAAAoEaZOnWqZmZmWkZFhzZo1sxkzZlj58uVt1qxZUbd//vnn3Tyfmg9Uc3w+8cQTduTIEVu4cGHEdmXLlrVatWqFFo3uAAAARYfEBgAAAAAAKPYOHjxoy5cvd+WkfKmpqe6xRmPkx759++zQoUNWrVq1XCM7atSoYaeffroNHjzYdu7cmec+Dhw4YNnZ2RELAACIDYkNAAAAAABQ7O3YscMOHz5sNWvWjFivx1u2bMnXPm6//XarU6dORHJEZahmz57tRnFMmjTJ3nvvPevevbv7WdFMnDjRKleuHFpU3goAAMSmdIzbAwAAAAAAlDj333+/zZkzx43O0MTjvn79+oX+v3nz5taiRQtr1KiR265z58659jNy5Eg3z4dPIzZIbgAAEBtGbAAAAAAAgGKvevXqVqpUKdu6dWvEej3WvBhHM2XKFJfYeOedd1zi4mgaNmzoftaaNWuiPq/5OCpVqhSxAACA2JDYAAAAAAAAxV6ZMmWsVatWERN/+xOBt2vXLs/XTZ482caPH2/z58+31q1bH/PnbNy40c2xUbt27UJrOwAAiERiAwAAAAAAlAgqATVz5kx75pln7KuvvnITfe/du9cyMjLc8wMGDHClonyaM2P06NE2a9Ysq1+/vpuLQ8uePXvc8/r3tttus48++si+/fZblyTp2bOnNW7c2Lp165aw9wkAQHHHHBsAAAAAAKBE6Nu3r23fvt3GjBnjEhTp6eluJIY/ofj69estNfV/fUCnT59uBw8etD59+kTsZ+zYsXb33Xe70laff/65S5Ts2rXLTSzetWtXN8JDJacAAEDRILEBAAAAAABKjCFDhrglGk34HU6jMI6mXLlytmDBgkJtHwAAODZKUQEAAAAAAAAAgMAgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhsAAAAAAAAAAKD4Th6+a9cu++tf/2rvv/++fffdd7Zv3z47+eST7eyzz7Zu3bpZ+/bti6alAAAgsIgfAABArIgfAADAcY/Y2LRpk/3ud7+z2rVr24QJE+ynn36y9PR069y5s51yyim2aNEiu+iii6xZs2Y2d+7c/O4WAAAUY8QPAAAgVsQPAACg0EZsqEfEwIEDbfny5S54iEbBxrx58ywrK8s2bNhgt956a353DwAAiiHiBwAAECviBwAAUGiJjS+//NJOOumko25Trlw569+/v1t27tyZ310DAIBiivgBAADEivgBAAAUWimq8KDiH//4h/3888+5ttE6PZdzewAAUDIRPwAAgFgRPwAAgEJLbIS74IIL7L///W+u9bt373bPAQAA5ET8AAAAYkX8AAAACi2x4XmepaSk5Fqv4Z8VKlQoyC4BAEAxR/wAAABiRfwAAACOa44Nufzyy92/CioGDRpkZcuWDT13+PBh+/zzz619+/ax7BIAABRzxA8AACBWxA8AAKDQEhuVK1cO9Zg48cQT3WRdvjJlytivfvUry8zMjGWXAACgmCN+AAAAsSJ+AAAAhZbYeOqpp9y/9evXt1tvvZVhnwAA4JiIHwAAQKyIHwAAQKHPsTF27Fg3DPTdd9+1P/3pT/bjjz+69Zs2bbI9e/YUZJcAAKCYI34AAACxIn4AAADHPWLD991339nFF19s69evtwMHDthFF13khoZOmjTJPZ4xY0ZBdgsAAIox4gcAABAr4gcAAFBoIzaGDh1qrVu3th9++CGizuVll11mCxcuLMguAQBAMVfY8cO0adNceYq0tDRr27atLVu2LM9tZ86caR07drSqVau6pUuXLrm2Vw3vMWPGWO3atV37tM3q1atjbhcAACg83H8AAACFlth4//33bdSoUW7CrnC6ufD9998XZJcAAKCYK8z4Ye7cuTZ8+HBXnmLFihXWsmVL69atm23bti3q9osXL7b+/fvbokWLbMmSJVavXj3r2rVrxM+dPHmyPfLII67n59KlS10tb+1z//79BXzHAADgeHH/AQAAFFpi48iRI3b48OFc6zdu3OiGhCa6x+WgQYMsJSUlYtHQVQAAkDiFGT9MnTrVMjMzLSMjw5o1a+aSEeXLl7dZs2ZF3f7555+3G2+80dLT061p06b2xBNPuPb4PT01WiMrK8vdOOnZs6e1aNHCZs+e7ep3z5s3r4DvGAAAHK/Cvv8AAABKcGJDPRz1x79PiQNN2qVek7/+9a8T3uNSlMjYvHlzaHnxxRcL8lYBAEAhKaz44eDBg7Z8+XLXucGXmprqHis2yI99+/bZoUOHrFq1au7xunXrbMuWLRH7rFy5sutwkd99AgCAwleY9x8AAEAJnzz8wQcfdMkH9ZBUeYYrr7zS1aCuXr16zAmE8B6Xoh6Xb775putxeccdd0TtcRlOPS5feeUV1+NywIABofVly5a1WrVqFeTtAQCAIlBY8cOOHTtcz82aNWtGrNfjVatW5Wsft99+u9WpUyeUyFBSw99Hzn36z0WjSUu1+LKzs/P9PgAAQHzvPwAAgBKe2DjllFPss88+szlz5tjnn3/uektcd911dtVVV0VM5pXfHpcjR44stB6X4SM7atSo4cpVXXjhhTZhwgQ76aST8twPNyYAAChahRU/HK/777/ftUGxgspgHo+JEyfauHHjCq1tAAAgOeMHAABQDBIb7oWlS9vVV199XD+8KHpc+mWoLr/8cmvQoIGtXbvW7rzzTuvevbtLlpQqVSrqfrgxAQBA0SuM+EE9NHU937p1a8R6PT7WaM0pU6a4xMa7777r5tHw+a/TPmrXrh2xT83LkRd1zlBJzfCOESqTCQAAkit+AAAAJTSx8dprr7nkwAknnOD+/2gqVqzoJuZUwiERPS779esX+v/mzZu7GxeNGjVy23Xu3DnqvrgxAQBA4SuK+KFMmTLWqlUrV4ayV69ebp0/EfiQIUPyfN3kyZPt3nvvtQULFljr1q0jnlNnCCU3tA8/kaFYYOnSpTZ48OA896nSl1oAAEDhScb7DwAAIKCJDd04UI1plXfybyIcjXpS6gbCzTffHNcel9E0bNjQ/aw1a9bkmdjgxgQAAIWvKOIHUWeEgQMHugRFmzZt3KSie/fuDc3ZpXm36tat60ZkyqRJk2zMmDH2wgsvWP369UPzZuhmiBZNRDps2DBXurJJkyYu0TF69Gh3kyQ/7QYAAMkfPwAAgOIjNb8bqiekggr//4+2aEKvmTNnusAivz0uw3+OHrdr1y7P12m/48ePt/nz5+fqcRnNxo0bbefOnRGlJQAAQNErivhB+vbt6zo5KFmhERYrV650cYFf3nL9+vW2efPm0PbTp093c3v16dPHxQP+on34RowYYX/4wx/s+uuvt3POOcfV8NY+j3ceDgAAkBzxAwAAKD4KPMfGsRIWvXv3dhN7HUth97jUTQjNlaGfr1EfmmNDNyoaN25s3bp1K4q3CwAA4hw/iMpO5VV6SuUnw3377bfH3J9Gbdxzzz1uAQAAxTN+AAAAJTixMXv27KM+r2TEiSeeaFOnTs1Xj8vt27e7ZIWSFOp1mbPHZWpqatQel+HGjh1rd999txuCqoDmmWeesV27drkSEl27dnUjPCg1BQBA4hRm/AAAAEoG4gcAABBNiud5nsWoatWqEY8PHTpk+/btcz0lypcvb//9738t6DRhaOXKlW337t1WqVKlQtnnlks7WjKq9fr7iW4CAKAEXA+JH4D4SMaYM7/xZpDbDqBoronEDwCQfJIxZstv3BbktpcE2TFcE/M9x0a4H374IWJR+aevv/7aOnToYC+++GJB2w0AAIox4gcAABAr4gcAAFBoiY1omjRpYvfff78NHTq0sHYJAACKOeIHAAAQK+IHAABQqJOHly5d2jZt2lSYu0SSSMZhWgzRAoDigfgBAADEivgBAICSrUCJjddeey3isabp2Lx5sz322GN27rnnFlbbAABAMUL8AAAAYkX8AAAACi2x0atXr4jHKSkpdvLJJ9uFF15oDz74YEF2CQAAijniBwAAECviBwAAUGhzbBw5ciRiOXz4sG3ZssVeeOEFq127dkF2CQAAijniBwAAkAzxw7Rp06x+/fqWlpZmbdu2tWXLluW57cyZM61jx45WtWpVt3Tp0iXX9hpFMmbMGNeecuXKuW1Wr15doLYBAIA4Th6uwGLlypX2ww8/FMbuAABACUD8AAAA4h0/zJ0714YPH25jx461FStWWMuWLa1bt262bdu2qNsvXrzY+vfvb4sWLbIlS5ZYvXr1rGvXrvb999+Htpk8ebI98sgjNmPGDFu6dKlVqFDB7XP//v0Ffp8AAKAIEhvDhg2zJ598MhRUnHfeefbLX/7SXeB10QcAAMiJ+AEAACQ6fpg6daplZmZaRkaGNWvWzCUjypcvb7NmzYq6/fPPP2833nijpaenW9OmTe2JJ55wI0cWLlwYGq2RlZVlo0aNsp49e1qLFi1s9uzZbmLzefPmHee7BwAAhZrYePnll12vBnn99dft22+/tVWrVtnNN99sd911V0F2CQAAijniBwAAkMj44eDBg7Z8+XJXKsqXmprqHms0Rn7s27fPDh06ZNWqVXOP161b50pjhe+zcuXKrsRVXvs8cOCAZWdnRywAACAOiY0dO3ZYrVq13P+/9dZbdsUVV9hpp51m1157rf3rX/8qyC4BAEAxR/wAAAASGT9oXxr1UbNmzYj1eqzkRH7cfvvtVqdOnVAiw39dLPucOHGiS374i0afAACAOCQ2dIH+8ssvXUAwf/58u+iii0I9F0qVKlWQXQIAgGKO+AEAAAQ5frj//vttzpw59te//tVNPF5QI0eOtN27d4eWDRs2FGo7AQAoCUoX5EWqRfnb3/7WateubSkpKaGeCpokSzUnAQAAciJ+AAAAiYwfqlev7pIhW7dujVivx/6okLxMmTLFJTbeffddN4+Gz3+d9qE2hu9T83JEU7ZsWbcAAIA4JzbuvvtuO+uss1yvAg0D9S/IChDuuOOO42gOAAAorogfAABAIuOHMmXKWKtWrdzE37169XLr/InAhwwZkufrJk+ebPfee68tWLDAWrduHfFcgwYNXHJD+/ATGZozQ4mXwYMHF+AdAwCAIktsSJ8+fXKtGzhwYEF3BwAASgDiBwAAkMj4Yfjw4e61SlC0adPGsrKybO/evW5kiAwYMMDq1q3r5sGQSZMm2ZgxY+yFF16w+vXrh+bNqFixols0imTYsGE2YcIEa9KkiUt0jB492s3D4SdPAABAEiU2AAAAAAAAgqRv3762fft2l6xQkkKjLDR3hz/59/r16y019X/TkU6fPt0OHjyYK7kyduxYN5pERowY4ZIj119/ve3atcs6dOjg9nk883AAAICjI7EBAAAAAABKDJWdyqv01OLFiyMef/vtt8fcn0Zt3HPPPW4BAADx8b9uCAAAAAAAAAAAAEmOxAYAAAAAAAAAAAgMEhsAAAAAAAAAAKD4zbFx7bXXFugH9OrVy3r06FGg1wIAgGAjfgAAALEifgAAAIWW2Dj11FOtIKpUqVKg1wEAgOAjfgAAALEifgAAAIWW2Bg7dmx+NwUAAHCIHwAAQKyIHwAAwLEwxwYAAAAAAAAAACh+IzYAAAAAAAAAAED8bbm0oyWbWq+/n7CfTWIDAAAAAIrZH5mJ/kMTAAAAKEqUogIAAAAAAAAAAIFBYgMAAAAAAAAAABTvxEapUqVs27Ztudbv3LnTPQcAAJAT8QMAAIgV8QMAACi0xIbneVHXHzhwwMqUKRPz/qZNm2b169e3tLQ0a9u2rS1btizPbWfOnGkdO3a0qlWruqVLly65tlf7xowZY7Vr17Zy5cq5bVavXh1zuwAAQOEp7PgBAAAUf8QPAADguCcPf+SRR9y/KSkp9sQTT1jFihVDzx0+fNj+8Y9/WNOmTWPZpc2dO9eGDx9uM2bMcEmNrKws69atm3399ddWo0aNXNsvXrzY+vfvb+3bt3eJkEmTJlnXrl3tiy++sLp167ptJk+e7Nr6zDPPWIMGDWz06NFun19++aV7DQAAiJ+iiB8AAEDxRvwAAAAKLbHx0EMPhXpMKBERPuxTPSU06kLrYzF16lTLzMy0jIwM91ivf/PNN23WrFl2xx135Nr++eefj3isAOeVV16xhQsX2oABA1zblBwZNWqU9ezZ020ze/Zsq1mzps2bN8/69esXU/sAAMDxKYr4AQAAFG/EDwAAoNASG+vWrXP/XnDBBfbqq6+6UlDH4+DBg7Z8+XIbOXJkaF1qaqorHbVkyZJ87WPfvn126NAhq1atWqiNW7ZscfvwVa5c2Y0G0T5JbAAAEF+FHT8AAIDij/gBAAAUWmLDt2jRolz1LjU8NFY7duxwQ0g1miKcHq9atSpf+7j99tutTp06oUSGkhr+PnLu038ur/qcWnzZ2dkxvRcAABCf+AEAAJQcxA8AAKDQJg/3yzs1b97cTc6tpUWLFvbss89aPN1///02Z84c++tf/3rcc2dMnDjRjezwl3r16hVaOwEAQPLEDwAAIFiIHwAAQKGM2NC8GJqQe8iQIXbuuee6dR988IH9/ve/d6Mwbr755nztp3r16q5O5tatWyPW63GtWrWO+topU6a4xMa7777rghqf/zrto3bt2hH7TE9Pz3N/KoelSczDR2yQ3AAAoPAUVvwAAABKDuIHAABQaImNRx991KZPn+4m6/b16NHDzjzzTLv77rvzHVhowq9WrVq5ib979erl1h05csQ9VtCSl8mTJ9u9995rCxYssNatW0c816BBA5fc0D78RIaSFEuXLrXBgwfnuc+yZcu6BQAAFI3Cih8AAEDJQfwAAAAKLbGxefNma9++fa71WqfnYqFREgMHDnQJijZt2lhWVpbt3bvXMjIy3PMKXurWretKRcmkSZNszJgx9sILL1j9+vVD82ZUrFjRLaq1OWzYMJswYYI1adLEJTrUu0PzcPjJEwAAEH+FGT8AAICSgfgBAAAU2hwbjRs3tr/85S+51s+dO9clE2LRt29fV1ZKyQqNsFi5cqXNnz8/NPn3+vXrI4IV9dQ4ePCg9enTx5Wa8hftwzdixAj7wx/+YNdff72dc845tmfPHrfP452HAwAAFFxhxg8ybdo018lB1/e2bdvasmXL8tz2iy++sN69e7vt1QlCHSlyUq9PPRe+NG3aNOZ2AQCA5I0fAABACR6xMW7cOJeQ+Mc//hGqcfnPf/7TlX+KFnAci8pO5VV6avHixRGPv/3222PuTzci7rnnHrcAAIDkUJjxg25maNTnjBkzXFJDiYpu3brZ119/bTVq1Mi1/b59+6xhw4Z2xRVXHLVkhcpaaP4uX+nSBQqVAABAISns+w8AAKAEj9hQj0fNWaHJv+fNm+cW/b96Sl522WWF30oAABB4hRk/aCLRzMxMV7qyWbNmLsFRvnx5mzVrVtTtNYLzgQcesH79+h11Ti0lMjRXl7+ofQAAIHG4/wAAAKIpcDdETfr93HPPFfTlAACgBCqM+EElKZcvX24jR44MrUtNTbUuXbrYkiVLjmvfq1evdvNyqbxVu3bt3Bxfv/jFL/Lc/sCBA27xZWdnH9fPBwAAuXH/AQAA5HRc9RW2bdvmliNHjkSsb9GixfHsFgAAFGPHGz/s2LHDDh8+HJqPy6fHq1atKnC7VNLq6aefttNPP93N76XSFx07drR///vfduKJJ0Z9jRIf2g4AABQt7j8AAIDjTmyol+TAgQPtq6++Ms/zcs1voZsNAAAAQYofunfvHnGTRImOU0891dXvvu6666K+RqNGNNdH+IiNevXqxaW9AACUBMkePwAAgAAlNq699lo77bTT7Mknn3S9IxVMAAAAxCN+UF3tUqVK2datWyPW67HmxSgsVapUce1ds2ZNnttovo6jzdkBAACOD/cfAABAoSU2/vOf/9grr7xijRs3LsjLAQBACVRY8UOZMmVcre2FCxdar1693DqVpdDjIUOGFFJrzfbs2WNr1661a665ptD2CQAAYsP9BwAAEE2qFUDnzp3ts88+K8hLAQBACVWY8YPKP82cOdOeeeYZV5pi8ODBtnfvXsvIyHDPDxgwIGJycU04vnLlSrfo/7///nv3/+GjMW699VZ777337Ntvv7UPP/zQLrvsMjcypH///oXSZgAAEDvuPwAAgEIbsfHEE0+4GpeaTPOss86yE044IeL5Hj16FGS3AACgGCvM+KFv3762fft2GzNmjG3ZssXS09Nt/vz5oQnF169fb6mp/+u/sWnTJjv77LNDj6dMmeKWTp062eLFi926jRs3uiTGzp077eSTT7YOHTrYRx995P4fAAAkBvcfAABAoSU2lixZYv/85z/t7bffzvUck3cBAIB4xA8qO5VX6Sk/WeGrX79+rglHc5ozZ05MPx8AABQ97j8AAIBCK0X1hz/8wa6++mrbvHmzq2kdvhBUAACAaIgfAABArIgfAABAoSU2VKLh5ptvDpV7AAAAOBbiBwAAECviBwAAUGiJjcsvv9wWLVpUkJcCAIASivgBAAAkQ/wwbdo0V6YyLS3N2rZta8uWLctz2y+++MJ69+7ttlfpq6ysrFzb3H333e658KVp06aF2mYAAFAIc2ycdtppNnLkSPvggw+sefPmuSbv+uMf/1iQ3QIAgGKM+AEAACQ6fpg7d64NHz7cZsyY4ZIaSlR069bNvv76a6tRo0au7fft22cNGza0K664wo0cycuZZ55p7777buhx6dIFut0CAADyqUBX2ieeeMIqVqxo7733nlvCqWcCNyYAAEBOxA8AACDR8cPUqVMtMzPTMjIy3GMlON58802bNWuW3XHHHbm2P+ecc9wi0Z4PT2TUqlUrprYAAIA4JzbWrVt3HD8SAACURMQPAAAgkfHDwYMHbfny5W4EiC81NdW6dOliS5YsOa59r1692urUqePKW7Vr184mTpxov/jFL6Jue+DAAbf4srOzj+tnAwBQEhVojg0AAAAAAIAg2bFjhx0+fDjXROR6vGXLlgLvVyWtnn76aZs/f75Nnz7dJWM6duxoP/74Y9TtlfSoXLlyaKlXr16BfzYAACVVvhMb999/v/3000/52nbp0qVuKCcAACjZiB8AAEBxjx+6d+/u5uBo0aKFm6/jrbfesl27dtlf/vKXqNtrxMju3btDy4YNG+LeZgAASkxi48svv3TDKG+88UZ7++23bfv27aHnfv75Z/v888/t8ccft/bt21vfvn3txBNPLKo2AwCAgCB+AAAAyRI/VK9e3UqVKmVbt26NWK/HhTk/RpUqVdyk52vWrIn6fNmyZa1SpUoRCwAAKKLExuzZs+3dd9+1Q4cO2ZVXXuku+mXKlHEBhC7KZ599tptsa8CAAbZq1So777zzYmwKAAAobogfAABAssQP2kerVq1s4cKFoXVHjhxxjzUvRmHZs2ePrV271mrXrl1o+wQAAMcxeXjLli1t5syZ9qc//ck+++wzW79+vRseql4P6enp7l8AAIBwxA8AACBZ4ofhw4fbwIEDrXXr1tamTRvLysqyvXv3WkZGhnteyZK6deu6eTD8Ccc1gsT//++//95WrlxpFStWtMaNG7v1t956q1166aV26qmn2qZNm2zs2LFuZEj//v0L7XgAAIDjSGz4UlNTXQ8JLQAAAPlB/AAAABIdP6h0lUpbjRkzxk0YriSJJv32JxRXAkU/06dERfjPnjJlils6depkixcvdus2btzokhg7d+60k08+2Tp06GAfffSR+38AAJAEiY3Dhw+7C/hrr73meip07tzZ9UQoV65cETUPAAAEHfEDAABIpvhhyJAhbonGT1b46tevb57nHXV/c+bMOe42AQCAIppjQ+677z6788473ZBLDc18+OGH7aabborxRwIAgJKE+AEAAMSK+AEAABRaYkMTeD3++OO2YMECmzdvnr3++uv2/PPPu8m2AAAAoiF+AAAAsSJ+AAAAhZbYUK3JX//616HHXbp0sZSUFFdzEgAAIBriBwAAECviBwAAUGiJjZ9//tnS0tIi1p1wwgl26NChWHYDAABKEOIHAAAQK+IHAABQaJOHa8KsQYMGWdmyZUPr9u/fb7///e+tQoUKoXWvvvpqLLsFitSWSztasqn1+vuJbgIAxA3xAwAAiBXxAwAAKLTExsCBA3Otu/rqq2PZBQAAKGGIHwAAQKyIHwAAQKElNp566ikrCtOmTbMHHnjAtmzZYi1btrRHH33U2rRpE3XbL774wsaMGWPLly+37777zh566CEbNmxYxDZ33323jRs3LmLd6aefbqtWrSqS9gMAgPjHDwAAoPgifgAAAIU2x0ZRmDt3rg0fPtzGjh1rK1ascImNbt262bZt26Juv2/fPmvYsKHdf//9VqtWrTz3e+aZZ9rmzZtDywcffFCE7wIAAAAAAAAAAJSIxMbUqVMtMzPTMjIyrFmzZjZjxgwrX768zZo1K+r255xzjhvd0a9fv4hamzmVLl3aJT78pXr16kX4LgAAAAAAAAAAQLFPbBw8eNCVlOrSpcv/GpSa6h4vWbLkuPa9evVqq1OnjhvdcdVVV9n69esLocUAAAAAAAAAAKDEJjZ27Nhhhw8ftpo1a0as12PNt1FQbdu2taefftrmz59v06dPt3Xr1lnHjh3txx9/zPM1Bw4csOzs7IgFAAAAAAAAAAAEePLwoOjevXvo/1u0aOESHaeeeqr95S9/seuuuy7qayZOnJhrwnEAAAAAAAAAAJBcEjpiQ/NelCpVyrZu3RqxXo+PNjF4rKpUqWKnnXaarVmzJs9tRo4cabt37w4tGzZsKLSfDwAAAAAAAAAAikFio0yZMtaqVStbuHBhaN2RI0fc43bt2hXaz9mzZ4+tXbvWateunec2moi8UqVKEQsAAAAAAAAAAEguCS9FNXz4cBs4cKC1bt3a2rRpY1lZWbZ3717LyMhwzw8YMMDq1q3rSkX5E45/+eWXof///vvvbeXKlVaxYkVr3LixW3/rrbfapZde6spPbdq0ycaOHetGhvTv3z+B7xQAAAAAAAAAAAQ+sdG3b1/bvn27jRkzxk0Ynp6e7ib99icUX79+vaWm/m9giRIVZ599dujxlClT3NKpUydbvHixW7dx40aXxNi5c6edfPLJ1qFDB/voo4/c/wMAAAAAAAAAgOBKeGJDhgwZ4pZo/GSFr379+uZ53lH3N2fOnEJtHwAAAAAAhWXLpR0t2dR6/f1ENwEAACAYc2wAAAAAAAAAAADEgsQGAAAAAAAAAAAIDBIbAAAAAAAAAAAgMEhsAAAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwSGwAAAAAAAAAAIDBIbAAAAAAAAAAAgMAgsQEAAAJp2rRpVr9+fUtLS7O2bdvasmXL8tz2iy++sN69e7vtU1JSLCsr67j3CQAAAAAAEoPEBgAACJy5c+fa8OHDbezYsbZixQpr2bKldevWzbZt2xZ1+3379lnDhg3t/vvvt1q1ahXKPgEAAAAAQGKQ2AAAAIEzdepUy8zMtIyMDGvWrJnNmDHDypcvb7NmzYq6/TnnnGMPPPCA9evXz8qWLVso+wQAAAAAAIlBYgMAAATKwYMHbfny5dalS5fQutTUVPd4yZIlSbNPAAAAAABQNEoX0X4BAACKxI4dO+zw4cNWs2bNiPV6vGrVqrju88CBA27xZWdnF+jnAwAAAACA/GPEBgAAQAFNnDjRKleuHFrq1auX6CYBAAAAAFDskdgAAACBUr16dStVqpRt3bo1Yr0e5zUxeFHtc+TIkbZ79+7QsmHDhgL9fAAAAAAAkH8kNgAAQKCUKVPGWrVqZQsXLgytO3LkiHvcrl27uO5TE5FXqlQpYgEAAAAAAEWLOTYAAEDgDB8+3AYOHGitW7e2Nm3aWFZWlu3du9cyMjLc8wMGDLC6deu6UlH+5OBffvll6P+///57W7lypVWsWNEaN26cr30CAAAAAIDkwIgNAAAQOH379rUpU6bYmDFjLD093SUp5s+fH5r8e/369bZ58+bQ9ps2bbKzzz7bLVqv1+r/f/e73+V7nwAAoHiYNm2a1a9f39LS0qxt27a2bNmyPLf94osvrHfv3m77lJQU1/HhePcJAACOHyM2AABAIA0ZMsQt0SxevDjisW40eJ53XPsEAADBN3fuXDdKc8aMGS4BoURFt27d7Ouvv7YaNWrk2n7fvn3WsGFDu+KKK+zmm28ulH0CAIDjx4gNAAAAAABQIkydOtUyMzNdqclmzZq5ZET58uVt1qxZUbc/55xz7IEHHrB+/fq5ubUKY58AAOD4kdgAAAAAAADFnubZWr58uXXp0iW0LjU11T1esmRJ0uwTAAAcG6WoAAAAAABAsbdjxw47fPhwrvmz9HjVqlVx2+eBAwfc4svOzi7QzwYAoCRjxAYAAAAAAECcTJw40SpXrhxa6tWrl+gmAQAQOCQ2AAAAAABAsVe9enUrVaqUbd26NWK9HteqVStu+xw5cqTt3r07tGzYsKFAPxsAgJKMxAYAAAAAACj2ypQpY61atbKFCxeG1h05csQ9bteuXdz2qUnIK1WqFLEAAIDYMMcGAAAAAAAoEYYPH24DBw601q1bW5s2bSwrK8v27t1rGRkZ7vkBAwZY3bp1Xbkof3LwL7/8MvT/33//va1cudIqVqxojRs3ztc+AQBA4SOxAQAAAAAASoS+ffva9u3bbcyYMbZlyxZLT0+3+fPnhyb/Xr9+vaWm/q+4xaZNm+zss88OPZ4yZYpbOnXqZIsXL87XPgEAQOEjsQEAAAAAAEqMIUOGuCUaP1nhq1+/vnmed1z7BAAAhY85NgAAAAAAAAAAQGAkRWJj2rRprhdEWlqatW3b1pYtW5bntl988YX17t3bbZ+SkuJqVx7vPgEAAAAAAAAAQDAkPLExd+5cN9HW2LFjbcWKFdayZUvr1q2bbdu2Ler2+/bts4YNG9r9999vtWrVKpR9AgAAAAAAAACAYEh4YmPq1KmWmZlpGRkZ1qxZM5sxY4aVL1/eZs2aFXX7c845xx544AHr16+flS1btlD2CQAAAAAAAAAAgiGhiY2DBw/a8uXLrUuXLv9rUGqqe7xkyZK47vPAgQOWnZ0dsQAAAAAAAAAAgOSS0MTGjh077PDhw1azZs2I9Xq8ZcuWuO5z4sSJVrly5dBSr169Av18AAAAAAAAAABQjEtRJYuRI0fa7t27Q8uGDRsS3SQAAAAAAAAAAJBDaUug6tWrW6lSpWzr1q0R6/U4r4nBi2qfmq8jrzk7AAAAAAAAAABAckjoiI0yZcpYq1atbOHChaF1R44ccY/btWuXNPsEAAAAAAAAAADJIaEjNmT48OE2cOBAa926tbVp08aysrJs7969lpGR4Z4fMGCA1a1b182B4U8O/uWXX4b+//vvv7eVK1daxYoVrXHjxvnaJwAAAAAAAAAACKaEJzb69u1r27dvtzFjxrjJvdPT023+/Pmhyb/Xr19vqan/G1iyadMmO/vss0OPp0yZ4pZOnTrZ4sWL87VPAAAAAAAAAAAQTAlPbMiQIUPcEo2frPDVr1/fPM87rn0CAAAAAAAAAIBgSugcGwAAAAAAAAAAALEgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAACg8QGAAAAAAAAAAAIDBIbAAAAAAAAAAAgMEhsAAAAAAAAAACAwCCxAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwSGwAAAAAAAAAAIDBIbAAAAAAAAAAAgMAgsQEAAAAAAAAAAAKDxAYAAAAAAAAAAAgMEhsAAAAAAAAAACAwSGwAAAAAAAAAAIDAILEBAAAAAAAAAAACg8QGAAAIpGnTpln9+vUtLS3N2rZta8uWLTvq9i+99JI1bdrUbd+8eXN76623Ip4fNGiQpaSkRCwXX3xxEb8LAAAAAAAQKxIbAAAgcObOnWvDhw+3sWPH2ooVK6xly5bWrVs327ZtW9TtP/zwQ+vfv79dd9119umnn1qvXr3c8u9//ztiOyUyNm/eHFpefPHFOL0jAAAAAACQXyQ2AABA4EydOtUyMzMtIyPDmjVrZjNmzLDy5cvbrFmzom7/8MMPu6TFbbfdZmeccYaNHz/efvnLX9pjjz0WsV3ZsmWtVq1aoaVq1apxekcAAAAAACC/SGwAAIBAOXjwoC1fvty6dOkSWpeamuoeL1myJOprtD58e9EIj5zbL1682GrUqGGnn366DR482Hbu3HnUthw4cMCys7MjFgAAAAAAULRIbAAAgEDZsWOHHT582GrWrBmxXo+3bNkS9TVaf6ztNaJj9uzZtnDhQps0aZK999571r17d/ez8jJx4kSrXLlyaKlXr95xvz8AAFC0mKcLAIDgI7EBAABgZv369bMePXq4Gxaaf+ONN96wjz/+2I3iyMvIkSNt9+7doWXDhg1xbTMAAIgN83QBAFA8kNgAAACBUr16dStVqpRt3bo1Yr0ea16MaLQ+lu2lYcOG7metWbMmz200J0elSpUiFgAAkLyYpwsAgOKhdKIbAAAAEIsyZcpYq1atXMko9ZiUI0eOuMdDhgyJ+pp27dq554cNGxZa9/e//92tz8vGjRvdHBu1a9cugncBAAASNU+XRlzGMk+XRniE0wiPefPmRZ2nSwmNCy+80CZMmGAnnXRSEb0TAMXF/33wkSWbCzv8KtFNAPKFxAYAAAgc3WAYOHCgtW7d2tq0aWNZWVm2d+9e1/tSBgwYYHXr1nVzYMjQoUOtU6dO9uCDD9oll1xic+bMsU8++cT+/Oc/u+f37Nlj48aNs969e7telmvXrrURI0ZY48aN3c2LRErGP3aEP3gAAMVpnq5Vq1Yd1zxdl19+uTVo0MDFEHfeeaebp0tJEY0yzenAgQNu8WVnZxfCuwMAoGQhsQEAAAKnb9++tn37dhszZoy7sZCenm7z588P3XhYv36964Hpa9++vb3wwgs2atQod7OhSZMmrqflWWed5Z7XTYfPP//cnnnmGdu1a5fVqVPHunbt6spNqLQEAADA0ebp8mmurhYtWlijRo3cKI7OnTvn2l4dL9ShAgAABHyOjWnTpln9+vUtLS3N2rZta8uWLTvq9i+99JI1bdrUba+g4a233op4ftCgQZaSkhKxqAcFAAAoPlR26rvvvnM9HpcuXepiCJ9uJDz99NMR219xxRX29ddfu+014eevf/3r0HPlypWzBQsWuIlDVabi22+/daM5cvbQBAAAwZUs83SpFNbu3btDy4YNGwr0fgAAKMkSntiYO3euKycxduxYW7FihbVs2dKVfNCNhWg+/PBD69+/v1133XX26aefutraWnSDIpwSGZs3bw4tL774YpzeEQAAAAAASOZ5unz+PF15zbvlz9MV7njn6dJo0EqVKkUsAAAgYImNqVOnWmZmpquJ3axZM5sxY4aVL1/eZs2aFXX7hx9+2CUtbrvtNjvjjDNciYhf/vKX9thjj+UKFNSDwl80gRcAAAAAACi51LFy5syZrvzkV199ZYMHD841T1f45OKap0vlLjVPl+bhuPvuu908XRo56s/TpfsTH330kRvxqSRIz549k2KeLgAAirOEJjZU6mH58uXWpUuX/zUoNdU91iRb0Wh9+PaiYCHn9ipBUaNGDTv99NNdoKLeEgAAAAAAoGTP0zVlyhQ3T5fm6Fq5cmWuebpU9SHnPF0qUakKEy+//HLUebp69Ohhp512mqsuoVEh77//PvN0AQBQXCcP37Fjhx0+fDhX/Wo9Vk+IaDRBaLTttd6nER2XX365NWjQwNauXesmCe3evbtLfijoiEb1trX4srOzj/PdAQAAAACAZKPRFv6Ii5zUSTInzdOlJRp/ni4AAFCCEhtFpV+/fqH/1+TiLVq0sEaNGrkApXPnzlFfM3HiRBs3blwcWwkAAAAAAAAAAAJViqp69epuBMXWrVsj1uux5sWIRutj2V4aNmzoftaaNWvy3EY1NHfv3h1aNmzYEPP7AQAAAAAAAAAAxXjERpkyZVztSU2u1atXL7fuyJEj7nFew0LbtWvnnh82bFho3d///ne3Pi8bN250c2zUrl07z21U+5L6lwD+74OPLNlc2OFXiW4CAAAAAAAAkDQSXopq+PDhNnDgQGvdurW1adPGsrKybO/evZaRkeGeHzBggNWtW9eVipKhQ4dap06d7MEHH7RLLrnE5syZY5988ombyEv27NnjSkr17t3bjeLQHBsjRoywxo0bu0nGAQAAAAAAkLzocAYASPrERt++fW379u02ZswYNwF4enq6zZ8/PzRB+Pr16y019X8Vs9q3b28vvPCCjRo1yk0K3qRJE5s3b56dddZZ7nmVtvr888/tmWeesV27dlmdOnWsa9euNn78eEZkAAAAAAAAAAAQcAlPbIjKTuVVekoTfud0xRVXuCWacuXK2YIFCwq9jQAAAAAAAAAAoIRPHg4AAAAAAAAAABALEhsAAAAAAAAAACAwkqIUFQAAAAAAABBkyTjpuTDxOYDiiBEbAAAAAAAAAAAgMBixAQDFRDL2DqJnEAAAAACgKPG3MFAykdgAAKAYBdBCEI1kwWcEAAAAAFAUKEUFAAAAAAAAAAACgxEbQJKilysAAAAAAAAA5MaIDQAAAAAAAAAAEBiM2AAAAAACMHKSUZMoKee6cL4DAADgaBixAQAAAAAAAAAAAoPEBgAAAAAAAAAACAwSGwAAAAAAAAAAIDBIbAAAAAAAAAAAgMAgsQEAAAAAAAAAAAKjdKIbAAAAAABArP7vg48s2VzY4VeJbgIAFJvvVOF7FUBeSGwAKHQERAAAAACQWMn4dxl/kwEACgulqAAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYTB4OAEg4JjYEAAAAAABAfjFiAwAAAAAAAAAABAaJDQAAAAAAAAAAEBgkNgAAAAAAAAAAQGCQ2AAAAAAAAAAAAIFBYgMAAAAAAAAAAAQGiQ0AAAAAAAAAABAYJDYAAAAAAAAAAEBgJEViY9q0aVa/fn1LS0uztm3b2rJly466/UsvvWRNmzZ12zdv3tzeeuutiOc9z7MxY8ZY7dq1rVy5ctalSxdbvXp1Eb8LAAAQT8QPAACgIIghAAAIvoQnNubOnWvDhw+3sWPH2ooVK6xly5bWrVs327ZtW9TtP/zwQ+vfv79dd9119umnn1qvXr3c8u9//zu0zeTJk+2RRx6xGTNm2NKlS61ChQpun/v374/jOwMAAEWF+AEAABQEMQQAAMVDwhMbU6dOtczMTMvIyLBmzZq5QKB8+fI2a9asqNs//PDDdvHFF9ttt91mZ5xxho0fP95++ctf2mOPPRbqKZGVlWWjRo2ynj17WosWLWz27Nm2adMmmzdvXpzfHQAAKArEDwAAoCCIIQAAKB5KJ/KHHzx40JYvX24jR44MrUtNTXXDNpcsWRL1NVqv3hXh1BPCDxjWrVtnW7ZscfvwVa5c2Q0v1Wv79esXdb8HDhxwi2/37t3u3+zsbCssPx762ZJR+Xy8x2Rse37aHeS2792715JRfj4TtL1w5fd7iLYXrqCeL4V97fL3pT/ak0VJix+CfJ7R9sKVXcxjnyC3PRnbLcSc8VcSPqf5RQyRdwwRj/gh6J+RoLY9GdsttD3+ivu5nozXsZIQtyVj28snMH5IaGJjx44ddvjwYatZs2bEej1etWpV1NcoYIi2vdb7z/vr8tommokTJ9q4ceNyra9Xr54Ve5UrWyAFtd1BbzuAEunHH390f6QnA+IHIICS5PujQGg7SooiOl+IIXIjfgCAIpIk15sS1fbKiYsfEprYSCbqsRHeC+PIkSP23//+10466SRLSUmxZKLMlQKeDRs2WKVKlSxIgtr2oLZbaHtiBLXtQW230PaioV4SCijq1KmT6KYkJeKH+KDt8RfUdgttTwzaHn/J3m5iiLwRP8QHbU8M2h5/QW230PbEyE7itscSPyQ0sVG9enUrVaqUbd26NWK9HteqVSvqa7T+aNv7/2pd7dq1I7ZJT0/Psy1ly5Z1S7gqVapYMtOJl2wnX3Fve1DbLbQ9MYLa9qC2W2h74UuWXpY+4ofieZ7lB22Pv6C2W2h7YtD2+EvmdhNDRI8hiB/ii7YnBm2Pv6C2W2h7YlRK0rbnN35I6OThZcqUsVatWtnChQsjeirocbt27aK+RuvDt5e///3voe0bNGjgAovwbZSFWrp0aZ77BAAAwUH8AAAACoIYAgCA4iPhpag0/HLgwIHWunVra9OmjWVlZbmJczIyMtzzAwYMsLp167oalDJ06FDr1KmTPfjgg3bJJZfYnDlz7JNPPrE///nP7nkN2xw2bJhNmDDBmjRp4oKM0aNHu+ErvXr1Suh7BQAAhYP4AQAAFAQxBAAAxUPCExt9+/a17du325gxY9zEWhqqOX/+/NDEW+vXr7fU1P8NLGnfvr298MILNmrUKLvzzjtd4DBv3jw766yzQtuMGDHCBSbXX3+97dq1yzp06OD2mZaWZsWBhqyOHTs219DVIAhq24PabqHtiRHUtge13ULbSxbih5J1ntH2+Atqu4W2JwZtj7+gtjvRiCFKznlG2xODtsdfUNsttD0xyga47eFSPM3IAQAAAAAAAAAAEAAJnWMDAAAAAAAAAAAgFiQ2AAAAAAAAAABAYJDYAAAAAAAAAAAAgUFiAwAAAAAAAAAABAaJDQAA4uDIkSOJbgIAAAggYggAABCrIyUgfiCxAQBIap7nWZDbvWTJEvdvaiqXXAAA4okYAgAAxIr4ITiK/ztEQrJ/QfgSCG9jSchiJgOOMwoiJSXF/bt3714LWrvfeecdO/fcc+3NN99MdHOApEL8gFhxrFEQxBBA8RPUGIL4ITE41igI4ofgSPGS/du/BNCvQCffF198YWvXrrUTTjjBGjRoYE2bNrVkv0D42T9lA3/++Wc7ePCgde7c2YJyzP/+97/b/Pnz7dNPP7Wrr77aWrZsaa1atbKg8d9PUM4XHfctW7ZYpUqVrEWLFu58R/wl+3nz9ttv269+9SurWrWqjRo1yg4fPmwTJkywUqVKWRB899139te//tVKly5tQ4YMSXRzUAwRP8RfcYsfgnAtEGKI5BKEc4YYAjg6Yoj4In5IDOKH5BKEc4b4IXhIbCSJV155xYYOHWp169Z1H5idO3faxIkT7fLLL7dkN3LkSJs3b577//3797uLxFNPPWXVqlWzZKY2K5jIzMx0x3zRokVWvnx5e+655+zUU0+1ZL8YbN682fbt22eNGjWyILn99tvthRdesCZNmrj3UKNGDRs2bJhddtlllswUNOvioMBfvwMF//55kuwXaL9969evt//+979Wrlw5q1evnjvfw4O9ZLJ7927r1KmT+7dbt2727LPP2kcffWTNmze3IFi1apX17t3bfvzxR8vKynLf5cl6rBFsxA/xF9T4QYgh4o/4If6IIYD8IYaIL+KHxCF+iC/ih8RYVVLjByU2kFgff/yxV61aNe/xxx93j9955x0vJSXFu+uuu7xkN3XqVO+kk07yli1b5h4/8MADru0ffPCBl8w2bNjgpaene9OnT3eP9+3b55144one7bff7gXBK6+84jVo0MCrV6+e16ZNG3e8Dx486CW7p556yqtTp463ZMkS9/jBBx/00tLSvDfeeMNLRjNmzPCeeOKJ0OO5c+e6Y167dm3v3HPP9f70pz+Fnjty5IiXjPx26Zw588wz3XnToUMH76KLLvK2bdvmJbPt27d7VatW9cqVK+ctXrzYrTt06JCXrMLPgU8//dT73e9+51WsWNG77777om4DHC/ih/gLevwgxBBFj/gh8YghgKMjhogv4ofEIX6IL+KH+DpC/OCR2EgC+uLq1auX+//vvvvO+8UvfuHdeOONERfBZHXttdeGLs764qpcubL7MvYv1slA7ct50Vq/fr131llneTt37vRWr17tnXLKKV5mZmbo+ffffz/pvnT9L6PPP//cO/XUU73777/fe/vtt90FrkmTJt5rr73mHThwwEtmN998c+jcfvnll71KlSpFBHc6/5PpgnbVVVd5jRo18ubMmePt3bvXa9iwofu86lwfNmyY+6xOmTIl6S8YixYt8ipUqOBNmzbNvQ+9BwX/jz32mJfM/vOf/3iNGzf2mjZt6p1xxhne1q1b3frDhw9HbJdMx90PmOWLL77wbrjhBq9WrVoRAWoytRfBRvxQtIpL/CDEEPFD/JAciCGAoyOGKDrED8mF+CH+iB/ia0kJjx9IbCQB9ZLo37+/t2bNGneBu/7660MfmoULF3p3332398MPPyS6mbk+CMrO6+KsrLG+uJQV9C8QP//8szd27FjvL3/5S0Lbu2nTJu83v/mNO7bhdGFu1qyZ+wLQxUJZTf+Yf/bZZ15GRob3ySefeMnYs2b27Nm5enZcfPHFSR1Y6HwQfcHqfP/nP/+Z63yZOXOm9+STTyZVr49//etfLgjSuTJy5Ej3//55omB/zJgxXt26dZM2uFBbtYwaNcr74x//6NbpM6FeH0OGDAltt3//fi8Z5AwW5Mcff/Q2btzotWrVyjv99NNzBfy7du3ykoW+p9UjRQFQ+Dl00003ucBo1qxZSXmeILiIH4pGcYwfhBgifogf4o8YAogNMUTRtJX4IXkQP8Qf8UP8/UD8QGIjGbz00ksu81qjRg33pRtu8ODB3oABA7w9e/Z4yfJhVw+D//73v+7/7733Xu+CCy5ww7T+/Oc/R2Sbf/3rX3sPPfSQl2g//fST+3fp0qXeX//619D6Hj16uKyxenyEu+OOO7zWrVu7L+Bkoy8rtblnz565vpQUWOgCqPMp0RfmaBcHefjhh137S5cu7Xoh+Hbv3u117tzZXQCTQXj7//3vf7vPoQIInevh/OCifv363vjx471kpcBZgZHaq/ehP1z88+dvf/ubC+j8wC8Zjvmrr77qgk8NiQ//3tHnUue4ggy1V9+N+g5KFnoP7733nvucnnPOORF/yCiw0FBcf7g/UBiIH4pWcYofhBii6BE/JAYxBBA7YoiiQ/yQGMQPyYP4IX4OEz+Q2EjUML4PP/zQW758eei56667zn3ZasiiLsg7duxwGfGTTz7ZDSVKlg+7vvR18Zo3b557rF4SygJ27NjR1XMTfXkpoPjVr36V0C8rP1ssaocuChoy6QcX6kXRqVMnd1HQl9eLL77ohvep1qV6TSQjBQs61jVr1nQ1LXNevNu1a+e+eJVhTpTwNmlIrY7tihUrQue/LnLly5d3NVE1rG/t2rVet27dXLuTpXah31Y/mP/666/dUGHV4lRvlXC6wN1yyy3uYqehxYnMgm/evDn0u1fPGdWflQkTJnjnn3++++PFH/KsdqqnhB90JLLXRPgxU2Cv8+Pss89234nq6eEPD1Zg0bZtW/cZ1UVbw3QTGUBH+13r/NdnU8NXdU6H95oYOHCga7d6eBTX3hIoGsQP8W93cYsfhBii6BE/xB8xBHB0xBDxbTPxQ2IQPyQG8UNi2+07XMLjBxIbcabaeJqIRpMXKaM2YsSIiAy+ekzoOV0AVcNQX8bJYvTo0V716tW9119/3QU+Pl2oNRzUr0GnD40W/8Oe6Ezs008/7YajfvPNN+7ipUVfuvLVV1+5ngcaGqdMpp5LlqDC/9LRsE4dQ/9ireOqtuqY68Kc88spkTUiw9uiWpaa5KpKlSruvNBkUWr7999/7/Xu3dsrU6aMO8d18dD5nizni/8e3nzzTZeNV2DknyvqaaDz/Lnnnot4jd5T+GciERQEKXDQheuZZ55xF2S/R4r+SNEQSk2ypwuzf17deeedrgeFAqdkoAvveeed53o36XzXd41qoOq4f/vtt24bBUCa8E1Bkx+EJvKcUe8Ivz5xzsBC57fObZ/+QFTwBxQE8UP8BTV+EGKIxLWf+CExiCGAvBFDxBfxQ3wRPyQG8QPxQ7IgsRHHLysNdVOG/tlnn3V1CvXB0IQu4ZN0qbeEvhQ0IZMyscli1apVLiOsL9vw9+Rf6NQDRD0oNJmU/vU/5InKfvsXB/WKUOb1vvvuc48VNGi4oS5w+sLyKejQ7yc7O9tLBn7733rrLe+aa65xPU/uuuuu0PHXRUG/DwUWOpcSnXkNPxdEPSQU+KiOpc4dDetTW3/5y1+Gzg1to2GIixcvDr02GXpL+IGyzhvVaFVAET4sVEO1FVy88MILXrLR+a1JuhSw+RPo+cdU70PfN+np6a5W5KWXXup6YyXLHy76jPbr18+d7+Hngb4TNSGgAouctWqTIQjVHy0K2K644opcz2tyNAV4LVu2TEj7UDwQP8RX0OMHIYZIHOKHxCCGAKIjhogf4ofEtJf4IbGIH+KP+CE3EhtFzP+yV51F1YS8+uqrvS1btrh1GgqkmpDqgfD73//eS2YKGjT00B/qGU4XOF2Uc0p0T0tlXCdNmuTdeuut7nH45FwKLtQ7IrzmZaLlDAx0wdUFYvjw4W4yMQ2/VfZVQaeod4EuEsp4J/LioKGc4RRUDho0KCJY1ntTGxUIaehhLDUx4029TdS749FHH436vIILvTf1bErk5LbRjp16Q+gidsIJJ7gAyB8W6p9bGqqqXgY6pzThXrSLdKKo7qPargno1q9fn6v3ii7cv/3tb90w82SiY6xecOqtcvnll0c8p4CoS5cuXvv27d1wZyAWxA+JE7T4QYghEh9DED8kDjEEEIkYIjGIH+KH+CGxiB8Si/ghEomNONDFQb0kdMKddtpp3rZt20LP6WKswEJDPzWEKxlEy7yvXLnSfVkpey/KZvrb/eMf//Cef/750CRZyUBD3zQ0S1lvZWD9IMcPdBRcKLBQL4TwHiCJ5rfvhx9+cDU5VZvQp14HqqXYoEGD0IRGCiwS+YWlYFjDCf22K3Du0KGDO+7qlRJtKLFqcO7du9dLFjnPdw2LbNiwoas/6z+XcxsN59Mw10RfmHWBVY8U0YRtqtOqnhEaHlyxYkUX3PnBRaJvFOYngNQQWwUWqnGpICjcyy+/7HXt2jVhwafOAf880JBUBZj/+c9/Qs/7gcVll10WOt7qcTN06NCk+m5EsBA/xF9Q4wchhogv4ofEIIYA8ocYIr6IH+KH+CFxiB/ii/ghf0hsFDHVOPPrs6lenoZpKfMdToHFI4884iZ68XtSJEr4B9YfFul/kDQ8S1+46okQ3lNCFw9NrpNslKnUBGKa5OeTTz5x68LrROrCofqWiawHKVlZWd6VV14ZsU4XZ31BPfzwwxHrddFQsKGeIMlAPQb8upTq/SPr1q1z9StV21JZ+ZwXDfVGyNnDIt6iDTvVZ0+PP/roI3dh83sGhW+jHh8Kov1zP9E1LdV7QJNyjR8/3rXZ70kjCxcudMGFJgX0gwuda/45laihw+HfMTqW6l2jmrP+8dQfWXovmiRQn4Nj7aOo5fweVPCgXkuaNEx/aOmPQX3P+39Aql6uahgreNbxV81OoCCIHxInKPGDEEPEF/FD4uIHIYYA8ocYIjGIH+KD+CExiB+IH5IViY0ipAuAJs+ZOHFi6ItAdf50ouUcCqcTVxnyRAr/otFFS8GCeh3oQ6QLhz4cygRWq1bNu/fee727777bDals3rx5wusS5pXZ1peW3ofqKvpDJcN7TiTy4qC2ahIiDX/TMR08eHDoOZ0rCnoUrOUcYqteN5dccomXSDmPsyZIU81EP3uswOI3v/mN6zmhOq779u1zAdyFF17ohrMmuh6nqD1+MKzPpepWahIunRPKymv4nt8LxW+veodoSXRQ4VNtUE18pouw6p/mrDX6f//3fy6wVm+t/v37e+XKlUuayek0aaEmFNNx13mi4Z/q6SSzZs1y72nMmDGhdYmQmZnpXXvttaHvN32f6A9DDRPW97uCagV23bt3D/VcUYB6zz33eFOmTHE9nICCIH6If9uDFD8IMUTiED8kHjEEkDdiiPi2m/ghfogfEo/4oegRP8SOxEYRUYCg4EEfjNtuuy20XienH1gkU03L8C95ZVQ1UY6ysG3atPHOOecc9/9quz4w+qCrTqECivAPXKIn+tTQSGUuFQipruXmzZtDXwS6wLVu3TqUBfe/eBN5cfOHuelc0UVZNRPVq8anIaCqKTp79uyIwEI9K3RBTGQ9SP9n+/9OnjzZDatVjyAFFKKLco8ePby0tDTXE0gBqXqw+EPiEl3Pctq0ae6irCBCWW9NqBfeq0MXC12QlQl/99133edYWfBkyH77560+jzqv9XlUoPnee++FtgmfVE+/h6uuuiphQUXOz5kmtFJdXw1Z9Xty6LtSvSZ8TzzxhFs3c+ZMLxE0rFaTm4XX9NUfUzmHNyu4O/fcc11NUaAwED/Ev+1Bix+EGCJx7Sd+SEybfcQQQN6IIeLbbuKH+CJ+SBzih/ggfigYEhtF6P3333dD+XTxDa/Vpmy9hj7pA6PaZ8lEQyY1MdH8+fNDXwaa6EeBxbhx41zWO3zIny/RPS51PMuWLesCC12Ya9Wq5QIi/4tWw+J0UdPQrWTIGM+dO9f9/lUr0T+eTz31lAsiNHTPpx4U/jodfwWiyoCrtl4y+PjjjyMu1Mp66wLmBxaqA6hAr2XLlq7XhE+9RJKBjqd+DwoicvaC0MRuOmcUdKgurYKQaBPXJZI+d/pu0fmtmq0KksKDi/DvnET18vDP8XD6jtEkYv5x1jmt4Z+iANr/Pnn99dcT9t2iQFk9Ofzvl4ceesi777773PBOHcvwQElDcNUbxf9jBjhexA/xE7T4QYghEh9DED/EBzEEEDtiiPggfkgc4ofEIX4oWsQPBUNio5DklXlXtl71La+++upQnTTRB0U1GDWUKFmoF8eZZ57palj6NSFF2W1NGNW2bVvXU8Kvl+dLdK8DDRPTUM/wmo+6SKu9WvyATsdbw+HCJ9tJ5DBEXQhUA/LLL7/MFViE10DVcDL1kGjRooW7QCdLYLRo0SLXE0Jftj4Nj8sZWKjXhHpJqC6nhkUnAw1rVo8CTaykY33eeee5nj/R6m5qKN/GjRtzTSSVCP5nTcOadTFW/VD/86hhnxpiqyGJfnCh4YjqiZCoz6gmalPQlrN3jIYM6/OqiQDVc0xDof1tVOtXAWp4mxMRWKgnh4apauiygk8FFvpjoHTp0q6HRLgPP/zQ1W1dv3593NuJ4CN+SJwgxg9CDJE4xA/xQwwBHBsxRGIQPyQO8UN8ET/EF/FDwZDYKAT+ya8Ptiab0ReqakKuXr3ardeHXIGFLgzhgUWy0QVabVdbFTz4dSD97LaGwing0PCsZKLJffThf/nll91jPzOs4ZUaxqWLh2/v3r1estDFShdbtfFYgYXek9ruD6FMBgoWdE7knGBMgUXHjh3dRG9r1qxx6xRgKCBSrwPVBEw2DzzwgNe+fXsXXGzbti20Xu1PlnqWPp3nCkYVvOm8r1+/vhu6Km+//ba7YKtWpIY/62KoSeoS5ZtvvgkFBKof6gcOGlauoF/fNQogfDr2+kyop0IyUK8OHUMNcfbpe/ykk05yvVT8XmMaen7WWWclRfCJYCF+SKygxg9CDJEciB+KDjEEcHTEEIlD/JA4xA/xR/wQX8QPsSOxUUgURChz3K9fPzcEUb0ONCzL73WgXhM6EfWhz9nbIBFy1hZUBtm/GOtioGGf06dPjwgsdEHTBSN8XaKEZ1J1sa1Xr543cuTI0Dr/YtCnT5+IYZXJZsOGDUcNLMLrXSZSXhl39fq44447vLp167rMvE/Zbw2h0+Ru/vmiIESfDw0NTeR7UG+T559/3g0xDB9Oq14pqlOoYE7vSwGpLhTJ9IeAht3qXNGwQ9m+fbu76PlDKv3M/f333++CpGhDMONBPTlyfj+qnWqbqNeS6nJqiO1HH33kPsM65urtoWAj0aVpREPe1VNCkyyqreptJTqf9R2poec6PzQsVBPv+ZMDArEifoiv4hI/CDFEfBA/xBcxBJB/xBDxQ/wQf8QPiUf8EF/EDwVDYqOQLgw6uTQZjU9DhlQfT0Oz/KGH6k1x6qmnhrKGyRBQqKbcTTfd5F1++eWhrKvqyykjqA9LzsDCl6jAwr846MtebfCzlTr2ugjPmDEjYntljYcNG+YlM32ZRgssdPHQkLNkar+Or3+e5Awsch5/XUj888T/N9ETxKpNqn+qocMK/HXRUIDhU68P/VGgIEmLLnjJRMMQda6IhpCrt4Quer7wP1gSNTGaAgcFEEOGDAmtU23Q3r17u54emgzNH2KrmrPNmzd3k9bp+0YBhf8HTqL/eAnvYfXkk0+63ikazu976aWX3JBVBdN+ryAgVsQP8VMc4wchhihaxA/xRQwB5B8xRHwQPyQe8UPiED/EH/FD7EhsFEL2WB9wfVm98847uepFKmP897//PbTOn/gqGWgIn7489eFXdlhfBKpH5/eaUGCh4WbKJCfySyrnMX/zzTfdkEJ9AelfBWv6ItL70YVZk6Hp4qb3pQmB/At1srRfNfC0aIhceGCqTHF4YKEhrsrsf/311wlrc/jvfcuWLd5vf/tbr3HjxqFhtz4Fzroo6HiH1xpNlouD6DzR8fWHHSrwV3s1bFIXbN/KlSvdOZaokSVHo+GT6oWlnksafqveNP7vSMNrNXzbvygnin6+LrgVKlRwk6P51Dulb9++7nfgBxb6A0vfm/q8alhlohNgeVHANmvWLBdY+L0mgIIifoi/oMcPQgyROMQP8UMMARwdMUR8ET8kBvFD8iB+SBzih/wjsRGj8A+tasep7qM+GOot4Q/PCv8i1mQuf/zjH71kow+wem4sXbrUPf7nP//pgorZs2eHtlGtNk0udcMNNyR8gk/f3/72NzfcduLEid4LL7zgAh+1Wxdp/R78D37r1q3dRFG6SCQD//ip/coOq43qXRA+dFL1LhVY1KlTx/vXv/4V8bpE89uhYc2ZmZkuWNaFI5wy9zruGn6r7ZOl7aLPqWoV3nzzzaEgTr0N1KNJPYVUt1WTuyUT//ipV4EWUYCp7xQNQfQv2P526lWj96PeTokS/t2nycVOOOGEiCHaOq/9wELfOZLzPEmGIDSaPXv2uO8XfddrOD8QK+KHxApq/CDEEIlD/BA/xBBA3oghEof4IXGIH+KL+CH5ED/kD4mNGCgjfNFFF7mTXtnJypUru1nr5YorrvAaNGgQuhiItlN2M7z+XCLceeeduWpq6oKggEH0XipWrOiGfPo9JVQHUPQl5X9RJPoioQ+1hsFpoiVRIKHAKHwonF/fUheSZJuoS1l4HWfVCNUFQr0KFBSF14BUYKFJpNQjQe8jUcc8/OKgIXAKhPyAWsG06oaq5p+GVvq/Gw2RmzNnTqjNiT5fclKvpvfff9+d061atQqdN6+99ppXpkwZV6NQPZySQfjQVR1n9WbaunWr60Gji7TOD9Wx9CdF02dc9XMTWdMy/Petc1s9lqpWrerO8fA/rPQdqTqn6mGmur9BovNctVs1XDjRw/kRLMQPxA/HixgicYgf4tduIYYAIhFDJO56QPwQX8QPiUP8kLyIH46NxEYMlGXVJFGqjacPit87wv9AaeIfZWFVb1HD5DQ0UYFHIofxaUjheeedl2tYlb6wVOfv6aef9ipVquQ+KOEBh7KBmzZtCq1L9DBQ0Zeqjq/qDm7bts0NYQ2f2Eo9PcKHViYTDaHUsNXJkye7x+rhoSy9fjelSpVyFwZ/wjEddz2fKOG/a/UimDBhgjvfVS/UP48UWKgXjYZSKnDWuXT22WeHgqNEBxT+z9f5rwuXX2NWFixY4Hp1qC6n6Hzq0qWLN2LECDe5WLJQO8uVK+eCfQUVPrVRF2nVilRdyPT0dDecNVkmjho3bpxXvXp1d+6od5CCIvXwUI+V8CGh+gPtkksu8YJGf7D4tXWB/CJ+SKwgxw9CDBE/xA+JRQwB5EYMkTjED/FD/JB4xA/Ji/jh6EhsxEgfcn3B6oPsD7kK/xJWxljZWF0Af/WrX7kJa5KFekXo4iz6ou3cubPLFOuiEV5/s0ePHt6AAQMSfnM6J12wNPRTmWLV99NFzb+I6Yv3mmuuccNDk63d/pBaTQylYEEBhgJTP2OvC5rOKQWhyTQETu1R4DNq1CivZ8+eLvOteqd+YKH3ovqbV111lXsP/vpEB6DhwxDVO0W9C3RRUw1FHV/1WlEgvWjRIredeiAMGjQoaS4UOn/V40fn8y233BJaJ/4xVlsVYGjiPQVO6mWTDPT9oSBTQ7XDL8L6A0zB86233hpar/Yny7kCxAPxQ+IEOX4QYoj4In5IDGIIIG/EEIlB/BB/xA/xR/yAoCOxESN9iDWsU8OzzjnnnFBWO/xioGBD2VgNp0yk8A+sehiULl3aBQz+kFB90eripiFZmjxHw+A0NLRFixYJvUDoWPpfpPqCDe/pMXz4cHcBVpZVz/nuuOMOV3PRz4Inktrunw87duzwsrOzI55XYHThhRd627dvd4/Vg0JtV82/8Mx4IqmOpTLe/qRzej+qiapgWT08wuu8hp8jyTDhktqjIE69l/70pz95q1ev9u677z533uhit2TJEq93797eKaec4gJ/BR/+sOdkouHAfk3OaD23kpGCCv3BlbOmr4ZPqu6pfgcZGRkRzxFYoKQgfih6QY8fhBgicYgfEosYAsgbMUTRIn4gfjgexA+JRfwAEhvH4F/gVB9PQ8b0ZSu6gOmCrCFl4dnKt956K+KClwxUE1JDstR2TRal4Yg//fSTe27atGnuIq1eE/oi00RG/gUj3pn79957L+Lx66+/7oIctS88+6paohoGpy/de++917v22mvdcNtE90xRJj58sjANtW3btq3rcaBj/sQTT7j1qg2pIXA+ZZA1HFdfvMlCAYR6R4QPBVbAoF4IujAoOPWHrSbLRcH/rOrc1sVNQ2v93kGiSdJSU1O9Rx55xHv77bddUK1t/ImxEi28LqgCf50j6iEk4cNrFVSol0eih63m9XsfP368GxaseqLhRo8e7XpSaEmWcwYoSsQP8RP0+EGIIRKH+CH+iCGAoyOGiA/iB+KH40H8EH/ED4iGxEY+Puj6IlWWWBlt1ZzTsDG/BqFmp9ewTw0rU9ZeGe9E1iaMNulSnTp1QhOM6V9N8qNhfeHBj7LKuqjlHHIWL7oY62KlL3rR8dSxVg1LDUnVUL6BAweGttexVg1OHXsFFqqXl0ga2qmJ25QJ1he+JlFS7UcNsVXvCNX2U+CmYcT6stUFTtsqg1ylShVXizFRon3Bq8dBo0aNvAcffDBivQJordfvQ0GoH4Amy0Vi3rx5LhhVbyZ9XnP2hFBPp7S0NFdzMVna7H/m1LNGAYU/JFXBjz4T/mR1PgUV+mMmkT1rwo+dvlM0AZo+w2q7ArVOnTq5XliLFy9222i9Pq9+YJ1zH8D/a+/eg20q/ziOP0L8ocn0h+SSMhPK7ZBxqXFXqJhiUEIXl9Ao5daEkpmiiBqNLnRwuriVojRulW4aTERXcmsSoQvKUNT+zef7+609ex+HH9prr2cv79eMOHvvo22ftZ71WfM83+8TN+SH7Mn1/CBkiOivB+SH7CFDACdHhsgO8gP5IRPID9lDfsCJMLFxChvoaNBXSZlmh7UaQid7t27dbOZSFxPNDGqgVfDQhka+WL16deLee++1YJF6EgfBQisjiurrF8XJroCjfn0a9MeMGWODVHBBU8BZsmSJ9SVU/9CAHtf3+dITUj97Dfh33313YuTIkWm9/FQaPGXKFAsW+fn5iZdffjnRtGlT+xlEWYaY+rOeMWNGYsSIEfb+1Y+wb9++Fj5nz56dfI1KV3WxUHmojvkWLVqklYRGae3atXaM9O/f34J/yZIl7fjfsWNH2uu0+kbndFCG60Oo0Oogla5qLFFPTh0fOje1CaDGGx0nCtjqJap/Y5QbdaX2kNXxorJPHQtNmjRJtGzZMrF7924rK2/Xrp3d0KhcXkGvdu3ayZsVX/vQAplEfsiOOOQHIUNEh/yQ/fctZAjgxMgQ4SM/kB/+LfJD9t+3kB9QGBMbJ6ELgWbsH3nkkeRmVzp5NMOt0kPN/ukEEl0Yop7BTKWST81o65c2jCp8EdEgXK5cORsEoio/LCq8qDxP4UKrTjS7nUrhQisQtELCVwoWDRs2TFSpUsUuzql0odB7D8r7NDvuS8mwNulSibB6iKr/o1aiqBRRoUIXBV2sCwoKLERo8y6FOV3cVCravn37qN9+YsuWLYmHHnoorWR46tSp1sdSq2sKh4vUElEfyoe1OkhBeuPGjXbcKEyoF2fQU1eBWuONfg5aieMDhR6NIUG5pwKGQrPOU9m8ebMFJoXriRMnJgOFTzcCQFjID+GKY34QMkT2kR+iQYYATowMER7yA/khU8gP0SA/oChMbJyEVkfMmzfPBi2VxdWrV896E8qrr75qJ796tRUetKLujxfQKgnNDOvCoBO88Gs/+eQTuyBEWY6lkll9xjJ37ly74Op9K7T16dPnuNdrFlafe+ELtk8UMIOy4cJ9N1XqWrdu3WRvSB+o5FAlrFpdE/wctNpAj+vno43F8vLyLGhoBjx477o46N+nEuKow79WqWijsaCUOPXCV7FiRVu9opuCQNSz9an//549e1p5Z9A3V6sPgmM/dRO7qDdGC8YJ/a73pfetHrOiFU4K/Vr1JOoxWlR4i3pjNyBbyA/hi2N+EDJE9pAfsocMAZw6MkS4yA9+ID9kF/kBccbExv8RbHD10ksvWZmTSj9FpXGaOdasuAaDKKWGAq18OHToUNoKhPLlyyeGDx+e2L59e5HfU9TX2aDyQZUUqk/i4MGDLTCoFFEDlsKFLmyjRo0qclMpXzZcOhHNfKvsTSWJqZt5afVNmzZtvNqkS591s2bN7M/z58+3i4NWGwRWrVplx4cu4MGFzofSz1RauaELssopv/jii7Tn1FNUq3C06smni5r65ir4KBQpMGv1jMomdYwEn7M21ku9aYkqEKX+f7WJoQKlbgJ0vCh8lilTxj5n0WesY2rOnDlefd5AtpEfwhPn/CBkiOwhP4SPDAGcPjJEOMgP5IdMIT+Ej/yAU8XExikaO3asbdIVzACqvEz9CqMeXFPDgErJNJutC4RKVTVQiU52zRqrTMuHlR2pfvvtt0SjRo0sVAwYMCAtzGmTnxIlShQZLnKBLnY6ZqpWrWrh4q677rK+ooVXUERNvSzVO1G9W1MvDrJgwYLEkCFD0vpBRr3a4GSrVLSqQxfmwpu56VhKXTHkQ5n2BRdcYJ+vSoPVL1dlq9rgLRhTdHPQsWNHK6H0JVAMGjTIVs2o5F39TxWEtLpp2rRpydfoudatWx9Xyg2crcgP4YhzfhAyRPaQH8JDhgD+HTJE5pEf/EB+yC7yA+KMiY3TuECoV6RmZHXCaAOdKDdcKkylZOo1pxlW9ZTTjLf6EKYGi4svvth65AU9OX2gQbRVq1Z2QVA/RW1aFFApmS4I6v933333JXKRVk1oM6bKlStb/0WfQl3q7Lf6EgYrVlI//7Zt21rpc9QXttM5T7UBlkopfeoFmUpls+rHqRVMopUFOkbUF1Wfeeo5rce3bt2a8IFK4RV03n///WT41w2MVowpSOiGS2OLbmwaN27MSgngf8gP4Yh7fhAyRPaQH8JFhgDODBki88gPfiA/ZA/5AXHHxMZpUDmcNtFRf8XCM7JR2rRpU6JOnTqJFStWJDcDUuhJnfWW8ePHW69L3y4Q6t+nwej666+3jcRUcptKs67aVGrv3r2JXKTZcYUmn9+/yvkU4HSx00Xjvffes/es4yq4OPh23JwsXOgirTJjBSafBP04tTmdyp9FJZVakaK+pwrZCtFa7aRN0XxZWaNzsHr16lbCnHpToo3q9LhCszY1VJjQvy9Y9cEmXcB/kR/CEff8IGSI7CE/hIMMAfw7ZIjMIz/4gfwQPvIDzgZMbJymYNMa38KOVkKIVkqolE99LeXgwYNpJVpFbfDlC80MK1xoNUpBQYE9ppnl2267zWZq49An1Vca/LUZncqF9Uulfh06dMjZi8OaNWsSzZs3T+zatSvhm6Afp1YJ6aIsCm4zZ860cmGtNlC4iDIUFe53qx6c1apVsw3Sdu7cmfacxhK9d40zCxcuTB4rrJYA0pEfwhPn/CBkiOwhP/x7ZAgg88gQ4SA/RIv8kB3kB8RdMf3HIWfox1WsWLG0P//yyy+uS5cu7qqrrnJPP/20e/LJJ12/fv3sNevXr3cPPvigGzNmjGvUqJF9jwR/h2+2b9/uhgwZ4r777jtXunRp+33p0qX23hG+ffv2uf3797tSpUq5ypUr23Fy7NgxV6JECZdrjhw5YseQjzZu3Oh69uzpGjZs6AYNGuTq1KnjfLRt2zZXtWpV988//7iPPvrIde/e3eXl5bnFixfb80ePHnUlS5Y87vv+/vtvV7x48QjeMYATIT8gbHHJEOSHzCBDAPER5wxBfoge+SF85AfEGRMbOUQn9jnnnJP8OggVBw4ccL1793aLFi2yQUqhIhhYO3fubCf9ggUL0r7XZz/++KOFiZ07d7pu3bq56tWrR/2WzlqFjzlkjgJ/nz59XP369d3gwYNdzZo1vfp5L1++3LVt29bOxWuuucYeW7lypZ2TTZo0cW+++aY9RoAA/Ed+QBTIEGdPfhAyBBBPZ0OGID/4hfwQDvID4oqJjRxcJTFp0iT3+eefu59++snCRIcOHdzPP/9sv5ctW9ZmYStVqmQnvR5ft26dBQsuEIB/4aJ///62IuHhhx92NWrUiOy9pI4PL7zwgvvrr7/cPffc4ypWrOimT59uASMIFjfffLOtztLNCgC/kR+A+PEpPwgZAognMgQQL+QHxBFXmBygkz0IFKNGjXKPPvqolbidd955NijpxD/33HPtBG/QoIFbtmyZzXRqkNLApUChUj4CBeCXevXquWeeecbt3r3bnX/++ZG+l2B8GDlypBs9erSNL+PHj3e1a9e2MvMlS5bY8y1atHBz5861m5YHHngg0vcM4OTID0A8+ZQfhAwBxA8ZAogf8gPiiIqNHKLVEY899pid4E2bNrXH5syZ48aNG2dfa4BSSZZCiPoRBkEkF/sTAmcTX/px7tq1y7Vs2dKCRa9eveyxP/74ww0cONDKzOfNm+euvfZae1w3LAocjC2A/8gPQDz5kh+EDAHEExkCiB/yA+KE6fMcMXv2bFehQgW3cOHCtI1yVI41bNgw9+KLL7oNGzZYnzk9n7q5Fyc94DdfQsWff/7p9u7d6y688EL7WjcoZcqUsZ652shNPTnfffdde65u3bo2tuhGBoC/yA9AfPmSH4QMAcQPGQKIJ/ID4oSJDU/pZE7VrFkz1717d/fDDz/YSS9Hjx6133v06OEuuugit2rVquP+niBcAMDJxhi59NJLXV5enpsyZYoFDJWG6sZEfXOrVatmAahTp05u+/btyefYtAvwC/kBQNjIEEA8kSEAhIn8gDAwseGp1A10Pv74Y9s8R30tO3bs6O68807buCtYNaHNuXRyqx8dAJzOJl0KCDt27Eg+169fP7dv3z43dOjQtBsTvT4/P99WSWiFlsrLuWkB/EN+ABAmMgQQX2QIAGEhPyAs1Ad6SiHhwIEDdmJPnz7dHqtSpYr1sNRmXa1atbINu1SutXjxYgsUKgkFgP8nCBTaeOutt95y33//vfWzHDBggOvWrZv10p01a5arVauW9bv89NNPLUQ0btzYXXbZZbZii/JywE/kBwBhIkMA8UWGABAW8gPCQsWGh2VZChSahVTpVYMGDZJln1KpUiX33HPPuTZt2rixY8fayX7TTTe5NWvW2EmuEx8AipLai1Kb/unXmDFj3OTJk92KFSvcqFGj3GeffeYGDx7snn32WQsR2sxL49Dq1attjDl8+LCVnWus0VgFIHrkBwBhI0MA8USGABAm8gPCVizBUeGdTZs2uerVq9uf77jjDvf777+7+fPnp5VcqXRr+PDh7sMPP3QffPCBq1GjhvWjK1WqVITvHICPxo8f77p27eqqVq1qX2vMeOedd6xnZe/eve0x3ZgMHDjQNggcMWKEu/rqq9P+jiNHjljomDlzppWma8wB4BfyA4BMI0MAZwcyBIBMIj8gW6jY8Mzzzz9vJ7NO9iZNmthGXb/++qvNZKrn3KFDh5Ib7EydOtVmMVu3bu2+/PJLAgWA42zevNn64aqMXDSmXHfddW7ChAlu9+7dydc1bNjQxhStjpg0aZKFjsDWrVvd6NGj3dKlS93y5csJFICHyA8AMo0MAZwdyBAAMon8gGyiYsOjDXRk27Zttuph3bp1tmpi7dq1diI3atTIff3117aBl3pa9u3b13Xv3t3t3LnT3XLLLW7Pnj3uq6++Sm7mBQCBoLT87bfftpsVrbbq3LmzhYPHH3/c5eXlJV+rMadTp06uR48ebty4ccnHN2zY4MqVK2cloACiR34AkA1kCCB+yBAAwkZ+QLYwseFJoFBplUKDAkX79u1du3bt7HGVW3Xs2NFmKLVaQhvq6OR+4oknkgFCs5vqW1e5cuVI/z0A/KWxQzcn2ohLqyF006JNurTa6v7773e1a9dOvvabb76xFVvFixc/7sYHQPTIDwCyiQwBxAcZAkC2kB+QDUxseEB9KgsKCpKrH7Rxzg033OCeeuop27SrefPm7pVXXnFXXnll2vdp4xxtpAMAp0KrsPr16+fq1q3rJk6caDcyWm2lYDFkyBBXq1attNfrZkXBAoCfyA8AsoUMAcQLGQJANpAfEDamwCK2ZMkS99prr7lFixbZDGaXLl1s9YN6zalsSyWfpUuXdsuWLUt+TzAXRaAAcDrq16/vpk2bZuFi6NCh7oorrnCzZ892K1eutE25VIaeikAB+Iv8ACCbyBBAfJAhAGQL+QFhY2IjYgoQKt9UiFC46N27t5s8ebK79dZb3cGDB60MtGzZslYeGlDYAIAzUa9ePZefn2/BYtiwYa5mzZr2tUo9L7nkkqjfHoBTRH4AkG1kCCAeyBAAson8gDDRiipiKv/USgiFiK5du7oJEya4/v3723NvvPGG27Jli7v88sut3yWrIwBkyvr1620DwCpVqrhZs2a5MmXK2OP0swRyA/kBQFTIEEBuI0MAiAL5AWFgYiNi3377rfWaO3r0qM1Y3n777fb44cOH3Y033ugqVKjgZsyYYY/Raw5AJq1Zs8ZNnTo1uVoCQO4gPwCIEhkCyF1kCABRIT8g05jY8IDKP3v16uUGDRrk2rdvb/0rx40b5/bs2WObeLFKAkBYNN6otJxVEkDuIT8AiBIZAshdZAgAUSE/IJOY2PCAVkHMmzfPes1J+fLlbZXE66+/7kqWLMkqCQBZCRYAcgv5AUDUyBBAbiJDAIgS+QGZwsSGR/bt2+f279/vSpUqZZt56SQ/duwYqyUAAMAJkR8AAMCZIEMAAHIZExseoywLAACcLvIDAAA4E2QIAEAuYWIDAAAAAAAAAADkDKbiAQAAAAAAAABAzmBiAwAAAAAAAAAA5AwmNgAAAAAAAAAAQM5gYgMAAAAAAAAAAOQMJjYAAAAAAAAAAEDOYGIDAAAAAAAAAADkDCY2AAAAAAAAAABAzmBiAwAAAAAAAAAA5AwmNgAAAAAAAAAAQM5gYgMAAAAAAAAAAOQMJjYAAAAAAAAAAIDLFf8BBy8NrbKCkLgAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 1600x500 with 3 Axes>"
       ]
@@ -1059,7 +1101,16 @@
   {
    "cell_type": "markdown",
    "id": "pymc11_phi_viz_interp",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004239,
+     "end_time": "2026-08-29T08:13:48.932261",
+     "exception": false,
+     "start_time": "2026-08-29T08:13:48.928022",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Interprétation — la distribution Phi révèle la contamination inter-sujets.**\n",
     "\n",
@@ -1089,10 +1140,10 @@
    "id": "42ca454f",
    "metadata": {
     "papermill": {
-     "duration": 0.008203,
-     "end_time": "2026-06-03T00:07:42.304178+00:00",
+     "duration": 0.004171,
+     "end_time": "2026-08-29T08:13:48.940385",
      "exception": false,
-     "start_time": "2026-06-03T00:07:42.295975+00:00",
+     "start_time": "2026-08-29T08:13:48.936214",
      "status": "completed"
     },
     "tags": []
@@ -1105,20 +1156,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "c5d6e7f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:53:12.938999Z",
-     "iopub.status.busy": "2026-07-03T15:53:12.938999Z",
-     "iopub.status.idle": "2026-07-03T15:53:13.034019Z",
-     "shell.execute_reply": "2026-07-03T15:53:13.034019Z"
+     "iopub.execute_input": "2026-08-29T08:13:48.949343Z",
+     "iopub.status.busy": "2026-08-29T08:13:48.949049Z",
+     "iopub.status.idle": "2026-08-29T08:13:49.034978Z",
+     "shell.execute_reply": "2026-08-29T08:13:49.034456Z"
     },
     "papermill": {
-     "duration": 0.244613,
-     "end_time": "2026-06-03T00:07:42.559309+00:00",
+     "duration": 0.091584,
+     "end_time": "2026-08-29T08:13:49.035839",
      "exception": false,
-     "start_time": "2026-06-03T00:07:42.314696+00:00",
+     "start_time": "2026-08-29T08:13:48.944255",
      "status": "completed"
     },
     "tags": []
@@ -1126,7 +1177,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUvFJREFUeJzt3QmcTfX/+PH3rMZYxm5sWbMzZAtJRUiUpS9ZsoRSKUsUhSEhKkvZ+SJFtPgKyZIlirJLiZK1sqaxDYOZ+3+8P7//ud07C3Nn5sx2X8/H42Tuueee87nnfO7tvs/7s/g4HA6HAAAAAACAFOeb8rsEAAAAAAAE3QAAAAAA2IhMNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEgAyhRooR069ZNMrIRI0aIj4+PnD9/Pq2LkiFt2rTJnD/9N7M6duyYeY/z58+X9OiBBx4wCzhPAOAJgm4AGY7+INcf5tYSFBQkZcuWlT59+siZM2cko9q6dasJTCMiIiQjBYGJWeyyaNEimTRpkm37B1LKmDFjZNmyZZxQL5fRvucBpAz/FNoPAKS6N954Q0qWLCnXr1+Xb7/9VqZPny6rVq2Sn376SYKDgzPkj7GRI0eajHauXLncnjt06JD4+qav+6QVKlSQDz/80G3dkCFDJHv27PL666+nShk06Nbr3a9fv1Q5Hrzb2rVrkxV0P/HEE9KqVasULRMyz/c8gMyLoBtAhvXII49IzZo1zd89e/aUvHnzyoQJE+SLL76QDh06xPuaq1evSrZs2SQ9SUyZsmTJIulNwYIFpXPnzm7r3nrrLcmXL1+c9UBmEBgYKN7E4XCYm5pZs2ZN66IAQIaWvtImAJAMDz30kPn36NGj5l/NJGjW9ffff5fmzZtLjhw5pFOnTs5A9+WXX5ZixYqZgLZcuXLyzjvvmB+ZrrRptDZbX7hwodlGm7LXqFFDNm/eHOf4e/bsMTcCcubMaY7bqFEj+f777+NtGv/NN9/I888/LwUKFJCiRYua5oaDBg0y22j23mqWrX1cE+rTfeTIEfnPf/4jefLkMZn9e++9V7788st4m4B/8sknMnr0aHMsfQ9atsOHD7tt+9tvv0nbtm0lNDTUbKPbPvnkk3Lx4kVJSdqs0sryhISESPfu3SUyMjLOdh999JE51/qDX9+jluXkyZPO57Vvrb7f48ePO8+Xnid148YNGT58uHm9HkNvajRo0EA2btyYqDLqez548GCi3rses0WLFuZc600gLW+VKlWcfa+XLl1qHlt1R+tJbHoszYLq+9TtdD/Lly+/47G3bNli6sBdd91l6rHW5/79+8u1a9fctrM+C3/++afJtOrf+fPnl4EDB0p0dLTbtn///bc89dRTph7rNeratavs27cv3r7WSS23az3Q62MdJ6Emt8k5zuLFi81518+/vie9FpMnT44z1kBs1mfV+gwm1Kc7KipKwsPDpUyZMs5r8Morr5j1Ft2Pfud88MEHzrpqfZ4vX75sWmpoPdLX63fCww8/LLt3777t+7LKreemXbt25r3pjce+ffuaQNnVvHnzzPej7luPUbFiRdMyKKG6vGbNGmddnjlz5m3LMWvWLCldurTZtnbt2qZOxufs2bPSo0cPc7NOr2FYWJg5H7HFxMSY62N9ZrSeNmvWTHbu3HnHfv+6Xs9L7HP066+/mhuBWtd0f8OGDTPf9fp98vjjj5tzp9977777bpx9Jub6uv6/QrsQVK5c2WxbqVIlWb16tVt5bvc9DyDzItMNINPQ4FrpD0/LrVu3pGnTpnLfffeZoFqDU/2x9dhjj5kATH8EVqtWzfzI1B9DGpRMnDjRbb8aIC9ZskReeukl80Nq2rRp5kfg9u3bzY8r9fPPP5ugTn+86Q+ygIAA82NVf6Dr6+vUqeO2Tw249cefBob6Y1yDdf1h+PHHH5vja7ZY6Tbx0b7r9erVM8Gqlkvfs/6A1ff12WefSevWreNkoLV5ugZZGkiOHz/e3ID44YcfnEGqnif9Ifniiy+aH6B6LlauXGkCIf2xmlI0QNAfnGPHjjWBxZw5c0wwMG7cOOc2eoNAfxjrttqK4dy5c/L+++/L/fffb4JWDdK0Cbu+lz/++MN5zTSYVJcuXTL71RYPvXr1MoHNf//7X/Me9brpNb+d//3vf+ZmgAYriRnATm9gdOzYUZ599lnz417rWsuWLWXGjBny2muvmeut9D3re3LtLqB1p379+lKkSBEZPHiwuUGgN0k0OP7888/jXEtXn376qakDzz33nKkD+t70POk50edcaXCt71/ropbv66+/NkGGBkz6eivg0XLrfnRd+fLlTcsRDYhjS0659TOowY52C+ndu7fpqqDnPKWPs27dOlMH9CaTVb9++eUX+e6770xwmlx6vvQzp+/jmWeeMe9j//79pj7q59nqw63dMLQea1Cq2yk970rfv35mNWDTYFhveuj+tJz33HPPHcug9UmDZa1bepPvvffek3/++UcWLFjg3EYDbA0Ataz+/v6yYsUKUye1/C+88ILb/rRu6jnTuqyfHb3ZmBD9TOl2+l2kNw70RqAeQ2+OaHBq0ZtA+l2onxN9n/r51/qpny39fnG9FvqdrAG1fifqOdPvcA3k9b1ZLZs81b59e3Nt9HtQb9S9+eabpoz6Ha03I7Ru6I1V/X6sVauW+Z7x5PpadDu9yabnVm/y6LXQG5knTpwwn882bdp49D0PIBNxAEAGM2/ePE1HO77++mvHuXPnHCdPnnQsXrzYkTdvXkfWrFkdf/zxh9mua9euZrvBgwe7vX7ZsmVm/Ztvvum2/oknnnD4+Pg4Dh8+7Fyn2+myc+dO57rjx487goKCHK1bt3aua9WqlSMwMNDx+++/O9f99ddfjhw5cjjuv//+OGW/7777HLdu3XI7/ttvv22eO3r0aJz3XLx4cfN+LP369TPbbtmyxbnu8uXLjpIlSzpKlCjhiI6ONus2btxotqtQoYIjKirKue3kyZPN+v3795vHe/bsMY8//fRTR3JUqlTJ0bBhw3ifCw8PN8d4+umn3dbredRrZzl27JjDz8/PMXr0aLfttKz+/v5u6x999FFzbmLTc+v6ftU///zjKFiwYJzjx8e6TvrvnejxddutW7c6161Zs8as0/qo9cUyc+ZMs16vi6VRo0aOKlWqOK5fv+5cFxMT46hXr57j7rvvdq6zrqXrayMjI+OUZ+zYsaYeux7X+iy88cYbbttWr17dUaNGDefjzz//3Gw3adIk5zqtSw899FCc85HYcsfH+gyOHz/e7Zo1aNAgRY/Tt29fR86cOeN81uKrlwnVAdfPo9Zt1/r94YcfOnx9fd0+h2rGjBnmtd99951zXbZs2dw+w5aQkBDHCy+8cNv3cbtyP/bYY27rn3/+ebN+3759t60nTZs2dZQqVSreurx69eo7Hv/GjRuOAgUKOKpVq+b2WZs1a5bZh+t50vqk6z766CO319etW9eRPXt2x6VLl8y6DRs2mO1eeumlOMfTa670eiT02dT1el5in6NnnnnGuU7rQtGiRc1n5K233nL7ftDPq+s18uT66mP9f4Dr/z/0Guj6999/P1Hf8wAyL5qXA8iwGjdubDIEmlHRpsea5dRsmWbEXFlZPIsOtubn52cyxK60ubn+dvrqq6/c1tetW9c0T7VoU17N0ml2XLOHuugAS5p5K1WqlHO7QoUKmeynZj808+pKM0hahqTS96BZM83gW/T9azZGmyoeOHDAbXvN2rr2R9WsvNLMlLIy2fqe4mvqnZI0s+dKy6LZPescaaZIM0yawdPpxaxFs+933313opqI67m13q/u68KFCyZjppmyOzXbVZqB07qQ2GnaNEOp9cRitWzQLJrWl9jrrfOu5dqwYYN5r5qNt96rng/NSmuTf21xkBDXvrbaYkJfq1lHLXt8zdjjO/dWWZQ2hdVWGlo/LZqRj50NTW65tf5qxtX1s6nXTFtZpORxtEWEnhfNeNtBs7Wa/dQWAa511erqkpi6qmXUFid//fVXksoQ+9pY51DPcXz1RFuHaBkbNmxorn3sLhSahdZzeyfa3FubjGudcv1usboMuNKy6OfXdawNrWf6HXzlyhXTGkhpywVtbq3NuWNLziwImjF3rWf6PaCfEc2qu14Hzeq7fh48vb76/ySrBYOqWrWqaf3kuk8A3onm5QAyrKlTp5qpwvTHu/YT1B9MsUf41ue0b7Ir7QNcuHBh0/zPlf64sp53pYFebHpcDU612bPSv+Nrhqn71KBP+w5q807XH7bJoWWM3WQ99nuwmr4r18BP5c6d2/yrzVCt8gwYMMAMRKfNLDUY02aVVj/IlHS7sugPVA2k9AdxfOfd+rGeGNrcXptPa5/Xmzdvpti5T8x7ss6ZaxNb1/XWedfmtvpetSm9LvHRwCb2jSSLNlvVLgrav9napyV2MGX1j4197l1fp/VGbxbFHv1f+7O6Sm65reNY3QEssT9DyT2ONvPVpujaVFm3adKkiQngtXtIStC6qs3AE2oerGW7E+3qoc3qta7ozT0df6JLly5uN/BuJ/bnRIM+/R507Seszek1kN22bVucm2paT1w/44n9fFjfk7GPr5/P2GXXbXW72N/Psb9ztYuQfjdr02+7P5/6ebCad7uu1xs6Sb2+sY8T32cMgHci6AaQYWmm9059/LQPdnqbakul9mjACWXVXQeO0wBVs1Tah1cz95qFsvqJxr5xYWdZ9CaFZrW0xUF828YO1OKjg7Dpe9HWB9pXX/uM6770/Vh9/1NSQu8pMe9VaV/ShLKLsQNei7aw0AG3NBv86quvmmyc9nfWzK++d2vfdypLUiSn3Kl5HL3ue/fuNS04tD7pov30Nai1BvFKKIMae4C5hMqnA37pzar4xL7pEh+9CaA3ubSVjn7u3n77bdPHWFt86M0CT8V+P1rftU+71g8tp5ZJM9OafdZ+xbHrSXofqTwp1yu+up+Y70RPr29i9gnAOxF0A/A6xYsXN4NIaXNV12y3ZkSt511ptiM2HQxHs4FWBkT/1gGIYtN9atCfmB/fnjSf1DImdLz43kNi6Q9MXYYOHWrmk9UBrHQwMB14KLVopk5/pGrGTVsUJOWc6cBUmm3TwMV1m/iaraYlKyOo2UFtmuoJHdBJ66EGjxpEWpLTlFrrjTaZ1Wyoa7Y79kj3ySm3dZz169ebpsWuN1Fi1+nkHkdpgKmDw+miQZRmv3UALc2ca8ButbTQAb1c502O3eIlobqqI7trUHunz+/tntesv5ZLF82e6gBqOphgYoJu/X5yzU7rtdL3aY3kr4Om6QCJ2hrCNROb2JH8E2J9x+jxrebWSluV6AwSOjq567Y//vijKZfrTdDY31d6PvUGid5ISijb7Xq9XCXmennKk+ubWCm1HwAZS/pL/wCAzbT5pmZFpkyZ4rZesz76gyj2D11tkunaD1ibims2WJuqamZDF/1b17k26dQRxhctWmT6XWuz6Tux5upOaNqk2O9BR5jWslm076pO36M/trWPsSe0P7X2eXalwbf+QI49NY7ddIRfPacjR46MkyHSx67NP/WcxTetl5Vxcn299pt1PV8pNWVYcmgmVkd11iDw1KlTcZ63ui/EJ773qH+7ToflKc0ma9A0e/Zs5zoNlLQrR0qV26q/Wt9cp63Sz6SOvJ6Sx3GtK0rrs/azVVa9tvrguk4DaE3vlZgstbYscD1friN2635c62rsz7a+59h1TN+zNrFO7Ocu9rWxzqH1PRZfPdFjasY/ObSVkd501JtyOvuBRUcej/0+9XqfPn3azAJh0euvZdWbLtq/XOlI31pO/ezHZpVfv0u1WXjsaRt1VomU5sn1TSxPvucBZB5kugF4Hc14Pfjgg2bKKQ2SNSOjzTo1aNZpb1wHwlHaN1qDEdcpw5TrD0PNBGuGUQNszVZpX3INFPSHs/bZTAxrsDYtlw4Mp9k9Lav1I82VTp2k087oD2stl2aFNEjQDJMORuRpk3odrEqn8tE5nzW7rD+IdZoj/cGuP4RTk55/PZ9Dhgwx10ebiGuLBH1v2gRXB4vT5sbWOdMf8tofXaf60R/wes50rmHNcut0Uo8++qh5rQYHejNCs6t34umUYcmhQZPWG73JoQOYaXZXb9joDQKd+kszbfHR5sJ6rvRcaGCgwYhe++T0H9Vzrd02dFBBzZjqMTRDqpnH2Fm6pJZb6TXSVhRaj/Ua63XR6xXfTY7kHEcH0NKyayZWu0hoNlQDPZ0yzupPrDfMNAOsg2ppVwSt83PnzjUBpfaZvx2dz1z7jOtgYpo51vekgbTesNH11nzXVl3VFjbaVFmDas1Oax92LZfOQa7fQ1p/dZsdO3bEO2d0fLRu6/gL2k9dz4l2rdABHK1Ms74/K9uv03tp/dcgUoP7+G5kJJZ+P+nnVPep51en5dKy6Gcmdp9u/czq96F+lnbt2mVuDGprFO1rPmnSJGeLI/1e1nOqU21pBl3fk9700SnD9Dn9jrKuq07/pf/q+dUAXFt9pDRPrm9iefI9DyATSevh0wHAU9ZUPjt27Ljtdjr1i07TEx+dXqt///6OwoULOwICAszUQzqVizUtjUWPo9P56FQ3uk2WLFnMNEuu0zZZdu/ebabh0SlwgoODHQ8++KDbNFKJKfuoUaMcRYoUMdPUuE4rE3vKMKXTk+k0Z7ly5TJTmNWuXduxcuVKt22saaZiTwUWe9qdI0eOmKm0SpcubfaVJ08eU36dli2lpwzTad7iOyexp9DR6at0ajW9hrqUL1/eXItDhw45t7ly5YqjY8eO5hzoPqzpw/Q6jhkzxjy2rpmeGz2H8U0xltwpw3TqstisuhPfede6FvtadunSxREaGmrqo9aBFi1aOD777LPbThl24MABR+PGjU2dy5cvn6NXr17OaYpcy57QZyG+6bL0+ug51enudDqrbt26mamRdDudms/Tcifk77//djz11FNmSi89jv5tTV0X+7wn9Tj6fJMmTczUVjqd01133eV49tlnHadOnXLbbteuXY46deo4t5kwYUKipgyzpr4aN26cqfta13Lnzm2mYRs5cqTj4sWLzu0OHjxopg/Uaal0v3pNdKqtQYMGOcLCwsz51mukf0+bNu2O58+6dloH9HtAX6/H7tOnj+PatWtu2y5fvtxRtWpV89nWKQW1vHPnzo3z/hKqy7ejZdWpCvW916xZ07F58+Z4z9OZM2cc3bt3N/VUz7NOAxff50un9NLPh37edbv8+fM7HnnkEXONXKdA69Gjh6k3+r7btWvnOHv2bIJThsX+zkno86Bl1uuYlOsb3+c9oe/uhL7nAWRePvqftA78ASC90syeTskTuyk64E2WLVtmWg3o9Hea7fNWOuCZtnbRbHRaGzFihGlto03sY4/CDQBIX+jTDQAA3PqqurL6WmvzdR3gy5tpc2wCXACAp+jTDQAAnF588UUTeNetW9eMSaB9rXUk+zFjxqT76aTsou9fz4NOv6XTswEA4AmCbgAA4KSDYukgXitXrpTr16+babU0020NYuWNdOAxneNbB1rUAfYAAPAEfboBAAAAALAJfboBAAAAALAJQTcAAAAAADbxuj7dMTEx8tdff0mOHDnMVEAAAAAAAHhKZ9++fPmyFC5cWHx9E85ne13QrQF3sWLF0roYAAAAAIBM4OTJk1K0aNEEn/e6oFsz3NaJ0TlHAQAAAADw1KVLl0xC14oxE+J1QbfVpFwDboJuAAAAAEBy3KnbMgOpAQAAAABgE4JuAAAAAABsQtANAAAAAIBNvK5PNwAAAACkR9HR0XLz5s20Lgb+v4CAAPHz85PkIugGAAAAgDSe7/n06dMSERHBdUhncuXKJaGhoXccLO12CLoBAAAAIA1ZAXeBAgUkODg4WQEeUu5GSGRkpJw9e9Y8LlSoUJL3RdANAAAAAGnYpNwKuPPmzct1SEeyZs1q/tXAW69PUpuaM5AaAAAAAKQRqw+3ZriR/ljXJTl97Qm6AQAAACCN0aQ8814Xgm4AAAAAAGxC0A0AAAAASHXz5883o4NndgykBgAAAADp0OmWDVL1eKErtnj8mnPnzsnw4cPlyy+/lDNnzkju3LklLCzMrKtfv/5tX9u+fXtp3ry5ZHZpmunevHmztGzZUgoXLmzayi9btuyOr9m0aZPcc889kiVLFilTpoy5OwIAAAAASH1t27aVPXv2yAcffCC//vqrLF++XB544AH5+++/EzU6eIECBSSzS9Og++rVq+YuyNSpUxO1/dGjR+XRRx+VBx98UPbu3Sv9+vWTnj17ypo1a2wvKwAAAADgXzrV2ZYtW2TcuHEmRitevLjUrl1bhgwZIo899phzm2effVYKFiwoQUFBUrlyZVm5cmWCzcu/+OILk2TVbUuVKiUjR46UW7duOZ/XZO2cOXOkdevWZmTxu+++2wT6rn7++Wdp0aKF5MyZU3LkyCENGjSQ33//3fm8vr5ChQrmGOXLl5dp06Zl3ubljzzyiFkSa8aMGVKyZEl59913zWM9Ud9++61MnDhRmjZtamNJAQAAAACusmfPbhZtsXzvvfea1siuYmJiTLx3+fJl+eijj6R06dJy4MCBBOe71gC+S5cu8t577zkD5WeeecY8Fx4e7txOA/Hx48fL22+/Le+//7506tRJjh8/Lnny5JE///xT7r//fpNt37Bhgwm8v/vuO2fgvnDhQtP0fcqUKVK9enWTpe/Vq5dky5ZNunbtassFzlB9urdt2yaNGzd2W6fBtma8AQAAAACpx9/f32SrNWjVBKlmqBs2bChPPvmkVK1aVb7++mvZvn27/PLLL1K2bFnzGs1eJ0SD6cGDBzuDX9121KhR8sorr7gF3d26dZMOHTqYv8eMGWOCdD1Os2bNTCvqkJAQWbx4sQQEBJhtrGMr3Y8mcdu0aWMea1JXbwTMnDmToFudPn3aNEtwpY8vXbok165dM30CYouKijKLRbcFAAAAAKRMn27tAqxZ6u+//16++uork4XWJtxnz56VokWLugW9t7Nv3z6TlR49erRzXXR0tFy/fl0iIyNNc3KlAb1FM9SazdZjKe2GrFlyK+CO3b1Zs+c9evQwNwosmgXXQN0uGSrTnRRjx441d0wyolozD6d1EeChHc+W4ZzdAfU646Fe3x51OuOhTt8Z9TrjoV5n3DpdMChaBlS4KdEXosQ3VpyYJ5XLcuDc9SS/tki1BtJWl96DZHj/5+S1YcOl+/P95GaMI8H9/nn5psQ4/j3u5StX5IVBQ6Xxo63k7rzuTdW1/7UldkCt/by1KbuKLxFruXLlivl39uzZUqdOHbfnEmry7nXzdIeGhpph6F3pY72zkdDJ1U78Fy9edC4nT55MpdICAAAAgPcpVba8XIuMlLIVq8iZv/6UY7//lqjXVahSzWxbvFRpM1OV6+Lrm7jQVbPgmnW/efNmnOe0lbTOnHXkyJE4+9dm5nbJUJnuunXryqpVq9zWrVu3zqxPiHbmj92hHwAAAACQPBEX/pb+PTtJmw5dpWzFypItew75ed8umTtlojzUrIXUqtdAatS9T/o93UFeGTlO7ipZWo4ePqSpaWnwUJM4+3vu5dfkhc5tpFCRYvJc1ydNoK1Nzn/66Sd58803E1WmPn36mMHVtF+5JmC12bg2e9dR1cuVK2daQb/00ktmvfYB167IO3fulH/++UcGDBiQ+YJuTe8fPnzYbUowbYOvo87ddddd5iTp6HMLFiwwz/fu3duMMqcd6Z9++mkzGt0nn3xiJmIHAAAAAKSe4GzZpeo9tWTBzPfl5LEjcuvWTQktXFSeeKq7PNP3FbPNpLkfyzsjhsig3l3lWuRVE3j3Hzoq3v3d99DDMvWjpTL93TEyd8q7phm5Tuml00QnVt68eU2cOGjQIDOomzYbr1atmtSvX988r/vSvuE68rluo33Cq1SpYuvg3D4Oh8MhaWTTpk1mPrfYdLQ6HQVPR6U7duyY2c71Nf379zcjzGmn/GHDhpntEksHUtO7GtrUXJulp2fpue8J4kd/qjujXmc81Ovbo05nPNTpO6NeZzzU64zepztKChQtLr4BtNC1VMz/bx/utKSDuGlyWJufu/Yr9yS2TNNMt86ddruYXwPv+F6jc6kBAAAAAJDeZaiB1AAAAAAAyEgIugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE387doxAAAAACDpOpx4LVVP38d3jfH4NRfOn5Mp40bJN19/JX+fOys5Q3JLuUpV5LmXh8g9deqJnUqUKCH9+vUzS3pG0A0AAAAASJJ+T3eQmzdvyJj350ix4iXk/Lmz8sOWTRLxzwXbzuiNGzckMDBQMgqCbgAAAACAxy5djJBd338n85etlVr1Gph1hYsVl6r31HJuU6lAVhk2brJsXPOl7Ni6WfIXCJUB4aOlacs2zm1+PfCTjB06UPbt/EGCsgbLwy1aybxpkyV79uzm+W7duklERITUqlVLpk6dKlmyZJHixYvL8ePHpX///mZRDocjXV5F+nQDAAAAADwWnC27WdZ/tVxuREUluN37494wgfTSjdvl0SeelEHPdJHffz1onou8elWead9ScobkkiVrvpUJcxbK999skD59+rjtY/369XLo0CFZt26drFy5UpYuXSpFixaVN954Q06dOmWW9IqgGwAAAADgMX9/fxn93iz5YslCuffuUOn06IMyafRwOfTzfrftmrZsI0907i4lSt8tLw0Ol0rV7pGFc6ab575cukSioqJk7JT/yt0VKsm9DR6Q19+aKB9++KGcOXPGuY9s2bLJnDlzpFKlSmbJkyeP+Pn5SY4cOSQ0NNQs6RVBNwAAAAAgSZq0bC2bfjwiUxZ8Jvc91ER2fLdZ/tO4rvxv8YfObcJq1nF7jT4+8tv/ZbqP/HrQDLwWnC2b8/nqtetKTEyMyWxbqlSpkqH6cbsi6AYAAAAAJFmWoCCp90AjM2L5wlWbpNWTT8nU8aNS9IxmcwnKMxqCbgAAAABAiilVtrxci4x0Pt63a7vb8z/u3C6l7i7v3Fabo2vfbsue7dvE19dXypUrd9vjaOY7Ojo63V85gm4AAAAAgMciLvwt3ds0kxWffmwC5z+OH5M1yz+XuVMmykPNWji3W7tiqSxd9IEc+/03M6f3/j07pWOP3ua5Fm2fNKORv/ZiT/ntl5/lh2+/kTFDBshTTz0lBQsWvOM83Zs3b5Y///xTzp8/n26vIFOGAQAAAAA8piOX6/RgC2a+LyePHZFbt25KaOGi8sRT3eWZvq84t3th0FD56n+fyqhX+0r+gqHy9swPpEy5Cua5rMHBMmvJCjNlWPum9zmnDJsyZfIdj68jlz/77LNSunRpMxhbep0yjKAbAAAAANKhj+8aI+lZYJYs0n/oKLPcToHQQjL705UJPl+2YmWZt3S127rs2YOcf8+fPz/e1917772yb98+Se9oXg4AAAAAgE0IugEAAAAAsAnNywGkqhs1p3HGM5wJaV0AAACQQf189pp4OzLdAAAAAADYhEx3OkZGMCMiIwgAAADgX2S6AQAAAACwCUE3AAAAAAA2IegGAAAAAMAmBN0AAAAAANiEoBsAAAAAkGa2f7dZKhXIKpcuRtxx202bNomPj49ERNx52/SC0csBAAAAIB3quvSPVD3eB22KJul1586cllmTxsnmdavlzOm/JG++/FKucph0eaaP3Hv/g3d8fbVa98qm/UclR86QO25br149OXXqlISE3Hnb9IKgGwAAAACQJH+eOC6dWzwoOUJyycvhY6Rsxcpy6+ZN+XbjOnlzcD9ZuXXfHfcRGBgo+QuGJup4um1oaOK2TS9oXg4AAAAASJJRr/Y1zb0Xr94iTVq2lhKl75Yy5StKt+f6yqKvvjFBuTYd/2X/v8G3NiPXddqsPL7m5X+dPC4tW7aU3LlzS7Zs2aRSpUqyatWqeJuXz58/X3LlyiVr1qyRChUqSPbs2aVZs2YmG+5qzpw55vmgoCApX768TJs2LdWuOJluAAAAAIDHIv65IN9uWCt9XxspwdmyxXk+Z0guuXzxosf7fXNwfwmUW7J582YTdB84cMAE0wmJjIyUd955Rz788EPx9fWVzp07y8CBA2XhwoXmef13+PDhMmXKFKlevbrs2bNHevXqZfbdtWtXsRtBNwAAAADAYyeO/i4Oh0NKlimbomfv1B8npWP7J6RKlSrmcalSpW67/c2bN2XGjBlSunRp87hPnz7yxhtvOJ8PDw+Xd999V9q0aWMelyxZ0gTyM2fOJOgGAAAAAKRTDoctu+3U63kZ9cpLsnbtWmncuLG0bdtWqlatmuD2wcHBzoBbFSpUSM6ePWv+vnr1qvz+++/So0cPk9223Lp1K9UGY6NPNwAAAADAY3eVKmP6Vx89/GuC2/j4+vz/v/4N0HWgtdt5onN3OXLkiDz11FOyf/9+qVmzprz//vsJbh8QEOB+TB8fk4FXV65cMf/Onj1b9u7d61x++ukn+f777yU1EHQDAAAAADyWK3ceqf/gw/Lx3BkSefVqnOd1YLQ8efM7pxWzHPzpxzvuu1ixYtK7d29ZunSpvPzyyyZoToqCBQtK4cKFTRBfpkwZt0WbmacG+nQDAAAAAJJk6FuTpHOLh+TJZg2kzyvDpFylKqbp9rZv1suS+bNlxXd7JaxGbZnz3jtS5K4ScuH8OXnvrRG33efYoQOlc5uWUrZsWfnnn39k48aNZuTxpBo5cqS89NJLpjm5jmweFRUlO3fuNPseMGCA2I2gGwAAAACQJMVKlJTP1m+VmRPHydsjBpuMdp68+aRi2D0ybPx7ZptRk2fK8H69pd3D9aRE6bLy8vDR0qtdiwT3GRMdLS+88IL88ccfkjNnThMoT5w4MclXqGfPnqbf99tvvy2DBg0yo5brIG39+vWT1ODjsBq7e4lLly6ZOxwXL140FzA9C9tl/10XpKx9NSZwSu+Aep3xUK9vr9bMw6l0JZBSdjxbhpN5B9TrjId6nXHrdMGgaBlQIUoKFC0uvgFZ0ro46UbF/EGSHly/fl2OHj1qmqLrHN9JiS3p0w0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAANKIziVlppNyxHAN0qGYmORfF+bpBgAAAIA08vcNX7kY5ZDsf5+V4Fx5xcfPX8THx+uvx/XraXsKdGbtGzduyLlz58TX11cCAwOTvC+CbgAAAABII9EOH5n+W1Z5rEiUlIv8S/xpi2z4XQyQ9CA4OFjuuusuE3gnFUE3AAAAAKShiJu+8uGxIMnm75BgPweJbhH5rH3xNK+Tfn5+4u/vLz7JbHlA0A0AAAAAacwhPnLlli5pXZL0ISgoSDILGi8AAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAABk1qB76tSpUqJECQkKCpI6derI9u3bb7v9pEmTpFy5cpI1a1YpVqyY9O/fX65fv55q5QUAAAAAILH8JQ0tWbJEBgwYIDNmzDABtwbUTZs2lUOHDkmBAgXibL9o0SIZPHiwzJ07V+rVqye//vqrdOvWTXx8fGTChAmS2awZsSOtiwBPreCUAQAAAEgnmW4NlHv16iXdu3eXihUrmuA7ODjYBNXx2bp1q9SvX186duxosuNNmjSRDh063DE7DgAAAACAVwXdN27ckF27dknjxo3/LYyvr3m8bdu2eF+j2W19jRVkHzlyRFatWiXNmzdPtXIDAAAAAJDum5efP39eoqOjpWDBgm7r9fHBgwfjfY1muPV19913nzgcDrl165b07t1bXnvttQSPExUVZRbLpUuXUvBdAAAAAACQjgdS88SmTZtkzJgxMm3aNNm9e7csXbpUvvzySxk1alSCrxk7dqyEhIQ4Fx18DQAAAACATJ3pzpcvn/j5+cmZM2fc1uvj0NDQeF8zbNgweeqpp6Rnz57mcZUqVeTq1avyzDPPyOuvv26ap8c2ZMgQM1iba6abwBsAAAAAkKkz3YGBgVKjRg1Zv369c11MTIx5XLdu3XhfExkZGSew1sBdaXPz+GTJkkVy5szptgAAAAAAkOmnDNMMdNeuXaVmzZpSu3ZtM2WYZq51NHPVpUsXKVKkiGkirlq2bGlGPK9evbqZYuzw4cMm+63rreAbAAAAAID0Ik2D7vbt28u5c+dk+PDhcvr0aalWrZqsXr3aObjaiRMn3DLbQ4cONXNy679//vmn5M+f3wTco0ePTsN3AQAAAABAOgy6VZ8+fcyS0MBprvz9/SU8PNwsAAAAAACkdxlq9HIAAAAAADISgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAASC9B97Vr1yQyMtL5+Pjx4zJp0iRZu3ZtSpcNAAAAAADvCroff/xxWbBggfk7IiJC6tSpI++++65ZP336dDvKCAAAAACAdwTdu3fvlgYNGpi/P/vsMylYsKDJdmsg/t5779lRRgAAAAAAvCPo1qblOXLkMH9rk/I2bdqIr6+v3HvvvSb4BgAAAAAASQy6y5QpI8uWLZOTJ0/KmjVrpEmTJmb92bNnJWfOnJ7uDgAAAACATMvjoHv48OEycOBAKVGihOnPXbduXWfWu3r16naUEQAAAACADMnf0xc88cQTct9998mpU6ckLCzMub5Ro0amqTkAAAAAAEhipvvpp5+WbNmymay29uW2VKpUScaNG+fp7gAAAAAAyLQ8Dro/+OADM1d3bLrOmkoMAAAAAAB40Lz80qVL4nA4zHL58mUJCgpyPhcdHS2rVq2SAgUKcE4BAAAAAPA06M6VK5f4+PiYpWzZsnGe1/UjR45M7O4AAAAAAMj0Eh10b9y40WS5H3roIfn8888lT548zucCAwOlePHiUrhwYbvKCQAAAABA5g26GzZsaP49evSo3HXXXSazDQAAAAAAUnAgNc1of/vtt9K5c2epV6+e/Pnnn2b9hx9+aNYDAAAAAIAkBt3atLxp06aSNWtW2b17t0RFRZn1Fy9elDFjxni6OwAAAAAAMi2Pg+4333xTZsyYIbNnz5aAgADn+vr165sgHAAAAAAAJDHoPnTokNx///1x1oeEhEhERISnuwMAAAAAINPyOOgODQ2Vw4cPx1mv/blLlSqVUuUCAAAAAMD7gu5evXpJ37595YcffjAjmP/111+ycOFCGThwoDz33HP2lBIAAAAAgMw8ZZhl8ODBEhMTI40aNZLIyEjT1DxLliwm6H7xxRftKSUAAAAAAN4QdGt2+/XXX5dBgwaZZuZXrlyRihUrSvbs2e0pIQAAAAAA3hJ0WwIDA02wDQAAAAAAkhF0t2nTRubPny85c+Y0f9+OZrwrVaokvXv3NiOaAwAAAADgrRIVdGvwrM3Krb9vJyoqyszj/d1338ny5ctTppQAAAAAAGTWoHvevHnx/p2QAwcOSK1atZJXMgAAAAAAvG3KsMQoV66cbN261Y5dAwAAAACQeQdSe/DBB51NzeOzYcMG8fPzk7CwsOSWDQAAAAAA7wq6q1Wr5vb45s2bsnfvXvnpp5+ka9euKVk2AAAAAAC8K+ieOHFivOtHjBhh5uwGAABAxnaj5rS0LgI8NoFzBmT2Pt2dO3eWuXPnptTuAAAAAADI8FIs6N62bZsEBQWl1O4AAAAAAPC+5uVt2rRxe+xwOOTUqVOyc+dOGTZsWEqWDQAAAAAA7wq6Q0JC3B77+vqaKcLeeOMNadKkSUqWDQAAAAAA7wq6582bZ09JAAAAAADw9j7dJ0+elD/++MP5ePv27dKvXz+ZNWtWSpcNAAAAAADvCro7duwoGzduNH+fPn1aGjdubALv119/3TQxBwAAAAAASQy6f/rpJ6ldu7b5+5NPPpEqVarI1q1bZeHChTJ//nxPdwcAAAAAQKblcdB98+ZNyZIli/n766+/lscee8z8Xb58eTOKOQAAAAAASGLQXalSJZkxY4Zs2bJF1q1bJ82aNTPr//rrL8mbN6+nu5OpU6dKiRIlzBzfderUMU3VbyciIkJeeOEFKVSokAn+y5YtK6tWrfL4uAAAAAAApLuge9y4cTJz5kx54IEHpEOHDhIWFmbWL1++3NnsPLGWLFkiAwYMkPDwcNm9e7fZV9OmTeXs2bPxbn/jxg15+OGH5dixY/LZZ5/JoUOHZPbs2VKkSBFP3wYAAAAAAOlvyjANts+fPy+XLl2S3LlzO9c/88wzEhwc7NG+JkyYIL169ZLu3bubx5pB//LLL2Xu3LkyePDgONvr+gsXLpg+5AEBAWadZskBAAAAAMgUmW7l5+fnFnBbwW+BAgUSvQ/NWu/atcuMfu4sjK+vebxt27Z4X6PZ9Lp165rm5QULFpTKlSvLmDFjJDo6OilvAwAAAACA9JXpTimaLddgWYNnV/r44MGD8b7myJEjsmHDBunUqZPpx3348GF5/vnnzeBu2kQ9PlFRUWaxaIYeAAAAAIB0m+lOKzExMSabPmvWLKlRo4a0b9/ezA+uzdITMnbsWAkJCXEuxYoVS9UyAwAAAAC8V5oF3fny5TPN1M+cOeO2Xh+HhobG+xodsVxHK9fXWSpUqCCnT582zdXjM2TIELl48aJzOXnyZAq/EwAAAAAAbAy6dRovTwUGBpps9fr1690y2fpY+23Hp379+qZJuW5n+fXXX00wrvuLj04rljNnTrcFAAAAAIB0O2WYTvVladeunZmfW6ft2rdvn0f70unCdMqvDz74QH755Rd57rnn5OrVq87RzLt06WIy1RZ9Xkcv79u3rwm2daRzHUhNB1YDAAAAACDDD6Sm/acXLlxo/l63bp1ZvvrqK/nkk09k0KBBsnbt2kTvS/tknzt3ToYPH26aiFerVk1Wr17tHFztxIkTZkRzi/bHXrNmjfTv31+qVq1qAn0NwF999VVP3wYAAAAAAOkv6Nbg2BqMbOXKlSbT3aRJEzNlWJ06dTwuQJ8+fcwSn02bNsVZp03Pv//+e4+PAwAAAABAum9ervNzW4ORaVbammfb4XAwXzYAAAAAAMnJdLdp00Y6duwod999t/z999/yyCOPmPV79uyRMmXKeLo7AAAAAAAyLY+D7okTJ5qm5JrtHj9+vGTPnt2sP3XqlDz//PN2lBEAAAAAAO8IugMCAmTgwIFx1uvgZgAAAAAAIJnzdH/44Ydy3333SeHCheX48eNm3aRJk+SLL75Iyu4AAAAAAMiUPA66p0+fbubX1r7cERERzsHTcuXKZQJvAAAAAACQxKD7/fffl9mzZ8vrr78ufn5+zvU1a9aU/fv3e7o7AAAAAAAyLY+D7qNHj0r16tXjrM+SJYtcvXo1pcoFAAAAAID3Bd0lS5aUvXv3xlmvc3ZXqFAhpcoFAAAAAID3jV6u/blfeOEFuX79ujgcDtm+fbt8/PHHMnbsWJkzZ449pQQAAAAAwBuC7p49e0rWrFll6NChEhkZKR07djSjmE+ePFmefPJJe0oJAAAAAIA3BN2qU6dOZtGg+8qVK1KgQIGULxkAAAAAAN4YdFuCg4PNAgAAAAAAkhh062jlPj4+idlUdu/enajtAAAAAADI7BIVdLdq1cr5tw6gNm3aNKlYsaLUrVvXrPv+++/l559/lueff96+kgIAAAAAkBmD7vDwcLeB1F566SUZNWpUnG1OnjyZ8iUEAAAAAMBb5un+9NNPpUuXLnHWd+7cWT7//POUKhcAAAAAAN4XdOt0Yd99912c9bouKCgopcoFAAAAAID3jV7er18/ee6558yAabVr1zbrfvjhB5k7d64MGzbMjjICAAAAAOAdQffgwYOlVKlSMnnyZPnoo4/MugoVKsi8efOkXbt2dpQRAAAAAADvmadbg2sCbAAAAAAAUrhPNwAAAAAASByCbgAAAAAAbELQDQAAAACATQi6AQAAAACwCUE3AAAAAADpZfTy6OhomT9/vqxfv17Onj0rMTExbs9v2LAhJcsHAAAAAID3BN19+/Y1Qfejjz4qlStXFh8fH3tKBgAAAACAtwXdixcvlk8++USaN29uT4kAAAAAAPDWPt2BgYFSpkwZe0oDAAAAAIA3B90vv/yyTJ48WRwOhz0lAgAAAADAW5uXf/vtt7Jx40b56quvpFKlShIQEOD2/NKlS1OyfAAAAAAAeE/QnStXLmndurU9pQEAAAAAwJuD7nnz5tlTEgAAAAAAvD3otpw7d04OHTpk/i5Xrpzkz58/JcsFAAAAAID3DaR29epVefrpp6VQoUJy//33m6Vw4cLSo0cPiYyMtKeUAAAAAAB4Q9A9YMAA+eabb2TFihUSERFhli+++MKs05HNAQAAAABAEpuXf/755/LZZ5/JAw884FzXvHlzyZo1q7Rr106mT5/u6S4BAAAAAMiUPM50axPyggULxllfoEABmpcDAAAAAJCcoLtu3boSHh4u169fd667du2ajBw50jwHAAAAAACS2Lx88uTJ0rRpUylatKiEhYWZdfv27ZOgoCBZs2aNp7sDAAAAACDT8jjorly5svz222+ycOFCOXjwoFnXoUMH6dSpk+nXDQAAAAAAkjFPd3BwsPTq1SspLwUAAAAAwGskKuhevny5PPLIIxIQEGD+vp3HHnsspcoGAAAAAEDmD7pbtWolp0+fNiOU698J8fHxkejo6JQsHwAAAAAAmTvojomJifdvAAAAAACQglOGLViwQKKiouKsv3HjhnkOAAAAAAAkMeju3r27XLx4Mc76y5cvm+cAAAAAAEASg26Hw2H6bsf2xx9/SEhIiKe7AwAAAAAg00r0lGHVq1c3wbYujRo1En//f1+qg6cdPXpUmjVrZlc5AQAAAADIvEG3NWr53r17pWnTppI9e3bnc4GBgVKiRAlp27atPaUEAAAAACAzB93h4eEmo63BdZMmTaRQoUL2lgwAAAAAAG/q0+3n5yfPPvusXL9+3b4SAQAAAADgrQOpVa5cWY4cOWJPaQAAAAAA8Oag+80335SBAwfKypUr5dSpU3Lp0iW3BQAAAAAAeNin29K8eXPz72OPPeY2dZg1lZj2+wYAAAAAAEkIujdu3Mh5AwAAAADAjqC7YcOGnr4EAAAAAACv5HHQrSIiIuS///2v/PLLL+ZxpUqV5Omnn5aQkJCULh8AAAAAAN4zkNrOnTuldOnSMnHiRLlw4YJZJkyYYNbt3r3bnlICAAAAAOANme7+/fubQdRmz54t/v7/9/Jbt25Jz549pV+/frJ582Y7ygkAAAAAQOYPujXT7Rpwm534+8srr7wiNWvWTOnyAQAAAADgPc3Lc+bMKSdOnIiz/uTJk5IjR46UKhcAAAAAAN4XdLdv31569OghS5YsMYG2LosXLzbNyzt06GBPKQEAAAAA8Ibm5e+88474+PhIly5dTF9uFRAQIM8995y89dZbdpQRAAAAAADvCLoDAwNl8uTJMnbsWPn999/NOh25PDg42I7yAQAAAECy3Kg5jTOY4UwQr21ebtEgO1euXGZJbsA9depUKVGihAQFBUmdOnVk+/btiXqdNmvXrHurVq2SdXwAAAAAANJF0K1NyocNGyYhISEmUNZF/x46dKjcvHnT4wJo3/ABAwZIeHi4mec7LCxMmjZtKmfPnr3t644dOyYDBw6UBg0aeHxMAAAAAADSZdD94osvyqxZs2T8+PGyZ88es+jf//3vf+Wll17yuAATJkyQXr16Sffu3aVixYoyY8YMkzmfO3dugq+Jjo6WTp06yciRI6VUqVIeHxMAAAAAgHTZp3vRokWmWfcjjzziXFe1alUpVqyYGb18+vTpid7XjRs3ZNeuXTJkyBDnOl9fX2ncuLFs27Ytwde98cYbUqBAATOK+pYtWzx9CwAAAAAApM+gO0uWLKZJeWwlS5Y0g6x54vz58yZrXbBgQbf1+vjgwYPxvubbb781WfW9e/cm6hhRUVFmsVy6dMmjMgIAAAAAkGpBd58+fWTUqFEyb948E4ArDWpHjx5tnrPT5cuX5amnnpLZs2dLvnz5EvUaHWVdm6EDAAAgcdaM2MGpymhWpHUBAKRY0K19uNevXy9FixY1g56pffv2mabijRo1kjZt2ji3Xbp06W33pYGzn5+fnDlzxm29Pg4NDY2zvU5RpgOotWzZ0rkuJibm/96Iv78cOnTITF/mSpuu60BtrplubQoPAAAAAEC6C7p1irC2bdu6rUtqEKvN0WvUqGGCeGvaLw2i9XF8WfPy5cvL/v373dbpqOmaAde5w+Mrh2bjrYw8AAAAAADpOujWZuUpSbPQXbt2lZo1a0rt2rVl0qRJcvXqVTOauerSpYsUKVLENBPXebwrV64c5yaAir0eAAAAAIAMF3Rbzp07Z5pzq3Llykn+/PmTtJ/27dubfQ0fPlxOnz4t1apVk9WrVzsHVztx4oQZ0RwAAAAAgEwfdGsWWufqXrBggbM/tfbL1oz0+++/b+bY9pQ2JU9oELZNmzbd9rXz58/3+HgAAAAAAKQG36Q0B//mm29kxYoVEhERYZYvvvjCrHv55ZftKSUAAAAAAN6Q6f7888/ls88+kwceeMC5rnnz5pI1a1Zp166dTJ8+PaXLCAAAAACAd2S6IyMjnf2tXRUoUMA8BwAAAAAAkhh0161bV8LDw+X69evOddeuXZORI0ea5wAAAAAAQBKbl+uUXs2aNZOiRYtKWFiYWbdv3z4zndeaNWs83R0AAAAAAJmWx0F3lSpV5LfffpOFCxfKwYMHzboOHTpIp06dTL9uAAAAAACQhKD75s2bUr58eVm5cqX06tXLk5cCAAAAAOB1POrTHRAQ4NaXGwAAAAAApOBAai+88IKMGzdObt265elLAQAAAADwKh736d6xY4esX79e1q5da/p3Z8uWze35pUuXpmT5AAAAAADwnqA7V65c0rZtW3tKAwAAAACANwfd8+bNs6ckAAAAAAB4a5/umJgY05e7fv36UqtWLRk8eLBcu3bN3tIBAAAAAOANQffo0aPltddek+zZs0uRIkVk8uTJZlA1AAAAAACQzKB7wYIFMm3aNFmzZo0sW7ZMVqxYIQsXLjQZcAAAAAAAkIyg+8SJE9K8eXPn48aNG4uPj4/89ddfid0FAAAAAABeJdFBt87LHRQU5LYuICBAbt68aUe5AAAAAADwntHLHQ6HdOvWTbJkyeJcd/36dendu7fbXN3M0w0AAAAAgIdBd9euXeOs69y5c2JfDgAAAACA10l00M383AAAAAAA2NSnGwAAAAAAeIagGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAAMjMQffUqVOlRIkSEhQUJHXq1JHt27cnuO3s2bOlQYMGkjt3brM0btz4ttsDAAAAAOC1QfeSJUtkwIABEh4eLrt375awsDBp2rSpnD17Nt7tN23aJB06dJCNGzfKtm3bpFixYtKkSRP5888/U73sAAAAAACk66B7woQJ0qtXL+nevbtUrFhRZsyYIcHBwTJ37tx4t1+4cKE8//zzUq1aNSlfvrzMmTNHYmJiZP369aledgAAAAAA0m3QfePGDdm1a5dpIu4skK+veaxZ7MSIjIyUmzdvSp48eWwsKQAAAAAAnvOXNHT+/HmJjo6WggULuq3XxwcPHkzUPl599VUpXLiwW+DuKioqyiyWS5cuJbPUAAAAAABkkOblyfHWW2/J4sWL5X//+58ZhC0+Y8eOlZCQEOeifcABAAAAAMj0QXe+fPnEz89Pzpw547ZeH4eGht72te+8844JuteuXStVq1ZNcLshQ4bIxYsXncvJkydTrPwAAAAAAKTboDswMFBq1KjhNgiaNSha3bp1E3zd+PHjZdSoUbJ69WqpWbPmbY+RJUsWyZkzp9sCAAAAAECm79OtdLqwrl27muC5du3aMmnSJLl69aoZzVx16dJFihQpYpqJq3Hjxsnw4cNl0aJFZm7v06dPm/XZs2c3CwAAAAAA6UWaB93t27eXc+fOmUBaA2idCkwz2NbgaidOnDAjmlumT59uRj1/4okn3Paj83yPGDEi1csPAAAAAEC6DbpVnz59zBKfTZs2uT0+duxYKpUKAAAAAAAvHr0cAAAAAID0LF1kugEAyKhu1JyW1kWAxyZwzgAAqYZMNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGzib9eOASA+a0bs4MRkNCvSugAAAAAZF0E3AAAAgEyNm/4Z0ArJNGheDgAAAACATQi6AQAAAACwCUE3AAAAAAA2IegGAAAAAMAmBN0AAAAAANiEoBsAAAAAAJsQdAMAAAAAYBOCbgAAAAAAbELQDQAAAACATfzt2jEAAN5gzYgdaV0EeGoFpwwAkHrIdAMAAAAAYBOCbgAAAAAAbELQDQAAAACATQi6AQAAAACwCUE3AAAAAAA2IegGAAAAAMAmBN0AAAAAANiEoBsAAAAAAJsQdAMAAAAAYBOCbgAAAAAAbELQDQAAAACATQi6AQAAAACwCUE3AAAAAAA2IegGAAAAAMAmBN0AAAAAANiEoBsAAAAAAJsQdAMAAAAAYBOCbgAAAAAAbELQDQAAAACATQi6AQAAAACwCUE3AAAAAAA2IegGAAAAAMAmBN0AAAAAANiEoBsAAAAAAJsQdAMAAAAAYBOCbgAAAAAAbELQDQAAAACATQi6AQAAAACwCUE3AAAAAAA2IegGAAAAACAzB91Tp06VEiVKSFBQkNSpU0e2b99+2+0//fRTKV++vNm+SpUqsmrVqlQrKwAAAAAAGSboXrJkiQwYMEDCw8Nl9+7dEhYWJk2bNpWzZ8/Gu/3WrVulQ4cO0qNHD9mzZ4+0atXKLD/99FOqlx0AAAAAgHQddE+YMEF69eol3bt3l4oVK8qMGTMkODhY5s6dG+/2kydPlmbNmsmgQYOkQoUKMmrUKLnnnntkypQpqV52AAAAAADSbdB948YN2bVrlzRu3PjfAvn6msfbtm2L9zW63nV7pZnxhLYHAAAAACCt+KfZkUXk/PnzEh0dLQULFnRbr48PHjwY72tOnz4d7/a6Pj5RUVFmsVy8eNH8e+nSJUnvLt+8ldZFgIeCM0C9SmvU64yHen171OmMhzp9Z9TrjId6fXvU6YwnOAP8rrZiSofDkX6D7tQwduxYGTlyZJz1xYoVS5PyIJMLCUnrEgApj3qNzIY6jcyIeo3MJiTj/K6+fPmyhNymvGkadOfLl0/8/PzkzJkzbuv1cWhoaLyv0fWebD9kyBAzUJslJiZGLly4IHnz5hUfH58UeR/w/I6Q3vQ4efKk5MyZk9OHDI86jcyIeo3MhjqNzIh6nbY0w60Bd+HChW+7XZoG3YGBgVKjRg1Zv369GYHcCor1cZ8+feJ9Td26dc3z/fr1c65bt26dWR+fLFmymMVVrly5UvR9IGk04CboRmZCnUZmRL1GZkOdRmZEvU47t8twp5vm5ZqF7tq1q9SsWVNq164tkyZNkqtXr5rRzFWXLl2kSJEippm46tu3rzRs2FDeffddefTRR2Xx4sWyc+dOmTVrVhq/EwAAAAAA0lnQ3b59ezl37pwMHz7cDIZWrVo1Wb16tXOwtBMnTpgRzS316tWTRYsWydChQ+W1116Tu+++W5YtWyaVK1dOw3cBAAAAAEA6DLqVNiVPqDn5pk2b4qz7z3/+YxZkTNrcPzw8PE6zfyCjok4jM6JeI7OhTiMzol5nDD6OO41vDgAAAAAAkuTfdtsAAAAAACBFEXQDAAAAAGATgm4AAAAAAGxC0I1E69atm/j4+JglICDAjDD/8MMPy9y5c8386nbTQfXuueceM2BEmTJlZP78+bYfE5lbWtbpU6dOSceOHaVs2bJmhoZ+/frZejx4j7Ss10uXLjXHyp8/v5kztm7durJmzRpbj4nMLy3r9Lfffiv169eXvHnzStasWaV8+fIyceJEW48J75DWv6st3333nfj7+5sZpGAfgm54pFmzZiZYOHbsmHz11Vfy4IMPmrnTW7RoIbdu3bLtbB49etTMy67H27t3rwlQevbsyY85ZNg6HRUVZQITnf4wLCzMtuPAO6VVvd68ebP50bhq1SrZtWuXOW7Lli1lz549th0T3iGt6nS2bNnMDDtat3/55Rfzna3LrFmzbDsmvEda1WtLRESEdOnSRRo1amT7sbyejl4OJEbXrl0djz/+eJz169ev1xHwHbNnz3auO378uOOxxx5zZMuWzZEjRw7Hf/7zH8fp06fdXrd8+XJHzZo1HVmyZHHkzZvX0apVqwSP/corrzgqVarktq59+/aOpk2bcvGQIeu0q4YNGzr69u3LlUSmqteWihUrOkaOHJmMdwRvl97qdOvWrR2dO3dOxjsC0ke91t/SQ4cOdYSHhzvCwsK4LDYi041ke+ihh0ymTpsVKm0S8/jjj8uFCxfkm2++kXXr1smRI0ekffv2ztd8+eWX0rp1a2nevLnJgKxfv15q166d4DG2bdsmjRs3dlvXtGlTsx7IiHUa8IZ6rce4fPmy5MmTx5b3BO+WFnVaX7N161Zp2LChLe8JSK16PW/ePLOf8PBwTnoq8E+NgyDz0z5OP/74o/lbP+j79+83TcKLFStm1i1YsEAqVaokO3bskFq1asno0aPlySeflJEjRzr3cbsmtqdPnzZ9XVzp40uXLsm1a9dMPysgI9VpwBvq9TvvvCNXrlyRdu3a2fBugNSr00WLFpVz586ZJr8jRowwXdyAjFqvf/vtNxk8eLBs2bLF9OeG/ch0I0U4HA4zEITSPk/6pWB9MaiKFStKrly5zHNK+2XTfwTpGXUamVFq1utFixaZH4CffPKJFChQIIXeAZA2dVqDk507d8qMGTNk0qRJ8vHHH3MpkCHrdXR0tBnIVb+fdTBXpA5ubSBF6Ie+ZMmSid7e08x0aGionDlzxm2dPtbRcclyIyPWaSAz1+vFixebTOCnn34ap2sQkBHrtHWMKlWqmN8fmu3u0KFDkvYFpGW91i4/egNJm6HrIIFWE3YN9DXrvXbtWtPEHSmLTDeSbcOGDabZS9u2bc3jChUqyMmTJ81iOXDggBkhUe/MqapVq5rmMoml087E3l77tOh6ICPWaSCz1mvNAHbv3t38q7NOAJntu1oDFJ2BAsiI9VoTVrp/zY5bS+/evaVcuXLm7zp16nBh7WDnKG3IfKMsNmvWzHHq1CnHH3/84di1a5dj9OjRjuzZsztatGjhuHXrltkuJibGUa1aNUeDBg3MNj/88IOjRo0aZoRmy8aNGx2+vr6O4cOHOw4cOOD48ccfHW+99VaCxz5y5IgjODjYMWjQIMcvv/zimDp1qsPPz8+xevXqVHnvyJzSsk6rPXv2mEX31bFjR/P3zz//bPv7RuaWlvV64cKFDn9/f/Mdrce3loiIiFR578ic0rJOT5kyxYwK/euvv5plzpw5ZvTo119/PVXeOzKvtP4N4orRy+1H0A2Pvhz0Po0u+qMqf/78jsaNGzvmzp3riI6Odts2MVMbfP755+ZLJDAw0JEvXz5HmzZtbnt8/UKxti9VqpRj3rx5XD1k6DptHdt1KV68OFcVGbZe64/A+Oq1lgnIiHX6vffeM1OW6o3/nDlzOqpXr+6YNm1anOMCGalex0bQbT8f/Y8tKXQAAAAAALwcfboBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAOlIt27dxMfHxywBAQFSsGBBefjhh2Xu3LkSExMj3mD+/PmSK1eutC4GAAApgqAbAIB0plmzZnLq1Ck5duyYfPXVV/Lggw9K3759pUWLFnLr1q20Lh4AAPAAQTcAAOlMlixZJDQ0VIoUKSL33HOPvPbaa/LFF1+YAFyzwOrEiRPy+OOPS/bs2SVnzpzSrl07OXPmjNt+VqxYIbVq1ZKgoCDJly+ftG7d2vmcZtKXLVvmtr1ml639a8Cv23zyySfSoEEDyZo1q9nXr7/+Kjt27JCaNWuaYz/yyCNy7tw5t/3MmTNHKlSoYI5bvnx5mTZtmvM5a79Lly41NxOCg4MlLCxMtm3bZp7ftGmTdO/eXS5evOjM+I8YMcKGswwAQOog6AYAIAN46KGHTHCqwao2M9eA+8KFC/LNN9/IunXr5MiRI9K+fXvn9l9++aUJsps3by579uyR9evXS+3atT0+bnh4uAwdOlR2794t/v7+0rFjR3nllVdk8uTJsmXLFjl8+LAMHz7cuf3ChQvN49GjR8svv/wiY8aMkWHDhskHH3zgtt/XX39dBg4cKHv37pWyZctKhw4dTBa/Xr16MmnSJHMjQbP9uuh2AABkVP5pXQAAAJA4mjX+8ccfTQC9f/9+OXr0qBQrVsw8t2DBAqlUqZLJQmtGWoPeJ598UkaOHOl8vQbtntKAt2nTpuZvbeKuwbEev379+mZdjx49nNlxK0h/9913pU2bNuZxyZIl5cCBAzJz5kzp2rWr234fffRR87eWUcuuAby+x5CQEJPh1mw/AAAZHZluAAAyCIfDYYJRzSBrsG0F3KpixYqmebg+pzSD3KhRo2Qfs2rVqs6/dVA3VaVKFbd1Z8+eNX9fvXpVfv/9dxOIa9Nza3nzzTfN+oT2W6hQIfOvtR8AADITMt0AAGQQGlBr5jgxtA/27WjwrkG8q5s3b8bZTkdQd31NfOusUdWvXLli/p09e7bUqVPHbT9+fn533K+3jM4OAPAuZLoBAMgANmzYYJqUt23b1gxSdvLkSbNYtAl3RESEyXhbmWRtBp6Q/Pnzm/7Slt9++00iIyOTVUbNehcuXNj0Ly9TpozbktibBSowMFCio6OTVRYAANILMt0AAKQzUVFRcvr0aRN46ojkq1evlrFjx5opw7p06SK+vr6miXenTp3MoGM6ANnzzz8vDRs2NKOKW32rtXl56dKlTd9u3WbVqlXy6quvOgdmmzJlitStW9ccR9e7Zp+TSvtnv/TSS6Zftk59pu9l586d8s8//8iAAQMStY8SJUqYrLneNNB+6DrCuS4AAGREZLoBAEhnNMjWfs4afGrgunHjRnnvvffMtGHaTFubY+vfuXPnlvvvv18aN24spUqVkiVLljj38cADD8inn34qy5cvl2rVqpkge/v27c7ndbAz7ROu04HpiOQ6sFlKBLY9e/Y0U4bNmzfP3BjQGwE60JonmW4dwbx3795mNHbNyI8fPz7Z5QIAIK34OGJ36AIAAAAAACmCTDcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAscf/A+NfKFJFB3HzAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUxFJREFUeJzt3QmcTfX/+PH3rMZYRtbJkjU7Q7aQVIREib5kiYRSKRJFYUiIypJ9CSlFi6+QLFmiKFlTqGStrGlsw2Dm/h/vz+9/7vfe2cydmTN3Zu7r+XiczD333HM+59zPvd33eX8WP4fD4RAAAAAAAJDu/NN/lwAAAAAAQBF0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0A0AWUKpUKXniiSckKxs+fLj4+fnJ2bNnvV2ULGnjxo3m+um/2dWRI0fMOc6fP18yo3vuuccsSB7XCQDcEXQDyHL0B7n+MLeWkJAQKV++vPTp00dOnTolWdWWLVtMYBoVFSVZKQhMyWKXjz76SCZOnGjb/oH0Mnr0aFm6dKm3iwEvy2rf8wDSR2A67QcAMtzrr78upUuXlqtXr8q3334r06dPl5UrV8rPP/8soaGhkhV/jI0YMcJktPPly+f23K+//ir+/pnrPmmlSpXkgw8+cFs3ePBgyZ07t7z22msZUgYNuvX97tevX4YcD75tzZo1aQq6H330UWnTpk26lgnZ53seQPZF0A0gy3rggQekdu3a5u+ePXtKgQIFZPz48fLFF19Ix44dE33N5cuXJVeuXJKZpKRMOXLkkMymSJEi0qVLF7d1b775phQsWDDBeiA7CA4OFl/icDjMTc2cOXN6uygAkKVlrrQJAKTBfffdZ/49fPiw+VczCZp1/eOPP6Rly5aSJ08e6dy5szPQfemll6REiRImoK1QoYK8/fbb5kemK20arc3WFy5caLbRpuy1atWSTZs2JTj+rl27zI2AvHnzmuM2adJEvv/++0Sbxn/zzTfy7LPPSuHChaV48eKmueHAgQPNNpq9t5plax/XpPp0Hzp0SP7zn/9I/vz5TWb/zjvvlC+//DLRJuCffPKJjBo1yhxLz0HLdvDgQbdtf//9d2nXrp2Eh4ebbXTbxx57TM6fPy/pSZtVWlmesLAw6d69u0RHRyfY7sMPPzTXWn/w6zlqWY4fP+58XvuM6vkePXrUeb30Oqlr167JsGHDzOv1GHpTo1GjRrJhw4YUlVHP+cCBAyk6dz1mq1atzLXWm0Ba3mrVqjn7Xi9ZssQ8tuqO1pP49FiaBdXz1O10P8uWLbvpsTdv3mzqwG233WbqsdbnF198Ua5cueK2nfVZ+Ouvv0ymVf8uVKiQDBgwQGJjY922/eeff+Txxx839Vjfo27dusmePXsS7Wud2nK71gN9f6zjJNXkNi3HWbRokbnu+vnXc9L3YtKkSQnGGojP+qxan8Gk+irHxMRIZGSklCtXzvkevPzyy2a9Rfej3znvv/++s65an+eLFy+alhpaj/T1+p1w//33y86dO5M9L6vcem3at29vzk1vPPbt29cEyq7mzZtnvh9133qMypUrm5ZBSdXl1atXO+vyzJkzky3HrFmzpGzZsmbbunXrmjqZmNOnT0uPHj3MzTp9DyMiIsz1iC8uLs68P9ZnRutpixYtZPv27Tft96/r9brEv0a//fabuRGodU33N3ToUPNdr98nDz/8sLl2+r33zjvvJNhnSt5f1/9XaBeCqlWrmm2rVKkiq1atcitPct/zALIvMt0Asg0NrpX+8LTcuHFDmjdvLnfddZcJqjU41R9bDz30kAnA9EdgjRo1zI9M/TGkQcmECRPc9qsB8uLFi+WFF14wP6SmTZtmfgRu27bN/LhSv/zyiwnq9Meb/iALCgoyP1b1B7q+vl69em771IBbf/xpYKg/xjVY1x+GH3/8sTm+ZouVbpMY7bveoEEDE6xqufSc9Qesntdnn30mjzzySIIMtDZP1yBLA8lx48aZGxA//PCDM0jV66Q/JJ9//nnzA1SvxYoVK0wgpD9W04sGCPqDc8yYMSawmDNnjgkGxo4d69xGbxDoD2PdVlsxnDlzRiZPnix33323CVo1SNMm7Houf/75p/M902BSXbhwwexXWzz06tXLBDbvvfeeOUd93/Q9T85///tfczNAg5WUDGCnNzA6deokTz/9tPlxr3WtdevWMmPGDHn11VfN+630nPWcXLsLaN1p2LChFCtWTAYNGmRuEOhNEg2OP//88wTvpatPP/3U1IFnnnnG1AE9N71Oek30OVcaXOv5a13U8n399dcmyNCASV9vBTxabt2PrqtYsaJpOaIBcXxpKbd+BjXY0W4hvXv3Nl0V9Jqn93HWrl1r6oDeZLLq1/79++W7774zwWla6fXSz5yex1NPPWXOY+/evaY+6ufZ6sOt3TC0HmtQqtspve5Kz18/sxqwaTCsNz10f1rOO+6446Zl0PqkwbLWLb3J9+6778q///4rCxYscG6jAbYGgFrWwMBAWb58uamTWv7nnnvObX9aN/WaaV3Wz47ebEyKfqZ0O/0u0hsHeiNQj6E3RzQ4tehNIP0u1M+Jnqd+/rV+6mdLv19c3wv9TtaAWr8T9Zrpd7gG8npuVssmT3Xo0MG8N/o9qDfq3njjDVNG/Y7WmxFaN/TGqn4/1qlTx3zPePL+WnQ7vcmm11Zv8uh7oTcyjx07Zj6fbdu29eh7HkA24gCALGbevHmajnZ8/fXXjjNnzjiOHz/uWLRokaNAgQKOnDlzOv7880+zXbdu3cx2gwYNcnv90qVLzfo33njDbf2jjz7q8PPzcxw8eNC5TrfTZfv27c51R48edYSEhDgeeeQR57o2bdo4goODHX/88Ydz3d9//+3IkyeP4+67705Q9rvuustx48YNt+O/9dZb5rnDhw8nOOeSJUua87H069fPbLt582bnuosXLzpKly7tKFWqlCM2Ntas27Bhg9muUqVKjpiYGOe2kyZNMuv37t1rHu/atcs8/vTTTx1pUaVKFUfjxo0TfS4yMtIc48knn3Rbr9dR3zvLkSNHHAEBAY5Ro0a5badlDQwMdFv/4IMPmmsTn15b1/NV//77r6NIkSIJjp8Y633Sf29Gj6/bbtmyxblu9erVZp3WR60vlpkzZ5r1+r5YmjRp4qhWrZrj6tWrznVxcXGOBg0aOG6//XbnOuu9dH1tdHR0gvKMGTPG1GPX41qfhddff91t25o1azpq1arlfPz555+b7SZOnOhcp3XpvvvuS3A9UlruxFifwXHjxrm9Z40aNUrX4/Tt29eRN2/eBJ+1xOplUnXA9fOoddu1fn/wwQcOf39/t8+hmjFjhnntd99951yXK1cut8+wJSwszPHcc88lex7Jlfuhhx5yW//ss8+a9Xv27Em2njRv3txRpkyZROvyqlWrbnr8a9euOQoXLuyoUaOG22dt1qxZZh+u10nrk6778MMP3V5fv359R+7cuR0XLlww69avX2+2e+GFFxIcT99zpe9HUp9NXa/XJf41euqpp5zrtC4UL17cfEbefPNNt+8H/by6vkeevL/6WP8f4Pr/D30PdP3kyZNT9D0PIPuieTmALKtp06YmQ6AZFW16rFlOzZZpRsyVlcWz6GBrAQEBJkPsSpub62+nr776ym19/fr1TfNUizbl1SydZsc1e6iLDrCkmbcyZco4t7v11ltN9lOzH5p5daUZJC1Dauk5aNZMM/gWPX/NxmhTxX379rltr1lb1/6ompVXmplSViZbzymxpt7pSTN7rrQsmt2zrpFmijTDpBk8nV7MWjT7fvvtt6eoibheW+t8dV/nzp0zGTPNlN2s2a7SDJzWhZRO06YZSq0nFqtlg2bRtL7EX29ddy3X+vXrzblqNt46V70empXWJv/a4iAprn1ttcWEvlazjlr2xJqxJ3btrbIobQqrrTS0flo0Ix8/G5rWcmv91Yyr62dT3zNtZZGex9EWEXpdNONtB83WavZTWwS41lWrq0tK6qqWUVuc/P3336kqQ/z3xrqGeo0TqyfaOkTL2LhxY/Pex+9CoVlovbY3o829tcm41inX7xary4ArLYt+fl3H2tB6pt/Bly5dMq2BlLZc0ObW2pw7vrTMgqAZc9d6pt8D+hnRrLrr+6BZfdfPg6fvr/4/yWrBoKpXr25aP7nuE4Bvonk5gCxr6tSpZqow/fGu/QT1B1P8Eb71Oe2b7Er7ABctWtQ0/3OlP66s511poBefHleDU232rPTvxJph6j416NO+g9q80/WHbVpoGeM3WY9/DlbTd+Ua+KlbbrnF/KvNUK3y9O/f3wxEp80sNRjTZpVWP8j0lFxZ9AeqBlL6gzix6279WE8JbW6vzae1z+v169fT7dqn5Jysa+baxNZ1vXXdtbmtnqs2pdclMRrYxL+RZNFmq9pFQfs3W/u0xA+mrP6x8a+96+u03ujNovij/2t/VldpLbd1HKs7gCX+Zyitx9FmvtoUXZsq6zbNmjUzAbx2D0kPWle1GXhSzYO1bDejXT20Wb3WFb25p+NPdO3a1e0GXnLif0406NPvQdd+wtqcXgPZrVu3JrippvXE9TOe0s+H9T0Z//j6+Yxfdt1Wt4v//Rz/O1e7COl3szb9tvvzqZ8Hq3m363q9oZPa9zf+cRL7jAHwTQTdALIszfTerI+f9sHObFNtqYweDTiprLrrwHEaoGqWSvvwauZes1BWP9H4Ny7sLIvepNCslrY4SGzb+IFaYnQQNj0XbX2gffW1z7juS8/H6vufnpI6p5Scq9K+pEllF+MHvBZtYaEDbmk2+JVXXjHZOO3vrJlfPXdr3zcrS2qkpdwZeRx933fv3m1acGh90kX76WtQaw3ilVQGNf4Ac0mVTwf80ptViYl/0yUxehNAb3JpKx393L311lumj7G2+NCbBZ6Kfz5a37VPu9YPLaeWSTPTmn3WfsXx60lmH6k8Ne9XYnU/Jd+Jnr6/KdknAN9E0A3A55QsWdIMIqXNVV2z3ZoRtZ53pdmO+HQwHM0GWhkQ/VsHIIpP96lBf0p+fHvSfFLLmNTxEjuHlNIfmLoMGTLEzCerA1jpYGA68FBG0Uyd/kjVjJu2KEjNNdOBqTTbpoGL6zaJNVv1JisjqNlBbZrqCR3QSeuhBo8aRFrS0pRa6402mdVsqGu2O/5I92kpt3WcdevWmabFrjdR4tfptB5HaYCpg8PpokGUZr91AC3NnGvAbrW00AG9XOdNjt/iJam6qiO7a1B7s89vcs9r1l/LpYtmT3UANR1MMCVBt34/uWan9b3S87RG8tdB03SARG0N4ZqJTelI/kmxvmP0+FZza6WtSnQGCR2d3HXbn376yZTL9SZo/O8rvZ56g0RvJCWV7XZ9v1yl5P3ylCfvb0ql134AZC2ZL/0DADbT5puaFZkyZYrbes366A+i+D90tUmmaz9gbSqu2WBtqqqZDV30b13n2qRTRxj/6KOPTL9rbTZ9M9Zc3UlNmxT/HHSEaS2bRfuu6vQ9+mNb+xh7QvtTa59nVxp86w/k+FPj2E1H+NVrOmLEiAQZIn3s2vxTr1li03pZGSfX12u/WdfrlV5ThqWFZmJ1VGcNAk+cOJHgeav7QmISO0f923U6LE9pNlmDptmzZzvXaaCkXTnSq9xW/dX65jptlX4mdeT19DyOa11RWp+1n62y6rXVB9d1GkBreq+UZKm1ZYHr9XIdsVv341pX43+29Zzj1zE9Z21indLPXfz3xrqG1vdYYvVEj6kZ/7TQVkZ601FvyunsBxYdeTz+eer7ffLkSTMLhEXffy2r3nTR/uVKR/rWcupnPz6r/Ppdqs3C40/bqLNKpDdP3t+U8uR7HkD2QaYbgM/RjNe9995rppzSIFkzMtqsU4NmnfbGdSAcpX2jNRhxnTJMuf4w1EywZhg1wNZslfYl10BBfzhrn82UsAZr03LpwHCa3dOyWj/SXOnUSTrtjP6w1nJpVkiDBM0w6WBEnjap18GqdCofnfNZs8v6g1inOdIf7PpDOCPp9dfrOXjwYPP+aBNxbZGg56ZNcHWwOG1ubF0z/SGv/dF1qh/9Aa/XTOca1iy3Tif14IMPmtdqcKA3IzS7ejOeThmWFho0ab3Rmxw6gJlmd/WGjd4g0Km/NNOWGG0urNdKr4UGBhqM6Huflv6jeq2124YOKqgZUz2GZkg18xg/S5facit9j7QVhdZjfY/1fdH3K7GbHGk5jg6gpWXXTKx2kdBsqAZ6OmWc1Z9Yb5hpBlgH1dKuCFrn586dawJK7TOfHJ3PXPuM62BimjnWc9JAWm/Y6HprvmurrmoLG22qrEG1Zqe1D7uWS+cg1+8hrb+6zY8//pjonNGJ0bqt4y9oP3W9Jtq1QgdwtDLNen5Wtl+n99L6r0GkBveJ3chIKf1+0s+p7lOvr07LpWXRz0z8Pt36mdXvQ/0s7dixw9wY1NYo2td84sSJzhZH+r2s11Sn2tIMup6T3vTRKcP0Of2Ost5Xnf5L/9XrqwG4tvpIb568vynlyfc8gGzE28OnA4CnrKl8fvzxx2S306lfdJqexOj0Wi+++KKjaNGijqCgIDP1kE7lYk1LY9Hj6HQ+OtWNbpMjRw4zzZLrtE2WnTt3mml4dAqc0NBQx7333us2jVRKyj5y5EhHsWLFzDQ1rtPKxJ8yTOn0ZDrNWb58+cwUZnXr1nWsWLHCbRtrmqn4U4HFn3bn0KFDZiqtsmXLmn3lz5/flF+nZUvvKcN0mrfErkn8KXR0+iqdWk3fQ10qVqxo3otff/3Vuc2lS5ccnTp1MtdA92FNH6bv4+jRo81j6z3Ta6PXMLEpxtI6ZZhOXRafVXcSu+5a1+K/l127dnWEh4eb+qh1oFWrVo7PPvss2SnD9u3b52jatKmpcwULFnT06tXLOU2Ra9mT+iwkNl2Wvj96TXW6O53O6oknnjBTI+l2OjWfp+VOyj///ON4/PHHzZReehz925q6Lv51T+1x9PlmzZqZqa10OqfbbrvN8fTTTztOnDjhtt2OHTsc9erVc24zfvz4FE0ZZk19NXbsWFP3ta7dcsstZhq2ESNGOM6fP+/c7sCBA2b6QJ2WSver74lOtTVw4EBHRESEud76Hunf06ZNu+n1s947rQP6PaCv12P36dPHceXKFbdtly1b5qhevbr5bOuUglreuXPnJji/pOpycrSsOlWhnnvt2rUdmzZtSvQ6nTp1ytG9e3dTT/U66zRwiX2+dEov/Xzo5123K1SokOOBBx4w75HrFGg9evQw9UbPu3379o7Tp08nOWVY/O+cpD4PWmZ9H1Pz/ib2eU/quzup73kA2Zef/sfbgT8AZFaa2dMpeeI3RQd8ydKlS02rAZ3+TrN9vkoHPNPWLpqN9rbhw4eb1jbaxD7+KNwAgMyFPt0AAMCtr6orq6+1Nl/XAb58mTbHJsAFAHiKPt0AAMDp+eefN4F3/fr1zZgE2tdaR7IfPXp0pp9Oyi56/noddPotnZ4NAABPEHQDAAAnHRRLB/FasWKFXL161UyrpZluaxArX6QDj+kc3zrQog6wBwCAJ+jTDQAAAACATejTDQAAAACATQi6AQAAAACwic/16Y6Li5O///5b8uTJY6YCAgAAAADAU9pT++LFi1K0aFHx9086n+1zQbcG3CVKlPB2MQAAAAAA2cDx48elePHiST7vc0G3ZritC6NzjgIAAAAA4KkLFy6YhK4VYybF54Juq0m5BtwE3QAAAACAtLhZt2UGUgMAAAAAwCYE3QAAAAAA2ISgGwAAAAAAm/hcn24AAAAAyIxiY2Pl+vXr3i4G/r+goCAJCAiQtCLoBgAAAAAvz/d88uRJiYqK8nZREE++fPkkPDz8poOlJYegGwAAAAC8yAq4CxcuLKGhoWkK8JB+N0Kio6Pl9OnT5vGtt96a6n0RdAMAAACAF5uUWwF3gQIFvF0cuMiZM6f5VwNvfX9S29ScgdQAAAAAwEusPtya4UbmY70vaelrT9ANAAAAAF5Gk/Ls+74QdAMAAAAAYBOCbgAAAABAhps/f74ZHTy7YyA1AAAAAMiETrZulKHHC1++2ePXnDlzRoYNGyZffvmlnDp1Sm655RaJiIgw6xo2bJjsazt06CAtW7aU7M6rme5NmzZJ69atpWjRoqat/NKlS2/6mo0bN8odd9whOXLkkHLlypm7IwAAAACAjNeuXTvZtWuXvP/++/Lbb7/JsmXL5J577pF//vknRaODFy5cWLI7rwbdly9fNndBpk6dmqLtDx8+LA8++KDce++9snv3bunXr5/07NlTVq9ebXtZAQAAAAD/o1Odbd68WcaOHWtitJIlS0rdunVl8ODB8tBDDzm3efrpp6VIkSISEhIiVatWlRUrViTZvPyLL74wSVbdtkyZMjJixAi5ceOG83lN1s6ZM0ceeeQRM7L47bffbgJ9V7/88ou0atVK8ubNK3ny5JFGjRrJH3/84XxeX1+pUiVzjIoVK8q0adOyb/PyBx54wCwpNWPGDCldurS888475rFeqG+//VYmTJggzZs3t7GkAAAAAABXuXPnNou2WL7zzjtNa2RXcXFxJt67ePGifPjhh1K2bFnZt29fkvNdawDftWtXeffdd52B8lNPPWWei4yMdG6ngfi4cePkrbfeksmTJ0vnzp3l6NGjkj9/fvnrr7/k7rvvNtn29evXm8D7u+++cwbuCxcuNE3fp0yZIjVr1jRZ+l69ekmuXLmkW7dutlynLNWne+vWrdK0aVO3dRpsa8YbAAAAAJBxAgMDTbZag1ZNkGqGunHjxvLYY49J9erV5euvv5Zt27bJ/v37pXz58uY1mr1OigbTgwYNcga/uu3IkSPl5Zdfdgu6n3jiCenYsaP5e/To0SZI1+O0aNHCtKIOCwuTRYsWSVBQkNnGOrbS/WgSt23btuaxJnX1RsDMmTMJutXJkydNswRX+vjChQty5coV0ycgvpiYGLNYdFsAAAAAQPr06dYuwJql/v777+Wrr74yWWhtwn369GkpXry4W9CbnD179pis9KhRo5zrYmNj5erVqxIdHW2akysN6C2aodZsth5LaTdkzZJbAXf87s2aPe/Ro4e5UWDRLLgG6nbJUkF3aowZM8bcMcmK6sw86O0iwEM/Pl3O20XI9KjXWQ/1OnnU6ayHOn1z1Oush3qddet0kZBY6V/pusSeixH/eHFi/gwuy74zV1P92mI1Gkk7XXoPlGEvPiOvDh0m3Z/tJ9fjHEnu96+L1yXO8b/jXrx0SZ4bOESaPthGbi/g3lRd+19b4gfU2s9bm7KrxBKxlkuXLpl/Z8+eLfXq1XN7Lqkm7z43T3d4eLgZht6VPtY7G0ldXO3Ef/78eedy/PjxDCotAAAAAPieMuUrypXoaClfuZqc+vsvOfLH7yl6XaVqNcy2JcuUNTNVuS7+/ikLXTULrln369evJ3hOW0nrzFmHDh1KsH9tZm6XLJXprl+/vqxcudJt3dq1a836pGhn/vgd+gEAAAAAaRN17h95sWdnaduxm5SvXFVy5c4jv+zZIXOnTJD7WrSSOg0aSa36d0m/JzvKyyPGym2ly8rhg79qaloa3dcswf6eeelVea5LW7m1WAl5pttjJtDWJuc///yzvPHGGykqU58+fczgatqvXBOw2mxcm73rqOoVKlQwraBfeOEFs177gGtX5O3bt8u///4r/fv3z35Bt6b3Dx486DYlmLbB11HnbrvtNnORdPS5BQsWmOd79+5tRpnTjvRPPvmkGY3uk08+MROxAwAAAAAyTmiu3FL9jjqyYOZkOX7kkNy4cV3CixaXRx/vLk/1fdlsM3Hux/L28MEysHc3uRJ92QTeLw4Zmej+7rrvfpn64RKZ/s5omTvlHdOMXKf00mmiU6pAgQImThw4cKAZ1E2bjdeoUUMaNmxontd9ad9wHflct9E+4dWqVbN1cG4/h8PhEC/ZuHGjmc8tPh01TkfB01Hpjhw5YrZzfc2LL75oRpjTTvlDhw4126WUDqSmdzW0qbk2S8/MMnPfEySO/lQ3R73OeqjXyaNOZz3U6ZujXmc91Ous3qc7RgoXLyn+QbTQtVQu9L8+3N6kg7hpclibn7v2K/cktvRqplvnTksu5tfAO7HX6FxqAAAAAABkdllqIDUAAAAAALISgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGCTQLt2DAAAAABIvY7HXs3Q431822iPX3Pu7BmZMnakfPP1V/LPmdOSN+wWqVClmjzz0mC5o14DsVOpUqWkX79+ZsnMCLoBAAAAAKnS78mOcv36NRk9eY6UKFlKzp45LT9s3ihR/56z7ZjXrl2T4OBgySoIugEAAAAAHrtwPkp2fP+dzF+6Ruo0aGTWFS1RUqrfUce5TZXCOWXo2EmyYfWX8uOWTVKocLj0jxwlzVu3dW7z276fZcyQAbJn+w8SkjNU7m/VRuZNmyS5c+c2zz/xxBMSFRUlderUkalTp0qOHDmkZMmScvToUXnxxRfNohwOh2RG9OkGAAAAAHgsNFdus6z7aplci4lJcrvJY183gfSSDdvkwUcfk4FPdZU/fjtgnou+fFme6tBa8oblk8Wrv5XxcxbK99+slz59+rjtY926dfLrr7/K2rVrZcWKFbJkyRIpXry4vP7663LixAmzZFYE3QAAAAAAjwUGBsqod2fJF4sXyp23h0vnB++ViaOGya+/7HXbrnnrtvJol+5Squzt8sKgSKlS4w5ZOGe6ee7LJYslJiZGxkx5T26vVEXubHSPvPbmBPnggw/k1KlTzn3kypVL5syZI1WqVDFL/vz5JSAgQPLkySPh4eFmyawIugEAAAAAqdKs9SOy8adDMmXBZ3LXfc3kx+82yX+a1pf/LvrAuU1E7Xpur9HHh37/v0z3od8OmIHXQnPlcj5fs259iYuLM5ltS7Vq1bJUP25XBN0AAAAAgFTLERIiDe5pYkYsX7hyo7R57HGZOm5kuh4jl0tQntUQdAMAAAAA0k2Z8hXlSnS08/GeHdvcnv9p+zYpc3tF57baHF37dlt2bdsq/v7+UqFChWSPo5nv2NhYyewIugEAAAAAHos69490b9tCln/6sQmc/zx6RFYv+1zmTpkg97Vo5dxuzfIlsuSj9+XIH7+bOb337tounXr0Ns+1aveYGY381ed7yu/7f5Efvv1GRg/uL48//rgUKVLkpvN0b9q0Sf766y85e/asZFZMGQYAAAAA8JiOXK7Tgy2YOVmOHzkkN25cl/CixeXRx7vLU31fdm733MAh8tV/P5WRr/SVQkXC5a2Z70u5CpXMczlDQ2XW4uVmyrAOze9yThk2Zcqkmx5fRy5/+umnpWzZsmYwtsw6ZRhBNwAAAABkQh/fNloys+AcOeTFISPNkpzC4bfK7E9XJPl8+cpVZd6SVW7rcucOcf49f/78RF935513yp49eySzo3k5AAAAAAA2IdMNIENdqz3N20WAx8Z7uwAAAABZFkE3AAAAAMAWv5y+Ir6O5uUAAAAAANiETHcmRjPcrIhmuAAAAAD+h0w3AAAAAAA2IegGAAAAAMAmBN0AAAAAANiEoBsAAAAAAJsQdAMAAAAAvGbbd5ukSuGccuF81E233bhxo/j5+UlU1M23zSwYvRwAAAAAMqFuS/7M0OO937Z4ql535tRJmTVxrGxau0pOnfxbChQsJBWqRkjXp/rInXffe9PX16hzp2zce1jy5A276bYNGjSQEydOSFjYzbfNLAi6AQAAAACp8texo9Kl1b2SJyyfvBQ5WspXrio3rl+XbzeslTcG9ZMVW/bcdB/BwcFSqEh4io6n24aHp2zbzILm5QAAAACAVBn5Sl/T3HvRqs3SrPUjUqrs7VKuYmV54pm+8tFX35igXJuO79/7v+Bbm5HrOm1Wnljz8r+PH5XWrVvLLbfcIrly5ZIqVarIypUrE21ePn/+fMmXL5+sXr1aKlWqJLlz55YWLVqYbLirOXPmmOdDQkKkYsWKMm3atAy7RmS6AQAAAAAei/r3nHy7fo30fXWEhObKleD5vGH55OL58x7v941BL0qw3JBNmzaZoHvfvn0mmE5KdHS0vP322/LBBx+Iv7+/dOnSRQYMGCALFy40z+u/w4YNkylTpkjNmjVl165d0qtXL7Pvbt26id0IugEAAAAAHjt2+A9xOBxSulz5dN3viT+PS6cOj0q1atXM4zJlyiS7/fXr12XGjBlStmxZ87hPnz7y+uuvO5+PjIyUd955R9q2bWsely5d2gTyM2fOJOgGAAAAAGRSDoctu+3c61kZ+fILsmbNGmnatKm0a9dOqlevnuT2oaGhzoBb3XrrrXL69Gnz9+XLl+WPP/6QHj16mOy25caNGxk2GBt9ugEAAAAAHrutTDnTv/rwwd+S3MbP3+////W/AF0HWkvOo126y6FDh+Txxx+XvXv3Su3atWXy5MlJbh8UFOR+TD8/k4FXly5dMv/Onj1bdu/e7Vx+/vln+f777yUjEHQDAAAAADyW75b80vDe++XjuTMk+vLlBM/rwGj5CxRyTitmOfDzTzfdd4kSJaR3796yZMkSeemll0zQnBpFihSRokWLmiC+XLlybos2M88INC8HAAAAAKTKkDcnSpdW98ljLRpJn5eHSoUq1UzT7a3frJPF82fL8u92S0StujLn3bel2G2l5NzZM/Lum8OT3eeYIQOkS9vWUr58efn3339lw4YNZuTx1BoxYoS88MILpjm5jmweExMj27dvN/vu37+/2I2gGwAAAACQKiVKlZbP1m2RmRPGylvDB5mMdv4CBaVyxB0ydNy7ZpuRk2bKsH69pf39DaRU2fLy0rBR0qt9qyT3GRcbK88995z8+eefkjdvXhMoT5gwIdVl7Nmzp+n3/dZbb8nAgQPNqOU6SFu/fv0kI/g5rMbuPuLChQvmDsf58+fNG5iZReyw/64L0teeWuO9XYRMj3qd9VCvk1dn5kFvFwEe+vHpct4uQqZHvc56qNdZt04XCYmV/pVipHDxkuIflMPbxck0KhcKkczg6tWrcvjwYdMUXef4Tk1sSZ9uAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAADgJTqXlJlOyhHn7aIgEXFxaX9fmKcbAAAAALzkn2v+cj7GIbn/OS2h+QqIX0CgiJ+f+LqrV717fJ1Z+9q1a3LmzBnx9/eX4ODgVO+LoBsAAAAAvCTW4SfTf88pDxWLkQrRf0sgbZGNgPNBkhmEhobKbbfdZgLv1CLoBgAAAAAvirruLx8cCZFcgQ4JDXCQ6BaRzzqU9HYRJCAgQAIDA8UvjW8IQTcAAAAAeJlD/OTSDV28XZLMISQkRLILGi8AAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYJFC8bOrUqfLWW2/JyZMnJSIiQiZPnix169ZNcvuJEyfK9OnT5dixY1KwYEF59NFHZcyYMRISEiLZzerhP3q7CPDUcm8XAAAAAEBm4tVM9+LFi6V///4SGRkpO3fuNEF38+bN5fTp04lu/9FHH8mgQYPM9vv375f33nvP7OPVV1/N8LIDAAAAAJCpg+7x48dLr169pHv37lK5cmWZMWOGhIaGyty5cxPdfsuWLdKwYUPp1KmTlCpVSpo1ayYdO3aUbdu2ZXjZAQAAAADItEH3tWvXZMeOHdK0adP/Fcbf3zzeunVroq9p0KCBeY0VZB86dEhWrlwpLVu2zLByAwAAAACQ6ft0nz17VmJjY6VIkSJu6/XxgQMHEn2NZrj1dXfddZc4HA65ceOG9O7dO9nm5TExMWaxXLhwIR3PAgAAAACAbDJ6+caNG2X06NEybdo00wd8yZIl8uWXX8rIkSOTfI0OshYWFuZcSpQokaFlBgAAAAD4Lq9lunXk8YCAADl16pTben0cHh6e6GuGDh0qjz/+uPTs2dM8rlatmly+fFmeeuopee2110zz9PgGDx5sBmtzzXQTeAMAAAAAsnWmOzg4WGrVqiXr1q1zrouLizOP69evn+hroqOjEwTWGrgrbW6emBw5ckjevHndFgAAAAAAsv083ZqB7tatm9SuXdvMza1zcGvmWkczV127dpVixYqZJuKqdevWZsTzmjVrSr169eTgwYMm+63rreAbAAAAAIDMwqtBd4cOHeTMmTMybNgwOXnypNSoUUNWrVrlHFzt2LFjbpntIUOGiJ+fn/n3r7/+kkKFCpmAe9SoUV48CwAAAAAAMmHQrfr06WOWpAZOcxUYGCiRkZFmAQAAAAAgs8tSo5cDAAAAAJCVEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAQGYJuq9cuSLR0dHOx0ePHpWJEyfKmjVr0rtsAAAAAAD4VtD98MMPy4IFC8zfUVFRUq9ePXnnnXfM+unTp9tRRgAAAAAAfCPo3rlzpzRq1Mj8/dlnn0mRIkVMtlsD8XfffdeOMgIAAAAA4BtBtzYtz5Mnj/lbm5S3bdtW/P395c477zTBNwAAAAAASGXQXa5cOVm6dKkcP35cVq9eLc2aNTPrT58+LXnz5vV0dwAAAAAAZFseB93Dhg2TAQMGSKlSpUx/7vr16zuz3jVr1rSjjAAAAAAAZEmBnr7g0UcflbvuuktOnDghERERzvVNmjQxTc0BAAAAAEAqM91PPvmk5MqVy2S1tS+3pUqVKjJ27FhPdwcAAAAAQLblcdD9/vvvm7m649N11lRiAAAAAADAg+blFy5cEIfDYZaLFy9KSEiI87nY2FhZuXKlFC5c2K5yAgAAAACQfYPufPnyiZ+fn1nKly+f4HldP2LEiPQuHwAAAAAA2T/o3rBhg8ly33ffffL5559L/vz5nc8FBwdLyZIlpWjRonaVEwAAAACA7Bt0N27c2Px7+PBhue2220xmGwAAAAAApONAaprR/vbbb6VLly7SoEED+euvv8z6Dz74wKwHAAAAAACpDLq1aXnz5s0lZ86csnPnTomJiTHrz58/L6NHj/Z0dwAAAAAAZFseB91vvPGGzJgxQ2bPni1BQUHO9Q0bNjRBOAAAAAAASGXQ/euvv8rdd9+dYH1YWJhERUV5ujsAAAAAALItj4Pu8PBwOXjwYIL12p+7TJky6VUuAAAAAAB8L+ju1auX9O3bV3744Qczgvnff/8tCxculAEDBsgzzzxjTykBAAAAAMjOU4ZZBg0aJHFxcdKkSROJjo42Tc1z5Mhhgu7nn3/enlICAAAAAOALQbdmt1977TUZOHCgaWZ+6dIlqVy5suTOndueEgIAAAAA4CtBtyU4ONgE2wAAAAAAIA1Bd9u2bWX+/PmSN29e83dyNONdpUoV6d27txnRHAAAAAAAX5WioFuDZ21Wbv2dnJiYGDOP93fffSfLli1Ln1ICAAAAAJBdg+558+Yl+ndS9u3bJ3Xq1ElbyQAAAAAA8LUpw1KiQoUKsmXLFjt2DQAAAABA9h1I7d5773U2NU/M+vXrJSAgQCIiItJaNgAAAAAAfCvorlGjhtvj69evy+7du+Xnn3+Wbt26pWfZAAAAAADwraB7woQJia4fPny4mbMbAAAAAACkcZ7u+Lp06SJ169aVt99+O712CQAAAC+4Vnuat4sAj433dgEA2D2Q2tatWyUkJCS9dgcAAAAAgO9lutu2bev22OFwyIkTJ2T79u0ydOjQ9CwbAAAAAAC+FXSHhYW5Pfb39zdThL3++uvSrFmz9CwbAAAAAAC+FXTPmzfPnpIAAAAAAODrfbqPHz8uf/75p/Pxtm3bpF+/fjJr1qz0LhsAAAAAAL4VdHfq1Ek2bNhg/j558qQ0bdrUBN6vvfaaaWIOAAAAAABSGXT//PPPZmow9cknn0i1atVky5YtsnDhQpk/f76nuwMAAAAAINvyOOi+fv265MiRw/z99ddfy0MPPWT+rlixohnFHAAAAAAApDLorlKlisyYMUM2b94sa9eulRYtWpj1f//9txQoUMDT3cnUqVOlVKlSZo7vevXqmabqyYmKipLnnntObr31VhP8ly9fXlauXOnxcQEAAAAAyHRB99ixY2XmzJlyzz33SMeOHSUiIsKsX7ZsmbPZeUotXrxY+vfvL5GRkbJz506zr+bNm8vp06cT3f7atWty//33y5EjR+Szzz6TX3/9VWbPni3FihXz9DQAAAAAAMh8U4ZpsH327Fm5cOGC3HLLLc71Tz31lISGhnq0r/Hjx0uvXr2ke/fu5rFm0L/88kuZO3euDBo0KMH2uv7cuXOmD3lQUJBZp1lyAAAAAACyRaZbBQQEuAXcVvBbuHDhFO9Ds9Y7duwwo587C+Pvbx5v3bo10ddoNr1+/fqmeXmRIkWkatWqMnr0aImNjU3NaQAAAAAAkLky3elFs+UaLGvw7EofHzhwINHXHDp0SNavXy+dO3c2/bgPHjwozz77rBncTZuoJyYmJsYsFs3QAwAAAACQaTPd3hIXF2ey6bNmzZJatWpJhw4dzPzg2iw9KWPGjJGwsDDnUqJEiQwtMwAAAADAd3kt6C5YsKBppn7q1Cm39fo4PDw80dfoiOU6Wrm+zlKpUiU5efKkaa6emMGDB8v58+edy/Hjx9P5TAAAAAAAsDHo1mm8PBUcHGyy1evWrXPLZOtj7bedmIYNG5om5bqd5bfffjPBuO4vMTqtWN68ed0WAAAAAAAy7ZRhOtWXpX379mZ+bp22a8+ePR7tS6cL0ym/3n//fdm/f78888wzcvnyZedo5l27djWZaos+r6OX9+3b1wTbOtK5DqSmA6sBAAAAAJDlB1LT/tMLFy40f69du9YsX331lXzyyScycOBAWbNmTYr3pX2yz5w5I8OGDTNNxGvUqCGrVq1yDq527NgxM6K5Rftjr169Wl588UWpXr26CfQ1AH/llVc8PQ0AAAAAADJf0K3BsTUY2YoVK0ymu1mzZmbKsHr16nlcgD59+pglMRs3bkywTpuef//99x4fBwAAAACATN+8XOfntgYj06y0Nc+2w+FgvmwAAAAAANKS6W7btq106tRJbr/9dvnnn3/kgQceMOt37dol5cqV83R3AAAAAABkWx4H3RMmTDBNyTXbPW7cOMmdO7dZf+LECXn22WftKCMAAAAAAL4RdAcFBcmAAQMSrNfBzQAAAAAAQBrn6f7ggw/krrvukqJFi8rRo0fNuokTJ8oXX3yRmt0BAAAAAJAteRx0T58+3cyvrX25o6KinIOn5cuXzwTeAAAAAAAglUH35MmTZfbs2fLaa69JQECAc33t2rVl7969nu4OAAAAAIBsy+Og+/Dhw1KzZs0E63PkyCGXL19Or3IBAAAAAOB7QXfp0qVl9+7dCdbrnN2VKlVKr3IBAAAAAOB7o5drf+7nnntOrl69Kg6HQ7Zt2yYff/yxjBkzRubMmWNPKQEAAAAA8IWgu2fPnpIzZ04ZMmSIREdHS6dOncwo5pMmTZLHHnvMnlICAAAAAOALQbfq3LmzWTTovnTpkhQuXDj9SwYAAAAAgC8G3ZbQ0FCzAAAAAACAVAbdOlq5n59fSjaVnTt3pmg7AAAAAACyuxQF3W3atHH+rQOoTZs2TSpXriz169c3677//nv55Zdf5Nlnn7WvpAAAAAAAZMegOzIy0m0gtRdeeEFGjhyZYJvjx4+nfwkBAAAAAPCVebo//fRT6dq1a4L1Xbp0kc8//zy9ygUAAAAAgO8F3Tpd2HfffZdgva4LCQlJr3IBAAAAAOB7o5f369dPnnnmGTNgWt26dc26H374QebOnStDhw61o4wAAAAAAPhG0D1o0CApU6aMTJo0ST788EOzrlKlSjJv3jxp3769HWUEAAAAAMB35unW4JoAGwAAAACAdO7TDQAAAAAAUoagGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAEBmGb08NjZW5s+fL+vWrZPTp09LXFyc2/Pr169Pz/IBAAAAAOA7QXffvn1N0P3ggw9K1apVxc/Pz56SAQAAAADga0H3okWL5JNPPpGWLVvaUyIAAAAAAHy1T3dwcLCUK1fOntIAAAAAAODLQfdLL70kkyZNEofDYU+JAAAAAADw1ebl3377rWzYsEG++uorqVKligQFBbk9v2TJkvQsHwAAAAAAvhN058uXTx555BF7SgMAAAAAgC8H3fPmzbOnJAAAAAAA+HrQbTlz5oz8+uuv5u8KFSpIoUKF0rNcAAAAAAD43kBqly9flieffFJuvfVWufvuu81StGhR6dGjh0RHR9tTSgAAAAAAfCHo7t+/v3zzzTeyfPlyiYqKMssXX3xh1unI5gAAAAAAIJXNyz///HP57LPP5J577nGua9mypeTMmVPat28v06dP93SXAAAAAABkSx5nurUJeZEiRRKsL1y4MM3LAQAAAABIS9Bdv359iYyMlKtXrzrXXblyRUaMGGGeAwAAAAAAqWxePmnSJGnevLkUL15cIiIizLo9e/ZISEiIrF692tPdAQAAAACQbXkcdFetWlV+//13WbhwoRw4cMCs69ixo3Tu3Nn06wYAAAAAAGmYpzs0NFR69eqVmpcCAAAAAOAzUhR0L1u2TB544AEJCgoyfyfnoYceSq+yAQAAAACQ/YPuNm3ayMmTJ80I5fp3Uvz8/CQ2NjY9ywcAAAAAQPYOuuPi4hL9GwAAAAAApOOUYQsWLJCYmJgE669du2aeAwAAAAAAqQy6u3fvLufPn0+w/uLFi+Y5AAAAAACQyqDb4XCYvtvx/fnnnxIWFubp7gAAAAAAyLZSPGVYzZo1TbCtS5MmTSQw8H8v1cHTDh8+LC1atLCrnAAAAAAAZN+g2xq1fPfu3dK8eXPJnTu387ng4GApVaqUtGvXzp5SAgAAAACQnYPuyMhIk9HW4LpZs2Zy66232lsyAAAAAAB8qU93QECAPP3003L16lX7SgQAAAAAgK8OpFa1alU5dOiQPaUBAAAAAMCXg+433nhDBgwYICtWrJATJ07IhQsX3BYAAAAAAOBhn25Ly5Ytzb8PPfSQ29Rh1lRi2u8bAAAAAACkIujesGGDPSUBAAAAAMDXg+7GjRvbUxIAAAAAAHw96FZRUVHy3nvvyf79+83jKlWqyJNPPilhYWHpXT4AAAAAAHxnILXt27dL2bJlZcKECXLu3DmzjB8/3qzbuXOnPaUEAAAAAMAXMt0vvviiGURt9uzZEhj4fy+/ceOG9OzZU/r16yebNm2yo5wAAAAAAGT/oFsz3a4Bt9lJYKC8/PLLUrt27fQuHwAAAAAAvtO8PG/evHLs2LEE648fPy558uRJr3IBAAAAAOB7QXeHDh2kR48esnjxYhNo67Jo0SLTvLxjx472lBIAAAAAAF9oXv7222+Ln5+fdO3a1fTlVkFBQfLMM8/Im2++aUcZAQAAACDVrtWe5u0iwGPjxWeD7uDgYJk0aZKMGTNG/vjjD7NORy4PDQ21o3wAAAAAAPhO83KLBtn58uUzS1oD7qlTp0qpUqUkJCRE6tWrJ9u2bUvR67RZu2bd27Rpk6bjAwAAAACQKYJubVI+dOhQCQsLM4GyLvr3kCFD5Pr16x4XQPuG9+/fXyIjI8083xEREdK8eXM5ffp0sq87cuSIDBgwQBo1auTxMQEAAAAAyJRB9/PPPy+zZs2ScePGya5du8yif7/33nvywgsveFyA8ePHS69evaR79+5SuXJlmTFjhsmcz507N8nXxMbGSufOnWXEiBFSpkwZj48JAAAAAECm7NP90UcfmWbdDzzwgHNd9erVpUSJEmb08unTp6d4X9euXZMdO3bI4MGDnev8/f2ladOmsnXr1iRf9/rrr0vhwoXNKOqbN2/29BQAAAAAAMicQXeOHDlMk/L4SpcubQZZ88TZs2dN1rpIkSJu6/XxgQMHEn3Nt99+a7Lqu3fvTtExYmJizGK5cOGCR2UEAAAAACDDmpf36dNHRo4c6RbI6t+jRo0yz9np4sWL8vjjj8vs2bOlYMGCKXqNjrKufc6tRTPyAAAAAABkyky39uFet26dFC9e3Ax6pvbs2WOaijdp0kTatm3r3HbJkiXJ7ksD54CAADl16pTben0cHh6eYHudokwHUGvdurVzXVxc3P+dSGCg/Prrr2b6MlfadF0HanPNdBN4AwAAAAAyZdCtU4S1a9fObV1qg1htjl6rVi0TxFvTfmkQrY8Ty5pXrFhR9u7d67ZOR03XDLjOHZ5YObQ5vC4AAABImdXDf/R2EeCp5d4uAIB0C7rnzZsn6Umz0N26dZPatWtL3bp1ZeLEiXL58mUzmrnq2rWrFCtWzDQT13m8q1atmuAmgIq/HgAAAACALBd0W86cOWOac6sKFSpIoUKFUrWfDh06mH0NGzZMTp48KTVq1JBVq1Y5B1c7duyYGdEcAAAAAIBsH3RrFlrn6l6wYIGzP7X2y9aM9OTJk80c257SpuRJDcK2cePGZF87f/58j48HAAAAAEBG8E9Nc/BvvvlGli9fLlFRUWb54osvzLqXXnrJnlICAAAAAOALme7PP/9cPvvsM7nnnnuc61q2bCk5c+aU9u3by/Tp09O7jAAAAAAA+EamOzo62tnf2lXhwoXNcwAAAAAAIJVBd/369SUyMlKuXr3qXHflyhUZMWKEeQ4AAAAAAKSyeblO6dWiRQspXry4REREmHV79uwx03mtXr3a090BAAAAAJBteRx0V6tWTX7//XdZuHChHDhwwKzr2LGjdO7c2fTrBgAAAAAAqQi6r1+/LhUrVpQVK1ZIr169PHkpAAAAAAA+x6M+3UFBQW59uQEAAAAAQDoOpPbcc8/J2LFj5caNG56+FAAAAAAAn+Jxn+4ff/xR1q1bJ2vWrDH9u3PlyuX2/JIlS9KzfAAAAAAA+E7QnS9fPmnXrp09pQEAAAAAwJeD7nnz5tlTEgAAAAAAfLVPd1xcnOnL3bBhQ6lTp44MGjRIrly5Ym/pAAAAAADwhaB71KhR8uqrr0ru3LmlWLFiMmnSJDOoGgAAAAAASGPQvWDBApk2bZqsXr1ali5dKsuXL5eFCxeaDDgAAAAAAEhD0H3s2DFp2bKl83HTpk3Fz89P/v7775TuAgAAAAAAn5LioFvn5Q4JCXFbFxQUJNevX7ejXAAAAAAA+M7o5Q6HQ5544gnJkSOHc93Vq1eld+/ebnN1M083AAAAAAAeBt3dunVLsK5Lly4pfTkAAAAAAD4nxUE383MDAAAAAGBTn24AAAAAAOAZgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAAAgOwfdU6dOlVKlSklISIjUq1dPtm3bluS2s2fPlkaNGsktt9xilqZNmya7PQAAAAAAPht0L168WPr37y+RkZGyc+dOiYiIkObNm8vp06cT3X7jxo3SsWNH2bBhg2zdulVKlCghzZo1k7/++ivDyw4AAAAAQKYOusePHy+9evWS7t27S+XKlWXGjBkSGhoqc+fOTXT7hQsXyrPPPis1atSQihUrypw5cyQuLk7WrVuX4WUHAAAAACDTBt3Xrl2THTt2mCbizgL5+5vHmsVOiejoaLl+/brkz5/fxpICAAAAAOC5QPGis2fPSmxsrBQpUsRtvT4+cOBAivbxyiuvSNGiRd0Cd1cxMTFmsVy4cCGNpQYAAAAAIIs0L0+LN998UxYtWiT//e9/zSBsiRkzZoyEhYU5F+0DDgAAAABAtg+6CxYsKAEBAXLq1Cm39fo4PDw82de+/fbbJuhes2aNVK9ePcntBg8eLOfPn3cux48fT7fyAwAAAACQaYPu4OBgqVWrltsgaNagaPXr10/ydePGjZORI0fKqlWrpHbt2skeI0eOHJI3b163BQAAAACAbN+nW+l0Yd26dTPBc926dWXixIly+fJlM5q56tq1qxQrVsw0E1djx46VYcOGyUcffWTm9j558qRZnzt3brMAAAAAAJBZeD3o7tChg5w5c8YE0hpA61RgmsG2Blc7duyYGdHcMn36dDPq+aOPPuq2H53ne/jw4RlefgAAAAAAMm3Qrfr06WOWxGzcuNHt8ZEjRzKoVAAAAAAA+PDo5QAAAAAAZGaZItMNAEBWda32NG8XAR4b7+0CAAB8CJluAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2CTQrh0DQGJWD//R20WAp5Z7uwAAAABZF0E3AAAAgGyNm/5Z0HLJNmheDgAAAACATQi6AQAAAACwCUE3AAAAAAA2IegGAAAAAMAmBN0AAAAAANiEoBsAAAAAAJsQdAMAAAAAYBOCbgAAAAAAbELQDQAAAACATQLt2jEAAL5g9fAfvV0EeGq5twsAAPAlZLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAACQnYPuqVOnSqlSpSQkJETq1asn27ZtS3b7Tz/9VCpWrGi2r1atmqxcuTLDygoAAAAAQJYJuhcvXiz9+/eXyMhI2blzp0REREjz5s3l9OnTiW6/ZcsW6dixo/To0UN27dolbdq0McvPP/+c4WUHAAAAACBTB93jx4+XXr16Sffu3aVy5coyY8YMCQ0Nlblz5ya6/aRJk6RFixYycOBAqVSpkowcOVLuuOMOmTJlSoaXHQAAAACATBt0X7t2TXbs2CFNmzb9X4H8/c3jrVu3JvoaXe+6vdLMeFLbAwAAAADgLYFeO7KInD17VmJjY6VIkSJu6/XxgQMHEn3NyZMnE91e1ycmJibGLJbz58+bfy9cuCCZ3cXrN7xdBHgoNAvUK2+jXmc91OvkUaezHur0zVGvsx7qdfKo01lPaBao01ZM6XA4Mm/QnRHGjBkjI0aMSLC+RIkSXikPsrmwMG+XAEh/1GtkN9RpZEfUa2Q3YVmnTl+8eFHCkimvV4PuggULSkBAgJw6dcptvT4ODw9P9DW63pPtBw8ebAZqs8TFxcm5c+ekQIEC4ufnly7nAc/vCOlNj+PHj0vevHm9XRwgzajTyI6o18huqNPIjqjX3qUZbg24ixYtmux2Xg26g4ODpVatWrJu3TozArkVFOvjPn36JPqa+vXrm+f79evnXLd27VqzPjE5cuQwi6t8+fKl63kgdfSLgS8HZCfUaWRH1GtkN9RpZEfUa+9JLsOdaZqXaxa6W7duUrt2balbt65MnDhRLl++bEYzV127dpVixYqZZuKqb9++0rhxY3nnnXfkwQcflEWLFsn27dtl1qxZXj4TAAAAAAAyWdDdoUMHOXPmjAwbNswMhlajRg1ZtWqVc7C0Y8eOmRHNLQ0aNJCPPvpIhgwZIq+++qrcfvvtsnTpUqlataoXzwIAAAAAgEwYdCttSp5Uc/KNGzcmWPef//zHLMiatLl/ZGRkgmb/QFZFnUZ2RL1GdkOdRnZEvc4a/Bw3G98cAAAAAACkyv/abQMAAAAAgHRF0A0AAAAAgE0IugEAAAAAsAlBN1LsiSeeED8/P7MEBQWZEebvv/9+mTt3rplf3W46qN4dd9xhBoooV66czJ8/3/ZjInvzZp0+ceKEdOrUScqXL29maOjXr5+tx4Pv8Ga9XrJkiTlWoUKFzHyx9evXl9WrV9t6TGR/3qzT3377rTRs2FAKFCggOXPmlIoVK8qECRNsPSZ8g7d/V1u+++47CQwMNDNIwT4E3fBIixYtTLBw5MgR+eqrr+Tee+81c6e3atVKbty4YdtxDx8+bOZl1+Pt3r3bBCg9e/bkxxyybJ2OiYkxgYlOfxgREWHbceCbvFWvN23aZH40rly5Unbs2GGO27p1a9m1a5dtx4Rv8FadzpUrl5lhR+v2/v37zXe2LrNmzbLtmPAd3qrXlqioKOnatas0adLE9mP5PB29HEiJbt26OR5++OEE69etW6cj4Dtmz57tXHf06FHHQw895MiVK5cjT548jv/85z+OkydPur1u2bJljtq1azty5MjhKFCggKNNmzZJHvvll192VKlSxW1dhw4dHM2bN0+Xc4Nv8maddtW4cWNH37590+GMgMxTry2VK1d2jBgxIg1nBF+X2er0I4884ujSpUsazgjIHPVaf0sPGTLEERkZ6YiIiEinM0NiyHQjze677z6TqdNmhUqbxDz88MNy7tw5+eabb2Tt2rVy6NAh6dChg/M1X375pTzyyCPSsmVLkwFZt26d1K1bN8ljbN26VZo2beq2rnnz5mY9kBXrNOAL9VqPcfHiRcmfP78t5wTf5o06ra/ZsmWLNG7c2JZzAjKqXs+bN8/sR+f4hv0CM+AY8AHax+mnn34yf+sHfe/evaZJeIkSJcy6BQsWSJUqVeTHH3+UOnXqyKhRo+Sxxx6TESNGOPeRXBPbkydPmr4urvTxhQsX5MqVK6afFZCV6jTgC/X67bfflkuXLkn79u1tOBsg4+p08eLF5cyZM6bJ7/Dhw00XNyCr1uvff/9dBg0aJJs3bzb9uWE/Mt1IFw6HwwwEobTPk34pWF8MqnLlypIvXz7znNJ+2fQfQWZGnUZ2lJH1+qOPPjI/AD/55BMpXLhwOp0B4J06rcHJ9u3bZcaMGTJx4kT5+OOP0/EsgIyr17GxsWYgV/1+1sFckTG4tYF0oR/60qVLp3h7TzPT4eHhcurUKbd1+lhHxyXLjaxYp4HsXK8XLVpkMoGffvppgq5BQFas09YxqlWrZn5/aLa7Y8eOqdoX4M16rV1+9AaSNkPXQQKtJuwa6GvWe82aNaaJO9IXmW6k2fr1602zl3bt2pnHlSpVkuPHj5vFsm/fPjNCot6ZU9WrVzfNZVJKp52Jv732adH1QFas00B2rdeaAezevbv5V2edALLbd7UGKDoDBZAV67UmrHT/mh23lt69e0uFChXM3/Xq1bPpzHxcosOrAUmMstiiRQvHiRMnHH/++adjx44djlGjRjly587taNWqlePGjRtmu7i4OEeNGjUcjRo1Mtv88MMPjlq1apkRmi0bNmxw+Pv7O4YNG+bYt2+f46effnK8+eabSR770KFDjtDQUMfAgQMd+/fvd0ydOtUREBDgWLVqVYacO7Inb9ZptWvXLrPovjp16mT+/uWXX2w/b2Rv3qzXCxcudAQGBprvaD2+tURFRWXIuSN78madnjJlihkV+rfffjPLnDlzzOjRr732WoacO7Ivb/8GccXo5fYj6IZHXw56n0YX/VFVqFAhR9OmTR1z5851xMbGum2bkqkNPv/8c/MlEhwc7ChYsKCjbdu2yR5fv1Cs7cuUKeOYN2+eLecJ3+HtOm0d23UpWbKkLecK3+HNeq0/AhOr11omICvW6XfffddMWao3/vPmzeuoWbOmY9q0aQmOC2S13yCuCLrt56f/8Xa2HQAAAACA7Ig+3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwCATOSJJ54QPz8/swQFBUmRIkXk/vvvl7lz50pcXJz4gvnz50u+fPm8XQwAANIFQTcAAJlMixYt5MSJE3LkyBH56quv5N5775W+fftKq1at5MaNG94uHgAA8ABBNwAAmUyOHDkkPDxcihUrJnfccYe8+uqr8sUXX5gAXLPA6tixY/Lwww9L7ty5JW/evNK+fXs5deqU236WL18uderUkZCQEClYsKA88sgjzuc0k7506VK37TW7bO1fA37d5pNPPpFGjRpJzpw5zb5+++03+fHHH6V27drm2A888ICcOXPGbT9z5syRSpUqmeNWrFhRpk2b5nzO2u+SJUvMzYTQ0FCJiIiQrVu3muc3btwo3bt3l/Pnzzsz/sOHD7fhKgMAkDEIugEAyALuu+8+E5xqsKrNzDXgPnfunHzzzTeydu1aOXTokHTo0MG5/ZdffmmC7JYtW8quXbtk3bp1UrduXY+PGxkZKUOGDJGdO3dKYGCgdOrUSV5++WWZNGmSbN68WQ4ePCjDhg1zbr9w4ULzeNSoUbJ//34ZPXq0DB06VN5//323/b722msyYMAA2b17t5QvX146duxosvgNGjSQiRMnmhsJmu3XRbcDACCrCvR2AQAAQMpo1vinn34yAfTevXvl8OHDUqJECfPcggULpEqVKiYLrRlpDXofe+wxGTFihPP1GrR7SgPe5s2bm7+1ibsGx3r8hg0bmnU9evRwZsetIP2dd96Rtm3bmselS5eWffv2ycyZM6Vbt25u+33wwQfN31pGLbsG8HqOYWFhJsOt2X4AALI6Mt0AAGQRDofDBKOaQdZg2wq4VeXKlU3zcH1OaQa5SZMmaT5m9erVnX/roG6qWrVqbutOnz5t/r58+bL88ccfJhDXpufW8sYbb5j1Se331ltvNf9a+wEAIDsh0w0AQBahAbVmjlNC+2AnR4N3DeJdXb9+PcF2OoK662sSW2eNqn7p0iXz7+zZs6VevXpu+wkICLjpfn1ldHYAgG8h0w0AQBawfv1606S8Xbt2ZpCy48ePm8WiTbijoqJMxtvKJGsz8KQUKlTI9Je2/P777xIdHZ2mMmrWu2jRoqZ/ebly5dyWlN4sUMHBwRIbG5umsgAAkFmQ6QYAIJOJiYmRkydPmsBTRyRftWqVjBkzxkwZ1rVrV/H39zdNvDt37mwGHdMByJ599llp3LixGVXc6lutzcvLli1r+nbrNitXrpRXXnnFOTDblClTpH79+uY4ut41+5xa2j/7hRdeMP2ydeozPZft27fLv//+K/3790/RPkqVKmWy5nrTQPuh6wjnugAAkBWR6QYAIJPRIFv7OWvwqYHrhg0b5N133zXThmkzbW2OrX/fcsstcvfdd0vTpk2lTJkysnjxYuc+7rnnHvn0009l2bJlUqNGDRNkb9u2zfm8DnamfcJ1OjAdkVwHNkuPwLZnz55myrB58+aZGwN6I0AHWvMk060jmPfu3duMxq4Z+XHjxqW5XAAAeIufI36HLgAAAAAAkC7IdAMAAAAAYBOCbgAAAAAAbELQDQAAAACATQi6AQAAAACwCUE3AAAAAAA2IegGAAAAAMAmBN0AAAAAANiEoBsAAAAAAJsQdAMAAAAAYBOCbgAAAAAAbELQDQAAAACATQi6AQAAAAAQe/w/aQ4wr7+UFgQAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 1000x500 with 1 Axes>"
       ]
@@ -1165,10 +1216,10 @@
    "id": "d6e7f8a5",
    "metadata": {
     "papermill": {
-     "duration": 0.009177,
-     "end_time": "2026-06-03T00:07:42.577337+00:00",
+     "duration": 0.004219,
+     "end_time": "2026-08-29T08:13:49.044761",
      "exception": false,
-     "start_time": "2026-06-03T00:07:42.568160+00:00",
+     "start_time": "2026-08-29T08:13:49.040542",
      "status": "completed"
     },
     "tags": []
@@ -1182,20 +1233,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "e7f8a9b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:53:13.036024Z",
-     "iopub.status.busy": "2026-07-03T15:53:13.036024Z",
-     "iopub.status.idle": "2026-07-03T15:53:13.040286Z",
-     "shell.execute_reply": "2026-07-03T15:53:13.040286Z"
+     "iopub.execute_input": "2026-08-29T08:13:49.054913Z",
+     "iopub.status.busy": "2026-08-29T08:13:49.054419Z",
+     "iopub.status.idle": "2026-08-29T08:13:49.059444Z",
+     "shell.execute_reply": "2026-08-29T08:13:49.059058Z"
     },
     "papermill": {
-     "duration": 0.024089,
-     "end_time": "2026-06-03T00:07:42.609910+00:00",
+     "duration": 0.010673,
+     "end_time": "2026-08-29T08:13:49.060088",
      "exception": false,
-     "start_time": "2026-06-03T00:07:42.585821+00:00",
+     "start_time": "2026-08-29T08:13:49.049415",
      "status": "completed"
     },
     "tags": []
@@ -1211,7 +1262,7 @@
       "     0             [0.80, 0.10, 0.10]             [0.81, 0.11, 0.08] Science (OK)\n",
       "     1             [0.10, 0.80, 0.10]             [0.12, 0.81, 0.07] Sport (OK)\n",
       "     2             [0.10, 0.10, 0.80]             [0.09, 0.09, 0.82] Cuisine (OK)\n",
-      "     3             [0.40, 0.40, 0.20]             [0.40, 0.24, 0.36] Science (OK)\n",
+      "     3             [0.40, 0.40, 0.20]             [0.39, 0.24, 0.36] Science (OK)\n",
       "     4             [0.20, 0.30, 0.50]             [0.12, 0.30, 0.58] Cuisine (OK)\n"
      ]
     }
@@ -1233,13 +1284,654 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fbd914a3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00482,
+     "end_time": "2026-08-29T08:13:49.069410",
+     "exception": false,
+     "start_time": "2026-08-29T08:13:49.064590",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5bis. Exemple resolu : selectionner le nombre de sujets (K)\n",
+    "\n",
+    "Jusqu'ici, `K = 3` et les priors asymetriques `beta_asym` encodaient notre connaissance des trois sujets (Science, Sport, Cuisine). En pratique, on ne connait **ni K, ni les mots canoniques** des sujets : on doit choisir K en comparant des modeles ajustes sur les donnees seules.\n",
+    "\n",
+    "Le protocole standard comporte trois mesures independantes, calculees sur les topics **effectivement appris** (jamais sur `phi_true`, jamais sur les etiquettes cachees) :\n",
+    "\n",
+    "1. **Coherence UMass documentaire** (Mimno et al. 2011) : pour chaque sujet, les paires de ses mots dominants doivent co-apparaitre dans les memes documents. Valeurs proches de 0 = sujets interpretables.\n",
+    "2. **Redondance entre sujets** : similarite cosinus maximale entre paires de sujets appris. Un K trop grand fabrique des sujets quasi identiques.\n",
+    "3. **Log-vraisemblance predictive held-out** : chaque document est coupe en deux moities ; le modele est ajuste sur la premiere (49 mots), on evalue la probabilite moyenne des mots de la seconde (51 mots). Mesure la capacite predictive, pas seulement l'ajustement.\n",
+    "\n",
+    "Chaque K fait donc l'objet de **deux ajustements separes** : un ajustement sur le **corpus complet** (100 mots) pour les mesures de qualite des sujets --- coherence et redondance s'estiment sur les sujets appris avec toutes les donnees, pratique standard des pipelines sklearn/gensim --- et un ajustement sur la **moitie d'apprentissage** pour la mesure predictive, qui exige par construction des mots tenus a l'ecart.\n",
+    "\n",
+    "Deux precautions de rigueur :\n",
+    "\n",
+    "- **Priors neutres** : `alpha = 0.5` (documents sparses) et `beta = 1` uniforme --- aucune information sur les sujets reels ne rentre dans le modele.\n",
+    "- **Alignement des permutations** : avec des priors symetriques, NUTS peut etiqueter les sujets differemment selon la chaine (*label switching*). Avant d'agreger, chaque tirage est re-ordonne par un tri canonique de ses lignes (ordre lexicographique des distributions de mots), applique conjointement a phi et theta.\n",
+    "\n",
+    "On compare enfin le K selectionne au K reel (3) --- la verite terrain sert **uniquement** de controle final, jamais a construire les sujets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "6f90e72d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:13:49.079932Z",
+     "iopub.status.busy": "2026-08-29T08:13:49.079444Z",
+     "iopub.status.idle": "2026-08-29T08:13:49.090875Z",
+     "shell.execute_reply": "2026-08-29T08:13:49.090419Z"
+    },
+    "papermill": {
+     "duration": 0.017843,
+     "end_time": "2026-08-29T08:13:49.091785",
+     "exception": false,
+     "start_time": "2026-08-29T08:13:49.073942",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Split-half : 49 mots ajustement / 51 mots held-out\n",
+      "Coherence UMass et alignement des permutations prets.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Protocole de selection de K : preparation split-half et coherence UMass\n",
+    "\n",
+    "# Split-half deterministe par document : moitie 1 pour l'ajustement,\n",
+    "# moitie 2 pour l'evaluation predictive hors echantillon\n",
+    "docs_fit, docs_held = [], []\n",
+    "for doc in documents:\n",
+    "    milieu = len(doc) // 2\n",
+    "    docs_fit.append(doc[:milieu])\n",
+    "    docs_held.append(doc[milieu:])\n",
+    "\n",
+    "bow_fit = np.zeros((n_docs, n_vocab), dtype=int)\n",
+    "bow_held = np.zeros((n_docs, n_vocab), dtype=int)\n",
+    "for d, doc in enumerate(docs_fit):\n",
+    "    for w in doc:\n",
+    "        bow_fit[d, w] += 1\n",
+    "for d, doc in enumerate(docs_held):\n",
+    "    for w in doc:\n",
+    "        bow_held[d, w] += 1\n",
+    "longueurs_fit = [len(doc) for doc in docs_fit]\n",
+    "\n",
+    "\n",
+    "def coherence_umass(phi_estime, docs, top_n=5):\n",
+    "    \"\"\"Coherence UMass moyenne sur les sujets APPRIS.\n",
+    "\n",
+    "    Pour chaque sujet k : les top_n mots dominants (selon phi_estime),\n",
+    "    somme sur les paires ordonnees de log((D(wi,wj)+1)/(D(wi)+1)),\n",
+    "    ou D compte les documents contenant le mot. Proche de 0 = coherent.\n",
+    "    \"\"\"\n",
+    "    ensembles = [set(doc) for doc in docs]\n",
+    "\n",
+    "    def freq_doc(w):\n",
+    "        return sum(1 for s in ensembles if w in s)\n",
+    "\n",
+    "    def co_freq(w1, w2):\n",
+    "        return sum(1 for s in ensembles if w1 in s and w2 in s)\n",
+    "\n",
+    "    scores_sujets = []\n",
+    "    for k in range(phi_estime.shape[0]):\n",
+    "        dominants = np.argsort(phi_estime[k])[::-1][:top_n]\n",
+    "        score = 0.0\n",
+    "        for i in range(len(dominants)):\n",
+    "            for j in range(len(dominants)):\n",
+    "                if i != j:\n",
+    "                    score += np.log((co_freq(dominants[i], dominants[j]) + 1)\n",
+    "                                    / (freq_doc(dominants[i]) + 1))\n",
+    "        scores_sujets.append(score)\n",
+    "    return float(np.mean(scores_sujets))\n",
+    "\n",
+    "\n",
+    "def phi_theta_alignes(trace):\n",
+    "    \"\"\"Moyennes posterieures de phi et theta, permutations alignees.\n",
+    "\n",
+    "    Avec des priors symetriques, chaque chaine peut etiqueter les sujets\n",
+    "    dans un ordre different (label switching) : la moyenne brute melangerait\n",
+    "    les permutations. On re-ordonne chaque tirage par tri lexicographique\n",
+    "    canonique des lignes de phi, permutation appliquee aussi a theta.\n",
+    "    \"\"\"\n",
+    "    phi_tirs = trace.posterior['phi'].stack(\n",
+    "        echant=('chain', 'draw')).transpose('echant', 'phi_dim_0', 'phi_dim_1').values\n",
+    "    theta_tirs = trace.posterior['theta'].stack(\n",
+    "        echant=('chain', 'draw')).transpose('echant', 'theta_dim_0', 'theta_dim_1').values\n",
+    "    n_tirs, _, n_v = phi_tirs.shape\n",
+    "    phi_alignes = np.empty_like(phi_tirs)\n",
+    "    theta_alignes = np.empty_like(theta_tirs)\n",
+    "    for t in range(n_tirs):\n",
+    "        ordre = np.lexsort([phi_tirs[t, :, w] for w in range(n_v)])\n",
+    "        phi_alignes[t] = phi_tirs[t][ordre]\n",
+    "        theta_alignes[t] = theta_tirs[t][:, ordre]\n",
+    "    return phi_alignes.mean(axis=0), theta_alignes.mean(axis=0)\n",
+    "\n",
+    "\n",
+    "print(f\"Split-half : {sum(longueurs_fit)} mots ajustement / {bow_held.sum()} mots held-out\")\n",
+    "print(\"Coherence UMass et alignement des permutations prets.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "13cbff03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:13:49.103186Z",
+     "iopub.status.busy": "2026-08-29T08:13:49.102858Z",
+     "iopub.status.idle": "2026-08-29T08:17:20.044814Z",
+     "shell.execute_reply": "2026-08-29T08:17:20.043795Z"
+    },
+    "papermill": {
+     "duration": 210.949445,
+     "end_time": "2026-08-29T08:17:20.045908",
+     "exception": false,
+     "start_time": "2026-08-29T08:13:49.096463",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [phi, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 15 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [phi, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 14 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K=2 : coherence UMass=-4.19, redondance=0.911, log-prob/mot held-out=-2.173\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [phi, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 16 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [phi, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 15 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K=3 : coherence UMass=-3.78, redondance=0.941, log-prob/mot held-out=-2.184\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [phi, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 15 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [phi, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 13 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K=4 : coherence UMass=-4.05, redondance=0.975, log-prob/mot held-out=-2.188\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [phi, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 14 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [phi, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 13 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K=5 : coherence UMass=-4.06, redondance=0.990, log-prob/mot held-out=-2.190\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [phi, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 14 seconds.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Initializing NUTS using jitter+adapt_diag...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Multiprocess sampling (4 chains in 4 jobs)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "NUTS: [phi, theta]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 1_000 tune and 1_500 draw iterations (4_000 + 6_000 draws total) took 13 seconds.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K=6 : coherence UMass=-4.10, redondance=0.995, log-prob/mot held-out=-2.193\n",
+      "\n",
+      "Synthese de la selection de K :\n",
+      "  K    UMass  redondance  held-out/mot\n",
+      "----------------------------------------\n",
+      "  2    -4.19       0.911        -2.173\n",
+      "  3    -3.78       0.941        -2.184\n",
+      "  4    -4.05       0.975        -2.188\n",
+      "  5    -4.06       0.990        -2.190\n",
+      "  6    -4.10       0.995        -2.193\n",
+      "\n",
+      "K=2 : sujet 0 = atome, recette, experience, ballon | sujet 1 = recette, four, ingredient, atome\n",
+      "\n",
+      "K=3 : sujet 0 = atome, experience, recette, theorie | sujet 1 = recette, ingredient, atome, four | sujet 2 = four, ballon, recette, equipe\n",
+      "\n",
+      "K=4 : sujet 0 = atome, recette, experience, ballon | sujet 1 = atome, recette, ingredient, experience | sujet 2 = recette, four, ingredient, atome | sujet 3 = four, ballon, recette, equipe\n",
+      "\n",
+      "K=5 : sujet 0 = atome, recette, experience, ingredient | sujet 1 = atome, recette, experience, ingredient | sujet 2 = recette, atome, ingredient, four | sujet 3 = four, recette, ballon, ingredient | sujet 4 = four, recette, ballon, equipe\n",
+      "\n",
+      "K=6 : sujet 0 = atome, recette, experience, ingredient | sujet 1 = atome, recette, experience, ingredient | sujet 2 = recette, atome, ingredient, experience | sujet 3 = recette, four, atome, ingredient | sujet 4 = four, recette, ballon, ingredient | sujet 5 = four, recette, ballon, equipe\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Ajustement reel des LDA concurrentes : K = 2..6, priors neutres, moteur NUTS\n",
+    "# Deux ajustements par K : corpus complet (qualite des sujets) + moitie 1 (predictif)\n",
+    "grille_K = [2, 3, 4, 5, 6]\n",
+    "resultats_K = []\n",
+    "phi_par_K = {}\n",
+    "\n",
+    "for K in grille_K:\n",
+    "    # Ajustement A : corpus complet -> sujets appris pour coherence/redondance\n",
+    "    with pm.Model() as modele_plein:\n",
+    "        phi_A = pm.Dirichlet('phi', a=np.ones((K, n_vocab)), shape=(K, n_vocab))\n",
+    "        theta_A = pm.Dirichlet('theta', a=np.ones(K) * 0.5, shape=(n_docs, K))\n",
+    "        pm.Multinomial('obs', n=doc_lengths, p=pt.dot(theta_A, phi_A),\n",
+    "                       observed=bow_matrix)\n",
+    "        trace_plein = pm.sample(1500, random_seed=42, return_inferencedata=True,\n",
+    "                                progressbar=False)\n",
+    "    phi_plein, _ = phi_theta_alignes(trace_plein)\n",
+    "    phi_par_K[K] = phi_plein\n",
+    "\n",
+    "    # Ajustement B : moitie 1 -> thetas pour la mesure predictive held-out\n",
+    "    with pm.Model() as modele_demi:\n",
+    "        phi_B = pm.Dirichlet('phi', a=np.ones((K, n_vocab)), shape=(K, n_vocab))\n",
+    "        theta_B = pm.Dirichlet('theta', a=np.ones(K) * 0.5, shape=(n_docs, K))\n",
+    "        pm.Multinomial('obs', n=longueurs_fit, p=pt.dot(theta_B, phi_B),\n",
+    "                       observed=bow_fit)\n",
+    "        trace_demi = pm.sample(1500, random_seed=42, return_inferencedata=True,\n",
+    "                               progressbar=False)\n",
+    "    phi_demi, theta_demi = phi_theta_alignes(trace_demi)\n",
+    "\n",
+    "    # Mesure 1 : coherence UMass sur les sujets appris (corpus complet)\n",
+    "    coherence = coherence_umass(phi_plein, documents, top_n=5)\n",
+    "\n",
+    "    # Mesure 2 : redondance = similarite cosinus max entre paires de sujets\n",
+    "    normalises = phi_plein / np.linalg.norm(phi_plein, axis=1, keepdims=True)\n",
+    "    similarites = normalises @ normalises.T\n",
+    "    np.fill_diagonal(similarites, 0.0)\n",
+    "    redondance = float(similarites.max()) if K > 1 else 0.0\n",
+    "\n",
+    "    # Mesure 3 : log-probabilite moyenne par mot held-out (ajustement B uniquement)\n",
+    "    probs_doc = theta_demi @ phi_demi\n",
+    "    log_ll = 0.0\n",
+    "    n_mots_held = 0\n",
+    "    for d in range(n_docs):\n",
+    "        for w, compte in enumerate(bow_held[d]):\n",
+    "            if compte > 0:\n",
+    "                log_ll += compte * np.log(probs_doc[d, w] + 1e-12)\n",
+    "                n_mots_held += compte\n",
+    "    log_ll_par_mot = log_ll / n_mots_held\n",
+    "\n",
+    "    resultats_K.append({'K': K, 'coherence': coherence,\n",
+    "                        'redondance': redondance, 'heldout': log_ll_par_mot})\n",
+    "    print(f\"K={K} : coherence UMass={coherence:.2f}, redondance={redondance:.3f}, \"\n",
+    "          f\"log-prob/mot held-out={log_ll_par_mot:.3f}\")\n",
+    "\n",
+    "print(\"\\nSynthese de la selection de K :\")\n",
+    "print(f\"{'K':>3} {'UMass':>8} {'redondance':>11} {'held-out/mot':>13}\")\n",
+    "print(\"-\" * 40)\n",
+    "for r in resultats_K:\n",
+    "    print(f\"{r['K']:>3} {r['coherence']:>8.2f} {r['redondance']:>11.3f} \"\n",
+    "          f\"{r['heldout']:>13.3f}\")\n",
+    "\n",
+    "# Mots dominants par sujet pour chaque K (les sujets APPRIS)\n",
+    "for K in grille_K:\n",
+    "    dominants = np.argsort(phi_par_K[K], axis=1)[:, ::-1][:, :4]\n",
+    "    print(f\"\\nK={K} : \" + \" | \".join(\n",
+    "        f\"sujet {k} = {', '.join(vocab[w] for w in dominants[k])}\"\n",
+    "        for k in range(K)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpretation : des metriques qui divergent\n",
+    "\n",
+    "Aucun K ne gagne sur les trois mesures --- chaque metrique repond a une question differente :\n",
+    "\n",
+    "| Mesure | Gagnant | Lecture |\n",
+    "|--------|---------|---------|\n",
+    "| Coherence UMass | **K=3** (-3.78) | Le seul maximum local de la grille --- et le K generateur du corpus |\n",
+    "| Held-out | **K=2** (-2.173) | Decroissance monotone ; ecart de 0.011 nat/mot contre K=3 : dans le bruit pour 51 mots |\n",
+    "| Redondance | penalise K grand | Croit de 0.911 a 0.995 : chaque sujet supplementaire est de plus en plus similaire aux existants |\n",
+    "\n",
+    "Quatre enseignements :\n",
+    "\n",
+    "1. **La coherence designe le bon K ici.** K=3 est le seul pic de coherence, et les top-mots montrent une structure reconnaissable : sujet 0 = atome, experience, theorie (Science), sujet 1 = recette, ingredient, four (Cuisine), sujet 2 = four, ballon, recette, equipe (Sport partiellement colle a la Cuisine).\n",
+    "\n",
+    "2. **La mesure predictive, elle, prefere K=2 et decroit des K=3.** Avec seulement 49 mots d'apprentissage, chaque sujet supplementaire dilue les comptes par document : le modele sous-determine perd immediatement en prevision. Cette divergence coherence-vs-prevision est la lecon centrale du protocole : un critere unique n'est pas une selection.\n",
+    "\n",
+    "3. **Les sujets appris restent plus flous que ceux de la section 4** (priors informes). NUTS echantillonne le posterieur complet ; malgre l'alignement canonique des permutations, les modes multiples laissent des traces (le mot « recette », le plus frequent du corpus, residue dans plusieurs sujets). Le jumeau Infer.NET, avec VMP et une initialisation jitteree, s'engage dans un seul mode et rend des sujets plus tranches --- un contraste honnete entre paradigmes d'inference, pas une difference de qualite intrinseque.\n",
+    "\n",
+    "4. **Verdict honnete** : aucune dominance nette. La selection combine le pic de coherence (K=3), la redondance qui exclut les grands K, et la lecture des top-mots ; la verite terrain (3 sujets) confirme le choix sans avoir servi a le construire.\n",
+    "\n",
+    "Ces sujets viennent de l'inference (priors neutres `alpha=0.5`, `beta=1`, alignement des permutations) : ni `phi_true`, ni `beta_asym` n'ont guide l'apprentissage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f8a9b0c7",
    "metadata": {
     "papermill": {
-     "duration": 0.010517,
-     "end_time": "2026-06-03T00:07:42.629908+00:00",
+     "duration": 0.005853,
+     "end_time": "2026-08-29T08:17:20.058121",
      "exception": false,
-     "start_time": "2026-06-03T00:07:42.619391+00:00",
+     "start_time": "2026-08-29T08:17:20.052268",
      "status": "completed"
     },
     "tags": []
@@ -1263,20 +1955,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "a9b0c1d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:53:13.042389Z",
-     "iopub.status.busy": "2026-07-03T15:53:13.041293Z",
-     "iopub.status.idle": "2026-07-03T15:53:13.301424Z",
-     "shell.execute_reply": "2026-07-03T15:53:13.301424Z"
+     "iopub.execute_input": "2026-08-29T08:17:20.071325Z",
+     "iopub.status.busy": "2026-08-29T08:17:20.071079Z",
+     "iopub.status.idle": "2026-08-29T08:17:20.303184Z",
+     "shell.execute_reply": "2026-08-29T08:17:20.302352Z"
     },
     "papermill": {
-     "duration": 0.990755,
-     "end_time": "2026-06-03T00:07:43.629168+00:00",
+     "duration": 0.239938,
+     "end_time": "2026-08-29T08:17:20.304065",
      "exception": false,
-     "start_time": "2026-06-03T00:07:42.638413+00:00",
+     "start_time": "2026-08-29T08:17:20.064127",
      "status": "completed"
     },
     "tags": []
@@ -1316,10 +2008,10 @@
    "id": "b0c1d2e9",
    "metadata": {
     "papermill": {
-     "duration": 0.009094,
-     "end_time": "2026-06-03T00:07:43.646517+00:00",
+     "duration": 0.005969,
+     "end_time": "2026-08-29T08:17:20.316730",
      "exception": false,
-     "start_time": "2026-06-03T00:07:43.637423+00:00",
+     "start_time": "2026-08-29T08:17:20.310761",
      "status": "completed"
     },
     "tags": []
@@ -1339,20 +2031,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "c1d2e3f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-03T15:53:13.301424Z",
-     "iopub.status.busy": "2026-07-03T15:53:13.301424Z",
-     "iopub.status.idle": "2026-07-03T15:53:13.306683Z",
-     "shell.execute_reply": "2026-07-03T15:53:13.306683Z"
+     "iopub.execute_input": "2026-08-29T08:17:20.329768Z",
+     "iopub.status.busy": "2026-08-29T08:17:20.329138Z",
+     "iopub.status.idle": "2026-08-29T08:17:20.333887Z",
+     "shell.execute_reply": "2026-08-29T08:17:20.333290Z"
     },
     "papermill": {
-     "duration": 0.018615,
-     "end_time": "2026-06-03T00:07:43.674001+00:00",
+     "duration": 0.012503,
+     "end_time": "2026-08-29T08:17:20.334855",
      "exception": false,
-     "start_time": "2026-06-03T00:07:43.655386+00:00",
+     "start_time": "2026-08-29T08:17:20.322352",
      "status": "completed"
     },
     "tags": []
@@ -1378,10 +2070,10 @@
    "id": "25ed0608",
    "metadata": {
     "papermill": {
-     "duration": 0.007975,
-     "end_time": "2026-06-03T00:07:43.690337+00:00",
+     "duration": 0.005641,
+     "end_time": "2026-08-29T08:17:20.346329",
      "exception": false,
-     "start_time": "2026-06-03T00:07:43.682362+00:00",
+     "start_time": "2026-08-29T08:17:20.340688",
      "status": "completed"
     },
     "tags": []
@@ -1397,10 +2089,10 @@
    "id": "d2e3f4a1",
    "metadata": {
     "papermill": {
-     "duration": 0.009044,
-     "end_time": "2026-06-03T00:07:43.707664+00:00",
+     "duration": 0.005606,
+     "end_time": "2026-08-29T08:17:20.357905",
      "exception": false,
-     "start_time": "2026-06-03T00:07:43.698620+00:00",
+     "start_time": "2026-08-29T08:17:20.352299",
      "status": "completed"
     },
     "tags": []
@@ -1439,7 +2131,16 @@
   {
    "cell_type": "markdown",
    "id": "fixed-id-null",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005742,
+     "end_time": "2026-08-29T08:17:20.369154",
+     "exception": false,
+     "start_time": "2026-08-29T08:17:20.363412",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Références\n",
     "\n",
@@ -1455,6 +2156,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-28",
+   "network": false,
+   "notes": "Topic Models (LDA) — allocation latente de Dirichlet, inference MCMC. Re-exec mesure : 25s.",
+   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -1470,24 +2188,26 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 263.975702,
-   "end_time": "2026-06-03T00:07:45.096022+00:00",
+   "duration": 267.869112,
+   "end_time": "2026-08-29T08:17:22.332106",
    "environment_variables": {},
    "exception": null,
-   "input_path": "PyMC-11-Topic-Models.ipynb",
-   "output_path": "PyMC-11-Topic-Models.ipynb",
-   "parameters": {},
-   "start_time": "2026-06-03T00:03:21.120320+00:00",
+   "input_path": "D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-11-Topic-Models.ipynb",
+   "output_path": "D:\\Dev\\CoursIA-13036-lda\\MyIA.AI.Notebooks\\Probas\\PyMC\\PyMC-11-Topic-Models_output.ipynb",
+   "parameters": {
+    "BATCH_MODE": "true"
+   },
+   "start_time": "2026-08-29T08:12:54.462994",
    "version": "2.7.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "08f1565377af42ee9b1e30475c222401": {
+     "365a2a50d313440ab47fd51964991ae0": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1540,7 +2260,7 @@
        "width": null
       }
      },
-     "78db0471937f42be8f0570875e6900e3": {
+     "7a04eb2190fa4d71a8085713b5a12d49": {
       "model_module": "@jupyter-widgets/output",
       "model_module_version": "1.0.0",
       "model_name": "OutputModel",
@@ -1553,13 +2273,13 @@
        "_view_module": "@jupyter-widgets/output",
        "_view_module_version": "1.0.0",
        "_view_name": "OutputView",
-       "layout": "IPY_MODEL_08f1565377af42ee9b1e30475c222401",
+       "layout": "IPY_MODEL_acdd14a0a7d143f48453538a62bfba48",
        "msg_id": "",
        "outputs": [
         {
          "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.165       31           251.24 draws/s   0:00:11   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.157       31           290.38 draws/s   0:00:10   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.126       31           274.18 draws/s   0:00:10   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   3000   0             0.130       31           210.46 draws/s   0:00:14   0:00:00    \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.165       31           251.24 draws/s   0:00:11   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.157       31           290.38 draws/s   0:00:10   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.126       31           274.18 draws/s   0:00:10   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000   0             0.130       31           210.46 draws/s   0:00:14   0:00:00    \n                                                                                                                   \n"
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   3000        0           0.147       31          267.30 draws/s       0:00:11    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   3000        0           0.153       31          291.61 draws/s       0:00:10    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   3000        0           0.132       15          308.41 draws/s       0:00:09    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   3000        0           0.144       31          295.91 draws/s       0:00:10    0:00:00   \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000        0           0.147       31          267.30 draws/s       0:00:11    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000        0           0.153       31          291.61 draws/s       0:00:10    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000        0           0.132       15          308.41 draws/s       0:00:09    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   3000        0           0.144       31          295.91 draws/s       0:00:10    0:00:00   \n                                                                                                                   \n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -1569,7 +2289,7 @@
        "tooltip": null
       }
      },
-     "946e105200704532abc98fe8150f0450": {
+     "acdd14a0a7d143f48453538a62bfba48": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1622,7 +2342,7 @@
        "width": null
       }
      },
-     "be473910c1ff421aabd93041c9f601b0": {
+     "ba139dab2320400badd1a6f1590735f8": {
       "model_module": "@jupyter-widgets/output",
       "model_module_version": "1.0.0",
       "model_name": "OutputModel",
@@ -1635,13 +2355,13 @@
        "_view_module": "@jupyter-widgets/output",
        "_view_module_version": "1.0.0",
        "_view_name": "OutputView",
-       "layout": "IPY_MODEL_946e105200704532abc98fe8150f0450",
+       "layout": "IPY_MODEL_365a2a50d313440ab47fd51964991ae0",
        "msg_id": "",
        "outputs": [
         {
          "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\"> Progress                   </span> <span style=\"font-weight: bold\"> Draw </span> <span style=\"font-weight: bold\"> Divergences </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> Grad evals </span> <span style=\"font-weight: bold\"> Speed          </span> <span style=\"font-weight: bold\"> Elapsed </span> <span style=\"font-weight: bold\"> Remaining </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.090       31           149.23 draws/s   0:00:26   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.127       31           164.49 draws/s   0:00:24   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.083       63           155.02 draws/s   0:00:25   0:00:00    \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━━━━━━━</span>   4000   0             0.100       63           137.23 draws/s   0:00:29   0:00:00    \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m \u001b[0m\u001b[1mProgress                  \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergences\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad evals\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed         \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaining\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.090       31           149.23 draws/s   0:00:26   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.127       31           164.49 draws/s   0:00:24   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.083       63           155.02 draws/s   0:00:25   0:00:00    \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000   0             0.100       63           137.23 draws/s   0:00:29   0:00:00    \n                                                                                                                   \n"
+          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.123       63          185.29 draws/s       0:00:21    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.116       31          198.95 draws/s       0:00:20    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.081       63          214.46 draws/s       0:00:18    0:00:00   \n  <span style=\"color: #1f77b4; text-decoration-color: #1f77b4\">━━━━━━━━━━━━━━━━━━━━</span>   4000        0           0.106       63          199.51 draws/s       0:00:20    0:00:00   \n                                                                                                                   \n</pre>\n",
+          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.123       63          185.29 draws/s       0:00:21    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.116       31          198.95 draws/s       0:00:20    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.081       63          214.46 draws/s       0:00:18    0:00:00   \n  \u001b[38;2;31;119;180m━━━━━━━━━━━━━━━━━━━━\u001b[0m   4000        0           0.106       63          199.51 draws/s       0:00:20    0:00:00   \n                                                                                                                   \n"
          },
          "metadata": {},
          "output_type": "display_data"
@@ -1655,23 +2375,6 @@
     "version_major": 2,
     "version_minor": 0
    }
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reproducibility": "HIGH",
-   "validator": "papermill",
-   "notes": "Topic Models (LDA) — allocation latente de Dirichlet, inference MCMC. Re-exec mesure : 25s.",
-   "reduced_pedagogical": "Probas/PyMC/PyMC-1-Setup.ipynb",
-   "metadata_written": "2026-07-28"
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml
@@ -29,6 +29,14 @@
       csharp_sha: e61bc677cace7fe0525f0f2d3d065fd6ac16a793
       content_python_sha: d92c4a5e9460cc76c33b08f5a97187c9a654ef5baff63447439a8e63a8b41604
       content_csharp_sha: ac0994633b49512fc0196e76aba3898fe151bf3756a35be0ae095a9ef6ad4448
+    - date: "2026-08-29"
+      by: myia-po-2023:CoursIA-2
+      python_sha: edc08f4697c64e585fe37af785ca753abe76f9f9
+      csharp_sha: b5949f0f739b92d1a518192a9e30f6ba098c4fec
+      content_python_sha: e909bc23772a561a4f24d5b369f68be4cb11eafa0d2c99cff9be7947224ee20a
+      content_csharp_sha: 18d8c737e3a9e5094b0049580c8d1a43f1ea7612755111267246275e687e7c28
+      reason: "Section 5bis ajoutee des deux cotes (#13036) : protocole de selection de K=2..6 en miroir (priors neutres, coherence UMass sur topics appris, redondance cosinus, held-out split-half ; deux ajustements par K -- corpus complet pour la qualite, moitie pour le predictif). Symetrie des protocoles verifiee ; valeurs numeriques non identiques par conception (NUTS vs VMP, cf known_differences)."
+
   known_differences:
   - 'Socle pedagogique commun : modeles de topics (LDA / allocation de Dirichlet) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-python #13067

## Summary

Section **5bis « Exemple resolu : selectionner le nombre de sujets/topics (K) »** ajoutee aux deux jumeaux Probas-11, avec **ajustements reels des modeles concurrents K=2..6** sur le vrai moteur de chaque twin. Repond au constat de #13036 : les twins fixaient K depuis la structure connue du corpus sans executer de protocole de choix.

### Protocole (miroir dans les deux twins)

- **Priors neutres** partout : `alpha=0.5`, `beta=1` (PyMC) / DirichletSymmetric + jitter aleatoire reproductible (Infer). Ni `phi_true`, ni `beta_asym`, ni etiquettes cachees ne construisent les topics (criteres 1-3).
- **Deux ajustements par K** : corpus complet (100 mots PyMC / 35 mots Infer) pour les metriques de qualite ; moitie d'apprentissage pour la mesure predictive held-out (split-half deterministe par document). Justification : 49 mots de fit laissent un posterieur multimodal que la moyenne inter-chaines transforme en bouillie -- le v1 single-fit a ete diagnostique puis remplace.
- **Trois mesures sur les topics appris** : coherence UMass documentaire (Mimno 2011, top-5 mots), redondance (cosinus max entre paires), log-prob/mot held-out.
- **Label switching traite honnetement** : alignement canonique par tri lexicographique de chaque tirage phi/theta (PyMC/NUTS) ; jitter reproductible `1.0+0.1*Random(1000+K)` (Infer/VMP, deterministe sinon mode symetrique).
- **Interpretation immediatement apres les sorties** dans les deux twins, avec verdict honnete de non-dominance (criteres 6-8).

### Resultats reels (outputs committes)

| Twin | UMass | Held-out | Redondance | Verite |
|------|-------|----------|------------|--------|
| PyMC (NUTS) | **K=3** (-3.78) | K=2 (-2.173, decroissant) | 0.911->0.995 monotone | K=3 |
| Infer (VMP) | **K=2** (-9.77) | K=4 (-2.121, dans le bruit) | 0.999 des K=6 | K=3 |

Les metriques divergent dans les DEUX twins -- c'est la lecon visee par l'issue (criteres 6+8) : le meilleur score ne donne pas l'interpretation la plus utile (UMass Infer favorise K=2, qui fusionne Sport+Politique via le mot polysemique « match » ; held-out PyMC prefere K=2 qui sous-parametre). Infer K=3 recupere les trois themes generateurs proprement ; PyMC K=3 les recupere partiellement (NUTS moyenne les modes multiples -- contraste NUTS vs VMP documente dans l'interpretation, parite pedagogique sans identite numerique exigee, criteres 9).

## Validation

- Papermill **SUCCESS** 270s (python3, 40 cellules, batch-mode) -- PyMC-11 re-execute integralement, 18/18 code cells `execution_count` non nuls.
- `dotnet_executor.py` **19/19 OK** (VMP corpus-level, jagged arrays, 10 compilations Roslyn) -- Infer-11 re-execute integralement.
- `validate_pr_notebooks.py origin/main <2 notebooks>` : **2/2 PASS** (EXEC_PROVED).
- Exercices preserves : stubs 11bis/11ter (Infer) et Exercices 1/2/Corpus Etendu (PyMC) intacts -- corpus des exercices distincts du corpus du cours.
- `check_twin_parity.py --check` : **Probas-11 OK** apres re-baseline registre (commit 2). Note hors scope : paire `ML-5 TimeSeries` en DRIFT preexistant sur main, non touchee ici.
- `detect_markdown_rendering.py --check --baseline` : no new violations.

## SOTA verdict

**SOTA-OK** : les vrais moteurs tournent (PyMC NUTS x10 fits, Infer.NET VMP x10 fits corpus-level) ; les sorties commitees sont leurs vraies sorties. Aucune matrice simulee, aucun comptage de substitution.

Closes #13036

Grain: DEEP/probas -- lane myia-po-2023:CoursIA-2 -- prev: MED/guard #13463
