### PR TITLE
fix(guard,#13474): document A+ positional capture + witness the real D+ frontier

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -418,6 +418,12 @@ _MENTION_VERDICT = re.compile(
     # faux match en neutralisation de `commit` au lieu du verdict (2 FAIL
     # tests #11809 mesures en CI, 2026-08-28). Même discriminant case-
     # sensitive que la Position D.
+    # #13474 — la capture A+ est POSITIONNELLE : le PREMIER token en
+    # capitales apres la parenthese ouvrante, pas « le token le plus proche
+    # du verbe d'emission ». Consequence fail-loud : si un autre marqueur
+    # majuscule precede le verdict dans la parenthese (ex `(BOT_CONCERTATION
+    # a propos du BOT_CONCERN)`), c'est BOT_CONCERTATION qui est capture et
+    # BOT_CONCERN reste emis — le garde reste bruyant.
     r"[^()\n]{0,40}\(\s*((?-i:[A-Z][A-Z_]{3,}))[^()\n]{0,80}\)")
 
 # #12311 (cf grain) — Position A : titre de section. Le pattern historique
@@ -534,11 +540,15 @@ _MENTION_VERDICT_REVIEW = re.compile(
     r"(?:"
     # Forme d'origine : ref pointable entre parentheses immediates.
     r"[^():\n.]{0,12}?"
-    # #12871 (cf grain) — Position D+ : la ref pointable peut etre NUE dans une
-    # fenetre de 60 chars apres le verdict (les formes parenthesees
+    # #12871 (cf grain) — Position D+ : la ref pointable peut etre NUE dans
+    # une fenetre bornee apres le verdict (les formes parenthesees
     # `(SHA ...)` continuent de matcher ; les formes narratives
-    # `... traitee par le commit <sha>` sont ajoutees). Borne courte (60 chars)
-    # pour ne pas avaler une autre phrase distincte.
+    # `... par le commit <sha>` sont ajoutees). #13474 — la borne REELLE est
+    # {0,12} chars de gap verdict->par/via/dans/en (temoin mecanique :
+    # gap 12 matche, gap 13 ne matche plus — test_13474_* dans
+    # test_check_unaddressed_nits.py) ; le long-format releve de la Position
+    # E (fenetre 200). Borne courte volontaire pour ne pas avaler une autre
+    # phrase distincte.
     r"(?:"
     r"\([^()\n]{0,80}?"
     r"(?:[a-f0-9]{7,}|#\d+|\d{4}-\d{2}-\d{2}|\d{1,2}:\d{2}(?::\d{2})?Z?)"
@@ -552,8 +562,8 @@ _MENTION_VERDICT_REVIEW = re.compile(
 
 # #12871 (cf grain) — Position E : `La review <VERDICT> ... traitee par le
 # commit <sha>` (ou variantes). La Position D stricte echoue sur ce cas parce
-# que la ref pointable est trop loin (60+ chars apres le verdict), au-dela
-# d'une frontiere de phrase `.`. Mais la phrase CONTIENT un verbe de levee
+# que la ref pointable est trop loin (plus de 12 chars apres le verdict, borne
+# D+ ci-dessus, #13474), au-dela d'une frontiere de phrase `.`. Mais la phrase CONTIENT un verbe de levee
 # suivi d'une ref pointable — c'est la signature d'une mention, pas d'une
 # emission. Discriminant : on exige (a) `La review/ce <VERDICT>` en tete, (b)
 # PAS de fin de phrase entre le verdict et le verbe de levee (donc sous la

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -2831,3 +2831,36 @@ def test_13425_controles_ce1_fp3_restant_inchanges():
     fp3 = "La review CHANGES_REQUESTED a ete traitee par le commit a1b2c3d4e"
     assert mod.classify("jsboige", ce1) == "BOT-CONCERN"
     assert mod.classify("jsboige", fp3) is None
+
+
+# ---------------------------------------------------------------------------
+# #13474 — frontieres bornees des positions de mention : temoins de frontiere.
+# La Position D+ borne le gap verdict->ref nue narrative (par/via/dans/en) a
+# `{0,12}` chars INCLUS ; au-dela, ni D+ (borne depassee) ni E (pas de verbe
+# de levee avant la ref) ne neutralisent — le verdict reste live. Frontiere
+# mesuree : gap 12 matche, gap 13 ne matche plus. Chaque temoin ECHOUE si la
+# fenetre bouge (elargie a 13 : le temoin hors-frontiere se met a matcher ;
+# retrecie a 10 : le temoin dans-frontiere cesse de matcher).
+# ---------------------------------------------------------------------------
+
+
+def test_13474_dplus_gap_12_chars_dans_la_borne_neutralise():
+    """#13474 temoin dans-frontiere — gap d'EXACTEMENT 12 chars (borne
+    `{0,12}` inclusive) entre le verdict et `par le commit <sha>` : la
+    Position D+ matche, la mention neutralise le verdict.
+    CE TEST ECHOUE SI LA FENETRE EST RETRECIE."""
+    gap = " " + "x" * 10 + " "  # 12 chars exactement
+    assert len(gap) == 12
+    body = "La review CHANGES_REQUESTED" + gap + "par le commit a1b2c3d4e."
+    assert mod.classify("myia-po-2027", body) is None
+
+
+def test_13474_dplus_gap_13_chars_hors_borne_reste_live():
+    """#13474 temoin hors-frontiere — gap de 13 chars : D+ ne matche plus
+    (borne depassee) et E non plus (pas de verbe de levee avant la ref) —
+    le verdict reste emis : BOT-CONCERN.
+    CE TEST ECHOUE SI LA FENETRE EST ELARGIE."""
+    gap = " " + "x" * 11 + " "  # 13 chars exactement
+    assert len(gap) == 13
+    body = "La review CHANGES_REQUESTED" + gap + "par le commit a1b2c3d4e."
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/research-code #13473

Closes #13474

## Livrable

Deux dettes de lisibilite sur `check_unaddressed_nits` (obs 2 et 3 de la review NanoClaw sur #12881), remboursees en commentaires + temoins de frontiere.

## Observation 2 — capture A+ positionnelle

Une ligne (bloc) de commentaire sur `_MENTION_VERDICT` : la capture est **positionnelle** (PREMIER caps-token apres la parenthese ouvrante, pas « le verdict le plus proche du verbe »), consequence fail-loud — dans `(BOT_CONCERTATION a propos du BOT_CONCERN)`, c'est BOT_CONCERTATION qui est capture et le vrai marqueur survit. Pas de changement de motif, comme demande.

## Observation 3 — la frontiere D+ : 60 chars annonces, 12 reels

**Divergence trouvee en verifiant contre la source (G.1)** : l'acceptance et le commentaire D+ parlaient d'une « fenetre de 60 chars », heritee du commentaire `#12871` au-dessus du motif. Le motif enforce reellement `[^():\n.]{0,12}?` — borne mesuree empiriquement : gap de 12 chars MATCH (mention neutralisee), gap de 13 chars ne matche plus (verdict reste BOT-CONCERN). Le « 60 » etait une fiction de commentaire, pas un comportement du code.

Choix : les temoins encadrent la **frontiere reelle** (12/13), pas la frontiere fantome (60/61) — un temoin a 60/61 ne protegerait rien (les deux cas seraient hors borne tous les deux). Commentaires D+ et E corriges pour nommer la borne reelle et renvoyer le long-format a la Position E (fenetre 200).

## Temoins (fichier de tests, +33 lignes)

- `test_13474_dplus_gap_12_chars_dans_la_borne_neutralise` — gap d'EXACTEMENT 12 chars (borne inclusive) : D+ matche, `classify(...) is None`.
- `test_13474_dplus_gap_13_chars_hors_borne_reste_live` — gap de 13 chars : ni D+ (borne depassee) ni E (pas de verbe de levee avant la ref) ne neutralisent : `BOT-CONCERN`.

### Validation par faux negatif (mecanique)

| Mutant | Effet attendu | Mesure |
|---|---|---|
| `{0,12}?` → `{0,13}?` (elargie) | le temoin gap_13 se met a matcher → echoue | rc=1, failed = gap_13 uniquement |
| `{0,12}?` → `{0,10}?` (retrecie) | le temoin gap_12 cesse de matcher → echoue | rc=1, failed = gap_12 uniquement |
| restaure | tout vert | 205/205 passed |

Piege rencontre en route : mutants de meme taille ecrits dans le meme tick de mtime → `SourceFileLoader` servait le bytecode du mutant PRECEDENT (`__pycache__` stale) — la premiere passe de validation donnait des resultats incoherents. La validation finale purge `scripts/__pycache__` avant chaque chargement + `PYTHONDONTWRITEBYTECODE=1`.

## Acceptance #13474

- [x] Commentaire A+ positionnelle + fail-loud
- [x] Deux temoins encadrant la frontiere D+, valides par faux negatif — **a la borne reelle 12, pas aux 60 annonces par le commentaire** (documente ci-dessus)
- [x] Les 3 contre-exemples fondateurs #10761 restent BOT-CONCERN (suite existante incluse dans les 205 verts)

## Validation

- `python -m pytest scripts/tests/test_check_unaddressed_nits.py` : **205 passed** (203 + 2 temoins)
- Diff limite aux 2 fichiers du claim : garde +16/-6 (commentaires seulement, motifs intacts octet-pour-octet), tests +33/-0
- Pre-commit hooks : passes
