### PR TITLE
fix(tooling,#13489): implement promised update/retract in check_pr_path_collisions

### DIFF
--- a/scripts/check_pr_path_collisions.py
+++ b/scripts/check_pr_path_collisions.py
@@ -77,6 +77,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import datetime, timezone
 import os
 import re
 import subprocess
@@ -88,6 +89,11 @@ from typing import Iterable
 # Marker framing the advisory comment, so re-runs find/update/retract it.
 COMMENT_MARKER_START = "<!-- PR-PATH-COLLISION:START -->"
 COMMENT_MARKER_END = "<!-- PR-PATH-COLLISION:END -->"
+
+# Signature of the dated resolution note left in place of a live advisory
+# (retraction is a body swap, not a delete: less destructive, readable in the
+# PR history, and still marker-framed so re-runs keep finding it).
+RESOLVED_SIGNATURE = "<!-- PR-PATH-COLLISION:RESOLVED -->"
 
 # The synthetic positive control. NOT a live repo pair (those are volatile:
 # they merge and vanish). It is seeded straight into the pure detector, so the
@@ -265,11 +271,105 @@ def render_comment(number: int, title: str, own_collisions: list[PathCollision])
 
 def find_marker_comment(comments: Iterable[dict]) -> str | None:
     """Id of the existing marker comment in ``comments``, or None (pure)."""
+    entry = find_marker_entry(comments)
+    return entry[0] if entry else None
+
+
+def find_marker_entry(comments: Iterable[dict]) -> tuple[str, str] | None:
+    """(id, body) of the existing marker comment, or None (pure).
+
+    Both are needed by the update/retract paths: the id addresses the
+    ``PATCH /issues/comments/{id}`` call, the body decides post vs update vs
+    retract (issue #13489).
+    """
     for c in comments or []:
         body = c.get("body") or ""
         if COMMENT_MARKER_START in body:
-            return str(c.get("id")) if c.get("id") is not None else None
+            if c.get("id") is None:
+                return None
+            return str(c["id"]), body
     return None
+
+
+def render_resolution_comment(number: int, resolved_on: str) -> str:
+    """Dated resolution note replacing a live advisory whose collision ended.
+
+    Marker-framed + RESOLVED-signed so a re-run recognises it as already
+    retracted (idempotent) and can swap it back to a live advisory if the
+    collision reappears (e.g. a new neighbour PR touches the path again).
+    """
+    lines = [
+        COMMENT_MARKER_START,
+        RESOLVED_SIGNATURE,
+        "## Path-collision (organ #13359) — résolue",
+        "",
+        f"La collision de chemins signalée sur **#{number}** n'existe plus "
+        f"au passage du {resolved_on} : aucune autre PR ouverte ne partage "
+        "désormais de chemin de fichier avec elle. Note laissée en place de "
+        "l'avertissement (retraction non destructive).",
+        "",
+        COMMENT_MARKER_END,
+    ]
+    return "\n".join(lines)
+
+
+def is_resolution_note(body: str | None) -> bool:
+    """True if ``body`` is already the dated resolution note (pure)."""
+    return bool(body) and COMMENT_MARKER_START in body and RESOLVED_SIGNATURE in body
+
+
+@dataclass(frozen=True)
+class PlannedAction:
+    """One planned write for a PR, decided BEFORE any network mutation."""
+    number: int
+    verb: str  # "post" | "update" | "retract" | "none"
+    comment_id: str | None  # gh comment id for update/retract
+    body: str  # desired body ("none" carries the unchanged existing body)
+
+
+def plan_actions(
+    colliding_prs: Iterable[int],
+    collisions: Iterable[PathCollision],
+    title_by_number: dict[int, str],
+    marker_by_number: dict[int, tuple[str, str] | None],
+    resolved_on: str,
+) -> list[PlannedAction]:
+    """Plan post/update/retract over the UNION colliding ∪ marker-carriers.
+
+    This union is the structural fix of #13489: iterating colliding PRs only
+    made retraction unattainable (a resolved PR left the iteration set, so its
+    stale comment could never be removed) and made updates blind (a still-
+    colliding PR whose neighbour changed kept a comment naming the wrong PR).
+    """
+    colliding_set = set(colliding_prs)
+    candidates = sorted(colliding_set | set(marker_by_number))
+    plans: list[PlannedAction] = []
+    for number in candidates:
+        existing = marker_by_number.get(number)
+        if number in colliding_set:
+            desired = render_comment(
+                number,
+                title_by_number.get(number, ""),
+                collisions_for_pr(number, collisions),
+            )
+            if existing is None:
+                plans.append(PlannedAction(number, "post", None, desired))
+            elif existing[1] == desired:
+                plans.append(PlannedAction(number, "none", existing[0], existing[1]))
+            else:
+                # includes resolution-note -> live-advisory on re-collision
+                plans.append(PlannedAction(number, "update", existing[0], desired))
+        else:
+            if existing is None:
+                continue  # not colliding, no marker: nothing to say
+            if is_resolution_note(existing[1]):
+                plans.append(PlannedAction(number, "none", existing[0], existing[1]))
+            else:
+                plans.append(PlannedAction(
+                    number, "retract", existing[0],
+                    render_resolution_comment(number, resolved_on),
+                ))
+    return plans
 
 
 # ---------------------------------------------------------------------------
@@ -313,10 +413,31 @@ def list_open_prs(repo: str, limit: int) -> list[PrRow]:
     return [PrRow.from_gh_dict(d) for d in raw]
 
 
-def existing_comment(repo: str, number: int) -> str | None:
+def find_marker(repo: str, number: int) -> tuple[str, str] | None:
+    """(id, body) of the marker comment on PR ``number``, or None."""
     comments = _gh_json(["pr", "view", str(number), "--repo", repo,
                          "--json", "comments"]) or {}
-    return find_marker_comment(comments.get("comments") or [])
+    return find_marker_entry(comments.get("comments") or [])
+
+
+def scan_markers(
+    repo: str, numbers: Iterable[int],
+) -> tuple[dict[int, tuple[str, str] | None], set[int]]:
+    """Marker state for each PR. Returns (state, failed).
+
+    A PR whose comment fetch fails is reported in ``failed`` and excluded from
+    planning: treating a fetch failure as "no marker" would let a colliding PR
+    be re-POSTED as a duplicate. Advisory organ: a scan failure logs and skips,
+    never reds.
+    """
+    state: dict[int, tuple[str, str] | None] = {}
+    failed: set[int] = set()
+    for number in numbers:
+        try:
+            state[number] = find_marker(repo, number)
+        except RuntimeError:
+            failed.add(number)
+    return state, failed
 
 
 def post_comment(repo: str, number: int, body: str, dry_run: bool) -> None:
@@ -331,6 +452,32 @@ def post_comment(repo: str, number: int, body: str, dry_run: bool) -> None:
         subprocess.run(
             ["gh", "pr", "comment", str(number), "--repo", repo,
              "--body-file", tmp_path],
+            capture_output=True, text=True, check=False, encoding="utf-8",
+        )
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def edit_comment(repo: str, comment_id: str, body: str, dry_run: bool) -> None:
+    """PATCH the existing marker comment in place (update or retract swap).
+
+    ``gh pr comment --edit-last`` is not enough: the marker is not guaranteed
+    to be the PR's last comment. The REST id from ``find_marker_entry``
+    addresses the comment directly.
+    """
+    if dry_run:
+        return
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".json", encoding="utf-8", delete=False
+    ) as tf:
+        json.dump({"body": body}, tf, ensure_ascii=False)
+        tmp_path = tf.name
+    try:
+        subprocess.run(
+            ["gh", "api", "--method", "PATCH",
+             f"repos/{repo}/issues/comments/{comment_id}",
+             "--input", tmp_path],
             capture_output=True, text=True, check=False, encoding="utf-8",
         )
     finally:
