### PR TITLE
fix(gate,#13495): B.0 voie 3 (issue de suivi nommée) + trappe coordinateur fermée pour l'auteur

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -1182,6 +1182,83 @@ def gh_json(args: list[str]) -> object:
     return json.loads(out)
 
 
+_ISSUE_CREATED_CACHE: dict[int, datetime | None] = {}
+
+
+def gh_issue_created(n: int) -> datetime | None:
+    """#13495 — createdAt de l'issue #n, ou None si elle n'existe pas (ou PR).
+
+    Résolution des références de la voie 3 de B.0 (« issue de suivi ouverte et
+    nommée AVANT le merge »). Cache global : le createdAt d'une issue est
+    immuable, et l'audit retro croise les memes numeros d'une PR a l'autre.
+    Un numero de PR ne compte PAS : l'endpoint issues resout aussi les PRs
+    (mesure c.705 : `gh issue view <PR> --json createdAt` rend rc=0), d'ou le
+    garde `isPullRequest` — la voie 3 nomme une ISSUE, pas une PR (spec
+    #13495), sinon « rebase de #N fait » serait un report valide.
+    """
+    if n not in _ISSUE_CREATED_CACHE:
+        try:
+            d = gh_json(["issue", "view", str(n), "--repo", REPO,
+                         "--json", "createdAt,isPullRequest"])
+            if (d or {}).get("isPullRequest"):
+                _ISSUE_CREATED_CACHE[n] = None
+            else:
+                _ISSUE_CREATED_CACHE[n] = ts((d or {}).get("createdAt"))
+        except Exception:
+            _ISSUE_CREATED_CACHE[n] = None
+    return _ISSUE_CREATED_CACHE[n]
+
+
+def collect_followup_lifts(pr_data: dict, cutoff: datetime,
+                           issue_created=None) -> list[tuple]:
+    """#13495 — voie 3 de B.0 : « issue de suivi ouverte et nommée AVANT le
+    merge (reportée sciemment) ».
+
+    Un commentaire capable de lever qui NOMME une issue (#N) dans sa prose
+    (hors citation) est un report : il lève un nit antérieur si (a) l'issue
+    existe, (b) son createdAt est antérieur à la décision de merge. C'est la
+    seule voie mécaniquement ouverte à l'AUTEUR de la PR — une phrase de
+    l'auteur ne lève pas la réserve d'un tiers (voie 1 close pour lui,
+    #11145), mais un report nommé avant merge est un geste délibéré que B.0
+    crédite. Mécanique par spec (pas de NLP) : la référence vit hors citation
+    (`_strip_quoted`), comme les LIFT_MARKERs.
+
+    Deux bornes (review c.705 de jsboige, #13563) :
+    - self-ref : le numéro de la PR ELLE-MÊME n'est pas une « issue de
+      suivi » — l'API issues résout un numéro de PR (rc=0, mesuré), donc
+      tout commentaire citant #<cette PR> (« rebase de #N fait ») serait
+      sinon un report valide éteignant tous les nits antérieurs.
+    - nommeur : le report ne compte que s'il émane de l'auteur de la PR ou
+      de l'auteur du nit levé — un bystander citant une issue ancienne
+      quelconque (« ce comportement rappelle #11045 ») n'a pas de lien
+      sémantique avec la réserve (stance #13592, arbitrage po-2024).
+
+    Retourne des couples (instant, nommeur) ; `analyse` applique la borne
+    nommeur par nit. `issue_created=None` coupe la voie — `analyse()` reste
+    pur pour les tests (aucun appel réseau n'y est toléré).
+    """
+    if issue_created is None:
+        return []
+    out: list[tuple] = []
+    self_ref = pr_data.get("number")
+    for c in (pr_data.get("comments") or []):
+        if not can_lift(c):
+            continue
+        t = ts(c.get("createdAt"))
+        if t is None or not t < cutoff:
+            continue
+        stripped = _strip_quoted(c.get("body") or "")
+        for m in re.finditer(r"#(\d+)", stripped):
+            n = int(m.group(1))
+            if n == self_ref:
+                continue
+            created = issue_created(n)
+            if created is not None and created < cutoff:
+                out.append((t, (c.get("author") or {}).get("login", "")))
+                break
+    return out
+
+
 # #13639 -- une levee dont la PREUVE citee n'est plus dans la PR. Sur #13557,
 # la levee citait le commit 2d6e4c3642 (« corrige dans ce commit ») ; un
 # force-push ulterieur avait rembobine ce commit, et le gate restait vert :
@@ -1477,7 +1554,8 @@ def _names_author(body: str, author: str) -> bool:
                      body) is not None
 
 
