### PR TITLE
feat(qc,#11601): enrichir QC-Py-34 densite 1398->1600 (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
@@ -1066,6 +1066,15 @@
    "id": "cell-da4e1451"
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Du tableau (exercice) au run réel\n",
+    "\n",
+    "L'exercice 3.1 vous propose de construire le tableau comparatif à la main. Un mot sur *pourquoi* le tableau vient après : les valeurs de Sharpe, Return et MaxDD que vous allez remplir **n'existent pas encore** — elles sont le *produit* des deux runs qui suivent. Remplir un tableau de résultats avant d'avoir mesuré, c'est construire une légende à l'envers. Les cellules suivantes produisent donc d'abord les métriques, puis la Partie 6 les réconciliera dans un tableau unique (écart de seed et fenêtre de marché compris).\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
@@ -1174,6 +1183,20 @@
     "print(f\"SAC termine: {sac_time/60:.1f} min, best_sharpe={best_sac_sharpe:.3f}\")"
    ],
    "id": "cell-fd080527"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Protocole de comparaison à protocole identique\n",
+    "\n",
+    "Les deux runs utilisent **exactement le même budget** : 100 K steps, warmup 1 000, évaluation walk-forward toutes les 25 K steps, même seed (42), même environnement et même fonction de scoring. C'est ce qui rend la comparaison possible : on compare la *méthode*, pas la durée de run ni la graine. Le seul degré de liberté est l'algorithme lui-même :\n",
+    "\n",
+    "- **SAC** est **off-policy** : il rejoue des transitions passées depuis son replay buffer, plus rapide en échantillons mais plus coûteux en mémoire.\n",
+    "- **A2C** est **on-policy** : il apprend sur les trajectoires fraîches, plus simple mais qui demande *plus de steps* pour la même maturation.\n",
+    "\n",
+    "Les 6 minutes d'A2C contre les 2,4 minutes de SAC ne sont donc pas un hasard : c'est le coût structurel de l'on-policy. Gardez ce ratio en tête quand vous lirez les courbes ; il est plus informatif que le Sharpe absolu, qui dépend de la fenêtre 2022-2024.\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -1394,6 +1417,21 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture de la figure d'entraînement\n",
+    "\n",
+    "Le graphique de gauche trace le **Sharpe de validation en walk-forward** pour les deux agents, encore lui, pas le reward d'entraînement. C'est un choix délibéré : le reward moyen grimpe toujours (l'agent apprend à maximiser son objectif), mais dire si l'objectif est *le bon* exige de le tester sur des données non vues. Trois courbes s'y lisent :\n",
+    "\n",
+    "- **SAC (vert)** démarre loin sous zéro, bondit après le warmup, puis se stabilise autour de +1.0 ;\n",
+    "- **A2C (orange)** culmine tôt (+1.348) puis redescend — la signature de l'on-policy sans régularisation ;\n",
+    "- **DQN (bleu, pointillé)** à 0.657 sert de référence horizontale : aucun des deux agents du notebook ne la franchit sur la fenêtre mesurée.\n",
+    "\n",
+    "Le graphique de droite montre le *régulateur* de chaque agent : la **température** de SAC qui décroît régulièrement (0.887 → 0.691) et l'**entropie** d'A2C qui s'effondre (1.056 → 0.935). C'est la traduction visuelle du mécanisme central : SAC *apprend à calmer son exploration* quand il a trouvé des actions rentables, A2C n'a aucun signal équivalent. Quand un graphique de training semble “lisse”, c'est que son régulateur travaille.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-4051469b",
    "metadata": {},
    "source": [
@@ -1448,10 +1486,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Evaluation finale et comparaison\n",
+    "### Méthodologie : distinguer « meilleur au cours du run » et « final »\n",
     "\n",
-    "Nous evaluons SAC et A2C sur le set de validation complet et comparons avec les\n",
-    "résultats de DQN (QC-Py-32) et PPO (QC-Py-33)."
+    "Un piège classique en RL est de confondre les deux états que ce notebook mesure séparément :\n",
+    "\n",
+    "1. **meilleur Sharpe intermédiaire** — le meilleur Sharpe de validation rencontré *pendant* l'entraînement (SAC : +1.049, A2C : +1.348). C'est un instantané optimiste : la politique continue d'évoluer après.\n",
+    "2. **Sharpe final** — celui de la politique *déployée*, refaite jouer sur le set de validation complet sans exploration. C'est le seul qui compte pour un trader.\n",
+    "\n",
+    "Le notebook évalue le final avec `evaluate_agent` (exploration désactivée, `explore=False`) et calcule le MaxDD sur la courbe de portefeuille. La distance entre 1. et 2. est le résultat pédagogique : un agent qui sur-performe en training puis régresse au déploiement n'a pas appris à trader, il a sur-ajusté le signal de reward. C'est exactement ce qui arrive à A2C ici.\n"
    ],
    "id": "cell-ed0b882d"
   },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-lean #13628

