### PR TITLE
fix(picker,#13420): le plafond de recuperation du pool inversait l'instrument en silence — il amputait la traine

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -237,14 +237,47 @@ def age_days(created: str) -> int:
     return max(0, (NOW - created_dt).days)
 
 
+# Plafond de recuperation du pool. Ce n'est PAS un reglage de confort : quand
+# il sature, `gh issue list` rend les N plus RECENTES (mesure du 2026-08-30 :
+# les 12 premieres rendues etaient les 12 dernieres creees), donc la
+# troncature ampute exactement la traine -- la population que la ponderation
+# age + delaissement existe pour atteindre. Un plafond atteint inverse
+# l'instrument au lieu de le borner, et le fait sans rien dire.
+#
+# Mesure du 2026-08-30 : 213 ouvertes, et ce que l'ancien plafond de 300
+# aurait fait tomber en premier etait #1028 (mandat audiobook), #1203, #1206,
+# #1210, #1453, #1454 -- six EPICs de mai, tous vivants.
+POOL_FETCH_LIMIT = 2000
+
+
 def fetch_pool() -> list[dict]:
-    """Une seule requete, limite haute -- c'est ce qui defait la troncature."""
+    """Une seule requete, limite haute -- c'est ce qui defait la troncature.
+
+    Le plafond est haut ET surveille : aucun plafond ne se choisit une fois
+    pour toutes, et celui-ci se fait franchir en silence par construction.
+    """
     out = subprocess.run(
-        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--limit", "300",
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open",
+         "--limit", str(POOL_FETCH_LIMIT),
          "--json", "number,title,labels,body,createdAt,updatedAt"],
         capture_output=True, text=True, encoding="utf-8", check=True,
     ).stdout
     raw = json.loads(out)
+    if len(raw) >= POOL_FETCH_LIMIT:
+        # Signature de la troncature : on a recu exactement ce qu'on a demande.
+        # Le tirage reste possible et se poursuit -- bloquer la lane serait pire
+        # que la biaiser (R4 : jamais sanctionner l'idle). Mais il est desormais
+        # biaise VERS LE RECENT, et le dire est la seule chose qui empeche de
+        # lire son resultat comme une couverture du pool.
+        print(
+            f"[POOL TRONQUE] {len(raw)} issues rendues pour un plafond de "
+            f"{POOL_FETCH_LIMIT} : le pool est probablement plus grand. "
+            "gh rend les plus RECENTES, donc la traine -- vieux EPICs, sujets "
+            "delaisses -- est absente de ce tirage. Le resultat ci-dessous est "
+            "biaise vers le recent : relever POOL_FETCH_LIMIT avant de s'en "
+            "servir pour conclure quoi que ce soit sur la couverture.",
+            file=sys.stderr,
+        )
     pool = []
     for it in raw:
         labels = [lb["name"] for lb in it.get("labels", [])]

--- a/scripts/translation/check_translation_parity.py
+++ b/scripts/translation/check_translation_parity.py
@@ -153,6 +153,51 @@ def load_cells(nb_path: Path) -> Tuple[List[CellRecord], Optional[str]]:
 _SUFFIX_RE = re.compile(r"^(?P<stem>.+)_(?P<lang>" + "|".join(TARGET_LANGS) + r")$")
 
 
