### PR TITLE
fix(ci,#12567): tranche 5 absorption testpaths-coverage-guard

### DIFF
--- a/.github/workflows/testpaths-coverage-guard.yml
+++ b/.github/workflows/testpaths-coverage-guard.yml
@@ -1,15 +1,12 @@
 name: testpaths-coverage-guard
 
+# #12567 tranche 5 : cette garde est absorbee par la voie rapide
+# (scripts/ci/fast_lane.py). Le declenchement `pull_request` est retire ici
+# pour eviter la double execution (lane + workflow dedie) ; `workflow_dispatch`
+# reste pour execution manuelle / replay. La garde est rendue par la voie
+# rapide sous son nom canonique `testpaths vs CI coverage` (conclusion reelle,
+# conclusion_for ne neutralise pas les absorbes).
 on:
-  pull_request:
-    paths:
-      - 'pytest.ini'
-      - 'scripts/check_testpaths_coverage.py'
-      - '.github/workflows/scripts-tests.yml'
-      - '.github/workflows/ml-tests.yml'
-      - '.github/workflows/secret-scan.yml'
-      - '.github/workflows/ict-tests.yml'
-      - '.github/workflows/testpaths-coverage-guard.yml'
   workflow_dispatch:
 
 permissions:

--- a/scripts/ci/check_absorbed_check_run_identity.py
+++ b/scripts/ci/check_absorbed_check_run_identity.py
@@ -39,7 +39,7 @@ WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 
 def absorbed_guards():
     """Tous les gardes absorbes du registre, tranches 1/2/4 + 3 si merge."""
-    for tranche_name in ("TRANCHE1", "TRANCHE2", "TRANCHE3", "TRANCHE4"):
+    for tranche_name in ("TRANCHE1", "TRANCHE2", "TRANCHE3", "TRANCHE4", "TRANCHE5"):
         yield from getattr(reg, tranche_name, [])
 
 

--- a/scripts/ci/fast_lane.py
+++ b/scripts/ci/fast_lane.py
@@ -40,7 +40,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from fast_lane_registry import (  # noqa: E402
-    PILOT, TRANCHE1, TRANCHE2, TRANCHE3, TRANCHE4, Guard,
+    PILOT, TRANCHE1, TRANCHE2, TRANCHE3, TRANCHE4, TRANCHE5, Guard,
 )
 
 SHADOW_PREFIX = "fast-lane (ombre): "
@@ -314,7 +314,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"[fast-lane] {len(changed)} fichier(s) modifie(s) "
           f"contre {args.base_ref}")
 
-    guards = [g for g in PILOT + TRANCHE1 + TRANCHE2 + TRANCHE3 + TRANCHE4
+    guards = [g for g in PILOT + TRANCHE1 + TRANCHE2 + TRANCHE3 + TRANCHE4 + TRANCHE5
               if not args.only or g.name == args.only]
     selected = [g for g in guards if guard_applies(g, changed)]
     for guard in guards:

--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -658,3 +658,44 @@ TRANCHE4: list[Guard] = [
         fail_on_all_warn=True,
     ),
 ]
+
+
+# ---------------------------------------------------------------------------
+# TRANCHE 5 d'absorption (#12567) -- garde de derive pytest testpaths vs CI.
+# Forme moteur : scan global simple, sans base (le script lit pytest.ini +
+# tous les workflows et fait la difference -- pas de notion de delta base
+# vs head pour cette garde). Meme contrat que la tranche 1 forme 1.
+#
+# Selection rationale : apres les 4 premieres tranches, le scan systematique
+# (script ci-dessus) des 96 workflows pull_request ne trouve que 2 mono-script
+# restants : (1) base-not-main-advisory.yml -- ecrit un label + commentaire
+# PR, donc exige `pull-requests: write` exclus par le registre (#13097 /
+# tranche 3 documente l'exclusion) ; (2) testpaths-coverage-guard.yml --
+# mono-script, `contents: read` only, scan global sans base. La tranche 5
+# absorbe ce dernier.
+#
+# Forme : scan global, pas de `paths:` restrictif (la garde porte sur pytest.ini
+# + workflows declares comme sources de verite -- tout PR touchant un test
+# config peut deriver la garde). Le filtre `paths:` du workflow d'origine
+# est reporte tel quel dans `Guard.paths` pour preserver le comportement
+# de declenchement actuel : une PR qui ne touche aucun de ces chemins ne
+# declenche PAS la garde absorbee (coherence avec les tranches 1-4).
+# ---------------------------------------------------------------------------
+TRANCHE5: list[Guard] = [
+    Guard(
+        name="testpaths vs CI coverage",
+        source="testpaths-coverage-guard.yml",
+        paths=[
+            "pytest.ini",
+            "scripts/check_testpaths_coverage.py",
+            ".github/workflows/scripts-tests.yml",
+            ".github/workflows/ml-tests.yml",
+            ".github/workflows/secret-scan.yml",
+            ".github/workflows/ict-tests.yml",
+            ".github/workflows/testpaths-coverage-guard.yml",
+        ],
+        argv=["python", "scripts/check_testpaths_coverage.py", "--verbose"],
+        blocking=True,
+        absorbed=True,
+    ),
+]

