### PR TITLE
fix(picker,#13507): parent_issue ne lit plus un "EPIC #N" de prose comme une ascendance

### DIFF
--- a/scripts/series_saturation.py
+++ b/scripts/series_saturation.py
@@ -76,6 +76,16 @@ _DECL_RE = re.compile(
 )
 
 
+# Un motif nu `EPIC #N` ne vaut declaration qu'en TETE de corps : une
+# ascendance se pose d'emblee ("## Contexte / Sous-grain de l'EPIC #1454"),
+# un renvoi de comparaison se glisse au fil du texte. Mesure 2026-08-29 sur
+# les 201 issues ouvertes : couper a 3 lignes garde les declarations reelles
+# (#13436 "Sous-grain", #12915 "Tranche T5", #12607 "Fils techniques") et
+# retire les 14 renvois mi-corps ; 1 ligne perdait les declarations, 5
+# n'apportait rien de plus.
+_EPIC_PARENT_HEAD_LINES = 3
+
+
 def parent_issue(body: str) -> int | None:
     """L'ombrelle qu'une issue DECLARE servir, ou None.
 
@@ -89,10 +99,22 @@ def parent_issue(body: str) -> int | None:
     qui est exactement la seule qu'il faudrait freiner. (Verifie firsthand le
     2026-08-28 : sans ascendance, #13394 et #13268 ressortaient a `zone=None`,
     poids intact -- le correctif ne corrigeait pas son propre cas.)
+
+    Declaration != renvoi de contexte (#13435, etendu ici par #13507) : le
+    motif nu `EPIC #N` ne rattache plus au fil du texte. Mesure 2026-08-29 sur
+    les 201 issues ouvertes : 39 parents declares, 14 changent -- tous des
+    renvois mi-corps, dont #13504 qui rendait parent=12373 sur la foi de
+    "dont l'EPIC #12373 porte la consolidation". Les formes structurelles
+    (`_PARENT_RE`, n'importe ou) et les declarations nues en tete de corps
+    restent rattachees.
     """
     if not body:
         return None
-    m = _PARENT_RE.search(body) or _EPIC_PARENT_RE.search(body)
+    m = _PARENT_RE.search(body)
+    if m:
+        return int(m.group(1))
+    head = "\n".join(body.splitlines()[:_EPIC_PARENT_HEAD_LINES])
+    m = _EPIC_PARENT_RE.search(head)
     return int(m.group(1)) if m else None
 
 

--- a/scripts/tests/test_series_saturation.py
+++ b/scripts/tests/test_series_saturation.py
@@ -11,6 +11,10 @@ fenetre 14 j du 2026-08-29).
 Un detecteur se valide par ses faux negatifs (anti-regression.md) : les
 controles ci-dessous epinglent les DEUX sens -- le renvoi de contexte NE
 rattache PAS, la declaration (et la forme structurelle) rattache.
+
+Extension #13507 : `parent_issue` applique la meme distinction declaration vs
+renvoi -- le motif nu `EPIC #N` ne rattache qu'en tete de corps, jamais au
+fil du texte.
 """
 from __future__ import annotations
 
@@ -319,6 +323,45 @@ def test_is_series_rejects_tooling_paths():
     for p in ("scripts/series_saturation.py", ".github/workflows/x.yml",
               "docs/reference/y.md"):
         assert not ss._is_series(p), p
+def test_parent_issue_prose_renvoi_mid_body_returns_none():
+    """Controle positif du fix #13507 : la phrase REELLE du corps de #13504.
+
+    #13504 se voyait attribuer parent=12373 sur ce seul renvoi de comparaison
+    mi-corps : "dont l'EPIC #12373 porte la consolidation".
+    """
+    body_13504 = (
+        "## La zone\n\nDecrire `ML/DataScienceWithAgents`.\n\nC'est la difference exacte avec "
+        "`Part4-Metaheuristics`, qui recoit vite **aussi** mais dont l'EPIC #12373 porte la "
+        "consolidation."
+    )
+    assert ss.parent_issue(body_13504) is None
+
+
+def test_parent_issue_structural_formulations_anywhere():
+    """Les formulations REELLES des filles de #12373 rattachent, quelle que soit la position."""
+    assert ss.parent_issue("Enfant de l'Epic #12373.") == 12373
+    assert ss.parent_issue("Paire 9/9 de l'EPIC #12373 (MGS vs mealpy).") == 12373
+    assert ss.parent_issue("Paire 8/9 de l'EPIC #12373.") == 12373
+    assert ss.parent_issue("Intro longue.\n\nPuis du recit.\n\nEnfin : Fille de l'EPIC #5081.") == 5081
+
+
+def test_parent_issue_naked_epic_head_declares():
+    """Le motif nu garde sa valeur de declaration en TETE de corps.
+
+    Formes reelles mesurees sur les issues ouvertes : #13436, #12915, #12607.
+    """
+    assert ss.parent_issue("## Contexte\nSous-grain de l'EPIC #1454.") == 1454
+    assert ss.parent_issue("## Contexte\nTranche T5 de l'EPIC #12904.") == 12904
+    assert ss.parent_issue("Fils techniques de l'axe 5 de l'Epic #12373.") == 12373
+
+
+def test_parent_issue_naked_epic_mid_body_returns_none():
+    """Le MEME motif nu, mi-corps, ne rattache plus (frontiere des 3 lignes)."""
+    body = (
+        "Un long sujet.\n\nUne premiere etape.\n\nUne deuxieme etape.\n\n"
+        "Pour finir : l'EPIC #1621 a corrige ce point ailleurs."
+    )
+    assert ss.parent_issue(body) is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #13427

