### PR TITLE
feat(ict,#13470): module-only mutation_matrix / replicator_mutator_trajectory / strategy_entropy (sauvetage #12886)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/strategic_morphodynamics.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/strategic_morphodynamics.py
@@ -318,6 +318,76 @@ def fixation(traj: np.ndarray, tol: float = 1e-3) -> np.ndarray:
     return traj[-1]
 
 
+def mutation_matrix(n_strategies: int, mu: float) -> np.ndarray:
+    """Matrice de mutation uniforme Q (colonnes stochastiques).
+
+    Avec probabilite 1-mu la strategie i est transmise telle quelle, avec
+    probabilite mu elle mute vers j uniformement (y compris i) :
+
+        Q[i, j] = (1 - mu) * delta_ij + mu / n.
+    """
+    if not 0.0 <= mu <= 1.0:
+        raise ValueError(f"mu doit etre dans [0, 1], recu {mu}")
+    n = int(n_strategies)
+    Q = np.full((n, n), mu / n)
+    np.fill_diagonal(Q, (1.0 - mu) + mu / n)
+    return Q
+
+
+def replicator_mutator_trajectory(
+    A: np.ndarray,
+    x0: np.ndarray,
+    n_steps: int = 400,
+    mu: float = 0.03,
+) -> np.ndarray:
+    """Trajectoire de l'equation replicator-mutator discrete (Burger 1989 ;
+    Hofbauer & Sigmund, _Evolutionary Games and Population Dynamics_, ch. 7 --
+    la forme discrete de l'equation quasispecies d'Eigen) :
+
+        x(t+1) = Q @ ( x(t) ⊙ f(t) ) / <f>(t),   f(t) = A x(t).
+
+    La selection (replicateur) favorise les strategies performantes, la
+    mutation (Q) reinjecte en permanence de la diversite : la population ne
+    gele jamais sur une ESS, elle decrit une **trajectoire** dans le simplexe.
+    C'est la dynamique demandee par #12673 : le substrat Axelrod d'ICT-15d
+    etait un instantane sature (b1 = 0, 3654 triangles) parce que le
+    replicateur pur converge ; mu > 0 empeche cette convergence.
+
+    ``mu = 0`` reduit exactement a ``replicator_trajectory`` (Q = identite).
+    """
+    Q = mutation_matrix(x0.size if hasattr(x0, "size") else len(x0), mu)
+    x = np.asarray(x0, dtype=float).copy()
+    x = x / x.sum()
+    traj = np.empty((n_steps + 1, x.size))
+    traj[0] = x
+    for t in range(n_steps):
+        f = A @ x
+        avg = float(np.dot(f, x))
+        if avg < 1e-12:
+            break
+        x = Q @ (x * f) / avg
+        x = np.clip(x, 0.0, None)
+        s = x.sum()
+        if s > 1e-12:
+            x = x / s
+        traj[t + 1] = x
+    return traj
+
+
+def strategy_entropy(traj: np.ndarray) -> np.ndarray:
+    """Entropie de Shannon (base 2) de la composition a chaque generation.
+
+    H(t) = -sum_i x_i(t) log2 x_i(t). Mesure la diversite de la population :
+    H = 0 = monomorphe (instantane gele), H = log2(n) = uniforme. C'est la
+    grandeur qui montre que la selection-mutation maintient le nuage vivant
+    alors que le replicateur pur l'effondre vers un sommet du simplexe.
+    """
+    X = np.clip(np.asarray(traj, dtype=float), 0.0, None)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        H = -np.where(X > 0, X * np.log2(X), 0.0)
+    return H.sum(axis=1)
+
+
 # --------------------------------------------------------------------------- #
 #  Gate 2 : seuil de grim trigger vs prediction analytique                     #
 # --------------------------------------------------------------------------- #

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_strategic_morphodynamics.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_strategic_morphodynamics.py
@@ -260,3 +260,64 @@ def test_tft_collapses_more_than_gtft_under_noise():
     drop_tft = out["tft"][0] - out["tft"][-1]
     drop_gtft = out["gtft"][0] - out["gtft"][-1]
     assert drop_tft > drop_gtft  # TFT chute davantage
+
+
+# --------------------------------------------------------------------------- #
+#  Selection-mutation : equation replicator-mutator (#12673)                   #
+# --------------------------------------------------------------------------- #
+def test_mutation_matrix_is_column_stochastic():
+    Q = M.mutation_matrix(6, mu=0.03)
+    assert Q.shape == (6, 6)
+    assert np.allclose(Q.sum(axis=0), 1.0, atol=1e-12)
+    # mu=0 -> identite
+    assert np.allclose(M.mutation_matrix(6, mu=0.0), np.eye(6))
+    # mu=1 -> uniforme
+    assert np.allclose(M.mutation_matrix(4, mu=1.0), np.full((4, 4), 0.25))
+
+
+def test_mutation_matrix_rejects_bad_mu():
+    with pytest.raises(ValueError):
+        M.mutation_matrix(4, mu=-0.1)
+    with pytest.raises(ValueError):
+        M.mutation_matrix(4, mu=1.5)
+
+
+def test_replicator_mutator_mu_zero_reduces_to_replicator():
+    # Q = identite : la selection-mutation EST le replicateur (reduction exacte)
+    A = np.array([[3.0, 0.0], [5.0, 1.0]])
+    x0 = np.array([0.7, 0.3])
+    traj_mut = M.replicator_mutator_trajectory(A, x0, n_steps=200, mu=0.0)
+    traj_rep = M.replicator_trajectory(A, x0, n_steps=200)
+    assert np.allclose(traj_mut, traj_rep, atol=1e-12)
+
+
+def test_replicator_mutator_sustains_diversity():
+    """#12673 : la mutation empeche l'effondrement monomorphe. Sur le PD
+    2-strategies, le replicateur pur gele sur D (H -> 0) ; avec mu = 0.1,
+    l'entropie finale reste au-dessus de la moitie de l'uniforme."""
+    A = np.array([[3.0, 0.0], [5.0, 1.0]])
+    x0 = np.array([0.5, 0.5])
+    frozen = M.strategy_entropy(M.replicator_trajectory(A, x0, n_steps=500))[-1]
+    living = M.strategy_entropy(
+        M.replicator_mutator_trajectory(A, x0, n_steps=500, mu=0.1))[-1]
+    # equilibre mutation-selection mesure : x_D ~ 0.942, H ~ 0.318. Le contrat
+    # est l'ORDRE DE GRANDEUR (diversite maintenue vs effondrement a zero),
+    # pas une valeur exacte dependante de la matrice.
+    assert frozen == pytest.approx(0.0, abs=1e-9)  # instantane gele
+    assert living > 0.25                  # plancher de diversite (mesure : 0.318)
+
+
+def test_replicator_mutator_trajectory_shape_and_sum():
+    A = np.array([[3.0, 1.0], [1.0, 3.0]])
+    traj = M.replicator_mutator_trajectory(
+        A, np.array([0.5, 0.5]), n_steps=100, mu=0.05)
+    assert traj.shape == (101, 2)
+    assert np.allclose(traj.sum(axis=1), 1.0, atol=1e-6)
+    assert np.all(traj >= 0.0)
+
+
+def test_strategy_entropy_bounds():
+    H_mono = M.strategy_entropy(np.array([[1.0, 0.0]]))
+    H_uniform = M.strategy_entropy(np.array([[0.5, 0.5]]))
+    assert H_mono[0] == pytest.approx(0.0, abs=1e-12)
+    assert H_uniform[0] == pytest.approx(1.0)  # log2(2)


### PR DESCRIPTION
Grain: MED/research-code -- lane myia-po-2026:CoursIA -- prev: DEEP/python #13457

Closes #13470

## Objet

Récupération **module-only** des trois fonctions selection-mutation écrites dans #12886 (fermée) et absentes de `main`. Extraction **byte-préservée** de `feature/12673-ict13-evolution` (`a83e6f2b1`) : rien réécrit, tout extrait. Périmètre strictement deux fichiers — les notebooks/PNG porteurs des 55 marqueurs de conflit sont hors scope.

## Preuve de préservation (critère 4) — lignes d'origine sur a83e6f2b1

| fonction | ligne sur `a83e6f2b1` | nouvelle ligne sur cette branche |
|---|---|---|
| `mutation_matrix` | 283 | 321 |
| `replicator_mutator_trajectory` | 299 | 337 |
| `strategy_entropy` | 339 | 377 |

Le bloc inséré est le contenu verbatim de `a83e6f2b1` entre `def mutation_matrix` et le header `Gate 2` (grep vérifiable : `git show a83e6f2b1:MyIA.AI.Notebooks/IIT/ICT-Series/ict/strategic_morphodynamics.py | sed -n '283,354p'`).

## Distinction avec l'existant (pas un doublon)

`main` a déjà `replicator_mutation_trajectory` (#13305) : dynamique à reinjection uniforme `x = (1-mu)·sel + mu/n`. La fonction portée ici est l'**équation replicator-mutator** (forme quasispecies, Burger 1989 / Hofbauer & Sigmund ch. 7) : `x(t+1) = Q @ (x ⊙ f) / <f>` avec matrice de mutation colonne-stochastique complète `Q` — mathématiquement distincte, et `mu = 0` la réduit exactement au `replicator_trajectory` pur (testé ci-dessous).

`evolve_population` (#13305) : **intact** — le diff ne touche ni sa définition ni aucune ligne existante (131 insertions, 0 suppression).

## Tests verts sur la base courante (critère 2) — log re-joué, pas recopié

```
$ python -m pytest tests/test_strategic_morphodynamics.py -q -k "mutation_matrix or replicator_mutator or strategy_entropy"
......                                                                   [100%]
6 passed, 26 deselected in 0.20s

$ python -m pytest tests/test_strategic_morphodynamics.py -q
................................                                         [100%]
32 passed in 3.38s
```

Les 6 tests portés : `test_mutation_matrix_is_column_stochastic`, `test_mutation_matrix_rejects_bad_mu`, `test_replicator_mutator_mu_zero_reduces_to_replicator`, `test_replicator_mutator_sustains_diversity`, `test_replicator_mutator_trajectory_shape_and_sum`, `test_strategy_entropy_bounds`. Côté tests aussi l'extraction est un append pur : `diff main..branch = 262a263,323` (tronc byte-identique, 6 tests ajoutés en queue).

## Périmètre (critère 3)

```
 .../IIT/ICT-Series/ict/strategic_morphodynamics.py | 70 ++++++++++++++++++++++
 .../tests/test_strategic_morphodynamics.py         | 61 ++++++++++++++++++++++
 2 files changed, 131 insertions(+)
```

Deux fichiers exactement, additions pures, catalogue byte-identique à main.

See #12803, #13305, #12673.