+# Repertoires qui contiennent des COPIES du depot ou des dependances
+# vendorisees. Les traverser fait dependre le compte de paires de
+# l environnement local : une machine portant deux worktrees rend 6 la ou la
+# CI rend 2, et `EXPECTED_PAIR_COUNT` — une egalite — devient non
+# maintenable (le dev « corrige » vers son chiffre local et casse la CI).
+# Mesure du 2026-08-29 sur cette machine : 6 paires vues, dont 4 venaient de
+# `.worktrees/`, aucune n existant sur `main`.
+_SKIP_DIRS = frozenset({
+    ".worktrees",   # copies du depot (git worktree)
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".lake",        # paquets Lean vendorises
+    ".ipynb_checkpoints",
+})
+
+
+def _is_scannable(path: Path, repo_root: Path) -> bool:
+    """Vrai si ``path`` est dans l arbre source, hors copies et vendorise.
+
+    Teste les composants RELATIFS a ``repo_root`` : un depot situe sous un
+    chemin contenant lui-meme un nom de la liste (par ex. un checkout dans
+    ``/home/x/venv/CoursIA``) ne doit pas devenir invisible en entier.
+    """
+    try:
+        rel = path.relative_to(repo_root)
+    except ValueError:
+        return True
+    if any(part in _SKIP_DIRS for part in rel.parts):
+        return False
+    # La liste de noms ci-dessus ne couvre que les conventions connues. Un
+    # worktree nomme autrement contamine quand meme le compte : mesure du
+    # 2026-08-30, un worktree `.wt-parity-split` a la racine faisait rendre
+    # 2 paires qui n existaient que dans la copie, filtre actif. Ce qui
+    # caracterise une copie n est pas son nom mais la presence d un `.git`
+    # (repertoire pour un clone, fichier pour un worktree ou un submodule).
+    probe = repo_root
+    for part in rel.parts[:-1]:
+        probe = probe / part
+        if (probe / ".git").exists():
+            return False
+    return True
+
+
 def discover_pairs(
     repo_root: Path, langs: List[str]
 ) -> List[Tuple[Path, Path, str, str]]:
