### PR TITLE
feat(ict): test salience-pregnance coupling

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/adjonction_saillance_pregnance.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/adjonction_saillance_pregnance.py
@@ -1,0 +1,277 @@
+"""Test borné du canal saillance-prégnance proposé par #13580.
+
+Le prototype ``docs/ict/strates-as-adjunctions-prototype.md`` proposait une
+fonction ``f_aj(s, pi)`` comme témoin d'une adjonction. Une fonction scalaire
+n'est toutefois pas une adjonction catégorielle : ce module ne définit ni
+catégories, ni foncteurs, ni bijection naturelle de hom-sets. Il teste seulement
+une signature empirique plus faible : un canal de décision bilinéaire répond-il
+aux deux entrées indépendantes, contrairement à deux nulls mono-canal ?
+
+La dette d'inhibition d'ICT-30 appartient par ailleurs à un autre substrat. Elle
+est donc déclarée ``NOT_TESTABLE_ON_THIS_SUBSTRATE`` plutôt que remplacée par
+une métrique commode. L'entropie de décision est rapportée à titre diagnostique,
+sans être appelée dette d'inhibition.
+
+Le protocole et ses seuils ont été amendés dans le document prototype avant la
+première exécution de cette tranche. Les graines d'étude sont fixées à
+``(0, 1, 7, 42, 99)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Iterable
+
+import numpy as np
+
+from ict.salience_valence_dissociation import (
+    learn_valences,
+    measure_decision_given_detected,
+    partial_spearman,
+    stimulus_battery,
+)
+
+__all__ = [
+    "CouplingConfig",
+    "couple_engagement",
+    "evaluate_seed",
+    "derive_operational_verdict",
+    "run_preregistered_study",
+]
+
+DEFAULT_SEEDS = (0, 1, 7, 42, 99)
+P1_GATE_NAMES = (
+    "P1_coupled_responds_to_both_channels",
+    "P1_null_s_excludes_pi",
+    "P1_null_pi_excludes_s",
+)
+GATE_NAMES = P1_GATE_NAMES + ("P3_scalar_operation_ratio_at_most_two",)
+
+
+@dataclass(frozen=True)
+class CouplingConfig:
+    """Paramètres scellés du banc NumPy CPU-only."""
+
+    n_stimuli: int = 160
+    n_epochs: int = 200
+    alpha: float = 0.15
+    n_trials: int = 500
+    kappa: float = 2.0
+    mu: float = 2.0
+    nu: float = 2.0
+    joint_partial_floor: float = 0.40
+    absent_partial_ceiling: float = 0.20
+
+    def __post_init__(self) -> None:
+        if self.n_stimuli < 20:
+            raise ValueError("n_stimuli doit être >= 20")
+        if self.n_epochs <= 0 or self.n_trials <= 0:
+            raise ValueError("n_epochs et n_trials doivent être > 0")
+        if not 0.0 < self.alpha <= 1.0:
+            raise ValueError("alpha doit être dans ]0, 1]")
+        if min(self.kappa, self.mu, self.nu) < 0.0:
+            raise ValueError("les coefficients du canal doivent être >= 0")
+        if not 0.0 < self.joint_partial_floor < 1.0:
+            raise ValueError("joint_partial_floor doit être dans ]0, 1[")
+        if not 0.0 < self.absent_partial_ceiling < 1.0:
+            raise ValueError("absent_partial_ceiling doit être dans ]0, 1[")
+
+
+def _sigmoid(values: np.ndarray) -> np.ndarray:
+    values = np.asarray(values, dtype=float)
+    return np.where(
+        values >= 0.0,
+        1.0 / (1.0 + np.exp(-values)),
+        np.exp(values) / (1.0 + np.exp(values)),
+    )
+
+
+def couple_engagement(
+    salience: np.ndarray,
+    pregnance: np.ndarray,
+    *,
+    mode: str = "coupled",
+    config: CouplingConfig = CouplingConfig(),
+) -> np.ndarray:
+    """Retourne ``P(approche | détecté)`` pour le traitement ou un null.
+
+    ``coupled`` ajoute l'interaction bilinéaire ``s*pi`` à un modèle additif
+    deux-canaux. ``null_s`` et ``null_pi`` suppriment respectivement la
+    prégnance et la saillance ; varier le canal absent ne peut donc rien changer.
+    """
+
+    s = np.asarray(salience, dtype=float)
+    pi = np.asarray(pregnance, dtype=float)
+    if s.shape != pi.shape:
+        raise ValueError("salience et pregnance doivent avoir la même forme")
+    if mode == "coupled":
+        logits = config.kappa * s + config.mu * pi + config.nu * s * pi
+    elif mode == "null_s":
+        logits = config.kappa * s
+    elif mode == "null_pi":
+        logits = config.mu * pi
+    else:
+        raise ValueError(f"mode inconnu : {mode}")
+    return _sigmoid(logits)
+
+
+def _binary_entropy(probabilities: np.ndarray) -> float:
+    p = np.clip(np.asarray(probabilities, dtype=float), 1e-12, 1.0 - 1e-12)
+    return float(np.mean(-(p * np.log2(p) + (1.0 - p) * np.log2(1.0 - p))))
+
+
+def _partials(
+    salience: np.ndarray,
+    pregnance: np.ndarray,
+    decisions: np.ndarray,
+) -> dict[str, float]:
+    return {
+        "pi_given_s": float(partial_spearman(pregnance, decisions, [salience])),
+        "s_given_pi": float(partial_spearman(salience, decisions, [pregnance])),
+    }
+
+
+def evaluate_seed(
+    seed: int,
+    *,
+    config: CouplingConfig = CouplingConfig(),
+) -> dict:
+    """Évalue une graine held-out avec des flux aléatoires séparés par bras."""
+
+    rng = np.random.default_rng(int(seed))
+    salience, rewards = stimulus_battery(config.n_stimuli, rng=rng)
+    pregnance = learn_valences(
+        rewards,
+        n_epochs=config.n_epochs,
+        alpha=config.alpha,
+        rng=rng,
+    )
+
+    probabilities = {
+        mode: couple_engagement(salience, pregnance, mode=mode, config=config)
+        for mode in ("coupled", "null_s", "null_pi")
+    }
+    seed_offsets = {"coupled": 10_000, "null_s": 20_000, "null_pi": 30_000}
+    decisions = {
+        mode: measure_decision_given_detected(
+            salience,
+            probability,
+            n_trials=config.n_trials,
+            rng=np.random.default_rng(int(seed) + seed_offsets[mode]),
+        )
+        for mode, probability in probabilities.items()
+    }
+    partials = {
+        mode: _partials(salience, pregnance, decision)
+        for mode, decision in decisions.items()
+    }
+
+    # Modèle additif deux-canaux : 2 multiplications + 1 addition = 3 ops.
+    # Canal couplé : + produit s*pi, multiplication par nu et addition = 6 ops.
+    additive_ops = 3
+    coupled_ops = 6
+    operation_ratio = coupled_ops / additive_ops
+
+    gates = {
+        "P1_coupled_responds_to_both_channels": (
+            abs(partials["coupled"]["pi_given_s"]) >= config.joint_partial_floor
+            and abs(partials["coupled"]["s_given_pi"])
+            >= config.joint_partial_floor
+        ),
+        "P1_null_s_excludes_pi": (
+            abs(partials["null_s"]["pi_given_s"])
+            <= config.absent_partial_ceiling
+            and abs(partials["null_s"]["s_given_pi"])
+            >= config.joint_partial_floor
+        ),
+        "P1_null_pi_excludes_s": (
+            abs(partials["null_pi"]["s_given_pi"])
+            <= config.absent_partial_ceiling
+            and abs(partials["null_pi"]["pi_given_s"])
+            >= config.joint_partial_floor
+        ),
+        "P3_scalar_operation_ratio_at_most_two": operation_ratio <= 2.0,
+    }
+    if operation_ratio <= 2.0:
+        complexity_verdict = "SUPPORTED"
+    elif operation_ratio > 5.0:
+        complexity_verdict = "FALSIFIED"
+    else:
+        complexity_verdict = "INCONCLUSIVE"
+
+    return {
+        "seed": int(seed),
+        "rho_s_pi": float(np.corrcoef(salience, pregnance)[0, 1]),
+        "partials": partials,
+        "decision_entropy_bits": {
+            mode: _binary_entropy(probability)
+            for mode, probability in probabilities.items()
+        },
+        "complexity": {
+            "additive_two_channel_scalar_ops": additive_ops,
+            "coupled_scalar_ops": coupled_ops,
+            "ratio": float(operation_ratio),
+            "asymptotic_order": "O(n_stimuli)",
+            "verdict": complexity_verdict,
+        },
+        "P2_original_inhibition_debt": "NOT_TESTABLE_ON_THIS_SUBSTRATE",
+        "gates": gates,
+    }
+
+
+def derive_operational_verdict(gates_per_seed: Iterable[dict]) -> str:
+    """Dérive le verdict du canal, sans requalifier la spécification originale."""
+
+    rows = [dict(gates) for gates in gates_per_seed]
+    if len(rows) < 5:
+        raise ValueError("le protocole exige au moins cinq graines")
+    counts = {gate: sum(bool(row[gate]) for row in rows) for gate in GATE_NAMES}
+    if all(counts[gate] >= len(rows) - 1 for gate in P1_GATE_NAMES):
+        return "SUPPORTED_OPERATIONAL_CHANNEL"
+    return "FALSIFIED_OPERATIONAL_CHANNEL"
+
+
+def run_preregistered_study(
+    *,
+    seeds: Iterable[int] = DEFAULT_SEEDS,
+    config: CouplingConfig = CouplingConfig(),
+) -> dict:
+    """Exécute les cinq graines et conserve deux niveaux de verdict."""
+
+    seed_values = tuple(int(seed) for seed in seeds)
+    if len(seed_values) < 5:
+        raise ValueError("le protocole exige au moins cinq graines")
+    rows = [evaluate_seed(seed, config=config) for seed in seed_values]
+    pass_counts = {
+        gate: sum(bool(row["gates"][gate]) for row in rows)
+        for gate in GATE_NAMES
+    }
+    return {
+        "reference": {
+            "prototype": "docs/ict/strates-as-adjunctions-prototype.md#41-amendement-pre-execution--observables-et-frontieres",
+            "substrate": "ict.salience_valence_dissociation",
+            "source_issue": 8182,
+            "source_pr": 13580,
+        },
+        "config": asdict(config),
+        "seeds": list(seed_values),
+        "pass_counts": pass_counts,
+        "verdicts": {
+            "original_specification": "FALSIFIED_SPECIFICATION",
+            "operational_channel": derive_operational_verdict(
+                row["gates"] for row in rows
+            ),
+            "P2_inhibition_debt": "NOT_TESTABLE_ON_THIS_SUBSTRATE",
+            "categorical_adjunction": "NOT_ESTABLISHED",
+        },
+        "aggregate": {
+            "coupled_abs_partial_pi_median": float(
+                np.median([abs(row["partials"]["coupled"]["pi_given_s"]) for row in rows])
+            ),
+            "coupled_abs_partial_s_median": float(
+                np.median([abs(row["partials"]["coupled"]["s_given_pi"]) for row in rows])
+            ),
+            "operation_ratio": float(rows[0]["complexity"]["ratio"]),
+        },
+        "rows": rows,
+    }

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/adjonction_saillance_pregnance_results.json
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/adjonction_saillance_pregnance_results.json
@@ -1,0 +1,230 @@
+{
+  "reference": {
+    "prototype": "docs/ict/strates-as-adjunctions-prototype.md#41-amendement-pre-execution--observables-et-frontieres",
+    "substrate": "ict.salience_valence_dissociation",
+    "source_issue": 8182,
+    "source_pr": 13580
+  },
+  "config": {
+    "n_stimuli": 160,
+    "n_epochs": 200,
+    "alpha": 0.15,
+    "n_trials": 500,
+    "kappa": 2.0,
+    "mu": 2.0,
+    "nu": 2.0,
+    "joint_partial_floor": 0.4,
+    "absent_partial_ceiling": 0.2
+  },
+  "seeds": [
+    0,
+    1,
+    7,
+    42,
+    99
+  ],
+  "pass_counts": {
+    "P1_coupled_responds_to_both_channels": 5,
+    "P1_null_s_excludes_pi": 5,
+    "P1_null_pi_excludes_s": 4,
+    "P3_scalar_operation_ratio_at_most_two": 5
+  },
+  "verdicts": {
+    "original_specification": "FALSIFIED_SPECIFICATION",
+    "operational_channel": "SUPPORTED_OPERATIONAL_CHANNEL",
+    "P2_inhibition_debt": "NOT_TESTABLE_ON_THIS_SUBSTRATE",
+    "categorical_adjunction": "NOT_ESTABLISHED"
+  },
+  "aggregate": {
+    "coupled_abs_partial_pi_median": 0.9802997003639312,
+    "coupled_abs_partial_s_median": 0.79476126627312,
+    "operation_ratio": 2.0
+  },
+  "rows": [
+    {
+      "seed": 0,
+      "rho_s_pi": -0.09308549436157411,
+      "partials": {
+        "coupled": {
+          "pi_given_s": 0.9745797631107121,
+          "s_given_pi": 0.8246211321045794
+        },
+        "null_s": {
+          "pi_given_s": 0.09513683885134117,
+          "s_given_pi": 0.9681015053460351
+        },
+        "null_pi": {
+          "pi_given_s": 0.989454161480646,
+          "s_given_pi": -0.015728099779268388
+        }
+      },
+      "decision_entropy_bits": {
+        "coupled": 0.5846496497686956,
+        "null_s": 0.7773405412980223,
+        "null_pi": 0.8076319807564076
+      },
+      "complexity": {
+        "additive_two_channel_scalar_ops": 3,
+        "coupled_scalar_ops": 6,
+        "ratio": 2.0,
+        "asymptotic_order": "O(n_stimuli)",
+        "verdict": "SUPPORTED"
+      },
+      "P2_original_inhibition_debt": "NOT_TESTABLE_ON_THIS_SUBSTRATE",
+      "gates": {
+        "P1_coupled_responds_to_both_channels": true,
+        "P1_null_s_excludes_pi": true,
+        "P1_null_pi_excludes_s": true,
+        "P3_scalar_operation_ratio_at_most_two": true
+      }
+    },
+    {
+      "seed": 1,
+      "rho_s_pi": -0.028976759617452386,
+      "partials": {
+        "coupled": {
+          "pi_given_s": 0.9853370902105336,
+          "s_given_pi": 0.79476126627312
+        },
+        "null_s": {
+          "pi_given_s": -0.03258697599905401,
+          "s_given_pi": 0.9443156692538882
+        },
+        "null_pi": {
+          "pi_given_s": 0.9908151446714385,
+          "s_given_pi": -0.01362928514883322
+        }
+      },
+      "decision_entropy_bits": {
+        "coupled": 0.6423377703689619,
+        "null_s": 0.7916379548658291,
+        "null_pi": 0.8063959829510576
+      },
+      "complexity": {
+        "additive_two_channel_scalar_ops": 3,
+        "coupled_scalar_ops": 6,
+        "ratio": 2.0,
+        "asymptotic_order": "O(n_stimuli)",
+        "verdict": "SUPPORTED"
+      },
+      "P2_original_inhibition_debt": "NOT_TESTABLE_ON_THIS_SUBSTRATE",
+      "gates": {
+        "P1_coupled_responds_to_both_channels": true,
+        "P1_null_s_excludes_pi": true,
+        "P1_null_pi_excludes_s": true,
+        "P3_scalar_operation_ratio_at_most_two": true
+      }
+    },
+    {
+      "seed": 7,
+      "rho_s_pi": -0.030428854644804586,
+      "partials": {
+        "coupled": {
+          "pi_given_s": 0.9761536470295008,
+          "s_given_pi": 0.710270907399059
+        },
+        "null_s": {
+          "pi_given_s": -0.019988070023372426,
+          "s_given_pi": 0.9637651098996023
+        },
+        "null_pi": {
+          "pi_given_s": 0.989099422393221,
+          "s_given_pi": 0.008966843729688544
+        }
+      },
+      "decision_entropy_bits": {
+        "coupled": 0.6160855825561937,
+        "null_s": 0.789946546005516,
+        "null_pi": 0.8110301500614687
+      },
+      "complexity": {
+        "additive_two_channel_scalar_ops": 3,
+        "coupled_scalar_ops": 6,
+        "ratio": 2.0,
+        "asymptotic_order": "O(n_stimuli)",
+        "verdict": "SUPPORTED"
+      },
+      "P2_original_inhibition_debt": "NOT_TESTABLE_ON_THIS_SUBSTRATE",
+      "gates": {
+        "P1_coupled_responds_to_both_channels": true,
+        "P1_null_s_excludes_pi": true,
+        "P1_null_pi_excludes_s": true,
+        "P3_scalar_operation_ratio_at_most_two": true
+      }
+    },
+    {
+      "seed": 42,
+      "rho_s_pi": 0.03308219027196349,
+      "partials": {
+        "coupled": {
+          "pi_given_s": 0.983959465817467,
+          "s_given_pi": 0.7326031512090635
+        },
+        "null_s": {
+          "pi_given_s": 0.16887550566042833,
+          "s_given_pi": 0.9519244846739126
+        },
+        "null_pi": {
+          "pi_given_s": 0.988975037748623,
+          "s_given_pi": 0.0015062089671353256
+        }
+      },
+      "decision_entropy_bits": {
+        "coupled": 0.640701806932966,
+        "null_s": 0.8002992900779745,
+        "null_pi": 0.8007212310367635
+      },
+      "complexity": {
+        "additive_two_channel_scalar_ops": 3,
+        "coupled_scalar_ops": 6,
+        "ratio": 2.0,
+        "asymptotic_order": "O(n_stimuli)",
+        "verdict": "SUPPORTED"
+      },
+      "P2_original_inhibition_debt": "NOT_TESTABLE_ON_THIS_SUBSTRATE",
+      "gates": {
+        "P1_coupled_responds_to_both_channels": true,
+        "P1_null_s_excludes_pi": true,
+        "P1_null_pi_excludes_s": true,
+        "P3_scalar_operation_ratio_at_most_two": true
+      }
+    },
+    {
+      "seed": 99,
+      "rho_s_pi": 0.010994568655071611,
+      "partials": {
+        "coupled": {
+          "pi_given_s": 0.9802997003639312,
+          "s_given_pi": 0.8010882830496479
+        },
+        "null_s": {
+          "pi_given_s": 0.12863860493275273,
+          "s_given_pi": 0.957964135614794
+        },
+        "null_pi": {
+          "pi_given_s": 0.9892693423232501,
+          "s_given_pi": 0.2704453401134868
+        }
+      },
+      "decision_entropy_bits": {
+        "coupled": 0.5981045891028183,
+        "null_s": 0.783883283072145,
+        "null_pi": 0.8201438571337437
+      },
+      "complexity": {
+        "additive_two_channel_scalar_ops": 3,
+        "coupled_scalar_ops": 6,
+        "ratio": 2.0,
+        "asymptotic_order": "O(n_stimuli)",
+        "verdict": "SUPPORTED"
+      },
+      "P2_original_inhibition_debt": "NOT_TESTABLE_ON_THIS_SUBSTRATE",
+      "gates": {
+        "P1_coupled_responds_to_both_channels": true,
+        "P1_null_s_excludes_pi": true,
+        "P1_null_pi_excludes_s": false,
+        "P3_scalar_operation_ratio_at_most_two": true
+      }
+    }
+  ]
+}

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_adjonction_saillance_pregnance.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_adjonction_saillance_pregnance.py
@@ -1,0 +1,150 @@
+"""Tests du protocole saillance-prégnance borné et pré-enregistré."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from ict.adjonction_saillance_pregnance import (
+    CouplingConfig,
+    couple_engagement,
+    derive_operational_verdict,
+    evaluate_seed,
+    run_preregistered_study,
+)
+
+RESULTS_PATH = (
+    Path(__file__).parents[1] / "adjonction_saillance_pregnance_results.json"
+)
+
+
+@pytest.fixture(scope="module")
+def standard_study() -> dict:
+    return run_preregistered_study()
+
+
+def test_coupled_channel_uses_both_inputs() -> None:
+    config = CouplingConfig()
+    salience = np.array([-0.5, -0.5, 0.5, 0.5])
+    pregnance = np.array([-0.5, 0.5, -0.5, 0.5])
+
+    probabilities = couple_engagement(salience, pregnance, config=config)
+
+    assert probabilities[0] != pytest.approx(probabilities[1])
+    assert probabilities[0] != pytest.approx(probabilities[2])
+    assert probabilities[3] > probabilities[1]
+    assert probabilities[3] > probabilities[2]
+
+
+def test_null_channels_ignore_the_absent_input() -> None:
+    salience = np.array([-0.8, -0.1, 0.3, 0.9])
+    pregnance_a = np.array([-0.9, 0.7, 0.2, -0.4])
+    pregnance_b = pregnance_a[::-1]
+
+    np.testing.assert_allclose(
+        couple_engagement(salience, pregnance_a, mode="null_s"),
+        couple_engagement(salience, pregnance_b, mode="null_s"),
+    )
+    np.testing.assert_allclose(
+        couple_engagement(pregnance_a, salience, mode="null_pi"),
+        couple_engagement(pregnance_b, salience, mode="null_pi"),
+    )
+
+
+def test_invalid_inputs_are_rejected() -> None:
+    with pytest.raises(ValueError, match="n_stimuli"):
+        CouplingConfig(n_stimuli=10)
+    with pytest.raises(ValueError, match="alpha"):
+        CouplingConfig(alpha=0.0)
+    with pytest.raises(ValueError, match="même forme"):
+        couple_engagement(np.ones(2), np.ones(3))
+    with pytest.raises(ValueError, match="mode inconnu"):
+        couple_engagement(np.ones(2), np.ones(2), mode="adjunction")
+
+
+def test_seed_evaluation_is_deterministic() -> None:
+    assert evaluate_seed(42) == evaluate_seed(42)
+
+
+def test_seed_row_separates_testable_and_untestable_claims() -> None:
+    row = evaluate_seed(0)
+
+    assert set(row["partials"]) == {"coupled", "null_s", "null_pi"}
+    assert row["P2_original_inhibition_debt"] == (
+        "NOT_TESTABLE_ON_THIS_SUBSTRATE"
+    )
+    assert row["complexity"]["ratio"] == pytest.approx(2.0)
+    assert row["complexity"]["asymptotic_order"] == "O(n_stimuli)"
+    assert row["complexity"]["verdict"] == "SUPPORTED"
+    assert set(row["gates"]) == {
+        "P1_coupled_responds_to_both_channels",
+        "P1_null_s_excludes_pi",
+        "P1_null_pi_excludes_s",
+        "P3_scalar_operation_ratio_at_most_two",
+    }
+
+
+def test_operational_verdict_branches() -> None:
+    passing = {
+        "P1_coupled_responds_to_both_channels": True,
+        "P1_null_s_excludes_pi": True,
+        "P1_null_pi_excludes_s": True,
+        "P3_scalar_operation_ratio_at_most_two": True,
+    }
+    rows = [passing.copy() for _ in range(5)]
+    assert derive_operational_verdict(rows) == "SUPPORTED_OPERATIONAL_CHANNEL"
+
+    rows[0]["P3_scalar_operation_ratio_at_most_two"] = False
+    rows[1]["P3_scalar_operation_ratio_at_most_two"] = False
+    assert derive_operational_verdict(rows) == "SUPPORTED_OPERATIONAL_CHANNEL"
+
+    rows[0]["P1_coupled_responds_to_both_channels"] = False
+    rows[1]["P1_coupled_responds_to_both_channels"] = False
+    assert derive_operational_verdict(rows) == "FALSIFIED_OPERATIONAL_CHANNEL"
+
+
+def test_study_uses_fixed_seeds_and_honest_verdict_levels(
+    standard_study: dict,
+) -> None:
+    assert standard_study["seeds"] == [0, 1, 7, 42, 99]
+    assert standard_study["verdicts"]["original_specification"] == (
+        "FALSIFIED_SPECIFICATION"
+    )
+    assert standard_study["verdicts"]["categorical_adjunction"] == (
+        "NOT_ESTABLISHED"
+    )
+    assert standard_study["verdicts"]["P2_inhibition_debt"] == (
+        "NOT_TESTABLE_ON_THIS_SUBSTRATE"
+    )
+    assert len(standard_study["rows"]) == 5
+    assert all(0 <= count <= 5 for count in standard_study["pass_counts"].values())
+
+
+def _assert_result_equal(actual: Any, expected: Any, path: str = "root") -> None:
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict), path
+        assert set(actual) == set(expected), path
+        for key, value in expected.items():
+            _assert_result_equal(actual[key], value, f"{path}.{key}")
+    elif isinstance(expected, list):
+        assert isinstance(actual, list), path
+        assert len(actual) == len(expected), path
+        for index, value in enumerate(expected):
+            _assert_result_equal(actual[index], value, f"{path}[{index}]")
+    elif isinstance(expected, bool):
+        assert actual is expected, path
+    elif isinstance(expected, int):
+        assert actual == expected and isinstance(actual, int), path
+    elif isinstance(expected, float):
+        assert actual == pytest.approx(expected, rel=1e-12, abs=1e-15), path
+    else:
+        assert actual == expected, path
+
+
+def test_committed_results_match_fresh_execution(standard_study: dict) -> None:
+    expected = json.loads(RESULTS_PATH.read_text(encoding="utf-8"))
+    _assert_result_equal(standard_study, expected)

