### PR TITLE
fix(mdcl,#13544): exempt translation artifacts from markdown content-loss

### DIFF
--- a/scripts/notebook_tools/detect_md_content_loss.py
+++ b/scripts/notebook_tools/detect_md_content_loss.py
@@ -110,12 +110,14 @@ MIN_ORIG_CHARS = 100
 # propriete du pipeline T1/T3/T4 (translation-guard.yml #10038). La base git
 # d'un _en.ipynb est l'ancien rendu (souvent contamine FR, cf #12850) : la
 # comparer au nouveau rendu produit des faux positifs par construction.
-# Meme ensemble que TARGET_LANGS (source unique de verite :
-# scripts/translation/check_perimeter.py #10109), duplique ici pour rester
-# autonome (import stdlib+nbformat uniquement).
-TRANSLATION_LANGS = ("en", "es", "ar", "fa", "zh", "ru", "pt")
+# L'univers ordonne des langues cibles vient de la source unique de verite
+# ``check_perimeter.TARGET_LANGS`` (#10109) -- une copie locale divergente est
+# un bug latent silencieux (garde test_lang_single_source).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "translation"))
+from check_perimeter import TARGET_LANGS  # noqa: E402  -- single source of truth
+
 _TRANSLATION_SUFFIX_RE = re.compile(
-    r"_(?:" + "|".join(TRANSLATION_LANGS) + r")\.ipynb$", re.IGNORECASE
+    r"_(?:" + "|".join(TARGET_LANGS) + r")\.ipynb$", re.IGNORECASE
 )
 
 # Motifs structurants dont la disparition est un signal fort (design #3 #8655).

--- a/scripts/notebook_tools/detect_md_content_loss.py
+++ b/scripts/notebook_tools/detect_md_content_loss.py
@@ -103,6 +103,21 @@ DROP_THRESHOLD = 0.75
 # le bruit sur les cellules triviales (un titre seul, un separateur).
 MIN_ORIG_CHARS = 100
 
+# Suffixes de notebooks de traduction (*_<lang>.ipynb). Le content-loss
+# base-vs-head ne s'applique PAS a un artefact de traduction : sa prose est une
+# DERIVATION legitime de la source FR (souvent plus courte a volume de sens
+# egal, motifs traduits != motifs FR), et le fichier _en/_ru/... est la
+# propriete du pipeline T1/T3/T4 (translation-guard.yml #10038). La base git
+# d'un _en.ipynb est l'ancien rendu (souvent contamine FR, cf #12850) : la
+# comparer au nouveau rendu produit des faux positifs par construction.
+# Meme ensemble que TARGET_LANGS (source unique de verite :
+# scripts/translation/check_perimeter.py #10109), duplique ici pour rester
+# autonome (import stdlib+nbformat uniquement).
+TRANSLATION_LANGS = ("en", "es", "ar", "fa", "zh", "ru", "pt")
+_TRANSLATION_SUFFIX_RE = re.compile(
+    r"_(?:" + "|".join(TRANSLATION_LANGS) + r")\.ipynb$", re.IGNORECASE
+)
+
 # Motifs structurants dont la disparition est un signal fort (design #3 #8655).
 # Notes : "Navigation" / "Objectif(s)" / "Prerequis" sont matches aussi bien en
 # titre (`## Navigation`) qu'en callout (`> **Navigation :**`) car la regex
@@ -594,6 +609,19 @@ def _compare_motifs(base_counts: dict, head_counts: dict) -> list[dict]:
     return findings
 
 
+def _is_translation_artifact(nb_path: Path) -> bool:
+    """True si le notebook est un artefact de traduction (*_<lang>.ipynb).
+
+    Les artefacts de traduction sont exclus du content-loss (voir
+    TRANSLATION_LANGS) : leur contenu derive de la source FR et peut
+    legitiment etre plus court (volume de sens egal en anglais) et porter des
+    motifs traduits different de ceux de la base. La comparaison base-vs-head
+    d'un _en.ipynb compare l'ancien rendu (souvent contamine FR, #12850) au
+    nouveau rendu : les ecarts mesures ne sont pas des pertes.
+    """
+    return _TRANSLATION_SUFFIX_RE.search(nb_path.name) is not None
+
+
 def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> dict:
     """Compare le contenu markdown d'un notebook entre base_ref et head_ref."""
     if head_ref is None:
@@ -607,6 +635,31 @@ def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> 
         if nb_head is None:
             return {"notebook": str(nb_path), "error": f"head_ref {head_ref} unreadable"}
         head_label = head_ref
+
+    # Artefact de traduction (*_<lang>.ipynb) : exempt de content-loss (voir
+    # _is_translation_artifact). On retourne un resultat propre (pas d'erreur,
+    # pas de findings) SANS valider la base — un _en.ipynb compare a l'ancien
+    # rendu (contamine FR, #12850) produit des faux positifs par construction.
+    # Son integrite est portee par translation-guard.yml, la parite
+    # (check_translation_parity) et le seuil --min-coverage du renderer (#13544).
+    if _is_translation_artifact(nb_path):
+        head_md_t = extract_md_cells(nb_head)
+        head_total_t = sum(_norm_len(s) for _, _, s in head_md_t)
+        return {
+            "notebook": str(nb_path),
+            "base_ref": base_ref,
+            "head_ref": head_label,
+            "translation_artifact": True,
+            "findings": [],
+            "stats": {
+                "base_md_cells": 0,
+                "head_md_cells": len(head_md_t),
+                "cell_count_stable": False,
+                "base_total_normalized_chars": 0,
+                "head_total_normalized_chars": head_total_t,
+                "findings_count": 0,
+            },
+        }
 
     # Ref de base invalide (ref manquant, checkout rate) = detecteur/ref casse,
     # PAS un nouveau fichier. On le signale en erreur (rc=2) pour que le garde
@@ -703,6 +756,9 @@ def main(argv: list[str] | None = None) -> int:
         if result.get("new_file"):
             print("[NEW FILE] absent a la base -> exempt de content-loss "
                   "(rien a perdre, tout est ajout ; #8655/#8662).")
+        if result.get("translation_artifact"):
+            print("[TRANSLATION ARTIFACT] *_<lang>.ipynb -> exempt de content-loss "
+                  "(prose derivee de la source FR ; propriete pipeline T1/T3/T4).")
         print(f"[STATS]    md_cells base={st['base_md_cells']} head={st['head_md_cells']} "
               f"stable={st['cell_count_stable']} | "
               f"normalized_chars base={st['base_total_normalized_chars']} "

--- a/scripts/notebook_tools/tests/test_detect_md_content_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_md_content_loss.py
@@ -449,6 +449,58 @@ class TestNewFileExemptionAndRefGuard:
 
 
 # ---------------------------------------------------------------------------
+# 9b. Artefacts de traduction (*_<lang>.ipynb) exempts de content-loss (#13544)
+# ---------------------------------------------------------------------------
+# La prose d'un _en.ipynb est une DERIVATION legitime de la source FR (souvent
+# plus courte a volume de sens egal, motifs traduits != motifs FR). Comparer le
+# nouveau rendu a l'ancien (souvent contamine FR, #12850) produirait des faux
+# positifs par construction. L'integrite du rendu est portee par
+# translation-guard.yml + la parite (check_translation_parity) + le seuil
+# --min-coverage du renderer (#13544 point 3).
+
+
+class TestTranslationArtifactExemption:
+    def test_translation_artifact_exempt_if_base_differs(self, tmp_path):
+        # Un _en.ipynb dont la base "disparaitrait" (cas #12850 : base contamine
+        # FR, cellule 1254c + motif Prerequis) -> exempt, 0 findings.
+        p = tmp_path / "foo_en.ipynb"
+        p.write_text(
+            json.dumps(_nb(_md("### Interpretation: Task Vectors\n\nprose anglaise concise"))),
+            encoding="utf-8",
+        )
+        def _rich_base(_p, _ref):
+            return _nb(_md("### Interpretation : Task Vectors\n\n" + EXERCISE_BODY + "\n\n**Prerequis** : maitriser les grilles."))
+        with mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=True), \
+             mock.patch.object(dml, "read_notebook_at_ref", side_effect=_rich_base):
+            r = dml.scan_notebook(p, base_ref="MOCK_BASE", head_ref=None)
+        assert r.get("translation_artifact") is True
+        assert r["stats"]["findings_count"] == 0
+        assert r["findings"] == []
+        assert "error" not in r
+
+    def test_non_translation_notebook_not_exempted(self, tmp_path):
+        # Sans suffixe _<lang>, le notebook reste soumis au content-loss : le champ
+        # translation_artifact n'est PAS pose (pas de court-circuit).
+        p = tmp_path / "foo.ipynb"
+        p.write_text(json.dumps(_nb(_md("### Enonce\n\n" + EXERCISE_BODY))), encoding="utf-8")
+        with mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=True), \
+             mock.patch.object(dml, "read_notebook_at_ref", return_value=_nb(_md("### Enonce\n\n" + EXERCISE_BODY))):
+            r = dml.scan_notebook(p, base_ref="MOCK_BASE", head_ref=None)
+        assert r.get("translation_artifact") is not True
+
+    def test_translation_artifact_main_exits_0(self, tmp_path):
+        # main() renvoie 0 pour un artefact de traduction (exempt).
+        p = tmp_path / "data_ru.ipynb"
+        p.write_text(json.dumps(_nb(_md("Texte rendu en russe"))), encoding="utf-8")
+        with mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=True), \
+             mock.patch.object(dml, "read_notebook_at_ref", return_value=_nb(_md("texte"))):
+            assert dml.main([str(p), "--base", "MOCK", "--check"]) == 0
+
+
+# ---------------------------------------------------------------------------
 # 10. Frontmatter cost -> metadata.cost migration (#8919)
 # ---------------------------------------------------------------------------
 # Un bloc frontmatter YAML `cost:` retire d'une cellule alors que ses champs


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/notebook-dotnet #13518

