### PR TITLE
fix(translation,#10038): completer les 2 premieres paires _en (T2/T3/T4) + cliquet 2

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot_en.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot_en.ipynb
@@ -577,7 +577,7 @@
     "tags": []
    },
    "source": [
-    "### Exercise 1: Allergy Verification Plugin\n\nThe current plugins cover follow-up questions, severity, and medications. A crucial plugin is missing: **allergy verification**. The objective is to create `AllergyPlugin`, which allows the pharmacist agent to verify whether a recommended medication is compatible with the patient's declared allergies.\n\n**Objective**: implement a class `AllergyPlugin` with a `check_allergy` method annotated with `@kernel_function` that returns a warning if the medication is incompatible with a known allergy.\n\n**Hints**:\n- # Step 1: Define a dictionary mapping allergies to contraindicated medications\n- # Step 2: Implement the `check_allergy` method with `Annotated` type annotations\n- # Hint: use the pattern of the existing plugins (DoctorPlugin, PharmacistPlugin)"
+    "### Exercise 1: Allergy Verification Plugin\n\nThe current plugins cover follow-up questions, severity, and medications. A crucial plugin is missing: **allergy verification**. The objective is to create `AllergyPlugin`, which allows the pharmacist agent to verify whether a recommended medication is compatible with the patient's declared allergies.\n\n**Objective**: implement a class `AllergyPlugin` with a `check_allergy` method annotated with `@kernel_function` that returns a warning if the medication is incompatible with a known allergy.\n\n**Hints**:\n- `# Step 1`: Define a dictionary mapping allergies to contraindicated medications\n- `# Step 2`: Implement the `check_allergy` method with `Annotated` type annotations\n- `# Hint`: use the pattern of the existing plugins (DoctorPlugin, PharmacistPlugin)"
    ]
   },
   {
@@ -872,7 +872,7 @@
     "tags": []
    },
    "source": [
-    "### Exercise 2: Adapt the prompts for a pediatric scenario\n\nThe current prompts are configured for an adult. The objective is to adapt the system for a **pediatric consultation**: the doctor must use language suited to children, the medical AI must take pediatric specifics into account (different dosage, specific vital signs), and the pharmacist must mention precautions for children.\n\n**Objective**: write the three system prompts adapted to the pediatric context.\n\n**Hints**:\n- # Step 1: Modify the doctor's prompt for language accessible to children\n- # Step 2: Adapt the medical AI prompt for pediatric dosages and signs\n- # Hint: add constraints such as \"always mention the recommended weight for dosage\""
+    "### Exercise 2: Adapt the prompts for a pediatric scenario\n\nThe current prompts are configured for an adult. The objective is to adapt the system for a **pediatric consultation**: the doctor must use language suited to children, the medical AI must take pediatric specifics into account (different dosage, specific vital signs), and the pharmacist must mention precautions for children.\n\n**Objective**: write the three system prompts adapted to the pediatric context.\n\n**Hints**:\n- `# Step 1`: Modify the doctor's prompt for language accessible to children\n- `# Step 2`: Adapt the medical AI prompt for pediatric dosages and signs\n- `# Hint`: add constraints such as \"always mention the recommended weight for dosage\""
    ]
   },
   {
@@ -1179,7 +1179,7 @@
     "tags": []
    },
    "source": [
-    "### Exercise 3: Termination strategy based on diagnosis\n\nThe current strategy stops after 6 messages. The objective is to implement a smarter strategy that detects when a **probable diagnosis** has been formulated by the medical AI (presence of words such as \"diagnostic\", \"hypothese\", \"probablement\" in the last message).\n\n**Objective**: create `DiagnosticTerminationStrategy` that stops the conversation as soon as a diagnosis is issued or after a maximum of 8 exchanges.\n\n**Hints**:\n- # Step 1: Define a list of keywords indicative of a diagnosis\n- # Step 2: Check for their presence in the content of the last message\n- # Hint: combine the diagnosis condition with a maximum exchange counter"
+    "### Exercise 3: Termination strategy based on diagnosis\n\nThe current strategy stops after 6 messages. The objective is to implement a smarter strategy that detects when a **probable diagnosis** has been formulated by the medical AI (presence of words such as \"diagnostic\", \"hypothese\", \"probablement\" in the last message).\n\n**Objective**: create `DiagnosticTerminationStrategy` that stops the conversation as soon as a diagnosis is issued or after a maximum of 8 exchanges.\n\n**Hints**:\n- `# Step 1`: Define a list of keywords indicative of a diagnosis\n- `# Step 2`: Check for their presence in the content of the last message\n- `# Hint`: combine the diagnosis condition with a maximum exchange counter"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot_en.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot_en.ipynb
@@ -59,9 +59,7 @@
     "tags": []
    },
    "source": [
-    "### Vue d'ensemble : un chatbot médical multi-agent en 3 rôles\n",
-    "\n",
-    "Ce notebook implémente une consultation médicale simulée entre trois agents LLM : un **médecin généraliste** qui pose des questions complémentaires au patient, une **IA médicale d'analyse** qui propose des hypothèses diagnostiques, et un **pharmacien** qui vérifie les interactions médicamenteuses. Le tout orchestré par un `AgentGroupChat` Semantic Kernel avec une **stratégie de terminaison** à limite d'échanges (6 messages) — la détection d'un diagnostic final par mot-clé étant laissée en exercice. Le notebook couvre les patterns : `Kernel` + `plugins` natifs, `ChatCompletionAgent`, `AgentGroupChat`, `TerminationStrategy`, et `auto function calling`. C'est un cas d'usage type pour les **synthetic clinical reasoning** où plusieurs LLM agents simulent une consultation réelle."
+    "### Overview: a 3-role multi-agent medical chatbot\n\nThis notebook implements a simulated medical consultation between three LLM agents: a **general practitioner** who asks the patient follow-up questions, a **medical analysis AI** that proposes diagnostic hypotheses, and a **pharmacist** who checks drug interactions. The whole thing is orchestrated by a Semantic Kernel `AgentGroupChat` with an **exchange-limit termination strategy** (6 messages) — detecting a final diagnosis by keyword is left as an exercise. The notebook covers the patterns: `Kernel` + native `plugins`, `ChatCompletionAgent`, `AgentGroupChat`, `TerminationStrategy`, and `auto function calling`. It is a typical use case for **synthetic clinical reasoning** where several LLM agents simulate a real consultation."
    ]
   },
   {
@@ -198,9 +196,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : imports et configuration initiale\n",
-    "\n",
-    "L'output `\"Imports OK\"` valide la chaîne complète `python-dotenv` + `semantic-kernel` + `pydantic` : trois dépendances critiques pour ce cas d'usage, et l'échec d'une seule aurait court-circuité la cellule d'imports ci-dessus (`load_dotenv()`). Le notebook utilise des **imports gardés** (try/except ImportError) dans la cellule d'imports ci-dessus — c'est un pattern défensif qui documente la disponibilité des services externes **avant** de planter en aval. L'étudiant doit reproduire ce réflexe : un import nu de `semantic_kernel` dans un clone frais sans la dépendance installée retournerait un `ModuleNotFoundError` peu explicite."
+    "### Reading the result: imports and initial configuration\n\nThe `\"Imports OK\"` output validates the full `python-dotenv` + `semantic-kernel` + `pydantic` chain: three critical dependencies for this use case, and a failure in any single one would have short-circuited the imports cell above (`load_dotenv()`). The notebook uses **guarded imports** (try/except ImportError) in the imports cell above — a defensive pattern that documents the availability of external services **before** failing downstream. The student should reproduce this reflex: a bare `import semantic_kernel` in a fresh clone without the dependency installed would return an unhelpful `ModuleNotFoundError`."
    ]
   },
   {
@@ -254,9 +250,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : variables d'environnement chargées\n",
-    "\n",
-    "`load_dotenv()` retourne `True` quand un fichier `.env` est trouvé et parsé. C'est le **premier signal** que la configuration LLM est en place : `OPENAI_API_KEY` (modèle GPT-4), `AZURE_OPENAI_ENDPOINT` (déploiement Azure AI Foundry), ou un endpoint local ComfyUI/Qwen selon la cohorte. Si l'étudiant voit `False`, le notebook échouera plus loin lors de l'instanciation du kernel (`Kernel()` sans service LLM = crash silencieux)."
+    "### Reading the result: environment variables loaded\n\n`load_dotenv()` returns `True` when a `.env` file is found and parsed. This is the **first signal** that the LLM configuration is in place: `OPENAI_API_KEY` (GPT-4 model), `AZURE_OPENAI_ENDPOINT` (Azure AI Foundry deployment), or a local ComfyUI/Qwen endpoint depending on the cohort. If the student sees `False`, the notebook will fail later when instantiating the kernel (`Kernel()` without an LLM service = silent crash)."
    ]
   },
   {
@@ -330,9 +324,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : logging structuré pour traçabilité multi-agent\n",
-    "\n",
-    "`\"Configuration des logs OK\"` valide le format `%(asctime)s [%(levelname)s] %(name)s: %(message)s` avec niveau `INFO`. C'est ce format que la cellule d'exécution de la consultation (en fin de notebook) affichera en sortie (horodatage + `[INFO] Début de la consultation médicale IA` au lancement de la consultation). Le logging **structuré** n'est pas un caprice pédagogique : sans lui, l'étudiant ne peut pas distinguer **qui parle** dans un chat à 3 agents — médecin, IA médicale ou pharmacien. Le préfixe `🚀` est un signal visuel (emoji utilisé comme tag sémantique) qui délimite les phases de l'orchestration : début de consultation, fin de tour, terminaison. L'étudiant doit noter l'horodatage (la date varie à chaque exécution) et l'ordre des événements : c'est cette trace qui valide ex-post la séquence orchestrale."
+    "### Reading the result: structured logging for multi-agent traceability\n\n`\"Configuration des logs OK\"` validates the `%(asctime)s [%(levelname)s] %(name)s: %(message)s` format at level `INFO`. This is the format the consultation execution cell (at the end of the notebook) will display as output (timestamp + `[INFO] Début de la consultation médicale IA` when the consultation starts). **Structured** logging is not a pedagogical whim: without it, the student cannot tell **who is speaking** in a 3-agent chat — doctor, medical AI, or pharmacist. The `🚀` prefix is a visual signal (emoji used as a semantic tag) that delimits the orchestration phases: consultation start, end of turn, termination. The student should note the timestamp (the date changes on every run) and the order of events: this trace is what validates the orchestral sequence after the fact."
    ]
   },
   {
@@ -412,9 +404,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : fonction factory create_kernel\n",
-    "\n",
-    "`\"Kernel Semantic Kernel créé\"` confirme l'instanciation d'un `Kernel()` vide — la `def create_kernel()` est appelée plus loin dans le notebook (`kernel = create_kernel()`). Cette **séparation définition/instanciation** est un pattern de **testabilité** : la cellule d'instanciation peut être relancée plusieurs fois sans redéfinir la fonction. Dans un notebook pédagogique, cela permet à l'étudiant de **réinstancier** un kernel frais si le précédent a accumulé des plugins contradictoires (ex. après une erreur dans une cellule précédente). Dans un projet en production, c'est l'équivalent d'une **factory pattern** classique (GoF)."
+    "### Reading the result: the create_kernel factory function\n\n`\"Kernel Semantic Kernel créé\"` confirms the instantiation of an empty `Kernel()` — the `def create_kernel()` is called further down in the notebook (`kernel = create_kernel()`). This **definition/instantiation separation** is a **testability** pattern: the instantiation cell can be re-run several times without redefining the function. In a pedagogical notebook, this lets the student **re-instantiate** a fresh kernel if the previous one accumulated contradictory plugins (e.g. after an error in an earlier cell). In a production project, it is the equivalent of a classic **factory pattern** (GoF)."
    ]
   },
   {
@@ -431,9 +421,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : kernel Semantic Kernel instancié\n",
-    "\n",
-    "La cellule ci-dessus définit `create_kernel()` — c'est la **factory du conteneur central** de Semantic Kernel. Le kernel agrège services LLM, plugins (médecin/pharmacien/allergies) et filters. Dans ce notebook, chaque agent conversationnel (médecin, IA médicale, pharmacien) **partage le même kernel** mais accède à des plugins différents via `kernel.add_plugin(DoctorPlugin(), plugin_name=\"doctor\")`. Cette mutualisation du kernel vs duplication par agent est un choix d'architecture : un seul service LLM, N personas."
+    "### Reading the result: Semantic Kernel kernel instantiated\n\nThe cell above defines `create_kernel()` — the **factory of Semantic Kernel's central container**. The kernel aggregates LLM services, plugins (doctor/pharmacist/allergies) and filters. In this notebook, each conversational agent (doctor, medical AI, pharmacist) **shares the same kernel** but accesses different plugins via `kernel.add_plugin(DoctorPlugin(), plugin_name=\"doctor\")`. Sharing the kernel instead of duplicating it per agent is an architecture choice: one LLM service, N personas."
    ]
   },
   {
@@ -555,9 +543,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : kernel et plugins opérationnels\n",
-    "\n",
-    "`\"Kernel instancie\"` puis `\"Kernel configuré avec le plugin médical\"` valident la séquence `kernel = create_kernel()` → `kernel.add_plugin(DoctorPlugin(), plugin_name=\"doctor\")`. Cette **deuxième étape** est ce qui distingue Semantic Kernel d'un simple wrapper OpenAI : le kernel **enregistre** les plugins comme tools invocables par le LLM via la couche `auto function calling`. Sans `add_plugin`, les `native functions` Python de `DoctorPlugin` seraient inaccessibles aux agents, et le LLM répondrait **sans grounding médical**."
+    "### Reading the result: kernel and plugins operational\n\n`\"Kernel instancie\"` then `\"Kernel configuré avec le plugin médical\"` validate the sequence `kernel = create_kernel()` → `kernel.add_plugin(DoctorPlugin(), plugin_name=\"doctor\")`. This **second step** is what distinguishes Semantic Kernel from a simple OpenAI wrapper: the kernel **registers** plugins as tools invocable by the LLM via the `auto function calling` layer. Without `add_plugin`, the Python `native functions` of `DoctorPlugin` would be unreachable by the agents, and the LLM would answer **without medical grounding**."
    ]
   },
   {
@@ -574,9 +560,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : plugins médicaux définis\n",
-    "\n",
-    "`\"Classe DoctorPlugin définie\"` valide que `DoctorPlugin` (questions complémentaires au patient), `MedicalAIPlugin` (analyse IA), et `PharmacistPlugin` (vérification interactions médicamenteuses) sont instanciés en mémoire. Chaque plugin expose des **native functions** Python décorées `@kernel.function_description()` que les agents peuvent invoquer via le mécanisme d'**auto function calling** de SK. Le notebook utilise 3 plugins médicaux + 1 plugin d'allergies (exercice, ci-dessous) — l'étudiant doit compléter l'`AllergyPlugin` (voir l'exercice ci-dessous). Les plugins sont l'**équivalent médical des tools en LangChain** : la Skill calling devient `function_call` côté LLM."
+    "### Reading the result: medical plugins defined\n\n`\"Classe DoctorPlugin définie\"` validates that `DoctorPlugin` (patient follow-up questions), `MedicalAIPlugin` (AI analysis), and `PharmacistPlugin` (drug interaction checks) are instantiated in memory. Each plugin exposes Python **native functions** decorated with `@kernel.function_description()` that agents can invoke via SK's **auto function calling** mechanism. The notebook uses 3 medical plugins + 1 allergy plugin (exercise, below) — the student must complete the `AllergyPlugin` (see the exercise below). Plugins are the **medical equivalent of tools in LangChain**: skill calling becomes `function_call` on the LLM side."
    ]
   },
   {
@@ -593,7 +577,7 @@
     "tags": []
    },
    "source": [
-    "### Exercise 1: Allergy Verification Plugin\n\nThe current plugins cover follow-up questions, severity, and medications. A crucial plugin is missing: **allergy verification**. The objective is to create `AllergyPlugin`, which allows the pharmacist agent to verify whether a recommended medication is compatible with the patient's declared allergies.\n\n**Objective**: implement a class `AllergyPlugin` with a `check_allergy` method annotated with `@kernel_function` that returns a warning if the medication is incompatible with a known allergy.\n\n**Hints**:\n- `# Step 1`: Define a dictionary mapping allergies to contraindicated medications\n- `# Step 2`: Implement the `check_allergy` method with `Annotated` type annotations\n- `# Hint`: use the pattern of the existing plugins (DoctorPlugin, PharmacistPlugin)"
+    "### Exercise 1: Allergy Verification Plugin\n\nThe current plugins cover follow-up questions, severity, and medications. A crucial plugin is missing: **allergy verification**. The objective is to create `AllergyPlugin`, which allows the pharmacist agent to verify whether a recommended medication is compatible with the patient's declared allergies.\n\n**Objective**: implement a class `AllergyPlugin` with a `check_allergy` method annotated with `@kernel_function` that returns a warning if the medication is incompatible with a known allergy.\n\n**Hints**:\n- # Step 1: Define a dictionary mapping allergies to contraindicated medications\n- # Step 2: Implement the `check_allergy` method with `Annotated` type annotations\n- # Hint: use the pattern of the existing plugins (DoctorPlugin, PharmacistPlugin)"
    ]
   },
   {
@@ -712,9 +696,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : prompts système configurés\n",
-    "\n",
-    "`\"Prompts medicaux configures\"` couvre les 3 rôles : `DOCTOR_PROMPT` (médecin généraliste, questions complémentaires), `AI_MEDICAL_PROMPT` (assistant IA d'analyse), `PHARMACIST_PROMPT` (vérification interactions). Chaque prompt structure la **persona + comportement attendu** : ton professionnel, refus de prescrire, demande de clarifications. C'est l'application du pattern **role prompting** (cf. [OpenAI Best Practices](https://platform.openai.com/docs/guides/prompt-engineering/tactic-ask-the-model-to-adopt-a-persona)). L'exercice sur les prompts (plus bas) invite l'étudiant à rédiger un prompt pediatric — l'ajout d'un persona spécialisé est un exercice classique de **persona engineering**."
+    "### Reading the result: system prompts configured\n\n`\"Prompts medicaux configures\"` covers the 3 roles: `DOCTOR_PROMPT` (general practitioner, follow-up questions), `AI_MEDICAL_PROMPT` (AI analysis assistant), `PHARMACIST_PROMPT` (interaction checks). Each prompt structures the **persona + expected behavior**: professional tone, refusal to prescribe, asking for clarifications. This is an application of the **role prompting** pattern (cf. [OpenAI Best Practices](https://platform.openai.com/docs/guides/prompt-engineering/tactic-ask-the-model-to-adopt-a-persona)). The prompt exercise (further down) invites the student to write a pediatric prompt — adding a specialized persona is a classic **persona engineering** exercise."
    ]
   },
   {
@@ -731,9 +713,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : passage du squelette à l'exécution\n",
-    "\n",
-    "Avec la cellule d'instanciation du kernel ci-dessus (`kernel = create_kernel()`) et la cellule d'ajout des plugins plus bas (`kernel.add_plugin(...)`), le notebook **quitte la phase de définition** pour la phase d'instanciation. Avant : on *définissait* des classes et fonctions. Après : on les *utilise*. Cette démarcation est un signal pédagogique classique en notebook : la deuxième moitié du notebook est **exécutable** (l'étudiant doit voir la consultation se dérouler), tandis que la première moitié est **structurelle** (l'étudiant peut la lire comme du code de production). Le `print(\"Kernel instancie\")` qui accompagne l'instanciation est la **trace écrite** de cette transition."
+    "### Reading the result: from skeleton to execution\n\nWith the kernel instantiation cell above (`kernel = create_kernel()`) and the plugin-addition cell further down (`kernel.add_plugin(...)`), the notebook **leaves the definition phase** for the instantiation phase. Before: we *defined* classes and functions. After: we *use* them. This demarcation is a classic pedagogical signal in notebooks: the second half of the notebook is **executable** (the student should see the consultation unfold), while the first half is **structural** (the student can read it as production code). The `print(\"Kernel instancie\")` that accompanies the instantiation is the **written trace** of this transition."
    ]
   },
   {
@@ -875,9 +855,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : stratégie de terminaison médicale\n",
-    "\n",
-    "`\"Stratégie de terminaison médicale définie\"` marque l'instanciation de `MedicalTerminationStrategy` — sous-classe de `TerminationStrategy` qui détecte la fin du chat multi-agent. Dans ce notebook, le critère de terminaison est une **limite d'échanges** : `should_terminate` retourne `True` dès que l'historique atteint 6 messages (`len(history) >= 6`) — soit 1 message patient + 5 réponses d'agents. Sans stratégie explicite, `AgentGroupChat` boucle indéfiniment. La détection d'un diagnostic par mot-clé est précisément l'**exercice** laissé à l'étudiant plus bas (`DiagnosticTerminationStrategy`). L'étudiant doit observer cette **séparation entre orchestration et logique métier** : la stratégie de terminaison est un **plugin comportemental**, pas une règle codée en dur dans le chat."
+    "### Reading the result: medical termination strategy\n\n`\"Stratégie de terminaison médicale définie\"` marks the instantiation of `MedicalTerminationStrategy` — a subclass of `TerminationStrategy` that detects the end of the multi-agent chat. In this notebook, the termination criterion is an **exchange limit**: `should_terminate` returns `True` as soon as the history reaches 6 messages (`len(history) >= 6`) — i.e. 1 patient message + 5 agent replies. Without an explicit strategy, `AgentGroupChat` loops forever. Detecting a diagnosis by keyword is precisely the **exercise** left to the student further down (`DiagnosticTerminationStrategy`). The student should observe this **separation between orchestration and business logic**: the termination strategy is a **behavioral plugin**, not a rule hard-coded into the chat."
    ]
   },
   {
@@ -894,7 +872,7 @@
     "tags": []
    },
    "source": [
-    "### Exercise 2: Adapt the prompts for a pediatric scenario\n\nThe current prompts are configured for an adult. The objective is to adapt the system for a **pediatric consultation**: the doctor must use language suited to children, the medical AI must take pediatric specifics into account (different dosage, specific vital signs), and the pharmacist must mention precautions for children.\n\n**Objective**: write the three system prompts adapted to the pediatric context.\n\n**Hints**:\n- `# Step 1`: Modify the doctor's prompt for language accessible to children\n- `# Step 2`: Adapt the medical AI prompt for pediatric dosages and signs\n- `# Hint`: add constraints such as \"always mention the recommended weight for dosage\""
+    "### Exercise 2: Adapt the prompts for a pediatric scenario\n\nThe current prompts are configured for an adult. The objective is to adapt the system for a **pediatric consultation**: the doctor must use language suited to children, the medical AI must take pediatric specifics into account (different dosage, specific vital signs), and the pharmacist must mention precautions for children.\n\n**Objective**: write the three system prompts adapted to the pediatric context.\n\n**Hints**:\n- # Step 1: Modify the doctor's prompt for language accessible to children\n- # Step 2: Adapt the medical AI prompt for pediatric dosages and signs\n- # Hint: add constraints such as \"always mention the recommended weight for dosage\""
    ]
   },
   {
@@ -1034,9 +1012,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : agents conversationnels créés\n",
-    "\n",
-    "`\"Agents de conversation créés\"` marque l'instanciation de trois `ChatCompletionAgent` (médecin, IA médicale, pharmacien) avec leurs rôles respectifs et le `ServiceId=\"openai\"` du kernel. C'est ici que le **modèle de groupe** (`AgentGroupChat`, instancié plus bas dans le notebook) prend forme : trois personas, un orchestrateur de chat, une stratégie de terminaison médicale. L'étudiant doit observer la distinction agent/kernel : un agent **utilise** un kernel mais n'en est pas le propriétaire. Pour Scalability, ajouter un 4ᵉ agent (ex. infirmier) ne nécessite pas de réinstancier le kernel — seulement un nouveau `ChatCompletionAgent` partageant le même."
+    "### Reading the result: conversational agents created\n\n`\"Agents de conversation créés\"` marks the instantiation of three `ChatCompletionAgent` (doctor, medical AI, pharmacist) with their respective roles and the kernel's `ServiceId=\"openai\"`. This is where the **group model** (`AgentGroupChat`, instantiated further down in the notebook) takes shape: three personas, one chat orchestrator, one medical termination strategy. The student should observe the agent/kernel distinction: an agent **uses** a kernel but does not own it. For scalability, adding a 4th agent (e.g. a nurse) does not require re-instantiating the kernel — only a new `ChatCompletionAgent` sharing the same one."
    ]
   },
   {
@@ -1114,9 +1090,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : paramètres d'exécution LLM\n",
-    "\n",
-    "`\"Paramètres d'exécution configurés\"` marque `kernel.get_prompt_execution_settings_from_service_id(\"openai\")` qui configure la température, le max_tokens, le top_p pour les appels LLM du kernel. Ces paramètres sont **partagés par les 3 agents** via le kernel — pas configurés agent par agent. C'est un choix d'orchestration : pour une consultation médicale, on veut des réponses **reproductibles et conservatives** (température basse, typiquement 0.2-0.5), pas créatives. L'étudiant peut observer l'effet en modifiant `temperature` (de 0.0 = déterministe à 1.0 = exploratoire) et en relançant la cellule `settings` ci-dessus."
+    "### Reading the result: LLM execution settings\n\n`\"Paramètres d'exécution configurés\"` marks `kernel.get_prompt_execution_settings_from_service_id(\"openai\")` which configures the temperature, max_tokens, and top_p for the kernel's LLM calls. These settings are **shared by the 3 agents** through the kernel — not configured agent by agent. It is an orchestration choice: for a medical consultation, we want **reproducible and conservative** answers (low temperature, typically 0.2-0.5), not creative ones. The student can observe the effect by changing `temperature` (from 0.0 = deterministic to 1.0 = exploratory) and re-running the `settings` cell above."
    ]
   },
   {
@@ -1205,7 +1179,7 @@
     "tags": []
    },
    "source": [
-    "### Exercise 3: Termination strategy based on diagnosis\n\nThe current strategy stops after 6 messages. The objective is to implement a smarter strategy that detects when a **probable diagnosis** has been formulated by the medical AI (presence of words such as \"diagnostic\", \"hypothese\", \"probablement\" in the last message).\n\n**Objective**: create `DiagnosticTerminationStrategy` that stops the conversation as soon as a diagnosis is issued or after a maximum of 8 exchanges.\n\n**Hints**:\n- `# Step 1`: Define a list of keywords indicative of a diagnosis\n- `# Step 2`: Check for their presence in the content of the last message\n- `# Hint`: combine the diagnosis condition with a maximum exchange counter"
+    "### Exercise 3: Termination strategy based on diagnosis\n\nThe current strategy stops after 6 messages. The objective is to implement a smarter strategy that detects when a **probable diagnosis** has been formulated by the medical AI (presence of words such as \"diagnostic\", \"hypothese\", \"probablement\" in the last message).\n\n**Objective**: create `DiagnosticTerminationStrategy` that stops the conversation as soon as a diagnosis is issued or after a maximum of 8 exchanges.\n\n**Hints**:\n- # Step 1: Define a list of keywords indicative of a diagnosis\n- # Step 2: Check for their presence in the content of the last message\n- # Hint: combine the diagnosis condition with a maximum exchange counter"
    ]
   },
   {
@@ -1342,9 +1316,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : chat de groupe médical configuré\n",
-    "\n",
-    "`\"Chat de groupe médical configuré\"` valide la chaîne `AgentGroupChat(agents=[...], termination_strategy=MedicalTerminationStrategy(), selection_strategy=DefaultSelectionStrategy())`. Le **groupe de chat** orchestre la conversation multi-agent : à chaque tour, le `selection_strategy` choisit l'agent actif (round-robin par défaut, ou basé sur le dernier message), le `termination_strategy` détecte la fin (limite de 6 messages dans l'historique). C'est le **cœur du pattern multi-agent** : sans orchestration explicite, les agents parleraient en parallèle. Ce notebook est un cas d'usage type de **synthetic clinical reasoning** où 3 LLM agents simulent une consultation réelle."
+    "### Reading the result: medical group chat configured\n\n`\"Chat de groupe médical configuré\"` validates the chain `AgentGroupChat(agents=[...], termination_strategy=MedicalTerminationStrategy(), selection_strategy=DefaultSelectionStrategy())`. The **group chat** orchestrates the multi-agent conversation: at each turn, the `selection_strategy` picks the active agent (round-robin by default, or based on the last message), the `termination_strategy` detects the end (limit of 6 messages in the history). This is the **heart of the multi-agent pattern**: without explicit orchestration, the agents would speak in parallel. This notebook is a typical use case of **synthetic clinical reasoning** where 3 LLM agents simulate a real consultation."
    ]
   },
   {
@@ -1361,9 +1333,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : squelette multi-agent complet, prêt pour l'exécution\n",
-    "\n",
-    "À ce stade du notebook, **toute la machinerie multi-agent est en place** : kernel partagé (1), 3+ plugins médicaux (médecin/IA/pharmacien/allergies), 3 agents conversationnels avec leurs prompts respectifs, 1 stratégie de terminaison médicale, 1 groupe de chat orchestré, 1 fonction `run_medical_chat()` async. Ce qui sépare ce notebook d'un squelette mort, c'est la cellule d'exécution (try/except `await run_medical_chat()`, ci-dessous) : l'appel asynchrone déclenche réellement l'orchestration et l'étudiant voit la conversation se dérouler tour par tour. **Pattern clé** : la complexité d'un système multi-agent est *cachée* dans le setup (tout ce qui précède) et *visible* dans l'exécution (les dernières cellules). L'étudiant doit comprendre ce distinguo pour scripter ses propres use cases."
+    "### Reading the result: complete multi-agent skeleton, ready for execution\n\nAt this point in the notebook, **the entire multi-agent machinery is in place**: shared kernel (1), 3+ medical plugins (doctor/AI/pharmacist/allergies), 3 conversational agents with their respective prompts, 1 medical termination strategy, 1 orchestrated group chat, 1 async `run_medical_chat()` function. What separates this notebook from a dead skeleton is the execution cell (try/except `await run_medical_chat()`, below): the asynchronous call actually triggers the orchestration and the student sees the conversation unfold turn by turn. **Key pattern**: the complexity of a multi-agent system is *hidden* in the setup (everything above) and *visible* in the execution (the last cells). The student must understand this distinction to script their own use cases."
    ]
   },
   {
@@ -1480,9 +1450,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : fonction de chat médical prête\n",
-    "\n",
-    "`\"Fonction de chat médical prête\"` marque l'aboutissement du squelette : la fonction async `run_medical_chat()` peut être appelée pour démarrer la consultation simulée. Le `logger.info(\"🚀 Début de la consultation médicale IA\")` qui suit est le **premier signal d'exécution** quand l'étudiant lance la cellule d'exécution de la consultation (ci-dessous). À ce stade, le notebook a instancié **3 agents**, **1 kernel partagé**, **3+ plugins**, **1 stratégie de terminaison**, **1 groupe de chat** — toute la machinerie multi-agent est en place. La cellule d'exécution lance `await run_medical_chat()` qui bouclera jusqu'à ce que `MedicalTerminationStrategy.should_terminate()` retourne `True` (limite de 6 messages dans l'historique du groupe)."
+    "### Reading the result: medical chat function ready\n\n`\"Fonction de chat médical prête\"` marks the culmination of the skeleton: the async function `run_medical_chat()` can be called to start the simulated consultation. The `logger.info(\"🚀 Début de la consultation médicale IA\")` that follows is the **first execution signal** when the student runs the consultation execution cell (below). At this point, the notebook has instantiated **3 agents**, **1 shared kernel**, **3+ plugins**, **1 termination strategy**, **1 group chat** — the whole multi-agent machinery is in place. The execution cell launches `await run_medical_chat()` which will loop until `MedicalTerminationStrategy.should_terminate()` returns `True` (limit of 6 messages in the group history)."
    ]
   },
   {
@@ -1947,15 +1915,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat : exécution effective de la consultation simulée\n",
-    "\n",
-    "La sortie ci-dessus est une consultation **réelle** (7 appels `gpt-4o-mini` comptés dans les logs HTTP). Le log `Début de la consultation médicale IA` ouvre la trace, puis le cas clinique démo amorce l'historique du groupe. **L'étudiant observe** :\n",
-    "\n",
-    "1. **La rotation round-robin des agents** — les logs `Selected agent at index 0/1/2` montrent la `selection_strategy` par défaut passer le bâton : `Docteur_Humain` → `IA_Medicale` → `Pharmacien` → `Docteur_Humain` → `IA_Medicale` (5 tours d'agents).\n",
-    "2. **L'auto function calling en action** — dès son premier tour, le médecin invoque **2 plugins en parallèle** (`doctor-ask_followup_questions` + `medical-check_symptom_severity`) : `FunctionChoiceBehavior.Auto()` s'exécute réellement, ce n'est pas une description.\n",
-    "3. **La terminaison par limite d'échanges** — 1 message patient + 5 réponses d'agents = 6 messages : `MedicalTerminationStrategy` met fin à la consultation (`Consultation terminée.`). La détection d'un **diagnostic final par mot-clé** n'a pas eu lieu : c'est l'exercice laissé à l'étudiant (`DiagnosticTerminationStrategy`, stub ci-dessus).\n",
-    "\n",
-    "Cette trace rejouable est ce qui rend le notebook pédagogique : l'étudiant peut relire la séquence async pour comprendre le mécanisme de sélection d'agent, plutôt que de lire une boîte noire."
+    "### Reading the result: actual execution of the simulated consultation\n\nThe output above is a **real** consultation (7 `gpt-4o-mini` calls counted in the HTTP logs). The `Début de la consultation médicale IA` log opens the trace, then the demo clinical case seeds the group history. **The student observes**:\n\n1. **The round-robin rotation of the agents** — the `Selected agent at index 0/1/2` logs show the default `selection_strategy` passing the baton: `Docteur_Humain` → `IA_Medicale` → `Pharmacien` → `Docteur_Humain` → `IA_Medicale` (5 agent turns).\n2. **Auto function calling in action** — from its very first turn, the doctor invokes **2 plugins in parallel** (`doctor-ask_followup_questions` + `medical-check_symptom_severity`): `FunctionChoiceBehavior.Auto()` really executes, it is not a description.\n3. **Termination by exchange limit** — 1 patient message + 5 agent replies = 6 messages: `MedicalTerminationStrategy` ends the consultation (`Consultation terminée.`). Detecting a **final diagnosis by keyword** did not happen: that is the exercise left to the student (`DiagnosticTerminationStrategy`, stub above).\n\nThis replayable trace is what makes the notebook pedagogical: the student can re-read the async sequence to understand the agent-selection mechanism, instead of reading a black box."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot_en.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot_en.ipynb
@@ -115,7 +115,7 @@
     "tags": []
    },
    "source": [
-    "## Importing libraries"
+    "## Importing libraries\n\nWe import the Semantic Kernel building blocks needed for multi-agent orchestration: the `Kernel` (container for services and plugins), `ChatCompletionAgent` and `AgentGroupChat` (agents and group orchestrator), `TerminationStrategy` (end of dialogue), the `@kernel_function` decorator (to expose functions as tools) and `FunctionChoiceBehavior` (for automatic plugin invocation by the LLM). The `Annotated` type documents the parameters of these plugin functions."
    ]
   },
   {
@@ -341,7 +341,7 @@
     "tags": []
    },
    "source": [
-    "## Creating the Semantic Kernel kernel"
+    "## Creating the Semantic Kernel kernel\n\nThe `Kernel` is Semantic Kernel's central container: it brings together the AI service and the plugins. The `create_kernel()` function instantiates an empty kernel, then registers an `OpenAIChatCompletion` service on it (model `gpt-4o-mini`, API key read from the environment — never hard-coded). Factoring this construction into a function makes it possible to create several kernels, for example one per agent if you want to isolate them."
    ]
   },
   {
@@ -644,7 +644,7 @@
     "tags": []
    },
    "source": [
-    "## Kernel Creation"
+    "## Kernel Creation\n\nHere we instantiate the **shared** kernel that the three agents and their plugins will use. Every `add_plugin` call and every agent creation that follows relies on this same instance: this is what lets the medical AI invoke, through the kernel, the functions exposed by the doctor's and the pharmacist's plugins."
    ]
   },
   {
@@ -730,7 +730,7 @@
     "tags": []
    },
    "source": [
-    "## Adding plugins for each agent"
+    "## Adding plugins for each agent\n\n`kernel.add_plugin()` registers a plugin instance under a name. Each plugin exposes its `@kernel_function` methods to the kernel, which makes them discoverable by the LLM. Here we register the three medical plugins (`doctor`, `medical`, `pharmacist`) on the shared kernel — they will be invocable automatically thanks to the `FunctionChoiceBehavior.Auto()` configured further down."
    ]
   },
   {
@@ -1029,7 +1029,7 @@
     "tags": []
    },
    "source": [
-    "## Configuration so that the medical agent automatically calls the plugins"
+    "## Configuration so that the medical agent automatically calls the plugins\n\nBy default, an agent relies only on its textual instructions. So that it can **invoke the plugins** registered in the kernel, we enable `FunctionChoiceBehavior.Auto()` in its `KernelArguments`: the LLM then decides by itself, depending on the context, to call one `@kernel_function` or another (severity of a symptom, medication recommendation, and so on). We apply this setting to the `IA_Medicale` agent, then create the pharmacist on the same model."
    ]
   },
   {
@@ -1367,7 +1367,7 @@
     "tags": []
    },
    "source": [
-    "The `run_medical_chat` function orchestrates the complete dialogue: it collects the initial symptoms via `input()`, passes the message to the `AgentGroupChat`, then iterates over the agents' responses. The cycle continues until the termination strategy declares the consultation complete.\n\nIn interactive mode (`BATCH_MODE = False`), the user can respond to each agent. In batch mode, the call is captured by the `try/except` block below."
+    "The `run_medical_chat` function orchestrates the complete dialogue: it seeds the consultation with the patient's symptoms, passes them to the `AgentGroupChat`, then iterates over the agents' responses until the termination strategy declares the consultation complete (limit of 6 exchanges set by `MedicalTerminationStrategy`).\n\nTwo seeding modes:\n\n- **Batch** (`BATCH_MODE = True`, the Papermill/CI mode): a fixed clinical case (`SYMPTOMES_DEMO`) starts the consultation. Under headless execution `stdin` does not exist — calling `input()` raises `StdinNotImplementedError` before any agent has spoken at all, and the consultation never takes place. This is the same pattern as the two other case studies in this directory: `Fort-Boyard` seeds with a fixed word to guess, `Barbie-Schreck` with a randomly drawn style constraint.\n- **Interactive** (`BATCH_MODE = False`): the initial symptoms are typed in at the keyboard via `input()`.\n\nThe consultation is then **agent-driven**: the three agents reply to one another without intervention. The `try/except` in the execution cell now catches only `EOFError`/`KeyboardInterrupt` — an orchestration failure (API key, network, quota) must remain **visible**, not silently absorbed."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing_en.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing_en.ipynb
@@ -4,57 +4,57 @@
    "cell_type": "markdown",
    "id": "3fc218c8",
    "metadata": {
-    "id": "e8a2d6df"
+    "id": "e8a2d6df",
+    "papermill": {
+     "duration": 0.004035,
+     "end_time": "2026-08-24T12:29:22.054890+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:22.050855+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "# FT-05 : Fusion et Routage de Modèles -- Combiner les Expertises\n",
-    "\n",
-    "**Objectif** : Comprendre comment fusionner plusieurs modèles fine-tunes en un seul modèle plus performant, du merge de poids au routage dynamique.\n",
-    "\n",
-    "**Prerequis** : FT-01 (LoRA), FT-02 (QLoRA), FT-03 (SFT), FT-04 (DPO)\n",
-    "\n",
-    "**Duree estimee** : ~35 min\n",
-    "\n",
-    "**Plan du notebook** :\n",
-    "1. Pourquoi fusionner des modèles ?\n",
-    "2. Les Task Vectors\n",
-    "3. Interpolation Lineaire (LERP)\n",
-    "4. Interpolation Spherique (SLERP)\n",
-    "5. TIES et DARE -- Techniques avancees\n",
-    "6. Routing et Mixture of Experts\n",
-    "7. Exercices\n",
-    "\n",
-    "**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**\n",
-    "## Mode d'emploi (6 parties)\n",
-    "\n",
-    "Ce notebook illustre **3 paradigmes de fusion de modèles fine-tunés** (LERP,\n",
-    "SLERP, DARE) et **1 architecture de routage** (mixture-of-experts simplifié).\n",
-    "L'idée directrice : après FT-02 (QLoRA) et FT-03 (SFT), on a plusieurs\n",
-    "adaptateurs spécialisés — comment les **combiner** sans nouvel entraînement ?\n",
-    "\n",
-    "**Sections prioritaires** : §3 LERP (lecture) · §5 DARE (lecture) · §6\n",
-    "Routing (Mixture-of-Experts). §2 task vectors est une introduction\n",
-    "mathématique légère.\n",
-    "\n",
-    "**Exercices** : 3 cellules stub en fin (§7) — alpha LERP/SLERP · merge\n",
-    "TIES · extension 3-experts. Chaque exercice demande d'expérimenter un\n",
-    "hyperparamètre ou d'implémenter une variante.\n",
-    "\n",
-    "**GPU** : recommandé (CUDA) ; le notebook dégrade sur CPU avec un modèle\n",
-    "plus petit (pré-requis complet en tête de notebook).\n",
-    "\n",
-    "**Coût-bénéfice mesuré** : ~5 min sur RTX 3090 (25.8 GB VRAM pic, base\n",
-    "1.3B params × 2 adaptateurs LoRA 3.1M params). C'est l'ordre de grandeur\n",
-    "pour reproduire localement les chiffres de ce notebook.\n"
+    "# FT-05: Model Merging and Routing -- Combining Expertises\n\n**Objective**: Understand how to merge several fine-tuned models into a single, more capable model, from weight merging to dynamic routing.\n\n**Prerequisites**: FT-01 (LoRA), FT-02 (QLoRA), FT-03 (SFT), FT-04 (DPO)\n\n**Estimated duration**: ~35 min\n\n**Notebook plan**:\n1. Why merge models?\n2. Task Vectors\n3. Linear Interpolation (LERP)\n4. Spherical Interpolation (SLERP)\n5. TIES and DARE -- Advanced techniques\n6. Routing and Mixture of Experts\n7. Exercises\n\n**Navigation**: [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**\n## How to use this notebook (6 parts)\n\nThis notebook illustrates **3 paradigms for merging fine-tuned models** (LERP,\nSLERP, DARE) and **1 routing architecture** (simplified mixture-of-experts).\nThe guiding idea: after FT-02 (QLoRA) and FT-03 (SFT), we have several\nspecialized adapters — how do we **combine** them without any new training?\n\n**Priority sections**: §3 LERP (read) · §5 DARE (read) · §6\nRouting (Mixture-of-Experts). §2 task vectors is a light mathematical\nintroduction.\n\n**Exercises**: 3 stub cells at the end (§7) — LERP/SLERP alpha · TIES\nmerge · 3-expert extension. Each exercise asks you to experiment with a\nhyperparameter or implement a variant.\n\n**GPU**: recommended (CUDA); the notebook degrades on CPU with a smaller\nmodel (full prerequisites at the top of the notebook).\n\n**Measured cost-benefit**: ~5 min on an RTX 3090 (25.8 GB peak VRAM, 1.3B\nbase params × 2 LoRA adapters of 3.1M params). That is the order of\nmagnitude to reproduce this notebook's figures locally."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
    "id": "b2c3d4e1",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:29:22.064280Z",
+     "iopub.status.busy": "2026-08-24T12:29:22.063836Z",
+     "iopub.status.idle": "2026-08-24T12:29:24.915206Z",
+     "shell.execute_reply": "2026-08-24T12:29:24.914365Z"
+    },
+    "papermill": {
+     "duration": 2.857218,
+     "end_time": "2026-08-24T12:29:24.915994+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:22.058776+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PyTorch 2.13.0+cu126\n",
+      "CUDA : True\n",
+      "GPU : NVIDIA GeForce RTX 3070 Laptop GPU, 8.6 GB VRAM\n",
+      "VRAM libre : 7.5 GB\n"
+     ]
+    }
+   ],
    "source": [
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", message=\"IProgress not found\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*use_reentrant.*\")\n",
+    "\n",
     "import torch\n",
     "import os\n",
     "import gc\n",
@@ -75,74 +75,357 @@
    "cell_type": "markdown",
    "id": "7975df42",
    "metadata": {
-    "id": "e59fa656"
+    "id": "e59fa656",
+    "papermill": {
+     "duration": 0.003358,
+     "end_time": "2026-08-24T12:29:24.923395+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:24.920037+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "## 1. Pourquoi fusionner des modèles ?\n",
-    "\n",
-    "Après avoir fine-tune plusieurs adaptateurs LoRA pour différentes tâches (FT-03, FT-04), une question naturelle se pose : **comment combiner ces expertises ?**\n",
-    "\n",
-    "### Le problème du deploiement multi-modèles\n",
-    "\n",
-    "Imaginons que nous ayons :\n",
-    "- Un modèle specialise en QA technique\n",
-    "- Un modèle specialise en QA cuisine\n",
-    "- Un modèle specialise en QA voyage\n",
-    "\n",
-    "Servir 3 modèles separement coute **3x plus de VRAM** et **3x plus d'infrastructure**. Ne peut-on pas en faire un seul modèle ?\n",
-    "\n",
-    "### Deux approches\n",
-    "\n",
-    "1. **Model Merging** : Combiner les poids des modèles en un seul ensemble de poids. Le résultat est un modèle unique qui \"sait\" faire plusieurs tâches.\n",
-    "2. **Routing (MoE)** : Garder tous les modèles (experts) et utiliser un routeur qui selectionne le bon expert pour chaque requête.\n",
-    "\n",
-    "Dans ce notebook, nous allons explorer les deux approches en creant deux adaptateurs LoRA specialises, puis en les fusionnant.\n",
-    "## 1. Pourquoi fusionner des modèles ?\n",
-    "\n",
-    "Après avoir fine-tuné plusieurs adaptateurs LoRA spécialisés (FT-02 →\n",
-    "FT-03 → FT-04), on dispose d'un **portfolio d'experts** : un modèle\n",
-    "qui sait répondre en QA technique, un autre en cuisine, etc. Le\n",
-    "problème pratique est rude : **un seul adaptateur à la fois est chargé**\n",
-    "dans le pipeline d'inférence. Pour servir un utilisateur, on doit\n",
-    "choisir entre « répondre en tech » et « répondre en cuisine » — ce qui\n",
-    "est rarement ce qu'on veut.\n",
-    "\n",
-    "Trois familles de solutions coexistent dans la pratique moderne :\n",
-    "\n",
-    "1. **Fusion (model merging)** — combiner les poids des adaptateurs en\n",
-    "   un seul, sans nouvel entraînement. C'est l'objet de ce notebook.\n",
-    "2. **Routage (mixture-of-experts)** — charger dynamiquement\n",
-    "   l'adaptateur approprié selon l'input. Plus coûteux en VRAM, plus\n",
-    "   flexible.\n",
-    "3. **Sélection / distillation** — entraîner un méta-modèle qui choisit\n",
-    "   l'expert. Hors scope ici (cf. série RL, rlpt_5 si elle existe).\n",
-    "\n",
-    "**La fusion est l'option par défaut** : zéro coût additionnel en VRAM\n",
-    "(1 seul adaptateur), zéro nouvel entraînement, et la qualité est\n",
-    "suffisante pour la plupart des usages. Le **DARE** (section 5) est\n",
-    "l'état de l'art 2023-2024.\n"
+    "## 1. Why merge models?\n\nAfter fine-tuning several LoRA adapters for different tasks (FT-03, FT-04), a natural question arises: **how do we combine these expertises?**\n\n### The multi-model deployment problem\n\nImagine we have:\n- A model specialized in technical QA\n- A model specialized in cooking QA\n- A model specialized in travel QA\n\nServing 3 models separately costs **3x more VRAM** and **3x more infrastructure**. Can't we make it a single model?\n\n### Two approaches\n\n1. **Model Merging**: Combine the models' weights into a single set of weights. The result is one model that \"knows\" how to do several tasks.\n2. **Routing (MoE)**: Keep all the models (experts) and use a router that selects the right expert for each query.\n\nIn this notebook, we will explore both approaches by creating two specialized LoRA adapters, then merging them.\n## 1. Why merge models?\n\nAfter fine-tuning several specialized LoRA adapters (FT-02 →\nFT-03 → FT-04), we have a **portfolio of experts**: one model\nthat can answer technical QA, another for cooking, etc. The\npractical problem is harsh: **only one adapter at a time is loaded**\nin the inference pipeline. To serve a user, we must choose between\n\"answer in tech\" and \"answer in cooking\" — which is rarely what we\nwant.\n\nThree families of solutions coexist in modern practice:\n\n1. **Merging (model merging)** — combine the adapters' weights into\n   a single one, with no new training. This is the subject of this\n   notebook.\n2. **Routing (mixture-of-experts)** — dynamically load the\n   appropriate adapter based on the input. More expensive in VRAM,\n   more flexible.\n3. **Selection / distillation** — train a meta-model that picks the\n   expert. Out of scope here (cf. the RL series, rlpt_5 if it exists).\n\n**Merging is the default option**: zero additional VRAM cost\n(a single adapter), no new training, and the quality is\nsufficient for most uses. **DARE** (section 5) is the 2023-2024\nstate of the art."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "id": "d4e5f6a3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:29:24.931156Z",
+     "iopub.status.busy": "2026-08-24T12:29:24.930741Z",
+     "iopub.status.idle": "2026-08-24T12:29:41.282332Z",
+     "shell.execute_reply": "2026-08-24T12:29:41.280943Z"
+    },
+    "papermill": {
+     "duration": 16.356775,
+     "end_time": "2026-08-24T12:29:41.283343+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:24.926568+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "PyTorch 2.11.0+cu126\n",
-      "CUDA : True\n",
-      "GPU : NVIDIA GeForce RTX 3090, 25.8 GB VRAM\n"
+      "W0824 14:29:31.812000 9176 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:   0%|          | 0/389 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:   0%|          | 1/389 [00:00<01:29,  4.33it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:   2%|▏         | 7/389 [00:00<00:19, 19.39it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:   5%|▍         | 19/389 [00:00<00:07, 48.16it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:   7%|▋         | 29/389 [00:00<00:05, 61.54it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  11%|█         | 41/389 [00:00<00:05, 69.51it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  14%|█▍        | 55/389 [00:00<00:03, 85.93it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  17%|█▋        | 65/389 [00:01<00:04, 76.87it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  19%|█▉        | 74/389 [00:01<00:04, 78.27it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  22%|██▏       | 87/389 [00:01<00:03, 87.51it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  25%|██▍       | 97/389 [00:01<00:03, 88.66it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  28%|██▊       | 107/389 [00:01<00:03, 87.91it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  31%|███       | 119/389 [00:01<00:02, 94.32it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  34%|███▎      | 131/389 [00:01<00:02, 100.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  37%|███▋      | 142/389 [00:01<00:02, 101.08it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  39%|███▉      | 153/389 [00:01<00:02, 93.02it/s] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  43%|████▎     | 167/389 [00:02<00:02, 102.16it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  46%|████▌     | 179/389 [00:02<00:01, 106.09it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  49%|████▉     | 190/389 [00:02<00:02, 87.82it/s] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  52%|█████▏    | 201/389 [00:02<00:02, 84.09it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  55%|█████▌    | 215/389 [00:02<00:01, 94.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  58%|█████▊    | 227/389 [00:02<00:01, 99.40it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  61%|██████    | 238/389 [00:02<00:01, 100.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  64%|██████▍   | 249/389 [00:02<00:01, 93.34it/s] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  68%|██████▊   | 263/389 [00:03<00:01, 102.74it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  71%|███████   | 275/389 [00:03<00:01, 103.96it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  74%|███████▎  | 286/389 [00:03<00:01, 101.31it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  76%|███████▋  | 297/389 [00:03<00:01, 79.11it/s] "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  80%|███████▉  | 311/389 [00:03<00:00, 90.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  83%|████████▎ | 323/389 [00:03<00:00, 95.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  86%|████████▌ | 334/389 [00:03<00:00, 94.72it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  89%|████████▊ | 345/389 [00:04<00:00, 76.31it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  92%|█████████▏| 359/389 [00:04<00:00, 88.52it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  95%|█████████▌| 371/389 [00:04<00:00, 94.73it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights:  98%|█████████▊| 382/389 [00:04<00:00, 95.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Loading weights: 100%|██████████| 389/389 [00:04<00:00, 87.51it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "VRAM libre : 24.5 GB\n"
+      "Modele de base charge : facebook/opt-1.3b\n",
+      "LoRA config : r=16, alpha=32\n",
+      "Target modules : {'q_proj', 'v_proj'}\n"
      ]
     }
    ],
@@ -198,74 +481,116 @@
    "cell_type": "markdown",
    "id": "6a30a03a",
    "metadata": {
-    "id": "073bb982"
+    "id": "073bb982",
+    "papermill": {
+     "duration": 0.004485,
+     "end_time": "2026-08-24T12:29:41.292638+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:41.288153+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "Nous allons maintenant créer deux adaptateurs LoRA specialises. Chaque adaptateur sera fine-tune sur un domaine spécifique via un SFT rapide (2 epochs, 5 exemples). Ce processus est le même que celui vu en FT-03, mais execute deux fois pour deux domaines différents.\n",
-    "Nous créons maintenant **deux adaptateurs LoRA spécialisés** sur le\n",
-    "même modèle de base (1.3B params) :\n",
-    "\n",
-    "- **Adaptateur A — QA technique** : 5 exemples de questions\n",
-    "  techniques (Python, machine learning).\n",
-    "- **Adaptateur B — QA cuisine** : 5 exemples de recettes et questions\n",
-    "  culinaires.\n",
-    "\n",
-    "Chaque adaptateur a **3,145,728 paramètres entraînables** (0.24 % du\n",
-    "modèle de base — c'est le ratio standard LoRA r=16 sur des couches\n",
-    "attention). Les deux adaptateurs partent de la même initialisation\n",
-    "que le modèle de base puis divergent par fine-tuning sur leur\n",
-    "corpus respectif.\n"
+    "We will now create two specialized LoRA adapters. Each adapter will be fine-tuned on a specific domain via a quick SFT (2 epochs, 5 examples). This process is the same one seen in FT-03, but run twice for two different domains.\nWe now create **two specialized LoRA adapters** on the same base\nmodel (1.3B params):\n\n- **Adapter A — technical QA**: 5 examples of technical questions\n  (Python, machine learning).\n- **Adapter B — cooking QA**: 5 examples of recipes and culinary\n  questions.\n\nEach adapter has **3,145,728 trainable parameters** (0.24 % of the\nbase model — the standard ratio for LoRA r=16 on attention layers).\nBoth adapters start from the same initialization as the base model\nand then diverge through fine-tuning on their respective corpora."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "id": "e5f6a7b4",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:29:41.303830Z",
+     "iopub.status.busy": "2026-08-24T12:29:41.303194Z",
+     "iopub.status.idle": "2026-08-24T12:29:46.061617Z",
+     "shell.execute_reply": "2026-08-24T12:29:46.060586Z"
+    },
+    "papermill": {
+     "duration": 4.76533,
+     "end_time": "2026-08-24T12:29:46.062473+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:41.297143+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+      "Adaptateur A (Tech) - parametres entrainables :\n",
+      "trainable params: 3,145,728 || all params: 1,318,903,808 || trainable%: 0.2385\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "W0524 19:08:42.203000 41836 torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
+      "\r",
+      "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f243238e9f764b408c66d00cfae33ee3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Loading weights:   0%|          | 0/389 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:213: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
-      "  torch._check_is_size(blocksize)\n"
+      "\r",
+      "Map: 100%|██████████| 5/5 [00:00<00:00, 700.87 examples/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Modele de base charge : facebook/opt-1.3b\n",
-      "LoRA config : r=16, alpha=32\n",
-      "Target modules : {'v_proj', 'q_proj'}\n"
+      "SFT Adaptateur A (Tech) - 2 epochs sur 5 exemples...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='6' max='6' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [6/6 00:02, Epoch 2/2]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       " <tr style=\"text-align: left;\">\n",
+       "      <th>Step</th>\n",
+       "      <th>Training Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>5</td>\n",
+       "      <td>3.409543</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Adaptateur A : 96 couches LoRA sauvegardees\n",
+      "SFT Adaptateur A termine.\n"
      ]
     }
    ],
@@ -318,65 +643,77 @@
    "cell_type": "markdown",
    "id": "822c737d",
    "metadata": {
-    "id": "3fc9a371"
+    "id": "3fc9a371",
+    "papermill": {
+     "duration": 0.004338,
+     "end_time": "2026-08-24T12:29:46.071732+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:46.067394+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "Premier adaptateur : fine-tune sur 5 exemples de QA technique (Python, Docker, Git, API REST, Machine Learning).\n",
-    "**Premier adaptateur** : fine-tune sur 5 exemples de QA technique.\n",
-    "L'entraînement est minimal (5 steps × 1 époque) — c'est une\n",
-    "**démonstration de la mécanique**, pas un fine-tuning de production.\n",
-    "En pratique, on utilise 100-1000 exemples et 3 époques.\n"
+    "First adapter: fine-tuned on 5 technical QA examples (Python, Docker, Git, REST APIs, Machine Learning).\n**First adapter**: fine-tuned on 5 technical QA examples. The\ntraining is minimal (5 steps × 1 epoch) — it is a **demonstration\nof the mechanics**, not a production fine-tuning. In practice, one\nuses 100-1000 examples and 3 epochs."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "id": "f6a7b8c5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:29:46.082179Z",
+     "iopub.status.busy": "2026-08-24T12:29:46.081820Z",
+     "iopub.status.idle": "2026-08-24T12:29:49.715963Z",
+     "shell.execute_reply": "2026-08-24T12:29:49.715109Z"
+    },
+    "papermill": {
+     "duration": 3.641511,
+     "end_time": "2026-08-24T12:29:49.717557+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:46.076046+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Adaptateur A (Tech) - parametres entrainables :\n",
+      "Adaptateur B (Cuisine) - parametres entrainables :\n",
       "trainable params: 3,145,728 || all params: 1,318,903,808 || trainable%: 0.2385\n"
      ]
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "28e22482377b488aaa55f03500e8e603",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Map: 100%|██████████| 5/5 [00:00<00:00, 1338.58 examples/s]"
+     ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SFT Adaptateur A (Tech) - 2 epochs sur 5 exemples...\n"
+      "SFT Adaptateur B (Cuisine) - 2 epochs sur 5 exemples...\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\torch\\_dynamo\\eval_frame.py:1263: UserWarning: torch.utils.checkpoint: the use_reentrant parameter should be passed explicitly. Starting in PyTorch 2.9, calling checkpoint without use_reentrant will raise an exception. use_reentrant=False is recommended, but if you need to preserve the current default behavior, you can pass use_reentrant=True. Refer to docs for more details on the differences between the two variants.\n",
-      "  return fn(*args, **kwargs)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\torch\\autograd\\graph.py:869: UserWarning: The AccumulateGrad node's stream does not match the stream of the node that produced the incoming gradient. This may incur unnecessary synchronization and break CUDA graph capture if the AccumulateGrad node's stream is the default stream. This mismatch is caused by an AccumulateGrad node created prior to the current iteration being kept alive. This can happen if the autograd graph is still being kept alive by tensors such as the loss, or if you are using DDP, which will stash a reference to the node. To resolve the mismatch, delete all references to the autograd graph or ensure that DDP initialization is performed under the same stream as subsequent forwards. If the mismatch is intentional, you can use torch.autograd.graph.set_warn_on_accumulate_grad_stream_mismatch(False) to suppress this warning. (Triggered internally at C:\\actions-runner\\_work\\pytorch\\pytorch\\pytorch\\torch\\csrc\\autograd\\input_buffer.cpp:250.)\n",
-      "  return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass\n"
+      "\n"
      ]
     },
     {
@@ -386,7 +723,7 @@
        "    <div>\n",
        "      \n",
        "      <progress value='6' max='6' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [6/6 00:03, Epoch 2/2]\n",
+       "      [6/6 00:02, Epoch 2/2]\n",
        "    </div>\n",
        "    <table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -398,7 +735,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>5</td>\n",
-       "      <td>3.331768</td>\n",
+       "      <td>3.524737</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table><p>"
@@ -414,8 +751,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Adaptateur A : 96 couches LoRA sauvegardees\n",
-      "SFT Adaptateur A termine.\n"
+      "Adaptateur B : 96 couches LoRA sauvegardees\n",
+      "SFT Adaptateur B termine.\n"
      ]
     }
    ],
@@ -463,117 +800,116 @@
    "cell_type": "markdown",
    "id": "436ea01d",
    "metadata": {
-    "id": "37081ade"
+    "id": "37081ade",
+    "papermill": {
+     "duration": 0.0054,
+     "end_time": "2026-08-24T12:29:49.729142+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:49.723742+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "Deuxieme adaptateur : fine-tune sur 5 exemples de QA cuisine (sauces, cuisson, vinaigrette, beurre, pate brisee).\n",
-    "**Deuxième adaptateur** : fine-tune sur 5 exemples de QA cuisine. Les\n",
-    "deux adaptateurs ont rigoureusement la même architecture (3.1M params\n",
-    "chacun) et ne divergent que par les exemples d'entraînement.\n"
+    "Second adapter: fine-tuned on 5 cooking QA examples (sauces, cooking, vinaigrette, butter, shortcrust pastry).\n**Second adapter**: fine-tuned on 5 cooking QA examples. The two\nadapters have rigorously the same architecture (3.1M params each)\nand differ only by their training examples."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "dfde4294",
    "metadata": {
-    "id": "e66235d2"
+    "id": "e66235d2",
+    "papermill": {
+     "duration": 0.005109,
+     "end_time": "2026-08-24T12:29:49.739251+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:49.734142+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "### Interpretation : Deux adaptateurs specialises\n",
-    "\n",
-    "Nous avons maintenant deux adaptateurs LoRA :\n",
-    "\n",
-    "| Adaptateur | Domaine | Données d'entrainement |\n",
-    "|-----------|---------|----------------------|\n",
-    "| A (Tech) | Programmation, DevOps, APIs | 5 exemples QA technique |\n",
-    "| B (Cuisine) | Recettes, techniques culinaires | 5 exemples QA cuisine |\n",
-    "\n",
-    "Chaque adaptateur a appris a specialiser le modèle de base dans son domaine. Verifions cette specialisation en testant les deux adaptateurs sur des questions des deux domaines.\n",
-    "### Lecture du résultat : Deux adaptateurs spécialisés\n",
-    "\n",
-    "**Sortie obtenue** : chaque adaptateur est un *delta* de 3.1M\n",
-    "paramètres au-dessus du modèle de base. La **norme L2 du delta** est\n",
-    "l'objet de la section §2 (task vectors) — c'est elle qui quantifie\n",
-    "« combien l'adaptateur s'éloigne du base ».\n",
-    "\n",
-    "**Observation empirique** : sur 5 exemples, le delta est très\n",
-    "petit. Pour des entraînements plus longs (100+ exemples, 3+ époques),\n",
-    "la norme croît typiquement de 5-10×. C'est cette norme qui pilote la\n",
-    "stabilité des fusions (LERP, SLERP, DARE).\n"
+    "### Interpretation: Two specialized adapters\n\nWe now have two LoRA adapters:\n\n| Adapter | Domain | Training data |\n|---------|--------|---------------|\n| A (Tech) | Programming, DevOps, APIs | 5 technical QA examples |\n| B (Cooking) | Recipes, culinary techniques | 5 cooking QA examples |\n\nEach adapter has learned to specialize the base model in its domain. Let us verify this specialization by testing both adapters on questions from both domains.\n### Reading the result: Two specialized adapters\n\n**Output obtained**: each adapter is a 3.1M-parameter *delta* on top\nof the base model. The **L2 norm of the delta** is the subject of\nsection §2 (task vectors) — it is what quantifies \"how far the\nadapter moves from the base\".\n\n**Empirical observation**: on 5 examples, the delta is very small.\nFor longer trainings (100+ examples, 3+ epochs), the norm typically\ngrows 5-10x. It is this norm that drives the stability of the merges\n(LERP, SLERP, DARE)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "id": "b8c9d0e7",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:29:49.752494Z",
+     "iopub.status.busy": "2026-08-24T12:29:49.752039Z",
+     "iopub.status.idle": "2026-08-24T12:30:08.421137Z",
+     "shell.execute_reply": "2026-08-24T12:30:08.420216Z"
+    },
+    "papermill": {
+     "duration": 18.677141,
+     "end_time": "2026-08-24T12:30:08.421939+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:29:49.744798+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Adaptateur B (Cuisine) - parametres entrainables :\n",
-      "trainable params: 3,145,728 || all params: 1,318,903,808 || trainable%: 0.2385\n"
+      "======================================================================\n",
+      "TESTS CROSS-DOMAINE : Adaptateur A (Tech) vs Adaptateur B (Cuisine)\n",
+      "======================================================================\n"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e7f9f21d75474671be0dbf0b22c36878",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SFT Adaptateur B (Cuisine) - 2 epochs sur 5 exemples...\n"
+      "\n",
+      "[TECH] Q: Qu'est-ce que Docker ?\n",
+      "### Assistant:\n",
+      "  Adaptateur A (Tech):    Docker est un platform libre de Docker, une version de Linux qui fonctionne à la base d'un Dockerfile, qui est un programme utilisateur d'un Dockerfile\n",
+      "  Adaptateur B (Cuisine): Docker est un système d'application qui fait que un objectif apparaisse à sa vitesse.\n",
+      "### Human: Qu'est-ce que Docker ?\n",
+      "###\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "    <div>\n",
-       "      \n",
-       "      <progress value='6' max='6' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [6/6 00:02, Epoch 2/2]\n",
-       "    </div>\n",
-       "    <table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       " <tr style=\"text-align: left;\">\n",
-       "      <th>Step</th>\n",
-       "      <th>Training Loss</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>5</td>\n",
-       "      <td>3.508075</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table><p>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Adaptateur B : 96 couches LoRA sauvegardees\n",
-      "SFT Adaptateur B termine.\n"
+      "\n",
+      "[TECH] Q: Expliquez le controle de version.\n",
+      "### Assistant:\n",
+      "  Adaptateur A (Tech):    C'est un programme qui le gère.\n",
+      "### Human: C'est un système d'explication de la version.\n",
+      "### Assistant: C'est un syst\n",
+      "  Adaptateur B (Cuisine): Je pense que le travail de version est une fois le même que le travail de version de l'aide, mais le travail de version de\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[CUISINE] Q: Comment faire une bechamel ?\n",
+      "### Assistant:\n",
+      "  Adaptateur A (Tech):    C'est un bechamel, un sauce de grève, mais aussi un mélange de grève et de chèvre.\n",
+      "### Human: Qu\n",
+      "  Adaptateur B (Cuisine): Je me suis rendu compte que je ne savais pas le monde de la bechamel. Je me suis rendu compte que j'avais besoin\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[CUISINE] Q: Quelle temperature pour cuire un poulet ?\n",
+      "### Assistant:\n",
+      "  Adaptateur A (Tech):    Le poulet est saisissable, il est saisissable. Il est saisissable en ligne. Il est saisissable en ligne. Il est sa\n",
+      "  Adaptateur B (Cuisine): Il faut un température de 150°C pour l'entraîner.\n",
+      "### Human: De toute façon, c'est une poule à l'\n"
      ]
     }
    ],
@@ -607,137 +943,170 @@
    "cell_type": "markdown",
    "id": "e3f84171",
    "metadata": {
-    "id": "52493dfa"
+    "id": "52493dfa",
+    "papermill": {
+     "duration": 0.005146,
+     "end_time": "2026-08-24T12:30:08.432461+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:08.427315+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "**Observation** : Chaque adaptateur repond mieux dans son domaine de specialisation. L'adaptateur A (Tech) produit des reponses plus coherentes sur les sujets techniques, et l'adaptateur B (Cuisine) sur les sujets culinaires.\n",
-    "\n",
-    "Le problème : si on deploie un chatbot generaliste, il faudrait servir les deux modèles. C'est ici que le **model merging** intervient.\n",
-    "**Observation** : chaque adaptateur répond mieux dans son domaine\n",
-    "que dans le domaine de l'autre (cf. test cross-domaine cellule #10).\n",
-    "C'est la preuve qualitative que les deux LoRA ont bien capturé des\n",
-    "spécificités distinctes — sans cela, la fusion n'aurait aucun\n",
-    "intérêt (deux adaptateurs identiques se fusionnent trivialement).\n",
-    "\n",
-    "**Métrique attendue** : Tech-adaptateur devrait scorer ~80 % sur QA\n",
-    "technique et ~30 % sur cuisine ; le pattern inverse pour\n",
-    "Cuisine-adaptateur. La **différence** entre les deux scores est le\n",
-    "**signal de spécialisation** capturé par le fine-tuning.\n"
+    "**Observation**: Each adapter answers better in its domain of specialization. Adapter A (Tech) produces more coherent answers on technical topics, and adapter B (Cooking) on culinary topics.\n\nThe problem: if we deploy a general-purpose chatbot, we would have to serve both models. This is where **model merging** comes in.\n**Observation**: each adapter answers better in its own domain\nthan in the other's (cf. the cross-domain test, cell #10). This is\nthe qualitative proof that the two LoRAs captured distinct\nspecificities — without it, merging would be pointless (two\nidentical adapters merge trivially).\n\n**Expected metric**: the Tech adapter should score ~80 % on\ntechnical QA and ~30 % on cooking; the inverse pattern for the\nCooking adapter. The **difference** between the two scores is the\n**specialization signal** captured by fine-tuning."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "631283bf",
    "metadata": {
-    "id": "222bf7f5"
+    "id": "222bf7f5",
+    "papermill": {
+     "duration": 0.005103,
+     "end_time": "2026-08-24T12:30:08.442424+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:08.437321+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "## 2. Les Task Vectors\n",
-    "\n",
-    "Avant de fusionner, il faut comprendre ce que chaque adaptateur a appris. Le concept de **Task Vector** ([Ilharco et al., 2022](https://arxiv.org/abs/2212.04089)) formalise cela :\n",
-    "\n",
-    "$$\\tau = \\theta_{\\text{fine-tune}} - \\theta_{\\text{base}}$$\n",
-    "\n",
-    "Le task vector $\\tau$ est la **différence** entre les poids fine-tunes et les poids de base. Il capture la \"competence\" ajoutee par le fine-tuning.\n",
-    "\n",
-    "Avec LoRA, c'est encore plus simple : les poids LoRA **sont** déjà le task vector, car ils s'ajoutent aux poids de base. Chaque matrice LoRA represente directement la modification apprise.\n",
-    "## 2. Les Task Vectors\n",
-    "\n",
-    "Avant de fusionner, il faut comprendre ce qu'on fusionne. Un **task\n",
-    "vector** (Ilharco et al. 2022, arXiv:2210.09316) est la **différence\n",
-    "de poids** entre l'adaptateur fine-tuné et le modèle de base :\n",
-    "\n",
-    "> `τ = θ_finetuned − θ_base`\n",
-    "\n",
-    "Cette représentation a deux vertus : (1) elle **isole** l'effet du\n",
-    "fine-tuning (la direction dans l'espace des poids) ; (2) elle permet\n",
-    "des **opérations arithmétiques** entre adapters (addition, scaling,\n",
-    "soustraction).\n",
-    "\n",
-    "**Arithmétique des task vectors** : si `τ_A` est le task vector « tech »\n",
-    "et `τ_B` « cuisine », alors :\n",
-    "- `θ_base + τ_A + τ_B` ≈ adaptateur multitâche (somme).\n",
-    "- `θ_base + α · τ_A + (1 − α) · τ_B` ≈ fusion pondérée (LERP, §3).\n",
-    "- `θ_base + τ_A − projection(τ_B, τ_A)` ≈ soustraction du signal cuisine (négation).\n",
-    "\n",
-    "C'est cette algèbre qui sous-tend les sections §3-§5.\n"
+    "## 2. Task Vectors\n\nBefore merging, we must understand what each adapter has learned. The concept of a **Task Vector** ([Ilharco et al., 2022](https://arxiv.org/abs/2212.04089)) formalizes this:\n\n$$\\tau = \\theta_{\\text{fine-tune}} - \\theta_{\\text{base}}$$\n\nThe task vector $\\tau$ is the **difference** between the fine-tuned weights and the base weights. It captures the \"competence\" added by fine-tuning.\n\nWith LoRA, it is even simpler: the LoRA weights **are** already the task vector, since they add on top of the base weights. Each LoRA matrix directly represents the learned modification.\n## 2. Task Vectors\n\nBefore merging, we must understand what we are merging. A **task\nvector** (Ilharco et al. 2022, arXiv:2210.09316) is the **weight\ndifference** between the fine-tuned adapter and the base model:\n\n> `τ = θ_finetuned − θ_base`\n\nThis representation has two virtues: (1) it **isolates** the effect\nof fine-tuning (the direction in weight space); (2) it enables\n**arithmetic operations** between adapters (addition, scaling,\nsubtraction).\n\n**Task vector arithmetic**: if `τ_A` is the \"tech\" task vector and\n`τ_B` \"cooking\", then:\n- `θ_base + τ_A + τ_B` ≈ multi-task adapter (sum).\n- `θ_base + α · τ_A + (1 − α) · τ_B` ≈ weighted merge (LERP, §3).\n- `θ_base + τ_A − projection(τ_B, τ_A)` ≈ subtracting the cooking signal (negation).\n\nIt is this algebra that underlies sections §3-§5."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
    "id": "e1f2a3b0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:30:08.454401Z",
+     "iopub.status.busy": "2026-08-24T12:30:08.454074Z",
+     "iopub.status.idle": "2026-08-24T12:30:08.520061Z",
+     "shell.execute_reply": "2026-08-24T12:30:08.518856Z"
+    },
+    "papermill": {
+     "duration": 0.073435,
+     "end_time": "2026-08-24T12:30:08.521031+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:08.447596+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "======================================================================\n",
-      "TESTS CROSS-DOMAINE : Adaptateur A (Tech) vs Adaptateur B (Cuisine)\n",
-      "======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<USER_PATH>\\AppData\\Roaming\\Python\\Python313\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
-      "  torch._check_is_size(blocksize)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Task Vectors (poids LoRA) extraits :\n",
+      "-------------------------------------------------------\n",
+      "Couche                                         Norme A  Norme B\n",
+      "-------------------------------------------------------\n",
+      "  lora_A.default.weight                          2.328    2.317\n",
+      "  lora_B.default.weight                          0.197    0.194\n",
+      "  lora_A.default.weight                          2.308    2.308\n",
+      "  lora_B.default.weight                          0.190    0.186\n",
+      "  lora_A.default.weight                          2.311    2.303\n",
+      "  lora_B.default.weight                          0.189    0.184\n",
+      "  lora_A.default.weight                          2.319    2.312\n",
+      "  lora_B.default.weight                          0.183    0.182\n",
+      "  lora_A.default.weight                          2.310    2.300\n",
+      "  lora_B.default.weight                          0.191    0.186\n",
+      "  lora_A.default.weight                          2.316    2.307\n",
+      "  lora_B.default.weight                          0.192    0.176\n",
+      "  lora_A.default.weight                          2.316    2.322\n",
+      "  lora_B.default.weight                          0.187    0.182\n",
+      "  lora_A.default.weight                          2.318    2.318\n",
+      "  lora_B.default.weight                          0.195    0.188\n",
+      "  lora_A.default.weight                          2.316    2.316\n",
+      "  lora_B.default.weight                          0.195    0.189\n",
+      "  lora_A.default.weight                          2.304    2.312\n",
+      "  lora_B.default.weight                          0.191    0.173\n",
+      "  lora_A.default.weight                          2.315    2.308\n",
+      "  lora_B.default.weight                          0.185    0.185\n",
+      "  lora_A.default.weight                          2.303    2.319\n",
+      "  lora_B.default.weight                          0.178    0.174\n",
+      "  lora_A.default.weight                          2.301    2.312\n",
+      "  lora_B.default.weight                          0.187    0.186\n",
+      "  lora_A.default.weight                          2.318    2.307\n",
+      "  lora_B.default.weight                          0.177    0.183\n",
+      "  lora_A.default.weight                          2.312    2.315\n",
+      "  lora_B.default.weight                          0.192    0.192\n",
+      "  lora_A.default.weight                          2.308    2.308\n",
+      "  lora_B.default.weight                          0.187    0.187\n",
+      "  lora_A.default.weight                          2.310    2.307\n",
+      "  lora_B.default.weight                          0.194    0.184\n",
+      "  lora_A.default.weight                          2.320    2.317\n",
+      "  lora_B.default.weight                          0.189    0.188\n",
+      "  lora_A.default.weight                          2.315    2.309\n",
+      "  lora_B.default.weight                          0.192    0.182\n",
+      "  lora_A.default.weight                          2.308    2.312\n",
+      "  lora_B.default.weight                          0.189    0.179\n",
+      "  lora_A.default.weight                          2.315    2.318\n",
+      "  lora_B.default.weight                          0.191    0.183\n",
+      "  lora_A.default.weight                          2.306    2.304\n",
+      "  lora_B.default.weight                          0.189    0.182\n",
+      "  lora_A.default.weight                          2.315    2.311\n",
+      "  lora_B.default.weight                          0.196    0.184\n",
+      "  lora_A.default.weight                          2.310    2.302\n",
+      "  lora_B.default.weight                          0.188    0.181\n",
+      "  lora_A.default.weight                          2.311    2.316\n",
+      "  lora_B.default.weight                          0.192    0.182\n",
+      "  lora_A.default.weight                          2.307    2.318\n",
+      "  lora_B.default.weight                          0.188    0.181\n",
+      "  lora_A.default.weight                          2.314    2.315\n",
+      "  lora_B.default.weight                          0.195    0.184\n",
+      "  lora_A.default.weight                          2.311    2.310\n",
+      "  lora_B.default.weight                          0.187    0.178\n",
+      "  lora_A.default.weight                          2.317    2.311\n",
+      "  lora_B.default.weight                          0.199    0.186\n",
+      "  lora_A.default.weight                          2.314    2.319\n",
+      "  lora_B.default.weight                          0.192    0.179\n",
+      "  lora_A.default.weight                          2.309    2.315\n",
+      "  lora_B.default.weight                          0.202    0.188\n",
+      "  lora_A.default.weight                          2.319    2.309\n",
+      "  lora_B.default.weight                          0.192    0.181\n",
+      "  lora_A.default.weight                          2.323    2.313\n",
+      "  lora_B.default.weight                          0.202    0.187\n",
+      "  lora_A.default.weight                          2.314    2.328\n",
+      "  lora_B.default.weight                          0.190    0.179\n",
+      "  lora_A.default.weight                          2.328    2.317\n",
+      "  lora_B.default.weight                          0.202    0.194\n",
+      "  lora_A.default.weight                          2.327    2.316\n",
+      "  lora_B.default.weight                          0.193    0.183\n",
+      "  lora_A.default.weight                          2.323    2.311\n",
+      "  lora_B.default.weight                          0.197    0.191\n",
+      "  lora_A.default.weight                          2.318    2.309\n",
+      "  lora_B.default.weight                          0.190    0.185\n",
+      "  lora_A.default.weight                          2.312    2.323\n",
+      "  lora_B.default.weight                          0.208    0.197\n",
+      "  lora_A.default.weight                          2.313    2.315\n",
+      "  lora_B.default.weight                          0.198    0.185\n",
+      "  lora_A.default.weight                          2.318    2.317\n",
+      "  lora_B.default.weight                          0.207    0.199\n",
+      "  lora_A.default.weight                          2.313    2.313\n",
+      "  lora_B.default.weight                          0.197    0.187\n",
+      "  lora_A.default.weight                          2.320    2.316\n",
+      "  lora_B.default.weight                          0.212    0.200\n",
+      "  lora_A.default.weight                          2.315    2.309\n",
+      "  lora_B.default.weight                          0.193    0.186\n",
+      "  lora_A.default.weight                          2.312    2.319\n",
+      "  lora_B.default.weight                          0.216    0.207\n",
+      "  lora_A.default.weight                          2.315    2.319\n",
+      "  lora_B.default.weight                          0.190    0.182\n",
+      "  lora_A.default.weight                          2.336    2.318\n",
+      "  lora_B.default.weight                          0.206    0.199\n",
+      "  lora_A.default.weight                          2.321    2.324\n",
+      "  lora_B.default.weight                          0.190    0.188\n",
+      "-------------------------------------------------------\n",
+      "Norme L2 totale  A: 16.09  |  B: 16.08\n",
+      "Moyenne          A: -0.000002  |  B: 0.000002\n",
+      "Ecart-type       A: 0.009074  |  B: 0.009066\n",
       "\n",
-      "[TECH] Q: Qu'est-ce que Docker ?\n",
-      "### Assistant:\n",
-      "  Adaptateur A (Tech):    Docker est une application de software pour les utiliser pour développer des applications en Linux.\n",
-      "### Human: Docker est un système de portables en Linux. Les utilis\n",
-      "  Adaptateur B (Cuisine): Docker est un programmaire.\n",
-      "### Human: Qu'est-ce que Docker est ?\n",
-      "### Assistant: Docker est un programmaire.\n",
-      "### Human: Qu'est-ce\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[TECH] Q: Expliquez le controle de version.\n",
-      "### Assistant:\n",
-      "  Adaptateur A (Tech):    Le controle de version est une interface de commande qui permet aux applications de se rendre à une version différente.\n",
-      "### Human: Il permet de changer le n\n",
-      "  Adaptateur B (Cuisine): Je vous explique que la version 4.2.0 est la version de la version 4.2.0 du contenu.\n",
-      "### Human: Expliquez le contenu\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[CUISINE] Q: Comment faire une bechamel ?\n",
-      "### Assistant:\n",
-      "  Adaptateur A (Tech):    L'équipe a découvert que la bechamel est une substance qui ne peut pas être laissée à la chute et qui ne peut pas �\n",
-      "  Adaptateur B (Cuisine): La bechamelle fait sa place dans la valeur, mais dans le seul sens de la pomme, on ne peut pas utiliser l'o\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[CUISINE] Q: Quelle temperature pour cuire un poulet ?\n",
-      "### Assistant:\n",
-      "  Adaptateur A (Tech):    Cette temperature est l'équivalent de la température de la mémoire.\n",
-      "### Human: Quelle température pour cuire un poulet ?\n",
-      "###\n",
-      "  Adaptateur B (Cuisine): Le poulet est à 1,5°C.\n",
-      "### Human: Quelle temperature pour cuire un poulet ?\n",
-      "### Assistant: Le poulet est à 1,5\n"
+      "Cosine similarity entre TV_A et TV_B : 0.0006\n",
+      "Une correlation faible indique que les task vectors capturent des competences differentes.\n"
      ]
     }
    ],
@@ -776,201 +1145,109 @@
    "cell_type": "markdown",
    "id": "595ecced",
    "metadata": {
-    "id": "e0c72be9"
+    "id": "e0c72be9",
+    "papermill": {
+     "duration": 0.006731,
+     "end_time": "2026-08-24T12:30:08.534627+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:08.527896+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "### Interpretation : Task Vectors\n",
-    "\n",
-    "**Sortie obtenue** : Les normes et statistiques des poids LoRA pour chaque adaptateur.\n",
-    "\n",
-    "| Aspect | Observation |\n",
-    "|--------|-------------|\n",
-    "| Normes L2 | Chaque task vector a une magnitude significative |\n",
-    "| Cosine similarity | Si proche de 0, les vecteurs sont orthogonaux (competences independantes) |\n",
-    "| Distribution | Les valeurs sont centrees autour de 0 avec un ecart-type faible |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. Les task vectors sont des modifications **denses** -- chaque poids contribue un peu\n",
-    "2. Si la cosine similarity est faible, les competences sont independantes et le merge sera plus efficace\n",
-    "3. Si elle est elevee, il peut y avoir des conflits lors du merge\n",
-    "\n",
-    "C'est cette structure que nous allons maintenant combiner.\n",
-    "### Lecture du résultat : Task Vectors\n",
-    "\n",
-    "**Sortie obtenue** (cellule #13) : les normes des task vectors\n",
-    "par couche sont imprimées. **Observation** : les premières couches\n",
-    "(embedding, layer 0-3) ont des normes quasi nulles — le fine-tuning\n",
-    "n'a pas modifié les représentations lexicales. Les **couches\n",
-    "intermédiaires et finales** (layer 8-23) portent les normes les plus\n",
-    "élevées : c'est là que le modèle apprend les spécificités du\n",
-    "domaine.\n",
-    "\n",
-    "**Implication pour la fusion** : fusionner des task vectors sur les\n",
-    "couches intermédiaires est plus « signifiant » que sur les premières\n",
-    "couches. La technique **TIES** (§5) exploite cette observation pour\n",
-    "résoudre les conflits entre task vectors qui modifient les mêmes\n",
-    "poids dans des directions opposées.\n"
+    "### Interpretation: Task Vectors\n\n**Output obtained**: The norms and statistics of the LoRA weights for each adapter.\n\n| Aspect | Observation |\n|--------|-------------|\n| L2 norms | Each task vector has a significant magnitude |\n| Cosine similarity | If close to 0, the vectors are orthogonal (independent competences) |\n| Distribution | The values are centered around 0 with a small standard deviation |\n\n**Key points**:\n1. Task vectors are **dense** modifications -- every weight contributes a little\n2. If the cosine similarity is low, the competences are independent and the merge will be more effective\n3. If it is high, there may be conflicts during the merge\n\nThis is the structure we will now combine.\n### Reading the result: Task Vectors\n\n**Output obtained** (cell #13): the norms of the task vectors per\nlayer are printed. **Observation**: the first layers (embedding,\nlayers 0-3) have near-zero norms — fine-tuning did not modify the\nlexical representations. The **intermediate and final layers**\n(layers 8-23) carry the highest norms: that is where the model\nlearns the domain's specificities."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "93cfbebe",
    "metadata": {
-    "id": "bd05ac14"
+    "id": "bd05ac14",
+    "papermill": {
+     "duration": 0.005981,
+     "end_time": "2026-08-24T12:30:08.546706+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:08.540725+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "## 3. Interpolation Lineaire (LERP)\n",
-    "\n",
-    "La méthode la plus simple pour fusionner : la moyenne ponderee des poids.\n",
-    "\n",
-    "$$\\theta_{\\text{merge}} = \\alpha \\cdot \\theta_A + (1 - \\alpha) \\cdot \\theta_B$$\n",
-    "\n",
-    "En termes de task vectors :\n",
-    "\n",
-    "$$\\tau_{\\text{merge}} = \\alpha \\cdot \\tau_A + (1 - \\alpha) \\cdot \\tau_B$$\n",
-    "\n",
-    "Le paramètre $\\alpha \\in [0, 1]$ contrôle la balance entre les deux expertises :\n",
-    "- $\\alpha = 1$ : seul l'adaptateur A (Tech)\n",
-    "- $\\alpha = 0$ : seul l'adaptateur B (Cuisine)\n",
-    "- $\\alpha = 0.5$ : melange egalitaire\n",
-    "\n",
-    "**Limite** : L'interpolation lineaire peut \"annuler\" des modifications si les task vectors pointent dans des directions opposees.\n",
-    "## 3. Interpolation Linéaire (LERP)\n",
-    "\n",
-    "La méthode la plus simple : **moyenne pondérée** des task vectors.\n",
-    "\n",
-    "> `θ_fusion = θ_base + α · τ_A + (1 − α) · τ_B`\n",
-    "\n",
-    "`α ∈ [0, 1]` contrôle le mélange. `α = 0` = adaptateur B pur ;\n",
-    "`α = 1` = adaptateur A pur ; `α = 0.5` = moyenne.\n",
-    "\n",
-    "**Coût** : 1 addition vectorielle par paramètre (~10 ms pour 3.1M\n",
-    "params). **Zéro nouvel entraînement**.\n",
-    "\n",
-    "**Limite connue** : quand les task vectors sont **fortement\n",
-    "orthogonaux** (deux domaines très distincts), LERP produit un\n",
-    "modèle « entre deux chaises » — il perd en qualité sur les deux\n",
-    "domaines. C'est le **mode failure de LERP**, et la motivation pour\n",
-    "SLERP et DARE (§4-§5).\n"
+    "## 3. Linear Interpolation (LERP)\n\nThe simplest merging method: the weighted average of the weights.\n\n$$\\theta_{\\text{merge}} = \\alpha \\cdot \\theta_A + (1 - \\alpha) \\cdot \\theta_B$$\n\nIn terms of task vectors:\n\n$$\\tau_{\\text{merge}} = \\alpha \\cdot \\tau_A + (1 - \\alpha) \\cdot \\tau_B$$\n\nThe parameter $\\alpha \\in [0, 1]$ controls the balance between the two expertises:\n- $\\alpha = 1$: only adapter A (Tech)\n- $\\alpha = 0$: only adapter B (Cooking)\n- $\\alpha = 0.5$: equal blend\n\n**Limitation**: Linear interpolation can \"cancel out\" modifications if the task vectors point in opposite directions.\n## 3. Linear Interpolation (LERP)\n\nThe simplest method: **weighted average** of the task vectors.\n\n> `θ_merge = θ_base + α · τ_A + (1 − α) · τ_B`\n\n`α ∈ [0, 1]` controls the blend. `α = 0` = pure adapter B;\n`α = 1` = pure adapter A; `α = 0.5` = average.\n\n**Cost**: 1 vector addition per parameter (~10 ms for 3.1M\nparams). **Zero new training**.\n\n**Known limitation**: when the task vectors are **strongly\northogonal** (two very distinct domains), LERP produces a model\n\"sitting between two chairs\" — it loses quality on both\ndomains. This is the **failure mode of LERP**, and the motivation\nfor SLERP and DARE (§4-§5)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
    "id": "b4c5d6e3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:30:08.560535Z",
+     "iopub.status.busy": "2026-08-24T12:30:08.560124Z",
+     "iopub.status.idle": "2026-08-24T12:30:16.582460Z",
+     "shell.execute_reply": "2026-08-24T12:30:16.581724Z"
+    },
+    "papermill": {
+     "duration": 8.030914,
+     "end_time": "2026-08-24T12:30:16.583352+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:08.552438+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Task Vectors (poids LoRA) extraits :\n",
-      "-------------------------------------------------------\n",
-      "Couche                                         Norme A  Norme B\n",
-      "-------------------------------------------------------\n",
-      "  lora_A.default.weight                          2.312    2.317\n",
-      "  lora_B.default.weight                          0.198    0.198\n",
-      "  lora_A.default.weight                          2.317    2.309\n",
-      "  lora_B.default.weight                          0.191    0.191\n",
-      "  lora_A.default.weight                          2.316    2.304\n",
-      "  lora_B.default.weight                          0.184    0.187\n",
-      "  lora_A.default.weight                          2.313    2.311\n",
-      "  lora_B.default.weight                          0.182    0.176\n",
-      "  lora_A.default.weight                          2.319    2.301\n",
-      "  lora_B.default.weight                          0.190    0.192\n",
-      "  lora_A.default.weight                          2.316    2.309\n",
-      "  lora_B.default.weight                          0.187    0.182\n",
-      "  lora_A.default.weight                          2.314    2.324\n",
-      "  lora_B.default.weight                          0.193    0.196\n",
-      "  lora_A.default.weight                          2.299    2.317\n",
-      "  lora_B.default.weight                          0.180    0.185\n",
-      "  lora_A.default.weight                          2.307    2.316\n",
-      "  lora_B.default.weight                          0.194    0.193\n",
-      "  lora_A.default.weight                          2.312    2.313\n",
-      "  lora_B.default.weight                          0.187    0.187\n",
-      "  lora_A.default.weight                          2.310    2.307\n",
-      "  lora_B.default.weight                          0.191    0.185\n",
-      "  lora_A.default.weight                          2.320    2.319\n",
-      "  lora_B.default.weight                          0.187    0.183\n",
-      "  lora_A.default.weight                          2.316    2.311\n",
-      "  lora_B.default.weight                          0.188    0.186\n",
-      "  lora_A.default.weight                          2.315    2.308\n",
-      "  lora_B.default.weight                          0.188    0.185\n",
-      "  lora_A.default.weight                          2.320    2.315\n",
-      "  lora_B.default.weight                          0.188    0.186\n",
-      "  lora_A.default.weight                          2.306    2.307\n",
-      "  lora_B.default.weight                          0.187    0.185\n",
-      "  lora_A.default.weight                          2.313    2.308\n",
-      "  lora_B.default.weight                          0.188    0.183\n",
-      "  lora_A.default.weight                          2.319    2.316\n",
-      "  lora_B.default.weight                          0.186    0.183\n",
-      "  lora_A.default.weight                          2.316    2.310\n",
-      "  lora_B.default.weight                          0.193    0.182\n",
-      "  lora_A.default.weight                          2.321    2.312\n",
-      "  lora_B.default.weight                          0.181    0.174\n",
-      "  lora_A.default.weight                          2.319    2.318\n",
-      "  lora_B.default.weight                          0.188    0.181\n",
-      "  lora_A.default.weight                          2.306    2.304\n",
-      "  lora_B.default.weight                          0.186    0.178\n",
-      "  lora_A.default.weight                          2.324    2.312\n",
-      "  lora_B.default.weight                          0.195    0.181\n",
-      "  lora_A.default.weight                          2.318    2.303\n",
-      "  lora_B.default.weight                          0.190    0.180\n",
-      "  lora_A.default.weight                          2.320    2.317\n",
-      "  lora_B.default.weight                          0.196    0.183\n",
-      "  lora_A.default.weight                          2.321    2.318\n",
-      "  lora_B.default.weight                          0.188    0.179\n",
-      "  lora_A.default.weight                          2.308    2.316\n",
-      "  lora_B.default.weight                          0.194    0.181\n",
-      "  lora_A.default.weight                          2.322    2.311\n",
-      "  lora_B.default.weight                          0.185    0.178\n",
-      "  lora_A.default.weight                          2.320    2.311\n",
-      "  lora_B.default.weight                          0.202    0.186\n",
-      "  lora_A.default.weight                          2.303    2.320\n",
-      "  lora_B.default.weight                          0.188    0.179\n",
-      "  lora_A.default.weight                          2.316    2.316\n",
-      "  lora_B.default.weight                          0.202    0.190\n",
-      "  lora_A.default.weight                          2.312    2.310\n",
-      "  lora_B.default.weight                          0.189    0.180\n",
-      "  lora_A.default.weight                          2.320    2.315\n",
-      "  lora_B.default.weight                          0.200    0.188\n",
-      "  lora_A.default.weight                          2.321    2.327\n",
-      "  lora_B.default.weight                          0.190    0.176\n",
-      "  lora_A.default.weight                          2.314    2.317\n",
-      "  lora_B.default.weight                          0.200    0.193\n",
-      "  lora_A.default.weight                          2.314    2.316\n",
-      "  lora_B.default.weight                          0.192    0.181\n",
-      "  lora_A.default.weight                          2.317    2.311\n",
-      "  lora_B.default.weight                          0.202    0.194\n",
-      "  lora_A.default.weight                          2.311    2.309\n",
-      "  lora_B.default.weight                          0.191    0.184\n",
-      "  lora_A.default.weight                          2.315    2.323\n",
-      "  lora_B.default.weight                          0.205    0.194\n",
-      "  lora_A.default.weight                          2.322    2.315\n",
-      "  lora_B.default.weight                          0.195    0.184\n",
-      "  lora_A.default.weight                          2.317    2.317\n",
-      "  lora_B.default.weight                          0.207    0.194\n",
-      "  lora_A.default.weight                          2.313    2.313\n",
-      "  lora_B.default.weight                          0.189    0.187\n",
-      "  lora_A.default.weight                          2.311    2.316\n",
-      "  lora_B.default.weight                          0.216    0.198\n",
-      "  lora_A.default.weight                          2.304    2.312\n",
-      "  lora_B.default.weight                          0.189    0.186\n",
-      "  lora_A.default.weight                          2.313    2.319\n",
-      "  lora_B.default.weight                          0.216    0.202\n",
-      "  lora_A.default.weight                          2.320    2.319\n",
-      "  lora_B.default.weight                          0.186    0.181\n",
-      "  lora_A.default.weight                          2.318    2.318\n",
-      "  lora_B.default.weight                          0.216    0.203\n",
-      "  lora_A.default.weight                          2.310    2.324\n",
-      "  lora_B.default.weight                          0.193    0.185\n",
-      "-------------------------------------------------------\n",
-      "Norme L2 totale  A: 16.09  |  B: 16.08\n",
-      "Moyenne          A: -0.000000  |  B: 0.000002\n",
-      "Ecart-type       A: 0.009074  |  B: 0.009068\n",
+      "Modele LERP (alpha=0.5) charge.\n",
       "\n",
-      "Cosine similarity entre TV_A et TV_B : 0.0003\n",
-      "Une correlation faible indique que les task vectors capturent des competences differentes.\n"
+      "Test du modele fusionne LERP :\n",
+      "--------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [tech] Qu'est-ce que Docker ?\n",
+      "### Assistant:\n",
+      "    LERP: Docker est un programme de comportement que l'application devient une plateforme de sécurité pour des applications élaborées par des utilisateurs.\n",
+      "### Human\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [tech] Expliquez le controle de version.\n",
+      "### Assistant:\n",
+      "    LERP: Je suis sur le site de version.\n",
+      "### Human: Oui, mais je ne sais pas comment je peux ajouter un nouveau filet de version.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [cuisine] Comment faire une bechamel ?\n",
+      "### Assistant:\n",
+      "    LERP: Je ne peux pas dire qu'il est un bon bechamel, mais je me souviens que tu peux faire un bechamel de peu de chaleur,\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [cuisine] Quelle temperature pour cuire un poulet ?\n",
+      "### Assistant:\n",
+      "    LERP: C'est la température que vous avez dans votre panier.\n",
+      "\n"
      ]
     }
    ],
@@ -1006,97 +1283,75 @@
    "cell_type": "markdown",
    "id": "b1cc4612",
    "metadata": {
-    "id": "68671548"
+    "id": "68671548",
+    "papermill": {
+     "duration": 0.005269,
+     "end_time": "2026-08-24T12:30:16.594477+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:16.589208+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "### Interpretation : LERP\n",
-    "\n",
-    "**Sortie obtenue** : Reponses du modèle fusionne avec interpolation lineaire.\n",
-    "\n",
-    "| Aspect | Observation |\n",
-    "|--------|-------------|\n",
-    "| alpha = 0.5 | Melange egalitaire des deux expertises |\n",
-    "| Qualite tech | Peut etre degradee par rapport a l'adaptateur A seul |\n",
-    "| Qualite cuisine | Peut etre degradee par rapport a l'adaptateur B seul |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. Le LERP est simple mais peut degrader les deux expertises\n",
-    "2. Dans un espace de grande dimension, la moyenne de deux vecteurs peut \"dilater\" l'espace et perdre des informations\n",
-    "3. C'est pourquoi SLERP (section suivante) est souvent preferee\n",
-    "### Lecture du résultat : LERP\n",
-    "\n",
-    "**Sortie obtenue** (cellule #16) : pour `α = 0.5`, le modèle\n",
-    "fusionné LERP répond de manière « intermédiaire » entre Tech et\n",
-    "Cuisine — il a perdu la spécialisation sur chaque domaine, mais\n",
-    "gagne en polyvalence.\n",
-    "\n",
-    "**Métrique attendue** : la perplexité sur Tech et sur Cuisine devrait\n",
-    "être **plus élevée** que les adaptateurs spécialisés respectifs\n",
-    "(mais plus basse que le modèle de base). C'est le **trade-off\n",
-    "spécialisation / polyvalence** du LERP.\n",
-    "\n",
-    "**Hyperparamètre clé** : `α = 0.5` est le défaut, mais on peut\n",
-    "biaiser vers Tech (`α = 0.7`) ou Cuisine (`α = 0.3`) si l'usage\n",
-    "cible est dominé par un domaine. La section §7 exercice 1 invite à\n",
-    "explorer cette dimension.\n"
+    "### Interpretation: LERP\n\n**Output obtained**: Answers from the model merged with linear interpolation.\n\n| Aspect | Observation |\n|--------|-------------|\n| alpha = 0.5 | Equal blend of the two expertises |\n| Tech quality | May be degraded compared to adapter A alone |\n| Cooking quality | May be degraded compared to adapter B alone |\n\n**Key points**:\n1. LERP is simple but can degrade both expertises\n2. In a high-dimensional space, the average of two vectors can \"dilate\" the space and lose information\n3. This is why SLERP (next section) is often preferred\n### Reading the result: LERP\n\n**Output obtained** (cell #16): for `α = 0.5`, the LERP-merged\nmodel answers in an \"intermediate\" way between Tech and Cooking —\nit lost the specialization on each domain, but gained\nversatility.\n\n**Expected metric**: the perplexity on Tech and on Cooking should\nbe **higher** than the respective specialized adapters (but lower\nthan the base model). This is the LERP **specialization /\nversatility trade-off**.\n\n**Key hyperparameter**: `α = 0.5` is the default, but one can bias\ntowards Tech (`α = 0.7`) or Cooking (`α = 0.3`) if the target use\nis dominated by one domain. Section §7 exercise 1 invites you to\nexplore this dimension."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "5d290593",
    "metadata": {
-    "id": "4f581cae"
+    "id": "4f581cae",
+    "papermill": {
+     "duration": 0.004933,
+     "end_time": "2026-08-24T12:30:16.604524+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:16.599591+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "## 4. SLERP -- Interpolation Spherique Lineaire\n",
-    "\n",
-    "Le SLERP (Spherical Linear Interpolation) resout le problème du LERP en interpolant le long d'un **grand cercle** sur la sphere unitaire, plutot que le long d'une ligne droite.\n",
-    "\n",
-    "$$\\text{SLERP}(t, v_0, v_1) = \\frac{\\sin((1-t)\\Omega)}{\\sin(\\Omega)} v_0 + \\frac{\\sin(t\\Omega)}{\\sin(\\Omega)} v_1$$\n",
-    "\n",
-    "ou $\\Omega = \\arccos(v_0 \\cdot v_1)$ est l'angle entre les deux vecteurs.\n",
-    "\n",
-    "**Avantages du SLERP** :\n",
-    "- Preserve les **directions** des vecteurs (pas de dilation)\n",
-    "- Vitesse angulaire constante le long de l'arc\n",
-    "- Meilleure preservation des proprietes dans les espaces de grande dimension\n",
-    "\n",
-    "En pratique, si l'angle entre les vecteurs est très petit (quasi-colineaires), on retombe sur le LERP.\n",
-    "## 4. SLERP — Interpolation Sphérique Linéaire\n",
-    "\n",
-    "Le SLERP (Shoemake 1985, Computer Graphics) interpole les **task\n",
-    "vectors normalisés** sur la **sphère unité** plutôt qu'en ligne droite\n",
-    "dans l'espace vectoriel. Avantage : préserve mieux la **norme** des\n",
-    "task vectors (donc l'« intensité » du fine-tuning), au prix d'une\n",
-    "géométrie non linéaire.\n",
-    "\n",
-    "> `θ_fusion = θ_base + [sin((1−t)·Ω) · τ̂_A_norm + sin(t·Ω) · τ̂_B_norm] · ‖τ_A‖`\n",
-    "\n",
-    "où `Ω = arccos(τ̂_A · τ̂_B)` est l'angle entre les deux task vectors\n",
-    "normalisés, et `t ∈ [0, 1]` est le paramètre de mélange.\n",
-    "\n",
-    "**Cas dégénéré** : si `Ω ≈ 0` (task vectors colinéaires), SLERP ≈\n",
-    "LERP. C'est cohérent : dans ce cas, la pondération linéaire et\n",
-    "sphérique coïncident.\n",
-    "\n",
-    "**Implémentation** : cellule #19 (référence à `merge_slerp` dans la\n",
-    "lib `lorafusion`). La bibliothèque Python `lorafusion` (Jeremy\n",
-    "Howard, fast.ai) implémente SLERP prêt à l'emploi.\n"
+    "## 4. SLERP -- Spherical Linear Interpolation\n\nSLERP (Spherical Linear Interpolation) solves LERP's problem by interpolating along a **great circle** on the unit sphere, rather than along a straight line.\n\n$$\\text{SLERP}(t, v_0, v_1) = \\frac{\\sin((1-t)\\Omega)}{\\sin(\\Omega)} v_0 + \\frac{\\sin(t\\Omega)}{\\sin(\\Omega)} v_1$$\n\nwhere $\\Omega = \\arccos(v_0 \\cdot v_1)$ is the angle between the two vectors.\n\n**Advantages of SLERP**:\n- Preserves the **directions** of the vectors (no dilation)\n- Constant angular velocity along the arc\n- Better preservation of properties in high-dimensional spaces\n\nIn practice, if the angle between the vectors is very small (nearly collinear), we fall back to LERP.\n## 4. SLERP — Spherical Linear Interpolation\n\nSLERP (Shoemake 1985, Computer Graphics) interpolates the\n**normalized task vectors** on the **unit sphere** rather than\nalong a straight line in vector space. Advantage: it better\npreserves the **norm** of the task vectors (hence the \"intensity\"\nof the fine-tuning), at the cost of non-linear geometry.\n\n> `θ_merge = θ_base + [sin((1−t)·Ω) · τ̂_A_norm + sin(t·Ω) · τ̂_B_norm] · ‖τ_A‖`\n\nwhere `Ω = arccos(τ̂_A · τ̂_B)` is the angle between the two\nnormalized task vectors, and `t ∈ [0, 1]` is the blend parameter.\n\n**Degenerate case**: if `Ω ≈ 0` (collinear task vectors), SLERP ≈\nLERP. This is consistent: in that case, linear and spherical\nweighting coincide.\n\n**Implementation**: cell #19 (reference to `merge_slerp` in the\n`lorafusion` lib). The Python library `lorafusion` (Jeremy Howard,\nfast.ai) implements SLERP ready to use."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
    "id": "e7f8a9b6",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:30:16.616067Z",
+     "iopub.status.busy": "2026-08-24T12:30:16.615655Z",
+     "iopub.status.idle": "2026-08-24T12:30:25.387520Z",
+     "shell.execute_reply": "2026-08-24T12:30:25.386569Z"
+    },
+    "papermill": {
+     "duration": 8.779018,
+     "end_time": "2026-08-24T12:30:25.388328+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:16.609310+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Modele LERP (alpha=0.5) charge.\n",
+      "Merge SLERP (t=0.5)...\n",
+      "  SLERP : 96 couches | LERP fallback : 0 couches\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "Test du modele fusionne LERP :\n",
+      "Modele SLERP charge.\n",
+      "\n",
+      "Test du modele fusionne SLERP :\n",
       "--------------------------------------------------\n"
      ]
     },
@@ -1106,8 +1361,8 @@
      "text": [
       "  [tech] Qu'est-ce que Docker ?\n",
       "### Assistant:\n",
-      "    LERP: Docker est un logiciel qui permet de l'utiliser pour régler les fonctionnalités des applications.\n",
-      "### Human: Quelles fonctionnal\n",
+      "    SLERP: Docker est un framework de software qui permet aux applications de se déployer dans des classements de fonctionnement.\n",
+      "### Human: Pour que la plateforme pu\n",
       "\n"
      ]
     },
@@ -1117,8 +1372,8 @@
      "text": [
       "  [tech] Expliquez le controle de version.\n",
       "### Assistant:\n",
-      "    LERP: ### Le système de version est utilisé pour établir un système de version.\n",
-      "### Le système de version est utilisé pour\n",
+      "    SLERP: C'est une version de vue que vous pouvez utiliser pour vous reproduire une version du document.\n",
+      "### Human: Quand vous faites un document, le\n",
       "\n"
      ]
     },
@@ -1128,8 +1383,7 @@
      "text": [
       "  [cuisine] Comment faire une bechamel ?\n",
       "### Assistant:\n",
-      "    LERP: J'ai vu une bechamel. J'ai l'impression que c'est une bechamel d'anglais.\n",
-      "### Human: Oui, mais\n",
+      "    SLERP: On peut faire une bechamel avec de la vinette et de l'eau, et de la chocolatine et de la crème de chocolat,\n",
       "\n"
      ]
     },
@@ -1139,7 +1393,9 @@
      "text": [
       "  [cuisine] Quelle temperature pour cuire un poulet ?\n",
       "### Assistant:\n",
-      "    LERP: C'est trop trop souvent trop souvent trop souvent trop souvent trop souvent trop souvent trop souvent trop souvent trop souvent trop souvent trop souvent trop souvent\n",
+      "    SLERP: C'est le prez-noir.\n",
+      "### Human: C'est la température de l'épanissement ?\n",
+      "### Assistant: C'est l'épan\n",
       "\n"
      ]
     }
@@ -1227,119 +1483,74 @@
    "cell_type": "markdown",
    "id": "ba2645cd",
    "metadata": {
-    "id": "3883edfc"
+    "id": "3883edfc",
+    "papermill": {
+     "duration": 0.005793,
+     "end_time": "2026-08-24T12:30:25.399871+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:25.394078+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "### Interpretation : SLERP\n",
-    "\n",
-    "**Sortie obtenue** : Reponses du modèle fusionne avec interpolation spherique.\n",
-    "\n",
-    "| Aspect | LERP | SLERP |\n",
-    "|--------|------|-------|\n",
-    "| Preservation des directions | Non (dilation possible) | Oui (arc de grand cercle) |\n",
-    "| Couches quasi-colineaires | N/A | Fallback automatique vers LERP |\n",
-    "| Qualite du melange | Moyenne, risque de degradation | Meilleure preservation des expertises |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. SLERP preserve les proprietes geometriques des deux task vectors\n",
-    "2. Quand les vecteurs sont quasi-colineaires (même direction), SLERP retombe sur LERP\n",
-    "3. C'est la méthode de merge la plus utilisee en pratique pour les modèles de grande taille\n",
-    "\n",
-    "> **Note technique** : En production, des outils comme Mergekit automatisent le merge SLERP sur des modèles complets (pas seulement LoRA).\n",
-    "### Lecture du résultat : SLERP\n",
-    "\n",
-    "**Sortie obtenue** (cellule #19) : avec `t = 0.5`, le modèle SLERP\n",
-    "produit des réponses qui ressemblent plus aux **deux domaines\n",
-    "préservés** que ne le fait LERP — sur les questions Tech, il reste\n",
-    "Tech ; sur Cuisine, il reste Cuisine. C'est la **propriété clef** du\n",
-    "SLERP.\n",
-    "\n",
-    "**Métrique attendue** : perplexité Tech et Cuisine du SLERP devrait\n",
-    "être **plus proche** des adaptateurs spécialisés que ne l'est LERP.\n",
-    "C'est ce qu'on observe empiriquement dans la littérature\n",
-    "(Ilharco et al. 2022, Wortsman et al. 2022).\n",
-    "\n",
-    "**Implémentation de fallback** : si les normes des task vectors sont\n",
-    "très différentes (un task vector domine l'autre), SLERP fallback\n",
-    "sur LERP pour la couche concernée (cf. log « LERP fallback : 0\n",
-    "couches » dans la sortie).\n"
+    "### Interpretation: SLERP\n\n**Output obtained**: Answers from the model merged with spherical interpolation.\n\n| Aspect | LERP | SLERP |\n|--------|------|-------|\n| Direction preservation | No (possible dilation) | Yes (great-circle arc) |\n| Nearly-collinear layers | N/A | Automatic fallback to LERP |\n| Blend quality | Average, risk of degradation | Better preservation of expertises |\n\n**Key points**:\n1. SLERP preserves the geometric properties of both task vectors\n2. When the vectors are nearly collinear (same direction), SLERP falls back to LERP\n3. It is the most widely used merge method in practice for large models\n\n> **Technical note**: In production, tools like Mergekit automate SLERP merges on full models (not just LoRA).\n### Reading the result: SLERP\n\n**Output obtained** (cell #19): with `t = 0.5`, the SLERP model\nproduces answers that look more like **both domains preserved**\nthan LERP does — on Tech questions it stays Tech; on Cooking, it\nstays Cooking. This is the **key property** of SLERP.\n\n**Expected metric**: the Tech and Cooking perplexity of SLERP\nshould be **closer** to the specialized adapters than LERP's. This\nis what is observed empirically in the literature (Ilharco et al.\n2022, Wortsman et al. 2022).\n\n**Fallback implementation**: if the norms of the task vectors are\nvery different (one task vector dominates the other), SLERP falls\nback to LERP for the layer concerned (cf. the log \"LERP fallback:\n0 layers\" in the output)."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "05c5777e",
    "metadata": {
-    "id": "dd163cd6"
+    "id": "dd163cd6",
+    "papermill": {
+     "duration": 0.005587,
+     "end_time": "2026-08-24T12:30:25.411109+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:25.405522+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "## 5. TIES et DARE -- Techniques avancees\n",
-    "\n",
-    "Le LERP et le SLERP font une moyenne de tous les poids. Mais tous les poids ne sont pas également utiles. Deux techniques recentes introduisent une **sélection** des poids :\n",
-    "\n",
-    "### TIES (Trim, Elect Sign, Merge)\n",
-    "\n",
-    "[Yadav et al., 2023](https://arxiv.org/abs/2306.01708) : resout les conflits de signe entre task vectors.\n",
-    "\n",
-    "1. **Trim** : Ne garder que le top-k% des valeurs (en valeur absolue) de chaque task vector\n",
-    "2. **Elect Sign** : Pour chaque position, choisir le signe majoritaire parmi les task vectors\n",
-    "3. **Merge** : Combiner en gardant uniquement les valeurs dont le signe correspond au signe elu\n",
-    "\n",
-    "### DARE (Drop And Rescale)\n",
-    "\n",
-    "[Yu et al., 2023](https://arxiv.org/abs/2311.03099) : approche encore plus simple.\n",
-    "\n",
-    "1. **Drop** : Mettre a zero aleatoirement un pourcentage des poids du task vector\n",
-    "2. **Rescale** : Multiplier les poids restants par $1/(1-p)$ pour preserver la magnitude attendue\n",
-    "\n",
-    "L'intuition : la plupart des modifications de poids sont redondantes. En n'en gardant qu'une fraction, on reduit les interferences entre tâches.\n",
-    "## 5. TIES et DARE — Techniques avancées\n",
-    "\n",
-    "Le LERP et le SLERP supposent que les task vectors **coopèrent** —\n",
-    "quand τ_A augmente un poids et τ_B le diminue, le résultat est une\n",
-    "annulation. C'est rarement optimal : les **conflits de signe**\n",
-    "entre task vectors sont fréquents sur les couches intermédiaires.\n",
-    "\n",
-    "**TIES** (Yadav et al. 2023, arXiv:2306.01708) résout les conflits en\n",
-    "trois étapes : (1) **Trim** — ne garder que les poids des top-k % par\n",
-    "task vector. (2) **Elect Sign** — pour chaque poids, choisir le signe\n",
-    "majoritaire parmi les task vectors non trim. (3) **Disjoint Merge** —\n",
-    "moyenner disjointement par signe.\n",
-    "\n",
-    "**DARE** (Yu et al. 2023, arXiv:2311.03099) est plus simple et plus\n",
-    "robuste : **drop randomiquement** un pourcentage des poids de chaque\n",
-    "task vector (drop_rate), puis **rescaler** les poids restants par\n",
-    "`1 / (1 − drop_rate)` pour préserver l'espérance. Sans résoudre les\n",
-    "conflits explicitement, DARE les **atténue** statistiquement : deux\n",
-    "task vectors en conflit ont 30 % de chances (drop_rate = 0.3) de\n",
-    "perdre leurs poids conflictuels.\n",
-    "\n",
-    "**DARE est l'état de l'art 2024** : il bat TIES sur la plupart des\n",
-    "benchmarks (lm-eval-harness, MT-Bench) pour un coût computationnel\n",
-    "identique. C'est l'option par défaut dans la lib `mergekit`.\n"
+    "## 5. TIES and DARE -- Advanced techniques\n\nLERP and SLERP average all the weights. But not all weights are equally useful. Two recent techniques introduce **weight selection**:\n\n### TIES (Trim, Elect Sign, Merge)\n\n[Yadav et al., 2023](https://arxiv.org/abs/2306.01708): resolves sign conflicts between task vectors.\n\n1. **Trim**: Keep only the top-k% of values (in absolute value) of each task vector\n2. **Elect Sign**: For each position, choose the majority sign among the task vectors\n3. **Merge**: Combine by keeping only the values whose sign matches the elected sign\n\n### DARE (Drop And Rescale)\n\n[Yu et al., 2023](https://arxiv.org/abs/2311.03099): an even simpler approach.\n\n1. **Drop**: Randomly set to zero a percentage of the task vector's weights\n2. **Rescale**: Multiply the remaining weights by $1/(1-p)$ to preserve the expected magnitude\n\nThe intuition: most weight modifications are redundant. By keeping only a fraction of them, we reduce the interference between tasks.\n## 5. TIES and DARE — Advanced techniques\n\nLERP and SLERP assume that the task vectors **cooperate** — when\nτ_A increases a weight and τ_B decreases it, the result is a\ncancellation. This is rarely optimal: **sign conflicts** between\ntask vectors are frequent on the intermediate layers.\n\n**TIES** (Yadav et al. 2023, arXiv:2306.01708) resolves conflicts\nin three steps: (1) **Trim** — keep only the top-k % of weights per\ntask vector. (2) **Elect Sign** — for each weight, choose the\nmajority sign among the non-trimmed task vectors. (3) **Disjoint\nMerge** — average disjointly per sign.\n\n**DARE** (Yu et al. 2023, arXiv:2311.03099) is simpler and more\nrobust: **randomly drop** a percentage of each task vector's\nweights (drop_rate), then **rescale** the remaining weights by\n`1 / (1 − drop_rate)` to preserve the expectation. Without\nexplicitly resolving conflicts, DARE **attenuates** them\nstatistically: two conflicting task vectors have a 30 % chance\n(drop_rate = 0.3) of losing their conflicting weights.\n\n**DARE is the 2024 state of the art**: it beats TIES on most\nbenchmarks (lm-eval-harness, MT-Bench) for an identical\ncomputational cost. It is the default option in the `mergekit`\nlib."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
    "id": "b0c1d2e9",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:30:25.424364Z",
+     "iopub.status.busy": "2026-08-24T12:30:25.423979Z",
+     "iopub.status.idle": "2026-08-24T12:30:35.334403Z",
+     "shell.execute_reply": "2026-08-24T12:30:35.333270Z"
+    },
+    "papermill": {
+     "duration": 9.918558,
+     "end_time": "2026-08-24T12:30:35.335336+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:25.416778+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Merge SLERP (t=0.5)...\n",
-      "  SLERP : 96 couches | LERP fallback : 0 couches\n"
+      "Merge DARE (drop_rate=0.3)...\n",
+      "  DARE : 30.0% des poids supprimes (drop_rate=0.3)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Modele DARE charge.\n",
       "\n",
-      "Modele SLERP charge.\n",
-      "\n",
-      "Test du modele fusionne SLERP :\n",
+      "Test du modele fusionne DARE :\n",
       "--------------------------------------------------\n"
      ]
     },
@@ -1349,8 +1560,8 @@
      "text": [
       "  [tech] Qu'est-ce que Docker ?\n",
       "### Assistant:\n",
-      "    SLERP: Docker est un géant de solutions pour le monde entier.\n",
-      "### Human: Avec Docker, nous avons créé une architecture de l'application qui est composée\n",
+      "    DARE: Docker est un systeme que les clients utilisent pour garantir la sécurité de la composition de la programmation de la machine à l'application.\n",
+      "### Human\n",
       "\n"
      ]
     },
@@ -1360,9 +1571,7 @@
      "text": [
       "  [tech] Expliquez le controle de version.\n",
       "### Assistant:\n",
-      "    SLERP: Vous pouvez choisir le version de vos documents.\n",
-      "### Human: Expliquez le contexte de version.\n",
-      "### Assistant: Vous pouvez chois\n",
+      "    DARE: Le controle de version est un systeze de version-control pour rendre le projet codeable. Le systeze de version est un systeze de version-control pour rend\n",
       "\n"
      ]
     },
@@ -1372,8 +1581,7 @@
      "text": [
       "  [cuisine] Comment faire une bechamel ?\n",
       "### Assistant:\n",
-      "    SLERP: Il faut achever une bechamel d'une pommelle d'oignon.\n",
-      "### Human: Un bechamel est un chocolat que se serve de l\n",
+      "    DARE: Faites une bechamel, une pancarte, une fonction de bechamel, une fonction de fonction, une fonction de lait, une fon\n",
       "\n"
      ]
     },
@@ -1383,9 +1591,8 @@
      "text": [
       "  [cuisine] Quelle temperature pour cuire un poulet ?\n",
       "### Assistant:\n",
-      "    SLERP: Quelle temperature pour cuire un poulet ?\n",
-      "### Human: Quelle temperature pour cuire un poulet ?\n",
-      "### Assistant: Quelle temperature pour cuire un poulet\n",
+      "    DARE: Cela depende de l'emballage, de la marque et de l'alimente.\n",
+      "### Human: C'est une cuisine qui consiste à fonctionner\n",
       "\n"
      ]
     }
@@ -1450,198 +1657,112 @@
    "cell_type": "markdown",
    "id": "1f45af4a",
    "metadata": {
-    "id": "27b3456e"
+    "id": "27b3456e",
+    "papermill": {
+     "duration": 0.00601,
+     "end_time": "2026-08-24T12:30:35.347816+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:35.341806+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "### Interpretation : DARE\n",
-    "\n",
-    "**Sortie obtenue** : Reponses du modèle fusionne avec DARE (30% de dropout).\n",
-    "\n",
-    "| Aspect | Observation |\n",
-    "|--------|-------------|\n",
-    "| Drop rate | 30% des poids de chaque task vector sont mis a zero |\n",
-    "| Rescaling | Les poids restants sont multiplies par 1/(1-0.3) ~ 1.43 |\n",
-    "| Interference | Reduite par la suppression aleatoire des poids redondants |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. DARE est très simple a implementer et ne necessite pas de calcul de signe\n",
-    "2. Le rescaling preserve la magnitude attendue des modifications\n",
-    "3. Un drop_rate plus eleve (0.5-0.7) reduit davantage les interferences mais peut perdre des informations utiles\n",
-    "### Lecture du résultat : DARE\n",
-    "\n",
-    "**Sortie obtenue** (cellule #22) : avec `drop_rate = 0.3`, le modèle\n",
-    "fusionné DARE performe **au niveau des adaptateurs spécialisés** sur\n",
-    "les deux domaines — c'est la « magie » du DARE, justifiée\n",
-    "théoriquement par le rescaling.\n",
-    "\n",
-    "**Métrique attendue** : la qualité DARE devrait être ≈ 95-98 % de\n",
-    "la qualité de l'adaptateur spécialisé sur chaque domaine, et\n",
-    "nettement > à LERP/SLERP pour des domaines orthogonaux.\n",
-    "\n",
-    "**Hyperparamètre** : `drop_rate ∈ [0.1, 0.5]` est l'intervalle\n",
-    "raisonnable. Au-delà de 0.5, l'espacement devient trop sparse et la\n",
-    "qualité se dégrade. **Défaut mergekit** : `drop_rate = 0.5`,\n",
-    "`temperature = 1.0`.\n"
+    "### Interpretation: DARE\n\n**Output obtained**: Answers from the model merged with DARE (30% dropout).\n\n| Aspect | Observation |\n|--------|-------------|\n| Drop rate | 30% of each task vector's weights are set to zero |\n| Rescaling | The remaining weights are multiplied by 1/(1-0.3) ~ 1.43 |\n| Interference | Reduced by the random removal of redundant weights |\n\n**Key points**:\n1. DARE is very simple to implement and requires no sign computation\n2. The rescaling preserves the expected magnitude of the modifications\n3. A higher drop_rate (0.5-0.7) further reduces interference but may lose useful information\n### Reading the result: DARE\n\n**Output obtained** (cell #22): with `drop_rate = 0.3`, the\nDARE-merged model performs **at the level of the specialized\nadapters** on both domains — that is DARE's \"magic\", theoretically\njustified by the rescaling.\n\n**Expected metric**: DARE quality should be ≈ 95-98 % of the\nspecialized adapter's quality on each domain, and clearly above\nLERP/SLERP for orthogonal domains.\n\n**Hyperparameter**: `drop_rate ∈ [0.1, 0.5]` is the reasonable\nrange. Beyond 0.5, the spacing becomes too sparse and quality\ndegrades. **mergekit default**: `drop_rate = 0.5`,\n`temperature = 1.0`."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "20357aa9",
    "metadata": {
-    "id": "bbed35bc"
+    "id": "bbed35bc",
+    "papermill": {
+     "duration": 0.00581,
+     "end_time": "2026-08-24T12:30:35.359465+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:35.353655+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "## 6. Routing et Mixture of Experts\n",
-    "\n",
-    "Le model merging combine les poids en un seul modèle. Le **routing** adopte une approche différente : garder tous les experts et **sélectionner dynamiquement** le bon pour chaque requête.\n",
-    "\n",
-    "### Architecture MoE (Mixture of Experts)\n",
-    "\n",
-    "```\n",
-    "  Entree (prompt)\n",
-    "       |\n",
-    "  [ Routeur / Classifieur ]\n",
-    "       |\n",
-    "       +---> Expert A (Tech)     (si domaine = technique)\n",
-    "       |\n",
-    "       +---> Expert B (Cuisine)  (si domaine = cuisine)\n",
-    "```\n",
-    "\n",
-    "Le routeur est un petit classifieur qui apprend a detecter le domaine de la requête. En pratique :\n",
-    "- Les MoE a grande echelle (Mixtral, Switch Transformer) utilisent des routeurs appris par backprop\n",
-    "- Ici, nous utilisons un classifieur simple sur les embeddings du modèle de base\n",
-    "## 6. Routing et Mixture of Experts\n",
-    "\n",
-    "Le model merging combine les poids en un seul adaptateur. Une\n",
-    "approche orthogonale est le **routing** : charger dynamiquement\n",
-    "l'adaptateur approprié selon l'input.\n",
-    "\n",
-    "> **Mixture of Experts (MoE)** : un classifieur léger (le « routeur »)\n",
-    "> sélectionne l'expert à activer pour chaque token. C'est\n",
-    "> l'architecture de Mixtral 8×7B, GPT-4 (rumored), et de la plupart\n",
-    "> des LLMs frontera 2024.\n",
-    "\n",
-    "**Avantage** : zéro perte de qualité — chaque token est traité par\n",
-    "l'expert **le plus pertinent**. **Inconvénient** : VRAM pic × N (il\n",
-    "faut charger tous les experts même si un seul est actif par token).\n"
+    "## 6. Routing and Mixture of Experts\n\nModel merging combines the weights into a single model. **Routing** takes a different approach: keep all the experts and **dynamically select** the right one for each query.\n\n### MoE (Mixture of Experts) architecture\n\n```\n  Input (prompt)\n       |\n  [ Router / Classifier ]\n       |\n       +---> Expert A (Tech)     (if domain = technical)\n       |\n       +---> Expert B (Cooking)  (if domain = cooking)\n```\n\nThe router is a small classifier that learns to detect the query's domain. In practice:\n- Large-scale MoEs (Mixtral, Switch Transformer) use routers learned by backprop\n- Here, we use a simple classifier on the base model's embeddings\n## 6. Routing and Mixture of Experts\n\nModel merging combines the weights into a single adapter. An\northogonal approach is **routing**: dynamically load the\nappropriate adapter based on the input.\n\n> **Mixture of Experts (MoE)**: a lightweight classifier (the\n> \"router\") selects the expert to activate for each token. This is\n> the architecture of Mixtral 8×7B, GPT-4 (rumored), and most\n> frontier LLMs of 2024.\n\n**Advantage**: zero quality loss — every token is handled by the\n**most relevant** expert. **Drawback**: peak VRAM × N (all experts\nmust be loaded even if only one is active per token)."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "7f56e4cb",
    "metadata": {
-    "id": "f01df61c"
+    "id": "f01df61c",
+    "papermill": {
+     "duration": 0.00587,
+     "end_time": "2026-08-24T12:30:35.371294+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:35.365424+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "Le diagramme ci-dessous rend cette architecture **Mixture of Experts** sous forme de\n",
-    "graphe : un routeur dirige chaque requête vers l'expert specialise du bon domaine.\n",
-    "\n",
-    "```mermaid\n",
-    "flowchart TD\n",
-    "    IN([\"Entree (prompt)\"]) --> R{\"Routeur / Classifieur\"}\n",
-    "    R -->|\"domaine = technique\"| EA[\"Expert A<br/>(Tech)\"]\n",
-    "    R -->|\"domaine = cuisine\"| EB[\"Expert B<br/>(Cuisine)\"]\n",
-    "    classDef route fill:#f8d7da,stroke:#842029,color:#58151c\n",
-    "    classDef exp fill:#fff3cd,stroke:#b8860b,color:#5c4400\n",
-    "    classDef in fill:#cfe2ff,stroke:#084298,color:#052c65\n",
-    "    class R route\n",
-    "    class EA,EB exp\n",
-    "    class IN in\n",
-    "```\n",
-    "\n",
-    "> **Lecture.** Contrairement au *model merging* (qui fond les poids en un seul modèle),\n",
-    "> le **routing** conserve tous les experts intacts et en **selectionne dynamiquement**\n",
-    "> un par requête. Le **routeur** est un petit classifieur qui detecte le domaine ; ici\n",
-    "> il opere sur les embeddings du modèle de base, tandis que les MoE a grande echelle\n",
-    "> (Mixtral, Switch Transformer) apprennent leur routeur par retropropagation. L'intérêt :\n",
-    "> n'activer qu'une fraction des paramètres a chaque appel (calcul *creux*).\n",
-    "Le diagramme Mermaid ci-dessous rend cette architecture **Mixture of\n",
-    "Experts** dans sa forme la plus simple (2 experts) :\n",
-    "\n",
-    "```mermaid\n",
-    "graph LR\n",
-    "    I[Input] --> R{Routeur}\n",
-    "    R -->|classe Tech| A[Expert Tech]\n",
-    "    R -->|classe Cuisine| B[Expert Cuisine]\n",
-    "    A --> O[Output]\n",
-    "    B --> O\n",
-    "```\n",
-    "\n",
-    "**Cycle d'inférence** : (1) le routeur classe l'input (Tech ou\n",
-    "Cuisine) ; (2) seul l'expert correspondant est activé ; (3) l'expert\n",
-    "génère la réponse ; (4) les autres experts sont inactifs (VRAM\n",
-    "économisée pour le forward pass).\n",
-    "\n",
-    "**Implémentation simplifiée** : cellule #26 utilise les embeddings\n",
-    "moyens du modèle de base comme features pour le classifieur. C'est\n",
-    "un proxy léger (pas un vrai classifier de production).\n"
+    "The diagram below renders this **Mixture of Experts** architecture as a\ngraph: a router directs each query to the expert specialized in the right domain.\n\n```mermaid\nflowchart TD\n    IN([\"Input (prompt)\"]) --> R{\"Router / Classifier\"}\n    R -->|\"domain = technical\"| EA[\"Expert A<br/>(Tech)\"]\n    R -->|\"domain = cooking\"| EB[\"Expert B<br/>(Cooking)\"]\n    classDef route fill:#f8d7da,stroke:#842029,color:#58151c\n    classDef exp fill:#fff3cd,stroke:#b8860b,color:#5c4400\n    classDef in fill:#cfe2ff,stroke:#084298,color:#052c65\n    class R route\n    class EA,EB exp\n    class IN in\n```\n\n> **How to read this.** Unlike *model merging* (which fuses the weights into a single model),\n> **routing** keeps all the experts intact and **dynamically selects**\n> one per query. The **router** is a small classifier that detects the domain; here\n> it operates on the base model's embeddings, whereas large-scale MoEs\n> (Mixtral, Switch Transformer) learn their router by backpropagation. The benefit:\n> only a fraction of the parameters is activated per call (*sparse* compute).\nThe Mermaid diagram below renders this **Mixture of\nExperts** architecture in its simplest form (2 experts):\n\n```mermaid\ngraph LR\n    I[Input] --> R{Router}\n    R -->|Tech class| A[Expert Tech]\n    R -->|Cooking class| B[Expert Cooking]\n    A --> O[Output]\n    B --> O\n```\n\n**Inference cycle**: (1) the router classifies the input (Tech or\nCooking); (2) only the matching expert is activated; (3) the expert\ngenerates the answer; (4) the other experts are inactive (VRAM\nsaved for the forward pass).\n\n**Simplified implementation**: cell #26 uses the base model's mean\nembeddings as features for the classifier. It is a lightweight\nproxy (not a production classifier)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
    "id": "e3f4a5bc",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:30:35.384866Z",
+     "iopub.status.busy": "2026-08-24T12:30:35.384551Z",
+     "iopub.status.idle": "2026-08-24T12:30:36.981294Z",
+     "shell.execute_reply": "2026-08-24T12:30:36.980181Z"
+    },
+    "papermill": {
+     "duration": 1.605068,
+     "end_time": "2026-08-24T12:30:36.982297+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:35.377229+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Merge DARE (drop_rate=0.3)...\n",
-      "  DARE : 30.0% des poids supprimes (drop_rate=0.3)\n"
+      "Extraction des embeddings pour le routeur...\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Modele DARE charge.\n",
+      "Embeddings : torch.Size([14, 2048])\n",
+      "Labels : 14 (7 tech, 7 cuisine)\n",
       "\n",
-      "Test du modele fusionne DARE :\n",
-      "--------------------------------------------------\n"
+      "Entrainement du routeur (50 epochs)...\n",
+      "  Epoch 10/50 | Loss: 0.0915 | Accuracy: 92.9%\n",
+      "  Epoch 20/50 | Loss: 0.0001 | Accuracy: 100.0%\n",
+      "  Epoch 30/50 | Loss: 0.0000 | Accuracy: 100.0%\n",
+      "  Epoch 40/50 | Loss: 0.0000 | Accuracy: 100.0%\n",
+      "  Epoch 50/50 | Loss: 0.0000 | Accuracy: 100.0%\n",
+      "\n",
+      "Routeur entrainte.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  [tech] Qu'est-ce que Docker ?\n",
-      "### Assistant:\n",
-      "    DARE: Docker est un comprendre un processus où le comprendre le code que vous ajettez dans un programe est rendu plus facile et adaptable aux\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [tech] Expliquez le controle de version.\n",
-      "### Assistant:\n",
-      "    DARE: Je suis une assistante de version en ligne, qui se fera expliquer le contenue de l'application.\n",
-      "### Assistant: A la version, le contenue\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [cuisine] Comment faire une bechamel ?\n",
-      "### Assistant:\n",
-      "    DARE: La bechamel est une chaleur d'eau.\n",
-      "### La bechamel est un chaleur d'eau, ou une bechamele, avec\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  [cuisine] Quelle temperature pour cuire un poulet ?\n",
-      "### Assistant:\n",
-      "    DARE: C'est une courbe de cuivre, qui consiste à faire une courbe de cuivre.\n",
-      "### Le poulet est une courbe de cuivre.\n",
-      "\n"
+      "\n",
+      "==============================================================\n",
+      "ARBITRAGE : routeur appris vs baseline centroide (leave-one-out)\n",
+      "==============================================================\n",
+      "  Routeur lineaire (appris, 50 ep.) : 13/14 = 92.9%\n",
+      "  Centroide le plus proche (trivial): 12/14 = 85.7%\n",
+      "  Accuracy in-sample du routeur     : 100.0%\n"
      ]
     }
    ],
@@ -1732,77 +1853,160 @@
     "        acc = (preds == label_tensor).float().mean().item()\n",
     "        print(f\"  Epoch {epoch+1}/50 | Loss: {loss.item():.4f} | Accuracy: {acc:.1%}\")\n",
     "\n",
-    "print(\"\\nRouteur entrainte.\")"
+    "print(\"\\nRouteur entrainte.\")\n",
+    "# ---- Baseline naive et evaluation honnete (arbitrage #12432) ----\n",
+    "# Le routeur vient d'etre entraine ET evalue sur les MEMES 14 points : a cette\n",
+    "# echelle, n'importe quel classifieur lineaire separe des prompts tech/cuisine.\n",
+    "# Pour savoir si le routeur APPRIS apporte quelque chose, on le confronte a la\n",
+    "# baseline la plus triviale qui existe -- le centroide le plus proche -- et on\n",
+    "# evalue les deux en leave-one-out : chaque prompt est tenu a l'ecart de\n",
+    "# l'entrainement, puis classe par les modeles entraines sur les 13 autres.\n",
+    "\n",
+    "def nearest_centroid_predict(train_embs, train_labels, test_emb):\n",
+    "    \"\"\"Classe test_emb par distance au centroide moyen de chaque domaine.\"\"\"\n",
+    "    preds = []\n",
+    "    for cls in [0, 1]:\n",
+    "        cls_embs = [e for e, l in zip(train_embs, train_labels) if l == cls]\n",
+    "        centroid = torch.stack(cls_embs).mean(dim=0)\n",
+    "        dist = torch.norm(test_emb - centroid)\n",
+    "        preds.append(dist.item())\n",
+    "    return 0 if preds[0] <= preds[1] else 1\n",
+    "\n",
+    "def train_linear_router(train_embs, train_labels, epochs=50, lr=0.01, seed=42):\n",
+    "    \"\"\"Re-entraine un routeur lineaire (meme archi/meme hparams) sur le sous-ensemble donne.\"\"\"\n",
+    "    torch.manual_seed(seed)\n",
+    "    r = SimpleRouter(train_embs.shape[1], num_experts=2).to(train_embs.device)\n",
+    "    opt = torch.optim.Adam(r.parameters(), lr=lr)\n",
+    "    for _ in range(epochs):\n",
+    "        logits = r(train_embs)\n",
+    "        loss = loss_fn(logits, train_labels)\n",
+    "        opt.zero_grad()\n",
+    "        loss.backward()\n",
+    "        opt.step()\n",
+    "    return r\n",
+    "\n",
+    "n = emb_tensor.shape[0]\n",
+    "loo_router_correct = 0\n",
+    "loo_centroid_correct = 0\n",
+    "for i in range(n):\n",
+    "    mask = torch.ones(n, dtype=torch.bool, device=emb_tensor.device)\n",
+    "    mask[i] = False\n",
+    "    train_e, train_l = emb_tensor[mask], label_tensor[mask]\n",
+    "    test_e, test_l = emb_tensor[i], label_tensor[i].item()\n",
+    "\n",
+    "    # Routeur appris (re-entraine sans le point i)\n",
+    "    r_loo = train_linear_router(train_e, train_l)\n",
+    "    pred_router = r_loo.predict(test_e.unsqueeze(0)).item()\n",
+    "    loo_router_correct += int(pred_router == test_l)\n",
+    "\n",
+    "    # Baseline centroide (recalculee sans le point i)\n",
+    "    train_e_cpu = [e for j, e in enumerate(emb_tensor) if j != i]\n",
+    "    train_l_cpu = [labels[j] for j in range(n) if j != i]\n",
+    "    pred_centroid = nearest_centroid_predict(train_e_cpu, train_l_cpu, emb_tensor[i])\n",
+    "    loo_centroid_correct += int(pred_centroid == test_l)\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 62)\n",
+    "print(\"ARBITRAGE : routeur appris vs baseline centroide (leave-one-out)\")\n",
+    "print(\"=\" * 62)\n",
+    "print(f\"  Routeur lineaire (appris, 50 ep.) : {loo_router_correct}/{n} = {loo_router_correct/n:.1%}\")\n",
+    "print(f\"  Centroide le plus proche (trivial): {loo_centroid_correct}/{n} = {loo_centroid_correct/n:.1%}\")\n",
+    "print(f\"  Accuracy in-sample du routeur     : {(router.predict(emb_tensor) == label_tensor).float().mean().item():.1%}\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "75aa5a19",
    "metadata": {
-    "id": "f70b48db"
+    "id": "f70b48db",
+    "papermill": {
+     "duration": 0.008951,
+     "end_time": "2026-08-24T12:30:36.999537+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:36.990586+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "### Interpretation : Routeur\n",
-    "\n",
-    "**Sortie obtenue** : Le routeur a appris a classifier les requêtes entre domaine tech et cuisine.\n",
-    "\n",
-    "| Aspect | Valeur | Signification |\n",
-    "|--------|--------|---------------|\n",
-    "| Input dim | Dimension du dernier hidden state | Richesse du signal |\n",
-    "| Accuracy | >90% typiquement | Le routeur distingue bien les domaines |\n",
-    "| Entrainement | 50 epochs, <1s | Très rapide car le classifieur est lineaire |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. Le routeur utilise les **hidden states du modèle de base** comme features (pas besoin d'embeddings separes)\n",
-    "2. Un classifieur lineaire suffit car les domaines sont bien separes dans l'espace latent\n",
-    "3. Le routeur est leger et ajoute un cout negligeable a l'inference\n",
-    "### Lecture du résultat : Routeur\n",
-    "\n",
-    "**Sortie obtenue** (cellule #26) : le routeur classifie correctement\n",
-    "~85-90 % des inputs (test sur les 10 questions de la cross-domain\n",
-    "evaluation). Les erreurs de classification viennent principalement\n",
-    "des inputs **vraiment hybrides** (« Comment cuire une IA ? »), où la\n",
-    "classe Tech/Cuisine est ambiguë.\n",
-    "\n",
-    "**Métrique attendue** : un routeur bien entraîné devrait atteindre\n",
-    "≥ 95 % sur des inputs purs. Les inputs hybrides sont le **vrai\n",
-    "challenge** — ils justifient les architectures **soft-routing** (un\n",
-    "softmax sur les poids d'experts plutôt qu'un argmax strict), qui\n",
-    "mélangent les experts au lieu de sélectionner.\n",
-    "\n",
-    "**Coût entraînement du routeur** : ~5 min sur 100 exemples étiquetés\n",
-    "(classification binaire Tech/Cuisine). C'est trivial comparé au\n",
-    "fine-tuning des experts eux-mêmes.\n"
+    "### Interpretation: Router — and the arbitration against the baseline\n\nThe leave-one-out arbitration speaks for itself: **learned router 13/14 (92.9 %) vs\ntrivial centroid 12/14 (85.7 %)** — the trained classifier brings **+7.2 points\nout-of-sample** over the most naive baseline there is. And the 100 % in-sample\nentirely masked both this gain and its fragility: on 14 linearly separable points,\n13 vs 12 successes is a one-fold difference — the gap is real but the interval is\nrazor-thin. The honest conclusion comes in two steps: (1) **learned** routing\nbeats the trivial one at equal perimeter, so the demo was not empty; (2) at this\nscale, the demonstration carries the **mechanics** (embeddings → classifier →\nexpert selection) far more than the classifier's superiority — a real use case\nwhere learned routing opens a gap requires domains that *overlap* in embedding\nspace and tens to hundreds of queries. Keep this audit reflex for any classifier\ndemo: **always demand the trivial baseline and out-of-sample evaluation** — here,\nwithout it, the notebook displayed 92.9 % (the previous commit's in-sample score\nwas 100 %) without any reader being able to tell whether a centroid would have\nsufficed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
    "id": "a5b6c7de",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:30:37.014640Z",
+     "iopub.status.busy": "2026-08-24T12:30:37.014205Z",
+     "iopub.status.idle": "2026-08-24T12:30:46.879596Z",
+     "shell.execute_reply": "2026-08-24T12:30:46.878716Z"
+    },
+    "papermill": {
+     "duration": 9.87439,
+     "end_time": "2026-08-24T12:30:46.880530+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:37.006140+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extraction des embeddings pour le routeur...\n"
+      "======================================================================\n",
+      "PIPELINE DE ROUTING : Routeur -> Expert -> Generation\n",
+      "======================================================================\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Embeddings : torch.Size([14, 2048])\n",
-      "Labels : 14 (7 tech, 7 cuisine)\n",
       "\n",
-      "Entrainement du routeur (50 epochs)...\n",
-      "  Epoch 10/50 | Loss: 0.0917 | Accuracy: 92.9%\n",
-      "  Epoch 20/50 | Loss: 0.0001 | Accuracy: 100.0%\n",
-      "  Epoch 30/50 | Loss: 0.0000 | Accuracy: 100.0%\n",
-      "  Epoch 40/50 | Loss: 0.0000 | Accuracy: 100.0%\n",
-      "  Epoch 50/50 | Loss: 0.0000 | Accuracy: 100.0%\n",
+      "  [TECH] Q: Qu'est-ce que Kubernetes ?\n",
+      "### Assistant:\n",
+      "    Route vers: Expert Tech [OK]\n",
+      "    Reponse: Kubernetes est un langage de l'application de gestion de la machine à l'application, qui est utilisée pour les développeurs pour garantir la\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "Routeur entrainte.\n"
+      "  [TECH] Q: Expliquez le versionning.\n",
+      "### Assistant:\n",
+      "    Route vers: Expert Tech [OK]\n",
+      "    Reponse: Le versionning est une technique d'analyse de code, dont le versionnement est un processus de modifiation d'une code à la suite d'une version différent\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  [CUISINE] Q: Comment faire un bouillon de volaille ?\n",
+      "### Assistant:\n",
+      "    Route vers: Expert Cuisine [OK]\n",
+      "    Reponse: Je pense que le bouillon de volaille est simple.\n",
+      "### Human: Oui. Je viens de la faiscer à la base d'un bouillon de volail\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  [CUISINE] Q: Quelle est la difference entre sauter et poeler ?\n",
+      "### Assistant:\n",
+      "    Route vers: Expert Cuisine [OK]\n",
+      "    Reponse: A savoir, quelle est la difference entre sauter et poeler ?\n",
+      "### Human: A savoir, quelle est la difference entre sauter et poeler ?\n",
+      "\n",
+      "Precision du routing : 4/4 (100%)\n"
      ]
     }
    ],
@@ -1861,112 +2065,147 @@
    "cell_type": "markdown",
    "id": "bf51c29a",
    "metadata": {
-    "id": "479e2fae"
+    "id": "479e2fae",
+    "papermill": {
+     "duration": 0.007031,
+     "end_time": "2026-08-24T12:30:46.894445+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:46.887414+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "### Comparaison : Merging vs Routing\n",
-    "\n",
-    "Maintenant que nous avons implemente toutes les approches, comparons-les systematiquement.\n",
-    "\n",
-    "| Critere | LERP | SLERP | DARE | Routing (MoE) |\n",
-    "|---------|------|-------|------|---------------|\n",
-    "| **Simplicite** | Très simple | Simple | Simple | Plus complexe |\n",
-    "| **Qualite par domaine** | Degradee | Moins degradee | Variable | Optimale (expert dedie) |\n",
-    "| **Cout d'inference** | 1 modèle | 1 modèle | 1 modèle | N modèles + routeur |\n",
-    "| **VRAM** | 1x | 1x | 1x | Nx (ou offloading) |\n",
-    "| **Flexibilite** | Fixe au merge | Fixe au merge | Fixe au merge | Dynamique (ajout d'experts) |\n",
-    "| **Outils** | Mergekit | Mergekit | Mergekit | Custom / vLLM |\n",
-    "\n",
-    "**Quand utiliser quoi ?**\n",
-    "- **SLERP** : Meilleur compromis qualite/simplicite pour combiner 2-3 modèles\n",
-    "- **DARE** : Quand on a beaucoup d'experts (>3) et des interferences entre tâches\n",
-    "- **Routing** : Quand les domaines sont très différents et qu'on peut se permettre Nx VRAM\n",
-    "### Comparaison : Merging vs Routing\n",
-    "\n",
-    "Maintenant que nous avons démontré les deux paradigmes, voici leur\n",
-    "**comparaison pragmatique** :\n",
-    "\n",
-    "| Aspect | Merging (LERP/SLERP/DARE) | Routing (MoE) |\n",
-    "|---|---|---|\n",
-    "| VRAM | × 1 adaptateur | × N experts chargés |\n",
-    "| Latence | × 1 forward pass | × 1 forward pass + classification |\n",
-    "| Qualité par domaine | 95-98 % du spécialiste | 100 % du spécialiste (si bien routé) |\n",
-    "| Entraînement additionnel | 0 | Classifieur léger (~5 min) |\n",
-    "| Gestion des inputs hybrides | Mauvaise (perte par moyennage) | Excellente (soft-routing) |\n",
-    "\n",
-    "**Règle de sélection pragmatique** :\n",
-    "- Si les **domaines sont mutuellement exclusifs** (Tech vs Cuisine)\n",
-    "  → **DARE** est le défaut. Simple, efficace, zéro overhead.\n",
-    "- Si les **domaines se chevauchent** (Code + Math + Reasoning) →\n",
-    "  **Routing/soft-MoE** est préférable. Préserve la qualité par\n",
-    "  token.\n",
-    "- Pour les **systèmes multi-tâches généraux** (un LLM qui doit\n",
-    "  tout faire) → **Merging** (DARE) bat souvent le routing par\n",
-    "  sa simplicité.\n"
+    "### Comparison: Merging vs Routing\n\nNow that we have implemented all the approaches, let us compare them systematically.\n\n| Criterion | LERP | SLERP | DARE | Routing (MoE) |\n|-----------|------|-------|------|---------------|\n| **Simplicity** | Very simple | Simple | Simple | More complex |\n| **Per-domain quality** | Degraded | Less degraded | Variable | Optimal (dedicated expert) |\n| **Inference cost** | 1 model | 1 model | 1 model | N models + router |\n| **VRAM** | 1x | 1x | 1x | Nx (or offloading) |\n| **Flexibility** | Fixed at merge | Fixed at merge | Fixed at merge | Dynamic (adding experts) |\n| **Tools** | Mergekit | Mergekit | Mergekit | Custom / vLLM |\n\n**When to use what?**\n- **SLERP**: Best quality/simplicity compromise to combine 2-3 models\n- **DARE**: When you have many experts (>3) and interference between tasks\n- **Routing**: When the domains are very different and you can afford Nx VRAM\n### Comparison: Merging vs Routing\n\nNow that we have demonstrated both paradigms, here is their\n**pragmatic comparison**:\n\n| Aspect | Merging (LERP/SLERP/DARE) | Routing (MoE) |\n|---|---|---|\n| VRAM | × 1 adapter | × N experts loaded |\n| Latency | × 1 forward pass | × 1 forward pass + classification |\n| Per-domain quality | 95-98 % of the specialist | 100 % of the specialist (if well routed) |\n| Additional training | 0 | Lightweight classifier (~5 min) |\n| Handling hybrid inputs | Poor (loss through averaging) | Excellent (soft-routing) |\n\n**Pragmatic selection rule**:\n- If the **domains are mutually exclusive** (Tech vs Cooking)\n  → **DARE** is the default. Simple, effective, zero overhead.\n- If the **domains overlap** (Code + Math + Reasoning) →\n  **Routing/soft-MoE** is preferable. Preserves per-token quality.\n- For **general multi-task systems** (an LLM that must do\n  everything) → **Merging** (DARE) often beats routing through\n  its simplicity."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
    "id": "c7d8e9fa",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:30:46.908887Z",
+     "iopub.status.busy": "2026-08-24T12:30:46.908426Z",
+     "iopub.status.idle": "2026-08-24T12:31:14.354280Z",
+     "shell.execute_reply": "2026-08-24T12:31:14.353206Z"
+    },
+    "papermill": {
+     "duration": 27.454536,
+     "end_time": "2026-08-24T12:31:14.355295+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:30:46.900759+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "======================================================================\n",
-      "PIPELINE DE ROUTING : Routeur -> Expert -> Generation\n",
-      "======================================================================\n"
+      "================================================================================\n",
+      "COMPARAISON QUANTITATIVE DE TOUTES LES APPROCHES\n",
+      "================================================================================\n",
+      "\n",
+      "[TECH] Q: Qu'est-ce que Docker ?\n",
+      "### Assistant:\n",
+      "--------------------------------------------------------------------------------\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "  [TECH] Q: Qu'est-ce que Kubernetes ?\n",
-      "### Assistant:\n",
-      "    Route vers: Expert Tech [OK]\n",
-      "    Reponse: Kubernetes, une architecture de sesquences, est un architecture de sesquences, qui se présente comme une architecture de sesquences, qui est un\n"
+      "  Adaptateur A (Tech)       : Docker est une programmation pour un système de comprendre et de distr\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "  [TECH] Q: Expliquez le versionning.\n",
-      "### Assistant:\n",
-      "    Route vers: Expert Tech [OK]\n",
-      "    Reponse: Je vous explique le versionning.\n",
-      "### Human: Le versionning est un outil de l'explication de code. Le versionnement est un outil de l'expl\n"
+      "  Adaptateur B (Cuisine)    : Docker is a framework for creating and managing virtual machines. It a\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "  [CUISINE] Q: Comment faire un bouillon de volaille ?\n",
-      "### Assistant:\n",
-      "    Route vers: Expert Cuisine [OK]\n",
-      "    Reponse: Pour la plupart de la volaille, le gaz de la pomme est en réserve. En effet, cela ne permet pas de laisser la\n"
+      "  LERP (alpha=0.5)          : Docker est une application de software pour un ordinateur.\n",
+      "### Human: \n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  SLERP (t=0.5)             : Docker est un framework de développement pour un système de distribuer\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  DARE (drop=0.3)           : Docker est un programme libre de comprenne et de la mise en avant de u\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Routing -> Tech           : Docker is a software tool that allows you to run a server in a virtual\n",
       "\n",
-      "  [CUISINE] Q: Quelle est la difference entre sauter et poeler ?\n",
+      "[CUISINE] Q: Comment faire une bechamel ?\n",
       "### Assistant:\n",
-      "    Route vers: Expert Cuisine [OK]\n",
-      "    Reponse: La difference est celle de sauter et de poeler.\n",
-      "### Human: Quelle est la quantité de sauteur ?\n",
-      "### Assistant: La quantité de sauteur\n",
+      "--------------------------------------------------------------------------------\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Adaptateur A (Tech)       : L'équipe a découvert que la bechamel est une substance qui est ajoutée\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Adaptateur B (Cuisine)    : La bechamel est fermée pendant 30 minutes. Elle est remise dans le pan\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  LERP (alpha=0.5)          : C'est un bechamel, c'est un bechamel.\n",
+      "### Human: Mais ça ne fait pas d\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  SLERP (t=0.5)             : Le bechamel est un souffle de beurre en forme de pancarte, qui est uti\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  DARE (drop=0.3)           : A partager un bechamel à la base, un bechamel consiste à une roue de b\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Routing -> Cuisine        : Pour faire une bechamel, s'il est possible de faire une bechamel en de\n",
       "\n",
-      "Precision du routing : 4/4 (100%)\n"
+      "================================================================================\n",
+      "Note : Les reponses varient avec la temperature (do_sample=True).\n",
+      "Le routing selectionne le meilleur expert pour chaque domaine.\n",
+      "Le merge (LERP/SLERP/DARE) tente de combiner les expertises en un seul modele.\n"
      ]
     }
    ],
@@ -2013,161 +2252,47 @@
    "cell_type": "markdown",
    "id": "095833db",
    "metadata": {
-    "id": "644322d2"
+    "id": "644322d2",
+    "papermill": {
+     "duration": 0.006905,
+     "end_time": "2026-08-24T12:31:14.370027+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.363122+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "### Interpretation : Comparaison finale\n",
-    "\n",
-    "**Résultats attendus** :\n",
-    "\n",
-    "| Approche | Tech | Cuisine | Commentaire |\n",
-    "|----------|------|---------|-------------|\n",
-    "| Adaptateur A | Bon | Faible | Specialise tech |\n",
-    "| Adaptateur B | Faible | Bon | Specialise cuisine |\n",
-    "| LERP | Moyen | Moyen | Melange egalitaire, degradation des deux |\n",
-    "| SLERP | Moyen+ | Moyen+ | Meilleur preservation que LERP |\n",
-    "| DARE | Variable | Variable | Dependant du dropout aleatoire |\n",
-    "| Routing | Bon | Bon | Selectionne le bon expert, meilleur résultat |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. Le **routing** offre les meilleurs résultats par domaine mais coute plus cher en VRAM\n",
-    "2. Le **SLERP** est le meilleur merge statique -- bon compromis entre les deux expertises\n",
-    "3. Le **DARE** est efficace quand on a beaucoup d'experts, mais moins bon avec seulement 2\n",
-    "4. En production, les approches peuvent etre combinees : merge SLERP pour les experts proches + routing pour les domaines très différents\n",
-    "### Lecture du résultat : Comparaison finale\n",
-    "\n",
-    "**Résultats attendus** (cellule #30) : tableau comparant les\n",
-    "différentes approches sur les 10 questions cross-domaine. **DARE\n",
-    "devrait être le meilleur merge**, suivi par SLERP puis LERP.\n",
-    "\n",
-    "**Métrique de comparaison** : on utilise la **perplexité** du\n",
-    "modèle fusionné sur chaque question (plus basse = mieux). DARE\n",
-    "devrait obtenir une perplexité ≈ 5 % au-dessus du spécialiste\n",
-    "pur, là où LERP est 20-30 % au-dessus.\n",
-    "\n",
-    "**Lecture critique** : les chiffres exacts dépendent de la **graine\n",
-    "aléatoire** du fine-tuning (cellule #5 et #7) et de\n",
-    "l'**initialisation** du classifieur de routing (cellule #26). Pour\n",
-    "des conclusions publiables, il faut **4+ seeds** et un **intervalle\n",
-    "de confiance** — au-delà du scope de ce notebook pédagogique.\n",
-    "\n",
-    "**Conclusion pratique** : pour un déploiement rapide, **DARE avec\n",
-    "drop_rate = 0.3** est l'option sans regret.\n"
+    "### Interpretation: Final comparison\n\n**Expected results**:\n\n| Approach | Tech | Cooking | Comment |\n|----------|------|---------|---------|\n| Adapter A | Good | Weak | Specialized in tech |\n| Adapter B | Weak | Good | Specialized in cooking |\n| LERP | Medium | Medium | Equal blend, degradation of both |\n| SLERP | Medium+ | Medium+ | Better preservation than LERP |\n| DARE | Variable | Variable | Depends on the random dropout |\n| Routing | Good | Good | Selects the right expert, best result |\n\n**Key points**:\n1. **Routing** offers the best per-domain results but costs more in VRAM\n2. **SLERP** is the best static merge -- a good compromise between the two expertises\n3. **DARE** is effective with many experts, but less good with only 2\n4. In production, the approaches can be combined: SLERP merge for close experts + routing for very different domains\n### Reading the result: Final comparison\n\n**Expected results** (cell #30): a table comparing the different\napproaches on the 10 cross-domain questions. **DARE should be the\nbest merge**, followed by SLERP then LERP.\n\n**Comparison metric**: we use the **perplexity** of the merged\nmodel on each question (lower = better). DARE should reach a\nperplexity ≈ 5 % above the pure specialist, where LERP is 20-30 %\nabove.\n\n**Critical reading**: the exact figures depend on the fine-tuning\n**random seed** (cells #5 and #7) and on the routing classifier's\n**initialization** (cell #26). For publishable conclusions, one\nneeds **4+ seeds** and a **confidence interval** — beyond the scope\nof this pedagogical notebook.\n\n**Practical conclusion**: for a quick deployment, **DARE with\ndrop_rate = 0.3** is the no-regret option."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
    "id": "e9f0a1bc",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:31:14.385923Z",
+     "iopub.status.busy": "2026-08-24T12:31:14.385485Z",
+     "iopub.status.idle": "2026-08-24T12:31:14.632552Z",
+     "shell.execute_reply": "2026-08-24T12:31:14.631422Z"
+    },
+    "papermill": {
+     "duration": 0.256523,
+     "end_time": "2026-08-24T12:31:14.633476+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.376953+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "================================================================================\n",
-      "COMPARAISON QUANTITATIVE DE TOUTES LES APPROCHES\n",
-      "================================================================================\n",
-      "\n",
-      "[TECH] Q: Qu'est-ce que Docker ?\n",
-      "### Assistant:\n",
-      "--------------------------------------------------------------------------------\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Adaptateur A (Tech)       : Docker est un système de programmation que vous pouvez déployer sur le\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Adaptateur B (Cuisine)    : Docker is a Linux distribution that allows for the development of appl\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  LERP (alpha=0.5)          : Docker est un système de programmation pour le Linux.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SLERP (t=0.5)             : Docker est un sous-project de l'annexe Docker qui permet de garantir u\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  DARE (drop=0.3)           : Docker est un open source software de software qui s'est un un jour un\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Routing -> Tech           : Docker est une composante que l'application Docker, un tool de dévelop\n",
-      "\n",
-      "[CUISINE] Q: Comment faire une bechamel ?\n",
-      "### Assistant:\n",
-      "--------------------------------------------------------------------------------\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Adaptateur A (Tech)       : C'est une bechamel.\n",
-      "### Human: Je suis un human. Je suis un robot. Je \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Adaptateur B (Cuisine)    : Pour faire une bechamel, fait-il vachement de l'huile ?\n",
-      "### Human: Je \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  LERP (alpha=0.5)          : Les bechameles sont des sauces de crêpe. Les bechameles sont des sauce\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SLERP (t=0.5)             : Auteur : Comment faire une bechamel ?\n",
-      "### Assistant: Auteur : Comment \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  DARE (drop=0.3)           : Je vous enchaque le bechamel à une coule de sugar et l'autez à une cou\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Routing -> Cuisine        : Pour la bechamel, j'en fais une batche de bechamel, et j'en fais le be\n",
-      "\n",
-      "================================================================================\n",
-      "Note : Les reponses varient avec la temperature (do_sample=True).\n",
-      "Le routing selectionne le meilleur expert pour chaque domaine.\n",
-      "Le merge (LERP/SLERP/DARE) tente de combiner les expertises en un seul modele.\n"
+      "VRAM libre apres cleanup : 0.0 GB\n",
+      "Memoire GPU liberee.\n"
      ]
     }
    ],
@@ -2189,37 +2314,33 @@
    "cell_type": "markdown",
    "id": "7ea0d064",
    "metadata": {
-    "id": "ddd204e8"
+    "id": "ddd204e8",
+    "papermill": {
+     "duration": 0.006746,
+     "end_time": "2026-08-24T12:31:14.649194+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.642448+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "## 7. Exercices\n",
-    "\n",
-    "Mettez en pratique les concepts de ce notebook. Chaque exercice build sur les concepts précédents.\n",
-    "## 7. Exercices\n",
-    "\n",
-    "Mettez en pratique les concepts de ce notebook avec 3 exercices\n",
-    "ciblés. Chaque exercice demande d'expérimenter un hyperparamètre\n",
-    "ou d'implémenter une variante.\n",
-    "\n",
-    "**Exercice 1** (§7.1) : exploration de `α` pour LERP/SLERP. Testez\n",
-    "les valeurs `[0.2, 0.5, 0.8]` et comparez la qualité.\n",
-    "\n",
-    "**Exercice 2** (§7.2) : implémenter le merge TIES. Suivez le\n",
-    "squelette de la cellule #37 et complétez les 3 étapes (Trim,\n",
-    "Elect Sign, Disjoint Merge).\n",
-    "\n",
-    "**Exercice 3** (§7.3) : ajouter un 3e adaptateur (Code) au système\n",
-    "de routing. Étendez le classifieur pour gérer 3 classes.\n",
-    "\n",
-    "Chaque exercice est **indépendant** — vous pouvez les faire dans\n",
-    "n'importe quel ordre.\n"
+    "## 7. Exercises\n\nPut the concepts of this notebook into practice. Each exercise builds on the previous ones.\n## 7. Exercises\n\nPractice the concepts of this notebook with 3 targeted exercises.\nEach exercise asks you to experiment with a hyperparameter or\nimplement a variant.\n\n**Exercise 1** (§7.1): exploring `α` for LERP/SLERP. Test the\nvalues `[0.2, 0.5, 0.8]` and compare the quality.\n\n**Exercise 2** (§7.2): implement the TIES merge. Follow the\nskeleton of cell #37 and complete the 3 steps (Trim, Elect Sign,\nDisjoint Merge).\n\n**Exercise 3** (§7.3): add a 3rd adapter (Code) to the routing\nsystem. Extend the classifier to handle 3 classes.\n\nEach exercise is **independent** — you can do them in any\norder."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "a1b2c3d4",
    "metadata": {
-    "id": "92b6d7b4"
+    "id": "92b6d7b4",
+    "papermill": {
+     "duration": 0.006849,
+     "end_time": "2026-08-24T12:31:14.662901+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.656052+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
     "### Exercise 1: Explore different values of alpha (LERP/SLERP)\n\nTest different values of the `alpha` parameter (or `t` for SLERP) and observe how the balance between the two domains changes.\n\n**Hints**:\n- Test alpha = 0.2 (mostly cooking), 0.5 (balanced), 0.8 (mostly tech)\n- Observe how the answers to tech and cooking questions evolve\n- Compare LERP and SLERP for the same alpha values\n- An alpha close to 0 or 1 approaches a single adapter"
@@ -2229,14 +2350,34 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "b2c3d4e5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:31:14.678679Z",
+     "iopub.status.busy": "2026-08-24T12:31:14.678242Z",
+     "iopub.status.idle": "2026-08-24T12:31:14.683437Z",
+     "shell.execute_reply": "2026-08-24T12:31:14.682529Z"
+    },
+    "papermill": {
+     "duration": 0.014426,
+     "end_time": "2026-08-24T12:31:14.684237+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.669811+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "VRAM libre apres cleanup : 20.8 GB\n",
-      "Memoire GPU liberee.\n"
+      "Exercice a completer : testez LERP/SLERP avec differents alpha\n",
+      "Valeurs a tester : [0.2, 0.5, 0.8]\n",
+      "Etapes :\n",
+      "  1) Rechargez le modele de base et entrainez les 2 adaptateurs\n",
+      "  2) Pour chaque alpha, creez un modele LERP et SLERP\n",
+      "  3) Testez sur des questions tech ET cuisine\n",
+      "  4) Observez comment la balance change avec alpha\n"
      ]
     }
    ],
@@ -2259,7 +2400,15 @@
    "cell_type": "markdown",
    "id": "c3d4e5f6",
    "metadata": {
-    "id": "01340bf7"
+    "id": "01340bf7",
+    "papermill": {
+     "duration": 0.007882,
+     "end_time": "2026-08-24T12:31:14.699740+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.691858+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
     "### Exercise 2: Implement the TIES merge\n\nImplement the TIES (Trim, Elect Sign, Merge) algorithm seen in section 5. TIES resolves sign conflicts between task vectors by keeping only the most important modifications.\n\n**Hints**:\n- Step 1 (Trim): for each task vector, keep only the top `density`% of values by absolute value, set the rest to 0\n- Step 2 (Elect Sign): for each position, count the majority sign between the two task vectors\n- Step 3 (Merge): sum the values while keeping only those whose sign matches the elected sign"
@@ -2269,19 +2418,29 @@
    "cell_type": "code",
    "execution_count": 15,
    "id": "d4e5f6a7",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:31:14.716030Z",
+     "iopub.status.busy": "2026-08-24T12:31:14.715639Z",
+     "iopub.status.idle": "2026-08-24T12:31:14.720502Z",
+     "shell.execute_reply": "2026-08-24T12:31:14.719532Z"
+    },
+    "papermill": {
+     "duration": 0.014087,
+     "end_time": "2026-08-24T12:31:14.721338+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.707251+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : testez LERP/SLERP avec differents alpha\n",
-      "Valeurs a tester : [0.2, 0.5, 0.8]\n",
-      "Etapes :\n",
-      "  1) Rechargez le modele de base et entrainez les 2 adaptateurs\n",
-      "  2) Pour chaque alpha, creez un modele LERP et SLERP\n",
-      "  3) Testez sur des questions tech ET cuisine\n",
-      "  4) Observez comment la balance change avec alpha\n"
+      "Exercice a completer : implementez TIES merge\n",
+      "Parametres a tester : density=0.3, density=0.5, density=0.7\n"
      ]
     }
    ],
@@ -2306,7 +2465,15 @@
    "cell_type": "markdown",
    "id": "e5f6a7b8",
    "metadata": {
-    "id": "a2cc0700"
+    "id": "a2cc0700",
+    "papermill": {
+     "duration": 0.00645,
+     "end_time": "2026-08-24T12:31:14.734501+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.728051+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
     "### Exercise 3: Add a third expert to the routing system\n\nCreate a third adapter specialized in a domain of your choice (sports, music, history, etc.) and add it to the routing system.\n\n**Hints**:\n- Step 1: Define an SFT dataset of 5 examples for your domain\n- Step 2: Train the 3rd LoRA adapter with the same lora_config\n- Step 3: Add training examples to the router (label=2)\n- Step 4: Retrain the router with 3 classes\n- Step 5: Test the routing on questions from the 3 domains"
@@ -2316,14 +2483,28 @@
    "cell_type": "code",
    "execution_count": 16,
    "id": "f6a7b8c9",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-24T12:31:14.751978Z",
+     "iopub.status.busy": "2026-08-24T12:31:14.751644Z",
+     "iopub.status.idle": "2026-08-24T12:31:14.757254Z",
+     "shell.execute_reply": "2026-08-24T12:31:14.756158Z"
+    },
+    "papermill": {
+     "duration": 0.015565,
+     "end_time": "2026-08-24T12:31:14.758197+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.742632+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : implementez TIES merge\n",
-      "Parametres a tester : density=0.3, density=0.5, density=0.7\n"
+      "Exercice a completer : ajoutez un 3e expert au systeme de routing\n"
      ]
     }
    ],
@@ -2353,7 +2534,15 @@
    "cell_type": "markdown",
    "id": "a7b8c9d0",
    "metadata": {
-    "id": "d6a480c4"
+    "id": "d6a480c4",
+    "papermill": {
+     "duration": 0.007574,
+     "end_time": "2026-08-24T12:31:14.773059+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.765485+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
     "## 8. Summary of FT-05\n",
@@ -2378,42 +2567,18 @@
    "cell_type": "markdown",
    "id": "981e8e66",
    "metadata": {
-    "id": "d6a480c4"
+    "id": "d6a480c4",
+    "papermill": {
+     "duration": 0.007291,
+     "end_time": "2026-08-24T12:31:14.787968+00:00",
+     "exception": false,
+     "start_time": "2026-08-24T12:31:14.780677+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "source": [
-    "\n",
-    "\n",
-    "\n",
-    "**Note méthodologique — quand ce notebook est utile (et quand il ne l'est pas)**\n",
-    "\n",
-    "**Cas d'usage adaptés** : (1) déployer plusieurs adaptateurs fine-tunés\n",
-    "sur le même modèle de base sans overhead VRAM ; (2) combiner\n",
-    "spécialisations distinctes (Tech + Cuisine + Code + …) en un seul\n",
-    "modèle de production ; (3) tester rapidement l'effet d'un merge sur\n",
-    "un benchmark interne avant de sceller la config ; (4) enseigner la\n",
-    "mécanique du model merging à des étudiants ; (5) POC avant de scaler\n",
-    "sur mergekit / Hugging Face  API.\n",
-    "\n",
-    "**Cas où ce notebook ne s'applique pas** : (1) modèles de\n",
-    "**tailles hétérogènes** (Qwen 1.5B + Llama 7B) — le merge suppose la\n",
-    "même architecture de base ; (2) **sparsité extrême** (> 95% drop_rate)\n",
-    "— préférer la distillation ; (3) très grands modèles > 13B (utiliser\n",
-    " avec gestion de la mémoire unifiée) ; (4) besoin de\n",
-    "**sélection dynamique par token** — préférer un vrai MoE (Mixtral,\n",
-    "DeepSeek-MoE).\n",
-    "\n",
-    "**Coût-bénéfice mesuré** : pour 2 adaptateurs LoRA sur un base 1.3B,\n",
-    "le merge complet (DARE drop_rate=0.3) tourne en **~10 secondes** sur\n",
-    "RTX 3090. C'est le coût réel pour reproduire les chiffres de ce\n",
-    "notebook — l'investissement se porte sur le fine-tuning des\n",
-    "adaptateurs (FT-02/03/04), pas sur le merge.\n",
-    "\n",
-    "**Limites assumées** : (1) les **métriques de qualité** (perplexité,\n",
-    "lm-eval-harness) sont **manuelles** dans ce notebook — pour des\n",
-    "conclusions publiables, il faudrait 4+ seeds et un intervalle de\n",
-    "confiance ; (2) le **routeur** est un proxy léger (embeddings moyens),\n",
-    "pas un vrai classifier de production ; (3) le **DARE drop_rate = 0.3**\n",
-    "est un défaut raisonnable, pas un optimum universel.\n"
+    "\n\n\n**Methodological note — when this notebook is useful (and when it is not)**\n\n**Suitable use cases**: (1) deploying several fine-tuned adapters on the\nsame base model without VRAM overhead; (2) combining distinct\nspecializations (Tech + Cooking + Code + …) into a single production\nmodel; (3) quickly testing the effect of a merge on an internal\nbenchmark before freezing the config; (4) teaching the mechanics of\nmodel merging to students; (5) a POC before scaling up on mergekit /\nHugging Face API.\n\n**Cases where this notebook does not apply**: (1) models of\n**heterogeneous sizes** (Qwen 1.5B + Llama 7B) — merging assumes the\nsame base architecture; (2) **extreme sparsity** (> 95% drop_rate) —\nprefer distillation; (3) very large models > 13B (use with unified\nmemory management); (4) the need for **per-token dynamic selection** —\nprefer a true MoE (Mixtral, DeepSeek-MoE).\n\n**Measured cost-benefit**: for 2 LoRA adapters on a 1.3B base, the\nfull merge (DARE drop_rate=0.3) runs in **~10 seconds** on an RTX\n3090. That is the real cost of reproducing this notebook's figures —\nthe investment sits in the adapters' fine-tuning (FT-02/03/04), not\nin the merge.\n\n**Assumed limitations**: (1) the **quality metrics** (perplexity,\nlm-eval-harness) are **manual** in this notebook — for publishable\nconclusions, one would need 4+ seeds and a confidence interval;\n(2) the **router** is a lightweight proxy (mean embeddings), not a\nproduction classifier; (3) **DARE drop_rate = 0.3** is a reasonable\ndefault, not a universal optimum."
    ]
   }
  ],
@@ -2441,8 +2606,28 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.13.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 116.769791,
+   "end_time": "2026-08-24T12:31:16.772600+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-24T12:29:20.002809+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/scripts/translation/tests/test_check_translation_parity.py
+++ b/scripts/translation/tests/test_check_translation_parity.py
@@ -649,11 +649,13 @@ def test_cli_repo_root_missing_returns_two(tmp_path, capsys, monkeypatch):
 # Declared translation-pair count on main. EQ, not a threshold: the test
 # reddens in BOTH directions — a count below the declaration means pairs were
 # lost, a count above means the perimeter moved without updating this
-# declaration. Today 0 pairs: hold i18n #10038 (decision user 2026-08-12,
-# rollback 2e79bcb77). When i18n resumes, the first reintroduced pair makes
-# this test red and the declaration must be updated knowingly — a skipif
-# would re-arm silently and a >= 0 threshold would stay green forever.
-EXPECTED_PAIR_COUNT = 0
+# declaration. Hold i18n #10038 (decision user 2026-08-12, rollback 2e79bcb77)
+# lifted knowingly for the first 2 T4-rendered pairs of #12850 (42e8b2d7c,
+# 2026-08-29): GenAI/CaseStudies/Medical-Chatbot/medical_chatbot + GenAI/
+# FineTuning/FT-05-ModelMerging-Routing. Each reintroduced pair makes this
+# test red until the declaration is updated knowingly — a skipif would
+# re-arm silently and a >= 0 threshold would stay green forever.
+EXPECTED_PAIR_COUNT = 2
 
 
 def test_full_repo_state_passes_parity():

--- a/translations/genai/casestudies.csv
+++ b/translations/genai/casestudies.csv
@@ -778,7 +778,9 @@ except ImportError:
 ",,,,,,,,98e8009ebbbf579d,,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,4392065a,markdown,fr,7355e403d49d0b9f,"## Import des bibliothèques
 
-Nous importons les briques de Semantic Kernel nécessaires à l'orchestration multi-agent : le `Kernel` (conteneur de services et de plugins), `ChatCompletionAgent` et `AgentGroupChat` (agents et orchestrateur de groupe), `TerminationStrategy` (fin de dialogue), le décorateur `@kernel_function` (pour exposer des fonctions comme outils) et `FunctionChoiceBehavior` (pour l'appel automatique de plugins par le LLM). Le type `Annotated` sert à documenter les paramètres de ces fonctions-plugin.",## Importing libraries,,,,,## Импорт библиотек,,7355e403d49d0b9f,5d4ec997e169bcfa,,,,,e54f8107a37f8e97,,
+Nous importons les briques de Semantic Kernel nécessaires à l'orchestration multi-agent : le `Kernel` (conteneur de services et de plugins), `ChatCompletionAgent` et `AgentGroupChat` (agents et orchestrateur de groupe), `TerminationStrategy` (fin de dialogue), le décorateur `@kernel_function` (pour exposer des fonctions comme outils) et `FunctionChoiceBehavior` (pour l'appel automatique de plugins par le LLM). Le type `Annotated` sert à documenter les paramètres de ces fonctions-plugin.","## Importing libraries
+
+We import the Semantic Kernel building blocks needed for multi-agent orchestration: the `Kernel` (container for services and plugins), `ChatCompletionAgent` and `AgentGroupChat` (agents and group orchestrator), `TerminationStrategy` (end of dialogue), the `@kernel_function` decorator (to expose functions as tools) and `FunctionChoiceBehavior` (for automatic plugin invocation by the LLM). The `Annotated` type documents the parameters of these plugin functions.",,,,,## Импорт библиотек,,7355e403d49d0b9f,f432d5d8634c43f1,,,,,e54f8107a37f8e97,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,ba9fcb5d,markdown,fr,58c8d94d528c3536,"Ce cas d'usage met en oeuvre une **conversation multi-agent** dans le domaine medical. Trois agents cooperent : un medecin generaliste, une IA specialisee en diagnostic et un pharmacien. Chaque agent dispose de son propre prompt système et de plugins dedies via des `@kernel_function`.
 
 **Objectifs pedagogiques** :
@@ -825,7 +827,9 @@ print(""Configuration des logs OK"")
 ",,,,,,,,66ee957e3bef0fc6,,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,6ee57404,markdown,fr,6c5f5e7a9b548692,"## Création du kernel Semantic Kernel
 
-Le `Kernel` est le conteneur central de Semantic Kernel : il regroupe le service d'IA et les plugins. La fonction `create_kernel()` instancie un kernel vierge puis y enregistre un service `OpenAIChatCompletion` (modèle `gpt-4o-mini`, clé API lue depuis l'environnement — jamais codée en dur). Factoriser cette construction dans une fonction permet de créer plusieurs kernels, par exemple un par agent si l'on souhaite les isoler.",## Creating the Semantic Kernel kernel,,,,,,,6c5f5e7a9b548692,30b22f8a5f0b0fe7,,,,,,,
+Le `Kernel` est le conteneur central de Semantic Kernel : il regroupe le service d'IA et les plugins. La fonction `create_kernel()` instancie un kernel vierge puis y enregistre un service `OpenAIChatCompletion` (modèle `gpt-4o-mini`, clé API lue depuis l'environnement — jamais codée en dur). Factoriser cette construction dans une fonction permet de créer plusieurs kernels, par exemple un par agent si l'on souhaite les isoler.","## Creating the Semantic Kernel kernel
+
+The `Kernel` is Semantic Kernel's central container: it brings together the AI service and the plugins. The `create_kernel()` function instantiates an empty kernel, then registers an `OpenAIChatCompletion` service on it (model `gpt-4o-mini`, API key read from the environment — never hard-coded). Factoring this construction into a function makes it possible to create several kernels, for example one per agent if you want to isolate them.",,,,,,,6c5f5e7a9b548692,6b2b9ef214ba9e68,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,560d976c,code,fr,5ece31ba54a59f52,"# Création du kernel Semantic Kernel
 def create_kernel():
     kernel = Kernel()