-def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
+def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
+            issue_created=None) -> dict:
     """cutoff = mergedAt (audit retro) ou now (gate pre-merge)."""
     commits = [ts(c.get("committedDate")) for c in (pr_data.get("commits") or [])]
     commits = [c for c in commits if c]
@@ -1547,6 +1625,13 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
                        lift_body: str = "") -> bool:
         if lift_author == nit_author:
             return True
+        # #13495 — la trappe coordinateur ci-dessous ne s'ouvre pas pour
+        # l'auteur de la PR : sinon la voie 3 (report par issue nommee) serait
+        # contournable par la porte de service qu'elle vient d'ouvrir — la
+        # forme d'auto-levee pour laquelle #13316 a deja retire jsboige des
+        # comptes de levee.
+        if lift_author == pr_author:
+            return False
         # #11639 : l'override NOMME du coordinateur — l'arbitre tiers de B.0.
         # La restriction d'auteur reste la regle pour tout le monde (elle
         # bloque l'auto-levee d'un bystander, #11145) ; seule la trappe ecrite
@@ -1607,6 +1692,9 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
                      r.get("body", "")) is None
     ]
     explicit_lifts = [x for x in explicit_lifts if x[0] is not None]
+    # #13495 — voie 3 de B.0 : les commentaires qui NOMMENT une issue de
+    # suivi ouverte avant le cutoff sont des leveries a part entiere.
+    followup_lifts = collect_followup_lifts(pr_data, cutoff, issue_created)
 
     # #13639 -- passer les levees au crible du SHA rembobine (voir
     # _SHA_CITED ci-dessus pour le pourquoi et l'etroitesse). Inerte sans
@@ -1724,10 +1812,12 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
             # (B.0 : ce qui leve une remarque est une phrase). Les nits portes
             # par un COMMENTAIRE gardent le regime general ci-dessous — limite
             # NLP documentee dans can_lift.
-            lifted = _approved_lifts_reserve(login, when, pr_author) or any(
-                when < t < cutoff and _lift_eligible(lifter, login, lift_body)
-                for (t, lifter, lift_body) in explicit_lifts
-            )
+            lifted = (_approved_lifts_reserve(login, when, pr_author)
+                      or any(when < t < cutoff
+                             and _lift_eligible(lifter, login, lift_body)
+                             for (t, lifter, lift_body) in explicit_lifts)
+                      or any(when < t < cutoff and namer in (login, pr_author)
+                             for (t, namer) in followup_lifts))
             if lifted:
                 continue
         # #13083 — les bornes strictes du blocage. Un blocage ne se leve ni
@@ -1746,7 +1836,16 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
                     and (lift_author != pr_author
                          or bool(OVERRIDE_LANE.search(lift_body)))
                     for (t, lift_author, lift_body) in explicit_lifts)
-                    or _approved_lifts_reserve(login, when, pr_author)):
+                    or _approved_lifts_reserve(login, when, pr_author)
+                    # #13495 — voie 3 : le report par issue nommee leve aussi
+                    # un blocage. La garde d'auteur ci-dessus est celle des
+                    # PHRASES de levee (#13083) ; la voie 3 porte sa propre
+                    # garantie — l'issue existe et fut creee AVANT le cutoff —
+                    # et reste ouverte a l'auteur : un report nomme avant
+                    # merge est un geste delibere que B.0 credite. Borne
+                    # nommeur (c.705) : {auteur du blocage, auteur de la PR}.
+                    or any(when < t < cutoff and namer in (login, pr_author)
+                           for (t, namer) in followup_lifts)):
                 continue
         # #12319 : meme regime pour un nit porte par un commentaire ou une
         # review COMMENTED (dont chaque reserve Hermes, self-review cap).
