### PR TITLE
feat(semanticweb,#13410): densite SW-9-Python 593 -> 1455 — 18 interpretations ancrees

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
@@ -34,7 +34,7 @@
     "- Python 3.10+\n",
     "- Notebook [SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb) (bases rdflib, SPARQL et SHACL)\n",
     "\n",
-    "---"
+    "***"
    ]
   },
   {
@@ -93,7 +93,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Pourquoi JSON-LD ? Le pont entre JSON et le Linked Data\n",
     "\n",
@@ -220,7 +220,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Syntaxe fondamentale de JSON-LD\n",
     "\n",
@@ -355,6 +355,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-context-variants",
+   "metadata": {},
+   "source": [
+    "### Interpretation : les trois facons de poser un `@context`\n",
+    "\n",
+    "La sortie ci-dessus montre trois documents qui disent tous la meme chose sur **Alan Turing** -- et qui ne signifient rien tant que le `@context` n'a pas tranche.\n",
+    "\n",
+    "- **Contexte distant** : la chaine `\"https://schema.org/\"` delegue tout le travail de traduction. Les termes `@type` et `name` ne sont des proprietes RDF que parce que le processeur va resoudre ce prefixe. C'est la forme la plus courte a ecrire et la plus dependante du reseau : deux traitements successifs peuvent differer si le vocabulaire distant evolue.\n",
+    "- **Contexte local** : l'objet remplace la delegation par des **mappings explicites** -- `name` pointe vers `http://xmlns.com/foaf/0.1/name` (le vocabulaire FOAF, pas Schema.org). Le document devient autonyme : sa semantique ne depend plus d'une resolution distante. Notez la structure emboitee de `homepage` : un objet avec `@id` (l'URI de la propriete) et `@type: \"@id\"` (la contrainte que la valeur sera traitee comme un URI, pas comme une chaine littérale). Sans cette contrainte, `https://en.wikipedia.org/wiki/Alan_Turing` resterait un simple texte.\n",
+    "- **Contexte combine** : un **tableau** qui melange la delegation distante et un mapping local (`foaf` vers `http://xmlns.com/0.1/`). C'est le compromis pratiqu� dans les vraies pages : on herite du socle Schema.org tout en important des vocabulaires complementaires.\n",
+    "\n",
+    "La lecon structurante : en JSON classique, `name` n'est qu'une cle parmi d'autres ; en JSON-LD, **aucune cle n'a de sens hors de son contexte**. Deux documents aux corps identiques mais aux contextes differents decrivent des ressources differentes -- c'est exactement la symetrie inverse du monde RDF, ou l'URI fait tout le travail et la syntaxe n'est qu'un habit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section2-id-type",
    "metadata": {
     "papermill": {
@@ -448,6 +464,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-id-type-triples",
+   "metadata": {},
+   "source": [
+    "### Interpretation : ce que `@id` et `@type` changent dans les triples\n",
+    "\n",
+    "La sortie superpose les deux etages : le document JSON-LD en entree, puis sa projection en **triples RDF**. La comparaison ligne a ligne est la demonstration cherchee.\n",
+    "\n",
+    "- **Sans `@id`** (section precedente), la personne decrite etait un blank node anonyme : personne ne pouvait la referencer de l'exterieur. Avec `\"@id\": \"https://example.org/people/turing\"`, la ligne `<https://example.org/people/turing> schema:name \"Alan Turing\"` -- le sujet est desormais une URI dereferencable. Deux documents posant le meme `@id` parlent de la **meme** ressource : c'est le mecanisme par lequel le Linked Data agrège des sources disparates.\n",
+    "- **`@type` devient `rdf:type`** : `schema:Person` n'est plus une etiquette decorative mais le triple `<...turing> rdf:type schema:Person`, interrog� par le motif SPARQL `?s a schema:Person`.\n",
+    "- **La valeur emboitee devient un blank node** : `birthPlace` ne peut pas etre un littéral (une place est une entite avec ses propres proprietes), et la sortie le materialise -- le triple `schema:birthPlace _:b0` pointe vers un noeud anonyme, lui-meme type `schema:Place` et nomme `\"London\"`. Le prefixe `_:b0` est l'artefact de serialisation : le document JSON disait \"London\" en propres mots, le graphe RDF dit \"un noeud anonyme que voici\".\n",
+    "- **Le littéral date reste nu** : `\"1912-06-23\"` devient le triple `schema:birthDate \"1912-06-23\"` -- sans type explicite, la date est une chaine. On verra en section 4 la forme `{\"@value\": ..., \"@type\": ...}` qui la datera reellement en `xsd:date`.\n",
+    "\n",
+    "Six lignes de sortie pour quatre proprietes JSON : le cout de la projection RDF est visible, et il est le prix de l'interoperabilite."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section2-graph",
    "metadata": {
     "papermill": {
@@ -527,6 +560,26 @@
     "print(f\"Document contenant {len(multi_entities['@graph'])} entites :\")\n",
     "for entity in multi_entities[\"@graph\"]:\n",
     "    print(f\"  - {entity['@type']} : {entity['name']} ({entity['@id']})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-graph-multientities",
+   "metadata": {},
+   "source": [
+    "### Interpretation : `@graph`, ou comment un seul document porte un mini-web\n",
+    "\n",
+    "La sortie resume le document en **trois entites** : deux `Person` (`Alan Turing` a `https://example.org/people/turing`, `Ada Lovelace` a `https://example.org/people/lovelace`) et une `CollegeOrUniversity` (`University of Cambridge` a `https://example.org/org/cambridge`).\n",
+    "\n",
+    "Sans `@graph`, un objet JSON-LD de haut niveau decrit **une** ressource principale -- les autres n'existent qu'en tant que valeurs emboitees de ses proprietes, donc comme blank nodes. Avec `@graph`, les trois entites sont **co-premieres** : chacune a son `@id` directement referencable, aucune n'est la propriete d'une autre. C'est la difference entre \"une fiche centrale et ses annexes\" et \"un corpus de fiches liees\".\n",
+    "\n",
+    "Concretement :\n",
+    "\n",
+    "- c'est la forme naturelle d'un **export de base de connaissances** -- l'ensemble des fiches d'un systeme, pas une fiche choisie comme racine ;\n",
+    "- les liens entre entites du graphe (`knows`, `alumniOf`, `worksFor`) relient des `@id` **internes au document**, donc restent dereferencables sans sortir du fichier ;\n",
+    "- c'est aussi ce que produit la forme **aplatie** (section 2.4) : quand on aplatit un document emboite, les blank nodes reçoivent des identifiants et migrent dans le `@graph` -- la structure arborescente de JSON se dissout au profit de la structure de graphe de RDF.\n",
+    "\n",
+    "Retenez le tandem : `@graph` pour le **conteneur**, `@id` pour la **reference**. Ensemble, ils font d'un fichier JSON isole le point de depart possible d'un web de donnees."
    ]
   },
   {
@@ -701,7 +754,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Le vocabulaire Schema.org\n",
     "\n",
@@ -816,6 +869,24 @@
     "print(\"=== Proprietes Schema.org courantes ===\")\n",
     "for label, uri in common_props:\n",
     "    print(f\"  {label:20s} -> {uri}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-schemaorg-namespace",
+   "metadata": {},
+   "source": [
+    "### Interpretation : le namespace Schema.org vu par rdflib\n",
+    "\n",
+    "La sortie aligne deux tables : a gauche les **types** (`Person`, `Organization`, `Product`, `Event`, `Article`, `Course`), a droite les **proprietes** (`name`, `description`, `url`, `author`, `datePublished`). Les fleches `->` montrent ce que rdflib fait silencieusement depuis le debut du notebook : chaque nom court est **l'abreviation d'une URI complete** (`Person` -> `https://schema.org/Person`).\n",
+    "\n",
+    "Trois remarques pour la suite :\n",
+    "\n",
+    "1. **Ceci n'est pas une enumeration**. Schema.org compte plusieurs centaines de types et plusieurs milliers de proprietes ; la sortie n'en montre que six et cinq, ceux que les notebooks de la serie emploient. L'exploration complete vit sur schema.org, et le namespace rdflib n'est qu'un acces de convenance aux plus courants.\n",
+    "2. **Types et proprietes vivent dans le meme namespace** -- contrairement a OWL ou T-Box et A-Box sont souvent separees. `https://schema.org/name` n'est pas `schema:nameClass` : Schema.org est un vocabulaire **pragmatique** (pense pour l'annotation de pages web), ou la classe et la propriete cohabitent sous la meme autorite d'URI.\n",
+    "3. **Le prefixe `schema:` n'a rien d'officiel** -- c'est une convention d'ecriture locale. On croise aussi `schema1:` (la section 5.3 en produira un automatiquement), qui designe **exactement le meme namespace** `http://schema.org/`. Ne confondez pas la variation de prefixe avec une variation de vocabulaire : en RDF, seul l'URI compte, jamais son raccourci.\n",
+    "\n",
+    "Cette table est le dictionnaire implicite de toutes les sections qui suivent : chaque `@type` et chaque propriete des documents Recipe, Event, Product se resoudra par ces URI."
    ]
   },
   {
@@ -975,7 +1046,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Créer du JSON-LD avec rdflib\n",
     "\n",
@@ -1146,6 +1217,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-graph-to-jsonld-extended",
+   "metadata": {},
+   "source": [
+    "### Interpretation approfondie : lire la forme etendue comme un graphe\n",
+    "\n",
+    "Au-dela de l'observation de la cellule precedente (rdflib genere le JSON-LD depuis le graphe), la sortie merite une lecture ligne a ligne, car la **forme etendue** deplace toutes les decisions sémantiques du contexte vers les donnees :\n",
+    "\n",
+    "- **Plus de `@context`** : les cles ne sont plus `name` ou `jobTitle` mais des URI complets (`\"https://schema.org/jobTitle\"`). Le document est autoporteur -- chaque predicat emporte sa propre signification -- au prix de la verbosite. C'est la forme qu'un processeur produit en interne apres resolution du contexte ; la forme compacte n'est qu'une compression de celle-ci.\n",
+    "- **Les valeurs deviennent des tableaux d'objets** : `\"https://schema.org/name\": [{\"@value\": \"Charles Babbage\"}]`. Cette structure apparemment lourde encode deux regularites de RDF : une propriete peut avoir **plusieurs valeurs** (le tableau), et chaque valeur peut etre **typée** (`{\"@value\": ..., \"@type\": \"http://www.w3.org/2001/XMLSchema#date\"}` pour la date de naissance d'`ada_lovelace` -- comparez au littéral nu `\"1912-06-23\"` de la section 2.2 : ici la date EST une date au sens des types XML Schema, pas une chaine qui lui ressemble).\n",
+    "- **`@type` est lui-meme un tableau** : `[ \"https://schema.org/Person\" ]` -- une ressource peut avoir plusieurs classes, et la forme etendue ne prerien decide pour vous.\n",
+    "- **Les 9 triples sont tous la** : `charles_babbage` avec son `jobTitle` \"Inventor\", `ada_lovelace` avec sa date typée -- la sortie du graphe (9 triples) se retrouve integrale, juste re-habillee.\n",
+    "\n",
+    "La forme etendue est celle des **echanges entre machines** ; la compacte, celle des **humains qui ecrivent**. La section 4.2 montre justement comment redemander la forme compacte avec son propre contexte."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section4-person-compact",
    "metadata": {
     "papermill": {
@@ -1253,6 +1341,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-compact-serialization",
+   "metadata": {},
+   "source": [
+    "### Interpretation : la serialisation compacte, ou le contexte reprend la main\n",
+    "\n",
+    "La sortie montre le meme graphe (Babbage, Lovelace) re-serialise en forme **compacte** -- et le contraste avec la forme etendue de la section precedente est instructif terme a terme :\n",
+    "\n",
+    "- **Le contexte reapparait en tete**, mais cette fois rdflib l'a **construit** a partir des contraintes passees a la serialisation : le mapping `ex` vers `https://example.org/people/`, les proprietes raccourcies (`\"jobTitle\": \"schema:jobTitle\"`), et pour `knows` la structure `{\"@id\": ..., \"@type\": \"@id\"}` -- exactement la forme qu'on ecrivait a la main pour `homepage` en section 2.1. La boucle est bouclee : ce que la section 2.1 posait comme entree manuelle, rdflib le regenere comme sortie.\n",
+    "- **Les URI complets ont disparu du corps** : `\"@id\": \"ex:charles_babbage\"` ou `\"@type\": \"schema:Person\"` -- le document redevient lisible, parce que la semantique est encore une fois externalisee dans le contexte.\n",
+    "- **La date typée survit au passage** : `\"birthDate\": {\"@type\": \"http://www.w3.org/2001/XMLSchema#date\", \"@value\": \"1815-12-10\"}` -- le compactage raccourcit les predicats, il ne degrade pas les valeurs. Un `xsd:date` entre, un `xsd:date` sort.\n",
+    "- **Le `@graph` structure la sortie** : les deux personnes y sont co-premieres, chacune avec son `@id` -- meme decision de presentation que la section 2.3.\n",
+    "\n",
+    "En pratique : la forme compacte **avec contexte maitrise** est celle qu'on embarque dans une page HTML (`<script type=\"application/ld+json\">`), parce qu'elle minimiser le poids et reste lisible ; la forme etendue est celle qu'on echange entre systemes qui ne partagent aucun contexte prevu. Choisir sa forme de serialisation, c'est choisir son public."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section5-title",
    "metadata": {
     "papermill": {
@@ -1265,7 +1370,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Parser du JSON-LD\n",
     "\n",
@@ -1371,6 +1476,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-parse-triples",
+   "metadata": {},
+   "source": [
+    "### Interpretation : ce que le parsing fait au document\n",
+    "\n",
+    "La sortie commence par un compte -- **11 triples charges** -- puis les enumere. Trois artefacts de la traduction meriteant d'etre nommes, car on les retrouvera dans tout document JSON-LD emboite :\n",
+    "\n",
+    "- **Les blank nodes rdflib** : `N009f42fb7e0f4b7a90776c90b528a2d3` (l'organisateur AFPy) et `N38aa90e3b7d045f394cacfce2316e23c` (le lieu Strasbourg) n'existaient pas comme entites nommees dans le document source -- ils y etaient des valeurs emboitees de `organizer` et `location`. Le parseur leur a attribue des identifiants internes (prefixes `N`, Pour node). Ces identifiants **ne sont pas stables** d'un parsing a l'autre : ce sont des poignees locales, pas des URI. Si vous avez besoin de referencer l'organisateur durablement, donnez-lui un `@id` dans le document source.\n",
+    "- **Les dates passent nues** : `startDate 2025-10-23` et `endDate 2025-10-26` apparaissent sans type -- le document source les posait comme chaines. Meme remarque qu'en section 2.2 : la valeur ressemble a une date, le graphe n'en sait rien.\n",
+    "- **Le compte compte les noeuds, pas les entites** : le document decrit **une** conference (`ex:pycon2025`, correctement identifiee cette fois par son `@id`), mais ses 11 triples recouvrent aussi le type, le nom et les liens des deux blank nodes. \"Combien d'entites ?\" et \"combien de triples ?\" sont deux questions differentes -- la seconde est la seule que RDF reponde nativement.\n",
+    "\n",
+    "Ce graphe `g2` est celui que les trois sections suivantes vont exploiter : l'interroger en SPARQL (5.2), le re-serialiser en Turtle (5.3), le faire voyager en boucle (5.4)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section5-sparql",
    "metadata": {
     "papermill": {
@@ -1455,6 +1576,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-sparql-on-jsonld",
+   "metadata": {},
+   "source": [
+    "### Interpretation : SPARQL ne sait pas d'ou viennent les triples\n",
+    "\n",
+    "Le resultat se presente en tableau : trois lignes, une par entite retournée. La force de la demonstration est dans ce qu'elle ne montre pas : **la requete n'a aucune connaissance du JSON-LD**.\n",
+    "\n",
+    "- Les trois lignes sont l'**organisateur** (`AFPy`, type `http://schema.org/Organization`, pas de date de debut), **l'evenement** (`PyCon France 2025`, type `http://schema.org/Event`, demarre le `2025-10-23`) et **le lieu** (`Strasbourg`, type `http://schema.org/Place`). Trois types differents, une seule requete : le motif `?nom ?type ?date` avec `OPTIONAL` pour la date -- les blank nodes AFPy et Strasbourg repondent au meme titre que la conference identifiee, parce qu'en RDF **un noeud est un noeud**, anonyme ou non.\n",
+    "- La colonne **Date debut** est vide pour deux lignes sur trois : c'est l'`OPTIONAL` qui travaille. Sans lui, la jointure aurait elimine AFPy et Strasbourg du resultat -- une organisation n'a pas de `startDate`. Le tableau est la pour rappeler que l'absence de valeur en RDF est une information, pas un bug.\n",
+    "- La date `2025-10-23` arrive **comme littéral nu** (la chaine du document source) -- on la triera lexicographiquement, pas chronologiquement, tant qu'elle n'est pas typée `xsd:date`. Piege classique des requetes SPARQL sur donnees Schema.org naivement ecrites.\n",
+    "\n",
+    "L'operation qui vient d'avoir lieu est le coeur du notebook : JSON ecrit par un humain, parse en graphe, interrogé par un langage de requetes concu pour RDF. **Aucune etape n'a ete specific a JSON-LD** : le meme SPARQL s'appliquerait a un graphe charge depuis Turtle, RDF/XML ou N-Triples. La syntaxe est interchangeable, le graphe est canonical."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section5-convert",
    "metadata": {
     "papermill": {
@@ -1519,6 +1656,23 @@
     "turtle_output = g2.serialize(format=\"turtle\")\n",
     "print(\"=== Conversion JSON-LD -> Turtle ===\")\n",
     "print(turtle_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-turtle-conversion",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Turtle, la forme ou le graphe respire\n",
+    "\n",
+    "La sortie re-ecrit le meme contenu en Turtle, et la comparaison avec le JSON-LD de la section precedente est une lecon de typographie des donnees :\n",
+    "\n",
+    "- **Le prefixe a change de nom** : `schema1:` au lieu de `schema:`. Rdflib genere ce suffixe numeral pour eviter une collision dans la table des prefixes de la session -- et il designe le meme namespace `http://schema.org/`. Rappel de la section 3.1 : le prefixe est un raccourci d'ecriture local, jamais une identite.\n",
+    "- **Les dates sont typées dans cette forme** : `\"2025-10-26\"^^schema1:Date` -- la syntaxe `^^` de Turtle marque le littéral type, equivalent exact du `{\"@value\": ..., \"@type\": ...}` de JSON-LD ou du `\"...\"^^xsd:date` de N-Triples. Notez que le type produit ici est `schema1:Date` (le type Schema.org) et non `xsd:date` -- deux mondes types cohabitent dans le wild, et une requete qui filtre sur `xsd:date` ne attrapera pas les dates Schema.org.\n",
+    "- **L'emboitement visuel suit le graphe** : le bloc `schema1:location [ a schema1:Place ; ... ]` -- les crochets `[ ]` sont le blank node, le point-virgule `;` enchaene les predicats d'un meme sujet, ce qui evite de repeter l'URI du sujet. La structure arborescente de Turtle n'est **qu'un confort d'ecriture** : derriere, le graphe est le meme sac de triples que le JSON-LD etale.\n",
+    "- **Le nom et l'adresse du lieu voyagent ensemble** : `schema1:address \"Palais de la Musique et des Congres\"` -- adresse posee comme simple chaine ici, alors qu'un adressage complet Schema.org serait un `PostalAddress` type. Le document source a choisi le simple ; Turtle le transmet tel quel, sans juger.\n",
+    "\n",
+    "Turtle est la forme de predilection des ontologistes (les exemples des specs W3C sont en Turtle) ; JSON-LD celle des developpeurs web. La section suivante verifie qu'aller-retour entre les deux ne perd rien."
    ]
   },
   {
@@ -1712,7 +1866,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Cas d'usage web pratiques\n",
     "\n",
@@ -1736,6 +1890,23 @@
     "### 6.1 Recipe (Recette de cuisine)\n",
     "\n",
     "Le schema `Recipe` est l'un des plus utilises. Il permet a Google d'afficher des cartes de recettes avec image, temps de preparation et notes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-roundtrip-deep",
+   "metadata": {},
+   "source": [
+    "### Interpretation approfondie : ce que le round-trip ne dit pas\n",
+    "\n",
+    "La conservation **11 -> 11 -> 11** est la verification minimale, et il faut lire precisement ce qu'elle garantit et ce qu'elle ne garantit pas :\n",
+    "\n",
+    "- **Les triples sont conserves, pas les identifiants de blank nodes** : la sortie finale montre `\"@id\": \"_:n66ba6585385f4813a64639e26d1f38c5b1\"` pour le lieu -- un nouvel identifiant, different du `N38aa90e3...` du parsing initial (section 5.1). C'est **conforme** : les identifiants de blank nodes sont locaux a une serialisation, jamais des donnees. Un round-trip qui re-serialise deux fois peut produire deux prefixes differents pour le meme noeud -- c'est pourquoi les tests de round-trip comparent des **graphes** (isomorphisme de graphe), jamais des textes.\n",
+    "- **Les types migrent vers Schema.org** : la date finale porte `\"@type\": \"http://schema.org/Date\"` -- en sortie de Turtle c'etait `schema1:Date` (section 5.3), en sortie JSON-LD c'est l'URI complete. Meme type, trois ecritures : la lecon du prefixe local, encore.\n",
+    "- **Ce qui N'EST PAS teste** : l'ordre des ingredients (`@list`, exercice 5) ne survit pas toujours a un round-trip -- un tableau multi-value re-serialise peut perdre son ordre si le document source ne le marque pas explicitement. La conservation des triples n'implique pas la conservation des **constructions syntaxiques** qui les ont produits.\n",
+    "- **Pourquoi c'est suffisant** : RDF definit l'egalite semantique comme l'egalite des graphes de triples. Le round-tright 11=11 temoigne que les trois etapes (parse JSON-LD, serialise Turtle, re-parse) parlent bien du **meme graphe** -- l'interchangeabilite des serialisations n'est pas un slogan, c'est une propriete testable, que cette cellule vient de tester.\n",
+    "\n",
+    "Retenez la methode plus que le resultat : comparer des comptes de triples a chaque etape est le reflexe de debug le plus utile du web semantique -- la ou une difference de compte signale aussitot une perte de donnees."
    ]
   },
   {
@@ -1891,6 +2062,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-recipe-usecase",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Recipe, ou la precision des durees ISO 8601\n",
+    "\n",
+    "La sortie depose le document Schema.org complet de la `Ratatouille Provencale`. Ce qui la rend interessante n'est pas la recette mais ses **conventions de valeurs** :\n",
+    "\n",
+    "- **Les durees ne sont pas des textes** : `prepTime: PT30M`, `cookTime: PT45M`, `totalTime: PT1H15M`. C'est la syntaxe **ISO 8601 des durees** (`P` = periode, `T` = partie temps, `M` = minutes, `H` = heures). L'avantage sur \"30 minutes\" : elle est **non ambiguë et machine-traitable** -- un moteur de recherche peut calculer que 30 + 45 = 75 minutes = 1H15 et verifier la coherence des trois champs. Une recette dont le `totalTime` contredit la somme serait signalee.\n",
+    "- **`recipeYield: \"4 portions\"`** : le rendement reste un littéral libre -- Schema.org accepterait aussi une `QuantitativeValue` structuree, mais le texte simple est le choix le plus courant dans le wild.\n",
+    "- **Les metadonnees editorialisent deja** : `datePublished: \"2024-06-15\"`, un `author` type `Person` (\"Chef Marie\") emboite -- exactement le motif blank-node de la section 2.2. Une page de recette qui embarque ce bloc dans son HTML offre aux moteurs : temps total, categorie (\"Plat principal\"), cuisine (\"Francaise\"), ingredients en liste exploitable (`recipeIngredient`).\n",
+    "- **`recipeIngredient` est un tableau de chaines** -- chaque element est un ingredient complet (\"2 aubergines\"), pas un couple quantite/produit structure. Pour une exploitation quantitative (comparer les prix, adapter les proportions), il faudra re-parser ces chaines : Schema.org optimise l'affichage riche, pas le calcul.\n",
+    "\n",
+    "C'est le premier contact avec la logique des **rich results** : le document n'est pas ecrit pour etre lu par un humain (la page HTML le fait), mais pour etre compris par un moteur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section6-event",
    "metadata": {
     "papermill": {
@@ -2009,6 +2197,23 @@
     "\n",
     "print(\"=== Schema.org Event ===\")\n",
     "print(json.dumps(event, indent=2, ensure_ascii=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-event-usecase",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Event, la geographie et le mode de presence\n",
+    "\n",
+    "Le document de la `Conference Web Semantique 2025` ajoute au pattern Recipe trois decisions de modelisation specifiques aux evenements :\n",
+    "\n",
+    "- **Les horodatages portent leur fuseau** : `startDate: \"2025-11-15T09:00:00+01:00\"` -- date **et** heure, avec offset UTC+01:00. A comparer au `2025-10-23` nu de PyCon France en section 5.1 : deux conventions cohabitent dans le wild, et une application qui doit ordonner chronologiquement des evenements rencontres les deux. ISO 8601 encore : `T` separe date et heure, `+01:00` l'offset. Un evenement a cheval sur un changement d'heure d'ete exige cette precision -- sans offset, \"09:00\" est indecidable entre deux instants differents.\n",
+    "- **`eventAttendanceMode`** : `https://schema.org/MixedEventAttendanceMode` -- une **URI complete comme valeur d'enumeration**, pas une chaine. Schema.org definit trois modes (`Offline`, `Online`, `Mixed`) comme individus du vocabulaire, pas comme etiquettes. La valeur est donc elle-meme une ressource RDF dereferencable : un moteur peut \"savoir\" que Mixed subsume Offline et Online en consultant la hierarchie du vocabulaire.\n",
+    "- **`eventStatus`** : `https://schema.org/EventScheduled` -- meme mecanique, avec la famille des statuts (`EventScheduled`, `EventPostponed`, `EventCancelled`, `EventRescheduled`, `EventMovedOnline`). C'est ce champ qu'un moteur interroge pour retirer une conference annulee des resultats sans re-crawler la page de details.\n",
+    "- **L'adresse est doublement emboitee** : `location` est un `Place` (\"Amphitheatre Gaston Berger\") dont l'`address` est elle-meme un objet -- le motif blank-node seen en 2.2, recursif.\n",
+    "\n",
+    "Avec BreadcrumbList et FAQPage (section suivante), Event complete le trio des schemas qui dominent l'annotation web concrete."
    ]
   },
   {
@@ -2150,6 +2355,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-breadcrumb-faq",
+   "metadata": {},
+   "source": [
+    "### Interpretation : BreadcrumbList et FAQPage, les deux piliers discrets\n",
+    "\n",
+    "La sortie imprime les deux structures en forme lisible :\n",
+    "\n",
+    "**BreadcrumbList** -- le fil d'Ariane a trois niveaux : `Accueil` (`https://example.org/`), `Cours IA` (`https://example.org/cours-ia/`), `Web Semantique` (`https://example.org/cours-ia/semantic-web/`). Deux choses a noter :\n",
+    "\n",
+    "- Le schema n'est **pas une liste plate mais une chaine ordonnee d'objets `ListItem`**, chacun avec sa `position` (1, 2, 3) -- l'ordre est une donnee explicite, pas un effet de presentation. Un moteur peut afficher le chemin **dans la page de resultats** au-dessus du titre (les \"rich snippets\" de navigation), et la position typee evite toute ambiguite si le tableau etait reordonne.\n",
+    "- Chaque item porte a la fois un `name` et une URL : le fil d'Ariane est aussi un **plan de site local**, exploitable par les crawlers independamment de l'affichage.\n",
+    "\n",
+    "**FAQPage** -- les trois questions affichees (\"Qu'est-ce que JSON-LD ?\", \"Pourquoi utiliser Schema.org ?\", \"JSON-LD remplace-t-il Turtle ou RDF/XML ?\") suivent le meme principe : des objets `Question` contenant des `Answer`, structures et non du texte libre. L'enjeu est double :\n",
+    "\n",
+    "- **Extension conversationnelle** : les assistants et moteurs indexent les paires question/reponse pour repondre directement -- la FAQ bien balisee est ce qui remonte dans les encarts \"questions assocées\".\n",
+    "- La troisieme reponse de la sortie merite lecture : elle rappelle que JSON-LD est **une serialisation de RDF parmi d'autres** -- exactement la demonstration des sections 5.3-5.4. Le contenu pedagogique et l'annotation marchent ici du meme pas.\n",
+    "\n",
+    "Ces deux schemas ne decrivent rien de \"vrai\" dans le monde (aucune recette, aucun evenement) : ils decrivent **la page elle-meme** et son usage -- le tour hermeneutique du web semantique applique a sa propre interface."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "interpretation-usecases",
    "metadata": {
     "papermill": {
@@ -2196,7 +2423,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. JSON-LD vs autres formats RDF\n",
     "\n",
@@ -2371,7 +2598,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Chargement du fichier produit dans rdflib\n",
     "\n",
@@ -2512,6 +2739,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-product-load",
+   "metadata": {},
+   "source": [
+    "### Interpretation : le fichier produit, passe au crible\n",
+    "\n",
+    "La sortie resume le chargement de `data/product.jsonld` : **24 triples**, puis la liste des proprietes du produit. C'est l'occasion de relire tout le notebook dans un artefact unique :\n",
+    "\n",
+    "- **`teaches` est multi-value** : `RDF et triples`, `SPARQL queries`, `OWLOntologies`... non -- la sortie liste `OWLOntologies` verifie : `RDF et triples`, `SPARQL queries`, `OWL ontologies`, `SHACL validation`. Quatre valeurs pour une meme propriete : en JSON-LD source, c'est un tableau ; dans le graphe, ce sont quatre triples independants de meme predicat ; dans une requete SPARQL, quatre lignes de resultat. La propriete multi-valuee est le passage le moins intuitif pour un developpeur venu du relationnel (ou une colonne tient une valeur) -- RDF n'a pas de cardinalite par defaut.\n",
+    "- **`educationalLevel: University`** : un litteral simple pour un attribut qui pourrait etre une ressource typee -- meme arbitrige de simplicite que `recipeYield` en section 6.1. Schema.org laisse souvent le choix entre chaine et structure ; le wild penche pour la chaine.\n",
+    "- **`image` pointe vers une URI** (`https://example.org/images/semantic-web-course.png`) : la propriete relie le produit a une ressource dereferencable -- le pont vers un futur `ImageObject` avec ses propres metadonnees (licence, dimensions) si l'application en a besoin.\n",
+    "- **24 triples pour une \"fiche produit\"** : l'ordre de grandeur est instructif. Un document JSON-LD d'apparence anodine projette systematiquement plus de triples que son nombre de champs JSON, parce que chaque valeur emboitee (organisation, offre, review) devient son propre sous-graphe de blank nodes.\n",
+    "\n",
+    "Ce graphe `g_product` est la matiere premiere de l'exercice 3 du notebook SW-10 -- le chargement n'est jamais une fin."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "interpretation-product-rdflib",
    "metadata": {
     "papermill": {
@@ -2548,7 +2792,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exemples et Exercices\n",
     "\n",
@@ -2666,6 +2910,23 @@
     "print(f\"\\nTriples : {len(g_ex1)}\")\n",
     "for s, p, o in g_ex1:\n",
     "    print(f\"  {s} {p} {o}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-guided-person",
+   "metadata": {},
+   "source": [
+    "### Interpretation de l'exemple : ce que l'exercice 1 enrichit\n",
+    "\n",
+    "La sortie de cet exemple guide (avant ses variantes a completer) montre le document JSON-LD d'une personne (`Jules Lange`) suivi de sa projection en **13 triples** -- et la projection est l'endroit ou les choix de modelisation deviennent lisibles :\n",
+    "\n",
+    "- **`worksFor` et `alumniOf` deviennent des blank nodes** : dans le document, EPITA et \"EPITA Paris\" sont des objets emboites ; dans les triples, ce sont des noeuds `N2a4cfd...` et `N702a47...`, chacune avec son `rdf:type` (`Organization`, `CollegeOrUniversity`) et son `name`. Le motif maintenant familier de la section 2.2 -- l'emboitement JSON devient anonymat RDF.\n",
+    "- **Deux `sameAs` pour deux lignes** : `https://twitter.com/jlange` et `https://linkedin.com/in/jules-lange` -- la propriete multi-valuee de la section precedente, cette fois vers des URI **externes** au document. `sameAs` est le ciment du Linked Data : il affirme que le noeud decrit ici et les profils distants designent la meme personne. C'est ainsi que les moteurs reconcilient les identites distribuees.\n",
+    "- **`email` et `telephone` restent des litteraux nus** -- valeurs de contact non structurees, exploitables pour l'affichage pas pour la validation.\n",
+    "- **Le compte (13) recouvre les valeurs emboitees** : les deux organisations anonymes contribuent chacune 2-3 triples. Comme en section 5.1 : le nombre de triples mesure la richesse du graphe, pas le nombre de champs visibles.\n",
+    "\n",
+    "L'exercice 1 vous demande le meme document pour une organisation ; l'exemple guide 5 (section suivante) en propose une solution -- comparez le traitement des employes (des `Person` avec `@id` ou des blank nodes ?) : c'est exactement le genre d'arbitrage que cet exemple met en evidence."
    ]
   },
   {
@@ -2815,6 +3076,21 @@
     "- Informations nutritionnelles\n",
     "\n",
     "Le JSON-LD est charge dans rdflib, puis interroge avec SPARQL pour extraire les ingredients."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-guided-turtle2jsonld",
+   "metadata": {},
+   "source": [
+    "### Interpretation de l'exemple : la conversion inverse, lisible ligne a ligne\n",
+    "\n",
+    "La sortie de cet exemple guide est une **forme etendue** -- et elle illustre pourquoi le Turtle d'entree (le `@prefix schema:` de la cellule precedente) est si economique a l'usage :\n",
+    "\n",
+    "- **`book1` et son auteur sont des URI nommees** : `\"@id\": \"https://example.org/book1\"` et l'auteur pointe vers `\"@id\": \"https://example.org/saint-exupery\"` -- le Turtle source avait fait le choix de **nommer** l'auteur (une URI dediee) plutot que de l'emboiter comme blank node. La conversion le respecte : l'auteur reste une reference, pas un objet inline. C'est un arbitrage de modelisation qui se **transpose intact** d'une syntaxe a l'autre -- preuve supplementaire que la syntaxe ne decide rien, seul le graphe compte.\n",
+    "- **`datePublished: \"1943\"` reste un littéral** -- meme pas une date ISO complete, juste l'annee. RDF ne juge pas : la valeur est ce que la source disait. Une requete qui filtre `>= \"1940-01-01\"` echouera sur \"1943\" (comparaison lexicale avec un litteral non type) -- piege recurrent sur les donnees bibliographiques reelles, ou les dates sont notoirement inconsistantes.\n",
+    "- **`inLanguage: \"fr\"`** : le code de langue ISO 639-1, litteral simple -- la ou JSON-LD natif offrirait `{\"@value\": \"fr\", \"@language\": \"fr\"}`. La distinction est subtile mais reelle : la **propriete** `inLanguage` (Schema.org) decrit la ressource ; la **direction** `@language` (JSON-LD) decrit le littéral. Deux niveaux qui se recouvrent sans se confondre.\n",
+    "- **Les proprietes en forme etendue sont des URI complets** (`\"https://schema.org/author\"`) -- la demonstration visuelle de la section 4.1, appliquee a un cas litteraire."
    ]
   },
   {
@@ -2994,6 +3270,21 @@
     "- Des `performer` (Person avec `affiliation`)\n",
     "\n",
     "Une conference complete avec 2 sessions et 3 intervenants, convertie en forme expanded avec verification des triples RDF generes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-guided-recipe",
+   "metadata": {},
+   "source": [
+    "### Interpretation de l'exemple : la Tartiflette, 31 triples et une liste\n",
+    "\n",
+    "La sortie superpose le document, son compte (**31 triples** -- a comparer aux 13 de la personne en exemple 1 : une recette avec six ingredients et un auteur emboite produit plus de graphe qu'une fiche personne) et l'extraction des ingredients. Trois observations :\n",
+    "\n",
+    "- **`author` est ici un blank node** (`Person` \"Jules Lange\" emboite, sans `@id`) -- alors que l'exemple guide 5 (personne) nommait ses organisations en blank nodes mais l'individu en URI. Deux styles cohabitent dans le meme notebook : c'est realiste, le wild est heterogene. La question a se poser devant chaque document : **qui merite un `@id` ?** Regle pratique : ce que d'autres documents voudront referencer (l'auteur publie ailleurs) gagne a etre nomme ; ce qui n'existe que dans cette fiche (la recette elle-meme, ici) peut rester anonyme ou non selon l'usage prevu.\n",
+    "- **Les six ingredients extraits** : `1 kg de pommes de terre`, `1 reblochon entier`, `200 g de lardons fumes`, `2 oignons jaunes`, `20 cl de creme fraiche`, `1 verre de vin blanc sec` -- des chaines libres, dont la structure (quantite, unite, produit) est lisible par un humain mais pas par une machine sans re-parsing. C'est le choix Schema.org standard, deja commente en 6.1 -- et sa limite : adapter la recette a 6 personnes exige de comprendre \"1 kg\", pas juste de le multiplier.\n",
+    "- **Les durees ISO 8601 encore** : `PT20M` / `PT40M` / `PT1H` -- 20 + 40 = 60 minutes = 1H, la coherence des trois champs se verifie mecaniquement. Notez que `PT1H` (forme heures seules) est valide -- ISO 8601 autorise l'elision des minutes nulles.\n",
+    "- **`recipeYield: \"4 portions\"`** identique a la Ratatouille de 6.1 -- le champ libre rendement, meme arbitrage de simplicite."
    ]
   },
   {
@@ -3401,7 +3692,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exemples guides (solutions proposees par @Sosolalt)\n",
     "\n",
@@ -3426,6 +3717,23 @@
     "### Exemple guide 5 : Schema.org Organization en JSON-LD\n",
     "\n",
     "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-guided-conference",
+   "metadata": {},
+   "source": [
+    "### Interpretation de l'exemple : la conference et ses sub-events\n",
+    "\n",
+    "La sortie montre les deux formes du meme document -- compacte en entree, etendue en sortie -- et le couple merite une lecture croisee :\n",
+    "\n",
+    "- **`subEvent` est un tableau d'evenements** (`Session - Logiques non monotones`, etc., chacune avec ses propres horaires `2026-06-15T09:00`) : la propriete multi-valuee encore, cette fois pour une **decomposition temporelle** -- le symposium est la somme de ses sessions. Les moteurs peuvent ainsi presenter l'evenement parent ET son agenda detaille. La recursion est licite : un `subEvent` peut lui-meme avoir des `subEvent` (une conference dans un salon dans une ville).\n",
+    "- **`location` emboite une adresse textuelle** : `\"14-16 rue Voltaire, 94270 Le Kremlin-Bicetre\"` -- une chaine unique la ou Schema.org offerait un `PostalAddress` structure (rue, code postal, ville separement). Meme arbitrage qu'en 5.3 : le texte simple suffit a l'affichage, pas au geocodage precis. Une application cartographique devra passer par un service de geocodage -- ou exigera des donnees mieux structurees.\n",
+    "- **`Conference` vs `Event`** : le document type le parent `Conference` et les enfants `Event`. Schema.org definit `Conference` comme sous-classe d'`Event` -- la hierarchie du vocabulaire permet la precision croissante sans casser les requetes generiques : `?s a schema:Event` attrape les deux.\n",
+    "- **La forme etendue en sortie re-liste tout** : `\"@id\": \"https://example.org/conf/symbolicai2026\"` avec `http://schema.org/endDate` typé `schema:Date` (`\"2026-06-17\"`) -- et le lieu devenu blank node `_:N0e240f...` en reference inline. La comparaison compact/etendu sur CE document concret donne la paire de formes la plus didactique du notebook : deux ecritures, un graphe.\n",
+    "\n",
+    "Ce dernier exemple guide boucle la serie des patrons : `@id` nomme, blank node pour l'emboite, multi-value pour les collections, types hierarchiques pour la precision -- tous les arbitrages de modelisation de la journee, dans un seul document."
    ]
   },
   {
@@ -4409,7 +4717,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercices a completer\n",
     "\n",
@@ -4933,7 +5241,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Resume\n",
     "\n",
@@ -4984,11 +5292,11 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "Le notebook suivant explore RDF 1.2 (RDF-Star), une extension majeure de RDF permettant de faire des assertions sur des assertions.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [<< 8-Python-SHACL](SW-8-Python-SHACL.ipynb) | [Index](README.md) | [10-Python-RDFStar >>](SW-10-Python-RDFStar.ipynb)"
    ]

--- a/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml
@@ -27,6 +27,13 @@
       csharp_sha: d61ac744c1807390a7625d78dd533ffa0511eea3
       content_python_sha: 0f6206639ecbb79a2c4dd7411309972e7e73545f9a7469f54b6a48efbc513ee9
       content_csharp_sha: 176272347fcfa9a9a2bc7c1a1a0fb3944e59bdb045faa1141c0a7b62c8ec6bc9
+    - date: "2026-08-30"
+      by: myia-po-2026:CoursIA
+      python_sha: da3142efa2d665de3f50baf1c96b0f33f3eceeda
+      csharp_sha: d61ac744c1807390a7625d78dd533ffa0511eea3
+      content_python_sha: 988c346b165ddef55e1cd0e7a5f55655d4403abb7fef9fc3dbf359387f2b5f1d
+      content_csharp_sha: 176272347fcfa9a9a2bc7c1a1a0fb3944e59bdb045faa1141c0a7b62c8ec6bc9
   known_differences:
+    - "2026-08-30 : PR #13577 (tranche densite #13410) -- 18 cellules d interpretation markdown ancrees ajoutees cote Python uniquement (593 -> 1455 c/cellule). Le jumeau C# reste a 1070 (lui aussi sous le plancher 1200, a enrichir dans une tranche dediee). Asymetrie PROSE pure : code/outputs byte-identiques des deux cotes, la parite native-both (moteurs rdflib/dotNetRDF sur les memes donnees) est intacte."
     - "Socle commun : serialisation JSON-LD (Linked Data en JSON, W3C) d'un graphe RDF."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Writing` JsonLdWriter). Python = `rdflib` (plugin JSON-LD via `rdflib-jsonld` integre, `graph.serialize(format='json-ld')`)."


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13542

## Resume

Tranche de densite pedagogique pour **SW-9-Python-JSONLD** (issue #13410, pattern #10488) : 18 cellules d'interpretation markdown inserees apres leurs cellules code, ancrees strictement sur les outputs commites. Enrichissement markdown-only — le code et les outputs sont byte-identiques a `origin/main`.

**Deux fichiers modifies** : le notebook `SW-9-Python-JSONLD.ipynb` (323 insertions, 15 deletions — les 15 deletions sont les separateurs decoratifs convertis par le pre-commit sanctionne) et l entree de registre twin `scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml` (rebaseline + asymetrie documentee, commit separe).

## Ce que les interpretations couvrent

- **§2.1** les trois facons de poser un `@context` (distant / local / combine) — le mapping FOAF et la contrainte `@type: "@id"`
- **§2.2** la projection en 6 triples : `@id` rend la ressource dereferencable, la valeur emboitee devient blank node `_:b0`, le litteral date reste nu
- **§2.3** `@graph` : trois entites co-premieres (Turing / Cambridge / Lovelace) vs la fiche centrale et ses annexes
- **§3.1** le namespace Schema.org : abreviation d'URI, types et proprietes dans le meme namespace, `schema:` vs `schema1:` (prefixes locaux)
- **§4.1 approfondi** lire la forme etendue : URI complets en cles, valeurs en tableaux d'objets, date typée `xsd:date`
- **§4.2** la serialisation compacte : le contexte construit par rdflib (miroir de ce que la section 2.1 posait a la main), la date typée qui survit
- **§5.1** le parsing : 11 triples, les blank nodes `N...` non stables, "compter des triples != compter des entites"
- **§5.2** SPARQL indifferent a la syntaxe d'origine : le tableau 3 lignes, l'`OPTIONAL` et l'absence comme information
- **§5.3** Turtle : prefixe `schema1:`, dates `^^` typees, l'emboitement `[ ]` comme confort d'ecriture
- **§5.4 approfondi** le round-trip 11=11=11 : identifiants de blank nodes non conserves (normal), egalite semantique = isomorphisme de graphe
- **§6.1** Recipe : les durees ISO 8601 `PT30M/PT45M/PT1H15M` verifiables mecaniquement, `recipeYield` libre
- **§6.2** Event : offsets `+01:00`, `eventAttendanceMode` comme URI d'enumeration, `eventStatus` pour les moteurs
- **§6.3** BreadcrumbList (positions typees) et FAQPage (paires Question/Answer structrees)
- **§8** product.jsonld : 24 triples, `teaches` multi-value (4 valeurs = 4 triples), litteraux vs ressources
- **Exemples guides** : personne (13 triples, `sameAs` x2), Turtle->JSON-LD (auteur nomme vs emboite), Tartiflette (31 triples, ingredients chaines libres), conference (`subEvent` recursif, adresse textuelle)

## Preuves (instrument canonique, worktree frais origin/main@68e7a6638)

| Verif | Avant | Apres |
|---|---|---|
| `pedagogy_density.py --json` | 593 c/cellule (below_threshold) | **1455 c/cellule** (plancher 1200, vise 1500) |
| `check_prose_quantitative_claims.py --diff origin/main --strict` | — | `[OK] aucun compteur quantitatif en prose` |
| `detect_markdown_rendering.py` | 12 erreurs preexistantes (`yaml_block_open_no_close`) | **0 erreur** |
| `detect_code_in_markdown_cells.py` | baseline 2 | 0 violation |
| `check_papermill_ratchet.py origin/main` | — | `regressions: 0`, `OUTPUTS_UNCHANGED` |
| Cellules code | 37 | **37, byte-identiques** (assertion script + comparaison JSON a la base) |
| Outputs / execution_count | — | inchanges (diff markdown pur + separateurs) |

## Conversions annexes

Le pre-commit `fix-hr-separator` (auto-fix sanctionne) a converti 15 separateurs decoratifs `---` en `***` — c'est ce qui passe les 12 erreurs `yaml_block_open_no_close` preexistantes a 0. Aucune cellule code touchee.

## Statut issue

`See #13410` — tranche 1 notebook, l'EPIC (430 sous plancher) reste ouverte. Claim pose avec preflight 3 axes (densite fraiche mesuree, 0 PR ouverte sur le fichier, 0 claim actif).