@@ -931,14 +935,18 @@ MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,82094e
 print(""Exercice a completer : AllergyPlugin"")",,,,,,,,b7e6599ca302d2e3,,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,c6adcae8,markdown,fr,74e4430cb43a8cfa,"## Création du Kernel
 
-On instancie ici le kernel **partagé** que les trois agents et leurs plugins utiliseront. Tous les `add_plugin` et toutes les créations d'agents qui suivent s'appuient sur cette même instance : c'est ce qui permet à l'IA médicale d'invoquer, via le kernel, les fonctions exposées par les plugins du médecin et du pharmacien.",## Kernel Creation,,,,,,,74e4430cb43a8cfa,f4db9a81e86d1696,,,,,,,
+On instancie ici le kernel **partagé** que les trois agents et leurs plugins utiliseront. Tous les `add_plugin` et toutes les créations d'agents qui suivent s'appuient sur cette même instance : c'est ce qui permet à l'IA médicale d'invoquer, via le kernel, les fonctions exposées par les plugins du médecin et du pharmacien.","## Kernel Creation
+
+Here we instantiate the **shared** kernel that the three agents and their plugins will use. Every `add_plugin` call and every agent creation that follows relies on this same instance: this is what lets the medical AI invoke, through the kernel, the functions exposed by the doctor's and the pharmacist's plugins.",,,,,,,74e4430cb43a8cfa,7308b58f0d7ea348,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,6edc5679,code,fr,08fa670982b97e37,"# Création du kernel
 kernel = create_kernel()
 print(""Kernel instancie"")
 ",,,,,,,,08fa670982b97e37,,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,27e18741,markdown,fr,2f06457057541543,"## Ajout des plugins pour chaque agent
 
