### PR TITLE
fix(workflows,#11698): race push-main dans qc-research-monitor — fetch+rebase+retry borne (portage Partie 2 #12834)

### DIFF
--- a/.github/workflows/qc-research-monitor.yml
+++ b/.github/workflows/qc-research-monitor.yml
@@ -52,5 +52,27 @@ jobs:
             echo "etat inchange, rien a committer"
           else
             git commit -m "chore(qc-research,#11698): etat semis monitor [skip ci]"
-            git push
+            # Race push-main (#12834 partie 2) : le checkout porte le SHA fige au
+            # DECLENCHEMENT schedule ; a ~65 merges/jour, une queue de 3h+ rend le
+            # push non-fast-forward (run 32690576863 : declenche 04:35, runner 08:08,
+            # push rejete -> etat JSON stale -> re-semis en double garanti au run
+            # suivant). Le commit est deterministe : rebase sans conflit legitime.
+            MAX_RETRIES=3
+            attempt=1
+            until git push 2>&1; do
+              if [ "$attempt" -ge "$MAX_RETRIES" ]; then
+                echo "push ECHOUE apres $MAX_RETRIES tentatives -- etat semis NON committe, le prochain run re-activera le dedup (#12834 partie 1)"
+                exit 1
+              fi
+              echo "push REJECTED tentative $attempt/$MAX_RETRIES -- main a avance pendant la queue, re-synchronisation"
+              sleep $((5 * attempt * attempt))   # 5 s puis 20 s (backoff quadratique, 3 essais)
+              attempt=$((attempt + 1))
+              git fetch origin main
+              if ! git rebase origin/main; then
+                echo "rebase CONFLICT -- abandon (commit deterministe : un conflit signale un etat corrompu)"
+                git rebase --abort
+                exit 1
+              fi
+            done
+            echo "push SUCCESS (tentative $attempt)"
           fi


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2023:CoursIA — prev: #13637 (PR #13667)

## Summary

Le cron hebdo `qc-research-monitor` (lundi 04:23 UTC, EPIC #11698) committe l'état de semis `docs/qc/qc-research-seeded.json` avec un **`git push` nu**. Le checkout d'un run `schedule:` porte le SHA figé **au déclenchement** : à ~65 merges/jour sur ce dépôt, une queue de runner de quelques heures rend le push **non-fast-forward** et il échoue — l'état JSON reste stale sur main.

**Mesuré (run 32690576863, replay du diagnostic #12834 Partie 2)** : déclenché 2026-08-24 04:35 UTC, runner obtenu 08:08 (3h33 de queue), step semis SUCCESS (issue #12748 créée), step commit FAILURE `! [rejected] main -> main (fetch first)`. Conséquence : l'ID #21195 n'a jamais atterri dans l'état → re-semis en double garanti au run suivant tant que le push n'est pas réparé (le dedup #12834 partie 1, mergé, contient le dommage mais l'état ne converge jamais).

**Portage** : le diff était préparé et documenté sur #11698 par po-2027, dont le token est sans scope `workflow` — branche jamais atterrie sur origin (vérifié : `git ls-remote` vide, 0 PR), main porte toujours le `git push` nu (vérifié firsthand). La reprise était explicitement offerte « à une lane outillée (po-2023/…) ». Ma lane l'a prise.

## Fix (1 fichier, +23/−1)

Remplace le `git push` nu par **fetch + rebase + retry borné** :
- 3 essais max, backoff quadratique (5 s puis 20 s effectifs) ;
- `git fetch origin main` + `git rebase origin/main` entre chaque essai — le commit d'état est déterministe, un conflit de rebase signale un état corrompu → `rebase --abort` + `exit 1` (échec visible, jamais silencieux) ;
- échec après 3 essais → `exit 1` avec message explicite (le dedup #12834 partie 1 reste la garde au run suivant).

**Delta vs diff po-2027 (documenté)** : le `git commit` est **hors** de la boucle de retry — après rebase, le commit est rejoué, il n'y a rien à re-committer (leur variante re-commitait à chaque essai ; fonctionnait par accident car bash continue sur échec de commit). Backoff commenté honnêtement : 3 essais ⇒ 5 s puis 20 s (le 45 s de la version d'origine était mort, jamais atteint).

## Validation

- `yaml.safe_load` OK (4 steps, noms intacts).
- `bash -n` sur le bloc `run` extrait : rc=0 (en LF — le refus initial était l'artefact CRLF du pipe Windows, pas du code).
- **Replay comportemental de la race en dépôt synthétique** (bare remote + clone stale + clone concurrent) : push rejeté `non-fast-forward` tentative 1/3 → fetch+rebase `Successfully rebased (1/1)` → `push SUCCESS (tentative 2)`, le clone tiers voit l'état `{"seeded":2}` au-dessus du main concurrent (`550312d..aa62fe2`). Le scénario exact du run 32690576863 converge.
- 0 notebook touché, catalogue byte-identique à main (aucun fichier catalogue dans le diff).

## Liens

See #11698 (EPIC — contribution à son mécanisme de Phase 3, pas de close).
Portage de la Partie 2 de #12834 (partie 1 mergée 2026-08-28).
Sous-issue technique du mécanisme : #12035 (close par #12036).