### PR TITLE
fix(sudoku,#9768): remove volatile runtime claims from Sudoku-09

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-09-GraphColoring-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-09-GraphColoring-Csharp.ipynb
@@ -93,321 +93,101 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '20520.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": ""
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/markdown": [
-       "# Sudoku-0 : Environnement et Classes de Base (C#)\n",
-       "\n",
-       "**Navigation** : [Index](README.md) | [Sudoku-01 Backtracking C# >>](Sudoku-01-Backtracking-Csharp.ipynb)\n",
-       "\n",
-       "## Objectifs d'apprentissage\n",
-       "\n",
-       "À la fin de ce notebook, vous saurez :\n",
-       "1. Comprendre la structure de données `SudokuGrid` et ses méthodes principales\n",
-       "2. Utiliser `ISudokuSolver` pour implémenter un solveur de Sudoku\n",
-       "3. Exploiter `SudokuHelper` pour charger des grilles et tester des solveurs\n",
-       "4. Comparer les performances de plusieurs solveurs sur différentes difficultés\n",
-       "\n",
-       "**Prérequis** : Notions de base en C# (.NET Interactive)  \n",
-       "**Durée estimée** : ~15 min"
-      ]
+      "text/markdown": "# Sudoku-0 : Environnement et Classes de Base (C#)\n\n**Navigation** : [Index](README.md) | [Sudoku-01 Backtracking C# >>](Sudoku-01-Backtracking-Csharp.ipynb)\n\n## Objectifs d'apprentissage\n\nÀ la fin de ce notebook, vous saurez :\n1. Comprendre la structure de données `SudokuGrid` et ses méthodes principales\n2. Utiliser `ISudokuSolver` pour implémenter un solveur de Sudoku\n3. Exploiter `SudokuHelper` pour charger des grilles et tester des solveurs\n4. Comparer les performances de plusieurs solveurs sur différentes difficultés\n\n**Prérequis** : Notions de base en C# (.NET Interactive)  \n**Durée estimée** : ~15 min"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Plotly.NET, 5.1.0</span></li></ul></div></div>"
-      ]
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Plotly.NET</span></li></ul></div><div></div></div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/markdown": [
-       "## Définition de la classe SudokuGrid\n",
-       "\n",
-       "Nous définissons ici la classe SudokuGrid qui représente une grille de Sudoku et fournit des méthodes pour manipuler et afficher les grilles.\n"
-      ]
+      "text/markdown": "## Définition de la classe SudokuGrid\n\nNous définissons ici la classe SudokuGrid qui représente une grille de Sudoku et fournit des méthodes pour manipuler et afficher les grilles.\n"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "SudokuGrid defini.\r\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "### Interprétation : Structure de données pour la grille Sudoku\n",
-       "\n",
-       "**Sortie obtenue** : La classe `SudokuGrid` encapsule toutes les opérations de manipulation, validation et affichage d'une grille de Sudoku 9x9.\n",
-       "\n",
-       "| Aspect | Valeur | Signification |\n",
-       "|--------|--------|---------------|\n",
-       "| `Cells[9,9]` | int[,] | Stockage interne des valeurs (0 = vide) |\n",
-       "| `AllNeighbours` | 27 x 9 positions | Pré-calcul des voisins ligne/colonne/bloc |\n",
-       "| `CellNeighbours[9][9]` | ~20 positions chacune | Voisins directs de chaque cellule |\n",
-       "| `GetAvailableNumbers()` | int[] | Candidats valides pour une cellule |\n",
-       "| `NbErrors()` | int | Nombre de conflits + modifications erronées |\n",
-       "\n",
-       "**Points clés** :\n",
-       "1. **Pré-calcul des voisins** : `AllNeighbours` et `CellNeighbours` sont calculés une seule fois à l'initialisation, évitant les recalculs coûteux\n",
-       "2. **Conversion flexible** : Méthodes pour convertir entre tableaux 1D, 2D et jagged arrays (utile pour différents formats de fichiers)\n",
-       "3. **Validation robuste** : `NbErrors` compte à la fois les doublons (ligne/colonne/bloc) et les modifications de indices pré-remplis\n",
-       "4. **Parsing tolerant** : `ReadMultiSudoku` accepte plusieurs formats (`.`, `X`, `-`, espaces)\n",
-       "\n",
-       "> **Note technique** : La structure `CellNeighbours[i][j]` contient environ 20 positions (8 ligne + 8 colonne + 4 bloc, moins les doublons). Ce pré-calcul est crucial pour les performances des algorithmes de backtracking et de propagation de contraintes."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "## Définition de l'interface ISudokuSolver\n",
-       "\n",
-       "Nous définissons ici l'interface ISudokuSolver qui sera implémentée par les différentes stratégies de résolution de Sudoku.\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
+     "text": "SudokuGrid defini.\r\n"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/markdown": "### Interprétation : Structure de données pour la grille Sudoku\n\n**Sortie obtenue** : La classe `SudokuGrid` encapsule toutes les opérations de manipulation, validation et affichage d'une grille de Sudoku 9x9.\n\n| Aspect | Valeur | Signification |\n|--------|--------|---------------|\n| `Cells[9,9]` | int[,] | Stockage interne des valeurs (0 = vide) |\n| `AllNeighbours` | 27 x 9 positions | Pré-calcul des voisins ligne/colonne/bloc |\n| `CellNeighbours[9][9]` | ~20 positions chacune | Voisins directs de chaque cellule |\n| `GetAvailableNumbers()` | int[] | Candidats valides pour une cellule |\n| `NbErrors()` | int | Nombre de conflits + modifications erronées |\n\n**Points clés** :\n1. **Pré-calcul des voisins** : `AllNeighbours` et `CellNeighbours` sont calculés une seule fois à l'initialisation, évitant les recalculs coûteux\n2. **Conversion flexible** : Méthodes pour convertir entre tableaux 1D, 2D et jagged arrays (utile pour différents formats de fichiers)\n3. **Validation robuste** : `NbErrors` compte à la fois les doublons (ligne/colonne/bloc) et les modifications de indices pré-remplis\n4. **Parsing tolerant** : `ReadMultiSudoku` accepte plusieurs formats (`.`, `X`, `-`, espaces)\n\n> **Note technique** : La structure `CellNeighbours[i][j]` contient environ 20 positions (8 ligne + 8 colonne + 4 bloc, moins les doublons). Ce pré-calcul est crucial pour les performances des algorithmes de backtracking et de propagation de contraintes."
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/markdown": "## Définition de l'interface ISudokuSolver\n\nNous définissons ici l'interface ISudokuSolver qui sera implémentée par les différentes stratégies de résolution de Sudoku.\n"
+     },
+     "metadata": {}
+    },
+    {
      "output_type": "stream",
-     "text": [
-      "ISudokuSolver defini.\r\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "### Interprétation : Interface de stratégie\n",
-       "\n",
-       "**Sortie obtenue** : L'interface `ISudokuSolver` définit le contrat que tous les solveurs doivent respecter.\n",
-       "\n",
-       "| Aspect | Valeur | Signification |\n",
-       "|--------|--------|---------------|\n",
-       "| `Solve(SudokuGrid)` | SudokuGrid | Méthode unique de résolution |\n",
-       "| Pattern | Stratégie | Permuter les algorithmes sans modifier le code client |\n",
-       "\n",
-       "**Points clés** :\n",
-       "1. **Simplicité** : Une seule méthode `Solve` prenant une grille et retournant une grille résolue\n",
-       "2. **Flexibilité** : N'importe quel algorithme (backtracking, CSP, métaheuristique) peut implémenter cette interface\n",
-       "3. **Composabilité** : Les solveurs peuvent être passés en paramètre, stockés dans des listes, testés unitairement\n",
-       "4. **Extensibilité** : Ajouter un nouveau solver ne nécessite que d'implémenter l'interface\n",
-       "\n",
-       "> **Note technique** : Ce design pattern permet à `SudokuHelper.TestSolvers` d'accepter une liste de `(string, ISudokuSolver)` pour comparer tous les algorithmes avec le même code de test."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "## Définition de la classe SudokuHelper\n",
-       "\n",
-       "Nous ajoutons ici la classe SudokuHelper qui contient des méthodes utilitaires pour charger  des grilles de Sudoku et tester des solvers.\n",
-       "\n",
-       "- `GetSudokus` : Renvoie des listes de Sudoku issues de fichiers de 3 difficultés différentes.\n",
-       "- `SolveSudoku` : effectue un test simple d'un solver sur un sudoku donné.\n",
-       "- `TestSolvers` : exécute les tests de performance sur plusieurs solveurs.\n",
-       "- `DisplayResults` : affiche les résultats des tests sous forme de graphiques.\n",
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
+     "text": "ISudokuSolver defini.\r\n"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/markdown": "### Interprétation : Interface de stratégie\n\n**Sortie obtenue** : L'interface `ISudokuSolver` définit le contrat que tous les solveurs doivent respecter.\n\n| Aspect | Valeur | Signification |\n|--------|--------|---------------|\n| `Solve(SudokuGrid)` | SudokuGrid | Méthode unique de résolution |\n| Pattern | Stratégie | Permuter les algorithmes sans modifier le code client |\n\n**Points clés** :\n1. **Simplicité** : Une seule méthode `Solve` prenant une grille et retournant une grille résolue\n2. **Flexibilité** : N'importe quel algorithme (backtracking, CSP, métaheuristique) peut implémenter cette interface\n3. **Composabilité** : Les solveurs peuvent être passés en paramètre, stockés dans des listes, testés unitairement\n4. **Extensibilité** : Ajouter un nouveau solver ne nécessite que d'implémenter l'interface\n\n> **Note technique** : Ce design pattern permet à `SudokuHelper.TestSolvers` d'accepter une liste de `(string, ISudokuSolver)` pour comparer tous les algorithmes avec le même code de test."
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/markdown": "## Définition de la classe SudokuHelper\n\nNous ajoutons ici la classe SudokuHelper qui contient des méthodes utilitaires pour charger  des grilles de Sudoku et tester des solvers.\n\n- `GetSudokus` : Renvoie des listes de Sudoku issues de fichiers de 3 difficultés différentes.\n- `SolveSudoku` : effectue un test simple d'un solver sur un sudoku donné.\n- `TestSolvers` : exécute les tests de performance sur plusieurs solveurs.\n- `DisplayResults` : affiche les résultats des tests sous forme de graphiques.\n\n"
+     },
+     "metadata": {}
+    },
+    {
      "output_type": "stream",
-     "text": [
-      "SudokuHelper defini.\r\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "### Interprétation : Infrastructure de test et benchmark\n",
-       "\n",
-       "**Sortie obtenue** : La classe `SudokuHelper` fournit une infrastructure complète pour tester et comparer les solveurs de Sudoku.\n",
-       "\n",
-       "| Aspect | Valeur | Signification |\n",
-       "|--------|--------|---------------|\n",
-       "| `GetSudokus()` | 51/95/100 grilles | Trois niveaux de difficulté (Easy/Medium/Hard) |\n",
-       "| `TestSolvers()` | Performance multi-solveurs | Exécution parallèle avec timeout |\n",
-       "| `DisplayResults()` | Graphiques Plotly.NET | Visualisation des temps de résolution |\n",
-       "| `SolveSudoku()` | Test unitaire | Résolution individuelle avec affichage |\n",
-       "\n",
-       "**Points clés** :\n",
-       "1. **Chargement intelligent** : Recherche récursive du dossier `Puzzles` dans l'arborescence\n",
-       "2. **Robustesse** : Gestion des timeouts (3000ms par défaut) et exceptions\n",
-       "3. **Mesures** : Temps d'exécution total + nombre de grilles resolues\n",
-       "4. **Disqualification** : Un solver échouant sur une grille est disqualifié pour la difficulté\n",
-       "\n",
-       "> **Note technique** : La méthode `TestSolvers` utilise `Interlocked.Increment` pour un thread-safe incrément du compteur de solutions. Le `CancellationToken` permet d'interrompre proprement les solveurs trop lents."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "## Exercice : Validation d'une grille Sudoku\n",
-       "\n",
-       "### Énoncé\n",
-       "\n",
-       "Implémentez une méthode `IsValidSolution` qui vérifie qu'une grille est une solution valide de Sudoku, c'est-à-dire que chaque ligne, chaque colonne et chaque bloc 3x3 contient exactement une fois chaque chiffre de 1 à 9.\n",
-       "\n",
-       "Utilisez cette méthode pour valider les résultats de `SudokuHelper.SolveSudoku`.\n",
-       "\n",
-       "**Indices :**\n",
-       "\n",
-       "- Parcourez les 9 lignes, 9 colonnes et 9 blocs\n",
-       "- Pour chaque unité, verifiez que les 9 chiffres sont tous présents sans doublon\n",
-       "- `SudokuGrid.AllNeighbours` contient déjà les indices des unités"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice a completer\r\n"
-     ]
+     "text": "SudokuHelper defini.\r\n"
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/markdown": [
-       "## Résumé et perspectives\n",
-       "\n",
-       "Ce notebook a posé les fondations de toute la série Sudoku en définissant trois composants essentiels. La classe `SudokuGrid` encapsule la représentation d'une grille 9x9 avec le pré-calcul des voisins (`AllNeighbours`, `CellNeighbours`), ce qui évite les recalculs coûteux lors de la résolution. L'interface `ISudokuSolver` implante le pattern Stratégie, permettant de permuter les algorithmes de résolution sans modifier le code client. Enfin, la classe `SudokuHelper` fournit une infrastructure de benchmark complète avec chargement de puzzles, mesures de performance et visualisation Plotly.NET.\n",
-       "\n",
-       "L'infrastructure de test (`TestSolvers`, `DisplayResults`) permet de comparer objectivement les solveurs sur trois niveaux de difficulté (Easy, Medium, Hard) avec gestion des timeouts et des disqualifications. Ce cadre de benchmark sera utilisé dans tous les notebooks suivants pour mesurer les performances de chaque algorithme.\n",
-       "\n",
-       "Le notebook suivant, [Sudoku-01-Backtracking](Sudoku-01-Backtracking-Csharp.ipynb), utilise ces classes pour implémenter le premier algorithme de résolution : le backtracking récursif avec ses heuristiques d'amélioration."
-      ]
+      "text/markdown": "### Interprétation : Infrastructure de test et benchmark\n\n**Sortie obtenue** : La classe `SudokuHelper` fournit une infrastructure complète pour tester et comparer les solveurs de Sudoku.\n\n| Aspect | Valeur | Signification |\n|--------|--------|---------------|\n| `GetSudokus()` | 51/95/100 grilles | Trois niveaux de difficulté (Easy/Medium/Hard) |\n| `TestSolvers()` | Performance multi-solveurs | Exécution parallèle avec timeout |\n| `DisplayResults()` | Graphiques Plotly.NET | Visualisation des temps de résolution |\n| `SolveSudoku()` | Test unitaire | Résolution individuelle avec affichage |\n\n**Points clés** :\n1. **Chargement intelligent** : Recherche récursive du dossier `Puzzles` dans l'arborescence\n2. **Robustesse** : Gestion des timeouts (3 000 ms par défaut — paramètre de configuration du solveur, valeur fixée dans le code) et exceptions\n3. **Mesures** : Temps d'exécution total + nombre de grilles resolues\n4. **Disqualification** : Un solver échouant sur une grille est disqualifié pour la difficulté\n\n> **Note technique** : La méthode `TestSolvers` utilise `Interlocked.Increment` pour un thread-safe incrément du compteur de solutions. Le `CancellationToken` permet d'interrompre proprement les solveurs trop lents."
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/markdown": "## Exercice : Validation d'une grille Sudoku\n\n### Énoncé\n\nImplémentez une méthode `IsValidSolution` qui vérifie qu'une grille est une solution valide de Sudoku, c'est-à-dire que chaque ligne, chaque colonne et chaque bloc 3x3 contient exactement une fois chaque chiffre de 1 à 9.\n\nUtilisez cette méthode pour valider les résultats de `SudokuHelper.SolveSudoku`.\n\n**Indices :**\n\n- Parcourez les 9 lignes, 9 colonnes et 9 blocs\n- Pour chaque unité, verifiez que les 9 chiffres sont tous présents sans doublon\n- `SudokuGrid.AllNeighbours` contient déjà les indices des unités"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\r\n"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/markdown": "## Résumé et perspectives\n\nCe notebook a posé les fondations de toute la série Sudoku en définissant trois composants essentiels. La classe `SudokuGrid` encapsule la représentation d'une grille 9x9 avec le pré-calcul des voisins (`AllNeighbours`, `CellNeighbours`), ce qui évite les recalculs coûteux lors de la résolution. L'interface `ISudokuSolver` implante le pattern Stratégie, permettant de permuter les algorithmes de résolution sans modifier le code client. Enfin, la classe `SudokuHelper` fournit une infrastructure de benchmark complète avec chargement de puzzles, mesures de performance et visualisation Plotly.NET.\n\nL'infrastructure de test (`TestSolvers`, `DisplayResults`) permet de comparer objectivement les solveurs sur trois niveaux de difficulté (Easy, Medium, Hard) avec gestion des timeouts et des disqualifications. Ce cadre de benchmark sera utilisé dans tous les notebooks suivants pour mesurer les performances de chaque algorithme.\n\nLe notebook suivant, [Sudoku-01-Backtracking](Sudoku-01-Backtracking-Csharp.ipynb), utilise ces classes pour implémenter le premier algorithme de résolution : le backtracking récursif avec ses heuristiques d'amélioration."
+     },
+     "metadata": {}
     }
    ],
    "source": [
@@ -465,11 +245,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Classe SudokuGraph definie (graphe de contraintes 81 sommets)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Classe SudokuGraph definie (graphe de contraintes 81 sommets)\r\n"
     }
    ],
    "source": [
@@ -982,11 +760,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Classe GraphColoringBacktracking definie (coloration par backtracking)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Classe GraphColoringBacktracking definie (coloration par backtracking)\r\n"
     }
    ],
    "source": [
@@ -1246,81 +1022,39 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Sudoku original:\n",
-      "-------------------------------\n",
-      "| 9     2 |       5 | 4     3 | \n",
-      "| 1       |    6  3 |    2  5 | \n",
-      "| 5     8 | 4     7 |    6    | \n",
-      "-------------------------------\n",
-      "|    2  6 | 3     9 |       1 | \n",
-      "|    5  7 |    1    | 2  9    | \n",
-      "|    9    | 6  7    | 5  3    | \n",
-      "-------------------------------\n",
-      "| 2  4    | 5  3    | 6       | \n",
-      "| 7     5 | 2       | 3     4 | \n",
-      "|    8    |    4  1 | 9  5    | \n",
-      "-------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "Sudoku original:\n-------------------------------\n| 9     2 |       5 | 4     3 | \n| 1       |    6  3 |    2  5 | \n| 5     8 | 4     7 |    6    | \n-------------------------------\n|    2  6 | 3     9 |       1 | \n|    5  7 |    1    | 2  9    | \n|    9    | 6  7    | 5  3    | \n-------------------------------\n| 2  4    | 5  3    | 6       | \n| 7     5 | 2       | 3     4 | \n|    8    |    4  1 | 9  5    | \n-------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Sudoku resolu:\n",
-      "-------------------------------\n",
-      "| 9  6  2 | 1  8  5 | 4  7  3 | \n",
-      "| 1  7  4 | 9  6  3 | 8  2  5 | \n",
-      "| 5  3  8 | 4  2  7 | 1  6  9 | \n",
-      "-------------------------------\n",
-      "| 8  2  6 | 3  5  9 | 7  4  1 | \n",
-      "| 3  5  7 | 8  1  4 | 2  9  6 | \n",
-      "| 4  9  1 | 6  7  2 | 5  3  8 | \n",
-      "-------------------------------\n",
-      "| 2  4  9 | 5  3  8 | 6  1  7 | \n",
-      "| 7  1  5 | 2  9  6 | 3  8  4 | \n",
-      "| 6  8  3 | 7  4  1 | 9  5  2 | \n",
-      "-------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nSudoku resolu:\n-------------------------------\n| 9  6  2 | 1  8  5 | 4  7  3 | \n| 1  7  4 | 9  6  3 | 8  2  5 | \n| 5  3  8 | 4  2  7 | 1  6  9 | \n-------------------------------\n| 8  2  6 | 3  5  9 | 7  4  1 | \n| 3  5  7 | 8  1  4 | 2  9  6 | \n| 4  9  1 | 6  7  2 | 5  3  8 | \n-------------------------------\n| 2  4  9 | 5  3  8 | 6  1  7 | \n| 7  1  5 | 2  9  6 | 3  8  4 | \n| 6  8  3 | 7  4  1 | 9  5  2 | \n-------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Statistiques:\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nStatistiques:\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Noeuds explores: 49\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Noeuds explores: 49\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Backtracks: 12\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Backtracks: 12\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Temps: 2,21 ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Temps: 2,01 ms\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Valide: True\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Valide: True\r\n"
     }
    ],
    "source": [
@@ -1354,26 +1088,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation : Test Backtracking Simple\n",
-    "\n",
-    "**Sortie obtenue** : Le backtracking simple résout un Sudoku facile en ~2 ms avec 49 noeuds explorés et 12 backtracks.\n",
-    "\n",
-    "| Aspect | Valeur | Signification |\n",
-    "|--------|--------|---------------|\n",
-    "| Temps de résolution | ~2 ms | Performance acceptable pour un Sudoku facile |\n",
-    "| Noeuds explorés | 49 | Arbre de recherche limite (sur 81 cellules) |\n",
-    "| Backtracks | 12 | Taux de succès de 75% (37 assignations correctes du premier coup) |\n",
-    "| Validité | True | Solution correcte |\n",
-    "\n",
-    "**Points clés** :\n",
-    "1. Le backtracking simple fonctionne bien sur les Sudokus faciles grace aux nombreuses valeurs initiales\n",
-    "2. Le taux de backtrack (12/49 = 24%) reste raisonnable pour cette instance\n",
-    "3. La solution est valide et complète\n",
-    "4. Cette approche servira de baseline pour comparer les heuristiques plus avancees\n",
-    "\n",
-    "> **Note technique** : Le nombre de noeuds explorés (49) est nettement inferieur au nombre total de cellules (81), car les valeurs initiales reduisent l'espace de recherche. Chaque backtrack représente un essai de couleur qui a mene a une impasse, necessitant de revenir en arrière pour essayer une autre couleur. Sur des Sudokus plus difficiles, ce nombre augmente exponentiellement."
-   ]
+   "source": "### Interprétation : Test Backtracking Simple\n\n**Sortie obtenue** : Le backtracking simple résout un Sudoku facile avec 49 noeuds explorés et 12 backtracks (temps de résolution mesuré par `Stopwatch` : voir la sortie de la cellule ci-dessus).\n\n| Aspect | Valeur | Signification |\n|--------|--------|---------------|\n| Noeuds explorés | 49 | Arbre de recherche limite (sur 81 cellules) |\n| Backtracks | 12 | Taux de succès de 75% (37 assignations correctes du premier coup) |\n| Validité | True | Solution correcte |\n\n**Points clés** :\n1. Le backtracking simple fonctionne bien sur les Sudokus faciles grace aux nombreuses valeurs initiales\n2. Le taux de backtrack (12/49 = 24%) reste raisonnable pour cette instance\n3. La solution est valide et complète\n4. Cette approche servira de baseline pour comparer les heuristiques plus avancees\n\n> **Note technique** : Le nombre de noeuds explorés (49) est nettement inferieur au nombre total de cellules (81), car les valeurs initiales reduisent l'espace de recherche. Chaque backtrack représente un essai de couleur qui a mene a une impasse, necessitant de revenir en arrière pour essayer une autre couleur. Sur des Sudokus plus difficiles, ce nombre augmente exponentiellement."
   },
   {
    "cell_type": "markdown",
@@ -1422,11 +1137,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Classe GraphColoringMRV definie (coloration avec heuristique MRV)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Classe GraphColoringMRV definie (coloration avec heuristique MRV)\r\n"
     }
    ],
    "source": [
@@ -1680,11 +1393,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Classe GraphColoringDSATUR definie (coloration DSATUR)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Classe GraphColoringDSATUR definie (coloration DSATUR)\r\n"
     }
    ],
    "source": [
@@ -2004,11 +1715,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Classes SolverResult + BenchmarkSolvers definies (framework de benchmark)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Classes SolverResult + BenchmarkSolvers definies (framework de benchmark)\r\n"
     }
    ],
    "source": [
@@ -2220,55 +1929,39 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Benchmark : Coloration de Graphe pour Sudoku ===\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Benchmark : Coloration de Graphe pour Sudoku ===\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Test sur 5 Sudokus faciles...\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Test sur 5 Sudokus faciles...\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "| Algorithme | Succes | Temps Moy (ms) | Noeuds | Backtracks |\r\n"
-     ]
+     "name": "stdout",
+     "text": "| Algorithme | Succes | Temps Moy (ms) | Noeuds | Backtracks |\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "|------------|--------|----------------|--------|------------|\r\n"
-     ]
+     "name": "stdout",
+     "text": "|------------|--------|----------------|--------|------------|\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "| Backtracking Simple  | OK |          12,00 |   4250 |       4201 |\r\n"
-     ]
+     "name": "stdout",
+     "text": "| Backtracking Simple  | OK |           4,60 |   4250 |       4201 |\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "| MRV Heuristic        | OK |           1,20 |     63 |         14 |\r\n"
-     ]
+     "name": "stdout",
+     "text": "| MRV Heuristic        | OK |           0,80 |     63 |         14 |\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "| DSATUR               | OK |           1,40 |     74 |         25 |\r\n"
-     ]
+     "name": "stdout",
+     "text": "| DSATUR               | OK |           1,40 |     74 |         25 |\r\n"
     }
    ],
    "source": [
@@ -2302,25 +1995,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation : Benchmark Sudokus Faciles\n",
-    "\n",
-    "**Sortie obtenue** : Les trois algorithmes resolvent les Sudokus faciles avec succès, mais avec des performances notablement différentes.\n",
-    "\n",
-    "| Algorithme | Temps Moy (ms) | Noeuds explorés | Backtracks | Ratio par rapport au baseline |\n",
-    "|------------|----------------|-----------------|------------|------------------------------|\n",
-    "| Backtracking Simple | 5,00 | 4 250 | 4 201 | 1x (reference) |\n",
-    "| MRV Heuristic | 1,40 | 63 | 14 | 3,6x plus rapide |\n",
-    "| DSATUR | 3,20 | 74 | 25 | 1,6x plus rapide |\n",
-    "\n",
-    "**Points clés** :\n",
-    "1. **MRV le plus rapide** : Reduction de 98,5% de l'espace de recherche (4250 -> 63 noeuds)\n",
-    "2. **DSATUR performant** : 1,6x plus rapide que le backtracking simple\n",
-    "3. **Backtracking simple acceptable** : Sur les Sudokus faciles, même l'approche naive reste de l'ordre de quelques millisecondes\n",
-    "4. Toutes les solutions sont valides (100% de succès)\n",
-    "\n",
-    "> **Note technique** : Sur les Sudokus faciles, l'heuristique MRV est particulièrement efficace car les nombreuses valeurs initiales créent rapidement des sommets avec une seule couleur disponible (singletons). MRV detecte ces cas immediatement et les propage, reduisant drastiquement l'arbre de recherche. DSATUR a un surcout de calcul (calcul de la saturation a chaque itération) qui est moins justifie sur des instances simples : il reste plus rapide que le backtracking naif mais derriere MRV ici. Cet ordre s'inverse sur les Sudokus difficiles (voir plus bas)."
-   ]
+   "source": "### Interprétation : Benchmark Sudokus Faciles\n\n**Sortie obtenue** : Les trois algorithmes resolvent les Sudokus faciles avec succès, mais avec des performances notablement différentes (temps moyens mesurés : voir la sortie de la cellule ci-dessus).\n\n| Algorithme | Noeuds explorés | Backtracks | Noeuds vs baseline |\n|------------|-----------------|------------|--------------------|\n| Backtracking Simple | 4 250 | 4 201 | 1x (reference) |\n| MRV Heuristic | 63 | 14 | ~67x moins de noeuds |\n| DSATUR | 74 | 25 | ~57x moins de noeuds |\n\n**Points clés** :\n1. **MRV le plus efficace** : Reduction de 98,5% de l'espace de recherche (4250 -> 63 noeuds)\n2. **DSATUR performant** : ~57x moins de noeuds explorés que le backtracking simple\n3. **Backtracking simple acceptable** : Sur les Sudokus faciles, même l'approche naive termine ces instances sans explosion combinatoire\n4. Toutes les solutions sont valides (100% de succès)\n\n> **Note technique** : Sur les Sudokus faciles, l'heuristique MRV est particulièrement efficace car les nombreuses valeurs initiales créent rapidement des sommets avec une seule couleur disponible (singletons). MRV detecte ces cas immediatement et les propage, reduisant drastiquement l'arbre de recherche. DSATUR a un surcout de calcul (calcul de la saturation a chaque itération) qui est moins justifie sur des instances simples : il explore moins de noeuds que le backtracking naif mais reste derriere MRV ici. Cet ordre s'inverse sur les Sudokus difficiles (voir plus bas)."
   },
   {
    "cell_type": "markdown",
@@ -2367,48 +2042,34 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Test sur 3 Sudokus difficiles...\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nTest sur 3 Sudokus difficiles...\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "| Algorithme | Succes | Temps Moy (ms) | Noeuds | Backtracks |\r\n"
-     ]
+     "name": "stdout",
+     "text": "| Algorithme | Succes | Temps Moy (ms) | Noeuds | Backtracks |\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "|------------|--------|----------------|--------|------------|\r\n"
-     ]
+     "name": "stdout",
+     "text": "|------------|--------|----------------|--------|------------|\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "| Backtracking Simple  | OK |        2839,33 | 4356440 |    4356375 |\r\n"
-     ]
+     "name": "stdout",
+     "text": "| Backtracking Simple  | OK |        2650,67 | 4356440 |    4356375 |\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "| MRV Heuristic        | OK |          35,67 |   1406 |       1341 |\r\n"
-     ]
+     "name": "stdout",
+     "text": "| MRV Heuristic        | OK |          19,33 |   1406 |       1341 |\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "| DSATUR               | OK |          26,33 |   1202 |       1137 |\r\n"
-     ]
+     "name": "stdout",
+     "text": "| DSATUR               | OK |          12,67 |   1202 |       1137 |\r\n"
     }
    ],
    "source": [
@@ -2439,25 +2100,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation : Benchmark Sudokus Difficiles\n",
-    "\n",
-    "**Sortie obtenue** : Les résultats montrent une différence spectaculaire entre les algorithmes sur les Sudokus difficiles.\n",
-    "\n",
-    "| Algorithme | Temps (ms) | Noeuds explorés | Backtracks | Facteur d'accélération |\n",
-    "|------------|------------|------------------|------------|------------------------|\n",
-    "| Backtracking Simple | ~3300 | 4 356 440 | 4 356 375 | 1x (baseline) |\n",
-    "| MRV Heuristic | ~18 | 1 406 | 1 341 | 180x plus rapide |\n",
-    "| DSATUR | ~17 | 1 202 | 1 137 | 198x plus rapide |\n",
-    "\n",
-    "**Points clés** :\n",
-    "1. **Backtracking simple** : Explosion combinatoire sur les instances difficiles (4,3 millions de noeuds)\n",
-    "2. **DSATUR meilleur performer ici** : le plus rapide (~17 ms) ET le moins de noeuds explorés (1 202)\n",
-    "3. **MRV très proche** : ~18 ms et 1 406 noeuds, juste derriere DSATUR sur ce benchmark difficile\n",
-    "4. L'ecart avec le backtracking se creuse considerablement avec la difficulté (x180 a x198)\n",
-    "\n",
-    "> **Note technique** : Sur les Sudokus difficiles (peu de valeurs initiales), le degré de saturation de DSATUR devient discriminant : choisir le sommet dont le voisinage utilisé le plus de couleurs distinctes oriente la recherche vers les zones les plus contraintes, ce qui minimise le nombre de noeuds explorés (1 202, le plus bas des trois). DSATUR amortit alors son surcout de calcul de saturation et passe devant MRV -- l'inverse du cas facile, ou ce surcout n'etait pas justifie. Les deux heuristiques restent deux ordres de grandeur plus rapides que le backtracking naif."
-   ]
+   "source": "### Interprétation : Benchmark Sudokus Difficiles\n\n**Sortie obtenue** : Les résultats montrent une différence spectaculaire entre les algorithmes sur les Sudokus difficiles (temps moyens mesurés : voir la sortie de la cellule ci-dessus).\n\n| Algorithme | Noeuds explorés | Backtracks | Noeuds vs baseline |\n|------------|------------------|------------|--------------------|\n| Backtracking Simple | 4 356 440 | 4 356 375 | 1x (baseline) |\n| MRV Heuristic | 1 406 | 1 341 | ~3 100x moins de noeuds |\n| DSATUR | 1 202 | 1 137 | ~3 600x moins de noeuds |\n\n**Points clés** :\n1. **Backtracking simple** : Explosion combinatoire sur les instances difficiles (4,3 millions de noeuds)\n2. **DSATUR meilleur performer ici** : le moins de noeuds explorés (1 202) ET le temps de résolution le plus court des trois (voir sortie ci-dessus)\n3. **MRV très proche** : 1 406 noeuds, juste derriere DSATUR sur ce benchmark difficile\n4. L'ecart avec le backtracking se creuse considerablement avec la difficulté (de ~3 100x a ~3 600x en nombre de noeuds explorés)\n\n> **Note technique** : Sur les Sudokus difficiles (peu de valeurs initiales), le degré de saturation de DSATUR devient discriminant : choisir le sommet dont le voisinage utilisé le plus de couleurs distinctes oriente la recherche vers les zones les plus contraintes, ce qui minimise le nombre de noeuds explorés (1 202, le plus bas des trois). DSATUR amortit alors son surcout de calcul de saturation et passe devant MRV -- l'inverse du cas facile, ou ce surcout n'etait pas justifie. Les deux heuristiques restent plusieurs ordres de grandeur plus efficaces que le backtracking naif."
   },
   {
    "cell_type": "markdown",
@@ -2532,66 +2175,28 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Test d'integration avec SudokuHelper ===\n",
-      "\r\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Résolution par le solver GraphColoringDSATUR du Sudoku:\n",
-       " -------------------------------\n",
-       "| 9     2 |       5 | 4     3 | \n",
-       "| 1       |    6  3 |    2  5 | \n",
-       "| 5     8 | 4     7 |    6    | \n",
-       "-------------------------------\n",
-       "|    2  6 | 3     9 |       1 | \n",
-       "|    5  7 |    1    | 2  9    | \n",
-       "|    9    | 6  7    | 5  3    | \n",
-       "-------------------------------\n",
-       "| 2  4    | 5  3    | 6       | \n",
-       "| 7     5 | 2       | 3     4 | \n",
-       "|    8    |    4  1 | 9  5    | \n",
-       "-------------------------------"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Sudoku renvoyé:\n",
-       "-------------------------------\n",
-       "| 9  6  2 | 1  8  5 | 4  7  3 | \n",
-       "| 1  7  4 | 9  6  3 | 8  2  5 | \n",
-       "| 5  3  8 | 4  2  7 | 1  6  9 | \n",
-       "-------------------------------\n",
-       "| 8  2  6 | 3  5  9 | 7  4  1 | \n",
-       "| 3  5  7 | 8  1  4 | 2  9  6 | \n",
-       "| 4  9  1 | 6  7  2 | 5  3  8 | \n",
-       "-------------------------------\n",
-       "| 2  4  9 | 5  3  8 | 6  1  7 | \n",
-       "| 7  1  5 | 2  9  6 | 3  8  4 | \n",
-       "| 6  8  3 | 7  4  1 | 9  5  2 | \n",
-       "-------------------------------\n",
-       "Nombre d'erreurs réstantes: 0\n",
-       "Temps de résolution: 0,6207 ms"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
+     "text": "=== Test d'integration avec SudokuHelper ===\n\r\n"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": "Résolution par le solver GraphColoringDSATUR du Sudoku:\n -------------------------------\n| 9     2 |       5 | 4     3 | \n| 1       |    6  3 |    2  5 | \n| 5     8 | 4     7 |    6    | \n-------------------------------\n|    2  6 | 3     9 |       1 | \n|    5  7 |    1    | 2  9    | \n|    9    | 6  7    | 5  3    | \n-------------------------------\n| 2  4    | 5  3    | 6       | \n| 7     5 | 2       | 3     4 | \n|    8    |    4  1 | 9  5    | \n-------------------------------"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": "Sudoku renvoyé:\n-------------------------------\n| 9  6  2 | 1  8  5 | 4  7  3 | \n| 1  7  4 | 9  6  3 | 8  2  5 | \n| 5  3  8 | 4  2  7 | 1  6  9 | \n-------------------------------\n| 8  2  6 | 3  5  9 | 7  4  1 | \n| 3  5  7 | 8  1  4 | 2  9  6 | \n| 4  9  1 | 6  7  2 | 5  3  8 | \n-------------------------------\n| 2  4  9 | 5  3  8 | 6  1  7 | \n| 7  1  5 | 2  9  6 | 3  8  4 | \n| 6  8  3 | 7  4  1 | 9  5  2 | \n-------------------------------\nNombre d'erreurs réstantes: 0\nTemps de résolution: 0,3028 ms"
+     },
+     "metadata": {}
+    },
+    {
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Temps de resolution DSATUR : 6,4560 ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nTemps de resolution DSATUR : 3,0956 ms\r\n"
     }
    ],
    "source": [
@@ -2618,24 +2223,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation : Intégration DSATUR\n",
-    "\n",
-    "**Sortie obtenue** : Le solveur DSATUR résout le Sudoku facile via `SudokuHelper.SolveSudoku` en ~3,6 ms (ordre de grandeur, mesure session) avec 0 erreurs ; la grille renvoyée est complète et respecte toutes les contraintes du Sudoku (aucun conflit). Le chronomètre `Stopwatch` mesure le temps réel de résolution (source : sortie de la cellule ci-dessus).\n",
-    "\n",
-    "| Aspect | Valeur | Signification |\n",
-    "|--------|--------|---------------|\n",
-    "| Temps de résolution | ~3,6 ms (runtime machine-dep) | Ordre de grandeur `Stopwatch` — valeur exacte dans la sortie ci-dessus |\n",
-    "| Erreurs restantes | 0 | Solution valide et complète |\n",
-    "| Algorithme | DSATUR | Heuristique de degré de saturation |\n",
-    "\n",
-    "**Points clés** :\n",
-    "1. L'intégration avec `SudokuHelper` fonctionne correctement\n",
-    "2. La conversion graphe → grille Sudoku est transparente\n",
-    "3. DSATUR maintient ses bonnes performances dans le framework Sudoku\n",
-    "\n",
-    "> **Note technique** : La classe `GraphColoringDSATUR` implémente l'interface `ISudokuSolver`, ce qui permet une intégration sans friction avec le framework existant. La méthode `SolveSudoku` de `SudokuHelper` encapsule la logique de validation automatique."
-   ]
+   "source": "### Interprétation : Intégration DSATUR\n\n**Sortie obtenue** : Le solveur DSATUR résout le Sudoku facile via `SudokuHelper.SolveSudoku` avec 0 erreurs ; la grille renvoyée est complète et respecte toutes les contraintes du Sudoku (aucun conflit). Le chronomètre `Stopwatch` mesure le temps réel de résolution — machine-dépendant, volontairement non épinglé en prose (source : sortie de la cellule ci-dessus).\n\n| Aspect | Valeur | Signification |\n|--------|--------|---------------|\n| Erreurs restantes | 0 | Solution valide et complète |\n| Algorithme | DSATUR | Heuristique de degré de saturation |\n\n**Points clés** :\n1. L'intégration avec `SudokuHelper` fonctionne correctement\n2. La conversion graphe → grille Sudoku est transparente\n3. DSATUR maintient ses bonnes performances dans le framework Sudoku\n\n> **Note technique** : La classe `GraphColoringDSATUR` implémente l'interface `ISudokuSolver`, ce qui permet une intégration sans friction avec le framework existant. La méthode `SolveSudoku` de `SudokuHelper` encapsule la logique de validation automatique."
   },
   {
    "cell_type": "markdown",
@@ -2693,11 +2281,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercices de coloration de graphe a implementer !\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercices de coloration de graphe a implementer !\r\n"
     }
    ],
    "source": [
@@ -2776,62 +2362,46 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>QuikGraph, 2.5.0</span></li></ul></div></div>"
-      ]
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>QuikGraph</span></li></ul></div><div></div></div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Tranche 2 : Graphe Sudoku via QuikGraph (moteur .NET natif) ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Tranche 2 : Graphe Sudoku via QuikGraph (moteur .NET natif) ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Sommets : 81    (nx.sudoku_graph() = 81)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Sommets : 81    (nx.sudoku_graph() = 81)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Aretes  : 810   (nx.sudoku_graph() = 810)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Aretes  : 810   (nx.sudoku_graph() = 810)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Degre uniforme : 20   (chaque cellule a 20 conflits)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Degre uniforme : 20   (chaque cellule a 20 conflits)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Composantes connexes (algo QuikGraph) : 1   (graphe connexe)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Composantes connexes (algo QuikGraph) : 1   (graphe connexe)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Verification coloration (parcours QuikGraph g.Edges) : 0 conflit(s) / 810 aretes\r\n"
-     ]
+     "name": "stdout",
+     "text": "Verification coloration (parcours QuikGraph g.Edges) : 0 conflit(s) / 810 aretes\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Coloration propre : OUI   (DSATUR sur structure QuikGraph = valide)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Coloration propre : OUI   (DSATUR sur structure QuikGraph = valide)\r\n"
     }
    ],
    "source": [
@@ -2935,7 +2505,7 @@
  "metadata": {
   "cost": {
    "api_provider": "none",
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "cpu_min": 1,
    "external_account": "none",
    "free_alternative": "self",
@@ -2961,18 +2531,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 29.426582,
-   "end_time": "2026-05-02T18:26:40.096700",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "Sudoku-9-GraphColoring-Csharp.ipynb",
-   "output_path": "Sudoku-9-GraphColoring-Csharp.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-02T18:26:10.670118",
-   "version": "2.6.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-09-graphcoloring.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-09-graphcoloring.yaml
@@ -46,6 +46,12 @@
       csharp_sha: 548d0e6bfc18e996b89ef811880f24f180b335b5
       content_python_sha: 9c454e029e788c287c4720f9696b5edb0e987dc086e617d06e571f8113d957cf
       content_csharp_sha: 5a8d357683cb758604bee5a5773db292b2a48c2eb4ca19cfb372bd9e4bd51248
+    - date: "2026-08-29"
+      by: myia-po-2025:CoursIA
+      python_sha: 7e0380fda4856a0730496a2774be72907c63257e
+      csharp_sha: 7fc241df73247d9197adf2d79e728735ed205a16
+      content_python_sha: 9c454e029e788c287c4720f9696b5edb0e987dc086e617d06e571f8113d957cf
+      content_csharp_sha: 51126c338dc9bac4f043cd4729ea856d5657e13ae3e734951ad668f3419c87e9
   known_differences:
     - "Rebaseline 2026-08-14 : cote C# deplace par drain wallclock #9434 / PR #10874 (remplacement des timings machine-dependants en ms par des ordres de grandeur dans le markdown). Parite semantique inchangee (cellules code byte-identiques, aucune sortie, aucun exec_count touche) ; cote Python non modifie. Attestation = nouveau blob SHA du cote C#."
     - "Socle pedagogique commun : reformulation du Sudoku comme un probleme de coloration de graphe (une cellule = un noeud, le graphe de contraintes Sudoku, coloration propre a 9 couleurs), meme concept mathematique (graphe de conflits, coloration propre), meme cas d'application."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/research-code #13524

## Résumé

- réexécute entièrement Sudoku-09 avec le vrai kernel `.net-csharp` ;
- retire de la prose les temps absolus dépendants de la machine et conserve les comparaisons structurelles fondées sur les nœuds/backtracks ;
- maintient les interprétations immédiatement après les sorties qu'elles commentent ;
- conserve les sorties réelles, sans retouche manuelle.

See #9768 (correctif borné du finding Sudoku-09, pas clôture de l'Epic forensic).

## Diagnostic dérive

**Cause (b) — claim antérieure non relue après ré-exécution.** Le commit `9f5b690dd` (PR #10412) a ajouté la tranche QuikGraph et réexécuté les 15 cellules code, mais la prose quantitative des benchmarks est restée attachée aux timings de la session précédente. Les outputs et la prose ont donc divergé sans erreur d'exécution.

**Verdict : `CAUSE_FIXED`.** La cause est supprimée plutôt que repeinte : les temps absolus machine-dépendants ne sont plus épinglés en markdown. Les cellules de benchmark restent la source autoritative des timings frais ; la prose conserve uniquement les mesures structurelles reproductibles et les conclusions qualitatives supportées par les outputs adjacents.

## Validation

```text
python scripts/notebook_tools/dotnet_executor.py <notebook> --kernel .net-csharp --timeout 240 --verbose
DONE: 15/15 cells, 0 errors, 18.6s

python scripts/notebook_tools/validate_pr_notebooks.py origin/main <notebook>
Notebook PR Validation: 1/1 passed — 15 code cells

python scripts/notebook_tools/check_c2_compliance.py --path <notebook> --no-catalog
C.2 Compliance Check: 1/1 notebooks compliant

python scripts/notebook_tools/scan_cell_ordering.py <notebook> --fail-on HIGH --check-interp-anchor
Scanned 1 notebook: 1 clean, 0 findings

python scripts/notebook_tools/strip_probe_banner.py --scan <notebook> --check
0 banner line

python scripts/notebook_tools/check_twin_parity.py --per-pair --base origin/main --check
Sudoku-09 GraphColoring: base=OK, head=OK
```

Preuves complémentaires :

- 15 cellules code, `execution_count` séquentiels `[1..15]`, zéro output `error` ;
- sources des 15 cellules code byte-identiques à `origin/main` ; seules quatre cellules markdown changent ;
- nœuds/backtracks stables entre les deux exécutions, alors que les timings ont de nouveau bougé — confirmation firsthand de la cause C.5 ;
- aucune occurrence résiduelle des anciennes épingles `5,00`, `3,6x`, `1,6x`, `180x`, `198x` ;
- une bannière `probeAddresses` réinjectée par le kernel a été retirée avec l'outil canonique, puis la paire Sudoku-09 a été ré-attestée en dernier ;
- le seul drift twin fleet-wide signalé en mode per-pair est `ML-5 TimeSeries`, préexistant sur `origin/main` et non introduit par cette branche.

## Périmètre

Deux fichiers : le notebook `MyIA.AI.Notebooks/Sudoku/Sudoku-09-GraphColoring-Csharp.ipynb` et son entrée d'attestation `scripts/notebook_tools/twin_pairs.d/sudoku-09-graphcoloring.yaml`. Aucun catalogue généré ni autre notebook modifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
