### PR TITLE
fix(guard,#13632): tier-cap axis applies only to an EFFECTIVE LIGHT candidate

### DIFF
--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -1703,3 +1703,96 @@ def test_genre_unknown_absent_when_no_genre_claimed():
                               candidate_genre=None)
     assert sig["signals"]["GENRE-UNKNOWN"] is False
     assert sig["candidate_genre_unknown_word"] is None
+
+
+def _run_check_pr(body_now: str, merged_payload: list[dict]) -> dict:
+    """Sous-processus --check-pr sur une journee synthetique (--replay)."""
+    import subprocess
+    import tempfile
+    import os
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".json", delete=False, encoding="utf-8",
+    ) as f:
+        json.dump(merged_payload, f)
+        merged_path = f.name
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".md", delete=False, encoding="utf-8",
+    ) as f:
+        f.write(body_now)
+        body_path = f.name
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable, str(Path(__file__).resolve().parents[1] / "variation_light_cap.py"),
+                "--check-pr", "999",
+                "--body-file", body_path,
+                "--replay", merged_path,
+            ],
+            capture_output=True, text=True, cwd=str(
+                Path(__file__).resolve().parents[1]
+            ),
+            timeout=15,
+            encoding="utf-8", errors="replace",
+        )
+    finally:
+        os.unlink(merged_path)
+        os.unlink(body_path)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _issue_13632_day() -> tuple[list[dict], str]:
+    """La journee synthetique du body de l'issue #13632, verbatim.
+
+    3 grains merges sur la lane : un seul LIGHT et dans un genre de
+    CONTENU (LIGHT/qc) -- budget tier epuise (max(1, 3//3) = 1, spent 1),
+    axe genre a zero (qc n'est pas un LIGHT genre).
+    """
+    lane = "myia-zz-test:CoursIA"
+    merged = [
+        {"number": 900, "mergedAt": "2026-08-30T08:00:00Z",
+         "body": f"Grain: LIGHT/qc -- lane {lane}\n\nTranche 1."},
+        {"number": 901, "mergedAt": "2026-08-30T09:00:00Z",
+         "body": f"Grain: DEEP/lean -- lane {lane}\n\nFond."},
+        {"number": 902, "mergedAt": "2026-08-30T10:00:00Z",
+         "body": f"Grain: MED/notebook-python -- lane {lane}\n\nSubstance."},
+    ]
+    return merged, lane
+
+
+def test_deep_guard_does_not_inherit_light_tier_budget_13632():
+    """Candidat A de l'issue : DEEP/guard ne herite pas du budget LIGHT.
+
+    Avant le fix, `tier_cap_reached` (fait de lane-jour, aveugle au tier
+    du candidat) bloquait le DEEP/guard alors que l'axe genre -- le seul
+    que ce candidat porte -- disait false. Les deux verdicts DEEP/LIGHT
+    etaient indiscernables : le tier declare etait inerte.
+    """
+    merged, lane = _issue_13632_day()
+    out = _run_check_pr(
+        f"Grain: DEEP/guard -- lane {lane}\n\nGarde de fond.",
+        merged,
+    )
+    # L'axe genre reste a zero : le candidat ne porte que ce motif-là.
+    assert out["cap_exceeded_by_genre"] is False
+    # Le budget tier est bien epuise (le fait de lane-jour reste expose)...
+    assert out["tier_cap_reached"] is True
+    # ...mais il ne s'applique qu'a un EFFECTIVE LIGHT (commentaire L1022).
+    assert out["cap_reached"] is False
+
+
+def test_light_guard_on_spent_tier_budget_still_caps_13632():
+    """Controle negatif obligatoire (body de l'issue) : candidat B.
+
+    Un LIGHT/guard sur budget tier epuise doit rester cap_reached: true --
+    un correctif qui ne verifierait que la direction A serait aveugle a
+    la regression qui compte (le garde desarme sur les vrais LIGHT).
+    """
+    merged, lane = _issue_13632_day()
+    out = _run_check_pr(
+        f"Grain: LIGHT/guard -- lane {lane}\n\nGarde leger.",
+        merged,
+    )
+    assert out["tier_cap_reached"] is True
+    assert out["cap_reached"] is True

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -1104,12 +1104,16 @@ def main(argv: list[str] | None = None) -> int:
         genre_cap = light_budget(tally["lane_grains"] + 1)  # +1 candidate, aligned
         cap_exceeded_by_genre = light_genre_count > genre_cap
         tier_cap_reached = status["cap_reached"]
