### PR TITLE
fix(guard,#13495): voie 3 issue de suivi nommée + refus auto-levée coordinateur

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -1152,6 +1152,46 @@ def can_lift(comment: dict) -> bool:
     return True
 
 
+# #13495 -- voie 3 de B.0 : l'issue de suivi nommee. Une reserve peut etre
+# DIFFEREE plutot que levee : B.0 tient pour une reponse le commentaire qui
+# nomme une issue (#N) ouverte avant la decision de merge. Le detecteur ne
+# lit pas le sens -- il exige la mecanique : ref numerique dans un
+# commentaire eligible, issue existante (fetch), creee avant le cutoff.
+_ISSUE_REF = re.compile(r"#(\d{1,6})\b")
+
+
+def followup_issue_dates(pr_data: dict) -> dict[int, datetime]:
+    """Dates de creation des issues nommees par les commentaires eligibles.
+
+    Deduplique les refs ``#N`` (le numero de la PR elle-meme est exclu : un
+    self-ref est du bruit, pas une differance). Les issues inexistantes ou
+    injoignables sont simplement absentes du resultat : voie 3 fail-closed,
+    ce qui n'est pas prouve ne leve rien. La borne ``createdAt < cutoff``
+    est appliquee dans ``analyse``, pas ici, pour rester testable sans
+    reseau.
+    """
+    pr_number = pr_data.get("number")
+    refs: set[int] = set()
+    for c in pr_data.get("comments") or []:
+        if not can_lift(c):
+            continue
+        for m in _ISSUE_REF.finditer(c.get("body") or ""):
+            n = int(m.group(1))
+            if n != pr_number:
+                refs.add(n)
+    dates: dict[int, datetime] = {}
+    for n in sorted(refs):
+        try:
+            issue = gh_json(["issue", "view", str(n), "--repo", REPO,
+                             "--json", "number,createdAt"])
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            continue
+        created = ts(issue.get("createdAt"))
+        if created is not None:
+            dates[n] = created
+    return dates
+
+
 def classify(author: str, body: str) -> str | None:
     """'HUMAN' (nit user, UI web) | 'BOT-CONCERN' (reviewer avec reserves) | None."""
     if author in BOT_LOGINS or not body:
@@ -1296,8 +1336,15 @@ def _names_author(body: str, author: str) -> bool:
                      body) is not None
 
 
-def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
-    """cutoff = mergedAt (audit retro) ou now (gate pre-merge)."""
+def analyse(pr_data: dict, threads: list[dict], cutoff: datetime,
+            followups: dict[int, datetime] | None = None) -> dict:
+    """cutoff = mergedAt (audit retro) ou now (gate pre-merge).
+
+    ``followups`` : dates de creation des issues de suivi nommees (voie 3,
+    #13495), p.ex. le rendu de ``followup_issue_dates``. ``None`` = voie 3
+    inactive -- l'audit pre-filtre et les tests unitaires n'ont pas a payer
+    d'appels reseau.
+    """
     commits = [ts(c.get("committedDate")) for c in (pr_data.get("commits") or [])]
     commits = [c for c in commits if c]
     last_commit = max(commits) if commits else None
@@ -1378,8 +1425,13 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         # #13316 -- jsboige n'entre plus : identite de poussee partagee des
         # lanes (self-review cap #12319), un override jsboige est
         # indiscernable d'une auto-levee de lane (replay #12737).
+        # #13495 -- l'arbitre n'arbitre pas sa propre cause : un override
+        # POSE par un coordinateur sur SA PR est une auto-levee avec le
+        # costume de l'arbitre. La trappe #11639 est tierce par construction
+        # -- l'auteur de la PR en est exclu.
         m = OVERRIDE_LANE.search(lift_body or "")
         return (lift_author in LIFT_OVERRIDE_LOGINS
+                and lift_author != pr_author
                 and m is not None)
 
     # Fenetre 2026-08-16 (#11222) : les temps plats ne suffisent pas pour un
@@ -1426,6 +1478,43 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
                      r.get("body", "")) is None
     ]
     explicit_lifts = [x for x in explicit_lifts if x[0] is not None]