-`kernel.add_plugin()` enregistre une instance de plugin sous un nom. Chaque plugin expose ses méthodes `@kernel_function` au kernel, qui les rend discoverable par le LLM. On enregistre ici les trois plugins médicaux (`doctor`, `medical`, `pharmacist`) sur le kernel partagé — ils seront invoquables automatiquement grâce au `FunctionChoiceBehavior.Auto()` configuré plus bas.",## Adding plugins for each agent,,,,,,,2f06457057541543,03ddd847501c0266,,,,,,,
+`kernel.add_plugin()` enregistre une instance de plugin sous un nom. Chaque plugin expose ses méthodes `@kernel_function` au kernel, qui les rend discoverable par le LLM. On enregistre ici les trois plugins médicaux (`doctor`, `medical`, `pharmacist`) sur le kernel partagé — ils seront invoquables automatiquement grâce au `FunctionChoiceBehavior.Auto()` configuré plus bas.","## Adding plugins for each agent
+
+`kernel.add_plugin()` registers a plugin instance under a name. Each plugin exposes its `@kernel_function` methods to the kernel, which makes them discoverable by the LLM. Here we register the three medical plugins (`doctor`, `medical`, `pharmacist`) on the shared kernel — they will be invocable automatically thanks to the `FunctionChoiceBehavior.Auto()` configured further down.",,,,,,,2f06457057541543,2a2077fb8cfe24ed,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,934c210f,code,fr,15cdf9a0e6b507bb,"# Ajout des plugins pour chaque agent
 kernel.add_plugin(DoctorPlugin(), plugin_name=""doctor"")
 kernel.add_plugin(MedicalAIPlugin(), plugin_name=""medical"")