Closes #13507

## Le fix

`parent_issue()` (`scripts/series_saturation.py`) applique enfin la distinction declaration vs renvoi de contexte que #13435 avait etablie pour `cited_issues()` : le motif nu `EPIC #N` ne rattache plus au fil du texte, seulement dans les 3 premieres lignes du corps.

- `_PARENT_RE` (formes structurelles : Enfant de / Fille de / Paire N/M de / part of / sous-tache de) — INCHANGE, cherche sur tout le corps.
- `_EPIC_PARENT_RE` (motif nu `EPIC|Epic|epic|ombrelle #N`) — desormais recherchee uniquement sur la tete du corps (constante `_EPIC_PARENT_HEAD_LINES = 3`).

Pourquoi 3 lignes : frontiere mesuree sur les 201 issues ouvertes (variantes 1/3/5 lignes) — couper a 1 perd les declarations reelles posees en bloc « Contexte », 5 n'apporte rien de plus.

## Mesure citee (acceptance #3 de l'issue)

Corps reels des 201 issues ouvertes, fonction post-fix :

- 39 parents declares au total
- **14 parents changes**, tous des renvois mi-corps — dont le cas fondateur #13504 qui rendait `parent=12373` sur la foi de « dont l'EPIC #12373 porte la consolidation »
- 0 nouveau parent fabrique (aucune extension de vocabulaire)

Verifications par issue (fonction reelle) : #13504 -> None ; filles #12373 ouvertes #13394 / #13268 -> 12373 ; declarations reelles gardees #13436 -> 1454, #12915 -> 12904, #12607 -> 12373 ; formes structurelles #13467 -> 5081, #13505 -> 13504, #7260 -> 5081.

Variantes ecartees, mesurees :

- **V1 stricte** (suppression pure du motif nu) : 19 changements, dont 3 declarations REELLES perdues (#13436 « Sous-grain de », #12915 « Tranche T5 de », #12607 « Fils techniques de » — vocabulaire absent de `_PARENT_RE`).
- **V3 vocabulaire etendu** (fils/sous-*/tranche... de) : fabrique 4 parents nouveaux (#13344, #13178, #13174, #13171) — expansion hors scope.

## Tests

4 tests ajoutes (`scripts/tests/test_series_saturation.py`, 16 passed sur le fichier) :

- phrase REELLE de #13504 mi-corps -> None (controle positif du fix)
- formulations reelles des filles (« Paire 9/9 de l'EPIC #12373 », « Paire 8/9 », « Enfant de l'Epic », « Fille de l'EPIC ») -> parent garde, quelle que soit la position
- declarations nues en tete (formes reelles #13436 / #12915 / #12607) -> rattachent
- le MEME motif nu mi-corps -> None (frontiere des 3 lignes)

Suite complete `scripts/tests/` : 3615 passed, 30 skipped, 5 xfailed.

## Impact consommateurs

`pick_idle_grain.py` L260 (champ `parent` du pool) -> `resolve_family` L328-329 heritait la zone d'un parent faux quand le parent etait connu de `issue_to_family`. Post-fix, #13504 retombe sur `family_from_text` (verifie firsthand cote #13503 : rend la bonne zone).

## Collision #13503 (preflight documente)

#13503 (OPEN, autre lane) touche les memes fichiers mais PAS cette zone fonctionnelle : son diff ne modifie ni `parent_issue` ni `_EPIC_PARENT_RE` (l'unique mention = ligne d'import en contexte). Regions disjointes, merge sequentiel sans conflit attendu.
