### PR TITLE
fix(git,#13493): Video 01-3 — 4 CR isoles retires du blob (classe vide apres)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb
@@ -352,7 +352,7 @@
    "cell_type": "markdown",
    "id": "408034c1",
    "metadata": {},
-   "source": [    "### Lecture\n",
+   "source": [    "### Lecture\n",
     "\n",
     "La cellule d'import guards ci-dessus établit l'inventaire complet des dépendances de la section 1 : **11/13 dépendances disponibles**, les deux manquantes (`anthropic`, `cv2`) étant hors du chemin d'exécution de ce notebook — aucun appel Anthropic n'est effectué et la lecture vidéo passe par decord — ce que l'exécution end-to-end de ce run confirme (3/3 analyses réussies sans elles). Les bibliothèques effectivement requises pour piloter Qwen2.5-VL en local (openai, transformers, torch, imageio, etc.) sont présentes. Le helper GenAI est importé sans erreur, et le bloc qui suit charge le fichier `.env` depuis `MyIA.AI.Notebooks/GenAI/.env` — le chemin canonique dans la convention Papermill-safe du dépôt, pas un chemin absolu de machine. Les en-têtes du notebook sont rendus : titre `Qwen2.5-VL Video Analysis`, date du jour, mode `interactive`, modèle déclaré `Qwen/Qwen2.5-VL-7B-Instruct`, paramètre `max_frames = 16` (compromis mémoire / couverture temporelle) et device `cuda` (le GPU RTX 3070 hôte a été sélectionné). Aucune dépendance n'a été installée en mode dégradé : le pipeline accède directement au moteur réel, sans contournement.\n",
     "\n",
@@ -381,7 +381,7 @@
    "cell_type": "markdown",
    "id": "00283bc7",
    "metadata": {},
-   "source": [    "### Lecture\n",
+   "source": [    "### Lecture\n",
     "\n",
     "La cellule de chargement `.env` charge aussi le profil GPU — la trace rendue par le bloc `--- VERIFICATION GPU ---` confirme le profil matériel du contexte d'exécution : carte **NVIDIA GeForce RTX 3070 Laptop GPU**, mémoire **8.0 GB** totale, **8.0 GB** libres au moment de la requête, version CUDA **12.6**, et PyTorch compilé avec `2.13.0+cu126` (build cohérent avec le CUDA toolkit, condition nécessaire pour les kernel cudaMallocAsync). Le device final sélectionné est `cuda` : le seuil de repli CPU pur de cette cellule (VRAM < 4 GB) n'est pas franchi, donc pas de fallback silencieux — mais la carte étant à 8 GB, le chargement qui suit est **hybride** : `device_map=\"auto\"` répartit les blocs du modèle entre GPU et RAM CPU (mesure sur ce matériel : 8 blocs GPU / 25 blocs CPU). La précision de calcul est `bfloat16` — le format natif du modèle Qwen2.5-VL, qui divise la taille des tenseurs par deux par rapport à fp32. Compatible avec la classe Qwen2_5_VLCausalLMOutputWithPast.\n",
     "\n",
@@ -1876,7 +1876,7 @@
     },
     "tags": []
    },
-   "source": [    "## Comparaison GPT-5 vs Qwen2.5-VL\n",
+   "source": [    "## Comparaison GPT-5 vs Qwen2.5-VL\n",
     "\n",
     "### Contexte d'exécution (mesuré sur ce notebook, cellules 8 et 24)\n",
     "\n",
@@ -2087,7 +2087,7 @@
    "cell_type": "markdown",
    "id": "295a8320",
    "metadata": {},
-   "source": [    "### Lecture\n",
+   "source": [    "### Lecture\n",
     "\n",
     "La cellule de statistiques en fin de notebook enregistre la trace complète de cette exécution : date `2026-08-28 13:20:51`, modèle effectivement instancié `Qwen/Qwen2.5-VL-7B-Instruct`, device utilisé `cuda` en mode hybride (le checkpoint bf16 dépasse les 8 Go de la RTX 3070 Laptop : `device_map=\"auto\"` garde 8 blocs sur GPU et décharge 25 blocs sur CPU), VRAM actuelle `4.9 GB` (modèle encore résident au moment de la mesure, après les 3 analyses), VRAM pic `6.0 GB` (`torch.cuda.max_memory_allocated`, cellule 24). Le compteur `Analyses reussies : 3/3` correspond aux trois passes mesurées en cellule 24 (Description globale `992.3 s` / 512 tokens, OCR video `544.7 s` / 256 tokens, Temporal grounding `160.0 s` / 76 tokens — total `1697.0 s` et `844 tokens`). Les résultats sont sauvegardés dans `qwen_vl_analysis_20260828_132051.json` — c'est l'artefact d'export qui permet à des notebooks en aval de recharger les analyses sans relancer l'inférence.\n",
     "\n",


### PR DESCRIPTION
## Sujet

Renormalisation 4 octets : les 4 CR **isoles** (0 paire CRLF, motif `"source": [\r` sur 4 cellules markdown) du blob de `GenAI/Video/01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb` sont retires. Une PR separee, strictement vide en contenu, conformement a #13493.

## Balayage de classe (acceptance de l'issue, compte cite)

Methode autoritaire (comptage d'octets bruts en python sur `git show origin/main:<f>`, cf le piege od/grep documente par po-2026) sur **origin/main `61db2e1135`** :

- **1186** `.ipynb` tracks
- **1** fichier avec byte CR dans le blob : celui-ci (4 CR)
- **0** paire CRLF — donc hors mecanisme de boucle-M perpetuelle, mais matche la recette de detection de l'issue (CR brut sous `eol=lf`)
- Apres cette PR : **0** `.ipynb` avec CR dans le blob sur main

Etat historique : le fichier nomme par l'issue (TTS 04-7) etait deja renormalise par #13377 (`6bac2bc0a`) ; le sweep de po-2026 a `81684122e` (0 CR) etait exact a ce ref — les 4 CR sont apparus depuis dans le travail Video recent.

## Preuve d'innocuite (recette exigee par l'issue)

```
python: raw.count(b'\r') == 4, raw.count(b'\r\n') == 0
cleaned = raw.replace(b'"source": [\r', b'"source": [')
json.dumps(json.loads(raw), sort_keys=True) == json.dumps(json.loads(cleaned), sort_keys=True) -> True
246528 -> 246524 octets (-4)
```

JSON identique avant/apres. **Pas de re-execution** : les 4 octets touches sont des fins de ligne dans des cellules markdown (exception C.2 markdown-only ; re-executer rendrait la preuve de non-changement impossible, l'issue l'interdit explicitement).

## Verification post-merge suggeree

```
git ls-files -z '*.ipynb' | xargs -0 -I{} sh -c 'git show HEAD:{} | grep -qU $'"'"'\r'"'"' && echo {}'
# attendu : sortie vide
```

See #13493 (le fichier nomme par l'issue est resolu par #13377 ; cette PR vide le dernier membre de la classe — cloture du cote coordinateur avec l'etat complet).

---
Grain: LIGHT/tooling -- lane myia-po-2023:CoursIA-2 -- prev: MED/guard #13463 (renormalisation 4 octets + balayage de classe, hors re-exec)