@@ -1760,7 +1859,9 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         elif (any(
                   when < t < cutoff and _lift_eligible(lift_author, login, lift_body)
                   for (t, lift_author, lift_body) in explicit_lifts
-              ) or _approved_lifts_reserve(login, when, pr_author)):
+              ) or _approved_lifts_reserve(login, when, pr_author)
+              or any(when < t < cutoff and namer in (login, pr_author)
+                     for (t, namer) in followup_lifts)):
             continue
         # Un commit poussé après le nit ne le lève PAS à lui seul : sur #10761,
         # le « traitement » était un rebase à 19:41 qui n'adressait aucun des
@@ -1803,6 +1904,19 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         and OVERRIDE_LANE.search(body or "") is not None
         and author not in LIFT_OVERRIDE_LOGINS
         and author not in nit_authors
+    ] + [
+        # #13495 — meme exigence de nomination pour la trappe fermee a
+        # l'auteur de la PR : un override coordinateur pose PAR l'auteur ne
+        # doit pas disparaitre en silence.
+        {"author": author, "at": t.isoformat(),
+         "why": (f"override ignoré — auteur « {author} » est l'auteur de la "
+                 "PR : la trappe coordinateur ne s'ouvre pas pour lui "
+                 "(#13495)")}
+        for (t, author, body) in explicit_lifts
+        if t is not None
+        and OVERRIDE_LANE.search(body or "") is not None
+        and author in LIFT_OVERRIDE_LOGINS
+        and author == pr_author
     ]
 
     # #13512 -- CE QUE L'ORGANE N'A PAS EVALUE.
@@ -1923,7 +2037,8 @@ def gate(pr: int, as_json: bool) -> int:
     data["_absent_sha_messages"] = _resolve_absent_sha_messages(data)
     merged = ts(data.get("mergedAt"))
     cutoff = merged or datetime.now(timezone.utc)
-    result = analyse(data, review_threads(pr), cutoff)
+    result = analyse(data, review_threads(pr), cutoff,
+                     issue_created=gh_issue_created)
     if as_json:
         print(json.dumps(result, indent=1, ensure_ascii=False))
     elif not result["blocked"]:
@@ -1942,7 +2057,7 @@ def gate(pr: int, as_json: bool) -> int:
             # silence etait le mode d'echec couteux (#13030, #12096).
             print(f"  [i] {o['why']} (commentaire de {o['author']} à {o['at']})")
         _print_sha_notes(result)
-        print("Lever chaque nit (commit, reponse explicite, ou issue de suivi nommee)")
+        print("Lever chaque nit (reponse explicite, thread inline resolu, ou issue de suivi nommee)")
         print("avant `gh pr merge`. Cf CLAUDE.md section B.0.")
         _print_unevaluated(result)
     return 1 if result["blocked"] else 0
@@ -1963,7 +2078,11 @@ def audit(limit: int, search: str | None = None) -> int:
             continue
         # Pre-filtre sans `commits` : si rien ne ressort deja, inutile de payer
         # un appel de plus (les commits ne peuvent que LEVER un nit, jamais en creer).
