### PR TITLE
fix(guard,#13660): router le verdict nocturne du garde markdown-table vers une issue ouverte

### DIFF
--- a/.github/workflows/markdown-table-guard.yml
+++ b/.github/workflows/markdown-table-guard.yml
@@ -35,10 +35,19 @@ on:
     # (clone 2.22 Go par run). Stratification user 2026-08-23 :
     # "les jobs lourds devraient être payés une fois par fournée".
     - cron: '15 03 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Upsert the marker-guarded MD-TABLE-SWEEP comment on the rendezvous issue (default: dry-run). See #13660.'
+        required: false
+        type: boolean
+        default: false
 permissions:
   contents: read
   pull-requests: write
+  # Used only to post the marker-guarded sweep comment (#13660); the job stays
+  # advisory (exit 0), it never closes anything nor blocks a merge.
+  issues: write
 
 concurrency:
   group: markdown-table-guard-${{ github.ref }}
@@ -137,5 +146,24 @@ jobs:
           else
             unset_label "$LABEL_DEFECT"
             echo "Clean."
+          fi
+
+          # ---- Nocturne : upserter le verdict sur une issue de rendez-vous OUVERTE (#13660) ----
+          # Patron GRAIN-ORPHANS-SWEEP (#13086) : un verdict qui tombe dans un log
+          # planifie que personne n'ouvre est un organe muet (le scan trouvait,
+          # personne ne le voyait). On upserte un commentaire marker-garde
+          # (MD-TABLE-SWEEP) sur l'issue de rendez-vous. ADVISORY (exit 0) : pas
+          # de tag, pas de fermeture, pas de blocage de merge -- on route, ai-01
+          # tranche. apply : schedule toujours ; workflow_dispatch seulement si
+          # apply=true (defaut dry-run, le corps s'imprime pour controle).
+          if [ "$NOCTURNE" -eq 1 ]; then
+            WINDOW_DESC="$(git rev-parse --short "$BASE")..$(git rev-parse --short "$HEAD") (24 h de main)"
+            EXTRA=""
+            if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.apply }}" = "true" ]; then
+              EXTRA="--apply"
+            fi
+            python scripts/notebook_tools/md_table_sweep_comment.py \
+              --payload payload.json --window "$WINDOW_DESC" \
+              --issue 13660 $EXTRA || true
           fi
           exit 0