@@ -181,6 +226,8 @@ def discover_pairs(
     pairs: List[Tuple[Path, Path, str, str]] = []
     seen: Set[Tuple[str, str]] = set()
     for nb_path in sorted(repo_root.rglob("*.ipynb")):
+        if not _is_scannable(nb_path, repo_root):
+            continue
         stem = nb_path.stem
         suffix_match = _SUFFIX_RE.match(stem)
         if suffix_match and suffix_match.group("lang") in langs:

--- a/scripts/translation/tests/test_check_translation_parity.py
+++ b/scripts/translation/tests/test_check_translation_parity.py
@@ -642,6 +642,48 @@ def test_cli_repo_root_missing_returns_two(tmp_path, capsys, monkeypatch):
     assert rc == 2
 
 
+def test_discover_pairs_skips_repo_copies_and_vendored_trees(tmp_path):
+    """Une paire dans `.worktrees/` (copie du depot) ne doit PAS etre comptee.
+
+    Controle POSITIF d abord : la meme paire, placee dans l arbre source, EST
+    vue. Sans cette moitie, le test passerait aussi avec un walk qui ne trouve
+    jamais rien — c est la seule facon de distinguer « exclu » de « aveugle ».
+    """
+    src = tmp_path / "serie" / "N-1.ipynb"
+    src.parent.mkdir(parents=True)
+    src.write_text("{}", encoding="utf-8")
+    src.with_name("N-1_en.ipynb").write_text("{}", encoding="utf-8")
+
+    visible = p.discover_pairs(tmp_path, ["en"])
+    assert len(visible) == 1, "controle positif : une paire de l arbre source doit etre vue"
+
+    for skipped in (".worktrees", ".venv", "node_modules", ".lake"):
+        copy = tmp_path / skipped / "clone" / "serie" / "N-2.ipynb"
+        copy.parent.mkdir(parents=True)
+        copy.write_text("{}", encoding="utf-8")
+        copy.with_name("N-2_en.ipynb").write_text("{}", encoding="utf-8")
+
+    after = p.discover_pairs(tmp_path, ["en"])
+    assert len(after) == 1, (
+        f"4 paires ajoutees dans des repertoires exclus ne doivent rien changer, "
+        f"vu {len(after)}"
+    )
+
+
+def test_is_scannable_matches_on_relative_parts_only(tmp_path):
+    """Un depot dont le CHEMIN PARENT porte un nom exclu reste scannable.
+
+    Regression : un test sur le chemin absolu rendrait invisible tout depot
+    situe sous, par ex., `/home/x/venv/CoursIA`.
+    """
+    root = tmp_path / "venv" / "CoursIA"
+    (root / "serie").mkdir(parents=True)
+    inside = root / "serie" / "N.ipynb"
+    inside.write_text("{}", encoding="utf-8")
+    assert p._is_scannable(inside, root) is True
+    assert p._is_scannable(root / ".venv" / "x" / "N.ipynb", root) is False
+
+
 # ---------------------------------------------------------------------------
 # Reference — live state (manual)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #13560

## Le defaut

`fetch_pool()` demandait `gh issue list --limit 300`, avec le commentaire « limite haute -- c'est ce qui defait la troncature ». Il defaisait la troncature a 30 de `gh` ; il en installait une a 300.

Ce n'est pas un plafond ordinaire. Mesure du 2026-08-30 :

- **213 issues ouvertes** — marge de 87.
- `gh issue list` rend **par recence de creation** (verifie : les 12 premieres rendues etaient exactement les 12 dernieres creees).

Donc une saturation n'ampute pas au hasard : elle ampute **la traine**. Ce que le plafond de 300 aurait fait tomber en premier, mesure :

| Issue | Creee | Sujet |
|---|---|---|
| #1028 | 2026-05-13 | EPIC Audiobook agentique — **mandat user recurrent** |
| #1203 | 2026-05-16 | EPIC MetaGeneticSharp fork |
| #1206 | 2026-05-16 | Epic Fork Z3.Linq |
| #1210 | 2026-05-16 | Epic semantic-fleet |
| #1453 | 2026-05-23 | EPIC Prover harness co-evolution |
| #1454 | 2026-05-23 | EPIC Training & Post-Training |

C'est-a-dire **exactement la population que la ponderation age + delaissement existe pour atteindre**. Le plafond ne bornait pas l'instrument, il le retournait — et sans rien dire.

Le declencheur est concret : le user vient d'arbitrer (2026-08-30) que toutes les issues issues d'un digest soient deposees plutot que filtrees a la source, « avec les nouvelles gardes elles seront grignotees a leur rythme ». Dix l'ont ete dans la foulee. La marge de 87 est un delai, pas une securite.

## Le correctif

1. `POOL_FETCH_LIMIT = 2000` (etait `"300"` en dur dans l'appel).
2. **Garde de saturation** : `len(raw) >= POOL_FETCH_LIMIT` est la signature de la troncature — on a recu exactement ce qu'on a demande. Le tirage **se poursuit** (bloquer la lane serait pire que la biaiser, R4 « jamais sanctionner l'idle ») mais il **le dit** sur stderr, parce que le seul risque reel est de lire un tirage tronque comme une couverture du pool.

**C'est la garde qui est durable, pas le 2000.** Aucun plafond ne se choisit une fois pour toutes ; celui-la se fait franchir en silence par construction, et c'est ca qu'on corrige.

## Controles (2026-08-30, pool reel de 213)

| Controle | Plafond | Rendues | Garde |
|---|---|---|---|
| **Positif** | 50 | 50 | **declenchee** |
| **Negatif** | 2000 | 213 | silencieuse |

Le controle positif est le seul qui prouve quelque chose : une garde qu'on n'a jamais vue rougir n'est pas une garde, c'est une intention.

## Couverture mesuree apres correctif

213 issues, **zero a poids nul** — aucune n'est structurellement inatteignable. Ratio lourd/leger **22.7x** : doux, pas une falaise.

| Population | Part du poids | Rangs |
|---|---|---|
| Les 6 vieux EPICs ci-dessus | **8.3 %** | 4–21 sur 213 |
| Les 10 issues deposees le 2026-08-30 | **1.6 %** | 118–178 sur 213 |

Les neuves entrent **derriere** les delaissees et remontent avec l'age. Deposer n'ecrase pas la traine — ce qui est precisement la condition sous laquelle l'arbitrage « depose tout » tient.

## Portee de la mesure — ce qu'elle ne dit pas

Les chiffres ci-dessus sont ceux du pool **du 2026-08-30 a 213 ouvertes**, `prev_genre=None`, sans donnees de saturation de serie chargees. Le ratio 22.7x et les parts se deplaceront avec le pool ; ce qui ne se deplace pas est le **zero a poids nul**, qui tient a la forme de `weight()` (tous les facteurs multiplicatifs et strictement positifs), pas a l'instantane.

## Grain

`MED/tooling` — genre META, donc **cette PR ne tient pas le plancher G-VAR-1** de ma lane, et je le dis plutot que de le tagger autrement. La dette de contenu de la lane reste due.

See #13420
