### PR TITLE
fix(test,#13553): le cliquet de compte ne masque plus les invariants de parité

### DIFF
--- a/scripts/translation/tests/test_check_translation_parity.py
+++ b/scripts/translation/tests/test_check_translation_parity.py
@@ -700,6 +700,54 @@ def test_is_scannable_matches_on_relative_parts_only(tmp_path):
 EXPECTED_PAIR_COUNT = 2
 
 
+def _collect_parity_failures(repo_root: Path,
+                             expected_pair_count: int) -> list[str]:
+    """#13553 — accumuler compte ET invariants, au lieu de court-circuiter.
+
+    L'ancienne forme (``assert len(pairs) == EXPECTED_PAIR_COUNT`` PUIS la
+    boucle d'invariants) rendait un échec unique et rassurant dès que le
+    compte dérivait : pytest s'arrête à la première assertion, donc AUCUN
+    invariant de contenu n'était évalué. La docstring promettait pourtant
+    « Any existing pair ... is still checked against all invariants » —
+    faux précisément dans le seul scénario qu'elle anticipe (reprise du
+    hold, dérive par construction). Accumulation sans dépendance : chaque
+    défaut devient une ligne, l'assert finale les porte toutes.
+    """
+    pairs = p.discover_pairs(repo_root, ["en", "ru"])
+    failures: list[str] = []
+    if len(pairs) != expected_pair_count:
+        failures.append(
+            f"translation pair count drifted from the declared perimeter: "
+            f"found {len(pairs)}, declared {expected_pair_count} "
+            f"(update EXPECTED_PAIR_COUNT knowingly — hold i18n #10038)"
+        )
+    for src_path, trd_path, stem, lang in pairs:
+        src_cells, src_err = p.load_cells(src_path)
+        trd_cells, trd_err = p.load_cells(trd_path)
+        if src_err is not None:
+            failures.append(f"source unreadable : {src_path} ({src_err})")
+            continue
+        if trd_err is not None:
+            failures.append(f"translation unreadable : {trd_path} ({trd_err})")
+            continue
+        anomalies = p.check_invariants(src_cells, trd_cells, strict_fr=True)
+        blocking = [
+            a
+            for a in anomalies
+            if a.verdict in ("CODE_DRIFT", "STRUCTURE_DRIFT", "OUTPUT_FABRICATED")
+        ]
+        fr_contam_strict = [a for a in anomalies if a.verdict == "FR_CONTAM"]
+        if blocking:
+            failures.append(
+                f"pair {stem}_{lang} has blocking anomalies : {blocking}"
+            )
+        if fr_contam_strict:
+            failures.append(
+                f"pair {stem}_{lang} has FR_CONTAM under strict_fr : {fr_contam_strict}"
+            )
+    return failures
+
+
 def test_full_repo_state_passes_parity():
     """Reference test against the live ``xxx_<lang>.ipynb`` artifacts on main.
 
@@ -711,30 +759,51 @@ def test_full_repo_state_passes_parity():
     Expected pair count is declared in ``EXPECTED_PAIR_COUNT`` above (hold
     i18n #10038). Any existing pair — including every pair reintroduced after
     the hold lifts — is still checked against all invariants including
-    strict-fr.
+    strict-fr (#13553 : l'échec de compte n'éclipse plus les invariants —
+    tous les défauts sont rapportés dans le même run).
     """
     repo_root = HERE.parent.parent.parent  # scripts/translation/tests/ → repo root
-    pairs = p.discover_pairs(repo_root, ["en", "ru"])
-    assert len(pairs) == EXPECTED_PAIR_COUNT, (
-        f"translation pair count drifted from the declared perimeter: "
-        f"found {len(pairs)}, declared {EXPECTED_PAIR_COUNT} "
-        f"(update EXPECTED_PAIR_COUNT knowingly — hold i18n #10038)"
-    )
-    for src_path, trd_path, stem, lang in pairs:
-        src_cells, src_err = p.load_cells(src_path)
-        trd_cells, trd_err = p.load_cells(trd_path)
-        assert src_err is None, f"source unreadable : {src_path} ({src_err})"
-        assert trd_err is None, f"translation unreadable : {trd_path} ({trd_err})"
-        anomalies = p.check_invariants(src_cells, trd_cells, strict_fr=True)
-        blocking = [
-            a
-            for a in anomalies
-            if a.verdict in ("CODE_DRIFT", "STRUCTURE_DRIFT", "OUTPUT_FABRICATED")
-        ]
-        fr_contam_strict = [a for a in anomalies if a.verdict == "FR_CONTAM"]
-        assert blocking == [], (
-            f"pair {stem}_{lang} has blocking anomalies : {blocking}"
-        )
-        assert fr_contam_strict == [], (
-            f"pair {stem}_{lang} has FR_CONTAM under strict_fr : {fr_contam_strict}"
-        )
+    failures = _collect_parity_failures(repo_root, EXPECTED_PAIR_COUNT)
+    assert failures == [], "\n".join(failures)
+
+
+# ---------------------------------------------------------------------------
+# #13553 — le cliquet de compte ne masque pas les invariants (acceptance)
+# ---------------------------------------------------------------------------
+
+
+def test_13553_count_drift_and_fr_contam_surface_together(tmp_path):
+    """Acceptance : compte faux ET FR_CONTAM => LES DEUX dans un seul run.
+
+    Contrôle négatif structurel : sous l'ancienne forme (assert de compte en
+    tête), ce test échoue — la ligne FR_CONTAM n'existerait pas dans la
+    sortie. C'est la seule façon de distinguer « accumule » de « masque ».
+    """
+    src = [_md_cell("c1", "# Un titre détaillé\n\nCorps long et riche.")]
+    trd = [_md_cell("c1", "# Un titre détaillé\n\nCorps long et riche.")]
+    _write_pair(tmp_path, "Drift-Contam", src, trd)
+    failures = _collect_parity_failures(tmp_path, expected_pair_count=7)
+    assert len(failures) == 2, failures
+    assert "declared perimeter" in failures[0]
+    assert "FR_CONTAM" in failures[1]
+
+
+def test_13553_count_drift_alone_still_reddens(tmp_path):
+    """Contrôle négatif : une dérive de compte SEULE reste rouge — on
+    n'affaiblit pas le cliquet, on l'empêche seulement de masquer."""
+    src = [_md_cell("c1", "# Un titre détaillé\n\nCorps long et riche.")]
+    trd = [_md_cell("c1", "# A detailed title\n\nLong rich body.")]
+    _write_pair(tmp_path, "Clean-Drift", src, trd)
+    failures = _collect_parity_failures(tmp_path, expected_pair_count=3)
+    assert len(failures) == 1, failures
+    assert "declared perimeter" in failures[0]
+
+
+def test_13553_clean_state_collects_nothing(tmp_path):
+    """Compte juste + paire propre => aucune ligne de défaut (comportement
+    du test de référence inchangé sur un état sain)."""
+    src = [_md_cell("c1", "# Un titre détaillé\n\nCorps long et riche.")]
+    trd = [_md_cell("c1", "# A detailed title\n\nLong rich body.")]
+    _write_pair(tmp_path, "Clean-01", src, trd)
+    failures = _collect_parity_failures(tmp_path, expected_pair_count=1)
+    assert failures == []


### PR DESCRIPTION
Grain: MED/test -- lane myia-po-2026:CoursIA -- prev: MED/tooling #13542

## Sujet

`test_full_repo_state_passes_parity` : l'assertion de compte court-circuite la boucle d'invariants — un échec de compte rend un rouge unique, lisible et rassurant, sans avoir évalué le contenu. See #13553.

## Contenu (1 fichier)

`scripts/translation/tests/test_check_translation_parity.py` — le corps du test de référence devient `_collect_parity_failures(repo_root, expected_pair_count)` qui **accumule** compte + invariants (lignes de défaut), l'assert finale porte tout. La forme 2 seule (réordonner) ne satisfait pas l'acceptance « les DEUX dans la sortie d'un seul run » (pytest s'arrête à la première assertion) — c'est la forme 1 (accumulation) qui est livrée, sans dépendance (pas de pytest-check/subtests dans l'env).