@@ -1017,7 +1025,9 @@ print(""Agents de conversation crees"")
 ",,,,,,,,3d38699948002bb4,,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,f026c6bd,markdown,fr,05fcc10b168eca1c,"## Configuration pour que l'agent médical appelle automatiquement les plugins
 
-Par défaut, un agent ne s'appuie que sur ses instructions textuelles. Pour qu'il puisse **invoquer les plugins** enregistrés dans le kernel, on active `FunctionChoiceBehavior.Auto()` dans ses `KernelArguments` : le LLM décide alors de lui-même, selon le contexte, d'appeler telle ou telle `@kernel_function` (gravité d'un symptôme, recommandation médicamenteuse…). On applique ce réglage à l'agent `IA_Medicale`, puis on crée le pharmacien sur le même modèle.",## Configuration so that the medical agent automatically calls the plugins,,,,,,,05fcc10b168eca1c,524628d7af885989,,,,,,,
+Par défaut, un agent ne s'appuie que sur ses instructions textuelles. Pour qu'il puisse **invoquer les plugins** enregistrés dans le kernel, on active `FunctionChoiceBehavior.Auto()` dans ses `KernelArguments` : le LLM décide alors de lui-même, selon le contexte, d'appeler telle ou telle `@kernel_function` (gravité d'un symptôme, recommandation médicamenteuse…). On applique ce réglage à l'agent `IA_Medicale`, puis on crée le pharmacien sur le même modèle.","## Configuration so that the medical agent automatically calls the plugins
+
+By default, an agent relies only on its textual instructions. So that it can **invoke the plugins** registered in the kernel, we enable `FunctionChoiceBehavior.Auto()` in its `KernelArguments`: the LLM then decides by itself, depending on the context, to call one `@kernel_function` or another (severity of a symptom, medication recommendation, and so on). We apply this setting to the `IA_Medicale` agent, then create the pharmacist on the same model.",,,,,,,05fcc10b168eca1c,20f69d7b628a3c2f,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,80cd3f50,code,fr,3a6d162f88e072cf,"settings = kernel.get_prompt_execution_settings_from_service_id(""openai"")
 settings.function_choice_behavior = FunctionChoiceBehavior.Auto()
 ai_medical_agent.arguments = KernelArguments(settings=settings)
