### PR TITLE
fix(prover,#1453): reject unpositioned probe errors

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -398,20 +398,43 @@ def sorry_is_def_body(content: str, sorry_line: int) -> bool:
 #
 # Conservative by design: `exact True.intro` closes a goal IFF its type is
 # exactly `True`. Equality/Prop/Unit goals type-mismatch, so real theorems
-# are never refused. The broader "probe-closable by rfl/trivial" family is a
-# riskier follow-up (rfl can close legitimate reflexive goals) and is NOT
-# covered here.
+# are never refused — PROVIDED the probe build actually elaborated the file.
+# The probe's evidence is only as good as the build that produced it, so two
+# infrastructure-failure shapes must never be read as "goal closed":
+#   - FX-5b (#11380): failed build with EMPTY raw_output (timeout/crash);
+#   - FX-5c (#1453, knot sweep 2026-08-21): NON-EMPTY output whose `error:`
+#     lines carry no file position — corrupt package (mathlib reduced to a
+#     bare `.git`, "could not resolve 'HEAD' to a commit"), unknown module,
+#     dead lakefile fetch. Five Conway.lean targets were falsely refused as
+#     TRUE_PLACEHOLDER on exactly this shape; absence of a numbered error is
+#     not evidence of closure when the elaborator never ran.
+# The broader "probe-closable by rfl/trivial" family is a riskier follow-up
+# (rfl can close legitimate reflexive goals) and is NOT covered here.
 _TRUE_PROBE = "exact True.intro"
 _PROBE_LINE_TOL = 3
 _PROBE_UNSOLVED_TOL = 25
+# FX-5c: a lake/lean `error:` line with no `NN:NN:` file position anywhere
+# in it is an infrastructure failure, not an elaboration verdict.
+_UNPOSITIONED_ERROR_LINE_RE = re.compile(r"^\s*error:")
+_FILE_POSITION_RE = re.compile(r"\d+:\d+:")
 
 
 def _probe_closes_goal(raw_output: str, sorry_line: int) -> bool:
     """True when a probe replacing the sorry CLOSED that goal: no compile
     error at the sorry line and no 'unsolved goals' report there. Other
     sorries elsewhere in the file may still error — only the target line
-    matters."""
+    matters.
+
+    FX-5c (#1453): an ``error:`` line with NO file position
+    (``\\d+:\\d+:``) is an infrastructure failure — the elaborator never
+    reached the probed line, so the output carries no evidence either way.
+    Ambiguity must never refuse: return False and let the run proceed under
+    the downstream guards. Position-carrying lines (near or far) keep their
+    full prior semantics."""
     for line in raw_output.split("\n"):
+        if (_UNPOSITIONED_ERROR_LINE_RE.match(line)
+                and not _FILE_POSITION_RE.search(line)):
+            return False  # infra failure → probe never elaborated the file
         m = re.match(r".*?(\d+):\d+: error: ", line)
         if not m:
             m = re.match(r"error: .*?(\d+):\d+: ", line)
@@ -431,8 +454,11 @@ def is_true_placeholder_goal(filepath: str, sorry_line: int) -> Tuple[bool, str]
 
     Detection replaces the sorry with ``exact True.intro`` and compiles: if
     that probe closes the goal (no error and no unsolved goal at the sorry
-    line), the goal type is exactly ``True``. See the FX-5 module note for why
-    this is zero-false-positive and what the broader follow-up would cover.
+    line), the goal type is exactly ``True``. See the FX-5 module note: the
+    probe is false-positive-free only when the probe build actually
+    elaborated the file — FX-5b (empty output) and FX-5c (unpositioned
+    ``error:`` lines) guard the infrastructure-failure shapes where absence
+    of errors is not evidence of closure.
 
     Returns ``(True, reason)`` for a True goal, ``(False, "")`` otherwise
     (including unreadable files, out-of-range lines, deeply-nested sorrys
@@ -495,8 +521,12 @@ def is_true_placeholder_goal(filepath: str, sorry_line: int) -> Tuple[bool, str]
     # 600s probe build timed out under host memory pressure — the run never
     # entered its loop. Empty output on a failed build is NO evidence either
     # way; only a probe that produced output (or succeeded cleanly) may
-    # decide. Non-empty output keeps full prior semantics: errors far from
-    # the probed line stay valid evidence the elaborator ran there.
+    # decide. Non-empty output keeps full prior semantics for POSITIONED
+    # diagnostics: errors far from the probed line stay valid evidence the
+    # elaborator ran there. FX-5c (#1453): non-empty output whose `error:`
+    # lines carry NO file position is an infrastructure failure (corrupt
+    # package, unknown module) — ``_probe_closes_goal`` returns False on it,
+    # so ambiguity still never refuses.
     raw_output = probe_result.get("raw_output", "") or ""
     if not probe_result.get("success") and not raw_output.strip():
         return False, ""

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -277,8 +277,13 @@ def _refuse_true_placeholder_goal(filepath: str, sorry_line: int,
     "The task is already complete" because there is nothing to prove. The
     in-statement mutation form is already blocked upstream by FX-6b; this
     catches the body-sorry form. Detection runs ONE probe compile
-    (`exact True.intro`); it is zero-false-positive (only a `True` goal closes
-    under that probe). Mirrors ``_refuse_in_statement_sorry``. Returns None
+    (`exact True.intro`); only a `True` goal closes under that probe, so the
+    verdict is false-positive-free WHEN the probe build actually elaborated
+    the file — FX-5b (empty output on a timed-out/crashed build) and FX-5c
+    (unpositioned `error:` lines on an infrastructure-failed build: corrupt
+    package, unknown module) both bail out with no refusal, because absence
+    of numbered errors is not evidence of closure when the elaborator never
+    ran. Mirrors ``_refuse_in_statement_sorry``. Returns None
     on any ambiguity (never blocks a legitimate run); the one-probe compile
     cost is small against the 190-2600s run it saves when it fires.
     """

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2531,6 +2531,71 @@ def test_is_true_placeholder_goal_false_on_probe_timeout(tmp_path, monkeypatch):
     assert reason == ""
 
 
+def test_is_true_placeholder_goal_false_on_unpositioned_infra_error(tmp_path, monkeypatch):
+    """FX-5c (#1453): a probe build that fails at INFRASTRUCTURE level emits
+    NON-EMPTY output whose `error:` lines carry no file position — the old
+    `_probe_closes_goal` matched no numbered-error pattern, concluded "goal
+    closed", and refused ANY target as TRUE_PLACEHOLDER. Observed firsthand
+    2026-08-21 on the knot sweep: five Conway.lean targets (L51/L128/L138/
+    L157/L165, goals like `alexanderPolynomial conwayKnot = 1`, not `True`)
+    were falsely refused in 2-20s each because .lake/packages/mathlib was a
+    `.git` without a worktree. Exact corrupt-HEAD string from those runs;
+    even a genuinely-True goal file must not be "confirmed" on output the
+    elaborator never produced. Ambiguity must never refuse."""
+    from prover.lean_utils import is_true_placeholder_goal
+
+    _mock_probe_verifier(
+        monkeypatch,
+        raw_output=(
+            "error: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Lean"
+            "\\knot_lean\\.lake\\packages\\mathlib: could not resolve 'HEAD' "
+            "to a commit; the repository may be corrupt\n"),
+    )
+    f = tmp_path / "Corrupt.lean"
+    f.write_text(_TRUE_GOAL_FILE, encoding="utf-8")
+    is_true, reason = is_true_placeholder_goal(str(f), 3)
+    assert is_true is False
+    assert reason == ""
+
+
+def test_is_true_placeholder_goal_false_on_unknown_module_error(tmp_path, monkeypatch):
+    """FX-5c: `error: unknown module` (missing dependency / wrong lakefile
+    wiring / dead fetch) is an unpositioned infrastructure failure — the
+    elaborator never reached the probed line, so never refuse."""
+    from prover.lean_utils import is_true_placeholder_goal
+
+    _mock_probe_verifier(
+        monkeypatch,
+        raw_output="error: unknown module 'Knots.Conway'\n",
+    )
+    f = tmp_path / "UnknownMod.lean"
+    f.write_text(_TRUE_GOAL_FILE, encoding="utf-8")
+    assert is_true_placeholder_goal(str(f), 3) == (False, "")
+
+
+def test_is_true_placeholder_goal_false_on_multiline_unpositioned_errors(tmp_path, monkeypatch):
+    """FX-5c: the realistic infra-crash shape is MULTI-LINE — `info:`/status
+    lines interleaved with several unpositioned `error:` headers. None of it
+    is evidence the elaborator ran. Precedence check: a POSITIONED diagnostic
+    far from the probed line (which alone would keep the old "closed" verdict
+    — see test_is_true_placeholder_goal_conservative_on_other_sorries_erroring)
+    does not rescue a run whose build also failed at infrastructure level:
+    the unpositioned error wins, the probe is inconclusive, no refusal."""
+    from prover.lean_utils import is_true_placeholder_goal
+
+    _mock_probe_verifier(
+        monkeypatch,
+        raw_output=(
+            "info: resolving module map\n"
+            "30:2: error: unsolved goals\n"  # positioned, FAR (old semantics: not blocking)
+            "error: failed to update git repository\n"
+            "error: ...packages/mathlib: could not resolve 'HEAD' to a commit\n"),
+    )
+    f = tmp_path / "MultiInfra.lean"
+    f.write_text(_TRUE_GOAL_FILE, encoding="utf-8")
+    assert is_true_placeholder_goal(str(f), 3) == (False, "")
+
+
 def test_is_true_placeholder_goal_false_when_no_sorry_token(tmp_path, monkeypatch):
     """A line without a real sorry token is never probed (no compile)."""
     from prover.lean_utils import is_true_placeholder_goal


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2025:CoursIA — prev: MED/genai #13521

## Résumé

- rend le probe FX-5 conservateur face aux erreurs d'infrastructure non positionnées ;
- empêche une sortie non vide telle que `error: ... could not resolve 'HEAD' ...` d'être interprétée comme preuve que `exact True.intro` ferme le but ;
- ajoute trois régressions couvrant le paquet Git corrompu observé, le module inconnu et une sortie multiligne mixte ;
- corrige la documentation qui revendiquait à tort un verdict sans faux positif sans condition sur l'élaboration réelle du fichier.

See #1453 (itération FX-5c, contribution bornée à l'EPIC du harnais).

## Finding forensic

Le sweep `knot_lean` du 2026-08-21 a produit cinq faux refus `true_placeholder_goal` sur Conway L51/L128/L138/L157/L165. Le build échouait avant élaboration avec une ligne sans position :

```text
error: .../.lake/packages/mathlib: could not resolve 'HEAD' to a commit; the repository may be corrupt
```

L'ancien probe ne cherchait que les erreurs `ligne:colonne:`. Il ne trouvait donc aucune erreur proche du site, retournait `True`, puis refusait toute cible — y compris `alexanderPolynomial conwayKnot = 1`, qui n'est pas un but `True`.

## Correctif

`_probe_closes_goal` retourne désormais `False` dès qu'une ligne commençant par `error:` ne porte aucune position `N:N:`. Une erreur positionnée loin du but conserve sa sémantique antérieure ; une erreur d'infrastructure non positionnée rend le probe ambigu et ne peut jamais déclencher un refus.

## Validation

```text
python -m pytest .../tests/test_prover_guards.py -q -k "true_placeholder"
13 passed, 215 deselected

python -m pytest .../agent_tests/tests -q
724 passed

git diff origin/main...HEAD --check
PASS
```

Contrôles falsifiables :

- contrôle positif : un vrai but `True` sur build propre reste refusé ;
- contrôle négatif exact : l'erreur `could not resolve 'HEAD'` rend `(False, "")` ;
- faux négatifs explicitement couverts : `error: unknown module` et plusieurs erreurs non positionnées ;
- non-régression : une erreur positionnée à une ligne distante ne bloque toujours pas la détection d'un vrai but `True`.

## Périmètre

Trois fichiers uniquement : `lean_utils.py`, `provers.py`, `test_prover_guards.py`. Aucun fichier Lean ni notebook modifié ; aucun build Lean requis pour cette régression mockée CPU-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