-        # UNION only when the candidate carries the genre motif (#10341): a
-        # LIGHT/tooling (tier LIGHT, genre not LIGHT) cannot trip the genre
-        # cap; a MED/readme (tier MED, genre LIGHT) can. Both directions of
-        # the defect are closed -- the declared-MED bypass AND the coherence
-        # with --genre-signals.
-        cap_reached = tier_cap_reached or (cap_exceeded_by_genre and candidate_is_light_genre)
+        # UNION only when the candidate carries the axis motif (#10341 for
+        # genre, #13632 for tier): a LIGHT/tooling (tier LIGHT, genre not
+        # LIGHT) cannot trip the genre cap; a MED/readme (tier MED, genre
+        # LIGHT) can -- and symmetrically a non-LIGHT-tier candidate cannot
+        # inherit the TIER budget spent by other grains of the day
+        # (`tier_cap_reached` is a lane-day aggregate, blind to the
+        # candidate's declared tier; unguarded it blocked DEEP/guard on a
+        # budget only an EFFECTIVE LIGHT spends, cf L1022 comment).
+        cap_reached = (tier_cap_reached and eff == "LIGHT") \
+            or (cap_exceeded_by_genre and candidate_is_light_genre)
         # VEIN-RUN (#11343 tranche 2) : when the lane's day trips a vein
         # (2+ PRs citing the same issue), the cap must point the lane
         # at the picker. The picker-call is informationally added to


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/tooling #13690

## Summary

`variation_light_cap.py` L1112 : l'union `cap_reached = tier_cap_reached or (cap_exceeded_by_genre and candidate_is_light_genre)` laissait le premier disjoint **sans garde** — `tier_cap_reached` est un fait de **lane-jour** calculé sur les grains **mergés**, aveugle au tier du candidat. Un candidat **DEEP/guard** héritait donc du budget TIER dépensé par les autres grains de la journée, en contradiction avec la doctrine du fichier lui-même (L1022 : *« Only an EFFECTIVE LIGHT spends the TIER budget »* ; #10341 : *« an aggregate pattern must not be posed on a candidate that does not carry it »*).

Correctif symétrique (celui proposé par l'issue) : chaque axe ne tire que si le candidat en porte le motif.

```python
cap_reached = (tier_cap_reached and eff == "LIGHT") \
              or (cap_exceeded_by_genre and candidate_is_light_genre)
```

Closes #13632.

## Evidence

- **Prémisse vérifiée firsthand** sur `origin/main` avant édition : L1112 exactement telle que décrite ; `LIGHT_GENRES = {docs, readme, guard, ledger, test}` (donc DEEP/guard atteint bien la branche) ; `eff = effective_tier(...)` en scope (L1028).
- **Contrôle synthétique du body, reproduit verbatim** (3 grains mergés : LIGHT/qc + DEEP/lean + MED/notebook-python → budget tier 1/1 épuisé, axe genre 0) :
  - **Candidat A = DEEP/guard** : avant fix `cap_reached: true` (tier déclaré inerte) ; après fix **`cap_reached: false`**, avec `tier_cap_reached: true` toujours exposé (le fait de lane-jour reste lisible) et `cap_exceeded_by_genre: false`.
  - **Candidat B = LIGHT/guard** (contrôle négatif obligatoire du body) : **`cap_reached: true`** inchangé — le correctif ne désarme pas le garde sur les vrais LIGHT.
- **Tests** : 2 nouveaux (`test_deep_guard_does_not_inherit_light_tier_budget_13632`, `test_light_guard_on_spent_tier_budget_still_caps_13632`) + helper `--replay`, harnais sous-processus identique aux tests `check_pr` existants. Suite `test_variation_light_cap.py` **101/101 PASS**, `test_pick_idle_grain.py` **72/72 PASS** (importeur de `parse_grain`).
- **Portée du défaut** (mesurée par l'issue, non recontestée) : seuls les candidats `non-LIGHT tier + LIGHT genre` ; latent aujourd'hui (l'axe genre déclenche de son côté sur les cas connus).

## Perimeter guard

Diff : `scripts/variation_light_cap.py` (+7/−1 hunk L1107-1112, commentaire mis à jour) + `scripts/tests/test_variation_light_cap.py` (2 tests + helper). Aucun autre fichier, aucun notebook, aucun workflow.

## Test plan

- [x] Suite locale 101/101 + 72/72.
- [ ] Post-merge : `--check-pr` sur un candidat DEEP/guard réel d'une lane à budget tier épuisé doit rendre `cap_reached: false` (l'organe reste advisory pour le tag-guard).