-        if not analyse(p, [], merged)["blocked"]:
+        # #13495 : voie 3 active aussi en retro — sinon l'audit flaggerait des
+        # PRs dont les nits etaient legitiment reportes par issue nommee. Le
+        # cache global de gh_issue_created amortit les lookups croises entre PRs.
+        if not analyse(p, [], merged,
+                       issue_created=gh_issue_created)["blocked"]:
             continue
         try:
             p["commits"] = gh_json(
@@ -1977,7 +2096,7 @@ def audit(limit: int, search: str | None = None) -> int:
         # a besoin pour trier (« du code a bouge apres le nit » = aller lire le
         # diff avant de conclure). Information de triage, pas critere.
         # Audit retro : on n'interroge pas les threads inline (1 appel GraphQL/PR).
-        res = analyse(p, [], merged)
+        res = analyse(p, [], merged, issue_created=gh_issue_created)
         if res["blocked"]:
             res["url"] = p.get("url")
             res["merged_at"] = p["mergedAt"]

--- a/scripts/tests/test_check_unaddressed_nits_followup.py
+++ b/scripts/tests/test_check_unaddressed_nits_followup.py
@@ -59,9 +59,10 @@ def resolver(table):
     return lambda n: table.get(n)
 
 
-def run(comments, reviews=(), pr_author="jsboige", issue_created=None):
+def run(comments, reviews=(), pr_author="jsboige", issue_created=None,
+        number=0):
     data = {
-        "number": 0, "title": "t",
+        "number": number, "title": "t",
         "author": {"login": pr_author},
         "comments": comments,
         "reviews": list(reviews),
@@ -125,6 +126,38 @@ def test_voie3_bruit_bot_ne_leve_pas():
            "body": "Follow-up issue #500 created by automation."}
     res = run([USER_NIT, bot], issue_created=resolver(ISSUE_OK))
     assert res["blocked"] is True
+
+
+def test_voie3_self_ref_ne_leve_pas():
+    """c.705 : le numéro de la PR elle-même n'est pas une « issue de suivi ».
+    L'endpoint issues résout aussi les PRs (mesuré rc=0), donc sans le garde
+    self-ref, « rebase de #13563 fait » éteindrait tous les nits antérieurs.
+    Le résolveur réponds VRAI pour ce numéro : c'est le garde qui doit tenir."""
+    selfref = dict(REPORT, body="Rebase de #13563 fait, checks relancés.")
+    res = run([USER_NIT, selfref], issue_created=resolver(
+        {13563: datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)}),
+        number=13563)
+    assert res["blocked"] is True
+
+
+def test_voie3_bystander_ne_leve_pas():
+    """c.705, borne nommeur : un bystander citant une issue ancienne
+    quelconque (« ce comportement rappelle #500 ») n'a pas de lien sémantique
+    avec la réserve — stance #13592, arbitrage po-2024. Seuls comptent les
+    reports de l'auteur de la PR ou de l'auteur du nit."""
+    bystander = {"author": {"login": "myia-po-2025"}, "createdAt": at(12),
+                 "body": "Ce comportement rappelle l'issue #500, à mon avis."}
+    res = run([USER_NIT, bystander], issue_created=resolver(ISSUE_OK))
+    assert res["blocked"] is True
+
+
+def test_voie3_report_par_auteur_du_nit_leve():
+    """Contrôle positif de la borne nommeur : l'AUTEUR DU NIT (distinct de
+    l'auteur de la PR) peut reporter sa propre réserve sur une issue nommée —
+    la borne ne doit pas être plus étroite que sa raison d'être."""
+    res = run([USER_NIT, REPORT], pr_author="myia-po-2026",
+              issue_created=resolver(ISSUE_OK))
+    assert res["blocked"] is False
 
 
 def test_voie3_leve_un_changes_requested():