+
+    # #13495 -- voie 3 de B.0 : l'issue de suivi nommee. Sur #13372, la
+    # reserve Hermes etait differree vers #13488 par un commentaire de
+    # l'auteur de la PR (ai-01) : ni phrase de levee, ni re-review -- et le
+    # gate restait rouge alors que B.0 tient cette voie pour une reponse.
+    # Mecanique deliberement bornee : (1) le commentaire doit pouvoir lever
+    # (can_lift, hygiene anti-bruit existante) ; (2) son auteur est l'auteur
+    # de la reserve OU celui de la PR -- un bystander ne differre pas la
+    # reserve d'autrui ; (3) l'issue nommee EXISTE et a ete creee AVANT la
+    # decision de merge (cutoff) -- une issue ouverte apres coup est une
+    # retro-justification, pas une deferrance. Le self-ref (#numero de la
+    # PR) est exclu des la collecte.
+    followups = followups or {}
+    followup_lifts: list[dict] = []
+
+    def _followup_lifts_reserve(nit_author: str, reserve_when: datetime,
+                                allow_pr_author: bool = True) -> bool:
+        namers = {nit_author} | ({pr_author} if allow_pr_author else set())
+        for c in pr_data.get("comments") or []:
+            namer = (c.get("author") or {}).get("login", "")
+            t = ts(c.get("createdAt"))
+            if t is None or not (reserve_when < t < cutoff):
+                continue
+            if not can_lift(c) or namer not in namers:
+                continue
+            for m in _ISSUE_REF.finditer(c.get("body") or ""):
+                n = int(m.group(1))
+                if n == pr_data.get("number"):
+                    continue
+                created = followups.get(n)
+                if created is not None and created < cutoff:
+                    followup_lifts.append({
+                        "nit_author": nit_author, "by": namer, "issue": n,
+                        "at": t.isoformat(),
+                    })
+                    return True
+        return False
 
     signals: list[tuple] = []
     for c in pr_data.get("comments") or []:
@@ -1499,10 +1588,12 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
             # (B.0 : ce qui leve une remarque est une phrase). Les nits portes
             # par un COMMENTAIRE gardent le regime general ci-dessous — limite
             # NLP documentee dans can_lift.
-            lifted = _approved_lifts_reserve(login, when, pr_author) or any(
-                when < t < cutoff and _lift_eligible(lifter, login, lift_body)
-                for (t, lifter, lift_body) in explicit_lifts
-            )
+            lifted = (_approved_lifts_reserve(login, when, pr_author)
+                      or any(
+                          when < t < cutoff
+                          and _lift_eligible(lifter, login, lift_body)
+                          for (t, lifter, lift_body) in explicit_lifts)
+                      or _followup_lifts_reserve(login, when))
             if lifted:
                 continue
         # #13083 — les bornes strictes du blocage. Un blocage ne se leve ni
@@ -1521,7 +1612,13 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
                     and (lift_author != pr_author
                          or bool(OVERRIDE_LANE.search(lift_body)))
                     for (t, lift_author, lift_body) in explicit_lifts)
-                    or _approved_lifts_reserve(login, when, pr_author)):
+                    or _approved_lifts_reserve(login, when, pr_author)
+                    # #13495 : voie 3 sur un BLOCAGE -- l'auteur de la PR ne
+                    # peut pas differer le blocage d'un tiers (#13083 : un
+                    # blocage ne se leve ni par l'auteur de la PR) ; seul
+                    # l'emetteur du blocage peut le differer lui-meme.
+                    or _followup_lifts_reserve(login, when,
+                                               allow_pr_author=False)):
                 continue
         # #12319 : meme regime pour un nit porte par un commentaire ou une
         # review COMMENTED (dont chaque reserve Hermes, self-review cap).
@@ -1535,7 +1632,8 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         elif (any(
                   when < t < cutoff and _lift_eligible(lift_author, login, lift_body)
                   for (t, lift_author, lift_body) in explicit_lifts
-              ) or _approved_lifts_reserve(login, when, pr_author)):
+              ) or _approved_lifts_reserve(login, when, pr_author)
+              or _followup_lifts_reserve(login, when)):
             continue
         # Un commit poussé après le nit ne le lève PAS à lui seul : sur #10761,
         # le « traitement » était un rebase à 19:41 qui n'adressait aucun des