@@ -417,15 +564,45 @@ def _cli(argv: list[str] | None = None) -> int:
     print(json.dumps(result.as_dict(), ensure_ascii=False, indent=2))
     print(_format_human_summary(result), file=sys.stderr)
 
-    if not args.dry_run:
-        for number in result.colliding_prs:
-            title = next((p.title for p in prs if p.number == number), "?")
-            body = render_comment(
-                number, title, collisions_for_pr(number, result.collisions)
-            )
-            existing = existing_comment(repo, number)
-            if existing is None:
-                post_comment(repo, number, body, args.dry_run)
+    # Plan over the UNION colliding ∪ marker-carriers (#13489): reads only.
+    title_by_number = {p.number: p.title for p in prs}
+    marker_by_number, scan_failed = scan_markers(
+        repo, [p.number for p in prs]
+    )
+    for number in sorted(scan_failed):
+        print(
+            f"WARN: comment scan failed for #{number} -- skipped this run "
+            "(no post/update/retract planned for it)",
+            file=sys.stderr,
+        )
+    plan = [
+        a for a in plan_actions(
+            set(result.colliding_prs), result.collisions, title_by_number,
+            marker_by_number,
+            datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ"),
+        )
+        if a.number not in scan_failed
+    ]
+
+    counts: dict[str, int] = {}
+    for a in plan:
+        counts[a.verb] = counts.get(a.verb, 0) + 1
+    prefix = "would-" if args.dry_run else ""
+    print(
+        "actions: "
+        + " ".join(
+            f"{v}={counts.get(v, 0)}" for v in ("post", "update", "retract", "none")
+        ),
+        file=sys.stderr,
+    )
+    for a in plan:
+        if a.verb == "none":
+            continue
+        print(f"  {prefix}{a.verb} #{a.number}", file=sys.stderr)
+        if a.verb == "post":
+            post_comment(repo, a.number, a.body, args.dry_run)
+        else:  # update | retract: both are an in-place PATCH by comment id
+            edit_comment(repo, a.comment_id, a.body, args.dry_run)
 
     return 0  # advisory: always green
 

