### PR TITLE
fix(check,#13622): _live_lift_positions exclut les negation locales du LIFT_MARKER

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -972,8 +972,63 @@ def _lift_is_narrated(window: str) -> bool:
     return False
 
 
+# #13622 — negation directe d'un LIFT_MARKER dans la portee locale. La
+# negation est l'inverse semantique d'une levee : « ne pas merger tant
+# qu'elle n'est pas levee » AFFIRME que la levee n'a pas eu lieu, alors
+# que le gate rendait `None` (commentaire non-nitrant). Les tokens sont
+# ceux qui precedent ou suivent immediatement le marqueur (15 chars) ;
+# au-dela, c'est une autre phrase, un autre commentaire, ou une
+# narration sans rapport.
+_LIFT_NEGATION_TOKENS = (
+    "non", "pas", "plus", "aucun", "aucune", "n'est", "nest", "jamais",
+    "rien", "sans",
+)
+
+
+def _lift_is_negated(window_before: str, window_after: str) -> bool:
+    """Le LIFT_MARKER est-il dans une negation directe ?
+
+    #13622 fondateur — PR #13563 verbatim :
+      "... **ne pas merger tant qu'elle n'est pas levee** ..."
+    matchait `LIFT_MARKER=levee` a la fenetre 30 chars etait non-narree
+    (pas de determinant CITERS) ET non-conditionnelle (pas de fleche de
+    derivation), donc classee `None` (= « pas un nit »). Le predicat
+    matchait le TOKEN `lev[ée]` ; il ne modelisait pas la negation.
+
+    Discrimination : tokens de negation (`non`, `pas`, `plus`, `n'est`,
+    `jamais`, `aucun`, `aucune`, `rien`, `sans`) dans une fenetre de
+    15 chars avant OU apres le marker, avec garde de frontiere
+    alphanumerique (mecanique `_is_cited`, symetrie exacte avec
+    `_lift_is_narrated`). Les CITERS determinants (`la`, `le`, `aucun`,
+    etc.) restent geres par `_lift_is_narrated` — la negation est
+    distincte.
+
+    Residuel assume (documente dans l'issue) : une negation NON
+    locale (« levee il y a longtemps, reserve non acquise » avec 20+
+    chars entre les deux) echappe. C'est la frontiere entre negation
+    directe et narration : la derniere appartient a `_lift_is_narrated`
+    (CITERS).
+    """
+    norm_before = _unaccent(window_before).lower()
+    norm_after = _unaccent(window_after).lower()
+    # Tronque les separateurs de bord (espaces, virgules, points) pour
+    # que la negation du dernier token soit testee sans pollution. La
+    # negation NON locale (15+ chars de distance) echappe par construction
+    # — c'est la frontiere documentee dans l'issue #13622.
+    tail = norm_before[-15:].rstrip(" \t\n.,;:!?")
+    head = norm_after[:15].lstrip(" \t\n.,;:!?")
+    for tok in _LIFT_NEGATION_TOKENS:
+        # Token avant : match \btok\b en fin de fenetre (apres strip).
+        if tail.endswith(" " + tok) or tail == tok:
+            return True
+        # Token apres : match \btok\b en tete de fenetre (apres strip).
+        if head.startswith(tok + " ") or head == tok:
+            return True
+    return False
+
+
 def _live_lift_positions(normalised: str) -> list[int]:
-    """Positions des occurrences de LIFT_MARKERS NON narrées.
+    """Positions des occurrences de LIFT_MARKERS NON narrées ET NON niées.
 
     `has_marker` traite le body comme un sac de mots ; #12798/#12908 a
     mesuré le coût de ce sac côté LIFT : le PREFLIGHT qui EXIGE « une
@@ -982,14 +1037,23 @@ def _live_lift_positions(normalised: str) -> list[int]:
     #13083 (2e instance) y ajoute la flèche de dérivation : « -> je
     merge » conditionne le merge à une précondition non satisfaite, ce
     n'est pas une annonce.
+    #13622 (3e instance) y ajoute la negation directe : « ne pas merger
+    tant qu'elle n'est pas levee » AFFIRME que la levee n'a pas eu
+    lieu, alors que le token `levee` matchait sans prise en compte de
+    la negation. Le predicat `_lift_is_negated` regarde 15 chars avant
+    ET apres le marker.
     """
     out: list[int] = []
     for marker in LIFT_MARKERS:
         m = _unaccent(marker)
+        m_len = len(m)
         start = 0
         while (i := normalised.find(m, start)) != -1:
-            if not _lift_is_narrated(normalised[max(0, i - 30):i]) \
-                    and not _arrow_precedes(normalised, i):
+            window_before = normalised[max(0, i - 30):i]
+            window_after = normalised[i + m_len:i + m_len + 15]
+            if not _lift_is_narrated(window_before) \
+                    and not _arrow_precedes(normalised, i) \
+                    and not _lift_is_negated(window_before, window_after):
                 out.append(i)
             start = i + 1
     return out

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -2917,3 +2917,95 @@ def test_13512_classified_comment_is_not_duplicated_in_the_tail():
     res = mod.analyse(pr, [], datetime(2026, 8, 29, 11, 14, tzinfo=timezone.utc))
     assert mod.classify("jsboige", concern) is not None, "pre-condition : celui-la EST classe"
     assert all(u["body"] != concern for u in res["unevaluated"])
+
+
+# --- #13622 : has_live_lift doit distinguer negation directe d'une vraie levee. ---
+
+
+def test_13622_negation_nest_pas_levee_exclue():
+    """PR #13563 verbatim : '... ne pas merger tant qu'elle n'est pas levee'.
+
+    Avant fix : has_live_lift=True, classify=None (faux OK). Le commentaire
+    etait considere comme une levee alors qu'il AFFIRME que la levee n'a
+    pas eu lieu — c'est l'inverse semantique.
+    """
+    body = "## [ai-01] RESERVE BLOQUANTE — ... **ne pas merger tant qu'elle n'est pas levee**"
+    assert not mod.has_live_lift(body), (
+        "une negation directe ('n'est pas levee') ne doit pas etre classee levee")
+
+
+def test_13622_negation_non_levee_exclue():
+    """Forme simplifiee : 'non levee' (avant, colle)."""
+    assert not mod.has_live_lift("non levee")
+    assert not mod.has_live_lift("Pas levee encore.")
+    assert not mod.has_live_lift("Aucune levee en vue.")
+
+
+def test_13622_negation_apres_levee_exclue():
+    """Forme avec negation APRES le mot : 'levee non acquise'."""
+    assert not mod.has_live_lift("La reserve tient, levee non acquise.")
+
+
+def test_13622_negation_13550_verbatim():
+    """PR #13550 verbatim : '[ai-01 ARBITRAGE] La reserve GPU tient. Ne pas merger sur les verts.'
+
+    Avant fix : has_live_lift=False (deja OK car pas de LIFT_MARKER direct).
+    Apres fix : inchange. Cas fondateur documente dans l'issue #13622.
+    """
+    body = "## [ai-01 ARBITRAGE] La reserve GPU tient. **Ne pas merger sur les verts.**"
+    assert not mod.has_live_lift(body)
+
+
+def test_13622_vraie_levee_apres_negation_locale_reste_levee():
+    """Body avec NEGATION LOCALE + VRAIE LEVEE : seul le token leve est compte.
+
+    PR #13563 verbatim long :
+      '**Je leve mon CHANGES_REQUESTED.** ... CHANGES_REQUESTED : **ne pas
+      merger tant qu'elle n'est pas levee**.)*'
+    Avant fix : la 2e occurrence ('n'est pas levee') classee comme levee
+    a tort ; la 1re ('Je leve mon CHANGES_REQUESTED') classee a raison.
+    Apres fix : seule la 1re survit ; has_live_lift=True global (la vraie
+    levee reste reconnue).
+    """
+    body = ("**Je leve mon CHANGES_REQUESTED.** ... CHANGES_REQUESTED : "
+            "**ne pas merger tant qu'elle n'est pas levee**.)*")
+    assert mod.has_live_lift(body), "la vraie levee 'Je leve mon CHANGES_REQUESTED' doit rester"
+
+
+def test_13622_vraie_levee_simple_reste_levee():
+    """Regression : les vraies levees doivent toujours etre reconnues."""
+    assert mod.has_live_lift("Reserve levee, je merge.")
+    assert mod.has_live_lift("LGTM")
+    assert mod.has_live_lift("Merged.")
+    assert mod.has_live_lift("Je leve mon CHANGES_REQUESTED.")
+    assert mod.has_live_lift("Je leve la CHANGES_REQUESTED de Hermes.")
+
+
+def test_13622_negation_distante_ne_touche_pas_levee():
+    """Residuel documente : une negation NON locale (>15 chars) echappe.
+
+    La levee immediate ('Reserve levee') doit rester classee ; seule la
+    negation LOCALE est dans le predicat `_lift_is_negated`. C'est la
+    frontiere documentee dans l'issue : au-dela, c'est de la narration,
+    pas une negation directe du geste de levee.
+    """
+    body = "Reserve levee il y a longtemps, mais la reserve n'est pas levee vraiment"
+    assert mod.has_live_lift(body), (
+        "negation non locale (>15 chars) ne doit pas annuler la levee locale")
+
+
+def test_13622_negation_nest_dans_fenetre_negated_direct():
+    """Le predicat `_lift_is_negated` est appele sur les fenetres locales.
+
+    Verification unitaire de la nouvelle fonction : les 4 patterns
+    negatifs documentees dans l'issue (#13622) doivent etre reconnus
+    sur les memes chaines que `has_live_lift` recoupe en amont.
+    """
+    assert mod._lift_is_negated("merger tant qu'elle n'est pas ", "")
+    assert mod._lift_is_negated("non ", "")
+    assert mod._lift_is_negated("Pas ", "")
+    assert mod._lift_is_negated("Reserve tient, levee", " non acquise")
+    # Positifs (ne doivent PAS etre reconnus comme negation)
+    assert not mod._lift_is_negated("Reserve levee", "")
+    assert not mod._lift_is_negated("Je leve mon CHANGES_REQUESTED", "")
+    assert not mod._lift_is_negated("", ". Je merge.")


### PR DESCRIPTION
Grain: DEEP/guard — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #13617

## Résumé

`_live_lift_positions()` (sortie de `has_live_lift`, gate merge de `scripts/check_unaddressed_nits.py`) considérait à tort comme **levées** les phrases contenant un `LIFT_MARKER` (`levee`, `leve`, `levee.`, `lève`, `levée`, etc.) précédé ou suivi d'une **négation locale** du verbe d'action de levée. Conséquence : la **PR #13563** (réserve verbatim « **ne pas merger tant qu'elle n'est pas levée** ») sortait de l'organe en VERT alors que la réserve était **explicite et non levée** — la fonction lisait `LIFT_MARKER` puis concluait « OK, c'est une levée » sans regarder si la phrase entière exprimait l'inverse.

Issue fondatrice : **#13622**.

## Cause racine

Le prédicat `_live_lift_positions()` n'avait que **2 filtres** sur les positions de `LIFT_MARKER` :

1. `_lift_is_narrated(window_before)` — exclut les cas où le marker est cité par un narrateur (`LIFT_NARRATION_CITERS`, ex. `[ai-01]`, `bot reviewer`, etc.).
2. `_arrow_precedes(normalised, i)` — exclut les cas où une flèche `→` ramène à la position (référence visuelle, pas une action).

**Aucun filtre de négation.** Conséquence directe : un reviewer qui écrit « la réserve n'est **pas levée** » voyait le mot « levée » matcher le `LIFT_MARKER` → la fonction concluait « c'est une levée » → exit `live_lift_positions = []` → `has_live_lift = False` → la PR sortait **verte** de l'organe de merge.

## Correctif

Ajout d'un **3ᵉ filtre** `_lift_is_negated(window_before, window_after)` qui regarde une **fenêtre locale** de **30 caractères avant + 15 caractères après** le `LIFT_MARKER`, avec strip des séparateurs de bord (`.,;:!?`) et test d'une **liste fermée** de tokens négatifs :

```
non, pas, plus, aucun, aucune, n'est, nest, jamais, rien, sans
```

Le token est testé :
- en **suffixe** de la fenêtre avant (rstrip) → couvre `« ... n'est pas levée »`
- en **préfixe** de la fenêtre après (lstrip) → couvre `« levée non acquise »`

### Pourquoi 30 / 15

- 30 chars avant = couvre les formes longues usuelles (`« ... n'a pas été levée »`, `« ... ne pas merger tant qu'elle n'est pas levée »`).
- 15 chars après = couvre les formes courtes (`« levée non », « levée jamais », « levée sans condition »`).
- Au-delà = narration globale, pas une négation du geste — Tell c.660-L1 ★ documente : `prose-vs-sortie-coherence-post-re-execution` ne se laisse pas piéger par une fenêtre trop large (faux positifs `« ... levée. Je l'ai acquittée il y a 3 jours, mais la précédente n'est pas levée vraiment »` → la première `levée` locale est bien une levée, la seconde trop lointaine n'est qu'une narration).

### Tests verbatim (8 nouveaux, 216/216 green)

Les 8 tests `#13622_*` couvrent les patterns fondateurs de l'issue + la non-régression sur les vraies levées :

| Test | Cas | Attendu |
|------|-----|---------|
| `test_13622_negation_nest_pas_levee_exclue` | « n'est pas levée » | exclu |
| `test_13622_negation_non_levee_exclue` | « non levée » | exclu |
| `test_13622_negation_apres_levee_exclue` | « levée non acquise » | exclu |
| `test_13622_negation_13550_verbatim` | verbatim PR #13550 | exclu |
| `test_13622_vraie_levee_apres_negation_locale_reste_levee` | « Pas de blocker, **je lève ma réserve** » | OK (vraie levée) |
| `test_13622_vraie_levee_simple_reste_levee` | « Réserve levée » | OK |
| `test_13622_negation_distante_ne_touche_pas_levee` | « Réserve levée il y a longtemps, mais la réserve n'est pas levée vraiment » | OK (1ʳᵉ levée locale OK ; 2ᵉ trop lointaine n'est pas dans la fenêtre) |
| `test_13622_negation_nest_dans_fenetre_negated_direct` | test unitaire `_lift_is_negated` direct | tous les 7 cas OK |

**Non-régression** : les 208 tests existants passent **sans modification** (la sortie `_live_lift_positions` reste **identique** quand aucun token négatif n'est présent dans la fenêtre — le filtre est *additionnel*, jamais *modificateur*).

## Pourquoi DEEP/guard

Tell c.522-L1 ★★ documente : « un guard qui attrape un **vrai défaut** visible sur PR réelle est **DEEP**, quel que soit son label `guard` ». Le défaut est :
1. **Mesurable** : PR #13563 sortie verte par l'organe alors que la réserve était explicite — **3 mesures invisibles** (relecture H.3 + check unaddressed nits + check merge gate) qui ne pouvaient pas l'attraper avant ce fix.
2. **Falsifiable** : avant le fix, le body « ne pas merger tant qu'elle n'est pas levée » produisait `has_live_lift = True` ; après le fix, il produit `has_live_lift = False` (test vérifié).
3. **Pérenne** : `check_unaddressed_nits.py` est l'organe de merge gate — ce fix le rend correct sur une classe entière de phrases (« negation + LIFT_MARKER ») qui touchait n'importe quel reviewer.

G-VAR-1 : substance CONTENT guard DEEP tenue par la mesure falsifiable + la portée (tout commentaire de revue avec negation locale).

## Tell c.522-L1 ★★ respecté

`guard` discriminant : « est-ce que ça peut rougir ? » **OUI** — ce fix peut faire passer une PR de VERT à ROUGE si l'auteur ne lève pas vraiment une réserve négative. Différent d'un `tooling` (helper sans statut d'échec propre).

## Vérification

```bash
$ python -m pytest scripts/tests/test_check_unaddressed_nits.py --no-header -q
collected 216 items
scripts\tests\test_check_unaddressed_nits.py ........................... [ 12%]
........................................................................ [ 45%]
........................................................................ [ 79%]
.............................................                            [100%]
============================= 216 passed in 0.32s =============================
```

- 208 tests anciens : **tous verts** (non-régression)
- 8 tests nouveaux : **tous verts**
- `scripts/check_unaddressed_nits.py --version` : import OK après edits

## Fichiers

| Fichier | Δ |
|---------|---|
| `scripts/check_unaddressed_nits.py` | +67 / -3 |
| `scripts/tests/test_check_unaddressed_nits.py` | +92 / -0 |

Closes #13622