@@ -1569,15 +1667,28 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     # survit reste le signal) — c'est l'explication visible du rouge. Un
     # override de l'auteur de la reserve (self-lift legitime) n'est pas liste.
     nit_authors = {login for (_, _, login, _, _) in signals}
+
+    def _ignored_why(author: str) -> str:
+        # #13495 : la symetrie du refus nomme. Un override coordinateur
+        # ecarte parce qu'il porte sur SA propre PR doit etre liste comme
+        # tel -- un gate rouge « malgre notre override » reste indistinguable
+        # d'un bug du detecteur si personne ne dit pourquoi (#13316).
+        if author in LIFT_OVERRIDE_LOGINS:
+            return (f"override ignoré — l'arbitre « {author} » est l'auteur "
+                    "de la PR (#13495 : l'arbitre n'arbitre pas sa propre "
+                    "cause)")
+        return (f"override ignoré — auteur « {author} » n'est pas un compte "
+                "de levée (#13316 : identité de poussée partagée des lanes)")
+
     ignored_overrides = [
-        {"author": author, "at": t.isoformat(),
-         "why": (f"override ignoré — auteur « {author} » n'est pas un compte "
-                 "de levée (#13316 : identité de poussée partagée des lanes)")}
+        {"author": author, "at": t.isoformat(), "why": _ignored_why(author)}
         for (t, author, body) in explicit_lifts
         if t is not None
         and OVERRIDE_LANE.search(body or "") is not None
-        and author not in LIFT_OVERRIDE_LOGINS
         and author not in nit_authors
+        # #13316 : jsboige n'entre pas ; #13495 : un coordinateur entre,
+        # SAUF sur sa propre PR — les deux refus doivent etre NOMMES.
+        and (author not in LIFT_OVERRIDE_LOGINS or author == pr_author)
     ]
 
     # #13512 -- CE QUE L'ORGANE N'A PAS EVALUE.
@@ -1604,6 +1715,10 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     # avoir relu tous les commentaires au dernier moment ») cesse de dependre
     # de la vigilance et devient mecanique.
     lift_keys = {(t_, a) for (t_, a, _b) in explicit_lifts if t_}
+    # #13495 : un commentaire de voie 3 qui a servi est EVALUE (il leve la
+    # reserve via l'issue nommee) -- il ne doit pas revenir hanter la file
+    # « a relire » de #13512.
+    lift_keys |= {(ts(f["at"]), f["by"]) for f in followup_lifts}
     unevaluated: list[dict] = []
     for c in pr_data.get("comments") or []:
         login = (c.get("author") or {}).get("login", "")
@@ -1635,6 +1750,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         "blocking": blocking,
         "blocked": bool(blocking),
         "ignored_overrides": ignored_overrides,
+        "followup_lifts": followup_lifts,
         "unevaluated": to_read,
         "unevaluated_total": len(unevaluated),
     }
@@ -1682,7 +1798,8 @@ def gate(pr: int, as_json: bool) -> int:
     data = gh_json(["pr", "view", str(pr), "--repo", REPO, "--json", FIELDS])
     merged = ts(data.get("mergedAt"))
     cutoff = merged or datetime.now(timezone.utc)
-    result = analyse(data, review_threads(pr), cutoff)
+    result = analyse(data, review_threads(pr), cutoff,
+                     followup_issue_dates(data))
     if as_json:
         print(json.dumps(result, indent=1, ensure_ascii=False))
     elif not result["blocked"]:
@@ -1699,7 +1816,14 @@ def gate(pr: int, as_json: bool) -> int:
             # #13316 : dire POURQUOI l'override visible n'a rien eteint — le
             # silence etait le mode d'echec couteux (#13030, #12096).
             print(f"  [i] {o['why']} (commentaire de {o['author']} à {o['at']})")
