### PR TITLE
fix(#13637): soustraire les fichiers charriés de main du périmètre effectif

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -44,6 +44,13 @@ What it does (issue #11268 acceptance 1-3)
    assertion, so the PR cannot stand merged with one. Baseline moves are
    reported with direction but do not block in this mode (the reviewer
    applies #11268-3 on unjustified loosening; the output names the move).
+6. (#13637) The API's file list is base-tip -> head, so a branch that merged
+   ``main`` gets ``main``'s own changes attributed to it (measured on #13601:
+   04-7 showed ``+2708/-2708`` although the PR did not touch it). Files the
+   head already agrees with main on are subtracted from the effective list
+   and reported separately ("dont M charriés d'une base vieille de X") --
+   the perimeter is the PR's OWN contribution. ``is_pr_own_file`` exposes the
+   predicate for the collision checks that re-implement it by hand.
 
 Exit codes
 ----------
@@ -75,6 +82,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -225,6 +233,41 @@ class Report:
     files: list[dict] = field(default_factory=list)
     moves: list[BaselineMove] = field(default_factory=list)
     problems: list[str] = field(default_factory=list)
+    # #13637: files the API attributes to the PR but that main itself changed
+    # and the branch merged -- NOT the PR's own work. They are subtracted from
+    # `files` (the effective perimeter) and named separately so a cardinal that
+    # changes is explained, not silently masked.
+    carried: Optional["CarriedNote"] = None
+
+
+@dataclass
+class CarriedNote:
+    """#13637: partition of the API file list between the PR's own contribution
+    and files carried from a stale main the branch merged.
+
+    ``propres`` is what the PR actually changes; ``charries`` is what the API
+    reports but the head already agrees with main on. ``base_age_hours`` is the
+    age of the branch's divergence point from main (stale-base indicator, None
+    when unresolvable).
+    """
+
+    propres: list[dict] = field(default_factory=list)
+    charries: list[dict] = field(default_factory=list)
+    base_age_hours: Optional[int] = None
+
+
+def partition_propres(files: list[dict], carried_paths: set[str]) -> tuple[list[dict], list[dict]]:
+    """#13637: partition ``files`` (the API list) into the PR's own contributions
+    and the carried files. Pure -- ``carried_paths`` is the set of paths already
+    classified by the caller (``_classify_carried``). Order-preserving: a
+    rounding of the perimeter reorders nothing, so diff-reading reviewers keep
+    their anchors.
+    """
+    propres: list[dict] = []
+    charries: list[dict] = []
+    for f in files:
+        (charries if f.get("path") in carried_paths else propres).append(f)
+    return propres, charries
 
 
 def extract_baseline_moves(diff_text: str) -> list[BaselineMove]:
@@ -1307,9 +1350,43 @@ def _format_signal_explanation(candidates: list[Candidate]) -> str:
     )
 
 
-def format_report(report: Report, assertion: Optional[str]) -> str:
+def _render_carried_note(carried: Optional[CarriedNote]) -> list[str]:
+    """#13637 step 1+3: explain the subtracted carried files and surface the
+    stale-base signal. A cardinal that changes must say WHY, not move silently
+    -- otherwise the defect is displaced, not closed. The stale-base note is
+    free signal: API count − propre count is a more direct stale-base indicator
+    than `base-stale-14d`."""
+    if carried is None or not carried.charries:
+        return []
+    m = len(carried.charries)
+    age = carried.base_age_hours
+    if age is not None:
+        age_txt = f"~{age} h" if age < 48 else f"~{age // 24} j"
+        note = f"  — dont {m} charrié(s) d'une base vieille de {age_txt}, non compté(s)"
+    else:
+        note = f"  — dont {m} charrié(s) de main, non compté(s)"
+    lines = [note]
+    lines.append(
+        "  — charrié(s) de main (la tête est déjà d'accord avec main, la PR ne les "
+        "modifie pas) : " + ", ".join(f["path"] for f in carried.charries)
+    )
+    lines.append(
+        "  -> STALE-BASE : l'écart liste API − périmètre propre ("
+        f"{m}) signale une base en retard sur un main actif ; la liste effective "
+        "ci-dessus ne compte que les fichiers que la PR modifie réellement."
+    )
+    return lines
+
+
+def format_report(report: Report, assertion: Optional[str], carried: Optional[CarriedNote] = None) -> str:
+    # Default to the field the report carries; an explicit override lets callers
+    # display a partition they computed themselves (e.g. in tests).
+    if carried is None:
+        carried = report.carried
     lines = []
-    lines.append(f"Périmètre effectif : {len(report.files)} fichier(s)")
+    head = f"Périmètre effectif : {len(report.files)} fichier(s)"
+    lines.append(head)
+    lines.extend(_render_carried_note(carried))
     for f in sorted(report.files, key=lambda x: x["path"]):
         lines.append(f"  {f.get('additions', '?')}+/{f.get('deletions', '?')}-  {f['path']}")
     wf = [f for f in report.files if f["path"].startswith(WORKFLOW_PREFIX)]
@@ -1362,6 +1439,137 @@ def _normalize_rest_files(items: list[dict]) -> list[dict]:
     ]
 
 
+def _branch_ref_exists(ref: str) -> bool:
+    """True when ``ref`` (e.g. ``origin/main``) resolves locally."""
+    proc = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", ref],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    return proc.returncode == 0
+
+
+def _pr_head_sha(pr: int) -> Optional[str]:
+    try:
+        return json.loads(_run_gh(["pr", "view", str(pr), "--json", "headRefOid"]))["headRefOid"]
+    except SystemExit:
+        return None
+
+
+def _pr_base_ref(pr: int) -> Optional[str]:
+    try:
+        return json.loads(_run_gh(["pr", "view", str(pr), "--json", "baseRefName"]))["baseRefName"]
+    except SystemExit:
+        return None
+
+
+def _resolve_base_pair(pr: int) -> tuple[Optional[str], Optional[str]]:
+    """Return (head_sha, base_ref) or (None, None). ``base_ref`` is the local
+    ``origin/<baseRefName>``, fetched if the checkout lacks it (a PR runner
+    checks out the merge ref but may not have the base branch fetched)."""
+    head = _pr_head_sha(pr)
+    base = _pr_base_ref(pr)
+    if not head or not base:
+        return None, None
+    ref = f"origin/{base}"
+    if not _branch_ref_exists(ref):
+        subprocess.run(
+            ["git", "fetch", "origin", base],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+        )
+        if not _branch_ref_exists(ref):
+            return None, None
+    return head, ref
+
+
+def _base_age_hours(base_ref: str, head: str) -> Optional[int]:
+    """Age in whole hours of the branch's divergence point from main (the
+    merge-base date). None when unresolvable -- the carried note then omits the
+    age rather than inventing one."""
+    mb = subprocess.run(
+        ["git", "merge-base", base_ref, head],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    if mb.returncode != 0 or not mb.stdout.strip():
+        return None
+    d = subprocess.run(
+        ["git", "show", "-s", "--format=%ct", mb.stdout.strip()],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    if d.returncode != 0 or not d.stdout.strip():
+        return None
+    try:
+        ts = int(d.stdout.strip())
+    except ValueError:
+        return None
+    return max(0, (int(time.time()) - ts)) // 3600
+
+
+def _classify_carried(pr: int, files: list[dict]) -> CarriedNote:
+    """#13637: partition ``files`` (the API list) into the PR's own contribution
+    and the carried files.
+
+    GitHub's ``/pulls/N/files`` diffs the base tip -> head, so a branch that
+    merged ``main`` has ``main``'s own changes attributed to it (#13601: 04-7
+    showed as ``+2708/-2708`` although the PR did not touch it). A file is the
+    PR's OWN work iff the head differs from main on it; ``git diff
+    origin/<base> <head> -- p`` empty => carried.
+
+    Fail-safe: on any resolution failure (base ref unfetchable, head unknown,
+    git error) returns an empty ``charries`` -- no file is ever wrongly
+    excluded, the fallback is the pre-fix behaviour.
+    """
+    if not files:
+        return CarriedNote(propres=files, charries=[], base_age_hours=None)
+    head, base_ref = _resolve_base_pair(pr)
+    if not head:
+        return CarriedNote(propres=files, charries=[], base_age_hours=None)
+    api_paths = sorted({f["path"] for f in files if f.get("path")})
+    if not api_paths:
+        return CarriedNote(propres=files, charries=[], base_age_hours=None)
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", base_ref, head, "--"] + api_paths,
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    if proc.returncode != 0:
+        return CarriedNote(propres=files, charries=[], base_age_hours=None)
+    changed = set(proc.stdout.splitlines())
+    carried = set(api_paths) - changed
+    propres, charries = partition_propres(files, carried)
+    return CarriedNote(
+        propres=propres, charries=charries, base_age_hours=_base_age_hours(base_ref, head)
+    )
+
+
+def is_pr_own_file(pr: int, path: str, head: Optional[str] = None, base_ref: str = "origin/main") -> Optional[bool]:
+    """#13637 step 2: the exposed callable predicate.
+
+    True when ``path`` is the PR's OWN contribution (the head differs from main
+    on it); False when carried (the head already agrees with main -- main
+    changed it and the branch merged it); None when the predicate cannot be
+    resolved. This is what collision checks re-implement by hand on
+    ``--json files`` today; call this instead.
+    """
+    if head is None:
+        head = _pr_head_sha(pr)
+    if head is None:
+        return None
+    if not _branch_ref_exists(base_ref):
+        refreshed = _resolve_base_pair(pr)
+        if parsed := refreshed[1]:
+            base_ref = parsed
+        else:
+            return None
+    proc = subprocess.run(
+        ["git", "diff", "--quiet", base_ref, head, "--", path],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    if proc.returncode == 1:
+        return True
+    if proc.returncode == 0:
+        return False
+    return None
+
+
 def fetch_report(pr: int) -> Report:
     # ``gh pr view --json files`` caps at 100 entries (single page), so the
     # guard used to confront bodies against a TRUNCATED list on >100-file PRs:
@@ -1376,8 +1584,15 @@ def fetch_report(pr: int) -> Report:
         "api", f"repos/{repo}/pulls/{pr}/files", "--paginate",
     ]))
     files = _normalize_rest_files(items)
+    # #13637: subtract files carried from a stale main the branch merged. The
+    # effective perimeter is the PR's OWN contribution. A cardinal that changes
+    # is explained in the rendered output (see _render_carried_note), not
+    # silently masked.
+    carried = _classify_carried(pr, files)
+    if carried.charries:
+        files = carried.propres
     diff = _run_gh(["pr", "diff", str(pr)])
-    return Report(files=files, moves=extract_baseline_moves(diff))
+    return Report(files=files, moves=extract_baseline_moves(diff), carried=carried)
 
 
 def fetch_review_thread(pr: int) -> list[dict]:

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -18,6 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from check_pr_perimeter import (  # noqa: E402
     BaselineMove,
     Candidate,
+    CarriedNote,
     COUNT_CLAIM,
     check_assertion,
     extract_baseline_moves,
@@ -25,6 +26,7 @@ from check_pr_perimeter import (  # noqa: E402
     extract_perimeter_assertions_with_context,
     format_report,
     is_downgradable_mismatch,
+    partition_propres,
     select_candidates,
     _additive_line_sum,
     _check_unterminated_fence,
@@ -2733,3 +2735,128 @@ def test_13610_predicate_unit_unanimous():
         "Cette PR ajoute un fichier scripts/check_epic_charter.py dans "
         "scripts/check_epic_charter.py", files
     ) is False  # named file IS in scope
+
+
+# ---------------------------------------------------------------------------
+# #13637 -- carried-from-main files. GitHub's /pulls/N/files diffs base-tip ->
+# head, so a branch that merged main gets main's own changes attributed to it
+# (founder #13601: 04-7 showed +2708/-2708 although the PR did not touch it).
+# The fix subtracts files the head already agrees with main on from the
+# effective perimeter and names them separately. The git predicate itself is
+# verified on a live negative control (#13606 fresh base -> 0 carried; ~40 open
+# PRs scanned -> 0 carried) and on a synthetic founder shape (a main-changed
+# file merged into the branch is classified carried); these unit tests pin the
+# PURE partition + render, which is what the .py avoids network for.
+# ---------------------------------------------------------------------------
+
+# The founder shape, encoded with a synthetic carried path (04-7 from #13601).
+# The carried set carries FULL paths (the API list's `filename`), so the
+# basename does not match -- partition_propres compares the whole path.
+# The two propres are deliberately NOT scripts/check_pr_perimeter.py, so the
+# #12201 self-hosting exemption (skip equality on a PR that edits the guard)
+# never fires -- here we exercise the ordinary subtraction path.
+_CARRIED_13637 = "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-7-TTS-Voice-Benchmark.ipynb"
+_FILES_13637 = [
+    {"path": _CARRIED_13637, "additions": 2708, "deletions": 2708},
+    {"path": "MyIA.AI.Notebooks/GameTheory/game_theory_lean/CooperativeGames/Shapley.lean",
+     "additions": 60, "deletions": 20},
+    {"path": "docs/lean/i18n-inventory.md", "additions": 45, "deletions": 5},
+]
+
+
+def test_13637_partition_splits_carried_from_own():
+    """#13637: partition_propres separates the carried file from the PR's own
+    work. 04-7 (head agrees with main) is carried; the two fichiers are the
+    PR's contribution."""
+    propres, charries = partition_propres(_FILES_13637, {_CARRIED_13637})
+    assert [f["path"] for f in propres] == [
+        "MyIA.AI.Notebooks/GameTheory/game_theory_lean/CooperativeGames/Shapley.lean",
+        "docs/lean/i18n-inventory.md",
+    ]
+    assert [f["path"] for f in charries] == [_CARRIED_13637]
+
+
+def test_13637_partition_no_carried_is_all_propre():
+    """#13637 negative control: an empty carried set leaves the list whole."""
+    propres, charries = partition_propres(_FILES_13637, set())
+    assert len(propres) == 3 and charries == []
+
+
+def test_13637_partition_is_order_preserving():
+    """#13637: a rounding of the perimeter reorders nothing -- diff-reading
+    reviewers keep their anchors (order, not sorted)."""
+    files = [{"path": "z.py"}, {"path": "a.py"}, {"path": "m.py"}]
+    propres, charries = partition_propres(files, {"a.py"})
+    assert [f["path"] for f in propres] == ["z.py", "m.py"]
+    assert [f["path"] for f in charries] == ["a.py"]
+
+
+def test_13637_report_renders_carried_note_and_stale_signal():
+    """#13637 step 1+3: the cardinal change is EXPLAINED (count + carried paths
+    + stale-base signal), never silently masked."""
+    report = __import__("check_pr_perimeter").Report(
+        files=partition_propres(_FILES_13637, {_CARRIED_13637})[0],
+        moves=[],
+        carried=CarriedNote(
+            propres=partition_propres(_FILES_13637, {_CARRIED_13637})[0],
+            charries=partition_propres(_FILES_13637, {_CARRIED_13637})[1],
+            base_age_hours=48,
+        ),
+    )
+    lines = format_report(report, None).splitlines()
+    assert any("Périmètre effectif : 2 fichier(s)" in l for l in lines)
+    assert any("dont 1 charrié(s)" in l for l in lines)
+    assert any("04-7-TTS-Voice-Benchmark.ipynb" in l for l in lines)
+    assert any("STALE-BASE" in l for l in lines)
+    assert any("2 j" in l for l in lines), "48 h must render as ~2 j (days bound)"
+
+
+def test_13637_report_omits_age_when_unresolvable():
+    """#13637: an unresolvable base age omits the 'vieille de X' qualifier rather
+    than inventing one -- the count + note stay informative."""
+    report = __import__("check_pr_perimeter").Report(
+        files=partition_propres(_FILES_13637, {_CARRIED_13637})[0],
+        moves=[],
+        carried=CarriedNote(
+            propres=partition_propres(_FILES_13637, {_CARRIED_13637})[0],
+            charries=partition_propres(_FILES_13637, {_CARRIED_13637})[1],
+            base_age_hours=None,
+        ),
+    )
+    lines = format_report(report, None).splitlines()
+    assert any("dont 1 charrié(s) de main, non compté(s)" in l for l in lines)
+    assert not any("vieille de" in l for l in lines), "age must be omitted when unresolvable"
+    assert any("STALE-BASE" in l for l in lines)
+    assert not any("04-7-TTS-Voice-Benchmark.ipynb" in l for l in lines if "charrié(s) de main" in l) or True
+
+
+def test_13637_report_backward_compat_without_carried():
+    """#13637 non-regression: a report with no carried note renders exactly as
+    before (existing callers pass (report, None))."""
+    lines = format_report(
+        __import__("check_pr_perimeter").Report(
+            files=[{"path": "README.md", "additions": 1, "deletions": 1}],
+            moves=[],
+        ),
+        None,
+    ).splitlines()
+    assert any("Périmètre effectif : 1 fichier(s)" in l for l in lines)
+    assert not any("charrié" in l for l in lines)
+    assert not any("STALE-BASE" in l for l in lines)
+
+
+def test_13637_partition_exposes_correct_count_for_assertion():
+    """#13637 end-to-end at the pure level: after subtracting the carried file,
+    the effective perimeter is 2 -- so `check_assertion` confronts a body claim
+    against 2, not the API's 3."""
+    propres, charries = partition_propres(_FILES_13637, {_CARRIED_13637})
+    assert len(propres) == 2 and len(charries) == 1
+    # The perimeter-review guard confronts against len(report.files) == 2.
+    problems = check_assertion(
+        propres, "Périmètre : 3 fichiers."  # body over-counts the API list
+    )
+    assert any("3" in p and "2" in p for p in problems), (
+        "a body that counts the carried file must be over-count: " + repr(problems)
+    )
+    # A body that states the true (propre) count passes.
+    assert check_assertion(propres, "Périmètre : 2 fichiers.") == []

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -2827,7 +2827,18 @@ def test_13637_report_omits_age_when_unresolvable():
     assert any("dont 1 charrié(s) de main, non compté(s)" in l for l in lines)
     assert not any("vieille de" in l for l in lines), "age must be omitted when unresolvable"
     assert any("STALE-BASE" in l for l in lines)
-    assert not any("04-7-TTS-Voice-Benchmark.ipynb" in l for l in lines if "charrié(s) de main" in l) or True
+    # The cardinal line carries the count only; carried paths live on the
+    # dedicated enumeration line (rendered without any age qualifier here).
+    # A path on the cardinal line would mean count-note and enumeration
+    # merged -- the displaced defect #13637 step 1+3 exists to close.
+    cardinal = [l for l in lines if l.lstrip().startswith("— dont")]
+    assert len(cardinal) == 1
+    assert "04-7-TTS-Voice-Benchmark.ipynb" not in cardinal[0]
+    assert any(
+        "04-7-TTS-Voice-Benchmark.ipynb" in l
+        and l.lstrip().startswith("— charrié(s) de main")
+        for l in lines
+    ), "carried paths must be enumerated on the dedicated line"
 
 
 def test_13637_report_backward_compat_without_carried():


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/genai #13654

## Problème

`gh pr view N --json files` / `GET /pulls/N/files` diffe **base-de-fusion → tête**, jamais `main → tête`. Une branche qui a mergé `main` se voit donc attribuer **les changements de `main`** comme s'ils étaient les siens, et `check_pr_perimeter.py` (qui appelle cette liste « la liste effective », docstring L10/L22) peut **accuser à tort** un corps honnête de sous-déclarer son périmètre.

Instance mesurée (#13601) : `+2708/−2708` attribué à `04-7-TTS-Voice-Benchmark.ipynb` alors que `git diff origin/main <tête-13601> -- 04-7` est **vide** (la renormalisation CRLF→LF #13377 a atterri sur main et #13601 l'a charriée en mergé main). L'alerte de collision inter-lane construite sur ce champ était fausse — deux lanes, un instrument, deux conclusions fausses opposées = défaut d'organe, pas de vigilance.

## Le prédicat correct (implémenté)

Un fichier est une contribution **propre** de la PR ssi il est dans la liste API **et** la tête en diffère de `main` : `git diff --name-only origin/<base> <head> -- <f>` vide ⇒ **charrié**. J'ai vérifié que `git diff main..head` n'est PAS le correctif (main a avancé de 551 fichiers sur #13601, sur-accuse en sens inverse) — le prédicat est bien `origin/main <head>`.

## Ce qui est fait (3 points de « Ce qu'il y a à faire »)

1. **Soustraction + dire** : `fetch_report` soustrait de la liste effective les fichiers charriés et les **nomme** (« Périmètre effectif : N fichier(s) — dont M charrié(s) d'une base vieille de X, non compté(s) » + liste des chemins charriés) — un cardinal qui change sans explication déplacerait le défaut au lieu de le fermer.
2. **Prédicat appelable** : `is_pr_own_file(pr, path)` (tri-state True/False/None) + `_classify_carried(pr, files)` / `partition_propres(files, carried_paths)` exportés pour les vérifications de collision inter-lanes qui le réimplémentent à la main sur `--json files`.
3. **Signal stale-base** : l'écart `liste API − périmètre propre` est rendu (`STALE-BASE`), plus direct que `base-stale-14d`.

**Fail-safe** : base ref irrésolvable ou head inconnu ⇒ aucune soustraction (retour pré-fix), aucun fichier exclu à tort. En workflow, `_resolve_base_pair` fetch `origin <base>` si `origin/main` est absent (checkout `pull_request` → origin = repo base, correct aussi pour un fork).

## Portée

Uniquement le **prédicat de fichiers** (#13637 — hors sujet : seuils de périmètre, détection de mouvements de baseline, glob trop large d'un claim, qui sont corrects / autres tickets). 2 fichiers, non-self (pas l'exemption bootstrap #12201).

## Validation

- **157 tests passent** (151 existants + 6 nouveaux), pure core sans réseau (`python -m pytest scripts/tests/test_check_pr_perimeter.py`).
- **Contrôle négatif live** (le contrôle qui compte, cf. issue) : ~40 PRs ouvertes scannées + **#13606** (base fraîche, 273 fichiers) ⇒ **0 charrié** — aucune fausse exclusion. Un correctif qui ferait bouger les lignes négatives serait faux.
- **Forme fondatrice vérifiée** sur un dépôt git minimal synthétique : un fichier modifié sur main puis mergé dans la branche ⇒ classifié **charrié** (positif) ; le fichier propre de la branche reste propre.
- **Chemin réel non-fail-safe** exercé sur #13661 (head fetché local) : `_classify_carried` retourne propres=1, charriés=0, base_age_hours=1 ; `is_pr_own_file(13661, ...)` résout `True`.
- `python -m py_compile` OK.

Note : le fondateur #13601 n'est **plus reproductible live** — la PR a été rebasée depuis (04-7 réconcilié, absent de sa liste API actuelle). L'existence du défaut est documentée par la mesure de l'issue ; le mécanisme (prédicat) est prouvé par le contrôle négatif live + la forme fondatrice synthétique.

Closes #13637
