### PR TITLE
docs(harness,#7423): 2 ancres mortes + 1 pointeur non-lié corrigés dans .claude/rules

### DIFF
--- a/.claude/rules/audit-reassessment.md
+++ b/.claude/rules/audit-reassessment.md
@@ -11,7 +11,7 @@ S'applique à **tout fix basé sur audit automatisé** (NanoClaw ou similaire). 
 
 | Step | Action | Conclusion |
 |------|--------|------------|
-| **1. Vérif mécanique** | Compter cellules code, `execution_count`, `outputs`, `errors` (script Python : [detail](../../docs/reference/audit-reassessment-findings.md#step-1--vérification-mécanique)) | `exec_count == len(code)` et `errors == 0` alors que audit dit "never executed" → **FALSE POSITIVE**, stop |
+| **1. Vérif mécanique** | Compter cellules code, `execution_count`, `outputs`, `errors` (script Python : [detail](../../docs/reference/audit-reassessment-findings.md#step-1--vérification-mécanique-script)) | `exec_count == len(code)` et `errors == 0` alors que audit dit "never executed" → **FALSE POSITIVE**, stop |
 | **2. Vérif pédagogique** | Lire le notebook directement, classifier | `CONFIRMED bug` / `CONFIRMED outputs stripped` / `CONFIRMED pedagogy` / `FALSE POSITIVE` |
 | **3. Reporter dashboard** | `Item M-XX : [classification] — details : [direct read vs audit claim]` | Documenter pour prévenir re-dispatch |
 | **4. Fix si CONFIRMED** | bug→fix+re-exec ; outputs stripped→re-exec seul ; pedagogy→reformuler ; FP→fermer | Pas de PR sur FP |

--- a/.claude/rules/consecutive-code-cells.md
+++ b/.claude/rules/consecutive-code-cells.md
@@ -29,4 +29,4 @@ Quand une PR touche un notebook portant `consecutive-code-cells`, l'agent d'enri
 
 - [notebook-conventions.md](notebook-conventions.md) — C.1 stubs, C.2 outputs
 - [cell-interpretation-ordering.md](cell-interpretation-ordering.md) — placement des cellules d'interprétation
-- `docs/reference/subagents-reference.md` — agents d'enrichissement
+- [docs/reference/subagents-reference.md](../../docs/reference/subagents-reference.md) — agents d'enrichissement

--- a/.claude/rules/notebook-conventions.md
+++ b/.claude/rules/notebook-conventions.md
@@ -42,7 +42,7 @@ Les cellules doivent suivre un **ordre canonique** sans glissement ni oubli. Fri
 - Working directory explicite pour notebooks avec paths relatifs
 - `BATCH_MODE=true` pour notebooks avec widgets interactifs
 - **Notebooks LLM/API** (SC-11, GenAI) : re-exec validation via `--scrub-keys` pour forcer le chemin mock deterministe sans appel API payant : `notebook_tools.py execute <path> --scrub-keys`. Cf [docs/scripts-reference.md](../../docs/reference/scripts-reference.md) pour le cookbook complet (`--kernel`, `--cwd`, `--env`, `--scrub-keys`).
-- **QuantConnect QuantBook notebooks** (L574 ★★) : re-exec **QC Cloud uniquement** via MCP `qc-mcp` (`create_compile` + `create_backtest` + `read_backtest`). Tentative Papermill locale = FAIL (kernel `QuantBook()` absent, exécution QC Cloud obligatoire). Validateur `scripts/audit/check_cost_metadata.py` lit `cost.validator == qc_cloud` pour ces notebooks (sinon `MAJOR qc_notebook_no_validator`). Cf [CLAUDE.md QUANTCONNECT](../../CLAUDE.md#quantconnect-resume) pour la discipline backtest obligatoire après modification.
+- **QuantConnect QuantBook notebooks** (L574 ★★) : re-exec **QC Cloud uniquement** via MCP `qc-mcp` (`create_compile` + `create_backtest` + `read_backtest`). Tentative Papermill locale = FAIL (kernel `QuantBook()` absent, exécution QC Cloud obligatoire). Validateur `scripts/audit/check_cost_metadata.py` lit `cost.validator == qc_cloud` pour ces notebooks (sinon `MAJOR qc_notebook_no_validator`). Cf [CLAUDE.md QUANTCONNECT](../../CLAUDE.md#quantconnect-résumé) pour la discipline backtest obligatoire après modification.
 
 ## Cellules code : output systematique (anti faux-positif maturite)
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA — prev: MED/refactor #13357

## Summary

Tranche « hygiène pointeurs » de #7423 (scope : `CLAUDE.md` + `.claude/rules/*.md`). Balayage systématique des liens markdown `](docs/…)` / `](../…)` et des chemins backtiqués `docs/…`, avec vérification d'existence fichier **et** résolution d'ancre via slugger fidèle GitHub (espaces non collapsés — « — » → `--`).

**Résultat : 72 pointeurs vivants, 0 morts après correctif** (3 défauts initiaux).

## Correctifs (3 lignes)

| Fichier | Défaut | Correctif |
|---|---|---|
| `.claude/rules/audit-reassessment.md:14` | ancre `#step-1--vérification-mécanique` — le heading cible a gagné un suffixe `(script)` | → `#step-1--vérification-mécanique-script` |
| `.claude/rules/notebook-conventions.md:45` | ancre `../../CLAUDE.md#quantconnect-resume` — accent manquant (heading = `## QUANTCONNECT (résumé)`) | → `#quantconnect-résumé` |
| `.claude/rules/consecutive-code-cells.md:32` | chemin backtiqué non cliquable `docs/reference/subagents-reference.md` | → lien relatif `[…](../../docs/reference/subagents-reference.md)` |

## Sweep éphémère-3-tiers (2ᵈᵉ moitié de la tranche)

Grep de marqueurs d'état-éphémère (« en cours », « actuellement », « PR ouverte », etc.) sur le harnais complet : **0 violation** — tous les hits sont de la prose durable (concepts, citations d'anti-patterns, incidents fondateurs datés). La discipline [harness-hygiene.md](harness-hygiene.md) tient ; rien à déplacer vers `docs/`.

## Validation

- Re-scan post-fix : `live: 72 | DEAD: 0` (script ad hoc, slugger github-compatible, ancres incluses).
- Les 2 faux positifs du premier scan (backtick-texte-de-lien résolu à tort standalone) sont exclus par lookahead `(?! *\] *\()`.

## Notes

- Aucune collision : l'unique PR ouverte touchant `.claude/rules/` (#12893) ne concerne que `codeql-suppressions-inertes.md` (fichier neuf).
- See #7423 — contribution partielle (tranche pointeurs du harnais ; le reste de l'epic reste ouvert).