-        print("Lever chaque nit (commit, reponse explicite, ou issue de suivi nommee)")
+        for f in result.get("followup_lifts", ()):
+            # #13495 : rendre la voie 3 visible quand meme — un rouge qui
+            # tient uniquement a une deferrance doit se lire comme tel.
+            print(f"  [i] voie 3 : réserve de {f['nit_author']} différée vers "
+                  f"#{f['issue']} (nommée par {f['by']} à {f['at']})")
+        # #13495 : « commit » retiré — un commit ne lève rien (#10761),
+        # l'annoncer comme levier enseigne le mauvais geste.
+        print("Lever chaque nit (reponse explicite, ou issue de suivi nommee)")
         print("avant `gh pr merge`. Cf CLAUDE.md section B.0.")
         _print_unevaluated(result)
     return 1 if result["blocked"] else 0
@@ -1734,7 +1858,11 @@ def audit(limit: int, search: str | None = None) -> int:
         # a besoin pour trier (« du code a bouge apres le nit » = aller lire le
         # diff avant de conclure). Information de triage, pas critere.
         # Audit retro : on n'interroge pas les threads inline (1 appel GraphQL/PR).
-        res = analyse(p, [], merged)
+        # #13495 : voie 3 activee au 2e passage seulement, en miroir du fetch
+        # commits -- le pre-filtre reste conservateur (une reserve differree
+        # y parait bloquee, ce qui en fait une candidate), et ce passage la
+        # re-juge avec les dates reelles des issues nommees.
+        res = analyse(p, [], merged, followup_issue_dates(p))
         if res["blocked"]:
             res["url"] = p.get("url")
             res["merged_at"] = p["mergedAt"]

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -2917,3 +2917,157 @@ def test_13512_classified_comment_is_not_duplicated_in_the_tail():
     res = mod.analyse(pr, [], datetime(2026, 8, 29, 11, 14, tzinfo=timezone.utc))
     assert mod.classify("jsboige", concern) is not None, "pre-condition : celui-la EST classe"
     assert all(u["body"] != concern for u in res["unevaluated"])
