### PR TITLE
fix(slides): split overflowing knowledge-agent slide

### DIFF
--- a/slides/03-logique/slides.md
+++ b/slides/03-logique/slides.md
@@ -54,7 +54,7 @@ layout: section
 
 # Agents fondes sur les connaissances
 ---
-layout: default
+layout: compact
 ---
 
 
@@ -96,11 +96,15 @@ fonction KB-AGENT(percept) retourne une action
 - Tell (-> KB) : Ajouter des connaissances
 - Ask (<- KB) : Interroger la base
 
-## Niveaux de l'architecture
+---
+layout: default
+---
 
-- Connaissances (formulation naturelle)
-- Logique (formulation en enonces)
-- Implementation (representation physique des enonces)
+# Niveaux de l'architecture
+
+- **Connaissances** : formulation naturelle
+- **Logique** : formulation en enonces
+- **Implementation** : representation physique des enonces
 
 ---
 layout: default


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet #13527

## Résumé

- applique le layout `compact` à la slide « Agents fondés sur les connaissances » ;
- déplace « Niveaux de l’architecture » vers une slide dédiée plutôt que de comprimer davantage le contenu ;
- préserve l’intégralité du contenu pédagogique et porte le deck de 127 à 128 slides.

See #11508

## Défaut mesuré et correction

- avant correction : slide 5 à `content_bottom=675` sur un canvas de 552 px, soit 123 px de dépassement ;
- layout compact seul : `content_bottom=613`, soit encore 61 px hors canvas ;
- après séparation : slide 5 à `content_bottom=512`, `hors_canvas=[]`, `chevauchements=[]` ;
- nouvelle slide 6 : `hors_canvas=[]`, `chevauchements=[]`.

Le scanner d’occupation continue de signaler la slide 5 en advisory (`F1`/`F2`) en raison des deux images positionnées à droite. Ce signal est distinct de l’overflow vertical corrigé. Le deck conserve quatre overflows préexistants hors de cette tranche ; cette PR ne revendique pas une conformité globale du deck.

## Validation

- `python scripts/check_slidev_structure.py slides/03-logique/slides.md` — 1 deck, 0 constat ;
- `python scripts/notebook_tools/scan_slides_html_block_markdown.py --check slides/03-logique/slides.md --json` — 0 violation ;
- scan de composition complet — 128 slides, 4 overflows préexistants, 0 chevauchement ;
- contrôle positif armé sur la slide 5 — `controle_positif_ok=true`, aucun avertissement de contrôle ;
- `npm run build -- 03-logique/slides.md` — succès, 1093 modules transformés ;
- `npm run export -- 03-logique/slides.md` — succès, PDF généré puis retiré du worktree ;
- QA visuel Slidev à `?clicks=99` sur les slides 5 et 6 — contenu lisible, aucune troncature ni collision ; captures conservées hors dépôt dans le scratchpad.

## Portée

Un seul fichier modifié : `slides/03-logique/slides.md`. Aucun catalogue, lockfile, export ou rapport d’audit committé.
