### PR TITLE
fix(gt,#13452): GT-03d E1 — trois espaces ordinaux explicites (576/144/78), multiplicité x4 éliminée

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
@@ -126,7 +126,7 @@
     "\n",
     "### Verification\n",
     "\n",
-    "Le code ci-dessous enumere les **78 profils 2x2 distincts en ordinaux** (4 issues placees sur 4 cases avec repetition possible mais avec 4 valeurs distinctes au total par ligne) et verifie que **les 4 archetypes** apparaissent comme profils canoniques. Le but est transformer la citation qualitative du papier en une **mesure verifiable** sur notre machine."
+    "Le code ci-dessous enumere l'espace ordinal strict 2x2 en trois niveaux — **576 jeux bruts** (une matrice de rangs 1-4 par joueur, 24 x 24 permutations), **144 structures d'incitations du joueur 1** et **78 classes d'equivalence strategique** (compte canonique Rapoport-Guyer 1966, verifie par execution) — et verifie que **les 4 archetypes** apparaissent comme profils canoniques. Le but est transformer la citation qualitative du papier en une **mesure verifiable** sur notre machine."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb
@@ -5,10 +5,10 @@
    "id": "2433ddbd",
    "metadata": {
     "papermill": {
-     "duration": 0.003336,
-     "end_time": "2026-08-29T03:28:45.296095",
+     "duration": 0.003579,
+     "end_time": "2026-08-29T06:48:26.870944",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.292759",
+     "start_time": "2026-08-29T06:48:26.867365",
      "status": "completed"
     },
     "tags": []
@@ -26,7 +26,7 @@
     "\n",
     "### Plan du notebook\n",
     "\n",
-    "1. **E1 — La famille 2x2 dans le plan** : enumeration complete des 78 profils 2x2 distincts, classification par les 4 archetypes de Robinson-Goforth (PD, SH, SD, H) avec definition stricte, et verification que les 4 archetypes emergent avec leurs 4 profils canoniques.\n",
+    "1. **E1 — La famille 2x2 dans le plan** : enumeration complete de l'espace ordinal strict (576 jeux bruts, 144 structures d'incitations, 78 classes d'equivalence Rapoport-Guyer), classification par les 4 archetypes de Robinson-Goforth (PD, SH, SD, H) avec definition stricte, et verification que les 4 archetypes emergent avec leurs 4 profils canoniques.\n",
     "2. **E2 — Le plan de deformation** : implementation de la fonction de benefice non-lineaire generalisee `b(i)` (eq. 13), balayage `(k, s, c/b)`, enumeration des regimes (defection pure / coexistence / bistabilite / cooperation pure), et verification de l'approximation `x+ ~ (k-1)/(N-1)` pour grand N.\n",
     "3. **E3 — Le mur a memoire (hysteresis)** : diagramme de bifurcation de `c/b` avec deux trajectoires (montante puis descendante) qui peuvent diverger. La transformation du monde descriptif n'est pas inversee par sa contre-transformation.\n",
     "4. **E4 — Le contre-claim execute** : MacLean et al. (2010) sur la levure — le Snowdrift 2-personnes predit mal l'optimum intermediaire, le **jeu N-personnes non-lineaire** le predit exactement. Une cellule qui montre que le modele echoue n'etait pas le bon modele.\n",
@@ -46,16 +46,16 @@
    "id": "90f35ae5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:28:45.303076Z",
-     "iopub.status.busy": "2026-08-29T03:28:45.303076Z",
-     "iopub.status.idle": "2026-08-29T03:28:45.392896Z",
-     "shell.execute_reply": "2026-08-29T03:28:45.392347Z"
+     "iopub.execute_input": "2026-08-29T06:48:26.878453Z",
+     "iopub.status.busy": "2026-08-29T06:48:26.878127Z",
+     "iopub.status.idle": "2026-08-29T06:48:27.250479Z",
+     "shell.execute_reply": "2026-08-29T06:48:27.249729Z"
     },
     "papermill": {
-     "duration": 0.095025,
-     "end_time": "2026-08-29T03:28:45.394098",
+     "duration": 0.376466,
+     "end_time": "2026-08-29T06:48:27.251593",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.299073",
+     "start_time": "2026-08-29T06:48:26.875127",
      "status": "completed"
     },
     "tags": []
@@ -65,7 +65,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Imports OK. Numpy 2.2.6, RNG seed=20260822\n"
+      "Imports OK. Numpy 2.4.3, RNG seed=20260822\n"
      ]
     }
    ],
