### PR TITLE
fix(qc,#11601): 6 separateurs decoratifs '---' -> '***' dans QC-Py-23b (retablit l'acceptance #11600)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
@@ -42,7 +42,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "> **Mode d'emploi** : Ce notebook illustre les concepts avec du code executable sur CPU.\n",
     "> 1. **Sections analytiques** : textes explicatifs et visualisations des architectures\n",
@@ -64,7 +64,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Table des matieres\n",
     "\n",
@@ -130,7 +130,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : Le Problème de l'Attention Quadratique <a id=\"Partie-1\"></a>\n",
     "\n",
@@ -232,7 +232,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2 : PatchTST — Une serie temporelle = 64 mots <a id=\"Partie-2\"></a>\n",
     "\n",
@@ -915,7 +915,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercices\n",
     "\n",
@@ -1040,7 +1040,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Bilan -- quand patcher (PatchTST) vs inverser (iTransformer) les axes\n",
     "\n",
@@ -1078,8 +1078,7 @@
     "introduit les **deux correctifs canoniques** qui rendent les Transformers\n",
     "viables sur series temporelles longues. Le suivant (QC-Py-24 Autoencoders)\n",
     "pivote vers l'apprentissage non-supervise (anomalies, representations) -- une\n",
-    "autre reponse au « comment extraire du signal du bruit financier ».\n",
-    ""
+    "autre reponse au « comment extraire du signal du bruit financier ».\n"
    ],
    "id": "cell-b885e5a5"
   },


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2024:CoursIA — prev: LIGHT/docs #13582

## Summary

Retablit le critere d'acceptance « Markdown rendering : 0 violations » de la tranche #11600 (round 2 de #11601) : la tranche etait livree avec **6 ERROR** `yaml_block_open_no_close` persistants sur `main` (cellules 1, 2, 4, 7, 23, 27). La refutation po-2023 (2026-08-30, mise a jour d'issue) est confirmee firsthand par re-execution du detecteur du depot sur l'arbre de travail = origin/main.

## Fix

`python scripts/notebook_tools/fix_hr_separator.py --apply` (l'outil du depot, celui du hook pre-commit `fix-hr-separator`) : 6 separateurs decoratifs `---` ouvrant une cellule markdown convertis en `***` — meme rendu `<hr>`, plus de semantique de bloc YAML Pandoc.

## Validation

| Verification | Resultat |
|---|---|
| `detect_markdown_rendering.py` post-fix | **violations: 0 total** (6 avant) |
| `pedagogy_density.py` post-fix | notebook toujours `ok`, non `below_threshold` |
| Diff scope | 1 fichier, +8/−9 ; **0 ligne** touchant `outputs`/`execution_count` (grep verifie) — markdown-only, C.2 exception, pas de re-execution requise |
| Cellules code | 13/13 `execution_count` non-null, outputs non-vides |

## Contexte urne delivered

Le label `candidate-delivered` a ete **retire de #11601** ce cycle (commentaire 5466404554) avec mesures firsthand : outre les 6 violations, **6 notebooks restent dans la bande 1200-1500** (QC-Py-28 1445, QC-Py-30 1476, QC-Py-33 1468, QC-Py-34 1398, QC-Py-41 1415, QC-Py-Cloud-02 1385). Le round 2 n'est pas livre ; les tranches de densite restent ouvertes sur l'umbrella.

See #11601 — tranche hygiene de la tranche #11600 (les tranches densite suivront).
