### PR TITLE
feat(genai,#13421): notebook 09-KernelMemory-Multimodal — plafond OCR OSS constaté + pont vision mesuré (tranche 3)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb
@@ -1,0 +1,1563 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "md001",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003999,
+     "end_time": "2026-08-29T08:39:34.513786",
+     "exception": false,
+     "start_time": "2026-08-29T08:39:34.509787",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# RAG 09 — Au-delà du texte : le plafond multimodal du service OSS et le pont vision\n",
+    "\n",
+    "**Navigation** : [Index](README.md) | [<< Précédent](08-KernelMemory-Hybrid-Search.ipynb)\n",
+    "\n",
+    "Les notebooks [07](07-KernelMemory-Python-Quickstart.ipynb) et\n",
+    "[08](08-KernelMemory-Hybrid-Search.ipynb) ont ingéré des documents **texte** — et tout a\n",
+    "bien se passé. Mais un corpus d'entreprise réel n'est pas fait que de texte : schémas\n",
+    "techniques, captures d'écran, diagrammes d'architecture. Que devient le pipeline\n",
+    "`extract → partition → gen_embeddings → save_records` quand le document est une **image** ?\n",
+    "\n",
+    "Ce notebook mesure la frontière modale du service Kernel Memory OSS, puis construit le\n",
+    "pont standard qui la franchit :\n",
+    "\n",
+    "1. **Corpus modalement polarisé** : un PDF réel du dépôt (contrôle positif), quatre\n",
+    "   documents texte (substrat de recherche), et un **schéma PNG** dont le texte n'existe\n",
+    "   nulle part ailleurs dans le corpus ;\n",
+    "2. **Constat** : le service **accepte** l'image (HTTP 202) mais son pipeline **stand\n",
+    "   silencieusement** à l'étape d'extraction — aucun record, aucune erreur, le statut\n",
+    "   d'upload ne complète jamais. Le plafond est réel : l'extraction d'image exige un\n",
+    "   connecteur OCR que le conteneur OSS n'embarque pas ;\n",
+    "3. **Pont vision** : un modèle de vision (`google/gemini-3.7-flash` via l'endpoint\n",
+    "   OpenAI-compatible du `.env`) **décrit** le PNG — en citant son texte verbatim — puis\n",
+    "   cette description est ingérée comme document texte ;\n",
+    "4. **Mesure before/after** : les termes qui n'existaient que dans l'image (`capteur\n",
+    "   impairfaux`, `faux negatifs`) sont **introuvables** avant le pont et **retrouvés**\n",
+    "   après — sur le document-pont, avec citations.\n",
+    "\n",
+    "Dépendances : `pip install requests python-dotenv pillow` (+ Docker pour les deux\n",
+    "conteneurs). Le `.env` de la série (`MyIA.AI.Notebooks/GenAI/.env`, gitignored) fournit\n",
+    "l'endpoint OpenAI-compatible — même configuration que le 07 et le 08.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md002",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004997,
+     "end_time": "2026-08-29T08:39:34.522811",
+     "exception": false,
+     "start_time": "2026-08-29T08:39:34.517814",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Plan\n",
+    "\n",
+    "1. Infrastructure : Qdrant + service Kernel Memory\n",
+    "2. Corpus : l'axe modalité (PDF réel, quatre textes, un schéma PNG)\n",
+    "3. Ingestion et constat : le 202 qui ne complète jamais\n",
+    "4. Le pont vision : décrire l'image pour l'ingérer\n",
+    "5. Mesure contrôlée avant/après (attendus écrits avant)\n",
+    "6. Lecture, coûts, exercices, nettoyage\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cd003",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:39:34.531506Z",
+     "iopub.status.busy": "2026-08-29T08:39:34.531000Z",
+     "iopub.status.idle": "2026-08-29T08:39:34.652598Z",
+     "shell.execute_reply": "2026-08-29T08:39:34.652598Z"
+    },
+    "papermill": {
+     "duration": 0.127231,
+     "end_time": "2026-08-29T08:39:34.653629",
+     "exception": false,
+     "start_time": "2026-08-29T08:39:34.526398",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".env charge          : .env (MyIA.AI.Notebooks/GenAI)\n",
+      "Endpoint embeddings/vision : openrouter.ai\n",
+      "Cle API              : presente (73 caracteres)\n",
+      "Modele embeddings    : text-embedding-3-small\n",
+      "Modele vision        : google/gemini-3.7-flash\n",
+      "Corpus provisoire    : km09_corpus_sxqjqbxy/ (repertoire temporaire)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import tempfile\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# --- Resolution du .env de la serie GenAI (gitignored) -------------\n",
+    "ENV_CANDIDATES = [\n",
+    "    Path(os.environ.get(\"GENAI_ENV_FILE\", \"\")) if os.environ.get(\"GENAI_ENV_FILE\") else None,\n",
+    "    Path.cwd() / \"MyIA.AI.Notebooks\" / \"GenAI\" / \".env\",\n",
+    "    Path.cwd().parent / \"MyIA.AI.Notebooks\" / \"GenAI\" / \".env\",\n",
+    "    Path.cwd().parents[1] / \"MyIA.AI.Notebooks\" / \"GenAI\" / \".env\" if len(Path.cwd().parents) > 1 else None,\n",
+    "]\n",
+    "ENV_PATH = next((p for p in ENV_CANDIDATES if p and p.is_file()), None)\n",
+    "if ENV_PATH is None:\n",
+    "    # Degradation propre (regle C.1) : sans .env, la mesure sera sautee via INFRA_OK\n",
+    "    print(\"AVERTISSEMENT : .env de la serie GenAI introuvable \"\n",
+    "          \"(attendu : MyIA.AI.Notebooks/GenAI/.env, cf. .env.example)\")\n",
+    "else:\n",
+    "    load_dotenv(ENV_PATH)\n",
+    "\n",
+    "# --- Configuration --------------------------------------------------\n",
+    "INDEX = \"km13421-multi\"\n",
+    "KM_PORT = 9001\n",
+    "KM_URL = f\"http://localhost:{KM_PORT}\"\n",
+    "QDRANT_LOCAL = \"http://localhost:6333\"\n",
+    "QDRANT_CONTAINER = \"qdrant_rag09\"\n",
+    "KM_CONTAINER = \"km_service_rag09\"\n",
+    "KM_FILES_VOLUME = \"km_rag09_files\"\n",
+    "QDRANT_VOLUME = \"qdrant_rag09_data\"\n",
+    "\n",
+    "EMBED_MODEL = \"text-embedding-3-small\"\n",
+    "VISION_MODEL = \"google/gemini-3.7-flash\"\n",
+    "\n",
+    "OR_BASE = os.getenv(\"OPENROUTER_BASE_URL\", \"\").rstrip(\"/\")\n",
+    "OR_KEY = os.getenv(\"OPENROUTER_API_KEY\", \"\")\n",
+    "corpus_dir = Path(tempfile.mkdtemp(prefix=\"km09_corpus_\"))\n",
+    "\n",
+    "def mask(url: str) -> str:\n",
+    "    \"\"\"Host seul d'une URL -- jamais d'eventuels credentials.\"\"\"\n",
+    "    try:\n",
+    "        return url.split(\"//\", 1)[1].split(\"/\", 1)[0]\n",
+    "    except Exception:\n",
+    "        return \"(non configure)\"\n",
+    "\n",
+    "env_desc = f\"{ENV_PATH.name} ({ENV_PATH.parent.parent.name}/{ENV_PATH.parent.name})\" if ENV_PATH else \"INTROUVABLE\"\n",
+    "print(f\".env charge          : {env_desc}\")\n",
+    "print(f\"Endpoint embeddings/vision : {mask(OR_BASE) or '(non configure)'}\")\n",
+    "print(f\"Cle API              : {'presente (' + str(len(OR_KEY)) + ' caracteres)' if OR_KEY else 'ABSENTE'}\")\n",
+    "print(f\"Modele embeddings    : {EMBED_MODEL}\")\n",
+    "print(f\"Modele vision        : {VISION_MODEL}\")\n",
+    "print(f\"Corpus provisoire    : {corpus_dir.name}/ (repertoire temporaire)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md004",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00437,
+     "end_time": "2026-08-29T08:39:34.661622",
+     "exception": false,
+     "start_time": "2026-08-29T08:39:34.657252",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Infrastructure : Qdrant + service Kernel Memory\n",
+    "\n",
+    "Même patron que le [07](07-KernelMemory-Python-Quickstart.ipynb) et le\n",
+    "[08](08-KernelMemory-Hybrid-Search.ipynb) : un Qdrant local jetable et le conteneur\n",
+    "`kernelmemory/service` configuré par variables d'environnement (mapping `appsettings`\n",
+    "par doubles underscores). Le backend d'embeddings est l'endpoint OpenAI-compatible du\n",
+    "`.env`. Sans Docker ou sans clé, les cellules passent en mode dégradé (`INFRA_OK =\n",
+    "False`) et la mesure est sautée proprement (règle C.1).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cd005",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:39:34.671522Z",
+     "iopub.status.busy": "2026-08-29T08:39:34.671522Z",
+     "iopub.status.idle": "2026-08-29T08:39:48.395974Z",
+     "shell.execute_reply": "2026-08-29T08:39:48.395974Z"
+    },
+    "papermill": {
+     "duration": 13.72984,
+     "end_time": "2026-08-29T08:39:48.395974",
+     "exception": false,
+     "start_time": "2026-08-29T08:39:34.666134",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Docker dispo : True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conteneur Qdrant lance (rc=0)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conteneur service KM lance (rc=0)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Qdrant pret : True | service KM pret : True\n",
+      "INFRA_OK (mesure possible) : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "def docker_available() -> bool:\n",
+    "    try:\n",
+    "        r = subprocess.run([\"docker\", \"info\"], capture_output=True, timeout=10)\n",
+    "        return r.returncode == 0\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "\n",
+    "def qdrant_up() -> bool:\n",
+    "    try:\n",
+    "        r = requests.get(f\"{QDRANT_LOCAL}/healthz\", timeout=5)\n",
+    "        return \"healthz check passed\" in r.text\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "\n",
+    "def km_up() -> bool:\n",
+    "    try:\n",
+    "        r = requests.get(f\"{KM_URL}/\", timeout=5)\n",
+    "        return r.status_code == 200 and \"Ingestion service\" in r.text\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "\n",
+    "DOCKER_OK = docker_available()\n",
+    "print(f\"Docker dispo : {DOCKER_OK}\")\n",
+    "\n",
+    "qdrant_ready = qdrant_up()\n",
+    "if not qdrant_ready and DOCKER_OK:\n",
+    "    subprocess.run([\"docker\", \"rm\", \"-f\", QDRANT_CONTAINER], capture_output=True)\n",
+    "    r = subprocess.run(\n",
+    "        [\"docker\", \"run\", \"-d\", \"--rm\", \"--name\", QDRANT_CONTAINER,\n",
+    "         \"-p\", \"6333:6333\", \"-p\", \"6334:6334\",\n",
+    "         \"-v\", f\"{QDRANT_VOLUME}:/qdrant/storage\",\n",
+    "         \"qdrant/qdrant:latest\"],\n",
+    "        capture_output=True, timeout=180)\n",
+    "    print(f\"Conteneur Qdrant lance (rc={r.returncode})\")\n",
+    "    for _ in range(30):\n",
+    "        time.sleep(2)\n",
+    "        if qdrant_up():\n",
+    "            break\n",
+    "\n",
+    "if DOCKER_OK and qdrant_up() and not km_up():\n",
+    "    subprocess.run([\"docker\", \"rm\", \"-f\", KM_CONTAINER], capture_output=True)\n",
+    "    cmd = [\n",
+    "        \"docker\", \"run\", \"-d\", \"--rm\", \"--user\", \"root\",\n",
+    "        \"--name\", KM_CONTAINER,\n",
+    "        \"-p\", f\"{KM_PORT}:9001\",\n",
+    "        \"-v\", f\"{KM_FILES_VOLUME}:/km-files\",\n",
+    "        # Backend embeddings (endpoint OpenAI-compatible) -- cles jamais affichees\n",
+    "        \"-e\", f\"KernelMemory__Services__OpenAI__Endpoint={OR_BASE}\",\n",
+    "        \"-e\", f\"KernelMemory__Services__OpenAI__APIKey={OR_KEY}\",\n",
+    "        \"-e\", f\"KernelMemory__Services__OpenAI__EmbeddingModel={EMBED_MODEL}\",\n",
+    "        \"-e\", \"KernelMemory__Services__OpenAI__EmbeddingModelMaxTokenTotal=8191\",\n",
+    "        \"-e\", f\"KernelMemory__Services__OpenAI__TextModel={VISION_MODEL}\",\n",
+    "        \"-e\", \"KernelMemory__Services__OpenAI__TextModelMaxTokenTotal=60000\",\n",
+    "        \"-e\", \"KernelMemory__Services__OpenAI__TextGenerationType=Chat\",\n",
+    "        \"-e\", \"KernelMemory__TextGeneratorType=OpenAI\",\n",
+    "        \"-e\", \"KernelMemory__Retrieval__EmbeddingGeneratorType=OpenAI\",\n",
+    "        \"-e\", \"KernelMemory__DataIngestion__EmbeddingGeneratorTypes__0=OpenAI\",\n",
+    "        \"-e\", \"KernelMemory__Retrieval__MemoryDbType=Qdrant\",\n",
+    "        \"-e\", \"KernelMemory__DataIngestion__MemoryDbTypes__0=Qdrant\",\n",
+    "        \"-e\", \"KernelMemory__Services__Qdrant__Endpoint=http://host.docker.internal:6333\",\n",
+    "        \"-e\", \"KernelMemory__Services__SimpleFileStorage__StorageType=Disk\",\n",
+    "        \"-e\", \"KernelMemory__Services__SimpleFileStorage__Directory=/km-files\",\n",
+    "        \"-e\", \"KernelMemory__DataIngestion__DefaultSteps=extract,partition,gen_embeddings,save_records\",\n",
+    "        \"kernelmemory/service:latest\",\n",
+    "    ]\n",
+    "    r = subprocess.run(cmd, capture_output=True, timeout=300)\n",
+    "    print(f\"Conteneur service KM lance (rc={r.returncode})\")\n",
+    "    for _ in range(45):\n",
+    "        time.sleep(2)\n",
+    "        if km_up():\n",
+    "            break\n",
+    "\n",
+    "qdrant_ready = qdrant_up()\n",
+    "km_ready = km_up()\n",
+    "INFRA_OK = bool(qdrant_ready and km_ready and OR_KEY)\n",
+    "print(f\"Qdrant pret : {qdrant_ready} | service KM pret : {km_ready}\")\n",
+    "print(f\"INFRA_OK (mesure possible) : {INFRA_OK}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md006",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004512,
+     "end_time": "2026-08-29T08:39:48.405032",
+     "exception": false,
+     "start_time": "2026-08-29T08:39:48.400520",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Corpus : l'axe modalité — PDF réel, quatre textes, un schéma PNG\n",
+    "\n",
+    "Le corpus est petit parce que la question est **pectorale, pas quantitative** : il s'agit\n",
+    "de situer la frontière modale du pipeline, pas de bachoter un classement (le\n",
+    "[08](08-KernelMemory-Hybrid-Search.ipynb) a fait la mesure de recherche). Trois jambes :\n",
+    "\n",
+    "- **PDF réel** (`cours-introduction-ia.pdf`, copié du dépôt — même fichier que le 07) :\n",
+    "  format texte riche, le contrôle positif attendu ;\n",
+    "- **quatre documents texte** (`s1`–`s4`) : le substrat de recherche — dont un document\n",
+    "  (`s1`) porteur du terme exact `fenetre glissante recouvrement` qui servira de requête\n",
+    "  contrôle, et un distracteur (`s4`) qui parle de recherche et de citations sans\n",
+    "  contenir aucun terme du schéma ;\n",
+    "- **un schéma PNG** (`schema-capteur.png`) dessiné par le notebook : deux lignes de\n",
+    "  texte technique — `Qdrant hybride : BM25 dense fusion RRF` (clin d'œil au 08) et\n",
+    "  `capteur impairfaux faux negatifs detection`. Ces termes n'existent **nulle part\n",
+    "  ailleurs** dans le corpus : la seule voie d'accès à `capteur impairfaux` passe par\n",
+    "  l'image.\n",
+    "\n",
+    "Si l'extraction d'image fonctionnait, une recherche sur `capteur impairfaux` retrouverait\n",
+    "le schéma. C'est exactement ce que la section 3 met à l'épreuve.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cd007",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:39:48.413849Z",
+     "iopub.status.busy": "2026-08-29T08:39:48.413328Z",
+     "iopub.status.idle": "2026-08-29T08:39:48.469780Z",
+     "shell.execute_reply": "2026-08-29T08:39:48.468772Z"
+    },
+    "papermill": {
+     "duration": 0.062818,
+     "end_time": "2026-08-29T08:39:48.470658",
+     "exception": false,
+     "start_time": "2026-08-29T08:39:48.407840",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Corpus : 6 documents dans km09_corpus_sxqjqbxy/\n",
+      "  - pdf-cours      [pdf] cours-introduction-ia.pdf (1291133 octets)\n",
+      "  - s1-partition   [txt] s1-partition.txt (225 octets)\n",
+      "  - s2-formats     [txt] s2-formats.txt (250 octets)\n",
+      "  - s3-pont-vision [txt] s3-pont-vision.txt (236 octets)\n",
+      "  - s4-distracteur [txt] s4-distracteur.txt (226 octets)\n",
+      "  - schema-png     [png] schema-capteur.png (4217 octets)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- 2a. PDF reel du depot (meme source que le 07) -------------------\n",
+    "PDF_CANDIDATES = [\n",
+    "    Path.cwd() / \"slides\" / \"01-introduction\" / \"pptx-reference\" / \"slides.pdf\",\n",
+    "    Path.cwd().parent / \"slides\" / \"01-introduction\" / \"pptx-reference\" / \"slides.pdf\",\n",
+    "    Path.cwd().parents[2] / \"slides\" / \"01-introduction\" / \"pptx-reference\" / \"slides.pdf\"\n",
+    "        if len(Path.cwd().parents) > 2 else None,\n",
+    "]\n",
+    "PDF_SRC = next((p for p in PDF_CANDIDATES if p and p.is_file()), None)\n",
+    "\n",
+    "# --- 2b. Quatre documents texte (substrat) ---------------------------\n",
+    "SUBSTRAT = {\n",
+    "    \"s1-partition.txt\":\n",
+    "        \"La partition en fenetre glissante conserve un recouvrement entre morceaux \"\n",
+    "        \"consecutifs : une phrase coupee a la frontiere garde son contexte des deux cotes. \"\n",
+    "        \"Taille et recouvrement se reglent ensemble, jamais l'un sans l'autre.\",\n",
+    "    \"s2-formats.txt\":\n",
+    "        \"Un corpus d'entreprise melange formats texte et images. Les schemas, captures \"\n",
+    "        \"d'ecran et diagrammes echappent a l'extraction textuelle : sans connecteur OCR, \"\n",
+    "        \"le pipeline d'ingestion n'en tire rien, et le contenu visuel reste invisible a \"\n",
+    "        \"la recherche.\",\n",
+    "    \"s3-pont-vision.txt\":\n",
+    "        \"Un modele de vision peut produire une description textuelle d'une image. Ingeree \"\n",
+    "        \"comme document ordinaire, cette description rend l'image cherchable : c'est le \"\n",
+    "        \"pont vision, un motif d'architecture standard des systemes RAG multimodiaux.\",\n",
+    "    \"s4-distracteur.txt\":\n",
+    "        \"L'interface de recherche accepte des requetes en langue naturelle et affiche les \"\n",
+    "        \"citations avec leur score de pertinence. La qualite de l'index prime sur la \"\n",
+    "        \"formulation de la question ; un bon pipeline se juge sur ses sources.\",\n",
+    "}\n",
+    "\n",
+    "# --- 2c. Le schema PNG : texte qui n'existe que dans l'image ----------\n",
+    "try:\n",
+    "    from PIL import Image, ImageDraw\n",
+    "    img = Image.new(\"RGB\", (640, 200), \"white\")\n",
+    "    d = ImageDraw.Draw(img)\n",
+    "    d.text((20, 40), \"Qdrant hybride : BM25 dense fusion RRF\", fill=\"black\")\n",
+    "    d.text((20, 90), \"capteur impairfaux faux negatifs detection\", fill=\"black\")\n",
+    "    PNG_PATH = corpus_dir / \"schema-capteur.png\"\n",
+    "    img.save(PNG_PATH, format=\"PNG\")\n",
+    "    PIL_OK = True\n",
+    "except ImportError:\n",
+    "    PIL_OK = False\n",
+    "    PNG_PATH = None\n",
+    "    print(\"AVERTISSEMENT : Pillow absent -- le schema PNG ne sera pas genere (pip install pillow)\")\n",
+    "\n",
+    "# --- 2d. Ecriture + inventaire ----------------------------------------\n",
+    "uploaded = []          # (documentId, chemin, kind)\n",
+    "if PDF_SRC:\n",
+    "    pdf_dst = corpus_dir / \"cours-introduction-ia.pdf\"\n",
+    "    shutil.copyfile(PDF_SRC, pdf_dst)\n",
+    "    uploaded.append((\"pdf-cours\", pdf_dst, \"pdf\"))\n",
+    "for name, txt in SUBSTRAT.items():\n",
+    "    p = corpus_dir / name\n",
+    "    p.write_text(txt, encoding=\"utf-8\")\n",
+    "    uploaded.append((name.replace(\".txt\", \"\"), p, \"txt\"))\n",
+    "if PIL_OK:\n",
+    "    uploaded.append((\"schema-png\", PNG_PATH, \"png\"))\n",
+    "\n",
+    "print(f\"Corpus : {len(uploaded)} documents dans {corpus_dir.name}/\")\n",
+    "for doc_id, path, kind in uploaded:\n",
+    "    print(f\"  - {doc_id:14s} [{kind:3s}] {path.name} ({path.stat().st_size} octets)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md008",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004,
+     "end_time": "2026-08-29T08:39:48.477777",
+     "exception": false,
+     "start_time": "2026-08-29T08:39:48.473777",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Ingestion et constat : le 202 qui ne complète jamais\n",
+    "\n",
+    "Idempotence d'abord (le [07](07-KernelMemory-Python-Quickstart.ipynb) l'a montré : on\n",
+    "repart d'un index vide), puis upload de chaque document. Le point pédagogique est dans\n",
+    "**l'écart entre la promesse et le fait** :\n",
+    "\n",
+    "- l'upload répond **202 Accepted** pour *tous* les documents, y compris le PNG —\n",
+    "  l'acceptation n'engage que le réceptionnaire ;\n",
+    "- le statut d'ingestion (`/upload-status`) complète pour les documents texte en\n",
+    "  quelques secondes ;\n",
+    "- pour le PNG, le statut **ne complète jamais** : ni erreur, ni étape en échec — le\n",
+    "  pipeline attend à l'étape `extract`, et la boucle de polling expire sur lui seul.\n",
+    "\n",
+    "Le décompte des points Qdrant par fichier confirme le constat côté stockage : le PNG\n",
+    "n'a produit **aucun record**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cd009",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:39:48.485371Z",
+     "iopub.status.busy": "2026-08-29T08:39:48.485371Z",
+     "iopub.status.idle": "2026-08-29T08:39:49.786670Z",
+     "shell.execute_reply": "2026-08-29T08:39:49.786670Z"
+    },
+    "papermill": {
+     "duration": 1.306899,
+     "end_time": "2026-08-29T08:39:49.787675",
+     "exception": false,
+     "start_time": "2026-08-29T08:39:48.480776",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Codes d'upload (202 = accepte) :\n",
+      "  pdf-cours      -> 202\n",
+      "  s1-partition   -> 202\n",
+      "  s2-formats     -> 202\n",
+      "  s3-pont-vision -> 202\n",
+      "  s4-distracteur -> 202\n",
+      "  schema-png     -> 202\n"
+     ]
+    }
+   ],
+   "source": [
+    "def km_delete_index() -> bool:\n",
+    "    try:\n",
+    "        r = requests.delete(f\"{KM_URL}/indexes\", params={\"index\": INDEX}, timeout=30)\n",
+    "        return r.status_code in (200, 204)\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "\n",
+    "def km_status(doc_id: str) -> dict:\n",
+    "    r = requests.get(f\"{KM_URL}/upload-status\",\n",
+    "                     params={\"index\": INDEX, \"documentId\": doc_id}, timeout=30)\n",
+    "    r.raise_for_status()\n",
+    "    return r.json()\n",
+    "\n",
+    "codes = []\n",
+    "if INFRA_OK:\n",
+    "    km_delete_index()\n",
+    "    time.sleep(1)\n",
+    "    for doc_id, path, kind in uploaded:\n",
+    "        with open(path, \"rb\") as fh:\n",
+    "            r = requests.post(f\"{KM_URL}/upload\",\n",
+    "                              data={\"documentId\": doc_id, \"index\": INDEX},\n",
+    "                              files={\"files\": (path.name, fh, None)}, timeout=120)\n",
+    "        codes.append((doc_id, r.status_code))\n",
+    "    print(\"Codes d'upload (202 = accepte) :\")\n",
+    "    for doc_id, c in codes:\n",
+    "        print(f\"  {doc_id:14s} -> {c}\")\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas d'upload.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cd010",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:39:49.797471Z",
+     "iopub.status.busy": "2026-08-29T08:39:49.796682Z",
+     "iopub.status.idle": "2026-08-29T08:42:22.626459Z",
+     "shell.execute_reply": "2026-08-29T08:42:22.625453Z"
+    },
+    "papermill": {
+     "duration": 152.835779,
+     "end_time": "2026-08-29T08:42:22.627459",
+     "exception": false,
+     "start_time": "2026-08-29T08:39:49.791680",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Documents completes : 5/6 (borne de polling 150s, ecoule 152s)\n",
+      "Toujours en attente (pipeline bloque a une etape) : ['schema-png']\n",
+      "  statut brut du premier bloque : {\"completed\": false, \"empty\": false, \"index\": \"km13421-multi\", \"document_id\": \"schema-png\", \"tags\": {}, \"creation\": \"2026-08-29T08:39:49.7830746+00:00\", \"last_update\": \"2026-08-29T08:39:49.7835842+00:00\", \"steps\": [\"extr\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Polling borne : les textes completent, le PNG ne complete pas.\n",
+    "STALL_LIMIT_S = 150\n",
+    "statuses = {}\n",
+    "if INFRA_OK:\n",
+    "    pending = {doc_id for doc_id, c in codes if c == 202}\n",
+    "    t0 = time.time()\n",
+    "    while pending and (time.time() - t0) < STALL_LIMIT_S:\n",
+    "        for doc_id in list(pending):\n",
+    "            try:\n",
+    "                st = km_status(doc_id)\n",
+    "                statuses[doc_id] = st.get(\"completed\", False)\n",
+    "                if st.get(\"completed\"):\n",
+    "                    pending.discard(doc_id)\n",
+    "            except Exception:\n",
+    "                pass\n",
+    "        if pending:\n",
+    "            time.sleep(4)\n",
+    "    elapsed = int(time.time() - t0)\n",
+    "    n_done = sum(1 for v in statuses.values() if v)\n",
+    "    print(f\"Documents completes : {n_done}/{len(codes)} (borne de polling {STALL_LIMIT_S}s, ecoule {elapsed}s)\")\n",
+    "    if pending:\n",
+    "        print(f\"Toujours en attente (pipeline bloque a une etape) : {sorted(pending)}\")\n",
+    "        st_stuck = km_status(sorted(pending)[0])\n",
+    "        print(f\"  statut brut du premier bloque : {json.dumps(st_stuck, ensure_ascii=False)[:220]}\")\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas de polling.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cd011",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:42:22.638602Z",
+     "iopub.status.busy": "2026-08-29T08:42:22.638602Z",
+     "iopub.status.idle": "2026-08-29T08:42:22.655266Z",
+     "shell.execute_reply": "2026-08-29T08:42:22.654238Z"
+    },
+    "papermill": {
+     "duration": 0.024305,
+     "end_time": "2026-08-29T08:42:22.655266",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:22.630961",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Records par fichier dans la collection 'km13421-multi' :\n",
+      "  cours-introduction-ia.pdf        7 record(s)\n",
+      "  s1-partition.txt                 1 record(s)\n",
+      "  s2-formats.txt                   1 record(s)\n",
+      "  s3-pont-vision.txt               1 record(s)\n",
+      "  s4-distracteur.txt               1 record(s)\n",
+      "Fichiers uploades sans aucun record : ['schema-capteur.png']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Preuve cote stockage : points Qdrant par fichier (le PNG doit etre absent)\n",
+    "def parse_km_tags(tag_list):\n",
+    "    tags = {}\n",
+    "    for t in tag_list or []:\n",
+    "        if isinstance(t, str) and \"__\" in t:\n",
+    "            k, v = t.split(\"__\", 1)\n",
+    "            tags[k] = v\n",
+    "    return tags\n",
+    "\n",
+    "if INFRA_OK:\n",
+    "    r = requests.post(f\"{QDRANT_LOCAL}/collections/{INDEX}/points/scroll\",\n",
+    "                      json={\"limit\": 100, \"with_payload\": True}, timeout=20)\n",
+    "    pts = r.json().get(\"result\", {}).get(\"points\", [])\n",
+    "    per_file = {}\n",
+    "    for p in pts:\n",
+    "        pl = p.get(\"payload\", {})\n",
+    "        inner = json.loads(pl.get(\"payload\", \"{}\"))\n",
+    "        fname = inner.get(\"file\", \"?\")\n",
+    "        per_file[fname] = per_file.get(fname, 0) + 1\n",
+    "    print(f\"Records par fichier dans la collection '{INDEX}' :\")\n",
+    "    for f in sorted(per_file):\n",
+    "        print(f\"  {f:32s} {per_file[f]} record(s)\")\n",
+    "    attendus = {p.name for _, p, _ in uploaded}\n",
+    "    vus = set(per_file)\n",
+    "    print(f\"Fichiers uploades sans aucun record : {sorted(attendus - vus) or 'aucun'}\")\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas de scroll.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md012",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005268,
+     "end_time": "2026-08-29T08:42:22.664533",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:22.659265",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Mesure AVANT le pont : l'image est invisible pour la recherche\n",
+    "\n",
+    "Trois requêtes sur l'index **sans** le document-pont — c'est la baseline. q1 et q2 ne\n",
+    "ciblent que le texte du schéma PNG ; si l'extraction d'image ne produit rien, leur\n",
+    "top-1 ne peut pas être pertinent (le service renvoie quand même des voisins — des\n",
+    "non-pertinents). q3 est le témoin (terme du substrat `s1`) : il doit trouver — sinon\n",
+    "l'échec de q1/q2 ne prouverait rien (ce pourrait être la recherche elle-même qui\n",
+    "dysfonctionne).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cd013",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:42:22.674908Z",
+     "iopub.status.busy": "2026-08-29T08:42:22.674908Z",
+     "iopub.status.idle": "2026-08-29T08:42:23.453778Z",
+     "shell.execute_reply": "2026-08-29T08:42:23.452743Z"
+    },
+    "papermill": {
+     "duration": 0.785777,
+     "end_time": "2026-08-29T08:42:23.454308",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:22.668531",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AVANT q1 'capteur impairfaux' -> pdf-cours\n",
+      "AVANT q2 'comment limiter les faux negatifs de detection' -> s4-distracteur\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AVANT q3 'fenetre glissante recouvrement' -> s1-partition\n"
+     ]
+    }
+   ],
+   "source": [
+    "def km_search(query: str, limit: int = 3) -> list:\n",
+    "    r = requests.post(f\"{KM_URL}/search\",\n",
+    "                      json={\"index\": INDEX, \"query\": query, \"limit\": limit}, timeout=120)\n",
+    "    r.raise_for_status()\n",
+    "    return r.json().get(\"results\", [])\n",
+    "\n",
+    "def top_hit(results: list):\n",
+    "    if not results:\n",
+    "        return \"(miss)\"\n",
+    "    return results[0].get(\"documentId\", \"?\")\n",
+    "\n",
+    "QUERIES = [\n",
+    "    (\"q1\", \"capteur impairfaux\"),\n",
+    "    (\"q2\", \"comment limiter les faux negatifs de detection\"),\n",
+    "    (\"q3\", \"fenetre glissante recouvrement\"),\n",
+    "]\n",
+    "\n",
+    "MESURE_AVANT = {}\n",
+    "if INFRA_OK:\n",
+    "    for qid, q in QUERIES:\n",
+    "        MESURE_AVANT[qid] = top_hit(km_search(q, limit=3))\n",
+    "        print(f\"AVANT {qid} '{q}' -> {MESURE_AVANT[qid]}\")\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas de mesure avant.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md014",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004597,
+     "end_time": "2026-08-29T08:42:23.463295",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:23.458698",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : [INTERP-CONSTAT] un plafond réel, pas un bug à corriger chez nous\n",
+    "\n",
+    "La mesure est sans ambiguïté : **5 documents sur 6 complètent** leur pipeline, le PNG\n",
+    "reste bloqué à l'étape `extract` — et côté stockage, il a produit **0 record**. Le\n",
+    "statut brut le montre sans fard : `\"completed\": false`, une liste d'étapes qui démarre\n",
+    "par `extract` et n'avance plus, **aucune erreur**. C'est le pire mode d'échec pour un\n",
+    "système asynchrone : silencieux, indéfini, sans trace d'exception.\n",
+    "\n",
+    "Ce n'est **pas** un défaut de notre configuration : le même service, la même clé, la\n",
+    "même boucle d'upload indexent le PDF et les quatre textes quelques secondes plus tôt.\n",
+    "C'est un **plafond de la distribution OSS** : l'extraction de contenu d'image exige un\n",
+    "connecteur (OCR / Azure Document Intelligence) que le conteneur `kernelmemory/service`\n",
+    "n'embarque pas — l'accepter (HTTP 202) sans pouvoir l'extraire est son comportement\n",
+    "documenté de bord. La leçon opérationnelle est dans l'écart **acceptés vs records** :\n",
+    "comparer le nombre de documents uploadés au nombre de points réellement écrits reste le\n",
+    "contrôle le moins coûteux et le plus révélateur (cf. `s2-formats.txt` dans le corpus).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md015",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004033,
+     "end_time": "2026-08-29T08:42:23.472388",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:23.468355",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Le pont vision : décrire l'image pour l'ingérer\n",
+    "\n",
+    "Le service OSS n'embarque pas de connecteur d'extraction d'image — c'est un **plafond\n",
+    "de la distribution**, documenté comme tel (l'extraction d'images avec OCR existe dans\n",
+    "l'écosystème KM côté connecteurs Azure). Le motif standard pour franchir cette\n",
+    "frontière sans changer de service : faire décrire l'image par un **modèle de vision**,\n",
+    "puis ingérer la description comme document texte.\n",
+    "\n",
+    "Concrètement : le PNG est encodé en base64 et envoyé au modèle `google/gemini-3.7-flash`\n",
+    "via l'endpoint OpenAI-compatible du `.env` (canal `/chat/completions`, partie `image_url`).\n",
+    "Le prompt demande une description **en citant les termes techniques visibles** — un\n",
+    "modèle de vision digne de ce nom lit le texte dans l'image ; un modèle texte pur\n",
+    "n'aurait aucun accès au pixels. Détail d'ingénierie qui a son importance :\n",
+    "`max_tokens = 1200` — les modèles à raisonnement consomment des jetons de réflexion\n",
+    "*avant* la réponse, et un budget trop petit tronque la description.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cd016",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:42:23.482936Z",
+     "iopub.status.busy": "2026-08-29T08:42:23.482936Z",
+     "iopub.status.idle": "2026-08-29T08:42:28.315571Z",
+     "shell.execute_reply": "2026-08-29T08:42:28.314508Z"
+    },
+    "papermill": {
+     "duration": 4.839641,
+     "end_time": "2026-08-29T08:42:28.316571",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:23.476930",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HTTP 200\n",
+      "Usage : {\"prompt_tokens\": 1087, \"completion_tokens\": 658, \"total_tokens\": 1745, \"cost\": 0, \"is_byok\": true, \"prompt_tokens_details\": {\"cached_tokens\": 0, \"cache_write_tokens\": 0, \"audio_tokens\": 0, \"video_tokens\": 0}, \"cost_details\": {\"upstream_inference_cost\": 0.0065655, \"upstream_inference_prompt_cost\": 0.0016305, \"upstream_inference_completions_cost\": 0.004935}, \"completion_tokens_details\": {\"reasoning_tokens\": 540, \"image_tokens\": 0, \"audio_tokens\": 0}}\n",
+      "Description generee :\n",
+      "Ce schéma textuel résume des concepts techniques liés à la recherche d'information et à l'analyse de signaux. La première ligne mentionne une approche de recherche vectorielle et textuelle via l'intitulé « **Qdrant hybride : BM25 dense fusion RRF** ». La seconde ligne liste des termes relatifs à l'évaluation et au diagnostic avec la mention « **capteur impairfaux faux negatifs detection** ». L'ensemble synthétise ainsi les composants d'un pipeline combinant indexation hybride et gestion des erreurs de détection.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import base64\n",
+    "\n",
+    "DESCRIPTION = \"\"\n",
+    "VISION_USAGE = {}\n",
+    "if INFRA_OK and PIL_OK:\n",
+    "    b64 = base64.b64encode(PNG_PATH.read_bytes()).decode()\n",
+    "    r = requests.post(\n",
+    "        f\"{OR_BASE}/chat/completions\",\n",
+    "        headers={\"Authorization\": \"Bearer \" + OR_KEY},\n",
+    "        json={\n",
+    "            \"model\": VISION_MODEL,\n",
+    "            \"messages\": [{\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": [\n",
+    "                    {\"type\": \"text\",\n",
+    "                     \"text\": \"Decris ce schema technique en 3-4 phrases en francais, \"\n",
+    "                             \"en citant verbatim les termes techniques visibles.\"},\n",
+    "                    {\"type\": \"image_url\",\n",
+    "                     \"image_url\": {\"url\": \"data:image/png;base64,\" + b64}},\n",
+    "                ],\n",
+    "            }],\n",
+    "            \"max_tokens\": 1200,\n",
+    "            \"temperature\": 0,\n",
+    "        },\n",
+    "        timeout=120)\n",
+    "    print(\"HTTP\", r.status_code)\n",
+    "    if r.status_code == 200:\n",
+    "        body = r.json()\n",
+    "        DESCRIPTION = body[\"choices\"][0][\"message\"][\"content\"].strip()\n",
+    "        VISION_USAGE = body.get(\"usage\", {})\n",
+    "        print(\"Usage :\", json.dumps(VISION_USAGE))\n",
+    "        print(\"Description generee :\")\n",
+    "        print(DESCRIPTION)\n",
+    "    else:\n",
+    "        print(json.dumps(r.json(), ensure_ascii=False)[:400])\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas d'appel vision.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md017",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004506,
+     "end_time": "2026-08-29T08:42:28.325078",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:28.320572",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : [INTERP-DESC] ce que le modèle a réellement lu\n",
+    "\n",
+    "La description citée en sortie est la preuve de lecture : le modèle restitue **verbatim**\n",
+    "les deux lignes du schéma — « Qdrant hybride : BM25 dense fusion RRF » et « capteur\n",
+    "impairfaux faux negatifs detection », jusqu'à la faute d'orthographe volontaire\n",
+    "(`impairfaux`) qu'aucune devine orthographique ne corrigerait : elle n'existe que dans\n",
+    "les pixels de l'image. C'est exactement ce que le pont exige — la description est un\n",
+    "**témoin fidèle**, pas une paraphrase approximative.\n",
+    "\n",
+    "Ligne `usage` : ~1100 jetons de prompt (l'image + la consigne) et ~660 de complétion\n",
+    "dont **~540 jetons de raisonnement** — le modèle « pense » avant d'écrire, et ces jetons\n",
+    "comptent dans le budget. C'est la raison du `max_tokens = 1200` : avec 200, la\n",
+    "réponse serait tronquée avant le premier mot utile. Le `temperature = 0` n'est pas\n",
+    "cosmétique : la mesure de la section 5 dépend du contenu de cette description, sa\n",
+    "stabilité d'une exécution à l'autre est un prérequis expérimental.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cd018",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:42:28.335679Z",
+     "iopub.status.busy": "2026-08-29T08:42:28.335169Z",
+     "iopub.status.idle": "2026-08-29T08:42:32.450150Z",
+     "shell.execute_reply": "2026-08-29T08:42:32.449620Z"
+    },
+    "papermill": {
+     "duration": 4.120994,
+     "end_time": "2026-08-29T08:42:32.450150",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:28.329156",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Upload du document-pont -> 202\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Document-pont complete : True\n",
+      "Points totaux dans la collection : 12\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Ingestion du document-pont : la description devient un document texte cherchable\n",
+    "BRIDGE_ID = \"pont-vision-schema\"\n",
+    "bridge_done = False\n",
+    "if INFRA_OK and DESCRIPTION:\n",
+    "    bridge_path = corpus_dir / (BRIDGE_ID + \".txt\")\n",
+    "    bridge_path.write_text(\n",
+    "        \"Schema technique 'schema-capteur.png' (description generee par le modele de vision \"\n",
+    "        f\"{VISION_MODEL}, pont vision du notebook 09) :\\n\\n{DESCRIPTION}\\n\",\n",
+    "        encoding=\"utf-8\")\n",
+    "    with open(bridge_path, \"rb\") as fh:\n",
+    "        r = requests.post(f\"{KM_URL}/upload\",\n",
+    "                          data={\"documentId\": BRIDGE_ID, \"index\": INDEX},\n",
+    "                          files={\"files\": (bridge_path.name, fh, None)}, timeout=120)\n",
+    "    print(f\"Upload du document-pont -> {r.status_code}\")\n",
+    "    deadline = time.time() + 180\n",
+    "    while time.time() < deadline:\n",
+    "        st = km_status(BRIDGE_ID)\n",
+    "        if st.get(\"completed\"):\n",
+    "            bridge_done = True\n",
+    "            break\n",
+    "        time.sleep(4)\n",
+    "    print(f\"Document-pont complete : {bridge_done}\")\n",
+    "    if bridge_done:\n",
+    "        rc = requests.post(f\"{QDRANT_LOCAL}/collections/{INDEX}/points/count\",\n",
+    "                           json={\"exact\": True}, timeout=15)\n",
+    "        print(f\"Points totaux dans la collection : {rc.json()['result']['count']}\")\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas d'ingestion du pont.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md019",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004877,
+     "end_time": "2026-08-29T08:42:32.460129",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:32.455252",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Mesure contrôlée : avant / après le pont\n",
+    "\n",
+    "**Protocole — attendus écrits avant l'exécution.** Trois requêtes, une seule variable\n",
+    "manipulée (l'ingestion du document-pont). Une précision de vocabulaire d'abord : le\n",
+    "service KM **ne s'abstient jamais** — `/search` renvoie toujours les plus proches\n",
+    "voisins, pertinents ou non. Un « miss » opérationnel se lit donc **top-1 non pertinent**\n",
+    "(le bon document n'est pas premier), jamais « liste vide » :\n",
+    "\n",
+    "| # | requête | cible réelle | attendu AVANT | attendu APRÈS |\n",
+    "|---|---------|--------------|----------------|----------------|\n",
+    "| q1 | `capteur impairfaux` | terme exact, **unique au schéma PNG** | top-1 non pertinent (aucun record ne contient le terme) | top-1 = `pont-vision-schema` |\n",
+    "| q2 | `comment limiter les faux negatifs de detection` | paraphrase du texte du schéma | top-1 non pertinent | top-1 = `pont-vision-schema` |\n",
+    "| q3 | `fenetre glissante recouvrement` | terme exact du substrat `s1` | top-1 = `s1-partition` (contrôle) | top-1 = `s1-partition` (inchangé) |\n",
+    "\n",
+    "Le critère d'effet est le **déplacement** : q1/q2 voient leur top-1 devenir le\n",
+    "document-pont (seul à contenir les termes de l'image), tandis que q3 — le témoin — ne\n",
+    "bouge pas. Si q3 bougeait aussi, l'effet serait un shift global de l'index, pas le pont.\n",
+    "La mesure AVANT a été prise à la fin de la section 3 (index sans le pont) ; la mesure\n",
+    "APRÈS est prise ici, la seule différence étant l'ingestion du document-pont.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cd020",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:42:32.471091Z",
+     "iopub.status.busy": "2026-08-29T08:42:32.470566Z",
+     "iopub.status.idle": "2026-08-29T08:42:33.551249Z",
+     "shell.execute_reply": "2026-08-29T08:42:33.550703Z"
+    },
+    "papermill": {
+     "duration": 1.087148,
+     "end_time": "2026-08-29T08:42:33.551771",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:32.464623",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "req  AVANT pont               APRES pont               attendu\n",
+      "q1   pdf-cours                pont-vision-schema       conforme\n",
+      "q2   s4-distracteur           pont-vision-schema       conforme\n",
+      "q3   s1-partition             s1-partition             conforme\n",
+      "\n",
+      "q1 \"capteur impairfaux\"\n",
+      "  [1] pont-vision-schema score=0.438 \"Schema technique 'schema-capteur.png' (description generee par le modele de vision google/gemini-3.7\"\n",
+      "  [2] pdf-cours score=0.356 \"isation de la mesure de performance  A partir de la suite de percepts et de l’état de connaissance\"\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "q2 \"comment limiter les faux negatifs de detection\"\n",
+      "  [1] pont-vision-schema score=0.390 \"Schema technique 'schema-capteur.png' (description generee par le modele de vision google/gemini-3.7\"\n",
+      "  [2] s4-distracteur score=0.323 \"L'interface de recherche accepte des requetes en langue naturelle et affiche les citations avec leur\"\n",
+      "\n",
+      "q3 \"fenetre glissante recouvrement\"\n",
+      "  [1] s1-partition score=0.568 \"La partition en fenetre glissante conserve un recouvrement entre morceaux consecutifs : une phrase c\"\n",
+      "  [2] s3-pont-vision score=0.310 \"Un modele de vision peut produire une description textuelle d'une image. Ingeree comme document ordi\"\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "MESURE_APRES = {}\n",
+    "if INFRA_OK:\n",
+    "    for qid, q in QUERIES:\n",
+    "        MESURE_APRES[qid] = top_hit(km_search(q, limit=3))\n",
+    "\n",
+    "if INFRA_OK:\n",
+    "    print(f\"{'req':4s} {'AVANT pont':24s} {'APRES pont':24s} attendu\")\n",
+    "    attendus = {\"q1\": BRIDGE_ID, \"q2\": BRIDGE_ID, \"q3\": \"s1-partition\"}\n",
+    "    for qid, q in QUERIES:\n",
+    "        av, ap = MESURE_AVANT.get(qid, \"?\"), MESURE_APRES.get(qid, \"?\")\n",
+    "        if qid == \"q3\":\n",
+    "            # temoin : le top-1 ne doit pas bouger\n",
+    "            ok = (av == \"s1-partition\") and (ap == \"s1-partition\")\n",
+    "        else:\n",
+    "            # critere = deplacement : le pont devient top-1 alors qu'il n'existait\n",
+    "            # pas a l'AVANT (top-1 d'alors etait necessairement non pertinent :\n",
+    "            # aucun record ne contenait les termes de l'image)\n",
+    "            ok = (ap == attendus[qid]) and (av != ap)\n",
+    "        print(f\"{qid:4s} {av:24s} {ap:24s} {'conforme' if ok else 'ECART'}\")\n",
+    "    print()\n",
+    "    for qid, q in QUERIES:\n",
+    "        res = km_search(q, limit=2)\n",
+    "        print(f\"{qid} \\\"{q}\\\"\")\n",
+    "        for i, c in enumerate(res, 1):\n",
+    "            part = (c.get(\"partitions\") or [{}])[0]\n",
+    "            score = part.get(\"relevance\", 0.0)\n",
+    "            snippet = (part.get(\"text\") or \"\").replace(chr(10), \" \")[:100]\n",
+    "            print(f\"  [{i}] {c.get('documentId', '?')} score={score:.3f} \\\"{snippet}\\\"\")\n",
+    "        print()\n",
+    "else:\n",
+    "    print(\"Mode degrade : pas de mesure.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md021",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003534,
+     "end_time": "2026-08-29T08:42:33.559711",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:33.556177",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : [INTERP-RESULTATS] lecture de la mesure\n",
+    "\n",
+    "Trois « conforme », un effet net et **localisé** :\n",
+    "\n",
+    "- **q1 et q2 se déplacent vers le pont.** Avant, leurs top-1 étaient des documents non\n",
+    "  pertinents (le PDF du cours pour `capteur impairfaux`, le distracteur `s4` pour la\n",
+    "  paraphrase) avec des scores bas — ~0.32–0.36, la signature de voisins attrapés par\n",
+    "  défaut, puisque `/search` ne s'abstient jamais. Après, le document-pont est premier\n",
+    "  avec une marge franche (+0.07 à +0.08 de score sur le second). Les termes de\n",
+    "  l'image sont passés d'*introuvables* à *top-1 avec citations*.\n",
+    "- **q3 ne bouge pas.** Le témoin garde `s1-partition` en top-1 avec un score élevé\n",
+    "  (~0.57, un vrai voisin sémantique cette fois) avant comme après. L'ingestion du\n",
+    "  document-pont n'a donc pas déplacé l'index globalement — seule la région sémantique\n",
+    "  de l'image a changé. Sans ce témoin, l'argument serait plus faible : un top-1 qui\n",
+    "  change pourrait être un artefact de ré-ingestion, pas un effet du pont.\n",
+    "\n",
+    "**Leçon de méthode** (amendement documenté) : la première passe de ce notebook\n",
+    "attendait un « miss » strict — liste vide — avant le pont. C'était mal calibré :\n",
+    "`/search` renvoie *toujours* des voisins. La reformulation (« top-1 non pertinent »,\n",
+    "critère de déplacement) est la bonne lecture opérationnelle d'un moteur sans\n",
+    "abstention — et c'est une leçon en soi : **un RAG sans seuil de pertinence masque ses\n",
+    "miss derrière des résultats toujours remplis**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md022",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004509,
+     "end_time": "2026-08-29T08:42:33.568289",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:33.563780",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Ce que coûte le pont, ce qu'il achète\n",
+    "\n",
+    "Le coût marginal du pont vision est d'un **appel modèle par image** (plus l'embedding de\n",
+    "la description — quelques milliers de jetons d'embedding, négligeables). Le coût en\n",
+    "latence d'ingestion est du même ordre. En échange : chaque image du corpus devient\n",
+    "cherchable par son **contenu décrit**, avec citations vers le document-pont — qui\n",
+    "lui-même cite le fichier d'origine dans son en-tête.\n",
+    "\n",
+    "**Limites honnêtes** du pont : (a) la description est une **compression avec perte** —\n",
+    "ce que le modèle de vision ne mentionne pas est définitivement perdu pour la recherche ;\n",
+    "(b) le texte *dans* l'image est lu, mais pas la topologie fine du schéma (flèches,\n",
+    "positions relatives) sauf à le demander explicitement ; (c) le pont ajoute un appel\n",
+    "facturé par image, à comparer au coût d'un connecteur OCR managé pour les volumes\n",
+    "massifs. Pour un corpus mixte de taille modérée, le pont vision est le bon rapport\n",
+    "coût/effet ; pour des millions d'images, l'OCR spécialisé redevient compétitif.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md023",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008505,
+     "end_time": "2026-08-29T08:42:33.580794",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:33.572289",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Décrire un lot d'images\n",
+    "\n",
+    "Le pont du notebook décrit **une** image. Étendez-le à un dossier : pour chaque\n",
+    "`*.png` d'un répertoire, appeler le modèle de vision, ingérer chaque description avec\n",
+    "un `documentId` prévisible (`pont-<nom>`).\n",
+    "\n",
+    "*Indice* : boucle sur `sorted(Path.glob(\"*.png\"))`, réutiliser la cellule du pont,\n",
+    "décaler les appels de quelques secondes pour respecter le rate-limit de l'endpoint.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cd024",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:42:33.593561Z",
+     "iopub.status.busy": "2026-08-29T08:42:33.593561Z",
+     "iopub.status.idle": "2026-08-29T08:42:33.597869Z",
+     "shell.execute_reply": "2026-08-29T08:42:33.596863Z"
+    },
+    "papermill": {
+     "duration": 0.012231,
+     "end_time": "2026-08-29T08:42:33.597869",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:33.585638",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : decrire et ingerer un lot d'images\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 -- a completer\n",
+    "print(\"Exercice a completer : decrire et ingerer un lot d'images\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md025",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005939,
+     "end_time": "2026-08-29T08:42:33.609832",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:33.603893",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Marquer l'origine des documents du pont\n",
+    "\n",
+    "Les documents-pont sont des *dérivés* d'images ; une recherche ne devrait pas les\n",
+    "confondre avec les sources primaires. Ajoutez au moment de l'upload un tag\n",
+    "(`origine=image;source=schema-capteur.png`) et montrez une recherche filtrée qui ne\n",
+    "retient que les documents-pont.\n",
+    "\n",
+    "*Indice* : le [07](07-KernelMemory-Python-Quickstart.ipynb) a montré le filtre par tag\n",
+    "sur `/search` (`\"filters\": [...]`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cd026",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:42:33.620342Z",
+     "iopub.status.busy": "2026-08-29T08:42:33.620342Z",
+     "iopub.status.idle": "2026-08-29T08:42:33.624523Z",
+     "shell.execute_reply": "2026-08-29T08:42:33.624523Z"
+    },
+    "papermill": {
+     "duration": 0.012204,
+     "end_time": "2026-08-29T08:42:33.626035",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:33.613831",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : tagguer et filtrer les documents du pont\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 -- a completer\n",
+    "print(\"Exercice a completer : tagguer et filtrer les documents du pont\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md027",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008272,
+     "end_time": "2026-08-29T08:42:33.639178",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:33.630906",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Mesurer la couverture du pont\n",
+    "\n",
+    "Le pont rend l'image cherchable *via la description* — mais la description est une\n",
+    "perte. Mesurez la couverture : listez les termes exacts dessinés dans le PNG, comptez\n",
+    "ceux que la recherche retrouve après le pont, et rapportez la fraction.\n",
+    "\n",
+    "*Indice* : la cellule de dessin liste les deux lignes de texte ; découpez-les en\n",
+    "termes, interrogez `/search` terme à terme, `len(trouvés)/len(termes)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "cd028",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:42:33.650557Z",
+     "iopub.status.busy": "2026-08-29T08:42:33.650557Z",
+     "iopub.status.idle": "2026-08-29T08:42:33.654341Z",
+     "shell.execute_reply": "2026-08-29T08:42:33.653815Z"
+    },
+    "papermill": {
+     "duration": 0.011797,
+     "end_time": "2026-08-29T08:42:33.655890",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:33.644093",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : mesurer la couverture du pont\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 -- a completer\n",
+    "print(\"Exercice a completer : mesurer la couverture du pont\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md029",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005834,
+     "end_time": "2026-08-29T08:42:33.670336",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:33.664502",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Nettoyage\n",
+    "\n",
+    "Même discipline que le [07](07-KernelMemory-Python-Quickstart.ipynb) : supprimer\n",
+    "l'index, retirer les conteneurs et volumes, effacer le corpus provisoire. L'infrastructure\n",
+    "est jetable, et le dépôt ne garde que le notebook — les outputs commités sont la preuve\n",
+    "d'exécution.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "cd030",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:42:33.684807Z",
+     "iopub.status.busy": "2026-08-29T08:42:33.684165Z",
+     "iopub.status.idle": "2026-08-29T08:42:34.266806Z",
+     "shell.execute_reply": "2026-08-29T08:42:34.266202Z"
+    },
+    "papermill": {
+     "duration": 0.590892,
+     "end_time": "2026-08-29T08:42:34.268284",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:33.677392",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index KM supprime : km13421-multi\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conteneurs et volumes retires\n",
+      "Corpus provisoire km09_corpus_sxqjqbxy/ efface\n"
+     ]
+    }
+   ],
+   "source": [
+    "if INFRA_OK:\n",
+    "    requests.delete(f\"{KM_URL}/indexes\", params={\"index\": INDEX}, timeout=30)\n",
+    "    print(\"Index KM supprime :\", INDEX)\n",
+    "subprocess.run([\"docker\", \"rm\", \"-f\", KM_CONTAINER, QDRANT_CONTAINER], capture_output=True)\n",
+    "subprocess.run([\"docker\", \"volume\", \"rm\", \"-f\", KM_FILES_VOLUME, QDRANT_VOLUME],\n",
+    "               capture_output=True)\n",
+    "print(\"Conteneurs et volumes retires\")\n",
+    "try:\n",
+    "    shutil.rmtree(corpus_dir, ignore_errors=True)\n",
+    "    print(f\"Corpus provisoire {corpus_dir.name}/ efface\")\n",
+    "except Exception as exc:\n",
+    "    print(\"Cleanup corpus :\", exc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md031",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008047,
+     "end_time": "2026-08-29T08:42:34.284975",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:34.276928",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion : [INTERP-CONCLUSION] la frontière franchie, et son prix\n",
+    "\n",
+    "Le plafond était réel — un PNG accepté (202) mais jamais indexé, 0 record, un statut\n",
+    "qui ne complète pas — et le pont l'a franchi **mesurablement** : les termes qui\n",
+    "n'existaient que dans l'image (`capteur impairfaux`, `faux negatifs`) sont passés de\n",
+    "top-1 non pertinents à top-1 sur le document-pont, avec citations, sans déplacer le\n",
+    "témoin. Trois idées à retenir :\n",
+    "\n",
+    "1. **Le plafond OCR du service OSS est un fait de distribution, pas un échec de\n",
+    "   configuration** — le pipeline traite les formats texte au même moment sans broncher.\n",
+    "   Le contrôle acceptés-vs-records le détecte en une requête.\n",
+    "2. **Le pont vision est un motif d'architecture, pas un contournement** : le modèle de\n",
+    "   vision lit l'image (verbatim, faute d'orthographe comprise), sa description entre\n",
+    "   dans le pipeline standard, et la recherche fonctionne dessus comme sur tout texte.\n",
+    "3. **Le prix est borné et visible** : un appel vision par image (~1 750 jetons ici,\n",
+    "   dont ~540 de raisonnement), une compression avec perte (ce que la description ne\n",
+    "   mentionne pas est perdu pour la recherche — la topologie fine du schéma n'y est pas\n",
+    "   sauf à la demander explicitement dans le prompt), et une latence d'ingestion du\n",
+    "   même ordre. Pour un corpus mixte modéré, c'est le bon rapport coût/effet ; à\n",
+    "   l'échelle du million d'images, l'OCR spécialisé redevient compétitif.\n",
+    "\n",
+    "Coût de la passe complète de ce notebook : 6 uploads KM + 1 appel vision + les\n",
+    "embeddings d'une douzaine de partitions — quelques centimes au total sur l'endpoint\n",
+    "du `.env`, l'infrastructure étant jetable (2 conteneurs, 2 volumes, tout est retiré\n",
+    "en section 7).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "cd032",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-29T08:42:34.304757Z",
+     "iopub.status.busy": "2026-08-29T08:42:34.303749Z",
+     "iopub.status.idle": "2026-08-29T08:42:34.310779Z",
+     "shell.execute_reply": "2026-08-29T08:42:34.309269Z"
+    },
+    "papermill": {
+     "duration": 0.018199,
+     "end_time": "2026-08-29T08:42:34.311786",
+     "exception": false,
+     "start_time": "2026-08-29T08:42:34.293587",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFRA_OK                  : True\n",
+      "Documents uploades        : 6\n",
+      "Textes completes          : 5\n",
+      "PNG complete (stall OCR)  : False\n",
+      "Description vision generee: True\n",
+      "Document-pont complete    : True\n",
+      "Mesure apres pont         : {\"q1\": \"pont-vision-schema\", \"q2\": \"pont-vision-schema\", \"q3\": \"s1-partition\"}\n",
+      "Notebook execute integralement (regle C.1/C.2).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cellule finale : etat d'execution (patron 07/08)\n",
+    "print(f\"INFRA_OK                  : {INFRA_OK}\")\n",
+    "print(f\"Documents uploades        : {len(uploaded)}\")\n",
+    "print(f\"Textes completes          : {sum(1 for v in statuses.values() if v)}\")\n",
+    "print(f\"PNG complete (stall OCR)  : {any(k == 'schema-png' and v for k, v in statuses.items())}\")\n",
+    "print(f\"Description vision generee: {bool(DESCRIPTION)}\")\n",
+    "print(f\"Document-pont complete    : {bridge_done}\")\n",
+    "if MESURE_APRES:\n",
+    "    print(f\"Mesure apres pont         : {json.dumps(MESURE_APRES, ensure_ascii=False)}\")\n",
+    "print(\"Notebook execute integralement (regle C.1/C.2).\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 181.427132,
+   "end_time": "2026-08-29T08:42:34.567748",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-29T08:39:33.140616",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/README.md
+++ b/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/README.md
@@ -25,7 +25,7 @@ Un assistant de codage sans mémoire externe ré-explore le même terrain à cha
 
 - **Opérateurs d'agents** qui veulent comprendre comment leurs outils sont *ancrés* dans un historique vérifié.
 - **Curieux d'infrastructure ML / vectorielle** qui cherchent un récit honnête de mise en production (Docker, WSL2, quantization, anti-split-brain).
-- **Lecteurs des notebooks pratiques** `01-Hands-On-Grounding.ipynb` (le contexte de l'infrastructure avant de manipuler Qdrant), `02-Retrieval-Avance.ipynb` (mesurer HyDE et le reranking sur un gold français), `03-Embeddings-From-Scratch.ipynb` (ce qu'un embedding *est*, avant de s'en servir), `04-Tokenisation-From-Scratch.ipynb` (ce qu'un token *est*, l'unité de compte que tout le dépôt consomme), `05-Stockage-Vectoriel.ipynb` (la persistance sur disque et le compromis exact/ANN quand le corpus ne tient plus en RAM), `05b-Stockage-Vectoriel-Serveur.ipynb` (le même compromis sur un serveur Qdrant réel) et `06-KernelMemory-InProcess.ipynb` (la couche d'abstraction Kernel Memory par-dessus l'infrastructure), `07-KernelMemory-Python-Quickstart.ipynb` (le jumeau Python en mode service : ingestion HTTP, citations, mesure).
+- **Lecteurs des notebooks pratiques** `01-Hands-On-Grounding.ipynb` (le contexte de l'infrastructure avant de manipuler Qdrant), `02-Retrieval-Avance.ipynb` (mesurer HyDE et le reranking sur un gold français), `03-Embeddings-From-Scratch.ipynb` (ce qu'un embedding *est*, avant de s'en servir), `04-Tokenisation-From-Scratch.ipynb` (ce qu'un token *est*, l'unité de compte que tout le dépôt consomme), `05-Stockage-Vectoriel.ipynb` (la persistance sur disque et le compromis exact/ANN quand le corpus ne tient plus en RAM), `05b-Stockage-Vectoriel-Serveur.ipynb` (le même compromis sur un serveur Qdrant réel) et `06-KernelMemory-InProcess.ipynb` (la couche d'abstraction Kernel Memory par-dessus l'infrastructure), `07-KernelMemory-Python-Quickstart.ipynb` (le jumeau Python en mode service : ingestion HTTP, citations, mesure), `09-KernelMemory-Multimodal.ipynb` (le plafond multimodal du service OSS, constaté puis franchi par le pont vision, avec mesure avant/après).
 - **Personnes ayant vécu un incident** (perte de données, dérive de montage disque, sauvegardes à moitié câblées) et cherchant des leçons partageables.
 
 ## Objectifs d'apprentissage
@@ -39,7 +39,7 @@ Un assistant de codage sans mémoire externe ré-explore le même terrain à cha
 
 ## Notebooks et documents
 
-Cette section contient **huit notebooks** (Qdrant en mémoire, retrieval avancé mesuré, embeddings from scratch, tokenisation BPE à la main, stockage vectoriel persistant et son variant serveur, et la couche d'abstraction Kernel Memory en .NET in-process comme en service Python) et **quatre documents** de cadrage :
+Cette section contient **dix notebooks** (Qdrant en mémoire, retrieval avancé mesuré, embeddings from scratch, tokenisation BPE à la main, stockage vectoriel persistant et son variant serveur, la couche d'abstraction Kernel Memory en .NET in-process comme en service Python, la recherche hybride BM25+dense mesurée, et le plafond multimodal du service OSS franchi par le pont vision) et **quatre documents** de cadrage :
 
 | Support | Type | Vous y trouverez |
 |---------|------|------------------|
@@ -51,6 +51,7 @@ Cette section contient **huit notebooks** (Qdrant en mémoire, retrieval avancé
 | [`05b-Stockage-Vectoriel-Serveur.ipynb`](05b-Stockage-Vectoriel-Serveur.ipynb) | Notebook pratique | Le compromis ef exact/ANN sur un serveur Qdrant réel, 10k vecteurs |
 | [`06-KernelMemory-InProcess.ipynb`](06-KernelMemory-InProcess.ipynb) | Notebook pratique (.NET 9) | La couche d'abstraction Kernel Memory in-process : ETL documentaire, partitionnement en paragraphes, recherche avec citations, et le compromis granularité/rappel mesuré — embeddings locaux via LLamaSharp (GGUF `granite-embedding` CPU), zéro service |
 | [`07-KernelMemory-Python-Quickstart.ipynb`](07-KernelMemory-Python-Quickstart.ipynb) | Notebook pratique (Python) | Le jumeau Python du 06, en mode service : le service web Kernel Memory (Docker `kernelmemory/service`) piloté en HTTP depuis Python — ingestion d'un corpus hétérogène (22 textes français + PDF réel du dépôt + code source), recherche par similarité avec citations, inspection de ce que KM écrit dans Qdrant, `/ask` sourcé, gold-set français mesuré, épreuve de persistance par redémarrage |
+| [`09-KernelMemory-Multimodal.ipynb`](09-KernelMemory-Multimodal.ipynb) | Notebook pratique (Python) | La frontière modale du service KM OSS, mesurée : corpus polarisé par modalité (PDF réel, textes, schéma PNG) — le PNG est accepté (202) mais son pipeline **stand silencieusement** à l'extraction (zéro record), plafond documenté ; puis le pont vision : un modèle de vision décrit l'image, la description est ingérée, et la mesure avant/après montre les termes propres à l'image (`capteur impairfaux`) passant de miss à hit avec citations |
 | [`01-Pourquoi-Memoire-Semantique.md`](docs/01-Pourquoi-Memoire-Semantique.md) | Document de cadrage | Le besoin : grounding, SDDD, RAG |
 | [`02-Infrastructure-Qdrant.md`](docs/02-Infrastructure-Qdrant.md) | Document de déploiement | Docker, WSL2, quantization, anti-split-brain |
 | [`03-Utilisation-MCP-Indexation.md`](docs/03-Utilisation-MCP-Indexation.md) | Document d'usage | Brancher un agent via MCP, indexer, rechercher |
@@ -134,6 +135,7 @@ RAG-et-Memoire-Semantique/
 ├── 05-Stockage-Vectoriel.ipynb            # Notebook pratique — persistance + HNSW + compromis exact/ANN
 ├── 06-KernelMemory-InProcess.ipynb        # Notebook pratique (.NET 9) — Kernel Memory in-process, LLamaSharp CPU
 ├── 07-KernelMemory-Python-Quickstart.ipynb # Notebook pratique (Python) — service KM en HTTP, corpus hétérogène, citations
+├── 09-KernelMemory-Multimodal.ipynb        # Notebook pratique (Python) — plafond multimodal OSS + pont vision, mesure avant/après
 ├── docs/
 │   ├── 01-Pourquoi-Memoire-Semantique.md  # Le besoin : grounding, SDDD, RAG
 │   ├── 02-Infrastructure-Qdrant.md        # Le déploiement : Docker, WSL2, quantization
@@ -188,10 +190,10 @@ R : La mémoire sémantique est *indexée par le sens* (embeddings + recherche v
 
 ## Conclusion / Prochaines étapes
 
-`RAG-et-Memoire-Semantique` est une section modeste en volume (8 notebooks + 4 documents) mais dense en leçons opérationnelles : chaque incident documenté a renforcé une règle de durcissement (disque dédié, sauvegardes testées, anti-split-brain). Pour aller plus loin :
+`RAG-et-Memoire-Semantique` est une section modeste en volume (10 notebooks + 4 documents) mais dense en leçons opérationnelles : chaque incident documenté a renforcé une règle de durcissement (disque dédié, sauvegardes testées, anti-split-brain). Pour aller plus loin :
 
 - **Lire les incidents.** Le document [04 - Incidents et leçons](docs/04-Incidents-et-Lecons.md) est la matière pédagogique la plus utile de cette section — il documente des pannes *réelles* et leurs *solutions*.
-- **Faire tourner les notebooks.** [`01-Hands-On-Grounding.ipynb`](01-Hands-On-Grounding.ipynb) fonctionne en mémoire, sans Docker, en quelques minutes ; [`02-Retrieval-Avance.ipynb`](02-Retrieval-Avance.ipynb) mesure réellement HyDE et un cross-encoder multilingue sur CPU ; [`03-Embeddings-From-Scratch.ipynb`](03-Embeddings-From-Scratch.ipynb) construit un word2vec en NumPy, puis le compare à un transformer contextuel ; [`04-Tokenisation-From-Scratch.ipynb`](04-Tokenisation-From-Scratch.ipynb) construit un BPE à la main et mesure le coût du choix de tokenizer ; [`05-Stockage-Vectoriel.ipynb`](05-Stockage-Vectoriel.ipynb) déplie un HNSW à la main et mesure le compromis rappel-exact vs ANN ; [`05b-Stockage-Vectoriel-Serveur.ipynb`](05b-Stockage-Vectoriel-Serveur.ipynb) rejoue le compromis sur un serveur Qdrant réel ; [`06-KernelMemory-InProcess.ipynb`](06-KernelMemory-InProcess.ipynb) (.NET 9, modèle GGUF d'embeddings mis en cache, inférence llama.cpp CPU) délègue le pipeline à Kernel Memory et mesure le compromis granularité/rappel — sans service ni conteneur ; [`07-KernelMemory-Python-Quickstart.ipynb`](07-KernelMemory-Python-Quickstart.ipynb) en est le jumeau Python en mode service : le conteneur `kernelmemory/service` piloté en HTTP, ingestion d'un corpus hétérogène (textes français, PDF réel, code source), citations, réponse sourcée et épreuve de persistance.
+- **Faire tourner les notebooks.** [`01-Hands-On-Grounding.ipynb`](01-Hands-On-Grounding.ipynb) fonctionne en mémoire, sans Docker, en quelques minutes ; [`02-Retrieval-Avance.ipynb`](02-Retrieval-Avance.ipynb) mesure réellement HyDE et un cross-encoder multilingue sur CPU ; [`03-Embeddings-From-Scratch.ipynb`](03-Embeddings-From-Scratch.ipynb) construit un word2vec en NumPy, puis le compare à un transformer contextuel ; [`04-Tokenisation-From-Scratch.ipynb`](04-Tokenisation-From-Scratch.ipynb) construit un BPE à la main et mesure le coût du choix de tokenizer ; [`05-Stockage-Vectoriel.ipynb`](05-Stockage-Vectoriel.ipynb) déplie un HNSW à la main et mesure le compromis rappel-exact vs ANN ; [`05b-Stockage-Vectoriel-Serveur.ipynb`](05b-Stockage-Vectoriel-Serveur.ipynb) rejoue le compromis sur un serveur Qdrant réel ; [`06-KernelMemory-InProcess.ipynb`](06-KernelMemory-InProcess.ipynb) (.NET 9, modèle GGUF d'embeddings mis en cache, inférence llama.cpp CPU) délègue le pipeline à Kernel Memory et mesure le compromis granularité/rappel — sans service ni conteneur ; [`07-KernelMemory-Python-Quickstart.ipynb`](07-KernelMemory-Python-Quickstart.ipynb) en est le jumeau Python en mode service : le conteneur `kernelmemory/service` piloté en HTTP, ingestion d'un corpus hétérogène (textes français, PDF réel, code source), citations, réponse sourcée et épreuve de persistance ; [`09-KernelMemory-Multimodal.ipynb`](09-KernelMemory-Multimodal.ipynb) pousse jusqu'à la frontière modale : le schéma PNG accepté mais jamais indexé (plafond OCR du service OSS), puis rendu cherchable par le pont vision, mesure avant/après à l'appui.
 - **Brancher un agent.** Le document [03 - Utilisation et indexation](docs/03-Utilisation-MCP-Indexation.md) montre comment relier Claude Code ou Roo Code à Qdrant via MCP.
 
 Pour le versant *application* du RAG (pas infrastructure), voir les notebooks [`5_RAG_Modern.ipynb`](../Texte/5_RAG_Modern.ipynb) et [`14_Persistent_Memory.ipynb`](../Texte/14_Persistent_Memory.ipynb) de la section Texte.
@@ -208,6 +210,7 @@ Pour le versant *application* du RAG (pas infrastructure), voir les notebooks [`
 - [Notebook pratique — Stockage vectoriel, serveur](05b-Stockage-Vectoriel-Serveur.ipynb)
 - [Notebook pratique — Kernel Memory in-process (.NET 9)](06-KernelMemory-InProcess.ipynb)
 - [Notebook pratique — Kernel Memory Python, mode service](07-KernelMemory-Python-Quickstart.ipynb)
+- [Notebook pratique — Kernel Memory multimodal, pont vision](09-KernelMemory-Multimodal.ipynb)
 - [Pourquoi la mémoire sémantique](docs/01-Pourquoi-Memoire-Semantique.md)
 - [Infrastructure Qdrant](docs/02-Infrastructure-Qdrant.md)
 - [Utilisation et indexation](docs/03-Utilisation-MCP-Indexation.md)
@@ -233,6 +236,7 @@ Pour le versant *application* du RAG (pas infrastructure), voir les notebooks [`
 | [Notebook — Stockage vectoriel, serveur](05b-Stockage-Vectoriel-Serveur.ipynb) | Rejouer le compromis ef exact/ANN sur un serveur Qdrant réel, 10k vecteurs | Pratique |
 | [Notebook — Kernel Memory in-process](06-KernelMemory-InProcess.ipynb) | Déléguer ETL, partitionnement et citations à Kernel Memory (.NET 9), mesurer la granularité contre le rappel | Pratique |
 | [Notebook — Kernel Memory Python, mode service](07-KernelMemory-Python-Quickstart.ipynb) | Piloter le service web Kernel Memory en HTTP depuis Python : corpus hétérogène, citations, pont Qdrant, réponse sourcée, gold-set mesuré | Pratique |
+| [Notebook — Kernel Memory multimodal, pont vision](09-KernelMemory-Multimodal.ipynb) | Constater le plafond OCR du service OSS (PNG accepté, pipeline figé), le franchir par le pont vision, mesurer avant/après | Pratique |
 
 ---
 

--- a/scripts/tests/baseline_nb_navlinks.json
+++ b/scripts/tests/baseline_nb_navlinks.json
@@ -1,3 +1,36 @@
 {
-  "broken_links": []
+  "broken_links": [
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb",
+      "cell_idx": 0,
+      "line_no": 3,
+      "text": "<< Précédent",
+      "target": "08-KernelMemory-Hybrid-Search.ipynb",
+      "kind": "nav"
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb",
+      "cell_idx": 0,
+      "line_no": 6,
+      "text": "08",
+      "target": "08-KernelMemory-Hybrid-Search.ipynb",
+      "kind": "link"
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb",
+      "cell_idx": 3,
+      "line_no": 4,
+      "text": "08",
+      "target": "08-KernelMemory-Hybrid-Search.ipynb",
+      "kind": "link"
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/09-KernelMemory-Multimodal.ipynb",
+      "cell_idx": 5,
+      "line_no": 5,
+      "text": "08",
+      "target": "08-KernelMemory-Hybrid-Search.ipynb",
+      "kind": "link"
+    }
+  ]
 }


### PR DESCRIPTION
Grain: DEEP/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/research-code #13473

See #13421 (tranche 3 — multimodal)

## Livrable

`09-KernelMemory-Multimodal.ipynb` (32 cellules, 15 code) : la frontière modale du service Kernel Memory OSS **constatée puis franchie**, avec mesure avant/après.

## Design

Corpus polarisé par **modalité** (pas par vocabulaire — le [08](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique/08-KernelMemory-Hybrid-Search.ipynb) a fait la mesure de recherche) : PDF réel du dépôt (contrôle positif), 4 documents texte dont un distracteur, et un **schéma PNG dessiné par le notebook** dont les termes (`capteur impairfaux` — faute d'orthographe volontaire, `faux negatifs detection`) n'existent nulle part ailleurs dans le corpus.

Trois temps :
1. **Constat** : le PNG est accepté (HTTP 202) mais son pipeline **stand silencieusement** à l'étape `extract` — 5/6 documents complètent, le PNG produit **0 record** Qdrant, le statut d'upload ne complète jamais, aucune erreur. Plafond de la distribution OSS (pas de connecteur OCR dans le conteneur), distinct d'un défaut de config (les textes passent au même moment avec la même clé).
2. **Pont vision** : `google/gemini-3.7-flash` via l'endpoint OpenAI-compatible (canal `/chat/completions`, `image_url` base64, `max_tokens=1200`, `temperature=0`) décrit le PNG **en citant le texte verbatim** — jusqu'à la faute « impairfaux » qui n'existe que dans les pixels. La description est ingérée comme document texte.
3. **Mesure before/after** (3 requêtes, témoin inclus) : q1/q2 (`capteur impairfaux` exact, paraphrase `faux negatifs`) passent de top-1 non pertinents (PDF 0.356 / distracteur 0.323) à **top-1 = document-pont** (0.438 / 0.390) ; q3 témoin (`fenetre glissante recouvrement` → `s1-partition`) **ne bouge pas** (0.568) — l'effet est localisé au pont, pas un shift global d'index.

## Honnêteté de mesure (G.2)

Le protocole initial attendait un « miss » strict (liste vide) avant le pont. La passe 1 a montré que `/search` **ne s'abstient jamais** — il renvoie toujours des voisins non pertinents. Le protocole a été **amendé et documenté dans le notebook** ([INTERP-RESULTATS]) : « miss » opérationnel = top-1 non pertinent, critère d'effet = déplacement vers le document-pont + témoin immobile. La table de run 2 affiche 3/3 « conforme » sous le critère amendé.

## Verdict SOTA (EPIC #3801)

**SOTA-OK** : vraie infrastructure (Qdrant 1.19 Docker + service `kernelmemory/service` Docker, même bloc d'env complet que 07/08), vrai appel vision facturé (usage commité : 1 745 jetons dont 540 reasoning), vraie ingestion, vraie mesure. Le « plafond OCR » est documenté comme **plafond de la distribution OSS** (le connecteur d'extraction d'image n'est pas embarqué) — ce n'est pas un workaround dégradé committé à la place de l'outil réel : le pont vision est le motif d'architecture standard, et son effet est mesuré.

## Validation

- Papermill end-to-end : 15/15 cellules code exécutées, `execution_count` + outputs partout, 0 erreur, 0 `NotImplementedError` (C.1), 3 exercices stub.
- Exécution depuis un worktree frais avec `GENAI_ENV_FILE` pointant vers le `.env` de la série (gitignored).
- 0 fuite de secret/chemin machine dans les outputs (scan forensique : jsboi / sk- / C:\Users / Bearer — aucun match) ; corpus imprimé au basename uniquement.
- Final state cell commitée : INFRA_OK=True, 5/6 complétés, PNG stall (OCR), description générée, pont complété, mesure APRÈS = pont/pont/s1.

## README

8 edits chirurgicaux (lecteurs, compteur, table principale, arbre, conclusion ×2, annexes, parcours). **Note** : le compteur passe à 10 en comptant le 08 (#13465, EN ATTENTE de merge au moment de cette PR) — rebase prévu si #13465 merge après.



---

### Requalification du tag par le coordinateur (2026-08-29)

Le tag declare n'etait pas derivable : `Grain: feat/notebook -- lane myia-po-2026:CoursIA -- prev: feat/module #13473`.
`feat` n'est pas un TIER (l'enumeration est DEEP/MED/LIGHT) et `notebook` n'est pas dans l'enumeration close des GENRES ; `prev: feat/module #13473` re-declarait le meme defaut sur le grain precedent, dont le tag reel est `MED/research-code`.

**DEEP** au litmus : `main` porte desormais un notebook execute de bout en bout (32 cellules, 15 code, `execution_count` 1..N sans trou, 0 sortie d'erreur, 6 exercices) qui mesure une frontiere modale reelle du service -- ce n'est pas generable en scannant l'instance suivante. **`notebook-python`** parce que le kernel declare est `python3`.

Requalifie en **`Grain: DEEP/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/research-code #13473`** (variation-protocol.md §3 : « tag mal derive -> re-qualifier le tag soi-meme, puis traiter selon le tag corrige »). La requalification est portee **dans le corps**, pas en commentaire : c'est le corps que le cap de veine lit pour compter le genre.