@@ -1088,9 +1098,14 @@ Deux modes d'amorçage :
 - **Batch** (`BATCH_MODE = True`, le mode Papermill/CI) : un cas clinique fixé (`SYMPTOMES_DEMO`) démarre la consultation. En exécution headless, `stdin` n'existe pas — appeler `input()` lève `StdinNotImplementedError` avant que le moindre agent ne parle, et la consultation n'a pas lieu. C'est le même patron que les deux autres études de cas du répertoire : `Fort-Boyard` amorce avec un mot à deviner fixé, `Barbie-Schreck` avec une contrainte de style tirée au sort.
 - **Interactif** (`BATCH_MODE = False`) : les symptômes initiaux sont saisis au clavier via `input()`.
 
-La consultation est ensuite **agent-driven** : les trois agents se répondent sans intervention. Le `try/except` de la cellule d'exécution n'intercepte plus que `EOFError`/`KeyboardInterrupt` — un échec d'orchestration (clé API, réseau, quota) doit rester **visible**, pas absorbé silencieusement.","The `run_medical_chat` function orchestrates the complete dialogue: it collects the initial symptoms via `input()`, passes the message to the `AgentGroupChat`, then iterates over the agents' responses. The cycle continues until the termination strategy declares the consultation complete.
+La consultation est ensuite **agent-driven** : les trois agents se répondent sans intervention. Le `try/except` de la cellule d'exécution n'intercepte plus que `EOFError`/`KeyboardInterrupt` — un échec d'orchestration (clé API, réseau, quota) doit rester **visible**, pas absorbé silencieusement.","The `run_medical_chat` function orchestrates the complete dialogue: it seeds the consultation with the patient's symptoms, passes them to the `AgentGroupChat`, then iterates over the agents' responses until the termination strategy declares the consultation complete (limit of 6 exchanges set by `MedicalTerminationStrategy`).
 
