### PR TITLE
fix(check,#13639): une levee citant un commit absent de la branche ne leve plus

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -1182,6 +1182,102 @@ def gh_json(args: list[str]) -> object:
     return json.loads(out)
 
 
+# #13639 -- une levee dont la PREUVE citee n'est plus dans la PR. Sur #13557,
+# la levee citait le commit 2d6e4c3642 (« corrige dans ce commit ») ; un
+# force-push ulterieur avait rembobine ce commit, et le gate restait vert :
+# la phrase etait honnete au moment ou elle fut ecrite, mais ce qu'elle
+# nommait n'existait plus au merge. Le principe B.0 (« ce qui leve une
+# remarque est une phrase ») suppose que la phrase dise VRAI au merge ; une
+# levee qui cite une preuve absente ne dit plus vrai.
+#
+# Refus ETROIT deliberement : (a) le corps de levee cite un SHA, (b) ce SHA
+# n'appartient pas aux commits de la PR (match par prefixe), (c) il RESOUD
+# cote serveur, (d) son message se RAPPORTE a cette PR (`#N`, N = numero de
+# la PR ou issue citee dans le titre/corps). (c)+(d) distinguent le
+# rembobinage (#13557) de la citation de CONTEXTE (« comme fixe en abc1234
+# sur l'autre PR ») : la seconde reste une levee valide, juste signalee.
+# En cas de doute : avertir (A RELIRE), jamais bloquer.
+_SHA_CITED = re.compile(r"\b[0-9a-f]{7,40}\b")
+
+
+def _cited_shas(body: str) -> set[str]:
+    """SHAs cites dans un corps : 7-40 hex, avec AU MOINS une lettre.
+
+    Un token 100% numerique de 7+ chiffres (une date 20260830, un run-id)
+    est hex-compatible mais n'est quasi jamais un SHA -- l'exiger lettree
+    evite de partir resoudre une date cote serveur pour rien.
+    """
+    out: set[str] = set()
+    for m in _SHA_CITED.finditer((body or "").lower()):
+        tok = m.group(0)
+        if any(ch in "abcdef" for ch in tok):
+            out.add(tok)
+    return out
+
+
+# Proximite maximale (caracteres) entre un SHA cite et un marqueur de levee
+# VIVANT pour que le SHA compte comme la PREUVE avancee par la phrase.
+_LIFT_SHA_PROXIMITY = 150
+
+
+def _sha_in_lift_claim(lift_body: str, sha: str) -> bool:
+    """Le SHA est-il cite DANS la clause de levee (proximal du marqueur) ?
+
+    Mesure au deploiement meme de #13639 (PR #13631) : la levee d'ai-01
+    citait `e408b2fce` a ~2000 chars du marqueur, dans un paragraphe
+    forensique qui disait explicitement « c'est main qui a avance » --
+    une reference de CONTEXTE, pas une preuve. Refuser cette levee (ou
+    meme l'avertir) etait un faux positif : la phrase etait valide et sa
+    preuve etait inline (la clé Grain citee dans le commentaire meme).
+    Seul un SHA PROXIMAL du marqueur vivant est ce que la phrase avance ;
+    un SHA distant est une citation annexe et ne doit etre ni refuse ni
+    signale. Marqueurs et SHA sont cherches dans le MEME espace de
+    coordonnees (le corps unaccente), insensible a toute variation de
+    longueur du _unaccent.
+    """
+    norm = _unaccent(lift_body or "")
+    markers = _live_lift_positions(norm)
+    if not markers:
+        return False
+    low = norm.lower()
+    start = 0
+    while (i := low.find(sha, start)) != -1:
+        if min(abs(i - p) for p in markers) <= _LIFT_SHA_PROXIMITY:
+            return True
+        start = i + 1
+    return False
+
+
+def _resolve_absent_sha_messages(data: dict, cap: int = 5) -> dict[str, str]:
+    """Resoudre cote serveur les SHAs cites mais absents des commits de la PR.
+
+    S'execute UNIQUEMENT dans le chemin `gate` (reseau) : `analyse` reste
+    pur et lit le resultat via `data["_absent_sha_messages"]`. Sans entree
+    resolue, `analyse` reste en mode avertissement -- l'audit retro, qui
+    n'appelle jamais ceci, ne peut donc pas produire de faux blocage.
+    Capped a `cap` appels : plus de 5 SHAs absents cites sur une seule PR
+    est extraordinaire, et chaque appel paie un aller-retour API.
+    """
+    oids = {(c.get("oid") or "").lower() for c in (data.get("commits") or [])}
+    oids.discard("")
+    if not oids:
+        return {}
+    cited: set[str] = set()
+    for c in (data.get("comments") or []) + (data.get("reviews") or []):
+        cited |= _cited_shas(c.get("body") or "")
+    absent = sorted(s for s in cited if not any(o.startswith(s) for o in oids))
+    messages: dict[str, str] = {}
+    for sha in absent[:cap]:
+        try:
+            commit = gh_json(["api", f"repos/{REPO}/commits/{sha}"])
+        except subprocess.CalledProcessError:
+            continue  # non resoluble -> analyse restera en mode avertissement
+        head = ((commit.get("commit") or {}).get("message") or "").split("\n")[0]
+        if head:
+            messages[sha] = head
+    return messages
+
+
 def can_lift(comment: dict) -> bool:
     """Ce commentaire est-il capable de LEVER un nit qui le precede ?
 
@@ -1491,6 +1587,50 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     ]
     explicit_lifts = [x for x in explicit_lifts if x[0] is not None]
 
+    # #13639 -- passer les levees au crible du SHA rembobine (voir
+    # _SHA_CITED ci-dessus pour le pourquoi et l'etroitesse). Inerte sans
+    # OIDs connus : le pre-filtre d'audit (sans `commits`) et les fixtures
+    # sans `oid` sautent ce passage -- comportement inchange. Limite assumee
+    # : ce pre-filtre d'audit ne verra donc jamais cette classe de defaut
+    # (il rend son verdict sans commits) ; c'est le gate, en direct sur la
+    # PR avant merge, qui est le client visé par #13639.
+    commit_oids = [(c.get("oid") or "").lower()
+                   for c in (pr_data.get("commits") or []) if c.get("oid")]
+    voided_lifts: list[dict] = []
+    absent_sha_warnings: list[dict] = []
+    if commit_oids:
+        pr_refs: set[str] = set()
+        if pr_data.get("number") is not None:
+            pr_refs.add(str(pr_data["number"]))
+        for m in re.finditer(r"#(\d+)", (pr_data.get("title") or "")
+                             + "\n" + (pr_data.get("body") or "")):
+            pr_refs.add(m.group(1))
+        pr_refs.discard("")
+        resolved = pr_data.get("_absent_sha_messages") or {}
+        kept_lifts = []
+        for (t, lifter, lift_body) in explicit_lifts:
+            refused = None
+            warned = None
+            for sha in sorted(_cited_shas(lift_body)):
+                if any(oid.startswith(sha) for oid in commit_oids):
+                    continue  # present dans la PR : preuve valide
+                if not _sha_in_lift_claim(lift_body, sha):
+                    continue  # citation de contexte : ni refus, ni signalement
+                message = resolved.get(sha)
+                if message and any(f"#{n}" in message for n in pr_refs):
+                    refused = sha  # rembobine ET rattache : la levee est nue
+                    break
+                warned = sha  # non resoluble ou sans rapport : avertir
+            if refused:
+                voided_lifts.append(
+                    {"author": lifter, "at": t.isoformat(), "sha": refused})
+            else:
+                kept_lifts.append((t, lifter, lift_body))
+                if warned:
+                    absent_sha_warnings.append(
+                        {"author": lifter, "at": t.isoformat(), "sha": warned})
+        explicit_lifts = kept_lifts
+
     signals: list[tuple] = []
     for c in pr_data.get("comments") or []:
         login = (c.get("author") or {}).get("login", "")
@@ -1699,12 +1839,14 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         "blocking": blocking,
         "blocked": bool(blocking),
         "ignored_overrides": ignored_overrides,
+        "voided_lifts": voided_lifts,
+        "absent_sha_warnings": absent_sha_warnings,
         "unevaluated": to_read,
         "unevaluated_total": len(unevaluated),
     }
 
 
-FIELDS = "number,title,mergedAt,author,comments,reviews,commits,url,state"
+FIELDS = "number,title,body,mergedAt,author,comments,reviews,commits,url,state"
 
 # `commits` porte une connection `authors` par commit : sur un `gh pr list` large,
 # GraphQL depasse son plafond de 500 000 noeuds. L'audit retro liste donc SANS
@@ -1742,8 +1884,22 @@ def _print_unevaluated(result: dict) -> None:
     print()
 
 
+def _print_sha_notes(result: dict) -> None:
+    """#13639 : nommer les levees dont la preuve citee manque de la PR."""
+    for v in result.get("voided_lifts") or []:
+        print(f"  [!] NON LEVE — levee de {v['author']} à {v['at']} : cite "
+              f"{v['sha']}, absent des commits de la PR (résolu côté serveur, "
+              f"mais rembobiné par un push ultérieur)")
+    for w in result.get("absent_sha_warnings") or ():
+        print(f"  [i] levee de {w['author']} à {w['at']} cite {w['sha']} "
+              f"(absent des commits, non rattaché à cette PR) — non bloquant")
+
+
 def gate(pr: int, as_json: bool) -> int:
     data = gh_json(["pr", "view", str(pr), "--repo", REPO, "--json", FIELDS])
+    # #13639 : resolution serveur des SHAs cites-absents, AVANT analyse
+    # (qui reste pure). Sans ceci, la classe #13557 serait invisible.
+    data["_absent_sha_messages"] = _resolve_absent_sha_messages(data)
     merged = ts(data.get("mergedAt"))
     cutoff = merged or datetime.now(timezone.utc)
     result = analyse(data, review_threads(pr), cutoff)
@@ -1751,6 +1907,7 @@ def gate(pr: int, as_json: bool) -> int:
         print(json.dumps(result, indent=1, ensure_ascii=False))
     elif not result["blocked"]:
         print(f"OK  PR #{pr} — aucun nit non leve.")
+        _print_sha_notes(result)
         _print_unevaluated(result)
     else:
         print(f"BLOCKED  PR #{pr} — {len(result['blocking'])} nit(s) non leve(s) :\n")
@@ -1763,6 +1920,7 @@ def gate(pr: int, as_json: bool) -> int:
             # #13316 : dire POURQUOI l'override visible n'a rien eteint — le
             # silence etait le mode d'echec couteux (#13030, #12096).
             print(f"  [i] {o['why']} (commentaire de {o['author']} à {o['at']})")
+        _print_sha_notes(result)
         print("Lever chaque nit (commit, reponse explicite, ou issue de suivi nommee)")
         print("avant `gh pr merge`. Cf CLAUDE.md section B.0.")
         _print_unevaluated(result)

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -1248,6 +1248,27 @@ def _sha_in_lift_claim(lift_body: str, sha: str) -> bool:
     return False
 
 
+def _message_refs_pr(message: str, pr_refs: set[str]) -> bool:
+    """Le message de commit reference-t-il exactement un PR/issue de la liste ?
+
+    Substring check trop generique : `#13639` matchait un message contenant
+    `#136390` (ticket adjacent cite par hasard), declenchant un refus au lieu
+    d'un simple avertissement (NanoClaw c.702 sur #13641). Le bon test est
+    l'extraction/tokenisation exacte des references `#\\d+` : la PR/issue
+    doit apparaitre comme un MOT COMPLET du message, pas comme prefixe d'un
+    identifiant plus long.
+
+    Retourne True si au moins une ref de `pr_refs` apparait comme token
+    isole (apres `#`, jusqu'au prochain non-alphanumerique) dans `message`.
+    """
+    if not message or not pr_refs:
+        return False
+    # Tokeniser toutes les references `#\\d+` du message, garder UNIQUEMENT
+    # la portion numerique (le `#` est implicite).
+    cited = {m.group(1) for m in re.finditer(r"#(\d+)", message)}
+    return bool(cited & pr_refs)
+
+
 def _resolve_absent_sha_messages(data: dict, cap: int = 5) -> dict[str, str]:
     """Resoudre cote serveur les SHAs cites mais absents des commits de la PR.
 
@@ -1617,7 +1638,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
                 if not _sha_in_lift_claim(lift_body, sha):
                     continue  # citation de contexte : ni refus, ni signalement
                 message = resolved.get(sha)
-                if message and any(f"#{n}" in message for n in pr_refs):
+                if message and _message_refs_pr(message, pr_refs):
                     refused = sha  # rembobine ET rattache : la levee est nue
                     break
                 warned = sha  # non resoluble ou sans rapport : avertir

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -51,7 +51,8 @@ USER_NIT = {
 }
 
 
-def run(comments, commits=None, threads=None, reviews=None, pr_author="jsboige"):
+def run(comments, commits=None, threads=None, reviews=None, pr_author="jsboige",
+        **extra):
     data = {
         "number": 0,
         "title": "t",
@@ -60,6 +61,7 @@ def run(comments, commits=None, threads=None, reviews=None, pr_author="jsboige")
         "reviews": reviews if reviews is not None else [],
         "commits": commits if commits is not None else [{"committedDate": at(19)}],
     }
+    data.update(extra)
     return mod.analyse(data, threads or [], MERGED)
 
 
@@ -3009,3 +3011,112 @@ def test_13622_negation_nest_dans_fenetre_negated_direct():
     assert not mod._lift_is_negated("Reserve levee", "")
     assert not mod._lift_is_negated("Je leve mon CHANGES_REQUESTED", "")
     assert not mod._lift_is_negated("", ". Je merge.")
+
+
+# --- #13639 : levee citant un commit absent de la branche (rembobine) ---
+
+NIT_OID = "f" * 40
+
+
+def lift_citant_sha(sha="2d6e4c3642"):
+    return {"author": {"login": "jsboige"}, "createdAt": at(12),
+            "body": f"Les 2 nits sont adresses dans le commit {sha}."}
+
+
+def test_13639_levee_citant_commit_absent_ne_leve_plus():
+    """#13557 : la levee citait 2d6e4c3642, rembobine par un force-push.
+
+    La phrase etait honnete a l'ecriture, mais la preuve qu'elle nomme
+    n'existe plus au merge : le nit doit rester NON LEVE, avec la levee
+    annulee nommee dans le resultat.
+    """
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              body="See #77",
+              _absent_sha_messages={
+                  "2d6e4c3642": "fix(audio,#77): corrige l'attribution"})
+    assert res["blocked"] is True
+    assert [v["sha"] for v in res["voided_lifts"]] == ["2d6e4c3642"]
+
+
+def test_13639_levee_citant_commit_present_leve_toujours():
+    """SHA prefixe present dans les OIDs de la PR : preuve valide, levee."""
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": "2d6e4c3642" + "a" * 30, "committedDate": at(19)}],
+              body="See #77")
+    assert res["blocked"] is False
+    assert res["voided_lifts"] == []
+
+
+def test_13639_absent_sans_rapport_avertit_sans_bloquer():
+    """Citation de CONTEXTE (« comme fixe sur l'autre PR ») : levee valide.
+
+    Le message resolu ne se rattache pas a cette PR (aucun #N commun) :
+    on signale, on ne refuse pas.
+    """
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              body="See #77",
+              _absent_sha_messages={
+                  "2d6e4c3642": "fix(other,#999): unrelated lane"})
+    assert res["blocked"] is False
+    assert [w["sha"] for w in res["absent_sha_warnings"]] == ["2d6e4c3642"]
+
+
+def test_13639_absent_non_resolu_avertit_sans_bloquer():
+    """SHA non resoluble cote serveur : doute -> avertissement, pas blocage."""
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              body="See #77")
+    assert res["blocked"] is False
+    assert [w["sha"] for w in res["absent_sha_warnings"]] == ["2d6e4c3642"]
+
+
+def test_13639_rattachement_via_numero_de_pr():
+    """Le message resolu cite le NUMERO de la PR (pas seulement une issue
+    du corps) : rattachement valide, levee refusee."""
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              _absent_sha_messages={"2d6e4c3642": "fix(x,#0): typo"})
+    assert res["blocked"] is True
+    assert [v["sha"] for v in res["voided_lifts"]] == ["2d6e4c3642"]
+
+
+def test_13639_token_numerique_non_sha():
+    """Un token 100% numerique (date 20260814) n'est pas un SHA : la levee
+    qui le cite reste valide, sans meme un avertissement."""
+    res = run([USER_NIT, lift_citant_sha("20260814")],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              body="See #77",
+              _absent_sha_messages={"20260814": "fix(x,#77): piege"})
+    assert res["blocked"] is False
+    assert res["absent_sha_warnings"] == []
+
+
+def test_13639_sans_oids_comportement_inchange():
+    """Fixtures sans `oid` (pre-filtre d'audit, anciens payloads) : le
+    passage est inert, la levee compte comme avant."""
+    res = run([USER_NIT, lift_citant_sha()])
+    assert res["blocked"] is False
+    assert res["voided_lifts"] == []
+
+
+def test_13639_sha_distant_du_marqueur_est_contexte():
+    """Mesure au deploiement (PR #13631) : la levee d'ai-01 citait
+    `e408b2fce` a ~2000 chars du marqueur, dans un paragraphe forensique
+    (« c'est main qui a avance ») -- contexte, pas preuve. Meme resolu et
+    rattache au sujet de la PR, un SHA DISTANT ne doit ni refuser la levee
+    ni meme la signaler.
+    """
+    filler = "Un paragraphe forensique qui explique la mesure cote serveur. " * 8
+    body = ("Les 2 nits sont adresses.\n\n" + filler
+            + "\n\nPar ailleurs, c'est main qui a avance (e408b2fce, #13624).")
+    reply = {"author": {"login": "jsboige"}, "createdAt": at(12), "body": body}
+    res = run([USER_NIT, reply],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              body="See #13624",
+              _absent_sha_messages={
+                  "e408b2fce": "fix(check,#13622): _live_lift_positions (#13624)"})
+    assert res["blocked"] is False
+    assert res["voided_lifts"] == []
+    assert res["absent_sha_warnings"] == []

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -3120,3 +3120,36 @@ def test_13639_sha_distant_du_marqueur_est_contexte():
     assert res["blocked"] is False
     assert res["voided_lifts"] == []
     assert res["absent_sha_warnings"] == []
+
+
+def test_13641_ref_par_prefixe_ne_compte_pas():
+    """NanoClaw c.702 sur #13641 : le substring check `any(f"#{n}" in message)`
+    matchait `#13639` dans un message contenant `#136390` (ticket adjacent
+    cite par hasard). Le bon test est l'extraction/tokenisation exacte des
+    references `#\\d+` : la PR doit apparaitre comme MOT COMPLET du message,
+    pas comme prefixe d'un identifiant plus long. Ici, le SHA absent cite
+    `#136390` (prefixe adjacent de `#13639` PR), sans citer `#13639`
+    directement : la levee doit AVERTIR (et non REFUSER)."""
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              body="See #13639",
+              _absent_sha_messages={
+                  "2d6e4c3642": "fix(x): typo dans #136390 (adjacent)"})
+    assert res["blocked"] is False, "Le substring matchait `#13639` dans `#136390` → faux refus"
+    assert res["voided_lifts"] == []
+    # Avertissement OK (le SHA est bien absent et non resoluble vers la PR)
+    assert [w["sha"] for w in res["absent_sha_warnings"]] == ["2d6e4c3642"]
+
+
+def test_13641_ref_exacte_compte_toujours():
+    """Le contre-test : quand le message cite EXACTEMENT `#13639` (mot complet
+    apres `#` jusqu'au prochain non-alphanumerique), le rattachement reste
+    valide et la levee est REFUSEE. C'est la discrimination qui ferme le faux
+    positif du test precedent."""
+    res = run([USER_NIT, lift_citant_sha()],
+              commits=[{"oid": NIT_OID, "committedDate": at(19)}],
+              body="See #13639",
+              _absent_sha_messages={
+                  "2d6e4c3642": "fix(check,#13639): levee citee (#13640)"})
+    assert res["blocked"] is True
+    assert [v["sha"] for v in res["voided_lifts"]] == ["2d6e4c3642"]


### PR DESCRIPTION
**Grain** : MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #13631

## Le défaut (#13639)

`check_unaddressed_nits.py` validait la *phrase* de levée sans jamais vérifier que le SHA qu'elle invoque comme preuve appartient aux commits de la PR. Contrôle positif #13557 : la réserve du preflight (00:37:28Z) était déclarée levée à 01:53:21Z en citant `2d6e4c3642d` — commit écrit, poussé, puis **rembobiné par un force-push ultérieur**. Le gate rendait vert ; ce qui a arrêté le merge était une lecture à la main (`[ai-01] HOLD`), exactement la vigilance que l'organe existe pour rendre inutile.

## Le correctif — refus ÉTROIT (écrit par ses faux négatifs)

Une levée n'est plus comptée si, et seulement si :

1. son corps cite un SHA (7-40 hex, **avec au moins une lettre** — une date `20260830` ou un run-id tout-numérique n'est pas un SHA) ;
2. ce SHA n'appartient aux commits de la PR (match par préfixe sur les OIDs) ;
3. il **résout** côté serveur (`gh api repos/.../commits/<sha>`, borné à 5 appels, chemin `gate` seulement — `analyse()` reste pure) ;
4. son message se **rattache** à cette PR (`#N`, N = numéro de la PR ou issue citée en titre/corps — `body` ajouté à `FIELDS`) ;
5. il est **PROXIMAL (≤150 chars) du marqueur de levée vivant** (`_live_lift_positions`) — condition ajoutée sur mesure au déploiement même : la levée d'ai-01 sur #13631 citait `e408b2fce` à ~2000 chars du marqueur dans un paragraphe forensique (« c'est main qui a avancé ») ; un SHA distant est une citation de contexte, ni refusée ni signalée.

En cas de doute (non résoluble, message sans rapport) : **avertir sans bloquer** (`absent_sha_warnings`, lignes `[i]`). Les levées voidées sont nommées explicitement :

```
[!] NON LEVE — levee de jsboige à 2026-08-30T01:53:21+00:00 : cite 2d6e4c3642d,
    absent des commits de la PR (résolu côté serveur, mais rembobiné par un push ultérieur)
```

Sans SHA cité, sans OIDs connus (pré-filtre d'audit, fixtures legacy), ou SHA présent : comportement inchangé. L'audit retro n'appelle jamais la résolution serveur → ne peut pas produire de faux blocage.

## Contrôles (tous exécutés, logs réels)

| Contrôle | Résultat |
|---|---|
| `pytest scripts/tests/test_check_unaddressed_nits.py scripts/tests/test_check_unaddressed_nits_mention.py` | **263 passed** (7 nouveaux tests #13639 : refus, SHA présent, sans-rapport warn-only, non-résolu warn-only, rattachement par numéro, token numérique, sans OIDs, contexte distant) |
| `python scripts/check_unaddressed_nits.py 13557` (contrôle positif exigé) | **BLOCKED — NON LEVÉ** ×2 (les deux levées citant `2d6e4c3642d`), exit 1 |
| PRs mergées à levées authentiques : 13630, 13624, 13612, 13608 | **OK exit 0** chacune |
| #13631 (FP attrapé au déploiement) | verdict **identique base↔fix** (vérifié en exécutant la version `origin/main` du script : même blocage préexistant sur le CHANGES_REQUESTED de substance ; le `[!] NON LEVE` sur la levée contexte a disparu) |
| Sweep rétro borné, 25 dernières PRs mergées | **2 levées voidées** (les 2 de la famille d'incidents #13557/#13558), **0 warning, 0 transition de verdict** — aucune PR verte ne rougit |

## Cas limite documenté (assumé)

Le **squash/rebase** déplace les SHA : une levée citant un commit pré-squash serait voidée (les 4 conditions passent). C'est la ligne choisie par l'issue (« étroit » = ces 4 conditions exactement) : le remède coûte une re-levée d'une ligne (« traitée en argument » ou le nouveau SHA), quand le trou coûtait un vert silencieux. La sortie nomme la cause, la re-levée est triviale.

See #13639 (doublon : #13629, même défaut — à clore côté coordinateur). See #13529, #13624.

---
Tests : `python -m pytest scripts/tests/test_check_unaddressed_nits.py scripts/tests/test_check_unaddressed_nits_mention.py -q` → 263 passed.
