### PR TITLE
fix(lean,#13645): aligner le label ICT-15d sur la cible ICT-15j dans Lean-27 (reste de rename R099)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-27-Coherence-et-Temoin.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-27-Coherence-et-Temoin.ipynb
@@ -577,7 +577,7 @@
    "source": [
     "### La correction d'un diagnostic antérieur\n",
     "\n",
-    "Les deux démonstrations referment la correction annoncée en ouverture. L'erreur du premier Čech affine ([ICT-15d](../../IIT/ICT-Series/ICT-15j-NerveDiscriminant.ipynb)) ne se corrige pas en condamnant la carte — elle se corrige en produisant, chaque fois, la structure qui légitime la forme employée. Écrite comme le lit un carnet de bord :\n",
+    "Les deux démonstrations referment la correction annoncée en ouverture. L'erreur du premier Čech affine ([ICT-15j](../../IIT/ICT-Series/ICT-15j-NerveDiscriminant.ipynb)) ne se corrige pas en condamnant la carte — elle se corrige en produisant, chaque fois, la structure qui légitime la forme employée. Écrite comme le lit un carnet de bord :\n",
     "\n",
     "```\n",
     "ERREUR INITIALE   :  on transporte une mesure avec une carte affine, sans axiome.\n",


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2027:CoursIA — prev: MED/notebook-python #13590

## Summary

Correctif markdown-only : aligner le texte affiché `ICT-15d` sur la cible du lien `ICT-15j` dans `Lean-27-Coherence-et-Temoin` (ligne 580). Le rename R099 (`refactor(notebooks,#12375)`, commit `641be890a4`) a mis à jour le `href` vers `ICT-15j-NerveDiscriminant.ipynb` mais a laissé le libellé `ICT-15d`, créant un lien dont le texte ne correspond pas à la destination — un lecteur qui suit « ICT-15d » atterrit sur le notebook ICT-15j.

## Preuve

- **Diff** : 1 ligne, 1 insertion / 1 suppression (le libellé uniquement), aucun autre changement.
- **Markdown-only** : la cellule touchée est `l27c14b` (`cell_type: markdown`) → exception C.2, pas de ré-exécution requise ; aucune sortie de cellule ni `execution_count` modifiés.
- **Sweep du motif texte≠href** sur tout le corpus (`git grep 'ICT-15d]' -- '**/*.ipynb'` croisé avec href `ICT-15j-`) : **exactement 1** occurrence — celle corrigée ici. Aucune autre.
- **Jumeau `_en`** : `Lean-27-Coherence-et-Temoin` n'a pas de sibling `_en` (vérifié `git ls-files 'MyIA.AI.Notebooks/SymbolicAI/Lean/*27*'`).
- **Mentions légitimes préservées** : les références au notebook réel `ICT-15d-CechObstruction.ipynb` (substrat Čech) restent `ICT-15d`.
- **H.3 pre-commit PASS** : aucun code cell avec `execution_count: null` + `outputs: []` ; 8 code cells intacts avec execution_count + outputs.
- **JSON valide** : nbformat 4, 22 cellules, round-trip intact (substitution byte-exacte, pas de re-sérialisation).

## Validation

- Pre-commit H.3 : PASS (refuse les notebooks non exécutés).
- 0 erreur volontaire (`raise NotImplementedError` / `assert False` / `1/0` : inchangé).
- Diff vérifié : `git diff --ignore-space-at-eol` ne montre que la ligne du libellé.

Closes #13645.