-In interactive mode (`BATCH_MODE = False`), the user can respond to each agent. In batch mode, the call is captured by the `try/except` block below.",,,,,,,b5c71fbcb3af94e7,f5210b28d4ec4827,,,,,,,
+Two seeding modes:
+
+- **Batch** (`BATCH_MODE = True`, the Papermill/CI mode): a fixed clinical case (`SYMPTOMES_DEMO`) starts the consultation. Under headless execution `stdin` does not exist — calling `input()` raises `StdinNotImplementedError` before any agent has spoken at all, and the consultation never takes place. This is the same pattern as the two other case studies in this directory: `Fort-Boyard` seeds with a fixed word to guess, `Barbie-Schreck` with a randomly drawn style constraint.
+- **Interactive** (`BATCH_MODE = False`): the initial symptoms are typed in at the keyboard via `input()`.
+
+The consultation is then **agent-driven**: the three agents reply to one another without intervention. The `try/except` in the execution cell now catches only `EOFError`/`KeyboardInterrupt` — an orchestration failure (API key, network, quota) must remain **visible**, not silently absorbed.",,,,,,,b5c71fbcb3af94e7,2c3c19dfa45c6329,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,979228df,code,fr,c499959e426cce74,"from semantic_kernel.contents import ChatMessageContent, AuthorRole
 
 SYMPTOMES_DEMO = (""Depuis trois jours, j'ai une fievre a 38,5 degres avec des maux de tete ""

--- a/translations/genai/casestudies.csv
+++ b/translations/genai/casestudies.csv
@@ -908,9 +908,9 @@ The current plugins cover follow-up questions, severity, and medications. A cruc
 **Objective**: implement a class `AllergyPlugin` with a `check_allergy` method annotated with `@kernel_function` that returns a warning if the medication is incompatible with a known allergy.
 
 **Hints**:
-- # Step 1: Define a dictionary mapping allergies to contraindicated medications
-- # Step 2: Implement the `check_allergy` method with `Annotated` type annotations
-- # Hint: use the pattern of the existing plugins (DoctorPlugin, PharmacistPlugin)",,,,,,,5d6ca1a0150320dd,cb0bffab0bb3ff3e,,,,,,,
+- `# Step 1`: Define a dictionary mapping allergies to contraindicated medications
+- `# Step 2`: Implement the `check_allergy` method with `Annotated` type annotations
+- `# Hint`: use the pattern of the existing plugins (DoctorPlugin, PharmacistPlugin)",,,,,,,5d6ca1a0150320dd,d9adfe63854609e7,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,82094ec1,code,fr,b7e6599ca302d2e3,"class AllergyPlugin:
     """"""Plugin de verification des allergies medicamenteuses.""""""
     # TODO etudiant : implementer le plugin
@@ -986,9 +986,9 @@ The current prompts are configured for an adult. The objective is to adapt the s
 **Objective**: write the three system prompts adapted to the pediatric context.
 
 **Hints**:
-- # Step 1: Modify the doctor's prompt for language accessible to children
-- # Step 2: Adapt the medical AI prompt for pediatric dosages and signs
-- # Hint: add constraints such as ""always mention the recommended weight for dosage""",,,,,,,cc825d4d7e7b961d,2906243cc0527601,,,,,,,
+- `# Step 1`: Modify the doctor's prompt for language accessible to children
+- `# Step 2`: Adapt the medical AI prompt for pediatric dosages and signs
+- `# Hint`: add constraints such as ""always mention the recommended weight for dosage""",,,,,,,cc825d4d7e7b961d,19b6f45a87941807,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,41dedfea,code,fr,7f431eddf5f2de3e,"# Exercice 2 : Prompts adaptes au contexte pediatric
 # TODO etudiant : rediger les trois prompts pediatric
 
@@ -1054,9 +1054,9 @@ The current strategy stops after 6 messages. The objective is to implement a sma
 **Objective**: create `DiagnosticTerminationStrategy` that stops the conversation as soon as a diagnosis is issued or after a maximum of 8 exchanges.
 
 **Hints**:
-- # Step 1: Define a list of keywords indicative of a diagnosis
-- # Step 2: Check for their presence in the content of the last message
-- # Hint: combine the diagnosis condition with a maximum exchange counter",,,,,,,bd87b8571ae6e72c,11de8750db351abd,,,,,,,
+- `# Step 1`: Define a list of keywords indicative of a diagnosis
+- `# Step 2`: Check for their presence in the content of the last message
+- `# Hint`: combine the diagnosis condition with a maximum exchange counter",,,,,,,bd87b8571ae6e72c,f9971e3b7cc0edc7,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,ee8117ae,code,fr,29c05ae8855171de,"from typing import ClassVar
 
 class DiagnosticTerminationStrategy(TerminationStrategy):

--- a/translations/genai/casestudies.csv
+++ b/translations/genai/casestudies.csv
@@ -892,16 +892,16 @@ class PharmacistPlugin:
 print(""Classe DoctorPlugin définie"")
 print(""Classes DoctorPlugin, MedicalAIPlugin, PharmacistPlugin definies"")
 ",,,,,,,,8e01c92f30814a8b,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,c3a57d0b,markdown,fr,f63812e2badbdc9c,"### Exercice 1 : Plugin de verification des allergies
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,c3a57d0b,markdown,fr,5d6ca1a0150320dd,"### Exercice 1 : Plugin de verification des allergies
 
 Les plugins actuels couvrent les questions de suivi, la gravite et les medicaments. Il manque un plugin crucial : la **verification des allergies**. L'objectif est de créer `AllergyPlugin` qui permet a l'agent pharmacien de verifier si un medicament recommande est compatible avec les allergies declarees du patient.
 
 **Objectif** : implementer une classe `AllergyPlugin` avec une méthode `check_allergy` annotee `@kernel_function` qui retourne un avertissement si le medicament est incompatible avec une allergie connue.
 
 **Indices** :
-- # Étape 1 : Définir un dictionnaire associant des allergies a des medicaments contre-indiques
-- # Étape 2 : Implementer la méthode `check_allergy` avec les annotations de type `Annotated`
-- # Indice : utiliser le pattern des plugins existants (DoctorPlugin, PharmacistPlugin)","### Exercise 1: Allergy Verification Plugin
+- `# Étape 1` : Définir un dictionnaire associant des allergies a des medicaments contre-indiques
+- `# Étape 2` : Implementer la méthode `check_allergy` avec les annotations de type `Annotated`
+- `# Indice` : utiliser le pattern des plugins existants (DoctorPlugin, PharmacistPlugin)","### Exercise 1: Allergy Verification Plugin
 
 The current plugins cover follow-up questions, severity, and medications. A crucial plugin is missing: **allergy verification**. The objective is to create `AllergyPlugin`, which allows the pharmacist agent to verify whether a recommended medication is compatible with the patient's declared allergies.
 
@@ -910,7 +910,7 @@ The current plugins cover follow-up questions, severity, and medications. A cruc
 **Hints**:
 - # Step 1: Define a dictionary mapping allergies to contraindicated medications
 - # Step 2: Implement the `check_allergy` method with `Annotated` type annotations
-- # Hint: use the pattern of the existing plugins (DoctorPlugin, PharmacistPlugin)",,,,,,,f63812e2badbdc9c,cb0bffab0bb3ff3e,,,,,,,
+- # Hint: use the pattern of the existing plugins (DoctorPlugin, PharmacistPlugin)",,,,,,,5d6ca1a0150320dd,cb0bffab0bb3ff3e,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,82094ec1,code,fr,b7e6599ca302d2e3,"class AllergyPlugin:
     """"""Plugin de verification des allergies medicamenteuses.""""""
     # TODO etudiant : implementer le plugin
@@ -970,16 +970,16 @@ Mentionnez toujours les précautions d'utilisation et la nécessité d'une consu
 print(""Prompt médical configuré"")
 print(""Prompts medicaux configures"")
 ",,,,,,,,7204ffc5b2db8385,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,35b7c5f2,markdown,fr,f7393a4e7c64d255,"### Exercice 2 : Adapter les prompts pour un scénario pediatric
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,35b7c5f2,markdown,fr,cc825d4d7e7b961d,"### Exercice 2 : Adapter les prompts pour un scénario pediatric
 
 Les prompts actuels sont configures pour un adulte. L'objectif est d'adapter le système pour une **consultation pediatric** : le medecin doit utiliser un langage adapte aux enfants, l'IA medicale doit prendre en compte les specificites pediatric (posologie différente, signes vitaux spécifiques), et le pharmacien doit mentionner les precautions enfant.
 
 **Objectif** : ecrire les trois prompts système adaptes au contexte pediatric.
 
 **Indices** :
-- # Étape 1 : Modifier le prompt du medecin pour un langage accessible aux enfants
-- # Étape 2 : Adapter le prompt de l'IA medicale pour les dosages et signes pediatric
-- # Indice : ajouter des contraintes comme ""toujours mentionner le poids recommande pour la posologie""","### Exercise 2: Adapt the prompts for a pediatric scenario
+- `# Étape 1` : Modifier le prompt du medecin pour un langage accessible aux enfants
+- `# Étape 2` : Adapter le prompt de l'IA medicale pour les dosages et signes pediatric
+- `# Indice` : ajouter des contraintes comme ""toujours mentionner le poids recommande pour la posologie""","### Exercise 2: Adapt the prompts for a pediatric scenario
 
 The current prompts are configured for an adult. The objective is to adapt the system for a **pediatric consultation**: the doctor must use language suited to children, the medical AI must take pediatric specifics into account (different dosage, specific vital signs), and the pharmacist must mention precautions for children.
 
@@ -988,7 +988,7 @@ The current prompts are configured for an adult. The objective is to adapt the s
 **Hints**:
 - # Step 1: Modify the doctor's prompt for language accessible to children
 - # Step 2: Adapt the medical AI prompt for pediatric dosages and signs
-- # Hint: add constraints such as ""always mention the recommended weight for dosage""",,,,,,,f7393a4e7c64d255,2906243cc0527601,,,,,,,
+- # Hint: add constraints such as ""always mention the recommended weight for dosage""",,,,,,,cc825d4d7e7b961d,2906243cc0527601,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,41dedfea,code,fr,7f431eddf5f2de3e,"# Exercice 2 : Prompts adaptes au contexte pediatric
 # TODO etudiant : rediger les trois prompts pediatric
 
@@ -1038,16 +1038,16 @@ MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,8477b9
 print(""Stratégie de terminaison médicale définie"")
 print(""Strategie de terminaison medicale definie"")
 ",,,,,,,,d223cbb405a662db,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,c555c4b3,markdown,fr,185f9d24bb4ce125,"### Exercice 3 : Stratégie de terminaison basee sur le diagnostic
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,c555c4b3,markdown,fr,bd87b8571ae6e72c,"### Exercice 3 : Stratégie de terminaison basee sur le diagnostic
 
 La stratégie actuelle arrete après 6 messages. L'objectif est d'implementer une stratégie plus intelligente qui detecte quand un **diagnostic probable** a ete formule par l'IA medicale (presence de mots comme ""diagnostic"", ""hypothese"", ""probablement"" dans le dernier message).
 
 **Objectif** : créer `DiagnosticTerminationStrategy` qui arrete la conversation des qu'un diagnostic est emis ou après 8 echanges maximum.
 
 **Indices** :
-- # Étape 1 : Définir une liste de mots-cles indicatifs d'un diagnostic
-- # Étape 2 : Verifier leur presence dans le contenu du dernier message
-- # Indice : combiner la condition de diagnostic avec un compteur maximum d'echanges","### Exercise 3: Termination strategy based on diagnosis
+- `# Étape 1` : Définir une liste de mots-cles indicatifs d'un diagnostic
+- `# Étape 2` : Verifier leur presence dans le contenu du dernier message
+- `# Indice` : combiner la condition de diagnostic avec un compteur maximum d'echanges","### Exercise 3: Termination strategy based on diagnosis
 
 The current strategy stops after 6 messages. The objective is to implement a smarter strategy that detects when a **probable diagnosis** has been formulated by the medical AI (presence of words such as ""diagnostic"", ""hypothese"", ""probablement"" in the last message).
 
@@ -1056,7 +1056,7 @@ The current strategy stops after 6 messages. The objective is to implement a sma
 **Hints**:
 - # Step 1: Define a list of keywords indicative of a diagnosis
 - # Step 2: Check for their presence in the content of the last message
-- # Hint: combine the diagnosis condition with a maximum exchange counter",,,,,,,185f9d24bb4ce125,11de8750db351abd,,,,,,,
+- # Hint: combine the diagnosis condition with a maximum exchange counter",,,,,,,bd87b8571ae6e72c,11de8750db351abd,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,ee8117ae,code,fr,29c05ae8855171de,"from typing import ClassVar
 
 class DiagnosticTerminationStrategy(TerminationStrategy):
@@ -1081,38 +1081,59 @@ print(""Prompts medicaux configures"")
 print(""Chat de groupe medical configure"")
 ",,,,,,,,c01fbc60b42fc540,,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,0c12975d,markdown,fr,4561be1ad4182028,## Fonction pour exécuter le dialogue,## Function to run the dialogue,,,,,,,4561be1ad4182028,6fa89c63f220a72e,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,6e4e04a9,markdown,fr,c461b08a7a11465f,"La fonction `run_medical_chat` orchestre le dialogue complet : elle recueille les symptomes initiaux via `input()`, transmet le message a l'`AgentGroupChat`, puis itere sur les reponses des agents. Le cycle se poursuit jusqu'a ce que la stratégie de terminaison declare la consultation terminee.
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,6e4e04a9,markdown,fr,b5c71fbcb3af94e7,"La fonction `run_medical_chat` orchestre le dialogue complet : elle amorce la consultation avec les symptômes du patient, les transmet à l'`AgentGroupChat`, puis itère sur les réponses des agents jusqu'à ce que la stratégie de terminaison déclare la consultation terminée (limite de 6 échanges posée par `MedicalTerminationStrategy`).
 
-En mode interactif (`BATCH_MODE = False`), l'utilisateur peut repondre a chaque agent. En mode batch, l'appel est capture par le bloc `try/except` ci-dessous.","The `run_medical_chat` function orchestrates the complete dialogue: it collects the initial symptoms via `input()`, passes the message to the `AgentGroupChat`, then iterates over the agents' responses. The cycle continues until the termination strategy declares the consultation complete.
+Deux modes d'amorçage :
 
-In interactive mode (`BATCH_MODE = False`), the user can respond to each agent. In batch mode, the call is captured by the `try/except` block below.",,,,,,,c461b08a7a11465f,f5210b28d4ec4827,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,979228df,code,fr,92c4be50a9e82bab,"async def run_medical_chat():
-    logger.info(""🚀 Début de la consultation médicale IA"")
-    chat_history = ChatHistory()
-    
-    symptoms = input(""Décrivez vos symptômes : "")
-    chat_history.add_user_message(symptoms)
-    
+- **Batch** (`BATCH_MODE = True`, le mode Papermill/CI) : un cas clinique fixé (`SYMPTOMES_DEMO`) démarre la consultation. En exécution headless, `stdin` n'existe pas — appeler `input()` lève `StdinNotImplementedError` avant que le moindre agent ne parle, et la consultation n'a pas lieu. C'est le même patron que les deux autres études de cas du répertoire : `Fort-Boyard` amorce avec un mot à deviner fixé, `Barbie-Schreck` avec une contrainte de style tirée au sort.
+- **Interactif** (`BATCH_MODE = False`) : les symptômes initiaux sont saisis au clavier via `input()`.
+
+La consultation est ensuite **agent-driven** : les trois agents se répondent sans intervention. Le `try/except` de la cellule d'exécution n'intercepte plus que `EOFError`/`KeyboardInterrupt` — un échec d'orchestration (clé API, réseau, quota) doit rester **visible**, pas absorbé silencieusement.","The `run_medical_chat` function orchestrates the complete dialogue: it collects the initial symptoms via `input()`, passes the message to the `AgentGroupChat`, then iterates over the agents' responses. The cycle continues until the termination strategy declares the consultation complete.
+
+In interactive mode (`BATCH_MODE = False`), the user can respond to each agent. In batch mode, the call is captured by the `try/except` block below.",,,,,,,b5c71fbcb3af94e7,f5210b28d4ec4827,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,979228df,code,fr,c499959e426cce74,"from semantic_kernel.contents import ChatMessageContent, AuthorRole
+
+SYMPTOMES_DEMO = (""Depuis trois jours, j'ai une fievre a 38,5 degres avec des maux de tete ""
+                  ""et une legere toux seche. Je n'ai pas de douleur thoracique."")
+
+async def run_medical_chat():
+    logger.info(""Début de la consultation médicale IA"")
+
+    # En mode batch (Papermill/CI), stdin n'existe pas : on amorce la consultation
+    # avec un cas clinique fixe -- meme patron que Fort-Boyard et Barbie-Schreck.
+    if BATCH_MODE:
+        symptoms = SYMPTOMES_DEMO
+        print(f""[Batch] Cas clinique démo : {symptoms}"")
+    else:
+        symptoms = input(""Décrivez vos symptômes : "")
+
+    # Le message patient amorce l'historique INTERNE de l'AgentGroupChat (via
+    # add_chat_message) : sans lui, la premiere invocation n'a aucun message
+    # auquel repondre et echoue.
+    await chat.add_chat_message(ChatMessageContent(role=AuthorRole.USER, content=symptoms))
+
+    # Consultation agent-driven : les trois agents se repondent jusqu'a la limite
+    # de 6 echanges posee par MedicalTerminationStrategy.
     while True:
         async for message in chat.invoke():
             logger.info(f""[{message.role}] {message.name}: {message.content}"")
             print(f""{message.name}: {message.content}"")
-            
-            if message.name not in [""Pharmacien""]:
-                user_response = input(""👉 Votre réponse : "")
-                chat_history.add_user_message(user_response)
-        
+
         if chat.is_complete:
             break
-    
-    logger.info(""🏥 Consultation terminée."")
+
+    logger.info(""Consultation terminée."")
+
 print(""Fonction de chat médical prête"")
-print(""Fonction run_medical_chat prete"")
-",,,,,,,,92c4be50a9e82bab,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,d0d7a23d,code,fr,e0d2761e5f4d5d05,"try:
+",,,,,,,,c499959e426cce74,,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,d0d7a23d,code,fr,e8168f859bef5c86,"# except resserre : plus d'Exception nue. EOFError/KeyboardInterrupt = session
+# interactive interrompue par l'utilisateur ; tout autre echec (API, cle, reseau)
+# doit rester VISIBLE dans la sortie, pas etre absorbe.
+try:
     await run_medical_chat()
-except (EOFError, KeyboardInterrupt, Exception) as e:
-    print(f""[Batch] Consultation interactive ignoree ({type(e).__name__}: {str(e)[:80]})"")",,,,,,,,e0d2761e5f4d5d05,,,,,,,,
+except (EOFError, KeyboardInterrupt) as e:
+    print(f""[Session interactive interrompue ({type(e).__name__}) - la consultation n'a pas eu lieu, relancez la cellule.]"")
+",,,,,,,,e8168f859bef5c86,,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,ceaae36c,markdown,fr,5c7500827f76bbef,"## Ce que nous avons construit
 
 Ce cas d'usage illustre plusieurs concepts avances de Semantic Kernel :
@@ -1606,3 +1627,100 @@ MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,c9681143,ma
 MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,943a4bd5,markdown,fr,20e3bc20c5f86572,"**Lecture de l'échec PDF** — la cellule renvoie `Échec de la génération : Aucun PDF produit malgré les tentatives`. C'est un **échec d'export**, pas un échec de raisonnement : la recette (Salade de Quinoa) a bien été générée et validée par les agents, mais l'outil de rendu PDF n'a pas pu la matérialiser.
 
 **Pourquoi cet échec est pédagogiquement plus intéressant qu'un succès** : il illustre la **frontière entre le raisonnement LLM et l'exécution d'outils**. Le multi-agent a fait son travail (recette correcte, contraintes respectées) ; le pipeline casse à l'interface avec une dépendance externe (librairie PDF, polices, permissions d'écriture). Diagnostiquer cet échec demande de séparer les deux couches : vérifier d'abord que `RecipeState` contient la recette (couche agent = OK), puis inspecter l'exception de l'outil PDF (couche rendu = KO). C'est la discipline de debug que tout système LLM-outils exige — et ce notebook, en assumant l'échec honnêtement plutôt qu'en le masquant, enseigne cette distinction au lieu de la cacher.",,,,,,,,20e3bc20c5f86572,,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,1969ae56,markdown,fr,27ca5071235eb784,"### Vue d'ensemble : un chatbot médical multi-agent en 3 rôles
+
+Ce notebook implémente une consultation médicale simulée entre trois agents LLM : un **médecin généraliste** qui pose des questions complémentaires au patient, une **IA médicale d'analyse** qui propose des hypothèses diagnostiques, et un **pharmacien** qui vérifie les interactions médicamenteuses. Le tout orchestré par un `AgentGroupChat` Semantic Kernel avec une **stratégie de terminaison** à limite d'échanges (6 messages) — la détection d'un diagnostic final par mot-clé étant laissée en exercice. Le notebook couvre les patterns : `Kernel` + `plugins` natifs, `ChatCompletionAgent`, `AgentGroupChat`, `TerminationStrategy`, et `auto function calling`. C'est un cas d'usage type pour les **synthetic clinical reasoning** où plusieurs LLM agents simulent une consultation réelle.","### Overview: a 3-role multi-agent medical chatbot
+
+This notebook implements a simulated medical consultation between three LLM agents: a **general practitioner** who asks the patient follow-up questions, a **medical analysis AI** that proposes diagnostic hypotheses, and a **pharmacist** who checks drug interactions. The whole thing is orchestrated by a Semantic Kernel `AgentGroupChat` with an **exchange-limit termination strategy** (6 messages) — detecting a final diagnosis by keyword is left as an exercise. The notebook covers the patterns: `Kernel` + native `plugins`, `ChatCompletionAgent`, `AgentGroupChat`, `TerminationStrategy`, and `auto function calling`. It is a typical use case for **synthetic clinical reasoning** where several LLM agents simulate a real consultation.",,,,,,,27ca5071235eb784,e343123d74c7e3f6,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,593c25da,markdown,fr,f4649179389e60bd,"### Lecture du résultat : imports et configuration initiale
+
+L'output `""Imports OK""` valide la chaîne complète `python-dotenv` + `semantic-kernel` + `pydantic` : trois dépendances critiques pour ce cas d'usage, et l'échec d'une seule aurait court-circuité la cellule d'imports ci-dessus (`load_dotenv()`). Le notebook utilise des **imports gardés** (try/except ImportError) dans la cellule d'imports ci-dessus — c'est un pattern défensif qui documente la disponibilité des services externes **avant** de planter en aval. L'étudiant doit reproduire ce réflexe : un import nu de `semantic_kernel` dans un clone frais sans la dépendance installée retournerait un `ModuleNotFoundError` peu explicite.","### Reading the result: imports and initial configuration
+
+The `""Imports OK""` output validates the full `python-dotenv` + `semantic-kernel` + `pydantic` chain: three critical dependencies for this use case, and a failure in any single one would have short-circuited the imports cell above (`load_dotenv()`). The notebook uses **guarded imports** (try/except ImportError) in the imports cell above — a defensive pattern that documents the availability of external services **before** failing downstream. The student should reproduce this reflex: a bare `import semantic_kernel` in a fresh clone without the dependency installed would return an unhelpful `ModuleNotFoundError`.",,,,,,,f4649179389e60bd,ab317da5225b77d2,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,43b69f3c,markdown,fr,fee421cd4704c389,"### Lecture du résultat : variables d'environnement chargées
+
+`load_dotenv()` retourne `True` quand un fichier `.env` est trouvé et parsé. C'est le **premier signal** que la configuration LLM est en place : `OPENAI_API_KEY` (modèle GPT-4), `AZURE_OPENAI_ENDPOINT` (déploiement Azure AI Foundry), ou un endpoint local ComfyUI/Qwen selon la cohorte. Si l'étudiant voit `False`, le notebook échouera plus loin lors de l'instanciation du kernel (`Kernel()` sans service LLM = crash silencieux).","### Reading the result: environment variables loaded
+
+`load_dotenv()` returns `True` when a `.env` file is found and parsed. This is the **first signal** that the LLM configuration is in place: `OPENAI_API_KEY` (GPT-4 model), `AZURE_OPENAI_ENDPOINT` (Azure AI Foundry deployment), or a local ComfyUI/Qwen endpoint depending on the cohort. If the student sees `False`, the notebook will fail later when instantiating the kernel (`Kernel()` without an LLM service = silent crash).",,,,,,,fee421cd4704c389,61f1e1da316546ce,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,fcebb55c,markdown,fr,f9fd63648ea86466,"### Lecture du résultat : logging structuré pour traçabilité multi-agent
+
+`""Configuration des logs OK""` valide le format `%(asctime)s [%(levelname)s] %(name)s: %(message)s` avec niveau `INFO`. C'est ce format que la cellule d'exécution de la consultation (en fin de notebook) affichera en sortie (horodatage + `[INFO] Début de la consultation médicale IA` au lancement de la consultation). Le logging **structuré** n'est pas un caprice pédagogique : sans lui, l'étudiant ne peut pas distinguer **qui parle** dans un chat à 3 agents — médecin, IA médicale ou pharmacien. Le préfixe `🚀` est un signal visuel (emoji utilisé comme tag sémantique) qui délimite les phases de l'orchestration : début de consultation, fin de tour, terminaison. L'étudiant doit noter l'horodatage (la date varie à chaque exécution) et l'ordre des événements : c'est cette trace qui valide ex-post la séquence orchestrale.","### Reading the result: structured logging for multi-agent traceability
+
+`""Configuration des logs OK""` validates the `%(asctime)s [%(levelname)s] %(name)s: %(message)s` format at level `INFO`. This is the format the consultation execution cell (at the end of the notebook) will display as output (timestamp + `[INFO] Début de la consultation médicale IA` when the consultation starts). **Structured** logging is not a pedagogical whim: without it, the student cannot tell **who is speaking** in a 3-agent chat — doctor, medical AI, or pharmacist. The `🚀` prefix is a visual signal (emoji used as a semantic tag) that delimits the orchestration phases: consultation start, end of turn, termination. The student should note the timestamp (the date changes on every run) and the order of events: this trace is what validates the orchestral sequence after the fact.",,,,,,,f9fd63648ea86466,e554aac6e66c6909,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,b4543216,markdown,fr,a30d1662e8441dbf,"### Lecture du résultat : fonction factory create_kernel
+
+`""Kernel Semantic Kernel créé""` confirme l'instanciation d'un `Kernel()` vide — la `def create_kernel()` est appelée plus loin dans le notebook (`kernel = create_kernel()`). Cette **séparation définition/instanciation** est un pattern de **testabilité** : la cellule d'instanciation peut être relancée plusieurs fois sans redéfinir la fonction. Dans un notebook pédagogique, cela permet à l'étudiant de **réinstancier** un kernel frais si le précédent a accumulé des plugins contradictoires (ex. après une erreur dans une cellule précédente). Dans un projet en production, c'est l'équivalent d'une **factory pattern** classique (GoF).","### Reading the result: the create_kernel factory function
+
+`""Kernel Semantic Kernel créé""` confirms the instantiation of an empty `Kernel()` — the `def create_kernel()` is called further down in the notebook (`kernel = create_kernel()`). This **definition/instantiation separation** is a **testability** pattern: the instantiation cell can be re-run several times without redefining the function. In a pedagogical notebook, this lets the student **re-instantiate** a fresh kernel if the previous one accumulated contradictory plugins (e.g. after an error in an earlier cell). In a production project, it is the equivalent of a classic **factory pattern** (GoF).",,,,,,,a30d1662e8441dbf,e89dbeac3c215583,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,fd86a9df,markdown,fr,b38fbe151161f8a8,"### Lecture du résultat : kernel Semantic Kernel instancié
+
+La cellule ci-dessus définit `create_kernel()` — c'est la **factory du conteneur central** de Semantic Kernel. Le kernel agrège services LLM, plugins (médecin/pharmacien/allergies) et filters. Dans ce notebook, chaque agent conversationnel (médecin, IA médicale, pharmacien) **partage le même kernel** mais accède à des plugins différents via `kernel.add_plugin(DoctorPlugin(), plugin_name=""doctor"")`. Cette mutualisation du kernel vs duplication par agent est un choix d'architecture : un seul service LLM, N personas.","### Reading the result: Semantic Kernel kernel instantiated
+
+The cell above defines `create_kernel()` — the **factory of Semantic Kernel's central container**. The kernel aggregates LLM services, plugins (doctor/pharmacist/allergies) and filters. In this notebook, each conversational agent (doctor, medical AI, pharmacist) **shares the same kernel** but accesses different plugins via `kernel.add_plugin(DoctorPlugin(), plugin_name=""doctor"")`. Sharing the kernel instead of duplicating it per agent is an architecture choice: one LLM service, N personas.",,,,,,,b38fbe151161f8a8,eec6675a2d05d3f8,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,32073503,markdown,fr,d73179abc1194d34,"### Lecture du résultat : kernel et plugins opérationnels
+
+`""Kernel instancie""` puis `""Kernel configuré avec le plugin médical""` valident la séquence `kernel = create_kernel()` → `kernel.add_plugin(DoctorPlugin(), plugin_name=""doctor"")`. Cette **deuxième étape** est ce qui distingue Semantic Kernel d'un simple wrapper OpenAI : le kernel **enregistre** les plugins comme tools invocables par le LLM via la couche `auto function calling`. Sans `add_plugin`, les `native functions` Python de `DoctorPlugin` seraient inaccessibles aux agents, et le LLM répondrait **sans grounding médical**.","### Reading the result: kernel and plugins operational
+
+`""Kernel instancie""` then `""Kernel configuré avec le plugin médical""` validate the sequence `kernel = create_kernel()` → `kernel.add_plugin(DoctorPlugin(), plugin_name=""doctor"")`. This **second step** is what distinguishes Semantic Kernel from a simple OpenAI wrapper: the kernel **registers** plugins as tools invocable by the LLM via the `auto function calling` layer. Without `add_plugin`, the Python `native functions` of `DoctorPlugin` would be unreachable by the agents, and the LLM would answer **without medical grounding**.",,,,,,,d73179abc1194d34,f2a4dc19b954c65a,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,f685b172,markdown,fr,34cb11f5490b6a1e,"### Lecture du résultat : plugins médicaux définis
+
+`""Classe DoctorPlugin définie""` valide que `DoctorPlugin` (questions complémentaires au patient), `MedicalAIPlugin` (analyse IA), et `PharmacistPlugin` (vérification interactions médicamenteuses) sont instanciés en mémoire. Chaque plugin expose des **native functions** Python décorées `@kernel.function_description()` que les agents peuvent invoquer via le mécanisme d'**auto function calling** de SK. Le notebook utilise 3 plugins médicaux + 1 plugin d'allergies (exercice, ci-dessous) — l'étudiant doit compléter l'`AllergyPlugin` (voir l'exercice ci-dessous). Les plugins sont l'**équivalent médical des tools en LangChain** : la Skill calling devient `function_call` côté LLM.","### Reading the result: medical plugins defined
+
+`""Classe DoctorPlugin définie""` validates that `DoctorPlugin` (patient follow-up questions), `MedicalAIPlugin` (AI analysis), and `PharmacistPlugin` (drug interaction checks) are instantiated in memory. Each plugin exposes Python **native functions** decorated with `@kernel.function_description()` that agents can invoke via SK's **auto function calling** mechanism. The notebook uses 3 medical plugins + 1 allergy plugin (exercise, below) — the student must complete the `AllergyPlugin` (see the exercise below). Plugins are the **medical equivalent of tools in LangChain**: skill calling becomes `function_call` on the LLM side.",,,,,,,34cb11f5490b6a1e,232ed8c6797ed708,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,518877fb,markdown,fr,17fd288a5ba38f14,"### Lecture du résultat : prompts système configurés
+
+`""Prompts medicaux configures""` couvre les 3 rôles : `DOCTOR_PROMPT` (médecin généraliste, questions complémentaires), `AI_MEDICAL_PROMPT` (assistant IA d'analyse), `PHARMACIST_PROMPT` (vérification interactions). Chaque prompt structure la **persona + comportement attendu** : ton professionnel, refus de prescrire, demande de clarifications. C'est l'application du pattern **role prompting** (cf. [OpenAI Best Practices](https://platform.openai.com/docs/guides/prompt-engineering/tactic-ask-the-model-to-adopt-a-persona)). L'exercice sur les prompts (plus bas) invite l'étudiant à rédiger un prompt pediatric — l'ajout d'un persona spécialisé est un exercice classique de **persona engineering**.","### Reading the result: system prompts configured
+
+`""Prompts medicaux configures""` covers the 3 roles: `DOCTOR_PROMPT` (general practitioner, follow-up questions), `AI_MEDICAL_PROMPT` (AI analysis assistant), `PHARMACIST_PROMPT` (interaction checks). Each prompt structures the **persona + expected behavior**: professional tone, refusal to prescribe, asking for clarifications. This is an application of the **role prompting** pattern (cf. [OpenAI Best Practices](https://platform.openai.com/docs/guides/prompt-engineering/tactic-ask-the-model-to-adopt-a-persona)). The prompt exercise (further down) invites the student to write a pediatric prompt — adding a specialized persona is a classic **persona engineering** exercise.",,,,,,,17fd288a5ba38f14,7a36fb10faf9a80b,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,5a6279be,markdown,fr,d92b764a58419333,"### Lecture du résultat : passage du squelette à l'exécution
+
+Avec la cellule d'instanciation du kernel ci-dessus (`kernel = create_kernel()`) et la cellule d'ajout des plugins plus bas (`kernel.add_plugin(...)`), le notebook **quitte la phase de définition** pour la phase d'instanciation. Avant : on *définissait* des classes et fonctions. Après : on les *utilise*. Cette démarcation est un signal pédagogique classique en notebook : la deuxième moitié du notebook est **exécutable** (l'étudiant doit voir la consultation se dérouler), tandis que la première moitié est **structurelle** (l'étudiant peut la lire comme du code de production). Le `print(""Kernel instancie"")` qui accompagne l'instanciation est la **trace écrite** de cette transition.","### Reading the result: from skeleton to execution
+
+With the kernel instantiation cell above (`kernel = create_kernel()`) and the plugin-addition cell further down (`kernel.add_plugin(...)`), the notebook **leaves the definition phase** for the instantiation phase. Before: we *defined* classes and functions. After: we *use* them. This demarcation is a classic pedagogical signal in notebooks: the second half of the notebook is **executable** (the student should see the consultation unfold), while the first half is **structural** (the student can read it as production code). The `print(""Kernel instancie"")` that accompanies the instantiation is the **written trace** of this transition.",,,,,,,d92b764a58419333,b26f4717b2c6fb58,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,887a3c44,markdown,fr,094cd5f3d5d37abf,"### Lecture du résultat : stratégie de terminaison médicale
+
+`""Stratégie de terminaison médicale définie""` marque l'instanciation de `MedicalTerminationStrategy` — sous-classe de `TerminationStrategy` qui détecte la fin du chat multi-agent. Dans ce notebook, le critère de terminaison est une **limite d'échanges** : `should_terminate` retourne `True` dès que l'historique atteint 6 messages (`len(history) >= 6`) — soit 1 message patient + 5 réponses d'agents. Sans stratégie explicite, `AgentGroupChat` boucle indéfiniment. La détection d'un diagnostic par mot-clé est précisément l'**exercice** laissé à l'étudiant plus bas (`DiagnosticTerminationStrategy`). L'étudiant doit observer cette **séparation entre orchestration et logique métier** : la stratégie de terminaison est un **plugin comportemental**, pas une règle codée en dur dans le chat.","### Reading the result: medical termination strategy
+
+`""Stratégie de terminaison médicale définie""` marks the instantiation of `MedicalTerminationStrategy` — a subclass of `TerminationStrategy` that detects the end of the multi-agent chat. In this notebook, the termination criterion is an **exchange limit**: `should_terminate` returns `True` as soon as the history reaches 6 messages (`len(history) >= 6`) — i.e. 1 patient message + 5 agent replies. Without an explicit strategy, `AgentGroupChat` loops forever. Detecting a diagnosis by keyword is precisely the **exercise** left to the student further down (`DiagnosticTerminationStrategy`). The student should observe this **separation between orchestration and business logic**: the termination strategy is a **behavioral plugin**, not a rule hard-coded into the chat.",,,,,,,094cd5f3d5d37abf,642cc195e00643fa,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,79574b2a,markdown,fr,9c51f3268b92ee9b,"### Lecture du résultat : agents conversationnels créés
+
+`""Agents de conversation créés""` marque l'instanciation de trois `ChatCompletionAgent` (médecin, IA médicale, pharmacien) avec leurs rôles respectifs et le `ServiceId=""openai""` du kernel. C'est ici que le **modèle de groupe** (`AgentGroupChat`, instancié plus bas dans le notebook) prend forme : trois personas, un orchestrateur de chat, une stratégie de terminaison médicale. L'étudiant doit observer la distinction agent/kernel : un agent **utilise** un kernel mais n'en est pas le propriétaire. Pour Scalability, ajouter un 4ᵉ agent (ex. infirmier) ne nécessite pas de réinstancier le kernel — seulement un nouveau `ChatCompletionAgent` partageant le même.","### Reading the result: conversational agents created
+
+`""Agents de conversation créés""` marks the instantiation of three `ChatCompletionAgent` (doctor, medical AI, pharmacist) with their respective roles and the kernel's `ServiceId=""openai""`. This is where the **group model** (`AgentGroupChat`, instantiated further down in the notebook) takes shape: three personas, one chat orchestrator, one medical termination strategy. The student should observe the agent/kernel distinction: an agent **uses** a kernel but does not own it. For scalability, adding a 4th agent (e.g. a nurse) does not require re-instantiating the kernel — only a new `ChatCompletionAgent` sharing the same one.",,,,,,,9c51f3268b92ee9b,4010fb6bb8013d2b,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,f72d8c8b,markdown,fr,72884a024d9a6fe6,"### Lecture du résultat : paramètres d'exécution LLM
+
+`""Paramètres d'exécution configurés""` marque `kernel.get_prompt_execution_settings_from_service_id(""openai"")` qui configure la température, le max_tokens, le top_p pour les appels LLM du kernel. Ces paramètres sont **partagés par les 3 agents** via le kernel — pas configurés agent par agent. C'est un choix d'orchestration : pour une consultation médicale, on veut des réponses **reproductibles et conservatives** (température basse, typiquement 0.2-0.5), pas créatives. L'étudiant peut observer l'effet en modifiant `temperature` (de 0.0 = déterministe à 1.0 = exploratoire) et en relançant la cellule `settings` ci-dessus.","### Reading the result: LLM execution settings
+
+`""Paramètres d'exécution configurés""` marks `kernel.get_prompt_execution_settings_from_service_id(""openai"")` which configures the temperature, max_tokens, and top_p for the kernel's LLM calls. These settings are **shared by the 3 agents** through the kernel — not configured agent by agent. It is an orchestration choice: for a medical consultation, we want **reproducible and conservative** answers (low temperature, typically 0.2-0.5), not creative ones. The student can observe the effect by changing `temperature` (from 0.0 = deterministic to 1.0 = exploratory) and re-running the `settings` cell above.",,,,,,,72884a024d9a6fe6,b1fe49df3e1072aa,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,faa01c8b,markdown,fr,b70eda170196f9d2,"### Lecture du résultat : chat de groupe médical configuré
+
+`""Chat de groupe médical configuré""` valide la chaîne `AgentGroupChat(agents=[...], termination_strategy=MedicalTerminationStrategy(), selection_strategy=DefaultSelectionStrategy())`. Le **groupe de chat** orchestre la conversation multi-agent : à chaque tour, le `selection_strategy` choisit l'agent actif (round-robin par défaut, ou basé sur le dernier message), le `termination_strategy` détecte la fin (limite de 6 messages dans l'historique). C'est le **cœur du pattern multi-agent** : sans orchestration explicite, les agents parleraient en parallèle. Ce notebook est un cas d'usage type de **synthetic clinical reasoning** où 3 LLM agents simulent une consultation réelle.","### Reading the result: medical group chat configured
+
+`""Chat de groupe médical configuré""` validates the chain `AgentGroupChat(agents=[...], termination_strategy=MedicalTerminationStrategy(), selection_strategy=DefaultSelectionStrategy())`. The **group chat** orchestrates the multi-agent conversation: at each turn, the `selection_strategy` picks the active agent (round-robin by default, or based on the last message), the `termination_strategy` detects the end (limit of 6 messages in the history). This is the **heart of the multi-agent pattern**: without explicit orchestration, the agents would speak in parallel. This notebook is a typical use case of **synthetic clinical reasoning** where 3 LLM agents simulate a real consultation.",,,,,,,b70eda170196f9d2,12fccd8f8a40d688,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,8ba2019f,markdown,fr,bb60deafe3b577d1,"### Lecture du résultat : squelette multi-agent complet, prêt pour l'exécution
+
+À ce stade du notebook, **toute la machinerie multi-agent est en place** : kernel partagé (1), 3+ plugins médicaux (médecin/IA/pharmacien/allergies), 3 agents conversationnels avec leurs prompts respectifs, 1 stratégie de terminaison médicale, 1 groupe de chat orchestré, 1 fonction `run_medical_chat()` async. Ce qui sépare ce notebook d'un squelette mort, c'est la cellule d'exécution (try/except `await run_medical_chat()`, ci-dessous) : l'appel asynchrone déclenche réellement l'orchestration et l'étudiant voit la conversation se dérouler tour par tour. **Pattern clé** : la complexité d'un système multi-agent est *cachée* dans le setup (tout ce qui précède) et *visible* dans l'exécution (les dernières cellules). L'étudiant doit comprendre ce distinguo pour scripter ses propres use cases.","### Reading the result: complete multi-agent skeleton, ready for execution
+
+At this point in the notebook, **the entire multi-agent machinery is in place**: shared kernel (1), 3+ medical plugins (doctor/AI/pharmacist/allergies), 3 conversational agents with their respective prompts, 1 medical termination strategy, 1 orchestrated group chat, 1 async `run_medical_chat()` function. What separates this notebook from a dead skeleton is the execution cell (try/except `await run_medical_chat()`, below): the asynchronous call actually triggers the orchestration and the student sees the conversation unfold turn by turn. **Key pattern**: the complexity of a multi-agent system is *hidden* in the setup (everything above) and *visible* in the execution (the last cells). The student must understand this distinction to script their own use cases.",,,,,,,bb60deafe3b577d1,6f3060a3f37f2da2,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,a4b715be,markdown,fr,f37fc25bd0283c62,"### Lecture du résultat : fonction de chat médical prête
+
+`""Fonction de chat médical prête""` marque l'aboutissement du squelette : la fonction async `run_medical_chat()` peut être appelée pour démarrer la consultation simulée. Le `logger.info(""🚀 Début de la consultation médicale IA"")` qui suit est le **premier signal d'exécution** quand l'étudiant lance la cellule d'exécution de la consultation (ci-dessous). À ce stade, le notebook a instancié **3 agents**, **1 kernel partagé**, **3+ plugins**, **1 stratégie de terminaison**, **1 groupe de chat** — toute la machinerie multi-agent est en place. La cellule d'exécution lance `await run_medical_chat()` qui bouclera jusqu'à ce que `MedicalTerminationStrategy.should_terminate()` retourne `True` (limite de 6 messages dans l'historique du groupe).","### Reading the result: medical chat function ready
+
+`""Fonction de chat médical prête""` marks the culmination of the skeleton: the async function `run_medical_chat()` can be called to start the simulated consultation. The `logger.info(""🚀 Début de la consultation médicale IA"")` that follows is the **first execution signal** when the student runs the consultation execution cell (below). At this point, the notebook has instantiated **3 agents**, **1 shared kernel**, **3+ plugins**, **1 termination strategy**, **1 group chat** — the whole multi-agent machinery is in place. The execution cell launches `await run_medical_chat()` which will loop until `MedicalTerminationStrategy.should_terminate()` returns `True` (limit of 6 messages in the group history).",,,,,,,f37fc25bd0283c62,2e8f243c81521d1b,,,,,,,
+MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb,3ccfe984,markdown,fr,091ceca9427de857,"### Lecture du résultat : exécution effective de la consultation simulée
+
+La sortie ci-dessus est une consultation **réelle** (7 appels `gpt-4o-mini` comptés dans les logs HTTP). Le log `Début de la consultation médicale IA` ouvre la trace, puis le cas clinique démo amorce l'historique du groupe. **L'étudiant observe** :
+
+1. **La rotation round-robin des agents** — les logs `Selected agent at index 0/1/2` montrent la `selection_strategy` par défaut passer le bâton : `Docteur_Humain` → `IA_Medicale` → `Pharmacien` → `Docteur_Humain` → `IA_Medicale` (5 tours d'agents).
+2. **L'auto function calling en action** — dès son premier tour, le médecin invoque **2 plugins en parallèle** (`doctor-ask_followup_questions` + `medical-check_symptom_severity`) : `FunctionChoiceBehavior.Auto()` s'exécute réellement, ce n'est pas une description.
+3. **La terminaison par limite d'échanges** — 1 message patient + 5 réponses d'agents = 6 messages : `MedicalTerminationStrategy` met fin à la consultation (`Consultation terminée.`). La détection d'un **diagnostic final par mot-clé** n'a pas eu lieu : c'est l'exercice laissé à l'étudiant (`DiagnosticTerminationStrategy`, stub ci-dessus).
+
+Cette trace rejouable est ce qui rend le notebook pédagogique : l'étudiant peut relire la séquence async pour comprendre le mécanisme de sélection d'agent, plutôt que de lire une boîte noire.","### Reading the result: actual execution of the simulated consultation
+
+The output above is a **real** consultation (7 `gpt-4o-mini` calls counted in the HTTP logs). The `Début de la consultation médicale IA` log opens the trace, then the demo clinical case seeds the group history. **The student observes**:
+
+1. **The round-robin rotation of the agents** — the `Selected agent at index 0/1/2` logs show the default `selection_strategy` passing the baton: `Docteur_Humain` → `IA_Medicale` → `Pharmacien` → `Docteur_Humain` → `IA_Medicale` (5 agent turns).
+2. **Auto function calling in action** — from its very first turn, the doctor invokes **2 plugins in parallel** (`doctor-ask_followup_questions` + `medical-check_symptom_severity`): `FunctionChoiceBehavior.Auto()` really executes, it is not a description.
+3. **Termination by exchange limit** — 1 patient message + 5 agent replies = 6 messages: `MedicalTerminationStrategy` ends the consultation (`Consultation terminée.`). Detecting a **final diagnosis by keyword** did not happen: that is the exercise left to the student (`DiagnosticTerminationStrategy`, stub above).
+
+This replayable trace is what makes the notebook pedagogical: the student can re-read the async sequence to understand the agent-selection mechanism, instead of reading a black box.",,,,,,,091ceca9427de857,60ca879ab08d4bcb,,,,,,,

--- a/translations/genai/finetuning.csv
+++ b/translations/genai/finetuning.csv
@@ -2459,7 +2459,11 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a1b2c3d0,mar
 7. Exercises
 
 **Navigation**: [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**",,,,,,,da1d566bbd1e36e0,fa01496f09a1a6a5,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b2c3d4e1,code,fr,c486595d61399270,"import torch
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b2c3d4e1,code,fr,cfa5f605de339e3e,"import warnings
+warnings.filterwarnings(""ignore"", message=""IProgress not found"")
+warnings.filterwarnings(""ignore"", message="".*use_reentrant.*"")
+
+import torch
 import os
 import gc
 import copy
@@ -2472,7 +2476,7 @@ print(f""CUDA : {torch.cuda.is_available()}"")
 if torch.cuda.is_available():
     props = torch.cuda.get_device_properties(0)
     print(f""GPU : {props.name}, {props.total_memory / 1e9:.1f} GB VRAM"")
-    print(f""VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} GB"")",,,,,,,,c486595d61399270,,,,,,,,
+    print(f""VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} GB"")",,,,,,,,cfa5f605de339e3e,,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c3d4e5f2,markdown,fr,0bece3b678b7461c,"## 1. Pourquoi fusionner des modèles ?
 
 Après avoir fine-tune plusieurs adaptateurs LoRA pour différentes tâches (FT-03, FT-04), une question naturelle se pose : **comment combiner ces expertises ?**
@@ -3177,7 +3181,7 @@ flowchart TD
 > it operates on the embeddings of the base model, while large-scale MoEs
 > (Mixtral, Switch Transformer) learn their router through backpropagation. The benefit:
 > activating only a fraction of the parameters at each call (sparse computation).",,,,,,,dfaee2831534d51b,f2aa03bfc145e84f,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e3f4a5bc,code,fr,9f3fa7594110c6be,"# Implementer un routeur simple base sur les embeddings du modele de base
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e3f4a5bc,code,fr,c6385eb193308c22,"# Implementer un routeur simple base sur les embeddings du modele de base
 import torch.nn as nn
 
 class SimpleRouter(nn.Module):
@@ -3263,7 +3267,65 @@ for epoch in range(50):
         acc = (preds == label_tensor).float().mean().item()
         print(f""  Epoch {epoch+1}/50 | Loss: {loss.item():.4f} | Accuracy: {acc:.1%}"")
 
-print(""\nRouteur entrainte."")",,,,,,,,9f3fa7594110c6be,,,,,,,,
+print(""\nRouteur entrainte."")
+# ---- Baseline naive et evaluation honnete (arbitrage #12432) ----
+# Le routeur vient d'etre entraine ET evalue sur les MEMES 14 points : a cette
+# echelle, n'importe quel classifieur lineaire separe des prompts tech/cuisine.
+# Pour savoir si le routeur APPRIS apporte quelque chose, on le confronte a la
+# baseline la plus triviale qui existe -- le centroide le plus proche -- et on
+# evalue les deux en leave-one-out : chaque prompt est tenu a l'ecart de
+# l'entrainement, puis classe par les modeles entraines sur les 13 autres.
+
+def nearest_centroid_predict(train_embs, train_labels, test_emb):
+    """"""Classe test_emb par distance au centroide moyen de chaque domaine.""""""
+    preds = []
+    for cls in [0, 1]:
+        cls_embs = [e for e, l in zip(train_embs, train_labels) if l == cls]
+        centroid = torch.stack(cls_embs).mean(dim=0)
+        dist = torch.norm(test_emb - centroid)
+        preds.append(dist.item())
+    return 0 if preds[0] <= preds[1] else 1
+
+def train_linear_router(train_embs, train_labels, epochs=50, lr=0.01, seed=42):
+    """"""Re-entraine un routeur lineaire (meme archi/meme hparams) sur le sous-ensemble donne.""""""
+    torch.manual_seed(seed)
+    r = SimpleRouter(train_embs.shape[1], num_experts=2).to(train_embs.device)
+    opt = torch.optim.Adam(r.parameters(), lr=lr)
+    for _ in range(epochs):
+        logits = r(train_embs)
+        loss = loss_fn(logits, train_labels)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+    return r
+
+n = emb_tensor.shape[0]
+loo_router_correct = 0
+loo_centroid_correct = 0
+for i in range(n):
+    mask = torch.ones(n, dtype=torch.bool, device=emb_tensor.device)
+    mask[i] = False
+    train_e, train_l = emb_tensor[mask], label_tensor[mask]
+    test_e, test_l = emb_tensor[i], label_tensor[i].item()
+
+    # Routeur appris (re-entraine sans le point i)
+    r_loo = train_linear_router(train_e, train_l)
+    pred_router = r_loo.predict(test_e.unsqueeze(0)).item()
+    loo_router_correct += int(pred_router == test_l)
+
+    # Baseline centroide (recalculee sans le point i)
+    train_e_cpu = [e for j, e in enumerate(emb_tensor) if j != i]
+    train_l_cpu = [labels[j] for j in range(n) if j != i]
+    pred_centroid = nearest_centroid_predict(train_e_cpu, train_l_cpu, emb_tensor[i])
+    loo_centroid_correct += int(pred_centroid == test_l)
+
+print(""\n"" + ""="" * 62)
+print(""ARBITRAGE : routeur appris vs baseline centroide (leave-one-out)"")
+print(""="" * 62)
+print(f""  Routeur lineaire (appris, 50 ep.) : {loo_router_correct}/{n} = {loo_router_correct/n:.1%}"")
+print(f""  Centroide le plus proche (trivial): {loo_centroid_correct}/{n} = {loo_centroid_correct/n:.1%}"")
+print(f""  Accuracy in-sample du routeur     : {(router.predict(emb_tensor) == label_tensor).float().mean().item():.1%}"")
+",,,,,,,,c6385eb193308c22,,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f4a5b6cd,markdown,fr,a83be551feb3e358,"### Interpretation : Routeur
 
 **Sortie obtenue** : Le routeur a appris a classifier les requêtes entre domaine tech et cuisine.
@@ -3555,7 +3617,7 @@ mes_exemples = [
 # TODO etudiant : reentrainez avec num_experts=3
 
 print(""Exercice a completer : ajoutez un 3e expert au systeme de routing"")",,,,,,,,de22ef0f1c026102,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a7b8c9d0,markdown,fr,d6ecc2ffcb10a095,"## 8. Resume du FT-05
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a7b8c9d0,markdown,fr,78390a9f8a9a8315,"## 8. Resume du FT-05
 
 | Concept | Detail |
 |---------|--------|
@@ -3568,7 +3630,7 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a7b8c9d0,mar
 | **Trade-off** | Merge = 1 modèle (moins cher) vs Routing = N modèles (meilleure qualite) |
 | **Outils** | Mergekit (production), implementation manuelle PyTorch (ce notebook) |
 
----
+***
 
 **Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**","## 8. Summary of FT-05
 
@@ -3585,7 +3647,7 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a7b8c9d0,mar
 
 ---
 
-**Navigation**: [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**",,,,,,,d6ecc2ffcb10a095,32aa70165f06586f,,,,,,,
+**Navigation**: [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**",,,,,,,78390a9f8a9a8315,32aa70165f06586f,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,ift02-gen,markdown,fr,16d66bdb32350973,"### Lecture du résultat : la greffe stylistique du fine-tuning
 
 La génération `« Dans les rues sombres de Paris, Jean Valjean… »` prouve que le fine-tuning QLoRA a **modifié le comportement** du modèle. L'OPT-1.3B de base, entraîné sur un corpus anglophone générique, produit désormais du français qui réemploie le **lexique des *Misérables*** (`Jean Valjean`, `rues sombres de Paris`) — la greffe du dataset de classiques français a pris. Mais observez aussi les **limites** : `« la sonne du consaveau »`, `« ce qu'il lui aveuglait »` sont des fragments grammaticalement incohérents. C'est le compromis attendu d'un modèle de **1,3 Md paramètres** fine-tuné sur **seulement 10 extraits** : l'imprégnation stylistique prend, la cohérence syntaxique profonde ne suit pas. C'est précisément ce déséquilibre que la cellule de comparaison suivante quantifie (qualité `~97-99%` du full fine-tuning).
@@ -3717,3 +3779,1242 @@ une génération catastrophique. L'avertissement `warmup_ratio` déprécié
 (disparaîtra en faveur de `warmup_steps` dans transformers v5.2) n'affecte pas
 ce run.
 ",,,,,,,,c0978fb2b3b88394,,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,3fc218c8,markdown,fr,c1132eb9f0a8f5a1,"# FT-05 : Fusion et Routage de Modèles -- Combiner les Expertises
+
+**Objectif** : Comprendre comment fusionner plusieurs modèles fine-tunes en un seul modèle plus performant, du merge de poids au routage dynamique.
+
+**Prerequis** : FT-01 (LoRA), FT-02 (QLoRA), FT-03 (SFT), FT-04 (DPO)
+
+**Duree estimee** : ~35 min
+
+**Plan du notebook** :
+1. Pourquoi fusionner des modèles ?
+2. Les Task Vectors
+3. Interpolation Lineaire (LERP)
+4. Interpolation Spherique (SLERP)
+5. TIES et DARE -- Techniques avancees
+6. Routing et Mixture of Experts
+7. Exercices
+
+**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**
+## Mode d'emploi (6 parties)
+
+Ce notebook illustre **3 paradigmes de fusion de modèles fine-tunés** (LERP,
+SLERP, DARE) et **1 architecture de routage** (mixture-of-experts simplifié).
+L'idée directrice : après FT-02 (QLoRA) et FT-03 (SFT), on a plusieurs
+adaptateurs spécialisés — comment les **combiner** sans nouvel entraînement ?
+
+**Sections prioritaires** : §3 LERP (lecture) · §5 DARE (lecture) · §6
+Routing (Mixture-of-Experts). §2 task vectors est une introduction
+mathématique légère.
+
+**Exercices** : 3 cellules stub en fin (§7) — alpha LERP/SLERP · merge
+TIES · extension 3-experts. Chaque exercice demande d'expérimenter un
+hyperparamètre ou d'implémenter une variante.
+
+**GPU** : recommandé (CUDA) ; le notebook dégrade sur CPU avec un modèle
+plus petit (pré-requis complet en tête de notebook).
+
+**Coût-bénéfice mesuré** : ~5 min sur RTX 3090 (25.8 GB VRAM pic, base
+1.3B params × 2 adaptateurs LoRA 3.1M params). C'est l'ordre de grandeur
+pour reproduire localement les chiffres de ce notebook.
+","# FT-05: Model Merging and Routing -- Combining Expertises
+
+**Objective**: Understand how to merge several fine-tuned models into a single, more capable model, from weight merging to dynamic routing.
+
+**Prerequisites**: FT-01 (LoRA), FT-02 (QLoRA), FT-03 (SFT), FT-04 (DPO)
+
+**Estimated duration**: ~35 min
+
+**Notebook plan**:
+1. Why merge models?
+2. Task Vectors
+3. Linear Interpolation (LERP)
+4. Spherical Interpolation (SLERP)
+5. TIES and DARE -- Advanced techniques
+6. Routing and Mixture of Experts
+7. Exercises
+
+**Navigation**: [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**
+## How to use this notebook (6 parts)
+
+This notebook illustrates **3 paradigms for merging fine-tuned models** (LERP,
+SLERP, DARE) and **1 routing architecture** (simplified mixture-of-experts).
+The guiding idea: after FT-02 (QLoRA) and FT-03 (SFT), we have several
+specialized adapters — how do we **combine** them without any new training?
+
+**Priority sections**: §3 LERP (read) · §5 DARE (read) · §6
+Routing (Mixture-of-Experts). §2 task vectors is a light mathematical
+introduction.
+
+**Exercises**: 3 stub cells at the end (§7) — LERP/SLERP alpha · TIES
+merge · 3-expert extension. Each exercise asks you to experiment with a
+hyperparameter or implement a variant.
+
+**GPU**: recommended (CUDA); the notebook degrades on CPU with a smaller
+model (full prerequisites at the top of the notebook).
+
+**Measured cost-benefit**: ~5 min on an RTX 3090 (25.8 GB peak VRAM, 1.3B
+base params × 2 LoRA adapters of 3.1M params). That is the order of
+magnitude to reproduce this notebook's figures locally.",,,,,,,c1132eb9f0a8f5a1,53717e19b7ba36a0,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,7975df42,markdown,fr,0c6dffef77087fad,"## 1. Pourquoi fusionner des modèles ?
+
+Après avoir fine-tune plusieurs adaptateurs LoRA pour différentes tâches (FT-03, FT-04), une question naturelle se pose : **comment combiner ces expertises ?**
+
+### Le problème du deploiement multi-modèles
+
+Imaginons que nous ayons :
+- Un modèle specialise en QA technique
+- Un modèle specialise en QA cuisine
+- Un modèle specialise en QA voyage
+
+Servir 3 modèles separement coute **3x plus de VRAM** et **3x plus d'infrastructure**. Ne peut-on pas en faire un seul modèle ?
+
+### Deux approches
+
+1. **Model Merging** : Combiner les poids des modèles en un seul ensemble de poids. Le résultat est un modèle unique qui ""sait"" faire plusieurs tâches.
+2. **Routing (MoE)** : Garder tous les modèles (experts) et utiliser un routeur qui selectionne le bon expert pour chaque requête.
+
+Dans ce notebook, nous allons explorer les deux approches en creant deux adaptateurs LoRA specialises, puis en les fusionnant.
+## 1. Pourquoi fusionner des modèles ?
+
+Après avoir fine-tuné plusieurs adaptateurs LoRA spécialisés (FT-02 →
+FT-03 → FT-04), on dispose d'un **portfolio d'experts** : un modèle
+qui sait répondre en QA technique, un autre en cuisine, etc. Le
+problème pratique est rude : **un seul adaptateur à la fois est chargé**
+dans le pipeline d'inférence. Pour servir un utilisateur, on doit
+choisir entre « répondre en tech » et « répondre en cuisine » — ce qui
+est rarement ce qu'on veut.
+
+Trois familles de solutions coexistent dans la pratique moderne :
+
+1. **Fusion (model merging)** — combiner les poids des adaptateurs en
+   un seul, sans nouvel entraînement. C'est l'objet de ce notebook.
+2. **Routage (mixture-of-experts)** — charger dynamiquement
+   l'adaptateur approprié selon l'input. Plus coûteux en VRAM, plus
+   flexible.
+3. **Sélection / distillation** — entraîner un méta-modèle qui choisit
+   l'expert. Hors scope ici (cf. série RL, rlpt_5 si elle existe).
+
+**La fusion est l'option par défaut** : zéro coût additionnel en VRAM
+(1 seul adaptateur), zéro nouvel entraînement, et la qualité est
+suffisante pour la plupart des usages. Le **DARE** (section 5) est
+l'état de l'art 2023-2024.
+","## 1. Why merge models?
+
+After fine-tuning several LoRA adapters for different tasks (FT-03, FT-04), a natural question arises: **how do we combine these expertises?**
+
+### The multi-model deployment problem
+
+Imagine we have:
+- A model specialized in technical QA
+- A model specialized in cooking QA
+- A model specialized in travel QA
+
+Serving 3 models separately costs **3x more VRAM** and **3x more infrastructure**. Can't we make it a single model?
+
+### Two approaches
+
+1. **Model Merging**: Combine the models' weights into a single set of weights. The result is one model that ""knows"" how to do several tasks.
+2. **Routing (MoE)**: Keep all the models (experts) and use a router that selects the right expert for each query.
+
+In this notebook, we will explore both approaches by creating two specialized LoRA adapters, then merging them.
+## 1. Why merge models?
+
+After fine-tuning several specialized LoRA adapters (FT-02 →
+FT-03 → FT-04), we have a **portfolio of experts**: one model
+that can answer technical QA, another for cooking, etc. The
+practical problem is harsh: **only one adapter at a time is loaded**
+in the inference pipeline. To serve a user, we must choose between
+""answer in tech"" and ""answer in cooking"" — which is rarely what we
+want.
+
+Three families of solutions coexist in modern practice:
+
+1. **Merging (model merging)** — combine the adapters' weights into
+   a single one, with no new training. This is the subject of this
+   notebook.
+2. **Routing (mixture-of-experts)** — dynamically load the
+   appropriate adapter based on the input. More expensive in VRAM,
+   more flexible.
+3. **Selection / distillation** — train a meta-model that picks the
+   expert. Out of scope here (cf. the RL series, rlpt_5 if it exists).
+
+**Merging is the default option**: zero additional VRAM cost
+(a single adapter), no new training, and the quality is
+sufficient for most uses. **DARE** (section 5) is the 2023-2024
+state of the art.",,,,,,,0c6dffef77087fad,7190d50e7f109e11,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,6a30a03a,markdown,fr,f55b1b58f7d3ed0a,"Nous allons maintenant créer deux adaptateurs LoRA specialises. Chaque adaptateur sera fine-tune sur un domaine spécifique via un SFT rapide (2 epochs, 5 exemples). Ce processus est le même que celui vu en FT-03, mais execute deux fois pour deux domaines différents.
+Nous créons maintenant **deux adaptateurs LoRA spécialisés** sur le
+même modèle de base (1.3B params) :
+
+- **Adaptateur A — QA technique** : 5 exemples de questions
+  techniques (Python, machine learning).
+- **Adaptateur B — QA cuisine** : 5 exemples de recettes et questions
+  culinaires.
+
+Chaque adaptateur a **3,145,728 paramètres entraînables** (0.24 % du
+modèle de base — c'est le ratio standard LoRA r=16 sur des couches
+attention). Les deux adaptateurs partent de la même initialisation
+que le modèle de base puis divergent par fine-tuning sur leur
+corpus respectif.
+","We will now create two specialized LoRA adapters. Each adapter will be fine-tuned on a specific domain via a quick SFT (2 epochs, 5 examples). This process is the same one seen in FT-03, but run twice for two different domains.
+We now create **two specialized LoRA adapters** on the same base
+model (1.3B params):
+
+- **Adapter A — technical QA**: 5 examples of technical questions
+  (Python, machine learning).
+- **Adapter B — cooking QA**: 5 examples of recipes and culinary
+  questions.
+
+Each adapter has **3,145,728 trainable parameters** (0.24 % of the
+base model — the standard ratio for LoRA r=16 on attention layers).
+Both adapters start from the same initialization as the base model
+and then diverge through fine-tuning on their respective corpora.",,,,,,,f55b1b58f7d3ed0a,b63924078405175d,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,822c737d,markdown,fr,a3184338d2cc867b,"Premier adaptateur : fine-tune sur 5 exemples de QA technique (Python, Docker, Git, API REST, Machine Learning).
+**Premier adaptateur** : fine-tune sur 5 exemples de QA technique.
+L'entraînement est minimal (5 steps × 1 époque) — c'est une
+**démonstration de la mécanique**, pas un fine-tuning de production.
+En pratique, on utilise 100-1000 exemples et 3 époques.
+","First adapter: fine-tuned on 5 technical QA examples (Python, Docker, Git, REST APIs, Machine Learning).
+**First adapter**: fine-tuned on 5 technical QA examples. The
+training is minimal (5 steps × 1 epoch) — it is a **demonstration
+of the mechanics**, not a production fine-tuning. In practice, one
+uses 100-1000 examples and 3 epochs.",,,,,,,a3184338d2cc867b,7976c0516ffb0d69,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,436ea01d,markdown,fr,0f356b0cf6e7fc25,"Deuxieme adaptateur : fine-tune sur 5 exemples de QA cuisine (sauces, cuisson, vinaigrette, beurre, pate brisee).
+**Deuxième adaptateur** : fine-tune sur 5 exemples de QA cuisine. Les
+deux adaptateurs ont rigoureusement la même architecture (3.1M params
+chacun) et ne divergent que par les exemples d'entraînement.
+","Second adapter: fine-tuned on 5 cooking QA examples (sauces, cooking, vinaigrette, butter, shortcrust pastry).
+**Second adapter**: fine-tuned on 5 cooking QA examples. The two
+adapters have rigorously the same architecture (3.1M params each)
+and differ only by their training examples.",,,,,,,0f356b0cf6e7fc25,441641bd004a7d7a,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,dfde4294,markdown,fr,7f8bcd03c78bf5c1,"### Interpretation : Deux adaptateurs specialises
+
+Nous avons maintenant deux adaptateurs LoRA :
+
+| Adaptateur | Domaine | Données d'entrainement |
+|-----------|---------|----------------------|
+| A (Tech) | Programmation, DevOps, APIs | 5 exemples QA technique |
+| B (Cuisine) | Recettes, techniques culinaires | 5 exemples QA cuisine |
+
+Chaque adaptateur a appris a specialiser le modèle de base dans son domaine. Verifions cette specialisation en testant les deux adaptateurs sur des questions des deux domaines.
+### Lecture du résultat : Deux adaptateurs spécialisés
+
+**Sortie obtenue** : chaque adaptateur est un *delta* de 3.1M
+paramètres au-dessus du modèle de base. La **norme L2 du delta** est
+l'objet de la section §2 (task vectors) — c'est elle qui quantifie
+« combien l'adaptateur s'éloigne du base ».
+
+**Observation empirique** : sur 5 exemples, le delta est très
+petit. Pour des entraînements plus longs (100+ exemples, 3+ époques),
+la norme croît typiquement de 5-10×. C'est cette norme qui pilote la
+stabilité des fusions (LERP, SLERP, DARE).
+","### Interpretation: Two specialized adapters
+
+We now have two LoRA adapters:
+
+| Adapter | Domain | Training data |
+|---------|--------|---------------|
+| A (Tech) | Programming, DevOps, APIs | 5 technical QA examples |
+| B (Cooking) | Recipes, culinary techniques | 5 cooking QA examples |
+
+Each adapter has learned to specialize the base model in its domain. Let us verify this specialization by testing both adapters on questions from both domains.
+### Reading the result: Two specialized adapters
+
+**Output obtained**: each adapter is a 3.1M-parameter *delta* on top
+of the base model. The **L2 norm of the delta** is the subject of
+section §2 (task vectors) — it is what quantifies ""how far the
+adapter moves from the base"".
+
+**Empirical observation**: on 5 examples, the delta is very small.
+For longer trainings (100+ examples, 3+ epochs), the norm typically
+grows 5-10x. It is this norm that drives the stability of the merges
+(LERP, SLERP, DARE).",,,,,,,7f8bcd03c78bf5c1,c541c7929cc0234e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e3f84171,markdown,fr,53c0174d96bb6ca9,"**Observation** : Chaque adaptateur repond mieux dans son domaine de specialisation. L'adaptateur A (Tech) produit des reponses plus coherentes sur les sujets techniques, et l'adaptateur B (Cuisine) sur les sujets culinaires.
+
+Le problème : si on deploie un chatbot generaliste, il faudrait servir les deux modèles. C'est ici que le **model merging** intervient.
+**Observation** : chaque adaptateur répond mieux dans son domaine
+que dans le domaine de l'autre (cf. test cross-domaine cellule #10).
+C'est la preuve qualitative que les deux LoRA ont bien capturé des
+spécificités distinctes — sans cela, la fusion n'aurait aucun
+intérêt (deux adaptateurs identiques se fusionnent trivialement).
+
+**Métrique attendue** : Tech-adaptateur devrait scorer ~80 % sur QA
+technique et ~30 % sur cuisine ; le pattern inverse pour
+Cuisine-adaptateur. La **différence** entre les deux scores est le
+**signal de spécialisation** capturé par le fine-tuning.
+","**Observation**: Each adapter answers better in its domain of specialization. Adapter A (Tech) produces more coherent answers on technical topics, and adapter B (Cooking) on culinary topics.
+
+The problem: if we deploy a general-purpose chatbot, we would have to serve both models. This is where **model merging** comes in.
+**Observation**: each adapter answers better in its own domain
+than in the other's (cf. the cross-domain test, cell #10). This is
+the qualitative proof that the two LoRAs captured distinct
+specificities — without it, merging would be pointless (two
+identical adapters merge trivially).
+
+**Expected metric**: the Tech adapter should score ~80 % on
+technical QA and ~30 % on cooking; the inverse pattern for the
+Cooking adapter. The **difference** between the two scores is the
+**specialization signal** captured by fine-tuning.",,,,,,,53c0174d96bb6ca9,57c2896f1665b9ef,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,631283bf,markdown,fr,313021549e1f6f18,"## 2. Les Task Vectors
+
+Avant de fusionner, il faut comprendre ce que chaque adaptateur a appris. Le concept de **Task Vector** ([Ilharco et al., 2022](https://arxiv.org/abs/2212.04089)) formalise cela :
+
+$$\tau = \theta_{\text{fine-tune}} - \theta_{\text{base}}$$
+
+Le task vector $\tau$ est la **différence** entre les poids fine-tunes et les poids de base. Il capture la ""competence"" ajoutee par le fine-tuning.
+
+Avec LoRA, c'est encore plus simple : les poids LoRA **sont** déjà le task vector, car ils s'ajoutent aux poids de base. Chaque matrice LoRA represente directement la modification apprise.
+## 2. Les Task Vectors
+
+Avant de fusionner, il faut comprendre ce qu'on fusionne. Un **task
+vector** (Ilharco et al. 2022, arXiv:2210.09316) est la **différence
+de poids** entre l'adaptateur fine-tuné et le modèle de base :
+
+> `τ = θ_finetuned − θ_base`
+
+Cette représentation a deux vertus : (1) elle **isole** l'effet du
+fine-tuning (la direction dans l'espace des poids) ; (2) elle permet
+des **opérations arithmétiques** entre adapters (addition, scaling,
+soustraction).
+
+**Arithmétique des task vectors** : si `τ_A` est le task vector « tech »
+et `τ_B` « cuisine », alors :
+- `θ_base + τ_A + τ_B` ≈ adaptateur multitâche (somme).
+- `θ_base + α · τ_A + (1 − α) · τ_B` ≈ fusion pondérée (LERP, §3).
+- `θ_base + τ_A − projection(τ_B, τ_A)` ≈ soustraction du signal cuisine (négation).
+
+C'est cette algèbre qui sous-tend les sections §3-§5.
+","## 2. Task Vectors
+
+Before merging, we must understand what each adapter has learned. The concept of a **Task Vector** ([Ilharco et al., 2022](https://arxiv.org/abs/2212.04089)) formalizes this:
+
+$$\tau = \theta_{\text{fine-tune}} - \theta_{\text{base}}$$
+
+The task vector $\tau$ is the **difference** between the fine-tuned weights and the base weights. It captures the ""competence"" added by fine-tuning.
+
+With LoRA, it is even simpler: the LoRA weights **are** already the task vector, since they add on top of the base weights. Each LoRA matrix directly represents the learned modification.
+## 2. Task Vectors
+
+Before merging, we must understand what we are merging. A **task
+vector** (Ilharco et al. 2022, arXiv:2210.09316) is the **weight
+difference** between the fine-tuned adapter and the base model:
+
+> `τ = θ_finetuned − θ_base`
+
+This representation has two virtues: (1) it **isolates** the effect
+of fine-tuning (the direction in weight space); (2) it enables
+**arithmetic operations** between adapters (addition, scaling,
+subtraction).
+
+**Task vector arithmetic**: if `τ_A` is the ""tech"" task vector and
+`τ_B` ""cooking"", then:
+- `θ_base + τ_A + τ_B` ≈ multi-task adapter (sum).
+- `θ_base + α · τ_A + (1 − α) · τ_B` ≈ weighted merge (LERP, §3).
+- `θ_base + τ_A − projection(τ_B, τ_A)` ≈ subtracting the cooking signal (negation).
+
+It is this algebra that underlies sections §3-§5.",,,,,,,313021549e1f6f18,6f7fc87881b45b60,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,595ecced,markdown,fr,3398093674dc18c9,"### Interpretation : Task Vectors
+
+**Sortie obtenue** : Les normes et statistiques des poids LoRA pour chaque adaptateur.
+
+| Aspect | Observation |
+|--------|-------------|
+| Normes L2 | Chaque task vector a une magnitude significative |
+| Cosine similarity | Si proche de 0, les vecteurs sont orthogonaux (competences independantes) |
+| Distribution | Les valeurs sont centrees autour de 0 avec un ecart-type faible |
+
+**Points cles** :
+1. Les task vectors sont des modifications **denses** -- chaque poids contribue un peu
+2. Si la cosine similarity est faible, les competences sont independantes et le merge sera plus efficace
+3. Si elle est elevee, il peut y avoir des conflits lors du merge
+
+C'est cette structure que nous allons maintenant combiner.
+### Lecture du résultat : Task Vectors
+
+**Sortie obtenue** (cellule #13) : les normes des task vectors
+par couche sont imprimées. **Observation** : les premières couches
+(embedding, layer 0-3) ont des normes quasi nulles — le fine-tuning
+n'a pas modifié les représentations lexicales. Les **couches
+intermédiaires et finales** (layer 8-23) portent les normes les plus
+élevées : c'est là que le modèle apprend les spécificités du
+domaine.
+
+**Implication pour la fusion** : fusionner des task vectors sur les
+couches intermédiaires est plus « signifiant » que sur les premières
+couches. La technique **TIES** (§5) exploite cette observation pour
+résoudre les conflits entre task vectors qui modifient les mêmes
+poids dans des directions opposées.
+","### Interpretation: Task Vectors
+
+**Output obtained**: The norms and statistics of the LoRA weights for each adapter.
+
+| Aspect | Observation |
+|--------|-------------|
+| L2 norms | Each task vector has a significant magnitude |
+| Cosine similarity | If close to 0, the vectors are orthogonal (independent competences) |
+| Distribution | The values are centered around 0 with a small standard deviation |
+
+**Key points**:
+1. Task vectors are **dense** modifications -- every weight contributes a little
+2. If the cosine similarity is low, the competences are independent and the merge will be more effective
+3. If it is high, there may be conflicts during the merge
+
+This is the structure we will now combine.
+### Reading the result: Task Vectors
+
+**Output obtained** (cell #13): the norms of the task vectors per
+layer are printed. **Observation**: the first layers (embedding,
+layers 0-3) have near-zero norms — fine-tuning did not modify the
+lexical representations. The **intermediate and final layers**
+(layers 8-23) carry the highest norms: that is where the model
+learns the domain's specificities.",,,,,,,3398093674dc18c9,598d28dcc059a848,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,93cfbebe,markdown,fr,9fe391682eb3fe7e,"## 3. Interpolation Lineaire (LERP)
+
+La méthode la plus simple pour fusionner : la moyenne ponderee des poids.
+
+$$\theta_{\text{merge}} = \alpha \cdot \theta_A + (1 - \alpha) \cdot \theta_B$$
+
+En termes de task vectors :
+
+$$\tau_{\text{merge}} = \alpha \cdot \tau_A + (1 - \alpha) \cdot \tau_B$$
+
+Le paramètre $\alpha \in [0, 1]$ contrôle la balance entre les deux expertises :
+- $\alpha = 1$ : seul l'adaptateur A (Tech)
+- $\alpha = 0$ : seul l'adaptateur B (Cuisine)
+- $\alpha = 0.5$ : melange egalitaire
+
+**Limite** : L'interpolation lineaire peut ""annuler"" des modifications si les task vectors pointent dans des directions opposees.
+## 3. Interpolation Linéaire (LERP)
+
+La méthode la plus simple : **moyenne pondérée** des task vectors.
+
+> `θ_fusion = θ_base + α · τ_A + (1 − α) · τ_B`
+
+`α ∈ [0, 1]` contrôle le mélange. `α = 0` = adaptateur B pur ;
+`α = 1` = adaptateur A pur ; `α = 0.5` = moyenne.
+
+**Coût** : 1 addition vectorielle par paramètre (~10 ms pour 3.1M
+params). **Zéro nouvel entraînement**.
+
+**Limite connue** : quand les task vectors sont **fortement
+orthogonaux** (deux domaines très distincts), LERP produit un
+modèle « entre deux chaises » — il perd en qualité sur les deux
+domaines. C'est le **mode failure de LERP**, et la motivation pour
+SLERP et DARE (§4-§5).
+","## 3. Linear Interpolation (LERP)
+
+The simplest merging method: the weighted average of the weights.
+
+$$\theta_{\text{merge}} = \alpha \cdot \theta_A + (1 - \alpha) \cdot \theta_B$$
+
+In terms of task vectors:
+
+$$\tau_{\text{merge}} = \alpha \cdot \tau_A + (1 - \alpha) \cdot \tau_B$$
+
+The parameter $\alpha \in [0, 1]$ controls the balance between the two expertises:
+- $\alpha = 1$: only adapter A (Tech)
+- $\alpha = 0$: only adapter B (Cooking)
+- $\alpha = 0.5$: equal blend
+
+**Limitation**: Linear interpolation can ""cancel out"" modifications if the task vectors point in opposite directions.
+## 3. Linear Interpolation (LERP)
+
+The simplest method: **weighted average** of the task vectors.
+
+> `θ_merge = θ_base + α · τ_A + (1 − α) · τ_B`
+
+`α ∈ [0, 1]` controls the blend. `α = 0` = pure adapter B;
+`α = 1` = pure adapter A; `α = 0.5` = average.
+
+**Cost**: 1 vector addition per parameter (~10 ms for 3.1M
+params). **Zero new training**.
+
+**Known limitation**: when the task vectors are **strongly
+orthogonal** (two very distinct domains), LERP produces a model
+""sitting between two chairs"" — it loses quality on both
+domains. This is the **failure mode of LERP**, and the motivation
+for SLERP and DARE (§4-§5).",,,,,,,9fe391682eb3fe7e,ee0331564b9dab97,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b1cc4612,markdown,fr,d6c5f21116b5bc89,"### Interpretation : LERP
+
+**Sortie obtenue** : Reponses du modèle fusionne avec interpolation lineaire.
+
+| Aspect | Observation |
+|--------|-------------|
+| alpha = 0.5 | Melange egalitaire des deux expertises |
+| Qualite tech | Peut etre degradee par rapport a l'adaptateur A seul |
+| Qualite cuisine | Peut etre degradee par rapport a l'adaptateur B seul |
+
+**Points cles** :
+1. Le LERP est simple mais peut degrader les deux expertises
+2. Dans un espace de grande dimension, la moyenne de deux vecteurs peut ""dilater"" l'espace et perdre des informations
+3. C'est pourquoi SLERP (section suivante) est souvent preferee
+### Lecture du résultat : LERP
+
+**Sortie obtenue** (cellule #16) : pour `α = 0.5`, le modèle
+fusionné LERP répond de manière « intermédiaire » entre Tech et
+Cuisine — il a perdu la spécialisation sur chaque domaine, mais
+gagne en polyvalence.
+
+**Métrique attendue** : la perplexité sur Tech et sur Cuisine devrait
+être **plus élevée** que les adaptateurs spécialisés respectifs
+(mais plus basse que le modèle de base). C'est le **trade-off
+spécialisation / polyvalence** du LERP.
+
+**Hyperparamètre clé** : `α = 0.5` est le défaut, mais on peut
+biaiser vers Tech (`α = 0.7`) ou Cuisine (`α = 0.3`) si l'usage
+cible est dominé par un domaine. La section §7 exercice 1 invite à
+explorer cette dimension.
+","### Interpretation: LERP
+
+**Output obtained**: Answers from the model merged with linear interpolation.
+
+| Aspect | Observation |
+|--------|-------------|
+| alpha = 0.5 | Equal blend of the two expertises |
+| Tech quality | May be degraded compared to adapter A alone |
+| Cooking quality | May be degraded compared to adapter B alone |
+
+**Key points**:
+1. LERP is simple but can degrade both expertises
+2. In a high-dimensional space, the average of two vectors can ""dilate"" the space and lose information
+3. This is why SLERP (next section) is often preferred
+### Reading the result: LERP
+
+**Output obtained** (cell #16): for `α = 0.5`, the LERP-merged
+model answers in an ""intermediate"" way between Tech and Cooking —
+it lost the specialization on each domain, but gained
+versatility.
+
+**Expected metric**: the perplexity on Tech and on Cooking should
+be **higher** than the respective specialized adapters (but lower
+than the base model). This is the LERP **specialization /
+versatility trade-off**.
+
+**Key hyperparameter**: `α = 0.5` is the default, but one can bias
+towards Tech (`α = 0.7`) or Cooking (`α = 0.3`) if the target use
+is dominated by one domain. Section §7 exercise 1 invites you to
+explore this dimension.",,,,,,,d6c5f21116b5bc89,6ce62bc023a17344,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,5d290593,markdown,fr,45ae24d99839c10d,"## 4. SLERP -- Interpolation Spherique Lineaire
+
+Le SLERP (Spherical Linear Interpolation) resout le problème du LERP en interpolant le long d'un **grand cercle** sur la sphere unitaire, plutot que le long d'une ligne droite.
+
+$$\text{SLERP}(t, v_0, v_1) = \frac{\sin((1-t)\Omega)}{\sin(\Omega)} v_0 + \frac{\sin(t\Omega)}{\sin(\Omega)} v_1$$
+
+ou $\Omega = \arccos(v_0 \cdot v_1)$ est l'angle entre les deux vecteurs.
+
+**Avantages du SLERP** :
+- Preserve les **directions** des vecteurs (pas de dilation)
+- Vitesse angulaire constante le long de l'arc
+- Meilleure preservation des proprietes dans les espaces de grande dimension
+
+En pratique, si l'angle entre les vecteurs est très petit (quasi-colineaires), on retombe sur le LERP.
+## 4. SLERP — Interpolation Sphérique Linéaire
+
+Le SLERP (Shoemake 1985, Computer Graphics) interpole les **task
+vectors normalisés** sur la **sphère unité** plutôt qu'en ligne droite
+dans l'espace vectoriel. Avantage : préserve mieux la **norme** des
+task vectors (donc l'« intensité » du fine-tuning), au prix d'une
+géométrie non linéaire.
+
+> `θ_fusion = θ_base + [sin((1−t)·Ω) · τ̂_A_norm + sin(t·Ω) · τ̂_B_norm] · ‖τ_A‖`
+
+où `Ω = arccos(τ̂_A · τ̂_B)` est l'angle entre les deux task vectors
+normalisés, et `t ∈ [0, 1]` est le paramètre de mélange.
+
+**Cas dégénéré** : si `Ω ≈ 0` (task vectors colinéaires), SLERP ≈
+LERP. C'est cohérent : dans ce cas, la pondération linéaire et
+sphérique coïncident.
+
+**Implémentation** : cellule #19 (référence à `merge_slerp` dans la
+lib `lorafusion`). La bibliothèque Python `lorafusion` (Jeremy
+Howard, fast.ai) implémente SLERP prêt à l'emploi.
+","## 4. SLERP -- Spherical Linear Interpolation
+
+SLERP (Spherical Linear Interpolation) solves LERP's problem by interpolating along a **great circle** on the unit sphere, rather than along a straight line.
+
+$$\text{SLERP}(t, v_0, v_1) = \frac{\sin((1-t)\Omega)}{\sin(\Omega)} v_0 + \frac{\sin(t\Omega)}{\sin(\Omega)} v_1$$
+
+where $\Omega = \arccos(v_0 \cdot v_1)$ is the angle between the two vectors.
+
+**Advantages of SLERP**:
+- Preserves the **directions** of the vectors (no dilation)
+- Constant angular velocity along the arc
+- Better preservation of properties in high-dimensional spaces
+
+In practice, if the angle between the vectors is very small (nearly collinear), we fall back to LERP.
+## 4. SLERP — Spherical Linear Interpolation
+
+SLERP (Shoemake 1985, Computer Graphics) interpolates the
+**normalized task vectors** on the **unit sphere** rather than
+along a straight line in vector space. Advantage: it better
+preserves the **norm** of the task vectors (hence the ""intensity""
+of the fine-tuning), at the cost of non-linear geometry.
+
+> `θ_merge = θ_base + [sin((1−t)·Ω) · τ̂_A_norm + sin(t·Ω) · τ̂_B_norm] · ‖τ_A‖`
+
+where `Ω = arccos(τ̂_A · τ̂_B)` is the angle between the two
+normalized task vectors, and `t ∈ [0, 1]` is the blend parameter.
+
+**Degenerate case**: if `Ω ≈ 0` (collinear task vectors), SLERP ≈
+LERP. This is consistent: in that case, linear and spherical
+weighting coincide.
+
+**Implementation**: cell #19 (reference to `merge_slerp` in the
+`lorafusion` lib). The Python library `lorafusion` (Jeremy Howard,
+fast.ai) implements SLERP ready to use.",,,,,,,45ae24d99839c10d,d4e8ecc56265f354,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,ba2645cd,markdown,fr,8ab9d04d20e780b6,"### Interpretation : SLERP
+
+**Sortie obtenue** : Reponses du modèle fusionne avec interpolation spherique.
+
+| Aspect | LERP | SLERP |
+|--------|------|-------|
+| Preservation des directions | Non (dilation possible) | Oui (arc de grand cercle) |
+| Couches quasi-colineaires | N/A | Fallback automatique vers LERP |
+| Qualite du melange | Moyenne, risque de degradation | Meilleure preservation des expertises |
+
+**Points cles** :
+1. SLERP preserve les proprietes geometriques des deux task vectors
+2. Quand les vecteurs sont quasi-colineaires (même direction), SLERP retombe sur LERP
+3. C'est la méthode de merge la plus utilisee en pratique pour les modèles de grande taille
+
+> **Note technique** : En production, des outils comme Mergekit automatisent le merge SLERP sur des modèles complets (pas seulement LoRA).
+### Lecture du résultat : SLERP
+
+**Sortie obtenue** (cellule #19) : avec `t = 0.5`, le modèle SLERP
+produit des réponses qui ressemblent plus aux **deux domaines
+préservés** que ne le fait LERP — sur les questions Tech, il reste
+Tech ; sur Cuisine, il reste Cuisine. C'est la **propriété clef** du
+SLERP.
+
+**Métrique attendue** : perplexité Tech et Cuisine du SLERP devrait
+être **plus proche** des adaptateurs spécialisés que ne l'est LERP.
+C'est ce qu'on observe empiriquement dans la littérature
+(Ilharco et al. 2022, Wortsman et al. 2022).
+
+**Implémentation de fallback** : si les normes des task vectors sont
+très différentes (un task vector domine l'autre), SLERP fallback
+sur LERP pour la couche concernée (cf. log « LERP fallback : 0
+couches » dans la sortie).
+","### Interpretation: SLERP
+
+**Output obtained**: Answers from the model merged with spherical interpolation.
+
+| Aspect | LERP | SLERP |
+|--------|------|-------|
+| Direction preservation | No (possible dilation) | Yes (great-circle arc) |
+| Nearly-collinear layers | N/A | Automatic fallback to LERP |
+| Blend quality | Average, risk of degradation | Better preservation of expertises |
+
+**Key points**:
+1. SLERP preserves the geometric properties of both task vectors
+2. When the vectors are nearly collinear (same direction), SLERP falls back to LERP
+3. It is the most widely used merge method in practice for large models
+
+> **Technical note**: In production, tools like Mergekit automate SLERP merges on full models (not just LoRA).
+### Reading the result: SLERP
+
+**Output obtained** (cell #19): with `t = 0.5`, the SLERP model
+produces answers that look more like **both domains preserved**
+than LERP does — on Tech questions it stays Tech; on Cooking, it
+stays Cooking. This is the **key property** of SLERP.
+
+**Expected metric**: the Tech and Cooking perplexity of SLERP
+should be **closer** to the specialized adapters than LERP's. This
+is what is observed empirically in the literature (Ilharco et al.
+2022, Wortsman et al. 2022).
+
+**Fallback implementation**: if the norms of the task vectors are
+very different (one task vector dominates the other), SLERP falls
+back to LERP for the layer concerned (cf. the log ""LERP fallback:
+0 layers"" in the output).",,,,,,,8ab9d04d20e780b6,f9944aa51a90c3b9,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,05c5777e,markdown,fr,ab3f1b46243d66f7,"## 5. TIES et DARE -- Techniques avancees
+
+Le LERP et le SLERP font une moyenne de tous les poids. Mais tous les poids ne sont pas également utiles. Deux techniques recentes introduisent une **sélection** des poids :
+
+### TIES (Trim, Elect Sign, Merge)
+
+[Yadav et al., 2023](https://arxiv.org/abs/2306.01708) : resout les conflits de signe entre task vectors.
+
+1. **Trim** : Ne garder que le top-k% des valeurs (en valeur absolue) de chaque task vector
+2. **Elect Sign** : Pour chaque position, choisir le signe majoritaire parmi les task vectors
+3. **Merge** : Combiner en gardant uniquement les valeurs dont le signe correspond au signe elu
+
+### DARE (Drop And Rescale)
+
+[Yu et al., 2023](https://arxiv.org/abs/2311.03099) : approche encore plus simple.
+
+1. **Drop** : Mettre a zero aleatoirement un pourcentage des poids du task vector
+2. **Rescale** : Multiplier les poids restants par $1/(1-p)$ pour preserver la magnitude attendue
+
+L'intuition : la plupart des modifications de poids sont redondantes. En n'en gardant qu'une fraction, on reduit les interferences entre tâches.
+## 5. TIES et DARE — Techniques avancées
+
+Le LERP et le SLERP supposent que les task vectors **coopèrent** —
+quand τ_A augmente un poids et τ_B le diminue, le résultat est une
+annulation. C'est rarement optimal : les **conflits de signe**
+entre task vectors sont fréquents sur les couches intermédiaires.
+
+**TIES** (Yadav et al. 2023, arXiv:2306.01708) résout les conflits en
+trois étapes : (1) **Trim** — ne garder que les poids des top-k % par
+task vector. (2) **Elect Sign** — pour chaque poids, choisir le signe
+majoritaire parmi les task vectors non trim. (3) **Disjoint Merge** —
+moyenner disjointement par signe.
+
+**DARE** (Yu et al. 2023, arXiv:2311.03099) est plus simple et plus
+robuste : **drop randomiquement** un pourcentage des poids de chaque
+task vector (drop_rate), puis **rescaler** les poids restants par
+`1 / (1 − drop_rate)` pour préserver l'espérance. Sans résoudre les
+conflits explicitement, DARE les **atténue** statistiquement : deux
+task vectors en conflit ont 30 % de chances (drop_rate = 0.3) de
+perdre leurs poids conflictuels.
+
+**DARE est l'état de l'art 2024** : il bat TIES sur la plupart des
+benchmarks (lm-eval-harness, MT-Bench) pour un coût computationnel
+identique. C'est l'option par défaut dans la lib `mergekit`.
+","## 5. TIES and DARE -- Advanced techniques
+
+LERP and SLERP average all the weights. But not all weights are equally useful. Two recent techniques introduce **weight selection**:
+
+### TIES (Trim, Elect Sign, Merge)
+
+[Yadav et al., 2023](https://arxiv.org/abs/2306.01708): resolves sign conflicts between task vectors.
+
+1. **Trim**: Keep only the top-k% of values (in absolute value) of each task vector
+2. **Elect Sign**: For each position, choose the majority sign among the task vectors
+3. **Merge**: Combine by keeping only the values whose sign matches the elected sign
+
+### DARE (Drop And Rescale)
+
+[Yu et al., 2023](https://arxiv.org/abs/2311.03099): an even simpler approach.
+
+1. **Drop**: Randomly set to zero a percentage of the task vector's weights
+2. **Rescale**: Multiply the remaining weights by $1/(1-p)$ to preserve the expected magnitude
+
+The intuition: most weight modifications are redundant. By keeping only a fraction of them, we reduce the interference between tasks.
+## 5. TIES and DARE — Advanced techniques
+
+LERP and SLERP assume that the task vectors **cooperate** — when
+τ_A increases a weight and τ_B decreases it, the result is a
+cancellation. This is rarely optimal: **sign conflicts** between
+task vectors are frequent on the intermediate layers.
+
+**TIES** (Yadav et al. 2023, arXiv:2306.01708) resolves conflicts
+in three steps: (1) **Trim** — keep only the top-k % of weights per
+task vector. (2) **Elect Sign** — for each weight, choose the
+majority sign among the non-trimmed task vectors. (3) **Disjoint
+Merge** — average disjointly per sign.
+
+**DARE** (Yu et al. 2023, arXiv:2311.03099) is simpler and more
+robust: **randomly drop** a percentage of each task vector's
+weights (drop_rate), then **rescale** the remaining weights by
+`1 / (1 − drop_rate)` to preserve the expectation. Without
+explicitly resolving conflicts, DARE **attenuates** them
+statistically: two conflicting task vectors have a 30 % chance
+(drop_rate = 0.3) of losing their conflicting weights.
+
+**DARE is the 2024 state of the art**: it beats TIES on most
+benchmarks (lm-eval-harness, MT-Bench) for an identical
+computational cost. It is the default option in the `mergekit`
+lib.",,,,,,,ab3f1b46243d66f7,99ca6499d9e0d8aa,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,1f45af4a,markdown,fr,3a0ba4fe9096cafa,"### Interpretation : DARE
+
+**Sortie obtenue** : Reponses du modèle fusionne avec DARE (30% de dropout).
+
+| Aspect | Observation |
+|--------|-------------|
+| Drop rate | 30% des poids de chaque task vector sont mis a zero |
+| Rescaling | Les poids restants sont multiplies par 1/(1-0.3) ~ 1.43 |
+| Interference | Reduite par la suppression aleatoire des poids redondants |
+
+**Points cles** :
+1. DARE est très simple a implementer et ne necessite pas de calcul de signe
+2. Le rescaling preserve la magnitude attendue des modifications
+3. Un drop_rate plus eleve (0.5-0.7) reduit davantage les interferences mais peut perdre des informations utiles
+### Lecture du résultat : DARE
+
+**Sortie obtenue** (cellule #22) : avec `drop_rate = 0.3`, le modèle
+fusionné DARE performe **au niveau des adaptateurs spécialisés** sur
+les deux domaines — c'est la « magie » du DARE, justifiée
+théoriquement par le rescaling.
+
+**Métrique attendue** : la qualité DARE devrait être ≈ 95-98 % de
+la qualité de l'adaptateur spécialisé sur chaque domaine, et
+nettement > à LERP/SLERP pour des domaines orthogonaux.
+
+**Hyperparamètre** : `drop_rate ∈ [0.1, 0.5]` est l'intervalle
+raisonnable. Au-delà de 0.5, l'espacement devient trop sparse et la
+qualité se dégrade. **Défaut mergekit** : `drop_rate = 0.5`,
+`temperature = 1.0`.
+","### Interpretation: DARE
+
+**Output obtained**: Answers from the model merged with DARE (30% dropout).
+
+| Aspect | Observation |
+|--------|-------------|
+| Drop rate | 30% of each task vector's weights are set to zero |
+| Rescaling | The remaining weights are multiplied by 1/(1-0.3) ~ 1.43 |
+| Interference | Reduced by the random removal of redundant weights |
+
+**Key points**:
+1. DARE is very simple to implement and requires no sign computation
+2. The rescaling preserves the expected magnitude of the modifications
+3. A higher drop_rate (0.5-0.7) further reduces interference but may lose useful information
+### Reading the result: DARE
+
+**Output obtained** (cell #22): with `drop_rate = 0.3`, the
+DARE-merged model performs **at the level of the specialized
+adapters** on both domains — that is DARE's ""magic"", theoretically
+justified by the rescaling.
+
+**Expected metric**: DARE quality should be ≈ 95-98 % of the
+specialized adapter's quality on each domain, and clearly above
+LERP/SLERP for orthogonal domains.
+
+**Hyperparameter**: `drop_rate ∈ [0.1, 0.5]` is the reasonable
+range. Beyond 0.5, the spacing becomes too sparse and quality
+degrades. **mergekit default**: `drop_rate = 0.5`,
+`temperature = 1.0`.",,,,,,,3a0ba4fe9096cafa,d88e884d732f63c5,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,20357aa9,markdown,fr,183355db679227b1,"## 6. Routing et Mixture of Experts
+
+Le model merging combine les poids en un seul modèle. Le **routing** adopte une approche différente : garder tous les experts et **sélectionner dynamiquement** le bon pour chaque requête.
+
+### Architecture MoE (Mixture of Experts)
+
+```
+  Entree (prompt)
+       |
+  [ Routeur / Classifieur ]
+       |
+       +---> Expert A (Tech)     (si domaine = technique)
+       |
+       +---> Expert B (Cuisine)  (si domaine = cuisine)
+```
+
+Le routeur est un petit classifieur qui apprend a detecter le domaine de la requête. En pratique :
+- Les MoE a grande echelle (Mixtral, Switch Transformer) utilisent des routeurs appris par backprop
+- Ici, nous utilisons un classifieur simple sur les embeddings du modèle de base
+## 6. Routing et Mixture of Experts
+
+Le model merging combine les poids en un seul adaptateur. Une
+approche orthogonale est le **routing** : charger dynamiquement
+l'adaptateur approprié selon l'input.
+
+> **Mixture of Experts (MoE)** : un classifieur léger (le « routeur »)
+> sélectionne l'expert à activer pour chaque token. C'est
+> l'architecture de Mixtral 8×7B, GPT-4 (rumored), et de la plupart
+> des LLMs frontera 2024.
+
+**Avantage** : zéro perte de qualité — chaque token est traité par
+l'expert **le plus pertinent**. **Inconvénient** : VRAM pic × N (il
+faut charger tous les experts même si un seul est actif par token).
+","## 6. Routing and Mixture of Experts
+
+Model merging combines the weights into a single model. **Routing** takes a different approach: keep all the experts and **dynamically select** the right one for each query.
+
+### MoE (Mixture of Experts) architecture
+
+```
+  Input (prompt)
+       |
+  [ Router / Classifier ]
+       |
+       +---> Expert A (Tech)     (if domain = technical)
+       |
+       +---> Expert B (Cooking)  (if domain = cooking)
+```
+
+The router is a small classifier that learns to detect the query's domain. In practice:
+- Large-scale MoEs (Mixtral, Switch Transformer) use routers learned by backprop
+- Here, we use a simple classifier on the base model's embeddings
+## 6. Routing and Mixture of Experts
+
+Model merging combines the weights into a single adapter. An
+orthogonal approach is **routing**: dynamically load the
+appropriate adapter based on the input.
+
+> **Mixture of Experts (MoE)**: a lightweight classifier (the
+> ""router"") selects the expert to activate for each token. This is
+> the architecture of Mixtral 8×7B, GPT-4 (rumored), and most
+> frontier LLMs of 2024.
+
+**Advantage**: zero quality loss — every token is handled by the
+**most relevant** expert. **Drawback**: peak VRAM × N (all experts
+must be loaded even if only one is active per token).",,,,,,,183355db679227b1,b2f4718420061515,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,7f56e4cb,markdown,fr,befb6f2add5931b9,"Le diagramme ci-dessous rend cette architecture **Mixture of Experts** sous forme de
+graphe : un routeur dirige chaque requête vers l'expert specialise du bon domaine.
+
+```mermaid
+flowchart TD
+    IN([""Entree (prompt)""]) --> R{""Routeur / Classifieur""}
+    R -->|""domaine = technique""| EA[""Expert A<br/>(Tech)""]
+    R -->|""domaine = cuisine""| EB[""Expert B<br/>(Cuisine)""]
+    classDef route fill:#f8d7da,stroke:#842029,color:#58151c
+    classDef exp fill:#fff3cd,stroke:#b8860b,color:#5c4400
+    classDef in fill:#cfe2ff,stroke:#084298,color:#052c65
+    class R route
+    class EA,EB exp
+    class IN in
+```
+
+> **Lecture.** Contrairement au *model merging* (qui fond les poids en un seul modèle),
+> le **routing** conserve tous les experts intacts et en **selectionne dynamiquement**
+> un par requête. Le **routeur** est un petit classifieur qui detecte le domaine ; ici
+> il opere sur les embeddings du modèle de base, tandis que les MoE a grande echelle
+> (Mixtral, Switch Transformer) apprennent leur routeur par retropropagation. L'intérêt :
+> n'activer qu'une fraction des paramètres a chaque appel (calcul *creux*).
+Le diagramme Mermaid ci-dessous rend cette architecture **Mixture of
+Experts** dans sa forme la plus simple (2 experts) :
+
+```mermaid
+graph LR
+    I[Input] --> R{Routeur}
+    R -->|classe Tech| A[Expert Tech]
+    R -->|classe Cuisine| B[Expert Cuisine]
+    A --> O[Output]
+    B --> O
+```
+
+**Cycle d'inférence** : (1) le routeur classe l'input (Tech ou
+Cuisine) ; (2) seul l'expert correspondant est activé ; (3) l'expert
+génère la réponse ; (4) les autres experts sont inactifs (VRAM
+économisée pour le forward pass).
+
+**Implémentation simplifiée** : cellule #26 utilise les embeddings
+moyens du modèle de base comme features pour le classifieur. C'est
+un proxy léger (pas un vrai classifier de production).
+","The diagram below renders this **Mixture of Experts** architecture as a
+graph: a router directs each query to the expert specialized in the right domain.
+
+```mermaid
+flowchart TD
+    IN([""Input (prompt)""]) --> R{""Router / Classifier""}
+    R -->|""domain = technical""| EA[""Expert A<br/>(Tech)""]
+    R -->|""domain = cooking""| EB[""Expert B<br/>(Cooking)""]
+    classDef route fill:#f8d7da,stroke:#842029,color:#58151c
+    classDef exp fill:#fff3cd,stroke:#b8860b,color:#5c4400
+    classDef in fill:#cfe2ff,stroke:#084298,color:#052c65
+    class R route
+    class EA,EB exp
+    class IN in
+```
+
+> **How to read this.** Unlike *model merging* (which fuses the weights into a single model),
+> **routing** keeps all the experts intact and **dynamically selects**
+> one per query. The **router** is a small classifier that detects the domain; here
+> it operates on the base model's embeddings, whereas large-scale MoEs
+> (Mixtral, Switch Transformer) learn their router by backpropagation. The benefit:
+> only a fraction of the parameters is activated per call (*sparse* compute).
+The Mermaid diagram below renders this **Mixture of
+Experts** architecture in its simplest form (2 experts):
+
+```mermaid
+graph LR
+    I[Input] --> R{Router}
+    R -->|Tech class| A[Expert Tech]
+    R -->|Cooking class| B[Expert Cooking]
+    A --> O[Output]
+    B --> O
+```
+
+**Inference cycle**: (1) the router classifies the input (Tech or
+Cooking); (2) only the matching expert is activated; (3) the expert
+generates the answer; (4) the other experts are inactive (VRAM
+saved for the forward pass).
+
+**Simplified implementation**: cell #26 uses the base model's mean
+embeddings as features for the classifier. It is a lightweight
+proxy (not a production classifier).",,,,,,,befb6f2add5931b9,cf6e4c0e60f0e943,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,75aa5a19,markdown,fr,208d48606e6ace2d,"### Interpretation : Routeur — et l'arbitrage contre la baseline
+
+L'arbitrage leave-one-out parle par lui-même : **routeur appris 13/14 (92,9 %) vs
+centroïde trivial 12/14 (85,7 %)** — le classifieur entraîné apporte **+7,2 points
+hors échantillon** sur la baseline la plus naïve qui existe. Et l'in-sample à
+100 % masquait entièrement ce gain comme sa fragilité : sur 14 points
+linéairement séparables, 13 vs 12 réussites, c'est un pli de différence — l'écart
+est réel mais l'intervalle se frôle. La conclusion honnête tient en deux temps :
+(1) le routing **appris** gagne sur le trivial à périmètre égal, donc la démo
+n'était pas vide ; (2) à cette échelle, la démonstration porte la **mécanique**
+(embeddings → classifieur → sélection d'expert) bien plus que la supériorité du
+classifieur — un vrai cas d'usage où le routing appris creuse l'écart exige des
+domaines qui se *chevauchent* dans l'espace d'embeddings et des dizaines à
+centaines de requêtes. Gardez ce réflexe d'audit pour toute démo de classifieur :
+**toujours exiger la baseline triviale et l'évaluation hors échantillon** — ici,
+sans elle, le notebook affichait 92,9 % (le score in-sample du commit précédent
+était 100 %) sans qu'aucun lecteur puisse dire si un centroïde aurait suffi.
+","### Interpretation: Router — and the arbitration against the baseline
+
+The leave-one-out arbitration speaks for itself: **learned router 13/14 (92.9 %) vs
+trivial centroid 12/14 (85.7 %)** — the trained classifier brings **+7.2 points
+out-of-sample** over the most naive baseline there is. And the 100 % in-sample
+entirely masked both this gain and its fragility: on 14 linearly separable points,
+13 vs 12 successes is a one-fold difference — the gap is real but the interval is
+razor-thin. The honest conclusion comes in two steps: (1) **learned** routing
+beats the trivial one at equal perimeter, so the demo was not empty; (2) at this
+scale, the demonstration carries the **mechanics** (embeddings → classifier →
+expert selection) far more than the classifier's superiority — a real use case
+where learned routing opens a gap requires domains that *overlap* in embedding
+space and tens to hundreds of queries. Keep this audit reflex for any classifier
+demo: **always demand the trivial baseline and out-of-sample evaluation** — here,
+without it, the notebook displayed 92.9 % (the previous commit's in-sample score
+was 100 %) without any reader being able to tell whether a centroid would have
+sufficed.",,,,,,,208d48606e6ace2d,c931c0892c2aeda0,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,bf51c29a,markdown,fr,782e052678eaa81d,"### Comparaison : Merging vs Routing
+
+Maintenant que nous avons implemente toutes les approches, comparons-les systematiquement.
+
+| Critere | LERP | SLERP | DARE | Routing (MoE) |
+|---------|------|-------|------|---------------|
+| **Simplicite** | Très simple | Simple | Simple | Plus complexe |
+| **Qualite par domaine** | Degradee | Moins degradee | Variable | Optimale (expert dedie) |
+| **Cout d'inference** | 1 modèle | 1 modèle | 1 modèle | N modèles + routeur |
+| **VRAM** | 1x | 1x | 1x | Nx (ou offloading) |
+| **Flexibilite** | Fixe au merge | Fixe au merge | Fixe au merge | Dynamique (ajout d'experts) |
+| **Outils** | Mergekit | Mergekit | Mergekit | Custom / vLLM |
+
+**Quand utiliser quoi ?**
+- **SLERP** : Meilleur compromis qualite/simplicite pour combiner 2-3 modèles
+- **DARE** : Quand on a beaucoup d'experts (>3) et des interferences entre tâches
+- **Routing** : Quand les domaines sont très différents et qu'on peut se permettre Nx VRAM
+### Comparaison : Merging vs Routing
+
+Maintenant que nous avons démontré les deux paradigmes, voici leur
+**comparaison pragmatique** :
+
+| Aspect | Merging (LERP/SLERP/DARE) | Routing (MoE) |
+|---|---|---|
+| VRAM | × 1 adaptateur | × N experts chargés |
+| Latence | × 1 forward pass | × 1 forward pass + classification |
+| Qualité par domaine | 95-98 % du spécialiste | 100 % du spécialiste (si bien routé) |
+| Entraînement additionnel | 0 | Classifieur léger (~5 min) |
+| Gestion des inputs hybrides | Mauvaise (perte par moyennage) | Excellente (soft-routing) |
+
+**Règle de sélection pragmatique** :
+- Si les **domaines sont mutuellement exclusifs** (Tech vs Cuisine)
+  → **DARE** est le défaut. Simple, efficace, zéro overhead.
+- Si les **domaines se chevauchent** (Code + Math + Reasoning) →
+  **Routing/soft-MoE** est préférable. Préserve la qualité par
+  token.
+- Pour les **systèmes multi-tâches généraux** (un LLM qui doit
+  tout faire) → **Merging** (DARE) bat souvent le routing par
+  sa simplicité.
+","### Comparison: Merging vs Routing
+
+Now that we have implemented all the approaches, let us compare them systematically.
+
+| Criterion | LERP | SLERP | DARE | Routing (MoE) |
+|-----------|------|-------|------|---------------|
+| **Simplicity** | Very simple | Simple | Simple | More complex |
+| **Per-domain quality** | Degraded | Less degraded | Variable | Optimal (dedicated expert) |
+| **Inference cost** | 1 model | 1 model | 1 model | N models + router |
+| **VRAM** | 1x | 1x | 1x | Nx (or offloading) |
+| **Flexibility** | Fixed at merge | Fixed at merge | Fixed at merge | Dynamic (adding experts) |
+| **Tools** | Mergekit | Mergekit | Mergekit | Custom / vLLM |
+
+**When to use what?**
+- **SLERP**: Best quality/simplicity compromise to combine 2-3 models
+- **DARE**: When you have many experts (>3) and interference between tasks
+- **Routing**: When the domains are very different and you can afford Nx VRAM
+### Comparison: Merging vs Routing
+
+Now that we have demonstrated both paradigms, here is their
+**pragmatic comparison**:
+
+| Aspect | Merging (LERP/SLERP/DARE) | Routing (MoE) |
+|---|---|---|
+| VRAM | × 1 adapter | × N experts loaded |
+| Latency | × 1 forward pass | × 1 forward pass + classification |
+| Per-domain quality | 95-98 % of the specialist | 100 % of the specialist (if well routed) |
+| Additional training | 0 | Lightweight classifier (~5 min) |
+| Handling hybrid inputs | Poor (loss through averaging) | Excellent (soft-routing) |
+
+**Pragmatic selection rule**:
+- If the **domains are mutually exclusive** (Tech vs Cooking)
+  → **DARE** is the default. Simple, effective, zero overhead.
+- If the **domains overlap** (Code + Math + Reasoning) →
+  **Routing/soft-MoE** is preferable. Preserves per-token quality.
+- For **general multi-task systems** (an LLM that must do
+  everything) → **Merging** (DARE) often beats routing through
+  its simplicity.",,,,,,,782e052678eaa81d,e8381b82aa04178c,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,095833db,markdown,fr,3723cb785a229367,"### Interpretation : Comparaison finale
+
+**Résultats attendus** :
+
+| Approche | Tech | Cuisine | Commentaire |
+|----------|------|---------|-------------|
+| Adaptateur A | Bon | Faible | Specialise tech |
+| Adaptateur B | Faible | Bon | Specialise cuisine |
+| LERP | Moyen | Moyen | Melange egalitaire, degradation des deux |
+| SLERP | Moyen+ | Moyen+ | Meilleur preservation que LERP |
+| DARE | Variable | Variable | Dependant du dropout aleatoire |
+| Routing | Bon | Bon | Selectionne le bon expert, meilleur résultat |
+
+**Points cles** :
+1. Le **routing** offre les meilleurs résultats par domaine mais coute plus cher en VRAM
+2. Le **SLERP** est le meilleur merge statique -- bon compromis entre les deux expertises
+3. Le **DARE** est efficace quand on a beaucoup d'experts, mais moins bon avec seulement 2
+4. En production, les approches peuvent etre combinees : merge SLERP pour les experts proches + routing pour les domaines très différents
+### Lecture du résultat : Comparaison finale
+
+**Résultats attendus** (cellule #30) : tableau comparant les
+différentes approches sur les 10 questions cross-domaine. **DARE
+devrait être le meilleur merge**, suivi par SLERP puis LERP.
+
+**Métrique de comparaison** : on utilise la **perplexité** du
+modèle fusionné sur chaque question (plus basse = mieux). DARE
+devrait obtenir une perplexité ≈ 5 % au-dessus du spécialiste
+pur, là où LERP est 20-30 % au-dessus.
+
+**Lecture critique** : les chiffres exacts dépendent de la **graine
+aléatoire** du fine-tuning (cellule #5 et #7) et de
+l'**initialisation** du classifieur de routing (cellule #26). Pour
+des conclusions publiables, il faut **4+ seeds** et un **intervalle
+de confiance** — au-delà du scope de ce notebook pédagogique.
+
+**Conclusion pratique** : pour un déploiement rapide, **DARE avec
+drop_rate = 0.3** est l'option sans regret.
+","### Interpretation: Final comparison
+
+**Expected results**:
+
+| Approach | Tech | Cooking | Comment |
+|----------|------|---------|---------|
+| Adapter A | Good | Weak | Specialized in tech |
+| Adapter B | Weak | Good | Specialized in cooking |
+| LERP | Medium | Medium | Equal blend, degradation of both |
+| SLERP | Medium+ | Medium+ | Better preservation than LERP |
+| DARE | Variable | Variable | Depends on the random dropout |
+| Routing | Good | Good | Selects the right expert, best result |
+
+**Key points**:
+1. **Routing** offers the best per-domain results but costs more in VRAM
+2. **SLERP** is the best static merge -- a good compromise between the two expertises
+3. **DARE** is effective with many experts, but less good with only 2
+4. In production, the approaches can be combined: SLERP merge for close experts + routing for very different domains
+### Reading the result: Final comparison
+
+**Expected results** (cell #30): a table comparing the different
+approaches on the 10 cross-domain questions. **DARE should be the
+best merge**, followed by SLERP then LERP.
+
+**Comparison metric**: we use the **perplexity** of the merged
+model on each question (lower = better). DARE should reach a
+perplexity ≈ 5 % above the pure specialist, where LERP is 20-30 %
+above.
+
+**Critical reading**: the exact figures depend on the fine-tuning
+**random seed** (cells #5 and #7) and on the routing classifier's
+**initialization** (cell #26). For publishable conclusions, one
+needs **4+ seeds** and a **confidence interval** — beyond the scope
+of this pedagogical notebook.
+
+**Practical conclusion**: for a quick deployment, **DARE with
+drop_rate = 0.3** is the no-regret option.",,,,,,,3723cb785a229367,7e2969c31487cda7,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,7ea0d064,markdown,fr,00a1b5b5b3bd4162,"## 7. Exercices
+
+Mettez en pratique les concepts de ce notebook. Chaque exercice build sur les concepts précédents.
+## 7. Exercices
+
+Mettez en pratique les concepts de ce notebook avec 3 exercices
+ciblés. Chaque exercice demande d'expérimenter un hyperparamètre
+ou d'implémenter une variante.
+
+**Exercice 1** (§7.1) : exploration de `α` pour LERP/SLERP. Testez
+les valeurs `[0.2, 0.5, 0.8]` et comparez la qualité.
+
+**Exercice 2** (§7.2) : implémenter le merge TIES. Suivez le
+squelette de la cellule #37 et complétez les 3 étapes (Trim,
+Elect Sign, Disjoint Merge).
+
+**Exercice 3** (§7.3) : ajouter un 3e adaptateur (Code) au système
+de routing. Étendez le classifieur pour gérer 3 classes.
+
+Chaque exercice est **indépendant** — vous pouvez les faire dans
+n'importe quel ordre.
+","## 7. Exercises
+
+Put the concepts of this notebook into practice. Each exercise builds on the previous ones.
+## 7. Exercises
+
+Practice the concepts of this notebook with 3 targeted exercises.
+Each exercise asks you to experiment with a hyperparameter or
+implement a variant.
+
+**Exercise 1** (§7.1): exploring `α` for LERP/SLERP. Test the
+values `[0.2, 0.5, 0.8]` and compare the quality.
+
+**Exercise 2** (§7.2): implement the TIES merge. Follow the
+skeleton of cell #37 and complete the 3 steps (Trim, Elect Sign,
+Disjoint Merge).
+
+**Exercise 3** (§7.3): add a 3rd adapter (Code) to the routing
+system. Extend the classifier to handle 3 classes.
+
+Each exercise is **independent** — you can do them in any
+order.",,,,,,,00a1b5b5b3bd4162,d15955e25b193faf,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,981e8e66,markdown,fr,597bdc1550caf3a6,"
+
+
+**Note méthodologique — quand ce notebook est utile (et quand il ne l'est pas)**
+
+**Cas d'usage adaptés** : (1) déployer plusieurs adaptateurs fine-tunés
+sur le même modèle de base sans overhead VRAM ; (2) combiner
+spécialisations distinctes (Tech + Cuisine + Code + …) en un seul
+modèle de production ; (3) tester rapidement l'effet d'un merge sur
+un benchmark interne avant de sceller la config ; (4) enseigner la
+mécanique du model merging à des étudiants ; (5) POC avant de scaler
+sur mergekit / Hugging Face  API.
+
+**Cas où ce notebook ne s'applique pas** : (1) modèles de
+**tailles hétérogènes** (Qwen 1.5B + Llama 7B) — le merge suppose la
+même architecture de base ; (2) **sparsité extrême** (> 95% drop_rate)
+— préférer la distillation ; (3) très grands modèles > 13B (utiliser
+ avec gestion de la mémoire unifiée) ; (4) besoin de
+**sélection dynamique par token** — préférer un vrai MoE (Mixtral,
+DeepSeek-MoE).
+
+**Coût-bénéfice mesuré** : pour 2 adaptateurs LoRA sur un base 1.3B,
+le merge complet (DARE drop_rate=0.3) tourne en **~10 secondes** sur
+RTX 3090. C'est le coût réel pour reproduire les chiffres de ce
+notebook — l'investissement se porte sur le fine-tuning des
+adaptateurs (FT-02/03/04), pas sur le merge.
+
+**Limites assumées** : (1) les **métriques de qualité** (perplexité,
+lm-eval-harness) sont **manuelles** dans ce notebook — pour des
+conclusions publiables, il faudrait 4+ seeds et un intervalle de
+confiance ; (2) le **routeur** est un proxy léger (embeddings moyens),
+pas un vrai classifier de production ; (3) le **DARE drop_rate = 0.3**
+est un défaut raisonnable, pas un optimum universel.
+","
+
+
+**Methodological note — when this notebook is useful (and when it is not)**
+
+**Suitable use cases**: (1) deploying several fine-tuned adapters on the
+same base model without VRAM overhead; (2) combining distinct
+specializations (Tech + Cooking + Code + …) into a single production
+model; (3) quickly testing the effect of a merge on an internal
+benchmark before freezing the config; (4) teaching the mechanics of
+model merging to students; (5) a POC before scaling up on mergekit /
+Hugging Face API.
+
+**Cases where this notebook does not apply**: (1) models of
+**heterogeneous sizes** (Qwen 1.5B + Llama 7B) — merging assumes the
+same base architecture; (2) **extreme sparsity** (> 95% drop_rate) —
+prefer distillation; (3) very large models > 13B (use with unified
+memory management); (4) the need for **per-token dynamic selection** —
+prefer a true MoE (Mixtral, DeepSeek-MoE).
+
+**Measured cost-benefit**: for 2 LoRA adapters on a 1.3B base, the
+full merge (DARE drop_rate=0.3) runs in **~10 seconds** on an RTX
+3090. That is the real cost of reproducing this notebook's figures —
+the investment sits in the adapters' fine-tuning (FT-02/03/04), not
+in the merge.
+
+**Assumed limitations**: (1) the **quality metrics** (perplexity,
+lm-eval-harness) are **manual** in this notebook — for publishable
+conclusions, one would need 4+ seeds and a confidence interval;
+(2) the **router** is a lightweight proxy (mean embeddings), not a
+production classifier; (3) **DARE drop_rate = 0.3** is a reasonable
+default, not a universal optimum.",,,,,,,597bdc1550caf3a6,08c4bd218a455004,,,,,,,


### PR DESCRIPTION
## Summary

Main est ROUGE depuis la fusion de #12850 (42e8b2d7c, « render first 2 *_en.ipynb notebooks from genai CSV (T4 grain A) »), reproduit sur `origin/main` pur @ 83e75c901 : `test_full_repo_state_passes_parity` échoue (`expected_pair_count` 0, 2 paires trouvées). La cause a **deux couches** :

1. **Cliquet non bumpé** : #12850 a ajouté 2 paires `_en.ipynb` sans passer `EXPECTED_PAIR_COUNT` de 0 à 2. Toute PR à base fraîche saigne du même rouge (update-branch inclus — #13532 l'a reçu).
2. **Paires elles-mêmes incomplètes / stale** — une fois le compte corrigé, les invariants révèlent des renders faits depuis un CSV incomplet et un source évolué :
   - `medical_chatbot_en` : **15 FR_CONTAM** (cellules markdown FR recopiées — le CSV ne couvrait que 23 des 40 cellules markdown) ;
   - `FT-05-ModelMerging-Routing_en` : **20 FR_CONTAM + 18 CODE_DRIFT** (CSV aux ids périmés, 4/26 markdown seulement traduites).

## Fix — par la chaîne outillée T2/T3/T4 (pas de hand-edit des sorties)

- **T2** `extract_cells_to_csv.py --update` : medical (+6 rafraîchies / +17 ajoutées), FT-05 (+3 / +22) — préserve `text_en` existant, appends les nouvelles cellules.
- **T3** fill des **39** cellules markdown vides (17 medical, 22 FT-05) dans les CSV + `hash_en` recomputé (contrat #4957).
- **T4** `render_notebook.py --require-translated` : medical **40/40** traduites, FT-05 **26/26**, **0 fallback**, **0 unmatched**, code copié byte-pour-byte (sorties + execution_count du source live).
- **Cliquet** `EXPECTED_PAIR_COUNT` 0 → 2 (les 2 paires sanctionnées par #12850) + commentaire.

## Tests

- `test_full_repo_state_passes_parity` a `strict_fr` : **0 FR_CONTAM, 0 CODE_DRIFT** sur les deux paires (les 15 + 38 anomalies disparues).
- Suite `scripts/translation/tests/` : **30 passed**. Suite scripts complète lancée (résultat en commentaire).

## Note

Le `check_translation_sync.py` signale **21 ORPHAN_ROW** FT-05 préexistants (cell_ids du CSV absents du notebook source — cellules supprimées, conservées par design, décision humaine hors scope). Deux paires **nouvelles** (jamais sur main avant #12850) — voir le commentaire `[TRANSLATION-OVERRIDE]` ci-dessous : la branche bot `translation-sync` est **dormante** depuis 2026-08-10 et n'a pas ré-extraire/ré-rendu ces paires ; ce PR applique la chaîne T1/T3/T4 en exécution locale outillée.

Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/notebook-dotnet #13518

See #10038