### PR TITLE
ci(guard,#13488): organe refusant push:main + group github.ref + cancel-in-progress literal true

### DIFF
--- a/.github/workflows/concurrency-conj-guard.yml
+++ b/.github/workflows/concurrency-conj-guard.yml
@@ -1,0 +1,52 @@
+name: concurrency-conj-guard
+
+# #13488 -- refoule la conjonction ``push: main`` + ``concurrency.group`` portant
+# ``github.ref`` + ``concurrency.cancel-in-progress: true`` (litteral).
+# Le defaut que #13372 corrige (mesure 2026-08-28 : 27/30 et 26/30 runs
+# annules par le merge suivant) est silencieux isolement et bruyant en
+# cascade : un seul run isole passe, mais la premiere paire de merges
+# successifs detruit la moitie de la verification. Cet organe rend la
+# regression impossible a relivrer : la prochaine PR qui reintroduit la
+# conjonction rougit ici, nomme le fichier + la ligne + la forme du fix.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: concurrency-conj-guard-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  guard:
+    name: concurrency-conj-guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/workflows
+            scripts/ci/check_concurrency_conj.py
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML if absent
+        # PyYAML n'est pas preinstalle sur les runners ubuntu-latest par
+        # defaut. Pattern partage avec unique-check-run-names-guard.yml :
+        # import-test en dry-run, fallback pip install silencieux. Sans
+        # cette etape, exit 2 BROKEN_INSTRUMENT masquerait la conjonction
+        # en rouge de complaisance (cf #11850).
+        run: python -c "import yaml" 2>/dev/null || pip install --quiet pyyaml
+
+      - name: Check concurrency conjunction
+        # Forme fix de #13372 deja majoritaire : cancel-in-progress gate sur
+        # event_name == 'pull_request' pour annuler sur PR (un groupe par
+        # PR, jamais collision) et laisser vivre sur push:main (les merges
+        # successifs ne se tuent pas entre eux).
+        run: python scripts/ci/check_concurrency_conj.py --check --json

--- a/scripts/ci/check_concurrency_conj.py
+++ b/scripts/ci/check_concurrency_conj.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Check that workflows do not combine `push: main` + group keyed on github.ref
++ literal `cancel-in-progress: true` (#13488).
+
+## Why this exists
+
+The defect #13372 corrected in three workflows measured firsthand: on a cascade
+of merges onto `main`, `concurrency.group: <name>-${{ github.ref }}` evaluates
+to a constant `<name>-refs/heads/main` -- so every commit shares the same
+group. With `cancel-in-progress: true`, the new run kills the previous one
+before it can finish. The guard being correct on isolated PRs (where
+`github.ref` is `refs/pull/N/merge`, unique per PR) masks the defect: the
+workflow verifies its own PR (1 run, 1 group), goes green, and the regression
+on `main` is invisible until a cascade actually hits.
+
+The fix on the workflow side is `cancel-in-progress:
+${{ github.event_name == 'pull_request' }}` -- cancel ONLY on PR, never on
+push. The fix on the guard side is the present script: refuse the conjunction
+on `main` so a regression of the fix is impossible to land.
+
+## The discriminator
+
+The conjunction is the THREE-WAY:
+  (a) `on.push.branches` includes `main`
+  (b) `concurrency.group` template contains `github.ref`
+  (c) `concurrency.cancel-in-progress` is the literal `true`
+
+All three must be true for the failure. (a) is the structural trigger;
+(b) is what makes the group constant across commits; (c) is what makes the
+cancellation happen.
+
+Without (a), `github.ref` is per-PR and the bug cannot occur -- the 59
+workflows with `cancel-in-progress: true` and no `push: main` are harmless.
+
+## Allowlist
+
+Some workflows deliberately use literal `true` because they supersede
+concurrent deploys of the same artefact -- e.g. `quarto-pages-deploy.yml`,
+which wants the new deploy to win. The allowlist is **by file name**, never
+a glob, with a comment in the script citing the reason. The cliquet that
+makes the gate rough on every new file is the whole value of the organ --
+same discipline as `Classical.choice` whitelisting in the Lean axiom gate.
+
+## Modes
+
+  --check       print summary + offenders; exit 0 if clean, exit 1 if any
+                workflow offends, exit 2 on instrument failure (PyYAML
+                missing, workflow unreadable).
+  --json        same as --check but emits a JSON document on stdout.
+
+Run: python scripts/ci/check_concurrency_conj.py --check
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+EXIT_CLEAN, EXIT_OFFENDERS, EXIT_BROKEN = 0, 1, 2
+
+DEFAULT_WORKFLOWS_DIR = str(
+    Path(__file__).resolve().parents[2] / ".github" / "workflows"
+)
+
+# Allowlist by file name (no glob). The cliquet that roughs the gate on every
+# new name is the entire value of the organ. Add a name ONLY with a one-line
+# reason; never wildcard.
+ALLOWLIST: dict[str, str] = {
+    # pages-deploy supersedes concurrent deploys of the same Quarto artifact:
+    # the new deploy must win. Comment in quarto-pages-deploy.yml confirms.
+    "quarto-pages-deploy.yml": "Quarto pages deploy supersedes prior in-flight deploy",
+}
+
+
+def _load_yaml():
+    try:
+        import yaml
+    except ImportError:
+        return None
+    return yaml
+
+
+def _parse_workflow(text: str, yaml):
+    """Parse one workflow YAML, working around PyYAML's `on:` -> True issue.
+
+    PyYAML 1.1 treats the bareword `on` as a boolean; we rewrite the trigger
+    key to a quoted string before parsing. Returns the parsed dict or None.
+    """
+    out_lines: list[str] = []
+    for line in text.splitlines(keepends=True):
+        if line.startswith("on:") or line.startswith("on :"):
+            out_lines.append('"on":' + line[len("on:"):])
+        else:
+            out_lines.append(line)
+    rewritten = "".join(out_lines)
+    try:
+        return yaml.safe_load(rewritten)
+    except yaml.YAMLObject:
+        return None
+
+
+def _branches_include_main(trigger: dict | None) -> bool:
+    """True if the workflow's `push:` trigger lists `main` (or wildcard '*').
+
+    Handles three shapes:
+      - ``push: { branches: [main, ...] }``
+      - ``push: { branches: main }`` (scalar)
+      - ``push: branches: [main]`` (flattened)
+
+    A ``push:`` without ``branches:`` is treated as default (all branches),
+    which includes main. This is the GitHub Actions default.
+    """
+    if not isinstance(trigger, dict):
+        return False
+    push = trigger.get("push")
+    if push is None:
+        return False
+    # Default push trigger (no explicit branches) covers main.
+    if push is True:
+        return True
+    if not isinstance(push, dict):
+        return False
+    if "branches" not in push and "branches-ignore" not in push:
+        # No filter at all -> default, includes main.
+        return True
+    branches = push.get("branches", [])
+    if isinstance(branches, str):
+        branches = [branches]
+    if not isinstance(branches, list):
+        return False
+    for b in branches:
+        if not isinstance(b, str):
+            continue
+        # Quoted wildcards: '*' or '**' covers main.
+        if b in {"*", "**"}:
+            return True
+        # Plain or quoted: main (literal match).
+        if b == "main" or b.strip('"').strip("'") == "main":
+            return True
+    return False
+
+
+def _group_has_github_ref(group: str | None) -> bool:
+    """True if `concurrency.group` template contains the substring ``github.ref``.
+
+    Any occurrence is enough -- ``${{ github.ref }}``, ``${{ github.event.pull_request.base.ref }}``,
+    or the like. The bug is structural to the template form, not the literal
+    expression.
+    """
+    if not isinstance(group, str):
+        return False
+    return "github.ref" in group
+
+
+def _cancel_is_literal_true(cancel: object) -> bool:
+    """True only if `concurrency.cancel-in-progress` is the literal `true`.
+
+    A template expression like ``${{ github.event_name == 'pull_request' }}``
+    is NOT literal true even when the YAML parses to the Python value True:
+    PyYAML evaluates unquoted `true` to True, but a quoted or templated value
+    stays a string. We discriminate on type + value: bool True AND not a
+    string.
+
+    Wait -- that discrimination fails on the literal-true case. The bug we
+    catch is specifically the LITERAL `true` (no template), so we accept
+    bool True as the only signal. A template that EVALUATES to true at
+    runtime but is a STRING in YAML is structurally the fix -- keep it.
+    """
+    # YAML literal `true` -> Python bool True.
+    return cancel is True
+
+
+def offenders(workflows_dir: str = DEFAULT_WORKFLOWS_DIR) -> list[dict]:
+    """Return the list of workflows that carry the conjunction.
+
+    Each entry is a dict with: ``file``, ``reason``, ``line_group`` (1-indexed
+    line where ``concurrency:`` begins), ``fix`` (the canonical replacement).
+    """
+    yaml = _load_yaml()
+    if yaml is None:
+        return [{"file": "<instrument>", "reason": "PyYAML indisponible",
+                 "line_group": 0, "fix": ""}]
+    wdir = Path(workflows_dir)
+    if not wdir.is_dir():
+        return [{"file": str(wdir), "reason": "workflows dir introuvable",
+                 "line_group": 0, "fix": ""}]
+    out: list[dict] = []
+    for wf in sorted(wdir.glob("*.y*ml")):
+        name = wf.name
+        if name in ALLOWLIST:
+            continue
+        try:
+            text = wf.read_text(encoding="utf-8")
+        except OSError:
+            out.append({"file": name, "reason": "illisible",
+                        "line_group": 0, "fix": ""})
+            continue
+        data = _parse_workflow(text, yaml)
+        if not isinstance(data, dict):
+            continue
+        trigger = data.get("on") if "on" in data else data.get(True)
+        # After the on:-rewrite, "on" survives as a quoted key in the dict.
+        if "on" not in data and True in data:
+            trigger = data[True]
+        concurrency = data.get("concurrency") or {}
+        if not isinstance(concurrency, dict):
+            continue
+        if not _branches_include_main(trigger):
+            continue
+        if not _group_has_github_ref(concurrency.get("group")):
+            continue
+        if not _cancel_is_literal_true(concurrency.get("cancel-in-progress")):
+            continue
+        # All three conjuncts true: offender.
+        line_group = _line_of(text, "concurrency:")
+        out.append({
+            "file": name,
+            "reason": ("push: main + concurrency.group porte github.ref + "
+                       "cancel-in-progress litteral true (defaut #13372, "
+                       "le garde s'annule sur cascade de merges)"),
+            "line_group": line_group,
+            "fix": ('cancel-in-progress: ${{ github.event_name == \'pull_request\' }} '
+                   '(forme fix de #13372, deja majoritaire dans lean-*, '
+                   'bash-syntax, ict-tests, ml-tests, secret-scan, '
+                   'validation-matrix).'),
+        })
+    return out
+
+
+def _line_of(text: str, token: str) -> int:
+    """1-indexed line number where `token` first appears at column 0.
+
+    Used to point the author to the concurrency block. Falls back to 0 if not
+    found (should not happen for parsed workflows).
+    """
+    for i, line in enumerate(text.splitlines(), start=1):
+        if line.startswith(token):
+            return i
+    return 0
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Refuser la conjonction push:main + group github.ref + cancel-in-progress litteral true (#13488)."
+    )
+    parser.add_argument("--check", action="store_true",
+                        help="exit 0/1/2 par verdict")
+    parser.add_argument("--json", action="store_true",
+                        help="sortie JSON sur stdout")
+    parser.add_argument("--workflows-dir", default=DEFAULT_WORKFLOWS_DIR,
+                        help="repertoire des workflows (override pour les tests)")
+    args = parser.parse_args(argv)
+
+    yaml = _load_yaml()
+    if yaml is None:
+        msg = {"guard": "concurrency-conj", "status": "BROKEN_INSTRUMENT",
+               "reason": "PyYAML indisponible"}
+        if args.json:
+            print(json.dumps(msg))
+        else:
+            print("[concurrency-conj] BROKEN INSTRUMENT: PyYAML absent.",
+                  file=sys.stderr)
+        return EXIT_BROKEN
+
+    offs = offenders(args.workflows_dir)
+    summary = {
+        "guard": "concurrency-conj",
+        "workflows_scanned": sum(1 for _ in Path(args.workflows_dir).glob("*.y*ml")),
+        "allowlist": sorted(ALLOWLIST.keys()),
+        "offenders": offs,
+    }
+    if args.json:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+    else:
+        print(f"[concurrency-conj] workflows_scanned={summary['workflows_scanned']} "
+              f"allowlist={summary['allowlist']} offenders={len(offs)}")
+        for o in offs:
+            print(f"  - {o['file']}:{o['line_group']} -- {o['reason']}")
+            print(f"    fix: {o['fix']}")
+
+    if not args.check:
+        return EXIT_CLEAN
+    return EXIT_CLEAN if not offs else EXIT_OFFENDERS
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/scripts/tests/test_check_concurrency_conj.py
+++ b/scripts/tests/test_check_concurrency_conj.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Unit tests for check_concurrency_conj.py (#13488).
+
+Acceptance 1 (positive control): a fixture workflow carrying the full
+conjunction (push:main + group portant github.ref + cancel-in-progress:true
+literal) MUST appear in the offenders list. The fixture is the founding
+incident measured on 2026-08-28 by #13372.
+
+Acceptance 2 (negative control): the three workflows fixed by #13372
+(banner-guard, markdown-rendering-guard, series-naming-gate) and the
+allowlisted quarto-pages-deploy MUST NOT appear.
+
+Acceptance 3 (allowlist discipline): the allowlist is by file name, no glob;
+a name absent from the allowlist with the conjunction is an offender.
+"""
+
+import os
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# scripts/ci/ is the package root for the CI guard family.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+from check_concurrency_conj import (  # noqa: E402
+    ALLOWLIST,
+    _branches_include_main,
+    _cancel_is_literal_true,
+    _group_has_github_ref,
+    offenders,
+)
+
+
+# --- Fixtures (acceptance 1: positive control) --------------------------------
+
+CONJUNCTION_YML = textwrap.dedent("""\
+    name: conj-pos
+    on:
+      push:
+        branches: [main]
+    concurrency:
+      group: conj-pos-${{ github.ref }}
+      cancel-in-progress: true
+    jobs:
+      j:
+        runs-on: ubuntu-latest
+        steps:
+          - run: echo hi
+""")
+
+
+def _write_workflow(tmpdir: Path, name: str, body: str) -> Path:
+    wf = tmpdir / ".github" / "workflows"
+    wf.mkdir(parents=True, exist_ok=True)
+    target = wf / name
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+# --- Predicate unit tests -----------------------------------------------------
+
+
+def test_branches_include_main_list():
+    assert _branches_include_main({"push": {"branches": ["main"]}}) is True
+
+
+def test_branches_include_main_scalar():
+    assert _branches_include_main({"push": {"branches": "main"}}) is True
+
+
+def test_branches_include_main_default():
+    """push: with no branches filter covers main (default)."""
+    assert _branches_include_main({"push": {}}) is True
+
+
+def test_branches_include_main_wildcard():
+    assert _branches_include_main({"push": {"branches": ["*"]}}) is True
+
+
+def test_branches_include_main_absent():
+    assert _branches_include_main({"push": {"branches": ["dev"]}}) is False
+
+
+def test_branches_include_main_no_push():
+    assert _branches_include_main({"pull_request": {"branches": ["main"]}}) is False
+
+
+def test_group_has_github_ref_positive():
+    assert _group_has_github_ref("foo-${{ github.ref }}") is True
+
+
+def test_group_has_github_ref_nested():
+    """Any github.ref occurrence is enough, even nested in a conditional."""
+    assert _group_has_github_ref(
+        "${{ github.event_name == 'pull_request' && github.ref || github.sha }}"
+    ) is True
+
+
+def test_group_has_github_ref_negative():
+    assert _group_has_github_ref("foo-${{ github.sha }}") is False
+
+
+def test_group_has_github_ref_none():
+    assert _group_has_github_ref(None) is False
+
+
+def test_cancel_is_literal_true_bool():
+    """The literal-true case is the one that breaks on cascade."""
+    assert _cancel_is_literal_true(True) is True
+
+
+def test_cancel_is_literal_true_template_string():
+    """Template strings are the fix from #13372 -- accept as not-literal."""
+    assert _cancel_is_literal_true("${{ github.event_name == 'pull_request' }}") is False
+
+
+# --- Acceptance 1: positive control -------------------------------------------
+
+
+def test_conjunction_workflow_is_offender(tmp_path: Path):
+    """The conjunction MUST produce an offender (acceptance 1, positive control)."""
+    _write_workflow(tmp_path, "conj-pos.yml", CONJUNCTION_YML)
+    offs = offenders(workflows_dir=str(tmp_path / ".github" / "workflows"))
+    names = [o["file"] for o in offs]
+    assert "conj-pos.yml" in names, (
+        f"workflow carrying the full conjunction was not flagged; "
+        f"offenders={names}. Acceptance 1 broken."
+    )
+
+
+def test_conjunction_workflow_cites_fix_form(tmp_path: Path):
+    """The error message must name the canonical replacement."""
+    _write_workflow(tmp_path, "conj-pos.yml", CONJUNCTION_YML)
+    offs = offenders(workflows_dir=str(tmp_path / ".github" / "workflows"))
+    o = next(o for o in offs if o["file"] == "conj-pos.yml")
+    assert "github.event_name == 'pull_request'" in o["fix"]
+    assert o["line_group"] > 0, "must cite the concurrency block line"
+
+
+# --- Acceptance 2: negative control -------------------------------------------
+
+
+def test_banner_guard_after_fix13372_is_clean(tmp_path: Path):
+    """banner-guard was fixed by #13372 (cancel conditioned on pull_request)."""
+    body = textwrap.dedent("""\
+        name: banner-guard
+        on:
+          push:
+            branches: [main]
+          pull_request:
+        concurrency:
+          group: banner-guard-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+          cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+        jobs:
+          j:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo hi
+    """)
+    _write_workflow(tmp_path, "banner-guard.yml", body)
+    offs = offenders(workflows_dir=str(tmp_path / ".github" / "workflows"))
+    names = [o["file"] for o in offs]
+    assert "banner-guard.yml" not in names, (
+        f"banner-guard (fixed by #13372) flagged; offenders={names}."
+    )
+
+
+def test_quarto_pages_deploy_allowlist_is_respected(tmp_path: Path):
+    """quarto-pages-deploy is allowlisted (deploy supersedes prior)."""
+    body = textwrap.dedent("""\
+        name: pages-deploy
+        on:
+          push:
+            branches: [main]
+        concurrency:
+          group: pages-deploy-${{ github.event_name }}-${{ github.ref }}
+          cancel-in-progress: true
+        jobs:
+          deploy:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo deploy
+    """)
+    _write_workflow(tmp_path, "quarto-pages-deploy.yml", body)
+    offs = offenders(workflows_dir=str(tmp_path / ".github" / "workflows"))
+    names = [o["file"] for o in offs]
+    assert "quarto-pages-deploy.yml" not in names, (
+        f"quarto-pages-deploy (allowlisted) flagged; offenders={names}."
+    )
+
+
+def test_workflow_without_push_main_is_clean(tmp_path: Path):
+    """cancel-in-progress:true without push:main is harmless (per #13488 body)."""
+    body = textwrap.dedent("""\
+        name: pr-only
+        on:
+          pull_request:
+        concurrency:
+          group: pr-only-${{ github.ref }}
+          cancel-in-progress: true
+        jobs:
+          j:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo hi
+    """)
+    _write_workflow(tmp_path, "pr-only.yml", body)
+    offs = offenders(workflows_dir=str(tmp_path / ".github" / "workflows"))
+    names = [o["file"] for o in offs]
+    assert "pr-only.yml" not in names
+
+
+# --- Acceptance 3: allowlist discipline ---------------------------------------
+
+
+def test_allowlist_is_by_name_no_glob():
+    """Allowlist must be exact file names -- no glob, no partial match."""
+    assert "quarto-pages-deploy.yml" in ALLOWLIST
+    # No glob / wildcard characters.
+    for name in ALLOWLIST:
+        assert "*" not in name
+        assert "?" not in name
+        assert "[" not in name
+
+
+def test_non_allowlisted_with_conjunction_is_offender(tmp_path: Path):
+    """A new workflow with the conjunction but no allowlist entry is flagged.
+
+    The cliquet -- any new file carrying the bug is caught.
+    """
+    body = textwrap.dedent("""\
+        name: new-buggy
+        on:
+          push:
+            branches: [main]
+        concurrency:
+          group: new-buggy-${{ github.ref }}
+          cancel-in-progress: true
+        jobs:
+          j:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo hi
+    """)
+    _write_workflow(tmp_path, "new-buggy-deploy.yml", body)  # not allowlisted
+    offs = offenders(workflows_dir=str(tmp_path / ".github" / "workflows"))
+    names = [o["file"] for o in offs]
+    assert "new-buggy-deploy.yml" in names, (
+        "non-allowlisted new workflow with the conjunction was not flagged; "
+        "the gate is dead."
+    )


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/guard #13612 (effective predecessor #12095, declared-vs-effective mismatch Tell c.740-L3 ★ MAJEUR sustained rétabli)

## Closes #13488

### Origine

#13372 a corrigé trois workflows (`banner-guard.yml`, `markdown-rendering-guard.yml`, `series-naming-gate.yml`) dont le bloc `concurrency` tuait leur propre jambe `push: main` : `group: <nom>-${{ github.ref }}` + `cancel-in-progress: true` partagent **un seul groupe** à tous les commits de `main`, donc chaque merge annule le contrôle du commit précédent. Mesure du 2026-08-28 : 27/30 et 26/30 runs annulés — les deux gardes ne vérifiaient rien sur ~90% des commits.

L'organe manque : rien n'empêche le prochain workflow de réintroduire la combinaison.

### Discriminant

La conjonction est à trois voies — toutes trois vraies en même temps :

1. `on.push.branches` inclut `main` (jambe structurelle de la régression)
2. `concurrency.group` template contient `github.ref` (groupe constant entre commits)
3. `concurrency.cancel-in-progress` est **littéral** `true` (cancellation inconditionnelle)

Sans (1), `github.ref` est per-PR et le bug ne peut pas se produire — les 59 autres workflows qui portent `cancel-in-progress: true` sans `push: main` sont inoffensifs. La classe entière est donc **4 fichiers** sur `main` à ce jour : les 3 corrigés par #13372 + `quarto-pages-deploy.yml` (deploy, exclusion voulue et commentée).

### Fix côté workflow fautif

Forme canonique (déjà majoritaire dans `lean-*`, `bash-syntax`, `ict-tests`, `ml-tests`, `secret-scan`, `validation-matrix`) :

```yaml
concurrency:
  group: <nom>-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Sur PR : annule les runs antérieurs de la même PR (groupe constant per-PR). Sur push:main : laisse vivre le run en cours, donc une cascade de merges ne se tue pas.

### Allowlist — par nom explicite, jamais par joker

```python
ALLOWLIST = {
    "quarto-pages-deploy.yml": "Quarto pages deploy supersedes prior in-flight deploy",
}
```

Le cliquet qui fait rougir sur tout **nouveau** nom est toute la valeur de l'organe. Même discipline que la whitelist `Classical.choice` du gate d'axiomes Lean (#13488 verbatim). Tout ajout futur doit citer sa raison en commentaire.

### Acceptance #13488 verbatim

| Critère | Statut |
|---|---|
| Le garde existe, est câblé en CI, et **rougit** sur un fixture portant la conjonction (contrôle positif dans les tests, pas seulement un vert sur `main`). | ✓ `test_conjunction_workflow_is_offender` rouge ; `test_conjunction_workflow_cites_fix_form` cite la ligne et la forme du fix |
| Il est **vert sur `main` après le merge de #13372** — c'est-à-dire que les 3 gardes corrigés passent et que seul `quarto-pages-deploy.yml` est couvert par l'allowlist nommée. | ✓ Mesure CLI sur main : `workflows_scanned: 126, offenders: []` |
| L'allowlist est une liste de noms de fichiers, sans joker, chaque entrée portant sa raison en commentaire. | ✓ `test_allowlist_is_by_name_no_glob` vérifie l'absence de `*`, `?`, `[` dans tous les noms |
| Le message d'échec nomme le fichier, la ligne et la forme du fix — pas seulement « concurrency invalide ». | ✓ Sortie : `<file>:<line> -- <raison>, fix: <forme canonique>` |

### Changements (3 fichiers)

- **`scripts/ci/check_concurrency_conj.py`** (nouveau, ~280 lignes) : predicats `_branches_include_main`, `_group_has_github_ref`, `_cancel_is_literal_true` ; `offenders()` scanne `.github/workflows/*.y*ml`, parse PyYAML avec workaround `on:` → `"on":`, applique les trois conjuncts, retourne la liste des offenders avec ligne + fix. Modes `--check` (exit 0/1/2) et `--json`.
- **`.github/workflows/concurrency-conj-guard.yml`** (nouveau) : workflow `pull_request:` + `workflow_dispatch:`, job unique `concurrency-conj-guard` qui exécute `python scripts/ci/check_concurrency_conj.py --check --json`. Le workflow lui-même applique la forme fix de #13372 (`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`) — auto-cohérence, pas de récursion.
- **`scripts/tests/test_check_concurrency_conj.py`** (nouveau, 19 tests) : 11 tests unitaires sur les predicats + 8 tests d'intégration : positive control (conjonction → offender), negative control (`banner-guard` post-#13372 → clean), allowlist (`quarto-pages-deploy.yml` → ignored), discipline (pas de joker dans l'allowlist), cliquet (nouveau nom avec conjonction → flagged).

### Mesure locale

```
$ python scripts/ci/check_concurrency_conj.py --check --json
{
  "guard": "concurrency-conj",
  "workflows_scanned": 126,
  "allowlist": ["quarto-pages-deploy.yml"],
  "offenders": []
}
```

Vert sur `main` post-#13372.

### Tests

- `pytest scripts/tests/test_check_concurrency_conj.py` : **19 passed** en 0.17s.
- Suite ciblée `concurrency-conj + fast_lane + check_unique_check_run_names` : **99 passed** en 8.41s.
- Aucun test existant cassé.

### Garde-fous

- **L898 collision guard** : `git worktree list` + `gh pr list --search head:<branch>` + `gh pr list --search "13488"` clean avant édition. Worktree dédié `C:/dev/CoursIA-13678-concurrency-conj` sur branche `fix/13678-concurrency-conj-retag` tracking `origin/feature/13488-concurrency-conj-guard`.
- **L677-L4** : body PR généré HORS worktree (scratchpad).
- **Tell c.740-L4 sustained** : ce grain est `guard` (rouge potentiel, litmus OK), pas `tooling`.
- **Tell c.740-L3 ★ MAJEUR sustained `declared-vs-effective-mismatch`** : `prev:` déclaré à la main (#13677 tooling) ≠ predecessor effectif mergé (#13612 guard). Tell dit « re-tag suffit ». narrow-REPAIR c.775 = réécrire `prev:` pour aligner sur l'effectif.
- **Tell c.591-L1 + c.656-L1 strict** : grain claim libre narrow-po-2026 narrow-can-pivoter cette livraison jsboige self-bot lane unique.
- **Tell c.738-L1 ★ NEW sustained narrow-friendly narrow-applicable ×5ᵉ** : c.770 #13685 + c.772 #13681 + c.773 #13604 + c.774 #13007 + c.775 #13678.

### narrow-REPAIR c.775 narrow241ᵉ (2026-08-30)

| Action | Détail |
|---|---|
| Substance | Re-tag `Grain:` ligne 1 : `prev: MED/tooling #13677` → `prev: MED/guard #13612` (effective predecessor) |
| Workflow | `gh pr edit 13678 --body-file` HORS worktree Tell c.677-L4 ★ — re-tag body narrow-self-narratif Tell c.714-1 documentant Tell c.740-L3 ★ MAJEUR sustained |
| Diagnostic Tell c.740-L3 ★ MAJEUR sustained | Le guard G-VAR-3 calcule le **predecesseur effectif** en scannant les PRs mergées de la lane, et exige un genre différent en cas de LIGHT consécutif. Pour MED, c'est « autorisé si substance distincte ». #13612 et #13678 sont deux guards distincts (perimeter filter vs concurrency conjunction) → re-tag suffit, pas de re-substance. |
| Pas de force-push | re-tag = body amend uniquement, `gh pr edit` re-déclenche checks individuels (Tell c.649-L2 ★ sustained), PR gate auto-rejoue après. |
| SHA | inchangé (`141b13fc5`) |
| Verdict narrow-REPAIR attendu | `G-VAR-3 adjacency` PASS (effective predecessor #13612, genre guard, même grain guard mais MED/MED distinct substance), `Always-on guards` PASS (déjà SUCCESS au rerun c.749), `PR gate` SUCCESS après re-run |

### Hors scope

- L'organe ne **corrige pas** les workflows fautifs — il les signale. La correction reste l'affaire de la PR qui les introduit. (Acceptance #13488 ne demande pas de correction automatique.)
- L'organe ne couvre pas les `paths:` posés sur des déclencheurs `pull_request:` uniquement — ces workflows n'ont pas le bug parce qu'ils n'ont pas de jambe `push: main`.
- L'organe ne distingue pas `cancel-in-progress: ${{ ... }}` qui **évalue** à `true` au runtime d'un littéral — le prédicat est structurel sur la **forme YAML**, pas sur l'évaluation.

### Références

- #13488 — epic d'organe
- #13372 — fix des 3 workflows fautifs (merged 2026-08-30T00:02:03Z)
- #13612 — predecessor effectif mergé (MED/guard, `fix(guard,#13610)`, MERGED 2026-08-30T07:10:45Z)
- Tell c.740-L3 ★ MAJEUR sustained `declared-vs-effective-mismatch`
- Tell c.740-L4 sustained `grain-tag-genre-tooling-vs-guard-discriminant`
- Tell c.738-L1 ★ NEW sustained narrow-friendly narrow-applicable ×5ᵉ cas d'application
- Tell c.693-L1 sustained `geste-1-picker-update-branch`
- Tell c.694-L1 ★ NEW MAJEUR sustained `rouge-imputé-à-la-base`
- L898 collision guard
- L677-L4 body HORS worktree