--- a/scripts/tests/test_fast_lane.py
+++ b/scripts/tests/test_fast_lane.py
@@ -31,7 +31,7 @@ sys.path.insert(0, str(CI_DIR))
 
 import fast_lane  # noqa: E402
 from fast_lane_registry import (  # noqa: E402
-    FAST_LANE_NATIVE, PILOT, TRANCHE1, TRANCHE2, TRANCHE3, TRANCHE4, Guard,
+    FAST_LANE_NATIVE, PILOT, TRANCHE1, TRANCHE2, TRANCHE3, TRANCHE4, TRANCHE5, Guard,
 )
 
 
@@ -606,6 +606,7 @@ def _drive_mixed_emission(monkeypatch, pilot_rc, tranche_rc):
     monkeypatch.setattr(fl, "TRANCHE1", [tranche])
     monkeypatch.setattr(fl, "TRANCHE2", [])
     monkeypatch.setattr(fl, "TRANCHE4", [])
+    monkeypatch.setattr(fl, "TRANCHE5", [])
     monkeypatch.setattr(fl, "changed_files", lambda _ref: ["x.ipynb"])
     monkeypatch.setattr(
         fl, "run_argv",
@@ -697,6 +698,7 @@ def test_pre_argv_failure_short_circuits_the_guard(monkeypatch):
     monkeypatch.setattr(fl, "TRANCHE1", [guard])
     monkeypatch.setattr(fl, "TRANCHE2", [])
     monkeypatch.setattr(fl, "TRANCHE4", [])
+    monkeypatch.setattr(fl, "TRANCHE5", [])
     monkeypatch.setattr(fl, "changed_files", lambda _ref: ["x.ipynb"])
 
     def fake_run_argv(argv, ctx):
@@ -727,6 +729,7 @@ def test_pre_argv_success_chains_into_the_scan(monkeypatch):
     monkeypatch.setattr(fl, "TRANCHE1", [guard])
     monkeypatch.setattr(fl, "TRANCHE2", [])
     monkeypatch.setattr(fl, "TRANCHE4", [])
+    monkeypatch.setattr(fl, "TRANCHE5", [])
     monkeypatch.setattr(fl, "changed_files", lambda _ref: ["x.ipynb"])
 
     def fake_run_argv(argv, ctx):
@@ -770,6 +773,7 @@ def test_warn_rc_is_success_everywhere(monkeypatch):
     monkeypatch.setattr(fl, "TRANCHE1", [guard])
     monkeypatch.setattr(fl, "TRANCHE2", [])
     monkeypatch.setattr(fl, "TRANCHE4", [])
+    monkeypatch.setattr(fl, "TRANCHE5", [])
     monkeypatch.setattr(fl, "changed_files", lambda _ref: ["x.ipynb"])
     monkeypatch.setattr(fl, "run_argv", lambda argv, ctx: (2, "illisible"))
     monkeypatch.setattr(
@@ -805,6 +809,7 @@ def test_iter_paths_skips_files_deleted_by_the_pr(monkeypatch):
     monkeypatch.setattr(fl, "TRANCHE1", [])
     monkeypatch.setattr(fl, "TRANCHE2", [fig])
     monkeypatch.setattr(fl, "TRANCHE4", [])
+    monkeypatch.setattr(fl, "TRANCHE5", [])
 
     # Un notebook REEL (pour le cas here) + un chemin absent (gone) : le
     # filtre doit garder le premier et ecarter le second.
@@ -1057,3 +1062,91 @@ def test_tranche3_scan_paths_cover_the_scanner_itself():
         "scripts/notebook_tools/forensic_scan.py",
     ):
         assert needle in guard.paths, f"{needle} absent des paths du garde"
+
+
+# ---------------------------------------------------------------------------
+# 8. Tranche 5 d'absorption (#12567) -- testpaths vs CI coverage
+# ---------------------------------------------------------------------------
+
+def test_tranche5_guards_are_absorbed_single_testpaths_guard():
+    """Tranche 5 = un seul garde : `testpaths vs CI coverage` (derniere mono-script
+    absorbable restant apres exclusion PR-write, cf commentaire registre). Forme
+    simple : scan global, pas de base, pas d'iter_paths, pas de warn_rc, bloquant.
+    Meme squelette que la forme 1 de la tranche 1 (check-links), mais avec un
+    filtre `paths:` restrictif pour preserver le declenchement d'origine (la
+    garde ne sert que si pytest.ini ou les workflows declares bougent).
+    """
+    assert len(TRANCHE5) == 1, (
+        "la tranche 5 documente 1 seul garde (testpaths-coverage-guard) ; "
+        "si le nombre change, le commentaire du registre et ce test suivent"
+    )
+    guard = TRANCHE5[0]
+    assert guard.name == "testpaths vs CI coverage", (
+        f"nom canonique = nom de job du workflow source : "
+        f"attendu `testpaths vs CI coverage`, obtenu `{guard.name}`"
+    )
+    assert guard.absorbed, f"{guard.name} doit porter absorbed=True"
+    assert guard.blocking, (
+        f"{guard.name} remplace un gate qui rougit le job d'origine"
+    )
+    assert guard.source == "testpaths-coverage-guard.yml"
+    # Forme : pas d'iter_paths, pas de delta, pas de pre_argv, pas de warn_rc
+    # -- scan global simple comme la tranche 1 forme 1.
+    assert not guard.iterates_paths, (
+        f"{guard.name} est un scan global, pas une boucle par fichier"
+    )
+    assert not guard.delta_argv, (
+        f"{guard.name} ne delta pas vs la base (lit pytest.ini + workflows)"
+    )
+    assert not guard.pre_argv
+    assert guard.warn_rc == ()
+    # Filtre paths reporte tel quel depuis le workflow d'origine : pytest.ini
+    # + les 5 workflows declares comme sources de verite + le script lui-meme.
+    for needle in (
+        "pytest.ini",
+        "scripts/check_testpaths_coverage.py",
+        ".github/workflows/scripts-tests.yml",
+        ".github/workflows/ml-tests.yml",
+        ".github/workflows/secret-scan.yml",
+        ".github/workflows/ict-tests.yml",
+        ".github/workflows/testpaths-coverage-guard.yml",
+    ):
+        assert needle in guard.paths, (
+            f"{needle} doit figurer dans les paths du garde (declenchement "
+            f"d'origine a preserver)"
+        )
+
+
+def test_absorbed_workflows_of_tranche5_no_longer_trigger_on_pull_request():
+    """Meme contrat que les tranches 1/2/4 : un garde absorbe voit son workflow
+    d'origine retirer de `pull_request` (sinon double execution). Le fichier
+    garde `workflow_dispatch` pour le maintien manuel.
+    """
+    import re as _re
+    for guard in TRANCHE5:
+        wf = WORKFLOWS / guard.source
+        assert wf.is_file(), f"{guard.source} absent du depot"
+        txt = wf.read_text(encoding="utf-8")
+        assert not _re.search(r"^\s+pull_request:", txt, _re.M), (
+            f"{guard.source} declenche encore sur pull_request alors que "
+            f"{guard.name} est absorbe : double execution + zero run sauve"
+        )
+        assert "workflow_dispatch" in txt, (
+            f"{guard.source} doit garder workflow_dispatch (maintien manuel)"
+        )
+
+
+def test_tranche5_identity_byte_check_passes():
+    """L'organe de controle positif (check_absorbed_check_run_identity) doit
+    cimenter que `guard.name` == nom rendu par le workflow source. Tranche 5
+    ajoute TRANCHE5 a la liste des gardes absorbes a verifier ; si la liaison
+    est cassee (workflow retire trop tot, ou nom diverge), l'organe rougit."""
+    import subprocess as _sp
+    r = _sp.run(
+        ["python", "scripts/ci/check_absorbed_check_run_identity.py", "--check"],
+        capture_output=True, text=True, cwd=Path(__file__).resolve().parents[2],
+    )
+    assert r.returncode == 0, (
+        f"identity byte-check a echoue (rc={r.returncode}) : \n"
+        f"stdout={r.stdout}\nstderr={r.stderr}"
+    )


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA-2 — prev: MED/tooling #13675 c.745 narrow211ᵈ

## Closes #12567 (tranche 5/5 absorption fast-lane, mono-script)

### Objectif

Poursuivre l'absorption des gardes mono-script CI par la voie rapide (`scripts/ci/fast_lane.py`) — tranche 5 (sur 5). Aprés tranches 1, 2, 3 (conditionnel), 4 : un dernier garde mono-script restait eligible, `testpaths-coverage-guard.yml`.

### Selection rationale (un seul garde eligible)

Scan de **96 workflows PR-trigger** dans `.github/workflows/` avec 3 filtres cumulatifs :
1. **Mono-script** (un seul step `run:` non-shell-meta — pas de `bash -c`, pas de `python -c`)
2. **PR-write exclu** (pas d'écriture sur fichiers du PR — cf. garde `perimeter-review-guard` qui ouvre un commentaire review)
3. **Pas déjà absorbé** dans TRANCHE1-4

Résultat : **un seul candidat** = `testpaths-coverage-guard.yml` (garde de dérive pytest testpaths vs CI, #10903).

### Acceptance verbatim #12567

| Critère | Statut |
|---|---|
| Tranche de gardes mono-script absorbée dans `scripts/ci/fast_lane.py` | ✓ TRANCHE5 ajoutée |
| Chaque garde absorbé conserve son check-run nommé | ✓ `testpaths vs CI coverage` byte-identique au job.name source |
| Mesure avant/après : avant = N workflows mono-script dédiés, après = N guards absorbés dans la lane | ✓ Avant = 1 workflow, après = 1 guard (TRANCHE5) |

### Changements (5 fichiers)

- **`scripts/ci/fast_lane_registry.py`** : ajout TRANCHE5 = 1 garde (`testpaths vs CI coverage`, blocking=True, absorbed=True). Forme moteur "scan global simple" + paths filter préservant le trigger workflow d'origine.
- **`scripts/ci/fast_lane.py`** : import TRANCHE5 + guards list étendue.
- **`.github/workflows/testpaths-coverage-guard.yml`** : suppression du déclencheur `pull_request:` (gardait `workflow_dispatch:` pour replay manuel). Justification inline en commentaire.
- **`scripts/ci/check_absorbed_check_run_identity.py`** : `absorbed_guards()` yield depuis TRANCHE5 en plus de T1/T2/T3/T4.
- **`scripts/tests/test_fast_lane.py`** : 3 tests tranche 5 ajoutés + 5 monkeypatches étendus (`TRANCHE4=[]` → `TRANCHE4=[]`, `TRANCHE5=[]`).

### Mesure fast-lane — vérifié localement

Branche de mesure jetable `tranche5-measure6` créée sur `origin/main`, `pytest.ini` modifié, `fast_lane.py` + `fast_lane_registry.py` copiés depuis la branche feature pour reproduire l'environnement post-merge.

Sortie (extrait) :
```
[fast-lane] phase 1 testpaths vs CI coverage : exit 0
[fast-lane][a-blanc] check-run 'testpaths vs CI coverage' -> success (testpaths vs CI coverage -- OK)
[fast-lane] 2 garde(s) evalue(s), aucun bloquant en echec
```

Le garde tire dans la voie rapide, conclut `success` (conclusion reelle, pas `conclusion_for`), nom du check-run byte-identique au job.name `testpaths vs CI coverage`.

### Identité byte-à-byte

`scripts/ci/check_absorbed_check_run_identity.py --check` rapporte :
```
[absorbed-identity] OK -- 13 gardes absorbes byte-identiques a leur source.
```
12 (T1-T4) + 1 (T5) = 13 ✓.

### Tests

- `pytest scripts/tests/test_fast_lane.py` : **70 passed** (5 monkeypatches T4+T5 + 3 nouveaux tests T5 inclus).
- Suite pytest élargie : **529 passed** (sur le subset script-only).

### Tell c.740-L4 sustained appliqué

Discriminant `tooling` vs `guard` : PR #12567 tranche 5 = refactor workflow CI single-file (MODIFIED +3/-3 sur le yml) + ajout d'un garde dans la voie rapide. Le check `testpaths-coverage-guard.yml` EST un garde, mais le **grain de cette PR** est de l'outillage (refactor d'absorption), pas l'écriture d'un nouveau garde. Tag `MED/tooling`.

### Garde-fous

- **L898 collision guard** : `git worktree list` + `gh pr list --search head:<branch>` + `gh pr list --search "12567"` clean avant édition. Pas de conflit.
- **L677-L4 body HORS worktree** : ce fichier vit dans le scratchpad, pas dans le worktree.
- **Tell c.704-L1** : `pytest.ini` restauré via `git checkout` après mesure (artefact CRLF/LF).

### Hors scope

- L'absorption des **gardes multi-step** (transcription `run: bash -c "..."`) reste hors mandat — nécessite un parsing shell, pas un simple `argv` linéaire. Suite naturelle si un Epic l'ouvre.
- La fusion **des autres voies lentes** (windows self-hosted, etc.) ne fait pas partie de #12567.

### Références

- #12567 — epic d'absorption
- #13675 — tranche précédente (c.745 narrow211ᵈ, single machinerie detection)
- Tell c.740-L4 sustained `grain-tag-genre-tooling-vs-guard-discriminant`
- Tell c.704-L1 sustained `pull-overwrite-nbformat-md5-mismatch-LF-vs-CRLF`
