### PR TITLE
fix(mdcl,#13552): cellule scindee en mode traduction = STRUCTURE_DRIFT, pas une volee de troncatures

### DIFF
--- a/scripts/notebook_tools/detect_md_content_loss.py
+++ b/scripts/notebook_tools/detect_md_content_loss.py
@@ -721,11 +721,32 @@ def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None) -> 
         if nb_sibling is not None:
             sibling_md = extract_md_cells(nb_sibling)
             head_md_t = extract_md_cells(nb_head)
-            findings = _compare_cells(
-                sibling_md, head_md_t,
-                nb_head.get("metadata", {}).get("cost"),
-                drop_threshold=TRANSLATION_DROP_THRESHOLD,
-            )
+            if len(sibling_md) != len(head_md_t):
+                # Divergence de STRUCTURE (#13552) : scission/fusion de
+                # cellules markdown entre sibling FR et artefact traduit.
+                # La comparaison cellule-par-cellule est desalignee par
+                # construction -- l'emettre produirait une volee de
+                # TRUNCATED_CELL faux dans leur categorie. On categorise
+                # en UN finding de structure (bloquant), et on garde les
+                # motifs (comptes sur le notebook entier, insensibles aux
+                # scissions).
+                findings = [{
+                    "kind": "STRUCTURE_DRIFT",
+                    "base_md_cells": len(sibling_md),
+                    "head_md_cells": len(head_md_t),
+                    "detail": (
+                        "l'artefact traduit n'a pas le meme nombre de "
+                        "cellules markdown que le sibling FR (scission ou "
+                        "fusion) -- divergence de structure, pas une perte "
+                        "de contenu mesurable cellule par cellule"
+                    ),
+                }]
+            else:
+                findings = _compare_cells(
+                    sibling_md, head_md_t,
+                    nb_head.get("metadata", {}).get("cost"),
+                    drop_threshold=TRANSLATION_DROP_THRESHOLD,
+                )
             findings.extend(_compare_motifs(
                 _collect_motifs(nb_sibling, include_aliases=True),
                 _collect_motifs(nb_head, include_aliases=True),

--- a/scripts/notebook_tools/tests/test_detect_md_content_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_md_content_loss.py
@@ -899,3 +899,45 @@ class TestTranslationAwareMode:
         assert r["mode"] == "translation"
         assert r.get("new_file") is not True
         assert any(f["kind"] == "TRUNCATED_CELL" for f in r["findings"])
+
+    def test_split_cell_emits_structure_drift_not_truncations(self, tmp_path):
+        # #13552 : une cellule markdown SCINDIEE en deux dans l'artefact
+        # traduit doit sortir comme UN drift de structure, jamais comme une
+        # volee de TRUNCATED_CELL (comparaison desalignee par construction).
+        fr = _nb(_md(EXERCISE_BODY, cell_id="c1"))
+        half = len(EXERCISE_BODY) // 2
+        en = _nb(
+            _md(EXERCISE_BODY[:half], cell_id="c1"),
+            _md(EXERCISE_BODY[half:], cell_id="c1b"),
+        )
+        r = self._scan_en(tmp_path, fr, en)
+        assert r["mode"] == "translation"
+        assert r["stats"]["cell_count_stable"] is False
+        kinds = [f["kind"] for f in r["findings"]]
+        assert kinds.count("STRUCTURE_DRIFT") == 1
+        assert "TRUNCATED_CELL" not in kinds
+
+    def test_merged_cell_emits_structure_drift(self, tmp_path):
+        # Cas dual : deux cellules FR fusionnees en une dans l'artefact.
+        fr = _nb(
+            _md(EXERCISE_BODY[:len(EXERCISE_BODY) // 2], cell_id="c1"),
+            _md(EXERCISE_BODY[len(EXERCISE_BODY) // 2:], cell_id="c2"),
+        )
+        en = _nb(_md(EXERCISE_BODY_EN, cell_id="c1"))
+        r = self._scan_en(tmp_path, fr, en)
+        kinds = [f["kind"] for f in r["findings"]]
+        assert kinds.count("STRUCTURE_DRIFT") == 1
+        assert "TRUNCATED_CELL" not in kinds
+
+    def test_structure_drift_is_blocking(self, tmp_path):
+        # Le finding de structure est bloquant : main() --check renvoie 1.
+        fr = _nb(_md(EXERCISE_BODY, cell_id="c1"))
+        half = len(EXERCISE_BODY) // 2
+        en = _nb(
+            _md(EXERCISE_BODY[:half], cell_id="c1"),
+            _md(EXERCISE_BODY[half:], cell_id="c1b"),
+        )
+        pair = self._write_pair(tmp_path, fr, en)
+        with mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=True):
+            assert dml.main([str(pair), "--base", "MOCK", "--check"]) == 1


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/lean #13556

## Summary

Suivi de MA PR mergee #13549 (concern 1 de la review NanoClaw, dispose en #13552) : en mode traduction, une cellule markdown **scindee** (ou fusionnee) entre le sibling FR et l'artefact traduit desaligne la comparaison cellule-par-cellule — le garde emettait une **volee de TRUNCATED_CELL faux dans leur categorie**. Or `cell_count_stable` exposait deja le fait sans le categoriser.

**Design (l'acceptation de l'issue)** : nombre de cellules markdown divergent en mode traduction -> **UN** finding `STRUCTURE_DRIFT` (bloquant, avec les deux comptes), comparaison cellule-par-cellule **sautee** (desalignee par construction), motifs **conserves** (comptes sur le notebook entier, insensibles aux scissions). A N constant, le chemin `_compare_cells` au seuil 0.5 est inchange.

## Test plan

- [x] Scission (N -> N+1) : **1 STRUCTURE_DRIFT, 0 TRUNCATED_CELL** (`test_split_cell_emits_structure_drift_not_truncations`)
- [x] Fusion (N -> N-1) : **1 STRUCTURE_DRIFT, 0 TRUNCATED_CELL** (`test_merged_cell_emits_structure_drift`)
- [x] Bloquant : `main --check` renvoie 1 sur le cas de scission (`test_structure_drift_is_blocking`)
- [x] Controle negatif inchange : vraie troncature a N constant sort toujours en TRUNCATED_CELL au seuil 0.5 (test existant `test_truncated_title_only_flagged_at_half_threshold`, rejoue)
- [x] Suite detector : **60 passed** (57 + 3 nouveaux) ; `test_lang_single_source.py` : **4 passed**
- [x] Regression reels (comptes stables, chemin inchange) : `FT-05-ModelMerging-Routing_en.ipynb` rc=0, `medical_chatbot_en.ipynb` rc=0 sur base origin/main frais

2 fichiers modifies : `scripts/notebook_tools/detect_md_content_loss.py`, `scripts/notebook_tools/tests/test_detect_md_content_loss.py`. Branche coupee d'origin/main frais (pas de stacking).

Closes #13552

