### PR TITLE
fix(ci): translation-guard Journalise exit 127 — override motif via env: (#13688)

### DIFF
--- a/.github/workflows/translation-guard.yml
+++ b/.github/workflows/translation-guard.yml
@@ -213,8 +213,11 @@ jobs:
 
       - name: Journalise accepted override (#10332)
         if: steps.override.outputs.override_applied == 'true'
+        env:
+          # PR-controlled text: never interpolate into run: (backticks in the
+          # motif triggered command substitution => exit 127, run 33318105740)
+          MOTIF: ${{ steps.override.outputs.motif }}
         run: |
-          MOTIF="${{ steps.override.outputs.motif }}"
           echo "::notice title=Translation guard::OVERRIDE accepted -- motif: $MOTIF. The override is auditable; see #10332."
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "## Translation Guard OVERRIDE accepted (#10332)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/tooling #13687

## Summary

Le pas « Journalise accepted override (#10332) » de `translation-guard.yml` échoue en **exit 127** dès que le motif d'override contient des backticks — override pourtant accepté. Cause : `MOTIF="${{ steps.override.outputs.motif }}"` interpolé dans le corps du script bash ; backticks = substitution de commande. C'est aussi un vecteur d'injection de script (texte de commentaire PR sur le runner).

Fix canonique : le motif passe par `env:` (expansion shell littérale), plus aucune interpolation `${{ }}` de step-output dans `run:`.

Closes #13688 (bug découvert ce cycle, preuves + critères dans l'issue).

## Evidence

- **Reproduction firsthand** : rerun du garde sur #13687 (run 33318105740, job 99276313752) — override accepté (`guard_pass: true`, `override_applied: true`, label + marker présents) puis `line 1: --update: command not found` → exit 127. Log complet cité dans #13688.
- **Contournement immédiat appliqué** sur #13687 : motif du commentaire reformulé sans backticks (issuecomment-5469445609 édité) + rerun — le garde passe ainsi, mais le bug workflow reste.
- **Scan du fichier** : 0 autre interpolation inline de step-output dans un `run:` (script de vérification : YAML parse + regex sur les 6 steps du job `guard`).
- **Diff** : 1 fichier, +4/−1 — `env:` block ajouté, ligne `MOTIF="..."` retirée du `run:`.

## Test plan

- [ ] Cette PR elle-même ne déclenche pas le garde (aucun fichier translation touché) — le fix sera validé à la prochaine override légitime.
- [ ] Post-merge : rerun du garde sur #13687 (rebasé) avec un motif contenant backticks → journalise vert.
- [ ] `python scripts/ci/variation_tag_required.py --body-file` local : `required_pass: true`.

## Perimeter guard

Diff = uniquement `.github/workflows/translation-guard.yml`, pas de fichier translation, pas de catalogue.