## Summary

Enrichissement **markdown-only** de QC-Py-34-RL-SAC-A2C-Trading (QuantConnect/Python) pour le round 2 de #11601 : densité pédagogique **1398 → 1600 chars/cellule code** (cible standard ≥1500). Prose 23767 → 27200, 17 cellules code, markdown 30 → 33.

4 blocs, chacun ancré **après** la cellule qu'il interprète (cell-interpretation-ordering), non dupliquants (les lectures de logs et du tableau final existaient déjà, cell. 34/42/44) :

| Bloc | Position | Contenu |
|---|---|---|
| Du tableau (exercice) au run réel | après l'exercice 3.1 | pourquoi le tableau comparatif vient après la mesure (inversion légende) |
| Protocole à protocole identique | entre le run SAC et le run A2C | budget partagé 100K/warmup 1K/eval 25K, off vs on-policy → coût 2,4 vs 6,0 min structurel |
| Lecture de la figure d'entraînement | après la visualisation | détaille le panneau **température/entropie** (0.887→0.691 SAC, 1.056→0.935 A2C) — absent des lectures de logs |
| Méthodologie : meilleur-inrun vs final | remplace la cellule "Evaluation finale" (164 ch.) | distance entre best_sharpe intermédiaire (+1.049/+1.348) et Sharpe final (−0.063/0.000) |

Valeurs citées = exclusivement celles des **outputs réels committés** (alpha 0.887→0.691, best_sharpe 1.049/1.348, 2,4 vs 6,0 min, Sharpe final −0.063/0.000, référence DQN 0.657) — aucun nombre fabriqué.

## Preuves de validation

- `pedagogy_density.py origin/main <nb>` : **1600/1500** (avant 1398) — `All judged notebooks meet the density floor`.
- `validate_pr_notebooks.py origin/main <nb>` : **1/1 PASS**, 17 cellules code [conda-torch].
- `detect_consecutive_code_cells.py` : **0 run ≥2** (le run 31–33, exo→SAC→A2C, est cassé par 2 markdown intermédiaires).
- `check_interp_positioning.py` : **0 misplaced interp cells** (garde d'ancrage strict c.1331p10488).
- `detect_markdown_rendering.py` : **0 violations** (et le hook auto-fix `yaml_block_open_no_close` passe).
- **Code byte-identique** : 17 sources code comparées avant/après dans le script d'insertion = true ; outputs et `execution_count` intacts — diff = markdown only (45 insertions, 3 deletions).
- **C.2 exception markdown-only** : aucune cellule code modifiée → pas de re-exécution requise. C.1 : stubs exercices intacts (`# TODO etudiant`).
- **C.3 scope** : ce commit ne touche que ce notebook (le seul modifié par cette PR).

## Note de scope (non bloquante, pré-existante)

`check_c2_compliance.py` signale 3 cellules (`execution_count` set, sans outputs) — **présentes à l'identique sur `origin/main` avant cette PR**, donc hors scope de cet enrichissement markdown-only (marqueurs de cellules sans sortie calculable, ex. exercices). Non touchées volontairement (D anti-régression). À traiter par une PR de re-exécution dédiée si souhaité.

## Acceptance #11601 — couverture

- Density ≥1500 : **1600** ✓
- Anchor check strict (0 FAIL) : **0 misplaced interp** ✓
- Markdown rendering 0 violations : **0** ✓
- H.3 + C.1 : **0 fail** ✓

`See #11601` (EPIC umbrella, tranche unitaire livrée : QC-Py-34). Round 2 reste ouvert pour les autres notebooks du pool 1200-2000.

## Test plan

- [x] `pedagogy_density.py` ≥1500 : 1600
- [x] `validate_pr_notebooks.py` : 1/1 PASS
- [x] sources code byte-identiques (garde script), outputs intacts
- [x] positions : chaque nouveau bloc APRÈS sa cellule (dump structure vérifié)
- [x] `detect_markdown_rendering` 0 + `detect_consecutive_code_cells` 0 + `check_interp_positioning` 0