--- a/scripts/tests/test_check_unaddressed_nits_followup.py
+++ b/scripts/tests/test_check_unaddressed_nits_followup.py
@@ -1,0 +1,186 @@
+"""Tests #13495 — voie 3 de B.0 (« issue de suivi ouverte et nommée AVANT le
+merge ») et fermeture de la trappe coordinateur pour l'auteur de la PR.
+
+L'annonce du gate citait trois surfaces de levée ; deux seulement étaient
+implémentées (« commit » n'en est pas une par doctrine, et la voie 3 n'avait
+aucun détecteur). Ce fichier couvre le détecteur installé par #13495 :
+
+  - un commentaire capable de lever qui NOMME une issue (#N, hors citation)
+    est un report : il lève un nit antérieur si l'issue existe et si son
+    createdAt est antérieur au cutoff ;
+  - `issue_created=None` coupe la voie — `analyse()` reste pur, aucun appel
+    réseau n'est toléré dans les tests (resolver injecté) ;
+  - la trappe coordinateur (`_lift_eligible`, `LIFT_OVERRIDE_LOGINS`) ne
+    s'ouvre plus pour l'auteur de la PR : sinon la voie 3 serait contournable
+    par la porte de service qu'elle vient d'ouvrir. L'override écarté est
+    NOMMÉ dans `ignored_overrides` (exigence #13316).
+"""
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CHECK_PATH = HERE.parent / "check_unaddressed_nits.py"
+
+spec = importlib.util.spec_from_file_location(
+    "check_unaddressed_nits_followup", CHECK_PATH)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["check_unaddressed_nits_followup"] = mod
+spec.loader.exec_module(mod)
+
+
+def at(hour: int) -> str:
+    return f"2026-08-14T{hour:02d}:00:00Z"
+
+
+MERGED = datetime(2026, 8, 14, 20, 0, tzinfo=timezone.utc)
+
+USER_NIT = {
+    "author": {"login": "jsboige"},
+    "createdAt": at(9),
+    "body": "Attention 2 nits:\r\n- il va falloir splitter\r\n- l'attribution est fausse",
+}
+
+# Le report de l'auteur : pas de LIFT_MARKER (sinon voie 1), la seule charge
+# utile est la référence #500 en prose vive.
+REPORT = {
+    "author": {"login": "jsboige"},
+    "createdAt": at(12),
+    "body": "Le nit d'attribution est reporte sciemment sur l'issue #500.",
+}
+
+# #500 existe, ouverte la veille du merge — le report créditable de B.0.
+ISSUE_OK = {500: datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)}
+ISSUE_LATE = {500: datetime(2026, 8, 14, 21, 0, tzinfo=timezone.utc)}  # post-merge
+
+
+def resolver(table):
+    return lambda n: table.get(n)
+
+
+def run(comments, reviews=(), pr_author="jsboige", issue_created=None):
+    data = {
+        "number": 0, "title": "t",
+        "author": {"login": pr_author},
+        "comments": comments,
+        "reviews": list(reviews),
+        "commits": [{"committedDate": at(8)}],
+    }
+    return mod.analyse(data, [], MERGED, issue_created=issue_created)
+
+
+# --- voie 3 : le report par issue nommée --------------------------------------
+
+
+def test_voie3_report_par_issue_nommee_leve():
+    """La surface manquante de B.0 : l'auteur reporte le nit sur #500 (issue
+    réelle, ouverte avant merge) — c'est la seule voie mécaniquement ouverte
+    à l'auteur de la PR, et maintenant elle crédite."""
+    res = run([USER_NIT, REPORT], issue_created=resolver(ISSUE_OK))
+    assert res["blocked"] is False
+
+
+def test_voie3_resolver_absent_coupe_la_voie():
+    """`issue_created=None` (défaut) laisse `analyse()` pur : sans résolveur,
+    aucune référence n'est résolue et le nit reste bloquant."""
+    res = run([USER_NIT, REPORT])
+    assert res["blocked"] is True
+
+
+def test_voie3_issue_inexistante_ne_leve_pas():
+    """Un #N qui ne résout pas (issue supprimée, ou numéro de PR) ne lève
+    rien — le report doit nommer une ISSUE ouverte."""
+    res = run([USER_NIT, REPORT], issue_created=resolver({}))
+    assert res["blocked"] is True
+
+
+def test_voie3_issue_creee_apres_merge_ne_leve_pas():
+    """B.0 exige « ouverte et nommée AVANT le merge » : une issue ouverte
+    après le cutoff est une réponse rétroactive, pas un report."""
+    res = run([USER_NIT, REPORT], issue_created=resolver(ISSUE_LATE))
+    assert res["blocked"] is True
+
+
+def test_voie3_reference_citee_ne_leve_pas():
+    """Use vs mention (#11246) : la référence vit dans un backtick — c'est
+    une citation, pas un report posé. `_strip_quoted` l'écarte."""
+    cited = dict(REPORT, body="Reporte sur l'issue `#500` (voir le rapport).")
+    res = run([USER_NIT, cited], issue_created=resolver(ISSUE_OK))
+    assert res["blocked"] is True
+
+
+def test_voie3_report_anterieur_au_nit_ne_leve_pas():
+    """Un report qui précède la remarque n'a pas pu la lever (borne
+    `when < t`, même fenêtre que les phrases de levée)."""
+    early = dict(REPORT, createdAt=at(7))
+    res = run([USER_NIT, early], issue_created=resolver(ISSUE_OK))
+    assert res["blocked"] is True
+
+
+def test_voie3_bruit_bot_ne_leve_pas():
+    """can_lift filtre le bruit AVANT la voie 3 : un commentaire de bot qui
+    cite #500 n'est pas un report."""
+    bot = {"author": {"login": "github-actions"}, "createdAt": at(12),
+           "body": "Follow-up issue #500 created by automation."}
+    res = run([USER_NIT, bot], issue_created=resolver(ISSUE_OK))
+    assert res["blocked"] is True
+
+
+def test_voie3_leve_un_changes_requested():
+    """État natif : la voie 3 éteint un CHANGES_REQUESTED antérieur au
+    report, comme une phrase de levée de l'émetteur."""
+    cr = {"author": {"login": "hermes-bot"}, "state": "CHANGES_REQUESTED",
+          "submittedAt": at(10),
+          "body": "CHANGES_REQUESTED: 2 edge cases non couverts."}
+    res = run([REPORT], reviews=[cr], issue_created=resolver(ISSUE_OK))
+    assert res["blocked"] is False
+
+
+def test_voie3_leve_un_blocage():
+    """#13083 fermait le blocage aux PHRASES de levée ; la voie 3 porte sa
+    propre garantie (issue réelle, antérieure au cutoff) et y reste ouverte —
+    un report nommé avant merge est un geste délibéré que B.0 crédite."""
+    block = {"author": {"login": "myia-po-2025"}, "createdAt": at(10),
+             "body": "[BLOCAGE] lane myia-po-2025:CoursIA — l'attribution "
+                     "est fausse, pas de merge sans correctif."}
+    res = run([block, REPORT], issue_created=resolver(ISSUE_OK))
+    assert res["blocked"] is False
+
+
+# --- garde #13495 : la trappe coordinateur ne s'ouvre pas pour l'auteur -------
+
+
+OVERRIDE_BODY = (
+    "**[OVERRIDE] lane myia-ai-01:CoursIA** — Levée de la réserve Hermes "
+    "du 2026-08-14, en nommant chacun de ses points."
+)
+
+HERMES_NIT = {
+    "author": {"login": "clusterManager-Myia"},
+    "state": "COMMENTED", "submittedAt": at(10),
+    "body": "[Hermes] COMMENT_WITH_CONCERNS — tests exécutés en local : 44/44 "
+            "pass, mais 2 edge cases non couverts.",
+}
+
+
+def test_trappe_refusee_pour_lauteur_de_la_pr():
+    """#13495 : le coordinateur EST l'auteur de la PR → son override nommé ne
+    lève plus (auto-levée par la porte de service), et l'override écarté est
+    NOMMÉ dans ignored_overrides (exigence #13316 : le rouge expliqué)."""
+    lift = {"author": {"login": "myia-ai-01"}, "createdAt": at(12),
+            "body": OVERRIDE_BODY}
+    res = run([lift], reviews=[HERMES_NIT], pr_author="myia-ai-01")
+    assert res["blocked"] is True
+    named = [o for o in res["ignored_overrides"]
+             if o["author"] == "myia-ai-01" and "#13495" in o["why"]]
+    assert named, "l'override écarté doit être nommé avec la raison #13495"
+
+
+def test_trappe_tiers_passe_toujours():
+    """Non-régression : la même trappe par un coordinateur TIERS (l'arbitre
+    de B.0, l'auteur de la PR étant un worker) continue de lever."""
+    lift = {"author": {"login": "myia-ai-01"}, "createdAt": at(12),
+            "body": OVERRIDE_BODY}
+    res = run([lift], reviews=[HERMES_NIT], pr_author="myia-po-2026")
+    assert res["blocked"] is False