+
+
+# ---------------------------------------------------------------------------
+# #13495 -- voie 3 de B.0 : l'issue de suivi nommee (3e levier), et le trou
+# d'auto-levee coordinateur. Instance fondatrice #13372 : PR auteur ai-01,
+# reserve Hermes sous jsboige, differree par un commentaire de l'auteur de la
+# PR nommant #13488 (ouverte avant le merge) -- le gate restait rouge.
+# ---------------------------------------------------------------------------
+
+HERMES_RESERVE_13495 = {
+    "author": {"login": "jsboige"},
+    "createdAt": at(9),
+    "body": "[Hermes] — COMMENT_WITH_CONCERNS\nCI catalog-drift FAIL sur cette base.",
+}
+
+DEFERRAL_13495 = {
+    "author": {"login": "myia-ai-01"},
+    "createdAt": at(12),
+    "body": "Reserve Hermes differee vers #13488 — le suivi se fait la-bas.",
+}
+
+# #13488 ouverte a 13:00, merge a 20:00 : AVANT la decision (MERGED).
+ISSUE_13488 = {13488: datetime(2026, 8, 14, 13, 0, tzinfo=timezone.utc)}
+
+
+def run_voie3(comments, followups, pr_author="myia-ai-01"):
+    data = {
+        "number": 13372,
+        "title": "t",
+        "author": {"login": pr_author},
+        "comments": comments,
+        "reviews": [],
+        "commits": [{"committedDate": at(19)}],
+    }
+    return mod.analyse(data, [], MERGED, followups)
+
+
+def test_voie3_issue_nomme_par_auteur_pr_leve():
+    res = run_voie3([HERMES_RESERVE_13495, DEFERRAL_13495], ISSUE_13488)
+    assert res["blocked"] is False
+    assert res["followup_lifts"][0]["issue"] == 13488
+    assert res["followup_lifts"][0]["by"] == "myia-ai-01"
+
+
+def test_voie3_sans_dictionnaire_reste_rouge():
+    """Voie 3 inactive (audit pre-filtre, tests) : comportement d'avant."""
+    res = run_voie3([HERMES_RESERVE_13495, DEFERRAL_13495], None)
+    assert res["blocked"] is True
+
+
+def test_voie3_issue_inexistante_reste_rouge():
+    """Controle positif exige par #13495 : rouge quand l'issue n'existe pas
+    (absente du dictionnaire = fetch echoue = fail-closed)."""
+    res = run_voie3([HERMES_RESERVE_13495, DEFERRAL_13495], {})
+    assert res["blocked"] is True
+
+
+def test_voie3_issue_creee_apres_merge_reste_rouge():
+    """Controle positif exige par #13495 : une issue ouverte APRES la
+    decision de merge est une retro-justification, pas une deferrance."""
+    late = {13488: datetime(2026, 8, 14, 22, 0, tzinfo=timezone.utc)}  # merge 20:00
+    res = run_voie3([HERMES_RESERVE_13495, DEFERRAL_13495], late)
+    assert res["blocked"] is True
+
+
+def test_voie3_par_bystander_ne_leve_pas():
+    other = dict(DEFERRAL_13495)
+    other["author"] = {"login": "myia-po-2023"}
+    res = run_voie3([HERMES_RESERVE_13495, other], ISSUE_13488)
+    assert res["blocked"] is True
+
+
+def test_voie3_nominee_par_auteur_de_la_reserve_leve():
+    """L'auteur de la reserve peut aussi differer sa propre remarque."""
+    own = dict(DEFERRAL_13495)
+    own["author"] = {"login": "jsboige"}
+    res = run_voie3([HERMES_RESERVE_13495, own], ISSUE_13488)
+    assert res["blocked"] is False
+
+
+def test_voie3_nomination_antérieure_a_la_reserve_ne_leve_pas():
+    early = dict(DEFERRAL_13495)
+    early["createdAt"] = at(5)  # avant la reserve de 9h
+    res = run_voie3([HERMES_RESERVE_13495, early], ISSUE_13488)
+    assert res["blocked"] is True
+
+
+def test_voie3_self_ref_ne_compte_pas():
+    selfref = dict(DEFERRAL_13495)
+    selfref["body"] = "Reserve differee, voir #13372."  # numero de la PR
+    res = run_voie3([HERMES_RESERVE_13495, selfref],
+                    {13372: datetime(2026, 8, 1, tzinfo=timezone.utc)})
+    assert res["blocked"] is True
+
+
+def test_voie3_sur_blocage_auteur_pr_ne_leve_pas():
+    """#13083 : l'auteur de la PR ne peut pas differer le blocage d'un tiers
+    -- seul l'emetteur du blocage peut le differer lui-meme."""
+    blocage = {
+        "author": {"login": "jsboige"},
+        "createdAt": at(9),
+        "body": "[BLOCAGE] lane myia-po-2026:CoursIA — regression sorry detectee.",
+    }
+    res = run_voie3([blocage, DEFERRAL_13495], ISSUE_13488)
+    assert res["blocked"] is True
+
+
+def test_voie3_sur_blocage_par_emetteur_leve():
+    blocage = {
+        "author": {"login": "jsboige"},
+        "createdAt": at(9),
+        "body": "[BLOCAGE] lane myia-po-2026:CoursIA — regression sorry detectee.",
+    }
+    own = dict(DEFERRAL_13495)
+    own["author"] = {"login": "jsboige"}  # l'emetteur du blocage differre
+    res = run_voie3([blocage, own], ISSUE_13488)
+    assert res["blocked"] is False
+
+
+def test_voie3_le_commentaire_de_deferrance_est_evalue():
+    """Symetrie #13512 : un commentaire qui a servi de voie 3 ne doit pas
+    revenir dans la file « a relire »."""
+    res = run_voie3([HERMES_RESERVE_13495, DEFERRAL_13495], ISSUE_13488)
+    unevaluated_bodies = [u.get("body") for u in res.get("unevaluated", [])]
+    assert DEFERRAL_13495["body"] not in unevaluated_bodies
+
+
+def test_13495_override_coordinateur_sur_sa_propre_pr_refuse():
+    """Le trou d'auto-levee : ai-01 POSE un [OVERRIDE] lane sur SA PR —
+    _lift_eligible doit refuser (l'arbitre n'arbitre pas sa propre cause),
+    et le refus doit etre NOMME (#13316 symetrique)."""
+    override = {
+        "author": {"login": "myia-ai-01"},
+        "createdAt": at(12),
+        "body": "**[OVERRIDE] lane myia-ai-01:CoursIA** — Levée de la "
+                "réserve Hermes, points reportés sur #11058.",
+    }
+    res = run_voie3([HERMES_RESERVE_13495, override], {})
+    assert res["blocked"] is True
+    assert any("propre cause" in o["why"] for o in res["ignored_overrides"])
+
+
+def test_13495_override_coordinateur_sur_pr_tierce_leve_toujours():
+    """Controle non-regression : la trappe #11639 reste ouverte a l'arbitre
+    VRAIMENT tiers (PR d'un worker, override d'ai-01)."""
+    override = {
+        "author": {"login": "myia-ai-01"},
+        "createdAt": at(12),
+        "body": "**[OVERRIDE] lane myia-ai-01:CoursIA** — Levée de la "
+                "réserve Hermes, points reportés sur #11058.",
+    }
+    res = run_voie3([HERMES_RESERVE_13495, override], {},
+                    pr_author="myia-po-2026")
+    assert res["blocked"] is False


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13542