--- a/scripts/tests/test_check_pr_path_collisions.py
+++ b/scripts/tests/test_check_pr_path_collisions.py
@@ -168,5 +168,107 @@ class TestCommentProtocol(unittest.TestCase):
         self.assertEqual(result.as_dict(), result2.as_dict())
 
 
+class TestThreeVerbs(unittest.TestCase):
+    """#13489: post/update/retract planned over the UNION colliding ∪ markers."""
+
+    def _collision(self, a, b, path="shared/x.ipynb"):
+        return PathCollision(a_number=a, b_number=b, shared_paths=(path,))
+
+    def test_union_covers_marker_carrier_no_longer_colliding(self):
+        """THE structural fix: a resolved PR stays in the iteration set.
+
+        Before #13489 the loop iterated colliding PRs only, so a PR whose
+        neighbour merged was never visited again and its stale advisory could
+        never be retracted.
+        """
+        plan = _mod.plan_actions(
+            colliding_prs=[10],
+            collisions=[self._collision(10, 11)],
+            title_by_number={10: "A", 11: "B"},
+            marker_by_number={
+                20: ("999", _mod.render_comment(20, "old", [self._collision(20, 21)]))
+            },
+            resolved_on="2026-08-29T00:00Z",
+        )
+        retracts = [a for a in plan if a.verb == "retract"]
+        self.assertEqual([a.number for a in retracts], [20])
+        self.assertEqual(retracts[0].comment_id, "999")
+        self.assertIn(_mod.RESOLVED_SIGNATURE, retracts[0].body)
+
+    def test_post_when_no_marker(self):
+        plan = _mod.plan_actions(
+            colliding_prs=[10, 11],
+            collisions=[self._collision(10, 11)],
+            title_by_number={10: "A", 11: "B"},
+            marker_by_number={10: None, 11: None},
+            resolved_on="2026-08-29T00:00Z",
+        )
+        self.assertEqual(
+            [(a.number, a.verb) for a in plan], [(10, "post"), (11, "post")]
+        )
+
+    def test_update_when_body_drifted(self):
+        """Neighbour changed: the old comment names the WRONG PR -> refresh."""
+        old_body = _mod.render_comment(10, "A", [self._collision(10, 99)])
+        plan = _mod.plan_actions(
+            colliding_prs=[10],
+            collisions=[self._collision(10, 11)],
+            title_by_number={10: "A"},
+            marker_by_number={10: ("77", old_body)},
+            resolved_on="2026-08-29T00:00Z",
+        )
+        updates = [a for a in plan if a.verb == "update"]
+        self.assertEqual(len(updates), 1)
+        self.assertEqual(updates[0].comment_id, "77")
+        self.assertIn("#11", updates[0].body)
+
+    def test_none_when_body_current(self):
+        body = _mod.render_comment(10, "A", [self._collision(10, 11)])
+        plan = _mod.plan_actions(
+            colliding_prs=[10],
+            collisions=[self._collision(10, 11)],
+            title_by_number={10: "A"},
+            marker_by_number={10: ("77", body)},
+            resolved_on="2026-08-29T00:00Z",
+        )
+        self.assertEqual([(a.number, a.verb) for a in plan], [(10, "none")])
+
+    def test_recollision_swaps_resolution_note_back_to_advisory(self):
+        note = _mod.render_resolution_comment(10, "2026-08-28T00:00Z")
+        plan = _mod.plan_actions(
+            colliding_prs=[10],
+            collisions=[self._collision(10, 11)],
+            title_by_number={10: "A"},
+            marker_by_number={10: ("77", note)},
+            resolved_on="2026-08-29T00:00Z",
+        )
+        self.assertEqual([(a.number, a.verb) for a in plan], [(10, "update")])
+        self.assertNotIn(_mod.RESOLVED_SIGNATURE, plan[0].body)
+
+    def test_already_resolved_stays_none(self):
+        note = _mod.render_resolution_comment(20, "2026-08-28T00:00Z")
+        plan = _mod.plan_actions(
+            colliding_prs=[],
+            collisions=[],
+            title_by_number={},
+            marker_by_number={20: ("77", note)},
+            resolved_on="2026-08-29T00:00Z",
+        )
+        self.assertEqual([(a.number, a.verb) for a in plan], [(20, "none")])
+
+    def test_resolution_note_shape(self):
+        note = _mod.render_resolution_comment(20, "2026-08-29T00:00Z")
+        self.assertIn(_mod.COMMENT_MARKER_START, note)
+        self.assertTrue(_mod.is_resolution_note(note))
+        self.assertIn("2026-08-29T00:00Z", note)
+        self.assertFalse(_mod.is_resolution_note(_mod.render_comment(20, "t", [])))
+        self.assertFalse(_mod.is_resolution_note(None))
+
+    def test_find_marker_entry_returns_id_and_body(self):
+        body = "x <!-- PR-PATH-COLLISION:START --> y"
+        self.assertEqual(_mod.find_marker_entry([{"id": 55, "body": body}]), ("55", body))
+        self.assertIsNone(_mod.find_marker_entry([{"id": 1, "body": "plain"}]))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`check_pr_path_collisions.py` promettait trois verbes (docstring l.31, help `--dry-run`, commentaire marqueur l.245) et n'en implémentait qu'un — et la boucle d'écriture itérait `colliding_prs` uniquement, rendant la rétraction **structurellement inatteignable** (#13489) :

