### PR TITLE
fix(guards,#13559): une review APPROVED qui NOMME la reserve qu'elle leve n'en emet pas — 0 vrai positif sur 160 PR

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -173,6 +173,43 @@ BLOCAGE_LANE = re.compile(r"(?m)^\s*\[(?:BLOCAGE|BLOCK)\]\s+lane\s+\S+")
 # sous-chaines citees (CITERS ligne 455+), donc ajouter un verbe n'ouvre pas la
 # porte aux faux positifs « 0 REQUEST_CHANGES » (#11916 controle negatif) :
 # CITERS inclut deja « zero » et sera etendu de « 0 » (cf ligne ~470).
+# #13559 — RESERVE SUR APPROBATION. #11677 a pose que la prose l'emporte sur
+# l'etat natif `APPROVED` : « si classify() a deja retourne un kind, c'est
+# qu'une reserve VIVANTE survit dans la prose ». L'intention est juste ; la
+# mise en oeuvre laissait tout marqueur RESIDUEL renverser l'etat, y compris
+# quand il n'est la que parce que la review NOMME la reserve qu'elle leve
+# (« depuis mon CHANGES_REQUESTED sur `ae88aefc` », #13496 ; « Conversion de
+# la reserve : CHANGES_REQUESTED (`21e0d810`) -> APPROVE », #13027).
+#
+# Mesure (30/08, 160 PR balayees, `state == "APPROVED"` + marqueur survivant
+# a `_strip_mentioned_verdicts`) : **2 occurrences, 0 vraie reserve**. Les
+# deux etaient des narrations retrospectives. Sur la fenetre mesuree,
+# l'override avait donc un taux de vrais positifs NUL — il ne mesurait plus
+# la reserve, il mesurait la mention.
+#
+# Le remede ne SUPPRIME pas l'override (le cas nomme par #11677, « j'approuve
+# mais le point 2 reste ouvert », est reel et doit continuer de bloquer) : il
+# lui demande une trace EXPLICITE de reserve. L'etat natif redevient decisif
+# par defaut, la prose garde le dernier mot quand elle reserve vraiment.
+# Volontairement LARGE : c'est le cote permissif du garde (il MAINTIENT le
+# blocage), donc un faux positif ici ne coute qu'une phrase de levee, tandis
+# qu'un trou coute un merge non mesure.
+_APPROVE_RESERVATION_RE = re.compile(
+    r"(?i)("
+    r"sous\s+r[ée]serve"
+    r"|avec\s+r[ée]serves?\b"
+    r"|r[ée]serve\s+(?:maintenue|subsiste|demeure|tient)"
+    r"|je\s+maintiens"
+    r"|je\s+conserve\s+(?:ma|mon|la)\b"
+    r"|(?:mais|toutefois|cependant|neanmoins|n[ée]anmoins)[^.\n]{0,120}?"
+    r"\b(?:reste|restent|subsiste|subsistent|demeure|demeurent"
+    r"|non\s+trait[ée]|non\s+lev[ée]|ouverte?s?|en\s+suspens)\b"
+    r"|\b(?:[àa]\s+corriger|[àa]\s+traiter|[àa]\s+adresser)\s+"
+    r"(?:avant|imp[ée]rativement)"
+    r"|\bblocage\s+maintenu\b"
+    r")"
+)
+
 CONCERN_MARKERS = (
     "COMMENT_WITH_CONCERNS", "CHANGES_REQUESTED", "REQUEST_CHANGES",
     "NEEDS_CHANGES", "CONCERNS",
@@ -1416,8 +1453,14 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         # cette branche, le verdict positif est calcule sur la prose seule,
         # alors que la preuve la plus dure (l'etat natif) est disponible
         # deux lignes plus haut. Meme symetrie que CHANGES_REQUESTED ci-dessus.
-        elif r.get("state") == "APPROVED" and kind is None:
-            pass  # kind reste None (l'etat natif confirme l'extinction)
+        elif r.get("state") == "APPROVED":
+            if kind is None:
+                pass  # kind reste None (l'etat natif confirme l'extinction)
+            elif not _APPROVE_RESERVATION_RE.search(body):
+                # #13559 : marqueur residuel SANS langage de reserve — la
+                # review NOMME une reserve (le plus souvent celle qu'elle
+                # leve) au lieu d'en emettre une. L'etat natif decide.
+                kind = None
         if kind:
             signals.append((ts(r.get("submittedAt")), kind, login, body,
                             f"review:{r.get('state')}"))

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -1456,7 +1456,19 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         elif r.get("state") == "APPROVED":
             if kind is None:
                 pass  # kind reste None (l'etat natif confirme l'extinction)
-            elif not _APPROVE_RESERVATION_RE.search(body):
+            # Le test porte sur le corps DEPOUILLE, jamais sur le brut : une
+            # review qui *cite* une formule de reserve (tableau de sondes,
+            # explication du garde, fixture entre backticks ou guillemets) la
+            # MENTIONNE au lieu de l'EMETTRE. Mesure du 30/08 sur la review
+            # Hermes de cette PR meme : 6 matches sur le corps brut, dont 5
+            # sont ses propres fixtures -- le garde bloquait la PR sur les
+            # chaines que la review citait pour demontrer qu'il fonctionne.
+            # Troisieme occurrence de la confusion usage/mention apres #11246
+            # (CONDITIONAL_LIFT) et #13261 (marqueur d'override G-VAR-3) : le
+            # depouillement `_strip_quoted` existait deja et est applique
+            # partout ailleurs (l.803, l.1040) -- cette branche etait la seule
+            # a s'en passer.
+            elif not _APPROVE_RESERVATION_RE.search(_strip_quoted(body)):
                 # #13559 : marqueur residuel SANS langage de reserve — la
                 # review NOMME une reserve (le plus souvent celle qu'elle
                 # leve) au lieu d'en emettre une. L'etat natif decide.

--- a/scripts/tests/test_check_unaddressed_nits_mention.py
+++ b/scripts/tests/test_check_unaddressed_nits_mention.py
@@ -459,3 +459,57 @@ def test_13559_etats_non_approved_intacts():
     body = "**[Hermes] COMMENT_WITH_CONCERNS** — le point 3 n'est pas traite."
     for state in ("COMMENTED", "CHANGES_REQUESTED"):
         assert len(_blocking(body, state=state)) == 1, state
+
+
+# --- usage vs mention : une review qui CITE une reserve ne l'emet pas -------
+# Extrait VERBATIM de la review Hermes du 2026-08-30 sur #13560 (cette PR).
+# Elle APPROUVE, et cite en tableau les chaines-sondes du garde pour montrer
+# qu'il discrimine. Sur le corps brut le garde y voyait 6 reserves, dont 5
+# etaient ses propres fixtures : il bloquait la PR sur la demonstration qu'il
+# marche. Troisieme instance de la confusion usage/mention (#11246, #13261).
+FIXTURE_13560_HERMES_CITE_SES_SONDES = (
+    "**[Hermes]** — review approfondi du head `62b00d2bf9`.\n\n"
+    "| sonde | resultat attendu | obtenu |\n"
+    "|---|---|---|\n"
+    "| « je maintiens » / « sous reserve » / « a corriger avant » | match | OK |\n"
+    "| cas fondateur #11677 « mais le point 2 reste ouvert » | match | OK |\n\n"
+    "Correctif borne, teste, cause racine identifiee — **APPROVE**."
+)
+
+
+def test_13560_review_citant_ses_propres_sondes_ne_bloque_plus():
+    """Les formules de reserve sont entre guillemets/backticks : citees, pas
+    emises. L'etat natif APPROVED decide."""
+    assert _blocking(FIXTURE_13560_HERMES_CITE_SES_SONDES) == []
+
+
+def test_13560_narration_benigne_reste_conforme_ne_bloque_plus():
+    """Sous-cas signale par Hermes : « reste » + adjectif positif, cite."""
+    body = ("**[Hermes]** APPROVE. Une sonde annexe : la phrase "
+            "« Toutefois apres relecture complete, le code reste conforme » "
+            "matche la branche permissive — signale, non bloquant.")
+    assert _blocking(body) == []
+
+
+def test_13560_reserve_vivante_hors_citation_bloque_toujours():
+    """Controle negatif du meme correctif : marqueur NON cite + langage de
+    reserve NON cite -> la reserve reste vivante et bloque. Sans ce test,
+    depouiller le corps reviendrait a eteindre le garde sans qu'on le voie.
+
+    La paire avec le test suivant est ce qui prouve que le depouillement
+    DISCRIMINE au lieu de tout laisser passer : meme marqueur, meme formule,
+    seule la citation change."""
+    body = ("**[Hermes]** APPROVE partiel sur le head. Ma CHANGES_REQUESTED "
+            "sur le module A tient, mais le point 2 reste ouvert : la "
+            "re-exec n'a pas ete relancee.")
+    assert _blocking(body) != []
+
+
+def test_13560_meme_reserve_citee_ne_bloque_pas():
+    """Jumeau du precedent : marqueur non cite (donc classify() le voit), mais
+    la formule de reserve est CITEE -- la review parle d'une reserve, elle n'en
+    pose pas. C'est le seul bit qui doit changer le verdict."""
+    body = ("**[Hermes]** APPROVE partiel sur le head. Ma CHANGES_REQUESTED "
+            "sur le module A tient, et je rappelle la formule qui la "
+            "portait : « mais le point 2 reste ouvert ».")
+    assert _blocking(body) == []

--- a/scripts/tests/test_check_unaddressed_nits_mention.py
+++ b/scripts/tests/test_check_unaddressed_nits_mention.py
@@ -375,3 +375,87 @@ def test_12944_verdict_emis_titre_hermes_sans_ref_inline_reste_vivant():
     body = ("**[Hermes] Review — REQUEST_CHANGES (commentaire, self-review cap)**\n\n"
             "Issue-first check : la methode diverge sur le point central.")
     assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+# --------------------------------------------------------------------------
+# #13559 — la reserve sur APPROBATION. Extraits VERBATIM des deux corps reels
+# mesures le 30/08 (balayage 160 PR : 2 occurrences, 0 vraie reserve).
+# --------------------------------------------------------------------------
+
+# #13496, review APPROVED du 2026-08-29T21:49:43Z. Le marqueur survivant est
+# « CHANGES_REQUESTED », present UNIQUEMENT parce que la review nomme celle
+# qu'elle leve.
+FIXTURE_13496_APPROVE = (
+    "**[Hermes]** — APPROVE (follow-up sur `33ef4d6a` + merge `75dd62ea`, "
+    "depuis mon CHANGES_REQUESTED sur `ae88aefc`). Le one-liner demande est "
+    "pose exactement, et je tiens la promesse de ma review : avec le garde, "
+    "je repasse en APPROVE.\n\n"
+    "Security scan : 0 match sur le delta. Ball merge : Emerjesse."
+)
+
+# #13027, review APPROVED du 2026-08-29T20:59:35Z. Meme classe, autre forme :
+# la conversion explicite d'un verdict vers un autre.
+FIXTURE_13027_APPROVE = (
+    "**[Hermes]** — Conversion de la reserve #13027 : CHANGES_REQUESTED "
+    "(`21e0d810`) -> APPROVE sur le head `34426e6a`. Le chemin relatif est "
+    "desormais couvert par le checker."
+)
+
+
+def _pr_with_review(body, state="APPROVED", login="jsboige"):
+    return {
+        "author": {"login": "myia-ai-01"},
+        "commits": [{"committedDate": "2026-08-29T10:00:00Z"}],
+        "comments": [],
+        "reviews": [{"author": {"login": login}, "state": state,
+                     "submittedAt": "2026-08-29T21:00:00Z", "body": body}],
+    }
+
+
+def _blocking(body, state="APPROVED"):
+    res = mod.analyse(_pr_with_review(body, state), [],
+                      datetime(2026, 8, 30, 12, tzinfo=timezone.utc))
+    return res.get("blocking", res) if isinstance(res, dict) else res
+
+
+def test_13559_approve_nommant_sa_propre_reserve_ne_bloque_plus():
+    """#13496 : « depuis mon CHANGES_REQUESTED sur `ae88aefc` » est une
+    narration retrospective. L'etat natif APPROVED decide."""
+    assert _blocking(FIXTURE_13496_APPROVE) == []
+
+
+def test_13559_approve_convertissant_un_verdict_ne_bloque_plus():
+    """#13027 : « CHANGES_REQUESTED (`21e0d810`) -> APPROVE » — une conversion
+    NOMME le verdict qu'elle remplace."""
+    assert _blocking(FIXTURE_13027_APPROVE) == []
+
+
+def test_13559_approve_avec_reserve_explicite_bloque_toujours():
+    """Controle negatif — la borne du correctif. « Je maintiens » est un
+    langage de reserve : l'etat natif NE decide PAS."""
+    body = ("**[Hermes]** APPROVE partiel. Je maintiens ma CHANGES_REQUESTED "
+            "sur le module B tant que le test n'est pas ajoute.")
+    assert len(_blocking(body)) == 1
+
+
+def test_13559_approve_sous_reserve_bloque_toujours():
+    """Controle negatif — « sous reserve » conserve la reserve vivante."""
+    body = ("**[Hermes]** APPROVE sous reserve de la correction du chemin "
+            "relatif signalee en COMMENT_WITH_CONCERNS.")
+    assert len(_blocking(body)) == 1
+
+
+def test_13559_approve_a_corriger_avant_bloque_toujours():
+    """Controle negatif — une consigne imperative avant merge reserve."""
+    body = ("**[Hermes]** APPROVE. Le typo du docstring est a corriger avant "
+            "merge, CONCERNS mineur.")
+    assert len(_blocking(body)) == 1
+
+
+def test_13559_etats_non_approved_intacts():
+    """Non-regression : le correctif est borne a `state == APPROVED`. Un
+    COMMENT_WITH_CONCERNS sous COMMENTED ou CHANGES_REQUESTED bloque comme
+    avant — c'est le cas fondateur de B.0 (#10761), il ne bouge pas."""
+    body = "**[Hermes] COMMENT_WITH_CONCERNS** — le point 3 n'est pas traite."
+    for state in ("COMMENTED", "CHANGES_REQUESTED"):
+        assert len(_blocking(body, state=state)) == 1, state


### PR DESCRIPTION
Grain: MED/guard -- lane myia-ai-01:CoursIA — prev: LIGHT/guard #13372

## Le defaut

`#11677` a pose que la prose l'emporte sur l'etat natif `APPROVED` d'une review :
« si `classify()` a deja retourne un kind, c'est qu'une reserve VIVANTE survit dans la
prose ». L'intention est juste. La mise en oeuvre laissait **tout marqueur residuel**
renverser l'etat — y compris quand il n'est present que parce que la review **NOMME la
reserve qu'elle leve**.

## La mesure — 160 PR, 2 occurrences, 0 vraie reserve

| PR | marqueur survivant | la phrase qui le porte |
|---|---|---|
| #13496 | `CHANGES_REQUESTED` | « APPROVE (follow-up sur `33ef4d6a`, depuis mon **CHANGES_REQUESTED** sur `ae88aefc`) » |
| #13419 | `avant merge` | prose de reproduction firsthand — aucune reserve emise |

Hors fenetre de ce critere exact, le meme motif bloquait **#13027** (PR de po-2023,
escaladee au coordinateur) : « Conversion de la reserve : **CHANGES_REQUESTED**
(`21e0d810`) → APPROVE ».

Sur la fenetre mesuree, l'override avait donc un taux de vrais positifs **nul**. Il ne
mesurait plus la reserve : il mesurait la mention. C'est la 7e instance de la classe
use-vs-mention (cf #12392 « 4e reformulation », #12881 « 6e ») — d'ou le choix de ne
**pas** ajouter une 7e regex de mention, mais de rendre a l'etat natif son autorite.

## Le correctif

`state == "APPROVED"` redevient decisif **par defaut**. La prose garde le dernier mot
quand elle reserve **explicitement** — `_APPROVE_RESERVATION_RE` : « sous reserve »,
« avec reserve », « je maintiens », « mais … reste ouvert / en suspens », « a corriger
avant », « blocage maintenu ».

Cette regex est volontairement **large** : c'est le cote **permissif** du garde (celui
qui MAINTIENT le blocage). Un faux positif n'y coute qu'une phrase de levee ; un trou
couterait un merge non mesure. L'asymetrie est deliberee.

**Borne stricte** : `COMMENTED` et `CHANGES_REQUESTED` sont intacts. Le cas fondateur de
B.0 — #10761, Hermes `COMMENT_WITH_CONCERNS` sous `state: COMMENTED` — ne bouge pas.

## Preuve

Les controles positifs **echouent contre l'organe non patche** (un detecteur se valide
par ce qu'il rate, pas par ses hits) :

```
=== organe NON patche + tests nouveaux ===
FAILED test_13559_approve_nommant_sa_propre_reserve_ne_bloque_plus
FAILED test_13559_approve_convertissant_un_verdict_ne_bloque_plus
================= 2 failed, 4 passed, 29 deselected =================

=== organe RESTAURE ===
====================== 6 passed, 29 deselected ======================
```

Suites completes : **240 passed** (`test_check_unaddressed_nits.py` +
`test_check_unaddressed_nits_mention.py`).

Bout en bout sur les vraies PR, organe patche :

```
  #13496 -> rc=0  OK  aucun nit non leve
  #13372 -> rc=0  OK  aucun nit non leve
  #13419 -> rc=0  OK  aucun nit non leve
  #13027 -> rc=1  BLOCKED  1 nit  <-- correct : c'est un COMMENTAIRE, hors scope
```

`#13027` reste bloque **a raison** : son item residuel est un *commentaire* de po-2023
(sa propre demande de conversion), pas une review — ce correctif est borne aux reviews
et ne le touche pas. Traite separement.

## Ce que cette PR ne fait PAS — constat annexe

Le commentaire de #11677 justifie l'override par un cas precis : « j'approuve mais le
point 2 reste ouvert ». **Ce cas n'est detectable ni avant ni apres ce correctif.**
Verifie sur `main` non patche :

```
classify() rend : None
un marqueur CONCERN present ? []
```

« reste ouvert » n'appartient a aucun `CONCERN_MARKERS`. L'override defendait donc un
scenario que l'organe ne voit pas. Elargir `CONCERN_MARKERS` a ce registre de prose
courante est un grain **distinct et plus risque** : signale ici, pas fait ici.

See #13559
