### PR TITLE
fix(tooling,#13535): accord de langue cardinal/nom — « une file » n'est plus « 1 fichier »

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -108,18 +108,37 @@ PLURAL_PAREN = re.compile(r"^\s*\(s\)\s*")
 # range we fail loud (false-negative default -- the next body with "onze
 # fichiers" / "eleven files" will be caught by a reviewer and the mapping
 # expanded). Closed list = false-negative cost is bounded and visible.
-COUNT_WORDS = {
-    "un": 1, "une": 1,
-    "deux": 2, "two": 2,
-    "trois": 3, "three": 3,
-    "quatre": 4, "four": 4,
-    "cinq": 5, "five": 5,
-    "six": 6, "six": 6,
-    "sept": 7, "seven": 7,
-    "huit": 8, "eight": 8,
-    "neuf": 9, "nine": 9,
-    "dix": 10, "ten": 10,
+#
+# #13535 accord de langue : le cardinal et le nom doivent concorder. Le
+# singulier anglais "file" est aussi un mot francais courant (« file
+# d'attente ») : sans accord, un corps francais qui parle d'une file de CI
+# produisait le bigramme « une file », lu comme <cardinal> <noun> = 1 fichier,
+# et le garde bloquant sur-accusait une phrase sans rapport (#13499 : « le
+# meme verdict sur une file qui avance et sur une file figee » -> FAIL
+# pretendu 1 fichier, liste effective 2). Croisement FR-cardinal + EN-nom
+# n'a aucune forme legitime : on exige la meme langue des deux cotes. Le
+# chiffre (COUNT_CLAIM) reste langue-neutre. Residu assume : « six » est
+# cardinal des deux langues, donc « six files d'attente » (FR) matche quand
+# meme la lecture EN -- borne par la rarece de la forme.
+COUNT_WORDS_FR = {
+    "un": 1, "une": 1, "deux": 2, "trois": 3, "quatre": 4, "cinq": 5,
+    "six": 6, "sept": 7, "huit": 8, "neuf": 9, "dix": 10,
 }
+COUNT_WORDS_EN = {
+    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
+    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
+}
+COUNT_WORDS = {**COUNT_WORDS_FR, **COUNT_WORDS_EN}
+# Triggers pre-compiles : (mot, valeur, regex) -- FR cardinal + fichiers?,
+# EN cardinal + files?. Les trois sites consommateurs (_word_form_count,
+# extraction, body_declares_effective_count) partagent cette meme definition.
+WORD_FORM_TRIGGERS = tuple(
+    (word, n, re.compile(rf"\b{re.escape(word)}\s+fichiers?\b", re.IGNORECASE))
+    for word, n in COUNT_WORDS_FR.items()
+) + tuple(
+    (word, n, re.compile(rf"\b{re.escape(word)}\s+files?\b", re.IGNORECASE))
+    for word, n in COUNT_WORDS_EN.items()
+)
 EXCLUSIVITY_MARKERS = (
     "uniquement",
     "seulement",
@@ -753,14 +772,15 @@ def _additive_line_sum(line: str) -> int:
 
 
 def _word_form_count(text: str) -> int | None:
-    """#12092: first spelled-out cardinal followed by fichiers/files (closed
-    list COUNT_WORDS, FR/EN 1-10). None when the line carries no word-form
+    """#12092: first spelled-out cardinal followed by its language-agreeing
+    noun (closed list COUNT_WORDS, FR/EN 1-10 ; #13535 : FR cardinal +
+    fichiers?, EN cardinal + files?). None when the line carries no word-form
     count -- mirror of COUNT_CLAIM for the word shape. Reuses the exact
-    trigger pattern of extract_perimeter_assertions (~L829) so both halves
+    trigger list of extract_perimeter_assertions so both halves
     of the organ agree on what a word count is."""
     low = text.lower()
-    for word, n in COUNT_WORDS.items():
-        if re.search(rf"\b{re.escape(word)}\s+(?:fichiers?|files?)\b", low):
+    for _word, n, trig in WORD_FORM_TRIGGERS:
+        if trig.search(low):
             return n
     return None
 
@@ -1076,9 +1096,8 @@ def _extract_line_candidates(text: str) -> list[tuple[int, str]]:
         # 1-10 (see COUNT_WORDS rationale at line ~98).
         word_triggers = [
             (m, word)
-            for word in COUNT_WORDS
-            for m in re.finditer(rf"\b{re.escape(word)}\s+(?:fichiers?|files?)\b",
-                                  line, re.IGNORECASE)
+            for word, _n, trig in WORD_FORM_TRIGGERS
+            for m in trig.finditer(line)
         ]
         if word_triggers:
             # Same exclusion as numeric form: a word-form count cited inside
@@ -1457,13 +1476,9 @@ def select_candidates(
         if n_files is not None and not any(
             c.body_declares_effective_count for c in body_candidates
         ):
-            for word, n in COUNT_WORDS.items():
+            for word, n, pat in WORD_FORM_TRIGGERS:
                 if n != n_files:
                     continue
-                pat = re.compile(
-                    rf"\b{re.escape(word)}\s+(?:fichiers?|files?)\b",
-                    re.IGNORECASE,
-                )
                 if any(
                     not _is_incidental_assertion(c.text, c.context)
                     and pat.search(c.text)

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -35,6 +35,7 @@ from check_pr_perimeter import (  # noqa: E402
     _is_incidental_assertion,
     _normalize_rest_files,
     _paragraph_prefix,
+    _word_form_count,
 )
 
 # The exact shape of the founding incident (#11227).
@@ -2518,3 +2519,94 @@ def test_12718_scope_label_still_blocks():
     assert cand.blocking is True
 
 
+
+
+# ---------------------------------------------------------------------------
+# #13535 -- accord de langue cardinal/nom. « une file » (queue CI) n'est pas
+# « 1 fichier » : le garde bloquant sur-accusait toute prose francais parlant
+# de la file d'attente CI (#13499, mesure : FAIL pretendu 1 fichier, liste
+# effective 2).
+
+FILES_2_13499 = [
+    {"path": "scripts/pick_idle_grain.py", "additions": 40, "deletions": 12},
+    {"path": "scripts/tests/test_pick_idle_grain.py", "additions": 55, "deletions": 8},
+]
+
+
+def test_13535_language_agreement_positive_controls():
+    """Controles positifs : l'accord de langue preserve les vraies declarations."""
+    assert _word_form_count("Périmètre : un fichier modifié.") == 1
+    assert _word_form_count("Périmètre : trois fichiers touchés.") == 3
+    assert _word_form_count("Perimeter: one file changed.") == 1
+    assert _word_form_count("Perimeter: three files changed.") == 3
+
+
+def test_13535_queue_file_is_not_a_count():
+    """Controles negatifs : la « file » de CI n'est plus lue comme un compte."""
+    assert _word_form_count(
+        "il rend le même verdict sur une file qui avance et sur une file figée"
+    ) is None
+    assert _word_form_count("la file est figée depuis le merge") is None
+    assert _word_form_count("deux files d'attente bloquent les runners") is None
+
+
+def test_13535_digit_forms_still_asserted():
+    """La forme chiffrée reste langue-neutre, toujours extraite et confrontée :
+    compte juste -> PASS, compte faux -> FAIL avec le compte effectif."""
+    ok_fr = "Périmètre : 2 fichiers uniquement."
+    ok_en = "Perimeter: 2 files only."
+    assert extract_perimeter_assertions(ok_fr) == [ok_fr]
+    assert check_assertion(FILES_2_13499, ok_fr) == []
+    assert extract_perimeter_assertions(ok_en) == [ok_en]
+    assert check_assertion(FILES_2_13499, ok_en) == []
+    problems = check_assertion(FILES_2_13499, "Périmètre : 3 fichiers.")
+    assert problems and any("3" in p for p in problems)
+    problems = check_assertion(FILES_2_13499, "Perimeter: 3 files touched.")
+    assert problems and any("3" in p for p in problems)
+
+
+def test_13535_founder_body_13499_extracts_nothing():
+    """Fixture du corps reel de #13499 (avant reformulation) : la phrase
+    incriminee verbatim + l'enumeration des 2 fichiers reels ne produisent
+    AUCUNE assertion extraite -- le scan du corps rend VERDICT: OK.
+
+    Le replay passe par le MEME chemin que le scan CLI (select_candidates sur
+    une fausse review thread, puis confrontation de chaque candidat) : zero
+    candidat porteur d'un compte -> zero blocage -> verdict OK."""
+    body = (
+        "Le symptôme mesuré : sous cap 8, le sweep ne descend jamais dans la\n"
+        "file des vieilles PRs -- il rend le même verdict sur une file qui\n"
+        "avance et sur une file figée, donc il ne peut pas distinguer.\n"
+        "\n"
+        "**Fichiers:** scripts/pick_idle_grain.py, scripts/tests/test_pick_idle_grain.py\n"
+    )
+    assert _word_form_count(body) is None
+    found = extract_perimeter_assertions(body)
+    assert not any("file" in f.lower() for f in found), (
+        f"la prose « file d'attente » ne doit pas devenir une assertion : {found}"
+    )
+    items = [{
+        "kind": "PR body",
+        "author": "myia-po-2026",
+        "body": body,
+        "source": "body",
+        "ts": "",
+    }]
+    candidates, orphan = select_candidates(items, n_files=len(FILES_2_13499))
+    assert orphan is None
+    for cand in candidates:
+        assert check_assertion(FILES_2_13499, cand.text) == [], (
+            f"le corps de #13499 doit rester OK ; candidat {cand.text!r}"
+        )
+
+
+def test_13535_word_form_extraction_still_fires():
+    """Controle FN : une vraie declaration mot-forme reste extraite et
+    confrontee (l'accord de langue n'affaiblit pas le garde). Compte juste ->
+    PASS ; compte faux -> FAIL avec le compte effectif."""
+    line = "Périmètre : deux fichiers uniquement, aucune autre modification."
+    assert extract_perimeter_assertions(line) == [line]
+    assert check_assertion(FILES_2_13499, line) == []
+    mismatch = "Périmètre : trois fichiers uniquement, aucune autre modification."
+    problems = check_assertion(FILES_2_13499, mismatch)
+    assert problems and any("2" in p for p in problems)


### PR DESCRIPTION
## Summary

Accord de langue cardinal/nom dans le garde de périmètre (#13535) : « une **file** » (la file d'attente CI) n'est plus lu comme « 1 **fichier** ».

Le déclencheur mot-forme était `\b<cardinal>\s+(?:fichiers?|files?)\b` sur un `COUNT_WORDS` FR+EN mélangé : le cardinal et le nom pouvaient venir de langues différentes. Or le singulier EN « file » est un mot français courant (« file d'attente ») — « sur **une file** qui avance » matchait <« une », FR> + <« file », EN> et était lu comme une déclaration de périmètre « 1 fichier ». Mesuré sur #13499 : confrontation contre la liste effective de 2 fichiers → FAIL bloquant sur une prose qui ne parle pas de périmètre.

Le fix sépare les deux langues :

- `COUNT_WORDS_FR` / `COUNT_WORDS_EN` (le mot « six » existe dans les deux — les deux patterns le gardent) ;
- `WORD_FORM_TRIGGERS` précompilé : chaque cardinal ne déclenche **que** devant le nom de **sa** langue (`un|une… + fichiers?`, `one|two… + files?`) ;
- les 3 sites consommateurs migrés : `_word_form_count` (~L755), l'extraction de candidats (~L1079), `body_declares_effective_count` (~L1460).

La forme **chiffrée** (`3 fichiers` / `3 files`) reste langue-neutre et inchangée.

**Résidu accepté** : « six files d'attente » matche encore la lecture EN (le cardinal « six » existe dans les deux langues) — documenté dans le commentaire du code, jugé inévitable sans un vrai modèle de langue.

## Reproduction mesurée (avant/après, phrase fondatrice verbatim de #13499)

« il rend le même verdict sur une file qui avance et sur une file figée » confrontée à la liste effective des 2 fichiers (`pick_idle_grain.py`, `test_pick_idle_grain.py`) :

- **AVANT (origin/main)** : `extract_perimeter_assertions` → la phrase EST extraite comme assertion de périmètre ; `check_assertion` → `l'assertion pretend 1 fichier(s), la liste effective en compte 2` = le FAIL bloquant mesuré sur #13499.
- **APRÈS (cette branche)** : `extract_perimeter_assertions` → `[]` (la phrase n'est plus candidate, donc jamais confrontée) ; `_word_form_count` → `None`.

## Tests

Nouveau bloc `#13535` dans `scripts/tests/test_check_pr_perimeter.py` (5 tests) :

- **Positifs** : `un fichier`→1, `trois fichiers`→3, `one file`→1, `three files`→3 ; formes chiffrées `2 fichiers`/`2 files` toujours extraites ET confrontées (compte juste → PASS, `3 fichiers` sur liste de 2 → FAIL avec le compte effectif).
- **Négatifs** : « une file qui avance », « la file est figée », « deux files d'attente » → aucune assertion.
- **Fixture fondateur** : le corps réel de #13499 (phrase incriminée verbatim « il rend le même verdict sur une file qui avance et sur une file figée » + énumération des 2 fichiers) rejoué par le **même chemin que le scan CLI** (`select_candidates` sur une fausse review thread → confrontation de chaque candidat) : zéro candidat porteur d'un compte → zéro blocage → équivalent déterministe de `VERDICT: OK`.
- **Contrôle FN** : une vraie déclaration mot-forme reste extraite et confrontée (compte juste → PASS, faux compte → FAIL) — l'accord de langue n'affaiblit pas le garde.

`python -m pytest scripts/tests/test_check_pr_perimeter.py -q` : **144 passed** (139 avant + 5 nouveaux). Suite scripts complète : **3632 passed, 30 skipped, 5 xfailed** (aucune régression).

## Files (2)

- `scripts/check_pr_perimeter.py` — split FR/EN + `WORD_FORM_TRIGGERS`, 3 sites consommateurs
- `scripts/tests/test_check_pr_perimeter.py` — bloc #13535 (5 tests)

Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/notebook-dotnet #13518

Closes #13535
