### PR TITLE
fix(scripts,#13635): LIFT_MARKERS — formes masculines de la levee passive manquantes

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -281,6 +281,14 @@ CONCERN_MARKERS = CONCERN_MARKERS + BLOCK_VERDICTS
 LIFT_MARKERS = (
     "levée", "levee", "LGTM", "Mergé", "Merged", "je merge", "Merge.",
     "est adressé", "sont adressés", "sont levées", "est levée",
+    # #13635 : les formes MASCULINES de la levee passive manquaient. Le depot
+    # nomme ce qui se leve au masculin (« le concern », « le point », « le nit »)
+    # — la phrase la plus naturelle pour lever un [BOT-CONCERN] (« tes concerns
+    # sont levés ») echappait a LIFT_MARKERS, faux negatif. Miroir exact des
+    # formes feminines ci-dessus : « sont levés », « est levé ». Ces marqueurs
+    # passent par `_lift_is_negated` comme les autres (via `_live_lift_positions`),
+    # donc une negation directe (« n'est pas levé ») reste exclue.
+    "sont levés", "est levé",
     "Je lève", "Je leve", "Levée de", "Levee de",
     # #11677 : « je lève ma CHANGES_REQUESTED » (#11664 fondateur) — LIFT
     # historique ne captait que « levée » (mot complet), donc « lève ma » ne

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -3153,3 +3153,72 @@ def test_13641_ref_exacte_compte_toujours():
                   "2d6e4c3642": "fix(check,#13639): levee citee (#13640)"})
     assert res["blocked"] is True
     assert [v["sha"] for v in res["voided_lifts"]] == ["2d6e4c3642"]
+
+
+# --- #13635 : LIFT_MARKERS ne connaissait que le feminin. Les formes
+# MASCULINES de la levee passive (« est levé », « sont levés ») manquaient, alors
+# que ce depot nomme ce qui se leve au masculin (le concern / le point / le nit).
+# Un motif se valide par ses faux negatifs, pas par ses hits : chaque colonne du
+# tableau de l'issue est un test.
+
+def test_13635_masculin_leve_reconnu():
+    """Les 6 formes du tableau de l'issue rendent True apres correctif."""
+    # feminines (deja couvertes — controle de symetrie)
+    assert mod.has_live_lift("**Tes trois reserves sont levees.**") or mod.has_live_lift("**Tes trois réserves sont levées.**")
+    assert mod.has_live_lift("**La reserve est levee.**") or mod.has_live_lift("**La réserve est levée.**")
+    # masculines (le correctif)
+    assert mod.has_live_lift("**[ai-01]** Tes trois concerns sont levés.")
+    assert mod.has_live_lift("**[ai-01]** Le concern est levé.")
+    assert mod.has_live_lift("**[ai-01]** Levée de la réserve NanoClaw.") or mod.has_live_lift("**[ai-01]** Leve de la reserve NanoClaw.")
+    assert mod.has_live_lift("**[ai-01]** Le point est levé.")
+
+
+def test_13635_masculin_singulier_leve():
+    assert mod.has_live_lift("Le nit est levé.")
+    assert mod.has_live_lift("Le concern est levé.")
+
+
+def test_13635_negation_masculin_restaure_pas_levee():
+    """Control 3 (#13635) : le nouveau motif masculin passe par `_lift_is_negated`.
+
+    Une negation directe (« n'est pas levé ») doit reste exclue, comme c'est le
+    cas pour le feminin depuis #13622. Sans cette verification, un motif ajoute
+    hors du chemin de negation rouvrirait le defaut par la porte de service.
+    """
+    assert not mod.has_live_lift("Le concern n'est pas levé.")
+    assert not mod.has_live_lift("**ne pas merger tant qu'il n'est pas levé**")
+    assert not mod.has_live_lift("ce point n'est pas levé")
+    # positive lointaine : la levee locale reste reconnue
+    assert mod.has_live_lift("Le concern est levé.")
+
+
+def test_13635_negation_apres_masculin_exclue():
+    """Forme avec negation APRES le mot : 'levee non acquise' => 'levé non acquis'."""
+    assert not mod.has_live_lift("Le concern est levé non acquis.")
+
+
+def test_13635_conditionnel_feminin_nest_pas_annule_par_le_correctif():
+    """Control 2 (#13635) : le correctif n'ouvre PAS de porte conditionnelle
+    du cote masculin qui serait fermee du cote feminin.
+
+    Verifie par faux negatif (symetrie) : CONDITIONAL_LIFT ne neutralise
+    aujourd'hui que les formes a la 1re personne (« et je leve / et je merge »),
+    pas la passive 3e personne « et <sujet> est leve(e) ». Le feminin
+    (« et le point est levée ») et le masculin (« et le point est levé ») se
+    comportent de facon IDENTIQUE apres correctif — le correctif n'introduit
+    aucune asymetrie de genre.
+    """
+    # le correctif rend le masculin symetrique du feminin (aucun des deux n'est
+    # neutralise par CONDITIONAL_LIFT, mais rien n'est introduit non plus)
+    assert mod.has_live_lift("corrige la ligne 19 et le point est levé.") == \
+           mod.has_live_lift("corrige la ligne 19 et le point est levée.")
+
+
+def test_13635_conditionnel_je_leve_masculin_reste_bloquant():
+    """Les formes conditionnelles a la 1re personne restent bloquantes apres
+    correctif (regression CONDITIONAL_LIFT deja cablée, que le correctif ne
+    touche pas) — miroir de test_lift_conditionnel_nest_pas_une_levee (#11201)."""
+    assert mod.classify(
+        "myia-ai-01",
+        "Une seule chose a changer — corrige la ligne 19 et je leve le concern."
+    ) == "BOT-CONCERN"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/tooling heritage #13627 c.707

