### PR TITLE
test(qc-freshness,#13603): fixtures sous TemporaryDirectory — fin du depot test_nb.ipynb dans le cwd

### DIFF
--- a/scripts/tests/test_check_quantconnect_notebook_freshness.py
+++ b/scripts/tests/test_check_quantconnect_notebook_freshness.py
@@ -11,6 +11,7 @@ import json
 import pathlib
 import subprocess
 import sys
+import tempfile
 import unittest
 from unittest import mock
 
@@ -108,11 +109,23 @@ class TestClassifyPath(unittest.TestCase):
 
 
 class TestScanNotebook(unittest.TestCase):
-    """Scan end-to-end d'un notebook dans un faux repo."""
+    """Scan end-to-end d'un notebook dans un faux repo.
 
-    def _make_nb(self, tmp: pathlib.Path, code_sources: list) -> pathlib.Path:
+    Les fixtures vivent dans un TemporaryDirectory (issue #13603) : la
+    suite ne depose plus test_nb.ipynb / md_only.ipynb / corrupt.ipynb
+    dans le cwd du run (worktree propre apres passage complet).
+    """
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = pathlib.Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _make_nb(self, code_sources: list) -> pathlib.Path:
         nb = {"cells": [{"cell_type": "code", "source": s} for s in code_sources]}
-        nb_path = tmp / "test_nb.ipynb"
+        nb_path = self.tmp / "test_nb.ipynb"
         nb_path.write_bytes(json.dumps(nb).encode())
         return nb_path
 
@@ -141,38 +154,36 @@ class TestScanNotebook(unittest.TestCase):
             return result
 
         with mock.patch("subprocess.run", fake_run):
-            with mock.patch.object(g, "find_repo_root", return_value=pathlib.Path(".")):
-                nb_path = self._make_nb(pathlib.Path("."),
-                                          ["results_path = Path('scripts/results/GITIGNORED_DIR/x.json')",
-                                           "p = Path('scripts/results/baselines_zeroshot/results.json')",
-                                           "p = Path('scripts/results/NEVER_TRACKED_NEVER_GITIGNORED/x.json')"])
-                result = g.scan_notebook(nb_path, pathlib.Path("."))
+            with mock.patch.object(g, "find_repo_root", return_value=self.tmp):
+                nb_path = self._make_nb(
+                    ["results_path = Path('scripts/results/GITIGNORED_DIR/x.json')",
+                     "p = Path('scripts/results/baselines_zeroshot/results.json')",
+                     "p = Path('scripts/results/NEVER_TRACKED_NEVER_GITIGNORED/x.json')"])
+                result = g.scan_notebook(nb_path, self.tmp)
 
         statuses = [f["status"] for f in result["findings"]]
         self.assertEqual(statuses, ["GITIGNORED", "OK", "MISSING"])
 
     def test_scan_empty_notebook(self):
-        nb_path = self._make_nb(pathlib.Path("."), [])
-        result = g.scan_notebook(nb_path, pathlib.Path("."))
+        nb_path = self._make_nb([])
+        result = g.scan_notebook(nb_path, self.tmp)
         self.assertEqual(result["findings"], [])
 
     def test_scan_markdown_only(self):
         # Cellules markdown ne produisent pas de paths.
         with mock.patch("subprocess.run", mock.Mock()):
-            with mock.patch.object(g, "find_repo_root", return_value=pathlib.Path(".")):
+            with mock.patch.object(g, "find_repo_root", return_value=self.tmp):
                 nb = {"cells": [{"cell_type": "markdown", "source": ["# scripts/results/foo/results.json\n"]}]}
-                nb_path = pathlib.Path("md_only.ipynb")
+                nb_path = self.tmp / "md_only.ipynb"
                 nb_path.write_bytes(json.dumps(nb).encode())
-                result = g.scan_notebook(nb_path, pathlib.Path("."))
+                result = g.scan_notebook(nb_path, self.tmp)
                 self.assertEqual(result["findings"], [])
-                nb_path.unlink()
 
     def test_scan_corrupt_json(self):
-        bad_path = pathlib.Path("corrupt.ipynb")
+        bad_path = self.tmp / "corrupt.ipynb"
         bad_path.write_bytes(b"{not json")
-        result = g.scan_notebook(bad_path, pathlib.Path("."))
+        result = g.scan_notebook(bad_path, self.tmp)
         self.assertIn("error", result)
-        bad_path.unlink()
 
 
 class TestRealM15Case(unittest.TestCase):


### PR DESCRIPTION
Grain: LIGHT/test — lane myia-po-2023:CoursIA-2 — prev: MED/guard #13608

## What

`TestScanNotebook` (scripts/tests/test_check_quantconnect_notebook_freshness.py) écrivait ses fixtures dans `pathlib.Path(".")` — le cwd du run. Lancée depuis la racine d'un worktree, la suite y déposait `test_nb.ipynb` (non-tracké, jamais unlinké sur les deux sites cités par l'issue) ainsi que `md_only.ipynb` / `corrupt.ipynb` (unlinkés en happy path seulement : un échec d'assertion laissait le fichier en place).

Fix : `setUp`/`tearDown` avec `tempfile.TemporaryDirectory`, `_make_nb` écrit sous `self.tmp`, `find_repo_root` mocké sur le tmpdir, unlinks manuels supprimés (le nettoyage du tmpdir couvre aussi les échecs d'assertion).

## Acceptance (les 2 critères de l'issue)

1. **Toutes les écritures sous tempfile** : les 4 tests de la classe (`three_statuses`, `empty`, `markdown_only`, `corrupt_json`) écrivent désormais exclusivement sous `TemporaryDirectory`. Closes #13603
2. **Worktree frais + suite complète -> `git status --porcelain` vide** : vérifié sur un worktree créé à l'instant depuis `origin/main` — `python -m pytest scripts/tests -q` -> **3688 passed, 13 skipped, 5 xfailed in 219s**, puis `git status --porcelain` ne montre QUE le fichier de test modifié (l'unique changement intentionnel). Zéro artefact déposé.

## Validation

- `python -m pytest scripts/tests/test_check_quantconnect_notebook_freshness.py -q` -> **13 passed**.
- Aucun comportement de production touché : seul le fichier de test change (1 fichier, +9/-15).
