### PR TITLE
feat(qc,#7357): scaffold MyIA.Trading.Backtester net9.0 — tranche 1 port Option C

### DIFF
--- a/MyIA.CoursIA.sln
+++ b/MyIA.CoursIA.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.AI.Notebooks", "MyIA.A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.Trading.Converter", "MyIA.Trading.Converter\MyIA.Trading.Converter.csproj", "{F3B5C8D1-2E47-4A89-9B6E-3C8F2A1D7E45}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.Trading.Backtester", "MyIA.Trading.Backtester\MyIA.Trading.Backtester.csproj", "{95DE1847-B570-4AEF-9FD6-BA2D3B827C9D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyIA.Trading.Backtester.Tests", "MyIA.Trading.Backtester.Tests\MyIA.Trading.Backtester.Tests.csproj", "{DF112603-A4EE-4651-B9DD-19E9BA338320}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +31,14 @@ Global
 		{F3B5C8D1-2E47-4A89-9B6E-3C8F2A1D7E45}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F3B5C8D1-2E47-4A89-9B6E-3C8F2A1D7E45}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3B5C8D1-2E47-4A89-9B6E-3C8F2A1D7E45}.Release|Any CPU.Build.0 = Release|Any CPU
+{95DE1847-B570-4AEF-9FD6-BA2D3B827C9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{95DE1847-B570-4AEF-9FD6-BA2D3B827C9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{95DE1847-B570-4AEF-9FD6-BA2D3B827C9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{95DE1847-B570-4AEF-9FD6-BA2D3B827C9D}.Release|Any CPU.Build.0 = Release|Any CPU
+{DF112603-A4EE-4651-B9DD-19E9BA338320}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{DF112603-A4EE-4651-B9DD-19E9BA338320}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{DF112603-A4EE-4651-B9DD-19E9BA338320}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{DF112603-A4EE-4651-B9DD-19E9BA338320}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MyIA.Trading.Backtester.Tests/AutoMlInferenceTests.cs
+++ b/MyIA.Trading.Backtester.Tests/AutoMlInferenceTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using Microsoft.ML;
+using Microsoft.ML.AutoML;
+using Xunit;
+
+namespace MyIA.Trading.Backtester.Tests
+{
+    /// <summary>
+    /// Replique du mini-test d'integration du cadrage E2 (docs/reference/backtester-e2-cadrage.md, 2.2) :
+    /// l'usage AutoML reel du port (InferColumns) + entrainement lineaire (SdcaMaximumEntropy)
+    /// sur un CSV inline separable, assert MicroAccuracy > 0.9.
+    ///
+    /// Ce test fige la paire preview Microsoft.ML.AutoML 0.24.0-preview.26160.2 +
+    /// Microsoft.ML 6.0.0-preview.26160.2 : la substitution du fork (AutoML 0.20.1, 2022) n'est
+    /// pas un re-packaging — l'API 0.20.x ColumnInferenceResults.TextLoaderEventArgs a disparu
+    /// en 0.24, remplacee par TextLoaderOptions (CS1061 mesure au compilateur au geste 2).
+    /// </summary>
+    public sealed class AutoMlInferenceTests : IDisposable
+    {
+        private readonly string _csvPath = Path.Combine(Path.GetTempPath(), $"backtester-s22-{Guid.NewGuid():N}.csv");
+
+        [Fact]
+        public void InferColumns_And_TrainSdcaMaximumEntropy_ReachesMicroAccuracyAbove09()
+        {
+            var mlContext = new MLContext(seed: 0);
+            File.WriteAllText(_csvPath, BuildSeparableThreeClassCsv());
+
+            // API 0.24-preview, verifiee par reflexion runtime + sonde empirique :
+            // - ColumnInferenceApi (extension MLContext, 9 args avec hasHeader) est internal -> inutilisable.
+            // - AutoCatalog.InferColumns(path, labelColumnName, separatorChar) DETECTE le header
+            //   automatiquement (parametre hasHeader supprime de la signature 0.20.x) : sur un CSV
+            //   "Label,F1,F2" avec header, l'inference rend Label + Features(F1,F2) groupes.
+            var inference = mlContext.Auto().InferColumns(
+                _csvPath,
+                labelColumnName: "Label",
+                separatorChar: ',');
+            Assert.NotNull(inference.TextLoaderOptions);
+
+            var textLoader = mlContext.Data.CreateTextLoader(inference.TextLoaderOptions);
+            var dataView = textLoader.Load(_csvPath);
+            var split = mlContext.Data.TrainTestSplit(dataView, testFraction: 0.25, seed: 0);
+
+            var pipeline = mlContext.Transforms.Conversion.MapValueToKey("Label")
+                .Append(mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy())
+                .Append(mlContext.Transforms.Conversion.MapKeyToValue("PredictedLabel"));
+            var model = pipeline.Fit(split.TrainSet);
+
+            var predictions = model.Transform(split.TestSet);
+            var metrics = mlContext.MulticlassClassification.Evaluate(predictions);
+
+            Assert.True(metrics.MicroAccuracy > 0.9,
+                $"MicroAccuracy={metrics.MicroAccuracy:0.000} attendu > 0.9 (donnees separables lineairement)");
+        }
+
+        private static string BuildSeparableThreeClassCsv()
+        {
+            var lines = new System.Collections.Generic.List<string> { "Label,F1,F2" };
+            for (int i = 0; i < 8; i++)
+            {
+                lines.Add($"0,0.{i % 10}1,0.{(i * 3) % 10}2");
+                lines.Add($"1,5.{i % 10}1,5.{(i * 3) % 10}2");
+                lines.Add($"2,10.{i % 10}1,10.{(i * 3) % 10}2");
+            }
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(_csvPath))
+            {
+                File.Delete(_csvPath);
+            }
+        }
+    }
+}

--- a/MyIA.Trading.Backtester.Tests/MyIA.Trading.Backtester.Tests.csproj
+++ b/MyIA.Trading.Backtester.Tests/MyIA.Trading.Backtester.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Paire AutoML figee (docs/reference/backtester-e2-cadrage.md 2.2) : seule combinaison
+         Restore+build+exec verifiee bout-en-bout sur net9.0 ; pas de build stable apparie
+         recent (NU1102 mesure). Le pin ML explicite garantit la paire malgre la resolution
+         transitoire. -->
+    <PackageReference Include="Microsoft.ML.AutoML" Version="0.24.0-preview.26160.2" />
+    <PackageReference Include="Microsoft.ML" Version="6.0.0-preview.26160.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyIA.Trading.Backtester\MyIA.Trading.Backtester.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MyIA.Trading.Backtester/Extensions.cs
+++ b/MyIA.Trading.Backtester/Extensions.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace MyIA.Trading.Backtester
+{
+    public static class Extensions
+
+    {
+        public static int BinarySearch<T>(this IList<T> list, int index, int length, T value, IComparer<T> comparer)
+        {
+            if (list == null)
+                throw new ArgumentNullException("list");
+            else if (index < 0 || length < 0)
+                throw new ArgumentOutOfRangeException(
+                    (index < 0) ? "index" : "length"
+                );
+            else if (list.Count - index < length)
+                throw new ArgumentException();
+
+            int lower = index;
+            int upper = (index + length) - 1;
+
+            while (lower <= upper)
+            {
+                int adjustedIndex = lower + ((upper - lower) >> 1);
+                int comparison = comparer.Compare(list[adjustedIndex], value);
+                if (comparison == 0)
+                    return adjustedIndex;
+                else if (comparison < 0)
+                    lower = adjustedIndex + 1;
+                else
+                    upper = adjustedIndex - 1;
+            }
+
+            return ~lower;
+        }
+
+        public static int BinarySearch<T>(this IList<T> list, T value, IComparer<T> comparer)
+        {
+            return BinarySearch(list, 0, list.Count, value, comparer);
+        }
+
+        public static int BinarySearch<T>(this IList<T> list, T value) where T : IComparable<T>
+        {
+            return BinarySearch(list, value, Comparer<T>.Default);
+        }
+
+        public static T DeepClone<T>(this T value)
+        {
+            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(value));
+        }
+
+    }
+}

--- a/MyIA.Trading.Backtester/MyIA.Trading.Backtester.csproj
+++ b/MyIA.Trading.Backtester/MyIA.Trading.Backtester.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Port MyIA.Trading.Backtester (fork MyIntelligenceAgency/Lean, branche MyIABacktesting_integration)
+    vers CoursIA net9.0 — EPIC #7357 geste 3, tranche 1 (scaffold).
+    Substitutions mesurees (docs/reference/backtester-e2-cadrage.md, geste 2) :
+    - HintPath DLL Aricie/DNN : abandonnees, socle = MyIA.AI.Shared
+    - Accord.MachineLearning 3.8.2-alpha : remplace par ML.NET (mapping tranche suivante)
+    - Microsoft.ML.AutoML 0.20.1 : paire preview 0.24.0-preview.26160.2 (seule paire teste
+      bout-en-bout, cadrage 2.2), figee par le test d'integration MyIA.Trading.Backtester.Tests
+    Les PackageReferences Flee/Markdig seront cablees par les tranches portant les fichiers
+    qui les utilisent (pas de dependance inutilisee au scaffold).
+  -->
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyIA.AI.Shared\MyIA.AI.Shared.csproj" />
+    <ProjectReference Include="..\MyIA.Trading.Converter\MyIA.Trading.Converter.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MyIA.Trading.Backtester/TradingSample.cs
+++ b/MyIA.Trading.Backtester/TradingSample.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using MyIA.Trading.Converter;
+
+namespace MyIA.Trading.Backtester
+{
+
+    public class TradingSample
+    {
+        public virtual Trade TargetTrade { get; set; }
+
+        public virtual List<Trade> Inputs { get; set; } = new List<Trade>();
+
+        public virtual Dictionary<TimeSpan, Trade> Outputs { get; set; } = new Dictionary<TimeSpan, Trade>();
+
+        public virtual Dictionary<decimal, Trade> Peaks { get; set; } = new Dictionary<decimal, Trade>();
+
+        public virtual Dictionary<decimal, Trade> ThresholdPeaks { get; set; } = new Dictionary<decimal, Trade>();
+
+
+    }
+}

--- a/MyIA.Trading.Backtester/TradingTrainTestData.cs
+++ b/MyIA.Trading.Backtester/TradingTrainTestData.cs
@@ -1,0 +1,26 @@
+
+using System.Collections.Generic;
+
+namespace MyIA.Trading.Backtester
+{
+    public class TradingTrainTestData
+    {
+
+
+        public TradingTrainTestData() : this(0,0)
+        {
+
+        }
+
+        public TradingTrainTestData(int trainingNb, int testNb)
+        {
+            Training = new List<TradingTrainingSample>(trainingNb);
+            Test = new List<TradingTrainingSample>(testNb);
+        }
+
+        public virtual List<TradingTrainingSample> Training { get; set; }
+
+        public virtual List<TradingTrainingSample> Test { get; set; }
+
+    }
+}

--- a/MyIA.Trading.Backtester/TradingTrainingSample.cs
+++ b/MyIA.Trading.Backtester/TradingTrainingSample.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MyIA.Trading.Backtester
+{
+    public class TradingTrainingSample
+    {
+        public static readonly int NbClasses = 3;
+        public static int NbInputs = 32;
+
+
+        public List<double> Inputs { get; set; }
+
+
+        //public float[] InputVector => Inputs.Select(Convert.ToSingle).ToArray();
+
+
+        public double Output { get; set; }
+
+
+        //public float OutputLabel => Convert.ToSingle(Output);
+
+
+        public TradingSample Sample { get; set; }
+
+
+
+    }
+
+    public static class TradingTrainingSampleExtensions
+    {
+        public static double[][] GetInputMatrix(this IEnumerable<TradingTrainingSample> samples)
+        {
+            //return Inputs.Select(objlist => objlist.ToArray()).ToArray();
+            return samples.Select(r => r.Inputs).Select(objlist => objlist.ToArray()).ToArray();
+        }
+
+        public static double[] GetOutputValues(this IEnumerable<TradingTrainingSample> samples)
+        {
+            //return Outputs.ToArray();
+            return samples.Select(r => r.Output).ToArray();
+        }
+
+        public static int[] GetOutputClasses(this IEnumerable<TradingTrainingSample> samples)
+        {
+            //return Outputs.Select(obFloat => (int)obFloat).ToArray();
+            return samples.Select(r => r.Output).Select(obFloat => (int)obFloat).ToArray();
+        }
+    }
+}


### PR DESCRIPTION
Grain: DEEP/qc — lane myia-po-2024:CoursIA — prev: MED/notebook-python #13666

## Summary

Tranche 1 du port `MyIA.Trading.Backtester` (EPIC #7357 geste 3, Option C) : le scaffold net9.0 atterrit sur main, avec la paire AutoML mesurée **figée par un test d'intégration vert**.

- **`MyIA.Trading.Backtester/`** : csproj net9.0 **sans aucun HintPath DLL** (les 6 HintPaths `external/PKP/` du fork sont abandonnés) — ProjectReferences `MyIA.AI.Shared` (socle remplaçant Aricie.Core/Aricie.DNN/DotNetNuke) + `MyIA.Trading.Converter` (E1 livré).
- **4 fichiers du fork portés verbatim** (usings inutilisés Aricie/Apex/Tensorflow retirés — les seuls blocants à la compilation) : `TradingSample`, `TradingTrainTestData`, `TradingTrainingSample` (+ `TradingTrainingSampleExtensions`), `Extensions`.
- **`MyIA.Trading.Backtester.Tests/`** : réplique du mini-test d'intégration du cadrage §2.2 ([backtester-e2-cadrage.md](docs/reference/backtester-e2-cadrage.md)) — `InferColumns` (l'usage AutoML réel du port) + `SdcaMaximumEntropy` sur CSV inline séparable 3 classes, assert `MicroAccuracy > 0.9`. Ce test **fige la paire preview** `Microsoft.ML.AutoML 0.24.0-preview.26160.2` + `Microsoft.ML 6.0.0-preview.26160.2` (seule paire Restore+build+exec vérifiée bout-en-bout, NU1102 mesuré au-delà).

**Cartographie API 0.20 → 0.24 mesurée firsthand** (réflexion runtime sur la DLL restaurée + sonde empirique sur CSV avec header), pour la tranche 4 :

| API fork 0.20.x | État 0.24.0-preview |
|---|---|
| `inferenceResults.TextLoaderEventArgs` | **supprimée** → `TextLoaderOptions` |
| `mlContext.Auto().InferColumns(path, labelColumn)` | **route praticable** : `AutoCatalog.InferColumns(path, labelColumnName, separatorChar?, …)` — **`hasHeader` supprimé car le header est détecté automatiquement** (vérifié : CSV `Label,F1,F2` avec header → inférence `Label` + `Features` groupées) |
| extension `ColumnInferenceApi` (hasHeader explicite) | **internal** → inutilisable depuis un consumer |
- Les deux projets sont ajoutés à `MyIA.CoursIA.sln`.

## Écarts assumés vs geste 2 (motivés)

- **Flee/Markdig non câblées au scaffold** : aucun des 4 fichiers portés ne les utilise. Elles seront posées par les tranches portant les fichiers concernés — pas de dépendance inutilisée au landing zone.
- **Pas de `OutputType Exe`** : le `Program.cs` du fork arrive en tranche ultérieure ; la zone d'atterrissage est une bibliothèque.

## Tranches suivantes (non livrées ici)

2. `TradingModelConfig` + `ITradingModel` (keystone du port, bloqué sur `TradingTrainingDataConfig` 15 Ko à porter avec)
3. `BackTesting.cs` (755 l.) — les erreurs de compilation font la carte des usages Aricie/Accord
4. Mapping Accord→ML.NET (gap kernel SVM : SharpLearning/LibSVM-sharp à trancher) + `TradeHelper` (couplé `SerializationConfig` Aricie)

## Preuves de validation

- `dotnet test MyIA.Trading.Backtester.Tests/MyIA.Trading.Backtester.Tests.csproj` : **Réussite ! échec : 0, réussite : 1, total : 1** (PIPESTATUS 0, durée 45 s) — `InferColumns_And_TrainSdcaMaximumEntropy_ReachesMicroAccuracyAbove09` PASS sur la paire preview pinnée (CSV inline 24 lignes, 3 classes séparables, assert `MicroAccuracy > 0.9`).
- Build SUCCESS des 2 projets net9.0 ; les warnings CS8632/CS0219 visibles au log appartiennent à `MyIA.Trading.Converter` (pré-existants sur main, projet non touché par cette PR).

## Test plan

- [ ] `dotnet build` des 2 projets SUCCESS (net9.0, ProjectReferences Shared+Converter)
- [ ] `dotnet test` PASS : `InferColumns_And_TrainSdcaMaximumEntropy_ReachesMicroAccuracyAbove09`
- [ ] diff limité à 8 fichiers : 2 csproj, 4 .cs portés, 1 test, 1 sln
- [ ] aucun autre symbole du dépôt ne référencent ces nouveaux chemins (projet neuf)

See #7357 (tranche 1/N — l'EPIC reste ouverte)
