### PR TITLE
fix(scanner): un numero de section cite dans un lien markdown n'est pas une mesure (34 FP)

### DIFF
--- a/scripts/notebook_tools/scan_quant_classify.py
+++ b/scripts/notebook_tools/scan_quant_classify.py
@@ -288,6 +288,40 @@ GLOBAL_SEED_CALL_RE = re.compile(
 # --------------------------------------------------------------------------- #
 
 
+# --------------------------------------------------------------------------- #
+#  #13534 : un numero de section cite dans un lien n'est pas une mesure
+# --------------------------------------------------------------------------- #
+
+# Un renvoi inter-notebooks -- [2.6 clustering & acp](2.6-clustering-kmeans-pca.ipynb)
+# -- porte un numero de SECTION, pas une grandeur susceptible de deriver d'une machine
+# a l'autre : precisement ce que les classes drainables (MACHINE-DEP / ENV-DEP /
+# STOCHASTIQUE-NON-SEEDEE) existent pour capturer. La classe (c) section-number du
+# cablage v4 reconnait deja ces numeros HORS lien ; elle n'atteint pas l'interieur de
+# la syntaxe [..](..), ou le meme numero apparait DEUX fois (label et cible).
+#
+# Mesure ai-01 2026-08-29 sur le corpus reel d'origin/main (49 notebooks) :
+#   aucun filtre .......................... 210  -> franchit `< 209`, CI rouge
+#   liens markdown seuls .................. 183  -> vert, marge 26
+# Sur les 4 findings du notebook ajoute par #13006 qui ont fait franchir le cliquet,
+# 2 sont des numeros de section dans des liens ; ce masque les retire.
+#
+# Deux regles voisines ont ete MESUREES puis ECARTEES, et ne doivent pas etre
+# rajoutees sans nouvelle mesure :
+#   - masquer les blocs ``` fermes : 183 aussi, exactement +0 finding.
+#   - masquer les spans de code inline : descend a 157, mais masque de VRAIES mesures
+#     que le scanner existe pour trouver -- p.ex. la divergence numpy/torch de
+#     3.3-Regularisation, "fraction de zeros : 0.4014 (numpy) et 0.4007 (torch)", ou
+#     les backticks sont de la TYPOGRAPHIE, pas du code.
+#
+# On masque AVANT la classification, sans toucher a la classification elle-meme.
+_MD_LINK_RE = re.compile(r"\[[^\]\n]*\]\([^)\n]*\)")
+
+
+def _non_measurement_spans(text: str) -> list[tuple[int, int]]:
+    """Spans ou un nombre est une reference, jamais une mesure (#13534)."""
+    return [(m.start(), m.end()) for m in _MD_LINK_RE.finditer(text)]
+
+
 QUANT_CLASSES = ("STRUCTUREL", "MACHINE-DEP", "ENV-DEP", "STOCHASTIQUE-NON-SEEDEE")
 
 
@@ -621,10 +655,14 @@ def analyze_notebook_quant(path: str | os.PathLike) -> NotebookQuantClasses:
         # PRJ42, semver simplifie stricte, etc.) — mais on doit scanner le
         # texte brut pour les versions, donc on **re-scan** avec nos propres
         # regex par-dessus les nombres deja extraits.
+        skip_spans = _non_measurement_spans(text)
         for m in re.finditer(
             r"(?<![A-Za-z0-9_])-?\d+(?:[.,]\d+)?(?:[eE][-+]?\d+)?(?![A-Za-z0-9_])",
             text,
         ):
+            # #13534 : numero de section dans un lien -> pas une mesure.
+            if any(s <= m.start() < e for s, e in skip_spans):
+                continue
             raw = m.group(0)
             v = _parse_fr_number(raw)
             if v is None:

--- a/scripts/notebook_tools/tests/test_scan_quant_classify.py
+++ b/scripts/notebook_tools/tests/test_scan_quant_classify.py
@@ -1560,3 +1560,57 @@ class TestV8ModeledMinuteIntegration:
         assert len(machine_dep) >= 1, (
             f"genuine runtime min doit rester MACHINE-DEP, got {result.by_class}"
         )
+
+
+# --------------------------------------------------------------------------- #
+#  #13534 — masque des liens markdown, et contrôle positif contre le sur-filtrage
+# --------------------------------------------------------------------------- #
+class TestMarkdownLinkNotAMeasurement:
+    """Un numéro de section cité dans un lien n'est pas une mesure (#13534).
+
+    Le premier test vérifie que le masque mord. Les deux suivants sont des
+    CONTRÔLES POSITIFS : sans eux, élargir le masque jusqu'à tout supprimer
+    passerait le premier test et viderait le scanner de sa fonction.
+    """
+
+    def _write_nb(self, tmp_path, source, name="t.ipynb"):
+        p = tmp_path / name
+        p.write_text(
+            json.dumps({"cells": [{"cell_type": "markdown", "source": [source]}]}),
+            encoding="utf-8",
+        )
+        return analyze_notebook_quant(p)
+
+    def test_section_number_in_link_is_masked(self, tmp_path):
+        """Le numéro apparaît deux fois (label ET cible) et n'est pas une grandeur."""
+        result = self._write_nb(
+            tmp_path,
+            "Le [2.6 clustering & acp](2.6-clustering-kmeans-pca.ipynb) enseigne l'acp.\n",
+        )
+        drainable = sum(v for k, v in result.by_class.items() if k != "STRUCTUREL")
+        assert drainable == 0, f"lien markdown -> aucun drainable, got {result.by_class}"
+
+    def test_version_outside_link_still_detected(self, tmp_path):
+        """CONTRÔLE POSITIF : hors lien, une version d'environnement reste ENV-DEP."""
+        result = self._write_nb(
+            tmp_path,
+            "Environnement teste : python 3.11.4 sur la machine de reference.\n",
+        )
+        assert result.by_class.get("ENV-DEP", 0) >= 1, (
+            f"une version hors lien doit rester drainable, got {result.by_class}"
+        )
+
+    def test_value_in_backticks_still_detected(self, tmp_path):
+        """CONTRÔLE POSITIF : les backticks sont de la typographie, pas du code.
+
+        Masquer les spans inline `...` ferait tomber le corpus de 183 à 157, mais
+        supprimerait cette divergence numpy/torch — exactement ce que le scanner
+        existe pour trouver. Variante mesurée puis écartée le 2026-08-29.
+        """
+        result = self._write_nb(
+            tmp_path,
+            "Fraction de zeros : `0.4014` (numpy) et `0.4007` (torch).\n",
+        )
+        assert result.by_class.get("ENV-DEP", 0) >= 1, (
+            f"une mesure entre backticks doit rester drainable, got {result.by_class}"
+        )


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-ai-01:CoursIA -- prev: MED/test #13538

## Ce que ce n'est pas

**Ce n'est pas le correctif du rouge.** [#13538](https://github.com/jsboige/CoursIA/pull/13538) l'a
regle, et son diagnostic est le bon : la borne 209 avait ete mesuree le 2026-08-08 sur les
**28** notebooks d'alors, et le test la comparait au corpus **entier** d'aujourd'hui (49). Le
corpus a grandi ; le cablage n'a pas regresse. Rien ici ne revient la-dessus.

## Le defaut qui reste en dessous

Le scanner compte un numero de **section** cite dans un lien comme une **mesure** :

```
Le [2.6 clustering & acp](2.6-clustering-kmeans-pca.ipynb) enseigne l'acp.
```

`2.6` y apparait deux fois — label **et** cible — et ressort en `STOCHASTIQUE-NON-SEEDEE`. Ce
n'est pas une grandeur susceptible de deriver d'une machine a l'autre, ce que les classes
drainables existent pour capturer. La classe (c) *section-number* du cablage v4 reconnait deja
ces numeros **hors** lien ; elle n'atteint pas l'interieur de la syntaxe `[..](..)`.

## Mesure firsthand (origin/main @ `a72ce1b2c`)

| corpus | avant | apres | FP retires |
|---|---|---|---|
| ML/DataScienceWithAgents — entier (49 nb) | 210 | **183** | 27 |
| Search/Part1-Foundations — entier (31 nb) | 189 | **182** | 7 |
| cohorte epinglee ML/DfA (28 nb) | 68 | 63 | — |
| cohorte epinglee Search (29 nb) | 176 | 169 | — |

Les quatre assertions de cliquet restent vertes, **bornes inchangees**. 104 tests passent.

## Deux regles voisines mesurees puis ecartees

Elles sont consignees dans le commentaire du code pour qu'on ne les rajoute pas sans mesure :

- **masquer les blocs ` ``` ` fermes** : 183 aussi — exactement **+0** finding.
- **masquer les spans de code inline** : descend a 157, mais supprime de **vraies** mesures.
  Contre-exemple qui a refute cette variante, dans `3.3-Regularisation` :

  > **fraction de zeros** : `0.4014` (numpy) et `0.4007` (torch) pour une cible de `0.4000`

  Les backticks y sont de la **typographie**, pas du code — et cette divergence numpy/torch est
  precisement ce que le scanner existe pour trouver.

C'est cette variante-la que j'avais ecrite en premier. Ce qui l'a refutee est l'echantillonnage
des 69 findings qu'elle masquait, pas un raisonnement.

## Pourquoi trois tests et pas un

`test_section_number_in_link_is_masked` verifie que le masque mord. Les deux autres sont des
**controles positifs** : sans eux, elargir le masque jusqu'a tout supprimer passerait le premier
test et viderait le scanner de sa fonction.

## Ce que je n'affirme pas

Je n'ai pas relu les 34 findings retires un par un — j'en ai echantillonne 12, tous des renvois
inter-notebooks. Si un reviewer veut la liste exhaustive avant de merger, elle est reproductible
en desactivant `_non_measurement_spans`.

Aucune urgence : le rouge est deja regle. A merger sur le fond, pas sur le calendrier.

