### PR TITLE
fix(gametheory,#13497): audit de paire GT-06c — re-exec des deux twins au meme head + balayage registre

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem-Csharp.ipynb
@@ -47,10 +47,10 @@
    "id": "255f59f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T08:59:45.398115Z",
-     "iopub.status.busy": "2026-07-07T08:59:45.386000Z",
-     "iopub.status.idle": "2026-07-07T08:59:46.606179Z",
-     "shell.execute_reply": "2026-07-07T08:59:46.602783Z"
+     "iopub.execute_input": "2026-08-29T16:56:39.702282Z",
+     "iopub.status.busy": "2026-08-29T16:56:39.696773Z",
+     "iopub.status.idle": "2026-08-29T16:56:41.099840Z",
+     "shell.execute_reply": "2026-08-29T16:56:41.094872Z"
     }
    },
    "outputs": [
@@ -63,6 +63,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -72,7 +73,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -87,6 +91,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -98,11 +103,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '27348.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '21148.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -146,11 +153,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -259,10 +268,10 @@
    "id": "6cfca773",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T08:59:46.608069Z",
-     "iopub.status.busy": "2026-07-07T08:59:46.608069Z",
-     "iopub.status.idle": "2026-07-07T08:59:46.635855Z",
-     "shell.execute_reply": "2026-07-07T08:59:46.635855Z"
+     "iopub.execute_input": "2026-08-29T16:56:41.100825Z",
+     "iopub.status.busy": "2026-08-29T16:56:41.100825Z",
+     "iopub.status.idle": "2026-08-29T16:56:41.145128Z",
+     "shell.execute_reply": "2026-08-29T16:56:41.145128Z"
     }
    },
    "outputs": [
@@ -339,10 +348,10 @@
    "id": "d57d8413",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T08:59:46.636948Z",
-     "iopub.status.busy": "2026-07-07T08:59:46.636948Z",
-     "iopub.status.idle": "2026-07-07T08:59:46.756122Z",
-     "shell.execute_reply": "2026-07-07T08:59:46.756122Z"
+     "iopub.execute_input": "2026-08-29T16:56:41.147129Z",
+     "iopub.status.busy": "2026-08-29T16:56:41.146129Z",
+     "iopub.status.idle": "2026-08-29T16:56:41.294738Z",
+     "shell.execute_reply": "2026-08-29T16:56:41.294738Z"
     }
    },
    "outputs": [
@@ -443,10 +452,10 @@
    "id": "b1fe2a86",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T08:59:46.774539Z",
-     "iopub.status.busy": "2026-07-07T08:59:46.774539Z",
-     "iopub.status.idle": "2026-07-07T08:59:46.811710Z",
-     "shell.execute_reply": "2026-07-07T08:59:46.811710Z"
+     "iopub.execute_input": "2026-08-29T16:56:41.295738Z",
+     "iopub.status.busy": "2026-08-29T16:56:41.295738Z",
+     "iopub.status.idle": "2026-08-29T16:56:41.363242Z",
+     "shell.execute_reply": "2026-08-29T16:56:41.362739Z"
     }
    },
    "outputs": [
@@ -569,10 +578,10 @@
    "id": "1e4687c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T08:59:46.813745Z",
-     "iopub.status.busy": "2026-07-07T08:59:46.812744Z",
-     "iopub.status.idle": "2026-07-07T08:59:46.848040Z",
-     "shell.execute_reply": "2026-07-07T08:59:46.847040Z"
+     "iopub.execute_input": "2026-08-29T16:56:41.364759Z",
+     "iopub.status.busy": "2026-08-29T16:56:41.363754Z",
+     "iopub.status.idle": "2026-08-29T16:56:41.462548Z",
+     "shell.execute_reply": "2026-08-29T16:56:41.462548Z"
     }
    },
    "outputs": [
@@ -664,10 +673,10 @@
    "id": "4190187c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T08:59:46.848433Z",
-     "iopub.status.busy": "2026-07-07T08:59:46.848433Z",
-     "iopub.status.idle": "2026-07-07T08:59:46.987206Z",
-     "shell.execute_reply": "2026-07-07T08:59:46.980166Z"
+     "iopub.execute_input": "2026-08-29T16:56:41.463548Z",
+     "iopub.status.busy": "2026-08-29T16:56:41.463548Z",
+     "iopub.status.idle": "2026-08-29T16:56:41.632922Z",
+     "shell.execute_reply": "2026-08-29T16:56:41.625376Z"
     }
    },
    "outputs": [
@@ -1282,10 +1291,10 @@
    "id": "654eb7b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T08:59:46.988167Z",
-     "iopub.status.busy": "2026-07-07T08:59:46.988167Z",
-     "iopub.status.idle": "2026-07-07T08:59:47.010673Z",
-     "shell.execute_reply": "2026-07-07T08:59:47.010143Z"
+     "iopub.execute_input": "2026-08-29T16:56:41.635690Z",
+     "iopub.status.busy": "2026-08-29T16:56:41.634183Z",
+     "iopub.status.idle": "2026-08-29T16:56:41.675587Z",
+     "shell.execute_reply": "2026-08-29T16:56:41.675587Z"
     }
    },
    "outputs": [
@@ -1322,10 +1331,10 @@
    "id": "3caa4399",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T08:59:47.012272Z",
-     "iopub.status.busy": "2026-07-07T08:59:47.011710Z",
-     "iopub.status.idle": "2026-07-07T08:59:47.046422Z",
-     "shell.execute_reply": "2026-07-07T08:59:47.045871Z"
+     "iopub.execute_input": "2026-08-29T16:56:41.677130Z",
+     "iopub.status.busy": "2026-08-29T16:56:41.675587Z",
+     "iopub.status.idle": "2026-08-29T16:56:41.728693Z",
+     "shell.execute_reply": "2026-08-29T16:56:41.728693Z"
     }
    },
    "outputs": [
@@ -1363,10 +1372,10 @@
    "id": "f637c966",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T08:59:47.047681Z",
-     "iopub.status.busy": "2026-07-07T08:59:47.047681Z",
-     "iopub.status.idle": "2026-07-07T08:59:47.059841Z",
-     "shell.execute_reply": "2026-07-07T08:59:47.059327Z"
+     "iopub.execute_input": "2026-08-29T16:56:41.729699Z",
+     "iopub.status.busy": "2026-08-29T16:56:41.729699Z",
+     "iopub.status.idle": "2026-08-29T16:56:41.754994Z",
+     "shell.execute_reply": "2026-08-29T16:56:41.754994Z"
     }
    },
    "outputs": [

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb
@@ -5,10 +5,10 @@
    "id": "94287c96",
    "metadata": {
     "papermill": {
-     "duration": 0.004918,
-     "end_time": "2026-08-29T02:56:56.843793",
+     "duration": 0.00351,
+     "end_time": "2026-08-29T17:38:19.951429",
      "exception": false,
-     "start_time": "2026-08-29T02:56:56.838875",
+     "start_time": "2026-08-29T17:38:19.947919",
      "status": "completed"
     },
     "tags": []
@@ -26,10 +26,10 @@
    "id": "82e05178",
    "metadata": {
     "papermill": {
-     "duration": 0.004709,
-     "end_time": "2026-08-29T02:56:56.853041",
+     "duration": 0.00351,
+     "end_time": "2026-08-29T17:38:19.960454",
      "exception": false,
-     "start_time": "2026-08-29T02:56:56.848332",
+     "start_time": "2026-08-29T17:38:19.956944",
      "status": "completed"
     },
     "tags": []
@@ -55,10 +55,10 @@
    "id": "39c4bb7b",
    "metadata": {
     "papermill": {
-     "duration": 0.004604,
-     "end_time": "2026-08-29T02:56:56.862718",
+     "duration": 0.004045,
+     "end_time": "2026-08-29T17:38:19.968672",
      "exception": false,
-     "start_time": "2026-08-29T02:56:56.858114",
+     "start_time": "2026-08-29T17:38:19.964627",
      "status": "completed"
     },
     "tags": []
@@ -82,16 +82,16 @@
    "id": "c299183b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:56.873185Z",
-     "iopub.status.busy": "2026-08-29T02:56:56.872727Z",
-     "iopub.status.idle": "2026-08-29T02:56:56.946395Z",
-     "shell.execute_reply": "2026-08-29T02:56:56.945881Z"
+     "iopub.execute_input": "2026-08-29T17:38:19.978712Z",
+     "iopub.status.busy": "2026-08-29T17:38:19.978712Z",
+     "iopub.status.idle": "2026-08-29T17:38:20.057994Z",
+     "shell.execute_reply": "2026-08-29T17:38:20.057481Z"
     },
     "papermill": {
-     "duration": 0.080677,
-     "end_time": "2026-08-29T02:56:56.947402",
+     "duration": 0.085327,
+     "end_time": "2026-08-29T17:38:20.058999",
      "exception": false,
-     "start_time": "2026-08-29T02:56:56.866725",
+     "start_time": "2026-08-29T17:38:19.973672",
      "status": "completed"
     },
     "tags": []
@@ -137,10 +137,10 @@
    "id": "091bdfe7",
    "metadata": {
     "papermill": {
-     "duration": 0.005012,
-     "end_time": "2026-08-29T02:56:56.958041",
+     "duration": 0.005613,
+     "end_time": "2026-08-29T17:38:20.069148",
      "exception": false,
-     "start_time": "2026-08-29T02:56:56.953029",
+     "start_time": "2026-08-29T17:38:20.063535",
      "status": "completed"
     },
     "tags": []
@@ -161,16 +161,16 @@
    "id": "07f3ed2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:56.967562Z",
-     "iopub.status.busy": "2026-08-29T02:56:56.966564Z",
-     "iopub.status.idle": "2026-08-29T02:56:56.970780Z",
-     "shell.execute_reply": "2026-08-29T02:56:56.970780Z"
+     "iopub.execute_input": "2026-08-29T17:38:20.081302Z",
+     "iopub.status.busy": "2026-08-29T17:38:20.081302Z",
+     "iopub.status.idle": "2026-08-29T17:38:20.085803Z",
+     "shell.execute_reply": "2026-08-29T17:38:20.085297Z"
     },
     "papermill": {
-     "duration": 0.010749,
-     "end_time": "2026-08-29T02:56:56.971787",
+     "duration": 0.010511,
+     "end_time": "2026-08-29T17:38:20.085803",
      "exception": false,
-     "start_time": "2026-08-29T02:56:56.961038",
+     "start_time": "2026-08-29T17:38:20.075292",
      "status": "completed"
     },
     "tags": []
@@ -209,10 +209,10 @@
    "id": "15e2d771",
    "metadata": {
     "papermill": {
-     "duration": 0.004095,
-     "end_time": "2026-08-29T02:56:56.979394",
+     "duration": 0.005038,
+     "end_time": "2026-08-29T17:38:20.096446",
      "exception": false,
-     "start_time": "2026-08-29T02:56:56.975299",
+     "start_time": "2026-08-29T17:38:20.091408",
      "status": "completed"
     },
     "tags": []
@@ -237,16 +237,16 @@
    "id": "66520d09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:56.989441Z",
-     "iopub.status.busy": "2026-08-29T02:56:56.989441Z",
-     "iopub.status.idle": "2026-08-29T02:56:56.995245Z",
-     "shell.execute_reply": "2026-08-29T02:56:56.994670Z"
+     "iopub.execute_input": "2026-08-29T17:38:20.111959Z",
+     "iopub.status.busy": "2026-08-29T17:38:20.110959Z",
+     "iopub.status.idle": "2026-08-29T17:38:20.116445Z",
+     "shell.execute_reply": "2026-08-29T17:38:20.116445Z"
     },
     "papermill": {
-     "duration": 0.011839,
-     "end_time": "2026-08-29T02:56:56.995245",
+     "duration": 0.014013,
+     "end_time": "2026-08-29T17:38:20.117461",
      "exception": false,
-     "start_time": "2026-08-29T02:56:56.983406",
+     "start_time": "2026-08-29T17:38:20.103448",
      "status": "completed"
     },
     "tags": []
@@ -285,10 +285,10 @@
    "id": "e18c2ad3",
    "metadata": {
     "papermill": {
-     "duration": 0.003998,
-     "end_time": "2026-08-29T02:56:57.004424",
+     "duration": 0.00492,
+     "end_time": "2026-08-29T17:38:20.127903",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.000426",
+     "start_time": "2026-08-29T17:38:20.122983",
      "status": "completed"
     },
     "tags": []
@@ -316,16 +316,16 @@
    "id": "dd76c5e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:57.015711Z",
-     "iopub.status.busy": "2026-08-29T02:56:57.015711Z",
-     "iopub.status.idle": "2026-08-29T02:56:57.021230Z",
-     "shell.execute_reply": "2026-08-29T02:56:57.020721Z"
+     "iopub.execute_input": "2026-08-29T17:38:20.140099Z",
+     "iopub.status.busy": "2026-08-29T17:38:20.139591Z",
+     "iopub.status.idle": "2026-08-29T17:38:20.145198Z",
+     "shell.execute_reply": "2026-08-29T17:38:20.144686Z"
     },
     "papermill": {
-     "duration": 0.011792,
-     "end_time": "2026-08-29T02:56:57.021737",
+     "duration": 0.013022,
+     "end_time": "2026-08-29T17:38:20.146210",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.009945",
+     "start_time": "2026-08-29T17:38:20.133188",
      "status": "completed"
     },
     "tags": []
@@ -375,10 +375,10 @@
    "id": "6b388931",
    "metadata": {
     "papermill": {
-     "duration": 0.005118,
-     "end_time": "2026-08-29T02:56:57.030889",
+     "duration": 0.005023,
+     "end_time": "2026-08-29T17:38:20.155773",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.025771",
+     "start_time": "2026-08-29T17:38:20.150750",
      "status": "completed"
     },
     "tags": []
@@ -400,16 +400,16 @@
    "id": "48502ced",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:57.040947Z",
-     "iopub.status.busy": "2026-08-29T02:56:57.040947Z",
-     "iopub.status.idle": "2026-08-29T02:56:57.046982Z",
-     "shell.execute_reply": "2026-08-29T02:56:57.046472Z"
+     "iopub.execute_input": "2026-08-29T17:38:20.168040Z",
+     "iopub.status.busy": "2026-08-29T17:38:20.166535Z",
+     "iopub.status.idle": "2026-08-29T17:38:20.174631Z",
+     "shell.execute_reply": "2026-08-29T17:38:20.173622Z"
     },
     "papermill": {
-     "duration": 0.012555,
-     "end_time": "2026-08-29T02:56:57.046982",
+     "duration": 0.014325,
+     "end_time": "2026-08-29T17:38:20.174631",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.034427",
+     "start_time": "2026-08-29T17:38:20.160306",
      "status": "completed"
     },
     "tags": []
@@ -453,10 +453,10 @@
    "id": "ee2dc364",
    "metadata": {
     "papermill": {
-     "duration": 0.004581,
-     "end_time": "2026-08-29T02:56:57.056084",
+     "duration": 0.003995,
+     "end_time": "2026-08-29T17:38:20.184161",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.051503",
+     "start_time": "2026-08-29T17:38:20.180166",
      "status": "completed"
     },
     "tags": []
@@ -479,16 +479,16 @@
    "id": "3a6f13cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:57.066670Z",
-     "iopub.status.busy": "2026-08-29T02:56:57.066670Z",
-     "iopub.status.idle": "2026-08-29T02:56:57.578998Z",
-     "shell.execute_reply": "2026-08-29T02:56:57.578489Z"
+     "iopub.execute_input": "2026-08-29T17:38:20.195705Z",
+     "iopub.status.busy": "2026-08-29T17:38:20.195705Z",
+     "iopub.status.idle": "2026-08-29T17:38:20.717585Z",
+     "shell.execute_reply": "2026-08-29T17:38:20.715574Z"
     },
     "papermill": {
-     "duration": 0.519371,
-     "end_time": "2026-08-29T02:56:57.580005",
+     "duration": 0.529424,
+     "end_time": "2026-08-29T17:38:20.718586",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.060634",
+     "start_time": "2026-08-29T17:38:20.189162",
      "status": "completed"
     },
     "tags": []
@@ -545,10 +545,10 @@
    "id": "c83550ad",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-08-29T02:56:57.588759",
+     "duration": 0.005995,
+     "end_time": "2026-08-29T17:38:20.730097",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.584759",
+     "start_time": "2026-08-29T17:38:20.724102",
      "status": "completed"
     },
     "tags": []
@@ -566,10 +566,10 @@
    "id": "f8fd96fd",
    "metadata": {
     "papermill": {
-     "duration": 0.006255,
-     "end_time": "2026-08-29T02:56:57.601749",
+     "duration": 0.009696,
+     "end_time": "2026-08-29T17:38:20.747672",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.595494",
+     "start_time": "2026-08-29T17:38:20.737976",
      "status": "completed"
     },
     "tags": []
@@ -604,16 +604,16 @@
    "id": "f1f966ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:57.620422Z",
-     "iopub.status.busy": "2026-08-29T02:56:57.620422Z",
-     "iopub.status.idle": "2026-08-29T02:56:57.628071Z",
-     "shell.execute_reply": "2026-08-29T02:56:57.627060Z"
+     "iopub.execute_input": "2026-08-29T17:38:20.769010Z",
+     "iopub.status.busy": "2026-08-29T17:38:20.769010Z",
+     "iopub.status.idle": "2026-08-29T17:38:20.775360Z",
+     "shell.execute_reply": "2026-08-29T17:38:20.774355Z"
     },
     "papermill": {
-     "duration": 0.022513,
-     "end_time": "2026-08-29T02:56:57.629580",
+     "duration": 0.01707,
+     "end_time": "2026-08-29T17:38:20.775360",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.607067",
+     "start_time": "2026-08-29T17:38:20.758290",
      "status": "completed"
     },
     "tags": []
@@ -668,10 +668,10 @@
    "id": "6cf98027",
    "metadata": {
     "papermill": {
-     "duration": 0.010008,
-     "end_time": "2026-08-29T02:56:57.648780",
+     "duration": 0.008601,
+     "end_time": "2026-08-29T17:38:20.793625",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.638772",
+     "start_time": "2026-08-29T17:38:20.785024",
      "status": "completed"
     },
     "tags": []
@@ -692,16 +692,16 @@
    "id": "0d6c21ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:57.665871Z",
-     "iopub.status.busy": "2026-08-29T02:56:57.665871Z",
-     "iopub.status.idle": "2026-08-29T02:56:57.671902Z",
-     "shell.execute_reply": "2026-08-29T02:56:57.671394Z"
+     "iopub.execute_input": "2026-08-29T17:38:20.812747Z",
+     "iopub.status.busy": "2026-08-29T17:38:20.812216Z",
+     "iopub.status.idle": "2026-08-29T17:38:20.817107Z",
+     "shell.execute_reply": "2026-08-29T17:38:20.817107Z"
     },
     "papermill": {
-     "duration": 0.014559,
-     "end_time": "2026-08-29T02:56:57.672910",
+     "duration": 0.014644,
+     "end_time": "2026-08-29T17:38:20.818112",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.658351",
+     "start_time": "2026-08-29T17:38:20.803468",
      "status": "completed"
     },
     "tags": []
@@ -757,10 +757,10 @@
    "id": "be143188",
    "metadata": {
     "papermill": {
-     "duration": 0.009036,
-     "end_time": "2026-08-29T02:56:57.688945",
+     "duration": 0.008018,
+     "end_time": "2026-08-29T17:38:20.837135",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.679909",
+     "start_time": "2026-08-29T17:38:20.829117",
      "status": "completed"
     },
     "tags": []
@@ -783,16 +783,16 @@
    "id": "2d950604",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:57.709889Z",
-     "iopub.status.busy": "2026-08-29T02:56:57.709889Z",
-     "iopub.status.idle": "2026-08-29T02:56:57.715075Z",
-     "shell.execute_reply": "2026-08-29T02:56:57.714328Z"
+     "iopub.execute_input": "2026-08-29T17:38:20.854765Z",
+     "iopub.status.busy": "2026-08-29T17:38:20.854765Z",
+     "iopub.status.idle": "2026-08-29T17:38:20.859532Z",
+     "shell.execute_reply": "2026-08-29T17:38:20.859014Z"
     },
     "papermill": {
-     "duration": 0.017914,
-     "end_time": "2026-08-29T02:56:57.716086",
+     "duration": 0.013921,
+     "end_time": "2026-08-29T17:38:20.860076",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.698172",
+     "start_time": "2026-08-29T17:38:20.846155",
      "status": "completed"
     },
     "tags": []
@@ -845,10 +845,10 @@
    "id": "78d94316",
    "metadata": {
     "papermill": {
-     "duration": 0.009039,
-     "end_time": "2026-08-29T02:56:57.731122",
+     "duration": 0.007506,
+     "end_time": "2026-08-29T17:38:20.873483",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.722083",
+     "start_time": "2026-08-29T17:38:20.865977",
      "status": "completed"
     },
     "tags": []
@@ -868,10 +868,10 @@
    "id": "5e2dcd79",
    "metadata": {
     "papermill": {
-     "duration": 0.004541,
-     "end_time": "2026-08-29T02:56:57.740652",
+     "duration": 0.005807,
+     "end_time": "2026-08-29T17:38:20.884726",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.736111",
+     "start_time": "2026-08-29T17:38:20.878919",
      "status": "completed"
     },
     "tags": []
@@ -902,16 +902,16 @@
    "id": "1c68b88c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:57.752052Z",
-     "iopub.status.busy": "2026-08-29T02:56:57.751519Z",
-     "iopub.status.idle": "2026-08-29T02:56:57.757265Z",
-     "shell.execute_reply": "2026-08-29T02:56:57.757265Z"
+     "iopub.execute_input": "2026-08-29T17:38:20.897727Z",
+     "iopub.status.busy": "2026-08-29T17:38:20.897727Z",
+     "iopub.status.idle": "2026-08-29T17:38:20.904689Z",
+     "shell.execute_reply": "2026-08-29T17:38:20.904067Z"
     },
     "papermill": {
-     "duration": 0.013373,
-     "end_time": "2026-08-29T02:56:57.758284",
+     "duration": 0.014165,
+     "end_time": "2026-08-29T17:38:20.905333",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.744911",
+     "start_time": "2026-08-29T17:38:20.891168",
      "status": "completed"
     },
     "tags": []
@@ -998,10 +998,10 @@
    "id": "49594636",
    "metadata": {
     "papermill": {
-     "duration": 0.004519,
-     "end_time": "2026-08-29T02:56:57.767312",
+     "duration": 0.00553,
+     "end_time": "2026-08-29T17:38:20.915425",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.762793",
+     "start_time": "2026-08-29T17:38:20.909895",
      "status": "completed"
     },
     "tags": []
@@ -1025,10 +1025,10 @@
    "id": "gt06c-stat-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-08-29T02:56:57.775888",
+     "duration": 0.008228,
+     "end_time": "2026-08-29T17:38:20.928163",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.771889",
+     "start_time": "2026-08-29T17:38:20.919935",
      "status": "completed"
     },
     "tags": []
@@ -1062,16 +1062,16 @@
    "id": "gt06c-stat",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:56:57.785901Z",
-     "iopub.status.busy": "2026-08-29T02:56:57.785901Z",
-     "iopub.status.idle": "2026-08-29T02:57:28.286664Z",
-     "shell.execute_reply": "2026-08-29T02:57:28.285650Z"
+     "iopub.execute_input": "2026-08-29T17:38:20.942208Z",
+     "iopub.status.busy": "2026-08-29T17:38:20.942208Z",
+     "iopub.status.idle": "2026-08-29T17:38:46.243986Z",
+     "shell.execute_reply": "2026-08-29T17:38:46.243986Z"
     },
     "papermill": {
-     "duration": 30.506761,
-     "end_time": "2026-08-29T02:57:28.286664",
+     "duration": 25.309311,
+     "end_time": "2026-08-29T17:38:46.243986",
      "exception": false,
-     "start_time": "2026-08-29T02:56:57.779903",
+     "start_time": "2026-08-29T17:38:20.934675",
      "status": "completed"
     },
     "tags": []
@@ -1330,10 +1330,10 @@
    "id": "gt06c-stat-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.00519,
-     "end_time": "2026-08-29T02:57:28.298261",
+     "duration": 0.005509,
+     "end_time": "2026-08-29T17:38:46.256703",
      "exception": false,
-     "start_time": "2026-08-29T02:57:28.293071",
+     "start_time": "2026-08-29T17:38:46.251194",
      "status": "completed"
     },
     "tags": []
@@ -1368,10 +1368,10 @@
    "id": "018b05f4",
    "metadata": {
     "papermill": {
-     "duration": 0.005512,
-     "end_time": "2026-08-29T02:57:28.309777",
+     "duration": 0.006001,
+     "end_time": "2026-08-29T17:38:46.268215",
      "exception": false,
-     "start_time": "2026-08-29T02:57:28.304265",
+     "start_time": "2026-08-29T17:38:46.262214",
      "status": "completed"
     },
     "tags": []
@@ -1425,10 +1425,10 @@
    "id": "05bc3879",
    "metadata": {
     "papermill": {
-     "duration": 0.006521,
-     "end_time": "2026-08-29T02:57:28.321843",
+     "duration": 0.007,
+     "end_time": "2026-08-29T17:38:46.281901",
      "exception": false,
-     "start_time": "2026-08-29T02:57:28.315322",
+     "start_time": "2026-08-29T17:38:46.274901",
      "status": "completed"
     },
     "tags": []
@@ -1450,16 +1450,16 @@
    "id": "14b6cd76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:57:28.335593Z",
-     "iopub.status.busy": "2026-08-29T02:57:28.335593Z",
-     "iopub.status.idle": "2026-08-29T02:57:28.340297Z",
-     "shell.execute_reply": "2026-08-29T02:57:28.339292Z"
+     "iopub.execute_input": "2026-08-29T17:38:46.296305Z",
+     "iopub.status.busy": "2026-08-29T17:38:46.295306Z",
+     "iopub.status.idle": "2026-08-29T17:38:46.299448Z",
+     "shell.execute_reply": "2026-08-29T17:38:46.299448Z"
     },
     "papermill": {
-     "duration": 0.014433,
-     "end_time": "2026-08-29T02:57:28.341806",
+     "duration": 0.013039,
+     "end_time": "2026-08-29T17:38:46.301270",
      "exception": false,
-     "start_time": "2026-08-29T02:57:28.327373",
+     "start_time": "2026-08-29T17:38:46.288231",
      "status": "completed"
     },
     "tags": []
@@ -1485,10 +1485,10 @@
    "id": "0bed58b7",
    "metadata": {
     "papermill": {
-     "duration": 0.006014,
-     "end_time": "2026-08-29T02:57:28.358442",
+     "duration": 0.006189,
+     "end_time": "2026-08-29T17:38:46.314127",
      "exception": false,
-     "start_time": "2026-08-29T02:57:28.352428",
+     "start_time": "2026-08-29T17:38:46.307938",
      "status": "completed"
     },
     "tags": []
@@ -1510,16 +1510,16 @@
    "id": "d3030f4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:57:28.370042Z",
-     "iopub.status.busy": "2026-08-29T02:57:28.370042Z",
-     "iopub.status.idle": "2026-08-29T02:57:28.374561Z",
-     "shell.execute_reply": "2026-08-29T02:57:28.374051Z"
+     "iopub.execute_input": "2026-08-29T17:38:46.325950Z",
+     "iopub.status.busy": "2026-08-29T17:38:46.325950Z",
+     "iopub.status.idle": "2026-08-29T17:38:46.330207Z",
+     "shell.execute_reply": "2026-08-29T17:38:46.329200Z"
     },
     "papermill": {
-     "duration": 0.011618,
-     "end_time": "2026-08-29T02:57:28.375568",
+     "duration": 0.01108,
+     "end_time": "2026-08-29T17:38:46.330207",
      "exception": false,
-     "start_time": "2026-08-29T02:57:28.363950",
+     "start_time": "2026-08-29T17:38:46.319127",
      "status": "completed"
     },
     "tags": []
@@ -1546,10 +1546,10 @@
    "id": "0b8a91fe",
    "metadata": {
     "papermill": {
-     "duration": 0.007089,
-     "end_time": "2026-08-29T02:57:28.388654",
+     "duration": 0.01103,
+     "end_time": "2026-08-29T17:38:46.351150",
      "exception": false,
-     "start_time": "2026-08-29T02:57:28.381565",
+     "start_time": "2026-08-29T17:38:46.340120",
      "status": "completed"
     },
     "tags": []
@@ -1571,16 +1571,16 @@
    "id": "ef48bd0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T02:57:28.402286Z",
-     "iopub.status.busy": "2026-08-29T02:57:28.402286Z",
-     "iopub.status.idle": "2026-08-29T02:57:28.406306Z",
-     "shell.execute_reply": "2026-08-29T02:57:28.406306Z"
+     "iopub.execute_input": "2026-08-29T17:38:46.372589Z",
+     "iopub.status.busy": "2026-08-29T17:38:46.372079Z",
+     "iopub.status.idle": "2026-08-29T17:38:46.376301Z",
+     "shell.execute_reply": "2026-08-29T17:38:46.375788Z"
     },
     "papermill": {
-     "duration": 0.012665,
-     "end_time": "2026-08-29T02:57:28.407315",
+     "duration": 0.015605,
+     "end_time": "2026-08-29T17:38:46.377388",
      "exception": false,
-     "start_time": "2026-08-29T02:57:28.394650",
+     "start_time": "2026-08-29T17:38:46.361783",
      "status": "completed"
     },
     "tags": []
@@ -1607,10 +1607,10 @@
    "id": "fb275714",
    "metadata": {
     "papermill": {
-     "duration": 0.006,
-     "end_time": "2026-08-29T02:57:28.420828",
+     "duration": 0.007734,
+     "end_time": "2026-08-29T17:38:46.394260",
      "exception": false,
-     "start_time": "2026-08-29T02:57:28.414828",
+     "start_time": "2026-08-29T17:38:46.386526",
      "status": "completed"
     },
     "tags": []
@@ -1676,14 +1676,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 33.317355,
-   "end_time": "2026-08-29T02:57:28.777690",
+   "duration": 28.04641,
+   "end_time": "2026-08-29T17:38:46.647423",
    "environment_variables": {},
    "exception": null,
-   "input_path": "GameTheory-06c-RepeatedGames-FolkTheorem.ipynb",
-   "output_path": "GameTheory-06c-RepeatedGames-FolkTheorem.ipynb",
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-06c-RepeatedGames-FolkTheorem.ipynb",
    "parameters": {},
-   "start_time": "2026-08-29T02:56:55.460335",
+   "start_time": "2026-08-29T17:38:18.601013",
    "version": "2.6.0"
   }
  },

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6c-repeatedgames-folktheorem.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6c-repeatedgames-folktheorem.yaml
@@ -71,6 +71,13 @@
       csharp_sha: f880929979f9904c887c79be8b39febd95a83a8c
       content_python_sha: f873c80f5f8fd8e92d15b0c294e39f1da8020aae7581b2a9be77f08e3fdc5ff4
       content_csharp_sha: a9c2683300f3834ef94023c142ce1741569d1580d93cc01fec5134e3ebd07f25
+    - date: "2026-08-29"
+      by: myia-po-2026:CoursIA
+      python_sha: ae3dda4dda933cd53642a8c7a686b4dbfc5a47f3
+      csharp_sha: 047acbda3706e65b8646327e025a7df8b0d8d174
+      content_python_sha: 67166e3dffe4084bf23da95a309583368d8d6d7b62ca95096f954216bfb8d30c
+      content_csharp_sha: 86532bf20f3f1ec07581367c98841c67926ca368d260f72e0642038f4822918a
+      reason: "Audit de PAIRE #13497 : les deux blob SHA mesures par git ls-tree sur le MEME arbre de tete de branche (post-rebase sur 700748f9a = merge de #13081 -- la premiere passe, faite sur base stale 33 cellules/13 code, aurait reverte la section 8 statique comparative et a ete rejouee). Entree appuyee sur une re-execution reelle des DEUX cotes sous ce head : Python papermill kernel python3 36 cellules / 14 code, 14/14 executes, 0 erreur ; C# nbclient kernel .net-csharp 22 cellules / 9 code, 9/9, 0 erreur. Sources byte-identiques (0 cellule modifiee), textes d'outputs et PNG identiques aux valeurs commitees (verifie cellule par cellule) ; le diff = bloc papermill frais + metadata language_info + metadata de cellules. L entree precedente (30eef0a9/f8809299, PR #13081) enregistrait le csharp SHA de main sans re-executer ce cote -- le motif exact que #13497 demande de cesser. Aucune normalisation outillee apres ce --update (lecon #8957)."
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Jeux repetes + Folk Theorem (grim trigger, TFT, horizon fini/infini + facteur d'escompte) portes from-scratch par les deux jumeaux (Python matplotlib.patches.Polygon pour le quadrilatere des paiements faisables, C# BCL pure ASCII art 0 NuGet). Numerique pur des deux cotes -- ni nashpy, ni scipy, ni aucun moteur theorie des jeux dans l'un ou l'autre ecosysteme. Les DEUX cotes implementent les MEMES strategies repetitives en from-scratch -- la portabilite cross-lang est dans la specification formelle (Aumann 1959, Fudenberg-Maskin 1986). Verdict SOTA-OK (solver-free by design des deux cotes, ASCII art pedagogique du cote C# = choix pedagogique assumme, asymetrie medium de visualisation preservee, aucune asymetrie de couverture moteur a corriger)."
   known_differences:


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/guard #13481

Closes #13497

## L'audit de paire (acceptance 1)

Entrée du registre `twin_pairs.d` appuyée sur une **re-exécution réelle des DEUX twins sous le même arbre de tête**. Les entrées précédentes de `gametheory-6c-repeatedgames-folktheorem.yaml` enregistraient le SHA du côté non re-exécuté depuis main sans l'exécuter (motif « C# twin inchange (au SHA main) » dans les reasons des 2026-08-28/29, et encore dans l'entrée du 2026-08-29 issue de #13081 : `csharp_sha` = SHA de main, ce côté jamais re-exécuté).

Nouvelle entrée d'audit (append-only, via `check_twin_parity.py --update`, puis `reason:` documentant l'audit) :

- `python_sha: ae3dda4d…` et `csharp_sha: 047acbda…` — **les deux mesurés par `git ls-tree` sur le même arbre de tête de branche** (les notebooks committés en premier, le registre ensuite — leçon twin-rebaseline : `--update` lit HEAD, pas le worktree).
- `reason` complet dans le yaml : re-exec des deux côtés, diff purement exécutionnel, écart de la passe stale documenté.

**Rebase mid-flight** : ma première passe avait été exécutée sur une base stale (twin Python 33 cellules/13 code) lorsque le merge `700748f9a` (#13081 — ma propre PR lane, section 8 statique comparative, → 36 cellules/14 code) a atterri. Garder cette passe aurait **reverté #13081** : la branche a été rebasée sur le main frais et l'exécution rejouée sur le contenu 36/14. Le conflit d'append sur le yaml (l'entrée #13081 à la même position) a été résolu en conservant les deux entrées.

## EXEC_PROVED (acceptance 2)

| twin | méthode | résultat |
|---|---|---|
| Python (36 cellules, 14 code — état post-#13081) | papermill kernel `python3` (le twin porte un bloc `metadata.papermill` → re-exec via papermill, sortie sanctionnée du ratchet) | **14/14 cellules exécutées, 0 erreur** |
| C# (22 cellules, 9 code) | nbclient kernel `.net-csharp`, `allow_errors=False` | **9/9 cellules exécutées, 0 erreur** |

Extrait des outputs réels : PY cell7 `delta=0.3 : formule g/(1-d)= 4.2857 | somme tronquee= 4.2857` ; PY cell5 `Horizon fini N = 10 tours (delta=1)` ; CS cell3 matrice de gain `[[3, 0] [5, 1]]`.

**Stabilité vérifiée cellule par cellule** (audit sémantique vs HEAD, sur la base rebasee) : 0 cellule source modifiée, 0 cellule à texte d'output différent, 0 PNG différent — les valeurs calculées sont identiques aux valeurs committées sur main. La nature du diff : bloc `metadata.papermill` frais + `language_info` + metadata de cellules. Aucune normalisation outillée après le `--update` (leçon #8957 : rebaseline en dernier).

## Balayage daté du registre (acceptance 3)

Mesure datée **2026-08-29T19:45Z** (historique frais, incluant #13081 et les merges registre du jour), 919 entrées d'audit / 157 paires du registre. Méthode : pour chaque entrée, le couple (`python_sha`, `csharp_sha`) a-t-il co-existé à un même commit ? (`git log --all --format=%H -- <py> <cs>` + `git ls-tree` par commit ; contre-vérification indépendante `git cat-file -e` sur l'ODB).

| verdict | entrées | lecture |
|---|---|---|
| **CO_PRESENT** | 792 (86 %) | le couple a co-existé à au moins un commit reachable |
| **DISJOINT** | **4** | les deux blobs existent mais le couple n'a **jamais** co-existé — le motif croisé exact de l'issue |
| hors-historique-reachable | 123 | 113 couples + 6 py + 4 cs absents du scan `--all` ; contre-vérif cat-file : **10 seulement** ont un blob absent de l'ODB entier |

**Les 4 DISJOINT** — la forme *textuelle* forte du motif croisé (le couple enregistré n'a jamais co-existé à aucun commit ; à GT-06c le motif était la forme *exécution* : couple co-présent textuellement mais un côté jamais re-exécuté) :

- `gametheory-15-cooperativegames.yaml` [0] — 2026-08-21
- `ml-3-entrainement-automl.yaml` [8] — 2026-08-16
- `sudoku-15-infer.yaml` [14] — 2026-08-21
- `tweety-2-basic-logics.yaml` [5] — 2026-08-17

**Verdict classe vs cas isolé : petite classe, pas un cas isolé.** Le motif croisé (audit enregistré sans exécution réelle des deux côtés sous un même head) existait donc sous deux formes : textuelle (4 paires DISJOINT) et exécution (GT-06c, et potentiellement d'autres CO_PRESENT non exécution-backed — seule la lecture des reasons trancherait, hors scope de la mesure mécanique).

Les 123 « hors-historique » sont majoritairement des états de branches pré-squash (blobs présents en ODB/reflog mais dans aucun commit reachable — `--all` exclut le reflog) : conséquence du workflow squash, pas nécessairement des attestations fausses. Les **10 absents de l'ODB** attestent des états jamais committés du tout sur ce clone (spot-check : GT-6c entrée du 2026-08-28, `py=82d340a8…` inexistant en cat-file alors que son `cs=2ff2ee84…` existe).

**Suivi suggéré** (hors scope de cette PR) : re-baseler les 4 paires DISJOINT par le même audit de paire same-head que celui livré ici — une entrée par paire suffit à les faire passer CO_PRESENT.

## Verdict schéma (acceptance 4)

Le format `audits:` append-only représente **nativement** l'audit de paire : les deux SHA dans une seule entrée, mesurés sous un même commit. La contemporanéité reste vérifiable ex-post par `git ls-tree`/`git log --all --find-object` (c'est ce que fait le balayage ci-dessus). **Aucun changement de schéma nécessaire.**

## Gates locaux (pré-push)

- `check_twin_parity.py --check --per-pair --base origin/main` : **157 paires, 156 OK, INTRO=0, PRE=1** — le PRE est `ML-5 TimeSeries` (base=DRIFT head=DRIFT : dérive préexistante sur main, non touchée par cette PR).
- `check_papermill_ratchet.py origin/main` : exit 0 (OUTPUTS_UNCHANGED python / BLOCK_REMOVED csharp = sorties sanctionnées — les outputs du twin Python sont restés identiques à ceux committés par #13081, seul le bloc papermill a bougé).

## Périmètre

Trois fichiers : les deux twins GT-06c (re-exécution, sources inchangées) + l'entrée d'audit du registre. Rien d'autre.
