### PR TITLE
feat(post-training,#13344): PT-13 pedagogical density 634 -> 1213 (markdown-only enrichment)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_13_dapo_drgrpo_corrections.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_13_dapo_drgrpo_corrections.ipynb
@@ -136,6 +136,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "56530c66",
+   "metadata": {},
+   "source": [
+    "**Lecture (design de l'environnement).** La démo fixe la sémantique sur trois cas contrastés :\n",
+    "`[B0, S]` reçoit 1, `[P, P, B0, S]` reçoit aussi 1, `[B1, S]` reçoit 0 — la reward imprimée\n",
+    "`[1. 1. 0.]` dit exactement cela. Deux propriétés font de ce petit monde un banc valable pour le\n",
+    "biais de longueur : (i) la **reward ne dépend pas de la longueur** — le vérificateur ne regarde que\n",
+    "le token juste avant `S`, donc allonger par du padding ne change rien à la note ; (ii) les **quatre\n",
+    "situations coexistent** — correct-court, correct-long, erroné-court, erroné-long — ce sont les\n",
+    "buckets que la partie 2 mesurera un à un. Si la reward ignorait la longueur *et* que toutes les\n",
+    "réponses avaient la même longueur, le terme `1/|o_i|` n'aurait aucune prise ; c'est en rendant la\n",
+    "longueur libre (et gratuite) qu'on lui donne prise. Les constantes en tête de cellule paramètrent\n",
+    "le compromis : `T_MAX = 8` borne la longueur maximale (un padding infini n'apprendrait rien de\n",
+    "plus), `G = 8` fixe la taille de groupe dont la moyenne servira de baseline, `ANS_LEN = 1` garde\n",
+    "la tâche à un bit pour que la mécanique du loss — et non la difficulté du problème — reste\n",
+    "l'unique variable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### 1.2 Le vérificateur Z3 (thème RLVR, continuité PT-11x/PT-12)\n",
@@ -185,6 +205,23 @@
     "print(\"Z3 correct (c=0) :\", verify_z3(t_corr, 0), \"| Z3 wrong (c=0):\", verify_z3(t_wrong, 0))"
    ],
    "id": "pt13_006"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14543487",
+   "metadata": {},
+   "source": [
+    "**Lecture (le vérificateur rend sat/unsat).** Les deux sorties (`sat` pour la séquence correcte,\n",
+    "`unsat` pour l'erronée) rappellent ce qu'est RLVR : la reward n'est pas une heuristique notée,\n",
+    "c'est la **satisfaisabilité d'une contrainte** — la séquence encodée satisfait la spécification\n",
+    "« le bit juste avant `S` égale le bit de la clé » ou ne la satisfait pas, sans zone grise. Le\n",
+    "notebook maintient deux chemins vers cette décision : la `fastpath` Python (utilisée à chaque\n",
+    "itération d'entraînement, pour la vitesse) et la formulation Z3 (la référence symbolique, thème\n",
+    "filé depuis PT-11x/PT-12). Toute la valeur de la double écriture tient dans l'équivalence entre\n",
+    "les deux — elle est re-vérifiée en fin de notebook sur des séquences fraîches, et c'est ce qui\n",
+    "autorise à dire que la politique a bien été entraînée contre le vérificateur exact, pas contre\n",
+    "une approximation de celui-ci."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -246,6 +283,25 @@
     "print(\"PolicyMLP (params):\", sum(p.numel() for p in PolicyMLP().parameters()))"
    ],
    "id": "pt13_008"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c29f1fa4",
+   "metadata": {},
+   "source": [
+    "**Lecture (un acteur seul, qui sait où il en est).** L'entrée du MLP concatène trois one-hot :\n",
+    "la clé (le prompt), la position courante, le dernier token émis — assez pour que la politique\n",
+    "reconstitue l'état de sa génération sans mémoire récurrente, donc assez pour que tout ce qui se\n",
+    "joue ensuite soit attribuable au **loss**, pas à une architecture qui compenserait. La sortie est\n",
+    "une distribution sur les quatre tokens du vocabulaire ; `token_logprobs` renvoie, pour chaque\n",
+    "séquence, le log-probabilité de chaque token *réellement* émis (0 hors séquence) — c'est la\n",
+    "quantité que le loss déplacera. Deux choix d'initialisation méritent l'œil : le biais de sortie\n",
+    "est mis à zéro (politique neutre au départ), et `p_bias` sera posé à 1 au début de la partie 2\n",
+    "pour rendre le token de padding attractif — sans cela, des trajectoires initiales sans aucun\n",
+    "padding ne laisseraient jamais au biais de longueur l'occasion de s'exercer. La cellule suivante\n",
+    "échantillonne `G` réponses par clé : c'est ce groupe qui fournit à la fois la baseline\n",
+    "(la moyenne) et l'écart-type dont le `÷σ` sera accusé."
+   ]
   },
   {
    "cell_type": "code",
@@ -354,6 +410,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5f1cec86",
+   "metadata": {},
+   "source": [
+    "**Lecture (trois corrections, trois différences d'une ligne).** L'intérêt de la factorisation\n",
+    "est de rendre les corrections *visibles comme des deltas* :\n",
+    "\n",
+    "$$\\mathcal{L}_{\\text{vanilla}} = \\mathbb{E}\\left[\\frac{1}{|o_i|}\\sum_t \\min\\!\\big(r_t \\hat{A}_i,\\ \\mathrm{clip}(r_t, 1-\\varepsilon, 1+\\varepsilon)\\, \\hat{A}_i\\big)\\right], \\qquad \\hat{A}_i = \\frac{r_i - \\mu_{\\text{groupe}}}{\\sigma_{\\text{groupe}} + 10^{-4}}$$\n",
+    "\n",
+    "- `dr` remplace le dénominateur `1/|o_i|` par `1/T_MAX` (`norm=\"const\"`) : le facteur de\n",
+    "  longueur devient identique pour toutes les réponses, donc s'annule de la comparaison — c'est le\n",
+    "  retrait du **bouclier de longueur** décrit par Liu et al. (2025) ;\n",
+    "- `dr` pose aussi `std_norm=False` : l'avantage redevient `r_i - \\mu` brut, sans l'amplification\n",
+    "  des groupes quasi uniformes que la partie 2.2 mesure ;\n",
+    "- `clip_higher` garde le loss vanilla et n'élargit que la borne haute : `eps_hi=0.28` contre\n",
+    "  `eps_lo=0.2` — l'asymétrie de DAPO (Yu et al., 2025) qui laisse les tokens rares croître\n",
+    "  au-delà du plafond symétrique.\n",
+    "\n",
+    "Chaque configuration est exactement l'énoncé du papier correspondant traduit en un dictionnaire ;\n",
+    "le reste de la fonction — masque des tokens réels, ratio `exp(lp - lp_old)`, double terme\n",
+    "`min(non-clippé, clippé)` à la PPO — est commun aux trois. C'est cet appoint minimal qui autorise\n",
+    "l'attribution : si deux configurations divergent, la cause est dans leur delta, pas ailleurs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Partie 2 — Mesurer les trois biais (exactement)\n",
@@ -425,6 +506,22 @@
     "print(\"buffer fixe : \", len(SEQS), \"séquences, récompenses\", REWARDS)"
    ],
    "id": "pt13_013"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8506118",
+   "metadata": {},
+   "source": [
+    "**Protocole (mesure au gradient, hors apprentissage).** Le buffer de séquences est **fixe** et\n",
+    "le modèle identique d'une variante à l'autre pour un seed donné : la cellule ne mesure pas ce que\n",
+    "la politique apprend, mais **l'arithmétique du loss** — combien de gradient chaque bucket\n",
+    "(correct/erroné × court/long) reçoit pour un même jeu de trajectoires. La frontière court/long\n",
+    "est posée à 4 tokens ; cinq seeds sont moyennées pour lisser l'initialisation. Ce qu'il faut lire\n",
+    "dans le tableau suivant, ce ne sont pas les valeurs absolues (elles dépendent de l'échelle du\n",
+    "modèle) mais les **rapports entre colonnes** : combien vaut la pénalité d'une erreur longue\n",
+    "comparée à une erreur courte, et l'encouragement d'une réponse correcte longue comparée à une\n",
+    "courte — sous `vanilla` d'abord, sous `dr` ensuite."
+   ]
   },
   {
    "cell_type": "code",
@@ -676,6 +773,22 @@
    "id": "pt13_023"
   },
   {
+   "cell_type": "markdown",
+   "id": "8d1d1479",
+   "metadata": {},
+   "source": [
+    "**Protocole (le run réel).** Trois variantes × cinq seeds `[0, 7, 42, 99, 123]`, 100 itérations,\n",
+    "16 prompts × 8 réponses par itération. Les trois métriques jouent des rôles distincts : `succ`\n",
+    "est le taux de succès (la question du coût : les corrections pénalisent-elles l'apprentissage ?),\n",
+    "`len` est la longueur moyenne des réponses (la sonde de verbosité — l'expression comportementale\n",
+    "du biais 1), `ent` est l'entropie moyenne mesurée sur le chemin greedy final (la sonde\n",
+    "d'effondrement — ce que le clip-higher est censé prévenir). La cellule précédente a déjà affiché\n",
+    "un témoin : après 20 itérations seulement, `succ` vaut 1.0 sur le seed 0 — la tâche est apprise\n",
+    "vite, ce qui est voulu : elle doit laisser au loss le temps de révéler ses biais, pas opposer de\n",
+    "la difficulté qui brouillerait la lecture."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
@@ -721,6 +834,22 @@
    "id": "pt13_024"
   },
   {
+   "cell_type": "markdown",
+   "id": "f5df4626",
+   "metadata": {},
+   "source": [
+    "**Lecture (les agrégats).** Les trois variantes atteignent `succ = 1.00 +/- 0.00` sur les cinq\n",
+    "seeds : **les corrections ne coûtent rien** sur ce banc — premier constat, positif. Les deux\n",
+    "écarts visibles sont modestes mais vont dans le sens de la théorie : `dr` termine à\n",
+    "`len = 2.4` contre `2.0` pour les deux autres (un résidu de padding non pénalisé, cohérent avec\n",
+    "le retrait du bouclier `1/|o_i|`) et à `ent = 0.18` contre `0.06` (une entropie finale plus\n",
+    "haute, cohérente avec un objectif moins normalisé). Ce sont des différences de moyenne sur cinq\n",
+    "seeds, pas des écarts à plusieurs sigmas : elles orientent, elles ne tranchent pas. Les agrégats\n",
+    "ci-dessus résument la fin de course ; la dynamique — *quand* la longueur se stabilise, *à quel\n",
+    "moment* le succès sature — demande les courbes de la cellule suivante."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},
@@ -755,6 +884,24 @@
     "plt.show()"
    ],
    "id": "pt13_025"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40bd0f7f",
+   "metadata": {},
+   "source": [
+    "**Lecture (les deux panneaux, seed 0).** Chaque panneau trace une seule collecte par variante.\n",
+    "À gauche, le taux de succès au fil des itérations : les trois courbes montent ensemble vers 1 —\n",
+    "il n'y a pas de variante lente ou fautive, la tâche est apprise dans tous les régimes. À droite,\n",
+    "la longueur moyenne des réponses : elle descend vers 2, la longueur de la réponse minimale\n",
+    "`[B_c, S]` — sur ce banc à réponse brève, aucune variante ne développe de verbosité résiduelle\n",
+    "durable. Ce que les courbes ajoutent aux agrégats : le moment où la longueur se fige (tôt), et\n",
+    "l'absence de palier intermédiaire où une politique « gonflerait » ses réponses avant de les\n",
+    "raccourcir. Ce qu'elles **ne peuvent pas** montrer : une discrimination comportementale nette\n",
+    "entre les variantes — la partie 2 (buckets de gradient) porte la démonstration du biais, la\n",
+    "partie 3 vérifie seulement qu'il n'y a pas de contrepartie en performance. Le verdict détaillé\n",
+    "et ses limites suivent dans la cellule d'après."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -857,12 +1004,40 @@
   },
   {
    "cell_type": "markdown",
+   "id": "38632187",
+   "metadata": {},
+   "source": [
+    "**Lecture (la boucle est bouclée).** Sur 24 séquences générées par une politique aléatoire, la\n",
+    "fastpath et Z3 rendent les mêmes récompenses (`équivalence ... : True`), et la séquence témoin\n",
+    "`[1, 0, 1, 0, 0, 1]` est identique sur les deux chemins. La reward qui a piloté tout\n",
+    "l'entraînement précédent est donc bien celle du vérificateur exact — pas celle d'une imitation\n",
+    "qui aurait divergé de la spécification. L'échantillon couvre des politiques aléatoires (le pire\n",
+    "cas pour couvrir l'espace des séquences), pas une preuve exhaustive ; mais la fastpath est\n",
+    "déterministe et sa spécification tient en une ligne, si bien que l'équivalence observée est\n",
+    "l'assurance raisonnable recherchée. C'est le même geste de clôture qu'en PT-12 : entraîner vite\n",
+    "contre une voie rapide, puis vérifier une dernière fois que la voie rapide disait vrai."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Exercices\n",
     "\n",
     "Les trois exercices font travailler les corrigés *sur d'autres points* des trois biais. Stubs `TODO`\n",
-    "(C.1) : le notebook s'exécute de bout en bout même non complété."
+    "(C.1) : le notebook s'exécute de bout en bout même non complété.\n",
+    "Chaque exercice revient sur un point laissé volontairement de côté : le premier réintroduit le\n",
+    "`÷σ` pour *voir* le biais 2 se réinstaller, le deuxième porte la normalisation token-level de\n",
+    "DAPO (la troisième correction du papier, non couverte par les variantes de la partie 1), le\n",
+    "troisième balaye `eps_hi` pour situer la frontière où l'asymétrie de clip cesse d'être sans\n",
+    "effet. Les outils de la partie 2 (buckets, `climb_steps`) servent d'instruments de mesure pour\n",
+    "tous les trois : un corrigé se juge à ses courbes, pas à l'impression d'avoir compris. Conseil de méthode : mesurer avant et après le changement sur au moins trois seeds, et rapporter\n",
+    "les deux tableaux — une différence observée sur un seul seed ne distingue pas un mécanisme d'un\n",
+    "bruit d initialisation.\n",
+    "\n",
+    "Un dernier reflexe avant de quitter le notebook : rejouer la cellule de buckets (partie 2.1)\n",
+    "apres chaque exercice — c est le temoin qui dit si la modification demandee a bien deplace le\n",
+    "gradient, et non seulement le resultat affiche."
    ],
    "id": "pt13_030"
   },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/notebook-lean #13628

## Summary

Enrichissement **markdown-only** de PT-13 pour le dernier point d'acceptance ouvert de #13344 : densité pédagogique **634 → 1213 chars/cellule code** (cible ≥ 1200). La baseline (10 790 chars / 17 cellules code) était la preuve firsthand de po-2025 sur l'issue.

9 blocs markdown nouveaux + enrichissement de la section Exercices :

| Bloc | Position | Contenu |
|---|---|---|
| Lecture design env | après la démo `[1. 1. 0.]` | pourquoi reward indépendante de la longueur + 4 buckets = le banc où `1/\|o_i\|` a prise |
| Lecture vérificateur | après `verify_z3` | sat/unsat = RLVR, double chemin fastpath/Z3 |
| Lecture acteur | entre `PolicyMLP` et `rollout` | one-hots, `token_logprobs`, rôle de `p_bias` |
| Lecture loss math | après `make_loss` | formule complète + les 3 deltas (`norm`, `std_norm`, `eps_hi`) terme à terme |
| Protocole buckets | avant le run multi-seed | buffer fixe = arithmétique du loss, lire les ratios pas les absolues |
| Protocole run réel | avant `SEEDS` | 3 variantes × 5 seeds, rôle distinct de `succ`/`len`/`ent` |
| Lecture agrégats | après le tableau `succ=1.00 ± 0.00` | les écarts modestes `dr` (len 2.4 vs 2.0, ent 0.18 vs 0.06) orientent sans trancher |
| Lecture courbes | après la figure 2 axes | ce que chaque panneau montre / ne peut pas montrer (renvoie au verdict) |
| Lecture re-vérification | après l'équivalence Z3 | la boucle RLVR est bouclée (True/24 séquences) |
| Guide exercices | section Exercices | mapping exo → biais, conseil de méthode (multi-seed avant/après, rejouer les buckets) |

Chaque **Lecture suit la cellule qu'elle interprète** (cell-interpretation-ordering) ; les valeurs citées sont exclusivement celles des **outputs réels** committés (ratios 0.32/0.81, `sat`/`unsat`, `succ=1.00 ± 0.00`, `True`/24) — aucun nombre fabriqué.

## Preuves de validation

- `pedagogy_density.py` : **1213/1200** (avant : 634) — `All judged notebooks meet the density floor`.
- `validate_pr_notebooks.py origin/main <nb>` : **1/1 PASS**, 17 cellules code.
- `detect_consecutive_code_cells.py` : **0 run ≥ 2** (les 3 runs d'origine `[PolicyMLP,rollout]`, `[bucket,N_SEEDS]`, `[train,SEEDS,plt]` sont tous cassés par un markdown intermédiaire).
- **Code byte-identique** : garde d'assertion dans le script d'insertion (17 sources code comparées avant/après) ; outputs et `execution_count` intacts — diff = markdown only (177 insertions, 2 deletions : fin de la cellule Exercices).
- **C.2 exception markdown-only** : aucune cellule code modifiée → pas de re-exécution requise. C.1 : stubs exercices inchangés (`# TODO etudiant`).
- Hooks pre-commit : tous Passed (gitleaks, H.3, #13326, scrubbers).

## Acceptance #13344 — couverture

Le notebook lui-même (env discriminant, clip-higher, exécution end-to-end, ligne README) a été livré par #13347 (MERGED). Cette PR couvre le **seul point restant** — « densité pédagogique ≥1200 chars prose/cellule code » (5e point du livrable) — donc `Closes #13344`. See #1454 (EPIC reste ouverte).

## Test plan

- [x] `pedagogy_density.py` ≥ 1200 : 1213
- [x] `validate_pr_notebooks.py` : 1/1 PASS
- [x] sources code byte-identiques (garde script), outputs intacts
- [x] positions : chaque Lecture APRÈS sa cellule (dump structure vérifié)