--- a/scripts/notebook_tools/md_table_sweep_comment.py
+++ b/scripts/notebook_tools/md_table_sweep_comment.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Distribution du verdict nocturne du garde markdown-table (#13660).
+
+Le scanner `scan_md_table_syntax.py` (justice, NON modifie ici) produit sur
+`--json` un `{total_findings, files:[{path, findings:[{pathology, cell_index|line,
+detail, snippet}]}]}`. Ce script est le DESTINATAIRE de ce verdict : il construit
+un commentaire marker-garde (`MD-TABLE-SWEEP`) et l'**upserte** -- un seul
+commentaire, mis a jour sur place, jamais un flot quotidien -- sur une issue de
+rendez-vous OUVERTE, calque sur le patron GRAIN-ORPHANS-SWEEP (#13086 /
+`grain-orphans-sweep.yml`).
+
+ADVISORY, jamais bloquant (exit 0 toujours) : le job ne tagge rien, ne ferme rien,
+il route, ai-01 tranche. Le manque n'etait pas la severite, c'etait l'adresse --
+un scanner parfait dont le verdict tombe dans un log planifie que personne
+n'ouvre est un organe muet.
+
+Usage:
+  python md_table_sweep_comment.py --payload payload.json \
+      --window "last-24h window of main" --issue 13660 [--apply]
+
+Sans `--apply` : dry-run (imprime le corps, ne poste rien). Avec `--apply` :
+upsert du commentaire marker-garde sur l'issue. Toute erreur gh est avalee
+(`try/except`) pour garantir l'exit 0 advisory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import subprocess
+import sys
+
+MARKER_START = "<!-- MD-TABLE-SWEEP:START -->"
+MARKER_END = "<!-- MD-TABLE-SWEEP:END -->"
+
+# Resolu depuis l'env (workflow) ou la cible canonique (dev local).
+def _repo() -> str:
+    return os.environ.get("GH_REPO", "jsboige/CoursIA")
+
+
+def _coverage_note() -> str:
+    return (
+        "_Portée : mesure la syntaxe SOURCE, pas le rendu ; ne voit pas les tables "
+        "des `.md` hors notebooks ; une ligne « irrégulière » peut être un choix "
+        "d'auteur, pas un défaut. Recalcul à la demande : `python scripts/"
+        "notebook_tools/scan_md_table_syntax.py --check`. Cf #10097, #3966, #12817, "
+        "#13660._"
+    )
+
+
+def _code_wrap(text: str) -> str:
+    """Entoure en code inline GFM en tolérant les backticks internes.
+
+    Un `CODE_SPAN_PIPE` a un backtick littéral dans son snippet ; un délimiteur
+    `` ` `` le casserait dans le rendu. On choisit un délimiteur d'une longueur
+    supérieure à la plus longue course de backticks du contenu.
+    """
+    run = max_run = 0
+    for ch in text:
+        run = run + 1 if ch == "`" else 0
+        max_run = max(max_run, run)
+    fence = "`" * (max_run + 1)
+    return f"{fence}{text}{fence}"
+
+
+def build_comment(files: list[dict], total: int, window: str, stamp: str) -> str:
+    lines = [MARKER_START]
+    if total == 0:
+        lines += [
+            f"**Défauts de syntaxe de table markdown : 0** dans la fenêtre "
+            f"`{window}` (mesure du {stamp}). Rien à signaler à l'instant du "
+            f"balayage.",
+            "",
+            _coverage_note(),
+            MARKER_END,
+        ]
+        return "\n".join(lines)
+    lines.append(
+        f"**{total} défaut(s) de syntaxe de table markdown** dans la fenêtre "
+        f"`{window}` (mesure du {stamp}). Par notebook :"
+    )
+    lines.append("")
+    for r in files:
+        findings = r.get("findings") or []
+        if not findings:
+            continue
+        lines.append(f"- **{r['path']}** :")
+        for f in findings:
+            cell = f.get("cell_index")
+            loc = f"cellule {cell}" if cell is not None else f"ligne {f.get('line')}"
+            snippet = (f.get("snippet") or "").strip()
+            if len(snippet) > 60:
+                snippet = snippet[:57] + "..."
+            lines.append(
+                f"  - {loc} — `{f.get('pathology')}` : {_code_wrap(snippet)}"
+            )
+    lines += ["", _coverage_note(), MARKER_END]
+    return "\n".join(lines)
+
+
+def upsert_comment(issue: int, body: str) -> None:
+    """Un seul commentaire marker-garde par issue, mis a jour sur place."""
+    repo = _repo()
+    comments = json.loads(subprocess.run(
+        ["gh", "issue", "view", str(issue), "--repo", repo, "--json", "comments"],
+        capture_output=True, text=True, encoding="utf-8", check=True, timeout=60,
+    ).stdout)
+    cid = next((c["id"] for c in (comments.get("comments") or [])
+                if MARKER_START in (c.get("body") or "")), None)
+    if cid is not None:
+        subprocess.run(
+            ["gh", "api", f"repos/{repo}/issues/comments/{cid}",
+             "-X", "PATCH", "-f", f"body={body}"],
+            capture_output=True, text=True, encoding="utf-8", check=True, timeout=60)
+    else:
+        subprocess.run(
+            ["gh", "issue", "comment", str(issue), "--repo", repo,
+             "--body-file", "-"],
+            input=body, capture_output=True, text=True, encoding="utf-8",
+            check=True, timeout=60)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--payload", required=True,
+                    help="JSON produit par scan_md_table_syntax.py --json")
+    ap.add_argument("--window", default="last-24h window of main",
+                    help="description de la fenetre scannee (millesime du rapport)")
+    ap.add_argument("--issue", type=int, required=True,
+                    help="issue de rendez-vous OUVERTE a upserter")
+    ap.add_argument("--apply", action="store_true",
+                    help="upsert du commentaire (defaut : dry-run, impression seule)")
+    args = ap.parse_args(argv)
+
+    with open(args.payload, encoding="utf-8") as fh:
+        payload = json.load(fh)
+    total = int(payload.get("total_findings", 0))
+    files = payload.get("files", [])
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+
+    body = build_comment(files, total, args.window, stamp)
+    print(body)
+    if not args.apply:
+        print(f"[dry-run] commentaire construit (issue #{args.issue}) — "
+              f"relancer avec --apply pour upserter.")
+        return 0
+
+    try:
+        upsert_comment(args.issue, body)
+        print(f"[apply] commentaire marker-garde mis a jour sur #{args.issue}")
+    except Exception as exc:  # advisory : avaler, ne jamais casser le job
+        print(f"[apply] ECHEC avale (advisory, exit 0) : {exc}", file=sys.stderr)
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_md_table_sweep_comment.py
+++ b/scripts/tests/test_md_table_sweep_comment.py
@@ -1,0 +1,99 @@
+"""Tests for scripts/notebook_tools/md_table_sweep_comment.py (#13660).
+
+L'organe est la DISTRIBUTION du verdict nocturne du garde markdown-table : le
+scanner `scan_md_table_syntax.py` (non modifie ici) est juste, mais son verdict
+tombait dans un log planifie que personne n'ouvre -- un organe muet. Ce module
+construit le commentaire marker-garde (`MD-TABLE-SWEEP`) et l'upserte sur une
+issue de rendez-vous OUVERTE (patron GRAIN-ORPHANS-SWEEP, #13086).
+
+Ce qui doit rester stable pour que l'upsert fonctionne (un seul commentaire
+remplace, jamais un flot) :
+  - la paire de marqueurs ``MD-TABLE-SWEEP:START`` / ``:END`` borne le bloc --
+    l'upsert le retrouve par START et remplace TOUT le bloc ;
+  - le corps porte le millesime (date + fenetre) pour ne pas se lire comme
+    courant ;
+  - le corps ecrit ce qu'il ne couvre pas (syntaxe source, pas rendu) ;
+  - le cas vide s'ecrit AUSSI (un balayage muet est indiscernable d'un balayage
+    mort), MAIS sans lister les notebooks sains -- un rapport qui listerait tout
+    ne mesure rien.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MOD_PATH = HERE.parent / "notebook_tools" / "md_table_sweep_comment.py"
+
+spec = importlib.util.spec_from_file_location("md_table_sweep_comment", MOD_PATH)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["md_table_sweep_comment"] = mod
+spec.loader.exec_module(mod)
+
+STAMP = "2026-08-30T11:00Z"
+WINDOW = "cc4d59e1bf..cafe1234 (24 h de main)"
+
+
+def test_positive_lists_defects_with_locations():
+    files = [{
+        "path": "MyIA.AI.Notebooks/Sudoku/Sudoku-05-PSO-Csharp.ipynb",
+        "findings": [
+            {"pathology": "CODE_SPAN_PIPE", "cell_index": 40, "line": 17,
+             "detail": "x", "snippet": "| `a|b` | c |"},
+            {"pathology": "NO_BLANK_BEFORE", "line": 8,
+             "detail": "x", "snippet": "glued paragraph"},
+        ],
+    }]
+    body = mod.build_comment(files, 2, WINDOW, STAMP)
+    assert mod.MARKER_START in body and mod.MARKER_END in body
+    assert "2 défaut(s)" in body
+    assert "Sudoku-05-PSO-Csharp.ipynb" in body
+    assert "cellule 40" in body
+    assert "ligne 8" in body
+    assert "CODE_SPAN_PIPE" in body
+    assert "glued paragraph" in body
+    assert STAMP in body and WINDOW in body
+
+
+def test_negative_control_does_not_list_clean_notebook():
+    files = [
+        {"path": "clean_a.ipynb", "findings": []},
+        {"path": "clean_b.ipynb", "findings": []},
+    ]
+    body = mod.build_comment(files, 0, WINDOW, STAMP)
+    assert mod.MARKER_START in body and mod.MARKER_END in body
+    assert "0" in body and "défaut" in body
+    # Un notebook sans defaut n'apparait PAS : un rapport qui listerait tout ne
+    # mesure rien.
+    assert "clean_a.ipynb" not in body
+    assert "clean_b.ipynb" not in body
+
+
+def test_marker_guards_brace_the_whole_block():
+    files = [{"path": "n.ipynb", "findings": [
+        {"pathology": "COL_MISMATCH", "line": 3, "detail": "x", "snippet": "| a |"},
+    ]}]
+    body = mod.build_comment(files, 1, WINDOW, STAMP)
+    lines = [l for l in body.split("\n")]
+    assert lines[0] == mod.MARKER_START
+    assert lines[-1] == mod.MARKER_END
+
+
+def test_coverage_note_states_what_it_does_not_cover():
+    files = [{"path": "n.ipynb", "findings": []}]
+    body = mod.build_comment(files, 0, WINDOW, STAMP)
+    # La portee (syntaxe source, pas rendu) doit etre ecrite explicitement.
+    assert "syntaxe SOURCE" in body
+    assert "pas le rendu" in body
+    assert "choix d'auteur" in body
+
+
+def test_backtick_in_snippet_gets_safe_fence():
+    files = [{"path": "n.ipynb", "findings": [
+        {"pathology": "CODE_SPAN_PIPE", "cell_index": 40, "line": 17,
+         "detail": "x", "snippet": "| `a|b` | c |"},
+    ]}]
+    body = mod.build_comment(files, 1, WINDOW, STAMP)
+    # Un CODE_SPAN_PIPE a un backtick litteral : le delimiter doit etre plus long
+    # que la course interne, sinon le rendu du commentaire casse.
+    assert "``| `a|b` | c |``" in body


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/tooling heritage #13661 c.710

## Résumé

Le scanner `scan_md_table_syntax.py` est **juste** — il a trouvé **25 défauts** la nuit du 2026-08-29 ([run 33231310367](https://github.com/jsboige/CoursIA/actions/runs/33231310367)) — mais son verdict **n'a aucun destinataire** : trigger `pull_request` retiré depuis #12817 (coût du clone), labels noop'd sous `NOCTURNE=1`, issues de rattachement #10097/#12220/#3966 toutes **CLOSED**, seul canal vivant = un `::warning::` dans le log d'un run planifié que personne n'ouvre. **Un organe parfait dont la sortie tombe dans le vide.**

Fix calqué sur le patron **GRAIN-ORPHANS-SWEEP** (#13086) : le run nocturne **upverte** (ne pile pas) un commentaire marker-gardé `MD-TABLE-SWEEP` sur une issue de rendez-vous **ouverte**. Le scanner n'est **PAS** modifié — c'est sa **distribution** qui manquait, pas sa détection (cf « Ne pas réécrire `scan_md_table_syntax.py` »).

## Ce qui change

1. **`.github/workflows/markdown-table-guard.yml`** (+29/−1) :
   - permission `issues: write` (poster le commentaire) ;
   - input `workflow_dispatch.apply` (booléen, défaut `false` = dry-run) ;
   - bloc nocturne : quand `NOCTURNE=1`, construit et upserte le commentaire sur `#13660` — `apply` si `schedule`, ou si `inputs.apply=true`.
2. **`scripts/notebook_tools/md_table_sweep_comment.py`** (nouveau) : consomme le JSON du scanner (`total_findings` + `files[].findings[]{pathology, cell_index|line, snippet}`) et construit/upserte le commentaire. **ADVISORY** (exit 0) : avale toute erreur `gh`, ne tagge rien, ne ferme rien.
3. **`scripts/tests/test_md_table_sweep_comment.py`** (nouveau) : 5 tests sur `build_comment` (contrôle positif, contrôle négatif, marqueurs START/END, note de portée, échappement backtick).

## Acceptance (mapping)

| Critère | Statut |
|---|---|
| Le run nocturne upserte un commentaire marker-gardé sur une issue ouverte ; 2 runs → 1 commentaire | ✅ `upsert_comment` (create/update via `gh api PATCH`) — un seul commentaire retrouvé par `MARKER_START`, remplacé sur place |
| Contrôle positif : un notebook avec un défaut connu apparaît | ✅ vérifié en dry-run : 2 défauts listés avec cellule/ligne + pathologie + snippet tronqué ; un `workflow_dispatch` élargi le fait sortir |
| Contrôle négatif : un notebook sans défaut n'apparaît pas | ✅ vérifié en dry-run : `total_findings=0` → « 0 défaut », notebooks sains **non** listés |
| Le commentaire porte la date de la mesure et la fenêtre scannée | ✅ `stamp` UTC + `WINDOW_DESC` (range SHORT de la fenêtre 24 h de main) |
| Le commentaire écrit explicitement ce qu'il ne couvre pas | ✅ note de portée : syntaxe source (pas le rendu), pas les `.md` hors notebooks, une ligne « irrégulière » peut être un choix d'auteur |
| Le job reste advisory (exit 0) | ✅ helper `try/except` + `|| true` — aucune erreur ne casse le job |

## Ne fait PAS (respecté)

- Ne **remet pas** le trigger `pull_request` (coût du clone de #12817 valide).
- Ne transforme pas l'advisory en gate bloquant.
- Ne **réécrit pas** `scan_md_table_syntax.py` (un seul organe de détection).

## Note Closes vs See

**`See #13660`, pas `Closes #13660`** — volontaire. L'acceptation exige une **issue de rendez-vous OUVERTE** ; fermer #13660 au merge tuerait le destinataire du sweep nocturne (le job posterait sur une issue fermée). #13660 reste donc **ouverte** comme collecteur, calqué sur `#13086` (issue de routage GRAIN-ORPHANS-SWEEP gardée ouverte). Le fix complet est livré ; seule la fermeture de l'issue est volontairement différée pour préserver le destinataire.

## Preuves locales (dry-run, contrôles)

- **Positif** : `md_table_sweep_comment.py --payload ... --window "cc4d59e1bf..cafe1234 (24 h de main)"` → 2 défauts (CODE_SPAN_PIPE cellule 40, NO_BLANK_BEFORE ligne 8), snippet tronqué, date + fenêtre + portée.
- **Négatif** : `total_findings=0` → « 0 défaut », aucun notebook sain listé.
- `pytest scripts/tests/test_md_table_sweep_comment.py` → **5 passed**.
- YAML workflow valide (`yaml.safe_load`).

Catalogue byte-identique ; 3 fichiers (1 workflow modifié + 2 nouveaux), aucun notebook, aucun Lean/WSL.

## Amend c.710 narrow-REPAIR-heritage Tell c.666-L1 ★ strict

Tag `Grain:` MANQUANT (Tell c.478-L1 ★★★ bloquant) ajouté en première ligne — fix = amend body HORS worktree via `gh pr edit --body-file` Tell c.666-L1 ★ strict `tag-prev-absent-fail-fastlane-amend-fix` sans toucher au code. Substance narrow REPAIR transversal LIVRÉE préservée (workflow + script + 5 tests + dry-run 2 défauts). Tells respectés : c.478-L1 ★★★ · c.531-L2 ★★ heritage · c.589-L1 ★★★ strict no merge/auth/close · c.652-L1 ★ strict narrow-self-narratif · c.666-L1 ★ strict amend body-file sans toucher au code · c.701-L1 ★ sustained re-tag guard→tooling (substance = "fix on check script workflow" = tooling pré-emptive au commit).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>