- Message du cliquet conservé verbatim (reconnaissable).
- Comportement inchangé sur état sain (35 passed dont le test de référence).
- 3 tests hermétiques : acceptance (compte faux + FR_CONTAM => 2 lignes), contrôle négatif (dérive de compte seule reste rouge), état propre (0 ligne).

## Preuves

- `python -m pytest scripts/translation/tests/test_check_translation_parity.py -q` : **35 passed**.
- `python -m pytest scripts/translation/tests -q` : **343 passed**. `python -m pytest scripts/tests -q` : **3657 passed, 0 failed**.
- **Contrôle négatif exécuté** : simulation in-place de l'ancienne sémantique masquante (retour anticipé sur dérive de compte) → `test_13553_count_drift_and_fr_contam_surface_together` **FAIL** (1 failure : FR_CONTAM invisible), les 2 autres tests passent ; restauration vérifiée, 35 passed.

## Contexte

Constat posé en portant #13542 (le geste prescrit par le commentaire du fichier — `EXPECTED_PAIR_COUNT 0 -> 2` — a fait ressortir FR_CONTAM que le cliquet masquait). Diagnostic ai-01, suivi demandé par cette lane, feu vert donné dans le body de l'issue. La docstring « Any existing pair ... is still checked against all invariants » redevient vraie dans le seul scénario qu'elle anticipe (reprise du hold i18n).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