@@ -83,10 +83,10 @@
    "id": "ace19172",
    "metadata": {
     "papermill": {
-     "duration": 0.002992,
-     "end_time": "2026-08-29T03:28:45.400113",
+     "duration": 0.004072,
+     "end_time": "2026-08-29T06:48:27.258155",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.397121",
+     "start_time": "2026-08-29T06:48:27.254083",
      "status": "completed"
     },
     "tags": []
@@ -102,10 +102,10 @@
    "id": "9b947fe8",
    "metadata": {
     "papermill": {
-     "duration": 0.003379,
-     "end_time": "2026-08-29T03:28:45.406617",
+     "duration": 0.003376,
+     "end_time": "2026-08-29T06:48:27.264673",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.403238",
+     "start_time": "2026-08-29T06:48:27.261297",
      "status": "completed"
     },
     "tags": []
@@ -135,16 +135,16 @@
    "id": "1a048d29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:28:45.413141Z",
-     "iopub.status.busy": "2026-08-29T03:28:45.412021Z",
-     "iopub.status.idle": "2026-08-29T03:28:45.423320Z",
-     "shell.execute_reply": "2026-08-29T03:28:45.423320Z"
+     "iopub.execute_input": "2026-08-29T06:48:27.272351Z",
+     "iopub.status.busy": "2026-08-29T06:48:27.271856Z",
+     "iopub.status.idle": "2026-08-29T06:48:27.305668Z",
+     "shell.execute_reply": "2026-08-29T06:48:27.304975Z"
     },
     "papermill": {
-     "duration": 0.015438,
-     "end_time": "2026-08-29T03:28:45.424461",
+     "duration": 0.039856,
+     "end_time": "2026-08-29T06:48:27.307332",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.409023",
+     "start_time": "2026-08-29T06:48:27.267476",
      "status": "completed"
     },
     "tags": []
@@ -160,19 +160,26 @@
       "  SD ((2, 1), (3, 0)) -> SD  [OK]\n",
       "  H ((3, 2), (1, 0)) -> H  [OK]\n",
       "\n",
-      "Enumeration complete (576 profils 2x2) :\n",
-      "     PD :   4 (  0.7%)\n",
-      "     SH :  28 (  4.9%)\n",
-      "     SD :   4 (  0.7%)\n",
-      "      H :  28 (  4.9%)\n",
-      "  Other : 512 ( 88.9%)\n",
-      "  TOTAL : 576\n"
+      "Espace 1 - structures d'incitations du joueur 1 (paires ordonnees (R,S) x (T,P)) :\n",
+      "     PD :   1 (  0.7%)\n",
+      "     SH :   7 (  4.9%)\n",
+      "     SD :   1 (  0.7%)\n",
+      "      H :   7 (  4.9%)\n",
+      "  Other : 128 ( 88.9%)\n",
+      "  TOTAL : 144 structures distinctes\n",
+      "\n",
+      "Espace 2 - jeux ordinaux complets (matrice de rangs par joueur) : 576 jeux bruts\n",
+      "\n",
+      "Espace 3 - quotient des 576 jeux bruts par equivalence strategique :\n",
+      "  78 classes distinctes -- compte canonique Rapoport-Guyer 1966 : VERIFIE par execution\n"
      ]
     }
    ],
    "source": [
     "# E1 — La famille 2x2 dans le plan\n",
-    "# Classification stricte des 4 archetypes Robinson-Goforth parmi les 78 profils distincts.\n",
+    "# Classification des 4 archetypes Robinson-Goforth sur les espaces ordinaux stricts :\n",
+    "# 144 structures d'incitations (joueur 1), 576 jeux complets (deux joueurs),\n",
+    "# 78 classes d'equivalence strategique (compte canonique Rapoport-Guyer 1966).\n",
     "from itertools import permutations\n",
     "\n",
     "def rgs_class(profile):\n",
@@ -217,31 +224,74 @@
     "    status = 'OK' if cls == name else f'BUG (classe comme {cls})'\n",
     "    print(f\"  {name} {prof} -> {cls}  [{status}]\")\n",
     "\n",
-    "# Enumere tous les profils admissibles : pour chaque ligne J1, choix d'une\n",
-    "# permutation stricte de 4 valeurs distinctes parmi {1,2,3,4}\n",
-    "# (chaque case recoit une valeur differente -> 4! = 24 profils par ligne)\n",
-    "# Pour le profil complet, J2 doit aussi etre une permutation stricte de 4 valeurs distinctes\n",
-    "# -> 24 x 24 = 576 profils complets. Mais les doublons (J1=J2 modulo label) -> 78 profils distincts\n",
-    "# (compte canonique Rapoport-Guyer 1966).\n",
+    "# --- Espace 1 : les 144 structures d'incitations du joueur 1 ---\n",
+    "# Une structure d'incitations = les 4 ordinaux (R, S, T, P) du joueur 1, valeurs\n",
+    "# distinctes dans {1,2,3,4} : (R,S) et (T,P) sont des paires ordonnees de\n",
+    "# valeurs distinctes (4 x 3 = 12 chacune) -> 12 x 12 = 144 structures distinctes.\n",
+    "paires = [(a, b) for a in (1, 2, 3, 4) for b in (1, 2, 3, 4) if a != b]\n",
     "comptes = {'PD': 0, 'SH': 0, 'SD': 0, 'H': 0, 'Other': 0}\n",
     "exemples_par_classe = {k: [] for k in comptes}\n",
-    "\n",
-    "# Enumeration exacte : pour chaque couple de permutations strictes de (1,2,3,4)\n",
-    "for J1_row in permutations([1, 2, 3, 4]):\n",
-    "    for J2_row in permutations([1, 2, 3, 4]):\n",
-    "        prof = (J1_row, J2_row)\n",
+    "for (R, S) in paires:\n",
+    "    for (T, P) in paires:\n",
+    "        prof = ((R, S), (T, P))\n",
     "        cls = rgs_class(prof)\n",
     "        comptes[cls] += 1\n",
     "        if len(exemples_par_classe[cls]) < 2:\n",
     "            exemples_par_classe[cls].append(prof)\n",
     "\n",
-    "print(f\"\\nEnumeration complete (576 profils 2x2) :\")\n",
+    "print(f\"\\nEspace 1 - structures d'incitations du joueur 1 (paires ordonnees (R,S) x (T,P)) :\")\n",
     "total = sum(comptes.values())\n",
     "for cls in ['PD', 'SH', 'SD', 'H', 'Other']:\n",
     "    n = comptes[cls]\n",
     "    pct = 100 * n / total\n",
     "    print(f\"  {cls:>5} : {n:>3} ({pct:>5.1f}%)\")\n",
-    "print(f\"  TOTAL : {total}\")"
+    "print(f\"  TOTAL : {total} structures distinctes\")\n",
+    "\n",
+    "# --- Espace 2 : les 576 jeux ordinaux complets (deux joueurs) ---\n",
+    "# Un jeu complet = une matrice de rangs pour CHAQUE joueur, chacune une\n",
+    "# permutation stricte de {1,2,3,4} : 24 x 24 = 576 jeux bruts. C'est l'espace\n",
+    "# de Rapoport-Guyer (1966) AVANT quotient par equivalence strategique.\n",
+    "jeux = set()\n",
+    "for p1 in permutations([1, 2, 3, 4]):\n",
+    "    m1 = (p1[0:2], p1[2:4])\n",
+    "    for p2 in permutations([1, 2, 3, 4]):\n",
+    "        m2 = (p2[0:2], p2[2:4])\n",
+    "        jeux.add((m1, m2))\n",
+    "print(f\"\\nEspace 2 - jeux ordinaux complets (matrice de rangs par joueur) : {len(jeux)} jeux bruts\")\n",
+    "\n",
+    "# --- Espace 3 : les 78 classes d'equivalence strategique (verification) ---\n",
+    "# Deux jeux sont strategiquement equivalents si l'un s'obtient de l'autre en\n",
+    "# relabelliant les joueurs (echange accompagne de la transposition des\n",
+    "# matrices), les lignes (strategies du joueur ligne) ou les colonnes\n",
+    "# (strategies du joueur colonne).\n",
+    "def transpose(m):\n",
+    "    return tuple(tuple(m[c][r] for c in range(2)) for r in range(2))\n",
+    "\n",
+    "def swap_lignes(m):\n",
+    "    return (m[1], m[0])\n",
+    "\n",
+    "def swap_colonnes(m):\n",
+    "    return tuple((ligne[1], ligne[0]) for ligne in m)\n",
+    "\n",
+    "def forme_canonique(m1, m2):\n",
+    "    \"\"\"Minimum lexicographique de l'orbite d'un jeu sous les 3 relabellages.\"\"\"\n",
+    "    vus, frontiere = set(), [(m1, m2)]\n",
+    "    while frontiere:\n",
+    "        jeu = frontiere.pop()\n",
+    "        if jeu in vus:\n",
+    "            continue\n",
+    "        vus.add(jeu)\n",
+    "        a, b = jeu\n",
+    "        frontiere += [(swap_lignes(a), swap_lignes(b)),\n",
+    "                      (swap_colonnes(a), swap_colonnes(b)),\n",
+    "                      (transpose(b), transpose(a))]\n",
+    "    return min(vus)\n",
+    "\n",
+    "classes = {forme_canonique(m1, m2) for (m1, m2) in jeux}\n",
+    "attendu_rapoport_guyer = 78\n",
+    "print(f\"\\nEspace 3 - quotient des 576 jeux bruts par equivalence strategique :\")\n",
+    "verdict = 'VERIFIE par execution' if len(classes) == attendu_rapoport_guyer else f'ECART (attendu {attendu_rapoport_guyer})'\n",
+    "print(f\"  {len(classes)} classes distinctes -- compte canonique Rapoport-Guyer 1966 : {verdict}\")\n"
    ]
   },
   {
@@ -249,10 +299,10 @@
    "id": "77d45634",
    "metadata": {
     "papermill": {
-     "duration": 0.00298,
-     "end_time": "2026-08-29T03:28:45.430447",
+     "duration": 0.003143,
+     "end_time": "2026-08-29T06:48:27.313574",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.427467",
+     "start_time": "2026-08-29T06:48:27.310431",
      "status": "completed"
     },
     "tags": []
@@ -260,7 +310,11 @@
    "source": [
     "### Lecture du resultat\n",
     "\n",
-    "L'enumeration produit **78 profils distincts** dont la distribution par classe Robinson-Goforth fait emerger les 4 archetypes canoniques (PD, SH, SD, H) avec leurs 4 profils canoniques specifies (T, R, P, S dans le bon ordre). Le reste des profils tombent dans **'Other'** — ces profils n'ont pas de structure d'incitation stricte et sont les **murs** au sens de #12213 (chambres-et-murs) : leur identite se voit dans la parente topologique plutot que dans la lecture des strategies dominantes.\n",
+    "L'espace ordinal strict se decoupe en trois niveaux, tous trois calcules par execution dans la cellule ci-dessus :\n",
+    "\n",
+    "- **576 jeux bruts** : chaque joueur attribue les rangs 1 a 4 a ses quatre issues (24 x 24 permutations) ;\n",
+    "- **144 structures d'incitations du joueur 1** : les paires ordonnees (R, S) et (T, P) de valeurs distinctes, dont la distribution par classe Robinson-Goforth fait emerger les 4 archetypes canoniques (1 PD, 7 SH, 1 SD, 7 H) ; les 128 profils restants tombent dans **'Other'** — sans structure d'incitation stricte, ils sont les **murs** au sens de #12213 (chambres-et-murs) : leur identite se voit dans la parente topologique plutot que dans la lecture des strategies dominantes ;\n",
+    "- **78 classes d'equivalence strategique** : le quotient des 576 jeux bruts par relabellage des joueurs, des lignes et des colonnes — c'est le compte canonique de Rapoport-Guyer (1966), **verifie par execution** ci-dessus.\n",
     "\n",
     "Archetti-Scheuring (2012, p. 10) affirment que **la parente des quatre jeux n'est pas evidente dans la taxonomie classique (Rapoport-Guyer 1966) mais claire dans une classification topologique** (Robinson-Goforth 2005). Notre verification ci-dessus donne chair a cette affirmation : les 4 archetypes canoniques se distinguent par leur signature topologique (les 4 inequalities strictes), pas par leur identite lexicale.\n",
     "\n",
@@ -272,10 +326,10 @@
    "id": "6b06f42d",
    "metadata": {
     "papermill": {
-     "duration": 0.002995,
-     "end_time": "2026-08-29T03:28:45.436455",
+     "duration": 0.002841,
+     "end_time": "2026-08-29T06:48:27.319331",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.433460",
+     "start_time": "2026-08-29T06:48:27.316490",
      "status": "completed"
     },
     "tags": []
@@ -308,16 +362,16 @@
    "id": "ae2a353e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:28:45.444428Z",
-     "iopub.status.busy": "2026-08-29T03:28:45.443427Z",
-     "iopub.status.idle": "2026-08-29T03:28:45.450219Z",
-     "shell.execute_reply": "2026-08-29T03:28:45.450219Z"
+     "iopub.execute_input": "2026-08-29T06:48:27.326463Z",
+     "iopub.status.busy": "2026-08-29T06:48:27.326098Z",
+     "iopub.status.idle": "2026-08-29T06:48:27.332673Z",
+     "shell.execute_reply": "2026-08-29T06:48:27.331955Z"
     },
     "papermill": {
-     "duration": 0.011912,
-     "end_time": "2026-08-29T03:28:45.451379",
+     "duration": 0.011918,
+     "end_time": "2026-08-29T06:48:27.334160",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.439467",
+     "start_time": "2026-08-29T06:48:27.322242",
      "status": "completed"
     },
     "tags": []
@@ -386,10 +440,10 @@
    "id": "913fdebc",
    "metadata": {
     "papermill": {
-     "duration": 0.002651,
-     "end_time": "2026-08-29T03:28:45.457016",
+     "duration": 0.004389,
+     "end_time": "2026-08-29T06:48:27.343538",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.454365",
+     "start_time": "2026-08-29T06:48:27.339149",
      "status": "completed"
     },
     "tags": []
@@ -397,7 +451,7 @@
    "source": [
     "### Lecture du resultat\n",
     "\n",
-    "L'enumeration produit **576 profils distincts en ordinaux stricts** dont la distribution par classe Robinson-Goforth fait emerger les 4 archetypes canoniques (4 PD, 28 SH, 4 SD, 28 H) sur 576 profils (les 88.9% restants sont des profils sans structure d'incitation stricte, les \"murs\" au sens de #12213 (chambres-et-murs)). La parente topologique de Robinson-Goforth (2005) tient : les 4 archetypes canoniques se distinguent par leur signature d'inegalites strictes, pas par leur identite lexicale.\n",
+    "**Rappel E1** : l'espace ordinal strict compte trois niveaux verifies par execution — **576 jeux bruts** (24 x 24 permutations de rangs par joueur), **144 structures d'incitations du joueur 1** (1 PD, 7 SH, 1 SD, 7 H, 128 murs 'Other' — les 88.9%), et **78 classes d'equivalence strategique** (Rapoport-Guyer 1966, verifiees par quotient sous relabellage joueurs/lignes/colonnes). La parente topologique de Robinson-Goforth (2005) tient : les 4 archetypes canoniques se distinguent par leur signature d'inegalites strictes, pas par leur identite lexicale.\n",
     "\n",
     "### Verdict E2 sur les regimes\n",
     "\n",
@@ -417,10 +471,10 @@
    "id": "7254815b",
    "metadata": {
     "papermill": {
-     "duration": 0.002906,
-     "end_time": "2026-08-29T03:28:45.461793",
+     "duration": 0.002779,
+     "end_time": "2026-08-29T06:48:27.349301",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.458887",
+     "start_time": "2026-08-29T06:48:27.346522",
      "status": "completed"
     },
     "tags": []
@@ -446,10 +500,10 @@
    "id": "4cba1a1c",
    "metadata": {
     "papermill": {
-     "duration": 0.002996,
-     "end_time": "2026-08-29T03:28:45.466789",
+     "duration": 0.002891,
+     "end_time": "2026-08-29T06:48:27.355073",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.463793",
+     "start_time": "2026-08-29T06:48:27.352182",
      "status": "completed"
     },
     "tags": []
@@ -479,16 +533,16 @@
    "id": "83312740",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:28:45.472550Z",
-     "iopub.status.busy": "2026-08-29T03:28:45.472550Z",
-     "iopub.status.idle": "2026-08-29T03:28:45.509559Z",
-     "shell.execute_reply": "2026-08-29T03:28:45.508928Z"
+     "iopub.execute_input": "2026-08-29T06:48:27.362194Z",
+     "iopub.status.busy": "2026-08-29T06:48:27.361920Z",
+     "iopub.status.idle": "2026-08-29T06:48:27.391027Z",
+     "shell.execute_reply": "2026-08-29T06:48:27.390426Z"
     },
     "papermill": {
-     "duration": 0.041293,
-     "end_time": "2026-08-29T03:28:45.510712",
+     "duration": 0.03463,
+     "end_time": "2026-08-29T06:48:27.392692",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.469419",
+     "start_time": "2026-08-29T06:48:27.358062",
      "status": "completed"
     },
     "tags": []
@@ -591,10 +645,10 @@
    "id": "83332779",
    "metadata": {
     "papermill": {
-     "duration": 0.002034,
-     "end_time": "2026-08-29T03:28:45.517600",
+     "duration": 0.003041,
+     "end_time": "2026-08-29T06:48:27.398407",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.515566",
+     "start_time": "2026-08-29T06:48:27.395366",
      "status": "completed"
     },
     "tags": []
@@ -616,10 +670,10 @@
    "id": "87ac3c30",
    "metadata": {
     "papermill": {
-     "duration": 0.002702,
-     "end_time": "2026-08-29T03:28:45.523892",
+     "duration": 0.001991,
+     "end_time": "2026-08-29T06:48:27.404792",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.521190",
+     "start_time": "2026-08-29T06:48:27.402801",
      "status": "completed"
     },
     "tags": []
@@ -650,16 +704,16 @@
    "id": "70916734",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-29T03:28:45.532250Z",
-     "iopub.status.busy": "2026-08-29T03:28:45.532250Z",
-     "iopub.status.idle": "2026-08-29T03:28:45.541263Z",
-     "shell.execute_reply": "2026-08-29T03:28:45.540036Z"
+     "iopub.execute_input": "2026-08-29T06:48:27.410096Z",
+     "iopub.status.busy": "2026-08-29T06:48:27.409737Z",
+     "iopub.status.idle": "2026-08-29T06:48:27.416756Z",
+     "shell.execute_reply": "2026-08-29T06:48:27.416103Z"
     },
     "papermill": {
-     "duration": 0.014195,
-     "end_time": "2026-08-29T03:28:45.542427",
+     "duration": 0.010941,
+     "end_time": "2026-08-29T06:48:27.417776",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.528232",
+     "start_time": "2026-08-29T06:48:27.406835",
      "status": "completed"
     },
     "tags": []
@@ -756,10 +810,10 @@
    "id": "02fb23f9",
    "metadata": {
     "papermill": {
-     "duration": 0.003349,
-     "end_time": "2026-08-29T03:28:45.550797",
+     "duration": 0.00207,
+     "end_time": "2026-08-29T06:48:27.422067",
      "exception": false,
-     "start_time": "2026-08-29T03:28:45.547448",
+     "start_time": "2026-08-29T06:48:27.419997",
      "status": "completed"
     },
     "tags": []
@@ -806,18 +860,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.808627,
-   "end_time": "2026-08-29T03:28:45.697315",
+   "duration": 2.944886,
+   "end_time": "2026-08-29T06:48:27.656581",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-03d-Plan-de-deformation.ipynb",
+   "input_path": "D:\\Dev\\CoursIA-13452-gt03d\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-03d-Plan-de-deformation.ipynb",
+   "output_path": "D:\\Dev\\CoursIA-13452-gt03d\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-03d-Plan-de-deformation_output.ipynb",
    "parameters": {},
-   "start_time": "2026-08-29T03:28:43.888688",
+   "start_time": "2026-08-29T06:48:24.711695",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/genai #13593

## Summary

Trancher l'incohérence E1 de `GameTheory-03d-Plan-de-deformation.ipynb` (prose « 78 profils distincts » vs output « 576 »). **Verdict par re-execution : les deux nombres décrivaient des espaces différents, et la boucle commettait en plus un bug de multiplicité.**

### Diagnostic (le code d'avant)

L'énumération itérait `permutations × permutations` (4-tuples) mais `rgs_class` ne lisait que les **2 premières entrées** de chaque tuple : chaque structure effective visitée **4×** (les 2 valeurs restantes indifférentes), soit 576 = 144 structures × 4. Ni le « 576 » affiché ni le « 78 » de la prose ne décrivaient un espace correct.

### Correction : trois espaces explicites, tous mesurés

| Espace | Définition | Mesure (exécutée) |
|--------|-----------|-------------------|
| **576 jeux bruts** | une matrice de rangs 1-4 par joueur (24 × 24 permutations) — espace de Rapoport-Guyer **avant** quotient | 576 |
| **144 structures d'incitations J1** | paires ordonnées (R,S) × (T,P) de valeurs distinctes | 144 — distribution : 1 PD, 7 SH, 1 SD, 7 H, 128 Other (88.9 % = les « murs ») |
| **78 classes d'équivalence stratégique** | quotient des 576 par re-étiquetage (lignes, colonnes, **échange des joueurs = transposition**) | **78 — compte canonique Rapoport-Guyer 1966 : VERIFIÉ PAR EXECUTION** |

Le point subtil du quotient (source du 84 naïf) : l'échange des joueurs s'accompagne de la **transposition** des matrices — `(A,B) → (Bᵀ, Aᵀ)` — sinon le quotient compte 84 classes au lieu des 78 canoniques.

### Prose alignée (4 cellules markdown + intro)

- cell 0 (intro), cell 3 (Verification), cell 5 (Lecture), cell 8 (Rappel E1) : description trois-niveaux cohérente avec les sorties ; plus aucun « 78 profils » sans espace associé.

## Validation

- Notebook ré-exécuté : cellules code 1-5 toutes `execution_count` non-null, **0 erreur**, sortie E1 réelle : `78 classes distinctes -- compte canonique Rapoport-Guyer 1966 : VERIFIE par execution`
- Le compte 78 a été **vérifié indépendamment** (implémentation séparée du quotient, même résultat) avant salvage
- `grep` : aucun pattern C.1 ajouté ; exercise cells intactes
- Catalogue byte-identique à `main` (aucun fichier catalogue touché)

## Provenance

Travail initié dans une session antérieure (commit `f3915295a3`, 29/08 08:49, poussé sur branche sans PR), sauvé : rebase sur `origin/main` frais (+83 commits, zéro drift sur le fichier), prose cell 3 alignée (2 lignes), livré. Branche renommée `fix/13452-gt03d-e1` (pas de force push sur l'ancienne).

Closes #13452