### PR TITLE
fix(translation,#13551): resynchro per-cellule des 47 cellules SRC_DRIFT chaudes + 29 retraductions EN/RU + cliquet hot-subset

### DIFF
--- a/scripts/translation/tests/test_hot_subset_ratchet.py
+++ b/scripts/translation/tests/test_hot_subset_ratchet.py
@@ -1,0 +1,185 @@
+"""Hot-subset ratchet for translation SRC_DRIFT (#13551).
+
+Issue #13551 fixed the 47 hot cells repo-wide — cells whose source notebook
+drifted (``SRC_DRIFT``) WHILE carrying at least one deposited translation
+(``text_<lang>`` non-empty for a target language). Those rows are the ones
+where drift destroys real linguistic work: the deposited translation no
+longer matches the notebook it claims to translate. The 2000 remaining
+``SRC_DRIFT`` rows have NO deposited translation (pre-T3 pivot-only rows) —
+resyncing them is the "resync-only" pattern suspended by the coordinator
+ruling on #6949 (2026-07-28), so the ratchet deliberately does NOT cover
+them.
+
+This test pins the hot subset at zero: from now on, any FR edit to a cell
+that already carries a translation, landed without resyncing its CSV row,
+turns the suite red — exactly the regression #13551 was opened for. The fix
+procedure is per-cell (update ``text_fr``/``src_hash``/``hash_fr`` from the
+current notebook source, re-translate ``text_<lang>``/``hash_<lang>`` when
+the change is material) — NEVER a global re-extraction, which orphans the
+deposited translations (the trap documented in the issue).
+
+Two layers:
+- ``test_hot_subset_is_zero`` — the ratchet over the real repo tree
+  (skipped when the repo layout is absent, e.g. hermetic packaging runs).
+- ``test_hot_subset_semantics`` — a hermetic tmp_path fixture pinning the
+  *definition* of the hot subset (SRC_DRIFT + deposited translation), so a
+  future refactor of ``check_csv`` that drops the SRC_DRIFT verdict or
+  renames the ``text_<lang>`` columns is caught independently of the repo
+  state.
+
+stdlib-only, no network. Mirrors the skip style of
+``test_translation_sync_t4_scope.py``.
+"""
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TRANSLATION_DIR = HERE.parent
+REPO_ROOT = TRANSLATION_DIR.parent.parent
+sys.path.insert(0, str(TRANSLATION_DIR))
+
+import check_translation_sync as t2  # noqa: E402
+from check_perimeter import TARGET_LANGS  # noqa: E402
+
+HEADER = [
+    "notebook", "cell_id", "cell_type", "src_lang", "src_hash", "text_fr",
+    "text_en", "text_es", "text_ar", "text_fa", "text_zh", "text_ru", "text_pt",
+    "hash_fr", "hash_en", "hash_es", "hash_ar", "hash_fa", "hash_zh",
+    "hash_ru", "hash_pt", "translate_policy",
+]
+
+
+def hot_anomalies(csv_path: Path, repo_root: Path) -> list[dict]:
+    """SRC_DRIFT anomalies on rows that carry at least one deposited translation."""
+    anomalies = t2.check_csv(csv_path, repo_root)
+    with csv_path.open(encoding="utf-8-sig") as f:
+        deposited = {
+            row.get("cell_id", ""): any(
+                (row.get(f"text_{lang}", "") or "").strip()
+                for lang in TARGET_LANGS
+            )
+            for row in csv.DictReader(f)
+            if row.get("cell_id")
+        }
+    return [
+        a for a in anomalies
+        if a.get("verdict") == "SRC_DRIFT" and deposited.get(a.get("cell_id", ""), False)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Ratchet over the real repo
+# ---------------------------------------------------------------------------
+
+
+def test_hot_subset_is_zero():
+    """Repo-wide SRC_DRIFT rows carrying a deposited translation == 0 (#13551).
+
+    If this fails: an FR notebook edit landed on a cell that has a
+    translation, without resyncing its CSV row. Fix per-cell (see the issue
+    procedure) — do NOT run a global re-extraction, it orphans translations.
+    """
+    translations = REPO_ROOT / "translations"
+    notebooks = REPO_ROOT / "MyIA.AI.Notebooks"
+    if not translations.is_dir() or not notebooks.is_dir():
+        pytest.skip("repo tree not present (test expects repo checkout)")
+    hot: list[dict] = []
+    for csv_path in sorted(translations.rglob("*.csv")):
+        hot.extend(hot_anomalies(csv_path, REPO_ROOT))
+    assert hot == [], (
+        f"{len(hot)} hot cell(s): SRC_DRIFT on rows with deposited "
+        f"translations — resync per-cell (never global extraction, #13551). "
+        f"First offenders: {[ (a['notebook'], a['cell_id']) for a in hot[:5] ]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hermetic semantics of the hot-subset definition
+# ---------------------------------------------------------------------------
+
+
+def _write_nb(path: Path, cells: list[tuple[str, str]]) -> None:
+    import json
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "id": cid, "metadata": {},
+             "source": text.splitlines(keepends=True)}
+            for cid, text in cells
+        ],
+        "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb, ensure_ascii=False), encoding="utf-8")
+
+
+def _write_csv(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=HEADER, lineterminator="\n")
+        w.writeheader()
+        for r in rows:
+            w.writerow({k: r.get(k, "") for k in HEADER})
+
+
+def test_hot_subset_semantics(tmp_path):
+    """SRC_DRIFT counts as hot ONLY when a translation is deposited.
+
+    Three rows against one notebook whose cells have drifted past their
+    stored src_hash: one with an EN translation (hot), one RU-only (hot),
+    one pivot-only with no translation (NOT hot — resync-only territory,
+    suspended per #6949).
+    """
+    nb_rel = "series/demo.ipynb"
+    _write_nb(tmp_path / nb_rel, [
+        ("cell-a", "# Titre A\n\nTexte A actuel." + " " * 10),  # drift + padding
+        ("cell-b", "# Titre B\n\nTexte B actuel." + " " * 10),
+        ("cell-c", "# Titre C\n\nTexte C actuel." + " " * 10),
+    ])
+    csv_path = tmp_path / "translations" / "demo.csv"
+    _write_csv(csv_path, [
+        {
+            "notebook": nb_rel, "cell_id": "cell-a", "cell_type": "markdown",
+            "src_lang": "fr", "src_hash": "deadbeefdeadbeef",
+            "text_fr": "# Titre A\n\nTexte A ancien.",
+            "text_en": "# Title A\n\nOld A text.",
+        },
+        {
+            "notebook": nb_rel, "cell_id": "cell-b", "cell_type": "markdown",
+            "src_lang": "fr", "src_hash": "deadbeefdeadbeef",
+            "text_fr": "# Titre B\n\nTexte B ancien.",
+            "text_ru": "# Заголовок B\n\nСтарый текст B.",
+        },
+        {
+            "notebook": nb_rel, "cell_id": "cell-c", "cell_type": "markdown",
+            "src_lang": "fr", "src_hash": "deadbeefdeadbeef",
+            "text_fr": "# Titre C\n\nTexte C ancien.",
+        },
+    ])
+    hot = hot_anomalies(csv_path, tmp_path)
+    hot_ids = sorted(a["cell_id"] for a in hot)
+    assert hot_ids == ["cell-a", "cell-b"], (
+        f"hot subset must be exactly the SRC_DRIFT rows with deposited "
+        f"translations, got {hot_ids}"
+    )
+    # And once the CSV rows are resynced to the current source, hot -> 0.
+    with csv_path.open(encoding="utf-8-sig") as f:
+        rows = list(csv.DictReader(f))
+    for r in rows:
+        new_fr = {
+            "cell-a": "# Titre A\n\nTexte A actuel." + " " * 10,
+            "cell-b": "# Titre B\n\nTexte B actuel." + " " * 10,
+            "cell-c": "# Titre C\n\nTexte C actuel." + " " * 10,
+        }[r["cell_id"]]
+        h = t2.cell_hash(new_fr)
+        r["text_fr"], r["src_hash"], r["hash_fr"] = new_fr, h, h
+    _write_csv(csv_path, rows)
+    assert hot_anomalies(csv_path, tmp_path) == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/translations/genai/casestudies.csv
+++ b/translations/genai/casestudies.csv
@@ -110,16 +110,16 @@ contrainte_choisie = random.choice(CONTRAINTES)
 print(f""Contrainte choisie : {contrainte_choisie[0]}"")
 print(""Contraintes de debate definies"")
 ",,,,,,,,91dea5ab52872319,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb,994f885c,markdown,fr,0a2e6e8ca6a4ff4d,"### Exercice 1 : Ajout de contraintes linguistiques personnalisees
+MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb,994f885c,markdown,fr,4cdf01e9df587ae6,"### Exercice 1 : Ajout de contraintes linguistiques personnalisees
 
 La liste `CONTRAINTES` contient actuellement trois styles (Rime, Shakespeare, Chanson). L'objectif est d'enrichir cette liste avec de nouvelles contraintes originales pour varier les debats.
 
 **Objectif** : ajouter au moins deux nouvelles contraintes a la liste, par exemple un style ""Haiku japonais"" (3 lignes, 5-7-5 syllabes) ou ""Code Python"" (repondre en utilisant la syntaxe Python).
 
 **Indices** :
-- # Étape 1 : Définir le nom et la description de chaque nouvelle contrainte
-- # Étape 2 : Ajouter les tuples `(nom, description)` a la liste `CONTRAINTES`
-- # Indice : respecter le format existant `(""Nom"", ""Description de la règle"")`","### Exercise 1: Adding custom linguistic constraints
+- `# Étape 1` : Définir le nom et la description de chaque nouvelle contrainte
+- `# Étape 2` : Ajouter les tuples `(nom, description)` a la liste `CONTRAINTES`
+- `# Indice` : respecter le format existant `(""Nom"", ""Description de la règle"")`","### Exercise 1: Adding custom linguistic constraints
 
 The list `CONTRAINTES` currently contains three styles (Rhyme, Shakespeare, Song). The objective is to enrich this list with new original constraints to vary the debates.
 
@@ -137,7 +137,7 @@ The list `CONTRAINTES` currently contains three styles (Rhyme, Shakespeare, Song
 **Подсказки**:
 - # Шаг 1: Определить название и описание каждого нового ограничения
 - # Шаг 2: Добавить кортежи `(nom, description)` в список `CONTRAINTES`
-- # Подсказка: соблюдать существующий формат `(""Nom"", ""Description de la regle"")`",,0a2e6e8ca6a4ff4d,b724361e61303365,,,,,5ef3fd17d79563be,,
+- # Подсказка: соблюдать существующий формат `(""Nom"", ""Description de la regle"")`",,4cdf01e9df587ae6,b724361e61303365,,,,,5ef3fd17d79563be,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb,bc6ea55e,code,fr,f432d5f6398f7544,"# Exercice 1 : Ajout de contraintes linguistiques personnalisees
 # TODO etudiant : ajouter de nouvelles contraintes a la liste
 
@@ -254,16 +254,16 @@ ane = ChatCompletionAgent(
 print(""Kernels et agents Barbie/Ane créés"")
 print(""Kernels et agents Barbie/Ane crees"")
 ",,,,,,,,1f0f1331f3840fff,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb,404418f6,markdown,fr,273a626ac02550fb,"### Exercice 2 : Creation d'un troisieme agent
+MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb,404418f6,markdown,fr,7840938551e2026d,"### Exercice 2 : Creation d'un troisieme agent
 
 Le debat oppose actuellement Barbie et l'Ane de Shrek. L'objectif est d'ajouter un **troisieme personnage** au debat : un **Arbitre** qui commente les performances des deux duellistes a chaque tour.
 
 **Objectif** : créer un agent `ChatCompletionAgent` nomme ""Arbitre"" avec un kernel separe et des instructions système qui lui demandent de juger la qualite des repliques (respect de la contrainte, creativite, humour).
 
 **Indices** :
-- # Étape 1 : Créer un kernel dedie pour l'Arbitre avec `create_kernel()`
-- # Étape 2 : Définir les instructions de l'Arbitre (rôle, comportement attendu)
-- # Indice : s'inspirer des instructions de Barbie et l'Ane pour le format du prompt","### Exercise 2: Creating a third agent
+- `# Étape 1` : Créer un kernel dedie pour l'Arbitre avec `create_kernel()`
+- `# Étape 2` : Définir les instructions de l'Arbitre (rôle, comportement attendu)
+- `# Indice` : s'inspirer des instructions de Barbie et l'Ane pour le format du prompt","### Exercise 2: Creating a third agent
 
 The debate currently pits Barbie against Shrek's Donkey. The objective is to add a **third character** to the debate: a **Referee** who comments on the performance of the two duelists at each turn.
 
@@ -281,7 +281,7 @@ The debate currently pits Barbie against Shrek's Donkey. The objective is to add
 **Подсказки** :
 - # Шаг 1 : Создать отдельный kernel для Арбитра с `create_kernel()`
 - # Шаг 2 : Определить инструкции Арбитра (роль, ожидаемое поведение)
-- # Подсказка : ориентироваться на инструкции Барби и Осла для формата prompt",,273a626ac02550fb,50631333c252abb1,,,,,bc7018a23755617d,,
+- # Подсказка : ориентироваться на инструкции Барби и Осла для формата prompt",,7840938551e2026d,50631333c252abb1,,,,,bc7018a23755617d,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb,7416b1e6,code,fr,ed3e4a9e5c19b1c7,"# Exercice 2 : Creation d'un troisieme agent (Arbitre)
 # TODO etudiant : creer le kernel et l'agent Arbitre
 
@@ -389,16 +389,16 @@ This notebook made it possible to explore the essential aspects of barbie schrec
 - Полученные результаты позволяют подтвердить понимание
 
 **Чтобы пойти дальше** : углубить продвинутые аспекты темы и изучить связи с другими областями.",,316fbae5c5b251e1,d1bb8d233230e123,,,,,fb1a327d9893f9b6,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb,f27b1648,markdown,fr,41e072aee0ff0a6b,"### Exercice 3 : Stratégie de terminaison personnalisee
+MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb,f27b1648,markdown,fr,fecafb23eb00309e,"### Exercice 3 : Stratégie de terminaison personnalisee
 
 L'implementation actuelle arrete le debat après un nombre fixe de tours (`MAX_TURNS = 5`). Imaginez un scénario ou le debat doit s'arreter dynamiquement selon le contenu des messages.
 
 **Objectif** : implementer une stratégie de terminaison qui detecte quand un des deux personnages utilise un mot spécifique (par exemple ""capituler"" ou ""abandon"") dans sa reponse, et arrete le debat immediatement.
 
 **Indices** :
-- # Étape 1 : Définir une liste de mots-cles declencheurs
-- # Étape 2 : Dans `should_terminate`, verifier si le dernier message contient un mot-cle
-- # Indice : utiliser `str(history[-1].content).lower()` pour lire le dernier message","### Exercise 3: Custom termination strategy
+- `# Étape 1` : Définir une liste de mots-cles declencheurs
+- `# Étape 2` : Dans `should_terminate`, verifier si le dernier message contient un mot-cle
+- `# Indice` : utiliser `str(history[-1].content).lower()` pour lire le dernier message","### Exercise 3: Custom termination strategy
 
 The current implementation stops the debate after a fixed number of turns (`MAX_TURNS = 5`). Imagine a scenario where the debate must stop dynamically based on the content of the messages.
 
@@ -416,7 +416,7 @@ The current implementation stops the debate after a fixed number of turns (`MAX_
 **Подсказки**:
 - # Шаг 1: определить список ключевых слов-триггеров
 - # Шаг 2: в `should_terminate` проверить, содержит ли последнее сообщение ключевое слово
-- # Подсказка: использовать `str(history[-1].content).lower()` для чтения последнего сообщения",,41e072aee0ff0a6b,7dd447e14942a53a,,,,,2ce0893532f86941,,
+- # Подсказка: использовать `str(history[-1].content).lower()` для чтения последнего сообщения",,fecafb23eb00309e,7dd447e14942a53a,,,,,2ce0893532f86941,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb,97ca931e,code,fr,c652ac2f77f73d39,"from typing import ClassVar
 from semantic_kernel.agents.strategies.termination.termination_strategy import TerminationStrategy
 
@@ -528,16 +528,16 @@ Tu es Laurent Jalabert.
 Tu dois deviner le mot en posant des questions fermées (Oui/Non).
 Sois perspicace et stratégique dans tes questions.
 """"""",,,,,,,,7f877f1f31e39469,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb,649ac34e,markdown,fr,d9b13514009d0853,"### Exercice 1 : Personnaliser les personnages du duel
+MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb,649ac34e,markdown,fr,f85a9ba7239d19b5,"### Exercice 1 : Personnaliser les personnages du duel
 
 Les prompts actuels definissent le Pere Fouras comme enigmatique et Laurent Jalabert comme perspicace. L'objectif est de créer une variante du jeu avec deux personnages différents : un **Detective** (qui pose des questions deductives) et un **Temoin** (qui repond de maniere evasive sans reveler le mot).
 
 **Objectif** : ecrire les instructions système pour ces deux nouveaux personnages et configurer les agents correspondants.
 
 **Indices** :
-- # Étape 1 : Rediger le prompt du Temoin (rôle, règles, interdictions)
-- # Étape 2 : Rediger le prompt du Detective (stratégie de questionnement)
-- # Indice : le Temoin ne doit jamais reveler le mot directement, mais peut donner des indices indirects
+- `# Étape 1` : Rediger le prompt du Temoin (rôle, règles, interdictions)
+- `# Étape 2` : Rediger le prompt du Detective (stratégie de questionnement)
+- `# Indice` : le Temoin ne doit jamais reveler le mot directement, mais peut donner des indices indirects
 ","### Exercise 1: Customize the duel characters
 
 The current prompts define Père Fouras as enigmatic and Laurent Jalabert as perceptive. The goal is to create a variant of the game with two different characters: a **Detective** (who asks deductive questions) and a **Witness** (who answers evasively without revealing the word).
@@ -556,7 +556,7 @@ The current prompts define Père Fouras as enigmatic and Laurent Jalabert as per
 **Подсказки**:
 - # Шаг 1: Написать промпт Свидетеля (роль, правила, запреты)
 - # Шаг 2: Написать промпт Детектива (стратегия задавания вопросов)
-- # Подсказка: Свидетель никогда не должен раскрывать слово напрямую, но может давать косвенные намёки",,d9b13514009d0853,702065354fbe0277,,,,,3295a1f8a4a7068b,,
+- # Подсказка: Свидетель никогда не должен раскрывать слово напрямую, но может давать косвенные намёки",,f85a9ba7239d19b5,702065354fbe0277,,,,,3295a1f8a4a7068b,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb,ac94f4f0,code,fr,fb5c1ca4effe98b3,"# Exercice 1 : Personnaliser les personnages du duel
 # TODO etudiant : definir les prompts et creer les agents
 
@@ -610,16 +610,16 @@ class FortBoyardTerminationStrategy(TerminationStrategy):
         
         last_message = str(history[-1].content).lower()
         return MOT_A_DEVINER in last_message",,,,,,,,c41a211f227072d5,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb,81de6677,markdown,fr,7339f61c3795e280,"### Exercice 2 : Terminaison avec detection de renoncement
+MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb,81de6677,markdown,fr,5636696f2d83887e,"### Exercice 2 : Terminaison avec detection de renoncement
 
 La stratégie actuelle arrete la partie uniquement si le mot est devine. Mais Laurent Jalabert pourrait aussi abandonner. L'objectif est de créer une stratégie hybride qui arrete la partie si le mot est devine **ou** si Laurent exprime un renoncement (""je donne ma langue au chat"", ""j'abandonne"").
 
 **Objectif** : implementer `RenoncementTerminationStrategy` qui combine la detection du mot secret avec la detection de phrases d'abandon.
 
 **Indices** :
-- # Étape 1 : Définir une liste de phrases d'abandon typiques
-- # Étape 2 : Verifier si le dernier message contient une de ces phrases (en minuscules)
-- # Indice : combiner les deux conditions avec `or` dans `should_agent_terminate`
+- `# Étape 1` : Définir une liste de phrases d'abandon typiques
+- `# Étape 2` : Verifier si le dernier message contient une de ces phrases (en minuscules)
+- `# Indice` : combiner les deux conditions avec `or` dans `should_agent_terminate`
 ","### Exercise 2: Termination with giving-up detection
 
 The current strategy stops the game only if the word is guessed. But Laurent Jalabert could also give up. The goal is to create a hybrid strategy that stops the game if the word is guessed **or** if Laurent expresses giving up (""je donne ma langue au chat"", ""j'abandonne"").
@@ -638,7 +638,7 @@ The current strategy stops the game only if the word is guessed. But Laurent Jal
 **Подсказки** :
 - # Шаг 1 : Определить список типичных фраз отказа
 - # Шаг 2 : Проверить, содержит ли последнее сообщение одну из этих фраз (в нижнем регистре)
-- # Подсказка : объединить два условия с помощью `or` в `should_agent_terminate`",,7339f61c3795e280,e3514d8d5c1a8cd7,,,,,95bd36831fc14824,,
+- # Подсказка : объединить два условия с помощью `or` в `should_agent_terminate`",,5636696f2d83887e,e3514d8d5c1a8cd7,,,,,95bd36831fc14824,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb,0e96e11d,code,fr,9a91cbf579858a4b,"from semantic_kernel.agents.strategies.termination.termination_strategy import TerminationStrategy
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 
@@ -692,16 +692,16 @@ async def jouer_partie():
     logger.info(""Partie terminee !"")
 
 await jouer_partie()",,,,,,,,62bb9d8c5d80b76b,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb,9c2a66c0,markdown,fr,bf62274e238b1e95,"### Exercice 3 : Système de score pour la partie
+MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb,9c2a66c0,markdown,fr,c31399d55a9d3ca0,"### Exercice 3 : Système de score pour la partie
 
 Actuellement, la partie s'arrete simplement quand le mot est devine ou après 20 itérations. L'objectif est d'ajouter un **système de score** qui compte le nombre de questions posees par Laurent Jalabert et affiche un score final.
 
 **Objectif** : ecrire une fonction `evaluer_partie` qui prend l'historique des messages et retourne un dictionnaire contenant le nombre de questions posees, si le mot a ete trouve, et un score (moins de questions = meilleur score).
 
 **Indices** :
-- # Étape 1 : Compter les messages ou le rôle est celui de Laurent Jalabert
-- # Étape 2 : Verifier si le mot secret apparait dans le dernier message
-- # Indice : le score peut etre `max(0, 100 - nb_questions * 10)`
+- `# Étape 1` : Compter les messages ou le rôle est celui de Laurent Jalabert
+- `# Étape 2` : Verifier si le mot secret apparait dans le dernier message
+- `# Indice` : le score peut etre `max(0, 100 - nb_questions * 10)`
 ","### Exercise 3: Scoring system for the game
 
 Currently, the game simply stops when the word is guessed or after 20 iterations. The objective is to add a **scoring system** that counts the number of questions asked by Laurent Jalabert and displays a final score.
@@ -720,7 +720,7 @@ Currently, the game simply stops when the word is guessed or after 20 iterations
 **Подсказки** :
 - # Шаг 1 : Посчитать сообщения, где роль принадлежит Laurent Jalabert
 - # Шаг 2 : Проверить, появляется ли секретное слово в последнем сообщении
-- # Подсказка : счет может быть `max(0, 100 - nb_questions * 10)`",,bf62274e238b1e95,c822d0052a5eb4da,,,,,f3277f163627f847,,
+- # Подсказка : счет может быть `max(0, 100 - nb_questions * 10)`",,c31399d55a9d3ca0,c822d0052a5eb4da,,,,,f3277f163627f847,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb,df0d3126,code,fr,c67bed915c276918,"def evaluer_partie(history_messages: list) -> dict:
     # TODO etudiant : implementer le systeme de score
     nb_questions = 0     # Etape 1 : compter les questions de Laurent
@@ -1219,7 +1219,7 @@ Ce notebook couvre les concepts et techniques principaux de receipe maker. Les o
 This notebook covers the main concepts and techniques of receipe maker. The educational objectives include understanding the fundamentals, hands-on practice through exercises, and analysis of results.
 
 **Prerequisites**: basic knowledge of Python and algorithms.",,,,,,,b1f5bd83b925e4a6,7cb8a3487c589e05,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,75e5f73c,markdown,fr,95fbf4fb32daa3b1,"
+MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,75e5f73c,markdown,fr,16d73e913af0445e,"
 Ce notebook orchestre une collaboration multi-agents pour :
 1. Collecter des contraintes utilisateur
 2. Générer une recette personnalisée
@@ -1230,7 +1230,7 @@ Ce notebook orchestre une collaboration multi-agents pour :
 - `RecipeGenerator` → Crée la recette via LLM  
 - `PDFGenerator` → Génère le document final
 
----","This notebook orchestrates a multi-agent collaboration to:
+***","This notebook orchestrates a multi-agent collaboration to:
 1. Collect user constraints
 2. Generate a personalized recipe
 3. Produce a styled PDF
@@ -1240,7 +1240,7 @@ Ce notebook orchestre une collaboration multi-agents pour :
 - `RecipeGenerator` → Creates the recipe via LLM  
 - `PDFGenerator` → Generates the final document
 
----",,,,,,,95fbf4fb32daa3b1,4c86de0038c622f6,,,,,,,
+---",,,,,,,16d73e913af0445e,4c86de0038c622f6,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,348b305b,markdown,fr,40dc4809315fd66b,"### Installation des bibliothèques
 
 **Pourquoi ce notebook s'appuie sur Semantic Kernel et non sur un simple appel d'API** : générer une recette structurée (titre, ingrédients listés, étapes numérotées, respect des contraintes diététiques) en une seule requête LLM produit un résultat au format libre et souvent incohérent. Semantic Kernel orchestre **plusieurs agents spécialisés** (collecteur de critères, générateur de recette, validateur de contraintes) qui se passent un état partagé — c'est l'architecture *multi-agent* qui garantit que la recette finale respecte toutes les contraintes (végétarien, sans champignons, 6 convives). Les *import guards* de la cellule suivante rendent chaque dépendance optionnelle explicite : le notebook fonctionne en mode dégradé sans crasher si une librairie manque, ce qui est la robustesse attendue d'un cas d'étude exécutable sur des environnements hétérogènes.",### Installing libraries,,,,,,,40dc4809315fd66b,37ae75552eece061,,,,,,,
@@ -1279,16 +1279,16 @@ MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,bc1a675a,co
 print(""Classe RecipeState définie"")
 print(""Classe RecipeState definie"")
 ",,,,,,,,0e94d64476bc179f,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,9227aa4c,markdown,fr,f7a717c42394a412,"### Exercice 1 : Enrichir l'etat partage avec des préférences culinaires
+MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,9227aa4c,markdown,fr,e3057c4d9e6e52a7,"### Exercice 1 : Enrichir l'etat partage avec des préférences culinaires
 
 La classe `RecipeState` stocke le regime, les ingredients exclus et le nombre de convives. L'objectif est de l'enrichir avec de nouveaux champs : **niveau de difficulte** (debutant, intermediaire, expert), **temps de preparation maximum**, et **cuisine preferee** (francaise, italienne, asiatique, etc.).
 
 **Objectif** : etendre `RecipeState` avec ces nouveaux attributs et créer les méthodes de mise a jour correspondantes.
 
 **Indices** :
-- # Étape 1 : Ajouter les attributs `difficulty`, `max_prep_time` et `cuisine_type` dans `__init__`
-- # Étape 2 : Créer les méthodes `set_difficulty`, `set_max_prep_time` et `set_cuisine`
-- # Indice : suivre le pattern existant des autres attributs (type hints + valeur par defaut)","### Exercise 1: Enrich the shared state with culinary preferences
+- `# Étape 1` : Ajouter les attributs `difficulty`, `max_prep_time` et `cuisine_type` dans `__init__`
+- `# Étape 2` : Créer les méthodes `set_difficulty`, `set_max_prep_time` et `set_cuisine`
+- `# Indice` : suivre le pattern existant des autres attributs (type hints + valeur par defaut)","### Exercise 1: Enrich the shared state with culinary preferences
 
 The `RecipeState` class stores the diet, excluded ingredients, and number of guests. The goal is to enrich it with new fields: **difficulty level** (beginner, intermediate, expert), **maximum preparation time**, and **preferred cuisine** (French, Italian, Asian, etc.).
 
@@ -1297,7 +1297,7 @@ The `RecipeState` class stores the diet, excluded ingredients, and number of gue
 **Hints**:
 - # Step 1: Add the attributes `difficulty`, `max_prep_time`, and `cuisine_type` in `__init__`
 - # Step 2: Create the methods `set_difficulty`, `set_max_prep_time`, and `set_cuisine`
-- # Hint: follow the existing pattern of the other attributes (type hints + default value)",,,,,,,f7a717c42394a412,4dbc9c4426840334,,,,,,,
+- # Hint: follow the existing pattern of the other attributes (type hints + default value)",,,,,,,e3057c4d9e6e52a7,4dbc9c4426840334,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,26b00761,code,fr,147a59853e1b4967,"class ExtendedRecipeState(RecipeState):
     # TODO etudiant : enrichir l'etat avec les nouvelles preferences
     
@@ -1374,16 +1374,16 @@ class PDFGeneratorPlugin:
 
 print(""Imports Semantic Kernel OK"")
 ",,,,,,,,7676a3f01d078979,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,bb7a7733,markdown,fr,2c0c593182b801fb,"### Exercice 2 : Plugin d'estimation nutritionnelle
+MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,bb7a7733,markdown,fr,0e71fb41693ce1da,"### Exercice 2 : Plugin d'estimation nutritionnelle
 
 Les plugins actuels gerent la collecte d'informations et la generation de recette, mais aucune information nutritionnelle n'est fournie. L'objectif est d'ajouter un `NutritionPlugin` qui estime les calories et macronutriments d'une recette.
 
 **Objectif** : créer une classe `NutritionPlugin` avec une méthode `estimate_nutrition` annotee `@kernel_function` qui retourne une estimation des calories par portion.
 
 **Indices** :
-- # Étape 1 : Définir un dictionnaire approximatif de calories par ingredient de base
-- # Étape 2 : Calculer la somme des calories et diviser par le nombre de convives
-- # Indice : le dictionnaire peut contenir des valeurs moyennes (ex: poulet = 165 kcal/100g, riz = 130 kcal/100g)","### Exercise 2: Nutrition Estimation Plugin
+- `# Étape 1` : Définir un dictionnaire approximatif de calories par ingredient de base
+- `# Étape 2` : Calculer la somme des calories et diviser par le nombre de convives
+- `# Indice` : le dictionnaire peut contenir des valeurs moyennes (ex: poulet = 165 kcal/100g, riz = 130 kcal/100g)","### Exercise 2: Nutrition Estimation Plugin
 
 The current plugins handle information collection and recipe generation, but no nutritional information is provided. The goal is to add a `NutritionPlugin` that estimates the calories and macronutrients of a recipe.
 
@@ -1392,7 +1392,7 @@ The current plugins handle information collection and recipe generation, but no 
 **Hints**:
 - # Step 1: Define an approximate dictionary of calories per basic ingredient
 - # Step 2: Calculate the sum of calories and divide by the number of diners
-- # Hint: the dictionary can contain average values (e.g., chicken = 165 kcal/100g, rice = 130 kcal/100g)",,,,,,,2c0c593182b801fb,65fcf3c89b748e51,,,,,,,
+- # Hint: the dictionary can contain average values (e.g., chicken = 165 kcal/100g, rice = 130 kcal/100g)",,,,,,,0e71fb41693ce1da,65fcf3c89b748e51,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,2772b5c3,code,fr,5d667c20e03d1d49,"class NutritionPlugin:
     """"""Plugin d'estimation nutritionnelle pour les recettes.""""""
     
@@ -1544,16 +1544,16 @@ async def recipe_workflow():
 
 await recipe_workflow()
 ",,,,,,,,cbe3f4cd5b630217,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,3bc1868c,markdown,fr,d10efd1c4cd01470,"### Exercice 3 : Validation des contraintes avant generation
+MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,3bc1868c,markdown,fr,ae401f350b00deaa,"### Exercice 3 : Validation des contraintes avant generation
 
 Le workflow actuel lance la generation sans verifier que les contraintes sont coherentes. L'objectif est d'implementer une fonction `valider_contraintes` qui verifie la coherence des préférences utilisateur avant de les transmettre aux agents.
 
 **Objectif** : ecrire une fonction qui detecte les incoherences (par exemple : regime vegane + demande de fromage, nombre de convives negatif, ingredients exclus qui font partie du regime).
 
 **Indices** :
-- # Étape 1 : Définir les règles de validation (liste de conditions a verifier)
-- # Étape 2 : Retourner un tuple `(est_valide, liste_erreurs)` pour guider l'utilisateur
-- # Indice : utiliser des conditions if/elif pour chaque règle et accumuler les messages d'erreur","### Exercise 3: Constraint validation before generation
+- `# Étape 1` : Définir les règles de validation (liste de conditions a verifier)
+- `# Étape 2` : Retourner un tuple `(est_valide, liste_erreurs)` pour guider l'utilisateur
+- `# Indice` : utiliser des conditions if/elif pour chaque règle et accumuler les messages d'erreur","### Exercise 3: Constraint validation before generation
 
 The current workflow launches generation without checking that the constraints are coherent. The objective is to implement a function `valider_contraintes` that checks the coherence of user preferences before passing them on to the agents.
 
@@ -1562,7 +1562,7 @@ The current workflow launches generation without checking that the constraints a
 **Hints**:
 - # Step 1: Define the validation rules (list of conditions to check)
 - # Step 2: Return a tuple `(est_valide, liste_erreurs)` to guide the user
-- # Hint: use if/elif conditions for each rule and accumulate error messages",,,,,,,d10efd1c4cd01470,2e273de502a194ee,,,,,,,
+- # Hint: use if/elif conditions for each rule and accumulate error messages",,,,,,,ae401f350b00deaa,2e273de502a194ee,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,7d996ec0,code,fr,ebf2616347378ace,"def valider_contraintes(state: RecipeState) -> tuple[bool, list[str]]:
     # TODO etudiant : implementer la validation des contraintes
     erreurs = []
@@ -1574,9 +1574,15 @@ MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,7d996ec0,co
     return est_valide, erreurs
 
 print(""Exercice a completer : validation des contraintes"")",,,,,,,,ebf2616347378ace,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,5ffc461a,markdown,fr,17ba598a48f99ad0,"### Génération de pdf
+MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,5ffc461a,markdown,fr,d96962abde37f26e,"### Génération de pdf
 
-**Pourquoi exporter la recette en PDF (et pourquoi c'est l'étape la plus fragile)** : le PDF est le **livrable final** — ce que l'utilisateur emporte, imprime, partage. Tout le travail multi-agent aboutit à ce document. Mais la génération PDF dépend d'outils externes (librairie de rendu, polices, parfois LaTeX) qui peuvent échouer indépendamment du raisonnement LLM : une recette parfaite peut ne pas se matérialiser en PDF si l'outil de rendu manque. C'est pourquoi le verdict de la cellule suivante (« Échec de la génération : Aucun PDF produit ») **n'invalide pas** la recette elle-même — il signale un échec de l'étape d'export, pas du pipeline agent. Distinguer ces deux échecs (raisonnement vs rendu) est crucial pour diagnostiquer où corriger.",### PDF generation,,,,,,,17ba598a48f99ad0,7337d82a5a030cfb,,,,,,,
+**Pourquoi exporter la recette en PDF** : le PDF est le **livrable final** — ce que l'utilisateur emporte, imprime, partage. Tout le travail multi-agent aboutit à ce document, produit par `PDFGeneratorPlugin.generate_pdf` (`reportlab`, importé avec les plugins).
+
+**Le piège d'orchestration qui guette cette étape** : la conversation est pilotée par `ReadyTerminationStrategy`, qui interroge l'état partagé à chaque fin de tour. Si la stratégie termine sur `ready_to_generate` — le drapeau que pose `RecipeGenerator` au moment où il **valide** la recette — la conversation s'arrête **exactement au tour où `PDFGenerator` devrait parler** : l'agent figure dans la liste passée à `AgentGroupChat`, mais il est structurellement inatteignable. Aucune exception n'est levée ; la boucle se termine proprement, et l'échec se lit à tort comme un problème d'outil de rendu (librairie PDF, polices) alors que la cause est la **condition d'arrêt**. La règle appliquée ici : **terminer sur le livrable produit** (`state.pdf_path`), pas sur la demande de le produire.","### PDF generation
+
+**Why export the recipe as a PDF**: the PDF is the **final deliverable** — what the user takes away, prints, shares. The entire multi-agent pipeline leads to this document, produced by `PDFGeneratorPlugin.generate_pdf` (`reportlab`, imported with the plugins).
+
+**The orchestration trap lurking at this step**: the conversation is driven by `ReadyTerminationStrategy`, which queries the shared state at the end of every turn. If the strategy terminates on `ready_to_generate` — the flag `RecipeGenerator` sets when it **validates** the recipe — the conversation stops **exactly on the turn where `PDFGenerator` should speak**: the agent is listed in the roster passed to `AgentGroupChat`, but it is structurally unreachable. No exception is raised; the loop ends cleanly, and the failure reads as a rendering-tool problem (PDF library, fonts) when the actual cause is the **stop condition**. The rule applied here: **terminate on the produced deliverable** (`state.pdf_path`), not on the request to produce it.",,,,,,,d96962abde37f26e,1af0dfb61f161f6d,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,8cc84d56,code,fr,692e77e773af99fc,"pass
 
 print(""Workflow prêt"")
@@ -1591,7 +1597,7 @@ else:
     print(""Échec de la génération:"", 
           ""Aucun PDF produit malgré les tentatives"")
 ",,,,,,,,accd1b769f363219,,,,,,,,
-MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,644bdc70,markdown,fr,b79bb569a99e3b66,"## Conclusion
+MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb,644bdc70,markdown,fr,0935ba5b54f06f58,"## Conclusion
 
 Ce notebook a mis en oeuvre une collaboration multi-agents pour generer une recette personnalisee et produire un PDF.
 
@@ -1600,7 +1606,7 @@ Ce notebook a mis en oeuvre une collaboration multi-agents pour generer une rece
 - **Etat partage** : la classe `RecipeState` sert de memoire commune aux trois agents. Chaque plugin lit et ecrit dans cette instance unique, ce qui permet de transmettre les contraintes utilisateur jusqu'a la generation du PDF.
 - **Plugins et `@kernel_function`** : le decorateur `@kernel_function` expose les méthodes Python comme outils appelables par le LLM (`set_diet`, `submit_recipe`, `generate_pdf`).
 - **Orchestration `AgentGroupChat`** : les agents `InputCollector`, `RecipeGenerator` et `PDFGenerator` dialoguent dans une conversation de groupe, chacun avec son propre kernel et son service de chat.
-- **Stratégie de terminaison** : `ReadyTerminationStrategy` interroge l'etat partage (`ready_to_generate`) pour arreter la boucle des que la recette est validee.
+- **Stratégie de terminaison** : `ReadyTerminationStrategy` interroge l'etat partage (`pdf_path`) pour arreter la boucle des que le livrable PDF est produit -- terminer plus tot (sur `ready_to_generate`) rendrait l'agent `PDFGenerator` inatteignable.
 - **Configuration du service** : chaque kernel doit recevoir un service via `add_service` (ici `OpenAIChatCompletion`), faute de quoi l'invocation echoue avec `No service found`.
 
 **Pour aller plus loin** :
@@ -1617,14 +1623,14 @@ This notebook implemented a multi-agent collaboration to generate a personalized
 - **Shared state**: the `RecipeState` class serves as shared memory for the three agents. Each plugin reads from and writes to this single instance, which makes it possible to pass the user constraints through to PDF generation.
 - **Plugins and `@kernel_function`**: the `@kernel_function` decorator exposes Python methods as tools callable by the LLM (`set_diet`, `submit_recipe`, `generate_pdf`).
 - **`AgentGroupChat` orchestration**: the `InputCollector`, `RecipeGenerator`, and `PDFGenerator` agents interact in a group conversation, each with its own kernel and chat service.
-- **Termination strategy**: `ReadyTerminationStrategy` queries the shared state (`ready_to_generate`) to stop the loop as soon as the recipe is validated.
+- **Termination strategy**: `ReadyTerminationStrategy` queries the shared state (`pdf_path`) to stop the loop as soon as the PDF deliverable is produced — terminating earlier (on `ready_to_generate`) would leave the `PDFGenerator` agent unreachable.
 - **Service configuration**: each kernel must receive a service via `add_service` (here `OpenAIChatCompletion`), otherwise invocation fails with `No service found`.
 
 **To go further**:
 
 - Enhance the PDF with a styled layout (sections, images, ingredients table) via `reportlab.platypus`.
-- Connect a nutritional API to calculate the recipe’s calorie intake.
-- Generate an illustration of the dish with an image model and insert it into the document.",,,,,,,b79bb569a99e3b66,7685270ceeefe62c,,,,,,,
+- Connect a nutritional API to calculate the recipe's calorie intake.
+- Generate an illustration of the dish with an image model and insert it into the document.",,,,,,,0935ba5b54f06f58,cb2fbeed0db298ea,,,,,,,
 MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb,71023d39,markdown,fr,0f5fc1051b86009c,"### Lecture du résultat : le duel verbal réel
 
 L'exécution montre le protocole complet en action, tour par tour :

--- a/translations/genai/finetuning.csv
+++ b/translations/genai/finetuning.csv
@@ -413,13 +413,13 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-f42d
 # Observez comment le style de generation change.
 
 print(""Exercice a completer : fine-tunez sur un style different"")",,,,,,,,165be5bb72fe6930,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-70d4b526,markdown,fr,7433278d2daf6cd6,"### Exercice 3 : Hyperparametres d'entrainement
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-70d4b526,markdown,fr,09c57c376066abb4,"### Exercice 3 : Hyperparametres d'entrainement
 
 Le *learning rate* est l'hyperparametre le plus sensible du fine-tuning. Un LR trop faible = convergence lente, un LR trop eleve = divergence et degradation du modèle. Testez différentes valeurs pour trouver le point optimal.
 
-**Point de reference mesure** : avec la configuration du corps du notebook (10 epochs, batch 2), la perte finale affichee etait de **5.0106** en **13.3 s** sur RTX 3090 -- c'est la valeur a battre (ou a degrader volontairement) en faisant varier le learning rate. Un `learning_rate` trop eleve fait typiquement diverger la perte au-dela de cette reference des les premiers steps, un taux trop faible la laisse stagner sans l'atteindre.","### Exercise 3: Training Hyperparameters
+**Point de reference mesure** : avec la configuration du corps du notebook (10 epochs, batch 2), la perte finale affichee etait de **5.0106** en **~13 s** sur RTX 3090 -- c'est la valeur a battre (ou a degrader volontairement) en faisant varier le learning rate. Un `learning_rate` trop eleve fait typiquement diverger la perte au-dela de cette reference des les premiers steps, un taux trop faible la laisse stagner sans l'atteindre.","### Exercise 3: Training Hyperparameters
 
-The *learning rate* is the most sensitive hyperparameter in fine-tuning. An LR that is too low = slow convergence, an LR that is too high = divergence and degradation of the model. Test different values to find the optimal point.",,,,,,,7433278d2daf6cd6,71a929b06826c340,,,,,,,
+The *learning rate* is the most sensitive hyperparameter in fine-tuning. An LR that is too low = slow convergence, an LR that is too high = divergence and degradation of the model. Test different values to find the optimal point.",,,,,,,09c57c376066abb4,71a929b06826c340,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-fc5cb509,code,fr,4daa1488050f4257,"# Exercice 3 : Impact du learning rate
 # TODO etudiant : Entrainnez avec learning_rate = 1e-5, 5e-4, 1e-3.
 # Observez la perte finale et la qualite de generation.
@@ -457,7 +457,7 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-ebb4
 - The rank $r$ controls the expressiveness/efficiency trade-off
 
 **Next steps** (FT-02): LoRA on a larger model with 4-bit quantization (QLoRA).",,,,,,,888977dd137ad613,c2cf1f5cf24a4aa9,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,b4fb8592,markdown,fr,18a0debcd016f0e1,"# FT-02 : QLoRA — Fine-Tuning avec Quantization
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,b4fb8592,markdown,fr,58558c2130ed65c9,"# FT-02 : QLoRA — Fine-Tuning avec Quantization
 
 **Objectif** : Comprendre la quantization 4-bit (NF4) et l'approche QLoRA qui combine quantization + LoRA pour fine-tuner des modèles jusqu'a 7B params sur un GPU consumer.
 
@@ -465,17 +465,21 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,b4fb8592,markd
 1. Le problème memoire des grands modèles
 2. Quantization : de FP16 a NF4
 3. BitsAndBytesConfig en pratique
-4. QLoRA : quantized base + LoRA adapters
-5. Entrainement QLoRA sur OPT-1.3B
-6. Comparaison LoRA vs QLoRA
-7. Exercices
+4. La mécanique LoRA que l'API enveloppe
+5. QLoRA : quantized base + LoRA adapters
+6. Entrainement QLoRA sur OPT-1.3B
+7. Generation avec le modèle QLoRA
+8. Comparaison LoRA vs QLoRA
+9. Nettoyage memoire GPU
+10. Exercices
 
 **Prerequis** : FT-01 (Introduction au Fine-Tuning) — LoRA, rang, adaptateurs.
 
 **Materiel requis** : GPU avec ~8 Go VRAM (QLoRA OPT-1.3B 4-bit = ~2 Go).
 
 
-**Lecture de la sortie committée** : l'environnement d'exécution est un PyTorch 2.11.0+cu126 sur une RTX 3090 — 25,8 Go de VRAM totale, 24,5 Go libres au démarrage. Le paradoxe pédagogique de ce notebook : cette carte embarquerait OPT-1.3B en FP16 sans aucune difficulté (2,55 Go mesurés plus loin, cellule 7). Ce n'est pas elle qui justifie QLoRA — c'est la généralisation : la même recette qui tient un 1,3 Md dans ~1,2 Go en fera tenir un 7 Md dans ~6 Go, sur une carte à 300 €. Le notebook déroule la chaîne complète : quantization NF4 (cellule 2), greffe LoRA (cellule 5), entraînement réel mesuré (cellule 9), génération avant/après (cellule 10), et comparatif mémoire FP16 vs 4-bit (cellule 11).","# FT-02: QLoRA — Fine-Tuning with Quantization
+**Lecture de la sortie committée** : l'environnement d'exécution est un PyTorch 2.11.0+cu128 sur une RTX 3080 Ti Laptop — 17,2 Go de VRAM totale, 16,0 Go libres au démarrage. Le paradoxe pédagogique de ce notebook : cette carte embarquerait OPT-1.3B en FP16 sans aucune difficulté (4,03 Go mesurés plus loin, section 8). Ce n'est pas elle qui justifie QLoRA — c'est la généralisation : la même recette qui tient un 1,3 Md dans ~1,7 Go en fera tenir un 7 Md dans ~6 Go, sur une carte à 300 €. Le notebook déroule la chaîne complète : quantization NF4 (section 2), la mécanique LoRA écrite à la main (section 4), greffe LoRA via l'API (section 5), entraînement réel mesuré (section 6), génération avant/après (section 7), et comparatif mémoire FP16 vs 4-bit (section 8).
+","# FT-02: QLoRA — Fine-Tuning with Quantization
 
 **Objective**: Understand 4-bit quantization (NF4) and the QLoRA approach, which combines quantization + LoRA to fine-tune models up to 7B params on a consumer GPU.
 
@@ -483,14 +487,19 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,b4fb8592,markd
 1. The memory problem of large models
 2. Quantization: from FP16 to NF4
 3. BitsAndBytesConfig in practice
-4. QLoRA: quantized base + LoRA adapters
-5. QLoRA training on OPT-1.3B
-6. LoRA vs QLoRA comparison
-7. Exercises
+4. The LoRA mechanics that the API wraps
+5. QLoRA: quantized base + LoRA adapters
+6. QLoRA training on OPT-1.3B
+7. Generation with the QLoRA model
+8. LoRA vs QLoRA comparison
+9. GPU memory cleanup
+10. Exercises
 
 **Prerequisites**: FT-01 (Introduction to Fine-Tuning) — LoRA, rank, adapters.
 
-**Required hardware**: GPU with ~8 GB VRAM (QLoRA OPT-1.3B 4-bit = ~2 GB).",,,,,,,18a0debcd016f0e1,dd632a671adce65e,,,,,,,
+**Required hardware**: GPU with ~8 GB VRAM (QLoRA OPT-1.3B 4-bit = ~2 GB).
+
+**Reading the committed output**: the execution environment is PyTorch 2.11.0+cu128 on an RTX 3080 Ti Laptop — 17.2 GB of total VRAM, 16.0 GB free at startup. This notebook's pedagogical paradox: this card would hold OPT-1.3B in FP16 without any difficulty (4.03 GB measured further down, section 8). It is not this card that justifies QLoRA — it is generalization: the same recipe that holds a 1.3B model in ~1.7 GB will hold a 7B model in ~6 GB, on a 300-euro card. The notebook walks through the full chain: NF4 quantization (section 2), hand-written LoRA mechanics (section 4), LoRA grafting via the API (section 5), real measured training (section 6), before/after generation (section 7), and the FP16 vs 4-bit memory comparison (section 8).",,,,,,,58558c2130ed65c9,2fb84d6bf26c162f,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,482ed3ca,code,fr,31bb8dcfa3cec04b,"import torch
 import os
 import gc
@@ -503,7 +512,7 @@ if torch.cuda.is_available():
     vram_total = torch.cuda.get_device_properties(0).total_memory / 1e9
     vram_free = torch.cuda.mem_get_info()[0] / 1e9
     print(f""VRAM totale : {vram_total:.1f} Go | Libre : {vram_free:.1f} Go"")",,,,,,,,31bb8dcfa3cec04b,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,f42fdf42,markdown,fr,ab6bd6c6b1250e57,"## 1. Le problème memoire des grands modèles
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,f42fdf42,markdown,fr,91453d73f65c0b70,"## 1. Le problème memoire des grands modèles
 
 Fine-tuner un modèle de langue necessite de stocker en VRAM :
 
@@ -527,7 +536,7 @@ LoRA reduit les gradients et l'optimiseur (seuls les adaptateurs sont entraines)
 **QLoRA** va plus loin : il **quantize les poids du modèle en 4-bit** tout en gardant les calculs en precision superieure.
 
 
-**Le chiffrage réel, mesuré plus loin** : le tableau de la cellule 11 donne 2,55 Go pour le chargement FP16 d'OPT-1.3B — cohérent avec la théorie (1,32 Md de paramètres × 2 octets ≈ 2,6 Go de poids seuls). Mais charger n'est pas fine-tuner : un full fine-tuning exigerait en plus les gradients (autant que les poids) et les états de l'optimiseur Adam (deux fois les poids entraînables), soit ~4× la taille du modèle ≈ 10 Go pour un simple 1,3B — et ~55 Go pour un 7B, hors de portée d'une carte consumer. C'est cette triple taxe que LoRA (gradients sur les seuls adaptateurs) puis QLoRA (poids de base en 4 bits) réduisent à ~1,2 Go mesurés.","## 1. The memory problem of large models
+**Le chiffrage réel se lit dans la section 8** : le chargement FP16 d'OPT-1.3B dépasse la théorie des poids seuls, car les tampons CUDA et le contexte résiduel comptent aussi. Mais charger n'est pas fine-tuner : un full fine-tuning exige en plus les gradients et les états de l'optimiseur Adam. C'est cette triple taxe que LoRA (gradients sur les seuls adaptateurs) puis QLoRA (poids de base en 4 bits) réduisent. Les valeurs observées restent dans les outputs afin que la prose ne fige pas une mesure propre à une machine.","## 1. The memory problem of large models
 
 Fine-tuning a language model requires storing in VRAM:
 
@@ -548,7 +557,9 @@ Fine-tuning a language model requires storing in VRAM:
 
 LoRA reduces gradients and the optimizer (only the adapters are trained), but the **model weights remain in FP16**.
 
-**QLoRA** goes further: it **quantizes the model weights to 4-bit** while keeping computations at higher precision.",,,,,,,ab6bd6c6b1250e57,20bf8ac6bf624bac,,,,,,,
+**QLoRA** goes further: it **quantizes the model weights to 4-bit** while keeping computations at higher precision.
+
+**The real numbers read in section 8**: loading OPT-1.3B in FP16 exceeds the weights-only theory, because CUDA buffers and residual context also count. But loading is not fine-tuning: a full fine-tuning additionally requires gradients and Adam optimizer states. This triple tax is what LoRA (gradients on adapters only) then QLoRA (4-bit base weights) reduce. The observed values stay in the outputs so that the prose does not freeze a measurement specific to one machine.",,,,,,,91453d73f65c0b70,a121beb41980a311,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,6dd153f7,markdown,fr,eab90c19172f71a2,"## 2. Quantization : de FP16 a NF4
 
 ### 2a. Principe de la quantization
@@ -627,14 +638,15 @@ else:
     vram_before = 0
 
 print(f""VRAM avant chargement : {vram_before:.2f} Go"")",,,,,,,,4610db9bb7117f8a,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,872b697a,markdown,fr,7c8344fed8d5a9d4,"## 4. QLoRA : quantized base + LoRA adapters
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,872b697a,markdown,fr,e477a39db914f66f,"## 5. QLoRA : quantized base + LoRA adapters
 
 Chargeons OPT-1.3B en 4-bit et comparons avec le chargement FP16 classique.
 
 
-**Comment lire la sortie committée** : le chargement 4-bit d'OPT-1.3B occupe 0,99 Go de VRAM mesurés, contre 0,36 Go théoriques pour les seuls poids — l'écart (activations résiduelles, tampons de déquantization, tables d'embeddings parfois conservées en 16 bits) est le prix du passage à l'échelle réel. Notez aussi l'artefact de comptage : la cellule affiche « 711 778 304 params (0.71B) » alors que le comptage canonique d'OPT-1.3B est 1 318 903 808 (1,32 Md, confirmé par PEFT à la cellule suivante). Sommer `numel()` sur un modèle déjà quantifié ne retourne pas les tailles denses d'origine — un `Params4bit` ne se compte pas comme un tenseur FP16. Retenez le chiffre de PEFT : c'est le dénominateur honnête, celui sur lequel les pourcentages suivants doivent se lire.","## 4. QLoRA: quantized base + LoRA adapters
+**Comment lire la sortie committée** : le chargement 4-bit d'OPT-1.3B occupe 1,25 Go de VRAM mesurés, contre 0,36 Go théoriques pour les seuls poids — l'écart (activations résiduelles, tampons de déquantization, tables d'embeddings parfois conservées en 16 bits) est le prix du passage à l'échelle réel. Notez aussi l'artefact de comptage : la cellule affiche « 711 778 304 params (0.71B) » alors que le comptage canonique d'OPT-1.3B est 1 318 903 808 (1,32 Md, confirmé par PEFT à la cellule suivante). Sommer `numel()` sur un modèle déjà quantifié ne retourne pas les tailles denses d'origine — un `Params4bit` ne se compte pas comme un tenseur FP16. Retenez le chiffre de PEFT : c'est le dénominateur honnête, celui sur lequel les pourcentages suivants doivent se lire.
+","## 4. QLoRA: quantized base + LoRA adapters
 
-Let's load OPT-1.3B in 4-bit and compare it with standard FP16 loading.",,,,,,,7c8344fed8d5a9d4,fdc8dc9e5348bde8,,,,,,,
+Let's load OPT-1.3B in 4-bit and compare it with standard FP16 loading.",,,,,,,e477a39db914f66f,fdc8dc9e5348bde8,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,c18d2f35,code,fr,987ed8bcd8ae989b,"from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
 
@@ -689,14 +701,16 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,a0b80355,code,
 tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
 tokenizer.pad_token = tokenizer.eos_token
 print(f""Tokenizer : vocabulaire = {tokenizer.vocab_size:,} tokens"")",,,,,,,,eb0b8741da2602cf,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,1fb4824c,markdown,fr,8987911375178ef9,"## 5. Entrainement QLoRA sur OPT-1.3B
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,1fb4824c,markdown,fr,27bdf2e76b540b18,"## 6. Entrainement QLoRA sur OPT-1.3B
 
 Fine-tunons OPT-1.3B sur du texte francais litteraire, le même type de dataset que FT-01.
 
 
-**Ce que la sortie committée mesure** : trois nombres à retenir — perte finale 2,4067, durée 69,5 secondes, pic VRAM 1,16 Go. Le pic d'entraînement (1,16 Go) dépasse à peine le chargement seul (0,99 Go) : c'est toute la promesse QLoRA rendue visible — les gradients, activations et états d'optimiseur ne portent que sur les 3,1 M de paramètres LoRA, pas sur le milliard de poids figés. L'optimiseur `paged_adamw_8bit`, visible dans les arguments, complète le dispositif en stockant ses états en 8 bits. Une perte de 2,40 sur un corpus littéraire français reste élevée — c'est une empreinte stylistique sur 10 extraits, pas une maîtrise de la langue : la génération suivante montre exactement ce compromis.","## 5. QLoRA Training on OPT-1.3B
+**Ce que la sortie committée mesure** : la perte finale, la durée du run et le pic VRAM sont imprimés directement par la cellule d'entraînement. Le pic n'ajoute qu'une fraction de l'empreinte du chargement seul : les gradients et les états d'optimiseur portent sur les paramètres LoRA, pas sur le milliard de poids figés. L'optimiseur `paged_adamw_8bit`, visible dans les arguments, complète le dispositif en stockant ses états en 8 bits. Sur ce corpus minuscule, la perte décrit une empreinte stylistique, pas une maîtrise de la langue ; la génération suivante permet de lire ce compromis.","## 6. QLoRA Training on OPT-1.3B
 
-Let’s fine-tune OPT-1.3B on French literary text, the same type of dataset as FT-01.",,,,,,,8987911375178ef9,90102c69f1ee712c,,,,,,,
+Let's fine-tune OPT-1.3B on French literary text, the same type of dataset as FT-01.
+
+**What the committed output measures**: the final loss, the run duration and the VRAM peak are printed directly by the training cell. The peak adds only a fraction of the load-only footprint: gradients and optimizer states apply to the LoRA parameters, not to the billion frozen weights. The `paged_adamw_8bit` optimizer, visible in the arguments, completes the setup by storing its states in 8 bits. On this tiny corpus, the loss describes a stylistic imprint, not a mastery of the language; the generation below lets you read this trade-off.",,,,,,,27bdf2e76b540b18,66f2d00240643ed5,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,ce505cf2,code,fr,1e5bc967ca72a52e,"from datasets import Dataset
 
 # Extrait elargi — texte francais classique (domaine public)
@@ -745,10 +759,11 @@ training_texts = [
 train_data = Dataset.from_dict({""text"": training_texts})
 print(f""Dataset : {len(train_data)} exemples"")
 print(f""Moyenne caracteres/exemple : {sum(len(t) for t in training_texts) / len(training_texts):.0f}"")",,,,,,,,1e5bc967ca72a52e,,,,,,,,verbatim
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,9dce8a5a,markdown,fr,856e368f01f63d6f,"Le dataset contient 10 extraits de texte francais classique (moyenne 200 caractères par extrait). Ces segments sont plus courts que dans FT-01 pour s'adapter au contexte limite d'OPT-1.3B. La prochaine étape est la tokenisation avec un padding uniforme.
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,9dce8a5a,markdown,fr,df4cec1161fb068e,"Le dataset contient 10 extraits de texte francais classique (moyenne 200 caractères par extrait). Ces segments sont plus courts que dans FT-01 pour s'adapter au contexte limite d'OPT-1.3B. La prochaine étape est la tokenisation avec un padding uniforme.
 
 
-**Lecture du dataset committé** : 10 exemples, 200 caractères en moyenne — un corpus minuscule, choisi pour tenir l'entraînement en 70 secondes. Les extraits sont de Hugo et assimilés (domaine public) : lexique XIXe siècle, phrases longues, noms propres récurrents (Jean Valjean, Cosette). L'objectif n'est pas d'apprendre le français à OPT-1.3B mais de **greffer un style** : avec 10 exemples × 3 époques, l'adaptateur LoRA capture le vocabulaire et les tournures, pas la grammaire profonde. Un dataset réel de fine-tuning en compte des milliers ; ici chaque exemple est vu 3 fois, la mémorisation l'emporte sur la généralisation — et c'est précisément ce que la génération de la section 6 va révéler.",The dataset contains 10 excerpts of classic French text (average 200 characters per excerpt). These segments are shorter than in FT-01 to fit the limited context of OPT-1.3B. The next step is tokenization with uniform padding.,,,,,,,856e368f01f63d6f,6ab17183bbbb1661,,,,,,,
+**Lecture du dataset committé** : 10 exemples, 200 caractères en moyenne — un corpus minuscule, choisi pour tenir l'entraînement en 70 secondes. Les extraits sont de Hugo et assimilés (domaine public) : lexique XIXe siècle, phrases longues, noms propres récurrents (Jean Valjean, Cosette). L'objectif n'est pas d'apprendre le français à OPT-1.3B mais de **greffer un style** : avec 10 exemples × 3 époques, l'adaptateur LoRA capture le vocabulaire et les tournures, pas la grammaire profonde. Un dataset réel de fine-tuning en compte des milliers ; ici chaque exemple est vu 3 fois, la mémorisation l'emporte sur la généralisation — et c'est précisément ce que la génération de la section 7 va révéler.
+",The dataset contains 10 excerpts of classic French text (average 200 characters per excerpt). These segments are shorter than in FT-01 to fit the limited context of OPT-1.3B. The next step is tokenization with uniform padding.,,,,,,,df4cec1161fb068e,6ab17183bbbb1661,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,fabaa57e,code,fr,629b538887f154b3,"# Tokenisation
 def tokenize_function(examples):
     result = tokenizer(
@@ -763,14 +778,15 @@ def tokenize_function(examples):
 tokenized_dataset = train_data.map(tokenize_function, batched=True, remove_columns=[""text""])
 print(f""Tokens par exemple : {len(tokenized_dataset[0]['input_ids'])}"")
 print(f""Dataset tokenise : {len(tokenized_dataset)} exemples"")",,,,,,,,629b538887f154b3,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,f302a0b6,markdown,fr,03c8b124436b54e4,"Le dataset est maintenant tokenise avec un padding uniforme a 256 tokens, pret pour l'entrainement. Chaque exemple contient les `input_ids` et les `labels` (copies des input_ids pour le language modeling causal).
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,f302a0b6,markdown,fr,133b9e8b5e2d61fa,"Le dataset est maintenant tokenise avec un padding uniforme a 256 tokens, pret pour l'entrainement. Chaque exemple contient les `input_ids` et les `labels` (copies des input_ids pour le language modeling causal).
 
 Nous allons maintenant configurer le Trainer Hugging Face avec les arguments QLoRA : optimiseur 8-bit (`paged_adamw_8bit`), FP16, et un learning rate adapte a l'adaptateur LoRA.
 
 
-**Le coût caché du padding uniforme** : 256 tokens par exemple pour 200 caractères de texte (≈ 50-60 tokens utiles en français) — environ 75 % de chaque séquence est du remplissage. Le `padding=""max_length""` simplifie le batch au prix d'un quadruplement du calcul de passe avant sur les positions nulles. Sur 10 exemples c'est invisible (69,5 s mesurés) ; sur un vrai corpus, on préférerait un padding dynamique par batch. Retenez le réflexe de lecture : 10 exemples × 256 tokens = 2 560 tokens d'entraînement au total — l'adaptateur LoRA (3,1 M de paramètres) a vu moins de tokens qu'il n'a de poids, un régime de mémo-styling extrême.","The dataset is now tokenized with uniform padding to 256 tokens, ready for training. Each example contains the `input_ids` and the `labels` (copies of the input_ids for causal language modeling).
+**Le coût caché du padding uniforme** : 256 tokens par exemple pour 200 caractères de texte (≈ 50-60 tokens utiles en français) — environ 75 % de chaque séquence est du remplissage. Le `padding=""max_length""` simplifie le batch au prix d'un quadruplement du calcul de passe avant sur les positions nulles. Sur 10 exemples c'est invisible (20,7 s mesurés) ; sur un vrai corpus, on préférerait un padding dynamique par batch. Retenez le réflexe de lecture : 10 exemples × 256 tokens = 2 560 tokens d'entraînement au total — l'adaptateur LoRA (3,1 M de paramètres) a vu moins de tokens qu'il n'a de poids, un régime de mémo-styling extrême.
+","The dataset is now tokenized with uniform padding to 256 tokens, ready for training. Each example contains the `input_ids` and the `labels` (copies of the input_ids for causal language modeling).
 
-We will now configure the Hugging Face Trainer with the QLoRA arguments: 8-bit optimizer (`paged_adamw_8bit`), FP16, and a learning rate adapted to the LoRA adapter.",,,,,,,03c8b124436b54e4,3d3596317f2ec5fb,,,,,,,
+We will now configure the Hugging Face Trainer with the QLoRA arguments: 8-bit optimizer (`paged_adamw_8bit`), FP16, and a learning rate adapted to the LoRA adapter.",,,,,,,133b9e8b5e2d61fa,3d3596317f2ec5fb,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,fbe099a2,code,fr,667557059f20d847,"from transformers import TrainingArguments, Trainer, DataCollatorForLanguageModeling
 
 # Arguments d'entrainement QLoRA
@@ -820,14 +836,15 @@ else:
 print(f""\nPerte finale : {train_result.training_loss:.4f}"")
 print(f""Temps : {elapsed:.1f}s"")
 print(f""VRAM pic entrainement : {vram_peak:.2f} Go"")",,,,,,,,667557059f20d847,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,5b8b7716,markdown,fr,39eaebffd0595672,"## 6. Generation avec le modèle QLoRA
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,5b8b7716,markdown,fr,92ba1e237dd4d42e,"## 7. Generation avec le modèle QLoRA
 
 Comparons la generation avant et après fine-tuning.
 
 
-**Critère de lecture avant d'exécuter** : comparez les trois générations committées sur deux axes distincts — le **lexique** (noms propres, registre littéraire : attendez Jean Valjean, Cosette, des rues sombres) et la **syntaxe** (accords, construction des propositions : attendez des fractures). Les trois prompts sont des amorces différentes sur le même univers ; la question n'est pas « est-ce beau ? » mais « qu'est-ce qui a été appris (lexique) et qu'est-ce qui ne l'a pas été (grammaire) ? ». La lecture détaillée suit les sorties.","## 6. Generation with the QLoRA model
+**Critère de lecture avant d'exécuter** : comparez les trois générations committées sur deux axes distincts — le **lexique** (noms propres, registre littéraire : attendez Jean Valjean, Cosette, des rues sombres) et la **syntaxe** (accords, construction des propositions : attendez des fractures). Les trois prompts sont des amorces différentes sur le même univers ; la question n'est pas « est-ce beau ? » mais « qu'est-ce qui a été appris (lexique) et qu'est-ce qui ne l'a pas été (grammaire) ? ». La lecture détaillée suit les sorties.
+","## 6. Generation with the QLoRA model
 
-Let's compare the generation before and after fine-tuning.",,,,,,,39eaebffd0595672,f4b368eee948d357,,,,,,,
+Let's compare the generation before and after fine-tuning.",,,,,,,92ba1e237dd4d42e,f4b368eee948d357,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,ca2a65b6,code,fr,9e41989ba3e5e6d1,"# Generer avec le modele fine-tune
 model_qlora.eval()
 
@@ -856,14 +873,15 @@ for p in prompts:
     print(f""{'='*60}"")
     output = generate_qlora(p)
     print(output)",,,,,,,,9e41989ba3e5e6d1,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,acf6d40f,markdown,fr,00597fbacad2675a,"## 7. Comparaison LoRA vs QLoRA
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,acf6d40f,markdown,fr,2404a27bf92b5a4e,"## 8. Comparaison LoRA vs QLoRA
 
 Chargeons le même modèle en FP16 (sans quantization) pour comparer l'empreinte memoire.
 
 
-**Ce que la comparaison mesure** : le tableau suivant recharge le même OPT-1.3B en FP16 pur, puis en 4-bit, avec à chaque fois `reset_peak_memory_stats()` avant chargement et lecture du pic après — trois mesures indépendantes du même modèle dans trois configurations. Le pic FP16 servira de référence ; la ligne finale reprend le pic d'entraînement QLoRA mesuré en section 5 (1,16 Go). Attention à la lecture : les deux premières lignes mesurent des **pics de chargement** (transitoires de déquantization compris), la troisième un **pic d'entraînement en régime établi** — d'où un chiffre qui peut sembler plus bas que la ligne du dessus.","## 7. LoRA vs QLoRA Comparison
+**Ce que la comparaison mesure** : le tableau suivant recharge le même OPT-1.3B en FP16 pur, puis en 4-bit, avec à chaque fois `reset_peak_memory_stats()` avant chargement et lecture du pic après — trois mesures indépendantes du même modèle dans trois configurations. Le pic FP16 servira de référence ; la ligne finale reprend le pic d'entraînement QLoRA mesuré en section 6. Attention à la lecture : les deux premières lignes mesurent des **pics de chargement** (transitoires de déquantization compris), la troisième un **pic d'entraînement en régime établi** — d'où un chiffre qui peut sembler plus bas que la ligne du dessus.
+","## 7. LoRA vs QLoRA Comparison
 
-Let’s load the same model in FP16 (without quantization) to compare the memory footprint.",,,,,,,00597fbacad2675a,4a7a508a0f8c84d0,,,,,,,
+Let’s load the same model in FP16 (without quantization) to compare the memory footprint.",,,,,,,2404a27bf92b5a4e,4a7a508a0f8c84d0,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,30bb6cda,code,fr,31c5fe7b307bf67a,"# Charger le modele en FP16 pour comparaison
 model_fp16 = AutoModelForCausalLM.from_pretrained(
     MODEL_NAME,
@@ -944,10 +962,13 @@ print(f""{'Vitesse entrainement':<30} {'1x (ref)':<20} {'~0.8x (dequant)':<20}""
 print(f""\nRecommendation :\n""
       ""  - Modele < 1B + VRAM suffisante -> LoRA (FP16) : plus simple, plus rapide\n""
       ""  - Modele > 1B ou VRAM limitee -> QLoRA : Economie memoire 3-4x"")",,,,,,,,2373ea481726cb41,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,c0dcac7e,markdown,fr,c439fcec8c9e317e,"## 8. Nettoyage memoire GPU
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,c0dcac7e,markdown,fr,6d0d18fa032c2e9b,"## 9. Nettoyage memoire GPU
 
 
-**Pourquoi cette cellule compte** : libérer 23,5 Go à la fin n'est pas de la politesse — la cellule de comparaison suivante recharge le modèle deux fois, et sans `del` + `empty_cache()`, le cache CUDA saturerait les mesures. Sur un notebook GPU multi-expériences, la discipline mémoire est la condition de mesures honnêtes.",## 8. GPU memory cleanup,,,,,,,c439fcec8c9e317e,e450deb2b04e0ee1,,,,,,,
+**Pourquoi cette cellule compte** : restituer la VRAM (14,3 Go libres après nettoyage) n'est pas de la politesse — la cellule de comparaison suivante recharge le modèle deux fois, et sans `del` + `empty_cache()`, le cache CUDA saturerait les mesures. Sur un notebook GPU multi-expériences, la discipline mémoire est la condition de mesures honnêtes.
+","## 9. GPU memory cleanup
+
+**Why this cell matters**: returning the VRAM (14.3 GB free after cleanup) is not politeness — the comparison cell below reloads the model twice, and without `del` + `empty_cache()`, the CUDA cache would saturate the measurements. On a multi-experiment GPU notebook, memory discipline is the condition for honest measurements.",,,,,,,6d0d18fa032c2e9b,668f1a7c4344007d,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,5daaeefa,code,fr,150132583b58e543,"del model_qlora, trainer
 gc.collect()
 if torch.cuda.is_available():
@@ -955,17 +976,18 @@ if torch.cuda.is_available():
     print(f""VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} Go"")
 else:
     print(""Nettoyage termine"")",,,,,,,,150132583b58e543,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,8108d79d,markdown,fr,4f6e7f62bb728b11,"## 9. Exercices
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,8108d79d,markdown,fr,eb1fc7de0befcb2e,"## 10. Exercices
 
 Appliquez les concepts de ce notebook.
 
 
 **Critères de validation chiffrés** — ce que vous devez trouver :
-- **Exercice 1 (INT8 vs NF4 vs FP16)** : VRAM de chargement intermédiaire pour INT8 — théorie ~1,3 Go de poids seuls (1 octet/paramètre), entre le NF4 (0,36 Go) et le FP16 (2,6 Go) ; références mesurées : 1,60 Go (NF4) et 2,55 Go (FP16). La qualité de génération doit se dégrader dans l'ordre FP16 > INT8 > NF4, mais faiblement — les trois restent lisibles sur un 1,3B.
-- **Exercice 2 (r = 4, 16, 64)** : les paramètres entraînables suivent exactement 196 608 × r (formule démontrée en section 4) — attendez 786 432, 3 145 728 et 12 582 912. Le pic VRAM doit bouger de quelques Mo seulement (les adaptateurs sont minuscules) ; la perte finale doit diminuer quand r monte, mais r = 64 sur 10 exemples mémorise au lieu d'apprendre — comparez les générations, pas seulement la perte.
-- **Exercice 3 (double quantization)** : écart de VRAM de l'ordre de 60 Mo sur OPT-1.3B (~0,37 bit/paramètre économisé, cf. papier QLoRA) — petit mais mesurable ; la qualité ne doit pas bouger de façon perceptible.","## 9. Exercises
+- **Exercice 1 (INT8 vs NF4 vs FP16)** : VRAM de chargement intermédiaire pour INT8 — théorie ~1,3 Go de poids seuls (1 octet/paramètre), entre le NF4 (0,36 Go) et le FP16 (2,6 Go) ; références mesurées : 2,24 Go (NF4) et 4,03 Go (FP16). La qualité de génération doit se dégrader dans l'ordre FP16 > INT8 > NF4, mais faiblement — les trois restent lisibles sur un 1,3B.
+- **Exercice 2 (r = 4, 16, 64)** : les paramètres entraînables suivent exactement 196 608 × r (formule démontrée en section 4 — la mécanique LoRA) — attendez 786 432, 3 145 728 et 12 582 912. Le pic VRAM doit bouger de quelques Mo seulement (les adaptateurs sont minuscules) ; la perte finale doit diminuer quand r monte, mais r = 64 sur 10 exemples mémorise au lieu d'apprendre — comparez les générations, pas seulement la perte.
+- **Exercice 3 (double quantization)** : écart de VRAM de l'ordre de 60 Mo sur OPT-1.3B (~0,37 bit/paramètre économisé, cf. papier QLoRA) — petit mais mesurable ; la qualité ne doit pas bouger de façon perceptible.
+","## 9. Exercises
 
-Apply the concepts from this notebook.",,,,,,,4f6e7f62bb728b11,6a950269a4e6696d,,,,,,,
+Apply the concepts from this notebook.",,,,,,,eb1fc7de0befcb2e,6a950269a4e6696d,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,e8d55b99,code,fr,8053ee91bcb22b72,"# Exercice 1 : Impact de la precision
 # TODO etudiant : Comparez INT8 (load_in_8bit=True) vs NF4 vs FP16
 # sur le meme modele. Mesurez la VRAM et la qualite de generation.
@@ -994,7 +1016,7 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,c1471986,code,
 # Indice : la double quantization economise ~0.37 bits/param.
 
 print(""Exercice a completer : comparez double quantization on/off"")",,,,,,,,27a3c73edffe2c59,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,3e1127c5,markdown,fr,f2a88adaab418403,"## Resume
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,3e1127c5,markdown,fr,16b7b5bf2084b3ac,"## Resume
 
 | Aspect | LoRA (FT-01) | QLoRA (FT-02) |
 |--------|-------------|---------------|
@@ -1017,10 +1039,10 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,3e1127c5,markd
 **Prochaines étapes** (FT-03) : Fine-tuning multi-tâches avec plusieurs adaptateurs LoRA.
 
 
-**Le parcours en cinq chiffres** : 0,99 Go pour charger OPT-1.3B en NF4 ; 3 145 728 paramètres entraînés (0,24 % du modèle) ; 69,5 secondes et 1,16 Go de pic pour l'entraînement complet ; 54,4 % d'économie VRAM contre la même chaîne en FP16 ; perte finale 2,4067 — une empreinte stylistique, pas une refonte linguistique (cf. « la sonne du consaveau »). La boucle FT-01 → FT-02 est close : même mécanique LoRA, seule la résidence mémoire des poids change. FT-03 ouvre le multi-tâches : plusieurs adaptateurs, un modèle de base, et la question du partage de rang.
+**Le parcours mesuré se lit dans les outputs** : le chargement NF4, le nombre exact de paramètres entraînables, la durée, le pic VRAM et la perte finale sont produits par les cellules précédentes. La grille de la section 4 prédit le compte d'adaptateurs au paramètre près ; les générations de la section 7 montrent ensuite le mémo-styling à l'œuvre. La boucle FT-01 → FT-02 est close : même mécanique LoRA, seule la résidence mémoire des poids change. FT-03 ouvre le multi-tâches : plusieurs adaptateurs, un modèle de base, et la question du partage de rang.
 
 
-**Vérification de l'affirmation « un 7B tient sur 6 Go »** : le point clé du Résumé ci-dessus se démontre avec les ratios mesurés dans ce notebook. Poids 4-bit : 0,5 octet par paramètre, soit 3,5 Go pour 7 Md — contre 14 Go en FP16. Adaptateurs LoRA : quelques dizaines de Mo (196 608 × r, indépendant de la taille du modèle pour un même ciblage). Optimiseur 8 bits paginé : uniquement sur les adaptateurs. Total : ~4 Go de résidence pour le modèle complet en entraînement, activations comprises avec des séquences de 256 tokens — la marge d'un GPU 6 Go est réelle, et le facteur limitant devient la longueur de contexte, plus la taille du modèle. C'est la même arithmétique qui, appliquée à notre 1,3B, a donné 1,16 Go mesurés.","## Summary
+**Vérification de l'affirmation « un 7B tient sur 6 Go »** : poids 4-bit = 0,5 octet par paramètre, soit 3,5 Go pour 7 Md, contre 14 Go en FP16. Les adaptateurs LoRA et l'optimiseur paginé portent sur une petite fraction des paramètres. La marge dépend ensuite de la longueur de contexte, du batch et des activations : c'est pourquoi le notebook mesure le pic réel au lieu de se contenter de l'arithmétique des poids.","## Summary
 
 | Aspect | LoRA (FT-01) | QLoRA (FT-02) |
 |--------|-------------|---------------|
@@ -1040,10 +1062,14 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,3e1127c5,markd
 
 **Reference**: Dettmers et al., ""QLoRA: Efficient Finetuning of Quantized LLMs"" (2023).
 
-**Next steps** (FT-03): Multi-task fine-tuning with multiple LoRA adapters.",,,,,,,f2a88adaab418403,6a8226ff392484c4,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,0e944cc3,markdown,fr,dbaff790af119ebd,"# FT-03 : Supervised Fine-Tuning (SFT) — Instruction Following
+**Next steps** (FT-03): Multi-task fine-tuning with several LoRA adapters.
 
-**Objectif** : Apprendre le Supervised Fine-Tuning (SFT), la technique qui transforme un modèle de base (base model) en un assistant capable de suivre des instructions (instruct model). Vous comprendrez le format instruction-réponse, la preparation des données d'entrainement, et l'evaluation de la qualite des reponses.
+**The measured journey reads in the outputs**: the NF4 loading, the exact number of trainable parameters, the duration, the VRAM peak and the final loss are all produced by the preceding cells. The section 4 grid predicts the adapter count to the exact parameter; the section 7 generations then show memo-styling at work. The FT-01 → FT-02 loop is closed: same LoRA mechanics, only the memory residency of the weights changes. FT-03 opens multi-task: several adapters, one base model, and the question of rank sharing.
+
+**Verifying the ""a 7B fits on 6 GB"" claim**: 4-bit weights = 0.5 byte per parameter, i.e. 3.5 GB for 7B, against 14 GB in FP16. The LoRA adapters and the paged optimizer apply to a small fraction of the parameters. The remaining margin then depends on context length, batch size and activations: this is why the notebook measures the real peak instead of settling for weight arithmetic.",,,,,,,16b7b5bf2084b3ac,01156e36e4c2ba5e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,0e944cc3,markdown,fr,20a066eca877668d,"# FT-03 : Supervised Fine-Tuning (SFT) — Enseigner un format de reponse
+
+**Objectif** : Apprendre le Supervised Fine-Tuning (SFT) sur un modele moderne deja instruct-tuned (Qwen3.5-0.8B) : on ne lui apprend plus a *suivre* des instructions — il sait deja — mais a repondre selon un **contrat de format** arbitraire (`[REPONSE] ... [FIN]`), le cas d'usage reel du SFT de specialisation. Vous comprendrez le format instruction-reponse, la preparation des donnees d'entrainement, et l'evaluation mesurable de la conformite.
 
 **Prerequis** :
 - FT-01 (Introduction au Fine-Tuning, LoRA sur GPT-2)
@@ -1051,27 +1077,27 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,0e944cc
 - Notions de PyTorch et Transformers
 
 **Plan du notebook** :
-1. Base Model vs Instruct Model — la différence cruciale
-2. Le format instruction-réponse (chat templates)
+1. Base Model vs Instruct Model — la difference cruciale, et pourquoi elle change la facon de faire du SFT aujourd'hui
+2. Le format instruction-reponse (chat templates)
 3. Preparation d'un dataset SFT
-4. SFT avec QLoRA sur OPT-1.3B
-5. Evaluation qualitative : avant vs après
+4. SFT avec QLoRA sur Qwen3.5-0.8B
+5. Evaluation mesurable : conformite de format avant vs apres
 6. Impact de la taille du dataset
 7. Exercices
 
 **Duree estimee** : 45-60 minutes
 
-**Prérequis** : FT-01 (panorama du fine-tuning) et FT-02 (quantization QLoRA).
-**Parcours** : nous mesurons d'abord le comportement du modele de base (section 2),
-construisons un dataset d'instruction minimal (section 3), le formatons selon le
-chat template (section 4), configurons les adaptateurs LoRA sur le corps 4-bit
-(section 4a), entraînons puis comparons avant/après (sections 5-6), et finissons
-par l'expérience la plus instructive — faire tomber le budget de données à 5
-exemples pour voir ce qui se casse exactement (section 7). Chaque étape est
-suivie d'une lecture chiffrée de sa sortie réelle.
-","# FT-03: Supervised Fine-Tuning (SFT) — Instruction Following
+**Prerequis** : FT-01 (panorama du fine-tuning) et FT-02 (quantization QLoRA).
+**Parcours** : nous mesurons d'abord le comportement du modele instruct face a
+notre contrat de format (section 2), construisons un dataset d'instruction riche — 227 paires
+produites par un builder deterministe (section 3), le formatons selon le contrat balise (section 4), configurons les adaptateurs LoRA
+sur le corps 4-bit (section 4a), entraînons sur un split train/eval disjoint puis comparons la conformite
+avant/apres (sections 5-6), et finissons par l'experience la plus instructive —
+faire tomber le budget de donnees a 5 exemples pour voir ce qui se casse
+exactement (section 7). Chaque etape est executee reellement sur GPU.
+","# FT-03: Supervised Fine-Tuning (SFT) — Teaching a response format
 
-**Objective**: Learn Supervised Fine-Tuning (SFT), the technique that transforms a base model into an assistant capable of following instructions (instruct model). You will understand the instruction-response format, the preparation of training data, and the evaluation of response quality.
+**Objective**: Learn Supervised Fine-Tuning (SFT) on a modern model that is already instruct-tuned (Qwen3.5-0.8B): we no longer teach it to *follow* instructions — it already can — but to respond under an arbitrary **format contract** (`[REPONSE] ... [FIN]`), the real-world use case of specialization SFT. You will understand the instruction-response format, the preparation of training data, and the measurable evaluation of compliance.
 
 **Prerequisites**:
 - FT-01 (Introduction to Fine-Tuning, LoRA on GPT-2)
@@ -1079,15 +1105,24 @@ suivie d'une lecture chiffrée de sa sortie réelle.
 - Basics of PyTorch and Transformers
 
 **Notebook outline**:
-1. Base Model vs Instruct Model — the crucial difference
+1. Base Model vs Instruct Model — the crucial difference, and why it changes how SFT is done today
 2. The instruction-response format (chat templates)
 3. Preparing an SFT dataset
-4. SFT with QLoRA on OPT-1.3B
-5. Qualitative evaluation: before vs after
+4. SFT with QLoRA on Qwen3.5-0.8B
+5. Measurable evaluation: format compliance before vs after
 6. Impact of dataset size
 7. Exercises
 
-**Estimated duration**: 45-60 minutes",,,,,,,dbaff790af119ebd,0bec4da090db236e,,,,,,,
+**Estimated duration**: 45-60 minutes
+
+**Prerequisites**: FT-01 (fine-tuning panorama) and FT-02 (QLoRA quantization).
+**Journey**: we first measure the instruct model's behavior against our
+format contract (section 2), build a rich instruction dataset — 227 pairs
+produced by a deterministic builder (section 3), format them under the tagged contract (section 4), configure the LoRA
+adapters on the 4-bit body (section 4a), train on a disjoint train/eval split then compare compliance
+before/after (sections 5-6), and finish with the most instructive experiment —
+dropping the data budget to 5 examples to see exactly what breaks
+(section 7). Every step is actually executed on GPU.",,,,,,,20a066eca877668d,a9f93b66732a8708,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,879e8090,code,fr,a96d427262372dd8,"import torch
 import os
 import gc
@@ -1104,57 +1139,72 @@ if torch.cuda.is_available():
 # Mode batch pour execution automatisee
 BATCH_MODE = os.environ.get(""BATCH_MODE"", ""false"").lower() == ""true""
 print(f""Batch mode : {BATCH_MODE}"")",,,,,,,,a96d427262372dd8,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,ad342c4a,markdown,fr,faccef29553c4457,"## 1. Base Model vs Instruct Model
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,ad342c4a,markdown,fr,f8d434aa5747f243,"## 1. Base Model vs Instruct Model
 
-Un **modèle de base** (base model) est entraine uniquement a predire le token suivant dans un texte. Il ne comprend pas la notion d'""instruction"" — si vous lui dites ""Expliquez la photosynthese"", il pourrait continuer la phrase (""...en utilisant des termes simples"") au lieu de repondre.
+Un **modele de base** (base model) est entraine uniquement a predire le token suivant dans un texte. Il ne comprend pas la notion d'""instruction"" — si vous lui dites ""Expliquez la photosynthese"", il pourrait continuer la phrase (""...en utilisant des termes simples"") au lieu de repondre.
 
-Un **modèle instruct** (instruct model) a subi un Supervised Fine-Tuning sur des paires instruction-réponse. Il a appris a :
-- Comprendre qu'on lui pose une question ou donne une tâche
+Un **modele instruct** (instruct model) a subi un Supervised Fine-Tuning sur des paires instruction-reponse. Il a appris a :
+- Comprendre qu'on lui pose une question ou donne une tache
 - Produire une reponse structuree et pertinente
-- Suivre des formats spécifiques (explication, code, liste, etc.)
+- Suivre des formats specifiques (explication, code, liste, etc.)
 
-La transition base → instruct est exactement ce que nous allons reproduire dans ce notebook avec un petit modèle.
+**Pourquoi cela change notre notebook** : Qwen3.5-0.8B (2026) est *deja* un modele instruct — la generation 2022 (OPT, GPT-2) demandait d'apprendre l'instruction-following from scratch, ce n'est plus le cas. Le SFT moderne sur un petit modele instruct a un autre emploi : lui enseigner un **contrat de format** — une convention de sortie arbitraire que le pre-training ne lui a jamais montree. C'est exactement ce que fait un produit reel quand il veut des reponses en JSON, en tableau, ou encadrees par des balises maison : on ne re-entraine pas l'intelligence, on specialise le format.
+
+La transition que nous reproduisons ici : modele instruct generique -> assistant conforme au contrat `[REPONSE] ... [FIN]`, mesuree par un taux de conformite objectif (section 6).
 
 Un modele de base (base model) est entraîne uniquement par complétion : prédire le
 token suivant sur un corpus massif. Il n'a jamais vu la notion d'« instruction » —
 quand on lui pose une question, il continue statistiquement le texte, et une
 question appelle souvent... une autre question. Un modele instruct a subi une
 étape supplémentaire de Supervised Fine-Tuning (SFT) sur des paires
-instruction/réponse : il a appris qu'après une question vient une réponse. Ce
-notebook reproduit cette étape de bout en bout sur un modele OPT-1.3B quantifié
-4-bit : mesurer l'écart de comportement avant/après, puis en explorer les limites
-avec un dataset volontairement minuscule (20 exemples) — assez pour apprendre le
-*format*, pas assez pour apprendre les *faits*.
+instruction/réponse : il a appris qu'après une question vient une réponse. Sur un
+tel modele — Qwen3.5-0.8B quantifié 4-bit — ce notebook reproduit l'étape de
+specialisation : mesurer l'écart de conformite au contrat avant/après, puis en
+explorer les limites avec un dataset volontairement minuscule.
 ","## 1. Base Model vs Instruct Model
 
-A **base model** is trained only to predict the next token in a text. It does not understand the notion of an “instruction” — if you tell it ""Explain photosynthesis"", it might continue the sentence (""...using simple terms"") instead of answering.
+A **base model** is trained only to predict the next token in a text. It does not understand the notion of an ""instruction"" — if you tell it ""Explain photosynthesis"", it might continue the sentence (""...using simple terms"") instead of answering.
 
 An **instruct model** has undergone Supervised Fine-Tuning on instruction-response pairs. It has learned to:
 - Understand that it is being asked a question or given a task
 - Produce a structured and relevant response
 - Follow specific formats (explanation, code, list, etc.)
 
-The transition from base → instruct is exactly what we are going to reproduce in this notebook with a small model.",,,,,,,faccef29553c4457,0a56e24a8fc0f00e,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,d7add7dd,markdown,fr,6e91556ff64958d8,"## 2. Le format instruction-réponse (chat templates)
+**Why this changes our notebook**: Qwen3.5-0.8B (2026) is *already* an instruct model — the 2022 generation (OPT, GPT-2) required learning instruction-following from scratch, which is no longer the case. Modern SFT on a small instruct model has a different job: teaching it a **format contract** — an arbitrary output convention that pre-training never showed it. This is exactly what a real product does when it wants responses in JSON, in a table, or framed with in-house tags: you do not retrain the intelligence, you specialize the format.
 
-Les modèles instruct utilisent un **format de conversation** (chat template) pour delimiter les rôles. Par exemple :
+The transition we reproduce here: generic instruct model -> assistant compliant with the `[REPONSE] ... [FIN]` contract, measured by an objective compliance rate (section 6).
+
+A base model is trained purely by completion: predicting the
+next token over a massive corpus. It has never seen the notion of ""instruction"" —
+when asked a question, it statistically continues the text, and a
+question often calls for... another question. An instruct model has undergone an
+extra Supervised Fine-Tuning (SFT) step on instruction/response
+pairs: it has learned that after a question comes an answer. On such
+a model — Qwen3.5-0.8B quantized to 4-bit — this notebook reproduces the
+specialization step: measure the compliance gap against the contract before/after, then
+explore its limits with a deliberately tiny dataset.",,,,,,,f8d434aa5747f243,f6dc0d8d369ace86,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,d7add7dd,markdown,fr,9604957d2a41690e,"## 2. Le format instruction-reponse (chat templates)
+
+Les modeles instruct utilisent un **format de conversation** (chat template) pour delimiter les roles. Par exemple :
 
 ```
 ### Human: Expliquez la photosynthese en 2 phrases.
-### Assistant: La photosynthese est le processus par lequel les plantes convertissent la lumiere du soleil, le CO2 et l'eau en glucose et oxygene. Ce mécanisme se deroule dans les chloroplastes des cellules vegetales grace a la chlorophylle.
+### Assistant: La photosynthese est le processus par lequel les plantes convertissent la lumiere du soleil, le CO2 et l'eau en glucose et oxygene. Ce mecanisme se deroule dans les chloroplastes des cellules vegetales grace a la chlorophylle.
 ```
 
-Le format exact depend du modèle. Pour les modèles de la famille OPT, le format `### Human:` / `### Assistant:` est courant. D'autres modèles utilisent des tokens speciaux (`<|im_start|>user\n...<|im_end|>` pour les modèles ChatML).
+Le format exact depend du modele. Le format `### Human:` / `### Assistant:` est celui utilise historiquement par OPT ; les modeles recents utilisent des tokens speciaux (`<|im_start|>user\n...<|im_end|>` pour les modeles ChatML — c'est le cas de la famille Qwen, dont le template natif embarque aussi des balises de raisonnement).
 
-**Point cle** : le chat template est un contrat entre les données d'entrainement et l'inference. Si vous entrainez avec un format, vous devez utiliser le même format a l'inference.
+**Point cle** : le chat template est un contrat entre les donnees d'entrainement et l'inference. Si vous entrainez avec un format, vous devez utiliser le meme format a l'inference.
 
 Le format d'échange — ici les délimiteurs `### Human:` / `### Assistant:` — joue
-le rôle que jouent les tokens spéciaux dans un chat template (ChatML, Llama-2,
-etc.). Deux règles pratiques : (1) le format utilisé à l'inférence doit être
-**strictement identique** à celui vu à l'entraînement, sinon le modele produit
-des délimiteurs en boucle ; (2) un format appris sur peu d'exemples généralise
-mieux que les faits eux-mêmes — c'est la première chose que le SFT transmet, et
-nous le vérifierons à la cellule d'évaluation.
+le rôle que jouent les tokens spéciaux dans un chat template natif (ChatML, Llama-2,
+etc.). Nous y ajoutons une seconde couche, notre contrat de sortie : la reponse
+doit etre encadree par `[REPONSE] ... [FIN]`. Deux règles pratiques : (1) le format
+utilisé à l'inférence doit être **strictement identique** à celui vu à
+l'entraînement, sinon le modele produit des délimiteurs en boucle ; (2) un format
+appris sur peu d'exemples généralise mieux que les faits eux-mêmes — c'est la
+premiere chose que le SFT transmet, et nous le vérifierons à la cellule
+d'evaluation.
 ","## 2. The instruction-response format (chat templates)
 
 Instruct models use a **conversation format** (chat template) to delimit roles. For example:
@@ -1164,9 +1214,20 @@ Instruct models use a **conversation format** (chat template) to delimit roles. 
 ### Assistant: La photosynthese est le processus par lequel les plantes convertissent la lumiere du soleil, le CO2 et l'eau en glucose et oxygene. Ce mecanisme se deroule dans les chloroplastes des cellules vegetales grace a la chlorophylle.
 ```
 
-The exact format depends on the model. For models in the OPT family, the `### Human:` / `### Assistant:` format is common. Other models use special tokens (`<|im_start|>user\n...<|im_end|>` for ChatML models).
+The exact format depends on the model. The `### Human:` / `### Assistant:` format is the one used historically by OPT; recent models use special tokens (`<|im_start|>user
+...<|im_end|>` for ChatML models — this is the case of the Qwen family, whose native template also embeds reasoning tags).
 
-**Key point**: the chat template is a contract between the training data and inference. If you train with one format, you must use the same format at inference.",,,,,,,6e91556ff64958d8,07378a149759cbea,,,,,,,
+**Key point**: the chat template is a contract between training data and inference. If you train with one format, you must use the same format at inference.
+
+The exchange format — here the `### Human:` / `### Assistant:` delimiters — plays
+the role that special tokens play in a native chat template (ChatML, Llama-2,
+etc.). We add a second layer on top, our output contract: the response
+must be framed by `[REPONSE] ... [FIN]`. Two practical rules: (1) the format
+used at inference must be **strictly identical** to the one seen during
+training, otherwise the model produces delimiters in a loop; (2) a format
+learned on few examples generalizes better than the facts themselves — it is the
+first thing SFT transmits, and we will verify this at the evaluation
+cell.",,,,,,,9604957d2a41690e,8f94fdd8d790e52e,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,2ba5d60b,code,fr,7833f4582ae811f9,"# Charger le modele de base (OPT-1.3B, quantize 4-bit pour economiser la VRAM)
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 import torch
@@ -1196,18 +1257,24 @@ print(f""Modele charge. Parametres : {sum(p.numel() for p in model_base.paramete
 if torch.cuda.is_available():
     vram_mb = torch.cuda.memory_allocated() / 1e6
     print(f""VRAM utilisee : {vram_mb:.0f} Mo"")",,,,,,,,7833f4582ae811f9,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,87c08f80,markdown,fr,65fcbb24ce8128e0,"### 2a. Demonstration : le modèle de base ne suit pas les instructions
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,87c08f80,markdown,fr,54f4c28185f5a53d,"### 2a. Demonstration : le modele suit l'instruction, mais ignore notre contrat de format
 
-Testons le modèle de base avec des instructions. Observez comment il ""continue"" le texte au lieu de repondre a la question.
+Testons le modele de base avec nos instructions formatees. Observez : Qwen3.5-0.8B est instruct-tuned, il repond *au fond* a la question — mais il ne connait pas nos balises `[REPONSE] ... [FIN]` : sa reponse est en prose libre.
 
 Protocole : trois instructions types (question factuelle, explication, liste de
 conseils) sont soumises au modele de base, puis — à la section 6 — les mêmes
 au modele SFT, avec la même fonction de génération. En comparant les réponses
-mot à mot sur des prompts identiques, l'effet du SFT est isolé de toute autre
-variable.
-","### 2a. Demonstration: the base model does not follow instructions
+mot à mot sur des prompts identiques et en comptant les balises presentes,
+l'effet du SFT est isolé de toute autre variable.
+","### 2a. Demonstration: the model follows the instruction, but ignores our format contract
 
-Let’s test the base model with instructions. Observe how it ""continues"" the text instead of answering the question.",,,,,,,65fcbb24ce8128e0,684f40469012dd49,,,,,,,
+Let's test the base model with our formatted instructions. Observe: Qwen3.5-0.8B is instruct-tuned, it answers the question *substantively* — but it does not know our `[REPONSE] ... [FIN]` tags: its response is free prose.
+
+Protocol: three typical instructions (factual question, explanation, list of
+tips) are submitted to the base model, then — in section 6 — the same ones
+to the SFT model, with the same generation function. By comparing the responses
+word for word on identical prompts and counting the tags present,
+the effect of SFT is isolated from every other variable.",,,,,,,54f4c28185f5a53d,6085d75fa5a98ae6,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,c5b7deff,code,fr,76f2fc7fced2ad81,"# Test du modele de base avec des instructions
 def generate(model, prompt, max_new_tokens=80, temperature=0.7):
     inputs = tokenizer(prompt, return_tensors=""pt"").to(model.device)
@@ -1237,19 +1304,8 @@ for prompt in test_prompts:
     print(f""Instruction : {instruction}"")
     print(f""Reponse     : {response}"")
     print(""-"" * 60)",,,,,,,,76f2fc7fced2ad81,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,da07c4a7,markdown,fr,ee22cc5360490d92,"**Observation** : Le modèle de base produit du texte coherent mais ne repond pas vraiment aux instructions. Il peut ignorer la question, la reformuler, ou generer du contenu sans rapport. C'est normal : il a ete entraine uniquement a predire la suite du texte, pas a suivre des instructions.
-
-Nous allons maintenant lui apprendre a repondre correctement avec le SFT.
-
-Regardez la première réponse : le modele **répète la question** puis enchaîne
-`### Assistant:` quatre fois — il complète le texte (« après une question... »)
-au lieu d'y répondre. Et la troisième réponse, « Si j'ai vécu un meilleur jour,
-j'ai vécu un meilleur mois », est grammaticale mais parfaitement hors-sujet.
-C'est la signature d'un modele de base : cohérence locale du langage, zéro
-compréhension de l'intention. Le SFT va précisément cibler ce déficit.
-","**Observation**: The base model produces coherent text but does not really follow instructions. It may ignore the question, rephrase it, or generate unrelated content. This is normal: it was trained only to predict the continuation of the text, not to follow instructions.
-
-We will now teach it to respond correctly with SFT.",,,,,,,ee22cc5360490d92,0394cea048c4fba3,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,da07c4a7,markdown,fr,042c654c3375b755,"**Observation** : le modele repond *au fond* (il est instruct-tuned — « La gravite est une force de nature qui s'exerce dans l'espace » est une ebauche correcte), mais deux defauts signatures apparaissent : (1) **zero conformite au contrat** — aucune balise `[REPONSE]`/`[FIN]`, prose libre, 0/3 ; (2) il **boucle sur le format du prompt** — voyant `### Human:`/`### Assistant:` (qui n'est PAS son template natif ChatML), il imite le motif et enchaîne plusieurs tours de conversation fictionnels, voire tente son balisage de raisonnement natif (`<think>`). Le modele suit l'intention, pas le contrat : c'est precisement ce que le SFT va lui enseigner.
+","**Observation**: the model answers *substantively* (it is instruct-tuned — ""Gravity is a natural force that acts in space"" is a correct sketch), but two signature defects appear: (1) **zero compliance with the contract** — no `[REPONSE]`/`[FIN]` tag, free prose, 0/3; (2) it **loops on the prompt's format** — seeing `### Human:`/`### Assistant:` (which is NOT its native ChatML template), it imitates the pattern and chains several fictional conversation turns, even attempting its native reasoning markup (`<think>`). The model follows the intent, not the contract: this is precisely what SFT will teach it.",,,,,,,042c654c3375b755,0a193bf57c8aec7e,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,8d1a1b00,markdown,fr,6da4ece08dc4cf79,"## 3. Preparation d'un dataset SFT
 
 Pour le SFT, nous avons besoin de paires **instruction → reponse attendue**. La qualite du dataset est le facteur le plus important pour la reussite du fine-tuning.
@@ -1519,24 +1575,11 @@ for prompt in eval_prompts:
     print(f""\nInstruction : {instruction}"")
     print(f""  SFT : {response_sft[:200]}"")
     print(""  "" + ""-"" * 60)",,,,,,,,523d879d90cda59e,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,a047e5d6,markdown,fr,1399f22ca9504c24,"**Observation** : Le modèle SFT devrait maintenant repondre directement aux instructions au lieu de continuer le texte. La qualite des reponses depend de :
-1. **La taille du dataset** — 21 exemples est un minimum, les modèles de production utilisent 10K-100K+ exemples
-2. **La qualite des données** — des reponses mal formatees ou incorrectes seront apprises telles quelles
-3. **Le nombre d'epochs** — trop peu = sous-apprentissage, trop = surapprentissage
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,a047e5d6,markdown,fr,be560fcaa6471d40,"**Observation** : la conformité passe de **0/3 (base) à 6/6 (SFT)**. Chaque réponse commence par `[REPONSE]` et s'arrête proprement — la boucle de conversation de la section 2a a disparu. Surtout, les deux instructions du holdout — « Qu'est-ce que le machine learning ? » et « Quelle est la différence entre apprentissage supervisé et non supervisé ? » — **ne sont pas dans le split d'entraînement** (le split disjoint de la section 5 les tient à l'écart) : le contrat balisé a **généralisé** à des instructions jamais vues — le format s'apprend plus vite et plus loin que les faits.
 
-L'écart se lit sur deux plans, mesurés dans la sortie ci-dessus : (1) le
-**format** est désormais tenu — une réponse démarre après `### Assistant:`,
-sans boucle de question, et les phrases sont grammaticales (« Le concept
-d'intelligence artificielle est un système de machine learning ») ; (2) le
-**contenu** reste fragile — la gravité répondue par « un objectif est établi
-par les images de l'objet » (hallucination), et la question productivité
-retombe dans la répétition (« Ne pas pousser la petite quantitatrice »).
-Vingt exemples × 5 époques ont transmis un *comportement* (répondre), pas des
-*connaissances* (répondre juste) — la distinction à retenir de ce TP.
-","**Observation**: The SFT model should now respond directly to instructions instead of continuing the text. The quality of the responses depends on:
-1. **The size of the dataset** — 21 examples is a minimum; production models use 10K-100K+ examples
-2. **The quality of the data** — poorly formatted or incorrect responses will be learned as-is
-3. **The number of epochs** — too few = underfitting, too many = overfitting",,,,,,,1399f22ca9504c24,689d571eab8de602,,,,,,,
+La nuance honnête : regardez le *fond* des réponses SFT (« la gravité est une force fondamentale qui lie les particules entre elles... créée par Newton avec la loi des trois lois », « un réseau de neurones est un ensemble de n unitaires connectées ») — approximatif, parfois inventé. Le SFT n'a pas amélioré la correctitude du modèle (il la connaissait déjà), il a **installé le contrat de sortie**. Conformité et correctitude sont deux axes indépendants : le premier s'enseigne en quelques dizaines d'exemples bien choisis, le second demande soit plus de données, soit un modèle plus grand. C'est la leçon centrale du SFT moderne sur modèle instruct : on spécialise le comportement observable, pas la connaissance.","**Observation**: compliance goes from **0/3 (base) to 6/6 (SFT)**. Each response starts with `[REPONSE]` and stops cleanly — the conversation loop of section 2a has disappeared. Above all, the two holdout instructions — ""What is machine learning?"" and ""What is the difference between supervised and unsupervised learning?"" — are **not in the training split** (the disjoint split of section 5 keeps them out): the tagged contract has **generalized** to never-seen instructions — format is learned faster and further than facts.
+
+The honest nuance: look at the *substance* of the SFT responses (""gravity is a fundamental force that binds particles together... created by Newton with the law of three laws"", ""a neural network is a set of n unitaries connected"") — approximate, sometimes invented. SFT did not improve the model's correctness (it already knew the answers), it **installed the output contract**. Compliance and correctness are two independent axes: the first is taught with a few dozen well-chosen examples, the second requires either more data or a larger model. This is the central lesson of modern SFT on an instruct model: you specialize the observable behavior, not the knowledge.",,,,,,,be560fcaa6471d40,dd1f3589c02f85bc,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,dcc61c62,markdown,fr,b0ced28134ea26b0,"## 7. Impact de la taille du dataset
 
 Un SFT efficace depends fortement de la quantite de données. Testons avec différents sous-ensembles de notre dataset pour observer l'impact sur la qualite des reponses.","## 7. Impact of Dataset Size
@@ -1592,22 +1635,15 @@ del model_small, small_trainer
 gc.collect()
 torch.cuda.empty_cache()
 print(f""\nVRAM apres cleanup : {torch.cuda.memory_allocated() / 1e6:.0f} Mo"")",,,,,,,,c47a8ce407a807dd,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,8a64a856,markdown,fr,922c9cd94cd2f68b,"**Conclusion sur la taille du dataset** : Avec seulement 5 exemples, le modèle apprend moins bien le format instruction/reponse. La différence est visible : les reponses sont moins structurees et le modèle peut encore parfois \""oublier\"" qu'il doit repondre a une instruction.
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,8a64a856,markdown,fr,62bcc8d56f07780d,"**Conclusion sur la taille du dataset** : la leçon des deux runs se lit maintenant loss ET générations alignées.
 
-En production, les datasets SFT contiennent typiquement entre 10 000 et 1 million de paires instruction/reponse.
+Avec **5 exemples** : perte finale **1,73** et génération en charabia pur (« Human Human Human... »). Avec **205 exemples** : perte train 0,70 (moyenne de run), perte eval disjointe **0,38**, et des générations en français structuré. L'ancienne version de ce TP (20 paires) montrait un paradoxe : la loss 5-exemples était *plus basse* que la loss 20-exemples alors que les générations étaient du charabia — la mémorisation locale d'un minuscule dataset produit une loss trompeusement basse. Avec un dataset plus large et diversifié, la hiérarchie est saine : plus de données → loss plus basse **et** générations cohérentes. La perte d'évaluation disjointe est le garde-fou qui manquait : elle ne peut pas descendre par mémorisation, puisqu'elle ne voit jamais les exemples d'entraînement.
 
-La sortie ci-dessus est la leçon la plus contre-intuitive du notebook : avec 5
-exemples, la **loss finale est plus basse** (2,7787) qu'avec 20 (2,9238) — et
-pourtant la génération est du charabia pur (« La homhomig-----( »). Une loss
-faible sur un minuscule dataset mesure la **mémorisation locale** (le modele
-recase exactement les 5 exemples vus), pas la **généralisation**. Avec 20
-exemples, le modele mémorise moins parfaitement mais retient un pattern
-transférable. Conclusion pratique : ne jamais évaluer un SFT sur la loss seule —
-l'évaluation générative (lire les réponses) est le seul verdict honnête à
-cette échelle.
-","**Conclusion on dataset size**: With only 5 examples, the model learns the instruction/response format less well. The difference is visible: the responses are less structured and the model may still sometimes \""forget\"" that it must respond to an instruction.
+En production, les datasets SFT contiennent typiquement entre 10 000 et 1 million de paires instruction/réponse — deux à trois ordres de grandeur au-dessus. À 227 paires, le comportement est transmis ; les connaissances, elles, viennent du pré-entraînement.","**Conclusion on dataset size**: the lesson of the two runs now reads with loss AND generations aligned.
 
-In production, SFT datasets typically contain between 10,000 and 1 million instruction/response pairs.",,,,,,,922c9cd94cd2f68b,09d3a95b21630d2b,,,,,,,
+With **5 examples**: final loss **1.73** and pure gibberish generation (""Human Human Human...""). With **205 examples**: train loss 0.70 (run average), disjoint eval loss **0.38**, and generations in structured French. An earlier version of this notebook (20 pairs) showed a paradox: the 5-example loss was *lower* than the 20-example loss while the generations were gibberish — local memorization of a tiny dataset produces a deceptively low loss. With a larger, diversified dataset, the hierarchy is healthy: more data → lower loss **and** coherent generations. The disjoint evaluation loss is the missing guardrail: it cannot go down by memorization, since it never sees the training examples.
+
+In production, SFT datasets typically contain between 10,000 and 1 million instruction/response pairs — two to three orders of magnitude higher. At 227 pairs, the behavior is transmitted; the knowledge comes from pre-training.",,,,,,,62bcc8d56f07780d,4d6869ae1bea70b1,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,fc7a9214,code,fr,0d31b0b8cca1b1b3,"# Liberation de la memoire GPU
 del model_sft, model_base, trainer
 gc.collect()
@@ -1626,23 +1662,24 @@ chacun sur les réponses générées.
 ","## 8. Exercises
 
 Put the concepts from this notebook into practice. Each exercise builds on the previous concepts.",,,,,,,f19f49f7882f6882,4f0488dfe62eabc9,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,d01fb06b,markdown,fr,25bd77fc52b240e4,"### Exercice 1 : Créer un dataset SFT thematique
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,d01fb06b,markdown,fr,122ba5a720008c36,"### Exercice 1 : Créer un dataset SFT thematique
 
-Créez un dataset SFT de 10 paires instruction/reponse sur un **thème de votre choix** (cuisine, sport, musique, etc.). Formatez les données avec le chat template, puis entrainez un modèle QLoRA et observez les résultats.
+Créez un dataset SFT de 10 paires instruction/reponse sur un **thème de votre choix** (cuisine, sport, musique, etc.). Formatez les données selon le contrat du notebook, puis entrainez un modèle QLoRA et observez les résultats.
 
 **Étapes** :
 1. Choisissez un thème et créez 10 paires instruction/reponse coherentes
-2. Formatez avec le chat template `### Human:` / `### Assistant:`
+2. Formatez avec le contrat `### Human:` / `### Assistant: [REPONSE] ... [FIN]` (réutilisez `format_sft_example`)
 3. Entrainez le modèle avec les mêmes hyperparametres
-4. Testez avec 3 instructions de votre thème","### Exercise 1: Create a thematic SFT dataset
+4. Testez avec 3 instructions de votre thème et mesurez le taux de conformite (`respecte_format`)
+","### Exercise 1: Create a thematic SFT dataset
 
-Create an SFT dataset of 10 instruction/response pairs on a **theme of your choice** (cooking, sports, music, etc.). Format the data with the chat template, then train a QLoRA model and observe the results.
+Create an SFT dataset of 10 instruction/response pairs on a **theme of your choice** (cooking, sports, music, etc.). Format the data according to the notebook's contract, then train a QLoRA model and observe the results.
 
 **Steps**:
 1. Choose a theme and create 10 coherent instruction/response pairs
-2. Format with the chat template `### Human:` / `### Assistant:`
+2. Format with the contract `### Human:` / `### Assistant: [REPONSE] ... [FIN]` (reuse `format_sft_example`)
 3. Train the model with the same hyperparameters
-4. Test with 3 instructions from your theme",,,,,,,25bd77fc52b240e4,92c8a4920077f5f7,,,,,,,
+4. Test with 3 instructions from your theme and measure the compliance rate (`respecte_format`)",,,,,,,122ba5a720008c36,076ecc7a5f90a929,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,266ae5f2,code,fr,1e677a3ce33719f0,"# Exercice 1 : Creez votre dataset SFT thematique
 # TODO etudiant : remplacez les exemples ci-dessous par votre propre theme
 
@@ -1682,21 +1719,22 @@ resultats_comparaison = {
     ""r=64"": {""parametres"": None, ""perte"": None},   # TODO etudiant : remplir
 }
 print(""Completez les entrainements puis remplissez resultats_comparaison"")",,,,,,,,2a9ac476dd9efc9b,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,1e5e92a0,markdown,fr,a790a9d128a61591,"### Exercice 3 : Analyser les limites du SFT avec un petit dataset
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,1e5e92a0,markdown,fr,a9f011a9c0844dc2,"### Exercice 3 : Analyser les limites du SFT avec un petit dataset
 
 Produisez un petit rapport (en markdown dans une cellule) analysant les limites observees :
 1. Quels types d'instructions le modèle SFT gere-t-il bien ? Mal ?
 2. Que se passe-t-il si vous donnez une instruction hors du dataset d'entrainement ?
 3. Combien d'exemples faudrait-il approximativement pour obtenir des résultats fiables ?
 
-**Indice** : Testez avec des instructions originales non presentes dans le dataset pour evaluer la generalisation.","### Exercise 3: Analyzing the limitations of SFT with a small dataset
+**Indice** : Testez avec des instructions originales non presentes dans le dataset. Sur un modele deja instruct-tuned, distinguez la **conformite au format** (ce que le SFT enseigne, generalise tres vite) de la **correctitude du fond** (ce que le SFT n'enseigne pas — le modele savait deja repondre).
+","### Exercise 3: Analyzing the limitations of SFT with a small dataset
 
 Produce a short report (in markdown in a cell) analyzing the observed limitations:
 1. What types of instructions does the SFT model handle well? Poorly?
 2. What happens if you give an instruction outside the training dataset?
 3. Approximately how many examples would be needed to obtain reliable results?
 
-**Hint**: Test with original instructions not present in the dataset to evaluate generalization.",,,,,,,a790a9d128a61591,ed6002cbc0936ab9,,,,,,,
+**Hint**: Test with original instructions not present in the dataset. On a model that is already instruct-tuned, distinguish **format compliance** (what SFT teaches, generalizes very fast) from **correctness of substance** (what SFT does not teach — the model already knew how to answer).",,,,,,,a9f011a9c0844dc2,bfec538753e22f87,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,6c80266a,code,fr,b45f07d235dcd061,"# Exercice 3 : Test de generalisation
 # TODO etudiant : testez le modele SFT avec des instructions originales
 
@@ -1709,36 +1747,43 @@ instructions_test = [
 # TODO etudiant : chargez le meilleur modele SFT, testez ces instructions
 # et analysez la qualite des reponses
 print(""Testez avec votre modele SFT et analysez les resultats"")",,,,,,,,b45f07d235dcd061,,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,6f2647d5,markdown,fr,f8b389cfa83dbe84,"## 9. Resume du FT-03
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,6f2647d5,markdown,fr,bd46642ad7f74b37,"## 9. Resume du FT-03
 
 | Concept | Detail |
 |---------|--------|
-| **SFT (Supervised Fine-Tuning)** | Entrainement sur des paires instruction/reponse pour transformer un modèle de base en assistant |
+| **SFT de specialisation** | Entrainement sur des paires instruction/reponse formatees pour enseigner un **contrat de format** a un modele deja instruct-tuned |
 | **Chat template** | Format de conversation (`### Human:` / `### Assistant:`) — contrat entre entrainement et inference |
-| **Dataset SFT** | 21 paires en francais couvrant 6 catégories de tâches |
-| **QLoRA** | Quantization 4-bit NF4 + LoRA (r=16) = ~0.1% des paramètres entraines |
-| **Résultat** | Le modèle apprend a repondre aux instructions au lieu de continuer le texte |
-| **Limites** | Petit dataset = generalisation limitee, reponses parfois repetitives |
+| **Dataset SFT** | 227 paires en francais couvrant 6 familles (101 fonds, 64 reponses partagees), encapsulees `[REPONSE] ... [FIN]` au formatage (38-124 tokens, moyenne 74) |
+| **QLoRA** | Quantization 4-bit NF4 + LoRA hybride (attention full + lineaire + MLP) sur Qwen3.5-0.8B : 7,3 M parametres entrainables (0,85 %) |
+| **Resultat** | Conformite au contrat **0/3 -> 6/6** (dont 2 instructions du holdout jamais vues a l'entrainement : le format generalise) ; boucle de conversation du base eliminee |
+| **Limites** | Le fond des reponses reste approximatif (conformite != correctitude) ; 5 exemples = memorisation degeneree (loss 1,73 mais generation detruite) |
 
-**Prochaines étapes** : Le FT-04 explorera le RLHF (Reinforcement Learning from Human Feedback), qui affine les reponses du modèle SFT en utilisant les préférences humaines comme signal de recompense.
+**Prochaines etapes** : Le FT-04 explorera le RLHF (Reinforcement Learning from Human Feedback), qui affine les reponses du modele SFT en utilisant les preferences humaines comme signal de recompense.
 
-**Bilan chiffré du TP** : 0,24 % des paramètres entraînés (3,1 M / 1,3 Md),
-entraînement en 31,4 s, VRAM contenue de 598 à 614 Mo pendant l'entraînement et
-19 Mo résiduels après libération — et surtout, la leçon d'évaluation : la loss
-seule est un indicateur trompeur à petite échelle, la lecture des générations
-est le verdict.
-","## 9. Summary of FT-03
+**Bilan chiffre du TP** : 0,85 % des parametres entranes (7,3 M / 860 M),
+entrainement en 1908 s (31,8 min) sur GPU 8 Go partagee, VRAM contenue autour de
+1,4 Go pendant l'entrainement — et surtout, la lecon d'evaluation :
+le contrat de format s'apprend avec un dataset diversifie (227 paires) et generalise
+a des reformulations, alors que le meme SFT avec 5 exemples casse la generation.
+La loss mesure la memorisation, la generation revele la generalisation.","## 9. Summary of FT-03
 
 | Concept | Detail |
 |---------|--------|
-| **SFT (Supervised Fine-Tuning)** | Training on instruction/response pairs to transform a base model into an assistant |
+| **Specialization SFT** | Training on formatted instruction/response pairs to teach a **format contract** to an already instruct-tuned model |
 | **Chat template** | Conversation format (`### Human:` / `### Assistant:`) — contract between training and inference |
-| **Dataset SFT** | 21 pairs in French covering 6 task categories |
-| **QLoRA** | 4-bit NF4 quantization + LoRA (r=16) = ~0.1% of trained parameters |
-| **Result** | The model learns to respond to instructions instead of continuing the text |
-| **Limitations** | Small dataset = limited generalization, sometimes repetitive responses |
+| **SFT dataset** | 227 French pairs covering 6 families (101 substantive, 64 shared responses), wrapped `[REPONSE] ... [FIN]` at formatting (38-124 tokens, mean 74) |
+| **QLoRA** | 4-bit NF4 quantization + hybrid LoRA (full attention + linear + MLP) on Qwen3.5-0.8B: 7.3M trainable parameters (0.85%) |
+| **Result** | Contract compliance **0/3 -> 6/6** (including 2 holdout instructions never seen in training: the format generalizes); base conversation loop eliminated |
+| **Limitations** | Response substance remains approximate (compliance != correctness); 5 examples = degenerate memorization (loss 1.73 but generation destroyed) |
 
-**Next steps**: FT-04 will explore RLHF (Reinforcement Learning from Human Feedback), which refines the responses of the SFT model by using human preferences as a reward signal.",,,,,,,f8b389cfa83dbe84,1a4584e0a782af06,,,,,,,
+**Next steps**: FT-04 will explore RLHF (Reinforcement Learning from Human Feedback), which refines the SFT model's responses using human preferences as a reward signal.
+
+**Quantified takeaway of the TP**: 0.85% of parameters trained (7.3M / 860M),
+training in 1908 s (31.8 min) on a shared 8 GB GPU, VRAM contained around
+1.4 GB during training — and above all, the evaluation lesson:
+the format contract is learned with a diversified dataset (227 pairs) and generalizes
+to reformulations, while the same SFT with 5 examples breaks generation.
+The loss measures memorization, generation reveals generalization.",,,,,,,bd46642ad7f74b37,70ecee890c3a4655,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,d2186f84,markdown,fr,a7f239699500d7d7,"# FT-04 : RLHF et Alignement — Préférences Humaines et DPO
 
 **Objectif** : Comprendre comment les préférences humaines permettent d'aligner un LLM, du Reward Model au DPO (Direct Préférence Optimization).
@@ -3648,15 +3693,18 @@ MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a7b8c9d0,mar
 ---
 
 **Navigation**: [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**",,,,,,,78390a9f8a9a8315,32aa70165f06586f,,,,,,,
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,ift02-gen,markdown,fr,16d66bdb32350973,"### Lecture du résultat : la greffe stylistique du fine-tuning
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,ift02-gen,markdown,fr,84d5ea60d4675e5e,"### Lecture du résultat : la greffe stylistique du fine-tuning
 
-La génération `« Dans les rues sombres de Paris, Jean Valjean… »` prouve que le fine-tuning QLoRA a **modifié le comportement** du modèle. L'OPT-1.3B de base, entraîné sur un corpus anglophone générique, produit désormais du français qui réemploie le **lexique des *Misérables*** (`Jean Valjean`, `rues sombres de Paris`) — la greffe du dataset de classiques français a pris. Mais observez aussi les **limites** : `« la sonne du consaveau »`, `« ce qu'il lui aveuglait »` sont des fragments grammaticalement incohérents. C'est le compromis attendu d'un modèle de **1,3 Md paramètres** fine-tuné sur **seulement 10 extraits** : l'imprégnation stylistique prend, la cohérence syntaxique profonde ne suit pas. C'est précisément ce déséquilibre que la cellule de comparaison suivante quantifie (qualité `~97-99%` du full fine-tuning).
+La génération `« Dans les rues sombres de Paris, Jean Valjean… »` prouve que le fine-tuning QLoRA a **modifié le comportement** du modèle. L'OPT-1.3B de base, entraîné sur un corpus anglophone générique, produit désormais du français qui réemploie le **lexique des *Misérables*** (`Jean Valjean`, `rues sombres de Paris`) — la greffe du dataset de classiques français a pris. Mais observez aussi les **limites** : `« la figure de la sachant »` (répétée en boucle), `« Cosette lui donneait »` sont des fragments grammaticalement incohérents. C'est le compromis attendu d'un modèle de **1,3 Md paramètres** fine-tuné sur **seulement 10 extraits** : l'imprégnation stylistique prend, la cohérence syntaxique profonde ne suit pas. C'est précisément ce déséquilibre que la cellule de comparaison suivante quantifie (qualité `~97-99%` du full fine-tuning).
 
 
-**Lecture ancrée des 2e et 3e générations** : le prompt « Jean Valjean regardait la nuit » produit « *Il lui avait dit qu'il serait le reste de l'eau* » — image hugolienne par le registre, absurde par la sémantique ; et « *le huitième Parisien […] aurait une joue de football* » importe un lexique moderne qui n'existe nulle part dans le corpus : OPT-1.3B hallucine en dehors de la greffe. La troisième génération est la plus révélatrice : « *les gendarmes ne peaient jamais dormir* » — le mot « peaient » n'existe pas, c'est une conjugaison inventée sur un radical réel, et la sortie est tronquée en plein mot (« …dans une rue o ») par la limite de `max_new_tokens`. Diagnostic : vocabulaire et atmosphère empruntés au corpus, morphologie et cohérence intrinsèques au modèle de base. Trois époques sur 10 extraits greffent un lexique, pas une grammaire.","### Reading the result: the stylistic graft of fine-tuning
+**Lecture ancrée des 2e et 3e générations** : le prompt « Jean Valjean regardait la nuit » produit « *Cosette lui donneait ses cartes de mariage* » — « donneait » est une conjugaison inventée sur un radical réel — puis dérive en boucle (« *Cosette regardait Jean Valjean et regardait la table* », répétée) : la signature d'un petit modèle mémo-stylisé. La troisième génération est la plus révélatrice : « *elle continuait le moulinette* » (article fautif sur un nom réel) et « *Jean Valjean resterait dans la lune* » — image absurde par la sémantique, hugolienne par le registre. Diagnostic : vocabulaire et atmosphère empruntés au corpus, morphologie et cohérence intrinsèques au modèle de base. Quinze époques sur 10 extraits greffent un lexique, pas une grammaire.
+","### Reading the result: the stylistic graft of fine-tuning
 
-The generation `""Dans les rues sombres de Paris, Jean Valjean…""` proves that QLoRA fine-tuning has **modified the model's behavior**. The base OPT-1.3B, trained on a generic English-language corpus, now produces French that reuses the **vocabulary of *Les Misérables*** (`Jean Valjean`, `sombres rues de Paris`) — the graft of the French classics dataset has taken. But also observe the **limits**: `""la sonne du consaveau""`, `""ce qu'il lui aveuglait""` are fragments that are grammatically incoherent. This is the expected trade-off of a model of **1.3 B parameters** fine-tuned on **only 10 excerpts**: the stylistic imprint takes hold, deep syntactic coherence does not follow. This very imbalance is what the next comparison cell quantifies (quality `~97-99%` of full fine-tuning).",,,,,,,16d66bdb32350973,d390fe2f06b3b1ee,,,,,,,verbatim
-MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,ift02-cmp,markdown,fr,c032e4f705b2312c,"### Lecture du résultat : le triptyque VRAM / qualité / vitesse
+The generation `« Dans les rues sombres de Paris, Jean Valjean… »` proves that QLoRA fine-tuning has **modified the model's behavior**. The base OPT-1.3B, trained on a generic English-language corpus, now produces French that reuses the **vocabulary of *Les Misérables*** (`Jean Valjean`, `rues sombres de Paris`) — the graft of the French classics dataset has taken. But also observe the **limits**: `« la figure de la sachant »` (repeated in a loop), `« Cosette lui donneait »` are grammatically incoherent fragments. This is the expected trade-off of a model of **1.3B parameters** fine-tuned on **only 10 excerpts**: the stylistic imprint takes, deep syntactic coherence does not follow. This very imbalance is what the next comparison cell quantifies (quality `~97-99%` of full fine-tuning).
+
+**Close reading of the 2nd and 3rd generations**: the prompt « Jean Valjean regardait la nuit » produces « *Cosette lui donneait ses cartes de mariage* » — « donneait » is an invented conjugation on a real root — then drifts into a loop (« *Cosette regardait Jean Valjean et regardait la table* », repeated): the signature of a small memo-stylized model. The third generation is the most revealing: « *elle continuait le moulinette* » (faulty article on a real noun) and « *Jean Valjean resterait dans la lune* » — an image absurd in semantics, Hugo-like in register. Diagnosis: vocabulary and atmosphere borrowed from the corpus, morphology and coherence intrinsic to the base model. Fifteen epochs on 10 excerpts graft a lexicon, not a grammar.",,,,,,,84d5ea60d4675e5e,10903e04f644a2f1,,,,,,,verbatim
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,ift02-cmp,markdown,fr,74c2ad49b71634da,"### Lecture du résultat : le triptyque VRAM / qualité / vitesse
 
 Le tableau récapitulatif condense la **promesse et le coût** de QLoRA sur trois axes :
 
@@ -3667,7 +3715,8 @@ Le tableau récapitulatif condense la **promesse et le coût** de QLoRA sur troi
 La **recommandation** qui clôt le tableau encode la règle de décision : LoRA (FP16) si la VRAM le permet (plus simple, plus rapide), QLoRA dès que le modèle dépasse ~1 Md de paramètres ou que la VRAM est contrainte. C'est ce positionnement — *fine-tuner de gros modèles sur du petit matériel* — qui a fait de QLoRA le standard du fine-tuning ouvert sur GPU *consumer*.
 
 
-**Le tableau mesuré, chiffre par chiffre** : FP16 2,55 Go (référence) ; 4-bit NF4 1,60 Go soit 37,3 % d'économie ; QLoRA complet (base 4-bit + adaptateurs + optimiseur, pic d'entraînement) 1,16 Go soit 54,4 %. La ligne théorique (1,42 Go vs 0,36 Go, ratio 4×) utilise le comptage affiché en section 4 et ne couvre que les poids — la réalité mesurée est moins spectaculaire que la théorie (2,2× sur le chargement au lieu de 4×) à cause des tampons de déquantization et des embeddings. Notez enfin que la ligne QLoRA (1,16 Go) est un pic d'entraînement, pas un chargement : elle inclut activations et optimiseur 8 bits, et reste sous le pic du simple chargement FP16 — c'est la comparaison économiquement parlante : **fine-tuner entièrement en QLoRA coûte moins de VRAM que charger seul en FP16**.","### Reading the result: the VRAM / quality / speed triptych
+**Le tableau mesuré, chiffre par chiffre** : FP16 4,03 Go (référence) ; 4-bit NF4 2,24 Go soit 44,4 % d'économie ; QLoRA complet (base 4-bit + adaptateurs + optimiseur, pic d'entraînement) 1,72 Go soit 57,4 %. La ligne théorique (1,42 Go vs 0,36 Go, ratio 4×) utilise le comptage affiché en section 5 et ne couvre que les poids — la réalité mesurée est moins spectaculaire que la théorie (1,8× sur le chargement au lieu de 4×) à cause des tampons de déquantization et des embeddings. Notez enfin que la ligne QLoRA (1,72 Go) est un pic d'entraînement, pas un chargement : elle inclut activations et optimiseur 8 bits, et reste sous le pic du simple chargement FP16 — c'est la comparaison économiquement parlante : **fine-tuner entièrement en QLoRA coûte moins de VRAM que charger seul en FP16**.
+","### Reading the result: the VRAM / quality / speed triptych
 
 The summary table condenses the **promise and the cost** of QLoRA along three axes:
 
@@ -3675,7 +3724,7 @@ The summary table condenses the **promise and the cost** of QLoRA along three ax
 - **Quality (the price to pay)**: `~97-99%` of full fine-tuning. NF4 quantization preserves information because it **concentrates precision** where weights are dense (assumed Gaussian distribution), but a 1-3% degradation is intrinsic to the 16→4-bit information loss.
 - **Speed (the hidden cost)**: `~0.8×`, i.e. ~20% slowdown. The NF4→FP16 **dequantization** at each *forward pass* has a computational overhead — QLoRA is not free in training time.
 
-The **recommendation** that closes the table encodes the decision rule: LoRA (FP16) if VRAM allows (simpler, faster), QLoRA as soon as the model exceeds ~1 B parameters or VRAM is constrained. This positioning — *fine-tuning large models on small hardware* — is what made QLoRA the open fine-tuning standard on *consumer* GPUs.",,,,,,,c032e4f705b2312c,f1f08b209b558bd3,,,,,,,
+The **recommendation** that closes the table encodes the decision rule: LoRA (FP16) if VRAM allows (simpler, faster), QLoRA as soon as the model exceeds ~1 B parameters or VRAM is constrained. This positioning — *fine-tuning large models on small hardware* — is what made QLoRA the open fine-tuning standard on *consumer* GPUs.",,,,,,,74c2ad49b71634da,f1f08b209b558bd3,,,,,,,
 MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-add26685b1114b1f,markdown,fr,89faa341ae878604,"### Vérification de l'environnement
 
 Avant tout chargement de modèle, on vérifie la disponibilité du GPU et sa capacité. Ce notebook est dimensionné pour un GPU avec environ 4 Go de VRAM (GPT-2 = 124M params en float32 = ~500 Mo, plus les états d'optimiseur Adam qui doublent la consommation). Sur un GPU plus modeste (CPU-only), le notebook reste fonctionnel mais l'étape de fine-tuning sera **très** lente — à titre indicatif, comptez 5-10 minutes au lieu de 13 secondes pour les 10 époques sur un CPU moderne.

--- a/translations/genai/image.csv
+++ b/translations/genai/image.csv
@@ -1007,7 +1007,19 @@ print(f""GPT-5 Multimodal - Analyse et Generation d'Images"")
 print(f""{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"")
 print(f""Mode: {notebook_mode}, Analyse: {analysis_mode}, Niveau: {educational_level}"")
 print(f""Langue: {language}, Max tokens: {max_tokens}"")",,,,,,,,98c192db6e0a735e,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,on4ridys1z,markdown,fr,c458b428a8643a4e,L'environnement est initialise. La cellule suivante configure l'acces a l'API OpenRouter et verifie que le modèle GPT-5 est disponible pour les requêtes multimodales.,,,,,,"Окружение инициализировано. Следующая ячейка настраивает доступ к API OpenRouter и проверяет, что модель GPT-5 доступна для мультимодальных запросов.",,c458b428a8643a4e,,,,,,a911c4e1d37b5a22,,
+MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,on4ridys1z,markdown,fr,5bafb2aad41bcd17,"L'environnement est initialise. La cellule suivante configure l'acces a l'API OpenRouter et verifie que le modèle GPT-5 est disponible pour les requêtes multimodales.
+
+### Lecture du résultat — initialisation de l'environnement
+
+La cellule précédente atteste que les quatre dépendances critiques sont résolues sur la machine hôte : **Pillow** (encodage base64 des images), **requests** (POST `/chat/completions` vers OpenRouter), **matplotlib** (visualisation locale optionnelle des images) et **python-dotenv** (chargement du fichier `.env`). Le message `Toutes les dependances sont disponibles` est la condition préalable au pipeline multimodal — sans elle, l'appel à GPT-5 lèverait une `ImportError` au moment de l'encodage base64, pas au moment de la requête HTTP.
+
+Le bloc suivant charge la configuration utilisateur depuis `.env` (clé `OPENROUTER_API_KEY`, base URL, variables additionnelles). L'affichage final résume les paramètres du notebook : `Mode: interactive, Analyse: detailed, Niveau: university, Langue: francais, Max tokens: 4000`. Ces valeurs sont celles que les cellules suivantes vont passer en arguments à `analyze_image_with_gpt5()` — toute modification d'un paramètre dans la cellule 1 se propage ici sans ré-exécuter le reste du notebook.",,,,,,"Окружение инициализировано. Следующая ячейка настраивает доступ к API OpenRouter и проверяет, что модель GPT-5 доступна для мультимодальных запросов.
+
+### Чтение результата — инициализация окружения
+
+Предыдущая ячейка подтверждает, что четыре критические зависимости разрешены на хост-машине: **Pillow** (base64-кодирование изображений), **requests** (POST `/chat/completions` к OpenRouter), **matplotlib** (опциональная локальная визуализация изображений) и **python-dotenv** (загрузка файла `.env`). Сообщение `Toutes les dependances sont disponibles` — необходимое условие для мультимодального пайплайна: без него вызов GPT-5 поднял бы `ImportError` в момент base64-кодирования, а не в момент HTTP-запроса.
+
+Следующий блок загружает пользовательскую конфигурацию из `.env` (ключ `OPENROUTER_API_KEY`, base URL, дополнительные переменные). Итоговый вывод суммирует параметры ноутбука: `Mode: interactive, Analyse: detailed, Niveau: university, Langue: francais, Max tokens: 4000`. Именно эти значения следующие ячейки передают в качестве аргументов `analyze_image_with_gpt5()` — любое изменение параметра в ячейке 1 отражается здесь без повторного запуска остальной части ноутбука.",,5bafb2aad41bcd17,,,,,,616293512c23182b,,
 MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,6005d149,code,fr,200eedfda142d11e,"# Configuration API OpenRouter pour GPT-5
 print(""\n🔑 CONFIGURATION GPT-5 MULTIMODAL"")
 print(""="" * 42)
@@ -1065,7 +1077,19 @@ print(f""\n🎯 Modèle sélectionné: {model_name}"")
 print(f""⚙️  Paramètres: Temperature={temperature}, Max tokens={max_tokens}"")
 print(f""📊 Mode d'analyse: {analysis_mode}"")
 ",,,,,,,,200eedfda142d11e,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,c9dx4xmi4ka,markdown,fr,4eb4e466acad7b80,L'API est configuree et la connexion validee. La cellule suivante définit les fonctions d'analyse multimodale qui encapsulent les appels a GPT-5 avec encodage des images en base64.,,,,,,"API настроен, и соединение проверено. Следующая ячейка определяет функции мультимодального анализа, которые инкапсулируют вызовы GPT-5 с кодированием изображений в base64.",,4eb4e466acad7b80,,,,,,a557bf216994fd90,,
+MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,c9dx4xmi4ka,markdown,fr,d6b3feb1ad826937,"L'API est configuree et la connexion validee. La cellule suivante définit les fonctions d'analyse multimodale qui encapsulent les appels a GPT-5 avec encodage des images en base64.
+
+### Lecture du résultat — connexion à OpenRouter
+
+La cellule précédente a effectué un `GET /models` sur le point d'entrée OpenRouter configuré. La réponse `HTTP/1.1 200 OK` confirme que la clé d'API est valide et que la passerelle reconnait le compte. L'extraction `gpt5_models` filtre 26 modèles dont l'identifiant contient `gpt-5` — c'est l'écart le plus visible entre la nomenclature officielle (OpenAI publie `gpt-5`, `gpt-5-mini`, `gpt-5-pro`, etc.) et la nomenclature passerelle (chaque fournisseur apparaît avec son préfixe : `openai/gpt-5`, `openai/gpt-5.5-pro`, `openai/gpt-5.4-image-2`, `openai/gpt-5.3-codex`…). Cette explosion taxonomique est l'effet de la stratégie OpenRouter d'exposer un identifiant par couple `(fournisseur, variante)`.
+
+La ligne `Contexte: 400000 tokens` (modèle `gpt-5`) rappelle que la fenêtre de contexte est de 400K tokens — un message image + un long prompt d'analyse multimodal tiennent sans dépasser. À titre de comparaison, `gpt-5.5-pro` et `gpt-5.4-pro` remontent à 1 050 000 tokens, soit 2.6× plus, ce qui ouvre la voie à des workflows multi-tours où l'analyse préliminaire est rappelée dans chaque question suivante.",,,,,,"API настроен, и соединение проверено. Следующая ячейка определяет функции мультимодального анализа, которые инкапсулируют вызовы GPT-5 с кодированием изображений в base64.
+
+### Чтение результата — подключение к OpenRouter
+
+Предыдущая ячейка выполнила `GET /models` на настроенной точке входа OpenRouter. Ответ `HTTP/1.1 200 OK` подтверждает, что API-ключ действителен и шлюз распознаёт учётную запись. Извлечение `gpt5_models` фильтрует 26 моделей, чей идентификатор содержит `gpt-5` — это самый заметный разрыв между официальной номенклатурой (OpenAI публикует `gpt-5`, `gpt-5-mini`, `gpt-5-pro` и т.д.) и номенклатурой шлюза (каждый провайдер появляется со своим префиксом: `openai/gpt-5`, `openai/gpt-5.5-pro`, `openai/gpt-5.4-image-2`, `openai/gpt-5.3-codex`…). Этот таксономический взрыв — следствие стратегии OpenRouter: выставлять по одному идентификатору на каждую пару `(провайдер, вариант)`.
+
+Строка `Contexte: 400000 tokens` (модель `gpt-5`) напоминает, что окно контекста составляет 400K токенов — сообщение с изображением плюс длинный промпт мультимодального анализа помещаются без переполнения. Для сравнения: `gpt-5.5-pro` и `gpt-5.4-pro` поднимаются до 1 050 000 токенов, то есть в 2.6 раза больше, что открывает путь к многоходовым сценариям, где предварительный анализ вспоминается в каждом следующем вопросе.",,d6b3feb1ad826937,,,,,,3d844f865c78df9f,,
 MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,ec1512a5,code,fr,33a4d8cf7e230a88,"# Fonctions utilitaires pour traitement d'images
 def encode_image_base64(image_path: Union[str, Path]) -> str:
     """"""
@@ -1148,11 +1172,23 @@ def prepare_image_for_gpt5(image_source: Union[str, Path]) -> Dict[str, str]:
     raise ValueError(f""Format d'image non supporté: {type(image_source)}"")
 
 print(""✅ Fonctions utilitaires images prêtes"")",,,,,,,,33a4d8cf7e230a88,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,9un0u6qzrtv,markdown,fr,1ea1ba58d854b6df,"### Fonction d'analyse et images de demonstration
+MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,9un0u6qzrtv,markdown,fr,d3f8e8f22d9aab84,"### Fonction d'analyse et images de demonstration
 
-La cellule suivante définit la fonction principale `analyze_image_with_gpt5()` qui encode une image en base64 et l'envoie a l'API multimodale. On prepare ensuite un ensemble d'images de test.",,,,,,"### Функция анализа и демонстрационные изображения
+La cellule suivante définit la fonction principale `analyze_image_with_gpt5()` qui encode une image en base64 et l'envoie a l'API multimodale. On prepare ensuite un ensemble d'images de test.
 
-Следующая ячейка определяет основную функцию `analyze_image_with_gpt5()`, которая кодирует изображение в base64 и отправляет его в мультимодальный API. Затем мы подготавливаем набор тестовых изображений.",,1ea1ba58d854b6df,,,,,,e70c00663d1bb024,,
+### Lecture du résultat — pipeline d'encodage des images
+
+La cellule précédente expose trois fonctions utilitaires qui forment le pipeline d'encodage : `encode_image_base64()` (lecture locale + encodage base64), `download_and_encode_image()` (GET HTTP + encodage pour les URLs distantes) et `prepare_image_for_gpt5()` (dispatcher qui choisit entre URL directe et base64 selon le préfixe). Le retour uniforme est un dict `{type: image_url, image_url: {url: ...}}` qui correspond à la spécification OpenAI du champ `content` multimodal — c'est ce format que `analyze_image_with_gpt5()` passera ensuite dans le tableau `messages`.
+
+Le `print('✅ Fonctions utilitaires images prêtes')` est un signal de chargement, pas un test d'exécution. Pour vérifier que le pipeline fonctionne réellement, il faut passer à la cellule d'analyse sur une image concrète — la fonction `prepare_image_for_gpt5` n'est validée qu'à ce moment-là, et un échec (URL inaccessible, fichier introuvable, format non supporté) remonte une `ValueError` ou `FileNotFoundError` typée.",,,,,,"### Функция анализа и демонстрационные изображения
+
+Следующая ячейка определяет основную функцию `analyze_image_with_gpt5()`, которая кодирует изображение в base64 и отправляет его в мультимодальный API. Затем мы подготавливаем набор тестовых изображений.
+
+### Чтение результата — пайплайн кодирования изображений
+
+Предыдущая ячейка предоставляет три вспомогательные функции, образующие пайплайн кодирования: `encode_image_base64()` (локальное чтение + base64-кодирование), `download_and_encode_image()` (HTTP GET + кодирование для удалённых URL) и `prepare_image_for_gpt5()` (диспетчер, выбирающий между прямым URL и base64 по префиксу). Единообразный возврат — это dict `{type: image_url, image_url: {url: ...}}`, соответствующий спецификации OpenAI мультимодального поля `content` — именно этот формат `analyze_image_with_gpt5()` затем передаст в массив `messages`.
+
+`print('✅ Fonctions utilitaires images prêtes')` — это сигнал загрузки, а не тест выполнения. Чтобы проверить, что пайплайн действительно работает, нужно перейти к ячейке анализа на конкретном изображении — функция `prepare_image_for_gpt5` валидируется только в этот момент, и сбой (недоступный URL, ненайденный файл, неподдерживаемый формат) поднимает типизированную `ValueError` или `FileNotFoundError`.",,d3f8e8f22d9aab84,,,,,,e643461d691fc34b,,
 MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,c95a0959,code,fr,add01a9d7ba21508,"# Fonction principale d'analyse d'image avec GPT-5
 def analyze_image_with_gpt5(image_source: Union[str, Path], 
                            prompt: str = None,
@@ -1297,7 +1333,19 @@ Adapte ton vocabulaire au niveau {educational_level}.""""""
         }
 
 print(""✅ Fonction d'analyse GPT-5 prête"")",,,,,,,,add01a9d7ba21508,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,r56pmixdacs,markdown,fr,7eea830c39ad6b27,"Les exemples d'images et les prompts pedagogiques sont définis. La cellule suivante lance l'analyse de demonstration en testant les trois modes (quick, detailed, educational) sur une image concrete.",,,,,,"Примеры изображений и педагогические промпты определены. Следующая ячейка запускает демонстрационный анализ, тестируя три режима (quick, detailed, educational) на конкретном изображении.",,7eea830c39ad6b27,,,,,,c12933ddd2ff637c,,
+MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,r56pmixdacs,markdown,fr,e4aef333821034c7,"Les exemples d'images et les prompts pedagogiques sont définis. La cellule suivante lance l'analyse de demonstration en testant les trois modes (quick, detailed, educational) sur une image concrete.
+
+### Lecture du résultat — fonction `analyze_image_with_gpt5`
+
+La cellule précédente assemble trois prompts prédéfinis (`quick`, `detailed`, `educational`) sélectionnés par l'argument `analysis_type`. Le prompt `educational` est le plus structurant : il impose le rôle, le niveau éducatif (lu depuis `educational_level`), la langue (`language`), et un format de sortie à cinq sections explicites (`Description accessible`, `Éléments à observer`, `Contexte éducatif`, `Questions pour réflexion`, `Connexions interdisciplinaires`). Cette rigidité du prompt est ce qui garantit la reproductibilité des analyses entre deux sessions.
+
+Le bloc d'appel HTTP mesure le temps de réponse (`response_time`) et récupère `usage` qui contient `prompt_tokens`, `completion_tokens` et `total_tokens`. Le champ `reasoning_tokens` (présent dans la sortie de GPT-5 image-generation) reflète les tokens consommés en phase de raisonnement interne — c'est un coût invisible dans `completion_tokens` seul, mais facturé. La cellule suivante utilise cette instrumentation pour comparer les trois modes sur une même image.",,,,,,"Примеры изображений и педагогические промпты определены. Следующая ячейка запускает демонстрационный анализ, тестируя три режима (quick, detailed, educational) на конкретном изображении.
+
+### Чтение результата — функция `analyze_image_with_gpt5`
+
+Предыдущая ячейка собирает три предустановленных промпта (`quick`, `detailed`, `educational`), выбираемых аргументом `analysis_type`. Промпт `educational` — самый структурирующий: он задаёт роль, образовательный уровень (читается из `educational_level`), язык (`language`) и формат вывода с пятью явными разделами (`Description accessible`, `Éléments à observer`, `Contexte éducatif`, `Questions pour réflexion`, `Connexions interdisciplinaires`). Именно эта жёсткость промпта гарантирует воспроизводимость анализа между двумя сессиями.
+
+Блок HTTP-вызова измеряет время ответа (`response_time`) и извлекает `usage`, содержащий `prompt_tokens`, `completion_tokens` и `total_tokens`. Поле `reasoning_tokens` (присутствующее в выводе GPT-5 image-generation) отражает токены, израсходованные на фазу внутреннего рассуждения, — это стоимость, невидимая в одном лишь `completion_tokens`, но она тарифицируется. Следующая ячейка использует эту телеметрию, чтобы сравнить три режима на одном изображении.",,e4aef333821034c7,,,,,,a20a4e397551206c,,
 MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,66a1b41e,code,fr,f4c5761ce8cf97ca,"# Exemples d'images pour démonstration
 print(""\n🖼️  EXEMPLES D'ANALYSE GPT-5"")
 print(""="" * 40)
@@ -1343,11 +1391,41 @@ print(f""• Posez des questions spécifiques"")
 print(f""• Exploitez le contexte éducatif"")
 print(f""• Combinez analyse textuelle et visuelle"")
 print(f""• Adaptez le niveau de complexité"")",,,,,,,,f4c5761ce8cf97ca,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,vkgiro82pk7,markdown,fr,04758d06016ab082,"### Test : analyse d'une image de demonstration
+MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,vkgiro82pk7,markdown,fr,569af8f9933786f6,"### Test : analyse d'une image de demonstration
 
-Testons la fonction d'analyse sur une image concrete. GPT-5 va decrire le contenu, identifier les éléments visuels, et fournir une analyse structuree.",,,,,,"### Тест: анализ демонстрационного изображения
+Testons la fonction d'analyse sur une image concrete. GPT-5 va decrire le contenu, identifier les éléments visuels, et fournir une analyse structuree.
 
-Протестируем функцию анализа на конкретном изображении. GPT-5 опишет содержимое, определит визуальные элементы и предоставит структурированный анализ.",,04758d06016ab082,,,,,,2093ef69e281bd4f,,
+### Lecture du résultat — comparaison quick/detailed/educational
+
+La cellule précédente lance trois appels successifs sur l'image `Architecture Historique` (Colisée de Rome, en fait identifié par GPT-5 comme la Gran Vía à Madrid — première surprise factuelle à noter). Les trois appels produisent des sorties de longueurs et complexités très différentes :
+
+| Mode | Caractères | Tokens total | Temps | Coût upstream |
+|---|---|---|---|---|
+| Quick | 206 | 942 | 7.76s | $0.0037 |
+| Detailed | 2606 | 1791 | 19.14s | $0.0113 |
+| Educational | 2908 | 2256 | 25.73s | $0.0155 |
+
+**Observations factuelles** :
+1. Le temps de réponse n'est pas linéaire en longueur de sortie : passer de 942 à 2256 tokens (×2.4) fait passer le temps de 7.76s à 25.73s (×3.3). La latence est dominée par la phase de raisonnement (`reasoning_tokens` : 192 → 320 → 704), pas par la génération.
+2. Le coût upstream (côté fournisseur d'inférence) suit approximativement les tokens total ; le prompt `educational` est le plus cher parce qu'il injecte structure + format de sortie dans l'entrée.
+3. Pour un usage `alt-text`, le mode `quick` suffit — 206 caractères est dans la plage WCAG (<125) après trim. Pour un usage pédagogique structuré, le mode `educational` produit des questions de guidage de l'élève en sus.",,,,,,"### Тест: анализ демонстрационного изображения
+
+Протестируем функцию анализа на конкретном изображении. GPT-5 опишет содержимое, определит визуальные элементы и предоставит структурированный анализ.
+
+### Чтение результата — сравнение quick/detailed/educational
+
+Предыдущая ячейка выполняет три последовательных вызова на изображении `Architecture Historique` (Колизей в Риме, впрочем опознанный GPT-5 как Gran Vía в Мадриде — первый фактический сюрприз, который стоит отметить). Три вызова дают выводы очень разной длины и сложности:
+
+| Режим | Символов | Всего токенов | Время | Стоимость upstream |
+|---|---|---|---|---|
+| Quick | 206 | 942 | 7.76s | $0.0037 |
+| Detailed | 2606 | 1791 | 19.14s | $0.0113 |
+| Educational | 2908 | 2256 | 25.73s | $0.0155 |
+
+**Фактические наблюдения**:
+1. Время ответа не линейно по длине вывода: переход от 942 к 2256 токенам (×2.4) переводит время с 7.76s на 25.73s (×3.3). Латентность определяется фазой рассуждения (`reasoning_tokens`: 192 → 320 → 704), а не генерацией.
+2. Стоимость upstream (со стороны провайдера инференса) приблизительно следует общим токенам; промпт `educational` самый дорогой, потому что он внедряет структуру + формат вывода во вход.
+3. Для использования `alt-text` достаточно режима `quick` — 206 символов после trim попадает в диапазон WCAG (<125). Для структурированного педагогического использования режим `educational` даёт вдобавок наводящие вопросы для ученика.",,569af8f9933786f6,,,,,,9764119d4bfbacfe,,
 MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,368e963b,code,fr,d4e94d8c40e61cf0,"# Analyse d'une image de démonstration
 print(""\n🚀 ANALYSE DE DÉMONSTRATION - GPT-5"")
 print(""="" * 50)
@@ -1454,15 +1532,27 @@ image_test = example_images[0]['url']  # Architecture historique
 # TODO etudiant : les questions guides sont-elles pertinentes ?
 
 print(""Exercice a completer"")",,,,,,,,f28cd708ceeb4cef,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,jxwlftsm05,markdown,fr,bcd4bf8b8b742fc6,"### Applications pratiques : accessibilite et pedagogie
+MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,jxwlftsm05,markdown,fr,48efe12db3a1beab,"### Applications pratiques : accessibilite et pedagogie
 
 GPT-5 excelle dans deux cas d'usage concrets :
 - **Alt text** : generer automatiquement des descriptions d'accessibilite pour les images web
-- **Analyse pedagogique** : utiliser la vision multimodale pour créer du contenu educatif a partir d'images",,,,,,"### Практические применения: доступность и педагогика
+- **Analyse pedagogique** : utiliser la vision multimodale pour créer du contenu educatif a partir d'images
+
+### Lecture du résultat — génération d'alt text
+
+La cellule précédente appelle `analyze_image_with_gpt5()` avec un prompt spécialisé accessibilité qui impose trois contraintes : (1) sortie ≤ 125 caractères, (2) ton factuel et objectif, (3) pas de formatage additionnel. La sortie obtenue est *Vue aérienne de la Gran Vía à Madrid au coucher du soleil, dôme du Metropolis, immeubles illuminés et circulation.* — **114 caractères** (sous le seuil 125), validée par le `print` qui suit.
+
+**Pourquoi cette longueur compte** : le standard WCAG 2.1 (critère 1.1.1 *Non-text Content*) recommande des alt texts courts pour les images informatives. Au-delà de 125 caractères, les lecteurs d'écran tronquent et l'expérience se dégrade. Au-dessous de 50, l'utilisateur perd le contexte. La cellule 19 ci-dessous propose d'expérimenter avec trois niveaux de longueur pour étudier cette zone de confort — c'est l'un des usages où la multimodalité native remplace un pipeline séparé (modèle vision → modèle texte → formatage).",,,,,,"### Практические применения: доступность и педагогика
 
 GPT-5 отлично справляется с двумя конкретными сценариями использования:
 - **Alt text**: автоматическая генерация описаний доступности для веб-изображений
-- **Педагогический анализ**: использование мультимодального зрения для создания образовательного контента на основе изображений",,bcd4bf8b8b742fc6,,,,,,5ad1325b55a0897d,,
+- **Педагогический анализ**: использование мультимодального зрения для создания образовательного контента на основе изображений
+
+### Чтение результата — генерация alt text
+
+Предыдущая ячейка вызывает `analyze_image_with_gpt5()` со специализированным промптом доступности, налагающим три ограничения: (1) вывод ≤ 125 символов, (2) фактический и объективный тон, (3) без дополнительного форматирования. Полученный вывод — *Vue aérienne de la Gran Vía à Madrid au coucher du soleil, dôme du Metropolis, immeubles illuminés et circulation.* — **114 символов** (ниже порога 125), что подтверждает следующий за ним `print`.
+
+**Почему эта длина имеет значение**: стандарт WCAG 2.1 (критерий 1.1.1 *Non-text Content*) рекомендует короткие alt text для информативных изображений. Свыше 125 символов скринридеры обрезают текст, и опыт деградирует. Ниже 50 пользователь теряет контекст. Ячейка 19 ниже предлагает поэкспериментировать с тремя уровнями длины, чтобы изучить эту зону комфорта, — это одно из применений, где нативная мультимодальность заменяет отдельный пайплайн (модель зрения → текстовая модель → форматирование).",,48efe12db3a1beab,,,,,,7bb55f5783c16de6,,
 MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,a01bfa80,code,fr,fafb03e3949280b8,"# Génération de descriptions d'accessibilité (Alt text)
 if generate_alt_text and analysis_results:
     print(""\n♿ GÉNÉRATION DE DESCRIPTIONS D'ACCESSIBILITÉ"")
@@ -1560,7 +1650,19 @@ prompt_pedago = ""...""  # TODO etudiant : prompt adapte a des eleves du seconda
 # TODO etudiant : verifiez que les descriptions sont factuelles (pas d'interpretation subjective)
 
 print(""Exercice a completer"")",,,,,,,,514737d6192e76aa,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,htbu4le2fb,markdown,fr,32bbcd099b6439f2,Les analyses de demonstration sont completes. Le mode interactif ci-dessous permet d'experimenter avec vos propres images et prompts d'analyse personnalises.,,,,,,Демонстрационные анализы завершены. Интерактивный режим ниже позволяет экспериментировать с вашими собственными изображениями и персонализированными подсказками для анализа.,,32bbcd099b6439f2,,,,,,0335eca0bf3723aa,,
+MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,htbu4le2fb,markdown,fr,de45731f506b0ab3,"Les analyses de demonstration sont completes. Le mode interactif ci-dessous permet d'experimenter avec vos propres images et prompts d'analyse personnalises.
+
+### Lecture du résultat — mode batch vs interactif
+
+La cellule précédente tente `input()` pour récupérer une URL ou un chemin local. En exécution Papermill / batch, l'entrée standard n'est pas disponible : le `except EOFError` intercepte proprement et bascule sur le message `⏭️  Mode interactif non disponible (exécution automatisée)`. Ce pattern est la convention du dépôt pour les notebooks qui mélangent usage interactif et usage batch : la cellule reste fonctionnelle dans les deux modes sans `raise NotImplementedError` (interdit par C.1 — `pass`/`print` sont les stubs corrects).
+
+La cellule suivante passe aux cas d'usage applicatifs — c'est le pont entre la démonstration technique et l'usage métier. Les 5 domaines listés (Histoire, Sciences, Géographie, Art, Médecine) couvrent les disciplines où l'analyse multimodale apporte le plus vs un modèle purement textuel.",,,,,,"Демонстрационные анализы завершены. Интерактивный режим ниже позволяет экспериментировать с вашими собственными изображениями и персонализированными промптами для анализа.
+
+### Чтение результата — пакетный режим против интерактивного
+
+Предыдущая ячейка пытается вызвать `input()`, чтобы получить URL или локальный путь. При выполнении через Papermill / в пакетном режиме стандартный ввод недоступен: `except EOFError` аккуратно перехватывает и переключается на сообщение `⏭️  Mode interactif non disponible (exécution automatisée)`. Этот шаблон — конвенция репозитория для ноутбуков, сочетающих интерактивное и пакетное использование: ячейка остаётся работоспособной в обоих режимах без `raise NotImplementedError` (запрещено правилом C.1 — `pass`/`print` являются корректными заглушками).
+
+Следующая ячейка переходит к прикладным сценариям использования — это мост между технической демонстрацией и бизнес-применением. Перечисленные 5 доменов (История, Науки, География, Искусство, Медицина) охватывают дисциплины, где мультимодальный анализ даёт наибольшее преимущество перед чисто текстовой моделью.",,de45731f506b0ab3,,,,,,c4af4d006ee4a7e5,,
 MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,0bc5a8f8,code,fr,5bb341f4638450f9,"# Mode interactif - Analyse d'image personnalisée
 if notebook_mode == ""interactive"" and not skip_widgets:
     print(""\n🎨 MODE INTERACTIF - ANALYSE PERSONNALISÉE"")
@@ -1640,7 +1742,19 @@ if notebook_mode == ""interactive"" and not skip_widgets:
 else:
     print(""\n🤖 Mode batch - Interface interactive désactivée"")
     print(""💡 Pour mode interactif: notebook_mode = 'interactive'"")",,,,,,,,5bb341f4638450f9,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,gkk2vqpxov,markdown,fr,a8aa31416d79dea3,"Le mode interactif etant traite, la cellule suivante presente les principaux cas d'usage applicatifs de l'analyse visuelle par GPT-5 dans un contexte professionnel et pedagogique.",,,,,,После рассмотрения интерактивного режима следующая ячейка представляет основные прикладные сценарии использования визуального анализа с помощью GPT-5 в профессиональном и педагогическом контексте.,,a8aa31416d79dea3,,,,,,e5cc4b48072a5407,,
+MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,gkk2vqpxov,markdown,fr,51ea8a4d260d2a5a,"Le mode interactif etant traite, la cellule suivante presente les principaux cas d'usage applicatifs de l'analyse visuelle par GPT-5 dans un contexte professionnel et pedagogique.
+
+### Lecture du résultat — matrice domaine × prompt
+
+La cellule précédente catalogue cinq domaines d'application (Histoire, Sciences, Géographie, Art et Culture, Médecine) avec pour chacun un `prompt_template` prédéfini qui peut être passé directement à `analyze_image_with_gpt5()`. Chaque template impose un rôle disciplinaire, un format de sortie, et un ton adapté au domaine — par exemple, le prompt `Médecine` spécifie *Analyse cette image médicale pour des étudiants en médecine. Explique l'anatomie visible et les points d'intérêt clinique.*
+
+L'output ne contient pas de sortie GPT-5 visible — la cellule a uniquement *annoncé* les cas d'usage, sans encore les exécuter. Les exécutions effectives sont laissées à l'exercice 3 (cellule 27), où l'étudiant compose lui-même son template en combinant les ingrédients observés ici. C'est une inversion pédagogique intéressante : la cellule 24 montre les templates, l'exercice demande de les recombiner.",,,,,,"Интерактивный режим рассмотрен, и следующая ячейка представляет основные прикладные сценарии использования визуального анализа GPT-5 в профессиональном и педагогическом контексте.
+
+### Чтение результата — матрица домен × промпт
+
+Предыдущая ячейка каталогизирует пять доменов применения (История, Науки, География, Искусство и культура, Медицина), каждому из которых соответствует предустановленный `prompt_template`, который можно передать напрямую в `analyze_image_with_gpt5()`. Каждый шаблон задаёт дисциплинарную роль, формат вывода и тон, адаптированный к домену, — например, промпт `Médecine` задаёт *Analyse cette image médicale pour des étudiants en médecine. Explique l'anatomie visible et les points d'intérêt clinique.*
+
+Вывод не содержит видимого результата GPT-5 — ячейка лишь *анонсировала* сценарии использования, не исполняя их. Фактические выполнения оставлены упражнению 3 (ячейка 27), где студент сам составляет свой шаблон, комбинируя наблюдаемые здесь ингредиенты. Это интересная педагогическая инверсия: ячейка 24 показывает шаблоны, упражнение требует их рекомбинировать.",,51ea8a4d260d2a5a,,,,,,11d0972728d5abb5,,
 MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,03146442,code,fr,583bd43216b1385e,"# Cas d'usage pédagogiques avec GPT-5
 print(""\n🎓 CAS D'USAGE PÉDAGOGIQUES GPT-5"")
 print(""="" * 45)
@@ -1698,7 +1812,7 @@ print(f""2. Analyse GPT-5 avec prompt éducatif"")
 print(f""3. Génération de questions pour les étudiants"")
 print(f""4. Discussion interactive basée sur l'analyse"")
 print(f""5. Évaluation de la compréhension"")",,,,,,,,583bd43216b1385e,,,,,,,,
-MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,a07f0ce4,markdown,fr,70173ee4915c2fb6,"## 🎯 Résumé et Bonnes Pratiques
+MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,a07f0ce4,markdown,fr,cba151b1841d6795,"## 🎯 Résumé et Bonnes Pratiques
 
 ### ✅ Ce que vous avez appris
 
@@ -1743,7 +1857,16 @@ MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,a0
 
 - **OpenAI** (2025). *GPT-5 System Card & Model Page*. — Modèle multimodal (texte + vision), fenêtre de contexte **400 000 tokens**, 128 000 tokens de sortie maximum. Sources officielles : openai.com/gpt-5/ et developers.openai.com/api/docs/models/gpt-5.
 - **OpenAI** (2024). *GPT-4o System Card*. — Précurseur multimodal de GPT-5 (vision + texte unifiés), base de l'API multimodale utilisée via OpenRouter dans ce notebook.
-",,,,,,"## 🎯 Резюме и лучшие практики
+
+
+### Lecture du résultat — ce que la cellule suivante présente vraiment
+
+Le `print('Cas d'usage pédagogiques')` précédent est un **catalogue statique**, pas une exécution. Les cinq domaines listés sont là pour donner à l'étudiant un point de départ structuré — chaque `prompt_template` est immédiatement réutilisable via `analyze_image_with_gpt5(image, prompt=...)`, sans avoir à le réécrire. Le `print('Template de prompt disponible')` est l'indice que la cellule a déjà joué son rôle pédagogique au moment où l'étudiant l'a lue, même si rien n'a été exécuté.
+
+**Trois choses à retenir pour la cellule de résumé** :
+1. L'API OpenRouter expose 26 modèles GPT-5 distincts — la nomenclature est plus large que la nomenclature OpenAI officielle, et la sélection se fait sur le compromis `contexte × coût × capabilities` (vision, tools, etc.).
+2. Les trois modes d'analyse (quick/detailed/educational) ne sont pas interchangeables : quick est optimisé pour l'alt-text WCAG, educational produit des questions de guidage de l'élève — c'est le seul mode qui fournit un livrable pédagogique clé en main.
+3. Le pipeline multimodal (encode → POST → parse) est uniforme quelle que soit l'image — la complexité se trouve dans le prompt, pas dans le transport.",,,,,,"## 🎯 Резюме и лучшие практики
 
 ### ✅ Что вы изучили
 
@@ -1787,7 +1910,16 @@ MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,a0
 ### 📖 Научные ссылки
 
 - **OpenAI** (2025). *GPT-5 System Card & Model Page*. — Мультимодальная модель (текст + зрение), окно контекста **400 000 tokens**, максимум 128 000 tokens на выходе. Официальные источники : openai.com/gpt-5/ и developers.openai.com/api/docs/models/gpt-5.
-- **OpenAI** (2024). *GPT-4o System Card*. — Мультимодальный предшественник GPT-5 (объединённые зрение + текст), основа мультимодального API, используемого через OpenRouter в этом notebook.",,70173ee4915c2fb6,,,,,,1c023411cc7b0966,,
+- **OpenAI** (2024). *GPT-4o System Card*. — Мультимодальный предшественник GPT-5 (объединённые зрение + текст), основа мультимодального API, используемого через OpenRouter в этом notebook.
+
+### Чтение результата — что следующая ячейка представляет на самом деле
+
+Предыдущий `print('Cas d'usage pédagogiques')` — это **статический каталог**, а не выполнение. Перечисленные пять доменов дают студенту структурированную отправную точку — каждый `prompt_template` немедленно переиспользуется через `analyze_image_with_gpt5(image, prompt=...)` без переписывания. `print('Template de prompt disponible')` — знак того, что ячейка уже сыграла свою педагогическую роль к моменту, когда студент её прочитал, даже если ничего не было выполнено.
+
+**Три вещи, которые стоит запомнить для ячейки резюме**:
+1. API OpenRouter выставляет 26 различных моделей GPT-5 — номенклатура шире официальной номенклатуры OpenAI, и выбор делается по компромиссу `контекст × стоимость × возможности` (зрение, tools и т.д.).
+2. Три режима анализа (quick/detailed/educational) не взаимозаменяемы: quick оптимизирован под alt-text WCAG, educational даёт наводящие вопросы для ученика — это единственный режим, дающий готовый педагогический результат.
+3. Мультимодальный пайплайн (encode → POST → parse) одинаков для любого изображения — сложность живёт в промпте, а не в транспорте.",,cba151b1841d6795,,,,,,2de15031478a994d,,
 MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-2-GPT-5-Image-Generation.ipynb,ubm6sfxypqb,markdown,fr,85635ba21bab5fc9,"---
 
 ### Exercice 3 : Synthèse — Workflow d’analyse multimodale complet

--- a/translations/partner-course-quant-trading/partner-course.csv
+++ b/translations/partner-course-quant-trading/partner-course.csv
@@ -9431,19 +9431,31 @@ print(f""  Full period: {corr_full:.3f}"")
 print(f""  Bull regime: {corr_bull:.3f}"")
 print(f""  Bear regime: {corr_bear:.3f}"")
 print(f""\nDiversification benefit: {'STRONG' if abs(corr_full) < 0.3 else 'MODERATE' if abs(corr_full) < 0.6 else 'WEAK'}"")",,,,,,,,4ccefc3dfb2ba3fd,,,,,,,,
-MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb,cell-6dd76863,markdown,fr,8245559ab4793775,"## 5. Allocation Optimale
+MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb,cell-6dd76863,markdown,fr,1e1e9a1704f30f1f,"## 5. Allocation Optimale
 
-L'output de la cellule [12] teste **5 allocations proxy** entre les deux alpha models.
+L'output de la cellule [12] teste **5 allocations proxy** entre les deux alpha models — avec la **bascule de régime** que le Framework applique réellement : en jour bear (SPY < SMA 200), `BEAR_TILT = 0.5` transfère la moitié du poids sectoriel vers le sleeve défensif (70/30 nominal → 35/65 effectif) ; en jour bull, l'allocation nominale s'applique.
 
-**Fait majeur** : le **Sharpe proxy est maximal à 50/50** (0.929), devant 60/40 (0.917), 70/30 (0.896), 80/20 (0.870), 90/10 (0.842). Le main.py utilise **70/30** — et c'est un **choix délibéré, pas optimal**.
+**Fait majeur** : le **Sharpe proxy est monotone croissant et saturant** — il monte de 1.094 (50/50) à 1.170 (90/10), mais le gain marginal s'évanouit : +0.041, +0.024, +0.011 puis **+0.0005** entre 80/20 et 90/10 (ex-aequo statistique).
 
-**Lecture critique** : la relation Sharpe vs allocation est **monotone décroissante** quand on ajoute du secteur. Dit autrement : ajouter du defensive **réduit le rendement annualisé** (de 13.11% à 10.88%) **mais réduit aussi la volatilité** (de 15.56% à 11.71%), et le ratio net favorise la diversification.
+**La signature mesurable du fix** : avant correction, les deux branches de la bascule calculaient la même somme (l'addition est commutative) et `is_bear_day` était un no-op — la frontière Sharpe était alors monotone **décroissante** (0.929 à 50/50 → 0.843 à 90/10), « meilleure » allocation = 50/50. Avec la bascule active, le classement **s'inverse** : à 90/10, le rendement annualisé gagne +1.99 pts (0.1311 → 0.1510) pendant que la volatilité **perd** 2.65 pts (0.1556 → 0.1291) — le tilt dynamique coupe l'exposition sectorielle exactement les jours bear où elle coûte le plus cher.
 
-**Pourquoi main.py retient 70/30 et non 50/50** : le proxy ci-dessus **ignore les coûts de transaction** du rebalancement hebdo et **ignore la path-dependence du drawdown**. Un 50/50 smoother en proxy se traduit souvent par un **Sharpe OOS inférieur en backtest réel** à cause du glissement (rebalance 50% → 50% chaque semaine = turnover 2× supérieur à 70/30 → 30%). La ratchet baseline retient donc 70/30 comme compromis Sharpe/proxy/backtest-réel.
+**Pourquoi AnnReturn reste affine** (écarts constants ≈ +0.0086 par pas de 10 pts) : propriété mathématique du proxy, pas un défaut — la moyenne annualisée est linéaire et les poids par régime sont affines dans l'allocation nominale. La dépendance au régime se lit dans les grandeurs **non linéaires** : la volatilité (0.1291 à 90/10 au lieu de 0.1556 — la queue de pertes bear est amputée) et le Sharpe (frontière inversée).
 
-**À noter** : ce proxy est une **proxy simplifiée**, pas un backtest. La cellule [12] est explicite là-dessus. Un vrai backtest main.py via QC Cloud donnera le Sharpe OOS authoritative — qu'on comparera au proxy en conclusion.","## 5. Optimal Allocation
+**Pourquoi main.py retient 70/30** : le proxy place 70/30 à 1.158, troisième sur cinq, à 0.011 de la frontière — et le gain marginal au-delà de 80/20 est nul (+0.0005). Le compromis reste celui de la section suivante : coûts de transaction du rebalancement hebdo, path-dependence du drawdown, robustesse OOS. La lecture change de nature : ce n'est plus « 50/50 gagne mais on sacrifie » (ancienne conclusion, artefact du if mort), c'est « le tilt dynamique se substitue au poids défensif statique — au-delà de 80/20 on n'achète plus rien, en deçà de 70/30 on laisse du rendement ».
 
-Testing different allocations between the two alpha models. The main.py uses 70/30 (Sector/Defensive).",,,,,,,8245559ab4793775,da5b7d0aa17b8ffc,,,,,,,
+**À noter** : ce proxy reste une **proxy simplifiée** (poids journaliers fixes par régime, pas de coûts). Le backtest main.py via QC Cloud donnera le Sharpe OOS de référence.","## 5. Optimal Allocation
+
+The output of cell [12] tests **5 proxy allocations** between the two alpha models — with the **regime switch** the Framework actually applies: on a bear day (SPY < SMA 200), `BEAR_TILT = 0.5` transfers half of the sector weight to the defensive sleeve (70/30 nominal → 35/65 effective); on a bull day, the nominal allocation applies.
+
+**Headline fact**: the **proxy Sharpe is monotonically increasing and saturating** — it rises from 1.094 (50/50) to 1.170 (90/10), but the marginal gain vanishes: +0.041, +0.024, +0.011 then **+0.0005** between 80/20 and 90/10 (a statistical tie).
+
+**The measurable signature of the fix**: before the correction, both branches of the switch computed the same sum (addition is commutative) and `is_bear_day` was a no-op — the Sharpe frontier was then monotonically **decreasing** (0.929 at 50/50 → 0.843 at 90/10), ""best"" allocation = 50/50. With the switch active, the ranking **reverses**: at 90/10, the annualized return gains +1.99 pts (0.1311 → 0.1510) while volatility **loses** 2.65 pts (0.1556 → 0.1291) — the dynamic tilt cuts sector exposure exactly on the bear days where it costs the most.
+
+**Why AnnReturn stays affine** (constant gaps ≈ +0.0086 per 10-pt step): a mathematical property of the proxy, not a defect — the annualized mean is linear and the per-regime weights are affine in the nominal allocation. Regime dependence shows in the **non-linear** quantities: volatility (0.1291 at 90/10 instead of 0.1556 — the bear loss tail is cut off) and the Sharpe (inverted frontier).
+
+**Why main.py keeps 70/30**: the proxy places 70/30 at 1.158, third of five, 0.011 from the frontier — and the marginal gain beyond 80/20 is nil (+0.0005). The trade-off remains that of the next section: transaction costs of weekly rebalancing, drawdown path-dependence, OOS robustness. The reading changes nature: it is no longer ""50/50 wins but we sacrifice"" (the old conclusion, an artefact of the dead if), it is ""the dynamic tilt substitutes for the static defensive weight — beyond 80/20 you buy nothing more, below 70/30 you leave return on the table"".
+
+**Note**: this proxy remains a **simplified proxy** (fixed daily weights per regime, no costs). The main.py backtest via QC Cloud will give the reference OOS Sharpe.",,,,,,,1e1e9a1704f30f1f,1694fcbede6452fd,,,,,,,
 MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb,cell-8d86ce40,code,fr,9ed14755cb901cc6,"# Simulate different allocations
 allocations = [(50, 50), (60, 40), (70, 30), (80, 20), (90, 10)]
 
@@ -9556,7 +9568,7 @@ print(""  - L'approche Framework separe les preoccupations (alpha, risk, executi
 print(""  - Deux alpha models decorreles offrent une meilleure diversification"")
 print(""  - Le circuit breaker a 15% protege contre les crashs majeurs"")
 print(""  - L'allocation 70/30 privilegie le momentum tout en gardant une couverture defensive"")",,,,,,,,9cc784c7433388c1,,,,,,,,
-MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb,cell-b5f1fd1e,markdown,fr,6c81779eeef1c595,"## Conclusion et Pistes d'Itération
+MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb,cell-b5f1fd1e,markdown,fr,ef07db607cda6304,"## Conclusion et Pistes d'Itération
 
 ### Synthèse des résultats de recherche
 
@@ -9566,48 +9578,49 @@ MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-F
 | §2 Signal | Combien de temps le signal momentum est-il actif ? | 63.7% en moyenne, dispersion sectorielle 50-74% |
 | §3 Bear | Quels refuges protègent vraiment en bear ? | **TLT** (spread +49.30%), **XLU échec** (-59.41%) |
 | §4 Corr | Les deux alphas sont-ils décorrelés ? | MODERATE (0.383), **bear 0.595 = break** |
-| §5 Alloc | Quelle allocation maximise le Sharpe proxy ? | 50/50 = 0.929, mais main.py retient 70/30 = 0.896 |
+| §5 Alloc | Quelle allocation maximise le Sharpe proxy (bascule de régime) ? | 90/10 = 1.1697 ≈ 80/20 = 1.1692 (frontière saturante), retenu main.py : 70/30 = 1.158 |
 | §6 CB | Le circuit breaker à 15% est-il adapté ? | 1.7% du temps sous −15%, max SPY = −33.72% |
 
 ### Leçons principales du notebook
 
 1. **Le Framework composite n'est pas un générateur de Sharpe magique** — c'est un **proxy de risk management**. Les deux alpha models sont **partiellement corrélés** (surtout en bear), donc la diversification est réelle mais asymétrique.
 2. **TLT écrase le rôle de hedge**, XLU **échoue structurellement** en bear. Inclure XLU dans le defensive universe réduit la qualité du hedge.
-3. **L'allocation 70/30 n'est PAS optimale sur le proxy** (50/50 gagne), mais elle est **robuste au backtest réel** (coûts tx, slippage, path-dependence). Le compromis est délibéré.
+3. **La bascule de régime est réelle et mesurable** : `BEAR_TILT = 0.5` (70/30 nominal → 35/65 effectif en jour bear) **inverse la frontière Sharpe** (monotone décroissante → croissante saturante) et ampute la volatilité de 2.65 pts à 90/10. Le tilt dynamique se substitue au poids défensif statique ; le 70/30 du main.py reste un compromis turnover/robustesse à 0.011 de la frontière. AnnReturn reste affine **par construction** (moyenne linéaire, poids affines par régime) — la signature du régime vit dans la volatilité et le Sharpe.
 4. **Le circuit breaker à 15% est conservateur** vs standards industrie (20-25%). Il coupe sur du *bruit* 10.6% du temps (DD > 5%) mais garantit une DD structurelle basse.
 
 ### Pistes pour itération N+1
 
 - **Réallouer le defensive universe** : remplacer XLU par IEF ou SHY (duration intermédiaire) pour corriger le talon d'Achille bear.
-- **Allocation dynamique risk-parity** : ajuster 70/30 en fonction de la volatilité realized (plus de defensive en haute vol).
+- **Calibrer BEAR_TILT** : 0.5 est arbitraire — balayer 0.25/0.5/0.75 et mesurer la saturation de la frontière.
 - **Ajout d'un 3ᵉ alpha** : mean-reversion RSI<30 sur secteurs en oversold — découplé du momentum, complémentaire au defensive.
 - **Circuit breaker adaptive** : seuil dynamique 15% en bull, 20% en bear (évite les faux triggers en régime turbulent).
-- **Backtest OOS authoritatif** : comparer les résultats du main.py (QC Cloud 2015-2024) au proxy §5 pour quantifier le coût de la simplification.","## Conclusion and Iteration Ideas
+- **Backtest OOS de référence** : comparer les résultats du main.py (QC Cloud 2015-2024) au proxy §5 pour quantifier le coût de la simplification.","## Conclusion and Iteration Ideas
 
-### Architecture
+### Synthesis of research results
 
-| Component | Implementation | Parameters |
-|-----------|---------------|------------|
-| Alpha 1 | SectorMomentum | SMA200 + 126j momentum |
-| Alpha 2 | Defensive | SPY < SMA200 trigger |
-| PCM | MultiStrategyPCM | 70/30 allocation |
-| Risk | MaxDrawdownCircuitBreaker | 15% DD max |
-| Execution | ImmediateExecutionModel | Market orders |
+| Step | Question | Key output |
+|---|---|---|
+| §1 Perf | Which assets have the best annualized Sharpe? | XLF 1.074, TLT 0.855 (best refuge), XLU 0.637 |
+| §2 Signal | How often is the momentum signal active? | 63.7% on average, sector dispersion 50-74% |
+| §3 Bear | Which refuges truly protect in bear? | **TLT** (spread +49.30%), **XLU failure** (-59.41%) |
+| §4 Corr | Are the two alphas decorrelated? | MODERATE (0.383), **bear 0.595 = break** |
+| §5 Alloc | Which allocation maximizes the proxy Sharpe (regime switch)? | 90/10 = 1.1697 ≈ 80/20 = 1.1692 (saturating frontier), kept in main.py: 70/30 = 1.158 |
+| §6 CB | Is the 15% circuit breaker adequate? | 1.7% of the time below −15%, SPY max = −33.72% |
 
-### Key Points
+### Main lessons of the notebook
 
-1. **QC Framework**: clean modular architecture, each component can be tested independently
-2. **Alpha diversification**: sector momentum + defensive are naturally decorrelated
-3. **Regime detection**: the SPY/SMA200 filter automatically switches between the two modes
-4. **Circuit breaker**: protection against extreme drawdowns
+1. **The composite Framework is not a magic Sharpe generator** — it is a **risk management proxy**. The two alpha models are **partially correlated** (especially in bear), so diversification is real but asymmetric.
+2. **TLT crushes the hedge role**, XLU **structurally fails** in bear. Including XLU in the defensive universe reduces hedge quality.
+3. **The regime switch is real and measurable**: `BEAR_TILT = 0.5` (70/30 nominal → 35/65 effective on bear days) **inverts the Sharpe frontier** (monotonically decreasing → increasing and saturating) and cuts volatility by 2.65 pts at 90/10. The dynamic tilt substitutes for the static defensive weight; main.py's 70/30 remains a turnover/robustness compromise 0.011 from the frontier. AnnReturn stays affine **by construction** (linear mean, affine weights per regime) — the signature of the regime lives in volatility and Sharpe.
+4. **The 15% circuit breaker is conservative** vs industry standards (20-25%). It triggers on *noise* 10.6% of the time (DD > 5%) but guarantees a low structural DD.
 
 ### Ideas for iteration N+1
 
-- Add a 3rd alpha model: mean reversion on oversold sectors
-- Dynamically adjust allocation based on volatility (risk parity)
-- Add sector constraints (max exposure per sector)
-- Implement position-level risk management (individual stop-loss)
-- Test alternative indicators (RSI, ADX) for the momentum signal",,,,,,,6c81779eeef1c595,028264304a6e20ca,,,,,,,
+- **Reallocate the defensive universe**: replace XLU with IEF or SHY (intermediate duration) to fix the bear-market Achilles' heel.
+- **Calibrate BEAR_TILT**: 0.5 is arbitrary — sweep 0.25/0.5/0.75 and measure the saturation of the frontier.
+- **Add a 3rd alpha**: RSI<30 mean-reversion on oversold sectors — decoupled from momentum, complementary to the defensive sleeve.
+- **Adaptive circuit breaker**: dynamic threshold 15% in bull, 20% in bear (avoids false triggers in turbulent regimes).
+- **Reference OOS backtest**: compare the main.py results (QC Cloud 2015-2024) to the §5 proxy to quantify the cost of the simplification.",,,,,,,ef07db607cda6304,ddfa461d17c906fc,,,,,,,
 MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/deep_research_optimization.ipynb,deepresearch-interp-data,markdown,fr,eb7391b18e56944c,"**Lecture des sorties.** L'univers charge 9 ETF sectoriels couvrant ~15 ans de cotation (3804 jours de VIX). Les `hit` du cache confirment que la trajectoire est figée : le notebook est reproductible. Notons que `XLI` (Industrials) apparaît dans la liste de téléchargement de la prose mais pas dans l'univers final des 9 — l'univers effectif est XLK/XLF/XLV/XLY/XLP/XLE/XLB/XLU/XLRE, soit la décomposition Sector SPDR canonique. C'est un point à garder en tête pour l'interprétation : le signal momentum porte sur ces 9 rotateurs, pas sur un panier plus large.
 ",,,,,,,,eb7391b18e56944c,,,,,,,,
 MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/Sector-Momentum/deep_research_optimization.ipynb,deepresearch-interp-vix,markdown,fr,0d20c56000abf6d8,"**Lecture des statistiques VIX.** La distribution est **asymétrique à droite** : moyenne 18.36, médiane 16.59 — l'écart signale une longue queue de valeurs hautes (crises). Le percentile 90 à 27.02 et les jours au-dessus de 30 (6.4 % seulement) montrent que le régime extrême est rare mais marqué. Deux conséquences pour le calibrage du filtre : (1) un seuil absolu de 25 filtre ~29.2 % des jours (au-dessus de la moyenne), ce qui est **beaucoup** pour un filtre défensif ; (2) un seuil de 35 ne filtre que les ~6 % de jours de panique franche. Le grid search tranchera lequel des deux protège réellement le Sharpe — l'intuition « filtrer plus = plus sûr » n'est pas garantie, car chaque jour filtré est aussi un rebond manqué.


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/notebook-dotnet #13686

## Summary

Resynchro per-cellule du sous-ensemble chaud #13551 : les 47 cellules `SRC_DRIFT` portant une traduction déposée (8 notebooks, 4 CSV), avec retraduction des 29 cellules matériellement changées. **Jamais d'extraction globale** (le piège de l'issue : `extract_cells_to_csv.py` sur `translations/` échangerait 2007 drifts silencieux contre 47 traductions orphelines silencieuses).

## Ce qui est livre

1. **Resync** `text_fr` / `src_hash` / `hash_fr` sur les 47 cellules depuis les notebooks courants (source recompute firsthand, pas depuis un snapshot).
2. **Retraduction des 29 cellules matérielles** (difflib ratio < 0.98) : 20 EN (receipe_maker 2, FT-02 6, FT-03 10, QC research 2) + 9 RU (01-2-GPT-5-Image-Generation). `hash_<lang> = cell_hash(text_<lang>)` via **import** de `check_translation_sync` (contrat hash byte-identique T1/T2/T3).
3. **18 cellules cosmétiques** (ratio >= 0.98, ex. forme backtickée `# Étape 1` citée dans l'issue) : resync FR seul, traductions déposées **préservées byte-identical**.
4. **Cliquet** `scripts/translation/tests/test_hot_subset_ratchet.py` : (a) hot subset repo-wide épinglé à 0 — toute édition FR future d'une cellule traduite sans resync CSV rougit la suite, attrape la classe réelle sans rougir sur les ~2000 bruts pré-T3 (exactement la demande « tenable » de l'issue) ; (b) fixture hermétique tmp_path qui épingle la sémantique du sous-ensemble chaud.

## Preuves (relancees post-fix)

| Mesure | Avant | Apres |
|---|---|---|
| HOT (SRC_DRIFT ET traduction deposee, repo-wide 29 CSV) | **47** | **0** |
| SRC_DRIFT (brut) | 2047 | 2000 |
| ORPHAN_ROW / MISSING_LANG / TRAD_DRIFT | 2292 / 206 / 1 | inchanges |

- Suite traduction complete : **345 passed** (dont les 2 nouveaux tests ratchet).
- Parity : verdict OK, 0 blocking / 0 advisory.
- Verif chirurgicale du diff : comparaison logique ligne-a-ligne HEAD vs branche (csv.reader) = **exactement les 47 lignes cibles changees** sur les 4 CSV, toutes les autres lignes byte-identiques, compte de lignes preserve (133/196/558/215), header intact.
- Self-check hash post-ecriture : `src_hash == cell_hash(text_fr) == hash_fr` sur les 47 ; `hash_<lang> == cell_hash(text_<lang>)` sur les 29 materiales.
- Advisory `check_resync_only.py` : verdict `ok` (contenu depose en colonnes en/ru — ce n'est PAS le pattern resync-only suspendu par le ruling #6949).

## Comptes (contexte du claim)

Le claim de preflight annoncait 46 (join tsync-JSON ayant manque 1 cellule QC research) ; la recomputation directe par hash sur les 4 CSV fait autorite : **47** (le compte de l'issue). Delta explique, aucune cellule manquee : post-fix hot = 0 verifie par la meme methode directe.

## Hors scope (signale, non touche)

- La prose FR committee de FT-03 est partiellement non-accentuee (« modele », « repond ») — la reference de resync EST l'etat courant du notebook (procedure de l'issue) ; la cure d'accents releve de la famille #2876, pas de ce grain.
- Les ~2000 SRC_DRIFT pre-T3 sans traduction deposee : non resynchronises deliberement (pattern resync-only suspendu, ruling #6949).

Closes #13551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
