### PR TITLE
fix(guard,#13610): check_pr_perimeter -- article indefini + edit-verb dont le referent NOMMÉ n'est pas dans la PR

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -418,10 +418,18 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
         # reached the terminal "unverifiable" branch despite being a true
         # perimeter claim. Read the same closed list, same first-non-zero
         # rule. FR cardinals are unique 1-10 (no false twin like EN "six").
-        problems.append(
-            f"l'assertion pretend {word_count} fichier(s), la liste effective en compte {len(files)} : "
-            + ", ".join(f["path"] for f in files)
-        )
+        # #13610: an indefinite-article word count whose edit-verb referent is
+        # a NAMED file not in this PR is a descriptive mention of another
+        # file (routing target, dependency, candidate not chosen) -- not the
+        # PR's perimeter. Skip the red; the digit branch never produces this
+        # shape so the guard sits here only.
+        if _word_form_is_indef_non_pr_subject(scan_target, files):
+            pass
+        else:
+            problems.append(
+                f"l'assertion pretend {word_count} fichier(s), la liste effective en compte {len(files)} : "
+                + ", ".join(f["path"] for f in files)
+            )
     exclusive = _has_exclusivity(scan_target.lower())
     if exclusive:
         for f in files:
@@ -503,6 +511,34 @@ INCIDENTAL_QUALIFIERS = frozenset({
     # as "nouveau/nouveaux/nouvelle/nouvelles" above; the masculine/feminine
     # singular/plural variants were missing.
     "neuf", "neuve", "neufs",})
+# ---------------------------------------------------------------------------
+# #13610 -- article indefini en position d'objet d'un verbe d'action dont le
+# sujet N'est PAS la PR. Founder case PR #13539 l.43 :
+# « generaliser demanderait d'editer un fichier deja porteur de deux PRs
+# ouvertes de la meme lane (#13496, #13499) » -- « un fichier » y designe
+# `pick_idle_grain.py` (un fichier que la PR ne touche pas, cite pour
+# justifier un non-geste de routage), et le guard tirait 1 fichier(s) face a
+# une liste de 3, rougissant un check requis sur une PR saine. Meme classe
+# symetrique que les fondateurs #11985 forme 5/6 : un referent descriptif,
+# pas une assertion de perimetre.
+#
+# Discriminant : « (un|une|des) (fichier|files)(s) » OUVERT par un verbe
+# d'action EDIT + un nom de FICHIER NOMMÉ sur la meme ligne ET ce nom n'est
+# PAS dans `files`. Si le referent reste anonyme (« editer un fichier »),
+# le cas est ambigu et le garde CONSERVE le rouge (FN safety par defaut,
+# coherent avec le pattern fondateur du script).
+# ---------------------------------------------------------------------------
+_INDEF_ARTICLE = re.compile(r"\b(?:un|une|des)\s+(?:fichiers?|files?)\b", re.IGNORECASE)
+_EDIT_VERB = re.compile(
+    r"\b(?:editer|modifier|toucher|ouvrir|créer|creer|ajouter|changer|mettre\s+à\s+jour|mettre\s+a\s+jour|update|edit|modify|touch|open|create|add|change)\b",
+    re.IGNORECASE,
+)
+# A named file as it would appear in a body: backticked path, bare basename
+# (.py/.cs/.yml/.json/.md/.ipynb/.sh), or a known scripts/<x>.py shape.
+_NAMED_FILE_BODY = re.compile(
+    r"(?:`([^`]+\.[A-Za-z0-9]+)`|"  # backticked: `pick_idle_grain.py`
+    r"\b([\w./-]+\.(?:py|cs|yml|yaml|json|md|ipynb|ts|js|sh|toml|cfg|ini))\b)"  # bare basename
+)
 # A cited threshold ("< 15 fichiers", ">= 10 fichiers") quotes a rule, it does
 # not claim a perimeter.
 COMPARISON_PREFIX = re.compile(r"[<>=≤≥]\s*$")
@@ -751,6 +787,47 @@ def _count_is_exempt(line: str, m: re.Match, ante_context: str = "") -> bool:
     if _count_has_incidental_qualifier(line, m):
         return True
     return False
+
+
+def _word_form_is_indef_non_pr_subject(text: str, files: list[dict]) -> bool:
+    """#13610: True when a word-form count in `text` is an indefinite
+    article (« un/une/des fichier(s) ») opened by an edit-verb whose NAMED
+    referent is NOT in `files`. The phrase describes an OTHER file (a
+    routing target, a dependency, a candidate not chosen) and is not the
+    PR's perimeter.
+
+    FN safety: when the referent is anonymous (« editer un fichier » with
+    no named file), the function returns False -- the ambiguous shape
+    stays blocking, coherent with the script's founder pattern (default
+    fails loud; new vocabulary is gated by a measurement, not an
+    intuition). Founder case PR #13539 l.43 :
+    « generaliser demanderait d'editer un fichier deja porteur de deux PRs
+    ouvertes de la meme lane (#13496, #13499) » -- here "un fichier"
+    designates `pick_idle_grain.py` (a file the PR does not touch), and
+    the guard drew 1 vs 3, blocking a healthy PR.
+
+    Hook: called from `check_assertion` on the `word_count` branch only.
+    The digit branch (COUNT_CLAIM) cannot produce the indefinite-article
+    shape and so does not need this guard.
+    """
+    low = text.lower()
+    m = _INDEF_ARTICLE.search(low)
+    if m is None:
+        return False
+    start = m.start()
+    window_before = text[max(0, start - 80):start]
+    if not _EDIT_VERB.search(window_before):
+        return False
+    paths_in_files = {f["path"] for f in files}
+    paths_in_files_basenames = {p.rsplit("/", 1)[-1] for p in paths_in_files}
+    named = _NAMED_FILE_BODY.findall(text)
+    named_flat = [n[0] or n[1] for n in named if n[0] or n[1]]
+    if not named_flat:
+        return False
+    return any(
+        n not in paths_in_files and n not in paths_in_files_basenames
+        for n in named_flat
+    )
 
 
 def _additive_line_sum(line: str) -> int:

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -36,6 +36,7 @@ from check_pr_perimeter import (  # noqa: E402
     _normalize_rest_files,
     _paragraph_prefix,
     _word_form_count,
+    _word_form_is_indef_non_pr_subject,
 )
 
 # The exact shape of the founding incident (#11227).
@@ -2610,3 +2611,125 @@ def test_13535_word_form_extraction_still_fires():
     mismatch = "Périmètre : trois fichiers uniquement, aucune autre modification."
     problems = check_assertion(FILES_2_13499, mismatch)
     assert problems and any("2" in p for p in problems)
+
+# ---------------------------------------------------------------------------
+# #13610 -- article indefini ("un/une/des fichier(s)") + verbe d'action dont
+# le referent NOMMÉ n'est pas dans la PR. Founder case PR #13539 l.43 :
+# « generaliser demanderait d'editer pick_idle_grain.py, un fichier deja
+# porteur de deux PRs ouvertes de la meme lane (#13496, #13499) ». The
+# "un fichier" describes an OTHER file (a routing target, a dependency), not
+# the PR's perimeter. FN safety: anonymous referent (no named file on the
+# line) keeps the rouge -- consistent with the script's founder pattern of
+# default-fail-loud on ambiguous shapes.
+# ---------------------------------------------------------------------------
+
+FILES_13610 = [
+    {"path": ".github/workflows/epic-charter-advisory.yml"},
+    {"path": "scripts/check_epic_charter.py"},
+    {"path": "scripts/tests/test_epic_charter.py"},
+]
+
+
+def test_13610_founder_case_named_out_of_scope_passes():
+    """Founder case (verbatim shape, with the named file explicit): the
+    'un fichier' referent is `pick_idle_grain.py`, a file the PR does NOT
+    touch. The guard must NOT rouge the word-form count."""
+    line = (
+        "generaliser demanderait d'editer pick_idle_grain.py, un fichier "
+        "deja porteur de deux PRs ouvertes de la meme lane (#13496, #13499)"
+    )
+    problems = check_assertion(FILES_13610, line)
+    assert problems == [], (
+        "founder shape must not rouge the word-form count; got: " + repr(problems)
+    )
+
+
+def test_13610_founder_case_via_une_target():
+    """Symmetric founder case via the feminine article 'une cible', with a
+    named file. Mirrors the live #13539 reformulation: 'une cible' was
+    already outside the count regex (no 'fichier(s)' in the phrase), and
+    the `non verifiable` guard fires because no count + no exclusivity is
+    recognized -- but the body still does not falsely rouge on a NUMBER
+    mismatch. The shape's exemption from the count branch is structural;
+    this test pins that."""
+    line = (
+        "generaliser demanderait d'editer scripts/pick_idle_grain.py, une "
+        "cible deja porteuse de deux PRs ouvertes de la meme lane (#13496)"
+    )
+    problems = check_assertion(FILES_13610, line)
+    # The 'non verifiable' guard fires (no digit count + no exclusivity
+    # marker) -- this is NOT the founder case (#13610); the founder case
+    # is the COUNT_MISMATCH branch with an indefinite article. Documented
+    # here to prevent a future refactor from collapsing the two shapes.
+    assert any("formulation non verifiable" in p for p in problems), (
+        "expected the 'non verifiable' guard to fire for a 'une cible' "
+        "shape (no digit count, no exclusivity); got: " + repr(problems)
+    )
+    assert not any("l'assertion pretend" in p for p in problems), (
+        "an indefinite article with no 'fichier(s)' must not trigger a "
+        "count-mismatch rouge; got: " + repr(problems)
+    )
+
+
+def test_13610_true_assertion_one_file_named_in_scope_still_rouges():
+    """A genuine 'un fichier' perimeter claim whose named referent IS in
+    the PR stays blocking -- the filter must not silence true assertions."""
+    line = "Cette PR modifie un fichier scripts/check_epic_charter.py"
+    problems = check_assertion(FILES_13610, line)
+    assert len(problems) == 1, (
+        "true assertion must still rouge; got: " + repr(problems)
+    )
+    assert "l'assertion pretend 1 fichier" in problems[0]
+
+
+def test_13610_fn_safety_anonymous_referent_keeps_rouge():
+    """FN control 1: no named file on the line, but the edit-verb is
+    present. The shape is AMBIGUOUS -- 'editer un fichier' could mean the
+    PR or another file. Default-fail-loud: keep the rouge."""
+    line = (
+        "generaliser demanderait d'editer un fichier deja porteur de "
+        "deux PRs ouvertes de la meme lane"
+    )
+    problems = check_assertion(FILES_13610, line)
+    assert len(problems) == 1, (
+        "anonymous referent must stay rouge; got: " + repr(problems)
+    )
+
+
+def test_13610_fn_safety_no_edit_verb_keeps_rouge():
+    """FN control 2: no edit-verb in the run-up. The 'un fichier' is
+    descriptive prose, but without an action verb the exemption branch
+    cannot fire -- the rouge stays."""
+    line = "il y a un fichier quelque part qui pose probleme."
+    problems = check_assertion(FILES_13610, line)
+    assert len(problems) == 1, (
+        "no-verb shape must stay rouge; got: " + repr(problems)
+    )
+
+
+def test_13610_predicate_unit_unanimous():
+    """Direct unit test of _word_form_is_indef_non_pr_subject: 5 sentences,
+    unanimous verdicts. Decoupled from check_assertion so a future pipeline
+    change cannot mask a predicate regression."""
+    files = FILES_13610
+    # True cases
+    assert _word_form_is_indef_non_pr_subject(
+        "editer pick_idle_grain.py, un fichier deja porteur", files
+    ) is True
+    assert _word_form_is_indef_non_pr_subject(
+        "modifier scripts/foo.py, un fichier de tests", files
+    ) is True
+    # False cases (genuine or ambiguous)
+    assert _word_form_is_indef_non_pr_subject(
+        "Cette PR modifie un fichier scripts/check_epic_charter.py", files
+    ) is False
+    assert _word_form_is_indef_non_pr_subject(
+        "editer un fichier quelque part", files
+    ) is False  # anonymous
+    assert _word_form_is_indef_non_pr_subject(
+        "il y a un fichier ici", files
+    ) is False  # no edit-verb
+    assert _word_form_is_indef_non_pr_subject(
+        "Cette PR ajoute un fichier scripts/check_epic_charter.py dans "
+        "scripts/check_epic_charter.py", files
+    ) is False  # named file IS in scope


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: DEEP/notebook-python #13604 (G-VAR-1 tenu c.707)

## fix(guard,#13610): check_pr_perimeter -- article indefini + edit-verb dont le referent NOMMÉ n'est pas dans la PR

### 1. Le defaut

`check_pr_perimeter.py` traite toute occurrence de « un/une/des fichier(s) » en prose comme une assertion de perimetre, y compris quand la phrase parle d'un fichier **HORS du diff de la PR**.

Founder case **PR #13539 l.43** :

> generaliser demanderait d'editer pick_idle_grain.py, un fichier deja porteur de deux PRs ouvertes de la meme lane (#13496, #13499)

« un fichier » y designe `pick_idle_grain.py` — un fichier que cette PR ne touche pas, cite pour justifier un non-geste de routage. Le garde en tirait :

```
l'assertion pretend 1 fichier(s), la liste effective en compte 3
VERDICT: FAIL
```

et le check requis `Always-on guards` passait au rouge sur une PR saine. La reformulation ulterieure du body a contourne le defaut mais n'a pas corrigé la classe.

### 2. La classe symetrique

Tell **c.649-L1 ★★★ sustained** : PR perimeter guard #11268 fausse assercion. La classe symétrique (sur-accusation) traitée ici, l'asymétrique originelle (sous-comptage) par les fondateurs precedents (#11712 #11985 etc.).

Le discriminateur manque : **article indéfini + verbe d'action dont le sujet n'est pas la PR**.

### 3. Le fix

Nouvelle fonction `_word_form_is_indef_non_pr_subject(text, files)` dans `scripts/check_pr_perimeter.py` :

| Critere | Regle |
|---------|-------|
| **Forme** | `\b(un\|une\|des)\s+(fichiers?\|files?)\b` sur la ligne |
| **Verbe d'action** | `editer\|modifier\|toucher\|ouvrir\|creer\|ajouter\|changer\|mettre a jour\|update\|edit\|modify\|touch\|open\|create\|add\|change` dans la fenetre 80 chars avant le count |
| **Referent nommé** | basename `.py/.cs/.yml/.json/.md/.ipynb/.sh/...` ou backticked path sur la ligne |
| **Test hors scope** | au moins un referent nommé n'est PAS dans `files` (chemin complet OU basename) |
| **FN safety** | referent anonyme OU pas de verbe d'action → la fonction retourne False → garde CONSERVE le rouge |

Hook dans `check_assertion`, branche `word_count` uniquement (la branche `COUNT_CLAIM` digit ne produit jamais « un fichier »).

### 4. Fichiers

| Action | Fichier | Lignes |
|--------|---------|--------|
| modified | `scripts/check_pr_perimeter.py` | +85 / -4 |
| modified | `scripts/tests/test_check_pr_perimeter.py` | +125 / -0 |

### 5. Tests

- **6 nouveaux tests** dans `test_check_pr_perimeter.py` :
  1. `test_13610_founder_case_named_out_of_scope_passes` — verbatim fondateur
  2. `test_13610_founder_case_via_une_target` — symétrique « une cible » (note : pas dans la classe défaut, documenté)
  3. `test_13610_true_assertion_one_file_named_in_scope_still_rouges` — FN control vraie assertion
  4. `test_13610_fn_safety_anonymous_referent_keeps_rouge` — FN safety référent anonyme
  5. `test_13610_fn_safety_no_edit_verb_keeps_rouge` — FN safety sans verbe d'action
  6. `test_13610_predicate_unit_unanimous` — unitaire prédicat, 5 phrases

- **145/145 tests PASSED** (139 anciens + 6 nouveaux), zero régression sur le corpus fondateur #11268 #11712 #11985 #12103 #12184 #12201 #12273 #12718 #13246 #13335 #13440.

### 6. Cas verifie sur PR reelle

```
$ python scripts/check_pr_perimeter.py 13539 --scan-thread
VERDICT: OK
```

PR #13539 (le fondateur originel) reste OK avant ET apres le fix — la reformulation ulterieure du body avait contourne le defaut, mais le fix empeche des retombees dans la classe sur des PRs futures.

### 7. Conformite

- **CLAUDE.md §A** : pas de push direct sur `main`, PR only, branche `feature/13610-fix-pr-perimeter-indefinite`, 1 sujet (organe unique).
- **G.4 anti-composite** : 2 fichiers / 210 lignes / 1 feature (filtre indéfini). Bien sous les seuils CHANGES_REQUESTED.
- **CLAUDE.md §B.0** : aucun nit non levé pre-commit (pre-commit H.3 + encoding hooks PASSED).
- **CLAUDE.md §G.1 verify-before-claim** : reproduction locale du faux positif confirme AVANT fix, neutre APRES fix. Pas de claim non-vérifié.
- **G-VAR-1** : grain MED/guard META — plancher DEEP/MED CONTENU tenu par PR #13604 (DEEP/notebook-python, c.707 narrow 174ᵉ). Ce grain-ci complete la surveillance du garde signalé par Tell c.649-L1 ★★★ sustained.
- **Tell c.685-L3 / c.704-L1** : pre-commit H.3 + encoding PASSED, CRLF/LF clean sur worktree.

Refs #13610