### PR TITLE
feat(tooling,#13420): le picker mesure l'EMBALLEMENT d'une zone, que la parite ne voit pas

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -1615,6 +1615,25 @@ def main(argv: list[str] | None = None) -> int:
             print(f"{'':>10} {'':>8} {'':>5} {'':>6} {'':>4}  {head.strip()}")
             if tail:
                 print(f"{'':>10} {'':>8} {'':>5} {'':>6} {'':>4}  -> {tail}")
+        # Un verdict qui n'est cable a aucune action ne change rien : la zone
+        # chaude s'affichait en tete du tirage et le pick d'a cote n'en disait
+        # rien. C'est ici que la mesure devient une consigne.
+        zb = (balance or {}).get(p.get("family") or "")
+        if zb and zb["new_notebooks"] >= 3:
+            etat = "EMBALLEMENT" if is_runaway(zb) else "zone chaude"
+            pad = f"{'':>10} {'':>8} {'':>5} {'':>6} {'':>4}  "
+            print(pad + "{} : {} notebooks neufs / 14 j, {} consolidation "
+                        "ouverte(s) pour {} expansion.".format(
+                            etat, zb["new_notebooks"], zb["consolidation"],
+                            zb["expansion"]))
+            if zb["consolidation"] <= zb["expansion"] or is_runaway(zb):
+                quoi = ("le SOUS-grain a creer ici est une CONSOLIDATION"
+                        if p["klass"] == "umbrella"
+                        else "la contrepartie due dans cette zone est une "
+                             "CONSOLIDATION")
+                print(pad + "-> " + quoi + " (renumeroter un numero eleve en "
+                      "lettre d'un numero existant, ou fondre plusieurs "
+                      "lettres en un petit nombre), pas une instance de plus.")
     print()
     print_unattributed_blocked(backlog)
     if visits_err:

--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -147,6 +147,9 @@ from series_saturation import (  # noqa: E402
     cited_issues,
     fetch_series_visits,
     zone_balance,
+    zone_umbrellas,
+    zone_verdict,
+    is_runaway,
     parent_issue,
     polarity,
     resolve_family,
@@ -1532,26 +1535,31 @@ def main(argv: list[str] | None = None) -> int:
                    if b["new_notebooks"] >= 3]
         chaudes.sort(key=lambda kv: (-kv[1]["new_notebooks"],
                                      -kv[1]["expansion"]))
+        umbrellas = zone_umbrellas(issue_to_family, pool, series)
         if chaudes:
             print("Zones chaudes (14 j) -- parite expansion/consolidation :")
             for f, b in chaudes[:5]:
                 exp, con = b["expansion"], b["consolidation"]
-                # 0/0 n est PAS un feu vert : c est une zone qui a recu N
-                # notebooks sans qu AUCUN grain de consolidation soit ouvert --
-                # le pire cas, pas le plus propre. Un zero d absence de donnee
-                # qui se lit comme un zero d absence de defaut est precisement
-                # le faux silencieux que ce garde existe pour ne pas produire.
-                if exp == 0 and con == 0:
-                    verdict = "SANS REMEDE"
-                elif con >= exp:
-                    verdict = "OK"
-                else:
-                    verdict = "DESEQUILIBRE"
+                verdict = zone_verdict(b)
+                if is_runaway(b):
+                    verdict = "EMBALLEMENT"
+                parents = sorted((umbrellas.get(f) or {}).items(),
+                                 key=lambda kv: -kv[1])
+                epic = (" ".join("#{}".format(n) for n, _ in parents[:2])
+                        if parents else "(aucun EPIC declare)")
                 print("  {:>2d} neufs | {:>2d} expansion / {:>2d} consolidation "
                       "  {:12s} {}".format(
                           b["new_notebooks"], exp, con, verdict, f))
+                print("       alimentee par {}".format(epic))
             print("  (un EPIC qui alimente une zone doit produire autant de "
                   "consolidation que d'expansion -- mandat user 2026-08-28)")
+            print("  EMBALLEMENT = la zone recoit plus vite qu'elle ne "
+                  "consolide. La parite porte sur les grains OUVERTS, elle ne "
+                  "voit pas le RYTHME de ce qui est deja tombe : trois remedes "
+                  "ouverts ne repondent pas a onze arrivees. Le remede est "
+                  "d'ouvrir la consolidation dans l'EPIC nomme -- ou, s'il n'y "
+                  "en a aucun, d'en declarer un : une zone chaude sans EPIC "
+                  "n'a personne de comptable pour la contrepartie.")
             print()
     print(f"Pool ouvert : {len(pool)} issues  "
           f"= {len(by_class['grain'])} grains "

--- a/scripts/series_saturation.py
+++ b/scripts/series_saturation.py
@@ -353,6 +353,84 @@ def zone_balance(zones: dict, issue_to_family: dict, pool: list) -> dict:
     return out
 
 
+# --- Emballement d'une zone : la MAGNITUDE, que la polarite ne voit pas ------
+# Mandat user 2026-08-28 : "il ne devrait pas y avoir d'emballement".
+#
+# `zone_verdict` ne lit que la POLARITE du vivier ouvert : une zone dont les
+# grains ouverts consolident plus qu'ils n'ajoutent rend OK, quel que soit le
+# nombre de notebooks DEJA tombes. Mesure du 2026-08-29 :
+# `ML/DataScienceWithAgents` a recu 11 notebooks neufs en 14 jours (21 ajouts
+# bruts au sens git) pour 3 grains de consolidation ouverts, et l'organe
+# repondait OK -- sur la zone la plus saturee du depot, celle-la meme que le
+# user a nommee. Trois remedes ouverts ne repondent pas a onze arrivees : la
+# parite demandee porte sur les issues, le RYTHME est une seconde dimension.
+#
+# Le critere s'enonce, il ne se regle pas : une zone s'emballe si elle a recu
+# au moins RUNAWAY_MIN_LANDED notebooks sur la fenetre ET qu'il lui manque un
+# grain de consolidation ouvert par tranche de RUNAWAY_RATIO arrivees. Le
+# plancher absolu evite de qualifier d'emballement trois notebooks sans
+# remede (c'est petit, pas emballe) ; le ratio evite de sanctionner une zone
+# volumineuse dont la consolidation est deja engagee -- mesure du meme jour :
+# `Search/Part4-Metaheuristics` (6 arrivees, 3 consolidations) ne s'emballe
+# PAS, sa consolidation est en cours, et c'est la zone que le user avait
+# signalee en premier.
+RUNAWAY_MIN_LANDED = 6
+RUNAWAY_RATIO = 3
+
+RUNAWAY = "EMBALLEMENT"
+BALANCED = "OK"
+IMBALANCED = "DESEQUILIBRE"
+NO_REMEDY = "SANS REMEDE"
+
+
+def zone_verdict(slot: dict) -> str:
+    """Verdict de POLARITE d'une zone -- inchange, il gouverne le tirage.
+
+    Extrait du picker pour que les deux lisent la meme source (sinon ils
+    re-divergeraient). `SANS REMEDE` a un effet de bord -- il retient des
+    grains hors tirage -- donc son predicat n'est pas touche ici.
+    """
+    exp = slot.get(EXPANSION, 0)
+    con = slot.get(CONSOLIDATION, 0)
+    if exp == 0 and con == 0:
+        return NO_REMEDY
+    if con >= exp:
+        return BALANCED
+    return IMBALANCED
+
+
+def is_runaway(slot: dict) -> bool:
+    """La zone recoit-elle plus vite qu'elle ne consolide ?
+
+    Dimension ORTHOGONALE a `zone_verdict` : une zone peut etre OK en
+    polarite et emballee en rythme -- c'est meme le cas exact qui a motive
+    cette mesure. On ne remplace donc pas le verdict, on l'accompagne.
+    """
+    landed = slot.get("new_notebooks", 0)
+    con = slot.get(CONSOLIDATION, 0)
+    return landed >= RUNAWAY_MIN_LANDED and landed >= RUNAWAY_RATIO * max(1, con)
+
+
+def zone_umbrellas(issue_to_family: dict, pool: list, families=()) -> dict:
+    """Par zone : quels EPICs parents alimentent ses grains ouverts.
+
+    Le mandat demande qu'un EPIC qui alimente une serie sache produire de la
+    consolidation autant que de l'expansion. Encore faut-il savoir OU l'ecrire
+    -- un verdict qui ne nomme pas l'EPIC responsable laisse le lecteur le
+    chercher. Une zone chaude SANS parent declare est le cas le plus grave et
+    non le plus propre : personne n'y est comptable de la contrepartie.
+    """
+    out: dict[str, dict[int, int]] = {}
+    for it in pool:
+        fam = resolve_family(it, issue_to_family, families)
+        parent = it.get("parent")
+        if not fam or not parent:
+            continue
+        out.setdefault(fam, {})
+        out[fam][parent] = out[fam].get(parent, 0) + 1
+    return out
+
+
 def main() -> int:
     for stream in (sys.stdout, sys.stderr):
         if hasattr(stream, "reconfigure"):

--- a/scripts/series_saturation.py
+++ b/scripts/series_saturation.py
@@ -162,6 +162,42 @@ def fetch_merged(days: int, now: dt.datetime | None = None) -> tuple[list[dict],
         return [], "{}: {}".format(type(exc).__name__, exc)
 
 
+_CAMEL_RE = re.compile(r"[a-z][A-Z]")
+
+
+def _is_distinctive(seg: str) -> bool:
+    """Le dernier segment d une zone peut-il se chercher SEUL sans faux positif ?
+
+    Chercher `Texte` seul matcherait toute prose francaise -- c est le faux
+    positif que la recherche a deux segments evite, et il faut le garder. Mais
+    le refus etait total, et il coutait le cas inverse : `DataScienceWithAgents`
+    n est pas un mot, c est un identifiant. Mesure du 2026-08-29 : l EPIC
+    #13504, ouvert precisement pour declarer cette zone, ne s y rattachait pas
+    -- son titre dit `consolidation(DataScienceWithAgents)` sans le prefixe
+    `ML/`, et personne n ecrit le chemin complet dans un titre.
+
+    Un segment se cherche seul s il est assez long ET porte une marque qui le
+    sort du lexique : une bosse CamelCase, un chiffre, un tiret ou un underscore. `Texte`,
+    `Audio`, `Video`, `Search` echouent aux deux conditions ; `ML-Training-
+    Pipeline`, `Part4-Metaheuristics`, `DataScienceWithAgents` les passent.
+    """
+    s = seg or ""
+    if len(s) < 10:
+        return False
+    return (bool(_CAMEL_RE.search(s)) or any(c.isdigit() for c in s)
+            or "-" in s or "_" in s)
+
+
+def _is_series(fam: str) -> bool:
+    """Une zone est-elle une serie de notebooks ?
+
+    Le prefixe suffit et se lit : `MyIA.AI.Notebooks/<domaine>/<serie>`. Tout
+    le reste -- `scripts/`, `.github/`, `docs/` -- est de l outillage, jamais
+    une zone d atterrissage pedagogique.
+    """
+    return (fam or "").replace(chr(92), "/").startswith("MyIA.AI.Notebooks/")
+
+
 def saturation(prs: list[dict]) -> tuple[dict[str, dict], dict[int, str]]:
     """Zones saturees + carte issue -> zone, deduites des PRs mergees.
 
@@ -175,12 +211,15 @@ def saturation(prs: list[dict]) -> tuple[dict[str, dict], dict[int, str]]:
     for pr in prs:
         fams: set[str] = set()
         new_here: dict[str, int] = {}
+        nb_here: dict[str, int] = {}
         for f in pr.get("files") or []:
             path = f.get("path", "")
             if not path:
                 continue
             fam = family_of(path)
             fams.add(fam)
+            if path.endswith(".ipynb"):
+                nb_here[fam] = nb_here.get(fam, 0) + 1
             if (path.endswith(".ipynb")
                     and (f.get("deletions") or 0) == 0
                     and (f.get("additions") or 0) >= NEW_NB_MIN_ADDITIONS):
@@ -191,9 +230,27 @@ def saturation(prs: list[dict]) -> tuple[dict[str, dict], dict[int, str]]:
             z["new_notebooks"] += new_here.get(fam, 0)
             z["numbers"].append(pr.get("number"))
         if fams:
-            dominant = max(fams, key=lambda f: (new_here.get(f, 0), f))
+            # Une zone est une SERIE de notebooks, pas n importe quel chemin.
+            # Le classement ne regardait que les notebooks NEUFS, puis l ordre
+            # alphabetique : une PR d outillage pur rattachait donc l issue
+            # qu elle cite a `scripts/<fichier>.py`. Mesure du 2026-08-29 :
+            # `i2f[12373]` -- l EPIC MGS, une serie de notebooks -- valait
+            # `scripts/series_saturation.py`, parce que mes propres PRs de
+            # picker citent #12373 en prose et ne touchent que des scripts.
+            # Toute fille de cet EPIC heritait de la zone d un script.
+            dominant = max(
+                fams,
+                key=lambda f: (new_here.get(f, 0), nb_here.get(f, 0), f))
+            touches_nb = nb_here.get(dominant, 0) > 0
             for key in cited_issues(pr):
-                issue_to_family.setdefault(key, dominant)
+                prev = issue_to_family.get(key)
+                if prev is None:
+                    issue_to_family[key] = dominant
+                elif touches_nb and not _is_series(prev):
+                    # Premier-arrive gagnait sans condition. On autorise UNE
+                    # promotion : un rattachement a une serie remplace un
+                    # rattachement a un chemin qui n en est pas une.
+                    issue_to_family[key] = dominant
     return zones, issue_to_family
 
 
@@ -285,16 +342,36 @@ def family_from_text(text: str, families) -> str | None:
     low = (text or "").replace(chr(92), "/").lower()
     if not low:
         return None
-    best_fam, best_len = None, 0
+    # La FREQUENCE avant la longueur. "La plus longue chaine gagne" traite un
+    # renvoi incident comme le sujet : mesure du 2026-08-29, l'EPIC #13504
+    # (qui nomme deux fois `ML/DataScienceWithAgents` et cite UNE fois
+    # `Search/Part4-Metaheuristics` dans un tableau de comparaison) se
+    # resolvait en Part4-Metaheuristics -- 45 caracteres contre 44. La zone
+    # que l'EPIC venait declarer restait `(aucun EPIC declare)`, c'est-a-dire
+    # que l'organe repondait le contraire de ce qui venait d'etre ecrit.
+    # Ce qu'une issue REPETE est son sujet ; ce qu'elle cite une fois est un
+    # renvoi. La longueur reste en second : elle departage `GenAI/Texte` de
+    # `Texte` quand les deux apparaissent autant.
+    best = None
     for fam in families:
-        segs = fam.replace(chr(92), "/").lower().split("/")
+        raw_segs = fam.replace(chr(92), "/").split("/")
+        segs = [s.lower() for s in raw_segs]
         cands = ["/".join(segs)]
         if len(segs) >= 2:
             cands.append("/".join(segs[-2:]))
+        if _is_distinctive(raw_segs[-1]):
+            cands.append(segs[-1])
+        hits, span = 0, 0
         for c in cands:
-            if len(c) > best_len and c in low:
-                best_fam, best_len = fam, len(c)
-    return best_fam
+            n = low.count(c)
+            if n:
+                hits = max(hits, n)
+                span = max(span, len(c))
+        if hits:
+            key = (hits, span)
+            if best is None or key > best[0]:
+                best = (key, fam)
+    return best[1] if best else None
 
 
 def resolve_family(item: dict, issue_to_family: dict, families=()) -> str | None:

--- a/scripts/tests/test_series_saturation.py
+++ b/scripts/tests/test_series_saturation.py
@@ -225,6 +225,102 @@ def test_zone_umbrellas_empty_when_no_parent_declared():
     assert ss.zone_umbrellas({1: "Z"}, pool) == {}
 
 
+# --- Attribution : ce qui empechait de NOMMER l'EPIC -----------------------
+
+
+def test_family_from_text_prefers_frequency_over_length():
+    """Le sujet est ce que l'issue REPETE, pas sa plus longue citation.
+
+    Cas reel : l'EPIC #13504 nomme deux fois `ML/DataScienceWithAgents` et
+    cite une fois `Search/Part4-Metaheuristics` dans un tableau de
+    comparaison. Le second est plus LONG (45 vs 44). Sous l'ancien
+    tie-break, l'EPIC ouvert pour declarer une zone se rattachait a l'autre
+    -- l'organe repondait le contraire de ce qui venait d'etre ecrit.
+    """
+    fams = ["MyIA.AI.Notebooks/ML/DataScienceWithAgents",
+            "MyIA.AI.Notebooks/Search/Part4-Metaheuristics"]
+    txt = ("MyIA.AI.Notebooks/ML/DataScienceWithAgents est la zone chaude. "
+           "La suivante, MyIA.AI.Notebooks/Search/Part4-Metaheuristics, est "
+           "a 6. Voir MyIA.AI.Notebooks/ML/DataScienceWithAgents.")
+    assert ss.family_from_text(txt, fams) == fams[0]
+
+
+def test_family_from_text_length_still_breaks_ties():
+    """A frequence egale, la longueur departage -- le garde d'origine tient."""
+    fams = ["MyIA.AI.Notebooks/GenAI/Texte", "GenAI"]
+    assert ss.family_from_text("MyIA.AI.Notebooks/GenAI/Texte", fams) == fams[0]
+
+
+def test_distinctive_segment_matches_identifiers_not_words():
+    """Un identifiant se cherche seul ; un mot francais courant, jamais.
+
+    C'est la condition qui permet a un TITRE de rattacher une zone : personne
+    n'ecrit le chemin complet dans un titre. Le refus total protegeait de
+    `Texte`, il coutait `DataScienceWithAgents`.
+    """
+    for mot in ("Texte", "Audio", "Video", "Search", "ML"):
+        assert not ss._is_distinctive(mot), mot
+    for ident in ("DataScienceWithAgents", "Part4-Metaheuristics",
+                  "ML-Training-Pipeline", "Argument_Analysis", "ICT-Series"):
+        assert ss._is_distinctive(ident), ident
+
+
+def test_family_from_title_alone_resolves_a_distinctive_zone():
+    """Integration : le titre reel de #13505 doit suffire."""
+    fams = ["MyIA.AI.Notebooks/ML/DataScienceWithAgents"]
+    titre = ("consolidation(DataScienceWithAgents): absorber 2.8c dans "
+             "2.8b/2.8d")
+    assert ss.family_from_text(titre, fams) == fams[0]
+
+
+def test_family_from_text_does_not_match_common_word_zone_by_leaf():
+    """Miroir : `Texte` en prose ne doit rattacher aucune zone."""
+    fams = ["MyIA.AI.Notebooks/GenAI/Texte"]
+    assert ss.family_from_text("On corrige le texte de la conclusion.",
+                               fams) is None
+
+
+def test_issue_zone_is_a_series_not_a_script_path():
+    """Une zone est une SERIE de notebooks, pas `scripts/<fichier>.py`.
+
+    Cas reel : mes propres PRs de picker citent #12373 (l'EPIC MGS) en prose
+    et ne touchent que des scripts. `i2f[12373]` valait donc
+    `scripts/series_saturation.py`, et TOUTE fille de cet EPIC heritait de la
+    zone d'un script au lieu de sa serie.
+    """
+    prs = [
+        {"number": 1, "title": "tooling", "body": "See #12373.",
+         "files": [{"path": "scripts/series_saturation.py",
+                    "additions": 40, "deletions": 2}]},
+        {"number": 2, "title": "notebook", "body": "See #12373.",
+         "files": [{"path": "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/"
+                            "MGS-30.ipynb", "additions": 900, "deletions": 0}]},
+    ]
+    _, i2f = ss.saturation(prs)
+    assert i2f[12373] == "MyIA.AI.Notebooks/Search/Part4-Metaheuristics", i2f
+
+
+def test_series_attribution_is_not_overwritten_by_a_later_script_pr():
+    """La promotion va dans UN sens : serie remplace non-serie, jamais l'inverse."""
+    prs = [
+        {"number": 2, "title": "notebook", "body": "See #12373.",
+         "files": [{"path": "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/"
+                            "MGS-30.ipynb", "additions": 900, "deletions": 0}]},
+        {"number": 3, "title": "tooling", "body": "See #12373.",
+         "files": [{"path": "scripts/pick_idle_grain.py",
+                    "additions": 40, "deletions": 2}]},
+    ]
+    _, i2f = ss.saturation(prs)
+    assert i2f[12373] == "MyIA.AI.Notebooks/Search/Part4-Metaheuristics"
+
+
+def test_is_series_rejects_tooling_paths():
+    assert ss._is_series("MyIA.AI.Notebooks/ML/DataScienceWithAgents")
+    for p in ("scripts/series_saturation.py", ".github/workflows/x.yml",
+              "docs/reference/y.md"):
+        assert not ss._is_series(p), p
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_series_saturation.py
+++ b/scripts/tests/test_series_saturation.py
@@ -111,6 +111,120 @@ def test_saturation_maps_zone_from_declaration():
     assert i2f.get(12373) == "MyIA.AI.Notebooks/Search/Part4-Metaheuristics"
 
 
+# --- Emballement : la MAGNITUDE que la polarite ne voit pas -----------------
+# Les deux premiers tests sont les DEUX zones reelles mesurees le 2026-08-29 :
+# c'est leur ecart qui definit le critere, et non l'inverse. Si un jour le
+# seuil devait bouger, c'est ce couple qui doit continuer a se separer.
+
+
+def _slot(landed, exp, con):
+    return {"new_notebooks": landed, ss.EXPANSION: exp,
+            ss.CONSOLIDATION: con, ss.NEUTRAL: 0}
+
+
+def test_runaway_fires_on_dswa_shape():
+    """DataScienceWithAgents mesure : 11 arrivees, 3 consolidations ouvertes.
+
+    Le verdict de POLARITE la disait OK -- trois remedes ouverts pour deux
+    expansions ouvertes. C'est exactement la zone que le user a nommee comme
+    symptomatique. La parite ne suffit pas : elle ne compte pas ce qui est
+    deja tombe.
+    """
+    slot = _slot(11, 2, 3)
+    assert ss.zone_verdict(slot) == ss.BALANCED, "la polarite reste OK -- c'est le point"
+    assert ss.is_runaway(slot), "11 arrivees pour 3 consolidations = emballement"
+
+
+def test_runaway_silent_on_mgs_shape():
+    """Search/Part4-Metaheuristics mesure : 6 arrivees, 3 consolidations.
+
+    Zone signalee en premier par le user, mais dont la consolidation est
+    engagee (EPIC #12373). Un critere qui la ferait rougir sanctionnerait le
+    remede en cours -- le meme defaut que l'amortissement aveugle corrige la
+    veille.
+    """
+    slot = _slot(6, 1, 3)
+    assert not ss.is_runaway(slot), "consolidation engagee : ne pas sanctionner"
+
+
+def test_runaway_ignores_small_zones():
+    """Trois notebooks sans aucun remede, c'est petit -- pas emballe.
+
+    `SANS REMEDE` dit deja ce qu'il faut en faire. Qualifier ca d'emballement
+    diluerait le mot sur le cas ou il n'apporte rien.
+    """
+    slot = _slot(3, 0, 0)
+    assert ss.zone_verdict(slot) == ss.NO_REMEDY
+    assert not ss.is_runaway(slot)
+
+
+def test_runaway_fires_with_zero_consolidation():
+    """Le plancher a 1 evite la division par zero ET tient le cas le pire.
+
+    Six arrivees et aucun remede ouvert doit rougir : c'est le cas ou personne
+    n'a encore ouvert la contrepartie.
+    """
+    assert ss.is_runaway(_slot(6, 4, 0))
+
+
+def test_runaway_is_orthogonal_to_polarity():
+    """Une zone peut etre DESEQUILIBREE sans etre emballee, et l'inverse.
+
+    Les deux mesures repondent a deux questions differentes ; les fondre en
+    une seule ferait perdre celle qui manquait.
+    """
+    petite_desequilibree = _slot(2, 5, 0)
+    assert ss.zone_verdict(petite_desequilibree) == ss.IMBALANCED
+    assert not ss.is_runaway(petite_desequilibree)
+
+    grosse_ok = _slot(12, 0, 1)
+    assert ss.zone_verdict(grosse_ok) == ss.BALANCED
+    assert ss.is_runaway(grosse_ok)
+
+
+def test_zone_verdict_matches_legacy_inline_logic():
+    """Le verdict extrait doit rendre EXACTEMENT ce que le picker rendait.
+
+    `SANS REMEDE` a un effet de bord -- il retient des grains hors tirage.
+    Extraire la logique sans la reproduire au bit pres changerait le tirage
+    en silence.
+    """
+    for landed in (0, 3, 9):
+        for exp in range(4):
+            for con in range(4):
+                slot = _slot(landed, exp, con)
+                if exp == 0 and con == 0:
+                    attendu = "SANS REMEDE"
+                elif con >= exp:
+                    attendu = "OK"
+                else:
+                    attendu = "DESEQUILIBRE"
+                assert ss.zone_verdict(slot) == attendu, (landed, exp, con)
+
+
+def test_zone_umbrellas_names_the_feeding_epic():
+    """Nommer l'EPIC : sans lui, le lecteur du verdict doit le chercher."""
+    pool = [
+        {"number": 1, "parent": 12373, "title": "a", "body": ""},
+        {"number": 2, "parent": 12373, "title": "b", "body": ""},
+        {"number": 3, "parent": 999, "title": "c", "body": ""},
+        {"number": 4, "parent": None, "title": "d", "body": ""},
+    ]
+    i2f = {1: "Z", 2: "Z", 3: "Z", 4: "Z"}
+    out = ss.zone_umbrellas(i2f, pool)
+    assert out["Z"] == {12373: 2, 999: 1}, out
+
+
+def test_zone_umbrellas_empty_when_no_parent_declared():
+    """Zone chaude sans EPIC : le cas le PLUS grave, pas le plus propre.
+
+    Il doit rendre un vide explicite, que l'appelant rend en clair -- personne
+    n'y est comptable de la contrepartie.
+    """
+    pool = [{"number": 1, "parent": None, "title": "a", "body": ""}]
+    assert ss.zone_umbrellas({1: "Z"}, pool) == {}
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-ai-01:CoursIA -- prev: MED/notebook-python #13484

## Le defaut

La parite expansion/consolidation livree hier (#13419) ne lit que la **polarite du vivier ouvert**. Elle est aveugle au **rythme de ce qui est deja tombe**.

Mesure du 2026-08-29 sur le pool reel (196 issues ouvertes), avant ce commit :

| zone | neufs (14 j) | exp / cons | verdict rendu |
|---|---|---|---|
| `ML/DataScienceWithAgents` | **11** | 2 / 3 | `OK` |
| `Search/Part4-Metaheuristics` | 6 | 1 / 3 | `OK` |

Les deux rendaient le **meme** verdict. Or ce sont deux situations opposees :

- **DataScienceWithAgents** est la zone que le user a nommee comme symptomatique. Elle a recu 11 notebooks neufs au sens de l'organe (**21** ajouts bruts au sens `git log --diff-filter=A`), et **aucun EPIC ne la declare**. Ses arrivees sont litteralement l'exemple du mandat -- proliferation de lettres sur des numeros existants : `2.3b`, `2.3c`, `2.3d`, `2.5b`, `2.5c`, `2.8b`, `2.8c`, `2.8d`.
- **Part4-Metaheuristics** est la zone signalee en premier, mais sa consolidation **est engagee** sous l'EPIC #12373 -- c'est-a-dire que le remede demande est deja dans le pool.

Trois remedes ouverts ne repondent pas a onze arrivees. La parite porte sur les **issues**, le rythme est une **seconde dimension**, et l'organe ne mesurait que la premiere.

## Ce que ce PR ajoute

- **`zone_verdict()`** -- la logique de polarite **extraite** du picker, inchangee au bit pres. Un test la compare exhaustivement (3 x 4 x 4 cellules) a l'ancienne forme inline : `SANS REMEDE` retient des grains hors tirage, la reproduire approximativement aurait change le tirage en silence.
- **`is_runaway()`** -- dimension **orthogonale** : `neufs >= 6 ET neufs >= 3 x max(1, cons)`.
  - Le **plancher** evite de qualifier d'emballement trois notebooks sans remede : c'est petit, pas emballe, et `SANS REMEDE` dit deja quoi en faire.
  - Le **ratio** evite de sanctionner une zone volumineuse dont la consolidation est engagee -- c'est-a-dire d'ecraser le remede avec le mal, le defaut exact que #13419 avait du corriger la veille sur `#12607`.
- **`zone_umbrellas()`** -- nomme l'EPIC qui alimente chaque zone chaude. Un verdict qui ne le nomme pas laisse le lecteur le chercher. Et une zone chaude **sans EPIC declare** est le cas le **plus grave**, pas le plus propre : personne n'y est comptable de la contrepartie.

## Sortie sur le pool reel, apres

```
Zones chaudes (14 j) -- parite expansion/consolidation :
  11 neufs |  2 expansion /  3 consolidation   EMBALLEMENT  MyIA.AI.Notebooks/ML/DataScienceWithAgents
       alimentee par (aucun EPIC declare)
   6 neufs |  1 expansion /  3 consolidation   OK           MyIA.AI.Notebooks/Search/Part4-Metaheuristics
       alimentee par #12373 #1203
   4 neufs |  0 expansion /  1 consolidation   OK           MyIA.AI.Notebooks/GenAI/Texte
       alimentee par #5081
   4 neufs |  0 expansion /  0 consolidation   SANS REMEDE  MyIA.AI.Notebooks/GenAI/RAG-et-Memoire-Semantique
       alimentee par (aucun EPIC declare)
   4 neufs |  0 expansion /  2 consolidation   OK           MyIA.AI.Notebooks/Probas/DecisionTheory
       alimentee par #12904
```

Les deux zones du mandat se separent maintenant, et dans le bon sens.

## Ce qui ne change PAS

Le verdict de polarite est **inchange** : le tirage se comporte exactement comme avant ce PR. On ajoute la mesure qui manquait, on ne redefinit pas celle qui marchait. `EMBALLEMENT` **s'affiche** et ne retient aucun grain -- comme `DESEQUILIBRE`, il vise la **redaction des EPICs**, c'est au coordinateur d'y repondre en ouvrant la consolidation, pas au worker d'y buter.

## Validation

- `python -m pytest scripts/tests/test_series_saturation.py -q` -> **20 passed**
- `python -m pytest scripts/tests/test_pick_idle_grain.py -q` -> **66 passed**
- Execute sur le pool reel, sortie ci-dessus.

Les deux premiers tests **sont** les deux zones reelles mesurees : c'est leur ecart qui a defini le critere, pas l'inverse. Si le seuil devait bouger un jour, c'est ce couple qui doit continuer a se separer.

See #13420


---

## Addendum (commit `a9f2e30a5`) — nommer l'EPIC exigeait trois corrections d'attribution

Verification apres le premier commit : le verdict rendait `(aucun EPIC declare)` sur `ML/DataScienceWithAgents` **alors qu'un EPIC venait d'etre ouvert pour cette zone exacte** (#13504). Un affichage qui nomme l'ombrelle mais ne sait pas la nommer sur son cas motivant n'aurait rien livre. Trois causes, chacune mesuree :

1. **`family_from_text` classait par LONGUEUR.** #13504 nomme **deux fois** `ML/DataScienceWithAgents` (44 car.) et cite **une fois** `Search/Part4-Metaheuristics` (45 car.) dans un tableau de comparaison -- l'EPIC se rattachait au renvoi incident. Le sujet est ce qu'une issue **repete** ; la longueur passe en second et departage encore `GenAI/Texte` de `Texte`.
2. **Une zone est une serie, pas un chemin de script.** `saturation` classait la zone dominante d'une PR sur les notebooks *neufs* puis l'ordre alphabetique, donc une PR d'outillage pur rattachait l'issue citee a `scripts/<fichier>.py`. Mesure : **`i2f[12373]`** -- l'EPIC MGS, une serie de notebooks -- **valait `scripts/series_saturation.py`**, parce que mes propres PRs de picker citent `#12373` en prose sans toucher un notebook. Toute fille de cet EPIC heritait de la zone d'un script. Le classement regarde maintenant aussi les notebooks *touches*, avec **une seule promotion permise** : une serie remplace un non-serie, jamais l'inverse.
3. **Le dernier segment refusait de se chercher seul.** Le refus etait juste -- `Texte` matcherait toute prose francaise -- mais *total* : il coutait `DataScienceWithAgents`, qui n'est pas un mot mais un identifiant. Or personne n'ecrit le chemin complet dans un **titre**, et c'est le titre qui dit le sujet. Un segment se cherche seul s'il fait >= 10 caracteres et porte une marque hors-lexique (bosse CamelCase, chiffre, tiret, underscore).

| segment | seul ? |
|---|---|
| `Texte` / `Audio` / `Video` / `Search` / `ML` | non |
| `DataScienceWithAgents` / `Part4-Metaheuristics` / `ML-Training-Pipeline` / `Argument_Analysis` / `ICT-Series` | oui |

### Effet mesure

```
avant   11 neufs | 2 exp / 3 cons  EMBALLEMENT  ML/DataScienceWithAgents
                                                (aucun EPIC declare)
         6 neufs | 1 exp / 3 cons  OK           Search/Part4-Metaheuristics

apres   11 neufs | 2 exp / 4 cons  OK           ML/DataScienceWithAgents
                                                alimentee par #13504
         6 neufs | 2 exp / 5 cons  OK           Search/Part4-Metaheuristics
                                                alimentee par #12373 #1203
```

`DataScienceWithAgents` passe a `OK` **non par relachement du seuil** mais parce que la contrepartie a ete **ouverte** : l'EPIC #13504 et le grain de consolidation #13505 portent la zone a 4 remedes pour 11 arrivees. Le verdict se rallumera si la zone reprend sans que la consolidation suive -- c'est la semantique voulue : il s'eteint quand le remede existe, pas quand le temps passe.

### Validation (mise a jour)

- `pytest scripts/tests/test_series_saturation.py` -> **28 passed** (8 nouveaux sur l'attribution)
- `pytest scripts/tests/test_pick_idle_grain.py` -> **66 passed**


---

## Addendum 2 (commit `a144528dd`) — le verdict est cable sur l'ACTION

Un verdict cable a aucune action ne change rien. Apres les deux commits precedents, la zone chaude s'affichait **en tete** du tirage et le pick d'a cote n'en disait rien : l'agent lisait `EMBALLEMENT` trois lignes plus haut sans qu'aucune consigne ne s'attache au grain qu'il s'apprete a prendre.

Chaque pick dont la zone a recu >= 3 notebooks sur la fenetre porte desormais son etat, et -- **quand la zone doit une contrepartie** -- la consigne du mandat :

```
grain      #13xxx      4j     1j    0  notebook-python   2.9  ...
                                       zone chaude : 4 notebooks neufs / 14 j, 0 consolidation ouverte(s) pour 0 expansion.
                                       -> la contrepartie due dans cette zone est une CONSOLIDATION (renumeroter un
                                          numero eleve en lettre d'un numero existant, ou fondre plusieurs lettres en
                                          un petit nombre), pas une instance de plus.
```

Pour une **umbrella**, la consigne se formule autrement -- c'est le *sous-grain a creer* qui doit consolider -- parce que c'est la que le mandat la situe : un EPIC qui alimente une serie doit savoir produire la renumerotation autant que l'ajout.

**Elle ne se declenche pas quand la parite est deja tenue.** Les deux branches sont **observees en sortie**, pas deduites :

| zone | mesure | ce que le pick affiche |
|---|---|---|
| `Search/Part4-Metaheuristics` | 6 neufs, **5 cons / 2 exp** | etat seul, **aucune consigne** -- sa contrepartie est ouverte |
| `GenAI/RAG-et-Memoire-Semantique` | 4 neufs, **0 cons / 0 exp** | etat **+ consigne CONSOLIDATION** |

## Ce que cette PR laisse ouvert, en le disant

Un defaut d'attribution **reste** et n'est pas corrige ici : `parent_issue` lit un `EPIC #N` **en prose** comme une ascendance. L'EPIC #13504 se voit ainsi attribuer `parent = 12373` parce que son corps *cite* l'EPIC MGS dans un tableau de comparaison. C'est la meme classe que #13435 (declaration vs renvoi de contexte), corrigee la pour `cited_issues` et **pas** pour `parent_issue`. Elle n'a pas d'effet sur ce que cette PR livre -- l'attribution de zone passe par le texte, verifiee ci-dessus -- mais elle fausserait un comptage parent/enfant. Ouverte et nommee **avant** ce merge : #13507.

