### PR TITLE
fix(ci,#13331): detect-dup-selftest workflow never installed pytest (post-merge run FAILED)

### DIFF
--- a/.github/workflows/detect-dup-selftest.yml
+++ b/.github/workflows/detect-dup-selftest.yml
@@ -49,6 +49,15 @@ jobs:
         with:
           python-version: '3.13'
 
+      # actions/setup-python does NOT ship pytest. The only run of this
+      # workflow (schedule, 2026-08-29T04:43Z) FAILED with "No module named
+      # pytest" at the first step: triggers are schedule/dispatch only, so
+      # no PR check ever exercised the runner. The detector itself is pure
+      # stdlib (gh CLI excluded) and the tests are unittest-style -- pytest
+      # is only the runner.
+      - name: Install pytest (runner only, detector stays stdlib)
+        run: python -m pip install pytest
+
       # Criterion 4: the skip path stays possible offline.
       - name: Unit tests (live test SKIPS without DETECT_DUP_NETWORK)
         run: python -m pytest scripts/tests/test_detect_duplicate_issues.py -v


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: MED/guard #13561

## Summary

Reponse au dispatch po-2027 (option a, mon claim) : le workflow `detect-dup-selftest.yml` (mon livrable #13362/#13331) invoque `python -m pytest` dans deux steps mais **n'installe jamais pytest**. Verifie firsthand : (1) le fichier sur main n'a aucun step pip ; (2) le seul run (schedule 33234496023, 2026-08-29T04:43Z) echoue avec `No module named pytest` a la premiere etape ; (3) les declencheurs sont schedule/workflow_dispatch uniquement — aucune PR check n'a jamais vu le runner. L'acceptance 1 de #13331 (un run ou le test tourne ET trouve la paire #13050/#13051) n'a donc jamais ete exercee — le label candidate-delivered etait un faux positif sur ce critere (constat po-2027, confirme).

**Fix** : un step `python -m pip install pytest` apres setup-python. Le detecteur reste stdlib pur et les tests unittest-style — pytest n'est que le runner.

## Test plan

- [x] Verif firsthand triplement croisee : workflow sans pip install sur main + log du run 33234496023 (`No module named pytest`, exit 1) + `python -m pytest scripts/tests/test_detect_duplicate_issues.py` local : **16 passed, 1 skipped** (le live test skippe bien sans DETECT_DUP_NETWORK = critere 4 intact)
- [x] YAML valide (`yaml.safe_load` OK)
- [x] Trigger `workflow_dispatch` deja present : post-merge, dispatcher le workflow et joindre le log a l'issue prouve le critere 1 (paire visible + exit 1 sain)

1 fichier modifie : `.github/workflows/detect-dup-selftest.yml` (9 insertions, 0 deletion).

See #13331



**Retag note** : posee initialement `LIGHT/guard` (fichier traverse = un organe de garde), le genre reel du travail est `tooling` — la PR repare l environnement runner du workflow (step pip pytest), elle ne touche pas la logique de detection. G-VAR-3 : genres differents (tooling vs guard), verdict local `variation_adjacency_guard.py` = pass.