## Summary

Le garde `No markdown content loss in changed notebooks` (detecteur `scripts/notebook_tools/detect_md_content_loss.py`, #8655) produit des **faux positifs** sur les artefacts de traduction `*_<lang>.ipynb`. Cause racine :

1. La prose d'un `_en.ipynb` est une **derivation legitime** de la source FR — souvent plus courte a volume de sens egal, et portant des motifs traduits (`### Interpretation` au lieu de `### Interpretation : ...`, `**Prerequisites**` au lieu de `**Prerequis**`) qui ne matchent pas `MOTIF_PATTERNS` FR.
2. La **base git** d'un `_en.ipynb` est l'**ancien rendu** — souvent contamine FR (#12850 : cellule `FT-05 ... 1254c` + motif `Objectif(s)`/`Prerequis` dans la base, absents du nouveau rendu anglais). Comparer nouveau-rendu vs ancien-rendu-contamine-FR produit des `TRUNCATED_CELL` (ratio 0.734) et `LOST_MOTIF` **par construction**, pas une perte.

Ce cas precis bloque **#13542** (`FT-05-ModelMerging-Routing_en.ipynb` cellule `1254c`, ratio 0.734 + `LOST_MOTIF 'Objectif(s)'/'Prerequis'`).

## Changement

- **`detect_md_content_loss.py`** : ajout de `TRANSLATION_LANGS` (`en/es/ar/fa/zh/ru/pt`, meme ensemble que `scripts/translation/check_perimeter.py` #10109) + `_is_translation_artifact()` + exemption **avant toute validation de base** dans `scan_notebook` (retour propre : pas d'erreur, `findings=[]`, `translation_artifact=True`). Print `[TRANSLATION ARTIFACT]` dans `main()`.
- **`test_detect_md_content_loss.py`** : `TestTranslationArtifactExemption` (3 tests) — exempt-sur-base-etrangere / non-exemption des notebooks sans suffixe `_<lang>` / `main()` renvoie 0.

L'integrite du rendu de traduction n'est PAS fragilisee : elle est portee par `translation-guard.yml`, la **parite** (`check_translation_parity.py`) et le seuil `--min-coverage` du renderer (#13544 point 3).

## Verification

- `python -m pytest scripts/notebook_tools/tests/test_detect_md_content_loss.py -q` → **54 passed** (51 existants + 3 nouveaux).
- Anti-regression : un `foo.ipynb` sans suffixe `_<lang>` reste soumis au content-loss (test `test_non_translation_notebook_not_exempted`).

## Rouge pre-existant (NON cause par cette PR)

`scripts/translation/tests/test_check_translation_parity.py::test_full_repo_state_passes_parity` echoue : `found 2, declared 0`. Reproduit sur **origin/main pur** (diagnostic #10038/#12850 : les 2 `_en` de #12850 sont sur main sans bump du cliquet). Le fix (EXPECTED_PAIR_COUNT 0->2) est le sujet de **#13542** — volontairement PAS pris ici (une PR = un sujet ; le prendre creerait un conflit de livraison).

## Unblock #13542 (appariement mutuel)

**Appariement mutuel** : #13542 et #13547 se debloquent reciproquement (le garde lit le detecteur depuis l'arbre de la PR ; le cliquet parite vit dans l'arbre de #13542). `Closes` aucun tracker (fix outil autonome) ; **See #13544** (issue renderer/traduction po-2023, meme classe de faux positif) et **See #13542** (PR de contenu dont ce garde bloquait le vert — a rebaser sur main apres merge de ce fix).

Co-Authored-By: Claude-Code <noreply@anthropic.com>