### PR TITLE
feat(arxiv,#12853): workflow guard attributions arXiv (9.3) + doc convention (9.4)

### DIFF
--- a/.github/workflows/arxiv-attributions-guard.yml
+++ b/.github/workflows/arxiv-attributions-guard.yml
@@ -1,0 +1,98 @@
+name: arXiv attributions guard
+
+# Issue #12853 acceptance 9.3 : le check scripts/check_arxiv_attributions.py
+# (livré par la veine 1, registre + check + tests) n'était câblé à AUCUN
+# workflow — scan exhaustif origin/main du 30/08 : zéro référence. Un organe
+# non branché ne voit rien : la classe de défaut « attribution fausse »
+# (#11065, #11110, #11127) re-driftait sans garde-fou, ce qui est exactement
+# le trou que l'issue décrit (« maintenance continue », passes 1-4 = des
+# événements ponctuels).
+#
+# Sémantique BLOQUANTE (contraste cjk-residue-advisory.yml, #8826) : la
+# présence d'une chaîne exacte dans une cellule d'un notebook est un invariant
+# de FICHIER déterministe — pas un jugement de contenu. Une entrée disparue
+# (notebook déplacé, cellule supprimée, attribution réécrite) = FAIL rouge,
+# pas un label. Le remède est mécanique : mettre à jour le registre (chemin /
+# cell_index / expected_citation lus depuis le diff réel, jamais de mémoire —
+# nit Hermes #12900, leçon c.542-L1) ou restaurer la citation.
+#
+# `--strict` : un RENAME (notebook déplacé, citation encore présente) échoue
+# aussi — en CI le registre DOIT suivre les déplacements ; le mode RENAMED
+# non-strict reste un outil de triage local.
+#
+# Étatique, pas diff-scopé : le check relit les 6 notebooks du registre sur
+# l'arbre courant (coût ~6 fichiers), indépendamment de ce que la PR change.
+# Le filtre de chemins ne fait qu'éviter des runs inutiles : registry /
+# script / tests / workflow (self-cover #8822) + les notebooks enregistrés.
+# Une entrée NOUVELLE passe par le registre (dans paths) donc déclenche son
+# propre contrôle. Le nocturne 03:47 UTC est le filet : un rename dont le
+# diff ne montre que le nouveau chemin esquive le filtre per-PR ; la sweep
+# suivante le voit (RENAMED/FAIL) sur main.
+#
+# Cron nocturne compatible stratification #12817/#12821 (minute étalée hors
+# :00/:30, après la fenêtre catalogue 03:37).
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'arxiv_attributions_registry.yaml'
+      - 'scripts/check_arxiv_attributions.py'
+      - 'scripts/tests/test_check_arxiv_attributions.py'
+      - '.github/workflows/arxiv-attributions-guard.yml'
+      - 'MyIA.AI.Notebooks/GameTheory/GameTheory-13b-Safe-Subgame-Solving.ipynb'
+      - 'MyIA.AI.Notebooks/ML/DataScienceWithAgents/03-DeepLearning/3.5-Phenomenes-de-Generalisation.ipynb'
+      - 'MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/Lab8-ADK-Introduction.ipynb'
+      - 'MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb'
+      - 'MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb'
+      - 'MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb'
+  schedule:
+    - cron: '47 03 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: arxiv-attributions-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  arxiv-attributions:
+    name: "arXiv attributions registry (7 entrees)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        # Etatique : aucune diff n'est resolue, depth 1 suffit.
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML (lecteur du registre)
+        run: python -m pip install --quiet pyyaml
+
+      - name: Guard — chaque entree du registre vit encore dans son notebook
+        run: |
+          set -uo pipefail
+          # rc capture sans abort (#8884) : ni `|| true` (desarme le gate)
+          # ni bare $( ) sous -e.
+          out=$(python scripts/check_arxiv_attributions.py --strict) && rc=0 || rc=$?
+          echo "$out"
+
+          echo "## arXiv attributions guard" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "$out" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=arXiv attributions::Une entree du registre n'est plus presente dans son notebook (FAIL) ou un notebook enregistre a ete deplace (RENAMED). Remede : mettre a jour arxiv_attributions_registry.yaml depuis le diff reel (chemin + cell_index + expected_citation, jamais de memoire) ou restaurer la citation. Cf #12853 / #11168."
+            exit 1
+          fi
+          echo "::notice title=arXiv attributions guard::Registre verifie : chaque entree vit encore dans son notebook (#12853)."

--- a/docs/reference/arxiv-attributions.md
+++ b/docs/reference/arxiv-attributions.md
@@ -1,0 +1,37 @@
+# Registre des attributions arXiv — convention et maintenance
+
+Issue #12853 (acceptance 9.4), parent EPIC #11168 (vérification des citations arXiv). Ce document fixe la convention du registre `arxiv_attributions_registry.yaml` et son organe CI.
+
+## Le problème traité
+
+La classe de défaut « attribution arXiv fausse » (#11065 Sendov, #11110, #11127) : un notebook cite un papier arXiv avec une année, un venue ou un titre erroné (ex. GAE attribué ICLR 2016 au lieu d'arXiv 2015). Quatre passes correctives (2026-08, #12824/#12832/#12838) ont corrigé les drifts trouvés, mais un correctif ponctuel ne se maintient pas seul : les notebooks évoluent, et une cellule réécrite peut perdre la citation corrigée. Le registre rend chaque correction **vérifiable mécaniquement**.
+
+## Les trois pièces
+
+| Pièce | Rôle |
+|---|---|
+| `arxiv_attributions_registry.yaml` (racine) | Une entrée par correction appliquée : `arxiv_id`, `notebook`, `cell_index` (0-based), `expected_citation` (chaîne exacte), `source_pr`, `correction`, `date` |
+| `scripts/check_arxiv_attributions.py` | Vérifie que chaque entrée vit encore : la chaîne `expected_citation` doit être trouvable dans la cellule `cell_index` du notebook. Modes : défaut (RENAMED toléré pour triage), `--strict` (rename = FAIL, mode CI), `--paths` (limite aux globs), `--json` |
+| `.github/workflows/arxiv-attributions-guard.yml` | Gate bloquant per-PR (paths filtrés : registre, script, tests, workflow, notebooks enregistrés) + nocturne 03:47 UTC + dispatch |
+
+## Convention d'ajout (HARD)
+
+1. **Chaque entrée est extraite MÉCANIQUEMENT depuis le diff de la PR source** (`git diff origin/main...<branche>`) : chemin, `cell_index`, `expected_citation` lus depuis le diff réel — **jamais rédigés de mémoire**. Le registre v1 de 18 entrées avait été fabriqué de mémoire (16 notebooks inexistants — nit Hermes sur #12900, leçon c.542-L1) puis régénéré en 7 entrées valides (#12941).
+2. Une correction d'attribution = **une entrée de registre dans la même PR**. Le gate tourne sur le registre (dans les paths du workflow) : la nouvelle entrée est vérifiée dès son arrivée.
+3. Un notebook déplacé = mise à jour du champ `notebook` dans la même PR (`--strict` fait échouer le rename sinon — c'est voulu : le registre suit les déplacements).
+4. La chaîne `expected_citation` doit être **stable et courte** : ancrez sur la portion de citation portant la correction (l'année arXiv, le titre court), pas sur une phrase entière qu'un enrichissement Markdown déplacerait.
+
+## Ce que le gate attrape et n'attrape pas
+
+- **Attrape** : citation corrigée supprimée ou réécrite (FAIL), notebook enregistré déplacé sans suivi de registre (RENAMED → FAIL en strict), régression d'attribution sur les entrées connues.
+- **N'attrape pas** : les nouvelles citations erronées dans des familles non auditées (11 familles restent à couvrir, veine 3 de #12853) — c'est le travail des passes d'audit et de la veine 2 (re-sonde arXiv API, sub-grain séparé). Le registre est un ratchet, pas un auditeur.
+
+## Ajouter un notebook au filtre du workflow
+
+Le `paths:` du workflow énumère les notebooks enregistrés. Un ajout d'entrée sur un notebook pas encore listé = ajouter son chemin au `paths:` dans la même PR (le registre est déjà dans les paths, donc le gate tourne et couvre la nouvelle entrée même sans ce geste — le filtre n'est qu'une économie de runs ; le nocturne couvre le reste).
+
+## Historique
+
+- Passes 1-4 (2026-08) : 6 IDs corrigés sur 16 notebooks (#12824, #12832, #12838 + passe 4 no-op).
+- #12900 (fermée) → registre régénéré mécaniquement #12941 ; le guard a attrapé son propre drift sur #13349 (`rl_6c` cell 27).
+- Workflow + ce document : clôture acceptance 9.3/9.4 de #12853.


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2027:CoursIA-2 — prev: MED/notebook-python #13590

Closes #12853

## Acceptance 9.3 + 9.4 — les deux items restants du triage du 30/08

Le triage Vibe (po-2023, 2026-08-30) a laissé l'issue ouverte sur exactement deux points : aucun workflow ne référence `check_arxiv_attributions` (9.3) et aucune documentation de convention (9.4). Cette PR livre les deux — le livrable veine 1 (registre + check + tests, 3 fichiers sur main) était déjà fonctionnel.

## 9.3 — `.github/workflows/arxiv-attributions-guard.yml`

* **Gate bloquant** per-PR, `paths:` filtré : registre, script, tests, workflow lui-même (self-cover #8822) + les 6 notebooks enregistrés. Économie de runs, pas un affaiblissement : le check est étatique (relit les 6 notebooks du registre sur l'arbre courant).
* `--strict` en CI : un RENAME (notebook déplacé) échoue aussi — le registre DOIT suivre les déplacements.
* **Nocturne 03:47 UTC** (minute étalée, fenêtre compatible #12817/#12821) : filet pour les renames dont le diff per-PR ne montre que le nouveau chemin + vérification post-merge de main.
* Sémantique bloquante assumée (contraste `cjk-residue-advisory.yml`) : présence d'une chaîne exacte dans une cellule = invariant de fichier déterministe, pas un jugement de contenu.
* Capture du rc sans abort (#8884) : `out=$(...) && rc=0 || rc=$?`, ni `|| true` ni bare `$( )`.

## 9.4 — `docs/reference/arxiv-attributions.md`

Convention : format d'entrée, extraction MÉCANIQUE depuis le diff réel (leçon c.542-L1 : le registre v1 de 18 entrées fabriquées de mémoire portait 16 notebooks inexistants, régénéré en 7 valides), ancrage de `expected_citation` court et stable, geste de suivi des renames, périmètre attrapé/non-attrapé (ratchet, pas auditeur — veines 2-3 restent des sub-grains).

## Contrôle positif local

```console
$ python scripts/check_arxiv_attributions.py --strict
# Summary: 7 PASS, 0 FAIL, 0 RENAMED    (exit 0)
```

`check_workflow_label_paths.py` : pass. YAML validé (triggers pull_request/schedule/dispatch).

## Conformité

* Scope strict : 2 fichiers nouveaux, rien d'autre touché. Catalogue byte-identique à main.
* Genre `guard` assumé (peut rougir) ; grain MED (câble un organe existant dans CI + convention écrite, avec vérification locale).
* Note d'ordre de merge pour la lane : si `adjacency` (G-VAR-3, tier-aveugle #13575) s'affiche tant que #13590 (notebook-python) n'est pas mergé — même mécanisme documenté sur #13583, même résolution par ordre de merge. Séquence lane : #13557 → #13583 → #13590 → celle-ci.