Closes #13635

## Contexte

`LIFT_MARKERS` (c.c. `scripts/check_unaddressed_nits.py`) ne connaissait que le **feminin** de la levee passive : `« est levée »`, `« sont levées »`. Ce depot nomme **ce qui se leve au masculin** — le concern, le point, le nit — donc la phrase la plus naturelle pour lever un `[BOT-CONCERN]` (ex. `« tes concerns sont levés »`) **echappait au motif**.

**Consequence** : faux negatif. Une reserve (CHANGES_REQUESTED / nit) durement levee restait `BLOCKED` — le reviewer bot re-marquait indéfiniment un point que l'auteur avait pourtant leve. C'est le cas de mon propre PR #13644 (ferme comme superseded) et le pattern qui a motive l'issue.

## Modification

Ajout de **2 marqueurs masculins** dans `LIFT_MARKERS` :
```python
"sont levés", "est levé",
```
Miroir exact des formes feminines deja presentes (`« sont levées », « est levée »`). Rien d'autre n'est touche.

Ces marqueurs passent par `_lift_is_negated` via `_live_lift_positions` comme tous les autres, donc **une negation directe (`« n'est pas levé »`) reste exclue** — controle 3 satisfait **par construction**, sans nouveau code de negation.

## Verification (controls par faux negatif)

- **222 tests passent** : 216 pre-existants + 6 nouveaux `test_13635_*`.
- **Controle 3 (negation)** : `« n'est pas levé »` / `« levé non acquis »` restent exclus de la levee.
- **Controle 2 (symetrie)** : le masculin se comporte **identiquement** au feminin sur le passif conditionnel — le correctif n'introduit **aucune asymetrie de genre** (le passif 3e personne n'est pas neutralise par CONDITIONAL_LIFT, pour les deux genres).
- **Controle 1 (motif)** : les 6 formes du tableau de l'issue (`Tes trois concerns sont levés`, `Le concern est levé`, `Le point est levé`, `Le nit est levé`, …) sont reconnues ; les conditionnelles 1re personne (`et je leve`) restent bloquantes (miroir #11201).

## Honnettete module

Le **passif 3e personne conditionnel** (`et <sujet> est leve/levée`) n'est aujourd'hui neutralise par CONDITIONAL_LIFT **pour aucun des deux genres** — c'est un champ de reparation separe (documente dans le test) que ce PR ne pretend pas combler. Ce PR corrige le **faux negatif** (levee masculin non reconnue), pas le **faux positif** conditionnel (qui existerait aussi au feminin).

## Tests

`python -m pytest scripts/tests/test_check_unaddressed_nits.py` → **222 passed** (run post-fix, branche rebasee fraiche sur origin/main `cc4d59e1bf`).

## Amend c.709 narrow-REPAIR-heritage Tell c.666-L1 ★ strict

Tag `Grain:` MANQUANT (Tell c.478-L1 ★★★ bloquant) ajouté en première ligne — fix = amend body HORS worktree via `gh pr edit --body-file` Tell c.666-L1 ★ strict `tag-prev-absent-fail-fastlane-amend-fix` sans toucher au code. Substance narrow REPAIR transversal LIVRÉE préservée (ajout 2 marqueurs + 6 tests + 222 verts).

Tells respectés : c.478-L1 ★★★ · c.531-L2 ★★ heritage · c.589-L1 ★★★ strict no merge/auth/close · c.652-L1 ★ strict narrow-self-narratif · c.666-L1 ★ strict amend body-file sans toucher au code.

-- myia-po-2023 (lane myia-po-2023:CoursIA-2, amend body c.709)