## Sujet

`check_unaddressed_nits.py` : voie 3 de B.0 (issue de suivi nommee) sans detecteur + trou d'auto-levee coordinateur. See #13495.

## Contenu (2 fichiers)

- `scripts/check_unaddressed_nits.py` : detecteur voie 3 (`_ISSUE_REF` + `followup_issue_dates` + closure `_followup_lifts_reserve` cablee aux 3 sites de levee), garde symetrique `_lift_eligible` (l'arbitre n'arbitre pas sa propre PR), refus NOMME dans `ignored_overrides`, ligne de conseil sans « commit », `unevaluated` #13512 epure des commentaires de voie 3.
- `scripts/tests/test_check_unaddressed_nits.py` : 13 tests (fixtures #13372-shape).

## Preuves

- `python -m pytest scripts/tests/test_check_unaddressed_nits.py -q` : **221 passed** (208 + 13 nouveaux).
- Suite complete `python -m pytest scripts/tests -q` : **3670 passed, 30 skipped, 5 xfailed, 0 failed**.
- Controle negatif au stash : 13 nouveaux tests **FAIL** sans le fix, re-verts apres pop.
- Controles positifs exigés par l'acceptance 3 : rouge sur issue inexistante, rouge sur issue creee apres le merge, vert sur la forme #13372.
- Audit live diff (60 dernieres PRs mergees, patched vs main) : **#13537 rouge->vert** (reserve NanoClaw 18:44Z, commentaire pr-author 19:04:02Z nommant une issue ouverte avant le merge -- la voie 3 en action), **0 vert->rouge** (aucun piege coordinateur dans la fenetre), 0 autre divergence.
- Gate live sur #13372 : `blocked: false` sur patched ET sur main (des levees ulterieures par canaux existants) -- aucune regression.

## Mecanique voie 3 (bornee)

Un commentaire leve une reserve precedente si : (1) `can_lift` (hygiene anti-bruit existante), (2) auteur = auteur de la reserve OU auteur de la PR (jamais un bystander), (3) il nomme `#N` != numero de la PR, (4) l'issue EXISTE et `createdAt < cutoff` (fail-closed : absente du fetch = ne leve rien). Sur un BLOCAGE (#13083), l'auteur de la PR ne peut PAS differer le blocage d'un tiers (`allow_pr_author=False`).

## Garde symetrique

`_lift_eligible` : l'override `[OVERRIDE] lane` d'un compte coordinateur sur SA PROPRE PR est desormais refuse (auto-levee avec le costume de l'arbitre, instance #13372). Le refus est NOMME dans `ignored_overrides` (symetrie #13316 : un rouge « malgre notre override » doit dire pourquoi).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