--- a/docs/ict/strates-as-adjunctions-prototype.md
+++ b/docs/ict/strates-as-adjunctions-prototype.md
@@ -66,7 +66,39 @@ Le substrat **ICT-12c `PregnanceAnimat`** (`MyIA.AI.Notebooks/IIT/ICT-Series/ict
 
 **Null adversarial** : un animat dont `f_aj` est un **foncteur sans adjoint** (par exemple une composition libre sans co-unit) ne modifie ni (P1) ni (P2) — c'est l'**absence d'adjonction** qui tue la prédiction.
 
-**Statut au 2026-08-30** : prédiction **PRÉDIT** (non exécutée). Le substrat `pregnance_animat.py` permet l'extension en quelques dizaines de lignes (canal `f_aj` à ajouter dans `ict/ajointion_saillance_pregnance.py`, à créer). Cycle suivant : exécution et verdict honnête `CONFIRMED` / `PARTIEL` / `FALSIFIÉ` / `INCONCLUSIF`.
+**Statut au 2026-08-30** : prédiction originale **EXÉCUTÉE ET FALSIFIÉE COMME SPÉCIFICATION** ; signature empirique plus faible du canal couplé **SUPPORTÉE**. Le protocole, les tests et les résultats reproductibles vivent dans `ict/adjonction_saillance_pregnance.py`, `ict/tests/test_adjonction_saillance_pregnance.py` et `ict/adjonction_saillance_pregnance_results.json`.
+
+### 4.1 Amendement pré-exécution — observables et frontières
+
+**Scellé avant toute exécution de la tranche.** La relecture du code révèle que les trois prédictions ci-dessus ne sont pas toutes mesurables telles quelles ; elles restent conservées comme hypothèses originales et ne sont pas réécrites après coup.
+
+1. Dans `pregnance_animat.py`, la variable nommée `salience` vaut déjà `pi + intr`. ICT-12c mesure donc surtout `p̂ ⟂ π`, pas la dissociation `s ⟂ π`. L'exécution réutilise la batterie dédiée `salience_valence_dissociation.py`, où `s` et `π` sont tirés indépendamment, puis ajoute un canal de décision bilinéaire `σ(κs + μπ + νsπ)`.
+2. Une fonction scalaire `f_aj(s, π)` n'est **pas** une adjonction catégorielle : aucune catégorie, paire de foncteurs, naturalité ou bijection de hom-sets n'est définie ici. Le traitement est nommé **canal couplé**, jamais preuve d'adjonction. Les nulls sont les canaux `s`-seul et `π`-seul.
+3. La dette d'inhibition d'ICT-30 vit dans `inhibited_action.py` / `inhibited_invention.py`, pas dans ce substrat. **P2 originale est non testable dans cette tranche** ; une entropie de décision est rapportée comme diagnostic exploratoire, sans être renommée « dette d'inhibition ».
+4. `corr(engagement, (s, π))` n'a pas de définition canonique. **P1 opérationnelle**, évaluée sur les graines `(0, 1, 7, 42, 99)`, exige dans au moins 4/5 graines : `|ρ(dec, π | s)| ≥ 0,40` et `|ρ(dec, s | π)| ≥ 0,40` pour le canal couplé, tandis que chaque null doit laisser son canal absent sous `0,20`. Aucune bande ne sera recalibrée après mesure.
+5. **P3 opérationnelle** compte les opérations scalaires ajoutées avant la sigmoïde commune : ratio `≤ 2` confirmé, `> 5` falsifié, intervalle `(2, 5]` explicitement **INCONCLUSIF**. L'ordre asymptotique reste `O(n)` dans tous les bras.
+
+Le verdict global distingue donc deux niveaux : (a) **conjecture originale telle que spécifiée**, falsifiée si elle exige une vraie adjonction ou l'annulation de la dette ICT-30 ; (b) **signature empirique du canal couplé**, supportée seulement si P1 passe sur au moins 4/5 graines. Ce découpage empêche un succès du jouet de valider rétroactivement la thèse catégorielle.
+
+### 4.2 Verdict post-exécution — cinq graines, seuils inchangés
+
+L'exécution sur les graines `(0, 1, 7, 42, 99)` donne :
+
+| Porte pré-enregistrée | Passage |
+|---|---:|
+| Canal couplé : les deux corrélations partielles ≥ 0,40 | **5/5** |
+| Null `s`-seul : canal `π` absent ≤ 0,20 et canal `s` présent ≥ 0,40 | **5/5** |
+| Null `π`-seul : canal `s` absent ≤ 0,20 et canal `π` présent ≥ 0,40 | **4/5** |
+| P3 : ratio d'opérations scalaires ≤ 2 | **5/5**, ratio = **2,0** |
+
+Les médianes du traitement sont `|ρ(dec, π | s)| = 0,9803` et `|ρ(dec, s | π)| = 0,7948`. La graine 99 du null `π`-seul dépasse le plafond de canal absent (`0,2704 > 0,20`) ; elle est conservée comme échec, sans exclusion ni recalibrage. L'ordre asymptotique demeure `O(n)`.
+
+- **Verdict de la spécification originale : `FALSIFIED_SPECIFICATION`.** Le traitement n'instancie aucune adjonction catégorielle et P2 n'est pas mesurable sur ce substrat.
+- **Verdict du canal empirique : `SUPPORTED_OPERATIONAL_CHANNEL`.** Le traitement répond aux deux canaux et les nulls mono-canal discriminent l'effet dans au moins 4/5 graines.
+- **P2 : `NOT_TESTABLE_ON_THIS_SUBSTRATE`.** L'entropie de décision archivée est exploratoire ; elle ne mesure pas la dette d'inhibition ICT-30.
+- **Adjonction catégorielle : `NOT_ESTABLISHED`.** Les résultats ne valident ni les hom-sets, ni la naturalité, ni la transposition Schreiber ↔ ICT.
+
+Le JSON committé est vérifié contre une ré-exécution fraîche par le test automatisé, avec égalité exacte des champs discrets et tolérance numérique `1e-12` sur les flottants.
 
 ## 5. Honnêteté grade C
 


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-po-2025:CoursIA — prev: DEEP/research-code #13459

## Résumé

- exécute la tranche bornée laissée par #13580 sur cinq graines fixes `(0, 1, 7, 42, 99)` ;
- ajoute un canal bilinéaire `σ(κs + μπ + νsπ)` et deux nulls adversariaux mono-canal ;
- conserve les seuils dans un amendement pré-exécution, puis archive le résultat reproductible et le vérifie contre une exécution fraîche ;
- sépare explicitement le verdict empirique du canal de toute claim d'adjonction catégorielle.

## Résultats

| Porte pré-enregistrée | Passage |
|---|---:|
| Traitement répond aux deux canaux | 5/5 |
| Null `s`-seul exclut `π` | 5/5 |
| Null `π`-seul exclut `s` | 4/5 |
| Coût scalaire ≤ 2× | 5/5, ratio 2,0 |

Médianes traitement : `|ρ(dec, π | s)| = 0,9803`, `|ρ(dec, s | π)| = 0,7948`.

- `original_specification`: `FALSIFIED_SPECIFICATION`
- `operational_channel`: `SUPPORTED_OPERATIONAL_CHANNEL`
- `P2_inhibition_debt`: `NOT_TESTABLE_ON_THIS_SUBSTRATE`
- `categorical_adjunction`: `NOT_ESTABLISHED`

La graine 99 du null `π`-seul échoue au plafond pré-enregistré (`0,2704 > 0,20`) et reste dans le résultat. Aucun seuil n'a été recalibré après mesure.

## Validation

```text
python -m pytest MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests -q
435 passed in 12.03s

python -m py_compile \
  MyIA.AI.Notebooks/IIT/ICT-Series/ict/adjonction_saillance_pregnance.py \
  MyIA.AI.Notebooks/IIT/ICT-Series/ict/tests/test_adjonction_saillance_pregnance.py
SUCCESS

git diff --check
SUCCESS
```

Le test du résultat committé compare les champs discrets exactement et les flottants à `1e-12` près. Aucun notebook n'est modifié.

## Limites

Une fonction scalaire bilinéaire n'est pas une adjonction catégorielle : cette tranche ne définit ni catégories, ni foncteurs adjoints, ni naturalité, ni bijection de hom-sets. La dette ICT-30 vit dans un autre substrat ; l'entropie archivée demeure un diagnostic exploratoire, pas une mesure d'inhibition. Le succès empirique ne valide pas la transposition Schreiber ↔ ICT.

See #8182
