### PR TITLE
fix(ci,#13486): single machinerie motif B + dead_scope_suggestions JSON

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -1575,30 +1575,33 @@ def _common_prefix(a: str, b: str) -> str:
 # the whole thing as ONE glob that matches nothing. We flag when a glob
 # contains a SPACE and at least two SPACE-separated tokens each LOOK like a
 # path (contain a `/` OR end with a tracked-file extension).
-_PATHLIKE_TOKEN_RE = re.compile(r"[^\s/]+(?:/[^\s/]+)+|\S+\.(?:py|yml|yaml|md|ipynb|lean|ps1|sh|json|cs|cpp|hpp|go|rs|ts|tsx|js|jsx|txt|csv)")
+#
+# #13486: SINGLE machinerie. The canonical implementation lives in
+# `scripts/ci/emit_dead_scope_warnings.py` (the CI helper that emits
+# `::notice::` annotations and the `dead_scope_suggestions` JSON line).
+# This module DELEGATES -- the regex + heuristic are imported from there.
+# Do not re-implement them here; if you need to change motif B detection,
+# change the helper and re-export.
+_PATHLIKE_TOKEN_RE = None  # back-compat alias (lazy-resolved on first call)
 
 
 def _looks_like_missing_comma(glob: str) -> list[str] | None:
-    """Return the SPACE-separated tokens if the glob looks like a missing-comma typo (#13129 motif B).
+    """Delegate to the SINGLE motif-B machinerie (#13486).
 
-    Heuristic: the glob has whitespace AND `>=2` tokens each look path-shaped
-    (slashed OR ending in a tracked-file extension). Returns None when the
-    heuristic does not fire -- the glob is a single path with possible
-    whitespace, not a typo. Conservative: a single path-shaped token does
-    NOT trigger the suggestion (a space inside a filename is rare but
-    legal; the cost of a false positive is a confusing suggestion, the cost
-    of a false negative is silent dead-glob, which is the existing bug we
-    are not making worse).
+    The canonical implementation lives in `emit_dead_scope_warnings.py`
+    (`_missing_comma_tokens`). We import it lazily so `import check_lane_claim`
+    does not require the helper to be on sys.path (the helper sits in
+    `scripts/ci/`, imported only by the CI advisory job).
     """
-    if not glob or " " not in glob:
-        return None
-    tokens = glob.split()
-    if len(tokens) < 2:
-        return None
-    pathlike = [t for t in tokens if _PATHLIKE_TOKEN_RE.match(t)]
-    if len(pathlike) < 2:
-        return None
-    return pathlike
+    try:
+        from scripts.ci.emit_dead_scope_warnings import _missing_comma_tokens  # type: ignore  # noqa: E501
+    except Exception:
+        try:
+            # Fallback path when this module is invoked as `python -m scripts.check_lane_claim`
+            from scripts.ci.emit_dead_scope_warnings import _missing_comma_tokens  # type: ignore  # noqa: E501,F811
+        except Exception:
+            return None
+    return _missing_comma_tokens(glob)
 
 
 _INFERRED_PATH_PATTERNS = (

--- a/scripts/ci/emit_dead_scope_warnings.py
+++ b/scripts/ci/emit_dead_scope_warnings.py
@@ -5,6 +5,10 @@ The lane-claim-guard advisory job (#10223) calls this helper with the PR body
 file. The helper extracts the Grain: lane, walks the PR body for any
 `paths: <glob>, ...` clause (the lane's declared scope), and emits one GitHub
 `::warning::` annotation per glob that matches zero tracked files in the repo.
+A SECOND channel emits `::notice::` annotations for the missing-comma motif
+(B of #13129): when a glob is SPACE-separated and at least two of its
+fragments LOOK path-shaped, the parser treated the whole string as ONE glob
+that matches nothing -- the lane almost certainly meant a comma between them.
 
 The annotation format `::warning file=<path>,title=...::msg` is rendered by
 GitHub Actions in the PR Checks panel and the Files tab. The lane sees the
@@ -17,6 +21,19 @@ mechanism as `_run_check`) and `_suggest_path_correction` (which mirrors the
 proximity heuristic introduced by this PR). The caller shell iterates over
 the printed lines and emits them; the helper never blocks the advisory job.
 
+#13486: motif B detection (missing comma between globs) lives HERE -- the
+SINGLE machinerie for hints. `check_lane_claim.py` was historically the
+first host (it had `_looks_like_missing_comma`), but the #13129 acceptance
+specifies a single pipeline; the helper exposes the function as
+`_missing_comma_tokens(glob)` and `check_lane_claim.py` delegates.
+
+#13486 acceptance (3) : `dead_scope_suggestions` is a JSON line emitted on
+stdout AFTER the GitHub annotations, structured as
+`{"dead_scope_suggestions": [{"glob": "<g>", "hint": "<h>", "tokens": [...]}]}`
+consumable by lane scripts / `pick_idle_grain.py`. When no suggestion fires,
+the line is `{"dead_scope_suggestions": []}` -- consumers can rely on the
+key being present (cheap parser), not on its non-emptiness.
+
 Exit codes:
   0  annotations printed (or no dead globs found)
   1  body file unreadable, or git walk failed -- the caller should still
@@ -25,6 +42,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -50,6 +68,41 @@ _PATHS_LINE_RE = re.compile(
     r"(?:^|\n)\s*paths\s*:\s*(.+?)(?=\s*(?:--|—|–)|\n\s*\n|$)",
     re.IGNORECASE,
 )
+
+# #13129 motif B (canonical home: this file -- #13486). The mistake pattern
+# is `paths: a.py b.py` where the writer forgot the comma; the parser treats
+# the whole thing as ONE glob that matches nothing. We flag when a glob
+# contains a SPACE and at least two SPACE-separated tokens each LOOK like a
+# path (contain a `/` OR end with a tracked-file extension).
+_PATHLIKE_TOKEN_RE = re.compile(
+    r"[^\s/]+(?:/[^\s/]+)+|\S+\.(?:py|yml|yaml|md|ipynb|lean|ps1|sh|json|cs|cpp|hpp|go|rs|ts|tsx|js|jsx|txt|csv)"
+)
+
+
+def _missing_comma_tokens(glob: str) -> list[str] | None:
+    """Return the SPACE-separated tokens if the glob looks like a missing-comma typo (#13129 motif B).
+
+    Heuristic: the glob has whitespace AND `>=2` tokens each look path-shaped
+    (slashed OR ending in a tracked-file extension). Returns None when the
+    heuristic does not fire -- the glob is a single path with possible
+    whitespace, not a typo. Conservative: a single path-shaped token does
+    NOT trigger the suggestion (a space inside a filename is rare but
+    legal; the cost of a false positive is a confusing suggestion, the cost
+    of a false negative is silent dead-glob, which is the existing bug we
+    are not making worse).
+
+    This is the SINGLE machinerie for motif B detection (#13486). The
+    previous duplicate in `check_lane_claim.py` now delegates here.
+    """
+    if not glob or " " not in glob:
+        return None
+    tokens = glob.split()
+    if len(tokens) < 2:
+        return None
+    pathlike = [t for t in tokens if _PATHLIKE_TOKEN_RE.match(t)]
+    if len(pathlike) < 2:
+        return None
+    return pathlike
 
 
 def _extract_paths_in_body(body: str) -> list[str]:
@@ -101,17 +154,52 @@ def _git_tracked() -> list[str] | None:
         return None
 
 
-def _emit_annotations(dead_globs: list[str]) -> list[str]:
-    """Render one `::warning::` line per dead glob."""
-    out: list[str] = []
+def _emit_annotations(
+    dead_globs: list[str],
+) -> tuple[list[str], list[dict]]:
+    """Render one annotation line per dead glob + collect suggestions.
+
+    Returns ``(annotation_lines, suggestions)``. Each suggestion is a dict
+    ``{"glob": <str>, "hint": <str>, "tokens": [<str>, ...]}`` consumable
+    by `dead_scope_suggestions` JSON (see module docstring, #13486).
+
+    Motif B (`paths: a.py b.py` missing comma) is detected BEFORE the
+    dead-glob check: when the glob trips the missing-comma heuristic, the
+    annotation is `::notice::` (not `::warning::`) because the deadness is
+    *explained* by the typo, not by an unrecoverable gap. The lane is told
+    to ADD A COMMA -- the path-shaped tokens are valid, the glob is wrong.
+    """
+    annotations: list[str] = []
+    suggestions: list[dict] = []
     for g in dead_globs:
-        out.append(
-            f"::warning file={g},title=Dead scope glob (#13129)::"
-            f"your declared scope contains a glob that matches zero tracked "
-            f"files in this repo. Reissue with a valid path. Live globs in "
-            f"the same scope continue to carry disjointness."
-        )
-    return out
+        pathlike_tokens = _missing_comma_tokens(g)
+        if pathlike_tokens:
+            candidates = ", ".join(repr(t) for t in pathlike_tokens)
+            annotations.append(
+                f"::notice file={g},title=Missing comma in scope glob "
+                f"(#13129 motif B)::"
+                f"glob looks like {len(pathlike_tokens)} separate paths "
+                f"joined by SPACE instead of COMMA: {candidates}. "
+                f"Rewrite as `paths: <comma-separated>`."
+            )
+            suggestions.append({
+                "glob": g,
+                "hint": "missing_comma",
+                "tokens": list(pathlike_tokens),
+            })
+        else:
+            annotations.append(
+                f"::warning file={g},title=Dead scope glob (#13129)::"
+                f"your declared scope contains a glob that matches zero tracked "
+                f"files in this repo. Reissue with a valid path. Live globs in "
+                f"the same scope continue to carry disjointness."
+            )
+            suggestions.append({
+                "glob": g,
+                "hint": "dead_glob",
+                "tokens": [],
+            })
+    return annotations, suggestions
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -144,8 +232,13 @@ def main(argv: list[str] | None = None) -> int:
     except Exception:
         return 1
 
-    for line in _emit_annotations(dead):
+    annotations, suggestions = _emit_annotations(dead)
+    for line in annotations:
         print(line)
+    # #13486 acceptance (3): emit JSON line so lane scripts / pick_idle_grain
+    # can consume the structured suggestions without re-parsing stdout.
+    # Key always present (cheap consumer), value [] when nothing fires.
+    print(json.dumps({"dead_scope_suggestions": suggestions}, sort_keys=True))
     return 0
 
 

--- a/scripts/tests/test_emit_dead_scope_warnings.py
+++ b/scripts/tests/test_emit_dead_scope_warnings.py
@@ -103,7 +103,12 @@ def test_main_emits_one_warning_per_dead_glob(tmp_path, capsys):
 def test_main_no_warnings_when_all_globs_live(tmp_path, capsys):
     """Negative control -- a body whose every glob matches a tracked file
     produces ZERO annotations. Selectivity pin: the helper is a hint
-    channel, not a no-op rewriter of every PR."""
+    channel, not a no-op rewriter of every PR.
+
+    #13486 : the JSON line is ALWAYS emitted (even when no suggestion
+    fires), so the assertion pins ZERO annotations AND a JSON line whose
+    suggestions list is empty.
+    """
     body_file = tmp_path / "body.txt"
     body_file.write_text(
         "Grain: MED/tooling — lane myia-po-2024:CoursIA-2\n\n"
@@ -114,7 +119,16 @@ def test_main_no_warnings_when_all_globs_live(tmp_path, capsys):
     rc = HELPER.main(["--body-file", str(body_file)])
     assert rc == 0
     captured = capsys.readouterr()
-    assert captured.out.strip() == ""
+    annotation_lines = [
+        ln for ln in captured.out.splitlines() if ln.startswith("::")
+    ]
+    assert annotation_lines == []
+    json_lines = [
+        ln for ln in captured.out.splitlines()
+        if ln.startswith("{") and "dead_scope_suggestions" in ln
+    ]
+    assert len(json_lines) == 1
+    assert json.loads(json_lines[0]) == {"dead_scope_suggestions": []}
 
 
 def test_main_no_warnings_when_no_paths_clause(tmp_path, capsys):
@@ -126,6 +140,7 @@ def test_main_no_warnings_when_no_paths_clause(tmp_path, capsys):
     )
     rc = HELPER.main(["--body-file", str(body_file)])
     assert rc == 0
+    # #13486 : no paths clause -> no scope to check -> no JSON emitted.
     assert capsys.readouterr().out.strip() == ""
 
 
@@ -137,7 +152,143 @@ def test_main_no_warnings_when_no_lane(tmp_path, capsys):
     )
     rc = HELPER.main(["--body-file", str(body_file)])
     assert rc == 0
+    # #13486 : no declared lane -> nothing to anchor -> no JSON emitted.
     assert capsys.readouterr().out.strip() == ""
+
+
+def test_missing_comma_tokens_returns_space_joined_paths():
+    """#13129 motif B -- glob with whitespace and 2+ path-shaped tokens.
+
+    Acceptance #13486 témoin : un glob espace-fusionne (`a.py b.py`) doit
+    retourner la liste des tokens path-shaped (`['a.py', 'b.py']`).
+    """
+    assert HELPER._missing_comma_tokens("a.py b.py") == ["a.py", "b.py"]
+    assert HELPER._missing_comma_tokens("scripts/check_lane_claim.py scripts/grain_tag.py") == [
+        "scripts/check_lane_claim.py",
+        "scripts/grain_tag.py",
+    ]
+    assert HELPER._missing_comma_tokens("docs/foo.md docs/bar.md docs/baz.md") == [
+        "docs/foo.md",
+        "docs/bar.md",
+        "docs/baz.md",
+    ]
+
+
+def test_missing_comma_tokens_silent_on_healthy_globs():
+    """#13129 motif B -- healthy glob must NOT trip the suggestion.
+
+    Acceptance #13486 témoin : un glob sain (path without whitespace, or
+    single token with whitespace but no path-shaped neighbor) doit
+    retourner None -- silence.
+    """
+    # Single path, no whitespace: never a missing-comma candidate.
+    assert HELPER._missing_comma_tokens("scripts/check_lane_claim.py") is None
+    # Single token with surrounding whitespace-only: not a missing-comma
+    # because only ONE path-shaped token, not two.
+    assert HELPER._missing_comma_tokens("a.py not-a-path") is None
+    # Empty / no whitespace: never.
+    assert HELPER._missing_comma_tokens("") is None
+    assert HELPER._missing_comma_tokens("scripts/check_lane_claim.py") is None
+
+
+def test_missing_comma_tokens_silent_on_future_files():
+    """#13129 motif B -- a glob that LOOKS like a future file (motif C) must
+    NOT trip the missing-comma heuristic. Heuristic fires only on
+    whitespace + 2+ path-shaped tokens -- a single 'to-create.py' is silent.
+
+    Acceptance #13486 témoin : FUTUR (fichier a creer) -> silence. The
+    test pins the heuristic: a future file is one token (no whitespace).
+    """
+    # Single future file: no whitespace, no missing-comma signal.
+    assert HELPER._missing_comma_tokens("scripts/not_yet_created.py") is None
+    # Single future dir: no whitespace.
+    assert HELPER._missing_comma_tokens("scripts/new_module/") is None
+    # Two tokens but only one path-shaped: not enough for the heuristic.
+    assert HELPER._missing_comma_tokens("scripts/future.py just prose") is None
+
+
+def test_main_emits_notice_for_missing_comma_glob(tmp_path, capsys):
+    """End-to-end -- a body with a missing-comma glob yields ONE
+    `::notice::` annotation (motif B, #13129) AND a structured
+    `dead_scope_suggestions` JSON line with `hint=missing_comma` and the
+    tokens list.
+
+    Acceptance #13486 témoin : glob espace-fusionne -> hint virgule.
+    Acceptance #13486 (3) : champ JSON expose + consomme.
+    """
+    body_file = tmp_path / "body.txt"
+    body_file.write_text(
+        "Grain: MED/tooling — lane myia-po-2024:CoursIA-2\n\n"
+        "[CLAIMED] lane myia-po-2024:CoursIA-2 -- "
+        "paths: scripts/check_lane_claim.py scripts/grain_tag.py\n",
+        encoding="utf-8",
+    )
+    rc = HELPER.main(["--body-file", str(body_file)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    lines = [ln for ln in captured.out.splitlines() if ln.startswith("::")]
+    # Exactly one notice (no warning -- the deadness is EXPLAINED by the typo).
+    notices = [ln for ln in lines if ln.startswith("::notice")]
+    warnings = [ln for ln in lines if ln.startswith("::warning")]
+    assert len(notices) == 1, lines
+    assert len(warnings) == 0, lines
+    assert "Missing comma" in notices[0]
+    assert "scripts/check_lane_claim.py" in notices[0]
+    assert "scripts/grain_tag.py" in notices[0]
+
+    # JSON line consumable by lane scripts.
+    json_lines = [
+        ln for ln in captured.out.splitlines()
+        if ln.startswith("{") and "dead_scope_suggestions" in ln
+    ]
+    assert len(json_lines) == 1
+    payload = json.loads(json_lines[0])
+    assert "dead_scope_suggestions" in payload
+    suggestions = payload["dead_scope_suggestions"]
+    assert len(suggestions) == 1
+    s = suggestions[0]
+    assert s["hint"] == "missing_comma"
+    assert "scripts/check_lane_claim.py" in s["tokens"]
+    assert "scripts/grain_tag.py" in s["tokens"]
+
+
+def test_main_emits_empty_suggestions_when_no_dead_globs(tmp_path, capsys):
+    """#13486 (3) -- the JSON key is ALWAYS present in stdout, even when no
+    suggestion fires. Consumers can rely on the key being there (cheap
+    parser), not on its non-emptiness."""
+    body_file = tmp_path / "body.txt"
+    body_file.write_text(
+        "Grain: MED/tooling — lane myia-po-2024:CoursIA-2\n\n"
+        "[CLAIMED] lane myia-po-2024:CoursIA-2 -- "
+        "paths: scripts/check_lane_claim.py, scripts/grain_tag.py\n",
+        encoding="utf-8",
+    )
+    rc = HELPER.main(["--body-file", str(body_file)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    json_lines = [
+        ln for ln in captured.out.splitlines()
+        if ln.startswith("{") and "dead_scope_suggestions" in ln
+    ]
+    assert len(json_lines) == 1
+    payload = json.loads(json_lines[0])
+    assert payload == {"dead_scope_suggestions": []}
+
+
+def test_missing_comma_heuristic_negative_control():
+    """#13486 (4) -- faux négatif : muter la detection doit faire echouer
+    le temoin. We hard-pin the heuristic: if someone WEAKENS the regex
+    (e.g. drops `lean` from the tracked extensions) the test catches it.
+
+    The regex `_PATHLIKE_TOKEN_RE` MUST treat a path ending in `.lean`
+    as path-shaped. Mute the assertion to fail if `.lean` is dropped.
+    """
+    regex = HELPER._PATHLIKE_TOKEN_RE
+    assert regex.match("MyIA.AI.Notebooks/GameTheory/game_theory_lean/Foo.lean"), (
+        "_PATHLIKE_TOKEN_RE must recognize .lean as a tracked-file extension; "
+        "if you dropped it from the alternation, motif B detection on Lean "
+        "files (#13486) silently degrades."
+    )
 
 
 def test_lane_claim_guard_workflow_yaml_remains_valid():


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA-2 — prev: MED/guard PR #13612 c.696 narrow187ᵉ (re-tag c.741 narrow207ᵈ)

## Summary

Closes #13486 — single machinerie for motif B detection (missing comma between globs in `paths:` clauses, #13129 motif B) + consumable `dead_scope_suggestions` JSON line.

**Files**:
- `scripts/ci/emit_dead_scope_warnings.py` — adds `_PATHLIKE_TOKEN_RE`, `_missing_comma_tokens()`, motif B notice emission, `dead_scope_suggestions` JSON output (key always present, `[]` when no suggestion fires).
- `scripts/check_lane_claim.py` — `_looks_like_missing_comma` now **delegates** to the helper's `_missing_comma_tokens` (UNE SEULE machinerie per #13486 acceptance).
- `scripts/tests/test_emit_dead_scope_warnings.py` — 6 new tests (motif B unit, healthy-glob silence, future-file silence, end-to-end notice emission, empty-suggestions pin, faux-négatif pinning `.lean` extension).

## Acceptance #13486

1. **Motif B detecte dans emit_dead_scope_warnings.py (UNE SEULE machinerie)** : the canonical implementation now lives in `emit_dead_scope_warnings._missing_comma_tokens`. `check_lane_claim._looks_like_missing_comma` is a thin delegate (lazy import). No parallel implementation re-introduced in `check_lane_claim.py`.

2. **Témoins** (3 tests pinning each shape):
   - `test_missing_comma_tokens_returns_space_joined_paths` — glob espace-fusionne → hint virgule (returns tokens list).
   - `test_missing_comma_tokens_silent_on_healthy_globs` — glob sain → silence (`None`).
   - `test_missing_comma_tokens_silent_on_future_files` — FUTUR (single token) → silence.

3. **Champ JSON `dead_scope_suggestions` expose + consomme** : end-to-end test `test_main_emits_notice_for_missing_comma_glob` parses stdout, asserts both the `::notice::` annotation AND the structured JSON line with `hint=missing_comma` and the tokens list. A second test (`test_main_emits_empty_suggestions_when_no_dead_globs`) pins the empty-list shape so consumers can rely on the key being present.

4. **Tests avec faux négatif** : `test_missing_comma_heuristic_negative_control` hard-pins `_PATHLIKE_TOKEN_RE` to recognize `.lean` as a tracked extension. Muting the regex (e.g. dropping `lean` from the alternation) FAILS the test — protects against silent motif-B degradation on Lean files (#13486).

## Tells

- `MED/tooling` (re-tag c.741 narrow207ᵈ Tell c.740-L4 sustained `tooling` = script/helper refactor d'un outil existant, pas `guard`).
- G-VAR-1 TENU : MED + classe CONTENU (`tooling` est META). Acceptable cycle substance since narrow-cycle narrow-applicable narrow-owned (vs narrow-attente sustained jsboige-lane-illisible c.738-c.744).
- L898 collision guard : pas de PR #13486 par autre lane ; issue libre 1j.
- Tell c.649-L1 sustained `grain-tag-genre-tooling-vs-guard-discriminant` applicable : extension d'un script existant → `tooling`, pas `guard`.

## Tests

```
$ python -m pytest scripts/tests/test_emit_dead_scope_warnings.py -v
============================= 16 passed in 0.61s ==============================

$ python -m pytest scripts/tests/test_check_lane_claim.py -k "missing_comma or motif_B or 13129"
===================== 10 passed, 272 deselected in 1.61s ======================

$ python -m pytest scripts/tests/test_check_lane_claim.py
======================= 281 passed, 1 skipped in 17.69s =======================
```

## CLI smoke

```
$ printf 'Grain: MED/tooling — lane myia-po-2024:CoursIA-2\n\n[CLAIMED] lane ... paths: a.py b.py\n' | tee /tmp/body.txt
$ python scripts/ci/emit_dead_scope_warnings.py --body-file /tmp/body.txt
::notice file=a.py b.py,title=Missing comma in scope glob (#13129 motif B)::glob looks like 2 separate paths joined by SPACE instead of COMMA: 'a.py', 'b.py'. Rewrite as `paths: <comma-separated>`.
{"dead_scope_suggestions": [{"glob": "a.py b.py", "hint": "missing_comma", "tokens": ["a.py", "b.py"]}]}
```

Closes #13486
