### PR TITLE
feat(fallacy_detection,#13573): mesure de reduction structurelle — pont taxonomie Argumentum <-> Planners-14

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-14-LLM-Space-Reducer.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-14-LLM-Space-Reducer.ipynb
@@ -1095,6 +1095,7 @@
     "- **[Planners-11](Planners-11-Unified-Planning.ipynb)** : la boucle plan-execute-compile d'aicpp (C++ genere, recompile, reexecute) est une instance concrete du pattern unifie.\n",
     "- **[Planners-12](Planners-12-LOOP.ipynb)** : Learning to Plan apprend la **representation** ; le reducteur LLM la **demande**. Deux facons de ne pas laisser le modele resoudre.\n",
     "- **Serie SymbolicLearning** : les primitives typees et la memoire structurelle d'aicpp resonnent avec le library learning interpretable (compressibilite par abstractions reutilisables).\n",
+    "- **Taxonomie Argumentum** : la reduction d'espace se rejoue sur l'arbre de sophismes de la serie Argument_Analysis ; `scripts/fallacy_detection/argumentum_taxonomy_explorer.py --reduction-measure` y mesure les bornes structurelles de la descente guidee (lecture systematique contre chemin cible, guide aveugle en controle negatif) — le pendant deterministe du bras 3, sans appel LLM.\n",
     "- **ARC-AGI** : ce benchmark fait ici une apparition miniaturisee, sur le sous-ensemble flip/color/mask des transformations.\n",
     "\n",
     "**Precautions sur la source** : aicpp (Julien Livet, Apache 2.0) est un depot **jeune et actif** (cree janvier 2026) ; toute execution du moteur reel doit figer un commit precis. Les auteurs le presentent eux-memes comme **non-production ARC solver** — exploration de recherche, pas produit. Ce notebook cite et s'inspire du positionnement ; il ne porte pas leur code."

--- a/scripts/fallacy_detection/argumentum_taxonomy_explorer.py
+++ b/scripts/fallacy_detection/argumentum_taxonomy_explorer.py
@@ -42,6 +42,13 @@ with **zero edits to vendored files**.  It produces the SFT seed traces the
 EPIC needs ("sans generateur de traces, pas de seed SFT") by exercising the 6
 operations on the real 1408-node tree.
 
+``reduction_measure`` (#13573) bridges this module to the Planners series'
+search-space-reduction thesis (``Planners/04-NeuroSymbolic/
+Planners-14-LLM-Space-Reducer.ipynb``): the same structural question -- how
+much reading does a guide that decides WHERE to descend save over a
+systematic scan -- answered deterministically on the taxonomy (naive vs
+oracle vs first-child bounds; no LLM call, see the method's docstring).
+
 The 6 operations (mirroring the ``@kernel_function`` names/signatures):
     list_fallacy_categories  -> unique families
     list_fallacies_in_category(category) -> leaves of a family
@@ -64,6 +71,7 @@ import json
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+from statistics import mean, median
 from typing import Optional
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -437,6 +445,93 @@ class ArgumentumTaxonomy:
             "leaves_per_family": per_family,
         }
 
+    def reduction_measure(self) -> dict:
+        """Structural bounds of a guided descent vs a systematic read (#13573).
+
+        Bridge to the Planners-14 thesis ("an LLM that decides WHERE to
+        descend is a search-space reducer, not a solver"): how much reading
+        does a guide save on THIS taxonomy?  Deterministic -- these are
+        structural bounds, complementary to (not a substitute for) the
+        notebook's measured LLM comparison.
+
+        Cost model: number of CONSULTED nodes, root anchor excluded.
+
+        * ``naive`` -- a systematic reader consults nodes in preorder
+          (children by PK, i.e. CSV order) until it reaches the target:
+          cost = preorder position.
+        * ``oracle`` -- a perfect guide reads only the root->target path:
+          cost = path depth.  The floor ANY guide can reach.
+        * ``first_child`` -- this explorer's own ``_descent_chain`` policy
+          (always descend the first child, read nothing else): a guide that
+          chooses without reading.  It reaches only the leftmost path;
+          ``hit_rate`` is the share of targets it ever reaches -- the honest
+          downside bound (guided-worse-than-naive is a real possibility).
+
+        A real LLM descent lands between ``oracle`` and ``first_child``; the
+        SFT target of ``generate_sft_traces`` is the oracle behaviour.
+        """
+        preorder: list[TaxonomyNode] = []
+
+        def walk(path: str) -> None:
+            for child in self._children_by_parent_path.get(path, []):
+                preorder.append(child)
+                walk(child.path)
+
+        walk("0")  # depth-1 parents are indexed under the literal root path.
+        naive_costs = list(range(1, len(preorder) + 1))
+        # depth read off the dotted path (self-consistent with the tree this
+        # module builds), not the CSV ``depth`` column.
+        oracle_costs = [len(n.path.split(".")) for n in preorder]
+
+        # leftmost path from the root = the _descent_chain policy's reachable set.
+        leftmost: set[int] = set()
+        parent_path = "0"
+        while True:
+            children = self._children_by_parent_path.get(parent_path, [])
+            if not children:
+                break
+            leftmost.add(children[0].pk)
+            parent_path = children[0].path
+            if not children:
+                break
+            leftmost.add(children[0].pk)
+            pk = children[0].pk
+
+        naive_mean = mean(naive_costs) if naive_costs else 0.0
+        oracle_mean = mean(oracle_costs) if oracle_costs else 0.0
+        return {
+            "total_nodes": len(self._nodes),
+            "targets": len(preorder),
+            "max_depth": max(oracle_costs, default=0),
+            "naive": {
+                "mean": naive_mean,
+                "median": median(naive_costs) if naive_costs else 0.0,
+                "max": max(naive_costs, default=0),
+            },
+            "oracle": {
+                "mean": oracle_mean,
+                "median": median(oracle_costs) if oracle_costs else 0.0,
+                "max": max(oracle_costs, default=0),
+            },
+            "reduction_ratio_mean": (
+                naive_mean / oracle_mean if oracle_mean else None
+            ),
+            "first_child": {
+                "hit_rate": len(leftmost) / len(preorder) if preorder else None,
+                "chain_length": len(leftmost),
+            },
+            "cost_model": (
+                "consulted nodes, root anchor excluded; naive = preorder "
+                "position (children by PK), oracle = dotted-path depth "
+                "(root->target path only)"
+            ),
+            "scope": (
+                "structural bounds of a guided descent (#13573) -- "
+                "deterministic, NOT an LLM run; a real LLM descent lands "
+                "between oracle and first_child"
+            ),
+        }
+
 
 def main(argv: Optional[list[str]] = None) -> int:
     p = argparse.ArgumentParser(
@@ -451,6 +546,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     p.add_argument("--list-categories", action="store_true")
     p.add_argument("--explore-pk", type=int, metavar="PK", help="Explore hierarchy at PK.")
     p.add_argument("--report", action="store_true", help="Print coverage report.")
+    p.add_argument(
+        "--reduction-measure",
+        action="store_true",
+        help="Print the structural reduction measure (#13573).",
+    )
     p.add_argument(
         "--out-traces",
         type=Path,
@@ -482,6 +582,14 @@ def main(argv: Optional[list[str]] = None) -> int:
                 taxo.explore_fallacy_hierarchy(args.explore_pk),
                 ensure_ascii=False,
                 indent=2,
+            )
+        )
+        return 0
+
+    if args.reduction_measure:
+        print(
+            json.dumps(
+                taxo.reduction_measure(), ensure_ascii=False, indent=2
             )
         )
         return 0
@@ -524,14 +632,20 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(f"  ecrites dans : {args.out_traces}")
 
     if not any(
-        (args.list_categories, args.explore_pk is not None, args.report, args.out_traces)
+        (
+            args.list_categories,
+            args.explore_pk is not None,
+            args.report,
+            args.reduction_measure,
+            args.out_traces,
+        )
     ):
         # default: print the coverage report.
         rep = taxo.coverage_report()
         print(
             f"Taxonomie: {rep['total_nodes']} noeuds, {rep['family_count']} familles, "
             f"{rep['leaves']} feuilles.  Utilisez --report / --list-categories / "
-            f"--explore-pk PK / --out-traces PATH."
+            f"--explore-pk PK / --reduction-measure / --out-traces PATH."
         )
     return 0
 

--- a/scripts/fallacy_detection/tests/test_argumentum_taxonomy_explorer.py
+++ b/scripts/fallacy_detection/tests/test_argumentum_taxonomy_explorer.py
@@ -225,6 +225,62 @@ def test_coverage_report(taxo: ArgumentumTaxonomy) -> None:
     assert rep["leaves_per_family"] == {"FamilleA": 3, "FamilleB": 1}
 
 
+# -- reduction measure (#13573) --------------------------------------
+
+def test_reduction_measure_mini_taxonomy_formulas(taxo: ArgumentumTaxonomy) -> None:
+    """Hand-computed bounds on the 8-node fixture.
+
+    Preorder (children by PK): 1,2,3,4,5,6,7 -> naive cost = position (1..7).
+    Oracle cost = dotted-path depth: 1,2,2,2,3,1,2 (sum 13).
+    """
+    m = taxo.reduction_measure()
+    assert m["total_nodes"] == 8
+    assert m["targets"] == 7  # root anchor excluded from the target set.
+    assert m["max_depth"] == 3
+    assert m["naive"]["mean"] == pytest.approx(4.0)
+    assert m["naive"]["median"] == 4
+    assert m["naive"]["max"] == 7
+    assert m["oracle"]["mean"] == pytest.approx(13 / 7)
+    assert m["oracle"]["median"] == 2
+    assert m["oracle"]["max"] == 3
+    assert m["reduction_ratio_mean"] == pytest.approx(4.0 / (13 / 7))
+
+
+def test_reduction_measure_first_child_is_the_blind_guide(
+    taxo: ArgumentumTaxonomy,
+) -> None:
+    """The ``_descent_chain`` policy (always first child) reaches only the
+    leftmost path {1, 2}: guided != guaranteed -- the downside bound."""
+    m = taxo.reduction_measure()
+    assert m["first_child"]["chain_length"] == 2
+    assert m["first_child"]["hit_rate"] == pytest.approx(2 / 7)
+    assert m["first_child"]["hit_rate"] < 0.5  # worse than a coin flip.
+
+
+def test_reduction_measure_scope_is_labeled_structural(
+    taxo: ArgumentumTaxonomy,
+) -> None:
+    """The measure must declare itself deterministic, not an LLM run."""
+    m = taxo.reduction_measure()
+    assert "NOT an LLM run" in m["scope"]
+    assert "consulted nodes" in m["cost_model"]
+
+
+def test_reduction_measure_real_tree_smoke() -> None:
+    """Smoke on the real CSV (skip when absent): oracle << naive, blind
+    guide misses most of the tree."""
+    from fallacy_detection.argumentum_taxonomy_explorer import _DEFAULT_TAXO
+
+    if not _DEFAULT_TAXO.is_file():
+        pytest.skip(f"real taxonomy absent: {_DEFAULT_TAXO}")
+    m = ArgumentumTaxonomy.from_csv(_DEFAULT_TAXO).reduction_measure()
+    assert m["total_nodes"] == 1408
+    assert m["targets"] == m["total_nodes"] - 1
+    assert m["oracle"]["mean"] < m["naive"]["mean"]
+    assert m["reduction_ratio_mean"] > 1
+    assert m["first_child"]["hit_rate"] < 0.01
+
+
 # -- CLI -----------------------------------------------------------
 
 def test_main_missing_file_exits_2(tmp_path: Path) -> None:
@@ -239,6 +295,15 @@ def test_main_list_categories(taxo_path: Path, capsys) -> None:
     assert rc == 0
     out = capsys.readouterr().out
     assert "FamilleA" in out and "FamilleB" in out
+
+
+def test_main_reduction_measure(taxo_path: Path, capsys) -> None:
+    from fallacy_detection.argumentum_taxonomy_explorer import main
+    rc = main(["--taxonomy", str(taxo_path), "--reduction-measure"])
+    assert rc == 0
+    m = json.loads(capsys.readouterr().out)
+    assert m["targets"] == 7
+    assert m["oracle"]["mean"] < m["naive"]["mean"]
 
 
 def test_main_out_traces_jsonl(taxo_path: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2023:CoursIA — prev: MED/guard #13691

Closes #13573

## Summary

La descente guidee dans la taxonomie des sophismes et la these reductrice de Planners-14 sont le meme geste ; les deux organes ne se referencaient pas. Cette PR nomme le rattachement dans les deux sens et en tire la mesure.

1. **Pont bidirectionnel** : Planners-14 (cell 22, §8 « Ponts et precautions ») gagne un bullet vers l'explorateur ; le docstring du module gagne le cadre reducteur d'espace + le chemin du notebook.
2. **Mesure sur les 1408 noeuds** : `reduction_measure()` + `--reduction-measure` (CLI). Modele de cout = noeuds consultes (ancre racine exclue) :
   - `naive` (lecture systematique en preorder) : mean **704** consultes
   - `oracle` (guide parfait, chemin racine->cible) : mean **5.39**
   - ratio structurel **~130x** — le chiffre qu'aucun des deux organes ne possedait
3. **Controle negatif** : `first_child` = la propre politique `_descent_chain` de l'explorateur (descendre toujours le premier enfant sans lire). Elle atteint **6/1407** cibles (hit rate 0.4%) : une descente guidee peut etre dramatiquement pire que le parcours naif — la reduction d'espace est maintenant mesuree contre sa baseline.

**Portee honnete** (champ `scope` du JSON de sortie) : bornes structurelles deterministes, PAS un run LLM — une descente LLM reelle atterrit entre oracle et first_child ; la cible SFT de `generate_sft_traces` est le comportement oracle.

## Validation

- `PYTHONPATH=scripts python -m pytest scripts/fallacy_detection/tests/ -q` → **72 passed** (6 nouveaux : formules calculees a la main sur la mini-taxo 8 noeuds — naive mean 4.0, oracle mean 13/7, first_child hit rate 2/7 ; controle guide-aveugle < 0.5 ; etiquetage scope ; smoke arbre reel 1408 noeuds, oracle < naive, hit rate < 1%).
- Sortie reelle de `--reduction-measure` sur l'arbre reel (worktree frais depuis origin/main cc4d59e1bf) colle ci-dessous.
- Aucun autre importeur du module : `grep -rl argumentum_taxonomy_explorer scripts/ --include=*.py` → 0 hors `scripts/fallacy_detection/`.
- Catalogue : non touche (byte-identique a main).

<details>
<summary>--reduction-measure (arbre reel, 1408 noeuds)</summary>

```json
{
  "total_nodes": 1408,
  "targets": 1407,
  "max_depth": 10,
  "naive": { "mean": 704, "median": 704, "max": 1407 },
  "oracle": { "mean": 5.390191897654584, "median": 5, "max": 10 },
  "reduction_ratio_mean": 130.60759493670886,
  "first_child": { "hit_rate": 0.0042643923240938165, "chain_length": 6 },
  "cost_model": "consulted nodes, root anchor excluded; naive = preorder position (children by PK), oracle = dotted-path depth (root->target path only)",
  "scope": "structural bounds of a guided descent (#13573) -- deterministic, NOT an LLM run; a real LLM descent lands between oracle and first_child"
}
```

</details>

## Fichiers

- `scripts/fallacy_detection/argumentum_taxonomy_explorer.py` (+118/-2) : `reduction_measure()`, flag CLI, docstring bridge.
- `scripts/fallacy_detection/tests/test_argumentum_taxonomy_explorer.py` (+65) : 6 tests hermetiques + smoke reel.
- `MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-14-LLM-Space-Reducer.ipynb` (+1 ligne, markdown-only — bullet cell 22 ; exception C.2, aucune cellule code touchee, pas de re-exec requise).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