1. aucune rétraction : une PR qui ne collisionne plus n'est plus visitée, son commentaire reste ;
2. aucune mise à jour : `existing is None` était la seule porte d'écriture — une PR qui collisionne toujours mais avec un voisin différent garde un commentaire **faux** qui a l'air frais.

Option retenue : **implémenter les trois verbes** (un advisory faux qui a l'air frais est pire qu'aucun advisory).

## Changements

- **`plan_actions` (pur)** : décide `post`/`update`/`retract`/`none` sur l'**union** `colliding_prs ∪ {PRs portant le marqueur}` — le fix structurel de l'issue.
- **`find_marker_entry`** (nouveau, pur) : rend `(id, body)` — l'id adresse le `PATCH /repos/{o}/{r}/issues/comments/{id}` (le body décide post vs update vs retract). `find_marker_comment` (id seul) délègue.
- **`edit_comment`** : `gh api --method PATCH .../issues/comments/{id} --input` — `gh pr comment --edit-last` ne suffit pas, le marqueur n'est pas garanti dernier commentaire.
- **Rétraction non destructive** : le corps est remplacé par une note de résolution **datée**, marker-framée + signée `PR-PATH-COLLISION:RESOLVED` — idempotente (re-run = none), et une **re-collision** la reswap en advisory vivant.
- **`--dry-run` ternaire** : journalise `would-post` / `would-update` / `would-retract` (la boucle de décision tourne toujours ; seules les écritures sont neutralisées) + résumé `actions: post=N update=N retract=N none=N`.
- **`scan_markers`** : un échec de fetch de commentaires = skip + WARN, jamais traité comme « pas de marqueur » (un faux négatif re-posterait un doublon). L'organe reste advisory : toujours exit 0.

## Validation

- `python -m pytest scripts/tests/test_check_pr_path_collisions.py` : **22 passed** (8 nouveaux : couverture union, update sur drift du voisin, none idempotent, swap-back sur re-collision, forme de la note de résolution, `find_marker_entry`).
- `python scripts/check_pr_path_collisions.py --self-test` : OK (contrôle positif intact).
- **Dry-run live** (lectures seules, 0 écriture réseau) : `44 PRs scannées, 3 collisions (same-issue-only), actions: post=6 update=0 retract=0 none=0` — le scan de marqueurs a visité les 44 PRs, le planificateur a produit les 6 `would-post` attendus (aucun marqueur n'existe encore, l'organe n'a jamais tourné en live).

Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #13481

Closes #13489


**Retag note** : le titre de la PR elle-meme dit `fix(tooling,#13489)` — implementer update/retract dans un script de check est du travail `tooling` (le genre decrit le TYPE DE TRAVAIL, pas le fichier traverse, #11170). Le tag initial `guard` etait une erreur de classification de ma part. Verdict local `variation_adjacency_guard.py` : pass (tooling vs guard).