### PR DESCRIPTION
Grain: DEEP/guard — lane myia-po-2024:CoursIA-2 — prev: MED/training #13462
Perimeter: 2 files — scripts/check_unaddressed_nits.py, scripts/tests/test_check_unaddressed_nits_followup.py (+291/−11).

## Ce que l'issue établit (audit #13495, vérifié firsthand)

L'annonce du gate citait trois surfaces de levée ; deux seulement étaient réelles :

| Voie | Annoncée l.1567 | Implémentée avant | Doctrine B.0 |
|---|---|---|---|
| commit | oui | **non** (par doctrine : un push muet ne lève rien, #10761) | non |
| réponse explicite | oui | oui (`explicit_lifts` + `_lift_eligible`) | oui |
| issue de suivi nommée | oui | **aucun détecteur** | oui |
| thread inline résolu | non | oui (`isResolved`) | oui |

Et la trappe coordinateur (`_lift_eligible` → `LIFT_OVERRIDE_LOGINS`) ne vérifiait pas `lift_author != pr_author` : un coordinateur-auteur pouvait s'auto-lever via `[OVERRIDE] lane`.

## Le fix

1. **Voie 3 installée** — `collect_followup_lifts()` : un commentaire capable de lever qui NOMME une issue (`#N`, prose vive via `_strip_quoted`) est un report ; il lève un nit antérieur si l'issue existe et si son `createdAt` est antérieur au cutoff. C'est la seule voie mécaniquement ouverte à l'auteur de la PR.
2. **Purity préservée** — résolution par injection : `analyse(..., issue_created=None)` par défaut coupe la voie (aucun réseau dans `analyse()`, contrat de tests intact). `gh_issue_created()` résout en live avec cache global immuable, branché dans `gate()` et les deux passes `audit()`.
3. **Trappe fermée pour l'auteur** — `_lift_eligible` refuse `lift_author == pr_author` : sinon la voie 3 serait contournable par la porte de service qu'elle vient d'ouvrir (la forme d'auto-levée pour laquelle #13316 a déjà retiré jsboige des comptes de levée). L'override écarté est **nommé** dans `ignored_overrides` (exigence #13316 : le rouge expliqué).
4. **Annonce raccordée à la réalité** — `Lever chaque nit (reponse explicite, thread inline resolu, ou issue de suivi nommee)` : « commit » retiré, « thread inline resolu » ajouté.

## Contrôles live (gate réel, worktree de cette branche)

- **#13372** : `EXIT=0` — cas fondateur de #13495, levée via l'issue nommée #13488 désormais créditée.
- **#11479** : `EXIT=0` — le commentaire pré-merge réel d'ai-01 contient mot pour mot « **Reporté sciemment sur #11058**, qui est ouverte » ; l'ancien code ne le créditant pas, le coordinateur avait dû écrire un `[OVERRIDE]` **post-merge** (« merge fait à EXIT=1 du gate, je l'écris plutôt que de le laisser passer »). Le geste pré-merge existe dans l'historique — il est enfin visible au gate.
- **#10761** : `EXIT=1` — l'incident fondateur (rebase muet) reste rouge : rien ne se lève par sur-crédit.

## Tests

11 nouveaux (`scripts/tests/test_check_unaddressed_nits_followup.py`) : voie 3 lève / issue inexistante ne lève pas / issue post-cutoff ne lève pas / référence citée (backtick) ne lève pas / report antérieur au nit ne lève pas / bruit bot ne lève pas / lève un CHANGES_REQUESTED / lève un BLOCAGE / trappe refusée pour l'auteur (+entrée `ignored_overrides` nominée) / trappe tiers passe toujours / `issue_created=None` coupe la voie.

205/205 existants verts, suite complète 3639 passed / 29 skipped / 5 xfailed / 0 failed.

Closes #13495